### PR TITLE
fixes defender crest down oversight that allows unintended perks

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -147,6 +147,8 @@
 #define TRAIT_LEADERSHIP "t_leadership"
  /// If the mob can see the reagents contents of stuff
 #define TRAIT_REAGENT_SCANNER "reagent_scanner"
+/// Immune to knockback
+#define TRAIT_KNOCKBACK_IMMUNE "knockback_immune"
 
 // -- ability traits --
  /// Xenos with this trait cannot have plasma transfered to them
@@ -180,6 +182,7 @@ GLOBAL_LIST_INIT(mob_traits, list(
 	TRAIT_TWOBORE_TRAINING,
 	TRAIT_LEADERSHIP,
 	TRAIT_DEXTROUS,
+	TRAIT_KNOCKBACK_IMMUNE,
 	TRAIT_REAGENT_SCANNER
 ))
 

--- a/code/modules/mob/living/carbon/xenomorph/abilities/defender/defender_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/defender/defender_powers.dm
@@ -19,13 +19,13 @@
 		to_chat(X, SPAN_XENOWARNING("You lower your crest."))
 		X.ability_speed_modifier += speed_debuff
 		X.armor_deflection_buff += armor_buff
-		X.mob_size = MOB_SIZE_BIG //knockback immune
+		ADD_TRAIT(X, TRAIT_KNOCKBACK_IMMUNE, TRAIT_SOURCE_INHERENT) //knockback immune
 		X.update_icons()
 	else
 		to_chat(X, SPAN_XENOWARNING("You raise your crest."))
 		X.ability_speed_modifier -= speed_debuff
 		X.armor_deflection_buff -= armor_buff
-		X.mob_size = MOB_SIZE_XENO //no longer knockback immune
+		REMOVE_TRAIT(X, TRAIT_KNOCKBACK_IMMUNE, TRAIT_SOURCE_INHERENT) //no longer knockback immune
 		X.update_icons()
 
 	apply_cooldown()

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -97,6 +97,8 @@
 
 	if(L.mob_size >= MOB_SIZE_BIG)
 		return //Big xenos are not affected.
+	if(HAS_TRAIT(L, TRAIT_KNOCKBACK_IMMUNE))
+		return //if they are immune to knockback, they shrug it off.
 
 	shake_camera(L, 3, 4)
 
@@ -127,6 +129,8 @@
 		return
 	if(L.mob_size >= MOB_SIZE_BIG)
 		return
+	if(HAS_TRAIT(L, TRAIT_KNOCKBACK_IMMUNE))
+		return //if they are immune to knockback, they shrug it off.
 
 	shake_camera(L, 3, 4)
 	if(isCarbonSizeXeno(L))
@@ -159,6 +163,8 @@
 
 	if(M.mob_size >= MOB_SIZE_BIG)
 		return //too big to push
+	if(HAS_TRAIT(M, TRAIT_KNOCKBACK_IMMUNE))
+		return //if they are immune to knockback, they shrug it off.
 
 	to_chat(M, isXeno(M) ? SPAN_XENODANGER("You are pushed back by the sudden impact!") : SPAN_HIGHDANGER("You are pushed back by the sudden impact!"), null, 4, CHAT_TYPE_TAKING_HIT)
 	step(M, Get_Compass_Dir(P.z ? P : P.firer, M))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
So defender when crest down has its mob sized set to Big, this is to make it immune to knockback and also why it is able to open walls. This ability as i believed is only reserved for higher tier xenomorph. To fix that i added a new trait that provides immunity to knockback and have that trait be added to defender instead of increasing its mob size
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The mob size change was done mainly for the knockback immunity, it says so in the comment. The other perks that came with the crest down was because of this mob size change, this pr simply makes it does what it is meant to do without the other perks that comes with the mob size huge.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
Fix: fix an ovesight with defender crest ability that grants it unintended perks besides knockback immunity
balance: defender crest down will lose these unintended perks: APC slash, pushing vehicles, knockover vending machine (this one is the saddest), fire resistant and electric resistant,
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
