### PR TITLE
Minor M39 Buff / Tweak

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -757,7 +757,7 @@
 	effective_range_max = 4
 	penetration = ARMOR_PENETRATION_TIER_1
 	shell_speed = AMMO_SPEED_TIER_6
-	damage_falloff = DAMAGE_FALLOFF_TIER_3
+	damage_falloff = DAMAGE_FALLOFF_TIER_5 // Makes the M39 AP + HV Viable in mostly close range. Previous falloff problem was a bandaid on a bleeding artery.
 	scatter = SCATTER_AMOUNT_TIER_6
 	accuracy = HIT_ACCURACY_TIER_3
 

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -757,7 +757,7 @@
 	effective_range_max = 4
 	penetration = ARMOR_PENETRATION_TIER_1
 	shell_speed = AMMO_SPEED_TIER_6
-	damage_falloff = DAMAGE_FALLOFF_TIER_5 // Makes the M39 AP + HV Viable in mostly close range. Previous falloff problem was a bandaid on a bleeding artery.
+	damage_falloff = DAMAGE_FALLOFF_TIER_5
 	scatter = SCATTER_AMOUNT_TIER_6
 	accuracy = HIT_ACCURACY_TIER_3
 
@@ -767,7 +767,7 @@
 /datum/ammo/bullet/smg/ap
 	name = "armor-piercing submachinegun bullet"
 
-	damage = 26 //Set to 26, Nanu gave the okay to test it around 26-28 previously. Ordered to be 26 from 24 for now.
+	damage = 26
 	penetration = ARMOR_PENETRATION_TIER_6
 	shell_speed = AMMO_SPEED_TIER_4
 

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -767,7 +767,7 @@
 /datum/ammo/bullet/smg/ap
 	name = "armor-piercing submachinegun bullet"
 
-	damage = 24
+	damage = 26 //Set to 26, Nanu gave the okay to test it around 26-28 previously. Ordered to be 26 from 24 for now.
 	penetration = ARMOR_PENETRATION_TIER_6
 	shell_speed = AMMO_SPEED_TIER_4
 

--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -74,11 +74,11 @@
 	..()
 	fire_delay = FIRE_DELAY_TIER_SMG
 	burst_delay = FIRE_DELAY_TIER_SMG
-	burst_amount = BURST_AMOUNT_TIER_5
+	burst_amount = BURST_AMOUNT_TIER_3 //Triiodine said 5 was lore inaccurate, has a burst of three. Set to 3 to be lore accurate.
 	accuracy_mult = BASE_ACCURACY_MULT
 	accuracy_mult_unwielded = BASE_ACCURACY_MULT - HIT_ACCURACY_MULT_TIER_5
 	scatter = SCATTER_AMOUNT_TIER_4
-	burst_scatter_mult = SCATTER_AMOUNT_TIER_2
+	burst_scatter_mult = SCATTER_AMOUNT_TIER_4
 	scatter_unwielded = SCATTER_AMOUNT_TIER_4
 	damage_mult = BASE_BULLET_DAMAGE_MULT
 	recoil_unwielded = RECOIL_AMOUNT_TIER_5

--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -74,7 +74,7 @@
 	..()
 	fire_delay = FIRE_DELAY_TIER_SMG
 	burst_delay = FIRE_DELAY_TIER_SMG
-	burst_amount = BURST_AMOUNT_TIER_3 //Triiodine said 5 was lore inaccurate, has a burst of three. Set to 3 to be lore accurate.
+	burst_amount = BURST_AMOUNT_TIER_3
 	accuracy_mult = BASE_ACCURACY_MULT
 	accuracy_mult_unwielded = BASE_ACCURACY_MULT - HIT_ACCURACY_MULT_TIER_5
 	scatter = SCATTER_AMOUNT_TIER_4


### PR DESCRIPTION
(shaddeh has told me to thank him or else he will kill me thank u shaddeh thank u)
## About The Pull Request

Burst scatter amount changed from tier 2 to 4, meaning the burst amount should be more concise, and result in marine users being able to change between semi and burst when the situation calls, instead of having to default to semi-auto for every engagement.  Authorized by Nanu. (Original tier during M39 BFG era was Tier 6)

AP Damage improved from 24 to 26. Authorized by Nanu. (Previously stated 26-28 fine. Told to remain 26 for now.)

HV / AP Falloff from Tier 3 to Tier 5, should result in the weapon being useable in CQC, and bullets not doing no damage past tile 4. Advised by Stan.

Changed M39 Burst from 5 bullets, to 3 bullets to be lore accurate. Approved by Triiodine.

## Why It's Good For The Game

Generally adding this to help fix the M39 Question. For a long while it's been a noob-trap weapon that wasn't particularly viable, and this is coming from someone who still uses it to this day. 

I've improved the AP damage from 24 to 26. 

The burst scatter is now manageable and will not longer result in marines being able to fire directly behind them in game. (lol)

M39 Falloff for both HV and AP is improved, meaning it should do damage past tile 4. (That's not sarcasm) 

M39 Burst amount changed from 5 to 3, to be lore accurate, as advised by Triiodine. 

## Changelog

:cl:
balance: Changed burst scatter to be more bearable. From Tier 2 to 4.
balance: Improved the M39's falloff, from Tier 3 to Tier 5.
balance: Changed M39 AP from 24 > 26 Damage. 
fix: Fixed M39 Burst from 5 bullets to 3, to be lore accurate.
/:cl:
