### PR TITLE
Hotfix

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -148,7 +148,7 @@
 
 	updatehealth()
 
-	if(stat == CONSCIOUS)
+	if(health > 0)	//alive and not in crit! Turn on their vision.
 		see_in_dark = 50
 
 		SetEarDeafness(0) //All this stuff is prob unnecessary


### PR DESCRIPTION
## About The Pull Request

Update health check changed the condition on which regular checks were applying "normal" state of xeno which has health, leading to them unable to un-stun, once they hit unconscious state.

## Why It's Good For The Game

Hotfix
