### PR TITLE
Fixes w_class oversight for OT nades

### DIFF
--- a/code/game/objects/items/explosives/explosive.dm
+++ b/code/game/objects/items/explosives/explosive.dm
@@ -184,6 +184,7 @@
 			break
 
 	if(!has_reagents)
+		w_class = initial(w_class)
 		update_icon()
 		playsound(loc, 'sound/items/Screwdriver2.ogg', 25, 1)
 		return

--- a/code/game/objects/items/explosives/explosive.dm
+++ b/code/game/objects/items/explosives/explosive.dm
@@ -184,7 +184,6 @@
 			break
 
 	if(!has_reagents)
-		w_class = initial(w_class)
 		update_icon()
 		playsound(loc, 'sound/items/Screwdriver2.ogg', 25, 1)
 		return

--- a/code/game/objects/items/explosives/grenades/grenade.dm
+++ b/code/game/objects/items/explosives/grenades/grenade.dm
@@ -104,8 +104,8 @@
 		activate_sensors()
 	else
 		active = TRUE
-		w_class = SIZE_MASSIVE // We cheat a little, primed nades become massive so they cant be stored anywhere
 		det_time ? addtimer(CALLBACK(src, .proc/prime), det_time) : prime()
+	w_class = SIZE_MASSIVE // We cheat a little, primed nades become massive so they cant be stored anywhere
 	update_icon()
 
 /obj/item/explosive/grenade/update_icon()

--- a/code/game/objects/items/explosives/grenades/grenade.dm
+++ b/code/game/objects/items/explosives/grenades/grenade.dm
@@ -107,6 +107,11 @@
 		det_time ? addtimer(CALLBACK(src, .proc/prime), det_time) : prime()
 	w_class = SIZE_MASSIVE // We cheat a little, primed nades become massive so they cant be stored anywhere
 	update_icon()
+	
+/obj/item/explosive/grenade/prime(var/force = FALSE)
+	..()
+	if(!QDELETED(src))
+		w_class = initial(w_class)
 
 /obj/item/explosive/grenade/update_icon()
 	if(active && dangerous)


### PR DESCRIPTION

## About The Pull Request

Custom nades had a snowflake path that took them past intended w_class changes for grenades.

## Why It's Good For The Game

Bug bad.

## Changelog

:cl: Morrow
fix: Fixes size oversight for ordnance tech custom grenades.
/:cl:
