### PR TITLE
Increases Resin Spike Count from 15 to 25

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/resin_constructions.dm
+++ b/code/modules/mob/living/carbon/xenomorph/resin_constructions.dm
@@ -212,7 +212,7 @@ GLOBAL_VAR_INIT(resin_lz_allowed, FALSE)
 	desc = "Resin that harms any tallhosts when they walk over it."
 	construction_name = "resin spike"
 	cost = XENO_RESIN_SPIKE_COST
-	max_per_xeno = 15
+	max_per_xeno = 25
 
 	build_path = /obj/effect/alien/resin/spike
 


### PR DESCRIPTION
## About The Pull Request

Changed resin spike count from 15 to 25.

## Why It's Good For The Game

Is a pretty unique building element, an increased cap lets the builder castes build more elaborate traps.

## Changelog

:cl:
balance: Changed Resin Spike Count From 15 to 25.
/:cl:
