### PR TITLE
Add fira codeowners for review notifications

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,6 +4,26 @@
 # In the event that people are to be informed of changes
 # to the same file or dir, add them to the end of under Multiple Owners
 
+# Fira
+
+/.dockerignore @Fira
+/code/controllers/subsystem/atoms.dm @Fira
+/code/controllers/subsystem/mapping.dm @Fira
+/code/controllers/subsystem/sound.dm @Fira
+/code/controllers/subsystem/predships.dm @Fira
+/code/controllers/subsystem/quadtrees.dm @Fira
+/code/datums/quadtree.dm @Fira
+/code/datums/soundOutput.dm @Fira
+/code/game/cas_manager/ @Fira
+/code/game/machinery/computer/dropship_weapons.dm @Fira
+/code/game/sound.dm @Fira
+/code/game/world.dm @Fira
+/code/modules/mapping/reader.dm @Fira
+/code/modules/mapping/map_template.dm @Fira
+/code/modules/nightmare/ @Fira
+/tools/docker/ @Fira
+/Dockerfile @Fira
+
 # Stan_Albatross
 
 /code/modules/projectiles/guns/lever_action.dm @stanalbatross


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Adds CODEOWNERS entries for notifications 

These basically cover the following:
 * Docker and Server ops relevant bits (world.dm)
 * Mapping backend (including Nightmare and Predships)
 * Sound backend (including QT ranging)
 * CAS backend

These are rarely touched backend bits of codebase that can be somewhat cryptic despite being important, so I'd be wanting to help reviewing them