### PR TITLE
Camouflaged bell tower audio

### DIFF
--- a/code/modules/defenses/bell_tower.dm
+++ b/code/modules/defenses/bell_tower.dm
@@ -175,10 +175,6 @@
 	. = ..()
 	animate(src, alpha = cloak_alpha, time = 2 SECONDS, easing = LINEAR_EASING)
 
-/obj/structure/machinery/defenses/bell_tower/cloaker/mob_crossed(var/turf/location)
-	/// PLACEHOLDER
-	return
-
 
 
 /obj/item/storage/backpack/imp


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Removes the mob_crossed proc from the cloaker child from bell_tower so it uses the parent mob_crossed

This would allow the cloaked bell to makes an audio when a xeno crosses the bell

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The cloaked bell's invisibility is a lot harder to see than scout or pred, it also doesnt move. The only way to know a bell slows you is either you get hit by it and see the chat log, which isnt that a huge of a text to notice, so its harder to notice it, or you right click every single tile.

On top of that, the range is pretty wide that its not that easy to notice where its from unless you're trying to find the sweet spot on where the bell starts hitting you, and you'd have to wait long enough, so you'd have to slow walk around it

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
soundadd: added the bell sound when camouflaged bell is triggered
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
