### PR TITLE
Mortar interactions tweaks

### DIFF
--- a/code/modules/cm_marines/equipment/mortar/mortars.dm
+++ b/code/modules/cm_marines/equipment/mortar/mortars.dm
@@ -61,7 +61,7 @@
 		return XENO_NO_DELAY_ACTION
 
 	if(fixed)
-		to_chat(M, SPAN_XENOWARNING("[src]'s supports are bolted and welded into the floor. It looks like it's going to be staying there."))
+		to_chat(M, SPAN_XENOWARNING("\The [src]'s supports are bolted and welded into the floor. It looks like it's going to be staying there."))
 		return XENO_NO_DELAY_ACTION
 
 	if(firing)
@@ -70,11 +70,11 @@
 		playsound(src, "acid_hit", 25, 1)
 		playsound(M, "alien_help", 25, 1)
 		M.apply_damage(10, BURN)
-		M.visible_message(SPAN_DANGER("[M] has tried to knock steaming hot [src] over, but pulled away burning itself!"),
-		SPAN_XENOWARNING("[src] is burning hot! Wait a few seconds."))
+		M.visible_message(SPAN_DANGER("[M] tried to knock the steaming hot [src] over, but burned itself and pulled away!"),
+		SPAN_XENOWARNING("\The [src] is burning hot! Wait a few seconds."))
 		return XENO_ATTACK_ACTION
 
-	M.visible_message(SPAN_DANGER("[M] has lashed at \the [src] and knocked it over!"),
+	M.visible_message(SPAN_DANGER("[M] lashes at \the [src] and knocks it over!"),
 	SPAN_DANGER("You knock \the [src] over!"))
 	M.animation_attack_on(src)
 	M.flick_attack_overlay(src, "slash")

--- a/code/modules/cm_marines/equipment/mortar/mortars.dm
+++ b/code/modules/cm_marines/equipment/mortar/mortars.dm
@@ -45,6 +45,46 @@
 	qdel(internal_camera)
 	return ..()
 
+/obj/structure/mortar/initialize_pass_flags(var/datum/pass_flags_container/PF)
+	..()
+	if (PF)
+		PF.flags_can_pass_all = PASS_OVER
+
+/obj/structure/mortar/get_projectile_hit_boolean(obj/item/projectile/P)
+	if(P.original == src)
+		return TRUE
+	else
+		return FALSE
+
+/obj/structure/mortar/attack_alien(mob/living/carbon/Xenomorph/M)
+	if(isXenoLarva(M))
+		return XENO_NO_DELAY_ACTION
+
+	if(fixed)
+		to_chat(M, SPAN_XENOWARNING("[src]'s supports are bolted and welded into the floor. It looks like it's going to be staying there."))
+		return XENO_NO_DELAY_ACTION
+
+	if(firing)
+		M.animation_attack_on(src)
+		M.flick_attack_overlay(src, "slash")
+		playsound(src, "acid_hit", 25, 1)
+		playsound(M, "alien_help", 25, 1)
+		M.apply_damage(10, BURN)
+		M.visible_message(SPAN_DANGER("[M] has tried to knock steaming hot [src] over, but pulled away burning itself!"),
+		SPAN_XENOWARNING("[src] is burning hot! Wait a few seconds."))
+		return XENO_ATTACK_ACTION
+
+	M.visible_message(SPAN_DANGER("[M] has lashed at \the [src] and knocked it over!"),
+	SPAN_DANGER("You knock \the [src] over!"))
+	M.animation_attack_on(src)
+	M.flick_attack_overlay(src, "slash")
+	playsound(loc, 'sound/effects/metalhit.ogg', 25)
+	var/obj/item/mortar_kit/MK = new /obj/item/mortar_kit(loc)
+	MK.name = name
+	qdel(src)
+
+	return XENO_ATTACK_ACTION
+
 /obj/structure/mortar/attack_hand(mob/user)
 	if(isYautja(user))
 		to_chat(user, SPAN_WARNING("You kick [src] but nothing happens."))


### PR DESCRIPTION
## About The Pull Request

1. Mortar doesn't block flames, acid, spits and bullets.
2. Xenos can slash mortar to knock it over.

## Why It's Good For The Game

Mortar is no longer a perfect wall.

## Changelog

:cl: Jeser
code: Mortar doesn't block flames, acid spray, spits and bullets now.
code: Xenos can slash mortar to knock it over.
/:cl: