### PR TITLE
Big red loot nerf + fixes

### DIFF
--- a/code/game/objects/structures/crates_lockers/largecrate.dm
+++ b/code/game/objects/structures/crates_lockers/largecrate.dm
@@ -285,6 +285,316 @@
 		while(++m <= num_mags)
 			new new_mag(src)
 
+/obj/structure/largecrate/mediocre
+	name = "\improper Weapons crate"
+	desc = "What is in here?"
+
+// really mediocre weapons.
+
+/obj/structure/largecrate/mediocre/New()
+	..()
+	var/i = pick(1,5)
+	switch(i)
+		if(1) //Type 71 set
+			new /obj/item/weapon/gun/rifle/type71(src)
+			new /obj/item/ammo_magazine/rifle/type71(src)
+			new /obj/item/ammo_magazine/rifle/type71(src)
+			new /obj/item/ammo_magazine/rifle/type71(src)
+			new /obj/item/clothing/mask/gas/PMC(src)
+		if(2) //MAR carabine set
+			new /obj/item/weapon/gun/rifle/mar40/carbine(src)
+			new /obj/item/ammo_magazine/rifle/mar40(src)
+			new /obj/item/ammo_magazine/rifle/mar40(src)
+			new /obj/item/ammo_magazine/rifle/mar40(src)
+		if(3) //Uzi set
+			new /obj/item/weapon/gun/smg/uzi(src)
+			new /obj/item/ammo_magazine/smg/uzi(src)
+			new /obj/item/ammo_magazine/smg/uzi(src)
+			new /obj/item/ammo_magazine/smg/uzi(src)
+		if(4) //PPSH set
+			new /obj/item/weapon/gun/smg/ppsh(src)
+			new /obj/item/ammo_magazine/smg/ppsh(src)
+			new /obj/item/ammo_magazine/smg/ppsh(src)
+			new /obj/item/ammo_magazine/smg/ppsh(src)
+		if(5) //MP5
+			new /obj/item/weapon/gun/smg/mp5(src)
+			new /obj/item/ammo_magazine/smg/mp5(src)
+			new /obj/item/ammo_magazine/smg/mp5(src)
+			new /obj/item/ammo_magazine/smg/mp5(src)
+		if(6) //HEFA nade set with m74
+			new /obj/item/explosive/grenade/HE/frag(src)
+			new /obj/item/explosive/grenade/HE/frag(src)
+			new /obj/item/explosive/grenade/HE/frag(src)
+			new /obj/item/explosive/grenade/HE/frag(src)
+			new /obj/item/explosive/grenade/HE/frag(src)
+			new /obj/item/explosive/grenade/HE/frag(src)
+			new /obj/item/explosive/grenade/HE/frag(src)
+			new /obj/item/explosive/grenade/HE/frag(src)
+			new /obj/item/weapon/gun/launcher/grenade/m81/m79(src)
+
+
+/obj/structure/largecrate/crap
+	name = "\improper Weapons crate"
+	desc = "What is in here?"
+
+// Low tier SMGs, pistols and good ole bolt actions
+
+/obj/structure/largecrate/guns/crap/New()
+	..()
+	var/i = pick(1,5)
+	switch(i)
+		if(1) //KT42 x2 set
+			new /obj/item/weapon/gun/pistol/kt42(src)
+			new /obj/item/weapon/gun/pistol/kt42(src)
+			new /obj/item/ammo_magazine/pistol/automatic(src)
+			new /obj/item/ammo_magazine/pistol/automatic(src)
+			new /obj/item/ammo_magazine/pistol/automatic(src)
+			new /obj/item/ammo_magazine/pistol/automatic(src)
+			new /obj/item/ammo_magazine/pistol/automatic(src)
+		if(2) //MP27 set
+			new /obj/item/weapon/gun/smg/mp7(src)
+			new /obj/item/ammo_magazine/smg/mp7(src)
+			new /obj/item/ammo_magazine/smg/mp7(src)
+			new /obj/item/ammo_magazine/smg/mp7(src)
+		if(3) //CMB revolvers x2
+			new /obj/item/weapon/gun/revolver/cmb(src)
+			new /obj/item/weapon/gun/revolver/cmb(src)
+			new /obj/item/ammo_magazine/revolver/cmb(src)
+			new /obj/item/ammo_magazine/revolver/cmb(src)
+			new /obj/item/ammo_magazine/revolver/cmb(src)
+			new /obj/item/ammo_magazine/revolver/cmb(src)
+		if(4) // 2x ppsh
+			new /obj/item/weapon/gun/smg/ppsh(src)
+			new /obj/item/weapon/gun/smg/ppsh(src)
+			new /obj/item/ammo_magazine/smg/ppsh(src)
+			new /obj/item/ammo_magazine/smg/ppsh(src)
+			new /obj/item/ammo_magazine/smg/ppsh(src)
+			new /obj/item/ammo_magazine/smg/ppsh(src)
+		if(5) // assorted garbage
+			new /obj/item/weapon/gun/rifle/hunting(src)
+			new /obj/item/weapon/gun/rifle/hunting(src)
+			new /obj/item/weapon/gun/rifle/hunting(src)
+			new /obj/item/ammo_magazine/rifle/hunting(src)
+			new /obj/item/ammo_magazine/rifle/hunting(src)
+			new /obj/item/ammo_magazine/rifle/hunting(src)
+
+/obj/structure/largecrate/decent
+	name = "\improper Weapons crate"
+	desc = "What is in here?"
+
+// Decent weapon sets that shouldn't be too crazy. Bog standard marine weapons with some variance in quality
+
+/obj/structure/largecrate/guns/decent/New()
+	..()
+	var/i = pick(1,5)
+	switch(i)
+		if(1) //M41 MK2 set
+			new /obj/item/weapon/gun/rifle/m41a(src)
+			new /obj/item/ammo_magazine/rifle(src)
+			new /obj/item/ammo_magazine/rifle(src)
+			new /obj/item/ammo_magazine/rifle(src)
+		if(2) //MAR set
+			new /obj/item/weapon/gun/rifle/mar40(src)
+			new /obj/item/ammo_magazine/rifle/mar40(src)
+			new /obj/item/ammo_magazine/rifle/mar40(src)
+			new /obj/item/ammo_magazine/rifle/mar40(src)
+		if(3) //M16 set
+			new /obj/item/ammo_magazine/rifle/m16(src)
+			new /obj/item/weapon/gun/rifle/m16(src)
+			new /obj/item/ammo_magazine/rifle/m16(src)
+			new /obj/item/ammo_magazine/rifle/m16(src)
+		if(4) //Double barrel set
+			new /obj/item/weapon/gun/shotgun/double(src)
+			new /obj/item/ammo_magazine/shotgun/buckshot(src)
+			new /obj/item/ammo_magazine/shotgun/slugs(src)
+			new /obj/item/ammo_magazine/shotgun/flechette(src)
+		if(5) //Skorpian + 2 nades
+			new /obj/item/weapon/gun/pistol/skorpion(src)
+			new /obj/item/ammo_magazine/pistol/skorpion(src)
+			new /obj/item/ammo_magazine/pistol/skorpion(src)
+			new /obj/item/ammo_magazine/pistol/skorpion(src)
+
+/obj/structure/largecrate/good
+	name = "\improper Weapons crate"
+	desc = "What is in here?"
+
+// Good weapons sets that shouldn't be too crazy. Rifles, usually coming with AP
+
+/obj/structure/largecrate/guns/good/New()
+	..()
+	var/i = pick(1,5)
+	switch(i)
+		if(1) //L42 set
+			new /obj/item/weapon/gun/rifle/l42a(src)
+			new /obj/item/ammo_magazine/rifle/l42a(src)
+			new /obj/item/ammo_magazine/rifle/l42a(src)
+			new /obj/item/ammo_magazine/rifle/l42a(src)
+		if(2) //m39 set + 1 ap
+			new /obj/item/weapon/gun/smg/m39(src)
+			new /obj/item/ammo_magazine/smg/m39(src)
+			new /obj/item/ammo_magazine/smg/m39(src)
+			new /obj/item/ammo_magazine/smg/m39(src)
+			new /obj/item/ammo_magazine/smg/m39/ap(src)
+		if(3) //M16 set w/ 2 AP mag
+			new /obj/item/ammo_magazine/rifle/m16(src)
+			new /obj/item/weapon/gun/rifle/m16(src)
+			new /obj/item/ammo_magazine/rifle/m16/ap(src)
+			new /obj/item/ammo_magazine/rifle/m16/ap(src)
+		if(4) //M41 MK2 set w/ AP
+			new /obj/item/weapon/gun/rifle/m41a(src)
+			new /obj/item/ammo_magazine/rifle(src)
+			new /obj/item/ammo_magazine/rifle/ap(src)
+			new /obj/item/ammo_magazine/rifle/ap(src)
+		if(5) //fp9000 + 2 nades
+			new /obj/item/weapon/gun/smg/fp9000(src)
+			new /obj/item/ammo_magazine/smg/fp9000(src)
+			new /obj/item/ammo_magazine/smg/fp9000(src)
+			new /obj/item/ammo_magazine/smg/fp9000(src)
+			new /obj/item/explosive/grenade/HE/upp(src)
+			new /obj/item/explosive/grenade/HE/upp(src)
+
+/obj/structure/largecrate/exotic// Funny shit, either som
+	name = "\improper Exotic crate"
+	desc = "A deluxe weapons crate. Something good must be in here."
+	icon_state = "chest"
+
+// Powerful weapons. These can be considered OP and should be placed sparingly
+
+/obj/structure/largecrate/exotic/New()
+	..()
+	var/i = pick(1,5)
+	switch(i)
+		if(1) // NSG 23 set + 2ap
+			new /obj/item/weapon/gun/rifle/nsg23(src)
+			new /obj/item/ammo_magazine/rifle/nsg23(src)
+			new /obj/item/ammo_magazine/rifle/nsg23(src)
+			new /obj/item/ammo_magazine/rifle/nsg23/ap(src)
+			new /obj/item/ammo_magazine/rifle/nsg23/ap(src)
+		if(2) //Mk1 set
+			new /obj/item/weapon/gun/rifle/m41aMK1(src)
+			new /obj/item/ammo_magazine/rifle/m41aMK1(src)
+			new /obj/item/ammo_magazine/rifle/m41aMK1(src)
+			new /obj/item/ammo_magazine/rifle/m41aMK1(src)
+		if(3) //Tac shottie set + incen slugs
+			new /obj/item/weapon/gun/shotgun/combat(src)
+			new /obj/item/ammo_magazine/shotgun/buckshot(src)
+			new /obj/item/ammo_magazine/shotgun/slugs(src)
+			new /obj/item/ammo_magazine/shotgun/flechette(src)
+			new /obj/item/ammo_magazine/handful/shotgun/incendiary(src)
+		if(4) //TYPE 23
+			new /obj/item/weapon/gun/shotgun/type23(src)
+			new /obj/item/ammo_magazine/handful/shotgun/heavy/buckshot(src)
+			new /obj/item/ammo_magazine/handful/shotgun/heavy/buckshot(src)
+			new /obj/item/ammo_magazine/handful/shotgun/heavy/buckshot(src)
+			new /obj/item/ammo_magazine/handful/shotgun/heavy/slug(src)
+			new /obj/item/ammo_magazine/handful/shotgun/heavy/slug(src)
+			new /obj/item/ammo_magazine/handful/shotgun/heavy/slug(src)
+			new /obj/item/ammo_magazine/handful/shotgun/heavy/flechette(src)
+			new /obj/item/ammo_magazine/handful/shotgun/heavy/flechette(src)
+			new /obj/item/ammo_magazine/handful/shotgun/heavy/flechette(src)
+		if(5) //L42  AP + extended
+			new /obj/item/weapon/gun/rifle/l42a(src)
+			new /obj/item/ammo_magazine/rifle/l42a/ap(src)
+			new /obj/item/ammo_magazine/rifle/l42a/ap(src)
+			new /obj/item/ammo_magazine/rifle/l42a/ap(src)
+			new /obj/item/ammo_magazine/rifle/l42a/ap(src)
+			new /obj/item/ammo_magazine/rifle/l42a/extended(src)
+		if(6) //PMC FP9000 with 2 handheld mortar shell nades
+			new /obj/item/weapon/gun/smg/fp9000/pmc(src)
+			new /obj/item/ammo_magazine/smg/fp9000(src)
+			new /obj/item/ammo_magazine/smg/fp9000(src)
+			new /obj/item/ammo_magazine/smg/fp9000(src)
+			new /obj/item/explosive/grenade/HE/PMC(src)
+			new /obj/item/explosive/grenade/HE/PMC(src)
+
+
+
+/obj/structure/largecrate/funny // Funny shit
+	name = "\improper Exotic crate"
+	desc = "A deluxe weapons crate. Something good must be in here."
+	icon_state = "chest"
+
+// oh the misery
+
+/obj/structure/largecrate/funny/New()
+	..()
+	var/i = pick(1,5)
+	switch(i)
+		if(1) // VERIFIED TOP QUALITY PRE USED AMMO
+			new /obj/item/ammo_magazine/rifle(src)
+			new /obj/item/prop/helmetgarb/spent_buckshot(src)
+			new /obj/item/prop/helmetgarb/spent_slug(src)
+			new /obj/item/prop/helmetgarb/spent_flech(src)
+			new /obj/item/prop/helmetgarb/spent_buckshot(src)
+		if(2) // M40SD set (gun not included)
+			new /obj/item/ammo_magazine/rifle/m40_sd(src)
+			new /obj/item/ammo_magazine/rifle/m40_sd(src)
+			new /obj/item/ammo_magazine/rifle/m40_sd(src)
+			new /obj/item/ammo_magazine/rifle/m40_sd(src)
+			new /obj/item/weapon/gun/rifle/hunting(src)
+			new /obj/item/ammo_magazine/rifle/hunting(src)
+		if(3) //HEFA SET (m81 doesnt have IFF) (lol!)
+			new /obj/item/explosive/grenade/HE/frag(src)
+			new /obj/item/explosive/grenade/HE/frag(src)
+			new /obj/item/explosive/grenade/HE/frag(src)
+			new /obj/item/explosive/grenade/HE/frag(src)
+			new /obj/item/explosive/grenade/HE/frag(src)
+			new /obj/item/explosive/grenade/HE/frag(src)
+			new /obj/item/explosive/grenade/HE/frag(src)
+			new /obj/item/explosive/grenade/HE/frag(src)
+			new /obj/item/explosive/grenade/HE/frag(src)
+			new /obj/item/explosive/grenade/HE/frag(src)
+			new /obj/item/explosive/grenade/HE/frag(src)
+			new /obj/item/weapon/gun/launcher/grenade/m81(src)
+		if(4) //Type 23 SLUGGER (1 in 10, Lucky! Here is your reward, champ! A useful meme loadout)
+			new /obj/item/weapon/gun/shotgun/type23(src)
+			new /obj/item/ammo_magazine/handful/shotgun/heavy/slug(src)
+			new /obj/item/ammo_magazine/handful/shotgun/heavy/slug(src)
+			new /obj/item/ammo_magazine/handful/shotgun/heavy/slug(src)
+			new /obj/item/ammo_magazine/handful/shotgun/heavy/slug(src)
+			new /obj/item/ammo_magazine/handful/shotgun/heavy/slug(src)
+			new /obj/item/ammo_magazine/handful/shotgun/heavy/slug(src)
+		if(5) // LUNGE MINES
+			new /obj/item/weapon/melee/twohanded/lungemine(src)
+			new /obj/item/weapon/melee/twohanded/lungemine(src)
+			new /obj/item/weapon/melee/twohanded/lungemine(src)
+			new /obj/item/storage/bible(src)
+		if(6) // for the motherland set
+			new /obj/item/weapon/gun/smg/ppsh(src)
+			new /obj/item/weapon/gun/smg/ppsh(src)
+			new /obj/item/ammo_magazine/smg/ppsh(src)
+			new /obj/item/ammo_magazine/smg/ppsh(src)
+			new /obj/item/ammo_magazine/smg/ppsh(src)
+			new /obj/item/ammo_magazine/smg/ppsh(src)
+			new /obj/item/stack/flag/red(src)
+			new /obj/item/weapon/gun/rifle/hunting(src)
+			new /obj/item/ammo_magazine/rifle/hunting(src)
+			new /obj/item/explosive/grenade/HE/stick(src)
+			new /obj/item/clothing/head/ushanka(src)
+		if(7) // M. A. C. K. (munkie army creation kit)
+			new /obj/item/storage/box/monkeycubes(src)
+			new /obj/item/weapon/gun/smg/m39(src)
+			new /obj/item/weapon/gun/smg/m39(src)
+			new /obj/item/weapon/gun/smg/m39(src)
+			new /obj/item/weapon/gun/rifle/hunting(src)
+			new /obj/item/ammo_magazine/rifle/hunting(src)
+			new /obj/item/explosive/grenade/HE/stick(src)
+		if(8) // nailgun gaming
+			new /obj/item/weapon/gun/smg/nailgun(src)
+			new /obj/item/ammo_magazine/smg/nailgun(src)
+			new /obj/item/ammo_magazine/smg/nailgun(src)
+			new /obj/item/ammo_magazine/smg/nailgun(src)
+		if(9) // Union busting kit
+			new /obj/item/weapon/shield/riot(src)
+			new /obj/item/ammo_magazine/rifle/rubber(src)
+			new /obj/item/ammo_magazine/rifle/rubber(src)
+			new /obj/item/clothing/head/helmet/riot(src)
+			new /obj/item/prop/helmetgarb/riot_shield(src)
+			new /obj/item/weapon/gun/shotgun/combat/riot(src)
+			new /obj/item/ammo_magazine/handful/shotgun/beanbag/riot(src)
+		if(10) //The ultimate weapon
+			new /datum/gear/uno_reverse_red(src)
+			new /obj/item/paper/bigred/walls(src)
 /obj/structure/largecrate/guns/russian
 	num_guns = 3
 	num_mags = 3

--- a/code/game/objects/structures/crates_lockers/largecrate.dm
+++ b/code/game/objects/structures/crates_lockers/largecrate.dm
@@ -610,7 +610,6 @@
 			new /obj/item/ammo_magazine/handful/shotgun/beanbag/riot(src)
 		if(10) //The ultimate weapon
 			new /datum/gear/uno_reverse_red(src)
-			new /obj/item/paper/bigred/walls(src)
 
 /obj/structure/largecrate/guns/russian
 	num_guns = 3

--- a/code/game/objects/structures/crates_lockers/largecrate.dm
+++ b/code/game/objects/structures/crates_lockers/largecrate.dm
@@ -296,11 +296,8 @@
 	..()
 	var/i = pick(1,5)
 	switch(i)
-		if(1) //KT42 x2 set
+		if(1) //KT42 set
 			new /obj/item/weapon/gun/pistol/kt42(src)
-			new /obj/item/weapon/gun/pistol/kt42(src)
-			new /obj/item/ammo_magazine/pistol/automatic(src)
-			new /obj/item/ammo_magazine/pistol/automatic(src)
 			new /obj/item/ammo_magazine/pistol/automatic(src)
 			new /obj/item/ammo_magazine/pistol/automatic(src)
 			new /obj/item/ammo_magazine/pistol/automatic(src)
@@ -316,20 +313,43 @@
 			new /obj/item/ammo_magazine/revolver/cmb(src)
 			new /obj/item/ammo_magazine/revolver/cmb(src)
 			new /obj/item/ammo_magazine/revolver/cmb(src)
-		if(4) // 2x ppsh
+		if(4) // type 71c, deals garbage damage
+			new /obj/item/weapon/gun/rifle/type71/carbine(src)
+			new /obj/item/ammo_magazine/rifle/type71(src)
+			new /obj/item/ammo_magazine/rifle/type71(src)
+			new /obj/item/ammo_magazine/rifle/type71(src)
+			new /obj/item/ammo_magazine/rifle/type71(src)
+		if(5) // Bolt Action Rifle set x2
+			new /obj/item/weapon/gun/rifle/hunting(src)
+			new /obj/item/weapon/gun/rifle/hunting(src)
+			new /obj/item/ammo_magazine/rifle/hunting(src)
+			new /obj/item/ammo_magazine/rifle/hunting(src)
+			new /obj/item/ammo_magazine/rifle/hunting(src)
+			new /obj/item/ammo_magazine/rifle/hunting(src)
+			new /obj/item/ammo_magazine/rifle/hunting(src)
+			new /obj/item/ammo_magazine/rifle/hunting(src)
+		if(6)// Dual B92FS
+			new /obj/item/weapon/gun/pistol/b92fs(src)
+			new /obj/item/weapon/gun/pistol/b92fs(src)
+			new /obj/item/ammo_magazine/pistol/b92fs(src)
+			new /obj/item/ammo_magazine/pistol/b92fs(src)
+			new /obj/item/ammo_magazine/pistol/b92fs(src)
+			new /obj/item/ammo_magazine/pistol/b92fs(src)
+			new /obj/item/ammo_magazine/pistol/b92fs(src)
+		if(7) //M1911 kit + HEDP. 45 or nothin'
+			new /obj/item/weapon/gun/pistol/m1911(src)
+			new /obj/item/ammo_magazine/pistol/m1911(src)
+			new /obj/item/ammo_magazine/pistol/m1911(src)
+			new /obj/item/ammo_magazine/pistol/m1911(src)
+			new /obj/item/ammo_magazine/pistol/m1911(src)
+			new /obj/item/ammo_magazine/pistol/m1911(src)
+			new /obj/item/ammo_magazine/pistol/m1911(src)
+			new /obj/item/explosive/grenade/HE(src)
+		if(8) //PPSH set
 			new /obj/item/weapon/gun/smg/ppsh(src)
-			new /obj/item/weapon/gun/smg/ppsh(src)
 			new /obj/item/ammo_magazine/smg/ppsh(src)
 			new /obj/item/ammo_magazine/smg/ppsh(src)
 			new /obj/item/ammo_magazine/smg/ppsh(src)
-			new /obj/item/ammo_magazine/smg/ppsh(src)
-		if(5) // assorted garbage
-			new /obj/item/weapon/gun/rifle/hunting(src)
-			new /obj/item/weapon/gun/rifle/hunting(src)
-			new /obj/item/weapon/gun/rifle/hunting(src)
-			new /obj/item/ammo_magazine/rifle/hunting(src)
-			new /obj/item/ammo_magazine/rifle/hunting(src)
-			new /obj/item/ammo_magazine/rifle/hunting(src)
 
 /obj/structure/largecrate/mediocre
 	name = "\improper Weapons crate"
@@ -357,11 +377,11 @@
 			new /obj/item/ammo_magazine/smg/uzi(src)
 			new /obj/item/ammo_magazine/smg/uzi(src)
 			new /obj/item/ammo_magazine/smg/uzi(src)
-		if(4) //PPSH set
-			new /obj/item/weapon/gun/smg/ppsh(src)
-			new /obj/item/ammo_magazine/smg/ppsh(src)
-			new /obj/item/ammo_magazine/smg/ppsh(src)
-			new /obj/item/ammo_magazine/smg/ppsh(src)
+		if(4) //MP5 set
+			new /obj/item/weapon/gun/smg/mp5(src)
+			new /obj/item/ammo_magazine/smg/mp5(src)
+			new /obj/item/ammo_magazine/smg/mp5(src)
+			new /obj/item/ammo_magazine/smg/mp5(src)
 		if(5) //MP5
 			new /obj/item/weapon/gun/smg/mp5(src)
 			new /obj/item/ammo_magazine/smg/mp5(src)

--- a/code/game/objects/structures/crates_lockers/largecrate.dm
+++ b/code/game/objects/structures/crates_lockers/largecrate.dm
@@ -285,53 +285,6 @@
 		while(++m <= num_mags)
 			new new_mag(src)
 
-/obj/structure/largecrate/mediocre
-	name = "\improper Weapons crate"
-	desc = "What is in here?"
-
-// really mediocre weapons.
-
-/obj/structure/largecrate/mediocre/New()
-	..()
-	var/i = pick(1,5)
-	switch(i)
-		if(1) //Type 71 set
-			new /obj/item/weapon/gun/rifle/type71(src)
-			new /obj/item/ammo_magazine/rifle/type71(src)
-			new /obj/item/ammo_magazine/rifle/type71(src)
-			new /obj/item/ammo_magazine/rifle/type71(src)
-			new /obj/item/clothing/mask/gas/PMC(src)
-		if(2) //MAR carabine set
-			new /obj/item/weapon/gun/rifle/mar40/carbine(src)
-			new /obj/item/ammo_magazine/rifle/mar40(src)
-			new /obj/item/ammo_magazine/rifle/mar40(src)
-			new /obj/item/ammo_magazine/rifle/mar40(src)
-		if(3) //Uzi set
-			new /obj/item/weapon/gun/smg/uzi(src)
-			new /obj/item/ammo_magazine/smg/uzi(src)
-			new /obj/item/ammo_magazine/smg/uzi(src)
-			new /obj/item/ammo_magazine/smg/uzi(src)
-		if(4) //PPSH set
-			new /obj/item/weapon/gun/smg/ppsh(src)
-			new /obj/item/ammo_magazine/smg/ppsh(src)
-			new /obj/item/ammo_magazine/smg/ppsh(src)
-			new /obj/item/ammo_magazine/smg/ppsh(src)
-		if(5) //MP5
-			new /obj/item/weapon/gun/smg/mp5(src)
-			new /obj/item/ammo_magazine/smg/mp5(src)
-			new /obj/item/ammo_magazine/smg/mp5(src)
-			new /obj/item/ammo_magazine/smg/mp5(src)
-		if(6) //HEFA nade set with m74
-			new /obj/item/explosive/grenade/HE/frag(src)
-			new /obj/item/explosive/grenade/HE/frag(src)
-			new /obj/item/explosive/grenade/HE/frag(src)
-			new /obj/item/explosive/grenade/HE/frag(src)
-			new /obj/item/explosive/grenade/HE/frag(src)
-			new /obj/item/explosive/grenade/HE/frag(src)
-			new /obj/item/explosive/grenade/HE/frag(src)
-			new /obj/item/explosive/grenade/HE/frag(src)
-			new /obj/item/weapon/gun/launcher/grenade/m81/m79(src)
-
 
 /obj/structure/largecrate/crap
 	name = "\improper Weapons crate"
@@ -339,7 +292,7 @@
 
 // Low tier SMGs, pistols and good ole bolt actions
 
-/obj/structure/largecrate/guns/crap/New()
+/obj/structure/largecrate/crap/New()
 	..()
 	var/i = pick(1,5)
 	switch(i)
@@ -378,15 +331,62 @@
 			new /obj/item/ammo_magazine/rifle/hunting(src)
 			new /obj/item/ammo_magazine/rifle/hunting(src)
 
+/obj/structure/largecrate/mediocre
+	name = "\improper Weapons crate"
+	desc = "What is in here?"
+
+// really mediocre weapons.
+
+/obj/structure/largecrate/mediocre/New()
+	..()
+	var/i = pick(1,6)
+	switch(i)
+		if(1) //Type 71 set
+			new /obj/item/weapon/gun/rifle/type71(src)
+			new /obj/item/ammo_magazine/rifle/type71(src)
+			new /obj/item/ammo_magazine/rifle/type71(src)
+			new /obj/item/ammo_magazine/rifle/type71(src)
+			new /obj/item/clothing/mask/gas/PMC(src)
+		if(2) //MAR carabine set
+			new /obj/item/weapon/gun/rifle/mar40/carbine(src)
+			new /obj/item/ammo_magazine/rifle/mar40(src)
+			new /obj/item/ammo_magazine/rifle/mar40(src)
+			new /obj/item/ammo_magazine/rifle/mar40(src)
+		if(3) //Uzi set
+			new /obj/item/weapon/gun/smg/uzi(src)
+			new /obj/item/ammo_magazine/smg/uzi(src)
+			new /obj/item/ammo_magazine/smg/uzi(src)
+			new /obj/item/ammo_magazine/smg/uzi(src)
+		if(4) //PPSH set
+			new /obj/item/weapon/gun/smg/ppsh(src)
+			new /obj/item/ammo_magazine/smg/ppsh(src)
+			new /obj/item/ammo_magazine/smg/ppsh(src)
+			new /obj/item/ammo_magazine/smg/ppsh(src)
+		if(5) //MP5
+			new /obj/item/weapon/gun/smg/mp5(src)
+			new /obj/item/ammo_magazine/smg/mp5(src)
+			new /obj/item/ammo_magazine/smg/mp5(src)
+			new /obj/item/ammo_magazine/smg/mp5(src)
+		if(6) //MP27 with some assorted nades
+			new /obj/item/weapon/gun/smg/mp7(src)
+			new /obj/item/ammo_magazine/smg/mp7(src)
+			new /obj/item/ammo_magazine/smg/mp7(src)
+			new /obj/item/ammo_magazine/smg/mp7(src)
+			new /obj/item/explosive/grenade/HE(src)
+			new /obj/item/explosive/grenade/HE(src)
+			new /obj/item/explosive/grenade/HE/frag(src)
+			new /obj/item/explosive/grenade/HE/frag(src)
+
+
 /obj/structure/largecrate/decent
 	name = "\improper Weapons crate"
 	desc = "What is in here?"
 
 // Decent weapon sets that shouldn't be too crazy. Bog standard marine weapons with some variance in quality
 
-/obj/structure/largecrate/guns/decent/New()
+/obj/structure/largecrate/decent/New()
 	..()
-	var/i = pick(1,5)
+	var/i = pick(1,6)
 	switch(i)
 		if(1) //M41 MK2 set
 			new /obj/item/weapon/gun/rifle/m41a(src)
@@ -413,16 +413,23 @@
 			new /obj/item/ammo_magazine/pistol/skorpion(src)
 			new /obj/item/ammo_magazine/pistol/skorpion(src)
 			new /obj/item/ammo_magazine/pistol/skorpion(src)
+			new /obj/item/explosive/grenade/HE/upp(src)
+			new /obj/item/explosive/grenade/HE/upp(src)
+		if(6) // HG set
+			new /obj/item/weapon/gun/shotgun/pump/cmb(src)
+			new /obj/item/ammo_magazine/shotgun/buckshot(src)
+			new /obj/item/ammo_magazine/shotgun/slugs(src)
+			new /obj/item/ammo_magazine/shotgun/flechette(src)
 
 /obj/structure/largecrate/good
 	name = "\improper Weapons crate"
 	desc = "What is in here?"
 
-// Good weapons sets that shouldn't be too crazy. Rifles, usually coming with AP
+// Good weapons sets that shouldn't be too crazy. Rifles, usually come with AP
 
 /obj/structure/largecrate/guns/good/New()
 	..()
-	var/i = pick(1,5)
+	var/i = pick(1,7)
 	switch(i)
 		if(1) //L42 set
 			new /obj/item/weapon/gun/rifle/l42a(src)
@@ -452,8 +459,15 @@
 			new /obj/item/ammo_magazine/smg/fp9000(src)
 			new /obj/item/explosive/grenade/HE/upp(src)
 			new /obj/item/explosive/grenade/HE/upp(src)
+		if(6) // M60 set
+			new /obj/item/weapon/gun/m60(src) 
+			new /obj/item/ammo_magazine/m60(src)
+		if(7) // Sawn off + buckshit
+			new /obj/item/weapon/gun/shotgun/double/sawn(src)
+			new /obj/item/ammo_magazine/shotgun/buckshot(src)
+			new /obj/item/ammo_magazine/shotgun/buckshot(src)
 
-/obj/structure/largecrate/exotic// Funny shit, either som
+/obj/structure/largecrate/exotic
 	name = "\improper Exotic crate"
 	desc = "A deluxe weapons crate. Something good must be in here."
 	icon_state = "chest"
@@ -462,7 +476,7 @@
 
 /obj/structure/largecrate/exotic/New()
 	..()
-	var/i = pick(1,5)
+	var/i = pick(1,6)
 	switch(i)
 		if(1) // NSG 23 set + 2ap
 			new /obj/item/weapon/gun/rifle/nsg23(src)
@@ -492,11 +506,11 @@
 			new /obj/item/ammo_magazine/handful/shotgun/heavy/flechette(src)
 			new /obj/item/ammo_magazine/handful/shotgun/heavy/flechette(src)
 			new /obj/item/ammo_magazine/handful/shotgun/heavy/flechette(src)
-		if(5) //L42  AP + extended
+		if(5) //L42  AP + incen
 			new /obj/item/weapon/gun/rifle/l42a(src)
 			new /obj/item/ammo_magazine/rifle/l42a/ap(src)
 			new /obj/item/ammo_magazine/rifle/l42a/ap(src)
-			new /obj/item/ammo_magazine/rifle/l42a/ap(src)
+			new /obj/item/ammo_magazine/rifle/l42a/incen(src)
 			new /obj/item/ammo_magazine/rifle/l42a/ap(src)
 			new /obj/item/ammo_magazine/rifle/l42a/extended(src)
 		if(6) //PMC FP9000 with 2 handheld mortar shell nades
@@ -518,7 +532,7 @@
 
 /obj/structure/largecrate/funny/New()
 	..()
-	var/i = pick(1,5)
+	var/i = pick(1,10)
 	switch(i)
 		if(1) // VERIFIED TOP QUALITY PRE USED AMMO
 			new /obj/item/ammo_magazine/rifle(src)
@@ -571,6 +585,8 @@
 			new /obj/item/ammo_magazine/rifle/hunting(src)
 			new /obj/item/explosive/grenade/HE/stick(src)
 			new /obj/item/clothing/head/ushanka(src)
+			new /obj/item/clothing/head/ushanka(src)
+			new /obj/item/clothing/head/ushanka(src)
 		if(7) // M. A. C. K. (munkie army creation kit)
 			new /obj/item/storage/box/monkeycubes(src)
 			new /obj/item/weapon/gun/smg/m39(src)
@@ -595,6 +611,7 @@
 		if(10) //The ultimate weapon
 			new /datum/gear/uno_reverse_red(src)
 			new /obj/item/paper/bigred/walls(src)
+
 /obj/structure/largecrate/guns/russian
 	num_guns = 3
 	num_mags = 3

--- a/code/game/objects/structures/crates_lockers/largecrate.dm
+++ b/code/game/objects/structures/crates_lockers/largecrate.dm
@@ -460,7 +460,7 @@
 			new /obj/item/explosive/grenade/HE/upp(src)
 			new /obj/item/explosive/grenade/HE/upp(src)
 		if(6) // M60 set
-			new /obj/item/weapon/gun/m60(src) 
+			new /obj/item/weapon/gun/m60(src)
 			new /obj/item/ammo_magazine/m60(src)
 		if(7) // Sawn off + buckshit
 			new /obj/item/weapon/gun/shotgun/double/sawn(src)
@@ -510,7 +510,7 @@
 			new /obj/item/weapon/gun/rifle/l42a(src)
 			new /obj/item/ammo_magazine/rifle/l42a/ap(src)
 			new /obj/item/ammo_magazine/rifle/l42a/ap(src)
-			new /obj/item/ammo_magazine/rifle/l42a/incen(src)
+			new /obj/item/ammo_magazine/rifle/l42a/incendiary(src)
 			new /obj/item/ammo_magazine/rifle/l42a/ap(src)
 			new /obj/item/ammo_magazine/rifle/l42a/extended(src)
 		if(6) //PMC FP9000 with 2 handheld mortar shell nades

--- a/maps/map_files/BigRed/BigRed.dmm
+++ b/maps/map_files/BigRed/BigRed.dmm
@@ -30634,7 +30634,7 @@
 	},
 /area/bigredv2/caves_lambda)
 "eGa" = (
-/obj/item/weapon/gun/shotgun/pump/cmb,
+/obj/item/weapon/gun/shotgun/combat/riot,
 /turf/open/mars_cave{
 	icon_state = "mars_cave_17";
 	tag = "icon-mars_cave_17"
@@ -30759,16 +30759,16 @@
 /area/bigredv2/outside/virology)
 "eVo" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/weapon/gun/pistol/m4a3,
-/obj/item/ammo_magazine/pistol/hp{
-	pixel_y = -4
-	},
-/obj/item/ammo_magazine/pistol{
-	pixel_y = -4
-	},
 /obj/structure/cable{
 	icon_state = "9-10"
 	},
+/obj/item/weapon/gun/pistol/b92fs{
+	pixel_x = -8;
+	pixel_y = 5
+	},
+/obj/item/ammo_magazine/pistol/b92fs,
+/obj/item/ammo_magazine/pistol/b92fs,
+/obj/item/ammo_magazine/pistol/b92fs,
 /turf/open/floor/plating{
 	dir = 8;
 	icon_state = "platingdmg3";
@@ -31166,6 +31166,15 @@
 /turf/open/mars_cave{
 	icon_state = "mars_cave_17";
 	tag = "icon-mars_cave_17"
+	},
+/area/bigredv2/caves/mining)
+"fQy" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/crap_item,
+/turf/open/floor/plating{
+	dir = 8;
+	icon_state = "platingdmg3";
+	tag = "icon-platingdmg3 (WEST)"
 	},
 /area/bigredv2/caves/mining)
 "fRo" = (
@@ -31971,8 +31980,11 @@
 	},
 /area/bigredv2/caves/lambda/research)
 "hWM" = (
-/obj/structure/machinery/filtration/console{
-	pixel_y = 15
+/obj/structure/prop/almayer/cannon_cable_connector{
+	name = "\improper Control Module";
+	pixel_y = 15;
+	icon = 'icons/obj/structures/machinery/filtration.dmi';
+	icon_state = "console"
 	},
 /turf/open/mars_cave{
 	icon_state = "mars_cave_15";
@@ -33529,6 +33541,12 @@
 	},
 /turf/open/floor/plating,
 /area/bigredv2/caves/mining)
+"lcp" = (
+/obj/effect/landmark/item_pool_spawner/survivor_ammo,
+/turf/open/mars_cave{
+	icon_state = "mars_cave_3"
+	},
+/area/bigredv2/caves/mining)
 "lcu" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/clothing/mask/cigarette,
@@ -33648,7 +33666,6 @@
 	},
 /area/bigredv2/caves/mining)
 "lvh" = (
-/obj/item/weapon/gun/rifle/l42a,
 /obj/effect/landmark/corpsespawner/ua_riot,
 /obj/effect/decal/cleanable/blood{
 	dir = 8;
@@ -33658,6 +33675,7 @@
 	pixel_y = 3;
 	tag = "icon-gib6"
 	},
+/obj/item/weapon/gun/rifle/m41a/training,
 /turf/open/mars_cave{
 	icon_state = "mars_cave_3"
 	},
@@ -33774,7 +33792,9 @@
 	pixel_y = 3;
 	pixel_x = -24
 	},
-/obj/structure/largecrate/funny,
+/obj/structure/largecrate/funny{
+	desc = "A deluxe weapons crate. Something good must be in here. A note on the side reads \" TOP S 100% QUALITY WEAPONS GARUNTEE \" "
+	},
 /turf/open/floor/plating{
 	dir = 8;
 	icon_state = "platingdmg3";
@@ -33866,9 +33886,11 @@
 	},
 /area/bigredv2/caves/mining)
 "lSH" = (
-/obj/structure/largecrate/guns/merc{
-	icon_state = "case_double";
-	name = "supply crate"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/largecrate/crap{
+	icon_state = "barrel_white";
+	name = "\improper white barrel";
+	desc = "What is in here? A note reads on the side: \" For you, Yuri \" "
 	},
 /turf/open/floor/plating{
 	dir = 8;
@@ -36583,6 +36605,13 @@
 	icon_state = "warnplate"
 	},
 /area/bigredv2/oob)
+"rLQ" = (
+/obj/structure/prop/dam/crane/damaged,
+/turf/open/mars_cave{
+	icon_state = "mars_dirt_4";
+	tag = "icon-mars_dirt_4"
+	},
+/area/bigredv2/caves/mining)
 "rLR" = (
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_nest,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_nest,
@@ -38077,6 +38106,15 @@
 	tag = "icon-mars_cave_18"
 	},
 /area/bigredv2/caves_east)
+"utk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/largecrate/random/case/double,
+/turf/open/floor/plating{
+	dir = 8;
+	icon_state = "platingdmg3";
+	tag = "icon-platingdmg3 (WEST)"
+	},
+/area/bigredv2/caves/mining)
 "uuo" = (
 /obj/structure/blocker/forcefield/vehicles,
 /turf/open/mars_cave{
@@ -38298,8 +38336,11 @@
 	},
 /area/bigredv2/caves_se)
 "uPF" = (
-/obj/structure/machinery/filtration/console{
-	pixel_y = 13
+/obj/structure/prop/almayer/cannon_cable_connector{
+	name = "\improper Control Module";
+	pixel_y = 15;
+	icon = 'icons/obj/structures/machinery/filtration.dmi';
+	icon_state = "console"
 	},
 /turf/open/mars_cave{
 	icon_state = "mars_dirt_4";
@@ -38634,6 +38675,13 @@
 	tag = "icon-mars_cave_9"
 	},
 /area/bigredv2/caves_north)
+"vAL" = (
+/obj/item/prop/helmetgarb/riot_shield,
+/turf/open/mars_cave{
+	icon_state = "mars_dirt_7";
+	tag = "icon-mars_dirt_7"
+	},
+/area/bigredv2/caves_research)
 "vBy" = (
 /obj/item/ammo_magazine/shotgun/beanbag/riot,
 /turf/open/mars_cave{
@@ -39349,13 +39397,10 @@
 	},
 /area/bigredv2/caves/mining)
 "xhU" = (
-/obj/structure/closet/fireaxecabinet{
-	pixel_y = 27
-	},
-/turf/open/floor/plating{
-	dir = 8;
-	icon_state = "platingdmg3";
-	tag = "icon-platingdmg3 (WEST)"
+/obj/item/clothing/head/helmet/riot,
+/turf/open/mars_cave{
+	icon_state = "mars_cave_15";
+	tag = "icon-mars_cave_15"
 	},
 /area/bigredv2/caves/mining)
 "xkq" = (
@@ -39722,6 +39767,7 @@
 /obj/item/ore/uranium{
 	desc = "You feel fuzzy just looking at it.... it's slightly lumanesant"
 	},
+/obj/structure/largecrate/mediocre,
 /turf/open/floor/plating,
 /area/bigredv2/caves/mining)
 "xWz" = (
@@ -39971,8 +40017,6 @@
 /obj/item/ammo_magazine/rifle/nsg23,
 /obj/item/ammo_magazine/rifle/nsg23,
 /obj/item/ammo_magazine/rifle/nsg23/ap,
-/obj/item/ammo_magazine/rifle/nsg23/ap,
-/obj/item/ammo_magazine/rifle/nsg23/extended,
 /turf/open/floor/plating{
 	dir = 8;
 	icon_state = "platingdmg3";
@@ -44523,7 +44567,7 @@ heG
 pZe
 pSa
 wLD
-kCe
+utk
 uHQ
 szw
 szw
@@ -45173,8 +45217,8 @@ rbD
 kCe
 ufu
 vdS
-rbD
-kCe
+pSa
+lSH
 uHQ
 aao
 aao
@@ -45607,7 +45651,7 @@ kCe
 kCe
 xWz
 pSa
-lSH
+rbD
 yln
 uHQ
 aao
@@ -46041,7 +46085,7 @@ oTv
 kCe
 xte
 uHQ
-sWS
+pSa
 pSa
 oKy
 wRH
@@ -46684,8 +46728,8 @@ wCo
 wCo
 wVQ
 oKy
-lSH
-xhU
+pSa
+pSa
 hRy
 hCT
 pSa
@@ -46905,7 +46949,7 @@ jhj
 kCe
 ekV
 pSa
-kCe
+fQy
 kCe
 uHT
 pSa
@@ -47338,7 +47382,7 @@ uHQ
 wtj
 ohY
 pSa
-lSH
+pSa
 pSa
 sWS
 pSa
@@ -50159,8 +50203,8 @@ nSP
 wCo
 wVQ
 rxh
-rxh
-aao
+sZh
+rLQ
 aao
 aao
 aao
@@ -50376,8 +50420,8 @@ wCo
 wCo
 wVQ
 rxh
-aao
-aao
+sZh
+wCo
 aao
 aao
 aao
@@ -51686,7 +51730,7 @@ cCu
 wlE
 dNd
 wVQ
-rsv
+lcp
 rsv
 nxa
 rsv
@@ -55796,7 +55840,7 @@ xkq
 xkq
 nXC
 guM
-nny
+vAL
 guM
 ybk
 aao
@@ -56250,7 +56294,7 @@ szw
 yhc
 sxs
 vPP
-sZh
+xhU
 wCo
 wVQ
 rxh

--- a/maps/map_files/BigRed/BigRed.dmm
+++ b/maps/map_files/BigRed/BigRed.dmm
@@ -30761,8 +30761,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/weapon/gun/pistol/m4a3,
 /obj/item/ammo_magazine/pistol/hp{
-	pixel_x = 8;
-	pixel_y = -7
+	pixel_y = -4
 	},
 /obj/item/ammo_magazine/pistol{
 	pixel_y = -4
@@ -33442,6 +33441,9 @@
 /obj/structure/machinery/light{
 	dir = 4
 	},
+/obj/item/explosive/grenade/HE/frag,
+/obj/item/explosive/grenade/HE/frag,
+/obj/item/explosive/grenade/HE/frag,
 /turf/open/floor/plating{
 	dir = 8;
 	icon_state = "platingdmg3";
@@ -33769,8 +33771,10 @@
 /area/bigredv2/caves_lambda)
 "lEw" = (
 /obj/item/tool/pickaxe{
-	pixel_y = -3
+	pixel_y = 3;
+	pixel_x = -24
 	},
+/obj/structure/largecrate/funny,
 /turf/open/floor/plating{
 	dir = 8;
 	icon_state = "platingdmg3";
@@ -38637,20 +38641,6 @@
 	tag = "icon-mars_cave_17"
 	},
 /area/bigredv2/caves_research)
-"vCd" = (
-/obj/structure/surface/rack,
-/obj/item/weapon/melee/twohanded/lungemine{
-	pixel_y = 8
-	},
-/obj/item/weapon/melee/twohanded/lungemine{
-	pixel_y = -7
-	},
-/turf/open/floor/plating{
-	dir = 8;
-	icon_state = "platingdmg3";
-	tag = "icon-platingdmg3 (WEST)"
-	},
-/area/bigredv2/caves/mining)
 "vEU" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/mars{
@@ -38837,14 +38827,6 @@
 "wcw" = (
 /turf/open/gm/river,
 /area/bigredv2/outside/filtration_plant)
-"weO" = (
-/obj/structure/closet/secure_closet/medical_wall,
-/turf/open/floor/plating{
-	dir = 8;
-	icon_state = "platingdmg3";
-	tag = "icon-platingdmg3 (WEST)"
-	},
-/area/bigredv2/caves/mining)
 "wfd" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/solaris/reinforced,
@@ -39428,9 +39410,7 @@
 /turf/closed/wall/solaris,
 /area/bigredv2/outside/filtration_plant)
 "xrp" = (
-/obj/structure/largecrate/guns/merc{
-	name = "\improper dodgy crate"
-	},
+/obj/structure/largecrate/decent,
 /turf/open/floor/plating,
 /area/bigredv2/caves/mining)
 "xrO" = (
@@ -46030,8 +46010,8 @@ aao
 aao
 aao
 aao
-uHQ
-weO
+xTM
+pSa
 wtj
 rKs
 wJd
@@ -46706,7 +46686,7 @@ wVQ
 oKy
 lSH
 xhU
-vCd
+hRy
 hCT
 pSa
 tBK


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Fixes a large swath of bugs in SW mining caves. 

The loot was never intended to be this much, failure on my part to note that I added survivor loot already and ended up forgetting and adding more and more crates due to the extremely long development of it.

Looking at the loot again, I discovered a key issue in mapping. You either put down merc crates that potentially spawn with something OP or shit, spawn a crate with OP gear or pre place weapons.

To fix this, I made different categories of large weapons crates to introduce some level of control into this, so that loot crates can be balanced properly and be used more flexibly. 

All of these can only spawn 1 specific weapon in a "set" along with its ammo, unless otherwise stated.

- Crap: As it says, assorted garbage sets like dual CMB revolvers, KT-42, and bolt action rifle set.
- Mediocre: Survivor-tier weapons.
- Decent: Marine-tier weapons
- Good:  Marine+ weapons as this also includes some AP mags and sets that come with nades. On par with merc crate due to consistency in weapons.
- Exotic: PMC+ tier powerful weapons as it can contain either a type 23, NSG 23, tac shottie, and MK1 along with an L42 + AP and FP9000 + nade sets. Should be considered better than the merc crate as this one can _consistently_ give you powerful shit
- Funny: Funny sets. Disguised to look like an exotic crate. Quality varies widely and should be "mediocre" tier due to it
 
### *Ok cool but what are the changes?*

- The 4 merc crates were replaced with a decent crate, a mediocre crate, a crap one, and a funny one.
- Lunge mines removed
- Replaced some HGs with Riot combat shotguns (these shoot 20g beanbags so they are useless in real combat)
- Removed some other dumb OP weapons
- Removed ammo from the NSG 23 crate
- Compensated for this by adding a few more HEFA nades. These will truly result in the 12:10 surv major

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
fixes bugs, massive mapper QoL, less headaches for xenos.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: TotalEpicness
fix: Fixed Big red SW mining caves firealarm and medical cabinet being missaligned
fix: Fixed Big red SW mining caves drill consoles going invisible when weeds touch it
fix: Fixed various other minor bugs in SW mining caves.
qol: Mappers now have varying quality loot crates to place.
balance: Nerfed the loot in big red SW caves.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
