### PR TITLE
Survivor synths now spawn with colony radio

### DIFF
--- a/code/modules/gear_presets/_select_equipment.dm
+++ b/code/modules/gear_presets/_select_equipment.dm
@@ -649,7 +649,6 @@ var/list/rebel_rifles = list(
 			H.equip_to_slot_or_del(new /obj/item/clothing/shoes/marine(H), WEAR_FEET)
 			H.equip_to_slot_or_del(new /obj/item/storage/belt/utility/full(H), WEAR_WAIST)
 			H.equip_to_slot_or_del(new /obj/item/clothing/shoes/marine/knife(H), WEAR_FEET)
-			H.equip_to_slot_or_del(new /obj/item/device/radio/marine(H), WEAR_IN_BACK)
 			H.equip_to_slot_or_del(new /obj/item/storage/pouch/tools/full(H), WEAR_R_STORE)
 		if(1) // The Medical Synth
 			H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/medical(H), WEAR_BODY)

--- a/code/modules/gear_presets/synths.dm
+++ b/code/modules/gear_presets/synths.dm
@@ -131,7 +131,7 @@
 /datum/equipment_preset/synth/survivor/load_gear(mob/living/carbon/human/H)
 	add_random_synth_survivor_equipment(H)
 	H.equip_to_slot_or_del(new /obj/item/device/radio/headset/distress(H), WEAR_L_EAR)
-	H.equip_to_slot_or_del(new /obj/item/device/radio/marine(H), WEAR_IN_BACK)
+	H.equip_to_slot_or_del(new /obj/item/device/radio(H), WEAR_IN_BACK)
 	H.equip_to_slot_or_del(new /obj/item/storage/pouch/tools/full(H), WEAR_R_STORE)
 	H.equip_to_slot_or_del(new /obj/item/storage/pouch/survival/synth/full(H), WEAR_L_STORE)
 	H.equip_to_slot_or_del(new /obj/item/weapon/melee/twohanded/fireaxe(H), WEAR_L_HAND)


### PR DESCRIPTION
## About The Pull Request

Synth survivors now will spawn by default with colony radio

The removed line of code prevents assignment of marine radio before the colony radio can be assigned. 

closes #538 
I think the issue wrongly reports wrong headsets but both in the code and while testing I only could see colony headsets on synthetic survivors
## Why It's Good For The Game

Survivor synthetics should operate on their colony's net instead of unrelated marine net. 

## Changelog

:cl:Maciekkub
fix: Survivor synthetics will no longer be assigned marine radio and instead be given the colonial equivalent.  
/:cl:

