### PR TITLE
xenomorphs with opposable thumbs minor event button port

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -129,6 +129,8 @@
 // HIVE TRAITS
  /// If the Hive is a Xenonid Hive
 #define TRAIT_XENONID "t_xenonid"
+/// If the hive or xeno can use objects.
+#define TRAIT_OPPOSABLE_THUMBS "t_thumbs"
 
 // MISC MOB TRAITS
  /// If the mob is nested.

--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -166,7 +166,7 @@
 		I.ui_action_click(owner, holder_item)
 
 /datum/action/item_action/can_use_action()
-	if(ishuman(owner) && !owner.is_mob_incapacitated() && !owner.lying)
+	if((ishuman(owner) || HAS_TRAIT(owner, TRAIT_OPPOSABLE_THUMBS)) && !owner.is_mob_incapacitated() && !owner.lying)
 		return TRUE
 
 /datum/action/item_action/update_button_icon()

--- a/code/game/objects/items/explosives/grenades/grenade.dm
+++ b/code/game/objects/items/explosives/grenades/grenade.dm
@@ -34,7 +34,7 @@
 		to_chat(user, SPAN_WARNING("You don't have the dexterity to do this!"))
 		return FALSE
 
-	if(harmful && !user.allow_gun_usage)
+	if(harmful && ishuman(user) && !user.allow_gun_usage)
 		to_chat(user, SPAN_WARNING("Your programming prevents you from using this!"))
 		return FALSE
 
@@ -107,7 +107,7 @@
 		det_time ? addtimer(CALLBACK(src, .proc/prime), det_time) : prime()
 	w_class = SIZE_MASSIVE // We cheat a little, primed nades become massive so they cant be stored anywhere
 	update_icon()
-	
+
 /obj/item/explosive/grenade/prime(var/force = FALSE)
 	..()
 	if(!QDELETED(src))

--- a/code/modules/admin/tabs/event_tab.dm
+++ b/code/modules/admin/tabs/event_tab.dm
@@ -700,6 +700,7 @@
 		<A href='?src=\ref[src];[HrefToken()];events=jelly'>Award a royal jelly</A><BR>
 		<A href='?src=\ref[src];[HrefToken()];events=pmcguns'>Toggle PMC gun restrictions</A><BR>
 		<A href='?src=\ref[src];[HrefToken()];events=monkify'>Turn everyone into monkies</A><BR>
+		<A href='?src=\ref[src];[HrefToken()];events=xenothumbs'>Give or take opposable thumbs and gun permits from xenos</A><BR>
 		<BR>
 		"}
 

--- a/code/modules/admin/topic/topic_events.dm
+++ b/code/modules/admin/topic/topic_events.dm
@@ -86,6 +86,63 @@
 				message_staff("[key_name_admin(usr)] added [amount] research credits.")
 				chemical_data.update_credits(amount)
 
+		if("xenothumbs")
+			var/grant = alert(usr, "Do you wish to grant or revoke Xenomorph firearms permits?", "Give or Take", "Grant", "Revoke", "Cancel")
+			if(grant == "Cancel")
+				return
+
+			var/list/mob/living/carbon/Xenomorph/permit_recipients = list()
+			var/list/datum/hive_status/permit_hives = list()
+			switch(alert(usr, "Do you wish to do this for one Xeno or an entire hive?", "Recipients", "Xeno", "Hive", "All Xenos"))
+				if("Xeno")
+					permit_recipients += tgui_input_list(usr, "Select recipient Xenomorph:", "Armed Xenomorph", GLOB.living_xeno_list)
+					if(isnull(permit_recipients[1])) //Cancel button.
+						return
+				if("Hive")
+					permit_hives += GLOB.hive_datum[tgui_input_list(usr, "Select recipient hive:", "Armed Hive", GLOB.hive_datum)]
+					if(isnull(permit_hives[1])) //Cancel button.
+						return
+					permit_recipients = permit_hives[1].totalXenos.Copy()
+				if("All Xenos")
+					permit_recipients = GLOB.living_xeno_list.Copy()
+					for(var/H in GLOB.hive_datum)
+						permit_hives += GLOB.hive_datum[H]
+
+			var/list/handled_xenos = list()
+
+			for(var/mob/living/carbon/Xenomorph/X as anything in permit_recipients)
+				if(QDELETED(X) || X.stat == DEAD) //Xenos might die before the admin picks them.
+					to_chat(usr, SPAN_HIGHDANGER("[X] died before her firearms permit could be issued!"))
+					continue
+				if(HAS_TRAIT(X, TRAIT_OPPOSABLE_THUMBS))
+					if(grant == "Revoke")
+						REMOVE_TRAIT(X, TRAIT_OPPOSABLE_THUMBS, TRAIT_SOURCE_HIVE)
+						to_chat(X, SPAN_XENOANNOUNCE("You forget how thumbs work. You feel a terrible sense of loss."))
+						handled_xenos += X
+				else if(grant == "Grant")
+					ADD_TRAIT(X, TRAIT_OPPOSABLE_THUMBS, TRAIT_SOURCE_HIVE)
+					to_chat(X, SPAN_XENOANNOUNCE("You suddenly comprehend the magic of opposable thumbs. You could do... <b><i>so much</b></i> with this knowledge."))
+					handled_xenos += X
+
+			for(var/datum/hive_status/permit_hive as anything in permit_hives)
+				//Give or remove the trait from newly-born xenos in this hive.
+				if(grant == "Grant")
+					LAZYADD(permit_hive.hive_inherant_traits, TRAIT_OPPOSABLE_THUMBS)
+				else
+					LAZYREMOVE(permit_hive.hive_inherant_traits, TRAIT_OPPOSABLE_THUMBS)
+
+			if(!length(handled_xenos) && !length(permit_hives))
+				return
+
+			if(grant == "Grant")
+				message_staff("[usr] granted 2nd Amendment rights to [length(handled_xenos) > 1 ? "[length(handled_xenos)] xenos" : "[length(handled_xenos) == 1 ? "[handled_xenos[1]]" : "no xenos"]"]\
+					[length(permit_hives) > 1 ? " in all hives, and to any new xenos. Quite possibly we will all regret this." : "[length(permit_hives) == 1 ? " in [permit_hives[1]], and to any new xenos in that hive." : "."]"]")
+			else
+				message_staff("[usr] revoked 2nd Amendment rights from [length(handled_xenos) > 1 ? "[length(handled_xenos)] xenos" : "[length(handled_xenos) == 1 ? "[handled_xenos[1]]" : "no xenos"]"]\
+					[length(permit_hives) > 1 ? " in all hives, and from any new xenos." : "[length(permit_hives) == 1 ? " in [permit_hives[1]], and from any new xenos in that hive." : "."]"]")
+
+
+
 /datum/admins/proc/create_humans_list(var/href_list)
 	if(SSticker?.current_state < GAME_STATE_PLAYING)
 		alert("Please wait until the game has started before spawning humans")

--- a/code/modules/defenses/sentry.dm
+++ b/code/modules/defenses/sentry.dm
@@ -251,12 +251,9 @@
 	SetLuminosity(SENTRY_MUZZLELUM)
 	addtimer(CALLBACK(src, /atom.proc/SetLuminosity, -SENTRY_MUZZLELUM), 10)
 
-	var/image_layer = layer + 0.1
-	var/offset = 13
-
-	var/image/I = image('icons/obj/items/weapons/projectiles.dmi',src,"muzzle_flash",image_layer)
+	var/image/I = image('icons/obj/items/weapons/projectiles.dmi', src, "muzzle_flash", layer + 0.1)
 	var/matrix/rotate = matrix() //Change the flash angle.
-	rotate.Translate(0, offset)
+	rotate.Translate(0, 13)
 	rotate.Turn(angle)
 	I.transform = rotate
 	I.flick_overlay(src, 3)
@@ -527,16 +524,16 @@ obj/structure/machinery/defenses/sentry/premade/damaged_action()
 	var/obj/structure/machinery/camera/cas/linked_cam
 	var/static/sentry_count = 1
 	var/sentry_number
-	
+
 /obj/structure/machinery/defenses/sentry/launchable/Initialize()
 	. = ..()
 	sentry_number = sentry_count
 	sentry_count++
-	
+
 /obj/structure/machinery/defenses/sentry/launchable/Destroy()
 	QDEL_NULL(linked_cam)
 	. = ..()
-	
+
 /obj/structure/machinery/defenses/sentry/launchable/power_on_action()
 	. = ..()
 	linked_cam = new(loc, "[name] [sentry_number] at [get_area(src)] ([obfuscate_x(x)], [obfuscate_y(y)])")
@@ -544,7 +541,7 @@ obj/structure/machinery/defenses/sentry/premade/damaged_action()
 /obj/structure/machinery/defenses/sentry/launchable/power_off_action()
 	. = ..()
 	QDEL_NULL(linked_cam)
-	
+
 
 /obj/structure/machinery/defenses/sentry/launchable/attack_hand_checks(var/mob/user)
 	return TRUE // We want to be able to turn it on / off while keeping it immobile

--- a/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
@@ -682,3 +682,7 @@
 		to_chat(src, SPAN_XENONOTICE("You stop tracking the [tracked_marker.mark_meaning.name] resin mark."))
 	tracked_marker.xenos_tracking -= src
 	tracked_marker = null
+
+	///This permits xenos with thumbs to fire guns and arm grenades. God help us all.
+/mob/living/carbon/Xenomorph/IsAdvancedToolUser()
+	return HAS_TRAIT(src, TRAIT_OPPOSABLE_THUMBS)

--- a/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
@@ -50,6 +50,8 @@
 	faction = FACTION_XENOMORPH
 	gender = NEUTER
 	icon_size = 48
+	///How much to horizontally adjust the sprites of held item onmobs by. Based on icon size. Most xenos have hands about the same height as a human's.
+	var/xeno_inhand_item_offset
 	var/obj/item/clothing/suit/wear_suit = null
 	var/obj/item/clothing/head/head = null
 	var/obj/item/r_store = null
@@ -342,6 +344,7 @@
 	mutators.xeno = src
 
 	update_icon_source()
+	xeno_inhand_item_offset = (icon_size - 32) * 0.5
 
 	if(caste_type && GLOB.xeno_datum_list[caste_type])
 		caste = GLOB.xeno_datum_list[caste_type]

--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -294,10 +294,15 @@
 	else
 		return FALSE // leave the dead alone
 
-//This proc is here to prevent Xenomorphs from picking up objects (default attack_hand behaviour)
-//Note that this is overriden by every proc concerning a child of obj unless inherited
+/**This proc is here to prevent Xenomorphs from picking up objects (default attack_hand behaviour)
+Note that this is overriden by every proc concerning a child of obj unless inherited
+There is a trait that permits them to handle items.**/
 /obj/item/attack_alien(mob/living/carbon/Xenomorph/M)
+	if(HAS_TRAIT(M, TRAIT_OPPOSABLE_THUMBS))
+		attack_hand(M)
+		return XENO_NONCOMBAT_ACTION
 	return
+
 
 /obj/vehicle/attack_alien(mob/living/carbon/Xenomorph/M)
 	if(M.a_intent == INTENT_HARM)
@@ -368,6 +373,12 @@
 		to_chat(M, SPAN_WARNING("You stare at \the [src] cluelessly."))
 		return XENO_NO_DELAY_ACTION
 
+/obj/structure/magazine_box/attack_alien(mob/living/carbon/Xenomorph/M)
+	if(HAS_TRAIT(usr, TRAIT_OPPOSABLE_THUMBS))
+		attack_hand(M)
+		return XENO_NONCOMBAT_ACTION
+	else
+		. = ..()
 
 //Beds, nests and chairs - unbuckling
 /obj/structure/bed/attack_alien(mob/living/carbon/Xenomorph/M)

--- a/code/modules/mob/living/carbon/xenomorph/update_icons.dm
+++ b/code/modules/mob/living/carbon/xenomorph/update_icons.dm
@@ -86,7 +86,12 @@
 		var/t_state = r_hand.item_state
 		if(!t_state)
 			t_state = r_hand.icon_state
-		overlays_standing[X_R_HAND_LAYER] = r_hand.get_mob_overlay(src, WEAR_R_HAND)
+		/*Move inhand image to the center of the sprite. Strictly speaking this should probably be like monkey get_offset_overlay_image() and tailor item icon
+		positions to the hands of the xeno, but outside of special occasions xenos can't really pick items up and this tends to look better than human default.*/
+		var/image/inhand_image = r_hand.get_mob_overlay(src, WEAR_R_HAND)
+		inhand_image.pixel_x = xeno_inhand_item_offset
+		overlays_standing[X_R_HAND_LAYER] = inhand_image
+
 		apply_overlay(X_R_HAND_LAYER)
 
 /mob/living/carbon/Xenomorph/update_inv_l_hand()
@@ -99,7 +104,13 @@
 		var/t_state = l_hand.item_state
 		if(!t_state)
 			t_state = l_hand.icon_state
-		overlays_standing[X_L_HAND_LAYER] = l_hand.get_mob_overlay(src, WEAR_L_HAND)
+
+		/*Move inhand image overlay to the center of the sprite. Strictly speaking this should probably be like monkey get_offset_overlay_image() and tailor item icon
+		positions to the hands of the xeno, but outside of special occasions xenos can't really pick items up and this tends to look better than human default.*/
+		var/image/inhand_image = l_hand.get_mob_overlay(src, WEAR_L_HAND)
+		inhand_image.pixel_x = xeno_inhand_item_offset
+		overlays_standing[X_L_HAND_LAYER] = inhand_image
+
 		apply_overlay(X_L_HAND_LAYER)
 
 /mob/living/carbon/Xenomorph/proc/update_inv_resource()

--- a/code/modules/projectiles/ammo_boxes.dm
+++ b/code/modules/projectiles/ammo_boxes.dm
@@ -761,7 +761,7 @@
 			to_chat(usr, SPAN_DANGER("It's on fire and might explode!"))
 			return
 
-		if(!ishuman(usr))
+		if(!ishuman(usr) || !HAS_TRAIT(usr, TRAIT_OPPOSABLE_THUMBS))
 			return
 		visible_message(SPAN_NOTICE("[usr] picks up the [name]."))
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -1639,7 +1639,7 @@ not all weapons use normal magazines etc. load_into_chamber() itself is designed
 		else
 			total_recoil -= user.skills.get_skill_level(SKILL_FIREARMS)*RECOIL_AMOUNT_TIER_5
 
-	if(total_recoil > 0 && ishuman(user))
+	if(total_recoil > 0 && (ishuman(user) || HAS_TRAIT(user, TRAIT_OPPOSABLE_THUMBS)))
 		if(total_recoil >= 4)
 			shake_camera(user, total_recoil * 0.5, total_recoil)
 		else
@@ -1651,19 +1651,19 @@ not all weapons use normal magazines etc. load_into_chamber() itself is designed
 /obj/item/weapon/gun/proc/muzzle_flash(angle,mob/user)
 	if(!muzzle_flash || flags_gun_features & GUN_SILENCED || isnull(angle))
 		return //We have to check for null angle here, as 0 can also be an angle.
-	if(!istype(user) || !istype(user.loc,/turf))
+	if(!istype(user) || !isturf(user.loc))
 		return
 
 	if(user.luminosity <= muzzle_flash_lum)
 		user.SetLuminosity(muzzle_flash_lum, FALSE, src)
 		addtimer(CALLBACK(user, /atom.proc/SetLuminosity, 0, FALSE, src), 10)
 
-	var/image_layer = (user && user.dir == SOUTH) ? MOB_LAYER+0.1 : MOB_LAYER-0.1
-	var/offset = 5
-
-	var/image/I = image('icons/obj/items/weapons/projectiles.dmi',user,muzzle_flash,image_layer)
+	var/image/I = image('icons/obj/items/weapons/projectiles.dmi', user, muzzle_flash, user.dir == NORTH ? ABOVE_LYING_MOB_LAYER : FLOAT_LAYER)
 	var/matrix/rotate = matrix() //Change the flash angle.
-	rotate.Translate(0, offset)
+	if(isCarbonSizeXeno(user))
+		var/mob/living/carbon/Xenomorph/X = user
+		I.pixel_x = X.xeno_inhand_item_offset //To center it on the xeno sprite without being thrown off by rotation.
+	rotate.Translate(0, 5) //Y offset to push the flash overlay outwards.
 	rotate.Turn(angle)
 	I.transform = rotate
 	I.flick_overlay(user, 3)

--- a/code/modules/projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/gun_helpers.dm
@@ -480,7 +480,8 @@ As sniper rifles have both and weapon mods can change them as well. ..() deals w
 		else attack_verb = list("slashed", "stabbed", "speared", "torn", "punctured", "pierced", "gored") //Greater than 35
 
 /obj/item/weapon/gun/proc/get_active_firearm(mob/user, restrictive = TRUE)
-	if(!ishuman(usr)) return
+	if(!ishuman(usr) && !HAS_TRAIT(user, TRAIT_OPPOSABLE_THUMBS))
+		return
 	if(!user.canmove || user.stat || user.is_mob_restrained() || !user.loc || !isturf(usr.loc))
 		to_chat(user, SPAN_WARNING("Not right now."))
 		return
@@ -811,7 +812,7 @@ As sniper rifles have both and weapon mods can change them as well. ..() deals w
 	if(flags_gun_features & GUN_BURST_FIRING)
 		return
 
-	if(!ishuman(usr))
+	if(!ishuman(usr) && !HAS_TRAIT(usr, TRAIT_OPPOSABLE_THUMBS))
 		return
 
 	if(usr.is_mob_incapacitated() || !usr.loc || !isturf(usr.loc))

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -956,7 +956,7 @@
 
 	var/ammo_flags = P.ammo.flags_ammo_behavior | P.projectile_override_flags
 
-	if(isXeno(P.firer))
+	if(isXeno(P.firer) && ammo_flags & (AMMO_XENO_ACID|AMMO_XENO_TOX)) //Xenomorph shooting spit. Xenos with thumbs and guns can fully FF.
 		var/mob/living/carbon/Xenomorph/X = P.firer
 		if(X.can_not_harm(src))
 			bullet_ping(P)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Revived and fixed up https://gitlab.com/cmdevs/colonial-warfare/-/merge_requests/1915/diffs#9ec310cca070259d82839a4a70e89dd858ded438_958_958

All credit to Vanagandr, I just ported and fixed up from gitlab.

> TL;DR: https://streamable.com/rlvs86
> 
> Mainly this allows xenos to pick up items. They can then use most of them.
> 
> Ex. a xeno can't flip a plasteel cade open - but if she has a toolbelt and time to work, she can unwrench it.
> 
> They can fumble about but a lot of QoL and objects (middleclick container open, click-dragging containers, tables, etc.) were never designed to be interacted with by xenos so item interactions are a bit clunky.
> 
> They can't strip clothing and gear from people.
> 
> They *can* strip and attach attachments but can't aim down scopes.
> 
> They *can* FF.
> 
> They *can't* use MGs.
> 
> IFF works, roughly, not picking up on specific hives but allowing them to shoot past other xenos and hit humans.
> 
> They pass spec checks and can clumsily handle medic gear.
> 
> needless to say this is all colossally imbalanced and has potential for fuckery limited only by the xeno's imagination and whether the thing they're messing with makes an explicit ishuman() check. Or is a structure. They can't hand-interact with structures, so they can shove shells into a mortar but can't change its coords.
> 
> Cosmetically, gun inhands don't line up with xenos. Tweaked it a bit to center it horizontally but lining inhands up with hands for every xeno and xenonid sprite is a bit more hassle than seems worthwhile ATM.
> 

## Why It's Good For The Game


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

minor event

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:  Vanagandr
add: Added a button to event panel to give xenomorphs opposable thumbs and firearms permits, to individuals, to hives, or to all xenos everywhere. They're clumsy, though, and have issues with fine manipulation sometimes. Remember that warriors cannot throw objects and make for poor grenadiers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
