### PR TITLE
Droppable Sentries show on dropship cams

### DIFF
--- a/code/game/machinery/computer/camera_console.dm
+++ b/code/game/machinery/computer/camera_console.dm
@@ -118,10 +118,11 @@
 		var/list/cameras = get_available_cameras()
 		var/obj/structure/machinery/camera/selected_camera
 		selected_camera = cameras[c_tag]
-		// Cause Unicode breaks c_tags
+		// Unicode breaks c_tags
+		// Currently the only issues with character names comes from the improper or proper tags and so we strip and recheck if not found.
 		if(!selected_camera)
 			for(var/I in cameras)
-				if(copytext_char(I, 3) == c_tag)
+				if(strip_improper(I) == c_tag)
 					selected_camera = cameras[I]
 					break
 		current = selected_camera

--- a/code/modules/defenses/sentry.dm
+++ b/code/modules/defenses/sentry.dm
@@ -539,8 +539,7 @@ obj/structure/machinery/defenses/sentry/premade/damaged_action()
 	
 /obj/structure/machinery/defenses/sentry/launchable/power_on_action()
 	. = ..()
-	//The way the camera system is handled going back and forth from TGUI makes the \improper char not function correctly and it tries to find it at the beginning of the passed name. Our bad boy here's got one in our get_area() call so we gotta remove it.
-	linked_cam = new(loc, "[name] [sentry_number] at [copytext_char(get_area(src), 3)] ([obfuscate_x(x)], [obfuscate_y(y)])")
+	linked_cam = new(loc, "[name] [sentry_number] at [get_area(src)] ([obfuscate_x(x)], [obfuscate_y(y)])")
 
 /obj/structure/machinery/defenses/sentry/launchable/power_off_action()
 	. = ..()

--- a/code/modules/defenses/sentry.dm
+++ b/code/modules/defenses/sentry.dm
@@ -526,16 +526,25 @@ obj/structure/machinery/defenses/sentry/premade/damaged_action()
 	static = TRUE
 	var/obj/structure/machinery/camera/cas/linked_cam
 	var/static/sentry_count = 1
+	var/sentry_number
 	
 /obj/structure/machinery/defenses/sentry/launchable/Initialize()
 	. = ..()
-	linked_cam = new(loc, "[name] [sentry_count]")
-	SetLuminosity(7)
+	sentry_number = sentry_count
 	sentry_count++
 	
 /obj/structure/machinery/defenses/sentry/launchable/Destroy()
 	QDEL_NULL(linked_cam)
 	. = ..()
+	
+/obj/structure/machinery/defenses/sentry/launchable/power_on_action()
+	. = ..()
+	//The way the camera system is handled going back and forth from TGUI makes the \improper char not function correctly and it tries to find it at the beginning of the passed name. Our bad boy here's got one in our get_area() call so we gotta remove it.
+	linked_cam = new(loc, "[name] [sentry_number] at [copytext_char(get_area(src), 3)] ([obfuscate_x(x)], [obfuscate_y(y)])")
+
+/obj/structure/machinery/defenses/sentry/launchable/power_off_action()
+	. = ..()
+	QDEL_NULL(linked_cam)
 	
 
 /obj/structure/machinery/defenses/sentry/launchable/attack_hand_checks(var/mob/user)

--- a/code/modules/defenses/sentry.dm
+++ b/code/modules/defenses/sentry.dm
@@ -521,10 +521,22 @@ obj/structure/machinery/defenses/sentry/premade/damaged_action()
 	desc = "A deployable, omni-directional automated turret with AI targeting capabilities. Armed with an M30 Autocannon and a 1500-round drum magazine.  Due to the deployment method it is incapable of being moved."
 	ammo = new /obj/item/ammo_magazine/sentry/dropped
 	faction_group = FACTION_LIST_MARINE
-	luminosity = 5
 	omni_directional = TRUE
 	immobile = TRUE
 	static = TRUE
+	var/obj/structure/machinery/camera/cas/linked_cam
+	var/static/sentry_count = 1
+	
+/obj/structure/machinery/defenses/sentry/launchable/Initialize()
+	. = ..()
+	linked_cam = new(loc, "[name] [sentry_count]")
+	SetLuminosity(7)
+	sentry_count++
+	
+/obj/structure/machinery/defenses/sentry/launchable/Destroy()
+	QDEL_NULL(linked_cam)
+	. = ..()
+	
 
 /obj/structure/machinery/defenses/sentry/launchable/attack_hand_checks(var/mob/user)
 	return TRUE // We want to be able to turn it on / off while keeping it immobile


### PR DESCRIPTION
## About The Pull Request

The dropship droppable sentries now show on dropship cameras. Also, slight luminosity bugfix as it wasn't working correctly for whatever reason.

## Why It's Good For The Game

Allowing roles to witness the impact of their actions creates good game feel which is something that at times is critically lacking for dropship folk.

Also bug bad.

## Changelog

:cl: Morrow
add: Dropship droppable sentries can now be seen on dropship cameras.
fix: Dropship droppable sentries have working lights when dropped.
/:cl:

