### PR TITLE
m4a3 nerf

### DIFF
--- a/code/modules/projectiles/magazines/pistols.dm
+++ b/code/modules/projectiles/magazines/pistols.dm
@@ -9,7 +9,7 @@
 	icon_state = "m4a3"
 	max_rounds = 9
 	w_class = SIZE_SMALL
-	default_ammo = /datum/ammo/bullet/pistol/heavy
+	default_ammo = /datum/ammo/bullet/pistol
 	gun_type = /obj/item/weapon/gun/pistol/m4a3
 
 /obj/item/ammo_magazine/pistol/hp


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

m4a3 mags now use regular pistol bullets not heavy pistol bullets

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

m4a3 undeniably overperforms with its very high firerate - dual m4a3s especially so. This is not helped by the higher damage and AP of its normal ammo, which makes it especially good at shredding lower health t1s and t2s. As such it's nerf time. This has also been an issue for quite a while - thanks to tisx for posting a lot of videos that helped me see this.

:cl:
balance: nerfed the damage, ap, and shrapnel chance of standard m4a3 ammo by changing it to standard pistol ammo from heavy pistol ammo
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
