### PR TITLE
Fix for spawning corpse presets.

### DIFF
--- a/code/modules/objectives/mob_objectives.dm
+++ b/code/modules/objectives/mob_objectives.dm
@@ -32,7 +32,7 @@
 		if(spawnpoint)
 			var/mob/living/carbon/human/M = new /mob/living/carbon/human(spawnpoint)
 			M.create_hud() //Need to generate hud before we can equip anything apparently...
-			arm_equipment(M, "Corpse - [spawner.name]", TRUE, FALSE)
+			arm_equipment(M, spawner.equip_path, TRUE, FALSE)
 		objective_spawn_corpse.Remove(spawner)
 
 /datum/cm_objective/recover_corpses/post_round_start()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Followup to #874 and #878. This should be a lot more sensible way to do it.

## Why It's Good For The Game

Somewhere between IO return (forever stuck in development), update to `arm_equipment()` to make it use actual paths instead of hopefully correctly spelt names and the recent survivor/corpse updates, something did not quite align. But if you are trying to count spaces in names and deal with names like `Corpse - Corpse - loremipsum`, you are probably doing something wrong. Using the typepaths was a sensible choice, let us stand by it.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
refactor: Corpse spawning landmarks should now actually spawn their supposed corpses correctly in every case.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
