### PR TITLE
Gardener Fruit Visibility

### DIFF
--- a/code/modules/cm_aliens/structures/fruit.dm
+++ b/code/modules/cm_aliens/structures/fruit.dm
@@ -8,7 +8,7 @@
 	opacity = 0
 	anchored = TRUE
 	health = 25
-	layer = RESIN_STRUCTURE_LAYER
+	layer = BUSH_LAYER // technically a plant amiright
 	var/picked = FALSE
 	var/hivenumber = XENO_HIVE_NORMAL
 	var/consume_delay = 2 SECONDS
@@ -21,6 +21,8 @@
 	var/regeneration_ticks = 1
 	var/mature_icon_state = "fruit_lesser"
 	var/consumed_icon_state = "fruit_spent"
+
+	var/glow_color = "#17991b80"
 
 	var/mob/living/carbon/Xenomorph/bound_xeno // Drone linked to this fruit
 	var/fruit_type = /obj/item/reagent_container/food/snacks/resin_fruit
@@ -118,6 +120,8 @@
 	mature = TRUE
 	icon_state = mature_icon_state
 	timer_id = TIMER_ID_NULL
+	if(glow_color)
+		add_filter("fruity_glow", 1, list("type" = "outline", "color" = glow_color, "size" = 1))
 	update_icon()
 
 /obj/effect/alien/resin/fruit/proc/consume_effect(mob/living/carbon/Xenomorph/recipient)
@@ -208,6 +212,7 @@
 	var/shield_duration = 1 MINUTES
 	var/shield_decay = 10
 	fruit_type = /obj/item/reagent_container/food/snacks/resin_fruit/unstable
+	glow_color = "#17997280"
 
 /obj/effect/alien/resin/fruit/unstable/consume_effect(mob/living/carbon/Xenomorph/recipient)
 	if(mature && recipient && !QDELETED(recipient))
@@ -231,6 +236,7 @@
 	var/pheromone_range = 1
 	consumed_icon_state = "fruit_spent_2"
 	fruit_type = /obj/item/reagent_container/food/snacks/resin_fruit/spore
+	glow_color = "#99461780"
 
 /obj/effect/alien/resin/fruit/spore/consume_effect(mob/living/carbon/Xenomorph/recipient)
 	if(mature && recipient && !QDELETED(recipient))
@@ -267,6 +273,7 @@
 	consumed_icon_state = "fruit_spent_2"
 	flags = CAN_CONSUME_AT_FULL_HEALTH
 	fruit_type = /obj/item/reagent_container/food/snacks/resin_fruit/speed
+	glow_color = "#9559ca80"
 	var/speed_buff_amount = 0.4
 	var/speed_duration = 15 SECONDS
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Made Gardener fruits layer over most things, including weed nodes. Also glows when it's mature, see below.

![image](https://user-images.githubusercontent.com/22774890/174483960-f664b345-c1f8-4ec1-9f29-3baa4544e143.png)


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It's really difficult to see gardener fruits when you're in a high adrenaline state, so this'll make it a bit easier.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Gardener fruits now glow when they mature, they now also layer over most objects and items.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
