### PR TITLE
Vehicle environmental damage

### DIFF
--- a/code/game/objects/effects/aliens.dm
+++ b/code/game/objects/effects/aliens.dm
@@ -119,9 +119,7 @@
 
 		if(isVehicleMultitile(atm))
 			var/obj/vehicle/multitile/V = atm
-			for(var/obj/item/hardpoint/locomotion/Loco in V.hardpoints)
-				Loco.handle_acid_spray(src)
-				break
+			V.handle_acidic_environment(src)
 			continue
 
 	START_PROCESSING(SSobj, src)
@@ -155,9 +153,7 @@
 			apply_spray(AM)
 	else if(isVehicleMultitile(AM))
 		var/obj/vehicle/multitile/V = AM
-		for(var/obj/item/hardpoint/locomotion/Loco in V.hardpoints)
-			Loco.handle_acid_spray(src)
-			break
+		V.handle_acidic_environment(src)
 
 //damages human that comes in contact
 /obj/effect/xenomorph/spray/proc/apply_spray(mob/living/carbon/H, should_stun = TRUE)

--- a/code/modules/vehicles/apc/apc.dm
+++ b/code/modules/vehicles/apc/apc.dm
@@ -191,8 +191,8 @@ GLOBAL_LIST_EMPTY(command_apc_list)
 
 	load_misc(APC)
 	load_fpw(APC)
-	handle_direction(APC)
 	load_hardpoints(APC)
+	handle_direction(APC)
 	APC.update_icon()
 
 //PRESET: FPWs, wheels installed
@@ -205,8 +205,8 @@ GLOBAL_LIST_EMPTY(command_apc_list)
 
 	load_misc(APC)
 	load_fpw(APC)
-	handle_direction(APC)
 	load_hardpoints(APC)
+	handle_direction(APC)
 	load_damage(APC)
 	APC.update_icon()
 
@@ -232,16 +232,21 @@ GLOBAL_LIST_EMPTY(command_apc_list)
 /obj/effect/vehicle_spawner/apc/unarmed/spawn_vehicle()
 	var/obj/vehicle/multitile/apc/unarmed/APC = new (loc)
 
+	load_misc(APC)
 	load_hardpoints(APC)
 	handle_direction(APC)
 	APC.update_icon()
+
+/obj/effect/vehicle_spawner/apc/unarmed/load_hardpoints(var/obj/vehicle/multitile/apc/V)
+	return
 
 //PRESET: default hardpoints, destroyed
 /obj/effect/vehicle_spawner/apc/unarmed/decrepit/spawn_vehicle()
 	var/obj/vehicle/multitile/apc/unarmed/APC = new (loc)
 
-	handle_direction(APC)
+	load_misc(APC)
 	load_hardpoints(APC)
+	handle_direction(APC)
 	load_damage(APC)
 	APC.update_icon()
 

--- a/code/modules/vehicles/apc/apc_command.dm
+++ b/code/modules/vehicles/apc/apc_command.dm
@@ -190,8 +190,8 @@
 	var/obj/vehicle/multitile/apc/command/APC = new (loc)
 
 	load_misc(APC)
-	handle_direction(APC)
 	load_hardpoints(APC)
+	handle_direction(APC)
 	APC.update_icon()
 
 //PRESET: only wheels installed

--- a/code/modules/vehicles/apc/apc_medical.dm
+++ b/code/modules/vehicles/apc/apc_medical.dm
@@ -114,8 +114,8 @@
 	var/obj/vehicle/multitile/apc/medical/APC = new (loc)
 
 	load_misc(APC)
-	handle_direction(APC)
 	load_hardpoints(APC)
+	handle_direction(APC)
 	APC.update_icon()
 
 //PRESET: only wheels installed
@@ -127,8 +127,8 @@
 	var/obj/vehicle/multitile/apc/medical/APC = new (loc)
 
 	load_misc(APC)
-	handle_direction(APC)
 	load_hardpoints(APC)
+	handle_direction(APC)
 	load_damage(APC)
 	APC.update_icon()
 

--- a/code/modules/vehicles/multitile/multitile.dm
+++ b/code/modules/vehicles/multitile/multitile.dm
@@ -33,7 +33,7 @@
 	// List of verbs to give when a mob is seated in each seat type
 	var/list/seat_verbs
 
-	move_delay = VEHICLE_SPEED_SLOW
+	move_delay = VEHICLE_SPEED_STATIC
 	// The next world.time when the vehicle can move
 	var/next_move = 0
 	// How much momentum the vehicle has. Increases by 1 each move
@@ -391,7 +391,6 @@
 	if(desc)
 		V.desc = desc
 
-
 //Dealing enough damage to destroy the vehicle
 /obj/effect/vehicle_spawner/proc/load_damage(var/obj/vehicle/multitile/V)
 	V.take_damage_type(1e8, "abstract")
@@ -410,3 +409,8 @@
 
 /obj/vehicle/multitile/get_applying_acid_time()
 	return 3 SECONDS
+
+//handling dangerous acidic environment, like acidic spray or toxic waters, maybe toxic vapor in future
+/obj/vehicle/multitile/proc/handle_acidic_environment(var/atom/A)
+	for(var/obj/item/hardpoint/locomotion/Loco in hardpoints)
+		Loco.handle_acid_damage(A)

--- a/code/modules/vehicles/van/van.dm
+++ b/code/modules/vehicles/van/van.dm
@@ -268,6 +268,7 @@
 	var/obj/vehicle/multitile/van/VAN = new (loc)
 
 	load_misc(VAN)
+	load_hardpoints(VAN)
 	handle_direction(VAN)
 	load_damage(VAN)
 	VAN.update_icon()
@@ -276,5 +277,13 @@
 	V.add_hardpoint(new /obj/item/hardpoint/locomotion/van_wheels)
 
 //PRESET: wheels installed
+/obj/effect/vehicle_spawner/van/fixed/spawn_vehicle()
+	var/obj/vehicle/multitile/van/VAN = new (loc)
+
+	load_misc(VAN)
+	load_hardpoints(VAN)
+	handle_direction(VAN)
+	VAN.update_icon()
+
 /obj/effect/vehicle_spawner/van/fixed/load_hardpoints(var/obj/vehicle/multitile/van/V)
 	V.add_hardpoint(new /obj/item/hardpoint/locomotion/van_wheels)


### PR DESCRIPTION
## About The Pull Request

1. Reworked vehicle locomotion module acid damage handling to be better and part of vehicle itself. Added acid damage sound to it.
2. Toxic trijent river now deals damage to civillian vehicles. Cleaned up code a bit
3. Some fixes in vehicle spawners. Fix for vehicle speed speed.

![dreamseeker_Gisoy3VXOt](https://user-images.githubusercontent.com/43144601/183894588-7b2ab239-b841-4850-8a24-2d31b4073742.gif)

Fixes [!708](https://github.com/cmss13-devs/cmss13/issues/708)

## Why It's Good For The Game

Prevents using vans to succesfully avoid xenos in water, while leaving opportunity to drive on other side of broken bridge to ditch pursuit at the cost of damaged/losing wheels.
Fixes some bugs.

## Changelog

:cl: Jeser
balance: Vehicles now can receive damage from various environmental acidic sources like toxin rivers in addition to acid spray. Colony Vans receive wheels damage when driving through toxins river on Trijent Dam now.
fix: Fixed some vehicle spawners behaviour and vehicle speed.
/:cl:
