### PR TITLE
Fix Layer on Cigarrete Vending at Hangar

### DIFF
--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -41620,9 +41620,7 @@
 	dir = 1;
 	pixel_y = 2
 	},
-/obj/structure/machinery/vending/cigarette{
-	layer = 3.1
-	},
+/obj/structure/machinery/vending/cigarette,
 /obj/item/ashtray/plastic{
 	layer = 3.4;
 	pixel_x = 7;


### PR DESCRIPTION
## About The Pull Request
Wrong layer on a vending makes the objects ended up under it instead of over. 
![image](https://user-images.githubusercontent.com/46639834/165595843-7c219592-a641-42c5-a33b-d5cc50c37e18.png)

## Why It's Good For The Game
Now products dont end up under the vending.

## Changelog

:cl:
fix: Cigarrete Vendor at Hangar now puts the items over it instead of under it.
/:cl: