### PR TITLE
bugfix: move delay after stopping to pull a mob

### DIFF
--- a/code/modules/mob/mob_verbs.dm
+++ b/code/modules/mob/mob_verbs.dm
@@ -226,8 +226,6 @@
 		pulling = null
 
 		grab_level = 0
-
-
 		if(client)
 			client.recalculate_move_delay()
 			// When you stop pulling a mob after you move a tile with it your next movement will still include

--- a/code/modules/mob/mob_verbs.dm
+++ b/code/modules/mob/mob_verbs.dm
@@ -226,8 +226,13 @@
 		pulling = null
 
 		grab_level = 0
+
+
 		if(client)
 			client.recalculate_move_delay()
+			// When you stop pulling a mob after you move a tile with it your next movement will still include
+			// the grab delay so we have to fix it here (we love code)
+			client.next_movement = world.time + client.move_delay
 		if(hud_used && hud_used.pull_icon)
 			hud_used.pull_icon.icon_state = "pull0"
 		if(istype(r_hand, /obj/item/grab))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
If you grab and pull a mob then stop pulling it and try to move you will have the same move delay as if you are grabbing the mob even though you are not grabbing it for one tile - this fixes it

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
bugs are bad for the game so if there is less bad there is more good for the game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixed a bug which would make you have increased movement delay after stopping to pull a mob for one tile
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
