### PR TITLE
Minor Almayer changes at nanus request

### DIFF
--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -15128,7 +15128,8 @@
 	pixel_y = 24
 	},
 /turf/open/floor/almayer{
-	allow_construction = 0
+	icon_state = "plate";
+	tag = "icon-sterile"
 	},
 /area/almayer/shipboard/brig/perma)
 "aSY" = (
@@ -36626,7 +36627,8 @@
 	pixel_y = -24
 	},
 /turf/open/floor/almayer{
-	allow_construction = 0
+	icon_state = "plate";
+	tag = "icon-sterile"
 	},
 /area/almayer/shipboard/brig/perma)
 "deg" = (
@@ -39672,7 +39674,8 @@
 	pixel_y = 24
 	},
 /turf/open/floor/almayer{
-	allow_construction = 0
+	icon_state = "plate";
+	tag = "icon-sterile"
 	},
 /area/almayer/shipboard/brig/perma)
 "eoT" = (
@@ -41467,7 +41470,7 @@
 	},
 /area/almayer/medical/upper_medical)
 "fbY" = (
-/obj/structure/window/framed/almayer/hull/hijack_bustable,
+/obj/structure/window/framed/almayer,
 /obj/structure/machinery/door/poddoor/shutters/almayer/open{
 	dir = 2;
 	id = "Execution Shutters";
@@ -41645,12 +41648,11 @@
 	},
 /area/almayer/shipboard/starboard_point_defense)
 "fgl" = (
-/obj/structure/sign/safety/coffee{
-	pixel_x = 24;
-	pixel_y = -32
+/turf/open/floor/almayer{
+	icon_state = "plate";
+	tag = "icon-sterile"
 	},
-/turf/open/floor/almayer,
-/area/almayer/hallways/port_hallway)
+/area/almayer/shipboard/brig/perma)
 "fgm" = (
 /obj/structure/sign/safety/hvac_old{
 	pixel_x = 8;
@@ -47681,6 +47683,7 @@
 /obj/structure/machinery/reagentgrinder{
 	pixel_y = 3
 	},
+/obj/item/device/analyzer/plant_analyzer,
 /turf/open/floor/almayer{
 	icon_state = "green";
 	tag = "icon-green"
@@ -50685,7 +50688,8 @@
 	tag = "icon-chair (EAST)"
 	},
 /turf/open/floor/almayer{
-	allow_construction = 0
+	icon_state = "plate";
+	tag = "icon-sterile"
 	},
 /area/almayer/shipboard/brig/perma)
 "jlA" = (
@@ -53782,7 +53786,8 @@
 	pixel_y = -10
 	},
 /turf/open/floor/almayer{
-	allow_construction = 0
+	icon_state = "plate";
+	tag = "icon-sterile"
 	},
 /area/almayer/shipboard/brig/perma)
 "kOk" = (
@@ -63518,7 +63523,8 @@
 	tag = "icon-chair (EAST)"
 	},
 /turf/open/floor/almayer{
-	allow_construction = 0
+	icon_state = "plate";
+	tag = "icon-sterile"
 	},
 /area/almayer/shipboard/brig/perma)
 "ppe" = (
@@ -64258,6 +64264,9 @@
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/general_equipment)
+"pHp" = (
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/brig/perma)
 "pHA" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -65554,7 +65563,8 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	allow_construction = 0
+	icon_state = "plate";
+	tag = "icon-sterile"
 	},
 /area/almayer/shipboard/brig/perma)
 "qnh" = (
@@ -76885,6 +76895,10 @@
 /obj/structure/machinery/power/apc/almayer/hardened{
 	dir = 8
 	},
+/obj/structure/surface/rack,
+/obj/item/stack/sheet/glass/reinforced{
+	amount = 50
+	},
 /turf/open/floor/almayer{
 	dir = 8;
 	icon_state = "orange";
@@ -79645,7 +79659,8 @@
 /obj/item/tool/pen,
 /obj/structure/surface/table/reinforced/black,
 /turf/open/floor/almayer{
-	allow_construction = 0
+	icon_state = "plate";
+	tag = "icon-sterile"
 	},
 /area/almayer/shipboard/brig/perma)
 "wvT" = (
@@ -81787,7 +81802,8 @@
 	pixel_y = 13
 	},
 /turf/open/floor/almayer{
-	allow_construction = 0
+	icon_state = "plate";
+	tag = "icon-sterile"
 	},
 /area/almayer/shipboard/brig/perma)
 "xrr" = (
@@ -82430,7 +82446,8 @@
 	pixel_x = -32
 	},
 /turf/open/floor/almayer{
-	allow_construction = 0
+	icon_state = "plate";
+	tag = "icon-sterile"
 	},
 /area/almayer/shipboard/brig/perma)
 "xEz" = (
@@ -82784,7 +82801,22 @@
 /turf/open/space/basic,
 /area/space)
 "xMh" = (
-/obj/structure/closet/crate/trashcart,
+/obj/structure/closet/crate{
+	desc = "One of those old special operations crates from back in the day. After a leaked report from a meeting of MARSOC leadership lambasted the crates as 'waste of operational funds' the crates were removed from service.";
+	name = "special operations crate"
+	},
+/obj/item/clothing/mask/gas/swat,
+/obj/item/clothing/mask/gas/swat,
+/obj/item/clothing/mask/gas/swat,
+/obj/item/clothing/mask/gas/swat,
+/obj/item/attachable/suppressor,
+/obj/item/attachable/suppressor,
+/obj/item/attachable/suppressor,
+/obj/item/attachable/suppressor,
+/obj/item/explosive/grenade/smokebomb,
+/obj/item/explosive/grenade/smokebomb,
+/obj/item/explosive/grenade/smokebomb,
+/obj/item/explosive/grenade/smokebomb,
 /turf/open/floor/almayer{
 	icon_state = "plate";
 	tag = "icon-sterile"
@@ -96658,11 +96690,11 @@ xkd
 xkd
 naB
 eoP
-qyd
+fgl
 xEe
 naB
 xEe
-qyd
+fgl
 deb
 naB
 lmk
@@ -96861,11 +96893,11 @@ rSH
 xYj
 naB
 aSS
-qyd
+pHp
 poZ
 naB
 jkV
-qyd
+pHp
 kOi
 naB
 xCj
@@ -97064,11 +97096,11 @@ rvo
 oIc
 naB
 xro
-qyd
+fgl
 wvI
 naB
 wvI
-qyd
+fgl
 qmX
 naB
 lTK
@@ -116047,7 +116079,7 @@ tQd
 nyw
 buH
 bHL
-fgl
+buH
 yfS
 sEi
 dck
@@ -120084,7 +120116,7 @@ nsY
 kfp
 aYT
 beB
-aLG
+beB
 bdd
 bqZ
 bgO
@@ -120104,7 +120136,7 @@ xAt
 bgO
 bqZ
 bdd
-buH
+bJz
 bJz
 bHT
 qhQ
@@ -120717,7 +120749,7 @@ buH
 bHa
 bHL
 buH
-bJz
+buH
 cbD
 iZH
 sDQ


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Removed a semiotic that was in glass and had another of the same sign literally two tiles to its west
At nanus's request replaced some of the hull windows in the brig to reinforced windows
at nanus's request added a stack of 50 reinforced glass to the brig maint room
added a reference to an old req crate from 2016 to Almayer maint
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
The headdev told me to do it
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Almayer, Replaced hull windows in the execution room with reinforced windows at nanus request
add: Almayer, Added reinforced glass to brig maint
del: Almayer, Removed a coffee sign that was in the glass and was two tiles west of another coffee sign
add: Almayer, Did some tiling around the Almayer to make it look a little bit more pretty

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
