### PR TITLE
Fixes repeating area soundscapes

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -387,6 +387,9 @@
 /area/Exited(A)
 	if(istype(A, /obj/structure/machinery))
 		remove_machine(A)
+	else if(ismob(A))
+		var/mob/exiting_mob = A
+		exiting_mob?.client?.soundOutput?.update_ambience(target_area = null, ambience_override = null, force_update = TRUE)
 
 /area/proc/add_machine(var/obj/structure/machinery/M)
 	SHOULD_NOT_SLEEP(TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Closes #936 

## Why It's Good For The Game

Bug bad and I will literally have a joker moment if I have to listen to the looping medbay songs for another entire round as an observer.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Morrow
fix: Area soundscapes will now properly exit. No more looping medbay songs forever.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
