### PR TITLE
SciAnnex Minor Fixes - not broken this time

### DIFF
--- a/maps/map_files/FOP_v3_Sciannex/Fiorina_SciAnnex.dmm
+++ b/maps/map_files/FOP_v3_Sciannex/Fiorina_SciAnnex.dmm
@@ -989,7 +989,7 @@
 /area/fiorina/lz/near_lzI)
 "aAM" = (
 /obj/structure/reagent_dispensers/fueltank/gas/hydrogen{
-	layer = 2.5
+	layer = 2.6
 	},
 /obj/structure/machinery/light/double/blue,
 /turf/open/floor/prison{
@@ -2180,7 +2180,7 @@
 /area/fiorina/maintenance)
 "bgG" = (
 /obj/structure/reagent_dispensers/watertank{
-	layer = 2.5
+	layer = 2.6
 	},
 /turf/open/floor/prison{
 	icon_state = "floor_plate";
@@ -4169,7 +4169,7 @@
 "cvr" = (
 /obj/structure/platform,
 /obj/structure/reagent_dispensers/oxygentank{
-	layer = 2.5
+	layer = 2.6
 	},
 /turf/open/floor/prison,
 /area/fiorina/lz/near_lzI)
@@ -9529,7 +9529,7 @@
 /area/fiorina/station/security)
 "fMY" = (
 /obj/structure/reagent_dispensers/watertank{
-	layer = 2.5
+	layer = 2.6
 	},
 /obj/structure/machinery/light/double/blue,
 /turf/open/floor/prison{
@@ -12104,6 +12104,7 @@
 /area/fiorina/station/medbay)
 "hpN" = (
 /obj/structure/prop/almayer/computers/mission_planning_system{
+	density = 0;
 	desc = "Its a telephone, and a computer. Woah.";
 	name = "\improper funny telephone booth";
 	pixel_x = 2;
@@ -20205,7 +20206,7 @@
 /area/fiorina/tumor/servers)
 "mpf" = (
 /obj/structure/reagent_dispensers/fueltank/gas/hydrogen{
-	layer = 2.5
+	layer = 2.6
 	},
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/fiorina/lz/near_lzII)
@@ -33911,7 +33912,7 @@
 /area/fiorina/station/transit_hub)
 "uSQ" = (
 /obj/structure/reagent_dispensers/watertank{
-	layer = 2.5
+	layer = 2.6
 	},
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/fiorina/lz/near_lzII)

--- a/maps/map_files/FOP_v3_Sciannex/Fiorina_SciAnnex.dmm
+++ b/maps/map_files/FOP_v3_Sciannex/Fiorina_SciAnnex.dmm
@@ -3314,7 +3314,6 @@
 /obj/structure/machinery/portable_atmospherics/hydroponics{
 	draw_warnings = 0;
 	health = null;
-	icon_state = "hydrotray5";
 	indestructible = 1;
 	unacidable = 1
 	},


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

A group of three telephones all intended to be density 0, had one in the line that was density 1, meaning people could not walk through them as intended since they're offset onto a wall.
Reagent tanks around LZ1 and LZ2 were on lower layers than nearby floor decals, this changes it so that they will show above floor decals properly.
Hydrotrays on SciAnnex were using an icon state that no longer exists and as such were effectively invisible walls, their icon state has been changed to an existing & functional one.

## Why It's Good For The Game

Invisible walls are bad for the game, this fixes some.
Visual consistency & making sense is important for atmosphere, good for the game to have reagent tanks prioritised over floor decals.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: ChainsawMullet
fix: Annex telephone no longer so dense it creates an invisible wall.
fix: Reagent tanks around LZ1 and LZ2 now properly display over floor decals.
fix: Hydrotrays are no longer invisible on Science Annex.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
