### PR TITLE
Fix for fixing hardpoints.

### DIFF
--- a/code/modules/vehicles/hardpoints/hardpoint.dm
+++ b/code/modules/vehicles/hardpoints/hardpoint.dm
@@ -441,19 +441,15 @@ obj/item/hardpoint/proc/remove_buff(var/obj/vehicle/multitile/V)
 		if(!(world.time % 3))
 			playsound(get_turf(user), 'sound/items/weldingtool_weld.ogg', 25)
 		if(!do_after(user, 1 SECONDS, INTERRUPT_ALL, BUSY_ICON_BUILD))
-			user.visible_message(SPAN_NOTICE("[user] stops repairing \the [name]."), SPAN_NOTICE("You stop repairing \the [name]. The integrity of the module is at [SPAN_HELPFUL(round(get_integrity_percent()))]%."))
-			being_repaired = FALSE
-			return
+			break
 
 		//we check for adjacency only if we are not installed. This is for turret for now
 		if(!owner && !Adjacent(user))
-			user.visible_message(SPAN_NOTICE("[user] stops repairing \the [name]."), SPAN_NOTICE("You stop repairing \the [name]. The integrity of module is at [SPAN_HELPFUL(round(get_integrity_percent()))]%."))
-			being_repaired = FALSE
-			return
+			break
 
 		if(!WT.isOn())
 			to_chat(user, SPAN_WARNING("\The [WT] needs to be on!"))
-			return
+			break
 
 		WT.remove_fuel(1, user)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Out of these three `return`s, one did not reset the `being_repaired` back to false, so turning your welder off while repairing a hardpoint meant that it gets stuck as being repaired forever. Since both that reset and the visible message are already made to happen when the `while` cycle is finished, might as well cut down on copypasting and replace the `return`s with `break`s.

## Why It's Good For The Game

Is fix.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixing vehicular hardpoints no longer gets stuck with them being seen as being actively fixed when they are not.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
