### PR TITLE
Orbiters will now follow xenos if they evolve or de-evolve

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/Evolution.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Evolution.dm
@@ -144,6 +144,8 @@
 
 	if(hive.living_xeno_queen && hive.living_xeno_queen.observed_xeno == src)
 		hive.living_xeno_queen.overwatch(new_xeno)
+		
+	src.transfer_observers_to(new_xeno)
 
 	qdel(src)
 	new_xeno.xeno_jitter(25)
@@ -312,6 +314,9 @@
 	if(round_statistics && !new_xeno.statistic_exempt)
 		round_statistics.track_new_participant(faction, -1) //so an evolved xeno doesn't count as two.
 	SSround_recording.recorder.track_player(new_xeno)
+	
+	src.transfer_observers_to(new_xeno)
+	
 	qdel(src)
 
 /mob/living/carbon/Xenomorph/proc/can_evolve(castepick, potential_queens)

--- a/code/modules/mob/living/carbon/xenomorph/abilities/queen/queen_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/queen/queen_powers.dm
@@ -121,6 +121,9 @@
 
 	message_staff("[key_name_admin(X)] has deevolved [key_name_admin(T)]. Reason: [reason]")
 	log_admin("[key_name_admin(X)] has deevolved [key_name_admin(T)]. Reason: [reason]")
+	
+	T.transfer_observers_to(new_xeno)
+	
 	qdel(T)
 	..()
 	return


### PR DESCRIPTION

## About The Pull Request

Orbiters will now follow xenos if they evolve or de-evolve.

## Why It's Good For The Game

BUG BAD

## Changelog

:cl: Morrow
fix: Orbiters will now follow xenos if they evolve or de-evolve
/:cl:

Closes https://github.com/cmss13-devs/cmss13/issues/765