### PR TITLE
Shotgun Fire Delay Groups

### DIFF
--- a/code/__DEFINES/conflict.dm
+++ b/code/__DEFINES/conflict.dm
@@ -57,9 +57,8 @@
 #define GUN_ANTIQUE 			(1<<17)
 #define GUN_RECOIL_BUILDUP		(1<<18)
 /// Whether the gun has been fired by its current user (reset upon `dropped()`)
-#define GUN_FIRED_BY_USER		(1<<19)
-#define GUN_SUPPORT_PLATFORM	(1<<20) /// support weapon, bipod will grant IFF
-#define GUN_BURST_ONLY			(1<<21)
+#define GUN_SUPPORT_PLATFORM	(1<<19) /// support weapon, bipod will grant IFF
+#define GUN_BURST_ONLY			(1<<20)
 
 //Gun attachable related flags.
 #define ATTACH_REMOVABLE	1

--- a/code/__DEFINES/guns.dm
+++ b/code/__DEFINES/guns.dm
@@ -1,1 +1,1 @@
-#define FIRE_DELAY_GROUP_MOU "fdg_mou"
+#define FIRE_DELAY_GROUP_SHOTGUN "fdg_shtgn"

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -206,10 +206,7 @@
 	 * The group or groups of the gun where a fire delay is applied and the delays applied to each group when the gun is dropped
 	 * after being fired
 	 *
-	 * Guns with this var set will apply the specified delays for firing any other guns
-	 * in a specific group
-	 * e.g. FIRE_DELAY_GROUP_X = 1 SECONDS means any gun with the fire delay group FIRE_DELAY_GROUP_X will have to wait 1
-	 * second after the gun has been dropped (the user has to have fired the gun beforehand otherwise no delay is applied)
+	 * Guns with this var set will apply the gun's remaining fire delay to any other guns in the same group
 	 *
 	 * Set as null (does not apply any fire delays to any other gun group) or a list of fire delay groups (string defines)
 	 * matched with the corresponding fire delays applied
@@ -1159,7 +1156,6 @@ and you're good to go.
 				last_fired = world.time
 			SEND_SIGNAL(user, COMSIG_MOB_FIRED_GUN, src, projectile_to_fire)
 			. = TRUE
-			flags_gun_features |= GUN_FIRED_BY_USER
 
 			if(flags_gun_features & GUN_FULL_AUTO_ON)
 				fa_shots++
@@ -1371,7 +1367,6 @@ and you're good to go.
 			last_fired = world.time
 
 		SEND_SIGNAL(user, COMSIG_MOB_FIRED_GUN, src, projectile_to_fire)
-		flags_gun_features |= GUN_FIRED_BY_USER
 
 		if(EXECUTION_CHECK) //Continue execution if on the correct intent. Accounts for change via the earlier do_after
 			user.visible_message(SPAN_DANGER("[user] has executed [M] with [src]!"), SPAN_DANGER("You have executed [M] with [src]!"), message_flags = CHAT_TYPE_WEAPON_USE)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -212,6 +212,7 @@
 	 * matched with the corresponding fire delays applied
 	 */
 	var/list/fire_delay_group
+	var/additional_fire_group_delay = 0 // adds onto the fire delay of the above
 
 /**
  * An assoc list where the keys are fire delay group string defines

--- a/code/modules/projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/gun_helpers.dm
@@ -141,12 +141,10 @@ As sniper rifles have both and weapon mods can change them as well. ..() deals w
 
 	turn_off_light(user)
 
-	if(fire_delay_group && flags_gun_features & GUN_FIRED_BY_USER)
+	var/delay_left = (last_fired + fire_delay) - world.time
+	if(fire_delay_group && delay_left > 0)
 		for(var/group in fire_delay_group)
-			var/fire_delay = fire_delay_group[group]
-			LAZYSET(user.fire_delay_next_fire, group, world.time + fire_delay)
-
-	flags_gun_features &= ~GUN_FIRED_BY_USER
+			LAZYSET(user.fire_delay_next_fire, group, delay_left)
 
 	unwield(user)
 

--- a/code/modules/projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/gun_helpers.dm
@@ -141,7 +141,7 @@ As sniper rifles have both and weapon mods can change them as well. ..() deals w
 
 	turn_off_light(user)
 
-	var/delay_left = (last_fired + fire_delay) - world.time
+	var/delay_left = (last_fired + fire_delay + additional_fire_group_delay) - world.time
 	if(fire_delay_group && delay_left > 0)
 		for(var/group in fire_delay_group)
 			LAZYSET(user.fire_delay_next_fire, group, delay_left)

--- a/code/modules/projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/gun_helpers.dm
@@ -144,7 +144,7 @@ As sniper rifles have both and weapon mods can change them as well. ..() deals w
 	var/delay_left = (last_fired + fire_delay + additional_fire_group_delay) - world.time
 	if(fire_delay_group && delay_left > 0)
 		for(var/group in fire_delay_group)
-			LAZYSET(user.fire_delay_next_fire, group, delay_left)
+			LAZYSET(user.fire_delay_next_fire, group, world.time + delay_left)
 
 	unwield(user)
 

--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -598,6 +598,7 @@ can cause issues with ammo types getting mixed up during the burst.
 	reload_sound = 'sound/weapons/handling/gun_mou_reload.ogg'//unique shell insert
 	flags_equip_slot = SLOT_BACK
 	flags_gun_features = GUN_CAN_POINTBLANK|GUN_INTERNAL_MAG
+	additional_fire_group_delay = 1.5 SECONDS
 	current_mag = /obj/item/ammo_magazine/internal/shotgun/double/mou53 //Take care, she comes loaded!
 	attachable_allowed = list(
 						/obj/item/attachable/bayonet,

--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -19,6 +19,7 @@ can cause issues with ammo types getting mixed up during the burst.
 	wield_delay = WIELD_DELAY_NORMAL //Shotguns are as hard to pull up as a rifle. They're quite bulky afterall
 	has_empty_icon = FALSE
 	has_open_icon = FALSE
+	fire_delay_group = list(FIRE_DELAY_GROUP_SHOTGUN)
 	var/gauge = "12g"
 
 /obj/item/weapon/gun/shotgun/Initialize(mapload, spawn_empty)
@@ -614,9 +615,6 @@ can cause issues with ammo types getting mixed up during the burst.
 						/obj/item/attachable/lasersight,
 						/obj/item/attachable/stock/mou53)
 	map_specific_decoration = TRUE
-	fire_delay_group = list(
-		FIRE_DELAY_GROUP_MOU = 1.5 SECONDS
-	)
 
 /obj/item/weapon/gun/shotgun/double/mou53/set_gun_attachment_offsets()
 	attachable_offset = list("muzzle_x" = 33, "muzzle_y" = 18,"rail_x" = 11, "rail_y" = 21, "under_x" = 17, "under_y" = 15, "stock_x" = 10, "stock_y" = 9) //Weird stock values, make sure any new stock matches the old sprite placement in the .dmi


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Adds fire delay groups to shotguns to prevent firing one, dropping or holstering it, firing another, and repeating. Also rewrites fire delay group code to only factor in remaining fire delays rather than adding a blanket x seconds, preventing a xeno forcing you to drop your gun long after you've fired it giving you a fire delay.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It encourages roleplay by having a marine only use a single of each type of primary, rather than being a carousel of buckshot.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added a general shotgun fire delay group, while rewriting fire delay code to only factor in remaining fire delays. This'll prevent the infamous double chung playstyle by making it useless to carry two of the same kind of shotgun loaded with the same ammo.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
