### PR TITLE
Consistent planes.

### DIFF
--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -312,6 +312,15 @@ var/list/global/item_storage_box_cache = list()
 					return TRUE
 	return FALSE
 
+/obj/item/storage/Entered(atom/movable/AM, oldloc)
+	. = ..()
+	AM.layer = ABOVE_HUD_LAYER
+	AM.plane = ABOVE_HUD_PLANE
+
+/obj/item/storage/Exited(atom/movable/AM, newloc)
+	. = ..()
+	AM.layer = initial(AM.layer)
+	AM.plane = initial(AM.plane)
 
 /datum/numbered_display
 	var/obj/item/sample_object
@@ -486,11 +495,7 @@ W is always an item. stop_warning prevents messaging. user may be null.**/
 
 	if(new_location)
 		if(ismob(new_location))
-			W.layer = ABOVE_HUD_LAYER
-			W.plane = ABOVE_HUD_PLANE
 			W.pickup(new_location)
-		else
-			W.layer = initial(W.layer)
 		W.forceMove(new_location)
 	else
 		var/turf/T = get_turf(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Closes #845. And generally treats layers and planes for things entering and leaving storage more consistently.
It is still ugly, and I still have dreams of one day refactoring storage items into inventory datum/element/whatever-it-will-end-being, but that is distant imaginary future yet.

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/4447185/185918457-904d9763-3993-4fac-bcf2-c612a1e20b20.png)

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Items dumped out of containers no longer appear on top of mobs.
fix: Spawn pools and egg morphers no longer get blocked by documents and other indestructible items from melted bodies.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
