### PR TITLE
Preset Auto-Squad Tweak

### DIFF
--- a/code/modules/gear_presets/uscm.dm
+++ b/code/modules/gear_presets/uscm.dm
@@ -28,7 +28,7 @@
 
 /datum/equipment_preset/uscm/load_preset(mob/living/carbon/human/H, randomise, count_participant)
 	. = ..()
-	if(!auto_squad_name)
+	if(!auto_squad_name || is_admin_level(H.z))
 		return
 	if(!GLOB.data_core.manifest_modify(H.real_name, WEAKREF(H), assignment, rank))
 		GLOB.data_core.manifest_inject(H)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Stops marines spawned in tdome appearing on overwatch
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
## Why It's Good For The Game
No more tdome marines in overwatch
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
code: Autosquad no longer assigns spawned mobs into squads if on admin zlevel
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
