### PR TITLE
Brig Courtyard piping fix

### DIFF
--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -58756,13 +58756,6 @@
 /area/almayer/squads/charlie_delta_shared)
 "nhG" = (
 /obj/structure/surface/table/almayer,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4;
-	tag = "icon-intact-supply (EAST)"
-	},
 /obj/item/newspaper{
 	name = "character sheet"
 	},
@@ -80744,13 +80737,6 @@
 /area/almayer/squads/charlie_delta_shared)
 "xaM" = (
 /obj/structure/surface/table/almayer,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4;
-	tag = "icon-intact-supply (EAST)"
-	},
 /obj/item/newspaper{
 	name = "character sheet";
 	pixel_x = -6


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Fixes a mapping mistake in the Brig Courtyard which caused the garbage bin use the wrong pipes, removed the unecessary pipes and even air pipes (for some reason there were two gas pipes there not connected to anything)

## Why It's Good For The Game

its a bug fix so good. also my contributor social credits go up

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Unknownity
fix: The garbage bin in the Brig Courtyard now actually uses the correct disposal pipes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
