### PR TITLE
Sandbag Autofill

### DIFF
--- a/code/game/objects/items/tools/shovel_tools.dm
+++ b/code/game/objects/items/tools/shovel_tools.dm
@@ -68,6 +68,7 @@
 
 	if(user.action_busy)
 		return
+
 	if(!dirt_amt)
 		var/turf/T = target
 		var/turfdirt = T.get_dirt_type()
@@ -93,30 +94,35 @@
 			dirt_amt = transfer_amount
 			dirt_type = turfdirt
 			update_icon()
-			/*
-			var/digmore = FALSE
-			while(dirt_amt > 0)
 
+			var/digmore = FALSE
+			to_chat(user, SPAN_NOTICE("You begin filling the sandbags."))
+			if(!do_after(user, shovelspeed / 2, INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD)) // Sandbag filling speed faster than normal, no skillchecks required since filling bags is almost instant
+				to_chat(user, SPAN_NOTICE("You stop filling the sandbags."))
+				return
+
+			while(dirt_amt > 0)
 				var/obj/item/stack/sandbags_empty/SB = user.get_inactive_hand()
-				if(istype(SB))
-				else
+				if(!istype(SB, /obj/item/stack/sandbags_empty)) // If no sandbag in off hand, checks around the user
 					for(var/obj/item/stack/sandbags_empty/sandbags in range(1, user))
 						SB = sandbags
 						break
-				if(!SB)
+
+				if(!istype(SB, /obj/item/stack/sandbags_empty)) // Checks sandbag a second time to confirm, if none are found, cancels everything
+					to_chat(user, SPAN_NOTICE("There are no sandbags nearby to fill up."))
 					break
-				to_chat(user, SPAN_NOTICE("You begin filling \a [SB.name]."))
-				if(!do_after(user, shovelspeed * user.get_skill_duration_multiplier(SKILL_CONSTRUCTION), INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD))
-					to_chat(user, SPAN_NOTICE("You stop filling \a [SB.name]."))
-					return
-				while(dirt_amt > 0 && SB.amount > 0 && get_dist(user, SB) <= 1) // We can't be too sure that they aren't pulling something funny
+
+				if(get_dist(user, SB) > 1)
+					break
+
+				while(SB.amount > 0)
 					SB.attackby(src, user)
-				if(dirt_amt == 0)
-					digmore = TRUE
+					if(dirt_amt == 0)
+						digmore = TRUE
+						break
 			if(digmore)
 				afterattack(target, user, proximity)
 // auto repeat ends
-*/
 
 	else
 		dump_shovel(target, user)

--- a/code/game/objects/items/tools/shovel_tools.dm
+++ b/code/game/objects/items/tools/shovel_tools.dm
@@ -118,6 +118,10 @@
 				if(get_dist(user, SB) > 1) // check if sandbag still beside them
 					break
 
+				if(SB.amount < 0) // check if sandbag is used by someone else
+					SB = null
+					continue
+
 				var/dirttransfer_amount = min(SB.amount, dirt_amt)
 				dirt_amt -= dirttransfer_amount
 				update_icon()

--- a/code/game/objects/items/tools/shovel_tools.dm
+++ b/code/game/objects/items/tools/shovel_tools.dm
@@ -128,11 +128,10 @@
 				var/obj/item/stack/sandbags/new_bags = new(user.loc)
 				new_bags.amount = dirttransfer_amount
 				new_bags.add_to_stacks(user)
-				var/obj/item/stack/sandbags_empty/E = SB
-				var/replace = (user.get_inactive_hand() == E)
+				var/replace = (user.get_inactive_hand() == SB)
 				playsound(user.loc, "rustle", 30, 1, 6)
-				E.use(dirttransfer_amount)
-				if(!E && replace)
+				SB.use(dirttransfer_amount)
+				if(!SB && replace)
 					user.put_in_hands(new_bags)
 
 				if(dirt_amt <= 0) // Ends the loop when no dirt is left


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Fixed and readjusted the sandbag autofill, it reportedly crashed the server and was commented out. After testing the issue I found was it wasn't looking to check if the object in the offhand was a sandbag

Also added the filling time faster and to empty the dirt in the shovel before digging dirt again

Test on the local server

https://streamable.com/q8gig0

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Makes digging for sandbag more tolerable

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: Fixed and re-enabled sandbag autofilling, it will no longer crash the server.
:cl:

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->



<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
