### PR TITLE
Cultist XOOC

### DIFF
--- a/code/modules/admin/verbs/xooc.dm
+++ b/code/modules/admin/verbs/xooc.dm
@@ -15,8 +15,8 @@
 
 	msg = process_chat_markup(msg, list("*"))
 
-	for(var/mob/M in GLOB.living_xeno_list)
-		if(M.client && (!M.client.admin_holder || !(M.client.admin_holder.rights & R_MOD)))	// Send to xenos who are non-staff
+	for(var/mob/living/carbon/M in GLOB.alive_mob_list)
+		if(M.client && M.hivenumber && (!M.client.admin_holder || !(M.client.admin_holder.rights & R_MOD)))	// Send to xenos who are non-staff
 			to_chat(M, SPAN_XOOC("XOOC: [src.key]([src.admin_holder.rank]): [msg]"))
 
 	for(var/mob/dead/observer/M in GLOB.observer_list)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

XOOC messages now go to any carbon mob that has a hivenumber, meaning xeno cultists also get XOOCs.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Makes sense that people on the xeno team gets xeno OOC messages.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
admin: Xeno cultists now get XOOC messages too.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
