### PR TITLE
Recalling pred throwables.

### DIFF
--- a/code/modules/cm_preds/smartdisc.dm
+++ b/code/modules/cm_preds/smartdisc.dm
@@ -123,6 +123,7 @@
 		var/mob/living/carbon/human/H = hit_atom
 		if(H.put_in_hands(src))
 			hit_atom.visible_message("[hit_atom] expertly catches [src] out of the air.","You catch [src] easily.")
+			throwing = FALSE
 		return
 	..()
 

--- a/code/modules/cm_preds/yaut_bracers.dm
+++ b/code/modules/cm_preds/yaut_bracers.dm
@@ -840,12 +840,7 @@
 		qdel(S)
 
 	for(var/obj/item/explosive/grenade/spawnergrenade/smartdisc/D in range(10))
-		var/datum/launch_metadata/LM = new()
-		LM.target = usr
-		LM.range = 10
-		LM.speed = SPEED_FAST
-		LM.thrower = usr
-		D.launch_towards(LM)
+		D.boomerang(usr)
 	return 1
 
 /obj/item/clothing/gloves/yautja/hunter/verb/remove_tracked_item()
@@ -922,7 +917,7 @@
 			return
 
 	for(var/obj/item/weapon/melee/yautja/combistick/C in range(7))
-		if(usr.get_active_hand() == C || usr.get_inactive_hand() == C) //Check if THIS combistick is in our hands already.
+		if(C.loc == usr) //We are already wearing/holding it.
 			continue
 		else if(usr.put_in_active_hand(C))//Try putting it in our active hand, or, if it's full...
 			if(!drain_power(usr,70)) //We should only drain power if we actually yank the chain back. Failed attempts can quickly drain the charge away.

--- a/code/modules/cm_preds/yaut_bracers.dm
+++ b/code/modules/cm_preds/yaut_bracers.dm
@@ -840,7 +840,8 @@
 		qdel(S)
 
 	for(var/obj/item/explosive/grenade/spawnergrenade/smartdisc/D in range(10))
-		D.boomerang(usr)
+		if(isturf(D.loc))
+			D.boomerang(usr)
 	return 1
 
 /obj/item/clothing/gloves/yautja/hunter/verb/remove_tracked_item()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Closes #60.
Combisticks getting combistuck is simple: `range()` check apparently includes sticks worn by the user, so it tries to put them in hands without correctly clearing all the references to it being the back/on-armour object still. Clearly not the intended usage, so axed.
Smartdiscs are actually two issues in one. Firstly, their impact event does not use `..()`, so the state of being thrown is not reset to false, so it triggers impact both at trying to move into the mob's tile and at the end of the throw processing, resulting in two instances of being put into hands. And furthermore, trying to throw the smartdisc back to user, with user as the cause of launching, triggers fancy smartdisc process of adding a boomerang effect that causes the throw _again_ even as it is already held by the user. Might as well cut the middleman and use the boomeranging procedure itself to simulate the recalling.

## Why It's Good For The Game

It is not. Nothing about predators is good for the game. But a bug is a bug.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Predators recalling combisticks and smartdiscs no longer get phantom duplicates.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
