### PR TITLE
Fixes more MP jackets errors

### DIFF
--- a/code/modules/clothing/suits/marine_coat.dm
+++ b/code/modules/clothing/suits/marine_coat.dm
@@ -94,6 +94,7 @@
 	desc = "A marine service jacket adopted for use by Military Wardens on board USCM ships. Ironically most ships require their MP departments to use full armor, making these barely used by on duty Wardens. The jacket of choice for looking all night at a set of monitors, while cigarette butts pile around you."
 	has_buttons = TRUE
 	icon_state = "coat_warden"
+	flags_atom = NO_SNOW_TYPE
 	initial_icon_state = "coat_warden"
 
 /obj/item/clothing/suit/storage/jacket/marine/service/cmp

--- a/code/modules/clothing/suits/marine_coat.dm
+++ b/code/modules/clothing/suits/marine_coat.dm
@@ -87,13 +87,14 @@
 	has_buttons = TRUE
 	icon_state = "coat_mp"
 	flags_atom = NO_SNOW_TYPE
+	initial_icon_state = "coat_mp"
 
 /obj/item/clothing/suit/storage/jacket/marine/service/warden
 	name = "military warden service jacket"
 	desc = "A marine service jacket adopted for use by Military Wardens on board USCM ships. Ironically most ships require their MP departments to use full armor, making these barely used by on duty Wardens. The jacket of choice for looking all night at a set of monitors, while cigarette butts pile around you."
 	has_buttons = TRUE
 	icon_state = "coat_warden"
-	flags_atom = NO_SNOW_TYPE
+	initial_icon_state = "coat_warden"
 
 /obj/item/clothing/suit/storage/jacket/marine/service/cmp
 	name = "chief military police service jacket"
@@ -101,6 +102,7 @@
 	has_buttons = TRUE
 	icon_state = "coat_cmp"
 	flags_atom = NO_SNOW_TYPE
+	initial_icon_state = "coat_cmp"
 
 /obj/item/clothing/suit/storage/jacket/marine/chef
 	name = "mess technician jacket"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

So... Did you guys know that applying the NO_SNOW_TYPE flag breaks button code on clothing items that have it?

That is because adding the variable used to control the jackets is added after modifying them to their snow variants and if there are no snow variants, the variable is just not added at all because all of that is trapped in a wacky if statement and I need a drink.

Anyway, this refixes the damn jackets - adds the variables they need straight to their object definitions because I don't have time for this foolishness and also if I have to fix the jacket code again I will scream.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Items not broken good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:Silencer_pl
fix: MP service jackets can be opened and closed again without causing icon errors.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
