### PR TITLE
Prevention of dummy abuse.

### DIFF
--- a/code/game/objects/items/devices/dummy_tablet.dm
+++ b/code/game/objects/items/devices/dummy_tablet.dm
@@ -191,7 +191,7 @@
                 return
             if(limb.status & LIMB_DESTROYED)
                 return
-            limb.droplimb(1, 0, "tablet")
+            limb.droplimb(TRUE, TRUE, "tablet")
             playsound(loc, 'sound/weapons/slice.ogg', 25)
         if("reset")
             linked_dummy.revive()

--- a/code/modules/reagents/chemistry_properties/prop_special.dm
+++ b/code/modules/reagents/chemistry_properties/prop_special.dm
@@ -170,7 +170,7 @@
 	if(!ishuman(M))
 		return
 	var/mob/living/carbon/human/H = M
-	if((locate(/obj/item/alien_embryo) in H.contents) || (H.species.flags & IS_SYNTHETIC)) //No effect if already infected
+	if((locate(/obj/item/alien_embryo) in H.contents) || (H.species.flags & IS_SYNTHETIC) || !H.huggable) //No effect if already infected
 		return
 	for(var/i=1,i<=max((level % 100)/10,1),i++)//10's determine number of embryos
 		var/obj/item/alien_embryo/embryo = new /obj/item/alien_embryo(H)

--- a/code/modules/reagents/chemistry_reagents/other.dm
+++ b/code/modules/reagents/chemistry_reagents/other.dm
@@ -959,7 +959,7 @@
 		return
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
-		if((locate(/obj/item/alien_embryo) in H.contents) || (H.species.flags & IS_SYNTHETIC))
+		if((locate(/obj/item/alien_embryo) in H.contents) || (H.species.flags & IS_SYNTHETIC) || !H.huggable)
 			volume = 0
 			return
 		if(volume < overdose_critical)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

If anybody ever wonders wherefore research does not get updates, it is because I have to waste my time on _this_ kind of nonsense instead.

## Why It's Good For The Game

Somebody recently tried to take a dummy spawned for training purposes and abuse it for generating larvas for the corrupt hive. We simply _cannot_ have nice things, it seems.
And seeing medbay floor covered in dummy's severed heads gets annoying at times too. No more.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Professor Dummy being unhugable now properly means that it cannot be infected by other methods too.
fix: Professor Dummy can no longer be abused for spawning unhealthy amount of severed limb items.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
