### PR TITLE
XvX Boxer Nerf

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/warrior/warrior_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/warrior/warrior_powers.dm
@@ -213,7 +213,10 @@
 
 	var/datum/action/xeno_action/activable/jab/JA = get_xeno_action_by_type(X, /datum/action/xeno_action/activable/jab)
 	if (istype(JA) && !JA.action_cooldown_check())
-		JA.end_cooldown()
+		if(isXeno(H))
+			JA.reduce_cooldown(JA.xeno_cooldown / 2)
+		else
+			JA.end_cooldown()
 
 /datum/action/xeno_action/activable/jab/use_ability(atom/A)
 	var/mob/living/carbon/Xenomorph/X = owner
@@ -260,7 +263,10 @@
 		break
 
 	if (punch_action && !punch_action.action_cooldown_check())
-		punch_action.end_cooldown()
+		if(isXeno(H))
+			punch_action.reduce_cooldown(punch_action.xeno_cooldown / 2)
+		else
+			punch_action.end_cooldown()
 
 	H.Daze(3)
 	H.Slow(5)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Makes boxer not instantly end their punch/jab cooldown if the other is used on a xeno, instead cutting the cooldown by half. This should reduce the meta of going boxer during XvX and just using a macro to dominate the other team.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Makes more castes viable in XvX by weakening the boxer.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Boxers now half the cooldown of their abilities if they punch/jab a xeno rather than ending them. It still works as usual against humans.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
