### PR TITLE
Fixes Spec ID titles

### DIFF
--- a/code/game/machinery/vending/cm_vending.dm
+++ b/code/game/machinery/vending/cm_vending.dm
@@ -563,7 +563,7 @@ IN_USE						used for vending/denying
 							to_chat(H, SPAN_WARNING("<b>Something bad occured with [src], tell a Dev.</b>"))
 							vend_fail()
 							return
-					ID.set_assignment(H.assigned_squad ? (H.assigned_squad.name + " ") : "" + JOB_SQUAD_SPECIALIST + " ([specialist_assignment])")
+					ID.set_assignment((H.assigned_squad ? (H.assigned_squad.name + " ") : "") + JOB_SQUAD_SPECIALIST + " ([specialist_assignment])")
 					GLOB.data_core.manifest_modify(H.real_name, WEAKREF(H), ID.assignment)
 					available_specialist_sets -= p_name
 

--- a/code/modules/cm_marines/equipment/kit_boxes.dm
+++ b/code/modules/cm_marines/equipment/kit_boxes.dm
@@ -249,7 +249,7 @@
 				user.skills.set_skill(SKILL_ENGINEER, SKILL_ENGINEER_TRAINED)
 	if(specialist_assignment)
 		user.put_in_hands(spec_box)
-		ID.set_assignment(user.assigned_squad ? (user.assigned_squad.name + " ") : "" + ID.assignment + " ([specialist_assignment])")
+		ID.set_assignment((user.assigned_squad ? (user.assigned_squad.name + " ") : "") + ID.assignment + " ([specialist_assignment])")
 		GLOB.data_core.manifest_modify(user.real_name, WEAKREF(user), ID.assignment)
 		return TRUE
 	return FALSE


### PR DESCRIPTION
## About The Pull Request

Fixes Spec ID titles assignment, changed in https://github.com/cmss13-devs/cmss13/pull/842

## Why It's Good For The Game

No more indicated squad protags.

## Changelog

:cl: Jeser
fix: Fixed specialist dogtags specialization assignment.
/:cl:
