### PR TITLE
Multi-Broadcast Cooldown

### DIFF
--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -18,6 +18,9 @@
 
 	var/list/volume_settings
 
+	var/last_multi_broadcast = -999
+	var/multibroadcast_cooldown = 3 MINUTES
+
 	var/has_hud = FALSE
 	var/headset_hud_on = FALSE
 	var/locate_setting = TRACKER_SL
@@ -316,6 +319,7 @@
 	icon_state = "ce_headset"
 	initial_keys = list(/obj/item/device/encryptionkey/ce)
 	volume = RADIO_VOLUME_CRITICAL
+	multibroadcast_cooldown = 1 MINUTES
 
 /obj/item/device/radio/headset/almayer/cmo
 	name = "chief medical officer's headset"
@@ -323,6 +327,7 @@
 	icon_state = "cmo_headset"
 	initial_keys = list(/obj/item/device/encryptionkey/cmo)
 	volume = RADIO_VOLUME_CRITICAL
+	multibroadcast_cooldown = 1 MINUTES
 
 /obj/item/device/radio/headset/almayer/mt
 	name = "engineering radio headset"
@@ -354,6 +359,7 @@
 	icon_state = "ro_headset"
 	initial_keys = list(/obj/item/device/encryptionkey/ro)
 	volume = RADIO_VOLUME_CRITICAL
+	multibroadcast_cooldown = 1 MINUTES
 
 /obj/item/device/radio/headset/almayer/mmpo
 	name = "marine military police radio headset"
@@ -392,6 +398,7 @@
 	icon_state = "mcom_headset"
 	initial_keys = list(/obj/item/device/encryptionkey/mcom)
 	volume = RADIO_VOLUME_CRITICAL
+	multibroadcast_cooldown = 1 MINUTES
 
 /obj/item/device/radio/headset/almayer/marine/mp_honor/com
 	name = "marine honor guard command radio headset"
@@ -404,6 +411,7 @@
 	desc = "Used by Pilot Officers. Channels are as follows: :v - marine command, :a - alpha squad, :b - bravo squad, :c - charlie squad, :d - delta squad, :j - JTAC, :t - tactics."
 	initial_keys = list(/obj/item/device/encryptionkey/po)
 	volume = RADIO_VOLUME_CRITICAL
+	multibroadcast_cooldown = 1 MINUTES
 
 /obj/item/device/radio/headset/almayer/tactics
 	name = "marine tactics radio headset"
@@ -756,3 +764,4 @@
 	name = "marine vehicle crew radio headset"
 	desc = "Used by USCM vehicle crew, features a non-standard brace. Channels are as follows: :v - marine command, :a - alpha squad, :b - bravo squad, :c - charlie squad, :d - delta squad, :n - engineering, :m - medbay, :u - requisitions, :j - JTAC, :t - tactics."
 	volume = RADIO_VOLUME_RAISED
+	multibroadcast_cooldown = 3 MINUTES

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -1,3 +1,6 @@
+#define LOW_MULTIBROADCAST_COOLDOWN 1 MINUTES
+#define HIGH_MULTIBROADCAST_COOLDOWN 3 MINUTES
+
 /obj/item/device/radio/headset
 	name = "radio headset"
 	desc = "An updated, modular intercom that fits over the head. Takes encryption keys."
@@ -19,7 +22,7 @@
 	var/list/volume_settings
 
 	var/last_multi_broadcast = -999
-	var/multibroadcast_cooldown = 3 MINUTES
+	var/multibroadcast_cooldown = HIGH_MULTIBROADCAST_COOLDOWN
 
 	var/has_hud = FALSE
 	var/headset_hud_on = FALSE
@@ -319,7 +322,7 @@
 	icon_state = "ce_headset"
 	initial_keys = list(/obj/item/device/encryptionkey/ce)
 	volume = RADIO_VOLUME_CRITICAL
-	multibroadcast_cooldown = 1 MINUTES
+	multibroadcast_cooldown = LOW_MULTIBROADCAST_COOLDOWN
 
 /obj/item/device/radio/headset/almayer/cmo
 	name = "chief medical officer's headset"
@@ -327,7 +330,7 @@
 	icon_state = "cmo_headset"
 	initial_keys = list(/obj/item/device/encryptionkey/cmo)
 	volume = RADIO_VOLUME_CRITICAL
-	multibroadcast_cooldown = 1 MINUTES
+	multibroadcast_cooldown = LOW_MULTIBROADCAST_COOLDOWN
 
 /obj/item/device/radio/headset/almayer/mt
 	name = "engineering radio headset"
@@ -359,7 +362,7 @@
 	icon_state = "ro_headset"
 	initial_keys = list(/obj/item/device/encryptionkey/ro)
 	volume = RADIO_VOLUME_CRITICAL
-	multibroadcast_cooldown = 1 MINUTES
+	multibroadcast_cooldown = LOW_MULTIBROADCAST_COOLDOWN
 
 /obj/item/device/radio/headset/almayer/mmpo
 	name = "marine military police radio headset"
@@ -398,7 +401,7 @@
 	icon_state = "mcom_headset"
 	initial_keys = list(/obj/item/device/encryptionkey/mcom)
 	volume = RADIO_VOLUME_CRITICAL
-	multibroadcast_cooldown = 1 MINUTES
+	multibroadcast_cooldown = LOW_MULTIBROADCAST_COOLDOWN
 
 /obj/item/device/radio/headset/almayer/marine/mp_honor/com
 	name = "marine honor guard command radio headset"
@@ -411,7 +414,7 @@
 	desc = "Used by Pilot Officers. Channels are as follows: :v - marine command, :a - alpha squad, :b - bravo squad, :c - charlie squad, :d - delta squad, :j - JTAC, :t - tactics."
 	initial_keys = list(/obj/item/device/encryptionkey/po)
 	volume = RADIO_VOLUME_CRITICAL
-	multibroadcast_cooldown = 1 MINUTES
+	multibroadcast_cooldown = LOW_MULTIBROADCAST_COOLDOWN
 
 /obj/item/device/radio/headset/almayer/tactics
 	name = "marine tactics radio headset"
@@ -764,4 +767,4 @@
 	name = "marine vehicle crew radio headset"
 	desc = "Used by USCM vehicle crew, features a non-standard brace. Channels are as follows: :v - marine command, :a - alpha squad, :b - bravo squad, :c - charlie squad, :d - delta squad, :n - engineering, :m - medbay, :u - requisitions, :j - JTAC, :t - tactics."
 	volume = RADIO_VOLUME_RAISED
-	multibroadcast_cooldown = 3 MINUTES
+	multibroadcast_cooldown = HIGH_MULTIBROADCAST_COOLDOWN

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -5,20 +5,6 @@
 		.["modes"] += "headset"
 		return
 
-	if(length(message) >= 2 && message[1] == ",")
-		// Radio multibroadcast functionality.
-		// If a message starts with , we assume that up to MULTIBROADCAST_MAX_CHANNELS
-		// next symbols are channel names. If we run into a space we stop looking for more channels.
-		var/i
-		for(i in 2 to 1+MULTIBROADCAST_MAX_CHANNELS)
-			var/current_channel = message[i]
-			if(current_channel == " " || current_channel == ":" || current_channel == ".")
-				i--
-				break
-			.["modes"] += department_radio_keys[":[current_channel]"]
-		.["message_and_language"] = copytext(message, i+1)
-		return
-
 	if(length(message) >= 2 && (message[1] == "." || message[1] == ":"))
 		var/channel_prefix = copytext(message, 1, 3)
 		if(channel_prefix in department_radio_keys)

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -5,6 +5,30 @@
 		.["modes"] += "headset"
 		return
 
+	if(length(message) >= 2 && message[1] == ",")
+		// Radio multibroadcast functionality.
+		// If a message starts with , we assume that up to MULTIBROADCAST_MAX_CHANNELS
+		// next symbols are channel names. If we run into a space we stop looking for more channels.
+		var/i
+		for(i in 2 to 1 + MULTIBROADCAST_MAX_CHANNELS)
+			var/current_channel = message[i]
+			if(current_channel == " " || current_channel == ":" || current_channel == ".")
+				i--
+				break
+			.["modes"] += department_radio_keys[":[current_channel]"]
+		.["message_and_language"] = copytext(message, i+1)
+		var/multibroadcast_cooldown = 0
+		for(var/obj/item/device/radio/headset/headset in list(wear_l_ear, wear_r_ear))
+			if(world.time - headset.last_multi_broadcast < headset.multibroadcast_cooldown)
+				var/cooldown_remaining = (headset.last_multi_broadcast + headset.multibroadcast_cooldown) - world.time
+				if(cooldown_remaining > multibroadcast_cooldown)
+					multibroadcast_cooldown = cooldown_remaining
+			else
+				headset.last_multi_broadcast = world.time
+		if(multibroadcast_cooldown)
+			.["fail_with"] = "You've used the multi-broadcast system too recently, wait [round(multibroadcast_cooldown / 10)] more seconds."
+		return
+
 	if(length(message) >= 2 && (message[1] == "." || message[1] == ":"))
 		var/channel_prefix = copytext(message, 1, 3)
 		if(channel_prefix in department_radio_keys)
@@ -20,6 +44,7 @@
 	. = list("message", "language", "modes")
 	var/list/ml_and_modes = parse_say_modes(message)
 	.["modes"] = ml_and_modes["modes"]
+	.["fail_with"] = ml_and_modes["fail_with"]
 	var/message_and_language = ml_and_modes["message_and_language"]
 	var/parsed_language = parse_language(message_and_language)
 	if(parsed_language)
@@ -56,6 +81,10 @@
 		alt_name = "(as [get_id_name("Unknown")])"
 
 	var/list/parsed = parse_say(message)
+	var/fail_message = parsed["fail_with"]
+	if(fail_message)
+		to_chat(src, SPAN_WARNING(fail_message))
+		return
 	message = parsed["message"]
 	var/datum/language/speaking = parsed["language"]
 	if(!speaking)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Added a one minute cooldown to multi-broadcasting with command and PO headsets, all other headsets have a three minute cooldown.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It clogs up the channels, and useless info gets spread to all the squads rather than CIC speaking with SLs, who speak with their squads.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: Command and PO headsets have a 1 minute cooldown on multibroadcasts, while all other headsets have 3 minutes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
