### PR TITLE
Synth Blood Dodge

### DIFF
--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -94,6 +94,8 @@
 	var/stun_reduction = 1 //how much the stunned effect is reduced per Life call.
 	var/knock_out_reduction = 1 //same thing
 
+	var/acid_blood_dodge_chance = 0
+
 	var/list/slot_equipment_priority = DEFAULT_SLOT_PRIORITY
 	var/list/equip_adjust = list()
 	var/list/equip_overlays = list()

--- a/code/modules/mob/living/carbon/human/species/synthetic.dm
+++ b/code/modules/mob/living/carbon/human/species/synthetic.dm
@@ -39,6 +39,8 @@
 	knock_down_reduction = 5
 	stun_reduction = 5
 
+	acid_blood_dodge_chance = 35
+
 	inherent_verbs = list(
 		/mob/living/carbon/human/synthetic/proc/toggle_HUD
 	)

--- a/code/modules/mob/living/carbon/human/species/yautja.dm
+++ b/code/modules/mob/living/carbon/human/species/yautja.dm
@@ -50,6 +50,8 @@
 	knock_down_reduction = 4
 	stun_reduction = 4
 
+	acid_blood_dodge_chance = 70
+
 		//Set their special slot priority
 
 	slot_equipment_priority= list( \

--- a/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
@@ -263,8 +263,9 @@
 			splash_chance = 80 - (i * 5)
 			if(victim.loc == loc) splash_chance += 30 //Same tile? BURN
 			splash_chance += distance * -15
-			if(victim.species && victim.species.name == "Yautja")
-				splash_chance -= 70 //Preds know to avoid the splashback.
+			if(victim.species?.acid_blood_dodge_chance)
+				message_admins(victim.species.acid_blood_dodge_chance)
+				splash_chance -= victim.species.acid_blood_dodge_chance
 
 			if(splash_chance > 0 && prob(splash_chance)) //Success!
 				var/dmg = list("damage" = acid_blood_damage)

--- a/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
@@ -264,7 +264,6 @@
 			if(victim.loc == loc) splash_chance += 30 //Same tile? BURN
 			splash_chance += distance * -15
 			if(victim.species?.acid_blood_dodge_chance)
-				message_admins(victim.species.acid_blood_dodge_chance)
 				splash_chance -= victim.species.acid_blood_dodge_chance
 
 			if(splash_chance > 0 && prob(splash_chance)) //Success!


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Synths now have a 35% increased acid blood dodge chance.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

I buffed acid blood damage, but it's a bit too punishing to synths. This should make it a bit less eough.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Synths now have a 35% increased acid blood dodge chance.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
