### PR TITLE
Xeno strain purchase and evolving changes

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/Evolution.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Evolution.dm
@@ -13,24 +13,15 @@
 	if (!evolve_checks())
 		return
 
-	//Debugging that should've been done
-
 	var/castepick = tgui_input_list(usr, "You are growing into a beautiful alien! It is time to choose a caste.", "Evolve", caste.evolves_to)
 	if(!castepick) //Changed my mind
 		return
 
-	if(!isturf(loc)) //qdel'd or inside something
-		return
-
-	if (!evolve_checks())
+	if(!evolve_checks())
 		return
 
 	if((!hive.living_xeno_queen) && castepick != XENO_CASTE_QUEEN && !isXenoLarva(src) && !hive.allow_no_queen_actions)
 		to_chat(src, SPAN_WARNING("The Hive is shaken by the death of the last Queen. You can't find the strength to evolve."))
-		return
-
-	if(handcuffed || legcuffed)
-		to_chat(src, SPAN_WARNING("The restraints are too restricting to allow you to evolve."))
 		return
 
 	if(castepick == XENO_CASTE_QUEEN) //Special case for dealing with queenae
@@ -163,9 +154,8 @@
 	SSround_recording.recorder.track_player(new_xeno)
 
 /mob/living/carbon/Xenomorph/proc/evolve_checks()
-	if(evolving)
-		to_chat(src, SPAN_WARNING("You are already evolving!"))
-		return FALSE
+	if(!check_state())
+		return
 
 	if(is_ventcrawling)
 		to_chat(src, SPAN_WARNING("This place is too constraining to evolve."))
@@ -187,10 +177,6 @@
 		to_chat(src, SPAN_WARNING("You are jobbanned from aliens and cannot evolve. How did you even become an alien?"))
 		return FALSE
 
-	if(is_mob_incapacitated(TRUE))
-		to_chat(src, SPAN_WARNING("You can't evolve in your current state."))
-		return FALSE
-
 	if(handcuffed || legcuffed)
 		to_chat(src, SPAN_WARNING("The restraints are too restricting to allow you to evolve."))
 		return FALSE
@@ -208,15 +194,8 @@
 		to_chat(src, SPAN_WARNING("You must be at full health to evolve."))
 		return FALSE
 
-	if (agility || fortify || crest_defense)
+	if(agility || fortify || crest_defense)
 		to_chat(src, SPAN_WARNING("You cannot evolve while in this stance."))
-		return FALSE
-
-	if(is_mob_incapacitated(TRUE))
-		to_chat(src, SPAN_WARNING("You can't evolve in your current state."))
-		return FALSE
-
-	if(!isturf(loc)) //qdel'd or inside something
 		return FALSE
 
 	return TRUE

--- a/code/modules/mob/living/carbon/xenomorph/Evolution.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Evolution.dm
@@ -155,7 +155,7 @@
 
 /mob/living/carbon/Xenomorph/proc/evolve_checks()
 	if(!check_state())
-		return
+		return FALSE
 
 	if(is_ventcrawling)
 		to_chat(src, SPAN_WARNING("This place is too constraining to evolve."))

--- a/code/modules/mob/living/carbon/xenomorph/XenoMutatorSets.dm
+++ b/code/modules/mob/living/carbon/xenomorph/XenoMutatorSets.dm
@@ -26,12 +26,15 @@
 
 /datum/mutator_set/proc/list_and_purchase_mutators()
 	var/list/mutators_for_purchase = available_mutators()
+	var/mob/living/carbon/Xenomorph/X = usr
 	if(mutators_for_purchase.len == 0)
-		to_chat(usr, "You can't take another strain.")
+		to_chat(usr, "There are no avaliable strains.")
 	var/pick = tgui_input_list(usr, "Which strain would you like to purchase?", "Purchase strain", mutators_for_purchase)
 	if(!pick)
 		return FALSE
 	if(alert(usr, "[GLOB.xeno_mutator_list[pick].description]\n\nConfirm mutation?", "Strain purchase", "Yes", "No") == "No")		return
+	if(!X.strain_checks())
+		return
 	if(GLOB.xeno_mutator_list[pick].apply_mutator(src))
 		to_chat(usr, "Mutation complete!")
 		return TRUE
@@ -228,20 +231,34 @@
 	set desc = "Purchase Strains for yourself."
 	set category = "Alien"
 
-	if(is_dead())
-		return //Dead xenos can't mutate!
+	if(!strain_checks())
+		return
 	if(!src.mutators)
 		return //For some reason we don't have mutators
 	src.mutators.list_and_purchase_mutators()
 
-/mob/living/carbon/Xenomorph/verb/list_mutators()
-	set name = "List Strains"
-	set desc = "List your current Strain, if any."
-	set category = "Alien"
+/mob/living/carbon/Xenomorph/proc/strain_checks()
+	if(!check_state())
+		return
 
-	to_chat(src, SPAN_XENOANNOUNCE("Strain:"))
-	if(isnull(src.mutators) || isnull(src.mutators.purchased_mutators) || !src.mutators.purchased_mutators.len)
-		to_chat(src, "-")
-	else
-		for(var/m in src.mutators.purchased_mutators)
-			to_chat(src, m)
+	if(is_ventcrawling)
+		to_chat(src, SPAN_WARNING("This place is too constraining to take a strain."))
+		return FALSE
+
+	if(!isturf(loc))
+		to_chat(src, SPAN_WARNING("You can't take a strain here."))
+		return FALSE
+
+	if(handcuffed || legcuffed)
+		to_chat(src, SPAN_WARNING("The restraints are too restricting to allow you to take a strain."))
+		return FALSE
+
+	if(health < maxHealth)
+		to_chat(src, SPAN_WARNING("You must be at full health to take a strain."))
+		return FALSE
+
+	if(agility || fortify || crest_defense)
+		to_chat(src, SPAN_WARNING("You cannot take a strain while in this stance."))
+		return FALSE
+
+	return TRUE

--- a/code/modules/mob/living/carbon/xenomorph/XenoMutatorSets.dm
+++ b/code/modules/mob/living/carbon/xenomorph/XenoMutatorSets.dm
@@ -26,14 +26,14 @@
 
 /datum/mutator_set/proc/list_and_purchase_mutators()
 	var/list/mutators_for_purchase = available_mutators()
-	var/mob/living/carbon/Xenomorph/X = usr
+	var/mob/living/carbon/Xenomorph/Xeno = usr
 	if(mutators_for_purchase.len == 0)
 		to_chat(usr, "There are no available strains.")
 	var/pick = tgui_input_list(usr, "Which strain would you like to purchase?", "Purchase strain", mutators_for_purchase)
 	if(!pick)
 		return FALSE
 	if(alert(usr, "[GLOB.xeno_mutator_list[pick].description]\n\nConfirm mutation?", "Strain purchase", "Yes", "No") == "No")		return
-	if(!X.strain_checks())
+	if(!Xeno.strain_checks())
 		return
 	if(GLOB.xeno_mutator_list[pick].apply_mutator(src))
 		to_chat(usr, "Mutation complete!")

--- a/code/modules/mob/living/carbon/xenomorph/XenoMutatorSets.dm
+++ b/code/modules/mob/living/carbon/xenomorph/XenoMutatorSets.dm
@@ -28,7 +28,7 @@
 	var/list/mutators_for_purchase = available_mutators()
 	var/mob/living/carbon/Xenomorph/X = usr
 	if(mutators_for_purchase.len == 0)
-		to_chat(usr, "There are no avaliable strains.")
+		to_chat(usr, "There are no available strains.")
 	var/pick = tgui_input_list(usr, "Which strain would you like to purchase?", "Purchase strain", mutators_for_purchase)
 	if(!pick)
 		return FALSE

--- a/code/modules/mob/living/carbon/xenomorph/XenoMutatorSets.dm
+++ b/code/modules/mob/living/carbon/xenomorph/XenoMutatorSets.dm
@@ -239,7 +239,7 @@
 
 /mob/living/carbon/Xenomorph/proc/strain_checks()
 	if(!check_state())
-		return
+		return FALSE
 
 	if(is_ventcrawling)
 		to_chat(src, SPAN_WARNING("This place is too constraining to take a strain."))

--- a/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
@@ -133,7 +133,7 @@
 //A simple handler for checking your state. Used in pretty much all the procs.
 /mob/living/carbon/Xenomorph/proc/check_state(var/permissive = 0)
 	if(!permissive)
-		if(is_mob_incapacitated() || lying || buckled)
+		if(is_mob_incapacitated() || lying || buckled || evolving)
 			to_chat(src, SPAN_WARNING("You cannot do this in your current state."))
 			return FALSE
 		else if(caste_type != XENO_CASTE_QUEEN && observed_xeno)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

> add: Added basic checks to strain purchasing so you must be at full hp/not stunned/resting/in a stance/etc to purchase.

The above prevents strain purchasing (as there was only an isdead check before) while low hp/crit/etc so that you cannot abuse, for example; godcrest bug and/or purchasing acid runner strain to get out of crit.

> tweak: Made it so you cannot utilize abilities while evolving as a xeno.

The above prevents ability while in the evolve state so you cannot abuse, for example; pounce as a runner while evolving and then getting another pounce as a lurker.
Probably also good so a xeno in front of you does not quickly evolve in the middle of a fight while you're fighting it and get a free heal on a newmob.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added basic checks to strain purchasing so you must be at full hp/not stunned/resting/in a stance/etc to purchase.
add: Made it so you cannot utilize abilities while evolving as a xeno.
del: Removed the list mutators verb from xenos.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
