### PR TITLE
Lunge resist bugfix

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/Warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Warrior.dm
@@ -102,7 +102,8 @@
 		visible_message(SPAN_WARNING("[src] has broken [L.pulledby]'s grip on [L]!"), null, null, 5)
 		L.pulledby.stop_pulling()
 
-	lunging = TRUE
+	if(should_neckgrab)
+		lunging = TRUE
 	. = ..(L, lunge, should_neckgrab)
 
 	if(.) //successful pull

--- a/code/modules/mob/living/carbon/xenomorph/castes/Warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Warrior.dm
@@ -76,6 +76,11 @@
 /mob/living/carbon/Xenomorph/Warrior/throw_item(atom/target)
 	toggle_throw_mode(THROW_MODE_OFF)
 
+/mob/living/carbon/Xenomorph/Warrior/can_be_resisted()
+	if(lunging)
+		return FALSE
+	return TRUE
+
 /mob/living/carbon/Xenomorph/Warrior/stop_pulling()
 	if(isliving(pulling) && lunging)
 		lunging = FALSE // To avoid extreme cases of stopping a lunge then quickly pulling and stopping to pull someone else
@@ -97,6 +102,7 @@
 		visible_message(SPAN_WARNING("[src] has broken [L.pulledby]'s grip on [L]!"), null, null, 5)
 		L.pulledby.stop_pulling()
 
+	lunging = TRUE
 	. = ..(L, lunge, should_neckgrab)
 
 	if(.) //successful pull
@@ -111,8 +117,9 @@
 			L.pulledby = src
 			visible_message(SPAN_XENOWARNING("\The [src] grabs [L] by the throat!"), \
 			SPAN_XENOWARNING("You grab [L] by the throat!"))
-			lunging = TRUE
 			addtimer(CALLBACK(src, .proc/stop_lunging), get_xeno_stun_duration(L, 2) SECONDS + 1 SECONDS)
+	else
+		lunging = FALSE
 
 /mob/living/carbon/Xenomorph/Warrior/proc/stop_lunging(var/world_time)
 	lunging = FALSE

--- a/code/modules/mob/living/living_verbs.dm
+++ b/code/modules/mob/living/living_verbs.dm
@@ -38,9 +38,10 @@
 		return
 
 	//resisting grabs (as if it helps anyone...)
-	if(!is_mob_restrained(0) && pulledby && pulledby.can_be_resisted())
-		visible_message(SPAN_DANGER("[src] resists against [pulledby]'s grip!"))
-		resist_grab()
+	if(!is_mob_restrained(0) && pulledby)
+		if(pulledby.can_be_resisted())
+			visible_message(SPAN_DANGER("[src] resists against [pulledby]'s grip!"))
+			resist_grab()
 		return
 
 	//unbuckling yourself

--- a/code/modules/mob/living/living_verbs.dm
+++ b/code/modules/mob/living/living_verbs.dm
@@ -38,7 +38,7 @@
 		return
 
 	//resisting grabs (as if it helps anyone...)
-	if(!is_mob_restrained(0) && pulledby)
+	if(!is_mob_restrained(0) && pulledby && pulledby.can_be_resisted())
 		visible_message(SPAN_DANGER("[src] resists against [pulledby]'s grip!"))
 		resist_grab()
 		return

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1040,3 +1040,6 @@ mob/proc/yank_out_object()
 		if(client)
 			client.prefs.process_link(src, href_list)
 		return TRUE
+
+/mob/proc/can_be_resisted()
+	return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Fixes a bug which allowed you to resist out of a warrior lunge with the right timing
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bug bad fix good
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixed a bug which allowed you to resist out of a warrior lunge with the right timing
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
