### PR TITLE
CO minimum age change

### DIFF
--- a/code/modules/gear_presets/uscm_ship.dm
+++ b/code/modules/gear_presets/uscm_ship.dm
@@ -298,7 +298,7 @@
 	rank = JOB_CO
 	paygrade = "MO4"
 	role_comm_title = "CO"
-	minimum_age = 40
+	minimum_age = 30
 	skills = /datum/skills/commander
 
 	utility_under = list(/obj/item/clothing/under/marine,/obj/item/clothing/under/marine/officer/command)
@@ -367,7 +367,7 @@
 	rank = JOB_CO
 	paygrade = "MO5"
 	role_comm_title = "CO"
-	minimum_age = 45
+	minimum_age = 35
 
 /datum/equipment_preset/uscm_ship/commander/commodore/load_gear(mob/living/carbon/human/H)
 	H.equip_to_slot_or_del(new /obj/item/clothing/under/marine/officer/bridge(H), WEAR_BODY)


### PR DESCRIPTION

## About The Pull Request

Reduces minimum age for COs after rank rework. Signed off by CO Senator.

## Why It's Good For The Game

RP good.

## Changelog

:cl: Morrow
add: Changes CO minimum ages from O4/5 40/45 to 30/35.
/:cl:
