### PR TITLE
Sandcades are properly non mettalic in code

### DIFF
--- a/code/game/objects/structures/barricade/barricade.dm
+++ b/code/game/objects/structures/barricade/barricade.dm
@@ -357,6 +357,7 @@
 
 /obj/structure/barricade/proc/weld_cade(obj/item/tool/weldingtool/WT, mob/user)
 	if(!metallic)
+		user.visible_message(SPAN_WARNING("You can't weld \the [src]"))
 		return FALSE
 
 	if(!(WT.remove_fuel(2, user)))

--- a/code/game/objects/structures/barricade/sandbags.dm
+++ b/code/game/objects/structures/barricade/sandbags.dm
@@ -14,6 +14,7 @@
 	can_wire = TRUE
 	stack_amount = 1
 	var/build_stage = BARRICADE_SANDBAG_1
+	metallic = FALSE
 
 /obj/structure/barricade/sandbags/New(loc, mob/user, direction, var/amount = 1)
 	if(direction)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Fixes a consistency error and also adds a message that shows if you try to weld a non metallic barricade 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
consistency + bugfix funnies
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: TotalEpicness
fix: Fixes a consistency error and also adds a message that shows if you try to weld a non-metallic barricade.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
