### PR TITLE
Fixes an Typo on Survivor Types

### DIFF
--- a/maps/desert_dam.json
+++ b/maps/desert_dam.json
@@ -9,7 +9,7 @@
         "/datum/equipment_preset/survivor/chaplain/trijent",
         "/datum/equipment_preset/survivor/interstellar_commerce_commission_liason",
         "/datum/equipment_preset/survivor/colonial_marshal",
-        "/datum/equipment_preset/survivor/engineer/trjent",
+        "/datum/equipment_preset/survivor/engineer/trijent",
         "/datum/equipment_preset/survivor/engineer/trijent/hydro",
         "/datum/equipment_preset/survivor/trucker/trijent",
         "/datum/equipment_preset/survivor/security/trijent"


### PR DESCRIPTION
## About The Pull Request
Fixes an typo.
![image](https://user-images.githubusercontent.com/46639834/165204597-af897746-6c5e-4fe8-8ab4-04e90e918087.png)


## Why It's Good For The Game
/datum/equipment_preset/survivor/engineer/trjent doesnt exist for reference it use to be named like that but then they changed it and forgot to change it back. 

## Changelog
:cl:
fix: Survivor Engineer for Trijent its back on the kind of survivors you can spawn as
/:cl:

