### PR TITLE
M56D infinite ammo fix

### DIFF
--- a/code/modules/cm_marines/smartgun_mount.dm
+++ b/code/modules/cm_marines/smartgun_mount.dm
@@ -556,7 +556,7 @@
 		if(rounds)
 			var/obj/item/ammo_magazine/m56d/D = new(user.loc)
 			D.current_rounds = rounds
-		rounds = min(rounds + M.current_rounds, rounds_max)
+		rounds = M.current_rounds
 		update_icon()
 		user.temp_drop_inv_item(O)
 		qdel(O)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Fixes the M56D infinite ammo bug described in #907: swapping drums in an M56D twice would cause the drum currently inserted to reset to its max round count, providing effectively infinite ammunition.

## Why It's Good For The Game

No more infinite ammo, and all from one line of changed code. Wow!

Closes #907.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: nauticall
fix: Fixed M56D infinite ammo bug caused by swapping drum magazines on an M56D emplacement.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
