### PR TITLE
bugfix check if mob is synth when on fire

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -48,7 +48,7 @@
 			if(!stat && getToxLoss() >= 45 && nutrition > 20)
 				vomit()
 
-			if(on_fire)
+			if(on_fire && !isSynth(src))
 				INVOKE_ASYNC(src, /mob.proc/emote, pick("pain", "scream"))
 
 			//effects of being grabbed aggressively by another mob


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Stops synths from screaming, including whiteout, when on fire

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Synths dont feel pain, why are they screaming, HELLO GEEVES, THANKS FOR THE FREE GBP

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Synth type of mob no longer scream repeatedly when on fire
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
