### PR TITLE
Xeno Directional Attack IFF pref

### DIFF
--- a/code/__DEFINES/mode.dm
+++ b/code/__DEFINES/mode.dm
@@ -86,6 +86,7 @@
 #define TOGGLE_MEMBER_PUBLIC				(1<<11) //determines if you get a byond logo by your name in ooc if you're a member or not
 #define TOGGLE_OOC_FLAG						(1<<12) // determines if your country flag appears by your name in ooc chat
 #define TOGGLE_MIDDLE_MOUSE_SWAP_HANDS		(1<<13) //Toggle whether middle click swaps your hands
+#define TOGGLE_DIR_ASSIST_IFF				(1<<14) //Toggle whether directional assist attacks friendly xenos or not
 //=================================================
 
 var/list/be_special_flags = list(

--- a/code/_onclick/xeno.dm
+++ b/code/_onclick/xeno.dm
@@ -18,7 +18,12 @@
 				if (!alt)
 					alt = L // last option is a simple mob
 				continue
-
+			if (istype(L, /mob/living/carbon/Xenomorph) && client?.prefs?.toggle_prefs & TOGGLE_DIR_ASSIST_IFF)
+				var/mob/living/carbon/Xenomorph/X = L
+				to_chat_forced(world,"A")
+				if (X.hivenumber == src.hivenumber)
+					to_chat_forced(world,"B")
+					continue
 			if (!L.is_xeno_grabbable() || L == src) //Xenos never attack themselves.
 				continue
 			if (L.lying)

--- a/code/_onclick/xeno.dm
+++ b/code/_onclick/xeno.dm
@@ -20,9 +20,7 @@
 				continue
 			if (istype(L, /mob/living/carbon/Xenomorph) && client?.prefs?.toggle_prefs & TOGGLE_DIR_ASSIST_IFF)
 				var/mob/living/carbon/Xenomorph/X = L
-				to_chat_forced(world,"A")
 				if (X.hivenumber == src.hivenumber)
-					to_chat_forced(world,"B")
 					continue
 			if (!L.is_xeno_grabbable() || L == src) //Xenos never attack themselves.
 				continue

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -48,7 +48,7 @@ var/const/MAX_SAVE_SLOTS = 10
 	var/lastchangelog = ""				// Saved changlog filesize to detect if there was a change
 	var/ooccolor
 	var/be_special = 0				// Special role selection
-	var/toggle_prefs = TOGGLE_MIDDLE_MOUSE_CLICK|TOGGLE_DIRECTIONAL_ATTACK|TOGGLE_MEMBER_PUBLIC // flags in #define/mode.dm
+	var/toggle_prefs = TOGGLE_MIDDLE_MOUSE_CLICK|TOGGLE_DIRECTIONAL_ATTACK|TOGGLE_MEMBER_PUBLIC|TOGGLE_DIR_ASSIST_IFF // flags in #define/mode.dm
 	var/UI_style = "midnight"
 	var/toggles_chat = TOGGLES_CHAT_DEFAULT
 	var/toggles_ghost = TOGGLES_GHOST_DEFAULT
@@ -550,6 +550,8 @@ var/const/MAX_SAVE_SLOTS = 10
 					</b> <a href='?_src_=prefs;preference=toggle_prefs;flag=[TOGGLE_MIDDLE_MOUSE_CLICK]'><b>[toggle_prefs & TOGGLE_MIDDLE_MOUSE_CLICK ? "On" : "Off"]</b></a><br>"
 			dat += "<b>Toggle Directional Assist: \
 					</b> <a href='?_src_=prefs;preference=toggle_prefs;flag=[TOGGLE_DIRECTIONAL_ATTACK]'><b>[toggle_prefs & TOGGLE_DIRECTIONAL_ATTACK ? "On" : "Off"]</b></a><br>"
+			dat += "<b>Toggle Disable directional assist on friendly xenos: \
+					</b> <a href='?_src_=prefs;preference=toggle_prefs;flag=[TOGGLE_DIR_ASSIST_IFF]'><b>[toggle_prefs & TOGGLE_DIR_ASSIST_IFF ? "On" : "Off"]</b></a><br>"
 			dat += "<b>Toggle Magazine Auto-Ejection: \
 					</b> <a href='?_src_=prefs;preference=toggle_prefs;flag=[TOGGLE_AUTO_EJECT_MAGAZINE_OFF];flag_undo=[TOGGLE_AUTO_EJECT_MAGAZINE_TO_HAND]'><b>[!(toggle_prefs & TOGGLE_AUTO_EJECT_MAGAZINE_OFF) ? "On" : "Off"]</b></a><br>"
 			dat += "<b>Toggle Magazine Auto-Ejection to Offhand: \

--- a/code/modules/mob/living/carbon/xenomorph/xeno_verbs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_verbs.dm
@@ -125,6 +125,22 @@
 	else
 		to_chat(src, SPAN_NOTICE("Attacks will no longer use directional assist."))
 
+/mob/living/carbon/Xenomorph/verb/directional_attack_iff_toggle()
+	set name = "Toggle Directional Attack Friendly Fire"
+	set desc = "Toggles whether we should check for friendlies on a directional attack."
+	set category = "Alien"
+
+	if (!client || !client.prefs)
+		return
+
+	client.prefs.toggle_prefs ^= TOGGLE_DIR_ASSIST_IFF
+	client.prefs.save_preferences()
+	if(client.prefs.toggle_prefs & TOGGLE_DIR_ASSIST_IFF)
+		to_chat(src, SPAN_NOTICE("Directional assist will no longer target friendly xenomorphs. To target them, you now must click their sprite."))
+	else
+		to_chat(src, SPAN_NOTICE("Directional assist will now target xenomorphs even if their sprite is clicked."))
+
+
 /mob/living/carbon/Xenomorph/cancel_camera()
 	. = ..()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Added a preference to toggle a check that disables a friendly xeno from being caught in a directional attack. This is enabled by default.

It checks for xenos of the same hivenumber so XvX is unaffected

This is enabled by default.

it's also a verb that can be binded to a macro as needed with 
`directional_attack_iff_toggle`

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

massive qol + no more accidentally knocking down friendly xenos when trying to cap


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: totalepicness
qol: Added a preference to toggle a check that disables a friendly xeno from being caught in a directional attack. This is enabled by default.
qol: The above can be toggled by a verb if needed with "directional_attack_iff_toggle"
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
