### PR TITLE
VP78 Buffs (Stan said I could)

### DIFF
--- a/code/game/machinery/vending/vendor_types/squad_prep/squad_prep.dm
+++ b/code/game/machinery/vending/vendor_types/squad_prep/squad_prep.dm
@@ -138,7 +138,7 @@ GLOBAL_LIST_INIT(cm_vending_clothing_marine, list(
 		list("Rebreather", 0, /obj/item/clothing/mask/rebreather, MARINE_CAN_BUY_MASK, VENDOR_ITEM_REGULAR),
 
 		list("RESTRICTED FIREARMS", 0, null, null, null),
-		list("VP78 Pistol", 10, /obj/item/storage/box/guncase/vp78, null, VENDOR_ITEM_REGULAR),
+		list("VP78 Pistol", 15, /obj/item/storage/box/guncase/vp78, null, VENDOR_ITEM_REGULAR),
 		list("SU-6 Smart Pistol", 15, /obj/item/storage/box/guncase/smartpistol, null, VENDOR_ITEM_REGULAR),
 		list("M41AE2 Heavy Pulse Rifle", 30, /obj/item/storage/box/guncase/lmg, null, VENDOR_ITEM_REGULAR),
 		list("M79 Grenade Launcher", 30, /obj/item/storage/box/guncase/m79, null, VENDOR_ITEM_REGULAR),

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -447,6 +447,7 @@
 	damage = 45
 	penetration= ARMOR_PENETRATION_TIER_6
 	shrapnel_chance = SHRAPNEL_CHANCE_TIER_2
+	damage_falloff = DAMAGE_FALLOFF_TIER_6 //"VP78 - the only pistol viable as a primary."-Vampmare, probably.
 
 /datum/ammo/bullet/pistol/squash/toxin
 	name = "toxic squash-head pistol bullet"

--- a/code/modules/projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/guns/pistols.dm
@@ -465,6 +465,13 @@
 						/obj/item/attachable/extended_barrel,
 						/obj/item/attachable/heavy_barrel)
 
+/obj/item/weapon/gun/pistol/vp78/handle_starting_attachment()
+	..()
+	var/obj/item/attachable/lasersight/VP = new(src)
+	VP.flags_attach_features &= ~ATTACH_REMOVABLE
+	VP.hidden = FALSE
+	VP.Attach(src)
+	update_attachable(VP.slot)
 
 /obj/item/weapon/gun/pistol/vp78/set_gun_attachment_offsets()
 	attachable_offset = list("muzzle_x" = 29, "muzzle_y" = 21,"rail_x" = 10, "rail_y" = 23, "under_x" = 20, "under_y" = 17, "stock_x" = 18, "stock_y" = 14)

--- a/code/modules/projectiles/magazines/pistols.dm
+++ b/code/modules/projectiles/magazines/pistols.dm
@@ -106,7 +106,7 @@
 	default_ammo = /datum/ammo/bullet/pistol/squash
 	caliber = "9mm"
 	icon_state = "vp78" //PLACEHOLDER
-	max_rounds = 14
+	max_rounds = 18
 	gun_type = /obj/item/weapon/gun/pistol/vp78
 
 /obj/item/ammo_magazine/pistol/vp78/toxin


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Okay, so I buffed the magazine count of the VP78 to be 18 like it is in lore, I reduced its falloff to be 5 (one more than the MK2), gave it a premounted lasersight and upped its PFC vendor cost from 10 to 15 as stan requested

"It is fitted with a laser sight/flashlight unit underneath the barrel as standard, although it is not usable in the game; instead, [Rookie](https://avp.fandom.com/wiki/Rookie) (or multiplayer Marines) uses his [TNR Shoulder Lamp](https://avp.fandom.com/wiki/TNR_Shoulder_Lamp) for illumination, as with any other weapon."

Feed system: 18-round detachable box magazine

https://avp.fandom.com/wiki/VP78_Pistol

## Why It's Good For The Game

Gives the VP alittle bit of a boost when compared to the other objectively better and more readily available sidearms 

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:SpartanBobby
balance: VP78 Now costs 15 points in PFC vendor
balance: VP78 Now has the lore accurate 18 magazine capacity instead of 14
balance: VP78 Now has the lore-accurate pre-attached laser sight
balance: VP78 Now has falloff 5 from falloff 7, one more than the MK2
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
