### PR TITLE
Fixes Queens being able to gib marines with huggers attached

### DIFF
--- a/code/datums/diseases/gbs.dm
+++ b/code/datums/diseases/gbs.dm
@@ -35,6 +35,6 @@
 		if(5)
 			to_chat(affected_mob, SPAN_DANGER("Your body feels as if it's trying to rip itself open..."))
 			if(prob(50))
-				affected_mob.gib()
+				affected_mob.gib("GBS")
 		else
 			return

--- a/code/datums/diseases/rhumba_beat.dm
+++ b/code/datums/diseases/rhumba_beat.dm
@@ -46,6 +46,6 @@
 				src.cure()
 			to_chat(affected_mob, SPAN_DANGER("Your body is unable to contain the Rhumba Beat..."))
 			if(prob(50))
-				affected_mob.gib()
+				affected_mob.gib("Rhumba")
 		else
 			return

--- a/code/game/machinery/kitchen/gibber.dm
+++ b/code/game/machinery/kitchen/gibber.dm
@@ -48,7 +48,7 @@
 		if(M.loc == input_plate
 		)
 			M.forceMove(src)
-			M.gib()
+			M.gib("Gibber")
 
 
 /obj/structure/machinery/gibber/New()

--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -168,7 +168,7 @@
 				gibs_ready = 0
 				if(locate(/mob,contents))
 					var/mob/M = locate(/mob,contents)
-					M.gib()
+					M.gib("Washing Machine")
 			for(var/atom/movable/O in contents)
 				O.forceMove(loc)
 			crayon = null

--- a/code/game/objects/items/implants/implant.dm
+++ b/code/game/objects/items/implants/implant.dm
@@ -128,7 +128,7 @@ Implant Specifics:<BR>"}
 		if((!cause) || (!src.imp_in))	return 0
 		explosion(src, -1, 0, 2, 3, 0)//This might be a bit much, dono will have to see.
 		if(src.imp_in)
-			src.imp_in.gib()
+			src.imp_in.gib("Death Implant")
 
 	islegal()
 		return 0
@@ -195,16 +195,16 @@ Implant Specifics:<BR>"}
 							qdel(src)
 				if (elevel == "Destroy Body")
 					explosion(get_turf(T), -1, 0, 1, 6)
-					T.gib()
+					T.gib("Explosive Implant")
 				if (elevel == "Full Explosion")
 					explosion(get_turf(T), 0, 1, 3, 6)
-					T.gib()
+					T.gib("Explosive Implant")
 
 			else
 				explosion(get_turf(imp_in), 0, 1, 3, 6)
 
 		if(need_gib)
-			imp_in.gib()
+			imp_in.gib("Explosive Implant")
 
 
 	implanted(mob/source as mob)

--- a/code/modules/admin/verbs/mob_verbs.dm
+++ b/code/modules/admin/verbs/mob_verbs.dm
@@ -101,7 +101,7 @@
 		gibs(M.loc, M.viruses)
 		return
 
-	M.gib()
+	M.gib("Admin")
 
 /client/proc/cmd_admin_rejuvenate(mob/living/M as mob in GLOB.living_mob_list)
 	set category = null

--- a/code/modules/cm_marines/shuttle_backend.dm
+++ b/code/modules/cm_marines/shuttle_backend.dm
@@ -561,7 +561,7 @@ qdel(src)
 			if (isliving(A))
 				var/mob/living/L = A
 				L.last_damage_data = create_cause_data("dropship flattening")
-				L.gib()
+				L.gib("dropship")
 
 		target = target.ChangeTurf(/turf/open/gm/empty)
 

--- a/code/modules/cm_preds/smartdisc.dm
+++ b/code/modules/cm_preds/smartdisc.dm
@@ -196,7 +196,7 @@
 	spawn(1)
 		if(src) qdel(src)
 
-/mob/living/simple_animal/hostile/smartdisc/gib(var/cause = "gibbing")
+/mob/living/simple_animal/hostile/smartdisc/gib(var/cause = "smartdisc")
 	visible_message("\The [src] explodes!")
 	..(cause, icon_gib,1)
 	spawn(1)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -88,7 +88,7 @@
 		KnockOut(knock_value)
 		explosion_throw(severity, direction)
 
-/mob/living/carbon/gib(var/cause = "gibbing")
+/mob/living/carbon/gib(var/cause = "unknown means")
 	if(legcuffed)
 		drop_inv_item_on_ground(legcuffed)
 
@@ -105,8 +105,8 @@
 			if(O.unacidable)
 				O.forceMove(get_turf(loc))
 				O.throw_atom(pick(range(get_turf(loc), 1)), 1, SPEED_FAST)
-
-	. = ..(cause)
+	var/cause_data = create_cause_data("Gibbing by [cause]")
+	. = ..(cause_data)
 
 
 /mob/living/carbon/revive()

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -105,7 +105,7 @@
 			if(O.unacidable)
 				O.forceMove(get_turf(loc))
 				O.throw_atom(pick(range(get_turf(loc), 1)), 1, SPEED_FAST)
-	var/datum/cause_data = cause
+	var/datum/cause_data/cause_data = cause
 	if(!istype(cause_data))
 		cause_data = create_cause_data("Gibbing by [cause]")
 	. = ..(cause_data)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -105,7 +105,9 @@
 			if(O.unacidable)
 				O.forceMove(get_turf(loc))
 				O.throw_atom(pick(range(get_turf(loc), 1)), 1, SPEED_FAST)
-	var/cause_data = create_cause_data("Gibbing by [cause]")
+	var/datum/cause_data = cause
+	if(!istype(cause_data))
+		cause_data = create_cause_data("Gibbing by [cause]")
 	. = ..(cause_data)
 
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
@@ -697,6 +697,9 @@
 		if(!check_plasma(200))
 			return
 
+		if(locate(/obj/item/alien_embryo) in victim) //Maybe they ate it??
+			return//Checks for infection after gib starts, as hugger-stuns can be used for gib otherwise.
+
 		use_plasma(200)
 		last_special = world.time + 15 MINUTES
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
@@ -655,7 +655,7 @@
 	var/mob/living/carbon/human/H = victim
 	if(istype(H))
 		if(istype(H.wear_mask, /obj/item/clothing/mask/facehugger))
-			to_chat(src, SPAN_XENOWARNING("The host will soon bare a child of the hive!"))
+			to_chat(src, SPAN_XENOWARNING("The host will soon bear a child of the hive!"))
 			return FALSE
 
 		if(locate(/obj/item/alien_embryo) in victim) //Maybe they ate it??

--- a/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
@@ -652,18 +652,18 @@
 			to_chat(src, SPAN_WARNING("You can't bring yourself to harm a fellow sister to this magnitude."))
 			return FALSE
 
-	var/mob/living/carbon/human/H = victim
-	if(istype(H))
-		if(istype(H.wear_mask, /obj/item/clothing/mask/facehugger))
+	var/mob/living/carbon/human/Host = victim
+	if(istype(Host))
+		if(istype(Host.wear_mask, /obj/item/clothing/mask/facehugger))
 			to_chat(src, SPAN_XENOWARNING("The host will soon bear a child of the hive!"))
 			return FALSE
 
 		if(locate(/obj/item/alien_embryo) in victim) //Maybe they ate it??
-			if(H.status_flags & XENO_HOST)
+			if(Host.status_flags & XENO_HOST)
 				if(victim.stat != DEAD) //Not dead yet.
 					to_chat(src, SPAN_XENOWARNING("The host and child are still alive!"))
 					return FALSE
-				else if(( world.time <= H.timeofdeath + H.revive_grace_period )) //Dead, but the host can still hatch, possibly.
+				else if(( world.time <= Host.timeofdeath + Host.revive_grace_period )) //Dead, but the host can still hatch, possibly.
 					to_chat(src, SPAN_XENOWARNING("The child may still hatch! Not yet!"))
 					return FALSE
 	return TRUE

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -22,7 +22,7 @@
 	//animation = null
 
 	if(!species.primitive) //If the creature in question has no primitive set, this is going to be messy.
-		gib()
+		gib("Monkification")
 		return
 
 	var/mob/living/carbon/human/monkey/O = null

--- a/code/modules/movement/launching/launching.dm
+++ b/code/modules/movement/launching/launching.dm
@@ -192,7 +192,7 @@
 				if(A == LM.target)
 					hit_atom = A
 					break
-		launch_impact(hit_atom)
+//		launch_impact(hit_atom) causing duplication of smart discs
 	if (loc)
 		throwing = FALSE
 		rebounding = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Fixes Queen Gib to check for larva both before initiation and after, to prevent hugged humans being gibbed after infection when started before.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Queen Gib no longer works on hugged marines pre-infection
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
