### PR TITLE
Fixes NE side of briefing platform

### DIFF
--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -46397,9 +46397,8 @@
 /turf/open/floor/almayer,
 /area/almayer/living/briefing)
 "htI" = (
-/obj/structure/platform{
-	dir = 1;
-	icon_state = "platform_deco"
+/obj/structure/platform_decoration{
+	dir = 1
 	},
 /turf/open/floor/almayer,
 /area/almayer/living/briefing)


### PR DESCRIPTION
## About The Pull Request

The northeast side of the briefing platform was set to the wrong object and was creating odd functionality.

closes #550 

## Why It's Good For The Game

BUG BAD UNGA

## Changelog

:cl: Morrow
fix: Fixes NE side of briefing platform
/:cl: