### PR TITLE
Anti-Hug Fix

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
@@ -446,7 +446,7 @@
 	if(head && !(head.flags_item & NODROP))
 		var/obj/item/clothing/head/D = head
 		if(istype(D))
-			if(D.anti_hug > 1)
+			if(D.anti_hug >= 1)
 				visible_message(SPAN_DANGER("[hugger] smashes against [src]'s [D.name]!"))
 				D.anti_hug = max(0, --D.anti_hug)
 				if(prob(15)) // 15% chance the hugger will go idle after ripping off a helmet. Otherwise it will keep going.
@@ -474,7 +474,7 @@
 			if(FH.stat != DEAD)
 				return FALSE
 
-		if(W.anti_hug > 1)
+		if(W.anti_hug >= 1)
 			visible_message(SPAN_DANGER("[hugger] smashes against [src]'s [W.name]!"))
 			W.anti_hug = max(0, --W.anti_hug)
 			if(prob(15)) //15% chance the hugger will go idle after ripping off a mask. Otherwise it will keep going.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
This fixes an off-by-one error where all helmets/masks with anti-hug are treated as having "1 less anti-hug" than they should. For example the carved pumpkin (`pumpkinhead`) has an anti-hug of 1, but the error caused it to be treated like it has no anti-hug capabilities.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bug fixes are good. I'm pretty sure it's not intended for an anti-hug value of 1 to be the same as a value of 0.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Laser9
fix: Clothing items with anti-hug capabilities now resist the correct number of face-hugging attempts.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
