### PR TITLE
Replaces a donor hat icon on the sheriff

### DIFF
--- a/maps/map_files/Ice_Colony_v3/Shivas_Snowball.dmm
+++ b/maps/map_files/Ice_Colony_v3/Shivas_Snowball.dmm
@@ -6288,7 +6288,7 @@
 	desc = "Let's take the caveman back to the malt shop.";
 	dir = 4;
 	icon = 'icons/mob/humans/onmob/head_0.dmi';
-	icon_state = "killaninja12_u";
+	icon_state = "hopcap";
 	layer = 2.5;
 	name = "frozen hat";
 	pixel_x = -1;


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Like zoinks scoob, we broke mapping guidelines and used a donor sprite on a common item instance.

## Why It's Good For The Game

See above.

## Changelog

:cl:
fix: The sheriff on Shiva's no longer wears illegal donor drip.
/:cl:

