### PR TITLE
Acid Blood Tweaking 2

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
@@ -220,7 +220,7 @@
 	var/list/tackle_counter
 	var/evolving = FALSE // Whether the xeno is in the process of evolving
 	/// The damage dealt by a xeno whenever they take damage near someone
-	var/acid_blood_damage = 25
+	var/acid_blood_damage = 15
 	var/nocrit = FALSE
 
 


### PR DESCRIPTION
Lowers Acid Damage again. Higher than it's old 12,  lower than it's current 25

## Why It's Good For The Game
Acid Blood at it's current damage is very punishing to marines for...doing what they're intended to do?
It's very possible to take more damage from someone shooting a xeno that's on you than you would take from  just letting the xeno slash you.

Acid damage was at this high level initially, and it was nerfed back then because it's just frustrating to play against.  Time for history to repeat itself.



## Changelog

:cl: FoxyStalin
balance: Lowered Acid Blood damage down to 15
/:cl:
