### PR TITLE
Cloaked bell nerf part 2

### DIFF
--- a/code/modules/defenses/bell_tower.dm
+++ b/code/modules/defenses/bell_tower.dm
@@ -40,19 +40,9 @@
 	setup_tripwires()
 	visible_message("[icon2html(src, viewers(src))] [SPAN_NOTICE("The [name] gives a short ring, as it comes alive.")]")
 
-	// For cloaker bell, cloaks them when turned on
-	var/obj/structure/machinery/defenses/bell_tower/cloaker/cloakedbell = src
-	if(istype(cloakedbell, /obj/structure/machinery/defenses/bell_tower/cloaker))
-		animate(src, alpha = cloakedbell.cloak_alpha_max, time = cloakedbell.camouflage_break, easing = LINEAR_EASING, ANIMATION_END_NOW)
-
 /obj/structure/machinery/defenses/bell_tower/power_off_action()
 	clear_tripwires()
 	visible_message("[icon2html(src, viewers(src))] [SPAN_NOTICE("The [name] gives a beep and powers down.")]")
-
-	// For cloaker bell, uncloaks them when turned off
-	var/obj/structure/machinery/defenses/bell_tower/cloaker/cloakedbell = src
-	if(istype(cloakedbell, /obj/structure/machinery/defenses/bell_tower/cloaker))
-		animate(src, alpha = initial(src.alpha), flags = ANIMATION_END_NOW)
 
 /obj/structure/machinery/defenses/bell_tower/proc/clear_tripwires()
 	for(var/obj/effect/bell_tripwire/FE in tripwires_placed)
@@ -193,6 +183,21 @@
 	. = ..()
 	// Makes it so that the bell tower starts cloaked when deployed
 	// animate(src, alpha = cloak_alpha, time = 2 SECONDS, easing = LINEAR_EASING)
+
+/obj/structure/machinery/defenses/bell_tower/cloaker/power_on_action()
+	clear_tripwires()
+	setup_tripwires()
+	visible_message("[icon2html(src, viewers(src))] [SPAN_NOTICE("The [name] gives a short ring, as it comes alive.")]")
+
+	// For cloaker bell, cloaks them when turned on
+	animate(src, alpha = cloak_alpha_max, time = camouflage_break, easing = LINEAR_EASING, ANIMATION_END_NOW)
+
+/obj/structure/machinery/defenses/bell_tower/cloaker/power_off_action()
+	clear_tripwires()
+	visible_message("[icon2html(src, viewers(src))] [SPAN_NOTICE("The [name] gives a beep and powers down.")]")
+
+	// For cloaker bell, uncloaks them when turned off
+	animate(src, alpha = initial(src.alpha), flags = ANIMATION_END_NOW)
 
 /obj/structure/machinery/defenses/bell_tower/cloaker/proc/cloaker_fade_in()
 	// This is activated whenever the bell is rang, makes the cloaked tower visible a bit

--- a/code/modules/defenses/bell_tower.dm
+++ b/code/modules/defenses/bell_tower.dm
@@ -125,8 +125,8 @@
 	linked_bell.bell_cooldown = world.time + BELL_TOWER_COOLDOWN //1.5s cooldown between RINGS
 
 	// checks if cloaked bell, if it is, then it reduces the cloaked bells alpha
-	var/obj/structure/machinery/defenses/bell_tower/cloaker/cloakedbell = linked_bell
-	if(istype(cloakedbell, /obj/structure/machinery/defenses/bell_tower/cloaker))
+	if(istype(linked_bell, /obj/structure/machinery/defenses/bell_tower/cloaker))
+		var/obj/structure/machinery/defenses/bell_tower/cloaker/cloakedbell = linked_bell
 		cloakedbell.cloaker_fade_in()
 
 /obj/item/device/motiondetector/internal
@@ -179,23 +179,13 @@
 	health_max = 250
 	defense_type = "Cloaker"
 
-/obj/structure/machinery/defenses/bell_tower/cloaker/Initialize()
-	. = ..()
-	// Makes it so that the bell tower starts cloaked when deployed
-	// animate(src, alpha = cloak_alpha, time = 2 SECONDS, easing = LINEAR_EASING)
-
 /obj/structure/machinery/defenses/bell_tower/cloaker/power_on_action()
-	clear_tripwires()
-	setup_tripwires()
-	visible_message("[icon2html(src, viewers(src))] [SPAN_NOTICE("The [name] gives a short ring, as it comes alive.")]")
-
+	. = ..()
 	// For cloaker bell, cloaks them when turned on
 	animate(src, alpha = cloak_alpha_max, time = camouflage_break, easing = LINEAR_EASING, ANIMATION_END_NOW)
 
 /obj/structure/machinery/defenses/bell_tower/cloaker/power_off_action()
-	clear_tripwires()
-	visible_message("[icon2html(src, viewers(src))] [SPAN_NOTICE("The [name] gives a beep and powers down.")]")
-
+	. = ..()
 	// For cloaker bell, uncloaks them when turned off
 	animate(src, alpha = initial(src.alpha), flags = ANIMATION_END_NOW)
 

--- a/code/modules/defenses/bell_tower.dm
+++ b/code/modules/defenses/bell_tower.dm
@@ -182,7 +182,7 @@
 	handheld_type = /obj/item/defenses/handheld/bell_tower/cloaker
 	var/cloak_alpha_max = BELL_TOWER_CLOAKER_ALPHA
 	var/cloak_alpha_current = BELL_TOWER_CLOAKER_ALPHA
-	var/incremental_ring_camo_penalty = 70
+	var/incremental_ring_camo_penalty = 40
 	var/camouflage_break = 5 SECONDS
 	density = FALSE
 	health = 250

--- a/code/modules/defenses/bell_tower.dm
+++ b/code/modules/defenses/bell_tower.dm
@@ -40,9 +40,19 @@
 	setup_tripwires()
 	visible_message("[icon2html(src, viewers(src))] [SPAN_NOTICE("The [name] gives a short ring, as it comes alive.")]")
 
+	// For cloaker bell, cloaks them when turned on
+	var/obj/structure/machinery/defenses/bell_tower/cloaker/cloakedbell = src
+	if(istype(cloakedbell, /obj/structure/machinery/defenses/bell_tower/cloaker))
+		animate(src, alpha = cloakedbell.cloak_alpha_max, time = cloakedbell.camouflage_break, easing = LINEAR_EASING, ANIMATION_END_NOW)
+
 /obj/structure/machinery/defenses/bell_tower/power_off_action()
 	clear_tripwires()
 	visible_message("[icon2html(src, viewers(src))] [SPAN_NOTICE("The [name] gives a beep and powers down.")]")
+
+	// For cloaker bell, uncloaks them when turned off
+	var/obj/structure/machinery/defenses/bell_tower/cloaker/cloakedbell = src
+	if(istype(cloakedbell, /obj/structure/machinery/defenses/bell_tower/cloaker))
+		animate(src, alpha = initial(src.alpha), flags = ANIMATION_END_NOW)
 
 /obj/structure/machinery/defenses/bell_tower/proc/clear_tripwires()
 	for(var/obj/effect/bell_tripwire/FE in tripwires_placed)
@@ -124,6 +134,11 @@
 	to_chat(M, SPAN_DANGER("The frequency of the noise slows you down!"))
 	linked_bell.bell_cooldown = world.time + BELL_TOWER_COOLDOWN //1.5s cooldown between RINGS
 
+	// checks if cloaked bell, if it is, then it reduces the cloaked bells alpha
+	var/obj/structure/machinery/defenses/bell_tower/cloaker/cloakedbell = linked_bell
+	if(istype(cloakedbell, /obj/structure/machinery/defenses/bell_tower/cloaker))
+		cloakedbell.cloaker_fade_in()
+
 /obj/item/device/motiondetector/internal
 	name = "internal motion detector"
 	detector_range = 7 //yeah no offscreen bs with this
@@ -165,7 +180,10 @@
 	name = "camouflaged R-1NG bell tower"
 	desc = "A tactical advanced version of a normal alarm. Designed to trigger an old instinct ingrained in humans when they hear a wake-up alarm, for fast response. This one is camouflaged and reinforced."
 	handheld_type = /obj/item/defenses/handheld/bell_tower/cloaker
-	var/cloak_alpha = BELL_TOWER_CLOAKER_ALPHA
+	var/cloak_alpha_max = BELL_TOWER_CLOAKER_ALPHA
+	var/cloak_alpha_current = BELL_TOWER_CLOAKER_ALPHA
+	var/incremental_ring_camo_penalty = 70
+	var/camouflage_break = 5 SECONDS
 	density = FALSE
 	health = 250
 	health_max = 250
@@ -173,9 +191,25 @@
 
 /obj/structure/machinery/defenses/bell_tower/cloaker/Initialize()
 	. = ..()
-	animate(src, alpha = cloak_alpha, time = 2 SECONDS, easing = LINEAR_EASING)
+	// Makes it so that the bell tower starts cloaked when deployed
+	// animate(src, alpha = cloak_alpha, time = 2 SECONDS, easing = LINEAR_EASING)
 
+/obj/structure/machinery/defenses/bell_tower/cloaker/proc/cloaker_fade_in()
+	// This is activated whenever the bell is rang, makes the cloaked tower visible a bit
+	var/obj/structure/machinery/defenses/bell_tower/cloaker/cloakebelltower = src
+	if(turned_on)
+		if(cloak_alpha_current < cloak_alpha_max)
+			cloak_alpha_current = cloak_alpha_max
+		cloak_alpha_current = Clamp(cloak_alpha_current + incremental_ring_camo_penalty, cloak_alpha_max, 255)
+		cloakebelltower.alpha = cloak_alpha_current
+		addtimer(CALLBACK(src, .proc/cloaker_fade_out_finish, cloakebelltower), camouflage_break, TIMER_OVERRIDE|TIMER_UNIQUE)
+		animate(cloakebelltower, alpha = cloak_alpha_max, time = camouflage_break, easing = LINEAR_EASING, flags = ANIMATION_END_NOW)
 
+/obj/structure/machinery/defenses/bell_tower/cloaker/proc/cloaker_fade_out_finish()
+	// Resets the cloak to its max invisibility
+	if(turned_on)
+		animate(src, alpha = cloak_alpha_max)
+		cloak_alpha_current = cloak_alpha_max
 
 /obj/item/storage/backpack/imp
 	name = "IMP frame mount"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Part 2 of this PR https://github.com/cmss13-devs/cmss13/pull/397

Changes how the cloaked bell starts, it no longer starts cloaked but it activates the cloak when turned on. Also added a mechanic similar to the sniper spec when it shoots, for the cloaked bell, it becomes more visible when it rings a xeno.

Demo:
https://user-images.githubusercontent.com/67372229/177027185-bf70f845-baa6-41dd-ae60-b7f99675c2b5.mp4

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
With the added sound, it is still hard to notice because of how transparent it is, it takes awhile before the xeno can find it due to the range of the bell. The bell turret still deadly with the slow, but on the downside is that it becomes slightly visible when it rings a xeno, giving them a chance to notice it. The turret is meant to ambush the backline xenos, this will force engineers to move the turret around to encourage the idea this is used as an "ambush" tool. 

The cloak on and off feature I think just makes it look better, doesn't make sense the turret starts cloaked anyway

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Cloaked bell doesnt start cloaked anymore, it slowly becomes invisible when its turned on and instantly visible when turned off
balance: Cloaked bell becomes slightly more visible when it rings, more xenos around it means more ring and more visible
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
