### PR TITLE
Fix RTO Bag with other uniforms

### DIFF
--- a/code/modules/clothing/under/marine_uniform.dm
+++ b/code/modules/clothing/under/marine_uniform.dm
@@ -69,6 +69,11 @@
 	item_state = "marine_rto"
 	specialty = "marine Radio Telephone Operator"
 
+/obj/item/clothing/under/marine/rto/unequipped(mob/user, slot)
+	. = ..()
+	if(istype(user.back, /obj/item/storage/backpack/marine/satchel/rto))
+		user.drop_inv_item_on_ground(user.back)
+
 /obj/item/clothing/under/marine/sniper
 	name = "\improper USCM sniper uniform"
 	flags_jumpsuit = FALSE


### PR DESCRIPTION
## About The Pull Request
The RTO Bag has an uniform restriction but you can wear it with any other kind of uniform because wont unequip when you strip.

## Why It's Good For The Game
Fix's a bug with this bag

## Changelog

:cl:
fix: Now you drop the RTO Bag when you strip the RTO uniform
/:cl:
