### PR TITLE
Robolimbs and order of operations.

### DIFF
--- a/code/datums/elements/suturing.dm
+++ b/code/datums/elements/suturing.dm
@@ -73,7 +73,7 @@ YOU TO 200 DAMAGE. I ASK NOT FOR MY OWN MEDIC EGOSTROKING, BUT FOR THE GOOD OF T
 	if(!target_limb || target_limb.status & LIMB_DESTROYED)
 		to_chat(user, SPAN_WARNING("[user == target ? "You have" : "\The [target] has"] no [target_limb.display_name]!"))
 		return
-	if(target_limb.status & LIMB_ROBOT|LIMB_SYNTHSKIN)
+	if(target_limb.status & (LIMB_ROBOT|LIMB_SYNTHSKIN))
 		to_chat(user, SPAN_WARNING("You can't repair a robotic limb with \the [suturing_item]!"))
 		return
 	if(target_limb.get_incision_depth())

--- a/code/game/machinery/autodoc.dm
+++ b/code/game/machinery/autodoc.dm
@@ -69,7 +69,7 @@
 	var/list/obj/limb/parts = human.get_damaged_limbs(brute,burn)
 	if(!parts.len)	return
 	var/obj/limb/picked = pick(parts)
-	if(picked.status & LIMB_ROBOT|LIMB_SYNTHSKIN)
+	if(picked.status & (LIMB_ROBOT|LIMB_SYNTHSKIN))
 		picked.heal_damage(brute, burn, TRUE)
 		human.pain.apply_pain(-brute, BRUTE)
 		human.pain.apply_pain(-burn, BURN)

--- a/code/game/objects/items/stacks/cable_coil.dm
+++ b/code/game/objects/items/stacks/cable_coil.dm
@@ -310,7 +310,7 @@
 		var/mob/living/carbon/human/H = M
 
 		var/obj/limb/S = H.get_limb(user.zone_selected)
-		if(!(S.status & LIMB_ROBOT|LIMB_SYNTHSKIN) || user.a_intent != INTENT_HELP)
+		if(!(S.status & (LIMB_ROBOT|LIMB_SYNTHSKIN)) || user.a_intent != INTENT_HELP)
 			return ..()
 
 		if(user.action_busy)

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -40,7 +40,7 @@
 			to_chat(user, SPAN_WARNING("You can't apply [src] through [H.wear_suit]!"))
 			return 1
 
-	if(affecting.status & LIMB_ROBOT|LIMB_SYNTHSKIN)
+	if(affecting.status & (LIMB_ROBOT|LIMB_SYNTHSKIN))
 		to_chat(user, SPAN_WARNING("This isn't useful at all on a robotic limb."))
 		return 1
 

--- a/code/game/objects/items/stacks/nanopaste.dm
+++ b/code/game/objects/items/stacks/nanopaste.dm
@@ -33,7 +33,7 @@
 			return
 		var/obj/limb/S = H.get_limb(user.zone_selected)
 
-		if (S && (S.status & LIMB_ROBOT|LIMB_SYNTHSKIN))
+		if (S && (S.status & (LIMB_ROBOT|LIMB_SYNTHSKIN)))
 			if(S.get_damage())
 				S.heal_damage(15, 15, robo_repair = 1)
 				H.pain.recalculate_pain()

--- a/code/game/objects/items/tools/maintenance_tools.dm
+++ b/code/game/objects/items/tools/maintenance_tools.dm
@@ -210,7 +210,7 @@
 		var/obj/limb/S = H.get_limb(user.zone_selected)
 
 		if (!S) return
-		if(!(S.status & LIMB_ROBOT|LIMB_SYNTHSKIN) || user.a_intent != INTENT_HELP)
+		if(!(S.status & (LIMB_ROBOT|LIMB_SYNTHSKIN)) || user.a_intent != INTENT_HELP)
 			return ..()
 
 		if(user.action_busy)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -232,7 +232,7 @@
 				is_destroyed["[temp.display_name]"] = 1
 				wound_flavor_text["[temp.display_name]"] = SPAN_WARNING("<b>[t_He] is missing [t_his] [temp.display_name].</b>\n")
 				continue
-			if(temp.status & LIMB_ROBOT|LIMB_SYNTHSKIN)
+			if(temp.status & (LIMB_ROBOT|LIMB_SYNTHSKIN))
 				if(!(temp.brute_dam + temp.burn_dam))
 					if(!(temp.status & LIMB_SYNTHSKIN) && !(species && species.flags & IS_SYNTHETIC))
 						wound_flavor_text["[temp.display_name]"] = SPAN_WARNING("[t_He] has a[temp.status & LIMB_UNCALIBRATED_PROSTHETIC ? " nonfunctional" : ""] robot [temp.display_name]!\n")

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -242,7 +242,7 @@
 		var/burndamage = org.burn_dam
 		if(org.status & LIMB_DESTROYED)
 			status += "MISSING!"
-		else if(org.status & LIMB_ROBOT|LIMB_SYNTHSKIN)
+		else if(org.status & (LIMB_ROBOT|LIMB_SYNTHSKIN))
 			switch(brutedamage)
 				if(1 to 20)
 					status += "dented"

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -78,14 +78,14 @@
 /mob/living/carbon/human/getBruteLoss(var/organic_only=0)
 	var/amount = 0
 	for(var/obj/limb/O in limbs)
-		if(!(organic_only && O.status & LIMB_ROBOT|LIMB_SYNTHSKIN))
+		if(!(organic_only && O.status & (LIMB_ROBOT|LIMB_SYNTHSKIN)))
 			amount += O.brute_dam
 	return amount
 
 /mob/living/carbon/human/getFireLoss(var/organic_only=0)
 	var/amount = 0
 	for(var/obj/limb/O in limbs)
-		if(!(organic_only && O.status & LIMB_ROBOT|LIMB_SYNTHSKIN))
+		if(!(organic_only && O.status & (LIMB_ROBOT|LIMB_SYNTHSKIN)))
 			amount += O.burn_dam
 	return amount
 
@@ -127,7 +127,7 @@
 				O.take_damage(amount, 0, sharp=is_sharp(damage_source), edge=has_edge(damage_source), used_weapon=damage_source)
 			else
 				//if you don't want to heal robot limbs, they you will have to check that yourself before using this proc.
-				O.heal_damage(-amount, 0, O.status & LIMB_ROBOT|LIMB_SYNTHSKIN)
+				O.heal_damage(-amount, 0, O.status & (LIMB_ROBOT|LIMB_SYNTHSKIN))
 			break
 
 
@@ -145,7 +145,7 @@
 				O.take_damage(0, amount, sharp=is_sharp(damage_source), edge=has_edge(damage_source), used_weapon=damage_source)
 			else
 				//if you don't want to heal robot limbs, they you will have to check that yourself before using this proc.
-				O.heal_damage(0, -amount, O.status & LIMB_ROBOT|LIMB_SYNTHSKIN)
+				O.heal_damage(0, -amount, O.status & (LIMB_ROBOT|LIMB_SYNTHSKIN))
 			break
 
 

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -22,7 +22,7 @@ Contains most of the procs that are called when a mob is attacked by something
 				msg_admin_attack("[key_name(src)] was disarmed by a stun effect in [get_area(src)] ([src.loc.x],[src.loc.y],[src.loc.z]).", src.loc.x, src.loc.y, src.loc.z)
 
 				drop_inv_item_on_ground(c_hand)
-				if (affected.status & LIMB_ROBOT|LIMB_SYNTHSKIN)
+				if (affected.status & (LIMB_ROBOT|LIMB_SYNTHSKIN))
 					emote("me", 1, "drops what they were holding, their [affected.display_name] malfunctioning!")
 				else
 					var/emote_scream = pick("screams in pain and", "lets out a sharp cry and", "cries out and")

--- a/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
@@ -549,7 +549,7 @@
 	if(L.status & LIMB_DESTROYED)
 		return FALSE
 
-	if(L.status & LIMB_ROBOT|LIMB_SYNTHSKIN)
+	if(L.status & (LIMB_ROBOT|LIMB_SYNTHSKIN))
 		L.take_damage(rand(30,40), 0, 0) // just do more damage
 		visible_message(SPAN_XENOWARNING("You hear [M]'s [L.display_name] being pulled beyond its load limits!"), \
 		SPAN_XENOWARNING("[M]'s [L.display_name] begins to tear apart!"))

--- a/code/modules/mob/living/carbon/xenomorph/abilities/warrior/warrior_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/warrior/warrior_powers.dm
@@ -182,7 +182,7 @@
 			H.Slow(3)
 		if(isYautja(H))
 			damage = rand(base_punch_damage_pred, base_punch_damage_pred + damage_variance)
-		else if(L.status & LIMB_ROBOT|LIMB_SYNTHSKIN)
+		else if(L.status & (LIMB_ROBOT|LIMB_SYNTHSKIN))
 			damage = rand(base_punch_damage_synth, base_punch_damage_synth + damage_variance)
 
 
@@ -199,7 +199,7 @@
 	if(ishuman(H))
 		if(isYautja(H))
 			damage = rand(boxer_punch_damage_pred, boxer_punch_damage_pred + damage_variance)
-		else if(L.status & LIMB_ROBOT|LIMB_SYNTHSKIN)
+		else if(L.status & (LIMB_ROBOT|LIMB_SYNTHSKIN))
 			damage = rand(boxer_punch_damage_synth, boxer_punch_damage_synth + damage_variance)
 
 	H.apply_armoured_damage(get_xeno_damage_slash(H, damage), ARMOR_MELEE, BRUTE, L? L.name : "chest")

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -820,7 +820,7 @@ mob/proc/yank_out_object()
 		affected.take_damage((selection.w_class * 3), 0, 0, 1, "Embedded object extraction")
 		H.pain.apply_pain(selection.w_class * 3)
 
-		if(prob(selection.w_class * 5) && !(affected.status & LIMB_ROBOT|LIMB_SYNTHSKIN))
+		if(prob(selection.w_class * 5) && !(affected.status & (LIMB_ROBOT|LIMB_SYNTHSKIN)))
 			var/datum/wound/internal_bleeding/I = new (0)
 			affected.add_bleeding(I, TRUE)
 			affected.wounds += I

--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -166,7 +166,7 @@
 */
 
 /obj/limb/emp_act(severity)
-	if(!(status & LIMB_ROBOT|LIMB_SYNTHSKIN))	//meatbags do not care about EMP
+	if(!(status & (LIMB_ROBOT|LIMB_SYNTHSKIN)))	//meatbags do not care about EMP
 		return
 	var/probability = 30
 	var/damage = 15
@@ -288,7 +288,7 @@
 	if(!is_ff && take_damage_organ_damage(brute, sharp))
 		brute /= 2
 
-	if(CONFIG_GET(flag/bones_can_break) && !(status & LIMB_ROBOT|LIMB_SYNTHSKIN))
+	if(CONFIG_GET(flag/bones_can_break) && !(status & (LIMB_ROBOT|LIMB_SYNTHSKIN)))
 		take_damage_bone_break(brute)
 
 	if(status & LIMB_BROKEN && prob(40) && brute > 10)
@@ -297,7 +297,7 @@
 	if(used_weapon)
 		add_autopsy_data("[used_weapon]", brute + burn)
 
-	var/can_cut = (prob(brute*2) || sharp) && !(status & LIMB_ROBOT|LIMB_SYNTHSKIN)
+	var/can_cut = (prob(brute*2) || sharp) && !(status & (LIMB_ROBOT|LIMB_SYNTHSKIN))
 	// If the limbs can break, make sure we don't exceed the maximum damage a limb can take before breaking
 	if((brute_dam + burn_dam + brute + burn) < max_damage || !CONFIG_GET(flag/limbs_can_break))
 		if(brute)
@@ -376,7 +376,7 @@
 	start_processing()
 
 /obj/limb/proc/heal_damage(brute, burn, robo_repair = FALSE)
-	if(status & LIMB_ROBOT|LIMB_SYNTHSKIN && !robo_repair)
+	if(status & (LIMB_ROBOT|LIMB_SYNTHSKIN) && !robo_repair)
 		return
 
 	//Heal damage on the individual wounds
@@ -462,7 +462,7 @@ This function completely restores a damaged organ to perfect condition.
 
 	//moved this before the open_wound check so that having many small wounds for example doesn't somehow protect you from taking internal damage (because of the return)
 	//Possibly trigger an internal wound, too.
-	if(!is_ff && type != BURN && !(status & LIMB_ROBOT|LIMB_SYNTHSKIN))
+	if(!is_ff && type != BURN && !(status & (LIMB_ROBOT|LIMB_SYNTHSKIN)))
 		take_damage_internal_bleeding(damage)
 
 	if(!(status & LIMB_SPLINTED_INDESTRUCTIBLE) && (status & LIMB_SPLINTED) && damage > 5 && prob(50 + damage * 2.5)) //If they have it splinted, the splint won't hold.
@@ -517,7 +517,7 @@ This function completely restores a damaged organ to perfect condition.
 	if(!(SSticker.current_state >= GAME_STATE_PLAYING)) //If the game hasnt started, don't add bleed. Hacky fix to avoid having 100 bleed effect from roundstart.
 		return
 
-	if(status & LIMB_ROBOT|LIMB_SYNTHSKIN)
+	if(status & (LIMB_ROBOT|LIMB_SYNTHSKIN))
 		return
 
 	if(length(bleeding_effects_list))
@@ -599,7 +599,7 @@ This function completely restores a damaged organ to perfect condition.
 
 //Updating wounds. Handles wound natural I had some free spachealing, internal bleedings and infections
 /obj/limb/proc/update_wounds()
-	if((status & LIMB_ROBOT|LIMB_SYNTHSKIN)) //Robotic limbs don't heal or get worse.
+	if((status & (LIMB_ROBOT|LIMB_SYNTHSKIN))) //Robotic limbs don't heal or get worse.
 		return
 
 	owner.recalculate_move_delay = TRUE
@@ -866,7 +866,7 @@ This function completely restores a damaged organ to perfect condition.
 				owner.drop_inv_item_on_ground(owner.wear_mask, null, TRUE)
 				owner.update_hair()
 			if(BODY_FLAG_ARM_RIGHT)
-				if(status & LIMB_ROBOT|LIMB_SYNTHSKIN)
+				if(status & (LIMB_ROBOT|LIMB_SYNTHSKIN))
 					organ = new /obj/item/robot_parts/r_arm(owner.loc)
 				else
 					organ = new /obj/item/limb/arm/r_arm(owner.loc, owner)
@@ -875,7 +875,7 @@ This function completely restores a damaged organ to perfect condition.
 					U.removed_parts |= body_part
 					owner.update_inv_w_uniform()
 			if(BODY_FLAG_ARM_LEFT)
-				if(status & LIMB_ROBOT|LIMB_SYNTHSKIN)
+				if(status & (LIMB_ROBOT|LIMB_SYNTHSKIN))
 					organ = new /obj/item/robot_parts/l_arm(owner.loc)
 				else
 					organ = new /obj/item/limb/arm/l_arm(owner.loc, owner)
@@ -884,7 +884,7 @@ This function completely restores a damaged organ to perfect condition.
 					U.removed_parts |= body_part
 					owner.update_inv_w_uniform()
 			if(BODY_FLAG_LEG_RIGHT)
-				if(status & LIMB_ROBOT|LIMB_SYNTHSKIN)
+				if(status & (LIMB_ROBOT|LIMB_SYNTHSKIN))
 					organ = new /obj/item/robot_parts/r_leg(owner.loc)
 				else
 					organ = new /obj/item/limb/leg/r_leg(owner.loc, owner)
@@ -893,7 +893,7 @@ This function completely restores a damaged organ to perfect condition.
 					U.removed_parts |= body_part
 					owner.update_inv_w_uniform()
 			if(BODY_FLAG_LEG_LEFT)
-				if(status & LIMB_ROBOT|LIMB_SYNTHSKIN)
+				if(status & (LIMB_ROBOT|LIMB_SYNTHSKIN))
 					organ = new /obj/item/robot_parts/l_leg(owner.loc)
 				else
 					organ = new /obj/item/limb/leg/l_leg(owner.loc, owner)
@@ -902,21 +902,21 @@ This function completely restores a damaged organ to perfect condition.
 					U.removed_parts |= body_part
 					owner.update_inv_w_uniform()
 			if(BODY_FLAG_HAND_RIGHT)
-				if(!(status & LIMB_ROBOT|LIMB_SYNTHSKIN))
+				if(!(status & (LIMB_ROBOT|LIMB_SYNTHSKIN)))
 					organ= new /obj/item/limb/hand/r_hand(owner.loc, owner)
 				owner.drop_inv_item_on_ground(owner.gloves, null, TRUE)
 				owner.drop_inv_item_on_ground(owner.r_hand, null, TRUE)
 			if(BODY_FLAG_HAND_LEFT)
-				if(!(status & LIMB_ROBOT|LIMB_SYNTHSKIN))
+				if(!(status & (LIMB_ROBOT|LIMB_SYNTHSKIN)))
 					organ= new /obj/item/limb/hand/l_hand(owner.loc, owner)
 				owner.drop_inv_item_on_ground(owner.gloves, null, TRUE)
 				owner.drop_inv_item_on_ground(owner.l_hand, null, TRUE)
 			if(BODY_FLAG_FOOT_RIGHT)
-				if(!(status & LIMB_ROBOT|LIMB_SYNTHSKIN))
+				if(!(status & (LIMB_ROBOT|LIMB_SYNTHSKIN)))
 					organ= new /obj/item/limb/foot/r_foot/(owner.loc, owner)
 				owner.drop_inv_item_on_ground(owner.shoes, null, TRUE)
 			if(BODY_FLAG_FOOT_LEFT)
-				if(!(status & LIMB_ROBOT|LIMB_SYNTHSKIN))
+				if(!(status & (LIMB_ROBOT|LIMB_SYNTHSKIN)))
 					organ = new /obj/item/limb/foot/l_foot(owner.loc, owner)
 				owner.drop_inv_item_on_ground(owner.shoes, null, TRUE)
 
@@ -1131,7 +1131,7 @@ treat_grafted var tells it to apply to grafted but unsalved wounds, for burn kit
 	return ((status & LIMB_BROKEN) && !(status & LIMB_SPLINTED))
 
 /obj/limb/proc/is_malfunctioning()
-	return ((status & LIMB_ROBOT|LIMB_SYNTHSKIN) && prob(brute_dam + burn_dam))
+	return ((status & (LIMB_ROBOT|LIMB_SYNTHSKIN)) && prob(brute_dam + burn_dam))
 
 //for arms and hands
 /obj/limb/proc/process_grasp(var/obj/item/c_hand, var/hand_name)

--- a/code/modules/reagents/chemistry_properties/prop_negative.dm
+++ b/code/modules/reagents/chemistry_properties/prop_negative.dm
@@ -147,7 +147,7 @@
 		return
 	var/mob/living/carbon/human/H = M
 	var/obj/limb/L = pick(H.limbs)
-	if(!L || L.status & LIMB_ROBOT|LIMB_SYNTHSKIN)
+	if(!L || L.status & (LIMB_ROBOT|LIMB_SYNTHSKIN))
 		return
 	..()
 	if(prob(2.5 * potency * delta_time))

--- a/code/modules/reagents/chemistry_properties/prop_positive.dm
+++ b/code/modules/reagents/chemistry_properties/prop_positive.dm
@@ -68,7 +68,7 @@
 		return
 	var/mob/living/carbon/human/C = M
 	var/obj/limb/L = pick(C.limbs)
-	if(L && (L.status & LIMB_ROBOT|LIMB_SYNTHSKIN))
+	if(L && (L.status & (LIMB_ROBOT|LIMB_SYNTHSKIN)))
 		L.heal_damage(potency * delta_time, potency * delta_time, TRUE)
 
 /datum/chem_property/positive/repairing/process_overdose(mob/living/M, var/potency = 1, delta_time)
@@ -355,7 +355,7 @@
 	var/mob/living/carbon/human/H = M
 	var/obj/limb/L = pick(H.limbs)
 	if(L && prob(5 * potency * delta_time))
-		if(L.status & LIMB_ROBOT|LIMB_SYNTHSKIN)
+		if(L.status & (LIMB_ROBOT|LIMB_SYNTHSKIN))
 			L.take_damage(0, 2*potency)
 			return
 		if(L.implants && L.implants.len > 0)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Mathematic teaches us that multiplication goes before addition. `&` is multiplication. `|` is addition. `A & B|C` is `(A&B)|C`, not `A&(B|C)` as intended.
`(LIMB_ROBOT|LIMB_SYNTHSKIN)` really should have been its own define, but I cannot be bothered to come up with a fitting name for it in an emergency bugfix.

## Why It's Good For The Game

Puts an end to the replicants menace.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Human limbs are robotic no longer.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
