### PR TITLE
[Bugfix/QOL] Allows hive core repair again, Prevent XvX quick core destruction, Allow for core repair on "undamaged" core that lost health

### DIFF
--- a/code/modules/cm_aliens/structures/special/hive_cluster.dm
+++ b/code/modules/cm_aliens/structures/special/hive_cluster.dm
@@ -38,13 +38,14 @@
 /obj/effect/alien/resin/special/cluster/proc/do_repair(mob/living/carbon/Xenomorph/M)
 	if(!istype(M))
 		return
-	if(!damaged && health >= maxhealth)
+	var/can_repair = damaged || health < maxhealth
+	if(!can_repair)
 		to_chat(M, SPAN_XENONOTICE("\The [name] is in good condition, you don't need to repair it."))
 		return
 
 	to_chat(M, SPAN_XENONOTICE("You begin adding the plasma to \the [name] to repair it."))
 	xeno_attack_delay(M)
-	if(!do_after(M, CLUSTER_REPAIR_TIME, INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD, src) || !damaged)
+	if(!do_after(M, CLUSTER_REPAIR_TIME, INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD, src) || !can_repair)
 		return
 
 	var/amount_to_use = min(M.plasma_stored, (plasma_required_to_repair - plasma_stored))

--- a/code/modules/cm_aliens/structures/special/hive_cluster.dm
+++ b/code/modules/cm_aliens/structures/special/hive_cluster.dm
@@ -38,7 +38,7 @@
 /obj/effect/alien/resin/special/cluster/proc/do_repair(mob/living/carbon/Xenomorph/M)
 	if(!istype(M))
 		return
-	if(!damaged)
+	if(!damaged && health >= maxhealth)
 		to_chat(M, SPAN_XENONOTICE("\The [name] is in good condition, you don't need to repair it."))
 		return
 

--- a/code/modules/cm_aliens/structures/special/pylon_core.dm
+++ b/code/modules/cm_aliens/structures/special/pylon_core.dm
@@ -47,7 +47,7 @@
 /obj/effect/alien/resin/special/pylon/proc/do_repair(mob/living/carbon/Xenomorph/M)
 	if(!istype(M))
 		return
-	if(!damaged)
+	if(!damaged && health >= maxhealth)
 		to_chat(M, SPAN_XENONOTICE("\The [name] is in good condition, you don't need to repair it."))
 		return
 

--- a/code/modules/cm_aliens/structures/special/pylon_core.dm
+++ b/code/modules/cm_aliens/structures/special/pylon_core.dm
@@ -47,13 +47,14 @@
 /obj/effect/alien/resin/special/pylon/proc/do_repair(mob/living/carbon/Xenomorph/M)
 	if(!istype(M))
 		return
-	if(!damaged && health >= maxhealth)
+	var/can_repair = damaged || health < maxhealth
+	if(!can_repair)
 		to_chat(M, SPAN_XENONOTICE("\The [name] is in good condition, you don't need to repair it."))
 		return
 
 	to_chat(M, SPAN_XENONOTICE("You begin adding the plasma to \the [name] to repair it."))
 	xeno_attack_delay(M)
-	if(!do_after(M, PYLON_REPAIR_TIME, INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD, src) || !damaged)
+	if(!do_after(M, PYLON_REPAIR_TIME, INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD, src) || !can_repair)
 		return
 
 	var/amount_to_use = min(M.plasma_stored, (plasma_required_to_repair - plasma_stored))

--- a/code/modules/cm_aliens/structures/special/pylon_core.dm
+++ b/code/modules/cm_aliens/structures/special/pylon_core.dm
@@ -121,25 +121,24 @@
 
 
 /obj/effect/alien/resin/special/pylon/core/attack_alien(mob/living/carbon/Xenomorph/M)
-	if(M.a_intent != INTENT_HARM || !M.can_destroy_special())
-		return
-	if(!hardcore && last_attempt + 6 SECONDS > world.time)
-		to_chat(M,SPAN_WARNING("You have attempted to destroy \the [src] too recently! Wait a bit!")) // no spammy
-		return XENO_NO_DELAY_ACTION
-
-	else if(warn && world.time > HIVECORE_COOLDOWN_CUTOFF)
-		if((alert(M, "Are you sure that you want to destroy the hive core? (There will be a 5 minute cooldown before you can build another one.)", , "Yes", "No") == "No"))
+	if(M.a_intent == INTENT_HARM && M.can_destroy_special())
+		if(!hardcore && last_attempt + 6 SECONDS > world.time)
+			to_chat(M,SPAN_WARNING("You have attempted to destroy \the [src] too recently! Wait a bit!")) // no spammy
 			return XENO_NO_DELAY_ACTION
 
-		INVOKE_ASYNC(src, .proc/startDestroying,M)
-		return XENO_NO_DELAY_ACTION
+		else if(warn && world.time > HIVECORE_COOLDOWN_CUTOFF)
+			if((alert(M, "Are you sure that you want to destroy the hive core? (There will be a 5 minute cooldown before you can build another one.)", , "Yes", "No") == "No"))
+				return XENO_NO_DELAY_ACTION
 
-	else if(world.time < HIVECORE_COOLDOWN_CUTOFF)
-		if((alert(M, "Are you sure that you want to remove the hive core? No cooldown will be applied.", , "Yes", "No") == "No"))
+			INVOKE_ASYNC(src, .proc/startDestroying,M)
 			return XENO_NO_DELAY_ACTION
 
-		INVOKE_ASYNC(src, .proc/startDestroying,M)
-		return XENO_NO_DELAY_ACTION
+		else if(world.time < HIVECORE_COOLDOWN_CUTOFF)
+			if((alert(M, "Are you sure that you want to remove the hive core? No cooldown will be applied.", , "Yes", "No") == "No"))
+				return XENO_NO_DELAY_ACTION
+
+			INVOKE_ASYNC(src, .proc/startDestroying,M)
+			return XENO_NO_DELAY_ACTION
 
 	if(linked_hive)
 		var/current_health = health

--- a/code/modules/cm_aliens/structures/special/pylon_core.dm
+++ b/code/modules/cm_aliens/structures/special/pylon_core.dm
@@ -121,7 +121,7 @@
 
 
 /obj/effect/alien/resin/special/pylon/core/attack_alien(mob/living/carbon/Xenomorph/M)
-	if(M.a_intent == INTENT_HARM && M.can_destroy_special())
+	if(M.a_intent == INTENT_HARM && M.can_destroy_special() && M.hivenumber == linked_hive.hivenumber)
 		if(!hardcore && last_attempt + 6 SECONDS > world.time)
 			to_chat(M,SPAN_WARNING("You have attempted to destroy \the [src] too recently! Wait a bit!")) // no spammy
 			return XENO_NO_DELAY_ACTION


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Core can be repaired again. It was due to the early return that it never called it super function.

Core can only be destroyed with windup by the same hive member. Other hive xenos should still be able to destroy the core albiet with slashing as before instead of new wind up destruction.

Core and clusters can now be repaired when health is less than max outside of being damaged.
A core / cluster is only considered damaged when a weed tile is destroyed ( so even with no health loss you can repair it).
Since repairing repairs the health, I thought it makes sense to make it so if the health is also less than max, you should be able to repair it as well.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bug fixing for allowing xenos to repair core again. 

Bug fixing also to make sure only the same hive member can destroy the core to prevent XvX quick core destruction. Doesn't affect the slow clawing, just the new destruction of core mechanic that uses a simple wind up.

QOL change to allow core to be fixed when health is less than max and not just when one weed tile is removed ( which is when damaged is set to true ). 


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: TeDGamer
fix: Hive core can be repaired again
fix: Xenos must be in the same hive to destroy the core quickly
qol: Hive core and cluster can be repaired when health is less than max
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
