### PR TITLE
CM bugbash 3

### DIFF
--- a/code/datums/xeno_shields/xeno_shield.dm
+++ b/code/datums/xeno_shields/xeno_shield.dm
@@ -90,6 +90,5 @@
 
 
 /mob/living/carbon/Xenomorph/proc/remove_xeno_shield()
-	for (var/datum/xeno_shield/curr_shield in xeno_shields)
-		del(curr_shield)
-	return
+	for (var/datum/xeno_shield/curr_shield as anything in xeno_shields)
+		qdel(curr_shield)

--- a/code/datums/xeno_shields/xeno_shield.dm
+++ b/code/datums/xeno_shields/xeno_shield.dm
@@ -88,3 +88,8 @@
 	overlay_shields()
 	return new_shield
 
+
+/mob/living/carbon/Xenomorph/proc/remove_xeno_shield()
+	for (var/datum/xeno_shield/curr_shield in xeno_shields)
+		curr_shield.amount = max(0)
+	return

--- a/code/datums/xeno_shields/xeno_shield.dm
+++ b/code/datums/xeno_shields/xeno_shield.dm
@@ -91,5 +91,5 @@
 
 /mob/living/carbon/Xenomorph/proc/remove_xeno_shield()
 	for (var/datum/xeno_shield/curr_shield in xeno_shields)
-		curr_shield.amount = max(0)
+		del(curr_shield)
 	return

--- a/code/modules/clothing/glasses/thermal.dm
+++ b/code/modules/clothing/glasses/thermal.dm
@@ -29,12 +29,13 @@
 					spawn(100)
 						M.disabilities &= ~NEARSIGHTED
 	..()
-		
+
 
 /obj/item/clothing/glasses/thermal/syndi	//These are now a traitor item, concealed as mesons.	-Pete
 	name = "Optical Meson Scanner"
 	desc = "Used for seeing walls, floors, and stuff through anything."
 	icon_state = "meson"
+	deactive_state = "degoggles"
 	actions_types = list(/datum/action/item_action/toggle)
 
 /obj/item/clothing/glasses/thermal/monocle

--- a/code/modules/clothing/under/marine_uniform.dm
+++ b/code/modules/clothing/under/marine_uniform.dm
@@ -717,7 +717,7 @@
 	flags_jumpsuit = FALSE
 
 /obj/item/clothing/under/rank/ro_suit
-	name = "requisition officer suit."
+	name = "requisition officer suit"
 	desc = "A nicely-fitting military suit for a requisition officer. It has shards of light Kevlar to help protect against stabbing weapons and bullets."
 	icon_state = "RO_jumpsuit"
 	worn_state = "RO_jumpsuit"

--- a/code/modules/mob/living/carbon/xenomorph/castes/Warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Warrior.dm
@@ -144,6 +144,7 @@
 		bound_xeno.TakeComponent(shield_component)
 
 /datum/behavior_delegate/warrior_base/remove_from_xeno()
+	bound_xeno.remove_xeno_shield()
 	shield_component.RemoveComponent()
 	return ..()
 
@@ -171,7 +172,7 @@
 
 /datum/behavior_delegate/boxer/New()
 	. = ..()
-
+	//bound_xeno.remove_xeno_shield()
 	if(SSticker.mode && (SSticker.mode.flags_round_type & MODE_XVX)) // this is pain to do, but how else? hopefully we can replace clarity with something better in the future
 		clear_head = 0
 		max_clear_head = 0

--- a/code/modules/mob/living/carbon/xenomorph/castes/Warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Warrior.dm
@@ -172,7 +172,6 @@
 
 /datum/behavior_delegate/boxer/New()
 	. = ..()
-	//bound_xeno.remove_xeno_shield()
 	if(SSticker.mode && (SSticker.mode.flags_round_type & MODE_XVX)) // this is pain to do, but how else? hopefully we can replace clarity with something better in the future
 		clear_head = 0
 		max_clear_head = 0

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -83952,6 +83952,16 @@
 	tag = "icon-sterile_green_side (NORTH)"
 	},
 /area/almayer/medical/morgue)
+"yji" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/machinery/door/airlock/almayer/maint,
+/turf/open/floor/almayer{
+	icon_state = "plate";
+	tag = "icon-sterile"
+	},
+/area/almayer/hull/upper_hull/u_m_p)
 "yjM" = (
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/almayer{
@@ -113350,7 +113360,7 @@ adc
 adc
 adc
 pOZ
-wKn
+yji
 qVM
 gMA
 qVM


### PR DESCRIPTION
boxerfix

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Fixed #435 

Fixes an oversight which allowed warriors to pick boxer and keep their shield.

Fixed #480

Syndi goggles ( instanced as Bug-B-Gone goggles) no longer display incorrect sprites.

Fixed #474

Missing door just below south upper medbay stairwell fixed by throwing in a door there.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

![social-credit-social-credit-score](https://user-images.githubusercontent.com/42422230/172891088-713c48eb-1983-47e7-a651-90cc52aaf31d.gif)

further fixes may be added if this PR stays open

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: TotalEpicness
fix: Fixed a typo.
fix: Fixes an oversight that allowed woyers to keep their shield after choosing a strain by adding in a component to remove shield.
fix: Syndi goggles ( instanced as Bug-B-Gone goggles) no longer display incorrect sprites.
fix: The maintenance just below the south upper medbay stairwell now has a door.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
