### PR TITLE
Dancer buff: moar mobility, moar evasion

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/praetorian/praetorian_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/praetorian/praetorian_abilities.dm
@@ -208,6 +208,23 @@
 
 	var/click_miss_cooldown = 15
 
+/datum/action/xeno_action/activable/pounce/dancer
+	name = "Dive"
+	action_icon_state = "prae_dash"
+	ability_name = "Dive"
+	macro_path = /datum/action/xeno_action/verb/verb_dive
+	action_type = XENO_ACTION_CLICK
+	ability_primacy = XENO_PRIMARY_ACTION_4
+	xeno_cooldown = 40
+	plasma_cost = 50
+
+	// Config options
+	distance = 6
+	knockdown = FALSE
+	slash = FALSE
+	freeze_self = FALSE
+	throw_speed = SPEED_VERY_FAST //tier 3 agile xeno
+
 ////////// BASE PRAE
 
 /datum/action/xeno_action/activable/pounce/base_prae_dash

--- a/code/modules/mob/living/carbon/xenomorph/abilities/praetorian/praetorian_macros.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/praetorian/praetorian_macros.dm
@@ -68,6 +68,13 @@
 	var/action_name = "Dodge"
 	handle_xeno_macro(src, action_name) 
 
+/datum/action/xeno_action/verb/verb_dive()
+	set category = "Alien"
+	set name = "Praetorian Dive"
+	set hidden = 1
+	var/action_name = "Dive"
+	handle_xeno_macro(src, action_name)
+
 /datum/action/xeno_action/verb/verb_prae_tail_trip()
 	set category = "Alien"
 	set name = "Praetorian Tail Trip"

--- a/code/modules/mob/living/carbon/xenomorph/abilities/praetorian/praetorian_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/praetorian/praetorian_powers.dm
@@ -697,6 +697,34 @@
 	..()
 	return
 
+/datum/action/xeno_action/activable/pounce/dancer/use_ability(atom/A)
+	var/mob/living/carbon/Xenomorph/X = owner
+	if (!action_cooldown_check())
+		return
+
+	.=..()
+
+	var/mob/living/carbon/H = A
+	if(isXenoOrHuman(H))
+		var/mob/living/carbon/human/Hu = H
+		Hu.update_xeno_hostile_hud()
+	
+	if (X.mutation_type == PRAETORIAN_DANCER)
+		var/found = FALSE
+		for (var/datum/effects/dancer_tag/DT in H.effects_list)
+			found = TRUE
+			qdel(DT)
+			break
+
+		knockdown = found
+		slash = found
+	
+	X.emote("roar")
+
+/datum/action/xeno_action/activable/pounce/dancer/ability_cooldown_over()
+	update_button_icon()
+	return
+
 /datum/action/xeno_action/activable/prae_acid_ball/use_ability(atom/A)
 	var/mob/living/carbon/Xenomorph/X = owner
 	if (!X.check_state() || X.action_busy)

--- a/code/modules/mob/living/carbon/xenomorph/mutators/strains/praetorian/dancer.dm
+++ b/code/modules/mob/living/carbon/xenomorph/mutators/strains/praetorian/dancer.dm
@@ -16,6 +16,7 @@
 		/datum/action/xeno_action/activable/prae_impale,
 		/datum/action/xeno_action/activable/prae_dodge,
 		/datum/action/xeno_action/activable/prae_tail_trip,
+		/datum/action/xeno_action/activable/pounce/dancer,
 	)
 	behavior_delegate_type = /datum/behavior_delegate/praetorian_dancer
 	keystone = TRUE
@@ -43,7 +44,7 @@
 	name = "Praetorian Dancer Behavior Delegate"
 
 	var/evasion_buff_amount = 40
-	var/evasion_buff_ttl = 25     // 2.5 seconds seems reasonable
+	var/evasion_buff_ttl = 50     // 2.5 seconds seems reasonable
 
 	// State
 	var/next_slash_buffed = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Adds the dash ability to the dancer kit granting the strain more agility to perform its niche, it also slightly buff its evasion timer from slash to 5 seconds 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
So dancer, its purpose is a damage dealer, praetorians trade away their health and armour to gain the speed and damage granted by this strain. This strain's playstyle is supposed to be a get in, choose an unfortunate marine to nuke him with your abilities and slashes. Its a quick get in deal damage get out playstyle, of course others play it differently but i believe this is the inteded playstyle (theres also a high risk high reward situation with it punishing you for missing clicks). However,c urrent state of dancer is quite abysmal, its a tier 3 caste yet it doesnt function well on frontline thus many has resort to sideline fight where theres 1 to 3 marines. I believe this problem stems from the fact that dancer is too squishy to survive focus fire long enough to do meaningful damage and get out alive. This problem can be addressed in 2 ways, one is buffing its health which is lame or the other more fun way, which is giving it more mobility. So thats what i did, giving dancer a quick dashing ability that ranges to 6 tiles and functions with the tagging system, meaning if you dive into a target that has a tag you will slash and knock them down instead. This should hopefully allows dancer to get into the fight, deal their damage and get out before all the focus fire kills it. 

Argument 1: "But theres already dodge to help it get into the fight"
Counter-argument: dodge serves as a counter against block as well as a good speed buff to disengage in battle, keyword here is disengage because thats what it is imo. It allows you to pass through mobs and grants a speed buff to run away without being bodyblocked. The dash will give it something to engage while dodge will be used to disengage

Argument 2: "But this makes it too agile"
Counter-argument: Yes its supposed to be an agile caste since it is losing its health pool in exchange for this speed and agility 

Argument 3: "Why does it need the evasion buff then?"
Counter-argument: Because 2.5 seconds isnt enough window for it imo, what with time dilation and all this 2.5 seconds could be gone in a flash (not to mention players regularly experience crashes/freezes)

Of course all of this can be change at a request of a maintainer, so discuss your balance concerns


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: dancer evasion buff now last 5 seconds instead of 2.5
add: Through numerous battle the dancer caste has evolved a new ability to aid its fight against the tall horde. It can now dash  up to 6 tiles away and if it dashes on a human that has been tagged before, it will knock the human down and slash them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
