### PR TITLE
Say() optimizations

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -317,7 +317,8 @@ cases. Override_icon_state should be a list.*/
 	appearance_flags &= ~NO_CLIENT_COLOR
 	if(src in S.hearing_items)
 		LAZYREMOVE(S.hearing_items, src)
-
+		if(!S.hearing_items.len)
+			S.flags_atom &= ~USES_HEARING
 
 // called when this item is added into a storage item, which is passed on as S. The loc variable is already set to the storage item.
 /obj/item/proc/on_enter_storage(obj/item/storage/S as obj)
@@ -325,6 +326,7 @@ cases. Override_icon_state should be a list.*/
 	appearance_flags |= NO_CLIENT_COLOR //It's in an inventory item, so saturation/desaturation etc. effects shouldn't affect it.
 	if(src.flags_atom & USES_HEARING)
 		LAZYADD(S.hearing_items, src)
+		S.flags_atom |= USES_HEARING
 
 // called when "found" in pockets and storage items. Returns 1 if the search should end.
 /obj/item/proc/on_found(mob/finder as mob)

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -118,7 +118,7 @@ var/list/department_radio_keys = list(
 		if(T)
 			var/list/hearturfs = list()
 
-			for(var/I in hearers(message_range, T))
+			for(var/I in hear(message_range, T))
 				if(istype(I, /mob/))
 					var/mob/M = I
 					listening += M
@@ -131,7 +131,6 @@ var/list/department_radio_keys = list(
 					hearturfs += O.locs[1]
 					if(O.flags_atom & USES_HEARING)
 						listening_obj |= O
-
 
 			for(var/mob/M as anything in GLOB.player_list)
 				if((M.stat == DEAD || isobserver(M)) && M.client && M.client.prefs && (M.client.prefs.toggles_chat & CHAT_GHOSTEARS))

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -116,16 +116,16 @@ var/list/department_radio_keys = list(
 		var/list/listening_obj = list()
 
 		if(T)
-			var/list/hear = hear(message_range, T)
 			var/list/hearturfs = list()
 
-			for(var/I in hear)
+			for(var/I in hearers(message_range, T))
 				if(istype(I, /mob/))
 					var/mob/M = I
 					listening += M
 					hearturfs += M.locs[1]
 					for(var/obj/O in M.contents)
-						listening_obj |= O
+						if(O.flags_atom & USES_HEARING)
+							listening_obj |= O
 				else if(istype(I, /obj/))
 					var/obj/O = I
 					hearturfs += O.locs[1]
@@ -133,7 +133,7 @@ var/list/department_radio_keys = list(
 						listening_obj |= O
 
 
-			for(var/mob/M in GLOB.player_list)
+			for(var/mob/M as anything in GLOB.player_list)
 				if((M.stat == DEAD || isobserver(M)) && M.client && M.client.prefs && (M.client.prefs.toggles_chat & CHAT_GHOSTEARS))
 					listening |= M
 					continue
@@ -147,14 +147,14 @@ var/list/department_radio_keys = list(
 		var/not_dead_speaker = (stat != DEAD)
 		if(not_dead_speaker)
 			langchat_speech(message, listening, speaking)
-		for(var/mob/M in listening)
+		for(var/mob/M as anything in listening)
 			if(not_dead_speaker)
 				M << speech_bubble
 			M.hear_say(message, verb, speaking, alt_name, italics, src, speech_sound, sound_vol)
 
 		addtimer(CALLBACK(src, .proc/remove_speech_bubble, speech_bubble, listening), 30)
 
-		for(var/obj/O in listening_obj)
+		for(var/obj/O as anything in listening_obj)
 			if(O) //It's possible that it could be deleted in the meantime.
 				O.hear_talk(src, message, verb, speaking, italics)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Some small optimizations to Say()
1. Made sure objects in O.contents properly get checked if they have USES_HEARING flag
2. Added as anything where possible
3. Made storage items not have USES_HEARING if they don't have any items with that flag
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Less lag
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
code: Optimized some say() related code
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
