### PR TITLE
Buffed compact defib from 7 to 10 charges

### DIFF
--- a/code/game/objects/items/devices/defibrillator.dm
+++ b/code/game/objects/items/devices/defibrillator.dm
@@ -243,4 +243,4 @@
 	icon_state = "compact_defib"
 	item_state = "defib"
 	w_class = SIZE_SMALL
-	charge_cost = 132
+	charge_cost = 99


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Changed charge cost for the synthtools compact defib so it stores 10 charges instead of the previous 7
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The compact defibrillator is the odd one out and the least popular of the synth experimental tools currently available. By buffing it slightly, my aim is to make it a more appealing purchase option.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: 50RemAndCounting
balance: buffed the synth tools vendor compact defibrillator from storing 7 to 10 charges maximum.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
