### PR TITLE
Applying acid code tweak

### DIFF
--- a/code/game/machinery/computer/computer.dm
+++ b/code/game/machinery/computer/computer.dm
@@ -134,9 +134,6 @@
 		if(ishuman(usr))
 			playsound(src, pick('sound/machines/computer_typing4.ogg', 'sound/machines/computer_typing5.ogg', 'sound/machines/computer_typing6.ogg'), 5, 1)
 
-/obj/structure/machinery/computer/get_applying_acid_time()
-	return -1
-
 /obj/structure/machinery/computer/fixer
 	var/all_configs
 

--- a/code/game/machinery/computer/computer.dm
+++ b/code/game/machinery/computer/computer.dm
@@ -134,6 +134,9 @@
 		if(ishuman(usr))
 			playsound(src, pick('sound/machines/computer_typing4.ogg', 'sound/machines/computer_typing5.ogg', 'sound/machines/computer_typing6.ogg'), 5, 1)
 
+/obj/structure/machinery/computer/get_applying_acid_time()
+	return -1
+
 /obj/structure/machinery/computer/fixer
 	var/all_configs
 

--- a/code/game/objects/effects/effect.dm
+++ b/code/game/objects/effects/effect.dm
@@ -1,2 +1,5 @@
 /obj/effect
 	icon = 'icons/effects/effects.dmi'
+
+/obj/effect/get_applying_acid_time()
+	return -1

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -367,3 +367,13 @@
 
 /obj/proc/extinguish()
 	return
+
+//returns time or -1 if unmeltable
+/obj/proc/get_applying_acid_time()
+	if(unacidable)
+		return -1
+
+	if(density)//dense objects are big, so takes longer to melt.
+		return 4 SECONDS
+
+	return 1 SECONDS

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -220,3 +220,9 @@
 			else
 				user.visible_message(SPAN_NOTICE("[user] unanchors [src]."),SPAN_NOTICE("You unanchor [src]."))
 			return TRUE
+
+/obj/structure/get_applying_acid_time()
+	if(unacidable)
+		return -1
+
+	return 4 SECONDS

--- a/code/modules/mob/living/carbon/xenomorph/abilities/ability_helper_procs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/ability_helper_procs.dm
@@ -31,17 +31,16 @@
 	if(isobj(O))
 		I = O
 
-		if(I.unacidable || istype(I, /obj/structure/machinery/computer) || istype(I, /obj/effect)) //So the aliens don't destroy energy fields/singularies/other aliens/etc with their acid.
-			to_chat(src, SPAN_WARNING("You cannot dissolve [I].")) // ^^ Note for obj/effect.. this might check for unwanted stuff. Oh well
-			return
-		if(istype(O, /obj/structure/window_frame))
-			var/obj/structure/window_frame/WF = O
+		if(istype(I, /obj/structure/window_frame))
+			var/obj/structure/window_frame/WF = I
 			if(WF.reinforced && acid_type != /obj/effect/xenomorph/acid/strong)
 				to_chat(src, SPAN_WARNING("This [O.name] is too tough to be melted by your weak acid."))
 				return
 
-		if(O.density || istype(O, /obj/structure))
-			wait_time = 40 //dense objects are big, so takes longer to melt.
+		wait_time = I.get_applying_acid_time()
+		if(wait_time == -1)
+			to_chat(src, SPAN_WARNING("You cannot dissolve [I]."))
+			return
 
 	//TURF CHECK
 	else if(isturf(O))
@@ -136,7 +135,7 @@
 
 	if(istype(O, /obj/vehicle/multitile))
 		var/obj/vehicle/multitile/R = O
-		R.take_damage_type((1 / A.acid_strength) * 20, "acid", src)
+		R.take_damage_type((1 / A.acid_strength) * 40, "acid", src)
 		visible_message(SPAN_XENOWARNING("[src] vomits globs of vile stuff at \the [O]. It sizzles under the bubbling mess of acid!"), \
 			SPAN_XENOWARNING("You vomit globs of vile stuff at [O]. It sizzles under the bubbling mess of acid!"), null, 5)
 		playsound(loc, "sound/bullets/acid_impact1.ogg", 25)

--- a/code/modules/mob/living/carbon/xenomorph/abilities/ability_helper_procs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/ability_helper_procs.dm
@@ -39,7 +39,7 @@
 
 		wait_time = I.get_applying_acid_time()
 		if(wait_time == -1)
-			to_chat(src, SPAN_WARNING("You cannot dissolve [I]."))
+			to_chat(src, SPAN_WARNING("You cannot dissolve \the [I]."))
 			return
 
 	//TURF CHECK

--- a/code/modules/vehicles/hardpoints/hardpoint.dm
+++ b/code/modules/vehicles/hardpoints/hardpoint.dm
@@ -623,3 +623,6 @@ obj/item/hardpoint/proc/remove_buff(var/obj/vehicle/multitile/V)
 // debug proc
 /obj/item/hardpoint/proc/set_mf_use_trt(var/use)
 	use_mz_trt_offsets = use
+
+obj/item/hardpoint/get_applying_acid_time()
+	return 10 SECONDS //you are not supposed to be able to easily combat-melt irreplaceable things.

--- a/code/modules/vehicles/multitile/multitile.dm
+++ b/code/modules/vehicles/multitile/multitile.dm
@@ -409,3 +409,6 @@ GLOBAL_LIST_EMPTY(all_multi_vehicles)
 		if(NORTH)
 			M.try_rotate(90)
 			M.try_rotate(90)
+
+/obj/vehicle/multitile/get_applying_acid_time()
+	return 3 SECONDS


### PR DESCRIPTION
## About The Pull Request

1. Added proc/get_applying_acid_time() to objects. Returns time or -1 if unmeltable.
2. Multitile vehicles get 3 seconds timer and receive twice more damage from it now.
3. Hardpoint modules require 10 seconds to melt because they are irreplacable and should not be easy to combat melt.

## Why It's Good For The Game

More flexible melting time assignment. Prevents easy combat melting of irreplaceable gear.

## Changelog

:cl:
balance: Hardpoints require 10 seconds to apply acid to them to prevent easy combat melting.
balance: Vehicles require 3 seconds to apply acid instead of 4 and receive twice more damage for it.
/:cl:
