### PR TITLE
Yautja Code Modernization

### DIFF
--- a/code/datums/elements/yautja_tracked_item.dm
+++ b/code/datums/elements/yautja_tracked_item.dm
@@ -39,4 +39,6 @@
 		return TRUE
 	if(isHumanSynthStrict(carrier) && (carrier.hunter_data.honored || carrier.hunter_data.thralled) && !(carrier.hunter_data.dishonored || carrier.stat == DEAD))
 		return TRUE
+	if(istype(carrier, /mob/hologram/falcon))
+		return TRUE
 	return FALSE

--- a/code/modules/cm_preds/_yaut_defines.dm
+++ b/code/modules/cm_preds/_yaut_defines.dm
@@ -4,6 +4,7 @@
 #define YAUTJA_GEAR_SWORD		"The Piercing Hunting Sword"
 #define YAUTJA_GEAR_SCYTHE		"The Cleaving War-Scythe"
 #define YAUTJA_GEAR_STICK		"The Adaptive Combi-Stick"
+#define YAUTJA_GEAR_SPEAR		"The Nimble Spear"
 #define YAUTJA_GEAR_SCIMS		"The Fearsome Scimitars"
 #define YAUTJA_GEAR_LAUNCHER	"The Fleeting Spike Launcher"
 #define YAUTJA_GEAR_PISTOL		"The Swift Plasma Pistol"
@@ -11,3 +12,8 @@
 #define YAUTJA_GEAR_FULL_ARMOR	"The Formidable Plate Armor"
 #define YAUTJA_GEAR_SHIELD		"The Steadfast Shield"
 #define YAUTJA_GEAR_DRONE		"The Agile Drone"
+
+#define YAUTJA_THRALL_GEAR_MACHETE "The Swift Machete"
+#define YAUTJA_THRALL_GEAR_RAPIER "The Dancing Rapier"
+#define YAUTJA_THRALL_GEAR_CLAYMORE "The Broad Claymore"
+#define YAUTJA_THRALL_GEAR_FIREAXE "The Purposeful Fireaxe"

--- a/code/modules/cm_preds/huntdata.dm
+++ b/code/modules/cm_preds/huntdata.dm
@@ -2,6 +2,8 @@
 	var/mob/living/carbon/owner
 	var/name = "Hunter Data"
 
+	var/claimed_equipment = FALSE
+
 	//vars for Hunters targeting prey.
 	var/hunted = FALSE
 	var/mob/living/carbon/hunter //Target has their hunter variable linked to the Hunter.

--- a/code/modules/cm_preds/smartdisc.dm
+++ b/code/modules/cm_preds/smartdisc.dm
@@ -67,7 +67,7 @@
 
 	if(!isYautja(user))
 		if(prob(75))
-			to_chat(user, "You fiddle with the disc, but nothing happens. Try again maybe?")
+			to_chat(user, SPAN_WARNING("You fiddle with the disc, but nothing happens. Try again maybe?"))
 			return
 	to_chat(user, SPAN_WARNING("You activate the smart-disc and it whirrs to life!"))
 	activate(user)

--- a/code/modules/cm_preds/thrall_items.dm
+++ b/code/modules/cm_preds/thrall_items.dm
@@ -11,10 +11,10 @@
 	thrall = TRUE
 
 	allowed = list(
-			/obj/item/weapon/gun/launcher/spike,
-			/obj/item/weapon/gun/energy/yautja,
-			/obj/item/weapon/melee
-			)
+		/obj/item/weapon/gun/launcher/spike,
+		/obj/item/weapon/gun/energy/yautja,
+		/obj/item/weapon/melee
+	)
 
 /obj/item/clothing/suit/armor/yautja/thrall/New(mapload, armor_area = pick("shoulders", "chest", "mix"), armor_number = rand(1,3), armor_material = pick("cloth", "bare"))
 	if(armor_number > 3)
@@ -40,7 +40,7 @@
 		/obj/item/weapon/melee/throwing_knife,
 		/obj/item/weapon/gun/pistol/holdout,
 		/obj/item/weapon/gun/pistol/m43pistol
-		)
+	)
 
 /obj/item/clothing/shoes/yautja/thrall/New(mapload, greaves_number = 1, armor_material = pick("cloth", "bare"))
 	if(greaves_number > 1)

--- a/code/modules/cm_preds/thrall_procs.dm
+++ b/code/modules/cm_preds/thrall_procs.dm
@@ -132,14 +132,14 @@
 			playsound(loc, 'sound/items/pred_bracer.ogg', 75, 1)
 
 		to_chat(T, SPAN_WARNING("\The [thrall_gloves] locks around your wrist with a sharp click."))
-		to_chat(T, SPAN_YAUTJABOLD("[icon2html(thrall_gloves)] \The <b>[thrall_gloves]</b> beeps: Your mentor has linked their bracer to yours."))
+		to_chat(T, SPAN_YAUTJABOLD("[icon2html(thrall_gloves)] \The <b>[thrall_gloves]</b> beeps: Your master has linked their bracer to yours."))
 		if(thrall_gloves.notification_sound)
 			playsound(thrall_gloves.loc, 'sound/items/pred_bracer.ogg', 75, 1)
 
-// Message thrall or mentor
+// Message thrall or master
 /obj/item/clothing/gloves/yautja/verb/bracer_message()
 	set name = "Transmit Message"
-	set desc = "For direct communication between thrall and mentor."
+	set desc = "For direct communication between thrall and master."
 	set src in usr
 
 	var/mob/living/carbon/human/messenger = usr
@@ -148,12 +148,12 @@
 
 	var/mob/living/carbon/human/receiver
 	var/messenger_title = "thrall"
-	var/receiver_title = "mentor"
+	var/receiver_title = "master"
 	if(messenger.hunter_data.thralled)
 		receiver = messenger.hunter_data.thralled_set
 	else
 		receiver = messenger.hunter_data.thrall
-		messenger_title = "mentor"
+		messenger_title = "master"
 		receiver_title = "thrall"
 
 	if(!istype(receiver))

--- a/code/modules/cm_preds/thrall_procs.dm
+++ b/code/modules/cm_preds/thrall_procs.dm
@@ -1,75 +1,88 @@
 //Claim gear, same as the Hunter's get.
-/obj/item/clothing/gloves/yautja/thrall/proc/buy_gear()
-	set category = "Thrall.Misc"
+/obj/item/clothing/gloves/yautja/proc/buy_thrall_gear()
 	set name = "Claim Equipment"
 	set desc = "When you're on the Predator ship, claim some gear. You can only do this ONCE."
-	var/mob/living/carbon/human/user = usr
+	set category = "Thrall.Misc"
+	set src in usr
 
-	if(isSpeciesYautja(user))
+	var/mob/living/carbon/human/wearer = usr
+	if(wearer.gloves != src)
+		to_chat(wearer, SPAN_WARNING("You need to be wearing your thrall bracers to do this."))
 		return
 
-	if(user.is_mob_incapacitated() || user.lying || user.buckled)
-		to_chat(user, "You're not able to do that right now.")
+	if(wearer.hunter_data.claimed_equipment)
+		to_chat(wearer, SPAN_WARNING("You've already claimed your equipment."))
 		return
 
-	if(!istype(get_area(user),/area/yautja))
-		to_chat(user, "Not here. Only on the ship.")
+	if(wearer.is_mob_incapacitated() || wearer.lying || wearer.buckled)
+		to_chat(wearer, SPAN_WARNING("You're not able to do that right now."))
 		return
 
-	var/obj/item/clothing/gloves/yautja/thrall/Y = user.gloves
-	if(!istype(Y) || Y.upgrades) return
+	if(!istype(get_area(wearer), /area/yautja))
+		to_chat(wearer, SPAN_WARNING("Not here. Only on the ship."))
+		return
 
 	var/sure = alert("An array of powerful weapons are displayed to you. Pick your gear carefully. If you cancel at any point, you will not claim your equipment.","Sure?","Begin the Hunt","No, not now")
 	if(sure == "Begin the Hunt")
-		var/list/ymelee = list(YAUTJA_GEAR_GLAIVE, "The Nimble Spear", YAUTJA_GEAR_WHIP,YAUTJA_GEAR_SWORD,YAUTJA_GEAR_SCYTHE, YAUTJA_GEAR_STICK)
-		var/list/hmelee = list("The Swift Machete", "The Dancing Rapier", "The Broad Claymore", "The Purposeful Fireaxe")
-		var/list/radial_ymelee = list(YAUTJA_GEAR_GLAIVE = image(icon = 'icons/obj/items/hunter/pred_gear.dmi', icon_state = "glaive"), YAUTJA_GEAR_WHIP = image(icon = 'icons/obj/items/hunter/pred_gear.dmi', icon_state = "whip"),YAUTJA_GEAR_SWORD = image(icon = 'icons/obj/items/hunter/pred_gear.dmi', icon_state = "clansword"),YAUTJA_GEAR_SCYTHE = image(icon = 'icons/obj/items/hunter/pred_gear.dmi', icon_state = "predscythe"), YAUTJA_GEAR_STICK = image(icon = 'icons/obj/items/hunter/pred_gear.dmi', icon_state = "combistick"), "The Nimble Spear" = image(icon = 'icons/obj/items/hunter/pred_gear.dmi', icon_state = "spearhunter"))
-		var/list/radial_hmelee = list("The Swift Machete" = image(icon = 'icons/obj/items/weapons/weapons.dmi', icon_state = "machete"), "The Dancing Rapier" = image(icon = 'icons/obj/items/weapons/weapons.dmi', icon_state = "ceremonial"), "The Broad Claymore" = image(icon = 'icons/obj/items/weapons/weapons.dmi', icon_state = "mercsword"), "The Purposeful Fireaxe" = image(icon = 'icons/obj/items/weapons/weapons.dmi', icon_state = "fireaxe"))
-		var/msel
-		var/type = alert("Do you seek to bring honor to your race, or embrace an alien culture?", "Human or Alien?", "Semper Humanus!", "What's loyalty?")
-		if(type == "Semper Humanus!")
-			if(usr.client.prefs && usr.client.prefs.no_radials_preference)
-				msel = tgui_input_list(usr, "Which weapon shall you use on your hunt?:","Melee Weapon", hmelee)
-			else
-				msel = show_radial_menu(usr, src, radial_hmelee)
-		else if(type == "What's loyalty?")
-			if(usr.client.prefs && usr.client.prefs.no_radials_preference)
-				msel = tgui_input_list(usr, "Which weapon shall you use on your hunt?:","Melee Weapon", ymelee)
-			else
-				msel = show_radial_menu(usr, src, radial_ymelee)
-		if(!msel) return //We don't want them to cancel out then get nothing.
+		var/list/hmelee = list(YAUTJA_THRALL_GEAR_MACHETE = image(icon = 'icons/obj/items/weapons/weapons.dmi', icon_state = "machete"), YAUTJA_THRALL_GEAR_RAPIER = image(icon = 'icons/obj/items/weapons/weapons.dmi', icon_state = "ceremonial"), YAUTJA_THRALL_GEAR_CLAYMORE = image(icon = 'icons/obj/items/weapons/weapons.dmi', icon_state = "mercsword"), YAUTJA_THRALL_GEAR_FIREAXE = image(icon = 'icons/obj/items/weapons/weapons.dmi', icon_state = "fireaxe"))
+		var/list/ymelee = list(YAUTJA_GEAR_GLAIVE = image(icon = 'icons/obj/items/hunter/pred_gear.dmi', icon_state = "glaive"), YAUTJA_GEAR_WHIP = image(icon = 'icons/obj/items/hunter/pred_gear.dmi', icon_state = "whip"), YAUTJA_GEAR_SWORD = image(icon = 'icons/obj/items/hunter/pred_gear.dmi', icon_state = "clansword"), YAUTJA_GEAR_SCYTHE = image(icon = 'icons/obj/items/hunter/pred_gear.dmi', icon_state = "predscythe"), YAUTJA_GEAR_STICK = image(icon = 'icons/obj/items/hunter/pred_gear.dmi', icon_state = "combistick"), YAUTJA_GEAR_SPEAR = image(icon = 'icons/obj/items/hunter/pred_gear.dmi', icon_state = "spearhunter"))
 
+		var/main_weapon
+		var/use_radials = wearer.client.prefs?.no_radials_preference ? FALSE : TRUE
+		var/type = alert("Do you plan on embracing alien weaponry, or sticking to your human roots?", "Human or Alien?", "Once Human, Always Human", "Let's try Alien")
+		if(type == "Once Human, Always Human")
+			main_weapon = use_radials ? show_radial_menu(wearer, wearer, hmelee) : tgui_input_list(wearer, "Which weapon shall you use on your hunt?:", "Melee Weapon", hmelee)
+		else
+			main_weapon = use_radials ? show_radial_menu(wearer, wearer, ymelee) : tgui_input_list(wearer, "Which weapon shall you use on your hunt?:", "Melee Weapon", ymelee)
+		if(!main_weapon)
+			return //We don't want them to cancel out then get nothing.
 
-		if(!istype(Y) || Y.upgrades) return //Tried to run it several times in the same loop. That's not happening.
-		Y.upgrades++ //Just means gear was purchased.
+		if(wearer.gloves != src)
+			to_chat(wearer, SPAN_WARNING("You need to be wearing your thrall bracers to do this."))
+			return
 
-		switch(msel)
-			if("The Lumbering Glaive")
-				new /obj/item/weapon/melee/twohanded/yautja/glaive(user.loc)
-			if("The Nimble Spear")
-				new /obj/item/weapon/melee/twohanded/yautja/spear(user.loc)
-			if("The Rending Chain-Whip")
-				new /obj/item/weapon/melee/yautja/chain(user.loc)
-			if("The Piercing Hunting Sword")
-				new /obj/item/weapon/melee/yautja/sword(user.loc)
-			if("The Cleaving War-Scythe")
-				new /obj/item/weapon/melee/yautja/scythe(user.loc)
-			if("The Adaptive Combi-Stick")
-				new /obj/item/weapon/melee/yautja/combistick(user.loc)
-			if("The Swift Machete")
-				new /obj/item/weapon/melee/claymore/mercsword/machete(user.loc)
-			if("The Dancing Rapier")
-				new /obj/item/weapon/melee/claymore/mercsword/ceremonial(user.loc)
-			if("The Broad Claymore")
-				new /obj/item/weapon/melee/claymore(user.loc)
-			if("The Purposeful Fireaxe")
-				new /obj/item/weapon/melee/twohanded/fireaxe(user.loc)
+		if(wearer.hunter_data.claimed_equipment)
+			to_chat(src, SPAN_WARNING("You've already claimed your equipment."))
+			return
 
-		Y.verbs -= /obj/item/clothing/gloves/yautja/thrall/proc/buy_gear
-		new /obj/item/clothing/suit/armor/yautja/thrall(user.loc)
-		new /obj/item/clothing/shoes/yautja/thrall(user.loc)
-		new /obj/item/clothing/under/chainshirt/thrall(user.loc)
-		new /obj/item/clothing/mask/gas/yautja/thrall(user.loc)
+		var/obj/item/spawned_weapon
+		switch(main_weapon)
+			if(YAUTJA_GEAR_GLAIVE)
+				spawned_weapon = new /obj/item/weapon/melee/twohanded/yautja/glaive(wearer.loc)
+			if(YAUTJA_GEAR_SPEAR)
+				spawned_weapon = new /obj/item/weapon/melee/twohanded/yautja/spear(wearer.loc)
+			if(YAUTJA_GEAR_WHIP)
+				spawned_weapon = new /obj/item/weapon/melee/yautja/chain(wearer.loc)
+			if(YAUTJA_GEAR_SWORD)
+				spawned_weapon = new /obj/item/weapon/melee/yautja/sword(wearer.loc)
+			if(YAUTJA_GEAR_SCYTHE)
+				spawned_weapon = new /obj/item/weapon/melee/yautja/scythe(wearer.loc)
+			if(YAUTJA_GEAR_STICK)
+				spawned_weapon = new /obj/item/weapon/melee/yautja/combistick(wearer.loc)
+			if(YAUTJA_THRALL_GEAR_MACHETE)
+				spawned_weapon = new /obj/item/weapon/melee/claymore/mercsword/machete(wearer.loc)
+			if(YAUTJA_THRALL_GEAR_RAPIER)
+				spawned_weapon = new /obj/item/weapon/melee/claymore/mercsword/ceremonial(wearer.loc)
+			if(YAUTJA_THRALL_GEAR_CLAYMORE)
+				spawned_weapon = new /obj/item/weapon/melee/claymore(wearer.loc)
+			if(YAUTJA_THRALL_GEAR_FIREAXE)
+				spawned_weapon = new /obj/item/weapon/melee/twohanded/fireaxe(wearer.loc)
+
+		if(istype(spawned_weapon, /obj/item/weapon/melee/yautja))
+			var/obj/item/weapon/melee/yautja/yautja_melee = spawned_weapon
+			yautja_melee.human_adapted = TRUE
+		else if(istype(spawned_weapon, /obj/item/weapon/melee/twohanded/yautja))
+			var/obj/item/weapon/melee/twohanded/yautja/yautja_melee = spawned_weapon
+			yautja_melee.human_adapted = TRUE
+		spawned_weapon.desc += " It looks like this one has been modified for human use."
+
+		wearer.hunter_data.claimed_equipment = TRUE
+
+		verbs -= /obj/item/clothing/gloves/yautja/proc/buy_thrall_gear
+		new /obj/item/clothing/suit/armor/yautja/thrall(wearer.loc)
+		new /obj/item/clothing/shoes/yautja/thrall(wearer.loc)
+		new /obj/item/clothing/under/chainshirt/thrall(wearer.loc)
+		new /obj/item/clothing/mask/gas/yautja/thrall(wearer.loc)
 
 
 //Link to thrall bracer, enabling most of it's abilities
@@ -77,6 +90,7 @@
 	set name = "Link Thrall Bracer"
 	set desc = "Link your bracer to that of your thrall."
 	set category = "Yautja.Thrall"
+	set src in usr
 
 	var/mob/living/carbon/human/user = usr
 	if(!istype(user))
@@ -85,102 +99,96 @@
 		to_chat(user, SPAN_WARNING("ERROR: No hunter_data detected."))
 		return
 
-	var/mob/living/carbon/human/T = user.hunter_data.thrall
-	var/obj/item/clothing/gloves/yautja/hunter/G
-	var/obj/item/clothing/gloves/yautja/thrall/TG
+	if(linked_bracer)
+		to_chat(user, SPAN_YAUTJABOLD("[icon2html(src)] \The <b>[src]</b> beeps: Link is already established!"))
+		return
 
-	if(istype(user.gloves, /obj/item/clothing/gloves/yautja/hunter))
-		G = user.gloves
-	else if(user.gloves != src)
+	if(user.gloves != src)
 		to_chat(user, SPAN_WARNING("You are not wearing your bracer!"))
 		return
-	else if(!owner || !user == owner)
-		to_chat(user, SPAN_YAUTJABOLD("[icon2html(G)] \The <b>[G]</b> beep: Wrong user detected!"))
+	else if(!owner || user != owner)
+		to_chat(user, SPAN_YAUTJABOLD("[icon2html(src)] \The <b>[src]</b> beeps: Wrong user detected!"))
 		return
 
+	var/mob/living/carbon/human/T = user.hunter_data.thrall
 	if(!T)
 		to_chat(user, SPAN_WARNING("You do not have a thrall to link to!"))
 		return
 	else if(!istype(T.gloves, /obj/item/clothing/gloves/yautja/thrall))
-		to_chat(user, SPAN_YAUTJABOLD("[icon2html(G)] \The <b>[G]</b> beep: Your thrall is not wearing a bracer!"))
+		to_chat(user, SPAN_YAUTJABOLD("[icon2html(src)] \The <b>[src]</b> beeps: Your thrall is not wearing a bracer!"))
 		return
-	else if(G.linked_bracer)
-		to_chat(user, SPAN_YAUTJABOLD("[icon2html(G)] \The <b>[G]</b> beep: link is already established!"))
 	else
-		TG = T.gloves
+		var/obj/item/clothing/gloves/yautja/thrall/thrall_gloves = T.gloves
 
-		G.linked_bracer = TG
-		TG.linked_bracer = G
-		TG.owner = T
-		TG.verbs += /obj/item/clothing/gloves/yautja/thrall/proc/buy_gear
+		linked_bracer = thrall_gloves
+		thrall_gloves.linked_bracer = src
+		thrall_gloves.owner = T
+		thrall_gloves.verbs += /obj/item/clothing/gloves/yautja/proc/buy_thrall_gear
+		if(T.client)
+			T.client.init_statbrowser() // quite possibly the worst thing ever, we need to restart their stat panel to get the new verb to appear
 
-		to_chat(user, SPAN_YAUTJABOLD("[icon2html(G)] \The <b>[G]</b> beep: Your bracer is now linked to your thrall."))
-		if(G.notification_sound)
-			playsound(G.loc, 'sound/items/pred_bracer.ogg', 75, 1)
+		to_chat(user, SPAN_YAUTJABOLD("[icon2html(src)] \The <b>[src]</b> beeps: Your bracer is now linked to your thrall."))
+		if(notification_sound)
+			playsound(loc, 'sound/items/pred_bracer.ogg', 75, 1)
 
-		to_chat(T, SPAN_WARNING("The [TG] locks around your wrist with a sharp click."))
-		to_chat(T, SPAN_YAUTJABOLD("[icon2html(TG)] \The <b>[TG]</b> beep: Your master has linked their bracer to yours."))
-		if(TG.notification_sound)
-			playsound(TG.loc, 'sound/items/pred_bracer.ogg', 75, 1)
+		to_chat(T, SPAN_WARNING("\The [thrall_gloves] locks around your wrist with a sharp click."))
+		to_chat(T, SPAN_YAUTJABOLD("[icon2html(thrall_gloves)] \The <b>[thrall_gloves]</b> beeps: Your mentor has linked their bracer to yours."))
+		if(thrall_gloves.notification_sound)
+			playsound(thrall_gloves.loc, 'sound/items/pred_bracer.ogg', 75, 1)
 
-
-
-
-//Message thrall or master
+// Message thrall or mentor
 /obj/item/clothing/gloves/yautja/verb/bracer_message()
 	set name = "Transmit Message"
-	set desc = "For direct communication between thrall and master."
+	set desc = "For direct communication between thrall and mentor."
+	set src in usr
 
-	var/mob/living/carbon/human/O = usr
-	if(!O || !istype(O) || !O.hunter_data)
-		return
-	var/obj/item/clothing/gloves/yautja/OG = O.gloves
-	if(!OG || !istype(OG) || !OG.linked_bracer)
-		return
-	var/mob/living/carbon/human/T = O.hunter_data.thrall
-	var/obj/item/clothing/gloves/yautja/TG = OG.linked_bracer
-	var/TM = "thrall" //This is the target
-	var/OM = "master" //This is the origin
-
-	if(!istype(OG, /obj/item/clothing/gloves/yautja))
-		return
-	if(!isYautja(O)) //Swap origin and target due to race
-		T = O.hunter_data.thralled_set
-		TM = "master"
-		OM = "thrall"
-
-	if(!T)
-		to_chat(O, SPAN_WARNING("You do not have a [TM] to message."))
+	var/mob/living/carbon/human/messenger = usr
+	if(!istype(messenger))
 		return
 
-	if(!TG)
-		to_chat(usr, SPAN_YAUTJABOLD("[icon2html(OG)] \The <b>[OG]</b> beep: Your [TM]'s bracer is unlinked!"))
-	else if(!T.gloves == TG)
-		to_chat(usr, SPAN_YAUTJABOLD("[icon2html(OG)] \The <b>[OG]</b> beep: Your [TM] is not wearing their bracer!"))
-	else if(!TG.owner)
-		to_chat(usr, SPAN_YAUTJABOLD("[icon2html(OG)] \The <b>[OG]</b> beep: [TM] bracer is unbound."))
-		return
+	var/mob/living/carbon/human/receiver
+	var/messenger_title = "thrall"
+	var/receiver_title = "mentor"
+	if(messenger.hunter_data.thralled)
+		receiver = messenger.hunter_data.thralled_set
 	else
-		OG.bracer_message_int(O, OG, T, TG, TM, OM)
+		receiver = messenger.hunter_data.thrall
+		messenger_title = "mentor"
+		receiver_title = "thrall"
+
+	if(!istype(receiver))
+		to_chat(messenger, SPAN_WARNING("You have no one to message!"))
+		return
+	if(!istype(receiver.gloves, /obj/item/clothing/gloves/yautja))
+		to_chat(messenger, SPAN_WARNING("Your [receiver_title] isn't wearing their bracer!"))
+		return
+
+	var/message = sanitize(input(messenger, "Enter the message you want to send:", "Send Message") as null|text)
+	if(!message)
+		return
+
+	if(!istype(receiver))
+		to_chat(messenger, SPAN_WARNING("You have no one to message!"))
+		return
+	var/obj/item/clothing/gloves/yautja/receiver_gloves = receiver.gloves
+	if(!istype(receiver_gloves))
+		to_chat(messenger, SPAN_WARNING("Your [receiver_title] isn't wearing their bracer!"))
+		return
+
+	to_chat(receiver, SPAN_YAUTJABOLD("\The <b>[receiver_gloves]</b> beeps with a message from your [messenger_title]: [message]"))
+	to_chat(messenger, SPAN_YAUTJABOLD("\The <b>[src]</b> beeps: You have sent '[message]' to your [receiver_title]."))
+
+	if(notification_sound)
+		playsound(loc, 'sound/items/pred_bracer.ogg', 75, 1)
+	if(receiver_gloves.notification_sound)
+		playsound(receiver_gloves.loc, 'sound/items/pred_bracer.ogg', 75, 1)
+
+	log_game("HUNTER: [key_name(messenger)] has sent [key_name(receiver)] the message '[message]' via bracer")
 
 /obj/item/clothing/gloves/yautja/hunter/bracer_message()
 	set category = "Yautja.Thrall"
-
 	. = ..()
+
 /obj/item/clothing/gloves/yautja/thrall/bracer_message()
 	set category = "Thrall"
-
 	. = ..()
-
-/obj/item/clothing/gloves/yautja/proc/bracer_message_int(var/mob/living/carbon/human/O, var/obj/item/clothing/gloves/yautja/OG, var/mob/living/carbon/human/T, var/obj/item/clothing/gloves/yautja/TG, var/TM, var/OM, var/msg)
-
-	if(!msg)
-		msg = input("Enter a message to send to your [TM].")
-
-	to_chat(T, SPAN_YAUTJABOLD("[icon2html(TG)] \The <b>[TG]</b> beep with a message from your [OM]: [msg]"))
-	to_chat(O, SPAN_YAUTJABOLD("[icon2html(OG)] \The <b>[OG]</b> beep: you have sent '[msg]' to your [TM]"))
-	log_game("HUNTER: [key_name(owner)] has sent [key_name(T)] the message '[msg]' via bracer")
-	if(TG.notification_sound)
-		playsound(TG.loc, 'sound/items/pred_bracer.ogg', 75, 1)
-	if(OG.notification_sound)
-		playsound(OG.loc, 'sound/items/pred_bracer.ogg', 75, 1)

--- a/code/modules/cm_preds/yaut_bracers.dm
+++ b/code/modules/cm_preds/yaut_bracers.dm
@@ -464,6 +464,9 @@
 	var/mob/living/carbon/human/M = caller
 
 	if(cloaked) //Turn it off.
+		if(cloak_timer > world.time)
+			to_chat(M, SPAN_WARNING("Your cloaking device is busy! Time left: <B>[max(round((cloak_timer - world.time) / 10), 1)]</b> seconds."))
+			return FALSE
 		decloak(caller)
 	else //Turn it on!
 		if(exploding)
@@ -486,10 +489,12 @@
 		RegisterSignal(M, COMSIG_HUMAN_EXTINGUISH, .proc/wrapper_fizzle_camouflage)
 		RegisterSignal(M, COMSIG_HUMAN_PRE_BULLET_ACT, .proc/bullet_hit)
 
+		cloak_timer = world.time + 1.5 SECONDS
+
 		log_game("[key_name_admin(usr)] has enabled their cloaking device.")
 		M.visible_message(SPAN_WARNING("[M] vanishes into thin air!"), SPAN_NOTICE("You are now invisible to normal detection."))
 		playsound(M.loc,'sound/effects/pred_cloakon.ogg', 15, 1)
-		M.alpha = 25
+		animate(M, alpha = 10, time = 1.5 SECONDS, easing = SINE_EASING|EASE_OUT)
 
 		var/datum/mob_hud/security/advanced/SA = huds[MOB_HUD_SECURITY_ADVANCED]
 		SA.remove_from_hud(M)

--- a/code/modules/cm_preds/yaut_bracers.dm
+++ b/code/modules/cm_preds/yaut_bracers.dm
@@ -33,11 +33,10 @@
 	var/charge_max = 1500
 	var/cloaked = 0
 	var/cloak_timer = 0
-	var/cloak_cooldown
-	var/upgrades = 0
-	var/scimitars = FALSE
+	var/cloak_malfunction = 0
+
 	var/mob/living/carbon/human/owner //Pred spawned on, or thrall given to.
-	var/obj/item/clothing/gloves/yautja/linked_bracer //Bracer linked to this one (thrall or master).
+	var/obj/item/clothing/gloves/yautja/linked_bracer //Bracer linked to this one (thrall or mentor).
 
 /obj/item/clothing/gloves/yautja/equipped(mob/user, slot)
 	. = ..()
@@ -53,6 +52,9 @@
 
 /obj/item/clothing/gloves/yautja/Destroy()
 	STOP_PROCESSING(SSobj, src)
+	if(linked_bracer)
+		linked_bracer.linked_bracer = null
+		linked_bracer = null
 	return ..()
 
 /obj/item/clothing/gloves/yautja/dropped(mob/user)
@@ -80,10 +82,12 @@
 //It can take a negative value in amount to restore energy.
 //Also instantly updates the yautja power HUD display.
 /obj/item/clothing/gloves/yautja/proc/drain_power(var/mob/living/carbon/human/M, var/amount)
-	if(!M) return 0
+	if(!M)
+		return FALSE
 	if(charge < amount)
 		to_chat(M, SPAN_WARNING("Your bracers lack the energy. They have only <b>[charge]/[charge_max]</b> remaining and need <B>[amount]</b>."))
-		return 0
+		return FALSE
+
 	charge -= amount
 	var/perc = (charge / charge_max * 100)
 	M.update_power_display(perc)
@@ -92,7 +96,8 @@
 	if(!HAS_TRAIT(M, TRAIT_YAUTJA_TECH) && !M.hunter_data.thralled)
 		if(prob(15))
 			shock_user(M)
-	return 1
+
+	return TRUE
 
 /obj/item/clothing/gloves/yautja/proc/shock_user(var/mob/living/carbon/human/M)
 	if(!HAS_TRAIT(M, TRAIT_YAUTJA_TECH) && !M.hunter_data.thralled)
@@ -105,15 +110,48 @@
 		//Stun and knock out, scream in pain
 		M.Stun(2)
 		M.KnockDown(2)
-		M.emote("scream")
+		if(M.pain.feels_pain)
+			M.emote("scream")
 		//Apply a bit of burn damage
 		M.apply_damage(5, BURN, "l_arm", 0, 0, 0, src)
 		M.apply_damage(5, BURN, "r_arm", 0, 0, 0, src)
 
+//We use this to determine whether we should activate the given verb, or a random verb
+//0 - do nothing, 1 - random function, 2 - this function
+/obj/item/clothing/gloves/yautja/hunter/proc/check_random_function(var/mob/living/carbon/human/user, var/forced = FALSE, var/always_delimb = FALSE)
+	if(!istype(user))
+		return TRUE
+
+	if(forced || HAS_TRAIT(user, TRAIT_YAUTJA_TECH))
+		return FALSE
+
+	var/workingProbability = 20
+	var/randomProbability = 10
+	if(isSynth(user)) // Synths are smart, they can figure this out pretty well
+		workingProbability = 40
+		randomProbability = 4
+	else if(isResearcher(user)) // Researchers are sort of smart, they can sort of figure this out
+		workingProbability = 25
+		randomProbability = 7
+
+	to_chat(user, SPAN_NOTICE("You press a few buttons..."))
+	//Add a little delay so the user wouldn't be just spamming all the buttons
+	user.next_move = world.time + 3
+	if(do_after(usr, 3, INTERRUPT_ALL, BUSY_ICON_FRIENDLY, numticks = 1))
+		if(prob(randomProbability))
+			return activate_random_verb(user)
+		if(!prob(workingProbability))
+			to_chat(user, SPAN_WARNING("You fiddle with the buttons but nothing happens..."))
+			return TRUE
+
+	if(always_delimb)
+		return delimb_user(user)
+
+	return FALSE
 
 /obj/item/clothing/gloves/yautja/examine(mob/user)
 	..()
-	to_chat(user, "They currently have [charge] out of [charge_max] charge.")
+	to_chat(user, SPAN_NOTICE("They currently have <b>[charge]/[charge_max]</b> charge."))
 
 
 // Toggle the notification sound
@@ -121,6 +159,7 @@
 	set name = "Toggle Bracer Sound"
 	set desc = "Toggle your bracer's notification sound."
 	set src in usr
+
 	notification_sound = !notification_sound
 	to_chat(usr, SPAN_NOTICE("The bracer's sound is now turned [notification_sound ? "on" : "off"]."))
 
@@ -149,9 +188,6 @@
 	charge = 3000
 	charge_max = 3000
 
-	var/obj/item/weapon/gun/energy/yautja/plasma_caster/caster
-	var/blades_active = 0
-	var/caster_active = 0
 	var/exploding = 0
 	var/inject_timer = 0
 	var/disc_timer = 0
@@ -159,7 +195,15 @@
 	var/name_active = TRUE
 	var/translator_type = "Modern"
 	var/caster_material = "ebony"
+
 	var/obj/item/card/id/bracer_chip/embedded_id
+
+	var/caster_deployed = FALSE
+	var/obj/item/weapon/gun/energy/yautja/plasma_caster/caster
+
+	var/wristblades_deployed = FALSE
+	var/obj/item/weapon/wristblades/left_wristblades
+	var/obj/item/weapon/wristblades/right_wristblades
 
 /obj/item/clothing/gloves/yautja/hunter/Initialize(mapload, var/new_translator_type, var/new_caster_material)
 	. = ..()
@@ -169,14 +213,20 @@
 	if(new_caster_material)
 		caster_material = new_caster_material
 	caster = new(src, FALSE, caster_material)
+	left_wristblades = new(src)
+	right_wristblades = new(src)
 
 /obj/item/clothing/gloves/yautja/hunter/emp_act(severity)
-	charge -= (severity * 500)
-	if(charge < 0) charge = 0
-	if(usr)
-		usr.visible_message(SPAN_DANGER("You hear a hiss and crackle!"),SPAN_DANGER("Your bracers hiss and spark!"))
-		if(cloaked)
-			decloak(usr)
+	charge = max(charge - (severity * 500), 0)
+	if(ishuman(loc))
+		var/mob/living/carbon/human/wearer = loc
+		if(wearer.gloves == src)
+			wearer.visible_message(SPAN_DANGER("You hear a hiss and crackle!"), SPAN_DANGER("Your bracers hiss and spark!"), SPAN_DANGER("You hear a hiss and crackle!"))
+			if(cloaked)
+				decloak(wearer)
+		else
+			var/turf/our_turf = get_turf(src)
+			our_turf.visible_message(SPAN_DANGER("You hear a hiss and crackle!"), SPAN_DANGER("You hear a hiss and crackle!"))
 
 /obj/item/clothing/gloves/yautja/hunter/equipped(mob/user, slot)
 	. = ..()
@@ -189,10 +239,11 @@
 //Any projectile can decloak a predator. It does defeat one free bullet though.
 /obj/item/clothing/gloves/yautja/hunter/proc/bullet_hit(mob/living/carbon/human/H, obj/item/projectile/P)
 	SIGNAL_HANDLER
+
 	var/ammo_flags = P.ammo.flags_ammo_behavior | P.projectile_override_flags
-	if( ammo_flags & (AMMO_ROCKET|AMMO_ENERGY|AMMO_XENO_ACID) ) //<--- These will auto uncloak.
+	if(ammo_flags & (AMMO_ROCKET|AMMO_ENERGY|AMMO_XENO_ACID)) //<--- These will auto uncloak.
 		decloak(H) //Continue on to damage.
-	else if(rand(0,100) < 20)
+	else if(prob(20))
 		decloak(H)
 		return COMPONENT_CANCEL_BULLET_ACT //Absorb one free bullet.
 
@@ -209,12 +260,10 @@
 	if(!ishuman(loc))
 		STOP_PROCESSING(SSobj, src)
 		return
+
 	var/mob/living/carbon/human/H = loc
 
-	if(cloak_timer)
-		cloak_timer--
 	if(cloaked)
-		H.alpha = 10
 		charge = max(charge - 10, 0)
 		if(charge <= 0)
 			decloak(loc)
@@ -223,77 +272,43 @@
 			if(prob(15))
 				shock_user(H)
 				decloak(loc)
-	else
-		return ..()
+		return
+	return ..()
 
 /obj/item/clothing/gloves/yautja/hunter/dropped(mob/user)
 	move_chip_to_bracer()
 	..()
 
 //We use this to activate random verbs for non-Yautja
-/obj/item/clothing/gloves/yautja/hunter/proc/activate_random_verb()
+/obj/item/clothing/gloves/yautja/hunter/proc/activate_random_verb(var/mob/caller)
 	var/option = rand(1, 11)
 	//we have options from 1 to 8, but we're giving the user a higher probability of being punished if they already rolled this bad
 	switch(option)
 		if(1)
-			. = wristblades_internal(TRUE)
+			. = wristblades_internal(caller, TRUE)
 		if(2)
-			. = track_gear_internal(TRUE)
+			. = track_gear_internal(caller, TRUE)
 		if(3)
-			. = cloaker_internal(TRUE)
+			. = cloaker_internal(caller, TRUE)
 		if(4)
-			. = caster_internal(TRUE)
+			. = caster_internal(caller, TRUE)
 		if(5)
-			. = injectors_internal(TRUE)
+			. = injectors_internal(caller, TRUE)
 		if(6)
-			. = call_disk_internal(TRUE)
+			. = call_disk_internal(caller, TRUE)
 		if(7)
-			. = translate_internal(TRUE)
+			. = translate_internal(caller, TRUE)
 		if(8)
-			. = call_combi(TRUE)
+			. = call_combi_internal(caller, TRUE)
 		else
-			. = delimb_user()
-
-	return
-
-//We use this to determine whether we should activate the given verb, or a random verb
-//0 - do nothing, 1 - random function, 2 - this function
-/obj/item/clothing/gloves/yautja/hunter/proc/should_activate_random_or_this_function()
-	var/mob/living/carbon/human/user = usr
-	if(!istype(user))
-		return 0
-
-	var/workingProbability = 20
-	var/randomProbability = 10
-	if (isSynth(user))
-		//Synths are smart, they can figure this out pretty well
-		workingProbability = 40
-		randomProbability = 4
-	else
-		//Researchers are sort of smart, they can sort of figure this out
-		if (isResearcher(user))
-			workingProbability = 25
-			randomProbability = 7
-
-
-	to_chat(user, SPAN_NOTICE("You press a few buttons..."))
-	//Add a little delay so the user wouldn't be just spamming all the buttons
-	user.next_move = world.time + 3
-	if(do_after(usr, 3, INTERRUPT_ALL, BUSY_ICON_FRIENDLY, numticks = 1))
-		var/chance = rand(1, 100)
-		if(chance <= randomProbability)
-			return 1
-		chance-=randomProbability
-		if(chance <= workingProbability)
-			return 2
-	return 0
-
+			. = delimb_user(caller)
 
 //This is used to punish people that fiddle with technology they don't understand
-/obj/item/clothing/gloves/yautja/hunter/proc/delimb_user()
-	var/mob/living/carbon/human/user = usr
-	if(!istype(user)) return
-	if(isYautja(usr)) return
+/obj/item/clothing/gloves/yautja/hunter/proc/delimb_user(var/mob/living/carbon/human/user)
+	if(!istype(user))
+		return
+	if(isYautja(user))
+		return
 
 	var/obj/limb/O = user.get_limb(check_zone("r_arm"))
 	O.droplimb()
@@ -302,7 +317,7 @@
 
 	to_chat(user, SPAN_NOTICE("The device emits a strange noise and falls off... Along with your arms!"))
 	playsound(user,'sound/weapons/wristblades_on.ogg', 15, 1)
-	return 1
+	return TRUE
 
 // Toggle the notification sound
 /obj/item/clothing/gloves/yautja/hunter/toggle_notification_sound()
@@ -314,88 +329,66 @@
 	set desc = "Extend your wrist blades. They cannot be dropped, but can be retracted."
 	set category = "Yautja.Weapons"
 	set src in usr
-	. = wristblades_internal(FALSE)
+	. = wristblades_internal(usr, FALSE)
 
-
-/obj/item/clothing/gloves/yautja/hunter/proc/wristblades_internal(var/forced = FALSE)
-	if(!usr.loc || !usr.canmove || usr.stat) return
-	var/mob/living/carbon/human/user = usr
-	if(!istype(user)) return
-	if(!forced && !HAS_TRAIT(usr, TRAIT_YAUTJA_TECH))
-		var/option = should_activate_random_or_this_function()
-		if (option == 0)
-			to_chat(usr, SPAN_WARNING("You fiddle with the buttons but nothing happens..."))
-			return
-		if (option == 1)
-			. = activate_random_verb()
-			return
-	var/obj/item/weapon/wristblades/R = user.get_active_hand()
-	var/obj/item/weapon/wristblades/L = user.get_inactive_hand()
-	var/is_lefthand_full = FALSE
-	if(R && istype(R)) //Turn it off.
-		if(scimitars)
-			to_chat(user, SPAN_NOTICE("You retract your scimitars."))
-		else
-			to_chat(user, SPAN_NOTICE("You retract your wrist blades."))
-		playsound(user.loc,'sound/weapons/wristblades_off.ogg', 15, 1)
-		blades_active = 0
-		qdel(R)
-		if(L && istype(L)) //If they have one in the off hand as well turn it off.
-			qdel(L)
+/obj/item/clothing/gloves/yautja/hunter/proc/wristblades_internal(var/mob/living/carbon/human/caller, var/forced = FALSE)
+	if(!caller.loc || !caller.canmove || caller.stat || !ishuman(caller))
 		return
+
+	. = check_random_function(caller, forced)
+	if(.)
+		return
+
+	if(wristblades_deployed)
+		if(left_wristblades.loc == caller)
+			caller.drop_inv_item_to_loc(left_wristblades, src, FALSE, TRUE)
+		if(right_wristblades.loc == caller)
+			caller.drop_inv_item_to_loc(right_wristblades, src, FALSE, TRUE)
+		wristblades_deployed = FALSE
+		to_chat(caller, SPAN_NOTICE("You retract your [left_wristblades.name]."))
+		playsound(caller, 'sound/weapons/wristblades_off.ogg', 15, TRUE)
 	else
-		if(!drain_power(user,50)) return
-
-		if(R)
-			to_chat(user, SPAN_WARNING("Your hand must be free to activate your wristblade!"))
+		if(!drain_power(caller, 50))
 			return
-		if(L)
-			to_chat(user, SPAN_WARNING("Your other hand must be free to activate your off-hand wristblade!"))
-			is_lefthand_full = TRUE
-		var/obj/limb/hand = user.get_limb(user.hand ? "l_hand" : "r_hand")
+		var/deploying_into_left_hand = caller.hand ? TRUE : FALSE
+		if(caller.get_active_hand())
+			to_chat(caller, SPAN_WARNING("Your hand must be free to activate your wristblade!"))
+			return
+		var/obj/limb/hand = caller.get_limb(deploying_into_left_hand ? "l_hand" : "r_hand")
 		if(!istype(hand) || !hand.is_usable())
-			to_chat(user, SPAN_WARNING("You can't hold that!"))
+			to_chat(caller, SPAN_WARNING("You can't hold that!"))
 			return
-		if(scimitars)
-			var/obj/item/weapon/wristblades/scimitar/N = new()
-			user.put_in_active_hand(N)
-			if(!is_lefthand_full)
-				var/obj/item/weapon/wristblades/scimitar/W = new()
-				user.put_in_inactive_hand(W)
+		var/is_offhand_full = FALSE
+		var/obj/limb/off_hand = caller.get_limb(deploying_into_left_hand ? "r_hand" : "l_hand")
+		if(caller.get_inactive_hand() || (!istype(off_hand) || !off_hand.is_usable()))
+			is_offhand_full = TRUE
+		if(deploying_into_left_hand)
+			caller.put_in_active_hand(left_wristblades)
+			if(!is_offhand_full)
+				caller.put_in_inactive_hand(right_wristblades)
 		else
-			var/obj/item/weapon/wristblades/blades/N = new()
-			user.put_in_active_hand(N)
-			if(!is_lefthand_full)
-				var/obj/item/weapon/wristblades/blades/W = new()
-				user.put_in_inactive_hand(W)
-		blades_active = 1
-		if(scimitars)
-			to_chat(user, SPAN_NOTICE("You activate your scimitars."))
-		else
-			to_chat(user, SPAN_NOTICE("You activate your wrist blades."))
-		playsound(user,'sound/weapons/wristblades_on.ogg', 15, 1)
+			caller.put_in_active_hand(right_wristblades)
+			if(!is_offhand_full)
+				caller.put_in_inactive_hand(left_wristblades)
+		wristblades_deployed = TRUE
+		to_chat(caller, SPAN_NOTICE("You activate your [left_wristblades.plural_name]."))
+		playsound(caller, 'sound/weapons/wristblades_on.ogg', 15, TRUE)
 
-	return 1
+	return TRUE
 
 /obj/item/clothing/gloves/yautja/hunter/verb/track_gear()
 	set name = "Track Yautja Gear"
 	set desc = "Find Yauja Gear."
 	set category = "Yautja.Tracker"
 	set src in usr
-	. = track_gear_internal(FALSE)
+	. = track_gear_internal(usr, FALSE)
 
+/obj/item/clothing/gloves/yautja/hunter/proc/track_gear_internal(var/mob/caller, var/forced = FALSE)
+	. = check_random_function(caller, forced)
+	if(.)
+		return
 
-/obj/item/clothing/gloves/yautja/hunter/proc/track_gear_internal(var/forced = FALSE)
-	var/mob/living/carbon/human/M = usr
-	if(!istype(M)) return
-	if(!forced && !HAS_TRAIT(usr, TRAIT_YAUTJA_TECH))
-		var/option = should_activate_random_or_this_function()
-		if (option == 0)
-			to_chat(usr, SPAN_WARNING("You fiddle with the buttons but nothing happens..."))
-			return
-		if (option == 1)
-			. = activate_random_verb()
-			return
+	var/mob/living/carbon/human/M = caller
 
 	var/dead_on_planet = 0
 	var/dead_on_almayer = 0
@@ -461,55 +454,40 @@
 	set desc = "Activate your suit's cloaking device. It will malfunction if the suit takes damage or gets excessively wet."
 	set category = "Yautja.Utility"
 	set src in usr
-	. = cloaker_internal(FALSE)
+	. = cloaker_internal(usr, FALSE)
 
-/obj/item/clothing/gloves/yautja/hunter/proc/cloaker_internal(var/forced = FALSE)
-	if(!usr || usr.stat) return
-	var/mob/living/carbon/human/M = usr
-	if(!istype(M)) return
-	if(!forced && !HAS_TRAIT(usr, TRAIT_YAUTJA_TECH))
-		var/option = should_activate_random_or_this_function()
-		if (option == 0)
-			if(cloaked) //Turn it off.
-				//We're going to be nice here and say you can turn off the cloak without an issue
-				//Otherwise, humans wouldn't have any use for the cloak without being shocked every time they turn it on
-				//Since they couldn't turn it off in time afterwards with consistency
-				decloak(usr)
-				return 1
-			to_chat(usr, SPAN_WARNING("You fiddle with the buttons but nothing happens..."))
-			return
-		if (option == 1)
-			. = activate_random_verb()
-			return
+/obj/item/clothing/gloves/yautja/hunter/proc/cloaker_internal(var/mob/caller, var/forced = FALSE)
+	. = check_random_function(caller, forced)
+	if(.)
+		return
+
+	var/mob/living/carbon/human/M = caller
+
 	if(cloaked) //Turn it off.
-		decloak(usr)
+		decloak(caller)
 	else //Turn it on!
 		if(exploding)
 			to_chat(M, SPAN_WARNING("Your bracer is much too busy violently exploding to activate the cloaking device."))
-			return 0
+			return FALSE
 
-		if(cloak_cooldown && cloak_cooldown > world.time)
+		if(cloak_malfunction > world.time)
 			to_chat(M, SPAN_WARNING("Your cloak is malfunctioning and can't be enabled right now!"))
-			return
+			return FALSE
 
-		if(cloak_timer)
-			if(prob(50))
-				to_chat(M, SPAN_WARNING("Your cloaking device is still recharging! Time left: <B>[cloak_timer]</b> seconds."))
-			return 0
+		if(cloak_timer > world.time)
+			to_chat(M, SPAN_WARNING("Your cloaking device is still recharging! Time left: <B>[max(round((cloak_timer - world.time) / 10), 1)]</b> seconds."))
+			return FALSE
 
-		if(!drain_power(M,50))
-			return
-
+		if(!drain_power(M, 50))
+			return FALSE
 
 		cloaked = TRUE
 
 		RegisterSignal(M, COMSIG_HUMAN_EXTINGUISH, .proc/wrapper_fizzle_camouflage)
 		RegisterSignal(M, COMSIG_HUMAN_PRE_BULLET_ACT, .proc/bullet_hit)
 
-		to_chat(M, SPAN_NOTICE("You are now invisible to normal detection."))
 		log_game("[key_name_admin(usr)] has enabled their cloaking device.")
-		for(var/mob/O in oviewers(M))
-			O.show_message("[M] vanishes into thin air!",1)
+		M.visible_message(SPAN_WARNING("[M] vanishes into thin air!"), SPAN_NOTICE("You are now invisible to normal detection."))
 		playsound(M.loc,'sound/effects/pred_cloakon.ogg', 15, 1)
 		M.alpha = 25
 
@@ -519,42 +497,43 @@
 		XI.remove_from_hud(M)
 		anim(M.loc,M,'icons/mob/mob.dmi',,"cloak",,M.dir)
 
-	return 1
+	return TRUE
 
 /obj/item/clothing/gloves/yautja/hunter/proc/wrapper_fizzle_camouflage()
 	SIGNAL_HANDLER
+
 	var/mob/wearer = src.loc
 	wearer.visible_message(SPAN_DANGER("[wearer]'s cloak fizzles out!"), SPAN_DANGER("Your cloak fizzles out!"))
+
 	var/datum/effect_system/spark_spread/sparks = new /datum/effect_system/spark_spread
 	sparks.set_up(5, 4, src)
 	sparks.start()
+
 	decloak(wearer, TRUE)
 
 /obj/item/clothing/gloves/yautja/hunter/proc/decloak(var/mob/user, forced)
-	if(!user) return
+	if(!user)
+		return
 
 	UnregisterSignal(user, COMSIG_HUMAN_EXTINGUISH)
 	UnregisterSignal(user, COMSIG_HUMAN_PRE_BULLET_ACT)
 
 	if(forced)
-		cloak_cooldown = world.time + 10 SECONDS
+		cloak_malfunction = world.time + 10 SECONDS
 
-	to_chat(user, "Your cloaking device deactivates.")
-	cloaked = 0
+	cloaked = FALSE
 	log_game("[key_name_admin(usr)] has disabled their cloaking device.")
-	for(var/mob/O in oviewers(user))
-		O.show_message("[user.name] shimmers into existence!",1)
-	playsound(user.loc,'sound/effects/pred_cloakoff.ogg', 15, 1)
+	user.visible_message(SPAN_WARNING("[user] shimmers into existence!"), SPAN_WARNING("Your cloaking device deactivates."))
+	playsound(user.loc, 'sound/effects/pred_cloakoff.ogg', 15, 1)
 	user.alpha = initial(user.alpha)
-	cloak_timer = 5
+	cloak_timer = world.time + 5 SECONDS
 
 	var/datum/mob_hud/security/advanced/SA = huds[MOB_HUD_SECURITY_ADVANCED]
 	SA.add_to_hud(user)
 	var/datum/mob_hud/xeno_infection/XI = huds[MOB_HUD_XENO_INFECTION]
 	XI.add_to_hud(user)
 
-	if(user)
-		anim(user.loc,user,'icons/mob/mob.dmi',,"uncloak",,user.dir)
+	anim(user.loc, user, 'icons/mob/mob.dmi', null, "uncloak", null, user.dir)
 
 
 /obj/item/clothing/gloves/yautja/hunter/verb/caster()
@@ -562,61 +541,36 @@
 	set desc = "Activate your plasma caster. If it is dropped it will retract back into your armor."
 	set category = "Yautja.Weapons"
 	set src in usr
-	. = caster_internal(FALSE)
+	. = caster_internal(usr, FALSE)
 
-
-/obj/item/clothing/gloves/yautja/hunter/proc/caster_internal(var/forced = FALSE)
-	if(!usr.loc || !usr.canmove || usr.stat) return
-	var/mob/living/carbon/human/M = usr
-	if(!istype(M)) return
-	if(!forced && !HAS_TRAIT(usr, TRAIT_YAUTJA_TECH))
-		var/option = should_activate_random_or_this_function()
-		if (option == 0)
-			to_chat(usr, SPAN_WARNING("You fiddle with the buttons but nothing happens..."))
-			return
-		if (option == 1)
-			. = activate_random_verb()
-			return
-	var/obj/item/weapon/gun/energy/yautja/plasma_caster/R = usr.r_hand
-	var/obj/item/weapon/gun/energy/yautja/plasma_caster/L = usr.l_hand
-	if(!istype(R) && !istype(L))
-		caster_active = 0
-	if(caster_active) //Turn it off.
-		var/found = 0
-		if(R && istype(R))
-			found = 1
-			usr.r_hand = null
-			if(R)
-				M.temp_drop_inv_item(R)
-				R.forceMove(src)
-			M.update_inv_r_hand()
-		if(L && istype(L))
-			found = 1
-			usr.l_hand = null
-			if(L)
-				M.temp_drop_inv_item(L)
-				L.forceMove(src)
-			M.update_inv_l_hand()
-		if(found)
-			to_chat(usr, SPAN_NOTICE("You deactivate your plasma caster."))
-			playsound(src,'sound/weapons/pred_plasmacaster_off.ogg', 15, 1)
-			caster_active = 0
+/obj/item/clothing/gloves/yautja/hunter/proc/caster_internal(var/mob/living/carbon/human/caller, var/forced = FALSE)
+	if(!caller.loc || !caller.canmove || caller.stat || !ishuman(caller))
 		return
-	else //Turn it on!
-		if(usr.get_active_hand())
-			to_chat(usr, SPAN_WARNING("Your hand must be free to activate your caster!"))
-			return
-		if(!drain_power(usr,50)) return
 
-		var/obj/item/weapon/gun/energy/yautja/plasma_caster/W = caster
-		if(!istype(W))
-			W = new(usr, FALSE, caster_material)
-		usr.put_in_active_hand(W)
-		W.source = src
-		caster_active = 1
-		to_chat(usr, SPAN_NOTICE("You activate your plasma caster. It is in [W.mode] mode."))
-		playsound(src,'sound/weapons/pred_plasmacaster_on.ogg', 15, 1)
-	return 1
+	. = check_random_function(caller, forced)
+	if(.)
+		return
+
+	if(caster_deployed)
+		if(caster.loc == caller)
+			caller.drop_inv_item_to_loc(caster, src, FALSE, TRUE)
+		caster_deployed = FALSE
+	else
+		if(!drain_power(caller, 50))
+			return
+		if(caller.get_active_hand())
+			to_chat(caller, SPAN_WARNING("Your hand must be free to activate your wristblade!"))
+			return
+		var/obj/limb/hand = caller.get_limb(caller.hand ? "l_hand" : "r_hand")
+		if(!istype(hand) || !hand.is_usable())
+			to_chat(caller, SPAN_WARNING("You can't hold that!"))
+			return
+		caller.put_in_active_hand(caster)
+		caster_deployed = TRUE
+		to_chat(caller, SPAN_NOTICE("You activate your plasma caster. It is in [caster.mode] mode."))
+		playsound(src, 'sound/weapons/pred_plasmacaster_on.ogg', 15, TRUE)
+
+	return TRUE
 
 
 /obj/item/clothing/gloves/yautja/hunter/proc/explode(var/mob/living/carbon/victim)
@@ -646,18 +600,12 @@
 		else
 			cell_explosion(T, 800, 550, EXPLOSION_FALLOFF_SHAPE_LINEAR, null, cause_data)
 
-/obj/item/clothing/gloves/yautja/hunter/verb/activate_suicide()
-	set name = "Final Countdown (!)"
-	set desc = "Activate the explosive device implanted into your bracers. You have failed! Show some honor!"
-	set category = "Yautja.Misc"
-	set src in usr
-	. = activate_suicide_internal(FALSE)
-
 /obj/item/clothing/gloves/yautja/hunter/verb/change_explosion_type()
 	set name = "Change Explosion Type"
 	set desc = "Changes your bracer explosion to either only gib you or be a big explosion."
 	set category = "Yautja.Misc"
 	set src in usr
+
 	if(alert("Which explosion type do you want?","Explosive Bracers", "Small", "Big") == "Big")
 		explosion_type = 0
 		log_attack("[key_name_admin(usr)] has changed their Self Destruct to Large")
@@ -665,14 +613,24 @@
 		explosion_type = 1
 		log_attack("[key_name_admin(usr)] has changed their Self Destruct to Small")
 
+/obj/item/clothing/gloves/yautja/hunter/verb/activate_suicide()
+	set name = "Final Countdown (!)"
+	set desc = "Activate the explosive device implanted into your bracers. You have failed! Show some honor!"
+	set category = "Yautja.Misc"
+	set src in usr
+	. = activate_suicide_internal(usr, FALSE)
 
-/obj/item/clothing/gloves/yautja/hunter/proc/activate_suicide_internal(var/forced = FALSE)
-	if(!usr) return
-	var/mob/living/carbon/human/M = usr
+/obj/item/clothing/gloves/yautja/hunter/proc/activate_suicide_internal(var/mob/caller, var/forced = FALSE)
+	. = check_random_function(caller, forced, TRUE)
+	if(.)
+		return
+
+	var/mob/living/carbon/human/M = caller
+
 	if(cloaked)
 		to_chat(M, SPAN_WARNING("Not while you're cloaked. It might disrupt the sequence."))
 		return
-	if(!M.stat == CONSCIOUS)
+	if(!M.stat)
 		to_chat(M, SPAN_WARNING("Not while you're unconcious..."))
 		return
 	if(M.health < HEALTH_THRESHOLD_CRIT)
@@ -680,18 +638,6 @@
 		return
 	if(M.stat == DEAD)
 		to_chat(M, SPAN_WARNING("Little too late for that now!"))
-		return
-	if(!forced && !HAS_TRAIT(M, TRAIT_YAUTJA_TECH))
-		var/option = should_activate_random_or_this_function()
-		if (option == 0)
-			to_chat(usr, SPAN_WARNING("You fiddle with the buttons but nothing happens..."))
-			return
-		if (option == 1)
-			. = activate_random_verb()
-			return
-
-		//Council did not want the humans to trigger SD EVER
-		. = delimb_user()
 		return
 
 	var/obj/item/grab/G = M.get_active_hand()
@@ -705,8 +651,8 @@
 						var/area/A = get_area(M)
 						var/turf/T = get_turf(M)
 						if(A)
-							message_staff(FONT_SIZE_HUGE("ALERT: [usr] ([usr.key]) triggered the predator self-destruct sequence of [victim] ([victim.key]) in [A.name] (<A HREF='?_src_=admin_holder;adminplayerobservecoodjump=1;X=[T.x];Y=[T.y];Z=[T.z]'>JMP</a>)</font>"))
-							log_attack("[key_name(usr)] triggered the predator self-destruct sequence of [victim] ([victim.key]) in [A.name]")
+							message_staff(FONT_SIZE_HUGE("ALERT: [M] ([M.key]) triggered the predator self-destruct sequence of [victim] ([victim.key]) in [A.name] (<A HREF='?_src_=admin_holder;adminplayerobservecoodjump=1;X=[T.x];Y=[T.y];Z=[T.z]'>JMP</a>)</font>"))
+							log_attack("[key_name(M)] triggered the predator self-destruct sequence of [victim] ([victim.key]) in [A.name]")
 						if (!bracer.exploding)
 							bracer.explode(victim)
 						M.visible_message(SPAN_WARNING("[M] presses a few buttons on [victim]'s wrist bracer."),SPAN_DANGER("You activate the timer. May [victim]'s final hunt be swift."))
@@ -725,14 +671,14 @@
 			if(M.stat == DEAD)
 				to_chat(M, SPAN_WARNING("Little too late for that now!"))
 				return
-			if(!M.stat == CONSCIOUS)
+			if(M.stat)
 				to_chat(M, SPAN_WARNING("Not while you're unconcious..."))
 				return
-			exploding = 0
+			exploding = FALSE
 			to_chat(M, SPAN_NOTICE("Your bracers stop beeping."))
-			message_staff("[usr] ([usr.key]) has deactivated their Self Destruct.")
+			message_staff("[M] ([M.key]) has deactivated their Self Destruct.")
 		return
-	if((M.wear_mask && istype(M.wear_mask,/obj/item/clothing/mask/facehugger)) || M.status_flags & XENO_HOST)
+	if(istype(M.wear_mask,/obj/item/clothing/mask/facehugger) || (M.status_flags & XENO_HOST))
 		to_chat(M, SPAN_WARNING("Strange...something seems to be interfering with your bracer functions..."))
 		return
 	if(forced || alert("Detonate the bracers? Are you sure?","Explosive Bracers", "Yes", "No") == "Yes")
@@ -741,7 +687,7 @@
 		if(M.stat == DEAD)
 			to_chat(M, SPAN_WARNING("Little too late for that now!"))
 			return
-		if(!M.stat == CONSCIOUS)
+		if(M.stat)
 			to_chat(M, SPAN_WARNING("Not while you're unconcious..."))
 			return
 		if(exploding)
@@ -749,8 +695,8 @@
 		to_chat(M, SPAN_DANGER("You set the timer. May your journey to the great hunting grounds be swift."))
 		var/area/A = get_area(M)
 		var/turf/T = get_turf(M)
-		message_staff(FONT_SIZE_HUGE("ALERT: [usr] ([usr.key]) triggered their predator self-destruct sequence [A ? "in [A.name]":""] (<A HREF='?_src_=admin_holder;adminplayerobservecoodjump=1;X=[T.x];Y=[T.y];Z=[T.z]'>JMP</a>)"))
-		log_attack("[key_name(usr)] triggered their predator self-destruct sequence in [A ? "in [A.name]":""]")
+		message_staff(FONT_SIZE_HUGE("ALERT: [M] ([M.key]) triggered their predator self-destruct sequence [A ? "in [A.name]":""] (<A HREF='?_src_=admin_holder;adminplayerobservecoodjump=1;X=[T.x];Y=[T.y];Z=[T.z]'>JMP</a>)"))
+		log_attack("[key_name(M)] triggered their predator self-destruct sequence in [A ? "in [A.name]":""]")
 		message_all_yautja("[M.real_name] has triggered their bracer's self-destruction sequence.")
 		explode(M)
 	return 1
@@ -762,44 +708,40 @@
 	set category = "Yautja.Utility"
 	set desc = "Create a focus crystal to energize your natural healing processes."
 	set src in usr
-	. = injectors_internal(FALSE)
+	. = injectors_internal(usr, FALSE)
 
 
-/obj/item/clothing/gloves/yautja/hunter/proc/injectors_internal(var/forced = FALSE)
-	if(!usr.canmove || usr.stat || usr.is_mob_restrained())
-		return 0
+/obj/item/clothing/gloves/yautja/hunter/proc/injectors_internal(var/mob/caller, var/forced = FALSE)
+	if(caller.is_mob_incapacitated())
+		return FALSE
 
-	if(!forced && !HAS_TRAIT(usr, TRAIT_YAUTJA_TECH))
-		var/option = should_activate_random_or_this_function()
-		if (option == 0)
-			to_chat(usr, SPAN_WARNING("You fiddle with the buttons but nothing happens..."))
-			return
-		if (option == 1)
-			. = activate_random_verb()
-			return
-
-	if(usr.get_active_hand())
-		to_chat(usr, SPAN_WARNING("Your active hand must be empty!"))
-		return 0
-
-	if(inject_timer)
-		to_chat(usr, SPAN_WARNING("You recently activated the healing crystal. Be patient."))
+	. = check_random_function(caller, forced)
+	if(.)
 		return
 
-	if(!drain_power(usr,1000)) return
+	if(caller.get_active_hand())
+		to_chat(caller, SPAN_WARNING("Your active hand must be empty!"))
+		return FALSE
+
+	if(inject_timer)
+		to_chat(caller, SPAN_WARNING("You recently activated the healing crystal. Be patient."))
+		return FALSE
+
+	if(!drain_power(caller, 1000))
+		return FALSE
 
 	inject_timer = TRUE
 	addtimer(CALLBACK(src, .proc/injectors_ready), 2 MINUTES)
 
-	to_chat(usr, SPAN_NOTICE(" You feel a faint hiss and a crystalline injector drops into your hand."))
-	var/obj/item/reagent_container/hypospray/autoinjector/yautja/O = new(usr)
-	usr.put_in_active_hand(O)
+	to_chat(caller, SPAN_NOTICE("You feel a faint hiss and a crystalline injector drops into your hand."))
+	var/obj/item/reagent_container/hypospray/autoinjector/yautja/O = new(caller)
+	caller.put_in_active_hand(O)
 	playsound(src, 'sound/machines/click.ogg', 15, 1)
-	return 1
+	return TRUE
 
 /obj/item/clothing/gloves/yautja/hunter/proc/injectors_ready()
 	if(ismob(loc))
-		to_chat(loc, SPAN_NOTICE(" Your bracers beep faintly and inform you that a new healing crystal is ready to be created."))
+		to_chat(loc, SPAN_NOTICE("Your bracers beep faintly and inform you that a new healing crystal is ready to be created."))
 	inject_timer = FALSE
 
 /obj/item/clothing/gloves/yautja/hunter/verb/call_disk()
@@ -807,69 +749,63 @@
 	set category = "Yautja.Weapons"
 	set desc = "Call back your smart-disc, if it's in range. If not you'll have to go retrieve it."
 	set src in usr
-	. = call_disk_internal(FALSE)
+	. = call_disk_internal(usr, FALSE)
 
 
-/obj/item/clothing/gloves/yautja/hunter/proc/call_disk_internal(var/forced = FALSE)
-	if(usr.is_mob_incapacitated())
-		return 0
+/obj/item/clothing/gloves/yautja/hunter/proc/call_disk_internal(var/mob/caller, var/forced = FALSE)
+	if(caller.is_mob_incapacitated())
+		return FALSE
 
-	if(!forced && !HAS_TRAIT(usr, TRAIT_YAUTJA_TECH))
-		var/option = should_activate_random_or_this_function()
-		if (option == 0)
-			to_chat(usr, SPAN_WARNING("You fiddle with the buttons but nothing happens..."))
-			return
-		if (option == 1)
-			. = activate_random_verb()
-			return
+	. = check_random_function(caller, forced)
+	if(.)
+		return
 
 	if(disc_timer)
-		to_chat(usr, SPAN_WARNING("Your bracers need some time to recuperate first."))
-		return 0
+		to_chat(caller, SPAN_WARNING("Your bracers need some time to recuperate first."))
+		return FALSE
 
-	if(!drain_power(usr,70)) return
-	disc_timer = 1
+	if(!drain_power(caller, 70))
+		return FALSE
+
+	disc_timer = TRUE
 	addtimer(VARSET_CALLBACK(src, disc_timer, FALSE), 10 SECONDS)
 
 	for(var/mob/living/simple_animal/hostile/smartdisc/S in range(7))
-		to_chat(usr, SPAN_WARNING("The [S] skips back towards you!"))
+		to_chat(caller, SPAN_WARNING("The [S] skips back towards you!"))
 		new /obj/item/explosive/grenade/spawnergrenade/smartdisc(S.loc)
 		qdel(S)
 
 	for(var/obj/item/explosive/grenade/spawnergrenade/smartdisc/D in range(10))
 		if(isturf(D.loc))
-			D.boomerang(usr)
-	return 1
+			D.boomerang(caller)
+
+	return TRUE
 
 /obj/item/clothing/gloves/yautja/hunter/verb/remove_tracked_item()
 	set name = "Remove Item from Tracker"
 	set desc = "Remove an item from the Yautja tracker."
 	set category = "Yautja.Tracker"
 	set src in usr
-	. = remove_tracked_item_internal(FALSE)
+	. = remove_tracked_item_internal(usr, FALSE)
 
-/obj/item/clothing/gloves/yautja/hunter/proc/remove_tracked_item_internal(var/forced = FALSE)
-	if(usr.is_mob_incapacitated())
-		return 0
+/obj/item/clothing/gloves/yautja/hunter/proc/remove_tracked_item_internal(var/mob/caller, var/forced = FALSE)
+	if(caller.is_mob_incapacitated())
+		return FALSE
 
-	if(!forced && !HAS_TRAIT(usr, TRAIT_YAUTJA_TECH))
-		var/option = should_activate_random_or_this_function()
-		if (option == 0)
-			to_chat(usr, SPAN_WARNING("You fiddle with the buttons but nothing happens..."))
-			return
-		if (option == 1)
-			. = activate_random_verb()
-			return
+	. = check_random_function(caller, forced)
+	if(.)
+		return
 
-	var/obj/item/tracked_item = usr.get_active_hand()
+	var/obj/item/tracked_item = caller.get_active_hand()
 	if(!tracked_item)
-		to_chat(usr, SPAN_WARNING("You need the item in your active hand to remove it from the tracker!"))
-		return
+		to_chat(caller, SPAN_WARNING("You need the item in your active hand to remove it from the tracker!"))
+		return FALSE
 	if(!(tracked_item in GLOB.tracked_yautja_gear))
-		to_chat(usr, SPAN_WARNING("\The [tracked_item] isn't on the tracking system."))
-		return
+		to_chat(caller, SPAN_WARNING("\The [tracked_item] isn't on the tracking system."))
+		return FALSE
 	tracked_item.RemoveElement(/datum/element/yautja_tracked_item)
-	to_chat(usr, SPAN_NOTICE("You remove \the <b>[tracked_item]</b> from the tracking system."))
+	to_chat(caller, SPAN_NOTICE("You remove \the <b>[tracked_item]</b> from the tracking system."))
+	return TRUE
 
 
 /obj/item/clothing/gloves/yautja/hunter/verb/add_tracked_item()
@@ -877,96 +813,81 @@
 	set desc = "Add an item to the Yautja tracker."
 	set category = "Yautja.Tracker"
 	set src in usr
-	. = add_tracked_item_internal(FALSE)
+	. = add_tracked_item_internal(usr, FALSE)
 
-/obj/item/clothing/gloves/yautja/hunter/proc/add_tracked_item_internal(var/forced = FALSE)
-	if(usr.is_mob_incapacitated())
-		return 0
+/obj/item/clothing/gloves/yautja/hunter/proc/add_tracked_item_internal(var/mob/caller, var/forced = FALSE)
+	if(caller.is_mob_incapacitated())
+		return FALSE
 
-	if(!forced && !HAS_TRAIT(usr, TRAIT_YAUTJA_TECH))
-		var/option = should_activate_random_or_this_function()
-		if (option == 0)
-			to_chat(usr, SPAN_WARNING("You fiddle with the buttons but nothing happens..."))
-			return
-		if (option == 1)
-			. = activate_random_verb()
-			return
+	. = check_random_function(caller, forced)
+	if(.)
+		return
 
-	var/obj/item/untracked_item = usr.get_active_hand()
+	var/obj/item/untracked_item = caller.get_active_hand()
 	if(!untracked_item)
-		to_chat(usr, SPAN_WARNING("You need the item in your active hand to remove it from the tracker!"))
-		return
+		to_chat(caller, SPAN_WARNING("You need the item in your active hand to remove it from the tracker!"))
+		return FALSE
 	if(untracked_item in GLOB.tracked_yautja_gear)
-		to_chat(usr, SPAN_WARNING("\The [untracked_item] is already being tracked."))
-		return
+		to_chat(caller, SPAN_WARNING("\The [untracked_item] is already being tracked."))
+		return FALSE
 	untracked_item.AddElement(/datum/element/yautja_tracked_item)
-	to_chat(usr, SPAN_NOTICE("You add \the <b>[untracked_item]</b> to the tracking system."))
+	to_chat(caller, SPAN_NOTICE("You add \the <b>[untracked_item]</b> to the tracking system."))
+	return TRUE
 
 /obj/item/clothing/gloves/yautja/hunter/verb/call_combi()
 	set name = "Yank Combi-stick"
 	set category = "Yautja.Weapons"
 	set desc = "Yank on your combi-stick's chain, if it's in range. Otherwise... recover it yourself."
 	set src in usr
-	. = call_combi_internal(FALSE)
+	. = call_combi_internal(usr, FALSE)
 
-/obj/item/clothing/gloves/yautja/hunter/proc/call_combi_internal(var/forced = FALSE)
-	if(usr.is_mob_incapacitated())
-		return 0
+/obj/item/clothing/gloves/yautja/hunter/proc/call_combi_internal(var/mob/caller, var/forced = FALSE)
+	if(caller.is_mob_incapacitated())
+		return FALSE
 
-	if(!forced && !HAS_TRAIT(usr, TRAIT_YAUTJA_TECH))
-		var/option = should_activate_random_or_this_function()
-		if (option == 0)
-			to_chat(usr, SPAN_WARNING("You fiddle with the buttons but nothing happens..."))
-			return
-		if (option == 1)
-			. = activate_random_verb()
-			return
+	. = check_random_function(caller, forced)
+	if(.)
+		return
 
 	for(var/obj/item/weapon/melee/yautja/combistick/C in range(7))
-		if(C.loc == usr) //We are already wearing/holding it.
-			continue
-		else if(usr.put_in_active_hand(C))//Try putting it in our active hand, or, if it's full...
-			if(!drain_power(usr,70)) //We should only drain power if we actually yank the chain back. Failed attempts can quickly drain the charge away.
-				return
-			usr.visible_message(SPAN_WARNING("<b>[usr] yanks [C]'s chain back!</b>"), SPAN_WARNING("<b>You yank [C]'s chain back!</b>"))
-		else if(usr.put_in_inactive_hand(C))///...Try putting it in our inactive hand.
-			if(!drain_power(usr,70)) //We should only drain power if we actually yank the chain back. Failed attempts can quickly drain the charge away.
-				return
-			usr.visible_message(SPAN_WARNING("<b>[usr] yanks [C]'s chain back!</b>"), SPAN_WARNING("<b>You yank [C]'s chain back!</b>"))
+		if(caller.put_in_active_hand(C))//Try putting it in our active hand, or, if it's full...
+			if(!drain_power(caller, 70)) //We should only drain power if we actually yank the chain back. Failed attempts can quickly drain the charge away.
+				return TRUE
+			caller.visible_message(SPAN_WARNING("<b>[caller] yanks [C]'s chain back!</b>"), SPAN_WARNING("<b>You yank [C]'s chain back!</b>"))
+		else if(caller.put_in_inactive_hand(C))///...Try putting it in our inactive hand.
+			if(!drain_power(caller, 70)) //We should only drain power if we actually yank the chain back. Failed attempts can quickly drain the charge away.
+				return TRUE
+			caller.visible_message(SPAN_WARNING("<b>[caller] yanks [C]'s chain back!</b>"), SPAN_WARNING("<b>You yank [C]'s chain back!</b>"))
 		else //If neither hand can hold it, you must not have a free hand.
-			to_chat(usr, SPAN_WARNING("You need a free hand to do this!</b>"))
+			to_chat(caller, SPAN_WARNING("You need a free hand to do this!</b>"))
 
 /obj/item/clothing/gloves/yautja/hunter/verb/translate()
 	set name = "Translator"
 	set desc = "Emit a message from your bracer to those nearby."
 	set category = "Yautja.Utility"
 	set src in usr
-	. = translate_internal(FALSE)
+	. = translate_internal(usr, FALSE)
 
-/obj/item/clothing/gloves/yautja/hunter/proc/translate_internal(var/forced = FALSE)
-	if(!usr || usr.stat) return
-
-	if(!forced && !HAS_TRAIT(usr, TRAIT_YAUTJA_TECH))
-		var/option = should_activate_random_or_this_function()
-		if (option == 0)
-			to_chat(usr, SPAN_WARNING("You fiddle with the buttons but nothing happens..."))
-			return
-		if (option == 1)
-			. = activate_random_verb()
-			return
-
-	usr.set_typing_indicator(TRUE, "translator")
-	var/msg = sanitize(input(usr, "Your bracer beeps and waits patiently for you to input your message.", "Translator", "") as text)
-	usr.set_typing_indicator(FALSE, "translator")
-	if(!msg || !usr.client)
+/obj/item/clothing/gloves/yautja/hunter/proc/translate_internal(var/mob/caller, var/forced = FALSE)
+	if(!caller || caller.stat)
 		return
 
-	if(!drain_power(usr, 50))
+	. = check_random_function(caller, forced)
+	if(.)
 		return
 
-	log_say("[usr.name != "Unknown" ? usr.name : "([usr.real_name])"] \[Yautja Translator\]: [msg] (CKEY: [usr.key]) (JOB: [usr.job])")
+	caller.set_typing_indicator(TRUE, "translator")
+	var/msg = sanitize(input(caller, "Your bracer beeps and waits patiently for you to input your message.", "Translator", "") as text)
+	caller.set_typing_indicator(FALSE, "translator")
+	if(!msg || !caller.client)
+		return
 
-	var/list/heard = get_mobs_in_view(7, usr)
+	if(!drain_power(caller, 50))
+		return
+
+	log_say("[caller.name != "Unknown" ? caller.name : "([caller.real_name])"] \[Yautja Translator\]: [msg] (CKEY: [caller.key]) (JOB: [caller.job])")
+
+	var/list/heard = get_mobs_in_view(7, caller)
 	for(var/mob/M in heard)
 		if(M.ear_deaf)
 			heard -= M
@@ -984,12 +905,11 @@
 		msg = replacetext(msg, "s", "5")
 		msg = replacetext(msg, "l", "1")
 
-	usr.langchat_speech(msg, heard, GLOB.all_languages, overhead_color, TRUE)
+	caller.langchat_speech(msg, heard, GLOB.all_languages, overhead_color, TRUE)
 
-	var/mob/M = usr
 	var/voice_name = "A strange voice"
-	if(M.name == M.real_name)
-		voice_name = "<b>[M.name]</b>"
+	if(caller.name == caller.real_name && caller.alpha == initial(caller.alpha))
+		voice_name = "<b>[caller.name]</b>"
 	for(var/mob/Q as anything in heard)
 		if(Q.stat && !isobserver(Q))
 			continue //Unconscious

--- a/code/modules/cm_preds/yaut_bracers.dm
+++ b/code/modules/cm_preds/yaut_bracers.dm
@@ -630,14 +630,14 @@
 	if(cloaked)
 		to_chat(M, SPAN_WARNING("Not while you're cloaked. It might disrupt the sequence."))
 		return
-	if(!M.stat)
-		to_chat(M, SPAN_WARNING("Not while you're unconcious..."))
+	if(M.stat == DEAD)
+		to_chat(M, SPAN_WARNING("Little too late for that now!"))
 		return
 	if(M.health < HEALTH_THRESHOLD_CRIT)
 		to_chat(M, SPAN_WARNING("As you fall into unconsciousness you fail to activate your self-destruct device before you collapse."))
 		return
-	if(M.stat == DEAD)
-		to_chat(M, SPAN_WARNING("Little too late for that now!"))
+	if(M.stat)
+		to_chat(M, SPAN_WARNING("Not while you're unconcious..."))
 		return
 
 	var/obj/item/grab/G = M.get_active_hand()

--- a/code/modules/cm_preds/yaut_hudprocs.dm
+++ b/code/modules/cm_preds/yaut_hudprocs.dm
@@ -79,7 +79,7 @@
 		return
 
 	if(!isYautja(src))
-		to_chat(src, "How did you get this verb?")
+		to_chat(src, SPAN_WARNING("How did you get this verb?"))
 		return
 
 	// List all possible preys
@@ -124,8 +124,9 @@
 		return
 
 	if(!isYautja(src))
-		to_chat(src, "How did you get this verb?")
+		to_chat(src, SPAN_WARNING("How did you get this verb?"))
 		return
+
 	if (alert(usr, "Are you sure you want to abandon this prey?", "Remove from Hunt:", "Yes", "No") != "Yes")
 		return
 	var/mob/living/carbon/prey = hunter_data.prey
@@ -139,13 +140,12 @@
 
 
 /mob/living/carbon/human/proc/mark_honored()
-
 	if(is_mob_incapacitated())
 		to_chat(src, SPAN_DANGER("You're not able to do that right now."))
 		return
 
 	if(!isYautja(src))
-		to_chat(src, "How did you get this verb?")
+		to_chat(src, SPAN_WARNING("How did you get this verb?"))
 		return
 
 	var/list/target_list = list()
@@ -177,13 +177,12 @@
 
 
 /mob/living/carbon/human/proc/unmark_honored()
-
 	if(is_mob_incapacitated())
 		to_chat(src, SPAN_DANGER("You're not able to do that right now."))
 		return
 
 	if(!isYautja(src))
-		to_chat(src, "How did you get this verb?")
+		to_chat(src, SPAN_WARNING("How did you get this verb?"))
 		return
 
 	var/list/target_list = list()
@@ -220,7 +219,7 @@
 		return
 
 	if(!isYautja(src))
-		to_chat(src, "How did you get this verb?")
+		to_chat(src, SPAN_WARNING("How did you get this verb?"))
 		return
 
 	var/list/target_list = list()
@@ -260,7 +259,7 @@
 		return
 
 	if(!isYautja(src))
-		to_chat(src, "How did you get this verb?")
+		to_chat(src, SPAN_WARNING("How did you get this verb?"))
 		return
 
 	var/list/target_list = list()
@@ -301,7 +300,7 @@
 		return
 
 	if(!isYautja(src))
-		to_chat(src, "How did you get this verb?")
+		to_chat(src, SPAN_WARNING("How did you get this verb?"))
 		return
 
 	var/list/target_list = list()
@@ -332,7 +331,7 @@
 		return
 
 	if(!isYautja(src))
-		to_chat(src, "How did you get this verb?")
+		to_chat(src, SPAN_WARNING("How did you get this verb?"))
 		return
 
 	var/list/target_list = list()
@@ -367,11 +366,11 @@
 		return
 
 	if(!isYautja(src))
-		to_chat(src, "How did you get this verb?")
+		to_chat(src, SPAN_WARNING("How did you get this verb?"))
 		return
 
 	if(hunter_data.thrall)
-		to_chat(src, "You already have a thrall!")
+		to_chat(src, SPAN_WARNING("You already have a thrall."))
 		return
 
 	// List all possible targets
@@ -410,7 +409,7 @@
 		return
 
 	if(!isYautja(src))
-		to_chat(src, "How did you get this verb?")
+		to_chat(src, SPAN_WARNING("How did you get this verb?"))
 		return
 
 	// List all possible targets

--- a/code/modules/cm_preds/yaut_items.dm
+++ b/code/modules/cm_preds/yaut_items.dm
@@ -595,7 +595,7 @@
 	if(isYautja(user) || isobserver(user))
 		to_chat(user, true_desc)
 	else
-		to_chat(user, "Scalp-collecting is supposed to be a <i>joke</i>. Has someone been going around doing this shit for real? What next, a necklace of severed ears? Jesus Christ.")
+		to_chat(user, SPAN_WARNING("Scalp-collecting is supposed to be a <i>joke</i>. Has someone been going around doing this shit for real? What next, a necklace of severed ears? Jesus Christ."))
 
 /obj/item/explosive/grenade/spawnergrenade/hellhound
 	name = "hellhound caller"
@@ -617,7 +617,7 @@
 	..()
 	if(!active)
 		if(!HAS_TRAIT(user, TRAIT_YAUTJA_TECH))
-			to_chat(user, "What's this thing?")
+			to_chat(user, SPAN_WARNING("What's this thing?"))
 			return
 		to_chat(user, SPAN_WARNING("You activate the hellhound beacon!"))
 		activate(user)
@@ -748,7 +748,7 @@
 		disarm(user)
 	//Humans and synths don't know how to handle those traps!
 	if(isHumanSynthStrict(user) && armed)
-		to_chat(user, "You foolishly reach out for \the [src]...")
+		to_chat(user, SPAN_WARNING("You foolishly reach out for \the [src]..."))
 		trapMob(user)
 		return
 	. = ..()

--- a/code/modules/cm_preds/yaut_procs.dm
+++ b/code/modules/cm_preds/yaut_procs.dm
@@ -20,7 +20,7 @@
 
 //Update the power display thing. This is called in Life()
 /mob/living/carbon/human/proc/update_power_display(var/perc)
-	if(hud_used && hud_used.pred_power_icon)
+	if(hud_used?.pred_power_icon)
 		switch(perc)
 			if(91 to INFINITY)
 				hud_used.pred_power_icon.icon_state = "powerbar100"
@@ -49,128 +49,122 @@
 	set desc = "Butcher a corpse you're standing on for its tasty meats."
 
 	if(is_mob_incapacitated() || lying || buckled)
-		to_chat(src, "You're not able to do that right now.")
 		return
 
 	var/list/choices = list()
-	for(var/mob/living/carbon/M in view(1,src))
-		if(Adjacent(M) && M.stat)
-			if(istype(M,/mob/living/carbon/human))
+	for(var/mob/living/carbon/M in view(1, src) - src)
+		if(Adjacent(M) && M.stat == DEAD)
+			if(ishuman(M))
 				var/mob/living/carbon/human/Q = M
 				if(Q.species && isSameSpecies(Q, src))
 					continue
 			choices += M
 
-	if(src in choices)
-		choices -= src
-
-	var/mob/living/carbon/T = tgui_input_list(src,"What do you wish to butcher?", "Butcher", choices)
+	var/mob/living/carbon/T = tgui_input_list(src, "What do you wish to butcher?", "Butcher", choices)
 
 	var/mob/living/carbon/Xenomorph/xeno_victim
 	var/mob/living/carbon/human/victim
 
 	if(!T || !src || !T.stat)
-		to_chat(src, "Nope.")
+		to_chat(src, SPAN_WARNING("Nope."))
 		return
 
 	if(!Adjacent(T))
-		to_chat(src, "You have to be next to your target.")
+		to_chat(src, SPAN_WARNING("You have to be next to your target."))
 		return
 
-	if(istype(T,/mob/living/carbon/Xenomorph/Larva))
-		to_chat(src, "This tiny worm is not even worth using your tools on.")
+	if(isXenoLarva(T))
+		to_chat(src, SPAN_WARNING("This tiny worm is not even worth using your tools on."))
 		return
 
 	if(is_mob_incapacitated() || lying || buckled)
-		to_chat(src, "Not right now.")
 		return
-
-	if(!T) return
 
 	if(isXeno(T))
 		xeno_victim = T
 
-	var/list/procedureChoices = list(
-		"Skin",
-		"Behead",
-		"Delimb - right hand",
-		"Delimb - left hand",
-		"Delimb - right arm",
-		"Delimb - left arm",
-		"Delimb - right foot",
-		"Delimb - left foot",
-		"Delimb - right leg",
-		"Delimb - left leg",
+	var/static/list/procedure_choices = list(
+		"Skin" = null,
+		"Behead" = "head",
+		"Delimb - Right Hand" = "r_hand",
+		"Delimb - Left Hand" = "l_hand",
+		"Delimb - Right Arm" = "r_arm",
+		"Delimb - Left Arm" = "l_arm",
+		"Delimb - Right Foot" = "r_foot",
+		"Delimb - Left Foot" = "l_foot",
+		"Delimb - Right Leg" = "r_leg",
+		"Delimb - Left Leg" = "l_leg",
 	)
+
 	var/procedure = ""
 	if(ishuman(T))
 		victim = T
-		procedure = tgui_input_list(src,"Which slice would you like to take?", "Take slice", procedureChoices)
 
+	if(victim)
+		procedure = tgui_input_list(src, "Which slice would you like to take?", "Take Slice", procedure_choices)
+		if(!procedure)
+			return
 
-	if (isXeno(T) || procedure == "Skin")
+	if(isXeno(T) || procedure == "Skin")
 		if(T.butchery_progress)
 			playsound(loc, 'sound/weapons/pierce.ogg', 25)
-			visible_message("<b>[src] goes back to butchering \the [T].</b>","<b>You get back to butchering \the [T].</b>")
+			visible_message(SPAN_DANGER("[src] goes back to butchering \the [T]."), SPAN_NOTICE("You get back to butchering \the [T]."))
 		else
 			playsound(loc, 'sound/weapons/pierce.ogg', 25)
-			visible_message("<b>[src] begins chopping and mutilating \the [T].</b>","<b>You take out your tools and begin your gruesome work on \the [T]. Hold still.</b>")
+			visible_message(SPAN_DANGER("[src] begins chopping and mutilating \the [T]."), SPAN_NOTICE("You take out your tools and begin your gruesome work on \the [T]. Hold still."))
 			T.butchery_progress = 1
 
 		if(T.butchery_progress == 1)
-			if(do_after(src,70, INTERRUPT_NO_NEEDHAND, BUSY_ICON_HOSTILE) && Adjacent(T))
-				visible_message("[src] makes careful slices and tears out the viscera in \the [T]'s abdominal cavity.","You carefully vivisect \the [T], ripping out the guts and useless organs. What a stench!")
+			if(do_after(src, 7 SECONDS, INTERRUPT_NO_NEEDHAND, BUSY_ICON_HOSTILE))
+				visible_message(SPAN_DANGER("[src] makes careful slices and tears out the viscera in \the [T]'s abdominal cavity."), SPAN_NOTICE("You carefully vivisect \the [T], ripping out the guts and useless organs. What a stench!"))
 				T.butchery_progress = 2
 				playsound(loc, 'sound/weapons/slash.ogg', 25)
 			else
-				to_chat(src, "You pause your butchering for later.")
+				to_chat(src, SPAN_NOTICE("You pause your butchering for later."))
 
 		if(T.butchery_progress == 2)
-			if(do_after(src,65, INTERRUPT_NO_NEEDHAND, BUSY_ICON_HOSTILE) && Adjacent(T))
-				visible_message("[src] hacks away at \the [T]'s limbs and slices off strips of dripping meat.","You slice off a few of \the [T]'s limbs, making sure to get the finest cuts.")
+			if(do_after(src, 6.5 SECONDS, INTERRUPT_NO_NEEDHAND, BUSY_ICON_HOSTILE))
+				visible_message(SPAN_DANGER("[src] hacks away at \the [T]'s limbs and slices off strips of dripping meat."), SPAN_NOTICE("You slice off a few of \the [T]'s limbs, making sure to get the finest cuts."))
 				if(xeno_victim && isturf(xeno_victim.loc))
 					var/obj/item/reagent_container/food/snacks/meat/xenomeat = new /obj/item/reagent_container/food/snacks/meat/xenomeat(T.loc)
 					xenomeat.name = "raw [xeno_victim.age_prefix][xeno_victim.caste_type] steak"
 				else if(victim && isturf(victim.loc))
-					victim.apply_damage(100,BRUTE,pick("r_leg","l_leg","r_arm","l_arm"),0,1,1) //Basically just rips off a random limb.
+					victim.apply_damage(100, BRUTE, pick("r_leg", "l_leg", "r_arm", "l_arm"), FALSE, TRUE) //Basically just rips off a random limb.
 					var/obj/item/reagent_container/food/snacks/meat/meat = new /obj/item/reagent_container/food/snacks/meat(victim.loc)
 					meat.name = "raw [victim.name] steak"
 				T.butchery_progress = 3
 				playsound(loc, 'sound/weapons/bladeslice.ogg', 25)
 			else
-				to_chat(src, "You pause your butchering for later.")
+				to_chat(src, SPAN_NOTICE("You pause your butchering for later."))
 
 		if(T.butchery_progress == 3)
-			if(do_after(src,70, INTERRUPT_NO_NEEDHAND, BUSY_ICON_HOSTILE) && Adjacent(T))
-				visible_message("[src] tears apart \the [T]'s ribcage and begins chopping off bit and pieces.","You rip open \the [T]'s ribcage and start tearing the tastiest bits out.")
+			if(do_after(src, 7 SECONDS, INTERRUPT_NO_NEEDHAND, BUSY_ICON_HOSTILE))
+				visible_message(SPAN_DANGER("[src] tears apart \the [T]'s ribcage and begins chopping off bit and pieces."), SPAN_NOTICE("You rip open \the [T]'s ribcage and start tearing the tastiest bits out."))
 				if(xeno_victim && isturf(xeno_victim.loc))
 					var/obj/item/reagent_container/food/snacks/meat/xenomeat = new /obj/item/reagent_container/food/snacks/meat/xenomeat(T.loc)
 					xenomeat.name = "raw [xeno_victim.age_prefix][xeno_victim.caste_type] tenderloin"
 				else if(victim && isturf(T.loc))
 					var/obj/item/reagent_container/food/snacks/meat/meat = new /obj/item/reagent_container/food/snacks/meat(victim.loc)
 					meat.name = "raw [victim.name] tenderloin"
-	//				T.apply_damage(100,BRUTE,"chest",0,0,0) //Does random serious damage, so we make sure they're dead.
-	//				Why was this even in here?
+					victim.apply_damage(100, BRUTE,"chest", FALSE, FALSE)
 				T.butchery_progress = 4
 				playsound(loc, 'sound/weapons/wristblades_hit.ogg', 25)
 			else
-				to_chat(src, "You pause your butchering for later.")
+				to_chat(src, SPAN_NOTICE("You pause your butchering for later."))
 
 		if(T.butchery_progress == 4)
-			if(do_after(src,90, INTERRUPT_NO_NEEDHAND, BUSY_ICON_HOSTILE) && Adjacent(T))
+			if(do_after(src, 9 SECONDS, INTERRUPT_NO_NEEDHAND, BUSY_ICON_HOSTILE))
 				if(xeno_victim && isturf(T.loc))
-					visible_message("<b>[src] flenses the last of [victim]'s exoskeleton, revealing only bones!</b>.","<b>You flense the last of [victim]'s exoskeleton clean off!</b>")
+					visible_message(SPAN_DANGER("[src] flenses the last of [victim]'s exoskeleton, revealing only bones!."), SPAN_NOTICE("You flense the last of [victim]'s exoskeleton clean off!"))
 					new /obj/effect/decal/remains/xeno(xeno_victim.loc)
 					var/obj/item/stack/sheet/animalhide/xeno/xenohide = new /obj/item/stack/sheet/animalhide/xeno(xeno_victim.loc)
 					xenohide.name = "[xeno_victim.age_prefix][xeno_victim.caste_type]-hide"
 					xenohide.singular_name = "[xeno_victim.age_prefix][xeno_victim.caste_type]-hide"
 					xenohide.stack_id = "[xeno_victim.age_prefix][xeno_victim.caste_type]-hide"
-
 				else if(victim && isturf(T.loc))
-					visible_message("<b>[src] reaches down and rips out \the [T]'s spinal cord and skull!</b>.","<b>You firmly grip the revealed spinal column and rip [T]'s head off!</b>")
-					var/mob/living/carbon/human/H = T
-					if(H.get_limb("head"))
-						H.apply_damage(150,BRUTE,"head",0,1,1)
+					visible_message(SPAN_DANGER("[src] reaches down and rips out \the [T]'s spinal cord and skull!."), SPAN_NOTICE("You firmly grip the revealed spinal column and rip [T]'s head off!"))
+					if(victim.get_limb("head"))
+						victim.apply_damage(150, BRUTE, "head", FALSE, TRUE)
 					else
 						var/obj/item/reagent_container/food/snacks/meat/meat = new /obj/item/reagent_container/food/snacks/meat(victim.loc)
 						meat.name = "raw [victim.name] steak"
@@ -192,48 +186,23 @@
 					to_chat(src, SPAN_NOTICE("You finish butchering!"))
 				qdel(T)
 			else
-				to_chat(src, "You pause your butchering for later.")
+				to_chat(src, SPAN_NOTICE("You pause your butchering for later."))
 	else
-		var/limb = ""
-		switch(procedure)
-			if ("")
-				to_chat(src, "You pause your butchering for later.")
-				return
-			if ("Behead")
-				limb = "head"
-			if ("Delimb - right hand")
-				limb = "r_hand"
-			if ("Delimb - left hand")
-				limb = "l_hand"
-			if ("Delimb - right arm")
-				limb = "r_arm"
-			if ("Delimb - left arm")
-				limb = "l_arm"
-			if ("Delimb - right foot")
-				limb = "r_foot"
-			if ("Delimb - left foot")
-				limb = "l_foot"
-			if ("Delimb - right leg")
-				limb = "r_leg"
-			if ("Delimb - left leg")
-				limb = "l_leg"
-
+		var/limb = procedure_choices[procedure]
 		var/limbName = parse_zone(limb)
-		var/mob/living/carbon/human/H = T
-		if(H.get_limb(limb).status & LIMB_DESTROYED)
-			to_chat(src, "The victim lacks a [limbName].")
+		if(victim.get_limb(limb).status & LIMB_DESTROYED)
+			to_chat(src, SPAN_WARNING("The victim lacks a [limbName]."))
 			return
 		if(limb == "head")
 			visible_message("<b>[src] reaches down and starts beheading [T].</b>","<b>You reach down and start beheading [T].</b>")
 		else
 			visible_message("<b>[src] reaches down and starts removing [T]'s [limbName].</b>","<b>You reach down and start removing [T]'s [limbName].</b>")
-		if(do_after(src,90, INTERRUPT_NO_NEEDHAND, BUSY_ICON_HOSTILE) && Adjacent(T))
-			if(H.get_limb(limb).status & LIMB_DESTROYED)
-				to_chat(src, "The victim lacks a [limbName].")
+		if(do_after(src, 9 SECONDS, INTERRUPT_NO_NEEDHAND, BUSY_ICON_HOSTILE))
+			if(victim.get_limb(limb).status & LIMB_DESTROYED)
+				to_chat(src, SPAN_WARNING("The victim lacks a [limbName]."))
 				return
-			H.get_limb(limb).droplimb(1, 0, "butchering")
+			victim.get_limb(limb).droplimb(TRUE, FALSE, "butchering")
 			playsound(loc, 'sound/weapons/slice.ogg', 25)
-			H.butchery_progress = 0
 			if(hunter_data.prey == T)
 				to_chat(src, SPAN_YAUTJABOLD("You have claimed [T] as your trophy."))
 				emote("roar")
@@ -241,8 +210,6 @@
 				hunter_data.prey = null
 			else
 				to_chat(src, SPAN_NOTICE("You finish butchering!"))
-
-	return
 
 /area/yautja
 	name = "\improper Yautja Ship"
@@ -259,88 +226,96 @@
 	set name = "Claim Equipment"
 	set desc = "When you're on the Predator ship, claim some gear. You can only do this ONCE."
 
+	if(hunter_data.claimed_equipment)
+		to_chat(src, SPAN_WARNING("You've already claimed your equipment."))
+		return
+
 	if(is_mob_incapacitated() || lying || buckled)
-		to_chat(src, "You're not able to do that right now.")
+		to_chat(src, SPAN_WARNING("You're not able to do that right now."))
 		return
 
 	if(!isYautja(src))
-		to_chat(src, "How did you get this verb?")
+		to_chat(src, SPAN_WARNING("How did you get this verb?"))
 		return
 
-	if(!istype(get_area(src),/area/yautja))
-		to_chat(src, "Not here. Only on the ship.")
+	if(!istype(get_area(src), /area/yautja))
+		to_chat(src, SPAN_WARNING("Not here. Only on the ship."))
 		return
 
-	var/obj/item/clothing/gloves/yautja/hunter/Y = src.gloves
-	if(!istype(Y) || Y.upgrades) return
+	var/obj/item/clothing/gloves/yautja/hunter/bracers = gloves
+	if(!istype(bracers))
+		to_chat(src, SPAN_WARNING("You need to be wearing your bracers to do this."))
+		return
 
-	var/sure = alert("An array of powerful weapons are displayed to you. Pick your gear carefully. If you cancel at any point, you will not claim your equipment.","Sure?","Begin the Hunt","No, not now")
-	if(sure == "Begin the Hunt")
-		var/list/melee = list(YAUTJA_GEAR_GLAIVE, YAUTJA_GEAR_WHIP, YAUTJA_GEAR_SWORD, YAUTJA_GEAR_SCYTHE, YAUTJA_GEAR_STICK, YAUTJA_GEAR_SCIMS)
-		var/list/other = list(YAUTJA_GEAR_LAUNCHER, YAUTJA_GEAR_PISTOL, YAUTJA_GEAR_DISC, YAUTJA_GEAR_FULL_ARMOR, YAUTJA_GEAR_SHIELD, YAUTJA_GEAR_DRONE)
-		var/list/restricted = list(YAUTJA_GEAR_LAUNCHER, YAUTJA_GEAR_PISTOL, YAUTJA_GEAR_FULL_ARMOR, YAUTJA_GEAR_SHIELD, YAUTJA_GEAR_DRONE) //Can only select them once each.
-	//the radial ones have to be in seperate lists in order for the images to not fuck with the no radials one
-		var/list/radial_melee = list(YAUTJA_GEAR_GLAIVE = image(icon = 'icons/obj/items/hunter/pred_gear.dmi', icon_state = "glaive"), YAUTJA_GEAR_WHIP = image(icon = 'icons/obj/items/hunter/pred_gear.dmi', icon_state = "whip"),YAUTJA_GEAR_SWORD = image(icon = 'icons/obj/items/hunter/pred_gear.dmi', icon_state = "clansword"),YAUTJA_GEAR_SCYTHE = image(icon = 'icons/obj/items/hunter/pred_gear.dmi', icon_state = "predscythe"), YAUTJA_GEAR_STICK = image(icon = 'icons/obj/items/hunter/pred_gear.dmi', icon_state = "combistick"), YAUTJA_GEAR_SCIMS = image(icon = 'icons/obj/items/hunter/pred_gear.dmi', icon_state = "scim"))
-		var/list/radial_other = list(YAUTJA_GEAR_LAUNCHER = image(icon = 'icons/obj/items/hunter/pred_gear.dmi', icon_state = "spikelauncher"), YAUTJA_GEAR_PISTOL = image(icon = 'icons/obj/items/hunter/pred_gear.dmi', icon_state = "plasmapistol"), YAUTJA_GEAR_DISC = image(icon = 'icons/obj/items/hunter/pred_gear.dmi', icon_state = "disk"), YAUTJA_GEAR_FULL_ARMOR = image(icon = 'icons/obj/items/hunter/pred_gear.dmi', icon_state = "fullarmor_ebony"), YAUTJA_GEAR_SHIELD = image(icon = 'icons/obj/items/hunter/pred_gear.dmi', icon_state = "shield"), YAUTJA_GEAR_DRONE = image(icon = 'icons/obj/items/hunter/pred_gear.dmi', icon_state = "falcon_drone"))
-		var/list/radial_restricted = list(YAUTJA_GEAR_LAUNCHER, YAUTJA_GEAR_PISTOL, YAUTJA_GEAR_FULL_ARMOR, YAUTJA_GEAR_SHIELD, YAUTJA_GEAR_DRONE) //Can only select them once each.
+	var/sure = alert("An array of powerful weapons are displayed to you. Pick your gear carefully. If you cancel at any point, you will not claim your equipment.", "Sure?", "Begin the Hunt", "No, not now")
+	if(sure != "Begin the Hunt")
+		return
 
-		var/msel
-		var/mother_0
-		var/mother_1
+	var/list/melee = list(YAUTJA_GEAR_GLAIVE = image(icon = 'icons/obj/items/hunter/pred_gear.dmi', icon_state = "glaive"), YAUTJA_GEAR_WHIP = image(icon = 'icons/obj/items/hunter/pred_gear.dmi', icon_state = "whip"),YAUTJA_GEAR_SWORD = image(icon = 'icons/obj/items/hunter/pred_gear.dmi', icon_state = "clansword"),YAUTJA_GEAR_SCYTHE = image(icon = 'icons/obj/items/hunter/pred_gear.dmi', icon_state = "predscythe"), YAUTJA_GEAR_STICK = image(icon = 'icons/obj/items/hunter/pred_gear.dmi', icon_state = "combistick"), YAUTJA_GEAR_SCIMS = image(icon = 'icons/obj/items/hunter/pred_gear.dmi', icon_state = "scim"))
+	var/list/other = list(YAUTJA_GEAR_LAUNCHER = image(icon = 'icons/obj/items/hunter/pred_gear.dmi', icon_state = "spikelauncher"), YAUTJA_GEAR_PISTOL = image(icon = 'icons/obj/items/hunter/pred_gear.dmi', icon_state = "plasmapistol"), YAUTJA_GEAR_DISC = image(icon = 'icons/obj/items/hunter/pred_gear.dmi', icon_state = "disk"), YAUTJA_GEAR_FULL_ARMOR = image(icon = 'icons/obj/items/hunter/pred_gear.dmi', icon_state = "fullarmor_ebony"), YAUTJA_GEAR_SHIELD = image(icon = 'icons/obj/items/hunter/pred_gear.dmi', icon_state = "shield"), YAUTJA_GEAR_DRONE = image(icon = 'icons/obj/items/hunter/pred_gear.dmi', icon_state = "falcon_drone"))
+	var/list/restricted = list(YAUTJA_GEAR_LAUNCHER, YAUTJA_GEAR_PISTOL, YAUTJA_GEAR_FULL_ARMOR, YAUTJA_GEAR_SHIELD, YAUTJA_GEAR_DRONE) //Can only select them once each.
 
-		if(src.client.prefs && src.client.prefs.no_radials_preference)
-			msel = tgui_input_list(usr, "Which weapon shall you use on your hunt?:","Melee Weapon", melee)
-			if(!msel) return //We don't want them to cancel out then get nothing.
-			mother_0 = tgui_input_list(usr, "Which secondary gear shall you take?","Item 1 (of 2)", other)
-			if(!mother_0) return
-			if(mother_0 in restricted)
-				other -= mother_0
-			mother_1 = tgui_input_list(usr, "And the last piece of equipment?:","Item 2 (of 2)", other)
-			if(!mother_1) return
-		else
-			msel = show_radial_menu(src, src, radial_melee)
-			if(!msel) return //We don't want them to cancel out then get nothing.
-			mother_0 = show_radial_menu(src, src, radial_other)
-			if(!mother_0) return
-			if(mother_0 in radial_restricted)
-				radial_other -= mother_0
-			mother_1 = show_radial_menu(src, src, radial_other)
-			if(!mother_1) return
+	var/list/secondaries = list()
+	var/total_secondaries = 2
 
-		if(!istype(Y) || Y.upgrades) return //Tried to run it several times in the same loop. That's not happening.
-		Y.upgrades++ //Just means gear was purchased.
+	var/use_radials = src.client.prefs?.no_radials_preference ? FALSE : TRUE
+	var/main_weapon = use_radials ? show_radial_menu(src, src, melee) : tgui_input_list(usr, "Which weapon shall you use on your hunt?:", "Melee Weapon", melee)
+	if(!main_weapon)
+		return
+	for(var/i = 1 to total_secondaries)
+		var/secondary = use_radials ? show_radial_menu(src, src, other) : tgui_input_list(usr, "Which secondary gear shall you take?", "Item [i] (of [total_secondaries])", other)
+		if(!secondary)
+			return
+		secondaries += secondary
+		if(secondary in restricted)
+			other -= secondary
 
-		switch(msel)
-			if("The Lumbering Glaive")
-				new /obj/item/weapon/melee/twohanded/yautja/glaive(src.loc)
-			if("The Rending Chain-Whip")
-				new /obj/item/weapon/melee/yautja/chain(src.loc)
-			if("The Piercing Hunting Sword")
-				new /obj/item/weapon/melee/yautja/sword(src.loc)
-			if("The Cleaving War-Scythe")
-				new /obj/item/weapon/melee/yautja/scythe(src.loc)
-			if("The Adaptive Combi-Stick")
-				new /obj/item/weapon/melee/yautja/combistick(src.loc)
-			if("The Fearsome Scimitars")
-				Y.scimitars = TRUE
-				Y.charge_max -= 500
+	bracers = gloves
+	if(!istype(bracers))
+		to_chat(src, SPAN_WARNING("You need to be wearing your bracers to do this."))
+		return
 
-		var/choice = mother_0
-		var/i = 0
-		while(++i <= 2)
-			switch(choice)
-				if("The Fleeting Spike Launcher")
-					new /obj/item/weapon/gun/launcher/spike(src.loc)
-				if("The Swift Plasma Pistol")
-					new /obj/item/weapon/gun/energy/yautja/plasmapistol(src.loc)
-				if("The Purifying Smart-Disc")
-					new /obj/item/explosive/grenade/spawnergrenade/smartdisc(src.loc)
-				if("The Formidable Plate Armor")
-					new /obj/item/clothing/suit/armor/yautja/hunter/full(src.loc, 0,  src.client.prefs.predator_armor_material)
-				if("The Steadfast Shield")
-					new /obj/item/weapon/shield/riot/yautja(src.loc)
-				if("The Agile Drone")
-					new /obj/item/falcon_drone(src.loc)
-			choice = mother_1
+	if(hunter_data.claimed_equipment)
+		to_chat(src, SPAN_WARNING("You've already claimed your equipment."))
+		return
 
-		remove_verb(src, /mob/living/carbon/human/proc/pred_buy)
+	hunter_data.claimed_equipment = TRUE
+
+	switch(main_weapon)
+		if(YAUTJA_GEAR_GLAIVE)
+			equip_to_slot_if_possible(new /obj/item/weapon/melee/twohanded/yautja/glaive(src.loc), WEAR_J_STORE, disable_warning = TRUE)
+		if(YAUTJA_GEAR_WHIP)
+			equip_to_slot_if_possible(new /obj/item/weapon/melee/yautja/chain(src.loc), WEAR_J_STORE, disable_warning = TRUE)
+		if(YAUTJA_GEAR_SWORD)
+			equip_to_slot_if_possible(new /obj/item/weapon/melee/yautja/sword(src.loc), WEAR_J_STORE, disable_warning = TRUE)
+		if(YAUTJA_GEAR_SCYTHE)
+			equip_to_slot_if_possible(new /obj/item/weapon/melee/yautja/scythe(src.loc), WEAR_J_STORE, disable_warning = TRUE)
+		if(YAUTJA_GEAR_STICK)
+			equip_to_slot_if_possible(new /obj/item/weapon/melee/yautja/combistick(src.loc), WEAR_J_STORE, disable_warning = TRUE)
+		if(YAUTJA_GEAR_SCIMS)
+			if(bracers.wristblades_deployed)
+				bracers.wristblades_internal(usr, TRUE)
+			qdel(bracers.left_wristblades)
+			qdel(bracers.right_wristblades)
+			bracers.left_wristblades = new /obj/item/weapon/wristblades/scimitar(bracers)
+			bracers.right_wristblades = new /obj/item/weapon/wristblades/scimitar(bracers)
+			bracers.charge_max -= 500
+
+	for(var/choice in secondaries)
+		switch(choice)
+			if(YAUTJA_GEAR_LAUNCHER)
+				equip_to_slot_if_possible(new /obj/item/weapon/gun/launcher/spike(src.loc), WEAR_IN_BELT, disable_warning = TRUE)
+			if(YAUTJA_GEAR_PISTOL)
+				equip_to_slot_if_possible(new /obj/item/weapon/gun/energy/yautja/plasmapistol(src.loc), WEAR_IN_BELT, disable_warning = TRUE)
+			if(YAUTJA_GEAR_DISC)
+				equip_to_slot_if_possible(new /obj/item/explosive/grenade/spawnergrenade/smartdisc(src.loc), WEAR_IN_BELT, disable_warning = TRUE)
+			if(YAUTJA_GEAR_FULL_ARMOR)
+				if(wear_suit)
+					drop_inv_item_on_ground(wear_suit)
+				equip_to_slot_if_possible(new /obj/item/clothing/suit/armor/yautja/hunter/full(src.loc, 0, src.client.prefs.predator_armor_material), WEAR_JACKET, disable_warning = TRUE)
+			if(YAUTJA_GEAR_SHIELD)
+				equip_to_slot_if_possible(new /obj/item/weapon/shield/riot/yautja(src.loc), WEAR_BACK, disable_warning = TRUE)
+			if(YAUTJA_GEAR_DRONE)
+				equip_to_slot_if_possible(new /obj/item/falcon_drone(src.loc), WEAR_R_EAR, disable_warning = TRUE)
+
+	remove_verb(src, /mob/living/carbon/human/proc/pred_buy)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Tweaks and redoes a lot of Yautja code to be more sane. There's too many individual changes to list, so I'll just put down the biggest changes here.

What I Can Remember:
 - Thrall weapons now have a human_adapted var, which makes them work the same way as if a Yautja would use them. For instance, the combi-stick is now actually usable.
 - Thralls can now actually pick their weapons when using radial menus because it used the wrong anchor initially.
 - Thralls now get the Claim Equipment verb because it wouldn't show up correctly all the time because it was getting attached to the bracer and the bracer stayed stationary.
 - Thralls now have 'Mentors', not 'Masters'. Please don't roleplay having a master.
 - Cloak cooldowns are now actually measured in seconds, instead of two seconds pretending to be a second.
 - Hard refs to linked bracers are now cleared when the bracer is destroyed.
 - The check random function has been completely revamped to not be copy pasted everywhere, and also made to not rely on usr. Same goes for the internal bracer procs.
 - Casters and blades now have a sane deployment system. Blades will now be the same blades you deploy, so your bloodstained and/or labeled blades will remain in that state as you use them.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Predcode is known for being preeeeeetty awful, this does a fair bit to fix that.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Yautja thralls now refer to the thrallee as a mentor, not a master.
fix: Yautja thralls can now properly use their weaponry.
refactor: Refactored a whole lot of Yautja code, some things may be wonky.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
