### PR TITLE
dir locking now slows you down

### DIFF
--- a/code/__DEFINES/pain.dm
+++ b/code/__DEFINES/pain.dm
@@ -1,9 +1,10 @@
 // Pain
 
 // How slow we go from losing a limb
-#define MOVE_REDUCTION_LIMB_DESTROYED 4.0
-#define MOVE_REDUCTION_LIMB_BROKEN    1.5
-#define MOVE_REDUCTION_LIMB_SPLINTED  0.5
+#define MOVE_REDUCTION_LIMB_DESTROYED	4.0
+#define MOVE_REDUCTION_LIMB_BROKEN		1.5
+#define MOVE_REDUCTION_DIRECTION_LOCKED	1
+#define MOVE_REDUCTION_LIMB_SPLINTED	0.5
 
 // Traumatic shock reduction for different reagents
 #define PAIN_REDUCTION_MULTIPLIER	20

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -643,13 +643,19 @@ note dizziness decrements automatically in the mob's Life() proc.
 
 	if(laid_down)
 		lying = TRUE
-		flags_atom &= ~DIRLOCK
+		if(flags_atom & DIRLOCK)
+			flags_atom &= ~DIRLOCK
+			move_delay += MOVE_REDUCTION_DIRECTION_LOCKED
+			recalculate_move_delay = TRUE
 	else
 		lying = FALSE
 	if(buckled)
 		if(buckled.buckle_lying)
 			lying = TRUE
-			flags_atom &= ~DIRLOCK
+			if(flags_atom & DIRLOCK)
+				flags_atom &= ~DIRLOCK
+				move_delay += MOVE_REDUCTION_DIRECTION_LOCKED
+				recalculate_move_delay = TRUE
 		else
 			lying = FALSE
 
@@ -687,7 +693,10 @@ note dizziness decrements automatically in the mob's Life() proc.
 	if(!canface())	return 0
 	var/newdir = FALSE
 	if(dir != ndir)
-		flags_atom &= ~DIRLOCK
+		if(flags_atom & DIRLOCK)
+			flags_atom &= ~DIRLOCK
+			move_delay += MOVE_REDUCTION_DIRECTION_LOCKED
+			recalculate_move_delay = TRUE
 		setDir(ndir)
 		newdir = TRUE
 	if(buckled && !buckled.anchored)
@@ -707,8 +716,13 @@ note dizziness decrements automatically in the mob's Life() proc.
 /mob/proc/set_face_dir(var/newdir)
 	if(newdir == dir && flags_atom & DIRLOCK)
 		flags_atom &= ~DIRLOCK
+		move_delay += MOVE_REDUCTION_DIRECTION_LOCKED
+		recalculate_move_delay = TRUE
 	else if ( facedir(newdir) )
-		flags_atom |= DIRLOCK
+		if(!(flags_atom & DIRLOCK))
+			flags_atom |= DIRLOCK
+			move_delay -= MOVE_REDUCTION_DIRECTION_LOCKED
+			recalculate_move_delay = TRUE
 
 
 /mob/proc/IsAdvancedToolUser()//This might need a rename but it should replace the can this mob use things check

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -645,8 +645,6 @@ note dizziness decrements automatically in the mob's Life() proc.
 		lying = TRUE
 		if(flags_atom & DIRLOCK)
 			flags_atom &= ~DIRLOCK
-			move_delay += MOVE_REDUCTION_DIRECTION_LOCKED
-			recalculate_move_delay = TRUE
 	else
 		lying = FALSE
 	if(buckled)
@@ -654,8 +652,6 @@ note dizziness decrements automatically in the mob's Life() proc.
 			lying = TRUE
 			if(flags_atom & DIRLOCK)
 				flags_atom &= ~DIRLOCK
-				move_delay += MOVE_REDUCTION_DIRECTION_LOCKED
-				recalculate_move_delay = TRUE
 		else
 			lying = FALSE
 
@@ -695,8 +691,6 @@ note dizziness decrements automatically in the mob's Life() proc.
 	if(dir != ndir)
 		if(flags_atom & DIRLOCK)
 			flags_atom &= ~DIRLOCK
-			move_delay += MOVE_REDUCTION_DIRECTION_LOCKED
-			recalculate_move_delay = TRUE
 		setDir(ndir)
 		newdir = TRUE
 	if(buckled && !buckled.anchored)
@@ -716,13 +710,9 @@ note dizziness decrements automatically in the mob's Life() proc.
 /mob/proc/set_face_dir(var/newdir)
 	if(newdir == dir && flags_atom & DIRLOCK)
 		flags_atom &= ~DIRLOCK
-		move_delay += MOVE_REDUCTION_DIRECTION_LOCKED
-		recalculate_move_delay = TRUE
 	else if(facedir(newdir))
 		if(!(flags_atom & DIRLOCK))
 			flags_atom |= DIRLOCK
-			move_delay -= MOVE_REDUCTION_DIRECTION_LOCKED
-			recalculate_move_delay = TRUE
 
 
 /mob/proc/IsAdvancedToolUser()//This might need a rename but it should replace the can this mob use things check

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -643,15 +643,13 @@ note dizziness decrements automatically in the mob's Life() proc.
 
 	if(laid_down)
 		lying = TRUE
-		if(flags_atom & DIRLOCK)
-			flags_atom &= ~DIRLOCK
+		flags_atom &= ~DIRLOCK
 	else
 		lying = FALSE
 	if(buckled)
 		if(buckled.buckle_lying)
 			lying = TRUE
-			if(flags_atom & DIRLOCK)
-				flags_atom &= ~DIRLOCK
+			flags_atom &= ~DIRLOCK
 		else
 			lying = FALSE
 
@@ -689,8 +687,7 @@ note dizziness decrements automatically in the mob's Life() proc.
 	if(!canface())	return 0
 	var/newdir = FALSE
 	if(dir != ndir)
-		if(flags_atom & DIRLOCK)
-			flags_atom &= ~DIRLOCK
+		flags_atom &= ~DIRLOCK
 		setDir(ndir)
 		newdir = TRUE
 	if(buckled && !buckled.anchored)
@@ -711,8 +708,7 @@ note dizziness decrements automatically in the mob's Life() proc.
 	if(newdir == dir && flags_atom & DIRLOCK)
 		flags_atom &= ~DIRLOCK
 	else if(facedir(newdir))
-		if(!(flags_atom & DIRLOCK))
-			flags_atom |= DIRLOCK
+		flags_atom |= DIRLOCK
 
 
 /mob/proc/IsAdvancedToolUser()//This might need a rename but it should replace the can this mob use things check

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -718,7 +718,7 @@ note dizziness decrements automatically in the mob's Life() proc.
 		flags_atom &= ~DIRLOCK
 		move_delay += MOVE_REDUCTION_DIRECTION_LOCKED
 		recalculate_move_delay = TRUE
-	else if ( facedir(newdir) )
+	else if(facedir(newdir))
 		if(!(flags_atom & DIRLOCK))
 			flags_atom |= DIRLOCK
 			move_delay -= MOVE_REDUCTION_DIRECTION_LOCKED

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -158,6 +158,8 @@
 		if(mob.next_move_slowdown)
 			move_delay += mob.next_move_slowdown
 			mob.next_move_slowdown = 0
+/*		if((mob.flags_atom & DIRLOCK) && mob.dir != direct)
+			move_delay += MOVE_REDUCTION_DIRECTION_LOCKED */ //geeves solution, will test later, just keeping here for now
 
 		mob.last_move_intent = world.time + 10
 		mob.cur_speed = Clamp(10/(move_delay + 0.5), MIN_SPEED, MAX_SPEED)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -158,7 +158,7 @@
 		if(mob.next_move_slowdown)
 			move_delay += mob.next_move_slowdown
 			mob.next_move_slowdown = 0
-/*		if((mob.flags_atom & DIRLOCK) && mob.dir != direct)
+		/*if((mob.flags_atom & DIRLOCK) && mob.dir != direct)
 			move_delay += MOVE_REDUCTION_DIRECTION_LOCKED */ //geeves solution, will test later, just keeping here for now
 
 		mob.last_move_intent = world.time + 10

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -158,8 +158,8 @@
 		if(mob.next_move_slowdown)
 			move_delay += mob.next_move_slowdown
 			mob.next_move_slowdown = 0
-		/*if((mob.flags_atom & DIRLOCK) && mob.dir != direct)
-			move_delay += MOVE_REDUCTION_DIRECTION_LOCKED */ //geeves solution, will test later, just keeping here for now
+		if((mob.flags_atom & DIRLOCK) && mob.dir != direct)
+			move_delay += MOVE_REDUCTION_DIRECTION_LOCKED //by geeves
 
 		mob.last_move_intent = world.time + 10
 		mob.cur_speed = Clamp(10/(move_delay + 0.5), MIN_SPEED, MAX_SPEED)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -159,7 +159,7 @@
 			move_delay += mob.next_move_slowdown
 			mob.next_move_slowdown = 0
 		if((mob.flags_atom & DIRLOCK) && mob.dir != direct)
-			move_delay += MOVE_REDUCTION_DIRECTION_LOCKED //by geeves
+			move_delay += MOVE_REDUCTION_DIRECTION_LOCKED // by Geeves
 
 		mob.last_move_intent = world.time + 10
 		mob.cur_speed = Clamp(10/(move_delay + 0.5), MIN_SPEED, MAX_SPEED)


### PR DESCRIPTION
Changing directional lock

<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->

## About The Pull Request
Changes how directional locking works so it adds a slowdown when you are directional locked.

## Why It's Good For The Game

Direction lock needs a drawback as plenty of people just do it for no apparent reason except to make their sprite smaller and so forth. It also makes little sense you can sprint backwards at full speed without issue and shoot etc. which leads to gameplay immersion being broken.

This PR intends to change it so direction locking no longer is only, or rather, more used to permaface a certain direction by adding a slowdown when you are directional locked.

## Changelog

:cl: nanu308, stan_albatross
balance: being direction locked and not moving in the direction your character is facing will now slow you down a bit.
/:cl: