### PR TITLE
Fixes the light performance bug

### DIFF
--- a/code/controllers/_DynamicAreaLighting_TG.dm
+++ b/code/controllers/_DynamicAreaLighting_TG.dm
@@ -327,9 +327,7 @@ GLOBAL_LIST_INIT(comp2table, list(
 	if(!src) return
 	if(light <= 0)
 		light = 0
-		luminosity = 0
-	else
-		luminosity = 1
+	luminosity = 1
 	if(light > LIGHTING_STATES)
 		light = LIGHTING_STATES
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Lummox said in a post that byond's built-in darkness makes view() calls O(n^3) instead of O(n^2), which has shown to be significant on CM. Profiler has shown that procs using view() take a lot more cpu time than they normally would, and players have described the game feeling a lot more sluggish earlier on ever since the lighting changes. As a result, I am reverting the changes to luminosity that were made 

Closes #2

## Why It's Good For The Game

Performance improvements

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

