### PR TITLE
Shoulder Holster Quick Fix

### DIFF
--- a/code/modules/projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/gun_helpers.dm
@@ -541,6 +541,7 @@ As sniper rifles have both and weapon mods can change them as well. ..() deals w
 			var/obj/item/storage/internal/accessory/holster/HS = H.hold
 			if(HS.current_gun)
 				HS.current_gun.attack_hand(src)
+				return TRUE
 		return
 
 	if(istype(slot) && (slot.storage_flags & STORAGE_ALLOW_QUICKDRAW))
@@ -567,16 +568,21 @@ As sniper rifles have both and weapon mods can change them as well. ..() deals w
 		return
 
 	var/obj/item/W = get_active_hand()
-	var/obj/item/clothing/under/U = w_uniform
-	var/obj/item/clothing/accessory/holster/T
-	if(istype(U))
-		for(var/obj/item/clothing/accessory/holster/HS in U.accessories)
-			T = HS
-			break
 	if(W)
-		if(T && istype(W) && !T.holstered && T.can_holster(W))
-			T.holster(W, src)
-		else
+		if(w_uniform)
+			for(var/obj/A in w_uniform.accessories)
+				var/obj/item/clothing/accessory/holster/H = A
+				if(istype(H) && !H.holstered && H.can_holster(W))
+					H.holster(W, src)
+					return
+				
+				var/obj/item/clothing/accessory/storage/holster/HS = A
+				if(istype(HS))
+					var/obj/item/storage/internal/accessory/holster/S = HS.hold
+					if(S.can_be_inserted(W, TRUE))
+						S.handle_item_insertion(W, user = src)
+						return
+
 			quick_equip()
 	else //empty hand, start checking slots and holsters
 		var/list/slot_order


### PR DESCRIPTION
## About The Pull Request

Holster quick fix,
Unholstering from the shoulder holster shouldn't double draw anymore.

Holstering your gun now actually checks for shoulder holster before taking up a suit slot

fixes issue #4
goddamnit @stanalbatross fix your own bugs!

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: ghostsheet
fix: Shoulder holster should work like they used to.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
