### PR TITLE
Clamping tweaks

### DIFF
--- a/code/modules/vehicles/multitile/multitile_interaction.dm
+++ b/code/modules/vehicles/multitile/multitile_interaction.dm
@@ -29,18 +29,21 @@
 			to_chat(user, SPAN_WARNING("[src] already has a [O.name] attached."))
 			return
 
-		for(var/obj/item/hardpoint/locomotion/Loco in hardpoints)
-			if(skillcheck(user, SKILL_POLICE, SKILL_POLICE_SKILLED))
-				user.visible_message(SPAN_WARNING("[user] starts attaching the vehicle clamp to [src]."), SPAN_NOTICE("You start attaching the vehicle clamp to [src]."))
-				if(!do_after(user, 10, INTERRUPT_ALL, BUSY_ICON_BUILD))
-					user.visible_message(SPAN_WARNING("[user] stops attaching the vehicle clamp to [src]."), SPAN_WARNING("You stop attaching the vehicle clamp to [src]."))
-					return
-				user.visible_message(SPAN_WARNING("[user] attaches the vehicle clamp to [src]."), SPAN_NOTICE("You attach the vehicle clamp to [src] and lock the mechanism with your ID."))
-				attach_clamp(O, user)
-			else
-				to_chat(user, SPAN_WARNING("You don't know how to use [O] with [src]."))
+		//only can clamp friendly vehicles
+		if(!get_target_lock(user.faction_group))
+			to_chat(user, SPAN_WARNING("You can attach clamp to vehicles of your faction only."))
 			return
-		to_chat(user, SPAN_WARNING("There are no treads to attach [O.name] to."))
+
+		if(!skillcheck(user, SKILL_POLICE, SKILL_POLICE_SKILLED))
+			to_chat(user, SPAN_WARNING("You don't know how to use \the [O.name]."))
+			return
+
+		for(var/obj/item/hardpoint/locomotion/Loco in hardpoints)
+			user.visible_message(SPAN_WARNING("[user] attaches the vehicle clamp to \the [src]."), SPAN_NOTICE("You attach the vehicle clamp to \the [src] and lock the mechanism."))
+			attach_clamp(O, user)
+			return
+
+		to_chat(user, SPAN_WARNING("There are no treads or wheels to attach \the [O.name] to."))
 		return
 
 	// Are we trying to remove a vehicle clamp?
@@ -50,12 +53,12 @@
 
 		user.visible_message(SPAN_WARNING("[user] starts removing the vehicle clamp from [src]."), SPAN_NOTICE("You start removing the vehicle clamp from [src]."))
 		if(skillcheck(user, SKILL_POLICE, SKILL_POLICE_SKILLED))
-			if(!do_after(user, 20, INTERRUPT_ALL, BUSY_ICON_BUILD))
+			if(!do_after(user, 2 SECONDS, INTERRUPT_ALL, BUSY_ICON_BUILD))
 				user.visible_message(SPAN_WARNING("[user] stops removing the vehicle clamp from [src]."), SPAN_WARNING("You stop removing the vehicle clamp from [src]."))
 				return
-			user.visible_message(SPAN_WARNING("[user] skillfully removes the vehicle clamp from [src]."), SPAN_NOTICE("You unlock the mechanism with your ID and skillfully remove the vehicle clamp from [src]."))
+			user.visible_message(SPAN_WARNING("[user] swiftly removes the vehicle clamp from [src]."), SPAN_NOTICE("You skillfully unlock the mechanism and swiftly remove the vehicle clamp from [src]."))
 		else
-			if(!do_after(user, 30 SECONDS, INTERRUPT_ALL, BUSY_ICON_BUILD))
+			if(!do_after(user, 5 SECONDS, INTERRUPT_ALL, BUSY_ICON_BUILD))
 				user.visible_message(SPAN_WARNING("[user] stops removing the vehicle clamp from [src]."), SPAN_WARNING("You stop removing the vehicle clamp from [src]."))
 				return
 			user.visible_message(SPAN_WARNING("[user] clumsily removes the vehicle clamp from [src]."), SPAN_NOTICE("You manage to unlock vehicle clamp and take it off [src]."))

--- a/code/modules/vehicles/multitile/multitile_interaction.dm
+++ b/code/modules/vehicles/multitile/multitile_interaction.dm
@@ -483,14 +483,14 @@
 //CLAMP procs, unsafe proc, checks are done before calling it
 /obj/vehicle/multitile/proc/attach_clamp(obj/item/vehicle_clamp/O, mob/user)
 	user.temp_drop_inv_item(O, 0)
-	O.forceMove(src)
 	clamped = TRUE
 	move_delay = 50000
 	next_move = world.time + move_delay
+	qdel(O)
 	update_icon()
 	message_staff("[key_name(user)] ([user.job]) attached vehicle clamp to [src]")
 
-/obj/vehicle/multitile/proc/detach_clamp(mob/user)
+/obj/vehicle/multitile/proc/detach_clamp(var/mob/user)
 	clamped = FALSE
 	move_delay = initial(move_delay)
 
@@ -499,10 +499,11 @@
 		Loco.on_install(src)	//we restore speed respective to wheels/treads if any installed
 
 	next_move = world.time + move_delay
-	for(var/obj/item/vehicle_clamp/TC in src)
-		if(user)
-			TC.forceMove(get_turf(user))
-			message_staff("[key_name(user)] ([user.job]) detached vehicle clamp from [src]")
-		else
-			TC.forceMove(get_turf(src))
+	var/obj/item/vehicle_clamp/O = new(get_turf(src))
+	if(user)
+		O.forceMove(get_turf(user))
+		message_staff("[key_name(user)] ([user.job]) detached vehicle clamp from \the [src]")
+	else
+		O.forceMove(get_turf(src))
+		message_staff("Vehicle clamp was detached from \the [src].")
 	update_icon()


### PR DESCRIPTION
## About The Pull Request

1. Only vehicles of your faction can be clamped (no HvH shenanigans).
2. Wind up on installing is removed so they can actually be used.

## Why It's Good For The Game

Needed an actually working IC tool against bad VCs.

## Changelog

:cl: Jeser
add: Applying vehicle clamp is no longer a timed action.
add: Only vehicles of your faction can be clamped.
/:cl:

