### PR TITLE
Hunter Weapon Tweaks

### DIFF
--- a/code/modules/cm_preds/yaut_weapons.dm
+++ b/code/modules/cm_preds/yaut_weapons.dm
@@ -217,6 +217,7 @@
 	sharp = IS_SHARP_ITEM_SIMPLE
 	edge = TRUE
 	attack_verb = list("whipped", "slashed","sliced","diced","shredded")
+	attack_speed = 0.8 SECONDS
 	hitsound = 'sound/weapons/chain_whip.ogg'
 
 
@@ -241,11 +242,11 @@
 	w_class = SIZE_LARGE
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb = list("slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
-	attack_speed = 0.9 SECONDS
+	attack_speed = 1 SECONDS
 	unacidable = TRUE
 
 	var/parrying
-	var/parrying_duration = 3 SECONDS
+	var/parrying_duration = 1.5 SECONDS
 	var/cur_parrying_cooldown
 	var/parrying_delay = 11 SECONDS // effectively 8, starts counting on activation
 
@@ -712,7 +713,7 @@
 	item_state = "glaive"
 	force = MELEE_FORCE_TIER_3
 	force_wielded = MELEE_FORCE_TIER_9
-	throwforce = MELEE_FORCE_TIER_6
+	throwforce = MELEE_FORCE_TIER_3
 	embeddable = FALSE //so predators don't lose their glaive when thrown.
 	sharp = IS_SHARP_ITEM_BIG
 	flags_atom = FPRINT|CONDUCT


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

This MR is simple number tweaks but was made with permission from a developer.

Reduced Chainwhip's click delay (increased attack speed) to be faster than clansword since the whip does less damage and has no specific gimmick (yet).

Slightly increased the click delay of the clan sword since it has the second highest damage of all the pred weapons & has a strong special gimmick, while also reducing the time the parry + deflect is active to emphasise timing & proper usage.

Cut Glaive throw damage in half as it was dealing far too much damage on throw for a weapon that's meant to be about slow, sure hits, encouraging a hit+throw rapidfire playstyle completely at odds with the identity of the "Lumbering" Glaive. A hit -> throw combo will now do 60 damage instead of 75, which is still high enough to be equal with the Combi-Stick's hit -> throw combo, which also does 60 damage.

## Why It's Good For The Game

Brings the pred weapons onto more even terms with eachother allowing people to diversify what they use without feeling like they're hurting themselves. Also reduces frustration being killed by low-effort means on the part of people being hunted.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: ChainsawMullet
balance: Hunter Chainwhip attack speed increased by 20% (from 1.0 to .8)
balance: Hunter Clansword attack speed reduced by 10% (from .9 to 1.0), parry duration reduced by 50% (from 3 seconds to 1.5 seconds)
balance: Hunter Glaive throw damage reduced by 50% (from 30 to 15)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
