### PR TITLE
(QoL)Bring back the old engi prep tool vendors

### DIFF
--- a/code/game/machinery/vending/vendor_types/engineering.dm
+++ b/code/game/machinery/vending/vendor_types/engineering.dm
@@ -52,19 +52,15 @@
 
 /obj/structure/machinery/cm_vending/sorted/tech/comtech_tools
 	name = "\improper ColMarTech Squad ComTech Tools Vendor"
-	desc = "A vending machine that stores extra tools an engineer may need on the field."
+	desc = "A vending machine that stores various extra tools that are useful on the field."
 	icon_state = "tool"
 	req_access = list(ACCESS_MARINE_ENGPREP)
 
 /obj/structure/machinery/cm_vending/sorted/tech/comtech_tools/populate_product_list(var/scale)
 	listed_products = list(
 		list("EQUIPMENT", -1, null, null),
-		list("Combat Flashlight", round(scale * 4), /obj/item/device/flashlight/combat, VENDOR_ITEM_REGULAR),
 		list("Utility Tool Belt", round(scale * 4), /obj/item/storage/belt/utility, VENDOR_ITEM_REGULAR),
-		list("Welding Goggles", round(scale * 2), /obj/item/clothing/glasses/welding, VENDOR_ITEM_REGULAR),
-		list("M10 technician helmet", round(scale * 4), /obj/item/clothing/head/helmet/marine/tech, VENDOR_ITEM_REGULAR),
 		list("Cable Coil", round(scale * 4), /obj/item/stack/cable_coil/random, VENDOR_ITEM_REGULAR),
-		list("High-Capacity Power Cell", round(scale * 1), /obj/item/cell/high, VENDOR_ITEM_REGULAR),
 
 		list("TOOLS", -1, null, null),
 		list("Blowtorch", round(scale * 4), /obj/item/tool/weldingtool, VENDOR_ITEM_REGULAR),
@@ -72,8 +68,7 @@
 		list("Screwdriver", round(scale * 4), /obj/item/tool/screwdriver, VENDOR_ITEM_REGULAR),
 		list("Wirecutters", round(scale * 4), /obj/item/tool/wirecutters, VENDOR_ITEM_REGULAR),
 		list("Wrench", round(scale * 4), /obj/item/tool/wrench, VENDOR_ITEM_REGULAR),
-		list("Multitool", round(scale * 4), /obj/item/device/multitool, VENDOR_ITEM_REGULAR),
-		list("Entrenching tool", round(scale * 4), /obj/item/tool/shovel/etool, VENDOR_ITEM_REGULAR)
+		list("Multitool", round(scale * 4), /obj/item/device/multitool, VENDOR_ITEM_REGULAR)
 	)
 
 /obj/structure/machinery/cm_vending/sorted/tech/circuits

--- a/code/game/machinery/vending/vendor_types/engineering.dm
+++ b/code/game/machinery/vending/vendor_types/engineering.dm
@@ -50,6 +50,32 @@
 		list("Wrench", round(scale * 4), /obj/item/tool/wrench, VENDOR_ITEM_REGULAR)
 	)
 
+/obj/structure/machinery/cm_vending/sorted/tech/comtech_tools
+	name = "\improper ColMarTech Squad ComTech Tools Vendor"
+	desc = "A vending machine that stores extra tools an engineer may need on the field."
+	icon_state = "tool"
+	req_access = list(ACCESS_MARINE_ENGPREP)
+
+/obj/structure/machinery/cm_vending/sorted/tech/comtech_tools/populate_product_list(var/scale)
+	listed_products = list(
+		list("EQUIPMENT", -1, null, null),
+		list("Combat Flashlight", round(scale * 4), /obj/item/device/flashlight/combat, VENDOR_ITEM_REGULAR),
+		list("Utility Tool Belt", round(scale * 4), /obj/item/storage/belt/utility, VENDOR_ITEM_REGULAR),
+		list("Welding Goggles", round(scale * 2), /obj/item/clothing/glasses/welding, VENDOR_ITEM_REGULAR),
+		list("M10 technician helmet", round(scale * 4), /obj/item/clothing/head/helmet/marine/tech, VENDOR_ITEM_REGULAR),
+		list("Cable Coil", round(scale * 4), /obj/item/stack/cable_coil/random, VENDOR_ITEM_REGULAR),
+		list("High-Capacity Power Cell", round(scale * 1), /obj/item/cell/high, VENDOR_ITEM_REGULAR),
+
+		list("TOOLS", -1, null, null),
+		list("Blowtorch", round(scale * 4), /obj/item/tool/weldingtool, VENDOR_ITEM_REGULAR),
+		list("Crowbar", round(scale * 4), /obj/item/tool/crowbar, VENDOR_ITEM_REGULAR),
+		list("Screwdriver", round(scale * 4), /obj/item/tool/screwdriver, VENDOR_ITEM_REGULAR),
+		list("Wirecutters", round(scale * 4), /obj/item/tool/wirecutters, VENDOR_ITEM_REGULAR),
+		list("Wrench", round(scale * 4), /obj/item/tool/wrench, VENDOR_ITEM_REGULAR),
+		list("Multitool", round(scale * 4), /obj/item/device/multitool, VENDOR_ITEM_REGULAR),
+		list("Entrenching tool", round(scale * 4), /obj/item/tool/shovel/etool, VENDOR_ITEM_REGULAR)
+	)
+
 /obj/structure/machinery/cm_vending/sorted/tech/circuits
 	name = "circuit board vendor"
 	desc = "A safe storage for pre-programmed circuit boards, it has an internal gyroscope to keep any external force from moving the boards, thick insulation and a custom 2.1mm UPS port for charging various W-Y exclusive devices (sold separately)."

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -705,12 +705,14 @@
 	},
 /area/almayer/engineering/upper_engineering)
 "abS" = (
+/obj/structure/machinery/cm_vending/sorted/tech/comtech_tools,
 /turf/open/floor/almayer{
 	icon_state = "cargo";
 	tag = "icon-bluecorner (NORTH)"
 	},
 /area/almayer/squads/alpha)
 "abT" = (
+/obj/structure/machinery/cm_vending/sorted/tech/comtech_tools,
 /turf/open/floor/almayer{
 	icon_state = "cargo";
 	tag = "icon-bluecorner (NORTH)"
@@ -821,6 +823,7 @@
 /turf/open/floor/wood/ship,
 /area/almayer/living/basketball)
 "ack" = (
+/obj/structure/machinery/cm_vending/sorted/tech/comtech_tools,
 /turf/open/floor/almayer{
 	icon_state = "cargo";
 	tag = "icon-bluecorner (NORTH)"
@@ -864,6 +867,7 @@
 	},
 /area/almayer/living/chapel)
 "acp" = (
+/obj/structure/machinery/cm_vending/sorted/tech/comtech_tools,
 /turf/open/floor/almayer{
 	icon_state = "cargo";
 	tag = "icon-bluecorner (NORTH)"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
This quality of life PR brings back the old engineering tool vendors before they were removed, though lacking the hacked items available or the coin equipment selection. It sports all basic tools and does not contain upgraded welders or anything of the sort. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Engineers are pretty much forced to take a toolbelt for basic fucking tools or have to run all the way to engineering/maint. Which sucks because you are provided the illusion of choice when choosing a belt and less flexibility. Tools pouch isnt much better as it has a wirecutter rather than a crowbar, which is a pretty much-required tool and forces you to look for one.

It only has basic tools meaning that if you want a high-cap/industrial blowtorch, you still need to go to engineering and hack a vendor there. Also gave it some etools because those should honestly be free. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: TotalEpicness
add: Added back the engineering tool vendors to Comtech prep
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
