### PR TITLE
cluster ob buff

### DIFF
--- a/code/modules/cm_marines/orbital_cannon.dm
+++ b/code/modules/cm_marines/orbital_cannon.dm
@@ -485,10 +485,11 @@ var/list/ob_type_fuel_requirements
 	name = "\improper Cluster orbital warhead"
 	warhead_kind = "cluster"
 	icon_state = "ob_warhead_3"
-	var/total_amount = 60
-	var/instant_amount = 3
-	var/explosion_power = 300
+	var/total_amount = 75 // how many times will the shell fire?
+	var/instant_amount = 3 // how many explosions per time it fires?
+	var/explosion_power = 350
 	var/explosion_falloff = 150
+	var/delay_between_clusters = 0.4 SECONDS // how long between each firing?
 
 /obj/structure/ob_ammo/warhead/cluster/warhead_impact(turf/target)
 	. = ..()
@@ -513,7 +514,7 @@ var/list/ob_type_fuel_requirements
 		for(var/k = 1 to instant_amount)
 			var/turf/U = pick(turf_list)
 			fire_in_a_hole(U)
-		sleep(5)
+		sleep(delay_between_clusters)
 
 /obj/structure/ob_ammo/warhead/cluster/proc/fire_in_a_hole(var/turf/loc)
 	new /obj/effect/overlay/temp/blinking_laser (loc)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

minorly buffs cluster OB to make it more deadly

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

right now cluster is seen to be somewhat useless. It can barely kill ANYTHING as xenos can just walk out of its radius with ease and even tank the explosions. This should make it a bit better for killing and ensure that xenos caught in it have less chance of survival

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: the cluster OB now has 1/6th stronger explosions and fires 25% more explosives in the same time
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
