### PR TITLE
Adds missing vehicle blockers in shivas

### DIFF
--- a/maps/map_files/Ice_Colony_v3/Shivas_Snowball.dmm
+++ b/maps/map_files/Ice_Colony_v3/Shivas_Snowball.dmm
@@ -1072,6 +1072,7 @@
 /area/shiva/interior/colony/medseceng)
 "aeg" = (
 /obj/structure/machinery/door/airlock/almayer/maint/autoname,
+/obj/structure/blocker/forcefield/vehicles,
 /turf/open/floor/plating,
 /area/shiva/interior/colony/medseceng)
 "aeh" = (
@@ -7563,6 +7564,10 @@
 	icon_state = "red"
 	},
 /area/shiva/interior/colony/central)
+"buJ" = (
+/obj/structure/blocker/forcefield/vehicles,
+/turf/closed/wall/shiva/prefabricated/reinforced,
+/area/shiva/interior/colony/medseceng)
 "bvb" = (
 /obj/structure/platform_decoration/strata,
 /obj/structure/flora/bush/snow,
@@ -11553,6 +11558,7 @@
 	name = "\improper Colony Engineering Material Storage";
 	req_access_txt = "100"
 	},
+/obj/structure/blocker/forcefield/vehicles,
 /turf/open/floor/plating,
 /area/shiva/interior/colony/medseceng)
 "gjg" = (
@@ -19303,6 +19309,10 @@
 	icon_state = "floor3"
 	},
 /area/shiva/interior/bar)
+"oGg" = (
+/obj/structure/blocker/forcefield/vehicles,
+/turf/closed/wall/shiva/prefabricated,
+/area/shiva/interior/colony/medseceng)
 "oHf" = (
 /obj/structure/blocker/forcefield/vehicles,
 /turf/open/auto_turf/snow/layer2,
@@ -25043,6 +25053,7 @@
 	name = "\improper Colony Engineering Locker Room";
 	req_access_txt = "100"
 	},
+/obj/structure/blocker/forcefield/vehicles,
 /turf/open/floor/plating,
 /area/shiva/interior/colony/medseceng)
 "uOc" = (
@@ -25258,6 +25269,14 @@
 "uYC" = (
 /turf/closed/wall/shiva/prefabricated,
 /area/shiva/interior/fort_biceps)
+"uYR" = (
+/obj/structure/machinery/door/airlock/almayer/security/glass{
+	name = "\improper Underground Security";
+	req_access_txt = "100"
+	},
+/obj/structure/blocker/forcefield/vehicles,
+/turf/open/floor/plating,
+/area/shiva/interior/colony/medseceng)
 "uZf" = (
 /turf/open/floor/shiva{
 	icon_state = "wredcorners"
@@ -26010,6 +26029,10 @@
 	icon_state = "floor3"
 	},
 /area/shiva/interior/colony/research_hab)
+"vQZ" = (
+/obj/structure/blocker/forcefield/vehicles,
+/turf/closed/wall/shiva/prefabricated/reinforced,
+/area/shiva/exterior/cp_colony_grounds)
 "vRM" = (
 /obj/structure/platform/strata{
 	dir = 8
@@ -26181,6 +26204,7 @@
 	name = "\improper Underground Security Evidence Storage";
 	req_access_txt = "100"
 	},
+/obj/structure/blocker/forcefield/vehicles,
 /turf/open/floor/plating,
 /area/shiva/interior/colony/medseceng)
 "wfP" = (
@@ -26917,6 +26941,17 @@
 	},
 /turf/closed/wall/shiva/ice,
 /area/shiva/interior/caves/cp_camp)
+"xbz" = (
+/obj/structure/window/framed/shiva,
+/obj/structure/blocker/forcefield/vehicles,
+/turf/open/floor/plating,
+/area/shiva/interior/colony/medseceng)
+"xbP" = (
+/obj/structure/blocker/forcefield/vehicles,
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/interior/colony/medseceng)
 "xbZ" = (
 /obj/structure/prop/invuln/minecart_tracks{
 	dir = 8
@@ -27635,6 +27670,7 @@
 	name = "\improper Underground Security Showers";
 	req_access_txt = "100"
 	},
+/obj/structure/blocker/forcefield/vehicles,
 /turf/open/floor/plating,
 /area/shiva/interior/colony/medseceng)
 "yfE" = (
@@ -27735,6 +27771,11 @@
 /turf/open/floor/shiva{
 	dir = 1
 	},
+/area/shiva/interior/colony/medseceng)
+"ylz" = (
+/obj/structure/blocker/forcefield/vehicles,
+/obj/structure/blocker/forcefield/vehicles,
+/turf/closed/wall/shiva/prefabricated,
 /area/shiva/interior/colony/medseceng)
 "ylO" = (
 /obj/structure/machinery/colony_floodlight_switch{
@@ -51735,14 +51776,14 @@ puZ
 "}
 (149,1,1) = {"
 acH
-aDn
-aDn
+buJ
+buJ
 aeg
-aDn
-acT
-acT
-acT
-acT
+buJ
+oGg
+oGg
+oGg
+oGg
 tTd
 qrz
 qrz
@@ -51904,12 +51945,12 @@ acT
 aoK
 akL
 aoK
-acT
-acT
-arA
-aek
-arA
-acT
+oGg
+ylz
+uYR
+xbz
+uYR
+oGg
 acT
 vXh
 vXh
@@ -52071,7 +52112,7 @@ acT
 iJY
 uSn
 uSn
-acT
+oGg
 uSn
 uSn
 uSn
@@ -52233,7 +52274,7 @@ acT
 iJY
 uSn
 uSn
-acT
+oGg
 uSn
 uSn
 uSn
@@ -52395,13 +52436,13 @@ api
 iJY
 uSn
 uSn
-acT
-acT
-acT
+oGg
+oGg
+oGg
 wfL
-acT
-acT
-acT
+oGg
+oGg
+oGg
 aef
 aef
 fkq
@@ -52563,7 +52604,7 @@ yeu
 axG
 axG
 axG
-acT
+oGg
 acT
 acT
 acT
@@ -52725,7 +52766,7 @@ aoK
 hUM
 aoK
 axG
-aek
+xbz
 fMe
 yeu
 aAM
@@ -52887,7 +52928,7 @@ onl
 aNn
 aTZ
 rgu
-aek
+xbz
 pId
 uSn
 uSn
@@ -53049,7 +53090,7 @@ aoK
 aVR
 aoK
 axG
-aek
+xbz
 fMe
 axG
 nIB
@@ -53211,7 +53252,7 @@ axG
 axG
 axG
 axG
-acT
+oGg
 acT
 acT
 acT
@@ -53372,8 +53413,8 @@ acT
 acT
 acN
 acT
-acT
-acT
+oGg
+oGg
 axG
 axG
 yeu
@@ -53534,7 +53575,7 @@ uSn
 uSn
 uSn
 uSn
-uSn
+xbP
 agr
 axG
 uSn
@@ -53696,7 +53737,7 @@ uSn
 kbJ
 uSn
 uSn
-uSn
+xbP
 ajO
 axG
 uSn
@@ -53858,7 +53899,7 @@ acT
 acT
 aSz
 acT
-aDn
+buJ
 aDn
 axG
 axG
@@ -54020,7 +54061,7 @@ acT
 gvT
 lNV
 lGq
-aDn
+buJ
 aDn
 aek
 aek
@@ -54182,7 +54223,7 @@ aek
 lGq
 fGG
 lNV
-aDn
+buJ
 aDn
 fSm
 aes
@@ -54344,7 +54385,7 @@ aek
 oYw
 oYw
 lGq
-aek
+xbz
 uSn
 uSn
 uSn
@@ -54506,7 +54547,7 @@ aek
 oYw
 oYw
 goS
-aek
+xbz
 uSn
 uSn
 uSn
@@ -54668,7 +54709,7 @@ aek
 oYw
 oYw
 npi
-aek
+xbz
 syV
 uSn
 uSn
@@ -54829,31 +54870,31 @@ acT
 acT
 lGq
 oYw
-acT
-aDn
-acT
-acT
+oGg
+buJ
+oGg
+oGg
 giU
-acT
-acT
-acT
+oGg
+oGg
+oGg
 uNe
-acT
-acT
-acT
-acT
-acT
-acT
-acT
-acT
+oGg
+oGg
+oGg
+oGg
+oGg
+oGg
+oGg
+oGg
 yez
-aDn
-aDn
-aDn
-aDn
-aDn
-aDn
-aDn
+buJ
+buJ
+buJ
+buJ
+buJ
+buJ
+buJ
 eOM
 eOM
 sYu
@@ -55015,7 +55056,7 @@ qep
 qep
 xRY
 xRY
-xRY
+vQZ
 eOM
 eOM
 sYu
@@ -55177,7 +55218,7 @@ sYu
 qNj
 xRY
 xRY
-xRY
+vQZ
 bSC
 sYu
 sYu

--- a/maps/map_files/Ice_Colony_v3/Shivas_Snowball.dmm
+++ b/maps/map_files/Ice_Colony_v3/Shivas_Snowball.dmm
@@ -121,6 +121,7 @@
 	opacity = 1;
 	unacidable = 0
 	},
+/obj/structure/blocker/forcefield/vehicles,
 /turf/open/auto_turf/ice/layer1,
 /area/shiva/interior/caves/left_spiders)
 "aau" = (
@@ -9460,6 +9461,14 @@
 	icon_state = "stan2"
 	},
 /area/shiva/interior/aerodrome)
+"dCY" = (
+/obj/structure/ice/thin/single{
+	opacity = 1;
+	unacidable = 0
+	},
+/obj/structure/blocker/forcefield/vehicles,
+/turf/open/auto_turf/ice/layer2,
+/area/shiva/interior/caves/left_spiders)
 "dDo" = (
 /obj/structure/machinery/landinglight/ds1/spoke,
 /turf/open/floor/shiva{
@@ -29851,7 +29860,7 @@ aav
 aaP
 aav
 clK
-rpE
+dCY
 asz
 asz
 asz
@@ -30013,7 +30022,7 @@ aav
 clK
 aav
 clK
-rpE
+dCY
 asz
 wFB
 eSt
@@ -30175,7 +30184,7 @@ dRb
 dRb
 aaL
 abL
-rpE
+dCY
 asz
 gha
 uuN

--- a/maps/map_files/Ice_Colony_v3/Shivas_Snowball.dmm
+++ b/maps/map_files/Ice_Colony_v3/Shivas_Snowball.dmm
@@ -600,6 +600,7 @@
 "abV" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/blocker/forcefield/vehicles,
 /turf/open/auto_turf/ice/layer1,
 /area/shiva/interior/colony/research_hab)
 "abW" = (
@@ -4137,6 +4138,10 @@
 "axz" = (
 /turf/closed/wall/shiva/prefabricated,
 /area/shiva/interior/colony/central)
+"axF" = (
+/obj/structure/blocker/forcefield/vehicles,
+/turf/open/auto_turf/snow/layer2,
+/area/shiva/exterior/cp_colony_grounds)
 "axG" = (
 /turf/open/floor/shiva{
 	dir = 8;
@@ -8286,6 +8291,10 @@
 /obj/structure/platform_decoration/strata,
 /turf/open/auto_turf/snow/layer1,
 /area/shiva/exterior/lz1_valley)
+"ckH" = (
+/obj/structure/blocker/forcefield/vehicles,
+/turf/open/auto_turf/ice/layer1,
+/area/shiva/exterior/cp_s_research)
 "ckI" = (
 /obj/structure/surface/table,
 /obj/item/circuitboard{
@@ -8679,6 +8688,10 @@
 	},
 /turf/open/auto_turf/snow/layer3,
 /area/shiva/exterior/cp_lz2)
+"cIV" = (
+/obj/structure/blocker/forcefield/vehicles,
+/turf/open/auto_turf/ice/layer1,
+/area/shiva/interior/caves/research_caves)
 "cJy" = (
 /obj/structure/surface/table,
 /turf/open/floor/shiva{
@@ -10659,6 +10672,10 @@
 	icon_state = "yellowfull"
 	},
 /area/shiva/interior/colony/research_hab)
+"fjs" = (
+/obj/structure/blocker/forcefield/vehicles,
+/turf/open/auto_turf/ice/layer1,
+/area/shiva/interior/colony/medseceng)
 "fjv" = (
 /turf/open/auto_turf/snow/layer4,
 /area/shiva/interior/caves/research_caves)
@@ -10708,6 +10725,10 @@
 	icon_state = "wredfull"
 	},
 /area/shiva/interior/colony/medseceng)
+"fkB" = (
+/obj/structure/blocker/forcefield/vehicles,
+/turf/open/auto_turf/snow/layer4,
+/area/shiva/exterior/cp_s_research)
 "fkF" = (
 /obj/structure/machinery/vending/cigarette/colony,
 /turf/open/floor/shiva{
@@ -15037,6 +15058,7 @@
 	dir = 1;
 	pixel_y = 9
 	},
+/obj/structure/blocker/forcefield/vehicles,
 /turf/open/auto_turf/snow/layer1,
 /area/shiva/interior/colony/research_hab)
 "kbZ" = (
@@ -16595,6 +16617,10 @@
 	icon_state = "floor3"
 	},
 /area/shiva/interior/colony/central)
+"lIa" = (
+/obj/structure/blocker/forcefield/vehicles,
+/turf/open/auto_turf/snow/layer3,
+/area/shiva/exterior/cp_s_research)
 "lJh" = (
 /obj/structure/machinery/vending/snack,
 /turf/open/floor/shiva{
@@ -17558,6 +17584,11 @@
 	},
 /turf/open/floor/shiva,
 /area/shiva/interior/bar)
+"mKf" = (
+/obj/structure/girder,
+/obj/structure/blocker/forcefield/vehicles,
+/turf/open/auto_turf/ice/layer1,
+/area/shiva/interior/colony/medseceng)
 "mKk" = (
 /obj/structure/machinery/vending/cigarette/colony,
 /turf/open/floor/shiva{
@@ -17854,6 +17885,10 @@
 /obj/structure/machinery/newscaster/security_unit,
 /turf/closed/wall/shiva/prefabricated,
 /area/shiva/interior/colony/central)
+"mXV" = (
+/obj/structure/blocker/forcefield/vehicles,
+/turf/open/auto_turf/snow/layer0,
+/area/shiva/exterior/cp_colony_grounds)
 "mYm" = (
 /obj/structure/machinery/cm_vending/sorted/tech/electronics_storage,
 /obj/structure/machinery/light/double{
@@ -18882,6 +18917,10 @@
 /obj/item/clipboard,
 /turf/open/floor/wood,
 /area/shiva/interior/aerodrome)
+"oig" = (
+/obj/structure/blocker/forcefield/vehicles,
+/turf/open/auto_turf/snow/layer1,
+/area/shiva/exterior/cp_colony_grounds)
 "oiH" = (
 /obj/structure/flora/tree/dead,
 /turf/open/auto_turf/snow/layer3,
@@ -18892,6 +18931,11 @@
 	},
 /turf/open/auto_turf/snow/layer1,
 /area/shiva/interior/caves/cp_camp)
+"ojU" = (
+/obj/structure/fence,
+/obj/structure/blocker/forcefield/vehicles,
+/turf/open/auto_turf/snow/layer2,
+/area/shiva/exterior/valley)
 "okz" = (
 /obj/effect/decal/cleanable/blood{
 	layer = 3
@@ -19259,6 +19303,10 @@
 	icon_state = "floor3"
 	},
 /area/shiva/interior/bar)
+"oHf" = (
+/obj/structure/blocker/forcefield/vehicles,
+/turf/open/auto_turf/snow/layer2,
+/area/shiva/exterior/cp_s_research)
 "oHz" = (
 /obj/structure/machinery/space_heater,
 /turf/open/floor/shiva{
@@ -20684,6 +20732,10 @@
 	icon_state = "floor3"
 	},
 /area/shiva/interior/bar)
+"qjY" = (
+/obj/structure/blocker/forcefield/vehicles,
+/turf/open/auto_turf/snow/layer0,
+/area/shiva/exterior/cp_s_research)
 "qjZ" = (
 /obj/item/stack/sheet/metal/large_stack,
 /obj/structure/foamed_metal,
@@ -20954,6 +21006,10 @@
 	dir = 1
 	},
 /area/shiva/interior/colony/central)
+"qxQ" = (
+/obj/structure/blocker/forcefield/vehicles,
+/turf/open/auto_turf/snow/layer2,
+/area/shiva/exterior/valley)
 "qyd" = (
 /obj/structure/closet/secure_closet/medical3{
 	req_access_txt = "100"
@@ -22375,6 +22431,11 @@
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/auto_turf/snow/layer0,
 /area/shiva/interior/bar)
+"sgB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/blocker/forcefield/vehicles,
+/turf/open/auto_turf/snow/layer1,
+/area/shiva/interior/colony/research_hab)
 "sgS" = (
 /obj/structure/machinery/photocopier,
 /turf/open/floor/plating,
@@ -23258,6 +23319,10 @@
 	},
 /turf/open/gm/river,
 /area/shiva/interior/caves/cp_camp)
+"tig" = (
+/obj/structure/blocker/forcefield/vehicles,
+/turf/open/auto_turf/snow/layer1,
+/area/shiva/interior/caves/cp_camp)
 "tiw" = (
 /obj/structure/machinery/light,
 /turf/open/floor/shiva{
@@ -23460,6 +23525,10 @@
 	},
 /turf/open/auto_turf/snow/layer1,
 /area/shiva/exterior/junkyard)
+"tsK" = (
+/obj/structure/blocker/forcefield/vehicles,
+/turf/open/auto_turf/snow/layer1,
+/area/shiva/exterior/cp_s_research)
 "tsR" = (
 /obj/structure/largecrate/random/mini/small_case/b{
 	pixel_x = 3;
@@ -26856,6 +26925,10 @@
 	dir = 1
 	},
 /area/shiva/exterior/cp_colony_grounds)
+"xct" = (
+/obj/structure/blocker/forcefield/vehicles,
+/turf/open/auto_turf/ice/layer1,
+/area/shiva/interior/caves/cp_camp)
 "xcE" = (
 /obj/structure/inflatable/popped,
 /turf/open/floor/shiva{
@@ -33135,7 +33208,7 @@ wMh
 ntJ
 wMh
 lSU
-mIx
+sgB
 skl
 skl
 ors
@@ -34918,7 +34991,7 @@ tTc
 vtz
 aFO
 eFI
-wMh
+xct
 wMh
 kEs
 flN
@@ -35079,7 +35152,7 @@ xAS
 xAS
 wMh
 wMh
-xAS
+tig
 wMh
 eFI
 flN
@@ -35241,7 +35314,7 @@ wMh
 wMh
 wMh
 jmW
-wMh
+xct
 wMh
 wMh
 gCL
@@ -35402,7 +35475,7 @@ pcY
 wMh
 ntJ
 wMh
-wMh
+xct
 wMh
 wMh
 wMh
@@ -39622,25 +39695,25 @@ wMh
 wMh
 ukp
 kVd
-ukp
-kVd
-kVd
-boW
-boW
-boW
-boW
-xgc
-boW
-xgc
-kVd
-rAH
-rAH
-rAH
-kVd
-boW
-xgc
-xgc
-ukp
+ckH
+lIa
+lIa
+qjY
+qjY
+qjY
+qjY
+tsK
+qjY
+tsK
+lIa
+oHf
+oHf
+oHf
+lIa
+qjY
+tsK
+tsK
+ckH
 jrg
 jrg
 jrg
@@ -40941,7 +41014,7 @@ ukp
 ukp
 uzu
 uzu
-uzu
+fkB
 xgc
 uzu
 rAH
@@ -41103,7 +41176,7 @@ ukp
 pLf
 rAH
 rAH
-rAH
+oHf
 rAH
 kVd
 rAH
@@ -41265,7 +41338,7 @@ uzu
 rAH
 rAH
 rAH
-uzu
+fkB
 xgc
 rAH
 kVd
@@ -41427,7 +41500,7 @@ rAH
 ukp
 uzu
 rAH
-uzu
+fkB
 uzu
 uzu
 uzu
@@ -41590,7 +41663,7 @@ rAH
 rAH
 rAH
 rAH
-ukp
+ckH
 ukp
 ukp
 jrg
@@ -42731,9 +42804,9 @@ ukp
 jrg
 jrg
 jrg
-bJj
-bJj
-bJj
+cIV
+cIV
+cIV
 puZ
 puZ
 puZ
@@ -55266,7 +55339,7 @@ sYu
 sYu
 lwo
 sYu
-sYu
+mXV
 sYu
 sYu
 sYu
@@ -55428,7 +55501,7 @@ sYu
 sYu
 sYu
 sYu
-sYu
+mXV
 sYu
 sYu
 sYu
@@ -55590,7 +55663,7 @@ sYu
 sYu
 sYu
 sYu
-sYu
+mXV
 sYu
 sYu
 sYu
@@ -55752,7 +55825,7 @@ sYu
 lwo
 lwo
 eOM
-lwo
+axF
 lwo
 sYu
 sYu
@@ -55916,10 +55989,10 @@ xRY
 xRY
 xRY
 aOg
-eOM
-sYu
-lwo
-lwo
+oig
+mXV
+axF
+axF
 ecj
 ecj
 ecj
@@ -59170,7 +59243,7 @@ arX
 arX
 eOM
 eOM
-ebK
+ojU
 fQX
 fQX
 jAL
@@ -59332,7 +59405,7 @@ eOM
 eOM
 eOM
 eOM
-iMb
+qxQ
 jAL
 fQX
 jAL
@@ -59494,7 +59567,7 @@ arX
 arX
 arX
 arX
-ebK
+ojU
 fQX
 fQX
 fQX
@@ -62048,7 +62121,7 @@ pAB
 amU
 gXS
 axG
-aae
+mKf
 wje
 wje
 crJ
@@ -62210,7 +62283,7 @@ gXS
 amU
 pAB
 gXS
-gXS
+fjs
 aah
 kPl
 kPl
@@ -62372,7 +62445,7 @@ pAB
 pAB
 pAB
 axG
-gXS
+fjs
 crJ
 kPl
 crJ
@@ -62534,7 +62607,7 @@ pAB
 bhI
 gXS
 fHQ
-gXS
+fjs
 aah
 crJ
 crJ
@@ -62696,7 +62769,7 @@ pAB
 pAB
 bhI
 gXS
-aae
+mKf
 crJ
 crJ
 kPl


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Adds missing vehicle blockers in shivas around research and Med-Sec-Sci megastructure:
![image](https://user-images.githubusercontent.com/59925169/166968992-c2f5109a-13ba-4b08-a19c-5fec04d990e3.png)
![image](https://user-images.githubusercontent.com/59925169/166969080-2e23ecc9-e03c-4f1a-91d5-9f78b19cfb48.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Hive locations should have vehicle blockers, That's how it is on every map and this MR makes it so it is on Shivas as well. (Usually the entire cave system is blocked off but since Shivas doesn't have one it ended up with none)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Adds missing vehicle blockers in shivas around research and Med-Sec-Sci megastructure
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
