### PR TITLE
The Sandbag Buff No One Asked For

### DIFF
--- a/code/game/objects/items/stacks/sandbags.dm
+++ b/code/game/objects/items/stacks/sandbags.dm
@@ -6,7 +6,7 @@
 	icon = 'icons/obj/items/marine-items.dmi'
 	icon_state = "sandbag_stack"
 	item_state = "sandbag_stack"
-	w_class = SIZE_MEDIUM
+	w_class = SIZE_SMALL
 	force = 2
 	throwforce = 0
 	throw_speed = SPEED_VERY_FAST


### PR DESCRIPTION

## About The Pull Request

This changes unfilled sandbag stacks to be small items.

## Why It's Good For The Game

Currently we have a situation where sandbags are pretty much outclassed in every way by metal/plasteel. You have to take a stack (equal to the size of metal/plasteel stacks) and then dig (also a small item you have to carry) for a while before they're even usable and _then_ you can't even store them effectively. Even further down the line, the final product can only be repaired with more sandbags. Meanwhile, metal/plasteel is repaired by welding and welding fuel is easy to carry lots of and easily found.

Sandbags sort of share the same niche with portacades with quickly placing them to fill holes in lines but we can do better and I hope this is step one to seeing some neat sandbag usage.

## Changelog

:cl: Morrow
balance: Unfilled sandbag stacks are now small items.
/:cl:
