### PR TITLE
Destroys Yautja Queen Stomp

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -515,7 +515,6 @@
 				<span style='color: green;'>femalescream</span>, \
 				<span style='color: green;'>overhere</span>, \
 				<span style='color: green;'>turnaround</span>, \
-				<span style='color: green;'>queenstomp</span>, \
 				<span style='color: green;'>roar</span></b><br>")
 			if (Primate)
 				to_chat(src, "<br><b>As a Primate, you have the following additional emotes.<br><br>\
@@ -584,10 +583,6 @@
 			if(Pred && src.loc)
 				m_type = 1
 				playsound(src.loc, 'sound/voice/pred_overhere.ogg', 25, 0)
-		if ("queenstomp")
-			if(Pred && src.loc)
-				m_type = 1
-				playsound(src.loc, "alien_footstep_large", 35, rand(20000, 25000), 11, falloff = 4)
 		if ("roar")
 			if(Pred && src.loc)
 				message = "<B>[src] roars!</b>"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Removes the queen stomp emote from preds.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Apparently people have been complaining about it.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: Yautja no longer have a Queen Stomp emote.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
