### PR TITLE
Vehicle and hardpoints repair changes

### DIFF
--- a/code/modules/vehicles/hardpoints/hardpoint.dm
+++ b/code/modules/vehicles/hardpoints/hardpoint.dm
@@ -441,7 +441,7 @@ obj/item/hardpoint/proc/remove_buff(var/obj/vehicle/multitile/V)
 		if(!(world.time % 3))
 			playsound(get_turf(user), 'sound/items/weldingtool_weld.ogg', 25)
 		if(!do_after(user, 1 SECONDS, INTERRUPT_ALL, BUSY_ICON_BUILD))
-			user.visible_message(SPAN_NOTICE("[user] stops repairing \the [name]."), SPAN_NOTICE("You stop repairing \the [name]. Integrity of the module is at [SPAN_HELPFUL(round(get_integrity_percent()))]%."))
+			user.visible_message(SPAN_NOTICE("[user] stops repairing \the [name]."), SPAN_NOTICE("You stop repairing \the [name]. The integrity of the module is at [SPAN_HELPFUL(round(get_integrity_percent()))]%."))
 			being_repaired = FALSE
 			return
 

--- a/code/modules/vehicles/hardpoints/hardpoint.dm
+++ b/code/modules/vehicles/hardpoints/hardpoint.dm
@@ -460,7 +460,7 @@ obj/item/hardpoint/proc/remove_buff(var/obj/vehicle/multitile/V)
 			user.visible_message(SPAN_NOTICE("[user] finishes repairing \the [name]."), SPAN_NOTICE("You finish repairing \the [name]. Integrity of the module is at [SPAN_HELPFUL(round(get_integrity_percent()))]%."))
 			being_repaired = FALSE
 			return
-		to_chat(user, SPAN_NOTICE("Integrity of \the [src] is now at [SPAN_HELPFUL(round(get_integrity_percent()))]%."))
+		to_chat(user, SPAN_NOTICE("The integrity of \the [src] is now at [SPAN_HELPFUL(round(get_integrity_percent()))]%."))
 
 	being_repaired = FALSE
 	user.visible_message(SPAN_NOTICE("[user] stops repairing \the [name]."), SPAN_NOTICE("You stop repairing \the [name]. The integrity of the module is at [SPAN_HELPFUL(round(get_integrity_percent()))]%."))

--- a/code/modules/vehicles/hardpoints/hardpoint.dm
+++ b/code/modules/vehicles/hardpoints/hardpoint.dm
@@ -457,7 +457,7 @@ obj/item/hardpoint/proc/remove_buff(var/obj/vehicle/multitile/V)
 		health += initial(health)/100 * (amount_fixed / amount_fixed_adjustment)
 		if(health >= initial(health))
 			health = initial(health)
-			user.visible_message(SPAN_NOTICE("[user] finishes repairing \the [name]."), SPAN_NOTICE("You finish repairing \the [name]. Integrity of \the module is at [SPAN_HELPFUL(round(get_integrity_percent()))]%."))
+			user.visible_message(SPAN_NOTICE("[user] finishes repairing \the [name]."), SPAN_NOTICE("You finish repairing \the [name]. Integrity of the module is at [SPAN_HELPFUL(round(get_integrity_percent()))]%."))
 			being_repaired = FALSE
 			return
 		to_chat(user, SPAN_NOTICE("Integrity of \the [src] is now at [SPAN_HELPFUL(round(get_integrity_percent()))]%."))

--- a/code/modules/vehicles/hardpoints/hardpoint.dm
+++ b/code/modules/vehicles/hardpoints/hardpoint.dm
@@ -447,7 +447,7 @@ obj/item/hardpoint/proc/remove_buff(var/obj/vehicle/multitile/V)
 
 		//we check for adjacency only if we are not installed. This is for turret for now
 		if(!owner && !Adjacent(user))
-			user.visible_message(SPAN_NOTICE("[user] stops repairing \the [name]."), SPAN_NOTICE("You stop repairing \the [name]. Integrity of \the module is at [SPAN_HELPFUL(round(get_integrity_percent()))]%."))
+			user.visible_message(SPAN_NOTICE("[user] stops repairing \the [name]."), SPAN_NOTICE("You stop repairing \the [name]. The integrity of module is at [SPAN_HELPFUL(round(get_integrity_percent()))]%."))
 			being_repaired = FALSE
 			return
 
@@ -457,7 +457,7 @@ obj/item/hardpoint/proc/remove_buff(var/obj/vehicle/multitile/V)
 		health += initial(health)/100 * (amount_fixed / amount_fixed_adjustment)
 		if(health >= initial(health))
 			health = initial(health)
-			user.visible_message(SPAN_NOTICE("[user] finishes repairing \the [name]."), SPAN_NOTICE("You finish repairing \the [name]. Integrity of the module is at [SPAN_HELPFUL(round(get_integrity_percent()))]%."))
+			user.visible_message(SPAN_NOTICE("[user] finishes repairing \the [name]."), SPAN_NOTICE("You finish repairing \the [name]. The integrity of the module is at [SPAN_HELPFUL(round(get_integrity_percent()))]%."))
 			being_repaired = FALSE
 			return
 		to_chat(user, SPAN_NOTICE("The integrity of \the [src] is now at [SPAN_HELPFUL(round(get_integrity_percent()))]%."))

--- a/code/modules/vehicles/hardpoints/hardpoint.dm
+++ b/code/modules/vehicles/hardpoints/hardpoint.dm
@@ -385,8 +385,6 @@ obj/item/hardpoint/proc/remove_buff(var/obj/vehicle/multitile/V)
 
 /obj/item/hardpoint/attackby(var/obj/item/O, var/mob/user)
 	if(iswelder(O))
-		if(user.action_busy)
-			return
 		handle_repair(O, user)
 		return
 	..()
@@ -406,47 +404,66 @@ obj/item/hardpoint/proc/remove_buff(var/obj/vehicle/multitile/V)
 	if(!WT.isOn())
 		to_chat(user, SPAN_WARNING("You need to light your [WT] first."))
 		return
-	if(WT.get_fuel() < 10)
+	if(WT.get_fuel() < 1)
 		to_chat(user, SPAN_WARNING("You need to refill \the [WT] first."))
 		return
 	if(being_repaired)
 		to_chat(user, SPAN_WARNING("\The [src] is already being repaired."))
 		return
+	if(user.action_busy)
+		return
 
-	var/needed_time = 1
+	//instead of making timer for repairing 10% of HP longer, we adjust how much % of max HP we fix per 1 second.
+	//Using original 10% per welding as reference
+	var/amount_fixed = 5	//in %
 	switch(slot)
-		if(HDPT_TURRET)
-			needed_time = 6
-		if(HDPT_PRIMARY)
-			needed_time = 5
-		if(HDPT_SECONDARY)
-			needed_time = 4
-		if(HDPT_SUPPORT)
-			needed_time = 4
 		if(HDPT_ARMOR)
-			needed_time = 7
+			amount_fixed = 1.4
+		if(HDPT_TURRET)
+			amount_fixed = 1.6
+		if(HDPT_PRIMARY)
+			amount_fixed = 2
+		if(HDPT_SECONDARY)
+			amount_fixed = 2.5
+		if(HDPT_SUPPORT)
+			amount_fixed = 2.5
 		if(HDPT_TREADS)
-			needed_time = 3
+			amount_fixed = 3.3
 
 	being_repaired = TRUE
-	playsound(get_turf(user), 'sound/items/weldingtool_weld.ogg', 25)
+
+	//skill level adjustment: instead of reducing welding time, we increase amount fixed.
+	//Uses skill duration multiplier proc in order to not create a bicycle.
+	var/amount_fixed_adjustment = user.get_skill_duration_multiplier(SKILL_ENGINEER)
 	user.visible_message(SPAN_NOTICE("[user] starts repairing \the [name]."), SPAN_NOTICE("You start repairing \the [name]."))
-	if(!do_after(user, 1 SECONDS * needed_time * user.get_skill_duration_multiplier(SKILL_ENGINEER), INTERRUPT_ALL, BUSY_ICON_FRIENDLY, numticks = needed_time))
-		user.visible_message(SPAN_NOTICE("[user] stops repairing \the [name]."), SPAN_NOTICE("You stop repairing \the [name]."))
-		being_repaired = FALSE
-		return
+	playsound(get_turf(user), 'sound/items/weldingtool_weld.ogg', 25)
+	while(WT.get_fuel() > 1)
+		if(!(world.time % 3))
+			playsound(get_turf(user), 'sound/items/weldingtool_weld.ogg', 25)
+		if(!do_after(user, 1 SECONDS, INTERRUPT_ALL, BUSY_ICON_BUILD))
+			user.visible_message(SPAN_NOTICE("[user] stops repairing \the [name]."), SPAN_NOTICE("You stop repairing \the [name]. Integrity of the module is at [SPAN_HELPFUL(round(get_integrity_percent()))]%."))
+			being_repaired = FALSE
+			return
 
-	//we check for adjacency only if we are not installed. This is for turret for now
-	if(!owner && !Adjacent(user))
-		user.visible_message(SPAN_NOTICE("[user] stops repairing \the [name]."), SPAN_NOTICE("You stop repairing \the [name]."))
-		being_repaired = FALSE
-		return
+		//we check for adjacency only if we are not installed. This is for turret for now
+		if(!owner && !Adjacent(user))
+			user.visible_message(SPAN_NOTICE("[user] stops repairing \the [name]."), SPAN_NOTICE("You stop repairing \the [name]. Integrity of \the module is at [SPAN_HELPFUL(round(get_integrity_percent()))]%."))
+			being_repaired = FALSE
+			return
 
-	WT.remove_fuel(needed_time, user)
-	health += round(0.1 * initial(health))
-	health = Clamp(health, 0, initial(health))
-	user.visible_message(SPAN_NOTICE("[user] finishes repairing \the [name]."), SPAN_NOTICE("You finish repairing \the [name]. Integrity now at [round(get_integrity_percent())]%."))
+		WT.remove_fuel(1, user)
+
+		//get_skill_duration_multiplier returns a multiplier, so we delete by it
+		health += initial(health)/100 * (amount_fixed / amount_fixed_adjustment)
+		if(health >= initial(health))
+			health = initial(health)
+			user.visible_message(SPAN_NOTICE("[user] finishes repairing \the [name]."), SPAN_NOTICE("You finish repairing \the [name]. Integrity of \the module is at [SPAN_HELPFUL(round(get_integrity_percent()))]%."))
+			being_repaired = FALSE
+			return
+		to_chat(user, SPAN_NOTICE("Integrity of \the [src] is now at [SPAN_HELPFUL(round(get_integrity_percent()))]%."))
+
 	being_repaired = FALSE
+	user.visible_message(SPAN_NOTICE("[user] stops repairing \the [name]."), SPAN_NOTICE("You stop repairing \the [name]. Integrity of \the module is at [SPAN_HELPFUL(round(get_integrity_percent()))]%."))
 	return
 
 //determines whether something is in firing arc of a hardpoint

--- a/code/modules/vehicles/hardpoints/hardpoint.dm
+++ b/code/modules/vehicles/hardpoints/hardpoint.dm
@@ -463,7 +463,7 @@ obj/item/hardpoint/proc/remove_buff(var/obj/vehicle/multitile/V)
 		to_chat(user, SPAN_NOTICE("Integrity of \the [src] is now at [SPAN_HELPFUL(round(get_integrity_percent()))]%."))
 
 	being_repaired = FALSE
-	user.visible_message(SPAN_NOTICE("[user] stops repairing \the [name]."), SPAN_NOTICE("You stop repairing \the [name]. Integrity of \the module is at [SPAN_HELPFUL(round(get_integrity_percent()))]%."))
+	user.visible_message(SPAN_NOTICE("[user] stops repairing \the [name]."), SPAN_NOTICE("You stop repairing \the [name]. The integrity of the module is at [SPAN_HELPFUL(round(get_integrity_percent()))]%."))
 	return
 
 //determines whether something is in firing arc of a hardpoint


### PR DESCRIPTION
## About The Pull Request

Instead of repairing 10% of health with timed actions with different timers, it now loops 1 second timed action repair with accordingly adjusted amount repaired for as long as there is fuel (if welder is used) and health is below max health. Engineering level afflicts how much is repaired now. Overall time of repairs should remain more or less the same.

## Why It's Good For The Game

Timed actions with long timers are not good when used for gradual progression process like welding something. Inspired by sandbags refilling rework.

## Changelog

:cl: Jeser
qol: Repairing vehicles and vehicle modules was reworked to be more convenient.
add: Wheels and tracks are being repaired twice slower now, because it was way too fast before.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
