### PR TITLE
Fix: desert flora can now be cut down

### DIFF
--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -167,6 +167,7 @@ ICE GRASS
 	icon = 'icons/obj/structures/props/tallgrass.dmi'
 	unslashable = TRUE
 	unacidable = TRUE
+	cut_level = PLANT_CUT_MACHETE
 	var/overlay_type = "tallgrass_overlay"
 
 /obj/structure/flora/grass/tallgrass/Initialize()
@@ -220,7 +221,6 @@ ICE GRASS
 /obj/structure/flora/grass/tallgrass/desert/corner
 	icon_state = "tallgrass_corner"
 	overlay_type = "tallgrass_overlay_corner"
-	cut_level = PLANT_CUT_MACHETE
 	center = FALSE
 
 ///ICE COLONY - SOROKYNE///

--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -220,6 +220,7 @@ ICE GRASS
 /obj/structure/flora/grass/tallgrass/desert/corner
 	icon_state = "tallgrass_corner"
 	overlay_type = "tallgrass_overlay_corner"
+	cut_level = PLANT_CUT_MACHETE
 	center = FALSE
 
 ///ICE COLONY - SOROKYNE///
@@ -324,6 +325,7 @@ ICE GRASS
 
 /obj/structure/flora/bush/ausbushes/var3
 	icon_state = "leafybush_1"
+	cut_level = PLANT_CUT_KNIFE
 	variations = 3
 
 /obj/structure/flora/bush/ausbushes/var3/leafybush
@@ -373,6 +375,7 @@ ICE GRASS
 	icon = 'icons/obj/structures/props/dam.dmi'
 	desc = "A small, leafy bush."
 	icon_state = "tree_1"
+	cut_level = PLANT_CUT_KNIFE
 	layer = ABOVE_XENO_LAYER
 
 /obj/structure/flora/bush/desert/cactus

--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -240,7 +240,6 @@ ICE GRASS
 	color = COLOR_G_JUNG
 	icon_state = "tallgrass"
 	desc = "A clump of vibrant jungle grasses"
-	cut_level = PLANT_CUT_MACHETE
 	fire_flag = FLORA_BURN_SPREAD_ONCE
 
 /obj/structure/flora/grass/tallgrass/jungle/corner

--- a/map_config/maps.txt
+++ b/map_config/maps.txt
@@ -13,7 +13,7 @@ Format:
 endmap
 
 map lv624
-	default
+	//default
 endmap
 
 map bigredv2
@@ -44,6 +44,7 @@ map shivas_snowball
 endmap
 
 map kutjevo
+	default
 endmap
 
 map sorokyne_strata

--- a/map_config/maps.txt
+++ b/map_config/maps.txt
@@ -13,7 +13,7 @@ Format:
 endmap
 
 map lv624
-	//default
+	default
 endmap
 
 map bigredv2
@@ -44,7 +44,6 @@ map shivas_snowball
 endmap
 
 map kutjevo
-	default
 endmap
 
 map sorokyne_strata


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Desert tallgrass and bushes (the orange-map thematic ones, found on Kutjevo and Trijent) could not have been cut with machetes/knives beforehand. This fixes that.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bugfix good!
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: 50RemAndCounting
fix: Kutjevo/Trijent tallgrass and other flora can now be properly cut away with machetes and other bladed equipment.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
