### PR TITLE
CPR Can only be performed by one mob at a time

### DIFF
--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -1,4 +1,5 @@
 /mob/living/carbon/human/var/cpr_cooldown
+/mob/living/carbon/human/var/cpr_performer
 /mob/living/carbon/human/attack_hand(mob/living/carbon/human/M)
 	if(..())
 		return TRUE
@@ -26,10 +27,16 @@
 				return 1
 
 			if(M.head && (M.head.flags_inventory & COVERMOUTH) || M.wear_mask && (M.wear_mask.flags_inventory & COVERMOUTH) && !(M.wear_mask.flags_inventory & ALLOWCPR))
-				to_chat(M, SPAN_NOTICE(" <B>Remove your mask!</B>"))
+				to_chat(M, SPAN_NOTICE("<B>Remove your mask!</B>"))
 				return 0
 			if(head && (head.flags_inventory & COVERMOUTH) || wear_mask && (wear_mask.flags_inventory & COVERMOUTH) && !(wear_mask.flags_inventory & ALLOWCPR))
-				to_chat(M, SPAN_NOTICE(" <B>Remove [src.gender==MALE?"his":"her"] mask!</B>"))
+				to_chat(M, SPAN_NOTICE("<B>Remove [src.gender==MALE?"his":"her"] mask!</B>"))
+				return 0
+			if(cpr_performer != null)
+				if(cpr_performer == M)
+					to_chat(M, SPAN_NOTICE("<B>You're already performing CPR on [src]!</B>"))
+				else
+					to_chat(M, SPAN_NOTICE("<B>Someone else is already performing CPR on [src]!</B>"))
 				return 0
 
 			//CPR
@@ -39,6 +46,7 @@
 			M.visible_message(SPAN_NOTICE("<b>[M]</b> starts performing <b>CPR</b> on <b>[src]</b>."),
 				SPAN_HELPFUL("You start <b>performing CPR</b> on <b>[src]</b>."))
 
+			cpr_performer = M
 			if(do_after(M, HUMAN_STRIP_DELAY * M.get_skill_duration_multiplier(SKILL_MEDICAL), INTERRUPT_ALL, BUSY_ICON_GENERIC, src, INTERRUPT_MOVED, BUSY_ICON_MEDICAL))
 				if(stat != DEAD)
 					var/suff = min(getOxyLoss(), 10) //Pre-merge level, less healing, more prevention of dieing.
@@ -57,7 +65,7 @@
 						M.visible_message(SPAN_NOTICE("<b>[M]</b> fails to perform CPR on <b>[src]</b>."),
 							SPAN_HELPFUL("You <b>fail</b> to perform <b>CPR</b> on <b>[src]</b>. Incorrect rhythm. Do it <b>slower</b>."))
 					cpr_cooldown = world.time + 7 SECONDS
-
+			cpr_performer = null
 			return 1
 
 		if(INTENT_GRAB)


### PR DESCRIPTION
## About The Pull Request

This adds a check to ensure that only one person can perform CPR on the same target at any one time.

## Why It's Good For The Game

There isn't a clear visual indicator in game on whether someone is performing CPR, suturing, or healing, and many players will attempt to help a downed marine by performing CPR all at the same time, while not understanding why it's failing despite the messages. 

This will help preventing getting in each other's way while CPRing someone, while also making the process make more sense: After all, how would two people perform CPR at the same time, they'd share a three-way kiss or something?

## Changelog

:cl: VarenRoth
qol: CPR can only be performed by one person at a time, avoiding multiple people causing CPR to fail.
/:cl:
