### PR TITLE
QoL: viewing helmetless marines now gives a special status message in Overwatch console

### DIFF
--- a/code/modules/cm_marines/overwatch.dm
+++ b/code/modules/cm_marines/overwatch.dm
@@ -198,7 +198,6 @@
 				if(A)
 					area_name = sanitize(A.name)
 
-
 				switch(z_hidden)
 					if(HIDE_ALMAYER)
 						if(is_mainship_level(M_turf.z))

--- a/code/modules/cm_marines/overwatch.dm
+++ b/code/modules/cm_marines/overwatch.dm
@@ -198,6 +198,7 @@
 				if(A)
 					area_name = sanitize(A.name)
 
+
 				switch(z_hidden)
 					if(HIDE_ALMAYER)
 						if(is_mainship_level(M_turf.z))
@@ -240,6 +241,8 @@
 						mob_state = SET_CLASS("DEAD", INTERFACE_RED)
 						dead_text += "<tr><td><A href='?src=\ref[src];operation=use_cam;cam_target=\ref[H]'>[mob_name]</a></td><td>[role][act_sl]</td><td>[mob_state]</td><td>[area_name]</td><td>[dist]</td><td><A class='[is_filtered ? "green" : "red"]' href='?src=\ref[src];operation=filter_marine;squaddie=\ref[H]'>[is_filtered ? "Show" : "Hide"]</a></td></tr>"
 
+				if(!istype(H.head, /obj/item/clothing/head/helmet/marine))
+					mob_state += SET_CLASS(" <b>(NO HELMET)</b>", INTERFACE_ORANGE)
 
 				if(!H.key || !H.client)
 					if(H.stat != DEAD)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Adds a check in OW console code that writes (NO HELMET) in bolded orange letters if that marine does not wear an M10 marine helmet.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Trying to click any of the marine names on the squad monitor section will refresh the page and reset it back to the top. If a player's attempting to flip through marine cameras and clicks on a marine that doesn't wear a helmet, it's annoying to be forced to scroll all the way down and remember which person did you just click on, so you don't click on them again on accident and get your overwatch list scrolled back to top and then you scroll back down, accidentally click on that same name again and - you get the idea.
This is how it looks:
![unknown](https://user-images.githubusercontent.com/71565395/167121163-48b440d8-83a6-4c10-9fdc-39751f7e915d.png)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->


## Changelog
:cl: 50RemAndCounting
qol: Helmetless marines on Squad Overwatch Consoles now have a special status message indicating they're not wearing a helmet. Players no longer have to manually click on every marine's name to check if they're wearing a helmet or not.
/:cl:
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
