### PR TITLE
Only PO's can set on FlyBy

### DIFF
--- a/code/modules/shuttles/shuttle_console.dm
+++ b/code/modules/shuttles/shuttle_console.dm
@@ -338,16 +338,17 @@ GLOBAL_LIST_EMPTY(shuttle_controls)
 	if(href_list["fire_mission"])
 		if(shuttle.moving_status != SHUTTLE_IDLE) return
 		if(shuttle.locked) return
-		shuttle.transit_gun_mission = !shuttle.transit_gun_mission
-		if(shuttle.transit_gun_mission)
+		if(!shuttle.transit_gun_mission)
 			var/mob/M = usr
 			if(M.mind && M.skills && !M.skills.get_skill_level(SKILL_PILOT)) //only pilots can activate the fire mission mode, but everyone can reset it back to transport..
 				to_chat(usr, SPAN_WARNING("A screen with graphics and walls of physics and engineering values open, you immediately force it closed."))
 				return
 			else
 				to_chat(usr, SPAN_NOTICE("You upload a flight plan for a low altitude flyby above the planet."))
+				shuttle.transit_gun_mission = TRUE
 		else
 			to_chat(usr, SPAN_NOTICE("You reset the flight plan to a transport mission between the Almayer and the planet."))
+			shuttle.transit_gun_mission = FALSE
 
 	if(href_list["lockdown"])
 		if(shuttle.door_override)


### PR DESCRIPTION
## About The Pull Request
With this changes makes so that only PO's can change the Fly Type from Transport to Fly By. With the other logic anyone can change the Fly Type. Anyone can set it back to Transport.

## Why It's Good For The Game
Makes the code work how its expected to work.

## Changelog
🆑
fix: Fixes an oversight letting anyone set a shuttle to flyby. Now only players with the pilot skill can set the shuttle to flyby.
/🆑