### PR TITLE
Fixes Charlie Cafeteria Chair Orientation

### DIFF
--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -38557,9 +38557,9 @@
 /obj/structure/machinery/door_control{
 	id = "cl_shutters 2";
 	name = "Quarters Shutters";
-	req_access_txt = "200";
+	pixel_x = 11;
 	pixel_y = 37;
-	pixel_x = 11
+	req_access_txt = "200"
 	},
 /turf/open/floor/wood/ship,
 /area/almayer/command/corporateliason)
@@ -41824,20 +41824,20 @@
 "fqe" = (
 /obj/structure/surface/table/almayer,
 /obj/item/tool/pen/blue/clicky{
-	pixel_y = 2;
-	pixel_x = 2
+	pixel_x = 2;
+	pixel_y = 2
 	},
 /obj/item/tool/pen/red/clicky{
 	pixel_x = -1;
 	pixel_y = 1
 	},
 /obj/item/tool/pen/clicky{
-	pixel_y = -1;
-	pixel_x = 1
+	pixel_x = 1;
+	pixel_y = -1
 	},
 /obj/item/paper_bin/wy{
-	pixel_y = 5;
-	pixel_x = -5
+	pixel_x = -5;
+	pixel_y = 5
 	},
 /turf/open/floor/wood/ship,
 /area/almayer/command/corporateliason)
@@ -121318,10 +121318,10 @@ moQ
 hGO
 fvf
 uNM
-gAj
-gAj
-gAj
-gAj
+xAt
+xAt
+xAt
+xAt
 nNH
 bqZ
 bdg

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -42559,15 +42559,6 @@
 /obj/effect/decal/cleanable/blood/oil/streak,
 /turf/open/floor/almayer,
 /area/almayer/lifeboat_pumps/south1)
-"fGh" = (
-/obj/structure/bed/chair{
-	dir = 1
-	},
-/turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
-	},
-/area/almayer/living/briefing)
 "fGm" = (
 /turf/open/shuttle/escapepod{
 	icon_state = "floor9";
@@ -118888,7 +118879,7 @@ uMk
 uMk
 bgO
 beH
-fGh
+bqZ
 bdg
 buH
 hOR
@@ -119091,7 +119082,7 @@ uMk
 uMk
 bgO
 beH
-fGh
+bqZ
 bdg
 buH
 hOR


### PR DESCRIPTION
## About The Pull Request

Fixes Charlie Cafeteria Chair Orientation

## Why It's Good For The Game

BUG BAD

## Changelog

:cl: Morrow
fix: Charlie cafeteria chairs should face the correct way now. Also removes folding chairs missed in previous removal PR.
/:cl: