### PR TITLE
removes queen ow fruit

### DIFF
--- a/code/modules/cm_aliens/structures/fruit.dm
+++ b/code/modules/cm_aliens/structures/fruit.dm
@@ -151,8 +151,6 @@
 			xeno_noncombat_delay(X)
 			if(!do_after(X, consume_delay, INTERRUPT_ALL, BUSY_ICON_FRIENDLY))
 				return XENO_NO_DELAY_ACTION
-			if(isXenoQueen(X) && X.observed_xeno && X.observed_xeno.stat != DEAD)
-				consume_effect(X.observed_xeno, FALSE)
 			consume_effect(X)
 		else
 			to_chat(X, SPAN_XENOWARNING("[name] isn't ripe yet. You need to wait a little longer."))
@@ -385,8 +383,6 @@
 		SPAN_NOTICE("[user] [user == X ? "ate" : "fed [X]"] <b>[src]</b>."))
 	var/obj/effect/alien/resin/fruit/F = new fruit_type(X)
 	F.mature = TRUE
-	if(isXenoQueen(X) && X.observed_xeno && X.observed_xeno.stat != DEAD && X.z == X.observed_xeno.z)
-		F.consume_effect(X.observed_xeno, FALSE)
 	F.consume_effect(X)
 	//Notify the fruit's bound xeno if they exist
 	if(!QDELETED(bound_xeno))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

removes the ability of fruits fed through OW to affect other xenos

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

turns out being able to give UAV heals, shields, and speed boosts was not very balanced.

gardener drones should need to be near to the xenos they are helping in order to apply buffs

they should not be able to do it from the entire map's distance away while their target is stunned

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: feeding a fruit to a queen on ovi who is overwatching a xeno will no longer give the overwatched xeno the fruit's effects.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
