### PR TITLE
M5RPG text fix

### DIFF
--- a/code/__DEFINES/conflict.dm
+++ b/code/__DEFINES/conflict.dm
@@ -42,7 +42,7 @@
 #define GUN_UNUSUAL_DESIGN		(1<<2)
 #define GUN_SILENCED			(1<<3)
 #define GUN_AUTOMATIC			(1<<4)
-#define GUN_INTERNAL_MAG		(1<<5)
+#define GUN_INTERNAL_MAG		(1<<5)  // If checking for ammo with current.mag you have to check it against numerical values, as booleans will not trigger.
 #define GUN_AUTO_EJECTOR		(1<<6)
 #define GUN_AMMO_COUNTER		(1<<7)
 #define GUN_BURST_ON			(1<<8)

--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -1206,7 +1206,7 @@ obj/item/weapon/gun/launcher/grenade/update_icon()
 						/obj/item/attachable/magnetic_harness
 						)
 
-	flags_gun_features = GUN_SPECIALIST|GUN_WIELDED_FIRING_ONLY
+	flags_gun_features = GUN_SPECIALIST|GUN_WIELDED_FIRING_ONLY|GUN_INTERNAL_MAG
 	var/datum/effect_system/smoke_spread/smoke
 
 	flags_item = TWOHANDED|NO_CRYO_STORE
@@ -1233,7 +1233,8 @@ obj/item/weapon/gun/launcher/grenade/update_icon()
 
 /obj/item/weapon/gun/launcher/rocket/examine(mob/user)
 	..()
-	if(!current_mag)
+	if(current_mag.current_rounds <= 0)
+		to_chat(user, "It's not loaded.")
 		return
 	if(current_mag.current_rounds > 0)
 		to_chat(user, "It has an 84mm [ammo.name] loaded.")


### PR DESCRIPTION
## About The Pull Request

closes #477 
Also now upon examine properly displays if the round is not loaded

## Why It's Good For The Game

Fixes issues

## Changelog

:cl:Maciekkub
fix: Fixes M5RPG text displaying "It's unloaded but has round chambered" and now correctly displays if it's empty upon examine
/:cl:
