### PR TITLE
Fix unbreakable power APCs after basic repairs

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -811,8 +811,9 @@
 		set_broken()
 		visible_message(SPAN_DANGER("[src]'s electronics are destroyed!"), null, null, 5)
 	else if(wiresexposed)
-		for(var/wire = 1; wire < length(get_wire_descriptions()); wire++)
-			cut(wire, M)
+		for(var/wire = 1; wire <= length(get_wire_descriptions()); wire++) // Cut all the wires because xenos don't know any better
+			if(!isWireCut(wire)) // Xenos don't need to mend the wires either
+				cut(wire, M, FALSE) // This is XOR so it toggles; FALSE just because we don't want the messages
 		update_icon()
 		beenhit = XENO_HITS_TO_CUT_WIRES
 		visible_message(SPAN_DANGER("[src]'s wires snap apart in a rain of sparks!"), null, null, 5)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -631,6 +631,7 @@ GLOBAL_LIST_INIT(apc_wire_descriptions, list(
 				update_icon()
 		else
 			wiresexposed = !wiresexposed
+			beenhit = wiresexposed ? XENO_HITS_TO_EXPOSE_WIRES_MIN : 0
 			user.visible_message(SPAN_NOTICE("[user] [wiresexposed ? "exposes" : "unexposes"] [src]'s wiring."),
 			SPAN_NOTICE("You [wiresexposed ? "expose" : "unexpose"] [src]'s wiring."))
 			playsound(src.loc, 'sound/items/Screwdriver.ogg', 25, 1)
@@ -890,22 +891,22 @@ GLOBAL_LIST_INIT(apc_wire_descriptions, list(
 	var/wireFlag = getWireFlag(wire)
 	return !(apcwires & wireFlag)
 
-/obj/structure/machinery/power/apc/proc/cut(wire, mob/user)
+/obj/structure/machinery/power/apc/proc/cut(var/wire, mob/user, var/withMessage = TRUE)
 	apcwires ^= getWireFlag(wire)
 
 	switch(wire)
 		if(APC_WIRE_MAIN_POWER)
 			shock(usr, 50)
 			shorted = 1
-			visible_message(SPAN_WARNING("\The [src] begins flashing error messages wildly!"))
+			if(withMessage)
+				visible_message(SPAN_WARNING("\The [src] begins flashing error messages wildly!"))
 			SSclues.create_print(get_turf(user), user, "The fingerprint contains specks of wire.")
 			SEND_SIGNAL(user, COMSIG_MOB_APC_CUT_WIRE, src)
 
 		if(APC_WIRE_IDSCAN)
 			locked = 0
-			visible_message(SPAN_NOTICE("\The [src] emits a click."))
-	if(isXeno(usr)) //So aliens don't see this when they cut all of the wires.
-		return
+			if(withMessage)
+				visible_message(SPAN_NOTICE("\The [src] emits a click."))
 
 /obj/structure/machinery/power/apc/proc/mend(var/wire)
 	apcwires |= getWireFlag(wire)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -891,21 +891,21 @@ GLOBAL_LIST_INIT(apc_wire_descriptions, list(
 	var/wireFlag = getWireFlag(wire)
 	return !(apcwires & wireFlag)
 
-/obj/structure/machinery/power/apc/proc/cut(var/wire, mob/user, var/withMessage = TRUE)
+/obj/structure/machinery/power/apc/proc/cut(var/wire, mob/user, var/with_message = TRUE)
 	apcwires ^= getWireFlag(wire)
 
 	switch(wire)
 		if(APC_WIRE_MAIN_POWER)
 			shock(usr, 50)
 			shorted = 1
-			if(withMessage)
+			if(with_message)
 				visible_message(SPAN_WARNING("\The [src] begins flashing error messages wildly!"))
 			SSclues.create_print(get_turf(user), user, "The fingerprint contains specks of wire.")
 			SEND_SIGNAL(user, COMSIG_MOB_APC_CUT_WIRE, src)
 
 		if(APC_WIRE_IDSCAN)
 			locked = 0
-			if(withMessage)
+			if(with_message)
 				visible_message(SPAN_NOTICE("\The [src] emits a click."))
 
 /obj/structure/machinery/power/apc/proc/mend(var/wire)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Resolves #890 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Don't break my immersion: If a power APC is fixed, it should be able to be deactivated again. Additionally, if wires are exposed, they now can be immediately cut by a xeno.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixed power APCs being unbreakable (atleast not by small/med xenos) after basic repairs have been made (mending wires and closing panel)
fix: Xenos now cut all power APC wires, not just all - 1 because of an off-by-one error
fix: If a power APC's wires are exposed some reason, now they can just immediately be slashed
code: Power APC cut proc now can take a boolean argument to hide messages (And xeno slashing now doesn't produce the redundant messages)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
