### PR TITLE
Mouth Item HRP Buff

### DIFF
--- a/ColonialMarinesALPHA.dme
+++ b/ColonialMarinesALPHA.dme
@@ -360,6 +360,7 @@
 #include "code\datums\elements\_element.dm"
 #include "code\datums\elements\bloody_feet.dm"
 #include "code\datums\elements\drop_retrieval.dm"
+#include "code\datums\elements\mouth_drop_item.dm"
 #include "code\datums\elements\poor_eyesight_correction.dm"
 #include "code\datums\elements\suturing.dm"
 #include "code\datums\elements\bullet_trait\damage_boost.dm"

--- a/code/datums/elements/mouth_drop_item.dm
+++ b/code/datums/elements/mouth_drop_item.dm
@@ -1,0 +1,27 @@
+/datum/element/mouth_drop_item
+	element_flags = ELEMENT_DETACH
+
+/datum/element/mouth_drop_item/Attach(datum/target)
+	. = ..()
+	if(!isitem(target))
+		return ELEMENT_INCOMPATIBLE
+	RegisterSignal(target, COMSIG_ITEM_EQUIPPED, .proc/item_equipped)
+	RegisterSignal(target, COMSIG_ITEM_DROPPED, .proc/item_dropped)
+
+/datum/element/mouth_drop_item/Detach(datum/source, force)
+	UnregisterSignal(source, list(
+		COMSIG_ITEM_EQUIPPED,
+		COMSIG_ITEM_DROPPED
+	))
+	return ..()
+
+/datum/element/mouth_drop_item/proc/item_equipped(obj/item/I, mob/living/carbon/human/user, slot)
+	SIGNAL_HANDLER
+
+	if(slot == WEAR_FACE)
+		I.RegisterSignal(user, COMSIG_MOB_KNOCKED_DOWN, /obj/item.proc/drop_to_floor)
+
+/datum/element/mouth_drop_item/proc/item_dropped(obj/item/I, mob/living/carbon/human/user)
+	SIGNAL_HANDLER
+
+	I.UnregisterSignal(user, COMSIG_MOB_KNOCKED_DOWN)

--- a/code/game/objects/effects/effect_system/particle_effects.dm
+++ b/code/game/objects/effects/effect_system/particle_effects.dm
@@ -18,13 +18,13 @@
 	name = "fire"
 	icon = 'icons/effects/fire.dmi'
 	icon_state = "3"
-	var/life = 0.5 //In seconds
+	var/life = 0.5 SECONDS
 	mouse_opacity = 0
 
 /obj/effect/particle_effect/fire/New()
 	if(!istype(loc, /turf))
 		qdel(src)
-	extinguish()
+	addtimer(CALLBACK(src, .proc/handle_extinguish), life)
 
 	setDir(pick(cardinal))
 	SetLuminosity(3)
@@ -38,11 +38,10 @@
 	for(var/obj/structure/bed/nest/N in loc)//Nests
 		N.fire_act()
 
-/obj/effect/particle_effect/fire/proc/extinguish()
-	spawn(life * 10)
-		if (istype(loc, /turf))
-			SetLuminosity(0)
-		qdel(src)
+/obj/effect/particle_effect/fire/proc/handle_extinguish()
+	if(istype(loc, /turf))
+		SetLuminosity(0)
+	qdel(src)
 
 /obj/effect/particle_effect/fire/Crossed(mob/living/L)
 	..()

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -857,3 +857,7 @@ keep_zoom - do we keep zoom during movement. be careful with setting this to 1
 		mob_state = icon_state
 	return mob_state
 
+/obj/item/proc/drop_to_floor(mob/wearer)
+	SIGNAL_HANDLER
+
+	wearer.drop_inv_item_on_ground(src)

--- a/code/game/objects/items/reagent_containers/food/snacks.dm
+++ b/code/game/objects/items/reagent_containers/food/snacks.dm
@@ -1584,6 +1584,10 @@
 		new monkey_type(T)
 	qdel(src)
 
+/obj/item/reagent_container/food/snacks/monkeycube/extinguish()
+	. = ..()
+	if(!package)
+		Expand()
 
 /obj/item/reagent_container/food/snacks/monkeycube/wrapped
 	desc = "Still wrapped in some paper."

--- a/code/game/objects/items/tools/extinguisher.dm
+++ b/code/game/objects/items/tools/extinguisher.dm
@@ -99,7 +99,8 @@
 			return
 		var/mob/living/M = user
 		M.ExtinguishMob()
-		new /obj/effect/particle_effect/water(get_turf(user))
+		var/obj/effect/particle_effect/water/water_effect = new /obj/effect/particle_effect/water(get_turf(user))
+		QDEL_IN(water_effect, 1 SECONDS)
 		reagents.total_volume -= EXTINGUISHER_WATER_USE_AMT
 		return
 

--- a/code/game/objects/items/tools/flame_tools.dm
+++ b/code/game/objects/items/tools/flame_tools.dm
@@ -391,12 +391,13 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 
 /obj/item/clothing/mask/cigarette/pickup(mob/user)
 	. = ..()
+	RegisterSignal(user, COMSIG_LIVING_PREIGNITION, .proc/light)
 	RegisterSignal(user, COMSIG_HUMAN_EXTINGUISH, .proc/handle_extinguish)
 
 /obj/item/clothing/mask/cigarette/dropped(mob/user)
 	. = ..()
 	if(loc != user)
-		UnregisterSignal(user, COMSIG_HUMAN_EXTINGUISH)
+		UnregisterSignal(user, list(COMSIG_LIVING_PREIGNITION, COMSIG_HUMAN_EXTINGUISH))
 
 /obj/item/clothing/mask/cigarette/ucigarette
 	icon_on = "ucigon"

--- a/code/game/objects/items/tools/flame_tools.dm
+++ b/code/game/objects/items/tools/flame_tools.dm
@@ -204,6 +204,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	flags_atom |= NOREACT // so it doesn't react until you light it
 	create_reagents(chem_volume) // making the cigarrete a chemical holder with a maximum volume of 15
 	reagents.add_reagent("nicotine",10)
+	AddElement(/datum/element/mouth_drop_item)
 
 /obj/item/clothing/mask/cigarette/attackby(obj/item/W, mob/user)
 	..()
@@ -372,6 +373,30 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		M.update_inv_wear_mask()
 	STOP_PROCESSING(SSobj, src)
 	qdel(src)
+
+/obj/item/clothing/mask/cigarette/flamer_fire_act()
+	. = ..()
+	if(!heat_source)
+		light()
+
+/obj/item/clothing/mask/cigarette/extinguish()
+	. = ..()
+	die()
+
+/obj/item/clothing/mask/cigarette/proc/handle_extinguish()
+	SIGNAL_HANDLER
+
+	if(heat_source)
+		die()
+
+/obj/item/clothing/mask/cigarette/pickup(mob/user)
+	. = ..()
+	RegisterSignal(user, COMSIG_HUMAN_EXTINGUISH, .proc/handle_extinguish)
+
+/obj/item/clothing/mask/cigarette/dropped(mob/user)
+	. = ..()
+	if(loc != user)
+		UnregisterSignal(user, COMSIG_HUMAN_EXTINGUISH)
 
 /obj/item/clothing/mask/cigarette/ucigarette
 	icon_on = "ucigon"

--- a/code/game/objects/items/tools/flame_tools.dm
+++ b/code/game/objects/items/tools/flame_tools.dm
@@ -306,6 +306,8 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 			light(SPAN_NOTICE("[user] lights their [src] from the broken light."))
 
 /obj/item/clothing/mask/cigarette/proc/light(flavor_text)
+	SIGNAL_HANDLER
+
 	if(!heat_source)
 		heat_source = 1000
 		damtype = "fire"
@@ -381,7 +383,8 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 
 /obj/item/clothing/mask/cigarette/extinguish()
 	. = ..()
-	die()
+	if(heat_source)
+		die()
 
 /obj/item/clothing/mask/cigarette/proc/handle_extinguish()
 	SIGNAL_HANDLER

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -365,3 +365,6 @@
 		return
 
 	O.name += " ([label])"
+
+/obj/proc/extinguish()
+	return

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -138,7 +138,7 @@
 
 /mob/living/carbon/human/IgniteMob()
 	. = ..()
-	if(. && !stat && pain.feels_pain)
+	if((. & IGNITE_IGNITED) && !stat && pain.feels_pain)
 		INVOKE_ASYNC(src, /mob.proc/emote, "scream")
 
 /mob/living/proc/ExtinguishMob()

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -285,6 +285,11 @@ Defined in conflicts.dm of the #defines folder.
 	hud_offset_mod = -4
 	var/pry_delay = 3 SECONDS
 
+/obj/item/attachable/bayonet/Initialize(mapload, ...)
+	. = ..()
+	if(flags_equip_slot & SLOT_FACE)
+		AddElement(/datum/element/mouth_drop_item)
+
 /obj/item/attachable/bayonet/New()
 	..()
 	accuracy_unwielded_mod = -HIT_ACCURACY_MULT_TIER_1

--- a/code/modules/reagents/chemistry_reagents/other.dm
+++ b/code/modules/reagents/chemistry_reagents/other.dm
@@ -119,10 +119,7 @@
 
 /datum/reagent/water/reaction_obj(var/obj/O, var/volume)
 	src = null
-	if(istype(O,/obj/item/reagent_container/food/snacks/monkeycube))
-		var/obj/item/reagent_container/food/snacks/monkeycube/cube = O
-		if(!cube.package)
-			cube.Expand()
+	O.extinguish()
 
 /datum/reagent/water/reaction_mob(var/mob/living/M, var/method=TOUCH, var/volume)//Splashing people with water can help put them out!
 	if(!istype(M, /mob/living))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Items held in your mouth, like knives and cigarettes, will now fall to the ground when you get knocked over. As we all know due to not being able to hold anything, SS13 spacemen lose all motor function the moment they go horizontal.

Additionally, you can now light a cigarette on the floor by shooting at it with a flamethrower, extinguish it by throwing water on it. If you're holding a lit cigarette and get extinguished, your cigarette goes out.

Running into fire while holding an unlit cigarette will now light it.

You will no longer spam scream each time you walk into fire.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It helps the world feel more alive by being realistic.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Items held in the mouth like knives or cigarettes now fall out when you get knocked over.
add: You can now light and extinguish cigarettes on the ground, as well as cigarettes held on someone's person by extinguishing them. Getting lit on fire while holding an unlit cigarette will now light it.
fix: You will no longer spam scream when you get lit on fire while already lit on fire.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
