### PR TITLE
Coffin material fix

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/coffin.dm
+++ b/code/game/objects/structures/crates_lockers/closets/coffin.dm
@@ -16,7 +16,7 @@
 	if(istype(item, /obj/item/tool/crowbar))
 		new /obj/item/stack/sheet/wood(src.loc)
 		for(var/mob/in_view in viewers(src))
-			in_view.show_message(SPAN_NOTICE("\The [src] has been wrenched apart by [user] with a [item]."), 3, "You hear wood breaking.", 2)
+			in_view.show_message(SPAN_NOTICE("\The [src] has been wrenched apart by [user] with [item]."), 3, "You hear wood breaking.", 2)
 		qdel(src)
 		return
 	if(isrobot(user))

--- a/code/game/objects/structures/crates_lockers/closets/coffin.dm
+++ b/code/game/objects/structures/crates_lockers/closets/coffin.dm
@@ -12,6 +12,46 @@
 	else
 		icon_state = icon_opened
 
+/obj/structure/closet/coffin/attackby(obj/item/W, mob/living/user)
+	if(src.opened)
+		if(istype(W, /obj/item/grab))
+			if(isXeno(user)) return
+			var/obj/item/grab/G = W
+			if(G.grabbed_thing)
+				src.MouseDrop_T(G.grabbed_thing, user)      //act like they were dragged onto the closet
+			return
+		if(W.flags_item & ITEM_ABSTRACT)
+			return 0
+		if(istype(W, /obj/item/tool/weldingtool))
+			var/obj/item/tool/weldingtool/WT = W
+			if(!WT.remove_fuel(0,user))
+				to_chat(user, SPAN_NOTICE("You need more welding fuel to complete this task."))
+				return
+			new /obj/item/stack/sheet/wood(src.loc)
+			for(var/mob/M in viewers(src))
+				M.show_message(SPAN_NOTICE("\The [src] has been cut apart by [user] with [WT]."), 3, "You hear welding.", 2)
+			qdel(src)
+			return
+		if(isrobot(user))
+			return
+		user.drop_inv_item_to_loc(W,loc)
+
+	else if(istype(W, /obj/item/packageWrap))
+		return
+	else if(istype(W, /obj/item/tool/weldingtool))
+		var/obj/item/tool/weldingtool/WT = W
+		if(!WT.remove_fuel(0,user))
+			to_chat(user, SPAN_NOTICE("You need more welding fuel to complete this task."))
+			return
+		welded = !welded
+		update_icon()
+		for(var/mob/M in viewers(src))
+			M.show_message(SPAN_WARNING("[src] has been [welded?"welded shut":"unwelded"] by [user.name]."), 3, "You hear welding.", 2)
+	else
+		src.attack_hand(user)
+	return
+
+
 /obj/structure/closet/coffin/predator
 	name = "strange coffin"
 	desc = "It's a burial receptacle for the dearly departed. Seems to have weird markings on the side..?"

--- a/code/game/objects/structures/crates_lockers/closets/coffin.dm
+++ b/code/game/objects/structures/crates_lockers/closets/coffin.dm
@@ -12,17 +12,17 @@
 	else
 		icon_state = icon_opened
 
-/obj/structure/closet/coffin/attackby(obj/item/W, mob/living/user)
-	if(istype(W, /obj/item/tool/crowbar))
-		var/obj/item/tool/crowbar/WT = W
+/obj/structure/closet/coffin/attackby(obj/item/Prybar, mob/living/user)
+	if(istype(Prybar, /obj/item/tool/crowbar))
+		var/obj/item/tool/crowbar/CrB = Prybar
 		new /obj/item/stack/sheet/wood(src.loc)
-		for(var/mob/M in viewers(src))
-			M.show_message(SPAN_NOTICE("\The [src] has been wrenched apart by [user] with [WT]."), 3, "You hear wood breaking.", 2)
+		for(var/mob/Mob in viewers(src))
+			Mob.show_message(SPAN_NOTICE("\The [src] has been wrenched apart by [user] with [CrB]."), 3, "You hear wood breaking.", 2)
 		qdel(src)
 		return
 	if(isrobot(user))
 		return
-	user.drop_inv_item_to_loc(W,loc)
+	user.drop_inv_item_to_loc(Prybar,loc)
 
 /obj/structure/closet/coffin/predator
 	name = "strange coffin"

--- a/code/game/objects/structures/crates_lockers/closets/coffin.dm
+++ b/code/game/objects/structures/crates_lockers/closets/coffin.dm
@@ -13,44 +13,16 @@
 		icon_state = icon_opened
 
 /obj/structure/closet/coffin/attackby(obj/item/W, mob/living/user)
-	if(src.opened)
-		if(istype(W, /obj/item/grab))
-			if(isXeno(user)) return
-			var/obj/item/grab/G = W
-			if(G.grabbed_thing)
-				src.MouseDrop_T(G.grabbed_thing, user)      //act like they were dragged onto the closet
-			return
-		if(W.flags_item & ITEM_ABSTRACT)
-			return 0
-		if(istype(W, /obj/item/tool/weldingtool))
-			var/obj/item/tool/weldingtool/WT = W
-			if(!WT.remove_fuel(0,user))
-				to_chat(user, SPAN_NOTICE("You need more welding fuel to complete this task."))
-				return
-			new /obj/item/stack/sheet/wood(src.loc)
-			for(var/mob/M in viewers(src))
-				M.show_message(SPAN_NOTICE("\The [src] has been cut apart by [user] with [WT]."), 3, "You hear welding.", 2)
-			qdel(src)
-			return
-		if(isrobot(user))
-			return
-		user.drop_inv_item_to_loc(W,loc)
-
-	else if(istype(W, /obj/item/packageWrap))
-		return
-	else if(istype(W, /obj/item/tool/weldingtool))
-		var/obj/item/tool/weldingtool/WT = W
-		if(!WT.remove_fuel(0,user))
-			to_chat(user, SPAN_NOTICE("You need more welding fuel to complete this task."))
-			return
-		welded = !welded
-		update_icon()
+	if(istype(W, /obj/item/tool/crowbar))
+		var/obj/item/tool/crowbar/WT = W
+		new /obj/item/stack/sheet/wood(src.loc)
 		for(var/mob/M in viewers(src))
-			M.show_message(SPAN_WARNING("[src] has been [welded?"welded shut":"unwelded"] by [user.name]."), 3, "You hear welding.", 2)
-	else
-		src.attack_hand(user)
-	return
-
+			M.show_message(SPAN_NOTICE("\The [src] has been wrenched apart by [user] with [WT]."), 3, "You hear wood breaking.", 2)
+		qdel(src)
+		return
+	if(isrobot(user))
+		return
+	user.drop_inv_item_to_loc(W,loc)
 
 /obj/structure/closet/coffin/predator
 	name = "strange coffin"

--- a/code/game/objects/structures/crates_lockers/closets/coffin.dm
+++ b/code/game/objects/structures/crates_lockers/closets/coffin.dm
@@ -12,17 +12,16 @@
 	else
 		icon_state = icon_opened
 
-/obj/structure/closet/coffin/attackby(obj/item/Prybar, mob/living/user)
-	if(istype(Prybar, /obj/item/tool/crowbar))
-		var/obj/item/tool/crowbar/CrB = Prybar
+/obj/structure/closet/coffin/attackby(obj/item/item, mob/living/user)
+	if(istype(item, /obj/item/tool/crowbar))
 		new /obj/item/stack/sheet/wood(src.loc)
-		for(var/mob/Mob in viewers(src))
-			Mob.show_message(SPAN_NOTICE("\The [src] has been wrenched apart by [user] with [CrB]."), 3, "You hear wood breaking.", 2)
+		for(var/mob/in_view in viewers(src))
+			in_view.show_message(SPAN_NOTICE("\The [src] has been wrenched apart by [user] with a [item]."), 3, "You hear wood breaking.", 2)
 		qdel(src)
 		return
 	if(isrobot(user))
 		return
-	user.drop_inv_item_to_loc(Prybar,loc)
+	user.drop_inv_item_to_loc(item,loc)
 
 /obj/structure/closet/coffin/predator
 	name = "strange coffin"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Fixes a bug with coffin deconstruction as stated in issue #392 by changing the material returned in the deconstruction of coffins and wooden crates from metal to wood.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Why It's Good For The Game

Consistency.

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

## Changelog

:cl: Insertusername

fix: Coffins and wooden crates now return wood when deconstructed

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
