### PR TITLE
Survivor Snow Suit Bugfix

### DIFF
--- a/code/modules/clothing/suits/labcoat.dm
+++ b/code/modules/clothing/suits/labcoat.dm
@@ -145,7 +145,7 @@
 	armor_laser = CLOTHING_ARMOR_LOW
 	armor_energy = CLOTHING_ARMOR_LOW
 	armor_bomb = CLOTHING_ARMOR_NONE
-	armor_bio = CLOTHING_ARMOR_NONE
+	armor_bio = CLOTHING_ARMOR_MEDIUM
 	armor_rad = CLOTHING_ARMOR_NONE
 	armor_internaldamage = CLOTHING_ARMOR_LOW
 	min_cold_protection_temperature = ICE_PLANET_min_cold_protection_temperature

--- a/code/modules/clothing/suits/labcoat.dm
+++ b/code/modules/clothing/suits/labcoat.dm
@@ -163,6 +163,7 @@
 	armor_bullet = CLOTHING_ARMOR_NONE
 	armor_laser = CLOTHING_ARMOR_NONE
 	armor_energy = CLOTHING_ARMOR_NONE
+	armor_bio = CLOTHING_ARMOR_NONE
 	armor_internaldamage = CLOTHING_ARMOR_NONE
 	allowed = list(
 		/obj/item/device/analyzer,


### PR DESCRIPTION
## Abstract

Fixes oversight related to armor vest buff update.

## Goals

This update basically resolves the issue of the robust snowsuit not having bio protection due to it inheriting the traits from the normal snowsuit. 

## Content

Updates parent snowsuit to have bio protection robust snowsuit is supposed to have

## Potential Changes

Doctors' snowsuits found on colonies now have bio protection. This really shouldn't be a problem as snowsuits don't spawn normally on the alyamer. Doctors use the service jacket and other methods of protection from the cold.


## Why It's Good For The Game

Fixes a cheese strategy of capturing survivors which were intended to be fixed by https://gitlab.com/cmdevs/colonial-warfare/-/merge_requests/2537/diffs . Apparently, the oversight of a parent results in its return.

## Changelog
:cl:
fix: fixed robust snowsuit not having bio protection due to bad parent
/:cl:


