### PR TITLE
Fixes a bug with warrior lunge

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/Warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Warrior.dm
@@ -95,7 +95,6 @@
 	if(!QDELETED(L) && !QDELETED(L.pulledby) && L != src ) //override pull of other mobs
 		visible_message(SPAN_WARNING("[src] has broken [L.pulledby]'s grip on [L]!"), null, null, 5)
 		L.pulledby.stop_pulling()
-		return // Warrior should not-regrab the victim to reset the knockdown
 
 	. = ..(L, lunge, should_neckgrab)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Fixes a few bugs related to warrior lunging / grabbing an already grabbed mob

Before:

https://user-images.githubusercontent.com/59925169/166627702-fba1a484-c3d3-4fb0-aac6-2d9392c7b94e.mp4


https://user-images.githubusercontent.com/59925169/166627707-4f3bba63-9ac1-4ba8-bb12-9b2617082b64.mp4

After:

https://user-images.githubusercontent.com/59925169/166627744-c8afa3fd-00b3-47ab-97bf-885f2f014340.mp4


https://user-images.githubusercontent.com/59925169/166627735-13113ac1-2de6-4aa2-8703-f5d8d5af7d21.mp4



<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bug bad. Fix good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixed a few bugs with warrior lunge and grab
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
