### PR TITLE
New synthvivor loadouts & Fiorina spelling fixes

### DIFF
--- a/code/game/machinery/vending/vendor_types/crew/synthetic.dm
+++ b/code/game/machinery/vending/vendor_types/crew/synthetic.dm
@@ -80,7 +80,7 @@ GLOBAL_LIST_INIT(cm_vending_clothing_synth, list(
 		list("Experimental Tool Vendor Token", 0, /obj/item/coin/marine/synth, MARINE_CAN_BUY_ESSENTIALS, VENDOR_ITEM_MANDATORY),
 
 		list("RADIO (TAKE ALL)", 0, null, null, null),
-		list("Headset", 0, /obj/item/device/radio/headset/almayer/mcom/cdrcom, MARINE_CAN_BUY_EAR, VENDOR_ITEM_MANDATORY),
+		list("Headset", 0, /obj/item/device/radio/headset/almayer/mcom/synth, MARINE_CAN_BUY_EAR, VENDOR_ITEM_MANDATORY),
 
 		list("UNIFORM (CHOOSE 1)", 0, null, null, null),
 		list("Medical Scrubs, Green", 0, /obj/item/clothing/under/rank/medical/green, MARINE_CAN_BUY_UNIFORM, VENDOR_ITEM_REGULAR),

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -352,6 +352,18 @@
 	if(ishuman(user))
 		to_chat(user, SPAN_NOTICE("It reads \"[registered_name] - [assignment] - [blood_type]\""))
 
+/obj/item/card/id/dogtag_synth //not a subtype because synths cannot "die", prevents unintended behaviour with info tag removal.
+	name = "synthetic dog tag"
+	desc = "A military synthetic dog tag. Lacks a standard information tag."
+	icon_state = "dogtag"
+	item_state = "dogtag"
+	pinned_on_uniform = FALSE
+
+/obj/item/card/id/dogtag_synth/examine(mob/user)
+	..()
+	if(ishuman(user))
+		to_chat(user, SPAN_NOTICE("It reads \"[registered_name] - [assignment]\""))
+
 
 /obj/item/dogtag
 	name = "information dog tag"

--- a/code/modules/gear_presets/_select_equipment.dm
+++ b/code/modules/gear_presets/_select_equipment.dm
@@ -20,6 +20,7 @@
 	var/minimum_age
 	var/faction = FACTION_NEUTRAL
 	var/list/faction_group
+	var/list/override_faction_group
 
 	//Uniform data
 	var/utility_under = null
@@ -121,7 +122,11 @@
 	W.uniform_sets = uniform_sets
 	H.equip_to_slot_or_del(W, WEAR_ID)
 	H.faction = faction
-	H.faction_group = faction_group.Copy()
+	if(length(override_faction_group))
+		H.faction_group = override_faction_group.Copy()
+		override_faction_group = null
+	else
+		H.faction_group = faction_group.Copy()
 	if(H.mind)
 		H.mind.name = H.real_name
 		if(H.mind.initial_account)
@@ -652,9 +657,8 @@ var/list/rebel_rifles = list(
 		H.equip_to_slot_or_del(new /obj/item/clothing/gloves/black(H), WEAR_HANDS)
 
 /datum/equipment_preset/proc/add_random_synth_survivor_equipment(var/mob/living/carbon/human/H)
-	var/random_gear = rand(0,14)
-	faction = initial (faction)
-	faction_group = list(initial(faction_group))
+	var/random_gear = rand(0, 14)
+	faction = initial(faction)
 	idtype = initial(idtype)
 	switch(random_gear)
 		if(0) // The Classic Joe
@@ -779,7 +783,6 @@ var/list/rebel_rifles = list(
 			H.equip_to_slot_or_del(new /obj/item/device/motiondetector(H.back), WEAR_IN_BACK)
 		if(11) //PMC support synth
 			idtype = /obj/item/card/id/pmc
-			//H.equip_to_slot_or_del(new /obj/item/card/id/pmc(H), WEAR_ID)
 			H.equip_to_slot_or_del(new /obj/item/device/radio/headset/distress/PMC, WEAR_L_EAR)
 			H.equip_to_slot_or_del(new /obj/item/clothing/under/marine/veteran/PMC, WEAR_BODY)
 			H.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/marine/veteran/PMC, WEAR_JACKET)
@@ -791,7 +794,8 @@ var/list/rebel_rifles = list(
 			H.equip_to_slot_or_del(new /obj/item/storage/belt/medical/full, WEAR_WAIST)
 			H.equip_to_slot_or_del(new /obj/item/clothing/glasses/hud/health, WEAR_EYES)
 			faction = FACTION_PMC
-			faction_group = FACTION_LIST_WY
+			var/list/wy_factions = FACTION_LIST_WY
+			override_faction_group = wy_factions.Copy()
 		if(12) // UA synthetic carrying spare ammo supplies and dogtags
 			H.equip_to_slot_or_del(new /obj/item/clothing/under/marine/ua_riot(H), WEAR_BODY)
 			H.equip_to_slot_or_del(new /obj/item/clothing/gloves/marine(H), WEAR_HANDS)

--- a/code/modules/gear_presets/_select_equipment.dm
+++ b/code/modules/gear_presets/_select_equipment.dm
@@ -652,7 +652,7 @@ var/list/rebel_rifles = list(
 		H.equip_to_slot_or_del(new /obj/item/clothing/gloves/black(H), WEAR_HANDS)
 
 /datum/equipment_preset/proc/add_random_synth_survivor_equipment(var/mob/living/carbon/human/H)
-	var/random_gear = rand(0,10)
+	var/random_gear = rand(0,13)
 	switch(random_gear)
 		if(0) // The Classic Joe
 			H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/synthetic/joe(H), WEAR_BODY)
@@ -774,6 +774,49 @@ var/list/rebel_rifles = list(
 			H.equip_to_slot_or_del(new /obj/item/clothing/shoes/marine/knife(H), WEAR_FEET)
 			H.equip_to_slot_or_del(new /obj/item/storage/firstaid/toxin(H.back), WEAR_IN_BACK)
 			H.equip_to_slot_or_del(new /obj/item/device/motiondetector(H.back), WEAR_IN_BACK)
+		if(11) //PMC support synth
+			H.equip_to_slot_or_del(new /obj/item/card/id/pmc(H), WEAR_ID)
+			H.equip_to_slot_or_del(new /obj/item/device/radio/headset/distress/PMC, WEAR_L_EAR)
+			H.equip_to_slot_or_del(new /obj/item/clothing/under/marine/veteran/PMC, WEAR_BODY)
+			H.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/marine/veteran/PMC, WEAR_JACKET)
+			H.equip_to_slot_or_del(new /obj/item/clothing/gloves/marine/veteran/PMC, WEAR_HANDS)
+			H.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/marine/veteran/PMC, WEAR_HEAD)
+			H.equip_to_slot_or_del(new /obj/item/clothing/shoes/veteran/PMC/knife, WEAR_FEET)
+			H.equip_to_slot_or_del(new /obj/item/clothing/mask/rebreather/scarf, WEAR_FACE)
+			H.equip_to_slot_or_del(new /obj/item/storage/backpack/satchel, WEAR_BACK)
+			H.equip_to_slot_or_del(new /obj/item/storage/belt/medical/full, WEAR_WAIST)
+			H.equip_to_slot_or_del(new /obj/item/clothing/glasses/hud/health, WEAR_EYES)
+			faction = FACTION_PMC
+			faction_group = FACTION_LIST_WY
+		if(12) // UA synthetic carrying spare ammo supplies and dogtags
+			H.equip_to_slot_or_del(new /obj/item/clothing/under/marine/ua_riot(H), WEAR_BODY)
+			H.equip_to_slot_or_del(new /obj/item/clothing/gloves/marine(H), WEAR_HANDS)
+			H.equip_to_slot_or_del(new /obj/item/storage/backpack/marine/satchel(H), WEAR_BACK)
+			H.equip_to_slot_or_del(new /obj/item/clothing/shoes/jackboots(H), WEAR_FEET)
+			H.equip_to_slot_or_del(new /obj/item/storage/belt/marine(H), WEAR_WAIST)
+			H.equip_to_slot_or_del(new /obj/item/clothing/shoes/marine/knife(H), WEAR_FEET)
+			H.equip_to_slot_or_del(new /obj/item/storage/firstaid/regular(H), WEAR_IN_BACK)
+			H.equip_to_slot_or_del(new /obj/item/ammo_magazine/smg/mac15(H), WEAR_IN_BACK)
+			H.equip_to_slot_or_del(new /obj/item/ammo_magazine/handful/shotgun/buckshot(H), WEAR_IN_BELT)
+			H.equip_to_slot_or_del(new /obj/item/ammo_magazine/rifle/mar40(H), WEAR_IN_BELT)
+			H.equip_to_slot_or_del(new /obj/item/ammo_magazine/smg/mp5(H), WEAR_IN_BELT)
+			H.equip_to_slot_or_del(new /obj/item/ammo_magazine/smg/mp27(H), WEAR_IN_BELT)
+			H.equip_to_slot_or_del(new /obj/item/ammo_magazine/pistol/skorpion(H), WEAR_IN_BELT)
+			idtype = /obj/item/card/id/dogtag_synth
+			faction = FACTION_SURVIVOR
+			faction_group = list(FACTION_MARINE, FACTION_SURVIVOR)
+		if(13) //Firefighter synth
+			H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/synthetic/joe(H), WEAR_BODY)
+			H.equip_to_slot_or_del(new /obj/item/storage/backpack/marine/satchel(H), WEAR_BACK)
+			H.equip_to_slot_or_del(new /obj/item/clothing/gloves/black(H), WEAR_HANDS)
+			H.equip_to_slot_or_del(new /obj/item/clothing/shoes/marine(H), WEAR_FEET)
+			H.equip_to_slot_or_del(new /obj/item/storage/belt/utility/full(H), WEAR_WAIST)
+			H.equip_to_slot_or_del(new /obj/item/clothing/shoes/marine/knife(H), WEAR_FEET)
+			H.equip_to_slot_or_del(new /obj/item/clothing/head/hardhat/red(H), WEAR_HEAD)
+			H.equip_to_slot_or_del(new /obj/item/clothing/suit/fire/firefighter(H), WEAR_JACKET)
+			H.equip_to_slot_or_del(new /obj/item/tool/extinguisher(H), WEAR_IN_J_STORE)
+			idtype = /obj/item/card/id/lanyard
+
 
 /datum/equipment_preset/proc/add_random_survivor_medical_gear(var/mob/living/carbon/human/H) // Randomized medical gear. Survivors wont have their gear all kitted out once the outbreak began much like a doctor on a coffee break wont carry their instruments around. This is a generation of items they may or maynot get when the outbreak happens
 	var/random_gear = rand(0,4)

--- a/code/modules/gear_presets/_select_equipment.dm
+++ b/code/modules/gear_presets/_select_equipment.dm
@@ -658,8 +658,8 @@ var/list/rebel_rifles = list(
 
 /datum/equipment_preset/proc/add_random_synth_survivor_equipment(var/mob/living/carbon/human/H)
 	var/random_gear = rand(0, 13)
-	if(SSmapping.configs[GROUND_MAP].map_name == MAP_LV522_CHANCES_CLAIM)
-		random_gear=99
+	//if(SSmapping.configs[GROUND_MAP].map_name == MAP_LV522_CHANCES_CLAIM) //Uncomment these once !797 is merged!
+	//	random_gear=99
 	switch(random_gear)
 		if(0) // The Classic Joe
 			H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/synthetic/joe(H), WEAR_BODY)

--- a/code/modules/gear_presets/_select_equipment.dm
+++ b/code/modules/gear_presets/_select_equipment.dm
@@ -652,7 +652,10 @@ var/list/rebel_rifles = list(
 		H.equip_to_slot_or_del(new /obj/item/clothing/gloves/black(H), WEAR_HANDS)
 
 /datum/equipment_preset/proc/add_random_synth_survivor_equipment(var/mob/living/carbon/human/H)
-	var/random_gear = rand(0,13)
+	var/random_gear = rand(0,14)
+	faction = initial (faction)
+	faction_group = list(initial(faction_group))
+	idtype = initial(idtype)
 	switch(random_gear)
 		if(0) // The Classic Joe
 			H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/synthetic/joe(H), WEAR_BODY)
@@ -775,7 +778,8 @@ var/list/rebel_rifles = list(
 			H.equip_to_slot_or_del(new /obj/item/storage/firstaid/toxin(H.back), WEAR_IN_BACK)
 			H.equip_to_slot_or_del(new /obj/item/device/motiondetector(H.back), WEAR_IN_BACK)
 		if(11) //PMC support synth
-			H.equip_to_slot_or_del(new /obj/item/card/id/pmc(H), WEAR_ID)
+			idtype = /obj/item/card/id/pmc
+			//H.equip_to_slot_or_del(new /obj/item/card/id/pmc(H), WEAR_ID)
 			H.equip_to_slot_or_del(new /obj/item/device/radio/headset/distress/PMC, WEAR_L_EAR)
 			H.equip_to_slot_or_del(new /obj/item/clothing/under/marine/veteran/PMC, WEAR_BODY)
 			H.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/marine/veteran/PMC, WEAR_JACKET)
@@ -803,8 +807,7 @@ var/list/rebel_rifles = list(
 			H.equip_to_slot_or_del(new /obj/item/ammo_magazine/smg/mp27(H), WEAR_IN_BELT)
 			H.equip_to_slot_or_del(new /obj/item/ammo_magazine/pistol/skorpion(H), WEAR_IN_BELT)
 			idtype = /obj/item/card/id/dogtag_synth
-			faction = FACTION_SURVIVOR
-			faction_group = list(FACTION_MARINE, FACTION_SURVIVOR)
+			faction = FACTION_MARINE
 		if(13) //Firefighter synth
 			H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/synthetic/joe(H), WEAR_BODY)
 			H.equip_to_slot_or_del(new /obj/item/storage/backpack/marine/satchel(H), WEAR_BACK)
@@ -815,7 +818,15 @@ var/list/rebel_rifles = list(
 			H.equip_to_slot_or_del(new /obj/item/clothing/head/hardhat/red(H), WEAR_HEAD)
 			H.equip_to_slot_or_del(new /obj/item/clothing/suit/fire/firefighter(H), WEAR_JACKET)
 			H.equip_to_slot_or_del(new /obj/item/tool/extinguisher(H), WEAR_IN_J_STORE)
-			idtype = /obj/item/card/id/lanyard
+		if(14) //Bishop from Aliens - steal his look! (wristwatch not included) - LV-522 exclusive
+			H.equip_to_slot_or_del(new /obj/item/clothing/under/marine/officer/engi, WEAR_BODY)
+			H.equip_to_slot_or_del(new /obj/item/storage/backpack/marine/satchel(H), WEAR_BACK)
+			H.equip_to_slot_or_del(new /obj/item/clothing/shoes/red(H), WEAR_FEET)
+			H.equip_to_slot_or_del(new /obj/item/clothing/accessory/patch(H), WEAR_ACCESSORY)
+			H.equip_to_slot_or_del(new /obj/item/device/motiondetector(H), WEAR_L_HAND)
+			H.equip_to_slot_or_del(new /obj/item/storage/firstaid/regular(H), WEAR_R_HAND)
+			idtype = /obj/item/card/id/dogtag_synth
+			faction = FACTION_MARINE
 
 
 /datum/equipment_preset/proc/add_random_survivor_medical_gear(var/mob/living/carbon/human/H) // Randomized medical gear. Survivors wont have their gear all kitted out once the outbreak began much like a doctor on a coffee break wont carry their instruments around. This is a generation of items they may or maynot get when the outbreak happens

--- a/code/modules/gear_presets/_select_equipment.dm
+++ b/code/modules/gear_presets/_select_equipment.dm
@@ -657,9 +657,9 @@ var/list/rebel_rifles = list(
 		H.equip_to_slot_or_del(new /obj/item/clothing/gloves/black(H), WEAR_HANDS)
 
 /datum/equipment_preset/proc/add_random_synth_survivor_equipment(var/mob/living/carbon/human/H)
-	var/random_gear = rand(0, 14)
-	faction = initial(faction)
-	idtype = initial(idtype)
+	var/random_gear = rand(0, 13)
+	if(SSmapping.configs[GROUND_MAP].map_name == MAP_LV522_CHANCES_CLAIM)
+		random_gear=99
 	switch(random_gear)
 		if(0) // The Classic Joe
 			H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/synthetic/joe(H), WEAR_BODY)
@@ -822,7 +822,7 @@ var/list/rebel_rifles = list(
 			H.equip_to_slot_or_del(new /obj/item/clothing/head/hardhat/red(H), WEAR_HEAD)
 			H.equip_to_slot_or_del(new /obj/item/clothing/suit/fire/firefighter(H), WEAR_JACKET)
 			H.equip_to_slot_or_del(new /obj/item/tool/extinguisher(H), WEAR_IN_J_STORE)
-		if(14) //Bishop from Aliens - steal his look! (wristwatch not included) - LV-522 exclusive
+		if(99) //Bishop from Aliens - steal his look! (wristwatch not included) - LV-522 exclusive
 			H.equip_to_slot_or_del(new /obj/item/clothing/under/marine/officer/engi, WEAR_BODY)
 			H.equip_to_slot_or_del(new /obj/item/storage/backpack/marine/satchel(H), WEAR_BACK)
 			H.equip_to_slot_or_del(new /obj/item/clothing/shoes/red(H), WEAR_FEET)

--- a/code/modules/gear_presets/survivors.dm
+++ b/code/modules/gear_presets/survivors.dm
@@ -105,11 +105,11 @@
 
 	..()
 
-/datum/equipment_preset/survivor/scientist/florina
-	name = "Survivor - Florina Researcher"
-	assignment = "Florina Researcher"
+/datum/equipment_preset/survivor/scientist/fiorina
+	name = "Survivor - Fiorina Researcher"
+	assignment = "Fiorina Researcher"
 
-/datum/equipment_preset/survivor/scientist/florina/load_gear(mob/living/carbon/human/H)
+/datum/equipment_preset/survivor/scientist/fiorina/load_gear(mob/living/carbon/human/H)
 	H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/medical/purple(H), WEAR_BODY)
 	H.equip_to_slot_or_del(new /obj/item/clothing/head/surgery/purple(H), WEAR_HEAD)
 	H.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/labcoat/science(H), WEAR_JACKET)
@@ -207,11 +207,11 @@
 
 	..()
 
-/datum/equipment_preset/survivor/doctor/florina
-	name = "Survivor - Florina Doctor"
-	assignment = "Florina Doctor"
+/datum/equipment_preset/survivor/doctor/fiorina
+	name = "Survivor - Fiorina Doctor"
+	assignment = "Fiorina Doctor"
 
-/datum/equipment_preset/survivor/doctor/florina/load_gear(mob/living/carbon/human/H)
+/datum/equipment_preset/survivor/doctor/fiorina/load_gear(mob/living/carbon/human/H)
 	H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/medical(H), WEAR_BODY)
 	H.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/marine/veteran/PMC(H), WEAR_HEAD)
 
@@ -393,11 +393,11 @@
 
 	..()
 
-/datum/equipment_preset/survivor/security/florina
-	name = "Survivor - Florina Prison Guard"
-	assignment = "Florina Prison Guard"
+/datum/equipment_preset/survivor/security/fiorina
+	name = "Survivor - Fiorina Prison Guard"
+	assignment = "Fiorina Prison Guard"
 
-/datum/equipment_preset/survivor/security/florina/load_gear(mob/living/carbon/human/H)
+/datum/equipment_preset/survivor/security/fiorina/load_gear(mob/living/carbon/human/H)
 	H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/security(H), WEAR_BODY)
 	H.equip_to_slot_or_del(new /obj/item/storage/backpack/satchel/sec(H), WEAR_BACK)
 	H.equip_to_slot_or_del(new /obj/item/clothing/suit/armor/vest/security(H), WEAR_JACKET)
@@ -652,7 +652,7 @@
 	H.equip_to_slot_or_del(new /obj/item/clothing/glasses/welding(H), WEAR_EYES)
 	H.equip_to_slot_or_del(new /obj/item/clothing/gloves/marine/insulated(H), WEAR_HANDS)
 	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/marine/knife(H), WEAR_FEET)
-		
+
 	..()
 
 
@@ -737,11 +737,11 @@
 
 	..()
 
-/datum/equipment_preset/survivor/engineer/florina
-	name = "Survivor - Florina Engineer"
-	assignment = "Florina Engineer"
+/datum/equipment_preset/survivor/engineer/fiorina
+	name = "Survivor - Fiorina Engineer"
+	assignment = "Fiorina Engineer"
 
-/datum/equipment_preset/survivor/engineer/florina/load_gear(mob/living/carbon/human/H)
+/datum/equipment_preset/survivor/engineer/fiorina/load_gear(mob/living/carbon/human/H)
 	H.equip_to_slot_or_del(new /obj/item/clothing/under/color/white(H), WEAR_BODY)
 	H.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/apron/overalls(H), WEAR_JACKET)
 	H.equip_to_slot_or_del(new /obj/item/storage/backpack/satchel/eng(H), WEAR_BACK)
@@ -927,11 +927,11 @@
 
 	..()
 
-/datum/equipment_preset/survivor/colonial_marshal/florina
+/datum/equipment_preset/survivor/colonial_marshal/fiorina
 	name = "Survivor - United Americas Riot Officer"
 	assignment = "United Americas Riot Officer"
 
-/datum/equipment_preset/survivor/colonial_marshal/florina/load_gear(mob/living/carbon/human/H)
+/datum/equipment_preset/survivor/colonial_marshal/fiorina/load_gear(mob/living/carbon/human/H)
 	H.equip_to_slot_or_del(new /obj/item/clothing/under/marine/ua_riot(H), WEAR_BODY)
 	H.equip_to_slot_or_del(new /obj/item/storage/backpack/satchel/sec(H), WEAR_BACK)
 	H.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/marine/veteran/ua_riot(H), WEAR_JACKET)

--- a/maps/fiorina_sciannex.json
+++ b/maps/fiorina_sciannex.json
@@ -3,15 +3,15 @@
     "map_path": "map_files/FOP_v3_Sciannex",
     "map_file": "Fiorina_SciAnnex.dmm",
     "survivor_types": [
-        "/datum/equipment_preset/survivor/scientist/florina",
-        "/datum/equipment_preset/survivor/doctor/florina",
+        "/datum/equipment_preset/survivor/scientist/fiorina",
+        "/datum/equipment_preset/survivor/doctor/fiorina",
         "/datum/equipment_preset/survivor/interstellar_human_rights_observer",
-        "/datum/equipment_preset/survivor/security/florina",
-        "/datum/equipment_preset/survivor/colonial_marshal/florina",
+        "/datum/equipment_preset/survivor/security/fiorina",
+        "/datum/equipment_preset/survivor/colonial_marshal/fiorina",
         "/datum/equipment_preset/survivor/prisoner",
         "/datum/equipment_preset/survivor/prisoner",
         "/datum/equipment_preset/survivor/gangleader",
-        "/datum/equipment_preset/survivor/engineer/florina"
+        "/datum/equipment_preset/survivor/engineer/fiorina"
     ],
     "defcon_triggers": [
         3750,

--- a/maps/prison_station_fop.json
+++ b/maps/prison_station_fop.json
@@ -3,14 +3,14 @@
     "map_path": "map_files/FOP_v2_Cellblocks",
     "map_file": "Prison_Station_FOP.dmm",
     "survivor_types": [
-        "/datum/equipment_preset/survivor/scientist/florina",
-        "/datum/equipment_preset/survivor/doctor/florina",
+        "/datum/equipment_preset/survivor/scientist/fiorina",
+        "/datum/equipment_preset/survivor/doctor/fiorina",
         "/datum/equipment_preset/survivor/interstellar_human_rights_observer",
-        "/datum/equipment_preset/survivor/security/florina",
+        "/datum/equipment_preset/survivor/security/fiorina",
         "/datum/equipment_preset/survivor/prisoner",
         "/datum/equipment_preset/survivor/prisoner",
         "/datum/equipment_preset/survivor/gangleader",
-        "/datum/equipment_preset/survivor/engineer/florina"
+        "/datum/equipment_preset/survivor/engineer/fiorina"
     ],
     "defcon_triggers": [
         3750,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Adds three new synth survivor loadouts to the pool the game randomly selects from upon spawning - the firefighter, the UA military synthvivor with an unique dogtag variant and carrying misc low-grade spare ammo and medicine, and a PMC support synthetic with PMC ID and IFF. Also fixes code that misspells "Fiorina" as "FLorina"
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The synthvivor loadout randomizer system has been received warmly, so further expansion on it is welcome.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: 50RemAndCounting
add: Added a few new synth survivor loadouts that are picked randomly upon spawning as one.
spellcheck: fixed all occurences in code and ingame where Fiorina is spelled as FLorina
fix: fixed synthetics still having the CO headset as their replacement headset in the vendor.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
