### PR TITLE
[Bugfix] Fix core cooldown on hijack launch

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -737,10 +737,6 @@
 		last_locked = world.time
 		if(almayer_orbital_cannon)
 			almayer_orbital_cannon.is_disabled = TRUE
-			if(M.hive.hivecore_cooldown)
-				M.hive.hivecore_cooldown = FALSE
-				message = "The weeds have recovered! A new hive core can be built!"
-				xeno_message(SPAN_XENOBOLDNOTICE("[message]"),3,M.hivenumber)
 			addtimer(CALLBACK(almayer_orbital_cannon, .obj/structure/orbital_cannon/proc/enable), 10 MINUTES, TIMER_UNIQUE)
 		queen_locked = 1
 

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -775,6 +775,7 @@
 		for(var/obj/item/alien_embryo/embryo in potential_host)
 			embryo.hivenumber = XENO_HIVE_FORSAKEN
 		potential_host.update_med_icon()
+	hivecore_cooldown = FALSE
 	hijack_pooled_surge = TRUE
 
 /datum/hive_status/proc/free_respawn(var/client/C)

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -778,7 +778,7 @@
 	hijack_pooled_surge = TRUE
 	hivecore_cooldown = FALSE
 	message = "The weeds have recovered! A new hive core can be built!"
-	xeno_message(SPAN_XENOBOLDNOTICE("[message]"),3,M.hivenumber)
+	xeno_message(SPAN_XENOBOLDNOTICE("[message]"),3,hivenumber)
 
 /datum/hive_status/proc/free_respawn(var/client/C)
 	stored_larva++

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -775,8 +775,10 @@
 		for(var/obj/item/alien_embryo/embryo in potential_host)
 			embryo.hivenumber = XENO_HIVE_FORSAKEN
 		potential_host.update_med_icon()
-	hivecore_cooldown = FALSE
 	hijack_pooled_surge = TRUE
+	hivecore_cooldown = FALSE
+	message = "The weeds have recovered! A new hive core can be built!"
+	xeno_message(SPAN_XENOBOLDNOTICE("[message]"),3,M.hivenumber)
 
 /datum/hive_status/proc/free_respawn(var/client/C)
 	stored_larva++

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -777,8 +777,7 @@
 		potential_host.update_med_icon()
 	hijack_pooled_surge = TRUE
 	hivecore_cooldown = FALSE
-	message = "The weeds have recovered! A new hive core can be built!"
-	xeno_message(SPAN_XENOBOLDNOTICE("[message]"),3,hivenumber)
+	xeno_message(SPAN_XENOBOLDNOTICE("The weeds have recovered! A new hive core can be built!"),3,hivenumber)
 
 /datum/hive_status/proc/free_respawn(var/client/C)
 	stored_larva++


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Simply a core can be rebuilt once hijack starts. This fixes the issue of having to wait 5 minutes into hijack to rebuild the core.

You can't relocate core after 20 minutes into the game so you need to destroy it but then wait 5 minutes. So this PR makes it so that on launch, AFTER the special structures are destroyed can you rebuild the hive core
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Build pool early, get larva surge early.

Also it's a bugfix.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: TeDGamer
fix: Hive core cooldown is reset on launching the dropship after all special structures are destroyed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
