### PR TITLE
[Code] Knock out crit xenos for consistency sake

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -478,6 +478,7 @@ updatehealth()
 		return
 
 	sound_environment_override = SOUND_ENVIRONMENT_NONE
+	KnockOut(3)
 	stat = UNCONSCIOUS
 	blinded = 1
 	see_in_dark = 5


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Similar to humans/hellhounds when in crit, xenos will now be knocked out when put into crit.

hellhound\life.dm
```
		if(health < 0)
			if(health <= 10 && prob(1))
				INVOKE_ASYNC(src, /mob.proc/emote, "gasp")
			if(!reagents.has_reagent("inaprovaline"))
				apply_damage(11, OXY)
			KnockOut(3)
            if(knocked_out)
		AdjustKnockedout(-1)
		blinded = 1
		stat = UNCONSCIOUS
```

human/life.dm
```
     if(regular_update && ((getOxyLoss() > 50)))
			KnockOut(3)
    ...
     if(knocked_out)
			blinded = 1
			stat = UNCONSCIOUS
```
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Consistency sake. Hellhounds will start to be [based on xenos](https://github.com/cmss13-devs/cmss13/pull/684) and this was in their code. Similarly, humans are knocked out when entering heavy into crit. It only seems to make sense that xenos will be knocked out when put into crit as well.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: TeDGamer
balance: Xenos are now knocked out when in crit
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
