### PR TITLE
Adds non-LS cig packs as Custom Loadout items and as maintenance garbage, a few other minor Almayer map tweaks.

### DIFF
--- a/code/modules/client/preferences_gear.dm
+++ b/code/modules/client/preferences_gear.dm
@@ -272,15 +272,15 @@ var/global/list/gear_datums = list()
 	slot = WEAR_IN_BACK
 	cost = 2
 
-/datum/gear/pack_emeraldgreen
-	display_name = "Pack Of Emerald Greens"
-	path = /obj/item/storage/fancy/cigarettes/emeraldgreen
+/datum/gear/pack_arcturian_ace
+	display_name = "Pack Of Arcturian Aces"
+	path = /obj/item/storage/fancy/cigarettes/arcturian_ace
 	slot = WEAR_IN_BACK
 	cost = 3
 
-/datum/gear/pack_wypacket
-	display_name = "Pack Of Weyland-Yutani Golds"
-	path = /obj/item/storage/fancy/cigarettes/wypacket
+/datum/gear/pack_emeraldgreen
+	display_name = "Pack Of Emerald Greens"
+	path = /obj/item/storage/fancy/cigarettes/emeraldgreen
 	slot = WEAR_IN_BACK
 	cost = 3
 
@@ -296,12 +296,6 @@ var/global/list/gear_datums = list()
 	slot = WEAR_IN_BACK
 	cost = 3
 
-/datum/gear/pack_arcturian_ace
-	display_name = "Pack Of Arcturian Aces"
-	path = /obj/item/storage/fancy/cigarettes/arcturian_ace
-	slot = WEAR_IN_BACK
-	cost = 3
-
 /datum/gear/pack_lady_finger
 	display_name = "Pack Of Lady Fingers"
 	path = /obj/item/storage/fancy/cigarettes/lady_finger
@@ -313,6 +307,12 @@ var/global/list/gear_datums = list()
 	path = /obj/item/storage/fancy/cigarettes/lucky_strikes
 	slot = WEAR_IN_BACK
 	cost = 1
+
+/datum/gear/pack_wypacket
+	display_name = "Pack Of Weyland-Yutani Golds"
+	path = /obj/item/storage/fancy/cigarettes/wypacket
+	slot = WEAR_IN_BACK
+	cost = 3
 
 /datum/gear/weed_joint
 	display_name = "Joint of Space Weed"

--- a/code/modules/client/preferences_gear.dm
+++ b/code/modules/client/preferences_gear.dm
@@ -276,7 +276,37 @@ var/global/list/gear_datums = list()
 	display_name = "Pack Of Emerald Greens"
 	path = /obj/item/storage/fancy/cigarettes/emeraldgreen
 	slot = WEAR_IN_BACK
-	cost = 1
+	cost = 3
+
+/datum/gear/pack_wypacket
+	display_name = "Pack Of Weyland-Yutani Golds"
+	path = /obj/item/storage/fancy/cigarettes/wypacket
+	slot = WEAR_IN_BACK
+	cost = 3
+
+/datum/gear/pack_blackpack
+	display_name = "Pack Of Executive Selects"
+	path = /obj/item/storage/fancy/cigarettes/blackpack
+	slot = WEAR_IN_BACK
+	cost = 3
+
+/datum/gear/pack_kpack
+	display_name = "Pack Of Koorlander Golds"
+	path = /obj/item/storage/fancy/cigarettes/kpack
+	slot = WEAR_IN_BACK
+	cost = 3
+
+/datum/gear/pack_arcturian_ace
+	display_name = "Pack Of Arcturian Aces"
+	path = /obj/item/storage/fancy/cigarettes/arcturian_ace
+	slot = WEAR_IN_BACK
+	cost = 3
+
+/datum/gear/pack_lady_finger
+	display_name = "Pack Of Lady Fingers"
+	path = /obj/item/storage/fancy/cigarettes/lady_finger
+	slot = WEAR_IN_BACK
+	cost = 3
 
 /datum/gear/pack_lucky_strikes
 	display_name = "Pack Of Lucky Strikes"

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -44121,10 +44121,6 @@
 /area/almayer/hull/lower_hull/l_m_p)
 "gqW" = (
 /obj/structure/surface/table/almayer,
-/obj/item/storage/donut_box{
-	pixel_x = 7;
-	pixel_y = 10
-	},
 /turf/open/floor/almayer{
 	icon_state = "plate";
 	tag = "icon-sterile"
@@ -59343,6 +59339,9 @@
 /area/almayer/shipboard/brig/main_office)
 "ntq" = (
 /obj/structure/surface/table/almayer,
+/obj/item/storage/donut_box{
+	pixel_y = 20
+	},
 /obj/structure/machinery/computer/security/almayer_network{
 	dir = 8
 	},
@@ -69889,6 +69888,9 @@
 	pixel_x = -6
 	},
 /obj/structure/pipes/standard/simple/hidden/supply,
+/obj/item/storage/donut_box{
+	pixel_y = -11
+	},
 /turf/open/floor/almayer{
 	dir = 4;
 	icon_state = "red";
@@ -73932,8 +73934,7 @@
 	pixel_y = -9
 	},
 /obj/item/storage/donut_box{
-	pixel_x = 10;
-	pixel_y = 10
+	pixel_y = 19
 	},
 /turf/open/floor/almayer{
 	dir = 8;
@@ -83084,10 +83085,6 @@
 	pixel_x = -6;
 	pixel_y = 18;
 	req_access_txt = "3"
-	},
-/obj/item/storage/donut_box{
-	pixel_x = 9;
-	pixel_y = 10
 	},
 /turf/open/floor/almayer{
 	icon_state = "plate";

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -8028,6 +8028,10 @@
 "avh" = (
 /obj/structure/surface/table/reinforced/almayer_B,
 /obj/item/storage/box/uscm_mre,
+/obj/item/storage/fancy/cigarettes/arcturian_ace{
+	pixel_x = 10;
+	pixel_y = 14
+	},
 /turf/open/floor/almayer{
 	icon_state = "plate";
 	tag = "icon-sterile"
@@ -10111,6 +10115,10 @@
 /area/almayer/medical/morgue)
 "aAK" = (
 /obj/structure/surface/table/almayer,
+/obj/item/storage/fancy/cigarettes/arcturian_ace{
+	pixel_x = -4;
+	pixel_y = 14
+	},
 /obj/item/device/camera,
 /obj/item/device/camera_film,
 /obj/structure/machinery/camera/autoname/almayer{
@@ -13109,6 +13117,10 @@
 /area/almayer/evacuation/pod10)
 "aLk" = (
 /obj/structure/largecrate/random/case,
+/obj/item/storage/fancy/cigarettes/emeraldgreen{
+	pixel_x = -8;
+	pixel_y = 5
+	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_f_s)
 "aLl" = (
@@ -35429,6 +35441,9 @@
 	pixel_x = 5;
 	pixel_y = 10
 	},
+/obj/item/storage/fancy/cigarettes/lady_finger{
+	pixel_x = -6
+	},
 /turf/open/floor/almayer{
 	icon_state = "plate";
 	tag = "icon-sterile"
@@ -41696,6 +41711,10 @@
 	pixel_y = 5
 	},
 /obj/item/toy/deck/uno,
+/obj/item/storage/fancy/cigarettes/blackpack{
+	pixel_x = -11;
+	pixel_y = 9
+	},
 /turf/open/floor/almayer{
 	icon_state = "plate";
 	tag = "icon-sterile"
@@ -42612,14 +42631,16 @@
 /turf/open/floor/almayer,
 /area/almayer/lifeboat_pumps/south1)
 "fGh" = (
-/obj/structure/bed/chair{
-	dir = 1
+/obj/item/storage/fancy/cigarettes/emeraldgreen{
+	pixel_x = 12;
+	pixel_y = 8
 	},
+/obj/structure/largecrate/random/case,
 /turf/open/floor/almayer{
 	icon_state = "plate";
 	tag = "icon-sterile"
 	},
-/area/almayer/living/briefing)
+/area/almayer/hull/upper_hull/u_a_s)
 "fGm" = (
 /turf/open/shuttle/escapepod{
 	icon_state = "floor9";
@@ -44100,6 +44121,10 @@
 /area/almayer/hull/lower_hull/l_m_p)
 "gqW" = (
 /obj/structure/surface/table/almayer,
+/obj/item/storage/donut_box{
+	pixel_x = 7;
+	pixel_y = 10
+	},
 /turf/open/floor/almayer{
 	icon_state = "plate";
 	tag = "icon-sterile"
@@ -47626,6 +47651,10 @@
 	pixel_x = -10;
 	pixel_y = 13
 	},
+/obj/item/storage/fancy/cigarettes/emeraldgreen{
+	pixel_x = 9;
+	pixel_y = 11
+	},
 /turf/open/floor/almayer{
 	icon_state = "plate";
 	tag = "icon-sterile"
@@ -50276,6 +50305,9 @@
 /area/almayer/command/cichallway)
 "jgM" = (
 /obj/structure/surface/table/almayer,
+/obj/item/storage/fancy/cigarettes/blackpack{
+	pixel_x = 8
+	},
 /turf/open/floor/almayer{
 	icon_state = "plate";
 	tag = "icon-sterile"
@@ -52084,6 +52116,9 @@
 	layer = 3.7;
 	pixel_x = 5;
 	pixel_y = 8
+	},
+/obj/item/storage/fancy/cigarettes/lady_finger{
+	pixel_x = -5
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_a_p)
@@ -54172,9 +54207,6 @@
 /turf/open/floor/almayer,
 /area/almayer/hallways/hangar)
 "lcW" = (
-/obj/item/storage/donut_box{
-	pixel_y = 8
-	},
 /obj/structure/closet/secure_closet/personal/cabinet{
 	req_access = null
 	},
@@ -61433,6 +61465,10 @@
 	desc = "A small coin, bearing the falling falcons insignia.";
 	name = "falling falcons challenge coin"
 	},
+/obj/item/storage/donut_box{
+	pixel_x = -3;
+	pixel_y = 9
+	},
 /turf/open/floor/wood/ship,
 /area/almayer/shipboard/brig/chief_mp_office)
 "ott" = (
@@ -61509,6 +61545,14 @@
 	tag = "icon-greencorner (WEST)"
 	},
 /area/almayer/command/cichallway)
+"ovc" = (
+/obj/structure/surface/table/almayer,
+/obj/item/storage/fancy/cigarettes/blackpack,
+/turf/open/floor/almayer{
+	icon_state = "plate";
+	tag = "icon-sterile"
+	},
+/area/almayer/hull/lower_hull/l_a_p)
 "ovn" = (
 /turf/open/floor/almayer{
 	dir = 5;
@@ -69866,6 +69910,18 @@
 	tag = "icon-test_floor4"
 	},
 /area/almayer/hallways/repair_bay)
+"ssi" = (
+/obj/structure/machinery/door/poddoor/almayer/open{
+	dir = 4;
+	id = "Hangar Lockdown";
+	name = "\improper Hangar Lockdown Blast Door"
+	},
+/obj/item/storage/fancy/cigarettes/arcturian_ace,
+/turf/open/floor/almayer{
+	icon_state = "test_floor4";
+	tag = "icon-test_floor4"
+	},
+/area/almayer/hallways/hangar)
 "ssD" = (
 /obj/structure/machinery/light/small{
 	dir = 4
@@ -73875,6 +73931,10 @@
 	pixel_x = -17;
 	pixel_y = -9
 	},
+/obj/item/storage/donut_box{
+	pixel_x = 10;
+	pixel_y = 10
+	},
 /turf/open/floor/almayer{
 	dir = 8;
 	icon_state = "red";
@@ -73900,6 +73960,9 @@
 /obj/structure/surface/table/almayer,
 /obj/item/trash/cigbutt,
 /obj/item/ashtray/glass,
+/obj/item/storage/fancy/cigarettes/arcturian_ace{
+	pixel_x = -11
+	},
 /turf/open/floor/wood/ship,
 /area/almayer/living/offices)
 "uhP" = (
@@ -83021,6 +83084,10 @@
 	pixel_x = -6;
 	pixel_y = 18;
 	req_access_txt = "3"
+	},
+/obj/item/storage/donut_box{
+	pixel_x = 9;
+	pixel_y = 10
 	},
 /turf/open/floor/almayer{
 	icon_state = "plate";
@@ -93181,7 +93248,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+bdH
 aaa
 aaa
 aaa
@@ -109025,7 +109092,7 @@ aRu
 aRu
 aRu
 bcm
-aZZ
+ssi
 aYC
 aZZ
 bkA
@@ -118994,7 +119061,7 @@ uMk
 uMk
 bgO
 beH
-fGh
+bqZ
 bdg
 buH
 hOR
@@ -119197,7 +119264,7 @@ uMk
 uMk
 bgO
 beH
-fGh
+bqZ
 bdg
 buH
 hOR
@@ -128402,7 +128469,7 @@ atG
 psm
 seO
 aDF
-amP
+fGh
 egB
 xlX
 aDF
@@ -132402,7 +132469,7 @@ osE
 cAH
 cAH
 vuR
-gHv
+ovc
 gHv
 haq
 vuR


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Now that the on-board machines use the lore friendly Lucky Strikes, it is all but impossible to get other cig brands from anywhere other than colony machines.

This PR addresses that, adding to possible customization and variety to the items marines put in their mouths and set on fire:

- All cigarette packs are now available as Loadout items. To reflect the relative rarity of the non-Lucky packs, all but the Luckies have had their cost bumped to 3 (originally I considered 5 but that seems too harsh. I can be convinced to 4, but 3 seemed like a good balance considering the original cost of the ones that were already there is 1)

- Strewn out packs of other brands across the Almayer, there are now 2-3 packs of each brand to be found by those too lazy or frugal to add them to their loadout.

There are also two more minor map tweaks: 

- Removed 2 folding chairs from briefing that I missed in my original pass. You would think that leaving 2 folding chairs would send the message, but no. They have still caused multiple issues with the excuse being "well they are there"; well they aren't anymore. 

- Fixed 1 and added 2 more donut boxes to the Brig. There was only 1 donut box in the land of the donut eaters, unacceptable (also one of them apparently was supposed to spawn in the CMPs closet but it never actually did that or rather spawned under it and was effectively invisible, it was moved to the table next to it)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Variety Good. Adding more character to the map good. Briefing chair dumbassery bad.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:silencer_pl
add: All cigarette brands are now available as Custom Loadout items for 3 points (except Luckies that still cost 1)
add: A few packs of all cigarette brands can now be found in various spots on the Almayer.
add: MPs get a few more donut boxes in the Brig.
del: Folding chairs that were left over in the briefing room have been removed.
/:cl:

