### PR TITLE
Fix for ghost pills.

### DIFF
--- a/code/game/objects/items/reagent_containers/pill.dm
+++ b/code/game/objects/items/reagent_containers/pill.dm
@@ -84,22 +84,25 @@
 			return
 
 		user.affected_message(M,
-			SPAN_HELPFUL("You <b>start feeding</b> [user == M ? "yourself" : "[M]"] a pill."),
+			SPAN_HELPFUL("You <b>start feeding</b> [M] a pill."),
 			SPAN_HELPFUL("[user] <b>starts feeding</b> you a pill."),
-			SPAN_NOTICE("[user] starts feeding [user == M ? "themselves" : "[M]"] a pill."))
+			SPAN_NOTICE("[user] starts feeding [M] a pill."))
 
 		var/ingestion_time = 30
 		if(user.skills)
 			ingestion_time = max(10, 30 - 10*user.skills.get_skill_level(SKILL_MEDICAL))
 
-		if(!do_after(user, ingestion_time, INTERRUPT_NO_NEEDHAND, BUSY_ICON_FRIENDLY, M, INTERRUPT_MOVED, BUSY_ICON_MEDICAL)) return
+		if(!do_after(user, ingestion_time, INTERRUPT_NO_NEEDHAND, BUSY_ICON_FRIENDLY, M, INTERRUPT_MOVED, BUSY_ICON_MEDICAL))
+			return
+		if(QDELETED(src))
+			return
 
 		user.drop_inv_item_on_ground(src) //icon update
 
 		user.affected_message(M,
-			SPAN_HELPFUL("You [user == M ? "<b>swallowed</b>" : "<b>fed</b> [M]"] a pill."),
+			SPAN_HELPFUL("You <b>fed</b> [M] a pill."),
 			SPAN_HELPFUL("[user] <b>fed</b> you a pill."),
-			SPAN_NOTICE("[user] [user == M ? "swallowed" : "fed [M]"] a pill."))
+			SPAN_NOTICE("[user] fed [M] a pill."))
 		user.count_niche_stat(STATISTICS_NICHE_PILLS)
 
 		var/rgt_list_text = get_reagent_list_text()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Trying to feed the pill a second time during the `do_after` (which is more likely to happen on high lag) resulted in it being properly dropped and qdeleted on first feed, but then dropped again on second feed resolving anyway, resulting in the ghost pill on the ground, which escapes deletion. Checking for `QDELETED` prevents it for now, and one day I will get to actually updating all the `do_after`s to run proper checks for items being used.
Also removed the unnecessary checks in text messages: all of that is happening in the `else` of `if(M==user)`, no need to check for it again.

## Why It's Good For The Game

Closes #897.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Feeding pills to somebody while lagging and clicking a lot no longer leaves ghost pills on the floor.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
