### PR TITLE
[Balance] Ignited carbon humans take variable damage based on fire reagent now

### DIFF
--- a/code/__DEFINES/weapon_stats.dm
+++ b/code/__DEFINES/weapon_stats.dm
@@ -317,3 +317,5 @@ Fire Variant = Markers for special fire types that behave outside of chemfire co
 #define FIRE_VARIANT_DEFAULT 0
 ///"Type B" Armor Shredding Greenfire: Burn Time T5, Burn Level T2, Slows on Tile, Increased Tile Damage, Easier Extinguishing.
 #define FIRE_VARIANT_TYPE_B 1
+// Lowers burn damage to humans
+#define HUMAN_BURN_DIVIDER 5

--- a/code/modules/mob/living/carbon/human/life/handle_fire.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_fire.dm
@@ -12,5 +12,5 @@
 	if((1 - thermal_protection) > 0.0001)
 		bodytemperature += BODYTEMP_HEATING_MAX
 		recalculate_move_delay = TRUE
-		var/dmg = armor_damage_reduction(GLOB.marine_fire, fire_reagent.burn_level / HUMAN_BURN_DIVIDER)
+		var/dmg = armor_damage_reduction(GLOB.marine_fire, fire_reagent.intensityfire / HUMAN_BURN_DIVIDER)
 		apply_damage(dmg, BURN)

--- a/code/modules/mob/living/carbon/human/life/handle_fire.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_fire.dm
@@ -12,5 +12,5 @@
 	if((1 - thermal_protection) > 0.0001)
 		bodytemperature += BODYTEMP_HEATING_MAX
 		recalculate_move_delay = TRUE
-		var/dmg = armor_damage_reduction(GLOB.marine_fire, R.burn_level / HUMAN_BURN_DIVIDER)
+		var/dmg = armor_damage_reduction(GLOB.marine_fire, fire_reagent.burn_level / HUMAN_BURN_DIVIDER)
 		apply_damage(dmg, BURN)

--- a/code/modules/mob/living/carbon/human/life/handle_fire.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_fire.dm
@@ -12,5 +12,5 @@
 	if((1 - thermal_protection) > 0.0001)
 		bodytemperature += BODYTEMP_HEATING_MAX
 		recalculate_move_delay = TRUE
-		var/dmg = armor_damage_reduction(GLOB.marine_fire, 5)
+		var/dmg = armor_damage_reduction(GLOB.marine_fire, R.burn_level / HUMAN_BURN_DIVIDER)
 		apply_damage(dmg, BURN)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Changes the flat magic number of 5 damage per second from fire to depend on the fire type.

Previously:
Carbon humans took a flat 5 burn damage while they were on fire no matter the reagent

Now:
Carbon humans take damage based on the fire reagent:
Welder Fire ( mini-flamer): 2 dps ( much much less dangerous, feel free to use this more )
Napalm B-Gel (Green fire):  3 dps ( much less dangerous now )
UT-Napthal Fuel (Orange fire): 6 dps ( slightly more dangerous now)
Napalm X (Blue fire): 8 dps ( more dangerous now!!! )
Incidendary OB ( white fire): 14 dps (MUCH MUCH MORE DANGEROUS NOW. DO NOT WALK IN)

I still use the magic number 5 as a divider of damage due to how otherwise flames would be too dangerous for carbon humans
(5 was the only number that would nicely divide into all the burn levels which are seperated by 5 ).

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Rejoice marines, you can run into green fire, pull a burnt marine without suffering as much damage as you would previously.

Also, I hate magic numbers considering we have an actual working flamer reagent system in the game and this just hasn't been updated. Flamer system doesn't really get a lot of love anymore.

Plus buffs pyros for HvH when using better flame reagents.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: TeDGamer
balance: Fire damage dealt to carbon humans on fire is based on the fire reagent.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
