### PR TITLE
Full-Auto Smartguns

### DIFF
--- a/code/__DEFINES/conflict.dm
+++ b/code/__DEFINES/conflict.dm
@@ -59,6 +59,7 @@
 /// Whether the gun has been fired by its current user (reset upon `dropped()`)
 #define GUN_SUPPORT_PLATFORM	(1<<19) /// support weapon, bipod will grant IFF
 #define GUN_BURST_ONLY			(1<<20)
+#define GUN_FULL_AUTO_ONLY		(1<<21)
 
 //Gun attachable related flags.
 #define ATTACH_REMOVABLE	1

--- a/code/__DEFINES/weapon_stats.dm
+++ b/code/__DEFINES/weapon_stats.dm
@@ -77,6 +77,7 @@ var/accuracy_mult_unwielded
 #define SCATTER_AMOUNT_TIER_8 3
 #define SCATTER_AMOUNT_TIER_9 2
 #define SCATTER_AMOUNT_TIER_10 1
+#define SCATTER_AMOUNT_NONE 0
 
 /*
 ////FULL AUTO SCATTER PEAK////

--- a/code/modules/projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/gun_helpers.dm
@@ -699,7 +699,7 @@ As sniper rifles have both and weapon mods can change them as well. ..() deals w
 			flags_gun_features |= GUN_BURST_ON
 			return
 
-		to_chat(usr, SPAN_NOTICE("[src] can only be fired in bursts!"))
+		to_chat(usr, SPAN_NOTICE("\The [src] can only be fired in bursts!"))
 		return
 
 	if(flags_gun_features & GUN_FULL_AUTO_ONLY)
@@ -711,7 +711,7 @@ As sniper rifles have both and weapon mods can change them as well. ..() deals w
 			RegisterSignal(usr.client, COMSIG_CLIENT_LMB_DRAG, .proc/full_auto_new_target)
 			return
 
-		to_chat(usr, SPAN_NOTICE("[src] can only be fired in full auto mode!"))
+		to_chat(usr, SPAN_NOTICE("\The [src] can only be fired in full auto mode!"))
 		return
 
 	playsound(usr, 'sound/weapons/handling/gun_burst_toggle.ogg', 15, 1)

--- a/code/modules/projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/gun_helpers.dm
@@ -695,11 +695,23 @@ As sniper rifles have both and weapon mods can change them as well. ..() deals w
 
 	if(flags_gun_features & GUN_BURST_ONLY)
 		if(!(flags_gun_features & GUN_BURST_ON))
-			stack_trace("[src] has GUN_BUST_ONLY flag but not GUN_BURST_ON.")
+			stack_trace("[src] has GUN_BURST_ONLY flag but not GUN_BURST_ON.")
 			flags_gun_features |= GUN_BURST_ON
 			return
 
 		to_chat(usr, SPAN_NOTICE("[src] can only be fired in bursts!"))
+		return
+
+	if(flags_gun_features & GUN_FULL_AUTO_ONLY)
+		if(!(flags_gun_features & GUN_FULL_AUTO_ON))
+			stack_trace("[src] has GUN_FULL_AUTO_ONLY flag but not GUN_FULL_AUTO_ON.")
+			flags_gun_features |= GUN_FULL_AUTO_ON
+			RegisterSignal(usr.client, COMSIG_CLIENT_LMB_DOWN, .proc/full_auto_start)
+			RegisterSignal(usr.client, COMSIG_CLIENT_LMB_UP, .proc/full_auto_stop)
+			RegisterSignal(usr.client, COMSIG_CLIENT_LMB_DRAG, .proc/full_auto_new_target)
+			return
+
+		to_chat(usr, SPAN_NOTICE("[src] can only be fired in full auto mode!"))
 		return
 
 	playsound(usr, 'sound/weapons/handling/gun_burst_toggle.ogg', 15, 1)

--- a/code/modules/projectiles/guns/smartgun.dm
+++ b/code/modules/projectiles/guns/smartgun.dm
@@ -72,7 +72,7 @@
 	fire_delay = FIRE_DELAY_TIER_10
 	burst_amount = BURST_AMOUNT_TIER_3
 	burst_delay = FIRE_DELAY_TIER_9
-	fa_delay = FIRE_DELAY_TIER_9
+	fa_delay = FIRE_DELAY_TIER_10
 	fa_scatter_peak = FULL_AUTO_SCATTER_PEAK_TIER_10
 	fa_max_scatter = SCATTER_AMOUNT_NONE
 	if(accuracy_improvement)

--- a/code/modules/projectiles/guns/smartgun.dm
+++ b/code/modules/projectiles/guns/smartgun.dm
@@ -52,7 +52,7 @@
 						/obj/item/attachable/burstfire_assembly,
 						/obj/item/attachable/flashlight)
 
-	flags_gun_features = GUN_SPECIALIST|GUN_WIELDED_FIRING_ONLY|GUN_HAS_FULL_AUTO
+	flags_gun_features = GUN_SPECIALIST|GUN_WIELDED_FIRING_ONLY|GUN_HAS_FULL_AUTO|GUN_FULL_AUTO_ON|GUN_FULL_AUTO_ONLY
 	gun_category = GUN_CATEGORY_HEAVY
 	starting_attachment_types = list(/obj/item/attachable/smartbarrel)
 	auto_retrieval_slot = WEAR_J_STORE
@@ -74,8 +74,8 @@
 	burst_amount = BURST_AMOUNT_TIER_3
 	burst_delay = FIRE_DELAY_TIER_9
 	fa_delay = FIRE_DELAY_TIER_9
-	fa_scatter_peak = FULL_AUTO_SCATTER_PEAK_TIER_6
-	fa_max_scatter = SCATTER_AMOUNT_TIER_5
+	fa_scatter_peak = FULL_AUTO_SCATTER_PEAK_TIER_10
+	fa_max_scatter = SCATTER_AMOUNT_NONE
 	if(accuracy_improvement)
 		accuracy_mult += HIT_ACCURACY_MULT_TIER_3
 	else

--- a/code/modules/projectiles/guns/smartgun.dm
+++ b/code/modules/projectiles/guns/smartgun.dm
@@ -49,7 +49,6 @@
 
 	attachable_allowed = list(
 						/obj/item/attachable/smartbarrel,
-						/obj/item/attachable/burstfire_assembly,
 						/obj/item/attachable/flashlight)
 
 	flags_gun_features = GUN_SPECIALIST|GUN_WIELDED_FIRING_ONLY|GUN_HAS_FULL_AUTO|GUN_FULL_AUTO_ON|GUN_FULL_AUTO_ONLY


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Smartguns can now only fire in full-auto mode. They no longer scatter over time when firing in full auto mode.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Prevents people from breaking their mice by spam-clicking in single fire mode to get more DPS with no scatter.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Smartguns now only have a full-auto firing mode, but full-auto no longer causes scatter over time.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
