### PR TITLE
Synth eating

### DIFF
--- a/code/game/objects/items/reagent_containers/food/drinks.dm
+++ b/code/game/objects/items/reagent_containers/food/drinks.dm
@@ -30,7 +30,6 @@
 			reagents.trans_to_ingest(M, gulp_size)
 
 		playsound(M.loc,'sound/items/drink.ogg', 15, 1)
-		return TRUE
 
 		user.affected_message(M,
 			SPAN_HELPFUL("You <b>start feeding</b> [user == M ? "yourself" : "[M]"] <b>[src]</b>."),

--- a/code/game/objects/items/reagent_containers/food/drinks.dm
+++ b/code/game/objects/items/reagent_containers/food/drinks.dm
@@ -24,9 +24,6 @@
 		return FALSE
 
 	if(M == user)
-		if(istype(M,/mob/living/carbon/human))
-			var/mob/living/carbon/human/H = M
-
 		to_chat(M, SPAN_NOTICE(" You swallow a gulp from \the [src]."))
 		if(reagents.total_volume)
 			reagents.set_source_mob(user)
@@ -34,8 +31,6 @@
 
 		playsound(M.loc,'sound/items/drink.ogg', 15, 1)
 		return TRUE
-	else if(istype(M, /mob/living/carbon/human))
-		var/mob/living/carbon/human/H = M
 
 		user.affected_message(M,
 			SPAN_HELPFUL("You <b>start feeding</b> [user == M ? "yourself" : "[M]"] <b>[src]</b>."),

--- a/code/game/objects/items/reagent_containers/food/drinks.dm
+++ b/code/game/objects/items/reagent_containers/food/drinks.dm
@@ -26,9 +26,6 @@
 	if(M == user)
 		if(istype(M,/mob/living/carbon/human))
 			var/mob/living/carbon/human/H = M
-			if(H.species.flags & IS_SYNTHETIC)
-				to_chat(H, SPAN_DANGER("You have a monitor for a head, where do you think you're going to put that?"))
-				return FALSE
 
 		to_chat(M, SPAN_NOTICE(" You swallow a gulp from \the [src]."))
 		if(reagents.total_volume)
@@ -39,9 +36,6 @@
 		return TRUE
 	else if(istype(M, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = M
-		if(H.species.flags & IS_SYNTHETIC)
-			to_chat(user, SPAN_DANGER("They have a monitor for a head, where do you think you're going to put that?"))
-			return FALSE
 
 		user.affected_message(M,
 			SPAN_HELPFUL("You <b>start feeding</b> [user == M ? "yourself" : "[M]"] <b>[src]</b>."),

--- a/code/game/objects/items/reagent_containers/food/snacks.dm
+++ b/code/game/objects/items/reagent_containers/food/snacks.dm
@@ -58,16 +58,15 @@
 		if(fullness > 540 && world.time < C.overeat_cooldown)
 			to_chat(user, SPAN_WARNING("[user == M ? "You" : "They"] don't feel like eating more right now."))
 			return
+		if(istype(M,/mob/living/carbon/human))
+			var/mob/living/carbon/human/H = M
+			if(H.species.flags & IS_SYNTHETIC)
+				fullness = 200 //Synths never get full
 
 		if(fullness > 540)
 			C.overeat_cooldown = world.time + OVEREAT_TIME
 
 		if(M == user)//If you're eating it yourself
-			if(istype(M,/mob/living/carbon/human))
-				var/mob/living/carbon/human/H = M
-				if(H.species.flags & IS_SYNTHETIC)
-					to_chat(H, SPAN_DANGER("You have a monitor for a head, where do you think you're going to put that?"))
-					return
 			if (fullness <= 50)
 				to_chat(M, SPAN_WARNING("You hungrily chew out a piece of [src] and gobble it!"))
 			if (fullness > 50 && fullness <= 150)
@@ -79,12 +78,6 @@
 			if (fullness > 540)
 				to_chat(M, SPAN_WARNING("You reluctantly force more of [src] to go down your throat."))
 		else
-			if(istype(M,/mob/living/carbon/human))
-				var/mob/living/carbon/human/H = M
-				if(H.species.flags & IS_SYNTHETIC)
-					to_chat(H, SPAN_DANGER("They have a monitor for a head, where do you think you're going to put that?"))
-					return
-
 			if (fullness <= 540)
 				user.affected_message(M,
 					SPAN_HELPFUL("You <b>start feeding</b> [user == M ? "yourself" : "[M]"] <b>[src]</b>."),

--- a/code/game/objects/items/reagent_containers/food/snacks.dm
+++ b/code/game/objects/items/reagent_containers/food/snacks.dm
@@ -58,10 +58,8 @@
 		if(fullness > 540 && world.time < C.overeat_cooldown)
 			to_chat(user, SPAN_WARNING("[user == M ? "You" : "They"] don't feel like eating more right now."))
 			return
-		if(istype(M,/mob/living/carbon/human))
-			var/mob/living/carbon/human/H = M
-			if(H.species.flags & IS_SYNTHETIC)
-				fullness = 200 //Synths never get full
+		if(isSynth(C))
+			fullness = 200 //Synths never get full
 
 		if(fullness > 540)
 			C.overeat_cooldown = world.time + OVEREAT_TIME

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -176,7 +176,8 @@
 	var/datum/reagents/R = target.reagents
 	amount = min(min(amount, total_volume), R.maximum_volume - R.total_volume)
 	trans_to_datum(V, amount, reaction = FALSE)
-
+	if(isSynth(target))
+		return
 	to_chat(target, SPAN_NOTICE("You taste [pick(V.reagent_list)]."))
 
 	for(var/datum/reagent/RG in V.reagent_list) // If it can't be ingested, remove it.

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -145,6 +145,8 @@
 
 /// Transfers to the reagents datum of an object
 /datum/reagents/proc/trans_to(atom/target, var/amount=1, var/multiplier=1, var/preserve_data=1, var/reaction = TRUE)
+	if(isSynth(target))
+		return
 	var/datum/reagents/R = target?.reagents
 	if(R && !locked && !R.locked && total_volume > 0)
 		return trans_to_datum(R, amount, multiplier, preserve_data, reaction)
@@ -169,6 +171,7 @@
 
 /// Transfers to object as ingestion
 /datum/reagents/proc/trans_to_ingest(var/atom/movable/target, var/amount=1, var/multiplier=1, var/preserve_data=1) //For items ingested. A delay is added between ingestion and addition of the reagents
+
 	if(!target?.reagents || total_volume <= 0)
 		return
 

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -145,8 +145,6 @@
 
 /// Transfers to the reagents datum of an object
 /datum/reagents/proc/trans_to(atom/target, var/amount=1, var/multiplier=1, var/preserve_data=1, var/reaction = TRUE)
-	if(isSynth(target))
-		return
 	var/datum/reagents/R = target?.reagents
 	if(R && !locked && !R.locked && total_volume > 0)
 		return trans_to_datum(R, amount, multiplier, preserve_data, reaction)
@@ -171,7 +169,6 @@
 
 /// Transfers to object as ingestion
 /datum/reagents/proc/trans_to_ingest(var/atom/movable/target, var/amount=1, var/multiplier=1, var/preserve_data=1) //For items ingested. A delay is added between ingestion and addition of the reagents
-
 	if(!target?.reagents || total_volume <= 0)
 		return
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

"You sure you don't want some?"

What good is a synthetic at blending in if they can't even eat with humans?

This PR aims to give synthetics the ability to eat food. Until now whenever a synth tried to eat something, they'd be greeted by the clearly-taken-from-IPCs text "You have a monitor for a head, where are you gonna put that?". Does this make sense? Not really. But instead of just fixing that text I decided to go one further and let synths be able to consume stuff.

You might ask, is this realistic? Ask Ash and Bishop.

## Why It's Good For The Game

Synthetics were always stated in universe to be able to blend in almost flawlessly with humans, often not being able to find out if they're human or not except in certain conditions. A synth not being able to eat (you can only go "I'm not hungry" so many times) would eventually be a telltale sign that something's not right with them. So this PR aims to add immersion in that regard as well as just fostering more RP opportunities.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Synthetics can now eat and drink.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
