### PR TITLE
SurvSynth / WJ Nightvision

### DIFF
--- a/code/__DEFINES/human.dm
+++ b/code/__DEFINES/human.dm
@@ -142,6 +142,10 @@
 //Synthetic Defines
 #define SYNTH_COLONY	"Colonial Synthetic"
 #define SYNTH_COMBAT	"Combat Synthetic"
+#define SYNTH_WORKING_JOE "Working Joe"
 #define SYNTH_GEN_ONE	"First Generation Synthetic"
 #define SYNTH_GEN_TWO	"Second Generation Synthetic"
 #define SYNTH_GEN_THREE	"Third Generation Synthetic"
+
+#define PLAYER_SYNTHS list(SYNTH_GEN_ONE, SYNTH_GEN_TWO, SYNTH_GEN_THREE)
+#define SYNTH_TYPES list(SYNTH_COLONY, SYNTH_COMBAT, SYNTH_WORKING_JOE, SYNTH_GEN_ONE, SYNTH_GEN_TWO, SYNTH_GEN_THREE)

--- a/code/_globalvars/global_lists.dm
+++ b/code/_globalvars/global_lists.dm
@@ -128,7 +128,6 @@ var/global/list/untracked_yautja_gear = list() // List of untracked loose pred g
 GLOBAL_LIST_INIT_TYPED(all_species, /datum/species, setup_species())
 GLOBAL_REFERENCE_LIST_INDEXED(all_languages, /datum/language, name)
 GLOBAL_LIST_INIT(language_keys, setup_language_keys())					//table of say codes for all languages
-var/global/list/synth_types = list(SYNTH_GEN_ONE,SYNTH_GEN_TWO, SYNTH_GEN_THREE)
 
 //Xeno mutators
 GLOBAL_REFERENCE_LIST_INDEXED_SORTED(xeno_mutator_list, /datum/xeno_mutator, name)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -59,7 +59,7 @@ var/const/MAX_SAVE_SLOTS = 10
 
 	//Synthetic specific preferences
 	var/synthetic_name = "Undefined"
-	var/synthetic_type = "Synthetic"
+	var/synthetic_type = SYNTH_GEN_THREE
 	//Predator specific preferences.
 	var/predator_name = "Undefined"
 	var/predator_gender = MALE
@@ -918,7 +918,7 @@ var/const/MAX_SAVE_SLOTS = 10
 						if(new_name) synthetic_name = new_name
 						else to_chat(user, "<font color='red'>Invalid name. Your name should be at least 2 and at most [MAX_NAME_LEN] characters long. It may only contain the characters A-Z, a-z, -, ' and .</font>")
 				if("synth_type")
-					var/new_synth_type = tgui_input_list(user, "Choose your model of synthetic:", "Make and Model", synth_types)
+					var/new_synth_type = tgui_input_list(user, "Choose your model of synthetic:", "Make and Model", PLAYER_SYNTHS)
 					if(new_synth_type) synthetic_type = new_synth_type
 				if("pred_name")
 					var/raw_name = input(user, "Choose your Predator's name:", "Character Preference")  as text|null

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -138,7 +138,7 @@
 	no_radials_preference = sanitize_integer(no_radials_preference, FALSE, TRUE, FALSE)
 
 	synthetic_name 		= synthetic_name ? sanitize_text(synthetic_name, initial(synthetic_name)) : initial(synthetic_name)
-	synthetic_type		= sanitize_text(synthetic_type, initial(synthetic_type))
+	synthetic_type		= sanitize_inlist(synthetic_type, PLAYER_SYNTHS, initial(synthetic_type))
 	predator_name 		= predator_name ? sanitize_text(predator_name, initial(predator_name)) : initial(predator_name)
 	predator_gender 	= sanitize_text(predator_gender, initial(predator_gender))
 	predator_age 		= sanitize_integer(predator_age, 100, 10000, initial(predator_age))

--- a/code/modules/gear_presets/synths.dm
+++ b/code/modules/gear_presets/synths.dm
@@ -9,10 +9,10 @@
 	access = get_all_accesses()
 
 /datum/equipment_preset/synth/load_race(mob/living/carbon/human/H)
-	if(!H.client || !H.client.prefs || !H.client.prefs.synthetic_type)
-		H.set_species("Synthetic")
-	else
+	if(H.client?.prefs?.synthetic_type)
 		H.set_species(H.client.prefs.synthetic_type)
+		return
+	H.set_species(SYNTH_GEN_THREE)
 
 /datum/equipment_preset/synth/load_name(mob/living/carbon/human/H, var/randomise)
 	var/final_name = "David"
@@ -148,7 +148,7 @@
 	access = get_all_accesses()
 
 /datum/equipment_preset/synth/working_joe/load_race(mob/living/carbon/human/H)
-	H.set_species(SYNTH_COLONY)
+	H.set_species(SYNTH_WORKING_JOE)
 
 /datum/equipment_preset/synth/working_joe/load_gear(mob/living/carbon/human/H)
 	H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/synthetic/joe(H), WEAR_BODY)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1117,6 +1117,9 @@
 	if(!(species.flags & HAS_UNDERWEAR))
 		INVOKE_ASYNC(src, .proc/remove_underwear)
 
+	default_lighting_alpha = species.default_lighting_alpha
+	update_sight()
+
 	if(species)
 		return TRUE
 	else
@@ -1251,7 +1254,7 @@
 
 	sight &= ~BLIND // Never have blind on by default
 
-	lighting_alpha = LIGHTING_PLANE_ALPHA_VISIBLE
+	lighting_alpha = default_lighting_alpha
 	sight &= ~(SEE_TURFS|SEE_MOBS|SEE_OBJS)
 	see_in_dark = species.darksight
 	if(glasses)
@@ -1426,7 +1429,7 @@
 	. = ..(mapload, new_species = "Yiren")
 
 /mob/living/carbon/human/synthetic/Initialize(mapload)
-	. = ..(mapload, "Synthetic")
+	. = ..(mapload, SYNTH_GEN_THREE)
 
 /mob/living/carbon/human/synthetic/old/Initialize(mapload)
 	. = ..(mapload, SYNTH_COLONY)
@@ -1439,9 +1442,6 @@
 
 /mob/living/carbon/human/synthetic/second/Initialize(mapload)
 	. = ..(mapload, SYNTH_GEN_TWO)
-
-/mob/living/carbon/human/synthetic/third/Initialize(mapload)
-	. = ..(mapload, SYNTH_GEN_THREE)
 
 
 /mob/living/carbon/human/resist_fire()

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -140,6 +140,8 @@
 
 	var/list/synthetic_HUD_toggled = list(FALSE,FALSE)
 
+	var/default_lighting_alpha = LIGHTING_PLANE_ALPHA_VISIBLE
+
 	//Taken from update_icons
 	var/list/overlays_standing[TOTAL_LAYERS]
 	var/previous_damage_appearance // store what the body last looked like, so we only have to update it if something changed

--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -315,10 +315,11 @@
 	to_chat(src, SPAN_NOTICE("You are now [resting ? "resting." : "getting up."]"))
 
 // Used for synthetics
-/mob/living/carbon/human/synthetic/verb/toggle_HUD()
+/mob/living/carbon/human/synthetic/proc/toggle_HUD()
 	set category = "Synthetic"
 	set name = "Toggle HUDs"
 	set desc = "Toggles various HUDs."
+
 	if(!isSynth(usr) || usr.is_mob_incapacitated())
 		return
 

--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -314,6 +314,19 @@
 
 	to_chat(src, SPAN_NOTICE("You are now [resting ? "resting." : "getting up."]"))
 
+/mob/living/carbon/human/proc/toggle_inherent_nightvison()
+	set category = "Synthetic"
+	set name = "Toggle Nightvision"
+	set desc = "Toggles inherent nightvision."
+
+	if(usr.is_mob_incapacitated())
+		return
+
+	default_lighting_alpha = default_lighting_alpha == LIGHTING_PLANE_ALPHA_VISIBLE ? LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE : LIGHTING_PLANE_ALPHA_VISIBLE
+	update_sight()
+
+	to_chat(src, SPAN_NOTICE("Your vision is now set to <b>[default_lighting_alpha == LIGHTING_PLANE_ALPHA_VISIBLE ? "Normal Vision" : "Nightvision"]</b>."))
+
 // Used for synthetics
 /mob/living/carbon/human/synthetic/proc/toggle_HUD()
 	set category = "Synthetic"

--- a/code/modules/mob/living/carbon/human/life/life_helpers.dm
+++ b/code/modules/mob/living/carbon/human/life/life_helpers.dm
@@ -209,7 +209,8 @@
 	see_in_dark += G.darkness_view
 	if(G.vision_flags)
 		sight |= G.vision_flags
-	lighting_alpha = G.lighting_alpha
+	if(G.lighting_alpha < lighting_alpha)
+		lighting_alpha = G.lighting_alpha
 
 /mob/living/carbon/human/handle_silent()
 	if(..())

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -61,6 +61,7 @@
 	var/reagent_tag                 //Used for metabolizing reagents.
 
 	var/darksight = 2
+	var/default_lighting_alpha = LIGHTING_PLANE_ALPHA_VISIBLE
 
 	var/brute_mod = null    // Physical damage reduction/malus.
 	var/burn_mod = null     // Burn damage reduction/malus.

--- a/code/modules/mob/living/carbon/human/species/synthetic.dm
+++ b/code/modules/mob/living/carbon/human/species/synthetic.dm
@@ -1,6 +1,6 @@
 /datum/species/synthetic
 	group = SPECIES_SYNTHETIC
-	name = "Synthetic"
+	name = SYNTH_GEN_THREE
 	name_plural = "synthetics"
 	uses_ethnicity = TRUE //Uses ethnic presets
 
@@ -40,8 +40,8 @@
 	stun_reduction = 5
 
 	inherent_verbs = list(
-		/mob/living/carbon/human/synthetic/verb/toggle_HUD
-		)
+		/mob/living/carbon/human/synthetic/proc/toggle_HUD
+	)
 
 /datum/species/synthetic/handle_post_spawn(mob/living/carbon/human/H)
 	H.set_languages(list(LANGUAGE_ENGLISH, LANGUAGE_RUSSIAN, LANGUAGE_JAPANESE, LANGUAGE_WELTRAUMDEUTSCH, LANGUAGE_NEOSPANISH, LANGUAGE_YAUTJA, LANGUAGE_XENOMORPH))
@@ -49,16 +49,13 @@
 	return ..()
 
 /datum/species/synthetic/apply_signals(var/mob/living/carbon/human/H)
-	RegisterSignal(H, COMSIG_HUMAN_IMPREGNATE, .proc/cancel_impregnate)
+	RegisterSignal(H, COMSIG_HUMAN_IMPREGNATE, .proc/cancel_impregnate, TRUE)
 
 /datum/species/synthetic/proc/cancel_impregnate(datum/source)
 	SIGNAL_HANDLER
 	return COMPONENT_NO_IMPREGNATE
 
-/datum/species/synthetic/shipside
-	name = SYNTH_GEN_THREE
-
-/datum/species/synthetic/shipside/gen_one
+/datum/species/synthetic/gen_one
 	name = SYNTH_GEN_ONE
 	uses_ethnicity = FALSE
 	mob_inherent_traits = list(TRAIT_SUPER_STRONG, TRAIT_INTENT_EYES)
@@ -67,7 +64,7 @@
 	icobase = 'icons/mob/humans/species/r_synthetic.dmi'
 	deform = 'icons/mob/humans/species/r_synthetic.dmi'
 
-/datum/species/synthetic/shipside/gen_two
+/datum/species/synthetic/gen_two
 	name = SYNTH_GEN_TWO
 	uses_ethnicity = FALSE //2nd gen uses generic human look
 
@@ -86,12 +83,18 @@
 	slowdown = 0.45
 	total_health = 200 //But more durable
 
+	default_lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
+
 	hair_color = "#000000"
 
 	knock_down_reduction = 3.5
 	stun_reduction = 3.5
 
 	inherent_verbs = null
+
+/datum/species/synthetic/colonial/working_joe
+	name = SYNTH_WORKING_JOE
+	name_plural = "Working Joes"
 
 // Synth used for W-Y Deathsquads
 /datum/species/synthetic/colonial/combat
@@ -101,16 +104,7 @@
 
 	total_health = 250 //Made for Combat
 
+	default_lighting_alpha = LIGHTING_PLANE_ALPHA_VISIBLE // we don't want combat synths to run around in the dark
+
 	knock_down_reduction = 5.0
 	stun_reduction = 5.0
-
-
-//Event Synthetics
-/datum/species/synthetic/colonial/event
-	name = "Event Synthetic" //To prevent any conflicts with natural spawns for events.
-/datum/species/synthetic/shipside/event
-	name = "Event Synthetic" //To prevent any conflicts with natural spawns for events.
-/datum/species/synthetic/shipside/gen_one/event
-	name = "Event Synthetic" //To prevent any conflicts with natural spawns for events.
-/datum/species/synthetic/shipside/gen_two/event
-	name = "Event Synthetic" //To prevent any conflicts with natural spawns for events.

--- a/code/modules/mob/living/carbon/human/species/synthetic.dm
+++ b/code/modules/mob/living/carbon/human/species/synthetic.dm
@@ -90,7 +90,9 @@
 	knock_down_reduction = 3.5
 	stun_reduction = 3.5
 
-	inherent_verbs = null
+	inherent_verbs = list(
+		/mob/living/carbon/human/proc/toggle_inherent_nightvison
+	)
 
 /datum/species/synthetic/colonial/working_joe
 	name = SYNTH_WORKING_JOE
@@ -108,3 +110,5 @@
 
 	knock_down_reduction = 5.0
 	stun_reduction = 5.0
+
+	inherent_verbs = null

--- a/code/modules/mob/new_player/sprite_accessories.dm
+++ b/code/modules/mob/new_player/sprite_accessories.dm
@@ -32,13 +32,11 @@
 		"Human",
 		"Machine",
 		"Human Hero",
-		"Synthetic",
 		SYNTH_COLONY,
 		SYNTH_COMBAT,
 		SYNTH_GEN_ONE,
 		SYNTH_GEN_TWO,
-		SYNTH_GEN_THREE,
-		"Event Synthetic"
+		SYNTH_GEN_THREE
 		)
 
 	// Whether or not the accessory can be affected by colouration

--- a/code/modules/surgery/headreattach.dm
+++ b/code/modules/surgery/headreattach.dm
@@ -22,13 +22,11 @@
 	var/obj/item/limb/head/synth/patient_head
 	var/no_revive = FALSE
 	var/list/species_allowed = list(
-		"Synthetic",
 		SYNTH_COLONY,
 		SYNTH_COMBAT,
 		SYNTH_GEN_ONE,
 		SYNTH_GEN_TWO,
-		SYNTH_GEN_THREE,
-		"Event Synthetic"
+		SYNTH_GEN_THREE
 		)
 
 /datum/surgery/head_reattach/can_start(mob/user, mob/living/carbon/human/patient, obj/limb/L, obj/item/tool)
@@ -40,7 +38,7 @@
 
 /datum/surgery_step/peel_skin
 	name = "Peel Back Skin"
-	desc = "peel the skin back"	
+	desc = "peel the skin back"
 	//Tools used to pry things open without orthopedic dramatics.
 	tools = list(
 		/obj/item/tool/surgery/retractor = SURGERY_TOOL_MULT_IDEAL,
@@ -116,7 +114,7 @@
 
 /datum/surgery_step/mend_connections
 	name = "Reconstruct Throat"
-	desc = "reconstruct the throat"	
+	desc = "reconstruct the throat"
 	tools = SURGERY_TOOLS_MEND_BLOODVESSEL
 	time = 4 SECONDS
 
@@ -155,7 +153,7 @@
 	user.visible_message(SPAN_NOTICE("[user] finishes adjusting [target]'s neck."),	\
 	SPAN_NOTICE("You finish adjusting [target]'s neck."))
 	log_interact(user, target, "[key_name(user)] adjusted the area around [key_name(target)]'s neck with \the [tool].")
-	
+
 	if(!surgery.no_revive) //Unset this flag if they didn't have it before the surgery started.
 		target.status_flags &= ~PERMANENTLY_DEAD
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Cleans up the synth code by deleting all the additional useless synth species. (I assume these were added because smartpacks used to modify the species rather than the human)

Gives Survivor Synths and Working Joes partial nightvision, like xenos have. They can toggle this off and on in the Survivor tab.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Working Joes seem to have partial nightvision in the official video games, and also it would be kinda neat to give them a unique gimmick.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Survivor Synths and Working Joes now have partial nightvision.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
