### PR TITLE
fixes abuse with hmgs and windows

### DIFF
--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -70,14 +70,14 @@
 				user.put_in_hands(RG)
 
 /obj/item/stack/sheet/glass/proc/construct_window(mob/user)
-	if(!user || !src)	return 0
-	if(!istype(user.loc,/turf)) return 0
+	if(!user || !src)	return FALSE
+	if(!istype(user.loc,/turf)) return FALSE
 	if(!user.IsAdvancedToolUser())
 		to_chat(user, SPAN_DANGER("You don't have the dexterity to do this!"))
-		return 0
+		return FALSE
 	if(ishuman(user) && !skillcheck(user, SKILL_CONSTRUCTION, SKILL_CONSTRUCTION_ENGI))
 		to_chat(user, SPAN_WARNING("You are not trained to build with [src]..."))
-		return 0
+		return FALSE
 	var/title = "Sheet-[name]"
 	title += " ([src.amount] sheet\s left)"
 	var/to_build = tgui_input_list(user, title, "What would you like to construct?", construction_options)
@@ -87,22 +87,36 @@
 	if(!(istype(T) && T.allow_construction))
 		to_chat(user, SPAN_WARNING("Windows must be constructed on a proper surface!"))
 		return
+	var/fail = FALSE
+	for(var/obj/X in T.contents - src)
+		if(istype(X, /obj/structure/machinery/defenses))
+			fail = TRUE
+			break
+		else if(istype(X, /obj/structure/machinery/m56d_hmg))
+			fail = TRUE
+			break
+	if(fail)
+		to_chat(user, SPAN_WARNING("You can't make a window here, something is in the way."))
+		return
 	switch(to_build)
 		if("One Direction")
-			if(!src)	return 1
-			if(src.loc != user)	return 1
-
+			if(!src)	return TRUE
+			if(src.loc != user)	return TRUE
+			var/obj/structure/blocker/anti_cade/AC = locate(/obj/structure/blocker/anti_cade) in T // for M2C HMG, look at smartgun_mount.dm
+			if(AC)
+				to_chat(usr, SPAN_WARNING("\The [src] cannot be built here!"))
+				return TRUE
 			var/list/directions = new/list(cardinal)
 			var/i = 0
 			for (var/obj/structure/window/win in user.loc)
 				i++
 				if(i >= 4)
 					to_chat(user, SPAN_DANGER("There are too many windows in this location."))
-					return 1
+					return TRUE
 				directions-=win.dir
 				if(!(win.dir in cardinal))
 					to_chat(user, SPAN_DANGER("Can't let you do that."))
-					return 1
+					return TRUE
 
 			//Determine the direction. It will first check in the direction the person making the window is facing, if it finds an already made window it will try looking at the next cardinal direction, etc.
 			var/dir_to_set = 2
@@ -118,38 +132,43 @@
 			WD.set_constructed_window(dir_to_set)
 			src.use(1)
 		if("Full Window")
-			if(!src)	return 1
-			if(src.loc != user)	return 1
+			if(!src)	return TRUE
+			if(src.loc != user)	return TRUE
 			if(src.amount < 4)
 				to_chat(user, SPAN_DANGER("You need more glass to do that."))
-				return 1
+				return TRUE
 			if(locate(/obj/structure/window) in user.loc)
 				to_chat(user, SPAN_DANGER("There is a window in the way."))
-				return 1
+				return TRUE
 			var/obj/structure/window/WD = new created_full_window(user.loc)
 			WD.set_constructed_window()
 			src.use(4)
 		if("Windoor")
-			if(!is_reinforced) return 1
+			if(!is_reinforced) return TRUE
 
-			if(!src || src.loc != user) return 1
+			if(!src || src.loc != user) return TRUE
 
-			if(isturf(user.loc) && locate(/obj/structure/windoor_assembly/, user.loc))
+			var/obj/structure/blocker/anti_cade/AC = locate(/obj/structure/blocker/anti_cade) in T // for M2C HMG, look at smartgun_mount.dm
+			if(AC)
+				to_chat(usr, SPAN_WARNING("\The [src] cannot be built here!"))
+				return TRUE
+
+			if(isturf(T) && locate(/obj/structure/windoor_assembly/, T))
 				to_chat(user, SPAN_DANGER("There is already a windoor assembly in that location."))
-				return 1
+				return TRUE
 
-			if(isturf(user.loc) && locate(/obj/structure/machinery/door/window/, user.loc))
+			if(isturf(T) && locate(/obj/structure/machinery/door/window/, T))
 				to_chat(user, SPAN_DANGER("There is already a windoor in that location."))
-				return 1
+				return TRUE
 
 			if(src.amount < 5)
 				to_chat(user, SPAN_DANGER("You need more glass to do that."))
-				return 1
+				return TRUE
 
-			new /obj/structure/windoor_assembly(user.loc, user.dir, 1)
+			new /obj/structure/windoor_assembly(T, user.dir, 1)
 			src.use(5)
 
-	return 0
+	return FALSE
 
 
 /*

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -249,9 +249,14 @@
 	if(HAS_TRAIT(W, TRAIT_TOOL_SCREWDRIVER) && !not_deconstructable)
 		if(!anchored)
 			var/turf/open/T = loc
+			var/obj/structure/blocker/anti_cade/AC = locate(/obj/structure/blocker/anti_cade) in T // for M2C HMG, look at smartgun_mount.dm
 			if(!(istype(T) && T.allow_construction))
-				to_chat(user, SPAN_WARNING("[src] must be fastened on a proper surface!"))
+				to_chat(user, SPAN_WARNING("\The [src] must be fastened on a proper surface!"))
 				return
+			if(AC)
+				to_chat(usr, SPAN_WARNING("\The [src] cannot be fastened here!"))  //might cause some friendly fire regarding other items like barbed wire, shouldn't be a problem?
+				return
+
 		if(reinf && state >= 1)
 			state = 3 - state
 			playsound(loc, 'sound/items/Screwdriver.ogg', 25, 1)

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -305,6 +305,12 @@
 		handle_debris()
 	qdel(src)
 
+/obj/structure/window/clicked(mob/user, list/mods)
+	if(mods["alt"])
+		revrotate(user)
+		return TRUE
+
+	return ..()
 
 /obj/structure/window/verb/rotate()
 	set name = "Rotate Window Counter-Clockwise"

--- a/code/modules/cm_marines/smartgun_mount.dm
+++ b/code/modules/cm_marines/smartgun_mount.dm
@@ -120,7 +120,7 @@
 	M.anchored = TRUE
 	M.update_icon()
 	M.set_name_label(name_label)
-	to_chat(user, SPAN_NOTICE("You deploy [src]."))
+	to_chat(user, SPAN_NOTICE("You deploy \the [src]."))
 	qdel(src)
 
 
@@ -165,7 +165,7 @@
 	if(user.z == GLOB.interior_manager.interior_z)
 		to_chat(usr, SPAN_WARNING("It's too cramped in here to deploy \a [src]."))
 		return
-	to_chat(user, SPAN_NOTICE("You deploy [src]."))
+	to_chat(user, SPAN_NOTICE("You deploy \the [src]."))
 	var/obj/structure/machinery/m56d_post/M = new /obj/structure/machinery/m56d_post(user.loc)
 	M.set_name_label(name_label)
 	qdel(src)
@@ -299,6 +299,15 @@
 					fail = TRUE
 					break
 				if(istype(X, /obj/structure/machinery/defenses))
+					fail = TRUE
+					break
+				else if(istype(X, /obj/structure/window))
+					fail = TRUE
+					break
+				else if(istype(X, /obj/structure/windoor_assembly))
+					fail = TRUE
+					break
+				else if(istype(X, /obj/structure/machinery/door))
 					fail = TRUE
 					break
 		if(fail)
@@ -965,6 +974,9 @@
 /obj/item/device/m2c_gun/proc/check_can_setup(mob/user, var/turf/rotate_check, var/turf/open/OT, var/list/ACR)
 	if(!ishuman(user))
 		return FALSE
+	if(broken_gun)
+		to_chat(user, SPAN_WARNING("You can't set up \the [src], it's completely broken!"))
+		return FALSE
 	if(user.z == GLOB.interior_manager.interior_z)
 		to_chat(usr, SPAN_WARNING("It's too cramped in here to deploy \a [src]."))
 		return FALSE
@@ -974,12 +986,25 @@
 	if(rotate_check.density)
 		to_chat(user, SPAN_WARNING("You can't set up \the [src] that way, there's a wall behind you!"))
 		return FALSE
-	if((locate(/obj/structure/barricade) in ACR) || (locate(/obj/structure/window_frame) in ACR))
-		to_chat(user, SPAN_WARNING("There's barriers nearby, you can't set up here!"))
+	if((locate(/obj/structure/barricade) in ACR) || (locate(/obj/structure/window_frame) in ACR) || (locate(/obj/structure/window) in ACR) || (locate(/obj/structure/windoor_assembly) in ACR))
+		to_chat(user, SPAN_WARNING("There are barriers nearby, you can't set up \the [src] here!"))
 		return FALSE
-	if(broken_gun)
-		to_chat(user, SPAN_WARNING("You can't set up \the [src], it's completely broken!"))
+	var/fail = FALSE
+	for(var/obj/X in OT.contents - src)
+		if(istype(X, /obj/structure/machinery/defenses))
+			fail = TRUE
+			break
+		else if(istype(X, /obj/structure/machinery/door))
+			fail = TRUE
+			break
+		else if(istype(X, /obj/structure/machinery/m56d_hmg))
+			fail = TRUE
+			break
+	if(fail)
+		to_chat(user, SPAN_WARNING("You can't install \the [src] here, something is in the way."))
 		return FALSE
+
+
 	if(!(user.alpha > 60))
 		to_chat(user, SPAN_WARNING("You can't set this up while cloaked!"))
 		return FALSE
@@ -1006,7 +1031,7 @@
 	M.setDir(user.dir) // Make sure we face the right direction
 	M.anchored = TRUE
 	playsound(M, 'sound/items/m56dauto_setup.ogg', 75, TRUE)
-	to_chat(user, SPAN_NOTICE("You deploy [M]."))
+	to_chat(user, SPAN_NOTICE("You deploy \the [M]."))
 	if((rounds > 0) && !user.get_inactive_hand())
 		user.set_interaction(M)
 	M.rounds = rounds
@@ -1141,7 +1166,12 @@
 /obj/structure/blocker/anti_cade/BlockedPassDirs(atom/movable/AM, target_dir)
 	if(istype(AM, /obj/structure/barricade))
 		return BLOCKED_MOVEMENT
-
+	else if(istype(AM, /obj/structure/window))
+		return BLOCKED_MOVEMENT
+	else if(istype(AM, /obj/structure/windoor_assembly))
+		return BLOCKED_MOVEMENT
+	else if(istype(AM, /obj/structure/machinery/door))
+		return BLOCKED_MOVEMENT
 	return ..()
 
 /obj/structure/blocker/anti_cade/Destroy()

--- a/code/modules/cm_marines/smartgun_mount.dm
+++ b/code/modules/cm_marines/smartgun_mount.dm
@@ -110,6 +110,32 @@
 	if(user.z == GLOB.interior_manager.interior_z)
 		to_chat(usr, SPAN_WARNING("It's too cramped in here to deploy \a [src]."))
 		return
+	var/turf/T = get_turf(usr)
+	var/fail = FALSE
+	if(T.density)
+		fail = TRUE
+	else
+		for(var/obj/X in T.contents - src)
+			if(X.density && !(X.flags_atom & ON_BORDER))
+				fail = TRUE
+				break
+			if(istype(X, /obj/structure/machinery/defenses))
+				fail = TRUE
+				break
+			else if(istype(X, /obj/structure/window))
+				fail = TRUE
+				break
+			else if(istype(X, /obj/structure/windoor_assembly))
+				fail = TRUE
+				break
+			else if(istype(X, /obj/structure/machinery/door))
+				fail = TRUE
+				break
+	if(fail)
+		to_chat(usr, SPAN_WARNING("You can't deploy \the [src] here, something is in the way."))
+		return
+
+
 	if(!do_after(user, 1 SECONDS, INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD))
 		return
 
@@ -165,6 +191,31 @@
 	if(user.z == GLOB.interior_manager.interior_z)
 		to_chat(usr, SPAN_WARNING("It's too cramped in here to deploy \a [src]."))
 		return
+	var/turf/T = get_turf(user)
+	var/fail = FALSE
+	if(T.density)
+		fail = TRUE
+	else
+		for(var/obj/X in T.contents)
+			if(X.density && !(X.flags_atom & ON_BORDER))
+				fail = TRUE
+				break
+			if(istype(X, /obj/structure/machinery/defenses))
+				fail = TRUE
+				break
+			else if(istype(X, /obj/structure/window))
+				fail = TRUE
+				break
+			else if(istype(X, /obj/structure/windoor_assembly))
+				fail = TRUE
+				break
+			else if(istype(X, /obj/structure/machinery/door))
+				fail = TRUE
+				break
+	if(fail)
+		to_chat(user, SPAN_WARNING("You can't install \the [src] here, something is in the way."))
+		return
+
 	to_chat(user, SPAN_NOTICE("You deploy \the [src]."))
 	var/obj/structure/machinery/m56d_post/M = new /obj/structure/machinery/m56d_post(user.loc)
 	M.set_name_label(name_label)
@@ -238,8 +289,11 @@
 		return
 	var/mob/living/carbon/human/user = usr //this is us
 	if(over_object == user && in_range(src, user))
-		if(anchored)
-			to_chat(user, SPAN_WARNING("[src] can't be folded while screwed to the floor. Unscrew it first."))
+		if(anchored && gun_mounted)
+			to_chat(user, SPAN_WARNING("\The [src] can't be folded while there's an unsecured gun mounted on it. Either complete the assembly or take the gun off with a crowbar."))
+			return
+		else if(anchored)
+			to_chat(user, SPAN_WARNING("\The [src] can't be folded while screwed to the floor. Unscrew it first."))
 			return
 		to_chat(user, SPAN_NOTICE("You fold [src]."))
 		var/obj/item/device/m56d_post/P = new(loc)
@@ -461,7 +515,7 @@
 			return
 		else
 			playsound(src.loc, 'sound/items/Ratchet.ogg', 25, 1)
-			user.visible_message("[user] rotates the [src].","You rotate the [src].")
+			user.visible_message("[user] rotates \the [src].","You rotate \the [src].")
 			setDir(turn(dir, -90))
 			if(operator)
 				update_pixels(operator)
@@ -686,7 +740,7 @@
 		user.unset_interaction()
 		return HANDLE_CLICK_UNHANDLED
 	if(user.get_active_hand())
-		to_chat(usr, SPAN_WARNING("You need a free hand to shoot the [src]."))
+		to_chat(usr, SPAN_WARNING("You need a free hand to shoot \the [src]."))
 		return HANDLE_CLICK_UNHANDLED
 	if(!user.allow_gun_usage)
 		to_chat(user, SPAN_WARNING("You aren't allowed to use firearms!"))
@@ -786,7 +840,7 @@
 				to_chat(user, "You're already manning something!")
 				return
 			if(user.get_active_hand() != null)
-				to_chat(user, SPAN_WARNING("You need a free hand to man the [src]."))
+				to_chat(user, SPAN_WARNING("You need a free hand to man \the [src]."))
 
 			if(!user.allow_gun_usage)
 				to_chat(user, SPAN_WARNING("You aren't allowed to use firearms!"))
@@ -1247,8 +1301,8 @@
 			return
 
 		if(WT.remove_fuel(2, user))
-			user.visible_message(SPAN_NOTICE("[user] begins repairing damage on [src]."), \
-				SPAN_NOTICE("You begin repairing the damage on the [src]."))
+			user.visible_message(SPAN_NOTICE("[user] begins repairing damage on \the [src]."), \
+				SPAN_NOTICE("You begin repairing the damage on \the [src]."))
 			playsound(src.loc, 'sound/items/Welder2.ogg', 25, 1)
 			if(!do_after(user, repair_time * user.get_skill_duration_multiplier(SKILL_ENGINEER), INTERRUPT_ALL, BUSY_ICON_FRIENDLY, src))
 				return

--- a/code/modules/defenses/sentry.dm
+++ b/code/modules/defenses/sentry.dm
@@ -108,7 +108,7 @@
 /obj/structure/machinery/defenses/sentry/examine(mob/user)
 	. = ..()
 	if(ammo)
-		to_chat(user, SPAN_NOTICE("[src] has [ammo.current_rounds]/[ammo.max_rounds] rounds loaded."))
+		to_chat(user, SPAN_NOTICE("[src] has [ammo.current_rounds]/[ammo.max_rounds] round\s loaded."))
 	else
 		to_chat(user, SPAN_NOTICE("[src] is empty and needs to be refilled with ammo."))
 

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -1065,7 +1065,7 @@ Turn() or Shift() as there is virtually no overhead. ~N
 					AM.current_rounds += transfering
 					bullet_amount     -= transfering
 					playsound(src, pick('sound/weapons/handling/mag_refill_1.ogg', 'sound/weapons/handling/mag_refill_2.ogg', 'sound/weapons/handling/mag_refill_3.ogg'), 20, TRUE, 6)
-					to_chat(user, SPAN_NOTICE("You have transferred [abs(transfering)] rounds to [dumping ? src : AM]."))
+					to_chat(user, SPAN_NOTICE("You have transferred [abs(transfering)] round\s to [dumping ? src : AM]."))
 					transfering = 0
 
 			while(transferable >= 1)
@@ -1090,7 +1090,7 @@ Turn() or Shift() as there is virtually no overhead. ~N
 			bullet_amount += S
 			AM.update_icon()
 			update_icon()
-			to_chat(user, SPAN_NOTICE("You put [S] rounds into [src]."))
+			to_chat(user, SPAN_NOTICE("You put [S] round\s into [src]."))
 			if(AM.current_rounds <= 0)
 				user.temp_drop_inv_item(AM)
 				qdel(AM)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

you can no longer abuse one directional windows to shoot hmgs etc through them

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

fixes abuse

closes #743 

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: you can no longer build windows on the same tile as an m56d, this will prevent abuse via firing "through" a window on the same tile as you
fix: m2cs can no longer be built on top of each other
qol: you can now rotate windows with alt-click
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
