### PR TITLE
Fix for disappearing targets of objectives.

### DIFF
--- a/code/modules/objectives/data_retrieval.dm
+++ b/code/modules/objectives/data_retrieval.dm
@@ -171,6 +171,7 @@
 	var/label = ""
 	desc = "A boring looking computer disk. The name label is just a gibberish collection of letters and numbers."
 	unacidable = TRUE
+	indestructible = TRUE
 	is_objective = TRUE
 	var/datum/cm_objective/retrieve_data/disk/objective
 	var/datum/cm_objective/retrieve_item/document/retrieve_objective

--- a/code/modules/objectives/experimental_devices.dm
+++ b/code/modules/objectives/experimental_devices.dm
@@ -29,6 +29,7 @@
 /obj/item/device/mass_spectrometer/adv/objective
 	var/datum/cm_objective/retrieve_item/device/objective
 	unacidable = TRUE
+	indestructible = TRUE
 	is_objective = TRUE
 
 /obj/item/device/mass_spectrometer/adv/objective/Initialize()
@@ -44,6 +45,7 @@
 /obj/item/device/reagent_scanner/adv/objective
 	var/datum/cm_objective/retrieve_item/device/objective
 	unacidable = TRUE
+	indestructible = TRUE
 	is_objective = TRUE
 
 /obj/item/device/reagent_scanner/adv/objective/Initialize(mapload, ...)
@@ -59,6 +61,7 @@
 /obj/item/device/healthanalyzer/objective
 	var/datum/cm_objective/retrieve_item/device/objective
 	unacidable = TRUE
+	indestructible = TRUE
 	is_objective = TRUE
 
 /obj/item/device/healthanalyzer/objective/Initialize(mapload, ...)
@@ -74,6 +77,7 @@
 /obj/item/device/autopsy_scanner/objective
 	var/datum/cm_objective/retrieve_item/device/objective
 	unacidable = TRUE
+	indestructible = TRUE
 	is_objective = TRUE
 
 /obj/item/device/autopsy_scanner/objective/Initialize(mapload, ...)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

_One_ cause of #832 is objective items being destroyed by chance OB, stray grenade, IO's own C4 and whatever else tends to explode in the course of the round. Given that intel related things tend to be in general indestructible by acid, bomb and whatever else, it is probably much saner to extend that protection to all relevant items, so that their destruction does not leave objectives hanging and IOs bluescreening.
This is not the only cause, so not marking the bug report for closure yet.

## Why It's Good For The Game

Is fix.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: IO objectives tied to items no longer bluescreen due to said items getting exploded.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
