### PR TITLE
No more xenos in bodyscanners

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -236,11 +236,12 @@
 
 /obj/structure/machinery/sleeper/attackby(var/obj/item/W, var/mob/living/user)
 	if(istype(W, /obj/item/grab))
-		if(isXeno(user)) return
 		var/obj/item/grab/G = W
-		if(!ismob(G.grabbed_thing))
+		if(isXeno(G.grabbed_thing))
+			to_chat(user, SPAN_WARNING("An unsupported lifeform was detected, aborting!"))
 			return
-
+		if(!ismob(G.grabbed_thing) || (isXeno(user)))
+			return
 		if(occupant)
 			to_chat(user, SPAN_NOTICE("The sleeper is already occupied!"))
 			return
@@ -251,7 +252,8 @@
 			if(occupant)
 				to_chat(user, SPAN_NOTICE("The sleeper is already occupied!"))
 				return
-			if(!G || !G.grabbed_thing) return
+			if(!G || !G.grabbed_thing)
+				return
 			var/mob/M = G.grabbed_thing
 			go_in_sleeper(M)
 			add_fingerprint(user)

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -75,14 +75,18 @@
 
 
 /obj/structure/machinery/bodyscanner/proc/go_in_bodyscanner(mob/M)
-	M.forceMove(src)
-	occupant = M
-	update_use_power(2)
-	icon_state = "body_scanner_1"
-	//prevents occupant's belonging from landing inside the machine
-	for(var/obj/O in src)
-		O.forceMove(loc)
-	playsound(src, 'sound/machines/scanning_pod1.ogg')
+	if(isXeno(M))
+		return
+	if(do_after(usr, 10, INTERRUPT_NO_NEEDHAND, BUSY_ICON_GENERIC))
+		to_chat(usr, SPAN_NOTICE("You move [M.name] inside \the [src]."))
+		M.forceMove(src)
+		occupant = M
+		update_use_power(2)
+		icon_state = "body_scanner_1"
+		//prevents occupant's belonging from landing inside the machine
+		for(var/obj/O in src)
+			O.forceMove(loc)
+		playsound(src, 'sound/machines/scanning_pod1.ogg')
 
 /obj/structure/machinery/bodyscanner/proc/go_out()
 	if ((!( src.occupant ) || src.locked))
@@ -133,9 +137,11 @@
 	if (M.abiotic())
 		to_chat(user, SPAN_WARNING("Subject cannot have abiotic items on."))
 		return
+	if (isXeno(M))
+		to_chat(user, SPAN_WARNING("An unsupported lifeform was detected, aborting!"))
+		return
 
 	go_in_bodyscanner(M)
-
 	add_fingerprint(user)
 	//G = null
 

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -237,7 +237,7 @@
 	if (inoperable())
 		to_chat(usr, SPAN_DANGER("The cryo cell is not functioning."))
 		return
-	if (!istype(M))
+	if (!istype(M) || isXeno(M))
 		to_chat(usr, SPAN_DANGER("<B>The cryo cell cannot handle such a lifeform!</B>"))
 		return
 	if (occupant)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Xenomorphs can no longer stuff themselves into Cryopods/bodyscanners

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
address issue #370 
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Xenos can no longer get inside bodyscanners, cryopods, or sleepers.
fix: Humans cannot jump into body scanners instantly anymore.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
closes #370