### PR TITLE
Brings back Agility Mode to warrior, with tweaks.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/warrior/warrior_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/warrior/warrior_abilities.dm
@@ -6,7 +6,7 @@
 	macro_path = /datum/action/xeno_action/verb/verb_toggle_agility
 	action_type = XENO_ACTION_CLICK
 	ability_primacy = XENO_PRIMARY_ACTION_4
-	xeno_cooldown = 10
+	xeno_cooldown = 40
 
 /datum/action/xeno_action/onclick/toggle_agility/can_use_action()
 	var/mob/living/carbon/Xenomorph/X = owner

--- a/code/modules/mob/living/carbon/xenomorph/abilities/warrior/warrior_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/warrior/warrior_abilities.dm
@@ -5,6 +5,7 @@
 	ability_name = "toggle agility"
 	macro_path = /datum/action/xeno_action/verb/verb_toggle_agility
 	action_type = XENO_ACTION_CLICK
+	ability_primacy = XENO_PRIMARY_ACTION_4
 	xeno_cooldown = 10
 
 /datum/action/xeno_action/onclick/toggle_agility/can_use_action()

--- a/code/modules/mob/living/carbon/xenomorph/abilities/warrior/warrior_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/warrior/warrior_powers.dm
@@ -71,9 +71,6 @@
 	if (!isXenoOrHuman(A) || X.can_not_harm(A))
 		return
 
-	if (!X.check_state() || X.agility)
-		return
-
 	if (!X.Adjacent(A))
 		return
 
@@ -122,9 +119,6 @@
 		return
 
 	if (!isXenoOrHuman(A) || X.can_not_harm(A))
-		return
-
-	if (!X.check_state() || X.agility)
 		return
 
 	var/distance = get_dist(X, A)

--- a/code/modules/mob/living/carbon/xenomorph/abilities/warrior/warrior_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/warrior/warrior_powers.dm
@@ -14,9 +14,6 @@
 		to_chat(X, SPAN_XENOWARNING("You can't lunge from here!"))
 		return
 
-	if (!X.check_state() || X.agility)
-		return
-
 	if(X.can_not_harm(A) || !ismob(A))
 		apply_cooldown_override(click_miss_cooldown)
 		return

--- a/code/modules/mob/living/carbon/xenomorph/abilities/warrior/warrior_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/warrior/warrior_powers.dm
@@ -124,6 +124,9 @@
 	if (!isXenoOrHuman(A) || X.can_not_harm(A))
 		return
 
+	if (!X.check_state())
+		return
+
 	var/distance = get_dist(X, A)
 
 	if (distance > 2)

--- a/code/modules/mob/living/carbon/xenomorph/abilities/warrior/warrior_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/warrior/warrior_powers.dm
@@ -14,6 +14,9 @@
 		to_chat(X, SPAN_XENOWARNING("You can't lunge from here!"))
 		return
 
+	if (!X.check_state() || X.agility)
+		return
+
 	if(X.can_not_harm(A) || !ismob(A))
 		apply_cooldown_override(click_miss_cooldown)
 		return
@@ -66,6 +69,9 @@
 		return
 
 	if (!isXenoOrHuman(A) || X.can_not_harm(A))
+		return
+
+	if (!X.check_state() || X.agility)
 		return
 
 	if (!X.Adjacent(A))

--- a/code/modules/mob/living/carbon/xenomorph/castes/Warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Warrior.dm
@@ -23,7 +23,7 @@
 	tackle_min = 2
 	tackle_max = 4
 
-	agility_speed_increase = -0.4
+	agility_speed_increase = -0.5
 
 	heal_resting = 1.4
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/Warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Warrior.dm
@@ -44,6 +44,7 @@
 		/datum/action/xeno_action/onclick/xeno_resting,
 		/datum/action/xeno_action/onclick/regurgitate,
 		/datum/action/xeno_action/watch_xeno,
+		/datum/action/xeno_action/onclick/toggle_agility,
 		/datum/action/xeno_action/activable/warrior_punch,
 		/datum/action/xeno_action/activable/lunge,
 		/datum/action/xeno_action/activable/fling,

--- a/code/modules/mob/living/carbon/xenomorph/castes/Warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Warrior.dm
@@ -23,7 +23,7 @@
 	tackle_min = 2
 	tackle_max = 4
 
-	agility_speed_increase = -0.9
+	agility_speed_increase = -0.4
 
 	heal_resting = 1.4
 


### PR DESCRIPTION


## About The Pull Request

Brings back the Agility Mode ability from warrior. It gives a minor speed increase, and allows you to slash and use the Punch ability. You cannot use fling, or lunge while it is toggled. The speed is comparable to an uncloaked lurker (the lurker is still slightly faster).

## Why It's Good For The Game

Warrior as of right now is performing below average. After the double shotgun removal, slugs have been in use more commonly showing how powerful they actually are. Warrior on the other hand, has eaten multiple nerfs over time, such as bone break on punch removal, losing 60 shield and 50 points of HP, etc. Firerates and damage (HPR) for marines have also increased, and combos with loadouts (double a-grip slug/m41a) can burst a warrior over a single stun. This PR hopes to improve warriors front lining ability by bringing back its movement/semi-escape option and allowing it to contest with slug users as well as allowing warriors a form of brawling without being as slow as they are.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Agility Mode to warrior. The ability can be toggled on and off with a cooldown.
balance: Agility mode has been tweaked to be slower, you can now use Punch with it active.
/:cl:
