### PR TITLE
[Bugfix] Flamer's damage should be approriate for objects that handle it

### DIFF
--- a/code/modules/projectiles/guns/flamer/flamer.dm
+++ b/code/modules/projectiles/guns/flamer/flamer.dm
@@ -555,11 +555,11 @@
 
 /obj/flamer_fire/process(delta_time)
 	var/turf/T = loc
-	var/damage = burnlevel*delta_time
 	firelevel = max(0, firelevel)
 	if(!istype(T)) //Is it a valid turf? Has to be on a floor
 		qdel(src)
 		return PROCESS_KILL
+	var/damage = burnlevel*delta_time
 	T.flamer_fire_act(damage)
 
 	update_flame()

--- a/code/modules/projectiles/guns/flamer/flamer.dm
+++ b/code/modules/projectiles/guns/flamer/flamer.dm
@@ -555,11 +555,12 @@
 
 /obj/flamer_fire/process(delta_time)
 	var/turf/T = loc
+	var/damage = burnlevel*delta_time
 	firelevel = max(0, firelevel)
 	if(!istype(T)) //Is it a valid turf? Has to be on a floor
 		qdel(src)
 		return PROCESS_KILL
-	T.flamer_fire_act(burnlevel*delta_time)
+	T.flamer_fire_act(damage)
 
 	update_flame()
 
@@ -574,7 +575,7 @@
 			set_on_fire(i)
 		else if(isobj(i))
 			var/obj/O = i
-			O.flamer_fire_act(0, weapon_cause_data)
+			O.flamer_fire_act(damage, weapon_cause_data)
 
 	//This has been made a simple loop, for the most part flamer_fire_act() just does return, but for specific items it'll cause other effects.
 	firelevel -= 2 //reduce the intensity by 2 per tick


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Instead of objects taking 0 damage, they now take damage similar to the turf. The damage is based on the flamer fuel.

These use to take their default parameter value of damage but then it was set to 0 for some reason thus I changed it to the damage based on the flamer fuel similar to turf so stronger fires burn them faster rather than a constant damage based on a magic number

Objects that should take fire damage will now take flame damage appropriately:
- Barricades. Yes, make sure not to flame your own cades
```
/obj/structure/barricade/flamer_fire_act(var/dam = BURN_LEVEL_TIER_1)

	take_damage(dam * burn_multiplier)
```
- Thickbush
 ```
/obj/structure/flora/jungle/thickbush/flamer_fire_act(var/dam = BURN_LEVEL_TIER_1)

	health -= dam

	healthcheck(src)
```
- Alien doors
```
/obj/structure/mineral_door/resin/flamer_fire_act(var/dam = BURN_LEVEL_TIER_1)

	health -= dam

	healthcheck()
```
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
One of the weird things I see in the game after fixing the flamers melting walls is now doors are left standing. So after an incidenary OB, you would see every xeno wall burn but the doors are strong, so strong they survive if they still have support. This never really made sense to me so I took a look at the code and found that objects have 0 damage which makes no sense imo since there's code to handle damage for certain objects like mentioned above ( doors, thickbush and barricades).

This fixes the issue where resin doors are impossible to burn down. This however introduces barricades being burned ( since it has it's own handler that takes damage ) so flamers need to be more careful not to flame their own cades or at least put out the fire if the barricade is on fire.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: TeDGamer
fix: Flamers should deal non-zero damage to objects appropriately (resin doors, barricades, thickbush ).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
