### PR TITLE
Decreases Oppressor Abduct Cooldown

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/praetorian/praetorian_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/praetorian/praetorian_abilities.dm
@@ -113,7 +113,7 @@
 	macro_path = /datum/action/xeno_action/verb/verb_prae_abduct
 	ability_primacy = XENO_PRIMARY_ACTION_1
 	action_type = XENO_ACTION_CLICK
-	xeno_cooldown = 180
+	xeno_cooldown = 150
 	plasma_cost = 180
 
 	// Config


### PR DESCRIPTION
## About The Pull Request

Changes the oppressor's abduct cooldown from 18s down to 15s

## Why It's Good For The Game

With time dilation the time to dodge is quite large for marine, and waiting 23s~ (again, dilation) for the main gimmick ability while oppressor is (almost) the worst prae strain already results in sitting there for a cooldown.

## Changelog

:cl:
balance: Reduces Oppressor Abduct Cooldown.
/:cl:
