### PR TITLE
QoL: Medical belt mode now viewable on examining the belt.

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -174,6 +174,10 @@
 	new	/obj/item/tool/surgery/surgical_line(src)
 	new	/obj/item/tool/surgery/synthgraft(src)
 
+/obj/item/storage/belt/medical/examine()
+	..()
+	to_chat(usr, SPAN_NOTICE("The belt is currently set to [mode ? "take pills directly from bottles": "NOT take pills directly from bottles"]."))
+
 /obj/item/storage/belt/medical/lifesaver
 	name = "\improper M276 pattern lifesaver bag"
 	desc = "The M276 is the standard load-bearing equipment of the USCM. This configuration mounts a duffel bag filled with a range of injectors and light medical supplies, and is common among medics. \nRight click its sprite and click \"toggle belt mode\" to take pills out of bottles by simply clicking them."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Adds a to_chat message on examining any of the medical belts (medical rig, lifesaver belt, UPP lifesaver belt) that tells the player what kind of belt mode has it been set to i.e. which state the Toggle Belt Mode verb has been toggled to.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Right clicking the belt and toggling belt mode is far less practical than simply shift clicking the belt, and this will help players greatly in not unintentionally messing up the order of pill bottles in their medibelts, as this can make healing other players that much more of a tedious process for the players. Neither will players accidentally repeatedly click on empty pill bottles doing nothing instead of taking them out to dispose of them. The belt mode setting is an easy thing to forget about amidst all the info most medical players are overwhelmed with, this PR aims to rectify what I believe is one of the most common inventory frustrations currently.
Example of how this looks in game:
![image](https://user-images.githubusercontent.com/71565395/166152986-26a900f5-e72b-461b-8ce5-95099d31e7e6.png)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: 50RemAndCounting
qol: You can now examine medical storage rigs and lifesaver belts to check which belt mode they're currently toggled to.
/:cl:
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
