### PR TITLE
Resin building on dead log

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/Powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Powers.dm
@@ -130,6 +130,12 @@
 		RegisterSignal(new_resin, COMSIG_PARENT_QDELETING, .proc/remove_built_structure)
 
 	new_resin.add_hiddenprint(src) //so admins know who placed it
+	
+	if(istype(new_resin, /turf/closed))
+		for(var/mob/living/carbon/human/enclosed_human in new_resin.contents)
+			if(enclosed_human.stat == DEAD)
+				msg_admin_niche("[src.ckey]/([src]) has built a closed resin structure, [new_resin.name], on top of a dead human, [enclosed_human.ckey]/([enclosed_human]), at [new_resin.x],[new_resin.y],[new_resin.z]")
+	
 	return SECRETE_RESIN_SUCCESS
 
 /mob/living/carbon/Xenomorph/proc/remove_built_structure(var/atom/A)

--- a/code/modules/mob/living/carbon/xenomorph/Powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Powers.dm
@@ -134,7 +134,7 @@
 	if(istype(new_resin, /turf/closed))
 		for(var/mob/living/carbon/human/enclosed_human in new_resin.contents)
 			if(enclosed_human.stat == DEAD)
-				msg_admin_niche("[src.ckey]/([src]) has built a closed resin structure, [new_resin.name], on top of a dead human, [enclosed_human.ckey]/([enclosed_human]), at [new_resin.x],[new_resin.y],[new_resin.z]")
+				msg_admin_niche("[src.ckey]/([src]) has built a closed resin structure, [new_resin.name], on top of a dead human, [enclosed_human.ckey]/([enclosed_human]), at [new_resin.x],[new_resin.y],[new_resin.z] (<A HREF='?_src_=admin_holder;[HrefToken(forceGlobal = TRUE)];adminplayerobservecoodjump=1;X=[new_resin.x];Y=[new_resin.y];Z=[new_resin.z]'>JMP</a>)")
 	
 	return SECRETE_RESIN_SUCCESS
 


### PR DESCRIPTION

## About The Pull Request

Building a resin wall (or other closed turf) on a dead body will be logged. If this is meta'd by people then we can go harder but this seems to solve the basic issue for now.

## Why It's Good For The Game

Server logs good.

## Changelog

:cl: Morrow
admin: Resin walls on dead bodies will now be logged.
/:cl:
