### PR TITLE
m2c far vision nerf (standing still like a zombie nerfs part 1)

### DIFF
--- a/code/game/machinery/vending/vendor_types/squad_prep/squad_engineer.dm
+++ b/code/game/machinery/vending/vendor_types/squad_prep/squad_engineer.dm
@@ -53,7 +53,6 @@ GLOBAL_LIST_INIT(cm_vending_gear_engi, list(
 		list("M41AE2 Heavy Pulse Rifle", 18, /obj/item/storage/box/guncase/lmg, null, VENDOR_ITEM_REGULAR),
 		list("M79 Grenade Launcher", 24, /obj/item/storage/box/guncase/m79, null, VENDOR_ITEM_REGULAR),
 		list("M56D Heavy Machine Gun", 24, /obj/item/storage/box/guncase/m56d, null, VENDOR_ITEM_REGULAR),
-		list("M2C Heavy Machine Gun", 24, /obj/item/storage/box/guncase/m2c, null, VENDOR_ITEM_REGULAR),
 
 		list("UTILITIES", 0, null, null, null),
 		list("SensorMate Medical HUD", 12, /obj/item/clothing/glasses/hud/sensor, null, VENDOR_ITEM_REGULAR),

--- a/code/modules/cm_marines/smartgun_mount.dm
+++ b/code/modules/cm_marines/smartgun_mount.dm
@@ -1457,7 +1457,7 @@
 		var/diff_x = 0
 		var/diff_y = 0
 		var/tilesize = 32
-		var/viewoffset = tilesize * 5
+		var/viewoffset = tilesize * 1
 
 		user.reset_view(src)
 		if(dir == EAST)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

removes vision extension from the m2c by reducing it to 1 tile

regards to the title, standing still like a zombie nerfs will be a series of nerfs/rebalances to marine guns (primarily the m2c, m56d, and HPR) that will make standing still like a zombie and right clicking anything that comes on your screen less of an effective playstyle

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

this goes against the m2cs design - being able to see far ahead of your gun totally defeats its purpose as a mobile flanking weapon and encourages the "sit outside a choke and shit out bullets at people" playstyle which leads to boring, unfun choke focussed gameplay that both marines and xenos hate yet still participate in because given the opportunity, players will optimise the fun out of a game.

as for the engi vendor removal, this is a gun HEAVILY balanced around rarity and it being primarily used by frontliners/flanker PFCs. Engineers should not be able to buy tons of them.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: your vision is no longer extended by 5 tiles when you man an m2c
balance: removed the m2c from engineer vendors
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
