### PR TITLE
Drops FPW APC gun to 20 secs from 90

### DIFF
--- a/code/modules/vehicles/hardpoints/special/firing_port_weapon.dm
+++ b/code/modules/vehicles/hardpoints/special/firing_port_weapon.dm
@@ -16,7 +16,7 @@
 	var/burst_amount = 3
 	//FPWs reload automatically
 	var/reloading = FALSE
-	var/reload_time = 90 SECONDS
+	var/reload_time = 20 SECONDS
 	var/reload_time_started = 0
 
 	allowed_seat = VEHICLE_SUPPORT_GUNNER_ONE


### PR DESCRIPTION
## About The Pull Request

Pre-approved by Nanu, the one other GA. Buffs the APC M56 FPW variant from 90s reload time down 20s, making playing as a door gunner viable for riflemen and other squad rolls.
![Alt Text](https://thumbs.gfycat.com/EqualEvenIberiannase-max-1mb.gif)
## Why It's Good For The Game
Doorgunners are badass.

## Changelog

:cl: Triiodine
balance: Buff: reduced the APC M56 FPW reload time down to 20s from 90s.
/:cl:
