### PR TITLE
reverts blowtorches no longer causing eye damage ever

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -162,6 +162,9 @@
 #define TRAIT_TOOL_WRENCH "t_tool_wrench"
 #define TRAIT_TOOL_MULTITOOL "t_tool_multitool"
 
+#define TRAIT_TOOL_BLOWTORCH "t_tool_blowtorch"
+#define TRAIT_TOOL_SIMPLE_BLOWTORCH "t_tool_simple_blowtorch"
+
 // GUN TRAITS
 #define TRAIT_GUN_SILENCED "t_gun_silenced"
 

--- a/code/game/machinery/bio-dome_floodlights.dm
+++ b/code/game/machinery/bio-dome_floodlights.dm
@@ -107,6 +107,7 @@
 	if(istype(WT))
 		if(!damaged) return
 		if(!HAS_TRAIT(WT, TRAIT_TOOL_BLOWTORCH))
+			to_chat(user, SPAN_WARNING("You need a stronger blowtorch!"))
 			return
 		if(WT.remove_fuel(0, user))
 			playsound(src.loc, 'sound/items/weldingtool_weld.ogg', 25)

--- a/code/game/machinery/bio-dome_floodlights.dm
+++ b/code/game/machinery/bio-dome_floodlights.dm
@@ -106,6 +106,8 @@
 	var/obj/item/tool/weldingtool/WT = W
 	if(istype(WT))
 		if(!damaged) return
+		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH))
+			return
 		if(WT.remove_fuel(0, user))
 			playsound(src.loc, 'sound/items/weldingtool_weld.ogg', 25)
 			user.visible_message(SPAN_NOTICE("[user] starts welding [src]'s damage."), \

--- a/code/game/machinery/bio-dome_floodlights.dm
+++ b/code/game/machinery/bio-dome_floodlights.dm
@@ -106,7 +106,7 @@
 	var/obj/item/tool/weldingtool/WT = W
 	if(istype(WT))
 		if(!damaged) return
-		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH))
+		if(!HAS_TRAIT(WT, TRAIT_TOOL_BLOWTORCH))
 			return
 		if(WT.remove_fuel(0, user))
 			playsound(src.loc, 'sound/items/weldingtool_weld.ogg', 25)

--- a/code/game/machinery/bots/bots.dm
+++ b/code/game/machinery/bots/bots.dm
@@ -62,7 +62,7 @@
 			open = !open
 			to_chat(user, SPAN_NOTICE("Maintenance panel is now [src.open ? "opened" : "closed"]."))
 	else if(iswelder(W))
-		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
+		if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH)) return
 		if(health < maxhealth)
 			if(open)
 				health = min(maxhealth, health+10)

--- a/code/game/machinery/bots/bots.dm
+++ b/code/game/machinery/bots/bots.dm
@@ -61,7 +61,8 @@
 		if(!locked)
 			open = !open
 			to_chat(user, SPAN_NOTICE("Maintenance panel is now [src.open ? "opened" : "closed"]."))
-	else if(istype(W, /obj/item/tool/weldingtool))
+	else if(iswelder(W))
+		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
 		if(health < maxhealth)
 			if(open)
 				health = min(maxhealth, health+10)

--- a/code/game/machinery/bots/bots.dm
+++ b/code/game/machinery/bots/bots.dm
@@ -62,7 +62,9 @@
 			open = !open
 			to_chat(user, SPAN_NOTICE("Maintenance panel is now [src.open ? "opened" : "closed"]."))
 	else if(iswelder(W))
-		if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH)) return
+		if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH))
+			to_chat(user, SPAN_WARNING("You need a stronger blowtorch!"))
+			return
 		if(health < maxhealth)
 			if(open)
 				health = min(maxhealth, health+10)

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -120,7 +120,7 @@
 		interact(user)
 
 	else if(iswelder(W) && canDeconstruct())
-		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH))
+		if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH))
 			return
 		if(weld(W, user))
 			if(assembly)

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -121,6 +121,7 @@
 
 	else if(iswelder(W) && canDeconstruct())
 		if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH))
+			to_chat(user, SPAN_WARNING("You need a stronger blowtorch!"))
 			return
 		if(weld(W, user))
 			if(assembly)

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -120,6 +120,8 @@
 		interact(user)
 
 	else if(iswelder(W) && canDeconstruct())
+		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH))
+			return
 		if(weld(W, user))
 			if(assembly)
 				assembly.forceMove(loc)

--- a/code/game/machinery/computer/ai_core.dm
+++ b/code/game/machinery/computer/ai_core.dm
@@ -18,8 +18,10 @@
 					to_chat(user, SPAN_NOTICE(" You wrench the frame into place."))
 					anchored = 1
 					state = 1
-			if(istype(P, /obj/item/tool/weldingtool))
+			if(iswelder(P))
 				var/obj/item/tool/weldingtool/WT = P
+				if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH))
+					return
 				if(!WT.isOn())
 					to_chat(user, "The welder must be on for this task.")
 					return

--- a/code/game/machinery/computer/ai_core.dm
+++ b/code/game/machinery/computer/ai_core.dm
@@ -21,6 +21,7 @@
 			if(iswelder(P))
 				var/obj/item/tool/weldingtool/WT = P
 				if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH))
+					to_chat(user, SPAN_WARNING("You need a stronger blowtorch!"))
 					return
 				if(!WT.isOn())
 					to_chat(user, "The welder must be on for this task.")

--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -19,7 +19,8 @@
 					to_chat(user, SPAN_NOTICE(" You wrench the frame into place."))
 					src.anchored = 1
 					src.state = 1
-			if(istype(P, /obj/item/tool/weldingtool))
+			if(iswelder(P))
+				if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
 				var/obj/item/tool/weldingtool/WT = P
 				if(!WT.isOn())
 					to_chat(user, SPAN_WARNING("\The [WT] needs to be on!"))

--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -20,7 +20,9 @@
 					src.anchored = 1
 					src.state = 1
 			if(iswelder(P))
-				if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
+				if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH))
+					to_chat(user, SPAN_WARNING("You need a stronger blowtorch!"))
+					return
 				var/obj/item/tool/weldingtool/WT = P
 				if(!WT.isOn())
 					to_chat(user, SPAN_WARNING("\The [WT] needs to be on!"))

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -572,7 +572,7 @@ GLOBAL_LIST_INIT(airlock_wire_descriptions, list(
 	if((iswelder(C) && !operating && density))
 		var/obj/item/tool/weldingtool/W = C
 		var/weldtime = 50
-		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH))
+		if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH))
 			weldtime = 70
 
 		if(not_weldable)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -569,8 +569,11 @@ GLOBAL_LIST_INIT(airlock_wire_descriptions, list(
 
 		return
 
-	if((istype(C, /obj/item/tool/weldingtool) && !operating && density))
+	if((iswelder(C) && !operating && density))
 		var/obj/item/tool/weldingtool/W = C
+		var/weldtime = 50
+		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH))
+			weldtime = 70
 
 		if(not_weldable)
 			to_chat(user, SPAN_WARNING("\The [src] would require something a lot stronger than \the [W] to weld!"))
@@ -583,7 +586,7 @@ GLOBAL_LIST_INIT(airlock_wire_descriptions, list(
 			SPAN_NOTICE("You start working on \the [src] with \the [W]."), \
 			SPAN_NOTICE("You hear welding."))
 			playsound(loc, 'sound/items/weldingtool_weld.ogg', 25)
-			if(do_after(user, 50, INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD) && density)
+			if(do_after(user, weldtime, INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD) && density)
 				if(!welded)
 					welded = 1
 				else

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -175,7 +175,7 @@
 	add_fingerprint(user)
 	if(operating)
 		return//Already doing something.
-	if(istype(C, /obj/item/tool/weldingtool))
+	if(iswelder(C))
 		var/obj/item/tool/weldingtool/W = C
 		if(W.remove_fuel(0, user))
 			blocked = !blocked

--- a/code/game/machinery/fusion_engine.dm
+++ b/code/game/machinery/fusion_engine.dm
@@ -134,6 +134,8 @@
 			to_chat(user, SPAN_WARNING("You need to remove the fuel cell from [src] first."))
 			return TRUE
 	else if(iswelder(O))
+		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH))
+			return
 		if(buildstate == 1)
 			var/obj/item/tool/weldingtool/WT = O
 			if(WT.remove_fuel(1, user))

--- a/code/game/machinery/fusion_engine.dm
+++ b/code/game/machinery/fusion_engine.dm
@@ -135,6 +135,7 @@
 			return TRUE
 	else if(iswelder(O))
 		if(!HAS_TRAIT(O, TRAIT_TOOL_BLOWTORCH))
+			to_chat(user, SPAN_WARNING("You need a stronger blowtorch!"))
 			return
 		if(buildstate == 1)
 			var/obj/item/tool/weldingtool/WT = O

--- a/code/game/machinery/fusion_engine.dm
+++ b/code/game/machinery/fusion_engine.dm
@@ -134,7 +134,7 @@
 			to_chat(user, SPAN_WARNING("You need to remove the fuel cell from [src] first."))
 			return TRUE
 	else if(iswelder(O))
-		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH))
+		if(!HAS_TRAIT(O, TRAIT_TOOL_BLOWTORCH))
 			return
 		if(buildstate == 1)
 			var/obj/item/tool/weldingtool/WT = O

--- a/code/game/machinery/groundmap_geothermal.dm
+++ b/code/game/machinery/groundmap_geothermal.dm
@@ -135,7 +135,7 @@
 
 /obj/structure/machinery/power/geothermal/attackby(var/obj/item/O as obj, var/mob/user as mob)
 	if(iswelder(O))
-		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH))
+		if(!HAS_TRAIT(O, TRAIT_TOOL_BLOWTORCH))
 			return
 		if(buildstate == 1 && !is_on)
 			if(!skillcheck(user, SKILL_ENGINEER, SKILL_ENGINEER_ENGI))
@@ -374,7 +374,7 @@
 			return TRUE
 
 		else if(iswelder(I))
-			if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH))
+			if(!HAS_TRAIT(I, TRAIT_TOOL_BLOWTORCH))
 				return
 			var/obj/item/tool/weldingtool/WT = I
 

--- a/code/game/machinery/groundmap_geothermal.dm
+++ b/code/game/machinery/groundmap_geothermal.dm
@@ -135,6 +135,8 @@
 
 /obj/structure/machinery/power/geothermal/attackby(var/obj/item/O as obj, var/mob/user as mob)
 	if(iswelder(O))
+		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH))
+			return
 		if(buildstate == 1 && !is_on)
 			if(!skillcheck(user, SKILL_ENGINEER, SKILL_ENGINEER_ENGI))
 				to_chat(user, SPAN_WARNING("You have no clue how to repair this thing."))
@@ -372,6 +374,8 @@
 			return TRUE
 
 		else if(iswelder(I))
+			if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH))
+				return
 			var/obj/item/tool/weldingtool/WT = I
 
 			if(!skillcheck(user, SKILL_ENGINEER, SKILL_ENGINEER_ENGI))

--- a/code/game/machinery/groundmap_geothermal.dm
+++ b/code/game/machinery/groundmap_geothermal.dm
@@ -136,6 +136,7 @@
 /obj/structure/machinery/power/geothermal/attackby(var/obj/item/O as obj, var/mob/user as mob)
 	if(iswelder(O))
 		if(!HAS_TRAIT(O, TRAIT_TOOL_BLOWTORCH))
+			to_chat(user, SPAN_WARNING("You need a stronger blowtorch!"))
 			return
 		if(buildstate == 1 && !is_on)
 			if(!skillcheck(user, SKILL_ENGINEER, SKILL_ENGINEER_ENGI))
@@ -375,6 +376,7 @@
 
 		else if(iswelder(I))
 			if(!HAS_TRAIT(I, TRAIT_TOOL_BLOWTORCH))
+				to_chat(user, SPAN_WARNING("You need a stronger blowtorch!"))
 				return
 			var/obj/item/tool/weldingtool/WT = I
 

--- a/code/game/machinery/telecomms/presets.dm
+++ b/code/game/machinery/telecomms/presets.dm
@@ -113,7 +113,7 @@
 
 /obj/structure/machinery/telecomms/relay/preset/tower/attackby(obj/item/I, mob/user)
 	if(iswelder(I))
-		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
+		if(!HAS_TRAIT(I, TRAIT_TOOL_BLOWTORCH)) return
 		if(user.action_busy)
 			return
 		if(!skillcheck(user, SKILL_ENGINEER, SKILL_ENGINEER_TRAINED))

--- a/code/game/machinery/telecomms/presets.dm
+++ b/code/game/machinery/telecomms/presets.dm
@@ -113,7 +113,9 @@
 
 /obj/structure/machinery/telecomms/relay/preset/tower/attackby(obj/item/I, mob/user)
 	if(iswelder(I))
-		if(!HAS_TRAIT(I, TRAIT_TOOL_BLOWTORCH)) return
+		if(!HAS_TRAIT(I, TRAIT_TOOL_BLOWTORCH))
+			to_chat(user, SPAN_WARNING("You need a stronger blowtorch!"))
+			return
 		if(user.action_busy)
 			return
 		if(!skillcheck(user, SKILL_ENGINEER, SKILL_ENGINEER_TRAINED))

--- a/code/game/machinery/telecomms/presets.dm
+++ b/code/game/machinery/telecomms/presets.dm
@@ -113,6 +113,7 @@
 
 /obj/structure/machinery/telecomms/relay/preset/tower/attackby(obj/item/I, mob/user)
 	if(iswelder(I))
+		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
 		if(user.action_busy)
 			return
 		if(!skillcheck(user, SKILL_ENGINEER, SKILL_ENGINEER_TRAINED))

--- a/code/game/machinery/vending/vendor_types/engineering.dm
+++ b/code/game/machinery/vending/vendor_types/engineering.dm
@@ -45,6 +45,7 @@
 		list("Blowtorch", round(scale * 4), /obj/item/tool/weldingtool, VENDOR_ITEM_REGULAR),
 		list("Crowbar", round(scale * 4), /obj/item/tool/crowbar, VENDOR_ITEM_REGULAR),
 		list("High-Capacity Industrial Blowtorch", 2, /obj/item/tool/weldingtool/hugetank, VENDOR_ITEM_REGULAR),
+		list("Old Blowtorch", round(scale * 2), /obj/item/tool/weldingtool/simple, VENDOR_ITEM_REGULAR),
 		list("Screwdriver", round(scale * 4), /obj/item/tool/screwdriver, VENDOR_ITEM_REGULAR),
 		list("Wirecutters", round(scale * 4), /obj/item/tool/wirecutters, VENDOR_ITEM_REGULAR),
 		list("Wrench", round(scale * 4), /obj/item/tool/wrench, VENDOR_ITEM_REGULAR)
@@ -68,7 +69,8 @@
 		list("Screwdriver", round(scale * 4), /obj/item/tool/screwdriver, VENDOR_ITEM_REGULAR),
 		list("Wirecutters", round(scale * 4), /obj/item/tool/wirecutters, VENDOR_ITEM_REGULAR),
 		list("Wrench", round(scale * 4), /obj/item/tool/wrench, VENDOR_ITEM_REGULAR),
-		list("Multitool", round(scale * 4), /obj/item/device/multitool, VENDOR_ITEM_REGULAR)
+		list("Multitool", round(scale * 4), /obj/item/device/multitool, VENDOR_ITEM_REGULAR),
+		list("Old Blowtorch", round(scale * 2), /obj/item/tool/weldingtool/simple, VENDOR_ITEM_REGULAR)
 	)
 
 /obj/structure/machinery/cm_vending/sorted/tech/circuits

--- a/code/game/machinery/vending/vendor_types/engineering.dm
+++ b/code/game/machinery/vending/vendor_types/engineering.dm
@@ -45,7 +45,7 @@
 		list("Blowtorch", round(scale * 4), /obj/item/tool/weldingtool, VENDOR_ITEM_REGULAR),
 		list("Crowbar", round(scale * 4), /obj/item/tool/crowbar, VENDOR_ITEM_REGULAR),
 		list("High-Capacity Industrial Blowtorch", 2, /obj/item/tool/weldingtool/hugetank, VENDOR_ITEM_REGULAR),
-		list("Old Blowtorch", round(scale * 2), /obj/item/tool/weldingtool/simple, VENDOR_ITEM_REGULAR),
+		list("ME3 hand welder", round(scale * 2), /obj/item/tool/weldingtool/simple, VENDOR_ITEM_REGULAR),
 		list("Screwdriver", round(scale * 4), /obj/item/tool/screwdriver, VENDOR_ITEM_REGULAR),
 		list("Wirecutters", round(scale * 4), /obj/item/tool/wirecutters, VENDOR_ITEM_REGULAR),
 		list("Wrench", round(scale * 4), /obj/item/tool/wrench, VENDOR_ITEM_REGULAR)
@@ -70,7 +70,7 @@
 		list("Wirecutters", round(scale * 4), /obj/item/tool/wirecutters, VENDOR_ITEM_REGULAR),
 		list("Wrench", round(scale * 4), /obj/item/tool/wrench, VENDOR_ITEM_REGULAR),
 		list("Multitool", round(scale * 4), /obj/item/device/multitool, VENDOR_ITEM_REGULAR),
-		list("Old Blowtorch", round(scale * 2), /obj/item/tool/weldingtool/simple, VENDOR_ITEM_REGULAR)
+		list("ME3 hand welder", round(scale * 2), /obj/item/tool/weldingtool/simple, VENDOR_ITEM_REGULAR)
 	)
 
 /obj/structure/machinery/cm_vending/sorted/tech/circuits

--- a/code/game/machinery/vending/vendor_types/engineering.dm
+++ b/code/game/machinery/vending/vendor_types/engineering.dm
@@ -70,7 +70,7 @@
 		list("Wirecutters", round(scale * 4), /obj/item/tool/wirecutters, VENDOR_ITEM_REGULAR),
 		list("Wrench", round(scale * 4), /obj/item/tool/wrench, VENDOR_ITEM_REGULAR),
 		list("Multitool", round(scale * 4), /obj/item/device/multitool, VENDOR_ITEM_REGULAR),
-		list("ME3 hand welder", round(scale * 2), /obj/item/tool/weldingtool/simple, VENDOR_ITEM_REGULAR)
+		list("ME3 Hand Welder", round(scale * 2), /obj/item/tool/weldingtool/simple, VENDOR_ITEM_REGULAR)
 	)
 
 /obj/structure/machinery/cm_vending/sorted/tech/circuits

--- a/code/game/machinery/vending/vendor_types/engineering.dm
+++ b/code/game/machinery/vending/vendor_types/engineering.dm
@@ -45,7 +45,7 @@
 		list("Blowtorch", round(scale * 4), /obj/item/tool/weldingtool, VENDOR_ITEM_REGULAR),
 		list("Crowbar", round(scale * 4), /obj/item/tool/crowbar, VENDOR_ITEM_REGULAR),
 		list("High-Capacity Industrial Blowtorch", 2, /obj/item/tool/weldingtool/hugetank, VENDOR_ITEM_REGULAR),
-		list("ME3 hand welder", round(scale * 2), /obj/item/tool/weldingtool/simple, VENDOR_ITEM_REGULAR),
+		list("ME3 Hand Welder", round(scale * 2), /obj/item/tool/weldingtool/simple, VENDOR_ITEM_REGULAR),
 		list("Screwdriver", round(scale * 4), /obj/item/tool/screwdriver, VENDOR_ITEM_REGULAR),
 		list("Wirecutters", round(scale * 4), /obj/item/tool/wirecutters, VENDOR_ITEM_REGULAR),
 		list("Wrench", round(scale * 4), /obj/item/tool/wrench, VENDOR_ITEM_REGULAR)

--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -28,7 +28,7 @@
 
 	var/damage = W.force / 4.0
 
-	if(istype(W, /obj/item/tool/weldingtool))
+	if(iswelder(W))
 		var/obj/item/tool/weldingtool/WT = W
 
 		if(WT.remove_fuel(0, user))

--- a/code/game/objects/items/frames/camera.dm
+++ b/code/game/objects/items/frames/camera.dm
@@ -39,7 +39,9 @@
 		if(1)
 			// State 1
 			if(iswelder(W))
-				if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH)) return
+				if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH))
+					to_chat(user, SPAN_WARNING("You need a stronger blowtorch!"))
+					return
 				if(weld(W, user))
 					to_chat(user, "You weld the assembly securely into place.")
 					anchored = 1
@@ -66,7 +68,9 @@
 				return
 
 			else if(iswelder(W))
-				if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH)) return
+				if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH))
+					to_chat(user, SPAN_WARNING("You need a stronger blowtorch!"))
+					return
 				if(weld(W, user))
 					to_chat(user, "You unweld the assembly from it's place.")
 					state = 1

--- a/code/game/objects/items/frames/camera.dm
+++ b/code/game/objects/items/frames/camera.dm
@@ -39,6 +39,7 @@
 		if(1)
 			// State 1
 			if(iswelder(W))
+				if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
 				if(weld(W, user))
 					to_chat(user, "You weld the assembly securely into place.")
 					anchored = 1
@@ -65,7 +66,7 @@
 				return
 
 			else if(iswelder(W))
-
+				if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
 				if(weld(W, user))
 					to_chat(user, "You unweld the assembly from it's place.")
 					state = 1

--- a/code/game/objects/items/frames/camera.dm
+++ b/code/game/objects/items/frames/camera.dm
@@ -39,7 +39,7 @@
 		if(1)
 			// State 1
 			if(iswelder(W))
-				if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
+				if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH)) return
 				if(weld(W, user))
 					to_chat(user, "You weld the assembly securely into place.")
 					anchored = 1
@@ -66,7 +66,7 @@
 				return
 
 			else if(iswelder(W))
-				if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
+				if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH)) return
 				if(weld(W, user))
 					to_chat(user, "You unweld the assembly from it's place.")
 					state = 1

--- a/code/game/objects/items/shards.dm
+++ b/code/game/objects/items/shards.dm
@@ -42,7 +42,7 @@
 
 /obj/item/shard/attackby(obj/item/W, mob/user)
 	if ( iswelder(W))
-		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
+		if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH)) return
 		var/obj/item/tool/weldingtool/WT = W
 		if(source_sheet_type) //can be melted into something
 			if(WT.remove_fuel(0, user))

--- a/code/game/objects/items/shards.dm
+++ b/code/game/objects/items/shards.dm
@@ -42,7 +42,9 @@
 
 /obj/item/shard/attackby(obj/item/W, mob/user)
 	if ( iswelder(W))
-		if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH)) return
+		if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH))
+			to_chat(user, SPAN_WARNING("You need a stronger blowtorch!"))
+			return
 		var/obj/item/tool/weldingtool/WT = W
 		if(source_sheet_type) //can be melted into something
 			if(WT.remove_fuel(0, user))

--- a/code/game/objects/items/shards.dm
+++ b/code/game/objects/items/shards.dm
@@ -41,7 +41,8 @@
 
 
 /obj/item/shard/attackby(obj/item/W, mob/user)
-	if ( istype(W, /obj/item/tool/weldingtool))
+	if ( iswelder(W))
+		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
 		var/obj/item/tool/weldingtool/WT = W
 		if(source_sheet_type) //can be melted into something
 			if(WT.remove_fuel(0, user))

--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -25,7 +25,7 @@
 	if (!iswelder(W))
 		return ..()
 
-	if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
+	if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH)) return
 
 	var/obj/item/tool/weldingtool/WT = W
 

--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -25,7 +25,9 @@
 	if (!iswelder(W))
 		return ..()
 
-	if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH)) return
+	if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH))
+		to_chat(user, SPAN_WARNING("You need a stronger blowtorch!"))
+		return
 
 	var/obj/item/tool/weldingtool/WT = W
 

--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -22,8 +22,10 @@
 	recipes = GLOB.rod_recipes
 
 /obj/item/stack/rods/attackby(obj/item/W as obj, mob/user as mob)
-	if (!istype(W, /obj/item/tool/weldingtool))
+	if (!iswelder(W))
 		return ..()
+
+	if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
 
 	var/obj/item/tool/weldingtool/WT = W
 

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -725,7 +725,7 @@ GLOBAL_LIST_EMPTY_TYPED(radio_packs, /obj/item/storage/backpack/marine/satchel/r
 
 /obj/item/storage/backpack/marine/engineerpack/attackby(obj/item/W, mob/living/user)
 	if(reagents.total_volume)
-		if(istype(W, /obj/item/tool/weldingtool))
+		if(iswelder(W))
 			var/obj/item/tool/weldingtool/T = W
 			if(T.welding)
 				to_chat(user, SPAN_WARNING("That was close! However, you realized you had the welder on and prevented disaster."))

--- a/code/game/objects/items/tools/flame_tools.dm
+++ b/code/game/objects/items/tools/flame_tools.dm
@@ -49,7 +49,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	. = ..()
 
 /obj/item/tool/candle/attackby(obj/item/W as obj, mob/user as mob)
-	if(istype(W, /obj/item/tool/weldingtool))
+	if(iswelder(W))
 		var/obj/item/tool/weldingtool/WT = W
 		if(WT.isOn()) //Badasses dont get blinded by lighting their candle with a blowtorch
 			light(SPAN_NOTICE("[user] casually lights [src] with [W]."))
@@ -221,7 +221,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 
 /obj/item/clothing/mask/cigarette/attackby(obj/item/W, mob/user)
 	..()
-	if(istype(W, /obj/item/tool/weldingtool))
+	if(iswelder(W))
 		var/obj/item/tool/weldingtool/WT = W
 		if(WT.isOn())//Badasses dont get blinded while lighting their cig with a blowtorch
 			light(SPAN_NOTICE("[user] casually lights the [name] with [W]."))
@@ -511,7 +511,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	chem_volume = 30
 
 /obj/item/clothing/mask/cigarette/cigar/attackby(obj/item/W as obj, mob/user as mob)
-	if(istype(W, /obj/item/tool/weldingtool))
+	if(iswelder(W))
 		var/obj/item/tool/weldingtool/WT = W
 		if(WT.isOn())
 			light(SPAN_NOTICE("[user] insults [name] by lighting it with [W]."))
@@ -613,7 +613,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	..()
 
 /obj/item/clothing/mask/cigarette/pipe/attackby(obj/item/W as obj, mob/user as mob)
-	if(istype(W, /obj/item/tool/weldingtool))
+	if(iswelder(W))
 		var/obj/item/tool/weldingtool/WT = W
 		if(WT.isOn())//
 			light(SPAN_NOTICE("[user] recklessly lights [name] with [W]."))

--- a/code/game/objects/items/tools/maintenance_tools.dm
+++ b/code/game/objects/items/tools/maintenance_tools.dm
@@ -439,8 +439,10 @@
 		reagents = max_fuel
 
 /obj/item/tool/weldingtool/simple
-	name = "simple blowtorch"
+	name = "old blowtorch"
+	desc = "An old model blowtorch with very limited welding fuel capacity and torch strength. However, due to its low strength the light is weak enough to be blocked by a small welding shield on the torch itself. Can only weld doors and vents."
 	max_fuel = 5
+	color = "#cc0000"
 	has_welding_screen = TRUE
 	inherent_traits = (TRAIT_TOOL_SIMPLE_BLOWTORCH)
 

--- a/code/game/objects/items/tools/maintenance_tools.dm
+++ b/code/game/objects/items/tools/maintenance_tools.dm
@@ -164,7 +164,7 @@
 	//Cost to make in the autolathe
 	matter = list("metal" = 70, "glass" = 30)
 
-	inherent_traits = (TRAIT_TOOL_BLOWTORCH)
+	inherent_traits = list(TRAIT_TOOL_BLOWTORCH)
 
 	//blowtorch specific stuff
 	var/welding = 0 	//Whether or not the blowtorch is off(0), on(1) or currently welding(2)
@@ -444,7 +444,7 @@
 	max_fuel = 5
 	color = "#cc0000"
 	has_welding_screen = TRUE
-	inherent_traits = (TRAIT_TOOL_SIMPLE_BLOWTORCH)
+	inherent_traits = list(TRAIT_TOOL_SIMPLE_BLOWTORCH)
 
 /*
  * Crowbar

--- a/code/game/objects/items/tools/maintenance_tools.dm
+++ b/code/game/objects/items/tools/maintenance_tools.dm
@@ -168,7 +168,7 @@
 	var/welding = 0 	//Whether or not the blowtorch is off(0), on(1) or currently welding(2)
 	var/max_fuel = 20 	//The max amount of fuel the welder can hold
 	var/weld_tick = 0	//Used to slowly deplete the fuel when the tool is left on.
-	var/has_welding_screen = TRUE
+	var/has_welding_screen = FALSE
 
 /obj/item/tool/weldingtool/Initialize()
 	. = ..()

--- a/code/game/objects/items/tools/maintenance_tools.dm
+++ b/code/game/objects/items/tools/maintenance_tools.dm
@@ -439,7 +439,7 @@
 		reagents = max_fuel
 
 /obj/item/tool/weldingtool/simple
-	name = "old blowtorch"
+	name = "\improper ME3 hand welder"
 	desc = "An old model blowtorch with very limited welding fuel capacity and torch strength. However, due to its low strength the light is weak enough to be blocked by a small welding shield on the torch itself. Can only weld doors and vents."
 	max_fuel = 5
 	color = "#cc0000"

--- a/code/game/objects/items/tools/maintenance_tools.dm
+++ b/code/game/objects/items/tools/maintenance_tools.dm
@@ -164,6 +164,8 @@
 	//Cost to make in the autolathe
 	matter = list("metal" = 70, "glass" = 30)
 
+	inherent_traits = (TRAIT_TOOL_BLOWTORCH)
+
 	//blowtorch specific stuff
 	var/welding = 0 	//Whether or not the blowtorch is off(0), on(1) or currently welding(2)
 	var/max_fuel = 20 	//The max amount of fuel the welder can hold
@@ -436,6 +438,12 @@
 	if(reagents > max_fuel)
 		reagents = max_fuel
 
+/obj/item/tool/weldingtool/simple
+	name = "simple blowtorch"
+	max_fuel = 5
+	has_welding_screen = TRUE
+	inherent_traits = (TRAIT_TOOL_SIMPLE_BLOWTORCH)
+
 /*
  * Crowbar
  */
@@ -491,7 +499,7 @@
 	original_health = health
 
 /obj/item/tool/weldpack/attackby(obj/item/W as obj, mob/user as mob)
-	if(istype(W, /obj/item/tool/weldingtool))
+	if(iswelder(W))
 		var/obj/item/tool/weldingtool/T = W
 		if(T.welding & prob(50))
 			message_admins("[key_name_admin(user)] triggered a fueltank explosion.")

--- a/code/game/objects/items/tools/maintenance_tools.dm
+++ b/code/game/objects/items/tools/maintenance_tools.dm
@@ -440,7 +440,7 @@
 
 /obj/item/tool/weldingtool/simple
 	name = "\improper ME3 hand welder"
-	desc = "An old model blowtorch with very limited welding fuel capacity and torch strength. However, due to its low strength the light is weak enough to be blocked by a small welding shield on the torch itself. Can only weld doors and vents."
+	desc = "A compact, handheld welding torch used by the marines of the United States Colonial Marine Corps for cutting and welding jobs on the field. Due to the small size and slow strength, its function is limited compared to a full sized technician's blowtorch."
 	max_fuel = 5
 	color = "#cc0000"
 	has_welding_screen = TRUE

--- a/code/game/objects/structures/airlock_assembly.dm
+++ b/code/game/objects/structures/airlock_assembly.dm
@@ -157,7 +157,7 @@
 
 		if(STATE_SCREWDRIVER)
 			if(iswelder(W))
-				if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
+				if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH)) return
 				var/obj/item/tool/weldingtool/WT = W
 				if(!WT.remove_fuel(5, user))
 					return

--- a/code/game/objects/structures/airlock_assembly.dm
+++ b/code/game/objects/structures/airlock_assembly.dm
@@ -157,7 +157,9 @@
 
 		if(STATE_SCREWDRIVER)
 			if(iswelder(W))
-				if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH)) return
+				if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH))
+					to_chat(user, SPAN_WARNING("You need a stronger blowtorch!"))
+					return
 				var/obj/item/tool/weldingtool/WT = W
 				if(!WT.remove_fuel(5, user))
 					return

--- a/code/game/objects/structures/airlock_assembly.dm
+++ b/code/game/objects/structures/airlock_assembly.dm
@@ -157,6 +157,7 @@
 
 		if(STATE_SCREWDRIVER)
 			if(iswelder(W))
+				if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
 				var/obj/item/tool/weldingtool/WT = W
 				if(!WT.remove_fuel(5, user))
 					return

--- a/code/game/objects/structures/barricade/deployable.dm
+++ b/code/game/objects/structures/barricade/deployable.dm
@@ -26,7 +26,9 @@
 /obj/structure/barricade/deployable/attackby(obj/item/W, mob/user)
 
 	if(iswelder(W))
-		if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH)) return
+		if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH))
+			to_chat(user, SPAN_WARNING("You need a stronger blowtorch!"))
+			return
 		if(user.action_busy)
 			return
 		var/obj/item/tool/weldingtool/WT = W
@@ -205,7 +207,9 @@
 		return
 
 	else if(iswelder(W))
-		if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH)) return
+		if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH))
+			to_chat(user, SPAN_WARNING("You need a stronger blowtorch!"))
+			return
 		if(src != user.get_inactive_hand())
 			to_chat(user, SPAN_WARNING("You need to hold [src.singular_name] in hand or deploy to repair it."))
 			return

--- a/code/game/objects/structures/barricade/deployable.dm
+++ b/code/game/objects/structures/barricade/deployable.dm
@@ -26,6 +26,7 @@
 /obj/structure/barricade/deployable/attackby(obj/item/W, mob/user)
 
 	if(iswelder(W))
+		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
 		if(user.action_busy)
 			return
 		var/obj/item/tool/weldingtool/WT = W
@@ -204,6 +205,7 @@
 		return
 
 	else if(iswelder(W))
+		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
 		if(src != user.get_inactive_hand())
 			to_chat(user, SPAN_WARNING("You need to hold [src.singular_name] in hand or deploy to repair it."))
 			return

--- a/code/game/objects/structures/barricade/deployable.dm
+++ b/code/game/objects/structures/barricade/deployable.dm
@@ -26,7 +26,7 @@
 /obj/structure/barricade/deployable/attackby(obj/item/W, mob/user)
 
 	if(iswelder(W))
-		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
+		if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH)) return
 		if(user.action_busy)
 			return
 		var/obj/item/tool/weldingtool/WT = W
@@ -205,7 +205,7 @@
 		return
 
 	else if(iswelder(W))
-		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
+		if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH)) return
 		if(src != user.get_inactive_hand())
 			to_chat(user, SPAN_WARNING("You need to hold [src.singular_name] in hand or deploy to repair it."))
 			return

--- a/code/game/objects/structures/barricade/handrail.dm
+++ b/code/game/objects/structures/barricade/handrail.dm
@@ -153,7 +153,7 @@
 					return
 			else
 				if(iswelder(W))	// Finish reinforcing
-					if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
+					if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH)) return
 					if(user.action_busy)
 						return
 					if(!skillcheck(user, SKILL_CONSTRUCTION, SKILL_CONSTRUCTION_TRAINED))

--- a/code/game/objects/structures/barricade/handrail.dm
+++ b/code/game/objects/structures/barricade/handrail.dm
@@ -153,6 +153,7 @@
 					return
 			else
 				if(iswelder(W))	// Finish reinforcing
+					if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
 					if(user.action_busy)
 						return
 					if(!skillcheck(user, SKILL_CONSTRUCTION, SKILL_CONSTRUCTION_TRAINED))

--- a/code/game/objects/structures/barricade/handrail.dm
+++ b/code/game/objects/structures/barricade/handrail.dm
@@ -153,7 +153,9 @@
 					return
 			else
 				if(iswelder(W))	// Finish reinforcing
-					if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH)) return
+					if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH))
+						to_chat(user, SPAN_WARNING("You need a stronger blowtorch!"))
+						return
 					if(user.action_busy)
 						return
 					if(!skillcheck(user, SKILL_CONSTRUCTION, SKILL_CONSTRUCTION_TRAINED))

--- a/code/game/objects/structures/barricade/metal.dm
+++ b/code/game/objects/structures/barricade/metal.dm
@@ -39,7 +39,7 @@
 
 /obj/structure/barricade/metal/attackby(obj/item/W, mob/user)
 	if(iswelder(W))
-		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
+		if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH)) return
 		if(user.action_busy)
 			return
 		if(!skillcheck(user, SKILL_ENGINEER, SKILL_ENGINEER_TRAINED))

--- a/code/game/objects/structures/barricade/metal.dm
+++ b/code/game/objects/structures/barricade/metal.dm
@@ -39,7 +39,9 @@
 
 /obj/structure/barricade/metal/attackby(obj/item/W, mob/user)
 	if(iswelder(W))
-		if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH)) return
+		if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH))
+			to_chat(user, SPAN_WARNING("You need a stronger blowtorch!"))
+			return
 		if(user.action_busy)
 			return
 		if(!skillcheck(user, SKILL_ENGINEER, SKILL_ENGINEER_TRAINED))

--- a/code/game/objects/structures/barricade/metal.dm
+++ b/code/game/objects/structures/barricade/metal.dm
@@ -39,6 +39,7 @@
 
 /obj/structure/barricade/metal/attackby(obj/item/W, mob/user)
 	if(iswelder(W))
+		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
 		if(user.action_busy)
 			return
 		if(!skillcheck(user, SKILL_ENGINEER, SKILL_ENGINEER_TRAINED))

--- a/code/game/objects/structures/barricade/plasteel.dm
+++ b/code/game/objects/structures/barricade/plasteel.dm
@@ -64,7 +64,9 @@
 
 /obj/structure/barricade/plasteel/attackby(obj/item/W, mob/user)
 	if(iswelder(W))
-		if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH)) return
+		if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH))
+			to_chat(user, SPAN_WARNING("You need a stronger blowtorch!"))
+			return
 		if(busy || tool_cooldown > world.time)
 			return
 		tool_cooldown = world.time + 10

--- a/code/game/objects/structures/barricade/plasteel.dm
+++ b/code/game/objects/structures/barricade/plasteel.dm
@@ -64,7 +64,7 @@
 
 /obj/structure/barricade/plasteel/attackby(obj/item/W, mob/user)
 	if(iswelder(W))
-		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
+		if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH)) return
 		if(busy || tool_cooldown > world.time)
 			return
 		tool_cooldown = world.time + 10

--- a/code/game/objects/structures/barricade/plasteel.dm
+++ b/code/game/objects/structures/barricade/plasteel.dm
@@ -64,6 +64,7 @@
 
 /obj/structure/barricade/plasteel/attackby(obj/item/W, mob/user)
 	if(iswelder(W))
+		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
 		if(busy || tool_cooldown > world.time)
 			return
 		tool_cooldown = world.time + 10

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -211,7 +211,7 @@
 		if(W.flags_item & ITEM_ABSTRACT)
 			return 0
 		if(iswelder(W))
-			if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
+			if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH)) return
 			var/obj/item/tool/weldingtool/WT = W
 			if(!WT.isOn())
 				to_chat(user, SPAN_WARNING("\The [WT] needs to be on!"))
@@ -234,7 +234,7 @@
 	else if(istype(W, /obj/item/packageWrap) || istype(W, /obj/item/explosive/plastic))
 		return
 	else if(iswelder(W))
-		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
+		if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH)) return
 		var/obj/item/tool/weldingtool/WT = W
 		if(!WT.isOn())
 			to_chat(user, SPAN_WARNING("\The [WT] needs to be on!"))

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -210,7 +210,8 @@
 			return
 		if(W.flags_item & ITEM_ABSTRACT)
 			return 0
-		if(istype(W, /obj/item/tool/weldingtool))
+		if(iswelder(W))
+			if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
 			var/obj/item/tool/weldingtool/WT = W
 			if(!WT.isOn())
 				to_chat(user, SPAN_WARNING("\The [WT] needs to be on!"))
@@ -232,7 +233,8 @@
 
 	else if(istype(W, /obj/item/packageWrap) || istype(W, /obj/item/explosive/plastic))
 		return
-	else if(istype(W, /obj/item/tool/weldingtool))
+	else if(iswelder(W))
+		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
 		var/obj/item/tool/weldingtool/WT = W
 		if(!WT.isOn())
 			to_chat(user, SPAN_WARNING("\The [WT] needs to be on!"))

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -211,7 +211,9 @@
 		if(W.flags_item & ITEM_ABSTRACT)
 			return 0
 		if(iswelder(W))
-			if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH)) return
+			if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH))
+				to_chat(user, SPAN_WARNING("You need a stronger blowtorch!"))
+				return
 			var/obj/item/tool/weldingtool/WT = W
 			if(!WT.isOn())
 				to_chat(user, SPAN_WARNING("\The [WT] needs to be on!"))
@@ -234,7 +236,9 @@
 	else if(istype(W, /obj/item/packageWrap) || istype(W, /obj/item/explosive/plastic))
 		return
 	else if(iswelder(W))
-		if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH)) return
+		if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH))
+			to_chat(user, SPAN_WARNING("You need a stronger blowtorch!"))
+			return
 		var/obj/item/tool/weldingtool/WT = W
 		if(!WT.isOn())
 			to_chat(user, SPAN_WARNING("\The [WT] needs to be on!"))

--- a/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
@@ -96,7 +96,9 @@
 	else if(istype(W, /obj/item/packageWrap) || istype(W, /obj/item/explosive/plastic))
 		return
 	else if(iswelder(W))
-		if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH)) return
+		if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH))
+			to_chat(user, SPAN_WARNING("You need a stronger blowtorch!"))
+			return
 		return ..(W,user)
 	else
 		if(isXeno(user))

--- a/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
@@ -95,7 +95,8 @@
 		user.drop_inv_item_to_loc(W, loc)
 	else if(istype(W, /obj/item/packageWrap) || istype(W, /obj/item/explosive/plastic))
 		return
-	else if(istype(W,/obj/item/tool/weldingtool))
+	else if(iswelder(W))
+		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
 		return ..(W,user)
 	else
 		if(isXeno(user))

--- a/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
@@ -96,7 +96,7 @@
 	else if(istype(W, /obj/item/packageWrap) || istype(W, /obj/item/explosive/plastic))
 		return
 	else if(iswelder(W))
-		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
+		if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH)) return
 		return ..(W,user)
 	else
 		if(isXeno(user))

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -106,7 +106,7 @@
 		if(change_state(W, user))
 			return
 	else if(iswelder(W))
-		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
+		if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH)) return
 		if(do_after(user,30, INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD))
 			if(QDELETED(src))
 				return
@@ -232,7 +232,7 @@
 		return TRUE
 
 	if(iswelder(W) && step_state == STATE_SCREWDRIVER)
-		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
+		if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH)) return
 		var/obj/item/tool/weldingtool/WT = W
 		if(WT.remove_fuel(5, user))
 			to_chat(user, SPAN_NOTICE("You start welding the new additions."))
@@ -279,7 +279,7 @@
 		return TRUE
 
 	if(iswelder(W) && step_state == STATE_SCREWDRIVER)
-		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
+		if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH)) return
 		var/obj/item/tool/weldingtool/WT = W
 		if(WT.remove_fuel(5, user))
 			to_chat(user, SPAN_NOTICE("You start welding the new additions."))

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -106,6 +106,7 @@
 		if(change_state(W, user))
 			return
 	else if(iswelder(W))
+		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
 		if(do_after(user,30, INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD))
 			if(QDELETED(src))
 				return
@@ -231,6 +232,7 @@
 		return TRUE
 
 	if(iswelder(W) && step_state == STATE_SCREWDRIVER)
+		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
 		var/obj/item/tool/weldingtool/WT = W
 		if(WT.remove_fuel(5, user))
 			to_chat(user, SPAN_NOTICE("You start welding the new additions."))
@@ -277,6 +279,7 @@
 		return TRUE
 
 	if(iswelder(W) && step_state == STATE_SCREWDRIVER)
+		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
 		var/obj/item/tool/weldingtool/WT = W
 		if(WT.remove_fuel(5, user))
 			to_chat(user, SPAN_NOTICE("You start welding the new additions."))

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -106,7 +106,9 @@
 		if(change_state(W, user))
 			return
 	else if(iswelder(W))
-		if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH)) return
+		if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH))
+			to_chat(user, SPAN_WARNING("You need a stronger blowtorch!"))
+			return
 		if(do_after(user,30, INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD))
 			if(QDELETED(src))
 				return
@@ -232,7 +234,9 @@
 		return TRUE
 
 	if(iswelder(W) && step_state == STATE_SCREWDRIVER)
-		if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH)) return
+		if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH))
+			to_chat(user, SPAN_WARNING("You need a stronger blowtorch!"))
+			return
 		var/obj/item/tool/weldingtool/WT = W
 		if(WT.remove_fuel(5, user))
 			to_chat(user, SPAN_NOTICE("You start welding the new additions."))
@@ -279,7 +283,9 @@
 		return TRUE
 
 	if(iswelder(W) && step_state == STATE_SCREWDRIVER)
-		if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH)) return
+		if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH))
+			to_chat(user, SPAN_WARNING("You need a stronger blowtorch!"))
+			return
 		var/obj/item/tool/weldingtool/WT = W
 		if(WT.remove_fuel(5, user))
 			to_chat(user, SPAN_NOTICE("You start welding the new additions."))

--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -52,7 +52,7 @@
 		T.attackby(C, user) //BubbleWrap - hand this off to the underlying turf instead
 		return
 	if (iswelder(C))
-		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
+		if(!HAS_TRAIT(C, TRAIT_TOOL_BLOWTORCH)) return
 		var/obj/item/tool/weldingtool/WT = C
 		if(WT.remove_fuel(0, user))
 			to_chat(user, SPAN_NOTICE(" Slicing lattice joints ..."))

--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -51,7 +51,8 @@
 		var/turf/T = get_turf(src)
 		T.attackby(C, user) //BubbleWrap - hand this off to the underlying turf instead
 		return
-	if (istype(C, /obj/item/tool/weldingtool))
+	if (iswelder(C))
+		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
 		var/obj/item/tool/weldingtool/WT = C
 		if(WT.remove_fuel(0, user))
 			to_chat(user, SPAN_NOTICE(" Slicing lattice joints ..."))

--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -52,7 +52,9 @@
 		T.attackby(C, user) //BubbleWrap - hand this off to the underlying turf instead
 		return
 	if (iswelder(C))
-		if(!HAS_TRAIT(C, TRAIT_TOOL_BLOWTORCH)) return
+		if(!HAS_TRAIT(C, TRAIT_TOOL_BLOWTORCH))
+			to_chat(user, SPAN_WARNING("You need a stronger blowtorch!"))
+			return
 		var/obj/item/tool/weldingtool/WT = C
 		if(WT.remove_fuel(0, user))
 			to_chat(user, SPAN_NOTICE(" Slicing lattice joints ..."))

--- a/code/game/objects/structures/mineral_doors.dm
+++ b/code/game/objects/structures/mineral_doors.dm
@@ -45,7 +45,7 @@
 			return NO_BLOCKED_MOVEMENT
 		else
 			return BLOCKED_MOVEMENT
-	
+
 	return ..()
 
 /obj/structure/mineral_door/proc/TryToSwitchState(atom/user)
@@ -188,7 +188,7 @@
 	mineralType = "phoron"
 
 /obj/structure/mineral_door/transparent/phoron/attackby(obj/item/W as obj, mob/user as mob)
-	if(istype(W,/obj/item/tool/weldingtool))
+	if(iswelder(W))
 		var/obj/item/tool/weldingtool/WT = W
 		if(WT.remove_fuel(0, user))
 			TemperatureAct(100)

--- a/code/game/objects/structures/pipes/vents/vents.dm
+++ b/code/game/objects/structures/pipes/vents/vents.dm
@@ -74,7 +74,7 @@
 /obj/structure/pipes/vents/attackby(obj/item/W, mob/user)
 	if(iswelder(W))
 		var/weldtime = 50
-		if(HAS_TRAIT(P, TRAIT_TOOL_SIMPLE_BLOWTORCH))
+		if(HAS_TRAIT(W, TRAIT_TOOL_SIMPLE_BLOWTORCH))
 			weldtime = 60
 		var/obj/item/tool/weldingtool/WT = W
 		if(WT.remove_fuel(1, user))

--- a/code/game/objects/structures/pipes/vents/vents.dm
+++ b/code/game/objects/structures/pipes/vents/vents.dm
@@ -73,30 +73,33 @@
 
 /obj/structure/pipes/vents/attackby(obj/item/W, mob/user)
 	if(iswelder(W))
+		var/weldtime = 50
+		if(HAS_TRAIT(P, TRAIT_TOOL_SIMPLE_BLOWTORCH))
+			weldtime = 60
 		var/obj/item/tool/weldingtool/WT = W
 		if(WT.remove_fuel(1, user))
-			user.visible_message(SPAN_NOTICE("[user] starts welding [src] with [WT]."), \
-			SPAN_NOTICE("You start welding [src] with [WT]."))
+			user.visible_message(SPAN_NOTICE("[user] starts welding \the [src] with \the [WT]."), \
+			SPAN_NOTICE("You start welding \the [src] with \the [WT]."))
 			playsound(loc, 'sound/items/weldingtool_weld.ogg', 25)
-			if(do_after(user, 50 * user.get_skill_duration_multiplier(SKILL_CONSTRUCTION), INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD))
+			if(do_after(user, weldtime * user.get_skill_duration_multiplier(SKILL_CONSTRUCTION), INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD))
 				if(!src || !WT.isOn()) return 0
 				playsound(get_turf(src), 'sound/items/Welder2.ogg', 25, 1)
 				if(!welded)
-					user.visible_message(SPAN_NOTICE("[user] welds [src] shut."), \
-					SPAN_NOTICE("You weld [src] shut."))
+					user.visible_message(SPAN_NOTICE("[user] welds \the [src] shut."), \
+					SPAN_NOTICE("You weld \the [src] shut."))
 					welded = 1
 					update_icon()
 					msg_admin_niche("[key_name(user)] welded a vent pump.")
 					return 1
 				else
-					user.visible_message(SPAN_NOTICE("[user] welds [src] open."), \
-					SPAN_NOTICE("You weld [src] open."))
+					user.visible_message(SPAN_NOTICE("[user] welds \the [src] open."), \
+					SPAN_NOTICE("You weld \the [src] open."))
 					welded = 0
 					msg_admin_niche("[key_name(user)] un-welded a vent pump.")
 					update_icon()
 					return 1
 			else
-				to_chat(user, SPAN_WARNING("[W] needs to be on to start this task."))
+				to_chat(user, SPAN_WARNING("\The [W] needs to be on to start this task."))
 				return 0
 		else
 			to_chat(user, SPAN_WARNING("You need more welding fuel to complete this task."))

--- a/code/game/objects/structures/props.dm
+++ b/code/game/objects/structures/props.dm
@@ -107,7 +107,7 @@
 	var/L
 	if(lit)
 		return
-	if(istype(W, /obj/item/tool/weldingtool))
+	if(iswelder(W))
 		var/obj/item/tool/weldingtool/WT = W
 		if(WT.isOn())
 			L = 1

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -445,7 +445,8 @@
 	if(HAS_TRAIT(W, TRAIT_TOOL_WRENCH) && chair_state == DROPSHIP_CHAIR_BROKEN)
 		to_chat(user, SPAN_WARNING("\The [src] appears to be broken and needs welding."))
 		return
-	else if((istype(W, /obj/item/tool/weldingtool) && chair_state == DROPSHIP_CHAIR_BROKEN))
+	else if((iswelder(W) && chair_state == DROPSHIP_CHAIR_BROKEN))
+		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
 		var/obj/item/tool/weldingtool/C = W
 		if(C.remove_fuel(0,user))
 			playsound(src.loc, 'sound/items/weldingtool_weld.ogg', 25)
@@ -483,7 +484,8 @@
 			if(DROPSHIP_CHAIR_BROKEN)
 				to_chat(user, SPAN_WARNING("\The [src] appears to be broken and needs welding."))
 				return
-	else if((istype(W, /obj/item/tool/weldingtool) && chair_state == DROPSHIP_CHAIR_BROKEN))
+	else if((iswelder(W) && chair_state == DROPSHIP_CHAIR_BROKEN))
+		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
 		var/obj/item/tool/weldingtool/C = W
 		if(C.remove_fuel(0,user))
 			playsound(src.loc, 'sound/items/weldingtool_weld.ogg', 25)

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -446,7 +446,9 @@
 		to_chat(user, SPAN_WARNING("\The [src] appears to be broken and needs welding."))
 		return
 	else if((iswelder(W) && chair_state == DROPSHIP_CHAIR_BROKEN))
-		if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH)) return
+		if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH))
+			to_chat(user, SPAN_WARNING("You need a stronger blowtorch!"))
+			return
 		var/obj/item/tool/weldingtool/C = W
 		if(C.remove_fuel(0,user))
 			playsound(src.loc, 'sound/items/weldingtool_weld.ogg', 25)
@@ -485,7 +487,9 @@
 				to_chat(user, SPAN_WARNING("\The [src] appears to be broken and needs welding."))
 				return
 	else if((iswelder(W) && chair_state == DROPSHIP_CHAIR_BROKEN))
-		if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH)) return
+		if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH))
+			to_chat(user, SPAN_WARNING("You need a stronger blowtorch!"))
+			return
 		var/obj/item/tool/weldingtool/C = W
 		if(C.remove_fuel(0,user))
 			playsound(src.loc, 'sound/items/weldingtool_weld.ogg', 25)

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -446,7 +446,7 @@
 		to_chat(user, SPAN_WARNING("\The [src] appears to be broken and needs welding."))
 		return
 	else if((iswelder(W) && chair_state == DROPSHIP_CHAIR_BROKEN))
-		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
+		if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH)) return
 		var/obj/item/tool/weldingtool/C = W
 		if(C.remove_fuel(0,user))
 			playsound(src.loc, 'sound/items/weldingtool_weld.ogg', 25)
@@ -485,7 +485,7 @@
 				to_chat(user, SPAN_WARNING("\The [src] appears to be broken and needs welding."))
 				return
 	else if((iswelder(W) && chair_state == DROPSHIP_CHAIR_BROKEN))
-		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
+		if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH)) return
 		var/obj/item/tool/weldingtool/C = W
 		if(C.remove_fuel(0,user))
 			playsound(src.loc, 'sound/items/weldingtool_weld.ogg', 25)

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -503,7 +503,7 @@
 
 /obj/structure/surface/table/reinforced/attackby(obj/item/W as obj, mob/user as mob)
 	if (iswelder(W))
-		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
+		if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH)) return
 		var/obj/item/tool/weldingtool/WT = W
 		if(WT.remove_fuel(0, user))
 			if(status == 2)

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -502,7 +502,8 @@
 	return 0 //No, just no. It's a full desk, you can't flip that
 
 /obj/structure/surface/table/reinforced/attackby(obj/item/W as obj, mob/user as mob)
-	if (istype(W, /obj/item/tool/weldingtool))
+	if (iswelder(W))
+		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
 		var/obj/item/tool/weldingtool/WT = W
 		if(WT.remove_fuel(0, user))
 			if(status == 2)

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -503,7 +503,9 @@
 
 /obj/structure/surface/table/reinforced/attackby(obj/item/W as obj, mob/user as mob)
 	if (iswelder(W))
-		if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH)) return
+		if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH))
+			to_chat(user, SPAN_WARNING("You need a stronger blowtorch!"))
+			return
 		var/obj/item/tool/weldingtool/WT = W
 		if(WT.remove_fuel(0, user))
 			if(status == 2)

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -49,7 +49,9 @@ obj/structure/windoor_assembly/Destroy()
 	switch(state)
 		if("01")
 			if(iswelder(W) && !anchored )
-				if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH)) return
+				if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH))
+					to_chat(user, SPAN_WARNING("You need a stronger blowtorch!"))
+					return
 				var/obj/item/tool/weldingtool/WT = W
 				if (WT.remove_fuel(0,user))
 					user.visible_message("[user] dissassembles the windoor assembly.", "You start to dissassemble the windoor assembly.")

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -49,7 +49,7 @@ obj/structure/windoor_assembly/Destroy()
 	switch(state)
 		if("01")
 			if(iswelder(W) && !anchored )
-				if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
+				if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH)) return
 				var/obj/item/tool/weldingtool/WT = W
 				if (WT.remove_fuel(0,user))
 					user.visible_message("[user] dissassembles the windoor assembly.", "You start to dissassemble the windoor assembly.")

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -48,7 +48,8 @@ obj/structure/windoor_assembly/Destroy()
 	//I really should have spread this out across more states but thin little windoors are hard to sprite.
 	switch(state)
 		if("01")
-			if(istype(W, /obj/item/tool/weldingtool) && !anchored )
+			if(iswelder(W) && !anchored )
+				if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
 				var/obj/item/tool/weldingtool/WT = W
 				if (WT.remove_fuel(0,user))
 					user.visible_message("[user] dissassembles the windoor assembly.", "You start to dissassemble the windoor assembly.")

--- a/code/game/turfs/floor_types.dm
+++ b/code/game/turfs/floor_types.dm
@@ -49,7 +49,9 @@
 		coil.turf_place(src, user)
 		return
 	if(iswelder(C))
-		if(!HAS_TRAIT(C, TRAIT_TOOL_BLOWTORCH)) return
+		if(!HAS_TRAIT(C, TRAIT_TOOL_BLOWTORCH))
+			to_chat(user, SPAN_WARNING("You need a stronger blowtorch!"))
+			return
 		var/obj/item/tool/weldingtool/welder = C
 		if(welder.isOn() && (broken || burnt))
 			if(welder.remove_fuel(0, user))

--- a/code/game/turfs/floor_types.dm
+++ b/code/game/turfs/floor_types.dm
@@ -49,7 +49,7 @@
 		coil.turf_place(src, user)
 		return
 	if(iswelder(C))
-		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
+		if(!HAS_TRAIT(C, TRAIT_TOOL_BLOWTORCH)) return
 		var/obj/item/tool/weldingtool/welder = C
 		if(welder.isOn() && (broken || burnt))
 			if(welder.remove_fuel(0, user))

--- a/code/game/turfs/floor_types.dm
+++ b/code/game/turfs/floor_types.dm
@@ -48,7 +48,8 @@
 		var/obj/item/stack/cable_coil/coil = C
 		coil.turf_place(src, user)
 		return
-	if(istype(C, /obj/item/tool/weldingtool))
+	if(iswelder(C))
+		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
 		var/obj/item/tool/weldingtool/welder = C
 		if(welder.isOn() && (broken || burnt))
 			if(welder.remove_fuel(0, user))

--- a/code/game/turfs/walls/r_wall.dm
+++ b/code/game/turfs/walls/r_wall.dm
@@ -61,7 +61,7 @@
 	switch(d_state)
 		if(WALL_STATE_WELD)
 			if(iswelder(W))
-				if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
+				if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH)) return
 				var/obj/item/tool/weldingtool/WT = W
 				try_weldingtool_deconstruction(WT, user)
 

--- a/code/game/turfs/walls/r_wall.dm
+++ b/code/game/turfs/walls/r_wall.dm
@@ -29,7 +29,7 @@
 			if(hull)
 				to_chat(user, SPAN_WARNING("[src] is much too tough for you to do anything to it with [W]."))
 			else
-				if(istype(W, /obj/item/tool/weldingtool))
+				if(iswelder(W))
 					var/obj/item/tool/weldingtool/WT = W
 					WT.remove_fuel(0,user)
 				thermitemelt(user)
@@ -61,6 +61,7 @@
 	switch(d_state)
 		if(WALL_STATE_WELD)
 			if(iswelder(W))
+				if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
 				var/obj/item/tool/weldingtool/WT = W
 				try_weldingtool_deconstruction(WT, user)
 

--- a/code/game/turfs/walls/r_wall.dm
+++ b/code/game/turfs/walls/r_wall.dm
@@ -61,7 +61,9 @@
 	switch(d_state)
 		if(WALL_STATE_WELD)
 			if(iswelder(W))
-				if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH)) return
+				if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH))
+					to_chat(user, SPAN_WARNING("You need a stronger blowtorch!"))
+					return
 				var/obj/item/tool/weldingtool/WT = W
 				try_weldingtool_deconstruction(WT, user)
 

--- a/code/game/turfs/walls/walls.dm
+++ b/code/game/turfs/walls/walls.dm
@@ -381,7 +381,9 @@
 	switch(d_state)
 		if(WALL_STATE_WELD)
 			if(iswelder(W))
-				if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH)) return
+				if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH))
+					to_chat(user, SPAN_WARNING("You need a stronger blowtorch!"))
+					return
 				var/obj/item/tool/weldingtool/WT = W
 				try_weldingtool_deconstruction(WT, user)
 

--- a/code/game/turfs/walls/walls.dm
+++ b/code/game/turfs/walls/walls.dm
@@ -312,7 +312,7 @@
 			if(hull)
 				to_chat(user, SPAN_WARNING("[src] is much too tough for you to do anything to it with [W]."))
 			else
-				if(istype(W, /obj/item/tool/weldingtool))
+				if(iswelder(W))
 					var/obj/item/tool/weldingtool/WT = W
 					WT.remove_fuel(0,user)
 				thermitemelt(user)
@@ -381,6 +381,7 @@
 	switch(d_state)
 		if(WALL_STATE_WELD)
 			if(iswelder(W))
+				if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
 				var/obj/item/tool/weldingtool/WT = W
 				try_weldingtool_deconstruction(WT, user)
 
@@ -432,7 +433,7 @@
 	return attack_hand(user)
 
 /turf/closed/wall/proc/try_weldingtool_usage(obj/item/W, mob/user)
-	if(!damage || !istype(W, /obj/item/tool/weldingtool))
+	if(!damage || !iswelder(W))
 		return FALSE
 
 	var/obj/item/tool/weldingtool/WT = W

--- a/code/game/turfs/walls/walls.dm
+++ b/code/game/turfs/walls/walls.dm
@@ -381,7 +381,7 @@
 	switch(d_state)
 		if(WALL_STATE_WELD)
 			if(iswelder(W))
-				if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
+				if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH)) return
 				var/obj/item/tool/weldingtool/WT = W
 				try_weldingtool_deconstruction(WT, user)
 

--- a/code/modules/clothing/spacesuits/breaches.dm
+++ b/code/modules/clothing/spacesuits/breaches.dm
@@ -196,7 +196,7 @@ var/global/list/breach_burn_descriptors = list(
 
 	else if(iswelder(W))
 
-		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
+		if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH)) return
 
 		if(istype(src.loc,/mob/living))
 			to_chat(user, SPAN_DANGER("How do you intend to patch a hardsuit while someone is wearing it?"))

--- a/code/modules/clothing/spacesuits/breaches.dm
+++ b/code/modules/clothing/spacesuits/breaches.dm
@@ -196,7 +196,9 @@ var/global/list/breach_burn_descriptors = list(
 
 	else if(iswelder(W))
 
-		if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH)) return
+		if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH))
+			to_chat(user, SPAN_WARNING("You need a stronger blowtorch!"))
+			return
 
 		if(istype(src.loc,/mob/living))
 			to_chat(user, SPAN_DANGER("How do you intend to patch a hardsuit while someone is wearing it?"))

--- a/code/modules/clothing/spacesuits/breaches.dm
+++ b/code/modules/clothing/spacesuits/breaches.dm
@@ -194,7 +194,9 @@ var/global/list/breach_burn_descriptors = list(
 			repair_breaches(BURN, ( istype(P,/obj/item/stack/sheet/mineral/plastic) ? 3 : 5), user)
 		return
 
-	else if(istype(W, /obj/item/tool/weldingtool))
+	else if(iswelder(W))
+
+		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
 
 		if(istype(src.loc,/mob/living))
 			to_chat(user, SPAN_DANGER("How do you intend to patch a hardsuit while someone is wearing it?"))

--- a/code/modules/cm_aliens/structures/egg.dm
+++ b/code/modules/cm_aliens/structures/egg.dm
@@ -207,7 +207,7 @@
 	var/damage = W.force
 	if(W.w_class < SIZE_LARGE || !W.sharp || W.force < 20) //only big strong sharp weapon are adequate
 		damage /= 4
-	if(istype(W, /obj/item/tool/weldingtool))
+	if(iswelder(W))
 		var/obj/item/tool/weldingtool/WT = W
 
 		if(WT.remove_fuel(0, user))

--- a/code/modules/cm_marines/smartgun_mount.dm
+++ b/code/modules/cm_marines/smartgun_mount.dm
@@ -164,7 +164,9 @@
 
 /obj/item/device/m56d_post_frame/attackby(obj/item/W as obj, mob/user as mob)
 	if (iswelder(W))
-		if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH)) return
+		if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH))
+			to_chat(user, SPAN_WARNING("You need a stronger blowtorch!"))
+			return
 		var/obj/item/tool/weldingtool/WT = W
 
 		if(WT.remove_fuel(1, user))
@@ -564,7 +566,9 @@
 		return
 
 	if(iswelder(O))
-		if(!HAS_TRAIT(O, TRAIT_TOOL_BLOWTORCH)) return
+		if(!HAS_TRAIT(O, TRAIT_TOOL_BLOWTORCH))
+			to_chat(user, SPAN_WARNING("You need a stronger blowtorch!"))
+			return
 		if(user.action_busy)
 			return
 
@@ -1103,7 +1107,9 @@
 	if(!iswelder(O) || user.action_busy)
 		return
 
-	if(!HAS_TRAIT(O, TRAIT_TOOL_BLOWTORCH)) return
+	if(!HAS_TRAIT(O, TRAIT_TOOL_BLOWTORCH))
+		to_chat(user, SPAN_WARNING("You need a stronger blowtorch!"))
+		return
 
 	if(!broken_gun)
 		to_chat(user, SPAN_WARNING("\The [src] isn't critically broken, no need for field recovery operations."))
@@ -1295,7 +1301,9 @@
 
 	// WELDER REPAIR
 	if(iswelder(O))
-		if(!HAS_TRAIT(O, TRAIT_TOOL_BLOWTORCH)) return
+		if(!HAS_TRAIT(O, TRAIT_TOOL_BLOWTORCH))
+			to_chat(user, SPAN_WARNING("You need a stronger blowtorch!"))
+			return
 		if(user.action_busy)
 			return
 

--- a/code/modules/cm_marines/smartgun_mount.dm
+++ b/code/modules/cm_marines/smartgun_mount.dm
@@ -163,7 +163,8 @@
 	icon_state = "folded_mount_frame"
 
 /obj/item/device/m56d_post_frame/attackby(obj/item/W as obj, mob/user as mob)
-	if (istype(W, /obj/item/tool/weldingtool))
+	if (iswelder(W))
+		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
 		var/obj/item/tool/weldingtool/WT = W
 
 		if(WT.remove_fuel(1, user))
@@ -563,6 +564,7 @@
 		return
 
 	if(iswelder(O))
+		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
 		if(user.action_busy)
 			return
 
@@ -1101,6 +1103,8 @@
 	if(!iswelder(O) || user.action_busy)
 		return
 
+	if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
+
 	if(!broken_gun)
 		to_chat(user, SPAN_WARNING("\The [src] isn't critically broken, no need for field recovery operations."))
 		return
@@ -1291,6 +1295,7 @@
 
 	// WELDER REPAIR
 	if(iswelder(O))
+		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
 		if(user.action_busy)
 			return
 

--- a/code/modules/cm_marines/smartgun_mount.dm
+++ b/code/modules/cm_marines/smartgun_mount.dm
@@ -164,7 +164,7 @@
 
 /obj/item/device/m56d_post_frame/attackby(obj/item/W as obj, mob/user as mob)
 	if (iswelder(W))
-		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
+		if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH)) return
 		var/obj/item/tool/weldingtool/WT = W
 
 		if(WT.remove_fuel(1, user))
@@ -564,7 +564,7 @@
 		return
 
 	if(iswelder(O))
-		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
+		if(!HAS_TRAIT(O, TRAIT_TOOL_BLOWTORCH)) return
 		if(user.action_busy)
 			return
 
@@ -1103,7 +1103,7 @@
 	if(!iswelder(O) || user.action_busy)
 		return
 
-	if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
+	if(!HAS_TRAIT(O, TRAIT_TOOL_BLOWTORCH)) return
 
 	if(!broken_gun)
 		to_chat(user, SPAN_WARNING("\The [src] isn't critically broken, no need for field recovery operations."))
@@ -1295,7 +1295,7 @@
 
 	// WELDER REPAIR
 	if(iswelder(O))
-		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
+		if(!HAS_TRAIT(O, TRAIT_TOOL_BLOWTORCH)) return
 		if(user.action_busy)
 			return
 

--- a/code/modules/defenses/defenses.dm
+++ b/code/modules/defenses/defenses.dm
@@ -207,6 +207,7 @@
 			return
 
 	if(iswelder(O))
+		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
 		var/obj/item/tool/weldingtool/WT = O
 		if(health < 0)
 			to_chat(user, SPAN_WARNING("[src]'s internal circuitry is ruined, there's no way you can salvage this on the go."))

--- a/code/modules/defenses/defenses.dm
+++ b/code/modules/defenses/defenses.dm
@@ -207,7 +207,9 @@
 			return
 
 	if(iswelder(O))
-		if(!HAS_TRAIT(O, TRAIT_TOOL_BLOWTORCH)) return
+		if(!HAS_TRAIT(O, TRAIT_TOOL_BLOWTORCH))
+			to_chat(user, SPAN_WARNING("You need a stronger blowtorch!"))
+			return
 		var/obj/item/tool/weldingtool/WT = O
 		if(health < 0)
 			to_chat(user, SPAN_WARNING("[src]'s internal circuitry is ruined, there's no way you can salvage this on the go."))

--- a/code/modules/defenses/defenses.dm
+++ b/code/modules/defenses/defenses.dm
@@ -207,7 +207,7 @@
 			return
 
 	if(iswelder(O))
-		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
+		if(!HAS_TRAIT(O, TRAIT_TOOL_BLOWTORCH)) return
 		var/obj/item/tool/weldingtool/WT = O
 		if(health < 0)
 			to_chat(user, SPAN_WARNING("[src]'s internal circuitry is ruined, there's no way you can salvage this on the go."))

--- a/code/modules/desert_dam/motion_sensor/sensortower.dm
+++ b/code/modules/desert_dam/motion_sensor/sensortower.dm
@@ -104,6 +104,7 @@
 
 /obj/structure/machinery/sensortower/attackby(var/obj/item/O as obj, var/mob/user as mob)
 	if(iswelder(O))
+		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
 		if(buildstate == 1 && !is_on)
 			if(!skillcheck(user, SKILL_ENGINEER, SKILL_ENGINEER_ENGI))
 				to_chat(user, SPAN_WARNING("You have no clue how to repair this thing."))

--- a/code/modules/desert_dam/motion_sensor/sensortower.dm
+++ b/code/modules/desert_dam/motion_sensor/sensortower.dm
@@ -104,7 +104,7 @@
 
 /obj/structure/machinery/sensortower/attackby(var/obj/item/O as obj, var/mob/user as mob)
 	if(iswelder(O))
-		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
+		if(!HAS_TRAIT(O, TRAIT_TOOL_BLOWTORCH)) return
 		if(buildstate == 1 && !is_on)
 			if(!skillcheck(user, SKILL_ENGINEER, SKILL_ENGINEER_ENGI))
 				to_chat(user, SPAN_WARNING("You have no clue how to repair this thing."))

--- a/code/modules/desert_dam/motion_sensor/sensortower.dm
+++ b/code/modules/desert_dam/motion_sensor/sensortower.dm
@@ -104,7 +104,9 @@
 
 /obj/structure/machinery/sensortower/attackby(var/obj/item/O as obj, var/mob/user as mob)
 	if(iswelder(O))
-		if(!HAS_TRAIT(O, TRAIT_TOOL_BLOWTORCH)) return
+		if(!HAS_TRAIT(O, TRAIT_TOOL_BLOWTORCH))
+			to_chat(user, SPAN_WARNING("You need a stronger blowtorch!"))
+			return
 		if(buildstate == 1 && !is_on)
 			if(!skillcheck(user, SKILL_ENGINEER, SKILL_ENGINEER_ENGI))
 				to_chat(user, SPAN_WARNING("You have no clue how to repair this thing."))

--- a/code/modules/hydroponics/vines.dm
+++ b/code/modules/hydroponics/vines.dm
@@ -37,7 +37,7 @@
 		PF.flags_pass = PASS_OVER|PASS_AROUND|PASS_UNDER|PASS_THROUGH
 
 /obj/effect/plantsegment/attackby(obj/item/W as obj, mob/user as mob)
-	if(istype(W, /obj/item/tool/weldingtool))
+	if(iswelder(W))
 		var/obj/item/tool/weldingtool/WT = W
 		if(WT.remove_fuel(0, user))
 			qdel(src)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -450,7 +450,9 @@ var/list/robot_verbs_default = list(
 				return
 
 	if (iswelder(W))
-		if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH)) return
+		if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH))
+			to_chat(user, SPAN_WARNING("You need a stronger blowtorch!"))
+			return
 		if (src == user)
 			to_chat(user, SPAN_WARNING("You lack the reach to be able to repair yourself."))
 			return

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -450,7 +450,7 @@ var/list/robot_verbs_default = list(
 				return
 
 	if (iswelder(W))
-		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
+		if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH)) return
 		if (src == user)
 			to_chat(user, SPAN_WARNING("You lack the reach to be able to repair yourself."))
 			return

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -449,7 +449,8 @@ var/list/robot_verbs_default = list(
 
 				return
 
-	if (istype(W, /obj/item/tool/weldingtool))
+	if (iswelder(W))
+		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
 		if (src == user)
 			to_chat(user, SPAN_WARNING("You lack the reach to be able to repair yourself."))
 			return

--- a/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
+++ b/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
@@ -78,7 +78,8 @@
 		update_icon()
 		return 1
 
-	if (istype(O, /obj/item/tool/weldingtool))
+	if (iswelder(O))
+		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
 		var/obj/item/tool/weldingtool/WT = O
 		if (WT.remove_fuel(0))
 			if(health < maxHealth)

--- a/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
+++ b/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
@@ -79,7 +79,9 @@
 		return 1
 
 	if (iswelder(O))
-		if(!HAS_TRAIT(O, TRAIT_TOOL_BLOWTORCH)) return
+		if(!HAS_TRAIT(O, TRAIT_TOOL_BLOWTORCH))
+			to_chat(user, SPAN_WARNING("You need a stronger blowtorch!"))
+			return
 		var/obj/item/tool/weldingtool/WT = O
 		if (WT.remove_fuel(0))
 			if(health < maxHealth)

--- a/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
+++ b/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
@@ -79,7 +79,7 @@
 		return 1
 
 	if (iswelder(O))
-		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
+		if(!HAS_TRAIT(O, TRAIT_TOOL_BLOWTORCH)) return
 		var/obj/item/tool/weldingtool/WT = O
 		if (WT.remove_fuel(0))
 			if(health < maxHealth)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -724,7 +724,9 @@ GLOBAL_LIST_INIT(apc_wire_descriptions, list(
 		to_chat(user, SPAN_WARNING("You cannot put the board inside, the frame is damaged."))
 		return
 	else if(iswelder(W) && opened && has_electronics == 0 && !terminal)
-		if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH)) return
+		if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH))
+			to_chat(user, SPAN_WARNING("You need a stronger blowtorch!"))
+			return
 		if(!skillcheck(user, SKILL_ENGINEER, SKILL_ENGINEER_ENGI))
 			to_chat(user, SPAN_WARNING("You have no idea what to do with [W]."))
 			return

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -724,7 +724,7 @@ GLOBAL_LIST_INIT(apc_wire_descriptions, list(
 		to_chat(user, SPAN_WARNING("You cannot put the board inside, the frame is damaged."))
 		return
 	else if(iswelder(W) && opened && has_electronics == 0 && !terminal)
-		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
+		if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH)) return
 		if(!skillcheck(user, SKILL_ENGINEER, SKILL_ENGINEER_ENGI))
 			to_chat(user, SPAN_WARNING("You have no idea what to do with [W]."))
 			return

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -724,6 +724,7 @@ GLOBAL_LIST_INIT(apc_wire_descriptions, list(
 		to_chat(user, SPAN_WARNING("You cannot put the board inside, the frame is damaged."))
 		return
 	else if(iswelder(W) && opened && has_electronics == 0 && !terminal)
+		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
 		if(!skillcheck(user, SKILL_ENGINEER, SKILL_ENGINEER_ENGI))
 			to_chat(user, SPAN_WARNING("You have no idea what to do with [W]."))
 			return

--- a/code/modules/recycling/disposal-construction.dm
+++ b/code/modules/recycling/disposal-construction.dm
@@ -243,7 +243,8 @@
 			playsound(src.loc, 'sound/items/Ratchet.ogg', 25, 1)
 			update()
 
-		else if(istype(I, /obj/item/tool/weldingtool))
+		else if(iswelder(I))
+			if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
 			if(anchored)
 				var/obj/item/tool/weldingtool/W = I
 				if(W.remove_fuel(0,user))

--- a/code/modules/recycling/disposal-construction.dm
+++ b/code/modules/recycling/disposal-construction.dm
@@ -244,7 +244,7 @@
 			update()
 
 		else if(iswelder(I))
-			if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
+			if(!HAS_TRAIT(I, TRAIT_TOOL_BLOWTORCH)) return
 			if(anchored)
 				var/obj/item/tool/weldingtool/W = I
 				if(W.remove_fuel(0,user))

--- a/code/modules/recycling/disposal-construction.dm
+++ b/code/modules/recycling/disposal-construction.dm
@@ -244,7 +244,9 @@
 			update()
 
 		else if(iswelder(I))
-			if(!HAS_TRAIT(I, TRAIT_TOOL_BLOWTORCH)) return
+			if(!HAS_TRAIT(I, TRAIT_TOOL_BLOWTORCH))
+				to_chat(user, SPAN_WARNING("You need a stronger blowtorch!"))
+				return
 			if(anchored)
 				var/obj/item/tool/weldingtool/W = I
 				if(W.remove_fuel(0,user))

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -67,7 +67,7 @@
 				to_chat(user, SPAN_NOTICE("You attach the screws around the power connection."))
 				return
 		else if(iswelder(I) && mode == -1)
-			if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
+			if(!HAS_TRAIT(I, TRAIT_TOOL_BLOWTORCH)) return
 			if(contents.len > 0)
 				to_chat(user, SPAN_WARNING("Eject the contents first!"))
 				return
@@ -782,7 +782,7 @@
 		return //Prevent interaction with T-scanner revealed pipes
 	add_fingerprint(user)
 	if(iswelder(I))
-		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
+		if(!HAS_TRAIT(I, TRAIT_TOOL_BLOWTORCH)) return
 		var/obj/item/tool/weldingtool/W = I
 
 		if(W.remove_fuel(0, user))
@@ -1266,7 +1266,7 @@
 		return //Prevent interaction with T-scanner revealed pipes
 	add_fingerprint(user)
 	if(iswelder(I))
-		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
+		if(!HAS_TRAIT(I, TRAIT_TOOL_BLOWTORCH)) return
 		var/obj/item/tool/weldingtool/W = I
 		if(W.remove_fuel(0, user))
 			playsound(loc, 'sound/items/Welder2.ogg', 25, 1)
@@ -1374,7 +1374,7 @@
 			playsound(loc, 'sound/items/Screwdriver.ogg', 25, 1)
 			to_chat(user, SPAN_NOTICE("You attach the screws around the power connection."))
 	else if(iswelder(I) && mode == 1)
-		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
+		if(!HAS_TRAIT(I, TRAIT_TOOL_BLOWTORCH)) return
 		var/obj/item/tool/weldingtool/W = I
 		if(W.remove_fuel(0, user))
 			playsound(loc, 'sound/items/Welder2.ogg', 25, 1)

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -66,7 +66,8 @@
 				playsound(src.loc, 'sound/items/Screwdriver.ogg', 25, 1)
 				to_chat(user, SPAN_NOTICE("You attach the screws around the power connection."))
 				return
-		else if(istype(I, /obj/item/tool/weldingtool) && mode == -1)
+		else if(iswelder(I) && mode == -1)
+			if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
 			if(contents.len > 0)
 				to_chat(user, SPAN_WARNING("Eject the contents first!"))
 				return
@@ -780,7 +781,8 @@
 	if(T.intact_tile)
 		return //Prevent interaction with T-scanner revealed pipes
 	add_fingerprint(user)
-	if(istype(I, /obj/item/tool/weldingtool))
+	if(iswelder(I))
+		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
 		var/obj/item/tool/weldingtool/W = I
 
 		if(W.remove_fuel(0, user))
@@ -1263,7 +1265,8 @@
 	if(T.intact_tile)
 		return //Prevent interaction with T-scanner revealed pipes
 	add_fingerprint(user)
-	if(istype(I, /obj/item/tool/weldingtool))
+	if(iswelder(I))
+		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
 		var/obj/item/tool/weldingtool/W = I
 		if(W.remove_fuel(0, user))
 			playsound(loc, 'sound/items/Welder2.ogg', 25, 1)
@@ -1370,7 +1373,8 @@
 			mode = 0
 			playsound(loc, 'sound/items/Screwdriver.ogg', 25, 1)
 			to_chat(user, SPAN_NOTICE("You attach the screws around the power connection."))
-	else if(istype(I, /obj/item/tool/weldingtool) && mode == 1)
+	else if(iswelder(I) && mode == 1)
+		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
 		var/obj/item/tool/weldingtool/W = I
 		if(W.remove_fuel(0, user))
 			playsound(loc, 'sound/items/Welder2.ogg', 25, 1)

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -67,7 +67,9 @@
 				to_chat(user, SPAN_NOTICE("You attach the screws around the power connection."))
 				return
 		else if(iswelder(I) && mode == -1)
-			if(!HAS_TRAIT(I, TRAIT_TOOL_BLOWTORCH)) return
+			if(!HAS_TRAIT(I, TRAIT_TOOL_BLOWTORCH))
+				to_chat(user, SPAN_WARNING("You need a stronger blowtorch!"))
+				return
 			if(contents.len > 0)
 				to_chat(user, SPAN_WARNING("Eject the contents first!"))
 				return
@@ -782,7 +784,9 @@
 		return //Prevent interaction with T-scanner revealed pipes
 	add_fingerprint(user)
 	if(iswelder(I))
-		if(!HAS_TRAIT(I, TRAIT_TOOL_BLOWTORCH)) return
+		if(!HAS_TRAIT(I, TRAIT_TOOL_BLOWTORCH))
+			to_chat(user, SPAN_WARNING("You need a stronger blowtorch!"))
+			return
 		var/obj/item/tool/weldingtool/W = I
 
 		if(W.remove_fuel(0, user))
@@ -1266,7 +1270,9 @@
 		return //Prevent interaction with T-scanner revealed pipes
 	add_fingerprint(user)
 	if(iswelder(I))
-		if(!HAS_TRAIT(I, TRAIT_TOOL_BLOWTORCH)) return
+		if(!HAS_TRAIT(I, TRAIT_TOOL_BLOWTORCH))
+			to_chat(user, SPAN_WARNING("You need a stronger blowtorch!"))
+			return
 		var/obj/item/tool/weldingtool/W = I
 		if(W.remove_fuel(0, user))
 			playsound(loc, 'sound/items/Welder2.ogg', 25, 1)
@@ -1374,7 +1380,9 @@
 			playsound(loc, 'sound/items/Screwdriver.ogg', 25, 1)
 			to_chat(user, SPAN_NOTICE("You attach the screws around the power connection."))
 	else if(iswelder(I) && mode == 1)
-		if(!HAS_TRAIT(I, TRAIT_TOOL_BLOWTORCH)) return
+		if(!HAS_TRAIT(I, TRAIT_TOOL_BLOWTORCH))
+			to_chat(user, SPAN_WARNING("You need a stronger blowtorch!"))
+			return
 		var/obj/item/tool/weldingtool/W = I
 		if(W.remove_fuel(0, user))
 			playsound(loc, 'sound/items/Welder2.ogg', 25, 1)

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -422,7 +422,8 @@
 			playsound(src.loc, 'sound/items/Screwdriver.ogg', 25, 1)
 			to_chat(user, "You attach the screws around the power connection.")
 			return
-	else if(istype(I,/obj/item/tool/weldingtool) && c_mode==1)
+	else if(iswelder(I) && c_mode==1)
+		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
 		var/obj/item/tool/weldingtool/W = I
 		if(W.remove_fuel(0,user))
 			playsound(src.loc, 'sound/items/Welder2.ogg', 25, 1)

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -423,7 +423,9 @@
 			to_chat(user, "You attach the screws around the power connection.")
 			return
 	else if(iswelder(I) && c_mode==1)
-		if(!HAS_TRAIT(I, TRAIT_TOOL_BLOWTORCH)) return
+		if(!HAS_TRAIT(I, TRAIT_TOOL_BLOWTORCH))
+			to_chat(user, SPAN_WARNING("You need a stronger blowtorch!"))
+			return
 		var/obj/item/tool/weldingtool/W = I
 		if(W.remove_fuel(0,user))
 			playsound(src.loc, 'sound/items/Welder2.ogg', 25, 1)

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -423,7 +423,7 @@
 			to_chat(user, "You attach the screws around the power connection.")
 			return
 	else if(iswelder(I) && c_mode==1)
-		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
+		if(!HAS_TRAIT(I, TRAIT_TOOL_BLOWTORCH)) return
 		var/obj/item/tool/weldingtool/W = I
 		if(W.remove_fuel(0,user))
 			playsound(src.loc, 'sound/items/Welder2.ogg', 25, 1)

--- a/code/modules/vehicles/hardpoints/hardpoint.dm
+++ b/code/modules/vehicles/hardpoints/hardpoint.dm
@@ -385,7 +385,7 @@ obj/item/hardpoint/proc/remove_buff(var/obj/vehicle/multitile/V)
 
 /obj/item/hardpoint/attackby(var/obj/item/O, var/mob/user)
 	if(iswelder(O))
-		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
+		if(!HAS_TRAIT(O, TRAIT_TOOL_BLOWTORCH)) return
 		handle_repair(O, user)
 		return
 	..()

--- a/code/modules/vehicles/hardpoints/hardpoint.dm
+++ b/code/modules/vehicles/hardpoints/hardpoint.dm
@@ -385,6 +385,7 @@ obj/item/hardpoint/proc/remove_buff(var/obj/vehicle/multitile/V)
 
 /obj/item/hardpoint/attackby(var/obj/item/O, var/mob/user)
 	if(iswelder(O))
+		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
 		handle_repair(O, user)
 		return
 	..()

--- a/code/modules/vehicles/hardpoints/hardpoint.dm
+++ b/code/modules/vehicles/hardpoints/hardpoint.dm
@@ -385,7 +385,9 @@ obj/item/hardpoint/proc/remove_buff(var/obj/vehicle/multitile/V)
 
 /obj/item/hardpoint/attackby(var/obj/item/O, var/mob/user)
 	if(iswelder(O))
-		if(!HAS_TRAIT(O, TRAIT_TOOL_BLOWTORCH)) return
+		if(!HAS_TRAIT(O, TRAIT_TOOL_BLOWTORCH))
+			to_chat(user, SPAN_WARNING("You need a stronger blowtorch!"))
+			return
 		handle_repair(O, user)
 		return
 	..()

--- a/code/modules/vehicles/interior/interactable/seats.dm
+++ b/code/modules/vehicles/interior/interactable/seats.dm
@@ -410,7 +410,8 @@
 		break_seat()
 
 /obj/structure/bed/chair/vehicle/attackby(obj/item/W, mob/living/user)
-	if((istype(W, /obj/item/tool/weldingtool) && broken))
+	if((iswelder(W) && broken))
+		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
 		var/obj/item/tool/weldingtool/C = W
 		if(C.remove_fuel(0,user))
 			playsound(src.loc, 'sound/items/weldingtool_weld.ogg', 25)

--- a/code/modules/vehicles/interior/interactable/seats.dm
+++ b/code/modules/vehicles/interior/interactable/seats.dm
@@ -411,7 +411,9 @@
 
 /obj/structure/bed/chair/vehicle/attackby(obj/item/W, mob/living/user)
 	if((iswelder(W) && broken))
-		if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH)) return
+		if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH))
+			to_chat(user, SPAN_WARNING("You need a stronger blowtorch!"))
+			return
 		var/obj/item/tool/weldingtool/C = W
 		if(C.remove_fuel(0,user))
 			playsound(src.loc, 'sound/items/weldingtool_weld.ogg', 25)

--- a/code/modules/vehicles/interior/interactable/seats.dm
+++ b/code/modules/vehicles/interior/interactable/seats.dm
@@ -411,7 +411,7 @@
 
 /obj/structure/bed/chair/vehicle/attackby(obj/item/W, mob/living/user)
 	if((iswelder(W) && broken))
-		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
+		if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH)) return
 		var/obj/item/tool/weldingtool/C = W
 		if(C.remove_fuel(0,user))
 			playsound(src.loc, 'sound/items/weldingtool_weld.ogg', 25)

--- a/code/modules/vehicles/multitile/multitile_interaction.dm
+++ b/code/modules/vehicles/multitile/multitile_interaction.dm
@@ -20,7 +20,9 @@
 
 	// Are we trying to repair the frame?
 	if(iswelder(O) || HAS_TRAIT(O, TRAIT_TOOL_WRENCH))
-		if(!HAS_TRAIT(O, TRAIT_TOOL_BLOWTORCH)) return
+		if(!HAS_TRAIT(O, TRAIT_TOOL_BLOWTORCH))
+			to_chat(user, SPAN_WARNING("You need a stronger blowtorch!"))
+			return
 		handle_repairs(O, user)
 		return
 
@@ -147,7 +149,9 @@
 				if(!iswelder(O))
 					to_chat(user, SPAN_WARNING("You need welding tool to repair \the [H.name]."))
 					return
-				if(!HAS_TRAIT(O, TRAIT_TOOL_BLOWTORCH)) return
+				if(!HAS_TRAIT(O, TRAIT_TOOL_BLOWTORCH))
+					to_chat(user, SPAN_WARNING("You need a stronger blowtorch!"))
+					return
 				H.handle_repair(O, user)
 				update_icon()
 				return

--- a/code/modules/vehicles/multitile/multitile_interaction.dm
+++ b/code/modules/vehicles/multitile/multitile_interaction.dm
@@ -20,7 +20,7 @@
 
 	// Are we trying to repair the frame?
 	if(iswelder(O) || HAS_TRAIT(O, TRAIT_TOOL_WRENCH))
-		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
+		if(!HAS_TRAIT(O, TRAIT_TOOL_BLOWTORCH)) return
 		handle_repairs(O, user)
 		return
 
@@ -147,7 +147,7 @@
 				if(!iswelder(O))
 					to_chat(user, SPAN_WARNING("You need welding tool to repair \the [H.name]."))
 					return
-				if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
+				if(!HAS_TRAIT(O, TRAIT_TOOL_BLOWTORCH)) return
 				H.handle_repair(O, user)
 				update_icon()
 				return
@@ -165,7 +165,7 @@
 			to_chat(user, SPAN_NOTICE("The frame is way too busted! Try using a [SPAN_HELPFUL("welder")]."))
 			return
 
-		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH))
+		if(!HAS_TRAIT(O, TRAIT_TOOL_BLOWTORCH))
 			to_chat(user, SPAN_NOTICE("You need a more powerful blowtorch!"))
 			return
 

--- a/code/modules/vehicles/multitile/multitile_interaction.dm
+++ b/code/modules/vehicles/multitile/multitile_interaction.dm
@@ -20,6 +20,7 @@
 
 	// Are we trying to repair the frame?
 	if(iswelder(O) || HAS_TRAIT(O, TRAIT_TOOL_WRENCH))
+		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
 		handle_repairs(O, user)
 		return
 
@@ -146,6 +147,7 @@
 				if(!iswelder(O))
 					to_chat(user, SPAN_WARNING("You need welding tool to repair \the [H.name]."))
 					return
+				if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
 				H.handle_repair(O, user)
 				update_icon()
 				return
@@ -161,6 +163,10 @@
 	if(health < max_hp * 0.75)
 		if(!iswelder(O))
 			to_chat(user, SPAN_NOTICE("The frame is way too busted! Try using a [SPAN_HELPFUL("welder")]."))
+			return
+
+		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH))
+			to_chat(user, SPAN_NOTICE("You need a more powerful blowtorch!"))
 			return
 
 		WT = O

--- a/code/modules/vehicles/van/van.dm
+++ b/code/modules/vehicles/van/van.dm
@@ -182,7 +182,9 @@
 		return ..()
 
 	if(iswelder(O) && health >= initial(health))
-		if(!HAS_TRAIT(O, TRAIT_TOOL_BLOWTORCH)) return
+		if(!HAS_TRAIT(O, TRAIT_TOOL_BLOWTORCH))
+			to_chat(user, SPAN_WARNING("You need a stronger blowtorch!"))
+			return
 		var/obj/item/hardpoint/H
 		for(var/obj/item/hardpoint/potential_hardpoint in hardpoints)
 			if(potential_hardpoint.health < initial(potential_hardpoint.health))

--- a/code/modules/vehicles/van/van.dm
+++ b/code/modules/vehicles/van/van.dm
@@ -182,6 +182,7 @@
 		return ..()
 
 	if(iswelder(O) && health >= initial(health))
+		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
 		var/obj/item/hardpoint/H
 		for(var/obj/item/hardpoint/potential_hardpoint in hardpoints)
 			if(potential_hardpoint.health < initial(potential_hardpoint.health))

--- a/code/modules/vehicles/van/van.dm
+++ b/code/modules/vehicles/van/van.dm
@@ -182,7 +182,7 @@
 		return ..()
 
 	if(iswelder(O) && health >= initial(health))
-		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
+		if(!HAS_TRAIT(O, TRAIT_TOOL_BLOWTORCH)) return
 		var/obj/item/hardpoint/H
 		for(var/obj/item/hardpoint/potential_hardpoint in hardpoints)
 			if(potential_hardpoint.health < initial(potential_hardpoint.health))

--- a/code/modules/vehicles/vehicle.dm
+++ b/code/modules/vehicles/vehicle.dm
@@ -63,7 +63,9 @@
 	else if(istype(W, /obj/item/cell) && !cell && open)
 		insert_cell(W, user)
 	else if(iswelder(W))
-		if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH)) return
+		if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH))
+			to_chat(user, SPAN_WARNING("You need a stronger blowtorch!"))
+			return
 		var/obj/item/tool/weldingtool/WT = W
 		if(WT.remove_fuel(1, user))
 			if(health < maxhealth)

--- a/code/modules/vehicles/vehicle.dm
+++ b/code/modules/vehicles/vehicle.dm
@@ -62,7 +62,8 @@
 
 	else if(istype(W, /obj/item/cell) && !cell && open)
 		insert_cell(W, user)
-	else if(istype(W, /obj/item/tool/weldingtool))
+	else if(iswelder(W))
+		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
 		var/obj/item/tool/weldingtool/WT = W
 		if(WT.remove_fuel(1, user))
 			if(health < maxhealth)

--- a/code/modules/vehicles/vehicle.dm
+++ b/code/modules/vehicles/vehicle.dm
@@ -63,7 +63,7 @@
 	else if(istype(W, /obj/item/cell) && !cell && open)
 		insert_cell(W, user)
 	else if(iswelder(W))
-		if(!HAS_TRAIT(P, TRAIT_TOOL_BLOWTORCH)) return
+		if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH)) return
 		var/obj/item/tool/weldingtool/WT = W
 		if(WT.remove_fuel(1, user))
 			if(health < maxhealth)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

welding screen var turned to OFF

closes #859 

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

**gameplay**

cutting out an entire game mechanic solely because of a little quirk on the sprite is not good. There was no reason to remove the need for welding protection and it makes the entire system deprecated and useless - as well as nullifying several other interesting mechanics such as synth welding protection

you should also be more vulnerable while welding and not able to see everything around you with ease.

also, stuff like this 
![image](https://user-images.githubusercontent.com/66756236/184888165-a8e693f6-ce3e-433f-aaa8-ce49fed9f8ba.png)
 should not be possible

**realism**

a tiny little glass screen on a welder CANNOT protect you from the massive light caused by the torch. The light will go _around_ the screen and directly into your eyes.

I know that in alien isolation it works like that, but due to gameplay concerns this should not be a thing. If it really matters then change the sprite to not have the transparent gap in the screen. (their blowtorch also works off replaceable cans while ours does not - completely different item)

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: blowtorches no longer always protect you from eye damage
add: added "old blowtorches", which have a weaker flame that only lets them weld vents and doors. However, this makes their welding screens effective and as such they do not hurt your eyes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
