### PR TITLE
Offhand Attachment Activation

### DIFF
--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -94,7 +94,10 @@ Defined in conflicts.dm of the #defines folder.
 
 /obj/item/attachable/attackby(obj/item/I, mob/user)
 	if(flags_attach_features & ATTACH_RELOADABLE)
-		reload_attachment(I, user)
+		if(user.get_inactive_hand() != src)
+			to_chat(user, SPAN_WARNING("You have to hold [src] to do that!"))
+		else
+			reload_attachment(I, user)
 		return TRUE
 	else
 		. = ..()

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -94,10 +94,7 @@ Defined in conflicts.dm of the #defines folder.
 
 /obj/item/attachable/attackby(obj/item/I, mob/user)
 	if(flags_attach_features & ATTACH_RELOADABLE)
-		if(user.get_inactive_hand() != src)
-			to_chat(user, SPAN_WARNING("You have to hold [src] to do that!"))
-		else
-			reload_attachment(I, user)
+		reload_attachment(I, user)
 		return TRUE
 	else
 		. = ..()
@@ -202,11 +199,8 @@ Defined in conflicts.dm of the #defines folder.
 		G.in_chamber._RemoveElement(L)
 
 /obj/item/attachable/ui_action_click(mob/living/user, obj/item/weapon/gun/G)
-	if(G == user.get_active_hand())
-		if(activate_attachment(G, user)) //success
-			return
-	else
-		to_chat(user, SPAN_WARNING("[G] must be in our active hand to do this."))
+	activate_attachment(G, user)
+	return //success
 
 /obj/item/attachable/proc/activate_attachment(atom/target, mob/user) //This is for activating stuff like flamethrowers, or switching weapon modes.
 	return

--- a/code/modules/projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/gun_helpers.dm
@@ -479,8 +479,10 @@ As sniper rifles have both and weapon mods can change them as well. ..() deals w
 	var/obj/item/weapon/gun/G = user.get_held_item()
 
 	if(!istype(G))
-		to_chat(user, SPAN_WARNING("You need a gun in your active hand to do that!"))
-		return
+		G = user.get_inactive_hand()
+		if(!istype(G))
+			to_chat(user, SPAN_WARNING("You need a gun in your active hand to do that!"))
+			return
 
 	if(G.flags_gun_features & GUN_BURST_FIRING)
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Removes the requirement to have guns in the active hand to activate its attachments.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

This logically doesn't make any sense. Apparently, marines in CM somehow activate the grip light with the same hand that is holding the trigger of the gun. Rail lights have to annoyingly, be selected in order to be turned on.

You could kind of argue that it "balances" underbarrel attachments. However, It's literally only a very minor keypress and it wont have any balance implications since underbarrel weapons are trashy. ( if someone is low HP enough to be killed by an underbarrel, they have low enough HP to be killed by the gun its attached to) There is no round effecting changes if someone can switch to the underbarrel 0.1 seconds faster.


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: TotalEpicness5

qol: Removed the off-hand limitation on attachments

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
