### PR TITLE
Ghosts can look at a paper bundle's current page

### DIFF
--- a/code/modules/paperwork/paper_bundle.dm
+++ b/code/modules/paperwork/paper_bundle.dm
@@ -79,7 +79,7 @@
 
 /obj/item/paper_bundle/examine(mob/user)
 	to_chat(usr, desc)
-	if(in_range(user, src) || istype(user, /mob/dead/observer))
+	if(in_range(user, src) || isobserver(user))
 		src.attack_self(user)
 	else
 		to_chat(user, SPAN_NOTICE("It is too far away."))
@@ -87,7 +87,7 @@
 /obj/item/paper_bundle/attack_self(mob/user)
 	..()
 
-	if(!(ishuman(user) || istype(user, /mob/dead/observer)))
+	if(!(ishuman(user) || isobserver(user)))
 		return
 
 	var/mob/living/carbon/human/human_user = user
@@ -170,7 +170,7 @@
 
 		src.attack_self(src.loc)
 		updateUsrDialog()
-	else if(istype(usr, /mob/dead/observer))
+	else if(isobserver(usr))
 		to_chat(usr, SPAN_NOTICE("Ghosts don't have hands, you can't flip the page!"))
 	else
 		to_chat(usr, SPAN_NOTICE("You need to hold it in your hands!"))

--- a/code/modules/paperwork/paper_bundle.dm
+++ b/code/modules/paperwork/paper_bundle.dm
@@ -79,7 +79,7 @@
 
 /obj/item/paper_bundle/examine(mob/user)
 	to_chat(usr, desc)
-	if(in_range(user, src))
+	if(in_range(user, src) || istype(user, /mob/dead/observer))
 		src.attack_self(user)
 	else
 		to_chat(user, SPAN_NOTICE("It is too far away."))
@@ -171,7 +171,10 @@
 		src.attack_self(src.loc)
 		updateUsrDialog()
 	else
-		to_chat(usr, SPAN_NOTICE("You need to hold it in hands!"))
+		if(istype(usr, /mob/dead/observer))
+			to_chat(usr, SPAN_NOTICE("Ghosts don't have hands, you can't flip the page!"))
+		else
+		    to_chat(usr, SPAN_NOTICE("You need to hold it in your hands!"))
 
 /obj/item/paper_bundle/verb/rename()
 	set name = "Rename bundle"

--- a/code/modules/paperwork/paper_bundle.dm
+++ b/code/modules/paperwork/paper_bundle.dm
@@ -170,11 +170,10 @@
 
 		src.attack_self(src.loc)
 		updateUsrDialog()
+	else if(istype(usr, /mob/dead/observer))
+		to_chat(usr, SPAN_NOTICE("Ghosts don't have hands, you can't flip the page!"))
 	else
-		if(istype(usr, /mob/dead/observer))
-			to_chat(usr, SPAN_NOTICE("Ghosts don't have hands, you can't flip the page!"))
-		else
-		    to_chat(usr, SPAN_NOTICE("You need to hold it in your hands!"))
+		to_chat(usr, SPAN_NOTICE("You need to hold it in your hands!"))
 
 /obj/item/paper_bundle/verb/rename()
 	set name = "Rename bundle"

--- a/code/modules/paperwork/paper_bundle.dm
+++ b/code/modules/paperwork/paper_bundle.dm
@@ -87,7 +87,7 @@
 /obj/item/paper_bundle/attack_self(mob/user)
 	..()
 
-	if(!ishuman(user))
+	if(!(ishuman(user) || istype(user, /mob/dead/observer)))
 		return
 
 	var/mob/living/carbon/human/human_user = user


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Small QoL fix picked up from #ideas_guys, just shows ghosts the current page in a paper stack.

## Why It's Good For The Game

Ghosts wanna see what page people are looking at in a bundle

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Observers can now look at the current page of a paper bundle.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
