### PR TITLE
Brings WO CO gear up to par with their Distress Signal equivalent

### DIFF
--- a/code/modules/gear_presets/wo.dm
+++ b/code/modules/gear_presets/wo.dm
@@ -22,21 +22,20 @@
 	skills = /datum/skills/commander
 	idtype = /obj/item/card/id/gold
 
-	utility_under = /obj/item/clothing/under/marine
-	utility_hat = /obj/item/clothing/head/cmcap
-	utility_gloves = /obj/item/clothing/gloves/marine
-	utility_shoes = /obj/item/clothing/shoes/marine
-	utility_extra = list(/obj/item/clothing/head/beret/cm, /obj/item/clothing/head/beret/cm/tan)
+	utility_under = list(/obj/item/clothing/under/marine,/obj/item/clothing/under/marine/officer/command)
+	utility_hat = list(/obj/item/clothing/head/cmcap,/obj/item/clothing/head/beret/cm/tan)
+	utility_extra = list(/obj/item/clothing/glasses/sunglasses,/obj/item/clothing/glasses/sunglasses/big,/obj/item/clothing/glasses/sunglasses/aviator,/obj/item/clothing/glasses/mbcg)
 
-	service_under = /obj/item/clothing/under/marine/officer/bridge
-	service_over = /obj/item/clothing/suit/storage/jacket/marine/service
-	service_hat = /obj/item/clothing/head/cmcap
-	service_shoes = /obj/item/clothing/shoes/dress
+	service_under = list(/obj/item/clothing/under/marine/officer/formal/white, /obj/item/clothing/under/marine/officer/formal/black)
+	service_shoes = list(/obj/item/clothing/shoes/dress/commander)
+	service_extra = list(/obj/item/clothing/suit/storage/jacket/marine/dress/officer/bomber)
+	service_hat = list(/obj/item/clothing/head/beret/cm, /obj/item/clothing/head/beret/marine/commander/dress, /obj/item/clothing/head/beret/marine/commander/black)
 
-	dress_under = /obj/item/clothing/under/marine/dress
-	dress_over = /obj/item/clothing/suit/storage/jacket/marine/dress
-	dress_gloves = /obj/item/clothing/gloves/marine/dress
-	dress_shoes = /obj/item/clothing/shoes/dress
+	dress_under = list(/obj/item/clothing/under/marine/dress, /obj/item/clothing/under/marine/officer/formal/servicedress)
+	dress_extra = list(/obj/item/storage/large_holster/ceremonial_sword/full)
+	dress_hat = list(/obj/item/clothing/head/marine/peaked/captain/white, /obj/item/clothing/head/marine/peaked/captain/black)
+	dress_shoes = list(/obj/item/clothing/shoes/dress/commander)
+	dress_over = list(/obj/item/clothing/suit/storage/jacket/marine/dress/officer/white, /obj/item/clothing/suit/storage/jacket/marine/dress/officer/black, /obj/item/clothing/suit/storage/jacket/marine/dress/officer/suit)
 
 /datum/equipment_preset/wo/commander/New()
 	. = ..()
@@ -86,6 +85,7 @@
 	H.equip_to_slot_or_del(new /obj/item/device/binoculars/range/designator(H), WEAR_L_HAND)
 	//pockets
 	H.equip_to_slot_or_del(new /obj/item/storage/pouch/general/large(H), WEAR_R_STORE)
+	H.equip_to_slot_or_del(new /obj/item/storage/pouch/pistol/command(H), WEAR_L_STORE)
 
 
 //*****************************************************************************************************/


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Just as my previous WO gear fix was merged and I couldn't just add it as part of that, I was made aware of another WO gear related issue, namely the fact that CO's do not spawn with their unique tablet/pistol pouch that 50rem made a while ago.

This PR fixes that and also updates what fluff items are available as uniform option up to par with the shipside CO sets to properly tickle the CO vanity muscle.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Gear parity is good. More customization options for characters are also good. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:silencer_pl
add: Whiskey Outpost CO's now spawn in with their unique command pouch like their regular counterparts.
add: Whiskey Outpost CO's now have access to the same cosmetic gear options as their regular counterparts.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
