### PR TITLE
MR flaying changes

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -201,6 +201,8 @@
 #define COMSIG_HUMAN_OVERLAY_APPLIED "human_overlay_applied"
 /// From /mob/living/carbon/human/remove_overlay(): (cache_index, overlay_image)
 #define COMSIG_HUMAN_OVERLAY_REMOVED "human_overlay_removed"
+/// From /datum/flaying_datum
+#define COMSIG_HUMAN_FLAY_ATTEMPT "human_flay_attempt"
 
 #define COMSIG_HUMAN_BONEBREAK_PROBABILITY "human_bonebreak_probability"
 

--- a/code/game/objects/items/stacks/predator.dm
+++ b/code/game/objects/items/stacks/predator.dm
@@ -15,34 +15,33 @@
 	max_amount = 8
 
 /obj/item/stack/yautja_rope/attack(mob/living/mob_victim, mob/living/carbon/human/user)
-	. = ..()
-	if(!.)
-		return
+	if(mob_victim.stat != DEAD)
+		return ..()
+
+	if(mob_victim.mob_size != MOB_SIZE_HUMAN)
+		to_chat(user, SPAN_WARNING("[mob_victim] has the wrong body plan to hang up."))
+		return TRUE
 
 	if(!HAS_TRAIT(user, TRAIT_SUPER_STRONG))
 		to_chat(user, SPAN_WARNING("You're not strong enough to lift [mob_victim] up with a rope. Also, that's kind of fucked up."))
-		return
-
-	if(mob_victim.mob_size != MOB_SIZE_HUMAN)
-		return
+		return TRUE
 
 	var/mob/living/carbon/human/victim = mob_victim
-	if(victim.stat != DEAD)
-		return
 
 	if(!do_after(user, 1 SECONDS, INTERRUPT_NO_NEEDHAND, BUSY_ICON_HOSTILE, victim))
-		return
+		return TRUE
 
 	to_chat(user, SPAN_NOTICE("You start securing the rope to the ceiling..."))
+
 	if(do_after(user, 4 SECONDS, INTERRUPT_NO_NEEDHAND, BUSY_ICON_HOSTILE, victim))
 		var/turf/rturf = get_turf(victim)
 		var/area/rarea = get_area(victim)
 		if(rturf.density)
 			to_chat(user, SPAN_WARNING("They're in a wall!"))
-			return
+			return TRUE
 		if(rarea.ceiling == CEILING_NONE)
-			to_chat(user, SPAN_WARNING("There's no ceiling!"))
-			return
+			to_chat(user, SPAN_WARNING("There's no ceiling to hang them from!"))
+			return TRUE
 		to_chat(user, SPAN_NOTICE("You secure the rope."))
 		to_chat(user, SPAN_NOTICE("You start hanging [victim] by the rope..."))
 		if(do_after(user, 4 SECONDS, INTERRUPT_NO_NEEDHAND, BUSY_ICON_HOSTILE, victim))
@@ -50,6 +49,7 @@
 			user.stop_pulling()
 			victim.get_hung()
 			use(1)
+	return TRUE
 
 /mob/living/carbon/human/proc/get_hung()
 	animate(src, pixel_y = 9, time = 0.5 SECONDS, easing = SINE_EASING|EASE_OUT)

--- a/code/game/objects/items/stacks/predator.dm
+++ b/code/game/objects/items/stacks/predator.dm
@@ -31,7 +31,8 @@
 	if(!do_after(user, 1 SECONDS, INTERRUPT_NO_NEEDHAND, BUSY_ICON_HOSTILE, victim))
 		return TRUE
 
-	to_chat(user, SPAN_NOTICE("You start securing the rope to the ceiling..."))
+	user.visible_message(SPAN_NOTICE("[user] starts to secure \his rope to the ceiling..."),
+		SPAN_NOTICE("You start securing the rope to the ceiling..."))
 
 	if(do_after(user, 4 SECONDS, INTERRUPT_NO_NEEDHAND, BUSY_ICON_HOSTILE, victim))
 		var/turf/rturf = get_turf(victim)
@@ -42,13 +43,16 @@
 		if(rarea.ceiling == CEILING_NONE)
 			to_chat(user, SPAN_WARNING("There's no ceiling to hang them from!"))
 			return TRUE
-		to_chat(user, SPAN_NOTICE("You secure the rope."))
-		to_chat(user, SPAN_NOTICE("You start hanging [victim] by the rope..."))
-		if(do_after(user, 4 SECONDS, INTERRUPT_NO_NEEDHAND, BUSY_ICON_HOSTILE, victim))
-			to_chat(user, SPAN_NOTICE("You finish the hanging of [victim]."))
-			user.stop_pulling()
-			victim.get_hung()
-			use(1)
+		user.visible_message(SPAN_NOTICE("[user] secures the rope."),
+			SPAN_NOTICE("You secure the rope."))
+		if(do_after(user, 1 SECONDS, INTERRUPT_NO_NEEDHAND, BUSY_ICON_HOSTILE, victim))
+			user.visible_message(SPAN_WARNING("[user] begins hanging [victim] up by the rope..."),
+				SPAN_NOTICE("You start hanging [victim] up by the rope..."))
+			if(do_after(user, 3 SECONDS, INTERRUPT_NO_NEEDHAND, BUSY_ICON_HOSTILE, victim))
+				user.visible_message(SPAN_WARNING("[user] hangs [victim] from the ceiling!"), SPAN_NOTICE("You finish hanging [victim]."))
+				user.stop_pulling()
+				victim.get_hung()
+				use(1)
 	return TRUE
 
 /mob/living/carbon/human/proc/get_hung()

--- a/code/modules/cm_preds/yaut_weapons.dm
+++ b/code/modules/cm_preds/yaut_weapons.dm
@@ -586,7 +586,7 @@
 	unacidable = TRUE
 
 /obj/item/weapon/melee/yautja/knife/attack(mob/living/M, mob/living/carbon/human/user)
-	if(M.stat != DEAD)
+	if(M.stat != DEAD || user.action_busy)
 		return ..()
 
 	if(!ishuman(M))
@@ -717,7 +717,7 @@
 			victim.status_flags |= PERMANENTLY_DEAD
 			victim.add_flay_overlay(stage = 3)
 			
-			//End the loop, but keep the datum so nobody tries to skin him twice.
+			//End the loop and remove all references to the datum.
 			current_flayer = null
 			UnregisterSignal(victim, COMSIG_HUMAN_FLAY_ATTEMPT)
 			victim = null

--- a/code/modules/cm_preds/yaut_weapons.dm
+++ b/code/modules/cm_preds/yaut_weapons.dm
@@ -617,12 +617,12 @@
 	if(!do_after(user, 1 SECONDS, INTERRUPT_NO_NEEDHAND, BUSY_ICON_HOSTILE, victim))
 		return TRUE
 
-	user.visible_message(SPAN_WARNING("[user] begins to flay [victim] with \a [src]..."),
-		SPAN_WARNING("You start flaying [victim] with your [src.name]..."))
+	user.visible_message(SPAN_DANGER("<B>[user] begins to flay [victim] with \a [src]...</B>"),
+		SPAN_DANGER("<B>You start flaying [victim] with your [src.name]...</B>"))
 	playsound(loc, 'sound/weapons/pierce.ogg', 25)
 	if(do_after(user, 4 SECONDS, INTERRUPT_NO_NEEDHAND, BUSY_ICON_HOSTILE, victim))
-		user.visible_message(SPAN_WARNING("[user] makes a series of cuts in [victim]'s skin."),
-			SPAN_WARNING("You prepare the skin, cutting the flesh off in vital places."))
+		user.visible_message(SPAN_DANGER("<B>[user] makes a series of cuts in [victim]'s skin.</B>"),
+			SPAN_DANGER("<B>You prepare the skin, cutting the flesh off in vital places.</B>"))
 		playsound(loc, 'sound/weapons/slash.ogg', 25)
 		
 		for(var/L in victim.limbs)
@@ -656,8 +656,8 @@
 	else
 		current_flayer = user
 		if(!ongoing_attempt)
-			user.visible_message(SPAN_WARNING("[user] resumes the flaying of [victim] with \a [tool]..."),
-				SPAN_WARNING("You resume the flaying of [victim] with your [tool.name]..."))
+			user.visible_message(SPAN_DANGER("<B>[user] resumes the flaying of [victim] with \a [tool]...</B>"),
+				SPAN_DANGER("<B>You resume the flaying of [victim] with your [tool.name]...</B>"))
 		INVOKE_ASYNC(src, .proc/flay, target, user, tool) //do_after sleeps.
 	return COMPONENT_CANCEL_ATTACK
 
@@ -674,26 +674,26 @@
 			var/obj/limb/head/v_head = victim.get_limb("head")
 			if(!v_head || (v_head.status & LIMB_DESTROYED)) //they might be beheaded
 				victim.apply_damage(10, BRUTE, "chest", sharp = TRUE)
-				user.visible_message(SPAN_WARNING("[user] peels the skin around the stump of [victim]'s head loose with \the [tool]."),
-					SPAN_WARNING("[victim] is missing \his head. Pelts like this just aren't the same... You peel the skin around the stump loose with your [tool.name]."))
+				user.visible_message(SPAN_DANGER("<B>[user] peels the skin around the stump of [victim]'s head loose with \the [tool].</B>"),
+					SPAN_DANGER("<B>[victim] is missing \his head. Pelts like this just aren't the same... You peel the skin around the stump loose with your [tool.name].</B>"))
 			else
 				victim.apply_damage(10, BRUTE, v_head, sharp = TRUE)
 				v_head.disfigured = TRUE
 				create_leftovers(victim, has_meat = FALSE, skin_amount = 1)
 				if(victim.h_style == "Bald") //you can't scalp someone with no hair.
-					user.visible_message(SPAN_WARNING("[user] makes some rough cuts on [victim]'s head and face with \a [tool]."),
-						SPAN_WARNING("You make some rough cuts on [victim]'s head and face."))
+					user.visible_message(SPAN_DANGER("<B>[user] makes some rough cuts on [victim]'s head and face with \a [tool].</B>"),
+						SPAN_DANGER("<B>You make some rough cuts on [victim]'s head and face.</B>"))
 				else
-					user.visible_message(SPAN_WARNING("[user] cuts around [victim]'s hairline, then tears \his scalp from \his head!"),
-						SPAN_WARNING("You cut around [victim]'s hairline, then rip \his scalp from \his head."))
+					user.visible_message(SPAN_DANGER("<B>[user] cuts around [victim]'s hairline, then tears \his scalp from \his head!</B>"),
+						SPAN_DANGER("<B>You cut around [victim]'s hairline, then rip \his scalp from \his head.</B>"))
 					var/obj/item/scalp/cut_scalp = new(get_turf(user), victim, user) //Create a scalp of the victim at the user's feet.
 					user.put_in_inactive_hand(cut_scalp) //Put it in the user's offhand if possible.
 					victim.h_style = "Bald"
 					victim.update_hair() //tear the hair off with the scalp
 
 		if(FLAY_STAGE_STRIP)
-			user.visible_message(SPAN_WARNING("[user] jabs \his [tool.name] into [victim]'s cuts, prying, cutting, then tearing off large areas of skin. The remainder hangs loosely."),
-				SPAN_WARNING("You jab your [tool.name] into [victim]'s cuts, prying, cutting, then tearing off large areas of skin. The remainder hangs loosely."))
+			user.visible_message(SPAN_DANGER("<B>[user] jabs \his [tool.name] into [victim]'s cuts, prying, cutting, then tearing off large areas of skin. The remainder hangs loosely.</B>"),
+				SPAN_DANGER("<B>You jab your [tool.name] into [victim]'s cuts, prying, cutting, then tearing off large areas of skin. The remainder hangs loosely.</B>"))
 			playsound(user.loc, 'sound/weapons/bladeslice.ogg', 25)
 			create_leftovers(victim, has_meat = FALSE, skin_amount = 3)
 			flaying_stage = FLAY_STAGE_SKIN
@@ -705,8 +705,8 @@
 			victim.add_flay_overlay(stage = 2)
 
 		if(FLAY_STAGE_SKIN)
-			user.visible_message(SPAN_WARNING("[user] completely flays [victim], pulling the remaining skin off of \his body like a glove!"),
-				SPAN_WARNING("You completely flay [victim], pulling the remaining skin off of \his body like a glove.\nUse rope to hang \him from the ceiling."))
+			user.visible_message(SPAN_DANGER("<B>[user] completely flays [victim], pulling the remaining skin off of \his body like a glove!</B>"),
+				SPAN_DANGER("<B>You completely flay [victim], pulling the remaining skin off of \his body like a glove.\nUse rope to hang \him from the ceiling.</B>"))
 			playsound(user.loc, 'sound/weapons/wristblades_hit.ogg', 25)
 			create_leftovers(victim, has_meat = TRUE, skin_amount = 2)
 			for(var/L in victim.limbs)

--- a/code/modules/cm_preds/yaut_weapons.dm
+++ b/code/modules/cm_preds/yaut_weapons.dm
@@ -617,10 +617,12 @@
 	if(!do_after(user, 1 SECONDS, INTERRUPT_NO_NEEDHAND, BUSY_ICON_HOSTILE, victim))
 		return TRUE
 
-	to_chat(user, SPAN_WARNING("You start flaying [victim]..."))
+	user.visible_message(SPAN_WARNING("[user] begins to flay [victim] with \a [src]..."),
+		SPAN_WARNING("You start flaying [victim] with your [src.name]..."))
 	playsound(loc, 'sound/weapons/pierce.ogg', 25)
 	if(do_after(user, 4 SECONDS, INTERRUPT_NO_NEEDHAND, BUSY_ICON_HOSTILE, victim))
-		to_chat(user, SPAN_WARNING("You prepare the skin, cutting the flesh off in vital places."))
+		user.visible_message(SPAN_WARNING("[user] makes a series of cuts in [victim]'s skin."),
+			SPAN_WARNING("You prepare the skin, cutting the flesh off in vital places."))
 		playsound(loc, 'sound/weapons/slash.ogg', 25)
 		
 		for(var/L in victim.limbs)
@@ -654,7 +656,8 @@
 	else
 		current_flayer = user
 		if(!ongoing_attempt)
-			to_chat(user, SPAN_WARNING("You resume flaying [victim]..."))
+			user.visible_message(SPAN_WARNING("[user] resumes the flaying of [victim] with \a [tool]..."),
+				SPAN_WARNING("You resume the flaying of [victim] with your [tool.name]..."))
 		INVOKE_ASYNC(src, .proc/flay, target, user, tool) //do_after sleeps.
 	return COMPONENT_CANCEL_ATTACK
 
@@ -671,22 +674,26 @@
 			var/obj/limb/head/v_head = victim.get_limb("head")
 			if(!v_head || (v_head.status & LIMB_DESTROYED)) //they might be beheaded
 				victim.apply_damage(10, BRUTE, "chest", sharp = TRUE)
-				to_chat(user, SPAN_WARNING("[victim] is missing \his head. Pelts like this just aren't the same... You peel the skin around the stump loose with \the [tool]."))
+				user.visible_message(SPAN_WARNING("[user] peels the skin around the stump of [victim]'s head loose with \the [tool]."),
+					SPAN_WARNING("[victim] is missing \his head. Pelts like this just aren't the same... You peel the skin around the stump loose with your [tool.name]."))
 			else
 				victim.apply_damage(10, BRUTE, v_head, sharp = TRUE)
 				v_head.disfigured = TRUE
 				create_leftovers(victim, has_meat = FALSE, skin_amount = 1)
 				if(victim.h_style == "Bald") //you can't scalp someone with no hair.
-					to_chat(user, SPAN_WARNING("You make some rough cuts on [victim]'s head and face with \the [tool]."))
+					user.visible_message(SPAN_WARNING("[user] makes some rough cuts on [victim]'s head and face with \a [tool]."),
+						SPAN_WARNING("You make some rough cuts on [victim]'s head and face."))
 				else
-					to_chat(user, SPAN_WARNING("You use \the [tool] to cut around [victim]'s hairline, then rip \his scalp from \his head."))
+					user.visible_message(SPAN_WARNING("[user] cuts around [victim]'s hairline, then tears \his scalp from \his head!"),
+						SPAN_WARNING("You cut around [victim]'s hairline, then rip \his scalp from \his head."))
 					var/obj/item/scalp/cut_scalp = new(get_turf(user), victim, user) //Create a scalp of the victim at the user's feet.
 					user.put_in_inactive_hand(cut_scalp) //Put it in the user's offhand if possible.
 					victim.h_style = "Bald"
 					victim.update_hair() //tear the hair off with the scalp
 
 		if(FLAY_STAGE_STRIP)
-			to_chat(user, SPAN_WARNING("You jab \the [tool] into the flesh cuts, using them to tear off large areas of skin, the remainder hanging loosely."))
+			user.visible_message(SPAN_WARNING("[user] jabs \his [tool.name] into [victim]'s cuts, prying, cutting, then tearing off large areas of skin. The remainder hangs loosely."),
+				SPAN_WARNING("You jab your [tool.name] into [victim]'s cuts, prying, cutting, then tearing off large areas of skin. The remainder hangs loosely."))
 			playsound(user.loc, 'sound/weapons/bladeslice.ogg', 25)
 			create_leftovers(victim, has_meat = FALSE, skin_amount = 3)
 			flaying_stage = FLAY_STAGE_SKIN
@@ -698,7 +705,8 @@
 			victim.add_flay_overlay(stage = 2)
 
 		if(FLAY_STAGE_SKIN)
-			to_chat(user, SPAN_WARNING("You completely flay [victim], sloppily ripping the remaining skin off of \his body. Use rope to hang \him from the ceiling."))
+			user.visible_message(SPAN_WARNING("[user] completely flays [victim], pulling the remaining skin off of \his body like a glove!"),
+				SPAN_WARNING("You completely flay [victim], pulling the remaining skin off of \his body like a glove.\nUse rope to hang \him from the ceiling."))
 			playsound(user.loc, 'sound/weapons/wristblades_hit.ogg', 25)
 			create_leftovers(victim, has_meat = TRUE, skin_amount = 2)
 			for(var/L in victim.limbs)

--- a/code/modules/cm_preds/yaut_weapons.dm
+++ b/code/modules/cm_preds/yaut_weapons.dm
@@ -1,3 +1,7 @@
+#define FLAY_STAGE_SCALP 1
+#define FLAY_STAGE_STRIP 2
+#define FLAY_STAGE_SKIN 3
+
 /*#########################################
 ########### Weapon Reused Procs ###########
 #########################################*/
@@ -587,82 +591,141 @@
 
 	if(!ishuman(M))
 		to_chat(user, SPAN_WARNING("You can only use this dagger to flay humanoids!"))
-		return
+		return TRUE
 
 	var/mob/living/carbon/human/victim = M
 
 	if(!HAS_TRAIT(user, TRAIT_SUPER_STRONG))
 		to_chat(user, SPAN_WARNING("You're not strong enough to rip an entire humanoid apart. Also, that's kind of fucked up.")) //look at this dumbass
-		return
+		return TRUE
 
 	if(isSameSpecies(user, victim))
 		to_chat(user, SPAN_HIGHDANGER("ARE YOU OUT OF YOUR MIND!?"))
-		return
+		return TRUE
 
 	if(isSpeciesSynth(victim))
 		to_chat(user, SPAN_WARNING("You can't flay metal...")) //look at this dumbass
-		return
+		return TRUE
+
+	if(SEND_SIGNAL(victim, COMSIG_HUMAN_FLAY_ATTEMPT, user, src) & COMPONENT_CANCEL_ATTACK)
+		playsound(loc, 'sound/weapons/pierce.ogg', 25)
+		return TRUE
+
+	if(victim.overlays_standing[FLAY_LAYER]) //Already fully flayed. Possibly the user wants to cut them down?
+		return ..()
 
 	if(!do_after(user, 1 SECONDS, INTERRUPT_NO_NEEDHAND, BUSY_ICON_HOSTILE, victim))
-		return
+		return TRUE
 
-	to_chat(user, SPAN_WARNING("You start flaying [victim].."))
+	to_chat(user, SPAN_WARNING("You start flaying [victim]..."))
 	playsound(loc, 'sound/weapons/pierce.ogg', 25)
 	if(do_after(user, 4 SECONDS, INTERRUPT_NO_NEEDHAND, BUSY_ICON_HOSTILE, victim))
 		to_chat(user, SPAN_WARNING("You prepare the skin, cutting the flesh off in vital places."))
 		playsound(loc, 'sound/weapons/slash.ogg', 25)
-		create_leftovers(victim, has_meat = TRUE, skin_amount = 0)
+		
 		for(var/L in victim.limbs)
 			victim.apply_damage(15, BRUTE, L, sharp = FALSE)
 		victim.add_flay_overlay(stage = 1)
 
-		if(do_after(user, 4 SECONDS, INTERRUPT_ALL, BUSY_ICON_HOSTILE, victim))
+		var/datum/flaying_datum/flay_datum = new(victim)
+		flay_datum.create_leftovers(victim, TRUE, 0)
+		SEND_SIGNAL(victim, COMSIG_HUMAN_FLAY_ATTEMPT, user, src, TRUE)
+	else
+		to_chat(user, SPAN_WARNING("You were interrupted before you could finish your work!"))
+	return TRUE
+
+///Records status of flaying attempts and handles progress.
+/datum/flaying_datum
+	var/mob/living/carbon/human/victim
+	var/current_flayer
+	var/flaying_stage = FLAY_STAGE_SCALP
+
+/datum/flaying_datum/New(mob/living/carbon/human/target)
+	. = ..()
+	victim = target
+	RegisterSignal(victim, COMSIG_HUMAN_FLAY_ATTEMPT, .proc/begin_flaying)
+
+///Loops until interrupted or done.
+/datum/flaying_datum/proc/begin_flaying(mob/living/carbon/human/target, mob/living/carbon/human/user, obj/item/tool, ongoing_attempt)
+	SIGNAL_HANDLER
+	if(current_flayer)
+		if(current_flayer != user)
+			to_chat(user, SPAN_WARNING("You can't flay [target], [current_flayer] is already at work!"))
+	else
+		current_flayer = user
+		if(!ongoing_attempt)
+			to_chat(user, SPAN_WARNING("You resume flaying [victim]..."))
+		INVOKE_ASYNC(src, .proc/flay, target, user, tool) //do_after sleeps.
+	return COMPONENT_CANCEL_ATTACK
+
+/datum/flaying_datum/proc/flay(mob/living/carbon/human/target, mob/living/carbon/human/user, obj/item/tool)
+	if(!do_after(user, 4 SECONDS, INTERRUPT_ALL, BUSY_ICON_HOSTILE, victim))
+		to_chat(user, SPAN_WARNING("You were interrupted before you could finish your work!"))
+		current_flayer = null
+		return
+
+	switch(flaying_stage)
+		if(FLAY_STAGE_SCALP)
+			playsound(user.loc, 'sound/weapons/slashmiss.ogg', 25)
+			flaying_stage = FLAY_STAGE_STRIP
 			var/obj/limb/head/v_head = victim.get_limb("head")
-			if(v_head) //they might be beheaded
-				create_leftovers(victim, has_meat = FALSE, skin_amount = 1)
-				victim.apply_damage(10, BRUTE, v_head, sharp = FALSE)
+			if(!v_head || (v_head.status & LIMB_DESTROYED)) //they might be beheaded
+				victim.apply_damage(10, BRUTE, "chest", sharp = TRUE)
+				to_chat(user, SPAN_WARNING("[victim] is missing \his head. Pelts like this just aren't the same... You peel the skin around the stump loose with \the [tool]."))
+			else
+				victim.apply_damage(10, BRUTE, v_head, sharp = TRUE)
 				v_head.disfigured = TRUE
+				create_leftovers(victim, has_meat = FALSE, skin_amount = 1)
 				if(victim.h_style == "Bald") //you can't scalp someone with no hair.
-					to_chat(user, SPAN_WARNING("You make some rough cuts on [victim]'s head and face with \the [src]."))
+					to_chat(user, SPAN_WARNING("You make some rough cuts on [victim]'s head and face with \the [tool]."))
 				else
-					to_chat(user, SPAN_WARNING("You use \the [src] to cut around [victim]'s hairline, then rip \his scalp from \his head."))
+					to_chat(user, SPAN_WARNING("You use \the [tool] to cut around [victim]'s hairline, then rip \his scalp from \his head."))
 					var/obj/item/scalp/cut_scalp = new(get_turf(user), victim, user) //Create a scalp of the victim at the user's feet.
 					user.put_in_inactive_hand(cut_scalp) //Put it in the user's offhand if possible.
 					victim.h_style = "Bald"
 					victim.update_hair() //tear the hair off with the scalp
-			playsound(loc, 'sound/weapons/slashmiss.ogg', 25)
 
-			if(do_after(user, 4 SECONDS, INTERRUPT_ALL, BUSY_ICON_HOSTILE, victim))
-				to_chat(user, SPAN_WARNING("You jab \the [src] into the flesh cuts, using them to tear off most of the skin, the remainder skin hanging off the flesh."))
-				playsound(loc, 'sound/weapons/bladeslice.ogg', 25)
-				create_leftovers(victim, has_meat = FALSE, skin_amount = 3)
-				for(var/L in victim.limbs)
-					victim.apply_damage(18, BRUTE, L, sharp = FALSE)
-				victim.remove_overlay(UNDERWEAR_LAYER)
-				victim.f_style = "Shaved"
-				victim.update_hair() //then rip the beard off along the skin
-				victim.add_flay_overlay(stage = 2)
+		if(FLAY_STAGE_STRIP)
+			to_chat(user, SPAN_WARNING("You jab \the [tool] into the flesh cuts, using them to tear off large areas of skin, the remainder hanging loosely."))
+			playsound(user.loc, 'sound/weapons/bladeslice.ogg', 25)
+			create_leftovers(victim, has_meat = FALSE, skin_amount = 3)
+			flaying_stage = FLAY_STAGE_SKIN
+			for(var/L in victim.limbs)
+				victim.apply_damage(18, BRUTE, L, sharp = TRUE)
+			victim.remove_overlay(UNDERWEAR_LAYER)
+			victim.f_style = "Shaved"
+			victim.update_hair() //then rip the beard off along the skin
+			victim.add_flay_overlay(stage = 2)
 
-				if(do_after(user, 4 SECONDS, INTERRUPT_ALL, BUSY_ICON_HOSTILE, victim))
-					to_chat(user, SPAN_WARNING("You completely flay [victim], sloppily ripping most remaining flesh and skin off the body. Use rope to hang them from the ceiling."))
-					playsound(loc, 'sound/weapons/wristblades_hit.ogg', 25)
-					create_leftovers(victim, has_meat = TRUE, skin_amount = 2)
-					for(var/L in victim.limbs)
-						victim.apply_damage(22, BRUTE, L, sharp = FALSE)
-					for(var/obj/item/I in victim)
-						victim.drop_inv_item_to_loc(I, victim.loc, FALSE, TRUE)
+		if(FLAY_STAGE_SKIN)
+			to_chat(user, SPAN_WARNING("You completely flay [victim], sloppily ripping the remaining skin off of \his body. Use rope to hang \him from the ceiling."))
+			playsound(user.loc, 'sound/weapons/wristblades_hit.ogg', 25)
+			create_leftovers(victim, has_meat = TRUE, skin_amount = 2)
+			for(var/L in victim.limbs)
+				victim.apply_damage(22, BRUTE, L, sharp = TRUE)
+			for(var/obj/item/I in victim)
+				victim.drop_inv_item_to_loc(I, victim.loc, FALSE, TRUE)
 
-					victim.status_flags |= PERMANENTLY_DEAD
-					victim.add_flay_overlay(stage = 3)
+			victim.status_flags |= PERMANENTLY_DEAD
+			victim.add_flay_overlay(stage = 3)
+			
+			//End the loop, but keep the datum so nobody tries to skin him twice.
+			current_flayer = null
+			UnregisterSignal(victim, COMSIG_HUMAN_FLAY_ATTEMPT)
+			victim = null
+			return
+
+	flay(target, user, tool)
 
 /mob/living/carbon/human/proc/add_flay_overlay(var/stage = 1)
 	remove_overlay(FLAY_LAYER)
 	var/image/flay_icon = new /image('icons/mob/humans/dam_human.dmi', "human_[stage]")
 	flay_icon.layer = -FLAY_LAYER
+	flay_icon.blend_mode = BLEND_INSET_OVERLAY
 	overlays_standing[FLAY_LAYER] = flay_icon
 	apply_overlay(FLAY_LAYER)
 
-/obj/item/weapon/melee/yautja/knife/proc/create_leftovers(mob/living/victim, var/has_meat, var/skin_amount)
+/datum/flaying_datum/proc/create_leftovers(mob/living/victim, var/has_meat, var/skin_amount)
 	if(has_meat)
 		var/obj/item/reagent_container/food/snacks/meat/meat = new /obj/item/reagent_container/food/snacks/meat(victim.loc)
 		meat.name = "raw [victim.name] steak"
@@ -673,7 +736,6 @@
 		hide.singular_name = "[victim.name]-hide"
 		hide.stack_id = "[victim.name]-hide"
 		hide.amount = skin_amount
-
 
 
 /*#########################################
@@ -1167,3 +1229,7 @@
 		var/mob/living/carbon/human/user = usr //Hacky...
 		user.update_power_display(perc)
 	return TRUE
+
+#undef FLAY_STAGE_SCALP
+#undef FLAY_STAGE_STRIP
+#undef FLAY_STAGE_SKIN

--- a/code/modules/cm_preds/yaut_weapons.dm
+++ b/code/modules/cm_preds/yaut_weapons.dm
@@ -608,7 +608,6 @@
 		return TRUE
 
 	if(SEND_SIGNAL(victim, COMSIG_HUMAN_FLAY_ATTEMPT, user, src) & COMPONENT_CANCEL_ATTACK)
-		playsound(loc, 'sound/weapons/pierce.ogg', 25)
 		return TRUE
 
 	if(victim.overlays_standing[FLAY_LAYER]) //Already fully flayed. Possibly the user wants to cut them down?
@@ -621,6 +620,8 @@
 		SPAN_DANGER("<B>You start flaying [victim] with your [src.name]...</B>"))
 	playsound(loc, 'sound/weapons/pierce.ogg', 25)
 	if(do_after(user, 4 SECONDS, INTERRUPT_NO_NEEDHAND, BUSY_ICON_HOSTILE, victim))
+		if(SEND_SIGNAL(victim, COMSIG_HUMAN_FLAY_ATTEMPT, user, src) & COMPONENT_CANCEL_ATTACK) //In case two preds try to flay the same person at once.
+			return TRUE
 		user.visible_message(SPAN_DANGER("<B>[user] makes a series of cuts in [victim]'s skin.</B>"),
 			SPAN_DANGER("<B>You prepare the skin, cutting the flesh off in vital places.</B>"))
 		playsound(loc, 'sound/weapons/slash.ogg', 25)
@@ -656,6 +657,7 @@
 	else
 		current_flayer = user
 		if(!ongoing_attempt)
+			playsound(user.loc, 'sound/weapons/pierce.ogg', 25)
 			user.visible_message(SPAN_DANGER("<B>[user] resumes the flaying of [victim] with \a [tool]...</B>"),
 				SPAN_DANGER("<B>You resume the flaying of [victim] with your [tool.name]...</B>"))
 		INVOKE_ASYNC(src, .proc/flay, target, user, tool) //do_after sleeps.
@@ -700,6 +702,7 @@
 			for(var/L in victim.limbs)
 				victim.apply_damage(18, BRUTE, L, sharp = TRUE)
 			victim.remove_overlay(UNDERWEAR_LAYER)
+			victim.drop_inv_item_on_ground(victim.get_item_by_slot(WEAR_BODY)) //Drop uniform, belt etc as well.
 			victim.f_style = "Shaved"
 			victim.update_hair() //then rip the beard off along the skin
 			victim.add_flay_overlay(stage = 2)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Fixes to a bunch of weirdness around rope and flaying, fixes for bugs with the flaying overlay ignoring missing heads, improved messaging to the user and witnesses. Refactors flaying along similar lines to suturing, using a datum to keep track of how much they've been flayed already.

Predators can kind of use ceremonial knife to cut down hung-up bodies but I'm not changelogging it because it's still incredibly janky. This closes one case where they can't but there's a bunch more.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes bugs, removes the 'whacking' before doing actions (whack then rope, whack then flay...) makes it a lot clearer to witnesses what's going on.

fixes #107. Wasn't able to reproduce #106.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Vanagandr
refactor: Refactored predator flaying. Should be a lot less janky across the board. Flaying can be paused and resumed.
expansion: Rope + flaying messages are now also shown to witnesses, instead of just the predator. Flaying has been given RED TEXT to make it clear something bad is going on.
fix: Predators can no longer flay someone who has already been flayed, or queue up multiple flayings at once.
fix: Predators can no longer scalp someone who has no head.
fix: Decapitated and flayed bodies no longer appear to have a head.
fix: Using the ceremonial dagger or rope no longer hits people before applying.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
