### PR TITLE
Balance: fixes wrongful surgical webbing availability creep

### DIFF
--- a/code/datums/supply_packs/clothing.dm
+++ b/code/datums/supply_packs/clothing.dm
@@ -159,17 +159,6 @@
 	containername = "Drop Pouch Crate"
 	group = "Clothing"
 
-/datum/supply_packs/webbing_surgical
-	name = "Surgical Webbing Crate (x3)"
-	contains = list(
-		/obj/item/clothing/accessory/storage/surg_vest,
-		/obj/item/clothing/accessory/storage/surg_vest,
-		/obj/item/clothing/accessory/storage/surg_vest,
-	)
-	cost = RO_PRICE_CHEAP
-	containertype = /obj/structure/closet/crate/green
-	containername = "Surgical Webbing Crate"
-	group = "Clothing"
 
 /datum/supply_packs/webbing_knives//for the lulz
 	name = "Knife Vest Crate (x3)"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Removes the surgical webbing vests as a purchasable option from the ASRS console menu.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I did not make the surgical webbing vest so that every single medbay staff member can get their hands on one, then hog all of the surgical tools from medbay and skinwalk around willy-nilly. Especially not for it to be available as a money drain for req. Medbay gets a surgical webbing vest as an item meant for whoever gets designated as the field surgeon for more reliable identification as such, alongside ease of operating as they'd likely get crowded by patients down groundside.

If more doctors want to deploy, they can make do with juggling their surgical tools tray and risk gimping the medbay by taking one from the ORs, since only the stuff in the field surgery prep room is meant to be used by deploying doctor/s. Forward any complaints to stan.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: 50RemAndCounting
del: Removed the wrongfully added surgical webbing vest crate as a purchasable option in the req console.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
