### PR TITLE
Adds Service Jacket and Patrol Cap to requisition surplus vendor

### DIFF
--- a/code/game/machinery/vending/vendor_types/requisitions.dm
+++ b/code/game/machinery/vending/vendor_types/requisitions.dm
@@ -546,6 +546,7 @@ obj/structure/machinery/cm_vending/sorted/uniform_supply
 		list("USCM Satchel", 20, /obj/item/storage/backpack/marine/satchel, VENDOR_ITEM_REGULAR),
 		list("USCM Uniform", 20, /obj/item/clothing/under/marine, VENDOR_ITEM_REGULAR),
 		list("USCM Service Jacket", 20, /obj/item/clothing/suit/storage/jacket/marine/service, VENDOR_ITEM_REGULAR),
+		list("USCM Patrol Cap", 20, /obj/item/clothing/head/cmcap, VENDOR_ITEM_REGULAR),
 
 		list("ARMOR", -1, null, null),
 		list("M10 Pattern Marine Helmet", 20, /obj/item/clothing/head/helmet/marine, VENDOR_ITEM_REGULAR),

--- a/code/game/machinery/vending/vendor_types/requisitions.dm
+++ b/code/game/machinery/vending/vendor_types/requisitions.dm
@@ -545,6 +545,7 @@ obj/structure/machinery/cm_vending/sorted/uniform_supply
 		list("M276 Shotgun Shell Loading Rig", 10, /obj/item/storage/belt/shotgun, VENDOR_ITEM_REGULAR),
 		list("USCM Satchel", 20, /obj/item/storage/backpack/marine/satchel, VENDOR_ITEM_REGULAR),
 		list("USCM Uniform", 20, /obj/item/clothing/under/marine, VENDOR_ITEM_REGULAR),
+		list("USCM Service Jacket", 20, /obj/item/clothing/suit/storage/jacket/marine/service, VENDOR_ITEM_REGULAR),
 
 		list("ARMOR", -1, null, null),
 		list("M10 Pattern Marine Helmet", 20, /obj/item/clothing/head/helmet/marine, VENDOR_ITEM_REGULAR),


### PR DESCRIPTION

## About The Pull Request

Adds the service jacket and patrol cap to requisition surplus vendor.

## Why It's Good For The Game

Service Jackets and Patrol Caps should be available for non-combat personnel without breaking into uniform vendors.

## Changelog

:cl: Morrow
add: Adds Service Jacket and Patrol Cap to requisition surplus vendor
/:cl: