### PR TITLE
Breaching Damage Nerf

### DIFF
--- a/code/datums/elements/bullet_trait/damage_boost.dm
+++ b/code/datums/elements/bullet_trait/damage_boost.dm
@@ -1,5 +1,4 @@
 GLOBAL_LIST_INIT(damage_boost_breaching, typecacheof(list(
-	/turf,
 	/obj/structure/machinery/door,
 	/obj/structure/mineral_door,
 	/obj/structure/window_frame,
@@ -7,7 +6,7 @@ GLOBAL_LIST_INIT(damage_boost_breaching, typecacheof(list(
 	/obj/structure/surface,
 	/obj/structure/window,
 	/obj/structure/grille,
-	/obj/structure/barricade,
+	/obj/structure/barricade
 )))
 
 GLOBAL_LIST_INIT(damage_boost_pylons, typecacheof(list(


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Removes the /turf path from the breaching damage boost list, meaning masterkeys (and other breaching damage weapons) are only useful for shooting down doors, girders, windows, window frames, grilles, barricades, and so forth.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Being able to destroy thick defenses in one click, as a PFC, is a little silly. With the upcoming breaching charges given to engineers, and the free availability to machetes, masterkeys no longer have a reason to be so powerful.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Masterkeys (and other breaching weapons) no longer deal bonus damage against turfs, meaning resin walls, and normal constructed walls. Other things like resin doors and airlocks are still affected as normal.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
