### PR TITLE
CAS deployed sentry description update

### DIFF
--- a/code/modules/defenses/sentry.dm
+++ b/code/modules/defenses/sentry.dm
@@ -516,7 +516,7 @@ obj/structure/machinery/defenses/sentry/premade/damaged_action()
 
 /obj/structure/machinery/defenses/sentry/launchable
 	name = "\improper UA 571-O sentry post"
-	desc = "A deployable, omni-directional automated turret with AI targeting capabilities. Armed with an M30 Autocannon and a 1500-round drum magazine."
+	desc = "A deployable, omni-directional automated turret with AI targeting capabilities. Armed with an M30 Autocannon and a 1500-round drum magazine.  Due to the deployment method it is incapable of being moved."
 	ammo = new /obj/item/ammo_magazine/sentry/dropped
 	faction_group = FACTION_LIST_MARINE
 	luminosity = 5


### PR DESCRIPTION
## About The Pull Request

Changes the description of CAS deployed sentries from

"A deployable, omni-directional automated turret with AI targeting capabilities. Armed with an M30 Autocannon and a 1500-round drum magazine."

to

"A deployable, omni-directional automated turret with AI targeting capabilities. Armed with an M30 Autocannon and a 1500-round drum magazine.  Due to the deployment method it is incapable of being moved."

## Why It's Good For The Game

There was some confusion as to why a turret wasn't able to be moved by a few engineers and this should prevent that confusion in the future.

## Changelog

:cl: Morrow
add: Slight change to CAS deployed turrets description.
/:cl:
