### PR TITLE
Performant Mob Verbs

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -261,15 +261,6 @@ its easier to just keep the beam vertical.
 
 	return TRUE
 
-//All atoms
-/atom/verb/atom_examine()
-	set name = "Examine"
-	set category = "IC"
-	set src in view(usr.client) //If it can be seen, it can be examined.
-
-	if(!usr) return
-	examine(usr)
-
 /atom/proc/examine(mob/user)
 	to_chat(user, "[icon2html(src, user)] That's \a [src].") //changed to "That's" from "This is" because "This is some metal sheets" sounds dumb compared to "That's some metal sheets" ~Carn
 	if(desc)

--- a/code/game/machinery/bots/mulebot.dm
+++ b/code/game/machinery/bots/mulebot.dm
@@ -89,8 +89,6 @@
 		suffix = "#[count]"
 	name = "Mulebot ([suffix])"
 
-	verbs -= /atom/movable/verb/pull
-
 
 // set up the wire colours in random order
 // and the random wire display order

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -155,20 +155,6 @@
 /obj/item/proc/suicide_act(mob/user)
 	return
 
-/obj/item/verb/move_to_top()
-	set name = "Move To Top"
-	set category = "Object"
-	set src in oview(1)
-
-	if(!istype(src.loc, /turf) || usr.stat || usr.is_mob_restrained() )
-		return
-
-	var/turf/T = src.loc
-
-	moveToNullspace()
-
-	src.forceMove(T)
-
 /*Global item proc for all of your unique item skin needs. Works with any
 item, and will change the skin to whatever you specify here. You can also
 manually override the icon with a unique skin if wanted, for the outlier
@@ -660,40 +646,6 @@ cases. Override_icon_state should be a list.*/
 			return TRUE
 		else
 			return !ignore_non_flags
-
-/obj/item/verb/verb_pickup()
-	set src in oview(1)
-	set category = "Object"
-	set name = "Pick up"
-
-	if(!(usr)) //BS12 EDIT
-		return
-	if(ismob(src))
-		return
-	if(!usr.canmove || usr.stat || usr.is_mob_restrained() || !Adjacent(usr))
-		return
-	if((!istype(usr, /mob/living/carbon)) || (istype(usr, /mob/living/brain)))//Is humanoid, and is not a brain
-		to_chat(usr, SPAN_DANGER("You can't pick things up!"))
-		return
-	if(src.anchored) //Object isn't anchored
-		to_chat(usr, SPAN_DANGER("You can't pick that up!"))
-		return
-	if(!usr.hand && usr.r_hand) //Right hand is not full
-		to_chat(usr, SPAN_DANGER("Your right hand is full."))
-		return
-	if(usr.hand && usr.l_hand) //Left hand is not full
-		to_chat(usr, SPAN_DANGER("Your left hand is full."))
-		return
-	if(!istype(src.loc, /turf)) //Object is on a turf
-		to_chat(usr, SPAN_DANGER("You can't pick that up!"))
-		return
-	//All checks are done, time to pick it up!
-	if (world.time <= usr.next_move)
-		return
-	usr.next_move += 6 // stop insane pickup speed
-	usr.UnarmedAttack(src)
-	return
-
 
 //This proc is executed when someone clicks the on-screen UI button. To make the UI button show, set the 'icon_action_button' to the icon_state of the image of the button in actions.dmi
 //The default action is attack_self().

--- a/code/game/objects/items/storage/internal.dm
+++ b/code/game/objects/items/storage/internal.dm
@@ -9,7 +9,6 @@
 		CRASH("Internal storage was created without a valid master object! ([loc], [usr])")
 	master_object = loc
 	name = master_object.name
-	verbs -= /obj/item/verb/verb_pickup	//make sure this is never picked up.
 
 /obj/item/storage/internal/attack_hand()
 	return		//make sure this is never picked up
@@ -41,7 +40,7 @@
 
 		if(!isitem(master_object)) //Everything after this point is for doffing worn items with internal storage pockets.
 			return FALSE //If we are not in an item, do nothing more.
-		
+
 		var/obj/item/master_item = master_object
 		if(master_item.flags_item & NODROP) return
 

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -13,8 +13,6 @@
 
 /obj/structure/bed/chair/Initialize()
 	. = ..()
-	if(anchored)
-		verbs -= /atom/movable/verb/pull
 	handle_rotation()
 
 /obj/structure/bed/initialize_pass_flags(var/datum/pass_flags_container/PF)

--- a/code/game/verbs/atom_verbs.dm
+++ b/code/game/verbs/atom_verbs.dm
@@ -1,8 +1,0 @@
-/atom/movable/verb/pull()
-	set name = "Pull"
-	set category = "Object"
-	set src in oview(1)
-
-	if(Adjacent(usr))
-		usr.start_pulling(src)
-

--- a/code/modules/cm_aliens/XenoStructures.dm
+++ b/code/modules/cm_aliens/XenoStructures.dm
@@ -834,11 +834,6 @@
 		to_chat(M, SPAN_XENOWARNING("It's about to burst!"))
 	return XENO_NO_DELAY_ACTION
 
-/obj/item/explosive/grenade/alien/verb_pickup()
-	if(isXeno(usr))
-		attack_alien(usr)
-	return
-
 /obj/item/explosive/grenade/alien/acid
 	name = "acid grenade"
 	desc = "Sprays acid projectiles outwards when detonated."

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -107,6 +107,11 @@
 	if(SSticker.mode && SSticker.mode.flags_round_type & MODE_PREDATOR)
 		addtimer(CALLBACK(GLOBAL_PROC, .proc/to_chat, src, "<span style='color: red;'>This is a <B>PREDATOR ROUND</B>! If you are whitelisted, you may Join the Hunt!</span>"), 2 SECONDS)
 
+/mob/dead/observer/Initialize()
+	. = ..()
+	verbs -= /mob/verb/pickup_item
+	verbs -= /mob/verb/pull_item
+
 /mob/dead/observer/proc/set_lighting_alpha_from_pref(var/client/ghost_client)
 	var/vision_level = ghost_client?.prefs?.ghost_vision_pref
 	switch(vision_level)

--- a/code/modules/mob/living/silicon/ai/freelook/eye.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/eye.dm
@@ -17,17 +17,6 @@
 /mob/aiEye/Move()
 	return 0
 
-// Hide popout menu verbs
-/mob/aiEye/atom_examine()
-	set popup_menu = 0
-	set src = usr.contents
-	return 0
-
-/mob/aiEye/pull()
-	set popup_menu = 0
-	set src = usr.contents
-	return 0
-
 // Use this when setting the aiEye's location.
 // It will also stream the chunk that the new loc is in.
 /mob/aiEye/proc/setLoc(var/T, var/cancel_tracking = 1)

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -429,3 +429,50 @@ It's fairly easy to fix if dealing with single letters but not so much with comp
 
 /mob/proc/can_see_reagents()
 	return stat == DEAD || isSynth(src) ||HAS_TRAIT(src, TRAIT_REAGENT_SCANNER) //Dead guys and synths can always see reagents
+
+/**
+ * Examine a mob
+ *
+ * mob verbs are faster than object verbs. See
+ * [this byond forum post](https://secure.byond.com/forum/?post=1326139&page=2#comment8198716)
+ * for why this isn't atom/verb/examine()
+ */
+/mob/verb/examinate(atom/examinify as mob|obj|turf in view())
+	set name = "Examine"
+	set category = "IC"
+
+	examinify.examine(src)
+
+/mob/verb/pickup_item(obj/item/pickupify in view(1, usr))
+	set name = "Pick Up"
+	set category = "Object"
+
+	if(!canmove || stat || is_mob_restrained() || !Adjacent(pickupify))
+		return
+
+	if(world.time <= next_move)
+		return
+
+	if(!hand && r_hand)
+		to_chat(usr, SPAN_DANGER("Your right hand is full."))
+		return
+	if(hand && l_hand)
+		to_chat(usr, SPAN_DANGER("Your left hand is full."))
+		return
+
+	if(pickupify.anchored)
+		to_chat(usr, SPAN_DANGER("You can't pick that up!"))
+		return
+	if(!isturf(pickupify.loc))
+		to_chat(usr, SPAN_DANGER("You can't pick that up!"))
+		return
+
+	next_move += 6 // stop insane pickup speed
+	UnarmedAttack(pickupify)
+
+/mob/verb/pull_item(atom/movable/pullify in view(1, usr))
+	set name = "Pull"
+	set category = "Object"
+
+	if(Adjacent(pullify))
+		start_pulling(pullify)

--- a/code/modules/vehicles/cargo_train.dm
+++ b/code/modules/vehicles/cargo_train.dm
@@ -35,7 +35,6 @@
 /obj/vehicle/train/cargo/engine/Initialize()
 	. = ..()
 	cell = new /obj/item/cell/apc
-	verbs -= /atom/movable/verb/pull
 	key = new()
 	var/image/I = new(icon = 'icons/obj/vehicles/vehicles.dmi', icon_state = "cargo_engine_overlay", layer = src.layer + 0.2) //over mobs
 	overlays += I
@@ -213,10 +212,5 @@
 
 	if(!lead && !tow)
 		anchored = 0
-		if(verbs.Find(/atom/movable/verb/pull))
-			return
-		else
-			verbs += /atom/movable/verb/pull
 	else
 		anchored = 1
-		verbs -= /atom/movable/verb/pull

--- a/code/modules/vehicles/vehicle.dm
+++ b/code/modules/vehicles/vehicle.dm
@@ -261,7 +261,6 @@
 	. = ..()
 	var/image/I = new(icon = 'icons/obj/vehicles/vehicles.dmi', icon_state = "soutomobile_overlay", layer = ABOVE_MOB_LAYER) //over mobs
 	overlays += I
-	verbs -= /atom/movable/verb/pull
 
 /obj/vehicle/souto/manual_unbuckle(mob/user)
 	if(buckled_mob && buckled_mob != user)
@@ -288,7 +287,7 @@
 	health = initial(health) //Souto Man never dies, and neither does his bike.
 
 /obj/vehicle/souto/super/buckle_mob(mob/M, mob/user)
-	if(!locked) //Vehicle is unlocked until first being mounted, since the Soutomobile is faction-locked and otherwise Souto Man cannot automatically buckle in on spawn as his equipment is spawned before his ID.	
+	if(!locked) //Vehicle is unlocked until first being mounted, since the Soutomobile is faction-locked and otherwise Souto Man cannot automatically buckle in on spawn as his equipment is spawned before his ID.
 		locked = TRUE
 	else if(M == user && M.faction != FACTION_SOUTO && locked == TRUE) //Are you a cool enough dude to drive this bike? Nah, nobody's THAT cool.
 		to_chat(user, SPAN_WARNING("Somehow, as you take hold of the handlebars, [src] manages to glare at you. You back off. We didn't sign up for haunted motorbikes, man."))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Replaces verbs on atoms and items with verbs on mobs because it's more performant or something like that. Also ripped out the Move to Top verb because I don't think anyone uses it?

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

More performance is always good.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
refactor: Tweaked how the Examine, Pickup, and Pull verbs work, they should still function as normal however.
del: Removed the move to top object verb.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
