### PR TITLE
fixes being able to lase through walls

### DIFF
--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -150,7 +150,7 @@
 
 /datum/job/proc/generate_entry_message()
 	if(!entry_message_intro)
-		entry_message_intro = "You are the [title]!."
+		entry_message_intro = "You are the [title]!
 	if(!entry_message_end)
 		entry_message_end = "As the [title] you answer to [supervisors]. Special circumstances may change this!"
 	return "[entry_message_intro]<br>[entry_message_body]<br>[entry_message_end]"

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -150,7 +150,7 @@
 
 /datum/job/proc/generate_entry_message()
 	if(!entry_message_intro)
-		entry_message_intro = "You are the [title]!
+		entry_message_intro = "You are the [title]!"
 	if(!entry_message_end)
 		entry_message_end = "As the [title] you answer to [supervisors]. Special circumstances may change this!"
 	return "[entry_message_intro]<br>[entry_message_body]<br>[entry_message_end]"

--- a/code/game/objects/items/devices/binoculars.dm
+++ b/code/game/objects/items/devices/binoculars.dm
@@ -101,7 +101,7 @@
 			var/list/turf/path = getline2(user, A, include_from_atom = FALSE)
 			for(var/turf/T in path)
 				if(T.opacity)
-					to_chat(user, SPAN_WARNING("There is something in the way of the laser!."))
+					to_chat(user, SPAN_WARNING("There is something in the way of the laser!"))
 					return FALSE
 		acquire_target(A, user)
 		return TRUE

--- a/code/game/objects/items/devices/binoculars.dm
+++ b/code/game/objects/items/devices/binoculars.dm
@@ -97,12 +97,12 @@
 			return FALSE
 		if(mods["click_catcher"])
 			return FALSE
-		var/list/turf/path = getline2(user, A, include_from_atom = FALSE)
-		for(var/turf/T in path)
-			if(T.opacity)
-				return FALSE
-			for(var/obj/effect/particle_effect/smoke/S in T)
-				return FALSE
+		if(user.sight & SEE_TURFS)
+			var/list/turf/path = getline2(user, A, include_from_atom = FALSE)
+			for(var/turf/T in path)
+				if(T.opacity)
+					to_chat(user, SPAN_WARNING("There is something in the way of the laser!."))
+					return FALSE
 		acquire_target(A, user)
 		return TRUE
 	return FALSE

--- a/code/game/objects/items/devices/binoculars.dm
+++ b/code/game/objects/items/devices/binoculars.dm
@@ -95,7 +95,14 @@
 	if(mods["ctrl"])
 		if(SEND_SIGNAL(user, COMSIG_BINOCULAR_HANDLE_CLICK, src))
 			return FALSE
-
+		if(mods["click_catcher"])
+			return FALSE
+		var/list/turf/path = getline2(user, A, include_from_atom = FALSE)
+		for(var/turf/T in path)
+			if(T.opacity)
+				return FALSE
+			for(var/obj/effect/particle_effect/smoke/S in T)
+				return FALSE
 		acquire_target(A, user)
 		return TRUE
 	return FALSE

--- a/code/game/objects/items/explosives/plastic.dm
+++ b/code/game/objects/items/explosives/plastic.dm
@@ -109,7 +109,7 @@
 
 	if(customizable)
 		user.visible_message(SPAN_WARNING("[user] plants [name] on [target]!"),
-		SPAN_WARNING("You plant [name] on [target]!."))
+		SPAN_WARNING("You plant [name] on [target]!"))
 		activate_sensors()
 		if(!istimer(detonator.a_right) && !istimer(detonator.a_left))
 			icon_state = overlay_image

--- a/code/game/objects/items/fulton.dm
+++ b/code/game/objects/items/fulton.dm
@@ -141,7 +141,7 @@ var/global/list/deployed_fultons = list()
 	playsound(loc, 'sound/items/fulton.ogg', 50, 1)
 	var/turf/space_tile = pick(get_area_turfs(/area/space/highalt))
 	if(!space_tile)
-		visible_message(SPAN_WARNING("[src] begins beeping like crazy. Something is wrong!."))
+		visible_message(SPAN_WARNING("[src] begins beeping like crazy. Something is wrong!"))
 		return
 
 	icon_state = ""

--- a/code/game/objects/items/tools/flame_tools.dm
+++ b/code/game/objects/items/tools/flame_tools.dm
@@ -546,7 +546,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 				break
 
 	else if(istype(W, /obj/item/tool/surgery/cautery))
-		light(SPAN_NOTICE("[user] lights their [src] with the [W], that can't be sterile!."))
+		light(SPAN_NOTICE("[user] lights their [src] with the [W], that can't be sterile!"))
 
 	else if(istype(W, /obj/item/clothing/mask/cigarette))
 		var/obj/item/clothing/mask/cigarette/C = W
@@ -665,14 +665,14 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	icon_on = "zippoon"
 	icon_off = "zippo"
 	var/engraved = FALSE
-	
+
 /obj/item/tool/lighter/zippo/attackby(obj/item/W as obj, mob/user as mob)
 	. = ..()
 	if(istype(W, /obj/item/attachable/bayonet))
 		if(engraved)
 			to_chat(user, SPAN_NOTICE("\The [src] is already engraved."))
 			return
-		
+
 		var/str = copytext(reject_bad_text(input(user,"Engrave text?", "Set engraving", "")), 1)
 		if(length(str) == 0 || length(str) > 32)
 			to_chat(user, SPAN_NOTICE("You fumble [W], maybe try again?"))
@@ -680,7 +680,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		desc += "\nEngraved with \"[str]\""
 		engraved = TRUE
 		to_chat(user, SPAN_NOTICE("You engrave \the [src] with \"[str]\"."))
-		
+
 		log_admin("[user] has engraved \the [src] with engraving \"[str]\". (CKEY: ([user.ckey]))")
 
 /obj/item/tool/lighter/zippo/gold

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -140,7 +140,7 @@ obj/structure/windoor_assembly/Destroy()
 				if(do_after(user, 40 * user.get_skill_duration_multiplier(SKILL_CONSTRUCTION), INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD))
 					if(!src) return
 
-					to_chat(user, SPAN_NOTICE(" You cut the windoor wires.!"))
+					to_chat(user, SPAN_NOTICE(" You cut the windoor wires!"))
 					new/obj/item/stack/cable_coil(get_turf(user), 1)
 					src.state = "01"
 					if(src.secure)

--- a/code/modules/cm_preds/yaut_hudprocs.dm
+++ b/code/modules/cm_preds/yaut_hudprocs.dm
@@ -93,7 +93,7 @@
 	if(!M)
 		return
 	if(M.hunter_data.hunter)
-		to_chat(src, SPAN_YAUTJABOLD("[M] is already being hunted by [M.hunter_data.hunter.real_name]!."))
+		to_chat(src, SPAN_YAUTJABOLD("[M] is already being hunted by [M.hunter_data.hunter.real_name]!"))
 		return
 	hunter_data.prey = M
 	M.hunter_data.hunter = src
@@ -157,7 +157,7 @@
 	if(!T)
 		return
 	if(T.hunter_data.honored)
-		to_chat(src, SPAN_YAUTJABOLD("[T] has already been honored by [T.hunter_data.honored_set.real_name] for '[T.hunter_data.honored_reason]'!."))
+		to_chat(src, SPAN_YAUTJABOLD("[T] has already been honored by [T.hunter_data.honored_set.real_name] for '[T.hunter_data.honored_reason]'!"))
 		return
 
 	var/reason = stripped_input(usr, "Enter the reason for marking your target as honored.", "Mark as Honored", "", 120)
@@ -235,7 +235,7 @@
 	if(!T)
 		return
 	if(T.hunter_data.dishonored)
-		to_chat(src, SPAN_YAUTJABOLD("[T] has already been marked as dishonorable by [T.hunter_data.dishonored_set.real_name] for '[T.hunter_data.dishonored_reason]'!."))
+		to_chat(src, SPAN_YAUTJABOLD("[T] has already been marked as dishonorable by [T.hunter_data.dishonored_set.real_name] for '[T.hunter_data.dishonored_reason]'!"))
 		return
 
 	var/reason = stripped_input(usr, "Enter the reason for marking your target as dishonorable.", "Mark as Dishonorable", "", 120)
@@ -313,7 +313,7 @@
 	if(!T)
 		return
 	if(T.hunter_data.gear)
-		to_chat(src, SPAN_YAUTJABOLD("[T] has already been marked as a gear carrier by [T.hunter_data.gear_set]!."))
+		to_chat(src, SPAN_YAUTJABOLD("[T] has already been marked as a gear carrier by [T.hunter_data.gear_set]!"))
 		return
 
 	log_interact(src, T, "[key_name(src)] has marked [key_name(T)] as a Gear Carrier!")
@@ -385,7 +385,7 @@
 	if(!T)
 		return
 	if(T.hunter_data.thralled)
-		to_chat(src, SPAN_YAUTJABOLD("[T] has already been thralled by [T.hunter_data.thralled_set.real_name] for '[T.hunter_data.thralled_reason]'!."))
+		to_chat(src, SPAN_YAUTJABOLD("[T] has already been thralled by [T.hunter_data.thralled_set.real_name] for '[T.hunter_data.thralled_reason]'!"))
 		return
 
 	var/reason = stripped_input(usr, "Enter the reason for marking your target as thralled.", "Mark as Thralled", "", 120)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -496,7 +496,7 @@
 			usr.attack_log += text("\[[time_stamp()]\] <font color='red'>Attempted to toggle [key_name(src)]'s' sensors</font>")
 			var/obj/item/clothing/under/U = w_uniform
 			if(QDELETED(U))
-				to_chat(usr, "You're not wearing a uniform!.")
+				to_chat(usr, "You're not wearing a uniform!")
 			else if(U.has_sensor >= UNIFORM_FORCED_SENSORS)
 				to_chat(usr, "The controls are locked.")
 			else

--- a/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
@@ -655,7 +655,7 @@
 
 /mob/living/carbon/Xenomorph/proc/start_tracking_resin_mark(obj/effect/alien/resin/marker/target)
 	if(!target)
-		to_chat(src, SPAN_XENONOTICE("This resin mark no longer exists!."))
+		to_chat(src, SPAN_XENONOTICE("This resin mark no longer exists!"))
 		return
 	target.xenos_tracking |= src
 	tracked_marker = target


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

stops marines from being able to shine lasers through walls, closes #460 

Details of exact implementation:

the click will return when caught on the click catcher (which means that if you try click on a vision blocked tile it will fail)

if you have SEE_TURFS (such as from nvgs), it will do a straight-line check for obstructions between you and the target turf. This **IS** somewhat temperamental and has a tendency to block stuff if you are standing near a tight corner. However, this is needed, or otherwise if you have SEE_TURFS you can lase wherever.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

bugs are bad

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: you can no longer lase through walls
fix: fixed some instances of "!." ending sentences
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
