### PR TITLE
earmuffs

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -147,6 +147,8 @@
 #define TRAIT_LEADERSHIP "t_leadership"
  /// If the mob can see the reagents contents of stuff
 #define TRAIT_REAGENT_SCANNER "reagent_scanner"
+ /// If the mob is immune to screech
+#define TRAIT_SCREECH_IMMUNE "screech_immune"
 
 // -- ability traits --
  /// Xenos with this trait cannot have plasma transfered to them

--- a/code/modules/admin/verbs/mob_verbs.dm
+++ b/code/modules/admin/verbs/mob_verbs.dm
@@ -25,6 +25,8 @@
 		XNO.generate_name()
 		XNO.set_lighting_alpha_from_prefs(M.client)
 	M.client?.change_view(world_view_size)
+	M.client.soundOutput.status_flags ^= EAR_DEAF_MUTE
+	M.client.soundOutput.apply_status()
 
 /client/proc/cmd_admin_changekey(mob/O in GLOB.mob_list)
 	set name = "Change CKey"

--- a/code/modules/admin/verbs/mob_verbs.dm
+++ b/code/modules/admin/verbs/mob_verbs.dm
@@ -25,8 +25,8 @@
 		XNO.generate_name()
 		XNO.set_lighting_alpha_from_prefs(M.client)
 	M.client?.change_view(world_view_size)
-	M.client.soundOutput.status_flags ^= EAR_DEAF_MUTE
-	M.client.soundOutput.apply_status()
+	M.client?.soundOutput.status_flags ^= EAR_DEAF_MUTE
+	M.client?.soundOutput.apply_status()
 
 /client/proc/cmd_admin_changekey(mob/O in GLOB.mob_list)
 	set name = "Change CKey"

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -126,16 +126,16 @@
 
 /obj/item/clothing/ears/earmuffs/equipped(mob/user, slot)
 	. = ..()
-	if(slot == (WEAR_L_EAR||WEAR_R_EAR))
-		user.client.soundOutput.status_flags |= EAR_DEAF_MUTE
-		user.client.soundOutput.apply_status()
+	if(slot in list(WEAR_L_EAR, WEAR_R_EAR))
+		user?.client.soundOutput.status_flags |= EAR_DEAF_MUTE
+		user?.client.soundOutput.apply_status()
 		user.on_deafness_gain()
 
 /obj/item/clothing/ears/earmuffs/unequipped(mob/user, slot)
 	. = ..()
-	if(slot == (WEAR_L_EAR||WEAR_R_EAR))
-		user.client.soundOutput.status_flags ^= EAR_DEAF_MUTE
-		user.client.soundOutput.apply_status()
+	if(slot in list(WEAR_L_EAR, WEAR_R_EAR))
+		user?.client.soundOutput.status_flags ^= EAR_DEAF_MUTE
+		user?.client.soundOutput.apply_status()
 		user.on_deafness_loss()
 
 /obj/item/clothing/ears/earmuffs/New()

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -120,6 +120,22 @@
 	icon_state = "earmuffs"
 	item_state = "earmuffs"
 	flags_equip_slot = SLOT_EAR
+	inherent_traits = list(TRAIT_ITEM_EAR_EXCLUSIVE)
+	clothing_traits = list(TRAIT_SCREECH_IMMUNE)
+
+/obj/item/clothing/ears/earmuffs/equipped(mob/user, slot)
+	. = ..()
+	if(slot == (WEAR_L_EAR||WEAR_R_EAR))
+		user.client.soundOutput.status_flags |= EAR_DEAF_MUTE
+		user.client.soundOutput.apply_status()
+		user.on_deafness_gain()
+
+/obj/item/clothing/ears/earmuffs/unequipped(mob/user, slot)
+	. = ..()
+	if(slot == (WEAR_L_EAR||WEAR_R_EAR))
+		user.client.soundOutput.status_flags ^= EAR_DEAF_MUTE
+		user.client.soundOutput.apply_status()
+		user.on_deafness_loss()
 
 /obj/item/clothing/ears/earmuffs/New()
 	. = ..()

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -122,6 +122,7 @@
 	flags_equip_slot = SLOT_EAR
 	inherent_traits = list(TRAIT_ITEM_EAR_EXCLUSIVE)
 	clothing_traits = list(TRAIT_SCREECH_IMMUNE)
+	time_to_equip = 40
 
 /obj/item/clothing/ears/earmuffs/equipped(mob/user, slot)
 	. = ..()

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -875,6 +875,8 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 	if(alert("Do you want to go DNR?", "Choose to go DNR", "Yes", "No") == "Yes")
 		can_reenter_corpse = FALSE
+		src.client.soundOutput.status_flags ^= EAR_DEAF_MUTE
+		src.client.soundOutput.apply_status()
 		var/ref
 		var/mob/living/carbon/human/H = mind.original
 		if(istype(H))

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -11,6 +11,8 @@
 			E.droplimb(0, 0, cause)
 
 	undefibbable = TRUE
+	client.soundOutput.status_flags ^= EAR_DEAF_MUTE
+	client.soundOutput.apply_status()
 
 	GLOB.data_core.manifest_modify(real_name, WEAKREF(src), null, null, "*Deceased*")
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -19,6 +19,14 @@
 
 	if(SSticker?.mode?.hardcore)
 		hardcore = TRUE //For WO disposing of corpses
+	RegisterSignal(src, COMSIG_MOB_SCREECH_ACT, .proc/handle_screech_act)
+
+/mob/living/carbon/human/proc/handle_screech_act(var/mob/self, var/mob/living/carbon/Xenomorph/Queen/queen)
+	SIGNAL_HANDLER
+	if(queen.can_not_harm(src))
+		return COMPONENT_SCREECH_ACT_CANCEL
+	if(HAS_TRAIT(src, TRAIT_SCREECH_IMMUNE))
+		return COMPONENT_SCREECH_ACT_CANCEL
 
 /mob/living/carbon/human/initialize_pass_flags(var/datum/pass_flags_container/PF)
 	..()

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -65,6 +65,8 @@
 				handle_necro_chemicals_in_body(delta_time) //Specifically for chemicals that still work while dead.
 				if(life_tick > 5 && timeofdeath && (timeofdeath < 5 || world.time - timeofdeath > revive_grace_period) && !isSynth(src))	//We are dead beyond revival, or we're junk mobs spawned like the clowns on the clown shuttle
 					undefibbable = TRUE
+					client.soundOutput.status_flags ^= EAR_DEAF_MUTE
+					client.soundOutput.apply_status()
 					med_hud_set_status()
 
 	else if(stat != DEAD)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage mainainers from merging your PR! -->

Brings earmuffs back to their older, funnier state with a few more disadvantages. Adds a bit of QOL. Does not fix the admin pm being silent while deaf bug.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Because it's funny, and earmuffs blocking screech is highly soulful. Making it so that earmuffs entirely deafen you is (I think) enough of a downside. Plus you can't wear them with a radio. If it's abused too hard then they can have the screech immunity taken away.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: earmuffs now make you 100% deaf when you wear them (this means all sound, not just voices)
balance: earmuffs now block screech again, they also take a little bit of time to put on
qol: going DNR/perma, being ckeyed into a body, or being gibbed will now undeafen you.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
