### PR TITLE
Fixes DD leader blinding themselves with their own EMP grenades

### DIFF
--- a/code/modules/clothing/glasses/thermal.dm
+++ b/code/modules/clothing/glasses/thermal.dm
@@ -14,19 +14,22 @@
 	eye_protection = -1
 	deactive_state = "goggles_off"
 	fullscreen_vision = /obj/screen/fullscreen/thermal
+	var/blinds_on_emp = TRUE
 
 /obj/item/clothing/glasses/thermal/emp_act(severity)
-	if(istype(src.loc, /mob/living/carbon/human))
-		var/mob/living/carbon/human/M = src.loc
-		to_chat(M, SPAN_WARNING("The Optical Thermal Scanner overloads and blinds you!"))
-		if(M.glasses == src)
-			M.eye_blind = 3
-			M.eye_blurry = 5
-			if(!(M.disabilities & NEARSIGHTED))
-				M.disabilities |= NEARSIGHTED
-				spawn(100)
-					M.disabilities &= ~NEARSIGHTED
+	if(blinds_on_emp)
+		if(istype(src.loc, /mob/living/carbon/human))
+			var/mob/living/carbon/human/M = src.loc
+			to_chat(M, SPAN_WARNING("The Optical Thermal Scanner overloads and blinds you!"))
+			if(M.glasses == src)
+				M.eye_blind = 3
+				M.eye_blurry = 5
+				if(!(M.disabilities & NEARSIGHTED))
+					M.disabilities |= NEARSIGHTED
+					spawn(100)
+						M.disabilities &= ~NEARSIGHTED
 	..()
+		
 
 /obj/item/clothing/glasses/thermal/syndi	//These are now a traitor item, concealed as mesons.	-Pete
 	name = "Optical Meson Scanner"
@@ -68,3 +71,7 @@
 	flags_inventory = COVEREYES
 	flags_item = NODROP|DELONDROP
 	toggleable = FALSE
+
+/obj/item/clothing/glasses/thermal/empproof
+	desc = "Thermals in the shape of glasses. This one is EMP proof."
+	blinds_on_emp = FALSE

--- a/code/modules/gear_presets/fun.dm
+++ b/code/modules/gear_presets/fun.dm
@@ -251,7 +251,7 @@
 /datum/equipment_preset/fun/dutch/arnie/load_gear(mob/living/carbon/human/H)
 	H.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/marine/veteran/dutch/cap(H), WEAR_HEAD)
 	H.equip_to_slot_or_del(new /obj/item/device/radio/headset/distress/dutch(H), WEAR_L_EAR)
-	H.equip_to_slot_or_del(new /obj/item/clothing/glasses/thermal(H), WEAR_EYES)
+	H.equip_to_slot_or_del(new /obj/item/clothing/glasses/thermal/empproof(H), WEAR_EYES)
 	H.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/yautja/hunter(H), WEAR_FACE)
 	H.equip_to_slot_or_del(new /obj/item/clothing/under/marine/veteran/dutch(H), WEAR_BODY)
 	H.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/marine/veteran/dutch(H), WEAR_JACKET)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Fixes DD leader's EMP grenades blinding the user. See #256.
This PR fixes the above by adding a new, EMP-proof subtype, given to the DD leader in place of the traditional ones.
See previous PR, #257, for councilor's comments.
Massive thanks to Geeves for his support in making this PR and teaching me how to deal with spaghetti code.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
DD leader really should not be discord light mode'd by their own EMP grenades, this was backed by a Yautja councilor.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Dutch's Dozen leader thermals are now EMP proof. They will no longer blind themselves with their own grenades.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

