### PR TITLE
Fixes not deleting empty DS ammo bug

### DIFF
--- a/code/modules/cm_marines/dropship_ammo.dm
+++ b/code/modules/cm_marines/dropship_ammo.dm
@@ -32,20 +32,20 @@
 		var/obj/item/powerloader_clamp/PC = I
 		if(!PC.linked_powerloader)
 			qdel(PC)
-			return TRUE
+			return FALSE
 		if(PC.loaded)
 			if(istype(PC.loaded, /obj/structure/ship_ammo))
 				var/obj/structure/ship_ammo/SA = PC.loaded
 				SA.transfer_ammo(src, user)
-				return TRUE
+				return FALSE
 			else
 				to_chat(user, SPAN_WARNING("\The [PC] must be empty in order to grab \the [src]!"))
-				return TRUE
+				return FALSE
 		else
 			if(ammo_count < 1)
 				to_chat(user, SPAN_WARNING("\The [src] has ran out of ammo, so you discard it!"))
 				qdel(src)
-				return TRUE
+				return FALSE
 
 			to_chat(user, SPAN_NOTICE("You grab \the [src] with \the [PC]."))
 			if(ammo_name == "rocket")
@@ -53,6 +53,7 @@
 			else
 				PC.grab_object(src, "ds_ammo", 'sound/machines/hydraulics_1.ogg')
 			update_icon()
+			return FALSE
 		return TRUE
 	else
 		. = ..()

--- a/code/modules/cm_marines/dropship_ammo.dm
+++ b/code/modules/cm_marines/dropship_ammo.dm
@@ -54,7 +54,6 @@
 				PC.grab_object(src, "ds_ammo", 'sound/machines/hydraulics_1.ogg')
 			update_icon()
 			return FALSE
-		return TRUE
 	else
 		. = ..()
 

--- a/code/modules/vehicles/powerloader.dm
+++ b/code/modules/vehicles/powerloader.dm
@@ -315,7 +315,7 @@
 		qdel(src)
 		return
 	loaded = target
-	loaded.forceMove(linked_powerloader)
+	loaded.forceMove(src)
 	playsound(src, sound, 40, 1)
 	update_icon(target_tag)
 	target.update_icon()


### PR DESCRIPTION
## About The Pull Request

Fixes not deleting empty DS ammo bug

## Why It's Good For The Game

Bugfix

## Changelog

:cl:
fix: fixed powerloaders not deleting empty DS ammo when they remove it from a weapon
/:cl: