### PR TITLE
Fix area names having their first letter sometimes truncated during sanitization

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -25,37 +25,41 @@
 	return t
 
 //Removes a few problematic characters
-/proc/sanitize_simple(var/t, var/list/repl_chars = list("\n"=" ","\t"=" ","�"=" "))
+/proc/sanitize_simple(var/text, var/list/repl_chars = list("\n"=" ","\t"=" ","�"=" "))
 	for(var/char in repl_chars)
-		t = replacetext(t, char, repl_chars[char])
-	return t
+		text = replacetext(text, char, repl_chars[char])
+	return text
 
-/proc/readd_quotes(var/t)
+/proc/readd_quotes(var/text)
 	var/list/repl_chars = list("&#34;" = "\"", "&#39;" = "'")
 	for(var/char in repl_chars)
-		t = replacetext(t, char, repl_chars[char])
-	return t
+		text = replacetext(text, char, repl_chars[char])
+	return text
 
 //Runs byond's sanitization proc along-side sanitize_simple
-/proc/sanitize(var/t,var/list/repl_chars = list("\n"=" ","\t"=" ","�"=" "))
-	var/msg = html_encode(sanitize_simple(t, repl_chars))
-	return readd_quotes(msg)
+/proc/sanitize(var/input, var/list/repl_chars = list("\n"=" ","\t"=" ","�"=" "))
+	var/output = html_encode(sanitize_simple(input, repl_chars))
+	return readd_quotes(output)
+
+//Runs byond's sanitization proc along-side sanitize_simple without the Specials unicode check
+/proc/sanitize_area(var/input, var/list/repl_chars = list("\n"=" ","\t"=" "))
+	var/output = html_encode(sanitize_simple(input, repl_chars))
+	return readd_quotes(output)
 
 //Removes control chars like "\n"
-/proc/sanitize_control_chars(var/stuff)
+/proc/sanitize_control_chars(var/text)
 	var/static/regex/whitelistedWords = regex(@{"([^\u0020-\u8000]+)"}, "g")
-	return whitelistedWords.Replace(stuff, "")
+	return whitelistedWords.Replace(text, "")
 
 //Runs sanitize and strip_html_simple
 //I believe strip_html_simple() is required to run first to prevent '<' from displaying as '&lt;' after sanitize() calls byond's html_encode()
-/proc/strip_html(var/t,var/limit=MAX_MESSAGE_LEN)
-	return copytext((sanitize(strip_html_simple(t))),1,limit)
+/proc/strip_html(var/text, var/limit=MAX_MESSAGE_LEN)
+	return copytext((sanitize(strip_html_simple(text))), 1, limit)
 
 //Runs byond's sanitization proc along-side strip_html_simple
 //I believe strip_html_simple() is required to run first to prevent '<' from displaying as '&lt;' that html_encode() would cause
-/proc/adminscrub(var/t,var/limit=MAX_MESSAGE_LEN)
-	return copytext((html_encode(strip_html_simple(t))),1,limit)
-
+/proc/adminscrub(var/text, var/limit=MAX_MESSAGE_LEN)
+	return copytext((html_encode(strip_html_simple(text))), 1, limit)
 
 //Returns null if there is any bad text in the string
 /proc/reject_bad_text(var/text, var/max_length=512)

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -41,9 +41,9 @@
 	var/output = html_encode(sanitize_simple(input, repl_chars))
 	return readd_quotes(output)
 
-//Runs byond's sanitization proc along-side sanitize_simple without the Specials unicode check
-/proc/sanitize_area(var/input, var/list/repl_chars = list("\n"=" ","\t"=" "))
-	var/output = html_encode(sanitize_simple(input, repl_chars))
+//Runs byond's sanitization proc along-side strip_improper
+/proc/sanitize_area(var/input)
+	var/output = html_encode(strip_improper(input))
 	return readd_quotes(output)
 
 //Removes control chars like "\n"

--- a/code/datums/statistics/entities/panel_stats.dm
+++ b/code/datums/statistics/entities/panel_stats.dm
@@ -117,7 +117,7 @@
 			death_list += list(list(
 				"mob_name" = sanitize(S.mob_name),
 				"job_name" = S.role_name,
-				"area_name" = sanitize(S.area_name, list("\n"=" ","\t"=" ")),
+				"area_name" = sanitize_area(S.area_name),
 				"cause_name" = sanitize(S.cause_name),
 				"total_kills" = S.total_kills,
 				"total_damage" = damage_list,
@@ -199,7 +199,7 @@
 				death_list += list(list(
 					"mob_name" = sanitize(DS.mob_name),
 					"job_name" = DS.role_name,
-					"area_name" = sanitize(DS.area_name, list("\n"=" ","\t"=" ")),
+					"area_name" = sanitize_area(DS.area_name),
 					"cause_name" = sanitize(DS.cause_name),
 					"total_kills" = DS.total_kills,
 					"total_damage" = damage_list,
@@ -311,7 +311,7 @@
 			death_list += list(list(
 				"mob_name" = sanitize(S.mob_name),
 				"job_name" = S.role_name,
-				"area_name" = sanitize(S.area_name, list("\n"=" ","\t"=" ")),
+				"area_name" = sanitize_area(S.area_name),
 				"cause_name" = sanitize(S.cause_name),
 				"total_kills" = S.total_kills,
 				"total_damage" = damage_list,
@@ -366,7 +366,7 @@
 				death_list += list(list(
 					"mob_name" = sanitize(DS.mob_name),
 					"job_name" = DS.role_name,
-					"area_name" = sanitize(DS.area_name, list("\n"=" ","\t"=" ")),
+					"area_name" = sanitize_area(DS.area_name),
 					"cause_name" = sanitize(DS.cause_name),
 					"total_kills" = DS.total_kills,
 					"total_damage" = damage_list,
@@ -468,7 +468,7 @@
 		var/death = list(list(
 			"mob_name" = sanitize(S.mob_name),
 			"job_name" = S.role_name,
-			"area_name" = sanitize(S.area_name, list("\n"=" ","\t"=" ")),
+			"area_name" = sanitize_area(S.area_name),
 			"cause_name" = sanitize(S.cause_name),
 			"total_kills" = S.total_kills,
 			"total_damage" = damage_list,
@@ -572,7 +572,7 @@
 			job_death_list += list(list(
 				"mob_name" = sanitize(DS.mob_name),
 				"job_name" = DS.role_name,
-				"area_name" = sanitize(DS.area_name, list("\n"=" ","\t"=" ")),
+				"area_name" = sanitize_area(DS.area_name),
 				"cause_name" = sanitize(DS.cause_name),
 				"total_kills" = DS.total_kills,
 				"total_damage" = damage_list,
@@ -663,7 +663,7 @@
 			caste_death_list += list(list(
 				"mob_name" = sanitize(DS.mob_name),
 				"job_name" = DS.role_name,
-				"area_name" = sanitize(DS.area_name, list("\n"=" ","\t"=" ")),
+				"area_name" = sanitize_area(DS.area_name),
 				"cause_name" = sanitize(DS.cause_name),
 				"total_kills" = DS.total_kills,
 				"total_damage" = damage_list,

--- a/code/datums/statistics/entities/panel_stats.dm
+++ b/code/datums/statistics/entities/panel_stats.dm
@@ -117,7 +117,7 @@
 			death_list += list(list(
 				"mob_name" = sanitize(S.mob_name),
 				"job_name" = S.role_name,
-				"area_name" = sanitize(S.area_name),
+				"area_name" = sanitize(S.area_name, list("\n"=" ","\t"=" ")),
 				"cause_name" = sanitize(S.cause_name),
 				"total_kills" = S.total_kills,
 				"total_damage" = damage_list,
@@ -199,7 +199,7 @@
 				death_list += list(list(
 					"mob_name" = sanitize(DS.mob_name),
 					"job_name" = DS.role_name,
-					"area_name" = sanitize(DS.area_name),
+					"area_name" = sanitize(DS.area_name, list("\n"=" ","\t"=" ")),
 					"cause_name" = sanitize(DS.cause_name),
 					"total_kills" = DS.total_kills,
 					"total_damage" = damage_list,
@@ -311,7 +311,7 @@
 			death_list += list(list(
 				"mob_name" = sanitize(S.mob_name),
 				"job_name" = S.role_name,
-				"area_name" = sanitize(S.area_name),
+				"area_name" = sanitize(S.area_name, list("\n"=" ","\t"=" ")),
 				"cause_name" = sanitize(S.cause_name),
 				"total_kills" = S.total_kills,
 				"total_damage" = damage_list,
@@ -366,7 +366,7 @@
 				death_list += list(list(
 					"mob_name" = sanitize(DS.mob_name),
 					"job_name" = DS.role_name,
-					"area_name" = sanitize(DS.area_name),
+					"area_name" = sanitize(DS.area_name, list("\n"=" ","\t"=" ")),
 					"cause_name" = sanitize(DS.cause_name),
 					"total_kills" = DS.total_kills,
 					"total_damage" = damage_list,
@@ -468,7 +468,7 @@
 		var/death = list(list(
 			"mob_name" = sanitize(S.mob_name),
 			"job_name" = S.role_name,
-			"area_name" = sanitize(S.area_name),
+			"area_name" = sanitize(S.area_name, list("\n"=" ","\t"=" ")),
 			"cause_name" = sanitize(S.cause_name),
 			"total_kills" = S.total_kills,
 			"total_damage" = damage_list,
@@ -572,7 +572,7 @@
 			job_death_list += list(list(
 				"mob_name" = sanitize(DS.mob_name),
 				"job_name" = DS.role_name,
-				"area_name" = sanitize(DS.area_name),
+				"area_name" = sanitize(DS.area_name, list("\n"=" ","\t"=" ")),
 				"cause_name" = sanitize(DS.cause_name),
 				"total_kills" = DS.total_kills,
 				"total_damage" = damage_list,
@@ -663,7 +663,7 @@
 			caste_death_list += list(list(
 				"mob_name" = sanitize(DS.mob_name),
 				"job_name" = DS.role_name,
-				"area_name" = sanitize(DS.area_name),
+				"area_name" = sanitize(DS.area_name, list("\n"=" ","\t"=" ")),
 				"cause_name" = sanitize(DS.cause_name),
 				"total_kills" = DS.total_kills,
 				"total_damage" = damage_list,

--- a/code/datums/statistics/entities/round_stats.dm
+++ b/code/datums/statistics/entities/round_stats.dm
@@ -274,7 +274,7 @@
 		var/death = list(list(
 			"mob_name" = sanitize(new_death.mob_name),
 			"job_name" = new_death.role_name,
-			"area_name" = sanitize(new_death.area_name, list("\n"=" ","\t"=" ")),
+			"area_name" = sanitize_area(new_death.area_name),
 			"cause_name" = sanitize(new_death.cause_name),
 			"total_kills" = new_death.total_kills,
 			"total_damage" = damage_list,

--- a/code/datums/statistics/entities/round_stats.dm
+++ b/code/datums/statistics/entities/round_stats.dm
@@ -274,7 +274,7 @@
 		var/death = list(list(
 			"mob_name" = sanitize(new_death.mob_name),
 			"job_name" = new_death.role_name,
-			"area_name" = sanitize(new_death.area_name),
+			"area_name" = sanitize(new_death.area_name, list("\n"=" ","\t"=" ")),
 			"cause_name" = sanitize(new_death.cause_name),
 			"total_kills" = new_death.total_kills,
 			"total_damage" = damage_list,

--- a/code/game/machinery/computer/groundside_operations.dm
+++ b/code/game/machinery/computer/groundside_operations.dm
@@ -126,7 +126,7 @@
 				var/area/A = get_area(H)
 				var/turf/M_turf = get_turf(H)
 				if(A)
-					area_name = sanitize(A.name)
+					area_name = sanitize(A.name, list("\n"=" ","\t"=" "))
 
 				if(H.job)
 					role = H.job

--- a/code/game/machinery/computer/groundside_operations.dm
+++ b/code/game/machinery/computer/groundside_operations.dm
@@ -126,7 +126,7 @@
 				var/area/A = get_area(H)
 				var/turf/M_turf = get_turf(H)
 				if(A)
-					area_name = sanitize(A.name, list("\n"=" ","\t"=" "))
+					area_name = sanitize_area(A.name)
 
 				if(H.job)
 					role = H.job

--- a/code/game/objects/items/tools/experimental_tools.dm
+++ b/code/game/objects/items/tools/experimental_tools.dm
@@ -82,7 +82,7 @@
 				var/area/A = get_area(H)
 				var/turf/M_turf = get_turf(H)
 				if(A)
-					area_name = sanitize(A.name)
+					area_name = sanitize(A.name, list("\n"=" ","\t"=" "))
 
 				if(H.undefibbable)
 					continue

--- a/code/game/objects/items/tools/experimental_tools.dm
+++ b/code/game/objects/items/tools/experimental_tools.dm
@@ -82,7 +82,7 @@
 				var/area/A = get_area(H)
 				var/turf/M_turf = get_turf(H)
 				if(A)
-					area_name = sanitize(A.name, list("\n"=" ","\t"=" "))
+					area_name = sanitize_area(A.name)
 
 				if(H.undefibbable)
 					continue

--- a/code/modules/cm_aliens/structures/resource_collector.dm
+++ b/code/modules/cm_aliens/structures/resource_collector.dm
@@ -22,7 +22,7 @@
 		linked_hive = hive_ref
 		if(linked_hive.living_xeno_queen)
 			var/current_area_name = get_area_name(src)
-			xeno_message("Hive: \A [src] has been constructed at [sanitize(current_area_name, list("\n"=" ","\t"=" "))]!", 3, linked_hive.hivenumber)
+			xeno_message("Hive: \A [src] has been constructed at [sanitize_area(current_area_name)]!", 3, linked_hive.hivenumber)
 	if(new_node)
 		connected_node = new_node
 		connected_node.update_icon()
@@ -50,7 +50,7 @@
 	if(!connected_node)
 		visible_message(SPAN_DANGER("\The [src] groans and collapses as its contents are reduced to nothing!"))
 		if(linked_hive.living_xeno_queen)
-			xeno_message("Hive: \A [src] has been depleted at [sanitize(current_area_name, list("\n"=" ","\t"=" "))]!", 3, linked_hive.hivenumber)
+			xeno_message("Hive: \A [src] has been depleted at [sanitize_area(current_area_name)]!", 3, linked_hive.hivenumber)
 		qdel(src)
 		return
 	last_gathered_time = world.time

--- a/code/modules/cm_aliens/structures/resource_collector.dm
+++ b/code/modules/cm_aliens/structures/resource_collector.dm
@@ -22,7 +22,7 @@
 		linked_hive = hive_ref
 		if(linked_hive.living_xeno_queen)
 			var/current_area_name = get_area_name(src)
-			xeno_message("Hive: \A [src] has been constructed at [sanitize(current_area_name)]!", 3, linked_hive.hivenumber)
+			xeno_message("Hive: \A [src] has been constructed at [sanitize(current_area_name, list("\n"=" ","\t"=" "))]!", 3, linked_hive.hivenumber)
 	if(new_node)
 		connected_node = new_node
 		connected_node.update_icon()
@@ -50,7 +50,7 @@
 	if(!connected_node)
 		visible_message(SPAN_DANGER("\The [src] groans and collapses as its contents are reduced to nothing!"))
 		if(linked_hive.living_xeno_queen)
-			xeno_message("Hive: \A [src] has been depleted at [sanitize(current_area_name)]!", 3, linked_hive.hivenumber)
+			xeno_message("Hive: \A [src] has been depleted at [sanitize(current_area_name, list("\n"=" ","\t"=" "))]!", 3, linked_hive.hivenumber)
 		qdel(src)
 		return
 	last_gathered_time = world.time

--- a/code/modules/cm_aliens/structures/special_structure.dm
+++ b/code/modules/cm_aliens/structures/special_structure.dm
@@ -57,7 +57,7 @@
 	if(linked_hive)
 		linked_hive.remove_special_structure(src)
 		if(linked_hive.living_xeno_queen)
-			xeno_message("Hive: \A [name] has been destroyed at [sanitize(get_area_name(src))]!", 3, linked_hive.hivenumber)
+			xeno_message("Hive: \A [name] has been destroyed at [sanitize(get_area_name(src), list("\n"=" ","\t"=" "))]!", 3, linked_hive.hivenumber)
 	linked_hive = null
 	STOP_PROCESSING(SSfastobj, src)
 

--- a/code/modules/cm_aliens/structures/special_structure.dm
+++ b/code/modules/cm_aliens/structures/special_structure.dm
@@ -57,7 +57,7 @@
 	if(linked_hive)
 		linked_hive.remove_special_structure(src)
 		if(linked_hive.living_xeno_queen)
-			xeno_message("Hive: \A [name] has been destroyed at [sanitize(get_area_name(src), list("\n"=" ","\t"=" "))]!", 3, linked_hive.hivenumber)
+			xeno_message("Hive: \A [name] has been destroyed at [sanitize_area(get_area_name(src))]!", 3, linked_hive.hivenumber)
 	linked_hive = null
 	STOP_PROCESSING(SSfastobj, src)
 

--- a/code/modules/cm_marines/marines_consoles.dm
+++ b/code/modules/cm_marines/marines_consoles.dm
@@ -831,7 +831,7 @@ GLOBAL_LIST_EMPTY_TYPED(crewmonitor, /datum/crewmonitor)
 			if(is_mainship_level(pos.z))
 				entry["side"] = "Almayer"
 			var/area/A = get_area(H)
-			entry["area"] = sanitize(A.name)
+			entry["area"] = sanitize(A.name, list("\n"=" ","\t"=" "))
 
 		// Trackability
 		entry["can_track"] = H.detectable_by_ai()

--- a/code/modules/cm_marines/marines_consoles.dm
+++ b/code/modules/cm_marines/marines_consoles.dm
@@ -831,7 +831,7 @@ GLOBAL_LIST_EMPTY_TYPED(crewmonitor, /datum/crewmonitor)
 			if(is_mainship_level(pos.z))
 				entry["side"] = "Almayer"
 			var/area/A = get_area(H)
-			entry["area"] = sanitize(A.name, list("\n"=" ","\t"=" "))
+			entry["area"] = sanitize_area(A.name)
 
 		// Trackability
 		entry["can_track"] = H.detectable_by_ai()

--- a/code/modules/cm_marines/overwatch.dm
+++ b/code/modules/cm_marines/overwatch.dm
@@ -197,7 +197,7 @@
 				if(!M_turf)
 					continue
 				if(A)
-					area_name = sanitize(A.name)
+					area_name = sanitize(A.name, list("\n"=" ","\t"=" "))
 
 				switch(z_hidden)
 					if(HIDE_ALMAYER)

--- a/code/modules/cm_marines/overwatch.dm
+++ b/code/modules/cm_marines/overwatch.dm
@@ -197,7 +197,7 @@
 				if(!M_turf)
 					continue
 				if(A)
-					area_name = sanitize(A.name, list("\n"=" ","\t"=" "))
+					area_name = sanitize_area(A.name)
 
 				switch(z_hidden)
 					if(HIDE_ALMAYER)

--- a/code/modules/mob/living/carbon/xenomorph/Powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Powers.dm
@@ -158,7 +158,7 @@
 	playsound(new_structure, "alien_resin_build", 25)
 
 	if(hive.living_xeno_queen)
-		xeno_message("Hive: A new <b>[structure_template]<b> construction has been designated at [sanitize(current_area_name)]!", 3, hivenumber)
+		xeno_message("Hive: A new <b>[structure_template]<b> construction has been designated at [sanitize(current_area_name, list("\n"=" ","\t"=" "))]!", 3, hivenumber)
 
 /mob/living/carbon/Xenomorph/proc/make_marker(turf/target_turf)
 	if(!target_turf)
@@ -194,6 +194,6 @@
 		var/current_area_name = get_area_name(target_turf)
 
 		for(var/mob/living/carbon/Xenomorph/X in hive.totalXenos)
-			to_chat(X, SPAN_XENOANNOUNCE("[src.name] has declared: [NM.mark_meaning.desc] in [sanitize(current_area_name)]! (<a href='?src=\ref[X];overwatch=1;target=\ref[NM]'>Watch</a>) (<a href='?src=\ref[X];track=1;target=\ref[NM]'>Track</a>)"))
+			to_chat(X, SPAN_XENOANNOUNCE("[src.name] has declared: [NM.mark_meaning.desc] in [sanitize(current_area_name, list("\n"=" ","\t"=" "))]! (<a href='?src=\ref[X];overwatch=1;target=\ref[NM]'>Watch</a>) (<a href='?src=\ref[X];track=1;target=\ref[NM]'>Track</a>)"))
 			//this is killing the tgui chat and I dont know why
 	return TRUE

--- a/code/modules/mob/living/carbon/xenomorph/Powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Powers.dm
@@ -158,7 +158,7 @@
 	playsound(new_structure, "alien_resin_build", 25)
 
 	if(hive.living_xeno_queen)
-		xeno_message("Hive: A new <b>[structure_template]<b> construction has been designated at [sanitize(current_area_name, list("\n"=" ","\t"=" "))]!", 3, hivenumber)
+		xeno_message("Hive: A new <b>[structure_template]<b> construction has been designated at [sanitize_area(current_area_name)]!", 3, hivenumber)
 
 /mob/living/carbon/Xenomorph/proc/make_marker(turf/target_turf)
 	if(!target_turf)
@@ -194,6 +194,6 @@
 		var/current_area_name = get_area_name(target_turf)
 
 		for(var/mob/living/carbon/Xenomorph/X in hive.totalXenos)
-			to_chat(X, SPAN_XENOANNOUNCE("[src.name] has declared: [NM.mark_meaning.desc] in [sanitize(current_area_name, list("\n"=" ","\t"=" "))]! (<a href='?src=\ref[X];overwatch=1;target=\ref[NM]'>Watch</a>) (<a href='?src=\ref[X];track=1;target=\ref[NM]'>Track</a>)"))
+			to_chat(X, SPAN_XENOANNOUNCE("[src.name] has declared: [NM.mark_meaning.desc] in [sanitize_area(current_area_name)]! (<a href='?src=\ref[X];overwatch=1;target=\ref[NM]'>Watch</a>) (<a href='?src=\ref[X];track=1;target=\ref[NM]'>Track</a>)"))
 			//this is killing the tgui chat and I dont know why
 	return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Instead of: 
![image](https://user-images.githubusercontent.com/76988376/186837590-9bcc89a2-c8f2-4a41-b8c3-35e32eb03499.png)
How about: 
![image](https://user-images.githubusercontent.com/76988376/186837605-79eec1c0-a9a0-4b8e-b79c-57561b323b11.png)

Some reason replacetext in code\__HELPERS\text.dm is also including the first char we want, usage of replacetext_char has no effect on this behavior, replacetextEx doesn't seem to match the special char, and html_encode is already removing the characters we don't want. Let me know if the default sanitization should just be changed, or if there's a different solution to this that would be preferred. I figured turf names are much harder to exploit so we can probably be less aggressive on the sanitization there, but I do not know what exploit was entailed in https://github.com/cmss13-devs/cmss13/commit/e0027fbde74cc4c6ed9caac81cbcc75f24679faf to know if this change would undo that fix.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Correct area names that don't have their first letter truncated.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Drathek
fix: Fixed strings of area names (e.g. "ombat Information Center") by using strip_improper instead.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
