### PR TITLE
fixes dancer triple impale

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/praetorian/praetorian_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/praetorian/praetorian_powers.dm
@@ -507,7 +507,7 @@
 		return
 
 	var/buffed = FALSE
-
+	apply_cooldown()
 	if (X.mutation_type == PRAETORIAN_DANCER)
 		var/found = FALSE
 		for (var/datum/effects/dancer_tag/DT in H.effects_list)
@@ -529,7 +529,7 @@
 	X.visible_message(SPAN_DANGER("\The [X] violently slices [A] with its tail[buffed?" twice":""]!"), \
 					SPAN_DANGER("You slice [A] with your tail[buffed?" twice":""]!"))
 
-	if (buffed)
+	if(buffed)
 		// Do two attacks instead of one
 		X.animation_attack_on(A)
 		X.flick_attack_overlay(A, "slash")
@@ -549,8 +549,6 @@
 	H.last_damage_data = create_cause_data(initial(X.caste_type), X)
 	H.apply_armoured_damage(damage, ARMOR_MELEE, BRUTE, "chest", 10)
 	playsound(get_turf(A), "alien_claw_flesh", 30, 1)
-
-	apply_cooldown()
 	..()
 	return
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

applies the cooldown earlier to stop triple impale abuse

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

bugfix

Thank you to Praetorian DIL for helping me find this bug!

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: dancer praes can no longer use the impale ability twice in a row, as the cooldown on the ability is now applied earlier
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
