### PR TITLE
Fixes tooltips crashing the admin supply pod interface

### DIFF
--- a/tgui/packages/tgui/interfaces/PodLauncher.js
+++ b/tgui/packages/tgui/interfaces/PodLauncher.js
@@ -466,7 +466,7 @@ const ReverseMenu = (props, context) => {
               Where the pods
               go after being recalled`}
             tooltipOverrideLong
-            tooltipPosition="bottom-right"
+            tooltipPosition="bottom"
             onClick={() => {
               if (data.target_mode === TARGET_MODE_DROPOFF) {
                 act("set_target_mode", {
@@ -607,7 +607,7 @@ class PresetsPage extends Component {
               color="transparent"
               icon="trash"
               tooltip="Deletes the selected preset"
-              tooltipPosition="bottom-left"
+              tooltipPosition="bottom"
               onClick={() => this.deletePreset(presetIndex)} />
           </>
         )}>
@@ -726,7 +726,7 @@ const Timing = (props, context) => {
           Reset all pod
           timings/delays`}
           tooltipOverrideLong
-          tooltipPosition="top-left"
+          tooltipPosition="top"
           onClick={() => {
             act('set_delays', {
               "drop_time": 0,
@@ -819,7 +819,7 @@ const Damage = (props, context) => {
           color="transparent"
           tooltip="Reset damage"
           tooltipOverrideLong
-          tooltipPosition="top-left"
+          tooltipPosition="top"
           onClick={() => {
             act('set_damage', {
               "damage": 0,
@@ -857,7 +857,7 @@ const Explosion = (props, context) => {
           color="transparent"
           tooltip="Toggle explosion"
           tooltipOverrideLong
-          tooltipPosition="top-left"
+          tooltipPosition="top"
           onClick={() => {
             if (enabled) {
               setEnabled(false);


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
What it says on the tin, closes #52 

Turns out, the current tgui implementation only accepts "cardinal" directions for tooltipPosition, so "top", "bottom", "left" and "right" work, but "bottom-left" for instance made it crash.

Problem fixed by removing all instances of these and making them stick to either top or bottom, depending on case.

I am somewhat annoyed at myself it took me this long to even take a look at.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Not going to lie, the supplypod launcher is an extremely versatile, customizable tool with a plethora of event uses. Want to simulate misses impacting the ship? Got it. Want to use them as a spawner for custom mobs? Yep, it does that. Want to use it to gib that one marine you don't like? Can do that too, but please don't. It sucks having to tiptoe around the "bad" buttons only to ruin all your works by one bad move, not to mention one of the broken buttons was fairly crucial to operation.

Robust tools lead to happy admins which means happy players, which means happy devs. Or something. Everyone's happy.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:silencer_pl
fix: The admin supply pod launcher no longer crashes when it tries to display some of its tooltips
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
