### PR TITLE
[Code] Human status check after health updates

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -76,10 +76,10 @@
 	//Handle temperature/pressure differences between body and environment
 	handle_environment() //Optimized a good bit.
 
+	updatehealth()
+
 	//Status updates, death etc.
 	handle_regular_status_updates() //Optimized a bit
-
-	updatehealth()
 
 	update_canmove()
 

--- a/code/modules/mob/living/carbon/human/life/handle_regular_status_updates.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_regular_status_updates.dm
@@ -9,10 +9,6 @@
 		blinded = 1
 		silent = 0
 	else //ALIVE. LIGHTS ARE ON
-		//updatehealth() // moved to Life()
-
-		recalculate_move_delay = TRUE
-
 		if(health <= HEALTH_THRESHOLD_DEAD || (species.has_organ["brain"] && !has_brain()))
 			death(last_damage_data)
 			blinded = 1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Keeps this consistent with the [xeno deathcheck](582). Also it seems like originally updatehealth was in the handle_status_updates and happened before the rest of the code so it basically goes back to that.

recalculate_move_delay is set to true in updatehealth so if we change the order, setting  that in handle_status_updates is no longer neccessary. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Consistency for code's sake and people will die when they should die, not based off of the health from the previous life cycle
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: TeDGamer
code: Humans handle status updates (such as death) after their health is updated in current life cycle
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
