### PR TITLE
Fix for logging custom warheads.

### DIFF
--- a/code/modules/cm_marines/equipment/mortar/mortar_shells.dm
+++ b/code/modules/cm_marines/equipment/mortar/mortar_shells.dm
@@ -5,7 +5,7 @@
 	icon_state = "mortar_ammo_cas"
 	w_class = SIZE_HUGE
 	flags_atom = FPRINT|CONDUCT
-	var/source_mob
+	var/datum/cause_data/cause_data
 
 /obj/item/mortar_shell/proc/detonate(var/turf/T)
 	forceMove(T)
@@ -22,7 +22,7 @@
 	icon_state = "mortar_ammo_he"
 
 /obj/item/mortar_shell/he/detonate(var/turf/T)
-	explosion(T, 0, 3, 5, 7, , , , create_cause_data(initial(name), source_mob))
+	explosion(T, 0, 3, 5, 7, explosion_cause_data = cause_data)
 
 /obj/item/mortar_shell/frag
 	name = "\improper 80mm fragmentation mortar shell"
@@ -30,7 +30,6 @@
 	icon_state = "mortar_ammo_frag"
 
 /obj/item/mortar_shell/frag/detonate(var/turf/T)
-	var/datum/cause_data/cause_data = create_cause_data(initial(name), source_mob)
 	create_shrapnel(T, 60, cause_data = cause_data)
 	sleep(2)
 	cell_explosion(T, 60, 20, EXPLOSION_FALLOFF_SHAPE_LINEAR, null, cause_data)
@@ -46,8 +45,7 @@
 	var/fire_type = FIRE_VARIANT_TYPE_B //Armor Shredding Greenfire
 
 /obj/item/mortar_shell/incendiary/detonate(var/turf/T)
-	var/datum/cause_data/cause_data = create_cause_data(initial(name), source_mob)
-	explosion(T, 0, 2, 4, 7, , , , cause_data)
+	explosion(T, 0, 2, 4, 7, explosion_cause_data = cause_data)
 	flame_radius(cause_data, radius, T, flame_level, burn_level, flameshape, null, fire_type)
 	playsound(T, 'sound/weapons/gun_flamethrower2.ogg', 35, 1, 4)
 
@@ -87,6 +85,7 @@
 			if(warhead?.has_camera)
 				deploy_camera(T)
 	if(warhead && locked && warhead.detonator)
+		warhead.cause_data = cause_data
 		warhead.prime()
 
 /obj/item/mortar_shell/custom/attack_self(mob/user)

--- a/code/modules/cm_marines/equipment/mortar/mortars.dm
+++ b/code/modules/cm_marines/equipment/mortar/mortars.dm
@@ -216,7 +216,7 @@
 			busy = FALSE
 			firing = TRUE
 			flick(icon_state + "_fire", src)
-			mortar_shell.source_mob = user
+			mortar_shell.cause_data = create_cause_data(initial(mortar_shell.name), user, src)
 			mortar_shell.forceMove(src)
 
 			var/turf/G = get_turf(src)

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -2021,6 +2021,7 @@
 	if(rocket.locked && rocket.warhead && rocket.warhead.detonator)
 		if(rocket.fuel && rocket.fuel.reagents.get_reagent_amount(rocket.fuel_type) >= rocket.fuel_requirement)
 			rocket.forceMove(P.loc)
+		rocket.warhead.cause_data = P.weapon_cause_data
 		rocket.warhead.prime()
 		qdel(rocket)
 	smoke.set_up(1, get_turf(A))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

`Cause_data` again. The saga never ends.

## Why It's Good For The Game

Is fix.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
admin: Custom OT rockets and mortar shells now correctly attribute their explosions to firer and not to maker.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
