### PR TITLE
Fix the inhand sprite for packaged burger 

### DIFF
--- a/code/game/objects/items/reagent_containers/food/snacks.dm
+++ b/code/game/objects/items/reagent_containers/food/snacks.dm
@@ -3147,6 +3147,7 @@
 		to_chat(user, SPAN_NOTICE("You pull off the wrapping from the squishy hamburger!"))
 		package = 0
 		icon_state = "hburger"
+		item_state = "burger"
 
 /obj/item/reagent_container/food/snacks/packaged_hdogs
 	name = "Packaged Hotdog"


### PR DESCRIPTION
## About The Pull Request

Makes the in hand sprite for burgers work as they are inteded to work.


## Why It's Good For The Game

If you remove the package the burger in hand sprite its gone.

## Changelog
:cl:
fix: Burger in hand item no longer dissapears after you remove the package. 
/:cl:
