### PR TITLE
Adds the ability for IOs to clear the Data Tab to resolve the BSOD

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -115,7 +115,8 @@ var/list/admin_verbs_debug = list(
 	/client/proc/debug_game_history,
 	/client/proc/construct_env_dmm,
 	/client/proc/enter_tree,
-	/client/proc/set_tree_points
+	/client/proc/set_tree_points,
+	/client/proc/purge_data_tab
 )
 
 var/list/admin_verbs_debug_advanced = list(

--- a/code/modules/admin/tabs/debug_tab.dm
+++ b/code/modules/admin/tabs/debug_tab.dm
@@ -76,6 +76,14 @@
 
 	tree.set_points(number_to_set)
 
+/client/proc/purge_data_tab()
+	set category = "Debug"
+	set name = "Reset Intel Data Tab"
+
+	if(tgui_alert(src, "Clear the data tab?", "Confirm", list("Yes", "No"), 10 SECONDS) == "Yes")
+		for(var/datum/cm_objective/O in intel_system.oms.disks)
+			intel_system.oms.disks -= O
+
 /client/proc/check_round_statistics()
 	set category = "Debug"
 	set name = "Round Statistics"

--- a/code/modules/admin/tabs/debug_tab.dm
+++ b/code/modules/admin/tabs/debug_tab.dm
@@ -81,8 +81,8 @@
 	set name = "Reset Intel Data Tab"
 
 	if(tgui_alert(src, "Clear the data tab?", "Confirm", list("Yes", "No"), 10 SECONDS) == "Yes")
-		for(var/datum/cm_objective/O in intel_system.oms.disks)
-			intel_system.oms.disks -= O
+		for(var/datum/cm_objective/Objective in intel_system.oms.disks)
+			intel_system.oms.disks -= Objective
 
 /client/proc/check_round_statistics()
 	set category = "Debug"

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1079,7 +1079,7 @@
 
 /mob/living/carbon/human/verb/purge_objective_memory()
 	set name = "Reset view objectives"
-	set category = "IC"
+	set category = "OOC.Fix"
 
 	if(!mind)
 		to_chat(src, "The game appears to have misplaced your mind datum.")

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1086,15 +1086,15 @@
 		return
 
 	if(tgui_alert(src, "Remove the faulty entry?", "Confirm", list("Yes", "No"), 10 SECONDS) == "Yes")
-		for(var/datum/cm_objective/retrieve_data/disk/O in src.mind.objective_memory.disks)
-			if(O.disk.disk_color == null || O.disk.display_color == null)
-				src.mind.objective_memory.disks -= O
+		for(var/datum/cm_objective/retrieve_data/disk/Objective in src.mind.objective_memory.disks)
+			if(!Objective.disk.disk_color || !Objective.disk.display_color)
+				src.mind.objective_memory.disks -= Objective
 	else
 		return
 
 	if(tgui_alert(src, "Did it work?", "Confirm", list("Yes", "No"), 10 SECONDS) == "No")
-		for(var/datum/cm_objective/O in src.mind.objective_memory.disks)
-			src.mind.objective_memory.disks -= O
+		for(var/datum/cm_objective/Objective in src.mind.objective_memory.disks)
+			src.mind.objective_memory.disks -= Objective
 
 /mob/living/carbon/human/proc/set_species(var/new_species, var/default_colour)
 	if(!new_species)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1077,6 +1077,25 @@
 
     mind.view_objective_memories(src)
 
+/mob/living/carbon/human/verb/purge_objective_memory()
+	set name = "Reset view objectives"
+	set category = "IC"
+
+	if(!mind)
+		to_chat(src, "The game appears to have misplaced your mind datum.")
+		return
+
+	if(tgui_alert(src, "Remove the faulty entry?", "Confirm", list("Yes", "No"), 10 SECONDS) == "Yes")
+		for(var/datum/cm_objective/retrieve_data/disk/O in src.mind.objective_memory.disks)
+			if(O.disk.disk_color == null || O.disk.display_color == null)
+				src.mind.objective_memory.disks -= O
+	else
+		return
+
+	if(tgui_alert(src, "Did it work?", "Confirm", list("Yes", "No"), 10 SECONDS) == "No")
+		for(var/datum/cm_objective/O in src.mind.objective_memory.disks)
+			src.mind.objective_memory.disks -= O
+
 /mob/living/carbon/human/proc/set_species(var/new_species, var/default_colour)
 	if(!new_species)
 		new_species = "Human"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Adds a new IC verb that allows people to reset their data tab in the case it BSODs, it will initially attempt to remove the faulty entry and then just clear the entire tab if it is unable to.
Also adds a new admin verb to the Debug tab that allows admins to purge the data tab of the entire intel database as a whole should an IO accidently upload a bugged entry and BSOD everyone else.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Provides a convenient solution until someone is able to figure out the cause of the BSODs and make a proper patch

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: CometBlaze
qol: Added a verb to the OOC fix tab that resets the Objectives Data Tab (use this when your objectives UI bluescreens)
admin: Added a new verb to the Debug tab that resets the Data Tab of the Intel Database as a whole
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
