### PR TITLE
Lifeboat Survival Cabinet

### DIFF
--- a/ColonialMarinesALPHA.dme
+++ b/ColonialMarinesALPHA.dme
@@ -749,6 +749,7 @@
 #include "code\game\machinery\vending\vendor_types\general.dm"
 #include "code\game\machinery\vending\vendor_types\medical.dm"
 #include "code\game\machinery\vending\vendor_types\requisitions.dm"
+#include "code\game\machinery\vending\vendor_types\supplies.dm"
 #include "code\game\machinery\vending\vendor_types\wo_vendors.dm"
 #include "code\game\machinery\vending\vendor_types\antag\antag_clothing.dm"
 #include "code\game\machinery\vending\vendor_types\antag\antag_gear.dm"

--- a/maps/shuttles/lifeboat-port.dmm
+++ b/maps/shuttles/lifeboat-port.dmm
@@ -77,7 +77,7 @@
 /area/shuttle/lifeboat)
 "jX" = (
 /obj/structure/extinguisher_cabinet/lifeboat{
-	pixel_x = 11;
+	pixel_x = 8;
 	pixel_y = 27
 	},
 /turf/open/shuttle/lifeboat,
@@ -153,6 +153,13 @@
 	icon_state = "7,0"
 	},
 /area/shuttle/lifeboat)
+"vd" = (
+/obj/structure/extinguisher_cabinet/lifeboat{
+	pixel_x = 15;
+	pixel_y = 27
+	},
+/turf/open/shuttle/lifeboat,
+/area/shuttle/lifeboat)
 "vx" = (
 /turf/closed/shuttle/lifeboat{
 	icon_state = "0,3"
@@ -178,6 +185,13 @@
 /turf/closed/shuttle/lifeboat{
 	icon_state = "0,0"
 	},
+/area/shuttle/lifeboat)
+"yf" = (
+/obj/structure/machinery/cm_vending/sorted/supplies/lifeboat{
+	pixel_x = -12;
+	pixel_y = 27
+	},
+/turf/open/shuttle/lifeboat,
 /area/shuttle/lifeboat)
 "yE" = (
 /turf/closed/shuttle/lifeboat{
@@ -243,7 +257,11 @@
 /area/shuttle/lifeboat)
 "FZ" = (
 /obj/structure/machinery/cm_vending/sorted/medical/wall_med/lifeboat{
-	pixel_x = -9;
+	pixel_x = -5;
+	pixel_y = 27
+	},
+/obj/structure/machinery/cm_vending/sorted/supplies/lifeboat{
+	pixel_x = 10;
 	pixel_y = 27
 	},
 /turf/open/shuttle/lifeboat,
@@ -494,7 +512,7 @@ vZ
 (8,1,1) = {"
 mB
 PU
-Ro
+yf
 nn
 Ro
 OX
@@ -575,7 +593,7 @@ fr
 (17,1,1) = {"
 Rs
 Id
-jX
+vd
 nn
 Ro
 iR

--- a/maps/shuttles/lifeboat-starboard.dmm
+++ b/maps/shuttles/lifeboat-starboard.dmm
@@ -53,7 +53,11 @@
 /area/shuttle/lifeboat)
 "hD" = (
 /obj/structure/machinery/cm_vending/sorted/medical/wall_med/lifeboat{
-	pixel_x = -9;
+	pixel_x = -5;
+	pixel_y = 27
+	},
+/obj/structure/machinery/cm_vending/sorted/supplies/lifeboat{
+	pixel_x = 10;
 	pixel_y = 27
 	},
 /turf/open/shuttle/lifeboat,
@@ -65,7 +69,7 @@
 /area/shuttle/lifeboat)
 "ix" = (
 /obj/structure/extinguisher_cabinet/lifeboat{
-	pixel_x = 11;
+	pixel_x = 8;
 	pixel_y = 27
 	},
 /turf/open/shuttle/lifeboat,
@@ -258,6 +262,13 @@
 	icon_state = "3,1"
 	},
 /area/shuttle/lifeboat)
+"GQ" = (
+/obj/structure/machinery/cm_vending/sorted/supplies/lifeboat{
+	pixel_x = -12;
+	pixel_y = 27
+	},
+/turf/open/shuttle/lifeboat,
+/area/shuttle/lifeboat)
 "HW" = (
 /turf/closed/shuttle/lifeboat{
 	icon_state = "2,1"
@@ -302,6 +313,13 @@
 /turf/closed/shuttle/lifeboat{
 	icon_state = "2,4"
 	},
+/area/shuttle/lifeboat)
+"NO" = (
+/obj/structure/extinguisher_cabinet/lifeboat{
+	pixel_x = 15;
+	pixel_y = 27
+	},
+/turf/open/shuttle/lifeboat,
 /area/shuttle/lifeboat)
 "Od" = (
 /turf/closed/shuttle/lifeboat{
@@ -481,7 +499,7 @@ Ow
 (8,1,1) = {"
 GA
 Td
-OO
+GQ
 XV
 OO
 GD
@@ -562,7 +580,7 @@ OO
 (17,1,1) = {"
 em
 kC
-ix
+NO
 XV
 OO
 zK


### PR DESCRIPTION
## About The Pull Request

This is another lifeboat udpate, shouldn't have merge conflict with the other once cause of sdmm

It adds the survival cabinet full of food, water and more importantly booze into the lifeboat, that was in the orginial MR

![StrongDMM_lVy0HgJaaw](https://user-images.githubusercontent.com/43085828/167993027-110a1d51-3999-4cb3-9099-cad6561ef8d5.png)


## Changelog

:cl:
add: Added a survival cabinet to the Lifeboats.
/:cl:
