### PR TITLE
Adds Mop to Autolathe

### DIFF
--- a/code/game/machinery/autolathe_datums.dm
+++ b/code/game/machinery/autolathe_datums.dm
@@ -62,6 +62,11 @@
 	path = /obj/item/tool/wrench
 	category = "Tools"
 
+/datum/autolathe/recipe/mop
+	name = "mop"
+	path = /obj/item/tool/mop
+	category = "Tools"
+
 /datum/autolathe/recipe/radio_headset
 	name = "radio headset"
 	path = /obj/item/device/radio/headset

--- a/code/game/objects/items/tools/cleaning_tools.dm
+++ b/code/game/objects/items/tools/cleaning_tools.dm
@@ -8,6 +8,7 @@
 	throw_speed = SPEED_VERY_FAST
 	throw_range = 10
 	w_class = SIZE_MEDIUM
+	matter = list("metal" = 110)
 	attack_verb = list("mopped", "bashed", "bludgeoned", "whacked")
 	var/mopping = 0
 	var/mopcount = 0


### PR DESCRIPTION
## About The Pull Request

Adds the mop to the autolathe.

## Why It's Good For The Game

Against would-be mop thieves. Maybe the MTs will help the Alamyer look cleaner for once.

## Changelog

:cl:
expansion: Adds Mop to Autolathe.
/:cl: