### PR TITLE
Hijack anti-delay : scouts and snipers.

### DIFF
--- a/code/modules/clothing/suits/marine_armor.dm
+++ b/code/modules/clothing/suits/marine_armor.dm
@@ -869,6 +869,7 @@ var/list/squad_colors_chat = list(rgb(230,125,125), rgb(255,230,80), rgb(255,150
 	var/camouflage_break = 5 SECONDS
 	var/camouflage_enter_delay = 4 SECONDS
 	var/aiming_time = 1.25 SECONDS
+	var/can_camo = TRUE
 
 	var/aimed_shot_cooldown
 	var/aimed_shot_cooldown_delay = 2.5 SECONDS
@@ -891,7 +892,7 @@ var/list/squad_colors_chat = list(rgb(230,125,125), rgb(255,230,80), rgb(255,150
 	if(!usr || usr.is_mob_incapacitated(TRUE))
 		return
 
-	if(!ishuman(usr) || hide_in_progress)
+	if(!ishuman(usr) || hide_in_progress || !can_camo)
 		return
 	var/mob/living/carbon/human/H = usr
 	if(!skillcheck(H, SKILL_SPEC_WEAPONS, SKILL_SPEC_ALL) && H.skills.get_skill_level(SKILL_SPEC_WEAPONS) != SKILL_SPEC_SNIPER)

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -77,7 +77,15 @@
 				var/mob/living/carbon/human/delayer = last_living_human
 				if(istype(delayer.back, /obj/item/storage/backpack/marine/satchel/scout_cloak))
 					var/obj/item/storage/backpack/marine/satchel/scout_cloak/delayer_cloak = delayer.back
-
+					if(delayer_cloak.camo_active)
+						delayer_cloak.deactivate_camouflage(delayer)
+						delayer_cloak.cloak_cooldown = world.time + 1 HOURS //fuck you
+						to_chat(delayer, SPAN_WARNING("Your [delayer_cloak] fizzles out and breaks!"))
+				if(istype(delayer.suit, /obj/item/clothing/suit/storage/marine/ghillie))
+					var/obj/item/clothing/suit/storage/marine/ghillie/delayer_armour = delayer.suit
+					if(delayer_armour.camo_active)
+						delayer_armour.deactivate_camouflage(delayer)
+						delayer_armour.can_camo = FALSE //fuck you
+						to_chat(delayer, SPAN_WARNING("Your [delayer_armour]'s camo system breaks!"))
 			announce_dchat("There is only one person left: [last_living_human.real_name].", last_living_human)
-
 	return ..(cause, gibbed, species.death_message)

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -79,13 +79,13 @@
 					var/obj/item/storage/backpack/marine/satchel/scout_cloak/delayer_cloak = delayer.back
 					if(delayer_cloak.camo_active)
 						delayer_cloak.deactivate_camouflage(delayer)
-						delayer_cloak.cloak_cooldown = world.time + 1 HOURS //fuck you
-						to_chat(delayer, SPAN_WARNING("Your [delayer_cloak] fizzles out and breaks!"))
+					delayer_cloak.cloak_cooldown = world.time + 1 HOURS //fuck you
+					to_chat(delayer, SPAN_WARNING("Your [delayer_cloak] fizzles out and breaks!"))
 				if(istype(delayer.suit, /obj/item/clothing/suit/storage/marine/ghillie))
 					var/obj/item/clothing/suit/storage/marine/ghillie/delayer_armour = delayer.suit
 					if(delayer_armour.camo_active)
 						delayer_armour.deactivate_camouflage(delayer)
-						delayer_armour.can_camo = FALSE //fuck you
-						to_chat(delayer, SPAN_WARNING("Your [delayer_armour]'s camo system breaks!"))
+					delayer_armour.can_camo = FALSE //fuck you
+					to_chat(delayer, SPAN_WARNING("Your [delayer_armour]'s camo system breaks!"))
 			announce_dchat("There is only one person left: [last_living_human.real_name].", last_living_human)
 	return ..(cause, gibbed, species.death_message)

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -74,6 +74,10 @@
 			// Tell the human he is the last guy.
 			if(last_living_human.client)
 				to_chat(last_living_human, SPAN_ANNOUNCEMENT_HEADER_BLUE("Panic creeps up your spine. You realize that you are the last survivor."))
+				var/mob/living/carbon/human/delayer = last_living_human
+				if(istype(delayer.back, /obj/item/storage/backpack/marine/satchel/scout_cloak))
+					var/obj/item/storage/backpack/marine/satchel/scout_cloak/delayer_cloak = delayer.back
+
 			announce_dchat("There is only one person left: [last_living_human.real_name].", last_living_human)
 
 	return ..(cause, gibbed, species.death_message)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

stops scouts and snipers from delaying the round end with cloak

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

stops delay

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: if a scout or a sniper is the last marine alive during hijack, their cloaking abilities will no longer function and they will be forcibly decloaked. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
