### PR TITLE
Thrown items and cause_data.

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -326,9 +326,9 @@ Contains most of the procs that are called when a mob is attacked by something
 		var/client/assailant = M.client
 		if (damage > 5)
 			last_damage_mob = M
-			M.track_hit(initial(name))
+			M.track_hit(initial(O.name))
 			if (M.faction == faction)
-				M.track_friendly_fire(initial(name))
+				M.track_friendly_fire(initial(O.name))
 		if (assailant)
 			src.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been hit with a [O], thrown by [key_name(M)]</font>")
 			M.attack_log += text("\[[time_stamp()]\] <font color='red'>Hit [key_name(src)] with a thrown [O]</font>")

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -52,7 +52,9 @@
 	src.visible_message(SPAN_DANGER("[src] has been hit by [O]."), null, null, 5)
 	var/damage_done = apply_armoured_damage(impact_damage, ARMOR_MELEE, dtype, null, , is_sharp(O), has_edge(O), null)
 
+	var/last_damage_source
 	if (damage_done > 5)
+		last_damage_source = initial(O.name)
 		animation_flash_color(src)
 		var/obj/item/I = O
 		if(istype(I) && I.sharp) //Hilarious is_sharp only returns true if it's sharp AND edged, while a bunch of things don't have edge to limit embeds.
@@ -62,14 +64,21 @@
 
 	O.throwing = 0		//it hit, so stop moving
 
+	var/mob/M
 	if(ismob(LM.thrower))
-		var/mob/M = LM.thrower
+		M = LM.thrower
+		if(damage_done > 5)
+			M.track_hit(initial(O.name))
+			if (M.faction == faction)
+				M.track_friendly_fire(initial(O.name))
 		var/client/assailant = M.client
 		if(assailant)
 			src.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been hit with a [O], thrown by [key_name(M)]</font>")
 			M.attack_log += text("\[[time_stamp()]\] <font color='red'>Hit [key_name(src)] with a thrown [O]</font>")
 			if(!istype(src,/mob/living/simple_animal/mouse))
 				msg_admin_attack("[key_name(src)] was hit by a [O], thrown by [key_name(M)] in [get_area(src)] ([src.loc.x],[src.loc.y],[src.loc.z]).", src.loc.x, src.loc.y, src.loc.z)
+	if(last_damage_source)
+		last_damage_data = create_cause_data(last_damage_source, M)
 
 /mob/living/mob_launch_collision(var/mob/living/L)
 	L.Move(get_step_away(L, src))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

In today's stanza of the saga of cause\_data, we discover that for thrown items it was only ever implemented in `human_defense` and not in general `living_defense`. And even then it took `initial()` of a wrong `name`, so all the hits on humans with thrown weapons are probably currently attributed to mysterious "human" as a weapon in database.

## Why It's Good For The Game

Will correctly log all the hits and kills by thrown weapons, to the rejoicing of all three scouts and two PFCs still using the knives.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Thrown items now properly attribute their damage in tracking statistics.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
