### PR TITLE
Flamer Crate bugfix

### DIFF
--- a/code/datums/supply_packs/weapons.dm
+++ b/code/datums/supply_packs/weapons.dm
@@ -39,8 +39,8 @@
 	contains = list(
 					/obj/item/storage/box/guncase/flamer,
 					/obj/item/storage/box/guncase/flamer,
-					/obj/item/storage/large_holster/fuelpack,
-					/obj/item/storage/large_holster/fuelpack
+					/obj/item/storage/backpack/marine/engineerpack/flamethrower/kit,
+					/obj/item/storage/backpack/marine/engineerpack/flamethrower/kit
 					)
 	cost = RO_PRICE_NORMAL
 	containertype = /obj/structure/closet/crate/ammo/alt/flame


### PR DESCRIPTION
## About The Pull Request

Fixed the flame thrower crate spawning flamer spec's backpack

## Changelog


:cl: ghostsheet
fix: M240 Flamethrower crate now contains Pyrotechnician G4-1 fueltank instead of Broiler-T flexible refueling system.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
