### PR TITLE
Gives admins the ability to modify requisitions points

### DIFF
--- a/code/modules/admin/tabs/event_tab.dm
+++ b/code/modules/admin/tabs/event_tab.dm
@@ -289,12 +289,17 @@
 	var/points_to_add = input(usr, "Enter the amount of points to give, or a negative number to subtract. 1 point = $100.", "Points", 0) as num
 	if(points_to_add == 0)
 		return
+	else if((supply_controller.points + points_to_add) < 0)
+		supply_controller.points = 0
+	else if((supply_controller.points + points_to_add) > 99999)
+		supply_controller.points = 99999
 	else
 		supply_controller.points += points_to_add
 
-		message_staff("[key_name_admin(usr)] granted requisitions [points_to_add] points.")
-		if(points_to_add >= 0)
-			shipwide_ai_announcement("Additional Supply Budget has been authorised for this operation.")
+
+	message_staff("[key_name_admin(usr)] granted requisitions [points_to_add] points.")
+	if(points_to_add >= 0)
+		shipwide_ai_announcement("Additional Supply Budget has been authorised for this operation.")
 
 /datum/admins/proc/admin_force_selfdestruct()
 	set name = "Self Destruct"

--- a/code/modules/admin/tabs/event_tab.dm
+++ b/code/modules/admin/tabs/event_tab.dm
@@ -286,7 +286,7 @@
 	if(!SSticker.mode || !check_rights(R_ADMIN))
 		return
 
-	var points_to_add = input(usr, "Enter the amount of points to give, or a negative number to subtract. 1 point = $100.", "Points", 0) as num
+	var/points_to_add = input(usr, "Enter the amount of points to give, or a negative number to subtract. 1 point = $100.", "Points", 0) as num
 	if(points_to_add == 0)
 		return
 	else

--- a/code/modules/admin/tabs/event_tab.dm
+++ b/code/modules/admin/tabs/event_tab.dm
@@ -269,7 +269,6 @@
 	set name = "Disable Shuttle Console"
 	set desc = "Prevents a shuttle control console from being accessed."
 	set category = "Admin.Events"
-
 	if(!SSticker.mode || !check_rights(R_ADMIN))
 		return
 
@@ -280,6 +279,20 @@
 
 	message_staff("[key_name_admin(usr)] set [input]'s disabled to [input.disabled].")
 
+/datum/admins/proc/add_req_points()
+	set name = "Add Requisitions Points"
+	set desc = "Add points to the ship requisitions department."
+	set category = "Admin.Events"
+	if(!SSticker.mode || !check_rights(R_ADMIN))
+		return
+
+	var points_to_add = input(usr, "Enter the amount of points to give, or a negative number to subtract. 1 point = $100.", "Points", 0) as num
+	if(points_to_add == 0)
+		return
+	else
+		supply_controller.points += points_to_add
+
+		message_staff("[key_name_admin(usr)] granted requisitions [points_to_add] points.")
 
 /datum/admins/proc/admin_force_selfdestruct()
 	set name = "Self Destruct"
@@ -622,6 +635,7 @@
 		<A href='?src=\ref[src];events=evacuation_start'>Trigger Evacuation</A><BR>
 		<A href='?src=\ref[src];events=evacuation_cancel'>Cancel Evacuation</A><BR>
 		<A href='?src=\ref[src];events=disable_shuttle_console'>Disable Shuttle Control</A><BR>
+		<A href='?src=\ref[src];events=add_req_points'>Add Requisitions Points</A><BR>
 		<BR>
 		<B>Research</B><BR>
 		<A href='?src=\ref[src];events=change_clearance'>Change Research Clearance</A><BR>

--- a/code/modules/admin/tabs/event_tab.dm
+++ b/code/modules/admin/tabs/event_tab.dm
@@ -293,6 +293,8 @@
 		supply_controller.points += points_to_add
 
 		message_staff("[key_name_admin(usr)] granted requisitions [points_to_add] points.")
+		if(points_to_add >= 0)
+			shipwide_ai_announcement("Additional Supply Budget has been authorised for this operation.")
 
 /datum/admins/proc/admin_force_selfdestruct()
 	set name = "Self Destruct"

--- a/code/modules/admin/topic/topic_events.dm
+++ b/code/modules/admin/topic/topic_events.dm
@@ -18,6 +18,8 @@
 			admin_cancel_evacuation()
 		if("disable_shuttle_console")
 			disable_shuttle_console()
+		if("add_req_points")
+			add_req_points()
 		if("medal")
 			owner.award_medal()
 		if("pmcguns")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Let's say, for example, a griefer rolled CT, ordered 500 boxes of crayons, and went to cryo. Now requisitions is bankrupt. Or maybe admins want to feel generous and reward the ship with something. How can admins do this? Well, as of now, they can just directly compensate by spawning in new stuff directly. But that ain't balanced, and the better solution is to give admins the ability to give requisitions points. That's what this PR intends to do.

The button is available for admins in the Event Panel, requiring Event panel permissions; and the rest is self-explanatory. Adding a positive value gives requisitions points and a negative value takes them away. When inputting points, note that 1 point is equal to $100 in the supply console. This is just for flavor.

![image](https://user-images.githubusercontent.com/55491249/168313685-1f19ad06-3b94-487d-b101-ec91bfe63684.png)

In addition, ARES will announce if admins have given points. It stays silent if points are subtracted; snitches get stitches.

## Why It's Good For The Game

Allows admins to give players req points so that nobody has to jump hoops and just allow them to gift requisitions with points directly.

## Changelog
:cl:
admin: Admins can now modify requisitions points via a button in the Event Panel.
/:cl:
