### PR TITLE
fixes some issues with xenos, mice, and closets

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -232,6 +232,10 @@
 		for(var/mob/M in viewers(src))
 			M.show_message(SPAN_WARNING("[src] has been [welded?"welded shut":"unwelded"] by [user.name]."), 3, "You hear welding.", 2)
 	else
+		if(isXeno(user))
+			var/mob/living/carbon/Xenomorph/opener = user
+			src.attack_alien(opener)
+			return
 		src.attack_hand(user)
 	return
 

--- a/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
@@ -96,6 +96,10 @@
 	else if(istype(W,/obj/item/packageWrap) || istype(W,/obj/item/tool/weldingtool))
 		return ..(W,user)
 	else
+		if(isXeno(user))
+			var/mob/living/carbon/Xenomorph/opener = user
+			src.attack_alien(opener)
+			return
 		togglelock(user)
 
 /obj/structure/closet/secure_closet/attack_hand(mob/living/user)

--- a/code/game/objects/structures/crates_lockers/secure_crates.dm
+++ b/code/game/objects/structures/crates_lockers/secure_crates.dm
@@ -69,12 +69,21 @@
 		src.toggle(user)
 
 /obj/structure/closet/crate/secure/attackby(obj/item/W as obj, mob/user as mob)
+	if(isXeno(user))
+		var/mob/living/carbon/Xenomorph/opener = user
+		src.attack_alien(opener)
+		return
 	if(is_type_in_list(W, list(/obj/item/packageWrap, /obj/item/stack/cable_coil, /obj/item/device/radio/electropack, /obj/item/tool/wirecutters, /obj/item/tool/weldingtool)))
 		return ..()
 	if(!opened)
 		src.togglelock(user)
 		return
 	return ..()
+
+/obj/structure/closet/crate/secure/break_open()
+	broken = TRUE
+	locked = FALSE
+	..()
 
 /obj/structure/closet/crate/secure/emp_act(severity)
 	for(var/obj/O in src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

closes #352 
should fix #351 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

bugfix

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: xenos can no longer open closets with a mouse or other item - they just smash it with their claws instead.
fix: xenos can now properly smash open secure crates.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
