### PR TITLE
Command Pouch quickdraw

### DIFF
--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -320,7 +320,6 @@
 	desc = "A specialized, sturdy pouch issued to Captains. Can hold their sidearm, the command tablet and a set of binoculars."
 	storage_slots = 3
 	icon_state = "command_pouch"
-	storage_flags = STORAGE_FLAGS_POUCH|STORAGE_USING_DRAWING_METHOD|STORAGE_ALLOW_QUICKDRAW
 	can_hold = list(
 					/obj/item/weapon/gun/revolver,
 					/obj/item/weapon/gun/pistol,

--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -320,7 +320,7 @@
 	desc = "A specialized, sturdy pouch issued to Captains. Can hold their sidearm, the command tablet and a set of binoculars."
 	storage_slots = 3
 	icon_state = "command_pouch"
-	storage_flags = STORAGE_FLAGS_POUCH
+	storage_flags = STORAGE_FLAGS_POUCH|STORAGE_USING_DRAWING_METHOD|STORAGE_ALLOW_QUICKDRAW
 	can_hold = list(
 					/obj/item/weapon/gun/revolver,
 					/obj/item/weapon/gun/pistol,


### PR DESCRIPTION

## About The Pull Request

Makes the pistol held in the command pouch drawable via your holster/unholster button.

## Why It's Good For The Game

It seems like an oversight that the pouch flags got overwritten when it was made.

## Changelog

:cl: Morrow
fix: You can now quickdraw via holster/unholster key weapons held in the command pouch.
/:cl:
