### PR TITLE
Pref Pain Overlays

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -383,3 +383,19 @@ var/list/default_onmob_icons = list(
 #define HANDLING_LIMBS list("l_arm","l_hand", "r_arm", "r_hand")
 #define EXTREMITY_LIMBS list("l_leg","l_foot","r_leg","r_foot","l_arm","l_hand","r_arm","r_hand")
 #define CORE_LIMBS list("chest","head","groin")
+
+#define OVERLAY_PAIN "pain"
+#define OVERLAY_XENO_PAIN "xeno_pain"
+#define OVERLAY_WEATHER "weather"
+#define OVERLAY_FLASH "flash"
+#define OVERLAY_BLIND "blind"
+#define OVERLAY_EYE_BLURRY "eye_blurry"
+#define OVERLAY_HIGH "high"
+#define OVERLAY_TINT "tint"
+#define OVERLAY_GLASSES_VISION "glasses_vision"
+#define OVERLAY_CRIT "crit"
+#define OVERLAY_OXY "oxy"
+#define OVERLAY_BRUTE "brute"
+#define OVERLAY_DAZED "dazed"
+
+#define PAIN_OVERLAYS list(OVERLAY_PAIN, OVERLAY_XENO_PAIN, OVERLAY_BRUTE)

--- a/code/_onclick/hud/fullscreen.dm
+++ b/code/_onclick/hud/fullscreen.dm
@@ -4,6 +4,8 @@
 	var/list/fullscreens = list()
 
 /mob/proc/overlay_fullscreen(category, type, severity)
+	if(client?.prefs.no_pain_overlays && (category in PAIN_OVERLAYS))
+		return
 	var/obj/screen/fullscreen/screen = fullscreens[category]
 	if (!screen || screen.type != type)
 		// needs to be recreated

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -188,6 +188,7 @@ var/const/MAX_SAVE_SLOTS = 10
 	var/hide_statusbar
 
 	var/no_radials_preference = FALSE
+	var/no_pain_overlays = FALSE
 
 	var/bg_state = "blank" // the icon_state of the floortile background displayed behind the mannequin in character creation
 	var/show_job_gear = TRUE // whether the job gear gets equipped to the mannequin in character creation
@@ -509,6 +510,7 @@ var/const/MAX_SAVE_SLOTS = 10
 			dat += "<b>Ghost Sight:</b> <a href='?_src_=prefs;preference=ghost_sight'><b>[(toggles_chat & CHAT_GHOSTSIGHT) ? "All Emotes" : "Nearest Creatures"]</b></a><br>"
 			dat += "<b>Ghost Radio:</b> <a href='?_src_=prefs;preference=ghost_radio'><b>[(toggles_chat & CHAT_GHOSTRADIO) ? "All Chatter" : "Nearest Speakers"]</b></a><br>"
 			dat += "<b>Ghost Hivemind:</b> <a href='?_src_=prefs;preference=ghost_hivemind'><b>[(toggles_chat & CHAT_GHOSTHIVEMIND) ? "Show Hivemind" : "Hide Hivemind"]</b></a><br>"
+			dat += "<b>Disable Pain Overlays:</b> <a href='?_src_=prefs;preference=no_pain_overlays'><b>[no_pain_overlays ? "TRUE" : "FALSE"]</b></a><br>"
 			if(CONFIG_GET(flag/allow_Metadata))
 				dat += "<b>OOC Notes:</b> <a href='?_src_=prefs;preference=metadata;task=input'> Edit </a>"
 			dat += "</div>"
@@ -1435,6 +1437,9 @@ var/const/MAX_SAVE_SLOTS = 10
 
 				if("no_radials_preference")
 					no_radials_preference = !no_radials_preference
+
+				if("no_pain_overlays")
+					no_pain_overlays = !no_pain_overlays
 
 				if("ViewMC")
 					if(user.client.admin_holder && user.client.admin_holder.rights & R_DEBUG)

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -119,6 +119,7 @@
 	S["hear_vox"] >> hear_vox
 	S["hide_statusbar"] >> hide_statusbar
 	S["no_radials_preference"] >> no_radials_preference
+	S["no_pain_overlays"] >> no_pain_overlays
 	S["hotkeys"] >> hotkeys
 
 	//Sanitize
@@ -141,6 +142,7 @@
 	hear_vox  		= sanitize_integer(hear_vox, FALSE, TRUE, TRUE)
 	hide_statusbar = sanitize_integer(hide_statusbar, FALSE, TRUE, FALSE)
 	no_radials_preference = sanitize_integer(no_radials_preference, FALSE, TRUE, FALSE)
+	no_pain_overlays = sanitize_integer(no_pain_overlays, FALSE, TRUE, FALSE)
 
 	synthetic_name 		= synthetic_name ? sanitize_text(synthetic_name, initial(synthetic_name)) : initial(synthetic_name)
 	synthetic_type		= sanitize_inlist(synthetic_type, PLAYER_SYNTHS, initial(synthetic_type))
@@ -250,6 +252,7 @@
 
 	S["hide_statusbar"] << hide_statusbar
 	S["no_radials_preference"] << no_radials_preference
+	S["no_pain_overlays"] << no_pain_overlays
 
 	return TRUE
 

--- a/code/modules/mob/living/brain/life.dm
+++ b/code/modules/mob/living/brain/life.dm
@@ -161,19 +161,19 @@
 
 	if(stat != DEAD) //the dead get zero fullscreens
 		if(blinded)
-			overlay_fullscreen("blind", /obj/screen/fullscreen/blind)
+			overlay_fullscreen(OVERLAY_BLIND, /obj/screen/fullscreen/blind)
 		else
-			clear_fullscreen("blind")
+			clear_fullscreen(OVERLAY_BLIND)
 
 			if(eye_blurry)
-				overlay_fullscreen("eye_blurry", /obj/screen/fullscreen/impaired, 5)
+				overlay_fullscreen(OVERLAY_EYE_BLURRY, /obj/screen/fullscreen/impaired, 5)
 			else
-				clear_fullscreen("eye_blurry")
+				clear_fullscreen(OVERLAY_EYE_BLURRY)
 
 			if(druggy)
-				overlay_fullscreen("high", /obj/screen/fullscreen/high)
+				overlay_fullscreen(OVERLAY_HIGH, /obj/screen/fullscreen/high)
 			else
-				clear_fullscreen("high")
+				clear_fullscreen(OVERLAY_HIGH)
 
 
 		if (interactee)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1294,10 +1294,10 @@
 		tint_level = VISION_IMPAIR_STRONG
 
 	if(tint_level)
-		overlay_fullscreen("tint", /obj/screen/fullscreen/impaired, tint_level)
+		overlay_fullscreen(OVERLAY_TINT, /obj/screen/fullscreen/impaired, tint_level)
 		return TRUE
 	else
-		clear_fullscreen("tint", 0)
+		clear_fullscreen(OVERLAY_TINT, 0)
 		return FALSE
 
 
@@ -1307,10 +1307,10 @@
 /mob/living/carbon/human/update_glass_vision(obj/item/clothing/glasses/G)
 	if(G.fullscreen_vision)
 		if(G == glasses && G.active) //equipped and activated
-			overlay_fullscreen("glasses_vision", G.fullscreen_vision)
+			overlay_fullscreen(OVERLAY_GLASSES_VISION, G.fullscreen_vision)
 			return TRUE
 		else //unequipped or deactivated
-			clear_fullscreen("glasses_vision", 0)
+			clear_fullscreen(OVERLAY_GLASSES_VISION, 0)
 
 /mob/living/carbon/human/verb/checkSkills()
 	set name = "Check Skills"

--- a/code/modules/mob/living/carbon/human/life/handle_regular_hud_updates.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_regular_hud_updates.dm
@@ -20,9 +20,9 @@
 				if(-90 to -80) severity = 8
 				if(-95 to -90) severity = 9
 				if(-INFINITY to -95) severity = 10
-			overlay_fullscreen("crit", /obj/screen/fullscreen/crit, severity)
+			overlay_fullscreen(OVERLAY_CRIT, /obj/screen/fullscreen/crit, severity)
 		else
-			clear_fullscreen("crit")
+			clear_fullscreen(OVERLAY_CRIT)
 			if(oxyloss)
 				var/severity = 0
 				switch(oxyloss)
@@ -33,9 +33,9 @@
 					if(35 to 40) severity = 5
 					if(40 to 45) severity = 6
 					if(45 to INFINITY) severity = 7
-				overlay_fullscreen("oxy", /obj/screen/fullscreen/oxy, severity)
+				overlay_fullscreen(OVERLAY_OXY, /obj/screen/fullscreen/oxy, severity)
 			else
-				clear_fullscreen("oxy")
+				clear_fullscreen(OVERLAY_OXY)
 
 
 			//Fire and Brute damage overlay (BSSR)
@@ -50,27 +50,27 @@
 					if(45 to 70) severity = 4
 					if(70 to 85) severity = 5
 					if(85 to INFINITY) severity = 6
-				overlay_fullscreen("brute", /obj/screen/fullscreen/brute, severity)
+				overlay_fullscreen(OVERLAY_BRUTE, /obj/screen/fullscreen/brute, severity)
 			else
-				clear_fullscreen("brute")
+				clear_fullscreen(OVERLAY_BRUTE)
 
 
 		if(blinded)
-			overlay_fullscreen("blind", /obj/screen/fullscreen/blind)
+			overlay_fullscreen(OVERLAY_BLIND, /obj/screen/fullscreen/blind)
 		else
-			clear_fullscreen("blind")
+			clear_fullscreen(OVERLAY_BLIND)
 
 		if(eye_blurry || dazed)
-			overlay_fullscreen("eye_blurry", /obj/screen/fullscreen/impaired, 5)
+			overlay_fullscreen(OVERLAY_EYE_BLURRY, /obj/screen/fullscreen/impaired, 5)
 		else if((disabilities & NEARSIGHTED) && !HAS_TRAIT(src, TRAIT_NEARSIGHTED_EQUIPMENT))
-			overlay_fullscreen("eye_blurry", /obj/screen/fullscreen/impaired, 2)
+			overlay_fullscreen(OVERLAY_EYE_BLURRY, /obj/screen/fullscreen/impaired, 2)
 		else
-			clear_fullscreen("eye_blurry")
+			clear_fullscreen(OVERLAY_EYE_BLURRY)
 
 		if(druggy)
-			overlay_fullscreen("high", /obj/screen/fullscreen/high)
+			overlay_fullscreen(OVERLAY_HIGH, /obj/screen/fullscreen/high)
 		else
-			clear_fullscreen("high")
+			clear_fullscreen(OVERLAY_HIGH)
 
 
 		if(hud_used)

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -195,11 +195,11 @@
 
 		if(regular_update)
 			if(eye_blurry)
-				overlay_fullscreen("eye_blurry", /obj/screen/fullscreen/impaired, 5)
+				overlay_fullscreen(OVERLAY_EYE_BLURRY, /obj/screen/fullscreen/impaired, 5)
 				src.eye_blurry--
 				src.eye_blurry = max(0, src.eye_blurry)
 			else
-				clear_fullscreen("eye_blurry")
+				clear_fullscreen(OVERLAY_EYE_BLURRY)
 
 			handle_statuses()//natural decrease of stunned, knocked_down, etc...
 			handle_interference()
@@ -229,7 +229,7 @@
 		return TRUE
 
 	if(stat == DEAD)
-		clear_fullscreen("xeno_pain")
+		clear_fullscreen(OVERLAY_XENO_PAIN)
 		if(hud_used)
 			if(hud_used.healths)
 				hud_used.healths.icon_state = "health_dead"
@@ -241,14 +241,14 @@
 
 	var/severity = HUD_PAIN_STATES_XENO - Ceiling(((max(health, 0) / maxHealth) * HUD_PAIN_STATES_XENO))
 	if(severity)
-		overlay_fullscreen("xeno_pain", /obj/screen/fullscreen/xeno_pain, severity)
+		overlay_fullscreen(OVERLAY_XENO_PAIN, /obj/screen/fullscreen/xeno_pain, severity)
 	else
-		clear_fullscreen("xeno_pain")
+		clear_fullscreen(OVERLAY_XENO_PAIN)
 
 	if(blinded)
-		overlay_fullscreen("blind", /obj/screen/fullscreen/blind)
+		overlay_fullscreen(OVERLAY_BLIND, /obj/screen/fullscreen/blind)
 	else
-		clear_fullscreen("blind")
+		clear_fullscreen(OVERLAY_BLIND)
 
 	if(interactee)
 		interactee.check_eye(src)
@@ -256,9 +256,9 @@
 		reset_view(null)
 
 	if(dazed)
-		overlay_fullscreen("dazed", /obj/screen/fullscreen/impaired, 5)
+		overlay_fullscreen(OVERLAY_DAZED, /obj/screen/fullscreen/impaired, 5)
 	else
-		clear_fullscreen("dazed")
+		clear_fullscreen(OVERLAY_DAZED)
 
 	if(!hud_used)
 		return TRUE

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -457,9 +457,9 @@
 
 /mob/living/flash_eyes(intensity = 1, bypass_checks, type = /obj/screen/fullscreen/flash, var/flash_timer = 40)
 	if( bypass_checks || (get_eye_protection() < intensity && !(sdisabilities & DISABILITY_BLIND)))
-		overlay_fullscreen("flash", type)
+		overlay_fullscreen(OVERLAY_FLASH, type)
 		spawn(flash_timer)
-			clear_fullscreen("flash", 20)
+			clear_fullscreen(OVERLAY_FLASH, 20)
 		return 1
 
 /datum/event_args/mob_movement

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -195,7 +195,7 @@
 		return
 
 	// Do this always
-	clear_fullscreen("weather")
+	clear_fullscreen(OVERLAY_WEATHER)
 	remove_weather_effects()
 
 	// Check if we're supposed to be something affected by weather
@@ -204,9 +204,7 @@
 
 		// Fullscreens
 		if(SSweather.weather_event_instance.fullscreen_type)
-			overlay_fullscreen("weather", SSweather.weather_event_instance.fullscreen_type)
-		else
-			clear_fullscreen("weather")
+			overlay_fullscreen(OVERLAY_WEATHER, SSweather.weather_event_instance.fullscreen_type)
 
 		// Effects
 		if(SSweather.weather_event_instance.effect_type)

--- a/code/modules/mob/living/silicon/ai/life.dm
+++ b/code/modules/mob/living/silicon/ai/life.dm
@@ -78,17 +78,17 @@
 			if (src:aiRestorePowerRoutine==2)
 				to_chat(src, "Alert cancelled. Power has been restored without our assistance.")
 				src:aiRestorePowerRoutine = 0
-				clear_fullscreen("blind")
+				clear_fullscreen(OVERLAY_BLIND)
 				return
 			else if (src:aiRestorePowerRoutine==3)
 				to_chat(src, "Alert cancelled. Power has been restored.")
 				src:aiRestorePowerRoutine = 0
-				clear_fullscreen("blind")
+				clear_fullscreen(OVERLAY_BLIND)
 				return
 		else
 
 			//stage = 6
-			overlay_fullscreen("blind", /obj/screen/fullscreen/blind)
+			overlay_fullscreen(OVERLAY_BLIND, /obj/screen/fullscreen/blind)
 			src.sight = src.sight&~SEE_TURFS
 			src.sight = src.sight&~SEE_MOBS
 			src.sight = src.sight&~SEE_OBJS
@@ -110,7 +110,7 @@
 							if (!istype(T, /turf/open/space))
 								to_chat(src, "Alert cancelled. Power has been restored without our assistance.")
 								src:aiRestorePowerRoutine = 0
-								clear_fullscreen("blind")
+								clear_fullscreen(OVERLAY_BLIND)
 								return
 						to_chat(src, "Fault confirmed: missing external power. Shutting down main control system to save power.")
 						sleep(20)
@@ -148,7 +148,7 @@
 								if (!istype(T, /turf/open/space))
 									to_chat(src, "Alert cancelled. Power has been restored without our assistance.")
 									src:aiRestorePowerRoutine = 0
-									clear_fullscreen("blind")
+									clear_fullscreen(OVERLAY_BLIND)
 									return
 							switch(PRP)
 								if (1) to_chat(src, "APC located. Optimizing route to APC to avoid needless power waste.")

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -220,19 +220,19 @@
 
 	if(stat != DEAD) //the dead get zero fullscreens
 		if(blinded)
-			overlay_fullscreen("blind", /obj/screen/fullscreen/blind)
+			overlay_fullscreen(OVERLAY_BLIND, /obj/screen/fullscreen/blind)
 		else
-			clear_fullscreen("blind")
+			clear_fullscreen(OVERLAY_BLIND)
 
 		if (eye_blurry)
-			overlay_fullscreen("eye_blurry", /obj/screen/fullscreen/impaired, 5)
+			overlay_fullscreen(OVERLAY_EYE_BLURRY, /obj/screen/fullscreen/impaired, 5)
 		else
-			clear_fullscreen("eye_blurry")
+			clear_fullscreen(OVERLAY_EYE_BLURRY)
 
 		if(druggy)
-			overlay_fullscreen("high", /obj/screen/fullscreen/high)
+			overlay_fullscreen(OVERLAY_HIGH, /obj/screen/fullscreen/high)
 		else
-			clear_fullscreen("high")
+			clear_fullscreen(OVERLAY_HIGH)
 
 
 		if(interactee)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -735,8 +735,8 @@ note dizziness decrements automatically in the mob's Life() proc.
 	return TRUE
 
 /mob/proc/flash_weak_pain()
-	overlay_fullscreen("pain", /obj/screen/fullscreen/pain, 1)
-	clear_fullscreen("pain")
+	overlay_fullscreen(OVERLAY_PAIN, /obj/screen/fullscreen/pain, 1)
+	clear_fullscreen(OVERLAY_PAIN)
 
 /mob/proc/get_visible_implants(var/class = 0)
 	var/list/visible_implants = list()

--- a/code/modules/organs/pain.dm
+++ b/code/modules/organs/pain.dm
@@ -1,6 +1,6 @@
 /mob/proc/flash_pain()
-	overlay_fullscreen("pain", /obj/screen/fullscreen/pain, 2)
-	clear_fullscreen("pain")
+	overlay_fullscreen(OVERLAY_PAIN, /obj/screen/fullscreen/pain, 2)
+	clear_fullscreen(OVERLAY_PAIN)
 
 mob/var/list/pain_stored = list()
 mob/var/last_pain_message = ""


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Adds a preference option to disable generating pain overlays, because they tend to lag clients when they first get added, and randomly thereafter. Also changes the overlay strings into defines.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Lagging during combat, which is where you'll get pain overlays, isn't that much fun.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added a preference to disable pain overlays to the settings tab in character creation.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
