### PR TITLE
Cryo Jelly and Latejoin RP

### DIFF
--- a/code/game/jobs/role_authority.dm
+++ b/code/game/jobs/role_authority.dm
@@ -522,7 +522,7 @@ var/global/players_preassigned = 0
 	if(!ishuman(M))
 		return
 
-	var/mob/living/carbon/H = M
+	var/mob/living/carbon/human/H = M
 
 	H.job = J.title //TODO Why is this a mob variable at all?
 
@@ -564,6 +564,17 @@ var/global/players_preassigned = 0
 	if(Check_WO() && job_squad_roles.Find(GET_DEFAULT_ROLE(H.job)))	//activates self setting proc for marine headsets for WO
 		var/datum/game_mode/whiskey_outpost/WO = SSticker.mode
 		WO.self_set_headset(H)
+
+	if(locate(/obj/structure/machinery/cryopod) in range(1, H))
+		var/obj/item/storage/backpack/marine/spawn_backpack = H.back
+		if(!spawn_backpack)
+			spawn_backpack = new /obj/item/storage/backpack/marine(H.loc)
+			H.equip_to_slot_if_possible(spawn_backpack, WEAR_L_HAND)
+		for(var/obj/item/item in list(H.r_store, H.l_store, H.s_store, H.wear_suit, H.w_uniform, H.shoes, H.belt, H.gloves, H.glasses, H.wear_l_ear, H.wear_r_ear))
+			H.drop_inv_item_to_loc(item, spawn_backpack, force = TRUE)
+		to_chat(H, SPAN_WARNING("You wake up covered in cryo jelly, maybe you should go hit the showers after getting food."))
+		H.nutrition = rand(NUTRITION_VERYLOW, NUTRITION_LOW)
+		H.fire_stacks = 10
 
 	H.sec_hud_set_ID()
 	H.hud_set_squad()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Anyone waking up next to a cryosleep chamber will now be covered in cryo jelly, which makes them flammable. This can be washed off at the showers. Additionally, latejoin roles that start equipped will deposit all their items into their backpack, since waking up fully equipped doesn't really make sense.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This is good for lore accuracy and pre-drop RP.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Geeves
add: Anyone that spawns next to a cryotube will now be hungry and covered in flammable cryo jelly, this can be washed off at the showers.
add: Any equipped role that spawns next to a cryotube will now drop their equipment into their backpack after spawning.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
