### PR TITLE
Rebalance: Removes greenfire slowdown

### DIFF
--- a/code/modules/projectiles/guns/flamer/flamer.dm
+++ b/code/modules/projectiles/guns/flamer/flamer.dm
@@ -513,8 +513,7 @@
 				var/mob/living/carbon/human/H = M
 				if (HAS_TRAIT(M, TRAIT_SUPER_STRONG))
 					resist_modifier = 0.25
-				H.next_move_slowdown = H.next_move_slowdown + (3 * resist_modifier)
-				to_chat(H, SPAN_DANGER("The viscous napalm clings to your limbs as you struggle to move through the flames!"))
+				to_chat(H, SPAN_DANGER("The viscous napalm clings to your body!"))
 			else if(isXeno(M))
 				var/mob/living/carbon/Xenomorph/X = M
 				if(!X.armor_deflection_debuff) //Only applies the xeno armor shred reset when the debuff isn't present or was recently removed.
@@ -522,8 +521,7 @@
 					//type_b_debuff_xeno_armor(X)
 				resist_modifier = type_b_debuff_xeno_armor(X)
 				set_on_fire(X) //Deals an extra proc of fire when you're crossing it. 30 damage per tile crossed, plus 15 per Process().
-				X.next_move_slowdown = X.next_move_slowdown + (3 * resist_modifier)
-				to_chat(X, SPAN_DANGER("You feel pieces of your exoskeleton fusing with the viscous fluid below and tearing off as you struggle to move through the flames!"))
+				to_chat(X, SPAN_DANGER("You feel pieces of your exoskeleton fusing with the viscous fluid below and being torn off!"))
 
 /obj/flamer_fire/proc/type_b_debuff_xeno_armor(var/mob/living/carbon/Xenomorph/X)
 	var/sig_result = SEND_SIGNAL(X, COMSIG_LIVING_FLAMER_CROSSED, tied_reagent)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Opened after discussing current greenfire balance with the development team. The slowdown effect has been axed, nothing else was touched.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Armor reduction is a good niche to give greenfire more use cases, but coupling it with the slowdown was overkill.  The armor reduction is a fair and significant punishment for xenos that walk on through the greenflamed tiles, but the slowdown messes hard with an essential cornerstone of xeno gameplay - the ability to engage or disengage from fights. Why is this so bad? Because this rather significant slowdown is applied per-flamed tile, and greenfire blankets a wide area - other flame types simply flame in a straight line. This in essence creates a significantly large Area-of-effect debuff, which is out of pocket even for squad specialist weapons, in my opinion. This makes RPG/grenade launcher/scout hi-impact ammo (none of which simultaneously apply an on-fire effect, mind you!) (chain)stuns look weak in comparison. By removing said slowdown effect but keeping the rest in, I believe greenfire will be actually manageable by xenos whilst still significantly punishing them for stepping into it.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: 50RemAndCounting
balance: Type-B fire (greenfire) no longer slows mobs down that walk over it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
