### PR TITLE
Adds the ability to engrave your zippo with a bayonet

### DIFF
--- a/code/game/objects/items/tools/flame_tools.dm
+++ b/code/game/objects/items/tools/flame_tools.dm
@@ -623,6 +623,24 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	item_state = "zippo"
 	icon_on = "zippoon"
 	icon_off = "zippo"
+	var/engraved = FALSE
+	
+/obj/item/tool/lighter/zippo/attackby(obj/item/W as obj, mob/user as mob)
+	. = ..()
+	if(istype(W, /obj/item/attachable/bayonet))
+		if(engraved)
+			to_chat(user, SPAN_NOTICE("Your lighter is already engraved."))
+			return
+		
+		var/str = copytext(reject_bad_text(input(user,"Engrave text?", "Set engraving", "")), 1)
+		if(!str || length(str) <= 0 || length(str) > 32)
+			to_chat(user, SPAN_NOTICE("Your hand trembles confused."))
+			return
+		desc += "\nEngraved with [str]"
+		engraved = TRUE
+		to_chat(user, SPAN_NOTICE("You engrave the zippo with '[str]'."))
+		
+		log_admin("[user] has engraved [name] with engraving \"[str]\". (CKEY: ([user.ckey]))")
 
 /obj/item/tool/lighter/zippo/gold
 	name = "golden Zippo lighter"

--- a/code/game/objects/items/tools/flame_tools.dm
+++ b/code/game/objects/items/tools/flame_tools.dm
@@ -634,7 +634,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		
 		var/str = copytext(reject_bad_text(input(user,"Engrave text?", "Set engraving", "")), 1)
 		if(length(str) == 0 || length(str) > 32)
-			to_chat(user, SPAN_NOTICE("Your hand trembles confusedly."))
+			to_chat(user, SPAN_NOTICE("You fumble [W], maybe try again?"))
 			return
 		desc += "\nEngraved with \"[str]\""
 		engraved = TRUE

--- a/code/game/objects/items/tools/flame_tools.dm
+++ b/code/game/objects/items/tools/flame_tools.dm
@@ -634,7 +634,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		
 		var/str = copytext(reject_bad_text(input(user,"Engrave text?", "Set engraving", "")), 1)
 		if(!str || length(str) <= 0 || length(str) > 32)
-			to_chat(user, SPAN_NOTICE("Your hand trembles confused."))
+			to_chat(user, SPAN_NOTICE("Your hand trembles confusedly."))
 			return
 		desc += "\nEngraved with [str]"
 		engraved = TRUE

--- a/code/game/objects/items/tools/flame_tools.dm
+++ b/code/game/objects/items/tools/flame_tools.dm
@@ -640,7 +640,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		engraved = TRUE
 		to_chat(user, SPAN_NOTICE("You engrave \the [src] with '[str]'."))
 		
-		log_admin("[user] has engraved [name] with engraving \"[str]\". (CKEY: ([user.ckey]))")
+		log_admin("[user] has engraved \the [src] with engraving \"[str]\". (CKEY: ([user.ckey]))")
 
 /obj/item/tool/lighter/zippo/gold
 	name = "golden Zippo lighter"

--- a/code/game/objects/items/tools/flame_tools.dm
+++ b/code/game/objects/items/tools/flame_tools.dm
@@ -636,7 +636,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		if(!str || length(str) <= 0 || length(str) > 32)
 			to_chat(user, SPAN_NOTICE("Your hand trembles confusedly."))
 			return
-		desc += "\nEngraved with [str]"
+		desc += "\nEngraved with \"[str]\""
 		engraved = TRUE
 		to_chat(user, SPAN_NOTICE("You engrave \the [src] with '[str]'."))
 		

--- a/code/game/objects/items/tools/flame_tools.dm
+++ b/code/game/objects/items/tools/flame_tools.dm
@@ -633,12 +633,12 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 			return
 		
 		var/str = copytext(reject_bad_text(input(user,"Engrave text?", "Set engraving", "")), 1)
-		if(!str || length(str) <= 0 || length(str) > 32)
+		if(length(str) == 0 || length(str) > 32)
 			to_chat(user, SPAN_NOTICE("Your hand trembles confusedly."))
 			return
 		desc += "\nEngraved with \"[str]\""
 		engraved = TRUE
-		to_chat(user, SPAN_NOTICE("You engrave \the [src] with '[str]'."))
+		to_chat(user, SPAN_NOTICE("You engrave \the [src] with \"[str]\"."))
 		
 		log_admin("[user] has engraved \the [src] with engraving \"[str]\". (CKEY: ([user.ckey]))")
 

--- a/code/game/objects/items/tools/flame_tools.dm
+++ b/code/game/objects/items/tools/flame_tools.dm
@@ -629,7 +629,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	. = ..()
 	if(istype(W, /obj/item/attachable/bayonet))
 		if(engraved)
-			to_chat(user, SPAN_NOTICE("Your lighter is already engraved."))
+			to_chat(user, SPAN_NOTICE("\The [src] is already engraved."))
 			return
 		
 		var/str = copytext(reject_bad_text(input(user,"Engrave text?", "Set engraving", "")), 1)

--- a/code/game/objects/items/tools/flame_tools.dm
+++ b/code/game/objects/items/tools/flame_tools.dm
@@ -638,7 +638,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 			return
 		desc += "\nEngraved with [str]"
 		engraved = TRUE
-		to_chat(user, SPAN_NOTICE("You engrave the zippo with '[str]'."))
+		to_chat(user, SPAN_NOTICE("You engrave \the [src] with '[str]'."))
 		
 		log_admin("[user] has engraved [name] with engraving \"[str]\". (CKEY: ([user.ckey]))")
 


### PR DESCRIPTION

## About The Pull Request

You can now engrave your zippo with a bayonet.

## Why It's Good For The Game

RP good

Plus engraved lighters are still coming out from the Vietnam war and are a staple of the tropes of the era.  Since CM is based (roughly) on it it would be neat to have them.

## Changelog

:cl: Morrow
add: You can now engrave your zippo lighter with a bayonet.
/:cl:
