### PR TITLE
Trijent Dam Survivor Hotfix

### DIFF
--- a/code/modules/gear_presets/survivors.dm
+++ b/code/modules/gear_presets/survivors.dm
@@ -1017,6 +1017,8 @@
 	H.equip_to_slot_or_del(new /obj/item/clothing/gloves/marine/insulated(H), WEAR_HANDS)
 	add_random_cl_survivor_loot(H)
 
+	..()
+
 /datum/equipment_preset/survivor/interstellar_commerce_commission_liason/corsat
 	name = "Survivor - Interstellar Commerce Commission Liaison CORSAT"
 	assignment = "Interstellar Commerce Commission Liaison"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->


## Why It's Good For The Game

The trijent dame CL survivor now spawns with survivor equipment. It was missing ..() in the end of the loadout which granted it the pouches, weapons, and etc. Now you don't spawn in gear less. But hey at least you were not naked. Likely caused by survivor QOL update when pouches and etc were moved around.

## Changelog

:cl:theflyingflail
fix: fixed trijent dam cl survivor not spawning with survivor equipment
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
