### PR TITLE
HoT Healer

### DIFF
--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -600,12 +600,17 @@ proc/sort_atoms_by_layer(var/list/atoms)
 		A.overlays.Remove(src)
 
 /mob/proc/flick_heal_overlay(time, color = "#00FF00") //used for warden and queen healing
-    var/image/I = new('icons/mob/mob.dmi', src, "heal_overlay")
-    I.layer = FLY_LAYER
-    I.appearance_flags = RESET_COLOR
+	var/image/I = image('icons/mob/mob.dmi', src, "heal_overlay")
+	switch(icon_size)
+		if(48)
+			I.pixel_x = 8
+		if(64)
+			I.pixel_x = 16
+	I.layer = FLY_LAYER
+	I.appearance_flags = RESET_COLOR
 
-    I.color = color
-    I.flick_overlay(src, time)
+	I.color = color
+	I.flick_overlay(src, time)
 
 /proc/icon2html(thing, target, icon_state, dir = SOUTH, frame = 1, moving = FALSE, sourceonly = FALSE)
 	if (!thing)

--- a/code/datums/effects/heal_over_time.dm
+++ b/code/datums/effects/heal_over_time.dm
@@ -29,5 +29,6 @@
 
 	var/mob/living/carbon/Xenomorph/affected_mob = affected_atom
 	affected_mob.gain_health(heal_each_process)
+	affected_mob.updatehealth()
 
 	return TRUE

--- a/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
@@ -49,7 +49,7 @@
 	rebounds = TRUE
 	faction = FACTION_XENOMORPH
 	gender = NEUTER
-	var/icon_size = 48
+	icon_size = 48
 	var/obj/item/clothing/suit/wear_suit = null
 	var/obj/item/clothing/head/head = null
 	var/obj/item/r_store = null

--- a/code/modules/mob/living/carbon/xenomorph/mutators/strains/drone/healer.dm
+++ b/code/modules/mob/living/carbon/xenomorph/mutators/strains/drone/healer.dm
@@ -77,20 +77,20 @@
 	if(!check_state())
 		return
 
-	if(target.stat == DEAD)
-		to_chat(src, SPAN_WARNING("[target] is already dead!"))
-		return
-
-	if(target.health >= target.maxHealth)
-		to_chat(src, SPAN_WARNING("\The [target] is already at max health!"))
-		return
-
 	if(!isturf(loc))
 		to_chat(src, SPAN_WARNING("You can't transfer health from here!"))
 		return
 
 	if(get_dist(src, target) > max_range)
 		to_chat(src, SPAN_WARNING("You need to be closer to [target]."))
+		return
+
+	if(target.stat == DEAD)
+		to_chat(src, SPAN_WARNING("[target] is already dead!"))
+		return
+
+	if(target.health >= target.maxHealth)
+		to_chat(src, SPAN_WARNING("\The [target] is already at max health!"))
 		return
 
 	if(health <= 0)

--- a/code/modules/mob/living/carbon/xenomorph/mutators/strains/drone/healer.dm
+++ b/code/modules/mob/living/carbon/xenomorph/mutators/strains/drone/healer.dm
@@ -47,9 +47,8 @@
 	name = "Transfer Health"
 	action_icon_state = "transfer_health"
 	ability_name = "transfer health"
-	var/health_transfer_amount = 30
-	var/transfer_delay = 2.5 SECONDS
-	var/max_range = 2
+	var/health_transfer_amount = 100
+	var/max_range = 1
 	var/self_health_drain_mod = 1.2
 	macro_path = /datum/action/xeno_action/verb/verb_transfer_health
 	action_type = XENO_ACTION_CLICK
@@ -57,7 +56,7 @@
 
 /datum/action/xeno_action/activable/transfer_health/use_ability(atom/A)
 	var/mob/living/carbon/Xenomorph/X = owner
-	X.xeno_transfer_health(A, health_transfer_amount, transfer_delay, max_range, self_health_drain_mod)
+	X.xeno_transfer_health(A, health_transfer_amount, max_range, self_health_drain_mod)
 	..()
 
 /datum/action/xeno_action/verb/verb_transfer_health()
@@ -67,7 +66,7 @@
 	var/action_name = "Transfer Health"
 	handle_xeno_macro(src, action_name)
 
-/mob/living/carbon/Xenomorph/proc/xeno_transfer_health(mob/living/carbon/Xenomorph/target, amount = 30, transfer_delay = 2.5 SECONDS, max_range = 2, damage_taken_mod = 1.2)
+/mob/living/carbon/Xenomorph/proc/xeno_transfer_health(mob/living/carbon/Xenomorph/target, amount = 100, max_range = 1, damage_taken_mod = 1.2)
 	if(!istype(target))
 		return
 
@@ -98,38 +97,11 @@
 		to_chat(src, SPAN_WARNING("You have no health left to give!"))
 		return
 
-	to_chat(src, SPAN_NOTICE("You start transfering some of your health towards [target]."))
-	to_chat(target, SPAN_NOTICE("You feel that [src] starts transferring some of their health to you."))
-	if(!do_after(src, transfer_delay, INTERRUPT_ALL, BUSY_ICON_FRIENDLY, target, INTERRUPT_MOVED, BUSY_ICON_MEDICAL, numticks = 10))
-		return
-
-	if(!check_state())
-		return
-
-	if(target.stat == DEAD)
-		to_chat(src, SPAN_WARNING("[target] is already dead!"))
-		return
-
-	if(target.health >= target.maxHealth)
-		to_chat(src, SPAN_WARNING("\The [target] is already at max health!"))
-		return
-
-	if(!isturf(loc))
-		to_chat(src, SPAN_WARNING("You can't transfer health from here!"))
-		return
-
-	if(get_dist(src, target) > max_range)
-		to_chat(src, SPAN_WARNING("You need to be closer to [target]."))
-		return
-
-	if(health <= 0)
-		to_chat(src, SPAN_WARNING("You have no health left to give!"))
-		return
-
 	adjustBruteLoss(amount * damage_taken_mod)
 	updatehealth()
-	target.gain_health(amount)
-	target.updatehealth()
+	new /datum/effects/heal_over_time(target, amount, 10, 2)
+	target.xeno_jitter(1 SECONDS)
+	target.flick_heal_overlay(10 SECONDS, "#00be6f")
 	to_chat(target, SPAN_XENOWARNING("\The [src] has transfered some of their health to you. You feel reinvigorated!"))
 	to_chat(src, SPAN_XENOWARNING("You have transferred some of your health to \the [target]. You feel weakened..."))
 	playsound(src, "alien_drool", 25)

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -6,6 +6,8 @@
 	var/mob_flags = NO_FLAGS
 	var/datum/mind/mind
 
+	var/icon_size = 32
+
 	// An ID that uniquely identifies this mob through the full round
 	var/gid = 0
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Healer drones now apply healing instantly, but the range has been dropped to touching range again. The healing effect takes 10 seconds, providing the target with 20 health every 2 seconds. This effect can be stacked.

Additionally, heal overlays now properly align with the xeno sprite.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The current way healer drones have to channel before delivering the healing makes it an extremely static role, this should make it more dynamic and fun as you can do drive-by heals. The amount of heals you can deliver is limited by the massive amount of damage you take providing them.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Healer drones now apply healing instantly, but the range has been dropped to touching range again. The healing effect takes 10 seconds, providing the target with 20 health every 2 seconds. This effect can be stacked.
fix: Health overlays now properly align with xeno sprites.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
