### PR TITLE
USCM Service (and other marine) Jacket Rebalance

### DIFF
--- a/code/modules/clothing/suits/marine_coat.dm
+++ b/code/modules/clothing/suits/marine_coat.dm
@@ -11,14 +11,14 @@
 	flags_armor_protection = BODY_FLAG_CHEST|BODY_FLAG_ARMS
 	flags_cold_protection = BODY_FLAG_CHEST|BODY_FLAG_GROIN|BODY_FLAG_ARMS|BODY_FLAG_LEGS
 	min_cold_protection_temperature = ICE_PLANET_min_cold_protection_temperature
-	armor_melee = CLOTHING_ARMOR_MEDIUMLOW
-	armor_bullet = CLOTHING_ARMOR_MEDIUM
-	armor_laser = CLOTHING_ARMOR_LOW
+	armor_melee = CLOTHING_ARMOR_LOW
+	armor_bullet = CLOTHING_ARMOR_LOW
+	armor_laser = CLOTHING_ARMOR_NONE
 	armor_energy = CLOTHING_ARMOR_NONE
 	armor_bomb = CLOTHING_ARMOR_NONE
 	armor_bio = CLOTHING_ARMOR_NONE
 	armor_rad = CLOTHING_ARMOR_NONE
-	armor_internaldamage = CLOTHING_ARMOR_LOW
+	armor_internaldamage = CLOTHING_ARMOR_NONE
 	allowed = list(
 		/obj/item/weapon/gun/,
 		/obj/item/storage/fancy/cigarettes,
@@ -38,6 +38,7 @@
 		/obj/item/tank/emergency_oxygen,
 		/obj/item/tool/crowbar,
 		/obj/item/tool/pen,
+		/obj/item/storage/large_holster/machete,
 	)
 	valid_accessory_slots = list(ACCESSORY_SLOT_ARMBAND, ACCESSORY_SLOT_RANK, ACCESSORY_SLOT_DECOR, ACCESSORY_SLOT_MEDAL)
 	restricted_accessory_slots = list(ACCESSORY_SLOT_ARMBAND, ACCESSORY_SLOT_RANK)
@@ -76,7 +77,7 @@
 //Marine service jacket
 /obj/item/clothing/suit/storage/jacket/marine/service
 	name = "marine service jacket"
-	desc = "A service jacket typically worn by officers of the USCM. It has shards of light Kevlar to help protect against stabbing weapons, bullets, and shrapnel from explosions, a small EMF distributor to help null energy-based weapons, and a hazmat chemical filter weave to ward off biological and radiation hazards."
+	desc = "A service jacket typically worn by officers of the USCM. It has shards of light Kevlar to help protect against stabbing weapons and bullets."
 	has_buttons = TRUE
 	icon_state = "coat_officer"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Rebalances the marine jacket parent type to have low-end protective values similar to the USCM uniform, and not have copy pasted light marine armor protection values, with a complete lack of slowdown as cherry on top. This affects the service jacket, at which the nerf is primarily aimed, alongside some of the snowflake CO jackets. Additionally expands some of the positive utility of this clothing item by adding machete scabbards to the item's exosuit allowlist. It can already hold firearms, so why not a machete?
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's legitimately bonkers that a jacket/coat somehow offers the exact same protection as the marine light armor, with the added bonus of not slowing the user down at all. This both made the light armor obsolete and heavily incentivized powergaming in the way of marines begging the CO to open the uniform vendors roundstart for no justifiable roleplay reason (like there was any to begin with ever, but I digress), or simply vandalizing the Almayer for the sake of gaining access to this straight-up light armor upgrade. I can see this be at least partially justified for survivors, even though it's extremely silly and handholdy as well, but every PFC having guaranteed access to something like this is unjustifiable and completely unrealistic in my eyes.
In contrast, considering how the service jacket can hold firearms and belts (since as explained, the service jacket is a reskin of the light armor suit and this fact is never communicated to the player in any way), but for some reason cannot hold a machete scabbard, which actual armor suits can, this has been rectified for consistency's sake.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: 50RemAndCounting
balance: Rebalanced the USCM Service Jacket and some of the Commanding Officer-exclusive jackets to not have the exact same protection stats as the M3 light armour. These jackets can now hold a machete scabbard in their exosuit slot as well.
/:cl:
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
