### PR TITLE
Xeno Language Understanding (Sort Of)

### DIFF
--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -17,17 +17,7 @@
 		if (!speaker || (src.sdisabilities & DISABILITY_BLIND || src.blinded) || !(speaker.z == z && get_dist(speaker, src) <= world_view_size))
 			message = language.scramble(message)
 
-	if(!say_understands(speaker,language))
-		if(istype(speaker,/mob/living/simple_animal))
-			var/mob/living/simple_animal/S = speaker
-			if(S.speak.len)
-				message = pick(S.speak)
-			else
-				message = stars(message)
-		else if(language)
-			message = language.scramble(message)
-		else
-			message = stars(message)
+	message = handle_language_scramble(message, language, speaker)
 
 	if(language)
 		style = language.colour
@@ -79,14 +69,7 @@
 		if (!speaker || (src.sdisabilities & DISABILITY_BLIND || src.blinded) || !(speaker in view(src)))
 			message = stars(message)
 
-	if(!say_understands(speaker,language))
-		if(istype(speaker,/mob/living/simple_animal))
-			var/mob/living/simple_animal/S = speaker
-			message = pick(S.speak)
-		else if(language)
-			message = language.scramble(message)
-		else
-			message = stars(message)
+	message = handle_language_scramble(message, language, speaker)
 
 	if(language)
 		style = language.colour
@@ -222,3 +205,29 @@
 		heard = SPAN_LOCALSAY("<span class = 'game_say'>...<i>You almost hear someone talking</i>...</span>")
 
 	to_chat(src, heard)
+
+/mob/proc/handle_language_scramble(var/message, var/datum/language/language, var/mob/speaker)
+	if(!say_understands(speaker, language))
+		if(istype(speaker,/mob/living/simple_animal))
+			var/mob/living/simple_animal/S = speaker
+			if(S.speak.len)
+				return pick(S.speak)
+			else
+				return stars(message)
+		else if(language)
+			return language.scramble(message)
+		else
+			return stars(message)
+	return message
+
+/mob/living/carbon/Xenomorph/handle_language_scramble(var/message, var/datum/language/language, var/mob/speaker)
+	if(!say_understands(speaker, language))
+		if(istype(speaker, /mob/living/simple_animal))
+			var/mob/living/simple_animal/S = speaker
+			if(S.speak.len)
+				return pick(S.speak)
+			else
+				return stars(message)
+		var/static/regex/illegal_letters = regex(@{"[prhwkqcomfd]+"}, "gi")
+		return illegal_letters.Replace(message, "")
+	return message


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Allows xenos to understand speech from languages they don't know, but with various letters taken out, making it pretty much impossible to decipher.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

I love seeing people scream when xenos run at them, but I don't get that same experience when I'm playing xeno because all the words are swapped out for stock phrases. This should maybe alleviate that.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Xenos can now semi-understand human speech, but various letters are taken out and replaced with nothing to make it near impossible to decipher. This allows the vibe of the words to be maintained but the words themselves are incomprehensible.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
