### PR TITLE
Fix for freeing spec kits.

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -318,7 +318,9 @@ GLOBAL_LIST_INIT(frozen_items, list(SQUAD_MARINE_1 = list(), SQUAD_MARINE_2 = li
 		var/mob/living/carbon/human/H = occupant
 		if(H.assigned_squad)
 			var/datum/squad/S = H.assigned_squad
-			if(GET_MAPPED_ROLE(H.job) == JOB_SQUAD_SPECIALIST)
+			S.forget_marine_in_squad(H)
+			var/datum/job/J = GET_MAPPED_ROLE(H.job)
+			if(istype(J, /datum/job/marine/specialist))
 				//we make the set this specialist took if any available again
 				if(H.skills)
 					var/set_name
@@ -336,7 +338,6 @@ GLOBAL_LIST_INIT(frozen_items, list(SQUAD_MARINE_1 = list(), SQUAD_MARINE_2 = li
 
 					if(set_name && !available_specialist_sets.Find(set_name))
 						available_specialist_sets += set_name
-			S.forget_marine_in_squad(H)
 
 	SSticker.mode.latejoin_tally-- //Cryoing someone out removes someone from the Marines, blocking further larva spawns until accounted for
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Apparently that macro (now? always did?) returns a datum, not a string. Fixing the comparison fixed the issue.
Note that this allows the new specialist _both_ get the shiny new box from the vendor _and_ get whichever gear old specialist had on him and the pod put into the cryo storage. Probably unlikely to cause much problems, but maybe at some point we will need to make spec gear unrecoverable if somebody will abuse the doubling.

## Why It's Good For The Game

Is fix.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Going to cryo as a squad specialist once again correctly allows a latejoining specialist to pick the same kit.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
