### PR TITLE
Balance: CO rifle meltable, CO tablet unmeltable

### DIFF
--- a/code/game/objects/items/devices/cictablet.dm
+++ b/code/game/objects/items/devices/cictablet.dm
@@ -17,6 +17,8 @@
 	suffix = "\[3\]"
 	icon_state = "Cotablet"
 	item_state = "Cotablet"
+	unacidable = TRUE
+	indestructible = TRUE
 	req_access = list(ACCESS_MARINE_COMMANDER)
 	var/on = 1 // 0 for off
 	var/mob/living/carbon/human/current_mapviewer

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -408,7 +408,6 @@
 							/obj/item/attachable/heavy_barrel,
 								)
 	flags_gun_features = GUN_AUTO_EJECTOR|GUN_CAN_POINTBLANK|GUN_AMMO_COUNTER
-	//unacidable = TRUE
 	indestructible = TRUE
 	auto_retrieval_slot = WEAR_J_STORE
 

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -408,7 +408,7 @@
 							/obj/item/attachable/heavy_barrel,
 								)
 	flags_gun_features = GUN_AUTO_EJECTOR|GUN_CAN_POINTBLANK|GUN_AMMO_COUNTER
-	unacidable = TRUE
+	//unacidable = TRUE
 	indestructible = TRUE
 	auto_retrieval_slot = WEAR_J_STORE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Makes the m46c pulse rifle meltable again, makes command tablet unmeltable (and indestructible too. Is this in reference to mobs caught in explosions having their held items deleted? I'm not sure - I was told repeatedly that is a bug, not a feature.)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
M46C being unmeltable is unjustifiable. The weapon already has an in-built magnetic harness and the weapon may be exclusively used by a role that should explicitly not be run-ahead-of-everyone frontlining and hosing down enemies with dummy strong bullets, which goes contrary to the weapon's current attributes which encourage doing just that.
On the other hand, something actually much more important like the command tablet is very bulky to carry around and can easily be lost and melted by comparison. Making it unmeltable should hopefully promote the importance of commanding and communicating and remind players that the Commanding Officer whitelist is not about burst PBing xenos half a screen ahead of the nearest squad rifleman and saying less than 20 messages throughout the round. :)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: 50RemAndCounting
balance: The M46C pulse rifle is now able to be melted by xenomorphs again. The Command Tablet is now unmeltable.
/:cl:
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
