### PR TITLE
Sentry gun un-nerf

### DIFF
--- a/code/modules/defenses/sentry.dm
+++ b/code/modules/defenses/sentry.dm
@@ -438,7 +438,6 @@ obj/structure/machinery/defenses/sentry/premade/damaged_action()
 	density = TRUE
 	faction_group = FACTION_LIST_MARINE
 	omni_directional = TRUE
-	damage_mult = 0.7
 	var/obj/structure/dropship_equipment/sentry_holder/deployment_system
 
 /obj/structure/machinery/defenses/sentry/premade/dropship/Destroy()
@@ -527,16 +526,16 @@ obj/structure/machinery/defenses/sentry/premade/damaged_action()
 	var/obj/structure/machinery/camera/cas/linked_cam
 	var/static/sentry_count = 1
 	var/sentry_number
-	
+
 /obj/structure/machinery/defenses/sentry/launchable/Initialize()
 	. = ..()
 	sentry_number = sentry_count
 	sentry_count++
-	
+
 /obj/structure/machinery/defenses/sentry/launchable/Destroy()
 	QDEL_NULL(linked_cam)
 	. = ..()
-	
+
 /obj/structure/machinery/defenses/sentry/launchable/power_on_action()
 	. = ..()
 	linked_cam = new(loc, "[name] [sentry_number] at [get_area(src)] ([obfuscate_x(x)], [obfuscate_y(y)])")
@@ -544,7 +543,7 @@ obj/structure/machinery/defenses/sentry/premade/damaged_action()
 /obj/structure/machinery/defenses/sentry/launchable/power_off_action()
 	. = ..()
 	QDEL_NULL(linked_cam)
-	
+
 
 /obj/structure/machinery/defenses/sentry/launchable/attack_hand_checks(var/mob/user)
 	return TRUE // We want to be able to turn it on / off while keeping it immobile


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Un-nerfs the DS mounted sentry guns
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Damage was reduced pre-emptively after I set them to fire 360, turns out they did not need that nerf so this PR removes the 30% damage reduction I had imposed prior.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
Removes 30% damage reduction on DS mounted sentry guns returning them to base stats.
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:

balance: Removed 30% damage reduction from DS mounted sentries.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
