### PR TITLE
Fix for reflective walls.

### DIFF
--- a/code/game/turfs/walls/wall_types.dm
+++ b/code/game/turfs/walls/wall_types.dm
@@ -1087,36 +1087,34 @@
 
 	var/brute_multiplier = 0.3
 	var/explosive_multiplier = 0.3
+	var/reflection_multiplier = 0.5
 
 /turf/closed/wall/resin/reflective/bullet_act(obj/item/projectile/P)
 	if(src in P.permutated)
 		return
 
-	var/original_damage = P.damage
-	if(P.ammo.damage_type == BRUTE)
-		damage *= brute_multiplier
-
-	if(prob(chance_to_reflect))
-		if(P.runtime_iff_group || P.ammo.flags_ammo_behavior & AMMO_NO_DEFLECT)
-			// Bullet gets absorbed if it has IFF or can't be reflected.
-			return
-
-		var/obj/item/projectile/new_proj = new(src, construction_data ? construction_data : create_cause_data(initial(name)))
-		new_proj.generate_bullet(P.ammo, special_flags = P.projectile_override_flags|AMMO_HOMING)
-		new_proj.damage = original_damage * 0.5 // don't make it too punishing
-		new_proj.accuracy = HIT_ACCURACY_TIER_7 // 35% chance to hit something
-
-		// Move back to who fired you.
-		RegisterSignal(new_proj, COMSIG_BULLET_PRE_HANDLE_TURF, .proc/bullet_ignore_turf)
-		new_proj.permutated |= src
-
-		var/angle = Get_Angle(src, P.firer) + rand(30, -30)
-		var/atom/target = get_angle_target_turf(src, angle, get_dist(src, P.firer))
-		new_proj.fire_at(target, P.firer, src, reflect_range, speed = P.ammo.shell_speed, is_shrapnel = TRUE)
-
-		return TRUE
-	else
+	if(!prob(chance_to_reflect))
+		if(P.ammo.damage_type == BRUTE)
+			P.damage *= brute_multiplier
 		return ..()
+	if(P.runtime_iff_group || P.ammo.flags_ammo_behavior & AMMO_NO_DEFLECT)
+		// Bullet gets absorbed if it has IFF or can't be reflected.
+		return
+
+	var/obj/item/projectile/new_proj = new(src, construction_data ? construction_data : create_cause_data(initial(name)))
+	new_proj.generate_bullet(P.ammo, special_flags = P.projectile_override_flags|AMMO_HOMING)
+	new_proj.damage = P.damage * reflection_multiplier // don't make it too punishing
+	new_proj.accuracy = HIT_ACCURACY_TIER_7 // 35% chance to hit something
+
+	// Move back to who fired you.
+	RegisterSignal(new_proj, COMSIG_BULLET_PRE_HANDLE_TURF, .proc/bullet_ignore_turf)
+	new_proj.permutated |= src
+
+	var/angle = Get_Angle(src, P.firer) + rand(30, -30)
+	var/atom/target = get_angle_target_turf(src, angle, get_dist(src, P.firer))
+	new_proj.fire_at(target, P.firer, src, reflect_range, speed = P.ammo.shell_speed, is_shrapnel = TRUE)
+
+	return TRUE
 
 /turf/closed/wall/resin/reflective/proc/bullet_ignore_turf(obj/item/projectile/P, var/turf/T)
 	SIGNAL_HANDLER


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Thanks to walls tracking damage from zero up to maximum instead of health from maximum down to zero, nobody ever noticed that the multiplier meant to reduce the damage of incoming projectile actually reduced the damage taken so far every time the wall got shot, meaning it is literally impossible to take a reflective wall down by shooting. Fixed at last.
Numbers involved will still need a look from balance perspective at some point. A hundred bullets to take down a single wall might be a bit unreasonable. Reflection itself will need a look too, but that is a general accuracy issue in need of a separate fix.

## Why It's Good For The Game

Is fix.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Reflective walls now actually take damage from the bullets they did not reflect.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
