### PR TITLE
ERT Station Phone Fix

### DIFF
--- a/maps/map_files/generic/Admin_level.dmm
+++ b/maps/map_files/generic/Admin_level.dmm
@@ -3391,10 +3391,9 @@
 	},
 /area/shuttle/distress/start_small)
 "qu" = (
-/obj/structure/transmitter{
+/obj/structure/transmitter/hidden{
 	dir = 8;
 	name = "Station Telephone";
-	phone_category = null;
 	phone_id = "Unknown Signal";
 	pixel_x = 14
 	},
@@ -4755,9 +4754,9 @@
 /area/adminlevel/ert_station)
 "Nt" = (
 /obj/structure/noticeboard{
-	pixel_y = 34;
+	desc = "It seems very, very empty.";
 	name = "departures board";
-	desc = "It seems very, very empty."
+	pixel_y = 34
 	},
 /turf/open/floor/almayer{
 	dir = 1;
@@ -5216,8 +5215,8 @@
 "TX" = (
 /obj/structure/surface/table/gamblingtable,
 /obj/item/ashtray/plastic{
-	pixel_y = -2;
-	pixel_x = -4
+	pixel_x = -4;
+	pixel_y = -2
 	},
 /obj/item/trash/cigbutt/ucigbutt,
 /obj/item/trash/cigbutt{


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Replaces the transmitter in the ERT station with the hidden variant, so one with a null value doesn't appear when trying to call people.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Having an null category whenever you try to call something looks odd.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixes one of the phones on the ERT station appearing on the phone list as an null entry by making it uncallable.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
