### PR TITLE
Japanese language OVERHAUL

### DIFF
--- a/ColonialMarinesALPHA.dme
+++ b/ColonialMarinesALPHA.dme
@@ -1416,6 +1416,7 @@
 #include "code\modules\events\comms_blackout.dm"
 #include "code\modules\flufftext\Dreaming.dm"
 #include "code\modules\flufftext\Hallucination.dm"
+#include "code\modules\flufftext\Japanese.dm"
 #include "code\modules\flufftext\TextFilters.dm"
 #include "code\modules\gear_presets\_select_equipment.dm"
 #include "code\modules\gear_presets\agents.dm"

--- a/code/modules/flufftext/Japanese.dm
+++ b/code/modules/flufftext/Japanese.dm
@@ -1,0 +1,253 @@
+///How likely the nucleus (vowel) is to geminate ie a -> aa
+#define JAPANESE_SOUND_GEMINATION_CHANCE_NUCLEUS		15
+///How likely the initial (consonant) is to geminate ie k -> kk
+#define JAPANESE_SOUND_GEMINATION_CHANCE_INITIAL		7.5
+///How likely the consonant is to palatalise ie r -> ry
+#define JAPANESE_SOUND_PALATALISATION_CHANCE			10
+///How likely the syllable is not to have a consonant at the start, needs to be kinda high for convincing diphthongs
+#define JAPANESE_SOUND_NULL_INITIAL_CHANCE				20
+///How likely the syllable is to end in an N
+#define JAPANESE_SOUND_NULL_FINAL_CHANCE				45
+///How likely it is to insert an apostrophe between two syllables (this can happen anywhere, mainly used for morpheme boundaries.)
+#define JAPANESE_SOUND_APOSTROPHE_CHANCE				30
+///how likely voiced sounds are to geminate, these mainly occur in foreign loans so quite unlikely
+#define JAPANESE_SOUND_GEMINATION_CHANCE_VOICED			10
+
+/*
+Hello and welcome to the Japanese language. Or rather, a random generator for it.
+Full of snowflake checks and maybe even hard dels (but hopefully not). You're sure to love this.
+*/
+
+///holds the syllable's sound itself and information such as if it has a null initial or final
+/datum/japanese_syllable
+	var/syllable_sound
+	var/null_initial
+	var/null_final
+
+/datum/japanese_syllable/proc/randomly_generate_japanese_syllable(var/initial_geminable = TRUE, var/nucleus_geminable = TRUE, var/no_null_initial = FALSE)
+	var/syllable
+	var/IN = (pick(subtypesof(/datum/japanese_sound/initial/))) //assign a random consonant and vowel
+	var/NU = (pick(subtypesof(/datum/japanese_sound/nucleus/)))
+	var/datum/japanese_sound/initial/initial = new IN
+	var/datum/japanese_sound/nucleus/nucleus = new NU
+	var/datum/japanese_sound/final/final = new /datum/japanese_sound/final/n //because we only have -n
+	//time to do compatibilty checks, nucleus comes first as it determines what we can and can't palatalise
+	if(prob(JAPANESE_SOUND_GEMINATION_CHANCE_NUCLEUS) && nucleus_geminable)
+		if(nucleus.geminate())
+			initial_geminable = FALSE
+	//now for checks on the initial
+	if(initial.forbidden_nuclei) //check if the nucleus is a W or a Y and then if it's trying to make yi/wi/wu/we/ye
+		if(NU in initial.forbidden_nuclei)
+			var/list/blacklist = list(/datum/japanese_sound/initial/w, /datum/japanese_sound/initial/y)
+			var/list/allsounds = subtypesof(/datum/japanese_sound/initial/)
+			var/list/good_sounds = allsounds - blacklist
+			var/new_IN = pick(good_sounds)
+			initial = new new_IN //swap the initial to something that's not w or y - we've already done the nucleus. This might make w and y a bit too uncommon.
+	//now that we know our initial doesn't form an inherently illegal combination, we apply sound change rules to it
+	if(prob(JAPANESE_SOUND_GEMINATION_CHANCE_INITIAL) && initial_geminable)
+		initial.geminate()
+	if(prob(JAPANESE_SOUND_PALATALISATION_CHANCE) || (initial.forced_to_palatalise && nucleus.forces_palatalisation))
+		initial.palatalise(nucleus)
+	initial.affricate(nucleus) //this doesn't force it to affricate, rather checks if it has to then does it if so
+	//now we construct our syllable, n.b. this is not a mora since we include the nasal final and soukon. For instance, ppyan is four morae - Q-p-a-N. This however is still just one syllable.
+	if(!(prob(JAPANESE_SOUND_NULL_INITIAL_CHANCE)) || no_null_initial)
+		syllable += "[initial.sound]"
+		null_initial = FALSE
+	else
+		null_initial = TRUE
+	syllable += "[nucleus.sound]"
+	if(!(prob(JAPANESE_SOUND_NULL_FINAL_CHANCE)))
+		syllable += "[final.sound]"
+		null_final = FALSE
+	else
+		null_final = TRUE
+	syllable_sound = syllable
+	QDEL_NULL(initial)
+	QDEL_NULL(nucleus)
+	QDEL_NULL(final)
+
+/proc/randomly_generate_japanese_word(var/syllables = pick(30;1, 35;2, 20;3, 10;4, 5;5)) //default has args which don't make obnoxiously massive words
+	var/datum/japanese_syllable/J = new /datum/japanese_syllable
+	if(syllables == 1) //only one syllable, no need for a loop
+		J.randomly_generate_japanese_syllable(FALSE) //word-initial syllables cannot be geminated
+		return J.syllable_sound //just return that as our word
+	else
+		var/word
+		J.randomly_generate_japanese_syllable(FALSE) //you can't have a geminate sound at the start of a word
+		word += J.syllable_sound //add this initial syllable (no geminate) to the word
+		for(var/i = 1, i < syllables, i++) //now, repeat for the rest of the syllables in the word
+			J.randomly_generate_japanese_syllable() //regenerate the syllable
+			if(J.null_initial) //did our new syllable get a null initial?
+				if(prob(JAPANESE_SOUND_APOSTROPHE_CHANCE)) //check for chance
+					word += "'" //add our apostrophe to the word
+			word += J.syllable_sound //add our newly generated syllable to the word, *after* the apostrophe
+		QDEL_NULL(J)
+		return word //now we're done, return our word
+
+///a generic sound
+/datum/japanese_sound
+	var/sound = "sound" // the sound it makes, duh
+	var/gemination_forbidden = FALSE //if it can geminate or not
+	var/geminated_form = "soundsound" //sound when geminated
+	var/low_chance_geminate = FALSE //just some basic phonetic information
+
+///handle gemination, and make sure that if the sound is voiced the chance is lower
+/datum/japanese_sound/proc/geminate()
+	if(gemination_forbidden)
+		return FALSE
+	if(low_chance_geminate)
+		if(!(prob(JAPANESE_SOUND_GEMINATION_CHANCE_VOICED)))
+			return FALSE
+	sound = geminated_form
+	return TRUE
+
+///an initial sound aka a consonant, contains a lot of data about stuff that only consonants can be
+/datum/japanese_sound/initial
+	sound = "intial"
+	var/palatalised_forbidden = FALSE //if it can palatalise or not
+	var/palatalised_form = "inyitial" //sound when palatalised
+	var/palatalised_geminated_form = "ininyitial" //sound when geminated AND palatalised
+	var/list/forbidden_nuclei //vowels it can't go before
+	var/affricated_form //special form it takes on before a u. Applies to t, d, and h.
+	var/forced_to_palatalise = FALSE //if it HAS to palatalise before an I. Applies to t, d, s and z. This lets it bypass anti-palatalise rules on I but not e.
+
+/datum/japanese_sound/initial/proc/palatalise(var/datum/japanese_sound/nucleus/nucleus)
+	if(nucleus.anti_palatalise && !forced_to_palatalise)
+		return
+	if(sound == geminated_form && !palatalised_forbidden)
+		sound = palatalised_geminated_form
+	else if(!palatalised_forbidden)
+		sound = palatalised_form
+
+/datum/japanese_sound/initial/proc/affricate(var/datum/japanese_sound/nucleus/nucleus)
+	if(affricated_form && nucleus.causes_affrication)
+		sound = affricated_form
+
+/datum/japanese_sound/initial/b
+	sound = "b"
+	palatalised_form = "by"
+	geminated_form = "bb"
+	palatalised_geminated_form = "bby"
+	low_chance_geminate = TRUE
+
+/datum/japanese_sound/initial/p
+	sound = "p"
+	palatalised_form = "py"
+	geminated_form = "pp"
+	palatalised_geminated_form = "ppy"
+
+/datum/japanese_sound/initial/t
+	sound = "t"
+	palatalised_form = "ch"
+	geminated_form = "tt"
+	palatalised_geminated_form = "tch" //nihon-shiki sucks, hepburn for life
+	affricated_form = "ts"
+	forced_to_palatalise = TRUE
+
+/datum/japanese_sound/initial/d
+	sound = "d"
+	palatalised_form = "j"
+	geminated_form = "dd"
+	palatalised_geminated_form = "jj"
+	affricated_form = "z" //no dialectal dz weirdness
+	forced_to_palatalise = TRUE
+	low_chance_geminate = TRUE
+
+/datum/japanese_sound/initial/s
+	sound = "s"
+	palatalised_form = "sh"
+	geminated_form = "ss"
+	palatalised_geminated_form = "ssh"
+	forced_to_palatalise = TRUE
+
+/datum/japanese_sound/initial/z
+	sound = "z"
+	palatalised_form = "j"
+	geminated_form = "zz"
+	palatalised_geminated_form = "jj"
+	forced_to_palatalise = TRUE
+	low_chance_geminate = TRUE
+
+/datum/japanese_sound/initial/k
+	sound = "k"
+	palatalised_form = "ky"
+	geminated_form = "kk"
+	palatalised_geminated_form = "kky"
+
+/datum/japanese_sound/initial/g
+	sound = "g"
+	palatalised_form = "gy"
+	geminated_form = "gg"
+	palatalised_geminated_form = "ggy"
+	low_chance_geminate = TRUE
+
+/datum/japanese_sound/initial/h
+	sound = "h"
+	palatalised_form = "hy"
+	affricated_form = "f"
+	gemination_forbidden = TRUE
+
+/datum/japanese_sound/initial/r
+	sound = "r"
+	palatalised_form = "ry"
+	gemination_forbidden = TRUE
+
+/datum/japanese_sound/initial/w
+	sound = "w"
+	palatalised_forbidden = TRUE
+	gemination_forbidden = TRUE
+	forbidden_nuclei = list(/datum/japanese_sound/nucleus/e, /datum/japanese_sound/nucleus/i, /datum/japanese_sound/nucleus/u)
+
+/datum/japanese_sound/initial/y
+	sound = "y"
+	palatalised_forbidden = TRUE
+	gemination_forbidden = TRUE
+	forbidden_nuclei = list(/datum/japanese_sound/nucleus/e, /datum/japanese_sound/nucleus/i)
+
+///a nucleus, aka a vowel sound
+/datum/japanese_sound/nucleus
+	sound = "nucleus"
+	var/anti_palatalise = FALSE //if you can't palatalise sounds before it, applies to E and I.
+	var/causes_affrication //if it's a U
+	var/forces_palatalisation //if it's an I - this forces T, D, S, and Z to palatalise but prevents all others from palatalising
+
+/datum/japanese_sound/nucleus/a
+	sound = "a"
+	geminated_form = "aa" //no diacritics, they fuck with capitalisation a ton, don't want to use combining diacritics since they can lead to even weirder problems
+
+/datum/japanese_sound/nucleus/e
+	sound = "e"
+	geminated_form = "ei" //yeah, we use hepburn because it's AWESOME
+	anti_palatalise = TRUE
+
+/datum/japanese_sound/nucleus/i
+	sound = "i"
+	geminated_form = "ii"
+	forces_palatalisation = TRUE
+	anti_palatalise = TRUE
+
+/datum/japanese_sound/nucleus/o
+	sound = "o"
+	geminated_form = "ou"
+
+/datum/japanese_sound/nucleus/u
+	sound = "u"
+	geminated_form = "uu"
+	causes_affrication = TRUE
+
+///a final sound, not used for much since the only one possible is N.
+/datum/japanese_sound/final
+	sound = "final"
+	gemination_forbidden = TRUE
+
+/datum/japanese_sound/final/n
+	sound = "n"
+	gemination_forbidden = TRUE
+
+#undef JAPANESE_SOUND_GEMINATION_CHANCE_INITIAL
+#undef JAPANESE_SOUND_GEMINATION_CHANCE_NUCLEUS
+#undef JAPANESE_SOUND_PALATALISATION_CHANCE
+#undef JAPANESE_SOUND_NULL_INITIAL_CHANCE
+#undef JAPANESE_SOUND_NULL_FINAL_CHANCE
+#undef JAPANESE_SOUND_APOSTROPHE_CHANCE
+#undef JAPANESE_SOUND_GEMINATION_CHANCE_VOICED

--- a/code/modules/flufftext/Japanese.dm
+++ b/code/modules/flufftext/Japanese.dm
@@ -1,17 +1,17 @@
 ///How likely the nucleus (vowel) is to geminate ie a -> aa
-#define JAPANESE_SOUND_GEMINATION_CHANCE_NUCLEUS		15
+#define JAPANESE_SOUND_GEMINATION_CHANCE_NUCLEUS		10
 ///How likely the initial (consonant) is to geminate ie k -> kk
-#define JAPANESE_SOUND_GEMINATION_CHANCE_INITIAL		7.5
+#define JAPANESE_SOUND_GEMINATION_CHANCE_INITIAL		5
 ///How likely the consonant is to palatalise ie r -> ry
 #define JAPANESE_SOUND_PALATALISATION_CHANCE			10
 ///How likely the syllable is not to have a consonant at the start, needs to be kinda high for convincing diphthongs
 #define JAPANESE_SOUND_NULL_INITIAL_CHANCE				20
 ///How likely the syllable is to end in an N
-#define JAPANESE_SOUND_NULL_FINAL_CHANCE				45
+#define JAPANESE_SOUND_N_FINAL_CHANCE					20
 ///How likely it is to insert an apostrophe between two syllables (this can happen anywhere, mainly used for morpheme boundaries.)
 #define JAPANESE_SOUND_APOSTROPHE_CHANCE				30
 ///how likely voiced sounds are to geminate, these mainly occur in foreign loans so quite unlikely
-#define JAPANESE_SOUND_GEMINATION_CHANCE_VOICED			10
+#define JAPANESE_SOUND_GEMINATION_CHANCE_VOICED			20
 
 /*
 Hello and welcome to the Japanese language. Or rather, a random generator for it.
@@ -56,7 +56,7 @@ Full of snowflake checks and maybe even hard dels (but hopefully not). You're su
 	else
 		null_initial = TRUE
 	syllable += "[nucleus.sound]"
-	if(!(prob(JAPANESE_SOUND_NULL_FINAL_CHANCE)))
+	if(prob(JAPANESE_SOUND_N_FINAL_CHANCE))
 		syllable += "[final.sound]"
 		null_final = FALSE
 	else
@@ -112,12 +112,23 @@ Full of snowflake checks and maybe even hard dels (but hopefully not). You're su
 	var/forced_to_palatalise = FALSE //if it HAS to palatalise before an I. Applies to t, d, s and z. This lets it bypass anti-palatalise rules on I but not e.
 
 /datum/japanese_sound/initial/proc/palatalise(var/datum/japanese_sound/nucleus/nucleus)
-	if(nucleus.anti_palatalise && !forced_to_palatalise)
+	if(forced_to_palatalise && nucleus.forces_palatalisation) //is the sound forced to palatalise and is the nucleus i? then palatalise
+		if(sound == geminated_form)
+			sound = palatalised_geminated_form
+			return
+		else
+			sound = palatalised_form
+			return
+
+	else if(nucleus.anti_palatalise) //if the nucleus is e or i and the sound is NOT forced to palatalise, return a nope
 		return
-	if(sound == geminated_form && !palatalised_forbidden)
+
+	if(sound == geminated_form && !palatalised_forbidden) //now actually palatalise
 		sound = palatalised_geminated_form
+		return
 	else if(!palatalised_forbidden)
 		sound = palatalised_form
+		return
 
 /datum/japanese_sound/initial/proc/affricate(var/datum/japanese_sound/nucleus/nucleus)
 	if(affricated_form && nucleus.causes_affrication)
@@ -248,6 +259,6 @@ Full of snowflake checks and maybe even hard dels (but hopefully not). You're su
 #undef JAPANESE_SOUND_GEMINATION_CHANCE_NUCLEUS
 #undef JAPANESE_SOUND_PALATALISATION_CHANCE
 #undef JAPANESE_SOUND_NULL_INITIAL_CHANCE
-#undef JAPANESE_SOUND_NULL_FINAL_CHANCE
+#undef JAPANESE_SOUND_N_FINAL_CHANCE
 #undef JAPANESE_SOUND_APOSTROPHE_CHANCE
 #undef JAPANESE_SOUND_GEMINATION_CHANCE_VOICED

--- a/code/modules/gear_presets/clf.dm
+++ b/code/modules/gear_presets/clf.dm
@@ -13,10 +13,14 @@
 /datum/equipment_preset/clf/load_name(mob/living/carbon/human/H, var/randomise)
 	H.gender = pick(60;MALE, 40;FEMALE)
 	var/random_name
-	if(H.gender == MALE)
-		random_name = "[pick(first_names_male_clf)] [pick(last_names_clf)]"
+	if(prob(50))
+		if(H.gender == MALE)
+			if(prob(50))
+				random_name = "[pick(first_names_male_clf)] [pick(last_names_clf)]"
+		else
+			random_name = "[pick(first_names_female_clf)] [pick(last_names_clf)]"
 	else
-		random_name = "[pick(first_names_female_clf)] [pick(last_names_clf)]"
+		random_name = "[capitalize(randomly_generate_japanese_word(rand(1, 4)))] [capitalize(randomly_generate_japanese_word(rand(1, 4)))]"
 	H.change_real_name(H, random_name)
 	H.age = rand(17,45)
 	H.r_hair = 25

--- a/code/modules/mob/language/language.dm
+++ b/code/modules/mob/language/language.dm
@@ -102,4 +102,39 @@
 
 	return scrambled_text
 
+/datum/language/japanese/scramble(input)
+	// If the input is cached already, move it to the end of the cache and return it
+	var/lookup = check_cache(input)
+	if(lookup)
+		return lookup
+
+	var/input_size = length_char(input)
+	var/scrambled_text = ""
+	var/capitalize = TRUE
+
+	while(length_char(scrambled_text) < input_size)
+		var/next = randomly_generate_japanese_word()
+		if(capitalize)
+			next = capitalize(next)
+			capitalize = FALSE
+		scrambled_text += next
+		var/chance = rand(100)
+		if(chance <= sentence_chance)
+			scrambled_text += ". "
+			capitalize = TRUE
+		else if(chance > sentence_chance && chance <= space_chance)
+			scrambled_text += " "
+
+	scrambled_text = trim(scrambled_text)
+	var/ending = copytext_char(scrambled_text, -1)
+	if(ending == ".")
+		scrambled_text = copytext_char(scrambled_text, 1, -2)
+	var/input_ending = copytext_char(input, -1)
+	if(input_ending in list("!","?","."))
+		scrambled_text += input_ending
+
+	add_to_cache(input, scrambled_text)
+
+	return scrambled_text
+
 #undef SCRAMBLE_CACHE_LEN

--- a/code/modules/mob/language/languages.dm
+++ b/code/modules/mob/language/languages.dm
@@ -22,8 +22,7 @@
 	speech_verb = "vocalizes"
 	colour = "japanese"
 	key = "2"
-
-	syllables = list("ka", "ki", "ku", "ke", "ko", "ta", "chi", "tsu", "te", "to", "sa", "shi", "su", "se", "so", "na", "ni", "nu", "ne", "no", "n", "ha", "hi", "fu", "he", "ho", "ma", "mi", "mu", "me", "mo", "ya", "yu", "yo", "ra", "ri", "ru", "re", "ro", "wa", "wo")
+	space_chance = 100 //uses a unique system
 
 /datum/language/russian
 	name = LANGUAGE_RUSSIAN
@@ -185,7 +184,7 @@
 
 /datum/language/event_hivemind
 	name = LANGUAGE_TELEPATH
-	desc = "An event only language that provides a hivemind for it's users."
+	desc = "An event only language that provides a hivemind for its users."
 	speech_verb = "resonates"
 	ask_verb = "resonates"
 	exclaim_verb = "resonates"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

![image](https://user-images.githubusercontent.com/66756236/167313827-0a35a07f-1727-4247-8fdc-988a3078d4a2.png)

Rejoice, weebs of CM. Your favourite PR is finally here.

This PR fully overhauls the generation of Japanese language text in the game, making it 100% phonetically legal under Japanese sound rules and making it look natural and nice. Also adds it to CLF names, because why not. 

This code allows convincing-looking Japanese language text to be generated anywhere on demand!

Warning : I made all this code myself, no ports or anything.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

MY IMMERSION

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Japanese-language text will now sound much more Japanese, as the entire system of generating it was reworked to make it consistent 100% with real Japanese.
add: added a 50% chance for CLF characters to get a randomly generated Japanese name.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
