### PR TITLE
fixes survivors not going in the survivors part of the orbit list

### DIFF
--- a/code/__DEFINES/typecheck/humanoids.dm
+++ b/code/__DEFINES/typecheck/humanoids.dm
@@ -30,4 +30,4 @@
 
 //job/role helpers
 #define ismarinejob(J) (istype(J, /datum/job/marine))
-#define issurvivorjob(J) (istype(J, /datum/job/civilian/survivor))
+#define issurvivorjob(J) (J == "Survivor")

--- a/code/__DEFINES/typecheck/humanoids.dm
+++ b/code/__DEFINES/typecheck/humanoids.dm
@@ -30,4 +30,4 @@
 
 //job/role helpers
 #define ismarinejob(J) (istype(J, /datum/job/marine))
-#define issurvivorjob(J) (J == "Survivor")
+#define issurvivorjob(J) (J == JOB_SURVIVOR)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

title

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

bugfix

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: survivors will now be properly sorted into the survivors part of the orbit menu
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
