### PR TITLE
getting noted now sends you a message telling you what the note is

### DIFF
--- a/code/datums/entities/player.dm
+++ b/code/datums/entities/player.dm
@@ -83,16 +83,15 @@ BSQL_PROTECT_DATUM(/datum/entity/player)
 	// this is here for a short transition period when we still are testing DB notes and constantly deleting the file
 	if(CONFIG_GET(flag/duplicate_notes_to_file))
 		if(!is_confidential && note_category == NOTE_ADMIN)
-			notes_add(ckey, note_text, admin.mob, TRUE)
-		else
 			notes_add(ckey, note_text, admin.mob)
 	else
 		// notes_add already sends a message
 		message_staff("[key_name_admin(admin.mob)] has edited [ckey]'s [note_categories[note_category]] notes: [sanitize(note_text)]")
-		if(!is_confidential && note_category == NOTE_ADMIN)
-			to_chat_immediate(usr, SPAN_WARNING(FONT_SIZE_LARGE("You have been noted by [key_name_admin(admin.mob, FALSE)].")))
-			to_chat_immediate(usr, SPAN_WARNING(FONT_SIZE_BIG("The note is : [sanitize(note_text)]")))
-			to_chat_immediate(usr, SPAN_WARNING(FONT_SIZE_BIG("If you think this was filed in error or wish to contest the note, make a staff report at <a href='https://cm-ss13.com/forums/forms.php?do=form&fid=12;'><b>The CM Forums</b></a>")))
+	if(!is_confidential && note_category == NOTE_ADMIN && owning_client)
+		to_chat_immediate(owning_client, SPAN_WARNING(FONT_SIZE_LARGE("You have been noted by [key_name_admin(admin.mob, FALSE)].")))
+		to_chat_immediate(owning_client, SPAN_WARNING(FONT_SIZE_BIG("The note is : [sanitize(note_text)]")))
+		to_chat_immediate(owning_client, SPAN_WARNING(FONT_SIZE_BIG("If you think this was filed in error or wish to contest the note, make a staff report at <a href='https://cm-ss13.com/forums/forms.php?do=form&fid=12;'><b>The CM Forums</b></a>")))
+		to_chat_immediate(owning_client, SPAN_WARNING(FONT_SIZE_BIG("You can also click the name of the staff member noting you to PM them.")))
 	// create new instance of player_note entity
 	var/datum/entity/player_note/note = DB_ENTITY(/datum/entity/player_note)
 	// set its related data

--- a/code/datums/entities/player.dm
+++ b/code/datums/entities/player.dm
@@ -82,11 +82,17 @@ BSQL_PROTECT_DATUM(/datum/entity/player)
 
 	// this is here for a short transition period when we still are testing DB notes and constantly deleting the file
 	if(CONFIG_GET(flag/duplicate_notes_to_file))
-		notes_add(ckey, note_text, admin.mob)
+		if(!is_confidential && note_category == NOTE_ADMIN)
+			notes_add(ckey, note_text, admin.mob, TRUE)
+		else
+			notes_add(ckey, note_text, admin.mob)
 	else
 		// notes_add already sends a message
 		message_staff("[key_name_admin(admin.mob)] has edited [ckey]'s [note_categories[note_category]] notes: [sanitize(note_text)]")
-
+		if(!is_confidential && note_category == NOTE_ADMIN)
+			to_chat_immediate(usr, SPAN_WARNING(FONT_SIZE_LARGE("You have been noted by [key_name_admin(admin.mob)].")))
+			to_chat_immediate(usr, SPAN_WARNING(FONT_SIZE_BIG("The note is : [sanitize(note_text)]")))
+			to_chat_immediate(usr, SPAN_WARNING(FONT_SIZE_BIG("If you think this was filed in error or wish to contest the note, make a staff report at <a href='https://cm-ss13.com/forums/forms.php?do=form&fid=12;'><b>The CM Forums</b></a>")))
 	// create new instance of player_note entity
 	var/datum/entity/player_note/note = DB_ENTITY(/datum/entity/player_note)
 	// set its related data

--- a/code/datums/entities/player.dm
+++ b/code/datums/entities/player.dm
@@ -90,7 +90,7 @@ BSQL_PROTECT_DATUM(/datum/entity/player)
 		// notes_add already sends a message
 		message_staff("[key_name_admin(admin.mob)] has edited [ckey]'s [note_categories[note_category]] notes: [sanitize(note_text)]")
 		if(!is_confidential && note_category == NOTE_ADMIN)
-			to_chat_immediate(usr, SPAN_WARNING(FONT_SIZE_LARGE("You have been noted by [key_name_admin(admin.mob)].")))
+			to_chat_immediate(usr, SPAN_WARNING(FONT_SIZE_LARGE("You have been noted by [key_name_admin].")))
 			to_chat_immediate(usr, SPAN_WARNING(FONT_SIZE_BIG("The note is : [sanitize(note_text)]")))
 			to_chat_immediate(usr, SPAN_WARNING(FONT_SIZE_BIG("If you think this was filed in error or wish to contest the note, make a staff report at <a href='https://cm-ss13.com/forums/forms.php?do=form&fid=12;'><b>The CM Forums</b></a>")))
 	// create new instance of player_note entity

--- a/code/datums/entities/player.dm
+++ b/code/datums/entities/player.dm
@@ -90,7 +90,7 @@ BSQL_PROTECT_DATUM(/datum/entity/player)
 		// notes_add already sends a message
 		message_staff("[key_name_admin(admin.mob)] has edited [ckey]'s [note_categories[note_category]] notes: [sanitize(note_text)]")
 		if(!is_confidential && note_category == NOTE_ADMIN)
-			to_chat_immediate(usr, SPAN_WARNING(FONT_SIZE_LARGE("You have been noted by [key_name_admin].")))
+			to_chat_immediate(usr, SPAN_WARNING(FONT_SIZE_LARGE("You have been noted by [key_name_admin(admin.mob, FALSE)].")))
 			to_chat_immediate(usr, SPAN_WARNING(FONT_SIZE_BIG("The note is : [sanitize(note_text)]")))
 			to_chat_immediate(usr, SPAN_WARNING(FONT_SIZE_BIG("If you think this was filed in error or wish to contest the note, make a staff report at <a href='https://cm-ss13.com/forums/forms.php?do=form&fid=12;'><b>The CM Forums</b></a>")))
 	// create new instance of player_note entity

--- a/code/modules/admin/player_notes.dm
+++ b/code/modules/admin/player_notes.dm
@@ -1,4 +1,4 @@
-/proc/notes_add(var/key, var/note, var/mob/usr)
+/proc/notes_add(var/key, var/note, var/mob/usr, var/send_message = FALSE)
 	if (!key || !note)
 		return
 
@@ -41,7 +41,9 @@
 	info << infos
 
 	message_staff("[key_name_admin(usr)] has edited [key]'s notes: [sanitize(note)]")
-
+	to_chat_immediate(usr, SPAN_WARNING(FONT_SIZE_LARGE("You have been noted by [key_name_admin(usr)].")))
+	to_chat_immediate(usr, SPAN_WARNING(FONT_SIZE_BIG("The note is : [sanitize(note)]")))
+	to_chat_immediate(usr, SPAN_WARNING(FONT_SIZE_BIG("If you think this was filed in error or wish to contest the note, make a staff report at <a href='https://cm-ss13.com/forums/forms.php?do=form&fid=12;'><b>The CM Forums</b></a>")))
 	qdel(info)
 
 	//Updating list of keys with notes on them

--- a/code/modules/admin/player_notes.dm
+++ b/code/modules/admin/player_notes.dm
@@ -1,4 +1,4 @@
-/proc/notes_add(var/key, var/note, var/mob/usr, var/send_message = FALSE)
+/proc/notes_add(var/key, var/note, var/mob/usr)
 	if (!key || !note)
 		return
 
@@ -41,9 +41,6 @@
 	info << infos
 
 	message_staff("[key_name_admin(usr)] has edited [key]'s notes: [sanitize(note)]")
-	to_chat_immediate(usr, SPAN_WARNING(FONT_SIZE_LARGE("You have been noted by [key_name_admin(usr, FALSE)].")))
-	to_chat_immediate(usr, SPAN_WARNING(FONT_SIZE_BIG("The note is : [sanitize(note)]")))
-	to_chat_immediate(usr, SPAN_WARNING(FONT_SIZE_BIG("If you think this was filed in error or wish to contest the note, make a staff report at <a href='https://cm-ss13.com/forums/forms.php?do=form&fid=12;'><b>The CM Forums</b></a>")))
 	qdel(info)
 
 	//Updating list of keys with notes on them

--- a/code/modules/admin/player_notes.dm
+++ b/code/modules/admin/player_notes.dm
@@ -41,7 +41,7 @@
 	info << infos
 
 	message_staff("[key_name_admin(usr)] has edited [key]'s notes: [sanitize(note)]")
-	to_chat_immediate(usr, SPAN_WARNING(FONT_SIZE_LARGE("You have been noted by [key_name_admin].")))
+	to_chat_immediate(usr, SPAN_WARNING(FONT_SIZE_LARGE("You have been noted by [key_name_admin(usr, FALSE)].")))
 	to_chat_immediate(usr, SPAN_WARNING(FONT_SIZE_BIG("The note is : [sanitize(note)]")))
 	to_chat_immediate(usr, SPAN_WARNING(FONT_SIZE_BIG("If you think this was filed in error or wish to contest the note, make a staff report at <a href='https://cm-ss13.com/forums/forms.php?do=form&fid=12;'><b>The CM Forums</b></a>")))
 	qdel(info)

--- a/code/modules/admin/player_notes.dm
+++ b/code/modules/admin/player_notes.dm
@@ -41,7 +41,7 @@
 	info << infos
 
 	message_staff("[key_name_admin(usr)] has edited [key]'s notes: [sanitize(note)]")
-	to_chat_immediate(usr, SPAN_WARNING(FONT_SIZE_LARGE("You have been noted by [key_name_admin(usr)].")))
+	to_chat_immediate(usr, SPAN_WARNING(FONT_SIZE_LARGE("You have been noted by [key_name_admin].")))
 	to_chat_immediate(usr, SPAN_WARNING(FONT_SIZE_BIG("The note is : [sanitize(note)]")))
 	to_chat_immediate(usr, SPAN_WARNING(FONT_SIZE_BIG("If you think this was filed in error or wish to contest the note, make a staff report at <a href='https://cm-ss13.com/forums/forms.php?do=form&fid=12;'><b>The CM Forums</b></a>")))
 	qdel(info)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

![image](https://user-images.githubusercontent.com/66756236/163727730-4b0747a5-56c8-4e4a-966b-276f356839f7.png)
basically, tells players when they get noted. 

PIC OUTDATED, NO LONGER SHOWS IC NAME OF THE ADMIN

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

There were a few staff reports recently about staff not properly communicating to people that they have been noted, and there's the everpresent issue of notes being put on the wrong player. As people can currently see their notes ingame with ease, there's little reason not to add this.

It does not show for cnotes or any type of note that's not an admin note such as a merit note.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
admin: when a player gets noted, they will get a to_chat telling them what their note is and who noted them, and giving instructions on how to appeal it. It will not display for cnotes or non-admin notes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
