### PR TITLE
Fix shoes with no sprites for CL and Stowaway 

### DIFF
--- a/code/modules/gear_presets/agents.dm
+++ b/code/modules/gear_presets/agents.dm
@@ -24,7 +24,7 @@
 	utility_under = list(/obj/item/clothing/under/liaison_suit/outing)
 	utility_hat = list()
 	utility_gloves = list()
-	utility_shoes = list(/obj/item/clothing/shoes)
+	utility_shoes = list(/obj/item/clothing/shoes/laceup)
 	utility_extra = list(/obj/item/clothing/under/liaison_suit/suspenders)
 
 	service_under = list(/obj/item/clothing/under/liaison_suit)

--- a/code/modules/gear_presets/uscm_ship.dm
+++ b/code/modules/gear_presets/uscm_ship.dm
@@ -55,7 +55,7 @@
 	utility_under = list(/obj/item/clothing/under/liaison_suit/outing)
 	utility_hat = list()
 	utility_gloves = list()
-	utility_shoes = list(/obj/item/clothing/shoes/black)
+	utility_shoes = list(/obj/item/clothing/shoes/laceup)
 	utility_extra = list(/obj/item/clothing/under/liaison_suit/suspenders)
 
 	service_under = list(/obj/item/clothing/under/liaison_suit)

--- a/code/modules/gear_presets/uscm_ship.dm
+++ b/code/modules/gear_presets/uscm_ship.dm
@@ -55,7 +55,7 @@
 	utility_under = list(/obj/item/clothing/under/liaison_suit/outing)
 	utility_hat = list()
 	utility_gloves = list()
-	utility_shoes = list(/obj/item/clothing/shoes)
+	utility_shoes = list(/obj/item/clothing/shoes/black)
 	utility_extra = list(/obj/item/clothing/under/liaison_suit/suspenders)
 
 	service_under = list(/obj/item/clothing/under/liaison_suit)


### PR DESCRIPTION
## About The Pull Request
There's no sprite for /obj/item/clothing/shoes since its an class from where others get atributes. So the sprite its missing for the item once you try to get it.

## Why It's Good For The Game
Fixes a weird direction error that creates some shoes with no sprite for the CL and to another outfit.

## Changelog
:cl:
fix: Now the uniform vendor for CL gives him a pair of laceup shoes instead of a missing object.
/:cl: