### PR TITLE
Readjust AGM-F

### DIFF
--- a/code/game/objects/items/explosives/grenades/marines.dm
+++ b/code/game/objects/items/explosives/grenades/marines.dm
@@ -144,7 +144,7 @@
 	falloff_mode = EXPLOSION_FALLOFF_SHAPE_LINEAR
 	shrapnel_type = /datum/ammo/bullet/shrapnel/jagged
 	var/direct_hit_shrapnel = 5
-	var/dispersion_angle = 60
+	var/dispersion_angle = 40
 
 /obj/item/explosive/grenade/HE/airburst/prime()
 // We don't prime, we use launch_impact.


### PR DESCRIPTION
## About The Pull Request

Reducing the cone to keep with the reduced shrapnel count.

## Why It's Good For The Game

Attempting to keep AGMF relevant while reducing the unexpected burst from the glitch triggering and doing omega damage.

## Changelog

:cl:
balance: Reduced AGM-F cone from 60 degree to 40 degree. Along with the shrapnel count reduction from a previous change, this has essentially two effects: The situation which caused targets to take all Shrapnels can now at most do ~133% expected damage (down from 250%) and the side-hits are even weaker than they were before. Directly in front of the target still deals damage similar to what it used to be (~8-13 shrapnels)
/:cl:


![image](https://user-images.githubusercontent.com/11231695/185830417-44869f07-89b5-44e8-a48f-1e56ed55431d.png)
