### PR TITLE
Xeno Name and Lighting Robustness

### DIFF
--- a/code/modules/admin/player_panel/actions/transform.dm
+++ b/code/modules/admin/player_panel/actions/transform.dm
@@ -174,9 +174,6 @@ GLOBAL_LIST_INIT(pp_transformables, list(
 			var/mob/living/carbon/Xenomorph/X = target
 			newXeno.set_hive_and_update(X.hivenumber)
 
-		newXeno.generate_name()
-		newXeno.set_lighting_alpha_from_prefs(user)
-
 
 	QDEL_IN(target, 0.3 SECONDS)
 	addtimer(CALLBACK(M.mob_panel, /datum.proc/tgui_interact, user.mob), 1 SECONDS)

--- a/code/modules/admin/verbs/mob_verbs.dm
+++ b/code/modules/admin/verbs/mob_verbs.dm
@@ -21,9 +21,6 @@
 
 	M.ckey = new_ckey
 	var/mob/living/carbon/Xenomorph/XNO = M
-	if(istype(XNO))
-		XNO.generate_name()
-		XNO.set_lighting_alpha_from_prefs(M.client)
 	M.client?.change_view(world_view_size)
 
 /client/proc/cmd_admin_changekey(mob/O in GLOB.mob_list)

--- a/code/modules/cm_aliens/structures/special/spawn_pool.dm
+++ b/code/modules/cm_aliens/structures/special/spawn_pool.dm
@@ -169,7 +169,6 @@
 		to_chat(new_xeno, SPAN_XENOANNOUNCE("You are a xenomorph larva awakened from slumber!"))
 		playsound(new_xeno, 'sound/effects/xeno_newlarva.ogg', 50, 1)
 		if(new_xeno.client)
-			new_xeno.set_lighting_alpha_from_prefs(new_xeno.client)
 			if(new_xeno.client?.prefs.toggles_flashing & FLASH_POOLSPAWN)
 				window_flash(new_xeno.client)
 

--- a/code/modules/mob/living/carbon/xenomorph/login.dm
+++ b/code/modules/mob/living/carbon/xenomorph/login.dm
@@ -1,3 +1,7 @@
 /mob/living/carbon/Xenomorph/Login()
 	..()
-	if(SSticker.mode) SSticker.mode.xenomorphs |= mind
+	generate_name()
+	if(client)
+		set_lighting_alpha_from_prefs(client)
+	if(SSticker.mode)
+		SSticker.mode.xenomorphs |= mind


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Xenos now always update their name and default vision mode when a client transfers into them.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

a

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Xenos now always update their name and default vision mode when a client transfers into them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
