### PR TITLE
Canister Pouch Pressurized Tank Bugfix

### DIFF
--- a/code/game/objects/items/reagent_containers/glass.dm
+++ b/code/game/objects/items/reagent_containers/glass.dm
@@ -524,7 +524,7 @@
 	volume = 480
 	splashable = FALSE
 	w_class = SIZE_MASSIVE
-	flags_atom = CAN_BE_DISPENSED_INTO
+	flags_atom = CAN_BE_DISPENSED_INTO|OPENCONTAINER
 
 /obj/item/reagent_container/glass/pressurized_canister/attackby(obj/item/I, mob/user)
 	return


### PR DESCRIPTION
## About The Pull Request

The canister pouch's pressuzied tank can now be filled up with medicine bottle again
Broke from #8 


## Why It's Good For The Game

What once was broken is now not

## Changelog


:cl:
fix: Canister Pouch's Pressuzied canister can now be filled from bottles again.
/:cl:
