### PR TITLE
Fixes another bug with warrior pulling

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/Warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Warrior.dm
@@ -54,8 +54,6 @@
 	icon_xeno = 'icons/mob/hostiles/warrior.dmi'
 	icon_xenonid = 'icons/mob/xenonids/warrior.dmi'
 
-	var/lunging = FALSE // whether or not the warrior is currently lunging (holding) a target
-
 
 /mob/living/carbon/Xenomorph/Warrior/update_icons()
 	if (stat == DEAD)
@@ -78,8 +76,7 @@
 
 
 /mob/living/carbon/Xenomorph/Warrior/stop_pulling()
-	if(isliving(pulling) && lunging)
-		lunging = FALSE // To avoid extreme cases of stopping a lunge then quickly pulling and stopping to pull someone else
+	if(isliving(pulling))
 		var/mob/living/L = pulling
 		L.SetStunned(0)
 		L.SetKnockeddown(0)
@@ -114,12 +111,6 @@
 			L.pulledby = src
 			visible_message(SPAN_XENOWARNING("\The [src] grabs [L] by the throat!"), \
 			SPAN_XENOWARNING("You grab [L] by the throat!"))
-			lunging = TRUE
-			addtimer(CALLBACK(src, .proc/stop_lunging), get_xeno_stun_duration(L, 2) SECONDS)
-
-/mob/living/carbon/Xenomorph/Warrior/proc/stop_lunging()
-	lunging = FALSE
-
 
 /mob/living/carbon/Xenomorph/Warrior/hitby(atom/movable/AM)
 	if(ishuman(AM))

--- a/code/modules/mob/living/carbon/xenomorph/castes/Warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Warrior.dm
@@ -74,15 +74,6 @@
 /mob/living/carbon/Xenomorph/Warrior/throw_item(atom/target)
 	toggle_throw_mode(THROW_MODE_OFF)
 
-
-/mob/living/carbon/Xenomorph/Warrior/stop_pulling()
-	if(isliving(pulling))
-		var/mob/living/L = pulling
-		L.SetStunned(0)
-		L.SetKnockeddown(0)
-	..()
-
-
 /mob/living/carbon/Xenomorph/Warrior/start_pulling(atom/movable/AM, lunge)
 	if (!check_state() || agility)
 		return FALSE

--- a/code/modules/mob/living/carbon/xenomorph/castes/Warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Warrior.dm
@@ -54,6 +54,8 @@
 	icon_xeno = 'icons/mob/hostiles/warrior.dmi'
 	icon_xenonid = 'icons/mob/xenonids/warrior.dmi'
 
+	var/lunging = FALSE // whether or not the warrior is currently lunging (holding) a target
+
 
 /mob/living/carbon/Xenomorph/Warrior/update_icons()
 	if (stat == DEAD)
@@ -76,7 +78,8 @@
 
 
 /mob/living/carbon/Xenomorph/Warrior/stop_pulling()
-	if(isliving(pulling))
+	if(isliving(pulling) && lunging)
+		lunging = FALSE // To avoid extreme cases of stopping a lunge then quickly pulling and stopping to pull someone else
 		var/mob/living/L = pulling
 		L.SetStunned(0)
 		L.SetKnockeddown(0)
@@ -111,6 +114,12 @@
 			L.pulledby = src
 			visible_message(SPAN_XENOWARNING("\The [src] grabs [L] by the throat!"), \
 			SPAN_XENOWARNING("You grab [L] by the throat!"))
+			lunging = TRUE
+			addtimer(CALLBACK(src, .proc/stop_lunging), get_xeno_stun_duration(L, 2) SECONDS)
+
+/mob/living/carbon/Xenomorph/Warrior/proc/stop_lunging()
+	lunging = FALSE
+
 
 /mob/living/carbon/Xenomorph/Warrior/hitby(atom/movable/AM)
 	if(ishuman(AM))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Fixes a bug with warrior which would make every mob you stopped grabbing would have its `stunned` and `knockedDown` set to 0 regardless if it was lunged or not.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bug bad.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixed a bug with warrior which would make you reset the stun timer on mobs you stop pulling that weren't lunged.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
