### PR TITLE
Xeno Generate Name Fix

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/login.dm
+++ b/code/modules/mob/living/carbon/xenomorph/login.dm
@@ -1,7 +1,8 @@
 /mob/living/carbon/Xenomorph/Login()
 	..()
-	generate_name()
 	if(client)
 		set_lighting_alpha_from_prefs(client)
+		if(client.player_data)
+			generate_name()
 	if(SSticker.mode)
 		SSticker.mode.xenomorphs |= mind


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Xenos no longer lose their age/name when they rejoin the game. It's caused by the fact that player_data only loads a bit after login, but at this point the xeno's already in the xeno and has the name generated, so we don't need to do it again.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

yea

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Xenos no longer lose their age/name when rejoining the game.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
