### PR TITLE
Fix throw speeds of various items

### DIFF
--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -53,7 +53,7 @@ GLOBAL_LIST_INIT(rod_recipes, list (
 	w_class = SIZE_MEDIUM
 	force = 9.0
 	throwforce = 15.0
-	throw_speed = 0
+	throw_speed = SPEED_VERY_FAST
 	throw_range = 20
 	matter = list("plasteel" = 3750)
 	max_amount = 60

--- a/code/game/objects/items/stacks/sandbags.dm
+++ b/code/game/objects/items/stacks/sandbags.dm
@@ -60,7 +60,7 @@
 	w_class = SIZE_LARGE
 	force = 9.0
 	throwforce = 15.0
-	throw_speed = 0
+	throw_speed = SPEED_VERY_FAST
 	throw_range = 20
 	max_amount = 25
 	attack_verb = list("hit", "bludgeoned", "whacked")

--- a/code/game/objects/items/stacks/sheets/light.dm
+++ b/code/game/objects/items/stacks/sheets/light.dm
@@ -6,7 +6,7 @@
 	w_class = SIZE_MEDIUM
 	force = 3.0
 	throwforce = 5.0
-	throw_speed = 0
+	throw_speed = SPEED_VERY_FAST
 	throw_range = 20
 	max_amount = 60
 	stack_id = "wired glass tile"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Fixes the throw speeds of plasteel rods, sandbags, and wired glass tiles. Previously the throw speeds were set to 0 (they were the only objects I could find in the codebase with that value). Now they have been set to match the throw speeds of normal rods, empty sandbags, and glass tiles, respectively (all of which happen to be SPEED_VERY_FAST).
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Currently the plasteel rods move extremely slowly when thrown. You could throw them, walk around ahead of them, and then be hit with the rods that you just threw. That doesn't seem very realistic, unless plasteel is so light that it just floats around on air.
The same applies to wired glass tiles and sandbags (full sandbags).
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Laser9
fix: Fixed throw speeds of plasteel rods, wired glass tiles, and sandbags.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
