### PR TITLE
ravs no longer get empower stacks off the queen eye

### DIFF
--- a/code/__DEFINES/typecheck/mobs_generic.dm
+++ b/code/__DEFINES/typecheck/mobs_generic.dm
@@ -4,7 +4,6 @@
 #define isRemoteControllingOrAI(M)	((M && M.client && M.client.remote_control) || (istype(M, /mob/living/silicon/ai)))
 
 #define isbrain(A) (istype(A, /mob/living/brain))
-#define ishologram(A) (istype(A, /mob/hologram))
 #define isrobot(A) (istype(A, /mob/living/silicon/robot))
 #define isanimal(A) (istype(A, /mob/living/simple_animal))
 #define iscorgi(A) (istype(A, /mob/living/simple_animal/corgi))

--- a/code/__DEFINES/typecheck/mobs_generic.dm
+++ b/code/__DEFINES/typecheck/mobs_generic.dm
@@ -4,6 +4,7 @@
 #define isRemoteControllingOrAI(M)	((M && M.client && M.client.remote_control) || (istype(M, /mob/living/silicon/ai)))
 
 #define isbrain(A) (istype(A, /mob/living/brain))
+#define ishologram(A) (istype(A, /mob/hologram))
 #define isrobot(A) (istype(A, /mob/living/silicon/robot))
 #define isanimal(A) (istype(A, /mob/living/simple_animal))
 #define iscorgi(A) (istype(A, /mob/living/simple_animal/corgi))

--- a/code/modules/mob/living/carbon/xenomorph/abilities/ravager/ravager_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/ravager/ravager_powers.dm
@@ -43,11 +43,11 @@
 	for(var/mob/M as anything in mobs_in_range)
 		if(empower_targets >= max_targets)
 			break
+		if(!istype(/mob/living))
+			break
 		if(M.stat == DEAD || HAS_TRAIT(M, TRAIT_NESTED))
 			continue
 		if(X.can_not_harm(M))
-			continue
-		if(ishologram(M))
 			continue
 
 		empower_targets++

--- a/code/modules/mob/living/carbon/xenomorph/abilities/ravager/ravager_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/ravager/ravager_powers.dm
@@ -47,6 +47,8 @@
 			continue
 		if(X.can_not_harm(M))
 			continue
+		if(ishologram(M))
+			continue
 
 		empower_targets++
 		accumulative_health += shield_per_human
@@ -534,7 +536,7 @@
 
 	if (!action_cooldown_check())
 		return
-		
+
 	if (!X.check_state())
 		return
 

--- a/code/modules/mob/living/carbon/xenomorph/abilities/ravager/ravager_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/ravager/ravager_powers.dm
@@ -40,10 +40,8 @@
 	var/list/telegraph_atom_list = list()
 
 	var/empower_targets
-	for(var/mob/M as anything in mobs_in_range)
+	for(var/mob/living/M in mobs_in_range)
 		if(empower_targets >= max_targets)
-			break
-		if(!istype(M, /mob/living))
 			break
 		if(M.stat == DEAD || HAS_TRAIT(M, TRAIT_NESTED))
 			continue

--- a/code/modules/mob/living/carbon/xenomorph/abilities/ravager/ravager_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/ravager/ravager_powers.dm
@@ -43,7 +43,7 @@
 	for(var/mob/M as anything in mobs_in_range)
 		if(empower_targets >= max_targets)
 			break
-		if(!istype(/mob/living))
+		if(!istype(M, /mob/living))
 			break
 		if(M.stat == DEAD || HAS_TRAIT(M, TRAIT_NESTED))
 			continue


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

closes #535 

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

bugfix

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Ravagers will no longer count holograms such as the queen eye as enemies for the purposes of empowering.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
