### PR TITLE
Revert warrior change

### DIFF
--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -78,6 +78,8 @@
 		if(isliving(A) && M.a_intent == INTENT_HARM)
 			if(isYautja(A))
 				return 0
+			if(isXeno(A))
+				return 0
 			if (ishuman(A))
 				var/mob/living/carbon/human/L = A
 				var/boxing_icon = pick("boxing_up","boxing_down","boxing_left","boxing_right")

--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -76,9 +76,7 @@
 	var/boxing_verb = pick(attack_verb)
 	if (A in range(1, M))
 		if(isliving(A) && M.a_intent == INTENT_HARM)
-			if(isYautja(A))
-				return 0
-			if(isXeno(A))
+			if(isYautja(A) || isXeno(A))
 				return 0
 			if (ishuman(A))
 				var/mob/living/carbon/human/L = A

--- a/code/modules/mob/living/carbon/xenomorph/abilities/warrior/warrior_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/warrior/warrior_powers.dm
@@ -134,6 +134,9 @@
 
 	var/mob/living/carbon/H = A
 
+	if (!X.Adjacent(H))
+		return
+
 	if(H.stat == DEAD) return
 	if(HAS_TRAIT(H, TRAIT_NESTED)) return
 

--- a/code/modules/mob/living/carbon/xenomorph/abilities/warrior/warrior_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/warrior/warrior_powers.dm
@@ -182,19 +182,3 @@
 
 	shake_camera(H, 2, 1)
 	step_away(H, X, 2)
-
-	// Check actions list for a warrior punch and reset it's cooldown if it's there
-	var/datum/action/xeno_action/activable/warrior_punch/punch_action = null
-	for (var/datum/action/xeno_action/activable/warrior_punch/P in X.actions)
-		punch_action = P
-		break
-
-	if (punch_action && !punch_action.action_cooldown_check())
-		if(isXeno(H))
-			punch_action.reduce_cooldown(punch_action.xeno_cooldown / 2)
-		else
-			punch_action.end_cooldown()
-
-	H.Daze(3)
-	H.Slow(5)
-	apply_cooldown()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
reversion: https://github.com/cmss13-devs/cmss13/pull/839#pullrequestreview-1087654817
reversion of daze as well + possible runtime with boxing gloves on xeno?


## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Unintended change.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Reverted a change allowing warriors to punch from 2 tiles away and giving them daze on punch.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
