### PR TITLE
Big Red Last Stand

### DIFF
--- a/code/game/objects/effects/landmarks/survivor_spawner.dm
+++ b/code/game/objects/effects/landmarks/survivor_spawner.dm
@@ -61,4 +61,16 @@
 	roundstart_damage_max = 10
 	roundstart_damage_times = 2
 
+/obj/effect/landmark/survivor_spawner/bigred_clf
+	equipment = /datum/equipment_preset/survivor/clf
+	intro_text = list("<h2>You are a survivor of a colonial uprising!</h2>",\
+	"<span class='notice'>You are NOT aware of the xenomorph threat.</span>",\
+	"<span class='danger'>Your primary objective is to heal up and survive. If you want to assault the hive - adminhelp.</span>")
+	story_text = "You are a soldier of the Colonial Liberation Front. Your ship received a distress signal from a planet bordering CLF controlled space under USCM control. Ready and willing to save poor colonists from parasitic tyrants, you and your team boarded a small ship called the Marie Curie. You took over the Colonial Marshal's office and sent an all clear signal to the nearby PMC distress team, however an unknown entity has responded to the call. You dont know who they are but they will likely identify you as a foe."
 
+/obj/effect/landmark/survivor_spawner/dnd
+	equipment = /datum/equipment_preset/survivor/civilian
+	intro_text = list("<h2>You are a civilian participating in a dungeons and dragons game!</h2>",\
+	"<span class='notice'>You are NOT aware of the xenomorph threat due to the rather engaging dnd game going on.</span>",\
+	"<span class='danger'>Your primary objective is to have a fun time and survive. If you want to assualt the hive - ahelp.</span>")
+	story_text = "You are a group of colonist who regularly meet up to play dnd in the library every friday night. You alongside your fellow colonist brought various costumes, food, drinks, and props (very real guns) to help get you all into character. You aren't very exceptional in your skills but you do have the one thing that bests even the mightiest demons. That special power imagination!"

--- a/code/modules/gear_presets/survivors.dm
+++ b/code/modules/gear_presets/survivors.dm
@@ -512,9 +512,8 @@
 	access = list(ACCESS_CIVILIAN_PUBLIC)
 
 /datum/equipment_preset/survivor/civilian/load_gear(mob/living/carbon/human/H)
-	H.equip_to_slot_or_del(new /obj/item/clothing/under/pj/red(H), WEAR_BODY)
-	if(SSmapping.configs[GROUND_MAP].environment_traits[MAP_COLD])
-		add_ice_colony_survivor_equipment(H)
+	H.equip_to_slot_or_del(new /obj/item/device/radio/headset/distress(H), WEAR_L_EAR)
+	H.equip_to_slot_or_del(new /obj/item/clothing/under/colonist(H), WEAR_BODY)
 	H.equip_to_slot_or_del(new /obj/item/storage/backpack/satchel/norm(H), WEAR_BACK)
 	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/black(H), WEAR_FEET)
 	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/black(H), WEAR_FEET)

--- a/maps/map_files/BigRed/BigRed.dmm
+++ b/maps/map_files/BigRed/BigRed.dmm
@@ -30223,6 +30223,12 @@
 	tag = "icon-mars_dirt_4"
 	},
 /area/bigredv2/caves_sw)
+"dxX" = (
+/obj/effect/landmark/nightmare{
+	insert_tag = "clfmarshalls"
+	},
+/turf/closed/wall/solaris/reinforced,
+/area/bigredv2/outside/marshal_office)
 "dyv" = (
 /turf/open/mars,
 /area/bigredv2/caves/eta/xenobiology)
@@ -35040,6 +35046,12 @@
 	tag = "icon-mars_dirt_7"
 	},
 /area/bigredv2/caves_research)
+"nnK" = (
+/obj/effect/landmark/nightmare{
+	insert_tag = "bigredbarls"
+	},
+/turf/closed/wall/solaris,
+/area/bigredv2/outside/bar)
 "npz" = (
 /obj/structure/surface/table,
 /obj/item/spacecash/c100,
@@ -38022,6 +38034,12 @@
 	tag = "icon-mars_cave_5"
 	},
 /area/bigredv2/caves_se)
+"sJp" = (
+/obj/effect/landmark/nightmare{
+	insert_tag = "dndsolaris"
+	},
+/turf/closed/wall/solaris,
+/area/bigredv2/outside/library)
 "sJq" = (
 /obj/structure/fence,
 /turf/open/floor{
@@ -58653,7 +58671,7 @@ acp
 als
 ajL
 anc
-acp
+dxX
 acp
 acp
 alX
@@ -65200,7 +65218,7 @@ aoz
 anJ
 aoz
 anJ
-anJ
+nnK
 aHD
 aBR
 aVo
@@ -73228,7 +73246,7 @@ anW
 anW
 anW
 anW
-anW
+sJp
 anW
 aTq
 aUp

--- a/maps/map_files/BigRed/sprinkles/25.bigredbarls.dmm
+++ b/maps/map_files/BigRed/sprinkles/25.bigredbarls.dmm
@@ -1,0 +1,1538 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ax" = (
+/obj/effect/landmark/corpsespawner/pmc,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"bM" = (
+/turf/open/mars_cave{
+	icon_state = "mars_dirt_4";
+	tag = "icon-mars_dirt_4"
+	},
+/area/template_noop)
+"cd" = (
+/obj/structure/surface/table/woodentable,
+/obj/item/storage/firstaid/regular,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"ct" = (
+/obj/structure/machinery/cm_vending/sorted/boozeomat,
+/obj/structure/machinery/light{
+	dir = 4;
+	tag = "icon-tube1 (EAST)"
+	},
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"eC" = (
+/turf/open/floor,
+/area/template_noop)
+"eQ" = (
+/obj/structure/machinery/reagentgrinder,
+/obj/structure/surface/table/woodentable,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"fa" = (
+/obj/structure/surface/table/woodentable,
+/obj/item/storage/firstaid/adv,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"fi" = (
+/obj/structure/machinery/alarm{
+	dir = 4;
+	pixel_x = -30
+	},
+/turf/open/floor{
+	dir = 8;
+	icon_state = "carpet15-15";
+	tag = "icon-carpet15-15 (WEST)"
+	},
+/area/template_noop)
+"fz" = (
+/obj/structure/bed/chair/wood/normal{
+	dir = 8;
+	tag = ""
+	},
+/obj/item/ammo_casing/bullet,
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"fG" = (
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_2"
+	},
+/obj/item/ammo_casing/bullet,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"fJ" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 6
+	},
+/obj/structure/barricade/plasteel/wired{
+	icon_state = "plasteel_2"
+	},
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"fS" = (
+/obj/structure/machinery/door/airlock/almayer/medical/glass{
+	dir = 1;
+	name = "\improper Recreation"
+	},
+/obj/structure/machinery/door/poddoor/shutters/almayer{
+	id = "Bar Complex";
+	name = "\improper Bar Complex Shutters"
+	},
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"gv" = (
+/turf/open/floor{
+	dir = 8;
+	icon_state = "carpet15-15";
+	tag = "icon-carpet15-15 (WEST)"
+	},
+/area/template_noop)
+"gM" = (
+/obj/structure/bed,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"gV" = (
+/obj/structure/pipes/standard/manifold/hidden/green,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"ha" = (
+/obj/structure/reagent_dispensers/beerkeg,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"he" = (
+/turf/open/floor{
+	dir = 8;
+	icon_state = "carpet11-12";
+	tag = "icon-carpet11-12 (WEST)"
+	},
+/area/template_noop)
+"hz" = (
+/obj/structure/pipes/standard/simple/hidden/green,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"hP" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"ic" = (
+/obj/effect/landmark/corpsespawner,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"iq" = (
+/obj/structure/pipes/standard/manifold/hidden/green{
+	dir = 1
+	},
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"iD" = (
+/obj/structure/machinery/chem_dispenser/soda{
+	density = 0;
+	pixel_y = 32
+	},
+/obj/structure/machinery/door_control{
+	id = "Bar Complex";
+	name = "Storm Shutters";
+	pixel_x = 32
+	},
+/obj/structure/machinery/camera/autoname{
+	dir = 8
+	},
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"jD" = (
+/obj/structure/machinery/light,
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_2"
+	},
+/obj/item/ammo_casing/bullet,
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"kp" = (
+/obj/structure/machinery/door/airlock/multi_tile/almayer/generic{
+	name = "\improper Bar"
+	},
+/obj/structure/machinery/door/poddoor/shutters/almayer{
+	id = "Bar Complex";
+	name = "\improper Bar Complex Shutters"
+	},
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"lb" = (
+/obj/structure/bed/stool,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"lq" = (
+/obj/structure/machinery/computer/arcade,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"lI" = (
+/obj/structure/window/framed/solaris,
+/obj/structure/machinery/door/poddoor/shutters/almayer{
+	dir = 4;
+	id = "Bar Complex";
+	name = "\improper Bar Complex Shutters"
+	},
+/turf/open/floor/plating,
+/area/template_noop)
+"md" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/obj/structure/surface/table/woodentable,
+/obj/item/stack/sheet/wood/large_stack,
+/obj/item/stack/sheet/wood/large_stack,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"mi" = (
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"nK" = (
+/obj/structure/bed/stool,
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"nV" = (
+/obj/structure/machinery/camera/autoname,
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 10
+	},
+/obj/structure/barricade/plasteel/wired{
+	dir = 8
+	},
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"nX" = (
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"ob" = (
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_2"
+	},
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"oe" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/obj/structure/machinery/door/poddoor/shutters/almayer{
+	dir = 4;
+	id = "Bar Complex";
+	name = "\improper Bar Complex Shutters"
+	},
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"oA" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "carpet15-15";
+	tag = "icon-carpet15-15 (WEST)"
+	},
+/area/template_noop)
+"oD" = (
+/obj/structure/barricade/plasteel/wired{
+	dir = 1;
+	icon_state = "plasteel_2"
+	},
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"oK" = (
+/obj/structure/surface/table/woodentable,
+/obj/structure/pipes/vents/pump{
+	dir = 8
+	},
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"pf" = (
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_2";
+	dir = 8
+	},
+/obj/effect/landmark/corpsespawner/engineer,
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"pL" = (
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_2"
+	},
+/obj/structure/barricade/plasteel/wired{
+	dir = 4;
+	icon_state = "plasteel_2"
+	},
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"qj" = (
+/turf/open/floor/plating,
+/area/template_noop)
+"qQ" = (
+/obj/effect/decal/cleanable/blood{
+	icon_state = "gib6";
+	tag = "icon-gib6"
+	},
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"qS" = (
+/obj/structure/window/framed/solaris,
+/obj/structure/machinery/door/poddoor/shutters/almayer{
+	id = "Bar Complex";
+	name = "\improper Bar Complex Shutters"
+	},
+/turf/open/floor/plating,
+/area/template_noop)
+"qX" = (
+/obj/structure/pipes/standard/simple/hidden/green,
+/turf/open/floor/plating,
+/area/template_noop)
+"qY" = (
+/obj/structure/machinery/light{
+	dir = 8
+	},
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"rb" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 9
+	},
+/obj/effect/landmark/corpsespawner/pmc,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"rd" = (
+/obj/structure/barricade/plasteel/wired{
+	dir = 1;
+	icon_state = "plasteel_2"
+	},
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "carpet15-15";
+	tag = "icon-carpet15-15 (WEST)"
+	},
+/area/template_noop)
+"rp" = (
+/obj/structure/pipes/standard/simple/hidden/green,
+/obj/structure/machinery/door/airlock/almayer/maint{
+	dir = 1;
+	name = "\improper Bar Maintenance";
+	req_one_access = null
+	},
+/obj/structure/machinery/door/poddoor/shutters/almayer{
+	id = "Bar Complex";
+	name = "\improper Bar Complex Shutters"
+	},
+/turf/open/floor/plating,
+/area/template_noop)
+"ry" = (
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "carpet15-15";
+	tag = "icon-carpet15-15 (WEST)"
+	},
+/area/template_noop)
+"rD" = (
+/obj/structure/pipes/standard/simple/hidden/green,
+/obj/item/ammo_casing/bullet,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"sg" = (
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_2"
+	},
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_2";
+	dir = 8
+	},
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"tj" = (
+/obj/structure/surface/table/woodentable,
+/obj/item/toy/beach_ball,
+/obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"tq" = (
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_2";
+	dir = 8
+	},
+/obj/effect/landmark/corpsespawner/chef,
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"ts" = (
+/turf/open/floor{
+	dir = 8;
+	icon_state = "carpet9-4";
+	tag = "icon-carpet9-4 (WEST)"
+	},
+/area/template_noop)
+"tF" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"tH" = (
+/obj/structure/machinery/light,
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/turf/open/floor,
+/area/template_noop)
+"tK" = (
+/obj/structure/machinery/light{
+	dir = 1;
+	tag = "icon-tube1 (NORTH)"
+	},
+/turf/open/floor/plating,
+/area/template_noop)
+"tR" = (
+/obj/structure/barricade/metal/wired{
+	dir = 1;
+	icon_state = "metal_2"
+	},
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"ul" = (
+/obj/item/paper_bin,
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_2"
+	},
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"uu" = (
+/obj/structure/machinery/power/apc,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"uR" = (
+/obj/structure/pipes/standard/simple/hidden/green,
+/obj/structure/barricade/plasteel/wired{
+	dir = 1;
+	icon_state = "plasteel_2"
+	},
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"uZ" = (
+/obj/structure/pipes/standard/manifold/hidden/green,
+/turf/open/floor,
+/area/template_noop)
+"vc" = (
+/obj/structure/machinery/door_control{
+	id = "Dormitories";
+	name = "Storm Shutters";
+	pixel_y = -32
+	},
+/obj/structure/machinery/camera/autoname{
+	dir = 1
+	},
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"vv" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/obj/structure/barricade/plasteel/wired{
+	dir = 4;
+	icon_state = "plasteel_2"
+	},
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"vQ" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/landmark/corpsespawner/pmc,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"yz" = (
+/obj/structure/machinery/squeezer,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"zm" = (
+/obj/structure/bed/stool,
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"zV" = (
+/obj/structure/machinery/door/airlock/multi_tile/almayer/generic{
+	dir = 1;
+	name = "\improper Bar"
+	},
+/obj/structure/machinery/door/poddoor/shutters/almayer{
+	dir = 4;
+	id = "Bar Complex";
+	name = "\improper Bar Complex Shutters"
+	},
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"Ac" = (
+/obj/structure/pipes/standard/simple/hidden/green,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor{
+	icon_state = "grimy"
+	},
+/area/template_noop)
+"AI" = (
+/obj/structure/surface/table/woodentable,
+/obj/structure/largecrate/guns/merc{
+	name = "\improper dodgy crate"
+	},
+/obj/structure/largecrate/guns/merc{
+	name = "\improper dodgy crate"
+	},
+/obj/structure/largecrate/guns/merc{
+	name = "\improper dodgy crate"
+	},
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"Bm" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor{
+	icon_state = "grimy"
+	},
+/area/template_noop)
+"BN" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/template_noop)
+"Cb" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/obj/structure/machinery/alarm{
+	dir = 1;
+	pixel_y = -30;
+	tag = "icon-alarm0 (NORTH)"
+	},
+/turf/open/floor,
+/area/template_noop)
+"Cm" = (
+/obj/structure/closet/boxinggloves,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"Cn" = (
+/obj/structure/bed/chair/wood/normal{
+	dir = 4;
+	tag = ""
+	},
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"CB" = (
+/obj/structure/pipes/standard/simple/hidden/green,
+/obj/effect/landmark/corpsespawner/doctor,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"Dc" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/obj/structure/surface/table/woodentable,
+/obj/item/stack/sheet/metal/large_stack,
+/obj/item/stack/sheet/metal/large_stack,
+/obj/item/ammo_casing/bullet,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"Dr" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"Ea" = (
+/obj/structure/machinery/light{
+	dir = 1
+	},
+/turf/open/floor{
+	dir = 8;
+	icon_state = "carpet15-15";
+	tag = "icon-carpet15-15 (WEST)"
+	},
+/area/template_noop)
+"Eb" = (
+/turf/open/floor{
+	dir = 8;
+	icon_state = "carpet13-5";
+	tag = "icon-carpet13-5 (WEST)"
+	},
+/area/template_noop)
+"Fa" = (
+/obj/structure/bed/chair/wood/normal{
+	dir = 8;
+	tag = ""
+	},
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"Fz" = (
+/obj/structure/barricade/plasteel/wired{
+	icon_state = "plasteel_2"
+	},
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"FC" = (
+/obj/structure/pipes/standard/simple/hidden/green,
+/obj/effect/landmark/corpsespawner/colonist,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"FP" = (
+/obj/structure/surface/table/woodentable,
+/obj/structure/largecrate/merc/ammo,
+/obj/structure/largecrate/merc/ammo,
+/obj/structure/largecrate/merc/ammo,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"Gc" = (
+/obj/structure/surface/table/woodentable,
+/obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"Gi" = (
+/obj/effect/decal/cleanable/blood{
+	layer = 3
+	},
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_2"
+	},
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"Gt" = (
+/obj/structure/barricade/plasteel/wired{
+	dir = 1;
+	icon_state = "plasteel_2"
+	},
+/turf/open/floor{
+	dir = 8;
+	icon_state = "carpet15-15";
+	tag = "icon-carpet15-15 (WEST)"
+	},
+/area/template_noop)
+"GX" = (
+/obj/structure/surface/table/woodentable,
+/obj/item/stack/sandbags/large_stack,
+/obj/item/stack/sandbags/large_stack,
+/obj/item/tool/shovel/etool,
+/obj/item/stack/sandbags_empty/full,
+/obj/item/stack/sandbags_empty/full,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"HC" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/template_noop)
+"Ic" = (
+/obj/structure/pipes/standard/manifold/hidden/green{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/template_noop)
+"In" = (
+/obj/structure/pipes/vents/pump{
+	dir = 1
+	},
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"IA" = (
+/turf/open/floor{
+	icon_state = "grimy"
+	},
+/area/template_noop)
+"IP" = (
+/obj/structure/machinery/door/airlock/almayer/generic{
+	dir = 1;
+	name = "\improper Bar Backroom"
+	},
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"Jk" = (
+/obj/structure/pipes/standard/simple/hidden/green,
+/obj/item/ammo_casing/bullet,
+/obj/item/ammo_casing/bullet,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"Kv" = (
+/obj/structure/bed/chair/wood/normal{
+	dir = 4;
+	tag = ""
+	},
+/obj/effect/landmark/survivor_spawner,
+/obj/effect/landmark/corpsespawner/pmc,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"KB" = (
+/obj/structure/barricade/plasteel/wired,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"Ld" = (
+/turf/open/floor{
+	icon_state = "asteroidwarning";
+	tag = "icon-asteroidwarning"
+	},
+/area/template_noop)
+"Li" = (
+/obj/item/device/radio/intercom{
+	freerange = 1;
+	frequency = 1469;
+	name = "General Listening Channel";
+	pixel_x = 30
+	},
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"LT" = (
+/obj/structure/machinery/light{
+	dir = 8;
+	tag = "icon-tube1 (WEST)"
+	},
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"Mr" = (
+/obj/structure/surface/table/woodentable,
+/obj/item/tool/weldpack,
+/obj/item/tool/weldingtool,
+/obj/item/clothing/glasses/welding,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"Nm" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/obj/structure/machinery/door/airlock/almayer/generic{
+	name = "\improper Bar Backroom"
+	},
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"Nn" = (
+/obj/structure/surface/table/woodentable,
+/obj/item/ammo_box/magazine/shotgun/buckshot,
+/obj/item/clothing/suit/armor/vest,
+/obj/item/clothing/suit/armor/vest,
+/obj/item/clothing/suit/armor/vest,
+/obj/item/ammo_casing/bullet,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"Ou" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/obj/structure/barricade/wooden{
+	desc = "This barricade is heavily reinforced. Nothing short of blasting it open seems like it'll do the trick, that or melting the breams supporting it...";
+	dir = 4;
+	health = 25000
+	},
+/turf/open/floor/plating,
+/area/template_noop)
+"Qn" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 5
+	},
+/obj/structure/bed/chair/wood/normal{
+	dir = 4;
+	tag = ""
+	},
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"Qz" = (
+/obj/structure/pipes/standard/manifold/hidden/green{
+	dir = 8
+	},
+/obj/structure/barricade/plasteel/wired{
+	dir = 1;
+	icon_state = "plasteel_2"
+	},
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"QA" = (
+/obj/effect/landmark/corpsespawner/colonist,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"QG" = (
+/obj/structure/machinery/light,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"QK" = (
+/turf/closed/wall/solaris,
+/area/template_noop)
+"Rs" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/obj/structure/barricade/wooden{
+	desc = "This barricade is heavily reinforced. Nothing short of blasting it open seems like it'll do the trick, that or melting the breams supporting it...";
+	dir = 8;
+	health = 25000
+	},
+/turf/open/floor/plating,
+/area/template_noop)
+"Si" = (
+/obj/structure/surface/table/woodentable,
+/obj/item/device/radio,
+/obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"SD" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "asteroidfloor";
+	tag = "icon-asteroidfloor (NORTH)"
+	},
+/area/template_noop)
+"SE" = (
+/obj/structure/pipes/standard/simple/hidden/green,
+/obj/effect/landmark/corpsespawner/pmc,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"SF" = (
+/obj/item/ammo_casing/bullet,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "carpet13-5";
+	tag = "icon-carpet13-5 (WEST)"
+	},
+/area/template_noop)
+"SX" = (
+/obj/structure/machinery/light{
+	dir = 1
+	},
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"Tc" = (
+/obj/structure/pipes/vents/pump,
+/obj/structure/bed/chair/wood/normal{
+	dir = 4;
+	tag = ""
+	},
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"Ts" = (
+/obj/structure/pipes/standard/manifold/hidden/green{
+	dir = 8
+	},
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"TF" = (
+/obj/structure/machinery/cm_vending/sorted/boozeomat,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"Uq" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/turf/open/floor,
+/area/template_noop)
+"UC" = (
+/obj/structure/bed/stool,
+/obj/item/ammo_casing/bullet,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"UF" = (
+/obj/structure/bed,
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"UL" = (
+/obj/structure/barricade/plasteel/wired{
+	icon_state = "plasteel_2"
+	},
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"UX" = (
+/obj/effect/decal/cleanable/blood/gibs/body,
+/obj/structure/pipes/standard/simple/hidden/green,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"Wd" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/obj/structure/bed/chair/wood/normal{
+	dir = 8;
+	tag = ""
+	},
+/obj/item/ammo_casing/bullet,
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"Wm" = (
+/obj/structure/reagent_dispensers/beerkeg,
+/obj/structure/machinery/light{
+	dir = 4;
+	tag = "icon-tube1 (EAST)"
+	},
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"Wn" = (
+/obj/effect/landmark/lv624/xeno_tunnel,
+/turf/open/mars_cave{
+	icon_state = "mars_dirt_4";
+	tag = "icon-mars_dirt_4"
+	},
+/area/template_noop)
+"Wq" = (
+/obj/structure/closet/athletic_mixed,
+/obj/structure/machinery/light{
+	dir = 8
+	},
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"Xl" = (
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_2";
+	dir = 8
+	},
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"Xu" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/obj/structure/machinery/door/airlock/almayer/maint{
+	name = "\improper Bar Maintenance";
+	req_one_access = null
+	},
+/turf/open/floor/plating,
+/area/template_noop)
+"XZ" = (
+/obj/structure/surface/table/woodentable,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"Yc" = (
+/obj/structure/closet/secure_closet/bar,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"Yd" = (
+/obj/item/ammo_casing/bullet,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"Yi" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/obj/item/ammo_casing/bullet,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"Yw" = (
+/obj/structure/pipes/standard/simple/hidden/green,
+/obj/structure/machinery/door/poddoor/shutters/almayer{
+	id = "Bar Complex";
+	name = "\improper Bar Complex Shutters"
+	},
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"ZP" = (
+/obj/structure/surface/table/woodentable,
+/obj/item/ammo_box/magazine/shotgun,
+/obj/item/weapon/gun/shotgun/pump/cmb,
+/obj/item/weapon/gun/shotgun/pump/cmb,
+/obj/item/weapon/gun/shotgun/pump/cmb,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"ZX" = (
+/obj/structure/surface/table/woodentable,
+/obj/item/stack/sheet/plasteel/large_stack,
+/obj/item/stack/sheet/plasteel/large_stack,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+
+(1,1,1) = {"
+Bm
+Cb
+QK
+QK
+QK
+QK
+QK
+QK
+QK
+QK
+QK
+QK
+QK
+lI
+QK
+lI
+QK
+lI
+QK
+lI
+QK
+QK
+"}
+(2,1,1) = {"
+Bm
+Uq
+QK
+tj
+Gc
+Cm
+Wq
+Gc
+Si
+QK
+ry
+fi
+Eb
+Xl
+mi
+Xl
+qY
+Xl
+mi
+Xl
+mi
+QK
+"}
+(3,1,1) = {"
+Ac
+uZ
+fS
+oD
+mi
+Yd
+mi
+mi
+mi
+fS
+Gt
+gv
+Eb
+Cn
+Tc
+FC
+SE
+Qn
+Kv
+Yd
+ob
+qS
+"}
+(4,1,1) = {"
+Bm
+tH
+QK
+tR
+mi
+mi
+mi
+Yd
+vc
+QK
+ry
+gv
+Eb
+ZP
+AI
+mi
+Dr
+md
+GX
+mi
+mi
+QK
+"}
+(5,1,1) = {"
+IA
+Uq
+fS
+oD
+UC
+lb
+lb
+lb
+lb
+fS
+rd
+oA
+SF
+Nn
+FP
+Yd
+mi
+Dc
+ZX
+mi
+fG
+qS
+"}
+(6,1,1) = {"
+eC
+Uq
+QK
+Gc
+lq
+lq
+lq
+lq
+lq
+QK
+Ea
+gv
+SF
+fz
+Fa
+mi
+mi
+Wd
+Fa
+nX
+mi
+QK
+"}
+(7,1,1) = {"
+QK
+Xu
+QK
+QK
+QK
+QK
+QK
+QK
+QK
+QK
+he
+SE
+ts
+ax
+vQ
+mi
+mi
+hP
+mi
+mi
+QG
+QK
+"}
+(8,1,1) = {"
+QK
+Rs
+qj
+qj
+qj
+QK
+SX
+mi
+ax
+mi
+tR
+mi
+mi
+Yd
+Yd
+mi
+nX
+hP
+mi
+qQ
+Fz
+kp
+"}
+(9,1,1) = {"
+QK
+BN
+Ic
+qX
+qX
+rp
+Qz
+hz
+hz
+hz
+uR
+UX
+hz
+Jk
+rD
+hz
+CB
+gV
+nX
+mi
+fJ
+Yw
+"}
+(10,1,1) = {"
+QK
+tK
+HC
+qj
+qj
+QK
+hP
+QA
+mi
+vQ
+tR
+nX
+mi
+Yd
+mi
+Dr
+mi
+iq
+rD
+Ts
+rb
+QK
+"}
+(11,1,1) = {"
+QK
+qj
+Ou
+qj
+qj
+QK
+hP
+mi
+nX
+mi
+tR
+ic
+Li
+zm
+zm
+zm
+zm
+nK
+mi
+hP
+mi
+QK
+"}
+(12,1,1) = {"
+QK
+QK
+Xu
+QK
+QK
+QK
+Nm
+QK
+QK
+QK
+QK
+QK
+QK
+fa
+cd
+Mr
+XZ
+oK
+XZ
+Yi
+Gi
+qS
+"}
+(13,1,1) = {"
+LT
+QK
+SD
+Ld
+Wn
+QK
+nV
+hz
+In
+nX
+eQ
+tF
+QK
+Xl
+tq
+Xl
+pf
+sg
+XZ
+hP
+nX
+QK
+"}
+(14,1,1) = {"
+gM
+QK
+SD
+Ld
+bM
+QK
+uu
+ic
+mi
+mi
+mi
+KB
+IP
+mi
+mi
+mi
+mi
+UL
+mi
+hP
+jD
+QK
+"}
+(15,1,1) = {"
+QK
+QK
+SD
+Ld
+bM
+QK
+ha
+ha
+Wm
+yz
+Yc
+UF
+QK
+TF
+ct
+QK
+iD
+ul
+XZ
+vv
+pL
+qS
+"}
+(16,1,1) = {"
+LT
+QK
+SD
+Ld
+bM
+QK
+QK
+QK
+QK
+QK
+QK
+QK
+QK
+QK
+QK
+QK
+QK
+QK
+QK
+oe
+zV
+QK
+"}

--- a/maps/map_files/BigRed/sprinkles/25.bigredbarls.dmm
+++ b/maps/map_files/BigRed/sprinkles/25.bigredbarls.dmm
@@ -1,13 +1,10 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-<<<<<<< HEAD
 "ax" = (
 /obj/effect/landmark/corpsespawner/pmc,
 /turf/open/floor{
 	icon_state = "wood"
 	},
 /area/template_noop)
-=======
->>>>>>> big_red_final_last_stand
 "bM" = (
 /turf/open/mars_cave{
 	icon_state = "mars_dirt_4";
@@ -546,7 +543,6 @@
 	icon_state = "wood"
 	},
 /area/template_noop)
-<<<<<<< HEAD
 "vQ" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/landmark/corpsespawner/pmc,
@@ -554,8 +550,6 @@
 	icon_state = "wood"
 	},
 /area/template_noop)
-=======
->>>>>>> big_red_final_last_stand
 "yz" = (
 /obj/structure/machinery/squeezer,
 /turf/open/floor{
@@ -634,7 +628,6 @@
 	icon_state = "wood"
 	},
 /area/template_noop)
-<<<<<<< HEAD
 "Cn" = (
 /obj/structure/bed/chair/wood/normal{
 	dir = 4;
@@ -645,8 +638,6 @@
 	icon_state = "wood"
 	},
 /area/template_noop)
-=======
->>>>>>> big_red_final_last_stand
 "CB" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/effect/landmark/corpsespawner/doctor,
@@ -813,10 +804,7 @@
 	tag = ""
 	},
 /obj/effect/landmark/survivor_spawner,
-<<<<<<< HEAD
 /obj/effect/landmark/corpsespawner/pmc,
-=======
->>>>>>> big_red_final_last_stand
 /turf/open/floor{
 	icon_state = "wood"
 	},
@@ -966,18 +954,10 @@
 	},
 /area/template_noop)
 "SE" = (
-<<<<<<< HEAD
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/effect/landmark/corpsespawner/pmc,
 /turf/open/floor{
 	icon_state = "wood"
-=======
-/obj/effect/landmark/corpsespawner/pmc,
-/turf/open/floor{
-	dir = 8;
-	icon_state = "carpet11-12";
-	tag = "icon-carpet11-12 (WEST)"
->>>>>>> big_red_final_last_stand
 	},
 /area/template_noop)
 "SF" = (
@@ -1207,11 +1187,7 @@ Wq
 Gc
 Si
 QK
-<<<<<<< HEAD
 ry
-=======
-gv
->>>>>>> big_red_final_last_stand
 fi
 Eb
 Xl
@@ -1238,17 +1214,10 @@ fS
 Gt
 gv
 Eb
-<<<<<<< HEAD
 Cn
 Tc
 FC
 SE
-=======
-Kv
-Tc
-FC
-hz
->>>>>>> big_red_final_last_stand
 Qn
 Kv
 Yd
@@ -1323,11 +1292,7 @@ mi
 mi
 Wd
 Fa
-<<<<<<< HEAD
 nX
-=======
-mi
->>>>>>> big_red_final_last_stand
 mi
 QK
 "}
@@ -1345,13 +1310,8 @@ QK
 he
 SE
 ts
-<<<<<<< HEAD
 ax
 vQ
-=======
-mi
-Dr
->>>>>>> big_red_final_last_stand
 mi
 mi
 hP
@@ -1369,11 +1329,7 @@ qj
 QK
 SX
 mi
-<<<<<<< HEAD
 ax
-=======
-mi
->>>>>>> big_red_final_last_stand
 mi
 tR
 mi
@@ -1381,11 +1337,7 @@ mi
 Yd
 Yd
 mi
-<<<<<<< HEAD
 nX
-=======
-mi
->>>>>>> big_red_final_last_stand
 hP
 mi
 qQ
@@ -1411,11 +1363,7 @@ rD
 hz
 CB
 gV
-<<<<<<< HEAD
 nX
-=======
-mi
->>>>>>> big_red_final_last_stand
 mi
 fJ
 Yw
@@ -1430,15 +1378,9 @@ QK
 hP
 QA
 mi
-<<<<<<< HEAD
 vQ
 tR
 nX
-=======
-Dr
-tR
-mi
->>>>>>> big_red_final_last_stand
 mi
 Yd
 mi
@@ -1459,11 +1401,7 @@ qj
 QK
 hP
 mi
-<<<<<<< HEAD
 nX
-=======
-mi
->>>>>>> big_red_final_last_stand
 mi
 tR
 ic
@@ -1512,11 +1450,7 @@ QK
 nV
 hz
 In
-<<<<<<< HEAD
 nX
-=======
-mi
->>>>>>> big_red_final_last_stand
 eQ
 tF
 QK

--- a/maps/map_files/BigRed/sprinkles/25.clfmarshalls.dmm
+++ b/maps/map_files/BigRed/sprinkles/25.clfmarshalls.dmm
@@ -1,0 +1,2689 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aw" = (
+/obj/structure/surface/table,
+/obj/item/ammo_magazine/rifle/hunting,
+/obj/item/ammo_magazine/rifle/hunting,
+/obj/item/ammo_magazine/rifle/hunting,
+/obj/item/ammo_magazine/rifle/hunting,
+/obj/item/ammo_magazine/rifle/hunting,
+/obj/item/ammo_magazine/rifle/hunting,
+/obj/item/ammo_magazine/rifle/hunting,
+/obj/item/ammo_magazine/rifle/hunting,
+/obj/item/ammo_magazine/rifle/hunting,
+/obj/item/ammo_magazine/rifle/hunting,
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/template_noop)
+"aM" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/template_noop)
+"aR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/metal/wired{
+	dir = 4;
+	icon_state = "metal_2"
+	},
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/template_noop)
+"aW" = (
+/obj/structure/surface/table/reinforced,
+/obj/structure/machinery/door/window/brigdoor/westright,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "vault"
+	},
+/area/template_noop)
+"bn" = (
+/obj/structure/surface/table/woodentable,
+/obj/item/paper/Court,
+/turf/open/floor{
+	icon_state = "cult"
+	},
+/area/template_noop)
+"bB" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/ash,
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/template_noop)
+"bD" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor,
+/area/template_noop)
+"bX" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"ca" = (
+/obj/structure/surface/table,
+/obj/item/tool/weldingtool,
+/obj/item/tool/weldpack,
+/obj/item/clothing/glasses/welding,
+/obj/item/clothing/glasses/welding,
+/obj/item/tool/weldingtool,
+/obj/item/tool/weldpack,
+/turf/open/floor,
+/area/template_noop)
+"cd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_2"
+	},
+/turf/open/floor{
+	icon_state = "redcorner"
+	},
+/area/template_noop)
+"cg" = (
+/obj/structure/barricade/metal/wired,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/template_noop)
+"ch" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/ammo_casing/bullet,
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/template_noop)
+"co" = (
+/obj/structure/barricade/plasteel/wired{
+	icon_state = "plasteel_2"
+	},
+/turf/open/floor,
+/area/template_noop)
+"cA" = (
+/obj/structure/machinery/light{
+	dir = 8
+	},
+/turf/open/floor{
+	dir = 9;
+	icon_state = "redfull"
+	},
+/area/template_noop)
+"di" = (
+/obj/effect/landmark/corpsespawner/security,
+/obj/item/ammo_casing/bullet,
+/obj/item/attachable/scope/mini,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "redcorner"
+	},
+/area/template_noop)
+"dm" = (
+/obj/structure/surface/table/woodentable/fancy,
+/obj/structure/machinery/recharger,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"dO" = (
+/obj/structure/machinery/cm_vending/sorted/medical/no_access,
+/turf/open/floor{
+	icon_state = "floor4";
+	tag = "icon-floor4"
+	},
+/area/template_noop)
+"ec" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/ammo_casing/bullet,
+/obj/effect/landmark/corpsespawner/doctor,
+/turf/open/floor,
+/area/template_noop)
+"eh" = (
+/obj/structure/machinery/light{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor,
+/area/template_noop)
+"et" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/decal/cleanable/ash,
+/turf/open/floor,
+/area/template_noop)
+"eF" = (
+/turf/closed/wall/solaris/reinforced,
+/area/template_noop)
+"eU" = (
+/obj/structure/pipes/standard/simple/hidden/green,
+/obj/effect/landmark/survivor_spawner/bigred_clf,
+/obj/effect/landmark/survivor_spawner/bigred_clf,
+/turf/open/floor{
+	icon_state = "grimy"
+	},
+/area/template_noop)
+"fe" = (
+/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/decal/cleanable/ash,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"fq" = (
+/obj/structure/machinery/light{
+	dir = 1
+	},
+/turf/open/floor,
+/area/template_noop)
+"fF" = (
+/obj/structure/pipes/standard/manifold/hidden/green{
+	dir = 8
+	},
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/template_noop)
+"fK" = (
+/obj/structure/pipes/standard/simple/hidden/green,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor{
+	icon_state = "grimy"
+	},
+/area/template_noop)
+"fP" = (
+/obj/structure/barricade/metal/wired{
+	dir = 8
+	},
+/obj/item/ammo_casing/bullet,
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/template_noop)
+"gp" = (
+/obj/structure/machinery/flasher/portable,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "vault"
+	},
+/area/template_noop)
+"gs" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/turf/open/floor,
+/area/template_noop)
+"gL" = (
+/obj/structure/filingcabinet,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"gM" = (
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/template_noop)
+"gP" = (
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_2"
+	},
+/obj/structure/barricade/metal/wired{
+	dir = 8
+	},
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/template_noop)
+"gX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/pipes/standard/manifold/hidden/green{
+	dir = 1
+	},
+/turf/open/floor,
+/area/template_noop)
+"hn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/attachable/bayonet,
+/turf/open/floor,
+/area/template_noop)
+"hr" = (
+/obj/structure/machinery/light{
+	dir = 1
+	},
+/obj/structure/surface/table,
+/obj/item/ammo_magazine/shotgun/slugs,
+/obj/item/ammo_magazine/shotgun/slugs,
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/template_noop)
+"hV" = (
+/obj/structure/surface/table/woodentable/fancy,
+/obj/item/device/camera,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"ia" = (
+/obj/structure/surface/rack,
+/obj/item/weapon/gun/shotgun/pump/cmb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/template_noop)
+"jC" = (
+/obj/structure/pipes/standard/simple/hidden/green,
+/obj/structure/barricade/plasteel/wired{
+	dir = 1;
+	icon_state = "plasteel_2"
+	},
+/obj/effect/landmark/survivor_spawner/bigred_clf,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"jQ" = (
+/obj/structure/barricade/metal/wired{
+	dir = 1
+	},
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"jT" = (
+/obj/structure/barricade/wooden,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"ki" = (
+/obj/effect/landmark/corpsespawner/security,
+/turf/open/floor{
+	icon_state = "grimy"
+	},
+/area/template_noop)
+"kl" = (
+/obj/structure/bed/chair/comfy/black{
+	dir = 8
+	},
+/obj/structure/machinery/camera/autoname{
+	dir = 8
+	},
+/obj/effect/landmark/corpsespawner/security,
+/turf/open/floor{
+	icon_state = "cult"
+	},
+/area/template_noop)
+"kq" = (
+/obj/structure/bookcase/manuals/engineering,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"kC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/survivor_spawner/bigred_clf,
+/obj/effect/landmark/survivor_spawner/bigred_clf,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "damaged3"
+	},
+/area/template_noop)
+"kE" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor,
+/area/template_noop)
+"kL" = (
+/obj/structure/filingcabinet/security,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"kN" = (
+/obj/effect/landmark/corpsespawner/security/liaison,
+/turf/open/floor{
+	icon_state = "grimy"
+	},
+/area/template_noop)
+"le" = (
+/obj/structure/surface/table/woodentable/fancy,
+/obj/structure/machinery/computer/security/wooden_tv,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"lu" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/corpsespawner/pmc,
+/turf/open/floor,
+/area/template_noop)
+"lz" = (
+/obj/structure/surface/table,
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/template_noop)
+"lP" = (
+/obj/structure/pipes/standard/simple/hidden/green,
+/turf/open/floor{
+	icon_state = "grimy"
+	},
+/area/template_noop)
+"lT" = (
+/obj/structure/surface/table,
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/obj/item/ammo_magazine/shotgun/slugs{
+	pixel_x = 5
+	},
+/obj/item/ammo_magazine/shotgun/buckshot{
+	pixel_x = -5
+	},
+/obj/item/ammo_magazine/shotgun/buckshot{
+	pixel_x = -5
+	},
+/obj/item/ammo_magazine/shotgun/buckshot{
+	pixel_x = -5;
+	pixel_y = 6
+	},
+/obj/item/ammo_magazine/shotgun/slugs{
+	pixel_x = 5
+	},
+/obj/item/ammo_magazine/shotgun/slugs{
+	pixel_x = 5;
+	pixel_y = 6
+	},
+/obj/item/ammo_magazine/shotgun/incendiary,
+/turf/open/floor,
+/area/template_noop)
+"mi" = (
+/obj/structure/surface/table/woodentable/fancy,
+/obj/item/reagent_container/food/drinks/flask/detflask,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"mt" = (
+/obj/structure/surface/table,
+/obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/template_noop)
+"mC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/plasteel/wired{
+	icon_state = "plasteel_2"
+	},
+/obj/effect/landmark/survivor_spawner/bigred_clf,
+/obj/effect/landmark/survivor_spawner/bigred_clf,
+/turf/open/floor{
+	icon_state = "redcorner"
+	},
+/area/template_noop)
+"mL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 10
+	},
+/turf/open/floor,
+/area/template_noop)
+"mY" = (
+/obj/structure/pipes/standard/manifold/hidden/green,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/ammo_casing/bullet,
+/turf/open/floor,
+/area/template_noop)
+"mZ" = (
+/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/decal/cleanable/ash,
+/turf/open/floor,
+/area/template_noop)
+"nd" = (
+/obj/item/ammo_casing/bullet,
+/obj/item/attachable/lasersight,
+/turf/open/floor{
+	icon_state = "redcorner"
+	},
+/area/template_noop)
+"ne" = (
+/obj/structure/pipes/vents/pump{
+	dir = 1
+	},
+/turf/open/floor{
+	icon_state = "grimy"
+	},
+/area/template_noop)
+"ng" = (
+/obj/structure/closet/l3closet/security,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "vault"
+	},
+/area/template_noop)
+"nm" = (
+/obj/item/ammo_casing/bullet,
+/obj/item/attachable/lasersight,
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/template_noop)
+"ns" = (
+/obj/structure/surface/rack,
+/obj/item/storage/firstaid/fire,
+/obj/item/storage/firstaid/fire,
+/turf/open/floor{
+	icon_state = "floor4";
+	tag = "icon-floor4"
+	},
+/area/template_noop)
+"nL" = (
+/turf/open/mars,
+/area/template_noop)
+"nP" = (
+/obj/structure/barricade/metal/wired{
+	dir = 1;
+	icon_state = "metal_2"
+	},
+/obj/effect/landmark/survivor_spawner/bigred_clf,
+/obj/effect/landmark/survivor_spawner/bigred_clf,
+/turf/open/floor,
+/area/template_noop)
+"nQ" = (
+/obj/item/ammo_casing/bullet,
+/turf/open/floor{
+	icon_state = "grimy"
+	},
+/area/template_noop)
+"nS" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/storage/firstaid/adv,
+/obj/item/storage/firstaid/adv,
+/turf/open/floor{
+	icon_state = "floor4";
+	tag = "icon-floor4"
+	},
+/area/template_noop)
+"nT" = (
+/obj/structure/machinery/light{
+	dir = 4;
+	tag = "icon-tube1 (EAST)"
+	},
+/obj/structure/surface/rack,
+/obj/item/storage/firstaid/o2,
+/obj/item/storage/firstaid/o2,
+/turf/open/floor{
+	icon_state = "floor4";
+	tag = "icon-floor4"
+	},
+/area/template_noop)
+"oi" = (
+/obj/structure/window/framed/solaris/reinforced,
+/turf/open/floor/plating,
+/area/template_noop)
+"pg" = (
+/obj/structure/surface/rack,
+/obj/item/ammo_magazine/revolver/cmb,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "vault"
+	},
+/area/template_noop)
+"ph" = (
+/obj/structure/machinery/light{
+	dir = 1
+	},
+/turf/open/floor{
+	dir = 4;
+	icon_state = "redcorner"
+	},
+/area/template_noop)
+"pl" = (
+/obj/structure/pipes/standard/simple/hidden/green,
+/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/decal/cleanable/ash,
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/template_noop)
+"pF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/plasteel/wired{
+	icon_state = "plasteel_2"
+	},
+/turf/open/floor,
+/area/template_noop)
+"pI" = (
+/obj/structure/surface/rack,
+/obj/item/weapon/gun/shotgun/pump/cmb,
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/template_noop)
+"pJ" = (
+/obj/structure/surface/table,
+/obj/item/stack/sheet/plasteel/large_stack,
+/turf/open/floor,
+/area/template_noop)
+"pV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/pipes/standard/simple/hidden/green,
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_2"
+	},
+/turf/open/floor,
+/area/template_noop)
+"qa" = (
+/obj/structure/surface/rack,
+/obj/item/storage/firstaid/toxin,
+/obj/item/storage/firstaid/toxin,
+/turf/open/floor{
+	icon_state = "floor4";
+	tag = "icon-floor4"
+	},
+/area/template_noop)
+"qg" = (
+/obj/structure/surface/table,
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/template_noop)
+"qm" = (
+/turf/open/floor{
+	icon_state = "redcorner"
+	},
+/area/template_noop)
+"qs" = (
+/obj/structure/pipes/standard/simple/hidden/green,
+/obj/item/ammo_casing/bullet,
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/template_noop)
+"qA" = (
+/obj/item/attachable/attached_gun/flamer,
+/turf/open/floor,
+/area/template_noop)
+"qJ" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood,
+/obj/structure/barricade/metal/wired,
+/turf/open/floor,
+/area/template_noop)
+"qP" = (
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_2"
+	},
+/obj/effect/landmark/survivor_spawner/bigred_clf,
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/template_noop)
+"rh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_2"
+	},
+/obj/structure/barricade/metal/wired{
+	dir = 4
+	},
+/obj/effect/landmark/survivor_spawner/bigred_clf,
+/obj/effect/landmark/survivor_spawner/bigred_clf,
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/template_noop)
+"rk" = (
+/obj/structure/machinery/door_control{
+	id = "Marshal Offices";
+	name = "Storm Shutters";
+	pixel_x = -32
+	},
+/obj/effect/landmark/corpsespawner/security,
+/turf/open/floor{
+	dir = 9;
+	icon_state = "redfull"
+	},
+/area/template_noop)
+"ro" = (
+/obj/item/ammo_casing/bullet,
+/obj/structure/surface/table,
+/obj/item/ammo_magazine/shotgun/buckshot{
+	pixel_x = -5;
+	pixel_y = 6
+	},
+/obj/item/ammo_magazine/shotgun/buckshot{
+	pixel_x = -5;
+	pixel_y = 6
+	},
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/template_noop)
+"rv" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/storage/firstaid/surgical,
+/turf/open/floor{
+	icon_state = "floor4";
+	tag = "icon-floor4"
+	},
+/area/template_noop)
+"rB" = (
+/turf/closed/wall/solaris/rock,
+/area/template_noop)
+"rH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/attachable/heavy_barrel,
+/turf/open/floor,
+/area/template_noop)
+"rS" = (
+/obj/structure/surface/table/reinforced,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "vault"
+	},
+/area/template_noop)
+"rZ" = (
+/obj/structure/surface/rack,
+/obj/item/weapon/gun/shotgun/pump/cmb,
+/obj/item/ammo_magazine/shotgun/slugs,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/template_noop)
+"sc" = (
+/obj/structure/barricade/metal/wired{
+	dir = 8;
+	icon_state = "metal_2"
+	},
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/template_noop)
+"sf" = (
+/obj/structure/surface/table/reinforced,
+/obj/item/weapon/shield/riot,
+/turf/closed/wall/solaris/reinforced,
+/area/template_noop)
+"so" = (
+/obj/structure/barricade/metal/wired{
+	dir = 4;
+	icon_state = "metal_2"
+	},
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"sp" = (
+/obj/item/ammo_casing/bullet,
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/template_noop)
+"st" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/template_noop)
+"sv" = (
+/obj/structure/machinery/deployable/barrier,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "vault"
+	},
+/area/template_noop)
+"sY" = (
+/obj/structure/surface/rack,
+/obj/item/explosive/grenade/incendiary/molotov,
+/obj/item/explosive/grenade/incendiary/molotov,
+/obj/item/explosive/grenade/incendiary/molotov,
+/obj/item/explosive/grenade/incendiary/molotov,
+/obj/item/explosive/grenade/incendiary/molotov,
+/turf/open/floor,
+/area/template_noop)
+"te" = (
+/obj/item/device/radio/intercom{
+	freerange = 1;
+	frequency = 1469;
+	name = "General Listening Channel";
+	pixel_x = 30
+	},
+/obj/item/ammo_casing/bullet,
+/turf/open/floor{
+	dir = 5;
+	icon_state = "red"
+	},
+/area/template_noop)
+"tC" = (
+/obj/structure/barricade/metal/wired{
+	dir = 4
+	},
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"tH" = (
+/obj/structure/surface/table/woodentable/fancy,
+/obj/item/device/camera_film,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"tN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/corpsespawner/security,
+/turf/open/floor,
+/area/template_noop)
+"tO" = (
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_2"
+	},
+/turf/open/floor,
+/area/template_noop)
+"um" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/template_noop)
+"ut" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor{
+	icon_state = "redcorner"
+	},
+/area/template_noop)
+"uv" = (
+/obj/effect/landmark/corpsespawner/security,
+/turf/open/floor{
+	icon_state = "redcorner"
+	},
+/area/template_noop)
+"uJ" = (
+/obj/structure/window_frame/solaris,
+/turf/open/floor/plating,
+/area/template_noop)
+"vg" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/template_noop)
+"vi" = (
+/obj/structure/surface/rack,
+/obj/structure/machinery/light{
+	dir = 1;
+	tag = "icon-tube1 (NORTH)"
+	},
+/obj/item/ammo_magazine/revolver/cmb,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "vault"
+	},
+/area/template_noop)
+"vu" = (
+/obj/item/attachable/verticalgrip,
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/template_noop)
+"vY" = (
+/obj/structure/machinery/camera/autoname{
+	dir = 4
+	},
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/turf/open/floor,
+/area/template_noop)
+"wo" = (
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_x = -32
+	},
+/obj/structure/bed,
+/turf/open/floor,
+/area/template_noop)
+"wq" = (
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"wv" = (
+/turf/open/floor{
+	dir = 4;
+	icon_state = "redcorner"
+	},
+/area/template_noop)
+"xe" = (
+/obj/effect/decal/cleanable/blood/gibs/body,
+/turf/open/floor,
+/area/template_noop)
+"xw" = (
+/obj/structure/barricade/metal/wired{
+	dir = 4;
+	icon_state = "metal_2"
+	},
+/obj/item/ammo_casing/bullet,
+/turf/open/floor{
+	dir = 9;
+	icon_state = "redfull"
+	},
+/area/template_noop)
+"xy" = (
+/obj/structure/barricade/metal/wired{
+	dir = 1;
+	icon_state = "metal_2"
+	},
+/obj/structure/barricade/metal/wired{
+	dir = 4;
+	icon_state = "metal_2"
+	},
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"xC" = (
+/obj/structure/closet/secure_closet/brig,
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/template_noop)
+"xE" = (
+/obj/effect/decal/cleanable/blood,
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor,
+/area/template_noop)
+"xF" = (
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/open/floor,
+/area/template_noop)
+"xH" = (
+/obj/structure/surface/rack,
+/turf/open/floor,
+/area/template_noop)
+"xV" = (
+/obj/structure/machinery/light{
+	dir = 4;
+	tag = "icon-tube1 (EAST)"
+	},
+/turf/open/floor,
+/area/template_noop)
+"yg" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/obj/effect/landmark/survivor_spawner/bigred_clf,
+/obj/effect/landmark/survivor_spawner/bigred_clf,
+/turf/open/floor,
+/area/template_noop)
+"yu" = (
+/obj/structure/surface/table,
+/obj/item/weapon/gun/rifle/m16,
+/turf/open/floor,
+/area/template_noop)
+"yz" = (
+/obj/structure/surface/table/woodentable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor{
+	icon_state = "cult"
+	},
+/area/template_noop)
+"yJ" = (
+/obj/structure/sign/poster/clf,
+/turf/closed/wall/solaris,
+/area/template_noop)
+"yN" = (
+/turf/open/floor{
+	icon_state = "grimy"
+	},
+/area/template_noop)
+"yP" = (
+/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/decal/cleanable/ash,
+/turf/open/floor{
+	dir = 9;
+	icon_state = "redfull"
+	},
+/area/template_noop)
+"za" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/template_noop)
+"zi" = (
+/obj/item/attachable/bayonet,
+/turf/open/floor,
+/area/template_noop)
+"zo" = (
+/obj/structure/bookcase/manuals/engineering,
+/obj/structure/machinery/light{
+	dir = 1
+	},
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"zS" = (
+/obj/structure/surface/table,
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/obj/item/weapon/gun/smg/fp9000,
+/turf/open/floor,
+/area/template_noop)
+"Ac" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor{
+	icon_state = "grimy"
+	},
+/area/template_noop)
+"AH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/pipes/standard/simple/hidden/green,
+/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/decal/cleanable/ash,
+/turf/open/floor,
+/area/template_noop)
+"AI" = (
+/obj/effect/decal/cleanable/blood,
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/turf/open/floor,
+/area/template_noop)
+"AV" = (
+/obj/structure/machinery/camera/autoname,
+/obj/structure/surface/table,
+/obj/item/weapon/gun/rifle/hunting,
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/template_noop)
+"Be" = (
+/obj/effect/landmark/survivor_spawner/bigred_clf,
+/obj/effect/landmark/survivor_spawner/bigred_clf,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "damaged3"
+	},
+/area/template_noop)
+"Bl" = (
+/obj/structure/surface/table/woodentable,
+/turf/open/floor{
+	icon_state = "cult"
+	},
+/area/template_noop)
+"Bz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/corpsespawner/security,
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/template_noop)
+"Ck" = (
+/obj/structure/machinery/camera/autoname{
+	dir = 8
+	},
+/turf/open/floor,
+/area/template_noop)
+"Cw" = (
+/obj/structure/machinery/camera/autoname{
+	dir = 1
+	},
+/obj/item/ammo_casing/bullet,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"CB" = (
+/obj/structure/surface/table,
+/obj/item/stack/sheet/metal/large_stack,
+/turf/open/floor,
+/area/template_noop)
+"Dc" = (
+/obj/structure/barricade/metal/wired{
+	dir = 4;
+	icon_state = "metal_2"
+	},
+/turf/open/floor{
+	dir = 9;
+	icon_state = "redfull"
+	},
+/area/template_noop)
+"Dk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/template_noop)
+"Dq" = (
+/turf/open/floor,
+/area/template_noop)
+"DA" = (
+/obj/structure/surface/table/woodentable/fancy,
+/obj/item/clothing/suit/storage/lawyer/bluejacket,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"DN" = (
+/obj/structure/machinery/door_control{
+	id = "Marshal Offices";
+	name = "Storm Shutters";
+	pixel_x = -32
+	},
+/obj/structure/barricade/wooden,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"DV" = (
+/obj/structure/machinery/vending/coffee,
+/turf/open/floor,
+/area/template_noop)
+"Fd" = (
+/obj/structure/surface/table/woodentable,
+/obj/structure/pipes/vents/pump{
+	dir = 8
+	},
+/turf/open/floor{
+	icon_state = "cult"
+	},
+/area/template_noop)
+"Fz" = (
+/obj/structure/bed/chair,
+/obj/effect/landmark/survivor_spawner/bigred_clf,
+/obj/effect/landmark/survivor_spawner/bigred_clf,
+/turf/open/floor,
+/area/template_noop)
+"FL" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"FO" = (
+/turf/open/floor{
+	dir = 1;
+	icon_state = "rampbottom";
+	tag = "icon-rampbottom"
+	},
+/area/template_noop)
+"FQ" = (
+/obj/structure/barricade/metal/wired,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "damaged3"
+	},
+/area/template_noop)
+"Ga" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/pipes/standard/simple/hidden/green,
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_2"
+	},
+/obj/effect/landmark/survivor_spawner/bigred_clf,
+/obj/effect/landmark/survivor_spawner/bigred_clf,
+/turf/open/floor{
+	icon_state = "redcorner"
+	},
+/area/template_noop)
+"Gi" = (
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/template_noop)
+"Gj" = (
+/obj/effect/landmark/corpsespawner/security,
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/template_noop)
+"GF" = (
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_2"
+	},
+/turf/open/floor{
+	icon_state = "floor4";
+	tag = "icon-floor4"
+	},
+/area/template_noop)
+"GT" = (
+/obj/structure/window/framed/solaris,
+/obj/structure/machinery/door/poddoor/shutters/almayer{
+	dir = 4;
+	id = "Office Complex 2";
+	name = "\improper Marshal Office Complex Shutters"
+	},
+/turf/open/floor/plating,
+/area/template_noop)
+"GW" = (
+/obj/structure/surface/table/woodentable/fancy,
+/obj/item/ashtray/bronze,
+/obj/item/attachable/attached_gun/flamer,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"GY" = (
+/obj/structure/barricade/plasteel/wired{
+	dir = 1;
+	icon_state = "plasteel_2"
+	},
+/turf/open/floor,
+/area/template_noop)
+"He" = (
+/turf/closed/wall/solaris,
+/area/template_noop)
+"Hj" = (
+/obj/structure/pipes/vents/pump/on,
+/obj/structure/surface/table,
+/obj/item/weapon/gun/rifle/mar40{
+	pixel_y = -1
+	},
+/turf/open/floor,
+/area/template_noop)
+"HE" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/obj/item/attachable/attached_gun/flamer,
+/turf/open/floor,
+/area/template_noop)
+"HJ" = (
+/obj/effect/decal/cleanable/blood,
+/obj/item/attachable/heavy_barrel,
+/turf/open/floor{
+	icon_state = "grimy"
+	},
+/area/template_noop)
+"HQ" = (
+/obj/structure/surface/table,
+/obj/item/ammo_magazine/rifle/mar40/lmg,
+/obj/item/ammo_magazine/rifle/mar40/lmg{
+	pixel_y = 6;
+	pixel_x = -7
+	},
+/obj/item/ammo_magazine/rifle/mar40/lmg{
+	pixel_x = -7;
+	pixel_y = -8
+	},
+/obj/item/ammo_magazine/rifle/mar40/lmg{
+	pixel_y = 5;
+	pixel_x = 7
+	},
+/obj/item/ammo_magazine/rifle/mar40/lmg{
+	pixel_y = -8;
+	pixel_x = 7
+	},
+/turf/open/floor,
+/area/template_noop)
+"HU" = (
+/obj/structure/surface/table,
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000{
+	pixel_y = 3;
+	pixel_x = -6
+	},
+/obj/item/ammo_magazine/smg/fp9000{
+	pixel_y = 5;
+	pixel_x = 4
+	},
+/obj/item/ammo_magazine/smg/fp9000{
+	pixel_x = -6
+	},
+/turf/open/floor,
+/area/template_noop)
+"IC" = (
+/obj/structure/machinery/light,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"IY" = (
+/obj/structure/machinery/light{
+	dir = 4;
+	tag = "icon-tube1 (EAST)"
+	},
+/turf/open/floor{
+	icon_state = "cult"
+	},
+/area/template_noop)
+"Jl" = (
+/obj/structure/pipes/vents/pump,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/template_noop)
+"Jx" = (
+/obj/structure/sign/poster/clf,
+/turf/closed/wall/solaris/reinforced,
+/area/template_noop)
+"JA" = (
+/obj/effect/landmark/corpsespawner/security,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "redcorner"
+	},
+/area/template_noop)
+"JH" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/template_noop)
+"JJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/corpsespawner/security,
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/template_noop)
+"JY" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "damaged3"
+	},
+/area/template_noop)
+"Kg" = (
+/obj/structure/pipes/standard/simple/hidden/green,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/ammo_casing/bullet,
+/obj/structure/barricade/plasteel/wired{
+	icon_state = "plasteel_2"
+	},
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/template_noop)
+"Kq" = (
+/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/decal/cleanable/ash,
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/template_noop)
+"Kz" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"KC" = (
+/turf/open/floor{
+	icon_state = "rampbottom";
+	tag = "icon-rampbottom"
+	},
+/area/template_noop)
+"KK" = (
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_x = -32
+	},
+/obj/effect/decal/cleanable/blood,
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/turf/open/floor,
+/area/template_noop)
+"Lu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor{
+	icon_state = "redcorner"
+	},
+/area/template_noop)
+"Ly" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/turf/open/floor,
+/area/template_noop)
+"LE" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/structure/machinery/door_control{
+	id = "Office Complex 2";
+	name = "Storm Shutters";
+	pixel_x = -32
+	},
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"LF" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "redcorner"
+	},
+/area/template_noop)
+"LH" = (
+/obj/structure/closet/l3closet/security,
+/obj/structure/machinery/light{
+	dir = 1;
+	tag = "icon-tube1 (NORTH)"
+	},
+/turf/open/floor{
+	dir = 8;
+	icon_state = "vault"
+	},
+/area/template_noop)
+"LZ" = (
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_x = -32
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/mask/breath/medical,
+/obj/item/tank/anesthetic,
+/obj/effect/landmark/corpsespawner/security,
+/obj/structure/bed,
+/turf/open/floor,
+/area/template_noop)
+"MU" = (
+/obj/structure/window/framed/solaris,
+/obj/structure/machinery/door/poddoor/shutters/almayer{
+	id = "Marshal Offices";
+	name = "\improper Marshal Offices Shutters"
+	},
+/turf/open/floor/plating,
+/area/template_noop)
+"MV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor,
+/area/template_noop)
+"Ni" = (
+/obj/structure/window/reinforced{
+	dir = 4;
+	health = 80
+	},
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/turf/open/floor,
+/area/template_noop)
+"No" = (
+/obj/structure/surface/rack,
+/obj/item/weapon/gun/revolver/cmb,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "vault"
+	},
+/area/template_noop)
+"Nu" = (
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_2"
+	},
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/template_noop)
+"NF" = (
+/obj/structure/bed/chair/comfy,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"NG" = (
+/obj/effect/landmark/corpsespawner/security,
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/template_noop)
+"NY" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/template_noop)
+"OD" = (
+/obj/structure/barricade/metal/wired{
+	dir = 4
+	},
+/obj/item/ammo_casing/bullet,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"OL" = (
+/obj/structure/pipes/standard/manifold/hidden/green,
+/obj/structure/surface/table,
+/obj/item/ammo_magazine/rifle/mar40/extended{
+	pixel_y = -4;
+	pixel_x = -5
+	},
+/obj/item/ammo_magazine/rifle/mar40/extended{
+	pixel_y = 1;
+	pixel_x = -6
+	},
+/obj/item/ammo_magazine/rifle/mar40/extended{
+	pixel_y = 4;
+	pixel_x = -6
+	},
+/obj/item/ammo_magazine/rifle/mar40/extended{
+	pixel_x = 7;
+	pixel_y = 7
+	},
+/obj/item/ammo_magazine/rifle/mar40/extended{
+	pixel_y = 11;
+	pixel_x = -6
+	},
+/obj/item/ammo_magazine/rifle/mar40/extended{
+	pixel_y = 11;
+	pixel_x = 7
+	},
+/obj/item/ammo_magazine/rifle/mar40/extended{
+	pixel_x = -6;
+	pixel_y = 7
+	},
+/obj/item/ammo_magazine/rifle/mar40/extended{
+	pixel_x = 7;
+	pixel_y = 7
+	},
+/obj/item/ammo_magazine/rifle/mar40/extended{
+	pixel_y = 4;
+	pixel_x = 11
+	},
+/obj/item/ammo_magazine/rifle/mar40/extended{
+	pixel_y = 4;
+	pixel_x = 11
+	},
+/obj/item/ammo_magazine/rifle/mar40/extended{
+	pixel_y = 1;
+	pixel_x = 11
+	},
+/obj/item/ammo_magazine/rifle/mar40/extended{
+	pixel_y = -5;
+	pixel_x = 11
+	},
+/obj/item/ammo_magazine/rifle/mar40/extended{
+	pixel_y = -5;
+	pixel_x = 11
+	},
+/turf/open/floor,
+/area/template_noop)
+"ON" = (
+/obj/structure/bed,
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/template_noop)
+"OR" = (
+/obj/structure/machinery/power/apc,
+/obj/structure/machinery/camera/autoname{
+	dir = 1
+	},
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/template_noop)
+"OU" = (
+/obj/structure/closet/secure_closet/detective,
+/obj/item/weapon/gun/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"Pa" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor,
+/area/template_noop)
+"Po" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/turf/open/floor,
+/area/template_noop)
+"Pq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/turf/open/floor,
+/area/template_noop)
+"Pu" = (
+/obj/structure/machinery/alarm{
+	dir = 1;
+	pixel_y = -30;
+	tag = "icon-alarm0 (NORTH)"
+	},
+/obj/item/ammo_casing/bullet,
+/turf/open/floor{
+	icon_state = "redcorner"
+	},
+/area/template_noop)
+"PT" = (
+/obj/structure/barricade/metal/wired,
+/turf/open/floor,
+/area/template_noop)
+"Qs" = (
+/obj/structure/surface/table,
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/obj/item/weapon/gun/pistol/holdout{
+	pixel_y = 8
+	},
+/obj/item/ammo_magazine/pistol/holdout,
+/obj/item/ammo_magazine/pistol/holdout,
+/obj/item/ammo_magazine/pistol/holdout{
+	pixel_y = 4;
+	pixel_x = 4
+	},
+/obj/item/ammo_magazine/pistol/holdout{
+	pixel_y = 6;
+	pixel_x = 9
+	},
+/obj/item/ammo_magazine/pistol/holdout{
+	pixel_y = 5;
+	pixel_x = -5
+	},
+/turf/open/floor,
+/area/template_noop)
+"Qy" = (
+/obj/item/shard,
+/obj/effect/decal/cleanable/blood{
+	icon_state = "gib6";
+	tag = "icon-gib6"
+	},
+/obj/structure/window_frame/solaris,
+/turf/closed/wall/solaris/reinforced,
+/area/template_noop)
+"QS" = (
+/obj/structure/machinery/camera/autoname{
+	dir = 1
+	},
+/turf/open/floor{
+	icon_state = "redcorner"
+	},
+/area/template_noop)
+"Rk" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/plasteel/wired{
+	dir = 4;
+	icon_state = "plasteel_2"
+	},
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/template_noop)
+"RC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/corpsespawner/pmc,
+/turf/open/floor,
+/area/template_noop)
+"RL" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "redcorner"
+	},
+/area/template_noop)
+"Sb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/pipes/standard/simple/hidden/green,
+/turf/open/floor,
+/area/template_noop)
+"Sm" = (
+/obj/structure/surface/rack,
+/obj/item/ammo_magazine/shotgun/incendiary,
+/obj/item/clothing/accessory/storage/black_vest,
+/obj/item/clothing/accessory/storage/black_vest,
+/obj/item/clothing/accessory/storage/black_vest,
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/template_noop)
+"Sr" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/template_noop)
+"SJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/ammo_casing/bullet,
+/turf/open/floor,
+/area/template_noop)
+"SR" = (
+/obj/structure/barricade/metal/wired{
+	dir = 8;
+	icon_state = "metal_2"
+	},
+/obj/structure/closet/secure_closet/marshal,
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/template_noop)
+"Ta" = (
+/obj/structure/window/framed/solaris/reinforced,
+/obj/structure/machinery/door/poddoor/shutters/almayer{
+	id = "Marshal Offices";
+	name = "\improper Marshal Offices Shutters"
+	},
+/turf/open/floor/plating,
+/area/template_noop)
+"Tl" = (
+/obj/structure/machinery/vending/security,
+/turf/open/floor,
+/area/template_noop)
+"To" = (
+/obj/structure/surface/table,
+/obj/item/ammo_magazine/rifle/m16/ap{
+	pixel_x = 8
+	},
+/obj/item/ammo_magazine/rifle/m16/ap{
+	pixel_x = 8
+	},
+/obj/item/ammo_magazine/rifle/m16/ap{
+	pixel_x = 8
+	},
+/obj/item/ammo_magazine/rifle/m16/ap{
+	pixel_x = 5;
+	pixel_y = 6
+	},
+/obj/item/ammo_magazine/rifle/m16/ap{
+	pixel_x = 2;
+	pixel_y = -3
+	},
+/obj/item/ammo_box/magazine/M16,
+/turf/open/floor,
+/area/template_noop)
+"TA" = (
+/obj/structure/pipes/standard/simple/hidden/green,
+/obj/item/attachable/heavy_barrel,
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/template_noop)
+"TU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/attachable/verticalgrip,
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/template_noop)
+"TV" = (
+/obj/structure/surface/rack,
+/obj/item/clothing/accessory/storage/webbing,
+/obj/item/clothing/accessory/storage/webbing,
+/turf/open/floor,
+/area/template_noop)
+"Uc" = (
+/obj/structure/surface/table,
+/obj/item/weapon/gun/rifle/mar40/lmg{
+	pixel_y = 9
+	},
+/turf/open/floor,
+/area/template_noop)
+"Uv" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/template_noop)
+"UJ" = (
+/obj/structure/machinery/door/airlock/almayer/security/glass{
+	dir = 1;
+	icon_state = "door_locked";
+	locked = 1;
+	name = "\improper Marshal Office Holding Cell";
+	req_access = null
+	},
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/template_noop)
+"UK" = (
+/obj/structure/surface/table/woodentable/fancy,
+/obj/item/clothing/head/det_hat,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"Vb" = (
+/obj/structure/machinery/light,
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/template_noop)
+"Vs" = (
+/obj/structure/barricade/metal/wired{
+	dir = 4;
+	icon_state = "metal_2"
+	},
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/template_noop)
+"VQ" = (
+/obj/structure/barricade/metal/wired{
+	dir = 4;
+	icon_state = "metal_2"
+	},
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"Xg" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/corpsespawner/security,
+/turf/open/floor,
+/area/template_noop)
+"Xj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/corpsespawner/security,
+/turf/open/floor{
+	icon_state = "redcorner"
+	},
+/area/template_noop)
+"Xv" = (
+/obj/effect/landmark/survivor_spawner/bigred_clf,
+/turf/open/floor,
+/area/template_noop)
+"XJ" = (
+/turf/open/floor{
+	dir = 8;
+	icon_state = "damaged3"
+	},
+/area/template_noop)
+"XL" = (
+/obj/structure/barricade/metal/wired{
+	dir = 1;
+	icon_state = "metal_2"
+	},
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"XM" = (
+/obj/structure/pipes/standard/simple/hidden/green,
+/obj/effect/decal/cleanable/blood,
+/obj/structure/barricade/plasteel/wired{
+	icon_state = "plasteel_2"
+	},
+/obj/effect/landmark/survivor_spawner/bigred_clf,
+/obj/effect/landmark/survivor_spawner/bigred_clf,
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/template_noop)
+"XX" = (
+/obj/structure/closet/hydrant{
+	pixel_y = 32
+	},
+/turf/open/floor{
+	dir = 4;
+	icon_state = "redcorner"
+	},
+/area/template_noop)
+"XZ" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor,
+/area/template_noop)
+"Yq" = (
+/obj/effect/landmark/corpsespawner/pmc,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"Yt" = (
+/obj/structure/barricade/metal/wired,
+/obj/item/ammo_casing/bullet,
+/obj/effect/landmark/survivor_spawner/bigred_clf,
+/obj/effect/landmark/survivor_spawner/bigred_clf,
+/obj/item/attachable/lasersight,
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/template_noop)
+"YA" = (
+/obj/structure/machinery/cm_vending/sorted/medical/wall_med{
+	name = "Emergency NanoMed";
+	pixel_x = 30;
+	req_access = null
+	},
+/turf/open/floor{
+	dir = 6;
+	icon_state = "red"
+	},
+/area/template_noop)
+"YN" = (
+/obj/structure/machinery/door_control{
+	id = "garage";
+	name = "Garage Shutters";
+	pixel_x = 26;
+	range = 500
+	},
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"YZ" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor,
+/area/template_noop)
+"ZA" = (
+/obj/structure/pipes/standard/simple/hidden/green,
+/obj/item/attachable/verticalgrip,
+/obj/effect/landmark/corpsespawner/pmc,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "redcorner"
+	},
+/area/template_noop)
+"ZB" = (
+/obj/structure/window/reinforced{
+	dir = 4;
+	health = 80
+	},
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/turf/open/floor,
+/area/template_noop)
+"ZD" = (
+/obj/structure/pipes/standard/simple/hidden/green,
+/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/decal/cleanable/ash,
+/turf/open/floor,
+/area/template_noop)
+"ZX" = (
+/obj/structure/surface/table,
+/obj/effect/landmark/good_item,
+/turf/open/floor,
+/area/template_noop)
+
+(1,1,1) = {"
+eF
+eF
+eF
+eF
+eF
+eF
+eF
+eF
+eF
+eF
+uJ
+aW
+uJ
+eF
+XX
+Po
+Pu
+eF
+eF
+eF
+eF
+"}
+(2,1,1) = {"
+rB
+nL
+nL
+eF
+gp
+sv
+sv
+sv
+eF
+SR
+fP
+sc
+gP
+uJ
+um
+bD
+uv
+uJ
+Gi
+xC
+eF
+"}
+(3,1,1) = {"
+rB
+nL
+nL
+eF
+LH
+sp
+Be
+Gj
+eF
+qg
+XJ
+NG
+Yt
+uJ
+di
+bD
+Lu
+UJ
+Gi
+Vb
+eF
+"}
+(4,1,1) = {"
+rB
+nL
+nL
+eF
+ng
+vu
+Sm
+st
+eF
+ro
+st
+ch
+Nu
+rS
+um
+YZ
+ut
+uJ
+Gi
+ON
+eF
+"}
+(5,1,1) = {"
+nL
+nL
+nL
+eF
+ng
+Bz
+pI
+sp
+eF
+AV
+Bz
+TU
+FQ
+uJ
+RL
+YZ
+Xj
+eF
+eF
+eF
+eF
+"}
+(6,1,1) = {"
+nL
+nL
+nL
+eF
+No
+um
+rZ
+OR
+eF
+aw
+JY
+ch
+Nu
+uJ
+LF
+Po
+mC
+yP
+rk
+cA
+eF
+"}
+(7,1,1) = {"
+nL
+nL
+nL
+eF
+pg
+Dk
+ia
+Vb
+eF
+hr
+vg
+JJ
+cg
+uJ
+wv
+Uv
+cd
+uJ
+xw
+Dc
+eF
+"}
+(8,1,1) = {"
+nL
+nL
+nL
+eF
+No
+kC
+Jl
+XM
+pl
+TA
+qs
+fF
+Kg
+pl
+ZA
+mY
+ut
+Jx
+uJ
+uJ
+eF
+"}
+(9,1,1) = {"
+nL
+nL
+nL
+eF
+vi
+nm
+aR
+NG
+eF
+JH
+Vs
+aM
+rh
+eF
+wv
+gX
+Ga
+AH
+Sb
+pV
+ZD
+"}
+(10,1,1) = {"
+eF
+eF
+eF
+eF
+eF
+eF
+sf
+eF
+eF
+eF
+uJ
+bB
+uJ
+Jx
+ph
+YZ
+mC
+mZ
+Dq
+pF
+mZ
+"}
+(11,1,1) = {"
+eF
+wo
+LZ
+KK
+vY
+AI
+Dq
+tO
+uJ
+Dq
+Dq
+Po
+Dq
+eF
+wv
+bD
+QS
+Jx
+eF
+eF
+eF
+"}
+(12,1,1) = {"
+eF
+fq
+ec
+Xv
+hn
+Dq
+SJ
+co
+mZ
+Dq
+Dq
+lu
+co
+mZ
+wv
+xE
+qm
+uJ
+Gi
+xC
+eF
+"}
+(13,1,1) = {"
+eF
+xH
+Dq
+Pa
+kE
+tN
+MV
+PT
+uJ
+pJ
+zi
+YZ
+sY
+eF
+JA
+YZ
+nd
+Kq
+Gi
+Vb
+eF
+"}
+(14,1,1) = {"
+eF
+rv
+nS
+dO
+ns
+nT
+qa
+GF
+uJ
+CB
+Dq
+Po
+ZX
+eF
+te
+Rk
+YA
+uJ
+Gi
+ON
+eF
+"}
+(15,1,1) = {"
+eF
+eF
+oi
+oi
+oi
+eF
+eF
+eF
+Jx
+ca
+Dq
+HE
+ZX
+eF
+eF
+et
+eF
+eF
+eF
+eF
+eF
+"}
+(16,1,1) = {"
+eF
+gL
+le
+dm
+wq
+DN
+uJ
+xF
+Dq
+kE
+RC
+Po
+TV
+He
+Pa
+za
+kE
+eh
+gs
+gs
+eF
+"}
+(17,1,1) = {"
+Ta
+kL
+wq
+mi
+FL
+jT
+Jx
+Dq
+Dq
+rH
+kE
+Po
+Dq
+He
+gs
+Ly
+XZ
+tN
+gs
+qJ
+MU
+"}
+(18,1,1) = {"
+Ta
+kq
+NF
+GW
+Yq
+Yq
+fe
+Dq
+kE
+Fz
+Hj
+OL
+yg
+He
+ZB
+Ni
+ZB
+Dq
+ZB
+ZB
+eF
+"}
+(19,1,1) = {"
+Ta
+zo
+wq
+UK
+FL
+jT
+Jx
+Dq
+RC
+Fz
+Uc
+Qs
+yg
+yJ
+NY
+Sr
+Dq
+xe
+NY
+qP
+Qy
+"}
+(20,1,1) = {"
+eF
+OU
+YN
+wq
+wq
+jT
+uJ
+Dq
+Dq
+Fz
+HQ
+lT
+yg
+He
+mt
+lz
+gM
+Pa
+mt
+mt
+eF
+"}
+(21,1,1) = {"
+eF
+eF
+eF
+eF
+eF
+eF
+eF
+DV
+Dq
+Fz
+yu
+zS
+yg
+He
+Dq
+Xg
+Dq
+kE
+kE
+PT
+MU
+"}
+(22,1,1) = {"
+nL
+nL
+nL
+nL
+nL
+nL
+eF
+Tl
+Dq
+Fz
+To
+HU
+yg
+He
+kE
+Fd
+bn
+Bl
+yz
+kE
+eF
+"}
+(23,1,1) = {"
+nL
+nL
+nL
+nL
+nL
+nL
+eF
+Tl
+qA
+Ck
+Dq
+Po
+xV
+He
+MV
+FO
+kl
+IY
+KC
+Dq
+eF
+"}
+(24,1,1) = {"
+nL
+nL
+nL
+nL
+nL
+nL
+eF
+eF
+eF
+eF
+Dq
+Po
+eF
+eF
+eF
+eF
+eF
+eF
+eF
+eF
+eF
+"}
+(25,1,1) = {"
+nL
+nL
+nL
+nL
+nL
+nL
+nL
+nL
+nL
+eF
+Dq
+Po
+uJ
+XL
+wq
+bX
+LE
+DA
+hV
+tH
+eF
+"}
+(26,1,1) = {"
+rB
+rB
+nL
+nL
+nL
+nL
+nL
+nL
+nL
+eF
+Dq
+Pq
+Jx
+wq
+nQ
+kN
+nQ
+nQ
+ki
+Kz
+eF
+"}
+(27,1,1) = {"
+rB
+rB
+rB
+nL
+nL
+nL
+nL
+nL
+nL
+Jx
+Dq
+mL
+ZD
+jC
+eU
+fK
+lP
+lP
+ne
+IC
+eF
+"}
+(28,1,1) = {"
+rB
+rB
+rB
+rB
+nL
+nL
+nL
+nL
+nL
+mZ
+nP
+kE
+Jx
+wq
+yN
+ki
+yN
+HJ
+yN
+Cw
+eF
+"}
+(29,1,1) = {"
+rB
+rB
+rB
+rB
+nL
+nL
+nL
+nL
+nL
+mZ
+GY
+kE
+uJ
+jQ
+Ac
+yN
+nQ
+yN
+yN
+wq
+eF
+"}
+(30,1,1) = {"
+rB
+rB
+rB
+rB
+rB
+nL
+nL
+nL
+nL
+Jx
+xV
+kE
+uJ
+xy
+OD
+VQ
+tC
+VQ
+tC
+so
+eF
+"}
+(31,1,1) = {"
+rB
+rB
+rB
+rB
+rB
+nL
+nL
+nL
+nL
+eF
+eF
+eF
+eF
+GT
+GT
+GT
+GT
+GT
+GT
+GT
+eF
+"}

--- a/maps/map_files/BigRed/sprinkles/25.dndsolaris.dmm
+++ b/maps/map_files/BigRed/sprinkles/25.dndsolaris.dmm
@@ -1,0 +1,887 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ab" = (
+/obj/structure/barricade/metal/wired{
+	dir = 4;
+	icon_state = "metal_2"
+	},
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"au" = (
+/turf/open/floor{
+	dir = 8;
+	icon_state = "carpet13-5";
+	tag = "icon-carpet13-5 (WEST)"
+	},
+/area/template_noop)
+"cv" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/obj/structure/machinery/door/airlock/almayer/medical/glass{
+	name = "\improper Greenhouse Storage"
+	},
+/obj/structure/machinery/door/poddoor/shutters/almayer{
+	dir = 4;
+	id = "Library";
+	name = "\improper Library Shutters"
+	},
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"dF" = (
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "carpet10-8";
+	tag = "icon-carpet10-8 (WEST)"
+	},
+/area/template_noop)
+"dL" = (
+/obj/structure/machinery/light{
+	dir = 4
+	},
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"eh" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 5
+	},
+/turf/open/floor{
+	dir = 8;
+	icon_state = "carpet13-5";
+	tag = "icon-carpet13-5 (WEST)"
+	},
+/area/template_noop)
+"ei" = (
+/obj/structure/bookcase/manuals/research_and_development,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"fe" = (
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_2"
+	},
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"fo" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/obj/structure/bookcase/manuals/engineering,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"ho" = (
+/turf/closed/wall/solaris/reinforced,
+/area/template_noop)
+"hF" = (
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "carpet7-3";
+	tag = "icon-carpet7-3 (WEST)"
+	},
+/area/template_noop)
+"hL" = (
+/obj/structure/surface/table/woodentable,
+/obj/effect/landmark/costume/chicken,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"hT" = (
+/obj/structure/pipes/standard/simple/hidden/green,
+/obj/structure/barricade/plasteel/wired{
+	icon_state = "plasteel_2"
+	},
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"iQ" = (
+/turf/closed/wall/solaris,
+/area/template_noop)
+"kv" = (
+/obj/structure/surface/table/woodentable,
+/obj/effect/landmark/costume/elpresidente,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"lH" = (
+/obj/structure/pipes/standard/simple/hidden/green,
+/obj/structure/surface/table/woodentable,
+/obj/effect/landmark/costume/plaguedoctor,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"mn" = (
+/obj/structure/machinery/alarm{
+	dir = 4;
+	pixel_x = -30
+	},
+/obj/structure/surface/table/woodentable,
+/obj/item/pizzabox/vegetable,
+/obj/item/pizzabox/vegetable,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"nn" = (
+/obj/structure/bed/chair/wood/normal,
+/obj/effect/landmark/survivor_spawner/dnd,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"nI" = (
+/obj/structure/surface/table/woodentable,
+/obj/effect/landmark/costume/scratch,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"nR" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 9
+	},
+/obj/structure/surface/table/woodentable,
+/obj/effect/landmark/costume/pirate,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"oh" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 6
+	},
+/obj/structure/bookcase/manuals/engineering,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"pk" = (
+/obj/structure/surface/table/woodentable,
+/obj/item/pizzabox/margherita,
+/obj/item/pizzabox/margherita,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"pr" = (
+/turf/open/floor{
+	dir = 8;
+	icon_state = "carpet5-1";
+	tag = "icon-carpet5-1 (WEST)"
+	},
+/area/template_noop)
+"pJ" = (
+/obj/structure/pipes/standard/simple/hidden/green,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "carpet11-12";
+	tag = "icon-carpet11-12 (WEST)"
+	},
+/area/template_noop)
+"qF" = (
+/obj/structure/machinery/door/poddoor/shutters/almayer{
+	id = "Library";
+	name = "\improper Library Shutters"
+	},
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"qK" = (
+/obj/structure/machinery/door_control{
+	id = "Library";
+	name = "Storm Shutters";
+	pixel_x = 32
+	},
+/obj/structure/surface/table/woodentable,
+/obj/effect/landmark/costume/highlander,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"ue" = (
+/obj/structure/machinery/light{
+	dir = 4;
+	tag = "icon-tube1 (EAST)"
+	},
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 10
+	},
+/obj/structure/machinery/power/apc,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"ww" = (
+/turf/open/floor{
+	dir = 8;
+	icon_state = "carpet7-3";
+	tag = "icon-carpet7-3 (WEST)"
+	},
+/area/template_noop)
+"xd" = (
+/turf/open/floor{
+	dir = 8;
+	icon_state = "carpet10-8";
+	tag = "icon-carpet10-8 (WEST)"
+	},
+/area/template_noop)
+"xx" = (
+/obj/structure/machinery/light{
+	dir = 4
+	},
+/obj/structure/surface/table/woodentable,
+/obj/effect/landmark/costume/commie,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"xz" = (
+/obj/structure/bed/chair/wood/normal{
+	dir = 1
+	},
+/obj/effect/landmark/survivor_spawner/dnd,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"yw" = (
+/obj/structure/window/framed/solaris,
+/obj/structure/machinery/door/poddoor/shutters/almayer{
+	id = "Library";
+	name = "\improper Library Shutters"
+	},
+/turf/open/floor/plating,
+/area/template_noop)
+"yx" = (
+/obj/structure/pipes/standard/simple/hidden/green,
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "carpet11-12";
+	tag = "icon-carpet11-12 (WEST)"
+	},
+/area/template_noop)
+"yT" = (
+/obj/structure/machinery/light{
+	dir = 8
+	},
+/obj/structure/surface/table/woodentable,
+/obj/item/pizzabox/meat,
+/obj/item/pizzabox/meat,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"zc" = (
+/obj/structure/surface/table/woodentable,
+/obj/item/tool/pen/clicky,
+/obj/item/paper{
+	name = "Pinwizard Data Sheet"
+	},
+/obj/item/toy/dice/d20,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"Bl" = (
+/obj/structure/surface/table/woodentable,
+/obj/item/storage/firstaid/adv,
+/obj/item/storage/firstaid/adv,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"Bp" = (
+/obj/structure/surface/table/woodentable,
+/obj/effect/landmark/costume/random,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"Cg" = (
+/obj/structure/surface/table/woodentable,
+/obj/item/pizzabox/mushroom,
+/obj/item/pizzabox/mushroom,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"ES" = (
+/obj/structure/surface/table/woodentable,
+/obj/item/paper{
+	name = "Pinwizard Data Sheet"
+	},
+/obj/item/tool/pen/clicky,
+/obj/item/toy/dice/d20,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"EX" = (
+/obj/structure/bed/chair/wood/normal{
+	dir = 8;
+	tag = ""
+	},
+/obj/effect/landmark/survivor_spawner/dnd,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"Fm" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 10
+	},
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "carpet11-12";
+	tag = "icon-carpet11-12 (WEST)"
+	},
+/area/template_noop)
+"FH" = (
+/obj/effect/landmark/survivor_spawner/dnd,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"Gt" = (
+/obj/structure/machinery/light,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"GW" = (
+/obj/structure/surface/table/woodentable,
+/obj/structure/largecrate/merc/clothing,
+/obj/structure/largecrate/merc/clothing,
+/obj/structure/largecrate/merc/clothing,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"Hu" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 9
+	},
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"HT" = (
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"HY" = (
+/obj/structure/pipes/standard/manifold/hidden/green{
+	dir = 4
+	},
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"Jb" = (
+/obj/structure/surface/table/woodentable,
+/obj/structure/largecrate/merc,
+/obj/structure/largecrate/merc,
+/obj/structure/largecrate/merc,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"JM" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/obj/structure/machinery/door/airlock/almayer/generic{
+	name = "\improper Library Backroom"
+	},
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"JU" = (
+/obj/structure/surface/table/woodentable,
+/obj/item/storage/beer_pack,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"Kj" = (
+/obj/structure/pipes/standard/simple/hidden/green,
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "carpet7-3";
+	tag = "icon-carpet7-3 (WEST)"
+	},
+/area/template_noop)
+"Kz" = (
+/obj/structure/machinery/camera/autoname,
+/obj/structure/surface/table/woodentable,
+/obj/effect/landmark/costume/butler,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"Lx" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 5
+	},
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "carpet7-3";
+	tag = "icon-carpet7-3 (WEST)"
+	},
+/area/template_noop)
+"Mh" = (
+/obj/structure/surface/table/woodentable,
+/obj/item/ammo_box/magazine/shotgun/buckshot,
+/obj/item/ammo_box/magazine/shotgun/flechette,
+/obj/item/ammo_magazine/shotgun/slugs,
+/obj/item/ammo_magazine/shotgun/slugs,
+/obj/item/ammo_magazine/shotgun/slugs,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"MF" = (
+/obj/structure/window/framed/solaris,
+/obj/structure/machinery/door/poddoor/shutters/almayer{
+	dir = 4;
+	id = "Library";
+	name = "\improper Library Shutters"
+	},
+/turf/open/floor/plating,
+/area/template_noop)
+"Nm" = (
+/obj/structure/pipes/standard/simple/hidden/green,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "carpet15-15";
+	tag = "icon-carpet15-15 (WEST)"
+	},
+/area/template_noop)
+"NE" = (
+/obj/structure/barricade/plasteel/wired{
+	icon_state = "plasteel_2"
+	},
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"NI" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"Oe" = (
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "carpet11-12";
+	tag = "icon-carpet11-12 (WEST)"
+	},
+/area/template_noop)
+"Oi" = (
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"OZ" = (
+/obj/structure/machinery/cm_vending/sorted/walkman,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"Pp" = (
+/obj/structure/bookcase/manuals/engineering,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"Rh" = (
+/obj/structure/surface/table/woodentable,
+/obj/structure/pipes/vents/pump{
+	dir = 4
+	},
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"Rj" = (
+/obj/structure/surface/table/woodentable,
+/obj/item/toy/dice/d20,
+/obj/item/tool/pen/clicky,
+/obj/item/paper{
+	name = "Pinwizard Data Sheet"
+	},
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"Ro" = (
+/obj/structure/surface/table/woodentable,
+/obj/item/clothing/suit/imperium_monk,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"RD" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 6
+	},
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"Ss" = (
+/obj/structure/pipes/standard/simple/hidden/green,
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "carpet6-2";
+	tag = "icon-carpet6-2 (WEST)"
+	},
+/area/template_noop)
+"SW" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/obj/structure/barricade/plasteel/wired{
+	icon_state = "plasteel_2";
+	dir = 8
+	},
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"Tq" = (
+/obj/structure/pipes/standard/simple/hidden/green,
+/obj/structure/machinery/door/airlock/multi_tile/almayer/generic{
+	name = "\improper Library"
+	},
+/obj/structure/machinery/door/poddoor/shutters/almayer{
+	id = "Library";
+	name = "\improper Library Shutters"
+	},
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"Tz" = (
+/obj/structure/surface/table/woodentable,
+/obj/effect/landmark/costume/gladiator,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"Uh" = (
+/turf/open/floor{
+	dir = 8;
+	icon_state = "carpet14-10";
+	tag = "icon-carpet14-10 (WEST)"
+	},
+/area/template_noop)
+"Vc" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 10
+	},
+/turf/open/floor{
+	dir = 8;
+	icon_state = "carpet13-5";
+	tag = "icon-carpet13-5 (WEST)"
+	},
+/area/template_noop)
+"Wf" = (
+/obj/structure/machinery/camera/autoname{
+	dir = 4
+	},
+/obj/structure/surface/table/woodentable,
+/obj/item/stack/sheet/wood/large_stack,
+/obj/item/stack/sheet/wood/large_stack,
+/obj/item/stack/sheet/wood/large_stack,
+/obj/item/tool/weldingtool,
+/obj/item/tool/weldpack,
+/obj/item/clothing/glasses/welding,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"Wz" = (
+/obj/structure/surface/table/woodentable,
+/obj/effect/landmark/costume/prig,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"WR" = (
+/obj/structure/machinery/light{
+	dir = 4
+	},
+/obj/structure/surface/table/woodentable,
+/obj/item/reagent_container/food/snacks/sliceable/cheesecake,
+/obj/item/tool/kitchen/knife,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"YF" = (
+/obj/structure/machinery/light{
+	dir = 1
+	},
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"ZD" = (
+/obj/structure/bookcase,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+"ZJ" = (
+/turf/open/floor{
+	dir = 8;
+	icon_state = "carpet9-4";
+	tag = "icon-carpet9-4 (WEST)"
+	},
+/area/template_noop)
+"ZV" = (
+/obj/structure/bookcase/manuals/medical,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/template_noop)
+
+(1,1,1) = {"
+ho
+ho
+ho
+ho
+cv
+ho
+ho
+ho
+ho
+ho
+ho
+ho
+ho
+ho
+ho
+ho
+ho
+"}
+(2,1,1) = {"
+ho
+Pp
+Pp
+Pp
+SW
+JU
+pk
+Cg
+mn
+yT
+OZ
+Mh
+Jb
+GW
+Bl
+Wf
+ho
+"}
+(3,1,1) = {"
+ho
+nI
+HT
+HT
+NI
+FH
+Oi
+Oi
+FH
+Oi
+FH
+HT
+FH
+HT
+FH
+fe
+yw
+"}
+(4,1,1) = {"
+ho
+Bp
+HT
+oh
+HY
+Ss
+Kj
+Kj
+Kj
+Lx
+hF
+ww
+ww
+ww
+pr
+fe
+yw
+"}
+(5,1,1) = {"
+ho
+Wz
+HT
+fo
+Oi
+dF
+Oe
+Oe
+Oe
+Fm
+yx
+pJ
+pJ
+Nm
+eh
+Gt
+ho
+"}
+(6,1,1) = {"
+ho
+YF
+HT
+NI
+Oi
+Oi
+Oi
+Oi
+Oi
+Oi
+Oi
+Pp
+ZD
+Uh
+Vc
+hT
+Tq
+"}
+(7,1,1) = {"
+ho
+RD
+lH
+nR
+qK
+Tz
+nn
+zc
+Rj
+xz
+Oi
+HT
+HT
+Uh
+au
+NE
+qF
+"}
+(8,1,1) = {"
+ho
+JM
+iQ
+iQ
+iQ
+hL
+nn
+ES
+zc
+xz
+Oi
+ZV
+ZD
+Uh
+au
+Gt
+ho
+"}
+(9,1,1) = {"
+ho
+SW
+Rh
+Ro
+iQ
+Kz
+Oi
+Oi
+Oi
+Oi
+Oi
+ei
+ZD
+xd
+ZJ
+fe
+yw
+"}
+(10,1,1) = {"
+ho
+ue
+Hu
+EX
+iQ
+xx
+kv
+ab
+ab
+WR
+ab
+ab
+dL
+ab
+ab
+fe
+yw
+"}
+(11,1,1) = {"
+ho
+ho
+ho
+ho
+ho
+ho
+ho
+MF
+MF
+ho
+MF
+MF
+ho
+MF
+MF
+ho
+ho
+"}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

- This update is seeking to shake up the survivor gameplay by providing unique scenarios for survivors. This update adds several survivor holdouts (neutral & hostile) for survivors. In addition, I added a minor bugfix for synth survivor,

This update got delayed due to gitkraken nonsense, the bot closing my mr, and etc and rebasing a million files.

## Why It's Good For The Game

- One of the most underrated aspects of survivors is the ability to be able to do a last stand. The current meta shift revolves around LZ holds or roaming if that's not possible. This update should encourage survivors not to leave their place of work and instead fight and in most cases die for their company if they feel inclined to as opposed to roaming or cheesing out LZ holds.

## Non-Goals

- Giving survivors additional gear. Given that their gear is random and spread across the maps survivors will now have a focal point to restock on valued items in a localized area and runoff. Although survivors are expected to stay and fight to the last colonist, nothing stops them from looting the place. In the end of the day its player agency and I don't think it would be good to force them to do something they don't want to do like die in the bar, library or marshalls. Given that most the CLF insert have 25% spawn rate, as well as the dnd, insert this shouldn't be a problem. Given the frequency of the bar holdout, I have purposely given them fewer resources.
- 
- Xenomorphs have a harder time killing survivors. Although killing or capturing survivors is not a xenomorph goal as they can ignore them entirely. Having a holdout at places like bar or even libraries for that matter could prove to be a nuisance due to premade defenses and gear being available. As stated previously nothing guarantees the survivors staying there in the first place so they could be unmanned and easily melted. Don't assault a survivor holdout alone.



## Changelog

_**- Maps**_

This update as mentioned adds 3 new survivor holdouts for survivors that will randomly spawn throughout the map. Currently, there are only 3 being added but more will be added in the future. The colony didn't get raptured it was a bloody mess with people crying and fighting a hell hole. The MR has been balanced using the CLF crashed ship insert on LV-624 as an example as to how much medical, guns and other items will be spawned in for survivors. These are prepared positions so they should have ok gear and protection if we actually want to encourage people to hold it.

_**CLF Marshalls Take Over**_ **(25% Chance)**

![2022 07 26-10 19 56](https://user-images.githubusercontent.com/103712112/181070705-e4fba42d-65d7-4324-87e8-9bd138b90781.png)

- As stated previously the CLF have invaded the colony and have taken over the last bastion of the authority of the colony that is the colonial marshall's offices and armory. After the successful takeover, the CLF decided to make the ruins of the office into their own area of operation for future CLF activities in the colony. much like the crashed ship insert, they have been equipped with identical gear to their LV-624 counterparts with minor exceptions. The exception is materials to repair and potentially expand their area of influence. The barricades for the most part are worn out and need some repairs if they expect to live long enough.


_**Dungeons and Dragons Last Stand**_ **(25% Chance)**
![2022 07 26-10 20 15](https://user-images.githubusercontent.com/103712112/181070733-aab17328-8493-469f-9936-a6664cd5002b.png)- This nightmare insert was inspired by the event held by jarek where survivors attempted to have a sleepover in the LV nexus dormitories only to be slaughtered. This insert mirrors that in that colonists are hosting a dnd session in the local library. Given that the civilian survivor is rather lackluster I have gone ahead and supplied them with cosplay material so that they can arm themselves and carry out their dnd session in style. Much of it is fluff in many regards with the exception of the illegally smuggled merc gear. The balance of the insert is similar in the crashed ship insert but the barricades are repaired and the shutters closed.

_**The Bar Last Stand**_ **_(25% Chance)_**
![2022 07 26-10 19 30](https://user-images.githubusercontent.com/103712112/181070678-ec34dedb-e12a-44b3-a5fd-77917538f454.png)
- This insert reflects the valiant efforts of the colonist to have a last stand within the colony bar. The bar (according to the colonist handbook) was designated as an emergency rally point for all personnel and staff in the event of an unforeseen event. They come equipped with standard wooden barricades with building material should they want to replace them. In addition, they have ammo, medical supplies, and liquid courage to help them in their endeavor.

_**Minor Updates**_

- Synth survivor now has colonist radio. Previously in the synth survivor update, I accidentally gave them the wrong radio. This prevented them from communicating with survivors as they had a unique radio. The auto lathes produce marine radios so they couldn't find an adequate communication device.

- Colonist survivor now has the colonist jumpsuit. They had PJs for some reason. Odd

🆑 TheFlyingFlail
add: Added three new survivor holdout nightmare inserts for big red
add: Added clf survivor to big red with their own unique story to go with it
expansion: Expanded existing mechanics or gameplay
fix: fixed synth survivors not having colonists' radio
fix: fixed civilian survivor not having actual colonist clothing
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
