### PR TITLE
The Colonial Liberation Front Nightmare Inserts

### DIFF
--- a/code/game/objects/effects/landmarks/corpsespawner.dm
+++ b/code/game/objects/effects/landmarks/corpsespawner.dm
@@ -111,3 +111,13 @@
 /obj/effect/landmark/corpsespawner/ua_riot/burst
 	name = "Burst UA Officer"
 	equip_path = /datum/equipment_preset/corpse/ua_riot/burst
+
+///Hostile Faction Spawner Corpse///
+
+/obj/effect/landmark/corpsespawner/clf
+	name = "Colonial Liberation Front Soldier"
+	equip_path = /datum/equipment_preset/corpse/clf
+
+/obj/effect/landmark/corpsespawner/clf/burst
+	name = "Burst Colonial Liberation Front Soldier"
+	equip_path = /datum/equipment_preset/corpse/clf/burst

--- a/code/game/objects/effects/landmarks/survivor_spawner.dm
+++ b/code/game/objects/effects/landmarks/survivor_spawner.dm
@@ -61,4 +61,10 @@
 	roundstart_damage_max = 10
 	roundstart_damage_times = 2
 
+/obj/effect/landmark/survivor_spawner/clf/generic
+	equipment = /datum/equipment_preset/survivor/clf
+	intro_text = list("<h2>You are a survivor of a colonial uprising!</h2>",\
+	"<span class='notice'>You are NOT aware of the xenomorph threat.</span>",\
+	"<span class='danger'>Your primary objective is to heal up and survive. If you want to assault the hive - adminhelp.</span>")
+	story_text = "You are a soldier of the Colonial Liberation Front. Your ship received a distress signal from a planet bordering CLF controlled space under USCM control. Ready and willing to save poor colonists from parasitic tyrants, you and your team boarded a small ship called the Marie Curie. You took over the Colonial Marshal's office and sent an all clear signal to the nearby PMC distress team, however an unknown entity has responded to the call. You dont know who they are but they will likely identify you as a foe."
 

--- a/code/game/objects/items/explosives/mine.dm
+++ b/code/game/objects/items/explosives/mine.dm
@@ -305,6 +305,18 @@
 	base_icon_state = "m20p"
 	map_deployed = TRUE
 
+/obj/item/explosive/mine/mine
+	name = "\improper Hacked M20P Claymore anti-personnel mine"
+	desc = "The M20P Claymore is a directional proximity triggered anti-personnel mine designed by Armat Systems for use by the United States Colonial Marines. It has been modified for use by the Colonial Liberation Front forces."
+	icon_state = "m20p"
+	iff_signal = FACTION_CLF
+	hard_iff_lock = TRUE
+
+/obj/item/explosive/mine/clf/active
+	icon_state = "m20p_active"
+	base_icon_state = "m20p"
+	map_deployed = TRUE
+
 /obj/item/explosive/mine/custom
 	name = "Custom mine"
 	desc = "A custom chemical mine built from an M20 casing."

--- a/code/modules/gear_presets/corpses.dm
+++ b/code/modules/gear_presets/corpses.dm
@@ -471,3 +471,42 @@
 /datum/equipment_preset/corpse/ua_riot/burst
 	name = "Corpse - Burst UA Officer"
 	xenovictim = TRUE
+
+//Hostile Faction Corpse
+/datum/equipment_preset/corpse/clf
+	name = "Corpse - Colonial Liberation Front Soldier"
+	assignment = "Colonial Liberation Front Soldier"
+	idtype = /obj/item/card/id/silver
+	xenovictim = FALSE
+	access = list(
+		ACCESS_CIVILIAN_PUBLIC,
+		ACCESS_CIVILIAN_LOGISTICS,
+		ACCESS_CIVILIAN_ENGINEERING,
+		ACCESS_CIVILIAN_RESEARCH,
+		ACCESS_CIVILIAN_BRIG,
+		ACCESS_CIVILIAN_MEDBAY,
+		ACCESS_CIVILIAN_COMMAND,
+		ACCESS_MARINE_MAINT,
+		ACCESS_WY_CORPORATE,
+	)
+
+/datum/equipment_preset/corpse/clf/load_gear(mob/living/carbon/human/H)
+	
+	spawn_rebel_uniform(H)
+	spawn_rebel_suit(H)
+	spawn_rebel_helmet(H)
+	spawn_rebel_shoes(H)
+	spawn_rebel_gloves(H)
+	spawn_rebel_belt(H)
+
+	H.equip_to_slot_or_del(new /obj/item/device/radio/headset/distress/CLF(H), WEAR_L_EAR)
+	H.equip_to_slot_or_del(new /obj/item/storage/backpack/lightpack(H), WEAR_BACK)
+	H.equip_to_slot_or_del(new /obj/item/device/flashlight(H), WEAR_IN_BACK)
+	H.equip_to_slot_or_del(new /obj/item/tool/crowbar(H), WEAR_IN_BACK)
+	H.equip_to_slot_or_del(new /obj/item/device/radio(H), WEAR_IN_BACK)
+	H.equip_to_slot_or_del(new /obj/item/storage/pouch/survival/full(H), WEAR_L_STORE)
+	H.equip_to_slot_or_del(new /obj/item/storage/pouch/tools/full(H), WEAR_R_STORE)
+
+/datum/equipment_preset/corpse/clf/burst
+	name = "Corpse - Colonial Liberation Front Soldier"
+	xenovictim = TRUE

--- a/maps/map_files/DesertDam/Desert_Dam.dmm
+++ b/maps/map_files/DesertDam/Desert_Dam.dmm
@@ -65095,6 +65095,9 @@
 	dir = 8
 	},
 /obj/effect/blocker/toxic_water/Group_1,
+/obj/effect/landmark/nightmare{
+	insert_tag = "clftrijent"
+	},
 /turf/open/gm/river/desert/shallow,
 /area/desert_dam/exterior/river/riverside_south)
 "jtz" = (

--- a/maps/map_files/DesertDam/Desert_Dam.dmm
+++ b/maps/map_files/DesertDam/Desert_Dam.dmm
@@ -65096,7 +65096,7 @@
 	},
 /obj/effect/blocker/toxic_water/Group_1,
 /obj/effect/landmark/nightmare{
-	insert_tag = "purple-south-bridge"
+	insert_tag = "clftrijent"
 	},
 /turf/open/gm/river/desert/shallow,
 /area/desert_dam/exterior/river/riverside_south)
@@ -67551,7 +67551,7 @@
 /area/desert_dam/exterior/valley/valley_hydro)
 "szl" = (
 /obj/effect/landmark/nightmare{
-	insert_tag = clftrijent
+	insert_tag = "clftrijent"
 	},
 /turf/closed/wall/hangar{
 	name = "reinforced metal wall"

--- a/maps/map_files/DesertDam/Desert_Dam.dmm
+++ b/maps/map_files/DesertDam/Desert_Dam.dmm
@@ -65096,11 +65096,14 @@
 	},
 /obj/effect/blocker/toxic_water/Group_1,
 <<<<<<< master
+<<<<<<< master
 =======
 /obj/effect/landmark/nightmare{
 	insert_tag = "clftrijent"
 	},
 >>>>>>> updated CLF spawner
+=======
+>>>>>>> fixed issue with invalid landmark
 /turf/open/gm/river/desert/shallow,
 /area/desert_dam/exterior/river/riverside_south)
 "jtz" = (

--- a/maps/map_files/DesertDam/Desert_Dam.dmm
+++ b/maps/map_files/DesertDam/Desert_Dam.dmm
@@ -65095,6 +65095,12 @@
 	dir = 8
 	},
 /obj/effect/blocker/toxic_water/Group_1,
+<<<<<<< master
+=======
+/obj/effect/landmark/nightmare{
+	insert_tag = "clftrijent"
+	},
+>>>>>>> updated CLF spawner
 /turf/open/gm/river/desert/shallow,
 /area/desert_dam/exterior/river/riverside_south)
 "jtz" = (
@@ -67549,10 +67555,14 @@
 "szl" = (
 /obj/effect/landmark/nightmare{
 <<<<<<< master
+<<<<<<< master
 	insert_tag = "clftrijent"
 =======
 	insert_tag = clftrijent
 >>>>>>> added nightmare insert tags to main maps
+=======
+	insert_tag = "clftrijent"
+>>>>>>> updated CLF spawner
 	},
 /turf/closed/wall/hangar{
 	name = "reinforced metal wall"

--- a/maps/map_files/DesertDam/Desert_Dam.dmm
+++ b/maps/map_files/DesertDam/Desert_Dam.dmm
@@ -65095,9 +65095,6 @@
 	dir = 8
 	},
 /obj/effect/blocker/toxic_water/Group_1,
-/obj/effect/landmark/nightmare{
-	insert_tag = "clftrijent"
-	},
 /turf/open/gm/river/desert/shallow,
 /area/desert_dam/exterior/river/riverside_south)
 "jtz" = (

--- a/maps/map_files/DesertDam/Desert_Dam.dmm
+++ b/maps/map_files/DesertDam/Desert_Dam.dmm
@@ -67548,7 +67548,11 @@
 /area/desert_dam/exterior/valley/valley_hydro)
 "szl" = (
 /obj/effect/landmark/nightmare{
+<<<<<<< master
 	insert_tag = "clftrijent"
+=======
+	insert_tag = clftrijent
+>>>>>>> added nightmare insert tags to main maps
 	},
 /turf/closed/wall/hangar{
 	name = "reinforced metal wall"

--- a/maps/map_files/DesertDam/Desert_Dam.dmm
+++ b/maps/map_files/DesertDam/Desert_Dam.dmm
@@ -67549,6 +67549,14 @@
 	icon_state = "cement_sunbleached4"
 	},
 /area/desert_dam/exterior/valley/valley_hydro)
+"szl" = (
+/obj/effect/landmark/nightmare{
+	insert_tag = clftrijent
+	},
+/turf/closed/wall/hangar{
+	name = "reinforced metal wall"
+	},
+/area/desert_dam/interior/dam_interior/smes_backup)
 "sDf" = (
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/prison{
@@ -93425,7 +93433,7 @@ bHm
 bHm
 bHm
 bHm
-bHm
+szl
 dCt
 naH
 ozu

--- a/maps/map_files/DesertDam/sprinkles/25.clftrijent.dmm
+++ b/maps/map_files/DesertDam/sprinkles/25.clftrijent.dmm
@@ -57,14 +57,6 @@
 	icon_state = "darkyellowcorners2"
 	},
 /area/desert_dam/interior/dam_interior/control_room)
-"bD" = (
-/obj/effect/spawner/random/attachment,
-/obj/effect/landmark/survivor_spawner/clf/generic,
-/turf/open/floor{
-	dir = 7;
-	icon_state = "warning"
-	},
-/area/desert_dam/interior/dam_interior/engine_room)
 "bJ" = (
 /turf/open/floor/prison{
 	dir = 10;
@@ -123,14 +115,6 @@
 	tag = "icon-floor (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
-"cq" = (
-/obj/effect/landmark/corpsespawner/clf,
-/obj/item/weapon/melee/twohanded/lungemine,
-/obj/effect/decal/cleanable/blood,
-/turf/open/asphalt{
-	icon_state = "tile"
-	},
-/area/desert_dam/exterior/valley/south_valley_dam)
 "cs" = (
 /obj/effect/blocker/toxic_water/Group_2,
 /turf/open/floor{
@@ -138,24 +122,30 @@
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
 "cw" = (
-/obj/effect/landmark/corpsespawner/clf,
-/obj/item/weapon/melee/katana,
-/obj/effect/decal/cleanable/blood,
-/turf/open/asphalt{
-	icon_state = "tile"
+/obj/structure/surface/rack,
+/obj/item/ammo_magazine/rifle/mar40,
+/obj/item/ammo_magazine/rifle/mar40,
+/obj/item/ammo_magazine/rifle/mar40,
+/obj/item/ammo_magazine/rifle/mar40,
+/obj/item/ammo_magazine/rifle/mar40,
+/obj/item/ammo_magazine/rifle/mar40/lmg,
+/obj/item/ammo_magazine/rifle/mar40/lmg,
+/obj/item/ammo_magazine/rifle/mar40/lmg,
+/obj/item/ammo_magazine/rifle/mar40/lmg,
+/obj/item/ammo_magazine/rifle/mar40/lmg,
+/obj/item/weapon/gun/rifle/mar40/lmg,
+/obj/item/weapon/gun/rifle/mar40{
+	pixel_y = 6
 	},
-/area/desert_dam/exterior/valley/south_valley_dam)
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/atmos_storage)
 "cz" = (
 /obj/effect/landmark/corpsespawner/engineer,
+/obj/item/weapon/melee/baseballbat/metal,
 /obj/effect/decal/cleanable/blood,
-/obj/item/weapon/gun/smg/fp9000{
-	pixel_y = 7
-	},
-/obj/item/ammo_magazine/smg/fp9000,
-/obj/item/ammo_magazine/smg/fp9000,
-/obj/item/ammo_magazine/smg/fp9000,
-/obj/item/ammo_magazine/smg/fp9000,
-/obj/item/ammo_magazine/smg/fp9000,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -170,6 +160,7 @@
 "cC" = (
 /obj/structure/window_frame/colony,
 /obj/structure/window_frame/colony,
+/obj/item/stack/rods,
 /obj/item/shard{
 	icon_state = "medium"
 	},
@@ -235,11 +226,10 @@
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
 "dq" = (
-/obj/item/stack/tile/plasteel,
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/desert_dam/exterior/valley/north_valley_dam)
+/obj/structure/window_frame/colony,
+/obj/item/stack/rods,
+/turf/open/floor/plating,
+/area/desert_dam/interior/dam_interior/smes_main)
 "du" = (
 /turf/open/desert/dirt{
 	dir = 10;
@@ -272,13 +262,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/desert_dam/interior/dam_interior/control_room)
-"dR" = (
-/obj/effect/landmark/survivor_spawner/clf/generic,
-/turf/open/floor/prison{
-	dir = 10;
-	tag = "icon-floor (SOUTHWEST)"
-	},
-/area/desert_dam/interior/dam_interior/atmos_storage)
 "dZ" = (
 /obj/structure/barricade/sandbags/wired{
 	icon_state = "sandbag_2";
@@ -289,11 +272,8 @@
 	dir = 1
 	},
 /obj/effect/landmark/corpsespawner/engineer,
+/obj/item/weapon/melee/baseballbat/metal,
 /obj/effect/decal/cleanable/blood,
-/obj/item/weapon/gun/rifle/m16{
-	pixel_x = 5;
-	pixel_y = 6
-	},
 /turf/open/floor{
 	icon_state = "neutral"
 	},
@@ -356,13 +336,8 @@
 "eA" = (
 /obj/effect/blocker/toxic_water/Group_2,
 /obj/effect/landmark/corpsespawner/engineer,
+/obj/item/weapon/melee/baseballbat/metal,
 /obj/effect/decal/cleanable/blood,
-/obj/item/weapon/gun/rifle/hunting,
-/obj/item/ammo_magazine/rifle/hunting,
-/obj/item/ammo_magazine/rifle/hunting,
-/obj/item/ammo_magazine/rifle/hunting,
-/obj/item/ammo_magazine/rifle/hunting,
-/obj/item/ammo_magazine/rifle/hunting,
 /turf/open/floor{
 	dir = 1;
 	icon_state = "warning"
@@ -396,9 +371,6 @@
 "fj" = (
 /obj/item/ammo_casing/bullet,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/ammo_box/magazine/shotgun/buckshot,
-/obj/item/ammo_box/magazine/shotgun,
-/obj/item/ammo_magazine/shotgun/incendiary,
 /turf/open/floor{
 	icon_state = "neutral"
 	},
@@ -423,11 +395,21 @@
 	},
 /area/desert_dam/interior/dam_interior/control_room)
 "fL" = (
-/obj/effect/decal/cleanable/blood/drip,
-/turf/open/asphalt{
-	icon_state = "tile"
+/obj/structure/surface/rack,
+/obj/item/weapon/gun/shotgun/pump/cmb{
+	pixel_y = -3
 	},
-/area/desert_dam/exterior/valley/south_valley_dam)
+/obj/item/weapon/gun/shotgun/pump/cmb{
+	pixel_y = 3
+	},
+/obj/item/weapon/gun/shotgun/pump/cmb{
+	pixel_y = 9
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/atmos_storage)
 "fM" = (
 /turf/closed/wall/hangar{
 	name = "reinforced metal wall"
@@ -470,14 +452,6 @@
 	icon_state = "tile"
 	},
 /area/desert_dam/exterior/valley/north_valley_dam)
-"gu" = (
-/obj/item/stack/sheet/wood,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean";
-	tag = "icon-bright_clean (SOUTHWEST)"
-	},
-/area/desert_dam/interior/dam_interior/smes_main)
 "gw" = (
 /obj/effect/decal/sand_overlay/sand1{
 	dir = 8
@@ -501,12 +475,15 @@
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 "gS" = (
-/obj/item/stack/sheet/wood,
+/obj/structure/surface/rack,
+/obj/item/ammo_magazine/shotgun/slugs,
+/obj/item/ammo_magazine/shotgun/slugs,
+/obj/item/ammo_magazine/shotgun/slugs,
 /turf/open/floor/prison{
-	dir = 1;
-	icon_state = "darkyellow2"
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
 	},
-/area/desert_dam/interior/dam_interior/smes_main)
+/area/desert_dam/interior/dam_interior/atmos_storage)
 "gU" = (
 /obj/structure/machinery/power/apc{
 	dir = 1;
@@ -536,6 +513,7 @@
 /area/desert_dam/interior/dam_interior/control_room)
 "hh" = (
 /obj/structure/window_frame/colony,
+/obj/item/stack/rods,
 /turf/open/floor/plating,
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 "hk" = (
@@ -543,31 +521,16 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
 	tag = "icon-bright_clean (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
-"hr" = (
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/item/explosive/mine/clf/active{
-	dir = 4
-	},
-/turf/open/floor{
-	icon_state = "neutral"
-	},
-/area/desert_dam/interior/dam_interior/engine_room)
 "ht" = (
+/obj/item/stack/rods,
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
-/obj/item/explosive/mine/clf/active,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -580,11 +543,16 @@
 	},
 /area/desert_dam/exterior/valley/south_valley_dam)
 "hH" = (
-/obj/item/stack/tile/plasteel,
-/turf/open/floor{
-	icon_state = "platingdmg1"
+/obj/structure/surface/rack,
+/obj/item/ammo_magazine/shotgun/buckshot,
+/obj/item/ammo_magazine/shotgun/buckshot,
+/obj/item/ammo_magazine/shotgun/buckshot,
+/obj/item/ammo_magazine/shotgun/buckshot,
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
 	},
-/area/desert_dam/interior/dam_interior/engine_east_wing)
+/area/desert_dam/interior/dam_interior/atmos_storage)
 "hJ" = (
 /obj/structure/pipes/standard/manifold/hidden/green{
 	dir = 4
@@ -612,31 +580,13 @@
 	name = "reinforced metal wall"
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
-"iD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/survivor_spawner/clf/generic,
+"iO" = (
+/obj/structure/bed,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "bright_clean";
-	tag = "icon-bright_clean (SOUTHWEST)"
+	tag = "icon-floor (SOUTHWEST)"
 	},
-/area/desert_dam/interior/dam_interior/smes_backup)
-"iO" = (
-/obj/effect/landmark/corpsespawner/engineer,
-/obj/item/tool/weldpack,
-/obj/item/tool/weldingtool{
-	pixel_y = -9;
-	pixel_x = 11
-	},
-/obj/item/clothing/glasses/welding{
-	pixel_y = 9;
-	pixel_x = -12
-	},
-/turf/open/floor{
-	dir = 8;
-	icon_state = "warning"
-	},
-/area/desert_dam/interior/dam_interior/engine_room)
+/area/desert_dam/interior/dam_interior/atmos_storage)
 "jb" = (
 /obj/structure/machinery/colony_floodlight,
 /obj/effect/decal/sand_overlay/sand1/corner1{
@@ -709,12 +659,6 @@
 /obj/effect/blocker/toxic_water/Group_2,
 /turf/open/gm/river/desert/deep,
 /area/desert_dam/exterior/river/riverside_central_south)
-"jS" = (
-/obj/effect/landmark/survivor_spawner/clf/generic,
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/desert_dam/interior/dam_interior/engine_east_wing)
 "jY" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
@@ -738,6 +682,7 @@
 /area/desert_dam/interior/dam_interior/engine_room)
 "ki" = (
 /obj/structure/window_frame/colony,
+/obj/item/stack/rods,
 /obj/item/shard{
 	icon_state = "medium"
 	},
@@ -756,7 +701,6 @@
 /obj/effect/landmark/corpsespawner/engineer,
 /obj/effect/decal/cleanable/blood,
 /obj/item/weapon/gun/smg/nailgun,
-/obj/item/clothing/accessory/storage/webbing,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -777,17 +721,9 @@
 	dir = 4
 	},
 /area/desert_dam/exterior/river/riverside_central_south)
-"kY" = (
-/obj/item/stack/tile/plasteel,
-/obj/item/explosive/mine/clf/active{
-	dir = 1
-	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/desert_dam/interior/dam_interior/engine_room)
 "lc" = (
 /obj/structure/disposalpipe/segment,
+/obj/item/stack/rods,
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
 /turf/open/floor/prison{
@@ -805,7 +741,6 @@
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 "lh" = (
-/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor{
 	dir = 5;
 	icon_state = "warning"
@@ -827,12 +762,6 @@
 	},
 /turf/open/floor/plating,
 /area/desert_dam/interior/dam_interior/smes_main)
-"lJ" = (
-/obj/item/stack/tile/plasteel,
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/desert_dam/interior/dam_interior/engine_room)
 "lX" = (
 /obj/structure/platform{
 	dir = 4
@@ -842,23 +771,15 @@
 	dir = 4
 	},
 /area/desert_dam/exterior/river/riverside_central_south)
-"lY" = (
-/obj/item/stack/sheet/wood,
-/turf/open/floor/prison{
-	icon_state = "darkyellow2"
-	},
-/area/desert_dam/interior/dam_interior/smes_backup)
 "mj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
+/obj/item/stack/rods,
 /obj/item/shard{
 	icon_state = "medium"
-	},
-/obj/item/explosive/mine/clf/active{
-	dir = 8
 	},
 /turf/open/floor/prison{
 	dir = 10;
@@ -879,18 +800,12 @@
 "mu" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
-/obj/item/explosive/mine/clf/active,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
 	tag = "icon-bright_clean (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
-"mw" = (
-/obj/effect/blocker/toxic_water/Group_2,
-/obj/item/explosive/mine/clf/active,
-/turf/open/floor/greengrid,
-/area/desert_dam/interior/dam_interior/engine_room)
 "mz" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/structure/disposalpipe/segment,
@@ -901,15 +816,6 @@
 	tag = "icon-bright_clean (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/control_room)
-"mB" = (
-/obj/effect/decal/cleanable/blood/drip,
-/obj/effect/landmark/survivor_spawner/clf/generic,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean";
-	tag = "icon-bright_clean (SOUTHWEST)"
-	},
-/area/desert_dam/interior/dam_interior/smes_main)
 "mH" = (
 /obj/structure/surface/table,
 /obj/item/device/flashlight/flare,
@@ -940,13 +846,6 @@
 /obj/effect/blocker/toxic_water/Group_2,
 /turf/open/gm/river/desert/deep,
 /area/desert_dam/exterior/river/riverside_central_north)
-"na" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/attachment,
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/desert_dam/interior/dam_interior/control_room)
 "ne" = (
 /obj/structure/platform{
 	dir = 4
@@ -955,13 +854,6 @@
 /obj/effect/blocker/toxic_water/Group_1,
 /turf/open/gm/river/desert/deep,
 /area/desert_dam/exterior/river/riverside_central_south)
-"nk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/survivor_spawner/clf/generic,
-/turf/open/floor{
-	icon_state = "platingdmg1"
-	},
-/area/desert_dam/interior/dam_interior/control_room)
 "nq" = (
 /obj/structure/platform{
 	dir = 1
@@ -971,8 +863,6 @@
 /area/desert_dam/exterior/river/riverside_central_south)
 "nr" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/stack/tile/plasteel,
-/obj/effect/spawner/random/attachment,
 /turf/open/floor/plating{
 	dir = 10;
 	icon_state = "warnplate"
@@ -1167,10 +1057,13 @@
 	icon_state = "sandbag_2"
 	},
 /obj/effect/landmark/corpsespawner/security/cmb,
+/obj/item/weapon/gun/rifle/hunting{
+	pixel_x = -5;
+	pixel_y = 7
+	},
 /obj/item/ammo_casing/bullet,
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/blood,
-/obj/item/weapon/gun/rifle/m16,
 /turf/open/floor{
 	icon_state = "neutral"
 	},
@@ -1184,15 +1077,6 @@
 	icon_state = "darkyellowcorners2"
 	},
 /area/desert_dam/interior/dam_interior/control_room)
-"qD" = (
-/obj/item/explosive/mine/clf/active{
-	dir = 4
-	},
-/obj/effect/landmark/survivor_spawner/clf/generic,
-/turf/open/floor{
-	icon_state = "neutral"
-	},
-/area/desert_dam/interior/dam_interior/engine_room)
 "qE" = (
 /turf/open/floor/prison{
 	dir = 1;
@@ -1204,17 +1088,6 @@
 	name = "reinforced metal wall"
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
-"qH" = (
-/obj/structure/pipes/standard/simple/hidden/green,
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/survivor_spawner/clf/generic,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean";
-	tag = "icon-bright_clean (SOUTHWEST)"
-	},
-/area/desert_dam/interior/dam_interior/control_room)
 "qJ" = (
 /turf/open/desert/dirt,
 /area/desert_dam/exterior/valley/north_valley_dam)
@@ -1252,16 +1125,12 @@
 /turf/open/gm/river/desert/deep,
 /area/desert_dam/exterior/river/riverside_central_south)
 "rq" = (
-/obj/structure/platform{
-	dir = 1
+/obj/structure/machinery/cm_vending/sorted/tech/tool_storage,
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
 	},
-/obj/structure/platform{
-	dir = 4
-	},
-/obj/effect/blocker/toxic_water/Group_2,
-/obj/effect/landmark/survivor_spawner/clf/generic,
-/turf/open/gm/river/desert/deep,
-/area/desert_dam/exterior/river/riverside_central_south)
+/area/desert_dam/interior/dam_interior/atmos_storage)
 "ru" = (
 /obj/structure/closet/toolcloset,
 /obj/structure/machinery/light{
@@ -1274,6 +1143,7 @@
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 "rv" = (
 /obj/structure/window_frame/colony,
+/obj/item/stack/rods,
 /obj/item/shard{
 	icon_state = "medium"
 	},
@@ -1293,6 +1163,7 @@
 /area/desert_dam/exterior/river/riverside_central_north)
 "rA" = (
 /obj/structure/window_frame/colony,
+/obj/item/stack/rods,
 /obj/item/shard{
 	icon_state = "medium"
 	},
@@ -1339,15 +1210,14 @@
 	},
 /area/desert_dam/interior/dam_interior/control_room)
 "rY" = (
-/obj/effect/blocker/toxic_water/Group_2,
-/obj/structure/barricade/metal/wired{
-	icon_state = "metal_1"
+/obj/structure/surface/rack,
+/obj/item/ammo_magazine/shotgun/incendiary,
+/obj/item/ammo_magazine/shotgun/incendiary,
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
 	},
-/obj/item/explosive/mine/clf/active{
-	dir = 1
-	},
-/turf/open/gm/river/desert/deep/covered,
-/area/desert_dam/exterior/river/riverside_central_south)
+/area/desert_dam/interior/dam_interior/atmos_storage)
 "sf" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/structure/disposalpipe/segment{
@@ -1372,6 +1242,7 @@
 "sq" = (
 /obj/effect/blocker/toxic_water/Group_2,
 /obj/structure/window_frame/colony,
+/obj/item/stack/rods,
 /obj/item/shard{
 	icon_state = "medium"
 	},
@@ -1428,13 +1299,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
 "td" = (
 /obj/structure/window_frame/colony,
+/obj/item/stack/rods,
 /obj/item/shard{
 	icon_state = "medium"
 	},
@@ -1445,19 +1316,6 @@
 	icon_state = "cement_sunbleached4"
 	},
 /area/desert_dam/exterior/valley/south_valley_dam)
-"tr" = (
-/obj/item/stack/rods,
-/obj/effect/decal/cleanable/blood/oil,
-/obj/item/stack/cable_coil/cut,
-/obj/item/explosive/mine/clf/active{
-	dir = 1
-	},
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean";
-	tag = "icon-bright_clean (SOUTHWEST)"
-	},
-/area/desert_dam/interior/dam_interior/engine_room)
 "tx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -1482,11 +1340,6 @@
 	dir = 4;
 	icon_state = "sandbag_2"
 	},
-/obj/item/explosive/mine/clf,
-/obj/item/explosive/mine/clf,
-/obj/item/explosive/mine/clf,
-/obj/item/explosive/mine/clf,
-/obj/item/explosive/mine/clf,
 /turf/open/floor{
 	icon_state = "neutral"
 	},
@@ -1515,12 +1368,33 @@
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
 "tN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/stack/tile/plasteel,
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
+/obj/structure/surface/rack,
+/obj/item/ammo_magazine/rifle/m16/ap{
+	pixel_x = -8
 	},
-/area/desert_dam/interior/dam_interior/engine_room)
+/obj/item/ammo_magazine/rifle/m16/ap{
+	pixel_x = -8
+	},
+/obj/item/ammo_magazine/rifle/m16/ap{
+	pixel_x = -8
+	},
+/obj/item/ammo_magazine/rifle/m16/ap{
+	pixel_x = -8
+	},
+/obj/item/ammo_magazine/rifle/m16/ap{
+	pixel_x = -8
+	},
+/obj/item/weapon/gun/rifle/m16,
+/obj/item/weapon/gun/rifle/m16{
+	pixel_x = 5;
+	pixel_y = 6
+	},
+/obj/item/ammo_box/magazine/M16,
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/atmos_storage)
 "tP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -1574,13 +1448,12 @@
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/smes_backup)
-"vo" = (
-/obj/effect/spawner/random/attachment,
-/turf/open/floor/prison{
-	dir = 10;
-	tag = "icon-floor (SOUTHWEST)"
+"vr" = (
+/obj/effect/landmark/survivor_spawn,
+/turf/open/floor{
+	icon_state = "neutral"
 	},
-/area/desert_dam/interior/dam_interior/engine_east_wing)
+/area/desert_dam/interior/dam_interior/engine_room)
 "vG" = (
 /obj/structure/surface/table,
 /obj/structure/machinery/cell_charger,
@@ -1650,11 +1523,8 @@
 "wY" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/corpsespawner/engineer,
+/obj/item/weapon/melee/baseballbat,
 /obj/effect/decal/cleanable/blood,
-/obj/item/weapon/gun/shotgun/pump/cmb{
-	pixel_y = 9
-	},
-/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -1686,15 +1556,6 @@
 	icon_state = "neutral"
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
-"xo" = (
-/obj/effect/blocker/toxic_water/Group_1,
-/obj/structure/barricade/metal/wired{
-	icon_state = "metal_1";
-	dir = 1
-	},
-/obj/effect/landmark/survivor_spawner/clf/generic,
-/turf/open/gm/river/desert/deep/covered,
-/area/desert_dam/exterior/river/riverside_central_north)
 "xp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade/wooden,
@@ -1752,11 +1613,6 @@
 	icon_state = "damaged3"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
-"ys" = (
-/obj/effect/landmark/corpsespawner/clf,
-/obj/item/weapon/melee/baseballbat/metal,
-/turf/open/desert/dirt,
-/area/desert_dam/exterior/valley/south_valley_dam)
 "yw" = (
 /obj/structure/barricade/wooden{
 	dir = 1
@@ -1766,12 +1622,6 @@
 	icon_state = "darkyellowcorners2"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
-"yC" = (
-/obj/item/explosive/mine/clf/active,
-/turf/open/floor{
-	icon_state = "neutral"
-	},
-/area/desert_dam/interior/dam_interior/engine_room)
 "yM" = (
 /turf/open/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached14"
@@ -1780,14 +1630,7 @@
 "yX" = (
 /obj/effect/landmark/corpsespawner/security,
 /obj/effect/decal/cleanable/blood,
-/obj/item/weapon/gun/smg/fp9000{
-	pixel_y = -8
-	},
-/obj/item/ammo_magazine/smg/fp9000,
-/obj/item/ammo_magazine/smg/fp9000,
-/obj/item/ammo_magazine/smg/fp9000,
-/obj/item/ammo_magazine/smg/fp9000,
-/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/weapon/gun/pistol/b92fs,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -1795,9 +1638,21 @@
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 "yZ" = (
-/obj/item/stack/tile/plasteel,
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
+/obj/structure/surface/rack,
+/obj/item/weapon/gun/rifle/hunting,
+/obj/item/ammo_magazine/rifle/hunting,
+/obj/item/ammo_magazine/rifle/hunting,
+/obj/item/ammo_magazine/rifle/hunting,
+/obj/item/ammo_magazine/rifle/hunting,
+/obj/item/ammo_magazine/rifle/hunting,
+/obj/item/ammo_magazine/rifle/hunting,
+/obj/item/ammo_magazine/rifle/hunting,
+/obj/item/ammo_magazine/rifle/hunting,
+/obj/item/ammo_magazine/rifle/hunting,
+/obj/item/ammo_magazine/rifle/hunting,
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
 "za" = (
@@ -1808,15 +1663,6 @@
 /obj/effect/blocker/toxic_water/Group_2,
 /turf/open/gm/river/desert/deep,
 /area/desert_dam/exterior/river/riverside_central_north)
-"zc" = (
-/obj/item/explosive/mine/clf/active{
-	dir = 4
-	},
-/turf/open/floor/prison{
-	dir = 10;
-	tag = "icon-floor (SOUTHWEST)"
-	},
-/area/desert_dam/interior/dam_interior/engine_east_wing)
 "zd" = (
 /obj/structure/platform{
 	dir = 1
@@ -1840,6 +1686,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
+/obj/item/stack/rods,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -1854,10 +1701,8 @@
 /area/desert_dam/interior/dam_interior/engine_room)
 "zR" = (
 /obj/effect/decal/cleanable/blood/oil,
+/obj/item/stack/rods,
 /obj/item/stack/cable_coil/cut,
-/obj/item/explosive/mine/clf/active{
-	dir = 1
-	},
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -1917,11 +1762,14 @@
 /turf/open/floor/plating,
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 "AV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/attachment,
-/turf/open/floor/greengrid,
-/area/desert_dam/interior/dam_interior/smes_main)
+/obj/structure/surface/rack,
+/obj/item/clothing/accessory/storage/webbing,
+/obj/item/clothing/accessory/storage/webbing,
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/atmos_storage)
 "Bi" = (
 /obj/structure/platform{
 	dir = 4
@@ -1989,17 +1837,7 @@
 	},
 /area/desert_dam/interior/dam_interior/smes_main)
 "Ce" = (
-/obj/item/explosive/mine/clf/active{
-	dir = 4
-	},
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean";
-	tag = "icon-bright_clean (SOUTHWEST)"
-	},
-/area/desert_dam/interior/dam_interior/engine_east_wing)
-"Cu" = (
-/obj/item/stack/tile/plasteel,
+/obj/structure/machinery/cm_vending/sorted/tech/electronics_storage,
 /turf/open/floor/prison{
 	dir = 10;
 	tag = "icon-floor (SOUTHWEST)"
@@ -2029,7 +1867,9 @@
 	},
 /area/desert_dam/interior/dam_interior/control_room)
 "CS" = (
-/obj/item/stack/sheet/wood,
+/obj/structure/barricade/wooden{
+	dir = 8
+	},
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "darkyellowcorners2"
@@ -2143,12 +1983,6 @@
 	icon_state = "tile"
 	},
 /area/desert_dam/exterior/valley/north_valley_dam)
-"Ev" = (
-/obj/effect/landmark/survivor_spawner/clf/generic,
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/desert_dam/interior/dam_interior/atmos_storage)
 "Ex" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -2169,6 +2003,7 @@
 "ED" = (
 /obj/effect/blocker/toxic_water/Group_1,
 /obj/structure/window_frame/colony,
+/obj/item/stack/rods,
 /obj/item/shard{
 	icon_state = "medium"
 	},
@@ -2248,10 +2083,19 @@
 	},
 /area/desert_dam/interior/dam_interior/control_room)
 "FO" = (
-/obj/effect/landmark/survivor_spawner/clf/generic,
-/turf/open/floor{
-	dir = 1;
-	icon_state = "warning"
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/item/stack/rods,
+/obj/item/stack/cable_coil/cut,
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
 "FR" = (
@@ -2262,13 +2106,6 @@
 /obj/effect/blocker/toxic_water/Group_1,
 /turf/open/gm/river/desert/deep,
 /area/desert_dam/exterior/river/riverside_central_north)
-"FY" = (
-/obj/item/stack/tile/plasteel,
-/turf/open/floor{
-	dir = 8;
-	icon_state = "damaged3"
-	},
-/area/desert_dam/interior/dam_interior/atmos_storage)
 "Gb" = (
 /obj/structure/machinery/power/smes/buildable{
 	capacity = 1e+006;
@@ -2288,8 +2125,26 @@
 /turf/open/gm/river/desert/deep,
 /area/desert_dam/exterior/river/riverside_central_south)
 "Go" = (
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
+/obj/structure/surface/rack,
+/obj/item/weapon/gun/smg/fp9000{
+	pixel_y = 7
+	},
+/obj/item/weapon/gun/smg/fp9000{
+	pixel_y = -8
+	},
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
 "Gr" = (
@@ -2312,12 +2167,6 @@
 	tag = "icon-bright_clean (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
-"Gz" = (
-/obj/effect/spawner/random/attachment,
-/turf/open/floor{
-	icon_state = "neutral"
-	},
-/area/desert_dam/interior/dam_interior/engine_room)
 "GM" = (
 /obj/structure/barricade/metal/wired{
 	icon_state = "metal_1";
@@ -2336,9 +2185,10 @@
 	},
 /area/desert_dam/interior/dam_interior/smes_main)
 "GW" = (
-/obj/effect/spawner/random/attachment,
-/turf/open/floor{
-	icon_state = "platingdmg1"
+/obj/structure/machinery/cm_vending/sorted/medical/no_access,
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
 "Hb" = (
@@ -2387,17 +2237,12 @@
 	tag = "icon-bright_clean (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
-"Hw" = (
-/obj/item/stack/tile/plasteel,
-/turf/open/floor{
-	icon_state = "platingdmg1"
-	},
-/area/desert_dam/interior/dam_interior/atmos_storage)
 "HB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
+/obj/item/stack/rods,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -2434,14 +2279,6 @@
 	tag = "icon-darkyellow2 (NORTH)"
 	},
 /area/desert_dam/interior/dam_interior/control_room)
-"IB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/stack/sheet/wood,
-/obj/item/stack/sheet/wood,
-/turf/open/floor/prison{
-	icon_state = "darkyellow2"
-	},
-/area/desert_dam/interior/dam_interior/smes_backup)
 "ID" = (
 /obj/structure/platform{
 	dir = 4
@@ -2474,9 +2311,7 @@
 	},
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
-/obj/item/explosive/mine/clf/active{
-	dir = 8
-	},
+/obj/item/stack/rods,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -2493,17 +2328,6 @@
 	tag = "icon-bright_clean (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/smes_main)
-"Kl" = (
-/obj/structure/barricade/metal/wired{
-	icon_state = "metal_1";
-	dir = 8
-	},
-/obj/effect/landmark/survivor_spawner/clf/generic,
-/turf/open/floor/prison{
-	dir = 10;
-	tag = "icon-floor (SOUTHWEST)"
-	},
-/area/desert_dam/interior/dam_interior/engine_room)
 "Kv" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
@@ -2534,7 +2358,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor{
 	icon_state = "neutral"
 	},
@@ -2551,8 +2374,10 @@
 	},
 /area/desert_dam/exterior/valley/north_valley_dam)
 "KY" = (
+/obj/structure/barricade/wooden{
+	dir = 1
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/item/stack/sheet/wood,
 /turf/open/floor/plating{
 	dir = 8;
 	icon_state = "warnplate"
@@ -2640,15 +2465,8 @@
 /obj/item/shard{
 	icon_state = "medium"
 	},
+/obj/item/stack/rods,
 /turf/open/floor/plating,
-/area/desert_dam/interior/dam_interior/engine_room)
-"Ml" = (
-/obj/item/explosive/mine/clf/active{
-	dir = 1
-	},
-/turf/open/floor{
-	icon_state = "neutral"
-	},
 /area/desert_dam/interior/dam_interior/engine_room)
 "Mm" = (
 /obj/structure/machinery/power/smes/buildable{
@@ -2671,6 +2489,7 @@
 /area/desert_dam/interior/dam_interior/engine_room)
 "Mw" = (
 /obj/structure/window_frame/colony,
+/obj/item/stack/rods,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -2682,14 +2501,8 @@
 	icon_state = "warnplate"
 	},
 /area/desert_dam/interior/dam_interior/smes_backup)
-"MH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/survivor_spawner/clf/generic,
-/turf/open/floor/greengrid,
-/area/desert_dam/interior/dam_interior/smes_main)
 "MQ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -2729,14 +2542,28 @@
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
 "Nj" = (
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
+/obj/structure/surface/table/reinforced/prison,
+/obj/effect/spawner/random/attachment,
+/obj/effect/spawner/random/attachment,
+/obj/effect/spawner/random/attachment,
+/obj/effect/spawner/random/attachment,
+/obj/effect/spawner/random/attachment,
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
 	},
-/area/desert_dam/exterior/valley/north_valley_dam)
+/area/desert_dam/interior/dam_interior/atmos_storage)
 "Nx" = (
-/turf/open/floor{
-	dir = 8;
-	icon_state = "damaged3"
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/clothing/glasses/welding,
+/obj/item/stack/sheet/metal/large_stack,
+/obj/item/stack/sheet/plasteel/large_stack,
+/obj/item/weapon/gun/smg/nailgun,
+/obj/item/ammo_magazine/smg/nailgun,
+/obj/item/ammo_magazine/smg/nailgun,
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
 "Nz" = (
@@ -2836,34 +2663,14 @@
 	icon_state = "platingdmg1"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
-"OS" = (
-/obj/effect/landmark/corpsespawner/clf,
-/obj/item/weapon/gun/smg/fp9000{
-	pixel_y = 7
-	},
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor{
-	icon_state = "platingdmg1"
-	},
-/area/desert_dam/exterior/valley/north_valley_dam)
 "OT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/ammo_casing/bullet,
-/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/prison{
 	dir = 10;
 	tag = "icon-floor (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/control_room)
-"Pk" = (
-/obj/effect/landmark/corpsespawner/clf,
-/obj/item/weapon/melee/twohanded/lungemine,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean";
-	tag = "icon-bright_clean (SOUTHWEST)"
-	},
-/area/desert_dam/interior/dam_interior/engine_east_wing)
 "Pr" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -2925,7 +2732,6 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -2982,26 +2788,6 @@
 	icon_state = "tile"
 	},
 /area/desert_dam/exterior/valley/south_valley_dam)
-"QK" = (
-/obj/item/clothing/accessory/storage/webbing,
-/turf/open/floor{
-	dir = 7;
-	icon_state = "warning"
-	},
-/area/desert_dam/interior/dam_interior/engine_room)
-"QM" = (
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/blocker/toxic_water/Group_2,
-/obj/effect/landmark/survivor_spawner/clf/generic,
-/turf/open/floor{
-	icon_state = "neutral"
-	},
-/area/desert_dam/interior/dam_interior/engine_room)
 "Rh" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
@@ -3019,10 +2805,8 @@
 	dir = 8
 	},
 /obj/effect/landmark/corpsespawner/security,
+/obj/item/weapon/gun/pistol/b92fs,
 /obj/effect/decal/cleanable/blood,
-/obj/item/weapon/gun/shotgun/pump/cmb{
-	pixel_y = 3
-	},
 /turf/open/floor/prison{
 	dir = 8;
 	icon_state = "darkyellow2"
@@ -3094,7 +2878,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/stack/tile/plasteel,
 /turf/open/floor{
 	dir = 8;
 	icon_state = "damaged3"
@@ -3154,8 +2937,9 @@
 	},
 /area/desert_dam/interior/dam_interior/control_room)
 "Te" = (
-/obj/effect/decal/cleanable/blood/oil,
-/obj/effect/decal/cleanable/ash,
+/obj/structure/machinery/door/airlock/almayer/maint{
+	name = "\improper Atmospheric Storage"
+	},
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -3165,6 +2949,7 @@
 "Th" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/stack/rods,
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
 /turf/open/floor/prison{
@@ -3199,7 +2984,6 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -3217,10 +3001,8 @@
 /area/desert_dam/interior/dam_interior/engine_west_wing)
 "TN" = (
 /obj/effect/decal/cleanable/blood/oil,
+/obj/item/stack/rods,
 /obj/item/stack/cable_coil/cut,
-/obj/item/explosive/mine/clf/active{
-	dir = 1
-	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -3240,10 +3022,13 @@
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
 "Uc" = (
-/obj/effect/landmark/survivor_spawner/clf/generic,
-/turf/open/floor{
-	dir = 8;
-	icon_state = "warning"
+/obj/item/stack/rods,
+/obj/item/stack/cable_coil/cut,
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
 "Um" = (
@@ -3264,13 +3049,6 @@
 	tag = "icon-floor (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/control_room)
-"Uw" = (
-/obj/effect/landmark/survivor_spawner/clf/generic,
-/turf/open/floor/prison{
-	dir = 10;
-	tag = "icon-floor (SOUTHWEST)"
-	},
-/area/desert_dam/interior/dam_interior/engine_east_wing)
 "Uy" = (
 /obj/structure/platform{
 	dir = 1
@@ -3289,16 +3067,8 @@
 /area/desert_dam/interior/dam_interior/engine_room)
 "UI" = (
 /obj/effect/landmark/corpsespawner/engineer,
+/obj/item/weapon/gun/pistol/m4a3,
 /obj/effect/decal/cleanable/blood,
-/obj/item/weapon/gun/rifle/mar40{
-	pixel_y = 6
-	},
-/obj/item/ammo_magazine/rifle/mar40/lmg,
-/obj/item/ammo_magazine/rifle/mar40/lmg,
-/obj/item/ammo_magazine/rifle/mar40/lmg,
-/obj/item/ammo_magazine/rifle/mar40/lmg,
-/obj/item/ammo_magazine/rifle/mar40/lmg,
-/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -3306,18 +3076,14 @@
 	},
 /area/desert_dam/interior/dam_interior/smes_backup)
 "UJ" = (
-/turf/open/floor{
-	icon_state = "platingdmg1"
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/storage/firstaid/regular,
+/obj/item/storage/firstaid/surgical,
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
-"UL" = (
-/obj/structure/platform{
-	dir = 1
-	},
-/obj/effect/blocker/toxic_water/Group_1,
-/obj/effect/landmark/survivor_spawner/clf/generic,
-/turf/open/gm/river/desert/deep,
-/area/desert_dam/exterior/river/riverside_central_south)
 "UR" = (
 /obj/structure/barricade/plasteel/wired{
 	icon_state = "plasteel_3";
@@ -3356,7 +3122,6 @@
 /area/desert_dam/interior/dam_interior/engine_room)
 "Vp" = (
 /obj/structure/bed/stool,
-/obj/item/clothing/accessory/storage/webbing,
 /turf/open/floor/prison{
 	dir = 10;
 	tag = "icon-floor (SOUTHWEST)"
@@ -3377,12 +3142,6 @@
 	icon_state = "darkyellowcorners2"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
-"VF" = (
-/obj/item/stack/tile/plasteel,
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/desert_dam/interior/dam_interior/control_room)
 "VG" = (
 /obj/structure/machinery/light{
 	dir = 4
@@ -3448,9 +3207,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/corpsespawner/engineer,
-/obj/item/weapon/gun/shotgun/pump/cmb{
-	pixel_y = 9
-	},
+/obj/item/weapon/melee/baseballbat,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -3510,14 +3267,6 @@
 	tag = "icon-floor (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
-"Xu" = (
-/obj/effect/landmark/survivor_spawner/clf/generic,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean";
-	tag = "icon-bright_clean (SOUTHWEST)"
-	},
-/area/desert_dam/interior/dam_interior/engine_east_wing)
 "Xy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -3534,12 +3283,6 @@
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
-"XF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/survivor_spawner/clf/generic,
-/turf/open/floor/greengrid,
-/area/desert_dam/interior/dam_interior/smes_main)
 "XI" = (
 /obj/structure/surface/table,
 /obj/item/reagent_container/food/drinks/cans/thirteenloko,
@@ -3548,13 +3291,6 @@
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
-"XO" = (
-/obj/effect/landmark/survivor_spawner/clf/generic,
-/turf/open/floor/prison{
-	dir = 10;
-	tag = "icon-floor (SOUTHWEST)"
-	},
-/area/desert_dam/interior/dam_interior/engine_room)
 "XS" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
@@ -3563,6 +3299,7 @@
 	dir = 4
 	},
 /obj/item/stack/cable_coil/cut,
+/obj/item/stack/rods,
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/prison{
 	dir = 10;
@@ -3590,6 +3327,7 @@
 /area/desert_dam/interior/dam_interior/smes_main)
 "Yh" = (
 /obj/item/stack/cable_coil/cut,
+/obj/item/stack/rods,
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/prison{
 	dir = 10;
@@ -3614,18 +3352,19 @@
 	},
 /turf/open/floor/plating,
 /area/desert_dam/interior/dam_interior/engine_room)
-"Yr" = (
-/obj/effect/landmark/survivor_spawner/clf/generic,
-/turf/open/floor{
-	icon_state = "neutral"
-	},
-/area/desert_dam/interior/dam_interior/engine_room)
 "Yt" = (
 /obj/effect/decal/sand_overlay/sand1,
 /turf/open/asphalt{
 	icon_state = "tile"
 	},
 /area/desert_dam/exterior/valley/north_valley_dam)
+"YO" = (
+/obj/effect/landmark/survivor_spawn,
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
 "YY" = (
 /obj/item/stack/sheet/wood,
 /turf/open/floor/prison{
@@ -3653,7 +3392,6 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/item/stack/tile/plasteel,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -3668,14 +3406,7 @@
 	},
 /obj/effect/landmark/corpsespawner/security,
 /obj/effect/decal/cleanable/blood,
-/obj/item/weapon/gun/rifle/mar40{
-	pixel_y = 6
-	},
-/obj/item/ammo_magazine/rifle/mar40/lmg,
-/obj/item/ammo_magazine/rifle/mar40/lmg,
-/obj/item/ammo_magazine/rifle/mar40/lmg,
-/obj/item/ammo_magazine/rifle/mar40/lmg,
-/obj/item/ammo_magazine/rifle/mar40/lmg,
+/obj/item/weapon/gun/pistol/b92fs,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -3711,33 +3442,20 @@
 	tag = "icon-bright_clean (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
-"ZO" = (
-/obj/item/clothing/accessory/storage/webbing,
-/turf/open/floor/greengrid,
-/area/desert_dam/interior/dam_interior/smes_main)
-"ZT" = (
-/obj/item/explosive/mine/clf/active{
+"ZV" = (
+/obj/structure/barricade/plasteel/wired{
 	dir = 8
 	},
-/turf/open/floor{
-	dir = 4;
-	icon_state = "warning"
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
 	},
-/area/desert_dam/interior/dam_interior/engine_room)
-"ZV" = (
-/obj/effect/blocker/toxic_water/Group_2,
-/obj/item/ammo_box/magazine/M16,
-/turf/open/floor{
-	icon_state = "neutral"
-	},
-/area/desert_dam/interior/dam_interior/engine_room)
+/area/desert_dam/interior/dam_interior/atmos_storage)
 "ZW" = (
+/obj/item/stack/rods,
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
 /obj/effect/decal/cleanable/blood/drip,
-/obj/item/explosive/mine/clf/active{
-	dir = 1
-	},
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -3809,7 +3527,7 @@ ET
 ET
 zi
 mz
-qH
+mz
 Sx
 mz
 fJ
@@ -3825,7 +3543,7 @@ ki
 "}
 (4,1,1) = {"
 rv
-gS
+Fr
 Ro
 cR
 cR
@@ -3846,7 +3564,7 @@ CZ
 Zx
 MF
 fS
-lY
+Im
 ki
 "}
 (5,1,1) = {"
@@ -3872,14 +3590,14 @@ RX
 oh
 Vb
 Mm
-IB
+xp
 ki
 "}
 (6,1,1) = {"
 rv
 Fr
 Ro
-MH
+TD
 SJ
 lD
 SJ
@@ -3895,7 +3613,7 @@ DW
 qu
 ki
 Xe
-iD
+Qe
 sk
 Qe
 xp
@@ -3906,17 +3624,17 @@ rv
 Fr
 Ro
 Xy
-AV
-ZO
+Fw
 cR
-XF
-gu
+cR
+Fw
+XU
 rv
 CO
 Td
 Xd
 hb
-nk
+hb
 ak
 pA
 ki
@@ -3934,15 +3652,15 @@ PB
 bJ
 Er
 Ee
-mB
+Ee
 Kd
 XU
 rv
 Iy
 EK
 Td
-VF
-na
+dQ
+NP
 BL
 vG
 cC
@@ -3982,18 +3700,18 @@ Hp
 (10,1,1) = {"
 fM
 sG
-rv
-rv
+dq
+dq
 sG
 fM
 rv
 pR
 rv
 dc
-Mh
-Mh
-Mh
-Mh
+Yq
+Yq
+Yq
+Yq
 Yh
 XS
 Mh
@@ -4018,7 +3736,7 @@ xg
 St
 xg
 xg
-Kl
+xg
 xg
 PS
 Ws
@@ -4027,7 +3745,7 @@ St
 Xf
 wU
 Oj
-ys
+Oj
 Oj
 fe
 "}
@@ -4038,18 +3756,18 @@ LD
 LD
 LD
 dc
-XO
+Xf
 KT
-Uc
 Eh
 Eh
-iO
 Eh
 Eh
-lJ
+Eh
+Eh
+ek
 tc
 sC
-kY
+ek
 Xf
 dc
 Rz
@@ -4064,7 +3782,7 @@ uM
 yh
 oq
 ED
-xo
+TO
 zg
 kJ
 fB
@@ -4100,7 +3818,7 @@ PL
 kt
 am
 da
-UL
+Wj
 tU
 NZ
 ED
@@ -4143,17 +3861,17 @@ eb
 eb
 dc
 Nz
-FO
-Hs
-yC
+zg
 Hs
 Hs
 Hs
 Hs
 Hs
-hr
 Hs
-bD
+Hs
+Ng
+Hs
+QD
 Dp
 dc
 QJ
@@ -4172,7 +3890,7 @@ NT
 mn
 Hs
 Hs
-Yr
+vr
 Hs
 Hs
 wU
@@ -4183,9 +3901,9 @@ QD
 LN
 ht
 QJ
-cq
-fL
-fL
+QJ
+QJ
+QJ
 "}
 (18,1,1) = {"
 eb
@@ -4250,15 +3968,15 @@ PD
 eA
 mq
 mq
-mw
 mq
-ZV
+mq
+cs
 es
 ia
 RK
 nq
 rp
-rY
+UX
 sq
 es
 nq
@@ -4292,9 +4010,9 @@ ez
 ez
 "}
 (22,1,1) = {"
-Nj
-Nj
-Nj
+eb
+eb
+eb
 eb
 eb
 dc
@@ -4318,12 +4036,12 @@ QJ
 QJ
 "}
 (23,1,1) = {"
-Nj
-Nj
-dq
-Nj
 eb
-tr
+eb
+eb
+eb
+eb
+ht
 UR
 Hs
 Hs
@@ -4334,33 +4052,33 @@ Hs
 wU
 Hs
 Ng
-Yr
-QK
+Hs
+QD
 LN
 ht
 QJ
 QJ
-cw
-fL
+QJ
+QJ
 "}
 (24,1,1) = {"
-dq
-OS
-Nj
-Nj
-Nj
+eb
+eb
+eb
+eb
+eb
 dc
 Nz
-FO
-qD
+zg
+Hs
 ep
 ek
-tN
+MQ
 Hs
-Yr
+Hs
 Hs
 Ng
-Ml
+Hs
 QD
 Dp
 dc
@@ -4382,7 +4100,7 @@ Tm
 Zh
 Tm
 gA
-Gz
+Hs
 es
 cs
 Kv
@@ -4437,8 +4155,8 @@ gA
 Hs
 es
 cs
-QM
-rq
+Kv
+Gc
 BN
 UX
 Vm
@@ -4460,13 +4178,13 @@ Bt
 Bt
 Bt
 Bt
-ZT
+Bt
 Bt
 Hs
 Ng
 Bt
 TR
-XO
+Xf
 dc
 py
 Ep
@@ -4513,10 +4231,10 @@ dc
 Yq
 Yq
 dc
-Mh
-Yh
-XS
-Mh
+Yq
+Uc
+FO
+Yq
 dc
 wU
 wU
@@ -4540,7 +4258,7 @@ lf
 Hm
 Hm
 Og
-Xu
+De
 nY
 DH
 gF
@@ -4558,9 +4276,8 @@ hh
 yw
 En
 Tz
-Uw
 Tz
->>>>>>> reimported backup
+Tz
 Tz
 Tz
 Tz
@@ -4589,16 +4306,13 @@ De
 De
 De
 De
-Pk
 De
-<<<<<<< master
-Pk
-=======
+De
 De
 nz
 yX
 nY
-Xu
+De
 De
 Ht
 mu
@@ -4611,7 +4325,7 @@ ge
 KW
 nw
 TN
-jS
+VK
 VK
 NY
 Zw
@@ -4638,18 +4352,18 @@ gr
 gw
 Mw
 fT
-hH
-hH
+ph
+ph
 OR
-Uw
-vo
+YO
+Tz
 Tz
 hk
 Lr
 EH
 oj
 wA
-Ce
+De
 De
 VG
 oW
@@ -4695,16 +4409,16 @@ rG
 rG
 pe
 Vp
-zc
+Tz
 De
 Gu
 oY
 rG
+Ce
+ZV
+ZV
 cn
-UJ
-cn
-GW
-cn
+fL
 qG
 Oj
 fe
@@ -4722,15 +4436,15 @@ rG
 od
 tJ
 Tz
-Xu
+De
 Gu
 oY
 rG
-UJ
-FY
-UJ
-dR
-Nx
+rq
+cn
+cn
+cn
+cw
 qG
 Oj
 fe
@@ -4752,10 +4466,10 @@ De
 Gu
 wH
 rG
+iO
 cn
-UJ
-FY
-Go
+cn
+cn
 yZ
 qG
 Oj
@@ -4780,9 +4494,9 @@ wH
 rG
 UJ
 cn
-Go
-Go
-UJ
+cn
+cn
+tN
 qG
 du
 fe
@@ -4804,9 +4518,9 @@ rG
 ee
 rG
 rG
+GW
 cn
-Ev
-UJ
+cn
 cn
 Go
 qG
@@ -4831,10 +4545,10 @@ tx
 wL
 rG
 cn
-Hw
-Cu
-UJ
 cn
+cn
+cn
+gS
 qG
 wL
 wL
@@ -4857,10 +4571,10 @@ tx
 wL
 rG
 Nx
-Go
-UJ
-Go
-cn
+AV
+Nj
+rY
+hH
 qG
 wL
 wL

--- a/maps/map_files/DesertDam/sprinkles/25.clftrijent.dmm
+++ b/maps/map_files/DesertDam/sprinkles/25.clftrijent.dmm
@@ -65,9 +65,13 @@
 =======
 "bD" = (
 /obj/effect/spawner/random/attachment,
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 >>>>>>> updated all maps to have CLF Mines and corpses
+=======
+/obj/effect/landmark/survivor_spawner/clf/generic,
+>>>>>>> Updated CLF spawner
 /turf/open/floor{
 	dir = 7;
 	icon_state = "warning"
@@ -358,6 +362,9 @@
 	},
 /area/desert_dam/interior/dam_interior/control_room)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> Updated CLF spawner
 "dR" = (
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/prison{
@@ -365,8 +372,11 @@
 	tag = "icon-floor (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> Updated CLF spawner
 "dZ" = (
 /obj/structure/barricade/sandbags/wired{
 	icon_state = "sandbag_2";
@@ -731,9 +741,13 @@
 	icon_state = "pipe-c"
 	},
 <<<<<<< master
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
 =======
 >>>>>>> reimported backup
+=======
+/obj/effect/landmark/survivor_spawner/clf/generic,
+>>>>>>> Updated CLF spawner
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -840,6 +854,9 @@
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> Updated CLF spawner
 "iD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/survivor_spawner/clf/generic,
@@ -849,6 +866,7 @@
 	tag = "icon-bright_clean (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/smes_backup)
+<<<<<<< master
 "iO" = (
 /obj/effect/landmark/corpsespawner/engineer,
 /obj/item/tool/weldpack,
@@ -866,6 +884,8 @@
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
 =======
+=======
+>>>>>>> Updated CLF spawner
 "iO" = (
 /obj/effect/landmark/corpsespawner/engineer,
 /obj/item/tool/weldpack,
@@ -960,14 +980,20 @@
 /turf/open/gm/river/desert/deep,
 /area/desert_dam/exterior/river/riverside_central_south)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> Updated CLF spawner
 "jS" = (
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> Updated CLF spawner
 "jY" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
@@ -1088,6 +1114,7 @@
 "lh" = (
 <<<<<<< master
 <<<<<<< master
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
 =======
 >>>>>>> reimported backup
@@ -1095,6 +1122,9 @@
 /obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 >>>>>>> updated all maps to have CLF Mines and corpses
+=======
+/obj/effect/landmark/survivor_spawner/clf/generic,
+>>>>>>> Updated CLF spawner
 /turf/open/floor{
 	dir = 5;
 	icon_state = "warning"
@@ -1241,6 +1271,9 @@
 	},
 /area/desert_dam/interior/dam_interior/control_room)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> Updated CLF spawner
 "mB" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/landmark/survivor_spawner/clf/generic,
@@ -1250,8 +1283,11 @@
 	tag = "icon-bright_clean (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/smes_main)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> Updated CLF spawner
 "mH" = (
 /obj/structure/surface/table,
 /obj/item/device/flashlight/flare,
@@ -1314,9 +1350,13 @@
 =======
 "nk" = (
 /obj/effect/decal/cleanable/dirt,
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 >>>>>>> updated all maps to have CLF Mines and corpses
+=======
+/obj/effect/landmark/survivor_spawner/clf/generic,
+>>>>>>> Updated CLF spawner
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
@@ -1426,8 +1466,6 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -1584,9 +1622,13 @@
 	dir = 4
 	},
 <<<<<<< master
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
 =======
 >>>>>>> updated all maps to have CLF Mines and corpses
+=======
+/obj/effect/landmark/survivor_spawner/clf/generic,
+>>>>>>> Updated CLF spawner
 /turf/open/floor{
 	icon_state = "neutral"
 	},
@@ -1624,14 +1666,21 @@
 >>>>>>> reimported backup
 =======
 "qH" = (
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/structure/pipes/standard/simple/hidden/green,
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/prison{
 	dir = 10;
-	tag = "icon-floor (SOUTHWEST)"
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
 	},
+<<<<<<< master
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 >>>>>>> updated all maps to have CLF Mines and corpses
+=======
+/area/desert_dam/interior/dam_interior/control_room)
+>>>>>>> Updated CLF spawner
 "qJ" = (
 /turf/open/desert/dirt,
 /area/desert_dam/exterior/valley/north_valley_dam)
@@ -1671,6 +1720,7 @@
 "rq" = (
 <<<<<<< master
 <<<<<<< master
+<<<<<<< master
 /obj/structure/platform{
 	dir = 1
 	},
@@ -1699,6 +1749,18 @@
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
 >>>>>>> updated all maps to have CLF Mines and corpses
+=======
+/obj/structure/platform{
+	dir = 1
+	},
+/obj/structure/platform{
+	dir = 4
+	},
+/obj/effect/blocker/toxic_water/Group_2,
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/gm/river/desert/deep,
+/area/desert_dam/exterior/river/riverside_central_south)
+>>>>>>> Updated CLF spawner
 "ru" = (
 /obj/structure/closet/toolcloset,
 /obj/structure/machinery/light{
@@ -1837,8 +1899,6 @@
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 "sk" = (
 /obj/item/ammo_casing/bullet,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -1912,9 +1972,13 @@
 	dir = 4
 	},
 <<<<<<< master
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
 =======
 >>>>>>> reimported backup
+=======
+/obj/effect/landmark/survivor_spawner/clf/generic,
+>>>>>>> Updated CLF spawner
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
@@ -2233,7 +2297,11 @@
 /obj/item/weapon/gun/shotgun/pump/cmb{
 	pixel_y = 9
 	},
+<<<<<<< master
 >>>>>>> updated all maps to have CLF Mines and corpses
+=======
+/obj/effect/landmark/survivor_spawner/clf/generic,
+>>>>>>> Updated CLF spawner
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -2266,6 +2334,9 @@
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> Updated CLF spawner
 "xo" = (
 /obj/effect/blocker/toxic_water/Group_1,
 /obj/structure/barricade/metal/wired{
@@ -2275,8 +2346,11 @@
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/gm/river/desert/deep/covered,
 /area/desert_dam/exterior/river/riverside_central_north)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> Updated CLF spawner
 "xp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade/wooden,
@@ -2600,8 +2674,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/attachment,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor/greengrid,
 /area/desert_dam/interior/dam_interior/smes_main)
 >>>>>>> updated all maps to have CLF Mines and corpses
@@ -2847,14 +2919,20 @@
 	},
 /area/desert_dam/exterior/valley/north_valley_dam)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> Updated CLF spawner
 "Ev" = (
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> Updated CLF spawner
 "Ex" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -2963,6 +3041,7 @@
 "FO" = (
 <<<<<<< master
 <<<<<<< master
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor{
 	dir = 1;
@@ -2985,6 +3064,9 @@
 =======
 /obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+=======
+/obj/effect/landmark/survivor_spawner/clf/generic,
+>>>>>>> Updated CLF spawner
 /turf/open/floor{
 	dir = 1;
 	icon_state = "warning"
@@ -3325,6 +3407,9 @@
 	},
 /area/desert_dam/interior/dam_interior/smes_main)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> Updated CLF spawner
 "Kl" = (
 /obj/structure/barricade/metal/wired{
 	icon_state = "metal_1";
@@ -3336,8 +3421,11 @@
 	tag = "icon-floor (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> Updated CLF spawner
 "Kv" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
@@ -3369,9 +3457,13 @@
 	dir = 4
 	},
 <<<<<<< master
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
 =======
 >>>>>>> reimported backup
+=======
+/obj/effect/landmark/survivor_spawner/clf/generic,
+>>>>>>> Updated CLF spawner
 /turf/open/floor{
 	icon_state = "neutral"
 	},
@@ -3558,11 +3650,15 @@
 	},
 /area/desert_dam/interior/dam_interior/smes_backup)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> Updated CLF spawner
 "MH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/greengrid,
 /area/desert_dam/interior/dam_interior/smes_main)
+<<<<<<< master
 "MQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/survivor_spawner/clf/generic,
@@ -3570,6 +3666,11 @@
 "MQ" = (
 /obj/effect/decal/cleanable/dirt,
 >>>>>>> reimported backup
+=======
+"MQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/survivor_spawner/clf/generic,
+>>>>>>> Updated CLF spawner
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -3770,11 +3871,14 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/ammo_casing/bullet,
 /obj/effect/landmark/survivor_spawner/clf/generic,
+<<<<<<< master
 =======
 "OT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/ammo_casing/bullet,
 >>>>>>> reimported backup
+=======
+>>>>>>> Updated CLF spawner
 /turf/open/floor/prison{
 	dir = 10;
 	tag = "icon-floor (SOUTHWEST)"
@@ -3860,9 +3964,13 @@
 	icon_state = "pipe-c"
 	},
 <<<<<<< master
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
 =======
 >>>>>>> reimported backup
+=======
+/obj/effect/landmark/survivor_spawner/clf/generic,
+>>>>>>> Updated CLF spawner
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -3931,6 +4039,9 @@
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> Updated CLF spawner
 "QM" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
@@ -3944,10 +4055,13 @@
 	icon_state = "neutral"
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
 =======
 >>>>>>> updated all maps to have CLF Mines and corpses
+=======
+>>>>>>> Updated CLF spawner
 "Rh" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
@@ -4088,8 +4202,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -4185,9 +4297,13 @@
 	},
 /obj/structure/disposalpipe/segment,
 <<<<<<< master
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
 =======
 >>>>>>> reimported backup
+=======
+/obj/effect/landmark/survivor_spawner/clf/generic,
+>>>>>>> Updated CLF spawner
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -4242,6 +4358,7 @@
 "Uc" = (
 <<<<<<< master
 <<<<<<< master
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor{
 	dir = 8;
@@ -4258,6 +4375,9 @@
 =======
 /obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+=======
+/obj/effect/landmark/survivor_spawner/clf/generic,
+>>>>>>> Updated CLF spawner
 /turf/open/floor{
 	dir = 8;
 	icon_state = "warning"
@@ -4283,6 +4403,9 @@
 	},
 /area/desert_dam/interior/dam_interior/control_room)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> Updated CLF spawner
 "Uw" = (
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/prison{
@@ -4290,8 +4413,11 @@
 	tag = "icon-floor (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> Updated CLF spawner
 "Uy" = (
 /obj/structure/platform{
 	dir = 1
@@ -4322,6 +4448,7 @@
 /obj/item/ammo_magazine/rifle/mar40/lmg,
 /obj/item/ammo_magazine/rifle/mar40/lmg,
 /obj/effect/landmark/survivor_spawner/clf/generic,
+<<<<<<< master
 =======
 /obj/item/weapon/gun/pistol/m4a3,
 /obj/effect/decal/cleanable/blood,
@@ -4337,6 +4464,8 @@
 /obj/item/ammo_magazine/rifle/mar40/lmg,
 /obj/item/ammo_magazine/rifle/mar40/lmg,
 >>>>>>> updated all maps to have CLF Mines and corpses
+=======
+>>>>>>> Updated CLF spawner
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -4358,6 +4487,7 @@
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/gm/river/desert/deep,
 /area/desert_dam/exterior/river/riverside_central_south)
+<<<<<<< master
 =======
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/storage/firstaid/regular,
@@ -4372,6 +4502,8 @@
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
 >>>>>>> reimported backup
+=======
+>>>>>>> Updated CLF spawner
 "UR" = (
 /obj/structure/barricade/plasteel/wired{
 	icon_state = "plasteel_3";
@@ -4596,9 +4728,13 @@
 /obj/effect/landmark/survivor_spawner/clf/generic,
 =======
 "Xu" = (
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 >>>>>>> updated all maps to have CLF Mines and corpses
+=======
+/obj/effect/landmark/survivor_spawner/clf/generic,
+>>>>>>> Updated CLF spawner
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -4638,6 +4774,7 @@
 >>>>>>> reimported backup
 =======
 "XF" = (
+<<<<<<< master
 /obj/item/stack/tile/plasteel,
 /obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
@@ -4647,6 +4784,13 @@
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
 >>>>>>> updated all maps to have CLF Mines and corpses
+=======
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/floor/greengrid,
+/area/desert_dam/interior/dam_interior/smes_main)
+>>>>>>> Updated CLF spawner
 "XI" = (
 /obj/structure/surface/table,
 /obj/item/reagent_container/food/drinks/cans/thirteenloko,
@@ -4656,6 +4800,9 @@
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> Updated CLF spawner
 "XO" = (
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/prison{
@@ -4663,8 +4810,11 @@
 	tag = "icon-floor (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> Updated CLF spawner
 "XS" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
@@ -4744,9 +4894,13 @@
 /obj/effect/landmark/survivor_spawner/clf/generic,
 =======
 "Yr" = (
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 >>>>>>> updated all maps to have CLF Mines and corpses
+=======
+/obj/effect/landmark/survivor_spawner/clf/generic,
+>>>>>>> Updated CLF spawner
 /turf/open/floor{
 	icon_state = "neutral"
 	},
@@ -5011,10 +5165,14 @@ ET
 zi
 mz
 <<<<<<< master
+<<<<<<< master
 qH
 =======
 mz
 >>>>>>> reimported backup
+=======
+qH
+>>>>>>> Updated CLF spawner
 Sx
 mz
 fJ
@@ -5109,10 +5267,14 @@ rv
 Fr
 Ro
 <<<<<<< master
+<<<<<<< master
 MH
 =======
 TD
 >>>>>>> reimported backup
+=======
+MH
+>>>>>>> Updated CLF spawner
 SJ
 lD
 SJ
@@ -5129,10 +5291,14 @@ qu
 ki
 Xe
 <<<<<<< master
+<<<<<<< master
 iD
 =======
 Qe
 >>>>>>> reimported backup
+=======
+iD
+>>>>>>> Updated CLF spawner
 sk
 Qe
 xp
@@ -5161,7 +5327,7 @@ XU
 AV
 ZO
 cR
-Fw
+XF
 gu
 >>>>>>> updated all maps to have CLF Mines and corpses
 rv
@@ -5196,10 +5362,14 @@ bJ
 Er
 Ee
 <<<<<<< master
+<<<<<<< master
 mB
 =======
 Ee
 >>>>>>> reimported backup
+=======
+mB
+>>>>>>> Updated CLF spawner
 Kd
 XU
 rv
@@ -5317,10 +5487,14 @@ St
 xg
 xg
 <<<<<<< master
+<<<<<<< master
 Kl
 =======
 xg
 >>>>>>> reimported backup
+=======
+Kl
+>>>>>>> Updated CLF spawner
 xg
 PS
 Ws
@@ -5349,6 +5523,7 @@ LD
 LD
 dc
 <<<<<<< master
+<<<<<<< master
 XO
 KT
 Uc
@@ -5363,6 +5538,9 @@ sC
 kY
 =======
 Xf
+=======
+XO
+>>>>>>> Updated CLF spawner
 KT
 Uc
 Eh
@@ -5394,10 +5572,14 @@ yh
 oq
 ED
 <<<<<<< master
+<<<<<<< master
 xo
 =======
 TO
 >>>>>>> reimported backup
+=======
+xo
+>>>>>>> Updated CLF spawner
 zg
 kJ
 fB
@@ -5434,10 +5616,14 @@ kt
 am
 da
 <<<<<<< master
+<<<<<<< master
 UL
 =======
 Wj
 >>>>>>> reimported backup
+=======
+UL
+>>>>>>> Updated CLF spawner
 tU
 NZ
 ED
@@ -5481,11 +5667,15 @@ eb
 dc
 Nz
 <<<<<<< master
+<<<<<<< master
 FO
 Hs
 yC
 =======
 zg
+=======
+FO
+>>>>>>> Updated CLF spawner
 Hs
 <<<<<<< master
 >>>>>>> reimported backup
@@ -5533,6 +5723,7 @@ Hs
 Hs
 <<<<<<< master
 <<<<<<< master
+<<<<<<< master
 Yr
 =======
 vr
@@ -5540,6 +5731,9 @@ vr
 =======
 Hs
 >>>>>>> updated CLF spawner
+=======
+Yr
+>>>>>>> Updated CLF spawner
 Hs
 Hs
 wU
@@ -5574,7 +5768,7 @@ eb
 eb
 dc
 Nz
-rq
+Qn
 Hs
 Hs
 Hs
@@ -5763,6 +5957,7 @@ wU
 Hs
 Ng
 <<<<<<< master
+<<<<<<< master
 Yr
 QK
 =======
@@ -5771,6 +5966,9 @@ Hs
 QD
 >>>>>>> reimported backup
 =======
+=======
+Yr
+>>>>>>> Updated CLF spawner
 QK
 >>>>>>> updated all maps to have CLF Mines and corpses
 LN
@@ -5916,12 +6114,17 @@ Hs
 es
 cs
 <<<<<<< master
+<<<<<<< master
 QM
 rq
 =======
 Kv
 Gc
 >>>>>>> reimported backup
+=======
+QM
+rq
+>>>>>>> Updated CLF spawner
 BN
 UX
 Vm
@@ -5958,10 +6161,14 @@ Ng
 Bt
 TR
 <<<<<<< master
+<<<<<<< master
 XO
 =======
 Xf
 >>>>>>> reimported backup
+=======
+XO
+>>>>>>> Updated CLF spawner
 dc
 py
 Ep
@@ -6049,10 +6256,14 @@ Hm
 Hm
 Og
 <<<<<<< master
+<<<<<<< master
 Xu
 =======
 De
 >>>>>>> reimported backup
+=======
+Xu
+>>>>>>> Updated CLF spawner
 nY
 DH
 gF
@@ -6071,10 +6282,14 @@ yw
 En
 Tz
 <<<<<<< master
+<<<<<<< master
 Uw
 =======
 Tz
 >>>>>>> reimported backup
+=======
+Uw
+>>>>>>> Updated CLF spawner
 Tz
 Tz
 Tz
@@ -6101,7 +6316,7 @@ Kz
 De
 VK
 De
-Xu
+De
 De
 De
 <<<<<<< master
@@ -6141,10 +6356,14 @@ KW
 nw
 TN
 <<<<<<< master
+<<<<<<< master
 jS
 =======
 VK
 >>>>>>> reimported backup
+=======
+jS
+>>>>>>> Updated CLF spawner
 VK
 NY
 Zw
@@ -6189,7 +6408,7 @@ Tz
 hH
 hH
 OR
-Tz
+Uw
 vo
 >>>>>>> updated all maps to have CLF Mines and corpses
 Tz
@@ -6227,7 +6446,7 @@ gZ
 VE
 Tz
 Tz
-Xu
+De
 Gu
 Oc
 rG
@@ -6304,6 +6523,7 @@ od
 tJ
 Tz
 <<<<<<< master
+<<<<<<< master
 Xu
 Gu
 oY
@@ -6315,17 +6535,24 @@ dR
 Nx
 =======
 De
+=======
+Xu
+>>>>>>> Updated CLF spawner
 Gu
 oY
 rG
 UJ
 FY
 UJ
+<<<<<<< master
 cn
 <<<<<<< master
 cw
 >>>>>>> reimported backup
 =======
+=======
+dR
+>>>>>>> Updated CLF spawner
 Nx
 >>>>>>> updated all maps to have CLF Mines and corpses
 qG
@@ -6344,7 +6571,7 @@ wL
 rG
 rG
 cM
-qH
+Tz
 De
 Gu
 wH
@@ -6364,7 +6591,7 @@ cn
 =======
 cn
 UJ
-XF
+FY
 Go
 >>>>>>> updated all maps to have CLF Mines and corpses
 yZ
@@ -6439,7 +6666,7 @@ cn
 >>>>>>> reimported backup
 =======
 cn
-Go
+Ev
 UJ
 >>>>>>> updated all maps to have CLF Mines and corpses
 cn

--- a/maps/map_files/DesertDam/sprinkles/25.clftrijent.dmm
+++ b/maps/map_files/DesertDam/sprinkles/25.clftrijent.dmm
@@ -57,6 +57,7 @@
 	icon_state = "darkyellowcorners2"
 	},
 /area/desert_dam/interior/dam_interior/control_room)
+<<<<<<< master
 "bD" = (
 /obj/effect/spawner/random/attachment,
 /obj/effect/landmark/survivor_spawner/clf/generic,
@@ -65,6 +66,8 @@
 	icon_state = "warning"
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
+=======
+>>>>>>> reimported backup
 "bJ" = (
 /turf/open/floor/prison{
 	dir = 10;
@@ -123,6 +126,7 @@
 	tag = "icon-floor (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
+<<<<<<< master
 "cq" = (
 /obj/effect/landmark/corpsespawner/clf,
 /obj/item/weapon/melee/twohanded/lungemine,
@@ -131,6 +135,8 @@
 	icon_state = "tile"
 	},
 /area/desert_dam/exterior/valley/south_valley_dam)
+=======
+>>>>>>> reimported backup
 "cs" = (
 /obj/effect/blocker/toxic_water/Group_2,
 /turf/open/floor{
@@ -138,6 +144,7 @@
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
 "cw" = (
+<<<<<<< master
 /obj/effect/landmark/corpsespawner/clf,
 /obj/item/weapon/melee/katana,
 /obj/effect/decal/cleanable/blood,
@@ -156,6 +163,32 @@
 /obj/item/ammo_magazine/smg/fp9000,
 /obj/item/ammo_magazine/smg/fp9000,
 /obj/item/ammo_magazine/smg/fp9000,
+=======
+/obj/structure/surface/rack,
+/obj/item/ammo_magazine/rifle/mar40,
+/obj/item/ammo_magazine/rifle/mar40,
+/obj/item/ammo_magazine/rifle/mar40,
+/obj/item/ammo_magazine/rifle/mar40,
+/obj/item/ammo_magazine/rifle/mar40,
+/obj/item/ammo_magazine/rifle/mar40/lmg,
+/obj/item/ammo_magazine/rifle/mar40/lmg,
+/obj/item/ammo_magazine/rifle/mar40/lmg,
+/obj/item/ammo_magazine/rifle/mar40/lmg,
+/obj/item/ammo_magazine/rifle/mar40/lmg,
+/obj/item/weapon/gun/rifle/mar40/lmg,
+/obj/item/weapon/gun/rifle/mar40{
+	pixel_y = 6
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/atmos_storage)
+"cz" = (
+/obj/effect/landmark/corpsespawner/engineer,
+/obj/item/weapon/melee/baseballbat/metal,
+/obj/effect/decal/cleanable/blood,
+>>>>>>> reimported backup
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -170,6 +203,10 @@
 "cC" = (
 /obj/structure/window_frame/colony,
 /obj/structure/window_frame/colony,
+<<<<<<< master
+=======
+/obj/item/stack/rods,
+>>>>>>> reimported backup
 /obj/item/shard{
 	icon_state = "medium"
 	},
@@ -235,11 +272,18 @@
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
 "dq" = (
+<<<<<<< master
 /obj/item/stack/tile/plasteel,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
 /area/desert_dam/exterior/valley/north_valley_dam)
+=======
+/obj/structure/window_frame/colony,
+/obj/item/stack/rods,
+/turf/open/floor/plating,
+/area/desert_dam/interior/dam_interior/smes_main)
+>>>>>>> reimported backup
 "du" = (
 /turf/open/desert/dirt{
 	dir = 10;
@@ -272,6 +316,7 @@
 	icon_state = "platingdmg3"
 	},
 /area/desert_dam/interior/dam_interior/control_room)
+<<<<<<< master
 "dR" = (
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/prison{
@@ -279,6 +324,8 @@
 	tag = "icon-floor (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
+=======
+>>>>>>> reimported backup
 "dZ" = (
 /obj/structure/barricade/sandbags/wired{
 	icon_state = "sandbag_2";
@@ -289,11 +336,16 @@
 	dir = 1
 	},
 /obj/effect/landmark/corpsespawner/engineer,
+<<<<<<< master
 /obj/effect/decal/cleanable/blood,
 /obj/item/weapon/gun/rifle/m16{
 	pixel_x = 5;
 	pixel_y = 6
 	},
+=======
+/obj/item/weapon/melee/baseballbat/metal,
+/obj/effect/decal/cleanable/blood,
+>>>>>>> reimported backup
 /turf/open/floor{
 	icon_state = "neutral"
 	},
@@ -356,6 +408,7 @@
 "eA" = (
 /obj/effect/blocker/toxic_water/Group_2,
 /obj/effect/landmark/corpsespawner/engineer,
+<<<<<<< master
 /obj/effect/decal/cleanable/blood,
 /obj/item/weapon/gun/rifle/hunting,
 /obj/item/ammo_magazine/rifle/hunting,
@@ -363,6 +416,10 @@
 /obj/item/ammo_magazine/rifle/hunting,
 /obj/item/ammo_magazine/rifle/hunting,
 /obj/item/ammo_magazine/rifle/hunting,
+=======
+/obj/item/weapon/melee/baseballbat/metal,
+/obj/effect/decal/cleanable/blood,
+>>>>>>> reimported backup
 /turf/open/floor{
 	dir = 1;
 	icon_state = "warning"
@@ -396,9 +453,12 @@
 "fj" = (
 /obj/item/ammo_casing/bullet,
 /obj/effect/decal/cleanable/dirt,
+<<<<<<< master
 /obj/item/ammo_box/magazine/shotgun/buckshot,
 /obj/item/ammo_box/magazine/shotgun,
 /obj/item/ammo_magazine/shotgun/incendiary,
+=======
+>>>>>>> reimported backup
 /turf/open/floor{
 	icon_state = "neutral"
 	},
@@ -423,11 +483,29 @@
 	},
 /area/desert_dam/interior/dam_interior/control_room)
 "fL" = (
+<<<<<<< master
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/asphalt{
 	icon_state = "tile"
 	},
 /area/desert_dam/exterior/valley/south_valley_dam)
+=======
+/obj/structure/surface/rack,
+/obj/item/weapon/gun/shotgun/pump/cmb{
+	pixel_y = -3
+	},
+/obj/item/weapon/gun/shotgun/pump/cmb{
+	pixel_y = 3
+	},
+/obj/item/weapon/gun/shotgun/pump/cmb{
+	pixel_y = 9
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/atmos_storage)
+>>>>>>> reimported backup
 "fM" = (
 /turf/closed/wall/hangar{
 	name = "reinforced metal wall"
@@ -470,6 +548,7 @@
 	icon_state = "tile"
 	},
 /area/desert_dam/exterior/valley/north_valley_dam)
+<<<<<<< master
 "gu" = (
 /obj/item/stack/sheet/wood,
 /turf/open/floor/prison{
@@ -478,6 +557,8 @@
 	tag = "icon-bright_clean (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/smes_main)
+=======
+>>>>>>> reimported backup
 "gw" = (
 /obj/effect/decal/sand_overlay/sand1{
 	dir = 8
@@ -501,12 +582,24 @@
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 "gS" = (
+<<<<<<< master
 /obj/item/stack/sheet/wood,
 /turf/open/floor/prison{
 	dir = 1;
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/smes_main)
+=======
+/obj/structure/surface/rack,
+/obj/item/ammo_magazine/shotgun/slugs,
+/obj/item/ammo_magazine/shotgun/slugs,
+/obj/item/ammo_magazine/shotgun/slugs,
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/atmos_storage)
+>>>>>>> reimported backup
 "gU" = (
 /obj/structure/machinery/power/apc{
 	dir = 1;
@@ -536,6 +629,10 @@
 /area/desert_dam/interior/dam_interior/control_room)
 "hh" = (
 /obj/structure/window_frame/colony,
+<<<<<<< master
+=======
+/obj/item/stack/rods,
+>>>>>>> reimported backup
 /turf/open/floor/plating,
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 "hk" = (
@@ -543,13 +640,17 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
 	tag = "icon-bright_clean (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
+<<<<<<< master
 "hr" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
@@ -568,6 +669,12 @@
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
 /obj/item/explosive/mine/clf/active,
+=======
+"ht" = (
+/obj/item/stack/rods,
+/obj/effect/decal/cleanable/blood/oil,
+/obj/item/stack/cable_coil/cut,
+>>>>>>> reimported backup
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -580,11 +687,24 @@
 	},
 /area/desert_dam/exterior/valley/south_valley_dam)
 "hH" = (
+<<<<<<< master
 /obj/item/stack/tile/plasteel,
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
+=======
+/obj/structure/surface/rack,
+/obj/item/ammo_magazine/shotgun/buckshot,
+/obj/item/ammo_magazine/shotgun/buckshot,
+/obj/item/ammo_magazine/shotgun/buckshot,
+/obj/item/ammo_magazine/shotgun/buckshot,
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/atmos_storage)
+>>>>>>> reimported backup
 "hJ" = (
 /obj/structure/pipes/standard/manifold/hidden/green{
 	dir = 4
@@ -612,6 +732,7 @@
 	name = "reinforced metal wall"
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
+<<<<<<< master
 "iD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/survivor_spawner/clf/generic,
@@ -637,6 +758,15 @@
 	icon_state = "warning"
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
+=======
+"iO" = (
+/obj/structure/bed,
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/atmos_storage)
+>>>>>>> reimported backup
 "jb" = (
 /obj/structure/machinery/colony_floodlight,
 /obj/effect/decal/sand_overlay/sand1/corner1{
@@ -709,12 +839,15 @@
 /obj/effect/blocker/toxic_water/Group_2,
 /turf/open/gm/river/desert/deep,
 /area/desert_dam/exterior/river/riverside_central_south)
+<<<<<<< master
 "jS" = (
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
+=======
+>>>>>>> reimported backup
 "jY" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
@@ -738,6 +871,10 @@
 /area/desert_dam/interior/dam_interior/engine_room)
 "ki" = (
 /obj/structure/window_frame/colony,
+<<<<<<< master
+=======
+/obj/item/stack/rods,
+>>>>>>> reimported backup
 /obj/item/shard{
 	icon_state = "medium"
 	},
@@ -756,7 +893,10 @@
 /obj/effect/landmark/corpsespawner/engineer,
 /obj/effect/decal/cleanable/blood,
 /obj/item/weapon/gun/smg/nailgun,
+<<<<<<< master
 /obj/item/clothing/accessory/storage/webbing,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -777,6 +917,7 @@
 	dir = 4
 	},
 /area/desert_dam/exterior/river/riverside_central_south)
+<<<<<<< master
 "kY" = (
 /obj/item/stack/tile/plasteel,
 /obj/item/explosive/mine/clf/active{
@@ -788,6 +929,11 @@
 /area/desert_dam/interior/dam_interior/engine_room)
 "lc" = (
 /obj/structure/disposalpipe/segment,
+=======
+"lc" = (
+/obj/structure/disposalpipe/segment,
+/obj/item/stack/rods,
+>>>>>>> reimported backup
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
 /turf/open/floor/prison{
@@ -805,7 +951,10 @@
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 "lh" = (
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
+=======
+>>>>>>> reimported backup
 /turf/open/floor{
 	dir = 5;
 	icon_state = "warning"
@@ -827,12 +976,15 @@
 	},
 /turf/open/floor/plating,
 /area/desert_dam/interior/dam_interior/smes_main)
+<<<<<<< master
 "lJ" = (
 /obj/item/stack/tile/plasteel,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
+=======
+>>>>>>> reimported backup
 "lX" = (
 /obj/structure/platform{
 	dir = 4
@@ -842,24 +994,34 @@
 	dir = 4
 	},
 /area/desert_dam/exterior/river/riverside_central_south)
+<<<<<<< master
 "lY" = (
 /obj/item/stack/sheet/wood,
 /turf/open/floor/prison{
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/smes_backup)
+=======
+>>>>>>> reimported backup
 "mj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
+<<<<<<< master
 /obj/item/shard{
 	icon_state = "medium"
 	},
 /obj/item/explosive/mine/clf/active{
 	dir = 8
 	},
+=======
+/obj/item/stack/rods,
+/obj/item/shard{
+	icon_state = "medium"
+	},
+>>>>>>> reimported backup
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -879,18 +1041,24 @@
 "mu" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
+<<<<<<< master
 /obj/item/explosive/mine/clf/active,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
 	tag = "icon-bright_clean (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
+<<<<<<< master
 "mw" = (
 /obj/effect/blocker/toxic_water/Group_2,
 /obj/item/explosive/mine/clf/active,
 /turf/open/floor/greengrid,
 /area/desert_dam/interior/dam_interior/engine_room)
+=======
+>>>>>>> reimported backup
 "mz" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/structure/disposalpipe/segment,
@@ -901,6 +1069,7 @@
 	tag = "icon-bright_clean (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/control_room)
+<<<<<<< master
 "mB" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/landmark/survivor_spawner/clf/generic,
@@ -910,6 +1079,8 @@
 	tag = "icon-bright_clean (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/smes_main)
+=======
+>>>>>>> reimported backup
 "mH" = (
 /obj/structure/surface/table,
 /obj/item/device/flashlight/flare,
@@ -940,6 +1111,7 @@
 /obj/effect/blocker/toxic_water/Group_2,
 /turf/open/gm/river/desert/deep,
 /area/desert_dam/exterior/river/riverside_central_north)
+<<<<<<< master
 "na" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/attachment,
@@ -947,6 +1119,8 @@
 	icon_state = "platingdmg3"
 	},
 /area/desert_dam/interior/dam_interior/control_room)
+=======
+>>>>>>> reimported backup
 "ne" = (
 /obj/structure/platform{
 	dir = 4
@@ -955,6 +1129,7 @@
 /obj/effect/blocker/toxic_water/Group_1,
 /turf/open/gm/river/desert/deep,
 /area/desert_dam/exterior/river/riverside_central_south)
+<<<<<<< master
 "nk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/survivor_spawner/clf/generic,
@@ -962,6 +1137,8 @@
 	icon_state = "platingdmg1"
 	},
 /area/desert_dam/interior/dam_interior/control_room)
+=======
+>>>>>>> reimported backup
 "nq" = (
 /obj/structure/platform{
 	dir = 1
@@ -971,8 +1148,11 @@
 /area/desert_dam/exterior/river/riverside_central_south)
 "nr" = (
 /obj/effect/decal/cleanable/dirt,
+<<<<<<< master
 /obj/item/stack/tile/plasteel,
 /obj/effect/spawner/random/attachment,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/plating{
 	dir = 10;
 	icon_state = "warnplate"
@@ -1167,10 +1347,20 @@
 	icon_state = "sandbag_2"
 	},
 /obj/effect/landmark/corpsespawner/security/cmb,
+<<<<<<< master
 /obj/item/ammo_casing/bullet,
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/blood,
 /obj/item/weapon/gun/rifle/m16,
+=======
+/obj/item/weapon/gun/rifle/hunting{
+	pixel_x = -5;
+	pixel_y = 7
+	},
+/obj/item/ammo_casing/bullet,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/blood,
+>>>>>>> reimported backup
 /turf/open/floor{
 	icon_state = "neutral"
 	},
@@ -1184,6 +1374,7 @@
 	icon_state = "darkyellowcorners2"
 	},
 /area/desert_dam/interior/dam_interior/control_room)
+<<<<<<< master
 "qD" = (
 /obj/item/explosive/mine/clf/active{
 	dir = 4
@@ -1193,6 +1384,8 @@
 	icon_state = "neutral"
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
+=======
+>>>>>>> reimported backup
 "qE" = (
 /turf/open/floor/prison{
 	dir = 1;
@@ -1204,6 +1397,7 @@
 	name = "reinforced metal wall"
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
+<<<<<<< master
 "qH" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/structure/disposalpipe/segment,
@@ -1215,6 +1409,8 @@
 	tag = "icon-bright_clean (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/control_room)
+=======
+>>>>>>> reimported backup
 "qJ" = (
 /turf/open/desert/dirt,
 /area/desert_dam/exterior/valley/north_valley_dam)
@@ -1252,6 +1448,7 @@
 /turf/open/gm/river/desert/deep,
 /area/desert_dam/exterior/river/riverside_central_south)
 "rq" = (
+<<<<<<< master
 /obj/structure/platform{
 	dir = 1
 	},
@@ -1262,6 +1459,14 @@
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/gm/river/desert/deep,
 /area/desert_dam/exterior/river/riverside_central_south)
+=======
+/obj/structure/machinery/cm_vending/sorted/tech/tool_storage,
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/atmos_storage)
+>>>>>>> reimported backup
 "ru" = (
 /obj/structure/closet/toolcloset,
 /obj/structure/machinery/light{
@@ -1274,6 +1479,10 @@
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 "rv" = (
 /obj/structure/window_frame/colony,
+<<<<<<< master
+=======
+/obj/item/stack/rods,
+>>>>>>> reimported backup
 /obj/item/shard{
 	icon_state = "medium"
 	},
@@ -1293,6 +1502,10 @@
 /area/desert_dam/exterior/river/riverside_central_north)
 "rA" = (
 /obj/structure/window_frame/colony,
+<<<<<<< master
+=======
+/obj/item/stack/rods,
+>>>>>>> reimported backup
 /obj/item/shard{
 	icon_state = "medium"
 	},
@@ -1339,6 +1552,7 @@
 	},
 /area/desert_dam/interior/dam_interior/control_room)
 "rY" = (
+<<<<<<< master
 /obj/effect/blocker/toxic_water/Group_2,
 /obj/structure/barricade/metal/wired{
 	icon_state = "metal_1"
@@ -1348,6 +1562,16 @@
 	},
 /turf/open/gm/river/desert/deep/covered,
 /area/desert_dam/exterior/river/riverside_central_south)
+=======
+/obj/structure/surface/rack,
+/obj/item/ammo_magazine/shotgun/incendiary,
+/obj/item/ammo_magazine/shotgun/incendiary,
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/atmos_storage)
+>>>>>>> reimported backup
 "sf" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/structure/disposalpipe/segment{
@@ -1372,6 +1596,10 @@
 "sq" = (
 /obj/effect/blocker/toxic_water/Group_2,
 /obj/structure/window_frame/colony,
+<<<<<<< master
+=======
+/obj/item/stack/rods,
+>>>>>>> reimported backup
 /obj/item/shard{
 	icon_state = "medium"
 	},
@@ -1428,13 +1656,20 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
+=======
+>>>>>>> reimported backup
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
 "td" = (
 /obj/structure/window_frame/colony,
+<<<<<<< master
+=======
+/obj/item/stack/rods,
+>>>>>>> reimported backup
 /obj/item/shard{
 	icon_state = "medium"
 	},
@@ -1445,6 +1680,7 @@
 	icon_state = "cement_sunbleached4"
 	},
 /area/desert_dam/exterior/valley/south_valley_dam)
+<<<<<<< master
 "tr" = (
 /obj/item/stack/rods,
 /obj/effect/decal/cleanable/blood/oil,
@@ -1458,6 +1694,8 @@
 	tag = "icon-bright_clean (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
+=======
+>>>>>>> reimported backup
 "tx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -1482,11 +1720,14 @@
 	dir = 4;
 	icon_state = "sandbag_2"
 	},
+<<<<<<< master
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor{
 	icon_state = "neutral"
 	},
@@ -1515,12 +1756,42 @@
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
 "tN" = (
+<<<<<<< master
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/tile/plasteel,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
+=======
+/obj/structure/surface/rack,
+/obj/item/ammo_magazine/rifle/m16/ap{
+	pixel_x = -8
+	},
+/obj/item/ammo_magazine/rifle/m16/ap{
+	pixel_x = -8
+	},
+/obj/item/ammo_magazine/rifle/m16/ap{
+	pixel_x = -8
+	},
+/obj/item/ammo_magazine/rifle/m16/ap{
+	pixel_x = -8
+	},
+/obj/item/ammo_magazine/rifle/m16/ap{
+	pixel_x = -8
+	},
+/obj/item/weapon/gun/rifle/m16,
+/obj/item/weapon/gun/rifle/m16{
+	pixel_x = 5;
+	pixel_y = 6
+	},
+/obj/item/ammo_box/magazine/M16,
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/atmos_storage)
+>>>>>>> reimported backup
 "tP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -1574,6 +1845,7 @@
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/smes_backup)
+<<<<<<< master
 "vo" = (
 /obj/effect/spawner/random/attachment,
 /turf/open/floor/prison{
@@ -1581,6 +1853,14 @@
 	tag = "icon-floor (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
+=======
+"vr" = (
+/obj/effect/landmark/survivor_spawn,
+/turf/open/floor{
+	icon_state = "neutral"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+>>>>>>> reimported backup
 "vG" = (
 /obj/structure/surface/table,
 /obj/structure/machinery/cell_charger,
@@ -1650,11 +1930,16 @@
 "wY" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/corpsespawner/engineer,
+<<<<<<< master
 /obj/effect/decal/cleanable/blood,
 /obj/item/weapon/gun/shotgun/pump/cmb{
 	pixel_y = 9
 	},
 /obj/effect/landmark/survivor_spawner/clf/generic,
+=======
+/obj/item/weapon/melee/baseballbat,
+/obj/effect/decal/cleanable/blood,
+>>>>>>> reimported backup
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -1686,6 +1971,7 @@
 	icon_state = "neutral"
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
+<<<<<<< master
 "xo" = (
 /obj/effect/blocker/toxic_water/Group_1,
 /obj/structure/barricade/metal/wired{
@@ -1695,6 +1981,8 @@
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/gm/river/desert/deep/covered,
 /area/desert_dam/exterior/river/riverside_central_north)
+=======
+>>>>>>> reimported backup
 "xp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade/wooden,
@@ -1752,11 +2040,14 @@
 	icon_state = "damaged3"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
+<<<<<<< master
 "ys" = (
 /obj/effect/landmark/corpsespawner/clf,
 /obj/item/weapon/melee/baseballbat/metal,
 /turf/open/desert/dirt,
 /area/desert_dam/exterior/valley/south_valley_dam)
+=======
+>>>>>>> reimported backup
 "yw" = (
 /obj/structure/barricade/wooden{
 	dir = 1
@@ -1766,12 +2057,15 @@
 	icon_state = "darkyellowcorners2"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
+<<<<<<< master
 "yC" = (
 /obj/item/explosive/mine/clf/active,
 /turf/open/floor{
 	icon_state = "neutral"
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
+=======
+>>>>>>> reimported backup
 "yM" = (
 /turf/open/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached14"
@@ -1780,6 +2074,7 @@
 "yX" = (
 /obj/effect/landmark/corpsespawner/security,
 /obj/effect/decal/cleanable/blood,
+<<<<<<< master
 /obj/item/weapon/gun/smg/fp9000{
 	pixel_y = -8
 	},
@@ -1788,6 +2083,9 @@
 /obj/item/ammo_magazine/smg/fp9000,
 /obj/item/ammo_magazine/smg/fp9000,
 /obj/item/ammo_magazine/smg/fp9000,
+=======
+/obj/item/weapon/gun/pistol/b92fs,
+>>>>>>> reimported backup
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -1795,9 +2093,27 @@
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 "yZ" = (
+<<<<<<< master
 /obj/item/stack/tile/plasteel,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
+=======
+/obj/structure/surface/rack,
+/obj/item/weapon/gun/rifle/hunting,
+/obj/item/ammo_magazine/rifle/hunting,
+/obj/item/ammo_magazine/rifle/hunting,
+/obj/item/ammo_magazine/rifle/hunting,
+/obj/item/ammo_magazine/rifle/hunting,
+/obj/item/ammo_magazine/rifle/hunting,
+/obj/item/ammo_magazine/rifle/hunting,
+/obj/item/ammo_magazine/rifle/hunting,
+/obj/item/ammo_magazine/rifle/hunting,
+/obj/item/ammo_magazine/rifle/hunting,
+/obj/item/ammo_magazine/rifle/hunting,
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
+>>>>>>> reimported backup
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
 "za" = (
@@ -1808,6 +2124,7 @@
 /obj/effect/blocker/toxic_water/Group_2,
 /turf/open/gm/river/desert/deep,
 /area/desert_dam/exterior/river/riverside_central_north)
+<<<<<<< master
 "zc" = (
 /obj/item/explosive/mine/clf/active{
 	dir = 4
@@ -1817,6 +2134,8 @@
 	tag = "icon-floor (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
+=======
+>>>>>>> reimported backup
 "zd" = (
 /obj/structure/platform{
 	dir = 1
@@ -1840,6 +2159,10 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
+<<<<<<< master
+=======
+/obj/item/stack/rods,
+>>>>>>> reimported backup
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -1854,10 +2177,15 @@
 /area/desert_dam/interior/dam_interior/engine_room)
 "zR" = (
 /obj/effect/decal/cleanable/blood/oil,
+<<<<<<< master
 /obj/item/stack/cable_coil/cut,
 /obj/item/explosive/mine/clf/active{
 	dir = 1
 	},
+=======
+/obj/item/stack/rods,
+/obj/item/stack/cable_coil/cut,
+>>>>>>> reimported backup
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -1917,11 +2245,22 @@
 /turf/open/floor/plating,
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 "AV" = (
+<<<<<<< master
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/attachment,
 /turf/open/floor/greengrid,
 /area/desert_dam/interior/dam_interior/smes_main)
+=======
+/obj/structure/surface/rack,
+/obj/item/clothing/accessory/storage/webbing,
+/obj/item/clothing/accessory/storage/webbing,
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/atmos_storage)
+>>>>>>> reimported backup
 "Bi" = (
 /obj/structure/platform{
 	dir = 4
@@ -1989,6 +2328,7 @@
 	},
 /area/desert_dam/interior/dam_interior/smes_main)
 "Ce" = (
+<<<<<<< master
 /obj/item/explosive/mine/clf/active{
 	dir = 4
 	},
@@ -2000,6 +2340,9 @@
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 "Cu" = (
 /obj/item/stack/tile/plasteel,
+=======
+/obj/structure/machinery/cm_vending/sorted/tech/electronics_storage,
+>>>>>>> reimported backup
 /turf/open/floor/prison{
 	dir = 10;
 	tag = "icon-floor (SOUTHWEST)"
@@ -2029,7 +2372,13 @@
 	},
 /area/desert_dam/interior/dam_interior/control_room)
 "CS" = (
+<<<<<<< master
 /obj/item/stack/sheet/wood,
+=======
+/obj/structure/barricade/wooden{
+	dir = 8
+	},
+>>>>>>> reimported backup
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "darkyellowcorners2"
@@ -2143,12 +2492,15 @@
 	icon_state = "tile"
 	},
 /area/desert_dam/exterior/valley/north_valley_dam)
+<<<<<<< master
 "Ev" = (
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
+=======
+>>>>>>> reimported backup
 "Ex" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -2169,6 +2521,10 @@
 "ED" = (
 /obj/effect/blocker/toxic_water/Group_1,
 /obj/structure/window_frame/colony,
+<<<<<<< master
+=======
+/obj/item/stack/rods,
+>>>>>>> reimported backup
 /obj/item/shard{
 	icon_state = "medium"
 	},
@@ -2248,10 +2604,26 @@
 	},
 /area/desert_dam/interior/dam_interior/control_room)
 "FO" = (
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor{
 	dir = 1;
 	icon_state = "warning"
+=======
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/item/stack/rods,
+/obj/item/stack/cable_coil/cut,
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+>>>>>>> reimported backup
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
 "FR" = (
@@ -2262,6 +2634,7 @@
 /obj/effect/blocker/toxic_water/Group_1,
 /turf/open/gm/river/desert/deep,
 /area/desert_dam/exterior/river/riverside_central_north)
+<<<<<<< master
 "FY" = (
 /obj/item/stack/tile/plasteel,
 /turf/open/floor{
@@ -2269,6 +2642,8 @@
 	icon_state = "damaged3"
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
+=======
+>>>>>>> reimported backup
 "Gb" = (
 /obj/structure/machinery/power/smes/buildable{
 	capacity = 1e+006;
@@ -2288,8 +2663,31 @@
 /turf/open/gm/river/desert/deep,
 /area/desert_dam/exterior/river/riverside_central_south)
 "Go" = (
+<<<<<<< master
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
+=======
+/obj/structure/surface/rack,
+/obj/item/weapon/gun/smg/fp9000{
+	pixel_y = 7
+	},
+/obj/item/weapon/gun/smg/fp9000{
+	pixel_y = -8
+	},
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
+>>>>>>> reimported backup
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
 "Gr" = (
@@ -2312,12 +2710,15 @@
 	tag = "icon-bright_clean (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
+<<<<<<< master
 "Gz" = (
 /obj/effect/spawner/random/attachment,
 /turf/open/floor{
 	icon_state = "neutral"
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
+=======
+>>>>>>> reimported backup
 "GM" = (
 /obj/structure/barricade/metal/wired{
 	icon_state = "metal_1";
@@ -2336,9 +2737,16 @@
 	},
 /area/desert_dam/interior/dam_interior/smes_main)
 "GW" = (
+<<<<<<< master
 /obj/effect/spawner/random/attachment,
 /turf/open/floor{
 	icon_state = "platingdmg1"
+=======
+/obj/structure/machinery/cm_vending/sorted/medical/no_access,
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
+>>>>>>> reimported backup
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
 "Hb" = (
@@ -2387,17 +2795,24 @@
 	tag = "icon-bright_clean (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
+<<<<<<< master
 "Hw" = (
 /obj/item/stack/tile/plasteel,
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
+=======
+>>>>>>> reimported backup
 "HB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
+<<<<<<< master
+=======
+/obj/item/stack/rods,
+>>>>>>> reimported backup
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -2434,6 +2849,7 @@
 	tag = "icon-darkyellow2 (NORTH)"
 	},
 /area/desert_dam/interior/dam_interior/control_room)
+<<<<<<< master
 "IB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/sheet/wood,
@@ -2442,6 +2858,8 @@
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/smes_backup)
+=======
+>>>>>>> reimported backup
 "ID" = (
 /obj/structure/platform{
 	dir = 4
@@ -2474,9 +2892,13 @@
 	},
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
+<<<<<<< master
 /obj/item/explosive/mine/clf/active{
 	dir = 8
 	},
+=======
+/obj/item/stack/rods,
+>>>>>>> reimported backup
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -2493,6 +2915,7 @@
 	tag = "icon-bright_clean (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/smes_main)
+<<<<<<< master
 "Kl" = (
 /obj/structure/barricade/metal/wired{
 	icon_state = "metal_1";
@@ -2504,6 +2927,8 @@
 	tag = "icon-floor (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
+=======
+>>>>>>> reimported backup
 "Kv" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
@@ -2534,7 +2959,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
+=======
+>>>>>>> reimported backup
 /turf/open/floor{
 	icon_state = "neutral"
 	},
@@ -2551,8 +2979,15 @@
 	},
 /area/desert_dam/exterior/valley/north_valley_dam)
 "KY" = (
+<<<<<<< master
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/sheet/wood,
+=======
+/obj/structure/barricade/wooden{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+>>>>>>> reimported backup
 /turf/open/floor/plating{
 	dir = 8;
 	icon_state = "warnplate"
@@ -2640,6 +3075,7 @@
 /obj/item/shard{
 	icon_state = "medium"
 	},
+<<<<<<< master
 /turf/open/floor/plating,
 /area/desert_dam/interior/dam_interior/engine_room)
 "Ml" = (
@@ -2650,6 +3086,11 @@
 	icon_state = "neutral"
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
+=======
+/obj/item/stack/rods,
+/turf/open/floor/plating,
+/area/desert_dam/interior/dam_interior/engine_room)
+>>>>>>> reimported backup
 "Mm" = (
 /obj/structure/machinery/power/smes/buildable{
 	capacity = 1e+006;
@@ -2671,6 +3112,10 @@
 /area/desert_dam/interior/dam_interior/engine_room)
 "Mw" = (
 /obj/structure/window_frame/colony,
+<<<<<<< master
+=======
+/obj/item/stack/rods,
+>>>>>>> reimported backup
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -2682,6 +3127,7 @@
 	icon_state = "warnplate"
 	},
 /area/desert_dam/interior/dam_interior/smes_backup)
+<<<<<<< master
 "MH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/survivor_spawner/clf/generic,
@@ -2690,6 +3136,10 @@
 "MQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/survivor_spawner/clf/generic,
+=======
+"MQ" = (
+/obj/effect/decal/cleanable/dirt,
+>>>>>>> reimported backup
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -2729,6 +3179,7 @@
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
 "Nj" = (
+<<<<<<< master
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -2737,6 +3188,30 @@
 /turf/open/floor{
 	dir = 8;
 	icon_state = "damaged3"
+=======
+/obj/structure/surface/table/reinforced/prison,
+/obj/effect/spawner/random/attachment,
+/obj/effect/spawner/random/attachment,
+/obj/effect/spawner/random/attachment,
+/obj/effect/spawner/random/attachment,
+/obj/effect/spawner/random/attachment,
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/atmos_storage)
+"Nx" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/clothing/glasses/welding,
+/obj/item/stack/sheet/metal/large_stack,
+/obj/item/stack/sheet/plasteel/large_stack,
+/obj/item/weapon/gun/smg/nailgun,
+/obj/item/ammo_magazine/smg/nailgun,
+/obj/item/ammo_magazine/smg/nailgun,
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
+>>>>>>> reimported backup
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
 "Nz" = (
@@ -2836,6 +3311,7 @@
 	icon_state = "platingdmg1"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
+<<<<<<< master
 "OS" = (
 /obj/effect/landmark/corpsespawner/clf,
 /obj/item/weapon/gun/smg/fp9000{
@@ -2850,11 +3326,17 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/ammo_casing/bullet,
 /obj/effect/landmark/survivor_spawner/clf/generic,
+=======
+"OT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/ammo_casing/bullet,
+>>>>>>> reimported backup
 /turf/open/floor/prison{
 	dir = 10;
 	tag = "icon-floor (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/control_room)
+<<<<<<< master
 "Pk" = (
 /obj/effect/landmark/corpsespawner/clf,
 /obj/item/weapon/melee/twohanded/lungemine,
@@ -2864,6 +3346,8 @@
 	tag = "icon-bright_clean (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
+=======
+>>>>>>> reimported backup
 "Pr" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -2925,7 +3409,10 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -2982,6 +3469,7 @@
 	icon_state = "tile"
 	},
 /area/desert_dam/exterior/valley/south_valley_dam)
+<<<<<<< master
 "QK" = (
 /obj/item/clothing/accessory/storage/webbing,
 /turf/open/floor{
@@ -3002,6 +3490,8 @@
 	icon_state = "neutral"
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
+=======
+>>>>>>> reimported backup
 "Rh" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
@@ -3019,10 +3509,15 @@
 	dir = 8
 	},
 /obj/effect/landmark/corpsespawner/security,
+<<<<<<< master
 /obj/effect/decal/cleanable/blood,
 /obj/item/weapon/gun/shotgun/pump/cmb{
 	pixel_y = 3
 	},
+=======
+/obj/item/weapon/gun/pistol/b92fs,
+/obj/effect/decal/cleanable/blood,
+>>>>>>> reimported backup
 /turf/open/floor/prison{
 	dir = 8;
 	icon_state = "darkyellow2"
@@ -3094,7 +3589,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+<<<<<<< master
 /obj/item/stack/tile/plasteel,
+=======
+>>>>>>> reimported backup
 /turf/open/floor{
 	dir = 8;
 	icon_state = "damaged3"
@@ -3154,8 +3652,14 @@
 	},
 /area/desert_dam/interior/dam_interior/control_room)
 "Te" = (
+<<<<<<< master
 /obj/effect/decal/cleanable/blood/oil,
 /obj/effect/decal/cleanable/ash,
+=======
+/obj/structure/machinery/door/airlock/almayer/maint{
+	name = "\improper Atmospheric Storage"
+	},
+>>>>>>> reimported backup
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -3165,6 +3669,10 @@
 "Th" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/effect/decal/cleanable/dirt,
+<<<<<<< master
+=======
+/obj/item/stack/rods,
+>>>>>>> reimported backup
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
 /turf/open/floor/prison{
@@ -3199,7 +3707,10 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -3217,10 +3728,15 @@
 /area/desert_dam/interior/dam_interior/engine_west_wing)
 "TN" = (
 /obj/effect/decal/cleanable/blood/oil,
+<<<<<<< master
 /obj/item/stack/cable_coil/cut,
 /obj/item/explosive/mine/clf/active{
 	dir = 1
 	},
+=======
+/obj/item/stack/rods,
+/obj/item/stack/cable_coil/cut,
+>>>>>>> reimported backup
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -3240,10 +3756,20 @@
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
 "Uc" = (
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor{
 	dir = 8;
 	icon_state = "warning"
+=======
+/obj/item/stack/rods,
+/obj/item/stack/cable_coil/cut,
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+>>>>>>> reimported backup
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
 "Um" = (
@@ -3264,6 +3790,7 @@
 	tag = "icon-floor (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/control_room)
+<<<<<<< master
 "Uw" = (
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/prison{
@@ -3271,6 +3798,8 @@
 	tag = "icon-floor (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
+=======
+>>>>>>> reimported backup
 "Uy" = (
 /obj/structure/platform{
 	dir = 1
@@ -3289,6 +3818,7 @@
 /area/desert_dam/interior/dam_interior/engine_room)
 "UI" = (
 /obj/effect/landmark/corpsespawner/engineer,
+<<<<<<< master
 /obj/effect/decal/cleanable/blood,
 /obj/item/weapon/gun/rifle/mar40{
 	pixel_y = 6
@@ -3299,6 +3829,10 @@
 /obj/item/ammo_magazine/rifle/mar40/lmg,
 /obj/item/ammo_magazine/rifle/mar40/lmg,
 /obj/effect/landmark/survivor_spawner/clf/generic,
+=======
+/obj/item/weapon/gun/pistol/m4a3,
+/obj/effect/decal/cleanable/blood,
+>>>>>>> reimported backup
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -3306,6 +3840,7 @@
 	},
 /area/desert_dam/interior/dam_interior/smes_backup)
 "UJ" = (
+<<<<<<< master
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
@@ -3318,6 +3853,16 @@
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/gm/river/desert/deep,
 /area/desert_dam/exterior/river/riverside_central_south)
+=======
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/storage/firstaid/regular,
+/obj/item/storage/firstaid/surgical,
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/atmos_storage)
+>>>>>>> reimported backup
 "UR" = (
 /obj/structure/barricade/plasteel/wired{
 	icon_state = "plasteel_3";
@@ -3356,7 +3901,10 @@
 /area/desert_dam/interior/dam_interior/engine_room)
 "Vp" = (
 /obj/structure/bed/stool,
+<<<<<<< master
 /obj/item/clothing/accessory/storage/webbing,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/prison{
 	dir = 10;
 	tag = "icon-floor (SOUTHWEST)"
@@ -3377,12 +3925,15 @@
 	icon_state = "darkyellowcorners2"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
+<<<<<<< master
 "VF" = (
 /obj/item/stack/tile/plasteel,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
 /area/desert_dam/interior/dam_interior/control_room)
+=======
+>>>>>>> reimported backup
 "VG" = (
 /obj/structure/machinery/light{
 	dir = 4
@@ -3448,9 +3999,13 @@
 	dir = 8
 	},
 /obj/effect/landmark/corpsespawner/engineer,
+<<<<<<< master
 /obj/item/weapon/gun/shotgun/pump/cmb{
 	pixel_y = 9
 	},
+=======
+/obj/item/weapon/melee/baseballbat,
+>>>>>>> reimported backup
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -3510,6 +4065,7 @@
 	tag = "icon-floor (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
+<<<<<<< master
 "Xu" = (
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/prison{
@@ -3518,6 +4074,8 @@
 	tag = "icon-bright_clean (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
+=======
+>>>>>>> reimported backup
 "Xy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -3534,12 +4092,15 @@
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
+<<<<<<< master
 "XF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/greengrid,
 /area/desert_dam/interior/dam_interior/smes_main)
+=======
+>>>>>>> reimported backup
 "XI" = (
 /obj/structure/surface/table,
 /obj/item/reagent_container/food/drinks/cans/thirteenloko,
@@ -3548,6 +4109,7 @@
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
+<<<<<<< master
 "XO" = (
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/prison{
@@ -3555,6 +4117,8 @@
 	tag = "icon-floor (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
+=======
+>>>>>>> reimported backup
 "XS" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
@@ -3563,6 +4127,10 @@
 	dir = 4
 	},
 /obj/item/stack/cable_coil/cut,
+<<<<<<< master
+=======
+/obj/item/stack/rods,
+>>>>>>> reimported backup
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/prison{
 	dir = 10;
@@ -3590,6 +4158,10 @@
 /area/desert_dam/interior/dam_interior/smes_main)
 "Yh" = (
 /obj/item/stack/cable_coil/cut,
+<<<<<<< master
+=======
+/obj/item/stack/rods,
+>>>>>>> reimported backup
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/prison{
 	dir = 10;
@@ -3614,18 +4186,31 @@
 	},
 /turf/open/floor/plating,
 /area/desert_dam/interior/dam_interior/engine_room)
+<<<<<<< master
 "Yr" = (
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor{
 	icon_state = "neutral"
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
+=======
+>>>>>>> reimported backup
 "Yt" = (
 /obj/effect/decal/sand_overlay/sand1,
 /turf/open/asphalt{
 	icon_state = "tile"
 	},
 /area/desert_dam/exterior/valley/north_valley_dam)
+<<<<<<< master
+=======
+"YO" = (
+/obj/effect/landmark/survivor_spawn,
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+>>>>>>> reimported backup
 "YY" = (
 /obj/item/stack/sheet/wood,
 /turf/open/floor/prison{
@@ -3653,7 +4238,10 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+<<<<<<< master
 /obj/item/stack/tile/plasteel,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -3668,6 +4256,7 @@
 	},
 /obj/effect/landmark/corpsespawner/security,
 /obj/effect/decal/cleanable/blood,
+<<<<<<< master
 /obj/item/weapon/gun/rifle/mar40{
 	pixel_y = 6
 	},
@@ -3676,6 +4265,9 @@
 /obj/item/ammo_magazine/rifle/mar40/lmg,
 /obj/item/ammo_magazine/rifle/mar40/lmg,
 /obj/item/ammo_magazine/rifle/mar40/lmg,
+=======
+/obj/item/weapon/gun/pistol/b92fs,
+>>>>>>> reimported backup
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -3711,6 +4303,7 @@
 	tag = "icon-bright_clean (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
+<<<<<<< master
 "ZO" = (
 /obj/item/clothing/accessory/storage/webbing,
 /turf/open/floor/greengrid,
@@ -3738,6 +4331,22 @@
 /obj/item/explosive/mine/clf/active{
 	dir = 1
 	},
+=======
+"ZV" = (
+/obj/structure/barricade/plasteel/wired{
+	dir = 8
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/atmos_storage)
+"ZW" = (
+/obj/item/stack/rods,
+/obj/effect/decal/cleanable/blood/oil,
+/obj/item/stack/cable_coil/cut,
+/obj/effect/decal/cleanable/blood/drip,
+>>>>>>> reimported backup
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -3809,7 +4418,11 @@ ET
 ET
 zi
 mz
+<<<<<<< master
 qH
+=======
+mz
+>>>>>>> reimported backup
 Sx
 mz
 fJ
@@ -3825,7 +4438,11 @@ ki
 "}
 (4,1,1) = {"
 rv
+<<<<<<< master
 gS
+=======
+Fr
+>>>>>>> reimported backup
 Ro
 cR
 cR
@@ -3846,7 +4463,11 @@ CZ
 Zx
 MF
 fS
+<<<<<<< master
 lY
+=======
+Im
+>>>>>>> reimported backup
 ki
 "}
 (5,1,1) = {"
@@ -3872,14 +4493,22 @@ RX
 oh
 Vb
 Mm
+<<<<<<< master
 IB
+=======
+xp
+>>>>>>> reimported backup
 ki
 "}
 (6,1,1) = {"
 rv
 Fr
 Ro
+<<<<<<< master
 MH
+=======
+TD
+>>>>>>> reimported backup
 SJ
 lD
 SJ
@@ -3895,7 +4524,11 @@ DW
 qu
 ki
 Xe
+<<<<<<< master
 iD
+=======
+Qe
+>>>>>>> reimported backup
 sk
 Qe
 xp
@@ -3906,17 +4539,29 @@ rv
 Fr
 Ro
 Xy
+<<<<<<< master
 AV
 ZO
 cR
 XF
 gu
+=======
+Fw
+cR
+cR
+Fw
+XU
+>>>>>>> reimported backup
 rv
 CO
 Td
 Xd
 hb
+<<<<<<< master
 nk
+=======
+hb
+>>>>>>> reimported backup
 ak
 pA
 ki
@@ -3934,15 +4579,24 @@ PB
 bJ
 Er
 Ee
+<<<<<<< master
 mB
+=======
+Ee
+>>>>>>> reimported backup
 Kd
 XU
 rv
 Iy
 EK
 Td
+<<<<<<< master
 VF
 na
+=======
+dQ
+NP
+>>>>>>> reimported backup
 BL
 vG
 cC
@@ -3982,18 +4636,30 @@ Hp
 (10,1,1) = {"
 fM
 sG
+<<<<<<< master
 rv
 rv
+=======
+dq
+dq
+>>>>>>> reimported backup
 sG
 fM
 rv
 pR
 rv
 dc
+<<<<<<< master
 Mh
 Mh
 Mh
 Mh
+=======
+Yq
+Yq
+Yq
+Yq
+>>>>>>> reimported backup
 Yh
 XS
 Mh
@@ -4018,7 +4684,11 @@ xg
 St
 xg
 xg
+<<<<<<< master
 Kl
+=======
+xg
+>>>>>>> reimported backup
 xg
 PS
 Ws
@@ -4027,7 +4697,11 @@ St
 Xf
 wU
 Oj
+<<<<<<< master
 ys
+=======
+Oj
+>>>>>>> reimported backup
 Oj
 fe
 "}
@@ -4038,6 +4712,7 @@ LD
 LD
 LD
 dc
+<<<<<<< master
 XO
 KT
 Uc
@@ -4050,6 +4725,20 @@ lJ
 tc
 sC
 kY
+=======
+Xf
+KT
+Eh
+Eh
+Eh
+Eh
+Eh
+Eh
+ek
+tc
+sC
+ek
+>>>>>>> reimported backup
 Xf
 dc
 Rz
@@ -4064,7 +4753,11 @@ uM
 yh
 oq
 ED
+<<<<<<< master
 xo
+=======
+TO
+>>>>>>> reimported backup
 zg
 kJ
 fB
@@ -4100,7 +4793,11 @@ PL
 kt
 am
 da
+<<<<<<< master
 UL
+=======
+Wj
+>>>>>>> reimported backup
 tU
 NZ
 ED
@@ -4143,17 +4840,29 @@ eb
 eb
 dc
 Nz
+<<<<<<< master
 FO
 Hs
 yC
+=======
+zg
+Hs
+>>>>>>> reimported backup
 Hs
 Hs
 Hs
 Hs
 Hs
+<<<<<<< master
 hr
 Hs
 bD
+=======
+Hs
+Ng
+Hs
+QD
+>>>>>>> reimported backup
 Dp
 dc
 QJ
@@ -4172,7 +4881,11 @@ NT
 mn
 Hs
 Hs
+<<<<<<< master
 Yr
+=======
+vr
+>>>>>>> reimported backup
 Hs
 Hs
 wU
@@ -4183,9 +4896,15 @@ QD
 LN
 ht
 QJ
+<<<<<<< master
 cq
 fL
 fL
+=======
+QJ
+QJ
+QJ
+>>>>>>> reimported backup
 "}
 (18,1,1) = {"
 eb
@@ -4250,15 +4969,25 @@ PD
 eA
 mq
 mq
+<<<<<<< master
 mw
 mq
 ZV
+=======
+mq
+mq
+cs
+>>>>>>> reimported backup
 es
 ia
 RK
 nq
 rp
+<<<<<<< master
 rY
+=======
+UX
+>>>>>>> reimported backup
 sq
 es
 nq
@@ -4292,9 +5021,15 @@ ez
 ez
 "}
 (22,1,1) = {"
+<<<<<<< master
 Nj
 Nj
 Nj
+=======
+eb
+eb
+eb
+>>>>>>> reimported backup
 eb
 eb
 dc
@@ -4318,12 +5053,21 @@ QJ
 QJ
 "}
 (23,1,1) = {"
+<<<<<<< master
 Nj
 Nj
 dq
 Nj
 eb
 tr
+=======
+eb
+eb
+eb
+eb
+eb
+ht
+>>>>>>> reimported backup
 UR
 Hs
 Hs
@@ -4334,12 +5078,18 @@ Hs
 wU
 Hs
 Ng
+<<<<<<< master
 Yr
 QK
+=======
+Hs
+QD
+>>>>>>> reimported backup
 LN
 ht
 QJ
 QJ
+<<<<<<< master
 cw
 fL
 "}
@@ -4361,6 +5111,29 @@ Yr
 Hs
 Ng
 Ml
+=======
+QJ
+QJ
+"}
+(24,1,1) = {"
+eb
+eb
+eb
+eb
+eb
+dc
+Nz
+zg
+Hs
+ep
+ek
+MQ
+Hs
+Hs
+Hs
+Ng
+Hs
+>>>>>>> reimported backup
 QD
 Dp
 dc
@@ -4382,7 +5155,11 @@ Tm
 Zh
 Tm
 gA
+<<<<<<< master
 Gz
+=======
+Hs
+>>>>>>> reimported backup
 es
 cs
 Kv
@@ -4437,8 +5214,13 @@ gA
 Hs
 es
 cs
+<<<<<<< master
 QM
 rq
+=======
+Kv
+Gc
+>>>>>>> reimported backup
 BN
 UX
 Vm
@@ -4460,13 +5242,21 @@ Bt
 Bt
 Bt
 Bt
+<<<<<<< master
 ZT
+=======
+Bt
+>>>>>>> reimported backup
 Bt
 Hs
 Ng
 Bt
 TR
+<<<<<<< master
 XO
+=======
+Xf
+>>>>>>> reimported backup
 dc
 py
 Ep
@@ -4513,10 +5303,17 @@ dc
 Yq
 Yq
 dc
+<<<<<<< master
 Mh
 Yh
 XS
 Mh
+=======
+Yq
+Uc
+FO
+Yq
+>>>>>>> reimported backup
 dc
 wU
 wU
@@ -4540,7 +5337,11 @@ lf
 Hm
 Hm
 Og
+<<<<<<< master
 Xu
+=======
+De
+>>>>>>> reimported backup
 nY
 DH
 gF
@@ -4558,7 +5359,11 @@ hh
 yw
 En
 Tz
+<<<<<<< master
 Uw
+=======
+Tz
+>>>>>>> reimported backup
 Tz
 Tz
 Tz
@@ -4588,13 +5393,21 @@ De
 De
 De
 De
+<<<<<<< master
 Pk
+=======
+De
+>>>>>>> reimported backup
 De
 De
 nz
 yX
 nY
+<<<<<<< master
 Xu
+=======
+De
+>>>>>>> reimported backup
 De
 Ht
 mu
@@ -4607,7 +5420,11 @@ ge
 KW
 nw
 TN
+<<<<<<< master
 jS
+=======
+VK
+>>>>>>> reimported backup
 VK
 NY
 Zw
@@ -4634,18 +5451,30 @@ gr
 gw
 Mw
 fT
+<<<<<<< master
 hH
 hH
 OR
 Uw
 vo
+=======
+ph
+ph
+OR
+YO
+Tz
+>>>>>>> reimported backup
 Tz
 hk
 Lr
 EH
 oj
 wA
+<<<<<<< master
 Ce
+=======
+De
+>>>>>>> reimported backup
 De
 VG
 oW
@@ -4691,16 +5520,28 @@ rG
 rG
 pe
 Vp
+<<<<<<< master
 zc
+=======
+Tz
+>>>>>>> reimported backup
 De
 Gu
 oY
 rG
+<<<<<<< master
 cn
 UJ
 cn
 GW
 cn
+=======
+Ce
+ZV
+ZV
+cn
+fL
+>>>>>>> reimported backup
 qG
 Oj
 fe
@@ -4718,6 +5559,7 @@ rG
 od
 tJ
 Tz
+<<<<<<< master
 Xu
 Gu
 oY
@@ -4727,6 +5569,17 @@ FY
 UJ
 dR
 Nx
+=======
+De
+Gu
+oY
+rG
+rq
+cn
+cn
+cn
+cw
+>>>>>>> reimported backup
 qG
 Oj
 fe
@@ -4748,10 +5601,17 @@ De
 Gu
 wH
 rG
+<<<<<<< master
 cn
 UJ
 FY
 Go
+=======
+iO
+cn
+cn
+cn
+>>>>>>> reimported backup
 yZ
 qG
 Oj
@@ -4776,9 +5636,15 @@ wH
 rG
 UJ
 cn
+<<<<<<< master
 Go
 Go
 UJ
+=======
+cn
+cn
+tN
+>>>>>>> reimported backup
 qG
 du
 fe
@@ -4800,9 +5666,15 @@ rG
 ee
 rG
 rG
+<<<<<<< master
 cn
 Ev
 UJ
+=======
+GW
+cn
+cn
+>>>>>>> reimported backup
 cn
 Go
 qG
@@ -4827,10 +5699,17 @@ tx
 wL
 rG
 cn
+<<<<<<< master
 Hw
 Cu
 UJ
 cn
+=======
+cn
+cn
+cn
+gS
+>>>>>>> reimported backup
 qG
 wL
 wL
@@ -4853,10 +5732,17 @@ tx
 wL
 rG
 Nx
+<<<<<<< master
 Go
 UJ
 Go
 cn
+=======
+AV
+Nj
+rY
+hH
+>>>>>>> reimported backup
 qG
 wL
 wL

--- a/maps/map_files/DesertDam/sprinkles/25.clftrijent.dmm
+++ b/maps/map_files/DesertDam/sprinkles/25.clftrijent.dmm
@@ -59,8 +59,7 @@
 /area/desert_dam/interior/dam_interior/control_room)
 "bD" = (
 /obj/effect/spawner/random/attachment,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor{
 	dir = 7;
 	icon_state = "warning"
@@ -273,6 +272,13 @@
 	icon_state = "platingdmg3"
 	},
 /area/desert_dam/interior/dam_interior/control_room)
+"dR" = (
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/atmos_storage)
 "dZ" = (
 /obj/structure/barricade/sandbags/wired{
 	icon_state = "sandbag_2";
@@ -537,6 +543,7 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -605,6 +612,15 @@
 	name = "reinforced metal wall"
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
+"iD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/smes_backup)
 "iO" = (
 /obj/effect/landmark/corpsespawner/engineer,
 /obj/item/tool/weldpack,
@@ -693,6 +709,12 @@
 /obj/effect/blocker/toxic_water/Group_2,
 /turf/open/gm/river/desert/deep,
 /area/desert_dam/exterior/river/riverside_central_south)
+"jS" = (
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
 "jY" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
@@ -783,8 +805,7 @@
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 "lh" = (
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor{
 	dir = 5;
 	icon_state = "warning"
@@ -880,6 +901,15 @@
 	tag = "icon-bright_clean (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/control_room)
+"mB" = (
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/smes_main)
 "mH" = (
 /obj/structure/surface/table,
 /obj/item/device/flashlight/flare,
@@ -927,8 +957,7 @@
 /area/desert_dam/exterior/river/riverside_central_south)
 "nk" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
@@ -1025,8 +1054,6 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -1161,6 +1188,7 @@
 /obj/item/explosive/mine/clf/active{
 	dir = 4
 	},
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor{
 	icon_state = "neutral"
 	},
@@ -1177,13 +1205,16 @@
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
 "qH" = (
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/structure/pipes/standard/simple/hidden/green,
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/prison{
 	dir = 10;
-	tag = "icon-floor (SOUTHWEST)"
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
 	},
-/area/desert_dam/interior/dam_interior/engine_east_wing)
+/area/desert_dam/interior/dam_interior/control_room)
 "qJ" = (
 /turf/open/desert/dirt,
 /area/desert_dam/exterior/valley/north_valley_dam)
@@ -1221,14 +1252,16 @@
 /turf/open/gm/river/desert/deep,
 /area/desert_dam/exterior/river/riverside_central_south)
 "rq" = (
-/obj/effect/decal/cleanable/blood/drip,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
-/turf/open/floor{
-	dir = 1;
-	icon_state = "warning"
+/obj/structure/platform{
+	dir = 1
 	},
-/area/desert_dam/interior/dam_interior/engine_room)
+/obj/structure/platform{
+	dir = 4
+	},
+/obj/effect/blocker/toxic_water/Group_2,
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/gm/river/desert/deep,
+/area/desert_dam/exterior/river/riverside_central_south)
 "ru" = (
 /obj/structure/closet/toolcloset,
 /obj/structure/machinery/light{
@@ -1330,8 +1363,6 @@
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 "sk" = (
 /obj/item/ammo_casing/bullet,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -1397,6 +1428,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
@@ -1622,6 +1654,7 @@
 /obj/item/weapon/gun/shotgun/pump/cmb{
 	pixel_y = 9
 	},
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -1653,6 +1686,15 @@
 	icon_state = "neutral"
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
+"xo" = (
+/obj/effect/blocker/toxic_water/Group_1,
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1";
+	dir = 1
+	},
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/gm/river/desert/deep/covered,
+/area/desert_dam/exterior/river/riverside_central_north)
 "xp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade/wooden,
@@ -1878,8 +1920,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/attachment,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor/greengrid,
 /area/desert_dam/interior/dam_interior/smes_main)
 "Bi" = (
@@ -2103,6 +2143,12 @@
 	icon_state = "tile"
 	},
 /area/desert_dam/exterior/valley/north_valley_dam)
+"Ev" = (
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/desert_dam/interior/dam_interior/atmos_storage)
 "Ex" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -2202,8 +2248,7 @@
 	},
 /area/desert_dam/interior/dam_interior/control_room)
 "FO" = (
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor{
 	dir = 1;
 	icon_state = "warning"
@@ -2448,6 +2493,17 @@
 	tag = "icon-bright_clean (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/smes_main)
+"Kl" = (
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1";
+	dir = 8
+	},
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
 "Kv" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
@@ -2478,6 +2534,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor{
 	icon_state = "neutral"
 	},
@@ -2625,8 +2682,14 @@
 	icon_state = "warnplate"
 	},
 /area/desert_dam/interior/dam_interior/smes_backup)
+"MH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/floor/greengrid,
+/area/desert_dam/interior/dam_interior/smes_main)
 "MQ" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -2786,6 +2849,7 @@
 "OT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/ammo_casing/bullet,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/prison{
 	dir = 10;
 	tag = "icon-floor (SOUTHWEST)"
@@ -2861,6 +2925,7 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -2922,6 +2987,19 @@
 /turf/open/floor{
 	dir = 7;
 	icon_state = "warning"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"QM" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/blocker/toxic_water/Group_2,
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/floor{
+	icon_state = "neutral"
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
 "Rh" = (
@@ -3045,8 +3123,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -3123,6 +3199,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -3163,8 +3240,7 @@
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
 "Uc" = (
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor{
 	dir = 8;
 	icon_state = "warning"
@@ -3188,6 +3264,13 @@
 	tag = "icon-floor (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/control_room)
+"Uw" = (
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
 "Uy" = (
 /obj/structure/platform{
 	dir = 1
@@ -3215,6 +3298,7 @@
 /obj/item/ammo_magazine/rifle/mar40/lmg,
 /obj/item/ammo_magazine/rifle/mar40/lmg,
 /obj/item/ammo_magazine/rifle/mar40/lmg,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -3226,6 +3310,14 @@
 	icon_state = "platingdmg1"
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
+"UL" = (
+/obj/structure/platform{
+	dir = 1
+	},
+/obj/effect/blocker/toxic_water/Group_1,
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/gm/river/desert/deep,
+/area/desert_dam/exterior/river/riverside_central_south)
 "UR" = (
 /obj/structure/barricade/plasteel/wired{
 	icon_state = "plasteel_3";
@@ -3419,8 +3511,7 @@
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
 "Xu" = (
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -3444,14 +3535,11 @@
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 "XF" = (
-/obj/item/stack/tile/plasteel,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
-/turf/open/floor{
-	dir = 8;
-	icon_state = "damaged3"
-	},
-/area/desert_dam/interior/dam_interior/atmos_storage)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/floor/greengrid,
+/area/desert_dam/interior/dam_interior/smes_main)
 "XI" = (
 /obj/structure/surface/table,
 /obj/item/reagent_container/food/drinks/cans/thirteenloko,
@@ -3460,6 +3548,13 @@
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
+"XO" = (
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
 "XS" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
@@ -3520,8 +3615,7 @@
 /turf/open/floor/plating,
 /area/desert_dam/interior/dam_interior/engine_room)
 "Yr" = (
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor{
 	icon_state = "neutral"
 	},
@@ -3715,7 +3809,7 @@ ET
 ET
 zi
 mz
-mz
+qH
 Sx
 mz
 fJ
@@ -3785,7 +3879,7 @@ ki
 rv
 Fr
 Ro
-TD
+MH
 SJ
 lD
 SJ
@@ -3801,7 +3895,7 @@ DW
 qu
 ki
 Xe
-Qe
+iD
 sk
 Qe
 xp
@@ -3815,7 +3909,7 @@ Xy
 AV
 ZO
 cR
-Fw
+XF
 gu
 rv
 CO
@@ -3840,7 +3934,7 @@ PB
 bJ
 Er
 Ee
-Ee
+mB
 Kd
 XU
 rv
@@ -3924,7 +4018,7 @@ xg
 St
 xg
 xg
-xg
+Kl
 xg
 PS
 Ws
@@ -3944,7 +4038,7 @@ LD
 LD
 LD
 dc
-Xf
+XO
 KT
 Uc
 Eh
@@ -3970,7 +4064,7 @@ uM
 yh
 oq
 ED
-TO
+xo
 zg
 kJ
 fB
@@ -4006,7 +4100,7 @@ PL
 kt
 am
 da
-Wj
+UL
 tU
 NZ
 ED
@@ -4049,7 +4143,7 @@ eb
 eb
 dc
 Nz
-zg
+FO
 Hs
 yC
 Hs
@@ -4078,7 +4172,7 @@ NT
 mn
 Hs
 Hs
-Hs
+Yr
 Hs
 Hs
 wU
@@ -4101,7 +4195,7 @@ eb
 eb
 dc
 Nz
-rq
+Qn
 Hs
 Hs
 Hs
@@ -4240,7 +4334,7 @@ Hs
 wU
 Hs
 Ng
-Hs
+Yr
 QK
 LN
 ht
@@ -4343,8 +4437,8 @@ gA
 Hs
 es
 cs
-Kv
-Gc
+QM
+rq
 BN
 UX
 Vm
@@ -4372,7 +4466,7 @@ Hs
 Ng
 Bt
 TR
-Xf
+XO
 dc
 py
 Ep
@@ -4446,7 +4540,7 @@ lf
 Hm
 Hm
 Og
-De
+Xu
 nY
 DH
 gF
@@ -4464,7 +4558,7 @@ hh
 yw
 En
 Tz
-Tz
+Uw
 Tz
 Tz
 Tz
@@ -4491,7 +4585,7 @@ Kz
 De
 VK
 De
-Xu
+De
 De
 De
 Pk
@@ -4513,7 +4607,7 @@ ge
 KW
 nw
 TN
-VK
+jS
 VK
 NY
 Zw
@@ -4543,7 +4637,7 @@ fT
 hH
 hH
 OR
-Tz
+Uw
 vo
 Tz
 hk
@@ -4572,7 +4666,7 @@ gZ
 VE
 Tz
 Tz
-Xu
+De
 Gu
 Oc
 rG
@@ -4624,14 +4718,14 @@ rG
 od
 tJ
 Tz
-De
+Xu
 Gu
 oY
 rG
 UJ
 FY
 UJ
-cn
+dR
 Nx
 qG
 Oj
@@ -4649,14 +4743,14 @@ wL
 rG
 rG
 cM
-qH
+Tz
 De
 Gu
 wH
 rG
 cn
 UJ
-XF
+FY
 Go
 yZ
 qG
@@ -4707,7 +4801,7 @@ ee
 rG
 rG
 cn
-Go
+Ev
 UJ
 cn
 Go

--- a/maps/map_files/DesertDam/sprinkles/25.clftrijent.dmm
+++ b/maps/map_files/DesertDam/sprinkles/25.clftrijent.dmm
@@ -57,17 +57,15 @@
 	icon_state = "darkyellowcorners2"
 	},
 /area/desert_dam/interior/dam_interior/control_room)
-<<<<<<< master
 "bD" = (
 /obj/effect/spawner/random/attachment,
-/obj/effect/landmark/survivor_spawner/clf/generic,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor{
 	dir = 7;
 	icon_state = "warning"
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
-=======
->>>>>>> reimported backup
 "bJ" = (
 /turf/open/floor/prison{
 	dir = 10;
@@ -126,7 +124,6 @@
 	tag = "icon-floor (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
-<<<<<<< master
 "cq" = (
 /obj/effect/landmark/corpsespawner/clf,
 /obj/item/weapon/melee/twohanded/lungemine,
@@ -135,8 +132,6 @@
 	icon_state = "tile"
 	},
 /area/desert_dam/exterior/valley/south_valley_dam)
-=======
->>>>>>> reimported backup
 "cs" = (
 /obj/effect/blocker/toxic_water/Group_2,
 /turf/open/floor{
@@ -144,7 +139,6 @@
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
 "cw" = (
-<<<<<<< master
 /obj/effect/landmark/corpsespawner/clf,
 /obj/item/weapon/melee/katana,
 /obj/effect/decal/cleanable/blood,
@@ -163,32 +157,6 @@
 /obj/item/ammo_magazine/smg/fp9000,
 /obj/item/ammo_magazine/smg/fp9000,
 /obj/item/ammo_magazine/smg/fp9000,
-=======
-/obj/structure/surface/rack,
-/obj/item/ammo_magazine/rifle/mar40,
-/obj/item/ammo_magazine/rifle/mar40,
-/obj/item/ammo_magazine/rifle/mar40,
-/obj/item/ammo_magazine/rifle/mar40,
-/obj/item/ammo_magazine/rifle/mar40,
-/obj/item/ammo_magazine/rifle/mar40/lmg,
-/obj/item/ammo_magazine/rifle/mar40/lmg,
-/obj/item/ammo_magazine/rifle/mar40/lmg,
-/obj/item/ammo_magazine/rifle/mar40/lmg,
-/obj/item/ammo_magazine/rifle/mar40/lmg,
-/obj/item/weapon/gun/rifle/mar40/lmg,
-/obj/item/weapon/gun/rifle/mar40{
-	pixel_y = 6
-	},
-/turf/open/floor/prison{
-	dir = 10;
-	tag = "icon-floor (SOUTHWEST)"
-	},
-/area/desert_dam/interior/dam_interior/atmos_storage)
-"cz" = (
-/obj/effect/landmark/corpsespawner/engineer,
-/obj/item/weapon/melee/baseballbat/metal,
-/obj/effect/decal/cleanable/blood,
->>>>>>> reimported backup
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -203,10 +171,6 @@
 "cC" = (
 /obj/structure/window_frame/colony,
 /obj/structure/window_frame/colony,
-<<<<<<< master
-=======
-/obj/item/stack/rods,
->>>>>>> reimported backup
 /obj/item/shard{
 	icon_state = "medium"
 	},
@@ -272,18 +236,11 @@
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
 "dq" = (
-<<<<<<< master
 /obj/item/stack/tile/plasteel,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
 /area/desert_dam/exterior/valley/north_valley_dam)
-=======
-/obj/structure/window_frame/colony,
-/obj/item/stack/rods,
-/turf/open/floor/plating,
-/area/desert_dam/interior/dam_interior/smes_main)
->>>>>>> reimported backup
 "du" = (
 /turf/open/desert/dirt{
 	dir = 10;
@@ -336,16 +293,11 @@
 	dir = 1
 	},
 /obj/effect/landmark/corpsespawner/engineer,
-<<<<<<< master
 /obj/effect/decal/cleanable/blood,
 /obj/item/weapon/gun/rifle/m16{
 	pixel_x = 5;
 	pixel_y = 6
 	},
-=======
-/obj/item/weapon/melee/baseballbat/metal,
-/obj/effect/decal/cleanable/blood,
->>>>>>> reimported backup
 /turf/open/floor{
 	icon_state = "neutral"
 	},
@@ -408,7 +360,6 @@
 "eA" = (
 /obj/effect/blocker/toxic_water/Group_2,
 /obj/effect/landmark/corpsespawner/engineer,
-<<<<<<< master
 /obj/effect/decal/cleanable/blood,
 /obj/item/weapon/gun/rifle/hunting,
 /obj/item/ammo_magazine/rifle/hunting,
@@ -416,10 +367,6 @@
 /obj/item/ammo_magazine/rifle/hunting,
 /obj/item/ammo_magazine/rifle/hunting,
 /obj/item/ammo_magazine/rifle/hunting,
-=======
-/obj/item/weapon/melee/baseballbat/metal,
-/obj/effect/decal/cleanable/blood,
->>>>>>> reimported backup
 /turf/open/floor{
 	dir = 1;
 	icon_state = "warning"
@@ -453,12 +400,9 @@
 "fj" = (
 /obj/item/ammo_casing/bullet,
 /obj/effect/decal/cleanable/dirt,
-<<<<<<< master
 /obj/item/ammo_box/magazine/shotgun/buckshot,
 /obj/item/ammo_box/magazine/shotgun,
 /obj/item/ammo_magazine/shotgun/incendiary,
-=======
->>>>>>> reimported backup
 /turf/open/floor{
 	icon_state = "neutral"
 	},
@@ -483,29 +427,11 @@
 	},
 /area/desert_dam/interior/dam_interior/control_room)
 "fL" = (
-<<<<<<< master
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/asphalt{
 	icon_state = "tile"
 	},
 /area/desert_dam/exterior/valley/south_valley_dam)
-=======
-/obj/structure/surface/rack,
-/obj/item/weapon/gun/shotgun/pump/cmb{
-	pixel_y = -3
-	},
-/obj/item/weapon/gun/shotgun/pump/cmb{
-	pixel_y = 3
-	},
-/obj/item/weapon/gun/shotgun/pump/cmb{
-	pixel_y = 9
-	},
-/turf/open/floor/prison{
-	dir = 10;
-	tag = "icon-floor (SOUTHWEST)"
-	},
-/area/desert_dam/interior/dam_interior/atmos_storage)
->>>>>>> reimported backup
 "fM" = (
 /turf/closed/wall/hangar{
 	name = "reinforced metal wall"
@@ -548,7 +474,6 @@
 	icon_state = "tile"
 	},
 /area/desert_dam/exterior/valley/north_valley_dam)
-<<<<<<< master
 "gu" = (
 /obj/item/stack/sheet/wood,
 /turf/open/floor/prison{
@@ -557,8 +482,6 @@
 	tag = "icon-bright_clean (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/smes_main)
-=======
->>>>>>> reimported backup
 "gw" = (
 /obj/effect/decal/sand_overlay/sand1{
 	dir = 8
@@ -582,24 +505,12 @@
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 "gS" = (
-<<<<<<< master
 /obj/item/stack/sheet/wood,
 /turf/open/floor/prison{
 	dir = 1;
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/smes_main)
-=======
-/obj/structure/surface/rack,
-/obj/item/ammo_magazine/shotgun/slugs,
-/obj/item/ammo_magazine/shotgun/slugs,
-/obj/item/ammo_magazine/shotgun/slugs,
-/turf/open/floor/prison{
-	dir = 10;
-	tag = "icon-floor (SOUTHWEST)"
-	},
-/area/desert_dam/interior/dam_interior/atmos_storage)
->>>>>>> reimported backup
 "gU" = (
 /obj/structure/machinery/power/apc{
 	dir = 1;
@@ -629,10 +540,6 @@
 /area/desert_dam/interior/dam_interior/control_room)
 "hh" = (
 /obj/structure/window_frame/colony,
-<<<<<<< master
-=======
-/obj/item/stack/rods,
->>>>>>> reimported backup
 /turf/open/floor/plating,
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 "hk" = (
@@ -650,7 +557,6 @@
 	tag = "icon-bright_clean (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
-<<<<<<< master
 "hr" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
@@ -669,12 +575,6 @@
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
 /obj/item/explosive/mine/clf/active,
-=======
-"ht" = (
-/obj/item/stack/rods,
-/obj/effect/decal/cleanable/blood/oil,
-/obj/item/stack/cable_coil/cut,
->>>>>>> reimported backup
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -687,24 +587,11 @@
 	},
 /area/desert_dam/exterior/valley/south_valley_dam)
 "hH" = (
-<<<<<<< master
 /obj/item/stack/tile/plasteel,
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
-=======
-/obj/structure/surface/rack,
-/obj/item/ammo_magazine/shotgun/buckshot,
-/obj/item/ammo_magazine/shotgun/buckshot,
-/obj/item/ammo_magazine/shotgun/buckshot,
-/obj/item/ammo_magazine/shotgun/buckshot,
-/turf/open/floor/prison{
-	dir = 10;
-	tag = "icon-floor (SOUTHWEST)"
-	},
-/area/desert_dam/interior/dam_interior/atmos_storage)
->>>>>>> reimported backup
 "hJ" = (
 /obj/structure/pipes/standard/manifold/hidden/green{
 	dir = 4
@@ -758,15 +645,6 @@
 	icon_state = "warning"
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
-=======
-"iO" = (
-/obj/structure/bed,
-/turf/open/floor/prison{
-	dir = 10;
-	tag = "icon-floor (SOUTHWEST)"
-	},
-/area/desert_dam/interior/dam_interior/atmos_storage)
->>>>>>> reimported backup
 "jb" = (
 /obj/structure/machinery/colony_floodlight,
 /obj/effect/decal/sand_overlay/sand1/corner1{
@@ -871,10 +749,6 @@
 /area/desert_dam/interior/dam_interior/engine_room)
 "ki" = (
 /obj/structure/window_frame/colony,
-<<<<<<< master
-=======
-/obj/item/stack/rods,
->>>>>>> reimported backup
 /obj/item/shard{
 	icon_state = "medium"
 	},
@@ -893,10 +767,7 @@
 /obj/effect/landmark/corpsespawner/engineer,
 /obj/effect/decal/cleanable/blood,
 /obj/item/weapon/gun/smg/nailgun,
-<<<<<<< master
 /obj/item/clothing/accessory/storage/webbing,
-=======
->>>>>>> reimported backup
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -917,7 +788,6 @@
 	dir = 4
 	},
 /area/desert_dam/exterior/river/riverside_central_south)
-<<<<<<< master
 "kY" = (
 /obj/item/stack/tile/plasteel,
 /obj/item/explosive/mine/clf/active{
@@ -929,11 +799,6 @@
 /area/desert_dam/interior/dam_interior/engine_room)
 "lc" = (
 /obj/structure/disposalpipe/segment,
-=======
-"lc" = (
-/obj/structure/disposalpipe/segment,
-/obj/item/stack/rods,
->>>>>>> reimported backup
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
 /turf/open/floor/prison{
@@ -951,10 +816,8 @@
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 "lh" = (
-<<<<<<< master
-/obj/effect/landmark/survivor_spawner/clf/generic,
-=======
->>>>>>> reimported backup
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor{
 	dir = 5;
 	icon_state = "warning"
@@ -976,15 +839,12 @@
 	},
 /turf/open/floor/plating,
 /area/desert_dam/interior/dam_interior/smes_main)
-<<<<<<< master
 "lJ" = (
 /obj/item/stack/tile/plasteel,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
-=======
->>>>>>> reimported backup
 "lX" = (
 /obj/structure/platform{
 	dir = 4
@@ -994,34 +854,24 @@
 	dir = 4
 	},
 /area/desert_dam/exterior/river/riverside_central_south)
-<<<<<<< master
 "lY" = (
 /obj/item/stack/sheet/wood,
 /turf/open/floor/prison{
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/smes_backup)
-=======
->>>>>>> reimported backup
 "mj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
-<<<<<<< master
 /obj/item/shard{
 	icon_state = "medium"
 	},
 /obj/item/explosive/mine/clf/active{
 	dir = 8
 	},
-=======
-/obj/item/stack/rods,
-/obj/item/shard{
-	icon_state = "medium"
-	},
->>>>>>> reimported backup
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -1041,24 +891,18 @@
 "mu" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
-<<<<<<< master
 /obj/item/explosive/mine/clf/active,
-=======
->>>>>>> reimported backup
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
 	tag = "icon-bright_clean (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
-<<<<<<< master
 "mw" = (
 /obj/effect/blocker/toxic_water/Group_2,
 /obj/item/explosive/mine/clf/active,
 /turf/open/floor/greengrid,
 /area/desert_dam/interior/dam_interior/engine_room)
-=======
->>>>>>> reimported backup
 "mz" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/structure/disposalpipe/segment,
@@ -1111,7 +955,6 @@
 /obj/effect/blocker/toxic_water/Group_2,
 /turf/open/gm/river/desert/deep,
 /area/desert_dam/exterior/river/riverside_central_north)
-<<<<<<< master
 "na" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/attachment,
@@ -1119,8 +962,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/desert_dam/interior/dam_interior/control_room)
-=======
->>>>>>> reimported backup
 "ne" = (
 /obj/structure/platform{
 	dir = 4
@@ -1129,16 +970,14 @@
 /obj/effect/blocker/toxic_water/Group_1,
 /turf/open/gm/river/desert/deep,
 /area/desert_dam/exterior/river/riverside_central_south)
-<<<<<<< master
 "nk" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/survivor_spawner/clf/generic,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
 /area/desert_dam/interior/dam_interior/control_room)
-=======
->>>>>>> reimported backup
 "nq" = (
 /obj/structure/platform{
 	dir = 1
@@ -1148,11 +987,8 @@
 /area/desert_dam/exterior/river/riverside_central_south)
 "nr" = (
 /obj/effect/decal/cleanable/dirt,
-<<<<<<< master
 /obj/item/stack/tile/plasteel,
 /obj/effect/spawner/random/attachment,
-=======
->>>>>>> reimported backup
 /turf/open/floor/plating{
 	dir = 10;
 	icon_state = "warnplate"
@@ -1234,6 +1070,8 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -1347,20 +1185,10 @@
 	icon_state = "sandbag_2"
 	},
 /obj/effect/landmark/corpsespawner/security/cmb,
-<<<<<<< master
 /obj/item/ammo_casing/bullet,
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/blood,
 /obj/item/weapon/gun/rifle/m16,
-=======
-/obj/item/weapon/gun/rifle/hunting{
-	pixel_x = -5;
-	pixel_y = 7
-	},
-/obj/item/ammo_casing/bullet,
-/obj/effect/decal/cleanable/blood,
-/obj/effect/decal/cleanable/blood,
->>>>>>> reimported backup
 /turf/open/floor{
 	icon_state = "neutral"
 	},
@@ -1374,18 +1202,14 @@
 	icon_state = "darkyellowcorners2"
 	},
 /area/desert_dam/interior/dam_interior/control_room)
-<<<<<<< master
 "qD" = (
 /obj/item/explosive/mine/clf/active{
 	dir = 4
 	},
-/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor{
 	icon_state = "neutral"
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
-=======
->>>>>>> reimported backup
 "qE" = (
 /turf/open/floor/prison{
 	dir = 1;
@@ -1397,20 +1221,14 @@
 	name = "reinforced metal wall"
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
-<<<<<<< master
 "qH" = (
-/obj/structure/pipes/standard/simple/hidden/green,
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/survivor_spawner/clf/generic,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "bright_clean";
-	tag = "icon-bright_clean (SOUTHWEST)"
+	tag = "icon-floor (SOUTHWEST)"
 	},
-/area/desert_dam/interior/dam_interior/control_room)
-=======
->>>>>>> reimported backup
+/area/desert_dam/interior/dam_interior/engine_east_wing)
 "qJ" = (
 /turf/open/desert/dirt,
 /area/desert_dam/exterior/valley/north_valley_dam)
@@ -1448,25 +1266,14 @@
 /turf/open/gm/river/desert/deep,
 /area/desert_dam/exterior/river/riverside_central_south)
 "rq" = (
-<<<<<<< master
-/obj/structure/platform{
-	dir = 1
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "warning"
 	},
-/obj/structure/platform{
-	dir = 4
-	},
-/obj/effect/blocker/toxic_water/Group_2,
-/obj/effect/landmark/survivor_spawner/clf/generic,
-/turf/open/gm/river/desert/deep,
-/area/desert_dam/exterior/river/riverside_central_south)
-=======
-/obj/structure/machinery/cm_vending/sorted/tech/tool_storage,
-/turf/open/floor/prison{
-	dir = 10;
-	tag = "icon-floor (SOUTHWEST)"
-	},
-/area/desert_dam/interior/dam_interior/atmos_storage)
->>>>>>> reimported backup
+/area/desert_dam/interior/dam_interior/engine_room)
 "ru" = (
 /obj/structure/closet/toolcloset,
 /obj/structure/machinery/light{
@@ -1479,10 +1286,6 @@
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 "rv" = (
 /obj/structure/window_frame/colony,
-<<<<<<< master
-=======
-/obj/item/stack/rods,
->>>>>>> reimported backup
 /obj/item/shard{
 	icon_state = "medium"
 	},
@@ -1502,10 +1305,6 @@
 /area/desert_dam/exterior/river/riverside_central_north)
 "rA" = (
 /obj/structure/window_frame/colony,
-<<<<<<< master
-=======
-/obj/item/stack/rods,
->>>>>>> reimported backup
 /obj/item/shard{
 	icon_state = "medium"
 	},
@@ -1552,7 +1351,6 @@
 	},
 /area/desert_dam/interior/dam_interior/control_room)
 "rY" = (
-<<<<<<< master
 /obj/effect/blocker/toxic_water/Group_2,
 /obj/structure/barricade/metal/wired{
 	icon_state = "metal_1"
@@ -1562,16 +1360,6 @@
 	},
 /turf/open/gm/river/desert/deep/covered,
 /area/desert_dam/exterior/river/riverside_central_south)
-=======
-/obj/structure/surface/rack,
-/obj/item/ammo_magazine/shotgun/incendiary,
-/obj/item/ammo_magazine/shotgun/incendiary,
-/turf/open/floor/prison{
-	dir = 10;
-	tag = "icon-floor (SOUTHWEST)"
-	},
-/area/desert_dam/interior/dam_interior/atmos_storage)
->>>>>>> reimported backup
 "sf" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/structure/disposalpipe/segment{
@@ -1587,6 +1375,8 @@
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 "sk" = (
 /obj/item/ammo_casing/bullet,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -1596,10 +1386,6 @@
 "sq" = (
 /obj/effect/blocker/toxic_water/Group_2,
 /obj/structure/window_frame/colony,
-<<<<<<< master
-=======
-/obj/item/stack/rods,
->>>>>>> reimported backup
 /obj/item/shard{
 	icon_state = "medium"
 	},
@@ -1666,10 +1452,6 @@
 /area/desert_dam/interior/dam_interior/engine_room)
 "td" = (
 /obj/structure/window_frame/colony,
-<<<<<<< master
-=======
-/obj/item/stack/rods,
->>>>>>> reimported backup
 /obj/item/shard{
 	icon_state = "medium"
 	},
@@ -1680,7 +1462,6 @@
 	icon_state = "cement_sunbleached4"
 	},
 /area/desert_dam/exterior/valley/south_valley_dam)
-<<<<<<< master
 "tr" = (
 /obj/item/stack/rods,
 /obj/effect/decal/cleanable/blood/oil,
@@ -1694,8 +1475,6 @@
 	tag = "icon-bright_clean (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
-=======
->>>>>>> reimported backup
 "tx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -1720,14 +1499,11 @@
 	dir = 4;
 	icon_state = "sandbag_2"
 	},
-<<<<<<< master
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
-=======
->>>>>>> reimported backup
 /turf/open/floor{
 	icon_state = "neutral"
 	},
@@ -1756,42 +1532,12 @@
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
 "tN" = (
-<<<<<<< master
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/tile/plasteel,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
-=======
-/obj/structure/surface/rack,
-/obj/item/ammo_magazine/rifle/m16/ap{
-	pixel_x = -8
-	},
-/obj/item/ammo_magazine/rifle/m16/ap{
-	pixel_x = -8
-	},
-/obj/item/ammo_magazine/rifle/m16/ap{
-	pixel_x = -8
-	},
-/obj/item/ammo_magazine/rifle/m16/ap{
-	pixel_x = -8
-	},
-/obj/item/ammo_magazine/rifle/m16/ap{
-	pixel_x = -8
-	},
-/obj/item/weapon/gun/rifle/m16,
-/obj/item/weapon/gun/rifle/m16{
-	pixel_x = 5;
-	pixel_y = 6
-	},
-/obj/item/ammo_box/magazine/M16,
-/turf/open/floor/prison{
-	dir = 10;
-	tag = "icon-floor (SOUTHWEST)"
-	},
-/area/desert_dam/interior/dam_interior/atmos_storage)
->>>>>>> reimported backup
 "tP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -1845,7 +1591,6 @@
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/smes_backup)
-<<<<<<< master
 "vo" = (
 /obj/effect/spawner/random/attachment,
 /turf/open/floor/prison{
@@ -1853,7 +1598,6 @@
 	tag = "icon-floor (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
-=======
 "vr" = (
 /obj/effect/landmark/survivor_spawn,
 /turf/open/floor{
@@ -1930,16 +1674,10 @@
 "wY" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/corpsespawner/engineer,
-<<<<<<< master
 /obj/effect/decal/cleanable/blood,
 /obj/item/weapon/gun/shotgun/pump/cmb{
 	pixel_y = 9
 	},
-/obj/effect/landmark/survivor_spawner/clf/generic,
-=======
-/obj/item/weapon/melee/baseballbat,
-/obj/effect/decal/cleanable/blood,
->>>>>>> reimported backup
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -2040,14 +1778,11 @@
 	icon_state = "damaged3"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
-<<<<<<< master
 "ys" = (
 /obj/effect/landmark/corpsespawner/clf,
 /obj/item/weapon/melee/baseballbat/metal,
 /turf/open/desert/dirt,
 /area/desert_dam/exterior/valley/south_valley_dam)
-=======
->>>>>>> reimported backup
 "yw" = (
 /obj/structure/barricade/wooden{
 	dir = 1
@@ -2057,15 +1792,12 @@
 	icon_state = "darkyellowcorners2"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
-<<<<<<< master
 "yC" = (
 /obj/item/explosive/mine/clf/active,
 /turf/open/floor{
 	icon_state = "neutral"
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
-=======
->>>>>>> reimported backup
 "yM" = (
 /turf/open/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached14"
@@ -2074,7 +1806,6 @@
 "yX" = (
 /obj/effect/landmark/corpsespawner/security,
 /obj/effect/decal/cleanable/blood,
-<<<<<<< master
 /obj/item/weapon/gun/smg/fp9000{
 	pixel_y = -8
 	},
@@ -2083,9 +1814,6 @@
 /obj/item/ammo_magazine/smg/fp9000,
 /obj/item/ammo_magazine/smg/fp9000,
 /obj/item/ammo_magazine/smg/fp9000,
-=======
-/obj/item/weapon/gun/pistol/b92fs,
->>>>>>> reimported backup
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -2093,27 +1821,9 @@
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 "yZ" = (
-<<<<<<< master
 /obj/item/stack/tile/plasteel,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
-=======
-/obj/structure/surface/rack,
-/obj/item/weapon/gun/rifle/hunting,
-/obj/item/ammo_magazine/rifle/hunting,
-/obj/item/ammo_magazine/rifle/hunting,
-/obj/item/ammo_magazine/rifle/hunting,
-/obj/item/ammo_magazine/rifle/hunting,
-/obj/item/ammo_magazine/rifle/hunting,
-/obj/item/ammo_magazine/rifle/hunting,
-/obj/item/ammo_magazine/rifle/hunting,
-/obj/item/ammo_magazine/rifle/hunting,
-/obj/item/ammo_magazine/rifle/hunting,
-/obj/item/ammo_magazine/rifle/hunting,
-/turf/open/floor/prison{
-	dir = 10;
-	tag = "icon-floor (SOUTHWEST)"
->>>>>>> reimported backup
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
 "za" = (
@@ -2124,7 +1834,6 @@
 /obj/effect/blocker/toxic_water/Group_2,
 /turf/open/gm/river/desert/deep,
 /area/desert_dam/exterior/river/riverside_central_north)
-<<<<<<< master
 "zc" = (
 /obj/item/explosive/mine/clf/active{
 	dir = 4
@@ -2134,8 +1843,6 @@
 	tag = "icon-floor (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
-=======
->>>>>>> reimported backup
 "zd" = (
 /obj/structure/platform{
 	dir = 1
@@ -2159,10 +1866,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
-<<<<<<< master
-=======
-/obj/item/stack/rods,
->>>>>>> reimported backup
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -2177,15 +1880,10 @@
 /area/desert_dam/interior/dam_interior/engine_room)
 "zR" = (
 /obj/effect/decal/cleanable/blood/oil,
-<<<<<<< master
 /obj/item/stack/cable_coil/cut,
 /obj/item/explosive/mine/clf/active{
 	dir = 1
 	},
-=======
-/obj/item/stack/rods,
-/obj/item/stack/cable_coil/cut,
->>>>>>> reimported backup
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -2245,22 +1943,13 @@
 /turf/open/floor/plating,
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 "AV" = (
-<<<<<<< master
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/attachment,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor/greengrid,
 /area/desert_dam/interior/dam_interior/smes_main)
-=======
-/obj/structure/surface/rack,
-/obj/item/clothing/accessory/storage/webbing,
-/obj/item/clothing/accessory/storage/webbing,
-/turf/open/floor/prison{
-	dir = 10;
-	tag = "icon-floor (SOUTHWEST)"
-	},
-/area/desert_dam/interior/dam_interior/atmos_storage)
->>>>>>> reimported backup
 "Bi" = (
 /obj/structure/platform{
 	dir = 4
@@ -2328,7 +2017,6 @@
 	},
 /area/desert_dam/interior/dam_interior/smes_main)
 "Ce" = (
-<<<<<<< master
 /obj/item/explosive/mine/clf/active{
 	dir = 4
 	},
@@ -2340,9 +2028,6 @@
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 "Cu" = (
 /obj/item/stack/tile/plasteel,
-=======
-/obj/structure/machinery/cm_vending/sorted/tech/electronics_storage,
->>>>>>> reimported backup
 /turf/open/floor/prison{
 	dir = 10;
 	tag = "icon-floor (SOUTHWEST)"
@@ -2372,13 +2057,7 @@
 	},
 /area/desert_dam/interior/dam_interior/control_room)
 "CS" = (
-<<<<<<< master
 /obj/item/stack/sheet/wood,
-=======
-/obj/structure/barricade/wooden{
-	dir = 8
-	},
->>>>>>> reimported backup
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "darkyellowcorners2"
@@ -2521,10 +2200,6 @@
 "ED" = (
 /obj/effect/blocker/toxic_water/Group_1,
 /obj/structure/window_frame/colony,
-<<<<<<< master
-=======
-/obj/item/stack/rods,
->>>>>>> reimported backup
 /obj/item/shard{
 	icon_state = "medium"
 	},
@@ -2604,26 +2279,11 @@
 	},
 /area/desert_dam/interior/dam_interior/control_room)
 "FO" = (
-<<<<<<< master
-/obj/effect/landmark/survivor_spawner/clf/generic,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor{
 	dir = 1;
 	icon_state = "warning"
-=======
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/item/stack/rods,
-/obj/item/stack/cable_coil/cut,
-/obj/effect/decal/cleanable/blood/oil,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean";
-	tag = "icon-bright_clean (SOUTHWEST)"
->>>>>>> reimported backup
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
 "FR" = (
@@ -2634,7 +2294,6 @@
 /obj/effect/blocker/toxic_water/Group_1,
 /turf/open/gm/river/desert/deep,
 /area/desert_dam/exterior/river/riverside_central_north)
-<<<<<<< master
 "FY" = (
 /obj/item/stack/tile/plasteel,
 /turf/open/floor{
@@ -2642,8 +2301,6 @@
 	icon_state = "damaged3"
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
-=======
->>>>>>> reimported backup
 "Gb" = (
 /obj/structure/machinery/power/smes/buildable{
 	capacity = 1e+006;
@@ -2663,31 +2320,8 @@
 /turf/open/gm/river/desert/deep,
 /area/desert_dam/exterior/river/riverside_central_south)
 "Go" = (
-<<<<<<< master
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
-=======
-/obj/structure/surface/rack,
-/obj/item/weapon/gun/smg/fp9000{
-	pixel_y = 7
-	},
-/obj/item/weapon/gun/smg/fp9000{
-	pixel_y = -8
-	},
-/obj/item/ammo_magazine/smg/fp9000,
-/obj/item/ammo_magazine/smg/fp9000,
-/obj/item/ammo_magazine/smg/fp9000,
-/obj/item/ammo_magazine/smg/fp9000,
-/obj/item/ammo_magazine/smg/fp9000,
-/obj/item/ammo_magazine/smg/fp9000,
-/obj/item/ammo_magazine/smg/fp9000,
-/obj/item/ammo_magazine/smg/fp9000,
-/obj/item/ammo_magazine/smg/fp9000,
-/obj/item/ammo_magazine/smg/fp9000,
-/turf/open/floor/prison{
-	dir = 10;
-	tag = "icon-floor (SOUTHWEST)"
->>>>>>> reimported backup
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
 "Gr" = (
@@ -2710,15 +2344,12 @@
 	tag = "icon-bright_clean (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
-<<<<<<< master
 "Gz" = (
 /obj/effect/spawner/random/attachment,
 /turf/open/floor{
 	icon_state = "neutral"
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
-=======
->>>>>>> reimported backup
 "GM" = (
 /obj/structure/barricade/metal/wired{
 	icon_state = "metal_1";
@@ -2737,16 +2368,9 @@
 	},
 /area/desert_dam/interior/dam_interior/smes_main)
 "GW" = (
-<<<<<<< master
 /obj/effect/spawner/random/attachment,
 /turf/open/floor{
 	icon_state = "platingdmg1"
-=======
-/obj/structure/machinery/cm_vending/sorted/medical/no_access,
-/turf/open/floor/prison{
-	dir = 10;
-	tag = "icon-floor (SOUTHWEST)"
->>>>>>> reimported backup
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
 "Hb" = (
@@ -2795,24 +2419,17 @@
 	tag = "icon-bright_clean (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
-<<<<<<< master
 "Hw" = (
 /obj/item/stack/tile/plasteel,
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
-=======
->>>>>>> reimported backup
 "HB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
-<<<<<<< master
-=======
-/obj/item/stack/rods,
->>>>>>> reimported backup
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -2849,7 +2466,6 @@
 	tag = "icon-darkyellow2 (NORTH)"
 	},
 /area/desert_dam/interior/dam_interior/control_room)
-<<<<<<< master
 "IB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/sheet/wood,
@@ -2858,8 +2474,6 @@
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/smes_backup)
-=======
->>>>>>> reimported backup
 "ID" = (
 /obj/structure/platform{
 	dir = 4
@@ -2892,13 +2506,9 @@
 	},
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
-<<<<<<< master
 /obj/item/explosive/mine/clf/active{
 	dir = 8
 	},
-=======
-/obj/item/stack/rods,
->>>>>>> reimported backup
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -2979,15 +2589,8 @@
 	},
 /area/desert_dam/exterior/valley/north_valley_dam)
 "KY" = (
-<<<<<<< master
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/sheet/wood,
-=======
-/obj/structure/barricade/wooden{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
->>>>>>> reimported backup
 /turf/open/floor/plating{
 	dir = 8;
 	icon_state = "warnplate"
@@ -3075,7 +2678,6 @@
 /obj/item/shard{
 	icon_state = "medium"
 	},
-<<<<<<< master
 /turf/open/floor/plating,
 /area/desert_dam/interior/dam_interior/engine_room)
 "Ml" = (
@@ -3086,11 +2688,6 @@
 	icon_state = "neutral"
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
-=======
-/obj/item/stack/rods,
-/turf/open/floor/plating,
-/area/desert_dam/interior/dam_interior/engine_room)
->>>>>>> reimported backup
 "Mm" = (
 /obj/structure/machinery/power/smes/buildable{
 	capacity = 1e+006;
@@ -3112,10 +2709,6 @@
 /area/desert_dam/interior/dam_interior/engine_room)
 "Mw" = (
 /obj/structure/window_frame/colony,
-<<<<<<< master
-=======
-/obj/item/stack/rods,
->>>>>>> reimported backup
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -3179,7 +2772,6 @@
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
 "Nj" = (
-<<<<<<< master
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -3188,30 +2780,6 @@
 /turf/open/floor{
 	dir = 8;
 	icon_state = "damaged3"
-=======
-/obj/structure/surface/table/reinforced/prison,
-/obj/effect/spawner/random/attachment,
-/obj/effect/spawner/random/attachment,
-/obj/effect/spawner/random/attachment,
-/obj/effect/spawner/random/attachment,
-/obj/effect/spawner/random/attachment,
-/turf/open/floor/prison{
-	dir = 10;
-	tag = "icon-floor (SOUTHWEST)"
-	},
-/area/desert_dam/interior/dam_interior/atmos_storage)
-"Nx" = (
-/obj/structure/surface/table/reinforced/prison,
-/obj/item/clothing/glasses/welding,
-/obj/item/stack/sheet/metal/large_stack,
-/obj/item/stack/sheet/plasteel/large_stack,
-/obj/item/weapon/gun/smg/nailgun,
-/obj/item/ammo_magazine/smg/nailgun,
-/obj/item/ammo_magazine/smg/nailgun,
-/turf/open/floor/prison{
-	dir = 10;
-	tag = "icon-floor (SOUTHWEST)"
->>>>>>> reimported backup
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
 "Nz" = (
@@ -3311,7 +2879,6 @@
 	icon_state = "platingdmg1"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
-<<<<<<< master
 "OS" = (
 /obj/effect/landmark/corpsespawner/clf,
 /obj/item/weapon/gun/smg/fp9000{
@@ -3336,7 +2903,6 @@
 	tag = "icon-floor (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/control_room)
-<<<<<<< master
 "Pk" = (
 /obj/effect/landmark/corpsespawner/clf,
 /obj/item/weapon/melee/twohanded/lungemine,
@@ -3346,8 +2912,6 @@
 	tag = "icon-bright_clean (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
-=======
->>>>>>> reimported backup
 "Pr" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -3469,7 +3033,6 @@
 	icon_state = "tile"
 	},
 /area/desert_dam/exterior/valley/south_valley_dam)
-<<<<<<< master
 "QK" = (
 /obj/item/clothing/accessory/storage/webbing,
 /turf/open/floor{
@@ -3477,21 +3040,6 @@
 	icon_state = "warning"
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
-"QM" = (
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/blocker/toxic_water/Group_2,
-/obj/effect/landmark/survivor_spawner/clf/generic,
-/turf/open/floor{
-	icon_state = "neutral"
-	},
-/area/desert_dam/interior/dam_interior/engine_room)
-=======
->>>>>>> reimported backup
 "Rh" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
@@ -3509,15 +3057,10 @@
 	dir = 8
 	},
 /obj/effect/landmark/corpsespawner/security,
-<<<<<<< master
 /obj/effect/decal/cleanable/blood,
 /obj/item/weapon/gun/shotgun/pump/cmb{
 	pixel_y = 3
 	},
-=======
-/obj/item/weapon/gun/pistol/b92fs,
-/obj/effect/decal/cleanable/blood,
->>>>>>> reimported backup
 /turf/open/floor/prison{
 	dir = 8;
 	icon_state = "darkyellow2"
@@ -3589,10 +3132,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-<<<<<<< master
 /obj/item/stack/tile/plasteel,
-=======
->>>>>>> reimported backup
 /turf/open/floor{
 	dir = 8;
 	icon_state = "damaged3"
@@ -3621,6 +3161,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -3652,14 +3194,8 @@
 	},
 /area/desert_dam/interior/dam_interior/control_room)
 "Te" = (
-<<<<<<< master
 /obj/effect/decal/cleanable/blood/oil,
 /obj/effect/decal/cleanable/ash,
-=======
-/obj/structure/machinery/door/airlock/almayer/maint{
-	name = "\improper Atmospheric Storage"
-	},
->>>>>>> reimported backup
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -3669,10 +3205,6 @@
 "Th" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/effect/decal/cleanable/dirt,
-<<<<<<< master
-=======
-/obj/item/stack/rods,
->>>>>>> reimported backup
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
 /turf/open/floor/prison{
@@ -3728,15 +3260,10 @@
 /area/desert_dam/interior/dam_interior/engine_west_wing)
 "TN" = (
 /obj/effect/decal/cleanable/blood/oil,
-<<<<<<< master
 /obj/item/stack/cable_coil/cut,
 /obj/item/explosive/mine/clf/active{
 	dir = 1
 	},
-=======
-/obj/item/stack/rods,
-/obj/item/stack/cable_coil/cut,
->>>>>>> reimported backup
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -3756,20 +3283,11 @@
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
 "Uc" = (
-<<<<<<< master
-/obj/effect/landmark/survivor_spawner/clf/generic,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor{
 	dir = 8;
 	icon_state = "warning"
-=======
-/obj/item/stack/rods,
-/obj/item/stack/cable_coil/cut,
-/obj/effect/decal/cleanable/blood/oil,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean";
-	tag = "icon-bright_clean (SOUTHWEST)"
->>>>>>> reimported backup
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
 "Um" = (
@@ -3818,7 +3336,6 @@
 /area/desert_dam/interior/dam_interior/engine_room)
 "UI" = (
 /obj/effect/landmark/corpsespawner/engineer,
-<<<<<<< master
 /obj/effect/decal/cleanable/blood,
 /obj/item/weapon/gun/rifle/mar40{
 	pixel_y = 6
@@ -3828,11 +3345,6 @@
 /obj/item/ammo_magazine/rifle/mar40/lmg,
 /obj/item/ammo_magazine/rifle/mar40/lmg,
 /obj/item/ammo_magazine/rifle/mar40/lmg,
-/obj/effect/landmark/survivor_spawner/clf/generic,
-=======
-/obj/item/weapon/gun/pistol/m4a3,
-/obj/effect/decal/cleanable/blood,
->>>>>>> reimported backup
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -3840,26 +3352,8 @@
 	},
 /area/desert_dam/interior/dam_interior/smes_backup)
 "UJ" = (
-<<<<<<< master
 /turf/open/floor{
 	icon_state = "platingdmg1"
-	},
-/area/desert_dam/interior/dam_interior/atmos_storage)
-"UL" = (
-/obj/structure/platform{
-	dir = 1
-	},
-/obj/effect/blocker/toxic_water/Group_1,
-/obj/effect/landmark/survivor_spawner/clf/generic,
-/turf/open/gm/river/desert/deep,
-/area/desert_dam/exterior/river/riverside_central_south)
-=======
-/obj/structure/surface/table/reinforced/prison,
-/obj/item/storage/firstaid/regular,
-/obj/item/storage/firstaid/surgical,
-/turf/open/floor/prison{
-	dir = 10;
-	tag = "icon-floor (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
 >>>>>>> reimported backup
@@ -3901,10 +3395,7 @@
 /area/desert_dam/interior/dam_interior/engine_room)
 "Vp" = (
 /obj/structure/bed/stool,
-<<<<<<< master
 /obj/item/clothing/accessory/storage/webbing,
-=======
->>>>>>> reimported backup
 /turf/open/floor/prison{
 	dir = 10;
 	tag = "icon-floor (SOUTHWEST)"
@@ -3925,15 +3416,12 @@
 	icon_state = "darkyellowcorners2"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
-<<<<<<< master
 "VF" = (
 /obj/item/stack/tile/plasteel,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
 /area/desert_dam/interior/dam_interior/control_room)
-=======
->>>>>>> reimported backup
 "VG" = (
 /obj/structure/machinery/light{
 	dir = 4
@@ -3999,13 +3487,9 @@
 	dir = 8
 	},
 /obj/effect/landmark/corpsespawner/engineer,
-<<<<<<< master
 /obj/item/weapon/gun/shotgun/pump/cmb{
 	pixel_y = 9
 	},
-=======
-/obj/item/weapon/melee/baseballbat,
->>>>>>> reimported backup
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -4065,17 +3549,15 @@
 	tag = "icon-floor (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
-<<<<<<< master
 "Xu" = (
-/obj/effect/landmark/survivor_spawner/clf/generic,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
 	tag = "icon-bright_clean (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
-=======
->>>>>>> reimported backup
 "Xy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -4092,15 +3574,15 @@
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
-<<<<<<< master
 "XF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/survivor_spawner/clf/generic,
-/turf/open/floor/greengrid,
-/area/desert_dam/interior/dam_interior/smes_main)
-=======
->>>>>>> reimported backup
+/obj/item/stack/tile/plasteel,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "damaged3"
+	},
+/area/desert_dam/interior/dam_interior/atmos_storage)
 "XI" = (
 /obj/structure/surface/table,
 /obj/item/reagent_container/food/drinks/cans/thirteenloko,
@@ -4127,10 +3609,6 @@
 	dir = 4
 	},
 /obj/item/stack/cable_coil/cut,
-<<<<<<< master
-=======
-/obj/item/stack/rods,
->>>>>>> reimported backup
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/prison{
 	dir = 10;
@@ -4158,10 +3636,6 @@
 /area/desert_dam/interior/dam_interior/smes_main)
 "Yh" = (
 /obj/item/stack/cable_coil/cut,
-<<<<<<< master
-=======
-/obj/item/stack/rods,
->>>>>>> reimported backup
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/prison{
 	dir = 10;
@@ -4186,15 +3660,13 @@
 	},
 /turf/open/floor/plating,
 /area/desert_dam/interior/dam_interior/engine_room)
-<<<<<<< master
 "Yr" = (
-/obj/effect/landmark/survivor_spawner/clf/generic,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor{
 	icon_state = "neutral"
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
-=======
->>>>>>> reimported backup
 "Yt" = (
 /obj/effect/decal/sand_overlay/sand1,
 /turf/open/asphalt{
@@ -4238,10 +3710,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-<<<<<<< master
 /obj/item/stack/tile/plasteel,
-=======
->>>>>>> reimported backup
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -4256,7 +3725,6 @@
 	},
 /obj/effect/landmark/corpsespawner/security,
 /obj/effect/decal/cleanable/blood,
-<<<<<<< master
 /obj/item/weapon/gun/rifle/mar40{
 	pixel_y = 6
 	},
@@ -4265,9 +3733,6 @@
 /obj/item/ammo_magazine/rifle/mar40/lmg,
 /obj/item/ammo_magazine/rifle/mar40/lmg,
 /obj/item/ammo_magazine/rifle/mar40/lmg,
-=======
-/obj/item/weapon/gun/pistol/b92fs,
->>>>>>> reimported backup
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -4303,7 +3768,6 @@
 	tag = "icon-bright_clean (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
-<<<<<<< master
 "ZO" = (
 /obj/item/clothing/accessory/storage/webbing,
 /turf/open/floor/greengrid,
@@ -4331,22 +3795,6 @@
 /obj/item/explosive/mine/clf/active{
 	dir = 1
 	},
-=======
-"ZV" = (
-/obj/structure/barricade/plasteel/wired{
-	dir = 8
-	},
-/turf/open/floor/prison{
-	dir = 10;
-	tag = "icon-floor (SOUTHWEST)"
-	},
-/area/desert_dam/interior/dam_interior/atmos_storage)
-"ZW" = (
-/obj/item/stack/rods,
-/obj/effect/decal/cleanable/blood/oil,
-/obj/item/stack/cable_coil/cut,
-/obj/effect/decal/cleanable/blood/drip,
->>>>>>> reimported backup
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -4438,11 +3886,7 @@ ki
 "}
 (4,1,1) = {"
 rv
-<<<<<<< master
 gS
-=======
-Fr
->>>>>>> reimported backup
 Ro
 cR
 cR
@@ -4463,11 +3907,7 @@ CZ
 Zx
 MF
 fS
-<<<<<<< master
 lY
-=======
-Im
->>>>>>> reimported backup
 ki
 "}
 (5,1,1) = {"
@@ -4493,11 +3933,7 @@ RX
 oh
 Vb
 Mm
-<<<<<<< master
 IB
-=======
-xp
->>>>>>> reimported backup
 ki
 "}
 (6,1,1) = {"
@@ -4539,29 +3975,17 @@ rv
 Fr
 Ro
 Xy
-<<<<<<< master
 AV
 ZO
 cR
-XF
+Fw
 gu
-=======
-Fw
-cR
-cR
-Fw
-XU
->>>>>>> reimported backup
 rv
 CO
 Td
 Xd
 hb
-<<<<<<< master
 nk
-=======
-hb
->>>>>>> reimported backup
 ak
 pA
 ki
@@ -4590,13 +4014,8 @@ rv
 Iy
 EK
 Td
-<<<<<<< master
 VF
 na
-=======
-dQ
-NP
->>>>>>> reimported backup
 BL
 vG
 cC
@@ -4636,30 +4055,18 @@ Hp
 (10,1,1) = {"
 fM
 sG
-<<<<<<< master
 rv
 rv
-=======
-dq
-dq
->>>>>>> reimported backup
 sG
 fM
 rv
 pR
 rv
 dc
-<<<<<<< master
 Mh
 Mh
 Mh
 Mh
-=======
-Yq
-Yq
-Yq
-Yq
->>>>>>> reimported backup
 Yh
 XS
 Mh
@@ -4697,11 +4104,7 @@ St
 Xf
 wU
 Oj
-<<<<<<< master
 ys
-=======
-Oj
->>>>>>> reimported backup
 Oj
 fe
 "}
@@ -4728,17 +4131,16 @@ kY
 =======
 Xf
 KT
+Uc
 Eh
 Eh
+iO
 Eh
 Eh
-Eh
-Eh
-ek
+lJ
 tc
 sC
-ek
->>>>>>> reimported backup
+kY
 Xf
 dc
 Rz
@@ -4847,22 +4249,15 @@ yC
 =======
 zg
 Hs
->>>>>>> reimported backup
+yC
 Hs
 Hs
 Hs
 Hs
 Hs
-<<<<<<< master
 hr
 Hs
 bD
-=======
-Hs
-Ng
-Hs
-QD
->>>>>>> reimported backup
 Dp
 dc
 QJ
@@ -4896,15 +4291,9 @@ QD
 LN
 ht
 QJ
-<<<<<<< master
 cq
 fL
 fL
-=======
-QJ
-QJ
-QJ
->>>>>>> reimported backup
 "}
 (18,1,1) = {"
 eb
@@ -4914,7 +4303,7 @@ eb
 eb
 dc
 Nz
-Qn
+rq
 Hs
 Hs
 Hs
@@ -4969,25 +4358,15 @@ PD
 eA
 mq
 mq
-<<<<<<< master
 mw
 mq
 ZV
-=======
-mq
-mq
-cs
->>>>>>> reimported backup
 es
 ia
 RK
 nq
 rp
-<<<<<<< master
 rY
-=======
-UX
->>>>>>> reimported backup
 sq
 es
 nq
@@ -5021,15 +4400,9 @@ ez
 ez
 "}
 (22,1,1) = {"
-<<<<<<< master
 Nj
 Nj
 Nj
-=======
-eb
-eb
-eb
->>>>>>> reimported backup
 eb
 eb
 dc
@@ -5053,21 +4426,12 @@ QJ
 QJ
 "}
 (23,1,1) = {"
-<<<<<<< master
 Nj
 Nj
 dq
 Nj
 eb
 tr
-=======
-eb
-eb
-eb
-eb
-eb
-ht
->>>>>>> reimported backup
 UR
 Hs
 Hs
@@ -5083,13 +4447,11 @@ Yr
 QK
 =======
 Hs
-QD
->>>>>>> reimported backup
+QK
 LN
 ht
 QJ
 QJ
-<<<<<<< master
 cw
 fL
 "}
@@ -5111,29 +4473,6 @@ Yr
 Hs
 Ng
 Ml
-=======
-QJ
-QJ
-"}
-(24,1,1) = {"
-eb
-eb
-eb
-eb
-eb
-dc
-Nz
-zg
-Hs
-ep
-ek
-MQ
-Hs
-Hs
-Hs
-Ng
-Hs
->>>>>>> reimported backup
 QD
 Dp
 dc
@@ -5155,11 +4494,7 @@ Tm
 Zh
 Tm
 gA
-<<<<<<< master
 Gz
-=======
-Hs
->>>>>>> reimported backup
 es
 cs
 Kv
@@ -5242,11 +4577,7 @@ Bt
 Bt
 Bt
 Bt
-<<<<<<< master
 ZT
-=======
-Bt
->>>>>>> reimported backup
 Bt
 Hs
 Ng
@@ -5303,17 +4634,10 @@ dc
 Yq
 Yq
 dc
-<<<<<<< master
 Mh
 Yh
 XS
 Mh
-=======
-Yq
-Uc
-FO
-Yq
->>>>>>> reimported backup
 dc
 wU
 wU
@@ -5390,24 +4714,19 @@ Kz
 De
 VK
 De
+Xu
 De
 De
+Pk
 De
 <<<<<<< master
 Pk
 =======
 De
->>>>>>> reimported backup
-De
-De
 nz
 yX
 nY
-<<<<<<< master
 Xu
-=======
-De
->>>>>>> reimported backup
 De
 Ht
 mu
@@ -5451,30 +4770,18 @@ gr
 gw
 Mw
 fT
-<<<<<<< master
 hH
 hH
-OR
-Uw
-vo
-=======
-ph
-ph
 OR
 YO
-Tz
->>>>>>> reimported backup
+vo
 Tz
 hk
 Lr
 EH
 oj
 wA
-<<<<<<< master
 Ce
-=======
-De
->>>>>>> reimported backup
 De
 VG
 oW
@@ -5495,7 +4802,7 @@ gZ
 VE
 Tz
 Tz
-De
+Xu
 Gu
 Oc
 rG
@@ -5520,28 +4827,16 @@ rG
 rG
 pe
 Vp
-<<<<<<< master
 zc
-=======
-Tz
->>>>>>> reimported backup
 De
 Gu
 oY
 rG
-<<<<<<< master
 cn
 UJ
 cn
 GW
 cn
-=======
-Ce
-ZV
-ZV
-cn
-fL
->>>>>>> reimported backup
 qG
 Oj
 fe
@@ -5574,12 +4869,11 @@ De
 Gu
 oY
 rG
-rq
+UJ
+FY
+UJ
 cn
-cn
-cn
-cw
->>>>>>> reimported backup
+Nx
 qG
 Oj
 fe
@@ -5596,22 +4890,15 @@ wL
 rG
 rG
 cM
-Tz
+qH
 De
 Gu
 wH
 rG
-<<<<<<< master
 cn
 UJ
-FY
+XF
 Go
-=======
-iO
-cn
-cn
-cn
->>>>>>> reimported backup
 yZ
 qG
 Oj
@@ -5636,15 +4923,9 @@ wH
 rG
 UJ
 cn
-<<<<<<< master
 Go
 Go
 UJ
-=======
-cn
-cn
-tN
->>>>>>> reimported backup
 qG
 du
 fe
@@ -5666,15 +4947,9 @@ rG
 ee
 rG
 rG
-<<<<<<< master
 cn
-Ev
+Go
 UJ
-=======
-GW
-cn
-cn
->>>>>>> reimported backup
 cn
 Go
 qG
@@ -5699,17 +4974,10 @@ tx
 wL
 rG
 cn
-<<<<<<< master
 Hw
 Cu
 UJ
 cn
-=======
-cn
-cn
-cn
-gS
->>>>>>> reimported backup
 qG
 wL
 wL
@@ -5732,17 +5000,10 @@ tx
 wL
 rG
 Nx
-<<<<<<< master
 Go
 UJ
 Go
 cn
-=======
-AV
-Nj
-rY
-hH
->>>>>>> reimported backup
 qG
 wL
 wL

--- a/maps/map_files/DesertDam/sprinkles/25.clftrijent.dmm
+++ b/maps/map_files/DesertDam/sprinkles/25.clftrijent.dmm
@@ -57,6 +57,15 @@
 	icon_state = "darkyellowcorners2"
 	},
 /area/desert_dam/interior/dam_interior/control_room)
+"bD" = (
+/obj/effect/spawner/random/attachment,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/turf/open/floor{
+	dir = 7;
+	icon_state = "warning"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
 "bJ" = (
 /turf/open/floor/prison{
 	dir = 10;
@@ -115,6 +124,14 @@
 	tag = "icon-floor (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
+"cq" = (
+/obj/effect/landmark/corpsespawner/clf,
+/obj/item/weapon/melee/twohanded/lungemine,
+/obj/effect/decal/cleanable/blood,
+/turf/open/asphalt{
+	icon_state = "tile"
+	},
+/area/desert_dam/exterior/valley/south_valley_dam)
 "cs" = (
 /obj/effect/blocker/toxic_water/Group_2,
 /turf/open/floor{
@@ -122,30 +139,24 @@
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
 "cw" = (
-/obj/structure/surface/rack,
-/obj/item/ammo_magazine/rifle/mar40,
-/obj/item/ammo_magazine/rifle/mar40,
-/obj/item/ammo_magazine/rifle/mar40,
-/obj/item/ammo_magazine/rifle/mar40,
-/obj/item/ammo_magazine/rifle/mar40,
-/obj/item/ammo_magazine/rifle/mar40/lmg,
-/obj/item/ammo_magazine/rifle/mar40/lmg,
-/obj/item/ammo_magazine/rifle/mar40/lmg,
-/obj/item/ammo_magazine/rifle/mar40/lmg,
-/obj/item/ammo_magazine/rifle/mar40/lmg,
-/obj/item/weapon/gun/rifle/mar40/lmg,
-/obj/item/weapon/gun/rifle/mar40{
-	pixel_y = 6
+/obj/effect/landmark/corpsespawner/clf,
+/obj/item/weapon/melee/katana,
+/obj/effect/decal/cleanable/blood,
+/turf/open/asphalt{
+	icon_state = "tile"
 	},
-/turf/open/floor/prison{
-	dir = 10;
-	tag = "icon-floor (SOUTHWEST)"
-	},
-/area/desert_dam/interior/dam_interior/atmos_storage)
+/area/desert_dam/exterior/valley/south_valley_dam)
 "cz" = (
 /obj/effect/landmark/corpsespawner/engineer,
-/obj/item/weapon/melee/baseballbat/metal,
 /obj/effect/decal/cleanable/blood,
+/obj/item/weapon/gun/smg/fp9000{
+	pixel_y = 7
+	},
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -160,7 +171,6 @@
 "cC" = (
 /obj/structure/window_frame/colony,
 /obj/structure/window_frame/colony,
-/obj/item/stack/rods,
 /obj/item/shard{
 	icon_state = "medium"
 	},
@@ -226,10 +236,11 @@
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
 "dq" = (
-/obj/structure/window_frame/colony,
-/obj/item/stack/rods,
-/turf/open/floor/plating,
-/area/desert_dam/interior/dam_interior/smes_main)
+/obj/item/stack/tile/plasteel,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/desert_dam/exterior/valley/north_valley_dam)
 "du" = (
 /turf/open/desert/dirt{
 	dir = 10;
@@ -272,8 +283,11 @@
 	dir = 1
 	},
 /obj/effect/landmark/corpsespawner/engineer,
-/obj/item/weapon/melee/baseballbat/metal,
 /obj/effect/decal/cleanable/blood,
+/obj/item/weapon/gun/rifle/m16{
+	pixel_x = 5;
+	pixel_y = 6
+	},
 /turf/open/floor{
 	icon_state = "neutral"
 	},
@@ -336,8 +350,13 @@
 "eA" = (
 /obj/effect/blocker/toxic_water/Group_2,
 /obj/effect/landmark/corpsespawner/engineer,
-/obj/item/weapon/melee/baseballbat/metal,
 /obj/effect/decal/cleanable/blood,
+/obj/item/weapon/gun/rifle/hunting,
+/obj/item/ammo_magazine/rifle/hunting,
+/obj/item/ammo_magazine/rifle/hunting,
+/obj/item/ammo_magazine/rifle/hunting,
+/obj/item/ammo_magazine/rifle/hunting,
+/obj/item/ammo_magazine/rifle/hunting,
 /turf/open/floor{
 	dir = 1;
 	icon_state = "warning"
@@ -371,6 +390,9 @@
 "fj" = (
 /obj/item/ammo_casing/bullet,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/ammo_box/magazine/shotgun/buckshot,
+/obj/item/ammo_box/magazine/shotgun,
+/obj/item/ammo_magazine/shotgun/incendiary,
 /turf/open/floor{
 	icon_state = "neutral"
 	},
@@ -395,21 +417,11 @@
 	},
 /area/desert_dam/interior/dam_interior/control_room)
 "fL" = (
-/obj/structure/surface/rack,
-/obj/item/weapon/gun/shotgun/pump/cmb{
-	pixel_y = -3
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/asphalt{
+	icon_state = "tile"
 	},
-/obj/item/weapon/gun/shotgun/pump/cmb{
-	pixel_y = 3
-	},
-/obj/item/weapon/gun/shotgun/pump/cmb{
-	pixel_y = 9
-	},
-/turf/open/floor/prison{
-	dir = 10;
-	tag = "icon-floor (SOUTHWEST)"
-	},
-/area/desert_dam/interior/dam_interior/atmos_storage)
+/area/desert_dam/exterior/valley/south_valley_dam)
 "fM" = (
 /turf/closed/wall/hangar{
 	name = "reinforced metal wall"
@@ -452,6 +464,14 @@
 	icon_state = "tile"
 	},
 /area/desert_dam/exterior/valley/north_valley_dam)
+"gu" = (
+/obj/item/stack/sheet/wood,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/smes_main)
 "gw" = (
 /obj/effect/decal/sand_overlay/sand1{
 	dir = 8
@@ -475,15 +495,12 @@
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 "gS" = (
-/obj/structure/surface/rack,
-/obj/item/ammo_magazine/shotgun/slugs,
-/obj/item/ammo_magazine/shotgun/slugs,
-/obj/item/ammo_magazine/shotgun/slugs,
+/obj/item/stack/sheet/wood,
 /turf/open/floor/prison{
-	dir = 10;
-	tag = "icon-floor (SOUTHWEST)"
+	dir = 1;
+	icon_state = "darkyellow2"
 	},
-/area/desert_dam/interior/dam_interior/atmos_storage)
+/area/desert_dam/interior/dam_interior/smes_main)
 "gU" = (
 /obj/structure/machinery/power/apc{
 	dir = 1;
@@ -513,7 +530,6 @@
 /area/desert_dam/interior/dam_interior/control_room)
 "hh" = (
 /obj/structure/window_frame/colony,
-/obj/item/stack/rods,
 /turf/open/floor/plating,
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 "hk" = (
@@ -527,10 +543,24 @@
 	tag = "icon-bright_clean (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
+"hr" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/item/explosive/mine/clf/active{
+	dir = 4
+	},
+/turf/open/floor{
+	icon_state = "neutral"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
 "ht" = (
-/obj/item/stack/rods,
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
+/obj/item/explosive/mine/clf/active,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -543,16 +573,11 @@
 	},
 /area/desert_dam/exterior/valley/south_valley_dam)
 "hH" = (
-/obj/structure/surface/rack,
-/obj/item/ammo_magazine/shotgun/buckshot,
-/obj/item/ammo_magazine/shotgun/buckshot,
-/obj/item/ammo_magazine/shotgun/buckshot,
-/obj/item/ammo_magazine/shotgun/buckshot,
-/turf/open/floor/prison{
-	dir = 10;
-	tag = "icon-floor (SOUTHWEST)"
+/obj/item/stack/tile/plasteel,
+/turf/open/floor{
+	icon_state = "platingdmg1"
 	},
-/area/desert_dam/interior/dam_interior/atmos_storage)
+/area/desert_dam/interior/dam_interior/engine_east_wing)
 "hJ" = (
 /obj/structure/pipes/standard/manifold/hidden/green{
 	dir = 4
@@ -581,12 +606,21 @@
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
 "iO" = (
-/obj/structure/bed,
-/turf/open/floor/prison{
-	dir = 10;
-	tag = "icon-floor (SOUTHWEST)"
+/obj/effect/landmark/corpsespawner/engineer,
+/obj/item/tool/weldpack,
+/obj/item/tool/weldingtool{
+	pixel_y = -9;
+	pixel_x = 11
 	},
-/area/desert_dam/interior/dam_interior/atmos_storage)
+/obj/item/clothing/glasses/welding{
+	pixel_y = 9;
+	pixel_x = -12
+	},
+/turf/open/floor{
+	dir = 8;
+	icon_state = "warning"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
 "jb" = (
 /obj/structure/machinery/colony_floodlight,
 /obj/effect/decal/sand_overlay/sand1/corner1{
@@ -682,7 +716,6 @@
 /area/desert_dam/interior/dam_interior/engine_room)
 "ki" = (
 /obj/structure/window_frame/colony,
-/obj/item/stack/rods,
 /obj/item/shard{
 	icon_state = "medium"
 	},
@@ -701,6 +734,7 @@
 /obj/effect/landmark/corpsespawner/engineer,
 /obj/effect/decal/cleanable/blood,
 /obj/item/weapon/gun/smg/nailgun,
+/obj/item/clothing/accessory/storage/webbing,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -721,9 +755,17 @@
 	dir = 4
 	},
 /area/desert_dam/exterior/river/riverside_central_south)
+"kY" = (
+/obj/item/stack/tile/plasteel,
+/obj/item/explosive/mine/clf/active{
+	dir = 1
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
 "lc" = (
 /obj/structure/disposalpipe/segment,
-/obj/item/stack/rods,
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
 /turf/open/floor/prison{
@@ -741,6 +783,8 @@
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 "lh" = (
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor{
 	dir = 5;
 	icon_state = "warning"
@@ -762,6 +806,12 @@
 	},
 /turf/open/floor/plating,
 /area/desert_dam/interior/dam_interior/smes_main)
+"lJ" = (
+/obj/item/stack/tile/plasteel,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
 "lX" = (
 /obj/structure/platform{
 	dir = 4
@@ -771,15 +821,23 @@
 	dir = 4
 	},
 /area/desert_dam/exterior/river/riverside_central_south)
+"lY" = (
+/obj/item/stack/sheet/wood,
+/turf/open/floor/prison{
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/interior/dam_interior/smes_backup)
 "mj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
-/obj/item/stack/rods,
 /obj/item/shard{
 	icon_state = "medium"
+	},
+/obj/item/explosive/mine/clf/active{
+	dir = 8
 	},
 /turf/open/floor/prison{
 	dir = 10;
@@ -800,12 +858,18 @@
 "mu" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
+/obj/item/explosive/mine/clf/active,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
 	tag = "icon-bright_clean (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
+"mw" = (
+/obj/effect/blocker/toxic_water/Group_2,
+/obj/item/explosive/mine/clf/active,
+/turf/open/floor/greengrid,
+/area/desert_dam/interior/dam_interior/engine_room)
 "mz" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/structure/disposalpipe/segment,
@@ -846,6 +910,13 @@
 /obj/effect/blocker/toxic_water/Group_2,
 /turf/open/gm/river/desert/deep,
 /area/desert_dam/exterior/river/riverside_central_north)
+"na" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/attachment,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/desert_dam/interior/dam_interior/control_room)
 "ne" = (
 /obj/structure/platform{
 	dir = 4
@@ -854,6 +925,14 @@
 /obj/effect/blocker/toxic_water/Group_1,
 /turf/open/gm/river/desert/deep,
 /area/desert_dam/exterior/river/riverside_central_south)
+"nk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/desert_dam/interior/dam_interior/control_room)
 "nq" = (
 /obj/structure/platform{
 	dir = 1
@@ -863,6 +942,8 @@
 /area/desert_dam/exterior/river/riverside_central_south)
 "nr" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/item/stack/tile/plasteel,
+/obj/effect/spawner/random/attachment,
 /turf/open/floor/plating{
 	dir = 10;
 	icon_state = "warnplate"
@@ -944,6 +1025,8 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -1057,13 +1140,10 @@
 	icon_state = "sandbag_2"
 	},
 /obj/effect/landmark/corpsespawner/security/cmb,
-/obj/item/weapon/gun/rifle/hunting{
-	pixel_x = -5;
-	pixel_y = 7
-	},
 /obj/item/ammo_casing/bullet,
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/blood,
+/obj/item/weapon/gun/rifle/m16,
 /turf/open/floor{
 	icon_state = "neutral"
 	},
@@ -1077,6 +1157,14 @@
 	icon_state = "darkyellowcorners2"
 	},
 /area/desert_dam/interior/dam_interior/control_room)
+"qD" = (
+/obj/item/explosive/mine/clf/active{
+	dir = 4
+	},
+/turf/open/floor{
+	icon_state = "neutral"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
 "qE" = (
 /turf/open/floor/prison{
 	dir = 1;
@@ -1088,6 +1176,14 @@
 	name = "reinforced metal wall"
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
+"qH" = (
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
 "qJ" = (
 /turf/open/desert/dirt,
 /area/desert_dam/exterior/valley/north_valley_dam)
@@ -1125,12 +1221,14 @@
 /turf/open/gm/river/desert/deep,
 /area/desert_dam/exterior/river/riverside_central_south)
 "rq" = (
-/obj/structure/machinery/cm_vending/sorted/tech/tool_storage,
-/turf/open/floor/prison{
-	dir = 10;
-	tag = "icon-floor (SOUTHWEST)"
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "warning"
 	},
-/area/desert_dam/interior/dam_interior/atmos_storage)
+/area/desert_dam/interior/dam_interior/engine_room)
 "ru" = (
 /obj/structure/closet/toolcloset,
 /obj/structure/machinery/light{
@@ -1143,7 +1241,6 @@
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 "rv" = (
 /obj/structure/window_frame/colony,
-/obj/item/stack/rods,
 /obj/item/shard{
 	icon_state = "medium"
 	},
@@ -1163,7 +1260,6 @@
 /area/desert_dam/exterior/river/riverside_central_north)
 "rA" = (
 /obj/structure/window_frame/colony,
-/obj/item/stack/rods,
 /obj/item/shard{
 	icon_state = "medium"
 	},
@@ -1210,14 +1306,15 @@
 	},
 /area/desert_dam/interior/dam_interior/control_room)
 "rY" = (
-/obj/structure/surface/rack,
-/obj/item/ammo_magazine/shotgun/incendiary,
-/obj/item/ammo_magazine/shotgun/incendiary,
-/turf/open/floor/prison{
-	dir = 10;
-	tag = "icon-floor (SOUTHWEST)"
+/obj/effect/blocker/toxic_water/Group_2,
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1"
 	},
-/area/desert_dam/interior/dam_interior/atmos_storage)
+/obj/item/explosive/mine/clf/active{
+	dir = 1
+	},
+/turf/open/gm/river/desert/deep/covered,
+/area/desert_dam/exterior/river/riverside_central_south)
 "sf" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/structure/disposalpipe/segment{
@@ -1233,6 +1330,8 @@
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 "sk" = (
 /obj/item/ammo_casing/bullet,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -1242,7 +1341,6 @@
 "sq" = (
 /obj/effect/blocker/toxic_water/Group_2,
 /obj/structure/window_frame/colony,
-/obj/item/stack/rods,
 /obj/item/shard{
 	icon_state = "medium"
 	},
@@ -1305,7 +1403,6 @@
 /area/desert_dam/interior/dam_interior/engine_room)
 "td" = (
 /obj/structure/window_frame/colony,
-/obj/item/stack/rods,
 /obj/item/shard{
 	icon_state = "medium"
 	},
@@ -1316,6 +1413,19 @@
 	icon_state = "cement_sunbleached4"
 	},
 /area/desert_dam/exterior/valley/south_valley_dam)
+"tr" = (
+/obj/item/stack/rods,
+/obj/effect/decal/cleanable/blood/oil,
+/obj/item/stack/cable_coil/cut,
+/obj/item/explosive/mine/clf/active{
+	dir = 1
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
 "tx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -1340,6 +1450,11 @@
 	dir = 4;
 	icon_state = "sandbag_2"
 	},
+/obj/item/explosive/mine/clf,
+/obj/item/explosive/mine/clf,
+/obj/item/explosive/mine/clf,
+/obj/item/explosive/mine/clf,
+/obj/item/explosive/mine/clf,
 /turf/open/floor{
 	icon_state = "neutral"
 	},
@@ -1368,33 +1483,12 @@
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
 "tN" = (
-/obj/structure/surface/rack,
-/obj/item/ammo_magazine/rifle/m16/ap{
-	pixel_x = -8
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/tile/plasteel,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
 	},
-/obj/item/ammo_magazine/rifle/m16/ap{
-	pixel_x = -8
-	},
-/obj/item/ammo_magazine/rifle/m16/ap{
-	pixel_x = -8
-	},
-/obj/item/ammo_magazine/rifle/m16/ap{
-	pixel_x = -8
-	},
-/obj/item/ammo_magazine/rifle/m16/ap{
-	pixel_x = -8
-	},
-/obj/item/weapon/gun/rifle/m16,
-/obj/item/weapon/gun/rifle/m16{
-	pixel_x = 5;
-	pixel_y = 6
-	},
-/obj/item/ammo_box/magazine/M16,
-/turf/open/floor/prison{
-	dir = 10;
-	tag = "icon-floor (SOUTHWEST)"
-	},
-/area/desert_dam/interior/dam_interior/atmos_storage)
+/area/desert_dam/interior/dam_interior/engine_room)
 "tP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -1448,6 +1542,13 @@
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/smes_backup)
+"vo" = (
+/obj/effect/spawner/random/attachment,
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
 "vr" = (
 /obj/effect/landmark/survivor_spawn,
 /turf/open/floor{
@@ -1523,8 +1624,10 @@
 "wY" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/corpsespawner/engineer,
-/obj/item/weapon/melee/baseballbat,
 /obj/effect/decal/cleanable/blood,
+/obj/item/weapon/gun/shotgun/pump/cmb{
+	pixel_y = 9
+	},
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -1613,6 +1716,11 @@
 	icon_state = "damaged3"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
+"ys" = (
+/obj/effect/landmark/corpsespawner/clf,
+/obj/item/weapon/melee/baseballbat/metal,
+/turf/open/desert/dirt,
+/area/desert_dam/exterior/valley/south_valley_dam)
 "yw" = (
 /obj/structure/barricade/wooden{
 	dir = 1
@@ -1622,6 +1730,12 @@
 	icon_state = "darkyellowcorners2"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
+"yC" = (
+/obj/item/explosive/mine/clf/active,
+/turf/open/floor{
+	icon_state = "neutral"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
 "yM" = (
 /turf/open/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached14"
@@ -1630,7 +1744,14 @@
 "yX" = (
 /obj/effect/landmark/corpsespawner/security,
 /obj/effect/decal/cleanable/blood,
-/obj/item/weapon/gun/pistol/b92fs,
+/obj/item/weapon/gun/smg/fp9000{
+	pixel_y = -8
+	},
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -1638,21 +1759,9 @@
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 "yZ" = (
-/obj/structure/surface/rack,
-/obj/item/weapon/gun/rifle/hunting,
-/obj/item/ammo_magazine/rifle/hunting,
-/obj/item/ammo_magazine/rifle/hunting,
-/obj/item/ammo_magazine/rifle/hunting,
-/obj/item/ammo_magazine/rifle/hunting,
-/obj/item/ammo_magazine/rifle/hunting,
-/obj/item/ammo_magazine/rifle/hunting,
-/obj/item/ammo_magazine/rifle/hunting,
-/obj/item/ammo_magazine/rifle/hunting,
-/obj/item/ammo_magazine/rifle/hunting,
-/obj/item/ammo_magazine/rifle/hunting,
-/turf/open/floor/prison{
-	dir = 10;
-	tag = "icon-floor (SOUTHWEST)"
+/obj/item/stack/tile/plasteel,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
 "za" = (
@@ -1663,6 +1772,15 @@
 /obj/effect/blocker/toxic_water/Group_2,
 /turf/open/gm/river/desert/deep,
 /area/desert_dam/exterior/river/riverside_central_north)
+"zc" = (
+/obj/item/explosive/mine/clf/active{
+	dir = 4
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
 "zd" = (
 /obj/structure/platform{
 	dir = 1
@@ -1686,7 +1804,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
-/obj/item/stack/rods,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -1701,8 +1818,10 @@
 /area/desert_dam/interior/dam_interior/engine_room)
 "zR" = (
 /obj/effect/decal/cleanable/blood/oil,
-/obj/item/stack/rods,
 /obj/item/stack/cable_coil/cut,
+/obj/item/explosive/mine/clf/active{
+	dir = 1
+	},
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -1762,14 +1881,13 @@
 /turf/open/floor/plating,
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 "AV" = (
-/obj/structure/surface/rack,
-/obj/item/clothing/accessory/storage/webbing,
-/obj/item/clothing/accessory/storage/webbing,
-/turf/open/floor/prison{
-	dir = 10;
-	tag = "icon-floor (SOUTHWEST)"
-	},
-/area/desert_dam/interior/dam_interior/atmos_storage)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/attachment,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/turf/open/floor/greengrid,
+/area/desert_dam/interior/dam_interior/smes_main)
 "Bi" = (
 /obj/structure/platform{
 	dir = 4
@@ -1837,7 +1955,17 @@
 	},
 /area/desert_dam/interior/dam_interior/smes_main)
 "Ce" = (
-/obj/structure/machinery/cm_vending/sorted/tech/electronics_storage,
+/obj/item/explosive/mine/clf/active{
+	dir = 4
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"Cu" = (
+/obj/item/stack/tile/plasteel,
 /turf/open/floor/prison{
 	dir = 10;
 	tag = "icon-floor (SOUTHWEST)"
@@ -1867,9 +1995,7 @@
 	},
 /area/desert_dam/interior/dam_interior/control_room)
 "CS" = (
-/obj/structure/barricade/wooden{
-	dir = 8
-	},
+/obj/item/stack/sheet/wood,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "darkyellowcorners2"
@@ -2003,7 +2129,6 @@
 "ED" = (
 /obj/effect/blocker/toxic_water/Group_1,
 /obj/structure/window_frame/colony,
-/obj/item/stack/rods,
 /obj/item/shard{
 	icon_state = "medium"
 	},
@@ -2083,19 +2208,11 @@
 	},
 /area/desert_dam/interior/dam_interior/control_room)
 "FO" = (
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/item/stack/rods,
-/obj/item/stack/cable_coil/cut,
-/obj/effect/decal/cleanable/blood/oil,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean";
-	tag = "icon-bright_clean (SOUTHWEST)"
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "warning"
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
 "FR" = (
@@ -2106,6 +2223,13 @@
 /obj/effect/blocker/toxic_water/Group_1,
 /turf/open/gm/river/desert/deep,
 /area/desert_dam/exterior/river/riverside_central_north)
+"FY" = (
+/obj/item/stack/tile/plasteel,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "damaged3"
+	},
+/area/desert_dam/interior/dam_interior/atmos_storage)
 "Gb" = (
 /obj/structure/machinery/power/smes/buildable{
 	capacity = 1e+006;
@@ -2125,26 +2249,8 @@
 /turf/open/gm/river/desert/deep,
 /area/desert_dam/exterior/river/riverside_central_south)
 "Go" = (
-/obj/structure/surface/rack,
-/obj/item/weapon/gun/smg/fp9000{
-	pixel_y = 7
-	},
-/obj/item/weapon/gun/smg/fp9000{
-	pixel_y = -8
-	},
-/obj/item/ammo_magazine/smg/fp9000,
-/obj/item/ammo_magazine/smg/fp9000,
-/obj/item/ammo_magazine/smg/fp9000,
-/obj/item/ammo_magazine/smg/fp9000,
-/obj/item/ammo_magazine/smg/fp9000,
-/obj/item/ammo_magazine/smg/fp9000,
-/obj/item/ammo_magazine/smg/fp9000,
-/obj/item/ammo_magazine/smg/fp9000,
-/obj/item/ammo_magazine/smg/fp9000,
-/obj/item/ammo_magazine/smg/fp9000,
-/turf/open/floor/prison{
-	dir = 10;
-	tag = "icon-floor (SOUTHWEST)"
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
 "Gr" = (
@@ -2167,6 +2273,12 @@
 	tag = "icon-bright_clean (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
+"Gz" = (
+/obj/effect/spawner/random/attachment,
+/turf/open/floor{
+	icon_state = "neutral"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
 "GM" = (
 /obj/structure/barricade/metal/wired{
 	icon_state = "metal_1";
@@ -2185,10 +2297,9 @@
 	},
 /area/desert_dam/interior/dam_interior/smes_main)
 "GW" = (
-/obj/structure/machinery/cm_vending/sorted/medical/no_access,
-/turf/open/floor/prison{
-	dir = 10;
-	tag = "icon-floor (SOUTHWEST)"
+/obj/effect/spawner/random/attachment,
+/turf/open/floor{
+	icon_state = "platingdmg1"
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
 "Hb" = (
@@ -2237,12 +2348,17 @@
 	tag = "icon-bright_clean (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
+"Hw" = (
+/obj/item/stack/tile/plasteel,
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/desert_dam/interior/dam_interior/atmos_storage)
 "HB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
-/obj/item/stack/rods,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -2279,6 +2395,14 @@
 	tag = "icon-darkyellow2 (NORTH)"
 	},
 /area/desert_dam/interior/dam_interior/control_room)
+"IB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/sheet/wood,
+/obj/item/stack/sheet/wood,
+/turf/open/floor/prison{
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/interior/dam_interior/smes_backup)
 "ID" = (
 /obj/structure/platform{
 	dir = 4
@@ -2311,7 +2435,9 @@
 	},
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
-/obj/item/stack/rods,
+/obj/item/explosive/mine/clf/active{
+	dir = 8
+	},
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -2374,10 +2500,8 @@
 	},
 /area/desert_dam/exterior/valley/north_valley_dam)
 "KY" = (
-/obj/structure/barricade/wooden{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/item/stack/sheet/wood,
 /turf/open/floor/plating{
 	dir = 8;
 	icon_state = "warnplate"
@@ -2465,8 +2589,15 @@
 /obj/item/shard{
 	icon_state = "medium"
 	},
-/obj/item/stack/rods,
 /turf/open/floor/plating,
+/area/desert_dam/interior/dam_interior/engine_room)
+"Ml" = (
+/obj/item/explosive/mine/clf/active{
+	dir = 1
+	},
+/turf/open/floor{
+	icon_state = "neutral"
+	},
 /area/desert_dam/interior/dam_interior/engine_room)
 "Mm" = (
 /obj/structure/machinery/power/smes/buildable{
@@ -2489,7 +2620,6 @@
 /area/desert_dam/interior/dam_interior/engine_room)
 "Mw" = (
 /obj/structure/window_frame/colony,
-/obj/item/stack/rods,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -2542,28 +2672,14 @@
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
 "Nj" = (
-/obj/structure/surface/table/reinforced/prison,
-/obj/effect/spawner/random/attachment,
-/obj/effect/spawner/random/attachment,
-/obj/effect/spawner/random/attachment,
-/obj/effect/spawner/random/attachment,
-/obj/effect/spawner/random/attachment,
-/turf/open/floor/prison{
-	dir = 10;
-	tag = "icon-floor (SOUTHWEST)"
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
 	},
-/area/desert_dam/interior/dam_interior/atmos_storage)
+/area/desert_dam/exterior/valley/north_valley_dam)
 "Nx" = (
-/obj/structure/surface/table/reinforced/prison,
-/obj/item/clothing/glasses/welding,
-/obj/item/stack/sheet/metal/large_stack,
-/obj/item/stack/sheet/plasteel/large_stack,
-/obj/item/weapon/gun/smg/nailgun,
-/obj/item/ammo_magazine/smg/nailgun,
-/obj/item/ammo_magazine/smg/nailgun,
-/turf/open/floor/prison{
-	dir = 10;
-	tag = "icon-floor (SOUTHWEST)"
+/turf/open/floor{
+	dir = 8;
+	icon_state = "damaged3"
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
 "Nz" = (
@@ -2663,6 +2779,16 @@
 	icon_state = "platingdmg1"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
+"OS" = (
+/obj/effect/landmark/corpsespawner/clf,
+/obj/item/weapon/gun/smg/fp9000{
+	pixel_y = 7
+	},
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/desert_dam/exterior/valley/north_valley_dam)
 "OT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/ammo_casing/bullet,
@@ -2671,6 +2797,15 @@
 	tag = "icon-floor (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/control_room)
+"Pk" = (
+/obj/effect/landmark/corpsespawner/clf,
+/obj/item/weapon/melee/twohanded/lungemine,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
 "Pr" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -2788,6 +2923,13 @@
 	icon_state = "tile"
 	},
 /area/desert_dam/exterior/valley/south_valley_dam)
+"QK" = (
+/obj/item/clothing/accessory/storage/webbing,
+/turf/open/floor{
+	dir = 7;
+	icon_state = "warning"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
 "Rh" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
@@ -2805,8 +2947,10 @@
 	dir = 8
 	},
 /obj/effect/landmark/corpsespawner/security,
-/obj/item/weapon/gun/pistol/b92fs,
 /obj/effect/decal/cleanable/blood,
+/obj/item/weapon/gun/shotgun/pump/cmb{
+	pixel_y = 3
+	},
 /turf/open/floor/prison{
 	dir = 8;
 	icon_state = "darkyellow2"
@@ -2878,6 +3022,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/stack/tile/plasteel,
 /turf/open/floor{
 	dir = 8;
 	icon_state = "damaged3"
@@ -2906,6 +3051,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -2937,9 +3084,8 @@
 	},
 /area/desert_dam/interior/dam_interior/control_room)
 "Te" = (
-/obj/structure/machinery/door/airlock/almayer/maint{
-	name = "\improper Atmospheric Storage"
-	},
+/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/decal/cleanable/ash,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -2949,7 +3095,6 @@
 "Th" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/stack/rods,
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
 /turf/open/floor/prison{
@@ -3001,8 +3146,10 @@
 /area/desert_dam/interior/dam_interior/engine_west_wing)
 "TN" = (
 /obj/effect/decal/cleanable/blood/oil,
-/obj/item/stack/rods,
 /obj/item/stack/cable_coil/cut,
+/obj/item/explosive/mine/clf/active{
+	dir = 1
+	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -3022,13 +3169,11 @@
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
 "Uc" = (
-/obj/item/stack/rods,
-/obj/item/stack/cable_coil/cut,
-/obj/effect/decal/cleanable/blood/oil,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean";
-	tag = "icon-bright_clean (SOUTHWEST)"
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "warning"
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
 "Um" = (
@@ -3067,8 +3212,15 @@
 /area/desert_dam/interior/dam_interior/engine_room)
 "UI" = (
 /obj/effect/landmark/corpsespawner/engineer,
-/obj/item/weapon/gun/pistol/m4a3,
 /obj/effect/decal/cleanable/blood,
+/obj/item/weapon/gun/rifle/mar40{
+	pixel_y = 6
+	},
+/obj/item/ammo_magazine/rifle/mar40/lmg,
+/obj/item/ammo_magazine/rifle/mar40/lmg,
+/obj/item/ammo_magazine/rifle/mar40/lmg,
+/obj/item/ammo_magazine/rifle/mar40/lmg,
+/obj/item/ammo_magazine/rifle/mar40/lmg,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -3076,12 +3228,8 @@
 	},
 /area/desert_dam/interior/dam_interior/smes_backup)
 "UJ" = (
-/obj/structure/surface/table/reinforced/prison,
-/obj/item/storage/firstaid/regular,
-/obj/item/storage/firstaid/surgical,
-/turf/open/floor/prison{
-	dir = 10;
-	tag = "icon-floor (SOUTHWEST)"
+/turf/open/floor{
+	icon_state = "platingdmg1"
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
 "UR" = (
@@ -3122,6 +3270,7 @@
 /area/desert_dam/interior/dam_interior/engine_room)
 "Vp" = (
 /obj/structure/bed/stool,
+/obj/item/clothing/accessory/storage/webbing,
 /turf/open/floor/prison{
 	dir = 10;
 	tag = "icon-floor (SOUTHWEST)"
@@ -3142,6 +3291,12 @@
 	icon_state = "darkyellowcorners2"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
+"VF" = (
+/obj/item/stack/tile/plasteel,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/desert_dam/interior/dam_interior/control_room)
 "VG" = (
 /obj/structure/machinery/light{
 	dir = 4
@@ -3207,7 +3362,9 @@
 	dir = 8
 	},
 /obj/effect/landmark/corpsespawner/engineer,
-/obj/item/weapon/melee/baseballbat,
+/obj/item/weapon/gun/shotgun/pump/cmb{
+	pixel_y = 9
+	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -3267,6 +3424,15 @@
 	tag = "icon-floor (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
+"Xu" = (
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
 "Xy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -3283,6 +3449,15 @@
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
+"XF" = (
+/obj/item/stack/tile/plasteel,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "damaged3"
+	},
+/area/desert_dam/interior/dam_interior/atmos_storage)
 "XI" = (
 /obj/structure/surface/table,
 /obj/item/reagent_container/food/drinks/cans/thirteenloko,
@@ -3299,7 +3474,6 @@
 	dir = 4
 	},
 /obj/item/stack/cable_coil/cut,
-/obj/item/stack/rods,
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/prison{
 	dir = 10;
@@ -3327,7 +3501,6 @@
 /area/desert_dam/interior/dam_interior/smes_main)
 "Yh" = (
 /obj/item/stack/cable_coil/cut,
-/obj/item/stack/rods,
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/prison{
 	dir = 10;
@@ -3351,6 +3524,13 @@
 	icon_state = "medium"
 	},
 /turf/open/floor/plating,
+/area/desert_dam/interior/dam_interior/engine_room)
+"Yr" = (
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/turf/open/floor{
+	icon_state = "neutral"
+	},
 /area/desert_dam/interior/dam_interior/engine_room)
 "Yt" = (
 /obj/effect/decal/sand_overlay/sand1,
@@ -3392,6 +3572,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/item/stack/tile/plasteel,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -3406,7 +3587,14 @@
 	},
 /obj/effect/landmark/corpsespawner/security,
 /obj/effect/decal/cleanable/blood,
-/obj/item/weapon/gun/pistol/b92fs,
+/obj/item/weapon/gun/rifle/mar40{
+	pixel_y = 6
+	},
+/obj/item/ammo_magazine/rifle/mar40/lmg,
+/obj/item/ammo_magazine/rifle/mar40/lmg,
+/obj/item/ammo_magazine/rifle/mar40/lmg,
+/obj/item/ammo_magazine/rifle/mar40/lmg,
+/obj/item/ammo_magazine/rifle/mar40/lmg,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -3442,20 +3630,33 @@
 	tag = "icon-bright_clean (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
-"ZV" = (
-/obj/structure/barricade/plasteel/wired{
+"ZO" = (
+/obj/item/clothing/accessory/storage/webbing,
+/turf/open/floor/greengrid,
+/area/desert_dam/interior/dam_interior/smes_main)
+"ZT" = (
+/obj/item/explosive/mine/clf/active{
 	dir = 8
 	},
-/turf/open/floor/prison{
-	dir = 10;
-	tag = "icon-floor (SOUTHWEST)"
+/turf/open/floor{
+	dir = 4;
+	icon_state = "warning"
 	},
-/area/desert_dam/interior/dam_interior/atmos_storage)
+/area/desert_dam/interior/dam_interior/engine_room)
+"ZV" = (
+/obj/effect/blocker/toxic_water/Group_2,
+/obj/item/ammo_box/magazine/M16,
+/turf/open/floor{
+	icon_state = "neutral"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
 "ZW" = (
-/obj/item/stack/rods,
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
 /obj/effect/decal/cleanable/blood/drip,
+/obj/item/explosive/mine/clf/active{
+	dir = 1
+	},
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -3543,7 +3744,7 @@ ki
 "}
 (4,1,1) = {"
 rv
-Fr
+gS
 Ro
 cR
 cR
@@ -3564,7 +3765,7 @@ CZ
 Zx
 MF
 fS
-Im
+lY
 ki
 "}
 (5,1,1) = {"
@@ -3590,7 +3791,7 @@ RX
 oh
 Vb
 Mm
-xp
+IB
 ki
 "}
 (6,1,1) = {"
@@ -3624,17 +3825,17 @@ rv
 Fr
 Ro
 Xy
-Fw
+AV
+ZO
 cR
-cR
 Fw
-XU
+gu
 rv
 CO
 Td
 Xd
 hb
-hb
+nk
 ak
 pA
 ki
@@ -3659,8 +3860,8 @@ rv
 Iy
 EK
 Td
-dQ
-NP
+VF
+na
 BL
 vG
 cC
@@ -3700,18 +3901,18 @@ Hp
 (10,1,1) = {"
 fM
 sG
-dq
-dq
+rv
+rv
 sG
 fM
 rv
 pR
 rv
 dc
-Yq
-Yq
-Yq
-Yq
+Mh
+Mh
+Mh
+Mh
 Yh
 XS
 Mh
@@ -3745,7 +3946,7 @@ St
 Xf
 wU
 Oj
-Oj
+ys
 Oj
 fe
 "}
@@ -3758,16 +3959,16 @@ LD
 dc
 Xf
 KT
+Uc
 Eh
 Eh
+iO
 Eh
 Eh
-Eh
-Eh
-ek
+lJ
 tc
 sC
-ek
+kY
 Xf
 dc
 Rz
@@ -3863,15 +4064,15 @@ dc
 Nz
 zg
 Hs
+yC
 Hs
 Hs
 Hs
 Hs
 Hs
+hr
 Hs
-Ng
-Hs
-QD
+bD
 Dp
 dc
 QJ
@@ -3901,9 +4102,9 @@ QD
 LN
 ht
 QJ
-QJ
-QJ
-QJ
+cq
+fL
+fL
 "}
 (18,1,1) = {"
 eb
@@ -3913,7 +4114,7 @@ eb
 eb
 dc
 Nz
-Qn
+rq
 Hs
 Hs
 Hs
@@ -3968,15 +4169,15 @@ PD
 eA
 mq
 mq
+mw
 mq
-mq
-cs
+ZV
 es
 ia
 RK
 nq
 rp
-UX
+rY
 sq
 es
 nq
@@ -4010,9 +4211,9 @@ ez
 ez
 "}
 (22,1,1) = {"
-eb
-eb
-eb
+Nj
+Nj
+Nj
 eb
 eb
 dc
@@ -4036,12 +4237,12 @@ QJ
 QJ
 "}
 (23,1,1) = {"
+Nj
+Nj
+dq
+Nj
 eb
-eb
-eb
-eb
-eb
-ht
+tr
 UR
 Hs
 Hs
@@ -4053,32 +4254,32 @@ wU
 Hs
 Ng
 Hs
-QD
+QK
 LN
 ht
 QJ
 QJ
-QJ
-QJ
+cw
+fL
 "}
 (24,1,1) = {"
-eb
-eb
-eb
-eb
-eb
+dq
+OS
+Nj
+Nj
+Nj
 dc
 Nz
-zg
-Hs
+FO
+qD
 ep
 ek
-MQ
+tN
 Hs
-Hs
+Yr
 Hs
 Ng
-Hs
+Ml
 QD
 Dp
 dc
@@ -4100,7 +4301,7 @@ Tm
 Zh
 Tm
 gA
-Hs
+Gz
 es
 cs
 Kv
@@ -4178,7 +4379,7 @@ Bt
 Bt
 Bt
 Bt
-Bt
+ZT
 Bt
 Hs
 Ng
@@ -4231,10 +4432,10 @@ dc
 Yq
 Yq
 dc
-Yq
-Uc
-FO
-Yq
+Mh
+Yh
+XS
+Mh
 dc
 wU
 wU
@@ -4303,16 +4504,16 @@ Kz
 De
 VK
 De
+Xu
 De
 De
-De
-De
+Pk
 De
 De
 nz
 yX
 nY
-De
+Xu
 De
 Ht
 mu
@@ -4352,18 +4553,18 @@ gr
 gw
 Mw
 fT
-ph
-ph
+hH
+hH
 OR
 YO
-Tz
+vo
 Tz
 hk
 Lr
 EH
 oj
 wA
-De
+Ce
 De
 VG
 oW
@@ -4384,7 +4585,7 @@ gZ
 VE
 Tz
 Tz
-De
+Xu
 Gu
 Oc
 rG
@@ -4409,16 +4610,16 @@ rG
 rG
 pe
 Vp
-Tz
+zc
 De
 Gu
 oY
 rG
-Ce
-ZV
-ZV
 cn
-fL
+UJ
+cn
+GW
+cn
 qG
 Oj
 fe
@@ -4440,11 +4641,11 @@ De
 Gu
 oY
 rG
-rq
+UJ
+FY
+UJ
 cn
-cn
-cn
-cw
+Nx
 qG
 Oj
 fe
@@ -4461,15 +4662,15 @@ wL
 rG
 rG
 cM
-Tz
+qH
 De
 Gu
 wH
 rG
-iO
 cn
-cn
-cn
+UJ
+XF
+Go
 yZ
 qG
 Oj
@@ -4494,9 +4695,9 @@ wH
 rG
 UJ
 cn
-cn
-cn
-tN
+Go
+Go
+UJ
 qG
 du
 fe
@@ -4518,9 +4719,9 @@ rG
 ee
 rG
 rG
-GW
 cn
-cn
+Go
+UJ
 cn
 Go
 qG
@@ -4545,10 +4746,10 @@ tx
 wL
 rG
 cn
+Hw
+Cu
+UJ
 cn
-cn
-cn
-gS
 qG
 wL
 wL
@@ -4571,10 +4772,10 @@ tx
 wL
 rG
 Nx
-AV
-Nj
-rY
-hH
+Go
+UJ
+Go
+cn
 qG
 wL
 wL

--- a/maps/map_files/DesertDam/sprinkles/25.clftrijent.dmm
+++ b/maps/map_files/DesertDam/sprinkles/25.clftrijent.dmm
@@ -59,8 +59,7 @@
 /area/desert_dam/interior/dam_interior/control_room)
 "bD" = (
 /obj/effect/spawner/random/attachment,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor{
 	dir = 7;
 	icon_state = "warning"
@@ -273,7 +272,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/desert_dam/interior/dam_interior/control_room)
-<<<<<<< master
 "dR" = (
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/prison{
@@ -281,8 +279,6 @@
 	tag = "icon-floor (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
-=======
->>>>>>> reimported backup
 "dZ" = (
 /obj/structure/barricade/sandbags/wired{
 	icon_state = "sandbag_2";
@@ -547,10 +543,7 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
-=======
->>>>>>> reimported backup
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -619,7 +612,6 @@
 	name = "reinforced metal wall"
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
-<<<<<<< master
 "iD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/survivor_spawner/clf/generic,
@@ -717,15 +709,12 @@
 /obj/effect/blocker/toxic_water/Group_2,
 /turf/open/gm/river/desert/deep,
 /area/desert_dam/exterior/river/riverside_central_south)
-<<<<<<< master
 "jS" = (
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
-=======
->>>>>>> reimported backup
 "jY" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
@@ -816,8 +805,7 @@
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 "lh" = (
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor{
 	dir = 5;
 	icon_state = "warning"
@@ -913,7 +901,6 @@
 	tag = "icon-bright_clean (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/control_room)
-<<<<<<< master
 "mB" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/landmark/survivor_spawner/clf/generic,
@@ -923,8 +910,6 @@
 	tag = "icon-bright_clean (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/smes_main)
-=======
->>>>>>> reimported backup
 "mH" = (
 /obj/structure/surface/table,
 /obj/item/device/flashlight/flare,
@@ -972,8 +957,7 @@
 /area/desert_dam/exterior/river/riverside_central_south)
 "nk" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
@@ -1070,8 +1054,6 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -1206,6 +1188,7 @@
 /obj/item/explosive/mine/clf/active{
 	dir = 4
 	},
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor{
 	icon_state = "neutral"
 	},
@@ -1222,13 +1205,16 @@
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
 "qH" = (
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/structure/pipes/standard/simple/hidden/green,
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/prison{
 	dir = 10;
-	tag = "icon-floor (SOUTHWEST)"
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
 	},
-/area/desert_dam/interior/dam_interior/engine_east_wing)
+/area/desert_dam/interior/dam_interior/control_room)
 "qJ" = (
 /turf/open/desert/dirt,
 /area/desert_dam/exterior/valley/north_valley_dam)
@@ -1266,14 +1252,16 @@
 /turf/open/gm/river/desert/deep,
 /area/desert_dam/exterior/river/riverside_central_south)
 "rq" = (
-/obj/effect/decal/cleanable/blood/drip,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
-/turf/open/floor{
-	dir = 1;
-	icon_state = "warning"
+/obj/structure/platform{
+	dir = 1
 	},
-/area/desert_dam/interior/dam_interior/engine_room)
+/obj/structure/platform{
+	dir = 4
+	},
+/obj/effect/blocker/toxic_water/Group_2,
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/gm/river/desert/deep,
+/area/desert_dam/exterior/river/riverside_central_south)
 "ru" = (
 /obj/structure/closet/toolcloset,
 /obj/structure/machinery/light{
@@ -1375,8 +1363,6 @@
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 "sk" = (
 /obj/item/ammo_casing/bullet,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -1442,10 +1428,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
-=======
->>>>>>> reimported backup
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
@@ -1671,6 +1654,7 @@
 /obj/item/weapon/gun/shotgun/pump/cmb{
 	pixel_y = 9
 	},
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -1702,7 +1686,6 @@
 	icon_state = "neutral"
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
-<<<<<<< master
 "xo" = (
 /obj/effect/blocker/toxic_water/Group_1,
 /obj/structure/barricade/metal/wired{
@@ -1712,8 +1695,6 @@
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/gm/river/desert/deep/covered,
 /area/desert_dam/exterior/river/riverside_central_north)
-=======
->>>>>>> reimported backup
 "xp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade/wooden,
@@ -1939,8 +1920,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/attachment,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor/greengrid,
 /area/desert_dam/interior/dam_interior/smes_main)
 "Bi" = (
@@ -2164,15 +2143,12 @@
 	icon_state = "tile"
 	},
 /area/desert_dam/exterior/valley/north_valley_dam)
-<<<<<<< master
 "Ev" = (
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
-=======
->>>>>>> reimported backup
 "Ex" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -2272,8 +2248,7 @@
 	},
 /area/desert_dam/interior/dam_interior/control_room)
 "FO" = (
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor{
 	dir = 1;
 	icon_state = "warning"
@@ -2518,7 +2493,6 @@
 	tag = "icon-bright_clean (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/smes_main)
-<<<<<<< master
 "Kl" = (
 /obj/structure/barricade/metal/wired{
 	icon_state = "metal_1";
@@ -2530,8 +2504,6 @@
 	tag = "icon-floor (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
-=======
->>>>>>> reimported backup
 "Kv" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
@@ -2562,10 +2534,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
-=======
->>>>>>> reimported backup
 /turf/open/floor{
 	icon_state = "neutral"
 	},
@@ -2713,7 +2682,6 @@
 	icon_state = "warnplate"
 	},
 /area/desert_dam/interior/dam_interior/smes_backup)
-<<<<<<< master
 "MH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/survivor_spawner/clf/generic,
@@ -2722,10 +2690,6 @@
 "MQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/survivor_spawner/clf/generic,
-=======
-"MQ" = (
-/obj/effect/decal/cleanable/dirt,
->>>>>>> reimported backup
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -2886,11 +2850,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/ammo_casing/bullet,
 /obj/effect/landmark/survivor_spawner/clf/generic,
-=======
-"OT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/ammo_casing/bullet,
->>>>>>> reimported backup
 /turf/open/floor/prison{
 	dir = 10;
 	tag = "icon-floor (SOUTHWEST)"
@@ -2966,10 +2925,7 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
-=======
->>>>>>> reimported backup
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -3031,6 +2987,19 @@
 /turf/open/floor{
 	dir = 7;
 	icon_state = "warning"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"QM" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/blocker/toxic_water/Group_2,
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/floor{
+	icon_state = "neutral"
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
 "Rh" = (
@@ -3154,8 +3123,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -3232,10 +3199,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
-=======
->>>>>>> reimported backup
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -3276,8 +3240,7 @@
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
 "Uc" = (
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor{
 	dir = 8;
 	icon_state = "warning"
@@ -3301,7 +3264,6 @@
 	tag = "icon-floor (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/control_room)
-<<<<<<< master
 "Uw" = (
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/prison{
@@ -3309,8 +3271,6 @@
 	tag = "icon-floor (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
-=======
->>>>>>> reimported backup
 "Uy" = (
 /obj/structure/platform{
 	dir = 1
@@ -3338,6 +3298,7 @@
 /obj/item/ammo_magazine/rifle/mar40/lmg,
 /obj/item/ammo_magazine/rifle/mar40/lmg,
 /obj/item/ammo_magazine/rifle/mar40/lmg,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -3349,7 +3310,14 @@
 	icon_state = "platingdmg1"
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
->>>>>>> reimported backup
+"UL" = (
+/obj/structure/platform{
+	dir = 1
+	},
+/obj/effect/blocker/toxic_water/Group_1,
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/gm/river/desert/deep,
+/area/desert_dam/exterior/river/riverside_central_south)
 "UR" = (
 /obj/structure/barricade/plasteel/wired{
 	icon_state = "plasteel_3";
@@ -3543,8 +3511,7 @@
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
 "Xu" = (
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -3568,14 +3535,11 @@
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 "XF" = (
-/obj/item/stack/tile/plasteel,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
-/turf/open/floor{
-	dir = 8;
-	icon_state = "damaged3"
-	},
-/area/desert_dam/interior/dam_interior/atmos_storage)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/floor/greengrid,
+/area/desert_dam/interior/dam_interior/smes_main)
 "XI" = (
 /obj/structure/surface/table,
 /obj/item/reagent_container/food/drinks/cans/thirteenloko,
@@ -3584,7 +3548,6 @@
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
-<<<<<<< master
 "XO" = (
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/prison{
@@ -3592,8 +3555,6 @@
 	tag = "icon-floor (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
-=======
->>>>>>> reimported backup
 "XS" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
@@ -3654,8 +3615,7 @@
 /turf/open/floor/plating,
 /area/desert_dam/interior/dam_interior/engine_room)
 "Yr" = (
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor{
 	icon_state = "neutral"
 	},
@@ -3849,11 +3809,7 @@ ET
 ET
 zi
 mz
-<<<<<<< master
 qH
-=======
-mz
->>>>>>> reimported backup
 Sx
 mz
 fJ
@@ -3923,11 +3879,7 @@ ki
 rv
 Fr
 Ro
-<<<<<<< master
 MH
-=======
-TD
->>>>>>> reimported backup
 SJ
 lD
 SJ
@@ -3943,11 +3895,7 @@ DW
 qu
 ki
 Xe
-<<<<<<< master
 iD
-=======
-Qe
->>>>>>> reimported backup
 sk
 Qe
 xp
@@ -3961,7 +3909,7 @@ Xy
 AV
 ZO
 cR
-Fw
+XF
 gu
 rv
 CO
@@ -3986,11 +3934,7 @@ PB
 bJ
 Er
 Ee
-<<<<<<< master
 mB
-=======
-Ee
->>>>>>> reimported backup
 Kd
 XU
 rv
@@ -4074,11 +4018,7 @@ xg
 St
 xg
 xg
-<<<<<<< master
 Kl
-=======
-xg
->>>>>>> reimported backup
 xg
 PS
 Ws
@@ -4098,21 +4038,7 @@ LD
 LD
 LD
 dc
-<<<<<<< master
 XO
-KT
-Uc
-Eh
-Eh
-iO
-Eh
-Eh
-lJ
-tc
-sC
-kY
-=======
-Xf
 KT
 Uc
 Eh
@@ -4138,11 +4064,7 @@ uM
 yh
 oq
 ED
-<<<<<<< master
 xo
-=======
-TO
->>>>>>> reimported backup
 zg
 kJ
 fB
@@ -4178,11 +4100,7 @@ PL
 kt
 am
 da
-<<<<<<< master
 UL
-=======
-Wj
->>>>>>> reimported backup
 tU
 NZ
 ED
@@ -4225,12 +4143,7 @@ eb
 eb
 dc
 Nz
-<<<<<<< master
 FO
-Hs
-yC
-=======
-zg
 Hs
 yC
 Hs
@@ -4259,7 +4172,7 @@ NT
 mn
 Hs
 Hs
-Hs
+Yr
 Hs
 Hs
 wU
@@ -4282,7 +4195,7 @@ eb
 eb
 dc
 Nz
-rq
+Qn
 Hs
 Hs
 Hs
@@ -4421,11 +4334,7 @@ Hs
 wU
 Hs
 Ng
-<<<<<<< master
 Yr
-QK
-=======
-Hs
 QK
 LN
 ht
@@ -4528,13 +4437,8 @@ gA
 Hs
 es
 cs
-<<<<<<< master
 QM
 rq
-=======
-Kv
-Gc
->>>>>>> reimported backup
 BN
 UX
 Vm
@@ -4562,11 +4466,7 @@ Hs
 Ng
 Bt
 TR
-<<<<<<< master
 XO
-=======
-Xf
->>>>>>> reimported backup
 dc
 py
 Ep
@@ -4640,11 +4540,7 @@ lf
 Hm
 Hm
 Og
-<<<<<<< master
 Xu
-=======
-De
->>>>>>> reimported backup
 nY
 DH
 gF
@@ -4662,12 +4558,9 @@ hh
 yw
 En
 Tz
-<<<<<<< master
 Uw
-=======
 Tz
 >>>>>>> reimported backup
-Tz
 Tz
 Tz
 Tz
@@ -4693,7 +4586,7 @@ Kz
 De
 VK
 De
-Xu
+De
 De
 De
 Pk
@@ -4718,11 +4611,7 @@ ge
 KW
 nw
 TN
-<<<<<<< master
 jS
-=======
-VK
->>>>>>> reimported backup
 VK
 NY
 Zw
@@ -4752,7 +4641,7 @@ fT
 hH
 hH
 OR
-Tz
+Uw
 vo
 Tz
 hk
@@ -4781,7 +4670,7 @@ gZ
 VE
 Tz
 Tz
-Xu
+De
 Gu
 Oc
 rG
@@ -4833,7 +4722,6 @@ rG
 od
 tJ
 Tz
-<<<<<<< master
 Xu
 Gu
 oY
@@ -4842,16 +4730,6 @@ UJ
 FY
 UJ
 dR
-Nx
-=======
-De
-Gu
-oY
-rG
-UJ
-FY
-UJ
-cn
 Nx
 qG
 Oj
@@ -4869,14 +4747,14 @@ wL
 rG
 rG
 cM
-qH
+Tz
 De
 Gu
 wH
 rG
 cn
 UJ
-XF
+FY
 Go
 yZ
 qG
@@ -4927,7 +4805,7 @@ ee
 rG
 rG
 cn
-Go
+Ev
 UJ
 cn
 Go

--- a/maps/map_files/DesertDam/sprinkles/25.clftrijent.dmm
+++ b/maps/map_files/DesertDam/sprinkles/25.clftrijent.dmm
@@ -2135,6 +2135,7 @@
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 <<<<<<< master
+<<<<<<< master
 =======
 =======
 >>>>>>> updated all maps to have CLF Mines and corpses
@@ -2145,6 +2146,8 @@
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
 >>>>>>> reimported backup
+=======
+>>>>>>> updated CLF spawner
 "vG" = (
 /obj/structure/surface/table,
 /obj/structure/machinery/cell_charger,
@@ -4760,6 +4763,7 @@
 	},
 /area/desert_dam/exterior/valley/north_valley_dam)
 <<<<<<< master
+<<<<<<< master
 =======
 "YO" = (
 /obj/effect/landmark/survivor_spawn,
@@ -4769,6 +4773,8 @@
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 >>>>>>> reimported backup
+=======
+>>>>>>> updated CLF spawner
 "YY" = (
 /obj/item/stack/sheet/wood,
 /turf/open/floor/prison{
@@ -5526,10 +5532,14 @@ mn
 Hs
 Hs
 <<<<<<< master
+<<<<<<< master
 Yr
 =======
 vr
 >>>>>>> reimported backup
+=======
+Hs
+>>>>>>> updated CLF spawner
 Hs
 Hs
 wU
@@ -6179,7 +6189,7 @@ Tz
 hH
 hH
 OR
-YO
+Tz
 vo
 >>>>>>> updated all maps to have CLF Mines and corpses
 Tz

--- a/maps/map_files/DesertDam/sprinkles/25.clftrijent.dmm
+++ b/maps/map_files/DesertDam/sprinkles/25.clftrijent.dmm
@@ -1,0 +1,4609 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ac" = (
+/obj/item/stack/sheet/wood,
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "darkyellowcorners2"
+	},
+/area/desert_dam/interior/dam_interior/smes_main)
+"ak" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 8;
+	icon_state = "pipe-j2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/desert_dam/interior/dam_interior/control_room)
+"am" = (
+/obj/effect/blocker/toxic_water/Group_1,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"au" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/obj/item/stack/rods,
+/obj/effect/decal/cleanable/blood/oil,
+/obj/item/stack/cable_coil/cut,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/smes_main)
+"aX" = (
+/obj/structure/barricade/sandbags/wired{
+	icon_state = "sandbag_2";
+	dir = 8
+	},
+/obj/structure/machinery/m56d_hmg{
+	dir = 8
+	},
+/turf/open/floor{
+	icon_state = "neutral"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"bq" = (
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "darkyellowcorners2"
+	},
+/area/desert_dam/interior/dam_interior/control_room)
+"bJ" = (
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/smes_main)
+"bZ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/structure/barricade/wooden{
+	dir = 1
+	},
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/interior/dam_interior/smes_main)
+"ci" = (
+/obj/structure/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/structure/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/interior/dam_interior/smes_backup)
+"cj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/corpsespawner/engineer,
+/obj/item/weapon/melee/baton/cattleprod,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/smes_backup)
+"cl" = (
+/obj/effect/decal/sand_overlay/sand1/corner1{
+	dir = 1
+	},
+/turf/open/asphalt{
+	icon_state = "tile"
+	},
+/area/desert_dam/exterior/valley/south_valley_dam)
+"cn" = (
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/atmos_storage)
+"cs" = (
+/obj/effect/blocker/toxic_water/Group_2,
+/turf/open/floor{
+	icon_state = "neutral"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"cw" = (
+/obj/structure/surface/rack,
+/obj/item/ammo_magazine/rifle/mar40,
+/obj/item/ammo_magazine/rifle/mar40,
+/obj/item/ammo_magazine/rifle/mar40,
+/obj/item/ammo_magazine/rifle/mar40,
+/obj/item/ammo_magazine/rifle/mar40,
+/obj/item/ammo_magazine/rifle/mar40/lmg,
+/obj/item/ammo_magazine/rifle/mar40/lmg,
+/obj/item/ammo_magazine/rifle/mar40/lmg,
+/obj/item/ammo_magazine/rifle/mar40/lmg,
+/obj/item/ammo_magazine/rifle/mar40/lmg,
+/obj/item/weapon/gun/rifle/mar40/lmg,
+/obj/item/weapon/gun/rifle/mar40{
+	pixel_y = 6
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/atmos_storage)
+"cz" = (
+/obj/effect/landmark/corpsespawner/engineer,
+/obj/item/weapon/melee/baseballbat/metal,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/smes_main)
+"cA" = (
+/turf/open/floor/prison{
+	icon_state = "darkyellowcorners2"
+	},
+/area/desert_dam/interior/dam_interior/smes_main)
+"cC" = (
+/obj/structure/window_frame/colony,
+/obj/structure/window_frame/colony,
+/obj/item/stack/rods,
+/obj/item/shard{
+	icon_state = "medium"
+	},
+/turf/open/floor/plating,
+/area/desert_dam/interior/dam_interior/smes_backup)
+"cH" = (
+/obj/structure/platform{
+	dir = 8
+	},
+/obj/effect/blocker/toxic_water/Group_2,
+/turf/open/gm/river/desert/deep,
+/area/desert_dam/exterior/river/riverside_central_north)
+"cM" = (
+/obj/structure/surface/table,
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"cQ" = (
+/obj/structure/machinery/light{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/interior/dam_interior/smes_main)
+"cR" = (
+/turf/open/floor/greengrid,
+/area/desert_dam/interior/dam_interior/smes_main)
+"cS" = (
+/obj/structure/platform{
+	dir = 1
+	},
+/obj/effect/blocker/toxic_water/Group_2,
+/turf/open/gm/river/desert/deep,
+/area/desert_dam/exterior/river/riverside_central_north)
+"cX" = (
+/obj/structure/barricade/wooden,
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"da" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/blocker/toxic_water/Group_1,
+/turf/open/floor{
+	icon_state = "neutral"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"dc" = (
+/obj/structure/sign/poster/clf,
+/turf/closed/wall/hangar{
+	name = "reinforced metal wall"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"dq" = (
+/obj/structure/window_frame/colony,
+/obj/item/stack/rods,
+/turf/open/floor/plating,
+/area/desert_dam/interior/dam_interior/smes_main)
+"du" = (
+/turf/open/desert/dirt{
+	dir = 10;
+	icon_state = "desert_transition_edge1"
+	},
+/area/desert_dam/exterior/valley/south_valley_dam)
+"dv" = (
+/turf/open/desert/dirt{
+	icon_state = "desert_transition_edge1"
+	},
+/area/desert_dam/exterior/valley/south_valley_dam)
+"dH" = (
+/turf/open/floor{
+	dir = 8;
+	icon_state = "damaged3"
+	},
+/area/desert_dam/interior/dam_interior/control_room)
+"dI" = (
+/obj/structure/machinery/light{
+	dir = 4
+	},
+/obj/structure/barricade/wooden,
+/turf/open/floor/prison{
+	dir = 6;
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/interior/dam_interior/smes_backup)
+"dQ" = (
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/desert_dam/interior/dam_interior/control_room)
+"dZ" = (
+/obj/structure/barricade/sandbags/wired{
+	icon_state = "sandbag_2";
+	dir = 8
+	},
+/obj/structure/barricade/sandbags/wired{
+	icon_state = "sandbag_2";
+	dir = 1
+	},
+/obj/effect/landmark/corpsespawner/engineer,
+/obj/item/weapon/melee/baseballbat/metal,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor{
+	icon_state = "neutral"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"eb" = (
+/turf/open/asphalt{
+	icon_state = "tile"
+	},
+/area/desert_dam/exterior/valley/north_valley_dam)
+"ee" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/closed/wall/r_wall/bunker{
+	name = "reinforced metal wall"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"ek" = (
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"ep" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor{
+	icon_state = "neutral"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"er" = (
+/obj/structure/platform{
+	dir = 1
+	},
+/obj/structure/platform{
+	dir = 4
+	},
+/obj/effect/blocker/toxic_water/Group_1,
+/turf/open/gm/river/desert/deep,
+/area/desert_dam/exterior/river/riverside_central_south)
+"es" = (
+/obj/effect/blocker/toxic_water/Group_2,
+/turf/open/gm/river/desert/deep/covered,
+/area/desert_dam/exterior/river/riverside_central_south)
+"eu" = (
+/obj/structure/platform{
+	dir = 1
+	},
+/obj/structure/platform{
+	dir = 8
+	},
+/obj/effect/blocker/toxic_water/Group_2,
+/turf/open/gm/river/desert/deep,
+/area/desert_dam/exterior/river/riverside_central_north)
+"ez" = (
+/obj/structure/platform{
+	dir = 4
+	},
+/obj/effect/blocker/toxic_water/Group_2,
+/turf/open/gm/river/desert/deep,
+/area/desert_dam/exterior/river/riverside_central_south)
+"eA" = (
+/obj/effect/blocker/toxic_water/Group_2,
+/obj/effect/landmark/corpsespawner/engineer,
+/obj/item/weapon/melee/baseballbat/metal,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "warning"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"eC" = (
+/obj/effect/blocker/toxic_water/Group_1,
+/turf/open/gm/river/desert/deep/covered,
+/area/desert_dam/exterior/river/riverside_central_north)
+"eD" = (
+/obj/structure/platform{
+	dir = 8
+	},
+/obj/structure/platform,
+/obj/effect/blocker/toxic_water/Group_2,
+/turf/open/gm/river/desert/deep,
+/area/desert_dam/exterior/river/riverside_central_north)
+"fb" = (
+/turf/closed/wall/hangar{
+	name = "reinforced metal wall"
+	},
+/area/desert_dam/interior/dam_interior/control_room)
+"fe" = (
+/obj/effect/decal/sand_overlay/sand1{
+	dir = 1
+	},
+/turf/open/asphalt{
+	icon_state = "tile"
+	},
+/area/desert_dam/exterior/valley/south_valley_dam)
+"fj" = (
+/obj/item/ammo_casing/bullet,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor{
+	icon_state = "neutral"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"fB" = (
+/obj/structure/machinery/power/geothermal,
+/obj/structure/lattice{
+	layer = 2.9
+	},
+/turf/open/floor/plating,
+/area/desert_dam/interior/dam_interior/engine_room)
+"fJ" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/pipes/standard/manifold/hidden/green{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/control_room)
+"fL" = (
+/obj/structure/surface/rack,
+/obj/item/weapon/gun/shotgun/pump/cmb{
+	pixel_y = -3
+	},
+/obj/item/weapon/gun/shotgun/pump/cmb{
+	pixel_y = 3
+	},
+/obj/item/weapon/gun/shotgun/pump/cmb{
+	pixel_y = 9
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/atmos_storage)
+"fM" = (
+/turf/closed/wall/hangar{
+	name = "reinforced metal wall"
+	},
+/area/desert_dam/interior/dam_interior/smes_main)
+"fN" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/smes_main)
+"fS" = (
+/obj/structure/machinery/power/smes/buildable{
+	capacity = 1e+006;
+	dir = 1
+	},
+/turf/open/floor/plating{
+	dir = 10;
+	icon_state = "warnplate"
+	},
+/area/desert_dam/interior/dam_interior/smes_backup)
+"fT" = (
+/obj/item/stack/sheet/wood,
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"ge" = (
+/turf/open/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached12"
+	},
+/area/desert_dam/exterior/valley/south_valley_dam)
+"gr" = (
+/obj/effect/decal/sand_overlay/sand1/corner1,
+/turf/open/asphalt{
+	icon_state = "tile"
+	},
+/area/desert_dam/exterior/valley/north_valley_dam)
+"gw" = (
+/obj/effect/decal/sand_overlay/sand1{
+	dir = 8
+	},
+/turf/open/asphalt{
+	icon_state = "tile"
+	},
+/area/desert_dam/exterior/valley/north_valley_dam)
+"gA" = (
+/turf/open/floor/greengrid,
+/area/desert_dam/interior/dam_interior/engine_room)
+"gF" = (
+/obj/structure/surface/table,
+/obj/structure/machinery/light{
+	dir = 8;
+	tag = "icon-tube1 (EAST)"
+	},
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"gS" = (
+/obj/structure/surface/rack,
+/obj/item/ammo_magazine/shotgun/slugs,
+/obj/item/ammo_magazine/shotgun/slugs,
+/obj/item/ammo_magazine/shotgun/slugs,
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/atmos_storage)
+"gU" = (
+/obj/structure/machinery/power/apc{
+	dir = 1;
+	pixel_y = 24;
+	start_charge = 0
+	},
+/turf/open/floor{
+	icon_state = "neutral"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"gV" = (
+/turf/open/gm/empty,
+/area/shuttle/tri_trans1/omega)
+"gZ" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"hb" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/desert_dam/interior/dam_interior/control_room)
+"hh" = (
+/obj/structure/window_frame/colony,
+/obj/item/stack/rods,
+/turf/open/floor/plating,
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"hk" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"ht" = (
+/obj/item/stack/rods,
+/obj/effect/decal/cleanable/blood/oil,
+/obj/item/stack/cable_coil/cut,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"hw" = (
+/turf/open/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached3"
+	},
+/area/desert_dam/exterior/valley/south_valley_dam)
+"hH" = (
+/obj/structure/surface/rack,
+/obj/item/ammo_magazine/shotgun/buckshot,
+/obj/item/ammo_magazine/shotgun/buckshot,
+/obj/item/ammo_magazine/shotgun/buckshot,
+/obj/item/ammo_magazine/shotgun/buckshot,
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/atmos_storage)
+"hJ" = (
+/obj/structure/pipes/standard/manifold/hidden/green{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"ia" = (
+/obj/effect/blocker/toxic_water/Group_2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor{
+	icon_state = "neutral"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"iv" = (
+/obj/structure/sign/poster/clf,
+/turf/closed/wall/r_wall/bunker{
+	name = "reinforced metal wall"
+	},
+/area/desert_dam/interior/dam_interior/atmos_storage)
+"iO" = (
+/obj/structure/bed,
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/atmos_storage)
+"jb" = (
+/obj/structure/machinery/colony_floodlight,
+/obj/effect/decal/sand_overlay/sand1/corner1{
+	dir = 8
+	},
+/turf/open/asphalt{
+	icon_state = "tile"
+	},
+/area/desert_dam/exterior/valley/north_valley_dam)
+"jd" = (
+/obj/structure/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"jl" = (
+/obj/structure/platform{
+	dir = 4
+	},
+/obj/effect/blocker/toxic_water/Group_1,
+/turf/open/gm/river/desert/deep,
+/area/desert_dam/exterior/river/riverside_central_north)
+"jq" = (
+/obj/structure/platform{
+	dir = 4
+	},
+/obj/structure/platform,
+/obj/effect/blocker/toxic_water/Group_2,
+/turf/open/gm/river/desert/shallow_edge{
+	dir = 4
+	},
+/area/desert_dam/exterior/river/riverside_central_north)
+"js" = (
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1";
+	dir = 8
+	},
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"jw" = (
+/obj/effect/blocker/toxic_water/Group_2,
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"jx" = (
+/obj/effect/blocker/toxic_water/Group_1,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "warning"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"jz" = (
+/obj/effect/landmark/corpsespawner/doctor,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"jL" = (
+/obj/structure/platform{
+	dir = 8
+	},
+/obj/structure/platform,
+/obj/effect/blocker/toxic_water/Group_2,
+/turf/open/gm/river/desert/deep,
+/area/desert_dam/exterior/river/riverside_central_south)
+"jY" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/barricade/sandbags/wired{
+	icon_state = "sandbag_2"
+	},
+/obj/structure/barricade/sandbags/wired{
+	dir = 4;
+	icon_state = "sandbag_2"
+	},
+/obj/structure/machinery/m56d_hmg{
+	dir = 4
+	},
+/turf/open/floor{
+	icon_state = "neutral"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"ki" = (
+/obj/structure/window_frame/colony,
+/obj/item/stack/rods,
+/obj/item/shard{
+	icon_state = "medium"
+	},
+/turf/open/floor/plating,
+/area/desert_dam/interior/dam_interior/smes_backup)
+"kt" = (
+/obj/effect/blocker/toxic_water/Group_1,
+/turf/open/gm/river/desert/deep/covered,
+/area/desert_dam/exterior/river/riverside_central_south)
+"ku" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/corpsespawner/engineer,
+/obj/effect/decal/cleanable/blood,
+/obj/item/weapon/gun/smg/nailgun,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/smes_backup)
+"kv" = (
+/obj/effect/blocker/toxic_water/Group_2,
+/turf/open/gm/river/desert/deep/covered,
+/area/desert_dam/exterior/river/riverside_central_north)
+"kJ" = (
+/obj/structure/machinery/power/geothermal,
+/turf/open/floor/plating,
+/area/desert_dam/interior/dam_interior/engine_room)
+"kQ" = (
+/obj/effect/blocker/toxic_water/Group_2,
+/turf/open/gm/river/desert/shallow_edge/covered{
+	dir = 4
+	},
+/area/desert_dam/exterior/river/riverside_central_south)
+"lc" = (
+/obj/structure/disposalpipe/segment,
+/obj/item/stack/rods,
+/obj/effect/decal/cleanable/blood/oil,
+/obj/item/stack/cable_coil/cut,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/smes_backup)
+"lf" = (
+/obj/structure/surface/table,
+/obj/item/storage/box/lights/mixed,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"lh" = (
+/turf/open/floor{
+	dir = 5;
+	icon_state = "warning"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"lt" = (
+/obj/structure/machinery/power/port_gen/pacman,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating{
+	dir = 8;
+	icon_state = "warnplate"
+	},
+/area/desert_dam/interior/dam_interior/smes_backup)
+"lD" = (
+/obj/structure/machinery/power/terminal{
+	dir = 8;
+	tag = "icon-term (WEST)"
+	},
+/turf/open/floor/plating,
+/area/desert_dam/interior/dam_interior/smes_main)
+"lX" = (
+/obj/structure/platform{
+	dir = 4
+	},
+/obj/effect/blocker/toxic_water/Group_2,
+/turf/open/gm/river/desert/shallow_edge{
+	dir = 4
+	},
+/area/desert_dam/exterior/river/riverside_central_south)
+"mj" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/oil,
+/obj/item/stack/cable_coil/cut,
+/obj/item/stack/rods,
+/obj/item/shard{
+	icon_state = "medium"
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/control_room)
+"mn" = (
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor{
+	icon_state = "neutral"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"mq" = (
+/obj/effect/blocker/toxic_water/Group_2,
+/turf/open/floor/greengrid,
+/area/desert_dam/interior/dam_interior/engine_room)
+"mu" = (
+/obj/effect/decal/cleanable/blood/oil,
+/obj/item/stack/cable_coil/cut,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"mz" = (
+/obj/structure/pipes/standard/simple/hidden/green,
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/control_room)
+"mH" = (
+/obj/structure/surface/table,
+/obj/item/device/flashlight/flare,
+/obj/item/device/radio,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"mO" = (
+/obj/structure/machinery/power/apc{
+	dir = 8;
+	pixel_x = -30;
+	start_charge = 0
+	},
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/interior/dam_interior/control_room)
+"mX" = (
+/obj/structure/platform{
+	dir = 1
+	},
+/obj/structure/platform{
+	dir = 4
+	},
+/obj/effect/blocker/toxic_water/Group_2,
+/turf/open/gm/river/desert/deep,
+/area/desert_dam/exterior/river/riverside_central_north)
+"ne" = (
+/obj/structure/platform{
+	dir = 4
+	},
+/obj/structure/platform,
+/obj/effect/blocker/toxic_water/Group_1,
+/turf/open/gm/river/desert/deep,
+/area/desert_dam/exterior/river/riverside_central_south)
+"nq" = (
+/obj/structure/platform{
+	dir = 1
+	},
+/obj/effect/blocker/toxic_water/Group_2,
+/turf/open/gm/river/desert/deep,
+/area/desert_dam/exterior/river/riverside_central_south)
+"nr" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating{
+	dir = 10;
+	icon_state = "warnplate"
+	},
+/area/desert_dam/interior/dam_interior/smes_backup)
+"nw" = (
+/turf/open/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached15"
+	},
+/area/desert_dam/exterior/valley/north_valley_dam)
+"nz" = (
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"nO" = (
+/obj/structure/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/structure/machinery/light{
+	dir = 1;
+	tag = "icon-tube1 (NORTH)"
+	},
+/turf/open/floor/prison{
+	dir = 9;
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/interior/dam_interior/smes_main)
+"nR" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/barricade/plasteel/wired{
+	icon_state = "plasteel_3";
+	dir = 4
+	},
+/turf/open/floor{
+	icon_state = "warning"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"nS" = (
+/obj/structure/barricade/wooden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating{
+	icon_state = "warnplate"
+	},
+/area/desert_dam/interior/dam_interior/smes_backup)
+"nY" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"od" = (
+/obj/structure/machinery/power/port_gen/pacman/super,
+/turf/open/floor/prison{
+	dir = 5;
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"oh" = (
+/obj/structure/pipes/vents/pump{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/smes_backup)
+"oj" = (
+/obj/structure/surface/table,
+/obj/structure/machinery/cell_charger,
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"oq" = (
+/obj/effect/blocker/toxic_water/Group_1,
+/turf/open/gm/river/desert/shallow_edge/covered{
+	dir = 8
+	},
+/area/desert_dam/exterior/river/riverside_central_north)
+"or" = (
+/obj/effect/decal/sand_overlay/sand1/corner1,
+/turf/open/asphalt{
+	icon_state = "tile"
+	},
+/area/desert_dam/exterior/valley/south_valley_dam)
+"oR" = (
+/obj/effect/blocker/toxic_water/Group_1,
+/turf/open/gm/river/desert/deep,
+/area/desert_dam/exterior/river/riverside_central_south)
+"oW" = (
+/obj/structure/barricade/wooden,
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"oY" = (
+/obj/structure/surface/table,
+/turf/open/floor/prison{
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"pd" = (
+/obj/effect/blocker/toxic_water/Group_1,
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1"
+	},
+/obj/effect/landmark/corpsespawner/engineer,
+/obj/item/weapon/gun/pistol/m4a3,
+/turf/open/gm/river/desert/deep/covered,
+/area/desert_dam/exterior/river/riverside_central_south)
+"pe" = (
+/obj/structure/machinery/power/port_gen/pacman/super,
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"ph" = (
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"py" = (
+/obj/effect/decal/sand_overlay/sand1{
+	dir = 8
+	},
+/turf/open/asphalt{
+	icon_state = "tile"
+	},
+/area/desert_dam/exterior/valley/south_valley_dam)
+"pA" = (
+/obj/structure/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/turf/open/floor/prison{
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/interior/dam_interior/control_room)
+"pR" = (
+/obj/effect/decal/cleanable/blood/oil,
+/obj/item/stack/rods,
+/obj/item/stack/cable_coil/cut,
+/turf/open/floor{
+	icon_state = "dark2";
+	tag = "icon-dark2"
+	},
+/area/desert_dam/interior/dam_interior/smes_main)
+"qh" = (
+/obj/effect/blocker/toxic_water/Group_1,
+/turf/open/gm/river/desert/deep,
+/area/desert_dam/exterior/river/riverside_central_north)
+"qj" = (
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/control_room)
+"qk" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/blocker/toxic_water/Group_2,
+/obj/structure/barricade/sandbags/wired{
+	icon_state = "sandbag_2"
+	},
+/obj/effect/landmark/corpsespawner/security/cmb,
+/obj/item/weapon/gun/rifle/hunting{
+	pixel_x = -5;
+	pixel_y = 7
+	},
+/obj/item/ammo_casing/bullet,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor{
+	icon_state = "neutral"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"qs" = (
+/obj/structure/flora/grass/desert,
+/turf/open/desert/dirt,
+/area/desert_dam/exterior/valley/north_valley_dam)
+"qu" = (
+/turf/open/floor/prison{
+	icon_state = "darkyellowcorners2"
+	},
+/area/desert_dam/interior/dam_interior/control_room)
+"qE" = (
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "darkyellowcorners2"
+	},
+/area/desert_dam/interior/dam_interior/control_room)
+"qG" = (
+/turf/closed/wall/r_wall/bunker{
+	name = "reinforced metal wall"
+	},
+/area/desert_dam/interior/dam_interior/atmos_storage)
+"qJ" = (
+/turf/open/desert/dirt,
+/area/desert_dam/exterior/valley/north_valley_dam)
+"qK" = (
+/obj/structure/platform{
+	dir = 1
+	},
+/obj/structure/platform{
+	dir = 8
+	},
+/obj/effect/blocker/toxic_water/Group_1,
+/turf/open/gm/river/desert/deep,
+/area/desert_dam/exterior/river/riverside_central_south)
+"rd" = (
+/obj/structure/pipes/vents/pump{
+	dir = 1
+	},
+/turf/open/floor{
+	icon_state = "neutral"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"rh" = (
+/obj/structure/machinery/door/poddoor/shutters{
+	dir = 2;
+	icon_state = "shutter1";
+	unacidable = 1
+	},
+/turf/closed/wall/hangar{
+	name = "reinforced metal wall"
+	},
+/area/desert_dam/interior/dam_interior/west_tunnel)
+"rp" = (
+/obj/structure/platform,
+/obj/effect/blocker/toxic_water/Group_2,
+/turf/open/gm/river/desert/deep,
+/area/desert_dam/exterior/river/riverside_central_south)
+"rq" = (
+/obj/structure/machinery/cm_vending/sorted/tech/tool_storage,
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/atmos_storage)
+"ru" = (
+/obj/structure/closet/toolcloset,
+/obj/structure/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"rv" = (
+/obj/structure/window_frame/colony,
+/obj/item/stack/rods,
+/obj/item/shard{
+	icon_state = "medium"
+	},
+/turf/open/floor/plating,
+/area/desert_dam/interior/dam_interior/smes_main)
+"ry" = (
+/obj/structure/platform{
+	dir = 1
+	},
+/obj/structure/platform{
+	dir = 8
+	},
+/obj/effect/blocker/toxic_water/Group_1,
+/turf/open/gm/river/desert/shallow_edge{
+	dir = 8
+	},
+/area/desert_dam/exterior/river/riverside_central_north)
+"rA" = (
+/obj/structure/window_frame/colony,
+/obj/item/stack/rods,
+/obj/item/shard{
+	icon_state = "medium"
+	},
+/turf/open/floor/plating,
+/area/desert_dam/interior/dam_interior/control_room)
+"rB" = (
+/obj/structure/surface/table,
+/obj/effect/spawner/random/toolbox,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellowcorners2";
+	tag = "icon-darkyellowcorners2 (NORTH)"
+	},
+/area/desert_dam/interior/dam_interior/control_room)
+"rG" = (
+/turf/closed/wall/r_wall/bunker{
+	name = "reinforced metal wall"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"rJ" = (
+/turf/open/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached3"
+	},
+/area/desert_dam/exterior/valley/north_valley_dam)
+"rP" = (
+/obj/structure/pipes/standard/simple/hidden/green,
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/smes_main)
+"rX" = (
+/obj/structure/barricade/wooden{
+	dir = 8
+	},
+/obj/effect/landmark/corpsespawner/security,
+/obj/item/weapon/gun/pistol/b92fs,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/prison{
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/interior/dam_interior/control_room)
+"rY" = (
+/obj/structure/surface/rack,
+/obj/item/ammo_magazine/shotgun/incendiary,
+/obj/item/ammo_magazine/shotgun/incendiary,
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/atmos_storage)
+"sf" = (
+/obj/structure/pipes/standard/simple/hidden/green,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c";
+	tag = "icon-pipe-c (NORTH)"
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"sk" = (
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/smes_backup)
+"sq" = (
+/obj/effect/blocker/toxic_water/Group_2,
+/obj/structure/window_frame/colony,
+/obj/item/stack/rods,
+/obj/item/shard{
+	icon_state = "medium"
+	},
+/turf/open/floor/plating,
+/area/desert_dam/interior/dam_interior/engine_room)
+"sv" = (
+/obj/structure/surface/table/reinforced,
+/turf/open/floor/prison{
+	dir = 9;
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"sC" = (
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"sE" = (
+/obj/structure/platform{
+	dir = 1
+	},
+/obj/structure/platform{
+	dir = 4
+	},
+/obj/effect/blocker/toxic_water/Group_2,
+/turf/open/gm/river/desert/shallow_edge{
+	dir = 4
+	},
+/area/desert_dam/exterior/river/riverside_central_south)
+"sF" = (
+/obj/structure/machinery/power/port_gen/pacman,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/desert_dam/interior/dam_interior/smes_backup)
+"sG" = (
+/obj/structure/sign/poster/clf,
+/turf/closed/wall/hangar{
+	name = "reinforced metal wall"
+	},
+/area/desert_dam/interior/dam_interior/smes_main)
+"sY" = (
+/obj/structure/barricade/wooden{
+	dir = 1
+	},
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/interior/dam_interior/smes_backup)
+"tc" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"td" = (
+/obj/structure/window_frame/colony,
+/obj/item/stack/rods,
+/obj/item/shard{
+	icon_state = "medium"
+	},
+/turf/open/floor/plating,
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"tj" = (
+/turf/open/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached4"
+	},
+/area/desert_dam/exterior/valley/south_valley_dam)
+"tx" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/closed/wall/rock/orange,
+/area/desert_dam/exterior/rock)
+"tB" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/item/stack/sandbags/large_stack,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "damaged3"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"tH" = (
+/obj/structure/barricade/sandbags/wired{
+	dir = 4;
+	icon_state = "sandbag_2"
+	},
+/turf/open/floor{
+	icon_state = "neutral"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"tJ" = (
+/obj/effect/spawner/random/powercell,
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "darkyellowcorners2"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"tL" = (
+/obj/structure/barricade/sandbags/wired{
+	dir = 4;
+	icon_state = "sandbag_2"
+	},
+/obj/item/ammo_casing/bullet,
+/obj/effect/landmark/corpsespawner/security,
+/obj/item/weapon/gun/pistol/b92fs{
+	pixel_x = -8;
+	pixel_y = 6
+	},
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"tN" = (
+/obj/structure/surface/rack,
+/obj/item/ammo_magazine/rifle/m16/ap{
+	pixel_x = -8
+	},
+/obj/item/ammo_magazine/rifle/m16/ap{
+	pixel_x = -8
+	},
+/obj/item/ammo_magazine/rifle/m16/ap{
+	pixel_x = -8
+	},
+/obj/item/ammo_magazine/rifle/m16/ap{
+	pixel_x = -8
+	},
+/obj/item/ammo_magazine/rifle/m16/ap{
+	pixel_x = -8
+	},
+/obj/item/weapon/gun/rifle/m16,
+/obj/item/weapon/gun/rifle/m16{
+	pixel_x = 5;
+	pixel_y = 6
+	},
+/obj/item/ammo_box/magazine/M16,
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/atmos_storage)
+"tP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/desert_dam/interior/dam_interior/control_room)
+"tU" = (
+/obj/structure/platform,
+/obj/effect/blocker/toxic_water/Group_1,
+/turf/open/gm/river/desert/deep,
+/area/desert_dam/exterior/river/riverside_central_south)
+"ul" = (
+/obj/structure/platform{
+	dir = 8
+	},
+/obj/structure/platform,
+/obj/effect/blocker/toxic_water/Group_1,
+/turf/open/gm/river/desert/deep,
+/area/desert_dam/exterior/river/riverside_central_south)
+"uu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/corpsespawner/engineer,
+/obj/item/weapon/melee/twohanded/fireaxe,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/greengrid,
+/area/desert_dam/interior/dam_interior/smes_main)
+"uv" = (
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/interior/dam_interior/smes_main)
+"uM" = (
+/obj/structure/platform{
+	dir = 8
+	},
+/obj/effect/blocker/toxic_water/Group_1,
+/turf/open/gm/river/desert/shallow_edge{
+	dir = 8
+	},
+/area/desert_dam/exterior/river/riverside_central_north)
+"uR" = (
+/obj/structure/machinery/power/apc{
+	dir = 1;
+	pixel_y = 24;
+	start_charge = 0
+	},
+/turf/open/floor/prison{
+	dir = 9;
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/interior/dam_interior/smes_backup)
+"vr" = (
+/obj/effect/landmark/survivor_spawn,
+/turf/open/floor{
+	icon_state = "neutral"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"vG" = (
+/obj/structure/surface/table,
+/obj/structure/machinery/cell_charger,
+/turf/open/floor/prison{
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/interior/dam_interior/control_room)
+"vM" = (
+/obj/structure/sign/poster/clf,
+/turf/closed/wall/hangar{
+	name = "reinforced metal wall"
+	},
+/area/desert_dam/interior/dam_interior/engine_west_wing)
+"vO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/wooden{
+	dir = 1
+	},
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "darkyellowcorners2"
+	},
+/area/desert_dam/interior/dam_interior/smes_backup)
+"wn" = (
+/obj/structure/platform{
+	dir = 1
+	},
+/obj/structure/platform{
+	dir = 4
+	},
+/obj/effect/blocker/toxic_water/Group_2,
+/turf/open/gm/river/desert/shallow_edge{
+	dir = 4
+	},
+/area/desert_dam/exterior/river/riverside_central_north)
+"wA" = (
+/obj/structure/machinery/power/apc{
+	dir = 4;
+	pixel_x = 24;
+	start_charge = 0
+	},
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "darkyellowcorners2"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"wH" = (
+/turf/open/floor/prison{
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"wK" = (
+/obj/structure/platform{
+	dir = 8
+	},
+/obj/effect/blocker/toxic_water/Group_2,
+/turf/open/gm/river/desert/deep,
+/area/desert_dam/exterior/river/riverside_central_south)
+"wL" = (
+/turf/closed/wall/rock/orange,
+/area/desert_dam/exterior/rock)
+"wU" = (
+/turf/closed/wall/hangar{
+	name = "reinforced metal wall"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"wY" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/landmark/corpsespawner/engineer,
+/obj/item/weapon/melee/baseballbat,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/smes_main)
+"xg" = (
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1";
+	dir = 8
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"xi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/desert_dam/interior/dam_interior/control_room)
+"xl" = (
+/obj/effect/blocker/toxic_water/Group_2,
+/obj/item/ammo_casing/bullet,
+/obj/item/ammo_magazine/m56d,
+/turf/open/floor{
+	icon_state = "neutral"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"xp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/wooden,
+/turf/open/floor/prison{
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/interior/dam_interior/smes_backup)
+"xu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/sandbags/large_stack,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"xC" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/control_room)
+"xO" = (
+/obj/structure/pipes/standard/simple/hidden/green,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"yh" = (
+/obj/structure/platform{
+	dir = 8
+	},
+/obj/structure/platform,
+/obj/effect/blocker/toxic_water/Group_1,
+/turf/open/gm/river/desert/shallow_edge{
+	dir = 8
+	},
+/area/desert_dam/exterior/river/riverside_central_north)
+"ym" = (
+/turf/open/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached2"
+	},
+/area/desert_dam/exterior/valley/south_valley_dam)
+"yn" = (
+/turf/open/floor{
+	dir = 8;
+	icon_state = "damaged3"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"yw" = (
+/obj/structure/barricade/wooden{
+	dir = 1
+	},
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "darkyellowcorners2"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"yM" = (
+/turf/open/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached14"
+	},
+/area/desert_dam/exterior/valley/north_valley_dam)
+"yX" = (
+/obj/effect/landmark/corpsespawner/security,
+/obj/effect/decal/cleanable/blood,
+/obj/item/weapon/gun/pistol/b92fs,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"yZ" = (
+/obj/structure/surface/rack,
+/obj/item/weapon/gun/rifle/hunting,
+/obj/item/ammo_magazine/rifle/hunting,
+/obj/item/ammo_magazine/rifle/hunting,
+/obj/item/ammo_magazine/rifle/hunting,
+/obj/item/ammo_magazine/rifle/hunting,
+/obj/item/ammo_magazine/rifle/hunting,
+/obj/item/ammo_magazine/rifle/hunting,
+/obj/item/ammo_magazine/rifle/hunting,
+/obj/item/ammo_magazine/rifle/hunting,
+/obj/item/ammo_magazine/rifle/hunting,
+/obj/item/ammo_magazine/rifle/hunting,
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/atmos_storage)
+"za" = (
+/obj/structure/platform{
+	dir = 4
+	},
+/obj/structure/platform,
+/obj/effect/blocker/toxic_water/Group_2,
+/turf/open/gm/river/desert/deep,
+/area/desert_dam/exterior/river/riverside_central_north)
+"zd" = (
+/obj/structure/platform{
+	dir = 1
+	},
+/obj/structure/platform{
+	dir = 8
+	},
+/obj/effect/blocker/toxic_water/Group_1,
+/turf/open/gm/river/desert/shallow_edge{
+	dir = 8
+	},
+/area/desert_dam/exterior/river/riverside_central_south)
+"zg" = (
+/turf/open/floor{
+	dir = 1;
+	icon_state = "warning"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"zi" = (
+/obj/structure/pipes/standard/simple/hidden/green,
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/blood/oil,
+/obj/item/stack/cable_coil/cut,
+/obj/item/stack/rods,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/control_room)
+"zs" = (
+/obj/item/ammo_casing/bullet,
+/turf/open/floor{
+	icon_state = "neutral"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"zR" = (
+/obj/effect/decal/cleanable/blood/oil,
+/obj/item/stack/rods,
+/obj/item/stack/cable_coil/cut,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"zT" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/control_room)
+"Af" = (
+/obj/structure/machinery/colony_floodlight_switch{
+	pixel_y = 30
+	},
+/obj/effect/decal/warning_stripes{
+	pixel_y = 30
+	},
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/interior/dam_interior/control_room)
+"Au" = (
+/obj/structure/platform{
+	dir = 1
+	},
+/obj/effect/blocker/toxic_water/Group_1,
+/turf/open/gm/river/desert/deep,
+/area/desert_dam/exterior/river/riverside_central_north)
+"Aw" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/control_room)
+"AB" = (
+/obj/structure/machinery/light{
+	dir = 1;
+	tag = "icon-tube1 (NORTH)"
+	},
+/turf/open/floor/prison{
+	dir = 5;
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/interior/dam_interior/smes_main)
+"AJ" = (
+/obj/structure/girder,
+/turf/open/floor/plating,
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"AV" = (
+/obj/structure/surface/rack,
+/obj/item/clothing/accessory/storage/webbing,
+/obj/item/clothing/accessory/storage/webbing,
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/atmos_storage)
+"Bi" = (
+/obj/structure/platform{
+	dir = 4
+	},
+/obj/effect/blocker/toxic_water/Group_1,
+/turf/open/gm/river/desert/deep,
+/area/desert_dam/exterior/river/riverside_central_south)
+"Bm" = (
+/obj/structure/platform,
+/obj/effect/blocker/toxic_water/Group_1,
+/turf/open/gm/river/desert/deep,
+/area/desert_dam/exterior/river/riverside_central_north)
+"Bt" = (
+/turf/open/floor{
+	dir = 4;
+	icon_state = "warning"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"BL" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/control_room)
+"BN" = (
+/obj/structure/platform{
+	dir = 4
+	},
+/obj/structure/platform,
+/obj/effect/blocker/toxic_water/Group_2,
+/turf/open/gm/river/desert/deep,
+/area/desert_dam/exterior/river/riverside_central_south)
+"BR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/wooden,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/smes_main)
+"BU" = (
+/obj/structure/machinery/door/poddoor/shutters,
+/turf/closed/wall/hangar{
+	name = "reinforced metal wall"
+	},
+/area/desert_dam/interior/dam_interior/west_tunnel)
+"Ca" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/rods,
+/obj/effect/decal/cleanable/blood/oil,
+/obj/item/stack/cable_coil/cut,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/smes_main)
+"Ce" = (
+/obj/structure/machinery/cm_vending/sorted/tech/electronics_storage,
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/atmos_storage)
+"Cy" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/smes_main)
+"CK" = (
+/obj/structure/flora/grass/desert{
+	icon_state = "lightgrass_3"
+	},
+/turf/open/desert/dirt,
+/area/desert_dam/exterior/valley/north_valley_dam)
+"CO" = (
+/obj/structure/surface/table,
+/obj/item/device/analyzer,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkyellow2";
+	tag = "icon-darkyellow2 (NORTH)"
+	},
+/area/desert_dam/interior/dam_interior/control_room)
+"CS" = (
+/obj/structure/barricade/wooden{
+	dir = 8
+	},
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "darkyellowcorners2"
+	},
+/area/desert_dam/interior/dam_interior/control_room)
+"CZ" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/smes_backup)
+"De" = (
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"Dp" = (
+/obj/structure/machinery/light,
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"DH" = (
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "darkyellowcorners2"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"DQ" = (
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/interior/dam_interior/control_room)
+"DW" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/desert_dam/interior/dam_interior/control_room)
+"Ee" = (
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/smes_main)
+"Ef" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 5
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 8;
+	tag = "icon-pipe-j1 (WEST)"
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/control_room)
+"Eh" = (
+/turf/open/floor{
+	dir = 8;
+	icon_state = "warning"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"En" = (
+/obj/effect/landmark/corpsespawner/engineer,
+/obj/effect/decal/cleanable/blood,
+/obj/item/weapon/gun/smg/nailgun,
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"Ep" = (
+/obj/effect/decal/sand_overlay/sand1/corner1{
+	dir = 4
+	},
+/turf/open/asphalt{
+	icon_state = "tile"
+	},
+/area/desert_dam/exterior/valley/south_valley_dam)
+"Er" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/vomit,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/smes_main)
+"Et" = (
+/obj/structure/machinery/colony_floodlight,
+/obj/effect/decal/sand_overlay/sand1/corner1,
+/turf/open/asphalt{
+	icon_state = "tile"
+	},
+/area/desert_dam/exterior/valley/north_valley_dam)
+"Ex" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/desert_dam/interior/dam_interior/control_room)
+"EC" = (
+/obj/structure/platform{
+	dir = 1
+	},
+/obj/structure/platform{
+	dir = 8
+	},
+/obj/effect/blocker/toxic_water/Group_2,
+/turf/open/gm/river/desert/deep,
+/area/desert_dam/exterior/river/riverside_central_south)
+"ED" = (
+/obj/effect/blocker/toxic_water/Group_1,
+/obj/structure/window_frame/colony,
+/obj/item/stack/rods,
+/obj/item/shard{
+	icon_state = "medium"
+	},
+/turf/open/floor/plating,
+/area/desert_dam/interior/dam_interior/engine_room)
+"EH" = (
+/obj/structure/surface/table,
+/obj/structure/machinery/cell_charger,
+/turf/open/floor/prison{
+	icon_state = "darkyellowcorners2"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"EK" = (
+/obj/structure/bed/chair/office/light{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/control_room)
+"ET" = (
+/obj/structure/pipes/standard/simple/hidden/green,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/smes_main)
+"Fb" = (
+/obj/structure/surface/table,
+/obj/item/tool/crowbar/red,
+/obj/item/device/flash,
+/obj/structure/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"Fe" = (
+/turf/open/floor/prison{
+	dir = 5;
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/interior/dam_interior/control_room)
+"Fi" = (
+/turf/open/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached9"
+	},
+/area/desert_dam/exterior/valley/south_valley_dam)
+"Fr" = (
+/obj/structure/barricade/wooden{
+	dir = 1
+	},
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/interior/dam_interior/smes_main)
+"Fw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/greengrid,
+/area/desert_dam/interior/dam_interior/smes_main)
+"FE" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/control_room)
+"FO" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/item/stack/rods,
+/obj/item/stack/cable_coil/cut,
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"FR" = (
+/obj/structure/platform{
+	dir = 4
+	},
+/obj/structure/platform,
+/obj/effect/blocker/toxic_water/Group_1,
+/turf/open/gm/river/desert/deep,
+/area/desert_dam/exterior/river/riverside_central_north)
+"Gb" = (
+/obj/structure/machinery/power/smes/buildable{
+	capacity = 1e+006;
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/desert_dam/interior/dam_interior/smes_main)
+"Gc" = (
+/obj/structure/platform{
+	dir = 1
+	},
+/obj/structure/platform{
+	dir = 4
+	},
+/obj/effect/blocker/toxic_water/Group_2,
+/turf/open/gm/river/desert/deep,
+/area/desert_dam/exterior/river/riverside_central_south)
+"Go" = (
+/obj/structure/surface/rack,
+/obj/item/weapon/gun/smg/fp9000{
+	pixel_y = 7
+	},
+/obj/item/weapon/gun/smg/fp9000{
+	pixel_y = -8
+	},
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/atmos_storage)
+"Gr" = (
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/prison{
+	icon_state = "darkyellowcorners2"
+	},
+/area/desert_dam/interior/dam_interior/smes_backup)
+"Gt" = (
+/obj/effect/blocker/toxic_water/Group_1,
+/turf/open/floor/greengrid,
+/area/desert_dam/interior/dam_interior/engine_room)
+"Gu" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"GM" = (
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1";
+	dir = 4
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"GP" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "darkyellowcorners2"
+	},
+/area/desert_dam/interior/dam_interior/smes_main)
+"GW" = (
+/obj/structure/machinery/cm_vending/sorted/medical/no_access,
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/atmos_storage)
+"Hb" = (
+/turf/closed/wall/hangar{
+	name = "reinforced metal wall"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"Hm" = (
+/obj/structure/surface/table,
+/obj/item/storage/box/lightstick,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"Hn" = (
+/obj/structure/closet/radiation,
+/obj/item/device/radio/intercom{
+	freerange = 1;
+	frequency = 1469;
+	name = "General Listening Channel";
+	pixel_x = -30
+	},
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"Hp" = (
+/turf/closed/wall/hangar{
+	name = "reinforced metal wall"
+	},
+/area/desert_dam/interior/dam_interior/smes_backup)
+"Hs" = (
+/turf/open/floor{
+	icon_state = "neutral"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"Ht" = (
+/obj/structure/barricade/plasteel/wired{
+	icon_state = "plasteel_3"
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"HB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/decal/cleanable/blood/oil,
+/obj/item/stack/cable_coil/cut,
+/obj/item/stack/rods,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/control_room)
+"HD" = (
+/obj/structure/surface/table,
+/turf/open/floor/prison{
+	dir = 5;
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"HS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/control_room)
+"Im" = (
+/obj/structure/barricade/wooden,
+/turf/open/floor/prison{
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/interior/dam_interior/smes_backup)
+"Iy" = (
+/obj/structure/machinery/computer3/powermonitor,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkyellow2";
+	tag = "icon-darkyellow2 (NORTH)"
+	},
+/area/desert_dam/interior/dam_interior/control_room)
+"ID" = (
+/obj/structure/platform{
+	dir = 4
+	},
+/obj/effect/blocker/toxic_water/Group_2,
+/turf/open/gm/river/desert/deep,
+/area/desert_dam/exterior/river/riverside_central_north)
+"IK" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 8;
+	icon_state = "pipe-j2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/control_room)
+"Jm" = (
+/obj/effect/blocker/toxic_water/Group_2,
+/turf/open/gm/river/desert/deep,
+/area/desert_dam/exterior/river/riverside_central_north)
+"JX" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/oil,
+/obj/item/stack/cable_coil/cut,
+/obj/item/stack/rods,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/control_room)
+"Kd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/smes_main)
+"Kv" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/blocker/toxic_water/Group_2,
+/turf/open/floor{
+	icon_state = "neutral"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"Kz" = (
+/obj/structure/barricade/plasteel/wired{
+	icon_state = "plasteel_3";
+	dir = 1
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"KP" = (
+/obj/structure/pipes/standard/manifold/hidden/green{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor{
+	icon_state = "neutral"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"KT" = (
+/turf/open/floor{
+	dir = 9;
+	icon_state = "warning"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"KW" = (
+/turf/open/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached1"
+	},
+/area/desert_dam/exterior/valley/north_valley_dam)
+"KY" = (
+/obj/structure/barricade/wooden{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating{
+	dir = 8;
+	icon_state = "warnplate"
+	},
+/area/desert_dam/interior/dam_interior/smes_backup)
+"Ld" = (
+/obj/structure/pipes/vents/pump{
+	dir = 1
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"Lj" = (
+/obj/structure/surface/table/reinforced,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/effect/spawner/random/toolbox,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/interior/dam_interior/smes_backup)
+"Lp" = (
+/obj/structure/barricade/plasteel/wired{
+	icon_state = "plasteel_3";
+	dir = 8
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"Lr" = (
+/obj/structure/disposalpipe/junction{
+	dir = 8;
+	tag = "icon-pipe-j1 (WEST)"
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"LD" = (
+/obj/effect/decal/sand_overlay/sand1{
+	dir = 4
+	},
+/turf/open/asphalt{
+	icon_state = "tile"
+	},
+/area/desert_dam/exterior/valley/north_valley_dam)
+"LH" = (
+/obj/effect/blocker/toxic_water/Group_1,
+/turf/open/gm/river/desert/shallow_edge/covered{
+	dir = 8
+	},
+/area/desert_dam/exterior/river/riverside_central_south)
+"LN" = (
+/obj/structure/barricade/plasteel/wired{
+	icon_state = "plasteel_3"
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"Mf" = (
+/obj/structure/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"Mh" = (
+/obj/structure/window_frame/colony,
+/obj/item/shard{
+	icon_state = "medium"
+	},
+/obj/item/stack/rods,
+/turf/open/floor/plating,
+/area/desert_dam/interior/dam_interior/engine_room)
+"Mm" = (
+/obj/structure/machinery/power/smes/buildable{
+	capacity = 1e+006;
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating{
+	dir = 6;
+	icon_state = "warnplate";
+	tag = "icon-warnplate (SOUTHEAST)"
+	},
+/area/desert_dam/interior/dam_interior/smes_backup)
+"Mu" = (
+/obj/structure/barricade/sandbags/wired{
+	dir = 1
+	},
+/obj/item/ammo_magazine/m56d,
+/turf/open/floor/greengrid,
+/area/desert_dam/interior/dam_interior/engine_room)
+"Mw" = (
+/obj/structure/window_frame/colony,
+/obj/item/stack/rods,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"MF" = (
+/obj/structure/machinery/power/terminal,
+/turf/open/floor/plating{
+	dir = 9;
+	icon_state = "warnplate"
+	},
+/area/desert_dam/interior/dam_interior/smes_backup)
+"MQ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"MS" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/blocker/toxic_water/Group_2,
+/obj/structure/barricade/sandbags/wired{
+	icon_state = "sandbag_2"
+	},
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"MZ" = (
+/obj/effect/decal/sand_overlay/sand1/corner1{
+	dir = 8
+	},
+/turf/open/asphalt{
+	icon_state = "tile"
+	},
+/area/desert_dam/exterior/valley/north_valley_dam)
+"Ng" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor{
+	icon_state = "neutral"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"Nj" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/effect/spawner/random/attachment,
+/obj/effect/spawner/random/attachment,
+/obj/effect/spawner/random/attachment,
+/obj/effect/spawner/random/attachment,
+/obj/effect/spawner/random/attachment,
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/atmos_storage)
+"Nx" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/clothing/glasses/welding,
+/obj/item/stack/sheet/metal/large_stack,
+/obj/item/stack/sheet/plasteel/large_stack,
+/obj/item/weapon/gun/smg/nailgun,
+/obj/item/ammo_magazine/smg/nailgun,
+/obj/item/ammo_magazine/smg/nailgun,
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/atmos_storage)
+"Nz" = (
+/obj/structure/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"NH" = (
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/interior/dam_interior/smes_main)
+"NP" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/desert_dam/interior/dam_interior/control_room)
+"NT" = (
+/obj/structure/barricade/plasteel/wired{
+	icon_state = "plasteel_3";
+	dir = 1
+	},
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"NY" = (
+/obj/structure/pipes/vents/pump,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"NZ" = (
+/obj/effect/blocker/toxic_water/Group_1,
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1"
+	},
+/turf/open/gm/river/desert/deep/covered,
+/area/desert_dam/exterior/river/riverside_central_south)
+"Oc" = (
+/obj/structure/surface/table,
+/obj/structure/machinery/light,
+/turf/open/floor/prison{
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"Og" = (
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "darkyellowcorners2"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"Oi" = (
+/obj/effect/blocker/toxic_water/Group_2,
+/turf/open/gm/river/desert/shallow_edge/covered{
+	dir = 4
+	},
+/area/desert_dam/exterior/river/riverside_central_north)
+"Oj" = (
+/turf/open/desert/dirt,
+/area/desert_dam/exterior/valley/south_valley_dam)
+"Ow" = (
+/obj/structure/barricade/sandbags/wired{
+	icon_state = "sandbag_2";
+	dir = 8
+	},
+/obj/effect/landmark/corpsespawner/security/cmb,
+/obj/item/weapon/gun/shotgun/pump/cmb{
+	pixel_y = 9;
+	pixel_x = 16
+	},
+/obj/item/prop/helmetgarb/spent_buckshot,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"Ox" = (
+/turf/closed/wall/hangar{
+	name = "reinforced metal wall"
+	},
+/area/desert_dam/interior/dam_interior/west_tunnel)
+"OR" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"OT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/control_room)
+"Pr" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/desert_dam/interior/dam_interior/smes_backup)
+"PB" = (
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/smes_main)
+"PD" = (
+/obj/effect/blocker/toxic_water/Group_2,
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1";
+	dir = 1
+	},
+/turf/open/gm/river/desert/deep/covered,
+/area/desert_dam/exterior/river/riverside_central_north)
+"PE" = (
+/obj/structure/surface/table,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"PG" = (
+/obj/structure/sign/poster/clf,
+/turf/closed/wall/hangar{
+	name = "reinforced metal wall"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"PH" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/control_room)
+"PL" = (
+/obj/effect/blocker/toxic_water/Group_1,
+/turf/open/floor{
+	icon_state = "neutral"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"PS" = (
+/obj/structure/barricade/plasteel/wired{
+	icon_state = "plasteel_3";
+	dir = 8
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"PT" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/smes_backup)
+"Qe" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/smes_backup)
+"Qn" = (
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "warning"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"Qq" = (
+/obj/structure/machinery/power/monitor{
+	name = "Core Power Monitoring"
+	},
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkyellow2";
+	tag = "icon-darkyellow2 (NORTH)"
+	},
+/area/desert_dam/interior/dam_interior/control_room)
+"QB" = (
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/smes_backup)
+"QD" = (
+/turf/open/floor{
+	dir = 7;
+	icon_state = "warning"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"QH" = (
+/obj/structure/bed/stool,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/interior/dam_interior/smes_backup)
+"QJ" = (
+/turf/open/asphalt{
+	icon_state = "tile"
+	},
+/area/desert_dam/exterior/valley/south_valley_dam)
+"Rh" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/blocker/toxic_water/Group_1,
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"Rn" = (
+/obj/structure/machinery/light{
+	dir = 8
+	},
+/obj/effect/landmark/corpsespawner/security,
+/obj/item/weapon/gun/pistol/b92fs,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/interior/dam_interior/control_room)
+"Ro" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/smes_main)
+"Rs" = (
+/obj/structure/girder,
+/obj/structure/sign/poster/clf,
+/turf/open/floor/plating,
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"Rw" = (
+/obj/effect/blocker/toxic_water/Group_2,
+/turf/open/gm/river/desert/deep,
+/area/desert_dam/exterior/river/riverside_central_south)
+"Rz" = (
+/obj/effect/decal/sand_overlay/sand1{
+	dir = 4
+	},
+/turf/open/asphalt{
+	icon_state = "tile"
+	},
+/area/desert_dam/exterior/valley/south_valley_dam)
+"RA" = (
+/turf/open/asphalt/cement_sunbleached,
+/area/desert_dam/exterior/valley/south_valley_dam)
+"RK" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/blocker/toxic_water/Group_2,
+/obj/structure/barricade/sandbags/wired{
+	icon_state = "sandbag_2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor{
+	icon_state = "neutral"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"RP" = (
+/obj/structure/barricade/wooden{
+	dir = 4
+	},
+/turf/open/floor/prison{
+	dir = 6;
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/interior/dam_interior/smes_backup)
+"RX" = (
+/obj/structure/pipes/standard/simple/hidden/green,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/smes_backup)
+"Sk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "damaged3"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"St" = (
+/obj/structure/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"Sv" = (
+/obj/structure/barricade/sandbags/wired{
+	dir = 1
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"Sx" = (
+/obj/structure/pipes/standard/manifold/hidden/green{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/control_room)
+"SG" = (
+/obj/structure/surface/table/reinforced,
+/obj/structure/disposalpipe/segment,
+/obj/effect/spawner/random/toolbox,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/interior/dam_interior/smes_backup)
+"SJ" = (
+/obj/structure/machinery/power/terminal{
+	dir = 8;
+	tag = "icon-term (WEST)"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/desert_dam/interior/dam_interior/smes_main)
+"Td" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/control_room)
+"Te" = (
+/obj/structure/machinery/door/airlock/almayer/maint{
+	name = "\improper Atmospheric Storage"
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/atmos_storage)
+"Th" = (
+/obj/structure/pipes/standard/simple/hidden/green,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/rods,
+/obj/effect/decal/cleanable/blood/oil,
+/obj/item/stack/cable_coil/cut,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/smes_backup)
+"Tk" = (
+/obj/structure/machinery/power/apc{
+	dir = 8;
+	pixel_x = -30;
+	start_charge = 0
+	},
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/interior/dam_interior/smes_main)
+"Tm" = (
+/obj/structure/machinery/power/geothermal,
+/turf/open/floor/greengrid,
+/area/desert_dam/interior/dam_interior/engine_room)
+"Tz" = (
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"TB" = (
+/obj/structure/pipes/standard/manifold/hidden/green{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/smes_main)
+"TD" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/greengrid,
+/area/desert_dam/interior/dam_interior/smes_main)
+"TM" = (
+/turf/closed/wall/hangar{
+	name = "reinforced metal wall"
+	},
+/area/desert_dam/interior/dam_interior/engine_west_wing)
+"TN" = (
+/obj/effect/decal/cleanable/blood/oil,
+/obj/item/stack/rods,
+/obj/item/stack/cable_coil/cut,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"TO" = (
+/obj/effect/blocker/toxic_water/Group_1,
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1";
+	dir = 1
+	},
+/turf/open/gm/river/desert/deep/covered,
+/area/desert_dam/exterior/river/riverside_central_north)
+"TR" = (
+/turf/open/floor{
+	dir = 6;
+	icon_state = "warning"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"Uc" = (
+/obj/item/stack/rods,
+/obj/item/stack/cable_coil/cut,
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"Um" = (
+/obj/structure/platform{
+	dir = 4
+	},
+/obj/effect/blocker/toxic_water/Group_2,
+/turf/open/gm/river/desert/shallow_edge{
+	dir = 4
+	},
+/area/desert_dam/exterior/river/riverside_central_north)
+"Ur" = (
+/obj/structure/bed/chair/office/light{
+	dir = 1
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/control_room)
+"Uy" = (
+/obj/structure/platform{
+	dir = 1
+	},
+/obj/structure/platform{
+	dir = 4
+	},
+/obj/effect/blocker/toxic_water/Group_1,
+/turf/open/gm/river/desert/deep,
+/area/desert_dam/exterior/river/riverside_central_north)
+"Uz" = (
+/obj/effect/blocker/toxic_water/Group_1,
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"UI" = (
+/obj/effect/landmark/corpsespawner/engineer,
+/obj/item/weapon/gun/pistol/m4a3,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/smes_backup)
+"UJ" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/storage/firstaid/regular,
+/obj/item/storage/firstaid/surgical,
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/atmos_storage)
+"UR" = (
+/obj/structure/barricade/plasteel/wired{
+	icon_state = "plasteel_3";
+	dir = 1
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"UX" = (
+/obj/effect/blocker/toxic_water/Group_2,
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1"
+	},
+/turf/open/gm/river/desert/deep/covered,
+/area/desert_dam/exterior/river/riverside_central_south)
+"Vb" = (
+/obj/structure/machinery/power/terminal,
+/turf/open/floor/plating{
+	dir = 5;
+	icon_state = "warnplate";
+	tag = "icon-warnplate (NORTHEAST)"
+	},
+/area/desert_dam/interior/dam_interior/smes_backup)
+"Vm" = (
+/obj/effect/blocker/toxic_water/Group_2,
+/obj/structure/window_frame/colony,
+/obj/item/stack/rods,
+/obj/item/shard{
+	icon_state = "medium"
+	},
+/obj/structure/sign/poster/clf,
+/turf/open/floor/plating,
+/area/desert_dam/interior/dam_interior/engine_room)
+"Vp" = (
+/obj/structure/bed/stool,
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"VC" = (
+/obj/structure/pipes/vents/pump/on,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/smes_main)
+"VE" = (
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "darkyellowcorners2"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"VG" = (
+/obj/structure/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/prison{
+	icon_state = "darkyellowcorners2"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"VK" = (
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"VQ" = (
+/obj/effect/blocker/toxic_water/Group_2,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "warning"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"VY" = (
+/turf/open/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached1"
+	},
+/area/desert_dam/exterior/valley/south_valley_dam)
+"Wc" = (
+/obj/structure/pipes/vents/pump{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/control_room)
+"Wj" = (
+/obj/structure/platform{
+	dir = 1
+	},
+/obj/effect/blocker/toxic_water/Group_1,
+/turf/open/gm/river/desert/deep,
+/area/desert_dam/exterior/river/riverside_central_south)
+"Wo" = (
+/obj/structure/barricade/plasteel/wired{
+	icon_state = "plasteel_3";
+	dir = 4
+	},
+/turf/open/floor{
+	dir = 1;
+	icon_state = "warning"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"Ws" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/barricade/plasteel/wired{
+	icon_state = "plasteel_3";
+	dir = 8
+	},
+/obj/effect/landmark/corpsespawner/engineer,
+/obj/item/weapon/melee/baseballbat,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"Ww" = (
+/obj/structure/sign/poster/clf,
+/turf/closed/wall/hangar{
+	name = "reinforced metal wall"
+	},
+/area/desert_dam/interior/dam_interior/smes_backup)
+"WI" = (
+/obj/structure/barricade/wooden{
+	dir = 4;
+	pixel_y = 4
+	},
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/interior/dam_interior/smes_main)
+"WX" = (
+/obj/structure/pipes/standard/simple/hidden/green,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"Xd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/corpsespawner/security,
+/obj/item/weapon/gun/pistol/b92fs,
+/obj/item/ammo_casing/bullet,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/control_room)
+"Xe" = (
+/obj/structure/barricade/wooden{
+	dir = 1
+	},
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "darkyellowcorners2"
+	},
+/area/desert_dam/interior/dam_interior/smes_backup)
+"Xf" = (
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"Xy" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/corpsespawner/engineer,
+/obj/item/weapon/gun/pistol/b92fs,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/greengrid,
+/area/desert_dam/interior/dam_interior/smes_main)
+"XB" = (
+/obj/structure/surface/rack,
+/obj/effect/spawner/random/tool,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"XI" = (
+/obj/structure/surface/table,
+/obj/item/reagent_container/food/drinks/cans/thirteenloko,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"XS" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/item/stack/cable_coil/cut,
+/obj/item/stack/rods,
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"XU" = (
+/obj/structure/barricade/wooden,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/smes_main)
+"XX" = (
+/obj/structure/barricade/wooden{
+	dir = 4;
+	pixel_y = 4
+	},
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
+/area/desert_dam/interior/dam_interior/smes_main)
+"Yh" = (
+/obj/item/stack/cable_coil/cut,
+/obj/item/stack/rods,
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+"Yj" = (
+/obj/structure/pipes/standard/simple/hidden/green,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/control_room)
+"Yq" = (
+/obj/structure/window_frame/colony,
+/obj/item/stack/rods,
+/obj/item/shard{
+	icon_state = "medium"
+	},
+/turf/open/floor/plating,
+/area/desert_dam/interior/dam_interior/engine_room)
+"Yt" = (
+/obj/effect/decal/sand_overlay/sand1,
+/turf/open/asphalt{
+	icon_state = "tile"
+	},
+/area/desert_dam/exterior/valley/north_valley_dam)
+"YO" = (
+/obj/effect/landmark/survivor_spawn,
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"YY" = (
+/obj/item/stack/sheet/wood,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "darkyellowcorners2"
+	},
+/area/desert_dam/interior/dam_interior/smes_main)
+"Zd" = (
+/obj/structure/platform,
+/obj/effect/blocker/toxic_water/Group_2,
+/turf/open/gm/river/desert/deep,
+/area/desert_dam/exterior/river/riverside_central_north)
+"Zh" = (
+/obj/structure/machinery/power/geothermal,
+/obj/structure/lattice{
+	layer = 2.9
+	},
+/turf/open/floor/greengrid,
+/area/desert_dam/interior/dam_interior/engine_room)
+"Zl" = (
+/obj/structure/pipes/standard/manifold/hidden/green{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/control_room)
+"Zw" = (
+/obj/structure/pipes/standard/simple/hidden/green,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/effect/landmark/corpsespawner/security,
+/obj/effect/decal/cleanable/blood,
+/obj/item/weapon/gun/pistol/b92fs,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"Zx" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/smes_backup)
+"Zy" = (
+/obj/structure/platform{
+	dir = 8
+	},
+/obj/effect/blocker/toxic_water/Group_1,
+/turf/open/gm/river/desert/shallow_edge{
+	dir = 8
+	},
+/area/desert_dam/exterior/river/riverside_central_south)
+"ZN" = (
+/obj/structure/pipes/standard/simple/hidden/green,
+/obj/structure/disposalpipe/segment,
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+"ZV" = (
+/obj/structure/barricade/plasteel/wired{
+	dir = 8
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/atmos_storage)
+"ZW" = (
+/obj/item/stack/rods,
+/obj/effect/decal/cleanable/blood/oil,
+/obj/item/stack/cable_coil/cut,
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+
+(1,1,1) = {"
+fM
+fM
+fM
+sG
+rv
+Ca
+au
+rv
+sG
+fM
+TM
+vM
+TM
+rA
+JX
+mj
+rA
+Ww
+Hp
+Hp
+Hp
+Hp
+Hp
+Hp
+"}
+(2,1,1) = {"
+sG
+nO
+NH
+NH
+ac
+Ro
+fN
+YY
+Tk
+fb
+Af
+Rn
+mO
+CS
+FE
+Aw
+rX
+Hp
+uR
+QH
+Lj
+SG
+ci
+Hp
+"}
+(3,1,1) = {"
+rv
+bZ
+wY
+Cy
+VC
+rP
+TB
+ET
+ET
+zi
+mz
+mz
+Sx
+mz
+fJ
+Ef
+bq
+ki
+vO
+ku
+PT
+QB
+Im
+ki
+"}
+(4,1,1) = {"
+rv
+Fr
+Ro
+cR
+cR
+TD
+cR
+TD
+Ro
+HB
+HS
+PH
+Wc
+PH
+PH
+IK
+zT
+lc
+CZ
+Zx
+MF
+fS
+Im
+ki
+"}
+(5,1,1) = {"
+rv
+Fr
+Ro
+TD
+Gb
+Gb
+Gb
+uu
+BR
+rv
+rB
+qj
+OT
+tP
+NP
+Zl
+Yj
+Th
+RX
+oh
+Vb
+Mm
+xp
+ki
+"}
+(6,1,1) = {"
+rv
+Fr
+Ro
+TD
+SJ
+lD
+SJ
+Fw
+BR
+rv
+Qq
+Ur
+xi
+Ex
+dH
+DW
+qu
+ki
+Xe
+Qe
+sk
+Qe
+xp
+ki
+"}
+(7,1,1) = {"
+rv
+Fr
+Ro
+Xy
+Fw
+cR
+cR
+Fw
+XU
+rv
+CO
+Td
+Xd
+hb
+hb
+ak
+pA
+ki
+sY
+cj
+Qe
+UI
+Im
+ki
+"}
+(8,1,1) = {"
+rv
+Fr
+PB
+bJ
+Er
+Ee
+Ee
+Kd
+XU
+rv
+Iy
+EK
+Td
+dQ
+NP
+BL
+vG
+cC
+KY
+lt
+nr
+Gr
+dI
+ki
+"}
+(9,1,1) = {"
+sG
+AB
+XX
+WI
+uv
+cQ
+GP
+cz
+cA
+fM
+Fe
+DQ
+DQ
+qE
+dQ
+xC
+vG
+Hp
+Pr
+sF
+nS
+RP
+Hp
+Hp
+"}
+(10,1,1) = {"
+fM
+sG
+dq
+dq
+sG
+fM
+rv
+pR
+rv
+dc
+Yq
+Yq
+Yq
+Yq
+Yh
+XS
+Mh
+Ww
+Hp
+Hp
+ki
+ki
+Ww
+Ep
+"}
+(11,1,1) = {"
+Yt
+qJ
+qs
+qJ
+qJ
+wU
+xg
+Lp
+xg
+St
+xg
+xg
+xg
+xg
+PS
+Ws
+js
+St
+Xf
+wU
+Oj
+Oj
+Oj
+fe
+"}
+(12,1,1) = {"
+jb
+LD
+LD
+LD
+LD
+dc
+Xf
+KT
+Eh
+Eh
+Eh
+Eh
+Eh
+Eh
+ek
+tc
+sC
+ek
+Xf
+dc
+Rz
+Rz
+Rz
+cl
+"}
+(13,1,1) = {"
+ry
+uM
+uM
+yh
+oq
+ED
+TO
+zg
+kJ
+fB
+kJ
+gA
+Hs
+kt
+Uz
+Rh
+qK
+ul
+NZ
+ED
+LH
+zd
+Zy
+Zy
+"}
+(14,1,1) = {"
+Au
+qh
+qh
+Bm
+eC
+ED
+TO
+jx
+Gt
+Gt
+Gt
+Gt
+PL
+kt
+am
+da
+Wj
+tU
+NZ
+ED
+kt
+Wj
+oR
+oR
+"}
+(15,1,1) = {"
+Uy
+jl
+jl
+FR
+eC
+ED
+TO
+zg
+kJ
+fB
+kJ
+gA
+Hs
+kt
+PL
+da
+er
+ne
+pd
+ED
+kt
+er
+Bi
+Bi
+"}
+(16,1,1) = {"
+eb
+eb
+eb
+eb
+eb
+dc
+Nz
+zg
+Hs
+Hs
+Hs
+Hs
+Hs
+Hs
+Hs
+Ng
+Hs
+QD
+Dp
+dc
+QJ
+QJ
+QJ
+QJ
+"}
+(17,1,1) = {"
+eb
+eb
+eb
+eb
+eb
+ZW
+NT
+mn
+Hs
+Hs
+vr
+Hs
+Hs
+wU
+gU
+KP
+rd
+QD
+LN
+ht
+QJ
+QJ
+QJ
+QJ
+"}
+(18,1,1) = {"
+eb
+eb
+eb
+eb
+eb
+dc
+Nz
+Qn
+Hs
+Hs
+Hs
+dZ
+aX
+fj
+Ow
+tB
+sC
+QD
+Dp
+dc
+QJ
+QJ
+QJ
+QJ
+"}
+(19,1,1) = {"
+eu
+cH
+cH
+eD
+kv
+sq
+PD
+Qn
+Tm
+Zh
+Tm
+Mu
+zs
+es
+jw
+MS
+EC
+jL
+UX
+sq
+es
+EC
+wK
+wK
+"}
+(20,1,1) = {"
+cS
+Jm
+Jm
+Zd
+kv
+sq
+PD
+eA
+mq
+mq
+mq
+mq
+cs
+es
+ia
+RK
+nq
+rp
+UX
+sq
+es
+nq
+Rw
+Rw
+"}
+(21,1,1) = {"
+mX
+ID
+ID
+za
+kv
+sq
+PD
+zg
+Tm
+Zh
+Tm
+Sv
+jz
+es
+xl
+qk
+Gc
+BN
+UX
+sq
+es
+Gc
+ez
+ez
+"}
+(22,1,1) = {"
+eb
+eb
+eb
+eb
+eb
+dc
+Nz
+zg
+Hs
+MQ
+sC
+xu
+tL
+zs
+tH
+jY
+Hs
+QD
+Dp
+dc
+QJ
+QJ
+QJ
+QJ
+"}
+(23,1,1) = {"
+eb
+eb
+eb
+eb
+eb
+ht
+UR
+Hs
+Hs
+ek
+Sk
+sC
+Hs
+wU
+Hs
+Ng
+Hs
+QD
+LN
+ht
+QJ
+QJ
+QJ
+QJ
+"}
+(24,1,1) = {"
+eb
+eb
+eb
+eb
+eb
+dc
+Nz
+zg
+Hs
+ep
+ek
+MQ
+Hs
+Hs
+Hs
+Ng
+Hs
+QD
+Dp
+dc
+QJ
+QJ
+QJ
+QJ
+"}
+(25,1,1) = {"
+eu
+cH
+cH
+eD
+kv
+sq
+PD
+zg
+Tm
+Zh
+Tm
+gA
+Hs
+es
+cs
+Kv
+EC
+jL
+UX
+sq
+es
+EC
+wK
+wK
+"}
+(26,1,1) = {"
+cS
+Jm
+Jm
+Zd
+kv
+sq
+PD
+VQ
+mq
+mq
+mq
+mq
+cs
+es
+cs
+Kv
+nq
+rp
+UX
+sq
+es
+nq
+Rw
+Rw
+"}
+(27,1,1) = {"
+wn
+Um
+Um
+jq
+Oi
+sq
+PD
+zg
+Tm
+Zh
+Tm
+gA
+Hs
+es
+cs
+Kv
+Gc
+BN
+UX
+Vm
+kQ
+sE
+lX
+lX
+"}
+(28,1,1) = {"
+Et
+gw
+gw
+gw
+gw
+dc
+Xf
+lh
+Bt
+Bt
+Bt
+Bt
+Bt
+Bt
+Hs
+Ng
+Bt
+TR
+Xf
+dc
+py
+Ep
+QJ
+QJ
+"}
+(29,1,1) = {"
+Yt
+qJ
+qJ
+qJ
+qJ
+wU
+Xf
+GM
+GM
+jd
+GM
+GM
+Xf
+GM
+Wo
+nR
+GM
+jd
+Xf
+wU
+Oj
+fe
+QJ
+QJ
+"}
+(30,1,1) = {"
+Yt
+CK
+Hb
+Hb
+Hb
+wU
+dc
+Yq
+Yq
+dc
+Yq
+Yq
+dc
+Yq
+Uc
+FO
+Yq
+dc
+wU
+wU
+Oj
+fe
+ym
+hw
+"}
+(31,1,1) = {"
+Yt
+qJ
+PG
+sv
+Hn
+ru
+XB
+XI
+mH
+Fb
+lf
+Hm
+Hm
+Og
+De
+nY
+DH
+gF
+PE
+PG
+Oj
+fe
+tj
+RA
+"}
+(32,1,1) = {"
+MZ
+LD
+hh
+yw
+En
+Tz
+Tz
+Tz
+Tz
+Tz
+Tz
+Tz
+Tz
+Tz
+De
+nY
+Tz
+Tz
+cX
+td
+Rz
+cl
+tj
+ge
+"}
+(33,1,1) = {"
+rJ
+yM
+zR
+Kz
+De
+VK
+De
+De
+De
+De
+De
+De
+De
+nz
+yX
+nY
+De
+De
+Ht
+mu
+ym
+hw
+RA
+ge
+"}
+(34,1,1) = {"
+KW
+nw
+TN
+VK
+VK
+NY
+Zw
+ZN
+xO
+xO
+sf
+WX
+xO
+xO
+ZN
+hJ
+Ld
+De
+Ht
+mu
+Fi
+VY
+RA
+ge
+"}
+(35,1,1) = {"
+gr
+gw
+Mw
+fT
+ph
+ph
+OR
+YO
+Tz
+Tz
+hk
+Lr
+EH
+oj
+wA
+De
+De
+VG
+oW
+td
+py
+Ep
+tj
+ge
+"}
+(36,1,1) = {"
+Yt
+qJ
+Rs
+yn
+yn
+ph
+gZ
+VE
+Tz
+Tz
+De
+Gu
+Oc
+rG
+iv
+Te
+Te
+iv
+qG
+iv
+Oj
+fe
+tj
+ge
+"}
+(37,1,1) = {"
+wL
+wL
+AJ
+AJ
+AJ
+rG
+rG
+pe
+Vp
+Tz
+De
+Gu
+oY
+rG
+Ce
+ZV
+ZV
+cn
+fL
+qG
+Oj
+fe
+tj
+ge
+"}
+(38,1,1) = {"
+BU
+rh
+BU
+Ox
+wL
+wL
+rG
+od
+tJ
+Tz
+De
+Gu
+oY
+rG
+rq
+cn
+cn
+cn
+cw
+qG
+Oj
+fe
+tj
+ge
+"}
+(39,1,1) = {"
+gV
+gV
+gV
+Ox
+wL
+wL
+rG
+rG
+cM
+Tz
+De
+Gu
+wH
+rG
+iO
+cn
+cn
+cn
+yZ
+qG
+Oj
+fe
+tj
+ge
+"}
+(40,1,1) = {"
+gV
+gV
+gV
+Ox
+wL
+wL
+wL
+rG
+HD
+VE
+Mf
+Gu
+wH
+rG
+UJ
+cn
+cn
+cn
+tN
+qG
+du
+fe
+Fi
+VY
+"}
+(41,1,1) = {"
+gV
+gV
+gV
+Ox
+wL
+wL
+wL
+rG
+rG
+rG
+rG
+ee
+rG
+rG
+GW
+cn
+cn
+cn
+Go
+qG
+dv
+fe
+QJ
+or
+"}
+(42,1,1) = {"
+gV
+gV
+gV
+Ox
+wL
+wL
+wL
+wL
+wL
+wL
+wL
+tx
+wL
+rG
+cn
+cn
+cn
+cn
+gS
+qG
+wL
+wL
+wL
+wL
+"}
+(43,1,1) = {"
+gV
+gV
+gV
+Ox
+wL
+wL
+wL
+wL
+wL
+wL
+wL
+tx
+wL
+rG
+Nx
+AV
+Nj
+rY
+hH
+qG
+wL
+wL
+wL
+wL
+"}
+(44,1,1) = {"
+gV
+gV
+gV
+Ox
+wL
+wL
+wL
+wL
+wL
+wL
+wL
+tx
+wL
+rG
+qG
+qG
+qG
+qG
+qG
+qG
+wL
+wL
+wL
+wL
+"}

--- a/maps/map_files/DesertDam/sprinkles/25.clftrijent.dmm
+++ b/maps/map_files/DesertDam/sprinkles/25.clftrijent.dmm
@@ -58,16 +58,26 @@
 	},
 /area/desert_dam/interior/dam_interior/control_room)
 <<<<<<< master
+<<<<<<< master
 "bD" = (
 /obj/effect/spawner/random/attachment,
 /obj/effect/landmark/survivor_spawner/clf/generic,
+=======
+"bD" = (
+/obj/effect/spawner/random/attachment,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor{
 	dir = 7;
 	icon_state = "warning"
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "bJ" = (
 /turf/open/floor/prison{
 	dir = 10;
@@ -127,6 +137,9 @@
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "cq" = (
 /obj/effect/landmark/corpsespawner/clf,
 /obj/item/weapon/melee/twohanded/lungemine,
@@ -135,8 +148,11 @@
 	icon_state = "tile"
 	},
 /area/desert_dam/exterior/valley/south_valley_dam)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "cs" = (
 /obj/effect/blocker/toxic_water/Group_2,
 /turf/open/floor{
@@ -145,11 +161,15 @@
 /area/desert_dam/interior/dam_interior/engine_room)
 "cw" = (
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 /obj/effect/landmark/corpsespawner/clf,
 /obj/item/weapon/melee/katana,
 /obj/effect/decal/cleanable/blood,
 /turf/open/asphalt{
 	icon_state = "tile"
+<<<<<<< master
 	},
 /area/desert_dam/exterior/valley/south_valley_dam)
 "cz" = (
@@ -182,13 +202,25 @@
 /turf/open/floor/prison{
 	dir = 10;
 	tag = "icon-floor (SOUTHWEST)"
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 	},
-/area/desert_dam/interior/dam_interior/atmos_storage)
+/area/desert_dam/exterior/valley/south_valley_dam)
 "cz" = (
 /obj/effect/landmark/corpsespawner/engineer,
-/obj/item/weapon/melee/baseballbat/metal,
 /obj/effect/decal/cleanable/blood,
+<<<<<<< master
 >>>>>>> reimported backup
+=======
+/obj/item/weapon/gun/smg/fp9000{
+	pixel_y = 7
+	},
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -204,9 +236,12 @@
 /obj/structure/window_frame/colony,
 /obj/structure/window_frame/colony,
 <<<<<<< master
+<<<<<<< master
 =======
 /obj/item/stack/rods,
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 /obj/item/shard{
 	icon_state = "medium"
 	},
@@ -273,17 +308,23 @@
 /area/desert_dam/interior/dam_interior/engine_room)
 "dq" = (
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 /obj/item/stack/tile/plasteel,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
 /area/desert_dam/exterior/valley/north_valley_dam)
+<<<<<<< master
 =======
 /obj/structure/window_frame/colony,
 /obj/item/stack/rods,
 /turf/open/floor/plating,
 /area/desert_dam/interior/dam_interior/smes_main)
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "du" = (
 /turf/open/desert/dirt{
 	dir = 10;
@@ -337,6 +378,7 @@
 	},
 /obj/effect/landmark/corpsespawner/engineer,
 <<<<<<< master
+<<<<<<< master
 /obj/effect/decal/cleanable/blood,
 /obj/item/weapon/gun/rifle/m16{
 	pixel_x = 5;
@@ -346,6 +388,13 @@
 /obj/item/weapon/melee/baseballbat/metal,
 /obj/effect/decal/cleanable/blood,
 >>>>>>> reimported backup
+=======
+/obj/effect/decal/cleanable/blood,
+/obj/item/weapon/gun/rifle/m16{
+	pixel_x = 5;
+	pixel_y = 6
+	},
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor{
 	icon_state = "neutral"
 	},
@@ -409,6 +458,7 @@
 /obj/effect/blocker/toxic_water/Group_2,
 /obj/effect/landmark/corpsespawner/engineer,
 <<<<<<< master
+<<<<<<< master
 /obj/effect/decal/cleanable/blood,
 /obj/item/weapon/gun/rifle/hunting,
 /obj/item/ammo_magazine/rifle/hunting,
@@ -420,6 +470,15 @@
 /obj/item/weapon/melee/baseballbat/metal,
 /obj/effect/decal/cleanable/blood,
 >>>>>>> reimported backup
+=======
+/obj/effect/decal/cleanable/blood,
+/obj/item/weapon/gun/rifle/hunting,
+/obj/item/ammo_magazine/rifle/hunting,
+/obj/item/ammo_magazine/rifle/hunting,
+/obj/item/ammo_magazine/rifle/hunting,
+/obj/item/ammo_magazine/rifle/hunting,
+/obj/item/ammo_magazine/rifle/hunting,
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor{
 	dir = 1;
 	icon_state = "warning"
@@ -454,11 +513,17 @@
 /obj/item/ammo_casing/bullet,
 /obj/effect/decal/cleanable/dirt,
 <<<<<<< master
+<<<<<<< master
 /obj/item/ammo_box/magazine/shotgun/buckshot,
 /obj/item/ammo_box/magazine/shotgun,
 /obj/item/ammo_magazine/shotgun/incendiary,
 =======
 >>>>>>> reimported backup
+=======
+/obj/item/ammo_box/magazine/shotgun/buckshot,
+/obj/item/ammo_box/magazine/shotgun,
+/obj/item/ammo_magazine/shotgun/incendiary,
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor{
 	icon_state = "neutral"
 	},
@@ -484,6 +549,7 @@
 /area/desert_dam/interior/dam_interior/control_room)
 "fL" = (
 <<<<<<< master
+<<<<<<< master
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/asphalt{
 	icon_state = "tile"
@@ -506,6 +572,13 @@
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
 >>>>>>> reimported backup
+=======
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/asphalt{
+	icon_state = "tile"
+	},
+/area/desert_dam/exterior/valley/south_valley_dam)
+>>>>>>> updated all maps to have CLF Mines and corpses
 "fM" = (
 /turf/closed/wall/hangar{
 	name = "reinforced metal wall"
@@ -549,6 +622,9 @@
 	},
 /area/desert_dam/exterior/valley/north_valley_dam)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "gu" = (
 /obj/item/stack/sheet/wood,
 /turf/open/floor/prison{
@@ -557,8 +633,11 @@
 	tag = "icon-bright_clean (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/smes_main)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "gw" = (
 /obj/effect/decal/sand_overlay/sand1{
 	dir = 8
@@ -583,6 +662,7 @@
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 "gS" = (
 <<<<<<< master
+<<<<<<< master
 /obj/item/stack/sheet/wood,
 /turf/open/floor/prison{
 	dir = 1;
@@ -594,12 +674,19 @@
 /obj/item/ammo_magazine/shotgun/slugs,
 /obj/item/ammo_magazine/shotgun/slugs,
 /obj/item/ammo_magazine/shotgun/slugs,
+=======
+/obj/item/stack/sheet/wood,
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor/prison{
-	dir = 10;
-	tag = "icon-floor (SOUTHWEST)"
+	dir = 1;
+	icon_state = "darkyellow2"
 	},
+<<<<<<< master
 /area/desert_dam/interior/dam_interior/atmos_storage)
 >>>>>>> reimported backup
+=======
+/area/desert_dam/interior/dam_interior/smes_main)
+>>>>>>> updated all maps to have CLF Mines and corpses
 "gU" = (
 /obj/structure/machinery/power/apc{
 	dir = 1;
@@ -630,9 +717,12 @@
 "hh" = (
 /obj/structure/window_frame/colony,
 <<<<<<< master
+<<<<<<< master
 =======
 /obj/item/stack/rods,
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor/plating,
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 "hk" = (
@@ -651,6 +741,9 @@
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "hr" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
@@ -665,16 +758,22 @@
 	icon_state = "neutral"
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
+<<<<<<< master
 "ht" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
 /obj/item/explosive/mine/clf/active,
 =======
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "ht" = (
-/obj/item/stack/rods,
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
+<<<<<<< master
 >>>>>>> reimported backup
+=======
+/obj/item/explosive/mine/clf/active,
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -687,6 +786,7 @@
 	},
 /area/desert_dam/exterior/valley/south_valley_dam)
 "hH" = (
+<<<<<<< master
 <<<<<<< master
 /obj/item/stack/tile/plasteel,
 /turf/open/floor{
@@ -705,6 +805,13 @@
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
 >>>>>>> reimported backup
+=======
+/obj/item/stack/tile/plasteel,
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+>>>>>>> updated all maps to have CLF Mines and corpses
 "hJ" = (
 /obj/structure/pipes/standard/manifold/hidden/green{
 	dir = 4
@@ -760,13 +867,26 @@
 /area/desert_dam/interior/dam_interior/engine_room)
 =======
 "iO" = (
-/obj/structure/bed,
-/turf/open/floor/prison{
-	dir = 10;
-	tag = "icon-floor (SOUTHWEST)"
+/obj/effect/landmark/corpsespawner/engineer,
+/obj/item/tool/weldpack,
+/obj/item/tool/weldingtool{
+	pixel_y = -9;
+	pixel_x = 11
 	},
+<<<<<<< master
 /area/desert_dam/interior/dam_interior/atmos_storage)
 >>>>>>> reimported backup
+=======
+/obj/item/clothing/glasses/welding{
+	pixel_y = 9;
+	pixel_x = -12
+	},
+/turf/open/floor{
+	dir = 8;
+	icon_state = "warning"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+>>>>>>> updated all maps to have CLF Mines and corpses
 "jb" = (
 /obj/structure/machinery/colony_floodlight,
 /obj/effect/decal/sand_overlay/sand1/corner1{
@@ -872,9 +992,12 @@
 "ki" = (
 /obj/structure/window_frame/colony,
 <<<<<<< master
+<<<<<<< master
 =======
 /obj/item/stack/rods,
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 /obj/item/shard{
 	icon_state = "medium"
 	},
@@ -894,9 +1017,13 @@
 /obj/effect/decal/cleanable/blood,
 /obj/item/weapon/gun/smg/nailgun,
 <<<<<<< master
+<<<<<<< master
 /obj/item/clothing/accessory/storage/webbing,
 =======
 >>>>>>> reimported backup
+=======
+/obj/item/clothing/accessory/storage/webbing,
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -918,6 +1045,9 @@
 	},
 /area/desert_dam/exterior/river/riverside_central_south)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "kY" = (
 /obj/item/stack/tile/plasteel,
 /obj/item/explosive/mine/clf/active{
@@ -927,6 +1057,7 @@
 	icon_state = "platingdmg3"
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
+<<<<<<< master
 "lc" = (
 /obj/structure/disposalpipe/segment,
 =======
@@ -934,6 +1065,10 @@
 /obj/structure/disposalpipe/segment,
 /obj/item/stack/rods,
 >>>>>>> reimported backup
+=======
+"lc" = (
+/obj/structure/disposalpipe/segment,
+>>>>>>> updated all maps to have CLF Mines and corpses
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
 /turf/open/floor/prison{
@@ -952,9 +1087,14 @@
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 "lh" = (
 <<<<<<< master
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
 =======
 >>>>>>> reimported backup
+=======
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor{
 	dir = 5;
 	icon_state = "warning"
@@ -977,14 +1117,20 @@
 /turf/open/floor/plating,
 /area/desert_dam/interior/dam_interior/smes_main)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "lJ" = (
 /obj/item/stack/tile/plasteel,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "lX" = (
 /obj/structure/platform{
 	dir = 4
@@ -995,20 +1141,27 @@
 	},
 /area/desert_dam/exterior/river/riverside_central_south)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "lY" = (
 /obj/item/stack/sheet/wood,
 /turf/open/floor/prison{
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/smes_backup)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "mj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
+<<<<<<< master
 <<<<<<< master
 /obj/item/shard{
 	icon_state = "medium"
@@ -1022,6 +1175,14 @@
 	icon_state = "medium"
 	},
 >>>>>>> reimported backup
+=======
+/obj/item/shard{
+	icon_state = "medium"
+	},
+/obj/item/explosive/mine/clf/active{
+	dir = 8
+	},
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -1042,9 +1203,13 @@
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
 <<<<<<< master
+<<<<<<< master
 /obj/item/explosive/mine/clf/active,
 =======
 >>>>>>> reimported backup
+=======
+/obj/item/explosive/mine/clf/active,
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -1052,13 +1217,19 @@
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "mw" = (
 /obj/effect/blocker/toxic_water/Group_2,
 /obj/item/explosive/mine/clf/active,
 /turf/open/floor/greengrid,
 /area/desert_dam/interior/dam_interior/engine_room)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "mz" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/structure/disposalpipe/segment,
@@ -1112,6 +1283,9 @@
 /turf/open/gm/river/desert/deep,
 /area/desert_dam/exterior/river/riverside_central_north)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "na" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/attachment,
@@ -1119,8 +1293,11 @@
 	icon_state = "platingdmg3"
 	},
 /area/desert_dam/interior/dam_interior/control_room)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "ne" = (
 /obj/structure/platform{
 	dir = 4
@@ -1130,15 +1307,25 @@
 /turf/open/gm/river/desert/deep,
 /area/desert_dam/exterior/river/riverside_central_south)
 <<<<<<< master
+<<<<<<< master
 "nk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/survivor_spawner/clf/generic,
+=======
+"nk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
 /area/desert_dam/interior/dam_interior/control_room)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "nq" = (
 /obj/structure/platform{
 	dir = 1
@@ -1149,10 +1336,15 @@
 "nr" = (
 /obj/effect/decal/cleanable/dirt,
 <<<<<<< master
+<<<<<<< master
 /obj/item/stack/tile/plasteel,
 /obj/effect/spawner/random/attachment,
 =======
 >>>>>>> reimported backup
+=======
+/obj/item/stack/tile/plasteel,
+/obj/effect/spawner/random/attachment,
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor/plating{
 	dir = 10;
 	icon_state = "warnplate"
@@ -1234,6 +1426,8 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -1348,6 +1542,7 @@
 	},
 /obj/effect/landmark/corpsespawner/security/cmb,
 <<<<<<< master
+<<<<<<< master
 /obj/item/ammo_casing/bullet,
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/blood,
@@ -1361,6 +1556,12 @@
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/blood,
 >>>>>>> reimported backup
+=======
+/obj/item/ammo_casing/bullet,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/blood,
+/obj/item/weapon/gun/rifle/m16,
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor{
 	icon_state = "neutral"
 	},
@@ -1375,17 +1576,26 @@
 	},
 /area/desert_dam/interior/dam_interior/control_room)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "qD" = (
 /obj/item/explosive/mine/clf/active{
 	dir = 4
 	},
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor{
 	icon_state = "neutral"
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "qE" = (
 /turf/open/floor/prison{
 	dir = 1;
@@ -1397,6 +1607,7 @@
 	name = "reinforced metal wall"
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
+<<<<<<< master
 <<<<<<< master
 "qH" = (
 /obj/structure/pipes/standard/simple/hidden/green,
@@ -1411,6 +1622,16 @@
 /area/desert_dam/interior/dam_interior/control_room)
 =======
 >>>>>>> reimported backup
+=======
+"qH" = (
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
+>>>>>>> updated all maps to have CLF Mines and corpses
 "qJ" = (
 /turf/open/desert/dirt,
 /area/desert_dam/exterior/valley/north_valley_dam)
@@ -1449,6 +1670,7 @@
 /area/desert_dam/exterior/river/riverside_central_south)
 "rq" = (
 <<<<<<< master
+<<<<<<< master
 /obj/structure/platform{
 	dir = 1
 	},
@@ -1467,6 +1689,16 @@
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
 >>>>>>> reimported backup
+=======
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "warning"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+>>>>>>> updated all maps to have CLF Mines and corpses
 "ru" = (
 /obj/structure/closet/toolcloset,
 /obj/structure/machinery/light{
@@ -1480,9 +1712,12 @@
 "rv" = (
 /obj/structure/window_frame/colony,
 <<<<<<< master
+<<<<<<< master
 =======
 /obj/item/stack/rods,
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 /obj/item/shard{
 	icon_state = "medium"
 	},
@@ -1503,9 +1738,12 @@
 "rA" = (
 /obj/structure/window_frame/colony,
 <<<<<<< master
+<<<<<<< master
 =======
 /obj/item/stack/rods,
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 /obj/item/shard{
 	icon_state = "medium"
 	},
@@ -1553,6 +1791,7 @@
 /area/desert_dam/interior/dam_interior/control_room)
 "rY" = (
 <<<<<<< master
+<<<<<<< master
 /obj/effect/blocker/toxic_water/Group_2,
 /obj/structure/barricade/metal/wired{
 	icon_state = "metal_1"
@@ -1572,6 +1811,17 @@
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
 >>>>>>> reimported backup
+=======
+/obj/effect/blocker/toxic_water/Group_2,
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1"
+	},
+/obj/item/explosive/mine/clf/active{
+	dir = 1
+	},
+/turf/open/gm/river/desert/deep/covered,
+/area/desert_dam/exterior/river/riverside_central_south)
+>>>>>>> updated all maps to have CLF Mines and corpses
 "sf" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/structure/disposalpipe/segment{
@@ -1587,6 +1837,8 @@
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 "sk" = (
 /obj/item/ammo_casing/bullet,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -1597,9 +1849,12 @@
 /obj/effect/blocker/toxic_water/Group_2,
 /obj/structure/window_frame/colony,
 <<<<<<< master
+<<<<<<< master
 =======
 /obj/item/stack/rods,
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 /obj/item/shard{
 	icon_state = "medium"
 	},
@@ -1667,9 +1922,12 @@
 "td" = (
 /obj/structure/window_frame/colony,
 <<<<<<< master
+<<<<<<< master
 =======
 /obj/item/stack/rods,
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 /obj/item/shard{
 	icon_state = "medium"
 	},
@@ -1681,6 +1939,9 @@
 	},
 /area/desert_dam/exterior/valley/south_valley_dam)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "tr" = (
 /obj/item/stack/rods,
 /obj/effect/decal/cleanable/blood/oil,
@@ -1694,8 +1955,11 @@
 	tag = "icon-bright_clean (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "tx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -1721,13 +1985,19 @@
 	icon_state = "sandbag_2"
 	},
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor{
 	icon_state = "neutral"
 	},
@@ -1757,10 +2027,14 @@
 /area/desert_dam/interior/dam_interior/engine_room)
 "tN" = (
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/tile/plasteel,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
+<<<<<<< master
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
 =======
@@ -1792,6 +2066,10 @@
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
 >>>>>>> reimported backup
+=======
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+>>>>>>> updated all maps to have CLF Mines and corpses
 "tP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -1846,6 +2124,9 @@
 	},
 /area/desert_dam/interior/dam_interior/smes_backup)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "vo" = (
 /obj/effect/spawner/random/attachment,
 /turf/open/floor/prison{
@@ -1853,7 +2134,10 @@
 	tag = "icon-floor (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
+<<<<<<< master
 =======
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "vr" = (
 /obj/effect/landmark/survivor_spawn,
 /turf/open/floor{
@@ -1931,6 +2215,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/corpsespawner/engineer,
 <<<<<<< master
+<<<<<<< master
 /obj/effect/decal/cleanable/blood,
 /obj/item/weapon/gun/shotgun/pump/cmb{
 	pixel_y = 9
@@ -1940,6 +2225,12 @@
 /obj/item/weapon/melee/baseballbat,
 /obj/effect/decal/cleanable/blood,
 >>>>>>> reimported backup
+=======
+/obj/effect/decal/cleanable/blood,
+/obj/item/weapon/gun/shotgun/pump/cmb{
+	pixel_y = 9
+	},
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -2041,13 +2332,19 @@
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "ys" = (
 /obj/effect/landmark/corpsespawner/clf,
 /obj/item/weapon/melee/baseballbat/metal,
 /turf/open/desert/dirt,
 /area/desert_dam/exterior/valley/south_valley_dam)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "yw" = (
 /obj/structure/barricade/wooden{
 	dir = 1
@@ -2058,14 +2355,20 @@
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "yC" = (
 /obj/item/explosive/mine/clf/active,
 /turf/open/floor{
 	icon_state = "neutral"
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "yM" = (
 /turf/open/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached14"
@@ -2075,6 +2378,9 @@
 /obj/effect/landmark/corpsespawner/security,
 /obj/effect/decal/cleanable/blood,
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 /obj/item/weapon/gun/smg/fp9000{
 	pixel_y = -8
 	},
@@ -2083,9 +2389,12 @@
 /obj/item/ammo_magazine/smg/fp9000,
 /obj/item/ammo_magazine/smg/fp9000,
 /obj/item/ammo_magazine/smg/fp9000,
+<<<<<<< master
 =======
 /obj/item/weapon/gun/pistol/b92fs,
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -2093,6 +2402,7 @@
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 "yZ" = (
+<<<<<<< master
 <<<<<<< master
 /obj/item/stack/tile/plasteel,
 /turf/open/floor/plating{
@@ -2114,6 +2424,11 @@
 	dir = 10;
 	tag = "icon-floor (SOUTHWEST)"
 >>>>>>> reimported backup
+=======
+/obj/item/stack/tile/plasteel,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+>>>>>>> updated all maps to have CLF Mines and corpses
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
 "za" = (
@@ -2125,6 +2440,9 @@
 /turf/open/gm/river/desert/deep,
 /area/desert_dam/exterior/river/riverside_central_north)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "zc" = (
 /obj/item/explosive/mine/clf/active{
 	dir = 4
@@ -2134,8 +2452,11 @@
 	tag = "icon-floor (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "zd" = (
 /obj/structure/platform{
 	dir = 1
@@ -2160,9 +2481,12 @@
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
 <<<<<<< master
+<<<<<<< master
 =======
 /obj/item/stack/rods,
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -2178,6 +2502,7 @@
 "zR" = (
 /obj/effect/decal/cleanable/blood/oil,
 <<<<<<< master
+<<<<<<< master
 /obj/item/stack/cable_coil/cut,
 /obj/item/explosive/mine/clf/active{
 	dir = 1
@@ -2186,6 +2511,12 @@
 /obj/item/stack/rods,
 /obj/item/stack/cable_coil/cut,
 >>>>>>> reimported backup
+=======
+/obj/item/stack/cable_coil/cut,
+/obj/item/explosive/mine/clf/active{
+	dir = 1
+	},
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -2246,6 +2577,7 @@
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 "AV" = (
 <<<<<<< master
+<<<<<<< master
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/attachment,
@@ -2261,6 +2593,15 @@
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
 >>>>>>> reimported backup
+=======
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/attachment,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/turf/open/floor/greengrid,
+/area/desert_dam/interior/dam_interior/smes_main)
+>>>>>>> updated all maps to have CLF Mines and corpses
 "Bi" = (
 /obj/structure/platform{
 	dir = 4
@@ -2329,6 +2670,9 @@
 /area/desert_dam/interior/dam_interior/smes_main)
 "Ce" = (
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 /obj/item/explosive/mine/clf/active{
 	dir = 4
 	},
@@ -2340,9 +2684,12 @@
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 "Cu" = (
 /obj/item/stack/tile/plasteel,
+<<<<<<< master
 =======
 /obj/structure/machinery/cm_vending/sorted/tech/electronics_storage,
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor/prison{
 	dir = 10;
 	tag = "icon-floor (SOUTHWEST)"
@@ -2373,12 +2720,16 @@
 /area/desert_dam/interior/dam_interior/control_room)
 "CS" = (
 <<<<<<< master
+<<<<<<< master
 /obj/item/stack/sheet/wood,
 =======
 /obj/structure/barricade/wooden{
 	dir = 8
 	},
 >>>>>>> reimported backup
+=======
+/obj/item/stack/sheet/wood,
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "darkyellowcorners2"
@@ -2522,9 +2873,12 @@
 /obj/effect/blocker/toxic_water/Group_1,
 /obj/structure/window_frame/colony,
 <<<<<<< master
+<<<<<<< master
 =======
 /obj/item/stack/rods,
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 /obj/item/shard{
 	icon_state = "medium"
 	},
@@ -2605,6 +2959,7 @@
 /area/desert_dam/interior/dam_interior/control_room)
 "FO" = (
 <<<<<<< master
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor{
 	dir = 1;
@@ -2624,6 +2979,13 @@
 	icon_state = "bright_clean";
 	tag = "icon-bright_clean (SOUTHWEST)"
 >>>>>>> reimported backup
+=======
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "warning"
+>>>>>>> updated all maps to have CLF Mines and corpses
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
 "FR" = (
@@ -2635,6 +2997,9 @@
 /turf/open/gm/river/desert/deep,
 /area/desert_dam/exterior/river/riverside_central_north)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "FY" = (
 /obj/item/stack/tile/plasteel,
 /turf/open/floor{
@@ -2642,8 +3007,11 @@
 	icon_state = "damaged3"
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "Gb" = (
 /obj/structure/machinery/power/smes/buildable{
 	capacity = 1e+006;
@@ -2663,6 +3031,7 @@
 /turf/open/gm/river/desert/deep,
 /area/desert_dam/exterior/river/riverside_central_south)
 "Go" = (
+<<<<<<< master
 <<<<<<< master
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
@@ -2688,6 +3057,10 @@
 	dir = 10;
 	tag = "icon-floor (SOUTHWEST)"
 >>>>>>> reimported backup
+=======
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+>>>>>>> updated all maps to have CLF Mines and corpses
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
 "Gr" = (
@@ -2711,14 +3084,20 @@
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "Gz" = (
 /obj/effect/spawner/random/attachment,
 /turf/open/floor{
 	icon_state = "neutral"
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "GM" = (
 /obj/structure/barricade/metal/wired{
 	icon_state = "metal_1";
@@ -2738,6 +3117,7 @@
 /area/desert_dam/interior/dam_interior/smes_main)
 "GW" = (
 <<<<<<< master
+<<<<<<< master
 /obj/effect/spawner/random/attachment,
 /turf/open/floor{
 	icon_state = "platingdmg1"
@@ -2747,6 +3127,11 @@
 	dir = 10;
 	tag = "icon-floor (SOUTHWEST)"
 >>>>>>> reimported backup
+=======
+/obj/effect/spawner/random/attachment,
+/turf/open/floor{
+	icon_state = "platingdmg1"
+>>>>>>> updated all maps to have CLF Mines and corpses
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
 "Hb" = (
@@ -2796,23 +3181,32 @@
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "Hw" = (
 /obj/item/stack/tile/plasteel,
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "HB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
 <<<<<<< master
+<<<<<<< master
 =======
 /obj/item/stack/rods,
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -2850,6 +3244,9 @@
 	},
 /area/desert_dam/interior/dam_interior/control_room)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "IB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/sheet/wood,
@@ -2858,8 +3255,11 @@
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/smes_backup)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "ID" = (
 /obj/structure/platform{
 	dir = 4
@@ -2893,12 +3293,18 @@
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
 <<<<<<< master
+<<<<<<< master
 /obj/item/explosive/mine/clf/active{
 	dir = 8
 	},
 =======
 /obj/item/stack/rods,
 >>>>>>> reimported backup
+=======
+/obj/item/explosive/mine/clf/active{
+	dir = 8
+	},
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -2980,6 +3386,7 @@
 /area/desert_dam/exterior/valley/north_valley_dam)
 "KY" = (
 <<<<<<< master
+<<<<<<< master
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/sheet/wood,
 =======
@@ -2988,6 +3395,10 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 >>>>>>> reimported backup
+=======
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/sheet/wood,
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor/plating{
 	dir = 8;
 	icon_state = "warnplate"
@@ -3076,6 +3487,7 @@
 	icon_state = "medium"
 	},
 <<<<<<< master
+<<<<<<< master
 /turf/open/floor/plating,
 /area/desert_dam/interior/dam_interior/engine_room)
 "Ml" = (
@@ -3091,6 +3503,18 @@
 /turf/open/floor/plating,
 /area/desert_dam/interior/dam_interior/engine_room)
 >>>>>>> reimported backup
+=======
+/turf/open/floor/plating,
+/area/desert_dam/interior/dam_interior/engine_room)
+"Ml" = (
+/obj/item/explosive/mine/clf/active{
+	dir = 1
+	},
+/turf/open/floor{
+	icon_state = "neutral"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
+>>>>>>> updated all maps to have CLF Mines and corpses
 "Mm" = (
 /obj/structure/machinery/power/smes/buildable{
 	capacity = 1e+006;
@@ -3113,9 +3537,12 @@
 "Mw" = (
 /obj/structure/window_frame/colony,
 <<<<<<< master
+<<<<<<< master
 =======
 /obj/item/stack/rods,
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -3180,6 +3607,7 @@
 /area/desert_dam/interior/dam_interior/engine_room)
 "Nj" = (
 <<<<<<< master
+<<<<<<< master
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -3198,9 +3626,14 @@
 /turf/open/floor/prison{
 	dir = 10;
 	tag = "icon-floor (SOUTHWEST)"
+=======
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+>>>>>>> updated all maps to have CLF Mines and corpses
 	},
-/area/desert_dam/interior/dam_interior/atmos_storage)
+/area/desert_dam/exterior/valley/north_valley_dam)
 "Nx" = (
+<<<<<<< master
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/clothing/glasses/welding,
 /obj/item/stack/sheet/metal/large_stack,
@@ -3212,6 +3645,11 @@
 	dir = 10;
 	tag = "icon-floor (SOUTHWEST)"
 >>>>>>> reimported backup
+=======
+/turf/open/floor{
+	dir = 8;
+	icon_state = "damaged3"
+>>>>>>> updated all maps to have CLF Mines and corpses
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
 "Nz" = (
@@ -3312,6 +3750,9 @@
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "OS" = (
 /obj/effect/landmark/corpsespawner/clf,
 /obj/item/weapon/gun/smg/fp9000{
@@ -3337,6 +3778,9 @@
 	},
 /area/desert_dam/interior/dam_interior/control_room)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "Pk" = (
 /obj/effect/landmark/corpsespawner/clf,
 /obj/item/weapon/melee/twohanded/lungemine,
@@ -3346,8 +3790,11 @@
 	tag = "icon-bright_clean (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "Pr" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -3470,6 +3917,9 @@
 	},
 /area/desert_dam/exterior/valley/south_valley_dam)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "QK" = (
 /obj/item/clothing/accessory/storage/webbing,
 /turf/open/floor{
@@ -3477,6 +3927,7 @@
 	icon_state = "warning"
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
+<<<<<<< master
 "QM" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
@@ -3492,6 +3943,8 @@
 /area/desert_dam/interior/dam_interior/engine_room)
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "Rh" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
@@ -3510,6 +3963,7 @@
 	},
 /obj/effect/landmark/corpsespawner/security,
 <<<<<<< master
+<<<<<<< master
 /obj/effect/decal/cleanable/blood,
 /obj/item/weapon/gun/shotgun/pump/cmb{
 	pixel_y = 3
@@ -3518,6 +3972,12 @@
 /obj/item/weapon/gun/pistol/b92fs,
 /obj/effect/decal/cleanable/blood,
 >>>>>>> reimported backup
+=======
+/obj/effect/decal/cleanable/blood,
+/obj/item/weapon/gun/shotgun/pump/cmb{
+	pixel_y = 3
+	},
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor/prison{
 	dir = 8;
 	icon_state = "darkyellow2"
@@ -3590,9 +4050,13 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 <<<<<<< master
+<<<<<<< master
 /obj/item/stack/tile/plasteel,
 =======
 >>>>>>> reimported backup
+=======
+/obj/item/stack/tile/plasteel,
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor{
 	dir = 8;
 	icon_state = "damaged3"
@@ -3621,6 +4085,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -3653,6 +4119,7 @@
 /area/desert_dam/interior/dam_interior/control_room)
 "Te" = (
 <<<<<<< master
+<<<<<<< master
 /obj/effect/decal/cleanable/blood/oil,
 /obj/effect/decal/cleanable/ash,
 =======
@@ -3660,6 +4127,10 @@
 	name = "\improper Atmospheric Storage"
 	},
 >>>>>>> reimported backup
+=======
+/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/decal/cleanable/ash,
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -3670,9 +4141,12 @@
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/effect/decal/cleanable/dirt,
 <<<<<<< master
+<<<<<<< master
 =======
 /obj/item/stack/rods,
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
 /turf/open/floor/prison{
@@ -3729,6 +4203,7 @@
 "TN" = (
 /obj/effect/decal/cleanable/blood/oil,
 <<<<<<< master
+<<<<<<< master
 /obj/item/stack/cable_coil/cut,
 /obj/item/explosive/mine/clf/active{
 	dir = 1
@@ -3737,6 +4212,12 @@
 /obj/item/stack/rods,
 /obj/item/stack/cable_coil/cut,
 >>>>>>> reimported backup
+=======
+/obj/item/stack/cable_coil/cut,
+/obj/item/explosive/mine/clf/active{
+	dir = 1
+	},
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -3757,6 +4238,7 @@
 /area/desert_dam/interior/dam_interior/engine_room)
 "Uc" = (
 <<<<<<< master
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor{
 	dir = 8;
@@ -3770,6 +4252,13 @@
 	icon_state = "bright_clean";
 	tag = "icon-bright_clean (SOUTHWEST)"
 >>>>>>> reimported backup
+=======
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "warning"
+>>>>>>> updated all maps to have CLF Mines and corpses
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
 "Um" = (
@@ -3819,6 +4308,7 @@
 "UI" = (
 /obj/effect/landmark/corpsespawner/engineer,
 <<<<<<< master
+<<<<<<< master
 /obj/effect/decal/cleanable/blood,
 /obj/item/weapon/gun/rifle/mar40{
 	pixel_y = 6
@@ -3833,6 +4323,17 @@
 /obj/item/weapon/gun/pistol/m4a3,
 /obj/effect/decal/cleanable/blood,
 >>>>>>> reimported backup
+=======
+/obj/effect/decal/cleanable/blood,
+/obj/item/weapon/gun/rifle/mar40{
+	pixel_y = 6
+	},
+/obj/item/ammo_magazine/rifle/mar40/lmg,
+/obj/item/ammo_magazine/rifle/mar40/lmg,
+/obj/item/ammo_magazine/rifle/mar40/lmg,
+/obj/item/ammo_magazine/rifle/mar40/lmg,
+/obj/item/ammo_magazine/rifle/mar40/lmg,
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -3840,6 +4341,7 @@
 	},
 /area/desert_dam/interior/dam_interior/smes_backup)
 "UJ" = (
+<<<<<<< master
 <<<<<<< master
 /turf/open/floor{
 	icon_state = "platingdmg1"
@@ -3860,6 +4362,10 @@
 /turf/open/floor/prison{
 	dir = 10;
 	tag = "icon-floor (SOUTHWEST)"
+=======
+/turf/open/floor{
+	icon_state = "platingdmg1"
+>>>>>>> updated all maps to have CLF Mines and corpses
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
 >>>>>>> reimported backup
@@ -3902,9 +4408,13 @@
 "Vp" = (
 /obj/structure/bed/stool,
 <<<<<<< master
+<<<<<<< master
 /obj/item/clothing/accessory/storage/webbing,
 =======
 >>>>>>> reimported backup
+=======
+/obj/item/clothing/accessory/storage/webbing,
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor/prison{
 	dir = 10;
 	tag = "icon-floor (SOUTHWEST)"
@@ -3926,14 +4436,20 @@
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "VF" = (
 /obj/item/stack/tile/plasteel,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
 /area/desert_dam/interior/dam_interior/control_room)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "VG" = (
 /obj/structure/machinery/light{
 	dir = 4
@@ -4000,12 +4516,18 @@
 	},
 /obj/effect/landmark/corpsespawner/engineer,
 <<<<<<< master
+<<<<<<< master
 /obj/item/weapon/gun/shotgun/pump/cmb{
 	pixel_y = 9
 	},
 =======
 /obj/item/weapon/melee/baseballbat,
 >>>>>>> reimported backup
+=======
+/obj/item/weapon/gun/shotgun/pump/cmb{
+	pixel_y = 9
+	},
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -4066,16 +4588,25 @@
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
 <<<<<<< master
+<<<<<<< master
 "Xu" = (
 /obj/effect/landmark/survivor_spawner/clf/generic,
+=======
+"Xu" = (
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
 	tag = "icon-bright_clean (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "Xy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -4093,6 +4624,7 @@
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 <<<<<<< master
+<<<<<<< master
 "XF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -4101,6 +4633,17 @@
 /area/desert_dam/interior/dam_interior/smes_main)
 =======
 >>>>>>> reimported backup
+=======
+"XF" = (
+/obj/item/stack/tile/plasteel,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "damaged3"
+	},
+/area/desert_dam/interior/dam_interior/atmos_storage)
+>>>>>>> updated all maps to have CLF Mines and corpses
 "XI" = (
 /obj/structure/surface/table,
 /obj/item/reagent_container/food/drinks/cans/thirteenloko,
@@ -4128,9 +4671,12 @@
 	},
 /obj/item/stack/cable_coil/cut,
 <<<<<<< master
+<<<<<<< master
 =======
 /obj/item/stack/rods,
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/prison{
 	dir = 10;
@@ -4159,9 +4705,12 @@
 "Yh" = (
 /obj/item/stack/cable_coil/cut,
 <<<<<<< master
+<<<<<<< master
 =======
 /obj/item/stack/rods,
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/prison{
 	dir = 10;
@@ -4187,14 +4736,23 @@
 /turf/open/floor/plating,
 /area/desert_dam/interior/dam_interior/engine_room)
 <<<<<<< master
+<<<<<<< master
 "Yr" = (
 /obj/effect/landmark/survivor_spawner/clf/generic,
+=======
+"Yr" = (
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor{
 	icon_state = "neutral"
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "Yt" = (
 /obj/effect/decal/sand_overlay/sand1,
 /turf/open/asphalt{
@@ -4239,9 +4797,13 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 <<<<<<< master
+<<<<<<< master
 /obj/item/stack/tile/plasteel,
 =======
 >>>>>>> reimported backup
+=======
+/obj/item/stack/tile/plasteel,
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -4257,6 +4819,9 @@
 /obj/effect/landmark/corpsespawner/security,
 /obj/effect/decal/cleanable/blood,
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 /obj/item/weapon/gun/rifle/mar40{
 	pixel_y = 6
 	},
@@ -4265,9 +4830,12 @@
 /obj/item/ammo_magazine/rifle/mar40/lmg,
 /obj/item/ammo_magazine/rifle/mar40/lmg,
 /obj/item/ammo_magazine/rifle/mar40/lmg,
+<<<<<<< master
 =======
 /obj/item/weapon/gun/pistol/b92fs,
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -4304,12 +4872,16 @@
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "ZO" = (
 /obj/item/clothing/accessory/storage/webbing,
 /turf/open/floor/greengrid,
 /area/desert_dam/interior/dam_interior/smes_main)
 "ZT" = (
 /obj/item/explosive/mine/clf/active{
+<<<<<<< master
 	dir = 8
 	},
 /turf/open/floor{
@@ -4334,19 +4906,33 @@
 =======
 "ZV" = (
 /obj/structure/barricade/plasteel/wired{
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 	dir = 8
 	},
-/turf/open/floor/prison{
-	dir = 10;
-	tag = "icon-floor (SOUTHWEST)"
+/turf/open/floor{
+	dir = 4;
+	icon_state = "warning"
 	},
-/area/desert_dam/interior/dam_interior/atmos_storage)
+/area/desert_dam/interior/dam_interior/engine_room)
+"ZV" = (
+/obj/effect/blocker/toxic_water/Group_2,
+/obj/item/ammo_box/magazine/M16,
+/turf/open/floor{
+	icon_state = "neutral"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
 "ZW" = (
-/obj/item/stack/rods,
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
 /obj/effect/decal/cleanable/blood/drip,
+<<<<<<< master
 >>>>>>> reimported backup
+=======
+/obj/item/explosive/mine/clf/active{
+	dir = 1
+	},
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -4439,10 +5025,14 @@ ki
 (4,1,1) = {"
 rv
 <<<<<<< master
+<<<<<<< master
 gS
 =======
 Fr
 >>>>>>> reimported backup
+=======
+gS
+>>>>>>> updated all maps to have CLF Mines and corpses
 Ro
 cR
 cR
@@ -4464,10 +5054,14 @@ Zx
 MF
 fS
 <<<<<<< master
+<<<<<<< master
 lY
 =======
 Im
 >>>>>>> reimported backup
+=======
+lY
+>>>>>>> updated all maps to have CLF Mines and corpses
 ki
 "}
 (5,1,1) = {"
@@ -4494,10 +5088,14 @@ oh
 Vb
 Mm
 <<<<<<< master
+<<<<<<< master
 IB
 =======
 xp
 >>>>>>> reimported backup
+=======
+IB
+>>>>>>> updated all maps to have CLF Mines and corpses
 ki
 "}
 (6,1,1) = {"
@@ -4540,6 +5138,7 @@ Fr
 Ro
 Xy
 <<<<<<< master
+<<<<<<< master
 AV
 ZO
 cR
@@ -4552,16 +5151,27 @@ cR
 Fw
 XU
 >>>>>>> reimported backup
+=======
+AV
+ZO
+cR
+Fw
+gu
+>>>>>>> updated all maps to have CLF Mines and corpses
 rv
 CO
 Td
 Xd
 hb
 <<<<<<< master
+<<<<<<< master
 nk
 =======
 hb
 >>>>>>> reimported backup
+=======
+nk
+>>>>>>> updated all maps to have CLF Mines and corpses
 ak
 pA
 ki
@@ -4591,12 +5201,17 @@ Iy
 EK
 Td
 <<<<<<< master
+<<<<<<< master
 VF
 na
 =======
 dQ
 NP
 >>>>>>> reimported backup
+=======
+VF
+na
+>>>>>>> updated all maps to have CLF Mines and corpses
 BL
 vG
 cC
@@ -4637,12 +5252,17 @@ Hp
 fM
 sG
 <<<<<<< master
+<<<<<<< master
 rv
 rv
 =======
 dq
 dq
 >>>>>>> reimported backup
+=======
+rv
+rv
+>>>>>>> updated all maps to have CLF Mines and corpses
 sG
 fM
 rv
@@ -4650,16 +5270,22 @@ pR
 rv
 dc
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 Mh
 Mh
 Mh
 Mh
+<<<<<<< master
 =======
 Yq
 Yq
 Yq
 Yq
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 Yh
 XS
 Mh
@@ -4698,10 +5324,14 @@ Xf
 wU
 Oj
 <<<<<<< master
+<<<<<<< master
 ys
 =======
 Oj
 >>>>>>> reimported backup
+=======
+ys
+>>>>>>> updated all maps to have CLF Mines and corpses
 Oj
 fe
 "}
@@ -4728,17 +5358,21 @@ kY
 =======
 Xf
 KT
+Uc
 Eh
 Eh
+iO
 Eh
 Eh
-Eh
-Eh
-ek
+lJ
 tc
 sC
+<<<<<<< master
 ek
 >>>>>>> reimported backup
+=======
+kY
+>>>>>>> updated all maps to have CLF Mines and corpses
 Xf
 dc
 Rz
@@ -4847,8 +5481,12 @@ yC
 =======
 zg
 Hs
+<<<<<<< master
 >>>>>>> reimported backup
 Hs
+=======
+yC
+>>>>>>> updated all maps to have CLF Mines and corpses
 Hs
 Hs
 Hs
@@ -4856,6 +5494,7 @@ Hs
 <<<<<<< master
 hr
 Hs
+<<<<<<< master
 bD
 =======
 Hs
@@ -4863,6 +5502,11 @@ Ng
 Hs
 QD
 >>>>>>> reimported backup
+=======
+hr
+Hs
+bD
+>>>>>>> updated all maps to have CLF Mines and corpses
 Dp
 dc
 QJ
@@ -4897,6 +5541,7 @@ LN
 ht
 QJ
 <<<<<<< master
+<<<<<<< master
 cq
 fL
 fL
@@ -4905,6 +5550,11 @@ QJ
 QJ
 QJ
 >>>>>>> reimported backup
+=======
+cq
+fL
+fL
+>>>>>>> updated all maps to have CLF Mines and corpses
 "}
 (18,1,1) = {"
 eb
@@ -4914,7 +5564,7 @@ eb
 eb
 dc
 Nz
-Qn
+rq
 Hs
 Hs
 Hs
@@ -4970,6 +5620,7 @@ eA
 mq
 mq
 <<<<<<< master
+<<<<<<< master
 mw
 mq
 ZV
@@ -4978,16 +5629,25 @@ mq
 mq
 cs
 >>>>>>> reimported backup
+=======
+mw
+mq
+ZV
+>>>>>>> updated all maps to have CLF Mines and corpses
 es
 ia
 RK
 nq
 rp
 <<<<<<< master
+<<<<<<< master
 rY
 =======
 UX
 >>>>>>> reimported backup
+=======
+rY
+>>>>>>> updated all maps to have CLF Mines and corpses
 sq
 es
 nq
@@ -5022,6 +5682,7 @@ ez
 "}
 (22,1,1) = {"
 <<<<<<< master
+<<<<<<< master
 Nj
 Nj
 Nj
@@ -5030,6 +5691,11 @@ eb
 eb
 eb
 >>>>>>> reimported backup
+=======
+Nj
+Nj
+Nj
+>>>>>>> updated all maps to have CLF Mines and corpses
 eb
 eb
 dc
@@ -5054,10 +5720,14 @@ QJ
 "}
 (23,1,1) = {"
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 Nj
 Nj
 dq
 Nj
+<<<<<<< master
 eb
 tr
 =======
@@ -5068,6 +5738,10 @@ eb
 eb
 ht
 >>>>>>> reimported backup
+=======
+eb
+tr
+>>>>>>> updated all maps to have CLF Mines and corpses
 UR
 Hs
 Hs
@@ -5083,12 +5757,17 @@ Yr
 QK
 =======
 Hs
+<<<<<<< master
 QD
 >>>>>>> reimported backup
+=======
+QK
+>>>>>>> updated all maps to have CLF Mines and corpses
 LN
 ht
 QJ
 QJ
+<<<<<<< master
 <<<<<<< master
 cw
 fL
@@ -5114,26 +5793,34 @@ Ml
 =======
 QJ
 QJ
+=======
+cw
+fL
+>>>>>>> updated all maps to have CLF Mines and corpses
 "}
 (24,1,1) = {"
-eb
-eb
-eb
-eb
-eb
+dq
+OS
+Nj
+Nj
+Nj
 dc
 Nz
-zg
-Hs
+FO
+qD
 ep
 ek
-MQ
+tN
 Hs
-Hs
+Yr
 Hs
 Ng
+<<<<<<< master
 Hs
 >>>>>>> reimported backup
+=======
+Ml
+>>>>>>> updated all maps to have CLF Mines and corpses
 QD
 Dp
 dc
@@ -5156,10 +5843,14 @@ Zh
 Tm
 gA
 <<<<<<< master
+<<<<<<< master
 Gz
 =======
 Hs
 >>>>>>> reimported backup
+=======
+Gz
+>>>>>>> updated all maps to have CLF Mines and corpses
 es
 cs
 Kv
@@ -5243,10 +5934,14 @@ Bt
 Bt
 Bt
 <<<<<<< master
+<<<<<<< master
 ZT
 =======
 Bt
 >>>>>>> reimported backup
+=======
+ZT
+>>>>>>> updated all maps to have CLF Mines and corpses
 Bt
 Hs
 Ng
@@ -5304,16 +5999,22 @@ Yq
 Yq
 dc
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 Mh
 Yh
 XS
 Mh
+<<<<<<< master
 =======
 Yq
 Uc
 FO
 Yq
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 dc
 wU
 wU
@@ -5390,24 +6091,33 @@ Kz
 De
 VK
 De
+Xu
 De
 De
+<<<<<<< master
 De
 <<<<<<< master
 Pk
 =======
 De
 >>>>>>> reimported backup
+=======
+Pk
+>>>>>>> updated all maps to have CLF Mines and corpses
 De
 De
 nz
 yX
 nY
 <<<<<<< master
+<<<<<<< master
 Xu
 =======
 De
 >>>>>>> reimported backup
+=======
+Xu
+>>>>>>> updated all maps to have CLF Mines and corpses
 De
 Ht
 mu
@@ -5452,6 +6162,7 @@ gw
 Mw
 fT
 <<<<<<< master
+<<<<<<< master
 hH
 hH
 OR
@@ -5464,6 +6175,13 @@ OR
 YO
 Tz
 >>>>>>> reimported backup
+=======
+hH
+hH
+OR
+YO
+vo
+>>>>>>> updated all maps to have CLF Mines and corpses
 Tz
 hk
 Lr
@@ -5471,10 +6189,14 @@ EH
 oj
 wA
 <<<<<<< master
+<<<<<<< master
 Ce
 =======
 De
 >>>>>>> reimported backup
+=======
+Ce
+>>>>>>> updated all maps to have CLF Mines and corpses
 De
 VG
 oW
@@ -5495,7 +6217,7 @@ gZ
 VE
 Tz
 Tz
-De
+Xu
 Gu
 Oc
 rG
@@ -5521,14 +6243,19 @@ rG
 pe
 Vp
 <<<<<<< master
+<<<<<<< master
 zc
 =======
 Tz
 >>>>>>> reimported backup
+=======
+zc
+>>>>>>> updated all maps to have CLF Mines and corpses
 De
 Gu
 oY
 rG
+<<<<<<< master
 <<<<<<< master
 cn
 UJ
@@ -5542,6 +6269,13 @@ ZV
 cn
 fL
 >>>>>>> reimported backup
+=======
+cn
+UJ
+cn
+GW
+cn
+>>>>>>> updated all maps to have CLF Mines and corpses
 qG
 Oj
 fe
@@ -5574,12 +6308,16 @@ De
 Gu
 oY
 rG
-rq
+UJ
+FY
+UJ
 cn
-cn
-cn
+<<<<<<< master
 cw
 >>>>>>> reimported backup
+=======
+Nx
+>>>>>>> updated all maps to have CLF Mines and corpses
 qG
 Oj
 fe
@@ -5596,11 +6334,12 @@ wL
 rG
 rG
 cM
-Tz
+qH
 De
 Gu
 wH
 rG
+<<<<<<< master
 <<<<<<< master
 cn
 UJ
@@ -5612,6 +6351,12 @@ cn
 cn
 cn
 >>>>>>> reimported backup
+=======
+cn
+UJ
+XF
+Go
+>>>>>>> updated all maps to have CLF Mines and corpses
 yZ
 qG
 Oj
@@ -5637,6 +6382,7 @@ rG
 UJ
 cn
 <<<<<<< master
+<<<<<<< master
 Go
 Go
 UJ
@@ -5645,6 +6391,11 @@ cn
 cn
 tN
 >>>>>>> reimported backup
+=======
+Go
+Go
+UJ
+>>>>>>> updated all maps to have CLF Mines and corpses
 qG
 du
 fe
@@ -5667,6 +6418,7 @@ ee
 rG
 rG
 <<<<<<< master
+<<<<<<< master
 cn
 Ev
 UJ
@@ -5675,6 +6427,11 @@ GW
 cn
 cn
 >>>>>>> reimported backup
+=======
+cn
+Go
+UJ
+>>>>>>> updated all maps to have CLF Mines and corpses
 cn
 Go
 qG
@@ -5700,6 +6457,7 @@ wL
 rG
 cn
 <<<<<<< master
+<<<<<<< master
 Hw
 Cu
 UJ
@@ -5710,6 +6468,12 @@ cn
 cn
 gS
 >>>>>>> reimported backup
+=======
+Hw
+Cu
+UJ
+cn
+>>>>>>> updated all maps to have CLF Mines and corpses
 qG
 wL
 wL
@@ -5733,16 +6497,22 @@ wL
 rG
 Nx
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 Go
 UJ
 Go
 cn
+<<<<<<< master
 =======
 AV
 Nj
 rY
 hH
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 qG
 wL
 wL

--- a/maps/map_files/DesertDam/sprinkles/25.clftrijent.dmm
+++ b/maps/map_files/DesertDam/sprinkles/25.clftrijent.dmm
@@ -73,7 +73,7 @@
 /obj/effect/landmark/survivor_spawner/clf/generic,
 >>>>>>> Updated CLF spawner
 /turf/open/floor{
-	dir = 7;
+	dir = 1;
 	icon_state = "warning"
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
@@ -175,9 +175,14 @@
 	icon_state = "tile"
 <<<<<<< master
 	},
-/area/desert_dam/exterior/valley/south_valley_dam)
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/atmos_storage)
 "cz" = (
 /obj/effect/landmark/corpsespawner/engineer,
+/obj/item/weapon/melee/baseballbat/metal,
 /obj/effect/decal/cleanable/blood,
 /obj/item/weapon/gun/smg/fp9000{
 	pixel_y = 7
@@ -538,6 +543,14 @@
 	icon_state = "neutral"
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
+"fA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/control_room)
 "fB" = (
 /obj/structure/machinery/power/geothermal,
 /obj/structure/lattice{
@@ -551,6 +564,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -625,6 +639,13 @@
 	icon_state = "cement_sunbleached12"
 	},
 /area/desert_dam/exterior/valley/south_valley_dam)
+"go" = (
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "darkyellowcorners2"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
 "gr" = (
 /obj/effect/decal/sand_overlay/sand1/corner1,
 /turf/open/asphalt{
@@ -675,8 +696,8 @@
 <<<<<<< master
 /obj/item/stack/sheet/wood,
 /turf/open/floor/prison{
-	dir = 1;
-	icon_state = "darkyellow2"
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/smes_main)
 =======
@@ -774,6 +795,7 @@
 /area/desert_dam/interior/dam_interior/engine_room)
 <<<<<<< master
 "ht" = (
+/obj/item/stack/rods,
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
 /obj/item/explosive/mine/clf/active,
@@ -862,8 +884,7 @@
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "bright_clean";
-	tag = "icon-bright_clean (SOUTHWEST)"
+	tag = "icon-floor (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/smes_backup)
 <<<<<<< master
@@ -1221,6 +1242,7 @@
 /area/desert_dam/interior/dam_interior/control_room)
 "mn" = (
 /obj/effect/decal/cleanable/blood/drip,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor{
 	icon_state = "neutral"
 	},
@@ -1308,6 +1330,13 @@
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/control_room)
+"mU" = (
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
 "mX" = (
 /obj/structure/platform{
 	dir = 1
@@ -1441,6 +1470,13 @@
 	icon_state = "warnplate"
 	},
 /area/desert_dam/interior/dam_interior/smes_backup)
+"nU" = (
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
 "nY" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
@@ -1466,6 +1502,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -1712,6 +1749,15 @@
 	name = "reinforced metal wall"
 	},
 /area/desert_dam/interior/dam_interior/west_tunnel)
+"ri" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/smes_backup)
 "rp" = (
 /obj/structure/platform,
 /obj/effect/blocker/toxic_water/Group_2,
@@ -1820,6 +1866,13 @@
 	tag = "icon-darkyellowcorners2 (NORTH)"
 	},
 /area/desert_dam/interior/dam_interior/control_room)
+"rC" = (
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "warning"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
 "rG" = (
 /turf/closed/wall/r_wall/bunker{
 	name = "reinforced metal wall"
@@ -1834,6 +1887,7 @@
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -2162,6 +2216,7 @@
 /turf/open/floor/greengrid,
 /area/desert_dam/interior/dam_interior/smes_main)
 "uv" = (
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "darkyellow2"
@@ -2195,7 +2250,8 @@
 /obj/effect/spawner/random/attachment,
 /turf/open/floor/prison{
 	dir = 10;
-	tag = "icon-floor (SOUTHWEST)"
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 <<<<<<< master
@@ -2576,6 +2632,13 @@
 	icon_state = "neutral"
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
+"zM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/desert_dam/interior/dam_interior/control_room)
 "zR" = (
 /obj/effect/decal/cleanable/blood/oil,
 <<<<<<< master
@@ -2778,6 +2841,12 @@
 	tag = "icon-bright_clean (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/smes_main)
+"CC" = (
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
 "CK" = (
 /obj/structure/flora/grass/desert{
 	icon_state = "lightgrass_3"
@@ -2940,6 +3009,20 @@
 	icon_state = "platingdmg1"
 	},
 /area/desert_dam/interior/dam_interior/control_room)
+"Ey" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
 "EC" = (
 /obj/structure/platform{
 	dir = 1
@@ -2982,6 +3065,17 @@
 	tag = "icon-floor (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/control_room)
+"EL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/floor/greengrid,
+/area/desert_dam/interior/dam_interior/smes_main)
+"EP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/floor/greengrid,
+/area/desert_dam/interior/dam_interior/smes_main)
 "ET" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/structure/disposalpipe/segment,
@@ -3014,6 +3108,17 @@
 	icon_state = "cement_sunbleached9"
 	},
 /area/desert_dam/exterior/valley/south_valley_dam)
+"Fn" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
 "Fr" = (
 /obj/structure/barricade/wooden{
 	dir = 1
@@ -3298,6 +3403,17 @@
 	tag = "icon-bright_clean (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/control_room)
+"HC" = (
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1";
+	dir = 8
+	},
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
 "HD" = (
 /obj/structure/surface/table,
 /turf/open/floor/prison{
@@ -3469,6 +3585,7 @@
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
 "KT" = (
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor{
 	dir = 9;
 	icon_state = "warning"
@@ -3556,6 +3673,16 @@
 	dir = 8
 	},
 /area/desert_dam/exterior/river/riverside_central_south)
+"LK" = (
+/obj/structure/machinery/light{
+	dir = 4
+	},
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
 "LN" = (
 /obj/structure/barricade/plasteel/wired{
 	icon_state = "plasteel_3"
@@ -3715,7 +3842,7 @@
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
-/area/desert_dam/exterior/valley/north_valley_dam)
+/area/desert_dam/interior/dam_interior/atmos_storage)
 "Nx" = (
 /turf/open/floor{
 	dir = 8;
@@ -3765,6 +3892,12 @@
 	tag = "icon-floor (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
+"ND" = (
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/floor{
+	icon_state = "neutral"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
 "NH" = (
 /turf/open/floor/prison{
 	dir = 8;
@@ -3789,6 +3922,16 @@
 	tag = "icon-bright_clean (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
+"NV" = (
+/obj/structure/pipes/standard/simple/hidden/green,
+/obj/structure/disposalpipe/segment,
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/engine_east_wing)
 "NY" = (
 /obj/structure/pipes/vents/pump,
 /turf/open/floor/plating{
@@ -3906,6 +4049,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/desert_dam/interior/dam_interior/smes_backup)
+"Pt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/desert_dam/interior/dam_interior/control_room)
 "PB" = (
 /obj/item/ammo_casing/bullet,
 /turf/open/floor/prison{
@@ -4051,8 +4201,10 @@
 	},
 /obj/effect/blocker/toxic_water/Group_2,
 /obj/effect/landmark/survivor_spawner/clf/generic,
-/turf/open/floor{
-	icon_state = "neutral"
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
 <<<<<<< master
@@ -4355,13 +4507,19 @@
 	icon_state = "warning"
 	},
 /area/desert_dam/interior/dam_interior/engine_room)
+"TW" = (
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/desert_dam/interior/dam_interior/engine_room)
 "Uc" = (
 <<<<<<< master
 <<<<<<< master
 <<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor{
-	dir = 8;
+	dir = 7;
 	icon_state = "warning"
 =======
 /obj/item/stack/rods,
@@ -4589,6 +4747,7 @@
 /obj/structure/machinery/light{
 	dir = 4
 	},
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/prison{
 	icon_state = "darkyellowcorners2"
 	},
@@ -4615,6 +4774,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean";
@@ -4880,6 +5040,17 @@
 	tag = "icon-bright_clean (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/control_room)
+"Yp" = (
+/obj/structure/pipes/standard/simple/hidden/green,
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/desert_dam/interior/dam_interior/control_room)
 "Yq" = (
 /obj/structure/window_frame/colony,
 /obj/item/stack/rods,
@@ -5044,19 +5215,13 @@
 <<<<<<< master
 	dir = 8
 	},
-/turf/open/floor{
-	dir = 4;
-	icon_state = "warning"
+/turf/open/floor/prison{
+	dir = 10;
+	tag = "icon-floor (SOUTHWEST)"
 	},
-/area/desert_dam/interior/dam_interior/engine_room)
-"ZV" = (
-/obj/effect/blocker/toxic_water/Group_2,
-/obj/item/ammo_box/magazine/M16,
-/turf/open/floor{
-	icon_state = "neutral"
-	},
-/area/desert_dam/interior/dam_interior/engine_room)
+/area/desert_dam/interior/dam_interior/atmos_storage)
 "ZW" = (
+/obj/item/stack/rods,
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
 /obj/effect/decal/cleanable/blood/drip,
@@ -5183,7 +5348,7 @@ vO
 ku
 PT
 QB
-Im
+YO
 ki
 "}
 (4,1,1) = {"
@@ -5232,7 +5397,7 @@ ki
 rv
 Fr
 Ro
-TD
+EL
 Gb
 Gb
 Gb
@@ -5278,7 +5443,7 @@ MH
 SJ
 lD
 SJ
-Fw
+EP
 BR
 rv
 Qq
@@ -5301,6 +5466,8 @@ iD
 >>>>>>> Updated CLF spawner
 sk
 Qe
+sk
+ri
 xp
 ki
 "}
@@ -5334,6 +5501,7 @@ rv
 CO
 Td
 Xd
+zM
 hb
 <<<<<<< master
 <<<<<<< master
@@ -5349,7 +5517,7 @@ pA
 ki
 sY
 cj
-Qe
+ri
 UI
 Im
 ki
@@ -5480,10 +5648,11 @@ qs
 qJ
 qJ
 wU
-xg
+HC
 Lp
 xg
 St
+HC
 xg
 xg
 <<<<<<< master
@@ -5526,13 +5695,13 @@ dc
 <<<<<<< master
 XO
 KT
-Uc
 Eh
 Eh
-iO
 Eh
 Eh
-lJ
+Eh
+Eh
+ek
 tc
 sC
 kY
@@ -5685,6 +5854,7 @@ yC
 >>>>>>> updated all maps to have CLF Mines and corpses
 Hs
 Hs
+Ng
 Hs
 Hs
 <<<<<<< master
@@ -5740,7 +5910,7 @@ wU
 gU
 KP
 rd
-QD
+Uf
 LN
 ht
 QJ
@@ -5866,7 +6036,7 @@ za
 kv
 sq
 PD
-zg
+by
 Tm
 Zh
 Tm
@@ -5947,7 +6117,7 @@ eb
 tr
 >>>>>>> updated all maps to have CLF Mines and corpses
 UR
-Hs
+ND
 Hs
 ek
 Sk
@@ -5981,20 +6151,20 @@ cw
 fL
 "}
 (24,1,1) = {"
-dq
-OS
-Nj
-Nj
-Nj
+eb
+eb
+eb
+eb
+eb
 dc
 Nz
-FO
-qD
-ep
-ek
-tN
+zg
 Hs
-Yr
+ep
+TW
+MQ
+Hs
+ND
 Hs
 Ng
 Ml
@@ -6185,7 +6355,7 @@ wU
 Xf
 GM
 GM
-jd
+LK
 GM
 GM
 Xf
@@ -6292,6 +6462,7 @@ Uw
 >>>>>>> Updated CLF spawner
 Tz
 Tz
+nU
 Tz
 Tz
 Tz
@@ -6316,7 +6487,10 @@ Kz
 De
 VK
 De
+vr
+vr
 De
+vr
 De
 De
 <<<<<<< master
@@ -6372,12 +6546,12 @@ xO
 xO
 sf
 WX
-xO
+NV
 xO
 ZN
 hJ
 Ld
-De
+vr
 Ht
 mu
 Fi
@@ -6443,9 +6617,9 @@ yn
 yn
 ph
 gZ
-VE
+go
 Tz
-Tz
+nU
 De
 Gu
 Oc
@@ -6573,7 +6747,7 @@ rG
 cM
 Tz
 De
-Gu
+Fn
 wH
 rG
 <<<<<<< master

--- a/maps/map_files/DesertDam/sprinkles/25.clftrijent.dmm
+++ b/maps/map_files/DesertDam/sprinkles/25.clftrijent.dmm
@@ -1549,12 +1549,6 @@
 	tag = "icon-floor (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
-"vr" = (
-/obj/effect/landmark/survivor_spawn,
-/turf/open/floor{
-	icon_state = "neutral"
-	},
-/area/desert_dam/interior/dam_interior/engine_room)
 "vG" = (
 /obj/structure/surface/table,
 /obj/structure/machinery/cell_charger,
@@ -3538,13 +3532,6 @@
 	icon_state = "tile"
 	},
 /area/desert_dam/exterior/valley/north_valley_dam)
-"YO" = (
-/obj/effect/landmark/survivor_spawn,
-/turf/open/floor/prison{
-	dir = 10;
-	tag = "icon-floor (SOUTHWEST)"
-	},
-/area/desert_dam/interior/dam_interior/engine_east_wing)
 "YY" = (
 /obj/item/stack/sheet/wood,
 /turf/open/floor/prison{
@@ -4091,7 +4078,7 @@ NT
 mn
 Hs
 Hs
-vr
+Hs
 Hs
 Hs
 wU
@@ -4556,7 +4543,7 @@ fT
 hH
 hH
 OR
-YO
+Tz
 vo
 Tz
 hk

--- a/maps/map_files/DesertDam/sprinkles/25.clftrijent.dmm
+++ b/maps/map_files/DesertDam/sprinkles/25.clftrijent.dmm
@@ -1598,13 +1598,6 @@
 	tag = "icon-floor (SOUTHWEST)"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
-"vr" = (
-/obj/effect/landmark/survivor_spawn,
-/turf/open/floor{
-	icon_state = "neutral"
-	},
-/area/desert_dam/interior/dam_interior/engine_room)
->>>>>>> reimported backup
 "vG" = (
 /obj/structure/surface/table,
 /obj/structure/machinery/cell_charger,
@@ -3673,16 +3666,6 @@
 	icon_state = "tile"
 	},
 /area/desert_dam/exterior/valley/north_valley_dam)
-<<<<<<< master
-=======
-"YO" = (
-/obj/effect/landmark/survivor_spawn,
-/turf/open/floor/prison{
-	dir = 10;
-	tag = "icon-floor (SOUTHWEST)"
-	},
-/area/desert_dam/interior/dam_interior/engine_east_wing)
->>>>>>> reimported backup
 "YY" = (
 /obj/item/stack/sheet/wood,
 /turf/open/floor/prison{
@@ -4276,11 +4259,7 @@ NT
 mn
 Hs
 Hs
-<<<<<<< master
-Yr
-=======
-vr
->>>>>>> reimported backup
+Hs
 Hs
 Hs
 wU
@@ -4773,7 +4752,7 @@ fT
 hH
 hH
 OR
-YO
+Tz
 vo
 Tz
 hk

--- a/maps/map_files/FOP_v3_Sciannex/Fiorina_SciAnnex.dmm
+++ b/maps/map_files/FOP_v3_Sciannex/Fiorina_SciAnnex.dmm
@@ -30036,6 +30036,9 @@
 /area/fiorina/station/power_ring)
 "sgb" = (
 /obj/item/ammo_box/magazine/misc/flares/empty,
+/obj/effect/landmark/nightmare{
+	insert_tag = "sciannexclfship"
+	},
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "whitegreenfull";

--- a/maps/map_files/FOP_v3_Sciannex/sprinkles/25.sciannexclfship.dmm
+++ b/maps/map_files/FOP_v3_Sciannex/sprinkles/25.sciannexclfship.dmm
@@ -4529,7 +4529,7 @@ Wz
 lI
 JA
 Nq
-nU
+Wz
 nC
 ji
 Bw
@@ -4574,7 +4574,7 @@ Wz
 Wz
 nC
 vh
-Wz
+QZ
 Wz
 JA
 yL

--- a/maps/map_files/FOP_v3_Sciannex/sprinkles/25.sciannexclfship.dmm
+++ b/maps/map_files/FOP_v3_Sciannex/sprinkles/25.sciannexclfship.dmm
@@ -190,6 +190,7 @@
 /obj/item/stack/rods,
 /obj/item/ammo_magazine/rifle/type71/ap,
 /obj/effect/landmark/corpsespawner/clf,
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor{
 	dir = 8;
 	icon_state = "damaged3"
@@ -271,6 +272,7 @@
 /area/fiorina/oob)
 "di" = (
 /obj/item/stack/rods,
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/plating,
 /area/lv624/lazarus/crashed_ship)
@@ -686,6 +688,7 @@
 /area/lv624/lazarus/crashed_ship)
 "kz" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/almayer,
 /area/lv624/lazarus/crashed_ship)
 "kC" = (
@@ -747,6 +750,12 @@
 "ly" = (
 /turf/closed/wall/mineral/bone_resin,
 /area/lv624/lazarus/crashed_ship)
+"lI" = (
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/lv624/lazarus/crashed_ship)
 "lN" = (
 /obj/item/stack/rods,
 /obj/effect/landmark/corpsespawner/colonist,
@@ -775,6 +784,7 @@
 /obj/item/ammo_casing/shell{
 	icon_state = "casing_2_1"
 	},
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -889,6 +899,7 @@
 /area/lv624/lazarus/crashed_ship)
 "nP" = (
 /obj/structure/bed/chair,
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/wood,
 /area/lv624/lazarus/crashed_ship)
@@ -1101,6 +1112,11 @@
 	icon_state = "whitegreen"
 	},
 /area/fiorina/tumor/ice_lab)
+"rl" = (
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/turf/open/floor/plating/plating_catwalk,
+/area/lv624/lazarus/crashed_ship)
 "rm" = (
 /obj/structure/surface/table/woodentable,
 /obj/item/storage/firstaid/adv,
@@ -1354,6 +1370,7 @@
 /obj/item/ammo_casing/shell{
 	icon_state = "casing_9_1"
 	},
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
@@ -1448,6 +1465,7 @@
 "uZ" = (
 /obj/item/stack/rods,
 /obj/effect/spawner/random/attachment,
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/plating,
 /area/lv624/lazarus/crashed_ship)
 "vd" = (
@@ -1594,6 +1612,7 @@
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/plating,
 /area/lv624/lazarus/crashed_ship)
 "vX" = (
@@ -2268,6 +2287,7 @@
 /area/fiorina/tumor/ice_lab)
 "Fa" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/almayer{
 	icon_state = "green";
 	tag = "icon-green"
@@ -2617,6 +2637,11 @@
 	},
 /turf/open/ice/noweed,
 /area/fiorina/tumor/ice_lab)
+"JA" = (
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/turf/open/floor/plating,
+/area/lv624/lazarus/crashed_ship)
 "JD" = (
 /obj/structure/blocker/invisible_wall,
 /turf/open/floor{
@@ -3454,6 +3479,10 @@
 	icon_state = "platingdmg3"
 	},
 /area/lv624/lazarus/crashed_ship)
+"WK" = (
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/turf/open/floor/wood,
+/area/lv624/lazarus/crashed_ship)
 "Xn" = (
 /obj/item/ammo_casing/shell{
 	icon_state = "shell_6_1"
@@ -3929,7 +3958,7 @@ Bs
 cS
 Df
 xl
-FB
+rl
 Iu
 QZ
 QH
@@ -3973,7 +4002,7 @@ io
 Rp
 QZ
 Mr
-Iu
+FB
 Gv
 Ne
 QZ
@@ -4069,13 +4098,13 @@ ko
 Nl
 NV
 Oi
-FB
+rl
 xA
 QZ
 vs
 tE
 Zz
-nC
+lI
 OS
 uZ
 mK
@@ -4159,7 +4188,7 @@ MT
 QZ
 gW
 kM
-Iu
+FB
 Iu
 Wz
 qW
@@ -4199,7 +4228,7 @@ VN
 QZ
 bX
 XG
-Iu
+FB
 Jd
 tY
 ko
@@ -4253,7 +4282,7 @@ bj
 Wz
 QZ
 Dw
-nC
+lI
 CZ
 nC
 gK
@@ -4293,8 +4322,8 @@ wv
 eo
 Wz
 Gj
-Wz
-nC
+Gf
+lI
 Wz
 wS
 Bc
@@ -4518,8 +4547,8 @@ Iu
 Iu
 VD
 Wz
-nC
-Gf
+lI
+JA
 Nq
 nU
 nC
@@ -4559,7 +4588,7 @@ Sn
 kd
 Ow
 pr
-pr
+WK
 pr
 Wz
 Wz
@@ -4568,7 +4597,7 @@ nC
 vh
 Wz
 Wz
-Gf
+JA
 yL
 eO
 us

--- a/maps/map_files/FOP_v3_Sciannex/sprinkles/25.sciannexclfship.dmm
+++ b/maps/map_files/FOP_v3_Sciannex/sprinkles/25.sciannexclfship.dmm
@@ -208,6 +208,7 @@
 /obj/item/bedsheet/rd,
 /obj/effect/landmark/corpsespawner/colonist,
 /obj/effect/decal/cleanable/blood,
+/obj/effect/landmark/survivor_spawner/clf,
 /turf/open/floor/almayer{
 	dir = 4;
 	icon_state = "green";
@@ -496,9 +497,7 @@
 <<<<<<< master
 =======
 "ho" = (
-/obj/structure/machinery/door/airlock/multi_tile/secure{
-	name = "\improper General Area"
-	},
+/obj/effect/landmark/survivor_spawner/clf,
 /turf/open/floor/plating,
 /area/lv624/lazarus/crashed_ship)
 >>>>>>> reimported backup
@@ -566,6 +565,7 @@
 	pixel_y = 4
 	},
 /obj/effect/spawner/random/attachment,
+/obj/effect/landmark/survivor_spawner/clf,
 /turf/open/floor/plating{
 	dir = 6;
 	icon_state = "warnplate"
@@ -1334,6 +1334,7 @@
 /area/fiorina/tumor/ice_lab)
 "th" = (
 /obj/structure/machinery/body_scanconsole,
+/obj/effect/landmark/survivor_spawner/clf,
 /turf/open/floor/almayer{
 	dir = 1;
 	icon_state = "emerald";
@@ -1396,6 +1397,15 @@
 	icon_state = "platingdmg1"
 	},
 /area/fiorina/oob)
+"tz" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/landmark/survivor_spawner/clf,
+/turf/open/floor/almayer{
+	dir = 8;
+	icon_state = "emeraldcorner";
+	tag = "icon-emeraldcorner (EAST)"
+	},
+/area/lv624/lazarus/crashed_ship)
 "tC" = (
 /turf/open/floor/plating{
 	dir = 10;
@@ -1891,6 +1901,7 @@
 /obj/structure/bed/chair{
 	dir = 1
 	},
+/obj/effect/landmark/survivor_spawner/clf,
 /turf/open/floor/wood,
 /area/lv624/lazarus/crashed_ship)
 "yk" = (
@@ -1950,6 +1961,7 @@
 /area/fiorina/tumor/ice_lab)
 "yL" = (
 /obj/effect/landmark/corpsespawner/clf,
+/obj/effect/landmark/survivor_spawner/clf,
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
@@ -2066,6 +2078,7 @@
 	pixel_y = 20
 	},
 /obj/item/toy/farwadoll,
+/obj/effect/landmark/survivor_spawner/clf,
 /turf/open/floor/almayer{
 	dir = 9;
 	icon_state = "green";
@@ -2312,8 +2325,8 @@
 	},
 /area/lv624/lazarus/crashed_ship)
 "CY" = (
-/obj/structure/bed/chair,
-/turf/open/floor/wood,
+/obj/effect/landmark/survivor_spawner/clf,
+/turf/open/floor/plating/plating_catwalk,
 /area/lv624/lazarus/crashed_ship)
 "CZ" = (
 /obj/item/stack/rods,
@@ -2355,6 +2368,7 @@
 /obj/structure/bed,
 /obj/item/bedsheet/yellow,
 /obj/item/toy/katana,
+/obj/effect/landmark/survivor_spawner/clf,
 /turf/open/floor/almayer{
 	dir = 8;
 	icon_state = "green";
@@ -2368,6 +2382,7 @@
 	pixel_y = 28;
 	range = 20
 	},
+/obj/effect/landmark/survivor_spawner/clf,
 /turf/open/floor/plating,
 /area/lv624/lazarus/crashed_ship)
 "DU" = (
@@ -2506,8 +2521,12 @@
 	},
 /area/fiorina/tumor/ice_lab)
 "FB" = (
-/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-/turf/open/floor/plating/plating_catwalk,
+/obj/effect/landmark/survivor_spawner/clf,
+/turf/open/floor/almayer{
+	dir = 8;
+	icon_state = "emeraldcorner";
+	tag = "icon-emeraldcorner (EAST)"
+	},
 /area/lv624/lazarus/crashed_ship)
 "FE" = (
 /obj/structure/barricade/plasteel/wired{
@@ -2767,6 +2786,7 @@
 /obj/item/ammo_magazine/pistol/heavy,
 /obj/item/ammo_magazine/pistol/heavy,
 /obj/item/ammo_magazine/pistol/heavy,
+/obj/effect/landmark/survivor_spawner/clf,
 /turf/open/floor/almayer{
 	dir = 5;
 	icon_state = "green";
@@ -3266,15 +3286,16 @@
 /obj/item/ammo_casing/shell{
 	icon_state = "shell_4_1"
 	},
+/obj/effect/landmark/survivor_spawner/clf,
 /turf/open/floor/plating,
 /area/lv624/lazarus/crashed_ship)
 <<<<<<< master
 =======
 "Qx" = (
-/obj/structure/machinery/door/airlock/multi_tile/secure{
-	name = "\improper Bunk Beds"
+/obj/effect/landmark/survivor_spawner/clf,
+/turf/open/floor{
+	icon_state = "platingdmg1"
 	},
-/turf/open/floor/plating,
 /area/lv624/lazarus/crashed_ship)
 >>>>>>> reimported backup
 "QE" = (
@@ -3821,6 +3842,7 @@
 /area/lv624/lazarus/crashed_ship)
 "YM" = (
 /obj/effect/spawner/random/attachment,
+/obj/effect/landmark/survivor_spawner/clf,
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
@@ -4156,7 +4178,7 @@ Oy
 vf
 QZ
 BM
-xA
+tz
 sp
 NJ
 xf
@@ -4214,6 +4236,7 @@ FB
 =======
 rl
 >>>>>>> added spawn pointss for clf survivors
+Iu
 Iu
 QZ
 QH
@@ -4315,7 +4338,7 @@ ZE
 So
 QZ
 wc
-CF
+FB
 Iu
 Xo
 QZ
@@ -4473,7 +4496,7 @@ Fj
 io
 QZ
 CO
-Iu
+CY
 Iu
 MT
 QZ
@@ -4491,7 +4514,7 @@ FB
 Iu
 Wz
 qW
-nC
+Qx
 di
 Hb
 im
@@ -4587,7 +4610,7 @@ JD
 Ky
 wk
 it
-kz
+XG
 Iu
 Iu
 <<<<<<< master
@@ -4674,7 +4697,7 @@ wS
 Bc
 Wi
 mK
-WI
+kz
 Xn
 Wz
 rU
@@ -4759,7 +4782,7 @@ Ky
 Ky
 Sn
 QZ
-CY
+nP
 yz
 rm
 yh
@@ -4815,7 +4838,7 @@ wk
 nP
 Qb
 WH
-yh
+VD
 QZ
 CH
 IA
@@ -4823,7 +4846,7 @@ Kf
 Nq
 QZ
 tq
-Wz
+ho
 Wz
 tq
 Ac
@@ -4887,6 +4910,7 @@ XE
 hi
 Wz
 tq
+Qx
 nC
 <<<<<<< master
 <<<<<<< master
@@ -5001,7 +5025,7 @@ pr
 Wz
 Wz
 Wz
-nC
+Qx
 vh
 <<<<<<< master
 QZ
@@ -5154,13 +5178,13 @@ io
 eu
 Nl
 nu
-kz
+XG
 BY
 Iu
 Wz
 PV
 Iu
-Iu
+CY
 vD
 QZ
 kl

--- a/maps/map_files/FOP_v3_Sciannex/sprinkles/25.sciannexclfship.dmm
+++ b/maps/map_files/FOP_v3_Sciannex/sprinkles/25.sciannexclfship.dmm
@@ -190,10 +190,7 @@
 /obj/item/stack/rods,
 /obj/item/ammo_magazine/rifle/type71/ap,
 /obj/effect/landmark/corpsespawner/clf,
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-=======
->>>>>>> reimported backup
 /turf/open/floor{
 	dir = 8;
 	icon_state = "damaged3"
@@ -276,10 +273,7 @@
 "di" = (
 /obj/item/stack/rods,
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-=======
->>>>>>> reimported backup
 /turf/open/floor/plating,
 /area/lv624/lazarus/crashed_ship)
 "dw" = (
@@ -694,10 +688,7 @@
 /area/lv624/lazarus/crashed_ship)
 "kz" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-=======
->>>>>>> reimported backup
 /turf/open/floor/almayer,
 /area/lv624/lazarus/crashed_ship)
 "kC" = (
@@ -759,15 +750,12 @@
 "ly" = (
 /turf/closed/wall/mineral/bone_resin,
 /area/lv624/lazarus/crashed_ship)
-<<<<<<< master
 "lI" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
 /area/lv624/lazarus/crashed_ship)
-=======
->>>>>>> reimported backup
 "lN" = (
 /obj/item/stack/rods,
 /obj/effect/landmark/corpsespawner/colonist,
@@ -796,10 +784,7 @@
 /obj/item/ammo_casing/shell{
 	icon_state = "casing_2_1"
 	},
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-=======
->>>>>>> reimported backup
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -915,10 +900,7 @@
 "nP" = (
 /obj/structure/bed/chair,
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-=======
->>>>>>> reimported backup
 /turf/open/floor/wood,
 /area/lv624/lazarus/crashed_ship)
 "nU" = (
@@ -1130,14 +1112,11 @@
 	icon_state = "whitegreen"
 	},
 /area/fiorina/tumor/ice_lab)
-<<<<<<< master
 "rl" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/plating/plating_catwalk,
 /area/lv624/lazarus/crashed_ship)
-=======
->>>>>>> reimported backup
 "rm" = (
 /obj/structure/surface/table/woodentable,
 /obj/item/storage/firstaid/adv,
@@ -1391,10 +1370,7 @@
 /obj/item/ammo_casing/shell{
 	icon_state = "casing_9_1"
 	},
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-=======
->>>>>>> reimported backup
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
@@ -1489,10 +1465,7 @@
 "uZ" = (
 /obj/item/stack/rods,
 /obj/effect/spawner/random/attachment,
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-=======
->>>>>>> reimported backup
 /turf/open/floor/plating,
 /area/lv624/lazarus/crashed_ship)
 "vd" = (
@@ -1639,6 +1612,7 @@
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/plating,
 /area/lv624/lazarus/crashed_ship)
 "vX" = (
@@ -2313,10 +2287,7 @@
 /area/fiorina/tumor/ice_lab)
 "Fa" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-=======
->>>>>>> reimported backup
 /turf/open/floor/almayer{
 	icon_state = "green";
 	tag = "icon-green"
@@ -2666,14 +2637,11 @@
 	},
 /turf/open/ice/noweed,
 /area/fiorina/tumor/ice_lab)
-<<<<<<< master
 "JA" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/plating,
 /area/lv624/lazarus/crashed_ship)
-=======
->>>>>>> reimported backup
 "JD" = (
 /obj/structure/blocker/invisible_wall,
 /turf/open/floor{
@@ -3511,13 +3479,10 @@
 	icon_state = "platingdmg3"
 	},
 /area/lv624/lazarus/crashed_ship)
-<<<<<<< master
 "WK" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/wood,
 /area/lv624/lazarus/crashed_ship)
-=======
->>>>>>> reimported backup
 "Xn" = (
 /obj/item/ammo_casing/shell{
 	icon_state = "shell_6_1"
@@ -3993,11 +3958,7 @@ Bs
 cS
 Df
 xl
-<<<<<<< master
 rl
-=======
-FB
->>>>>>> reimported backup
 Iu
 QZ
 QH
@@ -4041,11 +4002,7 @@ io
 Rp
 QZ
 Mr
-<<<<<<< master
 FB
-=======
-Iu
->>>>>>> reimported backup
 Gv
 Ne
 QZ
@@ -4141,21 +4098,13 @@ ko
 Nl
 NV
 Oi
-<<<<<<< master
 rl
-=======
-FB
->>>>>>> reimported backup
 xA
 QZ
 vs
 tE
 Zz
-<<<<<<< master
 lI
-=======
-nC
->>>>>>> reimported backup
 OS
 uZ
 mK
@@ -4239,11 +4188,7 @@ MT
 QZ
 gW
 kM
-<<<<<<< master
 FB
-=======
-Iu
->>>>>>> reimported backup
 Iu
 Wz
 qW
@@ -4283,11 +4228,7 @@ VN
 QZ
 bX
 XG
-<<<<<<< master
 FB
-=======
-Iu
->>>>>>> reimported backup
 Jd
 tY
 ko
@@ -4341,14 +4282,7 @@ bj
 Wz
 QZ
 Dw
-<<<<<<< master
 lI
-CZ
-nC
-gK
-Tt
-=======
-nC
 CZ
 nC
 gK
@@ -4388,13 +4322,8 @@ wv
 eo
 Wz
 Gj
-<<<<<<< master
 Gf
 lI
-=======
-Wz
-nC
->>>>>>> reimported backup
 Wz
 wS
 Bc
@@ -4618,13 +4547,8 @@ Iu
 Iu
 VD
 Wz
-<<<<<<< master
 lI
 JA
-=======
-nC
-Gf
->>>>>>> reimported backup
 Nq
 nU
 nC
@@ -4664,11 +4588,7 @@ Sn
 kd
 Ow
 pr
-<<<<<<< master
 WK
-=======
-pr
->>>>>>> reimported backup
 pr
 Wz
 Wz
@@ -4677,11 +4597,7 @@ nC
 vh
 Wz
 Wz
-<<<<<<< master
 JA
-=======
-Gf
->>>>>>> reimported backup
 yL
 eO
 us

--- a/maps/map_files/FOP_v3_Sciannex/sprinkles/25.sciannexclfship.dmm
+++ b/maps/map_files/FOP_v3_Sciannex/sprinkles/25.sciannexclfship.dmm
@@ -190,7 +190,10 @@
 /obj/item/stack/rods,
 /obj/item/ammo_magazine/rifle/type71/ap,
 /obj/effect/landmark/corpsespawner/clf,
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor{
 	dir = 8;
 	icon_state = "damaged3"
@@ -273,7 +276,10 @@
 "di" = (
 /obj/item/stack/rods,
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/plating,
 /area/lv624/lazarus/crashed_ship)
 "dw" = (
@@ -296,14 +302,20 @@
 /area/lv624/lazarus/crashed_ship)
 "dC" = (
 /obj/item/stack/rods,
+<<<<<<< master
 /obj/item/explosive/mine/clf/active,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
 /area/lv624/lazarus/crashed_ship)
 "dM" = (
 /obj/item/ammo_casing/bullet,
+<<<<<<< master
 /obj/item/explosive/mine/clf/active,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/prison{
 	dir = 1;
 	icon_state = "whitegreen"
@@ -489,6 +501,7 @@
 /obj/structure/machinery/cm_vending/sorted/medical/wall_med,
 /turf/closed/wall/prison,
 /area/fiorina/tumor/ice_lab)
+<<<<<<< master
 "hF" = (
 /obj/item/stack/tile/plasteel{
 	pixel_x = 5;
@@ -499,6 +512,8 @@
 	icon_state = "platingdmg3"
 	},
 /area/fiorina/tumor/ice_lab)
+=======
+>>>>>>> reimported backup
 "hI" = (
 /obj/structure/surface/table/reinforced/prison{
 	flipped = 1
@@ -688,7 +703,10 @@
 /area/lv624/lazarus/crashed_ship)
 "kz" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/almayer,
 /area/lv624/lazarus/crashed_ship)
 "kC" = (
@@ -750,12 +768,15 @@
 "ly" = (
 /turf/closed/wall/mineral/bone_resin,
 /area/lv624/lazarus/crashed_ship)
+<<<<<<< master
 "lI" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
 /area/lv624/lazarus/crashed_ship)
+=======
+>>>>>>> reimported backup
 "lN" = (
 /obj/item/stack/rods,
 /obj/effect/landmark/corpsespawner/colonist,
@@ -784,7 +805,10 @@
 /obj/item/ammo_casing/shell{
 	icon_state = "casing_2_1"
 	},
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -900,7 +924,10 @@
 "nP" = (
 /obj/structure/bed/chair,
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/wood,
 /area/lv624/lazarus/crashed_ship)
 "nU" = (
@@ -924,7 +951,10 @@
 	},
 /area/lv624/lazarus/crashed_ship)
 "ob" = (
+<<<<<<< master
 /obj/item/explosive/mine/clf/active,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/prison{
 	dir = 5;
 	icon_state = "whitegreen"
@@ -997,12 +1027,15 @@
 	icon_state = "platingdmg1"
 	},
 /area/fiorina/tumor/ice_lab)
+<<<<<<< master
 "pn" = (
 /obj/item/explosive/mine/clf/active,
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
 /area/lv624/lazarus/crashed_ship)
+=======
+>>>>>>> reimported backup
 "pr" = (
 /turf/open/floor/wood,
 /area/lv624/lazarus/crashed_ship)
@@ -1112,11 +1145,14 @@
 	icon_state = "whitegreen"
 	},
 /area/fiorina/tumor/ice_lab)
+<<<<<<< master
 "rl" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/plating/plating_catwalk,
 /area/lv624/lazarus/crashed_ship)
+=======
+>>>>>>> reimported backup
 "rm" = (
 /obj/structure/surface/table/woodentable,
 /obj/item/storage/firstaid/adv,
@@ -1370,7 +1406,10 @@
 /obj/item/ammo_casing/shell{
 	icon_state = "casing_9_1"
 	},
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
@@ -1465,7 +1504,10 @@
 "uZ" = (
 /obj/item/stack/rods,
 /obj/effect/spawner/random/attachment,
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/plating,
 /area/lv624/lazarus/crashed_ship)
 "vd" = (
@@ -1558,6 +1600,7 @@
 	},
 /turf/open/floor/plating,
 /area/lv624/lazarus/crashed_ship)
+<<<<<<< master
 "vy" = (
 /obj/item/explosive/mine/clf/active,
 /turf/open/floor/prison{
@@ -1565,6 +1608,8 @@
 	icon_state = "whitegreen"
 	},
 /area/fiorina/tumor/ice_lab)
+=======
+>>>>>>> reimported backup
 "vD" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/tool/weldpack,
@@ -1606,6 +1651,7 @@
 	icon_state = "whitegreen"
 	},
 /area/fiorina/tumor/ice_lab)
+<<<<<<< master
 "vV" = (
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
@@ -1615,6 +1661,8 @@
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/plating,
 /area/lv624/lazarus/crashed_ship)
+=======
+>>>>>>> reimported backup
 "vX" = (
 /obj/structure/surface/rack,
 /obj/effect/spawner/random/toolbox,
@@ -1872,10 +1920,13 @@
 	icon_state = "whitegreen"
 	},
 /area/fiorina/tumor/ice_lab)
+<<<<<<< master
 "zU" = (
 /obj/item/explosive/mine/clf/active,
 /turf/open/floor/plating/prison,
 /area/lv624/lazarus/crashed_ship)
+=======
+>>>>>>> reimported backup
 "Ab" = (
 /obj/structure/bed,
 /obj/item/bedsheet/yellow,
@@ -2217,6 +2268,7 @@
 	tag = "icon-whitegreenfull (SOUTHWEST)"
 	},
 /area/fiorina/tumor/ice_lab)
+<<<<<<< master
 "Ee" = (
 /obj/item/explosive/mine/clf/active,
 /turf/open/floor/prison{
@@ -2225,6 +2277,8 @@
 	tag = "icon-whitegreenfull (SOUTHWEST)"
 	},
 /area/fiorina/tumor/ice_lab)
+=======
+>>>>>>> reimported backup
 "El" = (
 /obj/structure/machinery/vending/snack,
 /turf/open/floor/prison{
@@ -2287,7 +2341,10 @@
 /area/fiorina/tumor/ice_lab)
 "Fa" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/almayer{
 	icon_state = "green";
 	tag = "icon-green"
@@ -2637,11 +2694,14 @@
 	},
 /turf/open/ice/noweed,
 /area/fiorina/tumor/ice_lab)
+<<<<<<< master
 "JA" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/plating,
 /area/lv624/lazarus/crashed_ship)
+=======
+>>>>>>> reimported backup
 "JD" = (
 /obj/structure/blocker/invisible_wall,
 /turf/open/floor{
@@ -3236,12 +3296,15 @@
 /obj/structure/blocker/invisible_wall,
 /turf/open/floor/plating,
 /area/fiorina/oob)
+<<<<<<< master
 "SA" = (
 /obj/item/explosive/mine/clf/active,
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
 /area/fiorina/tumor/ice_lab)
+=======
+>>>>>>> reimported backup
 "SC" = (
 /obj/structure/platform,
 /obj/structure/platform{
@@ -3280,10 +3343,13 @@
 	icon_state = "damaged3"
 	},
 /area/lv624/lazarus/crashed_ship)
+<<<<<<< master
 "Tt" = (
 /obj/item/explosive/mine/clf/active,
 /turf/open/floor/plating,
 /area/lv624/lazarus/crashed_ship)
+=======
+>>>>>>> reimported backup
 "TB" = (
 /obj/structure/stairs/perspective{
 	dir = 8;
@@ -3479,10 +3545,13 @@
 	icon_state = "platingdmg3"
 	},
 /area/lv624/lazarus/crashed_ship)
+<<<<<<< master
 "WK" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/wood,
 /area/lv624/lazarus/crashed_ship)
+=======
+>>>>>>> reimported backup
 "Xn" = (
 /obj/item/ammo_casing/shell{
 	icon_state = "shell_6_1"
@@ -3800,7 +3869,11 @@ pi
 pi
 Mo
 aB
+<<<<<<< master
 SA
+=======
+Fm
+>>>>>>> reimported backup
 Fm
 YB
 Nk
@@ -3940,7 +4013,11 @@ aB
 aB
 aB
 lR
+<<<<<<< master
 Ee
+=======
+aB
+>>>>>>> reimported backup
 nW
 Cu
 uI
@@ -3958,7 +4035,11 @@ Bs
 cS
 Df
 xl
+<<<<<<< master
 rl
+=======
+FB
+>>>>>>> reimported backup
 Iu
 QZ
 QH
@@ -4002,7 +4083,11 @@ io
 Rp
 QZ
 Mr
+<<<<<<< master
 FB
+=======
+Iu
+>>>>>>> reimported backup
 Gv
 Ne
 QZ
@@ -4068,7 +4153,11 @@ yF
 In
 tT
 Fm
+<<<<<<< master
 hF
+=======
+WE
+>>>>>>> reimported backup
 np
 WE
 UX
@@ -4098,13 +4187,21 @@ ko
 Nl
 NV
 Oi
+<<<<<<< master
 rl
+=======
+FB
+>>>>>>> reimported backup
 xA
 QZ
 vs
 tE
 Zz
+<<<<<<< master
 lI
+=======
+nC
+>>>>>>> reimported backup
 OS
 uZ
 mK
@@ -4188,7 +4285,11 @@ MT
 QZ
 gW
 kM
+<<<<<<< master
 FB
+=======
+Iu
+>>>>>>> reimported backup
 Iu
 Wz
 qW
@@ -4228,7 +4329,11 @@ VN
 QZ
 bX
 XG
+<<<<<<< master
 FB
+=======
+Iu
+>>>>>>> reimported backup
 Jd
 tY
 ko
@@ -4245,7 +4350,11 @@ Ti
 WI
 nC
 rU
+<<<<<<< master
 pn
+=======
+nC
+>>>>>>> reimported backup
 tq
 vo
 ow
@@ -4282,11 +4391,19 @@ bj
 Wz
 QZ
 Dw
+<<<<<<< master
 lI
 CZ
 nC
 gK
 Tt
+=======
+nC
+CZ
+nC
+gK
+Wz
+>>>>>>> reimported backup
 tq
 Pe
 tq
@@ -4322,8 +4439,13 @@ wv
 eo
 Wz
 Gj
+<<<<<<< master
 Gf
 lI
+=======
+Wz
+nC
+>>>>>>> reimported backup
 Wz
 wS
 Bc
@@ -4380,7 +4502,11 @@ WI
 WI
 tq
 WI
+<<<<<<< master
 zU
+=======
+Ws
+>>>>>>> reimported backup
 tE
 RV
 Fk
@@ -4429,7 +4555,11 @@ Ws
 tE
 iL
 av
+<<<<<<< master
 SA
+=======
+Fm
+>>>>>>> reimported backup
 VH
 Jt
 gt
@@ -4466,7 +4596,11 @@ Wz
 Wz
 tq
 Ac
+<<<<<<< master
 pn
+=======
+nC
+>>>>>>> reimported backup
 Ws
 Ws
 tq
@@ -4515,7 +4649,11 @@ hi
 Wz
 tq
 nC
+<<<<<<< master
 pn
+=======
+nC
+>>>>>>> reimported backup
 tq
 vo
 VH
@@ -4547,8 +4685,13 @@ Iu
 Iu
 VD
 Wz
+<<<<<<< master
 lI
 JA
+=======
+nC
+Gf
+>>>>>>> reimported backup
 Nq
 nU
 nC
@@ -4588,7 +4731,11 @@ Sn
 kd
 Ow
 pr
+<<<<<<< master
 WK
+=======
+pr
+>>>>>>> reimported backup
 pr
 Wz
 Wz
@@ -4597,7 +4744,11 @@ nC
 vh
 Wz
 Wz
+<<<<<<< master
 JA
+=======
+Gf
+>>>>>>> reimported backup
 yL
 eO
 us
@@ -4687,7 +4838,11 @@ af
 Jf
 QZ
 Uy
+<<<<<<< master
 vV
+=======
+Wz
+>>>>>>> reimported backup
 ZM
 nC
 dx
@@ -4838,7 +4993,11 @@ cz
 Ra
 NS
 OQ
+<<<<<<< master
 vy
+=======
+OQ
+>>>>>>> reimported backup
 OQ
 OQ
 LD
@@ -4974,7 +5133,11 @@ uI
 sS
 Fm
 VH
+<<<<<<< master
 SA
+=======
+Fm
+>>>>>>> reimported backup
 aP
 sS
 uI

--- a/maps/map_files/FOP_v3_Sciannex/sprinkles/25.sciannexclfship.dmm
+++ b/maps/map_files/FOP_v3_Sciannex/sprinkles/25.sciannexclfship.dmm
@@ -294,12 +294,14 @@
 /area/lv624/lazarus/crashed_ship)
 "dC" = (
 /obj/item/stack/rods,
+/obj/item/explosive/mine/clf/active,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
 /area/lv624/lazarus/crashed_ship)
 "dM" = (
 /obj/item/ammo_casing/bullet,
+/obj/item/explosive/mine/clf/active,
 /turf/open/floor/prison{
 	dir = 1;
 	icon_state = "whitegreen"
@@ -484,6 +486,16 @@
 "hD" = (
 /obj/structure/machinery/cm_vending/sorted/medical/wall_med,
 /turf/closed/wall/prison,
+/area/fiorina/tumor/ice_lab)
+"hF" = (
+/obj/item/stack/tile/plasteel{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/explosive/mine/clf/active,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
 /area/fiorina/tumor/ice_lab)
 "hI" = (
 /obj/structure/surface/table/reinforced/prison{
@@ -901,6 +913,7 @@
 	},
 /area/lv624/lazarus/crashed_ship)
 "ob" = (
+/obj/item/explosive/mine/clf/active,
 /turf/open/floor/prison{
 	dir = 5;
 	icon_state = "whitegreen"
@@ -973,6 +986,12 @@
 	icon_state = "platingdmg1"
 	},
 /area/fiorina/tumor/ice_lab)
+"pn" = (
+/obj/item/explosive/mine/clf/active,
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/lv624/lazarus/crashed_ship)
 "pr" = (
 /turf/open/floor/wood,
 /area/lv624/lazarus/crashed_ship)
@@ -1521,6 +1540,13 @@
 	},
 /turf/open/floor/plating,
 /area/lv624/lazarus/crashed_ship)
+"vy" = (
+/obj/item/explosive/mine/clf/active,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "whitegreen"
+	},
+/area/fiorina/tumor/ice_lab)
 "vD" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/tool/weldpack,
@@ -1562,6 +1588,14 @@
 	icon_state = "whitegreen"
 	},
 /area/fiorina/tumor/ice_lab)
+"vV" = (
+/obj/item/explosive/mine/clf,
+/obj/item/explosive/mine/clf,
+/obj/item/explosive/mine/clf,
+/obj/item/explosive/mine/clf,
+/obj/item/explosive/mine/clf,
+/turf/open/floor/plating,
+/area/lv624/lazarus/crashed_ship)
 "vX" = (
 /obj/structure/surface/rack,
 /obj/effect/spawner/random/toolbox,
@@ -1819,6 +1853,10 @@
 	icon_state = "whitegreen"
 	},
 /area/fiorina/tumor/ice_lab)
+"zU" = (
+/obj/item/explosive/mine/clf/active,
+/turf/open/floor/plating/prison,
+/area/lv624/lazarus/crashed_ship)
 "Ab" = (
 /obj/structure/bed,
 /obj/item/bedsheet/yellow,
@@ -2154,6 +2192,14 @@
 	dir = 8
 	},
 /obj/item/tool/warning_cone,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "whitegreenfull";
+	tag = "icon-whitegreenfull (SOUTHWEST)"
+	},
+/area/fiorina/tumor/ice_lab)
+"Ee" = (
+/obj/item/explosive/mine/clf/active,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "whitegreenfull";
@@ -3165,6 +3211,12 @@
 /obj/structure/blocker/invisible_wall,
 /turf/open/floor/plating,
 /area/fiorina/oob)
+"SA" = (
+/obj/item/explosive/mine/clf/active,
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/fiorina/tumor/ice_lab)
 "SC" = (
 /obj/structure/platform,
 /obj/structure/platform{
@@ -3202,6 +3254,10 @@
 	dir = 8;
 	icon_state = "damaged3"
 	},
+/area/lv624/lazarus/crashed_ship)
+"Tt" = (
+/obj/item/explosive/mine/clf/active,
+/turf/open/floor/plating,
 /area/lv624/lazarus/crashed_ship)
 "TB" = (
 /obj/structure/stairs/perspective{
@@ -3715,7 +3771,7 @@ pi
 pi
 Mo
 aB
-Fm
+SA
 Fm
 YB
 Nk
@@ -3855,7 +3911,7 @@ aB
 aB
 aB
 lR
-aB
+Ee
 nW
 Cu
 uI
@@ -3983,7 +4039,7 @@ yF
 In
 tT
 Fm
-WE
+hF
 np
 WE
 UX
@@ -4160,7 +4216,7 @@ Ti
 WI
 nC
 rU
-nC
+pn
 tq
 vo
 ow
@@ -4201,7 +4257,7 @@ nC
 CZ
 nC
 gK
-Wz
+Tt
 tq
 Pe
 tq
@@ -4295,7 +4351,7 @@ WI
 WI
 tq
 WI
-Ws
+zU
 tE
 RV
 Fk
@@ -4344,7 +4400,7 @@ Ws
 tE
 iL
 av
-Fm
+SA
 VH
 Jt
 gt
@@ -4381,7 +4437,7 @@ Wz
 Wz
 tq
 Ac
-nC
+pn
 Ws
 Ws
 tq
@@ -4430,7 +4486,7 @@ hi
 Wz
 tq
 nC
-nC
+pn
 tq
 vo
 VH
@@ -4602,7 +4658,7 @@ af
 Jf
 QZ
 Uy
-Wz
+vV
 ZM
 nC
 dx
@@ -4753,7 +4809,7 @@ cz
 Ra
 NS
 OQ
-OQ
+vy
 OQ
 OQ
 LD
@@ -4889,7 +4945,7 @@ uI
 sS
 Fm
 VH
-Fm
+SA
 aP
 sS
 uI

--- a/maps/map_files/FOP_v3_Sciannex/sprinkles/25.sciannexclfship.dmm
+++ b/maps/map_files/FOP_v3_Sciannex/sprinkles/25.sciannexclfship.dmm
@@ -303,9 +303,13 @@
 "dC" = (
 /obj/item/stack/rods,
 <<<<<<< master
+<<<<<<< master
 /obj/item/explosive/mine/clf/active,
 =======
 >>>>>>> reimported backup
+=======
+/obj/item/explosive/mine/clf/active,
+>>>>>>> updated clf ship to have mines
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -313,9 +317,13 @@
 "dM" = (
 /obj/item/ammo_casing/bullet,
 <<<<<<< master
+<<<<<<< master
 /obj/item/explosive/mine/clf/active,
 =======
 >>>>>>> reimported backup
+=======
+/obj/item/explosive/mine/clf/active,
+>>>>>>> updated clf ship to have mines
 /turf/open/floor/prison{
 	dir = 1;
 	icon_state = "whitegreen"
@@ -505,6 +513,9 @@
 /turf/closed/wall/prison,
 /area/fiorina/tumor/ice_lab)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated clf ship to have mines
 "hF" = (
 /obj/item/stack/tile/plasteel{
 	pixel_x = 5;
@@ -515,8 +526,11 @@
 	icon_state = "platingdmg3"
 	},
 /area/fiorina/tumor/ice_lab)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> updated clf ship to have mines
 "hI" = (
 /obj/structure/surface/table/reinforced/prison{
 	flipped = 1
@@ -961,9 +975,13 @@
 /area/lv624/lazarus/crashed_ship)
 "ob" = (
 <<<<<<< master
+<<<<<<< master
 /obj/item/explosive/mine/clf/active,
 =======
 >>>>>>> reimported backup
+=======
+/obj/item/explosive/mine/clf/active,
+>>>>>>> updated clf ship to have mines
 /turf/open/floor/prison{
 	dir = 5;
 	icon_state = "whitegreen"
@@ -1037,14 +1055,20 @@
 	},
 /area/fiorina/tumor/ice_lab)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated clf ship to have mines
 "pn" = (
 /obj/item/explosive/mine/clf/active,
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
 /area/lv624/lazarus/crashed_ship)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> updated clf ship to have mines
 "pr" = (
 /turf/open/floor/wood,
 /area/lv624/lazarus/crashed_ship)
@@ -1615,6 +1639,9 @@
 /turf/open/floor/plating,
 /area/lv624/lazarus/crashed_ship)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated clf ship to have mines
 "vy" = (
 /obj/item/explosive/mine/clf/active,
 /turf/open/floor/prison{
@@ -1622,8 +1649,11 @@
 	icon_state = "whitegreen"
 	},
 /area/fiorina/tumor/ice_lab)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> updated clf ship to have mines
 "vD" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/tool/weldpack,
@@ -1666,17 +1696,25 @@
 	},
 /area/fiorina/tumor/ice_lab)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated clf ship to have mines
 "vV" = (
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/plating,
 /area/lv624/lazarus/crashed_ship)
 =======
 >>>>>>> reimported backup
+=======
+/turf/open/floor/plating,
+/area/lv624/lazarus/crashed_ship)
+>>>>>>> updated clf ship to have mines
 "vX" = (
 /obj/structure/surface/rack,
 /obj/effect/spawner/random/toolbox,
@@ -1940,12 +1978,18 @@
 	},
 /area/fiorina/tumor/ice_lab)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated clf ship to have mines
 "zU" = (
 /obj/item/explosive/mine/clf/active,
 /turf/open/floor/plating/prison,
 /area/lv624/lazarus/crashed_ship)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> updated clf ship to have mines
 "Ab" = (
 /obj/structure/bed,
 /obj/item/bedsheet/yellow,
@@ -2295,6 +2339,9 @@
 	},
 /area/fiorina/tumor/ice_lab)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated clf ship to have mines
 "Ee" = (
 /obj/item/explosive/mine/clf/active,
 /turf/open/floor/prison{
@@ -2303,8 +2350,11 @@
 	tag = "icon-whitegreenfull (SOUTHWEST)"
 	},
 /area/fiorina/tumor/ice_lab)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> updated clf ship to have mines
 "El" = (
 /obj/structure/machinery/vending/snack,
 /turf/open/floor/prison{
@@ -3331,14 +3381,20 @@
 /turf/open/floor/plating,
 /area/fiorina/oob)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated clf ship to have mines
 "SA" = (
 /obj/item/explosive/mine/clf/active,
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
 /area/fiorina/tumor/ice_lab)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> updated clf ship to have mines
 "SC" = (
 /obj/structure/platform,
 /obj/structure/platform{
@@ -3378,12 +3434,18 @@
 	},
 /area/lv624/lazarus/crashed_ship)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated clf ship to have mines
 "Tt" = (
 /obj/item/explosive/mine/clf/active,
 /turf/open/floor/plating,
 /area/lv624/lazarus/crashed_ship)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> updated clf ship to have mines
 "TB" = (
 /obj/structure/stairs/perspective{
 	dir = 8;
@@ -3911,10 +3973,14 @@ pi
 Mo
 aB
 <<<<<<< master
+<<<<<<< master
 SA
 =======
 Fm
 >>>>>>> reimported backup
+=======
+SA
+>>>>>>> updated clf ship to have mines
 Fm
 YB
 Nk
@@ -4055,10 +4121,14 @@ aB
 aB
 lR
 <<<<<<< master
+<<<<<<< master
 Ee
 =======
 aB
 >>>>>>> reimported backup
+=======
+Ee
+>>>>>>> updated clf ship to have mines
 nW
 Cu
 uI
@@ -4195,10 +4265,14 @@ In
 tT
 Fm
 <<<<<<< master
+<<<<<<< master
 hF
 =======
 WE
 >>>>>>> reimported backup
+=======
+hF
+>>>>>>> updated clf ship to have mines
 np
 WE
 UX
@@ -4396,10 +4470,14 @@ WI
 nC
 rU
 <<<<<<< master
+<<<<<<< master
 pn
 =======
 nC
 >>>>>>> reimported backup
+=======
+pn
+>>>>>>> updated clf ship to have mines
 tq
 vo
 ow
@@ -4451,8 +4529,12 @@ nC
 CZ
 nC
 gK
+<<<<<<< master
 Wz
 >>>>>>> reimported backup
+=======
+Tt
+>>>>>>> updated clf ship to have mines
 tq
 Pe
 tq
@@ -4552,10 +4634,14 @@ WI
 tq
 WI
 <<<<<<< master
+<<<<<<< master
 zU
 =======
 Ws
 >>>>>>> reimported backup
+=======
+zU
+>>>>>>> updated clf ship to have mines
 tE
 RV
 Fk
@@ -4605,10 +4691,14 @@ tE
 iL
 av
 <<<<<<< master
+<<<<<<< master
 SA
 =======
 Fm
 >>>>>>> reimported backup
+=======
+SA
+>>>>>>> updated clf ship to have mines
 VH
 Jt
 gt
@@ -4646,10 +4736,14 @@ Wz
 tq
 Ac
 <<<<<<< master
+<<<<<<< master
 pn
 =======
 nC
 >>>>>>> reimported backup
+=======
+pn
+>>>>>>> updated clf ship to have mines
 Ws
 Ws
 tq
@@ -4703,10 +4797,14 @@ Wz
 tq
 nC
 <<<<<<< master
+<<<<<<< master
 pn
 =======
 nC
 >>>>>>> reimported backup
+=======
+pn
+>>>>>>> updated clf ship to have mines
 tq
 vo
 VH
@@ -4909,10 +5007,14 @@ Jf
 QZ
 Uy
 <<<<<<< master
+<<<<<<< master
 vV
 =======
 Wz
 >>>>>>> reimported backup
+=======
+vV
+>>>>>>> updated clf ship to have mines
 ZM
 nC
 dx
@@ -5064,10 +5166,14 @@ Ra
 NS
 OQ
 <<<<<<< master
+<<<<<<< master
 vy
 =======
 OQ
 >>>>>>> reimported backup
+=======
+vy
+>>>>>>> updated clf ship to have mines
 OQ
 >>>>>>> reimported backup
 =======
@@ -5206,10 +5312,14 @@ sS
 Fm
 VH
 <<<<<<< master
+<<<<<<< master
 SA
 =======
 Fm
 >>>>>>> reimported backup
+=======
+SA
+>>>>>>> updated clf ship to have mines
 aP
 sS
 uI

--- a/maps/map_files/FOP_v3_Sciannex/sprinkles/25.sciannexclfship.dmm
+++ b/maps/map_files/FOP_v3_Sciannex/sprinkles/25.sciannexclfship.dmm
@@ -465,12 +465,6 @@
 /obj/structure/machinery/floodlight,
 /turf/open/floor/plating,
 /area/lv624/lazarus/crashed_ship)
-"ho" = (
-/obj/structure/machinery/door/airlock/multi_tile/secure{
-	name = "\improper General Area"
-	},
-/turf/open/floor/plating,
-/area/lv624/lazarus/crashed_ship)
 "hs" = (
 /obj/structure/surface/rack,
 /obj/item/clothing/accessory/storage/webbing,
@@ -904,9 +898,7 @@
 /turf/open/floor/wood,
 /area/lv624/lazarus/crashed_ship)
 "nU" = (
-/obj/structure/machinery/door/airlock/multi_tile/secure{
-	name = "Cargo Airlock"
-	},
+/obj/structure/machinery/door/airlock/multi_tile/almayer/almayer/glass,
 /turf/open/floor/plating,
 /area/lv624/lazarus/crashed_ship)
 "nW" = (
@@ -1020,10 +1012,8 @@
 /turf/open/space,
 /area/fiorina/oob)
 "pJ" = (
-/obj/structure/machinery/door/airlock/multi_tile/secure{
-	name = "\improper Dining Room"
-	},
 /obj/structure/blocker/invisible_wall,
+/obj/structure/machinery/door/airlock/multi_tile/almayer/almayer,
 /turf/open/floor/plating/plating_catwalk,
 /area/lv624/lazarus/crashed_ship)
 "pR" = (
@@ -1849,9 +1839,8 @@
 /turf/open/floor/plating,
 /area/fiorina/oob)
 "zI" = (
-/obj/structure/machinery/door/airlock/multi_tile/secure{
-	dir = 1;
-	name = "\improper Medical Bay"
+/obj/structure/machinery/door/airlock/multi_tile/almayer/almayer/glass{
+	dir = 2
 	},
 /turf/open/floor/almayer{
 	dir = 1;
@@ -2167,13 +2156,10 @@
 	},
 /area/lv624/lazarus/crashed_ship)
 "Df" = (
-/obj/structure/machinery/power/apc{
-	dir = 1;
-	name = "Crashed Ship APC";
-	pixel_y = 30;
-	start_charge = 1
-	},
 /obj/structure/machinery/autolathe,
+/obj/structure/machinery/power/apc/high{
+	pixel_y = 24
+	},
 /turf/open/floor/almayer{
 	dir = 9;
 	icon_state = "orange";
@@ -2455,9 +2441,8 @@
 	},
 /area/fiorina/tumor/ice_lab)
 "HB" = (
-/obj/structure/machinery/door/airlock/multi_tile/secure{
-	dir = 1;
-	name = "\improper Medical Bay"
+/obj/structure/machinery/door/airlock/multi_tile/almayer/almayer/glass{
+	dir = 2
 	},
 /turf/open/floor/plating,
 /area/lv624/lazarus/crashed_ship)
@@ -3074,12 +3059,6 @@
 	},
 /turf/open/floor/plating,
 /area/lv624/lazarus/crashed_ship)
-"Qx" = (
-/obj/structure/machinery/door/airlock/multi_tile/secure{
-	name = "\improper Bunk Beds"
-	},
-/turf/open/floor/plating,
-/area/lv624/lazarus/crashed_ship)
 "QE" = (
 /obj/structure/surface/table/almayer,
 /obj/item/storage/toolbox/electrical{
@@ -3370,10 +3349,10 @@
 	},
 /area/fiorina/tumor/ice_lab)
 "VD" = (
-/obj/structure/machinery/door/airlock/multi_tile/secure{
-	name = "\improper Dining Room"
+/obj/structure/machinery/door/airlock/multi_tile/almayer/almayer/glass,
+/turf/closed/shuttle/ert{
+	icon_state = "stan_inner_w_1"
 	},
-/turf/open/floor/plating,
 /area/lv624/lazarus/crashed_ship)
 "VH" = (
 /obj/item/stack/tile/plasteel{
@@ -4093,7 +4072,7 @@ zv
 tY
 ko
 Wz
-Wz
+HB
 ko
 Nl
 NV
@@ -4275,7 +4254,7 @@ it
 kz
 Iu
 Iu
-ho
+nU
 Iu
 Wz
 bj
@@ -4505,7 +4484,7 @@ Wz
 xW
 hP
 Wz
-QZ
+VD
 Ez
 Cq
 Jw
@@ -4545,7 +4524,7 @@ qH
 Iu
 Iu
 Iu
-VD
+nU
 Wz
 lI
 JA
@@ -4680,7 +4659,7 @@ Ag
 Dp
 KU
 Sd
-Qx
+nU
 XG
 bj
 af

--- a/maps/map_files/FOP_v3_Sciannex/sprinkles/25.sciannexclfship.dmm
+++ b/maps/map_files/FOP_v3_Sciannex/sprinkles/25.sciannexclfship.dmm
@@ -302,20 +302,14 @@
 /area/lv624/lazarus/crashed_ship)
 "dC" = (
 /obj/item/stack/rods,
-<<<<<<< master
 /obj/item/explosive/mine/clf/active,
-=======
->>>>>>> reimported backup
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
 /area/lv624/lazarus/crashed_ship)
 "dM" = (
 /obj/item/ammo_casing/bullet,
-<<<<<<< master
 /obj/item/explosive/mine/clf/active,
-=======
->>>>>>> reimported backup
 /turf/open/floor/prison{
 	dir = 1;
 	icon_state = "whitegreen"
@@ -504,7 +498,6 @@
 /obj/structure/machinery/cm_vending/sorted/medical/wall_med,
 /turf/closed/wall/prison,
 /area/fiorina/tumor/ice_lab)
-<<<<<<< master
 "hF" = (
 /obj/item/stack/tile/plasteel{
 	pixel_x = 5;
@@ -515,8 +508,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/fiorina/tumor/ice_lab)
-=======
->>>>>>> reimported backup
 "hI" = (
 /obj/structure/surface/table/reinforced/prison{
 	flipped = 1
@@ -958,10 +949,7 @@
 	},
 /area/lv624/lazarus/crashed_ship)
 "ob" = (
-<<<<<<< master
 /obj/item/explosive/mine/clf/active,
-=======
->>>>>>> reimported backup
 /turf/open/floor/prison{
 	dir = 5;
 	icon_state = "whitegreen"
@@ -1034,15 +1022,12 @@
 	icon_state = "platingdmg1"
 	},
 /area/fiorina/tumor/ice_lab)
-<<<<<<< master
 "pn" = (
 /obj/item/explosive/mine/clf/active,
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
 /area/lv624/lazarus/crashed_ship)
-=======
->>>>>>> reimported backup
 "pr" = (
 /turf/open/floor/wood,
 /area/lv624/lazarus/crashed_ship)
@@ -1612,7 +1597,6 @@
 	},
 /turf/open/floor/plating,
 /area/lv624/lazarus/crashed_ship)
-<<<<<<< master
 "vy" = (
 /obj/item/explosive/mine/clf/active,
 /turf/open/floor/prison{
@@ -1620,8 +1604,6 @@
 	icon_state = "whitegreen"
 	},
 /area/fiorina/tumor/ice_lab)
-=======
->>>>>>> reimported backup
 "vD" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/tool/weldpack,
@@ -1663,18 +1645,14 @@
 	icon_state = "whitegreen"
 	},
 /area/fiorina/tumor/ice_lab)
-<<<<<<< master
 "vV" = (
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
-/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/plating,
 /area/lv624/lazarus/crashed_ship)
-=======
->>>>>>> reimported backup
 "vX" = (
 /obj/structure/surface/rack,
 /obj/effect/spawner/random/toolbox,
@@ -1937,13 +1915,10 @@
 	icon_state = "whitegreen"
 	},
 /area/fiorina/tumor/ice_lab)
-<<<<<<< master
 "zU" = (
 /obj/item/explosive/mine/clf/active,
 /turf/open/floor/plating/prison,
 /area/lv624/lazarus/crashed_ship)
-=======
->>>>>>> reimported backup
 "Ab" = (
 /obj/structure/bed,
 /obj/item/bedsheet/yellow,
@@ -2292,7 +2267,6 @@
 	tag = "icon-whitegreenfull (SOUTHWEST)"
 	},
 /area/fiorina/tumor/ice_lab)
-<<<<<<< master
 "Ee" = (
 /obj/item/explosive/mine/clf/active,
 /turf/open/floor/prison{
@@ -2301,8 +2275,6 @@
 	tag = "icon-whitegreenfull (SOUTHWEST)"
 	},
 /area/fiorina/tumor/ice_lab)
-=======
->>>>>>> reimported backup
 "El" = (
 /obj/structure/machinery/vending/snack,
 /turf/open/floor/prison{
@@ -3328,15 +3300,12 @@
 /obj/structure/blocker/invisible_wall,
 /turf/open/floor/plating,
 /area/fiorina/oob)
-<<<<<<< master
 "SA" = (
 /obj/item/explosive/mine/clf/active,
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
 /area/fiorina/tumor/ice_lab)
-=======
->>>>>>> reimported backup
 "SC" = (
 /obj/structure/platform,
 /obj/structure/platform{
@@ -3375,13 +3344,10 @@
 	icon_state = "damaged3"
 	},
 /area/lv624/lazarus/crashed_ship)
-<<<<<<< master
 "Tt" = (
 /obj/item/explosive/mine/clf/active,
 /turf/open/floor/plating,
 /area/lv624/lazarus/crashed_ship)
-=======
->>>>>>> reimported backup
 "TB" = (
 /obj/structure/stairs/perspective{
 	dir = 8;
@@ -3908,11 +3874,7 @@ pi
 pi
 Mo
 aB
-<<<<<<< master
 SA
-=======
-Fm
->>>>>>> reimported backup
 Fm
 YB
 Nk
@@ -4052,11 +4014,7 @@ aB
 aB
 aB
 lR
-<<<<<<< master
 Ee
-=======
-aB
->>>>>>> reimported backup
 nW
 Cu
 uI
@@ -4192,11 +4150,7 @@ yF
 In
 tT
 Fm
-<<<<<<< master
 hF
-=======
-WE
->>>>>>> reimported backup
 np
 WE
 UX
@@ -4393,11 +4347,7 @@ Ti
 WI
 nC
 rU
-<<<<<<< master
 pn
-=======
-nC
->>>>>>> reimported backup
 tq
 vo
 ow
@@ -4449,8 +4399,7 @@ nC
 CZ
 nC
 gK
-Wz
->>>>>>> reimported backup
+Tt
 tq
 Pe
 tq
@@ -4549,11 +4498,7 @@ WI
 WI
 tq
 WI
-<<<<<<< master
 zU
-=======
-Ws
->>>>>>> reimported backup
 tE
 RV
 Fk
@@ -4602,11 +4547,7 @@ Ws
 tE
 iL
 av
-<<<<<<< master
 SA
-=======
-Fm
->>>>>>> reimported backup
 VH
 Jt
 gt
@@ -4643,11 +4584,7 @@ Wz
 Wz
 tq
 Ac
-<<<<<<< master
 pn
-=======
-nC
->>>>>>> reimported backup
 Ws
 Ws
 tq
@@ -4700,11 +4637,7 @@ hi
 Wz
 tq
 nC
-<<<<<<< master
 pn
-=======
-nC
->>>>>>> reimported backup
 tq
 vo
 VH
@@ -4899,11 +4832,7 @@ af
 Jf
 QZ
 Uy
-<<<<<<< master
 vV
-=======
-Wz
->>>>>>> reimported backup
 ZM
 nC
 dx
@@ -5054,14 +4983,10 @@ cz
 Ra
 NS
 OQ
-<<<<<<< master
 vy
 OQ
 >>>>>>> reimported backup
 =======
-OQ
-OQ
->>>>>>> reimported backup
 OQ
 LD
 tl
@@ -5196,11 +5121,7 @@ uI
 sS
 Fm
 VH
-<<<<<<< master
 SA
-=======
-Fm
->>>>>>> reimported backup
 aP
 sS
 uI

--- a/maps/map_files/FOP_v3_Sciannex/sprinkles/25.sciannexclfship.dmm
+++ b/maps/map_files/FOP_v3_Sciannex/sprinkles/25.sciannexclfship.dmm
@@ -1,0 +1,5257 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aa" = (
+/obj/effect/decal/cleanable/blood/oil,
+/obj/structure/blocker/invisible_wall,
+/turf/open/floor/plating,
+/area/fiorina/oob)
+"af" = (
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "bluecorner";
+	tag = "icon-bluecorner (NORTH)"
+	},
+/area/lv624/lazarus/crashed_ship)
+"am" = (
+/obj/item/shard{
+	icon_state = "medium";
+	name = "ice shard"
+	},
+/turf/open/floor/prison{
+	icon_state = "whitegreen"
+	},
+/area/fiorina/tumor/ice_lab)
+"ar" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/structure/machinery/light/small{
+	dir = 1;
+	pixel_y = 20
+	},
+/turf/open/floor{
+	icon_state = "whitebluefull";
+	tag = "icon-whitebluefull"
+	},
+/area/lv624/lazarus/crashed_ship)
+"at" = (
+/obj/structure/barricade/handrail/type_b{
+	layer = 3.4
+	},
+/obj/structure/flora/pottedplant{
+	icon_state = "pottedplant_22";
+	tag = "icon-pottedplant_10"
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "whitegreenfull";
+	tag = "icon-whitegreenfull (SOUTHWEST)"
+	},
+/area/fiorina/tumor/ice_lab)
+"av" = (
+/obj/effect/landmark/corpsespawner/clf,
+/obj/item/weapon/gun/shotgun/double/with_stock,
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/fiorina/tumor/ice_lab)
+"aB" = (
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "whitegreenfull";
+	tag = "icon-whitegreenfull (SOUTHWEST)"
+	},
+/area/fiorina/tumor/ice_lab)
+"aD" = (
+/turf/closed/shuttle/ert{
+	icon_state = "rightengine_3"
+	},
+/area/lv624/lazarus/crashed_ship)
+"aH" = (
+/obj/effect/landmark/corpsespawner/clf,
+/obj/item/weapon/melee/twohanded/lungemine,
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/lv624/lazarus/crashed_ship)
+"aL" = (
+/obj/item/ammo_box/magazine/misc/flares{
+	layer = 3.1;
+	pixel_y = 16
+	},
+/obj/structure/largecrate/random/secure,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "whitegreenfull";
+	tag = "icon-whitegreenfull (SOUTHWEST)"
+	},
+/area/fiorina/tumor/ice_lab)
+"aP" = (
+/obj/structure/barricade/handrail/type_b{
+	dir = 4;
+	layer = 3.5
+	},
+/turf/open/floor/plating,
+/area/fiorina/tumor/ice_lab)
+"aQ" = (
+/obj/structure/barricade/metal/wired{
+	dir = 4;
+	icon_state = "metal_1"
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/lv624/lazarus/crashed_ship)
+"bj" = (
+/obj/effect/spawner/random/attachment,
+/turf/open/floor/plating/plating_catwalk,
+/area/lv624/lazarus/crashed_ship)
+"bk" = (
+/obj/item/clothing/head/pirate,
+/obj/item/clothing/under/pirate,
+/obj/item/clothing/suit/armor/swat/officer,
+/obj/structure/closet,
+/turf/open/floor/plating/prison,
+/area/fiorina/tumor/ice_lab)
+"bn" = (
+/obj/structure/surface/rack,
+/obj/structure/machinery/light/small{
+	dir = 1;
+	pixel_y = 20
+	},
+/obj/item/ammo_magazine/rifle/mar40,
+/obj/item/ammo_magazine/rifle/mar40,
+/obj/item/ammo_magazine/rifle/mar40,
+/obj/item/ammo_magazine/rifle/mar40,
+/obj/item/ammo_magazine/rifle/mar40,
+/obj/item/weapon/gun/rifle/mar40{
+	pixel_y = -1
+	},
+/obj/item/weapon/gun/rifle/mar40{
+	pixel_y = 6
+	},
+/turf/open/floor/almayer{
+	dir = 5;
+	icon_state = "orange";
+	tag = "icon-orange (NORTHEAST)"
+	},
+/area/lv624/lazarus/crashed_ship)
+"bo" = (
+/obj/structure/machinery/light/small{
+	dir = 1;
+	pixel_x = 3;
+	pixel_y = 20
+	},
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "green";
+	tag = "icon-green (NORTH)"
+	},
+/area/lv624/lazarus/crashed_ship)
+"bA" = (
+/obj/effect/spawner/random/tool,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "sterile_white";
+	tag = "icon-sterile_white (SOUTHWEST)"
+	},
+/area/fiorina/tumor/ice_lab)
+"bB" = (
+/obj/structure/closet/firecloset/full,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "whitegreenfull";
+	tag = "icon-whitegreenfull (SOUTHWEST)"
+	},
+/area/fiorina/tumor/ice_lab)
+"bG" = (
+/obj/effect/landmark/corpsespawner/colonist,
+/obj/structure/blocker/invisible_wall,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/fiorina/oob)
+"bM" = (
+/obj/structure/machinery/vending/coffee,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "whitegreenfull";
+	tag = "icon-whitegreenfull (SOUTHWEST)"
+	},
+/area/fiorina/tumor/ice_lab)
+"bX" = (
+/obj/structure/machinery/vending/coffee,
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "green";
+	tag = "icon-green (NORTH)"
+	},
+/area/lv624/lazarus/crashed_ship)
+"ca" = (
+/obj/item/stack/rods,
+/obj/item/ammo_magazine/rifle/type71/ap,
+/obj/effect/landmark/corpsespawner/clf,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "damaged3"
+	},
+/area/lv624/lazarus/crashed_ship)
+"ck" = (
+/obj/structure/bed,
+/obj/item/bedsheet/rd,
+/obj/effect/landmark/corpsespawner/colonist,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/almayer{
+	dir = 4;
+	icon_state = "green";
+	tag = "icon-green (EAST)"
+	},
+/area/lv624/lazarus/crashed_ship)
+"cu" = (
+/obj/structure/blocker/invisible_wall,
+/turf/closed/shuttle/ert{
+	icon_state = "stan_inner_w_2"
+	},
+/area/fiorina/oob)
+"cv" = (
+/obj/item/stack/sheet/wood,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "whitegreen"
+	},
+/area/fiorina/tumor/ice_lab)
+"cz" = (
+/obj/item/explosive/grenade/HE/frag,
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "whitegreen"
+	},
+/area/fiorina/tumor/ice_lab)
+"cI" = (
+/obj/structure/barricade/handrail/type_b{
+	layer = 3.4
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "whitegreenfull";
+	tag = "icon-whitegreenfull (SOUTHWEST)"
+	},
+/area/fiorina/tumor/ice_lab)
+"cN" = (
+/turf/closed/shuttle/ert{
+	icon_state = "stan_leftengine"
+	},
+/area/lv624/lazarus/crashed_ship)
+"cQ" = (
+/turf/closed/shuttle/ert{
+	icon_state = "stan_inner_t_left"
+	},
+/area/lv624/lazarus/crashed_ship)
+"cS" = (
+/turf/closed/shuttle/ert{
+	icon_state = "stan21"
+	},
+/area/lv624/lazarus/crashed_ship)
+"cW" = (
+/obj/structure/barricade/wooden,
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/fiorina/tumor/ice_lab)
+"cZ" = (
+/turf/open/space/basic,
+/area/fiorina/oob)
+"de" = (
+/obj/structure/girder/displaced,
+/obj/structure/girder/reinforced,
+/obj/structure/blocker/invisible_wall,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "damaged3"
+	},
+/area/fiorina/oob)
+"di" = (
+/obj/item/stack/rods,
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/turf/open/floor/plating,
+/area/lv624/lazarus/crashed_ship)
+"dw" = (
+/turf/closed/shuttle/ert{
+	icon_state = "stan9"
+	},
+/area/lv624/lazarus/crashed_ship)
+"dx" = (
+/obj/structure/cargo_container{
+	icon_state = "green 1,0"
+	},
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/lv624/lazarus/crashed_ship)
+"dy" = (
+/turf/closed/shuttle/ert{
+	icon_state = "rightengine_1"
+	},
+/area/lv624/lazarus/crashed_ship)
+"dC" = (
+/obj/item/stack/rods,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/lv624/lazarus/crashed_ship)
+"dM" = (
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "whitegreen"
+	},
+/area/fiorina/tumor/ice_lab)
+"eo" = (
+/turf/open/floor/almayer{
+	dir = 4;
+	icon_state = "greencorner";
+	tag = "icon-greencorner (EAST)"
+	},
+/area/lv624/lazarus/crashed_ship)
+"er" = (
+/obj/item/weapon/gun/smg/fp9000,
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/lv624/lazarus/crashed_ship)
+"eu" = (
+/obj/structure/machinery/door/airlock/multi_tile/secure{
+	dir = 1;
+	name = "\improper Side Entrance";
+	indestructible = 1
+	},
+/obj/structure/blocker/invisible_wall,
+/turf/open/floor/plating,
+/area/fiorina/oob)
+"ex" = (
+/obj/structure/machinery/door/airlock/secure{
+	name = "\improper Engineering Storage"
+	},
+/obj/structure/blocker/invisible_wall,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/fiorina/oob)
+"eO" = (
+/obj/item/stack/rods,
+/obj/item/ammo_magazine/rifle/type71/ap,
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/lv624/lazarus/crashed_ship)
+"fp" = (
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/structure/barricade/plasteel/wired{
+	dir = 4;
+	icon_state = "plasteel_closed_1"
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/lv624/lazarus/crashed_ship)
+"fr" = (
+/obj/structure/surface/table/reinforced/prison,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "whitegreenfull";
+	tag = "icon-whitegreenfull (SOUTHWEST)"
+	},
+/area/fiorina/tumor/ice_lab)
+"fD" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/ammo_magazine/rifle/m16/ap,
+/obj/item/ammo_magazine/rifle/m16/ap{
+	pixel_x = -2
+	},
+/obj/item/ammo_magazine/rifle/m16/ap{
+	pixel_x = -4
+	},
+/obj/item/ammo_magazine/rifle/m16/ap{
+	pixel_x = -6
+	},
+/obj/item/ammo_magazine/rifle/m16/ap{
+	pixel_x = -8
+	},
+/obj/item/weapon/melee/throwing_knife{
+	pixel_x = 18;
+	pixel_y = 9
+	},
+/obj/item/weapon/melee/throwing_knife{
+	pixel_x = 18;
+	pixel_y = 6
+	},
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "bluecorner";
+	tag = "icon-bluecorner (NORTH)"
+	},
+/area/lv624/lazarus/crashed_ship)
+"fZ" = (
+/obj/structure/platform_decoration,
+/turf/open/floor/prison{
+	icon_state = "whitegreen"
+	},
+/area/fiorina/tumor/ice_lab)
+"gk" = (
+/obj/structure/blocker/invisible_wall,
+/turf/closed/shuttle/ert{
+	icon_state = "stan20"
+	},
+/area/fiorina/oob)
+"gq" = (
+/obj/item/explosive/grenade/HE/frag,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "whitegreenfull";
+	tag = "icon-whitegreenfull (SOUTHWEST)"
+	},
+/area/fiorina/tumor/ice_lab)
+"gt" = (
+/obj/structure/barricade/wooden{
+	dir = 1;
+	pixel_y = 13
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "whitegreenfull";
+	tag = "icon-whitegreenfull (SOUTHWEST)"
+	},
+/area/fiorina/tumor/ice_lab)
+"gy" = (
+/obj/structure/machinery/door/airlock/secure{
+	name = "\improper Engineering Storage";
+	indestructible = 1
+	},
+/obj/structure/blocker/invisible_wall,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "damaged3"
+	},
+/area/fiorina/oob)
+"gK" = (
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_2"
+	},
+/obj/structure/machinery/m56d_hmg{
+	rounds = 700
+	},
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/lv624/lazarus/crashed_ship)
+"gW" = (
+/obj/structure/machinery/cm_vending/sorted/medical/no_access,
+/turf/open/floor/almayer{
+	dir = 5;
+	icon_state = "emerald";
+	tag = "icon-emerald (NORTHWEST)"
+	},
+/area/lv624/lazarus/crashed_ship)
+"hh" = (
+/obj/structure/blocker/invisible_wall,
+/turf/closed/shuttle/ert{
+	icon_state = "stan27"
+	},
+/area/fiorina/oob)
+"hi" = (
+/obj/structure/machinery/floodlight,
+/turf/open/floor/plating,
+/area/lv624/lazarus/crashed_ship)
+"ho" = (
+/obj/structure/machinery/door/airlock/multi_tile/secure{
+	name = "\improper General Area"
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/crashed_ship)
+"hs" = (
+/obj/structure/surface/rack,
+/obj/item/clothing/accessory/storage/webbing,
+/obj/item/clothing/accessory/storage/webbing,
+/obj/structure/machinery/light/small{
+	dir = 1;
+	pixel_y = 20
+	},
+/turf/open/floor/almayer{
+	dir = 4;
+	icon_state = "bluecorner";
+	tag = "icon-bluecorner (EAST)"
+	},
+/area/lv624/lazarus/crashed_ship)
+"hD" = (
+/obj/structure/machinery/cm_vending/sorted/medical/wall_med,
+/turf/closed/wall/prison,
+/area/fiorina/tumor/ice_lab)
+"hI" = (
+/obj/structure/surface/table/reinforced/prison{
+	flipped = 1
+	},
+/obj/item/device/cassette_tape/hiphop,
+/turf/open/floor/plating/prison,
+/area/fiorina/tumor/ice_lab)
+"hP" = (
+/obj/item/weapon/gun/rifle/m16,
+/obj/item/weapon/gun/rifle/m16{
+	pixel_x = 5;
+	pixel_y = 6
+	},
+/obj/structure/surface/rack,
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "bluecorner";
+	tag = "icon-bluecorner (NORTH)"
+	},
+/area/lv624/lazarus/crashed_ship)
+"ic" = (
+/obj/item/stack/sheet/metal{
+	amount = 2;
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/effect/spawner/random/attachment,
+/turf/open/floor/plating{
+	dir = 6;
+	icon_state = "warnplate"
+	},
+/area/lv624/lazarus/crashed_ship)
+"ie" = (
+/obj/structure/stairs/perspective{
+	dir = 4;
+	icon_state = "p_stair_sn_full_cap"
+	},
+/obj/structure/platform{
+	dir = 4
+	},
+/turf/open/floor/prison{
+	icon_state = "floor_plate";
+	tag = "icon-floor_plate"
+	},
+/area/fiorina/tumor/ice_lab)
+"ij" = (
+/obj/structure/girder/reinforced,
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/lv624/lazarus/crashed_ship)
+"il" = (
+/obj/item/stack/rods,
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "whitegreen"
+	},
+/area/fiorina/tumor/ice_lab)
+"im" = (
+/obj/item/weapon/gun/smg/fp9000,
+/obj/structure/barricade/metal/wired{
+	dir = 4;
+	icon_state = "metal_1"
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/crashed_ship)
+"io" = (
+/obj/structure/blocker/invisible_wall,
+/turf/open/floor/plating,
+/area/fiorina/oob)
+"it" = (
+/obj/structure/machinery/vending/snack,
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "green";
+	tag = "icon-green (NORTH)"
+	},
+/area/lv624/lazarus/crashed_ship)
+"iK" = (
+/obj/structure/blocker/invisible_wall,
+/turf/closed/shuttle/ert{
+	icon_state = "stan25"
+	},
+/area/fiorina/oob)
+"iL" = (
+/obj/structure/machinery/door/poddoor/almayer{
+	id = "clf_umbilical_1";
+	name = "\improper Umbillical Airlock"
+	},
+/turf/open/gm/dirt,
+/area/lv624/lazarus/crashed_ship)
+"iM" = (
+/obj/structure/machinery/space_heater,
+/obj/structure/platform{
+	dir = 8
+	},
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "whitegreen"
+	},
+/area/fiorina/tumor/ice_lab)
+"iS" = (
+/obj/item/stack/sheet/metal{
+	amount = 2;
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/structure/barricade/metal/wired{
+	dir = 8;
+	icon_state = "metal_1"
+	},
+/turf/open/floor/plating{
+	dir = 8;
+	icon_state = "warnplate"
+	},
+/area/lv624/lazarus/crashed_ship)
+"ji" = (
+/obj/item/ammo_magazine/rifle/type71/ap,
+/turf/open/floor/plating,
+/area/lv624/lazarus/crashed_ship)
+"jn" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/storage/belt/medical/full,
+/obj/item/storage/belt/medical/full{
+	pixel_x = 2;
+	pixel_y = 4
+	},
+/obj/item/storage/firstaid/regular,
+/turf/open/floor/almayer{
+	dir = 9;
+	icon_state = "emerald";
+	tag = "icon-emerald (NORTHWEST)"
+	},
+/area/lv624/lazarus/crashed_ship)
+"jq" = (
+/obj/structure/sign/poster/clf,
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "whitegreen"
+	},
+/area/fiorina/tumor/ice_lab)
+"jA" = (
+/obj/structure/ice/thin/indestructible{
+	icon_state = "Corner"
+	},
+/obj/structure/blocker/invisible_wall,
+/turf/open/ice/noweed,
+/area/fiorina/tumor/ice_lab)
+"jJ" = (
+/turf/closed/shuttle/ert{
+	icon_state = "rightengine_2"
+	},
+/area/lv624/lazarus/crashed_ship)
+"jP" = (
+/obj/structure/stairs/perspective{
+	dir = 1;
+	icon_state = "p_stair_sn_full_cap"
+	},
+/obj/structure/platform{
+	dir = 8
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "whitegreenfull";
+	tag = "icon-whitegreenfull (SOUTHWEST)"
+	},
+/area/fiorina/tumor/ice_lab)
+"kd" = (
+/obj/structure/blocker/invisible_wall,
+/turf/open/floor/almayer,
+/area/lv624/lazarus/crashed_ship)
+"kj" = (
+/obj/item/stack/rods,
+/obj/item/ammo_magazine/smg/mp5,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/fiorina/tumor/ice_lab)
+"kl" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plating,
+/area/lv624/lazarus/crashed_ship)
+"ko" = (
+/turf/closed/shuttle/ert{
+	icon_state = "stan_inner_w_2"
+	},
+/area/lv624/lazarus/crashed_ship)
+"kz" = (
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/turf/open/floor/almayer,
+/area/lv624/lazarus/crashed_ship)
+"kC" = (
+/obj/structure/machinery/cm_vending/sorted/marine_food,
+/turf/open/floor/almayer{
+	dir = 5;
+	icon_state = "green";
+	tag = "icon-green (NORTHEAST)"
+	},
+/area/lv624/lazarus/crashed_ship)
+"kK" = (
+/obj/effect/decal/cleanable/blood,
+/obj/structure/blocker/invisible_wall,
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/fiorina/oob)
+"kM" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/almayer{
+	dir = 4;
+	icon_state = "emeraldcorner";
+	tag = "icon-emeraldcorner (EAST)"
+	},
+/area/lv624/lazarus/crashed_ship)
+"kV" = (
+/obj/structure/surface/table/almayer,
+/obj/item/storage/backpack/general_belt{
+	pixel_y = 3
+	},
+/obj/structure/blocker/invisible_wall,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/fiorina/oob)
+"kY" = (
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/turf/open/floor/plating{
+	dir = 4;
+	icon_state = "warnplate"
+	},
+/area/lv624/lazarus/crashed_ship)
+"lg" = (
+/obj/structure/surface/rack,
+/obj/item/ammo_magazine/shotgun/buckshot,
+/obj/item/ammo_magazine/shotgun/buckshot,
+/obj/item/ammo_magazine/shotgun/buckshot,
+/obj/item/ammo_magazine/shotgun/buckshot,
+/turf/open/floor/almayer{
+	dir = 10;
+	icon_state = "orange";
+	tag = "icon-orange (SOUTHWEST)"
+	},
+/area/lv624/lazarus/crashed_ship)
+"lo" = (
+/turf/open/space,
+/area/fiorina/oob)
+"ly" = (
+/turf/closed/wall/mineral/bone_resin,
+/area/lv624/lazarus/crashed_ship)
+"lN" = (
+/obj/item/stack/rods,
+/obj/effect/landmark/corpsespawner/colonist,
+/obj/structure/blocker/invisible_wall,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "damaged3"
+	},
+/area/fiorina/oob)
+"lR" = (
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "whitegreenfull";
+	tag = "icon-whitegreenfull (SOUTHWEST)"
+	},
+/area/fiorina/tumor/ice_lab)
+"lT" = (
+/obj/structure/lattice,
+/obj/structure/blocker/invisible_wall,
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/fiorina/oob)
+"lU" = (
+/obj/item/ammo_casing/shell{
+	icon_state = "casing_2_1"
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/lv624/lazarus/crashed_ship)
+"mu" = (
+/obj/item/trash/pistachios,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "whitegreenfull";
+	tag = "icon-whitegreenfull (SOUTHWEST)"
+	},
+/area/fiorina/tumor/ice_lab)
+"mD" = (
+/obj/structure/ice/thin/indestructible{
+	icon_state = "Straight"
+	},
+/obj/structure/blocker/invisible_wall,
+/turf/open/ice/noweed,
+/area/fiorina/tumor/ice_lab)
+"mE" = (
+/obj/item/stack/rods,
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/plating,
+/area/fiorina/tumor/ice_lab)
+"mI" = (
+/obj/structure/ice/thin/indestructible{
+	dir = 1;
+	icon_state = "Straight"
+	},
+/obj/structure/blocker/invisible_wall,
+/turf/open/ice/noweed,
+/area/fiorina/tumor/ice_lab)
+"mK" = (
+/obj/effect/landmark/corpsespawner/clf,
+/turf/open/floor/plating,
+/area/lv624/lazarus/crashed_ship)
+"mN" = (
+/obj/structure/disposalpipe/segment{
+	icon_state = "delivery_outlet";
+	layer = 6;
+	name = "overhead ducting";
+	pixel_y = 33
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "whitegreenfull";
+	tag = "icon-whitegreenfull (SOUTHWEST)"
+	},
+/area/fiorina/tumor/ice_lab)
+"mS" = (
+/turf/closed/shuttle/ert{
+	icon_state = "stan_r_w"
+	},
+/area/lv624/lazarus/crashed_ship)
+"na" = (
+/obj/effect/landmark/corpsespawner/clf,
+/obj/item/weapon/gun/pistol/holdout,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "damaged3"
+	},
+/area/fiorina/tumor/ice_lab)
+"nb" = (
+/obj/item/tool/warning_cone{
+	pixel_x = -4;
+	pixel_y = 2
+	},
+/turf/open/floor/prison{
+	icon_state = "floor_plate";
+	tag = "icon-floor_plate"
+	},
+/area/fiorina/tumor/ice_lab)
+"ne" = (
+/obj/item/storage/pill_bottle/bicaridine/skillless,
+/obj/item/stack/sheet/metal,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/fiorina/tumor/ice_lab)
+"nh" = (
+/obj/structure/window_frame/prison,
+/obj/item/shard{
+	icon_state = "medium";
+	name = "ice shard"
+	},
+/turf/open/floor/plating/prison,
+/area/fiorina/tumor/ice_lab)
+"np" = (
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "whitegreen"
+	},
+/area/fiorina/tumor/ice_lab)
+"nu" = (
+/obj/structure/machinery/cm_vending/sorted/medical/wall_med{
+	pixel_y = 25
+	},
+/obj/item/storage/firstaid/regular/empty,
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "green";
+	tag = "icon-green (NORTH)"
+	},
+/area/lv624/lazarus/crashed_ship)
+"nC" = (
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/lv624/lazarus/crashed_ship)
+"nM" = (
+/turf/closed/shuttle/ert,
+/area/lv624/lazarus/crashed_ship)
+"nP" = (
+/obj/structure/bed/chair,
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/turf/open/floor/wood,
+/area/lv624/lazarus/crashed_ship)
+"nU" = (
+/obj/structure/machinery/door/airlock/multi_tile/secure{
+	name = "Cargo Airlock"
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/crashed_ship)
+"nW" = (
+/obj/structure/machinery/light/double/blue,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "whitegreenfull";
+	tag = "icon-whitegreenfull (SOUTHWEST)"
+	},
+/area/fiorina/tumor/ice_lab)
+"nZ" = (
+/turf/open/floor/almayer{
+	icon_state = "greencorner";
+	tag = "icon-greencorner"
+	},
+/area/lv624/lazarus/crashed_ship)
+"ob" = (
+/turf/open/floor/prison{
+	dir = 5;
+	icon_state = "whitegreen"
+	},
+/area/fiorina/tumor/ice_lab)
+"oj" = (
+/obj/effect/decal/cleanable/blood/oil,
+/obj/structure/blocker/invisible_wall,
+/turf/open/floor/almayer,
+/area/fiorina/oob)
+"ow" = (
+/obj/item/stack/tile/plasteel{
+	pixel_x = 12;
+	pixel_y = 13
+	},
+/obj/item/stack/rods,
+/obj/item/stack/rods,
+/turf/open/floor/plating/prison,
+/area/fiorina/tumor/ice_lab)
+"oy" = (
+/obj/structure/barricade/metal/wired{
+	dir = 4;
+	icon_state = "metal_3"
+	},
+/obj/structure/machinery/defenses/sentry/premade/dumb{
+	dir = 4;
+	faction_group = list("CLF")
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/lv624/lazarus/crashed_ship)
+"oA" = (
+/obj/effect/landmark/monkey_spawn,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "sterile_white";
+	tag = "icon-sterile_white (SOUTHWEST)"
+	},
+/area/fiorina/tumor/ice_lab)
+"oE" = (
+/obj/item/stack/rods,
+/obj/structure/lattice,
+/obj/structure/blocker/invisible_wall,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "damaged3"
+	},
+/area/fiorina/oob)
+"pe" = (
+/obj/structure/platform{
+	dir = 8
+	},
+/obj/item/device/flashlight/lamp/tripod,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "whitegreen"
+	},
+/area/fiorina/tumor/ice_lab)
+"pi" = (
+/obj/structure/prop/structure_lattice{
+	dir = 4
+	},
+/obj/structure/prop/structure_lattice{
+	dir = 4;
+	layer = 3.1;
+	pixel_y = 10
+	},
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/fiorina/tumor/ice_lab)
+"pr" = (
+/turf/open/floor/wood,
+/area/lv624/lazarus/crashed_ship)
+"pt" = (
+/obj/structure/machinery/light/double/blue,
+/obj/item/stack/rods,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "whitegreenfull";
+	tag = "icon-whitegreenfull (SOUTHWEST)"
+	},
+/area/fiorina/tumor/ice_lab)
+"pD" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/fiorina/oob)
+"pJ" = (
+/obj/structure/machinery/door/airlock/multi_tile/secure{
+	name = "\improper Dining Room"
+	},
+/obj/structure/blocker/invisible_wall,
+/turf/open/floor/plating/plating_catwalk,
+/area/lv624/lazarus/crashed_ship)
+"pR" = (
+/obj/item/stack/tile/plasteel{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/plating,
+/area/fiorina/tumor/ice_lab)
+"pW" = (
+/obj/structure/largecrate/supply/ammo/m56d,
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/lv624/lazarus/crashed_ship)
+"qh" = (
+/obj/item/tool/warning_cone{
+	pixel_x = -4;
+	pixel_y = 5
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "sterile_white";
+	tag = "icon-sterile_white (SOUTHWEST)"
+	},
+/area/fiorina/tumor/ice_lab)
+"qm" = (
+/obj/structure/machinery/computer/communications{
+	icon_state = "commb";
+	stat = 1
+	},
+/obj/structure/surface/table/reinforced/prison,
+/obj/structure/blocker/invisible_wall,
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/fiorina/oob)
+"qo" = (
+/obj/structure/platform{
+	dir = 4
+	},
+/obj/item/shard{
+	icon_state = "medium";
+	name = "ice shard"
+	},
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "whitegreen"
+	},
+/area/fiorina/tumor/ice_lab)
+"qp" = (
+/obj/structure/surface/table/woodentable,
+/obj/item/newspaper{
+	name = "character sheet";
+	pixel_x = -6
+	},
+/obj/item/newspaper{
+	name = "character sheet";
+	pixel_x = 4;
+	pixel_y = 8
+	},
+/turf/open/floor/plating/prison,
+/area/fiorina/tumor/ice_lab)
+"qH" = (
+/obj/structure/machinery/deployable/barrier{
+	anchored = 1
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/lv624/lazarus/crashed_ship)
+"qM" = (
+/obj/structure/ice/thin/indestructible{
+	dir = 4;
+	icon_state = "Straight"
+	},
+/obj/structure/blocker/invisible_wall,
+/turf/open/ice/noweed,
+/area/fiorina/tumor/ice_lab)
+"qW" = (
+/obj/effect/spawner/random/attachment,
+/turf/open/floor/plating,
+/area/lv624/lazarus/crashed_ship)
+"qY" = (
+/obj/structure/barricade/wooden,
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "whitegreen"
+	},
+/area/fiorina/tumor/ice_lab)
+"rm" = (
+/obj/structure/surface/table/woodentable,
+/obj/item/storage/firstaid/adv,
+/turf/open/floor/wood,
+/area/lv624/lazarus/crashed_ship)
+"rr" = (
+/turf/open/floor/prison,
+/area/fiorina/tumor/ice_lab)
+"rz" = (
+/obj/structure/blocker/invisible_wall,
+/turf/open/floor/plating/plating_catwalk,
+/area/fiorina/oob)
+"rQ" = (
+/turf/closed/shuttle/ert{
+	icon_state = "stan_l_w"
+	},
+/area/lv624/lazarus/crashed_ship)
+"rU" = (
+/obj/item/stack/rods,
+/turf/open/floor/plating/prison,
+/area/lv624/lazarus/crashed_ship)
+"sj" = (
+/obj/structure/stairs/perspective{
+	dir = 1;
+	icon_state = "p_stair_full"
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "whitegreenfull";
+	tag = "icon-whitegreenfull (SOUTHWEST)"
+	},
+/area/fiorina/tumor/ice_lab)
+"sm" = (
+/obj/item/stack/rods,
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/turf/open/floor/plating,
+/area/lv624/lazarus/crashed_ship)
+"sn" = (
+/obj/item/stool,
+/obj/structure/blocker/invisible_wall,
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/fiorina/oob)
+"sp" = (
+/turf/open/floor/almayer{
+	dir = 10;
+	icon_state = "emerald";
+	tag = "icon-emerald (NORTHWEST)"
+	},
+/area/lv624/lazarus/crashed_ship)
+"sC" = (
+/obj/structure/machinery/space_heater,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/fiorina/tumor/ice_lab)
+"sI" = (
+/turf/closed/shuttle/ert{
+	icon_state = "stan3"
+	},
+/area/lv624/lazarus/crashed_ship)
+"sL" = (
+/obj/effect/landmark/corpsespawner/clf,
+/turf/open/floor/almayer{
+	dir = 8;
+	icon_state = "emeraldcorner";
+	tag = "icon-emeraldcorner (EAST)"
+	},
+/area/lv624/lazarus/crashed_ship)
+"sP" = (
+/obj/structure/barricade/metal/wired{
+	dir = 4;
+	icon_state = "metal_1"
+	},
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_3"
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/crashed_ship)
+"sS" = (
+/obj/structure/barricade/handrail/type_b{
+	dir = 4;
+	layer = 3.5
+	},
+/turf/open/floor/prison{
+	icon_state = "floor_plate";
+	tag = "icon-floor_plate"
+	},
+/area/fiorina/tumor/ice_lab)
+"sU" = (
+/obj/structure/barricade/wooden{
+	desc = "This barricade is heavily reinforced. Nothing short of blasting it open seems like it'll do the trick, that or melting the breams supporting it...";
+	dir = 8;
+	health = 25000
+	},
+/obj/item/stack/tile/plasteel{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/plating,
+/area/fiorina/tumor/ice_lab)
+"tc" = (
+/obj/structure/machinery/space_heater,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "whitegreenfull";
+	tag = "icon-whitegreenfull (SOUTHWEST)"
+	},
+/area/fiorina/tumor/ice_lab)
+"th" = (
+/obj/structure/machinery/body_scanconsole,
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "emerald";
+	tag = "icon-emerald (NORTH)"
+	},
+/area/lv624/lazarus/crashed_ship)
+"tk" = (
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1"
+	},
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/lv624/lazarus/crashed_ship)
+"tl" = (
+/obj/structure/machinery/door/airlock/prison_hatch/autoname{
+	dir = 1
+	},
+/turf/open/floor/plating/prison,
+/area/fiorina/tumor/ice_lab)
+"tq" = (
+/turf/open/floor{
+	dir = 8;
+	icon_state = "damaged3"
+	},
+/area/lv624/lazarus/crashed_ship)
+"tt" = (
+/obj/structure/platform{
+	dir = 4
+	},
+/obj/item/device/flashlight/lamp/tripod,
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "whitegreen"
+	},
+/area/fiorina/tumor/ice_lab)
+"tv" = (
+/obj/item/stack/tile/plasteel{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/stack/tile/plasteel{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/fiorina/tumor/ice_lab)
+"tx" = (
+/obj/item/stack/rods,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/fiorina/tumor/ice_lab)
+"ty" = (
+/obj/structure/largecrate/random/barrel/yellow,
+/obj/structure/blocker/invisible_wall,
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/fiorina/oob)
+"tC" = (
+/turf/open/floor/plating{
+	dir = 10;
+	icon_state = "warnplate"
+	},
+/area/lv624/lazarus/crashed_ship)
+"tD" = (
+/turf/closed/shuttle/ert{
+	icon_state = "stan_inner_t_right"
+	},
+/area/lv624/lazarus/crashed_ship)
+"tE" = (
+/turf/open/floor/plating{
+	icon_state = "warnplate"
+	},
+/area/lv624/lazarus/crashed_ship)
+"tL" = (
+/obj/item/shard{
+	icon_state = "large";
+	name = "ice shard"
+	},
+/obj/structure/platform{
+	dir = 8
+	},
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "whitegreen"
+	},
+/area/fiorina/tumor/ice_lab)
+"tM" = (
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/fiorina/tumor/ice_lab)
+"tN" = (
+/turf/closed/shuttle/ert{
+	icon_state = "stan20"
+	},
+/area/lv624/lazarus/crashed_ship)
+"tP" = (
+/turf/open/floor/plating{
+	dir = 5;
+	icon_state = "warnplate"
+	},
+/area/lv624/lazarus/crashed_ship)
+"tS" = (
+/turf/open/floor/prison{
+	icon_state = "floor_plate";
+	tag = "icon-floor_plate"
+	},
+/area/fiorina/tumor/ice_lab)
+"tT" = (
+/turf/closed/shuttle/ert{
+	icon_state = "leftengine_1";
+	opacity = 0
+	},
+/area/lv624/lazarus/crashed_ship)
+"tY" = (
+/turf/closed/shuttle/ert{
+	icon_state = "stan_white_t_up"
+	},
+/area/lv624/lazarus/crashed_ship)
+"tZ" = (
+/obj/structure/machinery/light/small{
+	dir = 1;
+	pixel_y = 20
+	},
+/obj/structure/barricade/metal/wired{
+	dir = 4;
+	icon_state = "metal_1"
+	},
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/lv624/lazarus/crashed_ship)
+"ug" = (
+/obj/item/ammo_casing/shell{
+	icon_state = "casing_9_1"
+	},
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/lv624/lazarus/crashed_ship)
+"uh" = (
+/turf/open/floor/plating/prison,
+/area/fiorina/tumor/ice_lab)
+"ul" = (
+/obj/effect/landmark/corpsespawner/clf,
+/obj/item/weapon/gun/shotgun/double/sawn,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "damaged3"
+	},
+/area/fiorina/tumor/ice_lab)
+"us" = (
+/obj/effect/spawner/random/attachment,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "damaged3"
+	},
+/area/lv624/lazarus/crashed_ship)
+"uv" = (
+/obj/structure/sink{
+	pixel_y = 15
+	},
+/obj/item/tool/soap{
+	pixel_x = 2;
+	pixel_y = -4
+	},
+/turf/open/floor{
+	icon_state = "whitebluefull";
+	tag = "icon-whitebluefull"
+	},
+/area/lv624/lazarus/crashed_ship)
+"uy" = (
+/obj/effect/landmark/corpsespawner/ua_riot,
+/obj/item/weapon/gun/pistol/b92fs,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "whitegreen"
+	},
+/area/fiorina/tumor/ice_lab)
+"uB" = (
+/obj/structure/machinery/vending/cigarette/colony,
+/turf/open/floor/plating/prison,
+/area/fiorina/tumor/ice_lab)
+"uF" = (
+/obj/item/tool/shovel/snow,
+/obj/item/device/flashlight,
+/obj/structure/surface/rack,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "sterile_white";
+	tag = "icon-sterile_white (SOUTHWEST)"
+	},
+/area/fiorina/tumor/ice_lab)
+"uI" = (
+/obj/structure/sign/poster/clf,
+/turf/closed/wall/prison,
+/area/fiorina/tumor/ice_lab)
+"uK" = (
+/obj/structure/platform_decoration,
+/obj/item/shard{
+	icon_state = "medium";
+	name = "ice shard"
+	},
+/turf/open/floor/prison{
+	icon_state = "whitegreen"
+	},
+/area/fiorina/tumor/ice_lab)
+"uM" = (
+/obj/structure/ice/thin/indestructible{
+	dir = 8;
+	icon_state = "Straight"
+	},
+/obj/structure/blocker/invisible_wall,
+/obj/structure/platform{
+	dir = 1;
+	layer = 2.1
+	},
+/turf/open/ice/noweed,
+/area/fiorina/tumor/ice_lab)
+"uQ" = (
+/obj/structure/platform_decoration{
+	dir = 1
+	},
+/turf/open/floor/prison{
+	icon_state = "whitegreen"
+	},
+/area/fiorina/tumor/ice_lab)
+"uZ" = (
+/obj/item/stack/rods,
+/obj/effect/spawner/random/attachment,
+/turf/open/floor/plating,
+/area/lv624/lazarus/crashed_ship)
+"vd" = (
+/obj/structure/barricade/plasteel/wired{
+	icon_state = "plasteel_2"
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/lv624/lazarus/crashed_ship)
+"vf" = (
+/turf/open/floor/almayer{
+	dir = 8;
+	icon_state = "orangecorner";
+	tag = "icon-orangecorner (WEST)"
+	},
+/area/lv624/lazarus/crashed_ship)
+"vh" = (
+/obj/effect/spawner/random/attachment,
+/turf/open/floor/almayer{
+	icon_state = "bluecorner";
+	tag = "icon-bluecorner"
+	},
+/area/lv624/lazarus/crashed_ship)
+"vi" = (
+/obj/structure/barricade/wooden{
+	dir = 1;
+	pixel_y = 13
+	},
+/obj/structure/barricade/wooden{
+	dir = 4;
+	pixel_y = 4
+	},
+/obj/effect/landmark/corpsespawner/ua_riot,
+/obj/item/weapon/gun/smg/mp5,
+/obj/item/ammo_magazine/smg/mp5,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "whitegreen"
+	},
+/area/fiorina/tumor/ice_lab)
+"vo" = (
+/turf/closed/shuttle/ert{
+	icon_state = "stan2"
+	},
+/area/lv624/lazarus/crashed_ship)
+"vr" = (
+/obj/structure/surface/rack,
+/obj/item/ammo_magazine/shotgun/slugs,
+/obj/item/ammo_magazine/shotgun/slugs,
+/obj/item/ammo_magazine/shotgun/slugs,
+/turf/open/floor/almayer{
+	dir = 9;
+	icon_state = "orange";
+	tag = "icon-orange (NORTHWEST)"
+	},
+/area/lv624/lazarus/crashed_ship)
+"vs" = (
+/obj/structure/machinery/light/small{
+	dir = 1;
+	pixel_y = 20
+	},
+/turf/open/floor/plating{
+	dir = 1;
+	icon_state = "warnplate"
+	},
+/area/lv624/lazarus/crashed_ship)
+"vv" = (
+/obj/structure/surface/rack,
+/obj/item/device/radio{
+	pixel_x = 3
+	},
+/obj/item/device/radio,
+/obj/item/device/radio{
+	pixel_x = -3
+	},
+/turf/open/floor/almayer{
+	dir = 10;
+	icon_state = "green";
+	tag = "icon-green (SOUTHWEST)"
+	},
+/area/lv624/lazarus/crashed_ship)
+"vx" = (
+/obj/structure/barricade/metal/wired{
+	dir = 8;
+	icon_state = "metal_1"
+	},
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_2"
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/crashed_ship)
+"vD" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/tool/weldpack,
+/obj/item/clothing/glasses/welding,
+/obj/item/tool/weldingtool,
+/turf/open/floor/almayer{
+	dir = 8;
+	icon_state = "bluecorner";
+	tag = "icon-bluecorner (NORTH)"
+	},
+/area/lv624/lazarus/crashed_ship)
+"vG" = (
+/obj/structure/blocker/invisible_wall,
+/turf/closed/shuttle/ert{
+	icon_state = "stan23"
+	},
+/area/fiorina/oob)
+"vL" = (
+/obj/item/stack/rods,
+/turf/open/floor/plating{
+	dir = 8;
+	icon_state = "warnplate"
+	},
+/area/lv624/lazarus/crashed_ship)
+"vN" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/paper_bin,
+/obj/item/tool/pen,
+/turf/open/floor/almayer{
+	dir = 10;
+	icon_state = "emerald";
+	tag = "icon-emerald (NORTHWEST)"
+	},
+/area/lv624/lazarus/crashed_ship)
+"vT" = (
+/obj/structure/sign/poster/clf,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "whitegreen"
+	},
+/area/fiorina/tumor/ice_lab)
+"vX" = (
+/obj/structure/surface/rack,
+/obj/effect/spawner/random/toolbox,
+/turf/open/floor/plating/prison,
+/area/fiorina/tumor/ice_lab)
+"vY" = (
+/obj/structure/girder/reinforced,
+/obj/structure/blocker/invisible_wall,
+/turf/closed/shuttle/ert{
+	icon_state = "stan_inner_w_2"
+	},
+/area/fiorina/oob)
+"wa" = (
+/obj/item/ammo_casing/bullet,
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/fiorina/tumor/ice_lab)
+"wc" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/storage/firstaid/regular,
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "emerald";
+	tag = "icon-emerald (NORTH)"
+	},
+/area/lv624/lazarus/crashed_ship)
+"wk" = (
+/obj/structure/girder/reinforced,
+/turf/closed/shuttle/ert{
+	icon_state = "stan_inner_w_1"
+	},
+/area/lv624/lazarus/crashed_ship)
+"wv" = (
+/turf/open/floor/almayer{
+	dir = 4;
+	icon_state = "green";
+	tag = "icon-green (EAST)"
+	},
+/area/lv624/lazarus/crashed_ship)
+"wM" = (
+/obj/structure/ice/thin/indestructible{
+	dir = 1;
+	icon_state = "Corner"
+	},
+/obj/structure/blocker/invisible_wall,
+/obj/structure/platform{
+	dir = 1;
+	layer = 2.1
+	},
+/turf/open/ice/noweed,
+/area/fiorina/tumor/ice_lab)
+"wP" = (
+/obj/structure/blocker/invisible_wall,
+/turf/closed/shuttle/ert{
+	icon_state = "stan_inner_w_1"
+	},
+/area/fiorina/oob)
+"wS" = (
+/obj/structure/girder/reinforced,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "damaged3"
+	},
+/area/lv624/lazarus/crashed_ship)
+"xe" = (
+/obj/structure/blocker/invisible_wall,
+/turf/closed/shuttle/ert{
+	icon_state = "stan_inner_s_w"
+	},
+/area/fiorina/oob)
+"xf" = (
+/turf/closed/shuttle/ert{
+	icon_state = "stan1"
+	},
+/area/lv624/lazarus/crashed_ship)
+"xg" = (
+/obj/structure/blocker/invisible_wall,
+/turf/closed/shuttle/ert{
+	icon_state = "stan_white_t_up"
+	},
+/area/fiorina/oob)
+"xi" = (
+/turf/open/floor/plating,
+/area/fiorina/tumor/ice_lab)
+"xl" = (
+/obj/item/circuitboard/apc{
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/obj/item/cell{
+	pixel_x = -2
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/lv624/lazarus/crashed_ship)
+"xA" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/almayer{
+	dir = 8;
+	icon_state = "emeraldcorner";
+	tag = "icon-emeraldcorner (EAST)"
+	},
+/area/lv624/lazarus/crashed_ship)
+"xP" = (
+/obj/structure/platform,
+/obj/structure/platform{
+	dir = 4
+	},
+/obj/structure/platform_decoration{
+	dir = 6
+	},
+/obj/structure/sign/poster/clf,
+/turf/open/floor/prison{
+	dir = 6;
+	icon_state = "whitegreen"
+	},
+/area/fiorina/tumor/ice_lab)
+"xU" = (
+/obj/effect/landmark/corpsespawner/security,
+/obj/item/weapon/gun/pistol/b92fs,
+/turf/open/floor/prison{
+	icon_state = "floor_plate";
+	tag = "icon-floor_plate"
+	},
+/area/fiorina/tumor/ice_lab)
+"xW" = (
+/obj/structure/machinery/vending/cigarette/colony,
+/turf/open/floor/plating,
+/area/lv624/lazarus/crashed_ship)
+"yh" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/lv624/lazarus/crashed_ship)
+"yk" = (
+/obj/item/stack/sheet/metal,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/fiorina/tumor/ice_lab)
+"yw" = (
+/obj/structure/prop/structure_lattice{
+	dir = 4;
+	health = 300
+	},
+/obj/structure/prop/structure_lattice{
+	dir = 4;
+	layer = 3.1;
+	pixel_y = 10
+	},
+/turf/open/floor/prison{
+	icon_state = "floor_plate";
+	tag = "icon-floor_plate"
+	},
+/area/fiorina/tumor/ice_lab)
+"yx" = (
+/obj/item/tool/pickaxe,
+/obj/item/tool/pickaxe{
+	pixel_y = 5
+	},
+/obj/item/tool/pickaxe{
+	pixel_y = 10
+	},
+/obj/structure/surface/rack,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "sterile_white";
+	tag = "icon-sterile_white (SOUTHWEST)"
+	},
+/area/fiorina/tumor/ice_lab)
+"yz" = (
+/obj/structure/surface/table/woodentable,
+/obj/item/storage/firstaid/regular{
+	pixel_x = 3;
+	pixel_y = 5
+	},
+/obj/item/storage/firstaid/regular,
+/turf/open/floor/wood,
+/area/lv624/lazarus/crashed_ship)
+"yF" = (
+/turf/closed/shuttle/ert{
+	icon_state = "leftengine_3";
+	opacity = 0
+	},
+/area/lv624/lazarus/crashed_ship)
+"yI" = (
+/obj/item/tool/weldingtool,
+/turf/open/floor/plating/prison,
+/area/fiorina/tumor/ice_lab)
+"yL" = (
+/obj/effect/landmark/corpsespawner/clf,
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/lv624/lazarus/crashed_ship)
+"yQ" = (
+/obj/structure/largecrate/supply/supplies/mre{
+	desc = "A supply crate containing fifty reposessed USCM MRE packets.";
+	name = "\improper CLF Supply MRE crate (x50)"
+	},
+/turf/open/floor/plating{
+	dir = 9;
+	icon_state = "warnplate"
+	},
+/area/lv624/lazarus/crashed_ship)
+"ze" = (
+/obj/structure/machinery/door/airlock/multi_tile/secure{
+	name = "\improper Bridge"
+	},
+/obj/structure/blocker/invisible_wall,
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/fiorina/oob)
+"zr" = (
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "whitegreen"
+	},
+/area/fiorina/tumor/ice_lab)
+"zv" = (
+/obj/structure/blocker/invisible_wall,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "damaged3"
+	},
+/area/fiorina/oob)
+"zG" = (
+/obj/structure/lattice,
+/obj/structure/blocker/invisible_wall,
+/turf/open/floor/plating,
+/area/fiorina/oob)
+"zI" = (
+/obj/structure/machinery/door/airlock/multi_tile/secure{
+	dir = 1;
+	name = "\improper Medical Bay"
+	},
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "bluecorner";
+	tag = "icon-bluecorner (NORTH)"
+	},
+/area/lv624/lazarus/crashed_ship)
+"zM" = (
+/obj/structure/platform,
+/obj/structure/platform{
+	dir = 4
+	},
+/obj/structure/platform_decoration{
+	dir = 6
+	},
+/turf/open/floor/prison{
+	dir = 6;
+	icon_state = "whitegreen"
+	},
+/area/fiorina/tumor/ice_lab)
+"Ab" = (
+/obj/structure/bed,
+/obj/item/bedsheet/yellow,
+/obj/item/handcuffs{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/handcuffs,
+/turf/open/floor/almayer{
+	dir = 6;
+	icon_state = "green";
+	tag = "icon-green (SOUTHEAST)"
+	},
+/area/lv624/lazarus/crashed_ship)
+"Ac" = (
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1"
+	},
+/obj/structure/machinery/m56d_hmg{
+	rounds = 700
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/lv624/lazarus/crashed_ship)
+"Ag" = (
+/obj/structure/bed,
+/obj/item/bedsheet/green,
+/obj/structure/machinery/light/small{
+	dir = 1;
+	pixel_y = 20
+	},
+/obj/item/toy/farwadoll,
+/turf/open/floor/almayer{
+	dir = 9;
+	icon_state = "green";
+	tag = "icon-green (NORTHWEST)"
+	},
+/area/lv624/lazarus/crashed_ship)
+"Aj" = (
+/obj/structure/platform{
+	dir = 1
+	},
+/obj/structure/machinery/light/double/blue{
+	dir = 1;
+	pixel_y = 21
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "whitegreenfull";
+	tag = "icon-whitegreenfull (SOUTHWEST)"
+	},
+/area/fiorina/tumor/ice_lab)
+"Am" = (
+/obj/structure/platform{
+	dir = 1
+	},
+/obj/structure/platform{
+	dir = 4
+	},
+/obj/structure/platform_decoration{
+	dir = 9
+	},
+/turf/open/floor/prison{
+	dir = 5;
+	icon_state = "whitegreen"
+	},
+/area/fiorina/tumor/ice_lab)
+"Au" = (
+/obj/structure/cargo_container{
+	icon_state = "green 0,0"
+	},
+/turf/open/floor{
+	dir = 8;
+	icon_state = "damaged3"
+	},
+/area/lv624/lazarus/crashed_ship)
+"Av" = (
+/obj/item/newspaper,
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "whitegreen"
+	},
+/area/fiorina/tumor/ice_lab)
+"Aw" = (
+/obj/item/stack/rods,
+/obj/effect/landmark/corpsespawner/ua_riot,
+/obj/item/weapon/gun/smg/mp5,
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/fiorina/tumor/ice_lab)
+"AI" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 4;
+	layer = 3.25
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "whitegreenfull";
+	tag = "icon-whitegreenfull (SOUTHWEST)"
+	},
+/area/fiorina/tumor/ice_lab)
+"AV" = (
+/turf/closed/shuttle/ert{
+	icon_state = "stan_rightengine"
+	},
+/area/lv624/lazarus/crashed_ship)
+"Bc" = (
+/obj/structure/largecrate/supply/ammo/m56d,
+/turf/open/floor/plating,
+/area/lv624/lazarus/crashed_ship)
+"Bf" = (
+/obj/structure/girder/reinforced,
+/obj/structure/blocker/invisible_wall,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "damaged3"
+	},
+/area/fiorina/oob)
+"Bs" = (
+/obj/structure/blocker/invisible_wall,
+/turf/open/space/basic,
+/area/fiorina/oob)
+"Bw" = (
+/obj/item/weapon/gun/rifle/type71,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "damaged3"
+	},
+/area/lv624/lazarus/crashed_ship)
+"By" = (
+/obj/structure/lattice,
+/obj/structure/lattice,
+/turf/open/space,
+/area/fiorina/oob)
+"BG" = (
+/obj/structure/machinery/door/airlock/almayer/generic,
+/turf/open/floor/plating,
+/area/lv624/lazarus/crashed_ship)
+"BM" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/storage/surgical_tray{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/structure/machinery/cm_vending/sorted/medical/wall_med{
+	pixel_y = 25
+	},
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "emerald";
+	tag = "icon-emerald (NORTH)"
+	},
+/area/lv624/lazarus/crashed_ship)
+"BV" = (
+/obj/structure/barricade/wooden,
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "whitegreen"
+	},
+/area/fiorina/tumor/ice_lab)
+"BY" = (
+/obj/item/stool,
+/turf/open/floor/almayer,
+/area/lv624/lazarus/crashed_ship)
+"Cb" = (
+/obj/effect/landmark/corpsespawner/clf,
+/obj/item/weapon/melee/twohanded/lungemine,
+/turf/open/floor/plating{
+	icon_state = "warnplate"
+	},
+/area/lv624/lazarus/crashed_ship)
+"Cd" = (
+/obj/structure/surface/table/almayer,
+/obj/item/tool/wirecutters,
+/obj/item/tool/wrench{
+	pixel_y = 7
+	},
+/obj/item/tool/screwdriver{
+	pixel_x = -2;
+	pixel_y = 3
+	},
+/obj/structure/blocker/invisible_wall,
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/fiorina/oob)
+"Ce" = (
+/obj/structure/bed,
+/obj/item/bedsheet/blue,
+/obj/item/weapon/gun/pistol/heavy,
+/obj/item/ammo_magazine/pistol/heavy,
+/obj/item/ammo_magazine/pistol/heavy,
+/obj/item/ammo_magazine/pistol/heavy,
+/obj/item/ammo_magazine/pistol/heavy,
+/obj/item/clothing/accessory/storage/webbing,
+/turf/open/floor/almayer{
+	dir = 5;
+	icon_state = "green";
+	tag = "icon-green (NORTHEAST)"
+	},
+/area/lv624/lazarus/crashed_ship)
+"Cj" = (
+/obj/structure/machinery/door/poddoor/almayer{
+	id = "clf_umbilical_1";
+	name = "\improper Umbillical Airlock"
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/lv624/lazarus/crashed_ship)
+"Ck" = (
+/turf/closed/shuttle/ert{
+	icon_state = "stan22"
+	},
+/area/lv624/lazarus/crashed_ship)
+"Cq" = (
+/obj/structure/barricade/plasteel/wired{
+	dir = 8;
+	icon_state = "plasteel_closed_1"
+	},
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/lv624/lazarus/crashed_ship)
+"Cu" = (
+/turf/closed/wall/prison,
+/area/fiorina/tumor/ice_lab)
+"Cw" = (
+/turf/closed/wall/r_wall/prison_unmeltable,
+/area/fiorina/tumor/ice_lab)
+"Cy" = (
+/obj/structure/closet/emcloset,
+/obj/item/storage/pill_bottle/kelotane/skillless,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "whitegreenfull";
+	tag = "icon-whitegreenfull (SOUTHWEST)"
+	},
+/area/fiorina/tumor/ice_lab)
+"CF" = (
+/turf/open/floor/almayer{
+	dir = 8;
+	icon_state = "emeraldcorner";
+	tag = "icon-emeraldcorner (EAST)"
+	},
+/area/lv624/lazarus/crashed_ship)
+"CG" = (
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "whitegreen"
+	},
+/area/fiorina/tumor/ice_lab)
+"CH" = (
+/obj/structure/machinery/light/small{
+	dir = 1;
+	pixel_y = 20
+	},
+/turf/open/floor/almayer{
+	dir = 4;
+	icon_state = "bluecorner";
+	tag = "icon-bluecorner (EAST)"
+	},
+/area/lv624/lazarus/crashed_ship)
+"CO" = (
+/obj/structure/machinery/light/small{
+	dir = 1;
+	pixel_y = 20
+	},
+/turf/open/floor/almayer{
+	dir = 4;
+	icon_state = "greencorner";
+	tag = "icon-greencorner (EAST)"
+	},
+/area/lv624/lazarus/crashed_ship)
+"CY" = (
+/obj/structure/bed/chair,
+/turf/open/floor/wood,
+/area/lv624/lazarus/crashed_ship)
+"CZ" = (
+/obj/item/stack/rods,
+/obj/item/ammo_magazine/smg/fp9000,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "damaged3"
+	},
+/area/lv624/lazarus/crashed_ship)
+"Df" = (
+/obj/structure/machinery/power/apc{
+	dir = 1;
+	name = "Crashed Ship APC";
+	pixel_y = 30;
+	start_charge = 1
+	},
+/obj/structure/machinery/autolathe,
+/turf/open/floor/almayer{
+	dir = 9;
+	icon_state = "orange";
+	tag = "icon-orange (NORTHWEST)"
+	},
+/area/lv624/lazarus/crashed_ship)
+"Di" = (
+/obj/item/stack/cable_coil/blue,
+/obj/item/stack/rods,
+/turf/open/floor/prison{
+	icon_state = "whitegreencorner"
+	},
+/area/fiorina/tumor/ice_lab)
+"Dp" = (
+/obj/structure/bed,
+/obj/item/bedsheet/yellow,
+/obj/item/toy/katana,
+/turf/open/floor/almayer{
+	dir = 8;
+	icon_state = "green";
+	tag = "icon-green (WEST)"
+	},
+/area/lv624/lazarus/crashed_ship)
+"Dw" = (
+/obj/structure/machinery/door_control/brbutton{
+	id = "clf_umbilical_1";
+	pixel_x = 1;
+	pixel_y = 28;
+	range = 20
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/crashed_ship)
+"DU" = (
+/obj/structure/platform_decoration{
+	dir = 8
+	},
+/obj/item/tool/warning_cone,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "whitegreenfull";
+	tag = "icon-whitegreenfull (SOUTHWEST)"
+	},
+/area/fiorina/tumor/ice_lab)
+"El" = (
+/obj/structure/machinery/vending/snack,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "whitegreenfull";
+	tag = "icon-whitegreenfull (SOUTHWEST)"
+	},
+/area/fiorina/tumor/ice_lab)
+"Ez" = (
+/obj/structure/barricade/metal/wired{
+	dir = 8
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/lv624/lazarus/crashed_ship)
+"EI" = (
+/turf/open/floor/plating{
+	dir = 6;
+	icon_state = "warnplate"
+	},
+/area/lv624/lazarus/crashed_ship)
+"EU" = (
+/obj/structure/window_frame/prison,
+/obj/item/shard{
+	icon_state = "large";
+	name = "ice shard"
+	},
+/turf/open/floor/plating/prison,
+/area/fiorina/tumor/ice_lab)
+"EW" = (
+/obj/structure/ice/thin/indestructible,
+/obj/structure/prop/invuln{
+	desc = "It is slimy.";
+	dir = 4;
+	icon = 'icons/mob/hostiles/sentinel.dmi';
+	icon_state = "Normal Sentinel Knocked Down";
+	layer = 2.5;
+	name = "frozen creature";
+	pixel_x = -22;
+	pixel_y = 8
+	},
+/obj/structure/prop/invuln{
+	desc = "He knows something that you don't.";
+	dir = 4;
+	icon = 'icons/mob/hostiles/larva.dmi';
+	icon_state = "Larva Sleeping";
+	layer = 2.5;
+	name = "frozen creature";
+	pixel_x = 8;
+	pixel_y = -18
+	},
+/obj/structure/blocker/invisible_wall,
+/turf/open/ice/noweed,
+/area/fiorina/tumor/ice_lab)
+"EY" = (
+/obj/structure/surface/table/woodentable,
+/obj/item/toy/dice/d20,
+/turf/open/floor/plating/prison,
+/area/fiorina/tumor/ice_lab)
+"Fa" = (
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/turf/open/floor/almayer{
+	icon_state = "green";
+	tag = "icon-green"
+	},
+/area/lv624/lazarus/crashed_ship)
+"Fj" = (
+/obj/effect/decal/cleanable/blood/oil,
+/obj/structure/blocker/invisible_wall,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "damaged3"
+	},
+/area/fiorina/oob)
+"Fk" = (
+/turf/open/floor{
+	dir = 8;
+	icon_state = "damaged3"
+	},
+/area/fiorina/tumor/ice_lab)
+"Fm" = (
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/fiorina/tumor/ice_lab)
+"Fv" = (
+/obj/structure/barricade/wooden{
+	desc = "This barricade is heavily reinforced. Nothing short of blasting it open seems like it'll do the trick, that or melting the breams supporting it...";
+	dir = 8;
+	health = 25000
+	},
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "sterile_white";
+	tag = "icon-sterile_white (SOUTHWEST)"
+	},
+/area/fiorina/tumor/ice_lab)
+"FB" = (
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/turf/open/floor/plating/plating_catwalk,
+/area/lv624/lazarus/crashed_ship)
+"FE" = (
+/obj/structure/barricade/plasteel/wired{
+	icon_state = "plasteel_3"
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/lv624/lazarus/crashed_ship)
+"Gf" = (
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/turf/open/floor/plating,
+/area/lv624/lazarus/crashed_ship)
+"Gj" = (
+/obj/effect/spawner/random/attachment,
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "bluecorner";
+	tag = "icon-bluecorner (NORTH)"
+	},
+/area/lv624/lazarus/crashed_ship)
+"Gm" = (
+/obj/effect/vehicle_spawner/van/decrepit,
+/turf/open/floor/plating{
+	dir = 1;
+	icon_state = "warnplate"
+	},
+/area/lv624/lazarus/crashed_ship)
+"Go" = (
+/obj/structure/platform{
+	dir = 1
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "whitegreenfull";
+	tag = "icon-whitegreenfull (SOUTHWEST)"
+	},
+/area/fiorina/tumor/ice_lab)
+"Gr" = (
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "whitegreen"
+	},
+/area/fiorina/tumor/ice_lab)
+"Gv" = (
+/obj/effect/decal/cleanable/blood/oil/streak,
+/turf/open/floor/almayer,
+/area/lv624/lazarus/crashed_ship)
+"GJ" = (
+/obj/effect/landmark/corpsespawner/ua_riot,
+/obj/item/weapon/gun/smg/mp5,
+/obj/item/ammo_magazine/smg/mp5,
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/prison{
+	dir = 9;
+	icon_state = "whitegreen"
+	},
+/area/fiorina/tumor/ice_lab)
+"GK" = (
+/obj/structure/machinery/light/double/blue,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/fiorina/tumor/ice_lab)
+"GQ" = (
+/obj/item/ammo_magazine/rifle/type71/ap,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/lv624/lazarus/crashed_ship)
+"GU" = (
+/obj/structure/ice/thin/indestructible{
+	dir = 4;
+	icon_state = "End"
+	},
+/obj/structure/ice/thin/indestructible{
+	dir = 4;
+	icon_state = "End"
+	},
+/obj/structure/blocker/invisible_wall,
+/turf/open/ice/noweed,
+/area/fiorina/tumor/ice_lab)
+"GV" = (
+/obj/structure/machinery/optable,
+/obj/item/tank/anesthetic,
+/obj/item/clothing/mask/breath/medical,
+/obj/effect/landmark/corpsespawner/clf,
+/turf/open/floor/almayer{
+	dir = 10;
+	icon_state = "emerald";
+	tag = "icon-emerald (NORTHWEST)"
+	},
+/area/lv624/lazarus/crashed_ship)
+"Hb" = (
+/obj/structure/barricade/metal/wired{
+	dir = 4;
+	icon_state = "metal_1"
+	},
+/obj/effect/landmark/corpsespawner/clf,
+/turf/open/floor/plating,
+/area/lv624/lazarus/crashed_ship)
+"He" = (
+/obj/structure/platform{
+	dir = 1
+	},
+/obj/structure/platform{
+	dir = 8
+	},
+/obj/structure/platform_decoration{
+	dir = 5
+	},
+/turf/open/floor/prison{
+	dir = 9;
+	icon_state = "whitegreen"
+	},
+/area/fiorina/tumor/ice_lab)
+"Hu" = (
+/obj/structure/platform{
+	dir = 8
+	},
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "whitegreen"
+	},
+/area/fiorina/tumor/ice_lab)
+"HB" = (
+/obj/structure/machinery/door/airlock/multi_tile/secure{
+	dir = 1;
+	name = "\improper Medical Bay"
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/crashed_ship)
+"HD" = (
+/obj/structure/barricade/wooden{
+	desc = "This barricade is heavily reinforced. Nothing short of blasting it open seems like it'll do the trick, that or melting the breams supporting it...";
+	dir = 8;
+	health = 25000
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "whitegreenfull";
+	tag = "icon-whitegreenfull (SOUTHWEST)"
+	},
+/area/fiorina/tumor/ice_lab)
+"HF" = (
+/obj/item/stack/rods,
+/obj/effect/decal/cleanable/blood,
+/obj/structure/blocker/invisible_wall,
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/fiorina/oob)
+"HJ" = (
+/obj/structure/girder/displaced,
+/turf/open/floor/plating/prison,
+/area/fiorina/tumor/ice_lab)
+"HX" = (
+/obj/item/stack/tile/plasteel{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/structure/barricade/wooden,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "whitegreenfull";
+	tag = "icon-whitegreenfull (SOUTHWEST)"
+	},
+/area/fiorina/tumor/ice_lab)
+"Ih" = (
+/obj/item/stack/sheet/metal,
+/turf/open/floor/plating/prison,
+/area/fiorina/tumor/ice_lab)
+"In" = (
+/turf/closed/shuttle/ert{
+	icon_state = "leftengine_2";
+	opacity = 0
+	},
+/area/lv624/lazarus/crashed_ship)
+"Ip" = (
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "sterile_white";
+	tag = "icon-sterile_white (SOUTHWEST)"
+	},
+/area/fiorina/tumor/ice_lab)
+"Iu" = (
+/turf/open/floor/plating/plating_catwalk,
+/area/lv624/lazarus/crashed_ship)
+"IA" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/ammo_magazine/rifle/mar40/lmg{
+	pixel_y = 8;
+	pixel_x = -11
+	},
+/obj/item/ammo_magazine/rifle/mar40/lmg{
+	pixel_y = 3;
+	pixel_x = -2
+	},
+/obj/item/ammo_magazine/rifle/mar40/lmg{
+	pixel_y = 6;
+	pixel_x = 10
+	},
+/obj/item/ammo_magazine/rifle/mar40/lmg{
+	pixel_y = -8;
+	pixel_x = -11
+	},
+/obj/item/ammo_magazine/rifle/mar40/lmg{
+	pixel_y = -8;
+	pixel_x = 5
+	},
+/obj/item/ammo_magazine/rifle/mar40/lmg{
+	pixel_y = -2;
+	pixel_x = 8
+	},
+/obj/item/ammo_magazine/rifle/mar40/lmg{
+	pixel_y = -2
+	},
+/obj/item/ammo_magazine/rifle/mar40/lmg{
+	pixel_y = 8;
+	pixel_x = 8
+	},
+/obj/item/ammo_magazine/rifle/mar40/lmg{
+	pixel_y = 8;
+	pixel_x = -8
+	},
+/obj/item/ammo_magazine/rifle/mar40/lmg{
+	pixel_y = 8
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/lv624/lazarus/crashed_ship)
+"IB" = (
+/obj/structure/ice/thin/indestructible,
+/obj/structure/prop/invuln{
+	desc = "Its eyes follow you around through the ice.";
+	dir = 4;
+	icon = 'icons/mob/hostiles/queen.dmi';
+	icon_state = "Normal Queen Knocked Down";
+	layer = 2.5;
+	name = "frozen creature";
+	pixel_x = -15;
+	pixel_y = -16
+	},
+/obj/structure/blocker/invisible_wall,
+/turf/open/ice/noweed,
+/area/fiorina/tumor/ice_lab)
+"II" = (
+/obj/structure/bed,
+/obj/item/bedsheet/purple,
+/obj/item/weapon/gun/pistol/heavy,
+/obj/item/ammo_magazine/pistol/heavy,
+/obj/item/ammo_magazine/pistol/heavy,
+/obj/item/ammo_magazine/pistol/heavy,
+/obj/item/ammo_magazine/pistol/heavy,
+/turf/open/floor/almayer{
+	dir = 5;
+	icon_state = "green";
+	tag = "icon-green (NORTHEAST)"
+	},
+/area/lv624/lazarus/crashed_ship)
+"Jd" = (
+/turf/open/floor/almayer{
+	dir = 8;
+	icon_state = "greencorner";
+	tag = "icon-greencorner (WEST)"
+	},
+/area/lv624/lazarus/crashed_ship)
+"Jf" = (
+/turf/open/floor/almayer{
+	icon_state = "bluecorner";
+	tag = "icon-bluecorner"
+	},
+/area/lv624/lazarus/crashed_ship)
+"Jt" = (
+/obj/item/device/flashlight/lamp/tripod,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "whitegreenfull";
+	tag = "icon-whitegreenfull (SOUTHWEST)"
+	},
+/area/fiorina/tumor/ice_lab)
+"Jw" = (
+/obj/structure/barricade/metal/wired{
+	dir = 8
+	},
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1"
+	},
+/obj/structure/machinery/defenses/sentry/premade/dumb{
+	dir = 4;
+	faction_group = list("CLF")
+	},
+/turf/open/floor/plating{
+	dir = 10;
+	icon_state = "warnplate"
+	},
+/area/lv624/lazarus/crashed_ship)
+"Jx" = (
+/obj/structure/ice/thin/indestructible{
+	dir = 4;
+	icon_state = "Corner"
+	},
+/obj/structure/blocker/invisible_wall,
+/obj/structure/platform{
+	dir = 1;
+	layer = 2.1
+	},
+/turf/open/ice/noweed,
+/area/fiorina/tumor/ice_lab)
+"JD" = (
+/obj/structure/blocker/invisible_wall,
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/fiorina/oob)
+"JE" = (
+/obj/structure/barricade/metal/wired{
+	dir = 8;
+	icon_state = "metal_1"
+	},
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/lv624/lazarus/crashed_ship)
+"Kf" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/ammo_box/magazine/M16,
+/turf/open/floor/almayer{
+	dir = 4;
+	icon_state = "bluecorner";
+	tag = "icon-bluecorner (EAST)"
+	},
+/area/lv624/lazarus/crashed_ship)
+"Ky" = (
+/obj/structure/blocker/invisible_wall,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/fiorina/oob)
+"KH" = (
+/turf/closed/shuttle/ert{
+	icon_state = "stan25"
+	},
+/area/lv624/lazarus/crashed_ship)
+"KU" = (
+/obj/structure/surface/table/woodentable,
+/obj/item/device/flashlight/lamp{
+	pixel_y = 3
+	},
+/turf/open/floor/almayer{
+	dir = 8;
+	icon_state = "green";
+	tag = "icon-green (WEST)"
+	},
+/area/lv624/lazarus/crashed_ship)
+"Lj" = (
+/obj/structure/stairs/perspective{
+	icon_state = "p_stair_sn_full_cap"
+	},
+/turf/open/floor/prison{
+	icon_state = "floor_plate";
+	tag = "icon-floor_plate"
+	},
+/area/fiorina/tumor/ice_lab)
+"Lt" = (
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1"
+	},
+/obj/structure/barricade/metal/wired{
+	dir = 4;
+	icon_state = "metal_1"
+	},
+/obj/structure/machinery/defenses/sentry/premade/dumb{
+	dir = 4;
+	faction_group = list("CLF")
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/lv624/lazarus/crashed_ship)
+"LA" = (
+/obj/structure/lattice,
+/obj/structure/blocker/invisible_wall,
+/turf/open/floor/plating/plating_catwalk,
+/area/fiorina/oob)
+"LD" = (
+/obj/structure/barricade/wooden,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "whitegreen"
+	},
+/area/fiorina/tumor/ice_lab)
+"LF" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/weapon/gun/smg/nailgun,
+/obj/item/weapon/gun/smg/nailgun,
+/obj/item/ammo_box/magazine/smg/nailgun,
+/turf/open/floor/almayer{
+	icon_state = "bluecorner";
+	tag = "icon-bluecorner"
+	},
+/area/lv624/lazarus/crashed_ship)
+"LU" = (
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/fiorina/tumor/ice_lab)
+"Mn" = (
+/obj/item/stack/rods,
+/obj/effect/landmark/corpsespawner/ua_riot,
+/obj/item/weapon/gun/smg/mp5,
+/obj/item/ammo_magazine/smg/mp5,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/fiorina/tumor/ice_lab)
+"Mo" = (
+/obj/structure/flora/pottedplant{
+	icon_state = "pottedplant_21";
+	tag = "icon-pottedplant_10"
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "whitegreenfull";
+	tag = "icon-whitegreenfull (SOUTHWEST)"
+	},
+/area/fiorina/tumor/ice_lab)
+"Mr" = (
+/obj/structure/machinery/power/smes/buildable/charged,
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "orange";
+	tag = "icon-orange (NORTH)"
+	},
+/area/lv624/lazarus/crashed_ship)
+"MC" = (
+/obj/structure/closet,
+/obj/item/clothing/suit/poncho/red,
+/obj/item/clothing/suit/poncho/green,
+/obj/item/clothing/suit/suspenders,
+/turf/open/floor/plating/prison,
+/area/fiorina/tumor/ice_lab)
+"MF" = (
+/obj/structure/surface/table/almayer,
+/obj/item/tank/oxygen/red,
+/obj/item/storage/bag/trash,
+/obj/item/tool/screwdriver,
+/obj/structure/blocker/invisible_wall,
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/fiorina/oob)
+"MR" = (
+/mob/living/simple_animal/hostile/carp{
+	desc = "He is late for work.";
+	name = "Egbert"
+	},
+/turf/open/space,
+/area/fiorina/oob)
+"MS" = (
+/obj/structure/machinery/light/double/blue{
+	dir = 1;
+	pixel_y = 21
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "whitegreenfull";
+	tag = "icon-whitegreenfull (SOUTHWEST)"
+	},
+/area/fiorina/tumor/ice_lab)
+"MT" = (
+/obj/structure/surface/rack,
+/obj/item/device/radio{
+	pixel_x = -3
+	},
+/obj/item/device/radio,
+/obj/item/device/radio{
+	pixel_x = 3
+	},
+/turf/open/floor/almayer{
+	icon_state = "green";
+	tag = "icon-green"
+	},
+/area/lv624/lazarus/crashed_ship)
+"Nc" = (
+/obj/structure/bed/chair{
+	dir = 4;
+	pixel_x = -5;
+	tag = "icon-chair (EAST)"
+	},
+/turf/open/floor/plating/prison,
+/area/fiorina/tumor/ice_lab)
+"Ne" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/effect/spawner/random/toolbox,
+/turf/open/floor/almayer{
+	icon_state = "orangecorner";
+	tag = "icon-orangecorner"
+	},
+/area/lv624/lazarus/crashed_ship)
+"Nk" = (
+/obj/item/explosive/grenade/HE/frag,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/fiorina/tumor/ice_lab)
+"Nl" = (
+/turf/closed/shuttle/ert{
+	icon_state = "stan_inner_s_w"
+	},
+/area/lv624/lazarus/crashed_ship)
+"Nq" = (
+/turf/open/floor/almayer{
+	dir = 8;
+	icon_state = "bluecorner";
+	tag = "icon-bluecorner (NORTH)"
+	},
+/area/lv624/lazarus/crashed_ship)
+"Nt" = (
+/obj/item/stool,
+/obj/effect/landmark/corpsespawner/colonist,
+/obj/structure/blocker/invisible_wall,
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/fiorina/oob)
+"Nx" = (
+/obj/structure/largecrate/random/secure,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "whitegreenfull";
+	tag = "icon-whitegreenfull (SOUTHWEST)"
+	},
+/area/fiorina/tumor/ice_lab)
+"NJ" = (
+/turf/closed/shuttle/ert{
+	icon_state = "stan8"
+	},
+/area/lv624/lazarus/crashed_ship)
+"NN" = (
+/obj/item/stack/rods,
+/obj/effect/spawner/random/attachment,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "damaged3"
+	},
+/area/lv624/lazarus/crashed_ship)
+"NR" = (
+/obj/structure/blocker/invisible_wall,
+/turf/open/space,
+/area/fiorina/oob)
+"NS" = (
+/obj/effect/landmark/corpsespawner/clf,
+/obj/item/weapon/melee/twohanded/lungemine,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "whitegreen"
+	},
+/area/fiorina/tumor/ice_lab)
+"NV" = (
+/obj/structure/surface/rack,
+/obj/item/storage/firstaid/adv{
+	pixel_x = 3;
+	pixel_y = 5
+	},
+/obj/item/storage/firstaid/adv,
+/obj/structure/machinery/light/small{
+	dir = 1;
+	pixel_y = 20
+	},
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "emerald";
+	tag = "icon-emerald (NORTH)"
+	},
+/area/lv624/lazarus/crashed_ship)
+"NX" = (
+/obj/structure/machinery/space_heater,
+/obj/structure/platform{
+	dir = 4
+	},
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "whitegreen"
+	},
+/area/fiorina/tumor/ice_lab)
+"Ob" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/weapon/gun/rifle/mar40/lmg,
+/obj/item/weapon/gun/rifle/mar40/lmg{
+	pixel_y = 11
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/lv624/lazarus/crashed_ship)
+"Oi" = (
+/turf/open/floor/almayer{
+	icon_state = "emeraldcorner";
+	tag = "icon-emeraldcorner"
+	},
+/area/lv624/lazarus/crashed_ship)
+"Ol" = (
+/obj/item/stack/cable_coil/orange,
+/obj/structure/barricade/wooden,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/fiorina/tumor/ice_lab)
+"Op" = (
+/obj/item/tool/pickaxe,
+/obj/structure/platform{
+	dir = 4
+	},
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "whitegreen"
+	},
+/area/fiorina/tumor/ice_lab)
+"Ow" = (
+/obj/structure/machinery/deployable/barrier{
+	anchored = 1
+	},
+/turf/open/floor/wood,
+/area/lv624/lazarus/crashed_ship)
+"Oy" = (
+/obj/structure/machinery/light/small{
+	dir = 1;
+	pixel_x = -3;
+	pixel_y = 20
+	},
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "orangecorner";
+	tag = "icon-orangecorner (NORTH)"
+	},
+/area/lv624/lazarus/crashed_ship)
+"OD" = (
+/obj/structure/machinery/cm_vending/sorted/medical/wall_med{
+	pixel_y = 25
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/crashed_ship)
+"OM" = (
+/obj/item/ammo_box/magazine/type71,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "damaged3"
+	},
+/area/lv624/lazarus/crashed_ship)
+"OQ" = (
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "whitegreen"
+	},
+/area/fiorina/tumor/ice_lab)
+"OS" = (
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/effect/spawner/random/attachment,
+/turf/open/floor/plating{
+	icon_state = "warnplate"
+	},
+/area/lv624/lazarus/crashed_ship)
+"Pe" = (
+/obj/effect/landmark/corpsespawner/ua_riot,
+/turf/open/floor/plating/prison,
+/area/lv624/lazarus/crashed_ship)
+"Pg" = (
+/obj/item/stack/rods,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "damaged3"
+	},
+/area/lv624/lazarus/crashed_ship)
+"Pn" = (
+/obj/item/stack/tile/plasteel{
+	pixel_x = 3;
+	pixel_y = 4
+	},
+/turf/open/floor/plating/prison,
+/area/fiorina/tumor/ice_lab)
+"Py" = (
+/obj/item/shard{
+	icon_state = "medium";
+	name = "ice shard"
+	},
+/obj/structure/platform{
+	dir = 8
+	},
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "whitegreen"
+	},
+/area/fiorina/tumor/ice_lab)
+"PC" = (
+/turf/closed/shuttle/ert{
+	icon_state = "stan5"
+	},
+/area/lv624/lazarus/crashed_ship)
+"PH" = (
+/obj/item/ammo_casing/shell{
+	icon_state = "cartridge_2_1"
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/lv624/lazarus/crashed_ship)
+"PO" = (
+/obj/item/device/flashlight/lamp/tripod,
+/turf/open/floor/plating/prison,
+/area/fiorina/tumor/ice_lab)
+"PV" = (
+/obj/item/tool/wet_sign,
+/turf/open/floor/plating/plating_catwalk,
+/area/lv624/lazarus/crashed_ship)
+"Qb" = (
+/obj/structure/surface/table/woodentable,
+/obj/item/ammo_magazine/shotgun/incendiary{
+	pixel_x = 3;
+	pixel_y = 6
+	},
+/obj/item/ammo_magazine/shotgun/incendiary,
+/turf/open/floor/wood,
+/area/lv624/lazarus/crashed_ship)
+"Qf" = (
+/obj/structure/ice/thin/indestructible{
+	dir = 4;
+	icon_state = "Straight"
+	},
+/obj/structure/ice/thin/indestructible{
+	dir = 4;
+	icon_state = "Straight"
+	},
+/obj/structure/blocker/invisible_wall,
+/turf/open/ice/noweed,
+/area/fiorina/tumor/ice_lab)
+"Qw" = (
+/obj/item/ammo_casing/shell{
+	icon_state = "shell_4_1"
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/crashed_ship)
+"Qx" = (
+/obj/structure/machinery/door/airlock/multi_tile/secure{
+	name = "\improper Bunk Beds"
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/crashed_ship)
+"QE" = (
+/obj/structure/surface/table/almayer,
+/obj/item/storage/toolbox/electrical{
+	pixel_y = 9
+	},
+/obj/item/storage/toolbox/mechanical,
+/obj/structure/blocker/invisible_wall,
+/turf/open/floor/plating,
+/area/fiorina/oob)
+"QH" = (
+/obj/structure/machinery/light/small{
+	dir = 1;
+	pixel_y = 20
+	},
+/obj/structure/machinery/bodyscanner,
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "emerald";
+	tag = "icon-emerald (NORTH)"
+	},
+/area/lv624/lazarus/crashed_ship)
+"QI" = (
+/obj/structure/machinery/light/small{
+	dir = 1;
+	pixel_y = 20
+	},
+/turf/open/floor/wood,
+/area/lv624/lazarus/crashed_ship)
+"QM" = (
+/obj/structure/surface/table/woodentable,
+/obj/item/newspaper{
+	name = "character sheet"
+	},
+/obj/item/device/cassette_tape/heavymetal{
+	pixel_x = 5;
+	pixel_y = 7
+	},
+/turf/open/floor/plating/prison,
+/area/fiorina/tumor/ice_lab)
+"QT" = (
+/obj/structure/surface/table/woodentable,
+/obj/item/toy/dice,
+/obj/item/toy/crayon/blue{
+	pixel_x = -7;
+	pixel_y = 7
+	},
+/turf/open/floor/plating/prison,
+/area/fiorina/tumor/ice_lab)
+"QU" = (
+/obj/item/shard{
+	icon_state = "large";
+	name = "ice shard"
+	},
+/turf/open/floor/prison{
+	icon_state = "whitegreen"
+	},
+/area/fiorina/tumor/ice_lab)
+"QY" = (
+/obj/structure/largecrate/supply/supplies/flares,
+/turf/open/floor/plating{
+	dir = 10;
+	icon_state = "warnplate"
+	},
+/area/lv624/lazarus/crashed_ship)
+"QZ" = (
+/turf/closed/shuttle/ert{
+	icon_state = "stan_inner_w_1"
+	},
+/area/lv624/lazarus/crashed_ship)
+"Ra" = (
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "whitegreencorner"
+	},
+/area/fiorina/tumor/ice_lab)
+"Rk" = (
+/obj/structure/platform_decoration{
+	dir = 1
+	},
+/obj/item/tool/pickaxe,
+/turf/open/floor/prison{
+	icon_state = "whitegreen"
+	},
+/area/fiorina/tumor/ice_lab)
+"Rp" = (
+/obj/effect/decal/cleanable/blood/oil,
+/obj/structure/blocker/invisible_wall,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/fiorina/oob)
+"RK" = (
+/obj/structure/ice/thin/indestructible{
+	dir = 8;
+	icon_state = "End"
+	},
+/obj/structure/ice/thin/indestructible{
+	dir = 8;
+	icon_state = "End"
+	},
+/obj/structure/blocker/invisible_wall,
+/turf/open/ice/noweed,
+/area/fiorina/tumor/ice_lab)
+"RS" = (
+/obj/item/ammo_box/magazine/misc/flares/empty,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "whitegreenfull";
+	tag = "icon-whitegreenfull (SOUTHWEST)"
+	},
+/area/fiorina/tumor/ice_lab)
+"RV" = (
+/obj/structure/machinery/door/poddoor/almayer{
+	id = "clf_umbilical_1";
+	name = "\improper Umbillical Airlock"
+	},
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/lv624/lazarus/crashed_ship)
+"Sd" = (
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "greencorner";
+	tag = "icon-greencorner (NORTH)"
+	},
+/area/lv624/lazarus/crashed_ship)
+"Sm" = (
+/obj/effect/spawner/random/tool,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "whitegreenfull";
+	tag = "icon-whitegreenfull (SOUTHWEST)"
+	},
+/area/fiorina/tumor/ice_lab)
+"Sn" = (
+/obj/structure/blocker/invisible_wall,
+/turf/open/floor/almayer,
+/area/fiorina/oob)
+"So" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/clothing/glasses/welding,
+/obj/item/stack/sheet/metal/large_stack,
+/obj/item/stack/sheet/metal/large_stack,
+/obj/item/stack/sheet/plasteel/large_stack,
+/turf/open/floor/almayer{
+	dir = 6;
+	icon_state = "orange";
+	tag = "icon-orange (SOUTHEAST)"
+	},
+/area/lv624/lazarus/crashed_ship)
+"Sw" = (
+/obj/structure/largecrate/random/barrel/white,
+/obj/structure/blocker/invisible_wall,
+/turf/open/floor/plating,
+/area/fiorina/oob)
+"SC" = (
+/obj/structure/platform,
+/obj/structure/platform{
+	dir = 8
+	},
+/obj/structure/platform_decoration{
+	dir = 10
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "whitegreen"
+	},
+/area/fiorina/tumor/ice_lab)
+"SG" = (
+/obj/structure/blocker/invisible_wall,
+/turf/closed/shuttle/ert{
+	icon_state = "stan22"
+	},
+/area/fiorina/oob)
+"SL" = (
+/obj/structure/machinery/space_heater,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "sterile_white";
+	tag = "icon-sterile_white (SOUTHWEST)"
+	},
+/area/fiorina/tumor/ice_lab)
+"SO" = (
+/obj/structure/bed/chair,
+/turf/open/floor/plating/prison,
+/area/fiorina/tumor/ice_lab)
+"Ti" = (
+/obj/structure/machinery/floodlight,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "damaged3"
+	},
+/area/lv624/lazarus/crashed_ship)
+"TB" = (
+/obj/structure/stairs/perspective{
+	dir = 8;
+	icon_state = "p_stair_sn_full_cap"
+	},
+/obj/structure/platform{
+	dir = 4
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "whitegreenfull";
+	tag = "icon-whitegreenfull (SOUTHWEST)"
+	},
+/area/fiorina/tumor/ice_lab)
+"TO" = (
+/obj/structure/barricade/metal/wired{
+	dir = 8;
+	icon_state = "metal_1"
+	},
+/obj/structure/machinery/defenses/sentry/premade/dumb{
+	dir = 4;
+	faction_group = list("CLF")
+	},
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/lv624/lazarus/crashed_ship)
+"TT" = (
+/obj/item/stack/rods,
+/obj/structure/blocker/invisible_wall,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "damaged3"
+	},
+/area/fiorina/oob)
+"TU" = (
+/obj/structure/machinery/computer/station_alert{
+	icon_state = "atmosb";
+	stat = 1
+	},
+/obj/structure/surface/table/reinforced/prison,
+/obj/structure/blocker/invisible_wall,
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/fiorina/oob)
+"Ui" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/fiorina/oob)
+"Up" = (
+/obj/item/stack/rods,
+/obj/structure/blocker/invisible_wall,
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/fiorina/oob)
+"Uy" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/lv624/lazarus/crashed_ship)
+"UI" = (
+/turf/closed/shuttle/ert{
+	icon_state = "stan23"
+	},
+/area/lv624/lazarus/crashed_ship)
+"UM" = (
+/obj/item/stack/rods,
+/obj/item/ammo_magazine/smg/fp9000,
+/turf/open/floor/plating,
+/area/lv624/lazarus/crashed_ship)
+"UU" = (
+/obj/structure/machinery/vending/snack/packaged,
+/turf/open/floor/plating/prison,
+/area/fiorina/tumor/ice_lab)
+"UX" = (
+/obj/structure/barricade/wooden,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "whitegreenfull";
+	tag = "icon-whitegreenfull (SOUTHWEST)"
+	},
+/area/fiorina/tumor/ice_lab)
+"VD" = (
+/obj/structure/machinery/door/airlock/multi_tile/secure{
+	name = "\improper Dining Room"
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/crashed_ship)
+"VH" = (
+/obj/item/stack/tile/plasteel{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/fiorina/tumor/ice_lab)
+"VM" = (
+/obj/structure/barricade/metal/wired{
+	dir = 8
+	},
+/obj/effect/spawner/random/attachment,
+/turf/open/floor/plating{
+	dir = 8;
+	icon_state = "warnplate"
+	},
+/area/lv624/lazarus/crashed_ship)
+"VN" = (
+/obj/structure/machinery/floodlight,
+/obj/structure/lattice,
+/obj/structure/blocker/invisible_wall,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "damaged3"
+	},
+/area/fiorina/oob)
+"VZ" = (
+/obj/structure/machinery/light/small{
+	dir = 1;
+	pixel_y = 20
+	},
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/lv624/lazarus/crashed_ship)
+"Wd" = (
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/fiorina/tumor/ice_lab)
+"Wg" = (
+/obj/structure/machinery/light/small{
+	dir = 1;
+	pixel_y = 20
+	},
+/turf/closed/shuttle/ert{
+	icon_state = "stan_inner_s_w"
+	},
+/area/lv624/lazarus/crashed_ship)
+"Wh" = (
+/obj/structure/surface/rack,
+/obj/item/storage/backpack/general_belt{
+	pixel_y = 7
+	},
+/obj/item/storage/backpack/general_belt,
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "emerald";
+	tag = "icon-emerald (NORTH)"
+	},
+/area/lv624/lazarus/crashed_ship)
+"Wi" = (
+/obj/item/ammo_casing/shell{
+	icon_state = "shell_3_1"
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/crashed_ship)
+"Wr" = (
+/obj/structure/cargo_container{
+	icon_state = "green 2,0"
+	},
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/lv624/lazarus/crashed_ship)
+"Ws" = (
+/turf/open/floor/plating/prison,
+/area/lv624/lazarus/crashed_ship)
+"Wz" = (
+/turf/open/floor/plating,
+/area/lv624/lazarus/crashed_ship)
+"WE" = (
+/obj/item/stack/tile/plasteel{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/fiorina/tumor/ice_lab)
+"WH" = (
+/obj/structure/surface/table/woodentable,
+/obj/effect/spawner/random/toolbox,
+/obj/item/toy/deck/uno{
+	pixel_x = -3;
+	pixel_y = 4
+	},
+/turf/open/floor/wood,
+/area/lv624/lazarus/crashed_ship)
+"WI" = (
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/lv624/lazarus/crashed_ship)
+"Xn" = (
+/obj/item/ammo_casing/shell{
+	icon_state = "shell_6_1"
+	},
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1"
+	},
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/lv624/lazarus/crashed_ship)
+"Xo" = (
+/obj/structure/surface/rack,
+/obj/item/roller,
+/obj/item/roller{
+	pixel_x = 3;
+	pixel_y = 2
+	},
+/turf/open/floor/almayer{
+	icon_state = "emerald";
+	tag = "icon-emerald"
+	},
+/area/lv624/lazarus/crashed_ship)
+"Xz" = (
+/obj/item/stack/rods,
+/turf/open/floor/plating{
+	dir = 9;
+	icon_state = "warnplate"
+	},
+/area/lv624/lazarus/crashed_ship)
+"XE" = (
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1"
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/lv624/lazarus/crashed_ship)
+"XG" = (
+/turf/open/floor/almayer,
+/area/lv624/lazarus/crashed_ship)
+"XI" = (
+/obj/effect/landmark/corpsespawner/ua_riot,
+/obj/item/weapon/gun/smg/mp5,
+/obj/item/ammo_magazine/smg/mp5,
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "whitegreen"
+	},
+/area/fiorina/tumor/ice_lab)
+"XK" = (
+/obj/item/stack/sheet/wood,
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "whitegreen"
+	},
+/area/fiorina/tumor/ice_lab)
+"XS" = (
+/obj/item/poster,
+/turf/open/floor/plating/prison,
+/area/fiorina/tumor/ice_lab)
+"Yg" = (
+/obj/effect/landmark/corpsespawner/security,
+/obj/item/weapon/gun/pistol/b92fs,
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "whitegreen"
+	},
+/area/fiorina/tumor/ice_lab)
+"Yj" = (
+/obj/structure/blocker/invisible_wall,
+/turf/closed/shuttle/ert{
+	icon_state = "stan5"
+	},
+/area/fiorina/oob)
+"Yr" = (
+/obj/effect/landmark/corpsespawner/colonist,
+/obj/structure/blocker/invisible_wall,
+/turf/open/floor/plating,
+/area/fiorina/oob)
+"Yt" = (
+/obj/structure/lattice,
+/obj/structure/blocker/invisible_wall,
+/turf/open/space/basic,
+/area/fiorina/oob)
+"YB" = (
+/obj/item/paper/crumpled/bloody,
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/fiorina/tumor/ice_lab)
+"YD" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/structure/machinery/faxmachine{
+	department = "CLF - Cell 42"
+	},
+/obj/item/paper/prison_station/pirate_note{
+	info = "<p>We're hit!</p><p>MAYDAY! MAYDAY! We have been hit by the -... .</p><p>We're on a planet somewhere, seems there is a colony to our south. Might head on over there and see if there is any USCM presence. Our ship is fucking busted beyond normal means of repair, still waiting for a damage assessment tho.</p><p>Coby and Ryan died today from their wounds... \"Fucking USCM.\" I'll have my revenge someday...</p><p>And the colonies will be freed one day from the oppressive regime of Wey-Yu and USCM henchmen."
+	},
+/turf/open/floor/almayer{
+	icon_state = "emerald";
+	tag = "icon-emerald"
+	},
+/area/lv624/lazarus/crashed_ship)
+"YM" = (
+/obj/effect/spawner/random/attachment,
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/lv624/lazarus/crashed_ship)
+"Za" = (
+/obj/item/stack/rods,
+/obj/structure/barricade/wooden,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "whitegreenfull";
+	tag = "icon-whitegreenfull (SOUTHWEST)"
+	},
+/area/fiorina/tumor/ice_lab)
+"Zc" = (
+/obj/item/stack/rods,
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/fiorina/tumor/ice_lab)
+"Zg" = (
+/obj/structure/ice/thin/indestructible{
+	dir = 8;
+	icon_state = "Corner"
+	},
+/obj/structure/blocker/invisible_wall,
+/turf/open/ice/noweed,
+/area/fiorina/tumor/ice_lab)
+"Zj" = (
+/turf/closed/wall/mineral/bone_resin,
+/area/fiorina/tumor/ice_lab)
+"Zm" = (
+/obj/item/tool/warning_cone{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "sterile_white";
+	tag = "icon-sterile_white (SOUTHWEST)"
+	},
+/area/fiorina/tumor/ice_lab)
+"Zo" = (
+/obj/structure/machinery/door/poddoor/almayer{
+	id = "clf_umbilical_1";
+	name = "\improper Umbillical Airlock"
+	},
+/turf/open/floor{
+	dir = 8;
+	icon_state = "damaged3"
+	},
+/area/lv624/lazarus/crashed_ship)
+"Zw" = (
+/turf/open/floor/prison{
+	icon_state = "whitegreen"
+	},
+/area/fiorina/tumor/ice_lab)
+"Zz" = (
+/turf/open/floor/plating{
+	dir = 1;
+	icon_state = "warnplate"
+	},
+/area/lv624/lazarus/crashed_ship)
+"ZE" = (
+/obj/structure/surface/rack,
+/obj/item/weapon/gun/shotgun/pump/cmb{
+	pixel_y = -3
+	},
+/obj/item/weapon/gun/shotgun/pump/cmb{
+	pixel_y = 3
+	},
+/obj/item/weapon/gun/shotgun/pump/cmb{
+	pixel_y = 9
+	},
+/turf/open/floor/almayer{
+	icon_state = "orangecorner";
+	tag = "icon-orangecorner"
+	},
+/area/lv624/lazarus/crashed_ship)
+"ZM" = (
+/obj/item/stack/rods,
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/lv624/lazarus/crashed_ship)
+
+(1,1,1) = {"
+lo
+lo
+lo
+lo
+lo
+lo
+lo
+lo
+lo
+lo
+NR
+NR
+Zj
+Zj
+Zj
+Zj
+Zj
+Zj
+Cw
+Zj
+Zj
+Zj
+Zj
+Zj
+Zj
+Zj
+Zj
+Zj
+Zj
+Zj
+pi
+pi
+Cu
+Cu
+Cu
+Cu
+Cu
+Cu
+Cu
+Cu
+Cu
+aL
+RS
+"}
+(2,1,1) = {"
+lo
+lo
+lo
+lo
+lo
+lo
+lo
+pD
+lo
+lo
+NR
+Zj
+Zj
+Zj
+Zj
+Zj
+Zj
+Zj
+Cw
+Zj
+Zj
+Zj
+Cw
+Zj
+Zj
+Cw
+Cw
+Cw
+Cw
+Cw
+pi
+pi
+Cu
+El
+bM
+Cu
+Cu
+ne
+Cy
+Cu
+Cu
+Cu
+Cu
+"}
+(3,1,1) = {"
+lo
+lo
+lo
+lo
+lo
+pD
+lo
+pD
+By
+lo
+NR
+Zj
+Zj
+Zj
+Zj
+Zj
+Zj
+Zj
+Cw
+Zj
+Zj
+Zj
+Cw
+Cw
+Cw
+Cw
+Zj
+Zj
+Zj
+Zj
+pi
+pi
+Mo
+aB
+Fm
+Fm
+YB
+Nk
+lR
+Nx
+nW
+Cu
+uI
+"}
+(4,1,1) = {"
+cZ
+cZ
+cZ
+cZ
+cZ
+cZ
+Ui
+Ui
+Ui
+Ui
+Yt
+tN
+wS
+wS
+mS
+wS
+nM
+cN
+yF
+In
+tT
+Zj
+Zj
+Zj
+Zj
+Zj
+Zj
+Zj
+Zj
+Zj
+pi
+pi
+aB
+GJ
+LU
+ul
+LU
+OQ
+OQ
+OQ
+BV
+tl
+vT
+"}
+(5,1,1) = {"
+Ui
+cZ
+Ui
+cZ
+cZ
+cZ
+cZ
+Ui
+Yt
+Bs
+Bs
+wS
+vr
+lg
+QZ
+jn
+GV
+NJ
+cN
+yF
+In
+tT
+Zj
+Zj
+Zj
+Zj
+Zj
+Zj
+Zj
+Zj
+pi
+pi
+gq
+np
+LU
+LU
+yk
+zr
+Yg
+zr
+XK
+tl
+jq
+"}
+(6,1,1) = {"
+cZ
+cZ
+cZ
+Ui
+cZ
+Ui
+cZ
+cZ
+Bs
+tN
+nM
+Ck
+Oy
+vf
+QZ
+BM
+xA
+sp
+NJ
+xf
+ly
+ly
+Zj
+Zj
+Zj
+Zj
+Zj
+Zj
+Zj
+Zj
+pi
+pi
+aB
+np
+LU
+aB
+aB
+aB
+lR
+aB
+nW
+Cu
+uI
+"}
+(7,1,1) = {"
+cZ
+cZ
+cZ
+cZ
+cZ
+cZ
+cZ
+cZ
+Bs
+cS
+Df
+xl
+FB
+Iu
+QZ
+QH
+XG
+CF
+vN
+tD
+nM
+nM
+ij
+wS
+nM
+xf
+Zj
+Zj
+Zj
+Zj
+pi
+pi
+aB
+Av
+Zw
+aB
+Cu
+Cu
+nh
+EU
+EU
+Cu
+Cu
+"}
+(8,1,1) = {"
+cZ
+cZ
+cZ
+cZ
+cZ
+cZ
+gk
+io
+Rp
+QZ
+Mr
+Iu
+Gv
+Ne
+QZ
+th
+Iu
+Iu
+YD
+QZ
+yQ
+QY
+Xz
+vL
+tC
+NJ
+cN
+yF
+In
+tT
+Zj
+Zc
+aB
+dM
+Zw
+nW
+Cu
+He
+iM
+tL
+pe
+SC
+SL
+"}
+(9,1,1) = {"
+Ui
+Ui
+Ui
+cZ
+gk
+JD
+SG
+lT
+HF
+QZ
+bn
+Iu
+ZE
+So
+QZ
+wc
+CF
+Iu
+Xo
+QZ
+Zz
+tE
+Gm
+nC
+tE
+Wz
+NJ
+cN
+yF
+In
+tT
+Fm
+WE
+np
+WE
+UX
+EU
+Jx
+mD
+jA
+RK
+Rk
+jP
+"}
+(10,1,1) = {"
+cZ
+cZ
+cZ
+cZ
+Up
+MF
+io
+Yr
+zv
+tY
+ko
+Wz
+Wz
+ko
+Nl
+NV
+Oi
+FB
+xA
+QZ
+vs
+tE
+Zz
+nC
+OS
+uZ
+mK
+NJ
+cN
+yF
+In
+tT
+aB
+LU
+Mn
+Za
+nh
+uM
+IB
+qM
+Qf
+QU
+sj
+"}
+(11,1,1) = {"
+cZ
+cZ
+gk
+zv
+xe
+Cd
+io
+zv
+JD
+QZ
+Iu
+Iu
+Jd
+vv
+QZ
+Wh
+sL
+Iu
+XG
+nU
+tP
+EI
+tP
+kY
+ic
+sm
+PH
+Wz
+NJ
+nM
+nM
+xf
+aB
+LU
+kj
+Ol
+EU
+wM
+mI
+Zg
+GU
+uK
+TB
+"}
+(12,1,1) = {"
+cZ
+gk
+SG
+JD
+TT
+lT
+lN
+Fj
+io
+QZ
+CO
+Iu
+Iu
+MT
+QZ
+gW
+kM
+Iu
+Iu
+Wz
+qW
+nC
+di
+Hb
+im
+aQ
+oy
+sP
+hi
+WI
+Wz
+vo
+tx
+np
+tv
+GK
+Cu
+Am
+Op
+tt
+NX
+xP
+uF
+"}
+(13,1,1) = {"
+gk
+JD
+zv
+lT
+Up
+zv
+JD
+Ky
+VN
+QZ
+bX
+XG
+Iu
+Jd
+tY
+ko
+Wz
+HB
+ko
+Nl
+tZ
+fp
+Lt
+lU
+tk
+Ti
+WI
+nC
+rU
+nC
+tq
+vo
+ow
+tM
+Fm
+tM
+Cu
+EU
+EU
+nh
+Cu
+uI
+yx
+"}
+(14,1,1) = {"
+de
+qm
+Nt
+zv
+Up
+QE
+zv
+JD
+Ky
+wk
+it
+kz
+Iu
+Iu
+ho
+Iu
+Wz
+bj
+Wz
+QZ
+Dw
+nC
+CZ
+nC
+gK
+Wz
+tq
+Pe
+tq
+Pg
+Cb
+Zo
+LU
+LU
+Fk
+Fm
+gt
+aB
+gq
+aB
+Cu
+hD
+aB
+"}
+(15,1,1) = {"
+oE
+zv
+JD
+aa
+xg
+vY
+gy
+ex
+cu
+Nl
+kC
+wv
+wv
+eo
+Wz
+Gj
+Wz
+nC
+Wz
+wS
+Bc
+Wi
+mK
+WI
+Xn
+Wz
+rU
+Ws
+nC
+tq
+nC
+iL
+VH
+Fm
+Fm
+OQ
+vi
+OQ
+Gr
+uy
+cv
+tl
+OQ
+"}
+(16,1,1) = {"
+Bf
+io
+TT
+JD
+ze
+io
+JD
+TT
+kV
+tY
+ko
+ko
+ko
+ko
+Nl
+OD
+Wz
+Wz
+Wz
+QZ
+pW
+er
+nC
+UM
+vd
+WI
+WI
+tq
+WI
+Ws
+tE
+RV
+Fk
+Fm
+Di
+il
+zr
+CG
+zr
+XK
+zr
+tl
+zr
+"}
+(17,1,1) = {"
+hh
+TU
+sn
+io
+JD
+kK
+Ky
+Ky
+Sn
+QZ
+CY
+yz
+rm
+yh
+QZ
+af
+Ob
+fD
+Jf
+wS
+Wz
+NN
+Qw
+WI
+FE
+Ws
+aH
+dC
+Ws
+Ws
+tE
+iL
+av
+Fm
+VH
+Jt
+gt
+aB
+aB
+aB
+Cu
+hD
+aB
+"}
+(18,1,1) = {"
+iK
+vG
+io
+bG
+wP
+io
+io
+LA
+oj
+wk
+nP
+Qb
+WH
+yh
+QZ
+CH
+IA
+Kf
+Nq
+QZ
+tq
+Wz
+Wz
+tq
+Ac
+nC
+Ws
+Ws
+tq
+Pe
+Ws
+Cj
+Fm
+na
+VH
+aB
+Cu
+EU
+EU
+nh
+Cu
+uI
+yx
+"}
+(19,1,1) = {"
+cZ
+iK
+zG
+Sw
+JD
+JD
+LA
+LA
+Sn
+QZ
+QI
+pr
+pr
+pr
+QZ
+Wz
+xW
+hP
+Wz
+QZ
+Ez
+Cq
+Jw
+Wz
+XE
+hi
+Wz
+tq
+nC
+nC
+tq
+vo
+VH
+Zc
+Fm
+pt
+Cu
+He
+pe
+Hu
+Py
+SC
+uF
+"}
+(20,1,1) = {"
+cZ
+cZ
+JD
+ty
+JD
+io
+JD
+LA
+rz
+pJ
+qH
+Iu
+Iu
+Iu
+VD
+Wz
+nC
+Gf
+Nq
+nU
+nC
+ji
+Bw
+iS
+VM
+JE
+TO
+vx
+hi
+Wz
+WI
+vo
+Fm
+VH
+Zw
+UX
+EU
+Jx
+mD
+jA
+RK
+uQ
+jP
+"}
+(21,1,1) = {"
+Ui
+cZ
+JD
+zv
+zv
+lT
+zG
+rz
+Sn
+kd
+Ow
+pr
+pr
+pr
+Wz
+Wz
+Wz
+nC
+vh
+Wz
+Wz
+Gf
+yL
+eO
+us
+ca
+ug
+Wz
+dw
+PC
+PC
+sI
+Aw
+VH
+wa
+cW
+nh
+uM
+EW
+qM
+Qf
+am
+sj
+"}
+(22,1,1) = {"
+cZ
+cZ
+cZ
+cZ
+JD
+io
+zG
+rz
+Sn
+tY
+ko
+ko
+ko
+ko
+Nl
+Wg
+af
+zI
+Nl
+QZ
+VZ
+YM
+GQ
+tq
+Au
+nC
+Wz
+dw
+AV
+aD
+jJ
+dy
+Fm
+np
+Fm
+HX
+EU
+wM
+mI
+Zg
+GU
+fZ
+TB
+"}
+(23,1,1) = {"
+cZ
+cZ
+Ui
+cZ
+iK
+Yj
+vG
+rz
+Sn
+QZ
+Ag
+Dp
+KU
+Sd
+Qx
+XG
+bj
+af
+Jf
+QZ
+Uy
+Wz
+ZM
+nC
+dx
+Wz
+dw
+AV
+aD
+jJ
+dy
+Fm
+aB
+Fm
+Zw
+aB
+Cu
+Am
+qo
+tt
+NX
+zM
+SL
+"}
+(24,1,1) = {"
+Ui
+cZ
+Ui
+cZ
+Ui
+cZ
+iK
+io
+eu
+Nl
+nu
+kz
+BY
+Iu
+Wz
+PV
+Iu
+Iu
+vD
+QZ
+kl
+WI
+OM
+WI
+Wr
+dw
+AV
+aD
+jJ
+dy
+pi
+Fm
+aB
+np
+Zw
+aB
+Cu
+Cu
+EU
+EU
+nh
+Cu
+Cu
+"}
+(25,1,1) = {"
+cZ
+cZ
+Ui
+Ui
+Ui
+Ui
+cZ
+cZ
+Bs
+cS
+II
+ck
+eo
+nZ
+QZ
+BG
+UI
+XG
+LF
+cQ
+PC
+PC
+PC
+PC
+PC
+sI
+Zj
+Zj
+Zj
+Zj
+pi
+pi
+aB
+XI
+Zw
+aB
+aB
+aB
+aB
+aB
+nW
+Cu
+uI
+"}
+(26,1,1) = {"
+cZ
+cZ
+Ui
+cZ
+cZ
+cZ
+Ui
+cZ
+Bs
+KH
+PC
+UI
+bo
+Fa
+QZ
+uv
+QZ
+hs
+dw
+sI
+ly
+ly
+Zj
+Zj
+Zj
+Zj
+Zj
+Zj
+Zj
+Cu
+pi
+pi
+aB
+cz
+Ra
+NS
+OQ
+OQ
+OQ
+OQ
+LD
+tl
+OQ
+"}
+(27,1,1) = {"
+cZ
+Ui
+cZ
+cZ
+Ui
+Ui
+cZ
+cZ
+Bs
+Bs
+Bs
+cS
+Ce
+Ab
+QZ
+ar
+QZ
+dw
+AV
+aD
+jJ
+dy
+Zj
+Zj
+Zj
+Zj
+Zj
+Zj
+Zj
+Cu
+pi
+pi
+aB
+ob
+CG
+zr
+Fm
+Fm
+mE
+zr
+qY
+tl
+zr
+"}
+(28,1,1) = {"
+cZ
+cZ
+cZ
+cZ
+Ui
+cZ
+cZ
+cZ
+cZ
+cZ
+Bs
+KH
+PC
+PC
+rQ
+PC
+rQ
+AV
+aD
+jJ
+dy
+Zj
+Zj
+Zj
+Zj
+Zj
+Zj
+Zj
+Zj
+Cu
+pi
+pi
+aB
+aB
+aB
+aB
+VH
+Fk
+Fm
+pR
+nW
+Cu
+uI
+"}
+(29,1,1) = {"
+lo
+lo
+lo
+lo
+Zj
+Zj
+Zj
+Zj
+Zj
+Zj
+Zj
+Zj
+Zj
+lo
+lo
+Zj
+Zj
+Zj
+Zj
+Zj
+Cw
+Zj
+Zj
+Zj
+Zj
+Zj
+Zj
+Cu
+Cu
+Cu
+Cu
+Cu
+Cu
+Cu
+uI
+sS
+Fm
+VH
+Fm
+aP
+sS
+uI
+Cu
+"}
+(30,1,1) = {"
+lo
+pD
+lo
+lo
+Zj
+Zj
+Zj
+Zj
+Zj
+lo
+lo
+Zj
+lo
+lo
+lo
+lo
+Zj
+Zj
+Zj
+Zj
+Cw
+Zj
+Zj
+Zj
+Zj
+Zj
+Zj
+Cu
+vX
+Cu
+Cu
+Cu
+Cu
+Cu
+bB
+HD
+Fv
+xi
+Zc
+sU
+HD
+aB
+uh
+"}
+(31,1,1) = {"
+lo
+lo
+lo
+Zj
+Zj
+Zj
+Zj
+lo
+lo
+lo
+lo
+NR
+lo
+lo
+lo
+lo
+Zj
+Zj
+Zj
+Cw
+Cw
+Zj
+UU
+uB
+uh
+Nc
+Nc
+Cu
+vX
+Cu
+Cu
+Cu
+Cu
+Cu
+Cu
+mN
+Ip
+xU
+xi
+xi
+aB
+aB
+uh
+"}
+(32,1,1) = {"
+lo
+lo
+lo
+Zj
+Zj
+Zj
+lo
+lo
+lo
+lo
+lo
+NR
+lo
+lo
+lo
+lo
+Zj
+Zj
+Zj
+sC
+Cw
+Zj
+uh
+uh
+SO
+QT
+qp
+Cu
+hI
+Cu
+Cu
+rr
+rr
+Lj
+Lj
+aB
+bA
+tS
+Ip
+aB
+aB
+aB
+PO
+"}
+(33,1,1) = {"
+lo
+lo
+lo
+Zj
+Zj
+lo
+lo
+lo
+MR
+lo
+lo
+Zj
+lo
+lo
+lo
+lo
+lo
+Zj
+Zj
+Wd
+yw
+yI
+uh
+uh
+SO
+EY
+QM
+Cu
+Cu
+Cu
+tS
+rr
+rr
+ie
+ie
+DU
+Zm
+nb
+qh
+tc
+Cu
+Cu
+tS
+"}
+(34,1,1) = {"
+lo
+lo
+lo
+Zj
+Zj
+lo
+lo
+lo
+lo
+lo
+Zj
+Zj
+lo
+lo
+lo
+lo
+lo
+Zj
+Zj
+Cw
+Cw
+Ih
+Zj
+Zj
+uh
+uh
+uh
+Cu
+Cu
+Cu
+uh
+tS
+tS
+Cu
+Cu
+Aj
+Ip
+tS
+Ip
+aB
+Zj
+Zj
+Zj
+"}
+(35,1,1) = {"
+lo
+lo
+lo
+Zj
+Zj
+Zj
+lo
+lo
+lo
+Zj
+Zj
+lo
+lo
+lo
+lo
+lo
+lo
+Zj
+Zj
+Zj
+Cw
+HJ
+Cw
+Zj
+Zj
+Zj
+uh
+tl
+uh
+aB
+uh
+aB
+Pn
+AI
+cI
+Go
+Ip
+tS
+Ip
+Sm
+Zj
+Cu
+Cu
+"}
+(36,1,1) = {"
+lo
+lo
+lo
+lo
+Zj
+Zj
+Zj
+Zj
+Zj
+Zj
+lo
+lo
+lo
+lo
+lo
+lo
+lo
+lo
+Zj
+Zj
+Zj
+Ih
+uh
+XS
+MC
+Cu
+Cu
+Cu
+Cu
+MS
+uh
+aB
+mu
+fr
+at
+Go
+Ip
+tS
+Ip
+uh
+Cu
+Cu
+Zj
+"}
+(37,1,1) = {"
+lo
+lo
+lo
+lo
+lo
+Zj
+Zj
+Zj
+Zj
+lo
+lo
+lo
+lo
+lo
+lo
+lo
+lo
+lo
+Zj
+Zj
+Zj
+uh
+uh
+XS
+bk
+Cu
+Cu
+Cu
+Cu
+bM
+uh
+aB
+aB
+fr
+at
+Go
+oA
+tS
+Ip
+uh
+Cw
+Cw
+Cw
+"}

--- a/maps/map_files/FOP_v3_Sciannex/sprinkles/25.sciannexclfship.dmm
+++ b/maps/map_files/FOP_v3_Sciannex/sprinkles/25.sciannexclfship.dmm
@@ -191,9 +191,13 @@
 /obj/item/ammo_magazine/rifle/type71/ap,
 /obj/effect/landmark/corpsespawner/clf,
 <<<<<<< master
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 =======
 >>>>>>> reimported backup
+=======
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+>>>>>>> added spawn pointss for clf survivors
 /turf/open/floor{
 	dir = 8;
 	icon_state = "damaged3"
@@ -277,9 +281,13 @@
 /obj/item/stack/rods,
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 <<<<<<< master
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 =======
 >>>>>>> reimported backup
+=======
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+>>>>>>> added spawn pointss for clf survivors
 /turf/open/floor/plating,
 /area/lv624/lazarus/crashed_ship)
 "dw" = (
@@ -721,9 +729,13 @@
 "kz" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 <<<<<<< master
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 =======
 >>>>>>> reimported backup
+=======
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+>>>>>>> added spawn pointss for clf survivors
 /turf/open/floor/almayer,
 /area/lv624/lazarus/crashed_ship)
 "kC" = (
@@ -786,14 +798,20 @@
 /turf/closed/wall/mineral/bone_resin,
 /area/lv624/lazarus/crashed_ship)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> added spawn pointss for clf survivors
 "lI" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
 /area/lv624/lazarus/crashed_ship)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> added spawn pointss for clf survivors
 "lN" = (
 /obj/item/stack/rods,
 /obj/effect/landmark/corpsespawner/colonist,
@@ -823,9 +841,13 @@
 	icon_state = "casing_2_1"
 	},
 <<<<<<< master
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 =======
 >>>>>>> reimported backup
+=======
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+>>>>>>> added spawn pointss for clf survivors
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -942,9 +964,13 @@
 /obj/structure/bed/chair,
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 <<<<<<< master
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 =======
 >>>>>>> reimported backup
+=======
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+>>>>>>> added spawn pointss for clf survivors
 /turf/open/floor/wood,
 /area/lv624/lazarus/crashed_ship)
 "nU" = (
@@ -1184,13 +1210,19 @@
 	},
 /area/fiorina/tumor/ice_lab)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> added spawn pointss for clf survivors
 "rl" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/plating/plating_catwalk,
 /area/lv624/lazarus/crashed_ship)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> added spawn pointss for clf survivors
 "rm" = (
 /obj/structure/surface/table/woodentable,
 /obj/item/storage/firstaid/adv,
@@ -1445,9 +1477,13 @@
 	icon_state = "casing_9_1"
 	},
 <<<<<<< master
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 =======
 >>>>>>> reimported backup
+=======
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+>>>>>>> added spawn pointss for clf survivors
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
@@ -1543,9 +1579,13 @@
 /obj/item/stack/rods,
 /obj/effect/spawner/random/attachment,
 <<<<<<< master
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 =======
 >>>>>>> reimported backup
+=======
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+>>>>>>> added spawn pointss for clf survivors
 /turf/open/floor/plating,
 /area/lv624/lazarus/crashed_ship)
 "vd" = (
@@ -1706,6 +1746,9 @@
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> added spawn pointss for clf survivors
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/plating,
 /area/lv624/lazarus/crashed_ship)
@@ -2418,9 +2461,13 @@
 "Fa" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 <<<<<<< master
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 =======
 >>>>>>> reimported backup
+=======
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+>>>>>>> added spawn pointss for clf survivors
 /turf/open/floor/almayer{
 	icon_state = "green";
 	tag = "icon-green"
@@ -2776,13 +2823,19 @@
 /turf/open/ice/noweed,
 /area/fiorina/tumor/ice_lab)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> added spawn pointss for clf survivors
 "JA" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/plating,
 /area/lv624/lazarus/crashed_ship)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> added spawn pointss for clf survivors
 "JD" = (
 /obj/structure/blocker/invisible_wall,
 /turf/open/floor{
@@ -3649,12 +3702,18 @@
 	},
 /area/lv624/lazarus/crashed_ship)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> added spawn pointss for clf survivors
 "WK" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/wood,
 /area/lv624/lazarus/crashed_ship)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> added spawn pointss for clf survivors
 "Xn" = (
 /obj/item/ammo_casing/shell{
 	icon_state = "shell_6_1"
@@ -4147,10 +4206,14 @@ cS
 Df
 xl
 <<<<<<< master
+<<<<<<< master
 rl
 =======
 FB
 >>>>>>> reimported backup
+=======
+rl
+>>>>>>> added spawn pointss for clf survivors
 Iu
 QZ
 QH
@@ -4195,10 +4258,14 @@ Rp
 QZ
 Mr
 <<<<<<< master
+<<<<<<< master
 FB
 =======
 Iu
 >>>>>>> reimported backup
+=======
+FB
+>>>>>>> added spawn pointss for clf survivors
 Gv
 Ne
 QZ
@@ -4307,20 +4374,28 @@ Nl
 NV
 Oi
 <<<<<<< master
+<<<<<<< master
 rl
 =======
 FB
 >>>>>>> reimported backup
+=======
+rl
+>>>>>>> added spawn pointss for clf survivors
 xA
 QZ
 vs
 tE
 Zz
 <<<<<<< master
+<<<<<<< master
 lI
 =======
 nC
 >>>>>>> reimported backup
+=======
+lI
+>>>>>>> added spawn pointss for clf survivors
 OS
 uZ
 mK
@@ -4405,10 +4480,14 @@ QZ
 gW
 kM
 <<<<<<< master
+<<<<<<< master
 FB
 =======
 Iu
 >>>>>>> reimported backup
+=======
+FB
+>>>>>>> added spawn pointss for clf survivors
 Iu
 Wz
 qW
@@ -4449,10 +4528,14 @@ QZ
 bX
 XG
 <<<<<<< master
+<<<<<<< master
 FB
 =======
 Iu
 >>>>>>> reimported backup
+=======
+FB
+>>>>>>> added spawn pointss for clf survivors
 Jd
 tY
 ko
@@ -4519,6 +4602,7 @@ Wz
 QZ
 Dw
 <<<<<<< master
+<<<<<<< master
 lI
 CZ
 nC
@@ -4526,6 +4610,9 @@ gK
 Tt
 =======
 nC
+=======
+lI
+>>>>>>> added spawn pointss for clf survivors
 CZ
 nC
 gK
@@ -4571,12 +4658,17 @@ eo
 Wz
 Gj
 <<<<<<< master
+<<<<<<< master
 Gf
 lI
 =======
 Wz
 nC
 >>>>>>> reimported backup
+=======
+Gf
+lI
+>>>>>>> added spawn pointss for clf survivors
 Wz
 wS
 Bc
@@ -4845,12 +4937,17 @@ Wz
 VD
 Wz
 <<<<<<< master
+<<<<<<< master
 lI
 JA
 =======
 nC
 Gf
 >>>>>>> reimported backup
+=======
+lI
+JA
+>>>>>>> added spawn pointss for clf survivors
 Nq
 nU
 >>>>>>> reimported backup
@@ -4892,10 +4989,14 @@ kd
 Ow
 pr
 <<<<<<< master
+<<<<<<< master
 WK
 =======
 pr
 >>>>>>> reimported backup
+=======
+WK
+>>>>>>> added spawn pointss for clf survivors
 pr
 Wz
 Wz
@@ -4909,10 +5010,14 @@ JA
 =======
 Wz
 <<<<<<< master
+<<<<<<< master
 JA
 =======
 Gf
 >>>>>>> reimported backup
+=======
+JA
+>>>>>>> added spawn pointss for clf survivors
 yL
 eO
 us

--- a/maps/map_files/FOP_v3_Sciannex/sprinkles/25.sciannexclfship.dmm
+++ b/maps/map_files/FOP_v3_Sciannex/sprinkles/25.sciannexclfship.dmm
@@ -302,20 +302,14 @@
 /area/lv624/lazarus/crashed_ship)
 "dC" = (
 /obj/item/stack/rods,
-<<<<<<< master
 /obj/item/explosive/mine/clf/active,
-=======
->>>>>>> reimported backup
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
 /area/lv624/lazarus/crashed_ship)
 "dM" = (
 /obj/item/ammo_casing/bullet,
-<<<<<<< master
 /obj/item/explosive/mine/clf/active,
-=======
->>>>>>> reimported backup
 /turf/open/floor/prison{
 	dir = 1;
 	icon_state = "whitegreen"
@@ -501,7 +495,6 @@
 /obj/structure/machinery/cm_vending/sorted/medical/wall_med,
 /turf/closed/wall/prison,
 /area/fiorina/tumor/ice_lab)
-<<<<<<< master
 "hF" = (
 /obj/item/stack/tile/plasteel{
 	pixel_x = 5;
@@ -512,8 +505,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/fiorina/tumor/ice_lab)
-=======
->>>>>>> reimported backup
 "hI" = (
 /obj/structure/surface/table/reinforced/prison{
 	flipped = 1
@@ -951,10 +942,7 @@
 	},
 /area/lv624/lazarus/crashed_ship)
 "ob" = (
-<<<<<<< master
 /obj/item/explosive/mine/clf/active,
-=======
->>>>>>> reimported backup
 /turf/open/floor/prison{
 	dir = 5;
 	icon_state = "whitegreen"
@@ -1027,15 +1015,12 @@
 	icon_state = "platingdmg1"
 	},
 /area/fiorina/tumor/ice_lab)
-<<<<<<< master
 "pn" = (
 /obj/item/explosive/mine/clf/active,
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
 /area/lv624/lazarus/crashed_ship)
-=======
->>>>>>> reimported backup
 "pr" = (
 /turf/open/floor/wood,
 /area/lv624/lazarus/crashed_ship)
@@ -1600,7 +1585,6 @@
 	},
 /turf/open/floor/plating,
 /area/lv624/lazarus/crashed_ship)
-<<<<<<< master
 "vy" = (
 /obj/item/explosive/mine/clf/active,
 /turf/open/floor/prison{
@@ -1608,8 +1592,6 @@
 	icon_state = "whitegreen"
 	},
 /area/fiorina/tumor/ice_lab)
-=======
->>>>>>> reimported backup
 "vD" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/tool/weldpack,
@@ -1651,18 +1633,14 @@
 	icon_state = "whitegreen"
 	},
 /area/fiorina/tumor/ice_lab)
-<<<<<<< master
 "vV" = (
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
-/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/plating,
 /area/lv624/lazarus/crashed_ship)
-=======
->>>>>>> reimported backup
 "vX" = (
 /obj/structure/surface/rack,
 /obj/effect/spawner/random/toolbox,
@@ -1920,13 +1898,10 @@
 	icon_state = "whitegreen"
 	},
 /area/fiorina/tumor/ice_lab)
-<<<<<<< master
 "zU" = (
 /obj/item/explosive/mine/clf/active,
 /turf/open/floor/plating/prison,
 /area/lv624/lazarus/crashed_ship)
-=======
->>>>>>> reimported backup
 "Ab" = (
 /obj/structure/bed,
 /obj/item/bedsheet/yellow,
@@ -2268,7 +2243,6 @@
 	tag = "icon-whitegreenfull (SOUTHWEST)"
 	},
 /area/fiorina/tumor/ice_lab)
-<<<<<<< master
 "Ee" = (
 /obj/item/explosive/mine/clf/active,
 /turf/open/floor/prison{
@@ -2277,8 +2251,6 @@
 	tag = "icon-whitegreenfull (SOUTHWEST)"
 	},
 /area/fiorina/tumor/ice_lab)
-=======
->>>>>>> reimported backup
 "El" = (
 /obj/structure/machinery/vending/snack,
 /turf/open/floor/prison{
@@ -3296,15 +3268,12 @@
 /obj/structure/blocker/invisible_wall,
 /turf/open/floor/plating,
 /area/fiorina/oob)
-<<<<<<< master
 "SA" = (
 /obj/item/explosive/mine/clf/active,
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
 /area/fiorina/tumor/ice_lab)
-=======
->>>>>>> reimported backup
 "SC" = (
 /obj/structure/platform,
 /obj/structure/platform{
@@ -3343,13 +3312,10 @@
 	icon_state = "damaged3"
 	},
 /area/lv624/lazarus/crashed_ship)
-<<<<<<< master
 "Tt" = (
 /obj/item/explosive/mine/clf/active,
 /turf/open/floor/plating,
 /area/lv624/lazarus/crashed_ship)
-=======
->>>>>>> reimported backup
 "TB" = (
 /obj/structure/stairs/perspective{
 	dir = 8;
@@ -3869,11 +3835,7 @@ pi
 pi
 Mo
 aB
-<<<<<<< master
 SA
-=======
-Fm
->>>>>>> reimported backup
 Fm
 YB
 Nk
@@ -4013,11 +3975,7 @@ aB
 aB
 aB
 lR
-<<<<<<< master
 Ee
-=======
-aB
->>>>>>> reimported backup
 nW
 Cu
 uI
@@ -4153,11 +4111,7 @@ yF
 In
 tT
 Fm
-<<<<<<< master
 hF
-=======
-WE
->>>>>>> reimported backup
 np
 WE
 UX
@@ -4350,11 +4304,7 @@ Ti
 WI
 nC
 rU
-<<<<<<< master
 pn
-=======
-nC
->>>>>>> reimported backup
 tq
 vo
 ow
@@ -4402,8 +4352,7 @@ nC
 CZ
 nC
 gK
-Wz
->>>>>>> reimported backup
+Tt
 tq
 Pe
 tq
@@ -4502,11 +4451,7 @@ WI
 WI
 tq
 WI
-<<<<<<< master
 zU
-=======
-Ws
->>>>>>> reimported backup
 tE
 RV
 Fk
@@ -4555,11 +4500,7 @@ Ws
 tE
 iL
 av
-<<<<<<< master
 SA
-=======
-Fm
->>>>>>> reimported backup
 VH
 Jt
 gt
@@ -4596,11 +4537,7 @@ Wz
 Wz
 tq
 Ac
-<<<<<<< master
 pn
-=======
-nC
->>>>>>> reimported backup
 Ws
 Ws
 tq
@@ -4649,11 +4586,7 @@ hi
 Wz
 tq
 nC
-<<<<<<< master
 pn
-=======
-nC
->>>>>>> reimported backup
 tq
 vo
 VH
@@ -4838,11 +4771,7 @@ af
 Jf
 QZ
 Uy
-<<<<<<< master
 vV
-=======
-Wz
->>>>>>> reimported backup
 ZM
 nC
 dx
@@ -4993,12 +4922,9 @@ cz
 Ra
 NS
 OQ
-<<<<<<< master
 vy
-=======
 OQ
 >>>>>>> reimported backup
-OQ
 OQ
 LD
 tl
@@ -5133,11 +5059,7 @@ uI
 sS
 Fm
 VH
-<<<<<<< master
 SA
-=======
-Fm
->>>>>>> reimported backup
 aP
 sS
 uI

--- a/maps/map_files/FOP_v3_Sciannex/sprinkles/25.sciannexclfship.dmm
+++ b/maps/map_files/FOP_v3_Sciannex/sprinkles/25.sciannexclfship.dmm
@@ -190,7 +190,10 @@
 /obj/item/stack/rods,
 /obj/item/ammo_magazine/rifle/type71/ap,
 /obj/effect/landmark/corpsespawner/clf,
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor{
 	dir = 8;
 	icon_state = "damaged3"
@@ -273,7 +276,10 @@
 "di" = (
 /obj/item/stack/rods,
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/plating,
 /area/lv624/lazarus/crashed_ship)
 "dw" = (
@@ -296,14 +302,20 @@
 /area/lv624/lazarus/crashed_ship)
 "dC" = (
 /obj/item/stack/rods,
+<<<<<<< master
 /obj/item/explosive/mine/clf/active,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
 /area/lv624/lazarus/crashed_ship)
 "dM" = (
 /obj/item/ammo_casing/bullet,
+<<<<<<< master
 /obj/item/explosive/mine/clf/active,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/prison{
 	dir = 1;
 	icon_state = "whitegreen"
@@ -465,6 +477,15 @@
 /obj/structure/machinery/floodlight,
 /turf/open/floor/plating,
 /area/lv624/lazarus/crashed_ship)
+<<<<<<< master
+=======
+"ho" = (
+/obj/structure/machinery/door/airlock/multi_tile/secure{
+	name = "\improper General Area"
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/crashed_ship)
+>>>>>>> reimported backup
 "hs" = (
 /obj/structure/surface/rack,
 /obj/item/clothing/accessory/storage/webbing,
@@ -483,6 +504,7 @@
 /obj/structure/machinery/cm_vending/sorted/medical/wall_med,
 /turf/closed/wall/prison,
 /area/fiorina/tumor/ice_lab)
+<<<<<<< master
 "hF" = (
 /obj/item/stack/tile/plasteel{
 	pixel_x = 5;
@@ -493,6 +515,8 @@
 	icon_state = "platingdmg3"
 	},
 /area/fiorina/tumor/ice_lab)
+=======
+>>>>>>> reimported backup
 "hI" = (
 /obj/structure/surface/table/reinforced/prison{
 	flipped = 1
@@ -682,7 +706,10 @@
 /area/lv624/lazarus/crashed_ship)
 "kz" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/almayer,
 /area/lv624/lazarus/crashed_ship)
 "kC" = (
@@ -744,12 +771,15 @@
 "ly" = (
 /turf/closed/wall/mineral/bone_resin,
 /area/lv624/lazarus/crashed_ship)
+<<<<<<< master
 "lI" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
 /area/lv624/lazarus/crashed_ship)
+=======
+>>>>>>> reimported backup
 "lN" = (
 /obj/item/stack/rods,
 /obj/effect/landmark/corpsespawner/colonist,
@@ -778,7 +808,10 @@
 /obj/item/ammo_casing/shell{
 	icon_state = "casing_2_1"
 	},
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -894,11 +927,20 @@
 "nP" = (
 /obj/structure/bed/chair,
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/wood,
 /area/lv624/lazarus/crashed_ship)
 "nU" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/almayer/glass,
+=======
+/turf/open/floor/wood,
+/area/lv624/lazarus/crashed_ship)
+"nU" = (
+/obj/structure/machinery/door/airlock/multi_tile/secure{
+	name = "Cargo Airlock"
+	},
+>>>>>>> reimported backup
 /turf/open/floor/plating,
 /area/lv624/lazarus/crashed_ship)
 "nW" = (
@@ -916,7 +958,10 @@
 	},
 /area/lv624/lazarus/crashed_ship)
 "ob" = (
+<<<<<<< master
 /obj/item/explosive/mine/clf/active,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/prison{
 	dir = 5;
 	icon_state = "whitegreen"
@@ -989,12 +1034,15 @@
 	icon_state = "platingdmg1"
 	},
 /area/fiorina/tumor/ice_lab)
+<<<<<<< master
 "pn" = (
 /obj/item/explosive/mine/clf/active,
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
 /area/lv624/lazarus/crashed_ship)
+=======
+>>>>>>> reimported backup
 "pr" = (
 /turf/open/floor/wood,
 /area/lv624/lazarus/crashed_ship)
@@ -1012,8 +1060,15 @@
 /turf/open/space,
 /area/fiorina/oob)
 "pJ" = (
+<<<<<<< master
 /obj/structure/blocker/invisible_wall,
 /obj/structure/machinery/door/airlock/multi_tile/almayer/almayer,
+=======
+/obj/structure/machinery/door/airlock/multi_tile/secure{
+	name = "\improper Dining Room"
+	},
+/obj/structure/blocker/invisible_wall,
+>>>>>>> reimported backup
 /turf/open/floor/plating/plating_catwalk,
 /area/lv624/lazarus/crashed_ship)
 "pR" = (
@@ -1102,11 +1157,14 @@
 	icon_state = "whitegreen"
 	},
 /area/fiorina/tumor/ice_lab)
+<<<<<<< master
 "rl" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/plating/plating_catwalk,
 /area/lv624/lazarus/crashed_ship)
+=======
+>>>>>>> reimported backup
 "rm" = (
 /obj/structure/surface/table/woodentable,
 /obj/item/storage/firstaid/adv,
@@ -1360,7 +1418,10 @@
 /obj/item/ammo_casing/shell{
 	icon_state = "casing_9_1"
 	},
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
@@ -1455,7 +1516,10 @@
 "uZ" = (
 /obj/item/stack/rods,
 /obj/effect/spawner/random/attachment,
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/plating,
 /area/lv624/lazarus/crashed_ship)
 "vd" = (
@@ -1548,6 +1612,7 @@
 	},
 /turf/open/floor/plating,
 /area/lv624/lazarus/crashed_ship)
+<<<<<<< master
 "vy" = (
 /obj/item/explosive/mine/clf/active,
 /turf/open/floor/prison{
@@ -1555,6 +1620,8 @@
 	icon_state = "whitegreen"
 	},
 /area/fiorina/tumor/ice_lab)
+=======
+>>>>>>> reimported backup
 "vD" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/tool/weldpack,
@@ -1596,6 +1663,7 @@
 	icon_state = "whitegreen"
 	},
 /area/fiorina/tumor/ice_lab)
+<<<<<<< master
 "vV" = (
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
@@ -1605,6 +1673,8 @@
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/plating,
 /area/lv624/lazarus/crashed_ship)
+=======
+>>>>>>> reimported backup
 "vX" = (
 /obj/structure/surface/rack,
 /obj/effect/spawner/random/toolbox,
@@ -1839,8 +1909,14 @@
 /turf/open/floor/plating,
 /area/fiorina/oob)
 "zI" = (
+<<<<<<< master
 /obj/structure/machinery/door/airlock/multi_tile/almayer/almayer/glass{
 	dir = 2
+=======
+/obj/structure/machinery/door/airlock/multi_tile/secure{
+	dir = 1;
+	name = "\improper Medical Bay"
+>>>>>>> reimported backup
 	},
 /turf/open/floor/almayer{
 	dir = 1;
@@ -1861,10 +1937,13 @@
 	icon_state = "whitegreen"
 	},
 /area/fiorina/tumor/ice_lab)
+<<<<<<< master
 "zU" = (
 /obj/item/explosive/mine/clf/active,
 /turf/open/floor/plating/prison,
 /area/lv624/lazarus/crashed_ship)
+=======
+>>>>>>> reimported backup
 "Ab" = (
 /obj/structure/bed,
 /obj/item/bedsheet/yellow,
@@ -2156,10 +2235,20 @@
 	},
 /area/lv624/lazarus/crashed_ship)
 "Df" = (
+<<<<<<< master
 /obj/structure/machinery/autolathe,
 /obj/structure/machinery/power/apc/high{
 	pixel_y = 24
 	},
+=======
+/obj/structure/machinery/power/apc{
+	dir = 1;
+	name = "Crashed Ship APC";
+	pixel_y = 30;
+	start_charge = 1
+	},
+/obj/structure/machinery/autolathe,
+>>>>>>> reimported backup
 /turf/open/floor/almayer{
 	dir = 9;
 	icon_state = "orange";
@@ -2203,6 +2292,7 @@
 	tag = "icon-whitegreenfull (SOUTHWEST)"
 	},
 /area/fiorina/tumor/ice_lab)
+<<<<<<< master
 "Ee" = (
 /obj/item/explosive/mine/clf/active,
 /turf/open/floor/prison{
@@ -2211,6 +2301,8 @@
 	tag = "icon-whitegreenfull (SOUTHWEST)"
 	},
 /area/fiorina/tumor/ice_lab)
+=======
+>>>>>>> reimported backup
 "El" = (
 /obj/structure/machinery/vending/snack,
 /turf/open/floor/prison{
@@ -2273,7 +2365,10 @@
 /area/fiorina/tumor/ice_lab)
 "Fa" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/almayer{
 	icon_state = "green";
 	tag = "icon-green"
@@ -2441,8 +2536,14 @@
 	},
 /area/fiorina/tumor/ice_lab)
 "HB" = (
+<<<<<<< master
 /obj/structure/machinery/door/airlock/multi_tile/almayer/almayer/glass{
 	dir = 2
+=======
+/obj/structure/machinery/door/airlock/multi_tile/secure{
+	dir = 1;
+	name = "\improper Medical Bay"
+>>>>>>> reimported backup
 	},
 /turf/open/floor/plating,
 /area/lv624/lazarus/crashed_ship)
@@ -2622,11 +2723,14 @@
 	},
 /turf/open/ice/noweed,
 /area/fiorina/tumor/ice_lab)
+<<<<<<< master
 "JA" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/plating,
 /area/lv624/lazarus/crashed_ship)
+=======
+>>>>>>> reimported backup
 "JD" = (
 /obj/structure/blocker/invisible_wall,
 /turf/open/floor{
@@ -3059,6 +3163,15 @@
 	},
 /turf/open/floor/plating,
 /area/lv624/lazarus/crashed_ship)
+<<<<<<< master
+=======
+"Qx" = (
+/obj/structure/machinery/door/airlock/multi_tile/secure{
+	name = "\improper Bunk Beds"
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/crashed_ship)
+>>>>>>> reimported backup
 "QE" = (
 /obj/structure/surface/table/almayer,
 /obj/item/storage/toolbox/electrical{
@@ -3215,12 +3328,15 @@
 /obj/structure/blocker/invisible_wall,
 /turf/open/floor/plating,
 /area/fiorina/oob)
+<<<<<<< master
 "SA" = (
 /obj/item/explosive/mine/clf/active,
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
 /area/fiorina/tumor/ice_lab)
+=======
+>>>>>>> reimported backup
 "SC" = (
 /obj/structure/platform,
 /obj/structure/platform{
@@ -3259,10 +3375,13 @@
 	icon_state = "damaged3"
 	},
 /area/lv624/lazarus/crashed_ship)
+<<<<<<< master
 "Tt" = (
 /obj/item/explosive/mine/clf/active,
 /turf/open/floor/plating,
 /area/lv624/lazarus/crashed_ship)
+=======
+>>>>>>> reimported backup
 "TB" = (
 /obj/structure/stairs/perspective{
 	dir = 8;
@@ -3349,10 +3468,17 @@
 	},
 /area/fiorina/tumor/ice_lab)
 "VD" = (
+<<<<<<< master
 /obj/structure/machinery/door/airlock/multi_tile/almayer/almayer/glass,
 /turf/closed/shuttle/ert{
 	icon_state = "stan_inner_w_1"
 	},
+=======
+/obj/structure/machinery/door/airlock/multi_tile/secure{
+	name = "\improper Dining Room"
+	},
+/turf/open/floor/plating,
+>>>>>>> reimported backup
 /area/lv624/lazarus/crashed_ship)
 "VH" = (
 /obj/item/stack/tile/plasteel{
@@ -3458,10 +3584,13 @@
 	icon_state = "platingdmg3"
 	},
 /area/lv624/lazarus/crashed_ship)
+<<<<<<< master
 "WK" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/wood,
 /area/lv624/lazarus/crashed_ship)
+=======
+>>>>>>> reimported backup
 "Xn" = (
 /obj/item/ammo_casing/shell{
 	icon_state = "shell_6_1"
@@ -3779,7 +3908,11 @@ pi
 pi
 Mo
 aB
+<<<<<<< master
 SA
+=======
+Fm
+>>>>>>> reimported backup
 Fm
 YB
 Nk
@@ -3919,7 +4052,11 @@ aB
 aB
 aB
 lR
+<<<<<<< master
 Ee
+=======
+aB
+>>>>>>> reimported backup
 nW
 Cu
 uI
@@ -3937,7 +4074,11 @@ Bs
 cS
 Df
 xl
+<<<<<<< master
 rl
+=======
+FB
+>>>>>>> reimported backup
 Iu
 QZ
 QH
@@ -3981,7 +4122,11 @@ io
 Rp
 QZ
 Mr
+<<<<<<< master
 FB
+=======
+Iu
+>>>>>>> reimported backup
 Gv
 Ne
 QZ
@@ -4047,7 +4192,11 @@ yF
 In
 tT
 Fm
+<<<<<<< master
 hF
+=======
+WE
+>>>>>>> reimported backup
 np
 WE
 UX
@@ -4072,18 +4221,30 @@ zv
 tY
 ko
 Wz
+<<<<<<< master
 HB
+=======
+Wz
+>>>>>>> reimported backup
 ko
 Nl
 NV
 Oi
+<<<<<<< master
 rl
+=======
+FB
+>>>>>>> reimported backup
 xA
 QZ
 vs
 tE
 Zz
+<<<<<<< master
 lI
+=======
+nC
+>>>>>>> reimported backup
 OS
 uZ
 mK
@@ -4167,7 +4328,11 @@ MT
 QZ
 gW
 kM
+<<<<<<< master
 FB
+=======
+Iu
+>>>>>>> reimported backup
 Iu
 Wz
 qW
@@ -4207,7 +4372,11 @@ VN
 QZ
 bX
 XG
+<<<<<<< master
 FB
+=======
+Iu
+>>>>>>> reimported backup
 Jd
 tY
 ko
@@ -4224,7 +4393,11 @@ Ti
 WI
 nC
 rU
+<<<<<<< master
 pn
+=======
+nC
+>>>>>>> reimported backup
 tq
 vo
 ow
@@ -4254,18 +4427,30 @@ it
 kz
 Iu
 Iu
+<<<<<<< master
 nU
+=======
+ho
+>>>>>>> reimported backup
 Iu
 Wz
 bj
 Wz
 QZ
 Dw
+<<<<<<< master
 lI
 CZ
 nC
 gK
 Tt
+=======
+nC
+CZ
+nC
+gK
+Wz
+>>>>>>> reimported backup
 tq
 Pe
 tq
@@ -4301,8 +4486,13 @@ wv
 eo
 Wz
 Gj
+<<<<<<< master
 Gf
 lI
+=======
+Wz
+nC
+>>>>>>> reimported backup
 Wz
 wS
 Bc
@@ -4359,7 +4549,11 @@ WI
 WI
 tq
 WI
+<<<<<<< master
 zU
+=======
+Ws
+>>>>>>> reimported backup
 tE
 RV
 Fk
@@ -4408,7 +4602,11 @@ Ws
 tE
 iL
 av
+<<<<<<< master
 SA
+=======
+Fm
+>>>>>>> reimported backup
 VH
 Jt
 gt
@@ -4445,7 +4643,11 @@ Wz
 Wz
 tq
 Ac
+<<<<<<< master
 pn
+=======
+nC
+>>>>>>> reimported backup
 Ws
 Ws
 tq
@@ -4484,7 +4686,11 @@ Wz
 xW
 hP
 Wz
+<<<<<<< master
 VD
+=======
+QZ
+>>>>>>> reimported backup
 Ez
 Cq
 Jw
@@ -4494,7 +4700,11 @@ hi
 Wz
 tq
 nC
+<<<<<<< master
 pn
+=======
+nC
+>>>>>>> reimported backup
 tq
 vo
 VH
@@ -4524,12 +4734,21 @@ qH
 Iu
 Iu
 Iu
+<<<<<<< master
 nU
 Wz
 lI
 JA
 Nq
 Wz
+=======
+VD
+Wz
+nC
+Gf
+Nq
+nU
+>>>>>>> reimported backup
 nC
 ji
 Bw
@@ -4567,16 +4786,26 @@ Sn
 kd
 Ow
 pr
+<<<<<<< master
 WK
+=======
+pr
+>>>>>>> reimported backup
 pr
 Wz
 Wz
 Wz
 nC
 vh
+<<<<<<< master
 QZ
 Wz
 JA
+=======
+Wz
+Wz
+Gf
+>>>>>>> reimported backup
 yL
 eO
 us
@@ -4659,14 +4888,22 @@ Ag
 Dp
 KU
 Sd
+<<<<<<< master
 nU
+=======
+Qx
+>>>>>>> reimported backup
 XG
 bj
 af
 Jf
 QZ
 Uy
+<<<<<<< master
 vV
+=======
+Wz
+>>>>>>> reimported backup
 ZM
 nC
 dx
@@ -4817,7 +5054,12 @@ cz
 Ra
 NS
 OQ
+<<<<<<< master
 vy
+OQ
+>>>>>>> reimported backup
+=======
+OQ
 OQ
 >>>>>>> reimported backup
 OQ
@@ -4954,7 +5196,11 @@ uI
 sS
 Fm
 VH
+<<<<<<< master
 SA
+=======
+Fm
+>>>>>>> reimported backup
 aP
 sS
 uI

--- a/maps/map_files/FOP_v3_Sciannex/sprinkles/25.sciannexclfship.dmm
+++ b/maps/map_files/FOP_v3_Sciannex/sprinkles/25.sciannexclfship.dmm
@@ -190,7 +190,10 @@
 /obj/item/stack/rods,
 /obj/item/ammo_magazine/rifle/type71/ap,
 /obj/effect/landmark/corpsespawner/clf,
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor{
 	dir = 8;
 	icon_state = "damaged3"
@@ -273,7 +276,10 @@
 "di" = (
 /obj/item/stack/rods,
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/plating,
 /area/lv624/lazarus/crashed_ship)
 "dw" = (
@@ -296,14 +302,20 @@
 /area/lv624/lazarus/crashed_ship)
 "dC" = (
 /obj/item/stack/rods,
+<<<<<<< master
 /obj/item/explosive/mine/clf/active,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
 /area/lv624/lazarus/crashed_ship)
 "dM" = (
 /obj/item/ammo_casing/bullet,
+<<<<<<< master
 /obj/item/explosive/mine/clf/active,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/prison{
 	dir = 1;
 	icon_state = "whitegreen"
@@ -492,6 +504,7 @@
 /obj/structure/machinery/cm_vending/sorted/medical/wall_med,
 /turf/closed/wall/prison,
 /area/fiorina/tumor/ice_lab)
+<<<<<<< master
 "hF" = (
 /obj/item/stack/tile/plasteel{
 	pixel_x = 5;
@@ -502,6 +515,8 @@
 	icon_state = "platingdmg3"
 	},
 /area/fiorina/tumor/ice_lab)
+=======
+>>>>>>> reimported backup
 "hI" = (
 /obj/structure/surface/table/reinforced/prison{
 	flipped = 1
@@ -691,7 +706,10 @@
 /area/lv624/lazarus/crashed_ship)
 "kz" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/almayer,
 /area/lv624/lazarus/crashed_ship)
 "kC" = (
@@ -753,12 +771,15 @@
 "ly" = (
 /turf/closed/wall/mineral/bone_resin,
 /area/lv624/lazarus/crashed_ship)
+<<<<<<< master
 "lI" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
 /area/lv624/lazarus/crashed_ship)
+=======
+>>>>>>> reimported backup
 "lN" = (
 /obj/item/stack/rods,
 /obj/effect/landmark/corpsespawner/colonist,
@@ -787,7 +808,10 @@
 /obj/item/ammo_casing/shell{
 	icon_state = "casing_2_1"
 	},
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -903,7 +927,10 @@
 "nP" = (
 /obj/structure/bed/chair,
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/wood,
 /area/lv624/lazarus/crashed_ship)
 "nU" = (
@@ -933,7 +960,10 @@
 	},
 /area/lv624/lazarus/crashed_ship)
 "ob" = (
+<<<<<<< master
 /obj/item/explosive/mine/clf/active,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/prison{
 	dir = 5;
 	icon_state = "whitegreen"
@@ -1006,12 +1036,15 @@
 	icon_state = "platingdmg1"
 	},
 /area/fiorina/tumor/ice_lab)
+<<<<<<< master
 "pn" = (
 /obj/item/explosive/mine/clf/active,
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
 /area/lv624/lazarus/crashed_ship)
+=======
+>>>>>>> reimported backup
 "pr" = (
 /turf/open/floor/wood,
 /area/lv624/lazarus/crashed_ship)
@@ -1126,11 +1159,14 @@
 	icon_state = "whitegreen"
 	},
 /area/fiorina/tumor/ice_lab)
+<<<<<<< master
 "rl" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/plating/plating_catwalk,
 /area/lv624/lazarus/crashed_ship)
+=======
+>>>>>>> reimported backup
 "rm" = (
 /obj/structure/surface/table/woodentable,
 /obj/item/storage/firstaid/adv,
@@ -1384,7 +1420,10 @@
 /obj/item/ammo_casing/shell{
 	icon_state = "casing_9_1"
 	},
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
@@ -1479,7 +1518,10 @@
 "uZ" = (
 /obj/item/stack/rods,
 /obj/effect/spawner/random/attachment,
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/plating,
 /area/lv624/lazarus/crashed_ship)
 "vd" = (
@@ -1572,6 +1614,7 @@
 	},
 /turf/open/floor/plating,
 /area/lv624/lazarus/crashed_ship)
+<<<<<<< master
 "vy" = (
 /obj/item/explosive/mine/clf/active,
 /turf/open/floor/prison{
@@ -1579,6 +1622,8 @@
 	icon_state = "whitegreen"
 	},
 /area/fiorina/tumor/ice_lab)
+=======
+>>>>>>> reimported backup
 "vD" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/tool/weldpack,
@@ -1620,6 +1665,7 @@
 	icon_state = "whitegreen"
 	},
 /area/fiorina/tumor/ice_lab)
+<<<<<<< master
 "vV" = (
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
@@ -1629,6 +1675,8 @@
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/plating,
 /area/lv624/lazarus/crashed_ship)
+=======
+>>>>>>> reimported backup
 "vX" = (
 /obj/structure/surface/rack,
 /obj/effect/spawner/random/toolbox,
@@ -1891,10 +1939,13 @@
 	icon_state = "whitegreen"
 	},
 /area/fiorina/tumor/ice_lab)
+<<<<<<< master
 "zU" = (
 /obj/item/explosive/mine/clf/active,
 /turf/open/floor/plating/prison,
 /area/lv624/lazarus/crashed_ship)
+=======
+>>>>>>> reimported backup
 "Ab" = (
 /obj/structure/bed,
 /obj/item/bedsheet/yellow,
@@ -2243,6 +2294,7 @@
 	tag = "icon-whitegreenfull (SOUTHWEST)"
 	},
 /area/fiorina/tumor/ice_lab)
+<<<<<<< master
 "Ee" = (
 /obj/item/explosive/mine/clf/active,
 /turf/open/floor/prison{
@@ -2251,6 +2303,8 @@
 	tag = "icon-whitegreenfull (SOUTHWEST)"
 	},
 /area/fiorina/tumor/ice_lab)
+=======
+>>>>>>> reimported backup
 "El" = (
 /obj/structure/machinery/vending/snack,
 /turf/open/floor/prison{
@@ -2313,7 +2367,10 @@
 /area/fiorina/tumor/ice_lab)
 "Fa" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/almayer{
 	icon_state = "green";
 	tag = "icon-green"
@@ -2668,11 +2725,14 @@
 	},
 /turf/open/ice/noweed,
 /area/fiorina/tumor/ice_lab)
+<<<<<<< master
 "JA" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/plating,
 /area/lv624/lazarus/crashed_ship)
+=======
+>>>>>>> reimported backup
 "JD" = (
 /obj/structure/blocker/invisible_wall,
 /turf/open/floor{
@@ -3270,12 +3330,15 @@
 /obj/structure/blocker/invisible_wall,
 /turf/open/floor/plating,
 /area/fiorina/oob)
+<<<<<<< master
 "SA" = (
 /obj/item/explosive/mine/clf/active,
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
 /area/fiorina/tumor/ice_lab)
+=======
+>>>>>>> reimported backup
 "SC" = (
 /obj/structure/platform,
 /obj/structure/platform{
@@ -3314,10 +3377,13 @@
 	icon_state = "damaged3"
 	},
 /area/lv624/lazarus/crashed_ship)
+<<<<<<< master
 "Tt" = (
 /obj/item/explosive/mine/clf/active,
 /turf/open/floor/plating,
 /area/lv624/lazarus/crashed_ship)
+=======
+>>>>>>> reimported backup
 "TB" = (
 /obj/structure/stairs/perspective{
 	dir = 8;
@@ -3520,10 +3586,13 @@
 	icon_state = "platingdmg3"
 	},
 /area/lv624/lazarus/crashed_ship)
+<<<<<<< master
 "WK" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/wood,
 /area/lv624/lazarus/crashed_ship)
+=======
+>>>>>>> reimported backup
 "Xn" = (
 /obj/item/ammo_casing/shell{
 	icon_state = "shell_6_1"
@@ -3841,7 +3910,11 @@ pi
 pi
 Mo
 aB
+<<<<<<< master
 SA
+=======
+Fm
+>>>>>>> reimported backup
 Fm
 YB
 Nk
@@ -3981,7 +4054,11 @@ aB
 aB
 aB
 lR
+<<<<<<< master
 Ee
+=======
+aB
+>>>>>>> reimported backup
 nW
 Cu
 uI
@@ -3999,7 +4076,11 @@ Bs
 cS
 Df
 xl
+<<<<<<< master
 rl
+=======
+FB
+>>>>>>> reimported backup
 Iu
 QZ
 QH
@@ -4043,7 +4124,11 @@ io
 Rp
 QZ
 Mr
+<<<<<<< master
 FB
+=======
+Iu
+>>>>>>> reimported backup
 Gv
 Ne
 QZ
@@ -4109,7 +4194,11 @@ yF
 In
 tT
 Fm
+<<<<<<< master
 hF
+=======
+WE
+>>>>>>> reimported backup
 np
 WE
 UX
@@ -4143,13 +4232,21 @@ ko
 Nl
 NV
 Oi
+<<<<<<< master
 rl
+=======
+FB
+>>>>>>> reimported backup
 xA
 QZ
 vs
 tE
 Zz
+<<<<<<< master
 lI
+=======
+nC
+>>>>>>> reimported backup
 OS
 uZ
 mK
@@ -4233,7 +4330,11 @@ MT
 QZ
 gW
 kM
+<<<<<<< master
 FB
+=======
+Iu
+>>>>>>> reimported backup
 Iu
 Wz
 qW
@@ -4273,7 +4374,11 @@ VN
 QZ
 bX
 XG
+<<<<<<< master
 FB
+=======
+Iu
+>>>>>>> reimported backup
 Jd
 tY
 ko
@@ -4290,7 +4395,11 @@ Ti
 WI
 nC
 rU
+<<<<<<< master
 pn
+=======
+nC
+>>>>>>> reimported backup
 tq
 vo
 ow
@@ -4331,11 +4440,19 @@ bj
 Wz
 QZ
 Dw
+<<<<<<< master
 lI
 CZ
 nC
 gK
 Tt
+=======
+nC
+CZ
+nC
+gK
+Wz
+>>>>>>> reimported backup
 tq
 Pe
 tq
@@ -4371,8 +4488,13 @@ wv
 eo
 Wz
 Gj
+<<<<<<< master
 Gf
 lI
+=======
+Wz
+nC
+>>>>>>> reimported backup
 Wz
 wS
 Bc
@@ -4429,7 +4551,11 @@ WI
 WI
 tq
 WI
+<<<<<<< master
 zU
+=======
+Ws
+>>>>>>> reimported backup
 tE
 RV
 Fk
@@ -4478,7 +4604,11 @@ Ws
 tE
 iL
 av
+<<<<<<< master
 SA
+=======
+Fm
+>>>>>>> reimported backup
 VH
 Jt
 gt
@@ -4515,7 +4645,11 @@ Wz
 Wz
 tq
 Ac
+<<<<<<< master
 pn
+=======
+nC
+>>>>>>> reimported backup
 Ws
 Ws
 tq
@@ -4568,7 +4702,11 @@ hi
 Wz
 tq
 nC
+<<<<<<< master
 pn
+=======
+nC
+>>>>>>> reimported backup
 tq
 vo
 VH
@@ -4608,8 +4746,13 @@ Wz
 =======
 VD
 Wz
+<<<<<<< master
 lI
 JA
+=======
+nC
+Gf
+>>>>>>> reimported backup
 Nq
 nU
 >>>>>>> reimported backup
@@ -4650,7 +4793,11 @@ Sn
 kd
 Ow
 pr
+<<<<<<< master
 WK
+=======
+pr
+>>>>>>> reimported backup
 pr
 Wz
 Wz
@@ -4663,7 +4810,11 @@ Wz
 JA
 =======
 Wz
+<<<<<<< master
 JA
+=======
+Gf
+>>>>>>> reimported backup
 yL
 eO
 us
@@ -4757,7 +4908,11 @@ af
 Jf
 QZ
 Uy
+<<<<<<< master
 vV
+=======
+Wz
+>>>>>>> reimported backup
 ZM
 nC
 dx
@@ -4908,7 +5063,11 @@ cz
 Ra
 NS
 OQ
+<<<<<<< master
 vy
+=======
+OQ
+>>>>>>> reimported backup
 OQ
 >>>>>>> reimported backup
 =======
@@ -5046,7 +5205,11 @@ uI
 sS
 Fm
 VH
+<<<<<<< master
 SA
+=======
+Fm
+>>>>>>> reimported backup
 aP
 sS
 uI

--- a/maps/map_files/FOP_v3_Sciannex/sprinkles/25.sciannexclfship.dmm
+++ b/maps/map_files/FOP_v3_Sciannex/sprinkles/25.sciannexclfship.dmm
@@ -190,10 +190,7 @@
 /obj/item/stack/rods,
 /obj/item/ammo_magazine/rifle/type71/ap,
 /obj/effect/landmark/corpsespawner/clf,
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-=======
->>>>>>> reimported backup
 /turf/open/floor{
 	dir = 8;
 	icon_state = "damaged3"
@@ -276,10 +273,7 @@
 "di" = (
 /obj/item/stack/rods,
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-=======
->>>>>>> reimported backup
 /turf/open/floor/plating,
 /area/lv624/lazarus/crashed_ship)
 "dw" = (
@@ -697,10 +691,7 @@
 /area/lv624/lazarus/crashed_ship)
 "kz" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-=======
->>>>>>> reimported backup
 /turf/open/floor/almayer,
 /area/lv624/lazarus/crashed_ship)
 "kC" = (
@@ -762,15 +753,12 @@
 "ly" = (
 /turf/closed/wall/mineral/bone_resin,
 /area/lv624/lazarus/crashed_ship)
-<<<<<<< master
 "lI" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
 /area/lv624/lazarus/crashed_ship)
-=======
->>>>>>> reimported backup
 "lN" = (
 /obj/item/stack/rods,
 /obj/effect/landmark/corpsespawner/colonist,
@@ -799,10 +787,7 @@
 /obj/item/ammo_casing/shell{
 	icon_state = "casing_2_1"
 	},
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-=======
->>>>>>> reimported backup
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -918,7 +903,6 @@
 "nP" = (
 /obj/structure/bed/chair,
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/wood,
 /area/lv624/lazarus/crashed_ship)
@@ -1142,14 +1126,11 @@
 	icon_state = "whitegreen"
 	},
 /area/fiorina/tumor/ice_lab)
-<<<<<<< master
 "rl" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/plating/plating_catwalk,
 /area/lv624/lazarus/crashed_ship)
-=======
->>>>>>> reimported backup
 "rm" = (
 /obj/structure/surface/table/woodentable,
 /obj/item/storage/firstaid/adv,
@@ -1403,10 +1384,7 @@
 /obj/item/ammo_casing/shell{
 	icon_state = "casing_9_1"
 	},
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-=======
->>>>>>> reimported backup
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
@@ -1501,10 +1479,7 @@
 "uZ" = (
 /obj/item/stack/rods,
 /obj/effect/spawner/random/attachment,
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-=======
->>>>>>> reimported backup
 /turf/open/floor/plating,
 /area/lv624/lazarus/crashed_ship)
 "vd" = (
@@ -1651,6 +1626,7 @@
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/plating,
 /area/lv624/lazarus/crashed_ship)
 "vX" = (
@@ -2337,10 +2313,7 @@
 /area/fiorina/tumor/ice_lab)
 "Fa" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-=======
->>>>>>> reimported backup
 /turf/open/floor/almayer{
 	icon_state = "green";
 	tag = "icon-green"
@@ -2695,14 +2668,11 @@
 	},
 /turf/open/ice/noweed,
 /area/fiorina/tumor/ice_lab)
-<<<<<<< master
 "JA" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/plating,
 /area/lv624/lazarus/crashed_ship)
-=======
->>>>>>> reimported backup
 "JD" = (
 /obj/structure/blocker/invisible_wall,
 /turf/open/floor{
@@ -3550,13 +3520,10 @@
 	icon_state = "platingdmg3"
 	},
 /area/lv624/lazarus/crashed_ship)
-<<<<<<< master
 "WK" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/wood,
 /area/lv624/lazarus/crashed_ship)
-=======
->>>>>>> reimported backup
 "Xn" = (
 /obj/item/ammo_casing/shell{
 	icon_state = "shell_6_1"
@@ -4032,11 +3999,7 @@ Bs
 cS
 Df
 xl
-<<<<<<< master
 rl
-=======
-FB
->>>>>>> reimported backup
 Iu
 QZ
 QH
@@ -4080,11 +4043,7 @@ io
 Rp
 QZ
 Mr
-<<<<<<< master
 FB
-=======
-Iu
->>>>>>> reimported backup
 Gv
 Ne
 QZ
@@ -4184,21 +4143,13 @@ ko
 Nl
 NV
 Oi
-<<<<<<< master
 rl
-=======
-FB
->>>>>>> reimported backup
 xA
 QZ
 vs
 tE
 Zz
-<<<<<<< master
 lI
-=======
-nC
->>>>>>> reimported backup
 OS
 uZ
 mK
@@ -4282,11 +4233,7 @@ MT
 QZ
 gW
 kM
-<<<<<<< master
 FB
-=======
-Iu
->>>>>>> reimported backup
 Iu
 Wz
 qW
@@ -4326,11 +4273,7 @@ VN
 QZ
 bX
 XG
-<<<<<<< master
 FB
-=======
-Iu
->>>>>>> reimported backup
 Jd
 tY
 ko
@@ -4388,14 +4331,7 @@ bj
 Wz
 QZ
 Dw
-<<<<<<< master
 lI
-CZ
-nC
-gK
-Tt
-=======
-nC
 CZ
 nC
 gK
@@ -4435,13 +4371,8 @@ wv
 eo
 Wz
 Gj
-<<<<<<< master
 Gf
 lI
-=======
-Wz
-nC
->>>>>>> reimported backup
 Wz
 wS
 Bc
@@ -4677,8 +4608,8 @@ Wz
 =======
 VD
 Wz
-nC
-Gf
+lI
+JA
 Nq
 nU
 >>>>>>> reimported backup
@@ -4719,11 +4650,7 @@ Sn
 kd
 Ow
 pr
-<<<<<<< master
 WK
-=======
-pr
->>>>>>> reimported backup
 pr
 Wz
 Wz
@@ -4736,9 +4663,7 @@ Wz
 JA
 =======
 Wz
-Wz
-Gf
->>>>>>> reimported backup
+JA
 yL
 eO
 us

--- a/maps/map_files/Ice_Colony_v3/Shivas_Snowball.dmm
+++ b/maps/map_files/Ice_Colony_v3/Shivas_Snowball.dmm
@@ -27270,10 +27270,14 @@
 "wMB" = (
 /obj/effect/landmark/nightmare{
 <<<<<<< master
+<<<<<<< master
 	insert_tag = "shivaclf01"
 =======
 	insert_tag = shivaclf01
 >>>>>>> added nightmare insert tags to main maps
+=======
+	insert_tag = "shivaclf01"
+>>>>>>> fixed issue with invalid landmark
 	},
 /turf/open/auto_turf/snow/layer3,
 /area/shiva/exterior/cp_s_research)

--- a/maps/map_files/Ice_Colony_v3/Shivas_Snowball.dmm
+++ b/maps/map_files/Ice_Colony_v3/Shivas_Snowball.dmm
@@ -15887,6 +15887,12 @@
 	},
 /turf/open/auto_turf/snow/layer1,
 /area/shiva/exterior/cp_colony_grounds)
+"kCQ" = (
+/obj/effect/landmark/nightmare{
+	insert_tag = shivabarls
+	},
+/turf/closed/wall/shiva/prefabricated,
+/area/shiva/interior/bar)
 "kDi" = (
 /obj/structure/prop/invuln/ice_prefab/roof_greeble{
 	icon_state = "vent4";
@@ -27257,6 +27263,12 @@
 	icon_state = "bluefull"
 	},
 /area/shiva/interior/colony/n_admin)
+"wMB" = (
+/obj/effect/landmark/nightmare{
+	insert_tag = shivaclf01
+	},
+/turf/open/auto_turf/snow/layer3,
+/area/shiva/exterior/cp_s_research)
 "wMC" = (
 /obj/structure/closet/toolcloset,
 /turf/open/floor/shiva{
@@ -43080,7 +43092,7 @@ kOV
 kOV
 ukp
 kVd
-kVd
+wMB
 dHr
 rAH
 msh
@@ -46826,7 +46838,7 @@ tnu
 gWk
 gWk
 tnu
-tnu
+kCQ
 tiO
 muH
 cUQ

--- a/maps/map_files/Ice_Colony_v3/Shivas_Snowball.dmm
+++ b/maps/map_files/Ice_Colony_v3/Shivas_Snowball.dmm
@@ -15889,7 +15889,11 @@
 /area/shiva/exterior/cp_colony_grounds)
 "kCQ" = (
 /obj/effect/landmark/nightmare{
+<<<<<<< master
 	insert_tag = "shivabarls"
+=======
+	insert_tag = shivabarls
+>>>>>>> added nightmare insert tags to main maps
 	},
 /turf/closed/wall/shiva/prefabricated,
 /area/shiva/interior/bar)
@@ -27265,7 +27269,11 @@
 /area/shiva/interior/colony/n_admin)
 "wMB" = (
 /obj/effect/landmark/nightmare{
+<<<<<<< master
 	insert_tag = "shivaclf01"
+=======
+	insert_tag = shivaclf01
+>>>>>>> added nightmare insert tags to main maps
 	},
 /turf/open/auto_turf/snow/layer3,
 /area/shiva/exterior/cp_s_research)

--- a/maps/map_files/Ice_Colony_v3/Shivas_Snowball.dmm
+++ b/maps/map_files/Ice_Colony_v3/Shivas_Snowball.dmm
@@ -15890,10 +15890,14 @@
 "kCQ" = (
 /obj/effect/landmark/nightmare{
 <<<<<<< master
+<<<<<<< master
 	insert_tag = "shivabarls"
 =======
 	insert_tag = shivabarls
 >>>>>>> added nightmare insert tags to main maps
+=======
+	insert_tag = "shivabarls"
+>>>>>>> fix
 	},
 /turf/closed/wall/shiva/prefabricated,
 /area/shiva/interior/bar)

--- a/maps/map_files/Ice_Colony_v3/Shivas_Snowball.dmm
+++ b/maps/map_files/Ice_Colony_v3/Shivas_Snowball.dmm
@@ -27265,7 +27265,7 @@
 /area/shiva/interior/colony/n_admin)
 "wMB" = (
 /obj/effect/landmark/nightmare{
-	insert_tag = shivaclf01
+	insert_tag = "shivaclf01"
 	},
 /turf/open/auto_turf/snow/layer3,
 /area/shiva/exterior/cp_s_research)

--- a/maps/map_files/Ice_Colony_v3/Shivas_Snowball.dmm
+++ b/maps/map_files/Ice_Colony_v3/Shivas_Snowball.dmm
@@ -15889,7 +15889,7 @@
 /area/shiva/exterior/cp_colony_grounds)
 "kCQ" = (
 /obj/effect/landmark/nightmare{
-	insert_tag = shivabarls
+	insert_tag = "shivabarls"
 	},
 /turf/closed/wall/shiva/prefabricated,
 /area/shiva/interior/bar)

--- a/maps/map_files/Ice_Colony_v3/sprinkles/25.shivaclf01.dmm
+++ b/maps/map_files/Ice_Colony_v3/sprinkles/25.shivaclf01.dmm
@@ -1,0 +1,2642 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ad" = (
+/obj/structure/machinery/disposal,
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/interior/colony/s_admin)
+"ag" = (
+/obj/structure/machinery/m56d_hmg{
+	rounds = 700;
+	dir = 1
+	},
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/shiva/interior/colony/s_admin)
+"aj" = (
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/shiva{
+	dir = 8;
+	icon_state = "multi_tiles"
+	},
+/area/shiva/interior/colony/s_admin)
+"ak" = (
+/obj/effect/decal/cleanable/blood{
+	icon_state = "gib6";
+	tag = "icon-gib6"
+	},
+/obj/effect/decal/cleanable/blood{
+	layer = 3
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/shiva/interior/colony/s_admin)
+"av" = (
+/obj/structure/machinery/light/double{
+	dir = 8;
+	pixel_y = -5
+	},
+/turf/open/floor/shiva{
+	icon_state = "bluefull"
+	},
+/area/shiva/interior/colony/s_admin)
+"aC" = (
+/obj/structure/surface/rack,
+/obj/structure/machinery/light/small{
+	dir = 1;
+	pixel_y = 20
+	},
+/obj/item/ammo_magazine/rifle/mar40,
+/obj/item/ammo_magazine/rifle/mar40,
+/obj/item/ammo_magazine/rifle/mar40,
+/obj/item/ammo_magazine/rifle/mar40,
+/obj/item/ammo_magazine/rifle/mar40,
+/obj/item/weapon/gun/rifle/mar40{
+	pixel_y = -1
+	},
+/obj/item/ammo_magazine/rifle/mar40,
+/obj/item/ammo_magazine/rifle/mar40,
+/obj/item/ammo_magazine/rifle/mar40,
+/obj/item/ammo_magazine/rifle/mar40,
+/obj/item/ammo_magazine/rifle/mar40,
+/turf/open/floor/shiva{
+	icon_state = "bluefull"
+	},
+/area/shiva/interior/colony/s_admin)
+"aI" = (
+/obj/item/clipboard,
+/obj/item/tool/pen/blue,
+/obj/item/stack/sheet/metal,
+/obj/item/shard{
+	icon_state = "large"
+	},
+/obj/item/shard{
+	icon_state = "large"
+	},
+/obj/structure/surface/table/reinforced/prison,
+/obj/structure/machinery/door/window/eastright{
+	name = "Security Desk"
+	},
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/interior/colony/s_admin)
+"aQ" = (
+/obj/effect/decal/cleanable/blood{
+	layer = 3
+	},
+/turf/open/floor/shiva{
+	icon_state = "bluefull"
+	},
+/area/shiva/interior/colony/s_admin)
+"aY" = (
+/obj/structure/machinery/colony_floodlight,
+/turf/open/auto_turf/snow/layer2,
+/area/shiva/exterior/junkyard/cp_bar)
+"bv" = (
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1";
+	dir = 1
+	},
+/turf/open/floor/shiva{
+	icon_state = "floor3"
+	},
+/area/shiva/interior/colony/s_admin)
+"bF" = (
+/obj/effect/decal/cleanable/blood{
+	layer = 3
+	},
+/obj/effect/spawner/random/attachment,
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/interior/colony/s_admin)
+"bN" = (
+/obj/item/ammo_casing/bullet,
+/obj/item/shard{
+	icon_state = "medium"
+	},
+/obj/effect/decal/cleanable/blood{
+	layer = 3
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/shiva/interior/colony/s_admin)
+"bR" = (
+/obj/structure/largecrate/random/case/double,
+/turf/open/auto_turf/snow/layer2,
+/area/shiva/exterior/junkyard/cp_bar)
+"cC" = (
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_2";
+	dir = 1
+	},
+/obj/item/shard{
+	icon_state = "medium"
+	},
+/turf/open/floor/plating,
+/area/shiva/interior/colony/s_admin)
+"cL" = (
+/obj/structure/stairs/perspective{
+	icon_state = "p_stair_sn_full_cap"
+	},
+/turf/open/floor/shiva{
+	dir = 6;
+	icon_state = "multi_tiles"
+	},
+/area/shiva/interior/bar)
+"cR" = (
+/obj/structure/machinery/body_scanconsole,
+/turf/open/floor/shiva{
+	dir = 8;
+	icon_state = "redfull"
+	},
+/area/shiva/interior/colony/s_admin)
+"cZ" = (
+/obj/item/device/pinpointer,
+/turf/open/floor/shiva{
+	icon_state = "bluefull"
+	},
+/area/shiva/interior/colony/s_admin)
+"dg" = (
+/obj/structure/surface/rack,
+/obj/item/storage/firstaid/adv{
+	pixel_x = 3;
+	pixel_y = 5
+	},
+/obj/item/storage/firstaid/adv,
+/obj/structure/machinery/light/double{
+	dir = 8;
+	pixel_y = -5
+	},
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/shiva/interior/colony/s_admin)
+"dh" = (
+/obj/structure/machinery/bodyscanner,
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/shiva/interior/colony/s_admin)
+"dT" = (
+/obj/structure/barricade/plasteel/wired{
+	icon_state = "plasteel_3";
+	dir = 1
+	},
+/turf/open/floor/shiva{
+	dir = 8;
+	icon_state = "multi_tiles"
+	},
+/area/shiva/interior/colony/s_admin)
+"ex" = (
+/obj/structure/machinery/door/airlock/almayer/command{
+	dir = 1;
+	name = "\improper Colony Administration Office";
+	req_access_txt = "100"
+	},
+/turf/open/floor/wood,
+/area/shiva/interior/colony/s_admin)
+"ff" = (
+/obj/item/shard{
+	icon_state = "large"
+	},
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/interior/colony/s_admin)
+"fg" = (
+/obj/effect/spawner/random/attachment,
+/turf/open/floor/shiva{
+	icon_state = "bluefull"
+	},
+/area/shiva/interior/colony/s_admin)
+"fv" = (
+/obj/structure/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/open/floor/shiva{
+	icon_state = "bluefull"
+	},
+/area/shiva/interior/colony/s_admin)
+"fP" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/structure/machinery/computer/security{
+	dir = 1
+	},
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/interior/colony/s_admin)
+"go" = (
+/obj/item/shard{
+	icon_state = "medium"
+	},
+/turf/open/floor/shiva{
+	icon_state = "floor3"
+	},
+/area/shiva/interior/colony/s_admin)
+"gr" = (
+/turf/open/floor/shiva{
+	icon_state = "multi_tiles"
+	},
+/area/shiva/interior/colony/s_admin)
+"gS" = (
+/obj/structure/surface/rack,
+/obj/item/clothing/suit/storage/snow_suit/survivor{
+	pixel_x = -3
+	},
+/obj/item/clothing/mask/rebreather/scarf{
+	pixel_x = 4
+	},
+/obj/item/clothing/suit/storage/snow_suit/survivor{
+	pixel_x = -3
+	},
+/obj/item/clothing/suit/storage/snow_suit/survivor{
+	pixel_x = -3
+	},
+/obj/item/clothing/suit/storage/snow_suit/survivor{
+	pixel_x = -3
+	},
+/obj/item/clothing/mask/rebreather/scarf{
+	pixel_x = 4
+	},
+/obj/item/clothing/mask/rebreather/scarf{
+	pixel_x = 4
+	},
+/obj/item/clothing/mask/rebreather/scarf{
+	pixel_x = 4
+	},
+/turf/open/floor/shiva{
+	icon_state = "floor3"
+	},
+/area/shiva/interior/colony/s_admin)
+"hb" = (
+/obj/structure/machinery/light/double{
+	dir = 1;
+	pixel_y = 9
+	},
+/obj/item/shard{
+	icon_state = "large"
+	},
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/interior/colony/s_admin)
+"hi" = (
+/obj/structure/surface/rack,
+/obj/item/ammo_magazine/shotgun/buckshot,
+/obj/item/ammo_magazine/shotgun/buckshot,
+/obj/item/ammo_magazine/shotgun/buckshot,
+/obj/item/ammo_magazine/shotgun/buckshot,
+/turf/open/floor/almayer{
+	dir = 10;
+	icon_state = "orange";
+	tag = "icon-orange (SOUTHWEST)"
+	},
+/area/shiva/interior/colony/s_admin)
+"hn" = (
+/obj/structure/machinery/light/double{
+	dir = 4;
+	pixel_y = -5
+	},
+/obj/effect/decal/cleanable/vomit,
+/turf/open/floor/wood,
+/area/shiva/interior/colony/s_admin)
+"hv" = (
+/obj/structure/surface/rack,
+/obj/item/storage/backpack/general_belt{
+	pixel_y = 7
+	},
+/obj/item/storage/backpack/general_belt,
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/shiva/interior/colony/s_admin)
+"hw" = (
+/turf/open/auto_turf/snow/layer1,
+/area/shiva/exterior/cp_s_research)
+"hM" = (
+/turf/open/auto_turf/ice/layer1,
+/area/shiva/exterior/cp_s_research)
+"hO" = (
+/obj/structure/machinery/light/double,
+/turf/open/floor/shiva{
+	icon_state = "bluefull"
+	},
+/area/shiva/interior/colony/s_admin)
+"il" = (
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/shiva/interior/colony/s_admin)
+"is" = (
+/obj/structure/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/open/floor/shiva{
+	icon_state = "floor3"
+	},
+/area/shiva/interior/colony/s_admin)
+"iv" = (
+/obj/structure/coatrack,
+/turf/open/floor/wood,
+/area/shiva/interior/colony/s_admin)
+"iB" = (
+/obj/structure/prop/ice_colony/tiger_rug{
+	icon_state = "White"
+	},
+/turf/open/floor/shiva{
+	icon_state = "bluefull"
+	},
+/area/shiva/interior/colony/s_admin)
+"iG" = (
+/obj/structure/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/interior/colony/s_admin)
+"je" = (
+/obj/structure/machinery/door/airlock/almayer/security/glass{
+	name = "\improper Colony Security Checkpoint";
+	req_access_txt = "100"
+	},
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/interior/colony/s_admin)
+"jl" = (
+/obj/structure/sign/poster/clf,
+/turf/closed/wall/shiva/prefabricated,
+/area/shiva/interior/colony/s_admin)
+"jE" = (
+/turf/open/auto_turf/snow/layer1,
+/area/shiva/exterior/junkyard/cp_bar)
+"jS" = (
+/obj/structure/flora/pottedplant,
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/interior/colony/s_admin)
+"kb" = (
+/obj/item/stack/rods,
+/obj/effect/decal/cleanable/blood{
+	layer = 3
+	},
+/turf/open/floor/shiva{
+	icon_state = "bluefull"
+	},
+/area/shiva/interior/colony/s_admin)
+"kr" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/structure/machinery/faxmachine{
+	department = "CLF - Cell 42"
+	},
+/obj/item/paper/prison_station/pirate_note{
+	info = "<p>We're hit!</p><p>MAYDAY! MAYDAY! We have been hit by the -... .</p><p>We're on a planet somewhere, seems there is a colony to our south. Might head on over there and see if there is any USCM presence. Our ship is fucking busted beyond normal means of repair, still waiting for a damage assessment tho.</p><p>Coby and Ryan died today from their wounds... \"Fucking USCM.\" I'll have my revenge someday...</p><p>And the colonies will be freed one day from the oppressive regime of Wey-Yu and USCM henchmen."
+	},
+/turf/open/floor/shiva{
+	dir = 8;
+	icon_state = "redfull"
+	},
+/area/shiva/interior/colony/s_admin)
+"kL" = (
+/obj/structure/barricade/wooden{
+	dir = 4;
+	pixel_y = 4
+	},
+/turf/open/floor/wood,
+/area/shiva/interior/colony/s_admin)
+"kO" = (
+/obj/structure/machinery/door/airlock/multi_tile/almayer/comdoor{
+	name = "\improper Colony Administration";
+	req_access_txt = "100"
+	},
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/interior/colony/s_admin)
+"kT" = (
+/obj/structure/closet/secure_closet/security,
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/interior/colony/s_admin)
+"kU" = (
+/obj/item/stack/rods,
+/obj/effect/decal/cleanable/blood/oil,
+/obj/item/stack/cable_coil/cut,
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/interior/colony/s_admin)
+"kY" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/effect/landmark/good_item,
+/turf/open/floor/shiva{
+	icon_state = "bluefull"
+	},
+/area/shiva/interior/colony/s_admin)
+"mc" = (
+/obj/structure/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/structure/filingcabinet,
+/turf/open/floor/shiva{
+	icon_state = "floor3"
+	},
+/area/shiva/interior/colony/s_admin)
+"mh" = (
+/obj/effect/decal/cleanable/blood{
+	layer = 3
+	},
+/obj/structure/barricade/plasteel/wired{
+	icon_state = "plasteel_3";
+	dir = 1
+	},
+/obj/structure/barricade/plasteel/wired{
+	icon_state = "plasteel_3";
+	dir = 1
+	},
+/turf/open/floor/shiva{
+	dir = 8;
+	icon_state = "multi_tiles"
+	},
+/area/shiva/interior/colony/s_admin)
+"mE" = (
+/obj/effect/landmark/corpsespawner/security,
+/obj/item/weapon/gun/rifle/hunting,
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/shiva/interior/colony/s_admin)
+"nk" = (
+/obj/structure/surface/rack,
+/obj/item/ammo_magazine/shotgun/slugs,
+/obj/item/ammo_magazine/shotgun/slugs,
+/obj/item/ammo_magazine/shotgun/slugs,
+/turf/open/floor/almayer{
+	dir = 9;
+	icon_state = "orange";
+	tag = "icon-orange (NORTHWEST)"
+	},
+/area/shiva/interior/colony/s_admin)
+"ny" = (
+/obj/structure/barricade/sandbags{
+	dir = 4
+	},
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/interior/colony/s_admin)
+"nC" = (
+/turf/closed/wall/shiva/ice,
+/area/shiva/exterior/junkyard/cp_bar)
+"nD" = (
+/obj/structure/machinery/vending/snack,
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/interior/colony/s_admin)
+"nJ" = (
+/obj/structure/bed/chair{
+	dir = 8;
+	tag = "icon-chair (WEST)"
+	},
+/obj/structure/machinery/light/double{
+	dir = 4;
+	pixel_y = -5
+	},
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/interior/colony/s_admin)
+"nT" = (
+/obj/effect/landmark/corpsespawner/security,
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1";
+	dir = 1
+	},
+/obj/item/weapon/gun/shotgun/pump/cmb,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/shiva/interior/colony/s_admin)
+"nX" = (
+/turf/open/auto_turf/snow/layer0,
+/area/shiva/exterior/junkyard/cp_bar)
+"oZ" = (
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1";
+	dir = 1
+	},
+/obj/item/shard{
+	icon_state = "medium"
+	},
+/turf/open/floor/shiva{
+	icon_state = "bluefull"
+	},
+/area/shiva/interior/colony/s_admin)
+"pC" = (
+/obj/structure/window_frame/colony/reinforced,
+/obj/item/stack/rods,
+/turf/open/floor/plating,
+/area/shiva/interior/colony/s_admin)
+"pL" = (
+/turf/open/floor/plating,
+/area/shiva/interior/colony/s_admin)
+"pR" = (
+/obj/effect/decal/cleanable/blood{
+	layer = 3
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/shiva/interior/colony/s_admin)
+"qO" = (
+/obj/item/stack/rods,
+/obj/item/shard{
+	icon_state = "large"
+	},
+/obj/structure/window_frame/colony/reinforced,
+/turf/open/floor/plating,
+/area/shiva/interior/colony/s_admin)
+"qQ" = (
+/obj/structure/flora/bush/snow{
+	icon_state = "snowgrassbb_3";
+	layer = 2.9
+	},
+/turf/open/auto_turf/snow/layer2,
+/area/shiva/exterior/cp_lz2)
+"qT" = (
+/obj/structure/noticeboard{
+	pixel_y = 32
+	},
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/interior/colony/s_admin)
+"qZ" = (
+/turf/open/auto_turf/snow/layer3,
+/area/shiva/exterior/cp_lz2)
+"rp" = (
+/turf/open/auto_turf/snow/layer4,
+/area/shiva/exterior/cp_lz2)
+"rq" = (
+/obj/item/stack/folding_barricade,
+/turf/open/floor/shiva{
+	icon_state = "floor3"
+	},
+/area/shiva/interior/colony/s_admin)
+"rM" = (
+/turf/open/floor/wood,
+/area/shiva/interior/colony/s_admin)
+"rP" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/weapon/gun/rifle/mar40/lmg,
+/turf/open/floor/shiva{
+	icon_state = "bluefull"
+	},
+/area/shiva/interior/colony/s_admin)
+"rQ" = (
+/obj/effect/decal/cleanable/vomit{
+	icon_state = "vomit_4"
+	},
+/turf/open/floor/wood,
+/area/shiva/interior/colony/s_admin)
+"rT" = (
+/turf/open/auto_turf/snow/layer3,
+/area/shiva/exterior/junkyard/cp_bar)
+"sd" = (
+/obj/effect/landmark/corpsespawner/colonist,
+/obj/item/weapon/gun/pistol/holdout,
+/turf/open/floor/shiva{
+	icon_state = "bluefull"
+	},
+/area/shiva/interior/colony/s_admin)
+"sm" = (
+/obj/structure/machinery/vending/cigarette/colony,
+/turf/open/floor/shiva{
+	icon_state = "bluefull"
+	},
+/area/shiva/interior/colony/s_admin)
+"st" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/ammo_magazine/rifle/m16,
+/obj/item/ammo_magazine/rifle/m16{
+	pixel_x = 2
+	},
+/obj/item/ammo_magazine/rifle/m16{
+	pixel_x = 4
+	},
+/obj/item/ammo_magazine/rifle/m16{
+	pixel_x = 6
+	},
+/obj/item/ammo_magazine/rifle/m16{
+	pixel_x = 8
+	},
+/obj/item/ammo_magazine/rifle/m16{
+	pixel_x = 10
+	},
+/obj/item/ammo_magazine/rifle/m16{
+	pixel_x = -2
+	},
+/obj/item/ammo_magazine/rifle/m16{
+	pixel_x = -4
+	},
+/turf/open/floor/shiva{
+	icon_state = "bluefull"
+	},
+/area/shiva/interior/colony/s_admin)
+"sw" = (
+/obj/structure/flora/bush/snow,
+/turf/open/auto_turf/snow/layer2,
+/area/shiva/exterior/cp_lz2)
+"sB" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/structure/machinery/alarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/effect/landmark/crap_item,
+/turf/open/floor/shiva{
+	icon_state = "bluefull"
+	},
+/area/shiva/interior/colony/s_admin)
+"sK" = (
+/obj/item/lightstick/red{
+	anchored = 1;
+	icon_state = "lightstick_red1";
+	luminosity = 2
+	},
+/turf/open/auto_turf/snow/layer2,
+/area/shiva/exterior/junkyard/cp_bar)
+"sV" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/tool/weldpack,
+/obj/item/tool/weldingtool,
+/obj/item/clothing/glasses/welding,
+/turf/open/floor/shiva{
+	icon_state = "bluefull"
+	},
+/area/shiva/interior/colony/s_admin)
+"tx" = (
+/obj/structure/surface/table/reinforced/prison,
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/interior/colony/s_admin)
+"tF" = (
+/turf/open/auto_turf/snow/layer2,
+/area/shiva/exterior/cp_s_research)
+"uk" = (
+/obj/structure/surface/table/woodentable{
+	dir = 1;
+	flipped = 1
+	},
+/obj/item/tool/stamp,
+/obj/item/weapon/gun/rifle/lmg,
+/turf/open/floor/wood,
+/area/shiva/interior/colony/s_admin)
+"um" = (
+/obj/item/lightstick/red{
+	anchored = 1;
+	icon_state = "lightstick_red1";
+	luminosity = 2
+	},
+/turf/open/auto_turf/snow/layer2,
+/area/shiva/exterior/cp_lz2)
+"uq" = (
+/obj/item/ammo_casing/bullet,
+/obj/item/shard{
+	icon_state = "medium"
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/shiva/interior/colony/s_admin)
+"ux" = (
+/obj/effect/decal/cleanable/blood{
+	icon_state = "gib6";
+	tag = "icon-gib6"
+	},
+/obj/structure/barricade/plasteel/wired{
+	dir = 1;
+	icon_state = "plasteel_closed_1"
+	},
+/turf/open/floor/shiva{
+	icon_state = "floor3"
+	},
+/area/shiva/interior/colony/s_admin)
+"uK" = (
+/turf/open/auto_turf/snow/layer2,
+/area/shiva/exterior/junkyard/cp_bar)
+"uZ" = (
+/obj/structure/flora/tree/dead{
+	icon_state = "tree_6"
+	},
+/turf/open/auto_turf/snow/layer3,
+/area/shiva/exterior/cp_lz2)
+"vc" = (
+/obj/structure/bed/chair{
+	dir = 1;
+	tag = "icon-chair (NORTH)"
+	},
+/turf/open/floor/shiva{
+	icon_state = "bluefull"
+	},
+/area/shiva/interior/colony/s_admin)
+"vm" = (
+/obj/structure/pipes/standard/manifold/fourway/visible/supply,
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/shiva/interior/colony/s_admin)
+"vo" = (
+/obj/structure/surface/rack,
+/obj/item/ammo_magazine/shotgun/incendiary,
+/obj/item/ammo_magazine/shotgun/incendiary{
+	pixel_x = 3;
+	pixel_y = 6
+	},
+/obj/structure/machinery/light/double{
+	dir = 4;
+	pixel_y = -5
+	},
+/turf/open/floor/shiva{
+	icon_state = "floor3"
+	},
+/area/shiva/interior/colony/s_admin)
+"vK" = (
+/obj/structure/flora/tree/dead{
+	icon_state = "tree_4"
+	},
+/turf/open/auto_turf/snow/layer3,
+/area/shiva/exterior/cp_s_research)
+"vZ" = (
+/obj/item/ammo_casing/bullet,
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/shiva/interior/colony/s_admin)
+"wa" = (
+/obj/effect/landmark/corpsespawner/security,
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/interior/colony/s_admin)
+"wj" = (
+/turf/open/auto_turf/snow/layer0,
+/area/shiva/exterior/cp_lz2)
+"wu" = (
+/obj/structure/surface/rack,
+/obj/item/weapon/gun/smg/fp9000,
+/obj/item/weapon/gun/smg/fp9000,
+/obj/item/weapon/gun/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/turf/open/floor/shiva{
+	icon_state = "floor3"
+	},
+/area/shiva/interior/colony/s_admin)
+"wG" = (
+/obj/structure/machinery/light/double{
+	dir = 4;
+	pixel_y = -5
+	},
+/turf/open/floor/shiva{
+	icon_state = "bluefull"
+	},
+/area/shiva/interior/colony/s_admin)
+"wY" = (
+/obj/structure/machinery/power/apc{
+	dir = 1
+	},
+/turf/open/auto_turf/snow/layer2,
+/area/shiva/exterior/junkyard/cp_bar)
+"xh" = (
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_2";
+	dir = 1
+	},
+/obj/item/shard{
+	icon_state = "medium"
+	},
+/turf/open/floor/shiva{
+	icon_state = "bluefull"
+	},
+/area/shiva/interior/colony/s_admin)
+"xt" = (
+/turf/closed/wall/shiva/prefabricated,
+/area/shiva/interior/colony/s_admin)
+"yo" = (
+/obj/effect/spawner/random/attachment,
+/turf/open/floor/shiva{
+	dir = 8;
+	icon_state = "multi_tiles"
+	},
+/area/shiva/interior/colony/s_admin)
+"yq" = (
+/obj/structure/filingcabinet,
+/obj/item/paper/research_notes,
+/turf/open/floor/shiva{
+	icon_state = "floor3"
+	},
+/area/shiva/interior/colony/s_admin)
+"yw" = (
+/obj/structure/machinery/optable,
+/obj/item/clothing/mask/breath/medical,
+/obj/item/tank/anesthetic,
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/shiva/interior/colony/s_admin)
+"yS" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/stack/sheet/wood/large_stack,
+/obj/item/stack/sheet/wood/large_stack{
+	pixel_y = 12;
+	pixel_x = -6
+	},
+/turf/open/floor/shiva{
+	icon_state = "bluefull"
+	},
+/area/shiva/interior/colony/s_admin)
+"yZ" = (
+/obj/structure/surface/table/woodentable,
+/obj/item/paper_bin,
+/obj/item/tool/stamp,
+/turf/open/floor/wood,
+/area/shiva/interior/colony/s_admin)
+"zf" = (
+/obj/item/clothing/accessory/storage/webbing,
+/obj/item/clothing/accessory/storage/webbing,
+/obj/structure/machinery/light/small{
+	dir = 1;
+	pixel_y = 20
+	},
+/obj/structure/surface/table/reinforced/prison,
+/turf/open/floor/shiva{
+	icon_state = "bluefull"
+	},
+/area/shiva/interior/colony/s_admin)
+"zm" = (
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/interior/colony/s_admin)
+"zI" = (
+/obj/structure/barricade/plasteel/wired{
+	dir = 1;
+	icon_state = "plasteel_closed_1"
+	},
+/turf/open/floor/shiva{
+	icon_state = "floor3"
+	},
+/area/shiva/interior/colony/s_admin)
+"zJ" = (
+/obj/structure/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/open/floor/shiva{
+	icon_state = "bluefull"
+	},
+/area/shiva/interior/colony/s_admin)
+"zU" = (
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1";
+	dir = 1
+	},
+/obj/item/shard{
+	icon_state = "medium";
+	name = "ice shard"
+	},
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/interior/colony/s_admin)
+"zY" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/stack/sheet/metal{
+	amount = 5;
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/stack/sheet/metal{
+	amount = 5;
+	pixel_y = 1
+	},
+/obj/item/stack/sheet/plasteel{
+	pixel_x = 7;
+	pixel_y = 11
+	},
+/obj/item/clothing/glasses/welding,
+/turf/open/floor/shiva{
+	icon_state = "bluefull"
+	},
+/area/shiva/interior/colony/s_admin)
+"Ag" = (
+/obj/structure/machinery/cm_vending/sorted/medical/no_access,
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/shiva/interior/colony/s_admin)
+"Ap" = (
+/obj/effect/decal/cleanable/blood/oil/streak,
+/turf/open/floor/shiva{
+	dir = 8;
+	icon_state = "multi_tiles"
+	},
+/area/shiva/interior/colony/s_admin)
+"At" = (
+/obj/effect/landmark/corpsespawner/security,
+/obj/item/weapon/gun/shotgun/pump/cmb,
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/shiva/interior/colony/s_admin)
+"AH" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/reagent_container/food/drinks/cans/ale{
+	pixel_x = -7;
+	pixel_y = 3
+	},
+/obj/item/reagent_container/food/drinks/cans/ale{
+	pixel_y = 10
+	},
+/obj/item/reagent_container/food/drinks/cans/ale{
+	pixel_x = 7;
+	pixel_y = 4
+	},
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/interior/colony/s_admin)
+"AL" = (
+/obj/structure/stairs/perspective{
+	dir = 4;
+	icon_state = "p_stair_sn_full_cap"
+	},
+/turf/open/floor/shiva{
+	dir = 6;
+	icon_state = "multi_tiles"
+	},
+/area/shiva/interior/bar)
+"By" = (
+/turf/open/auto_turf/snow/layer4,
+/area/shiva/exterior/junkyard/cp_bar)
+"BG" = (
+/obj/item/ammo_casing/bullet,
+/obj/item/shard{
+	icon_state = "medium"
+	},
+/obj/effect/decal/cleanable/blood{
+	layer = 3
+	},
+/turf/open/floor/shiva{
+	icon_state = "bluefull"
+	},
+/area/shiva/interior/colony/s_admin)
+"BU" = (
+/obj/effect/decal/cleanable/blood/oil/streak,
+/obj/structure/barricade/plasteel/wired{
+	icon_state = "plasteel_3";
+	dir = 1
+	},
+/turf/open/floor/shiva{
+	dir = 8;
+	icon_state = "multi_tiles"
+	},
+/area/shiva/interior/colony/s_admin)
+"BY" = (
+/obj/structure/bed/chair,
+/turf/open/floor/shiva{
+	icon_state = "bluefull"
+	},
+/area/shiva/interior/colony/s_admin)
+"CN" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/shiva{
+	dir = 6;
+	icon_state = "multi_tiles"
+	},
+/area/shiva/interior/colony/s_admin)
+"CU" = (
+/obj/item/weapon/gun/energy/taser,
+/obj/structure/machinery/light/double{
+	dir = 8;
+	pixel_y = -5
+	},
+/turf/open/floor/wood,
+/area/shiva/interior/colony/s_admin)
+"CX" = (
+/obj/structure/bed/chair{
+	dir = 1;
+	tag = "icon-chair (NORTH)"
+	},
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/interior/colony/s_admin)
+"DI" = (
+/obj/effect/decal/cleanable/blood{
+	layer = 3
+	},
+/turf/open/floor/shiva{
+	dir = 6;
+	icon_state = "multi_tiles"
+	},
+/area/shiva/interior/colony/s_admin)
+"DM" = (
+/turf/open/auto_turf/snow/layer3,
+/area/shiva/exterior/cp_s_research)
+"Ed" = (
+/obj/effect/decal/cleanable/blood{
+	icon_state = "xgibdown1";
+	tag = "icon-xgibdown1"
+	},
+/obj/structure/machinery/light/double,
+/turf/open/floor/shiva{
+	icon_state = "bluefull"
+	},
+/area/shiva/interior/colony/s_admin)
+"Ey" = (
+/obj/item/shard{
+	icon_state = "medium"
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/shiva/interior/colony/s_admin)
+"EV" = (
+/turf/open/auto_turf/snow/layer1,
+/area/shiva/exterior/cp_lz2)
+"Fh" = (
+/obj/structure/machinery/disposal,
+/turf/open/floor/shiva{
+	icon_state = "floor3"
+	},
+/area/shiva/interior/colony/s_admin)
+"Fj" = (
+/obj/structure/machinery/power/apc{
+	dir = 8
+	},
+/obj/structure/machinery/power/terminal,
+/turf/open/floor/shiva{
+	icon_state = "bluefull"
+	},
+/area/shiva/interior/colony/s_admin)
+"Fq" = (
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1";
+	dir = 1
+	},
+/obj/item/shard{
+	icon_state = "medium";
+	name = "ice shard"
+	},
+/turf/open/floor/shiva{
+	icon_state = "bluefull"
+	},
+/area/shiva/interior/colony/s_admin)
+"Fw" = (
+/obj/structure/machinery/light/double,
+/turf/open/floor/shiva{
+	icon_state = "floor3"
+	},
+/area/shiva/interior/colony/s_admin)
+"FI" = (
+/obj/structure/safe,
+/obj/item/spacecash/c1000{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/obj/item/spacecash/c1000,
+/obj/item/spacecash/c500,
+/obj/effect/landmark/good_item,
+/obj/item/storage/pill_bottle/ultrazine/skillless,
+/turf/open/floor/shiva{
+	dir = 8;
+	icon_state = "redfull"
+	},
+/area/shiva/interior/colony/s_admin)
+"FM" = (
+/turf/open/floor{
+	dir = 8;
+	icon_state = "damaged3"
+	},
+/area/shiva/interior/colony/s_admin)
+"GH" = (
+/obj/structure/machinery/light/double{
+	dir = 8;
+	pixel_y = -5
+	},
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/interior/colony/s_admin)
+"GJ" = (
+/obj/effect/landmark/corpsespawner/engineer,
+/obj/item/weapon/gun/pistol/holdout,
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/interior/colony/s_admin)
+"GO" = (
+/obj/structure/filingcabinet,
+/turf/open/floor/shiva{
+	icon_state = "floor3"
+	},
+/area/shiva/interior/colony/s_admin)
+"GV" = (
+/obj/item/lightstick/red/variant/planted,
+/turf/open/auto_turf/snow/layer2,
+/area/shiva/exterior/junkyard/cp_bar)
+"Hj" = (
+/obj/structure/machinery/light/double{
+	dir = 1;
+	pixel_y = 9
+	},
+/turf/open/floor/shiva{
+	icon_state = "bluefull"
+	},
+/area/shiva/interior/colony/s_admin)
+"Hm" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/ammo_magazine/rifle/mar40/lmg{
+	pixel_y = -9
+	},
+/obj/item/ammo_magazine/rifle/mar40/lmg{
+	pixel_y = 8;
+	pixel_x = -8
+	},
+/obj/item/ammo_magazine/rifle/mar40/lmg{
+	pixel_y = 8;
+	pixel_x = 8
+	},
+/obj/item/ammo_magazine/rifle/mar40/lmg{
+	pixel_y = -2;
+	pixel_x = 8
+	},
+/obj/item/ammo_magazine/rifle/mar40/lmg,
+/turf/open/floor/shiva{
+	icon_state = "bluefull"
+	},
+/area/shiva/interior/colony/s_admin)
+"Ho" = (
+/obj/structure/machinery/alarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/effect/decal/cleanable/blood{
+	layer = 3
+	},
+/obj/effect/landmark/corpsespawner/security,
+/turf/open/floor/wood,
+/area/shiva/interior/colony/s_admin)
+"Hr" = (
+/turf/open/floor/shiva{
+	icon_state = "bluefull"
+	},
+/area/shiva/interior/colony/s_admin)
+"Ht" = (
+/turf/open/auto_turf/ice/layer1,
+/area/shiva/exterior/cp_lz2)
+"Hz" = (
+/obj/structure/machinery/door/poddoor/shutters/almayer{
+	name = "\improper Panic Room Shutters"
+	},
+/turf/open/floor/shiva,
+/area/shiva/interior/colony/s_admin)
+"Il" = (
+/obj/structure/filingcabinet,
+/turf/open/floor/shiva{
+	icon_state = "bluefull"
+	},
+/area/shiva/interior/colony/s_admin)
+"Iq" = (
+/turf/closed/wall/shiva/prefabricated/reinforced,
+/area/shiva/interior/bar)
+"IG" = (
+/obj/structure/surface/table/woodentable,
+/obj/item/device/flashlight/lamp,
+/obj/item/tool/pen/blue{
+	pixel_x = 5
+	},
+/turf/open/floor/shiva{
+	icon_state = "floor3"
+	},
+/area/shiva/interior/colony/s_admin)
+"IU" = (
+/obj/effect/decal/cleanable/blood{
+	icon_state = "gib6";
+	tag = "icon-gib6"
+	},
+/obj/item/shard{
+	icon_state = "medium"
+	},
+/turf/open/floor/plating,
+/area/shiva/interior/colony/s_admin)
+"Jd" = (
+/obj/structure/largecrate/random/case,
+/turf/open/auto_turf/snow/layer3,
+/area/shiva/exterior/junkyard/cp_bar)
+"Jk" = (
+/obj/structure/bed/chair,
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1";
+	dir = 1
+	},
+/obj/item/shard{
+	icon_state = "large";
+	name = "ice shard"
+	},
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/interior/colony/s_admin)
+"Jl" = (
+/turf/open/floor/shiva{
+	dir = 8;
+	icon_state = "redfull"
+	},
+/area/shiva/interior/colony/s_admin)
+"Jn" = (
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/interior/colony/s_admin)
+"JD" = (
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/interior/colony/s_admin)
+"JI" = (
+/obj/structure/flora/bush/snow{
+	icon_state = "snowgrassall_3"
+	},
+/turf/open/auto_turf/snow/layer2,
+/area/shiva/exterior/cp_lz2)
+"JV" = (
+/turf/open/auto_turf/snow/layer2,
+/area/shiva/exterior/cp_lz2)
+"Kk" = (
+/obj/item/shard{
+	icon_state = "medium"
+	},
+/obj/effect/landmark/corpsespawner/security,
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1";
+	dir = 1
+	},
+/obj/item/shard{
+	icon_state = "large"
+	},
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/interior/colony/s_admin)
+"Kr" = (
+/obj/structure/closet/secure_closet/personal,
+/obj/effect/landmark/good_item,
+/turf/open/floor/shiva{
+	icon_state = "floor3"
+	},
+/area/shiva/interior/colony/s_admin)
+"Kv" = (
+/obj/structure/machinery/power/port_gen/pacman/mrs,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/shiva/interior/colony/s_admin)
+"KP" = (
+/obj/structure/machinery/light/double{
+	dir = 4;
+	pixel_y = -5
+	},
+/obj/structure/machinery/vending/coffee,
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/interior/colony/s_admin)
+"Lr" = (
+/turf/open/auto_turf/snow/layer4,
+/area/shiva/exterior/cp_s_research)
+"Lw" = (
+/obj/structure/bed/chair/comfy/orange{
+	dir = 1
+	},
+/obj/item/paper_bin,
+/obj/structure/machinery/light/double,
+/turf/open/floor/shiva{
+	icon_state = "floor3"
+	},
+/area/shiva/interior/colony/s_admin)
+"LV" = (
+/obj/structure/flora/bush/snow{
+	icon_state = "snowgrassgb_2"
+	},
+/turf/open/auto_turf/snow/layer1,
+/area/shiva/exterior/cp_lz2)
+"Ml" = (
+/obj/structure/largecrate/random/barrel/red,
+/turf/open/auto_turf/snow/layer2,
+/area/shiva/exterior/junkyard/cp_bar)
+"Mo" = (
+/turf/open/floor/shiva{
+	icon_state = "floor3"
+	},
+/area/shiva/interior/colony/s_admin)
+"Mv" = (
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_2";
+	dir = 1
+	},
+/obj/item/shard{
+	icon_state = "large"
+	},
+/turf/open/floor/shiva{
+	icon_state = "bluefull"
+	},
+/area/shiva/interior/colony/s_admin)
+"MQ" = (
+/obj/structure/barricade/sandbags,
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/interior/colony/s_admin)
+"MT" = (
+/turf/open/floor/shiva{
+	dir = 8;
+	icon_state = "multi_tiles"
+	},
+/area/shiva/interior/colony/s_admin)
+"Nd" = (
+/obj/structure/barricade/sandbags{
+	dir = 4
+	},
+/obj/structure/barricade/sandbags,
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/interior/colony/s_admin)
+"Nt" = (
+/obj/item/stack/rods,
+/obj/structure/window_frame/colony/reinforced,
+/turf/open/floor/plating,
+/area/shiva/interior/colony/s_admin)
+"Nv" = (
+/obj/effect/decal/cleanable/blood/drip,
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1";
+	dir = 1
+	},
+/turf/open/floor/shiva{
+	icon_state = "floor3"
+	},
+/area/shiva/interior/colony/s_admin)
+"NB" = (
+/obj/effect/decal/cleanable/blood/drip,
+/obj/structure/bed/chair,
+/turf/open/floor/shiva{
+	icon_state = "bluefull"
+	},
+/area/shiva/interior/colony/s_admin)
+"NP" = (
+/obj/effect/decal/cleanable/blood{
+	layer = 3
+	},
+/obj/structure/bed/chair,
+/turf/open/floor/shiva{
+	icon_state = "bluefull"
+	},
+/area/shiva/interior/colony/s_admin)
+"NY" = (
+/obj/item/ammo_casing/bullet,
+/obj/effect/spawner/random/attachment,
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/interior/colony/s_admin)
+"OB" = (
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/decal/cleanable/blood/drip{
+	icon_state = "3";
+	tag = "icon-3"
+	},
+/turf/open/floor/shiva{
+	icon_state = "floor3"
+	},
+/area/shiva/interior/colony/s_admin)
+"OH" = (
+/obj/item/shard{
+	icon_state = "medium"
+	},
+/turf/open/floor/shiva{
+	icon_state = "bluefull"
+	},
+/area/shiva/interior/colony/s_admin)
+"OT" = (
+/obj/structure/bed/chair/office/light{
+	dir = 4;
+	tag = "icon-officechair_white (EAST)"
+	},
+/turf/open/floor/wood,
+/area/shiva/interior/colony/s_admin)
+"Pi" = (
+/obj/structure/flora/bush/ausbushes/lavendergrass,
+/turf/open/auto_turf/snow/layer2,
+/area/shiva/exterior/junkyard/cp_bar)
+"PF" = (
+/obj/structure/machinery/alarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/item/device/flashlight/lamp,
+/turf/open/floor/shiva{
+	icon_state = "floor3"
+	},
+/area/shiva/interior/colony/s_admin)
+"PH" = (
+/obj/item/reagent_container/food/drinks/cans/ale{
+	pixel_x = -7;
+	pixel_y = 3
+	},
+/obj/effect/decal/cleanable/vomit{
+	icon_state = "vomit_2"
+	},
+/turf/open/floor/wood,
+/area/shiva/interior/colony/s_admin)
+"PJ" = (
+/obj/structure/machinery/alarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/structure/machinery/power/smes/batteryrack,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/shiva/interior/colony/s_admin)
+"Qk" = (
+/turf/closed/wall/shiva/prefabricated/reinforced,
+/area/shiva/interior/colony/s_admin)
+"Qt" = (
+/obj/item/weapon/gun/rifle/m16,
+/obj/item/weapon/gun/rifle/m16{
+	pixel_x = 5;
+	pixel_y = 6
+	},
+/obj/structure/surface/rack,
+/turf/open/floor/shiva{
+	icon_state = "bluefull"
+	},
+/area/shiva/interior/colony/s_admin)
+"Qw" = (
+/obj/item/ammo_casing/bullet,
+/obj/structure/barricade/plasteel/wired{
+	icon_state = "plasteel_3";
+	dir = 1
+	},
+/turf/open/floor/shiva{
+	dir = 8;
+	icon_state = "multi_tiles"
+	},
+/area/shiva/interior/colony/s_admin)
+"QC" = (
+/obj/structure/window_frame/colony/reinforced,
+/obj/item/stack/rods,
+/obj/item/stack/rods,
+/turf/open/floor/plating,
+/area/shiva/interior/colony/s_admin)
+"QE" = (
+/obj/structure/machinery/light/double{
+	dir = 8;
+	pixel_y = -5
+	},
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/open/floor/shiva{
+	icon_state = "bluefull"
+	},
+/area/shiva/interior/colony/s_admin)
+"QG" = (
+/obj/effect/spawner/random/attachment,
+/turf/open/floor/shiva{
+	icon_state = "floor3"
+	},
+/area/shiva/interior/colony/s_admin)
+"QZ" = (
+/obj/structure/bed/chair/comfy/orange{
+	dir = 1
+	},
+/turf/open/floor/shiva{
+	icon_state = "floor3"
+	},
+/area/shiva/interior/colony/s_admin)
+"Rf" = (
+/obj/item/shard{
+	icon_state = "medium"
+	},
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1";
+	dir = 1
+	},
+/obj/effect/landmark/corpsespawner/security,
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/interior/colony/s_admin)
+"Rl" = (
+/obj/structure/surface/table/woodentable{
+	dir = 1;
+	flipped = 1
+	},
+/turf/open/floor/shiva{
+	icon_state = "floor3"
+	},
+/area/shiva/interior/colony/s_admin)
+"Ro" = (
+/obj/structure/flora/tree/dead{
+	icon_state = "tree_5"
+	},
+/turf/open/auto_turf/snow/layer2,
+/area/shiva/exterior/cp_lz2)
+"RD" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/weapon/melee/twohanded/fireaxe,
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/interior/colony/s_admin)
+"RN" = (
+/obj/structure/machinery/alarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/turf/open/floor/shiva{
+	icon_state = "floor3"
+	},
+/area/shiva/interior/colony/s_admin)
+"RR" = (
+/obj/item/shard{
+	icon_state = "large"
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/shiva/interior/colony/s_admin)
+"RV" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/paper_bin,
+/obj/item/tool/stamp,
+/obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
+/obj/structure/window/reinforced/tinted{
+	dir = 4
+	},
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/interior/colony/s_admin)
+"Sc" = (
+/obj/item/tool/pen/blue{
+	pixel_x = 5
+	},
+/turf/open/floor/wood,
+/area/shiva/interior/colony/s_admin)
+"Sg" = (
+/obj/structure/pipes/standard/simple/hidden/supply,
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/shiva/interior/colony/s_admin)
+"Su" = (
+/obj/effect/decal/cleanable/blood{
+	layer = 3
+	},
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/interior/colony/s_admin)
+"SA" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/storage/surgical_tray{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/turf/open/floor{
+	dir = 8;
+	icon_state = "damaged3"
+	},
+/area/shiva/interior/colony/s_admin)
+"SC" = (
+/obj/structure/surface/rack,
+/obj/item/weapon/gun/shotgun/pump/cmb{
+	pixel_y = -3
+	},
+/obj/item/weapon/gun/shotgun/pump/cmb{
+	pixel_y = 3
+	},
+/obj/item/weapon/gun/shotgun/pump/cmb{
+	pixel_y = 9
+	},
+/turf/open/floor/shiva{
+	icon_state = "bluefull"
+	},
+/area/shiva/interior/colony/s_admin)
+"SE" = (
+/turf/closed/wall/shiva/ice,
+/area/shiva/interior/colony/s_admin)
+"SI" = (
+/obj/structure/machinery/computer/security/wooden_tv{
+	pixel_y = 7
+	},
+/obj/structure/surface/table/reinforced/prison,
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/interior/colony/s_admin)
+"SN" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/ammo_magazine/rifle/m16/ap,
+/obj/item/ammo_magazine/rifle/m16/ap{
+	pixel_x = -2
+	},
+/obj/item/ammo_magazine/rifle/m16/ap{
+	pixel_x = -4
+	},
+/obj/item/ammo_magazine/rifle/m16/ap{
+	pixel_x = -6
+	},
+/obj/item/ammo_magazine/rifle/m16/ap{
+	pixel_x = -8
+	},
+/obj/item/weapon/melee/throwing_knife{
+	pixel_x = 18;
+	pixel_y = 9
+	},
+/obj/item/weapon/melee/throwing_knife{
+	pixel_x = 18;
+	pixel_y = 6
+	},
+/turf/open/floor/shiva{
+	icon_state = "bluefull"
+	},
+/area/shiva/interior/colony/s_admin)
+"Tf" = (
+/turf/open/floor/shiva{
+	dir = 6;
+	icon_state = "multi_tiles"
+	},
+/area/shiva/interior/colony/s_admin)
+"Ue" = (
+/obj/item/stack/sandbags,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/shiva/interior/colony/s_admin)
+"Un" = (
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/shiva/interior/colony/s_admin)
+"Uy" = (
+/obj/structure/machinery/light/double{
+	dir = 8;
+	pixel_y = -5
+	},
+/turf/open/floor/shiva{
+	icon_state = "floor3"
+	},
+/area/shiva/interior/colony/s_admin)
+"UL" = (
+/obj/structure/flora/bush/snow{
+	icon_state = "snowgrassall_3"
+	},
+/turf/open/auto_turf/snow/layer3,
+/area/shiva/exterior/cp_s_research)
+"UM" = (
+/obj/structure/machinery/door/poddoor/shutters/almayer{
+	name = "\improper Panic Room Shutters"
+	},
+/turf/open/floor/shiva{
+	icon_state = "floor3"
+	},
+/area/shiva/interior/colony/s_admin)
+"Vc" = (
+/obj/effect/landmark/corpsespawner/security,
+/turf/open/floor/shiva{
+	dir = 8;
+	icon_state = "multi_tiles"
+	},
+/area/shiva/interior/colony/s_admin)
+"Ve" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/paper_bin,
+/obj/item/tool/pen,
+/turf/open/floor/shiva{
+	icon_state = "floor3"
+	},
+/area/shiva/interior/colony/s_admin)
+"Vo" = (
+/obj/structure/largecrate/random/case/small,
+/turf/open/auto_turf/snow/layer2,
+/area/shiva/exterior/junkyard/cp_bar)
+"VF" = (
+/obj/item/shard{
+	icon_state = "medium"
+	},
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/shiva/interior/colony/s_admin)
+"VP" = (
+/obj/effect/landmark/corpsespawner/chef,
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/interior/colony/s_admin)
+"VY" = (
+/obj/structure/sign/poster/clf,
+/turf/closed/wall/shiva/prefabricated/reinforced,
+/area/shiva/interior/colony/s_admin)
+"Wl" = (
+/obj/structure/stairs/perspective{
+	icon_state = "p_stair_full"
+	},
+/turf/open/floor/shiva{
+	dir = 6;
+	icon_state = "multi_tiles"
+	},
+/area/shiva/interior/bar)
+"Wo" = (
+/obj/structure/flora/bush/snow{
+	icon_state = "snowgrassall_1"
+	},
+/turf/open/auto_turf/snow/layer3,
+/area/shiva/exterior/cp_s_research)
+"WC" = (
+/obj/structure/machinery/light/double{
+	dir = 1;
+	pixel_y = 9
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/shiva/interior/colony/s_admin)
+"WP" = (
+/obj/item/stack/sandbags,
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/shiva/interior/colony/s_admin)
+"XJ" = (
+/obj/effect/spawner/random/attachment,
+/turf/open/floor/shiva{
+	dir = 6;
+	icon_state = "multi_tiles"
+	},
+/area/shiva/interior/colony/s_admin)
+"XL" = (
+/obj/structure/closet/secure_closet/personal,
+/turf/open/floor/shiva{
+	icon_state = "floor3"
+	},
+/area/shiva/interior/colony/s_admin)
+"Yo" = (
+/obj/effect/landmark/corpsespawner/chef,
+/obj/item/ammo_casing/bullet,
+/obj/item/weapon/gun/pistol/m4a3,
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/interior/colony/s_admin)
+"YL" = (
+/obj/effect/landmark/corpsespawner/security,
+/obj/item/weapon/gun/revolver/m44,
+/obj/effect/spawner/random/attachment,
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/shiva/interior/colony/s_admin)
+"Zc" = (
+/obj/structure/bed/chair{
+	dir = 8;
+	tag = "icon-chair (WEST)"
+	},
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/interior/colony/s_admin)
+"Zk" = (
+/obj/structure/machinery/vending/cigarette/colony,
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/interior/colony/s_admin)
+"Zz" = (
+/obj/effect/landmark/corpsespawner/security,
+/obj/item/weapon/gun/shotgun/pump/cmb,
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/interior/colony/s_admin)
+
+(1,1,1) = {"
+xt
+JV
+JV
+EV
+wj
+JI
+qZ
+Ht
+Ht
+qZ
+qZ
+qZ
+rp
+qZ
+EV
+qZ
+qZ
+hM
+DM
+DM
+"}
+(2,1,1) = {"
+xt
+SE
+um
+EV
+wj
+EV
+JV
+qZ
+qZ
+qZ
+Ht
+qZ
+qZ
+qZ
+qZ
+EV
+qZ
+DM
+DM
+Wo
+"}
+(3,1,1) = {"
+xt
+SE
+JV
+EV
+wj
+EV
+EV
+JV
+qQ
+qZ
+qZ
+qZ
+qZ
+qZ
+qZ
+EV
+EV
+Lr
+vK
+Lr
+"}
+(4,1,1) = {"
+Qk
+SE
+JV
+Ro
+EV
+wj
+wj
+EV
+EV
+JV
+JV
+JV
+qZ
+qZ
+qZ
+EV
+EV
+DM
+Lr
+DM
+"}
+(5,1,1) = {"
+Qk
+SE
+SE
+sw
+rp
+rp
+rp
+qZ
+JV
+EV
+EV
+LV
+qZ
+uZ
+EV
+EV
+wj
+hw
+DM
+DM
+"}
+(6,1,1) = {"
+Qk
+SE
+SE
+SE
+SE
+SE
+SE
+rp
+rp
+SE
+SE
+Qk
+Qk
+Qk
+Qk
+Qk
+Qk
+hw
+hw
+DM
+"}
+(7,1,1) = {"
+Qk
+SE
+SE
+SE
+SE
+SE
+SE
+SE
+SE
+SE
+Qk
+Qk
+Ag
+hv
+dg
+SA
+Qk
+tF
+tF
+tF
+"}
+(8,1,1) = {"
+Qk
+SE
+SE
+SE
+SE
+SE
+SE
+SE
+SE
+SE
+Qk
+FI
+Mo
+Un
+Un
+yw
+Qk
+DM
+Wo
+hw
+"}
+(9,1,1) = {"
+Qk
+Qk
+Qk
+Qk
+Qk
+Qk
+Qk
+VY
+Qk
+Qk
+Qk
+Qk
+Ve
+QG
+Un
+dh
+Qk
+UL
+DM
+DM
+"}
+(10,1,1) = {"
+xt
+Hr
+Il
+QE
+sB
+kY
+Fj
+Kv
+PJ
+fv
+av
+VY
+kr
+Jl
+Jl
+cR
+Qk
+Qk
+Qk
+DM
+"}
+(11,1,1) = {"
+jl
+Hr
+JD
+JD
+JD
+aQ
+At
+FM
+VF
+bF
+Hr
+Qk
+Mo
+Mo
+Mo
+Mo
+Uy
+Mo
+Qk
+tF
+"}
+(12,1,1) = {"
+pC
+oZ
+VP
+tx
+Yo
+RR
+vZ
+Un
+Sg
+il
+Hr
+Qk
+Mo
+BY
+rP
+SN
+vc
+QG
+VY
+DM
+"}
+(13,1,1) = {"
+pC
+Mv
+NY
+tx
+JD
+il
+bN
+Un
+WP
+WP
+hO
+VY
+OB
+NB
+Hm
+st
+vc
+Mo
+Qk
+tF
+"}
+(14,1,1) = {"
+jl
+Hj
+JD
+JD
+JD
+Hr
+Hr
+WP
+FM
+Un
+Hr
+pL
+bv
+BY
+sm
+Qt
+vc
+Mo
+Qk
+tF
+"}
+(15,1,1) = {"
+pC
+Fq
+JD
+JD
+JD
+Hr
+iB
+il
+Ue
+mE
+Ey
+pL
+zI
+Hr
+fg
+Hr
+Hr
+Mo
+VY
+tF
+"}
+(16,1,1) = {"
+QC
+xh
+Su
+pR
+vm
+aQ
+Hr
+JD
+MQ
+ag
+ak
+IU
+ux
+Hr
+Hr
+Hr
+Hr
+Mo
+Qk
+tF
+"}
+(17,1,1) = {"
+jl
+WC
+Ey
+Un
+YL
+BG
+Hr
+JD
+MQ
+Zz
+OH
+pL
+Nv
+NP
+zf
+sV
+Hr
+Qk
+Qk
+Iq
+"}
+(18,1,1) = {"
+pC
+cC
+FM
+Un
+Ey
+Hr
+Hr
+JD
+Nd
+ny
+Ed
+VY
+go
+Hr
+aC
+yS
+Hr
+Mo
+UM
+cL
+"}
+(19,1,1) = {"
+pC
+nT
+uq
+il
+JD
+Hr
+Hr
+JD
+JD
+JD
+Hr
+Qk
+Mo
+Hr
+SC
+zY
+Hr
+Hr
+Hz
+Wl
+"}
+(20,1,1) = {"
+jl
+Hr
+Su
+NY
+JD
+sd
+Hr
+Jn
+GJ
+JD
+Hr
+Qk
+QG
+Hr
+Hr
+Hr
+Hr
+cZ
+Hz
+Wl
+"}
+(21,1,1) = {"
+xt
+Hr
+Hr
+wG
+Hr
+zJ
+Hr
+kb
+Hr
+fg
+Hr
+VY
+Mo
+Hr
+Hr
+Hr
+fg
+Hr
+Hz
+Wl
+"}
+(22,1,1) = {"
+Qk
+xt
+xt
+xt
+jl
+xt
+Qk
+ff
+Tf
+Tf
+JD
+Qk
+nk
+hi
+vo
+wu
+gS
+Mo
+UM
+AL
+"}
+(23,1,1) = {"
+xt
+iG
+Ho
+CU
+rQ
+AH
+xt
+jS
+gr
+gr
+jS
+Qk
+xt
+xt
+xt
+xt
+Qk
+Qk
+Qk
+Iq
+"}
+(24,1,1) = {"
+xt
+SI
+PH
+rM
+rM
+RD
+jl
+zm
+CN
+Tf
+JD
+xt
+XL
+PF
+Rl
+mc
+xt
+Ml
+uK
+jE
+"}
+(25,1,1) = {"
+xt
+kT
+kL
+hn
+OT
+fP
+xt
+qT
+Tf
+Tf
+JD
+ex
+rM
+Sc
+uk
+Lw
+xt
+rT
+uK
+uK
+"}
+(26,1,1) = {"
+Qk
+VY
+je
+Qk
+aI
+RV
+Qk
+hb
+Tf
+Tf
+JD
+xt
+Fh
+rq
+yq
+GO
+xt
+Vo
+uK
+uK
+"}
+(27,1,1) = {"
+Nt
+Rf
+Jn
+GH
+JD
+JD
+qO
+Kk
+DI
+XJ
+JD
+VY
+xt
+xt
+xt
+xt
+Qk
+bR
+sK
+jE
+"}
+(28,1,1) = {"
+kU
+BU
+Ap
+MT
+MT
+MT
+kO
+Qw
+gr
+gr
+JD
+xt
+Kr
+RN
+IG
+is
+xt
+Jd
+uK
+jE
+"}
+(29,1,1) = {"
+Su
+mh
+Vc
+yo
+aj
+MT
+JD
+dT
+gr
+gr
+JD
+xt
+iv
+rM
+yZ
+QZ
+xt
+rT
+uK
+uK
+"}
+(30,1,1) = {"
+pC
+Jk
+JD
+JD
+JD
+CX
+pC
+zU
+Su
+wa
+Su
+ex
+rM
+rM
+rM
+Fw
+xt
+rT
+uK
+Pi
+"}
+(31,1,1) = {"
+xt
+Zk
+Zc
+nJ
+Zc
+jS
+xt
+ad
+nD
+KP
+Zk
+xt
+Fh
+Mo
+GO
+GO
+xt
+wY
+uK
+uK
+"}
+(32,1,1) = {"
+xt
+xt
+xt
+xt
+xt
+xt
+xt
+xt
+xt
+xt
+Qk
+Qk
+Qk
+Qk
+xt
+xt
+Qk
+rT
+uK
+jE
+"}
+(33,1,1) = {"
+xt
+xt
+xt
+uK
+By
+By
+By
+rT
+rT
+uK
+nC
+nC
+nC
+nC
+uK
+GV
+uK
+uK
+jE
+jE
+"}
+(34,1,1) = {"
+xt
+xt
+xt
+uK
+rT
+jE
+jE
+uK
+rT
+rT
+nC
+nC
+nC
+jE
+uK
+jE
+jE
+jE
+jE
+nX
+"}
+(35,1,1) = {"
+xt
+aY
+jE
+jE
+jE
+nC
+jE
+jE
+uK
+uK
+nC
+nC
+jE
+nX
+nX
+nX
+nX
+nX
+nX
+nX
+"}

--- a/maps/map_files/Ice_Colony_v3/sprinkles/25.shivaclf01.dmm
+++ b/maps/map_files/Ice_Colony_v3/sprinkles/25.shivaclf01.dmm
@@ -389,10 +389,6 @@
 	dir = 1
 	},
 /area/shiva/interior/colony/s_admin)
-"jl" = (
-/obj/structure/sign/poster/clf,
-/turf/closed/wall/shiva/prefabricated,
-/area/shiva/interior/colony/s_admin)
 "jE" = (
 /turf/open/auto_turf/snow/layer1,
 /area/shiva/exterior/junkyard/cp_bar)
@@ -1151,8 +1147,8 @@
 	dir = 8
 	},
 /obj/structure/machinery/power/terminal,
-/turf/open/floor/shiva{
-	icon_state = "bluefull"
+/turf/open/floor{
+	icon_state = "platingdmg1"
 	},
 /area/shiva/interior/colony/s_admin)
 "Fq" = (
@@ -1377,6 +1373,7 @@
 /area/shiva/interior/colony/s_admin)
 "Kv" = (
 /obj/structure/machinery/power/port_gen/pacman/mrs,
+/obj/item/stack/sheet/mineral/phoron/medium_stack,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -2144,7 +2141,7 @@ DM
 DM
 "}
 (10,1,1) = {"
-xt
+Qk
 Hr
 Il
 QE
@@ -2166,7 +2163,7 @@ Qk
 DM
 "}
 (11,1,1) = {"
-jl
+VY
 Hr
 iM
 JD
@@ -2232,7 +2229,7 @@ Qk
 tF
 "}
 (14,1,1) = {"
-jl
+VY
 Hj
 iM
 JD
@@ -2298,7 +2295,7 @@ Qk
 tF
 "}
 (17,1,1) = {"
-jl
+VY
 WC
 Ey
 Un
@@ -2364,7 +2361,7 @@ Hz
 Wl
 "}
 (20,1,1) = {"
-jl
+VY
 Hr
 Su
 NY
@@ -2386,7 +2383,7 @@ Hz
 Wl
 "}
 (21,1,1) = {"
-xt
+Qk
 Hr
 Hr
 wG
@@ -2409,11 +2406,11 @@ Wl
 "}
 (22,1,1) = {"
 Qk
-xt
-xt
-xt
-jl
-xt
+Qk
+Qk
+Qk
+VY
+Qk
 Qk
 ff
 Tf
@@ -2430,57 +2427,57 @@ UM
 AL
 "}
 (23,1,1) = {"
-xt
+Qk
 iG
 Ho
 CU
 rQ
 AH
-xt
+Qk
 jS
 gr
 gr
 jS
 Qk
-xt
-xt
-xt
-xt
+Qk
+Qk
+Qk
+Qk
 Qk
 Qk
 Qk
 Iq
 "}
 (24,1,1) = {"
-xt
+Qk
 SI
 PH
 rM
 rM
 RD
-jl
+VY
 zm
 CN
 Tf
 JD
-xt
+Qk
 XL
 PF
 Rl
 mc
-xt
+Qk
 Ml
 uK
 jE
 "}
 (25,1,1) = {"
-xt
+Qk
 kT
 kL
 hn
 OT
 fP
-xt
+Qk
 qT
 Tf
 Tf
@@ -2490,7 +2487,7 @@ rM
 Sc
 uk
 Lw
-xt
+Qk
 rT
 uK
 uK
@@ -2507,12 +2504,12 @@ hb
 Tf
 CB
 JD
-xt
+Qk
 Fh
 rq
 yq
 GO
-xt
+Qk
 Vo
 uK
 uK
@@ -2530,10 +2527,10 @@ DI
 XJ
 JD
 VY
-xt
-xt
-xt
-xt
+Qk
+Qk
+Qk
+Qk
 Qk
 bR
 sK
@@ -2551,12 +2548,12 @@ Qw
 gr
 gr
 JD
-xt
+Qk
 Kr
 RN
 IG
 is
-xt
+Qk
 Jd
 uK
 jE
@@ -2573,12 +2570,12 @@ dT
 gr
 gr
 iM
-xt
+Qk
 iv
 rM
 yZ
 QZ
-xt
+Qk
 rT
 uK
 uK
@@ -2600,50 +2597,50 @@ rM
 KU
 rM
 Fw
-xt
+Qk
 rT
 uK
 Pi
 "}
 (31,1,1) = {"
-xt
+Qk
 Zk
 Zc
 nJ
 Zc
 jS
-xt
+Qk
 ad
 nD
 KP
 Zk
-xt
+Qk
 Fh
 Mo
 GO
 GO
-xt
+Qk
 wY
 uK
 uK
 "}
 (32,1,1) = {"
-xt
-xt
-xt
-xt
-xt
-xt
-xt
-xt
-xt
-xt
 Qk
 Qk
 Qk
 Qk
-xt
-xt
+Qk
+Qk
+Qk
+Qk
+Qk
+Qk
+Qk
+Qk
+Qk
+Qk
+Qk
+Qk
 Qk
 rT
 uK

--- a/maps/map_files/Ice_Colony_v3/sprinkles/25.shivaclf01.dmm
+++ b/maps/map_files/Ice_Colony_v3/sprinkles/25.shivaclf01.dmm
@@ -174,6 +174,13 @@
 	icon_state = "redfull"
 	},
 /area/shiva/interior/colony/s_admin)
+"cT" = (
+/obj/structure/barricade/sandbags,
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/interior/colony/s_admin)
 "cZ" = (
 /obj/item/device/pinpointer,
 <<<<<<< master
@@ -336,6 +343,7 @@
 	pixel_y = -5
 	},
 /obj/effect/decal/cleanable/vomit,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/wood,
 /area/shiva/interior/colony/s_admin)
 "hv" = (
@@ -372,6 +380,7 @@
 /area/shiva/exterior/cp_s_research)
 "hO" = (
 /obj/structure/machinery/light/double,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -407,6 +416,12 @@
 	dir = 8;
 	pixel_x = -24
 	},
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/interior/colony/s_admin)
+"iM" = (
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/shiva{
 	dir = 1
 	},
@@ -514,6 +529,7 @@
 /obj/effect/decal/cleanable/blood{
 	layer = 3
 	},
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -591,6 +607,12 @@
 >>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor/shiva{
 	dir = 1
+	},
+/area/shiva/interior/colony/s_admin)
+"kW" = (
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/floor/shiva{
+	icon_state = "bluefull"
 	},
 /area/shiva/interior/colony/s_admin)
 "kY" = (
@@ -674,6 +696,7 @@
 /obj/structure/barricade/sandbags{
 	dir = 4
 	},
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/shiva{
 	dir = 1
 	},
@@ -759,6 +782,7 @@
 /obj/item/shard{
 	icon_state = "medium"
 	},
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -1132,6 +1156,7 @@
 	dir = 4;
 	pixel_y = -5
 	},
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -1150,6 +1175,7 @@
 /obj/item/shard{
 	icon_state = "medium"
 	},
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -1159,6 +1185,7 @@
 /area/shiva/interior/colony/s_admin)
 "yo" = (
 /obj/effect/spawner/random/attachment,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/shiva{
 	dir = 8;
 	icon_state = "multi_tiles"
@@ -1282,6 +1309,7 @@
 "At" = (
 /obj/effect/landmark/corpsespawner/security,
 /obj/item/weapon/gun/shotgun/pump/cmb,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
@@ -1357,8 +1385,16 @@
 	icon_state = "bluefull"
 	},
 /area/shiva/interior/colony/s_admin)
+"CB" = (
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/floor/shiva{
+	dir = 6;
+	icon_state = "multi_tiles"
+	},
+/area/shiva/interior/colony/s_admin)
 "CN" = (
 /obj/effect/decal/cleanable/blood,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/shiva{
 	dir = 6;
 	icon_state = "multi_tiles"
@@ -1778,6 +1814,10 @@
 	dir = 1
 	},
 /area/shiva/interior/colony/s_admin)
+"KU" = (
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/floor/wood,
+/area/shiva/interior/colony/s_admin)
 "Lr" = (
 /turf/open/auto_turf/snow/layer4,
 /area/shiva/exterior/cp_s_research)
@@ -2138,6 +2178,7 @@
 /area/shiva/interior/colony/s_admin)
 "Sg" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
@@ -2219,6 +2260,13 @@
 /turf/open/floor/shiva{
 	dir = 6;
 	icon_state = "multi_tiles"
+	},
+/area/shiva/interior/colony/s_admin)
+"TL" = (
+/obj/effect/spawner/random/attachment,
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/floor/shiva{
+	icon_state = "bluefull"
 	},
 /area/shiva/interior/colony/s_admin)
 "Ue" = (
@@ -2376,6 +2424,13 @@
 /area/shiva/interior/colony/s_admin)
 "XL" = (
 /obj/structure/closet/secure_closet/personal,
+/turf/open/floor/shiva{
+	icon_state = "floor3"
+	},
+/area/shiva/interior/colony/s_admin)
+"XT" = (
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/shiva{
 	icon_state = "floor3"
 	},
@@ -2657,7 +2712,6 @@ Hr
 qW
 JD
 JD
-JD
 aQ
 At
 KB
@@ -2771,9 +2825,9 @@ tF
 (14,1,1) = {"
 jl
 Hj
+iM
 JD
-JD
-JD
+iM
 Hr
 Hr
 WP
@@ -2856,7 +2910,7 @@ xh
 Su
 pR
 vm
-aQ
+Xt
 Hr
 JD
 MQ
@@ -2889,7 +2943,7 @@ Hr
 Kr
 >>>>>>> Updated CLF spawner
 JD
-MQ
+cT
 Zz
 OH
 pL
@@ -2897,7 +2951,7 @@ Nv
 NP
 zf
 sV
-Hr
+kW
 Qk
 Qk
 Iq
@@ -2917,7 +2971,7 @@ FM
 Un
 Ey
 Hr
-Hr
+kW
 JD
 Nd
 ny
@@ -2944,7 +2998,7 @@ Nt
 >>>>>>> updated all maps to have CLF Mines and corpses
 nT
 uq
-il
+oJ
 JD
 <<<<<<< master
 <<<<<<< master
@@ -3050,7 +3104,11 @@ Hr
 Kr
 >>>>>>> Updated CLF spawner
 VY
-Mo
+XT
+kW
+kW
+kW
+TL
 Hr
 Hr
 <<<<<<< master
@@ -3081,8 +3139,8 @@ xt
 Qk
 ff
 Tf
-Tf
-JD
+CB
+iM
 Qk
 nk
 hi
@@ -3227,7 +3285,7 @@ Rf
 Jn
 GH
 JD
-JD
+iM
 qO
 Kk
 DI
@@ -3343,7 +3401,6 @@ Ds
 JD
 >>>>>>> reimported backup
 JD
-JD
 CX
 pC
 zU
@@ -3352,7 +3409,7 @@ wa
 Su
 ex
 rM
-rM
+KU
 rM
 Fw
 xt

--- a/maps/map_files/Ice_Colony_v3/sprinkles/25.shivaclf01.dmm
+++ b/maps/map_files/Ice_Colony_v3/sprinkles/25.shivaclf01.dmm
@@ -833,6 +833,7 @@
 "sd" = (
 /obj/effect/landmark/corpsespawner/colonist,
 /obj/item/weapon/gun/pistol/holdout,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -1145,6 +1146,7 @@
 	dir = 4;
 	pixel_x = 24
 	},
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -1191,6 +1193,7 @@
 /area/shiva/interior/colony/s_admin)
 "Ap" = (
 /obj/effect/decal/cleanable/blood/oil/streak,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor/shiva{
 	dir = 8;
 	icon_state = "multi_tiles"
@@ -1241,6 +1244,7 @@
 /obj/effect/decal/cleanable/blood{
 	layer = 3
 	},
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -1415,6 +1419,13 @@
 /turf/open/floor{
 	dir = 8;
 	icon_state = "damaged3"
+	},
+/area/shiva/interior/colony/s_admin)
+"Gm" = (
+/obj/item/stack/sandbags,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/turf/open/floor{
+	icon_state = "platingdmg1"
 	},
 /area/shiva/interior/colony/s_admin)
 "GH" = (
@@ -1807,6 +1818,7 @@
 	pixel_x = -24
 	},
 /obj/item/device/flashlight/lamp,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor/shiva{
 	icon_state = "floor3"
 	},
@@ -2419,7 +2431,7 @@ Qk
 FI
 Mo
 Un
-Un
+aN
 yw
 Qk
 DM
@@ -2572,7 +2584,7 @@ JD
 il
 bN
 Un
-WP
+Gm
 WP
 hO
 VY
@@ -2589,7 +2601,7 @@ tF
 jl
 Hj
 JD
-JD
+Ds
 JD
 Hr
 Hr
@@ -2662,7 +2674,7 @@ pR
 vm
 aQ
 Hr
-JD
+Ds
 MQ
 ag
 ak
@@ -2697,7 +2709,7 @@ Nv
 NP
 zf
 sV
-Hr
+Kr
 Qk
 Qk
 Iq
@@ -2845,7 +2857,7 @@ Kr
 Hr
 >>>>>>> reimported backup
 VY
-Mo
+QC
 Hr
 Hr
 Hr
@@ -2991,7 +3003,7 @@ Nt
 Rf
 Jn
 GH
-JD
+Ds
 JD
 qO
 Kk

--- a/maps/map_files/Ice_Colony_v3/sprinkles/25.shivaclf01.dmm
+++ b/maps/map_files/Ice_Colony_v3/sprinkles/25.shivaclf01.dmm
@@ -85,9 +85,9 @@
 	},
 /area/shiva/interior/colony/s_admin)
 "aN" = (
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
-/turf/open/floor{
-	icon_state = "platingdmg1"
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/floor/shiva{
+	icon_state = "multi_tiles"
 	},
 /area/shiva/interior/colony/s_admin)
 "aQ" = (
@@ -164,7 +164,7 @@
 /area/shiva/interior/colony/s_admin)
 "cZ" = (
 /obj/item/device/pinpointer,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -409,7 +409,7 @@
 /area/shiva/exterior/junkyard/cp_bar)
 "jH" = (
 /obj/effect/spawner/random/attachment,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/shiva{
 	icon_state = "floor3"
 	},
@@ -418,7 +418,7 @@
 /obj/effect/decal/cleanable/blood{
 	layer = 3
 	},
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/shiva{
 	dir = 1
 	},
@@ -458,12 +458,10 @@
 	},
 /area/shiva/interior/colony/s_admin)
 "kv" = (
-/obj/item/explosive/mine/clf/active{
-	dir = 4
-	},
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
-/turf/open/floor/shiva{
-	dir = 1
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "damaged3"
 	},
 /area/shiva/interior/colony/s_admin)
 "kL" = (
@@ -704,6 +702,7 @@
 /area/shiva/interior/colony/s_admin)
 "rJ" = (
 /obj/item/explosive/mine/clf/active,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -737,7 +736,6 @@
 "sd" = (
 /obj/effect/landmark/corpsespawner/colonist,
 /obj/item/weapon/gun/pistol/holdout,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -869,7 +867,7 @@
 	dir = 1;
 	tag = "icon-chair (NORTH)"
 	},
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -1039,7 +1037,6 @@
 	dir = 4;
 	pixel_x = 24
 	},
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -1086,7 +1083,6 @@
 /area/shiva/interior/colony/s_admin)
 "Ap" = (
 /obj/effect/decal/cleanable/blood/oil/streak,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor/shiva{
 	dir = 8;
 	icon_state = "multi_tiles"
@@ -1137,7 +1133,6 @@
 /obj/effect/decal/cleanable/blood{
 	layer = 3
 	},
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -1155,7 +1150,7 @@
 /area/shiva/interior/colony/s_admin)
 "BY" = (
 /obj/structure/bed/chair,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -1194,7 +1189,7 @@
 	},
 /area/shiva/interior/colony/s_admin)
 "Ds" = (
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/shiva{
 	dir = 1
 	},
@@ -1212,9 +1207,12 @@
 /turf/open/auto_turf/snow/layer3,
 /area/shiva/exterior/cp_s_research)
 "DZ" = (
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/effect/decal/cleanable/blood{
+	layer = 3
+	},
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/shiva{
-	icon_state = "multi_tiles"
+	icon_state = "bluefull"
 	},
 /area/shiva/interior/colony/s_admin)
 "Ed" = (
@@ -1280,7 +1278,6 @@
 	},
 /obj/item/spacecash/c1000,
 /obj/item/spacecash/c500,
-/obj/effect/landmark/good_item,
 /obj/item/storage/pill_bottle/ultrazine/skillless,
 /turf/open/floor/shiva{
 	dir = 8;
@@ -1291,13 +1288,6 @@
 /turf/open/floor{
 	dir = 8;
 	icon_state = "damaged3"
-	},
-/area/shiva/interior/colony/s_admin)
-"Gm" = (
-/obj/item/stack/sandbags,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
-/turf/open/floor{
-	icon_state = "platingdmg1"
 	},
 /area/shiva/interior/colony/s_admin)
 "GH" = (
@@ -1482,7 +1472,7 @@
 	},
 /area/shiva/interior/colony/s_admin)
 "Kr" = (
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -1593,7 +1583,7 @@
 "NB" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/structure/bed/chair,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -1603,7 +1593,7 @@
 	layer = 3
 	},
 /obj/structure/bed/chair,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -1650,7 +1640,6 @@
 	pixel_x = -24
 	},
 /obj/item/device/flashlight/lamp,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor/shiva{
 	icon_state = "floor3"
 	},
@@ -1709,9 +1698,10 @@
 	},
 /area/shiva/interior/colony/s_admin)
 "QC" = (
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/effect/spawner/random/attachment,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/shiva{
-	icon_state = "floor3"
+	icon_state = "bluefull"
 	},
 /area/shiva/interior/colony/s_admin)
 "QE" = (
@@ -1806,6 +1796,7 @@
 /obj/item/tool/pen/blue{
 	pixel_x = 5
 	},
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/wood,
 /area/shiva/interior/colony/s_admin)
 "Sg" = (
@@ -1947,7 +1938,7 @@
 /turf/open/auto_turf/snow/layer2,
 /area/shiva/exterior/junkyard/cp_bar)
 "VE" = (
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/wood,
 /area/shiva/interior/colony/s_admin)
 "VF" = (
@@ -1961,6 +1952,7 @@
 "VP" = (
 /obj/effect/landmark/corpsespawner/chef,
 /obj/item/ammo_casing/bullet,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/shiva{
 	dir = 1
 	},
@@ -2000,7 +1992,7 @@
 	},
 /area/shiva/interior/colony/s_admin)
 "Xu" = (
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/shiva{
 	dir = 6;
 	icon_state = "multi_tiles"
@@ -2228,7 +2220,7 @@ Qk
 FI
 Mo
 Un
-aN
+Un
 yw
 Qk
 DM
@@ -2282,10 +2274,10 @@ DM
 (11,1,1) = {"
 jl
 Hr
-kv
+qW
 JD
 JD
-aQ
+DZ
 At
 KB
 VF
@@ -2332,7 +2324,7 @@ JD
 il
 bN
 Un
-Gm
+WP
 WP
 hO
 VY
@@ -2349,12 +2341,12 @@ tF
 jl
 Hj
 JD
-Ds
+JD
 JD
 Hr
 Hr
 WP
-FM
+kv
 Un
 Hr
 pL
@@ -2370,7 +2362,7 @@ tF
 (15,1,1) = {"
 Nt
 Fq
-JD
+Ds
 JD
 JD
 Hr
@@ -2382,7 +2374,7 @@ Ey
 pL
 zI
 Hr
-fg
+QC
 Hr
 Hr
 Mo
@@ -2397,7 +2389,7 @@ pR
 vm
 aQ
 Hr
-Ds
+JD
 MQ
 ag
 ak
@@ -2418,7 +2410,7 @@ Ey
 Un
 YL
 BG
-Hr
+Kr
 JD
 MQ
 Zz
@@ -2428,7 +2420,7 @@ Nv
 NP
 zf
 sV
-Kr
+Hr
 Qk
 Qk
 Iq
@@ -2487,7 +2479,7 @@ sd
 rJ
 Jn
 GJ
-JD
+Ds
 Hr
 Qk
 jH
@@ -2510,13 +2502,13 @@ Hr
 kb
 Hr
 fg
-Hr
-VY
-QC
-Hr
-Hr
 Kr
-fg
+VY
+Mo
+Hr
+Hr
+Hr
+QC
 Hr
 Hz
 Wl
@@ -2553,7 +2545,7 @@ AH
 xt
 jS
 Qz
-DZ
+gr
 jS
 Qk
 xt
@@ -2596,7 +2588,7 @@ OT
 fP
 xt
 qT
-Tf
+Xu
 Tf
 hD
 ex
@@ -2619,7 +2611,7 @@ RV
 Qk
 hb
 Tf
-Xu
+Tf
 qW
 xt
 Fh
@@ -2636,7 +2628,7 @@ Nt
 Rf
 Jn
 GH
-Ds
+JD
 JD
 qO
 Kk
@@ -2685,7 +2677,7 @@ MT
 JD
 dT
 gr
-gr
+aN
 JD
 xt
 iv
@@ -2700,9 +2692,9 @@ uK
 (30,1,1) = {"
 Nt
 Jk
-JD
-JD
 Ds
+JD
+JD
 CX
 pC
 zU

--- a/maps/map_files/Ice_Colony_v3/sprinkles/25.shivaclf01.dmm
+++ b/maps/map_files/Ice_Colony_v3/sprinkles/25.shivaclf01.dmm
@@ -170,10 +170,7 @@
 /area/shiva/interior/colony/s_admin)
 "cZ" = (
 /obj/item/device/pinpointer,
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
-=======
->>>>>>> reimported backup
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -833,7 +830,6 @@
 "sd" = (
 /obj/effect/landmark/corpsespawner/colonist,
 /obj/item/weapon/gun/pistol/holdout,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -973,10 +969,7 @@
 	dir = 1;
 	tag = "icon-chair (NORTH)"
 	},
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
-=======
->>>>>>> reimported backup
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -1146,7 +1139,6 @@
 	dir = 4;
 	pixel_x = 24
 	},
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -1193,7 +1185,6 @@
 /area/shiva/interior/colony/s_admin)
 "Ap" = (
 /obj/effect/decal/cleanable/blood/oil/streak,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor/shiva{
 	dir = 8;
 	icon_state = "multi_tiles"
@@ -1244,7 +1235,6 @@
 /obj/effect/decal/cleanable/blood{
 	layer = 3
 	},
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -1262,10 +1252,7 @@
 /area/shiva/interior/colony/s_admin)
 "BY" = (
 /obj/structure/bed/chair,
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
-=======
->>>>>>> reimported backup
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -1405,10 +1392,6 @@
 	},
 /obj/item/spacecash/c1000,
 /obj/item/spacecash/c500,
-<<<<<<< master
-=======
-/obj/effect/landmark/good_item,
->>>>>>> reimported backup
 /obj/item/storage/pill_bottle/ultrazine/skillless,
 /turf/open/floor/shiva{
 	dir = 8;
@@ -1419,13 +1402,6 @@
 /turf/open/floor{
 	dir = 8;
 	icon_state = "damaged3"
-	},
-/area/shiva/interior/colony/s_admin)
-"Gm" = (
-/obj/item/stack/sandbags,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
-/turf/open/floor{
-	icon_state = "platingdmg1"
 	},
 /area/shiva/interior/colony/s_admin)
 "GH" = (
@@ -1616,7 +1592,6 @@
 	},
 /area/shiva/interior/colony/s_admin)
 "Kr" = (
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
@@ -1755,10 +1730,7 @@
 "NB" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/structure/bed/chair,
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
-=======
->>>>>>> reimported backup
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -1768,10 +1740,7 @@
 	layer = 3
 	},
 /obj/structure/bed/chair,
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
-=======
->>>>>>> reimported backup
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -1818,7 +1787,6 @@
 	pixel_x = -24
 	},
 /obj/item/device/flashlight/lamp,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor/shiva{
 	icon_state = "floor3"
 	},
@@ -1989,10 +1957,7 @@
 /obj/item/tool/pen/blue{
 	pixel_x = 5
 	},
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
-=======
->>>>>>> reimported backup
 /turf/open/floor/wood,
 /area/shiva/interior/colony/s_admin)
 "Sg" = (
@@ -2154,10 +2119,7 @@
 "VP" = (
 /obj/effect/landmark/corpsespawner/chef,
 /obj/item/ammo_casing/bullet,
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
-=======
->>>>>>> reimported backup
 /turf/open/floor/shiva{
 	dir = 1
 	},
@@ -2431,7 +2393,7 @@ Qk
 FI
 Mo
 Un
-aN
+Un
 yw
 Qk
 DM
@@ -2493,19 +2455,10 @@ DM
 (11,1,1) = {"
 jl
 Hr
-<<<<<<< master
 qW
 JD
 JD
 DZ
-At
-FM
->>>>>>> reimported backup
-=======
-JD
-JD
-JD
-aQ
 At
 FM
 >>>>>>> reimported backup
@@ -2584,7 +2537,7 @@ JD
 il
 bN
 Un
-Gm
+WP
 WP
 hO
 VY
@@ -2601,16 +2554,12 @@ tF
 jl
 Hj
 JD
-Ds
+JD
 JD
 Hr
 Hr
 WP
-<<<<<<< master
 kv
-=======
-FM
->>>>>>> reimported backup
 Un
 Hr
 pL
@@ -2635,9 +2584,6 @@ JD
 pC
 Fq
 JD
-JD
->>>>>>> reimported backup
-JD
 Hr
 iB
 il
@@ -2647,11 +2593,7 @@ Ey
 pL
 zI
 Hr
-<<<<<<< master
 QC
-=======
-fg
->>>>>>> reimported backup
 Hr
 Hr
 Mo
@@ -2674,7 +2616,7 @@ pR
 vm
 aQ
 Hr
-Ds
+JD
 MQ
 ag
 ak
@@ -2695,11 +2637,7 @@ Ey
 Un
 YL
 BG
-<<<<<<< master
 Kr
-=======
-Hr
->>>>>>> reimported backup
 JD
 MQ
 Zz
@@ -2709,7 +2647,7 @@ Nv
 NP
 zf
 sV
-Kr
+Hr
 Qk
 Qk
 Iq
@@ -2851,21 +2789,13 @@ Hr
 kb
 Hr
 fg
-<<<<<<< master
 Kr
-=======
-Hr
->>>>>>> reimported backup
 VY
+Mo
+Hr
+Hr
+Hr
 QC
-Hr
-Hr
-Hr
-<<<<<<< master
-QC
-=======
-fg
->>>>>>> reimported backup
 Hr
 Hz
 Wl
@@ -2904,9 +2834,6 @@ jS
 <<<<<<< master
 <<<<<<< master
 Qz
-=======
-gr
->>>>>>> reimported backup
 gr
 jS
 Qk
@@ -2950,15 +2877,9 @@ OT
 fP
 xt
 qT
-<<<<<<< master
 Xu
 Tf
 hD
-=======
-Tf
-Tf
-JD
->>>>>>> reimported backup
 ex
 rM
 Sc
@@ -2980,7 +2901,6 @@ Qk
 hb
 Tf
 Tf
-<<<<<<< master
 qW
 =======
 JD
@@ -3003,7 +2923,7 @@ Nt
 Rf
 Jn
 GH
-Ds
+JD
 JD
 qO
 Kk
@@ -3076,11 +2996,7 @@ MT
 JD
 dT
 gr
-<<<<<<< master
 aN
-=======
-gr
->>>>>>> reimported backup
 JD
 xt
 iv
@@ -3107,9 +3023,6 @@ JD
 =======
 pC
 Jk
-JD
-JD
->>>>>>> reimported backup
 JD
 CX
 pC

--- a/maps/map_files/Ice_Colony_v3/sprinkles/25.shivaclf01.dmm
+++ b/maps/map_files/Ice_Colony_v3/sprinkles/25.shivaclf01.dmm
@@ -2657,7 +2657,8 @@ Hr
 qW
 JD
 JD
-DZ
+JD
+aQ
 At
 KB
 =======
@@ -2982,7 +2983,7 @@ jN
 NY
 JD
 sd
-rJ
+Hr
 Jn
 GJ
 Ds
@@ -3341,6 +3342,7 @@ Jk
 Ds
 JD
 >>>>>>> reimported backup
+JD
 JD
 CX
 pC

--- a/maps/map_files/Ice_Colony_v3/sprinkles/25.shivaclf01.dmm
+++ b/maps/map_files/Ice_Colony_v3/sprinkles/25.shivaclf01.dmm
@@ -96,9 +96,9 @@
 >>>>>>> reimported backup
 =======
 "aN" = (
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
-/turf/open/floor{
-	icon_state = "platingdmg1"
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/floor/shiva{
+	icon_state = "multi_tiles"
 	},
 /area/shiva/interior/colony/s_admin)
 >>>>>>> updated all maps to have CLF Mines and corpses
@@ -178,12 +178,16 @@
 /obj/item/device/pinpointer,
 <<<<<<< master
 <<<<<<< master
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
 =======
 >>>>>>> reimported backup
 =======
 /obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 >>>>>>> updated all maps to have CLF Mines and corpses
+=======
+/obj/effect/landmark/survivor_spawner/clf/generic,
+>>>>>>> Updated CLF spawner
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -452,8 +456,12 @@
 =======
 "jH" = (
 /obj/effect/spawner/random/attachment,
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 >>>>>>> updated all maps to have CLF Mines and corpses
+=======
+/obj/effect/landmark/survivor_spawner/clf/generic,
+>>>>>>> Updated CLF spawner
 /turf/open/floor/shiva{
 	icon_state = "floor3"
 	},
@@ -463,10 +471,14 @@
 	layer = 3
 	},
 <<<<<<< master
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
 =======
 /obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 >>>>>>> updated all maps to have CLF Mines and corpses
+=======
+/obj/effect/landmark/survivor_spawner/clf/generic,
+>>>>>>> Updated CLF spawner
 /turf/open/floor/shiva{
 	dir = 1
 	},
@@ -532,12 +544,10 @@
 >>>>>>> reimported backup
 =======
 "kv" = (
-/obj/item/explosive/mine/clf/active{
-	dir = 4
-	},
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
-/turf/open/floor/shiva{
-	dir = 1
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "damaged3"
 	},
 /area/shiva/interior/colony/s_admin)
 >>>>>>> updated all maps to have CLF Mines and corpses
@@ -844,10 +854,13 @@
 "rJ" = (
 /obj/item/explosive/mine/clf/active,
 /obj/effect/landmark/survivor_spawner/clf/generic,
+<<<<<<< master
 =======
 "rJ" = (
 /obj/item/explosive/mine/clf/active,
 >>>>>>> updated all maps to have CLF Mines and corpses
+=======
+>>>>>>> Updated CLF spawner
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -896,7 +909,6 @@
 "sd" = (
 /obj/effect/landmark/corpsespawner/colonist,
 /obj/item/weapon/gun/pistol/holdout,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -1037,12 +1049,16 @@
 	},
 <<<<<<< master
 <<<<<<< master
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
 =======
 >>>>>>> reimported backup
 =======
 /obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 >>>>>>> updated all maps to have CLF Mines and corpses
+=======
+/obj/effect/landmark/survivor_spawner/clf/generic,
+>>>>>>> Updated CLF spawner
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -1212,7 +1228,6 @@
 	dir = 4;
 	pixel_x = 24
 	},
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -1259,7 +1274,6 @@
 /area/shiva/interior/colony/s_admin)
 "Ap" = (
 /obj/effect/decal/cleanable/blood/oil/streak,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor/shiva{
 	dir = 8;
 	icon_state = "multi_tiles"
@@ -1310,7 +1324,6 @@
 /obj/effect/decal/cleanable/blood{
 	layer = 3
 	},
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -1330,12 +1343,16 @@
 /obj/structure/bed/chair,
 <<<<<<< master
 <<<<<<< master
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
 =======
 >>>>>>> reimported backup
 =======
 /obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 >>>>>>> updated all maps to have CLF Mines and corpses
+=======
+/obj/effect/landmark/survivor_spawner/clf/generic,
+>>>>>>> Updated CLF spawner
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -1379,10 +1396,14 @@
 /area/shiva/interior/colony/s_admin)
 "Ds" = (
 <<<<<<< master
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
 =======
 /obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 >>>>>>> updated all maps to have CLF Mines and corpses
+=======
+/obj/effect/landmark/survivor_spawner/clf/generic,
+>>>>>>> Updated CLF spawner
 /turf/open/floor/shiva{
 	dir = 1
 	},
@@ -1419,9 +1440,12 @@
 >>>>>>> reimported backup
 =======
 "DZ" = (
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/effect/decal/cleanable/blood{
+	layer = 3
+	},
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/shiva{
-	icon_state = "multi_tiles"
+	icon_state = "bluefull"
 	},
 /area/shiva/interior/colony/s_admin)
 >>>>>>> updated all maps to have CLF Mines and corpses
@@ -1489,9 +1513,12 @@
 /obj/item/spacecash/c1000,
 /obj/item/spacecash/c500,
 <<<<<<< master
+<<<<<<< master
 =======
 /obj/effect/landmark/good_item,
 >>>>>>> reimported backup
+=======
+>>>>>>> Updated CLF spawner
 /obj/item/storage/pill_bottle/ultrazine/skillless,
 /turf/open/floor/shiva{
 	dir = 8;
@@ -1502,13 +1529,6 @@
 /turf/open/floor{
 	dir = 8;
 	icon_state = "damaged3"
-	},
-/area/shiva/interior/colony/s_admin)
-"Gm" = (
-/obj/item/stack/sandbags,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
-/turf/open/floor{
-	icon_state = "platingdmg1"
 	},
 /area/shiva/interior/colony/s_admin)
 "GH" = (
@@ -1704,6 +1724,7 @@
 "Kr" = (
 <<<<<<< master
 <<<<<<< master
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
@@ -1715,6 +1736,9 @@
 >>>>>>> reimported backup
 =======
 /obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+=======
+/obj/effect/landmark/survivor_spawner/clf/generic,
+>>>>>>> Updated CLF spawner
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 >>>>>>> updated all maps to have CLF Mines and corpses
@@ -1849,12 +1873,16 @@
 /obj/structure/bed/chair,
 <<<<<<< master
 <<<<<<< master
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
 =======
 >>>>>>> reimported backup
 =======
 /obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 >>>>>>> updated all maps to have CLF Mines and corpses
+=======
+/obj/effect/landmark/survivor_spawner/clf/generic,
+>>>>>>> Updated CLF spawner
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -1866,12 +1894,16 @@
 /obj/structure/bed/chair,
 <<<<<<< master
 <<<<<<< master
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
 =======
 >>>>>>> reimported backup
 =======
 /obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 >>>>>>> updated all maps to have CLF Mines and corpses
+=======
+/obj/effect/landmark/survivor_spawner/clf/generic,
+>>>>>>> Updated CLF spawner
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -1918,7 +1950,6 @@
 	pixel_x = -24
 	},
 /obj/item/device/flashlight/lamp,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor/shiva{
 	icon_state = "floor3"
 	},
@@ -1996,9 +2027,10 @@
 >>>>>>> reimported backup
 =======
 "QC" = (
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/effect/spawner/random/attachment,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/shiva{
-	icon_state = "floor3"
+	icon_state = "bluefull"
 	},
 >>>>>>> updated all maps to have CLF Mines and corpses
 /area/shiva/interior/colony/s_admin)
@@ -2095,9 +2127,13 @@
 	pixel_x = 5
 	},
 <<<<<<< master
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
 =======
 >>>>>>> reimported backup
+=======
+/obj/effect/landmark/survivor_spawner/clf/generic,
+>>>>>>> Updated CLF spawner
 /turf/open/floor/wood,
 /area/shiva/interior/colony/s_admin)
 "Sg" = (
@@ -2248,7 +2284,7 @@
 >>>>>>> reimported backup
 =======
 "VE" = (
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/wood,
 /area/shiva/interior/colony/s_admin)
 >>>>>>> updated all maps to have CLF Mines and corpses
@@ -2264,9 +2300,13 @@
 /obj/effect/landmark/corpsespawner/chef,
 /obj/item/ammo_casing/bullet,
 <<<<<<< master
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
 =======
 >>>>>>> reimported backup
+=======
+/obj/effect/landmark/survivor_spawner/clf/generic,
+>>>>>>> Updated CLF spawner
 /turf/open/floor/shiva{
 	dir = 1
 	},
@@ -2311,8 +2351,12 @@
 /obj/effect/landmark/survivor_spawner/clf/generic,
 =======
 "Xu" = (
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 >>>>>>> updated all maps to have CLF Mines and corpses
+=======
+/obj/effect/landmark/survivor_spawner/clf/generic,
+>>>>>>> Updated CLF spawner
 /turf/open/floor/shiva{
 	dir = 6;
 	icon_state = "multi_tiles"
@@ -2545,7 +2589,7 @@ Qk
 FI
 Mo
 Un
-aN
+Un
 yw
 Qk
 DM
@@ -2609,6 +2653,7 @@ jl
 Hr
 <<<<<<< master
 <<<<<<< master
+<<<<<<< master
 qW
 JD
 JD
@@ -2620,9 +2665,12 @@ JD
 =======
 kv
 >>>>>>> updated all maps to have CLF Mines and corpses
+=======
+qW
+>>>>>>> Updated CLF spawner
 JD
 JD
-aQ
+DZ
 At
 <<<<<<< master
 FM
@@ -2706,7 +2754,7 @@ JD
 il
 bN
 Un
-Gm
+WP
 WP
 hO
 VY
@@ -2723,16 +2771,20 @@ tF
 jl
 Hj
 JD
-Ds
+JD
 JD
 Hr
 Hr
 WP
 <<<<<<< master
+<<<<<<< master
 kv
 =======
 FM
 >>>>>>> reimported backup
+=======
+kv
+>>>>>>> Updated CLF spawner
 Un
 Hr
 pL
@@ -2757,8 +2809,12 @@ pC
 Nt
 >>>>>>> updated all maps to have CLF Mines and corpses
 Fq
+<<<<<<< master
 JD
 >>>>>>> reimported backup
+=======
+Ds
+>>>>>>> Updated CLF spawner
 JD
 JD
 Hr
@@ -2771,10 +2827,14 @@ pL
 zI
 Hr
 <<<<<<< master
+<<<<<<< master
 QC
 =======
 fg
 >>>>>>> reimported backup
+=======
+QC
+>>>>>>> Updated CLF spawner
 Hr
 Hr
 Mo
@@ -2797,7 +2857,7 @@ pR
 vm
 aQ
 Hr
-Ds
+JD
 MQ
 ag
 ak
@@ -2819,10 +2879,14 @@ Un
 YL
 BG
 <<<<<<< master
+<<<<<<< master
 Kr
 =======
 Hr
 >>>>>>> reimported backup
+=======
+Kr
+>>>>>>> Updated CLF spawner
 JD
 MQ
 Zz
@@ -2832,7 +2896,7 @@ Nv
 NP
 zf
 sV
-Kr
+Hr
 Qk
 Qk
 Iq
@@ -2922,6 +2986,7 @@ rJ
 Jn
 GJ
 Ds
+<<<<<<< master
 Hr
 Qk
 jH
@@ -2937,6 +3002,8 @@ rJ
 Jn
 GJ
 JD
+=======
+>>>>>>> Updated CLF spawner
 Hr
 Qk
 <<<<<<< master
@@ -2973,14 +3040,19 @@ kb
 Hr
 fg
 <<<<<<< master
+<<<<<<< master
 Kr
 =======
 Hr
 >>>>>>> reimported backup
+=======
+Kr
+>>>>>>> Updated CLF spawner
 VY
-QC
+Mo
 Hr
 Hr
+<<<<<<< master
 <<<<<<< master
 <<<<<<< master
 QC
@@ -2990,6 +3062,10 @@ Kr
 >>>>>>> updated all maps to have CLF Mines and corpses
 fg
 >>>>>>> reimported backup
+=======
+Hr
+QC
+>>>>>>> Updated CLF spawner
 Hr
 Hz
 Wl
@@ -3034,8 +3110,12 @@ gr
 gr
 =======
 Qz
+<<<<<<< master
 DZ
 >>>>>>> updated all maps to have CLF Mines and corpses
+=======
+gr
+>>>>>>> Updated CLF spawner
 jS
 Qk
 xt
@@ -3079,10 +3159,14 @@ fP
 xt
 qT
 <<<<<<< master
+<<<<<<< master
 Xu
 Tf
 hD
 =======
+=======
+Xu
+>>>>>>> Updated CLF spawner
 Tf
 Tf
 <<<<<<< master
@@ -3112,6 +3196,7 @@ Qk
 hb
 Tf
 <<<<<<< master
+<<<<<<< master
 Tf
 <<<<<<< master
 qW
@@ -3120,6 +3205,9 @@ JD
 >>>>>>> reimported backup
 =======
 Xu
+=======
+Tf
+>>>>>>> Updated CLF spawner
 qW
 >>>>>>> updated all maps to have CLF Mines and corpses
 xt
@@ -3137,7 +3225,7 @@ Nt
 Rf
 Jn
 GH
-Ds
+JD
 JD
 qO
 Kk
@@ -3211,6 +3299,7 @@ JD
 dT
 gr
 <<<<<<< master
+<<<<<<< master
 aN
 JD
 xt
@@ -3218,6 +3307,9 @@ iv
 VE
 =======
 gr
+=======
+aN
+>>>>>>> Updated CLF spawner
 JD
 xt
 iv
@@ -3246,10 +3338,10 @@ pC
 Nt
 >>>>>>> updated all maps to have CLF Mines and corpses
 Jk
+Ds
 JD
 >>>>>>> reimported backup
 JD
-Ds
 CX
 pC
 zU

--- a/maps/map_files/Ice_Colony_v3/sprinkles/25.shivaclf01.dmm
+++ b/maps/map_files/Ice_Colony_v3/sprinkles/25.shivaclf01.dmm
@@ -84,6 +84,12 @@
 	dir = 1
 	},
 /area/shiva/interior/colony/s_admin)
+"aN" = (
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/shiva/interior/colony/s_admin)
 "aQ" = (
 /obj/effect/decal/cleanable/blood{
 	layer = 3
@@ -158,6 +164,7 @@
 /area/shiva/interior/colony/s_admin)
 "cZ" = (
 /obj/item/device/pinpointer,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -321,6 +328,13 @@
 "hw" = (
 /turf/open/auto_turf/snow/layer1,
 /area/shiva/exterior/cp_s_research)
+"hD" = (
+/obj/effect/landmark/corpsespawner/clf,
+/obj/item/weapon/melee/twohanded/lungemine,
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/interior/colony/s_admin)
 "hM" = (
 /turf/open/auto_turf/ice/layer1,
 /area/shiva/exterior/cp_s_research)
@@ -374,6 +388,18 @@
 	dir = 1
 	},
 /area/shiva/interior/colony/s_admin)
+"ji" = (
+/obj/structure/bed/chair{
+	dir = 8;
+	tag = "icon-chair (WEST)"
+	},
+/obj/item/explosive/mine/clf/active{
+	dir = 8
+	},
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/interior/colony/s_admin)
 "jl" = (
 /obj/structure/sign/poster/clf,
 /turf/closed/wall/shiva/prefabricated,
@@ -381,10 +407,32 @@
 "jE" = (
 /turf/open/auto_turf/snow/layer1,
 /area/shiva/exterior/junkyard/cp_bar)
+"jH" = (
+/obj/effect/spawner/random/attachment,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/turf/open/floor/shiva{
+	icon_state = "floor3"
+	},
+/area/shiva/interior/colony/s_admin)
+"jN" = (
+/obj/effect/decal/cleanable/blood{
+	layer = 3
+	},
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/interior/colony/s_admin)
 "jS" = (
 /obj/structure/flora/pottedplant,
 /turf/open/floor/shiva{
 	dir = 1
+	},
+/area/shiva/interior/colony/s_admin)
+"jU" = (
+/obj/effect/landmark/corpsespawner/clf,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
 	},
 /area/shiva/interior/colony/s_admin)
 "kb" = (
@@ -407,6 +455,15 @@
 /turf/open/floor/shiva{
 	dir = 8;
 	icon_state = "redfull"
+	},
+/area/shiva/interior/colony/s_admin)
+"kv" = (
+/obj/item/explosive/mine/clf/active{
+	dir = 4
+	},
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/turf/open/floor/shiva{
+	dir = 1
 	},
 /area/shiva/interior/colony/s_admin)
 "kL" = (
@@ -435,13 +492,21 @@
 /obj/item/stack/rods,
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
+/obj/item/explosive/mine/clf/active{
+	dir = 1
+	},
 /turf/open/floor/shiva{
 	dir = 1
 	},
 /area/shiva/interior/colony/s_admin)
 "kY" = (
 /obj/structure/surface/table/reinforced/prison,
-/obj/effect/landmark/good_item,
+/turf/open/floor/shiva{
+	icon_state = "bluefull"
+	},
+/area/shiva/interior/colony/s_admin)
+"lZ" = (
+/obj/effect/landmark/corpsespawner/clf,
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -518,6 +583,7 @@
 	dir = 4;
 	pixel_y = -5
 	},
+/obj/effect/landmark/corpsespawner/clf,
 /turf/open/floor/shiva{
 	dir = 1
 	},
@@ -536,6 +602,26 @@
 "nX" = (
 /turf/open/auto_turf/snow/layer0,
 /area/shiva/exterior/junkyard/cp_bar)
+"oh" = (
+/obj/effect/decal/cleanable/blood{
+	layer = 3
+	},
+/obj/item/explosive/mine/clf/active{
+	dir = 1
+	},
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/interior/colony/s_admin)
+"oU" = (
+/obj/effect/landmark/corpsespawner/clf,
+/obj/item/weapon/gun/rifle/mar40/lmg{
+	pixel_y = 13
+	},
+/turf/open/floor/shiva{
+	icon_state = "bluefull"
+	},
+/area/shiva/interior/colony/s_admin)
 "oZ" = (
 /obj/structure/barricade/metal/wired{
 	icon_state = "metal_1";
@@ -555,6 +641,15 @@
 /area/shiva/interior/colony/s_admin)
 "pL" = (
 /turf/open/floor/plating,
+/area/shiva/interior/colony/s_admin)
+"pN" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/explosive/mine/clf/active{
+	dir = 1
+	},
+/turf/open/floor/shiva{
+	dir = 1
+	},
 /area/shiva/interior/colony/s_admin)
 "pR" = (
 /obj/effect/decal/cleanable/blood{
@@ -587,6 +682,14 @@
 	dir = 1
 	},
 /area/shiva/interior/colony/s_admin)
+"qW" = (
+/obj/item/explosive/mine/clf/active{
+	dir = 4
+	},
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/interior/colony/s_admin)
 "qZ" = (
 /turf/open/auto_turf/snow/layer3,
 /area/shiva/exterior/cp_lz2)
@@ -599,12 +702,25 @@
 	icon_state = "floor3"
 	},
 /area/shiva/interior/colony/s_admin)
+"rJ" = (
+/obj/item/explosive/mine/clf/active,
+/turf/open/floor/shiva{
+	icon_state = "bluefull"
+	},
+/area/shiva/interior/colony/s_admin)
 "rM" = (
 /turf/open/floor/wood,
 /area/shiva/interior/colony/s_admin)
 "rP" = (
 /obj/structure/surface/table/reinforced/prison,
-/obj/item/weapon/gun/rifle/mar40/lmg,
+/obj/item/weapon/gun/rifle/mar40/lmg{
+	pixel_y = 13
+	},
+/obj/item/explosive/mine/clf,
+/obj/item/explosive/mine/clf,
+/obj/item/explosive/mine/clf,
+/obj/item/explosive/mine/clf,
+/obj/item/explosive/mine/clf,
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -621,6 +737,7 @@
 "sd" = (
 /obj/effect/landmark/corpsespawner/colonist,
 /obj/item/weapon/gun/pistol/holdout,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -669,7 +786,6 @@
 	dir = 4;
 	pixel_x = -24
 	},
-/obj/effect/landmark/crap_item,
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -753,6 +869,7 @@
 	dir = 1;
 	tag = "icon-chair (NORTH)"
 	},
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -922,6 +1039,7 @@
 	dir = 4;
 	pixel_x = 24
 	},
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -968,6 +1086,7 @@
 /area/shiva/interior/colony/s_admin)
 "Ap" = (
 /obj/effect/decal/cleanable/blood/oil/streak,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor/shiva{
 	dir = 8;
 	icon_state = "multi_tiles"
@@ -1018,6 +1137,7 @@
 /obj/effect/decal/cleanable/blood{
 	layer = 3
 	},
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -1035,6 +1155,7 @@
 /area/shiva/interior/colony/s_admin)
 "BY" = (
 /obj/structure/bed/chair,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -1063,6 +1184,21 @@
 	dir = 1
 	},
 /area/shiva/interior/colony/s_admin)
+"Dc" = (
+/obj/item/explosive/mine/clf/active{
+	dir = 1
+	},
+/turf/open/floor/shiva{
+	dir = 8;
+	icon_state = "multi_tiles"
+	},
+/area/shiva/interior/colony/s_admin)
+"Ds" = (
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/interior/colony/s_admin)
 "DI" = (
 /obj/effect/decal/cleanable/blood{
 	layer = 3
@@ -1075,6 +1211,12 @@
 "DM" = (
 /turf/open/auto_turf/snow/layer3,
 /area/shiva/exterior/cp_s_research)
+"DZ" = (
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/turf/open/floor/shiva{
+	icon_state = "multi_tiles"
+	},
+/area/shiva/interior/colony/s_admin)
 "Ed" = (
 /obj/effect/decal/cleanable/blood{
 	icon_state = "xgibdown1";
@@ -1149,6 +1291,13 @@
 /turf/open/floor{
 	dir = 8;
 	icon_state = "damaged3"
+	},
+/area/shiva/interior/colony/s_admin)
+"Gm" = (
+/obj/item/stack/sandbags,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/turf/open/floor{
+	icon_state = "platingdmg1"
 	},
 /area/shiva/interior/colony/s_admin)
 "GH" = (
@@ -1304,6 +1453,14 @@
 	},
 /turf/open/auto_turf/snow/layer2,
 /area/shiva/exterior/cp_lz2)
+"JR" = (
+/obj/item/explosive/mine/clf/active{
+	dir = 8
+	},
+/turf/open/floor/shiva{
+	icon_state = "bluefull"
+	},
+/area/shiva/interior/colony/s_admin)
 "JV" = (
 /turf/open/auto_turf/snow/layer2,
 /area/shiva/exterior/cp_lz2)
@@ -1325,16 +1482,24 @@
 	},
 /area/shiva/interior/colony/s_admin)
 "Kr" = (
-/obj/structure/closet/secure_closet/personal,
-/obj/effect/landmark/good_item,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor/shiva{
-	icon_state = "floor3"
+	icon_state = "bluefull"
 	},
 /area/shiva/interior/colony/s_admin)
 "Kv" = (
 /obj/structure/machinery/power/port_gen/pacman/mrs,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
+	},
+/area/shiva/interior/colony/s_admin)
+"KB" = (
+/obj/item/explosive/mine/clf/active{
+	dir = 4
+	},
+/turf/open/floor{
+	dir = 8;
+	icon_state = "damaged3"
 	},
 /area/shiva/interior/colony/s_admin)
 "KP" = (
@@ -1409,8 +1574,10 @@
 	},
 /area/shiva/interior/colony/s_admin)
 "Nt" = (
-/obj/item/stack/rods,
 /obj/structure/window_frame/colony/reinforced,
+/obj/item/explosive/mine/clf/active{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/shiva/interior/colony/s_admin)
 "Nv" = (
@@ -1426,6 +1593,7 @@
 "NB" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/structure/bed/chair,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -1435,6 +1603,7 @@
 	layer = 3
 	},
 /obj/structure/bed/chair,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -1481,6 +1650,7 @@
 	pixel_x = -24
 	},
 /obj/item/device/flashlight/lamp,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor/shiva{
 	icon_state = "floor3"
 	},
@@ -1530,11 +1700,19 @@
 	icon_state = "multi_tiles"
 	},
 /area/shiva/interior/colony/s_admin)
+"Qz" = (
+/obj/item/explosive/mine/clf/active{
+	dir = 1
+	},
+/turf/open/floor/shiva{
+	icon_state = "multi_tiles"
+	},
+/area/shiva/interior/colony/s_admin)
 "QC" = (
-/obj/structure/window_frame/colony/reinforced,
-/obj/item/stack/rods,
-/obj/item/stack/rods,
-/turf/open/floor/plating,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/turf/open/floor/shiva{
+	icon_state = "floor3"
+	},
 /area/shiva/interior/colony/s_admin)
 "QE" = (
 /obj/structure/machinery/light/double{
@@ -1768,6 +1946,10 @@
 /obj/structure/largecrate/random/case/small,
 /turf/open/auto_turf/snow/layer2,
 /area/shiva/exterior/junkyard/cp_bar)
+"VE" = (
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/turf/open/floor/wood,
+/area/shiva/interior/colony/s_admin)
 "VF" = (
 /obj/item/shard{
 	icon_state = "medium"
@@ -1815,6 +1997,13 @@
 /obj/item/stack/sandbags,
 /turf/open/floor{
 	icon_state = "platingdmg1"
+	},
+/area/shiva/interior/colony/s_admin)
+"Xu" = (
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/turf/open/floor/shiva{
+	dir = 6;
+	icon_state = "multi_tiles"
 	},
 /area/shiva/interior/colony/s_admin)
 "XJ" = (
@@ -2039,7 +2228,7 @@ Qk
 FI
 Mo
 Un
-Un
+aN
 yw
 Qk
 DM
@@ -2070,7 +2259,7 @@ DM
 "}
 (10,1,1) = {"
 xt
-Hr
+lZ
 Il
 QE
 sB
@@ -2093,12 +2282,12 @@ DM
 (11,1,1) = {"
 jl
 Hr
-JD
+kv
 JD
 JD
 aQ
 At
-FM
+KB
 VF
 bF
 Hr
@@ -2113,17 +2302,17 @@ Qk
 tF
 "}
 (12,1,1) = {"
-pC
+Nt
 oZ
 VP
-tx
+pN
 Yo
 RR
 vZ
 Un
 Sg
-il
-Hr
+jU
+Kr
 Qk
 Mo
 BY
@@ -2135,7 +2324,7 @@ VY
 DM
 "}
 (13,1,1) = {"
-pC
+Nt
 Mv
 NY
 tx
@@ -2143,7 +2332,7 @@ JD
 il
 bN
 Un
-WP
+Gm
 WP
 hO
 VY
@@ -2160,7 +2349,7 @@ tF
 jl
 Hj
 JD
-JD
+Ds
 JD
 Hr
 Hr
@@ -2179,7 +2368,7 @@ Qk
 tF
 "}
 (15,1,1) = {"
-pC
+Nt
 Fq
 JD
 JD
@@ -2201,14 +2390,14 @@ VY
 tF
 "}
 (16,1,1) = {"
-QC
+Nt
 xh
 Su
 pR
 vm
 aQ
 Hr
-JD
+Ds
 MQ
 ag
 ak
@@ -2239,13 +2428,13 @@ Nv
 NP
 zf
 sV
-Hr
+Kr
 Qk
 Qk
 Iq
 "}
 (18,1,1) = {"
-pC
+Nt
 cC
 FM
 Un
@@ -2267,14 +2456,14 @@ UM
 cL
 "}
 (19,1,1) = {"
-pC
+Nt
 nT
 uq
 il
 JD
+oU
 Hr
-Hr
-JD
+Ds
 JD
 JD
 Hr
@@ -2291,17 +2480,17 @@ Wl
 (20,1,1) = {"
 jl
 Hr
-Su
+jN
 NY
 JD
 sd
-Hr
+rJ
 Jn
 GJ
 JD
 Hr
 Qk
-QG
+jH
 Hr
 Hr
 Hr
@@ -2315,7 +2504,7 @@ xt
 Hr
 Hr
 wG
-Hr
+JR
 zJ
 Hr
 kb
@@ -2323,10 +2512,10 @@ Hr
 fg
 Hr
 VY
-Mo
+QC
 Hr
 Hr
-Hr
+Kr
 fg
 Hr
 Hz
@@ -2363,8 +2552,8 @@ rQ
 AH
 xt
 jS
-gr
-gr
+Qz
+DZ
 jS
 Qk
 xt
@@ -2409,7 +2598,7 @@ xt
 qT
 Tf
 Tf
-JD
+hD
 ex
 rM
 Sc
@@ -2430,8 +2619,8 @@ RV
 Qk
 hb
 Tf
-Tf
-JD
+Xu
+qW
 xt
 Fh
 rq
@@ -2447,7 +2636,7 @@ Nt
 Rf
 Jn
 GH
-JD
+Ds
 JD
 qO
 Kk
@@ -2469,7 +2658,7 @@ kU
 BU
 Ap
 MT
-MT
+Dc
 MT
 kO
 Qw
@@ -2477,7 +2666,7 @@ gr
 gr
 JD
 xt
-Kr
+XL
 RN
 IG
 is
@@ -2487,7 +2676,7 @@ uK
 jE
 "}
 (29,1,1) = {"
-Su
+oh
 mh
 Vc
 yo
@@ -2500,7 +2689,7 @@ gr
 JD
 xt
 iv
-rM
+VE
 yZ
 QZ
 xt
@@ -2509,11 +2698,11 @@ uK
 uK
 "}
 (30,1,1) = {"
-pC
+Nt
 Jk
 JD
 JD
-JD
+Ds
 CX
 pC
 zU
@@ -2533,7 +2722,7 @@ Pi
 (31,1,1) = {"
 xt
 Zk
-Zc
+ji
 nJ
 Zc
 jS

--- a/maps/map_files/Ice_Colony_v3/sprinkles/25.shivaclf01.dmm
+++ b/maps/map_files/Ice_Colony_v3/sprinkles/25.shivaclf01.dmm
@@ -85,12 +85,15 @@
 	},
 /area/shiva/interior/colony/s_admin)
 <<<<<<< master
+<<<<<<< master
 "aN" = (
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/shiva{
 	icon_state = "multi_tiles"
 	},
 /area/shiva/interior/colony/s_admin)
+=======
+>>>>>>> reimported backup
 =======
 >>>>>>> reimported backup
 "aQ" = (
@@ -167,7 +170,10 @@
 /area/shiva/interior/colony/s_admin)
 "cZ" = (
 /obj/item/device/pinpointer,
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -332,6 +338,7 @@
 /turf/open/auto_turf/snow/layer1,
 /area/shiva/exterior/cp_s_research)
 <<<<<<< master
+<<<<<<< master
 "hD" = (
 /obj/effect/landmark/corpsespawner/clf,
 /obj/item/weapon/melee/twohanded/lungemine,
@@ -339,6 +346,8 @@
 	dir = 1
 	},
 /area/shiva/interior/colony/s_admin)
+=======
+>>>>>>> reimported backup
 =======
 >>>>>>> reimported backup
 "hM" = (
@@ -395,6 +404,7 @@
 	},
 /area/shiva/interior/colony/s_admin)
 <<<<<<< master
+<<<<<<< master
 "ji" = (
 /obj/structure/bed/chair{
 	dir = 8;
@@ -409,6 +419,8 @@
 /area/shiva/interior/colony/s_admin)
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> reimported backup
 "jl" = (
 /obj/structure/sign/poster/clf,
 /turf/closed/wall/shiva/prefabricated,
@@ -416,6 +428,7 @@
 "jE" = (
 /turf/open/auto_turf/snow/layer1,
 /area/shiva/exterior/junkyard/cp_bar)
+<<<<<<< master
 <<<<<<< master
 "jH" = (
 /obj/effect/spawner/random/attachment,
@@ -435,6 +448,8 @@
 /area/shiva/interior/colony/s_admin)
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> reimported backup
 "jS" = (
 /obj/structure/flora/pottedplant,
 /turf/open/floor/shiva{
@@ -442,12 +457,15 @@
 	},
 /area/shiva/interior/colony/s_admin)
 <<<<<<< master
+<<<<<<< master
 "jU" = (
 /obj/effect/landmark/corpsespawner/clf,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
 /area/shiva/interior/colony/s_admin)
+=======
+>>>>>>> reimported backup
 =======
 >>>>>>> reimported backup
 "kb" = (
@@ -473,6 +491,7 @@
 	},
 /area/shiva/interior/colony/s_admin)
 <<<<<<< master
+<<<<<<< master
 "kv" = (
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor{
@@ -480,6 +499,8 @@
 	icon_state = "damaged3"
 	},
 /area/shiva/interior/colony/s_admin)
+=======
+>>>>>>> reimported backup
 =======
 >>>>>>> reimported backup
 "kL" = (
@@ -509,9 +530,12 @@
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
 <<<<<<< master
+<<<<<<< master
 /obj/item/explosive/mine/clf/active{
 	dir = 1
 	},
+=======
+>>>>>>> reimported backup
 =======
 >>>>>>> reimported backup
 /turf/open/floor/shiva{
@@ -520,6 +544,7 @@
 /area/shiva/interior/colony/s_admin)
 "kY" = (
 /obj/structure/surface/table/reinforced/prison,
+<<<<<<< master
 <<<<<<< master
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
@@ -536,6 +561,9 @@
 /area/shiva/interior/colony/s_admin)
 "lZ" = (
 /obj/effect/landmark/corpsespawner/clf,
+=======
+/obj/effect/landmark/good_item,
+>>>>>>> reimported backup
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -613,7 +641,10 @@
 	pixel_y = -5
 	},
 <<<<<<< master
+<<<<<<< master
 /obj/effect/landmark/corpsespawner/clf,
+=======
+>>>>>>> reimported backup
 =======
 >>>>>>> reimported backup
 /turf/open/floor/shiva{
@@ -634,6 +665,7 @@
 "nX" = (
 /turf/open/auto_turf/snow/layer0,
 /area/shiva/exterior/junkyard/cp_bar)
+<<<<<<< master
 <<<<<<< master
 "oh" = (
 /obj/effect/decal/cleanable/blood{
@@ -657,6 +689,8 @@
 /area/shiva/interior/colony/s_admin)
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> reimported backup
 "oZ" = (
 /obj/structure/barricade/metal/wired{
 	icon_state = "metal_1";
@@ -678,6 +712,7 @@
 /turf/open/floor/plating,
 /area/shiva/interior/colony/s_admin)
 <<<<<<< master
+<<<<<<< master
 "pN" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/explosive/mine/clf/active{
@@ -687,6 +722,8 @@
 	dir = 1
 	},
 /area/shiva/interior/colony/s_admin)
+=======
+>>>>>>> reimported backup
 =======
 >>>>>>> reimported backup
 "pR" = (
@@ -721,6 +758,7 @@
 	},
 /area/shiva/interior/colony/s_admin)
 <<<<<<< master
+<<<<<<< master
 "qW" = (
 /obj/item/explosive/mine/clf/active{
 	dir = 4
@@ -729,6 +767,8 @@
 	dir = 1
 	},
 /area/shiva/interior/colony/s_admin)
+=======
+>>>>>>> reimported backup
 =======
 >>>>>>> reimported backup
 "qZ" = (
@@ -744,6 +784,7 @@
 	},
 /area/shiva/interior/colony/s_admin)
 <<<<<<< master
+<<<<<<< master
 "rJ" = (
 /obj/item/explosive/mine/clf/active,
 /obj/effect/landmark/survivor_spawner/clf/generic,
@@ -753,11 +794,14 @@
 /area/shiva/interior/colony/s_admin)
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> reimported backup
 "rM" = (
 /turf/open/floor/wood,
 /area/shiva/interior/colony/s_admin)
 "rP" = (
 /obj/structure/surface/table/reinforced/prison,
+<<<<<<< master
 <<<<<<< master
 /obj/item/weapon/gun/rifle/mar40/lmg{
 	pixel_y = 13
@@ -767,6 +811,9 @@
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
+=======
+/obj/item/weapon/gun/rifle/mar40/lmg,
+>>>>>>> reimported backup
 =======
 /obj/item/weapon/gun/rifle/mar40/lmg,
 >>>>>>> reimported backup
@@ -835,6 +882,10 @@
 	pixel_x = -24
 	},
 <<<<<<< master
+<<<<<<< master
+=======
+/obj/effect/landmark/crap_item,
+>>>>>>> reimported backup
 =======
 /obj/effect/landmark/crap_item,
 >>>>>>> reimported backup
@@ -921,7 +972,10 @@
 	dir = 1;
 	tag = "icon-chair (NORTH)"
 	},
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -1204,7 +1258,10 @@
 /area/shiva/interior/colony/s_admin)
 "BY" = (
 /obj/structure/bed/chair,
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -1234,6 +1291,7 @@
 	},
 /area/shiva/interior/colony/s_admin)
 <<<<<<< master
+<<<<<<< master
 "Dc" = (
 /obj/item/explosive/mine/clf/active{
 	dir = 1
@@ -1251,6 +1309,8 @@
 /area/shiva/interior/colony/s_admin)
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> reimported backup
 "DI" = (
 /obj/effect/decal/cleanable/blood{
 	layer = 3
@@ -1264,6 +1324,7 @@
 /turf/open/auto_turf/snow/layer3,
 /area/shiva/exterior/cp_s_research)
 <<<<<<< master
+<<<<<<< master
 "DZ" = (
 /obj/effect/decal/cleanable/blood{
 	layer = 3
@@ -1273,6 +1334,8 @@
 	icon_state = "bluefull"
 	},
 /area/shiva/interior/colony/s_admin)
+=======
+>>>>>>> reimported backup
 =======
 >>>>>>> reimported backup
 "Ed" = (
@@ -1338,6 +1401,10 @@
 	},
 /obj/item/spacecash/c1000,
 /obj/item/spacecash/c500,
+<<<<<<< master
+=======
+/obj/effect/landmark/good_item,
+>>>>>>> reimported backup
 /obj/item/storage/pill_bottle/ultrazine/skillless,
 /turf/open/floor/shiva{
 	dir = 8;
@@ -1504,6 +1571,7 @@
 /turf/open/auto_turf/snow/layer2,
 /area/shiva/exterior/cp_lz2)
 <<<<<<< master
+<<<<<<< master
 "JR" = (
 /obj/item/explosive/mine/clf/active{
 	dir = 8
@@ -1512,6 +1580,8 @@
 	icon_state = "bluefull"
 	},
 /area/shiva/interior/colony/s_admin)
+=======
+>>>>>>> reimported backup
 =======
 >>>>>>> reimported backup
 "JV" = (
@@ -1535,14 +1605,20 @@
 	},
 /area/shiva/interior/colony/s_admin)
 "Kr" = (
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 =======
+=======
+>>>>>>> reimported backup
 /obj/structure/closet/secure_closet/personal,
 /obj/effect/landmark/good_item,
 /turf/open/floor/shiva{
 	icon_state = "floor3"
+<<<<<<< master
+>>>>>>> reimported backup
+=======
 >>>>>>> reimported backup
 	},
 /area/shiva/interior/colony/s_admin)
@@ -1553,6 +1629,7 @@
 	},
 /area/shiva/interior/colony/s_admin)
 <<<<<<< master
+<<<<<<< master
 "KB" = (
 /obj/item/explosive/mine/clf/active{
 	dir = 4
@@ -1562,6 +1639,8 @@
 	icon_state = "damaged3"
 	},
 /area/shiva/interior/colony/s_admin)
+=======
+>>>>>>> reimported backup
 =======
 >>>>>>> reimported backup
 "KP" = (
@@ -1637,10 +1716,15 @@
 /area/shiva/interior/colony/s_admin)
 "Nt" = (
 <<<<<<< master
+<<<<<<< master
 /obj/structure/window_frame/colony/reinforced,
 /obj/item/explosive/mine/clf/active{
 	dir = 1
 	},
+=======
+/obj/item/stack/rods,
+/obj/structure/window_frame/colony/reinforced,
+>>>>>>> reimported backup
 =======
 /obj/item/stack/rods,
 /obj/structure/window_frame/colony/reinforced,
@@ -1660,7 +1744,10 @@
 "NB" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/structure/bed/chair,
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -1670,7 +1757,10 @@
 	layer = 3
 	},
 /obj/structure/bed/chair,
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -1767,6 +1857,7 @@
 	},
 /area/shiva/interior/colony/s_admin)
 <<<<<<< master
+<<<<<<< master
 "Qz" = (
 /obj/item/explosive/mine/clf/active{
 	dir = 1
@@ -1782,11 +1873,16 @@
 	icon_state = "bluefull"
 	},
 =======
+=======
+>>>>>>> reimported backup
 "QC" = (
 /obj/structure/window_frame/colony/reinforced,
 /obj/item/stack/rods,
 /obj/item/stack/rods,
 /turf/open/floor/plating,
+<<<<<<< master
+>>>>>>> reimported backup
+=======
 >>>>>>> reimported backup
 /area/shiva/interior/colony/s_admin)
 "QE" = (
@@ -1881,7 +1977,10 @@
 /obj/item/tool/pen/blue{
 	pixel_x = 5
 	},
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/wood,
 /area/shiva/interior/colony/s_admin)
 "Sg" = (
@@ -2023,10 +2122,13 @@
 /turf/open/auto_turf/snow/layer2,
 /area/shiva/exterior/junkyard/cp_bar)
 <<<<<<< master
+<<<<<<< master
 "VE" = (
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/wood,
 /area/shiva/interior/colony/s_admin)
+=======
+>>>>>>> reimported backup
 =======
 >>>>>>> reimported backup
 "VF" = (
@@ -2040,7 +2142,10 @@
 "VP" = (
 /obj/effect/landmark/corpsespawner/chef,
 /obj/item/ammo_casing/bullet,
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/shiva{
 	dir = 1
 	},
@@ -2080,6 +2185,7 @@
 	},
 /area/shiva/interior/colony/s_admin)
 <<<<<<< master
+<<<<<<< master
 "Xu" = (
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/shiva{
@@ -2087,6 +2193,8 @@
 	icon_state = "multi_tiles"
 	},
 /area/shiva/interior/colony/s_admin)
+=======
+>>>>>>> reimported backup
 =======
 >>>>>>> reimported backup
 "XJ" = (
@@ -2343,7 +2451,11 @@ DM
 (10,1,1) = {"
 xt
 <<<<<<< master
+<<<<<<< master
 lZ
+=======
+Hr
+>>>>>>> reimported backup
 =======
 Hr
 >>>>>>> reimported backup
@@ -2369,10 +2481,19 @@ DM
 (11,1,1) = {"
 jl
 Hr
+<<<<<<< master
 qW
 JD
 JD
 DZ
+At
+FM
+>>>>>>> reimported backup
+=======
+JD
+JD
+JD
+aQ
 At
 FM
 >>>>>>> reimported backup
@@ -2391,15 +2512,21 @@ tF
 "}
 (12,1,1) = {"
 <<<<<<< master
+<<<<<<< master
 Nt
 oZ
 VP
 pN
 =======
+=======
+>>>>>>> reimported backup
 pC
 oZ
 VP
 tx
+<<<<<<< master
+>>>>>>> reimported backup
+=======
 >>>>>>> reimported backup
 Yo
 RR
@@ -2407,8 +2534,13 @@ vZ
 Un
 Sg
 <<<<<<< master
+<<<<<<< master
 jU
 Kr
+=======
+il
+Hr
+>>>>>>> reimported backup
 =======
 il
 Hr
@@ -2425,7 +2557,11 @@ DM
 "}
 (13,1,1) = {"
 <<<<<<< master
+<<<<<<< master
 Nt
+=======
+pC
+>>>>>>> reimported backup
 =======
 pC
 >>>>>>> reimported backup
@@ -2458,7 +2594,11 @@ JD
 Hr
 Hr
 WP
+<<<<<<< master
 kv
+=======
+FM
+>>>>>>> reimported backup
 Un
 Hr
 pL
@@ -2473,9 +2613,16 @@ tF
 "}
 (15,1,1) = {"
 <<<<<<< master
+<<<<<<< master
 Nt
 Fq
 Ds
+JD
+>>>>>>> reimported backup
+=======
+pC
+Fq
+JD
 JD
 >>>>>>> reimported backup
 JD
@@ -2488,7 +2635,11 @@ Ey
 pL
 zI
 Hr
+<<<<<<< master
 QC
+=======
+fg
+>>>>>>> reimported backup
 Hr
 Hr
 Mo
@@ -2497,7 +2648,11 @@ tF
 "}
 (16,1,1) = {"
 <<<<<<< master
+<<<<<<< master
 Nt
+=======
+QC
+>>>>>>> reimported backup
 =======
 QC
 >>>>>>> reimported backup
@@ -2528,7 +2683,11 @@ Ey
 Un
 YL
 BG
+<<<<<<< master
 Kr
+=======
+Hr
+>>>>>>> reimported backup
 JD
 MQ
 Zz
@@ -2545,7 +2704,11 @@ Iq
 "}
 (18,1,1) = {"
 <<<<<<< master
+<<<<<<< master
 Nt
+=======
+pC
+>>>>>>> reimported backup
 =======
 pC
 >>>>>>> reimported backup
@@ -2571,7 +2734,11 @@ cL
 "}
 (19,1,1) = {"
 <<<<<<< master
+<<<<<<< master
 Nt
+=======
+pC
+>>>>>>> reimported backup
 =======
 pC
 >>>>>>> reimported backup
@@ -2580,12 +2747,19 @@ uq
 il
 JD
 <<<<<<< master
+<<<<<<< master
 oU
 Hr
 Ds
 =======
 Hr
 Hr
+JD
+>>>>>>> reimported backup
+=======
+Hr
+Hr
+JD
 JD
 >>>>>>> reimported backup
 JD
@@ -2604,6 +2778,7 @@ Wl
 jl
 Hr
 <<<<<<< master
+<<<<<<< master
 jN
 NY
 JD
@@ -2616,17 +2791,26 @@ Hr
 Qk
 jH
 =======
+=======
+>>>>>>> reimported backup
 Su
 NY
 JD
 sd
+<<<<<<< master
 rJ
+=======
+Hr
+>>>>>>> reimported backup
 Jn
 GJ
 JD
 Hr
 Qk
 QG
+<<<<<<< master
+>>>>>>> reimported backup
+=======
 >>>>>>> reimported backup
 Hr
 Hr
@@ -2642,7 +2826,11 @@ Hr
 Hr
 wG
 <<<<<<< master
+<<<<<<< master
 JR
+=======
+Hr
+>>>>>>> reimported backup
 =======
 Hr
 >>>>>>> reimported backup
@@ -2651,13 +2839,21 @@ Hr
 kb
 Hr
 fg
+<<<<<<< master
 Kr
+=======
+Hr
+>>>>>>> reimported backup
 VY
 Mo
 Hr
 Hr
 Hr
+<<<<<<< master
 QC
+=======
+fg
+>>>>>>> reimported backup
 Hr
 Hz
 Wl
@@ -2694,7 +2890,11 @@ AH
 xt
 jS
 <<<<<<< master
+<<<<<<< master
 Qz
+=======
+gr
+>>>>>>> reimported backup
 gr
 jS
 Qk
@@ -2738,9 +2938,15 @@ OT
 fP
 xt
 qT
+<<<<<<< master
 Xu
 Tf
 hD
+=======
+Tf
+Tf
+JD
+>>>>>>> reimported backup
 ex
 rM
 Sc
@@ -2762,7 +2968,11 @@ Qk
 hb
 Tf
 Tf
+<<<<<<< master
 qW
+=======
+JD
+>>>>>>> reimported backup
 =======
 JD
 >>>>>>> reimported backup
@@ -2804,7 +3014,11 @@ BU
 Ap
 MT
 <<<<<<< master
+<<<<<<< master
 Dc
+=======
+MT
+>>>>>>> reimported backup
 =======
 MT
 >>>>>>> reimported backup
@@ -2816,7 +3030,11 @@ gr
 JD
 xt
 <<<<<<< master
+<<<<<<< master
 XL
+=======
+Kr
+>>>>>>> reimported backup
 =======
 Kr
 >>>>>>> reimported backup
@@ -2830,7 +3048,11 @@ jE
 "}
 (29,1,1) = {"
 <<<<<<< master
+<<<<<<< master
 oh
+=======
+Su
+>>>>>>> reimported backup
 =======
 Su
 >>>>>>> reimported backup
@@ -2842,11 +3064,18 @@ MT
 JD
 dT
 gr
+<<<<<<< master
 aN
+=======
+gr
+>>>>>>> reimported backup
 JD
 xt
 iv
 rM
+<<<<<<< master
+>>>>>>> reimported backup
+=======
 >>>>>>> reimported backup
 yZ
 QZ
@@ -2857,9 +3086,16 @@ uK
 "}
 (30,1,1) = {"
 <<<<<<< master
+<<<<<<< master
 Nt
 Jk
 Ds
+JD
+>>>>>>> reimported backup
+=======
+pC
+Jk
+JD
 JD
 >>>>>>> reimported backup
 JD
@@ -2883,7 +3119,11 @@ Pi
 xt
 Zk
 <<<<<<< master
+<<<<<<< master
 ji
+=======
+Zc
+>>>>>>> reimported backup
 =======
 Zc
 >>>>>>> reimported backup

--- a/maps/map_files/Ice_Colony_v3/sprinkles/25.shivaclf01.dmm
+++ b/maps/map_files/Ice_Colony_v3/sprinkles/25.shivaclf01.dmm
@@ -85,6 +85,7 @@
 	},
 /area/shiva/interior/colony/s_admin)
 <<<<<<< master
+<<<<<<< master
 "aN" = (
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/shiva{
@@ -93,6 +94,14 @@
 /area/shiva/interior/colony/s_admin)
 =======
 >>>>>>> reimported backup
+=======
+"aN" = (
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/shiva/interior/colony/s_admin)
+>>>>>>> updated all maps to have CLF Mines and corpses
 "aQ" = (
 /obj/effect/decal/cleanable/blood{
 	layer = 3
@@ -168,9 +177,13 @@
 "cZ" = (
 /obj/item/device/pinpointer,
 <<<<<<< master
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
 =======
 >>>>>>> reimported backup
+=======
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -335,6 +348,9 @@
 /turf/open/auto_turf/snow/layer1,
 /area/shiva/exterior/cp_s_research)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "hD" = (
 /obj/effect/landmark/corpsespawner/clf,
 /obj/item/weapon/melee/twohanded/lungemine,
@@ -342,8 +358,11 @@
 	dir = 1
 	},
 /area/shiva/interior/colony/s_admin)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "hM" = (
 /turf/open/auto_turf/ice/layer1,
 /area/shiva/exterior/cp_s_research)
@@ -398,6 +417,9 @@
 	},
 /area/shiva/interior/colony/s_admin)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "ji" = (
 /obj/structure/bed/chair{
 	dir = 8;
@@ -410,8 +432,11 @@
 	dir = 1
 	},
 /area/shiva/interior/colony/s_admin)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "jl" = (
 /obj/structure/sign/poster/clf,
 /turf/closed/wall/shiva/prefabricated,
@@ -420,9 +445,15 @@
 /turf/open/auto_turf/snow/layer1,
 /area/shiva/exterior/junkyard/cp_bar)
 <<<<<<< master
+<<<<<<< master
 "jH" = (
 /obj/effect/spawner/random/attachment,
 /obj/effect/landmark/survivor_spawner/clf/generic,
+=======
+"jH" = (
+/obj/effect/spawner/random/attachment,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor/shiva{
 	icon_state = "floor3"
 	},
@@ -431,13 +462,20 @@
 /obj/effect/decal/cleanable/blood{
 	layer = 3
 	},
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
+=======
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor/shiva{
 	dir = 1
 	},
 /area/shiva/interior/colony/s_admin)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "jS" = (
 /obj/structure/flora/pottedplant,
 /turf/open/floor/shiva{
@@ -445,14 +483,20 @@
 	},
 /area/shiva/interior/colony/s_admin)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "jU" = (
 /obj/effect/landmark/corpsespawner/clf,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
 /area/shiva/interior/colony/s_admin)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "kb" = (
 /obj/item/stack/rods,
 /obj/effect/decal/cleanable/blood{
@@ -476,6 +520,7 @@
 	},
 /area/shiva/interior/colony/s_admin)
 <<<<<<< master
+<<<<<<< master
 "kv" = (
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor{
@@ -485,6 +530,17 @@
 /area/shiva/interior/colony/s_admin)
 =======
 >>>>>>> reimported backup
+=======
+"kv" = (
+/obj/item/explosive/mine/clf/active{
+	dir = 4
+	},
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/interior/colony/s_admin)
+>>>>>>> updated all maps to have CLF Mines and corpses
 "kL" = (
 /obj/structure/barricade/wooden{
 	dir = 4;
@@ -512,11 +568,17 @@
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
 <<<<<<< master
+<<<<<<< master
 /obj/item/explosive/mine/clf/active{
 	dir = 1
 	},
 =======
 >>>>>>> reimported backup
+=======
+/obj/item/explosive/mine/clf/active{
+	dir = 1
+	},
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor/shiva{
 	dir = 1
 	},
@@ -524,15 +586,21 @@
 "kY" = (
 /obj/structure/surface/table/reinforced/prison,
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
 /area/shiva/interior/colony/s_admin)
 "lZ" = (
 /obj/effect/landmark/corpsespawner/clf,
+<<<<<<< master
 =======
 /obj/effect/landmark/good_item,
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -619,9 +687,13 @@
 	pixel_y = -5
 	},
 <<<<<<< master
+<<<<<<< master
 /obj/effect/landmark/corpsespawner/clf,
 =======
 >>>>>>> reimported backup
+=======
+/obj/effect/landmark/corpsespawner/clf,
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor/shiva{
 	dir = 1
 	},
@@ -641,6 +713,9 @@
 /turf/open/auto_turf/snow/layer0,
 /area/shiva/exterior/junkyard/cp_bar)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "oh" = (
 /obj/effect/decal/cleanable/blood{
 	layer = 3
@@ -661,8 +736,11 @@
 	icon_state = "bluefull"
 	},
 /area/shiva/interior/colony/s_admin)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "oZ" = (
 /obj/structure/barricade/metal/wired{
 	icon_state = "metal_1";
@@ -684,6 +762,9 @@
 /turf/open/floor/plating,
 /area/shiva/interior/colony/s_admin)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "pN" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/explosive/mine/clf/active{
@@ -693,8 +774,11 @@
 	dir = 1
 	},
 /area/shiva/interior/colony/s_admin)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "pR" = (
 /obj/effect/decal/cleanable/blood{
 	layer = 3
@@ -727,6 +811,9 @@
 	},
 /area/shiva/interior/colony/s_admin)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "qW" = (
 /obj/item/explosive/mine/clf/active{
 	dir = 4
@@ -735,8 +822,11 @@
 	dir = 1
 	},
 /area/shiva/interior/colony/s_admin)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "qZ" = (
 /turf/open/auto_turf/snow/layer3,
 /area/shiva/exterior/cp_lz2)
@@ -750,21 +840,32 @@
 	},
 /area/shiva/interior/colony/s_admin)
 <<<<<<< master
+<<<<<<< master
 "rJ" = (
 /obj/item/explosive/mine/clf/active,
 /obj/effect/landmark/survivor_spawner/clf/generic,
+=======
+"rJ" = (
+/obj/item/explosive/mine/clf/active,
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
 /area/shiva/interior/colony/s_admin)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "rM" = (
 /turf/open/floor/wood,
 /area/shiva/interior/colony/s_admin)
 "rP" = (
 /obj/structure/surface/table/reinforced/prison,
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 /obj/item/weapon/gun/rifle/mar40/lmg{
 	pixel_y = 13
 	},
@@ -773,9 +874,12 @@
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
+<<<<<<< master
 =======
 /obj/item/weapon/gun/rifle/mar40/lmg,
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -792,6 +896,7 @@
 "sd" = (
 /obj/effect/landmark/corpsespawner/colonist,
 /obj/item/weapon/gun/pistol/holdout,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -841,9 +946,12 @@
 	pixel_x = -24
 	},
 <<<<<<< master
+<<<<<<< master
 =======
 /obj/effect/landmark/crap_item,
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -928,9 +1036,13 @@
 	tag = "icon-chair (NORTH)"
 	},
 <<<<<<< master
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
 =======
 >>>>>>> reimported backup
+=======
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -1100,6 +1212,7 @@
 	dir = 4;
 	pixel_x = 24
 	},
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -1146,6 +1259,7 @@
 /area/shiva/interior/colony/s_admin)
 "Ap" = (
 /obj/effect/decal/cleanable/blood/oil/streak,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor/shiva{
 	dir = 8;
 	icon_state = "multi_tiles"
@@ -1196,6 +1310,7 @@
 /obj/effect/decal/cleanable/blood{
 	layer = 3
 	},
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -1214,9 +1329,13 @@
 "BY" = (
 /obj/structure/bed/chair,
 <<<<<<< master
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
 =======
 >>>>>>> reimported backup
+=======
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -1246,6 +1365,9 @@
 	},
 /area/shiva/interior/colony/s_admin)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "Dc" = (
 /obj/item/explosive/mine/clf/active{
 	dir = 1
@@ -1256,13 +1378,20 @@
 	},
 /area/shiva/interior/colony/s_admin)
 "Ds" = (
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
+=======
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor/shiva{
 	dir = 1
 	},
 /area/shiva/interior/colony/s_admin)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "DI" = (
 /obj/effect/decal/cleanable/blood{
 	layer = 3
@@ -1276,6 +1405,7 @@
 /turf/open/auto_turf/snow/layer3,
 /area/shiva/exterior/cp_s_research)
 <<<<<<< master
+<<<<<<< master
 "DZ" = (
 /obj/effect/decal/cleanable/blood{
 	layer = 3
@@ -1287,6 +1417,14 @@
 /area/shiva/interior/colony/s_admin)
 =======
 >>>>>>> reimported backup
+=======
+"DZ" = (
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/turf/open/floor/shiva{
+	icon_state = "multi_tiles"
+	},
+/area/shiva/interior/colony/s_admin)
+>>>>>>> updated all maps to have CLF Mines and corpses
 "Ed" = (
 /obj/effect/decal/cleanable/blood{
 	icon_state = "xgibdown1";
@@ -1364,6 +1502,13 @@
 /turf/open/floor{
 	dir = 8;
 	icon_state = "damaged3"
+	},
+/area/shiva/interior/colony/s_admin)
+"Gm" = (
+/obj/item/stack/sandbags,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/turf/open/floor{
+	icon_state = "platingdmg1"
 	},
 /area/shiva/interior/colony/s_admin)
 "GH" = (
@@ -1520,6 +1665,9 @@
 /turf/open/auto_turf/snow/layer2,
 /area/shiva/exterior/cp_lz2)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "JR" = (
 /obj/item/explosive/mine/clf/active{
 	dir = 8
@@ -1528,8 +1676,11 @@
 	icon_state = "bluefull"
 	},
 /area/shiva/interior/colony/s_admin)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "JV" = (
 /turf/open/auto_turf/snow/layer2,
 /area/shiva/exterior/cp_lz2)
@@ -1552,6 +1703,7 @@
 /area/shiva/interior/colony/s_admin)
 "Kr" = (
 <<<<<<< master
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
@@ -1561,6 +1713,11 @@
 /turf/open/floor/shiva{
 	icon_state = "floor3"
 >>>>>>> reimported backup
+=======
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/turf/open/floor/shiva{
+	icon_state = "bluefull"
+>>>>>>> updated all maps to have CLF Mines and corpses
 	},
 /area/shiva/interior/colony/s_admin)
 "Kv" = (
@@ -1570,6 +1727,9 @@
 	},
 /area/shiva/interior/colony/s_admin)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "KB" = (
 /obj/item/explosive/mine/clf/active{
 	dir = 4
@@ -1579,8 +1739,11 @@
 	icon_state = "damaged3"
 	},
 /area/shiva/interior/colony/s_admin)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "KP" = (
 /obj/structure/machinery/light/double{
 	dir = 4;
@@ -1654,6 +1817,7 @@
 /area/shiva/interior/colony/s_admin)
 "Nt" = (
 <<<<<<< master
+<<<<<<< master
 /obj/structure/window_frame/colony/reinforced,
 /obj/item/explosive/mine/clf/active{
 	dir = 1
@@ -1662,6 +1826,12 @@
 /obj/item/stack/rods,
 /obj/structure/window_frame/colony/reinforced,
 >>>>>>> reimported backup
+=======
+/obj/structure/window_frame/colony/reinforced,
+/obj/item/explosive/mine/clf/active{
+	dir = 1
+	},
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor/plating,
 /area/shiva/interior/colony/s_admin)
 "Nv" = (
@@ -1678,9 +1848,13 @@
 /obj/effect/decal/cleanable/blood/drip,
 /obj/structure/bed/chair,
 <<<<<<< master
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
 =======
 >>>>>>> reimported backup
+=======
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -1691,9 +1865,13 @@
 	},
 /obj/structure/bed/chair,
 <<<<<<< master
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
 =======
 >>>>>>> reimported backup
+=======
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -1740,6 +1918,7 @@
 	pixel_x = -24
 	},
 /obj/item/device/flashlight/lamp,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor/shiva{
 	icon_state = "floor3"
 	},
@@ -1790,6 +1969,9 @@
 	},
 /area/shiva/interior/colony/s_admin)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "Qz" = (
 /obj/item/explosive/mine/clf/active{
 	dir = 1
@@ -1798,6 +1980,7 @@
 	icon_state = "multi_tiles"
 	},
 /area/shiva/interior/colony/s_admin)
+<<<<<<< master
 "QC" = (
 /obj/effect/spawner/random/attachment,
 /obj/effect/landmark/survivor_spawner/clf/generic,
@@ -1811,6 +1994,13 @@
 /obj/item/stack/rods,
 /turf/open/floor/plating,
 >>>>>>> reimported backup
+=======
+"QC" = (
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/turf/open/floor/shiva{
+	icon_state = "floor3"
+	},
+>>>>>>> updated all maps to have CLF Mines and corpses
 /area/shiva/interior/colony/s_admin)
 "QE" = (
 /obj/structure/machinery/light/double{
@@ -2049,12 +2239,19 @@
 /turf/open/auto_turf/snow/layer2,
 /area/shiva/exterior/junkyard/cp_bar)
 <<<<<<< master
+<<<<<<< master
 "VE" = (
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/wood,
 /area/shiva/interior/colony/s_admin)
 =======
 >>>>>>> reimported backup
+=======
+"VE" = (
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/turf/open/floor/wood,
+/area/shiva/interior/colony/s_admin)
+>>>>>>> updated all maps to have CLF Mines and corpses
 "VF" = (
 /obj/item/shard{
 	icon_state = "medium"
@@ -2109,15 +2306,23 @@
 	},
 /area/shiva/interior/colony/s_admin)
 <<<<<<< master
+<<<<<<< master
 "Xu" = (
 /obj/effect/landmark/survivor_spawner/clf/generic,
+=======
+"Xu" = (
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor/shiva{
 	dir = 6;
 	icon_state = "multi_tiles"
 	},
 /area/shiva/interior/colony/s_admin)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "XJ" = (
 /obj/effect/spawner/random/attachment,
 /turf/open/floor/shiva{
@@ -2340,7 +2545,7 @@ Qk
 FI
 Mo
 Un
-Un
+aN
 yw
 Qk
 DM
@@ -2372,10 +2577,14 @@ DM
 (10,1,1) = {"
 xt
 <<<<<<< master
+<<<<<<< master
 lZ
 =======
 Hr
 >>>>>>> reimported backup
+=======
+lZ
+>>>>>>> updated all maps to have CLF Mines and corpses
 Il
 QE
 sB
@@ -2399,6 +2608,7 @@ DM
 jl
 Hr
 <<<<<<< master
+<<<<<<< master
 qW
 JD
 JD
@@ -2407,12 +2617,19 @@ At
 KB
 =======
 JD
+=======
+kv
+>>>>>>> updated all maps to have CLF Mines and corpses
 JD
 JD
 aQ
 At
+<<<<<<< master
 FM
 >>>>>>> reimported backup
+=======
+KB
+>>>>>>> updated all maps to have CLF Mines and corpses
 VF
 bF
 Hr
@@ -2428,6 +2645,7 @@ tF
 "}
 (12,1,1) = {"
 <<<<<<< master
+<<<<<<< master
 Nt
 oZ
 VP
@@ -2438,11 +2656,18 @@ oZ
 VP
 tx
 >>>>>>> reimported backup
+=======
+Nt
+oZ
+VP
+pN
+>>>>>>> updated all maps to have CLF Mines and corpses
 Yo
 RR
 vZ
 Un
 Sg
+<<<<<<< master
 <<<<<<< master
 jU
 Kr
@@ -2450,6 +2675,10 @@ Kr
 il
 Hr
 >>>>>>> reimported backup
+=======
+jU
+Kr
+>>>>>>> updated all maps to have CLF Mines and corpses
 Qk
 Mo
 BY
@@ -2462,10 +2691,14 @@ DM
 "}
 (13,1,1) = {"
 <<<<<<< master
+<<<<<<< master
 Nt
 =======
 pC
 >>>>>>> reimported backup
+=======
+Nt
+>>>>>>> updated all maps to have CLF Mines and corpses
 Mv
 NY
 tx
@@ -2473,7 +2706,7 @@ JD
 il
 bN
 Un
-WP
+Gm
 WP
 hO
 VY
@@ -2490,7 +2723,7 @@ tF
 jl
 Hj
 JD
-JD
+Ds
 JD
 Hr
 Hr
@@ -2514,11 +2747,15 @@ tF
 "}
 (15,1,1) = {"
 <<<<<<< master
+<<<<<<< master
 Nt
 Fq
 Ds
 =======
 pC
+=======
+Nt
+>>>>>>> updated all maps to have CLF Mines and corpses
 Fq
 JD
 >>>>>>> reimported backup
@@ -2546,17 +2783,21 @@ tF
 "}
 (16,1,1) = {"
 <<<<<<< master
+<<<<<<< master
 Nt
 =======
 QC
 >>>>>>> reimported backup
+=======
+Nt
+>>>>>>> updated all maps to have CLF Mines and corpses
 xh
 Su
 pR
 vm
 aQ
 Hr
-JD
+Ds
 MQ
 ag
 ak
@@ -2591,17 +2832,21 @@ Nv
 NP
 zf
 sV
-Hr
+Kr
 Qk
 Qk
 Iq
 "}
 (18,1,1) = {"
 <<<<<<< master
+<<<<<<< master
 Nt
 =======
 pC
 >>>>>>> reimported backup
+=======
+Nt
+>>>>>>> updated all maps to have CLF Mines and corpses
 cC
 FM
 Un
@@ -2624,14 +2869,19 @@ cL
 "}
 (19,1,1) = {"
 <<<<<<< master
+<<<<<<< master
 Nt
 =======
 pC
 >>>>>>> reimported backup
+=======
+Nt
+>>>>>>> updated all maps to have CLF Mines and corpses
 nT
 uq
 il
 JD
+<<<<<<< master
 <<<<<<< master
 oU
 Hr
@@ -2641,6 +2891,11 @@ Hr
 Hr
 JD
 >>>>>>> reimported backup
+=======
+oU
+Hr
+Ds
+>>>>>>> updated all maps to have CLF Mines and corpses
 JD
 JD
 Hr
@@ -2658,6 +2913,7 @@ Wl
 jl
 Hr
 <<<<<<< master
+<<<<<<< master
 jN
 NY
 JD
@@ -2671,17 +2927,24 @@ Qk
 jH
 =======
 Su
+=======
+jN
+>>>>>>> updated all maps to have CLF Mines and corpses
 NY
 JD
 sd
-Hr
+rJ
 Jn
 GJ
 JD
 Hr
 Qk
+<<<<<<< master
 QG
 >>>>>>> reimported backup
+=======
+jH
+>>>>>>> updated all maps to have CLF Mines and corpses
 Hr
 Hr
 Hr
@@ -2696,10 +2959,14 @@ Hr
 Hr
 wG
 <<<<<<< master
+<<<<<<< master
 JR
 =======
 Hr
 >>>>>>> reimported backup
+=======
+JR
+>>>>>>> updated all maps to have CLF Mines and corpses
 zJ
 Hr
 kb
@@ -2711,13 +2978,16 @@ Kr
 Hr
 >>>>>>> reimported backup
 VY
-Mo
-Hr
+QC
 Hr
 Hr
 <<<<<<< master
+<<<<<<< master
 QC
 =======
+=======
+Kr
+>>>>>>> updated all maps to have CLF Mines and corpses
 fg
 >>>>>>> reimported backup
 Hr
@@ -2756,11 +3026,16 @@ AH
 xt
 jS
 <<<<<<< master
+<<<<<<< master
 Qz
 =======
 gr
 >>>>>>> reimported backup
 gr
+=======
+Qz
+DZ
+>>>>>>> updated all maps to have CLF Mines and corpses
 jS
 Qk
 xt
@@ -2810,8 +3085,12 @@ hD
 =======
 Tf
 Tf
+<<<<<<< master
 JD
 >>>>>>> reimported backup
+=======
+hD
+>>>>>>> updated all maps to have CLF Mines and corpses
 ex
 rM
 Sc
@@ -2832,12 +3111,17 @@ RV
 Qk
 hb
 Tf
+<<<<<<< master
 Tf
 <<<<<<< master
 qW
 =======
 JD
 >>>>>>> reimported backup
+=======
+Xu
+qW
+>>>>>>> updated all maps to have CLF Mines and corpses
 xt
 Fh
 rq
@@ -2853,7 +3137,7 @@ Nt
 Rf
 Jn
 GH
-JD
+Ds
 JD
 qO
 Kk
@@ -2876,10 +3160,14 @@ BU
 Ap
 MT
 <<<<<<< master
+<<<<<<< master
 Dc
 =======
 MT
 >>>>>>> reimported backup
+=======
+Dc
+>>>>>>> updated all maps to have CLF Mines and corpses
 MT
 kO
 Qw
@@ -2888,10 +3176,14 @@ gr
 JD
 xt
 <<<<<<< master
+<<<<<<< master
 XL
 =======
 Kr
 >>>>>>> reimported backup
+=======
+XL
+>>>>>>> updated all maps to have CLF Mines and corpses
 RN
 IG
 is
@@ -2902,10 +3194,14 @@ jE
 "}
 (29,1,1) = {"
 <<<<<<< master
+<<<<<<< master
 oh
 =======
 Su
 >>>>>>> reimported backup
+=======
+oh
+>>>>>>> updated all maps to have CLF Mines and corpses
 mh
 Vc
 yo
@@ -2925,8 +3221,12 @@ gr
 JD
 xt
 iv
+<<<<<<< master
 rM
 >>>>>>> reimported backup
+=======
+VE
+>>>>>>> updated all maps to have CLF Mines and corpses
 yZ
 QZ
 xt
@@ -2936,16 +3236,20 @@ uK
 "}
 (30,1,1) = {"
 <<<<<<< master
+<<<<<<< master
 Nt
 Jk
 Ds
 =======
 pC
+=======
+Nt
+>>>>>>> updated all maps to have CLF Mines and corpses
 Jk
 JD
 >>>>>>> reimported backup
 JD
-JD
+Ds
 CX
 pC
 zU
@@ -2966,10 +3270,14 @@ Pi
 xt
 Zk
 <<<<<<< master
+<<<<<<< master
 ji
 =======
 Zc
 >>>>>>> reimported backup
+=======
+ji
+>>>>>>> updated all maps to have CLF Mines and corpses
 nJ
 Zc
 jS

--- a/maps/map_files/Ice_Colony_v3/sprinkles/25.shivaclf01.dmm
+++ b/maps/map_files/Ice_Colony_v3/sprinkles/25.shivaclf01.dmm
@@ -85,15 +85,12 @@
 	},
 /area/shiva/interior/colony/s_admin)
 <<<<<<< master
-<<<<<<< master
 "aN" = (
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/shiva{
 	icon_state = "multi_tiles"
 	},
 /area/shiva/interior/colony/s_admin)
-=======
->>>>>>> reimported backup
 =======
 >>>>>>> reimported backup
 "aQ" = (
@@ -170,7 +167,10 @@
 /area/shiva/interior/colony/s_admin)
 "cZ" = (
 /obj/item/device/pinpointer,
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -335,7 +335,6 @@
 /turf/open/auto_turf/snow/layer1,
 /area/shiva/exterior/cp_s_research)
 <<<<<<< master
-<<<<<<< master
 "hD" = (
 /obj/effect/landmark/corpsespawner/clf,
 /obj/item/weapon/melee/twohanded/lungemine,
@@ -343,8 +342,6 @@
 	dir = 1
 	},
 /area/shiva/interior/colony/s_admin)
-=======
->>>>>>> reimported backup
 =======
 >>>>>>> reimported backup
 "hM" = (
@@ -401,7 +398,6 @@
 	},
 /area/shiva/interior/colony/s_admin)
 <<<<<<< master
-<<<<<<< master
 "ji" = (
 /obj/structure/bed/chair{
 	dir = 8;
@@ -416,8 +412,6 @@
 /area/shiva/interior/colony/s_admin)
 =======
 >>>>>>> reimported backup
-=======
->>>>>>> reimported backup
 "jl" = (
 /obj/structure/sign/poster/clf,
 /turf/closed/wall/shiva/prefabricated,
@@ -425,7 +419,6 @@
 "jE" = (
 /turf/open/auto_turf/snow/layer1,
 /area/shiva/exterior/junkyard/cp_bar)
-<<<<<<< master
 <<<<<<< master
 "jH" = (
 /obj/effect/spawner/random/attachment,
@@ -445,8 +438,6 @@
 /area/shiva/interior/colony/s_admin)
 =======
 >>>>>>> reimported backup
-=======
->>>>>>> reimported backup
 "jS" = (
 /obj/structure/flora/pottedplant,
 /turf/open/floor/shiva{
@@ -454,15 +445,12 @@
 	},
 /area/shiva/interior/colony/s_admin)
 <<<<<<< master
-<<<<<<< master
 "jU" = (
 /obj/effect/landmark/corpsespawner/clf,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
 /area/shiva/interior/colony/s_admin)
-=======
->>>>>>> reimported backup
 =======
 >>>>>>> reimported backup
 "kb" = (
@@ -488,7 +476,6 @@
 	},
 /area/shiva/interior/colony/s_admin)
 <<<<<<< master
-<<<<<<< master
 "kv" = (
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor{
@@ -496,8 +483,6 @@
 	icon_state = "damaged3"
 	},
 /area/shiva/interior/colony/s_admin)
-=======
->>>>>>> reimported backup
 =======
 >>>>>>> reimported backup
 "kL" = (
@@ -527,12 +512,9 @@
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
 <<<<<<< master
-<<<<<<< master
 /obj/item/explosive/mine/clf/active{
 	dir = 1
 	},
-=======
->>>>>>> reimported backup
 =======
 >>>>>>> reimported backup
 /turf/open/floor/shiva{
@@ -541,7 +523,6 @@
 /area/shiva/interior/colony/s_admin)
 "kY" = (
 /obj/structure/surface/table/reinforced/prison,
-<<<<<<< master
 <<<<<<< master
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
@@ -638,10 +619,7 @@
 	pixel_y = -5
 	},
 <<<<<<< master
-<<<<<<< master
 /obj/effect/landmark/corpsespawner/clf,
-=======
->>>>>>> reimported backup
 =======
 >>>>>>> reimported backup
 /turf/open/floor/shiva{
@@ -662,7 +640,6 @@
 "nX" = (
 /turf/open/auto_turf/snow/layer0,
 /area/shiva/exterior/junkyard/cp_bar)
-<<<<<<< master
 <<<<<<< master
 "oh" = (
 /obj/effect/decal/cleanable/blood{
@@ -686,8 +663,6 @@
 /area/shiva/interior/colony/s_admin)
 =======
 >>>>>>> reimported backup
-=======
->>>>>>> reimported backup
 "oZ" = (
 /obj/structure/barricade/metal/wired{
 	icon_state = "metal_1";
@@ -709,7 +684,6 @@
 /turf/open/floor/plating,
 /area/shiva/interior/colony/s_admin)
 <<<<<<< master
-<<<<<<< master
 "pN" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/explosive/mine/clf/active{
@@ -719,8 +693,6 @@
 	dir = 1
 	},
 /area/shiva/interior/colony/s_admin)
-=======
->>>>>>> reimported backup
 =======
 >>>>>>> reimported backup
 "pR" = (
@@ -755,7 +727,6 @@
 	},
 /area/shiva/interior/colony/s_admin)
 <<<<<<< master
-<<<<<<< master
 "qW" = (
 /obj/item/explosive/mine/clf/active{
 	dir = 4
@@ -764,8 +735,6 @@
 	dir = 1
 	},
 /area/shiva/interior/colony/s_admin)
-=======
->>>>>>> reimported backup
 =======
 >>>>>>> reimported backup
 "qZ" = (
@@ -781,7 +750,6 @@
 	},
 /area/shiva/interior/colony/s_admin)
 <<<<<<< master
-<<<<<<< master
 "rJ" = (
 /obj/item/explosive/mine/clf/active,
 /obj/effect/landmark/survivor_spawner/clf/generic,
@@ -791,14 +759,11 @@
 /area/shiva/interior/colony/s_admin)
 =======
 >>>>>>> reimported backup
-=======
->>>>>>> reimported backup
 "rM" = (
 /turf/open/floor/wood,
 /area/shiva/interior/colony/s_admin)
 "rP" = (
 /obj/structure/surface/table/reinforced/prison,
-<<<<<<< master
 <<<<<<< master
 /obj/item/weapon/gun/rifle/mar40/lmg{
 	pixel_y = 13
@@ -808,9 +773,6 @@
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
-=======
-/obj/item/weapon/gun/rifle/mar40/lmg,
->>>>>>> reimported backup
 =======
 /obj/item/weapon/gun/rifle/mar40/lmg,
 >>>>>>> reimported backup
@@ -879,10 +841,6 @@
 	pixel_x = -24
 	},
 <<<<<<< master
-<<<<<<< master
-=======
-/obj/effect/landmark/crap_item,
->>>>>>> reimported backup
 =======
 /obj/effect/landmark/crap_item,
 >>>>>>> reimported backup
@@ -969,7 +927,10 @@
 	dir = 1;
 	tag = "icon-chair (NORTH)"
 	},
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -1252,7 +1213,10 @@
 /area/shiva/interior/colony/s_admin)
 "BY" = (
 /obj/structure/bed/chair,
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -1282,7 +1246,6 @@
 	},
 /area/shiva/interior/colony/s_admin)
 <<<<<<< master
-<<<<<<< master
 "Dc" = (
 /obj/item/explosive/mine/clf/active{
 	dir = 1
@@ -1300,8 +1263,6 @@
 /area/shiva/interior/colony/s_admin)
 =======
 >>>>>>> reimported backup
-=======
->>>>>>> reimported backup
 "DI" = (
 /obj/effect/decal/cleanable/blood{
 	layer = 3
@@ -1315,7 +1276,6 @@
 /turf/open/auto_turf/snow/layer3,
 /area/shiva/exterior/cp_s_research)
 <<<<<<< master
-<<<<<<< master
 "DZ" = (
 /obj/effect/decal/cleanable/blood{
 	layer = 3
@@ -1325,8 +1285,6 @@
 	icon_state = "bluefull"
 	},
 /area/shiva/interior/colony/s_admin)
-=======
->>>>>>> reimported backup
 =======
 >>>>>>> reimported backup
 "Ed" = (
@@ -1392,6 +1350,10 @@
 	},
 /obj/item/spacecash/c1000,
 /obj/item/spacecash/c500,
+<<<<<<< master
+=======
+/obj/effect/landmark/good_item,
+>>>>>>> reimported backup
 /obj/item/storage/pill_bottle/ultrazine/skillless,
 /turf/open/floor/shiva{
 	dir = 8;
@@ -1558,7 +1520,6 @@
 /turf/open/auto_turf/snow/layer2,
 /area/shiva/exterior/cp_lz2)
 <<<<<<< master
-<<<<<<< master
 "JR" = (
 /obj/item/explosive/mine/clf/active{
 	dir = 8
@@ -1567,8 +1528,6 @@
 	icon_state = "bluefull"
 	},
 /area/shiva/interior/colony/s_admin)
-=======
->>>>>>> reimported backup
 =======
 >>>>>>> reimported backup
 "JV" = (
@@ -1592,19 +1551,15 @@
 	},
 /area/shiva/interior/colony/s_admin)
 "Kr" = (
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 =======
-=======
->>>>>>> reimported backup
 /obj/structure/closet/secure_closet/personal,
 /obj/effect/landmark/good_item,
 /turf/open/floor/shiva{
 	icon_state = "floor3"
-<<<<<<< master
->>>>>>> reimported backup
-=======
 >>>>>>> reimported backup
 	},
 /area/shiva/interior/colony/s_admin)
@@ -1615,7 +1570,6 @@
 	},
 /area/shiva/interior/colony/s_admin)
 <<<<<<< master
-<<<<<<< master
 "KB" = (
 /obj/item/explosive/mine/clf/active{
 	dir = 4
@@ -1625,8 +1579,6 @@
 	icon_state = "damaged3"
 	},
 /area/shiva/interior/colony/s_admin)
-=======
->>>>>>> reimported backup
 =======
 >>>>>>> reimported backup
 "KP" = (
@@ -1702,15 +1654,10 @@
 /area/shiva/interior/colony/s_admin)
 "Nt" = (
 <<<<<<< master
-<<<<<<< master
 /obj/structure/window_frame/colony/reinforced,
 /obj/item/explosive/mine/clf/active{
 	dir = 1
 	},
-=======
-/obj/item/stack/rods,
-/obj/structure/window_frame/colony/reinforced,
->>>>>>> reimported backup
 =======
 /obj/item/stack/rods,
 /obj/structure/window_frame/colony/reinforced,
@@ -1730,7 +1677,10 @@
 "NB" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/structure/bed/chair,
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -1740,7 +1690,10 @@
 	layer = 3
 	},
 /obj/structure/bed/chair,
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -1837,7 +1790,6 @@
 	},
 /area/shiva/interior/colony/s_admin)
 <<<<<<< master
-<<<<<<< master
 "Qz" = (
 /obj/item/explosive/mine/clf/active{
 	dir = 1
@@ -1853,16 +1805,11 @@
 	icon_state = "bluefull"
 	},
 =======
-=======
->>>>>>> reimported backup
 "QC" = (
 /obj/structure/window_frame/colony/reinforced,
 /obj/item/stack/rods,
 /obj/item/stack/rods,
 /turf/open/floor/plating,
-<<<<<<< master
->>>>>>> reimported backup
-=======
 >>>>>>> reimported backup
 /area/shiva/interior/colony/s_admin)
 "QE" = (
@@ -1957,7 +1904,10 @@
 /obj/item/tool/pen/blue{
 	pixel_x = 5
 	},
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/wood,
 /area/shiva/interior/colony/s_admin)
 "Sg" = (
@@ -2099,13 +2049,10 @@
 /turf/open/auto_turf/snow/layer2,
 /area/shiva/exterior/junkyard/cp_bar)
 <<<<<<< master
-<<<<<<< master
 "VE" = (
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/wood,
 /area/shiva/interior/colony/s_admin)
-=======
->>>>>>> reimported backup
 =======
 >>>>>>> reimported backup
 "VF" = (
@@ -2119,7 +2066,10 @@
 "VP" = (
 /obj/effect/landmark/corpsespawner/chef,
 /obj/item/ammo_casing/bullet,
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/shiva{
 	dir = 1
 	},
@@ -2159,7 +2109,6 @@
 	},
 /area/shiva/interior/colony/s_admin)
 <<<<<<< master
-<<<<<<< master
 "Xu" = (
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/shiva{
@@ -2167,8 +2116,6 @@
 	icon_state = "multi_tiles"
 	},
 /area/shiva/interior/colony/s_admin)
-=======
->>>>>>> reimported backup
 =======
 >>>>>>> reimported backup
 "XJ" = (
@@ -2425,11 +2372,7 @@ DM
 (10,1,1) = {"
 xt
 <<<<<<< master
-<<<<<<< master
 lZ
-=======
-Hr
->>>>>>> reimported backup
 =======
 Hr
 >>>>>>> reimported backup
@@ -2455,10 +2398,18 @@ DM
 (11,1,1) = {"
 jl
 Hr
+<<<<<<< master
 qW
 JD
 JD
 DZ
+At
+KB
+=======
+JD
+JD
+JD
+aQ
 At
 FM
 >>>>>>> reimported backup
@@ -2477,21 +2428,15 @@ tF
 "}
 (12,1,1) = {"
 <<<<<<< master
-<<<<<<< master
 Nt
 oZ
 VP
 pN
 =======
-=======
->>>>>>> reimported backup
 pC
 oZ
 VP
 tx
-<<<<<<< master
->>>>>>> reimported backup
-=======
 >>>>>>> reimported backup
 Yo
 RR
@@ -2499,13 +2444,8 @@ vZ
 Un
 Sg
 <<<<<<< master
-<<<<<<< master
 jU
 Kr
-=======
-il
-Hr
->>>>>>> reimported backup
 =======
 il
 Hr
@@ -2522,11 +2462,7 @@ DM
 "}
 (13,1,1) = {"
 <<<<<<< master
-<<<<<<< master
 Nt
-=======
-pC
->>>>>>> reimported backup
 =======
 pC
 >>>>>>> reimported backup
@@ -2559,7 +2495,11 @@ JD
 Hr
 Hr
 WP
+<<<<<<< master
 kv
+=======
+FM
+>>>>>>> reimported backup
 Un
 Hr
 pL
@@ -2574,15 +2514,15 @@ tF
 "}
 (15,1,1) = {"
 <<<<<<< master
-<<<<<<< master
 Nt
 Fq
 Ds
-JD
->>>>>>> reimported backup
 =======
 pC
 Fq
+JD
+>>>>>>> reimported backup
+JD
 JD
 Hr
 iB
@@ -2593,7 +2533,11 @@ Ey
 pL
 zI
 Hr
+<<<<<<< master
 QC
+=======
+fg
+>>>>>>> reimported backup
 Hr
 Hr
 Mo
@@ -2602,11 +2546,7 @@ tF
 "}
 (16,1,1) = {"
 <<<<<<< master
-<<<<<<< master
 Nt
-=======
-QC
->>>>>>> reimported backup
 =======
 QC
 >>>>>>> reimported backup
@@ -2637,7 +2577,11 @@ Ey
 Un
 YL
 BG
+<<<<<<< master
 Kr
+=======
+Hr
+>>>>>>> reimported backup
 JD
 MQ
 Zz
@@ -2654,11 +2598,7 @@ Iq
 "}
 (18,1,1) = {"
 <<<<<<< master
-<<<<<<< master
 Nt
-=======
-pC
->>>>>>> reimported backup
 =======
 pC
 >>>>>>> reimported backup
@@ -2684,11 +2624,7 @@ cL
 "}
 (19,1,1) = {"
 <<<<<<< master
-<<<<<<< master
 Nt
-=======
-pC
->>>>>>> reimported backup
 =======
 pC
 >>>>>>> reimported backup
@@ -2696,7 +2632,6 @@ nT
 uq
 il
 JD
-<<<<<<< master
 <<<<<<< master
 oU
 Hr
@@ -2706,12 +2641,7 @@ Hr
 Hr
 JD
 >>>>>>> reimported backup
-=======
-Hr
-Hr
 JD
-JD
->>>>>>> reimported backup
 JD
 Hr
 Qk
@@ -2728,7 +2658,6 @@ Wl
 jl
 Hr
 <<<<<<< master
-<<<<<<< master
 jN
 NY
 JD
@@ -2741,26 +2670,17 @@ Hr
 Qk
 jH
 =======
-=======
->>>>>>> reimported backup
 Su
 NY
 JD
 sd
-<<<<<<< master
-rJ
-=======
 Hr
->>>>>>> reimported backup
 Jn
 GJ
 JD
 Hr
 Qk
 QG
-<<<<<<< master
->>>>>>> reimported backup
-=======
 >>>>>>> reimported backup
 Hr
 Hr
@@ -2776,11 +2696,7 @@ Hr
 Hr
 wG
 <<<<<<< master
-<<<<<<< master
 JR
-=======
-Hr
->>>>>>> reimported backup
 =======
 Hr
 >>>>>>> reimported backup
@@ -2789,13 +2705,21 @@ Hr
 kb
 Hr
 fg
+<<<<<<< master
 Kr
+=======
+Hr
+>>>>>>> reimported backup
 VY
 Mo
 Hr
 Hr
 Hr
+<<<<<<< master
 QC
+=======
+fg
+>>>>>>> reimported backup
 Hr
 Hz
 Wl
@@ -2832,8 +2756,10 @@ AH
 xt
 jS
 <<<<<<< master
-<<<<<<< master
 Qz
+=======
+gr
+>>>>>>> reimported backup
 gr
 jS
 Qk
@@ -2877,9 +2803,15 @@ OT
 fP
 xt
 qT
+<<<<<<< master
 Xu
 Tf
 hD
+=======
+Tf
+Tf
+JD
+>>>>>>> reimported backup
 ex
 rM
 Sc
@@ -2901,10 +2833,8 @@ Qk
 hb
 Tf
 Tf
+<<<<<<< master
 qW
-=======
-JD
->>>>>>> reimported backup
 =======
 JD
 >>>>>>> reimported backup
@@ -2946,11 +2876,7 @@ BU
 Ap
 MT
 <<<<<<< master
-<<<<<<< master
 Dc
-=======
-MT
->>>>>>> reimported backup
 =======
 MT
 >>>>>>> reimported backup
@@ -2962,11 +2888,7 @@ gr
 JD
 xt
 <<<<<<< master
-<<<<<<< master
 XL
-=======
-Kr
->>>>>>> reimported backup
 =======
 Kr
 >>>>>>> reimported backup
@@ -2980,11 +2902,7 @@ jE
 "}
 (29,1,1) = {"
 <<<<<<< master
-<<<<<<< master
 oh
-=======
-Su
->>>>>>> reimported backup
 =======
 Su
 >>>>>>> reimported backup
@@ -2996,14 +2914,18 @@ MT
 JD
 dT
 gr
+<<<<<<< master
 aN
 JD
 xt
 iv
-rM
-<<<<<<< master
->>>>>>> reimported backup
+VE
 =======
+gr
+JD
+xt
+iv
+rM
 >>>>>>> reimported backup
 yZ
 QZ
@@ -3014,15 +2936,15 @@ uK
 "}
 (30,1,1) = {"
 <<<<<<< master
-<<<<<<< master
 Nt
 Jk
 Ds
-JD
->>>>>>> reimported backup
 =======
 pC
 Jk
+JD
+>>>>>>> reimported backup
+JD
 JD
 CX
 pC
@@ -3044,11 +2966,7 @@ Pi
 xt
 Zk
 <<<<<<< master
-<<<<<<< master
 ji
-=======
-Zc
->>>>>>> reimported backup
 =======
 Zc
 >>>>>>> reimported backup

--- a/maps/map_files/Ice_Colony_v3/sprinkles/25.shivaclf01.dmm
+++ b/maps/map_files/Ice_Colony_v3/sprinkles/25.shivaclf01.dmm
@@ -167,10 +167,7 @@
 /area/shiva/interior/colony/s_admin)
 "cZ" = (
 /obj/item/device/pinpointer,
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
-=======
->>>>>>> reimported backup
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -789,7 +786,6 @@
 "sd" = (
 /obj/effect/landmark/corpsespawner/colonist,
 /obj/item/weapon/gun/pistol/holdout,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -925,10 +921,7 @@
 	dir = 1;
 	tag = "icon-chair (NORTH)"
 	},
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
-=======
->>>>>>> reimported backup
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -1098,7 +1091,6 @@
 	dir = 4;
 	pixel_x = 24
 	},
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -1145,7 +1137,6 @@
 /area/shiva/interior/colony/s_admin)
 "Ap" = (
 /obj/effect/decal/cleanable/blood/oil/streak,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor/shiva{
 	dir = 8;
 	icon_state = "multi_tiles"
@@ -1196,7 +1187,6 @@
 /obj/effect/decal/cleanable/blood{
 	layer = 3
 	},
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -1214,10 +1204,7 @@
 /area/shiva/interior/colony/s_admin)
 "BY" = (
 /obj/structure/bed/chair,
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
-=======
->>>>>>> reimported backup
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -1351,10 +1338,6 @@
 	},
 /obj/item/spacecash/c1000,
 /obj/item/spacecash/c500,
-<<<<<<< master
-=======
-/obj/effect/landmark/good_item,
->>>>>>> reimported backup
 /obj/item/storage/pill_bottle/ultrazine/skillless,
 /turf/open/floor/shiva{
 	dir = 8;
@@ -1365,13 +1348,6 @@
 /turf/open/floor{
 	dir = 8;
 	icon_state = "damaged3"
-	},
-/area/shiva/interior/colony/s_admin)
-"Gm" = (
-/obj/item/stack/sandbags,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
-/turf/open/floor{
-	icon_state = "platingdmg1"
 	},
 /area/shiva/interior/colony/s_admin)
 "GH" = (
@@ -1559,7 +1535,6 @@
 	},
 /area/shiva/interior/colony/s_admin)
 "Kr" = (
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
@@ -1685,10 +1660,7 @@
 "NB" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/structure/bed/chair,
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
-=======
->>>>>>> reimported backup
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -1698,10 +1670,7 @@
 	layer = 3
 	},
 /obj/structure/bed/chair,
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
-=======
->>>>>>> reimported backup
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -1748,7 +1717,6 @@
 	pixel_x = -24
 	},
 /obj/item/device/flashlight/lamp,
-/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor/shiva{
 	icon_state = "floor3"
 	},
@@ -1913,10 +1881,7 @@
 /obj/item/tool/pen/blue{
 	pixel_x = 5
 	},
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
-=======
->>>>>>> reimported backup
 /turf/open/floor/wood,
 /area/shiva/interior/colony/s_admin)
 "Sg" = (
@@ -2075,10 +2040,7 @@
 "VP" = (
 /obj/effect/landmark/corpsespawner/chef,
 /obj/item/ammo_casing/bullet,
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
-=======
->>>>>>> reimported backup
 /turf/open/floor/shiva{
 	dir = 1
 	},
@@ -2349,7 +2311,7 @@ Qk
 FI
 Mo
 Un
-aN
+Un
 yw
 Qk
 DM
@@ -2407,18 +2369,10 @@ DM
 (11,1,1) = {"
 jl
 Hr
-<<<<<<< master
 qW
 JD
 JD
 DZ
-At
-KB
-=======
-JD
-JD
-JD
-aQ
 At
 FM
 >>>>>>> reimported backup
@@ -2482,7 +2436,7 @@ JD
 il
 bN
 Un
-Gm
+WP
 WP
 hO
 VY
@@ -2499,16 +2453,12 @@ tF
 jl
 Hj
 JD
-Ds
+JD
 JD
 Hr
 Hr
 WP
-<<<<<<< master
 kv
-=======
-FM
->>>>>>> reimported backup
 Un
 Hr
 pL
@@ -2526,12 +2476,8 @@ tF
 Nt
 Fq
 Ds
-=======
-pC
-Fq
 JD
 >>>>>>> reimported backup
-JD
 JD
 Hr
 iB
@@ -2542,11 +2488,7 @@ Ey
 pL
 zI
 Hr
-<<<<<<< master
 QC
-=======
-fg
->>>>>>> reimported backup
 Hr
 Hr
 Mo
@@ -2565,7 +2507,7 @@ pR
 vm
 aQ
 Hr
-Ds
+JD
 MQ
 ag
 ak
@@ -2586,11 +2528,7 @@ Ey
 Un
 YL
 BG
-<<<<<<< master
 Kr
-=======
-Hr
->>>>>>> reimported backup
 JD
 MQ
 Zz
@@ -2600,7 +2538,7 @@ Nv
 NP
 zf
 sV
-Kr
+Hr
 Qk
 Qk
 Iq
@@ -2713,21 +2651,13 @@ Hr
 kb
 Hr
 fg
-<<<<<<< master
 Kr
-=======
-Hr
->>>>>>> reimported backup
 VY
+Mo
+Hr
+Hr
+Hr
 QC
-Hr
-Hr
-Hr
-<<<<<<< master
-QC
-=======
-fg
->>>>>>> reimported backup
 Hr
 Hz
 Wl
@@ -2765,9 +2695,6 @@ xt
 jS
 <<<<<<< master
 Qz
-=======
-gr
->>>>>>> reimported backup
 gr
 jS
 Qk
@@ -2811,15 +2738,9 @@ OT
 fP
 xt
 qT
-<<<<<<< master
 Xu
 Tf
 hD
-=======
-Tf
-Tf
-JD
->>>>>>> reimported backup
 ex
 rM
 Sc
@@ -2841,7 +2762,6 @@ Qk
 hb
 Tf
 Tf
-<<<<<<< master
 qW
 =======
 JD
@@ -2861,7 +2781,7 @@ Nt
 Rf
 Jn
 GH
-Ds
+JD
 JD
 qO
 Kk
@@ -2922,14 +2842,7 @@ MT
 JD
 dT
 gr
-<<<<<<< master
 aN
-JD
-xt
-iv
-VE
-=======
-gr
 JD
 xt
 iv
@@ -2947,13 +2860,9 @@ uK
 Nt
 Jk
 Ds
-=======
-pC
-Jk
 JD
 >>>>>>> reimported backup
 JD
-Ds
 CX
 pC
 zU

--- a/maps/map_files/Ice_Colony_v3/sprinkles/25.shivaclf01.dmm
+++ b/maps/map_files/Ice_Colony_v3/sprinkles/25.shivaclf01.dmm
@@ -84,12 +84,15 @@
 	dir = 1
 	},
 /area/shiva/interior/colony/s_admin)
+<<<<<<< master
 "aN" = (
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/shiva{
 	icon_state = "multi_tiles"
 	},
 /area/shiva/interior/colony/s_admin)
+=======
+>>>>>>> reimported backup
 "aQ" = (
 /obj/effect/decal/cleanable/blood{
 	layer = 3
@@ -164,7 +167,10 @@
 /area/shiva/interior/colony/s_admin)
 "cZ" = (
 /obj/item/device/pinpointer,
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -328,6 +334,7 @@
 "hw" = (
 /turf/open/auto_turf/snow/layer1,
 /area/shiva/exterior/cp_s_research)
+<<<<<<< master
 "hD" = (
 /obj/effect/landmark/corpsespawner/clf,
 /obj/item/weapon/melee/twohanded/lungemine,
@@ -335,6 +342,8 @@
 	dir = 1
 	},
 /area/shiva/interior/colony/s_admin)
+=======
+>>>>>>> reimported backup
 "hM" = (
 /turf/open/auto_turf/ice/layer1,
 /area/shiva/exterior/cp_s_research)
@@ -388,6 +397,7 @@
 	dir = 1
 	},
 /area/shiva/interior/colony/s_admin)
+<<<<<<< master
 "ji" = (
 /obj/structure/bed/chair{
 	dir = 8;
@@ -400,6 +410,8 @@
 	dir = 1
 	},
 /area/shiva/interior/colony/s_admin)
+=======
+>>>>>>> reimported backup
 "jl" = (
 /obj/structure/sign/poster/clf,
 /turf/closed/wall/shiva/prefabricated,
@@ -407,6 +419,7 @@
 "jE" = (
 /turf/open/auto_turf/snow/layer1,
 /area/shiva/exterior/junkyard/cp_bar)
+<<<<<<< master
 "jH" = (
 /obj/effect/spawner/random/attachment,
 /obj/effect/landmark/survivor_spawner/clf/generic,
@@ -423,18 +436,23 @@
 	dir = 1
 	},
 /area/shiva/interior/colony/s_admin)
+=======
+>>>>>>> reimported backup
 "jS" = (
 /obj/structure/flora/pottedplant,
 /turf/open/floor/shiva{
 	dir = 1
 	},
 /area/shiva/interior/colony/s_admin)
+<<<<<<< master
 "jU" = (
 /obj/effect/landmark/corpsespawner/clf,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
 /area/shiva/interior/colony/s_admin)
+=======
+>>>>>>> reimported backup
 "kb" = (
 /obj/item/stack/rods,
 /obj/effect/decal/cleanable/blood{
@@ -457,6 +475,7 @@
 	icon_state = "redfull"
 	},
 /area/shiva/interior/colony/s_admin)
+<<<<<<< master
 "kv" = (
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor{
@@ -464,6 +483,8 @@
 	icon_state = "damaged3"
 	},
 /area/shiva/interior/colony/s_admin)
+=======
+>>>>>>> reimported backup
 "kL" = (
 /obj/structure/barricade/wooden{
 	dir = 4;
@@ -490,21 +511,28 @@
 /obj/item/stack/rods,
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
+<<<<<<< master
 /obj/item/explosive/mine/clf/active{
 	dir = 1
 	},
+=======
+>>>>>>> reimported backup
 /turf/open/floor/shiva{
 	dir = 1
 	},
 /area/shiva/interior/colony/s_admin)
 "kY" = (
 /obj/structure/surface/table/reinforced/prison,
+<<<<<<< master
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
 /area/shiva/interior/colony/s_admin)
 "lZ" = (
 /obj/effect/landmark/corpsespawner/clf,
+=======
+/obj/effect/landmark/good_item,
+>>>>>>> reimported backup
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -581,7 +609,10 @@
 	dir = 4;
 	pixel_y = -5
 	},
+<<<<<<< master
 /obj/effect/landmark/corpsespawner/clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/shiva{
 	dir = 1
 	},
@@ -600,6 +631,7 @@
 "nX" = (
 /turf/open/auto_turf/snow/layer0,
 /area/shiva/exterior/junkyard/cp_bar)
+<<<<<<< master
 "oh" = (
 /obj/effect/decal/cleanable/blood{
 	layer = 3
@@ -620,6 +652,8 @@
 	icon_state = "bluefull"
 	},
 /area/shiva/interior/colony/s_admin)
+=======
+>>>>>>> reimported backup
 "oZ" = (
 /obj/structure/barricade/metal/wired{
 	icon_state = "metal_1";
@@ -640,6 +674,7 @@
 "pL" = (
 /turf/open/floor/plating,
 /area/shiva/interior/colony/s_admin)
+<<<<<<< master
 "pN" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/explosive/mine/clf/active{
@@ -649,6 +684,8 @@
 	dir = 1
 	},
 /area/shiva/interior/colony/s_admin)
+=======
+>>>>>>> reimported backup
 "pR" = (
 /obj/effect/decal/cleanable/blood{
 	layer = 3
@@ -680,6 +717,7 @@
 	dir = 1
 	},
 /area/shiva/interior/colony/s_admin)
+<<<<<<< master
 "qW" = (
 /obj/item/explosive/mine/clf/active{
 	dir = 4
@@ -688,6 +726,8 @@
 	dir = 1
 	},
 /area/shiva/interior/colony/s_admin)
+=======
+>>>>>>> reimported backup
 "qZ" = (
 /turf/open/auto_turf/snow/layer3,
 /area/shiva/exterior/cp_lz2)
@@ -700,6 +740,7 @@
 	icon_state = "floor3"
 	},
 /area/shiva/interior/colony/s_admin)
+<<<<<<< master
 "rJ" = (
 /obj/item/explosive/mine/clf/active,
 /obj/effect/landmark/survivor_spawner/clf/generic,
@@ -707,11 +748,14 @@
 	icon_state = "bluefull"
 	},
 /area/shiva/interior/colony/s_admin)
+=======
+>>>>>>> reimported backup
 "rM" = (
 /turf/open/floor/wood,
 /area/shiva/interior/colony/s_admin)
 "rP" = (
 /obj/structure/surface/table/reinforced/prison,
+<<<<<<< master
 /obj/item/weapon/gun/rifle/mar40/lmg{
 	pixel_y = 13
 	},
@@ -720,6 +764,9 @@
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
+=======
+/obj/item/weapon/gun/rifle/mar40/lmg,
+>>>>>>> reimported backup
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -784,6 +831,10 @@
 	dir = 4;
 	pixel_x = -24
 	},
+<<<<<<< master
+=======
+/obj/effect/landmark/crap_item,
+>>>>>>> reimported backup
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -867,7 +918,10 @@
 	dir = 1;
 	tag = "icon-chair (NORTH)"
 	},
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -1150,7 +1204,10 @@
 /area/shiva/interior/colony/s_admin)
 "BY" = (
 /obj/structure/bed/chair,
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -1179,6 +1236,7 @@
 	dir = 1
 	},
 /area/shiva/interior/colony/s_admin)
+<<<<<<< master
 "Dc" = (
 /obj/item/explosive/mine/clf/active{
 	dir = 1
@@ -1194,6 +1252,8 @@
 	dir = 1
 	},
 /area/shiva/interior/colony/s_admin)
+=======
+>>>>>>> reimported backup
 "DI" = (
 /obj/effect/decal/cleanable/blood{
 	layer = 3
@@ -1206,6 +1266,7 @@
 "DM" = (
 /turf/open/auto_turf/snow/layer3,
 /area/shiva/exterior/cp_s_research)
+<<<<<<< master
 "DZ" = (
 /obj/effect/decal/cleanable/blood{
 	layer = 3
@@ -1215,6 +1276,8 @@
 	icon_state = "bluefull"
 	},
 /area/shiva/interior/colony/s_admin)
+=======
+>>>>>>> reimported backup
 "Ed" = (
 /obj/effect/decal/cleanable/blood{
 	icon_state = "xgibdown1";
@@ -1278,6 +1341,10 @@
 	},
 /obj/item/spacecash/c1000,
 /obj/item/spacecash/c500,
+<<<<<<< master
+=======
+/obj/effect/landmark/good_item,
+>>>>>>> reimported backup
 /obj/item/storage/pill_bottle/ultrazine/skillless,
 /turf/open/floor/shiva{
 	dir = 8;
@@ -1443,6 +1510,7 @@
 	},
 /turf/open/auto_turf/snow/layer2,
 /area/shiva/exterior/cp_lz2)
+<<<<<<< master
 "JR" = (
 /obj/item/explosive/mine/clf/active{
 	dir = 8
@@ -1451,6 +1519,8 @@
 	icon_state = "bluefull"
 	},
 /area/shiva/interior/colony/s_admin)
+=======
+>>>>>>> reimported backup
 "JV" = (
 /turf/open/auto_turf/snow/layer2,
 /area/shiva/exterior/cp_lz2)
@@ -1472,9 +1542,16 @@
 	},
 /area/shiva/interior/colony/s_admin)
 "Kr" = (
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
+=======
+/obj/structure/closet/secure_closet/personal,
+/obj/effect/landmark/good_item,
+/turf/open/floor/shiva{
+	icon_state = "floor3"
+>>>>>>> reimported backup
 	},
 /area/shiva/interior/colony/s_admin)
 "Kv" = (
@@ -1483,6 +1560,7 @@
 	icon_state = "platingdmg3"
 	},
 /area/shiva/interior/colony/s_admin)
+<<<<<<< master
 "KB" = (
 /obj/item/explosive/mine/clf/active{
 	dir = 4
@@ -1492,6 +1570,8 @@
 	icon_state = "damaged3"
 	},
 /area/shiva/interior/colony/s_admin)
+=======
+>>>>>>> reimported backup
 "KP" = (
 /obj/structure/machinery/light/double{
 	dir = 4;
@@ -1564,10 +1644,15 @@
 	},
 /area/shiva/interior/colony/s_admin)
 "Nt" = (
+<<<<<<< master
 /obj/structure/window_frame/colony/reinforced,
 /obj/item/explosive/mine/clf/active{
 	dir = 1
 	},
+=======
+/obj/item/stack/rods,
+/obj/structure/window_frame/colony/reinforced,
+>>>>>>> reimported backup
 /turf/open/floor/plating,
 /area/shiva/interior/colony/s_admin)
 "Nv" = (
@@ -1583,7 +1668,10 @@
 "NB" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/structure/bed/chair,
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -1593,7 +1681,10 @@
 	layer = 3
 	},
 /obj/structure/bed/chair,
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -1689,6 +1780,7 @@
 	icon_state = "multi_tiles"
 	},
 /area/shiva/interior/colony/s_admin)
+<<<<<<< master
 "Qz" = (
 /obj/item/explosive/mine/clf/active{
 	dir = 1
@@ -1703,6 +1795,13 @@
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
+=======
+"QC" = (
+/obj/structure/window_frame/colony/reinforced,
+/obj/item/stack/rods,
+/obj/item/stack/rods,
+/turf/open/floor/plating,
+>>>>>>> reimported backup
 /area/shiva/interior/colony/s_admin)
 "QE" = (
 /obj/structure/machinery/light/double{
@@ -1796,7 +1895,10 @@
 /obj/item/tool/pen/blue{
 	pixel_x = 5
 	},
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/wood,
 /area/shiva/interior/colony/s_admin)
 "Sg" = (
@@ -1937,10 +2039,13 @@
 /obj/structure/largecrate/random/case/small,
 /turf/open/auto_turf/snow/layer2,
 /area/shiva/exterior/junkyard/cp_bar)
+<<<<<<< master
 "VE" = (
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/wood,
 /area/shiva/interior/colony/s_admin)
+=======
+>>>>>>> reimported backup
 "VF" = (
 /obj/item/shard{
 	icon_state = "medium"
@@ -1952,7 +2057,10 @@
 "VP" = (
 /obj/effect/landmark/corpsespawner/chef,
 /obj/item/ammo_casing/bullet,
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/shiva{
 	dir = 1
 	},
@@ -1991,6 +2099,7 @@
 	icon_state = "platingdmg1"
 	},
 /area/shiva/interior/colony/s_admin)
+<<<<<<< master
 "Xu" = (
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/shiva{
@@ -1998,6 +2107,8 @@
 	icon_state = "multi_tiles"
 	},
 /area/shiva/interior/colony/s_admin)
+=======
+>>>>>>> reimported backup
 "XJ" = (
 /obj/effect/spawner/random/attachment,
 /turf/open/floor/shiva{
@@ -2251,7 +2362,11 @@ DM
 "}
 (10,1,1) = {"
 xt
+<<<<<<< master
 lZ
+=======
+Hr
+>>>>>>> reimported backup
 Il
 QE
 sB
@@ -2274,12 +2389,21 @@ DM
 (11,1,1) = {"
 jl
 Hr
+<<<<<<< master
 qW
 JD
 JD
 DZ
 At
 KB
+=======
+JD
+JD
+JD
+aQ
+At
+FM
+>>>>>>> reimported backup
 VF
 bF
 Hr
@@ -2294,17 +2418,29 @@ Qk
 tF
 "}
 (12,1,1) = {"
+<<<<<<< master
 Nt
 oZ
 VP
 pN
+=======
+pC
+oZ
+VP
+tx
+>>>>>>> reimported backup
 Yo
 RR
 vZ
 Un
 Sg
+<<<<<<< master
 jU
 Kr
+=======
+il
+Hr
+>>>>>>> reimported backup
 Qk
 Mo
 BY
@@ -2316,7 +2452,11 @@ VY
 DM
 "}
 (13,1,1) = {"
+<<<<<<< master
 Nt
+=======
+pC
+>>>>>>> reimported backup
 Mv
 NY
 tx
@@ -2346,7 +2486,11 @@ JD
 Hr
 Hr
 WP
+<<<<<<< master
 kv
+=======
+FM
+>>>>>>> reimported backup
 Un
 Hr
 pL
@@ -2360,9 +2504,15 @@ Qk
 tF
 "}
 (15,1,1) = {"
+<<<<<<< master
 Nt
 Fq
 Ds
+=======
+pC
+Fq
+JD
+>>>>>>> reimported backup
 JD
 JD
 Hr
@@ -2374,7 +2524,11 @@ Ey
 pL
 zI
 Hr
+<<<<<<< master
 QC
+=======
+fg
+>>>>>>> reimported backup
 Hr
 Hr
 Mo
@@ -2382,7 +2536,11 @@ VY
 tF
 "}
 (16,1,1) = {"
+<<<<<<< master
 Nt
+=======
+QC
+>>>>>>> reimported backup
 xh
 Su
 pR
@@ -2410,7 +2568,11 @@ Ey
 Un
 YL
 BG
+<<<<<<< master
 Kr
+=======
+Hr
+>>>>>>> reimported backup
 JD
 MQ
 Zz
@@ -2426,7 +2588,11 @@ Qk
 Iq
 "}
 (18,1,1) = {"
+<<<<<<< master
 Nt
+=======
+pC
+>>>>>>> reimported backup
 cC
 FM
 Un
@@ -2448,14 +2614,24 @@ UM
 cL
 "}
 (19,1,1) = {"
+<<<<<<< master
 Nt
+=======
+pC
+>>>>>>> reimported backup
 nT
 uq
 il
 JD
+<<<<<<< master
 oU
 Hr
 Ds
+=======
+Hr
+Hr
+JD
+>>>>>>> reimported backup
 JD
 JD
 Hr
@@ -2472,6 +2648,7 @@ Wl
 (20,1,1) = {"
 jl
 Hr
+<<<<<<< master
 jN
 NY
 JD
@@ -2483,6 +2660,19 @@ Ds
 Hr
 Qk
 jH
+=======
+Su
+NY
+JD
+sd
+Hr
+Jn
+GJ
+JD
+Hr
+Qk
+QG
+>>>>>>> reimported backup
 Hr
 Hr
 Hr
@@ -2496,19 +2686,31 @@ xt
 Hr
 Hr
 wG
+<<<<<<< master
 JR
+=======
+Hr
+>>>>>>> reimported backup
 zJ
 Hr
 kb
 Hr
 fg
+<<<<<<< master
 Kr
+=======
+Hr
+>>>>>>> reimported backup
 VY
 Mo
 Hr
 Hr
 Hr
+<<<<<<< master
 QC
+=======
+fg
+>>>>>>> reimported backup
 Hr
 Hz
 Wl
@@ -2544,7 +2746,11 @@ rQ
 AH
 xt
 jS
+<<<<<<< master
 Qz
+=======
+gr
+>>>>>>> reimported backup
 gr
 jS
 Qk
@@ -2588,9 +2794,15 @@ OT
 fP
 xt
 qT
+<<<<<<< master
 Xu
 Tf
 hD
+=======
+Tf
+Tf
+JD
+>>>>>>> reimported backup
 ex
 rM
 Sc
@@ -2612,7 +2824,11 @@ Qk
 hb
 Tf
 Tf
+<<<<<<< master
 qW
+=======
+JD
+>>>>>>> reimported backup
 xt
 Fh
 rq
@@ -2650,7 +2866,11 @@ kU
 BU
 Ap
 MT
+<<<<<<< master
 Dc
+=======
+MT
+>>>>>>> reimported backup
 MT
 kO
 Qw
@@ -2658,7 +2878,11 @@ gr
 gr
 JD
 xt
+<<<<<<< master
 XL
+=======
+Kr
+>>>>>>> reimported backup
 RN
 IG
 is
@@ -2668,7 +2892,11 @@ uK
 jE
 "}
 (29,1,1) = {"
+<<<<<<< master
 oh
+=======
+Su
+>>>>>>> reimported backup
 mh
 Vc
 yo
@@ -2677,11 +2905,19 @@ MT
 JD
 dT
 gr
+<<<<<<< master
 aN
 JD
 xt
 iv
 VE
+=======
+gr
+JD
+xt
+iv
+rM
+>>>>>>> reimported backup
 yZ
 QZ
 xt
@@ -2690,9 +2926,15 @@ uK
 uK
 "}
 (30,1,1) = {"
+<<<<<<< master
 Nt
 Jk
 Ds
+=======
+pC
+Jk
+JD
+>>>>>>> reimported backup
 JD
 JD
 CX
@@ -2714,7 +2956,11 @@ Pi
 (31,1,1) = {"
 xt
 Zk
+<<<<<<< master
 ji
+=======
+Zc
+>>>>>>> reimported backup
 nJ
 Zc
 jS

--- a/maps/map_files/Ice_Colony_v3/sprinkles/25.shivaclf01.dmm
+++ b/maps/map_files/Ice_Colony_v3/sprinkles/25.shivaclf01.dmm
@@ -537,6 +537,12 @@
 	icon_state = "bluefull"
 	},
 /area/shiva/interior/colony/s_admin)
+"lZ" = (
+/obj/effect/landmark/corpsespawner/clf,
+/turf/open/floor/shiva{
+	icon_state = "bluefull"
+	},
+/area/shiva/interior/colony/s_admin)
 "mc" = (
 /obj/structure/machinery/firealarm{
 	dir = 8;
@@ -783,6 +789,7 @@
 "sd" = (
 /obj/effect/landmark/corpsespawner/colonist,
 /obj/item/weapon/gun/pistol/holdout,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -1091,6 +1098,7 @@
 	dir = 4;
 	pixel_x = 24
 	},
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -1137,6 +1145,7 @@
 /area/shiva/interior/colony/s_admin)
 "Ap" = (
 /obj/effect/decal/cleanable/blood/oil/streak,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor/shiva{
 	dir = 8;
 	icon_state = "multi_tiles"
@@ -1187,6 +1196,7 @@
 /obj/effect/decal/cleanable/blood{
 	layer = 3
 	},
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
 	},
@@ -1355,6 +1365,13 @@
 /turf/open/floor{
 	dir = 8;
 	icon_state = "damaged3"
+	},
+/area/shiva/interior/colony/s_admin)
+"Gm" = (
+/obj/item/stack/sandbags,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/turf/open/floor{
+	icon_state = "platingdmg1"
 	},
 /area/shiva/interior/colony/s_admin)
 "GH" = (
@@ -1731,6 +1748,7 @@
 	pixel_x = -24
 	},
 /obj/item/device/flashlight/lamp,
+/obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
 /turf/open/floor/shiva{
 	icon_state = "floor3"
 	},
@@ -2331,7 +2349,7 @@ Qk
 FI
 Mo
 Un
-Un
+aN
 yw
 Qk
 DM
@@ -2464,7 +2482,7 @@ JD
 il
 bN
 Un
-WP
+Gm
 WP
 hO
 VY
@@ -2481,7 +2499,7 @@ tF
 jl
 Hj
 JD
-JD
+Ds
 JD
 Hr
 Hr
@@ -2547,7 +2565,7 @@ pR
 vm
 aQ
 Hr
-JD
+Ds
 MQ
 ag
 ak
@@ -2582,7 +2600,7 @@ Nv
 NP
 zf
 sV
-Hr
+Kr
 Qk
 Qk
 Iq
@@ -2633,7 +2651,6 @@ Hr
 JD
 >>>>>>> reimported backup
 JD
-JD
 Hr
 Qk
 Mo
@@ -2665,7 +2682,7 @@ Su
 NY
 JD
 sd
-Hr
+rJ
 Jn
 GJ
 JD
@@ -2702,7 +2719,7 @@ Kr
 Hr
 >>>>>>> reimported backup
 VY
-Mo
+QC
 Hr
 Hr
 Hr
@@ -2844,7 +2861,7 @@ Nt
 Rf
 Jn
 GH
-JD
+Ds
 JD
 qO
 Kk
@@ -2936,7 +2953,7 @@ Jk
 JD
 >>>>>>> reimported backup
 JD
-JD
+Ds
 CX
 pC
 zU

--- a/maps/map_files/Ice_Colony_v3/sprinkles/40.shivabarls.dmm
+++ b/maps/map_files/Ice_Colony_v3/sprinkles/40.shivabarls.dmm
@@ -166,9 +166,20 @@
 /area/shiva/interior/bar)
 "hR" = (
 /obj/structure/surface/table/woodentable,
+<<<<<<< master
 /obj/item/storage/firstaid/adv{
 	pixel_y = -4;
 	pixel_x = -3
+=======
+/obj/item/storage/firstaid/surgical{
+	pixel_x = -7
+	},
+/obj/item/storage/firstaid/toxin{
+	pixel_x = 10
+	},
+/obj/item/storage/firstaid/toxin{
+	pixel_x = 10
+>>>>>>> reimported backup
 	},
 /turf/open/floor/wood,
 /area/shiva/interior/bar)
@@ -485,7 +496,26 @@
 /area/shiva/interior/bar)
 "nU" = (
 /obj/structure/surface/table/woodentable,
+<<<<<<< master
 /obj/item/storage/firstaid/regular,
+=======
+/obj/item/storage/firstaid{
+	pixel_x = -7;
+	pixel_y = -4
+	},
+/obj/item/storage/firstaid/adv{
+	pixel_x = 10;
+	pixel_y = -4
+	},
+/obj/item/storage/firstaid{
+	pixel_x = -7;
+	pixel_y = -4
+	},
+/obj/item/storage/firstaid/adv{
+	pixel_x = 10;
+	pixel_y = -4
+	},
+>>>>>>> reimported backup
 /turf/open/floor/shiva{
 	icon_state = "floor3"
 	},
@@ -617,20 +647,44 @@
 	pixel_x = 8;
 	pixel_y = 12
 	},
+<<<<<<< master
 /obj/item/ammo_magazine/shotgun/slugs{
 	pixel_x = -8;
 	pixel_y = -5
+=======
+/obj/item/ammo_magazine/shotgun/buckshot{
+	pixel_x = 8;
+	pixel_y = 12
 	},
 /obj/item/ammo_magazine/shotgun/buckshot{
 	pixel_x = 8;
 	pixel_y = 12
 >>>>>>> reimported backup
 	},
+/obj/item/ammo_magazine/shotgun/buckshot{
+	pixel_x = 8;
+	pixel_y = 12
+<<<<<<< master
+>>>>>>> reimported backup
+=======
+>>>>>>> reimported backup
+	},
 /obj/item/ammo_magazine/shotgun/slugs{
 	pixel_x = -8;
 	pixel_y = -5
 	},
+<<<<<<< master
 /obj/item/ammo_magazine/shotgun/incendiary,
+=======
+/obj/item/weapon/gun/shotgun/double{
+	pixel_x = -16;
+	pixel_y = 10
+	},
+/obj/item/weapon/gun/shotgun/pump/cmb{
+	pixel_x = 20;
+	pixel_y = -5
+	},
+>>>>>>> reimported backup
 /turf/open/floor/wood,
 /area/shiva/interior/bar)
 "ud" = (
@@ -751,9 +805,15 @@
 	icon_state = "xtracks";
 	tag = "icon-xtracks"
 	},
+<<<<<<< master
 /obj/structure/barricade/metal/wired{
 	dir = 1;
 	icon_state = "metal_2"
+=======
+/obj/structure/barricade/plasteel/wired{
+	icon_state = "plasteel_3";
+	dir = 1
+>>>>>>> reimported backup
 	},
 /turf/open/floor/shiva,
 /area/shiva/interior/bar)
@@ -829,6 +889,7 @@
 /obj/structure/surface/table/woodentable,
 /obj/item/stack/sheet/wood/large_stack,
 /obj/item/stack/sheet/wood/large_stack,
+<<<<<<< master
 /obj/item/tool/weldpack{
 	pixel_y = -6;
 	pixel_x = -8
@@ -841,6 +902,11 @@
 	pixel_y = 9;
 	pixel_x = -12
 	},
+=======
+/obj/item/weapon/gun/smg/nailgun,
+/obj/item/ammo_box/magazine/smg/nailgun,
+/obj/item/weapon/gun/smg/nailgun,
+>>>>>>> reimported backup
 /turf/open/floor/wood,
 /area/shiva/interior/bar)
 "Cm" = (
@@ -854,6 +920,10 @@
 /area/shiva/interior/bar)
 "Cv" = (
 /obj/structure/window_frame/colony/reinforced,
+<<<<<<< master
+=======
+/obj/item/stack/rods,
+>>>>>>> reimported backup
 /obj/item/shard{
 	icon_state = "large"
 	},
@@ -884,6 +954,7 @@
 	},
 /turf/open/floor/wood,
 /area/shiva/interior/bar)
+<<<<<<< master
 "DZ" = (
 /obj/structure/barricade/metal/wired{
 	dir = 1;
@@ -891,6 +962,8 @@
 	},
 /turf/open/floor/shiva,
 /area/shiva/interior/bar)
+=======
+>>>>>>> reimported backup
 "Eb" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -1018,6 +1091,10 @@
 "Hb" = (
 /obj/structure/surface/table/woodentable,
 /obj/item/stack/sheet/plasteel/large_stack,
+<<<<<<< master
+=======
+/obj/item/stack/sheet/plasteel/large_stack,
+>>>>>>> reimported backup
 /turf/open/floor/wood,
 /area/shiva/interior/bar)
 "Hf" = (
@@ -1112,6 +1189,18 @@
 /area/shiva/interior/bar)
 "KF" = (
 /obj/structure/surface/table/woodentable,
+<<<<<<< master
+=======
+/obj/item/storage/firstaid/fire{
+	pixel_x = -7
+	},
+/obj/item/storage/firstaid/o2{
+	pixel_x = 11
+	},
+/obj/item/storage/firstaid/fire{
+	pixel_x = -7
+	},
+>>>>>>> reimported backup
 /obj/item/storage/firstaid/o2{
 	pixel_x = 11
 	},
@@ -1201,10 +1290,13 @@
 	},
 /turf/open/auto_turf/snow/layer0,
 /area/shiva/interior/bar)
+<<<<<<< master
 "Mu" = (
 /obj/structure/barricade/snow,
 /turf/open/auto_turf/snow/layer1,
 /area/shiva/exterior/junkyard/cp_bar)
+=======
+>>>>>>> reimported backup
 "MP" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/shiva,
@@ -1220,7 +1312,14 @@
 	},
 /area/shiva/interior/bar)
 "Nr" = (
+<<<<<<< master
 /obj/structure/machinery/cm_vending/sorted/boozeomat,
+=======
+/obj/structure/machinery/chem_dispenser/beer{
+	pixel_y = 8
+	},
+/obj/structure/surface/table/reinforced/prison,
+>>>>>>> reimported backup
 /turf/open/floor/shiva,
 /area/shiva/interior/bar)
 "NN" = (
@@ -1366,7 +1465,11 @@
 "Vg" = (
 /obj/structure/surface/table/woodentable,
 /obj/item/stack/sheet/metal/large_stack,
+<<<<<<< master
 /obj/effect/landmark/wo_supplies/storage/mines,
+=======
+/obj/item/stack/sheet/metal/large_stack,
+>>>>>>> reimported backup
 /turf/open/floor/wood,
 /area/shiva/interior/bar)
 "Vp" = (
@@ -1465,6 +1568,10 @@
 /area/shiva/interior/bar)
 "ZG" = (
 /obj/structure/window_frame/colony/reinforced,
+<<<<<<< master
+=======
+/obj/item/shard,
+>>>>>>> reimported backup
 /turf/open/floor/plating,
 /area/shiva/interior/bar)
 "ZX" = (
@@ -1534,7 +1641,11 @@ lf
 "}
 (4,1,1) = {"
 TD
+<<<<<<< master
 ZG
+=======
+CF
+>>>>>>> reimported backup
 fz
 wk
 md
@@ -1677,9 +1788,15 @@ KC
 ls
 "}
 (12,1,1) = {"
+<<<<<<< master
 Ja
 yz
 DZ
+=======
+XY
+yz
+Em
+>>>>>>> reimported backup
 if
 uL
 Eb
@@ -1713,7 +1830,11 @@ ei
 ls
 "}
 (14,1,1) = {"
+<<<<<<< master
 Mu
+=======
+ni
+>>>>>>> reimported backup
 yz
 zi
 jM
@@ -1767,7 +1888,11 @@ ls
 ls
 "}
 (17,1,1) = {"
+<<<<<<< master
 ZG
+=======
+CF
+>>>>>>> reimported backup
 LX
 Vg
 Ci
@@ -1785,7 +1910,11 @@ jG
 ls
 "}
 (18,1,1) = {"
+<<<<<<< master
 ZG
+=======
+yf
+>>>>>>> reimported backup
 ll
 HA
 rB
@@ -1797,7 +1926,11 @@ jM
 jM
 jM
 hk
+<<<<<<< master
 ZG
+=======
+CF
+>>>>>>> reimported backup
 PK
 ve
 jG
@@ -1815,14 +1948,22 @@ Bl
 jM
 HA
 hk
+<<<<<<< master
 ZG
+=======
+yf
+>>>>>>> reimported backup
 PK
 XD
 ve
 "}
 (20,1,1) = {"
 Ja
+<<<<<<< master
 ZG
+=======
+yf
+>>>>>>> reimported backup
 FH
 rx
 lc
@@ -1833,14 +1974,22 @@ qi
 lQ
 tV
 LT
+<<<<<<< master
 ZG
+=======
+CF
+>>>>>>> reimported backup
 jE
 XD
 lp
 "}
 (21,1,1) = {"
 Ja
+<<<<<<< master
 ZG
+=======
+CF
+>>>>>>> reimported backup
 kB
 ta
 rB
@@ -1851,7 +2000,11 @@ jM
 ud
 jM
 sU
+<<<<<<< master
 ZG
+=======
+yf
+>>>>>>> reimported backup
 Hu
 XD
 rq
@@ -1878,9 +2031,15 @@ AR
 XY
 ls
 ls
+<<<<<<< master
 ZG
 ZG
 ZG
+=======
+yf
+CF
+yf
+>>>>>>> reimported backup
 ls
 ls
 yM
@@ -1900,11 +2059,19 @@ II
 tt
 tt
 NT
+<<<<<<< master
 ZG
 EB
 mV
 LO
 ZG
+=======
+yf
+EB
+mV
+LO
+yf
+>>>>>>> reimported backup
 Hu
 rq
 rq

--- a/maps/map_files/Ice_Colony_v3/sprinkles/40.shivabarls.dmm
+++ b/maps/map_files/Ice_Colony_v3/sprinkles/40.shivabarls.dmm
@@ -166,20 +166,9 @@
 /area/shiva/interior/bar)
 "hR" = (
 /obj/structure/surface/table/woodentable,
-<<<<<<< master
 /obj/item/storage/firstaid/adv{
 	pixel_y = -4;
 	pixel_x = -3
-=======
-/obj/item/storage/firstaid/surgical{
-	pixel_x = -7
-	},
-/obj/item/storage/firstaid/toxin{
-	pixel_x = 10
-	},
-/obj/item/storage/firstaid/toxin{
-	pixel_x = 10
->>>>>>> reimported backup
 	},
 /turf/open/floor/wood,
 /area/shiva/interior/bar)
@@ -496,26 +485,7 @@
 /area/shiva/interior/bar)
 "nU" = (
 /obj/structure/surface/table/woodentable,
-<<<<<<< master
 /obj/item/storage/firstaid/regular,
-=======
-/obj/item/storage/firstaid{
-	pixel_x = -7;
-	pixel_y = -4
-	},
-/obj/item/storage/firstaid/adv{
-	pixel_x = 10;
-	pixel_y = -4
-	},
-/obj/item/storage/firstaid{
-	pixel_x = -7;
-	pixel_y = -4
-	},
-/obj/item/storage/firstaid/adv{
-	pixel_x = 10;
-	pixel_y = -4
-	},
->>>>>>> reimported backup
 /turf/open/floor/shiva{
 	icon_state = "floor3"
 	},
@@ -647,40 +617,20 @@
 	pixel_x = 8;
 	pixel_y = 12
 	},
-<<<<<<< master
 /obj/item/ammo_magazine/shotgun/slugs{
 	pixel_x = -8;
 	pixel_y = -5
-=======
-/obj/item/ammo_magazine/shotgun/buckshot{
-	pixel_x = 8;
-	pixel_y = 12
 	},
 /obj/item/ammo_magazine/shotgun/buckshot{
 	pixel_x = 8;
 	pixel_y = 12
 >>>>>>> reimported backup
 	},
-/obj/item/ammo_magazine/shotgun/buckshot{
-	pixel_x = 8;
-	pixel_y = 12
-	},
 /obj/item/ammo_magazine/shotgun/slugs{
 	pixel_x = -8;
 	pixel_y = -5
 	},
-<<<<<<< master
 /obj/item/ammo_magazine/shotgun/incendiary,
-=======
-/obj/item/weapon/gun/shotgun/double{
-	pixel_x = -16;
-	pixel_y = 10
-	},
-/obj/item/weapon/gun/shotgun/pump/cmb{
-	pixel_x = 20;
-	pixel_y = -5
-	},
->>>>>>> reimported backup
 /turf/open/floor/wood,
 /area/shiva/interior/bar)
 "ud" = (
@@ -801,15 +751,9 @@
 	icon_state = "xtracks";
 	tag = "icon-xtracks"
 	},
-<<<<<<< master
 /obj/structure/barricade/metal/wired{
 	dir = 1;
 	icon_state = "metal_2"
-=======
-/obj/structure/barricade/plasteel/wired{
-	icon_state = "plasteel_3";
-	dir = 1
->>>>>>> reimported backup
 	},
 /turf/open/floor/shiva,
 /area/shiva/interior/bar)
@@ -885,7 +829,6 @@
 /obj/structure/surface/table/woodentable,
 /obj/item/stack/sheet/wood/large_stack,
 /obj/item/stack/sheet/wood/large_stack,
-<<<<<<< master
 /obj/item/tool/weldpack{
 	pixel_y = -6;
 	pixel_x = -8
@@ -898,11 +841,6 @@
 	pixel_y = 9;
 	pixel_x = -12
 	},
-=======
-/obj/item/weapon/gun/smg/nailgun,
-/obj/item/ammo_box/magazine/smg/nailgun,
-/obj/item/weapon/gun/smg/nailgun,
->>>>>>> reimported backup
 /turf/open/floor/wood,
 /area/shiva/interior/bar)
 "Cm" = (
@@ -916,10 +854,6 @@
 /area/shiva/interior/bar)
 "Cv" = (
 /obj/structure/window_frame/colony/reinforced,
-<<<<<<< master
-=======
-/obj/item/stack/rods,
->>>>>>> reimported backup
 /obj/item/shard{
 	icon_state = "large"
 	},
@@ -950,7 +884,6 @@
 	},
 /turf/open/floor/wood,
 /area/shiva/interior/bar)
-<<<<<<< master
 "DZ" = (
 /obj/structure/barricade/metal/wired{
 	dir = 1;
@@ -958,8 +891,6 @@
 	},
 /turf/open/floor/shiva,
 /area/shiva/interior/bar)
-=======
->>>>>>> reimported backup
 "Eb" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -1087,10 +1018,6 @@
 "Hb" = (
 /obj/structure/surface/table/woodentable,
 /obj/item/stack/sheet/plasteel/large_stack,
-<<<<<<< master
-=======
-/obj/item/stack/sheet/plasteel/large_stack,
->>>>>>> reimported backup
 /turf/open/floor/wood,
 /area/shiva/interior/bar)
 "Hf" = (
@@ -1185,18 +1112,6 @@
 /area/shiva/interior/bar)
 "KF" = (
 /obj/structure/surface/table/woodentable,
-<<<<<<< master
-=======
-/obj/item/storage/firstaid/fire{
-	pixel_x = -7
-	},
-/obj/item/storage/firstaid/o2{
-	pixel_x = 11
-	},
-/obj/item/storage/firstaid/fire{
-	pixel_x = -7
-	},
->>>>>>> reimported backup
 /obj/item/storage/firstaid/o2{
 	pixel_x = 11
 	},
@@ -1286,13 +1201,10 @@
 	},
 /turf/open/auto_turf/snow/layer0,
 /area/shiva/interior/bar)
-<<<<<<< master
 "Mu" = (
 /obj/structure/barricade/snow,
 /turf/open/auto_turf/snow/layer1,
 /area/shiva/exterior/junkyard/cp_bar)
-=======
->>>>>>> reimported backup
 "MP" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/shiva,
@@ -1308,14 +1220,7 @@
 	},
 /area/shiva/interior/bar)
 "Nr" = (
-<<<<<<< master
 /obj/structure/machinery/cm_vending/sorted/boozeomat,
-=======
-/obj/structure/machinery/chem_dispenser/beer{
-	pixel_y = 8
-	},
-/obj/structure/surface/table/reinforced/prison,
->>>>>>> reimported backup
 /turf/open/floor/shiva,
 /area/shiva/interior/bar)
 "NN" = (
@@ -1461,11 +1366,7 @@
 "Vg" = (
 /obj/structure/surface/table/woodentable,
 /obj/item/stack/sheet/metal/large_stack,
-<<<<<<< master
 /obj/effect/landmark/wo_supplies/storage/mines,
-=======
-/obj/item/stack/sheet/metal/large_stack,
->>>>>>> reimported backup
 /turf/open/floor/wood,
 /area/shiva/interior/bar)
 "Vp" = (
@@ -1564,10 +1465,6 @@
 /area/shiva/interior/bar)
 "ZG" = (
 /obj/structure/window_frame/colony/reinforced,
-<<<<<<< master
-=======
-/obj/item/shard,
->>>>>>> reimported backup
 /turf/open/floor/plating,
 /area/shiva/interior/bar)
 "ZX" = (
@@ -1637,11 +1534,7 @@ lf
 "}
 (4,1,1) = {"
 TD
-<<<<<<< master
 ZG
-=======
-CF
->>>>>>> reimported backup
 fz
 wk
 md
@@ -1784,15 +1677,9 @@ KC
 ls
 "}
 (12,1,1) = {"
-<<<<<<< master
 Ja
 yz
 DZ
-=======
-XY
-yz
-Em
->>>>>>> reimported backup
 if
 uL
 Eb
@@ -1826,11 +1713,7 @@ ei
 ls
 "}
 (14,1,1) = {"
-<<<<<<< master
 Mu
-=======
-ni
->>>>>>> reimported backup
 yz
 zi
 jM
@@ -1884,11 +1767,7 @@ ls
 ls
 "}
 (17,1,1) = {"
-<<<<<<< master
 ZG
-=======
-CF
->>>>>>> reimported backup
 LX
 Vg
 Ci
@@ -1906,11 +1785,7 @@ jG
 ls
 "}
 (18,1,1) = {"
-<<<<<<< master
 ZG
-=======
-yf
->>>>>>> reimported backup
 ll
 HA
 rB
@@ -1922,11 +1797,7 @@ jM
 jM
 jM
 hk
-<<<<<<< master
 ZG
-=======
-CF
->>>>>>> reimported backup
 PK
 ve
 jG
@@ -1944,22 +1815,14 @@ Bl
 jM
 HA
 hk
-<<<<<<< master
 ZG
-=======
-yf
->>>>>>> reimported backup
 PK
 XD
 ve
 "}
 (20,1,1) = {"
 Ja
-<<<<<<< master
 ZG
-=======
-yf
->>>>>>> reimported backup
 FH
 rx
 lc
@@ -1970,22 +1833,14 @@ qi
 lQ
 tV
 LT
-<<<<<<< master
 ZG
-=======
-CF
->>>>>>> reimported backup
 jE
 XD
 lp
 "}
 (21,1,1) = {"
 Ja
-<<<<<<< master
 ZG
-=======
-CF
->>>>>>> reimported backup
 kB
 ta
 rB
@@ -1996,11 +1851,7 @@ jM
 ud
 jM
 sU
-<<<<<<< master
 ZG
-=======
-yf
->>>>>>> reimported backup
 Hu
 XD
 rq
@@ -2027,15 +1878,9 @@ AR
 XY
 ls
 ls
-<<<<<<< master
 ZG
 ZG
 ZG
-=======
-yf
-CF
-yf
->>>>>>> reimported backup
 ls
 ls
 yM
@@ -2055,19 +1900,11 @@ II
 tt
 tt
 NT
-<<<<<<< master
 ZG
 EB
 mV
 LO
 ZG
-=======
-yf
-EB
-mV
-LO
-yf
->>>>>>> reimported backup
 Hu
 rq
 rq

--- a/maps/map_files/Ice_Colony_v3/sprinkles/40.shivabarls.dmm
+++ b/maps/map_files/Ice_Colony_v3/sprinkles/40.shivabarls.dmm
@@ -166,9 +166,20 @@
 /area/shiva/interior/bar)
 "hR" = (
 /obj/structure/surface/table/woodentable,
+<<<<<<< master
 /obj/item/storage/firstaid/adv{
 	pixel_y = -4;
 	pixel_x = -3
+=======
+/obj/item/storage/firstaid/surgical{
+	pixel_x = -7
+	},
+/obj/item/storage/firstaid/toxin{
+	pixel_x = 10
+	},
+/obj/item/storage/firstaid/toxin{
+	pixel_x = 10
+>>>>>>> reimported backup
 	},
 /turf/open/floor/wood,
 /area/shiva/interior/bar)
@@ -485,7 +496,26 @@
 /area/shiva/interior/bar)
 "nU" = (
 /obj/structure/surface/table/woodentable,
+<<<<<<< master
 /obj/item/storage/firstaid/regular,
+=======
+/obj/item/storage/firstaid{
+	pixel_x = -7;
+	pixel_y = -4
+	},
+/obj/item/storage/firstaid/adv{
+	pixel_x = 10;
+	pixel_y = -4
+	},
+/obj/item/storage/firstaid{
+	pixel_x = -7;
+	pixel_y = -4
+	},
+/obj/item/storage/firstaid/adv{
+	pixel_x = 10;
+	pixel_y = -4
+	},
+>>>>>>> reimported backup
 /turf/open/floor/shiva{
 	icon_state = "floor3"
 	},
@@ -617,9 +647,19 @@
 	pixel_x = 8;
 	pixel_y = 12
 	},
+<<<<<<< master
 /obj/item/ammo_magazine/shotgun/slugs{
 	pixel_x = -8;
 	pixel_y = -5
+=======
+/obj/item/ammo_magazine/shotgun/buckshot{
+	pixel_x = 8;
+	pixel_y = 12
+	},
+/obj/item/ammo_magazine/shotgun/buckshot{
+	pixel_x = 8;
+	pixel_y = 12
+>>>>>>> reimported backup
 	},
 /obj/item/ammo_magazine/shotgun/buckshot{
 	pixel_x = 8;
@@ -629,7 +669,18 @@
 	pixel_x = -8;
 	pixel_y = -5
 	},
+<<<<<<< master
 /obj/item/ammo_magazine/shotgun/incendiary,
+=======
+/obj/item/weapon/gun/shotgun/double{
+	pixel_x = -16;
+	pixel_y = 10
+	},
+/obj/item/weapon/gun/shotgun/pump/cmb{
+	pixel_x = 20;
+	pixel_y = -5
+	},
+>>>>>>> reimported backup
 /turf/open/floor/wood,
 /area/shiva/interior/bar)
 "ud" = (
@@ -750,9 +801,15 @@
 	icon_state = "xtracks";
 	tag = "icon-xtracks"
 	},
+<<<<<<< master
 /obj/structure/barricade/metal/wired{
 	dir = 1;
 	icon_state = "metal_2"
+=======
+/obj/structure/barricade/plasteel/wired{
+	icon_state = "plasteel_3";
+	dir = 1
+>>>>>>> reimported backup
 	},
 /turf/open/floor/shiva,
 /area/shiva/interior/bar)
@@ -828,6 +885,7 @@
 /obj/structure/surface/table/woodentable,
 /obj/item/stack/sheet/wood/large_stack,
 /obj/item/stack/sheet/wood/large_stack,
+<<<<<<< master
 /obj/item/tool/weldpack{
 	pixel_y = -6;
 	pixel_x = -8
@@ -840,6 +898,11 @@
 	pixel_y = 9;
 	pixel_x = -12
 	},
+=======
+/obj/item/weapon/gun/smg/nailgun,
+/obj/item/ammo_box/magazine/smg/nailgun,
+/obj/item/weapon/gun/smg/nailgun,
+>>>>>>> reimported backup
 /turf/open/floor/wood,
 /area/shiva/interior/bar)
 "Cm" = (
@@ -853,6 +916,10 @@
 /area/shiva/interior/bar)
 "Cv" = (
 /obj/structure/window_frame/colony/reinforced,
+<<<<<<< master
+=======
+/obj/item/stack/rods,
+>>>>>>> reimported backup
 /obj/item/shard{
 	icon_state = "large"
 	},
@@ -883,6 +950,7 @@
 	},
 /turf/open/floor/wood,
 /area/shiva/interior/bar)
+<<<<<<< master
 "DZ" = (
 /obj/structure/barricade/metal/wired{
 	dir = 1;
@@ -890,6 +958,8 @@
 	},
 /turf/open/floor/shiva,
 /area/shiva/interior/bar)
+=======
+>>>>>>> reimported backup
 "Eb" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -1017,6 +1087,10 @@
 "Hb" = (
 /obj/structure/surface/table/woodentable,
 /obj/item/stack/sheet/plasteel/large_stack,
+<<<<<<< master
+=======
+/obj/item/stack/sheet/plasteel/large_stack,
+>>>>>>> reimported backup
 /turf/open/floor/wood,
 /area/shiva/interior/bar)
 "Hf" = (
@@ -1111,6 +1185,18 @@
 /area/shiva/interior/bar)
 "KF" = (
 /obj/structure/surface/table/woodentable,
+<<<<<<< master
+=======
+/obj/item/storage/firstaid/fire{
+	pixel_x = -7
+	},
+/obj/item/storage/firstaid/o2{
+	pixel_x = 11
+	},
+/obj/item/storage/firstaid/fire{
+	pixel_x = -7
+	},
+>>>>>>> reimported backup
 /obj/item/storage/firstaid/o2{
 	pixel_x = 11
 	},
@@ -1200,10 +1286,13 @@
 	},
 /turf/open/auto_turf/snow/layer0,
 /area/shiva/interior/bar)
+<<<<<<< master
 "Mu" = (
 /obj/structure/barricade/snow,
 /turf/open/auto_turf/snow/layer1,
 /area/shiva/exterior/junkyard/cp_bar)
+=======
+>>>>>>> reimported backup
 "MP" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/shiva,
@@ -1219,7 +1308,14 @@
 	},
 /area/shiva/interior/bar)
 "Nr" = (
+<<<<<<< master
 /obj/structure/machinery/cm_vending/sorted/boozeomat,
+=======
+/obj/structure/machinery/chem_dispenser/beer{
+	pixel_y = 8
+	},
+/obj/structure/surface/table/reinforced/prison,
+>>>>>>> reimported backup
 /turf/open/floor/shiva,
 /area/shiva/interior/bar)
 "NN" = (
@@ -1365,7 +1461,11 @@
 "Vg" = (
 /obj/structure/surface/table/woodentable,
 /obj/item/stack/sheet/metal/large_stack,
+<<<<<<< master
 /obj/effect/landmark/wo_supplies/storage/mines,
+=======
+/obj/item/stack/sheet/metal/large_stack,
+>>>>>>> reimported backup
 /turf/open/floor/wood,
 /area/shiva/interior/bar)
 "Vp" = (
@@ -1464,6 +1564,10 @@
 /area/shiva/interior/bar)
 "ZG" = (
 /obj/structure/window_frame/colony/reinforced,
+<<<<<<< master
+=======
+/obj/item/shard,
+>>>>>>> reimported backup
 /turf/open/floor/plating,
 /area/shiva/interior/bar)
 "ZX" = (
@@ -1533,7 +1637,11 @@ lf
 "}
 (4,1,1) = {"
 TD
+<<<<<<< master
 ZG
+=======
+CF
+>>>>>>> reimported backup
 fz
 wk
 md
@@ -1676,9 +1784,15 @@ KC
 ls
 "}
 (12,1,1) = {"
+<<<<<<< master
 Ja
 yz
 DZ
+=======
+XY
+yz
+Em
+>>>>>>> reimported backup
 if
 uL
 Eb
@@ -1712,7 +1826,11 @@ ei
 ls
 "}
 (14,1,1) = {"
+<<<<<<< master
 Mu
+=======
+ni
+>>>>>>> reimported backup
 yz
 zi
 jM
@@ -1766,7 +1884,11 @@ ls
 ls
 "}
 (17,1,1) = {"
+<<<<<<< master
 ZG
+=======
+CF
+>>>>>>> reimported backup
 LX
 Vg
 Ci
@@ -1784,7 +1906,11 @@ jG
 ls
 "}
 (18,1,1) = {"
+<<<<<<< master
 ZG
+=======
+yf
+>>>>>>> reimported backup
 ll
 HA
 rB
@@ -1796,7 +1922,11 @@ jM
 jM
 jM
 hk
+<<<<<<< master
 ZG
+=======
+CF
+>>>>>>> reimported backup
 PK
 ve
 jG
@@ -1814,14 +1944,22 @@ Bl
 jM
 HA
 hk
+<<<<<<< master
 ZG
+=======
+yf
+>>>>>>> reimported backup
 PK
 XD
 ve
 "}
 (20,1,1) = {"
 Ja
+<<<<<<< master
 ZG
+=======
+yf
+>>>>>>> reimported backup
 FH
 rx
 lc
@@ -1832,14 +1970,22 @@ qi
 lQ
 tV
 LT
+<<<<<<< master
 ZG
+=======
+CF
+>>>>>>> reimported backup
 jE
 XD
 lp
 "}
 (21,1,1) = {"
 Ja
+<<<<<<< master
 ZG
+=======
+CF
+>>>>>>> reimported backup
 kB
 ta
 rB
@@ -1850,7 +1996,11 @@ jM
 ud
 jM
 sU
+<<<<<<< master
 ZG
+=======
+yf
+>>>>>>> reimported backup
 Hu
 XD
 rq
@@ -1877,9 +2027,15 @@ AR
 XY
 ls
 ls
+<<<<<<< master
 ZG
 ZG
 ZG
+=======
+yf
+CF
+yf
+>>>>>>> reimported backup
 ls
 ls
 yM
@@ -1899,11 +2055,19 @@ II
 tt
 tt
 NT
+<<<<<<< master
 ZG
 EB
 mV
 LO
 ZG
+=======
+yf
+EB
+mV
+LO
+yf
+>>>>>>> reimported backup
 Hu
 rq
 rq

--- a/maps/map_files/Ice_Colony_v3/sprinkles/40.shivabarls.dmm
+++ b/maps/map_files/Ice_Colony_v3/sprinkles/40.shivabarls.dmm
@@ -167,6 +167,7 @@
 "hR" = (
 /obj/structure/surface/table/woodentable,
 <<<<<<< master
+<<<<<<< master
 /obj/item/storage/firstaid/adv{
 	pixel_y = -4;
 	pixel_x = -3
@@ -180,6 +181,11 @@
 /obj/item/storage/firstaid/toxin{
 	pixel_x = 10
 >>>>>>> reimported backup
+=======
+/obj/item/storage/firstaid/adv{
+	pixel_y = -4;
+	pixel_x = -3
+>>>>>>> updated all maps to have CLF Mines and corpses
 	},
 /turf/open/floor/wood,
 /area/shiva/interior/bar)
@@ -497,6 +503,7 @@
 "nU" = (
 /obj/structure/surface/table/woodentable,
 <<<<<<< master
+<<<<<<< master
 /obj/item/storage/firstaid/regular,
 =======
 /obj/item/storage/firstaid{
@@ -516,6 +523,9 @@
 	pixel_y = -4
 	},
 >>>>>>> reimported backup
+=======
+/obj/item/storage/firstaid/regular,
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor/shiva{
 	icon_state = "floor3"
 	},
@@ -648,6 +658,7 @@
 	pixel_y = 12
 	},
 <<<<<<< master
+<<<<<<< master
 /obj/item/ammo_magazine/shotgun/slugs{
 	pixel_x = -8;
 	pixel_y = -5
@@ -660,6 +671,11 @@
 	pixel_x = 8;
 	pixel_y = 12
 >>>>>>> reimported backup
+=======
+/obj/item/ammo_magazine/shotgun/slugs{
+	pixel_x = -8;
+	pixel_y = -5
+>>>>>>> updated all maps to have CLF Mines and corpses
 	},
 /obj/item/ammo_magazine/shotgun/buckshot{
 	pixel_x = 8;
@@ -669,6 +685,7 @@
 	pixel_x = -8;
 	pixel_y = -5
 	},
+<<<<<<< master
 <<<<<<< master
 /obj/item/ammo_magazine/shotgun/incendiary,
 =======
@@ -681,6 +698,9 @@
 	pixel_y = -5
 	},
 >>>>>>> reimported backup
+=======
+/obj/item/ammo_magazine/shotgun/incendiary,
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor/wood,
 /area/shiva/interior/bar)
 "ud" = (
@@ -802,6 +822,7 @@
 	tag = "icon-xtracks"
 	},
 <<<<<<< master
+<<<<<<< master
 /obj/structure/barricade/metal/wired{
 	dir = 1;
 	icon_state = "metal_2"
@@ -810,6 +831,11 @@
 	icon_state = "plasteel_3";
 	dir = 1
 >>>>>>> reimported backup
+=======
+/obj/structure/barricade/metal/wired{
+	dir = 1;
+	icon_state = "metal_2"
+>>>>>>> updated all maps to have CLF Mines and corpses
 	},
 /turf/open/floor/shiva,
 /area/shiva/interior/bar)
@@ -886,6 +912,9 @@
 /obj/item/stack/sheet/wood/large_stack,
 /obj/item/stack/sheet/wood/large_stack,
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 /obj/item/tool/weldpack{
 	pixel_y = -6;
 	pixel_x = -8
@@ -898,11 +927,14 @@
 	pixel_y = 9;
 	pixel_x = -12
 	},
+<<<<<<< master
 =======
 /obj/item/weapon/gun/smg/nailgun,
 /obj/item/ammo_box/magazine/smg/nailgun,
 /obj/item/weapon/gun/smg/nailgun,
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor/wood,
 /area/shiva/interior/bar)
 "Cm" = (
@@ -917,9 +949,12 @@
 "Cv" = (
 /obj/structure/window_frame/colony/reinforced,
 <<<<<<< master
+<<<<<<< master
 =======
 /obj/item/stack/rods,
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 /obj/item/shard{
 	icon_state = "large"
 	},
@@ -951,6 +986,9 @@
 /turf/open/floor/wood,
 /area/shiva/interior/bar)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "DZ" = (
 /obj/structure/barricade/metal/wired{
 	dir = 1;
@@ -958,8 +996,11 @@
 	},
 /turf/open/floor/shiva,
 /area/shiva/interior/bar)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "Eb" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -1088,9 +1129,12 @@
 /obj/structure/surface/table/woodentable,
 /obj/item/stack/sheet/plasteel/large_stack,
 <<<<<<< master
+<<<<<<< master
 =======
 /obj/item/stack/sheet/plasteel/large_stack,
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor/wood,
 /area/shiva/interior/bar)
 "Hf" = (
@@ -1186,6 +1230,7 @@
 "KF" = (
 /obj/structure/surface/table/woodentable,
 <<<<<<< master
+<<<<<<< master
 =======
 /obj/item/storage/firstaid/fire{
 	pixel_x = -7
@@ -1197,6 +1242,8 @@
 	pixel_x = -7
 	},
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 /obj/item/storage/firstaid/o2{
 	pixel_x = 11
 	},
@@ -1287,12 +1334,18 @@
 /turf/open/auto_turf/snow/layer0,
 /area/shiva/interior/bar)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "Mu" = (
 /obj/structure/barricade/snow,
 /turf/open/auto_turf/snow/layer1,
 /area/shiva/exterior/junkyard/cp_bar)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "MP" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/shiva,
@@ -1309,6 +1362,7 @@
 /area/shiva/interior/bar)
 "Nr" = (
 <<<<<<< master
+<<<<<<< master
 /obj/structure/machinery/cm_vending/sorted/boozeomat,
 =======
 /obj/structure/machinery/chem_dispenser/beer{
@@ -1316,6 +1370,9 @@
 	},
 /obj/structure/surface/table/reinforced/prison,
 >>>>>>> reimported backup
+=======
+/obj/structure/machinery/cm_vending/sorted/boozeomat,
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor/shiva,
 /area/shiva/interior/bar)
 "NN" = (
@@ -1462,10 +1519,14 @@
 /obj/structure/surface/table/woodentable,
 /obj/item/stack/sheet/metal/large_stack,
 <<<<<<< master
+<<<<<<< master
 /obj/effect/landmark/wo_supplies/storage/mines,
 =======
 /obj/item/stack/sheet/metal/large_stack,
 >>>>>>> reimported backup
+=======
+/obj/effect/landmark/wo_supplies/storage/mines,
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor/wood,
 /area/shiva/interior/bar)
 "Vp" = (
@@ -1565,9 +1626,12 @@
 "ZG" = (
 /obj/structure/window_frame/colony/reinforced,
 <<<<<<< master
+<<<<<<< master
 =======
 /obj/item/shard,
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor/plating,
 /area/shiva/interior/bar)
 "ZX" = (
@@ -1638,10 +1702,14 @@ lf
 (4,1,1) = {"
 TD
 <<<<<<< master
+<<<<<<< master
 ZG
 =======
 CF
 >>>>>>> reimported backup
+=======
+ZG
+>>>>>>> updated all maps to have CLF Mines and corpses
 fz
 wk
 md
@@ -1785,6 +1853,7 @@ ls
 "}
 (12,1,1) = {"
 <<<<<<< master
+<<<<<<< master
 Ja
 yz
 DZ
@@ -1793,6 +1862,11 @@ XY
 yz
 Em
 >>>>>>> reimported backup
+=======
+Ja
+yz
+DZ
+>>>>>>> updated all maps to have CLF Mines and corpses
 if
 uL
 Eb
@@ -1827,10 +1901,14 @@ ls
 "}
 (14,1,1) = {"
 <<<<<<< master
+<<<<<<< master
 Mu
 =======
 ni
 >>>>>>> reimported backup
+=======
+Mu
+>>>>>>> updated all maps to have CLF Mines and corpses
 yz
 zi
 jM
@@ -1885,10 +1963,14 @@ ls
 "}
 (17,1,1) = {"
 <<<<<<< master
+<<<<<<< master
 ZG
 =======
 CF
 >>>>>>> reimported backup
+=======
+ZG
+>>>>>>> updated all maps to have CLF Mines and corpses
 LX
 Vg
 Ci
@@ -1907,10 +1989,14 @@ ls
 "}
 (18,1,1) = {"
 <<<<<<< master
+<<<<<<< master
 ZG
 =======
 yf
 >>>>>>> reimported backup
+=======
+ZG
+>>>>>>> updated all maps to have CLF Mines and corpses
 ll
 HA
 rB
@@ -1923,10 +2009,14 @@ jM
 jM
 hk
 <<<<<<< master
+<<<<<<< master
 ZG
 =======
 CF
 >>>>>>> reimported backup
+=======
+ZG
+>>>>>>> updated all maps to have CLF Mines and corpses
 PK
 ve
 jG
@@ -1945,10 +2035,14 @@ jM
 HA
 hk
 <<<<<<< master
+<<<<<<< master
 ZG
 =======
 yf
 >>>>>>> reimported backup
+=======
+ZG
+>>>>>>> updated all maps to have CLF Mines and corpses
 PK
 XD
 ve
@@ -1956,10 +2050,14 @@ ve
 (20,1,1) = {"
 Ja
 <<<<<<< master
+<<<<<<< master
 ZG
 =======
 yf
 >>>>>>> reimported backup
+=======
+ZG
+>>>>>>> updated all maps to have CLF Mines and corpses
 FH
 rx
 lc
@@ -1971,10 +2069,14 @@ lQ
 tV
 LT
 <<<<<<< master
+<<<<<<< master
 ZG
 =======
 CF
 >>>>>>> reimported backup
+=======
+ZG
+>>>>>>> updated all maps to have CLF Mines and corpses
 jE
 XD
 lp
@@ -1982,10 +2084,14 @@ lp
 (21,1,1) = {"
 Ja
 <<<<<<< master
+<<<<<<< master
 ZG
 =======
 CF
 >>>>>>> reimported backup
+=======
+ZG
+>>>>>>> updated all maps to have CLF Mines and corpses
 kB
 ta
 rB
@@ -1997,10 +2103,14 @@ ud
 jM
 sU
 <<<<<<< master
+<<<<<<< master
 ZG
 =======
 yf
 >>>>>>> reimported backup
+=======
+ZG
+>>>>>>> updated all maps to have CLF Mines and corpses
 Hu
 XD
 rq
@@ -2028,6 +2138,7 @@ XY
 ls
 ls
 <<<<<<< master
+<<<<<<< master
 ZG
 ZG
 ZG
@@ -2036,6 +2147,11 @@ yf
 CF
 yf
 >>>>>>> reimported backup
+=======
+ZG
+ZG
+ZG
+>>>>>>> updated all maps to have CLF Mines and corpses
 ls
 ls
 yM
@@ -2056,6 +2172,7 @@ tt
 tt
 NT
 <<<<<<< master
+<<<<<<< master
 ZG
 EB
 mV
@@ -2068,6 +2185,13 @@ mV
 LO
 yf
 >>>>>>> reimported backup
+=======
+ZG
+EB
+mV
+LO
+ZG
+>>>>>>> updated all maps to have CLF Mines and corpses
 Hu
 rq
 rq

--- a/maps/map_files/Ice_Colony_v3/sprinkles/40.shivabarls.dmm
+++ b/maps/map_files/Ice_Colony_v3/sprinkles/40.shivabarls.dmm
@@ -166,14 +166,9 @@
 /area/shiva/interior/bar)
 "hR" = (
 /obj/structure/surface/table/woodentable,
-/obj/item/storage/firstaid/surgical{
-	pixel_x = -7
-	},
-/obj/item/storage/firstaid/toxin{
-	pixel_x = 10
-	},
-/obj/item/storage/firstaid/toxin{
-	pixel_x = 10
+/obj/item/storage/firstaid/adv{
+	pixel_y = -4;
+	pixel_x = -3
 	},
 /turf/open/floor/wood,
 /area/shiva/interior/bar)
@@ -490,22 +485,7 @@
 /area/shiva/interior/bar)
 "nU" = (
 /obj/structure/surface/table/woodentable,
-/obj/item/storage/firstaid{
-	pixel_x = -7;
-	pixel_y = -4
-	},
-/obj/item/storage/firstaid/adv{
-	pixel_x = 10;
-	pixel_y = -4
-	},
-/obj/item/storage/firstaid{
-	pixel_x = -7;
-	pixel_y = -4
-	},
-/obj/item/storage/firstaid/adv{
-	pixel_x = 10;
-	pixel_y = -4
-	},
+/obj/item/storage/firstaid/regular,
 /turf/open/floor/shiva{
 	icon_state = "floor3"
 	},
@@ -637,13 +617,9 @@
 	pixel_x = 8;
 	pixel_y = 12
 	},
-/obj/item/ammo_magazine/shotgun/buckshot{
-	pixel_x = 8;
-	pixel_y = 12
-	},
-/obj/item/ammo_magazine/shotgun/buckshot{
-	pixel_x = 8;
-	pixel_y = 12
+/obj/item/ammo_magazine/shotgun/slugs{
+	pixel_x = -8;
+	pixel_y = -5
 	},
 /obj/item/ammo_magazine/shotgun/buckshot{
 	pixel_x = 8;
@@ -653,14 +629,7 @@
 	pixel_x = -8;
 	pixel_y = -5
 	},
-/obj/item/weapon/gun/shotgun/double{
-	pixel_x = -16;
-	pixel_y = 10
-	},
-/obj/item/weapon/gun/shotgun/pump/cmb{
-	pixel_x = 20;
-	pixel_y = -5
-	},
+/obj/item/ammo_magazine/shotgun/incendiary,
 /turf/open/floor/wood,
 /area/shiva/interior/bar)
 "ud" = (
@@ -781,9 +750,9 @@
 	icon_state = "xtracks";
 	tag = "icon-xtracks"
 	},
-/obj/structure/barricade/plasteel/wired{
-	icon_state = "plasteel_3";
-	dir = 1
+/obj/structure/barricade/metal/wired{
+	dir = 1;
+	icon_state = "metal_2"
 	},
 /turf/open/floor/shiva,
 /area/shiva/interior/bar)
@@ -859,9 +828,18 @@
 /obj/structure/surface/table/woodentable,
 /obj/item/stack/sheet/wood/large_stack,
 /obj/item/stack/sheet/wood/large_stack,
-/obj/item/weapon/gun/smg/nailgun,
-/obj/item/ammo_box/magazine/smg/nailgun,
-/obj/item/weapon/gun/smg/nailgun,
+/obj/item/tool/weldpack{
+	pixel_y = -6;
+	pixel_x = -8
+	},
+/obj/item/tool/weldingtool{
+	pixel_y = -9;
+	pixel_x = 11
+	},
+/obj/item/clothing/glasses/welding{
+	pixel_y = 9;
+	pixel_x = -12
+	},
 /turf/open/floor/wood,
 /area/shiva/interior/bar)
 "Cm" = (
@@ -875,7 +853,6 @@
 /area/shiva/interior/bar)
 "Cv" = (
 /obj/structure/window_frame/colony/reinforced,
-/obj/item/stack/rods,
 /obj/item/shard{
 	icon_state = "large"
 	},
@@ -905,6 +882,13 @@
 	dir = 8
 	},
 /turf/open/floor/wood,
+/area/shiva/interior/bar)
+"DZ" = (
+/obj/structure/barricade/metal/wired{
+	dir = 1;
+	icon_state = "metal_2"
+	},
+/turf/open/floor/shiva,
 /area/shiva/interior/bar)
 "Eb" = (
 /obj/structure/bed/chair{
@@ -1033,7 +1017,6 @@
 "Hb" = (
 /obj/structure/surface/table/woodentable,
 /obj/item/stack/sheet/plasteel/large_stack,
-/obj/item/stack/sheet/plasteel/large_stack,
 /turf/open/floor/wood,
 /area/shiva/interior/bar)
 "Hf" = (
@@ -1128,15 +1111,6 @@
 /area/shiva/interior/bar)
 "KF" = (
 /obj/structure/surface/table/woodentable,
-/obj/item/storage/firstaid/fire{
-	pixel_x = -7
-	},
-/obj/item/storage/firstaid/o2{
-	pixel_x = 11
-	},
-/obj/item/storage/firstaid/fire{
-	pixel_x = -7
-	},
 /obj/item/storage/firstaid/o2{
 	pixel_x = 11
 	},
@@ -1226,6 +1200,10 @@
 	},
 /turf/open/auto_turf/snow/layer0,
 /area/shiva/interior/bar)
+"Mu" = (
+/obj/structure/barricade/snow,
+/turf/open/auto_turf/snow/layer1,
+/area/shiva/exterior/junkyard/cp_bar)
 "MP" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/shiva,
@@ -1241,10 +1219,7 @@
 	},
 /area/shiva/interior/bar)
 "Nr" = (
-/obj/structure/machinery/chem_dispenser/beer{
-	pixel_y = 8
-	},
-/obj/structure/surface/table/reinforced/prison,
+/obj/structure/machinery/cm_vending/sorted/boozeomat,
 /turf/open/floor/shiva,
 /area/shiva/interior/bar)
 "NN" = (
@@ -1390,7 +1365,7 @@
 "Vg" = (
 /obj/structure/surface/table/woodentable,
 /obj/item/stack/sheet/metal/large_stack,
-/obj/item/stack/sheet/metal/large_stack,
+/obj/effect/landmark/wo_supplies/storage/mines,
 /turf/open/floor/wood,
 /area/shiva/interior/bar)
 "Vp" = (
@@ -1489,7 +1464,6 @@
 /area/shiva/interior/bar)
 "ZG" = (
 /obj/structure/window_frame/colony/reinforced,
-/obj/item/shard,
 /turf/open/floor/plating,
 /area/shiva/interior/bar)
 "ZX" = (
@@ -1559,7 +1533,7 @@ lf
 "}
 (4,1,1) = {"
 TD
-CF
+ZG
 fz
 wk
 md
@@ -1702,9 +1676,9 @@ KC
 ls
 "}
 (12,1,1) = {"
-XY
+Ja
 yz
-Em
+DZ
 if
 uL
 Eb
@@ -1738,7 +1712,7 @@ ei
 ls
 "}
 (14,1,1) = {"
-ni
+Mu
 yz
 zi
 jM
@@ -1792,7 +1766,7 @@ ls
 ls
 "}
 (17,1,1) = {"
-CF
+ZG
 LX
 Vg
 Ci
@@ -1810,7 +1784,7 @@ jG
 ls
 "}
 (18,1,1) = {"
-yf
+ZG
 ll
 HA
 rB
@@ -1822,7 +1796,7 @@ jM
 jM
 jM
 hk
-CF
+ZG
 PK
 ve
 jG
@@ -1840,14 +1814,14 @@ Bl
 jM
 HA
 hk
-yf
+ZG
 PK
 XD
 ve
 "}
 (20,1,1) = {"
 Ja
-yf
+ZG
 FH
 rx
 lc
@@ -1858,14 +1832,14 @@ qi
 lQ
 tV
 LT
-CF
+ZG
 jE
 XD
 lp
 "}
 (21,1,1) = {"
 Ja
-CF
+ZG
 kB
 ta
 rB
@@ -1876,7 +1850,7 @@ jM
 ud
 jM
 sU
-yf
+ZG
 Hu
 XD
 rq
@@ -1903,9 +1877,9 @@ AR
 XY
 ls
 ls
-yf
-CF
-yf
+ZG
+ZG
+ZG
 ls
 ls
 yM
@@ -1925,11 +1899,11 @@ II
 tt
 tt
 NT
-yf
+ZG
 EB
 mV
 LO
-yf
+ZG
 Hu
 rq
 rq

--- a/maps/map_files/Ice_Colony_v3/sprinkles/40.shivabarls.dmm
+++ b/maps/map_files/Ice_Colony_v3/sprinkles/40.shivabarls.dmm
@@ -664,10 +664,6 @@
 /obj/item/ammo_magazine/shotgun/buckshot{
 	pixel_x = 8;
 	pixel_y = 12
-<<<<<<< master
->>>>>>> reimported backup
-=======
->>>>>>> reimported backup
 	},
 /obj/item/ammo_magazine/shotgun/slugs{
 	pixel_x = -8;

--- a/maps/map_files/Ice_Colony_v3/sprinkles/40.shivabarls.dmm
+++ b/maps/map_files/Ice_Colony_v3/sprinkles/40.shivabarls.dmm
@@ -1,0 +1,1955 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ak" = (
+/obj/item/stack/sheet/mineral/plastic/small_stack,
+/obj/structure/machinery/light/double{
+	dir = 4;
+	pixel_y = -5
+	},
+/turf/open/floor/shiva,
+/area/shiva/interior/bar)
+"ap" = (
+/obj/structure/barricade/metal/wired{
+	dir = 4;
+	icon_state = "metal_1"
+	},
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/shiva,
+/area/shiva/interior/bar)
+"aP" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/reagent_container/food/snacks/fortunecookie/prefilled{
+	pixel_x = -6;
+	pixel_y = 2
+	},
+/obj/item/reagent_container/food/snacks/fortunecookie/prefilled{
+	pixel_x = 6;
+	pixel_y = 11
+	},
+/turf/open/floor/prison{
+	icon_state = "kitchen"
+	},
+/area/shiva/interior/bar)
+"bi" = (
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1"
+	},
+/turf/open/floor/wood,
+/area/shiva/interior/bar)
+"cs" = (
+/obj/structure/bed/chair/wood/normal,
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1";
+	dir = 8
+	},
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor/wood,
+/area/shiva/interior/bar)
+"cA" = (
+/obj/structure/barricade/snow{
+	dir = 1
+	},
+/turf/open/auto_turf/snow/layer0,
+/area/shiva/interior/bar)
+"cH" = (
+/obj/structure/machinery/gibber,
+/turf/open/floor/prison,
+/area/shiva/interior/bar)
+"dt" = (
+/obj/structure/machinery/vending/cigarette,
+/turf/open/floor/shiva,
+/area/shiva/interior/bar)
+"dz" = (
+/obj/structure/flora/bush/ausbushes/lavendergrass,
+/turf/open/auto_turf/snow/layer2,
+/area/shiva/exterior/junkyard/cp_bar)
+"ef" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -11;
+	pixel_y = 5
+	},
+/turf/open/floor/prison{
+	icon_state = "kitchen";
+	tag = "icon-kitchen"
+	},
+/area/shiva/interior/bar)
+"ei" = (
+/obj/structure/closet/crate/freezer/rations,
+/obj/item/reagent_container/food/snacks/bigbiteburger,
+/obj/item/reagent_container/food/snacks/bigbiteburger,
+/obj/structure/machinery/light/double,
+/turf/open/floor/prison{
+	icon_state = "kitchen"
+	},
+/area/shiva/interior/bar)
+"ey" = (
+/obj/item/tool/kitchen/knife/butcher,
+/turf/open/floor/prison{
+	icon_state = "kitchen"
+	},
+/area/shiva/interior/bar)
+"eV" = (
+/obj/structure/bed/chair/wood/normal{
+	dir = 4
+	},
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor/wood,
+/area/shiva/interior/bar)
+"fs" = (
+/obj/structure/closet/crate/trashcart,
+/obj/item/clothing/glasses/sunglasses{
+	desc = "Polarized bioneural eyewear, designed to augment your vision.";
+	icon_state = "jensenshades";
+	name = "augmented shades"
+	},
+/turf/open/auto_turf/snow/layer0,
+/area/shiva/interior/bar)
+"fz" = (
+/obj/structure/barricade/metal/wired{
+	dir = 1;
+	icon_state = "metal_2"
+	},
+/obj/item/shard{
+	icon_state = "medium"
+	},
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/prison{
+	icon_state = "kitchen";
+	tag = "icon-kitchen"
+	},
+/area/shiva/interior/bar)
+"fL" = (
+/obj/structure/largecrate/random/case/double,
+/obj/structure/largecrate/random/mini{
+	pixel_x = 6;
+	pixel_y = 18
+	},
+/turf/open/auto_turf/snow/layer0,
+/area/shiva/interior/bar)
+"fV" = (
+/obj/structure/closet/crate/freezer/rations,
+/obj/item/reagent_container/food/snacks/bigbiteburger,
+/obj/item/reagent_container/food/snacks/bigbiteburger,
+/obj/item/stack/sheet/metal/medium_stack,
+/turf/open/floor/prison{
+	icon_state = "kitchen"
+	},
+/area/shiva/interior/bar)
+"gq" = (
+/obj/item/lightstick/red/spoke/planted{
+	pixel_x = 11;
+	pixel_y = 20
+	},
+/turf/open/auto_turf/snow/layer2,
+/area/shiva/exterior/junkyard)
+"gU" = (
+/obj/structure/reagent_dispensers/beerkeg,
+/obj/structure/reagent_dispensers/beerkeg{
+	pixel_y = 13
+	},
+/obj/item/reagent_container/food/drinks/cans/beer{
+	pixel_x = -6;
+	pixel_y = -12
+	},
+/turf/open/auto_turf/snow/layer0,
+/area/shiva/interior/bar)
+"hk" = (
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1"
+	},
+/obj/item/shard,
+/turf/open/floor/shiva,
+/area/shiva/interior/bar)
+"hr" = (
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/shiva,
+/area/shiva/interior/bar)
+"hR" = (
+/obj/structure/surface/table/woodentable,
+/obj/item/storage/firstaid/surgical{
+	pixel_x = -7
+	},
+/obj/item/storage/firstaid/toxin{
+	pixel_x = 10
+	},
+/obj/item/storage/firstaid/toxin{
+	pixel_x = 10
+	},
+/turf/open/floor/wood,
+/area/shiva/interior/bar)
+"hY" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/reagent_container/spray/cleaner{
+	pixel_x = 6;
+	pixel_y = 11
+	},
+/obj/item/tool/soap{
+	pixel_x = -7
+	},
+/turf/open/floor/prison{
+	icon_state = "kitchen";
+	tag = "icon-kitchen"
+	},
+/area/shiva/interior/bar)
+"if" = (
+/obj/item/stack/sheet/wood,
+/turf/open/floor/wood,
+/area/shiva/interior/bar)
+"iy" = (
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/item/clothing/head/cakehat,
+/turf/open/floor/prison{
+	icon_state = "kitchen"
+	},
+/area/shiva/interior/bar)
+"jC" = (
+/obj/structure/machinery/space_heater,
+/turf/open/floor/prison{
+	icon_state = "kitchen";
+	tag = "icon-kitchen"
+	},
+/area/shiva/interior/bar)
+"jE" = (
+/obj/structure/barricade/snow{
+	dir = 1
+	},
+/turf/open/auto_turf/snow/layer3,
+/area/shiva/exterior/junkyard)
+"jG" = (
+/obj/structure/flora/bush/ausbushes/lavendergrass,
+/turf/open/auto_turf/snow/layer3,
+/area/shiva/exterior/junkyard)
+"jM" = (
+/turf/open/floor/wood,
+/area/shiva/interior/bar)
+"jY" = (
+/obj/structure/machinery/door/airlock/almayer/generic{
+	dir = 8;
+	name = "\improper Anti-Freeze Lounge Freezer"
+	},
+/turf/open/floor/plating,
+/area/shiva/interior/bar)
+"kk" = (
+/obj/item/tool/shovel/snow,
+/turf/open/floor/shiva,
+/area/shiva/interior/bar)
+"kB" = (
+/obj/structure/barricade/metal/wired{
+	dir = 1;
+	icon_state = "metal_2"
+	},
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor/shiva,
+/area/shiva/interior/bar)
+"lc" = (
+/obj/structure/surface/table/woodentable,
+/obj/item/clothing/head/ushanka{
+	pixel_x = -7
+	},
+/obj/item/clothing/mask/rebreather/scarf{
+	pixel_x = 9
+	},
+/obj/item/clothing/head/ushanka{
+	pixel_x = -7
+	},
+/obj/item/clothing/head/ushanka{
+	pixel_x = -7
+	},
+/obj/item/clothing/head/ushanka{
+	pixel_x = -7
+	},
+/obj/item/clothing/head/ushanka{
+	pixel_x = -7
+	},
+/obj/item/clothing/head/ushanka{
+	pixel_x = -7
+	},
+/obj/item/clothing/mask/rebreather/scarf{
+	pixel_x = 9
+	},
+/obj/item/clothing/mask/rebreather/scarf{
+	pixel_x = 9
+	},
+/obj/item/clothing/mask/rebreather/scarf{
+	pixel_x = 9
+	},
+/obj/item/clothing/mask/rebreather/scarf{
+	pixel_x = 9
+	},
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor/wood,
+/area/shiva/interior/bar)
+"lf" = (
+/turf/open/auto_turf/snow/layer0,
+/area/shiva/interior/bar)
+"ll" = (
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1";
+	dir = 1
+	},
+/turf/open/floor/shiva,
+/area/shiva/interior/bar)
+"lp" = (
+/obj/structure/flora/bush/ausbushes/lavendergrass,
+/turf/open/auto_turf/snow/layer2,
+/area/shiva/exterior/junkyard)
+"ls" = (
+/turf/closed/wall/shiva/prefabricated,
+/area/shiva/interior/bar)
+"lK" = (
+/obj/structure/flora/bush/snow{
+	icon_state = "snowgrassall_1"
+	},
+/turf/open/auto_turf/snow/layer3,
+/area/shiva/exterior/junkyard/cp_bar)
+"lQ" = (
+/obj/structure/surface/table/woodentable,
+/obj/item/ammo_magazine/rifle/hunting{
+	pixel_y = 5;
+	pixel_x = 10
+	},
+/obj/item/weapon/gun/rifle/hunting{
+	pixel_y = 12
+	},
+/obj/item/ammo_magazine/rifle/mar40/lmg{
+	pixel_x = -9;
+	pixel_y = -3
+	},
+/obj/item/ammo_magazine/rifle/mar40{
+	pixel_x = 8;
+	pixel_y = -5
+	},
+/obj/item/ammo_magazine/rifle/mar40/lmg{
+	pixel_x = -9;
+	pixel_y = -3
+	},
+/obj/item/ammo_magazine/rifle/mar40/lmg{
+	pixel_x = -9;
+	pixel_y = -3
+	},
+/obj/item/ammo_magazine/rifle/mar40/lmg{
+	pixel_x = -9;
+	pixel_y = -3
+	},
+/obj/item/ammo_magazine/rifle/mar40/lmg{
+	pixel_x = -9;
+	pixel_y = -3
+	},
+/obj/item/ammo_magazine/rifle/mar40/lmg{
+	pixel_x = -9;
+	pixel_y = -3
+	},
+/obj/item/ammo_magazine/rifle/mar40/lmg{
+	pixel_x = -9;
+	pixel_y = -3
+	},
+/obj/item/ammo_magazine/rifle/mar40{
+	pixel_x = 8;
+	pixel_y = -5
+	},
+/obj/item/ammo_magazine/rifle/mar40{
+	pixel_x = 8;
+	pixel_y = -5
+	},
+/obj/item/ammo_magazine/rifle/mar40{
+	pixel_x = 8;
+	pixel_y = -5
+	},
+/obj/item/ammo_magazine/rifle/mar40{
+	pixel_x = 8;
+	pixel_y = -5
+	},
+/obj/item/ammo_magazine/rifle/mar40{
+	pixel_x = 8;
+	pixel_y = -5
+	},
+/obj/item/ammo_magazine/rifle/mar40{
+	pixel_x = 8;
+	pixel_y = -5
+	},
+/obj/item/ammo_magazine/rifle/hunting{
+	pixel_y = 5;
+	pixel_x = 10
+	},
+/obj/item/ammo_magazine/rifle/hunting{
+	pixel_y = 5;
+	pixel_x = 10
+	},
+/obj/item/ammo_magazine/rifle/hunting{
+	pixel_y = 5;
+	pixel_x = 10
+	},
+/obj/item/ammo_magazine/rifle/hunting{
+	pixel_y = 5;
+	pixel_x = 10
+	},
+/obj/item/ammo_magazine/rifle/hunting{
+	pixel_y = 5;
+	pixel_x = 10
+	},
+/obj/item/ammo_magazine/rifle/hunting{
+	pixel_y = 5;
+	pixel_x = 10
+	},
+/obj/item/ammo_magazine/rifle/hunting{
+	pixel_y = 5;
+	pixel_x = 10
+	},
+/obj/item/ammo_magazine/rifle/hunting{
+	pixel_y = 5;
+	pixel_x = 10
+	},
+/obj/item/ammo_magazine/rifle/hunting{
+	pixel_y = 5;
+	pixel_x = 10
+	},
+/obj/item/ammo_magazine/rifle/hunting{
+	pixel_y = 5;
+	pixel_x = 10
+	},
+/obj/item/ammo_magazine/rifle/hunting{
+	pixel_y = 5;
+	pixel_x = 10
+	},
+/obj/item/ammo_magazine/rifle/hunting{
+	pixel_y = 5;
+	pixel_x = 10
+	},
+/turf/open/floor/wood,
+/area/shiva/interior/bar)
+"md" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/reagent_container/food/snacks/flour{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/turf/open/floor/prison{
+	icon_state = "kitchen";
+	tag = "icon-kitchen"
+	},
+/area/shiva/interior/bar)
+"mf" = (
+/obj/structure/closet/bodybag,
+/obj/structure/machinery/light/double{
+	dir = 1;
+	pixel_y = 9
+	},
+/turf/open/floor/plating/plating_catwalk/shiva,
+/area/shiva/interior/bar)
+"mC" = (
+/obj/structure/machinery/space_heater,
+/obj/structure/machinery/light/double{
+	dir = 8;
+	pixel_y = -5
+	},
+/turf/open/floor/prison{
+	icon_state = "kitchen"
+	},
+/area/shiva/interior/bar)
+"mN" = (
+/obj/structure/surface/table/woodentable{
+	flipped = 1
+	},
+/obj/effect/spawner/random/technology_scanner,
+/obj/item/reagent_container/food/snacks/mre_pack,
+/obj/item/reagent_container/food/snacks/mre_pack,
+/obj/item/reagent_container/food/snacks/mre_pack,
+/obj/item/reagent_container/food/snacks/mre_pack,
+/turf/open/floor/shiva{
+	icon_state = "floor3"
+	},
+/area/shiva/interior/bar)
+"mT" = (
+/obj/item/reagent_container/food/drinks/cans/beer,
+/turf/open/auto_turf/snow/layer0,
+/area/shiva/interior/bar)
+"mV" = (
+/obj/item/ammo_casing/bullet,
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor/shiva{
+	dir = 8;
+	icon_state = "bluefull"
+	},
+/area/shiva/interior/bar)
+"ni" = (
+/turf/open/auto_turf/snow/layer1,
+/area/shiva/exterior/junkyard/cp_bar)
+"nv" = (
+/obj/structure/machinery/door/airlock/almayer/generic{
+	dir = 1;
+	name = "\improper Anti-Freeze Lounge"
+	},
+/turf/open/floor/plating,
+/area/shiva/interior/bar)
+"nK" = (
+/obj/structure/machinery/power/apc{
+	dir = 4
+	},
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/shiva,
+/area/shiva/interior/bar)
+"nU" = (
+/obj/structure/surface/table/woodentable,
+/obj/item/storage/firstaid{
+	pixel_x = -7;
+	pixel_y = -4
+	},
+/obj/item/storage/firstaid/adv{
+	pixel_x = 10;
+	pixel_y = -4
+	},
+/obj/item/storage/firstaid{
+	pixel_x = -7;
+	pixel_y = -4
+	},
+/obj/item/storage/firstaid/adv{
+	pixel_x = 10;
+	pixel_y = -4
+	},
+/turf/open/floor/shiva{
+	icon_state = "floor3"
+	},
+/area/shiva/interior/bar)
+"oh" = (
+/obj/effect/decal/cleanable/blood,
+/obj/item/weapon/gun/shotgun/double,
+/turf/open/floor/prison{
+	icon_state = "kitchen"
+	},
+/area/shiva/interior/bar)
+"om" = (
+/obj/structure/barricade/metal/wired{
+	dir = 4;
+	icon_state = "metal_2"
+	},
+/obj/item/shard,
+/turf/open/floor/shiva,
+/area/shiva/interior/bar)
+"oF" = (
+/obj/structure/window/framed/shiva,
+/turf/open/floor/plating,
+/area/shiva/interior/bar)
+"qd" = (
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1"
+	},
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/prison{
+	icon_state = "kitchen"
+	},
+/area/shiva/interior/bar)
+"qi" = (
+/obj/structure/surface/table/woodentable,
+/obj/item/weapon/gun/rifle/mar40{
+	pixel_x = -2;
+	pixel_y = 11
+	},
+/obj/item/weapon/gun/rifle/mar40/carbine,
+/obj/item/weapon/gun/rifle/mar40/lmg{
+	pixel_y = -12
+	},
+/obj/item/weapon/gun/rifle/mar40/lmg{
+	pixel_y = -12
+	},
+/obj/item/weapon/gun/rifle/mar40/carbine,
+/obj/item/weapon/gun/rifle/mar40{
+	pixel_x = -2;
+	pixel_y = 11
+	},
+/turf/open/floor/wood,
+/area/shiva/interior/bar)
+"qu" = (
+/obj/item/tool/wet_sign,
+/turf/open/floor/wood,
+/area/shiva/interior/bar)
+"rq" = (
+/turf/open/auto_turf/snow/layer3,
+/area/shiva/exterior/junkyard)
+"rx" = (
+/obj/structure/bed/chair/wood/normal,
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor/wood,
+/area/shiva/interior/bar)
+"rB" = (
+/obj/structure/bed/chair/wood/normal{
+	dir = 8
+	},
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor/wood,
+/area/shiva/interior/bar)
+"rZ" = (
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1";
+	dir = 8
+	},
+/turf/open/floor/plating/plating_catwalk/shiva,
+/area/shiva/interior/bar)
+"sU" = (
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1"
+	},
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/shiva,
+/area/shiva/interior/bar)
+"ta" = (
+/obj/item/shard,
+/turf/open/floor/wood,
+/area/shiva/interior/bar)
+"tt" = (
+/obj/structure/barricade/snow{
+	dir = 8
+	},
+/turf/open/auto_turf/snow/layer3,
+/area/shiva/exterior/junkyard/cp_bar)
+"tD" = (
+/obj/structure/surface/table/woodentable,
+/obj/item/clothing/shoes/jackboots,
+/obj/item/clothing/shoes/jackboots,
+/obj/item/clothing/shoes/jackboots,
+/obj/item/clothing/shoes/jackboots,
+/obj/item/clothing/shoes/jackboots,
+/turf/open/floor/wood,
+/area/shiva/interior/bar)
+"tR" = (
+/turf/open/floor/shiva,
+/area/shiva/interior/bar)
+"tU" = (
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1";
+	dir = 8
+	},
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1"
+	},
+/turf/open/floor/plating/plating_catwalk/shiva,
+/area/shiva/interior/bar)
+"tV" = (
+/obj/structure/surface/table/woodentable,
+/obj/item/weapon/gun/shotgun/pump/cmb{
+	pixel_x = 20;
+	pixel_y = -5
+	},
+/obj/item/weapon/gun/shotgun/double{
+	pixel_x = -16;
+	pixel_y = 10
+	},
+/obj/item/ammo_magazine/shotgun/buckshot{
+	pixel_x = 8;
+	pixel_y = 12
+	},
+/obj/item/ammo_magazine/shotgun/buckshot{
+	pixel_x = 8;
+	pixel_y = 12
+	},
+/obj/item/ammo_magazine/shotgun/buckshot{
+	pixel_x = 8;
+	pixel_y = 12
+	},
+/obj/item/ammo_magazine/shotgun/buckshot{
+	pixel_x = 8;
+	pixel_y = 12
+	},
+/obj/item/ammo_magazine/shotgun/slugs{
+	pixel_x = -8;
+	pixel_y = -5
+	},
+/obj/item/weapon/gun/shotgun/double{
+	pixel_x = -16;
+	pixel_y = 10
+	},
+/obj/item/weapon/gun/shotgun/pump/cmb{
+	pixel_x = 20;
+	pixel_y = -5
+	},
+/turf/open/floor/wood,
+/area/shiva/interior/bar)
+"ud" = (
+/obj/structure/bed/chair/wood/normal{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/shiva/interior/bar)
+"uD" = (
+/obj/structure/machinery/chem_master/condimaster,
+/turf/open/floor/shiva{
+	icon_state = "floor3"
+	},
+/area/shiva/interior/bar)
+"uI" = (
+/obj/item/tool/wet_sign,
+/obj/structure/barricade/plasteel/wired{
+	icon_state = "plasteel_3";
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/shiva/interior/bar)
+"uL" = (
+/obj/item/ammo_magazine/handful/shotgun/incendiary,
+/turf/open/floor/wood,
+/area/shiva/interior/bar)
+"ve" = (
+/turf/open/auto_turf/snow/layer4,
+/area/shiva/exterior/junkyard)
+"vZ" = (
+/obj/structure/machinery/light/double{
+	dir = 4;
+	pixel_y = -5
+	},
+/obj/effect/landmark/corpsespawner/security,
+/obj/item/weapon/gun/pistol/holdout,
+/turf/open/floor/shiva{
+	icon_state = "floor3"
+	},
+/area/shiva/interior/bar)
+"wf" = (
+/obj/structure/machinery/space_heater,
+/turf/open/floor/shiva,
+/area/shiva/interior/bar)
+"wk" = (
+/turf/open/floor/prison{
+	icon_state = "kitchen";
+	tag = "icon-kitchen"
+	},
+/area/shiva/interior/bar)
+"wQ" = (
+/turf/open/auto_turf/snow/layer3,
+/area/shiva/exterior/junkyard/cp_bar)
+"xc" = (
+/obj/structure/flora/tree/dead{
+	icon_state = "tree_4"
+	},
+/turf/open/auto_turf/snow/layer2,
+/area/shiva/exterior/junkyard/cp_bar)
+"xI" = (
+/obj/item/reagent_container/food/snacks/meat{
+	pixel_x = -1;
+	pixel_y = 2
+	},
+/obj/item/reagent_container/food/snacks/meat{
+	pixel_x = 1;
+	pixel_y = 4
+	},
+/obj/item/reagent_container/food/snacks/meat{
+	pixel_x = 8;
+	pixel_y = -11
+	},
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/prison,
+/area/shiva/interior/bar)
+"xQ" = (
+/obj/structure/machinery/door/airlock/almayer/generic{
+	name = "\improper Anti-Freeze Lounge"
+	},
+/turf/open/floor/plating,
+/area/shiva/interior/bar)
+"xS" = (
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1";
+	dir = 8
+	},
+/obj/effect/landmark/corpsespawner/PMC,
+/obj/item/weapon/gun/pistol/holdout,
+/turf/open/floor/plating/plating_catwalk/shiva,
+/area/shiva/interior/bar)
+"yf" = (
+/obj/structure/window_frame/colony/reinforced,
+/obj/item/stack/rods,
+/obj/item/shard,
+/turf/open/floor/plating,
+/area/shiva/interior/bar)
+"yh" = (
+/obj/item/stack/sheet/wood,
+/turf/open/floor/shiva{
+	icon_state = "floor3"
+	},
+/area/shiva/interior/bar)
+"yz" = (
+/obj/structure/machinery/door/airlock/almayer/generic{
+	dir = 1;
+	name = "\improper Anti-Freeze Lounge"
+	},
+/turf/open/floor/shiva{
+	icon_state = "floor3"
+	},
+/area/shiva/interior/bar)
+"yM" = (
+/obj/item/shard,
+/turf/open/floor/shiva,
+/area/shiva/interior/bar)
+"zi" = (
+/obj/effect/decal/cleanable/blood{
+	icon_state = "xtracks";
+	tag = "icon-xtracks"
+	},
+/obj/structure/barricade/plasteel/wired{
+	icon_state = "plasteel_3";
+	dir = 1
+	},
+/turf/open/floor/shiva,
+/area/shiva/interior/bar)
+"zE" = (
+/obj/item/tool/kitchen/rollingpin,
+/obj/structure/surface/table/reinforced/prison,
+/turf/open/floor/prison{
+	icon_state = "kitchen";
+	tag = "icon-kitchen"
+	},
+/area/shiva/interior/bar)
+"At" = (
+/obj/structure/flora/bush/snow{
+	icon_state = "snowgrassbb_1"
+	},
+/turf/open/auto_turf/snow/layer3,
+/area/shiva/exterior/junkyard/cp_bar)
+"Au" = (
+/obj/structure/machinery/chem_dispenser/soda{
+	pixel_y = 7
+	},
+/obj/structure/surface/table/reinforced/prison,
+/turf/open/floor/shiva,
+/area/shiva/interior/bar)
+"AR" = (
+/obj/structure/flora/tree/dead,
+/turf/open/auto_turf/snow/layer3,
+/area/shiva/exterior/junkyard)
+"AW" = (
+/obj/structure/fence{
+	layer = 2.9
+	},
+/turf/open/auto_turf/snow/layer0,
+/area/shiva/interior/bar)
+"Bl" = (
+/obj/structure/bed/chair/wood/normal{
+	dir = 4
+	},
+/obj/effect/landmark/corpsespawner/security/lawyer,
+/obj/item/weapon/gun/pistol/holdout,
+/turf/open/floor/wood,
+/area/shiva/interior/bar)
+"Bz" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/reagent_container/food/snacks/hotchili{
+	pixel_y = 4
+	},
+/obj/item/reagent_container/food/snacks/hotchili{
+	pixel_y = 14
+	},
+/turf/open/floor/prison{
+	icon_state = "kitchen"
+	},
+/area/shiva/interior/bar)
+"BA" = (
+/obj/item/lightstick/red/spoke/planted{
+	pixel_x = 11
+	},
+/turf/open/auto_turf/snow/layer3,
+/area/shiva/exterior/junkyard/cp_bar)
+"BQ" = (
+/obj/structure/barricade/snow,
+/obj/structure/barricade/snow,
+/turf/open/auto_turf/snow/layer2,
+/area/shiva/exterior/junkyard/cp_bar)
+"BV" = (
+/obj/item/weapon/melee/broken_bottle,
+/turf/open/floor/prison{
+	icon_state = "kitchen"
+	},
+/area/shiva/interior/bar)
+"Ci" = (
+/obj/structure/surface/table/woodentable,
+/obj/item/stack/sheet/wood/large_stack,
+/obj/item/stack/sheet/wood/large_stack,
+/obj/item/weapon/gun/smg/nailgun,
+/obj/item/ammo_box/magazine/smg/nailgun,
+/obj/item/weapon/gun/smg/nailgun,
+/turf/open/floor/wood,
+/area/shiva/interior/bar)
+"Cm" = (
+/obj/effect/decal/cleanable/blood/drip,
+/obj/structure/barricade/plasteel/wired{
+	icon_state = "plasteel_3"
+	},
+/turf/open/floor/shiva{
+	icon_state = "floor3"
+	},
+/area/shiva/interior/bar)
+"Cv" = (
+/obj/structure/window_frame/colony/reinforced,
+/obj/item/stack/rods,
+/obj/item/shard{
+	icon_state = "large"
+	},
+/turf/open/floor/plating,
+/area/shiva/interior/bar)
+"CF" = (
+/obj/structure/window_frame/colony/reinforced,
+/obj/item/stack/rods,
+/turf/open/floor/plating,
+/area/shiva/interior/bar)
+"CM" = (
+/obj/item/dogtag,
+/obj/effect/decal/cleanable/blood,
+/turf/open/auto_turf/snow/layer0,
+/area/shiva/interior/bar)
+"DJ" = (
+/obj/item/reagent_container/food/snacks/meat,
+/turf/open/floor/prison,
+/area/shiva/interior/bar)
+"DM" = (
+/turf/open/auto_turf/snow/layer2,
+/area/shiva/exterior/junkyard/cp_bar)
+"DY" = (
+/obj/item/tool/mop,
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1";
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/shiva/interior/bar)
+"Eb" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/effect/landmark/corpsespawner/engineer,
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1"
+	},
+/obj/item/weapon/gun/pistol/holdout,
+/turf/open/floor/wood,
+/area/shiva/interior/bar)
+"Em" = (
+/obj/structure/barricade/plasteel/wired{
+	icon_state = "plasteel_3";
+	dir = 1
+	},
+/turf/open/floor/shiva,
+/area/shiva/interior/bar)
+"Es" = (
+/obj/structure/surface/table/woodentable,
+/obj/item/clothing/suit/storage/snow_suit/survivor/parka/green{
+	pixel_x = -7;
+	pixel_y = -4
+	},
+/obj/item/clothing/suit/storage/snow_suit/survivor/parka/navy{
+	pixel_x = 8;
+	pixel_y = -4
+	},
+/obj/item/clothing/suit/storage/snow_suit/survivor/parka/purple{
+	pixel_x = -7;
+	pixel_y = 8
+	},
+/obj/item/clothing/suit/storage/snow_suit/survivor/parka/red{
+	pixel_y = 8;
+	pixel_x = 8
+	},
+/obj/item/clothing/suit/storage/snow_suit/survivor/parka/yellow,
+/turf/open/floor/wood,
+/area/shiva/interior/bar)
+"EB" = (
+/obj/structure/barricade/wooden{
+	dir = 4
+	},
+/obj/structure/machinery/light/double{
+	dir = 4;
+	pixel_y = -5
+	},
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1";
+	dir = 1
+	},
+/obj/item/stack/rods,
+/turf/open/floor/shiva{
+	dir = 8;
+	icon_state = "bluefull"
+	},
+/area/shiva/interior/bar)
+"ET" = (
+/obj/item/stack/cable_coil,
+/turf/open/floor/prison{
+	icon_state = "kitchen"
+	},
+/area/shiva/interior/bar)
+"Fd" = (
+/obj/structure/largecrate/random/mini/wooden,
+/obj/structure/largecrate/random/mini/wooden{
+	pixel_y = 8
+	},
+/turf/open/floor/plating/plating_catwalk/shiva,
+/area/shiva/interior/bar)
+"Fh" = (
+/obj/structure/surface/table/woodentable,
+/obj/item/paper_bin{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/item/storage/pill_bottle/russianRed{
+	pixel_x = 6;
+	pixel_y = 9
+	},
+/obj/item/reagent_container/food/drinks/drinkingglass{
+	pixel_x = 9
+	},
+/turf/open/floor/shiva{
+	icon_state = "floor3"
+	},
+/area/shiva/interior/bar)
+"Ft" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/reagent_container/food/snacks/sliceable/cheesecake,
+/obj/item/reagent_container/food/snacks/sliceable/cheesecake,
+/obj/item/reagent_container/food/snacks/cheesecakeslice{
+	pixel_y = 10
+	},
+/obj/item/reagent_container/food/snacks/cheesecakeslice{
+	pixel_y = 10
+	},
+/turf/open/floor/prison{
+	icon_state = "kitchen";
+	tag = "icon-kitchen"
+	},
+/area/shiva/interior/bar)
+"Fy" = (
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor/shiva,
+/area/shiva/interior/bar)
+"FH" = (
+/obj/structure/machinery/space_heater,
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1";
+	dir = 1
+	},
+/turf/open/floor/shiva,
+/area/shiva/interior/bar)
+"GT" = (
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1";
+	dir = 1
+	},
+/obj/item/shard,
+/turf/open/floor/shiva{
+	icon_state = "floor3"
+	},
+/area/shiva/interior/bar)
+"Hb" = (
+/obj/structure/surface/table/woodentable,
+/obj/item/stack/sheet/plasteel/large_stack,
+/obj/item/stack/sheet/plasteel/large_stack,
+/turf/open/floor/wood,
+/area/shiva/interior/bar)
+"Hf" = (
+/obj/structure/closet/secure_closet/freezer/meat,
+/obj/item/stack/sheet/metal/medium_stack,
+/turf/open/floor/prison{
+	icon_state = "kitchen"
+	},
+/area/shiva/interior/bar)
+"Hu" = (
+/obj/structure/barricade/snow{
+	dir = 1
+	},
+/turf/open/auto_turf/snow/layer4,
+/area/shiva/exterior/junkyard)
+"HA" = (
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/wood,
+/area/shiva/interior/bar)
+"HB" = (
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/prison{
+	icon_state = "kitchen"
+	},
+/area/shiva/interior/bar)
+"HE" = (
+/obj/item/reagent_container/food/drinks/cans/beer,
+/obj/effect/landmark/corpsespawner/security,
+/obj/item/weapon/gun/pistol/holdout,
+/turf/open/floor/prison{
+	icon_state = "kitchen"
+	},
+/area/shiva/interior/bar)
+"Iu" = (
+/turf/open/floor/shiva{
+	icon_state = "floor3"
+	},
+/area/shiva/interior/bar)
+"II" = (
+/obj/structure/barricade/snow{
+	dir = 8
+	},
+/turf/open/auto_turf/snow/layer4,
+/area/shiva/exterior/junkyard/cp_bar)
+"IR" = (
+/obj/structure/bed/chair/wood/normal{
+	dir = 4
+	},
+/obj/item/ammo_casing/bullet,
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor/wood,
+/area/shiva/interior/bar)
+"Ja" = (
+/obj/structure/barricade/snow,
+/turf/open/auto_turf/snow/layer0,
+/area/shiva/exterior/junkyard/cp_bar)
+"Jg" = (
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1";
+	dir = 1
+	},
+/obj/effect/landmark/corpsespawner/colonist,
+/obj/item/weapon/gun/pistol/holdout,
+/turf/open/floor/prison{
+	icon_state = "kitchen";
+	tag = "icon-kitchen"
+	},
+/area/shiva/interior/bar)
+"JC" = (
+/obj/item/trash/hotdog,
+/obj/effect/landmark/corpsespawner/chef,
+/obj/item/weapon/gun/pistol/holdout,
+/turf/open/floor/prison{
+	icon_state = "kitchen"
+	},
+/area/shiva/interior/bar)
+"JZ" = (
+/obj/structure/surface/table/woodentable,
+/obj/item/reagent_container/food/snacks/mre_pack,
+/obj/item/reagent_container/food/snacks/mre_pack,
+/obj/item/reagent_container/food/snacks/mre_pack,
+/obj/item/reagent_container/food/snacks/mre_pack,
+/turf/open/floor/shiva{
+	icon_state = "floor3"
+	},
+/area/shiva/interior/bar)
+"KC" = (
+/obj/structure/reagent_dispensers/beerkeg,
+/turf/open/floor/prison{
+	icon_state = "kitchen"
+	},
+/area/shiva/interior/bar)
+"KF" = (
+/obj/structure/surface/table/woodentable,
+/obj/item/storage/firstaid/fire{
+	pixel_x = -7
+	},
+/obj/item/storage/firstaid/o2{
+	pixel_x = 11
+	},
+/obj/item/storage/firstaid/fire{
+	pixel_x = -7
+	},
+/obj/item/storage/firstaid/o2{
+	pixel_x = 11
+	},
+/turf/open/floor/wood,
+/area/shiva/interior/bar)
+"Lc" = (
+/obj/effect/decal/cleanable/blood/drip,
+/obj/structure/barricade/plasteel/wired{
+	icon_state = "plasteel_3";
+	dir = 4
+	},
+/turf/open/floor/shiva,
+/area/shiva/interior/bar)
+"Lf" = (
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/shiva{
+	icon_state = "floor3"
+	},
+/area/shiva/interior/bar)
+"Lo" = (
+/obj/item/weapon/gun/shotgun/pump/cmb,
+/obj/item/ammo_magazine/handful/shotgun/buckshot{
+	pixel_x = 4;
+	pixel_y = -16
+	},
+/turf/open/floor/wood,
+/area/shiva/interior/bar)
+"LI" = (
+/obj/structure/machinery/reagentgrinder{
+	pixel_y = 12
+	},
+/obj/structure/surface/table/reinforced/prison,
+/turf/open/floor/prison{
+	icon_state = "kitchen"
+	},
+/area/shiva/interior/bar)
+"LK" = (
+/obj/item/trash/tray,
+/obj/item/trash/tray{
+	pixel_x = -2;
+	pixel_y = 5
+	},
+/turf/open/auto_turf/snow/layer0,
+/area/shiva/interior/bar)
+"LO" = (
+/obj/structure/machinery/light/double{
+	dir = 4;
+	pixel_y = -5
+	},
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1"
+	},
+/turf/open/floor/shiva{
+	dir = 8;
+	icon_state = "bluefull"
+	},
+/area/shiva/interior/bar)
+"LS" = (
+/obj/structure/closet/bodybag,
+/turf/open/floor/plating/plating_catwalk/shiva,
+/area/shiva/interior/bar)
+"LT" = (
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1"
+	},
+/turf/open/floor/shiva,
+/area/shiva/interior/bar)
+"LX" = (
+/obj/structure/barricade/metal/wired{
+	dir = 1;
+	icon_state = "metal_2"
+	},
+/obj/item/shard,
+/obj/effect/landmark/corpsespawner/security,
+/obj/item/weapon/gun/pistol/holdout,
+/turf/open/floor/shiva,
+/area/shiva/interior/bar)
+"Mj" = (
+/obj/structure/surface/rack,
+/obj/item/clothing/mask/rebreather{
+	pixel_x = 4;
+	pixel_y = 3
+	},
+/obj/item/clothing/mask/rebreather{
+	pixel_x = -4;
+	pixel_y = -3
+	},
+/turf/open/auto_turf/snow/layer0,
+/area/shiva/interior/bar)
+"MP" = (
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/shiva,
+/area/shiva/interior/bar)
+"MZ" = (
+/obj/structure/fence,
+/turf/open/auto_turf/snow/layer0,
+/area/shiva/interior/bar)
+"No" = (
+/obj/structure/kitchenspike,
+/turf/open/floor/prison{
+	icon_state = "kitchen"
+	},
+/area/shiva/interior/bar)
+"Nr" = (
+/obj/structure/machinery/chem_dispenser/beer{
+	pixel_y = 8
+	},
+/obj/structure/surface/table/reinforced/prison,
+/turf/open/floor/shiva,
+/area/shiva/interior/bar)
+"NN" = (
+/obj/structure/barricade/metal/wired{
+	dir = 1;
+	icon_state = "metal_2"
+	},
+/obj/item/shard,
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor/prison{
+	icon_state = "kitchen";
+	tag = "icon-kitchen"
+	},
+/area/shiva/interior/bar)
+"NO" = (
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/auto_turf/snow/layer0,
+/area/shiva/interior/bar)
+"NT" = (
+/obj/structure/barricade/snow,
+/turf/open/auto_turf/snow/layer3,
+/area/shiva/exterior/junkyard/cp_bar)
+"Oc" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -11;
+	pixel_y = 5
+	},
+/turf/open/floor/prison,
+/area/shiva/interior/bar)
+"Ot" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/prison,
+/area/shiva/interior/bar)
+"OE" = (
+/obj/item/lightstick/red/spoke,
+/turf/open/floor/shiva{
+	icon_state = "floor3"
+	},
+/area/shiva/interior/bar)
+"Pk" = (
+/obj/item/stool,
+/turf/open/floor/shiva,
+/area/shiva/interior/bar)
+"PI" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/auto_turf/snow/layer0,
+/area/shiva/interior/bar)
+"PK" = (
+/obj/structure/flora/bush/ausbushes/lavendergrass,
+/obj/structure/barricade/snow{
+	dir = 1
+	},
+/turf/open/auto_turf/snow/layer3,
+/area/shiva/exterior/junkyard)
+"Qq" = (
+/obj/item/lightstick/red/spoke,
+/turf/open/floor/shiva,
+/area/shiva/interior/bar)
+"Qr" = (
+/obj/effect/landmark/corpsespawner/colonist,
+/obj/item/weapon/gun/pistol/holdout,
+/turf/open/floor/wood,
+/area/shiva/interior/bar)
+"QA" = (
+/turf/open/floor/prison{
+	icon_state = "kitchen"
+	},
+/area/shiva/interior/bar)
+"QT" = (
+/obj/structure/machinery/colony_floodlight,
+/turf/open/auto_turf/snow/layer2,
+/area/shiva/exterior/junkyard/cp_bar)
+"QW" = (
+/obj/structure/flora/bush/ausbushes/lavendergrass,
+/turf/open/auto_turf/snow/layer1,
+/area/shiva/exterior/junkyard/cp_bar)
+"Rn" = (
+/obj/structure/flora/bush/ausbushes/lavendergrass,
+/obj/structure/barricade/snow,
+/turf/open/auto_turf/snow/layer2,
+/area/shiva/exterior/junkyard/cp_bar)
+"Rt" = (
+/obj/structure/machinery/smartfridge{
+	density = 0;
+	pixel_y = 22
+	},
+/obj/structure/surface/table/woodentable,
+/obj/item/reagent_container/food/snacks/mre_pack,
+/obj/item/reagent_container/food/snacks/mre_pack,
+/obj/item/reagent_container/food/snacks/mre_pack,
+/obj/item/reagent_container/food/snacks/mre_pack,
+/turf/open/floor/shiva{
+	icon_state = "floor3"
+	},
+/area/shiva/interior/bar)
+"Si" = (
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor/prison{
+	icon_state = "kitchen"
+	},
+/area/shiva/interior/bar)
+"Sy" = (
+/obj/structure/bed/chair/wood/normal,
+/obj/effect/decal/cleanable/blood{
+	icon_state = "xtracks";
+	tag = "icon-xtracks"
+	},
+/turf/open/floor/wood,
+/area/shiva/interior/bar)
+"Tm" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/structure/machinery/processor{
+	desc = "It CAN blend it.";
+	icon_state = "blender_e";
+	name = "Blendomatic";
+	pixel_x = -2;
+	pixel_y = 10
+	},
+/turf/open/floor/prison{
+	icon_state = "kitchen"
+	},
+/area/shiva/interior/bar)
+"TD" = (
+/obj/structure/barricade/snow,
+/turf/open/auto_turf/snow/layer2,
+/area/shiva/exterior/junkyard/cp_bar)
+"TJ" = (
+/obj/structure/coatrack,
+/turf/open/floor/shiva,
+/area/shiva/interior/bar)
+"TV" = (
+/obj/structure/surface/table/woodentable,
+/obj/item/reagent_container/food/drinks/bottle/sake{
+	pixel_x = -3;
+	pixel_y = 6
+	},
+/obj/structure/machinery/light/double,
+/turf/open/floor/shiva{
+	icon_state = "floor3"
+	},
+/area/shiva/interior/bar)
+"Vg" = (
+/obj/structure/surface/table/woodentable,
+/obj/item/stack/sheet/metal/large_stack,
+/obj/item/stack/sheet/metal/large_stack,
+/turf/open/floor/wood,
+/area/shiva/interior/bar)
+"Vp" = (
+/obj/effect/decal/cleanable/blood{
+	icon_state = "xtracks";
+	tag = "icon-xtracks"
+	},
+/turf/open/floor/wood,
+/area/shiva/interior/bar)
+"VT" = (
+/obj/structure/reagent_dispensers/beerkeg{
+	density = 0;
+	pixel_x = -12;
+	pixel_y = 10
+	},
+/obj/item/reagent_container/food/drinks/cans/beer,
+/turf/open/auto_turf/snow/layer0,
+/area/shiva/interior/bar)
+"WG" = (
+/turf/open/floor/plating/plating_catwalk/shiva,
+/area/shiva/interior/bar)
+"WW" = (
+/obj/structure/surface/table/woodentable,
+/obj/item/reagent_container/food/drinks/shaker{
+	pixel_x = -8;
+	pixel_y = 3
+	},
+/obj/item/reagent_container/food/drinks/drinkingglass{
+	pixel_x = 6;
+	pixel_y = 3
+	},
+/turf/open/floor/shiva{
+	icon_state = "floor3"
+	},
+/area/shiva/interior/bar)
+"WZ" = (
+/turf/closed/wall/shiva/prefabricated/reinforced,
+/area/shiva/interior/bar)
+"Xo" = (
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/prison{
+	icon_state = "kitchen";
+	tag = "icon-kitchen"
+	},
+/area/shiva/interior/bar)
+"XD" = (
+/turf/open/auto_turf/snow/layer2,
+/area/shiva/exterior/junkyard)
+"XY" = (
+/turf/open/auto_turf/snow/layer0,
+/area/shiva/exterior/junkyard/cp_bar)
+"Ym" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/auto_turf/snow/layer0,
+/area/shiva/interior/bar)
+"YN" = (
+/obj/structure/bed/chair/wood/normal{
+	dir = 8
+	},
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1";
+	dir = 8
+	},
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor/wood,
+/area/shiva/interior/bar)
+"YO" = (
+/obj/structure/surface/table/woodentable,
+/obj/item/reagent_container/food/condiment/saltshaker,
+/obj/item/reagent_container/food/condiment/peppermill{
+	pixel_x = -9;
+	pixel_y = 5
+	},
+/obj/item/reagent_container/food/drinks/bottle/sake{
+	pixel_x = 5;
+	pixel_y = 10
+	},
+/turf/open/floor/shiva{
+	icon_state = "floor3"
+	},
+/area/shiva/interior/bar)
+"YZ" = (
+/obj/structure/machinery/light/double{
+	dir = 1;
+	pixel_y = 9
+	},
+/turf/open/floor/shiva,
+/area/shiva/interior/bar)
+"Zw" = (
+/obj/structure/machinery/space_heater,
+/obj/structure/barricade/metal/wired{
+	dir = 4;
+	icon_state = "metal_1"
+	},
+/turf/open/floor/shiva,
+/area/shiva/interior/bar)
+"ZG" = (
+/obj/structure/window_frame/colony/reinforced,
+/obj/item/shard,
+/turf/open/floor/plating,
+/area/shiva/interior/bar)
+"ZX" = (
+/obj/structure/barricade/metal/wired{
+	dir = 1;
+	icon_state = "metal_2"
+	},
+/turf/open/floor/prison{
+	icon_state = "kitchen";
+	tag = "icon-kitchen"
+	},
+/area/shiva/interior/bar)
+
+(1,1,1) = {"
+ni
+WZ
+WZ
+ls
+ls
+ls
+ls
+ls
+ls
+ls
+ls
+ls
+oF
+oF
+ls
+ls
+"}
+(2,1,1) = {"
+DM
+WZ
+WZ
+ls
+ls
+ls
+ls
+ls
+ls
+ls
+ls
+gU
+lf
+lf
+LK
+MZ
+"}
+(3,1,1) = {"
+DM
+WZ
+hY
+ef
+zE
+WZ
+WZ
+iy
+Hf
+WZ
+WZ
+VT
+CM
+lf
+lf
+lf
+"}
+(4,1,1) = {"
+TD
+CF
+fz
+wk
+md
+Bz
+mC
+QA
+Si
+qd
+CF
+cA
+PI
+lf
+lf
+MZ
+"}
+(5,1,1) = {"
+BQ
+Cv
+Jg
+wk
+Ft
+JC
+QA
+HE
+QA
+Tm
+ls
+fL
+NO
+lf
+Ym
+AW
+"}
+(6,1,1) = {"
+TD
+Cv
+NN
+wk
+jC
+ET
+QA
+QA
+QA
+aP
+ls
+MZ
+lf
+MZ
+MZ
+ls
+"}
+(7,1,1) = {"
+Rn
+Cv
+ZX
+Xo
+wk
+QA
+BV
+QA
+QA
+LI
+ls
+mT
+NO
+lf
+lf
+fs
+"}
+(8,1,1) = {"
+xc
+yf
+GT
+tR
+tR
+Fy
+Qq
+kk
+hr
+Cm
+nv
+lf
+NO
+lf
+lf
+lf
+"}
+(9,1,1) = {"
+dz
+ls
+Iu
+Iu
+Iu
+Iu
+vZ
+OE
+Lf
+uD
+ls
+Mj
+lf
+NO
+lf
+lf
+"}
+(10,1,1) = {"
+QW
+ls
+ls
+Rt
+JZ
+mN
+ls
+ls
+Lc
+ls
+ls
+ls
+ls
+jY
+ls
+ls
+"}
+(11,1,1) = {"
+XY
+ls
+Fd
+rZ
+xS
+tU
+yf
+Nr
+tR
+WG
+ls
+LS
+Oc
+QA
+KC
+ls
+"}
+(12,1,1) = {"
+XY
+yz
+Em
+if
+uL
+Eb
+yf
+Au
+tR
+WG
+ls
+LS
+Ot
+HB
+fV
+ls
+"}
+(13,1,1) = {"
+XY
+yz
+Em
+jM
+Lo
+bi
+WW
+Pk
+MP
+WG
+ls
+mf
+DJ
+ey
+ei
+ls
+"}
+(14,1,1) = {"
+ni
+yz
+zi
+jM
+jM
+bi
+YO
+Fh
+yh
+TV
+ls
+LS
+xI
+QA
+No
+ls
+"}
+(15,1,1) = {"
+ls
+ls
+YZ
+Vp
+Sy
+jM
+YN
+cs
+uI
+DY
+ls
+LS
+cH
+oh
+No
+ls
+"}
+(16,1,1) = {"
+ZG
+FH
+jM
+IR
+jM
+jM
+jM
+eV
+if
+qu
+ls
+ls
+ls
+ls
+ls
+ls
+"}
+(17,1,1) = {"
+CF
+LX
+Vg
+Ci
+Hb
+jM
+hR
+nU
+KF
+rB
+jM
+wf
+ls
+ve
+jG
+ls
+"}
+(18,1,1) = {"
+yf
+ll
+HA
+rB
+Qr
+jM
+rB
+jM
+jM
+jM
+jM
+hk
+CF
+PK
+ve
+jG
+"}
+(19,1,1) = {"
+ls
+ls
+YZ
+jM
+jM
+eV
+eV
+jM
+Bl
+jM
+HA
+hk
+yf
+PK
+XD
+ve
+"}
+(20,1,1) = {"
+Ja
+yf
+FH
+rx
+lc
+Es
+tD
+jM
+qi
+lQ
+tV
+LT
+CF
+jE
+XD
+lp
+"}
+(21,1,1) = {"
+Ja
+CF
+kB
+ta
+rB
+jM
+jM
+jM
+jM
+ud
+jM
+sU
+yf
+Hu
+XD
+rq
+"}
+(22,1,1) = {"
+XY
+ls
+dt
+Zw
+om
+ap
+nK
+ak
+tR
+Iu
+tR
+TJ
+ls
+ve
+rq
+AR
+"}
+(23,1,1) = {"
+XY
+ls
+ls
+yf
+CF
+yf
+ls
+ls
+yM
+yh
+tR
+ls
+ls
+ls
+ve
+rq
+"}
+(24,1,1) = {"
+ni
+ni
+wQ
+II
+tt
+tt
+NT
+yf
+EB
+mV
+LO
+yf
+Hu
+rq
+rq
+XD
+"}
+(25,1,1) = {"
+XY
+QT
+ni
+lK
+wQ
+At
+BA
+WZ
+ls
+xQ
+ls
+WZ
+gq
+rq
+ve
+rq
+"}

--- a/maps/map_files/Ice_Colony_v3/sprinkles/40.shivabarls.dmm
+++ b/maps/map_files/Ice_Colony_v3/sprinkles/40.shivabarls.dmm
@@ -816,7 +816,7 @@
 /obj/structure/fence{
 	layer = 2.9
 	},
-/turf/open/auto_turf/snow/layer0,
+/turf/closed/wall/shiva/prefabricated/reinforced,
 /area/shiva/interior/bar)
 "Bl" = (
 /obj/structure/bed/chair/wood/normal{
@@ -844,6 +844,10 @@
 	},
 /turf/open/auto_turf/snow/layer3,
 /area/shiva/exterior/junkyard/cp_bar)
+"BM" = (
+/obj/structure/fence,
+/turf/closed/wall/shiva/prefabricated/reinforced,
+/area/shiva/interior/bar)
 "BQ" = (
 /obj/structure/barricade/snow,
 /obj/structure/barricade/snow,
@@ -1444,7 +1448,7 @@
 /area/shiva/exterior/junkyard/cp_bar)
 "Ym" = (
 /obj/structure/reagent_dispensers/watertank,
-/turf/open/auto_turf/snow/layer0,
+/turf/closed/wall/shiva/prefabricated/reinforced,
 /area/shiva/interior/bar)
 "YN" = (
 /obj/structure/bed/chair/wood/normal{
@@ -1525,14 +1529,14 @@ ls
 DM
 WZ
 WZ
-ls
-ls
-ls
-ls
-ls
-ls
-ls
-ls
+WZ
+WZ
+WZ
+WZ
+WZ
+WZ
+WZ
+WZ
 gU
 lf
 lf
@@ -1586,7 +1590,7 @@ QA
 HE
 QA
 Tm
-ls
+WZ
 fL
 NO
 lf
@@ -1604,12 +1608,12 @@ QA
 QA
 QA
 aP
-ls
+WZ
 MZ
 lf
 MZ
-MZ
-ls
+BM
+WZ
 "}
 (7,1,1) = {"
 Rn
@@ -1622,7 +1626,7 @@ BV
 QA
 QA
 LI
-ls
+WZ
 mT
 NO
 lf
@@ -1649,7 +1653,7 @@ lf
 "}
 (9,1,1) = {"
 dz
-ls
+WZ
 Iu
 Iu
 Iu
@@ -1658,7 +1662,7 @@ vZ
 OE
 Lf
 uD
-ls
+WZ
 Mj
 lf
 NO
@@ -1667,7 +1671,7 @@ lf
 "}
 (10,1,1) = {"
 QW
-ls
+WZ
 ls
 Rt
 JZ
@@ -1675,17 +1679,17 @@ mN
 ls
 ls
 Lc
-ls
-ls
-ls
-ls
+WZ
+WZ
+WZ
+WZ
 jY
-ls
-ls
+WZ
+WZ
 "}
 (11,1,1) = {"
 XY
-ls
+WZ
 Fd
 rZ
 xS
@@ -1694,12 +1698,12 @@ yf
 Nr
 tR
 WG
-ls
+WZ
 LS
 Oc
 QA
 KC
-ls
+WZ
 "}
 (12,1,1) = {"
 XY
@@ -1712,12 +1716,12 @@ yf
 Au
 tR
 WG
-ls
+WZ
 LS
 Ot
 HB
 fV
-ls
+WZ
 "}
 (13,1,1) = {"
 XY
@@ -1730,12 +1734,12 @@ WW
 Pk
 MP
 WG
-ls
+WZ
 mf
 DJ
 ey
 ei
-ls
+WZ
 "}
 (14,1,1) = {"
 ni
@@ -1748,16 +1752,16 @@ YO
 Fh
 yh
 TV
-ls
+WZ
 LS
 xI
 QA
 No
-ls
+WZ
 "}
 (15,1,1) = {"
-ls
-ls
+WZ
+WZ
 YZ
 Vp
 Sy
@@ -1766,12 +1770,12 @@ YN
 cs
 uI
 DY
-ls
+WZ
 LS
 cH
 oh
 No
-ls
+WZ
 "}
 (16,1,1) = {"
 ZG
@@ -1784,12 +1788,12 @@ jM
 eV
 if
 qu
-ls
-ls
-ls
-ls
-ls
-ls
+WZ
+WZ
+WZ
+WZ
+WZ
+WZ
 "}
 (17,1,1) = {"
 CF
@@ -1804,10 +1808,10 @@ KF
 rB
 jM
 wf
-ls
+WZ
 ve
 jG
-ls
+WZ
 "}
 (18,1,1) = {"
 yf
@@ -1828,8 +1832,8 @@ ve
 jG
 "}
 (19,1,1) = {"
-ls
-ls
+WZ
+WZ
 YZ
 jM
 jM
@@ -1883,7 +1887,7 @@ rq
 "}
 (22,1,1) = {"
 XY
-ls
+WZ
 dt
 Zw
 om
@@ -1894,26 +1898,26 @@ tR
 Iu
 tR
 TJ
-ls
+WZ
 ve
 rq
 AR
 "}
 (23,1,1) = {"
 XY
-ls
-ls
+WZ
+WZ
 yf
 CF
 yf
-ls
-ls
+WZ
+WZ
 yM
 yh
 tR
-ls
-ls
-ls
+WZ
+WZ
+WZ
 ve
 rq
 "}
@@ -1944,9 +1948,9 @@ wQ
 At
 BA
 WZ
-ls
+WZ
 xQ
-ls
+WZ
 WZ
 gq
 rq

--- a/maps/map_files/Kutjevo/Kutjevo.dmm
+++ b/maps/map_files/Kutjevo/Kutjevo.dmm
@@ -8838,6 +8838,12 @@
 /obj/structure/largecrate/random/case/double,
 /turf/open/floor/kutjevo/colors/orange,
 /area/kutjevo/exterior/Northwest_Colony)
+"mfs" = (
+/obj/effect/landmark/nightmare{
+	insert_tag = kutjevoclf01
+	},
+/turf/open/auto_turf/sand/layer1,
+/area/kutjevo/exterior/complex_border/med_rec)
 "mfD" = (
 /obj/structure/prop/dam/truck/mining,
 /turf/open/auto_turf/sand/layer1,
@@ -37594,7 +37600,7 @@ sYo
 sYo
 smo
 msK
-msK
+mfs
 msK
 msK
 msK

--- a/maps/map_files/Kutjevo/Kutjevo.dmm
+++ b/maps/map_files/Kutjevo/Kutjevo.dmm
@@ -8841,10 +8841,14 @@
 "mfs" = (
 /obj/effect/landmark/nightmare{
 <<<<<<< master
+<<<<<<< master
 	insert_tag = "kutjevoclf01"
 =======
 	insert_tag = kutjevoclf01
 >>>>>>> added nightmare insert tags to main maps
+=======
+	insert_tag = "kutjevoclf01"
+>>>>>>> fixed issue with invalid landmark
 	},
 /turf/open/auto_turf/sand/layer1,
 /area/kutjevo/exterior/complex_border/med_rec)

--- a/maps/map_files/Kutjevo/Kutjevo.dmm
+++ b/maps/map_files/Kutjevo/Kutjevo.dmm
@@ -8840,7 +8840,7 @@
 /area/kutjevo/exterior/Northwest_Colony)
 "mfs" = (
 /obj/effect/landmark/nightmare{
-	insert_tag = kutjevoclf01
+	insert_tag = "kutjevoclf01"
 	},
 /turf/open/auto_turf/sand/layer1,
 /area/kutjevo/exterior/complex_border/med_rec)

--- a/maps/map_files/Kutjevo/Kutjevo.dmm
+++ b/maps/map_files/Kutjevo/Kutjevo.dmm
@@ -8840,7 +8840,11 @@
 /area/kutjevo/exterior/Northwest_Colony)
 "mfs" = (
 /obj/effect/landmark/nightmare{
+<<<<<<< master
 	insert_tag = "kutjevoclf01"
+=======
+	insert_tag = kutjevoclf01
+>>>>>>> added nightmare insert tags to main maps
 	},
 /turf/open/auto_turf/sand/layer1,
 /area/kutjevo/exterior/complex_border/med_rec)

--- a/maps/map_files/Kutjevo/sprinkles/25.kutjevoclf01.dmm
+++ b/maps/map_files/Kutjevo/sprinkles/25.kutjevoclf01.dmm
@@ -1,7 +1,10 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "ac" = (
 /obj/effect/decal/cleanable/blood,
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
 "ad" = (
@@ -16,6 +19,7 @@
 	dir = 4
 	},
 /area/kutjevo/interior/construction)
+<<<<<<< master
 "as" = (
 /obj/item/explosive/mine/clf/active{
 	dir = 8
@@ -24,11 +28,16 @@
 	dir = 4
 	},
 /area/kutjevo/interior/construction)
+=======
+>>>>>>> reimported backup
 "aG" = (
 /obj/effect/landmark/corpsespawner/colonist,
 /obj/item/weapon/gun/pistol/holdout,
 /obj/effect/decal/cleanable/blood,
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/kutjevo/colors/purple/edge{
 	dir = 1
 	},
@@ -142,11 +151,14 @@
 /obj/item/storage/backpack/general_belt{
 	pixel_y = 7
 	},
+<<<<<<< master
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/kutjevo/colors/purple,
 /area/kutjevo/interior/construction)
 "dO" = (
@@ -198,6 +210,7 @@
 "fi" = (
 /turf/closed/wall/kutjevo/colony/reinforced,
 /area/kutjevo/interior/construction)
+<<<<<<< master
 "gw" = (
 /obj/item/stool{
 	pixel_y = 8
@@ -205,6 +218,8 @@
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
+=======
+>>>>>>> reimported backup
 "gy" = (
 /obj/structure/surface/table/gamblingtable,
 /obj/item/weapon/gun/rifle/mar40/lmg,
@@ -271,8 +286,11 @@
 "it" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/effect/decal/cleanable/ash,
+<<<<<<< master
 /obj/item/explosive/mine/clf/active,
 /obj/effect/landmark/survivor_spawner/clf/generic,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/plating/kutjevo,
 /area/kutjevo/interior/construction)
 "iM" = (
@@ -338,6 +356,7 @@
 /obj/item/paper_bin,
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
+<<<<<<< master
 "lY" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/effect/decal/cleanable/ash,
@@ -348,6 +367,8 @@
 	},
 /turf/open/floor/plating/kutjevo,
 /area/kutjevo/interior/construction)
+=======
+>>>>>>> reimported backup
 "md" = (
 /obj/structure/platform_decoration/kutjevo{
 	dir = 8
@@ -389,6 +410,7 @@
 /obj/structure/window_frame/kutjevo/reinforced,
 /turf/open/floor/kutjevo/multi_tiles,
 /area/kutjevo/interior/foremans_office)
+<<<<<<< master
 "ns" = (
 /obj/item/explosive/mine/clf/active,
 /obj/effect/landmark/survivor_spawner/clf/generic,
@@ -404,6 +426,8 @@
 /obj/item/explosive/mine/clf/active,
 /turf/open/floor/plating/kutjevo,
 /area/kutjevo/interior/construction)
+=======
+>>>>>>> reimported backup
 "or" = (
 /obj/effect/landmark/corpsespawner/colonist,
 /obj/effect/decal/cleanable/blood,
@@ -414,11 +438,14 @@
 "oB" = (
 /turf/closed/wall/kutjevo/colony/reinforced,
 /area/kutjevo/interior/foremans_office)
+<<<<<<< master
 "oO" = (
 /obj/item/ammo_magazine/smg/nailgun,
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/kutjevo/grey/plate,
 /area/kutjevo/interior/construction)
+=======
+>>>>>>> reimported backup
 "pe" = (
 /obj/structure/machinery/colony_floodlight{
 	pixel_y = 10
@@ -533,7 +560,10 @@
 	dir = 8;
 	tag = "icon-chair (WEST)"
 	},
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
 "vo" = (
@@ -544,7 +574,10 @@
 /obj/effect/decal/cleanable/blood,
 /obj/item/weapon/gun/pistol/holdout,
 /obj/effect/landmark/corpsespawner/chef,
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/kutjevo/grey/plate,
 /area/kutjevo/interior/construction)
 "wv" = (
@@ -758,6 +791,7 @@
 	dir = 1
 	},
 /area/kutjevo/interior/construction)
+<<<<<<< master
 "FB" = (
 /obj/structure/platform/kutjevo{
 	dir = 4
@@ -779,6 +813,12 @@
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/kutjevo/grey/plate,
 /area/kutjevo/interior/construction)
+=======
+"FP" = (
+/obj/effect/landmark/corpsespawner/colonist,
+/turf/open/auto_turf/sand/layer0,
+/area/kutjevo/exterior/complex_border/med_rec)
+>>>>>>> reimported backup
 "Gt" = (
 /obj/structure/platform/kutjevo{
 	dir = 1
@@ -819,10 +859,13 @@
 	},
 /turf/open/auto_turf/sand/layer0,
 /area/kutjevo/exterior/complex_border/med_rec)
+<<<<<<< master
 "ID" = (
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/kutjevo/colors/purple,
 /area/kutjevo/interior/construction)
+=======
+>>>>>>> reimported backup
 "IR" = (
 /obj/structure/barricade/metal/wired{
 	icon_state = "metal_2"
@@ -917,10 +960,13 @@
 	dir = 1
 	},
 /area/kutjevo/interior/construction)
+<<<<<<< master
 "Op" = (
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
+=======
+>>>>>>> reimported backup
 "Oq" = (
 /obj/effect/landmark/corpsespawner/doctor,
 /obj/effect/decal/cleanable/blood,
@@ -995,7 +1041,10 @@
 /obj/structure/bed/chair{
 	dir = 4
 	},
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
 "Si" = (
@@ -1015,6 +1064,7 @@
 /obj/item/tank/emergency_oxygen/engi,
 /turf/open/floor/kutjevo/grey/plate,
 /area/kutjevo/interior/foremans_office)
+<<<<<<< master
 "Sn" = (
 /obj/structure/platform/kutjevo{
 	dir = 1
@@ -1022,13 +1072,18 @@
 /obj/item/explosive/mine/clf/active,
 /turf/open/auto_turf/sand/layer0,
 /area/kutjevo/exterior/complex_border/med_rec)
+=======
+>>>>>>> reimported backup
 "SI" = (
 /turf/closed/wall/kutjevo/colony/reinforced,
 /area/kutjevo/exterior/complex_border/med_rec)
 "Tb" = (
 /obj/item/stack/rods,
 /obj/effect/spawner/random/attachment,
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/kutjevo/colors/purple,
 /area/kutjevo/interior/construction)
 "Tv" = (
@@ -1042,6 +1097,15 @@
 	dir = 8
 	},
 /area/kutjevo/interior/construction)
+<<<<<<< master
+=======
+"TK" = (
+/obj/item/stool{
+	pixel_y = 8
+	},
+/turf/open/floor/kutjevo/tan,
+/area/kutjevo/interior/construction)
+>>>>>>> reimported backup
 "Ua" = (
 /obj/structure/barricade/plasteel/wired{
 	dir = 8;
@@ -1068,6 +1132,7 @@
 /obj/structure/sign/poster/clf,
 /turf/closed/wall/kutjevo/colony/reinforced,
 /area/kutjevo/interior/foremans_office)
+<<<<<<< master
 "UD" = (
 /obj/structure/barricade/metal/wired{
 	icon_state = "metal_2"
@@ -1075,14 +1140,19 @@
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/kutjevo/colors/purple/edge,
 /area/kutjevo/interior/construction)
+=======
+>>>>>>> reimported backup
 "UP" = (
 /obj/structure/platform_decoration/kutjevo,
 /turf/open/floor/plating/kutjevo,
 /area/kutjevo/interior/foremans_office)
+<<<<<<< master
 "UU" = (
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/auto_turf/sand/layer0,
 /area/kutjevo/exterior/complex_border/med_rec)
+=======
+>>>>>>> reimported backup
 "Ve" = (
 /obj/structure/machinery/door/airlock/almayer/maint/autoname{
 	dir = 1;
@@ -1160,6 +1230,7 @@
 "Yg" = (
 /turf/open/auto_turf/sand/layer2,
 /area/kutjevo/interior/construction)
+<<<<<<< master
 "Yz" = (
 /obj/structure/platform_decoration/kutjevo{
 	dir = 8
@@ -1167,6 +1238,8 @@
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/auto_turf/sand/layer1,
 /area/kutjevo/exterior/complex_border/med_rec)
+=======
+>>>>>>> reimported backup
 "YJ" = (
 /obj/effect/landmark/corpsespawner/security/cmb,
 /obj/effect/decal/cleanable/blood,
@@ -1273,7 +1346,11 @@ Ro
 (2,1,1) = {"
 uv
 rG
+<<<<<<< master
 oO
+=======
+ZT
+>>>>>>> reimported backup
 QR
 fi
 Vg
@@ -1296,12 +1373,21 @@ Hu
 ZT
 fi
 QN
+<<<<<<< master
 gw
 gw
 gw
 Cx
 hv
 ns
+=======
+TK
+TK
+TK
+Cx
+hv
+Fv
+>>>>>>> reimported backup
 hp
 tN
 IB
@@ -1338,11 +1424,19 @@ ZI
 qn
 cz
 Ed
+<<<<<<< master
 oo
 Fv
 sx
 nn
 Yz
+=======
+ln
+Fv
+sx
+nn
+fb
+>>>>>>> reimported backup
 Ro
 Ro
 "}
@@ -1350,17 +1444,30 @@ Ro
 fi
 xK
 sx
+<<<<<<< master
 ID
 ck
 uj
 gw
 gw
 gw
+=======
+sx
+ck
+uj
+TK
+TK
+TK
+>>>>>>> reimported backup
 Cx
 hv
 aG
 hp
+<<<<<<< master
 UD
+=======
+tN
+>>>>>>> reimported backup
 IB
 Ro
 Ro
@@ -1378,7 +1485,11 @@ HE
 JV
 hv
 KQ
+<<<<<<< master
 as
+=======
+HE
+>>>>>>> reimported backup
 IR
 IB
 Ro
@@ -1387,7 +1498,11 @@ Ft
 (8,1,1) = {"
 fi
 fi
+<<<<<<< master
 lY
+=======
+ln
+>>>>>>> reimported backup
 fi
 fi
 fi
@@ -1407,7 +1522,11 @@ Ft
 fi
 Vu
 xQ
+<<<<<<< master
 FX
+=======
+QK
+>>>>>>> reimported backup
 Rb
 xk
 YJ
@@ -1418,7 +1537,11 @@ jr
 ih
 ad
 hv
+<<<<<<< master
 Sn
+=======
+IB
+>>>>>>> reimported backup
 ri
 Ro
 "}
@@ -1427,19 +1550,31 @@ fi
 ET
 wb
 QK
+<<<<<<< master
 ID
+=======
+sx
+>>>>>>> reimported backup
 Fv
 uc
 RP
 uc
 uc
+<<<<<<< master
 Op
+=======
+uc
+>>>>>>> reimported backup
 uc
 Cx
 hv
 Qk
 Me
+<<<<<<< master
 UU
+=======
+Ft
+>>>>>>> reimported backup
 "}
 (11,1,1) = {"
 fi
@@ -1448,7 +1583,11 @@ sT
 Vl
 jM
 Fv
+<<<<<<< master
 Op
+=======
+uc
+>>>>>>> reimported backup
 ji
 dL
 KH
@@ -1471,7 +1610,11 @@ uc
 uc
 uc
 Oq
+<<<<<<< master
 Op
+=======
+uc
+>>>>>>> reimported backup
 Jt
 Ed
 it
@@ -1486,7 +1629,11 @@ QK
 DE
 cR
 uj
+<<<<<<< master
 Op
+=======
+uc
+>>>>>>> reimported backup
 Jt
 ac
 uc
@@ -1494,7 +1641,11 @@ uc
 DU
 Ed
 ln
+<<<<<<< master
 FB
+=======
+cy
+>>>>>>> reimported backup
 wv
 FP
 "}
@@ -1506,7 +1657,11 @@ QK
 fi
 RJ
 Cp
+<<<<<<< master
 Op
+=======
+uc
+>>>>>>> reimported backup
 kX
 YX
 Si
@@ -1529,7 +1684,11 @@ Hd
 uc
 uM
 uM
+<<<<<<< master
 Op
+=======
+uc
+>>>>>>> reimported backup
 io
 hv
 zt

--- a/maps/map_files/Kutjevo/sprinkles/25.kutjevoclf01.dmm
+++ b/maps/map_files/Kutjevo/sprinkles/25.kutjevoclf01.dmm
@@ -1,6 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "ac" = (
 /obj/effect/decal/cleanable/blood,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
 "ad" = (
@@ -19,7 +20,6 @@
 /obj/item/explosive/mine/clf/active{
 	dir = 8
 	},
-/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/kutjevo/colors/purple/edge{
 	dir = 4
 	},
@@ -28,6 +28,7 @@
 /obj/effect/landmark/corpsespawner/colonist,
 /obj/item/weapon/gun/pistol/holdout,
 /obj/effect/decal/cleanable/blood,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/kutjevo/colors/purple/edge{
 	dir = 1
 	},
@@ -201,8 +202,7 @@
 /obj/item/stool{
 	pixel_y = 8
 	},
-/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
 "gy" = (
@@ -272,6 +272,7 @@
 /obj/effect/decal/cleanable/blood/oil,
 /obj/effect/decal/cleanable/ash,
 /obj/item/explosive/mine/clf/active,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/plating/kutjevo,
 /area/kutjevo/interior/construction)
 "iM" = (
@@ -352,7 +353,6 @@
 	dir = 8
 	},
 /obj/effect/spawner/random/attachment,
-/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/kutjevo/colors/purple/edge{
 	dir = 4
 	},
@@ -391,6 +391,7 @@
 /area/kutjevo/interior/foremans_office)
 "ns" = (
 /obj/item/explosive/mine/clf/active,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/kutjevo/colors/purple/edge{
 	dir = 1
 	},
@@ -414,12 +415,10 @@
 /turf/closed/wall/kutjevo/colony/reinforced,
 /area/kutjevo/interior/foremans_office)
 "oO" = (
-/obj/structure/platform/kutjevo{
-	dir = 1
-	},
-/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-/turf/open/auto_turf/sand/layer0,
-/area/kutjevo/exterior/complex_border/med_rec)
+/obj/item/ammo_magazine/smg/nailgun,
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/floor/kutjevo/grey/plate,
+/area/kutjevo/interior/construction)
 "pe" = (
 /obj/structure/machinery/colony_floodlight{
 	pixel_y = 10
@@ -534,7 +533,7 @@
 	dir = 8;
 	tag = "icon-chair (WEST)"
 	},
-/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
 "vo" = (
@@ -545,7 +544,7 @@
 /obj/effect/decal/cleanable/blood,
 /obj/item/weapon/gun/pistol/holdout,
 /obj/effect/landmark/corpsespawner/chef,
-/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/kutjevo/grey/plate,
 /area/kutjevo/interior/construction)
 "wv" = (
@@ -660,7 +659,6 @@
 /area/kutjevo/interior/construction)
 "DU" = (
 /obj/effect/spawner/random/attachment,
-/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
 "DX" = (
@@ -778,9 +776,8 @@
 /turf/open/auto_turf/sand/layer0,
 /area/kutjevo/exterior/complex_border/med_rec)
 "FX" = (
-/obj/item/ammo_casing/bullet,
-/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-/turf/open/floor/kutjevo/colors/purple,
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/floor/kutjevo/grey/plate,
 /area/kutjevo/interior/construction)
 "Gt" = (
 /obj/structure/platform/kutjevo{
@@ -802,7 +799,6 @@
 /area/kutjevo/interior/construction)
 "Hd" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
-/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/kutjevo/colors/purple/edge{
 	dir = 5
 	},
@@ -824,9 +820,9 @@
 /turf/open/auto_turf/sand/layer0,
 /area/kutjevo/exterior/complex_border/med_rec)
 "ID" = (
-/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-/turf/open/auto_turf/sand/layer1,
-/area/kutjevo/exterior/complex_border/med_rec)
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/floor/kutjevo/colors/purple,
+/area/kutjevo/interior/construction)
 "IR" = (
 /obj/structure/barricade/metal/wired{
 	icon_state = "metal_2"
@@ -922,7 +918,7 @@
 	},
 /area/kutjevo/interior/construction)
 "Op" = (
-/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
 "Oq" = (
@@ -965,7 +961,6 @@
 /area/kutjevo/interior/construction)
 "Rb" = (
 /obj/effect/spawner/random/attachment,
-/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/kutjevo/colors/purple,
 /area/kutjevo/interior/construction)
 "Rc" = (
@@ -1000,7 +995,7 @@
 /obj/structure/bed/chair{
 	dir = 4
 	},
-/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
 "Si" = (
@@ -1033,7 +1028,7 @@
 "Tb" = (
 /obj/item/stack/rods,
 /obj/effect/spawner/random/attachment,
-/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/kutjevo/colors/purple,
 /area/kutjevo/interior/construction)
 "Tv" = (
@@ -1046,13 +1041,6 @@
 /turf/open/floor/kutjevo/colors/purple/edge{
 	dir = 8
 	},
-/area/kutjevo/interior/construction)
-"TK" = (
-/obj/item/stool{
-	pixel_y = 8
-	},
-/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-/turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
 "Ua" = (
 /obj/structure/barricade/plasteel/wired{
@@ -1081,8 +1069,10 @@
 /turf/closed/wall/kutjevo/colony/reinforced,
 /area/kutjevo/interior/foremans_office)
 "UD" = (
-/obj/structure/machinery/light,
-/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_2"
+	},
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/kutjevo/colors/purple/edge,
 /area/kutjevo/interior/construction)
 "UP" = (
@@ -1090,11 +1080,9 @@
 /turf/open/floor/plating/kutjevo,
 /area/kutjevo/interior/foremans_office)
 "UU" = (
-/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-/turf/open/floor/kutjevo/colors/purple/edge{
-	dir = 1
-	},
-/area/kutjevo/interior/construction)
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/auto_turf/sand/layer0,
+/area/kutjevo/exterior/complex_border/med_rec)
 "Ve" = (
 /obj/structure/machinery/door/airlock/almayer/maint/autoname{
 	dir = 1;
@@ -1173,9 +1161,12 @@
 /turf/open/auto_turf/sand/layer2,
 /area/kutjevo/interior/construction)
 "Yz" = (
-/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/obj/structure/platform_decoration/kutjevo{
+	dir = 8
+	},
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/auto_turf/sand/layer1,
-/area/kutjevo/interior/construction)
+/area/kutjevo/exterior/complex_border/med_rec)
 "YJ" = (
 /obj/effect/landmark/corpsespawner/security/cmb,
 /obj/effect/decal/cleanable/blood,
@@ -1264,7 +1255,7 @@
 QK
 DE
 DE
-Yz
+DE
 Ms
 fi
 hv
@@ -1282,7 +1273,7 @@ Ro
 (2,1,1) = {"
 uv
 rG
-ZT
+oO
 QR
 fi
 Vg
@@ -1305,13 +1296,13 @@ Hu
 ZT
 fi
 QN
-TK
 gw
-TK
+gw
+gw
 Cx
 hv
 ns
-FX
+hp
 tN
 IB
 Ro
@@ -1351,7 +1342,7 @@ oo
 Fv
 sx
 nn
-fb
+Yz
 Ro
 Ro
 "}
@@ -1359,19 +1350,19 @@ Ro
 fi
 xK
 sx
-sx
+ID
 ck
 uj
-TK
-TK
-TK
+gw
+gw
+gw
 Cx
 hv
 aG
 hp
-tN
+UD
 IB
-ID
+Ro
 Ro
 "}
 (7,1,1) = {"
@@ -1416,7 +1407,7 @@ Ft
 fi
 Vu
 xQ
-QK
+FX
 Rb
 xk
 YJ
@@ -1436,19 +1427,19 @@ fi
 ET
 wb
 QK
-sx
+ID
 Fv
-Op
-RP
-Op
-Op
 uc
+RP
+uc
+uc
+Op
 uc
 Cx
 hv
 Qk
 Me
-Ft
+UU
 "}
 (11,1,1) = {"
 fi
@@ -1456,8 +1447,8 @@ ed
 sT
 Vl
 jM
-UU
-uc
+Fv
+Op
 ji
 dL
 KH
@@ -1466,7 +1457,7 @@ or
 Jj
 Ms
 ZS
-oO
+IB
 Ro
 "}
 (12,1,1) = {"
@@ -1476,11 +1467,11 @@ hv
 hv
 fi
 xY
-Op
+uc
 uc
 uc
 Oq
-uc
+Op
 Jt
 Ed
 it
@@ -1495,7 +1486,7 @@ QK
 DE
 cR
 uj
-uc
+Op
 Jt
 ac
 uc
@@ -1515,12 +1506,12 @@ QK
 fi
 RJ
 Cp
-uc
+Op
 kX
 YX
 Si
 uc
-UD
+Jj
 Ms
 ZS
 ue
@@ -1538,7 +1529,7 @@ Hd
 uc
 uM
 uM
-uc
+Op
 io
 hv
 zt

--- a/maps/map_files/Kutjevo/sprinkles/25.kutjevoclf01.dmm
+++ b/maps/map_files/Kutjevo/sprinkles/25.kutjevoclf01.dmm
@@ -19,17 +19,15 @@
 	dir = 4
 	},
 /area/kutjevo/interior/construction)
-"aA" = (
-/obj/structure/platform/kutjevo{
+"as" = (
+/obj/item/explosive/mine/clf/active{
+	dir = 8
+	},
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/turf/open/floor/kutjevo/colors/purple/edge{
 	dir = 4
 	},
-/obj/structure/stairs/perspective/kutjevo{
-	dir = 4;
-	icon_state = "p_stair_sn_full_cap"
-	},
-/obj/item/explosive/mine/clf/active,
-/turf/open/floor/plating/kutjevo,
-/area/kutjevo/exterior/complex_border/med_rec)
+/area/kutjevo/interior/construction)
 "aG" = (
 /obj/effect/landmark/corpsespawner/colonist,
 /obj/item/weapon/gun/pistol/holdout,
@@ -367,6 +365,7 @@
 	dir = 8
 	},
 /obj/effect/spawner/random/attachment,
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/kutjevo/colors/purple/edge{
 	dir = 4
 	},
@@ -526,16 +525,6 @@
 /obj/effect/decal/cleanable/ash,
 /turf/open/floor/plating/kutjevo,
 /area/kutjevo/interior/construction)
-"ua" = (
-/obj/effect/decal/cleanable/blood/oil,
-/obj/effect/decal/cleanable/ash,
-/obj/item/circuitboard/airlock,
-/obj/item/stack/cable_coil,
-/obj/item/explosive/mine/clf/active{
-	dir = 8
-	},
-/turf/open/floor/plating/kutjevo,
-/area/kutjevo/interior/construction)
 "uc" = (
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
@@ -654,14 +643,6 @@
 "yc" = (
 /turf/open/floor/kutjevo/colors/orange,
 /area/kutjevo/interior/foremans_office)
-"yk" = (
-/obj/item/explosive/mine/clf/active{
-	dir = 8
-	},
-/turf/open/floor/kutjevo/colors/purple/edge{
-	dir = 4
-	},
-/area/kutjevo/interior/construction)
 "zt" = (
 /obj/item/stack/sandbags/large_stack,
 /turf/open/floor/kutjevo/colors/purple,
@@ -703,6 +684,7 @@
 /area/kutjevo/interior/construction)
 "DU" = (
 /obj/effect/spawner/random/attachment,
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
 "DX" = (
@@ -850,6 +832,7 @@
 /area/kutjevo/interior/construction)
 "Hd" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/kutjevo/colors/purple/edge{
 	dir = 5
 	},
@@ -948,13 +931,6 @@
 /obj/structure/sign/poster/clf,
 /turf/closed/wall/kutjevo/colony/reinforced,
 /area/kutjevo/interior/construction)
-"MZ" = (
-/obj/structure/platform/kutjevo{
-	dir = 1
-	},
-/obj/item/explosive/mine/clf/active,
-/turf/open/auto_turf/sand/layer0,
-/area/kutjevo/exterior/complex_border/med_rec)
 "Nl" = (
 /obj/structure/machinery/cm_vending/sorted/medical/wall_med{
 	pixel_x = -28
@@ -989,14 +965,6 @@
 /obj/effect/landmark/corpsespawner/doctor,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/kutjevo/tan,
-/area/kutjevo/interior/construction)
-"Pw" = (
-/obj/effect/decal/cleanable/blood/oil,
-/obj/effect/decal/cleanable/ash,
-/obj/item/circuitboard/airlock,
-/obj/item/stack/cable_coil,
-/obj/item/explosive/mine/clf/active,
-/turf/open/floor/plating/kutjevo,
 /area/kutjevo/interior/construction)
 "PP" = (
 /obj/structure/closet/crate/freezer/rations,
@@ -1033,6 +1001,7 @@
 /area/kutjevo/interior/construction)
 "Rb" = (
 /obj/effect/spawner/random/attachment,
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/kutjevo/colors/purple,
 /area/kutjevo/interior/construction)
 "Rc" = (
@@ -1129,6 +1098,7 @@
 /obj/item/stool{
 	pixel_y = 8
 	},
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
 >>>>>>> reimported backup
@@ -1214,12 +1184,6 @@
 	},
 /turf/open/floor/kutjevo/grey/plate,
 /area/kutjevo/interior/foremans_office)
-"Wm" = (
-/obj/item/explosive/mine/clf/active,
-/turf/open/floor/kutjevo/colors/purple/edge{
-	dir = 1
-	},
-/area/kutjevo/interior/construction)
 "Ww" = (
 /obj/structure/platform/kutjevo{
 	dir = 4
@@ -1360,7 +1324,7 @@
 QK
 DE
 DE
-DE
+Yz
 Ms
 fi
 hv
@@ -1414,12 +1378,12 @@ hv
 ns
 =======
 TK
-TK
+gw
 TK
 Cx
 hv
-Wm
-hp
+ns
+FX
 tN
 IB
 Ro
@@ -1455,7 +1419,7 @@ ZI
 qn
 cz
 Ed
-Pw
+oo
 Fv
 sx
 nn
@@ -1493,7 +1457,7 @@ UD
 tN
 >>>>>>> reimported backup
 IB
-Ro
+ID
 Ro
 "}
 (7,1,1) = {"
@@ -1509,7 +1473,7 @@ HE
 JV
 hv
 KQ
-yk
+as
 IR
 IB
 Ro
@@ -1518,7 +1482,7 @@ Ft
 (8,1,1) = {"
 fi
 fi
-ua
+lY
 fi
 fi
 fi
@@ -1553,7 +1517,7 @@ jr
 ih
 ad
 hv
-MZ
+Sn
 ri
 Ro
 "}
@@ -1568,8 +1532,10 @@ ID
 sx
 >>>>>>> reimported backup
 Fv
-uc
+Op
 RP
+Op
+Op
 uc
 uc
 <<<<<<< master
@@ -1608,7 +1574,7 @@ or
 Jj
 Ms
 ZS
-IB
+oO
 Ro
 "}
 (12,1,1) = {"
@@ -1618,7 +1584,7 @@ hv
 hv
 fi
 xY
-uc
+Op
 uc
 uc
 Oq
@@ -1653,7 +1619,7 @@ uc
 DU
 Ed
 ln
-aA
+FB
 wv
 FP
 "}
@@ -1674,7 +1640,7 @@ kX
 YX
 Si
 uc
-Jj
+UD
 Ms
 ZS
 ue

--- a/maps/map_files/Kutjevo/sprinkles/25.kutjevoclf01.dmm
+++ b/maps/map_files/Kutjevo/sprinkles/25.kutjevoclf01.dmm
@@ -19,17 +19,15 @@
 	dir = 4
 	},
 /area/kutjevo/interior/construction)
-<<<<<<< master
 "as" = (
 /obj/item/explosive/mine/clf/active{
 	dir = 8
 	},
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/kutjevo/colors/purple/edge{
 	dir = 4
 	},
 /area/kutjevo/interior/construction)
-=======
->>>>>>> reimported backup
 "aG" = (
 /obj/effect/landmark/corpsespawner/colonist,
 /obj/item/weapon/gun/pistol/holdout,
@@ -210,19 +208,14 @@
 "fi" = (
 /turf/closed/wall/kutjevo/colony/reinforced,
 /area/kutjevo/interior/construction)
-<<<<<<< master
-<<<<<<< master
 "gw" = (
 /obj/item/stool{
 	pixel_y = 8
 	},
-/obj/effect/landmark/survivor_spawner/clf/generic,
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
-=======
->>>>>>> reimported backup
-=======
->>>>>>> reimported backup
 "gy" = (
 /obj/structure/surface/table/gamblingtable,
 /obj/item/weapon/gun/rifle/mar40/lmg,
@@ -359,8 +352,6 @@
 /obj/item/paper_bin,
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
-<<<<<<< master
-<<<<<<< master
 "lY" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/effect/decal/cleanable/ash,
@@ -371,15 +362,12 @@
 	},
 /turf/open/floor/plating/kutjevo,
 /area/kutjevo/interior/construction)
-=======
->>>>>>> reimported backup
-=======
->>>>>>> reimported backup
 "md" = (
 /obj/structure/platform_decoration/kutjevo{
 	dir = 8
 	},
 /obj/effect/spawner/random/attachment,
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/kutjevo/colors/purple/edge{
 	dir = 4
 	},
@@ -416,11 +404,8 @@
 /obj/structure/window_frame/kutjevo/reinforced,
 /turf/open/floor/kutjevo/multi_tiles,
 /area/kutjevo/interior/foremans_office)
-<<<<<<< master
-<<<<<<< master
 "ns" = (
 /obj/item/explosive/mine/clf/active,
-/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/kutjevo/colors/purple/edge{
 	dir = 1
 	},
@@ -433,10 +418,6 @@
 /obj/item/explosive/mine/clf/active,
 /turf/open/floor/plating/kutjevo,
 /area/kutjevo/interior/construction)
-=======
->>>>>>> reimported backup
-=======
->>>>>>> reimported backup
 "or" = (
 /obj/effect/landmark/corpsespawner/colonist,
 /obj/effect/decal/cleanable/blood,
@@ -447,15 +428,13 @@
 "oB" = (
 /turf/closed/wall/kutjevo/colony/reinforced,
 /area/kutjevo/interior/foremans_office)
-<<<<<<< master
-<<<<<<< master
 "oO" = (
-/obj/item/ammo_magazine/smg/nailgun,
-/obj/effect/landmark/survivor_spawner/clf/generic,
-/turf/open/floor/kutjevo/grey/plate,
-/area/kutjevo/interior/construction)
-=======
->>>>>>> reimported backup
+/obj/structure/platform/kutjevo{
+	dir = 1
+	},
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/turf/open/auto_turf/sand/layer0,
+/area/kutjevo/exterior/complex_border/med_rec)
 "pe" = (
 /obj/structure/machinery/colony_floodlight{
 	pixel_y = 10
@@ -543,16 +522,6 @@
 /obj/effect/decal/cleanable/ash,
 /turf/open/floor/plating/kutjevo,
 /area/kutjevo/interior/construction)
-"ua" = (
-/obj/effect/decal/cleanable/blood/oil,
-/obj/effect/decal/cleanable/ash,
-/obj/item/circuitboard/airlock,
-/obj/item/stack/cable_coil,
-/obj/item/explosive/mine/clf/active{
-	dir = 8
-	},
-/turf/open/floor/plating/kutjevo,
-/area/kutjevo/interior/construction)
 "uc" = (
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
@@ -580,10 +549,7 @@
 	dir = 8;
 	tag = "icon-chair (WEST)"
 	},
-<<<<<<< master
-/obj/effect/landmark/survivor_spawner/clf/generic,
-=======
->>>>>>> reimported backup
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
 "vo" = (
@@ -594,10 +560,7 @@
 /obj/effect/decal/cleanable/blood,
 /obj/item/weapon/gun/pistol/holdout,
 /obj/effect/landmark/corpsespawner/chef,
-<<<<<<< master
-/obj/effect/landmark/survivor_spawner/clf/generic,
-=======
->>>>>>> reimported backup
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/kutjevo/grey/plate,
 /area/kutjevo/interior/construction)
 "wv" = (
@@ -671,14 +634,6 @@
 "yc" = (
 /turf/open/floor/kutjevo/colors/orange,
 /area/kutjevo/interior/foremans_office)
-"yk" = (
-/obj/item/explosive/mine/clf/active{
-	dir = 8
-	},
-/turf/open/floor/kutjevo/colors/purple/edge{
-	dir = 4
-	},
-/area/kutjevo/interior/construction)
 "zt" = (
 /obj/item/stack/sandbags/large_stack,
 /turf/open/floor/kutjevo/colors/purple,
@@ -720,6 +675,7 @@
 /area/kutjevo/interior/construction)
 "DU" = (
 /obj/effect/spawner/random/attachment,
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
 "DX" = (
@@ -819,8 +775,6 @@
 	dir = 1
 	},
 /area/kutjevo/interior/construction)
-<<<<<<< master
-<<<<<<< master
 "FB" = (
 /obj/structure/platform/kutjevo{
 	dir = 4
@@ -839,20 +793,10 @@
 /turf/open/auto_turf/sand/layer0,
 /area/kutjevo/exterior/complex_border/med_rec)
 "FX" = (
-/obj/effect/landmark/survivor_spawner/clf/generic,
-/turf/open/floor/kutjevo/grey/plate,
+/obj/item/ammo_casing/bullet,
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/turf/open/floor/kutjevo/colors/purple,
 /area/kutjevo/interior/construction)
-=======
-=======
->>>>>>> reimported backup
-"FP" = (
-/obj/effect/landmark/corpsespawner/colonist,
-/turf/open/auto_turf/sand/layer0,
-/area/kutjevo/exterior/complex_border/med_rec)
-<<<<<<< master
->>>>>>> reimported backup
-=======
->>>>>>> reimported backup
 "Gt" = (
 /obj/structure/platform/kutjevo{
 	dir = 1
@@ -873,6 +817,7 @@
 /area/kutjevo/interior/construction)
 "Hd" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/kutjevo/colors/purple/edge{
 	dir = 5
 	},
@@ -893,14 +838,10 @@
 	},
 /turf/open/auto_turf/sand/layer0,
 /area/kutjevo/exterior/complex_border/med_rec)
-<<<<<<< master
-<<<<<<< master
 "ID" = (
-/obj/effect/landmark/survivor_spawner/clf/generic,
-/turf/open/floor/kutjevo/colors/purple,
-/area/kutjevo/interior/construction)
-=======
->>>>>>> reimported backup
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/turf/open/auto_turf/sand/layer1,
+/area/kutjevo/exterior/complex_border/med_rec)
 "IR" = (
 /obj/structure/barricade/metal/wired{
 	icon_state = "metal_2"
@@ -972,13 +913,6 @@
 /obj/structure/sign/poster/clf,
 /turf/closed/wall/kutjevo/colony/reinforced,
 /area/kutjevo/interior/construction)
-"MZ" = (
-/obj/structure/platform/kutjevo{
-	dir = 1
-	},
-/obj/item/explosive/mine/clf/active,
-/turf/open/auto_turf/sand/layer0,
-/area/kutjevo/exterior/complex_border/med_rec)
 "Nl" = (
 /obj/structure/machinery/cm_vending/sorted/medical/wall_med{
 	pixel_x = -28
@@ -1002,28 +936,14 @@
 	dir = 1
 	},
 /area/kutjevo/interior/construction)
-<<<<<<< master
-<<<<<<< master
 "Op" = (
-/obj/effect/landmark/survivor_spawner/clf/generic,
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
-=======
->>>>>>> reimported backup
-=======
->>>>>>> reimported backup
 "Oq" = (
 /obj/effect/landmark/corpsespawner/doctor,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/kutjevo/tan,
-/area/kutjevo/interior/construction)
-"Pw" = (
-/obj/effect/decal/cleanable/blood/oil,
-/obj/effect/decal/cleanable/ash,
-/obj/item/circuitboard/airlock,
-/obj/item/stack/cable_coil,
-/obj/item/explosive/mine/clf/active,
-/turf/open/floor/plating/kutjevo,
 /area/kutjevo/interior/construction)
 "PP" = (
 /obj/structure/closet/crate/freezer/rations,
@@ -1060,6 +980,7 @@
 /area/kutjevo/interior/construction)
 "Rb" = (
 /obj/effect/spawner/random/attachment,
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/kutjevo/colors/purple,
 /area/kutjevo/interior/construction)
 "Rc" = (
@@ -1094,10 +1015,7 @@
 /obj/structure/bed/chair{
 	dir = 4
 	},
-<<<<<<< master
-/obj/effect/landmark/survivor_spawner/clf/generic,
-=======
->>>>>>> reimported backup
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
 "Si" = (
@@ -1117,8 +1035,6 @@
 /obj/item/tank/emergency_oxygen/engi,
 /turf/open/floor/kutjevo/grey/plate,
 /area/kutjevo/interior/foremans_office)
-<<<<<<< master
-<<<<<<< master
 "Sn" = (
 /obj/structure/platform/kutjevo{
 	dir = 1
@@ -1126,20 +1042,13 @@
 /obj/item/explosive/mine/clf/active,
 /turf/open/auto_turf/sand/layer0,
 /area/kutjevo/exterior/complex_border/med_rec)
-=======
->>>>>>> reimported backup
-=======
->>>>>>> reimported backup
 "SI" = (
 /turf/closed/wall/kutjevo/colony/reinforced,
 /area/kutjevo/exterior/complex_border/med_rec)
 "Tb" = (
 /obj/item/stack/rods,
 /obj/effect/spawner/random/attachment,
-<<<<<<< master
-/obj/effect/landmark/survivor_spawner/clf/generic,
-=======
->>>>>>> reimported backup
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/kutjevo/colors/purple,
 /area/kutjevo/interior/construction)
 "Tv" = (
@@ -1159,6 +1068,7 @@
 /obj/item/stool{
 	pixel_y = 8
 	},
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
 >>>>>>> reimported backup
@@ -1188,31 +1098,21 @@
 /obj/structure/sign/poster/clf,
 /turf/closed/wall/kutjevo/colony/reinforced,
 /area/kutjevo/interior/foremans_office)
-<<<<<<< master
-<<<<<<< master
 "UD" = (
-/obj/structure/barricade/metal/wired{
-	icon_state = "metal_2"
-	},
-/obj/effect/landmark/survivor_spawner/clf/generic,
+/obj/structure/machinery/light,
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/kutjevo/colors/purple/edge,
 /area/kutjevo/interior/construction)
-=======
->>>>>>> reimported backup
-=======
->>>>>>> reimported backup
 "UP" = (
 /obj/structure/platform_decoration/kutjevo,
 /turf/open/floor/plating/kutjevo,
 /area/kutjevo/interior/foremans_office)
-<<<<<<< master
-<<<<<<< master
 "UU" = (
-/obj/effect/landmark/survivor_spawner/clf/generic,
-/turf/open/auto_turf/sand/layer0,
-/area/kutjevo/exterior/complex_border/med_rec)
-=======
->>>>>>> reimported backup
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/turf/open/floor/kutjevo/colors/purple/edge{
+	dir = 1
+	},
+/area/kutjevo/interior/construction)
 "Ve" = (
 /obj/structure/machinery/door/airlock/almayer/maint/autoname{
 	dir = 1;
@@ -1248,12 +1148,6 @@
 	},
 /turf/open/floor/kutjevo/grey/plate,
 /area/kutjevo/interior/foremans_office)
-"Wm" = (
-/obj/item/explosive/mine/clf/active,
-/turf/open/floor/kutjevo/colors/purple/edge{
-	dir = 1
-	},
-/area/kutjevo/interior/construction)
 "Ww" = (
 /obj/structure/platform/kutjevo{
 	dir = 4
@@ -1296,17 +1190,10 @@
 "Yg" = (
 /turf/open/auto_turf/sand/layer2,
 /area/kutjevo/interior/construction)
-<<<<<<< master
-<<<<<<< master
 "Yz" = (
-/obj/structure/platform_decoration/kutjevo{
-	dir = 8
-	},
-/obj/effect/landmark/survivor_spawner/clf/generic,
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/auto_turf/sand/layer1,
-/area/kutjevo/exterior/complex_border/med_rec)
-=======
->>>>>>> reimported backup
+/area/kutjevo/interior/construction)
 "YJ" = (
 /obj/effect/landmark/corpsespawner/security/cmb,
 /obj/effect/decal/cleanable/blood,
@@ -1395,7 +1282,7 @@
 QK
 DE
 DE
-DE
+Yz
 Ms
 fi
 hv
@@ -1449,13 +1336,12 @@ hv
 ns
 =======
 TK
-TK
+gw
 TK
 Cx
 hv
-Fv
->>>>>>> reimported backup
-hp
+ns
+FX
 tN
 IB
 Ro
@@ -1491,7 +1377,6 @@ ZI
 qn
 cz
 Ed
-<<<<<<< master
 oo
 Fv
 sx
@@ -1536,7 +1421,7 @@ UD
 tN
 >>>>>>> reimported backup
 IB
-Ro
+ID
 Ro
 "}
 (7,1,1) = {"
@@ -1552,11 +1437,7 @@ HE
 JV
 hv
 KQ
-<<<<<<< master
 as
-=======
-HE
->>>>>>> reimported backup
 IR
 IB
 Ro
@@ -1565,11 +1446,7 @@ Ft
 (8,1,1) = {"
 fi
 fi
-<<<<<<< master
 lY
-=======
-ln
->>>>>>> reimported backup
 fi
 fi
 fi
@@ -1604,11 +1481,7 @@ jr
 ih
 ad
 hv
-<<<<<<< master
 Sn
-=======
-IB
->>>>>>> reimported backup
 ri
 Ro
 "}
@@ -1623,15 +1496,11 @@ ID
 sx
 >>>>>>> reimported backup
 Fv
-uc
-RP
-uc
-uc
-<<<<<<< master
 Op
-=======
+RP
+Op
+Op
 uc
->>>>>>> reimported backup
 uc
 Cx
 hv
@@ -1649,10 +1518,7 @@ ed
 sT
 Vl
 jM
-Fv
-<<<<<<< master
-Op
-=======
+UU
 uc
 >>>>>>> reimported backup
 ji
@@ -1663,7 +1529,7 @@ or
 Jj
 Ms
 ZS
-IB
+oO
 Ro
 "}
 (12,1,1) = {"
@@ -1673,7 +1539,7 @@ hv
 hv
 fi
 xY
-uc
+Op
 uc
 uc
 Oq
@@ -1708,11 +1574,7 @@ uc
 DU
 Ed
 ln
-<<<<<<< master
 FB
-=======
-cy
->>>>>>> reimported backup
 wv
 FP
 "}
@@ -1733,7 +1595,7 @@ kX
 YX
 Si
 uc
-Jj
+UD
 Ms
 ZS
 ue

--- a/maps/map_files/Kutjevo/sprinkles/25.kutjevoclf01.dmm
+++ b/maps/map_files/Kutjevo/sprinkles/25.kutjevoclf01.dmm
@@ -1,0 +1,1569 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ac" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/kutjevo/tan,
+/area/kutjevo/interior/construction)
+"ad" = (
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1"
+	},
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1";
+	dir = 8
+	},
+/turf/open/floor/kutjevo/colors/purple/inner_corner{
+	dir = 4
+	},
+/area/kutjevo/interior/construction)
+"aG" = (
+/obj/effect/landmark/corpsespawner/colonist,
+/obj/item/weapon/gun/pistol/holdout,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/kutjevo/colors/purple/edge{
+	dir = 1
+	},
+/area/kutjevo/interior/construction)
+"br" = (
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_2";
+	dir = 8
+	},
+/turf/open/floor/kutjevo/colors/purple/inner_corner,
+/area/kutjevo/interior/construction)
+"bu" = (
+/obj/effect/decal/cleanable/blood{
+	icon_state = "xgib2";
+	tag = "icon-xgib2"
+	},
+/obj/effect/decal/cleanable/blood/gibs/core,
+/turf/open/floor/plating/kutjevo,
+/area/kutjevo/interior/construction)
+"ck" = (
+/obj/effect/decal/cleanable/blood/oil,
+/obj/item/stack/cable_coil,
+/obj/item/circuitboard/airlock,
+/turf/open/floor/kutjevo/multi_tiles,
+/area/kutjevo/interior/construction)
+"cy" = (
+/obj/structure/platform/kutjevo{
+	dir = 4
+	},
+/obj/structure/stairs/perspective/kutjevo{
+	dir = 4;
+	icon_state = "p_stair_sn_full_cap"
+	},
+/turf/open/floor/plating/kutjevo,
+/area/kutjevo/exterior/complex_border/med_rec)
+"cz" = (
+/obj/structure/surface/table/gamblingtable,
+/obj/item/weapon/gun/rifle/m16{
+	pixel_y = 13
+	},
+/obj/item/ammo_magazine/rifle/m16{
+	pixel_x = -10
+	},
+/obj/item/ammo_magazine/rifle/m16{
+	pixel_x = -7;
+	pixel_y = -1
+	},
+/obj/item/ammo_magazine/rifle/m16{
+	pixel_x = -4;
+	pixel_y = -2
+	},
+/obj/item/ammo_magazine/rifle/m16{
+	pixel_y = -3
+	},
+/obj/item/ammo_magazine/rifle/m16{
+	pixel_y = -4;
+	pixel_x = 2
+	},
+/obj/item/ammo_magazine/rifle/m16/ap{
+	pixel_x = 12;
+	pixel_y = 5
+	},
+/obj/item/ammo_magazine/rifle/m16/ap{
+	pixel_x = 12;
+	pixel_y = 3
+	},
+/obj/item/ammo_magazine/rifle/m16/ap{
+	pixel_x = 12;
+	pixel_y = 1
+	},
+/obj/item/ammo_magazine/rifle/m16/ap{
+	pixel_x = 12;
+	pixel_y = -1
+	},
+/obj/item/ammo_magazine/rifle/m16/ap{
+	pixel_x = 12;
+	pixel_y = -3
+	},
+/turf/open/floor/kutjevo/tan,
+/area/kutjevo/interior/construction)
+"cR" = (
+/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/decal/cleanable/ash,
+/obj/item/circuitboard/airlock,
+/obj/item/stack/cable_coil,
+/turf/open/floor/kutjevo/multi_tiles,
+/area/kutjevo/interior/construction)
+"dg" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/structure/machinery/computer/communications{
+	dir = 1
+	},
+/turf/open/floor/kutjevo/colors/orange/edge{
+	dir = 4
+	},
+/area/kutjevo/interior/foremans_office)
+"dx" = (
+/obj/effect/decal/cleanable/blood,
+/obj/structure/machinery/microwave{
+	pixel_y = 6
+	},
+/obj/structure/surface/table/reinforced/prison,
+/obj/structure/machinery/microwave{
+	pixel_y = 20
+	},
+/turf/open/floor/kutjevo/colors/purple,
+/area/kutjevo/interior/construction)
+"dL" = (
+/obj/structure/surface/table/almayer,
+/obj/item/storage/backpack/general_belt,
+/obj/item/storage/backpack/general_belt{
+	pixel_y = 7
+	},
+/turf/open/floor/kutjevo/colors/purple,
+/area/kutjevo/interior/construction)
+"dO" = (
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1"
+	},
+/turf/open/floor/kutjevo/colors/purple/inner_corner{
+	dir = 8
+	},
+/area/kutjevo/interior/construction)
+"ed" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/structure/machinery/reagentgrinder{
+	pixel_y = 9
+	},
+/obj/structure/mirror{
+	pixel_y = 28
+	},
+/turf/open/floor/kutjevo/colors/purple,
+/area/kutjevo/interior/construction)
+"ep" = (
+/obj/structure/platform/kutjevo{
+	dir = 8
+	},
+/obj/structure/stairs/perspective/kutjevo{
+	icon_state = "p_stair_sn_full_cap"
+	},
+/turf/open/floor/plating/kutjevo,
+/area/kutjevo/exterior/complex_border/med_rec)
+"ew" = (
+/obj/structure/platform/kutjevo{
+	dir = 8
+	},
+/obj/structure/stairs/perspective/kutjevo{
+	icon_state = "p_stair_sn_full_cap"
+	},
+/turf/open/floor/plating/kutjevo,
+/area/kutjevo/interior/construction)
+"fa" = (
+/obj/structure/machinery/space_heater,
+/turf/open/floor/kutjevo/colors/purple,
+/area/kutjevo/interior/construction)
+"fb" = (
+/obj/structure/platform_decoration/kutjevo{
+	dir = 8
+	},
+/turf/open/auto_turf/sand/layer1,
+/area/kutjevo/exterior/complex_border/med_rec)
+"fi" = (
+/turf/closed/wall/kutjevo/colony/reinforced,
+/area/kutjevo/interior/construction)
+"gy" = (
+/obj/structure/surface/table/gamblingtable,
+/obj/item/weapon/gun/rifle/mar40/lmg,
+/turf/open/floor/kutjevo/tan,
+/area/kutjevo/interior/construction)
+"hb" = (
+/obj/structure/bed/chair/office/light,
+/turf/open/floor/kutjevo/colors/orange/edge{
+	dir = 1
+	},
+/area/kutjevo/interior/foremans_office)
+"hp" = (
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/kutjevo/colors/purple,
+/area/kutjevo/interior/construction)
+"hq" = (
+/obj/structure/platform/kutjevo{
+	dir = 8
+	},
+/turf/open/floor/plating/kutjevo,
+/area/kutjevo/interior/foremans_office)
+"hv" = (
+/obj/structure/window_frame/kutjevo/reinforced,
+/turf/open/floor/plating/kutjevo,
+/area/kutjevo/interior/construction)
+"hE" = (
+/obj/structure/filingcabinet,
+/obj/structure/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/kutjevo/colors/orange/inner_corner{
+	dir = 1
+	},
+/area/kutjevo/interior/foremans_office)
+"hI" = (
+/obj/structure/platform_decoration/kutjevo{
+	dir = 4
+	},
+/turf/open/auto_turf/sand/layer1,
+/area/kutjevo/exterior/complex_border/med_rec)
+"hJ" = (
+/turf/open/floor/kutjevo/colors/orange/edge,
+/area/kutjevo/interior/foremans_office)
+"hS" = (
+/obj/structure/girder,
+/turf/open/floor/plating/kutjevo,
+/area/kutjevo/interior/construction)
+"ih" = (
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1";
+	dir = 8
+	},
+/turf/open/floor/kutjevo/colors/purple/edge{
+	dir = 8
+	},
+/area/kutjevo/interior/construction)
+"io" = (
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1"
+	},
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/kutjevo/colors/purple/edge,
+/area/kutjevo/interior/construction)
+"it" = (
+/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/decal/cleanable/ash,
+/turf/open/floor/plating/kutjevo,
+/area/kutjevo/interior/construction)
+"iM" = (
+/obj/item/device/flashlight,
+/turf/open/auto_turf/sand/layer1,
+/area/kutjevo/exterior/complex_border/med_rec)
+"jd" = (
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/open/floor/kutjevo/colors/orange/inner_corner{
+	dir = 8
+	},
+/area/kutjevo/interior/foremans_office)
+"ji" = (
+/obj/structure/surface/table/almayer,
+/obj/item/storage/firstaid/adv,
+/obj/item/storage/firstaid/adv{
+	pixel_x = 3;
+	pixel_y = 5
+	},
+/turf/open/floor/kutjevo/colors/purple,
+/area/kutjevo/interior/construction)
+"jk" = (
+/obj/structure/bed,
+/obj/item/storage/firstaid/surgical,
+/obj/item/clothing/mask/breath/medical,
+/obj/item/tank/anesthetic,
+/turf/open/floor/kutjevo/colors/purple,
+/area/kutjevo/interior/construction)
+"jr" = (
+/obj/effect/spawner/random/attachment,
+/turf/open/floor/kutjevo/colors/purple/edge{
+	dir = 8
+	},
+/area/kutjevo/interior/construction)
+"jK" = (
+/turf/open/floor/plating/kutjevo,
+/area/kutjevo/interior/foremans_office)
+"jM" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/reagent_container/food/snacks/meatballspagetti,
+/turf/open/floor/kutjevo/colors/purple,
+/area/kutjevo/interior/construction)
+"kX" = (
+/obj/structure/bed/chair,
+/obj/effect/decal/cleanable/blood/gibs/down,
+/turf/open/floor/kutjevo/colors/purple,
+/area/kutjevo/interior/construction)
+"ln" = (
+/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/decal/cleanable/ash,
+/obj/item/circuitboard/airlock,
+/obj/item/stack/cable_coil,
+/turf/open/floor/plating/kutjevo,
+/area/kutjevo/interior/construction)
+"lL" = (
+/obj/structure/surface/table/gamblingtable,
+/obj/item/weapon/gun/shotgun/pump/cmb{
+	pixel_y = 9
+	},
+/obj/item/weapon/gun/shotgun/pump/cmb{
+	pixel_y = -3
+	},
+/obj/item/paper_bin,
+/turf/open/floor/kutjevo/tan,
+/area/kutjevo/interior/construction)
+"md" = (
+/obj/structure/platform_decoration/kutjevo{
+	dir = 8
+	},
+/obj/effect/spawner/random/attachment,
+/turf/open/floor/kutjevo/colors/purple/edge{
+	dir = 4
+	},
+/area/kutjevo/interior/construction)
+"mn" = (
+/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/decal/cleanable/ash,
+/obj/item/circuitboard/airlock,
+/turf/open/floor/plating/kutjevo,
+/area/kutjevo/interior/foremans_office)
+"mE" = (
+/obj/structure/platform_decoration/kutjevo{
+	dir = 8
+	},
+/obj/structure/machinery/door/airlock/almayer/maint/autoname{
+	dir = 1;
+	name = "\improper Null Hatch REPLACE ME";
+	req_access = null;
+	req_one_access = null
+	},
+/turf/open/floor/plating/kutjevo,
+/area/kutjevo/interior/foremans_office)
+"nn" = (
+/obj/structure/platform/kutjevo{
+	dir = 4
+	},
+/obj/structure/stairs/perspective/kutjevo{
+	dir = 4;
+	icon_state = "p_stair_sn_full_cap"
+	},
+/turf/open/floor/plating/kutjevo,
+/area/kutjevo/interior/construction)
+"nr" = (
+/obj/structure/window_frame/kutjevo/reinforced,
+/turf/open/floor/kutjevo/multi_tiles,
+/area/kutjevo/interior/foremans_office)
+"or" = (
+/obj/effect/landmark/corpsespawner/colonist,
+/obj/effect/decal/cleanable/blood,
+/obj/item/weapon/gun/pistol/holdout,
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/kutjevo/tan,
+/area/kutjevo/interior/construction)
+"oB" = (
+/turf/closed/wall/kutjevo/colony/reinforced,
+/area/kutjevo/interior/foremans_office)
+"pe" = (
+/obj/structure/machinery/colony_floodlight{
+	pixel_y = 10
+	},
+/turf/open/floor/kutjevo/colors/orange,
+/area/kutjevo/interior/foremans_office)
+"ps" = (
+/obj/item/ammo_magazine/smg/nailgun,
+/obj/structure/surface/rack,
+/obj/item/weapon/gun/smg/nailgun,
+/obj/item/ammo_magazine/smg/nailgun,
+/obj/item/ammo_magazine/smg/nailgun,
+/turf/open/floor/kutjevo/colors/purple,
+/area/kutjevo/interior/construction)
+"qn" = (
+/obj/structure/surface/table/gamblingtable,
+/obj/item/ammo_magazine/rifle/mar40/lmg{
+	pixel_y = -8;
+	pixel_x = 5
+	},
+/obj/item/ammo_magazine/rifle/mar40/lmg{
+	pixel_y = -8;
+	pixel_x = -11
+	},
+/obj/item/ammo_magazine/rifle/mar40/lmg{
+	pixel_y = 6;
+	pixel_x = 10
+	},
+/obj/item/ammo_magazine/rifle/mar40/lmg{
+	pixel_y = 6;
+	pixel_x = 10
+	},
+/obj/item/ammo_magazine/rifle/mar40/lmg{
+	pixel_y = 3;
+	pixel_x = -2
+	},
+/obj/item/ammo_magazine/rifle/mar40/lmg{
+	pixel_y = 8;
+	pixel_x = -11
+	},
+/turf/open/floor/kutjevo/tan,
+/area/kutjevo/interior/construction)
+"qP" = (
+/turf/open/floor/kutjevo/colors/orange/inner_corner{
+	dir = 4
+	},
+/area/kutjevo/interior/foremans_office)
+"qZ" = (
+/obj/structure/machinery/power/apc{
+	dir = 1;
+	pixel_y = 24
+	},
+/turf/open/floor/kutjevo/colors/orange/inner_corner,
+/area/kutjevo/interior/foremans_office)
+"rg" = (
+/obj/structure/machinery/vending/snack,
+/turf/open/floor/kutjevo/colors/purple/inner_corner{
+	dir = 1
+	},
+/area/kutjevo/interior/construction)
+"ri" = (
+/turf/open/auto_turf/sand/layer2,
+/area/kutjevo/exterior/complex_border/med_rec)
+"rG" = (
+/obj/item/stack/rods,
+/turf/open/floor/kutjevo/grey/plate,
+/area/kutjevo/interior/construction)
+"sx" = (
+/turf/open/floor/kutjevo/colors/purple,
+/area/kutjevo/interior/construction)
+"sT" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/tool/kitchen/rollingpin,
+/turf/open/floor/kutjevo/colors/purple,
+/area/kutjevo/interior/construction)
+"tN" = (
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_2"
+	},
+/turf/open/floor/kutjevo/colors/purple/edge,
+/area/kutjevo/interior/construction)
+"tW" = (
+/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/decal/cleanable/ash,
+/turf/open/floor/plating/kutjevo,
+/area/kutjevo/interior/construction)
+"uc" = (
+/turf/open/floor/kutjevo/tan,
+/area/kutjevo/interior/construction)
+"ue" = (
+/obj/structure/platform/kutjevo{
+	dir = 1
+	},
+/obj/structure/machinery/portable_atmospherics/powered/scrubber,
+/turf/open/auto_turf/sand/layer0,
+/area/kutjevo/exterior/complex_border/med_rec)
+"uj" = (
+/obj/structure/barricade/plasteel/wired{
+	dir = 1;
+	icon_state = "plasteel_closed_1"
+	},
+/turf/open/floor/kutjevo/colors/purple/edge{
+	dir = 1
+	},
+/area/kutjevo/interior/construction)
+"uv" = (
+/turf/open/floor/plating/kutjevo,
+/area/kutjevo/interior/construction)
+"uM" = (
+/obj/structure/bed/chair{
+	dir = 8;
+	tag = "icon-chair (WEST)"
+	},
+/turf/open/floor/kutjevo/tan,
+/area/kutjevo/interior/construction)
+"vo" = (
+/obj/structure/platform/kutjevo,
+/turf/open/floor/plating/kutjevo,
+/area/kutjevo/interior/foremans_office)
+"wb" = (
+/obj/effect/decal/cleanable/blood,
+/obj/item/weapon/gun/pistol/holdout,
+/obj/effect/landmark/corpsespawner/chef,
+/turf/open/floor/kutjevo/grey/plate,
+/area/kutjevo/interior/construction)
+"wv" = (
+/obj/structure/platform_decoration/kutjevo{
+	dir = 8
+	},
+/obj/item/stack/sandbags/large_stack,
+/turf/open/auto_turf/sand/layer0,
+/area/kutjevo/exterior/complex_border/med_rec)
+"wE" = (
+/obj/structure/surface/rack,
+/obj/item/stack/sheet/metal/large_stack,
+/obj/item/stack/sheet/metal/large_stack,
+/turf/open/floor/kutjevo/grey/plate,
+/area/kutjevo/interior/construction)
+"wL" = (
+/obj/structure/machinery/door/airlock/almayer/maint/autoname{
+	name = "\improper Null Hatch REPLACE ME";
+	req_access = null;
+	req_one_access = null
+	},
+/turf/open/floor/plating/kutjevo,
+/area/kutjevo/interior/foremans_office)
+"wV" = (
+/obj/structure/surface/rack,
+/obj/item/tool/crowbar,
+/obj/structure/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/kutjevo/grey/plate,
+/area/kutjevo/interior/foremans_office)
+"xd" = (
+/obj/structure/bed/chair/office/light{
+	dir = 8;
+	tag = "icon-officechair_white (EAST)"
+	},
+/turf/open/floor/kutjevo/colors/orange/edge{
+	dir = 4
+	},
+/area/kutjevo/interior/foremans_office)
+"xk" = (
+/turf/open/floor/kutjevo/colors/purple/inner_corner,
+/area/kutjevo/interior/construction)
+"xK" = (
+/obj/item/stack/rods,
+/obj/effect/decal/cleanable/blood/gibs/limb,
+/obj/structure/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/kutjevo/colors/purple,
+/area/kutjevo/interior/construction)
+"xQ" = (
+/obj/structure/barricade/plasteel/wired{
+	dir = 8;
+	icon_state = "plasteel_closed_1"
+	},
+/obj/effect/spawner/random/attachment,
+/turf/open/floor/kutjevo/grey/plate,
+/area/kutjevo/interior/construction)
+"xY" = (
+/obj/structure/sign/poster{
+	pixel_y = 32
+	},
+/obj/structure/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/kutjevo/colors/purple/edge{
+	dir = 1
+	},
+/area/kutjevo/interior/construction)
+"yc" = (
+/turf/open/floor/kutjevo/colors/orange,
+/area/kutjevo/interior/foremans_office)
+"zt" = (
+/obj/item/stack/sandbags/large_stack,
+/turf/open/floor/kutjevo/colors/purple,
+/area/kutjevo/interior/construction)
+"zH" = (
+/obj/structure/flora/pottedplant{
+	icon_state = "pottedplant_29"
+	},
+/turf/open/floor/kutjevo/colors/purple,
+/area/kutjevo/interior/construction)
+"Cm" = (
+/obj/structure/machinery/door/airlock/almayer/maint/autoname{
+	name = "\improper Null Hatch REPLACE ME";
+	req_access = null;
+	req_one_access = null
+	},
+/turf/open/floor/kutjevo/multi_tiles,
+/area/kutjevo/interior/construction)
+"Cp" = (
+/turf/open/floor/kutjevo/colors/purple/edge{
+	dir = 5
+	},
+/area/kutjevo/interior/construction)
+"Cx" = (
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1"
+	},
+/turf/open/floor/kutjevo/colors/purple/edge,
+/area/kutjevo/interior/construction)
+"Dj" = (
+/obj/structure/platform/kutjevo{
+	dir = 1
+	},
+/obj/item/device/defibrillator,
+/turf/open/auto_turf/sand/layer0,
+/area/kutjevo/exterior/complex_border/med_rec)
+"DE" = (
+/turf/open/auto_turf/sand/layer1,
+/area/kutjevo/interior/construction)
+"DU" = (
+/obj/effect/spawner/random/attachment,
+/turf/open/floor/kutjevo/tan,
+/area/kutjevo/interior/construction)
+"DX" = (
+/obj/structure/platform/kutjevo{
+	dir = 4
+	},
+/turf/open/floor/kutjevo/colors/purple/edge{
+	dir = 4
+	},
+/area/kutjevo/interior/construction)
+"Ed" = (
+/obj/structure/barricade/plasteel/wired{
+	icon_state = "plasteel_closed_1"
+	},
+/turf/open/floor/kutjevo/colors/purple/edge,
+/area/kutjevo/interior/construction)
+"El" = (
+/obj/structure/surface/table/gamblingtable,
+/obj/item/weapon/gun/smg/fp9000{
+	pixel_y = 13
+	},
+/obj/item/ammo_magazine/smg/fp9000{
+	pixel_y = -4;
+	pixel_x = -8
+	},
+/obj/item/ammo_magazine/smg/fp9000{
+	pixel_y = -4;
+	pixel_x = -1
+	},
+/obj/item/ammo_magazine/smg/fp9000{
+	pixel_y = -4;
+	pixel_x = -5
+	},
+/obj/item/ammo_magazine/smg/fp9000{
+	pixel_y = -4;
+	pixel_x = 6
+	},
+/obj/item/ammo_magazine/smg/fp9000{
+	pixel_y = -4;
+	pixel_x = 13
+	},
+/obj/item/ammo_magazine/smg/fp9000{
+	pixel_y = -4;
+	pixel_x = -8
+	},
+/obj/item/ammo_magazine/smg/fp9000{
+	pixel_y = -4;
+	pixel_x = -5
+	},
+/obj/item/ammo_magazine/smg/fp9000{
+	pixel_y = -4;
+	pixel_x = -1
+	},
+/obj/item/ammo_magazine/smg/fp9000{
+	pixel_y = -4;
+	pixel_x = 6
+	},
+/obj/item/ammo_magazine/smg/fp9000{
+	pixel_y = -4;
+	pixel_x = 13
+	},
+/turf/open/floor/kutjevo/tan,
+/area/kutjevo/interior/construction)
+"EM" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/turf/open/auto_turf/sand/layer1,
+/area/kutjevo/exterior/complex_border/med_rec)
+"ER" = (
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_2";
+	dir = 8
+	},
+/obj/effect/landmark/corpsespawner/security,
+/obj/item/weapon/gun/pistol/b92fs,
+/obj/effect/decal/cleanable/blood/oil,
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/kutjevo/colors/purple/edge{
+	dir = 8
+	},
+/area/kutjevo/interior/construction)
+"ET" = (
+/obj/structure/sink{
+	pixel_y = 32
+	},
+/obj/item/stool{
+	pixel_y = 8
+	},
+/turf/open/floor/kutjevo/grey/plate,
+/area/kutjevo/interior/construction)
+"Ft" = (
+/turf/open/auto_turf/sand/layer0,
+/area/kutjevo/exterior/complex_border/med_rec)
+"Fv" = (
+/turf/open/floor/kutjevo/colors/purple/edge{
+	dir = 1
+	},
+/area/kutjevo/interior/construction)
+"FP" = (
+/obj/effect/landmark/corpsespawner/colonist,
+/turf/open/auto_turf/sand/layer0,
+/area/kutjevo/exterior/complex_border/med_rec)
+"Gt" = (
+/obj/structure/platform/kutjevo{
+	dir = 1
+	},
+/obj/structure/bed/roller,
+/turf/open/auto_turf/sand/layer0,
+/area/kutjevo/exterior/complex_border/med_rec)
+"GP" = (
+/obj/structure/machinery/light{
+	dir = 8
+	},
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1"
+	},
+/turf/open/floor/kutjevo/colors/purple/inner_corner{
+	dir = 4
+	},
+/area/kutjevo/interior/construction)
+"Hd" = (
+/obj/effect/decal/cleanable/blood/gibs/limb,
+/turf/open/floor/kutjevo/colors/purple/edge{
+	dir = 5
+	},
+/area/kutjevo/interior/construction)
+"Hu" = (
+/obj/item/weapon/gun/smg/nailgun,
+/obj/effect/decal/cleanable/blood/gibs/down,
+/turf/open/floor/plating/kutjevo,
+/area/kutjevo/interior/construction)
+"HE" = (
+/turf/open/floor/kutjevo/colors/purple/edge{
+	dir = 4
+	},
+/area/kutjevo/interior/construction)
+"IB" = (
+/obj/structure/platform/kutjevo{
+	dir = 1
+	},
+/turf/open/auto_turf/sand/layer0,
+/area/kutjevo/exterior/complex_border/med_rec)
+"IR" = (
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_2"
+	},
+/turf/open/floor/kutjevo/colors/purple/inner_corner{
+	dir = 8
+	},
+/area/kutjevo/interior/construction)
+"Jj" = (
+/obj/structure/machinery/light,
+/turf/open/floor/kutjevo/colors/purple/edge,
+/area/kutjevo/interior/construction)
+"Jt" = (
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/kutjevo/tan,
+/area/kutjevo/interior/construction)
+"JV" = (
+/obj/structure/machinery/light{
+	dir = 4
+	},
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1"
+	},
+/turf/open/floor/kutjevo/colors/purple/inner_corner{
+	dir = 8
+	},
+/area/kutjevo/interior/construction)
+"Kd" = (
+/turf/open/floor/kutjevo/colors/orange/edge{
+	dir = 9
+	},
+/area/kutjevo/interior/foremans_office)
+"KH" = (
+/obj/structure/surface/table/almayer,
+/obj/item/storage/belt/medical/full{
+	pixel_x = 2;
+	pixel_y = 4
+	},
+/obj/item/storage/belt/medical/full,
+/turf/open/floor/kutjevo/colors/purple,
+/area/kutjevo/interior/construction)
+"KQ" = (
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/kutjevo/colors/purple/inner_corner{
+	dir = 1
+	},
+/area/kutjevo/interior/construction)
+"Lw" = (
+/obj/structure/largecrate/random/case/small,
+/obj/effect/spawner/random/toolbox{
+	pixel_x = -2;
+	pixel_y = 5
+	},
+/turf/open/floor/kutjevo/grey/plate,
+/area/kutjevo/interior/foremans_office)
+"Mb" = (
+/obj/effect/spawner/random/attachment,
+/turf/open/floor/kutjevo/colors/purple/edge{
+	dir = 4
+	},
+/area/kutjevo/interior/construction)
+"Me" = (
+/obj/structure/platform_decoration/kutjevo{
+	dir = 8
+	},
+/turf/open/auto_turf/sand/layer0,
+/area/kutjevo/exterior/complex_border/med_rec)
+"Ms" = (
+/obj/structure/sign/poster/clf,
+/turf/closed/wall/kutjevo/colony/reinforced,
+/area/kutjevo/interior/construction)
+"Nl" = (
+/obj/structure/machinery/cm_vending/sorted/medical/wall_med{
+	pixel_x = -28
+	},
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/kutjevo/colors/purple/edge{
+	dir = 8
+	},
+/area/kutjevo/interior/construction)
+"Ol" = (
+/obj/structure/machinery/power/apc{
+	dir = 1;
+	pixel_y = 24;
+	start_charge = 0
+	},
+/obj/structure/machinery/light{
+	dir = 4
+	},
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/kutjevo/colors/purple/inner_corner{
+	dir = 1
+	},
+/area/kutjevo/interior/construction)
+"Oq" = (
+/obj/effect/landmark/corpsespawner/doctor,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/kutjevo/tan,
+/area/kutjevo/interior/construction)
+"PP" = (
+/obj/structure/closet/crate/freezer/rations,
+/obj/item/defenses/handheld/tesla_coil,
+/turf/open/floor/kutjevo/colors/purple,
+/area/kutjevo/interior/construction)
+"Qc" = (
+/obj/structure/platform_decoration/kutjevo{
+	dir = 4
+	},
+/turf/open/floor/plating/kutjevo,
+/area/kutjevo/interior/foremans_office)
+"Qk" = (
+/obj/structure/platform/kutjevo{
+	dir = 1
+	},
+/obj/structure/platform/kutjevo{
+	dir = 4
+	},
+/turf/open/auto_turf/sand/layer0,
+/area/kutjevo/exterior/complex_border/med_rec)
+"QK" = (
+/turf/open/floor/kutjevo/grey/plate,
+/area/kutjevo/interior/construction)
+"QN" = (
+/obj/effect/spawner/random/attachment,
+/turf/open/floor/kutjevo/colors/purple/edge{
+	dir = 1
+	},
+/area/kutjevo/interior/construction)
+"QR" = (
+/obj/item/stack/rods,
+/turf/open/floor/plating/kutjevo,
+/area/kutjevo/interior/construction)
+"Rb" = (
+/obj/effect/spawner/random/attachment,
+/turf/open/floor/kutjevo/colors/purple,
+/area/kutjevo/interior/construction)
+"Rc" = (
+/turf/open/floor/kutjevo/colors/orange/edge{
+	dir = 8
+	},
+/area/kutjevo/interior/foremans_office)
+"Ri" = (
+/obj/effect/decal/cleanable/blood/oil,
+/obj/item/stack/cable_coil,
+/turf/open/floor/plating/kutjevo,
+/area/kutjevo/interior/foremans_office)
+"Ro" = (
+/turf/open/auto_turf/sand/layer1,
+/area/kutjevo/exterior/complex_border/med_rec)
+"RJ" = (
+/obj/structure/machinery/vending/cigarette/colony,
+/obj/structure/sign/poster{
+	pixel_y = 32
+	},
+/turf/open/floor/kutjevo/colors/purple/inner_corner{
+	dir = 1
+	},
+/area/kutjevo/interior/construction)
+"RN" = (
+/obj/structure/platform/kutjevo{
+	dir = 4
+	},
+/turf/open/floor/plating/kutjevo,
+/area/kutjevo/interior/foremans_office)
+"RP" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/turf/open/floor/kutjevo/tan,
+/area/kutjevo/interior/construction)
+"Si" = (
+/obj/structure/surface/table/almayer,
+/obj/effect/landmark/wo_supplies/storage/webbing{
+	pixel_y = 3;
+	pixel_x = 5
+	},
+/obj/effect/landmark/wo_supplies/storage/webbing{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/turf/open/floor/kutjevo/colors/purple,
+/area/kutjevo/interior/construction)
+"Sk" = (
+/obj/structure/surface/rack,
+/obj/item/tank/emergency_oxygen/engi,
+/turf/open/floor/kutjevo/grey/plate,
+/area/kutjevo/interior/foremans_office)
+"SI" = (
+/turf/closed/wall/kutjevo/colony/reinforced,
+/area/kutjevo/exterior/complex_border/med_rec)
+"Tb" = (
+/obj/item/stack/rods,
+/obj/effect/spawner/random/attachment,
+/turf/open/floor/kutjevo/colors/purple,
+/area/kutjevo/interior/construction)
+"Tv" = (
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1";
+	dir = 8
+	},
+/obj/effect/spawner/random/attachment,
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/kutjevo/colors/purple/edge{
+	dir = 8
+	},
+/area/kutjevo/interior/construction)
+"TK" = (
+/obj/item/stool{
+	pixel_y = 8
+	},
+/turf/open/floor/kutjevo/tan,
+/area/kutjevo/interior/construction)
+"Ua" = (
+/obj/structure/barricade/plasteel/wired{
+	dir = 8;
+	icon_state = "plasteel_closed_1"
+	},
+/turf/open/floor/kutjevo/colors/purple/edge{
+	dir = 8
+	},
+/area/kutjevo/interior/construction)
+"Un" = (
+/obj/item/reagent_container/food/drinks/bottle/vodka,
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_2"
+	},
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_2";
+	dir = 8
+	},
+/turf/open/floor/kutjevo/colors/purple/inner_corner{
+	dir = 4
+	},
+/area/kutjevo/interior/construction)
+"Us" = (
+/obj/structure/sign/poster/clf,
+/turf/closed/wall/kutjevo/colony/reinforced,
+/area/kutjevo/interior/foremans_office)
+"UP" = (
+/obj/structure/platform_decoration/kutjevo,
+/turf/open/floor/plating/kutjevo,
+/area/kutjevo/interior/foremans_office)
+"Ve" = (
+/obj/structure/machinery/door/airlock/almayer/maint/autoname{
+	dir = 1;
+	name = "\improper Null Hatch REPLACE ME";
+	req_access = null;
+	req_one_access = null
+	},
+/turf/open/floor/plating/kutjevo,
+/area/kutjevo/interior/foremans_office)
+"Vg" = (
+/obj/structure/machinery/cm_vending/sorted/boozeomat,
+/obj/structure/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/kutjevo/colors/purple/inner_corner,
+/area/kutjevo/interior/construction)
+"Vl" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/reagent_container/food/snacks/bigbiteburger,
+/turf/open/floor/kutjevo/colors/purple,
+/area/kutjevo/interior/construction)
+"Vu" = (
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/structure/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/kutjevo/grey/plate,
+/area/kutjevo/interior/construction)
+"VT" = (
+/obj/structure/largecrate/random/secure,
+/obj/structure/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/kutjevo/grey/plate,
+/area/kutjevo/interior/foremans_office)
+"Ww" = (
+/obj/structure/platform/kutjevo{
+	dir = 4
+	},
+/turf/open/auto_turf/sand/layer0,
+/area/kutjevo/exterior/complex_border/med_rec)
+"WL" = (
+/obj/structure/machinery/vending/coffee,
+/turf/open/floor/kutjevo/colors/purple/inner_corner{
+	dir = 1
+	},
+/area/kutjevo/interior/construction)
+"Xa" = (
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1";
+	dir = 8
+	},
+/obj/effect/landmark/corpsespawner/security/cmb,
+/obj/item/weapon/gun/shotgun/pump/cmb,
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/kutjevo/colors/purple/edge{
+	dir = 8
+	},
+/area/kutjevo/interior/construction)
+"Xb" = (
+/obj/structure/platform_decoration/kutjevo,
+/turf/open/floor/kutjevo/colors/purple/edge{
+	dir = 4
+	},
+/area/kutjevo/interior/construction)
+"XP" = (
+/turf/closed/wall/kutjevo/rock,
+/area/kutjevo/interior/colony_north)
+"XV" = (
+/obj/structure/platform_decoration/kutjevo{
+	dir = 4
+	},
+/turf/open/auto_turf/sand/layer0,
+/area/kutjevo/exterior/complex_border/med_rec)
+"Yg" = (
+/turf/open/auto_turf/sand/layer2,
+/area/kutjevo/interior/construction)
+"YJ" = (
+/obj/effect/landmark/corpsespawner/security/cmb,
+/obj/effect/decal/cleanable/blood,
+/obj/item/weapon/gun/shotgun/pump/cmb,
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/kutjevo/colors/purple/edge{
+	dir = 8
+	},
+/area/kutjevo/interior/construction)
+"YO" = (
+/obj/structure/flora/pottedplant{
+	icon_state = "pottedplant_30"
+	},
+/turf/open/floor/kutjevo/colors/purple,
+/area/kutjevo/interior/construction)
+"YP" = (
+/turf/closed/wall/kutjevo/colony,
+/area/kutjevo/interior/foremans_office)
+"YX" = (
+/obj/structure/surface/table/almayer,
+/obj/item/tool/weldingtool{
+	pixel_x = 6
+	},
+/obj/item/tool/weldingtool{
+	pixel_y = -9;
+	pixel_x = 11
+	},
+/obj/item/tool/weldpack{
+	pixel_y = 8
+	},
+/obj/item/tool/weldpack{
+	pixel_y = -6;
+	pixel_x = -8
+	},
+/obj/item/clothing/glasses/welding,
+/obj/item/clothing/glasses/welding{
+	pixel_y = 9;
+	pixel_x = -12
+	},
+/turf/open/floor/kutjevo/colors/purple,
+/area/kutjevo/interior/construction)
+"Zd" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/structure/machinery/computer/security{
+	dir = 1
+	},
+/turf/open/floor/kutjevo/colors/orange,
+/area/kutjevo/interior/foremans_office)
+"Zu" = (
+/turf/open/floor/kutjevo/colors/orange/inner_corner,
+/area/kutjevo/interior/foremans_office)
+"ZI" = (
+/obj/structure/surface/table/gamblingtable,
+/obj/item/ammo_magazine/shotgun/slugs{
+	pixel_x = 6;
+	pixel_y = -4
+	},
+/obj/item/ammo_magazine/shotgun/incendiary,
+/obj/item/ammo_magazine/shotgun/buckshot{
+	pixel_x = -10;
+	pixel_y = 5
+	},
+/obj/item/ammo_magazine/shotgun/buckshot{
+	pixel_x = -10;
+	pixel_y = 5
+	},
+/obj/item/ammo_magazine/shotgun/incendiary,
+/obj/item/ammo_magazine/shotgun/slugs{
+	pixel_x = 6;
+	pixel_y = -4
+	},
+/turf/open/floor/kutjevo/tan,
+/area/kutjevo/interior/construction)
+"ZS" = (
+/obj/structure/machinery/colony_floodlight{
+	pixel_y = 10
+	},
+/turf/open/floor/kutjevo/colors/purple,
+/area/kutjevo/interior/construction)
+"ZT" = (
+/obj/item/ammo_magazine/smg/nailgun,
+/turf/open/floor/kutjevo/grey/plate,
+/area/kutjevo/interior/construction)
+
+(1,1,1) = {"
+QK
+DE
+DE
+DE
+Ms
+fi
+hv
+hv
+hv
+fi
+Ms
+Ww
+Ww
+Ww
+fb
+Ro
+Ro
+"}
+(2,1,1) = {"
+uv
+rG
+ZT
+QR
+fi
+Vg
+ih
+Xa
+Tv
+GP
+hv
+br
+ER
+Un
+IB
+Ro
+Ro
+"}
+(3,1,1) = {"
+uv
+ZT
+Hu
+ZT
+fi
+QN
+TK
+TK
+TK
+Cx
+hv
+Fv
+hp
+tN
+IB
+Ro
+Ro
+"}
+(4,1,1) = {"
+fi
+hS
+bu
+hS
+fi
+Fv
+lL
+gy
+El
+Ed
+tW
+Fv
+sx
+ew
+hI
+ri
+Ro
+"}
+(5,1,1) = {"
+fi
+dx
+Tb
+ps
+fi
+Fv
+ZI
+qn
+cz
+Ed
+ln
+Fv
+sx
+nn
+fb
+Ro
+Ro
+"}
+(6,1,1) = {"
+fi
+xK
+sx
+sx
+ck
+uj
+TK
+TK
+TK
+Cx
+hv
+aG
+hp
+tN
+IB
+Ro
+Ro
+"}
+(7,1,1) = {"
+fi
+PP
+sx
+fa
+fi
+Ol
+Mb
+HE
+HE
+JV
+hv
+KQ
+HE
+IR
+IB
+Ro
+Ft
+"}
+(8,1,1) = {"
+fi
+fi
+ln
+fi
+fi
+fi
+fi
+Cm
+Cm
+fi
+fi
+hv
+hv
+Ms
+IB
+Ro
+Ft
+"}
+(9,1,1) = {"
+fi
+Vu
+xQ
+QK
+Rb
+xk
+YJ
+ih
+Ua
+Nl
+jr
+ih
+ad
+hv
+IB
+ri
+Ro
+"}
+(10,1,1) = {"
+fi
+ET
+wb
+QK
+sx
+Fv
+uc
+RP
+uc
+uc
+uc
+uc
+Cx
+hv
+Qk
+Me
+Ft
+"}
+(11,1,1) = {"
+fi
+ed
+sT
+Vl
+jM
+Fv
+uc
+ji
+dL
+KH
+jk
+or
+Jj
+Ms
+ZS
+IB
+Ro
+"}
+(12,1,1) = {"
+fi
+hv
+hv
+hv
+fi
+xY
+uc
+uc
+uc
+Oq
+uc
+Jt
+Ed
+it
+ep
+XV
+Ro
+"}
+(13,1,1) = {"
+QK
+QK
+QK
+DE
+cR
+uj
+uc
+Jt
+ac
+uc
+uc
+DU
+Ed
+ln
+cy
+wv
+FP
+"}
+(14,1,1) = {"
+DE
+Yg
+QK
+QK
+fi
+RJ
+Cp
+uc
+kX
+YX
+Si
+uc
+Jj
+Ms
+ZS
+ue
+Ro
+"}
+(15,1,1) = {"
+DE
+DE
+wE
+wE
+fi
+fi
+QN
+Hd
+uc
+uM
+uM
+uc
+io
+hv
+zt
+Gt
+iM
+"}
+(16,1,1) = {"
+QK
+uv
+XP
+XP
+XP
+fi
+rg
+WL
+Xb
+DX
+DX
+md
+dO
+hv
+ZS
+Dj
+EM
+"}
+(17,1,1) = {"
+XP
+XP
+XP
+XP
+XP
+oB
+oB
+oB
+oB
+YO
+zH
+oB
+oB
+Us
+oB
+oB
+SI
+"}
+(18,1,1) = {"
+XP
+XP
+XP
+XP
+XP
+oB
+VT
+Lw
+oB
+oB
+oB
+oB
+qZ
+Rc
+qP
+YP
+pe
+"}
+(19,1,1) = {"
+XP
+XP
+XP
+XP
+XP
+oB
+hq
+hq
+Qc
+jK
+Ve
+Zu
+Kd
+yc
+hJ
+mn
+ep
+"}
+(20,1,1) = {"
+XP
+XP
+XP
+XP
+XP
+oB
+jK
+UP
+RN
+RN
+mE
+hb
+Zd
+yc
+hJ
+Ri
+cy
+"}
+(21,1,1) = {"
+XP
+XP
+XP
+XP
+XP
+oB
+jK
+vo
+Sk
+wV
+YP
+hE
+dg
+xd
+jd
+YP
+pe
+"}
+(22,1,1) = {"
+XP
+XP
+XP
+XP
+XP
+oB
+wL
+wL
+YP
+YP
+YP
+nr
+nr
+nr
+nr
+oB
+SI
+"}

--- a/maps/map_files/Kutjevo/sprinkles/25.kutjevoclf01.dmm
+++ b/maps/map_files/Kutjevo/sprinkles/25.kutjevoclf01.dmm
@@ -20,6 +20,7 @@
 	},
 /area/kutjevo/interior/construction)
 <<<<<<< master
+<<<<<<< master
 "as" = (
 /obj/item/explosive/mine/clf/active{
 	dir = 8
@@ -30,6 +31,19 @@
 /area/kutjevo/interior/construction)
 =======
 >>>>>>> reimported backup
+=======
+"aA" = (
+/obj/structure/platform/kutjevo{
+	dir = 4
+	},
+/obj/structure/stairs/perspective/kutjevo{
+	dir = 4;
+	icon_state = "p_stair_sn_full_cap"
+	},
+/obj/item/explosive/mine/clf/active,
+/turf/open/floor/plating/kutjevo,
+/area/kutjevo/exterior/complex_border/med_rec)
+>>>>>>> updated all maps to have CLF Mines and corpses
 "aG" = (
 /obj/effect/landmark/corpsespawner/colonist,
 /obj/item/weapon/gun/pistol/holdout,
@@ -152,13 +166,19 @@
 	pixel_y = 7
 	},
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor/kutjevo/colors/purple,
 /area/kutjevo/interior/construction)
 "dO" = (
@@ -287,10 +307,14 @@
 /obj/effect/decal/cleanable/blood/oil,
 /obj/effect/decal/cleanable/ash,
 <<<<<<< master
+<<<<<<< master
 /obj/item/explosive/mine/clf/active,
 /obj/effect/landmark/survivor_spawner/clf/generic,
 =======
 >>>>>>> reimported backup
+=======
+/obj/item/explosive/mine/clf/active,
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor/plating/kutjevo,
 /area/kutjevo/interior/construction)
 "iM" = (
@@ -533,6 +557,16 @@
 /obj/effect/decal/cleanable/ash,
 /turf/open/floor/plating/kutjevo,
 /area/kutjevo/interior/construction)
+"ua" = (
+/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/decal/cleanable/ash,
+/obj/item/circuitboard/airlock,
+/obj/item/stack/cable_coil,
+/obj/item/explosive/mine/clf/active{
+	dir = 8
+	},
+/turf/open/floor/plating/kutjevo,
+/area/kutjevo/interior/construction)
 "uc" = (
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
@@ -651,6 +685,14 @@
 "yc" = (
 /turf/open/floor/kutjevo/colors/orange,
 /area/kutjevo/interior/foremans_office)
+"yk" = (
+/obj/item/explosive/mine/clf/active{
+	dir = 8
+	},
+/turf/open/floor/kutjevo/colors/purple/edge{
+	dir = 4
+	},
+/area/kutjevo/interior/construction)
 "zt" = (
 /obj/item/stack/sandbags/large_stack,
 /turf/open/floor/kutjevo/colors/purple,
@@ -816,6 +858,8 @@
 =======
 "FP" = (
 /obj/effect/landmark/corpsespawner/colonist,
+/obj/item/weapon/gun/pistol/holdout,
+/obj/effect/decal/cleanable/blood,
 /turf/open/auto_turf/sand/layer0,
 /area/kutjevo/exterior/complex_border/med_rec)
 >>>>>>> reimported backup
@@ -937,6 +981,13 @@
 /obj/structure/sign/poster/clf,
 /turf/closed/wall/kutjevo/colony/reinforced,
 /area/kutjevo/interior/construction)
+"MZ" = (
+/obj/structure/platform/kutjevo{
+	dir = 1
+	},
+/obj/item/explosive/mine/clf/active,
+/turf/open/auto_turf/sand/layer0,
+/area/kutjevo/exterior/complex_border/med_rec)
 "Nl" = (
 /obj/structure/machinery/cm_vending/sorted/medical/wall_med{
 	pixel_x = -28
@@ -971,6 +1022,14 @@
 /obj/effect/landmark/corpsespawner/doctor,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/kutjevo/tan,
+/area/kutjevo/interior/construction)
+"Pw" = (
+/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/decal/cleanable/ash,
+/obj/item/circuitboard/airlock,
+/obj/item/stack/cable_coil,
+/obj/item/explosive/mine/clf/active,
+/turf/open/floor/plating/kutjevo,
 /area/kutjevo/interior/construction)
 "PP" = (
 /obj/structure/closet/crate/freezer/rations,
@@ -1188,6 +1247,12 @@
 	},
 /turf/open/floor/kutjevo/grey/plate,
 /area/kutjevo/interior/foremans_office)
+"Wm" = (
+/obj/item/explosive/mine/clf/active,
+/turf/open/floor/kutjevo/colors/purple/edge{
+	dir = 1
+	},
+/area/kutjevo/interior/construction)
 "Ww" = (
 /obj/structure/platform/kutjevo{
 	dir = 4
@@ -1386,8 +1451,12 @@ TK
 TK
 Cx
 hv
+<<<<<<< master
 Fv
 >>>>>>> reimported backup
+=======
+Wm
+>>>>>>> updated all maps to have CLF Mines and corpses
 hp
 tN
 IB
@@ -1425,6 +1494,7 @@ qn
 cz
 Ed
 <<<<<<< master
+<<<<<<< master
 oo
 Fv
 sx
@@ -1432,6 +1502,9 @@ nn
 Yz
 =======
 ln
+=======
+Pw
+>>>>>>> updated all maps to have CLF Mines and corpses
 Fv
 sx
 nn
@@ -1486,10 +1559,14 @@ JV
 hv
 KQ
 <<<<<<< master
+<<<<<<< master
 as
 =======
 HE
 >>>>>>> reimported backup
+=======
+yk
+>>>>>>> updated all maps to have CLF Mines and corpses
 IR
 IB
 Ro
@@ -1499,10 +1576,14 @@ Ft
 fi
 fi
 <<<<<<< master
+<<<<<<< master
 lY
 =======
 ln
 >>>>>>> reimported backup
+=======
+ua
+>>>>>>> updated all maps to have CLF Mines and corpses
 fi
 fi
 fi
@@ -1538,10 +1619,14 @@ ih
 ad
 hv
 <<<<<<< master
+<<<<<<< master
 Sn
 =======
 IB
 >>>>>>> reimported backup
+=======
+MZ
+>>>>>>> updated all maps to have CLF Mines and corpses
 ri
 Ro
 "}
@@ -1642,10 +1727,14 @@ DU
 Ed
 ln
 <<<<<<< master
+<<<<<<< master
 FB
 =======
 cy
 >>>>>>> reimported backup
+=======
+aA
+>>>>>>> updated all maps to have CLF Mines and corpses
 wv
 FP
 "}

--- a/maps/map_files/Kutjevo/sprinkles/25.kutjevoclf01.dmm
+++ b/maps/map_files/Kutjevo/sprinkles/25.kutjevoclf01.dmm
@@ -1,7 +1,10 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "ac" = (
 /obj/effect/decal/cleanable/blood,
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
 "ad" = (
@@ -16,6 +19,7 @@
 	dir = 4
 	},
 /area/kutjevo/interior/construction)
+<<<<<<< master
 "as" = (
 /obj/item/explosive/mine/clf/active{
 	dir = 8
@@ -24,11 +28,16 @@
 	dir = 4
 	},
 /area/kutjevo/interior/construction)
+=======
+>>>>>>> reimported backup
 "aG" = (
 /obj/effect/landmark/corpsespawner/colonist,
 /obj/item/weapon/gun/pistol/holdout,
 /obj/effect/decal/cleanable/blood,
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/kutjevo/colors/purple/edge{
 	dir = 1
 	},
@@ -142,11 +151,14 @@
 /obj/item/storage/backpack/general_belt{
 	pixel_y = 7
 	},
+<<<<<<< master
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/kutjevo/colors/purple,
 /area/kutjevo/interior/construction)
 "dO" = (
@@ -199,6 +211,7 @@
 /turf/closed/wall/kutjevo/colony/reinforced,
 /area/kutjevo/interior/construction)
 <<<<<<< master
+<<<<<<< master
 "gw" = (
 /obj/item/stool{
 	pixel_y = 8
@@ -206,6 +219,8 @@
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
+=======
+>>>>>>> reimported backup
 =======
 >>>>>>> reimported backup
 "gy" = (
@@ -274,8 +289,11 @@
 "it" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/effect/decal/cleanable/ash,
+<<<<<<< master
 /obj/item/explosive/mine/clf/active,
 /obj/effect/landmark/survivor_spawner/clf/generic,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/plating/kutjevo,
 /area/kutjevo/interior/construction)
 "iM" = (
@@ -342,6 +360,7 @@
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
 <<<<<<< master
+<<<<<<< master
 "lY" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/effect/decal/cleanable/ash,
@@ -352,6 +371,8 @@
 	},
 /turf/open/floor/plating/kutjevo,
 /area/kutjevo/interior/construction)
+=======
+>>>>>>> reimported backup
 =======
 >>>>>>> reimported backup
 "md" = (
@@ -396,6 +417,7 @@
 /turf/open/floor/kutjevo/multi_tiles,
 /area/kutjevo/interior/foremans_office)
 <<<<<<< master
+<<<<<<< master
 "ns" = (
 /obj/item/explosive/mine/clf/active,
 /obj/effect/landmark/survivor_spawner/clf/generic,
@@ -413,6 +435,8 @@
 /area/kutjevo/interior/construction)
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> reimported backup
 "or" = (
 /obj/effect/landmark/corpsespawner/colonist,
 /obj/effect/decal/cleanable/blood,
@@ -424,11 +448,14 @@
 /turf/closed/wall/kutjevo/colony/reinforced,
 /area/kutjevo/interior/foremans_office)
 <<<<<<< master
+<<<<<<< master
 "oO" = (
 /obj/item/ammo_magazine/smg/nailgun,
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/kutjevo/grey/plate,
 /area/kutjevo/interior/construction)
+=======
+>>>>>>> reimported backup
 "pe" = (
 /obj/structure/machinery/colony_floodlight{
 	pixel_y = 10
@@ -543,7 +570,10 @@
 	dir = 8;
 	tag = "icon-chair (WEST)"
 	},
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
 "vo" = (
@@ -554,7 +584,10 @@
 /obj/effect/decal/cleanable/blood,
 /obj/item/weapon/gun/pistol/holdout,
 /obj/effect/landmark/corpsespawner/chef,
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/kutjevo/grey/plate,
 /area/kutjevo/interior/construction)
 "wv" = (
@@ -769,6 +802,7 @@
 	},
 /area/kutjevo/interior/construction)
 <<<<<<< master
+<<<<<<< master
 "FB" = (
 /obj/structure/platform/kutjevo{
 	dir = 4
@@ -791,10 +825,15 @@
 /turf/open/floor/kutjevo/grey/plate,
 /area/kutjevo/interior/construction)
 =======
+=======
+>>>>>>> reimported backup
 "FP" = (
 /obj/effect/landmark/corpsespawner/colonist,
 /turf/open/auto_turf/sand/layer0,
 /area/kutjevo/exterior/complex_border/med_rec)
+<<<<<<< master
+>>>>>>> reimported backup
+=======
 >>>>>>> reimported backup
 "Gt" = (
 /obj/structure/platform/kutjevo{
@@ -837,10 +876,13 @@
 /turf/open/auto_turf/sand/layer0,
 /area/kutjevo/exterior/complex_border/med_rec)
 <<<<<<< master
+<<<<<<< master
 "ID" = (
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/kutjevo/colors/purple,
 /area/kutjevo/interior/construction)
+=======
+>>>>>>> reimported backup
 "IR" = (
 /obj/structure/barricade/metal/wired{
 	icon_state = "metal_2"
@@ -936,10 +978,13 @@
 	},
 /area/kutjevo/interior/construction)
 <<<<<<< master
+<<<<<<< master
 "Op" = (
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
+=======
+>>>>>>> reimported backup
 =======
 >>>>>>> reimported backup
 "Oq" = (
@@ -1016,7 +1061,10 @@
 /obj/structure/bed/chair{
 	dir = 4
 	},
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
 "Si" = (
@@ -1037,6 +1085,7 @@
 /turf/open/floor/kutjevo/grey/plate,
 /area/kutjevo/interior/foremans_office)
 <<<<<<< master
+<<<<<<< master
 "Sn" = (
 /obj/structure/platform/kutjevo{
 	dir = 1
@@ -1046,13 +1095,18 @@
 /area/kutjevo/exterior/complex_border/med_rec)
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> reimported backup
 "SI" = (
 /turf/closed/wall/kutjevo/colony/reinforced,
 /area/kutjevo/exterior/complex_border/med_rec)
 "Tb" = (
 /obj/item/stack/rods,
 /obj/effect/spawner/random/attachment,
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/kutjevo/colors/purple,
 /area/kutjevo/interior/construction)
 "Tv" = (
@@ -1066,6 +1120,15 @@
 	dir = 8
 	},
 /area/kutjevo/interior/construction)
+<<<<<<< master
+=======
+"TK" = (
+/obj/item/stool{
+	pixel_y = 8
+	},
+/turf/open/floor/kutjevo/tan,
+/area/kutjevo/interior/construction)
+>>>>>>> reimported backup
 "Ua" = (
 /obj/structure/barricade/plasteel/wired{
 	dir = 8;
@@ -1093,6 +1156,7 @@
 /turf/closed/wall/kutjevo/colony/reinforced,
 /area/kutjevo/interior/foremans_office)
 <<<<<<< master
+<<<<<<< master
 "UD" = (
 /obj/structure/barricade/metal/wired{
 	icon_state = "metal_2"
@@ -1102,15 +1166,20 @@
 /area/kutjevo/interior/construction)
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> reimported backup
 "UP" = (
 /obj/structure/platform_decoration/kutjevo,
 /turf/open/floor/plating/kutjevo,
 /area/kutjevo/interior/foremans_office)
 <<<<<<< master
+<<<<<<< master
 "UU" = (
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/auto_turf/sand/layer0,
 /area/kutjevo/exterior/complex_border/med_rec)
+=======
+>>>>>>> reimported backup
 "Ve" = (
 /obj/structure/machinery/door/airlock/almayer/maint/autoname{
 	dir = 1;
@@ -1189,6 +1258,7 @@
 /turf/open/auto_turf/sand/layer2,
 /area/kutjevo/interior/construction)
 <<<<<<< master
+<<<<<<< master
 "Yz" = (
 /obj/structure/platform_decoration/kutjevo{
 	dir = 8
@@ -1196,6 +1266,8 @@
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/auto_turf/sand/layer1,
 /area/kutjevo/exterior/complex_border/med_rec)
+=======
+>>>>>>> reimported backup
 "YJ" = (
 /obj/effect/landmark/corpsespawner/security/cmb,
 /obj/effect/decal/cleanable/blood,
@@ -1302,7 +1374,11 @@ Ro
 (2,1,1) = {"
 uv
 rG
+<<<<<<< master
 oO
+=======
+ZT
+>>>>>>> reimported backup
 QR
 fi
 Vg
@@ -1325,12 +1401,21 @@ Hu
 ZT
 fi
 QN
+<<<<<<< master
 gw
 gw
 gw
 Cx
 hv
 ns
+=======
+TK
+TK
+TK
+Cx
+hv
+Fv
+>>>>>>> reimported backup
 hp
 tN
 IB
@@ -1367,11 +1452,19 @@ ZI
 qn
 cz
 Ed
+<<<<<<< master
 oo
 Fv
 sx
 nn
 Yz
+=======
+ln
+Fv
+sx
+nn
+fb
+>>>>>>> reimported backup
 Ro
 Ro
 "}
@@ -1379,17 +1472,30 @@ Ro
 fi
 xK
 sx
+<<<<<<< master
 ID
 ck
 uj
 gw
 gw
 gw
+=======
+sx
+ck
+uj
+TK
+TK
+TK
+>>>>>>> reimported backup
 Cx
 hv
 aG
 hp
+<<<<<<< master
 UD
+=======
+tN
+>>>>>>> reimported backup
 IB
 Ro
 Ro
@@ -1407,7 +1513,11 @@ HE
 JV
 hv
 KQ
+<<<<<<< master
 as
+=======
+HE
+>>>>>>> reimported backup
 IR
 IB
 Ro
@@ -1416,7 +1526,11 @@ Ft
 (8,1,1) = {"
 fi
 fi
+<<<<<<< master
 lY
+=======
+ln
+>>>>>>> reimported backup
 fi
 fi
 fi
@@ -1436,7 +1550,11 @@ Ft
 fi
 Vu
 xQ
+<<<<<<< master
 FX
+=======
+QK
+>>>>>>> reimported backup
 Rb
 xk
 YJ
@@ -1447,7 +1565,11 @@ jr
 ih
 ad
 hv
+<<<<<<< master
 Sn
+=======
+IB
+>>>>>>> reimported backup
 ri
 Ro
 "}
@@ -1456,19 +1578,31 @@ fi
 ET
 wb
 QK
+<<<<<<< master
 ID
+=======
+sx
+>>>>>>> reimported backup
 Fv
 uc
 RP
 uc
 uc
+<<<<<<< master
 Op
+=======
+uc
+>>>>>>> reimported backup
 uc
 Cx
 hv
 Qk
 Me
+<<<<<<< master
 UU
+=======
+Ft
+>>>>>>> reimported backup
 "}
 (11,1,1) = {"
 fi
@@ -1477,7 +1611,11 @@ sT
 Vl
 jM
 Fv
+<<<<<<< master
 Op
+=======
+uc
+>>>>>>> reimported backup
 ji
 dL
 KH
@@ -1500,7 +1638,11 @@ uc
 uc
 uc
 Oq
+<<<<<<< master
 Op
+=======
+uc
+>>>>>>> reimported backup
 Jt
 Ed
 it
@@ -1515,7 +1657,11 @@ QK
 DE
 cR
 uj
+<<<<<<< master
 Op
+=======
+uc
+>>>>>>> reimported backup
 Jt
 ac
 uc
@@ -1523,7 +1669,11 @@ uc
 DU
 Ed
 ln
+<<<<<<< master
 FB
+=======
+cy
+>>>>>>> reimported backup
 wv
 FP
 "}
@@ -1535,7 +1685,11 @@ QK
 fi
 RJ
 Cp
+<<<<<<< master
 Op
+=======
+uc
+>>>>>>> reimported backup
 kX
 YX
 Si
@@ -1558,7 +1712,11 @@ Hd
 uc
 uM
 uM
+<<<<<<< master
 Op
+=======
+uc
+>>>>>>> reimported backup
 io
 hv
 zt

--- a/maps/map_files/Kutjevo/sprinkles/25.kutjevoclf01.dmm
+++ b/maps/map_files/Kutjevo/sprinkles/25.kutjevoclf01.dmm
@@ -19,17 +19,17 @@
 	dir = 4
 	},
 /area/kutjevo/interior/construction)
-<<<<<<< master
-"as" = (
-/obj/item/explosive/mine/clf/active{
-	dir = 8
-	},
-/turf/open/floor/kutjevo/colors/purple/edge{
+"aA" = (
+/obj/structure/platform/kutjevo{
 	dir = 4
 	},
-/area/kutjevo/interior/construction)
-=======
->>>>>>> reimported backup
+/obj/structure/stairs/perspective/kutjevo{
+	dir = 4;
+	icon_state = "p_stair_sn_full_cap"
+	},
+/obj/item/explosive/mine/clf/active,
+/turf/open/floor/plating/kutjevo,
+/area/kutjevo/exterior/complex_border/med_rec)
 "aG" = (
 /obj/effect/landmark/corpsespawner/colonist,
 /obj/item/weapon/gun/pistol/holdout,
@@ -151,14 +151,11 @@
 /obj/item/storage/backpack/general_belt{
 	pixel_y = 7
 	},
-<<<<<<< master
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
-=======
->>>>>>> reimported backup
 /turf/open/floor/kutjevo/colors/purple,
 /area/kutjevo/interior/construction)
 "dO" = (
@@ -286,11 +283,7 @@
 "it" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/effect/decal/cleanable/ash,
-<<<<<<< master
 /obj/item/explosive/mine/clf/active,
-/obj/effect/landmark/survivor_spawner/clf/generic,
-=======
->>>>>>> reimported backup
 /turf/open/floor/plating/kutjevo,
 /area/kutjevo/interior/construction)
 "iM" = (
@@ -533,6 +526,16 @@
 /obj/effect/decal/cleanable/ash,
 /turf/open/floor/plating/kutjevo,
 /area/kutjevo/interior/construction)
+"ua" = (
+/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/decal/cleanable/ash,
+/obj/item/circuitboard/airlock,
+/obj/item/stack/cable_coil,
+/obj/item/explosive/mine/clf/active{
+	dir = 8
+	},
+/turf/open/floor/plating/kutjevo,
+/area/kutjevo/interior/construction)
 "uc" = (
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
@@ -651,6 +654,14 @@
 "yc" = (
 /turf/open/floor/kutjevo/colors/orange,
 /area/kutjevo/interior/foremans_office)
+"yk" = (
+/obj/item/explosive/mine/clf/active{
+	dir = 8
+	},
+/turf/open/floor/kutjevo/colors/purple/edge{
+	dir = 4
+	},
+/area/kutjevo/interior/construction)
 "zt" = (
 /obj/item/stack/sandbags/large_stack,
 /turf/open/floor/kutjevo/colors/purple,
@@ -937,6 +948,13 @@
 /obj/structure/sign/poster/clf,
 /turf/closed/wall/kutjevo/colony/reinforced,
 /area/kutjevo/interior/construction)
+"MZ" = (
+/obj/structure/platform/kutjevo{
+	dir = 1
+	},
+/obj/item/explosive/mine/clf/active,
+/turf/open/auto_turf/sand/layer0,
+/area/kutjevo/exterior/complex_border/med_rec)
 "Nl" = (
 /obj/structure/machinery/cm_vending/sorted/medical/wall_med{
 	pixel_x = -28
@@ -971,6 +989,14 @@
 /obj/effect/landmark/corpsespawner/doctor,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/kutjevo/tan,
+/area/kutjevo/interior/construction)
+"Pw" = (
+/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/decal/cleanable/ash,
+/obj/item/circuitboard/airlock,
+/obj/item/stack/cable_coil,
+/obj/item/explosive/mine/clf/active,
+/turf/open/floor/plating/kutjevo,
 /area/kutjevo/interior/construction)
 "PP" = (
 /obj/structure/closet/crate/freezer/rations,
@@ -1188,6 +1214,12 @@
 	},
 /turf/open/floor/kutjevo/grey/plate,
 /area/kutjevo/interior/foremans_office)
+"Wm" = (
+/obj/item/explosive/mine/clf/active,
+/turf/open/floor/kutjevo/colors/purple/edge{
+	dir = 1
+	},
+/area/kutjevo/interior/construction)
 "Ww" = (
 /obj/structure/platform/kutjevo{
 	dir = 4
@@ -1386,8 +1418,7 @@ TK
 TK
 Cx
 hv
-Fv
->>>>>>> reimported backup
+Wm
 hp
 tN
 IB
@@ -1424,14 +1455,7 @@ ZI
 qn
 cz
 Ed
-<<<<<<< master
-oo
-Fv
-sx
-nn
-Yz
-=======
-ln
+Pw
 Fv
 sx
 nn
@@ -1485,11 +1509,7 @@ HE
 JV
 hv
 KQ
-<<<<<<< master
-as
-=======
-HE
->>>>>>> reimported backup
+yk
 IR
 IB
 Ro
@@ -1498,11 +1518,7 @@ Ft
 (8,1,1) = {"
 fi
 fi
-<<<<<<< master
-lY
-=======
-ln
->>>>>>> reimported backup
+ua
 fi
 fi
 fi
@@ -1537,11 +1553,7 @@ jr
 ih
 ad
 hv
-<<<<<<< master
-Sn
-=======
-IB
->>>>>>> reimported backup
+MZ
 ri
 Ro
 "}
@@ -1641,11 +1653,7 @@ uc
 DU
 Ed
 ln
-<<<<<<< master
-FB
-=======
-cy
->>>>>>> reimported backup
+aA
 wv
 FP
 "}

--- a/maps/map_files/Kutjevo/sprinkles/25.kutjevoclf01.dmm
+++ b/maps/map_files/Kutjevo/sprinkles/25.kutjevoclf01.dmm
@@ -1,10 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "ac" = (
 /obj/effect/decal/cleanable/blood,
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
-=======
->>>>>>> reimported backup
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
 "ad" = (
@@ -23,7 +20,6 @@
 /obj/item/explosive/mine/clf/active{
 	dir = 8
 	},
-/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/kutjevo/colors/purple/edge{
 	dir = 4
 	},
@@ -32,10 +28,7 @@
 /obj/effect/landmark/corpsespawner/colonist,
 /obj/item/weapon/gun/pistol/holdout,
 /obj/effect/decal/cleanable/blood,
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
-=======
->>>>>>> reimported backup
 /turf/open/floor/kutjevo/colors/purple/edge{
 	dir = 1
 	},
@@ -282,6 +275,7 @@
 /obj/effect/decal/cleanable/blood/oil,
 /obj/effect/decal/cleanable/ash,
 /obj/item/explosive/mine/clf/active,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/plating/kutjevo,
 /area/kutjevo/interior/construction)
 "iM" = (
@@ -365,7 +359,6 @@
 	dir = 8
 	},
 /obj/effect/spawner/random/attachment,
-/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/kutjevo/colors/purple/edge{
 	dir = 4
 	},
@@ -436,8 +429,6 @@
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/kutjevo/grey/plate,
 /area/kutjevo/interior/construction)
-=======
->>>>>>> reimported backup
 "pe" = (
 /obj/structure/machinery/colony_floodlight{
 	pixel_y = 10
@@ -552,10 +543,7 @@
 	dir = 8;
 	tag = "icon-chair (WEST)"
 	},
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
-=======
->>>>>>> reimported backup
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
 "vo" = (
@@ -566,10 +554,7 @@
 /obj/effect/decal/cleanable/blood,
 /obj/item/weapon/gun/pistol/holdout,
 /obj/effect/landmark/corpsespawner/chef,
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
-=======
->>>>>>> reimported backup
 /turf/open/floor/kutjevo/grey/plate,
 /area/kutjevo/interior/construction)
 "wv" = (
@@ -684,7 +669,6 @@
 /area/kutjevo/interior/construction)
 "DU" = (
 /obj/effect/spawner/random/attachment,
-/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
 "DX" = (
@@ -832,7 +816,6 @@
 /area/kutjevo/interior/construction)
 "Hd" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
-/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/kutjevo/colors/purple/edge{
 	dir = 5
 	},
@@ -858,8 +841,6 @@
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/kutjevo/colors/purple,
 /area/kutjevo/interior/construction)
-=======
->>>>>>> reimported backup
 "IR" = (
 /obj/structure/barricade/metal/wired{
 	icon_state = "metal_2"
@@ -1001,7 +982,6 @@
 /area/kutjevo/interior/construction)
 "Rb" = (
 /obj/effect/spawner/random/attachment,
-/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/kutjevo/colors/purple,
 /area/kutjevo/interior/construction)
 "Rc" = (
@@ -1036,10 +1016,7 @@
 /obj/structure/bed/chair{
 	dir = 4
 	},
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
-=======
->>>>>>> reimported backup
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
 "Si" = (
@@ -1075,10 +1052,7 @@
 "Tb" = (
 /obj/item/stack/rods,
 /obj/effect/spawner/random/attachment,
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
-=======
->>>>>>> reimported backup
 /turf/open/floor/kutjevo/colors/purple,
 /area/kutjevo/interior/construction)
 "Tv" = (
@@ -1092,16 +1066,6 @@
 	dir = 8
 	},
 /area/kutjevo/interior/construction)
-<<<<<<< master
-=======
-"TK" = (
-/obj/item/stool{
-	pixel_y = 8
-	},
-/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-/turf/open/floor/kutjevo/tan,
-/area/kutjevo/interior/construction)
->>>>>>> reimported backup
 "Ua" = (
 /obj/structure/barricade/plasteel/wired{
 	dir = 8;
@@ -1147,8 +1111,6 @@
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/auto_turf/sand/layer0,
 /area/kutjevo/exterior/complex_border/med_rec)
-=======
->>>>>>> reimported backup
 "Ve" = (
 /obj/structure/machinery/door/airlock/almayer/maint/autoname{
 	dir = 1;
@@ -1234,8 +1196,6 @@
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/auto_turf/sand/layer1,
 /area/kutjevo/exterior/complex_border/med_rec)
-=======
->>>>>>> reimported backup
 "YJ" = (
 /obj/effect/landmark/corpsespawner/security/cmb,
 /obj/effect/decal/cleanable/blood,
@@ -1324,7 +1284,7 @@
 QK
 DE
 DE
-Yz
+DE
 Ms
 fi
 hv
@@ -1342,11 +1302,7 @@ Ro
 (2,1,1) = {"
 uv
 rG
-<<<<<<< master
 oO
-=======
-ZT
->>>>>>> reimported backup
 QR
 fi
 Vg
@@ -1369,21 +1325,13 @@ Hu
 ZT
 fi
 QN
-<<<<<<< master
 gw
 gw
 gw
 Cx
 hv
 ns
-=======
-TK
-gw
-TK
-Cx
-hv
-ns
-FX
+hp
 tN
 IB
 Ro
@@ -1423,8 +1371,7 @@ oo
 Fv
 sx
 nn
-fb
->>>>>>> reimported backup
+Yz
 Ro
 Ro
 "}
@@ -1432,32 +1379,19 @@ Ro
 fi
 xK
 sx
-<<<<<<< master
 ID
 ck
 uj
 gw
 gw
 gw
-=======
-sx
-ck
-uj
-TK
-TK
-TK
->>>>>>> reimported backup
 Cx
 hv
 aG
 hp
-<<<<<<< master
 UD
-=======
-tN
->>>>>>> reimported backup
 IB
-ID
+Ro
 Ro
 "}
 (7,1,1) = {"
@@ -1502,11 +1436,7 @@ Ft
 fi
 Vu
 xQ
-<<<<<<< master
 FX
-=======
-QK
->>>>>>> reimported backup
 Rb
 xk
 YJ
@@ -1526,33 +1456,19 @@ fi
 ET
 wb
 QK
-<<<<<<< master
 ID
-=======
-sx
->>>>>>> reimported backup
 Fv
-Op
+uc
 RP
-Op
-Op
 uc
 uc
-<<<<<<< master
 Op
-=======
-uc
->>>>>>> reimported backup
 uc
 Cx
 hv
 Qk
 Me
-<<<<<<< master
 UU
-=======
-Ft
->>>>>>> reimported backup
 "}
 (11,1,1) = {"
 fi
@@ -1561,11 +1477,7 @@ sT
 Vl
 jM
 Fv
-<<<<<<< master
 Op
-=======
-uc
->>>>>>> reimported backup
 ji
 dL
 KH
@@ -1574,7 +1486,7 @@ or
 Jj
 Ms
 ZS
-oO
+IB
 Ro
 "}
 (12,1,1) = {"
@@ -1584,15 +1496,11 @@ hv
 hv
 fi
 xY
-Op
+uc
 uc
 uc
 Oq
-<<<<<<< master
 Op
-=======
-uc
->>>>>>> reimported backup
 Jt
 Ed
 it
@@ -1607,11 +1515,7 @@ QK
 DE
 cR
 uj
-<<<<<<< master
 Op
-=======
-uc
->>>>>>> reimported backup
 Jt
 ac
 uc
@@ -1631,16 +1535,12 @@ QK
 fi
 RJ
 Cp
-<<<<<<< master
 Op
-=======
-uc
->>>>>>> reimported backup
 kX
 YX
 Si
 uc
-UD
+Jj
 Ms
 ZS
 ue
@@ -1658,11 +1558,7 @@ Hd
 uc
 uM
 uM
-<<<<<<< master
 Op
-=======
-uc
->>>>>>> reimported backup
 io
 hv
 zt

--- a/maps/map_files/Kutjevo/sprinkles/25.kutjevoclf01.dmm
+++ b/maps/map_files/Kutjevo/sprinkles/25.kutjevoclf01.dmm
@@ -1,7 +1,10 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "ac" = (
 /obj/effect/decal/cleanable/blood,
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
 "ad" = (
@@ -16,6 +19,7 @@
 	dir = 4
 	},
 /area/kutjevo/interior/construction)
+<<<<<<< master
 "as" = (
 /obj/item/explosive/mine/clf/active{
 	dir = 8
@@ -24,11 +28,16 @@
 	dir = 4
 	},
 /area/kutjevo/interior/construction)
+=======
+>>>>>>> reimported backup
 "aG" = (
 /obj/effect/landmark/corpsespawner/colonist,
 /obj/item/weapon/gun/pistol/holdout,
 /obj/effect/decal/cleanable/blood,
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/kutjevo/colors/purple/edge{
 	dir = 1
 	},
@@ -201,6 +210,7 @@
 "fi" = (
 /turf/closed/wall/kutjevo/colony/reinforced,
 /area/kutjevo/interior/construction)
+<<<<<<< master
 "gw" = (
 /obj/item/stool{
 	pixel_y = 8
@@ -208,6 +218,8 @@
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
+=======
+>>>>>>> reimported backup
 "gy" = (
 /obj/structure/surface/table/gamblingtable,
 /obj/item/weapon/gun/rifle/mar40/lmg,
@@ -277,6 +289,8 @@
 <<<<<<< master
 /obj/item/explosive/mine/clf/active,
 /obj/effect/landmark/survivor_spawner/clf/generic,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/plating/kutjevo,
 /area/kutjevo/interior/construction)
 "iM" = (
@@ -342,6 +356,7 @@
 /obj/item/paper_bin,
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
+<<<<<<< master
 "lY" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/effect/decal/cleanable/ash,
@@ -352,6 +367,8 @@
 	},
 /turf/open/floor/plating/kutjevo,
 /area/kutjevo/interior/construction)
+=======
+>>>>>>> reimported backup
 "md" = (
 /obj/structure/platform_decoration/kutjevo{
 	dir = 8
@@ -393,6 +410,7 @@
 /obj/structure/window_frame/kutjevo/reinforced,
 /turf/open/floor/kutjevo/multi_tiles,
 /area/kutjevo/interior/foremans_office)
+<<<<<<< master
 "ns" = (
 /obj/item/explosive/mine/clf/active,
 /obj/effect/landmark/survivor_spawner/clf/generic,
@@ -408,6 +426,8 @@
 /obj/item/explosive/mine/clf/active,
 /turf/open/floor/plating/kutjevo,
 /area/kutjevo/interior/construction)
+=======
+>>>>>>> reimported backup
 "or" = (
 /obj/effect/landmark/corpsespawner/colonist,
 /obj/effect/decal/cleanable/blood,
@@ -418,11 +438,14 @@
 "oB" = (
 /turf/closed/wall/kutjevo/colony/reinforced,
 /area/kutjevo/interior/foremans_office)
+<<<<<<< master
 "oO" = (
 /obj/item/ammo_magazine/smg/nailgun,
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/kutjevo/grey/plate,
 /area/kutjevo/interior/construction)
+=======
+>>>>>>> reimported backup
 "pe" = (
 /obj/structure/machinery/colony_floodlight{
 	pixel_y = 10
@@ -537,7 +560,10 @@
 	dir = 8;
 	tag = "icon-chair (WEST)"
 	},
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
 "vo" = (
@@ -548,7 +574,10 @@
 /obj/effect/decal/cleanable/blood,
 /obj/item/weapon/gun/pistol/holdout,
 /obj/effect/landmark/corpsespawner/chef,
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/kutjevo/grey/plate,
 /area/kutjevo/interior/construction)
 "wv" = (
@@ -762,6 +791,7 @@
 	dir = 1
 	},
 /area/kutjevo/interior/construction)
+<<<<<<< master
 "FB" = (
 /obj/structure/platform/kutjevo{
 	dir = 4
@@ -783,6 +813,12 @@
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/kutjevo/grey/plate,
 /area/kutjevo/interior/construction)
+=======
+"FP" = (
+/obj/effect/landmark/corpsespawner/colonist,
+/turf/open/auto_turf/sand/layer0,
+/area/kutjevo/exterior/complex_border/med_rec)
+>>>>>>> reimported backup
 "Gt" = (
 /obj/structure/platform/kutjevo{
 	dir = 1
@@ -823,10 +859,13 @@
 	},
 /turf/open/auto_turf/sand/layer0,
 /area/kutjevo/exterior/complex_border/med_rec)
+<<<<<<< master
 "ID" = (
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/kutjevo/colors/purple,
 /area/kutjevo/interior/construction)
+=======
+>>>>>>> reimported backup
 "IR" = (
 /obj/structure/barricade/metal/wired{
 	icon_state = "metal_2"
@@ -921,10 +960,13 @@
 	dir = 1
 	},
 /area/kutjevo/interior/construction)
+<<<<<<< master
 "Op" = (
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
+=======
+>>>>>>> reimported backup
 "Oq" = (
 /obj/effect/landmark/corpsespawner/doctor,
 /obj/effect/decal/cleanable/blood,
@@ -999,7 +1041,10 @@
 /obj/structure/bed/chair{
 	dir = 4
 	},
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
 "Si" = (
@@ -1019,6 +1064,7 @@
 /obj/item/tank/emergency_oxygen/engi,
 /turf/open/floor/kutjevo/grey/plate,
 /area/kutjevo/interior/foremans_office)
+<<<<<<< master
 "Sn" = (
 /obj/structure/platform/kutjevo{
 	dir = 1
@@ -1026,13 +1072,18 @@
 /obj/item/explosive/mine/clf/active,
 /turf/open/auto_turf/sand/layer0,
 /area/kutjevo/exterior/complex_border/med_rec)
+=======
+>>>>>>> reimported backup
 "SI" = (
 /turf/closed/wall/kutjevo/colony/reinforced,
 /area/kutjevo/exterior/complex_border/med_rec)
 "Tb" = (
 /obj/item/stack/rods,
 /obj/effect/spawner/random/attachment,
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/kutjevo/colors/purple,
 /area/kutjevo/interior/construction)
 "Tv" = (
@@ -1046,6 +1097,15 @@
 	dir = 8
 	},
 /area/kutjevo/interior/construction)
+<<<<<<< master
+=======
+"TK" = (
+/obj/item/stool{
+	pixel_y = 8
+	},
+/turf/open/floor/kutjevo/tan,
+/area/kutjevo/interior/construction)
+>>>>>>> reimported backup
 "Ua" = (
 /obj/structure/barricade/plasteel/wired{
 	dir = 8;
@@ -1072,6 +1132,7 @@
 /obj/structure/sign/poster/clf,
 /turf/closed/wall/kutjevo/colony/reinforced,
 /area/kutjevo/interior/foremans_office)
+<<<<<<< master
 "UD" = (
 /obj/structure/barricade/metal/wired{
 	icon_state = "metal_2"
@@ -1079,14 +1140,19 @@
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/kutjevo/colors/purple/edge,
 /area/kutjevo/interior/construction)
+=======
+>>>>>>> reimported backup
 "UP" = (
 /obj/structure/platform_decoration/kutjevo,
 /turf/open/floor/plating/kutjevo,
 /area/kutjevo/interior/foremans_office)
+<<<<<<< master
 "UU" = (
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/auto_turf/sand/layer0,
 /area/kutjevo/exterior/complex_border/med_rec)
+=======
+>>>>>>> reimported backup
 "Ve" = (
 /obj/structure/machinery/door/airlock/almayer/maint/autoname{
 	dir = 1;
@@ -1164,6 +1230,7 @@
 "Yg" = (
 /turf/open/auto_turf/sand/layer2,
 /area/kutjevo/interior/construction)
+<<<<<<< master
 "Yz" = (
 /obj/structure/platform_decoration/kutjevo{
 	dir = 8
@@ -1171,6 +1238,8 @@
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/auto_turf/sand/layer1,
 /area/kutjevo/exterior/complex_border/med_rec)
+=======
+>>>>>>> reimported backup
 "YJ" = (
 /obj/effect/landmark/corpsespawner/security/cmb,
 /obj/effect/decal/cleanable/blood,
@@ -1277,7 +1346,11 @@ Ro
 (2,1,1) = {"
 uv
 rG
+<<<<<<< master
 oO
+=======
+ZT
+>>>>>>> reimported backup
 QR
 fi
 Vg
@@ -1300,12 +1373,21 @@ Hu
 ZT
 fi
 QN
+<<<<<<< master
 gw
 gw
 gw
 Cx
 hv
 ns
+=======
+TK
+TK
+TK
+Cx
+hv
+Fv
+>>>>>>> reimported backup
 hp
 tN
 IB
@@ -1342,11 +1424,19 @@ ZI
 qn
 cz
 Ed
+<<<<<<< master
 oo
 Fv
 sx
 nn
 Yz
+=======
+ln
+Fv
+sx
+nn
+fb
+>>>>>>> reimported backup
 Ro
 Ro
 "}
@@ -1354,17 +1444,30 @@ Ro
 fi
 xK
 sx
+<<<<<<< master
 ID
 ck
 uj
 gw
 gw
 gw
+=======
+sx
+ck
+uj
+TK
+TK
+TK
+>>>>>>> reimported backup
 Cx
 hv
 aG
 hp
+<<<<<<< master
 UD
+=======
+tN
+>>>>>>> reimported backup
 IB
 Ro
 Ro
@@ -1382,7 +1485,11 @@ HE
 JV
 hv
 KQ
+<<<<<<< master
 as
+=======
+HE
+>>>>>>> reimported backup
 IR
 IB
 Ro
@@ -1391,7 +1498,11 @@ Ft
 (8,1,1) = {"
 fi
 fi
+<<<<<<< master
 lY
+=======
+ln
+>>>>>>> reimported backup
 fi
 fi
 fi
@@ -1411,7 +1522,11 @@ Ft
 fi
 Vu
 xQ
+<<<<<<< master
 FX
+=======
+QK
+>>>>>>> reimported backup
 Rb
 xk
 YJ
@@ -1422,7 +1537,11 @@ jr
 ih
 ad
 hv
+<<<<<<< master
 Sn
+=======
+IB
+>>>>>>> reimported backup
 ri
 Ro
 "}
@@ -1431,19 +1550,31 @@ fi
 ET
 wb
 QK
+<<<<<<< master
 ID
+=======
+sx
+>>>>>>> reimported backup
 Fv
 uc
 RP
 uc
 uc
+<<<<<<< master
 Op
+=======
+uc
+>>>>>>> reimported backup
 uc
 Cx
 hv
 Qk
 Me
+<<<<<<< master
 UU
+=======
+Ft
+>>>>>>> reimported backup
 "}
 (11,1,1) = {"
 fi
@@ -1452,7 +1583,11 @@ sT
 Vl
 jM
 Fv
+<<<<<<< master
 Op
+=======
+uc
+>>>>>>> reimported backup
 ji
 dL
 KH
@@ -1475,7 +1610,11 @@ uc
 uc
 uc
 Oq
+<<<<<<< master
 Op
+=======
+uc
+>>>>>>> reimported backup
 Jt
 Ed
 it
@@ -1490,7 +1629,11 @@ QK
 DE
 cR
 uj
+<<<<<<< master
 Op
+=======
+uc
+>>>>>>> reimported backup
 Jt
 ac
 uc
@@ -1498,7 +1641,11 @@ uc
 DU
 Ed
 ln
+<<<<<<< master
 FB
+=======
+cy
+>>>>>>> reimported backup
 wv
 FP
 "}
@@ -1510,7 +1657,11 @@ QK
 fi
 RJ
 Cp
+<<<<<<< master
 Op
+=======
+uc
+>>>>>>> reimported backup
 kX
 YX
 Si
@@ -1533,7 +1684,11 @@ Hd
 uc
 uM
 uM
+<<<<<<< master
 Op
+=======
+uc
+>>>>>>> reimported backup
 io
 hv
 zt

--- a/maps/map_files/Kutjevo/sprinkles/25.kutjevoclf01.dmm
+++ b/maps/map_files/Kutjevo/sprinkles/25.kutjevoclf01.dmm
@@ -21,6 +21,7 @@
 /area/kutjevo/interior/construction)
 <<<<<<< master
 <<<<<<< master
+<<<<<<< master
 "as" = (
 /obj/item/explosive/mine/clf/active{
 	dir = 8
@@ -35,15 +36,24 @@
 "aA" = (
 /obj/structure/platform/kutjevo{
 	dir = 4
+=======
+"as" = (
+/obj/item/explosive/mine/clf/active{
+	dir = 8
+>>>>>>> added spawn pointss for clf survivors
 	},
-/obj/structure/stairs/perspective/kutjevo{
-	dir = 4;
-	icon_state = "p_stair_sn_full_cap"
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/turf/open/floor/kutjevo/colors/purple/edge{
+	dir = 4
 	},
+<<<<<<< master
 /obj/item/explosive/mine/clf/active,
 /turf/open/floor/plating/kutjevo,
 /area/kutjevo/exterior/complex_border/med_rec)
 >>>>>>> updated all maps to have CLF Mines and corpses
+=======
+/area/kutjevo/interior/construction)
+>>>>>>> added spawn pointss for clf survivors
 "aG" = (
 /obj/effect/landmark/corpsespawner/colonist,
 /obj/item/weapon/gun/pistol/holdout,
@@ -231,15 +241,25 @@
 /turf/closed/wall/kutjevo/colony/reinforced,
 /area/kutjevo/interior/construction)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> added spawn pointss for clf survivors
 "gw" = (
 /obj/item/stool{
 	pixel_y = 8
 	},
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
 =======
 >>>>>>> reimported backup
+=======
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/turf/open/floor/kutjevo/tan,
+/area/kutjevo/interior/construction)
+>>>>>>> added spawn pointss for clf survivors
 "gy" = (
 /obj/structure/surface/table/gamblingtable,
 /obj/item/weapon/gun/rifle/mar40/lmg,
@@ -381,6 +401,9 @@
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> added spawn pointss for clf survivors
 "lY" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/effect/decal/cleanable/ash,
@@ -391,13 +414,17 @@
 	},
 /turf/open/floor/plating/kutjevo,
 /area/kutjevo/interior/construction)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> added spawn pointss for clf survivors
 "md" = (
 /obj/structure/platform_decoration/kutjevo{
 	dir = 8
 	},
 /obj/effect/spawner/random/attachment,
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/kutjevo/colors/purple/edge{
 	dir = 4
 	},
@@ -435,9 +462,14 @@
 /turf/open/floor/kutjevo/multi_tiles,
 /area/kutjevo/interior/foremans_office)
 <<<<<<< master
+<<<<<<< master
 "ns" = (
 /obj/item/explosive/mine/clf/active,
 /obj/effect/landmark/survivor_spawner/clf/generic,
+=======
+"ns" = (
+/obj/item/explosive/mine/clf/active,
+>>>>>>> added spawn pointss for clf survivors
 /turf/open/floor/kutjevo/colors/purple/edge{
 	dir = 1
 	},
@@ -450,8 +482,11 @@
 /obj/item/explosive/mine/clf/active,
 /turf/open/floor/plating/kutjevo,
 /area/kutjevo/interior/construction)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> added spawn pointss for clf survivors
 "or" = (
 /obj/effect/landmark/corpsespawner/colonist,
 /obj/effect/decal/cleanable/blood,
@@ -463,6 +498,7 @@
 /turf/closed/wall/kutjevo/colony/reinforced,
 /area/kutjevo/interior/foremans_office)
 <<<<<<< master
+<<<<<<< master
 "oO" = (
 /obj/item/ammo_magazine/smg/nailgun,
 /obj/effect/landmark/survivor_spawner/clf/generic,
@@ -470,6 +506,15 @@
 /area/kutjevo/interior/construction)
 =======
 >>>>>>> reimported backup
+=======
+"oO" = (
+/obj/structure/platform/kutjevo{
+	dir = 1
+	},
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/turf/open/auto_turf/sand/layer0,
+/area/kutjevo/exterior/complex_border/med_rec)
+>>>>>>> added spawn pointss for clf survivors
 "pe" = (
 /obj/structure/machinery/colony_floodlight{
 	pixel_y = 10
@@ -557,16 +602,6 @@
 /obj/effect/decal/cleanable/ash,
 /turf/open/floor/plating/kutjevo,
 /area/kutjevo/interior/construction)
-"ua" = (
-/obj/effect/decal/cleanable/blood/oil,
-/obj/effect/decal/cleanable/ash,
-/obj/item/circuitboard/airlock,
-/obj/item/stack/cable_coil,
-/obj/item/explosive/mine/clf/active{
-	dir = 8
-	},
-/turf/open/floor/plating/kutjevo,
-/area/kutjevo/interior/construction)
 "uc" = (
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
@@ -595,9 +630,13 @@
 	tag = "icon-chair (WEST)"
 	},
 <<<<<<< master
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
 =======
 >>>>>>> reimported backup
+=======
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+>>>>>>> added spawn pointss for clf survivors
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
 "vo" = (
@@ -609,9 +648,13 @@
 /obj/item/weapon/gun/pistol/holdout,
 /obj/effect/landmark/corpsespawner/chef,
 <<<<<<< master
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
 =======
 >>>>>>> reimported backup
+=======
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+>>>>>>> added spawn pointss for clf survivors
 /turf/open/floor/kutjevo/grey/plate,
 /area/kutjevo/interior/construction)
 "wv" = (
@@ -685,14 +728,6 @@
 "yc" = (
 /turf/open/floor/kutjevo/colors/orange,
 /area/kutjevo/interior/foremans_office)
-"yk" = (
-/obj/item/explosive/mine/clf/active{
-	dir = 8
-	},
-/turf/open/floor/kutjevo/colors/purple/edge{
-	dir = 4
-	},
-/area/kutjevo/interior/construction)
 "zt" = (
 /obj/item/stack/sandbags/large_stack,
 /turf/open/floor/kutjevo/colors/purple,
@@ -734,6 +769,7 @@
 /area/kutjevo/interior/construction)
 "DU" = (
 /obj/effect/spawner/random/attachment,
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
 "DX" = (
@@ -834,6 +870,9 @@
 	},
 /area/kutjevo/interior/construction)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> added spawn pointss for clf survivors
 "FB" = (
 /obj/structure/platform/kutjevo{
 	dir = 4
@@ -845,6 +884,7 @@
 /obj/item/explosive/mine/clf/active,
 /turf/open/floor/plating/kutjevo,
 /area/kutjevo/exterior/complex_border/med_rec)
+<<<<<<< master
 "FP" = (
 /obj/effect/landmark/corpsespawner/colonist,
 /obj/item/weapon/gun/pistol/holdout,
@@ -856,13 +896,23 @@
 /turf/open/floor/kutjevo/grey/plate,
 /area/kutjevo/interior/construction)
 =======
+=======
+>>>>>>> added spawn pointss for clf survivors
 "FP" = (
 /obj/effect/landmark/corpsespawner/colonist,
 /obj/item/weapon/gun/pistol/holdout,
 /obj/effect/decal/cleanable/blood,
 /turf/open/auto_turf/sand/layer0,
 /area/kutjevo/exterior/complex_border/med_rec)
+<<<<<<< master
 >>>>>>> reimported backup
+=======
+"FX" = (
+/obj/item/ammo_casing/bullet,
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/turf/open/floor/kutjevo/colors/purple,
+/area/kutjevo/interior/construction)
+>>>>>>> added spawn pointss for clf survivors
 "Gt" = (
 /obj/structure/platform/kutjevo{
 	dir = 1
@@ -883,6 +933,7 @@
 /area/kutjevo/interior/construction)
 "Hd" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/kutjevo/colors/purple/edge{
 	dir = 5
 	},
@@ -904,12 +955,19 @@
 /turf/open/auto_turf/sand/layer0,
 /area/kutjevo/exterior/complex_border/med_rec)
 <<<<<<< master
+<<<<<<< master
 "ID" = (
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/kutjevo/colors/purple,
 /area/kutjevo/interior/construction)
 =======
 >>>>>>> reimported backup
+=======
+"ID" = (
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/turf/open/auto_turf/sand/layer1,
+/area/kutjevo/exterior/complex_border/med_rec)
+>>>>>>> added spawn pointss for clf survivors
 "IR" = (
 /obj/structure/barricade/metal/wired{
 	icon_state = "metal_2"
@@ -981,13 +1039,6 @@
 /obj/structure/sign/poster/clf,
 /turf/closed/wall/kutjevo/colony/reinforced,
 /area/kutjevo/interior/construction)
-"MZ" = (
-/obj/structure/platform/kutjevo{
-	dir = 1
-	},
-/obj/item/explosive/mine/clf/active,
-/turf/open/auto_turf/sand/layer0,
-/area/kutjevo/exterior/complex_border/med_rec)
 "Nl" = (
 /obj/structure/machinery/cm_vending/sorted/medical/wall_med{
 	pixel_x = -28
@@ -1012,24 +1063,23 @@
 	},
 /area/kutjevo/interior/construction)
 <<<<<<< master
+<<<<<<< master
 "Op" = (
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
 =======
 >>>>>>> reimported backup
+=======
+"Op" = (
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/turf/open/floor/kutjevo/tan,
+/area/kutjevo/interior/construction)
+>>>>>>> added spawn pointss for clf survivors
 "Oq" = (
 /obj/effect/landmark/corpsespawner/doctor,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/kutjevo/tan,
-/area/kutjevo/interior/construction)
-"Pw" = (
-/obj/effect/decal/cleanable/blood/oil,
-/obj/effect/decal/cleanable/ash,
-/obj/item/circuitboard/airlock,
-/obj/item/stack/cable_coil,
-/obj/item/explosive/mine/clf/active,
-/turf/open/floor/plating/kutjevo,
 /area/kutjevo/interior/construction)
 "PP" = (
 /obj/structure/closet/crate/freezer/rations,
@@ -1066,6 +1116,7 @@
 /area/kutjevo/interior/construction)
 "Rb" = (
 /obj/effect/spawner/random/attachment,
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/kutjevo/colors/purple,
 /area/kutjevo/interior/construction)
 "Rc" = (
@@ -1101,9 +1152,13 @@
 	dir = 4
 	},
 <<<<<<< master
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
 =======
 >>>>>>> reimported backup
+=======
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+>>>>>>> added spawn pointss for clf survivors
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
 "Si" = (
@@ -1124,6 +1179,9 @@
 /turf/open/floor/kutjevo/grey/plate,
 /area/kutjevo/interior/foremans_office)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> added spawn pointss for clf survivors
 "Sn" = (
 /obj/structure/platform/kutjevo{
 	dir = 1
@@ -1131,8 +1189,11 @@
 /obj/item/explosive/mine/clf/active,
 /turf/open/auto_turf/sand/layer0,
 /area/kutjevo/exterior/complex_border/med_rec)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> added spawn pointss for clf survivors
 "SI" = (
 /turf/closed/wall/kutjevo/colony/reinforced,
 /area/kutjevo/exterior/complex_border/med_rec)
@@ -1140,9 +1201,13 @@
 /obj/item/stack/rods,
 /obj/effect/spawner/random/attachment,
 <<<<<<< master
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
 =======
 >>>>>>> reimported backup
+=======
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+>>>>>>> added spawn pointss for clf survivors
 /turf/open/floor/kutjevo/colors/purple,
 /area/kutjevo/interior/construction)
 "Tv" = (
@@ -1162,6 +1227,7 @@
 /obj/item/stool{
 	pixel_y = 8
 	},
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
 >>>>>>> reimported backup
@@ -1192,6 +1258,7 @@
 /turf/closed/wall/kutjevo/colony/reinforced,
 /area/kutjevo/interior/foremans_office)
 <<<<<<< master
+<<<<<<< master
 "UD" = (
 /obj/structure/barricade/metal/wired{
 	icon_state = "metal_2"
@@ -1201,10 +1268,18 @@
 /area/kutjevo/interior/construction)
 =======
 >>>>>>> reimported backup
+=======
+"UD" = (
+/obj/structure/machinery/light,
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/turf/open/floor/kutjevo/colors/purple/edge,
+/area/kutjevo/interior/construction)
+>>>>>>> added spawn pointss for clf survivors
 "UP" = (
 /obj/structure/platform_decoration/kutjevo,
 /turf/open/floor/plating/kutjevo,
 /area/kutjevo/interior/foremans_office)
+<<<<<<< master
 <<<<<<< master
 "UU" = (
 /obj/effect/landmark/survivor_spawner/clf/generic,
@@ -1212,6 +1287,14 @@
 /area/kutjevo/exterior/complex_border/med_rec)
 =======
 >>>>>>> reimported backup
+=======
+"UU" = (
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/turf/open/floor/kutjevo/colors/purple/edge{
+	dir = 1
+	},
+/area/kutjevo/interior/construction)
+>>>>>>> added spawn pointss for clf survivors
 "Ve" = (
 /obj/structure/machinery/door/airlock/almayer/maint/autoname{
 	dir = 1;
@@ -1247,12 +1330,6 @@
 	},
 /turf/open/floor/kutjevo/grey/plate,
 /area/kutjevo/interior/foremans_office)
-"Wm" = (
-/obj/item/explosive/mine/clf/active,
-/turf/open/floor/kutjevo/colors/purple/edge{
-	dir = 1
-	},
-/area/kutjevo/interior/construction)
 "Ww" = (
 /obj/structure/platform/kutjevo{
 	dir = 4
@@ -1296,6 +1373,7 @@
 /turf/open/auto_turf/sand/layer2,
 /area/kutjevo/interior/construction)
 <<<<<<< master
+<<<<<<< master
 "Yz" = (
 /obj/structure/platform_decoration/kutjevo{
 	dir = 8
@@ -1305,6 +1383,12 @@
 /area/kutjevo/exterior/complex_border/med_rec)
 =======
 >>>>>>> reimported backup
+=======
+"Yz" = (
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/turf/open/auto_turf/sand/layer1,
+/area/kutjevo/interior/construction)
+>>>>>>> added spawn pointss for clf survivors
 "YJ" = (
 /obj/effect/landmark/corpsespawner/security/cmb,
 /obj/effect/decal/cleanable/blood,
@@ -1393,7 +1477,7 @@
 QK
 DE
 DE
-DE
+Yz
 Ms
 fi
 hv
@@ -1447,10 +1531,11 @@ hv
 ns
 =======
 TK
-TK
+gw
 TK
 Cx
 hv
+<<<<<<< master
 <<<<<<< master
 Fv
 >>>>>>> reimported backup
@@ -1458,6 +1543,10 @@ Fv
 Wm
 >>>>>>> updated all maps to have CLF Mines and corpses
 hp
+=======
+ns
+FX
+>>>>>>> added spawn pointss for clf survivors
 tN
 IB
 Ro
@@ -1495,6 +1584,7 @@ cz
 Ed
 <<<<<<< master
 <<<<<<< master
+<<<<<<< master
 oo
 Fv
 sx
@@ -1505,6 +1595,9 @@ ln
 =======
 Pw
 >>>>>>> updated all maps to have CLF Mines and corpses
+=======
+oo
+>>>>>>> added spawn pointss for clf survivors
 Fv
 sx
 nn
@@ -1542,7 +1635,7 @@ UD
 tN
 >>>>>>> reimported backup
 IB
-Ro
+ID
 Ro
 "}
 (7,1,1) = {"
@@ -1560,6 +1653,7 @@ hv
 KQ
 <<<<<<< master
 <<<<<<< master
+<<<<<<< master
 as
 =======
 HE
@@ -1567,6 +1661,9 @@ HE
 =======
 yk
 >>>>>>> updated all maps to have CLF Mines and corpses
+=======
+as
+>>>>>>> added spawn pointss for clf survivors
 IR
 IB
 Ro
@@ -1577,6 +1674,7 @@ fi
 fi
 <<<<<<< master
 <<<<<<< master
+<<<<<<< master
 lY
 =======
 ln
@@ -1584,6 +1682,9 @@ ln
 =======
 ua
 >>>>>>> updated all maps to have CLF Mines and corpses
+=======
+lY
+>>>>>>> added spawn pointss for clf survivors
 fi
 fi
 fi
@@ -1620,6 +1721,7 @@ ad
 hv
 <<<<<<< master
 <<<<<<< master
+<<<<<<< master
 Sn
 =======
 IB
@@ -1627,6 +1729,9 @@ IB
 =======
 MZ
 >>>>>>> updated all maps to have CLF Mines and corpses
+=======
+Sn
+>>>>>>> added spawn pointss for clf survivors
 ri
 Ro
 "}
@@ -1641,13 +1746,18 @@ ID
 sx
 >>>>>>> reimported backup
 Fv
-uc
+Op
 RP
+<<<<<<< master
 uc
 uc
 <<<<<<< master
 Op
 =======
+=======
+Op
+Op
+>>>>>>> added spawn pointss for clf survivors
 uc
 >>>>>>> reimported backup
 uc
@@ -1667,10 +1777,14 @@ ed
 sT
 Vl
 jM
+<<<<<<< master
 Fv
 <<<<<<< master
 Op
 =======
+=======
+UU
+>>>>>>> added spawn pointss for clf survivors
 uc
 >>>>>>> reimported backup
 ji
@@ -1681,7 +1795,7 @@ or
 Jj
 Ms
 ZS
-IB
+oO
 Ro
 "}
 (12,1,1) = {"
@@ -1691,7 +1805,7 @@ hv
 hv
 fi
 xY
-uc
+Op
 uc
 uc
 Oq
@@ -1728,6 +1842,7 @@ Ed
 ln
 <<<<<<< master
 <<<<<<< master
+<<<<<<< master
 FB
 =======
 cy
@@ -1735,6 +1850,9 @@ cy
 =======
 aA
 >>>>>>> updated all maps to have CLF Mines and corpses
+=======
+FB
+>>>>>>> added spawn pointss for clf survivors
 wv
 FP
 "}
@@ -1755,7 +1873,7 @@ kX
 YX
 Si
 uc
-Jj
+UD
 Ms
 ZS
 ue

--- a/maps/map_files/Kutjevo/sprinkles/25.kutjevoclf01.dmm
+++ b/maps/map_files/Kutjevo/sprinkles/25.kutjevoclf01.dmm
@@ -922,8 +922,6 @@
 <<<<<<< master
 "FP" = (
 /obj/effect/landmark/corpsespawner/colonist,
-/obj/item/weapon/gun/pistol/holdout,
-/obj/effect/decal/cleanable/blood,
 /turf/open/auto_turf/sand/layer0,
 /area/kutjevo/exterior/complex_border/med_rec)
 "FX" = (

--- a/maps/map_files/Kutjevo/sprinkles/25.kutjevoclf01.dmm
+++ b/maps/map_files/Kutjevo/sprinkles/25.kutjevoclf01.dmm
@@ -543,6 +543,16 @@
 /obj/effect/decal/cleanable/ash,
 /turf/open/floor/plating/kutjevo,
 /area/kutjevo/interior/construction)
+"ua" = (
+/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/decal/cleanable/ash,
+/obj/item/circuitboard/airlock,
+/obj/item/stack/cable_coil,
+/obj/item/explosive/mine/clf/active{
+	dir = 8
+	},
+/turf/open/floor/plating/kutjevo,
+/area/kutjevo/interior/construction)
 "uc" = (
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
@@ -661,6 +671,14 @@
 "yc" = (
 /turf/open/floor/kutjevo/colors/orange,
 /area/kutjevo/interior/foremans_office)
+"yk" = (
+/obj/item/explosive/mine/clf/active{
+	dir = 8
+	},
+/turf/open/floor/kutjevo/colors/purple/edge{
+	dir = 4
+	},
+/area/kutjevo/interior/construction)
 "zt" = (
 /obj/item/stack/sandbags/large_stack,
 /turf/open/floor/kutjevo/colors/purple,
@@ -954,6 +972,13 @@
 /obj/structure/sign/poster/clf,
 /turf/closed/wall/kutjevo/colony/reinforced,
 /area/kutjevo/interior/construction)
+"MZ" = (
+/obj/structure/platform/kutjevo{
+	dir = 1
+	},
+/obj/item/explosive/mine/clf/active,
+/turf/open/auto_turf/sand/layer0,
+/area/kutjevo/exterior/complex_border/med_rec)
 "Nl" = (
 /obj/structure/machinery/cm_vending/sorted/medical/wall_med{
 	pixel_x = -28
@@ -991,6 +1016,14 @@
 /obj/effect/landmark/corpsespawner/doctor,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/kutjevo/tan,
+/area/kutjevo/interior/construction)
+"Pw" = (
+/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/decal/cleanable/ash,
+/obj/item/circuitboard/airlock,
+/obj/item/stack/cable_coil,
+/obj/item/explosive/mine/clf/active,
+/turf/open/floor/plating/kutjevo,
 /area/kutjevo/interior/construction)
 "PP" = (
 /obj/structure/closet/crate/freezer/rations,
@@ -1215,6 +1248,12 @@
 	},
 /turf/open/floor/kutjevo/grey/plate,
 /area/kutjevo/interior/foremans_office)
+"Wm" = (
+/obj/item/explosive/mine/clf/active,
+/turf/open/floor/kutjevo/colors/purple/edge{
+	dir = 1
+	},
+/area/kutjevo/interior/construction)
 "Ww" = (
 /obj/structure/platform/kutjevo{
 	dir = 4

--- a/maps/map_files/Kutjevo/sprinkles/25.kutjevoclf01.dmm
+++ b/maps/map_files/Kutjevo/sprinkles/25.kutjevoclf01.dmm
@@ -15,6 +15,17 @@
 	dir = 4
 	},
 /area/kutjevo/interior/construction)
+"aA" = (
+/obj/structure/platform/kutjevo{
+	dir = 4
+	},
+/obj/structure/stairs/perspective/kutjevo{
+	dir = 4;
+	icon_state = "p_stair_sn_full_cap"
+	},
+/obj/item/explosive/mine/clf/active,
+/turf/open/floor/plating/kutjevo,
+/area/kutjevo/exterior/complex_border/med_rec)
 "aG" = (
 /obj/effect/landmark/corpsespawner/colonist,
 /obj/item/weapon/gun/pistol/holdout,
@@ -132,6 +143,11 @@
 /obj/item/storage/backpack/general_belt{
 	pixel_y = 7
 	},
+/obj/item/explosive/mine/clf,
+/obj/item/explosive/mine/clf,
+/obj/item/explosive/mine/clf,
+/obj/item/explosive/mine/clf,
+/obj/item/explosive/mine/clf,
 /turf/open/floor/kutjevo/colors/purple,
 /area/kutjevo/interior/construction)
 "dO" = (
@@ -249,6 +265,7 @@
 "it" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/effect/decal/cleanable/ash,
+/obj/item/explosive/mine/clf/active,
 /turf/open/floor/plating/kutjevo,
 /area/kutjevo/interior/construction)
 "iM" = (
@@ -452,6 +469,16 @@
 /obj/effect/decal/cleanable/ash,
 /turf/open/floor/plating/kutjevo,
 /area/kutjevo/interior/construction)
+"ua" = (
+/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/decal/cleanable/ash,
+/obj/item/circuitboard/airlock,
+/obj/item/stack/cable_coil,
+/obj/item/explosive/mine/clf/active{
+	dir = 8
+	},
+/turf/open/floor/plating/kutjevo,
+/area/kutjevo/interior/construction)
 "uc" = (
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
@@ -562,6 +589,14 @@
 "yc" = (
 /turf/open/floor/kutjevo/colors/orange,
 /area/kutjevo/interior/foremans_office)
+"yk" = (
+/obj/item/explosive/mine/clf/active{
+	dir = 8
+	},
+/turf/open/floor/kutjevo/colors/purple/edge{
+	dir = 4
+	},
+/area/kutjevo/interior/construction)
 "zt" = (
 /obj/item/stack/sandbags/large_stack,
 /turf/open/floor/kutjevo/colors/purple,
@@ -704,6 +739,8 @@
 /area/kutjevo/interior/construction)
 "FP" = (
 /obj/effect/landmark/corpsespawner/colonist,
+/obj/item/weapon/gun/pistol/holdout,
+/obj/effect/decal/cleanable/blood,
 /turf/open/auto_turf/sand/layer0,
 /area/kutjevo/exterior/complex_border/med_rec)
 "Gt" = (
@@ -817,6 +854,13 @@
 /obj/structure/sign/poster/clf,
 /turf/closed/wall/kutjevo/colony/reinforced,
 /area/kutjevo/interior/construction)
+"MZ" = (
+/obj/structure/platform/kutjevo{
+	dir = 1
+	},
+/obj/item/explosive/mine/clf/active,
+/turf/open/auto_turf/sand/layer0,
+/area/kutjevo/exterior/complex_border/med_rec)
 "Nl" = (
 /obj/structure/machinery/cm_vending/sorted/medical/wall_med{
 	pixel_x = -28
@@ -844,6 +888,14 @@
 /obj/effect/landmark/corpsespawner/doctor,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/kutjevo/tan,
+/area/kutjevo/interior/construction)
+"Pw" = (
+/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/decal/cleanable/ash,
+/obj/item/circuitboard/airlock,
+/obj/item/stack/cable_coil,
+/obj/item/explosive/mine/clf/active,
+/turf/open/floor/plating/kutjevo,
 /area/kutjevo/interior/construction)
 "PP" = (
 /obj/structure/closet/crate/freezer/rations,
@@ -1023,6 +1075,12 @@
 	},
 /turf/open/floor/kutjevo/grey/plate,
 /area/kutjevo/interior/foremans_office)
+"Wm" = (
+/obj/item/explosive/mine/clf/active,
+/turf/open/floor/kutjevo/colors/purple/edge{
+	dir = 1
+	},
+/area/kutjevo/interior/construction)
 "Ww" = (
 /obj/structure/platform/kutjevo{
 	dir = 4
@@ -1199,7 +1257,7 @@ TK
 TK
 Cx
 hv
-Fv
+Wm
 hp
 tN
 IB
@@ -1236,7 +1294,7 @@ ZI
 qn
 cz
 Ed
-ln
+Pw
 Fv
 sx
 nn
@@ -1276,7 +1334,7 @@ HE
 JV
 hv
 KQ
-HE
+yk
 IR
 IB
 Ro
@@ -1285,7 +1343,7 @@ Ft
 (8,1,1) = {"
 fi
 fi
-ln
+ua
 fi
 fi
 fi
@@ -1316,7 +1374,7 @@ jr
 ih
 ad
 hv
-IB
+MZ
 ri
 Ro
 "}
@@ -1392,7 +1450,7 @@ uc
 DU
 Ed
 ln
-cy
+aA
 wv
 FP
 "}

--- a/maps/map_files/Kutjevo/sprinkles/25.kutjevoclf01.dmm
+++ b/maps/map_files/Kutjevo/sprinkles/25.kutjevoclf01.dmm
@@ -15,17 +15,15 @@
 	dir = 4
 	},
 /area/kutjevo/interior/construction)
-"aA" = (
-/obj/structure/platform/kutjevo{
+"as" = (
+/obj/item/explosive/mine/clf/active{
+	dir = 8
+	},
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/turf/open/floor/kutjevo/colors/purple/edge{
 	dir = 4
 	},
-/obj/structure/stairs/perspective/kutjevo{
-	dir = 4;
-	icon_state = "p_stair_sn_full_cap"
-	},
-/obj/item/explosive/mine/clf/active,
-/turf/open/floor/plating/kutjevo,
-/area/kutjevo/exterior/complex_border/med_rec)
+/area/kutjevo/interior/construction)
 "aG" = (
 /obj/effect/landmark/corpsespawner/colonist,
 /obj/item/weapon/gun/pistol/holdout,
@@ -199,6 +197,14 @@
 "fi" = (
 /turf/closed/wall/kutjevo/colony/reinforced,
 /area/kutjevo/interior/construction)
+"gw" = (
+/obj/item/stool{
+	pixel_y = 8
+	},
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/turf/open/floor/kutjevo/tan,
+/area/kutjevo/interior/construction)
 "gy" = (
 /obj/structure/surface/table/gamblingtable,
 /obj/item/weapon/gun/rifle/mar40/lmg,
@@ -331,11 +337,22 @@
 /obj/item/paper_bin,
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
+"lY" = (
+/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/decal/cleanable/ash,
+/obj/item/circuitboard/airlock,
+/obj/item/stack/cable_coil,
+/obj/item/explosive/mine/clf/active{
+	dir = 8
+	},
+/turf/open/floor/plating/kutjevo,
+/area/kutjevo/interior/construction)
 "md" = (
 /obj/structure/platform_decoration/kutjevo{
 	dir = 8
 	},
 /obj/effect/spawner/random/attachment,
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/kutjevo/colors/purple/edge{
 	dir = 4
 	},
@@ -372,6 +389,20 @@
 /obj/structure/window_frame/kutjevo/reinforced,
 /turf/open/floor/kutjevo/multi_tiles,
 /area/kutjevo/interior/foremans_office)
+"ns" = (
+/obj/item/explosive/mine/clf/active,
+/turf/open/floor/kutjevo/colors/purple/edge{
+	dir = 1
+	},
+/area/kutjevo/interior/construction)
+"oo" = (
+/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/decal/cleanable/ash,
+/obj/item/circuitboard/airlock,
+/obj/item/stack/cable_coil,
+/obj/item/explosive/mine/clf/active,
+/turf/open/floor/plating/kutjevo,
+/area/kutjevo/interior/construction)
 "or" = (
 /obj/effect/landmark/corpsespawner/colonist,
 /obj/effect/decal/cleanable/blood,
@@ -382,6 +413,13 @@
 "oB" = (
 /turf/closed/wall/kutjevo/colony/reinforced,
 /area/kutjevo/interior/foremans_office)
+"oO" = (
+/obj/structure/platform/kutjevo{
+	dir = 1
+	},
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/turf/open/auto_turf/sand/layer0,
+/area/kutjevo/exterior/complex_border/med_rec)
 "pe" = (
 /obj/structure/machinery/colony_floodlight{
 	pixel_y = 10
@@ -469,16 +507,6 @@
 /obj/effect/decal/cleanable/ash,
 /turf/open/floor/plating/kutjevo,
 /area/kutjevo/interior/construction)
-"ua" = (
-/obj/effect/decal/cleanable/blood/oil,
-/obj/effect/decal/cleanable/ash,
-/obj/item/circuitboard/airlock,
-/obj/item/stack/cable_coil,
-/obj/item/explosive/mine/clf/active{
-	dir = 8
-	},
-/turf/open/floor/plating/kutjevo,
-/area/kutjevo/interior/construction)
 "uc" = (
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
@@ -506,6 +534,7 @@
 	dir = 8;
 	tag = "icon-chair (WEST)"
 	},
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
 "vo" = (
@@ -516,6 +545,7 @@
 /obj/effect/decal/cleanable/blood,
 /obj/item/weapon/gun/pistol/holdout,
 /obj/effect/landmark/corpsespawner/chef,
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/kutjevo/grey/plate,
 /area/kutjevo/interior/construction)
 "wv" = (
@@ -589,14 +619,6 @@
 "yc" = (
 /turf/open/floor/kutjevo/colors/orange,
 /area/kutjevo/interior/foremans_office)
-"yk" = (
-/obj/item/explosive/mine/clf/active{
-	dir = 8
-	},
-/turf/open/floor/kutjevo/colors/purple/edge{
-	dir = 4
-	},
-/area/kutjevo/interior/construction)
 "zt" = (
 /obj/item/stack/sandbags/large_stack,
 /turf/open/floor/kutjevo/colors/purple,
@@ -638,6 +660,7 @@
 /area/kutjevo/interior/construction)
 "DU" = (
 /obj/effect/spawner/random/attachment,
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
 "DX" = (
@@ -737,12 +760,28 @@
 	dir = 1
 	},
 /area/kutjevo/interior/construction)
+"FB" = (
+/obj/structure/platform/kutjevo{
+	dir = 4
+	},
+/obj/structure/stairs/perspective/kutjevo{
+	dir = 4;
+	icon_state = "p_stair_sn_full_cap"
+	},
+/obj/item/explosive/mine/clf/active,
+/turf/open/floor/plating/kutjevo,
+/area/kutjevo/exterior/complex_border/med_rec)
 "FP" = (
 /obj/effect/landmark/corpsespawner/colonist,
 /obj/item/weapon/gun/pistol/holdout,
 /obj/effect/decal/cleanable/blood,
 /turf/open/auto_turf/sand/layer0,
 /area/kutjevo/exterior/complex_border/med_rec)
+"FX" = (
+/obj/item/ammo_casing/bullet,
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/turf/open/floor/kutjevo/colors/purple,
+/area/kutjevo/interior/construction)
 "Gt" = (
 /obj/structure/platform/kutjevo{
 	dir = 1
@@ -763,6 +802,7 @@
 /area/kutjevo/interior/construction)
 "Hd" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/kutjevo/colors/purple/edge{
 	dir = 5
 	},
@@ -782,6 +822,10 @@
 	dir = 1
 	},
 /turf/open/auto_turf/sand/layer0,
+/area/kutjevo/exterior/complex_border/med_rec)
+"ID" = (
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/turf/open/auto_turf/sand/layer1,
 /area/kutjevo/exterior/complex_border/med_rec)
 "IR" = (
 /obj/structure/barricade/metal/wired{
@@ -854,13 +898,6 @@
 /obj/structure/sign/poster/clf,
 /turf/closed/wall/kutjevo/colony/reinforced,
 /area/kutjevo/interior/construction)
-"MZ" = (
-/obj/structure/platform/kutjevo{
-	dir = 1
-	},
-/obj/item/explosive/mine/clf/active,
-/turf/open/auto_turf/sand/layer0,
-/area/kutjevo/exterior/complex_border/med_rec)
 "Nl" = (
 /obj/structure/machinery/cm_vending/sorted/medical/wall_med{
 	pixel_x = -28
@@ -884,18 +921,14 @@
 	dir = 1
 	},
 /area/kutjevo/interior/construction)
+"Op" = (
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/turf/open/floor/kutjevo/tan,
+/area/kutjevo/interior/construction)
 "Oq" = (
 /obj/effect/landmark/corpsespawner/doctor,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/kutjevo/tan,
-/area/kutjevo/interior/construction)
-"Pw" = (
-/obj/effect/decal/cleanable/blood/oil,
-/obj/effect/decal/cleanable/ash,
-/obj/item/circuitboard/airlock,
-/obj/item/stack/cable_coil,
-/obj/item/explosive/mine/clf/active,
-/turf/open/floor/plating/kutjevo,
 /area/kutjevo/interior/construction)
 "PP" = (
 /obj/structure/closet/crate/freezer/rations,
@@ -932,6 +965,7 @@
 /area/kutjevo/interior/construction)
 "Rb" = (
 /obj/effect/spawner/random/attachment,
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/kutjevo/colors/purple,
 /area/kutjevo/interior/construction)
 "Rc" = (
@@ -966,6 +1000,7 @@
 /obj/structure/bed/chair{
 	dir = 4
 	},
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
 "Si" = (
@@ -985,12 +1020,20 @@
 /obj/item/tank/emergency_oxygen/engi,
 /turf/open/floor/kutjevo/grey/plate,
 /area/kutjevo/interior/foremans_office)
+"Sn" = (
+/obj/structure/platform/kutjevo{
+	dir = 1
+	},
+/obj/item/explosive/mine/clf/active,
+/turf/open/auto_turf/sand/layer0,
+/area/kutjevo/exterior/complex_border/med_rec)
 "SI" = (
 /turf/closed/wall/kutjevo/colony/reinforced,
 /area/kutjevo/exterior/complex_border/med_rec)
 "Tb" = (
 /obj/item/stack/rods,
 /obj/effect/spawner/random/attachment,
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/kutjevo/colors/purple,
 /area/kutjevo/interior/construction)
 "Tv" = (
@@ -1008,6 +1051,7 @@
 /obj/item/stool{
 	pixel_y = 8
 	},
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
 "Ua" = (
@@ -1036,10 +1080,21 @@
 /obj/structure/sign/poster/clf,
 /turf/closed/wall/kutjevo/colony/reinforced,
 /area/kutjevo/interior/foremans_office)
+"UD" = (
+/obj/structure/machinery/light,
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/turf/open/floor/kutjevo/colors/purple/edge,
+/area/kutjevo/interior/construction)
 "UP" = (
 /obj/structure/platform_decoration/kutjevo,
 /turf/open/floor/plating/kutjevo,
 /area/kutjevo/interior/foremans_office)
+"UU" = (
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/turf/open/floor/kutjevo/colors/purple/edge{
+	dir = 1
+	},
+/area/kutjevo/interior/construction)
 "Ve" = (
 /obj/structure/machinery/door/airlock/almayer/maint/autoname{
 	dir = 1;
@@ -1075,12 +1130,6 @@
 	},
 /turf/open/floor/kutjevo/grey/plate,
 /area/kutjevo/interior/foremans_office)
-"Wm" = (
-/obj/item/explosive/mine/clf/active,
-/turf/open/floor/kutjevo/colors/purple/edge{
-	dir = 1
-	},
-/area/kutjevo/interior/construction)
 "Ww" = (
 /obj/structure/platform/kutjevo{
 	dir = 4
@@ -1122,6 +1171,10 @@
 /area/kutjevo/exterior/complex_border/med_rec)
 "Yg" = (
 /turf/open/auto_turf/sand/layer2,
+/area/kutjevo/interior/construction)
+"Yz" = (
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/turf/open/auto_turf/sand/layer1,
 /area/kutjevo/interior/construction)
 "YJ" = (
 /obj/effect/landmark/corpsespawner/security/cmb,
@@ -1211,7 +1264,7 @@
 QK
 DE
 DE
-DE
+Yz
 Ms
 fi
 hv
@@ -1253,12 +1306,12 @@ ZT
 fi
 QN
 TK
-TK
+gw
 TK
 Cx
 hv
-Wm
-hp
+ns
+FX
 tN
 IB
 Ro
@@ -1294,7 +1347,7 @@ ZI
 qn
 cz
 Ed
-Pw
+oo
 Fv
 sx
 nn
@@ -1318,7 +1371,7 @@ aG
 hp
 tN
 IB
-Ro
+ID
 Ro
 "}
 (7,1,1) = {"
@@ -1334,7 +1387,7 @@ HE
 JV
 hv
 KQ
-yk
+as
 IR
 IB
 Ro
@@ -1343,7 +1396,7 @@ Ft
 (8,1,1) = {"
 fi
 fi
-ua
+lY
 fi
 fi
 fi
@@ -1374,7 +1427,7 @@ jr
 ih
 ad
 hv
-MZ
+Sn
 ri
 Ro
 "}
@@ -1385,10 +1438,10 @@ wb
 QK
 sx
 Fv
-uc
+Op
 RP
-uc
-uc
+Op
+Op
 uc
 uc
 Cx
@@ -1403,7 +1456,7 @@ ed
 sT
 Vl
 jM
-Fv
+UU
 uc
 ji
 dL
@@ -1413,7 +1466,7 @@ or
 Jj
 Ms
 ZS
-IB
+oO
 Ro
 "}
 (12,1,1) = {"
@@ -1423,7 +1476,7 @@ hv
 hv
 fi
 xY
-uc
+Op
 uc
 uc
 Oq
@@ -1450,7 +1503,7 @@ uc
 DU
 Ed
 ln
-aA
+FB
 wv
 FP
 "}
@@ -1467,7 +1520,7 @@ kX
 YX
 Si
 uc
-Jj
+UD
 Ms
 ZS
 ue

--- a/maps/map_files/Kutjevo/sprinkles/25.kutjevoclf01.dmm
+++ b/maps/map_files/Kutjevo/sprinkles/25.kutjevoclf01.dmm
@@ -160,6 +160,16 @@
 /obj/item/stack/cable_coil,
 /turf/open/floor/kutjevo/multi_tiles,
 /area/kutjevo/interior/construction)
+"cS" = (
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1";
+	dir = 8
+	},
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/floor/kutjevo/colors/purple/edge{
+	dir = 8
+	},
+/area/kutjevo/interior/construction)
 "dg" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/structure/machinery/computer/communications{
@@ -336,6 +346,7 @@
 	icon_state = "metal_1"
 	},
 /obj/item/ammo_casing/bullet,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/kutjevo/colors/purple/edge,
 /area/kutjevo/interior/construction)
 "it" = (
@@ -398,6 +409,7 @@
 "kX" = (
 /obj/structure/bed/chair,
 /obj/effect/decal/cleanable/blood/gibs/down,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/kutjevo/colors/purple,
 /area/kutjevo/interior/construction)
 "ln" = (
@@ -675,6 +687,10 @@
 /obj/structure/platform/kutjevo,
 /turf/open/floor/plating/kutjevo,
 /area/kutjevo/interior/foremans_office)
+"vI" = (
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/floor/kutjevo/colors/purple,
+/area/kutjevo/interior/construction)
 "wb" = (
 /obj/effect/decal/cleanable/blood,
 /obj/item/weapon/gun/pistol/holdout,
@@ -757,6 +773,7 @@
 /obj/structure/machinery/light{
 	dir = 1
 	},
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/kutjevo/colors/purple/edge{
 	dir = 1
 	},
@@ -774,6 +791,13 @@
 	},
 /turf/open/floor/kutjevo/colors/purple,
 /area/kutjevo/interior/construction)
+"Ae" = (
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_2"
+	},
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/floor/kutjevo/colors/purple/edge,
+/area/kutjevo/interior/construction)
 "Cm" = (
 /obj/structure/machinery/door/airlock/almayer/maint/autoname{
 	name = "\improper Null Hatch REPLACE ME";
@@ -783,6 +807,7 @@
 /turf/open/floor/kutjevo/multi_tiles,
 /area/kutjevo/interior/construction)
 "Cp" = (
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/kutjevo/colors/purple/edge{
 	dir = 5
 	},
@@ -792,6 +817,12 @@
 	icon_state = "metal_1"
 	},
 /turf/open/floor/kutjevo/colors/purple/edge,
+/area/kutjevo/interior/construction)
+"CC" = (
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/floor/kutjevo/colors/purple/edge{
+	dir = 1
+	},
 /area/kutjevo/interior/construction)
 "Dj" = (
 /obj/structure/platform/kutjevo{
@@ -805,6 +836,7 @@
 /area/kutjevo/interior/construction)
 "DU" = (
 /obj/effect/spawner/random/attachment,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
 "DX" = (
@@ -894,6 +926,7 @@
 /obj/item/stool{
 	pixel_y = 8
 	},
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/kutjevo/grey/plate,
 /area/kutjevo/interior/construction)
 "Ft" = (
@@ -983,6 +1016,10 @@
 	dir = 4
 	},
 /area/kutjevo/interior/construction)
+"HL" = (
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/floor/plating/kutjevo,
+/area/kutjevo/interior/construction)
 "IB" = (
 /obj/structure/platform/kutjevo{
 	dir = 1
@@ -1013,6 +1050,7 @@
 /obj/structure/barricade/metal/wired{
 	icon_state = "metal_2"
 	},
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/kutjevo/colors/purple/inner_corner{
 	dir = 8
 	},
@@ -1142,6 +1180,15 @@
 	},
 /turf/open/auto_turf/sand/layer0,
 /area/kutjevo/exterior/complex_border/med_rec)
+"Qt" = (
+/obj/item/ammo_casing/bullet,
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/floor/kutjevo/colors/purple,
+/area/kutjevo/interior/construction)
+"QF" = (
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/floor/kutjevo/grey/plate,
+/area/kutjevo/interior/construction)
 "QK" = (
 /turf/open/floor/kutjevo/grey/plate,
 /area/kutjevo/interior/construction)
@@ -1559,7 +1606,7 @@ Ro
 Ro
 "}
 (2,1,1) = {"
-uv
+HL
 rG
 <<<<<<< master
 <<<<<<< master
@@ -1736,7 +1783,7 @@ Ro
 (7,1,1) = {"
 fi
 PP
-sx
+vI
 fa
 fi
 Ol
@@ -1815,7 +1862,7 @@ ih
 Ua
 Nl
 jr
-ih
+cS
 ad
 hv
 <<<<<<< master
@@ -1854,6 +1901,7 @@ RP
 <<<<<<< master
 <<<<<<< master
 uc
+FA
 uc
 <<<<<<< master
 Op

--- a/maps/map_files/Kutjevo/sprinkles/25.kutjevoclf01.dmm
+++ b/maps/map_files/Kutjevo/sprinkles/25.kutjevoclf01.dmm
@@ -2,9 +2,13 @@
 "ac" = (
 /obj/effect/decal/cleanable/blood,
 <<<<<<< master
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
 =======
 >>>>>>> reimported backup
+=======
+/obj/effect/landmark/survivor_spawner/clf/generic,
+>>>>>>> Updated CLF spawner
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
 "ad" = (
@@ -26,6 +30,7 @@
 /obj/item/explosive/mine/clf/active{
 	dir = 8
 	},
+<<<<<<< master
 /turf/open/floor/kutjevo/colors/purple/edge{
 	dir = 4
 	},
@@ -43,6 +48,8 @@
 >>>>>>> added spawn pointss for clf survivors
 	},
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> Updated CLF spawner
 /turf/open/floor/kutjevo/colors/purple/edge{
 	dir = 4
 	},
@@ -59,9 +66,13 @@
 /obj/item/weapon/gun/pistol/holdout,
 /obj/effect/decal/cleanable/blood,
 <<<<<<< master
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
 =======
 >>>>>>> reimported backup
+=======
+/obj/effect/landmark/survivor_spawner/clf/generic,
+>>>>>>> Updated CLF spawner
 /turf/open/floor/kutjevo/colors/purple/edge{
 	dir = 1
 	},
@@ -249,6 +260,7 @@
 	pixel_y = 8
 	},
 <<<<<<< master
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
@@ -257,6 +269,9 @@
 =======
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+/obj/effect/landmark/survivor_spawner/clf/generic,
+>>>>>>> Updated CLF spawner
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
 >>>>>>> added spawn pointss for clf survivors
@@ -330,11 +345,14 @@
 <<<<<<< master
 /obj/item/explosive/mine/clf/active,
 /obj/effect/landmark/survivor_spawner/clf/generic,
+<<<<<<< master
 =======
 >>>>>>> reimported backup
 =======
 /obj/item/explosive/mine/clf/active,
 >>>>>>> updated all maps to have CLF Mines and corpses
+=======
+>>>>>>> Updated CLF spawner
 /turf/open/floor/plating/kutjevo,
 /area/kutjevo/interior/construction)
 "iM" = (
@@ -424,7 +442,6 @@
 	dir = 8
 	},
 /obj/effect/spawner/random/attachment,
-/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/kutjevo/colors/purple/edge{
 	dir = 4
 	},
@@ -469,7 +486,11 @@
 =======
 "ns" = (
 /obj/item/explosive/mine/clf/active,
+<<<<<<< master
 >>>>>>> added spawn pointss for clf survivors
+=======
+/obj/effect/landmark/survivor_spawner/clf/generic,
+>>>>>>> Updated CLF spawner
 /turf/open/floor/kutjevo/colors/purple/edge{
 	dir = 1
 	},
@@ -508,6 +529,7 @@
 >>>>>>> reimported backup
 =======
 "oO" = (
+<<<<<<< master
 /obj/structure/platform/kutjevo{
 	dir = 1
 	},
@@ -515,6 +537,12 @@
 /turf/open/auto_turf/sand/layer0,
 /area/kutjevo/exterior/complex_border/med_rec)
 >>>>>>> added spawn pointss for clf survivors
+=======
+/obj/item/ammo_magazine/smg/nailgun,
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/floor/kutjevo/grey/plate,
+/area/kutjevo/interior/construction)
+>>>>>>> Updated CLF spawner
 "pe" = (
 /obj/structure/machinery/colony_floodlight{
 	pixel_y = 10
@@ -631,12 +659,16 @@
 	},
 <<<<<<< master
 <<<<<<< master
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
 =======
 >>>>>>> reimported backup
 =======
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 >>>>>>> added spawn pointss for clf survivors
+=======
+/obj/effect/landmark/survivor_spawner/clf/generic,
+>>>>>>> Updated CLF spawner
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
 "vo" = (
@@ -649,12 +681,16 @@
 /obj/effect/landmark/corpsespawner/chef,
 <<<<<<< master
 <<<<<<< master
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
 =======
 >>>>>>> reimported backup
 =======
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 >>>>>>> added spawn pointss for clf survivors
+=======
+/obj/effect/landmark/survivor_spawner/clf/generic,
+>>>>>>> Updated CLF spawner
 /turf/open/floor/kutjevo/grey/plate,
 /area/kutjevo/interior/construction)
 "wv" = (
@@ -769,7 +805,6 @@
 /area/kutjevo/interior/construction)
 "DU" = (
 /obj/effect/spawner/random/attachment,
-/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
 "DX" = (
@@ -894,6 +929,7 @@
 "FX" = (
 /obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/kutjevo/grey/plate,
+<<<<<<< master
 /area/kutjevo/interior/construction)
 =======
 =======
@@ -911,6 +947,8 @@
 /obj/item/ammo_casing/bullet,
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/kutjevo/colors/purple,
+=======
+>>>>>>> Updated CLF spawner
 /area/kutjevo/interior/construction)
 >>>>>>> added spawn pointss for clf survivors
 "Gt" = (
@@ -933,7 +971,6 @@
 /area/kutjevo/interior/construction)
 "Hd" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
-/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/kutjevo/colors/purple/edge{
 	dir = 5
 	},
@@ -964,10 +1001,16 @@
 >>>>>>> reimported backup
 =======
 "ID" = (
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/auto_turf/sand/layer1,
 /area/kutjevo/exterior/complex_border/med_rec)
 >>>>>>> added spawn pointss for clf survivors
+=======
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/floor/kutjevo/colors/purple,
+/area/kutjevo/interior/construction)
+>>>>>>> Updated CLF spawner
 "IR" = (
 /obj/structure/barricade/metal/wired{
 	icon_state = "metal_2"
@@ -1072,7 +1115,7 @@
 >>>>>>> reimported backup
 =======
 "Op" = (
-/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
 >>>>>>> added spawn pointss for clf survivors
@@ -1116,7 +1159,6 @@
 /area/kutjevo/interior/construction)
 "Rb" = (
 /obj/effect/spawner/random/attachment,
-/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/kutjevo/colors/purple,
 /area/kutjevo/interior/construction)
 "Rc" = (
@@ -1153,12 +1195,16 @@
 	},
 <<<<<<< master
 <<<<<<< master
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
 =======
 >>>>>>> reimported backup
 =======
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 >>>>>>> added spawn pointss for clf survivors
+=======
+/obj/effect/landmark/survivor_spawner/clf/generic,
+>>>>>>> Updated CLF spawner
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
 "Si" = (
@@ -1202,12 +1248,16 @@
 /obj/effect/spawner/random/attachment,
 <<<<<<< master
 <<<<<<< master
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
 =======
 >>>>>>> reimported backup
 =======
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 >>>>>>> added spawn pointss for clf survivors
+=======
+/obj/effect/landmark/survivor_spawner/clf/generic,
+>>>>>>> Updated CLF spawner
 /turf/open/floor/kutjevo/colors/purple,
 /area/kutjevo/interior/construction)
 "Tv" = (
@@ -1222,6 +1272,7 @@
 	},
 /area/kutjevo/interior/construction)
 <<<<<<< master
+<<<<<<< master
 =======
 "TK" = (
 /obj/item/stool{
@@ -1231,6 +1282,8 @@
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
 >>>>>>> reimported backup
+=======
+>>>>>>> Updated CLF spawner
 "Ua" = (
 /obj/structure/barricade/plasteel/wired{
 	dir = 8;
@@ -1270,8 +1323,10 @@
 >>>>>>> reimported backup
 =======
 "UD" = (
-/obj/structure/machinery/light,
-/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_2"
+	},
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/kutjevo/colors/purple/edge,
 /area/kutjevo/interior/construction)
 >>>>>>> added spawn pointss for clf survivors
@@ -1289,12 +1344,18 @@
 >>>>>>> reimported backup
 =======
 "UU" = (
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/kutjevo/colors/purple/edge{
 	dir = 1
 	},
 /area/kutjevo/interior/construction)
 >>>>>>> added spawn pointss for clf survivors
+=======
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/auto_turf/sand/layer0,
+/area/kutjevo/exterior/complex_border/med_rec)
+>>>>>>> Updated CLF spawner
 "Ve" = (
 /obj/structure/machinery/door/airlock/almayer/maint/autoname{
 	dir = 1;
@@ -1385,10 +1446,17 @@
 >>>>>>> reimported backup
 =======
 "Yz" = (
-/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/obj/structure/platform_decoration/kutjevo{
+	dir = 8
+	},
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/auto_turf/sand/layer1,
+<<<<<<< master
 /area/kutjevo/interior/construction)
 >>>>>>> added spawn pointss for clf survivors
+=======
+/area/kutjevo/exterior/complex_border/med_rec)
+>>>>>>> Updated CLF spawner
 "YJ" = (
 /obj/effect/landmark/corpsespawner/security/cmb,
 /obj/effect/decal/cleanable/blood,
@@ -1477,7 +1545,7 @@
 QK
 DE
 DE
-Yz
+DE
 Ms
 fi
 hv
@@ -1496,10 +1564,14 @@ Ro
 uv
 rG
 <<<<<<< master
+<<<<<<< master
 oO
 =======
 ZT
 >>>>>>> reimported backup
+=======
+oO
+>>>>>>> Updated CLF spawner
 QR
 fi
 Vg
@@ -1523,6 +1595,7 @@ ZT
 fi
 QN
 <<<<<<< master
+<<<<<<< master
 gw
 gw
 gw
@@ -1531,8 +1604,11 @@ hv
 ns
 =======
 TK
+=======
+>>>>>>> Updated CLF spawner
 gw
-TK
+gw
+gw
 Cx
 hv
 <<<<<<< master
@@ -1545,8 +1621,12 @@ Wm
 hp
 =======
 ns
+<<<<<<< master
 FX
 >>>>>>> added spawn pointss for clf survivors
+=======
+hp
+>>>>>>> Updated CLF spawner
 tN
 IB
 Ro
@@ -1601,8 +1681,12 @@ oo
 Fv
 sx
 nn
+<<<<<<< master
 fb
 >>>>>>> reimported backup
+=======
+Yz
+>>>>>>> Updated CLF spawner
 Ro
 Ro
 "}
@@ -1611,6 +1695,7 @@ fi
 xK
 sx
 <<<<<<< master
+<<<<<<< master
 ID
 ck
 uj
@@ -1625,17 +1710,29 @@ TK
 TK
 TK
 >>>>>>> reimported backup
+=======
+ID
+ck
+uj
+gw
+gw
+gw
+>>>>>>> Updated CLF spawner
 Cx
 hv
 aG
 hp
 <<<<<<< master
+<<<<<<< master
 UD
 =======
 tN
 >>>>>>> reimported backup
+=======
+UD
+>>>>>>> Updated CLF spawner
 IB
-ID
+Ro
 Ro
 "}
 (7,1,1) = {"
@@ -1705,10 +1802,14 @@ fi
 Vu
 xQ
 <<<<<<< master
+<<<<<<< master
 FX
 =======
 QK
 >>>>>>> reimported backup
+=======
+FX
+>>>>>>> Updated CLF spawner
 Rb
 xk
 YJ
@@ -1741,13 +1842,18 @@ ET
 wb
 QK
 <<<<<<< master
+<<<<<<< master
 ID
 =======
 sx
 >>>>>>> reimported backup
+=======
+ID
+>>>>>>> Updated CLF spawner
 Fv
-Op
+uc
 RP
+<<<<<<< master
 <<<<<<< master
 uc
 uc
@@ -1758,18 +1864,26 @@ Op
 Op
 Op
 >>>>>>> added spawn pointss for clf survivors
+=======
+>>>>>>> Updated CLF spawner
 uc
 >>>>>>> reimported backup
+uc
+Op
 uc
 Cx
 hv
 Qk
 Me
 <<<<<<< master
+<<<<<<< master
 UU
 =======
 Ft
 >>>>>>> reimported backup
+=======
+UU
+>>>>>>> Updated CLF spawner
 "}
 (11,1,1) = {"
 fi
@@ -1778,6 +1892,7 @@ sT
 Vl
 jM
 <<<<<<< master
+<<<<<<< master
 Fv
 <<<<<<< master
 Op
@@ -1787,6 +1902,10 @@ UU
 >>>>>>> added spawn pointss for clf survivors
 uc
 >>>>>>> reimported backup
+=======
+Fv
+Op
+>>>>>>> Updated CLF spawner
 ji
 dL
 KH
@@ -1795,7 +1914,7 @@ or
 Jj
 Ms
 ZS
-oO
+IB
 Ro
 "}
 (12,1,1) = {"
@@ -1805,15 +1924,20 @@ hv
 hv
 fi
 xY
-Op
 uc
 uc
+<<<<<<< master
 Oq
 <<<<<<< master
 Op
 =======
 uc
 >>>>>>> reimported backup
+=======
+uc
+Oq
+Op
+>>>>>>> Updated CLF spawner
 Jt
 Ed
 it
@@ -1829,10 +1953,14 @@ DE
 cR
 uj
 <<<<<<< master
+<<<<<<< master
 Op
 =======
 uc
 >>>>>>> reimported backup
+=======
+Op
+>>>>>>> Updated CLF spawner
 Jt
 ac
 uc
@@ -1865,15 +1993,19 @@ fi
 RJ
 Cp
 <<<<<<< master
+<<<<<<< master
 Op
 =======
 uc
 >>>>>>> reimported backup
+=======
+Op
+>>>>>>> Updated CLF spawner
 kX
 YX
 Si
 uc
-UD
+Jj
 Ms
 ZS
 ue
@@ -1892,10 +2024,14 @@ uc
 uM
 uM
 <<<<<<< master
+<<<<<<< master
 Op
 =======
 uc
 >>>>>>> reimported backup
+=======
+Op
+>>>>>>> Updated CLF spawner
 io
 hv
 zt

--- a/maps/map_files/Kutjevo/sprinkles/25.kutjevoclf01.dmm
+++ b/maps/map_files/Kutjevo/sprinkles/25.kutjevoclf01.dmm
@@ -1,10 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "ac" = (
 /obj/effect/decal/cleanable/blood,
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
-=======
->>>>>>> reimported backup
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
 "ad" = (
@@ -23,7 +20,6 @@
 /obj/item/explosive/mine/clf/active{
 	dir = 8
 	},
-/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/kutjevo/colors/purple/edge{
 	dir = 4
 	},
@@ -32,10 +28,7 @@
 /obj/effect/landmark/corpsespawner/colonist,
 /obj/item/weapon/gun/pistol/holdout,
 /obj/effect/decal/cleanable/blood,
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/clf/generic,
-=======
->>>>>>> reimported backup
 /turf/open/floor/kutjevo/colors/purple/edge{
 	dir = 1
 	},
@@ -212,8 +205,7 @@
 /obj/item/stool{
 	pixel_y = 8
 	},
-/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
 "gy" = (
@@ -285,8 +277,6 @@
 <<<<<<< master
 /obj/item/explosive/mine/clf/active,
 /obj/effect/landmark/survivor_spawner/clf/generic,
-=======
->>>>>>> reimported backup
 /turf/open/floor/plating/kutjevo,
 /area/kutjevo/interior/construction)
 "iM" = (
@@ -367,7 +357,6 @@
 	dir = 8
 	},
 /obj/effect/spawner/random/attachment,
-/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/kutjevo/colors/purple/edge{
 	dir = 4
 	},
@@ -406,6 +395,7 @@
 /area/kutjevo/interior/foremans_office)
 "ns" = (
 /obj/item/explosive/mine/clf/active,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/kutjevo/colors/purple/edge{
 	dir = 1
 	},
@@ -429,12 +419,10 @@
 /turf/closed/wall/kutjevo/colony/reinforced,
 /area/kutjevo/interior/foremans_office)
 "oO" = (
-/obj/structure/platform/kutjevo{
-	dir = 1
-	},
-/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-/turf/open/auto_turf/sand/layer0,
-/area/kutjevo/exterior/complex_border/med_rec)
+/obj/item/ammo_magazine/smg/nailgun,
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/floor/kutjevo/grey/plate,
+/area/kutjevo/interior/construction)
 "pe" = (
 /obj/structure/machinery/colony_floodlight{
 	pixel_y = 10
@@ -549,7 +537,7 @@
 	dir = 8;
 	tag = "icon-chair (WEST)"
 	},
-/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
 "vo" = (
@@ -560,7 +548,7 @@
 /obj/effect/decal/cleanable/blood,
 /obj/item/weapon/gun/pistol/holdout,
 /obj/effect/landmark/corpsespawner/chef,
-/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/kutjevo/grey/plate,
 /area/kutjevo/interior/construction)
 "wv" = (
@@ -675,7 +663,6 @@
 /area/kutjevo/interior/construction)
 "DU" = (
 /obj/effect/spawner/random/attachment,
-/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
 "DX" = (
@@ -793,9 +780,8 @@
 /turf/open/auto_turf/sand/layer0,
 /area/kutjevo/exterior/complex_border/med_rec)
 "FX" = (
-/obj/item/ammo_casing/bullet,
-/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-/turf/open/floor/kutjevo/colors/purple,
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/floor/kutjevo/grey/plate,
 /area/kutjevo/interior/construction)
 "Gt" = (
 /obj/structure/platform/kutjevo{
@@ -817,7 +803,6 @@
 /area/kutjevo/interior/construction)
 "Hd" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
-/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/kutjevo/colors/purple/edge{
 	dir = 5
 	},
@@ -839,9 +824,9 @@
 /turf/open/auto_turf/sand/layer0,
 /area/kutjevo/exterior/complex_border/med_rec)
 "ID" = (
-/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-/turf/open/auto_turf/sand/layer1,
-/area/kutjevo/exterior/complex_border/med_rec)
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/floor/kutjevo/colors/purple,
+/area/kutjevo/interior/construction)
 "IR" = (
 /obj/structure/barricade/metal/wired{
 	icon_state = "metal_2"
@@ -937,7 +922,7 @@
 	},
 /area/kutjevo/interior/construction)
 "Op" = (
-/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
 "Oq" = (
@@ -980,7 +965,6 @@
 /area/kutjevo/interior/construction)
 "Rb" = (
 /obj/effect/spawner/random/attachment,
-/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/kutjevo/colors/purple,
 /area/kutjevo/interior/construction)
 "Rc" = (
@@ -1015,7 +999,7 @@
 /obj/structure/bed/chair{
 	dir = 4
 	},
-/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
 "Si" = (
@@ -1048,7 +1032,7 @@
 "Tb" = (
 /obj/item/stack/rods,
 /obj/effect/spawner/random/attachment,
-/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/kutjevo/colors/purple,
 /area/kutjevo/interior/construction)
 "Tv" = (
@@ -1062,16 +1046,6 @@
 	dir = 8
 	},
 /area/kutjevo/interior/construction)
-<<<<<<< master
-=======
-"TK" = (
-/obj/item/stool{
-	pixel_y = 8
-	},
-/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-/turf/open/floor/kutjevo/tan,
-/area/kutjevo/interior/construction)
->>>>>>> reimported backup
 "Ua" = (
 /obj/structure/barricade/plasteel/wired{
 	dir = 8;
@@ -1099,8 +1073,10 @@
 /turf/closed/wall/kutjevo/colony/reinforced,
 /area/kutjevo/interior/foremans_office)
 "UD" = (
-/obj/structure/machinery/light,
-/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_2"
+	},
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/kutjevo/colors/purple/edge,
 /area/kutjevo/interior/construction)
 "UP" = (
@@ -1108,11 +1084,9 @@
 /turf/open/floor/plating/kutjevo,
 /area/kutjevo/interior/foremans_office)
 "UU" = (
-/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-/turf/open/floor/kutjevo/colors/purple/edge{
-	dir = 1
-	},
-/area/kutjevo/interior/construction)
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/auto_turf/sand/layer0,
+/area/kutjevo/exterior/complex_border/med_rec)
 "Ve" = (
 /obj/structure/machinery/door/airlock/almayer/maint/autoname{
 	dir = 1;
@@ -1191,9 +1165,12 @@
 /turf/open/auto_turf/sand/layer2,
 /area/kutjevo/interior/construction)
 "Yz" = (
-/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/obj/structure/platform_decoration/kutjevo{
+	dir = 8
+	},
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/auto_turf/sand/layer1,
-/area/kutjevo/interior/construction)
+/area/kutjevo/exterior/complex_border/med_rec)
 "YJ" = (
 /obj/effect/landmark/corpsespawner/security/cmb,
 /obj/effect/decal/cleanable/blood,
@@ -1282,7 +1259,7 @@
 QK
 DE
 DE
-Yz
+DE
 Ms
 fi
 hv
@@ -1300,11 +1277,7 @@ Ro
 (2,1,1) = {"
 uv
 rG
-<<<<<<< master
 oO
-=======
-ZT
->>>>>>> reimported backup
 QR
 fi
 Vg
@@ -1327,21 +1300,13 @@ Hu
 ZT
 fi
 QN
-<<<<<<< master
 gw
 gw
 gw
 Cx
 hv
 ns
-=======
-TK
-gw
-TK
-Cx
-hv
-ns
-FX
+hp
 tN
 IB
 Ro
@@ -1382,13 +1347,6 @@ Fv
 sx
 nn
 Yz
-=======
-ln
-Fv
-sx
-nn
-fb
->>>>>>> reimported backup
 Ro
 Ro
 "}
@@ -1396,32 +1354,19 @@ Ro
 fi
 xK
 sx
-<<<<<<< master
 ID
 ck
 uj
 gw
 gw
 gw
-=======
-sx
-ck
-uj
-TK
-TK
-TK
->>>>>>> reimported backup
 Cx
 hv
 aG
 hp
-<<<<<<< master
 UD
-=======
-tN
->>>>>>> reimported backup
 IB
-ID
+Ro
 Ro
 "}
 (7,1,1) = {"
@@ -1466,11 +1411,7 @@ Ft
 fi
 Vu
 xQ
-<<<<<<< master
 FX
-=======
-QK
->>>>>>> reimported backup
 Rb
 xk
 YJ
@@ -1490,27 +1431,19 @@ fi
 ET
 wb
 QK
-<<<<<<< master
 ID
-=======
-sx
->>>>>>> reimported backup
 Fv
-Op
-RP
-Op
-Op
 uc
+RP
+uc
+uc
+Op
 uc
 Cx
 hv
 Qk
 Me
-<<<<<<< master
 UU
-=======
-Ft
->>>>>>> reimported backup
 "}
 (11,1,1) = {"
 fi
@@ -1518,9 +1451,8 @@ ed
 sT
 Vl
 jM
-UU
-uc
->>>>>>> reimported backup
+Fv
+Op
 ji
 dL
 KH
@@ -1529,7 +1461,7 @@ or
 Jj
 Ms
 ZS
-oO
+IB
 Ro
 "}
 (12,1,1) = {"
@@ -1539,15 +1471,11 @@ hv
 hv
 fi
 xY
-Op
+uc
 uc
 uc
 Oq
-<<<<<<< master
 Op
-=======
-uc
->>>>>>> reimported backup
 Jt
 Ed
 it
@@ -1562,11 +1490,7 @@ QK
 DE
 cR
 uj
-<<<<<<< master
 Op
-=======
-uc
->>>>>>> reimported backup
 Jt
 ac
 uc
@@ -1586,16 +1510,12 @@ QK
 fi
 RJ
 Cp
-<<<<<<< master
 Op
-=======
-uc
->>>>>>> reimported backup
 kX
 YX
 Si
 uc
-UD
+Jj
 Ms
 ZS
 ue
@@ -1613,11 +1533,7 @@ Hd
 uc
 uM
 uM
-<<<<<<< master
 Op
-=======
-uc
->>>>>>> reimported backup
 io
 hv
 zt

--- a/maps/map_files/LV624/LV624.dmm
+++ b/maps/map_files/LV624/LV624.dmm
@@ -15777,10 +15777,14 @@
 "gHv" = (
 /obj/effect/landmark/nightmare{
 <<<<<<< master
+<<<<<<< master
 	insert_tag = "clfhydrohold"
 =======
 	insert_tag = clfhydrohold
 >>>>>>> added nightmare insert tags to main maps
+=======
+	insert_tag = "clfhydrohold"
+>>>>>>> fixed issue with invalid landmark
 	},
 /turf/open/gm/dirt,
 /area/lv624/ground/colony/south_medbay_road)

--- a/maps/map_files/LV624/LV624.dmm
+++ b/maps/map_files/LV624/LV624.dmm
@@ -15776,7 +15776,7 @@
 /area/lv624/ground/jungle/south_central_jungle)
 "gHv" = (
 /obj/effect/landmark/nightmare{
-	insert_tag = clfhydrohold
+	insert_tag = "clfhydrohold"
 	},
 /turf/open/gm/dirt,
 /area/lv624/ground/colony/south_medbay_road)

--- a/maps/map_files/LV624/LV624.dmm
+++ b/maps/map_files/LV624/LV624.dmm
@@ -15774,6 +15774,12 @@
 /obj/structure/flora/bush/ausbushes/var3/sparsegrass,
 /turf/open/gm/grass,
 /area/lv624/ground/jungle/south_central_jungle)
+"gHv" = (
+/obj/effect/landmark/nightmare{
+	insert_tag = clfhydrohold
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/colony/south_medbay_road)
 "gKg" = (
 /obj/item/clothing/head/hardhat/orange,
 /turf/open/floor/plating{
@@ -44185,7 +44191,7 @@ jHN
 jHN
 jHN
 szy
-udP
+gHv
 udP
 udP
 udP

--- a/maps/map_files/LV624/LV624.dmm
+++ b/maps/map_files/LV624/LV624.dmm
@@ -15776,7 +15776,11 @@
 /area/lv624/ground/jungle/south_central_jungle)
 "gHv" = (
 /obj/effect/landmark/nightmare{
+<<<<<<< master
 	insert_tag = "clfhydrohold"
+=======
+	insert_tag = clfhydrohold
+>>>>>>> added nightmare insert tags to main maps
 	},
 /turf/open/gm/dirt,
 /area/lv624/ground/colony/south_medbay_road)

--- a/maps/map_files/LV624/sprinkles/25.clfhydrohold.dmm
+++ b/maps/map_files/LV624/sprinkles/25.clfhydrohold.dmm
@@ -101,12 +101,28 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
+"gp" = (
+/obj/item/explosive/mine/clf/active,
+/turf/open/gm/dirt,
+/area/lv624/ground/colony/north_nexus_road)
 "hj" = (
 /obj/item/stack/sheet/metal,
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
 /area/lv624/lazarus/hydroponics)
+"iM" = (
+/obj/item/explosive/mine/clf/active{
+	dir = 8
+	},
+/turf/open/gm/grass,
+/area/lv624/ground/jungle/north_jungle)
+"jn" = (
+/obj/item/explosive/mine/clf/active{
+	dir = 8
+	},
+/turf/open/gm/grass,
+/area/lv624/ground/colony/south_medbay_road)
 "jA" = (
 /obj/structure/surface/table,
 /obj/effect/landmark/wo_supplies/storage/webbing,
@@ -139,6 +155,9 @@
 "kV" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/effect/decal/cleanable/ash,
+/obj/item/explosive/mine/clf/active{
+	dir = 4
+	},
 /turf/open/floor{
 	dir = 9;
 	icon_state = "green"
@@ -151,6 +170,14 @@
 	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
+	},
+/area/lv624/lazarus/hydroponics)
+"lU" = (
+/obj/structure/surface/table,
+/obj/item/stack/sheet/wood/large_stack,
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
 "me" = (
@@ -222,6 +249,17 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
+"pv" = (
+/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/decal/cleanable/ash,
+/obj/item/explosive/mine/clf/active{
+	dir = 8
+	},
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
 "pw" = (
 /obj/structure/barricade/metal/wired{
 	icon_state = "metal_1";
@@ -236,6 +274,7 @@
 	},
 /area/lv624/lazarus/hydroponics)
 "pK" = (
+/obj/item/explosive/mine/clf/active,
 /turf/open/gm/dirtgrassborder{
 	icon_state = "grassdirt_corner2"
 	},
@@ -298,6 +337,12 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
+"tj" = (
+/obj/item/explosive/mine/clf/active{
+	dir = 1
+	},
+/turf/open/gm/grass,
+/area/lv624/ground/jungle/north_jungle)
 "vh" = (
 /turf/open/floor,
 /area/lv624/lazarus/hydroponics)
@@ -352,6 +397,7 @@
 /area/lv624/lazarus/hydroponics)
 "wj" = (
 /obj/structure/surface/table,
+/obj/item/stack/sheet/metal/large_stack,
 /turf/open/floor{
 	dir = 9;
 	icon_state = "green"
@@ -368,6 +414,10 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
+"xs" = (
+/obj/item/explosive/mine/clf/active,
+/turf/open/gm/dirt,
+/area/lv624/ground/colony/south_medbay_road)
 "xX" = (
 /obj/structure/barricade/plasteel/wired{
 	icon_state = "plasteel_closed_1";
@@ -456,6 +506,7 @@
 "EG" = (
 /obj/effect/decal/cleanable/ash,
 /obj/effect/decal/cleanable/blood/oil,
+/obj/item/explosive/mine/clf/active,
 /turf/open/floor{
 	dir = 9;
 	icon_state = "green"
@@ -511,6 +562,24 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
+"Gy" = (
+/obj/structure/surface/table,
+/obj/item/clothing/glasses/welding{
+	pixel_y = 9;
+	pixel_x = -12
+	},
+/obj/item/tool/weldingtool{
+	pixel_y = -9;
+	pixel_x = 11
+	},
+/obj/item/tool/weldpack{
+	pixel_y = 8
+	},
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
 "GS" = (
 /turf/open/floor{
 	dir = 8;
@@ -523,6 +592,18 @@
 	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
+	},
+/area/lv624/lazarus/hydroponics)
+"Ht" = (
+/obj/structure/surface/table,
+/obj/item/explosive/mine/clf,
+/obj/item/explosive/mine/clf,
+/obj/item/explosive/mine/clf,
+/obj/item/explosive/mine/clf,
+/obj/item/explosive/mine/clf,
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
 "HU" = (
@@ -594,6 +675,12 @@
 /obj/structure/fence,
 /turf/open/gm/dirtgrassborder,
 /area/lv624/ground/colony/north_nexus_road)
+"Ks" = (
+/obj/item/explosive/mine/clf/active{
+	dir = 4
+	},
+/turf/open/gm/grass,
+/area/lv624/ground/jungle/north_jungle)
 "Kt" = (
 /obj/structure/surface/table,
 /obj/item/ammo_box/magazine/M16,
@@ -643,6 +730,17 @@
 /obj/item/stack/sheet/wood/small_stack,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
+	},
+/area/lv624/lazarus/hydroponics)
+"NX" = (
+/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/decal/cleanable/ash,
+/obj/item/explosive/mine/clf/active{
+	dir = 1
+	},
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
 "OJ" = (
@@ -755,6 +853,8 @@
 	},
 /area/lv624/lazarus/hydroponics)
 "RZ" = (
+/obj/item/explosive/mine/clf/active,
+/obj/item/explosive/mine/clf/active,
 /turf/open/gm/dirtgrassborder{
 	dir = 4;
 	icon_state = "grassdirt_corner2"
@@ -850,6 +950,13 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
+"WZ" = (
+/obj/structure/flora/bush/ausbushes/genericbush,
+/obj/item/explosive/mine/clf/active{
+	dir = 8
+	},
+/turf/open/gm/grass,
+/area/lv624/ground/jungle/north_jungle)
 "Xk" = (
 /turf/open/floor{
 	dir = 9;
@@ -914,16 +1021,16 @@ Tx
 DE
 DE
 DE
-DE
-HU
+iM
+WZ
 Ec
 Ec
-kV
-kV
+pv
+pv
 Ec
 Ec
-Cb
-Cb
+jn
+jn
 Cb
 rK
 Tx
@@ -948,7 +1055,7 @@ Tx
 "}
 (4,1,1) = {"
 DE
-DE
+tj
 XF
 nw
 Fn
@@ -966,7 +1073,7 @@ Tx
 "}
 (5,1,1) = {"
 DE
-DE
+tj
 Ew
 WY
 Tu
@@ -979,7 +1086,7 @@ yr
 HW
 cF
 SQ
-Tx
+xs
 Tx
 "}
 (6,1,1) = {"
@@ -1001,26 +1108,26 @@ Ec
 Tx
 "}
 (7,1,1) = {"
-DE
+tj
 Jj
 WY
 Xk
 Xk
-wj
+Ht
 LS
 ne
 Rw
-wj
-wj
+Gy
+lU
 Xk
 Jp
 Ql
 Gs
-vN
+gp
 "}
 (8,1,1) = {"
 DE
-kV
+NX
 Ph
 Xk
 Xk
@@ -1038,7 +1145,7 @@ vN
 "}
 (9,1,1) = {"
 DE
-kV
+NX
 Ph
 Cj
 Xk
@@ -1055,7 +1162,7 @@ EG
 vN
 "}
 (10,1,1) = {"
-DE
+tj
 wa
 WY
 Xk
@@ -1070,7 +1177,7 @@ Md
 XR
 Ql
 bR
-vN
+gp
 "}
 (11,1,1) = {"
 DE
@@ -1092,7 +1199,7 @@ vN
 "}
 (12,1,1) = {"
 DE
-DE
+tj
 qC
 bY
 Xk
@@ -1105,12 +1212,12 @@ Xk
 Cj
 Ql
 cs
-vN
+gp
 vN
 "}
 (13,1,1) = {"
 DE
-DE
+tj
 SQ
 Pe
 wx
@@ -1148,16 +1255,16 @@ vN
 DE
 DE
 DE
-DE
-DE
+Ks
+Ks
 Ec
 Ew
 kV
 kV
 Bj
 Ec
-DE
-DE
+Ks
+Ks
 DE
 Km
 vN

--- a/maps/map_files/LV624/sprinkles/25.clfhydrohold.dmm
+++ b/maps/map_files/LV624/sprinkles/25.clfhydrohold.dmm
@@ -1,0 +1,1164 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"as" = (
+/obj/item/ammo_magazine/shotgun/slugs,
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
+"ay" = (
+/obj/item/stack/sheet/wood/small_stack{
+	pixel_y = 8
+	},
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/lv624/lazarus/hydroponics)
+"bJ" = (
+/obj/structure/surface/table,
+/obj/item/weapon/gun/rifle/m16{
+	pixel_x = 5;
+	pixel_y = 6
+	},
+/obj/item/weapon/gun/rifle/m16,
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
+"bR" = (
+/obj/structure/window_frame/colony/reinforced,
+/obj/item/shard{
+	icon_state = "large";
+	pixel_y = -7;
+	pixel_x = -9
+	},
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
+"bY" = (
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1";
+	dir = 1
+	},
+/obj/effect/landmark/corpsespawner/colonist,
+/obj/item/weapon/gun/pistol/holdout{
+	pixel_y = -11;
+	pixel_x = -11
+	},
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
+"cj" = (
+/obj/item/stack/sheet/wood/small_stack{
+	pixel_y = -22;
+	pixel_x = 10
+	},
+/obj/item/stack/sheet/wood/small_stack,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/lv624/lazarus/hydroponics)
+"cs" = (
+/obj/structure/window_frame/colony/reinforced,
+/obj/item/shard{
+	icon_state = "medium";
+	pixel_y = 7;
+	pixel_x = -11
+	},
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
+"cF" = (
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_2"
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/lv624/lazarus/hydroponics)
+"eE" = (
+/obj/structure/machinery/light,
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
+"fO" = (
+/obj/structure/barricade/plasteel/wired{
+	icon_state = "plasteel_closed_1";
+	dir = 4
+	},
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
+"hj" = (
+/obj/item/stack/sheet/metal,
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/lv624/lazarus/hydroponics)
+"jA" = (
+/obj/structure/surface/table,
+/obj/effect/landmark/wo_supplies/storage/webbing,
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
+"jL" = (
+/obj/item/ammo_casing/bullet,
+/obj/item/ammo_magazine/shotgun/buckshot,
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
+"kN" = (
+/obj/structure/barricade/wooden{
+	dir = 8
+	},
+/obj/item/stack/sheet/wood/small_stack{
+	pixel_x = 4;
+	pixel_y = 7
+	},
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
+"kV" = (
+/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/decal/cleanable/ash,
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
+"kY" = (
+/obj/structure/barricade/wooden{
+	dir = 1;
+	pixel_y = 7
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/lv624/lazarus/hydroponics)
+"me" = (
+/obj/structure/surface/table,
+/obj/item/ammo_magazine/rifle/m16/ap{
+	pixel_x = -8
+	},
+/obj/item/ammo_magazine/rifle/m16/ap{
+	pixel_x = -6
+	},
+/obj/item/ammo_magazine/rifle/m16/ap{
+	pixel_x = -4
+	},
+/obj/item/ammo_magazine/rifle/m16/ap{
+	pixel_x = -4
+	},
+/obj/item/ammo_magazine/rifle/m16/ap{
+	pixel_x = -2
+	},
+/obj/item/ammo_magazine/rifle/m16/ap,
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
+"mn" = (
+/obj/structure/machinery/light{
+	dir = 4
+	},
+/obj/effect/spawner/random/attachment,
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
+"mH" = (
+/obj/item/frame/table{
+	pixel_y = -5;
+	pixel_x = 6
+	},
+/turf/open/floor{
+	dir = 8;
+	icon_state = "damaged3"
+	},
+/area/lv624/lazarus/hydroponics)
+"ne" = (
+/obj/effect/landmark/corpsespawner/doctor,
+/obj/item/tool/crowbar/red{
+	pixel_x = -7;
+	pixel_y = 8
+	},
+/obj/effect/spawner/random/attachment,
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
+"nw" = (
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1";
+	dir = 8
+	},
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1";
+	dir = 1
+	},
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
+"pw" = (
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1";
+	dir = 4
+	},
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1"
+	},
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
+"pK" = (
+/turf/open/gm/dirtgrassborder{
+	icon_state = "grassdirt_corner2"
+	},
+/area/lv624/ground/colony/south_medbay_road)
+"qC" = (
+/obj/structure/window_frame/colony/reinforced,
+/obj/item/shard{
+	icon_state = "large"
+	},
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
+"qN" = (
+/obj/structure/barricade/wooden{
+	dir = 4
+	},
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
+"rG" = (
+/obj/structure/barricade/wooden{
+	dir = 8
+	},
+/obj/item/stack/sheet/wood/small_stack{
+	pixel_y = 19;
+	pixel_x = -22
+	},
+/obj/item/ammo_casing/bullet,
+/obj/effect/spawner/random/attachment,
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
+"rK" = (
+/obj/structure/fence,
+/turf/open/gm/dirtgrassborder,
+/area/lv624/ground/colony/south_medbay_road)
+"sc" = (
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1";
+	dir = 4
+	},
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
+"sY" = (
+/obj/structure/barricade/wooden{
+	dir = 4
+	},
+/obj/item/stack/sheet/wood/small_stack,
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
+"vh" = (
+/turf/open/floor,
+/area/lv624/lazarus/hydroponics)
+"vK" = (
+/obj/structure/barricade/wooden{
+	dir = 1;
+	pixel_y = 7
+	},
+/obj/structure/barricade/wooden{
+	dir = 8
+	},
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
+"vM" = (
+/obj/structure/machinery/power/apc{
+	dir = 1;
+	name = "Hydroponics APC";
+	pixel_y = 30;
+	start_charge = 0
+	},
+/obj/structure/surface/rack,
+/obj/item/storage/firstaid/adv{
+	pixel_y = -4;
+	pixel_x = -3
+	},
+/obj/effect/landmark/wo_supplies/storage/webbing,
+/obj/item/storage/firstaid/adv{
+	pixel_x = 6;
+	pixel_y = 3
+	},
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
+"vN" = (
+/turf/open/gm/dirt,
+/area/lv624/ground/colony/north_nexus_road)
+"wa" = (
+/obj/structure/window_frame/colony/reinforced,
+/obj/item/shard{
+	icon_state = "medium";
+	pixel_y = -5
+	},
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
+"wj" = (
+/obj/structure/surface/table,
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
+"wx" = (
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1";
+	dir = 4
+	},
+/obj/item/ammo_casing/bullet,
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
+"xX" = (
+/obj/structure/barricade/plasteel/wired{
+	icon_state = "plasteel_closed_1";
+	dir = 8
+	},
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
+"yk" = (
+/obj/effect/landmark/corpsespawner/bridgeofficer,
+/obj/item/weapon/gun/pistol/heavy/co{
+	pixel_x = 3;
+	pixel_y = 11
+	},
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
+"yr" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
+"zV" = (
+/obj/structure/machinery/light{
+	dir = 1
+	},
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
+"Bj" = (
+/obj/structure/window_frame/colony/reinforced,
+/obj/item/shard{
+	icon_state = "medium";
+	pixel_y = 5;
+	pixel_x = -11
+	},
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
+"BL" = (
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1";
+	dir = 8
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/lv624/lazarus/hydroponics)
+"Cb" = (
+/turf/open/gm/grass,
+/area/lv624/ground/colony/south_medbay_road)
+"Cj" = (
+/obj/item/ammo_casing/bullet,
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
+"DE" = (
+/turf/open/gm/grass,
+/area/lv624/ground/jungle/north_jungle)
+"Ec" = (
+/turf/closed/wall/r_wall,
+/area/lv624/lazarus/hydroponics)
+"Ew" = (
+/obj/structure/window_frame/colony/reinforced,
+/obj/item/shard{
+	icon_state = "large";
+	pixel_x = 7
+	},
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
+"EG" = (
+/obj/effect/decal/cleanable/ash,
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
+"Fn" = (
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1";
+	dir = 8
+	},
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
+"Gj" = (
+/obj/structure/barricade/wooden{
+	dir = 8
+	},
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
+"Gs" = (
+/obj/structure/window_frame/colony/reinforced,
+/obj/item/shard{
+	icon_state = "large";
+	pixel_x = 7;
+	pixel_y = 14
+	},
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
+"Gw" = (
+/obj/structure/machinery/light{
+	dir = 1
+	},
+/obj/effect/landmark/corpsespawner/PMC,
+/obj/item/weapon/gun/smg/fp9000{
+	pixel_y = 6;
+	pixel_x = 11
+	},
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
+"GS" = (
+/turf/open/floor{
+	dir = 8;
+	icon_state = "damaged3"
+	},
+/area/lv624/lazarus/hydroponics)
+"Hr" = (
+/obj/structure/barricade/wooden{
+	dir = 8
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/lv624/lazarus/hydroponics)
+"HU" = (
+/obj/structure/flora/bush/ausbushes/genericbush,
+/turf/open/gm/grass,
+/area/lv624/ground/jungle/north_jungle)
+"HW" = (
+/obj/effect/landmark/corpsespawner/security/cmb,
+/obj/item/weapon/gun/shotgun/pump/cmb{
+	pixel_y = 8;
+	pixel_x = 16
+	},
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/lv624/lazarus/hydroponics)
+"Ih" = (
+/obj/item/device/radio/intercom{
+	freerange = 1;
+	frequency = 1469;
+	name = "General Listening Channel";
+	pixel_x = -30
+	},
+/obj/structure/surface/rack,
+/obj/item/explosive/grenade/incendiary/molotov{
+	pixel_x = -5;
+	pixel_y = -3
+	},
+/obj/item/explosive/grenade/incendiary/molotov{
+	pixel_x = 6
+	},
+/obj/item/explosive/grenade/incendiary/molotov{
+	pixel_x = 6;
+	pixel_y = -1
+	},
+/obj/item/explosive/grenade/incendiary/molotov{
+	pixel_x = -5;
+	pixel_y = -3
+	},
+/obj/item/explosive/grenade/incendiary/molotov{
+	pixel_y = -2
+	},
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
+"Jj" = (
+/obj/structure/window_frame/colony/reinforced,
+/obj/item/shard{
+	icon_state = "medium";
+	pixel_y = 5;
+	pixel_x = 4
+	},
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
+"Jp" = (
+/obj/effect/spawner/random/attachment,
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
+"Km" = (
+/obj/structure/fence,
+/turf/open/gm/dirtgrassborder,
+/area/lv624/ground/colony/north_nexus_road)
+"Kt" = (
+/obj/structure/surface/table,
+/obj/item/ammo_box/magazine/M16,
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
+"Ku" = (
+/obj/structure/machinery/light{
+	dir = 8
+	},
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
+"LS" = (
+/obj/structure/surface/table,
+/obj/item/stack/sheet/wood/small_stack{
+	pixel_x = -11;
+	pixel_y = 6
+	},
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
+"LZ" = (
+/obj/item/frame/table{
+	pixel_y = 6;
+	pixel_x = -8
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/lv624/lazarus/hydroponics)
+"Md" = (
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/lv624/lazarus/hydroponics)
+"MV" = (
+/obj/structure/barricade/wooden{
+	dir = 4
+	},
+/obj/item/stack/sheet/wood/small_stack,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/lv624/lazarus/hydroponics)
+"OJ" = (
+/obj/structure/machinery/light,
+/obj/effect/spawner/random/attachment,
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
+"Pe" = (
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1";
+	dir = 1
+	},
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1";
+	dir = 4
+	},
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
+"Ph" = (
+/obj/structure/barricade/plasteel/wired{
+	icon_state = "plasteel_closed_1";
+	dir = 1
+	},
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
+"Pj" = (
+/obj/item/ammo_magazine/shotgun/incendiary{
+	pixel_x = 3;
+	pixel_y = 6
+	},
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
+"Pm" = (
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1";
+	dir = 4
+	},
+/obj/effect/landmark/corpsespawner/security,
+/obj/item/weapon/gun/pistol/b92fs{
+	pixel_x = -6;
+	pixel_y = 9
+	},
+/obj/effect/decal/cleanable/blood,
+/obj/item/ammo_casing/bullet,
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
+"PB" = (
+/obj/item/frame/table{
+	pixel_y = 6;
+	pixel_x = -6
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/lv624/lazarus/hydroponics)
+"Ql" = (
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1"
+	},
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
+"QK" = (
+/obj/effect/landmark/corpsespawner/security,
+/obj/item/weapon/gun/pistol/b92fs{
+	pixel_y = -5;
+	pixel_x = 13
+	},
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
+"Ra" = (
+/obj/structure/barricade/wooden{
+	dir = 1;
+	pixel_y = 7
+	},
+/obj/structure/barricade/wooden{
+	dir = 4
+	},
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
+"Rw" = (
+/obj/structure/barricade/wooden,
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
+"RZ" = (
+/turf/open/gm/dirtgrassborder{
+	dir = 4;
+	icon_state = "grassdirt_corner2"
+	},
+/area/lv624/ground/colony/north_nexus_road)
+"Sq" = (
+/obj/structure/flora/bush/ausbushes/ausbush,
+/turf/open/gm/grass,
+/area/lv624/ground/jungle/north_jungle)
+"SQ" = (
+/obj/structure/window_frame/colony/reinforced,
+/obj/item/shard{
+	icon_state = "medium";
+	pixel_y = -9;
+	pixel_x = 4
+	},
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
+"SZ" = (
+/obj/item/stack/sheet/wood/small_stack{
+	pixel_x = -11
+	},
+/obj/effect/landmark/corpsespawner/security/cmb,
+/obj/item/weapon/gun/shotgun/pump/cmb{
+	pixel_y = -15;
+	pixel_x = 11
+	},
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/lv624/lazarus/hydroponics)
+"Tu" = (
+/obj/effect/landmark/corpsespawner/colonist,
+/obj/item/weapon/gun/pistol/holdout{
+	pixel_x = 7;
+	pixel_y = 6
+	},
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
+"Tx" = (
+/turf/open/gm/dirt,
+/area/lv624/ground/colony/south_medbay_road)
+"TY" = (
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/lv624/lazarus/hydroponics)
+"UK" = (
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1";
+	dir = 4
+	},
+/obj/effect/landmark/corpsespawner/colonist,
+/obj/item/weapon/melee/baseballbat/metal{
+	pixel_y = -10;
+	pixel_x = -12
+	},
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
+"WM" = (
+/obj/structure/barricade/wooden{
+	dir = 8
+	},
+/obj/item/stack/sheet/wood/small_stack{
+	pixel_x = -7;
+	pixel_y = 8
+	},
+/obj/item/ammo_casing/bullet,
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
+"WY" = (
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1";
+	dir = 1
+	},
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
+"Xk" = (
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
+"XF" = (
+/obj/structure/window_frame/colony/reinforced,
+/obj/item/shard{
+	icon_state = "medium"
+	},
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
+"XR" = (
+/obj/effect/landmark/corpsespawner/PMC,
+/obj/item/weapon/gun/smg/fp9000{
+	pixel_y = 6;
+	pixel_x = 11
+	},
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
+"Yz" = (
+/obj/structure/barricade/plasteel/wired{
+	icon_state = "plasteel_closed_1"
+	},
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
+
+(1,1,1) = {"
+DE
+DE
+HU
+DE
+DE
+DE
+Ec
+vh
+vh
+Ec
+Cb
+Cb
+Cb
+Cb
+rK
+Tx
+"}
+(2,1,1) = {"
+DE
+DE
+DE
+DE
+HU
+Ec
+Ec
+kV
+kV
+Ec
+Ec
+Cb
+Cb
+Cb
+rK
+Tx
+"}
+(3,1,1) = {"
+DE
+Sq
+Ec
+wa
+qC
+Ec
+vM
+xX
+xX
+Ih
+Ec
+Gs
+hj
+Ec
+rK
+Tx
+"}
+(4,1,1) = {"
+DE
+DE
+XF
+nw
+Fn
+Jp
+yr
+QK
+Xk
+jL
+Ku
+BL
+GS
+hj
+pK
+Tx
+"}
+(5,1,1) = {"
+DE
+DE
+Ew
+WY
+Tu
+Cj
+Xk
+Xk
+Xk
+Xk
+yr
+HW
+cF
+SQ
+Tx
+Tx
+"}
+(6,1,1) = {"
+DE
+Ec
+Ec
+Gw
+Xk
+as
+jA
+vK
+kN
+wj
+Xk
+Xk
+OJ
+Ec
+Ec
+Tx
+"}
+(7,1,1) = {"
+DE
+Jj
+WY
+Xk
+Xk
+wj
+LS
+ne
+Rw
+wj
+wj
+Xk
+Jp
+Ql
+Gs
+vN
+"}
+(8,1,1) = {"
+DE
+kV
+Ph
+Xk
+Xk
+WM
+Gj
+yk
+Md
+Hr
+rG
+Xk
+Xk
+Yz
+EG
+vN
+"}
+(9,1,1) = {"
+DE
+kV
+Ph
+Cj
+Xk
+sY
+qN
+TY
+Md
+ay
+cj
+Xk
+Xk
+Yz
+EG
+vN
+"}
+(10,1,1) = {"
+DE
+wa
+WY
+Xk
+Xk
+me
+bJ
+kY
+SZ
+mH
+LZ
+Md
+XR
+Ql
+bR
+vN
+"}
+(11,1,1) = {"
+DE
+Ec
+Ec
+zV
+Jp
+Xk
+Kt
+Ra
+MV
+PB
+Md
+Xk
+eE
+Ec
+Ec
+vN
+"}
+(12,1,1) = {"
+DE
+DE
+qC
+bY
+Xk
+Pj
+Xk
+Xk
+Xk
+Md
+Xk
+Cj
+Ql
+cs
+vN
+vN
+"}
+(13,1,1) = {"
+DE
+DE
+SQ
+Pe
+wx
+mn
+Cj
+Xk
+Xk
+Xk
+Jp
+Pm
+pw
+Ew
+RZ
+vN
+"}
+(14,1,1) = {"
+DE
+DE
+Ec
+cs
+Ew
+Ec
+UK
+fO
+fO
+sc
+Ec
+Bj
+Ew
+Ec
+Km
+vN
+"}
+(15,1,1) = {"
+DE
+DE
+DE
+DE
+DE
+Ec
+Ew
+kV
+kV
+Bj
+Ec
+DE
+DE
+DE
+Km
+vN
+"}

--- a/maps/map_files/LV624/sprinkles/25.clfhydrohold.dmm
+++ b/maps/map_files/LV624/sprinkles/25.clfhydrohold.dmm
@@ -106,12 +106,18 @@
 	},
 /area/lv624/lazarus/hydroponics)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "gp" = (
 /obj/item/explosive/mine/clf/active,
 /turf/open/gm/dirt,
 /area/lv624/ground/colony/north_nexus_road)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "hj" = (
 /obj/item/stack/sheet/metal,
 /turf/open/floor{
@@ -119,6 +125,9 @@
 	},
 /area/lv624/lazarus/hydroponics)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "iM" = (
 /obj/item/explosive/mine/clf/active{
 	dir = 8
@@ -131,8 +140,11 @@
 	},
 /turf/open/gm/grass,
 /area/lv624/ground/colony/south_medbay_road)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "jA" = (
 /obj/structure/surface/table,
 /obj/effect/landmark/wo_supplies/storage/webbing,
@@ -166,11 +178,17 @@
 /obj/effect/decal/cleanable/blood/oil,
 /obj/effect/decal/cleanable/ash,
 <<<<<<< master
+<<<<<<< master
 /obj/item/explosive/mine/clf/active{
 	dir = 4
 	},
 =======
 >>>>>>> reimported backup
+=======
+/obj/item/explosive/mine/clf/active{
+	dir = 4
+	},
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor{
 	dir = 9;
 	icon_state = "green"
@@ -186,6 +204,9 @@
 	},
 /area/lv624/lazarus/hydroponics)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "lU" = (
 /obj/structure/surface/table,
 /obj/item/stack/sheet/wood/large_stack,
@@ -194,8 +215,11 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "me" = (
 /obj/structure/surface/table,
 /obj/item/ammo_magazine/rifle/m16/ap{
@@ -266,6 +290,9 @@
 	},
 /area/lv624/lazarus/hydroponics)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "pv" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/effect/decal/cleanable/ash,
@@ -277,8 +304,11 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "pw" = (
 /obj/structure/barricade/metal/wired{
 	icon_state = "metal_1";
@@ -294,9 +324,13 @@
 /area/lv624/lazarus/hydroponics)
 "pK" = (
 <<<<<<< master
+<<<<<<< master
 /obj/item/explosive/mine/clf/active,
 =======
 >>>>>>> reimported backup
+=======
+/obj/item/explosive/mine/clf/active,
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/gm/dirtgrassborder{
 	icon_state = "grassdirt_corner2"
 	},
@@ -381,14 +415,20 @@
 	},
 /area/lv624/lazarus/hydroponics)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "tj" = (
 /obj/item/explosive/mine/clf/active{
 	dir = 1
 	},
 /turf/open/gm/grass,
 /area/lv624/ground/jungle/north_jungle)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "vh" = (
 /turf/open/floor,
 /area/lv624/lazarus/hydroponics)
@@ -444,9 +484,13 @@
 "wj" = (
 /obj/structure/surface/table,
 <<<<<<< master
+<<<<<<< master
 /obj/item/stack/sheet/metal/large_stack,
 =======
 >>>>>>> reimported backup
+=======
+/obj/item/stack/sheet/metal/large_stack,
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor{
 	dir = 9;
 	icon_state = "green"
@@ -464,10 +508,14 @@
 	},
 /area/lv624/lazarus/hydroponics)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "xs" = (
 /obj/item/explosive/mine/clf/active,
 /turf/open/gm/dirt,
 /area/lv624/ground/colony/south_medbay_road)
+<<<<<<< master
 "xH" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
@@ -478,6 +526,8 @@
 /area/lv624/lazarus/hydroponics)
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "xX" = (
 /obj/structure/barricade/plasteel/wired{
 	icon_state = "plasteel_closed_1";
@@ -575,9 +625,13 @@
 /obj/effect/decal/cleanable/ash,
 /obj/effect/decal/cleanable/blood/oil,
 <<<<<<< master
+<<<<<<< master
 /obj/item/explosive/mine/clf/active,
 =======
 >>>>>>> reimported backup
+=======
+/obj/item/explosive/mine/clf/active,
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor{
 	dir = 9;
 	icon_state = "green"
@@ -638,6 +692,9 @@
 	},
 /area/lv624/lazarus/hydroponics)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "Gy" = (
 /obj/structure/surface/table,
 /obj/item/clothing/glasses/welding{
@@ -656,8 +713,11 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "GS" = (
 /turf/open/floor{
 	dir = 8;
@@ -673,6 +733,9 @@
 	},
 /area/lv624/lazarus/hydroponics)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "Ht" = (
 /obj/structure/surface/table,
 /obj/item/explosive/mine/clf,
@@ -685,8 +748,11 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "HU" = (
 /obj/structure/flora/bush/ausbushes/genericbush,
 /turf/open/gm/grass,
@@ -757,14 +823,20 @@
 /turf/open/gm/dirtgrassborder,
 /area/lv624/ground/colony/north_nexus_road)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "Ks" = (
 /obj/item/explosive/mine/clf/active{
 	dir = 4
 	},
 /turf/open/gm/grass,
 /area/lv624/ground/jungle/north_jungle)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "Kt" = (
 /obj/structure/surface/table,
 /obj/item/ammo_box/magazine/M16,
@@ -829,6 +901,9 @@
 	},
 /area/lv624/lazarus/hydroponics)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "NX" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/effect/decal/cleanable/ash,
@@ -840,8 +915,11 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "OJ" = (
 /obj/structure/machinery/light,
 /obj/effect/spawner/random/attachment,
@@ -970,10 +1048,15 @@
 /area/lv624/lazarus/hydroponics)
 "RZ" = (
 <<<<<<< master
+<<<<<<< master
 /obj/item/explosive/mine/clf/active,
 /obj/item/explosive/mine/clf/active,
 =======
 >>>>>>> reimported backup
+=======
+/obj/item/explosive/mine/clf/active,
+/obj/item/explosive/mine/clf/active,
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/gm/dirtgrassborder{
 	dir = 4;
 	icon_state = "grassdirt_corner2"
@@ -1074,6 +1157,9 @@
 	},
 /area/lv624/lazarus/hydroponics)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "WZ" = (
 /obj/structure/flora/bush/ausbushes/genericbush,
 /obj/item/explosive/mine/clf/active{
@@ -1081,6 +1167,7 @@
 	},
 /turf/open/gm/grass,
 /area/lv624/ground/jungle/north_jungle)
+<<<<<<< master
 "Xh" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
@@ -1091,6 +1178,8 @@
 /area/lv624/lazarus/hydroponics)
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "Xk" = (
 /turf/open/floor{
 	dir = 9;
@@ -1156,6 +1245,7 @@ DE
 DE
 DE
 <<<<<<< master
+<<<<<<< master
 iM
 WZ
 Ec
@@ -1169,15 +1259,24 @@ jn
 =======
 DE
 HU
+=======
+iM
+WZ
+>>>>>>> updated all maps to have CLF Mines and corpses
 Ec
 Ec
-kV
-kV
+pv
+pv
 Ec
 Ec
+<<<<<<< master
 Cb
 Cb
 >>>>>>> reimported backup
+=======
+jn
+jn
+>>>>>>> updated all maps to have CLF Mines and corpses
 Cb
 rK
 Tx
@@ -1203,10 +1302,14 @@ Tx
 (4,1,1) = {"
 DE
 <<<<<<< master
+<<<<<<< master
 tj
 =======
 DE
 >>>>>>> reimported backup
+=======
+tj
+>>>>>>> updated all maps to have CLF Mines and corpses
 XF
 nw
 Fn
@@ -1229,6 +1332,7 @@ Tx
 (5,1,1) = {"
 DE
 <<<<<<< master
+<<<<<<< master
 tj
 Ew
 WY
@@ -1240,6 +1344,9 @@ Xk
 sn
 =======
 DE
+=======
+tj
+>>>>>>> updated all maps to have CLF Mines and corpses
 Ew
 WY
 Tu
@@ -1254,10 +1361,14 @@ HW
 cF
 SQ
 <<<<<<< master
+<<<<<<< master
 xs
 =======
 Tx
 >>>>>>> reimported backup
+=======
+xs
+>>>>>>> updated all maps to have CLF Mines and corpses
 Tx
 "}
 (6,1,1) = {"
@@ -1288,14 +1399,19 @@ Tx
 "}
 (7,1,1) = {"
 <<<<<<< master
+<<<<<<< master
 tj
 =======
 DE
 >>>>>>> reimported backup
+=======
+tj
+>>>>>>> updated all maps to have CLF Mines and corpses
 Jj
 WY
 Xk
 Xk
+<<<<<<< master
 <<<<<<< master
 Ht
 LS
@@ -1314,21 +1430,28 @@ DE
 NX
 =======
 wj
+=======
+Ht
+>>>>>>> updated all maps to have CLF Mines and corpses
 LS
 ne
 Rw
-wj
-wj
+Gy
+lU
 Xk
 Jp
 Ql
 Gs
-vN
+gp
 "}
 (8,1,1) = {"
 DE
+<<<<<<< master
 kV
 >>>>>>> reimported backup
+=======
+NX
+>>>>>>> updated all maps to have CLF Mines and corpses
 Ph
 Xk
 Xk
@@ -1347,11 +1470,15 @@ vN
 (9,1,1) = {"
 DE
 <<<<<<< master
+<<<<<<< master
 NX
 Ph
 LN
 =======
 kV
+=======
+NX
+>>>>>>> updated all maps to have CLF Mines and corpses
 Ph
 Cj
 >>>>>>> reimported backup
@@ -1374,6 +1501,7 @@ vN
 "}
 (10,1,1) = {"
 <<<<<<< master
+<<<<<<< master
 tj
 wa
 WY
@@ -1381,6 +1509,9 @@ Xk
 Xh
 =======
 DE
+=======
+tj
+>>>>>>> updated all maps to have CLF Mines and corpses
 wa
 WY
 Xk
@@ -1397,10 +1528,14 @@ XR
 Ql
 bR
 <<<<<<< master
+<<<<<<< master
 gp
 =======
 vN
 >>>>>>> reimported backup
+=======
+gp
+>>>>>>> updated all maps to have CLF Mines and corpses
 "}
 (11,1,1) = {"
 DE
@@ -1423,10 +1558,14 @@ vN
 (12,1,1) = {"
 DE
 <<<<<<< master
+<<<<<<< master
 tj
 =======
 DE
 >>>>>>> reimported backup
+=======
+tj
+>>>>>>> updated all maps to have CLF Mines and corpses
 qC
 bY
 Xk
@@ -1446,17 +1585,25 @@ Xk
 Cj
 Ql
 cs
+<<<<<<< master
 vN
 >>>>>>> reimported backup
+=======
+gp
+>>>>>>> updated all maps to have CLF Mines and corpses
 vN
 "}
 (13,1,1) = {"
 DE
 <<<<<<< master
+<<<<<<< master
 tj
 =======
 DE
 >>>>>>> reimported backup
+=======
+tj
+>>>>>>> updated all maps to have CLF Mines and corpses
 SQ
 Pe
 wx
@@ -1501,18 +1648,6 @@ DE
 DE
 DE
 <<<<<<< master
-Ks
-Ks
-=======
-DE
-DE
->>>>>>> reimported backup
-Ec
-Ew
-kV
-kV
-Bj
-Ec
 <<<<<<< master
 Ks
 Ks
@@ -1520,6 +1655,28 @@ Ks
 DE
 DE
 >>>>>>> reimported backup
+=======
+Ks
+Ks
+>>>>>>> updated all maps to have CLF Mines and corpses
+Ec
+Ew
+kV
+kV
+Bj
+Ec
+<<<<<<< master
+<<<<<<< master
+Ks
+Ks
+=======
+DE
+DE
+>>>>>>> reimported backup
+=======
+Ks
+Ks
+>>>>>>> updated all maps to have CLF Mines and corpses
 DE
 Km
 vN

--- a/maps/map_files/LV624/sprinkles/25.clfhydrohold.dmm
+++ b/maps/map_files/LV624/sprinkles/25.clfhydrohold.dmm
@@ -10,7 +10,10 @@
 /obj/item/stack/sheet/wood/small_stack{
 	pixel_y = 8
 	},
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
@@ -102,16 +105,20 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
+<<<<<<< master
 "gp" = (
 /obj/item/explosive/mine/clf/active,
 /turf/open/gm/dirt,
 /area/lv624/ground/colony/north_nexus_road)
+=======
+>>>>>>> reimported backup
 "hj" = (
 /obj/item/stack/sheet/metal,
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
 /area/lv624/lazarus/hydroponics)
+<<<<<<< master
 "iM" = (
 /obj/item/explosive/mine/clf/active{
 	dir = 8
@@ -124,6 +131,8 @@
 	},
 /turf/open/gm/grass,
 /area/lv624/ground/colony/south_medbay_road)
+=======
+>>>>>>> reimported backup
 "jA" = (
 /obj/structure/surface/table,
 /obj/effect/landmark/wo_supplies/storage/webbing,
@@ -156,9 +165,12 @@
 "kV" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/effect/decal/cleanable/ash,
+<<<<<<< master
 /obj/item/explosive/mine/clf/active{
 	dir = 4
 	},
+=======
+>>>>>>> reimported backup
 /turf/open/floor{
 	dir = 9;
 	icon_state = "green"
@@ -173,6 +185,7 @@
 	icon_state = "platingdmg3"
 	},
 /area/lv624/lazarus/hydroponics)
+<<<<<<< master
 "lU" = (
 /obj/structure/surface/table,
 /obj/item/stack/sheet/wood/large_stack,
@@ -181,6 +194,8 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
+=======
+>>>>>>> reimported backup
 "me" = (
 /obj/structure/surface/table,
 /obj/item/ammo_magazine/rifle/m16/ap{
@@ -250,6 +265,7 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
+<<<<<<< master
 "pv" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/effect/decal/cleanable/ash,
@@ -261,6 +277,8 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
+=======
+>>>>>>> reimported backup
 "pw" = (
 /obj/structure/barricade/metal/wired{
 	icon_state = "metal_1";
@@ -275,7 +293,10 @@
 	},
 /area/lv624/lazarus/hydroponics)
 "pK" = (
+<<<<<<< master
 /obj/item/explosive/mine/clf/active,
+=======
+>>>>>>> reimported backup
 /turf/open/gm/dirtgrassborder{
 	icon_state = "grassdirt_corner2"
 	},
@@ -299,6 +320,7 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
+<<<<<<< master
 "rr" = (
 /obj/item/ammo_casing/bullet,
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
@@ -307,6 +329,8 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
+=======
+>>>>>>> reimported backup
 "rG" = (
 /obj/structure/barricade/wooden{
 	dir = 8
@@ -336,6 +360,7 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
+<<<<<<< master
 "sn" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor{
@@ -343,6 +368,8 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
+=======
+>>>>>>> reimported backup
 "sY" = (
 /obj/structure/barricade/wooden{
 	dir = 4
@@ -353,12 +380,15 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
+<<<<<<< master
 "tj" = (
 /obj/item/explosive/mine/clf/active{
 	dir = 1
 	},
 /turf/open/gm/grass,
 /area/lv624/ground/jungle/north_jungle)
+=======
+>>>>>>> reimported backup
 "vh" = (
 /turf/open/floor,
 /area/lv624/lazarus/hydroponics)
@@ -413,7 +443,10 @@
 /area/lv624/lazarus/hydroponics)
 "wj" = (
 /obj/structure/surface/table,
+<<<<<<< master
 /obj/item/stack/sheet/metal/large_stack,
+=======
+>>>>>>> reimported backup
 /turf/open/floor{
 	dir = 9;
 	icon_state = "green"
@@ -430,6 +463,7 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
+<<<<<<< master
 "xs" = (
 /obj/item/explosive/mine/clf/active,
 /turf/open/gm/dirt,
@@ -442,6 +476,8 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
+=======
+>>>>>>> reimported backup
 "xX" = (
 /obj/structure/barricade/plasteel/wired{
 	icon_state = "plasteel_closed_1";
@@ -458,7 +494,10 @@
 	pixel_x = 3;
 	pixel_y = 11
 	},
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor{
 	dir = 9;
 	icon_state = "green"
@@ -497,7 +536,10 @@
 	icon_state = "metal_1";
 	dir = 8
 	},
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -532,7 +574,10 @@
 "EG" = (
 /obj/effect/decal/cleanable/ash,
 /obj/effect/decal/cleanable/blood/oil,
+<<<<<<< master
 /obj/item/explosive/mine/clf/active,
+=======
+>>>>>>> reimported backup
 /turf/open/floor{
 	dir = 9;
 	icon_state = "green"
@@ -552,7 +597,10 @@
 /obj/structure/barricade/wooden{
 	dir = 8
 	},
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor{
 	dir = 9;
 	icon_state = "green"
@@ -589,6 +637,7 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
+<<<<<<< master
 "Gy" = (
 /obj/structure/surface/table,
 /obj/item/clothing/glasses/welding{
@@ -607,6 +656,8 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
+=======
+>>>>>>> reimported backup
 "GS" = (
 /turf/open/floor{
 	dir = 8;
@@ -621,6 +672,7 @@
 	icon_state = "platingdmg3"
 	},
 /area/lv624/lazarus/hydroponics)
+<<<<<<< master
 "Ht" = (
 /obj/structure/surface/table,
 /obj/item/explosive/mine/clf,
@@ -633,6 +685,8 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
+=======
+>>>>>>> reimported backup
 "HU" = (
 /obj/structure/flora/bush/ausbushes/genericbush,
 /turf/open/gm/grass,
@@ -702,12 +756,15 @@
 /obj/structure/fence,
 /turf/open/gm/dirtgrassborder,
 /area/lv624/ground/colony/north_nexus_road)
+<<<<<<< master
 "Ks" = (
 /obj/item/explosive/mine/clf/active{
 	dir = 4
 	},
 /turf/open/gm/grass,
 /area/lv624/ground/jungle/north_jungle)
+=======
+>>>>>>> reimported backup
 "Kt" = (
 /obj/structure/surface/table,
 /obj/item/ammo_box/magazine/M16,
@@ -725,6 +782,7 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
+<<<<<<< master
 "LN" = (
 /obj/item/ammo_casing/bullet,
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
@@ -734,6 +792,8 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
+=======
+>>>>>>> reimported backup
 "LS" = (
 /obj/structure/surface/table,
 /obj/item/stack/sheet/wood/small_stack{
@@ -768,6 +828,7 @@
 	icon_state = "platingdmg3"
 	},
 /area/lv624/lazarus/hydroponics)
+<<<<<<< master
 "NX" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/effect/decal/cleanable/ash,
@@ -779,6 +840,8 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
+=======
+>>>>>>> reimported backup
 "OJ" = (
 /obj/structure/machinery/light,
 /obj/effect/spawner/random/attachment,
@@ -816,8 +879,11 @@
 	pixel_x = 3;
 	pixel_y = 6
 	},
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor{
 	dir = 9;
 	icon_state = "green"
@@ -885,6 +951,7 @@
 /area/lv624/lazarus/hydroponics)
 "Rw" = (
 /obj/structure/barricade/wooden,
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor{
 	dir = 9;
@@ -894,14 +961,19 @@
 "Rx" = (
 /obj/effect/spawner/random/attachment,
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor{
 	dir = 9;
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
 "RZ" = (
+<<<<<<< master
 /obj/item/explosive/mine/clf/active,
 /obj/item/explosive/mine/clf/active,
+=======
+>>>>>>> reimported backup
 /turf/open/gm/dirtgrassborder{
 	dir = 4;
 	icon_state = "grassdirt_corner2"
@@ -932,7 +1004,10 @@
 	pixel_y = -15;
 	pixel_x = 11
 	},
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
@@ -998,6 +1073,7 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
+<<<<<<< master
 "WZ" = (
 /obj/structure/flora/bush/ausbushes/genericbush,
 /obj/item/explosive/mine/clf/active{
@@ -1013,6 +1089,8 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
+=======
+>>>>>>> reimported backup
 "Xk" = (
 /turf/open/floor{
 	dir = 9;
@@ -1077,6 +1155,7 @@ Tx
 DE
 DE
 DE
+<<<<<<< master
 iM
 WZ
 Ec
@@ -1087,6 +1166,18 @@ Ec
 Ec
 jn
 jn
+=======
+DE
+HU
+Ec
+Ec
+kV
+kV
+Ec
+Ec
+Cb
+Cb
+>>>>>>> reimported backup
 Cb
 rK
 Tx
@@ -1111,12 +1202,20 @@ Tx
 "}
 (4,1,1) = {"
 DE
+<<<<<<< master
 tj
+=======
+DE
+>>>>>>> reimported backup
 XF
 nw
 Fn
 Jp
+<<<<<<< master
 xH
+=======
+yr
+>>>>>>> reimported backup
 QK
 Xk
 jL
@@ -1129,6 +1228,7 @@ Tx
 "}
 (5,1,1) = {"
 DE
+<<<<<<< master
 tj
 Ew
 WY
@@ -1138,11 +1238,26 @@ Xk
 sn
 Xk
 sn
+=======
+DE
+Ew
+WY
+Tu
+Cj
+Xk
+Xk
+Xk
+Xk
+>>>>>>> reimported backup
 yr
 HW
 cF
 SQ
+<<<<<<< master
 xs
+=======
+Tx
+>>>>>>> reimported backup
 Tx
 "}
 (6,1,1) = {"
@@ -1150,25 +1265,38 @@ DE
 Ec
 Ec
 Gw
+<<<<<<< master
 Xh
+=======
+Xk
+>>>>>>> reimported backup
 as
 jA
 vK
 kN
 wj
 Xk
+<<<<<<< master
 sn
+=======
+Xk
+>>>>>>> reimported backup
 OJ
 Ec
 Ec
 Tx
 "}
 (7,1,1) = {"
+<<<<<<< master
 tj
+=======
+DE
+>>>>>>> reimported backup
 Jj
 WY
 Xk
 Xk
+<<<<<<< master
 Ht
 LS
 ne
@@ -1184,6 +1312,23 @@ gp
 (8,1,1) = {"
 DE
 NX
+=======
+wj
+LS
+ne
+Rw
+wj
+wj
+Xk
+Jp
+Ql
+Gs
+vN
+"}
+(8,1,1) = {"
+DE
+kV
+>>>>>>> reimported backup
 Ph
 Xk
 Xk
@@ -1201,9 +1346,15 @@ vN
 "}
 (9,1,1) = {"
 DE
+<<<<<<< master
 NX
 Ph
 LN
+=======
+kV
+Ph
+Cj
+>>>>>>> reimported backup
 Xk
 sY
 qN
@@ -1212,17 +1363,29 @@ Md
 ay
 cj
 Xk
+<<<<<<< master
 Xh
+=======
+Xk
+>>>>>>> reimported backup
 Yz
 EG
 vN
 "}
 (10,1,1) = {"
+<<<<<<< master
 tj
 wa
 WY
 Xk
 Xh
+=======
+DE
+wa
+WY
+Xk
+Xk
+>>>>>>> reimported backup
 me
 bJ
 kY
@@ -1233,7 +1396,11 @@ Md
 XR
 Ql
 bR
+<<<<<<< master
 gp
+=======
+vN
+>>>>>>> reimported backup
 "}
 (11,1,1) = {"
 DE
@@ -1255,7 +1422,11 @@ vN
 "}
 (12,1,1) = {"
 DE
+<<<<<<< master
 tj
+=======
+DE
+>>>>>>> reimported backup
 qC
 bY
 Xk
@@ -1264,25 +1435,43 @@ Xk
 Xk
 Xk
 Md
+<<<<<<< master
 sn
 Cj
 Ql
 cs
 gp
+=======
+Xk
+Cj
+Ql
+cs
+vN
+>>>>>>> reimported backup
 vN
 "}
 (13,1,1) = {"
 DE
+<<<<<<< master
 tj
+=======
+DE
+>>>>>>> reimported backup
 SQ
 Pe
 wx
 mn
 Cj
 Xk
+<<<<<<< master
 Xh
 Xk
 Rx
+=======
+Xk
+Xk
+Jp
+>>>>>>> reimported backup
 Pm
 pw
 Ew
@@ -1311,16 +1500,26 @@ vN
 DE
 DE
 DE
+<<<<<<< master
 Ks
 Ks
+=======
+DE
+DE
+>>>>>>> reimported backup
 Ec
 Ew
 kV
 kV
 Bj
 Ec
+<<<<<<< master
 Ks
 Ks
+=======
+DE
+DE
+>>>>>>> reimported backup
 DE
 Km
 vN

--- a/maps/map_files/LV624/sprinkles/25.clfhydrohold.dmm
+++ b/maps/map_files/LV624/sprinkles/25.clfhydrohold.dmm
@@ -1171,10 +1171,12 @@ DE
 HU
 Ec
 Ec
-kV
-kV
+pv
+pv
 Ec
 Ec
+jn
+jn
 Cb
 Cb
 >>>>>>> reimported backup
@@ -1317,13 +1319,13 @@ wj
 LS
 ne
 Rw
-wj
-wj
+Gy
+lU
 Xk
 Jp
 Ql
 Gs
-vN
+gp
 "}
 (8,1,1) = {"
 DE
@@ -1446,6 +1448,7 @@ Xk
 Cj
 Ql
 cs
+gp
 vN
 >>>>>>> reimported backup
 vN

--- a/maps/map_files/LV624/sprinkles/25.clfhydrohold.dmm
+++ b/maps/map_files/LV624/sprinkles/25.clfhydrohold.dmm
@@ -105,20 +105,16 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
-<<<<<<< master
 "gp" = (
 /obj/item/explosive/mine/clf/active,
 /turf/open/gm/dirt,
 /area/lv624/ground/colony/north_nexus_road)
-=======
->>>>>>> reimported backup
 "hj" = (
 /obj/item/stack/sheet/metal,
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
 /area/lv624/lazarus/hydroponics)
-<<<<<<< master
 "iM" = (
 /obj/item/explosive/mine/clf/active{
 	dir = 8
@@ -131,8 +127,6 @@
 	},
 /turf/open/gm/grass,
 /area/lv624/ground/colony/south_medbay_road)
-=======
->>>>>>> reimported backup
 "jA" = (
 /obj/structure/surface/table,
 /obj/effect/landmark/wo_supplies/storage/webbing,
@@ -165,12 +159,9 @@
 "kV" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/effect/decal/cleanable/ash,
-<<<<<<< master
 /obj/item/explosive/mine/clf/active{
 	dir = 4
 	},
-=======
->>>>>>> reimported backup
 /turf/open/floor{
 	dir = 9;
 	icon_state = "green"
@@ -185,7 +176,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/lv624/lazarus/hydroponics)
-<<<<<<< master
 "lU" = (
 /obj/structure/surface/table,
 /obj/item/stack/sheet/wood/large_stack,
@@ -194,8 +184,6 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
-=======
->>>>>>> reimported backup
 "me" = (
 /obj/structure/surface/table,
 /obj/item/ammo_magazine/rifle/m16/ap{
@@ -265,7 +253,6 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
-<<<<<<< master
 "pv" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/effect/decal/cleanable/ash,
@@ -277,8 +264,6 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
-=======
->>>>>>> reimported backup
 "pw" = (
 /obj/structure/barricade/metal/wired{
 	icon_state = "metal_1";
@@ -293,10 +278,7 @@
 	},
 /area/lv624/lazarus/hydroponics)
 "pK" = (
-<<<<<<< master
 /obj/item/explosive/mine/clf/active,
-=======
->>>>>>> reimported backup
 /turf/open/gm/dirtgrassborder{
 	icon_state = "grassdirt_corner2"
 	},
@@ -380,15 +362,12 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
-<<<<<<< master
 "tj" = (
 /obj/item/explosive/mine/clf/active{
 	dir = 1
 	},
 /turf/open/gm/grass,
 /area/lv624/ground/jungle/north_jungle)
-=======
->>>>>>> reimported backup
 "vh" = (
 /turf/open/floor,
 /area/lv624/lazarus/hydroponics)
@@ -443,10 +422,7 @@
 /area/lv624/lazarus/hydroponics)
 "wj" = (
 /obj/structure/surface/table,
-<<<<<<< master
 /obj/item/stack/sheet/metal/large_stack,
-=======
->>>>>>> reimported backup
 /turf/open/floor{
 	dir = 9;
 	icon_state = "green"
@@ -463,21 +439,10 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
-<<<<<<< master
 "xs" = (
 /obj/item/explosive/mine/clf/active,
 /turf/open/gm/dirt,
 /area/lv624/ground/colony/south_medbay_road)
-"xH" = (
-/obj/effect/decal/cleanable/blood,
-/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-/turf/open/floor{
-	dir = 9;
-	icon_state = "green"
-	},
-/area/lv624/lazarus/hydroponics)
-=======
->>>>>>> reimported backup
 "xX" = (
 /obj/structure/barricade/plasteel/wired{
 	icon_state = "plasteel_closed_1";
@@ -574,10 +539,7 @@
 "EG" = (
 /obj/effect/decal/cleanable/ash,
 /obj/effect/decal/cleanable/blood/oil,
-<<<<<<< master
 /obj/item/explosive/mine/clf/active,
-=======
->>>>>>> reimported backup
 /turf/open/floor{
 	dir = 9;
 	icon_state = "green"
@@ -637,7 +599,6 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
-<<<<<<< master
 "Gy" = (
 /obj/structure/surface/table,
 /obj/item/clothing/glasses/welding{
@@ -656,8 +617,6 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
-=======
->>>>>>> reimported backup
 "GS" = (
 /turf/open/floor{
 	dir = 8;
@@ -672,7 +631,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/lv624/lazarus/hydroponics)
-<<<<<<< master
 "Ht" = (
 /obj/structure/surface/table,
 /obj/item/explosive/mine/clf,
@@ -685,8 +643,6 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
-=======
->>>>>>> reimported backup
 "HU" = (
 /obj/structure/flora/bush/ausbushes/genericbush,
 /turf/open/gm/grass,
@@ -756,15 +712,12 @@
 /obj/structure/fence,
 /turf/open/gm/dirtgrassborder,
 /area/lv624/ground/colony/north_nexus_road)
-<<<<<<< master
 "Ks" = (
 /obj/item/explosive/mine/clf/active{
 	dir = 4
 	},
 /turf/open/gm/grass,
 /area/lv624/ground/jungle/north_jungle)
-=======
->>>>>>> reimported backup
 "Kt" = (
 /obj/structure/surface/table,
 /obj/item/ammo_box/magazine/M16,
@@ -828,7 +781,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/lv624/lazarus/hydroponics)
-<<<<<<< master
 "NX" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/effect/decal/cleanable/ash,
@@ -840,8 +792,6 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
-=======
->>>>>>> reimported backup
 "OJ" = (
 /obj/structure/machinery/light,
 /obj/effect/spawner/random/attachment,
@@ -969,11 +919,8 @@
 	},
 /area/lv624/lazarus/hydroponics)
 "RZ" = (
-<<<<<<< master
 /obj/item/explosive/mine/clf/active,
 /obj/item/explosive/mine/clf/active,
-=======
->>>>>>> reimported backup
 /turf/open/gm/dirtgrassborder{
 	dir = 4;
 	icon_state = "grassdirt_corner2"
@@ -1073,7 +1020,6 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
-<<<<<<< master
 "WZ" = (
 /obj/structure/flora/bush/ausbushes/genericbush,
 /obj/item/explosive/mine/clf/active{
@@ -1081,16 +1027,6 @@
 	},
 /turf/open/gm/grass,
 /area/lv624/ground/jungle/north_jungle)
-"Xh" = (
-/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-/turf/open/floor{
-	dir = 9;
-	icon_state = "green"
-	},
-/area/lv624/lazarus/hydroponics)
-=======
->>>>>>> reimported backup
 "Xk" = (
 /turf/open/floor{
 	dir = 9;
@@ -1155,7 +1091,6 @@ Tx
 DE
 DE
 DE
-<<<<<<< master
 iM
 WZ
 Ec
@@ -1166,18 +1101,6 @@ Ec
 Ec
 jn
 jn
-=======
-DE
-HU
-Ec
-Ec
-kV
-kV
-Ec
-Ec
-Cb
-Cb
->>>>>>> reimported backup
 Cb
 rK
 Tx
@@ -1202,11 +1125,7 @@ Tx
 "}
 (4,1,1) = {"
 DE
-<<<<<<< master
 tj
-=======
-DE
->>>>>>> reimported backup
 XF
 nw
 Fn
@@ -1228,18 +1147,7 @@ Tx
 "}
 (5,1,1) = {"
 DE
-<<<<<<< master
 tj
-Ew
-WY
-Tu
-rr
-Xk
-sn
-Xk
-sn
-=======
-DE
 Ew
 WY
 Tu
@@ -1253,11 +1161,7 @@ yr
 HW
 cF
 SQ
-<<<<<<< master
 xs
-=======
-Tx
->>>>>>> reimported backup
 Tx
 "}
 (6,1,1) = {"
@@ -1287,23 +1191,18 @@ Ec
 Tx
 "}
 (7,1,1) = {"
-<<<<<<< master
 tj
-=======
-DE
->>>>>>> reimported backup
 Jj
 WY
 Xk
 Xk
-<<<<<<< master
 Ht
 LS
 ne
 Rw
 Gy
 lU
-sn
+Xk
 Jp
 Ql
 Gs
@@ -1312,23 +1211,6 @@ gp
 (8,1,1) = {"
 DE
 NX
-=======
-wj
-LS
-ne
-Rw
-wj
-wj
-Xk
-Jp
-Ql
-Gs
-vN
-"}
-(8,1,1) = {"
-DE
-kV
->>>>>>> reimported backup
 Ph
 Xk
 Xk
@@ -1346,12 +1228,7 @@ vN
 "}
 (9,1,1) = {"
 DE
-<<<<<<< master
 NX
-Ph
-LN
-=======
-kV
 Ph
 Cj
 >>>>>>> reimported backup
@@ -1373,14 +1250,7 @@ EG
 vN
 "}
 (10,1,1) = {"
-<<<<<<< master
 tj
-wa
-WY
-Xk
-Xh
-=======
-DE
 wa
 WY
 Xk
@@ -1396,11 +1266,7 @@ Md
 XR
 Ql
 bR
-<<<<<<< master
 gp
-=======
-vN
->>>>>>> reimported backup
 "}
 (11,1,1) = {"
 DE
@@ -1422,11 +1288,7 @@ vN
 "}
 (12,1,1) = {"
 DE
-<<<<<<< master
 tj
-=======
-DE
->>>>>>> reimported backup
 qC
 bY
 Xk
@@ -1446,17 +1308,12 @@ Xk
 Cj
 Ql
 cs
-vN
->>>>>>> reimported backup
+gp
 vN
 "}
 (13,1,1) = {"
 DE
-<<<<<<< master
 tj
-=======
-DE
->>>>>>> reimported backup
 SQ
 Pe
 wx
@@ -1500,26 +1357,16 @@ vN
 DE
 DE
 DE
-<<<<<<< master
 Ks
 Ks
-=======
-DE
-DE
->>>>>>> reimported backup
 Ec
 Ew
 kV
 kV
 Bj
 Ec
-<<<<<<< master
 Ks
 Ks
-=======
-DE
-DE
->>>>>>> reimported backup
 DE
 Km
 vN

--- a/maps/map_files/LV624/sprinkles/25.clfhydrohold.dmm
+++ b/maps/map_files/LV624/sprinkles/25.clfhydrohold.dmm
@@ -10,10 +10,7 @@
 /obj/item/stack/sheet/wood/small_stack{
 	pixel_y = 8
 	},
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-=======
->>>>>>> reimported backup
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
@@ -302,7 +299,6 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
-<<<<<<< master
 "rr" = (
 /obj/item/ammo_casing/bullet,
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
@@ -311,8 +307,6 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
-=======
->>>>>>> reimported backup
 "rG" = (
 /obj/structure/barricade/wooden{
 	dir = 8
@@ -342,7 +336,6 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
-<<<<<<< master
 "sn" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor{
@@ -350,8 +343,6 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
-=======
->>>>>>> reimported backup
 "sY" = (
 /obj/structure/barricade/wooden{
 	dir = 4
@@ -443,6 +434,14 @@
 /obj/item/explosive/mine/clf/active,
 /turf/open/gm/dirt,
 /area/lv624/ground/colony/south_medbay_road)
+"xH" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
 "xX" = (
 /obj/structure/barricade/plasteel/wired{
 	icon_state = "plasteel_closed_1";
@@ -459,10 +458,7 @@
 	pixel_x = 3;
 	pixel_y = 11
 	},
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-=======
->>>>>>> reimported backup
 /turf/open/floor{
 	dir = 9;
 	icon_state = "green"
@@ -501,10 +497,7 @@
 	icon_state = "metal_1";
 	dir = 8
 	},
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-=======
->>>>>>> reimported backup
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -559,10 +552,7 @@
 /obj/structure/barricade/wooden{
 	dir = 8
 	},
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-=======
->>>>>>> reimported backup
 /turf/open/floor{
 	dir = 9;
 	icon_state = "green"
@@ -735,7 +725,6 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
-<<<<<<< master
 "LN" = (
 /obj/item/ammo_casing/bullet,
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
@@ -745,8 +734,6 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
-=======
->>>>>>> reimported backup
 "LS" = (
 /obj/structure/surface/table,
 /obj/item/stack/sheet/wood/small_stack{
@@ -829,11 +816,8 @@
 	pixel_x = 3;
 	pixel_y = 6
 	},
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-=======
->>>>>>> reimported backup
 /turf/open/floor{
 	dir = 9;
 	icon_state = "green"
@@ -901,7 +885,6 @@
 /area/lv624/lazarus/hydroponics)
 "Rw" = (
 /obj/structure/barricade/wooden,
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor{
 	dir = 9;
@@ -911,8 +894,6 @@
 "Rx" = (
 /obj/effect/spawner/random/attachment,
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-=======
->>>>>>> reimported backup
 /turf/open/floor{
 	dir = 9;
 	icon_state = "green"
@@ -951,10 +932,7 @@
 	pixel_y = -15;
 	pixel_x = 11
 	},
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-=======
->>>>>>> reimported backup
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
@@ -1027,6 +1005,14 @@
 	},
 /turf/open/gm/grass,
 /area/lv624/ground/jungle/north_jungle)
+"Xh" = (
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
 "Xk" = (
 /turf/open/floor{
 	dir = 9;
@@ -1130,11 +1116,7 @@ XF
 nw
 Fn
 Jp
-<<<<<<< master
 xH
-=======
-yr
->>>>>>> reimported backup
 QK
 Xk
 jL
@@ -1151,12 +1133,11 @@ tj
 Ew
 WY
 Tu
-Cj
+rr
 Xk
+sn
 Xk
-Xk
-Xk
->>>>>>> reimported backup
+sn
 yr
 HW
 cF
@@ -1169,22 +1150,14 @@ DE
 Ec
 Ec
 Gw
-<<<<<<< master
 Xh
-=======
-Xk
->>>>>>> reimported backup
 as
 jA
 vK
 kN
 wj
 Xk
-<<<<<<< master
 sn
-=======
-Xk
->>>>>>> reimported backup
 OJ
 Ec
 Ec
@@ -1202,7 +1175,7 @@ ne
 Rw
 Gy
 lU
-Xk
+sn
 Jp
 Ql
 Gs
@@ -1230,8 +1203,7 @@ vN
 DE
 NX
 Ph
-Cj
->>>>>>> reimported backup
+LN
 Xk
 sY
 qN
@@ -1240,11 +1212,7 @@ Md
 ay
 cj
 Xk
-<<<<<<< master
 Xh
-=======
-Xk
->>>>>>> reimported backup
 Yz
 EG
 vN
@@ -1254,8 +1222,7 @@ tj
 wa
 WY
 Xk
-Xk
->>>>>>> reimported backup
+Xh
 me
 bJ
 kY
@@ -1297,14 +1264,7 @@ Xk
 Xk
 Xk
 Md
-<<<<<<< master
 sn
-Cj
-Ql
-cs
-gp
-=======
-Xk
 Cj
 Ql
 cs
@@ -1320,15 +1280,9 @@ wx
 mn
 Cj
 Xk
-<<<<<<< master
 Xh
 Xk
 Rx
-=======
-Xk
-Xk
-Jp
->>>>>>> reimported backup
 Pm
 pw
 Ew

--- a/maps/map_files/LV624/sprinkles/25.clfhydrohold.dmm
+++ b/maps/map_files/LV624/sprinkles/25.clfhydrohold.dmm
@@ -22,6 +22,13 @@
 	icon_state = "platingdmg1"
 	},
 /area/lv624/lazarus/hydroponics)
+"bw" = (
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
 "bJ" = (
 /obj/structure/surface/table,
 /obj/item/weapon/gun/rifle/m16{
@@ -57,6 +64,7 @@
 	pixel_x = -11
 	},
 /obj/effect/decal/cleanable/blood,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor{
 	dir = 9;
 	icon_state = "green"
@@ -88,12 +96,14 @@
 /obj/structure/barricade/metal/wired{
 	icon_state = "metal_2"
 	},
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
 /area/lv624/lazarus/hydroponics)
 "eE" = (
 /obj/structure/machinery/light,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor{
 	dir = 9;
 	icon_state = "green"
@@ -160,6 +170,7 @@
 "jL" = (
 /obj/item/ammo_casing/bullet,
 /obj/item/ammo_magazine/shotgun/buckshot,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor{
 	dir = 9;
 	icon_state = "green"
@@ -247,11 +258,22 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
+"mi" = (
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1"
+	},
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
 "mn" = (
 /obj/structure/machinery/light{
 	dir = 4
 	},
 /obj/effect/spawner/random/attachment,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor{
 	dir = 9;
 	icon_state = "green"
@@ -288,6 +310,7 @@
 	icon_state = "metal_1";
 	dir = 1
 	},
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor{
 	dir = 9;
 	icon_state = "green"
@@ -321,6 +344,7 @@
 /obj/structure/barricade/metal/wired{
 	icon_state = "metal_1"
 	},
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor{
 	dir = 9;
 	icon_state = "green"
@@ -518,6 +542,7 @@
 	dir = 4
 	},
 /obj/item/ammo_casing/bullet,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor{
 	dir = 9;
 	icon_state = "green"
@@ -581,6 +606,7 @@
 /area/lv624/lazarus/hydroponics)
 "yr" = (
 /obj/effect/decal/cleanable/blood,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor{
 	dir = 9;
 	icon_state = "green"
@@ -590,6 +616,7 @@
 /obj/structure/machinery/light{
 	dir = 1
 	},
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor{
 	dir = 9;
 	icon_state = "green"
@@ -629,6 +656,7 @@
 /area/lv624/ground/colony/south_medbay_road)
 "Cj" = (
 /obj/item/ammo_casing/bullet,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor{
 	dir = 9;
 	icon_state = "green"
@@ -672,6 +700,7 @@
 	icon_state = "metal_1";
 	dir = 8
 	},
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor{
 	dir = 9;
 	icon_state = "green"
@@ -720,6 +749,7 @@
 /obj/item/ammo_magazine/smg/fp9000,
 /obj/item/ammo_magazine/smg/fp9000,
 /obj/item/ammo_magazine/smg/fp9000,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor{
 	dir = 9;
 	icon_state = "green"
@@ -753,6 +783,7 @@
 =======
 >>>>>>> updated all maps to have CLF Mines and corpses
 "GS" = (
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor{
 	dir = 8;
 	icon_state = "damaged3"
@@ -798,6 +829,7 @@
 	pixel_x = 16
 	},
 /obj/effect/decal/cleanable/blood,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -847,6 +879,7 @@
 /area/lv624/lazarus/hydroponics)
 "Jp" = (
 /obj/effect/spawner/random/attachment,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor{
 	dir = 9;
 	icon_state = "green"
@@ -883,6 +916,7 @@
 /obj/structure/machinery/light{
 	dir = 8
 	},
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor{
 	dir = 9;
 	icon_state = "green"
@@ -963,6 +997,7 @@
 "OJ" = (
 /obj/structure/machinery/light,
 /obj/effect/spawner/random/attachment,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor{
 	dir = 9;
 	icon_state = "green"
@@ -977,6 +1012,7 @@
 	icon_state = "metal_1";
 	dir = 4
 	},
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor{
 	dir = 9;
 	icon_state = "green"
@@ -1024,6 +1060,7 @@
 	},
 /obj/effect/decal/cleanable/blood,
 /obj/item/ammo_casing/bullet,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor{
 	dir = 9;
 	icon_state = "green"
@@ -1054,6 +1091,7 @@
 	pixel_x = 13
 	},
 /obj/effect/decal/cleanable/blood,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor{
 	dir = 9;
 	icon_state = "green"
@@ -1157,6 +1195,7 @@
 	pixel_y = 6
 	},
 /obj/effect/decal/cleanable/blood,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor{
 	dir = 9;
 	icon_state = "green"
@@ -1268,6 +1307,7 @@
 /obj/item/ammo_magazine/smg/fp9000,
 /obj/item/ammo_magazine/smg/fp9000,
 /obj/item/ammo_magazine/smg/fp9000,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor{
 	dir = 9;
 	icon_state = "green"
@@ -1385,7 +1425,7 @@ yr
 xH
 >>>>>>> added spawn pointss for clf survivors
 QK
-Xk
+bw
 jL
 Ku
 BL
@@ -1400,7 +1440,7 @@ DE
 <<<<<<< master
 tj
 Ew
-WY
+tZ
 Tu
 Cj
 Xk
@@ -1494,7 +1534,7 @@ ne
 Rw
 wj
 wj
-Xk
+bw
 Jp
 Ql
 Gs
@@ -1528,16 +1568,16 @@ kV
 NX
 >>>>>>> updated all maps to have CLF Mines and corpses
 Ph
-Xk
-Xk
+bw
+bw
 WM
 Gj
 yk
 Md
 Hr
 rG
-Xk
-Xk
+bw
+bw
 Yz
 EG
 vN
@@ -1609,7 +1649,7 @@ kY
 SZ
 mH
 LZ
-Md
+uT
 XR
 Ql
 bR
@@ -1635,7 +1675,7 @@ Ra
 MV
 PB
 Md
-Xk
+bw
 eE
 Ec
 Ec
@@ -1654,7 +1694,7 @@ tj
 >>>>>>> updated all maps to have CLF Mines and corpses
 qC
 bY
-Xk
+bw
 Pj
 Xk
 Xk
@@ -1673,7 +1713,7 @@ Xk
 sn
 >>>>>>> added spawn pointss for clf survivors
 Cj
-Ql
+mi
 cs
 <<<<<<< master
 vN

--- a/maps/map_files/LV624/sprinkles/25.clfhydrohold.dmm
+++ b/maps/map_files/LV624/sprinkles/25.clfhydrohold.dmm
@@ -10,7 +10,10 @@
 /obj/item/stack/sheet/wood/small_stack{
 	pixel_y = 8
 	},
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
@@ -317,6 +320,7 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
+<<<<<<< master
 "rr" = (
 /obj/item/ammo_casing/bullet,
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
@@ -325,6 +329,8 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
+=======
+>>>>>>> reimported backup
 "rG" = (
 /obj/structure/barricade/wooden{
 	dir = 8
@@ -354,6 +360,7 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
+<<<<<<< master
 "sn" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor{
@@ -361,6 +368,8 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
+=======
+>>>>>>> reimported backup
 "sY" = (
 /obj/structure/barricade/wooden{
 	dir = 4
@@ -467,6 +476,8 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
+=======
+>>>>>>> reimported backup
 "xX" = (
 /obj/structure/barricade/plasteel/wired{
 	icon_state = "plasteel_closed_1";
@@ -483,7 +494,10 @@
 	pixel_x = 3;
 	pixel_y = 11
 	},
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor{
 	dir = 9;
 	icon_state = "green"
@@ -522,7 +536,10 @@
 	icon_state = "metal_1";
 	dir = 8
 	},
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -580,7 +597,10 @@
 /obj/structure/barricade/wooden{
 	dir = 8
 	},
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor{
 	dir = 9;
 	icon_state = "green"
@@ -762,6 +782,7 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
+<<<<<<< master
 "LN" = (
 /obj/item/ammo_casing/bullet,
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
@@ -771,6 +792,8 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
+=======
+>>>>>>> reimported backup
 "LS" = (
 /obj/structure/surface/table,
 /obj/item/stack/sheet/wood/small_stack{
@@ -856,8 +879,11 @@
 	pixel_x = 3;
 	pixel_y = 6
 	},
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor{
 	dir = 9;
 	icon_state = "green"
@@ -925,6 +951,7 @@
 /area/lv624/lazarus/hydroponics)
 "Rw" = (
 /obj/structure/barricade/wooden,
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor{
 	dir = 9;
@@ -934,6 +961,8 @@
 "Rx" = (
 /obj/effect/spawner/random/attachment,
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor{
 	dir = 9;
 	icon_state = "green"
@@ -975,7 +1004,10 @@
 	pixel_y = -15;
 	pixel_x = 11
 	},
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
@@ -1057,6 +1089,8 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
+=======
+>>>>>>> reimported backup
 "Xk" = (
 /turf/open/floor{
 	dir = 9;
@@ -1137,12 +1171,10 @@ DE
 HU
 Ec
 Ec
-pv
-pv
+kV
+kV
 Ec
 Ec
-jn
-jn
 Cb
 Cb
 >>>>>>> reimported backup
@@ -1179,7 +1211,11 @@ XF
 nw
 Fn
 Jp
+<<<<<<< master
 xH
+=======
+yr
+>>>>>>> reimported backup
 QK
 Xk
 jL
@@ -1202,6 +1238,17 @@ Xk
 sn
 Xk
 sn
+=======
+DE
+Ew
+WY
+Tu
+Cj
+Xk
+Xk
+Xk
+Xk
+>>>>>>> reimported backup
 yr
 HW
 cF
@@ -1218,14 +1265,22 @@ DE
 Ec
 Ec
 Gw
+<<<<<<< master
 Xh
+=======
+Xk
+>>>>>>> reimported backup
 as
 jA
 vK
 kN
 wj
 Xk
+<<<<<<< master
 sn
+=======
+Xk
+>>>>>>> reimported backup
 OJ
 Ec
 Ec
@@ -1256,6 +1311,22 @@ gp
 "}
 (8,1,1) = {"
 DE
+NX
+=======
+wj
+LS
+ne
+Rw
+wj
+wj
+Xk
+Jp
+Ql
+Gs
+vN
+"}
+(8,1,1) = {"
+DE
 kV
 >>>>>>> reimported backup
 Ph
@@ -1279,6 +1350,11 @@ DE
 NX
 Ph
 LN
+=======
+kV
+Ph
+Cj
+>>>>>>> reimported backup
 Xk
 sY
 qN
@@ -1287,7 +1363,11 @@ Md
 ay
 cj
 Xk
+<<<<<<< master
 Xh
+=======
+Xk
+>>>>>>> reimported backup
 Yz
 EG
 vN
@@ -1299,6 +1379,13 @@ wa
 WY
 Xk
 Xh
+=======
+DE
+wa
+WY
+Xk
+Xk
+>>>>>>> reimported backup
 me
 bJ
 kY
@@ -1348,11 +1435,17 @@ Xk
 Xk
 Xk
 Md
+<<<<<<< master
 sn
 Cj
 Ql
 cs
 gp
+=======
+Xk
+Cj
+Ql
+cs
 vN
 >>>>>>> reimported backup
 vN
@@ -1370,9 +1463,15 @@ wx
 mn
 Cj
 Xk
+<<<<<<< master
 Xh
 Xk
 Rx
+=======
+Xk
+Xk
+Jp
+>>>>>>> reimported backup
 Pm
 pw
 Ew

--- a/maps/map_files/LV624/sprinkles/25.clfhydrohold.dmm
+++ b/maps/map_files/LV624/sprinkles/25.clfhydrohold.dmm
@@ -10,6 +10,7 @@
 /obj/item/stack/sheet/wood/small_stack{
 	pixel_y = 8
 	},
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
@@ -298,6 +299,14 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
+"rr" = (
+/obj/item/ammo_casing/bullet,
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
 "rG" = (
 /obj/structure/barricade/wooden{
 	dir = 8
@@ -322,6 +331,13 @@
 	icon_state = "metal_1";
 	dir = 4
 	},
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
+"sn" = (
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor{
 	dir = 9;
 	icon_state = "green"
@@ -418,6 +434,14 @@
 /obj/item/explosive/mine/clf/active,
 /turf/open/gm/dirt,
 /area/lv624/ground/colony/south_medbay_road)
+"xH" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
 "xX" = (
 /obj/structure/barricade/plasteel/wired{
 	icon_state = "plasteel_closed_1";
@@ -434,6 +458,7 @@
 	pixel_x = 3;
 	pixel_y = 11
 	},
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor{
 	dir = 9;
 	icon_state = "green"
@@ -472,6 +497,7 @@
 	icon_state = "metal_1";
 	dir = 8
 	},
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -526,6 +552,7 @@
 /obj/structure/barricade/wooden{
 	dir = 8
 	},
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor{
 	dir = 9;
 	icon_state = "green"
@@ -698,6 +725,15 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
+"LN" = (
+/obj/item/ammo_casing/bullet,
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
 "LS" = (
 /obj/structure/surface/table,
 /obj/item/stack/sheet/wood/small_stack{
@@ -780,6 +816,8 @@
 	pixel_x = 3;
 	pixel_y = 6
 	},
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor{
 	dir = 9;
 	icon_state = "green"
@@ -847,6 +885,15 @@
 /area/lv624/lazarus/hydroponics)
 "Rw" = (
 /obj/structure/barricade/wooden,
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
+"Rx" = (
+/obj/effect/spawner/random/attachment,
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor{
 	dir = 9;
 	icon_state = "green"
@@ -885,6 +932,7 @@
 	pixel_y = -15;
 	pixel_x = 11
 	},
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
@@ -957,6 +1005,14 @@
 	},
 /turf/open/gm/grass,
 /area/lv624/ground/jungle/north_jungle)
+"Xh" = (
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
 "Xk" = (
 /turf/open/floor{
 	dir = 9;
@@ -1060,7 +1116,7 @@ XF
 nw
 Fn
 Jp
-yr
+xH
 QK
 Xk
 jL
@@ -1077,11 +1133,11 @@ tj
 Ew
 WY
 Tu
-Cj
+rr
 Xk
+sn
 Xk
-Xk
-Xk
+sn
 yr
 HW
 cF
@@ -1094,14 +1150,14 @@ DE
 Ec
 Ec
 Gw
-Xk
+Xh
 as
 jA
 vK
 kN
 wj
 Xk
-Xk
+sn
 OJ
 Ec
 Ec
@@ -1119,7 +1175,7 @@ ne
 Rw
 Gy
 lU
-Xk
+sn
 Jp
 Ql
 Gs
@@ -1147,7 +1203,7 @@ vN
 DE
 NX
 Ph
-Cj
+LN
 Xk
 sY
 qN
@@ -1156,7 +1212,7 @@ Md
 ay
 cj
 Xk
-Xk
+Xh
 Yz
 EG
 vN
@@ -1166,7 +1222,7 @@ tj
 wa
 WY
 Xk
-Xk
+Xh
 me
 bJ
 kY
@@ -1208,7 +1264,7 @@ Xk
 Xk
 Xk
 Md
-Xk
+sn
 Cj
 Ql
 cs
@@ -1224,9 +1280,9 @@ wx
 mn
 Cj
 Xk
+Xh
 Xk
-Xk
-Jp
+Rx
 Pm
 pw
 Ew

--- a/maps/map_files/LV624/sprinkles/25.clfhydrohold.dmm
+++ b/maps/map_files/LV624/sprinkles/25.clfhydrohold.dmm
@@ -10,10 +10,7 @@
 /obj/item/stack/sheet/wood/small_stack{
 	pixel_y = 8
 	},
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-=======
->>>>>>> reimported backup
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
@@ -320,7 +317,6 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
-<<<<<<< master
 "rr" = (
 /obj/item/ammo_casing/bullet,
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
@@ -329,8 +325,6 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
-=======
->>>>>>> reimported backup
 "rG" = (
 /obj/structure/barricade/wooden{
 	dir = 8
@@ -360,7 +354,6 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
-<<<<<<< master
 "sn" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor{
@@ -368,8 +361,6 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
-=======
->>>>>>> reimported backup
 "sY" = (
 /obj/structure/barricade/wooden{
 	dir = 4
@@ -476,8 +467,6 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
-=======
->>>>>>> reimported backup
 "xX" = (
 /obj/structure/barricade/plasteel/wired{
 	icon_state = "plasteel_closed_1";
@@ -494,10 +483,7 @@
 	pixel_x = 3;
 	pixel_y = 11
 	},
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-=======
->>>>>>> reimported backup
 /turf/open/floor{
 	dir = 9;
 	icon_state = "green"
@@ -536,10 +522,7 @@
 	icon_state = "metal_1";
 	dir = 8
 	},
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-=======
->>>>>>> reimported backup
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -597,10 +580,7 @@
 /obj/structure/barricade/wooden{
 	dir = 8
 	},
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-=======
->>>>>>> reimported backup
 /turf/open/floor{
 	dir = 9;
 	icon_state = "green"
@@ -782,7 +762,6 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
-<<<<<<< master
 "LN" = (
 /obj/item/ammo_casing/bullet,
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
@@ -792,8 +771,6 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
-=======
->>>>>>> reimported backup
 "LS" = (
 /obj/structure/surface/table,
 /obj/item/stack/sheet/wood/small_stack{
@@ -879,11 +856,8 @@
 	pixel_x = 3;
 	pixel_y = 6
 	},
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-=======
->>>>>>> reimported backup
 /turf/open/floor{
 	dir = 9;
 	icon_state = "green"
@@ -951,7 +925,6 @@
 /area/lv624/lazarus/hydroponics)
 "Rw" = (
 /obj/structure/barricade/wooden,
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor{
 	dir = 9;
@@ -961,8 +934,6 @@
 "Rx" = (
 /obj/effect/spawner/random/attachment,
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-=======
->>>>>>> reimported backup
 /turf/open/floor{
 	dir = 9;
 	icon_state = "green"
@@ -1004,10 +975,7 @@
 	pixel_y = -15;
 	pixel_x = 11
 	},
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-=======
->>>>>>> reimported backup
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
@@ -1089,8 +1057,6 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
-=======
->>>>>>> reimported backup
 "Xk" = (
 /turf/open/floor{
 	dir = 9;
@@ -1213,11 +1179,7 @@ XF
 nw
 Fn
 Jp
-<<<<<<< master
 xH
-=======
-yr
->>>>>>> reimported backup
 QK
 Xk
 jL
@@ -1240,17 +1202,6 @@ Xk
 sn
 Xk
 sn
-=======
-DE
-Ew
-WY
-Tu
-Cj
-Xk
-Xk
-Xk
-Xk
->>>>>>> reimported backup
 yr
 HW
 cF
@@ -1267,22 +1218,14 @@ DE
 Ec
 Ec
 Gw
-<<<<<<< master
 Xh
-=======
-Xk
->>>>>>> reimported backup
 as
 jA
 vK
 kN
 wj
 Xk
-<<<<<<< master
 sn
-=======
-Xk
->>>>>>> reimported backup
 OJ
 Ec
 Ec
@@ -1313,22 +1256,6 @@ gp
 "}
 (8,1,1) = {"
 DE
-NX
-=======
-wj
-LS
-ne
-Rw
-Gy
-lU
-Xk
-Jp
-Ql
-Gs
-gp
-"}
-(8,1,1) = {"
-DE
 kV
 >>>>>>> reimported backup
 Ph
@@ -1352,11 +1279,6 @@ DE
 NX
 Ph
 LN
-=======
-kV
-Ph
-Cj
->>>>>>> reimported backup
 Xk
 sY
 qN
@@ -1365,11 +1287,7 @@ Md
 ay
 cj
 Xk
-<<<<<<< master
 Xh
-=======
-Xk
->>>>>>> reimported backup
 Yz
 EG
 vN
@@ -1381,13 +1299,6 @@ wa
 WY
 Xk
 Xh
-=======
-DE
-wa
-WY
-Xk
-Xk
->>>>>>> reimported backup
 me
 bJ
 kY
@@ -1437,14 +1348,7 @@ Xk
 Xk
 Xk
 Md
-<<<<<<< master
 sn
-Cj
-Ql
-cs
-gp
-=======
-Xk
 Cj
 Ql
 cs
@@ -1466,15 +1370,9 @@ wx
 mn
 Cj
 Xk
-<<<<<<< master
 Xh
 Xk
 Rx
-=======
-Xk
-Xk
-Jp
->>>>>>> reimported backup
 Pm
 pw
 Ew

--- a/maps/map_files/LV624/sprinkles/25.clfhydrohold.dmm
+++ b/maps/map_files/LV624/sprinkles/25.clfhydrohold.dmm
@@ -11,9 +11,13 @@
 	pixel_y = 8
 	},
 <<<<<<< master
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 =======
 >>>>>>> reimported backup
+=======
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+>>>>>>> added spawn pointss for clf survivors
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
@@ -355,6 +359,9 @@
 	},
 /area/lv624/lazarus/hydroponics)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> added spawn pointss for clf survivors
 "rr" = (
 /obj/item/ammo_casing/bullet,
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
@@ -363,8 +370,11 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> added spawn pointss for clf survivors
 "rG" = (
 /obj/structure/barricade/wooden{
 	dir = 8
@@ -395,6 +405,9 @@
 	},
 /area/lv624/lazarus/hydroponics)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> added spawn pointss for clf survivors
 "sn" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor{
@@ -402,8 +415,11 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> added spawn pointss for clf survivors
 "sY" = (
 /obj/structure/barricade/wooden{
 	dir = 4
@@ -516,6 +532,9 @@
 /turf/open/gm/dirt,
 /area/lv624/ground/colony/south_medbay_road)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> added spawn pointss for clf survivors
 "xH" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
@@ -524,10 +543,13 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
 =======
 >>>>>>> updated all maps to have CLF Mines and corpses
+=======
+>>>>>>> added spawn pointss for clf survivors
 "xX" = (
 /obj/structure/barricade/plasteel/wired{
 	icon_state = "plasteel_closed_1";
@@ -545,9 +567,13 @@
 	pixel_y = 11
 	},
 <<<<<<< master
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 =======
 >>>>>>> reimported backup
+=======
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+>>>>>>> added spawn pointss for clf survivors
 /turf/open/floor{
 	dir = 9;
 	icon_state = "green"
@@ -587,9 +613,13 @@
 	dir = 8
 	},
 <<<<<<< master
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 =======
 >>>>>>> reimported backup
+=======
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+>>>>>>> added spawn pointss for clf survivors
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -652,9 +682,13 @@
 	dir = 8
 	},
 <<<<<<< master
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 =======
 >>>>>>> reimported backup
+=======
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+>>>>>>> added spawn pointss for clf survivors
 /turf/open/floor{
 	dir = 9;
 	icon_state = "green"
@@ -855,6 +889,9 @@
 	},
 /area/lv624/lazarus/hydroponics)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> added spawn pointss for clf survivors
 "LN" = (
 /obj/item/ammo_casing/bullet,
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
@@ -864,8 +901,11 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> added spawn pointss for clf survivors
 "LS" = (
 /obj/structure/surface/table,
 /obj/item/stack/sheet/wood/small_stack{
@@ -958,10 +998,15 @@
 	pixel_y = 6
 	},
 <<<<<<< master
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 =======
 >>>>>>> reimported backup
+=======
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+>>>>>>> added spawn pointss for clf survivors
 /turf/open/floor{
 	dir = 9;
 	icon_state = "green"
@@ -1030,6 +1075,9 @@
 "Rw" = (
 /obj/structure/barricade/wooden,
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> added spawn pointss for clf survivors
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor{
 	dir = 9;
@@ -1039,8 +1087,11 @@
 "Rx" = (
 /obj/effect/spawner/random/attachment,
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> added spawn pointss for clf survivors
 /turf/open/floor{
 	dir = 9;
 	icon_state = "green"
@@ -1088,9 +1139,13 @@
 	pixel_x = 11
 	},
 <<<<<<< master
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 =======
 >>>>>>> reimported backup
+=======
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+>>>>>>> added spawn pointss for clf survivors
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
@@ -1168,6 +1223,9 @@
 /turf/open/gm/grass,
 /area/lv624/ground/jungle/north_jungle)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> added spawn pointss for clf survivors
 "Xh" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
@@ -1176,10 +1234,13 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
 =======
 >>>>>>> updated all maps to have CLF Mines and corpses
+=======
+>>>>>>> added spawn pointss for clf survivors
 "Xk" = (
 /turf/open/floor{
 	dir = 9;
@@ -1315,10 +1376,14 @@ nw
 Fn
 Jp
 <<<<<<< master
+<<<<<<< master
 xH
 =======
 yr
 >>>>>>> reimported backup
+=======
+xH
+>>>>>>> added spawn pointss for clf survivors
 QK
 Xk
 jL
@@ -1350,12 +1415,15 @@ tj
 Ew
 WY
 Tu
-Cj
+rr
 Xk
+sn
 Xk
-Xk
-Xk
+<<<<<<< master
 >>>>>>> reimported backup
+=======
+sn
+>>>>>>> added spawn pointss for clf survivors
 yr
 HW
 cF
@@ -1377,10 +1445,14 @@ Ec
 Ec
 Gw
 <<<<<<< master
+<<<<<<< master
 Xh
 =======
 Xk
 >>>>>>> reimported backup
+=======
+Xh
+>>>>>>> added spawn pointss for clf survivors
 as
 jA
 vK
@@ -1388,10 +1460,14 @@ kN
 wj
 Xk
 <<<<<<< master
+<<<<<<< master
 sn
 =======
 Xk
 >>>>>>> reimported backup
+=======
+sn
+>>>>>>> added spawn pointss for clf survivors
 OJ
 Ec
 Ec
@@ -1438,7 +1514,7 @@ ne
 Rw
 Gy
 lU
-Xk
+sn
 Jp
 Ql
 Gs
@@ -1474,6 +1550,7 @@ DE
 NX
 Ph
 LN
+<<<<<<< master
 =======
 kV
 =======
@@ -1482,6 +1559,8 @@ NX
 Ph
 Cj
 >>>>>>> reimported backup
+=======
+>>>>>>> added spawn pointss for clf survivors
 Xk
 sY
 qN
@@ -1491,10 +1570,14 @@ ay
 cj
 Xk
 <<<<<<< master
+<<<<<<< master
 Xh
 =======
 Xk
 >>>>>>> reimported backup
+=======
+Xh
+>>>>>>> added spawn pointss for clf survivors
 Yz
 EG
 vN
@@ -1515,8 +1598,12 @@ tj
 wa
 WY
 Xk
+<<<<<<< master
 Xk
 >>>>>>> reimported backup
+=======
+Xh
+>>>>>>> added spawn pointss for clf survivors
 me
 bJ
 kY
@@ -1575,6 +1662,7 @@ Xk
 Xk
 Md
 <<<<<<< master
+<<<<<<< master
 sn
 Cj
 Ql
@@ -1582,6 +1670,9 @@ cs
 gp
 =======
 Xk
+=======
+sn
+>>>>>>> added spawn pointss for clf survivors
 Cj
 Ql
 cs
@@ -1611,6 +1702,7 @@ mn
 Cj
 Xk
 <<<<<<< master
+<<<<<<< master
 Xh
 Xk
 Rx
@@ -1619,6 +1711,11 @@ Xk
 Xk
 Jp
 >>>>>>> reimported backup
+=======
+Xh
+Xk
+Rx
+>>>>>>> added spawn pointss for clf survivors
 Pm
 pw
 Ew

--- a/maps/map_files/LV624/sprinkles/25.clfhydrohold.dmm
+++ b/maps/map_files/LV624/sprinkles/25.clfhydrohold.dmm
@@ -1311,8 +1311,8 @@ iM
 WZ
 Ec
 Ec
-pv
-pv
+kV
+kV
 Ec
 Ec
 jn
@@ -1402,9 +1402,8 @@ tj
 Ew
 WY
 Tu
-rr
+Cj
 Xk
-sn
 Xk
 sn
 =======
@@ -1493,13 +1492,13 @@ Ht
 LS
 ne
 Rw
-Gy
-lU
-sn
+wj
+wj
+Xk
 Jp
 Ql
 Gs
-gp
+vN
 "}
 (8,1,1) = {"
 DE

--- a/maps/map_files/Sorokyne_Strata/Sorokyne_Strata.dmm
+++ b/maps/map_files/Sorokyne_Strata/Sorokyne_Strata.dmm
@@ -33108,7 +33108,11 @@
 /area/strata/ag/exterior)
 "gAN" = (
 /obj/effect/landmark/nightmare{
+<<<<<<< master
 	insert_tag = "clfsoro"
+=======
+	insert_tag = clfsoro
+>>>>>>> added nightmare insert tags to main maps
 	},
 /turf/closed/wall/strata_outpost,
 /area/strata/ag/interior/outpost/engi)

--- a/maps/map_files/Sorokyne_Strata/Sorokyne_Strata.dmm
+++ b/maps/map_files/Sorokyne_Strata/Sorokyne_Strata.dmm
@@ -33109,10 +33109,14 @@
 "gAN" = (
 /obj/effect/landmark/nightmare{
 <<<<<<< master
+<<<<<<< master
 	insert_tag = "clfsoro"
 =======
 	insert_tag = clfsoro
 >>>>>>> added nightmare insert tags to main maps
+=======
+	insert_tag = "clfsoro"
+>>>>>>> fixed issue with invalid landmark
 	},
 /turf/closed/wall/strata_outpost,
 /area/strata/ag/interior/outpost/engi)

--- a/maps/map_files/Sorokyne_Strata/Sorokyne_Strata.dmm
+++ b/maps/map_files/Sorokyne_Strata/Sorokyne_Strata.dmm
@@ -33108,7 +33108,7 @@
 /area/strata/ag/exterior)
 "gAN" = (
 /obj/effect/landmark/nightmare{
-	insert_tag = clfsoro
+	insert_tag = "clfsoro"
 	},
 /turf/closed/wall/strata_outpost,
 /area/strata/ag/interior/outpost/engi)

--- a/maps/map_files/Sorokyne_Strata/Sorokyne_Strata.dmm
+++ b/maps/map_files/Sorokyne_Strata/Sorokyne_Strata.dmm
@@ -33106,6 +33106,12 @@
 /obj/structure/machinery/iv_drip,
 /turf/open/floor/strata,
 /area/strata/ag/exterior)
+"gAN" = (
+/obj/effect/landmark/nightmare{
+	insert_tag = clfsoro
+	},
+/turf/closed/wall/strata_outpost,
+/area/strata/ag/interior/outpost/engi)
 "gBj" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/auto_turf/ice/layer1,
@@ -66781,7 +66787,7 @@ ayP
 ayP
 acf
 acC
-oKo
+gAN
 aMX
 dgB
 bfM

--- a/maps/map_files/Sorokyne_Strata/sprinkles/25.clfsoro.dmm
+++ b/maps/map_files/Sorokyne_Strata/sprinkles/25.clfsoro.dmm
@@ -206,7 +206,6 @@
 "eN" = (
 /turf/open/auto_turf/snow/brown_base/layer4,
 /area/strata/ag/exterior/paths/north_outpost)
-<<<<<<< master
 "fa" = (
 /obj/item/stack/rods,
 /obj/effect/decal/cleanable/blood/oil,
@@ -216,8 +215,6 @@
 	},
 /turf/open/floor/strata,
 /area/strata/ag/interior/outpost/security)
-=======
->>>>>>> reimported backup
 "fr" = (
 /obj/structure/pipes/standard/simple/hidden/cyan{
 	dir = 4
@@ -413,7 +410,9 @@
 =======
 /obj/item/stack/rods,
 /obj/item/stack/cable_coil/cut,
->>>>>>> reimported backup
+/obj/item/explosive/mine/clf/active{
+	dir = 8
+	},
 /turf/open/floor/strata{
 	dir = 10;
 	icon_state = "multi_tiles"
@@ -428,15 +427,12 @@
 	icon_state = "multi_tiles"
 	},
 /area/strata/ag/interior/outpost/security)
-<<<<<<< master
 "ko" = (
 /obj/item/explosive/mine/clf/active,
 /turf/open/floor/strata{
 	icon_state = "red1"
 	},
 /area/strata/ag/interior/outpost/security)
-=======
->>>>>>> reimported backup
 "kA" = (
 /obj/structure/machinery/cm_vending/sorted/medical/wall_med,
 /turf/closed/wall/strata_outpost,
@@ -556,7 +552,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/strata/ag/interior/outpost/security)
-<<<<<<< master
 "ne" = (
 /obj/structure/barricade/handrail/strata,
 /obj/item/explosive/mine/clf/active{
@@ -566,8 +561,6 @@
 	icon_state = "floor3"
 	},
 /area/strata/ag/interior/outpost/security)
-=======
->>>>>>> reimported backup
 "nH" = (
 /turf/open/floor/strata{
 	dir = 8;
@@ -579,12 +572,9 @@
 /obj/item/shard{
 	icon_state = "large"
 	},
-<<<<<<< master
 /obj/item/explosive/mine/clf/active{
 	dir = 4
 	},
-=======
->>>>>>> reimported backup
 /turf/open/floor/strata{
 	icon_state = "floor3"
 	},
@@ -788,7 +778,6 @@
 /obj/item/paper_bin,
 /obj/structure/pipes/standard/manifold/hidden/cyan,
 /obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
-<<<<<<< master
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
@@ -799,10 +788,6 @@
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
-=======
-/obj/item/storage/box/explosive_mines,
-/obj/item/storage/box/explosive_mines,
->>>>>>> reimported backup
 /turf/open/floor/strata{
 	icon_state = "red1"
 	},
@@ -1188,13 +1173,10 @@
 	icon_state = "red1"
 	},
 /area/strata/ag/interior/outpost/security)
-<<<<<<< master
 "BG" = (
 /obj/item/explosive/mine/clf/active,
 /turf/open/floor/strata,
 /area/strata/ag/interior/outpost/security)
-=======
->>>>>>> reimported backup
 "BZ" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -1395,7 +1377,7 @@
 =======
 /obj/item/stack/rods,
 /obj/item/stack/cable_coil/cut,
->>>>>>> reimported backup
+/obj/item/explosive/mine/clf/active,
 /turf/open/floor/strata{
 	dir = 6;
 	icon_state = "multi_tiles"
@@ -1856,12 +1838,9 @@
 /obj/structure/machinery/light/small{
 	dir = 1
 	},
-<<<<<<< master
 /obj/item/explosive/mine/clf/active{
 	dir = 4
 	},
-=======
->>>>>>> reimported backup
 /turf/open/floor/strata{
 	icon_state = "floor3"
 	},
@@ -2364,11 +2343,7 @@ wY
 cp
 nW
 RT
-<<<<<<< master
 BG
-=======
-hV
->>>>>>> reimported backup
 NE
 "}
 (13,1,1) = {"
@@ -2394,15 +2369,7 @@ zQ
 ui
 "}
 (14,1,1) = {"
-<<<<<<< master
 fa
-Sd
-yT
-dZ
-dZ
-im
-=======
-WP
 Sd
 yT
 PJ
@@ -2415,12 +2382,9 @@ LZ
 wx
 iT
 yM
-<<<<<<< master
 ko
-=======
 yT
 >>>>>>> reimported backup
-yT
 yT
 oc
 "}
@@ -2611,11 +2575,7 @@ lo
 Ik
 nN
 lx
-<<<<<<< master
 ne
-=======
-nP
->>>>>>> reimported backup
 Ik
 "}
 (24,1,1) = {"

--- a/maps/map_files/Sorokyne_Strata/sprinkles/25.clfsoro.dmm
+++ b/maps/map_files/Sorokyne_Strata/sprinkles/25.clfsoro.dmm
@@ -88,6 +88,7 @@
 	dir = 1;
 	tag = "icon-chair (NORTH)"
 	},
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/strata{
 	icon_state = "fake_wood"
 	},
@@ -150,6 +151,7 @@
 	dir = 1
 	},
 /obj/effect/spawner/random/attachment,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/strata{
 	icon_state = "fake_wood"
 	},
@@ -263,6 +265,12 @@
 	icon_state = "fake_wood"
 	},
 /area/strata/ag/interior/outpost/security)
+"fT" = (
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/floor/strata{
+	icon_state = "fake_wood"
+	},
+/area/strata/ag/interior/outpost/security)
 "gb" = (
 /obj/structure/machinery/light/small,
 /turf/open/auto_turf/snow/brown_base/layer0,
@@ -272,6 +280,7 @@
 	dir = 4;
 	icon_state = "metal_1"
 	},
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -281,6 +290,7 @@
 	dir = 4
 	},
 /obj/item/ammo_casing/bullet,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/strata,
 /area/strata/ag/interior/outpost/security)
 "gz" = (
@@ -391,6 +401,7 @@
 /area/strata/ag/interior/outpost/security)
 "iM" = (
 /obj/effect/decal/cleanable/blood/drip,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/strata{
 	icon_state = "fake_wood"
 	},
@@ -607,6 +618,12 @@
 	icon_state = "fake_wood"
 	},
 /area/strata/ag/interior/outpost/security)
+"mB" = (
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/floor/strata{
+	icon_state = "floor3"
+	},
+/area/strata/ag/interior/outpost/security)
 "mP" = (
 /obj/effect/landmark/corpsespawner/russian,
 /obj/structure/barricade/metal/wired{
@@ -616,6 +633,7 @@
 /obj/item/weapon/gun/rifle/type71/carbine,
 /obj/effect/decal/cleanable/blood,
 /obj/item/ammo_magazine/rifle/type71,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -639,6 +657,7 @@
 =======
 >>>>>>> updated all maps to have CLF Mines and corpses
 "nH" = (
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/strata{
 	dir = 8;
 	icon_state = "white_cyan2"
@@ -676,6 +695,7 @@
 	dir = 1;
 	pixel_y = 20
 	},
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/strata,
 /area/strata/ag/interior/outpost/security)
 "nX" = (
@@ -791,6 +811,7 @@
 	},
 /area/strata/ag/interior/outpost/engi)
 "qj" = (
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -976,6 +997,7 @@
 /area/strata/ag/interior/outpost/security)
 "tB" = (
 /obj/item/ammo_casing/bullet,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/strata{
 	icon_state = "fake_wood"
 	},
@@ -1001,6 +1023,7 @@
 	},
 /area/strata/ag/interior/outpost/security)
 "ux" = (
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
@@ -1040,6 +1063,16 @@
 	icon_state = "floor3"
 	},
 /area/strata/ag/interior/outpost/security)
+"vF" = (
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1";
+	dir = 1
+	},
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/floor/strata{
+	icon_state = "red1"
+	},
+/area/strata/ag/interior/outpost/security)
 "vJ" = (
 /obj/structure/barricade/plasteel/wired{
 	icon_state = "plasteel_3";
@@ -1054,6 +1087,7 @@
 /obj/structure/pipes/vents/pump{
 	dir = 4
 	},
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -1134,6 +1168,10 @@
 	icon_state = "red1"
 	},
 /area/strata/ag/interior/outpost/security)
+"xq" = (
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/floor/strata,
+/area/strata/ag/interior/outpost/security)
 "xu" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/landmark/corpsespawner/doctor,
@@ -1166,6 +1204,7 @@
 "yu" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/item/ammo_casing/bullet,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/strata{
 	dir = 10;
 	icon_state = "multi_tiles"
@@ -1177,6 +1216,12 @@
 	icon_state = "platingdmg3"
 	},
 /area/strata/ag/interior/outpost/engi)
+"yJ" = (
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/floor/strata{
+	icon_state = "red1"
+	},
+/area/strata/ag/interior/outpost/security)
 "yM" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
@@ -1220,6 +1265,13 @@
 	icon_state = "red1"
 	},
 /area/strata/ag/interior/outpost/security)
+"yX" = (
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "damaged3"
+	},
+/area/strata/ag/interior/outpost/security)
 "zt" = (
 /obj/structure/pipes/vents/pump{
 	dir = 1
@@ -1237,6 +1289,7 @@
 /area/strata/ag/interior/outpost/security)
 "zG" = (
 /obj/item/ammo_magazine/rifle/type71,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/strata{
 	icon_state = "fake_wood"
 	},
@@ -1248,6 +1301,7 @@
 "zQ" = (
 /obj/structure/pipes/standard/simple/hidden/cyan,
 /obj/effect/spawner/random/attachment,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/strata{
 	icon_state = "red1"
 	},
@@ -1359,6 +1413,12 @@
 	icon_state = "red1"
 	},
 /area/strata/ag/interior/outpost/security)
+"CJ" = (
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/strata/ag/interior/outpost/security)
 "Dg" = (
 /obj/item/ammo_casing/bullet,
 /turf/open/floor/plating{
@@ -1402,6 +1462,15 @@
 /obj/structure/bed/chair/office/light,
 /turf/open/floor/strata{
 	icon_state = "floor3"
+	},
+/area/strata/ag/interior/outpost/security)
+"Ex" = (
+/obj/structure/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/landmark/survivor_spawner/clf/generic,
+/turf/open/floor/strata{
+	icon_state = "red1"
 	},
 /area/strata/ag/interior/outpost/security)
 "EV" = (
@@ -1751,6 +1820,7 @@
 /obj/structure/pipes/standard/manifold/hidden/cyan{
 	dir = 8
 	},
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/strata{
 	icon_state = "red1"
 	},
@@ -2126,6 +2196,7 @@
 /obj/structure/pipes/standard/simple/hidden/cyan{
 	dir = 4
 	},
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/strata,
 /area/strata/ag/interior/outpost/security)
 "Ut" = (
@@ -2283,6 +2354,7 @@
 /area/strata/ag/interior/outpost/canteen/lower_cafeteria)
 "ZU" = (
 /obj/structure/pipes/vents/pump,
+/obj/effect/landmark/survivor_spawner/clf/generic,
 /turf/open/floor/strata{
 	icon_state = "fake_wood"
 	},
@@ -2369,7 +2441,7 @@ Pn
 Pn
 Pn
 OW
-Ik
+mB
 AY
 Lx
 SO
@@ -2389,7 +2461,7 @@ Pn
 OW
 jl
 LF
-uh
+fT
 cg
 ZW
 ym
@@ -2434,7 +2506,7 @@ Gb
 FX
 yQ
 yT
-yT
+yJ
 SJ
 ym
 qj
@@ -2501,13 +2573,13 @@ OW
 vP
 PJ
 ix
-DI
+CJ
 eA
 OJ
 "}
 (9,1,1) = {"
 Gt
-Sd
+vF
 Sf
 Gk
 <<<<<<< master
@@ -2559,7 +2631,7 @@ XY
 "}
 (11,1,1) = {"
 OW
-hN
+Ex
 IZ
 My
 cQ
@@ -2651,7 +2723,7 @@ DI
 =======
 >>>>>>> added spawn pointss for clf survivors
 pq
-ui
+km
 LZ
 wx
 iT
@@ -2671,10 +2743,10 @@ oc
 "}
 (15,1,1) = {"
 cp
-hV
+xq
 MC
 Re
-hV
+xq
 sL
 ek
 MC

--- a/maps/map_files/Sorokyne_Strata/sprinkles/25.clfsoro.dmm
+++ b/maps/map_files/Sorokyne_Strata/sprinkles/25.clfsoro.dmm
@@ -99,11 +99,11 @@
 	},
 /area/strata/ag/interior/outpost/engi)
 "dx" = (
-/obj/structure/window_frame/strata,
 /obj/item/stack/rods,
 /obj/item/shard{
 	icon_state = "medium"
 	},
+/obj/structure/window_frame/strata/reinforced,
 /turf/open/floor/strata{
 	icon_state = "fake_wood"
 	},
@@ -175,11 +175,11 @@
 	},
 /area/strata/ag/interior/outpost/engi)
 "eH" = (
-/obj/structure/window_frame/strata,
 /obj/item/stack/rods,
 /obj/item/shard{
 	icon_state = "large"
 	},
+/obj/structure/window_frame/strata/reinforced,
 /turf/open/floor/strata{
 	icon_state = "fake_wood"
 	},
@@ -395,7 +395,7 @@
 /area/strata/ag/interior/outpost/security)
 "kA" = (
 /obj/structure/machinery/cm_vending/sorted/medical/wall_med,
-/turf/closed/wall/strata_outpost,
+/turf/closed/wall/strata_outpost/reinforced,
 /area/strata/ag/interior/outpost/engi)
 "lo" = (
 /obj/item/storage/box/ids,
@@ -461,6 +461,17 @@
 	icon_state = "platingdmg3"
 	},
 /area/strata/ag/interior/outpost/engi)
+"lZ" = (
+/obj/item/stack/rods,
+/obj/item/shard{
+	icon_state = "large"
+	},
+/obj/structure/window_frame/strata/reinforced,
+/turf/open/floor/strata{
+	dir = 8;
+	icon_state = "multi_tiles"
+	},
+/area/strata/ag/interior/outpost/security)
 "mk" = (
 /obj/structure/pipes/standard/simple/hidden/cyan{
 	dir = 4
@@ -565,11 +576,11 @@
 	},
 /area/strata/ag/interior/outpost/security)
 "po" = (
-/obj/structure/window_frame/strata,
 /obj/item/stack/rods,
 /obj/item/shard{
 	icon_state = "large"
 	},
+/obj/structure/window_frame/strata/reinforced,
 /turf/open/floor/strata{
 	icon_state = "red1"
 	},
@@ -681,11 +692,11 @@
 	},
 /area/strata/ag/interior/outpost/security)
 "rC" = (
-/obj/structure/window_frame/strata,
 /obj/item/stack/rods,
 /obj/item/shard{
 	icon_state = "medium"
 	},
+/obj/structure/window_frame/strata/reinforced,
 /turf/open/floor/strata{
 	dir = 6;
 	icon_state = "multi_tiles"
@@ -760,7 +771,6 @@
 	},
 /area/strata/ag/interior/outpost/engi)
 "tv" = (
-/obj/structure/window_frame/strata,
 /obj/item/stack/rods,
 /obj/item/shard{
 	icon_state = "large"
@@ -768,6 +778,7 @@
 /obj/item/shard{
 	icon_state = "medium"
 	},
+/obj/structure/window_frame/strata/reinforced,
 /turf/open/floor/strata{
 	icon_state = "fake_wood"
 	},
@@ -1025,7 +1036,7 @@
 /area/strata/ag/interior/outpost/security)
 "zL" = (
 /obj/structure/sign/poster/clf,
-/turf/closed/wall/strata_outpost,
+/turf/closed/wall/strata_outpost/reinforced,
 /area/strata/ag/interior/outpost/engi)
 "zQ" = (
 /obj/structure/pipes/standard/simple/hidden/cyan,
@@ -1239,11 +1250,11 @@
 	},
 /area/strata/ag/interior/outpost/security)
 "Gb" = (
-/obj/structure/window_frame/strata,
 /obj/item/stack/rods,
 /obj/item/shard{
 	icon_state = "large"
 	},
+/obj/structure/window_frame/strata/reinforced,
 /turf/open/floor/strata{
 	dir = 6;
 	icon_state = "multi_tiles"
@@ -1307,8 +1318,8 @@
 	},
 /area/strata/ag/interior/outpost/security)
 "Gt" = (
-/obj/structure/window_frame/strata,
 /obj/item/stack/rods,
+/obj/structure/window_frame/strata/reinforced,
 /turf/open/floor/strata{
 	dir = 6;
 	icon_state = "multi_tiles"
@@ -1530,8 +1541,8 @@
 /turf/closed/wall/strata_ice/dirty,
 /area/strata/ag/exterior/paths/north_outpost)
 "Pq" = (
-/obj/structure/window_frame/strata,
 /obj/item/stack/rods,
+/obj/structure/window_frame/strata/reinforced,
 /turf/open/floor/strata,
 /area/strata/ag/interior/outpost/security)
 "PJ" = (
@@ -1623,11 +1634,11 @@
 	},
 /area/strata/ag/interior/outpost/engi)
 "Ro" = (
-/obj/structure/window_frame/strata,
 /obj/item/shard{
 	icon_state = "large"
 	},
 /obj/item/stack/rods,
+/obj/structure/window_frame/strata/reinforced,
 /turf/open/floor/strata{
 	dir = 6;
 	icon_state = "multi_tiles"
@@ -1794,8 +1805,16 @@
 	},
 /area/strata/ag/interior/outpost/security)
 "WG" = (
-/turf/closed/wall/strata_outpost,
-/area/strata/ag/interior/outpost/engi)
+/obj/item/stack/rods,
+/obj/item/shard{
+	icon_state = "medium"
+	},
+/obj/structure/window_frame/strata/reinforced,
+/turf/open/floor/strata{
+	dir = 8;
+	icon_state = "multi_tiles"
+	},
+/area/strata/ag/interior/outpost/security)
 "WP" = (
 /obj/item/stack/rods,
 /obj/effect/decal/cleanable/blood/oil,
@@ -2002,7 +2021,7 @@ ym
 lY
 yw
 RV
-WG
+ym
 zL
 "}
 (4,1,1) = {"
@@ -2021,7 +2040,7 @@ db
 qc
 nX
 tt
-WG
+ym
 "}
 (5,1,1) = {"
 fs
@@ -2054,10 +2073,10 @@ OW
 OW
 ym
 sh
-WG
-WG
+ym
+ym
 sh
-WG
+ym
 "}
 (7,1,1) = {"
 OW
@@ -2216,9 +2235,9 @@ Yf
 hV
 Uh
 cp
-Qs
-Gh
-Qs
+lZ
+WG
+lZ
 cp
 "}
 (16,1,1) = {"

--- a/maps/map_files/Sorokyne_Strata/sprinkles/25.clfsoro.dmm
+++ b/maps/map_files/Sorokyne_Strata/sprinkles/25.clfsoro.dmm
@@ -3,7 +3,10 @@
 /obj/structure/pipes/standard/manifold/hidden/cyan{
 	dir = 4
 	},
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/strata{
 	icon_state = "red1"
 	},
@@ -64,6 +67,10 @@
 /obj/structure/pipes/standard/simple/hidden/cyan,
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
+<<<<<<< master
+=======
+/obj/item/stack/rods,
+>>>>>>> reimported backup
 /turf/open/floor/strata,
 /area/strata/ag/interior/outpost/security)
 "cQ" = (
@@ -98,6 +105,10 @@
 /area/strata/ag/interior/outpost/engi)
 "dx" = (
 /obj/structure/window_frame/strata,
+<<<<<<< master
+=======
+/obj/item/stack/rods,
+>>>>>>> reimported backup
 /obj/item/shard{
 	icon_state = "medium"
 	},
@@ -133,12 +144,15 @@
 	icon_state = "fake_wood"
 	},
 /area/strata/ag/interior/outpost/security)
+<<<<<<< master
 "dZ" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
 /area/strata/ag/interior/outpost/security)
+=======
+>>>>>>> reimported backup
 "ek" = (
 /obj/structure/machinery/light/small{
 	dir = 4
@@ -178,6 +192,10 @@
 /area/strata/ag/interior/outpost/engi)
 "eH" = (
 /obj/structure/window_frame/strata,
+<<<<<<< master
+=======
+/obj/item/stack/rods,
+>>>>>>> reimported backup
 /obj/item/shard{
 	icon_state = "large"
 	},
@@ -188,6 +206,7 @@
 "eN" = (
 /turf/open/auto_turf/snow/brown_base/layer4,
 /area/strata/ag/exterior/paths/north_outpost)
+<<<<<<< master
 "fa" = (
 /obj/item/stack/rods,
 /obj/effect/decal/cleanable/blood/oil,
@@ -197,6 +216,8 @@
 	},
 /turf/open/floor/strata,
 /area/strata/ag/interior/outpost/security)
+=======
+>>>>>>> reimported backup
 "fr" = (
 /obj/structure/pipes/standard/simple/hidden/cyan{
 	dir = 4
@@ -292,7 +313,10 @@
 "hX" = (
 /obj/structure/pipes/standard/simple/hidden/cyan,
 /obj/item/ammo_casing/bullet,
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/strata{
 	icon_state = "red1"
 	},
@@ -314,12 +338,15 @@
 	icon_state = "red1"
 	},
 /area/strata/ag/interior/outpost/security)
+<<<<<<< master
 "im" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
 /area/strata/ag/interior/outpost/security)
+=======
+>>>>>>> reimported backup
 "ix" = (
 /obj/effect/spawner/random/attachment,
 /turf/open/floor{
@@ -378,10 +405,15 @@
 /area/strata/ag/interior/outpost/security)
 "jQ" = (
 /obj/effect/decal/cleanable/blood/oil,
+<<<<<<< master
 /obj/item/stack/cable_coil/cut,
 /obj/item/explosive/mine/clf/active{
 	dir = 8
 	},
+=======
+/obj/item/stack/rods,
+/obj/item/stack/cable_coil/cut,
+>>>>>>> reimported backup
 /turf/open/floor/strata{
 	dir = 10;
 	icon_state = "multi_tiles"
@@ -396,12 +428,15 @@
 	icon_state = "multi_tiles"
 	},
 /area/strata/ag/interior/outpost/security)
+<<<<<<< master
 "ko" = (
 /obj/item/explosive/mine/clf/active,
 /turf/open/floor/strata{
 	icon_state = "red1"
 	},
 /area/strata/ag/interior/outpost/security)
+=======
+>>>>>>> reimported backup
 "kA" = (
 /obj/structure/machinery/cm_vending/sorted/medical/wall_med,
 /turf/closed/wall/strata_outpost,
@@ -410,6 +445,10 @@
 /obj/item/storage/box/ids,
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/storage/box/ids,
+<<<<<<< master
+=======
+/obj/item/stack/rods,
+>>>>>>> reimported backup
 /obj/item/shard{
 	icon_state = "large"
 	},
@@ -453,6 +492,10 @@
 "lO" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
+<<<<<<< master
+=======
+/obj/item/stack/rods,
+>>>>>>> reimported backup
 /turf/open/floor/strata{
 	dir = 8;
 	icon_state = "multi_tiles"
@@ -474,7 +517,10 @@
 	},
 /obj/effect/decal/cleanable/blood/drip,
 /obj/item/weapon/melee/twohanded/folded_metal_chair,
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/strata{
 	icon_state = "fake_wood"
 	},
@@ -489,7 +535,10 @@
 /obj/structure/machinery/light/small{
 	dir = 4
 	},
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/strata{
 	icon_state = "fake_wood"
 	},
@@ -507,6 +556,7 @@
 	icon_state = "platingdmg3"
 	},
 /area/strata/ag/interior/outpost/security)
+<<<<<<< master
 "ne" = (
 /obj/structure/barricade/handrail/strata,
 /obj/item/explosive/mine/clf/active{
@@ -516,6 +566,8 @@
 	icon_state = "floor3"
 	},
 /area/strata/ag/interior/outpost/security)
+=======
+>>>>>>> reimported backup
 "nH" = (
 /turf/open/floor/strata{
 	dir = 8;
@@ -527,9 +579,12 @@
 /obj/item/shard{
 	icon_state = "large"
 	},
+<<<<<<< master
 /obj/item/explosive/mine/clf/active{
 	dir = 4
 	},
+=======
+>>>>>>> reimported backup
 /turf/open/floor/strata{
 	icon_state = "floor3"
 	},
@@ -552,7 +607,10 @@
 	dir = 1;
 	pixel_y = 20
 	},
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
@@ -578,6 +636,10 @@
 /area/strata/ag/interior/outpost/security)
 "po" = (
 /obj/structure/window_frame/strata,
+<<<<<<< master
+=======
+/obj/item/stack/rods,
+>>>>>>> reimported backup
 /obj/item/shard{
 	icon_state = "large"
 	},
@@ -626,7 +688,10 @@
 /area/strata/ag/interior/outpost/security)
 "qb" = (
 /obj/item/stool,
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/strata{
 	dir = 8;
 	icon_state = "white_cyan2"
@@ -693,6 +758,10 @@
 /area/strata/ag/interior/outpost/security)
 "rC" = (
 /obj/structure/window_frame/strata,
+<<<<<<< master
+=======
+/obj/item/stack/rods,
+>>>>>>> reimported backup
 /obj/item/shard{
 	icon_state = "medium"
 	},
@@ -719,6 +788,7 @@
 /obj/item/paper_bin,
 /obj/structure/pipes/standard/manifold/hidden/cyan,
 /obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
+<<<<<<< master
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
@@ -729,6 +799,10 @@
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
+=======
+/obj/item/storage/box/explosive_mines,
+/obj/item/storage/box/explosive_mines,
+>>>>>>> reimported backup
 /turf/open/floor/strata{
 	icon_state = "red1"
 	},
@@ -773,13 +847,20 @@
 /obj/item/stack/sheet/metal/medium_stack,
 /obj/item/stack/sheet/metal/medium_stack,
 /obj/structure/surface/rack,
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
 /area/strata/ag/interior/outpost/engi)
 "tv" = (
 /obj/structure/window_frame/strata,
+<<<<<<< master
+=======
+/obj/item/stack/rods,
+>>>>>>> reimported backup
 /obj/item/shard{
 	icon_state = "large"
 	},
@@ -831,6 +912,7 @@
 	icon_state = "floor3"
 	},
 /area/strata/ag/interior/outpost/security)
+<<<<<<< master
 "uR" = (
 /obj/structure/pipes/standard/simple/hidden/cyan{
 	dir = 4
@@ -840,6 +922,8 @@
 	icon_state = "red1"
 	},
 /area/strata/ag/interior/outpost/security)
+=======
+>>>>>>> reimported backup
 "vi" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/reagent_container/food/drinks/cans/souto/grape,
@@ -906,7 +990,10 @@
 	dir = 9
 	},
 /obj/item/ammo_magazine/rifle/type71,
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/strata{
 	icon_state = "red1"
 	},
@@ -980,6 +1067,10 @@
 "yM" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
+<<<<<<< master
+=======
+/obj/item/stack/rods,
+>>>>>>> reimported backup
 /turf/open/floor/strata,
 /area/strata/ag/interior/outpost/security)
 "yQ" = (
@@ -992,6 +1083,7 @@
 	icon_state = "red1"
 	},
 /area/strata/ag/interior/outpost/security)
+<<<<<<< master
 "yR" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor{
@@ -999,6 +1091,8 @@
 	icon_state = "damaged3"
 	},
 /area/strata/ag/interior/outpost/security)
+=======
+>>>>>>> reimported backup
 "yT" = (
 /turf/open/floor/strata{
 	icon_state = "red1"
@@ -1094,10 +1188,13 @@
 	icon_state = "red1"
 	},
 /area/strata/ag/interior/outpost/security)
+<<<<<<< master
 "BG" = (
 /obj/item/explosive/mine/clf/active,
 /turf/open/floor/strata,
 /area/strata/ag/interior/outpost/security)
+=======
+>>>>>>> reimported backup
 "BZ" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -1190,6 +1287,7 @@
 	icon_state = "red1"
 	},
 /area/strata/ag/interior/outpost/security)
+<<<<<<< master
 "Fl" = (
 /obj/structure/window_frame/strata,
 /obj/item/shard{
@@ -1200,6 +1298,8 @@
 	icon_state = "multi_tiles"
 	},
 /area/strata/ag/interior/outpost/security)
+=======
+>>>>>>> reimported backup
 "FK" = (
 /obj/structure/pipes/standard/simple/hidden/cyan,
 /obj/effect/landmark/corpsespawner/russian,
@@ -1240,6 +1340,10 @@
 /area/strata/ag/interior/outpost/security)
 "Gb" = (
 /obj/structure/window_frame/strata,
+<<<<<<< master
+=======
+/obj/item/stack/rods,
+>>>>>>> reimported backup
 /obj/item/shard{
 	icon_state = "large"
 	},
@@ -1285,8 +1389,13 @@
 /area/strata/ag/interior/outpost/security)
 "Gr" = (
 /obj/effect/decal/cleanable/blood/oil,
+<<<<<<< master
 /obj/item/stack/cable_coil/cut,
 /obj/item/explosive/mine/clf/active,
+=======
+/obj/item/stack/rods,
+/obj/item/stack/cable_coil/cut,
+>>>>>>> reimported backup
 /turf/open/floor/strata{
 	dir = 6;
 	icon_state = "multi_tiles"
@@ -1307,6 +1416,10 @@
 /area/strata/ag/interior/outpost/security)
 "Gt" = (
 /obj/structure/window_frame/strata,
+<<<<<<< master
+=======
+/obj/item/stack/rods,
+>>>>>>> reimported backup
 /turf/open/floor/strata{
 	dir = 6;
 	icon_state = "multi_tiles"
@@ -1330,6 +1443,10 @@
 /area/strata/ag/interior/outpost/security)
 "Hh" = (
 /obj/structure/surface/table/reinforced/prison,
+<<<<<<< master
+=======
+/obj/item/stack/rods,
+>>>>>>> reimported backup
 /obj/item/shard{
 	icon_state = "large"
 	},
@@ -1341,7 +1458,10 @@
 /obj/structure/pipes/standard/simple/hidden/cyan{
 	dir = 10
 	},
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/strata{
 	icon_state = "red1"
 	},
@@ -1392,7 +1512,10 @@
 "IZ" = (
 /obj/structure/barricade/handrail/strata,
 /obj/item/ammo_casing/bullet,
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/strata{
 	icon_state = "red1"
 	},
@@ -1509,12 +1632,15 @@
 /obj/structure/barricade/wooden,
 /turf/open/floor/strata,
 /area/strata/ag/interior/outpost/security)
+<<<<<<< master
 "NU" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/strata{
 	icon_state = "red1"
 	},
 /area/strata/ag/interior/outpost/security)
+=======
+>>>>>>> reimported backup
 "OJ" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/stack/rods,
@@ -1535,6 +1661,7 @@
 /area/strata/ag/exterior/paths/north_outpost)
 "Pq" = (
 /obj/structure/window_frame/strata,
+<<<<<<< master
 /turf/open/floor/strata,
 /area/strata/ag/interior/outpost/security)
 "Pv" = (
@@ -1543,6 +1670,11 @@
 	icon_state = "fake_wood"
 	},
 /area/strata/ag/interior/outpost/security)
+=======
+/obj/item/stack/rods,
+/turf/open/floor/strata,
+/area/strata/ag/interior/outpost/security)
+>>>>>>> reimported backup
 "PJ" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
@@ -1644,6 +1776,10 @@
 /area/strata/ag/interior/outpost/security)
 "Rt" = (
 /obj/effect/decal/cleanable/blood/oil,
+<<<<<<< master
+=======
+/obj/item/stack/rods,
+>>>>>>> reimported backup
 /obj/item/stack/cable_coil/cut,
 /turf/open/floor/strata{
 	dir = 10;
@@ -1720,9 +1856,12 @@
 /obj/structure/machinery/light/small{
 	dir = 1
 	},
+<<<<<<< master
 /obj/item/explosive/mine/clf/active{
 	dir = 4
 	},
+=======
+>>>>>>> reimported backup
 /turf/open/floor/strata{
 	icon_state = "floor3"
 	},
@@ -1732,7 +1871,10 @@
 	dir = 4;
 	icon_state = "metal_1"
 	},
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/strata{
 	icon_state = "red1"
 	},
@@ -1765,17 +1907,23 @@
 	icon_state = "metal_1";
 	dir = 1
 	},
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/strata{
 	icon_state = "fake_wood"
 	},
 /area/strata/ag/interior/outpost/security)
+<<<<<<< master
 "Ub" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/strata{
 	icon_state = "floor3"
 	},
 /area/strata/ag/interior/outpost/security)
+=======
+>>>>>>> reimported backup
 "Uh" = (
 /obj/structure/pipes/standard/simple/hidden/cyan{
 	dir = 4
@@ -1800,10 +1948,13 @@
 	icon_state = "platingdmg3"
 	},
 /area/strata/ag/interior/outpost/security)
+<<<<<<< master
 "Wv" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/strata,
 /area/strata/ag/interior/outpost/security)
+=======
+>>>>>>> reimported backup
 "WE" = (
 /obj/structure/bed/chair{
 	dir = 1;
@@ -1862,6 +2013,7 @@
 	icon_state = "multi_tiles"
 	},
 /area/strata/ag/interior/outpost/security)
+<<<<<<< master
 "YG" = (
 /obj/structure/window_frame/strata,
 /obj/item/shard{
@@ -1872,6 +2024,8 @@
 	icon_state = "multi_tiles"
 	},
 /area/strata/ag/interior/outpost/security)
+=======
+>>>>>>> reimported backup
 "YN" = (
 /obj/structure/machinery/space_heater,
 /obj/structure/barricade/metal/wired{
@@ -2044,7 +2198,11 @@ Gb
 qa
 rK
 fC
+<<<<<<< master
 NU
+=======
+yT
+>>>>>>> reimported backup
 Nr
 ym
 db
@@ -2115,7 +2273,11 @@ Gk
 qn
 xu
 mk
+<<<<<<< master
 Pv
+=======
+uh
+>>>>>>> reimported backup
 Ch
 OW
 vP
@@ -2130,7 +2292,11 @@ Gt
 Sd
 Sf
 Gk
+<<<<<<< master
 Pv
+=======
+uh
+>>>>>>> reimported backup
 uh
 fr
 uh
@@ -2154,7 +2320,11 @@ lz
 iM
 tX
 OW
+<<<<<<< master
 uR
+=======
+LS
+>>>>>>> reimported backup
 hN
 gv
 SF
@@ -2194,7 +2364,11 @@ wY
 cp
 nW
 RT
+<<<<<<< master
 BG
+=======
+hV
+>>>>>>> reimported backup
 NE
 "}
 (13,1,1) = {"
@@ -2205,7 +2379,11 @@ zV
 DI
 ID
 DI
+<<<<<<< master
 dZ
+=======
+PJ
+>>>>>>> reimported backup
 yT
 Zz
 CC
@@ -2216,19 +2394,33 @@ zQ
 ui
 "}
 (14,1,1) = {"
+<<<<<<< master
 fa
 Sd
 yT
 dZ
 dZ
 im
+=======
+WP
+Sd
+yT
+PJ
+PJ
+DI
+>>>>>>> reimported backup
 pq
 ui
 LZ
 wx
 iT
 yM
+<<<<<<< master
 ko
+yT
+>>>>>>> reimported backup
+=======
+yT
 yT
 >>>>>>> reimported backup
 yT
@@ -2247,14 +2439,24 @@ Yf
 hV
 Uh
 cp
+<<<<<<< master
 YG
 Fl
 YG
+=======
+Qs
+Gh
+Qs
+>>>>>>> reimported backup
 cp
 "}
 (16,1,1) = {"
 qR
+<<<<<<< master
 Pv
+=======
+uh
+>>>>>>> reimported backup
 zz
 OW
 OW
@@ -2294,9 +2496,15 @@ dL
 sk
 OW
 qS
+<<<<<<< master
 Ub
 Ik
 Ub
+=======
+Ik
+Ik
+Ik
+>>>>>>> reimported backup
 OW
 FO
 Hj
@@ -2338,7 +2546,11 @@ od
 yT
 QA
 PJ
+<<<<<<< master
 yR
+=======
+ID
+>>>>>>> reimported backup
 FT
 rC
 "}
@@ -2352,7 +2564,11 @@ nH
 Ut
 hV
 Gd
+<<<<<<< master
 Ub
+=======
+Ik
+>>>>>>> reimported backup
 hN
 Sp
 mP
@@ -2368,7 +2584,11 @@ qR
 IR
 IB
 Ro
+<<<<<<< master
 Wv
+=======
+hV
+>>>>>>> reimported backup
 Jl
 Ik
 cp
@@ -2393,7 +2613,11 @@ lo
 Ik
 nN
 lx
+<<<<<<< master
 ne
+=======
+nP
+>>>>>>> reimported backup
 Ik
 "}
 (24,1,1) = {"

--- a/maps/map_files/Sorokyne_Strata/sprinkles/25.clfsoro.dmm
+++ b/maps/map_files/Sorokyne_Strata/sprinkles/25.clfsoro.dmm
@@ -3,7 +3,10 @@
 /obj/structure/pipes/standard/manifold/hidden/cyan{
 	dir = 4
 	},
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/strata{
 	icon_state = "red1"
 	},
@@ -64,6 +67,10 @@
 /obj/structure/pipes/standard/simple/hidden/cyan,
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
+<<<<<<< master
+=======
+/obj/item/stack/rods,
+>>>>>>> reimported backup
 /turf/open/floor/strata,
 /area/strata/ag/interior/outpost/security)
 "cQ" = (
@@ -98,6 +105,10 @@
 /area/strata/ag/interior/outpost/engi)
 "dx" = (
 /obj/structure/window_frame/strata,
+<<<<<<< master
+=======
+/obj/item/stack/rods,
+>>>>>>> reimported backup
 /obj/item/shard{
 	icon_state = "medium"
 	},
@@ -133,12 +144,15 @@
 	icon_state = "fake_wood"
 	},
 /area/strata/ag/interior/outpost/security)
+<<<<<<< master
 "dZ" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
 /area/strata/ag/interior/outpost/security)
+=======
+>>>>>>> reimported backup
 "ek" = (
 /obj/structure/machinery/light/small{
 	dir = 4
@@ -178,6 +192,10 @@
 /area/strata/ag/interior/outpost/engi)
 "eH" = (
 /obj/structure/window_frame/strata,
+<<<<<<< master
+=======
+/obj/item/stack/rods,
+>>>>>>> reimported backup
 /obj/item/shard{
 	icon_state = "large"
 	},
@@ -295,7 +313,10 @@
 "hX" = (
 /obj/structure/pipes/standard/simple/hidden/cyan,
 /obj/item/ammo_casing/bullet,
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/strata{
 	icon_state = "red1"
 	},
@@ -317,12 +338,15 @@
 	icon_state = "red1"
 	},
 /area/strata/ag/interior/outpost/security)
+<<<<<<< master
 "im" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
 /area/strata/ag/interior/outpost/security)
+=======
+>>>>>>> reimported backup
 "ix" = (
 /obj/effect/spawner/random/attachment,
 /turf/open/floor{
@@ -381,6 +405,7 @@
 /area/strata/ag/interior/outpost/security)
 "jQ" = (
 /obj/effect/decal/cleanable/blood/oil,
+<<<<<<< master
 /obj/item/stack/cable_coil/cut,
 /obj/item/explosive/mine/clf/active{
 	dir = 8
@@ -420,6 +445,10 @@
 /obj/item/storage/box/ids,
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/storage/box/ids,
+<<<<<<< master
+=======
+/obj/item/stack/rods,
+>>>>>>> reimported backup
 /obj/item/shard{
 	icon_state = "large"
 	},
@@ -463,6 +492,10 @@
 "lO" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
+<<<<<<< master
+=======
+/obj/item/stack/rods,
+>>>>>>> reimported backup
 /turf/open/floor/strata{
 	dir = 8;
 	icon_state = "multi_tiles"
@@ -484,7 +517,10 @@
 	},
 /obj/effect/decal/cleanable/blood/drip,
 /obj/item/weapon/melee/twohanded/folded_metal_chair,
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/strata{
 	icon_state = "fake_wood"
 	},
@@ -499,7 +535,10 @@
 /obj/structure/machinery/light/small{
 	dir = 4
 	},
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/strata{
 	icon_state = "fake_wood"
 	},
@@ -568,7 +607,10 @@
 	dir = 1;
 	pixel_y = 20
 	},
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
@@ -594,6 +636,10 @@
 /area/strata/ag/interior/outpost/security)
 "po" = (
 /obj/structure/window_frame/strata,
+<<<<<<< master
+=======
+/obj/item/stack/rods,
+>>>>>>> reimported backup
 /obj/item/shard{
 	icon_state = "large"
 	},
@@ -642,7 +688,10 @@
 /area/strata/ag/interior/outpost/security)
 "qb" = (
 /obj/item/stool,
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/strata{
 	dir = 8;
 	icon_state = "white_cyan2"
@@ -709,6 +758,10 @@
 /area/strata/ag/interior/outpost/security)
 "rC" = (
 /obj/structure/window_frame/strata,
+<<<<<<< master
+=======
+/obj/item/stack/rods,
+>>>>>>> reimported backup
 /obj/item/shard{
 	icon_state = "medium"
 	},
@@ -794,13 +847,20 @@
 /obj/item/stack/sheet/metal/medium_stack,
 /obj/item/stack/sheet/metal/medium_stack,
 /obj/structure/surface/rack,
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
 /area/strata/ag/interior/outpost/engi)
 "tv" = (
 /obj/structure/window_frame/strata,
+<<<<<<< master
+=======
+/obj/item/stack/rods,
+>>>>>>> reimported backup
 /obj/item/shard{
 	icon_state = "large"
 	},
@@ -852,6 +912,7 @@
 	icon_state = "floor3"
 	},
 /area/strata/ag/interior/outpost/security)
+<<<<<<< master
 "uR" = (
 /obj/structure/pipes/standard/simple/hidden/cyan{
 	dir = 4
@@ -861,6 +922,8 @@
 	icon_state = "red1"
 	},
 /area/strata/ag/interior/outpost/security)
+=======
+>>>>>>> reimported backup
 "vi" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/reagent_container/food/drinks/cans/souto/grape,
@@ -927,7 +990,10 @@
 	dir = 9
 	},
 /obj/item/ammo_magazine/rifle/type71,
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/strata{
 	icon_state = "red1"
 	},
@@ -1001,6 +1067,10 @@
 "yM" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
+<<<<<<< master
+=======
+/obj/item/stack/rods,
+>>>>>>> reimported backup
 /turf/open/floor/strata,
 /area/strata/ag/interior/outpost/security)
 "yQ" = (
@@ -1013,6 +1083,7 @@
 	icon_state = "red1"
 	},
 /area/strata/ag/interior/outpost/security)
+<<<<<<< master
 "yR" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor{
@@ -1020,6 +1091,8 @@
 	icon_state = "damaged3"
 	},
 /area/strata/ag/interior/outpost/security)
+=======
+>>>>>>> reimported backup
 "yT" = (
 /turf/open/floor/strata{
 	icon_state = "red1"
@@ -1214,6 +1287,7 @@
 	icon_state = "red1"
 	},
 /area/strata/ag/interior/outpost/security)
+<<<<<<< master
 "Fl" = (
 /obj/structure/window_frame/strata,
 /obj/item/shard{
@@ -1224,6 +1298,8 @@
 	icon_state = "multi_tiles"
 	},
 /area/strata/ag/interior/outpost/security)
+=======
+>>>>>>> reimported backup
 "FK" = (
 /obj/structure/pipes/standard/simple/hidden/cyan,
 /obj/effect/landmark/corpsespawner/russian,
@@ -1264,6 +1340,10 @@
 /area/strata/ag/interior/outpost/security)
 "Gb" = (
 /obj/structure/window_frame/strata,
+<<<<<<< master
+=======
+/obj/item/stack/rods,
+>>>>>>> reimported backup
 /obj/item/shard{
 	icon_state = "large"
 	},
@@ -1309,6 +1389,11 @@
 /area/strata/ag/interior/outpost/security)
 "Gr" = (
 /obj/effect/decal/cleanable/blood/oil,
+<<<<<<< master
+/obj/item/stack/cable_coil/cut,
+/obj/item/explosive/mine/clf/active,
+=======
+/obj/item/stack/rods,
 /obj/item/stack/cable_coil/cut,
 >>>>>>> reimported backup
 /turf/open/floor/strata{
@@ -1331,6 +1416,10 @@
 /area/strata/ag/interior/outpost/security)
 "Gt" = (
 /obj/structure/window_frame/strata,
+<<<<<<< master
+=======
+/obj/item/stack/rods,
+>>>>>>> reimported backup
 /turf/open/floor/strata{
 	dir = 6;
 	icon_state = "multi_tiles"
@@ -1354,6 +1443,10 @@
 /area/strata/ag/interior/outpost/security)
 "Hh" = (
 /obj/structure/surface/table/reinforced/prison,
+<<<<<<< master
+=======
+/obj/item/stack/rods,
+>>>>>>> reimported backup
 /obj/item/shard{
 	icon_state = "large"
 	},
@@ -1365,7 +1458,10 @@
 /obj/structure/pipes/standard/simple/hidden/cyan{
 	dir = 10
 	},
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/strata{
 	icon_state = "red1"
 	},
@@ -1416,7 +1512,10 @@
 "IZ" = (
 /obj/structure/barricade/handrail/strata,
 /obj/item/ammo_casing/bullet,
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/strata{
 	icon_state = "red1"
 	},
@@ -1533,12 +1632,15 @@
 /obj/structure/barricade/wooden,
 /turf/open/floor/strata,
 /area/strata/ag/interior/outpost/security)
+<<<<<<< master
 "NU" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/strata{
 	icon_state = "red1"
 	},
 /area/strata/ag/interior/outpost/security)
+=======
+>>>>>>> reimported backup
 "OJ" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/stack/rods,
@@ -1559,6 +1661,7 @@
 /area/strata/ag/exterior/paths/north_outpost)
 "Pq" = (
 /obj/structure/window_frame/strata,
+<<<<<<< master
 /turf/open/floor/strata,
 /area/strata/ag/interior/outpost/security)
 "Pv" = (
@@ -1567,6 +1670,11 @@
 	icon_state = "fake_wood"
 	},
 /area/strata/ag/interior/outpost/security)
+=======
+/obj/item/stack/rods,
+/turf/open/floor/strata,
+/area/strata/ag/interior/outpost/security)
+>>>>>>> reimported backup
 "PJ" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
@@ -1668,6 +1776,10 @@
 /area/strata/ag/interior/outpost/security)
 "Rt" = (
 /obj/effect/decal/cleanable/blood/oil,
+<<<<<<< master
+=======
+/obj/item/stack/rods,
+>>>>>>> reimported backup
 /obj/item/stack/cable_coil/cut,
 /turf/open/floor/strata{
 	dir = 10;
@@ -1759,7 +1871,10 @@
 	dir = 4;
 	icon_state = "metal_1"
 	},
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/strata{
 	icon_state = "red1"
 	},
@@ -1792,17 +1907,23 @@
 	icon_state = "metal_1";
 	dir = 1
 	},
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/strata{
 	icon_state = "fake_wood"
 	},
 /area/strata/ag/interior/outpost/security)
+<<<<<<< master
 "Ub" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/strata{
 	icon_state = "floor3"
 	},
 /area/strata/ag/interior/outpost/security)
+=======
+>>>>>>> reimported backup
 "Uh" = (
 /obj/structure/pipes/standard/simple/hidden/cyan{
 	dir = 4
@@ -1827,10 +1948,13 @@
 	icon_state = "platingdmg3"
 	},
 /area/strata/ag/interior/outpost/security)
+<<<<<<< master
 "Wv" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/strata,
 /area/strata/ag/interior/outpost/security)
+=======
+>>>>>>> reimported backup
 "WE" = (
 /obj/structure/bed/chair{
 	dir = 1;
@@ -1889,6 +2013,7 @@
 	icon_state = "multi_tiles"
 	},
 /area/strata/ag/interior/outpost/security)
+<<<<<<< master
 "YG" = (
 /obj/structure/window_frame/strata,
 /obj/item/shard{
@@ -1899,6 +2024,8 @@
 	icon_state = "multi_tiles"
 	},
 /area/strata/ag/interior/outpost/security)
+=======
+>>>>>>> reimported backup
 "YN" = (
 /obj/structure/machinery/space_heater,
 /obj/structure/barricade/metal/wired{
@@ -2071,7 +2198,11 @@ Gb
 qa
 rK
 fC
+<<<<<<< master
 NU
+=======
+yT
+>>>>>>> reimported backup
 Nr
 ym
 db
@@ -2142,7 +2273,11 @@ Gk
 qn
 xu
 mk
+<<<<<<< master
 Pv
+=======
+uh
+>>>>>>> reimported backup
 Ch
 OW
 vP
@@ -2157,7 +2292,11 @@ Gt
 Sd
 Sf
 Gk
+<<<<<<< master
 Pv
+=======
+uh
+>>>>>>> reimported backup
 uh
 fr
 uh
@@ -2181,7 +2320,11 @@ lz
 iM
 tX
 OW
+<<<<<<< master
 uR
+=======
+LS
+>>>>>>> reimported backup
 hN
 gv
 SF
@@ -2236,7 +2379,11 @@ zV
 DI
 ID
 DI
+<<<<<<< master
 dZ
+=======
+PJ
+>>>>>>> reimported backup
 yT
 Zz
 CC
@@ -2254,6 +2401,14 @@ yT
 dZ
 dZ
 im
+=======
+WP
+Sd
+yT
+PJ
+PJ
+DI
+>>>>>>> reimported backup
 pq
 ui
 LZ
@@ -2262,12 +2417,10 @@ iT
 yM
 <<<<<<< master
 ko
-yT
->>>>>>> reimported backup
 =======
 yT
-yT
 >>>>>>> reimported backup
+yT
 yT
 oc
 "}
@@ -2284,14 +2437,24 @@ Yf
 hV
 Uh
 cp
+<<<<<<< master
 YG
 Fl
 YG
+=======
+Qs
+Gh
+Qs
+>>>>>>> reimported backup
 cp
 "}
 (16,1,1) = {"
 qR
+<<<<<<< master
 Pv
+=======
+uh
+>>>>>>> reimported backup
 zz
 OW
 OW
@@ -2331,9 +2494,15 @@ dL
 sk
 OW
 qS
+<<<<<<< master
 Ub
 Ik
 Ub
+=======
+Ik
+Ik
+Ik
+>>>>>>> reimported backup
 OW
 FO
 Hj
@@ -2375,7 +2544,11 @@ od
 yT
 QA
 PJ
+<<<<<<< master
 yR
+=======
+ID
+>>>>>>> reimported backup
 FT
 rC
 "}
@@ -2389,7 +2562,11 @@ nH
 Ut
 hV
 Gd
+<<<<<<< master
 Ub
+=======
+Ik
+>>>>>>> reimported backup
 hN
 Sp
 mP
@@ -2405,7 +2582,11 @@ qR
 IR
 IB
 Ro
+<<<<<<< master
 Wv
+=======
+hV
+>>>>>>> reimported backup
 Jl
 Ik
 cp

--- a/maps/map_files/Sorokyne_Strata/sprinkles/25.clfsoro.dmm
+++ b/maps/map_files/Sorokyne_Strata/sprinkles/25.clfsoro.dmm
@@ -3,7 +3,10 @@
 /obj/structure/pipes/standard/manifold/hidden/cyan{
 	dir = 4
 	},
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/strata{
 	icon_state = "red1"
 	},
@@ -64,6 +67,10 @@
 /obj/structure/pipes/standard/simple/hidden/cyan,
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
+<<<<<<< master
+=======
+/obj/item/stack/rods,
+>>>>>>> reimported backup
 /turf/open/floor/strata,
 /area/strata/ag/interior/outpost/security)
 "cQ" = (
@@ -98,6 +105,10 @@
 /area/strata/ag/interior/outpost/engi)
 "dx" = (
 /obj/structure/window_frame/strata,
+<<<<<<< master
+=======
+/obj/item/stack/rods,
+>>>>>>> reimported backup
 /obj/item/shard{
 	icon_state = "medium"
 	},
@@ -133,12 +144,15 @@
 	icon_state = "fake_wood"
 	},
 /area/strata/ag/interior/outpost/security)
+<<<<<<< master
 "dZ" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
 /area/strata/ag/interior/outpost/security)
+=======
+>>>>>>> reimported backup
 "ek" = (
 /obj/structure/machinery/light/small{
 	dir = 4
@@ -178,6 +192,10 @@
 /area/strata/ag/interior/outpost/engi)
 "eH" = (
 /obj/structure/window_frame/strata,
+<<<<<<< master
+=======
+/obj/item/stack/rods,
+>>>>>>> reimported backup
 /obj/item/shard{
 	icon_state = "large"
 	},
@@ -188,6 +206,7 @@
 "eN" = (
 /turf/open/auto_turf/snow/brown_base/layer4,
 /area/strata/ag/exterior/paths/north_outpost)
+<<<<<<< master
 "fa" = (
 /obj/item/stack/rods,
 /obj/effect/decal/cleanable/blood/oil,
@@ -197,6 +216,8 @@
 	},
 /turf/open/floor/strata,
 /area/strata/ag/interior/outpost/security)
+=======
+>>>>>>> reimported backup
 "fr" = (
 /obj/structure/pipes/standard/simple/hidden/cyan{
 	dir = 4
@@ -292,7 +313,10 @@
 "hX" = (
 /obj/structure/pipes/standard/simple/hidden/cyan,
 /obj/item/ammo_casing/bullet,
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/strata{
 	icon_state = "red1"
 	},
@@ -314,12 +338,15 @@
 	icon_state = "red1"
 	},
 /area/strata/ag/interior/outpost/security)
+<<<<<<< master
 "im" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
 /area/strata/ag/interior/outpost/security)
+=======
+>>>>>>> reimported backup
 "ix" = (
 /obj/effect/spawner/random/attachment,
 /turf/open/floor{
@@ -378,10 +405,15 @@
 /area/strata/ag/interior/outpost/security)
 "jQ" = (
 /obj/effect/decal/cleanable/blood/oil,
+<<<<<<< master
 /obj/item/stack/cable_coil/cut,
 /obj/item/explosive/mine/clf/active{
 	dir = 8
 	},
+=======
+/obj/item/stack/rods,
+/obj/item/stack/cable_coil/cut,
+>>>>>>> reimported backup
 /turf/open/floor/strata{
 	dir = 10;
 	icon_state = "multi_tiles"
@@ -396,12 +428,15 @@
 	icon_state = "multi_tiles"
 	},
 /area/strata/ag/interior/outpost/security)
+<<<<<<< master
 "ko" = (
 /obj/item/explosive/mine/clf/active,
 /turf/open/floor/strata{
 	icon_state = "red1"
 	},
 /area/strata/ag/interior/outpost/security)
+=======
+>>>>>>> reimported backup
 "kA" = (
 /obj/structure/machinery/cm_vending/sorted/medical/wall_med,
 /turf/closed/wall/strata_outpost,
@@ -410,6 +445,10 @@
 /obj/item/storage/box/ids,
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/storage/box/ids,
+<<<<<<< master
+=======
+/obj/item/stack/rods,
+>>>>>>> reimported backup
 /obj/item/shard{
 	icon_state = "large"
 	},
@@ -453,6 +492,10 @@
 "lO" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
+<<<<<<< master
+=======
+/obj/item/stack/rods,
+>>>>>>> reimported backup
 /turf/open/floor/strata{
 	dir = 8;
 	icon_state = "multi_tiles"
@@ -474,7 +517,10 @@
 	},
 /obj/effect/decal/cleanable/blood/drip,
 /obj/item/weapon/melee/twohanded/folded_metal_chair,
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/strata{
 	icon_state = "fake_wood"
 	},
@@ -489,7 +535,10 @@
 /obj/structure/machinery/light/small{
 	dir = 4
 	},
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/strata{
 	icon_state = "fake_wood"
 	},
@@ -507,6 +556,7 @@
 	icon_state = "platingdmg3"
 	},
 /area/strata/ag/interior/outpost/security)
+<<<<<<< master
 "ne" = (
 /obj/structure/barricade/handrail/strata,
 /obj/item/explosive/mine/clf/active{
@@ -516,6 +566,8 @@
 	icon_state = "floor3"
 	},
 /area/strata/ag/interior/outpost/security)
+=======
+>>>>>>> reimported backup
 "nH" = (
 /turf/open/floor/strata{
 	dir = 8;
@@ -527,9 +579,12 @@
 /obj/item/shard{
 	icon_state = "large"
 	},
+<<<<<<< master
 /obj/item/explosive/mine/clf/active{
 	dir = 4
 	},
+=======
+>>>>>>> reimported backup
 /turf/open/floor/strata{
 	icon_state = "floor3"
 	},
@@ -552,7 +607,10 @@
 	dir = 1;
 	pixel_y = 20
 	},
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
@@ -578,6 +636,10 @@
 /area/strata/ag/interior/outpost/security)
 "po" = (
 /obj/structure/window_frame/strata,
+<<<<<<< master
+=======
+/obj/item/stack/rods,
+>>>>>>> reimported backup
 /obj/item/shard{
 	icon_state = "large"
 	},
@@ -626,7 +688,10 @@
 /area/strata/ag/interior/outpost/security)
 "qb" = (
 /obj/item/stool,
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/strata{
 	dir = 8;
 	icon_state = "white_cyan2"
@@ -693,6 +758,10 @@
 /area/strata/ag/interior/outpost/security)
 "rC" = (
 /obj/structure/window_frame/strata,
+<<<<<<< master
+=======
+/obj/item/stack/rods,
+>>>>>>> reimported backup
 /obj/item/shard{
 	icon_state = "medium"
 	},
@@ -719,6 +788,7 @@
 /obj/item/paper_bin,
 /obj/structure/pipes/standard/manifold/hidden/cyan,
 /obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
+<<<<<<< master
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
@@ -729,6 +799,10 @@
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
+=======
+/obj/item/storage/box/explosive_mines,
+/obj/item/storage/box/explosive_mines,
+>>>>>>> reimported backup
 /turf/open/floor/strata{
 	icon_state = "red1"
 	},
@@ -773,13 +847,20 @@
 /obj/item/stack/sheet/metal/medium_stack,
 /obj/item/stack/sheet/metal/medium_stack,
 /obj/structure/surface/rack,
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
 /area/strata/ag/interior/outpost/engi)
 "tv" = (
 /obj/structure/window_frame/strata,
+<<<<<<< master
+=======
+/obj/item/stack/rods,
+>>>>>>> reimported backup
 /obj/item/shard{
 	icon_state = "large"
 	},
@@ -831,6 +912,7 @@
 	icon_state = "floor3"
 	},
 /area/strata/ag/interior/outpost/security)
+<<<<<<< master
 "uR" = (
 /obj/structure/pipes/standard/simple/hidden/cyan{
 	dir = 4
@@ -840,6 +922,8 @@
 	icon_state = "red1"
 	},
 /area/strata/ag/interior/outpost/security)
+=======
+>>>>>>> reimported backup
 "vi" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/reagent_container/food/drinks/cans/souto/grape,
@@ -906,7 +990,10 @@
 	dir = 9
 	},
 /obj/item/ammo_magazine/rifle/type71,
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/strata{
 	icon_state = "red1"
 	},
@@ -980,6 +1067,10 @@
 "yM" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
+<<<<<<< master
+=======
+/obj/item/stack/rods,
+>>>>>>> reimported backup
 /turf/open/floor/strata,
 /area/strata/ag/interior/outpost/security)
 "yQ" = (
@@ -992,6 +1083,7 @@
 	icon_state = "red1"
 	},
 /area/strata/ag/interior/outpost/security)
+<<<<<<< master
 "yR" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor{
@@ -999,6 +1091,8 @@
 	icon_state = "damaged3"
 	},
 /area/strata/ag/interior/outpost/security)
+=======
+>>>>>>> reimported backup
 "yT" = (
 /turf/open/floor/strata{
 	icon_state = "red1"
@@ -1094,10 +1188,13 @@
 	icon_state = "red1"
 	},
 /area/strata/ag/interior/outpost/security)
+<<<<<<< master
 "BG" = (
 /obj/item/explosive/mine/clf/active,
 /turf/open/floor/strata,
 /area/strata/ag/interior/outpost/security)
+=======
+>>>>>>> reimported backup
 "BZ" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -1190,6 +1287,7 @@
 	icon_state = "red1"
 	},
 /area/strata/ag/interior/outpost/security)
+<<<<<<< master
 "Fl" = (
 /obj/structure/window_frame/strata,
 /obj/item/shard{
@@ -1200,6 +1298,8 @@
 	icon_state = "multi_tiles"
 	},
 /area/strata/ag/interior/outpost/security)
+=======
+>>>>>>> reimported backup
 "FK" = (
 /obj/structure/pipes/standard/simple/hidden/cyan,
 /obj/effect/landmark/corpsespawner/russian,
@@ -1240,6 +1340,10 @@
 /area/strata/ag/interior/outpost/security)
 "Gb" = (
 /obj/structure/window_frame/strata,
+<<<<<<< master
+=======
+/obj/item/stack/rods,
+>>>>>>> reimported backup
 /obj/item/shard{
 	icon_state = "large"
 	},
@@ -1285,8 +1389,13 @@
 /area/strata/ag/interior/outpost/security)
 "Gr" = (
 /obj/effect/decal/cleanable/blood/oil,
+<<<<<<< master
 /obj/item/stack/cable_coil/cut,
 /obj/item/explosive/mine/clf/active,
+=======
+/obj/item/stack/rods,
+/obj/item/stack/cable_coil/cut,
+>>>>>>> reimported backup
 /turf/open/floor/strata{
 	dir = 6;
 	icon_state = "multi_tiles"
@@ -1307,6 +1416,10 @@
 /area/strata/ag/interior/outpost/security)
 "Gt" = (
 /obj/structure/window_frame/strata,
+<<<<<<< master
+=======
+/obj/item/stack/rods,
+>>>>>>> reimported backup
 /turf/open/floor/strata{
 	dir = 6;
 	icon_state = "multi_tiles"
@@ -1330,6 +1443,10 @@
 /area/strata/ag/interior/outpost/security)
 "Hh" = (
 /obj/structure/surface/table/reinforced/prison,
+<<<<<<< master
+=======
+/obj/item/stack/rods,
+>>>>>>> reimported backup
 /obj/item/shard{
 	icon_state = "large"
 	},
@@ -1341,7 +1458,10 @@
 /obj/structure/pipes/standard/simple/hidden/cyan{
 	dir = 10
 	},
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/strata{
 	icon_state = "red1"
 	},
@@ -1392,7 +1512,10 @@
 "IZ" = (
 /obj/structure/barricade/handrail/strata,
 /obj/item/ammo_casing/bullet,
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/strata{
 	icon_state = "red1"
 	},
@@ -1509,12 +1632,15 @@
 /obj/structure/barricade/wooden,
 /turf/open/floor/strata,
 /area/strata/ag/interior/outpost/security)
+<<<<<<< master
 "NU" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/strata{
 	icon_state = "red1"
 	},
 /area/strata/ag/interior/outpost/security)
+=======
+>>>>>>> reimported backup
 "OJ" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/stack/rods,
@@ -1535,6 +1661,7 @@
 /area/strata/ag/exterior/paths/north_outpost)
 "Pq" = (
 /obj/structure/window_frame/strata,
+<<<<<<< master
 /turf/open/floor/strata,
 /area/strata/ag/interior/outpost/security)
 "Pv" = (
@@ -1543,6 +1670,11 @@
 	icon_state = "fake_wood"
 	},
 /area/strata/ag/interior/outpost/security)
+=======
+/obj/item/stack/rods,
+/turf/open/floor/strata,
+/area/strata/ag/interior/outpost/security)
+>>>>>>> reimported backup
 "PJ" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
@@ -1644,6 +1776,10 @@
 /area/strata/ag/interior/outpost/security)
 "Rt" = (
 /obj/effect/decal/cleanable/blood/oil,
+<<<<<<< master
+=======
+/obj/item/stack/rods,
+>>>>>>> reimported backup
 /obj/item/stack/cable_coil/cut,
 /turf/open/floor/strata{
 	dir = 10;
@@ -1720,9 +1856,12 @@
 /obj/structure/machinery/light/small{
 	dir = 1
 	},
+<<<<<<< master
 /obj/item/explosive/mine/clf/active{
 	dir = 4
 	},
+=======
+>>>>>>> reimported backup
 /turf/open/floor/strata{
 	icon_state = "floor3"
 	},
@@ -1732,7 +1871,10 @@
 	dir = 4;
 	icon_state = "metal_1"
 	},
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/strata{
 	icon_state = "red1"
 	},
@@ -1765,17 +1907,23 @@
 	icon_state = "metal_1";
 	dir = 1
 	},
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+=======
+>>>>>>> reimported backup
 /turf/open/floor/strata{
 	icon_state = "fake_wood"
 	},
 /area/strata/ag/interior/outpost/security)
+<<<<<<< master
 "Ub" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/strata{
 	icon_state = "floor3"
 	},
 /area/strata/ag/interior/outpost/security)
+=======
+>>>>>>> reimported backup
 "Uh" = (
 /obj/structure/pipes/standard/simple/hidden/cyan{
 	dir = 4
@@ -1800,10 +1948,13 @@
 	icon_state = "platingdmg3"
 	},
 /area/strata/ag/interior/outpost/security)
+<<<<<<< master
 "Wv" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/strata,
 /area/strata/ag/interior/outpost/security)
+=======
+>>>>>>> reimported backup
 "WE" = (
 /obj/structure/bed/chair{
 	dir = 1;
@@ -1862,6 +2013,7 @@
 	icon_state = "multi_tiles"
 	},
 /area/strata/ag/interior/outpost/security)
+<<<<<<< master
 "YG" = (
 /obj/structure/window_frame/strata,
 /obj/item/shard{
@@ -1872,6 +2024,8 @@
 	icon_state = "multi_tiles"
 	},
 /area/strata/ag/interior/outpost/security)
+=======
+>>>>>>> reimported backup
 "YN" = (
 /obj/structure/machinery/space_heater,
 /obj/structure/barricade/metal/wired{
@@ -2044,7 +2198,11 @@ Gb
 qa
 rK
 fC
+<<<<<<< master
 NU
+=======
+yT
+>>>>>>> reimported backup
 Nr
 ym
 db
@@ -2115,7 +2273,11 @@ Gk
 qn
 xu
 mk
+<<<<<<< master
 Pv
+=======
+uh
+>>>>>>> reimported backup
 Ch
 OW
 vP
@@ -2130,7 +2292,11 @@ Gt
 Sd
 Sf
 Gk
+<<<<<<< master
 Pv
+=======
+uh
+>>>>>>> reimported backup
 uh
 fr
 uh
@@ -2154,7 +2320,11 @@ lz
 iM
 tX
 OW
+<<<<<<< master
 uR
+=======
+LS
+>>>>>>> reimported backup
 hN
 gv
 SF
@@ -2194,7 +2364,11 @@ wY
 cp
 nW
 RT
+<<<<<<< master
 BG
+=======
+hV
+>>>>>>> reimported backup
 NE
 "}
 (13,1,1) = {"
@@ -2205,7 +2379,11 @@ zV
 DI
 ID
 DI
+<<<<<<< master
 dZ
+=======
+PJ
+>>>>>>> reimported backup
 yT
 Zz
 CC
@@ -2216,19 +2394,32 @@ zQ
 ui
 "}
 (14,1,1) = {"
+<<<<<<< master
 fa
 Sd
 yT
 dZ
 dZ
 im
+=======
+WP
+Sd
+yT
+PJ
+PJ
+DI
+>>>>>>> reimported backup
 pq
 ui
 LZ
 wx
 iT
 yM
+<<<<<<< master
 ko
+=======
+yT
+>>>>>>> reimported backup
 yT
 yT
 oc
@@ -2246,14 +2437,24 @@ Yf
 hV
 Uh
 cp
+<<<<<<< master
 YG
 Fl
 YG
+=======
+Qs
+Gh
+Qs
+>>>>>>> reimported backup
 cp
 "}
 (16,1,1) = {"
 qR
+<<<<<<< master
 Pv
+=======
+uh
+>>>>>>> reimported backup
 zz
 OW
 OW
@@ -2293,9 +2494,15 @@ dL
 sk
 OW
 qS
+<<<<<<< master
 Ub
 Ik
 Ub
+=======
+Ik
+Ik
+Ik
+>>>>>>> reimported backup
 OW
 FO
 Hj
@@ -2337,7 +2544,11 @@ od
 yT
 QA
 PJ
+<<<<<<< master
 yR
+=======
+ID
+>>>>>>> reimported backup
 FT
 rC
 "}
@@ -2351,7 +2562,11 @@ nH
 Ut
 hV
 Gd
+<<<<<<< master
 Ub
+=======
+Ik
+>>>>>>> reimported backup
 hN
 Sp
 mP
@@ -2367,7 +2582,11 @@ qR
 IR
 IB
 Ro
+<<<<<<< master
 Wv
+=======
+hV
+>>>>>>> reimported backup
 Jl
 Ik
 cp
@@ -2392,7 +2611,11 @@ lo
 Ik
 nN
 lx
+<<<<<<< master
 ne
+=======
+nP
+>>>>>>> reimported backup
 Ik
 "}
 (24,1,1) = {"

--- a/maps/map_files/Sorokyne_Strata/sprinkles/25.clfsoro.dmm
+++ b/maps/map_files/Sorokyne_Strata/sprinkles/25.clfsoro.dmm
@@ -184,6 +184,15 @@
 "eN" = (
 /turf/open/auto_turf/snow/brown_base/layer4,
 /area/strata/ag/exterior/paths/north_outpost)
+"fa" = (
+/obj/item/stack/rods,
+/obj/effect/decal/cleanable/blood/oil,
+/obj/item/stack/cable_coil/cut,
+/obj/item/explosive/mine/clf/active{
+	dir = 1
+	},
+/turf/open/floor/strata,
+/area/strata/ag/interior/outpost/security)
 "fr" = (
 /obj/structure/pipes/standard/simple/hidden/cyan{
 	dir = 4
@@ -360,6 +369,9 @@
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/rods,
 /obj/item/stack/cable_coil/cut,
+/obj/item/explosive/mine/clf/active{
+	dir = 8
+	},
 /turf/open/floor/strata{
 	dir = 10;
 	icon_state = "multi_tiles"
@@ -372,6 +384,12 @@
 /turf/open/floor/strata{
 	dir = 8;
 	icon_state = "multi_tiles"
+	},
+/area/strata/ag/interior/outpost/security)
+"ko" = (
+/obj/item/explosive/mine/clf/active,
+/turf/open/floor/strata{
+	icon_state = "red1"
 	},
 /area/strata/ag/interior/outpost/security)
 "kA" = (
@@ -479,6 +497,15 @@
 	icon_state = "platingdmg3"
 	},
 /area/strata/ag/interior/outpost/security)
+"ne" = (
+/obj/structure/barricade/handrail/strata,
+/obj/item/explosive/mine/clf/active{
+	dir = 4
+	},
+/turf/open/floor/strata{
+	icon_state = "floor3"
+	},
+/area/strata/ag/interior/outpost/security)
 "nH" = (
 /turf/open/floor/strata{
 	dir = 8;
@@ -489,6 +516,9 @@
 /obj/structure/barricade/handrail/strata,
 /obj/item/shard{
 	icon_state = "large"
+	},
+/obj/item/explosive/mine/clf/active{
+	dir = 4
 	},
 /turf/open/floor/strata{
 	icon_state = "floor3"
@@ -679,8 +709,16 @@
 /obj/item/paper_bin,
 /obj/structure/pipes/standard/manifold/hidden/cyan,
 /obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
-/obj/item/storage/box/explosive_mines,
-/obj/item/storage/box/explosive_mines,
+/obj/item/explosive/mine/clf,
+/obj/item/explosive/mine/clf,
+/obj/item/explosive/mine/clf,
+/obj/item/explosive/mine/clf,
+/obj/item/explosive/mine/clf,
+/obj/item/explosive/mine/clf,
+/obj/item/explosive/mine/clf,
+/obj/item/explosive/mine/clf,
+/obj/item/explosive/mine/clf,
+/obj/item/explosive/mine/clf,
 /turf/open/floor/strata{
 	icon_state = "red1"
 	},
@@ -1030,6 +1068,10 @@
 	icon_state = "red1"
 	},
 /area/strata/ag/interior/outpost/security)
+"BG" = (
+/obj/item/explosive/mine/clf/active,
+/turf/open/floor/strata,
+/area/strata/ag/interior/outpost/security)
 "BZ" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -1210,6 +1252,7 @@
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/rods,
 /obj/item/stack/cable_coil/cut,
+/obj/item/explosive/mine/clf/active,
 /turf/open/floor/strata{
 	dir = 6;
 	icon_state = "multi_tiles"
@@ -1632,6 +1675,9 @@
 "SB" = (
 /obj/structure/machinery/light/small{
 	dir = 1
+	},
+/obj/item/explosive/mine/clf/active{
+	dir = 4
 	},
 /turf/open/floor/strata{
 	icon_state = "floor3"
@@ -2082,7 +2128,7 @@ wY
 cp
 nW
 RT
-hV
+BG
 NE
 "}
 (13,1,1) = {"
@@ -2104,7 +2150,7 @@ zQ
 ui
 "}
 (14,1,1) = {"
-WP
+fa
 Sd
 yT
 PJ
@@ -2116,7 +2162,7 @@ LZ
 wx
 iT
 yM
-yT
+ko
 yT
 yT
 oc
@@ -2280,7 +2326,7 @@ lo
 Ik
 nN
 lx
-nP
+ne
 Ik
 "}
 (24,1,1) = {"

--- a/maps/map_files/Sorokyne_Strata/sprinkles/25.clfsoro.dmm
+++ b/maps/map_files/Sorokyne_Strata/sprinkles/25.clfsoro.dmm
@@ -4,9 +4,13 @@
 	dir = 4
 	},
 <<<<<<< master
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 =======
 >>>>>>> reimported backup
+=======
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+>>>>>>> added spawn pointss for clf survivors
 /turf/open/floor/strata{
 	icon_state = "red1"
 	},
@@ -68,9 +72,12 @@
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
 <<<<<<< master
+<<<<<<< master
 =======
 /obj/item/stack/rods,
 >>>>>>> reimported backup
+=======
+>>>>>>> added spawn pointss for clf survivors
 /turf/open/floor/strata,
 /area/strata/ag/interior/outpost/security)
 "cQ" = (
@@ -106,9 +113,12 @@
 "dx" = (
 /obj/structure/window_frame/strata,
 <<<<<<< master
+<<<<<<< master
 =======
 /obj/item/stack/rods,
 >>>>>>> reimported backup
+=======
+>>>>>>> added spawn pointss for clf survivors
 /obj/item/shard{
 	icon_state = "medium"
 	},
@@ -145,14 +155,20 @@
 	},
 /area/strata/ag/interior/outpost/security)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> added spawn pointss for clf survivors
 "dZ" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
 /area/strata/ag/interior/outpost/security)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> added spawn pointss for clf survivors
 "ek" = (
 /obj/structure/machinery/light/small{
 	dir = 4
@@ -193,9 +209,12 @@
 "eH" = (
 /obj/structure/window_frame/strata,
 <<<<<<< master
+<<<<<<< master
 =======
 /obj/item/stack/rods,
 >>>>>>> reimported backup
+=======
+>>>>>>> added spawn pointss for clf survivors
 /obj/item/shard{
 	icon_state = "large"
 	},
@@ -320,9 +339,13 @@
 /obj/structure/pipes/standard/simple/hidden/cyan,
 /obj/item/ammo_casing/bullet,
 <<<<<<< master
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 =======
 >>>>>>> reimported backup
+=======
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+>>>>>>> added spawn pointss for clf survivors
 /turf/open/floor/strata{
 	icon_state = "red1"
 	},
@@ -345,14 +368,20 @@
 	},
 /area/strata/ag/interior/outpost/security)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> added spawn pointss for clf survivors
 "im" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
 /area/strata/ag/interior/outpost/security)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> added spawn pointss for clf survivors
 "ix" = (
 /obj/effect/spawner/random/attachment,
 /turf/open/floor{
@@ -412,12 +441,15 @@
 "jQ" = (
 /obj/effect/decal/cleanable/blood/oil,
 <<<<<<< master
+<<<<<<< master
 /obj/item/stack/cable_coil/cut,
 /obj/item/explosive/mine/clf/active{
 	dir = 8
 	},
 =======
 /obj/item/stack/rods,
+=======
+>>>>>>> added spawn pointss for clf survivors
 /obj/item/stack/cable_coil/cut,
 <<<<<<< master
 >>>>>>> reimported backup
@@ -464,9 +496,12 @@
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/storage/box/ids,
 <<<<<<< master
+<<<<<<< master
 =======
 /obj/item/stack/rods,
 >>>>>>> reimported backup
+=======
+>>>>>>> added spawn pointss for clf survivors
 /obj/item/shard{
 	icon_state = "large"
 	},
@@ -511,9 +546,12 @@
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
 <<<<<<< master
+<<<<<<< master
 =======
 /obj/item/stack/rods,
 >>>>>>> reimported backup
+=======
+>>>>>>> added spawn pointss for clf survivors
 /turf/open/floor/strata{
 	dir = 8;
 	icon_state = "multi_tiles"
@@ -536,9 +574,13 @@
 /obj/effect/decal/cleanable/blood/drip,
 /obj/item/weapon/melee/twohanded/folded_metal_chair,
 <<<<<<< master
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 =======
 >>>>>>> reimported backup
+=======
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+>>>>>>> added spawn pointss for clf survivors
 /turf/open/floor/strata{
 	icon_state = "fake_wood"
 	},
@@ -554,9 +596,13 @@
 	dir = 4
 	},
 <<<<<<< master
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 =======
 >>>>>>> reimported backup
+=======
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+>>>>>>> added spawn pointss for clf survivors
 /turf/open/floor/strata{
 	icon_state = "fake_wood"
 	},
@@ -638,9 +684,13 @@
 	pixel_y = 20
 	},
 <<<<<<< master
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 =======
 >>>>>>> reimported backup
+=======
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+>>>>>>> added spawn pointss for clf survivors
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
@@ -667,9 +717,12 @@
 "po" = (
 /obj/structure/window_frame/strata,
 <<<<<<< master
+<<<<<<< master
 =======
 /obj/item/stack/rods,
 >>>>>>> reimported backup
+=======
+>>>>>>> added spawn pointss for clf survivors
 /obj/item/shard{
 	icon_state = "large"
 	},
@@ -719,9 +772,13 @@
 "qb" = (
 /obj/item/stool,
 <<<<<<< master
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 =======
 >>>>>>> reimported backup
+=======
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+>>>>>>> added spawn pointss for clf survivors
 /turf/open/floor/strata{
 	dir = 8;
 	icon_state = "white_cyan2"
@@ -789,9 +846,12 @@
 "rC" = (
 /obj/structure/window_frame/strata,
 <<<<<<< master
+<<<<<<< master
 =======
 /obj/item/stack/rods,
 >>>>>>> reimported backup
+=======
+>>>>>>> added spawn pointss for clf survivors
 /obj/item/shard{
 	icon_state = "medium"
 	},
@@ -884,9 +944,13 @@
 /obj/item/stack/sheet/metal/medium_stack,
 /obj/structure/surface/rack,
 <<<<<<< master
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 =======
 >>>>>>> reimported backup
+=======
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+>>>>>>> added spawn pointss for clf survivors
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
@@ -894,9 +958,12 @@
 "tv" = (
 /obj/structure/window_frame/strata,
 <<<<<<< master
+<<<<<<< master
 =======
 /obj/item/stack/rods,
 >>>>>>> reimported backup
+=======
+>>>>>>> added spawn pointss for clf survivors
 /obj/item/shard{
 	icon_state = "large"
 	},
@@ -949,6 +1016,9 @@
 	},
 /area/strata/ag/interior/outpost/security)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> added spawn pointss for clf survivors
 "uR" = (
 /obj/structure/pipes/standard/simple/hidden/cyan{
 	dir = 4
@@ -958,8 +1028,11 @@
 	icon_state = "red1"
 	},
 /area/strata/ag/interior/outpost/security)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> added spawn pointss for clf survivors
 "vi" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/reagent_container/food/drinks/cans/souto/grape,
@@ -1027,9 +1100,13 @@
 	},
 /obj/item/ammo_magazine/rifle/type71,
 <<<<<<< master
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 =======
 >>>>>>> reimported backup
+=======
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+>>>>>>> added spawn pointss for clf survivors
 /turf/open/floor/strata{
 	icon_state = "red1"
 	},
@@ -1104,9 +1181,12 @@
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
 <<<<<<< master
+<<<<<<< master
 =======
 /obj/item/stack/rods,
 >>>>>>> reimported backup
+=======
+>>>>>>> added spawn pointss for clf survivors
 /turf/open/floor/strata,
 /area/strata/ag/interior/outpost/security)
 "yQ" = (
@@ -1120,6 +1200,9 @@
 	},
 /area/strata/ag/interior/outpost/security)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> added spawn pointss for clf survivors
 "yR" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor{
@@ -1127,8 +1210,11 @@
 	icon_state = "damaged3"
 	},
 /area/strata/ag/interior/outpost/security)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> added spawn pointss for clf survivors
 "yT" = (
 /turf/open/floor/strata{
 	icon_state = "red1"
@@ -1330,6 +1416,9 @@
 	},
 /area/strata/ag/interior/outpost/security)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> added spawn pointss for clf survivors
 "Fl" = (
 /obj/structure/window_frame/strata,
 /obj/item/shard{
@@ -1340,8 +1429,11 @@
 	icon_state = "multi_tiles"
 	},
 /area/strata/ag/interior/outpost/security)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> added spawn pointss for clf survivors
 "FK" = (
 /obj/structure/pipes/standard/simple/hidden/cyan,
 /obj/effect/landmark/corpsespawner/russian,
@@ -1383,9 +1475,12 @@
 "Gb" = (
 /obj/structure/window_frame/strata,
 <<<<<<< master
+<<<<<<< master
 =======
 /obj/item/stack/rods,
 >>>>>>> reimported backup
+=======
+>>>>>>> added spawn pointss for clf survivors
 /obj/item/shard{
 	icon_state = "large"
 	},
@@ -1432,10 +1527,13 @@
 "Gr" = (
 /obj/effect/decal/cleanable/blood/oil,
 <<<<<<< master
+<<<<<<< master
 /obj/item/stack/cable_coil/cut,
 /obj/item/explosive/mine/clf/active,
 =======
 /obj/item/stack/rods,
+=======
+>>>>>>> added spawn pointss for clf survivors
 /obj/item/stack/cable_coil/cut,
 <<<<<<< master
 >>>>>>> reimported backup
@@ -1463,9 +1561,12 @@
 "Gt" = (
 /obj/structure/window_frame/strata,
 <<<<<<< master
+<<<<<<< master
 =======
 /obj/item/stack/rods,
 >>>>>>> reimported backup
+=======
+>>>>>>> added spawn pointss for clf survivors
 /turf/open/floor/strata{
 	dir = 6;
 	icon_state = "multi_tiles"
@@ -1490,9 +1591,12 @@
 "Hh" = (
 /obj/structure/surface/table/reinforced/prison,
 <<<<<<< master
+<<<<<<< master
 =======
 /obj/item/stack/rods,
 >>>>>>> reimported backup
+=======
+>>>>>>> added spawn pointss for clf survivors
 /obj/item/shard{
 	icon_state = "large"
 	},
@@ -1505,9 +1609,13 @@
 	dir = 10
 	},
 <<<<<<< master
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 =======
 >>>>>>> reimported backup
+=======
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+>>>>>>> added spawn pointss for clf survivors
 /turf/open/floor/strata{
 	icon_state = "red1"
 	},
@@ -1559,9 +1667,13 @@
 /obj/structure/barricade/handrail/strata,
 /obj/item/ammo_casing/bullet,
 <<<<<<< master
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 =======
 >>>>>>> reimported backup
+=======
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+>>>>>>> added spawn pointss for clf survivors
 /turf/open/floor/strata{
 	icon_state = "red1"
 	},
@@ -1679,14 +1791,20 @@
 /turf/open/floor/strata,
 /area/strata/ag/interior/outpost/security)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> added spawn pointss for clf survivors
 "NU" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/strata{
 	icon_state = "red1"
 	},
 /area/strata/ag/interior/outpost/security)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> added spawn pointss for clf survivors
 "OJ" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/stack/rods,
@@ -1708,6 +1826,7 @@
 "Pq" = (
 /obj/structure/window_frame/strata,
 <<<<<<< master
+<<<<<<< master
 /turf/open/floor/strata,
 /area/strata/ag/interior/outpost/security)
 "Pv" = (
@@ -1721,6 +1840,16 @@
 /turf/open/floor/strata,
 /area/strata/ag/interior/outpost/security)
 >>>>>>> reimported backup
+=======
+/turf/open/floor/strata,
+/area/strata/ag/interior/outpost/security)
+"Pv" = (
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/turf/open/floor/strata{
+	icon_state = "fake_wood"
+	},
+/area/strata/ag/interior/outpost/security)
+>>>>>>> added spawn pointss for clf survivors
 "PJ" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
@@ -1823,9 +1952,12 @@
 "Rt" = (
 /obj/effect/decal/cleanable/blood/oil,
 <<<<<<< master
+<<<<<<< master
 =======
 /obj/item/stack/rods,
 >>>>>>> reimported backup
+=======
+>>>>>>> added spawn pointss for clf survivors
 /obj/item/stack/cable_coil/cut,
 /turf/open/floor/strata{
 	dir = 10;
@@ -1924,9 +2056,13 @@
 	icon_state = "metal_1"
 	},
 <<<<<<< master
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 =======
 >>>>>>> reimported backup
+=======
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+>>>>>>> added spawn pointss for clf survivors
 /turf/open/floor/strata{
 	icon_state = "red1"
 	},
@@ -1960,22 +2096,32 @@
 	dir = 1
 	},
 <<<<<<< master
+<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 =======
 >>>>>>> reimported backup
+=======
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+>>>>>>> added spawn pointss for clf survivors
 /turf/open/floor/strata{
 	icon_state = "fake_wood"
 	},
 /area/strata/ag/interior/outpost/security)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> added spawn pointss for clf survivors
 "Ub" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/strata{
 	icon_state = "floor3"
 	},
 /area/strata/ag/interior/outpost/security)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> added spawn pointss for clf survivors
 "Uh" = (
 /obj/structure/pipes/standard/simple/hidden/cyan{
 	dir = 4
@@ -2001,12 +2147,18 @@
 	},
 /area/strata/ag/interior/outpost/security)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> added spawn pointss for clf survivors
 "Wv" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/strata,
 /area/strata/ag/interior/outpost/security)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> added spawn pointss for clf survivors
 "WE" = (
 /obj/structure/bed/chair{
 	dir = 1;
@@ -2066,6 +2218,9 @@
 	},
 /area/strata/ag/interior/outpost/security)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> added spawn pointss for clf survivors
 "YG" = (
 /obj/structure/window_frame/strata,
 /obj/item/shard{
@@ -2076,8 +2231,11 @@
 	icon_state = "multi_tiles"
 	},
 /area/strata/ag/interior/outpost/security)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> added spawn pointss for clf survivors
 "YN" = (
 /obj/structure/machinery/space_heater,
 /obj/structure/barricade/metal/wired{
@@ -2251,10 +2409,14 @@ qa
 rK
 fC
 <<<<<<< master
+<<<<<<< master
 NU
 =======
 yT
 >>>>>>> reimported backup
+=======
+NU
+>>>>>>> added spawn pointss for clf survivors
 Nr
 ym
 db
@@ -2326,10 +2488,14 @@ qn
 xu
 mk
 <<<<<<< master
+<<<<<<< master
 Pv
 =======
 uh
 >>>>>>> reimported backup
+=======
+Pv
+>>>>>>> added spawn pointss for clf survivors
 Ch
 OW
 vP
@@ -2345,10 +2511,14 @@ Sd
 Sf
 Gk
 <<<<<<< master
+<<<<<<< master
 Pv
 =======
 uh
 >>>>>>> reimported backup
+=======
+Pv
+>>>>>>> added spawn pointss for clf survivors
 uh
 fr
 uh
@@ -2373,10 +2543,14 @@ iM
 tX
 OW
 <<<<<<< master
+<<<<<<< master
 uR
 =======
 LS
 >>>>>>> reimported backup
+=======
+uR
+>>>>>>> added spawn pointss for clf survivors
 hN
 gv
 SF
@@ -2436,10 +2610,14 @@ DI
 ID
 DI
 <<<<<<< master
+<<<<<<< master
 dZ
 =======
 PJ
 >>>>>>> reimported backup
+=======
+dZ
+>>>>>>> added spawn pointss for clf survivors
 yT
 Zz
 CC
@@ -2458,6 +2636,7 @@ yT
 dZ
 dZ
 im
+<<<<<<< master
 =======
 WP
 =======
@@ -2469,6 +2648,8 @@ PJ
 PJ
 DI
 >>>>>>> reimported backup
+=======
+>>>>>>> added spawn pointss for clf survivors
 pq
 ui
 LZ
@@ -2502,6 +2683,7 @@ hV
 Uh
 cp
 <<<<<<< master
+<<<<<<< master
 YG
 Fl
 YG
@@ -2510,15 +2692,24 @@ Qs
 Gh
 Qs
 >>>>>>> reimported backup
+=======
+YG
+Fl
+YG
+>>>>>>> added spawn pointss for clf survivors
 cp
 "}
 (16,1,1) = {"
 qR
 <<<<<<< master
+<<<<<<< master
 Pv
 =======
 uh
 >>>>>>> reimported backup
+=======
+Pv
+>>>>>>> added spawn pointss for clf survivors
 zz
 OW
 OW
@@ -2559,6 +2750,7 @@ sk
 OW
 qS
 <<<<<<< master
+<<<<<<< master
 Ub
 Ik
 Ub
@@ -2567,6 +2759,11 @@ Ik
 Ik
 Ik
 >>>>>>> reimported backup
+=======
+Ub
+Ik
+Ub
+>>>>>>> added spawn pointss for clf survivors
 OW
 FO
 Hj
@@ -2609,10 +2806,14 @@ yT
 QA
 PJ
 <<<<<<< master
+<<<<<<< master
 yR
 =======
 ID
 >>>>>>> reimported backup
+=======
+yR
+>>>>>>> added spawn pointss for clf survivors
 FT
 rC
 "}
@@ -2627,10 +2828,14 @@ Ut
 hV
 Gd
 <<<<<<< master
+<<<<<<< master
 Ub
 =======
 Ik
 >>>>>>> reimported backup
+=======
+Ub
+>>>>>>> added spawn pointss for clf survivors
 hN
 Sp
 mP
@@ -2647,10 +2852,14 @@ IR
 IB
 Ro
 <<<<<<< master
+<<<<<<< master
 Wv
 =======
 hV
 >>>>>>> reimported backup
+=======
+Wv
+>>>>>>> added spawn pointss for clf survivors
 Jl
 Ik
 cp

--- a/maps/map_files/Sorokyne_Strata/sprinkles/25.clfsoro.dmm
+++ b/maps/map_files/Sorokyne_Strata/sprinkles/25.clfsoro.dmm
@@ -207,6 +207,9 @@
 /turf/open/auto_turf/snow/brown_base/layer4,
 /area/strata/ag/exterior/paths/north_outpost)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "fa" = (
 /obj/item/stack/rods,
 /obj/effect/decal/cleanable/blood/oil,
@@ -216,8 +219,11 @@
 	},
 /turf/open/floor/strata,
 /area/strata/ag/interior/outpost/security)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "fr" = (
 /obj/structure/pipes/standard/simple/hidden/cyan{
 	dir = 4
@@ -413,7 +419,13 @@
 =======
 /obj/item/stack/rods,
 /obj/item/stack/cable_coil/cut,
+<<<<<<< master
 >>>>>>> reimported backup
+=======
+/obj/item/explosive/mine/clf/active{
+	dir = 8
+	},
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor/strata{
 	dir = 10;
 	icon_state = "multi_tiles"
@@ -429,14 +441,20 @@
 	},
 /area/strata/ag/interior/outpost/security)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "ko" = (
 /obj/item/explosive/mine/clf/active,
 /turf/open/floor/strata{
 	icon_state = "red1"
 	},
 /area/strata/ag/interior/outpost/security)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "kA" = (
 /obj/structure/machinery/cm_vending/sorted/medical/wall_med,
 /turf/closed/wall/strata_outpost,
@@ -557,6 +575,9 @@
 	},
 /area/strata/ag/interior/outpost/security)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "ne" = (
 /obj/structure/barricade/handrail/strata,
 /obj/item/explosive/mine/clf/active{
@@ -566,8 +587,11 @@
 	icon_state = "floor3"
 	},
 /area/strata/ag/interior/outpost/security)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "nH" = (
 /turf/open/floor/strata{
 	dir = 8;
@@ -580,11 +604,17 @@
 	icon_state = "large"
 	},
 <<<<<<< master
+<<<<<<< master
 /obj/item/explosive/mine/clf/active{
 	dir = 4
 	},
 =======
 >>>>>>> reimported backup
+=======
+/obj/item/explosive/mine/clf/active{
+	dir = 4
+	},
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor/strata{
 	icon_state = "floor3"
 	},
@@ -789,6 +819,9 @@
 /obj/structure/pipes/standard/manifold/hidden/cyan,
 /obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
@@ -799,10 +832,13 @@
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
 /obj/item/explosive/mine/clf,
+<<<<<<< master
 =======
 /obj/item/storage/box/explosive_mines,
 /obj/item/storage/box/explosive_mines,
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor/strata{
 	icon_state = "red1"
 	},
@@ -1189,12 +1225,18 @@
 	},
 /area/strata/ag/interior/outpost/security)
 <<<<<<< master
+<<<<<<< master
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "BG" = (
 /obj/item/explosive/mine/clf/active,
 /turf/open/floor/strata,
 /area/strata/ag/interior/outpost/security)
+<<<<<<< master
 =======
 >>>>>>> reimported backup
+=======
+>>>>>>> updated all maps to have CLF Mines and corpses
 "BZ" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -1395,7 +1437,11 @@
 =======
 /obj/item/stack/rods,
 /obj/item/stack/cable_coil/cut,
+<<<<<<< master
 >>>>>>> reimported backup
+=======
+/obj/item/explosive/mine/clf/active,
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor/strata{
 	dir = 6;
 	icon_state = "multi_tiles"
@@ -1857,11 +1903,17 @@
 	dir = 1
 	},
 <<<<<<< master
+<<<<<<< master
 /obj/item/explosive/mine/clf/active{
 	dir = 4
 	},
 =======
 >>>>>>> reimported backup
+=======
+/obj/item/explosive/mine/clf/active{
+	dir = 4
+	},
+>>>>>>> updated all maps to have CLF Mines and corpses
 /turf/open/floor/strata{
 	icon_state = "floor3"
 	},
@@ -2365,10 +2417,14 @@ cp
 nW
 RT
 <<<<<<< master
+<<<<<<< master
 BG
 =======
 hV
 >>>>>>> reimported backup
+=======
+BG
+>>>>>>> updated all maps to have CLF Mines and corpses
 NE
 "}
 (13,1,1) = {"
@@ -2395,6 +2451,7 @@ ui
 "}
 (14,1,1) = {"
 <<<<<<< master
+<<<<<<< master
 fa
 Sd
 yT
@@ -2403,6 +2460,9 @@ dZ
 im
 =======
 WP
+=======
+fa
+>>>>>>> updated all maps to have CLF Mines and corpses
 Sd
 yT
 PJ
@@ -2416,10 +2476,14 @@ wx
 iT
 yM
 <<<<<<< master
+<<<<<<< master
 ko
 =======
 yT
 >>>>>>> reimported backup
+=======
+ko
+>>>>>>> updated all maps to have CLF Mines and corpses
 yT
 yT
 oc
@@ -2612,10 +2676,14 @@ Ik
 nN
 lx
 <<<<<<< master
+<<<<<<< master
 ne
 =======
 nP
 >>>>>>> reimported backup
+=======
+ne
+>>>>>>> updated all maps to have CLF Mines and corpses
 Ik
 "}
 (24,1,1) = {"

--- a/maps/map_files/Sorokyne_Strata/sprinkles/25.clfsoro.dmm
+++ b/maps/map_files/Sorokyne_Strata/sprinkles/25.clfsoro.dmm
@@ -3,10 +3,7 @@
 /obj/structure/pipes/standard/manifold/hidden/cyan{
 	dir = 4
 	},
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-=======
->>>>>>> reimported backup
 /turf/open/floor/strata{
 	icon_state = "red1"
 	},
@@ -67,10 +64,6 @@
 /obj/structure/pipes/standard/simple/hidden/cyan,
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
-<<<<<<< master
-=======
-/obj/item/stack/rods,
->>>>>>> reimported backup
 /turf/open/floor/strata,
 /area/strata/ag/interior/outpost/security)
 "cQ" = (
@@ -105,10 +98,6 @@
 /area/strata/ag/interior/outpost/engi)
 "dx" = (
 /obj/structure/window_frame/strata,
-<<<<<<< master
-=======
-/obj/item/stack/rods,
->>>>>>> reimported backup
 /obj/item/shard{
 	icon_state = "medium"
 	},
@@ -144,15 +133,12 @@
 	icon_state = "fake_wood"
 	},
 /area/strata/ag/interior/outpost/security)
-<<<<<<< master
 "dZ" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
 /area/strata/ag/interior/outpost/security)
-=======
->>>>>>> reimported backup
 "ek" = (
 /obj/structure/machinery/light/small{
 	dir = 4
@@ -192,10 +178,6 @@
 /area/strata/ag/interior/outpost/engi)
 "eH" = (
 /obj/structure/window_frame/strata,
-<<<<<<< master
-=======
-/obj/item/stack/rods,
->>>>>>> reimported backup
 /obj/item/shard{
 	icon_state = "large"
 	},
@@ -313,10 +295,7 @@
 "hX" = (
 /obj/structure/pipes/standard/simple/hidden/cyan,
 /obj/item/ammo_casing/bullet,
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-=======
->>>>>>> reimported backup
 /turf/open/floor/strata{
 	icon_state = "red1"
 	},
@@ -338,15 +317,12 @@
 	icon_state = "red1"
 	},
 /area/strata/ag/interior/outpost/security)
-<<<<<<< master
 "im" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
 /area/strata/ag/interior/outpost/security)
-=======
->>>>>>> reimported backup
 "ix" = (
 /obj/effect/spawner/random/attachment,
 /turf/open/floor{
@@ -405,7 +381,6 @@
 /area/strata/ag/interior/outpost/security)
 "jQ" = (
 /obj/effect/decal/cleanable/blood/oil,
-<<<<<<< master
 /obj/item/stack/cable_coil/cut,
 /obj/item/explosive/mine/clf/active{
 	dir = 8
@@ -445,10 +420,6 @@
 /obj/item/storage/box/ids,
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/storage/box/ids,
-<<<<<<< master
-=======
-/obj/item/stack/rods,
->>>>>>> reimported backup
 /obj/item/shard{
 	icon_state = "large"
 	},
@@ -492,10 +463,6 @@
 "lO" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
-<<<<<<< master
-=======
-/obj/item/stack/rods,
->>>>>>> reimported backup
 /turf/open/floor/strata{
 	dir = 8;
 	icon_state = "multi_tiles"
@@ -517,10 +484,7 @@
 	},
 /obj/effect/decal/cleanable/blood/drip,
 /obj/item/weapon/melee/twohanded/folded_metal_chair,
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-=======
->>>>>>> reimported backup
 /turf/open/floor/strata{
 	icon_state = "fake_wood"
 	},
@@ -535,10 +499,7 @@
 /obj/structure/machinery/light/small{
 	dir = 4
 	},
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-=======
->>>>>>> reimported backup
 /turf/open/floor/strata{
 	icon_state = "fake_wood"
 	},
@@ -607,10 +568,7 @@
 	dir = 1;
 	pixel_y = 20
 	},
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-=======
->>>>>>> reimported backup
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
@@ -636,10 +594,6 @@
 /area/strata/ag/interior/outpost/security)
 "po" = (
 /obj/structure/window_frame/strata,
-<<<<<<< master
-=======
-/obj/item/stack/rods,
->>>>>>> reimported backup
 /obj/item/shard{
 	icon_state = "large"
 	},
@@ -688,10 +642,7 @@
 /area/strata/ag/interior/outpost/security)
 "qb" = (
 /obj/item/stool,
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-=======
->>>>>>> reimported backup
 /turf/open/floor/strata{
 	dir = 8;
 	icon_state = "white_cyan2"
@@ -758,10 +709,6 @@
 /area/strata/ag/interior/outpost/security)
 "rC" = (
 /obj/structure/window_frame/strata,
-<<<<<<< master
-=======
-/obj/item/stack/rods,
->>>>>>> reimported backup
 /obj/item/shard{
 	icon_state = "medium"
 	},
@@ -847,20 +794,13 @@
 /obj/item/stack/sheet/metal/medium_stack,
 /obj/item/stack/sheet/metal/medium_stack,
 /obj/structure/surface/rack,
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-=======
->>>>>>> reimported backup
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
 /area/strata/ag/interior/outpost/engi)
 "tv" = (
 /obj/structure/window_frame/strata,
-<<<<<<< master
-=======
-/obj/item/stack/rods,
->>>>>>> reimported backup
 /obj/item/shard{
 	icon_state = "large"
 	},
@@ -912,7 +852,6 @@
 	icon_state = "floor3"
 	},
 /area/strata/ag/interior/outpost/security)
-<<<<<<< master
 "uR" = (
 /obj/structure/pipes/standard/simple/hidden/cyan{
 	dir = 4
@@ -922,8 +861,6 @@
 	icon_state = "red1"
 	},
 /area/strata/ag/interior/outpost/security)
-=======
->>>>>>> reimported backup
 "vi" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/reagent_container/food/drinks/cans/souto/grape,
@@ -990,10 +927,7 @@
 	dir = 9
 	},
 /obj/item/ammo_magazine/rifle/type71,
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-=======
->>>>>>> reimported backup
 /turf/open/floor/strata{
 	icon_state = "red1"
 	},
@@ -1067,10 +1001,6 @@
 "yM" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
-<<<<<<< master
-=======
-/obj/item/stack/rods,
->>>>>>> reimported backup
 /turf/open/floor/strata,
 /area/strata/ag/interior/outpost/security)
 "yQ" = (
@@ -1083,7 +1013,6 @@
 	icon_state = "red1"
 	},
 /area/strata/ag/interior/outpost/security)
-<<<<<<< master
 "yR" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor{
@@ -1091,8 +1020,6 @@
 	icon_state = "damaged3"
 	},
 /area/strata/ag/interior/outpost/security)
-=======
->>>>>>> reimported backup
 "yT" = (
 /turf/open/floor/strata{
 	icon_state = "red1"
@@ -1287,7 +1214,6 @@
 	icon_state = "red1"
 	},
 /area/strata/ag/interior/outpost/security)
-<<<<<<< master
 "Fl" = (
 /obj/structure/window_frame/strata,
 /obj/item/shard{
@@ -1298,8 +1224,6 @@
 	icon_state = "multi_tiles"
 	},
 /area/strata/ag/interior/outpost/security)
-=======
->>>>>>> reimported backup
 "FK" = (
 /obj/structure/pipes/standard/simple/hidden/cyan,
 /obj/effect/landmark/corpsespawner/russian,
@@ -1340,10 +1264,6 @@
 /area/strata/ag/interior/outpost/security)
 "Gb" = (
 /obj/structure/window_frame/strata,
-<<<<<<< master
-=======
-/obj/item/stack/rods,
->>>>>>> reimported backup
 /obj/item/shard{
 	icon_state = "large"
 	},
@@ -1389,11 +1309,6 @@
 /area/strata/ag/interior/outpost/security)
 "Gr" = (
 /obj/effect/decal/cleanable/blood/oil,
-<<<<<<< master
-/obj/item/stack/cable_coil/cut,
-/obj/item/explosive/mine/clf/active,
-=======
-/obj/item/stack/rods,
 /obj/item/stack/cable_coil/cut,
 >>>>>>> reimported backup
 /turf/open/floor/strata{
@@ -1416,10 +1331,6 @@
 /area/strata/ag/interior/outpost/security)
 "Gt" = (
 /obj/structure/window_frame/strata,
-<<<<<<< master
-=======
-/obj/item/stack/rods,
->>>>>>> reimported backup
 /turf/open/floor/strata{
 	dir = 6;
 	icon_state = "multi_tiles"
@@ -1443,10 +1354,6 @@
 /area/strata/ag/interior/outpost/security)
 "Hh" = (
 /obj/structure/surface/table/reinforced/prison,
-<<<<<<< master
-=======
-/obj/item/stack/rods,
->>>>>>> reimported backup
 /obj/item/shard{
 	icon_state = "large"
 	},
@@ -1458,10 +1365,7 @@
 /obj/structure/pipes/standard/simple/hidden/cyan{
 	dir = 10
 	},
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-=======
->>>>>>> reimported backup
 /turf/open/floor/strata{
 	icon_state = "red1"
 	},
@@ -1512,10 +1416,7 @@
 "IZ" = (
 /obj/structure/barricade/handrail/strata,
 /obj/item/ammo_casing/bullet,
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-=======
->>>>>>> reimported backup
 /turf/open/floor/strata{
 	icon_state = "red1"
 	},
@@ -1632,15 +1533,12 @@
 /obj/structure/barricade/wooden,
 /turf/open/floor/strata,
 /area/strata/ag/interior/outpost/security)
-<<<<<<< master
 "NU" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/strata{
 	icon_state = "red1"
 	},
 /area/strata/ag/interior/outpost/security)
-=======
->>>>>>> reimported backup
 "OJ" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/stack/rods,
@@ -1661,7 +1559,6 @@
 /area/strata/ag/exterior/paths/north_outpost)
 "Pq" = (
 /obj/structure/window_frame/strata,
-<<<<<<< master
 /turf/open/floor/strata,
 /area/strata/ag/interior/outpost/security)
 "Pv" = (
@@ -1670,11 +1567,6 @@
 	icon_state = "fake_wood"
 	},
 /area/strata/ag/interior/outpost/security)
-=======
-/obj/item/stack/rods,
-/turf/open/floor/strata,
-/area/strata/ag/interior/outpost/security)
->>>>>>> reimported backup
 "PJ" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
@@ -1776,10 +1668,6 @@
 /area/strata/ag/interior/outpost/security)
 "Rt" = (
 /obj/effect/decal/cleanable/blood/oil,
-<<<<<<< master
-=======
-/obj/item/stack/rods,
->>>>>>> reimported backup
 /obj/item/stack/cable_coil/cut,
 /turf/open/floor/strata{
 	dir = 10;
@@ -1871,10 +1759,7 @@
 	dir = 4;
 	icon_state = "metal_1"
 	},
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-=======
->>>>>>> reimported backup
 /turf/open/floor/strata{
 	icon_state = "red1"
 	},
@@ -1907,23 +1792,17 @@
 	icon_state = "metal_1";
 	dir = 1
 	},
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-=======
->>>>>>> reimported backup
 /turf/open/floor/strata{
 	icon_state = "fake_wood"
 	},
 /area/strata/ag/interior/outpost/security)
-<<<<<<< master
 "Ub" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/strata{
 	icon_state = "floor3"
 	},
 /area/strata/ag/interior/outpost/security)
-=======
->>>>>>> reimported backup
 "Uh" = (
 /obj/structure/pipes/standard/simple/hidden/cyan{
 	dir = 4
@@ -1948,13 +1827,10 @@
 	icon_state = "platingdmg3"
 	},
 /area/strata/ag/interior/outpost/security)
-<<<<<<< master
 "Wv" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/strata,
 /area/strata/ag/interior/outpost/security)
-=======
->>>>>>> reimported backup
 "WE" = (
 /obj/structure/bed/chair{
 	dir = 1;
@@ -2013,7 +1889,6 @@
 	icon_state = "multi_tiles"
 	},
 /area/strata/ag/interior/outpost/security)
-<<<<<<< master
 "YG" = (
 /obj/structure/window_frame/strata,
 /obj/item/shard{
@@ -2024,8 +1899,6 @@
 	icon_state = "multi_tiles"
 	},
 /area/strata/ag/interior/outpost/security)
-=======
->>>>>>> reimported backup
 "YN" = (
 /obj/structure/machinery/space_heater,
 /obj/structure/barricade/metal/wired{
@@ -2198,11 +2071,7 @@ Gb
 qa
 rK
 fC
-<<<<<<< master
 NU
-=======
-yT
->>>>>>> reimported backup
 Nr
 ym
 db
@@ -2273,11 +2142,7 @@ Gk
 qn
 xu
 mk
-<<<<<<< master
 Pv
-=======
-uh
->>>>>>> reimported backup
 Ch
 OW
 vP
@@ -2292,11 +2157,7 @@ Gt
 Sd
 Sf
 Gk
-<<<<<<< master
 Pv
-=======
-uh
->>>>>>> reimported backup
 uh
 fr
 uh
@@ -2320,11 +2181,7 @@ lz
 iM
 tX
 OW
-<<<<<<< master
 uR
-=======
-LS
->>>>>>> reimported backup
 hN
 gv
 SF
@@ -2379,11 +2236,7 @@ zV
 DI
 ID
 DI
-<<<<<<< master
 dZ
-=======
-PJ
->>>>>>> reimported backup
 yT
 Zz
 CC
@@ -2401,14 +2254,6 @@ yT
 dZ
 dZ
 im
-=======
-WP
-Sd
-yT
-PJ
-PJ
-DI
->>>>>>> reimported backup
 pq
 ui
 LZ
@@ -2439,24 +2284,14 @@ Yf
 hV
 Uh
 cp
-<<<<<<< master
 YG
 Fl
 YG
-=======
-Qs
-Gh
-Qs
->>>>>>> reimported backup
 cp
 "}
 (16,1,1) = {"
 qR
-<<<<<<< master
 Pv
-=======
-uh
->>>>>>> reimported backup
 zz
 OW
 OW
@@ -2496,15 +2331,9 @@ dL
 sk
 OW
 qS
-<<<<<<< master
 Ub
 Ik
 Ub
-=======
-Ik
-Ik
-Ik
->>>>>>> reimported backup
 OW
 FO
 Hj
@@ -2546,11 +2375,7 @@ od
 yT
 QA
 PJ
-<<<<<<< master
 yR
-=======
-ID
->>>>>>> reimported backup
 FT
 rC
 "}
@@ -2564,11 +2389,7 @@ nH
 Ut
 hV
 Gd
-<<<<<<< master
 Ub
-=======
-Ik
->>>>>>> reimported backup
 hN
 Sp
 mP
@@ -2584,11 +2405,7 @@ qR
 IR
 IB
 Ro
-<<<<<<< master
 Wv
-=======
-hV
->>>>>>> reimported backup
 Jl
 Ik
 cp

--- a/maps/map_files/Sorokyne_Strata/sprinkles/25.clfsoro.dmm
+++ b/maps/map_files/Sorokyne_Strata/sprinkles/25.clfsoro.dmm
@@ -3,6 +3,7 @@
 /obj/structure/pipes/standard/manifold/hidden/cyan{
 	dir = 4
 	},
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/strata{
 	icon_state = "red1"
 	},
@@ -63,7 +64,6 @@
 /obj/structure/pipes/standard/simple/hidden/cyan,
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
-/obj/item/stack/rods,
 /turf/open/floor/strata,
 /area/strata/ag/interior/outpost/security)
 "cQ" = (
@@ -98,7 +98,6 @@
 /area/strata/ag/interior/outpost/engi)
 "dx" = (
 /obj/structure/window_frame/strata,
-/obj/item/stack/rods,
 /obj/item/shard{
 	icon_state = "medium"
 	},
@@ -132,6 +131,12 @@
 /obj/effect/spawner/random/attachment,
 /turf/open/floor/strata{
 	icon_state = "fake_wood"
+	},
+/area/strata/ag/interior/outpost/security)
+"dZ" = (
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
 	},
 /area/strata/ag/interior/outpost/security)
 "ek" = (
@@ -173,7 +178,6 @@
 /area/strata/ag/interior/outpost/engi)
 "eH" = (
 /obj/structure/window_frame/strata,
-/obj/item/stack/rods,
 /obj/item/shard{
 	icon_state = "large"
 	},
@@ -288,6 +292,7 @@
 "hX" = (
 /obj/structure/pipes/standard/simple/hidden/cyan,
 /obj/item/ammo_casing/bullet,
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/strata{
 	icon_state = "red1"
 	},
@@ -307,6 +312,12 @@
 	},
 /turf/open/floor/strata{
 	icon_state = "red1"
+	},
+/area/strata/ag/interior/outpost/security)
+"im" = (
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/turf/open/floor{
+	icon_state = "platingdmg1"
 	},
 /area/strata/ag/interior/outpost/security)
 "ix" = (
@@ -367,7 +378,6 @@
 /area/strata/ag/interior/outpost/security)
 "jQ" = (
 /obj/effect/decal/cleanable/blood/oil,
-/obj/item/stack/rods,
 /obj/item/stack/cable_coil/cut,
 /obj/item/explosive/mine/clf/active{
 	dir = 8
@@ -400,7 +410,6 @@
 /obj/item/storage/box/ids,
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/storage/box/ids,
-/obj/item/stack/rods,
 /obj/item/shard{
 	icon_state = "large"
 	},
@@ -444,7 +453,6 @@
 "lO" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
-/obj/item/stack/rods,
 /turf/open/floor/strata{
 	dir = 8;
 	icon_state = "multi_tiles"
@@ -466,6 +474,7 @@
 	},
 /obj/effect/decal/cleanable/blood/drip,
 /obj/item/weapon/melee/twohanded/folded_metal_chair,
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/strata{
 	icon_state = "fake_wood"
 	},
@@ -480,6 +489,7 @@
 /obj/structure/machinery/light/small{
 	dir = 4
 	},
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/strata{
 	icon_state = "fake_wood"
 	},
@@ -542,6 +552,7 @@
 	dir = 1;
 	pixel_y = 20
 	},
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
@@ -567,7 +578,6 @@
 /area/strata/ag/interior/outpost/security)
 "po" = (
 /obj/structure/window_frame/strata,
-/obj/item/stack/rods,
 /obj/item/shard{
 	icon_state = "large"
 	},
@@ -616,6 +626,7 @@
 /area/strata/ag/interior/outpost/security)
 "qb" = (
 /obj/item/stool,
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/strata{
 	dir = 8;
 	icon_state = "white_cyan2"
@@ -682,7 +693,6 @@
 /area/strata/ag/interior/outpost/security)
 "rC" = (
 /obj/structure/window_frame/strata,
-/obj/item/stack/rods,
 /obj/item/shard{
 	icon_state = "medium"
 	},
@@ -763,13 +773,13 @@
 /obj/item/stack/sheet/metal/medium_stack,
 /obj/item/stack/sheet/metal/medium_stack,
 /obj/structure/surface/rack,
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
 /area/strata/ag/interior/outpost/engi)
 "tv" = (
 /obj/structure/window_frame/strata,
-/obj/item/stack/rods,
 /obj/item/shard{
 	icon_state = "large"
 	},
@@ -819,6 +829,15 @@
 /obj/item/ammo_magazine/rifle/type71,
 /turf/open/floor/strata{
 	icon_state = "floor3"
+	},
+/area/strata/ag/interior/outpost/security)
+"uR" = (
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 4
+	},
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/turf/open/floor/strata{
+	icon_state = "red1"
 	},
 /area/strata/ag/interior/outpost/security)
 "vi" = (
@@ -887,6 +906,7 @@
 	dir = 9
 	},
 /obj/item/ammo_magazine/rifle/type71,
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/strata{
 	icon_state = "red1"
 	},
@@ -960,7 +980,6 @@
 "yM" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
-/obj/item/stack/rods,
 /turf/open/floor/strata,
 /area/strata/ag/interior/outpost/security)
 "yQ" = (
@@ -971,6 +990,13 @@
 /obj/effect/spawner/random/attachment,
 /turf/open/floor/strata{
 	icon_state = "red1"
+	},
+/area/strata/ag/interior/outpost/security)
+"yR" = (
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "damaged3"
 	},
 /area/strata/ag/interior/outpost/security)
 "yT" = (
@@ -1164,6 +1190,16 @@
 	icon_state = "red1"
 	},
 /area/strata/ag/interior/outpost/security)
+"Fl" = (
+/obj/structure/window_frame/strata,
+/obj/item/shard{
+	icon_state = "medium"
+	},
+/turf/open/floor/strata{
+	dir = 8;
+	icon_state = "multi_tiles"
+	},
+/area/strata/ag/interior/outpost/security)
 "FK" = (
 /obj/structure/pipes/standard/simple/hidden/cyan,
 /obj/effect/landmark/corpsespawner/russian,
@@ -1204,7 +1240,6 @@
 /area/strata/ag/interior/outpost/security)
 "Gb" = (
 /obj/structure/window_frame/strata,
-/obj/item/stack/rods,
 /obj/item/shard{
 	icon_state = "large"
 	},
@@ -1250,7 +1285,6 @@
 /area/strata/ag/interior/outpost/security)
 "Gr" = (
 /obj/effect/decal/cleanable/blood/oil,
-/obj/item/stack/rods,
 /obj/item/stack/cable_coil/cut,
 /obj/item/explosive/mine/clf/active,
 /turf/open/floor/strata{
@@ -1273,7 +1307,6 @@
 /area/strata/ag/interior/outpost/security)
 "Gt" = (
 /obj/structure/window_frame/strata,
-/obj/item/stack/rods,
 /turf/open/floor/strata{
 	dir = 6;
 	icon_state = "multi_tiles"
@@ -1297,7 +1330,6 @@
 /area/strata/ag/interior/outpost/security)
 "Hh" = (
 /obj/structure/surface/table/reinforced/prison,
-/obj/item/stack/rods,
 /obj/item/shard{
 	icon_state = "large"
 	},
@@ -1309,6 +1341,7 @@
 /obj/structure/pipes/standard/simple/hidden/cyan{
 	dir = 10
 	},
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/strata{
 	icon_state = "red1"
 	},
@@ -1359,6 +1392,7 @@
 "IZ" = (
 /obj/structure/barricade/handrail/strata,
 /obj/item/ammo_casing/bullet,
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/strata{
 	icon_state = "red1"
 	},
@@ -1475,6 +1509,12 @@
 /obj/structure/barricade/wooden,
 /turf/open/floor/strata,
 /area/strata/ag/interior/outpost/security)
+"NU" = (
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/turf/open/floor/strata{
+	icon_state = "red1"
+	},
+/area/strata/ag/interior/outpost/security)
 "OJ" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/stack/rods,
@@ -1495,8 +1535,13 @@
 /area/strata/ag/exterior/paths/north_outpost)
 "Pq" = (
 /obj/structure/window_frame/strata,
-/obj/item/stack/rods,
 /turf/open/floor/strata,
+/area/strata/ag/interior/outpost/security)
+"Pv" = (
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/turf/open/floor/strata{
+	icon_state = "fake_wood"
+	},
 /area/strata/ag/interior/outpost/security)
 "PJ" = (
 /turf/open/floor/plating{
@@ -1599,7 +1644,6 @@
 /area/strata/ag/interior/outpost/security)
 "Rt" = (
 /obj/effect/decal/cleanable/blood/oil,
-/obj/item/stack/rods,
 /obj/item/stack/cable_coil/cut,
 /turf/open/floor/strata{
 	dir = 10;
@@ -1688,6 +1732,7 @@
 	dir = 4;
 	icon_state = "metal_1"
 	},
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/strata{
 	icon_state = "red1"
 	},
@@ -1720,8 +1765,15 @@
 	icon_state = "metal_1";
 	dir = 1
 	},
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/strata{
 	icon_state = "fake_wood"
+	},
+/area/strata/ag/interior/outpost/security)
+"Ub" = (
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/turf/open/floor/strata{
+	icon_state = "floor3"
 	},
 /area/strata/ag/interior/outpost/security)
 "Uh" = (
@@ -1747,6 +1799,10 @@
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
+/area/strata/ag/interior/outpost/security)
+"Wv" = (
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
+/turf/open/floor/strata,
 /area/strata/ag/interior/outpost/security)
 "WE" = (
 /obj/structure/bed/chair{
@@ -1800,6 +1856,16 @@
 "Yz" = (
 /obj/structure/pipes/standard/simple/hidden/cyan{
 	dir = 4
+	},
+/turf/open/floor/strata{
+	dir = 8;
+	icon_state = "multi_tiles"
+	},
+/area/strata/ag/interior/outpost/security)
+"YG" = (
+/obj/structure/window_frame/strata,
+/obj/item/shard{
+	icon_state = "large"
 	},
 /turf/open/floor/strata{
 	dir = 8;
@@ -1978,7 +2044,7 @@ Gb
 qa
 rK
 fC
-yT
+NU
 Nr
 ym
 db
@@ -2049,7 +2115,7 @@ Gk
 qn
 xu
 mk
-uh
+Pv
 Ch
 OW
 vP
@@ -2064,7 +2130,7 @@ Gt
 Sd
 Sf
 Gk
-uh
+Pv
 uh
 fr
 uh
@@ -2088,7 +2154,7 @@ lz
 iM
 tX
 OW
-LS
+uR
 hN
 gv
 SF
@@ -2139,7 +2205,7 @@ zV
 DI
 ID
 DI
-PJ
+dZ
 yT
 Zz
 CC
@@ -2153,9 +2219,9 @@ ui
 fa
 Sd
 yT
-PJ
-PJ
-DI
+dZ
+dZ
+im
 pq
 ui
 LZ
@@ -2180,14 +2246,14 @@ Yf
 hV
 Uh
 cp
-Qs
-Gh
-Qs
+YG
+Fl
+YG
 cp
 "}
 (16,1,1) = {"
 qR
-uh
+Pv
 zz
 OW
 OW
@@ -2227,9 +2293,9 @@ dL
 sk
 OW
 qS
+Ub
 Ik
-Ik
-Ik
+Ub
 OW
 FO
 Hj
@@ -2271,7 +2337,7 @@ od
 yT
 QA
 PJ
-ID
+yR
 FT
 rC
 "}
@@ -2285,7 +2351,7 @@ nH
 Ut
 hV
 Gd
-Ik
+Ub
 hN
 Sp
 mP
@@ -2301,7 +2367,7 @@ qR
 IR
 IB
 Ro
-hV
+Wv
 Jl
 Ik
 cp

--- a/maps/map_files/Sorokyne_Strata/sprinkles/25.clfsoro.dmm
+++ b/maps/map_files/Sorokyne_Strata/sprinkles/25.clfsoro.dmm
@@ -1,0 +1,2321 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"as" = (
+/obj/structure/pipes/standard/manifold/hidden/cyan{
+	dir = 4
+	},
+/turf/open/floor/strata{
+	icon_state = "red1"
+	},
+/area/strata/ag/interior/outpost/security)
+"at" = (
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 4
+	},
+/obj/structure/bed/chair{
+	dir = 1;
+	tag = "icon-chair (NORTH)"
+	},
+/turf/open/floor/strata{
+	icon_state = "fake_wood"
+	},
+/area/strata/ag/interior/outpost/security)
+"aD" = (
+/obj/structure/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/bed,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/landmark/corpsespawner/russian,
+/turf/open/floor/strata{
+	icon_state = "fake_wood"
+	},
+/area/strata/ag/interior/outpost/security)
+"aJ" = (
+/obj/structure/machinery/space_heater,
+/turf/open/floor/strata{
+	icon_state = "red1"
+	},
+/area/strata/ag/interior/outpost/security)
+"bl" = (
+/obj/item/device/megaphone,
+/obj/structure/surface/table/reinforced/prison,
+/obj/structure/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/strata{
+	icon_state = "red1"
+	},
+/area/strata/ag/interior/outpost/security)
+"cg" = (
+/obj/effect/landmark/corpsespawner/security/cmb,
+/obj/item/weapon/gun/rifle/type71/carbine,
+/obj/item/ammo_casing/bullet,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/strata{
+	icon_state = "red1"
+	},
+/area/strata/ag/interior/outpost/security)
+"cp" = (
+/obj/structure/sign/poster/clf,
+/turf/closed/wall/strata_outpost/reinforced,
+/area/strata/ag/interior/outpost/security)
+"cw" = (
+/obj/structure/pipes/standard/simple/hidden/cyan,
+/obj/effect/decal/cleanable/blood/oil,
+/obj/item/stack/cable_coil/cut,
+/obj/item/stack/rods,
+/turf/open/floor/strata,
+/area/strata/ag/interior/outpost/security)
+"cQ" = (
+/obj/structure/machinery/camera/autoname{
+	dir = 8
+	},
+/obj/structure/bed/chair{
+	dir = 1;
+	tag = "icon-chair (NORTH)"
+	},
+/turf/open/floor/strata{
+	icon_state = "fake_wood"
+	},
+/area/strata/ag/interior/outpost/security)
+"db" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/item/shard{
+	icon_state = "medium"
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/strata/ag/interior/outpost/engi)
+"dp" = (
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/strata{
+	dir = 10;
+	icon_state = "multi_tiles"
+	},
+/area/strata/ag/interior/outpost/engi)
+"dx" = (
+/obj/structure/window_frame/strata,
+/obj/item/stack/rods,
+/obj/item/shard{
+	icon_state = "medium"
+	},
+/turf/open/floor/strata{
+	icon_state = "fake_wood"
+	},
+/area/strata/ag/interior/outpost/security)
+"dF" = (
+/obj/structure/machinery/weather_siren{
+	dir = 1;
+	pixel_y = 28
+	},
+/obj/structure/sign/poster/clf,
+/turf/closed/wall/strata_outpost/reinforced,
+/area/strata/ag/interior/outpost/security)
+"dG" = (
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1"
+	},
+/obj/structure/machinery/m56d_hmg,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/strata/ag/interior/outpost/security)
+"dL" = (
+/obj/item/ammo_casing/bullet,
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1";
+	dir = 1
+	},
+/obj/effect/spawner/random/attachment,
+/turf/open/floor/strata{
+	icon_state = "fake_wood"
+	},
+/area/strata/ag/interior/outpost/security)
+"ek" = (
+/obj/structure/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/strata,
+/area/strata/ag/interior/outpost/security)
+"el" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/structure/machinery/computer/security{
+	dir = 1
+	},
+/obj/item/stack/rods,
+/obj/item/shard{
+	icon_state = "medium"
+	},
+/turf/open/floor/strata{
+	dir = 6;
+	icon_state = "multi_tiles"
+	},
+/area/strata/ag/interior/outpost/security)
+"eA" = (
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1"
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/strata/ag/interior/outpost/security)
+"eB" = (
+/obj/item/shard{
+	icon_state = "medium"
+	},
+/turf/open/floor{
+	dir = 8;
+	icon_state = "damaged3"
+	},
+/area/strata/ag/interior/outpost/engi)
+"eH" = (
+/obj/structure/window_frame/strata,
+/obj/item/stack/rods,
+/obj/item/shard{
+	icon_state = "large"
+	},
+/turf/open/floor/strata{
+	icon_state = "fake_wood"
+	},
+/area/strata/ag/interior/outpost/security)
+"eN" = (
+/turf/open/auto_turf/snow/brown_base/layer4,
+/area/strata/ag/exterior/paths/north_outpost)
+"fr" = (
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/strata{
+	icon_state = "fake_wood"
+	},
+/area/strata/ag/interior/outpost/security)
+"fs" = (
+/turf/open/auto_turf/snow/brown_base/layer2,
+/area/strata/ag/exterior/paths/north_outpost)
+"fC" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/turf/open/floor/strata{
+	icon_state = "fake_wood"
+	},
+/area/strata/ag/interior/outpost/security)
+"gb" = (
+/obj/structure/machinery/light/small,
+/turf/open/auto_turf/snow/brown_base/layer0,
+/area/strata/ag/exterior/paths/north_outpost)
+"gv" = (
+/obj/structure/barricade/metal/wired{
+	dir = 4;
+	icon_state = "metal_1"
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/strata/ag/interior/outpost/security)
+"gx" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/strata,
+/area/strata/ag/interior/outpost/security)
+"gz" = (
+/obj/structure/flora/pottedplant{
+	icon_state = "pottedplant_22";
+	tag = "icon-pottedplant_10"
+	},
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1"
+	},
+/turf/open/floor/strata{
+	icon_state = "red1"
+	},
+/area/strata/ag/interior/outpost/security)
+"hq" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/structure/machinery/light/small{
+	dir = 1;
+	pixel_y = 20
+	},
+/obj/structure/barricade/metal/wired{
+	dir = 8;
+	icon_state = "metal_1"
+	},
+/turf/open/floor/strata{
+	icon_state = "red1"
+	},
+/area/strata/ag/interior/outpost/security)
+"hA" = (
+/obj/structure/surface/rack,
+/obj/item/weapon/gun/shotgun/pump/cmb{
+	pixel_y = -3
+	},
+/obj/item/weapon/gun/shotgun/pump/cmb{
+	pixel_y = 3
+	},
+/obj/item/weapon/gun/shotgun/pump/cmb{
+	pixel_y = 9
+	},
+/turf/open/floor/strata{
+	icon_state = "red1"
+	},
+/area/strata/ag/interior/outpost/security)
+"hN" = (
+/obj/structure/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/strata{
+	icon_state = "red1"
+	},
+/area/strata/ag/interior/outpost/security)
+"hV" = (
+/turf/open/floor/strata,
+/area/strata/ag/interior/outpost/security)
+"hX" = (
+/obj/structure/pipes/standard/simple/hidden/cyan,
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/strata{
+	icon_state = "red1"
+	},
+/area/strata/ag/interior/outpost/security)
+"ia" = (
+/obj/structure/barricade/plasteel/wired{
+	icon_state = "plasteel_3"
+	},
+/turf/open/floor/strata{
+	dir = 10;
+	icon_state = "multi_tiles"
+	},
+/area/strata/ag/interior/outpost/engi)
+"id" = (
+/obj/structure/bed/chair/office/light{
+	dir = 1
+	},
+/turf/open/floor/strata{
+	icon_state = "red1"
+	},
+/area/strata/ag/interior/outpost/security)
+"ix" = (
+/obj/effect/spawner/random/attachment,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "damaged3"
+	},
+/area/strata/ag/interior/outpost/security)
+"iM" = (
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/strata{
+	icon_state = "fake_wood"
+	},
+/area/strata/ag/interior/outpost/security)
+"iT" = (
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 4
+	},
+/obj/structure/barricade/plasteel/wired{
+	icon_state = "plasteel_3"
+	},
+/turf/open/floor/strata{
+	icon_state = "red1"
+	},
+/area/strata/ag/interior/outpost/security)
+"jl" = (
+/obj/structure/bed/chair/office/light,
+/obj/effect/landmark/corpsespawner/security/cmb,
+/obj/item/weapon/gun/rifle/type71/carbine,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/strata{
+	icon_state = "floor3"
+	},
+/area/strata/ag/interior/outpost/security)
+"jr" = (
+/obj/structure/closet/secure_closet/security,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/strata/ag/interior/outpost/security)
+"jG" = (
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/strata/ag/interior/outpost/security)
+"jL" = (
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 4
+	},
+/obj/structure/machinery/cm_vending/sorted/medical/no_access,
+/turf/open/floor/strata{
+	icon_state = "fake_wood"
+	},
+/area/strata/ag/interior/outpost/security)
+"jQ" = (
+/obj/effect/decal/cleanable/blood/oil,
+/obj/item/stack/rods,
+/obj/item/stack/cable_coil/cut,
+/turf/open/floor/strata{
+	dir = 10;
+	icon_state = "multi_tiles"
+	},
+/area/strata/ag/interior/outpost/security)
+"kd" = (
+/obj/effect/decal/cleanable/blood/oil,
+/obj/item/stack/rods,
+/obj/item/stack/cable_coil/cut,
+/turf/open/floor/strata{
+	dir = 8;
+	icon_state = "multi_tiles"
+	},
+/area/strata/ag/interior/outpost/security)
+"kA" = (
+/obj/structure/machinery/cm_vending/sorted/medical/wall_med,
+/turf/closed/wall/strata_outpost,
+/area/strata/ag/interior/outpost/engi)
+"lo" = (
+/obj/item/storage/box/ids,
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/storage/box/ids,
+/obj/item/stack/rods,
+/obj/item/shard{
+	icon_state = "large"
+	},
+/turf/open/floor/strata{
+	icon_state = "red1"
+	},
+/area/strata/ag/interior/outpost/security)
+"lt" = (
+/obj/structure/flora/pottedplant{
+	icon_state = "pottedplant_10";
+	tag = "icon-pottedplant_10"
+	},
+/obj/structure/barricade/handrail/strata{
+	dir = 8
+	},
+/obj/structure/barricade/handrail/strata{
+	dir = 4
+	},
+/turf/open/floor/strata{
+	icon_state = "red1"
+	},
+/area/strata/ag/interior/outpost/security)
+"lx" = (
+/obj/item/shard{
+	icon_state = "large"
+	},
+/turf/open/floor/strata{
+	icon_state = "floor3"
+	},
+/area/strata/ag/interior/outpost/security)
+"lz" = (
+/obj/structure/pipes/standard/manifold/hidden/cyan,
+/obj/structure/bed/chair{
+	dir = 1;
+	tag = "icon-chair (NORTH)"
+	},
+/turf/open/floor/strata{
+	icon_state = "fake_wood"
+	},
+/area/strata/ag/interior/outpost/security)
+"lO" = (
+/obj/effect/decal/cleanable/blood/oil,
+/obj/item/stack/cable_coil/cut,
+/obj/item/stack/rods,
+/turf/open/floor/strata{
+	dir = 8;
+	icon_state = "multi_tiles"
+	},
+/area/strata/ag/interior/outpost/security)
+"lY" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/spawner/random/attachment,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/strata/ag/interior/outpost/engi)
+"mk" = (
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/drip,
+/obj/item/weapon/melee/twohanded/folded_metal_chair,
+/turf/open/floor/strata{
+	icon_state = "fake_wood"
+	},
+/area/strata/ag/interior/outpost/security)
+"mv" = (
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 4
+	},
+/turf/closed/wall/strata_outpost/reinforced,
+/area/strata/ag/interior/outpost/security)
+"mw" = (
+/obj/structure/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/strata{
+	icon_state = "fake_wood"
+	},
+/area/strata/ag/interior/outpost/security)
+"mP" = (
+/obj/effect/landmark/corpsespawner/russian,
+/obj/structure/barricade/metal/wired{
+	dir = 4;
+	icon_state = "metal_1"
+	},
+/obj/item/weapon/gun/rifle/type71/carbine,
+/obj/effect/decal/cleanable/blood,
+/obj/item/ammo_magazine/rifle/type71,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/strata/ag/interior/outpost/security)
+"nH" = (
+/turf/open/floor/strata{
+	dir = 8;
+	icon_state = "white_cyan2"
+	},
+/area/strata/ag/interior/outpost/security)
+"nN" = (
+/obj/structure/barricade/handrail/strata,
+/obj/item/shard{
+	icon_state = "large"
+	},
+/turf/open/floor/strata{
+	icon_state = "floor3"
+	},
+/area/strata/ag/interior/outpost/security)
+"nP" = (
+/obj/structure/barricade/handrail/strata,
+/turf/open/floor/strata{
+	icon_state = "floor3"
+	},
+/area/strata/ag/interior/outpost/security)
+"nW" = (
+/obj/structure/machinery/light/small{
+	dir = 1;
+	pixel_y = 20
+	},
+/turf/open/floor/strata,
+/area/strata/ag/interior/outpost/security)
+"nX" = (
+/obj/structure/machinery/light/small{
+	dir = 1;
+	pixel_y = 20
+	},
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/strata/ag/interior/outpost/engi)
+"oc" = (
+/obj/structure/barricade/wooden,
+/turf/open/floor/strata{
+	icon_state = "red1"
+	},
+/area/strata/ag/interior/outpost/security)
+"od" = (
+/obj/structure/flora/pottedplant{
+	icon_state = "pottedplant_22";
+	tag = "icon-pottedplant_10"
+	},
+/obj/structure/machinery/light/small{
+	dir = 1;
+	pixel_y = 20
+	},
+/turf/open/floor/strata{
+	icon_state = "floor3"
+	},
+/area/strata/ag/interior/outpost/security)
+"po" = (
+/obj/structure/window_frame/strata,
+/obj/item/stack/rods,
+/obj/item/shard{
+	icon_state = "large"
+	},
+/turf/open/floor/strata{
+	icon_state = "red1"
+	},
+/area/strata/ag/interior/outpost/security)
+"pq" = (
+/obj/effect/landmark/corpsespawner/doctor,
+/obj/item/weapon/gun/rifle/type71/carbine,
+/obj/item/ammo_magazine/rifle/type71,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/strata/ag/interior/outpost/security)
+"pz" = (
+/obj/structure/surface/table/reinforced/prison,
+/turf/open/floor/strata{
+	icon_state = "floor3"
+	},
+/area/strata/ag/interior/outpost/security)
+"pT" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/attachable/heavy_barrel,
+/obj/item/attachable/verticalgrip,
+/obj/item/attachable/verticalgrip,
+/obj/item/attachable/attached_gun/flamer,
+/obj/item/attachable/bayonet,
+/obj/item/attachable/bayonet,
+/obj/item/clothing/accessory/storage/webbing,
+/obj/item/clothing/accessory/storage/webbing,
+/obj/item/storage/belt/marine,
+/obj/item/storage/belt/marine,
+/obj/item/storage/belt/marine,
+/turf/open/floor/strata{
+	icon_state = "red1"
+	},
+/area/strata/ag/interior/outpost/security)
+"qa" = (
+/obj/structure/pipes/vents/pump,
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/strata{
+	icon_state = "floor3"
+	},
+/area/strata/ag/interior/outpost/security)
+"qb" = (
+/obj/item/stool,
+/turf/open/floor/strata{
+	dir = 8;
+	icon_state = "white_cyan2"
+	},
+/area/strata/ag/interior/outpost/security)
+"qc" = (
+/obj/item/stack/rods,
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/strata/ag/interior/outpost/engi)
+"qj" = (
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/strata/ag/interior/outpost/engi)
+"qn" = (
+/obj/item/weapon/melee/twohanded/folded_metal_chair,
+/obj/effect/spawner/random/attachment,
+/turf/open/floor/strata{
+	icon_state = "fake_wood"
+	},
+/area/strata/ag/interior/outpost/security)
+"qo" = (
+/obj/structure/barricade/metal/wired{
+	dir = 4;
+	icon_state = "metal_1"
+	},
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1"
+	},
+/obj/item/ammo_magazine/m56d,
+/turf/open/floor/strata{
+	icon_state = "red1"
+	},
+/area/strata/ag/interior/outpost/security)
+"qR" = (
+/obj/structure/machinery/weather_siren{
+	dir = 1;
+	pixel_y = 28
+	},
+/turf/closed/wall/strata_outpost/reinforced,
+/area/strata/ag/interior/outpost/security)
+"qS" = (
+/obj/structure/surface/rack,
+/obj/item/weapon/gun/smg/fp9000,
+/obj/item/weapon/gun/smg/fp9000,
+/obj/item/weapon/gun/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000,
+/turf/open/floor/strata{
+	icon_state = "floor3"
+	},
+/area/strata/ag/interior/outpost/security)
+"rC" = (
+/obj/structure/window_frame/strata,
+/obj/item/stack/rods,
+/obj/item/shard{
+	icon_state = "medium"
+	},
+/turf/open/floor/strata{
+	dir = 6;
+	icon_state = "multi_tiles"
+	},
+/area/strata/ag/interior/outpost/security)
+"rE" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/paper_bin,
+/turf/open/floor/strata{
+	dir = 6;
+	icon_state = "multi_tiles"
+	},
+/area/strata/ag/interior/outpost/security)
+"rK" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/phone{
+	pixel_x = 8;
+	pixel_y = 6
+	},
+/obj/item/tool/stamp,
+/obj/item/paper_bin,
+/obj/structure/pipes/standard/manifold/hidden/cyan,
+/obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
+/obj/item/storage/box/explosive_mines,
+/obj/item/storage/box/explosive_mines,
+/turf/open/floor/strata{
+	icon_state = "red1"
+	},
+/area/strata/ag/interior/outpost/security)
+"sh" = (
+/obj/effect/decal/cleanable/blood/oil,
+/obj/item/stack/rods,
+/obj/item/stack/cable_coil/cut,
+/turf/open/floor/strata{
+	dir = 8;
+	icon_state = "multi_tiles"
+	},
+/area/strata/ag/interior/outpost/engi)
+"sj" = (
+/obj/effect/landmark/corpsespawner/security/cmb,
+/obj/item/weapon/gun/rifle/type71/carbine,
+/obj/effect/decal/cleanable/blood,
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/strata{
+	dir = 10;
+	icon_state = "multi_tiles"
+	},
+/area/strata/ag/interior/outpost/engi)
+"sk" = (
+/obj/structure/bed/chair{
+	dir = 1;
+	tag = "icon-chair (NORTH)"
+	},
+/turf/open/floor/strata{
+	icon_state = "fake_wood"
+	},
+/area/strata/ag/interior/outpost/security)
+"sL" = (
+/obj/structure/machinery/camera/autoname{
+	dir = 8
+	},
+/turf/open/floor/strata,
+/area/strata/ag/interior/outpost/security)
+"tt" = (
+/obj/item/stack/sheet/plasteel/medium_stack,
+/obj/item/stack/sheet/plasteel/medium_stack,
+/obj/item/stack/sheet/metal/medium_stack,
+/obj/item/stack/sheet/metal/medium_stack,
+/obj/structure/surface/rack,
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/strata/ag/interior/outpost/engi)
+"tv" = (
+/obj/structure/window_frame/strata,
+/obj/item/stack/rods,
+/obj/item/shard{
+	icon_state = "large"
+	},
+/obj/item/shard{
+	icon_state = "medium"
+	},
+/turf/open/floor/strata{
+	icon_state = "fake_wood"
+	},
+/area/strata/ag/interior/outpost/security)
+"tB" = (
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/strata{
+	icon_state = "fake_wood"
+	},
+/area/strata/ag/interior/outpost/security)
+"tX" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/tool/stamp,
+/obj/item/device/flashlight/lamp/green,
+/turf/open/floor/strata{
+	dir = 6;
+	icon_state = "multi_tiles"
+	},
+/area/strata/ag/interior/outpost/security)
+"uh" = (
+/turf/open/floor/strata{
+	icon_state = "fake_wood"
+	},
+/area/strata/ag/interior/outpost/security)
+"ui" = (
+/obj/structure/pipes/standard/simple/hidden/cyan,
+/turf/open/floor/strata{
+	icon_state = "red1"
+	},
+/area/strata/ag/interior/outpost/security)
+"ux" = (
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/strata/ag/interior/outpost/engi)
+"uO" = (
+/obj/effect/landmark/corpsespawner/russian,
+/obj/effect/decal/cleanable/blood,
+/obj/item/ammo_casing/bullet,
+/obj/item/weapon/gun/rifle/type71/carbine,
+/obj/item/ammo_magazine/rifle/type71,
+/turf/open/floor/strata{
+	icon_state = "floor3"
+	},
+/area/strata/ag/interior/outpost/security)
+"vi" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/reagent_container/food/drinks/cans/souto/grape,
+/turf/open/floor/strata{
+	icon_state = "floor3"
+	},
+/area/strata/ag/interior/outpost/security)
+"vJ" = (
+/obj/structure/barricade/plasteel/wired{
+	icon_state = "plasteel_3";
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/strata{
+	icon_state = "fake_wood"
+	},
+/area/strata/ag/interior/outpost/security)
+"vP" = (
+/obj/structure/pipes/vents/pump{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/strata/ag/interior/outpost/security)
+"vW" = (
+/obj/structure/surface/rack,
+/obj/structure/barricade/metal/wired{
+	dir = 8;
+	icon_state = "metal_1"
+	},
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1"
+	},
+/turf/open/floor/strata{
+	icon_state = "red1"
+	},
+/area/strata/ag/interior/outpost/security)
+"we" = (
+/turf/closed/wall/strata_outpost/reinforced,
+/area/strata/ag/interior/outpost/canteen/lower_cafeteria)
+"wr" = (
+/obj/structure/pipes/standard/simple/hidden/cyan,
+/obj/structure/machinery/power/apc{
+	dir = 8;
+	pixel_x = -24;
+	start_charge = 0
+	},
+/turf/open/floor/strata{
+	icon_state = "red1"
+	},
+/area/strata/ag/interior/outpost/security)
+"wu" = (
+/obj/structure/barricade/handrail/strata,
+/obj/structure/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/strata{
+	icon_state = "floor3"
+	},
+/area/strata/ag/interior/outpost/security)
+"wx" = (
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 9
+	},
+/obj/item/ammo_magazine/rifle/type71,
+/turf/open/floor/strata{
+	icon_state = "red1"
+	},
+/area/strata/ag/interior/outpost/security)
+"wW" = (
+/turf/closed/wall/strata_outpost/reinforced,
+/area/strata/ag/exterior/paths/north_outpost)
+"wY" = (
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 4
+	},
+/obj/effect/spawner/random/attachment,
+/turf/open/floor/strata{
+	dir = 8;
+	icon_state = "multi_tiles"
+	},
+/area/strata/ag/interior/outpost/security)
+"xn" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/device/flashlight/lamp/green,
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 4
+	},
+/turf/open/floor/strata{
+	icon_state = "red1"
+	},
+/area/strata/ag/interior/outpost/security)
+"xu" = (
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/landmark/corpsespawner/doctor,
+/turf/open/floor/strata{
+	icon_state = "fake_wood"
+	},
+/area/strata/ag/interior/outpost/security)
+"xM" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/structure/machinery/computer/secure_data{
+	dir = 8
+	},
+/turf/open/floor/strata,
+/area/strata/ag/interior/outpost/security)
+"xU" = (
+/obj/item/fuelCell,
+/obj/structure/barricade/handrail/strata{
+	dir = 4
+	},
+/obj/structure/platform/strata/metal{
+	dir = 8
+	},
+/turf/open/floor/strata{
+	icon_state = "red2"
+	},
+/area/strata/ag/interior/outpost/engi)
+"ym" = (
+/turf/closed/wall/strata_outpost/reinforced,
+/area/strata/ag/interior/outpost/engi)
+"yu" = (
+/obj/effect/decal/cleanable/blood/drip,
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/strata{
+	dir = 10;
+	icon_state = "multi_tiles"
+	},
+/area/strata/ag/interior/outpost/engi)
+"yw" = (
+/obj/structure/girder,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/strata/ag/interior/outpost/engi)
+"yM" = (
+/obj/effect/decal/cleanable/blood/oil,
+/obj/item/stack/cable_coil/cut,
+/obj/item/stack/rods,
+/turf/open/floor/strata,
+/area/strata/ag/interior/outpost/security)
+"yQ" = (
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 4
+	},
+/obj/item/ammo_casing/bullet,
+/obj/effect/spawner/random/attachment,
+/turf/open/floor/strata{
+	icon_state = "red1"
+	},
+/area/strata/ag/interior/outpost/security)
+"yT" = (
+/turf/open/floor/strata{
+	icon_state = "red1"
+	},
+/area/strata/ag/interior/outpost/security)
+"zt" = (
+/obj/structure/pipes/vents/pump{
+	dir = 1
+	},
+/turf/open/floor/strata{
+	icon_state = "red1"
+	},
+/area/strata/ag/interior/outpost/security)
+"zz" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/structure/machinery/microwave,
+/turf/open/floor/strata{
+	icon_state = "fake_wood"
+	},
+/area/strata/ag/interior/outpost/security)
+"zG" = (
+/obj/item/ammo_magazine/rifle/type71,
+/turf/open/floor/strata{
+	icon_state = "fake_wood"
+	},
+/area/strata/ag/interior/outpost/security)
+"zL" = (
+/obj/structure/sign/poster/clf,
+/turf/closed/wall/strata_outpost,
+/area/strata/ag/interior/outpost/engi)
+"zQ" = (
+/obj/structure/pipes/standard/simple/hidden/cyan,
+/obj/effect/spawner/random/attachment,
+/turf/open/floor/strata{
+	icon_state = "red1"
+	},
+/area/strata/ag/interior/outpost/security)
+"zV" = (
+/obj/structure/pipes/vents/pump{
+	dir = 4
+	},
+/turf/open/floor/strata{
+	icon_state = "red1"
+	},
+/area/strata/ag/interior/outpost/security)
+"Al" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/structure/barricade/metal/wired{
+	dir = 8;
+	icon_state = "metal_1"
+	},
+/turf/open/floor/strata{
+	icon_state = "red1"
+	},
+/area/strata/ag/interior/outpost/security)
+"Aq" = (
+/obj/structure/flora/pottedplant{
+	icon_state = "pottedplant_22";
+	tag = "icon-pottedplant_10"
+	},
+/turf/open/floor/strata{
+	dir = 6;
+	icon_state = "multi_tiles"
+	},
+/area/strata/ag/interior/outpost/security)
+"Au" = (
+/obj/structure/barricade/plasteel/wired{
+	icon_state = "plasteel_3";
+	dir = 8
+	},
+/turf/open/floor/strata{
+	icon_state = "floor3"
+	},
+/area/strata/ag/interior/outpost/security)
+"AV" = (
+/obj/structure/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/barricade/plasteel/wired{
+	icon_state = "plasteel_3"
+	},
+/turf/open/floor/strata{
+	icon_state = "floor3"
+	},
+/area/strata/ag/interior/outpost/security)
+"AY" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/structure/machinery/faxmachine,
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 4
+	},
+/turf/open/floor/strata{
+	icon_state = "red1"
+	},
+/area/strata/ag/interior/outpost/security)
+"BZ" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/turf/open/floor/strata,
+/area/strata/ag/interior/outpost/security)
+"Ch" = (
+/obj/structure/bookcase{
+	icon_state = "book-5"
+	},
+/turf/open/floor/strata{
+	dir = 6;
+	icon_state = "multi_tiles"
+	},
+/area/strata/ag/interior/outpost/security)
+"Ci" = (
+/obj/structure/machinery/vending/coffee,
+/turf/open/floor/strata{
+	icon_state = "fake_wood"
+	},
+/area/strata/ag/interior/outpost/security)
+"Cj" = (
+/obj/structure/closet/secure_closet/personal,
+/turf/open/floor/strata{
+	icon_state = "floor3"
+	},
+/area/strata/ag/interior/outpost/canteen/lower_cafeteria)
+"CC" = (
+/obj/structure/pipes/standard/manifold/fourway/hidden/cyan,
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1"
+	},
+/turf/open/floor/strata{
+	icon_state = "red1"
+	},
+/area/strata/ag/interior/outpost/security)
+"Dg" = (
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/strata/ag/interior/outpost/security)
+"DI" = (
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/strata/ag/interior/outpost/security)
+"Eh" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/paper_bin,
+/obj/structure/barricade/handrail/strata,
+/turf/open/floor/strata{
+	icon_state = "red1"
+	},
+/area/strata/ag/interior/outpost/security)
+"Ei" = (
+/obj/structure/surface/rack,
+/obj/item/ammo_magazine/rifle/mar40,
+/obj/item/ammo_magazine/rifle/mar40,
+/obj/item/ammo_magazine/rifle/mar40,
+/obj/item/ammo_magazine/rifle/mar40,
+/obj/item/ammo_magazine/rifle/mar40,
+/obj/item/weapon/gun/rifle/mar40{
+	pixel_y = 6
+	},
+/obj/item/ammo_magazine/rifle/mar40/lmg,
+/obj/item/weapon/gun/rifle/mar40/lmg,
+/obj/item/ammo_magazine/rifle/mar40/lmg,
+/obj/item/ammo_magazine/rifle/mar40/lmg,
+/obj/item/ammo_magazine/rifle/mar40/lmg,
+/obj/item/ammo_magazine/rifle/mar40/lmg,
+/turf/open/floor/strata{
+	icon_state = "red1"
+	},
+/area/strata/ag/interior/outpost/security)
+"Ev" = (
+/obj/structure/bed/chair/office/light,
+/turf/open/floor/strata{
+	icon_state = "floor3"
+	},
+/area/strata/ag/interior/outpost/security)
+"EV" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/phone{
+	pixel_x = 8;
+	pixel_y = 6
+	},
+/obj/structure/barricade/handrail/strata,
+/turf/open/floor/strata{
+	icon_state = "red1"
+	},
+/area/strata/ag/interior/outpost/security)
+"FK" = (
+/obj/structure/pipes/standard/simple/hidden/cyan,
+/obj/effect/landmark/corpsespawner/russian,
+/obj/item/weapon/gun/rifle/type71/carbine,
+/obj/effect/decal/cleanable/blood,
+/obj/item/ammo_magazine/rifle/type71,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/strata/ag/interior/outpost/security)
+"FO" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/device/flashlight/lamp,
+/obj/structure/machinery/light/small{
+	dir = 1;
+	pixel_y = 20
+	},
+/turf/open/floor/strata{
+	icon_state = "floor3"
+	},
+/area/strata/ag/interior/outpost/security)
+"FT" = (
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1"
+	},
+/obj/structure/machinery/m56d_hmg,
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/strata/ag/interior/outpost/security)
+"FX" = (
+/obj/structure/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/strata{
+	icon_state = "floor3"
+	},
+/area/strata/ag/interior/outpost/security)
+"Gb" = (
+/obj/structure/window_frame/strata,
+/obj/item/stack/rods,
+/obj/item/shard{
+	icon_state = "large"
+	},
+/turf/open/floor/strata{
+	dir = 6;
+	icon_state = "multi_tiles"
+	},
+/area/strata/ag/interior/outpost/security)
+"Gd" = (
+/obj/structure/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/strata,
+/area/strata/ag/interior/outpost/security)
+"Gf" = (
+/obj/structure/barricade/metal/wired{
+	dir = 4;
+	icon_state = "metal_1"
+	},
+/obj/item/ammo_casing/bullet,
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/strata/ag/interior/outpost/security)
+"Gh" = (
+/obj/structure/window_frame/strata,
+/obj/item/stack/rods,
+/obj/item/shard{
+	icon_state = "medium"
+	},
+/turf/open/floor/strata{
+	dir = 8;
+	icon_state = "multi_tiles"
+	},
+/area/strata/ag/interior/outpost/security)
+"Gk" = (
+/obj/structure/platform/strata/metal{
+	dir = 1
+	},
+/turf/open/floor/strata{
+	icon_state = "fake_wood"
+	},
+/area/strata/ag/interior/outpost/security)
+"Gr" = (
+/obj/effect/decal/cleanable/blood/oil,
+/obj/item/stack/rods,
+/obj/item/stack/cable_coil/cut,
+/turf/open/floor/strata{
+	dir = 6;
+	icon_state = "multi_tiles"
+	},
+/area/strata/ag/interior/outpost/engi)
+"Gs" = (
+/obj/effect/landmark/corpsespawner/russian,
+/obj/item/weapon/gun/rifle/type71/carbine,
+/obj/effect/decal/cleanable/blood,
+/obj/item/ammo_casing/bullet,
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1";
+	dir = 1
+	},
+/turf/open/floor/strata{
+	icon_state = "red1"
+	},
+/area/strata/ag/interior/outpost/security)
+"Gt" = (
+/obj/structure/window_frame/strata,
+/obj/item/stack/rods,
+/turf/open/floor/strata{
+	dir = 6;
+	icon_state = "multi_tiles"
+	},
+/area/strata/ag/interior/outpost/security)
+"Gx" = (
+/obj/structure/machinery/vending/snack,
+/turf/open/floor/strata{
+	icon_state = "fake_wood"
+	},
+/area/strata/ag/interior/outpost/security)
+"GN" = (
+/obj/effect/landmark/corpsespawner/russian,
+/obj/item/ammo_casing/bullet,
+/obj/item/weapon/gun/rifle/type71/carbine,
+/obj/effect/decal/cleanable/blood,
+/obj/item/ammo_magazine/rifle/type71,
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/strata/ag/interior/outpost/security)
+"Hh" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/stack/rods,
+/obj/item/shard{
+	icon_state = "large"
+	},
+/turf/open/floor/strata{
+	icon_state = "red1"
+	},
+/area/strata/ag/interior/outpost/security)
+"Hj" = (
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 10
+	},
+/turf/open/floor/strata{
+	icon_state = "red1"
+	},
+/area/strata/ag/interior/outpost/security)
+"Ik" = (
+/turf/open/floor/strata{
+	icon_state = "floor3"
+	},
+/area/strata/ag/interior/outpost/security)
+"In" = (
+/obj/structure/window/framed/strata/reinforced,
+/turf/open/floor/strata{
+	dir = 6;
+	icon_state = "multi_tiles"
+	},
+/area/strata/ag/interior/outpost/canteen/lower_cafeteria)
+"IB" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/turf/open/floor/strata{
+	dir = 8;
+	icon_state = "white_cyan2"
+	},
+/area/strata/ag/interior/outpost/security)
+"ID" = (
+/turf/open/floor{
+	dir = 8;
+	icon_state = "damaged3"
+	},
+/area/strata/ag/interior/outpost/security)
+"IR" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/effect/landmark/corpsespawner/russian,
+/obj/item/ammo_casing/bullet,
+/obj/item/weapon/gun/pistol/c99/upp,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/spawner/random/attachment,
+/turf/open/floor/strata{
+	dir = 8;
+	icon_state = "white_cyan2"
+	},
+/area/strata/ag/interior/outpost/security)
+"IZ" = (
+/obj/structure/barricade/handrail/strata,
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/strata{
+	icon_state = "red1"
+	},
+/area/strata/ag/interior/outpost/security)
+"Jj" = (
+/turf/closed/wall/strata_outpost,
+/area/strata/ag/interior/outpost/canteen/lower_cafeteria)
+"Jl" = (
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/strata,
+/area/strata/ag/interior/outpost/security)
+"Jy" = (
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 4
+	},
+/turf/open/floor/strata{
+	icon_state = "floor3"
+	},
+/area/strata/ag/interior/outpost/security)
+"Kg" = (
+/turf/closed/wall/strata_outpost/reinforced/hull,
+/area/strata/ag/interior/outpost/security)
+"Kl" = (
+/obj/structure/machinery/light/small{
+	dir = 8
+	},
+/turf/open/auto_turf/snow/brown_base/layer0,
+/area/strata/ag/exterior/paths/north_outpost)
+"Ky" = (
+/turf/open/auto_turf/snow/brown_base/layer0,
+/area/strata/ag/exterior/paths/north_outpost)
+"Ll" = (
+/obj/structure/machinery/light/small{
+	dir = 4
+	},
+/turf/open/auto_turf/snow/brown_base/layer3,
+/area/strata/ag/exterior/paths/north_outpost)
+"Lx" = (
+/obj/structure/machinery/camera/autoname{
+	dir = 4
+	},
+/turf/open/floor/strata{
+	icon_state = "red1"
+	},
+/area/strata/ag/interior/outpost/security)
+"LF" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/structure/machinery/computer/security{
+	dir = 1
+	},
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 4
+	},
+/turf/open/floor/strata{
+	icon_state = "red1"
+	},
+/area/strata/ag/interior/outpost/security)
+"LQ" = (
+/obj/structure/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/strata/ag/interior/outpost/security)
+"LS" = (
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 4
+	},
+/turf/open/floor/strata{
+	icon_state = "red1"
+	},
+/area/strata/ag/interior/outpost/security)
+"LZ" = (
+/obj/structure/pipes/standard/manifold/hidden/cyan{
+	dir = 8
+	},
+/turf/open/floor/strata{
+	icon_state = "red1"
+	},
+/area/strata/ag/interior/outpost/security)
+"My" = (
+/obj/structure/flora/pottedplant{
+	icon_state = "pottedplant_22";
+	tag = "icon-pottedplant_10"
+	},
+/obj/structure/platform/strata/metal{
+	dir = 1
+	},
+/turf/open/floor/strata{
+	icon_state = "fake_wood"
+	},
+/area/strata/ag/interior/outpost/security)
+"MC" = (
+/obj/effect/spawner/random/attachment,
+/turf/open/floor/strata,
+/area/strata/ag/interior/outpost/security)
+"MO" = (
+/obj/structure/filingcabinet,
+/obj/structure/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/strata{
+	icon_state = "red1"
+	},
+/area/strata/ag/interior/outpost/security)
+"Nr" = (
+/obj/structure/machinery/photocopier,
+/turf/open/floor/strata{
+	icon_state = "floor3"
+	},
+/area/strata/ag/interior/outpost/security)
+"NE" = (
+/obj/structure/barricade/wooden,
+/turf/open/floor/strata,
+/area/strata/ag/interior/outpost/security)
+"OJ" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/stack/rods,
+/obj/item/shard{
+	icon_state = "large";
+	name = "ice shard"
+	},
+/turf/open/floor/strata{
+	dir = 6;
+	icon_state = "multi_tiles"
+	},
+/area/strata/ag/interior/outpost/security)
+"OW" = (
+/turf/closed/wall/strata_outpost/reinforced,
+/area/strata/ag/interior/outpost/security)
+"Pn" = (
+/turf/closed/wall/strata_ice/dirty,
+/area/strata/ag/exterior/paths/north_outpost)
+"Pq" = (
+/obj/structure/window_frame/strata,
+/obj/item/stack/rods,
+/turf/open/floor/strata,
+/area/strata/ag/interior/outpost/security)
+"PJ" = (
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/strata/ag/interior/outpost/security)
+"PX" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/structure/machinery/computer/security{
+	dir = 8
+	},
+/turf/open/floor/strata,
+/area/strata/ag/interior/outpost/security)
+"Qa" = (
+/obj/structure/barricade/metal/wired{
+	dir = 4;
+	icon_state = "metal_1"
+	},
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1"
+	},
+/obj/item/ammo_magazine/m56d,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/strata/ag/interior/outpost/security)
+"Qs" = (
+/obj/structure/window_frame/strata,
+/obj/item/stack/rods,
+/obj/item/shard{
+	icon_state = "large"
+	},
+/turf/open/floor/strata{
+	dir = 8;
+	icon_state = "multi_tiles"
+	},
+/area/strata/ag/interior/outpost/security)
+"QA" = (
+/obj/effect/spawner/random/attachment,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/strata/ag/interior/outpost/security)
+"QE" = (
+/obj/item/stack/rods,
+/obj/effect/decal/cleanable/blood/oil,
+/obj/item/stack/cable_coil/cut,
+/turf/open/floor/strata{
+	dir = 10;
+	icon_state = "multi_tiles"
+	},
+/area/strata/ag/interior/outpost/security)
+"QG" = (
+/obj/structure/barricade/plasteel/wired{
+	icon_state = "plasteel_3";
+	dir = 8
+	},
+/turf/open/floor/strata{
+	icon_state = "red1"
+	},
+/area/strata/ag/interior/outpost/security)
+"QT" = (
+/obj/structure/barricade/plasteel/wired{
+	icon_state = "plasteel_3";
+	dir = 1
+	},
+/turf/open/floor/strata{
+	icon_state = "red1"
+	},
+/area/strata/ag/interior/outpost/security)
+"QX" = (
+/turf/open/auto_turf/snow/brown_base/layer1,
+/area/strata/ag/exterior/paths/north_outpost)
+"Re" = (
+/obj/structure/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/flora/pottedplant{
+	icon_state = "pottedplant_22";
+	tag = "icon-pottedplant_10"
+	},
+/turf/open/floor/strata,
+/area/strata/ag/interior/outpost/security)
+"Rf" = (
+/obj/structure/girder,
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/strata/ag/interior/outpost/engi)
+"Ro" = (
+/obj/structure/window_frame/strata,
+/obj/item/shard{
+	icon_state = "large"
+	},
+/obj/item/stack/rods,
+/turf/open/floor/strata{
+	dir = 6;
+	icon_state = "multi_tiles"
+	},
+/area/strata/ag/interior/outpost/security)
+"Rt" = (
+/obj/effect/decal/cleanable/blood/oil,
+/obj/item/stack/rods,
+/obj/item/stack/cable_coil/cut,
+/turf/open/floor/strata{
+	dir = 10;
+	icon_state = "multi_tiles"
+	},
+/area/strata/ag/interior/outpost/engi)
+"RP" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/ammo_magazine/shotgun/slugs{
+	pixel_x = -7;
+	pixel_y = 6
+	},
+/obj/item/ammo_magazine/shotgun/slugs{
+	pixel_x = -7;
+	pixel_y = 6
+	},
+/obj/item/ammo_magazine/shotgun/buckshot{
+	pixel_x = 6;
+	pixel_y = -3
+	},
+/obj/item/ammo_magazine/shotgun/buckshot{
+	pixel_x = 6;
+	pixel_y = -3
+	},
+/obj/item/ammo_magazine/shotgun/incendiary,
+/obj/item/ammo_magazine/shotgun/incendiary,
+/turf/open/floor/strata{
+	icon_state = "red1"
+	},
+/area/strata/ag/interior/outpost/security)
+"RT" = (
+/obj/structure/pipes/vents/pump{
+	dir = 4
+	},
+/turf/open/floor/strata,
+/area/strata/ag/interior/outpost/security)
+"RV" = (
+/obj/structure/girder,
+/obj/item/shard{
+	icon_state = "medium"
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/strata/ag/interior/outpost/engi)
+"Sd" = (
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1";
+	dir = 1
+	},
+/turf/open/floor/strata{
+	icon_state = "red1"
+	},
+/area/strata/ag/interior/outpost/security)
+"Sf" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/structure/barricade/handrail/strata,
+/turf/open/floor/strata{
+	icon_state = "red1"
+	},
+/area/strata/ag/interior/outpost/security)
+"Sp" = (
+/obj/item/poster,
+/obj/structure/barricade/metal/wired{
+	dir = 4;
+	icon_state = "metal_1"
+	},
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/strata{
+	icon_state = "red1"
+	},
+/area/strata/ag/interior/outpost/security)
+"SB" = (
+/obj/structure/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/strata{
+	icon_state = "floor3"
+	},
+/area/strata/ag/interior/outpost/security)
+"SF" = (
+/obj/structure/barricade/metal/wired{
+	dir = 4;
+	icon_state = "metal_1"
+	},
+/turf/open/floor/strata{
+	icon_state = "red1"
+	},
+/area/strata/ag/interior/outpost/security)
+"SJ" = (
+/obj/structure/bookcase{
+	icon_state = "book-5"
+	},
+/obj/structure/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/strata{
+	icon_state = "floor3"
+	},
+/area/strata/ag/interior/outpost/security)
+"SO" = (
+/obj/structure/barricade/plasteel/wired{
+	icon_state = "plasteel_3";
+	dir = 8
+	},
+/turf/open/floor/strata{
+	icon_state = "fake_wood"
+	},
+/area/strata/ag/interior/outpost/security)
+"TN" = (
+/obj/effect/landmark/corpsespawner/russian,
+/obj/effect/decal/cleanable/blood,
+/obj/item/weapon/gun/rifle/type71/carbine,
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1";
+	dir = 1
+	},
+/turf/open/floor/strata{
+	icon_state = "fake_wood"
+	},
+/area/strata/ag/interior/outpost/security)
+"Uh" = (
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 4
+	},
+/turf/open/floor/strata,
+/area/strata/ag/interior/outpost/security)
+"Ut" = (
+/obj/structure/machinery/door/airlock/almayer/security{
+	dir = 2;
+	name = "Security Barracks";
+	req_access = null
+	},
+/turf/open/floor/strata,
+/area/strata/ag/interior/outpost/security)
+"VX" = (
+/obj/item/ammo_casing/bullet,
+/obj/structure/barricade/plasteel/wired{
+	icon_state = "plasteel_3";
+	dir = 8
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/strata/ag/interior/outpost/security)
+"WE" = (
+/obj/structure/bed/chair{
+	dir = 1;
+	tag = "icon-chair (NORTH)"
+	},
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/strata{
+	icon_state = "fake_wood"
+	},
+/area/strata/ag/interior/outpost/security)
+"WG" = (
+/turf/closed/wall/strata_outpost,
+/area/strata/ag/interior/outpost/engi)
+"WP" = (
+/obj/item/stack/rods,
+/obj/effect/decal/cleanable/blood/oil,
+/obj/item/stack/cable_coil/cut,
+/turf/open/floor/strata,
+/area/strata/ag/interior/outpost/security)
+"Xc" = (
+/turf/open/auto_turf/snow/brown_base/layer3,
+/area/strata/ag/exterior/paths/north_outpost)
+"XA" = (
+/obj/structure/machinery/camera/autoname{
+	dir = 4
+	},
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/strata/ag/interior/outpost/security)
+"XY" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/stack/rods,
+/obj/item/shard{
+	icon_state = "large"
+	},
+/turf/open/floor/strata{
+	dir = 6;
+	icon_state = "multi_tiles"
+	},
+/area/strata/ag/interior/outpost/security)
+"Yf" = (
+/obj/structure/pipes/vents/pump{
+	dir = 8;
+	id_tag = "mining_outpost_pump"
+	},
+/turf/open/floor/strata,
+/area/strata/ag/interior/outpost/security)
+"Yz" = (
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 4
+	},
+/turf/open/floor/strata{
+	dir = 8;
+	icon_state = "multi_tiles"
+	},
+/area/strata/ag/interior/outpost/security)
+"YN" = (
+/obj/structure/machinery/space_heater,
+/obj/structure/barricade/metal/wired{
+	icon_state = "metal_1"
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/strata/ag/interior/outpost/security)
+"Zb" = (
+/obj/item/weapon/gun/rifle/m16,
+/obj/item/weapon/gun/rifle/m16{
+	pixel_x = 5;
+	pixel_y = 6
+	},
+/obj/structure/surface/rack,
+/turf/open/floor/strata{
+	icon_state = "red1"
+	},
+/area/strata/ag/interior/outpost/security)
+"Zk" = (
+/obj/structure/surface/rack,
+/obj/item/storage/firstaid/surgical,
+/turf/open/floor/strata{
+	icon_state = "fake_wood"
+	},
+/area/strata/ag/interior/outpost/security)
+"Zz" = (
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 6
+	},
+/obj/effect/landmark/corpsespawner/russian,
+/obj/item/weapon/gun/rifle/type71/carbine,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/strata{
+	icon_state = "red1"
+	},
+/area/strata/ag/interior/outpost/security)
+"ZM" = (
+/obj/structure/closet/secure_closet/personal,
+/obj/item/clothing/suit/radiation,
+/turf/open/floor/strata{
+	icon_state = "floor3"
+	},
+/area/strata/ag/interior/outpost/canteen/lower_cafeteria)
+"ZU" = (
+/obj/structure/pipes/vents/pump,
+/turf/open/floor/strata{
+	icon_state = "fake_wood"
+	},
+/area/strata/ag/interior/outpost/security)
+"ZW" = (
+/obj/structure/filingcabinet,
+/turf/open/floor/strata{
+	icon_state = "floor3"
+	},
+/area/strata/ag/interior/outpost/security)
+"ZZ" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/ammo_magazine/rifle/m16/ap,
+/obj/item/ammo_magazine/rifle/m16/ap{
+	pixel_x = -2
+	},
+/obj/item/ammo_magazine/rifle/m16/ap{
+	pixel_x = -4
+	},
+/obj/item/ammo_magazine/rifle/m16/ap{
+	pixel_x = -6
+	},
+/obj/item/ammo_magazine/rifle/m16/ap{
+	pixel_x = -8
+	},
+/obj/item/weapon/melee/throwing_knife{
+	pixel_x = 18;
+	pixel_y = 9
+	},
+/obj/item/weapon/melee/throwing_knife{
+	pixel_x = 18;
+	pixel_y = 6
+	},
+/obj/item/ammo_magazine/rifle/m16{
+	pixel_x = 6
+	},
+/obj/item/ammo_magazine/rifle/m16{
+	pixel_x = 6
+	},
+/obj/item/ammo_magazine/rifle/m16{
+	pixel_x = 6
+	},
+/obj/item/ammo_magazine/rifle/m16{
+	pixel_x = 6
+	},
+/obj/item/ammo_magazine/rifle/m16{
+	pixel_x = 6
+	},
+/obj/item/ammo_magazine/rifle/m16{
+	pixel_x = 6
+	},
+/obj/item/ammo_magazine/rifle/m16{
+	pixel_x = 6
+	},
+/obj/item/ammo_magazine/rifle/m16{
+	pixel_x = 6
+	},
+/turf/open/floor/strata{
+	icon_state = "red1"
+	},
+/area/strata/ag/interior/outpost/security)
+
+(1,1,1) = {"
+fs
+Pn
+Pn
+Pn
+OW
+MO
+xn
+cp
+jQ
+cp
+ym
+xU
+xU
+xU
+xU
+zL
+"}
+(2,1,1) = {"
+eN
+Pn
+Pn
+Pn
+OW
+Ik
+AY
+Lx
+SO
+AV
+Rt
+yu
+dp
+sj
+ia
+Gr
+"}
+(3,1,1) = {"
+QX
+eN
+Pn
+Pn
+OW
+jl
+LF
+uh
+cg
+ZW
+ym
+lY
+yw
+RV
+WG
+zL
+"}
+(4,1,1) = {"
+QX
+fs
+eN
+eN
+Gb
+qa
+rK
+fC
+yT
+Nr
+ym
+db
+qc
+nX
+tt
+WG
+"}
+(5,1,1) = {"
+fs
+Xc
+eN
+eN
+Gb
+FX
+yQ
+yT
+yT
+SJ
+ym
+qj
+Rf
+eB
+ux
+kA
+"}
+(6,1,1) = {"
+Ll
+eN
+wW
+wW
+OW
+OW
+mv
+kd
+OW
+OW
+ym
+sh
+WG
+WG
+sh
+WG
+"}
+(7,1,1) = {"
+OW
+OW
+OW
+My
+Zk
+aD
+jL
+SO
+Aq
+OW
+jr
+VX
+LQ
+XA
+QG
+OW
+"}
+(8,1,1) = {"
+dF
+bl
+Eh
+Gk
+qn
+xu
+mk
+uh
+Ch
+OW
+vP
+PJ
+ix
+DI
+eA
+OJ
+"}
+(9,1,1) = {"
+Gt
+Sd
+Sf
+Gk
+uh
+uh
+fr
+uh
+Ch
+OW
+jG
+Dg
+DI
+GN
+dG
+el
+"}
+(10,1,1) = {"
+Gt
+Gs
+EV
+Gk
+sk
+ZU
+lz
+iM
+tX
+OW
+LS
+hN
+gv
+SF
+qo
+XY
+"}
+(11,1,1) = {"
+OW
+hN
+IZ
+My
+cQ
+mw
+at
+vJ
+rE
+OW
+Jy
+OW
+Qs
+Gh
+Gh
+cp
+"}
+(12,1,1) = {"
+cp
+OW
+QE
+OW
+OW
+OW
+mv
+lO
+OW
+cp
+wY
+cp
+nW
+RT
+hV
+NE
+"}
+(13,1,1) = {"
+WP
+QT
+yT
+zV
+DI
+ID
+DI
+PJ
+yT
+Zz
+CC
+cw
+ui
+as
+zQ
+ui
+"}
+(14,1,1) = {"
+WP
+Sd
+yT
+PJ
+PJ
+DI
+pq
+ui
+LZ
+wx
+iT
+yM
+yT
+yT
+yT
+oc
+"}
+(15,1,1) = {"
+cp
+hV
+MC
+Re
+hV
+sL
+ek
+MC
+Yf
+hV
+Uh
+cp
+Qs
+Gh
+Qs
+cp
+"}
+(16,1,1) = {"
+qR
+uh
+zz
+OW
+OW
+OW
+OW
+lO
+OW
+cp
+Yz
+OW
+hq
+Al
+vW
+Gb
+"}
+(17,1,1) = {"
+Pq
+TN
+WE
+OW
+Ei
+hA
+RP
+Au
+OW
+vi
+LS
+Kg
+aJ
+tB
+gz
+rC
+"}
+(18,1,1) = {"
+Pq
+dL
+sk
+OW
+qS
+Ik
+Ik
+Ik
+OW
+FO
+Hj
+wr
+hX
+FK
+zt
+cp
+"}
+(19,1,1) = {"
+OW
+Gx
+Ci
+OW
+Ei
+Zb
+ZZ
+pT
+OW
+pz
+id
+zG
+PJ
+PJ
+YN
+Gb
+"}
+(20,1,1) = {"
+OW
+OW
+OW
+OW
+OW
+OW
+OW
+OW
+OW
+od
+yT
+QA
+PJ
+ID
+FT
+rC
+"}
+(21,1,1) = {"
+Kl
+QX
+fs
+OW
+qb
+nH
+Ut
+hV
+Gd
+Ik
+hN
+Sp
+mP
+Gf
+Qa
+cp
+"}
+(22,1,1) = {"
+Ky
+fs
+QX
+qR
+IR
+IB
+Ro
+hV
+Jl
+Ik
+cp
+eH
+dx
+tv
+po
+OW
+"}
+(23,1,1) = {"
+Ky
+Ky
+QX
+OW
+OW
+OW
+OW
+BZ
+gx
+uO
+lo
+Ik
+nN
+lx
+nP
+Ik
+"}
+(24,1,1) = {"
+Ky
+gb
+we
+we
+Jj
+Jj
+OW
+PX
+xM
+Ev
+Hh
+nP
+FX
+nP
+Ik
+wu
+"}
+(25,1,1) = {"
+Ky
+Ky
+In
+ZM
+Cj
+Jj
+OW
+OW
+OW
+OW
+cp
+SB
+OW
+lt
+lt
+OW
+"}

--- a/maps/map_files/Sorokyne_Strata/sprinkles/25.clfsoro.dmm
+++ b/maps/map_files/Sorokyne_Strata/sprinkles/25.clfsoro.dmm
@@ -3,10 +3,7 @@
 /obj/structure/pipes/standard/manifold/hidden/cyan{
 	dir = 4
 	},
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-=======
->>>>>>> reimported backup
 /turf/open/floor/strata{
 	icon_state = "red1"
 	},
@@ -67,10 +64,6 @@
 /obj/structure/pipes/standard/simple/hidden/cyan,
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
-<<<<<<< master
-=======
-/obj/item/stack/rods,
->>>>>>> reimported backup
 /turf/open/floor/strata,
 /area/strata/ag/interior/outpost/security)
 "cQ" = (
@@ -105,10 +98,6 @@
 /area/strata/ag/interior/outpost/engi)
 "dx" = (
 /obj/structure/window_frame/strata,
-<<<<<<< master
-=======
-/obj/item/stack/rods,
->>>>>>> reimported backup
 /obj/item/shard{
 	icon_state = "medium"
 	},
@@ -144,15 +133,12 @@
 	icon_state = "fake_wood"
 	},
 /area/strata/ag/interior/outpost/security)
-<<<<<<< master
 "dZ" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
 /area/strata/ag/interior/outpost/security)
-=======
->>>>>>> reimported backup
 "ek" = (
 /obj/structure/machinery/light/small{
 	dir = 4
@@ -192,10 +178,6 @@
 /area/strata/ag/interior/outpost/engi)
 "eH" = (
 /obj/structure/window_frame/strata,
-<<<<<<< master
-=======
-/obj/item/stack/rods,
->>>>>>> reimported backup
 /obj/item/shard{
 	icon_state = "large"
 	},
@@ -310,10 +292,7 @@
 "hX" = (
 /obj/structure/pipes/standard/simple/hidden/cyan,
 /obj/item/ammo_casing/bullet,
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-=======
->>>>>>> reimported backup
 /turf/open/floor/strata{
 	icon_state = "red1"
 	},
@@ -335,15 +314,12 @@
 	icon_state = "red1"
 	},
 /area/strata/ag/interior/outpost/security)
-<<<<<<< master
 "im" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
 /area/strata/ag/interior/outpost/security)
-=======
->>>>>>> reimported backup
 "ix" = (
 /obj/effect/spawner/random/attachment,
 /turf/open/floor{
@@ -402,13 +378,6 @@
 /area/strata/ag/interior/outpost/security)
 "jQ" = (
 /obj/effect/decal/cleanable/blood/oil,
-<<<<<<< master
-/obj/item/stack/cable_coil/cut,
-/obj/item/explosive/mine/clf/active{
-	dir = 8
-	},
-=======
-/obj/item/stack/rods,
 /obj/item/stack/cable_coil/cut,
 /obj/item/explosive/mine/clf/active{
 	dir = 8
@@ -441,10 +410,6 @@
 /obj/item/storage/box/ids,
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/storage/box/ids,
-<<<<<<< master
-=======
-/obj/item/stack/rods,
->>>>>>> reimported backup
 /obj/item/shard{
 	icon_state = "large"
 	},
@@ -488,10 +453,6 @@
 "lO" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
-<<<<<<< master
-=======
-/obj/item/stack/rods,
->>>>>>> reimported backup
 /turf/open/floor/strata{
 	dir = 8;
 	icon_state = "multi_tiles"
@@ -513,10 +474,7 @@
 	},
 /obj/effect/decal/cleanable/blood/drip,
 /obj/item/weapon/melee/twohanded/folded_metal_chair,
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-=======
->>>>>>> reimported backup
 /turf/open/floor/strata{
 	icon_state = "fake_wood"
 	},
@@ -531,10 +489,7 @@
 /obj/structure/machinery/light/small{
 	dir = 4
 	},
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-=======
->>>>>>> reimported backup
 /turf/open/floor/strata{
 	icon_state = "fake_wood"
 	},
@@ -597,10 +552,7 @@
 	dir = 1;
 	pixel_y = 20
 	},
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-=======
->>>>>>> reimported backup
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
@@ -626,10 +578,6 @@
 /area/strata/ag/interior/outpost/security)
 "po" = (
 /obj/structure/window_frame/strata,
-<<<<<<< master
-=======
-/obj/item/stack/rods,
->>>>>>> reimported backup
 /obj/item/shard{
 	icon_state = "large"
 	},
@@ -678,10 +626,7 @@
 /area/strata/ag/interior/outpost/security)
 "qb" = (
 /obj/item/stool,
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-=======
->>>>>>> reimported backup
 /turf/open/floor/strata{
 	dir = 8;
 	icon_state = "white_cyan2"
@@ -748,10 +693,6 @@
 /area/strata/ag/interior/outpost/security)
 "rC" = (
 /obj/structure/window_frame/strata,
-<<<<<<< master
-=======
-/obj/item/stack/rods,
->>>>>>> reimported backup
 /obj/item/shard{
 	icon_state = "medium"
 	},
@@ -832,20 +773,13 @@
 /obj/item/stack/sheet/metal/medium_stack,
 /obj/item/stack/sheet/metal/medium_stack,
 /obj/structure/surface/rack,
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-=======
->>>>>>> reimported backup
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
 /area/strata/ag/interior/outpost/engi)
 "tv" = (
 /obj/structure/window_frame/strata,
-<<<<<<< master
-=======
-/obj/item/stack/rods,
->>>>>>> reimported backup
 /obj/item/shard{
 	icon_state = "large"
 	},
@@ -897,7 +831,6 @@
 	icon_state = "floor3"
 	},
 /area/strata/ag/interior/outpost/security)
-<<<<<<< master
 "uR" = (
 /obj/structure/pipes/standard/simple/hidden/cyan{
 	dir = 4
@@ -907,8 +840,6 @@
 	icon_state = "red1"
 	},
 /area/strata/ag/interior/outpost/security)
-=======
->>>>>>> reimported backup
 "vi" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/reagent_container/food/drinks/cans/souto/grape,
@@ -975,10 +906,7 @@
 	dir = 9
 	},
 /obj/item/ammo_magazine/rifle/type71,
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-=======
->>>>>>> reimported backup
 /turf/open/floor/strata{
 	icon_state = "red1"
 	},
@@ -1052,10 +980,6 @@
 "yM" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
-<<<<<<< master
-=======
-/obj/item/stack/rods,
->>>>>>> reimported backup
 /turf/open/floor/strata,
 /area/strata/ag/interior/outpost/security)
 "yQ" = (
@@ -1068,7 +992,6 @@
 	icon_state = "red1"
 	},
 /area/strata/ag/interior/outpost/security)
-<<<<<<< master
 "yR" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor{
@@ -1076,8 +999,6 @@
 	icon_state = "damaged3"
 	},
 /area/strata/ag/interior/outpost/security)
-=======
->>>>>>> reimported backup
 "yT" = (
 /turf/open/floor/strata{
 	icon_state = "red1"
@@ -1269,7 +1190,6 @@
 	icon_state = "red1"
 	},
 /area/strata/ag/interior/outpost/security)
-<<<<<<< master
 "Fl" = (
 /obj/structure/window_frame/strata,
 /obj/item/shard{
@@ -1280,8 +1200,6 @@
 	icon_state = "multi_tiles"
 	},
 /area/strata/ag/interior/outpost/security)
-=======
->>>>>>> reimported backup
 "FK" = (
 /obj/structure/pipes/standard/simple/hidden/cyan,
 /obj/effect/landmark/corpsespawner/russian,
@@ -1322,10 +1240,6 @@
 /area/strata/ag/interior/outpost/security)
 "Gb" = (
 /obj/structure/window_frame/strata,
-<<<<<<< master
-=======
-/obj/item/stack/rods,
->>>>>>> reimported backup
 /obj/item/shard{
 	icon_state = "large"
 	},
@@ -1371,11 +1285,6 @@
 /area/strata/ag/interior/outpost/security)
 "Gr" = (
 /obj/effect/decal/cleanable/blood/oil,
-<<<<<<< master
-/obj/item/stack/cable_coil/cut,
-/obj/item/explosive/mine/clf/active,
-=======
-/obj/item/stack/rods,
 /obj/item/stack/cable_coil/cut,
 /obj/item/explosive/mine/clf/active,
 /turf/open/floor/strata{
@@ -1398,10 +1307,6 @@
 /area/strata/ag/interior/outpost/security)
 "Gt" = (
 /obj/structure/window_frame/strata,
-<<<<<<< master
-=======
-/obj/item/stack/rods,
->>>>>>> reimported backup
 /turf/open/floor/strata{
 	dir = 6;
 	icon_state = "multi_tiles"
@@ -1425,10 +1330,6 @@
 /area/strata/ag/interior/outpost/security)
 "Hh" = (
 /obj/structure/surface/table/reinforced/prison,
-<<<<<<< master
-=======
-/obj/item/stack/rods,
->>>>>>> reimported backup
 /obj/item/shard{
 	icon_state = "large"
 	},
@@ -1440,10 +1341,7 @@
 /obj/structure/pipes/standard/simple/hidden/cyan{
 	dir = 10
 	},
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-=======
->>>>>>> reimported backup
 /turf/open/floor/strata{
 	icon_state = "red1"
 	},
@@ -1494,10 +1392,7 @@
 "IZ" = (
 /obj/structure/barricade/handrail/strata,
 /obj/item/ammo_casing/bullet,
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-=======
->>>>>>> reimported backup
 /turf/open/floor/strata{
 	icon_state = "red1"
 	},
@@ -1614,15 +1509,12 @@
 /obj/structure/barricade/wooden,
 /turf/open/floor/strata,
 /area/strata/ag/interior/outpost/security)
-<<<<<<< master
 "NU" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/strata{
 	icon_state = "red1"
 	},
 /area/strata/ag/interior/outpost/security)
-=======
->>>>>>> reimported backup
 "OJ" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/stack/rods,
@@ -1643,7 +1535,6 @@
 /area/strata/ag/exterior/paths/north_outpost)
 "Pq" = (
 /obj/structure/window_frame/strata,
-<<<<<<< master
 /turf/open/floor/strata,
 /area/strata/ag/interior/outpost/security)
 "Pv" = (
@@ -1652,11 +1543,6 @@
 	icon_state = "fake_wood"
 	},
 /area/strata/ag/interior/outpost/security)
-=======
-/obj/item/stack/rods,
-/turf/open/floor/strata,
-/area/strata/ag/interior/outpost/security)
->>>>>>> reimported backup
 "PJ" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
@@ -1758,10 +1644,6 @@
 /area/strata/ag/interior/outpost/security)
 "Rt" = (
 /obj/effect/decal/cleanable/blood/oil,
-<<<<<<< master
-=======
-/obj/item/stack/rods,
->>>>>>> reimported backup
 /obj/item/stack/cable_coil/cut,
 /turf/open/floor/strata{
 	dir = 10;
@@ -1850,10 +1732,7 @@
 	dir = 4;
 	icon_state = "metal_1"
 	},
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-=======
->>>>>>> reimported backup
 /turf/open/floor/strata{
 	icon_state = "red1"
 	},
@@ -1886,23 +1765,17 @@
 	icon_state = "metal_1";
 	dir = 1
 	},
-<<<<<<< master
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
-=======
->>>>>>> reimported backup
 /turf/open/floor/strata{
 	icon_state = "fake_wood"
 	},
 /area/strata/ag/interior/outpost/security)
-<<<<<<< master
 "Ub" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/strata{
 	icon_state = "floor3"
 	},
 /area/strata/ag/interior/outpost/security)
-=======
->>>>>>> reimported backup
 "Uh" = (
 /obj/structure/pipes/standard/simple/hidden/cyan{
 	dir = 4
@@ -1927,13 +1800,10 @@
 	icon_state = "platingdmg3"
 	},
 /area/strata/ag/interior/outpost/security)
-<<<<<<< master
 "Wv" = (
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/strata,
 /area/strata/ag/interior/outpost/security)
-=======
->>>>>>> reimported backup
 "WE" = (
 /obj/structure/bed/chair{
 	dir = 1;
@@ -1992,7 +1862,6 @@
 	icon_state = "multi_tiles"
 	},
 /area/strata/ag/interior/outpost/security)
-<<<<<<< master
 "YG" = (
 /obj/structure/window_frame/strata,
 /obj/item/shard{
@@ -2003,8 +1872,6 @@
 	icon_state = "multi_tiles"
 	},
 /area/strata/ag/interior/outpost/security)
-=======
->>>>>>> reimported backup
 "YN" = (
 /obj/structure/machinery/space_heater,
 /obj/structure/barricade/metal/wired{
@@ -2177,11 +2044,7 @@ Gb
 qa
 rK
 fC
-<<<<<<< master
 NU
-=======
-yT
->>>>>>> reimported backup
 Nr
 ym
 db
@@ -2252,11 +2115,7 @@ Gk
 qn
 xu
 mk
-<<<<<<< master
 Pv
-=======
-uh
->>>>>>> reimported backup
 Ch
 OW
 vP
@@ -2271,11 +2130,7 @@ Gt
 Sd
 Sf
 Gk
-<<<<<<< master
 Pv
-=======
-uh
->>>>>>> reimported backup
 uh
 fr
 uh
@@ -2299,11 +2154,7 @@ lz
 iM
 tX
 OW
-<<<<<<< master
 uR
-=======
-LS
->>>>>>> reimported backup
 hN
 gv
 SF
@@ -2354,11 +2205,7 @@ zV
 DI
 ID
 DI
-<<<<<<< master
 dZ
-=======
-PJ
->>>>>>> reimported backup
 yT
 Zz
 CC
@@ -2372,10 +2219,9 @@ ui
 fa
 Sd
 yT
-PJ
-PJ
-DI
->>>>>>> reimported backup
+dZ
+dZ
+im
 pq
 ui
 LZ
@@ -2401,24 +2247,14 @@ Yf
 hV
 Uh
 cp
-<<<<<<< master
 YG
 Fl
 YG
-=======
-Qs
-Gh
-Qs
->>>>>>> reimported backup
 cp
 "}
 (16,1,1) = {"
 qR
-<<<<<<< master
 Pv
-=======
-uh
->>>>>>> reimported backup
 zz
 OW
 OW
@@ -2458,15 +2294,9 @@ dL
 sk
 OW
 qS
-<<<<<<< master
 Ub
 Ik
 Ub
-=======
-Ik
-Ik
-Ik
->>>>>>> reimported backup
 OW
 FO
 Hj
@@ -2508,11 +2338,7 @@ od
 yT
 QA
 PJ
-<<<<<<< master
 yR
-=======
-ID
->>>>>>> reimported backup
 FT
 rC
 "}
@@ -2526,11 +2352,7 @@ nH
 Ut
 hV
 Gd
-<<<<<<< master
 Ub
-=======
-Ik
->>>>>>> reimported backup
 hN
 Sp
 mP
@@ -2546,11 +2368,7 @@ qR
 IR
 IB
 Ro
-<<<<<<< master
 Wv
-=======
-hV
->>>>>>> reimported backup
 Jl
 Ik
 cp


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

This update hopes to introduce colonial liberation into standard games through nightmare inserts survivors. The update was done with the consultation of staff and development as to the best way to re-introduce hostile survivors. This should be the first step in accomplishing this.

## Why It's Good For The Game

First a little back story. This update grew after a short test conducted by staff and in which they introduced hostile survivors. The test initially had survivors choose to either be friendly, neutral, or hostile towards the Marine forces once they landed on the colony. Although the initial test yielded some results as to how to police bad role-playing behavior. I believe more can be done as to the successful implementation of hostile survivors.  In almost all the reports about end proper escalation, the determining Factor seems to revolve around failing to identify which survivor was hostile resulting in antagonistic interaction between the two parties even when the Survivor was declaring themselves as neutral or friendly. 

To resolve this I create these various nightmare inserts for each of the currently playable Maps and end the game to help remedy this issue by giving hostile survivors proper roles that could be easily identified. It was not enough to simply add clf survivors to the normal roster so I decided to add lore-friendly inserts to all of the playable maps to help provide context as to why the CLF is at the colony in the first place.

Much like private military contractor Survivor rules, the colonial Liberation Front Survivor role will only have a 25% chance of spawning on all maps, and when they do spawn they will have a small base of operation to loot for supplies and Stage their Valiant last stand against Zeno's or submarines once they do arrive. The inserts were initially modeled after the crashed ship insert from the LV-624 map As it was the only example of a hostile survivor insert existing.  after discussion with development team members in particular we managed to agree upon design details and proper balance for such hostile forces in an exceedingly rare insert so as to not upset the current flow of the round.

 In order to help facilitate the new survivor roll in its intended purpose several additions needed to be made. The addition of corpses, specifically CLF corpses that could be looted, coding of various objects such as hacked mines with CLF IFF, and the creation of inserts in suitable locations as to not favor marines or Xenos should they take refuge. In addition to the CLF update, I also added in an additional neutral survivor holdout on the map of Shiva's snowball. It was initially slated for another project that never came to pass and I thought why not put it in here.

## Methodology

Initially, the inserts were balanced around the crashed ship insert on the L V6 24 map.  this provided the initial basis for what you see today. The part way during the creation of these inserts I was working on the big red Last Stand update which had a similar map. what is the most common feedback I received from that update was that, unlike the LV counterpart, these Maps were not in an isolated section of the map which had very little to no chance of survival which is why they had an abundance of weapons and ammunition as it was unlikely that they the survivors would be unable to forage additional gear? With that in mind, I made changes to the pre-existing inserts in addition to the big red last add update to help reflect these requests. The map has much of the same gear as the inserts with the exception of turrets add event weapons like the M60 or the UPP specialist sniper rifle.

The locations of the maps were selected for two main reasons. The first reason was to help provide an engaging story or a reasonable area in which a firefight of sorts would take place should a clone of Liberation Front cell attack The Colony or the colonists themselves rise up. Secondly, the maps or areas selected had to be far away from The Landing zones and from the hive as to not have a considerable impact on the flow of the rounds.  This understandably made the selection very difficult with various different buildings across all the colonies had received some sort of insert until one was picked.  had I placed a clf hold out nearby Landing Zone then the direct conflict between Marines and hostile forces would happen immediately disrupting the start of the round. Not to mention the fact that loot would be immediately available to the marines. Had I put the insert closer to Hive locations then Xenomorphs would have to attack the fortified clf soldiers at an early stage or have to relocate as a result. These locations should provide for a happy medium between all forces at play.


## Maps

**_Florina Science Annex Crashed Ship Insert_**

![2022 07 23-17 17 00](https://user-images.githubusercontent.com/103712112/182244548-9748ac0d-e0fd-4075-9284-0e43bd05a5e6.png)

- I know what you are thinking. Yes this is the crashed ship insert from LV posted here with some minor alterations. Initial credits for ship go to benedict. I did this because the map was too good not to use and there were really no go areas to stage a clf invasion that wouldn't be a meta pick for survivors, marines, or Xenos. So I decided to crash the CLF ship once more onto the northern side of the prison station where the crew of the prison attempted to thwart the invasion. Both side have taken many casualties and here you play as recently awaken CLF survivors who managed to sleep threw the ordeal. Will you fight to take over the prison or will you wait to call for backup? The choice is yours.

**_Soro Map Insert_**

![2022 07 23-17 15 53](https://user-images.githubusercontent.com/103712112/182244567-fd374996-c86e-4e2d-95aa-4a124e788f6a.png)

- In this insert, the political prisoners of the colony have taken arms against the UPP and WY overlords and have raided the armory for weapons. After a successful fight they managed to take over the security department and have established themselves as a new cell of the colonial liberation front with a vendetta not just for the corporation but also the  UPP.

**_LV-624 Hydroponics CLF Insert_**

![2022 07 23-17 15 32](https://user-images.githubusercontent.com/103712112/182244586-744eef54-869c-4a3d-a82d-94283a6f885b.png)

- This insert reflects the valiant efforts of the colonist and pmc forces having a last stand in the hydroponics facility of the colony. This location was selected due to its distance between LZ1 and LZ2. In this insert, the CLF have just recently slain the last of the loyalist colonist and their paid guns for hire. Although the map does feature a CLF insert the most common complaint received about it was that the hostile survivors had no way of escaping. Even with their sentries, the clf survivors there had no chance of surviving. This insert should at least give the survivors a fighting chance at the cost of all the gear they would have normally received had they stayed in the ship

**_Kutjevo CLF Survivor Insert_**

![2022 07 23-17 15 08](https://user-images.githubusercontent.com/103712112/182244609-8d2cb24c-aeea-46f6-b569-25a0e6c6b978.png)

- The kutjevo refinery luck seemed to have run out. The colonist banded together to form their very own cell of the colonial liberation front after their calls for better working conditions and pay failed to yield results. In secret the colonist have been amassing a great deal of equipment in order to stage a rebellion when they were caught in the act by local security forces resulting in a shootout at the local bar.

**_Shiva Snowball CLF Insert_**

![2022 07 23-17 14 53](https://user-images.githubusercontent.com/103712112/182244622-41d81c20-6b8e-4b3c-824d-20378e5fcee1.png)

- In this insert, the CLF forces having received a distress signal from the shivas snowball facility dispatched a small cadre of foot soldiers to take over the guarded facility. An intense firefight broke out at the administration section of the colony in which security forces, colonist, and their cowardly administrators barricaded themselves in sending a distress signal of their own which would be eventually received by the marines. In this insert, CLF survivors play as the remaining survivors of the battle and have established themselves as the new authority of the colony.

**_New Survivor Neutral Last Stand Insert_**

![2022 07 23-17 14 34](https://user-images.githubusercontent.com/103712112/182244644-546ed211-1d50-4aa3-8146-986c63efcbc5.png)

This map was supposed to be a part of an extended last-stand update for all maps however given the number of projects I had I was unable to complete it to the fullest. It didn't help that my repo corrupted on multiple occasions. I managed to find a backup of the map and decide to insert it here having updated it with the Big Red last stand insert in mind. Here survivors have barricaded themselves in the colony bar in the hopes they are to be rescued after having sent a distress signal. Only time will tell if help arrives.


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: theflyingflail
add: Added new clf corpses to help decorate maps with
add: Added new clf survivor spawner with updated text
add: Added new clf mines at the request of Geeves
add: Added new clf inserts to all currently playable maps
add: Added new survivor last stand map to Shiva snowball

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
