### PR TITLE
No more stored suicide bomb mice

### DIFF
--- a/code/modules/mob/holder.dm
+++ b/code/modules/mob/holder.dm
@@ -43,10 +43,13 @@
 	if(isXeno(grabber))
 		to_chat(SPAN_WARNING("You leave [src] alone. It cannot be made a host, so there is no use for it."))
 		return
-	var/obj/item/holder/H = new holder_type(loc)
-	src.forceMove(H)
-	H.name = loc.name
-	H.attack_hand(grabber)
+	var/obj/item/holder/mob_holder = new holder_type(loc)
+	src.forceMove(mob_holder)
+	mob_holder.name = loc.name
+	mob_holder.attack_hand(grabber)
+	
+	if(locate(/obj/item/explosive/plastic) in contents)
+		mob_holder.w_class = SIZE_MASSIVE
 
 	to_chat(grabber, "You scoop up [src].")
 	to_chat(src, "[grabber] scoops you up.")

--- a/code/modules/mob/holder.dm
+++ b/code/modules/mob/holder.dm
@@ -41,15 +41,16 @@
 	if(!holder_type)
 		return
 	if(isXeno(grabber))
-		to_chat(SPAN_WARNING("You leave [src] alone. It cannot be made a host, so there is no use for it."))
+		to_chat(grabber, SPAN_WARNING("You leave [src] alone. It cannot be made a host, so there is no use for it."))
 		return
+	if(locate(/obj/item/explosive/plastic) in contents)
+		to_chat(grabber, SPAN_WARNING("You leave [src] alone. It's got live explosives on it!"))
+		return
+
 	var/obj/item/holder/mob_holder = new holder_type(loc)
 	src.forceMove(mob_holder)
 	mob_holder.name = loc.name
 	mob_holder.attack_hand(grabber)
-	
-	if(locate(/obj/item/explosive/plastic) in contents)
-		mob_holder.w_class = SIZE_MASSIVE
 
 	to_chat(grabber, "You scoop up [src].")
 	to_chat(src, "[grabber] scoops you up.")


### PR DESCRIPTION

## About The Pull Request

Previously people were planting custom C4 on simple mobs and then picking them up and placing them in storage containers allowing another person to then use a signaler to blow the capped person up in the hive.

## Why It's Good For The Game

This is not an intentional usage for custom C4 and was a way to get around checks.

## Changelog

:cl: Morrow
fix: You can no longer use picked up simple mobs to get around the C4 limits.
/:cl:
