### PR TITLE
refactor: Fixes various internal issues with throwing objects launch_metadata

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -11,21 +11,19 @@
 	var/mob/pulledby = null
 	var/rebounds = FALSE
 	var/rebounding = FALSE // whether an object that was launched was rebounded (to prevent infinite recursive loops from wall bouncing)
-
 	var/acid_damage = 0 //Counter for stomach acid damage. At ~60 ticks, dissolved
-
 	var/move_intentionally = FALSE // this is for some deep stuff optimization. This means that it is regular movement that can only be NSWE and you don't need to perform checks on diagonals. ALWAYS reset it back to FALSE when done
+
+	/// Data for an ongoing throwing/flight of the atom
+	var/datum/launch_metadata/launch_metadata
 
 //===========================================================================
 /atom/movable/Destroy()
-	for(var/atom/movable/I in contents)
-		qdel(I)
-	if(pulledby)
-		pulledby.stop_pulling()
+	for(var/atom/A as anything in contents)
+		qdel(A)
+	pulledby?.stop_pulling()
 	QDEL_NULL(launch_metadata)
-
-	if(loc)
-		loc.on_stored_atom_del(src) //things that container need to do when a movable atom inside it is deleted
+	loc?.on_stored_atom_del(src) //things that container need to do when a movable atom inside it is deleted
 	vis_contents.Cut()
 	. = ..()
 	moveToNullspace() //so we move into null space. Must be after ..() b/c atom's Dispose handles deleting our lighting stuff

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -236,7 +236,7 @@ cases. Override_icon_state should be a list.*/
 		var/obj/item/storage/S = loc
 		S.remove_from_storage(src, user.loc)
 
-	throwing = 0
+	reset_throw()
 
 	if(loc == user)
 		if(!user.drop_inv_item_on_ground(src))

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -292,7 +292,8 @@ Contains most of the procs that are called when a mob is attacked by something
 	if (!zone)
 		visible_message(SPAN_NOTICE("\The [O] misses [src] narrowly!"), null, null, 5)
 		return
-	O.throwing = FALSE		//it hit, so stop moving
+
+	O.reset_throw() //it hit, so stop moving
 
 	if ((LM.thrower != src) && check_shields(impact_damage, "[O]"))
 		return

--- a/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
@@ -254,7 +254,7 @@
 
 	var/mob/living/carbon/M = L
 	if(M.stat || M.mob_size >= MOB_SIZE_BIG || can_not_harm(L))
-		throwing = FALSE
+		reset_throw()
 		return
 
 	if (pounceAction.can_be_shield_blocked)
@@ -264,7 +264,7 @@
 				visible_message(SPAN_DANGER("[src] slams into [H]!"),
 					SPAN_XENODANGER("You slam into [H]!"), null, 5)
 				KnockDown(1)
-				throwing = FALSE //Reset throwing manually.
+				reset_throw()
 				playsound(H, "bonk", 75, FALSE) //bonk
 				return
 
@@ -272,20 +272,20 @@
 				if(H.check_shields(0, "the pounce", 1))
 					visible_message(SPAN_DANGER("[H] blocks the pounce of [src] with the combistick!"), SPAN_XENODANGER("[H] blocks your pouncing form with the combistick!"), null, 5)
 					KnockDown(3)
-					throwing = FALSE
+					reset_throw()
 					playsound(H, "bonk", 75, FALSE)
 					return
 				else if(prob(75)) //Body slam the fuck out of xenos jumping at your front.
 					visible_message(SPAN_DANGER("[H] body slams [src]!"),
 						SPAN_XENODANGER("[H] body slams you!"), null, 5)
 					KnockDown(3)
-					throwing = FALSE
+					reset_throw()
 					return
 			if(isColonySynthetic(H) && prob(60))
 				visible_message(SPAN_DANGER("[H] withstands being pounced and slams down [src]!"),
 					SPAN_XENODANGER("[H] throws you down after withstanding the pounce!"), null, 5)
 				KnockDown(1.5)
-				throwing = FALSE
+				reset_throw()
 				return
 
 
@@ -306,7 +306,7 @@
 	if(pounceAction.slash)
 		M.attack_alien(src, pounceAction.slash_bonus_damage)
 
-	throwing = FALSE //Reset throwing since something was hit.
+	reset_throw()
 
 /mob/living/carbon/Xenomorph/proc/pounced_mob_wrapper(var/mob/living/L)
 	pounced_mob(L)

--- a/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
@@ -408,7 +408,7 @@
 	LM.thrower = X
 	LM.spin = FALSE
 	LM.pass_flags = pounce_pass_flags
-	LM.collision_callbacks = pounce_callbacks
+	LM.collision_callbacks = pounce_callbacks.Copy()
 
 	X.launch_towards(LM) //Victim, distance, speed
 

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -60,7 +60,7 @@
 		else
 			playsound(loc, 'sound/effects/thud.ogg', 25, TRUE, falloff = 2)
 
-	O.throwing = 0		//it hit, so stop moving
+	O.reset_throw()		//it hit, so stop moving
 
 	if(ismob(LM.thrower))
 		var/mob/M = LM.thrower


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

(gitlab port)

This fixes a number of loose ends with launch_metadata used in throws that result in improperly cleared mob references. 

It also refactors launch to use a common `reset_throw` proc rather than several odds and ends in code doing it their own (partial) way. This should fix some rare observed race conditions when several sources handle it differently at same time.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

 * Performance
 * Less references causing deletion failures for mobs
 * Less intermediate datums kept around for no reason

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
refactor: Fixed various internal issues with throwing objects
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
