### PR TITLE
Fixes issue #330 and removes reduntant holster code

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -589,9 +589,9 @@ cases. Override_icon_state should be a list.*/
 							var/obj/item/clothing/accessory/storage/S = A
 							if(S.hold.can_be_inserted(src, TRUE))
 								return TRUE
-						else if(istype(A, /obj/item/clothing/accessory/holster))
-							var/obj/item/clothing/accessory/holster/AH = A
-							if(!(AH.holstered) && AH.can_holster(src))
+						else if(istype(A, /obj/item/storage/internal/accessory/holster))
+							var/obj/item/storage/internal/accessory/holster/AH = A
+							if(!(AH.current_gun) && AH.can_be_inserted(src))
 								return TRUE
 				return FALSE
 			if(WEAR_IN_JACKET)

--- a/code/modules/clothing/under/ties.dm
+++ b/code/modules/clothing/under/ties.dm
@@ -354,6 +354,8 @@
 	desc = "A fire resistant shoulder patch, worn by the men and women of the Falling Falcons, the 2nd battalion of the 4th brigade of the USCM."
 	icon_state = "fallingfalconspatch"
 
+//Ties that can store stuff
+
 /obj/item/storage/internal/accessory
 	storage_slots = 3
 

--- a/code/modules/clothing/under/ties.dm
+++ b/code/modules/clothing/under/ties.dm
@@ -665,7 +665,7 @@ obj/item/storage/internal/accessory/knifeharness/duelling
 				if(!stop_messages)
 					to_chat(usr, SPAN_WARNING("[src] already holds \a [W]."))
 				return
-		else //Must be ammo.s
+		else //Must be ammo.
 			var/ammo_slots = storage_slots - 1 //We have a slot reserved for the gun
 			var/ammo_stored = length(contents)
 			if(current_gun)

--- a/code/modules/clothing/under/ties.dm
+++ b/code/modules/clothing/under/ties.dm
@@ -354,105 +354,6 @@
 	desc = "A fire resistant shoulder patch, worn by the men and women of the Falling Falcons, the 2nd battalion of the 4th brigade of the USCM."
 	icon_state = "fallingfalconspatch"
 
-//holsters
-/obj/item/clothing/accessory/holster
-	name = "shoulder holster"
-	desc = "A handgun holster."
-	icon_state = "holster"
-	var/obj/item/weapon/gun/holstered = null
-	slot = ACCESSORY_SLOT_UTILITY
-	high_visibility = TRUE
-
-/obj/item/clothing/accessory/holster/Destroy()
-	QDEL_NULL(holstered)
-	. = ..()
-
-//subtypes can override this to specify what can be holstered
-/obj/item/clothing/accessory/holster/proc/can_holster(obj/item/I, mob/user)
-	if(!isgun(I) && !isbanana(I))
-		to_chat(user, SPAN_DANGER("Only guns can be holstered!"))
-		return FALSE
-	if(I.w_class > SIZE_MEDIUM)
-		to_chat(user, SPAN_DANGER("\The [I] won't fit in \the [src]!"))
-		return FALSE
-	return TRUE
-
-/obj/item/clothing/accessory/holster/proc/holster(obj/item/I, mob/user)
-	if(holstered)
-		to_chat(user, SPAN_DANGER("There is already a [holstered] holstered here!"))
-		return
-
-	var/obj/item/weapon/gun/W = I
-	if(!can_holster(W, user))
-		return
-
-	holstered = W
-	user.drop_inv_item_to_loc(holstered, src)
-	holstered.add_fingerprint(user)
-	user.visible_message(SPAN_NOTICE("[user] holsters \the [holstered]."), "You holster \the [holstered].")
-
-/obj/item/clothing/accessory/holster/proc/unholster(mob/user as mob)
-	if(!holstered)
-		return
-
-	if(user.get_active_hand() && user.get_inactive_hand())
-		to_chat(user, SPAN_WARNING("You need an empty hand to draw the [holstered]!"))
-	else
-		if(user.a_intent == INTENT_HARM)
-			usr.visible_message(SPAN_DANGER("[user] draws the [holstered], ready to shoot!"), \
-			SPAN_DANGER("You draw [holstered], ready to shoot!"))
-		else
-			user.visible_message(SPAN_NOTICE("[user] draws the [holstered], pointing it at the ground."), \
-			SPAN_NOTICE("You draw the [holstered], pointing it at the ground."))
-		user.put_in_hands(holstered)
-		holstered.add_fingerprint(user)
-		holstered = null
-
-/obj/item/clothing/accessory/holster/attack_hand(mob/user as mob)
-	if (has_suit)	//if we are part of a suit
-		if (holstered)
-			unholster(user)
-		return TRUE
-
-	..(user)
-
-/obj/item/clothing/accessory/holster/attackby(obj/item/W as obj, mob/user as mob)
-	holster(W, user)
-
-/obj/item/clothing/accessory/holster/emp_act(severity)
-	if (holstered)
-		holstered.emp_act(severity)
-	..()
-
-/obj/item/clothing/accessory/holster/examine(mob/user)
-	..()
-	if (holstered)
-		to_chat(user, "A [holstered] is holstered here.")
-	else
-		to_chat(user, "It is empty.")
-
-/obj/item/clothing/accessory/holster/additional_examine_text()
-	if(holstered)
-		return ", carrying \a [holstered]."
-	. = ..()
-
-/obj/item/clothing/accessory/holster/armpit
-	name = "shoulder holster"
-	desc = "A worn-out handgun holster. Perfect for concealed carry"
-	icon_state = "holster"
-
-/obj/item/clothing/accessory/holster/waist
-	name = "shoulder holster"
-	desc = "A handgun holster. Made of expensive leather."
-	icon_state = "holster"
-	item_state = "holster_low"
-
-
-
-
-
-//Ties that can store stuff
-
 /obj/item/storage/internal/accessory
 	storage_slots = 3
 
@@ -728,12 +629,14 @@ obj/item/storage/internal/accessory/knifeharness/duelling
 	storage_flags = STORAGE_ALLOW_QUICKDRAW|STORAGE_FLAGS_POUCH
 	can_hold = list(
 
-// Change flare gun to pistol preferably - + testing needed but that tomorrow now im going to sleep
+//Can hold variety of pistols and revolvers together with ammo for them. Can also hold the flare pistol and signal/illumination flares.
 	/obj/item/weapon/gun/pistol,
-	/obj/item/weapon/gun/flare,
 	/obj/item/weapon/gun/energy/taser,
+	/obj/item/weapon/gun/revolver,
 	/obj/item/ammo_magazine/pistol,
-	/obj/item/ammo_magazine/revolver
+	/obj/item/ammo_magazine/revolver,
+	/obj/item/ammo_magazine/internal/flare,
+	/obj/item/device/flashlight/flare
 
 	 )
 
@@ -760,9 +663,9 @@ obj/item/storage/internal/accessory/knifeharness/duelling
 		if(isgun(W))
 			if(current_gun)
 				if(!stop_messages)
-					to_chat(usr, SPAN_WARNING("[src] already holds a gun."))
+					to_chat(usr, SPAN_WARNING("[src] already holds \a [W]."))
 				return
-		else //Must be ammo.
+		else //Must be ammo.s
 			var/ammo_slots = storage_slots - 1 //We have a slot reserved for the gun
 			var/ammo_stored = length(contents)
 			if(current_gun)

--- a/code/modules/clothing/under/ties.dm
+++ b/code/modules/clothing/under/ties.dm
@@ -727,18 +727,15 @@ obj/item/storage/internal/accessory/knifeharness/duelling
 	var/drawSound = 'sound/weapons/gun_pistol_draw.ogg'
 	storage_flags = STORAGE_ALLOW_QUICKDRAW|STORAGE_FLAGS_POUCH
 	can_hold = list(
-		/obj/item/weapon/gun/pistol,
-		/obj/item/ammo_magazine/pistol,
-		/obj/item/ammo_magazine/pistol/heavy,
-		/obj/item/ammo_magazine/pistol/heavy/super,
-		/obj/item/ammo_magazine/pistol/heavy/super/highimpact,
-		/obj/item/weapon/gun/revolver/m44,
-		/obj/item/ammo_magazine/revolver,
-		/obj/item/weapon/gun/pistol/smart,
-		/obj/item/ammo_magazine/pistol/smart,
-		/obj/item/weapon/gun/energy/taser,
-		/obj/item/weapon/gun/flare
-	)
+
+// Change flare gun to pistol preferably - + testing needed but that tomorrow now im going to sleep
+	/obj/item/weapon/gun/pistol,
+	/obj/item/weapon/gun/flare,
+	/obj/item/weapon/gun/energy/taser,
+	/obj/item/ammo_magazine/pistol,
+	/obj/item/ammo_magazine/revolver
+
+	 )
 
 /obj/item/storage/internal/accessory/holster/on_stored_atom_del(atom/movable/AM)
 	if(AM == current_gun)

--- a/code/modules/projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/gun_helpers.dm
@@ -533,8 +533,8 @@ As sniper rifles have both and weapon mods can change them as well. ..() deals w
 		return
 
 	if(slot == w_uniform)
-		for(var/obj/item/clothing/accessory/holster/T in w_uniform.accessories)
-			if(T.holstered)
+		for(var/obj/item/storage/internal/accessory/holster/T in w_uniform.accessories)
+			if(T.current_gun)
 				w_uniform.attack_hand(src)
 				return TRUE
 		for(var/obj/item/clothing/accessory/storage/holster/H in w_uniform.accessories)
@@ -571,9 +571,9 @@ As sniper rifles have both and weapon mods can change them as well. ..() deals w
 	if(W)
 		if(w_uniform)
 			for(var/obj/A in w_uniform.accessories)
-				var/obj/item/clothing/accessory/holster/H = A
-				if(istype(H) && !H.holstered && H.can_holster(W))
-					H.holster(W, src)
+				var/obj/item/storage/internal/accessory/holster/H = A
+				if(istype(H) && !H.current_gun && H.can_be_inserted(W))
+					H._item_insertion(W, src)
 					return
 
 				var/obj/item/clothing/accessory/storage/holster/HS = A


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
 - Holsters now can hold pistols, revolvers, as well as ammunition for them as a general category instead of specific objects. They can also hold the flare gun and illumination/signal flares.
- Removed unused holster code for a separate entity, which caused holsters to be defined twice as two different objects, meanwhile the removed version was not being used except:
- Replaced references to the ability to be holstered and whether a weapon can be insterted from now removed and unused holster to the widely used holster.
## Why It's Good For The Game

Fixes an issue and I think the other object is pointless to have, clutters the code and is not used. 
If you can carry the flare gun and normal magazines then you might as well be able to carry flares in the holster.
You can examine the holster now and know what weapon you have got holstered. 

## Changelog

:cl:
add: you can now hold flares in your holster to supplement your flare gun
add: Examining equipped holster shows what weapon is inside of it
del: Removed old holster (not used anymore)
fix: fixed the issue where some revolvers and ammo were not able to be inserted into shoulder holsters
code: changed references to the new code and replaced methods to match the commonly used holsters
/:cl: