### PR TITLE
Misc vehicle fixes

### DIFF
--- a/code/__DEFINES/vehicle.dm
+++ b/code/__DEFINES/vehicle.dm
@@ -18,6 +18,7 @@
 #define VEHICLE_SUPPORT_GUNNER_ONE  "1st support gunner"
 #define VEHICLE_SUPPORT_GUNNER_TWO  "2nd support gunner"
 
+#define VEHICLE_SPEED_STATIC		5000 //500 seconds per tile, while not actually static, it's much better than adding check for each movement attempt.
 #define VEHICLE_SPEED_SLOW          30 //3 seconds per tile
 #define VEHICLE_SPEED_NORMAL        10 //default 1 second per tile
 #define VEHICLE_SPEED_FASTNORMAL    7

--- a/code/game/objects/items/devices/motion_detector.dm
+++ b/code/game/objects/items/devices/motion_detector.dm
@@ -16,7 +16,7 @@
 
 /obj/item/device/motiondetector
 	name = "motion detector"
-	desc = "A device that detects movement, but ignores marines."
+	desc = "A device that detects movement, but ignores marines. Can also be used to scan a vehicle interior from outside, but accuracy of such scanning is low and there is no way to differentiate friends from foes."
 	icon = 'icons/obj/items/marine-items.dmi'
 	icon_state = "detector"
 	item_state = "motion_detector"

--- a/code/modules/vehicles/hardpoints/wheels/locomotion.dm
+++ b/code/modules/vehicles/hardpoints/wheels/locomotion.dm
@@ -15,6 +15,7 @@
 	owner.move_max_momentum = initial(owner.move_max_momentum)
 	owner.move_momentum_build_factor = initial(owner.move_momentum_build_factor)
 	owner.move_turn_momentum_loss_factor = initial(owner.move_turn_momentum_loss_factor)
+	owner.next_move = world.time + move_delay
 
 /obj/item/hardpoint/locomotion/on_install(var/obj/vehicle/multitile/V)
 	if(move_delay)
@@ -25,6 +26,7 @@
 		V.move_momentum_build_factor = move_momentum_build_factor
 	if(move_turn_momentum_loss_factor)
 		V.move_turn_momentum_loss_factor = move_turn_momentum_loss_factor
+	owner.next_move = world.time + move_delay
 
 /obj/item/hardpoint/locomotion/on_uninstall(var/obj/vehicle/multitile/V)
 	deactivate()

--- a/code/modules/vehicles/interior/interior.dm
+++ b/code/modules/vehicles/interior/interior.dm
@@ -183,10 +183,10 @@
 // Moves the atom to the interior
 /datum/interior/proc/enter(var/atom/movable/A, var/entrance_used)
 	if(!ready)
-		return
+		return FALSE
 
 	if(!A)
-		return
+		return FALSE
 
 	if(forbidden_atoms)
 		for(var/type in forbidden_atoms)

--- a/code/modules/vehicles/multitile/multitile.dm
+++ b/code/modules/vehicles/multitile/multitile.dm
@@ -118,8 +118,9 @@ GLOBAL_LIST_EMPTY(all_multi_vehicles)
 	//Amount of seconds spent on entering/leaving. Always the same when dragging stuff (2 seconds) and for xenos (1 second)
 	var/entrance_speed = 1
 
-	// Whether or not entering the vehicle is ID restricted to crewmen only. Toggleable by the driver
-	var/door_locked = TRUE
+	//Whether or not entering the vehicle is ID restricted to those with crewman, command or MP access only. Toggleable by the driver.
+	//Having command/MP/Crewmen access won't matter if the faction of the vehicle is not yours, so you can't infiltrate the vehicle.
+	var/door_locked = FALSE
 	req_one_access = list(
 		ACCESS_MARINE_CREWMAN,
 		// Officers always have access

--- a/code/modules/vehicles/multitile/multitile_interaction.dm
+++ b/code/modules/vehicles/multitile/multitile_interaction.dm
@@ -113,7 +113,7 @@
 
 		var/msg = ""
 		if(humans_inside || interior.xenos_taken_slots)
-			msg += "\The [MD] shows [humans_inside ? ("approximately [SPAN_HELPFUL(humans_inside)] signature") : "no signatures"] of unknown affiliation\
+			msg += "\The [MD] shows [humans_inside ? ("approximately [SPAN_HELPFUL(humans_inside)] signatures") : "no signatures"] of unknown affiliation\
 			[interior.xenos_taken_slots ? (" and about [SPAN_HELPFUL(interior.xenos_taken_slots)] abnormal signature") : ""] inside of \the [src]."
 			MD.show_blip(user, src)
 			playsound(user, pick('sound/items/detector_ping_1.ogg', 'sound/items/detector_ping_2.ogg', 'sound/items/detector_ping_3.ogg', 'sound/items/detector_ping_4.ogg'), 60, FALSE, 7, 2)

--- a/code/modules/vehicles/multitile/multitile_interaction.dm
+++ b/code/modules/vehicles/multitile/multitile_interaction.dm
@@ -114,7 +114,7 @@
 		var/msg = ""
 		if(humans_inside || interior.xenos_taken_slots)
 			msg += "\The [MD] shows [humans_inside ? ("approximately [SPAN_HELPFUL(humans_inside)] signatures") : "no signatures"] of unknown affiliation\
-			[interior.xenos_taken_slots ? (" and about [SPAN_HELPFUL(interior.xenos_taken_slots)] abnormal signature") : ""] inside of \the [src]."
+			[interior.xenos_taken_slots ? (" and about [SPAN_HELPFUL(interior.xenos_taken_slots)] abnormal signatures") : ""] inside of \the [src]."
 			MD.show_blip(user, src)
 			playsound(user, pick('sound/items/detector_ping_1.ogg', 'sound/items/detector_ping_2.ogg', 'sound/items/detector_ping_3.ogg', 'sound/items/detector_ping_4.ogg'), 60, FALSE, 7, 2)
 			to_chat(user, SPAN_NOTICE(msg))

--- a/code/modules/vehicles/multitile/multitile_interaction.dm
+++ b/code/modules/vehicles/multitile/multitile_interaction.dm
@@ -120,7 +120,7 @@
 			to_chat(user, SPAN_NOTICE(msg))
 		else
 			playsound(user, 'sound/items/detector.ogg', 60, FALSE, 7, 2)
-			to_chat(user, SPAN_WARNING("\The [MD] doesn't pick up any signatures, so vehicle should be empty. In theory."))
+			to_chat(user, SPAN_WARNING("\The [MD] can't pick up any signatures, so the vehicle should be empty. In theory."))
 		return
 
 	if(user.a_intent != INTENT_HARM)

--- a/code/modules/vehicles/multitile/multitile_interaction.dm
+++ b/code/modules/vehicles/multitile/multitile_interaction.dm
@@ -80,7 +80,7 @@
 					handle_fitting_pulled_atom(user, dragged_atom)
 					return
 		else
-			to_chat(user, SPAN_INFO("Use [SPAN_HELPFUL("HELP")] intent to fit pulled object or creature into vehicle without getting inside yourself."))
+			to_chat(user, SPAN_INFO("Use [SPAN_HELPFUL("HELP")] intent to put a pulled object or creature into the vehicle without getting inside yourself."))
 			return
 
 	if(istype(O, /obj/item/device/motiondetector))

--- a/code/modules/vehicles/multitile/multitile_interaction.dm
+++ b/code/modules/vehicles/multitile/multitile_interaction.dm
@@ -84,25 +84,44 @@
 			return
 
 	if(istype(O, /obj/item/device/motiondetector))
+		if(!interior)
+			to_chat(user, SPAN_WARNING("It appears that [O] cannot establish borders of space inside \the [src]. (PLEASE, TELL A DEV, SOMETHING BROKE)"))
+			return
+		var/obj/item/device/motiondetector/MD = O
 
-		user.visible_message(SPAN_WARNING("[user] fumbles with \the [O] aimed at \the [src]."), SPAN_NOTICE("You start recalibrating \the [O] to scan \the [src]'s interior for abnormal activity."))
+		if(!MD.active)
+			to_chat(user, SPAN_WARNING("\The [MD] must be activated in order to scan \the [src]'s interior."))
+			return
+
+		user.visible_message(SPAN_WARNING("[user] fumbles with \the [MD] aimed at \the [src]."), SPAN_NOTICE("You start recalibrating \the [MD] to scan \the [src]'s interior for signatures."))
 		if(!do_after(user, 3 SECONDS, INTERRUPT_ALL, BUSY_ICON_GENERIC))
-			user.visible_message(SPAN_WARNING("[user] stops fumbling with \the [O]."), SPAN_WARNING("You stop trying to scan \the [src]'s interior."))
+			user.visible_message(SPAN_WARNING("[user] stops fumbling with \the [MD]."), SPAN_WARNING("You stop trying to scan \the [src]'s interior."))
 			return
 		if(get_dist(src, user) > 2)
 			to_chat(user, SPAN_WARNING("You are too far from \the [src]."))
 			return
 
-		user.visible_message(SPAN_WARNING("[user] finishes fumbling with \the [O]."), SPAN_NOTICE("You finish recalibrating \the [O] and scanning \the [src]'s interior for abnormal activity."))
+		user.visible_message(SPAN_WARNING("[user] finishes fumbling with \the [MD]."), SPAN_NOTICE("You finish recalibrating \the [MD] and scanning \the [src]'s interior for signatures."))
 
 		interior.update_passenger_count()
-		var/obj/item/device/motiondetector/MD = O
-		if(interior.xenos_taken_slots + interior.passengers_taken_slots)
+
+		var/humans_inside = 0
+		if(length(interior.role_reserved_slots))
+			for(var/datum/role_reserved_slots/RRS in interior.role_reserved_slots)
+				humans_inside += RRS.taken
+		humans_inside += interior.passengers_taken_slots
+
+		var/msg = ""
+		if(humans_inside || interior.xenos_taken_slots)
+			msg += "\The [MD] shows [humans_inside ? ("approximately [SPAN_HELPFUL(humans_inside)] signature") : "no signatures"] of unknown affiliation\
+			[interior.xenos_taken_slots ? (" and about [SPAN_HELPFUL(interior.xenos_taken_slots)] abnormal signature") : ""] inside of \the [src]."
 			MD.show_blip(user, src)
-			to_chat(user, SPAN_WARNING("\The [MD] shows that there are approximately [interior.xenos_taken_slots + interior.passengers_taken_slots] signatures inside. Affiliation unknown."))
 			playsound(user, pick('sound/items/detector_ping_1.ogg', 'sound/items/detector_ping_2.ogg', 'sound/items/detector_ping_3.ogg', 'sound/items/detector_ping_4.ogg'), 60, FALSE, 7, 2)
+			to_chat(user, SPAN_NOTICE(msg))
 		else
 			playsound(user, 'sound/items/detector.ogg', 60, FALSE, 7, 2)
+			to_chat(user, SPAN_WARNING("\The [MD] doesn't pick up any signatures, so vehicle should be empty. In theory."))
+		return
 
 	if(user.a_intent != INTENT_HARM)
 		handle_player_entrance(user)


### PR DESCRIPTION
## About The Pull Request

1. Vehicles start unlocked.
2. Having Crewman, Command or MP access won't negate door lock of a vehicle of another faction.
3. Small tweak and fix for scanning vehicle with Motion Detector. It now shows xenos and passengers slots taken.
4. You no longer able to fit pulled objects and creatures into vehicle if it's locked and you have no access to it.
5. Added proper delay move level to use for vehicles that are supposed to be immobile for whatever reasons as well as tweaks to ensure they will be immobilized immediately.

## Why It's Good For The Game

QoL, fixes, HvH balance.

## Changelog

:cl: Jeser
fix: Having access level that circumvents door lock no longer works on vehicles of other factions.
fix: Fitting pulled mobs or objects into vehicle does actually check for access now if doors are locked.
fix: Fixed and improved vehicle scanning with Motion Detectors. MDs description now mentions this feature. Takes 3 seconds, shows humanoid and xenos signatures separately. It is by no means intended to be precise. Caution is advised.
add: Vehicles now spawn unlocked.
code: Added proper delay for vehicles with broken or without wheels or tracks and delay should apply instantly upon meeting requirements now.
/:cl:
