### PR TITLE
Aimed Shot size modifier fix.

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1629,12 +1629,15 @@
 /datum/ammo/bullet/sniper/anti_materiel/on_hit_mob(mob/M,obj/item/projectile/P)
 	if(P.homing_target && M == P.homing_target)
 		var/mob/living/L = M
+		var/size_damage_mod = 0.8
 		if(isXeno(M))
 			var/mob/living/carbon/Xenomorph/target = M
+			if(target.mob_size >= MOB_SIZE_XENO)
+				size_damage_mod += 0.6
 			if(target.mob_size >= MOB_SIZE_BIG)
-				L.apply_armoured_damage(damage*1.2, ARMOR_BULLET, BRUTE, null, penetration)
-		L.apply_armoured_damage(damage*0.8, ARMOR_BULLET, BRUTE, null, penetration)
-		// 180% damage to all targets (225), 300% against Big xenos (375). -Kaga
+				size_damage_mod += 0.6
+		L.apply_armoured_damage(damage*size_damage_mod, ARMOR_BULLET, BRUTE, null, penetration)
+		// 180% damage to all targets (225), 240% (300) against non-Runner xenos, and 300% against Big xenos (375). -Kaga
 		to_chat(P.firer, SPAN_WARNING("Bullseye!"))
 
 /datum/ammo/bullet/sniper/elite
@@ -1654,14 +1657,17 @@
 /datum/ammo/bullet/sniper/elite/on_hit_mob(mob/M,obj/item/projectile/P)
 	if(P.homing_target && M == P.homing_target)
 		var/mob/living/L = M
+		var/size_damage_mod = 0.5
 		if(isXeno(M))
 			var/mob/living/carbon/Xenomorph/target = M
+			if(target.mob_size >= MOB_SIZE_XENO)
+				size_damage_mod += 0.5
 			if(target.mob_size >= MOB_SIZE_BIG)
-				L.apply_armoured_damage(damage*1.5, ARMOR_BULLET, BRUTE, null, penetration)
-			L.apply_armoured_damage(damage*0.5, ARMOR_BULLET, BRUTE, null, penetration)
+				size_damage_mod += 1
+			L.apply_armoured_damage(damage*size_damage_mod, ARMOR_BULLET, BRUTE, null, penetration)
 		else
 			L.apply_armoured_damage(damage, ARMOR_BULLET, BRUTE, null, penetration)
-		// 150% damage to non-Big xenos (225), 300% against Big xenos (450), and 200% against all others (300). -Kaga
+		// 150% damage to runners (225), 300% against Big xenos (450), and 200% against all others (300). -Kaga
 		to_chat(P.firer, SPAN_WARNING("Bullseye!"))
 
 /*


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Fix for Aimed Shot since I found there's actually a MOB_SIZE_XENO_SMALL tier exclusively for Runners below MOB_SIZE_XENO. Also cleans up the way the damage is calculated, so that it doesn't call the damage proc multiple times based on size.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Makes the functionality less binary, while also slightly cleaning up the ability code.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Kaga
fix: Fixed an unintended oversight where mobs were taking damage calculated for runners from the Aimed Shot ability when used by an XMB or M42C sniper rifle. Normal-size Xenos now have their own tier for damage calculation.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
