### PR TITLE
Autoturf Fix

### DIFF
--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -29,37 +29,48 @@
 		auto_turf_dirs["[direction]"] = T
 
 	var/list/handled_dirs = list()
+	var/list/unhandled_diagonals = list()
 	for(var/direction in diagonals)
-		var/x_dir = direction & (direction-1) // X-component if fdir diagonal, 0 otherwise
-		var/y_dir = direction - x_dir // Y-component if fdir diagonal, fdir otherwise
+		var/x_dir = direction & (direction-1)
+		var/y_dir = direction - x_dir
 
 		if(!("[direction]" in auto_turf_dirs))
-			if(("[x_dir]" in auto_turf_dirs) && !("[x_dir]" in handled_dirs))
-				var/turf/open/auto_turf/x_turf = auto_turf_dirs["[x_dir]"]
-				var/special_icon_state = "[x_turf.icon_prefix]_[pick("innercorner", "outercorner")]"
-				var/image/I = image(x_turf.icon, special_icon_state, dir = REVERSE_DIR(x_dir), layer = layer + 0.001 + x_turf.bleed_layer * 0.0001)
-				I.appearance_flags = RESET_TRANSFORM|RESET_ALPHA|RESET_COLOR
-				overlays += I
-				handled_dirs += x_dir
-			if(("[y_dir]" in auto_turf_dirs) && !("[y_dir]" in handled_dirs))
-				var/turf/open/auto_turf/y_turf = auto_turf_dirs["[y_dir]"]
-				var/special_icon_state = "[y_turf.icon_prefix]_[pick("innercorner", "outercorner")]"
-				var/image/I = image(y_turf.icon, special_icon_state, dir = REVERSE_DIR(y_dir), layer = layer + 0.001 + y_turf.bleed_layer * 0.0001)
-				I.appearance_flags = RESET_TRANSFORM|RESET_ALPHA|RESET_COLOR
-				overlays += I
-				handled_dirs += y_dir
+			unhandled_diagonals += direction
 			continue
+
 		var/turf/open/auto_turf/xy_turf = auto_turf_dirs["[direction]"]
 		if(("[x_dir]" in auto_turf_dirs) && ("[y_dir]" in auto_turf_dirs))
 			var/special_icon_state = "[xy_turf.icon_prefix]_innercorner"
 			var/image/I = image(xy_turf.icon, special_icon_state, dir = REVERSE_DIR(direction), layer = layer + 0.001 + xy_turf.bleed_layer * 0.0001)
 			I.appearance_flags = RESET_TRANSFORM|RESET_ALPHA|RESET_COLOR
 			overlays += I
+			handled_dirs += "[x_dir]"
+			handled_dirs += "[y_dir]"
 			continue
+
 		var/special_icon_state = "[xy_turf.icon_prefix]_outercorner"
 		var/image/I = image(xy_turf.icon, special_icon_state, dir = REVERSE_DIR(direction), layer = layer + 0.001 + xy_turf.bleed_layer * 0.0001)
 		I.appearance_flags = RESET_TRANSFORM|RESET_ALPHA|RESET_COLOR
 		overlays += I
+
+	for(var/direction in unhandled_diagonals)
+		var/x_dir = direction & (direction-1)
+		var/y_dir = direction - x_dir
+
+		if(("[x_dir]" in auto_turf_dirs) && !("[x_dir]" in handled_dirs))
+			var/turf/open/auto_turf/x_turf = auto_turf_dirs["[x_dir]"]
+			var/special_icon_state = "[x_turf.icon_prefix]_[pick("innercorner", "outercorner")]"
+			var/image/I = image(x_turf.icon, special_icon_state, dir = REVERSE_DIR(x_dir), layer = layer + 0.001 + x_turf.bleed_layer * 0.0001)
+			I.appearance_flags = RESET_TRANSFORM|RESET_ALPHA|RESET_COLOR
+			overlays += I
+			handled_dirs += "[x_dir]"
+		if(("[y_dir]" in auto_turf_dirs) && !("[y_dir]" in handled_dirs))
+			var/turf/open/auto_turf/y_turf = auto_turf_dirs["[y_dir]"]
+			var/special_icon_state = "[y_turf.icon_prefix]_[pick("innercorner", "outercorner")]"
+			var/image/I = image(y_turf.icon, special_icon_state, dir = REVERSE_DIR(y_dir), layer = layer + 0.001 + y_turf.bleed_layer * 0.0001)
+			I.appearance_flags = RESET_TRANSFORM|RESET_ALPHA|RESET_COLOR
+			overlays += I
+			handled_dirs += "[y_dir]"
 
 
 /turf/open/examine(mob/user)

--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -29,13 +29,14 @@
 		auto_turf_dirs["[direction]"] = T
 
 	var/list/handled_dirs = list()
-	var/list/unhandled_diagonals = list()
+	var/list/unhandled_dirs = list()
 	for(var/direction in diagonals)
 		var/x_dir = direction & (direction-1)
 		var/y_dir = direction - x_dir
 
 		if(!("[direction]" in auto_turf_dirs))
-			unhandled_diagonals += direction
+			unhandled_dirs |= x_dir
+			unhandled_dirs |= y_dir
 			continue
 
 		var/turf/open/auto_turf/xy_turf = auto_turf_dirs["[direction]"]
@@ -52,25 +53,16 @@
 		var/image/I = image(xy_turf.icon, special_icon_state, dir = REVERSE_DIR(direction), layer = layer + 0.001 + xy_turf.bleed_layer * 0.0001)
 		I.appearance_flags = RESET_TRANSFORM|RESET_ALPHA|RESET_COLOR
 		overlays += I
+		unhandled_dirs |= x_dir
+		unhandled_dirs |= y_dir
 
-	for(var/direction in unhandled_diagonals)
-		var/x_dir = direction & (direction-1)
-		var/y_dir = direction - x_dir
-
-		if(("[x_dir]" in auto_turf_dirs) && !("[x_dir]" in handled_dirs))
-			var/turf/open/auto_turf/x_turf = auto_turf_dirs["[x_dir]"]
-			var/special_icon_state = "[x_turf.icon_prefix]_[pick("innercorner", "outercorner")]"
-			var/image/I = image(x_turf.icon, special_icon_state, dir = REVERSE_DIR(x_dir), layer = layer + 0.001 + x_turf.bleed_layer * 0.0001)
+	for(var/direction in unhandled_dirs)
+		if(("[direction]" in auto_turf_dirs) && !("[direction]" in handled_dirs))
+			var/turf/open/auto_turf/turf = auto_turf_dirs["[direction]"]
+			var/special_icon_state = "[turf.icon_prefix]_[pick("innercorner", "outercorner")]"
+			var/image/I = image(turf.icon, special_icon_state, dir = REVERSE_DIR(direction), layer = layer + 0.001 + turf.bleed_layer * 0.0001)
 			I.appearance_flags = RESET_TRANSFORM|RESET_ALPHA|RESET_COLOR
 			overlays += I
-			handled_dirs += "[x_dir]"
-		if(("[y_dir]" in auto_turf_dirs) && !("[y_dir]" in handled_dirs))
-			var/turf/open/auto_turf/y_turf = auto_turf_dirs["[y_dir]"]
-			var/special_icon_state = "[y_turf.icon_prefix]_[pick("innercorner", "outercorner")]"
-			var/image/I = image(y_turf.icon, special_icon_state, dir = REVERSE_DIR(y_dir), layer = layer + 0.001 + y_turf.bleed_layer * 0.0001)
-			I.appearance_flags = RESET_TRANSFORM|RESET_ALPHA|RESET_COLOR
-			overlays += I
-			handled_dirs += "[y_dir]"
 
 
 /turf/open/examine(mob/user)

--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -17,19 +17,50 @@
 
 	add_cleanable_overlays()
 
+	var/list/turf/open/auto_turf/auto_turf_dirs = list()
 	for(var/direction in alldirs)
 		var/turf/open/auto_turf/T = get_step(src, direction)
 		if(!istype(T))
 			continue
 
-		if(bleed_layer > T.bleed_layer || bleed_layer == T.bleed_layer)
+		if(bleed_layer >= T.bleed_layer)
 			continue
 
-		var/special_icon_state = "[T.icon_prefix]_[(direction & (direction-1)) ? "outercorner" : pick("innercorner", "outercorner")]"
-		var/image/I = image(T.icon, special_icon_state, dir = REVERSE_DIR(direction), layer = layer + 0.001 + T.bleed_layer * 0.0001)
-		I.appearance_flags = RESET_TRANSFORM|RESET_ALPHA|RESET_COLOR
+		auto_turf_dirs["[direction]"] = T
 
+	var/list/handled_dirs = list()
+	for(var/direction in diagonals)
+		var/x_dir = direction & (direction-1) // X-component if fdir diagonal, 0 otherwise
+		var/y_dir = direction - x_dir // Y-component if fdir diagonal, fdir otherwise
+
+		if(!("[direction]" in auto_turf_dirs))
+			if(("[x_dir]" in auto_turf_dirs) && !("[x_dir]" in handled_dirs))
+				var/turf/open/auto_turf/x_turf = auto_turf_dirs["[x_dir]"]
+				var/special_icon_state = "[x_turf.icon_prefix]_[pick("innercorner", "outercorner")]"
+				var/image/I = image(x_turf.icon, special_icon_state, dir = REVERSE_DIR(x_dir), layer = layer + 0.001 + x_turf.bleed_layer * 0.0001)
+				I.appearance_flags = RESET_TRANSFORM|RESET_ALPHA|RESET_COLOR
+				overlays += I
+				handled_dirs += x_dir
+			if(("[y_dir]" in auto_turf_dirs) && !("[y_dir]" in handled_dirs))
+				var/turf/open/auto_turf/y_turf = auto_turf_dirs["[y_dir]"]
+				var/special_icon_state = "[y_turf.icon_prefix]_[pick("innercorner", "outercorner")]"
+				var/image/I = image(y_turf.icon, special_icon_state, dir = REVERSE_DIR(y_dir), layer = layer + 0.001 + y_turf.bleed_layer * 0.0001)
+				I.appearance_flags = RESET_TRANSFORM|RESET_ALPHA|RESET_COLOR
+				overlays += I
+				handled_dirs += y_dir
+			continue
+		var/turf/open/auto_turf/xy_turf = auto_turf_dirs["[direction]"]
+		if(("[x_dir]" in auto_turf_dirs) && ("[y_dir]" in auto_turf_dirs))
+			var/special_icon_state = "[xy_turf.icon_prefix]_innercorner"
+			var/image/I = image(xy_turf.icon, special_icon_state, dir = REVERSE_DIR(direction), layer = layer + 0.001 + xy_turf.bleed_layer * 0.0001)
+			I.appearance_flags = RESET_TRANSFORM|RESET_ALPHA|RESET_COLOR
+			overlays += I
+			continue
+		var/special_icon_state = "[xy_turf.icon_prefix]_outercorner"
+		var/image/I = image(xy_turf.icon, special_icon_state, dir = REVERSE_DIR(direction), layer = layer + 0.001 + xy_turf.bleed_layer * 0.0001)
+		I.appearance_flags = RESET_TRANSFORM|RESET_ALPHA|RESET_COLOR
 		overlays += I
+
 
 /turf/open/examine(mob/user)
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Autoturfs will now properly use their outer and inner corner sprites as the situation necessitates, additionally inner corners will no longer be three overlays, it's condensed down into one. I calculated it and we should have a 32% lag reduction because of this change.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

working autoturfs good

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Auto-turfs now generate their inner and outer corners correctly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
