### PR TITLE
Fixes double evolution readiness notification and sound

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -44,7 +44,7 @@
 	var/ovipositor_check = (hive.allow_no_queen_actions || hive.evolution_without_ovipositor || (hive.living_xeno_queen && hive.living_xeno_queen.ovipositor))
 	if(caste && caste.evolution_allowed && evolution_stored < evolution_threshold && ovipositor_check)
 		evolution_stored = min(evolution_stored + progress_amount, evolution_threshold)
-		if(evolution_stored >= evolution_threshold - 1)
+		if(evolution_stored > evolution_threshold - 1)
 			to_chat(src, SPAN_XENODANGER("Your carapace crackles and your tendons strengthen. You are ready to <a href='?src=\ref[src];evolve=1;'>evolve</a>!")) //Makes this bold so the Xeno doesn't miss it
 			src << sound('sound/effects/xeno_evolveready.ogg')
 


### PR DESCRIPTION
## About The Pull Request

The evolution notification and sound will now only play once the treshold is at or above max level.

Personally I cannot find a good reason for the threshold - 1 in code but I removed the equality check. If the preferred alternative is to have it operate a >= on unmodified threshold then it is not an issue to have it changed due to the scale of the changes. 

closes #532 

## Why It's Good For The Game

You should not hear the evolve hiss twice nor have a double notification in chat about it.

## Changelog
:cl: Maciekkub
fix: Sound and notification now only play when you reach max threshold or above. 
/:cl:

