### PR TITLE
Galoshes Slowdown Removal

### DIFF
--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -5,7 +5,7 @@
 	item_state = "brown"
 	permeability_coefficient = 0.05
 	flags_inventory = NOSLIPPING
-	
+
 	var/list/clothing_choices = list()
 	siemens_coefficient = 0.8
 
@@ -87,7 +87,6 @@
 	icon_state = "galoshes"
 	permeability_coefficient = 0.05
 	flags_inventory = NOSLIPPING
-	slowdown = SHOES_SLOWDOWN+1
 
 /obj/item/clothing/shoes/clown_shoes
 	desc = "The prankster's standard-issue clowning shoes. Damn they're huge!"


### PR DESCRIPTION
## About The Pull Request

Removes the slowdown from those big yellow janitor shoes.

## Why It's Good For The Game

In base SS13, Galoshes have slowdown because they're No-slip shoes, but, CM, unfortunately doesn't have slipping anymore.
One of the random synth-survivor jobs is Janitor, which starts with Galoshes. This will let them keep their shoes, if they so choose. 

## Changelog


:cl:  FoxyStalin
del: Removes Slowdown from Galoshes 
/:cl:

