### PR TITLE
hijack ladders + mess sarge to officers mess ladder

### DIFF
--- a/code/_globalvars/lists/object_lists.dm
+++ b/code/_globalvars/lists/object_lists.dm
@@ -27,3 +27,4 @@ GLOBAL_LIST_EMPTY_TYPED(disposalpipe_down_list, /obj/structure/disposalpipe/down
 
 GLOBAL_LIST_EMPTY_TYPED(hijack_bustable_windows, /obj/structure/window)
 GLOBAL_LIST_EMPTY_TYPED(hijack_deletable_windows, /obj/structure/machinery/door/window/ultra)
+GLOBAL_LIST_EMPTY_TYPED(hijack_bustable_ladders, /obj/structure/ladder/fragile_almayer)

--- a/code/game/objects/structures/ladders.dm
+++ b/code/game/objects/structures/ladders.dm
@@ -255,3 +255,29 @@
 			step_away(F,src,rand(1, 5))
 	else
 		return attack_hand(user)
+
+/obj/structure/ladder/fragile_almayer //goes away on hijack
+	name = "rickety ladder"
+	desc = "A slightly less stable-looking ladder, installed out of dry dock by some enterprising maintenance tech. Looks like it could collapse at any moment."
+
+/obj/structure/ladder/fragile_almayer/Initialize()
+	. = ..()
+	GLOB.hijack_bustable_ladders += src
+
+/obj/structure/ladder/fragile_almayer/Destroy()
+	GLOB.hijack_bustable_windows -= src
+	return ..()
+
+/obj/structure/ladder/fragile_almayer/proc/break_and_replace()
+	new /obj/structure/prop/broken_ladder(loc)
+	qdel(src)
+
+/obj/structure/prop/broken_ladder
+	name = "rickety ladder"
+	desc = "Well, it was only a matter of time."
+	icon = 'icons/obj/structures/structures.dmi'
+	icon_state = "ladder00"
+	anchored = 1
+	unslashable = TRUE
+	unacidable = TRUE
+	layer = LADDER_LAYER

--- a/code/modules/shuttles/marine_ferry.dm
+++ b/code/modules/shuttles/marine_ferry.dm
@@ -519,6 +519,10 @@
 		var/obj/structure/window/H = i
 		H.shatter_window(1)
 
+	for(var/k in GLOB.hijack_bustable_ladders)
+		var/obj/structure/ladder/fragile_almayer/L = k
+		L.break_and_replace()
+
 	// Delete the briefing door(s).
 	for(var/D in GLOB.hijack_deletable_windows)
 		qdel(D)

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -70241,10 +70241,15 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/upper_hull/u_f_p)
 "szi" = (
-/turf/closed/wall/almayer/reinforced{
-	color = null
+/obj/structure/machinery/door/airlock/almayer/maint{
+	req_one_access = list(2,34,30);
+	dir = 2
 	},
-/area/almayer/shipboard/brig/general_equipment)
+/turf/open/floor/almayer{
+	icon_regular_floor = "mono";
+	icon_state = "mono"
+	},
+/area/almayer/hull/upper_hull/u_m_p)
 "szm" = (
 /obj/structure/machinery/power/fusion_engine{
 	name = "\improper S-52 fusion reactor 10"

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -36539,7 +36539,10 @@
 	},
 /area/almayer/hull/lower_hull/l_a_p)
 "dcW" = (
-/obj/structure/machinery/door/airlock/almayer/maint,
+/obj/structure/machinery/door/airlock/almayer/maint{
+	req_one_access = list(2,34,30);
+	dir = 8
+	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/upper_hull/u_m_p)
 "ddj" = (
@@ -45243,12 +45246,14 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_f_p)
 "gMA" = (
-/obj/effect/decal/cleanable/cobweb{
-	dir = 4;
-	pixel_x = 9;
-	pixel_y = 19
+/obj/structure/machinery/door/airlock/almayer/maint{
+	req_one_access = list(2,34,30);
+	dir = 8
 	},
-/turf/open/floor/plating/plating_catwalk,
+/turf/open/floor/almayer{
+	icon_state = "plate";
+	tag = "icon-sterile"
+	},
 /area/almayer/hull/upper_hull/u_m_p)
 "gMU" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
@@ -83216,6 +83221,16 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/cic_hallway)
+"xWF" = (
+/obj/structure/machinery/door/airlock/almayer/maint{
+	req_one_access = list(2,34,30);
+	dir = 2
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate";
+	tag = "icon-sterile"
+	},
+/area/almayer/hull/upper_hull/u_m_p)
 "xWO" = (
 /obj/item/stack/catwalk,
 /obj/structure/cable/heavyduty{
@@ -109874,7 +109889,7 @@ avZ
 iYr
 cxk
 qVM
-jmR
+csz
 qVM
 eRR
 vce
@@ -113124,7 +113139,7 @@ adc
 pOZ
 wKn
 qVM
-xeG
+gMA
 qVM
 qVM
 crh
@@ -113935,7 +113950,7 @@ eHU
 qVM
 qVM
 qVM
-xeG
+gMA
 qVM
 qVM
 qVM
@@ -118199,7 +118214,7 @@ awE
 awE
 awE
 csz
-xCX
+xWF
 csz
 csz
 qVM
@@ -118405,7 +118420,7 @@ ieH
 qVM
 dYK
 csz
-xCX
+xWF
 csz
 qVM
 czu
@@ -118606,7 +118621,7 @@ eKK
 awE
 oLw
 qVM
-gMA
+jmR
 vGk
 qVM
 hoX

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -4655,7 +4655,6 @@
 	},
 /area/shuttle/drop1/sulaco)
 "ana" = (
-/obj/structure/machinery/cm_vending/sorted/cargo_guns/pilot_officer,
 /obj/structure/sign/safety/hazard{
 	pixel_x = -17;
 	pixel_y = -8
@@ -4664,6 +4663,7 @@
 	pixel_x = -17;
 	pixel_y = 7
 	},
+/obj/structure/machinery/cm_vending/clothing/pilot_officer,
 /turf/open/floor/almayer{
 	icon_state = "plate";
 	tag = "icon-sterile"
@@ -11954,7 +11954,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/machinery/door/airlock/almayer/maint,
+/obj/structure/machinery/door/airlock/almayer/maint{
+	req_one_access = list(2,34,30)
+	},
 /turf/open/floor/almayer{
 	icon_state = "plate";
 	tag = "icon-sterile"
@@ -50676,8 +50678,14 @@
 	},
 /area/almayer/living/captain_mess)
 "jmR" = (
-/obj/structure/surface/table/almayer,
-/obj/item/device/cassette_tape,
+/obj/structure/ladder/fragile_almayer{
+	id = "kitchen";
+	height = 2
+	},
+/obj/structure/sign/safety/ladder{
+	pixel_x = 8;
+	pixel_y = 24
+	},
 /turf/open/floor/almayer{
 	icon_state = "plate";
 	tag = "icon-sterile"
@@ -58164,7 +58172,7 @@
 	name = "\improper Privacy Shutters"
 	},
 /obj/structure/machinery/door/airlock/almayer/maint/reinforced{
-	req_access_txt = "19"
+	req_one_access_txt = "19;30"
 	},
 /turf/open/floor/almayer{
 	icon_state = "plate";
@@ -63937,7 +63945,14 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/obj/structure/reagent_dispensers/beerkeg,
+/obj/structure/ladder/fragile_almayer{
+	id = "kitchen";
+	height = 1
+	},
+/obj/structure/sign/safety/ladder{
+	pixel_x = 8;
+	pixel_y = 24
+	},
 /turf/open/floor/almayer{
 	dir = 1;
 	icon_state = "green";
@@ -70225,6 +70240,11 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/upper_hull/u_f_p)
+"szi" = (
+/turf/closed/wall/almayer/reinforced{
+	color = null
+	},
+/area/almayer/shipboard/brig/general_equipment)
 "szm" = (
 /obj/structure/machinery/power/fusion_engine{
 	name = "\improper S-52 fusion reactor 10"
@@ -70261,6 +70281,13 @@
 	tag = "icon-emerald (SOUTHEAST)"
 	},
 /area/almayer/squads/charlie)
+"szO" = (
+/obj/structure/machinery/cm_vending/sorted/cargo_guns/pilot_officer,
+/turf/open/floor/almayer{
+	icon_state = "plate";
+	tag = "icon-sterile"
+	},
+/area/almayer/living/pilotbunks)
 "sAc" = (
 /obj/structure/machinery/cm_vending/clothing/senior_officer{
 	density = 0;
@@ -75132,7 +75159,6 @@
 /area/almayer/hull/lower_hull/l_m_s)
 "uGz" = (
 /obj/structure/machinery/camera/autoname/almayer{
-	dir = 1;
 	name = "ship-grade camera";
 	tag = "icon-camera (NORTH)"
 	},
@@ -106564,7 +106590,7 @@ aws
 amh
 aiX
 ana
-aqw
+szO
 aqw
 aiX
 amh
@@ -110045,9 +110071,9 @@ baw
 mnA
 rKs
 aJU
-xCX
+szi
 csz
-xCX
+szi
 aJU
 baw
 aJU


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Adds a new ladder between the hydro room and top deck for easier travel by the mess sarge up there, plus an exciting new back route around the ship. 

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Adds a way for the mess sarge to get to the officer's mess faster (the walk is long and annoying) To prevent this fucking up hijack balance, it breaks on hijack.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
expansion: Added a ladder between the chef's hydroponics garden and a maint tunnel near the officers' mess for easier travel
expansion: Added a new type of ladder that breaks on hijack. The above ladder is one of them.
bugfix: fixed yet more poorly offset almayer cameras
expansion: swapped the PO guns and PO gear vendor positions around to let two people gear up properly at once
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
