### PR TITLE
log_say Unknown Tweak

### DIFF
--- a/code/modules/cm_preds/yaut_bracers.dm
+++ b/code/modules/cm_preds/yaut_bracers.dm
@@ -960,7 +960,7 @@
 	if(!drain_power(usr, 50))
 		return
 
-	log_say("Yautja Translator/[usr.client.ckey] : [msg]")
+	log_say("[usr.name != "Unknown" ? usr.name : "([usr.real_name])"] \[Yautja Translator\]: [msg] (CKEY: [usr.key]) (JOB: [usr.job])")
 
 	var/list/heard = get_mobs_in_view(7, usr)
 	for(var/mob/M in heard)

--- a/code/modules/mob/living/carbon/human/whisper.dm
+++ b/code/modules/mob/living/carbon/human/whisper.dm
@@ -112,7 +112,7 @@
 	spawn(30)
 		if(client) client.images -= speech_bubble
 		if(not_dead_speaker)
-			log_say("[name] \[Whisper\]: [message] (CKEY: [key]) (JOB: [job])")
+			log_say("[name != "Unknown" ? name : "([real_name])"] \[Whisper\]: [message] (CKEY: [key]) (JOB: [job])")
 			for(var/mob/M in listening)
 				if(M.client) M.client.images -= speech_bubble
 			for(var/mob/M in eavesdropping)

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -167,11 +167,11 @@ var/list/department_radio_keys = list(
 		if(message_mode)	// we are talking into a radio
 			if(message_mode == "headset")	// default value, means general
 				message_mode = "General"
-			log_say("[name] \[[message_mode]\]: [message] (CKEY: [key]) (JOB: [job])")
+			log_say("[name != "Unknown" ? name : "([real_name])"] \[[message_mode]\]: [message] (CKEY: [key]) (JOB: [job])")
 		else				// we talk normally
-			log_say("[name]: [message] (CKEY: [key]) (JOB: [job])")
+			log_say("[name != "Unknown" ? name : "([real_name])"]: [message] (CKEY: [key]) (JOB: [job])")
 	else
-		log_say("[name]: [message] (CKEY: [key])")
+		log_say("[name != "Unknown" ? name : "([real_name])"]: [message] (CKEY: [key])")
 
 	return 1
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

When someone speaks and their name displays as 'Unknown', it'll now display them as '(real_name)' instead. This applies primarily to preds. Additionally, adjusted pred translator speak to fit the standard log_say style.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Logging good.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
