### PR TITLE
Scout goggles improvement

### DIFF
--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -236,11 +236,11 @@
 
 /obj/item/clothing/glasses/m42_goggles
 	name = "\improper M42 scout sight"
-	desc = "A headset and goggles system for the M42 Scout Rifle. Allows highlighted imaging of surroundings. Click it to toggle."
+	desc = "A headset and goggles system for the M42 Scout Rifle. Allows highlighted imaging of surroundings, as well as detection of thermal signatures even from a great distance. Click it to toggle."
 	icon = 'icons/obj/items/clothing/glasses.dmi'
 	icon_state = "m56_goggles"
 	deactive_state = "m56_goggles_0"
-	vision_flags = SEE_TURFS
+	vision_flags = SEE_TURFS|SEE_MOBS
 	toggleable = 1
 	actions_types = list(/datum/action/item_action/toggle)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Scouts can now see mobs through walls

## Why It's Good For The Game

Scouts can now gain more battlefield information and relay it to their team, like the name "scout" implies

## Changelog



:cl:
add: Scout specialists can now see through walls with their sights
code: changed some code regarding how Scout specialist's sights work, along with description
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
