### PR TITLE
Surgery in interiors tweak

### DIFF
--- a/code/game/turfs/floors/desert.dm
+++ b/code/game/turfs/floors/desert.dm
@@ -103,6 +103,7 @@
 	icon = 'icons/turf/floors/desert_water.dmi'
 	icon_state = "shore1"
 	var/toxic = 0
+	supports_surgery = FALSE
 
 /turf/open/desert/desert_shore/update_icon()
 	..()
@@ -144,6 +145,8 @@
 /turf/open/desert/waterway
 	icon = 'icons/turf/floors/desert_water.dmi'
 	icon_state = "dock"
+	supports_surgery = FALSE
+
 /turf/open/desert/waterway/desert_waterway
 	icon = 'icons/turf/floors/desert_water.dmi'
 	icon_state = "dock"

--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -618,6 +618,7 @@
 	icon_state = "floor"
 	icon = 'icons/turf/shuttle.dmi'
 	allow_construction = FALSE
+	supports_surgery = FALSE
 
 /turf/open/shuttle/dropship
 	name = "floor"
@@ -657,7 +658,6 @@
 	name = "floor"
 	icon = 'icons/turf/vehicle_interior.dmi'
 	icon_state = "floor_0"
-	supports_surgery = FALSE
 
 //vehicle interior floors
 /turf/open/shuttle/vehicle/med

--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -5,6 +5,7 @@
 	var/allow_construction = TRUE //whether you can build things like barricades on this turf.
 	var/bleed_layer = 0 //snow layer
 	var/wet = 0 //whether the turf is wet (only used by floors).
+	var/supports_surgery = TRUE
 
 /turf/open/Initialize(mapload, ...)
 	. = ..()
@@ -41,6 +42,7 @@
 	icon_state = "black"
 	mouse_opacity = FALSE
 	can_bloody = FALSE
+	supports_surgery = FALSE
 
 /turf/open/void/vehicle
 	density = TRUE
@@ -50,6 +52,7 @@
 
 /turf/open/river
 	can_bloody = FALSE
+	supports_surgery = FALSE
 
 // Prison grass
 /turf/open/organic/grass
@@ -115,6 +118,7 @@
 /turf/open/beach
 	name = "Beach"
 	icon = 'icons/turf/floors/beach.dmi'
+	supports_surgery = FALSE
 
 /turf/open/beach/Entered(atom/movable/AM)
 	..()
@@ -130,6 +134,7 @@
 /turf/open/beach/sand
 	name = "Sand"
 	icon_state = "sand"
+	supports_surgery = TRUE
 
 /turf/open/beach/coastline
 	name = "Coastline"
@@ -240,6 +245,7 @@
 	var/default_name = "river"
 	var/no_overlay = FALSE
 	baseturfs = /turf/open/gm/river
+	supports_surgery = FALSE
 
 /turf/open/gm/river/Initialize(mapload, ...)
 	. = ..()
@@ -346,12 +352,16 @@
 	name = "coastline"
 	icon_state = "beach"
 	baseturfs = /turf/open/gm/coast
+	supports_surgery = FALSE
+
 
 /turf/open/gm/riverdeep
 	name = "river"
 	icon_state = "seadeep"
 	can_bloody = FALSE
 	baseturfs = /turf/open/gm/riverdeep
+	supports_surgery = FALSE
+
 
 /turf/open/gm/riverdeep/Initialize(mapload, ...)
 	. = ..()
@@ -359,6 +369,7 @@
 
 /turf/open/gm/river/no_overlay
 	no_overlay = TRUE
+	supports_surgery = FALSE
 
 
 
@@ -369,6 +380,7 @@
 	icon = 'icons/turf/floors/floors.dmi'
 	icon_state = "black"
 	density = 1
+	supports_surgery = FALSE
 
 /turf/open/gm/empty/is_weedable()
 	return FALSE
@@ -383,6 +395,7 @@
 	icon = 'icons/turf/ground_map.dmi'
 	icon_state = "seadeep"
 	can_bloody = FALSE
+	supports_surgery = FALSE
 
 //Ice Colony grounds
 
@@ -541,6 +554,7 @@
 	icon_state = "water"
 	icon_spawn_state = "water"
 	can_bloody = FALSE
+	supports_surgery = FALSE
 
 
 /turf/open/jungle/water/Initialize(mapload, ...)
@@ -643,8 +657,10 @@
 	name = "floor"
 	icon = 'icons/turf/vehicle_interior.dmi'
 	icon_state = "floor_0"
+	supports_surgery = FALSE
 
 //vehicle interior floors
 /turf/open/shuttle/vehicle/med
 	name = "floor"
 	icon_state = "dark_sterile"
+	supports_surgery = TRUE

--- a/code/game/turfs/space.dm
+++ b/code/game/turfs/space.dm
@@ -10,6 +10,7 @@
 	icon_state = "0"
 	can_bloody = FALSE
 	layer = UNDER_TURF_LAYER
+	supports_surgery = FALSE
 
 /turf/open/space/basic/New()	//Do not convert to Initialize
 	//This is used to optimize the map loader

--- a/code/modules/surgery/surgery_initiator.dm
+++ b/code/modules/surgery/surgery_initiator.dm
@@ -9,6 +9,10 @@ proc/initiate_surgery_moment(obj/item/tool, mob/living/carbon/target, obj/limb/a
 	var/list/available_surgeries = list()
 	var/list/valid_steps = list() //Steps that could be performed, if we had the right tool.
 
+	if(user.z == GLOB.interior_manager.interior_z && !istype(target.loc, /turf/open/shuttle/vehicle/med))
+		to_chat(user, SPAN_WARNING("You can't perform surgery under these bad conditions!"))
+		return FALSE
+
 	if(user.action_busy) //already doing an action
 		return FALSE
 

--- a/code/modules/surgery/surgery_initiator.dm
+++ b/code/modules/surgery/surgery_initiator.dm
@@ -9,7 +9,11 @@ proc/initiate_surgery_moment(obj/item/tool, mob/living/carbon/target, obj/limb/a
 	var/list/available_surgeries = list()
 	var/list/valid_steps = list() //Steps that could be performed, if we had the right tool.
 
-	if(user.z == GLOB.interior_manager.interior_z && !istype(target.loc, /turf/open/shuttle/vehicle/med))
+	var/turf/open/T = get_turf(target)
+	if(!istype(user.loc, /turf/open))
+		to_chat(user, SPAN_WARNING("You can't perform surgery here!"))
+		return FALSE
+	else if(!T.supports_surgery)
 		to_chat(user, SPAN_WARNING("You can't perform surgery under these bad conditions!"))
 		return FALSE
 

--- a/code/modules/surgery/surgery_steps.dm
+++ b/code/modules/surgery/surgery_steps.dm
@@ -58,6 +58,10 @@ datum/surgery_step/proc/repeat_step_criteria(mob/user, mob/living/carbon/target,
 	if(!tool_type) //Can't perform the step.
 		return FALSE
 
+	if(user.z == GLOB.interior_manager.interior_z && !istype(target.loc, /turf/open/shuttle/vehicle/med))
+		to_chat(user, SPAN_WARNING("You can't perform surgery under these bad conditions!"))
+		return FALSE
+
 	surgery.step_in_progress = TRUE
 
 	var/step_duration = time

--- a/code/modules/surgery/surgery_steps.dm
+++ b/code/modules/surgery/surgery_steps.dm
@@ -58,7 +58,11 @@ datum/surgery_step/proc/repeat_step_criteria(mob/user, mob/living/carbon/target,
 	if(!tool_type) //Can't perform the step.
 		return FALSE
 
-	if(user.z == GLOB.interior_manager.interior_z && !istype(target.loc, /turf/open/shuttle/vehicle/med))
+	var/turf/open/T = get_turf(target)
+	if(!istype(user.loc, /turf/open))
+		to_chat(user, SPAN_WARNING("You can't perform surgery here!"))
+		return FALSE
+	else if(!T.supports_surgery)
 		to_chat(user, SPAN_WARNING("You can't perform surgery under these bad conditions!"))
 		return FALSE
 


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Disallowing surgery in interiors outside of interior medical tiles, in water and in shuttles.

## Why It's Good For The Game

Disallows surgery in vehicles by default.


## Changelog

:cl: Jeser
balance: Surgery in vehicle interiors is now only allowed if the patient is located on interior medical tile. Surgery is impossible on water and shuttle tiles.
/:cl:
