### PR TITLE
Fix for mark path check.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/mark_menu.dm
+++ b/code/modules/mob/living/carbon/xenomorph/mark_menu.dm
@@ -109,7 +109,7 @@
 	switch(action)
 		if("choose_mark")
 			var/selected_type = text2path(params["type"])
-			if(!istype(selected_type, /datum/xeno_mark_define)) // Hacky fix
+			if(!ispath(selected_type, /datum/xeno_mark_define)) // Hacky fix
 				return
 			var/datum/xeno_mark_define/x = new selected_type
 			var/datum/action/xeno_action/activable/info_marker/Xenos_mark_info_action


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Followup to #322. A decent-ish idea, but unfortunately botched execution. `istype(X, Path)` can only check whether `X` is an _object_ of type `Path`; to check whether `Path1` is a subtype of `Path2`, `ispath(Path1, Path2)` should be used instead.

## Why It's Good For The Game

Is fix.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Resin marks work once again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
