### PR TITLE
Removes PMC Mask from PMC Corpse and Black Market Clothing Crate and minor corpse tweak

### DIFF
--- a/code/game/objects/structures/crates_lockers/largecrate.dm
+++ b/code/game/objects/structures/crates_lockers/largecrate.dm
@@ -346,7 +346,7 @@
 			new /obj/item/clothing/head/helmet/marine/veteran/PMC(src)
 			new /obj/item/clothing/suit/storage/marine/veteran/PMC(src)
 			new /obj/item/clothing/gloves/marine/veteran(src)
-			new /obj/item/clothing/mask/gas/PMC(src)
+			new /obj/item/clothing/mask/rebreather/scarf(src)
 		if(2) //dutch's
 			new /obj/item/clothing/head/helmet/marine/veteran/dutch(src)
 			new /obj/item/clothing/under/marine/veteran/dutch(src)

--- a/code/modules/gear_presets/corpses.dm
+++ b/code/modules/gear_presets/corpses.dm
@@ -818,11 +818,12 @@
 	H.equip_to_slot_or_del(new /obj/item/clothing/gloves/marine/veteran/PMC, WEAR_HANDS)
 	H.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/marine/veteran/PMC, WEAR_HEAD)
 	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/veteran/PMC/knife, WEAR_FEET)
-	H.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/PMC, WEAR_FACE)
+	H.equip_to_slot_or_del(new /obj/item/clothing/mask/rebreather/scarf, WEAR_FACE)
 	H.equip_to_slot_or_del(new /obj/item/storage/backpack/satchel, WEAR_BACK)
 	H.equip_to_slot_or_del(new /obj/item/device/radio(H), WEAR_IN_BACK)
 	H.equip_to_slot_or_del(new /obj/item/storage/belt/gun/m4a3/mod88, WEAR_WAIST)
 	H.equip_to_slot_or_del(new /obj/item/storage/pouch/tools/full(H), WEAR_R_STORE)
+	H.equip_to_slot_or_del(new /obj/item/storage/pouch/firstaid/ert(H), WEAR_L_STORE)
 	add_random_survivor_equipment(H)
 
 /datum/equipment_preset/corpse/pmc/burst
@@ -858,6 +859,8 @@
 	H.equip_to_slot_or_del(new /obj/item/storage/belt/marine, WEAR_WAIST)
 	H.equip_to_slot_or_del(new /obj/item/storage/backpack/lightpack, WEAR_BACK)
 	H.equip_to_slot_or_del(new /obj/item/device/radio(H), WEAR_IN_BACK)
+	H.equip_to_slot_or_del(new /obj/item/storage/pouch/tools/full(H), WEAR_R_STORE)
+	H.equip_to_slot_or_del(new /obj/item/storage/pouch/firstaid/ert(H), WEAR_L_STORE)
 	spawn_merc_helmet(H)
 
 /datum/equipment_preset/corpse/freelancer/burst
@@ -895,7 +898,8 @@
 	H.equip_to_slot_or_del(new /obj/item/storage/backpack/lightpack(H), WEAR_BACK)
 	H.equip_to_slot_or_del(new /obj/item/storage/firstaid/regular(H), WEAR_IN_BACK)
 	H.equip_to_slot_or_del(new /obj/item/clothing/gloves/marine/veteran(H), WEAR_HANDS)
-	H.equip_to_slot_or_del(new /obj/item/storage/pouch/firstaid/ert(H), WEAR_R_STORE)
+	H.equip_to_slot_or_del(new /obj/item/storage/pouch/tools/full(H), WEAR_R_STORE)
+	H.equip_to_slot_or_del(new /obj/item/storage/pouch/firstaid/ert(H), WEAR_L_STORE)
 	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/marine/jungle/knife(H), WEAR_FEET)
 	spawn_merc_helmet(H)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Minor rebalancing of items of ert-related corpses and black-market clothing crate.

## Why It's Good For The Game

Removes PMC Coif from black market crates and PMC corpses. It has hugger protection and having corpses littered around the map with them isn't exactly the best thing in the world. The mask was swapped out for the heat coif which looks better tbh and archives the same purpose except for no hugger protection. This should put mappers at ease a little now that corpses don't have ERT level loot other than fluffy armor. 

Added medical pouch to ERT Corpses which would incentive looting corpses. This spot originally belonged to the survival pouch but it was removed since it contained 50 metal. Since that is no longer the case after the survivor QOL and corpse update got merged it remained empty.

## Changelog


:cl: theflyingflail
add: Added ert medical pouch to ert corpses
tweak: Swapped PMC mask for heat coif in black market crate and pmc corpses
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
