### PR TITLE
Balance: synthskin arms no longer malf below a 10 combined damage threshold

### DIFF
--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -1131,12 +1131,10 @@ treat_grafted var tells it to apply to grafted but unsalved wounds, for burn kit
 	return ((status & LIMB_BROKEN) && !(status & LIMB_SPLINTED))
 
 /obj/limb/proc/is_malfunctioning()
-{
 	if(status & LIMB_ROBOT)
 		return ((status & LIMB_ROBOT) && prob(brute_dam + burn_dam))
 	else if(status & LIMB_SYNTHSKIN && (brute_dam + burn_dam) > 10)
 		return (status & LIMB_SYNTHSKIN) && (prob(brute_dam + burn_dam))
-}
 
 //for arms and hands
 /obj/limb/proc/process_grasp(var/obj/item/c_hand, var/hand_name)

--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -1132,9 +1132,9 @@ treat_grafted var tells it to apply to grafted but unsalved wounds, for burn kit
 
 /obj/limb/proc/is_malfunctioning()
 	if(status & LIMB_ROBOT)
-		return ((status & LIMB_ROBOT) && prob(brute_dam + burn_dam))
+		return prob(brute_dam + burn_dam)
 	else if(status & LIMB_SYNTHSKIN && (brute_dam + burn_dam) > 10)
-		return (status & LIMB_SYNTHSKIN) && (prob(brute_dam + burn_dam))
+		return prob(brute_dam + burn_dam)
 
 //for arms and hands
 /obj/limb/proc/process_grasp(var/obj/item/c_hand, var/hand_name)

--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -1131,7 +1131,12 @@ treat_grafted var tells it to apply to grafted but unsalved wounds, for burn kit
 	return ((status & LIMB_BROKEN) && !(status & LIMB_SPLINTED))
 
 /obj/limb/proc/is_malfunctioning()
-	return ((status & (LIMB_ROBOT|LIMB_SYNTHSKIN)) && prob(brute_dam + burn_dam))
+{
+	if(status & LIMB_ROBOT)
+		return ((status & LIMB_ROBOT) && prob(brute_dam + burn_dam))
+	else if(status & LIMB_SYNTHSKIN && (brute_dam + burn_dam) > 10)
+		return (status & LIMB_SYNTHSKIN) && (prob(brute_dam + burn_dam))
+}
 
 //for arms and hands
 /obj/limb/proc/process_grasp(var/obj/item/c_hand, var/hand_name)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Essentially a rehearse of this Gitlab merge request, but with a more sensible threshold value, and applies to synthetics only: https://gitlab.com/cmdevs/colonial-warfare/-/merge_requests/2102
If the combined brute/burn damage on a synthskin arm or hand is at or below 10 points, the malfunction proc will not trigger.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Prevents situations where punching a synth once or throwing a piece of paper at one's arm causes their arms to malf and drop held items until smartpack charge/welder/cable coil was expended to repair it, due to synths lacking the natural hp regeneration that human mobs have, which is an unreasonably expensive process both time and resources-wise for something so comparatively meaningless. A marine wearing light armor receives infinitesimal damage from another human's punch, and said damage amount heals itself almost immediately, which leads to comical situations where synths appear more fragile than your average human. More importantly, this balance change does not affect regular prosthetic limbs' balance, which was what Nanu requested to be done in the previous MR after closing it.

In short, it will make synthetic gameplay less frustrating and greatly reduce fussing over, say 0.534568 points of brute damage causing a synth to drop what they were holding, which feels completely nonsensical and unrealistic.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: 50RemAndCounting
balance: synthskin arms and hands will no longer malfunction and drop items if the combined brute and burn damage on them does not exceed 10 points.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
