### PR TITLE
Minor surgery fix in interior and shuttles

### DIFF
--- a/code/__DEFINES/surgery.dm
+++ b/code/__DEFINES/surgery.dm
@@ -68,7 +68,8 @@ unless the surgical tool is completely unsuited to what it's being used for.*/
 	/obj/item/tool/weldingtool,\
 	/obj/item/tool/pen,\
 	/obj/item/stack/rods,\
-	/obj/item/tool/surgery/surgical_line\
+	/obj/item/tool/surgery/surgical_line,\
+	/obj/item/tool/surgery/synthgraft\
 	)
 
 /////////////////////////////

--- a/code/modules/surgery/surgery_initiator.dm
+++ b/code/modules/surgery/surgery_initiator.dm
@@ -5,6 +5,9 @@
 	  */
 
 proc/initiate_surgery_moment(obj/item/tool, mob/living/carbon/target, obj/limb/affecting, mob/living/user)
+	if(!tool)
+		return FALSE
+
 	var/target_zone = user.zone_selected
 	var/list/available_surgeries = list()
 	var/list/valid_steps = list() //Steps that could be performed, if we had the right tool.
@@ -13,9 +16,11 @@ proc/initiate_surgery_moment(obj/item/tool, mob/living/carbon/target, obj/limb/a
 	if(!istype(user.loc, /turf/open))
 		to_chat(user, SPAN_WARNING("You can't perform surgery here!"))
 		return FALSE
-	else if(!T.supports_surgery)
-		to_chat(user, SPAN_WARNING("You can't perform surgery under these bad conditions!"))
-		return FALSE
+	else
+		if(!T.supports_surgery)
+			if(!(tool.type in SURGERY_TOOLS_NO_INIT_MSG))
+				to_chat(user, SPAN_WARNING("You can't perform surgery under these bad conditions!"))
+			return FALSE
 
 	if(user.action_busy) //already doing an action
 		return FALSE

--- a/code/modules/surgery/surgery_initiator.dm
+++ b/code/modules/surgery/surgery_initiator.dm
@@ -18,7 +18,7 @@ proc/initiate_surgery_moment(obj/item/tool, mob/living/carbon/target, obj/limb/a
 		return FALSE
 	else
 		if(!T.supports_surgery)
-			if(!(tool.type in SURGERY_TOOLS_NO_INIT_MSG) && !istype(tool, /obj/item/tool/surgery/synthgraft))
+			if(!(tool.type in SURGERY_TOOLS_NO_INIT_MSG))
 				to_chat(user, SPAN_WARNING("You can't perform surgery under these bad conditions!"))
 			return FALSE
 

--- a/code/modules/surgery/surgery_initiator.dm
+++ b/code/modules/surgery/surgery_initiator.dm
@@ -18,7 +18,7 @@ proc/initiate_surgery_moment(obj/item/tool, mob/living/carbon/target, obj/limb/a
 		return FALSE
 	else
 		if(!T.supports_surgery)
-			if(!(tool.type in SURGERY_TOOLS_NO_INIT_MSG))
+			if(!(tool.type in SURGERY_TOOLS_NO_INIT_MSG) && !istype(tool, /obj/item/tool/surgery/synthgraft))
 				to_chat(user, SPAN_WARNING("You can't perform surgery under these bad conditions!"))
 			return FALSE
 

--- a/code/modules/surgery/surgery_steps.dm
+++ b/code/modules/surgery/surgery_steps.dm
@@ -62,9 +62,11 @@ datum/surgery_step/proc/repeat_step_criteria(mob/user, mob/living/carbon/target,
 	if(!istype(user.loc, /turf/open))
 		to_chat(user, SPAN_WARNING("You can't perform surgery here!"))
 		return FALSE
-	else if(!T.supports_surgery)
-		to_chat(user, SPAN_WARNING("You can't perform surgery under these bad conditions!"))
-		return FALSE
+	else
+		if(!T.supports_surgery)
+			if(!(tool.type in SURGERY_TOOLS_NO_INIT_MSG))
+				to_chat(user, SPAN_WARNING("You can't perform surgery under these bad conditions!"))
+			return FALSE
 
 	surgery.step_in_progress = TRUE
 

--- a/code/modules/surgery/surgery_steps.dm
+++ b/code/modules/surgery/surgery_steps.dm
@@ -64,7 +64,7 @@ datum/surgery_step/proc/repeat_step_criteria(mob/user, mob/living/carbon/target,
 		return FALSE
 	else
 		if(!T.supports_surgery)
-			if(!(tool.type in SURGERY_TOOLS_NO_INIT_MSG))
+			if(!(tool.type in SURGERY_TOOLS_NO_INIT_MSG) && !istype(tool, /obj/item/tool/surgery/synthgraft))
 				to_chat(user, SPAN_WARNING("You can't perform surgery under these bad conditions!"))
 			return FALSE
 

--- a/code/modules/surgery/surgery_steps.dm
+++ b/code/modules/surgery/surgery_steps.dm
@@ -64,7 +64,7 @@ datum/surgery_step/proc/repeat_step_criteria(mob/user, mob/living/carbon/target,
 		return FALSE
 	else
 		if(!T.supports_surgery)
-			if(!(tool.type in SURGERY_TOOLS_NO_INIT_MSG) && !istype(tool, /obj/item/tool/surgery/synthgraft))
+			if(!(tool.type in SURGERY_TOOLS_NO_INIT_MSG))
 				to_chat(user, SPAN_WARNING("You can't perform surgery under these bad conditions!"))
 			return FALSE
 


### PR DESCRIPTION
## About The Pull Request

Fixes surgical line and synthgraft showing warning in interior and shuttles.

## Why It's Good For The Game

Just a small fix.

## Changelog

:cl: Jeser
fix: Fixed some medical items showing warning message when used for treating wounds in vehicle interiors and shuttles.
/:cl: