### PR TITLE
Fix hivestatus breaking when transforming a queen

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
@@ -441,7 +441,7 @@
 		overwatch(observed_xeno, TRUE)
 
 	if(hive && hive.living_xeno_queen == src)
-		var/mob/living/carbon/Xenomorph/Queen/next_queen
+		var/mob/living/carbon/Xenomorph/Queen/next_queen = null
 		for(var/mob/living/carbon/Xenomorph/Queen/queen in hive.totalXenos)
 			if(!is_admin_level(queen.z) && queen != src && !QDELETED(queen))
 				next_queen = queen

--- a/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
@@ -439,8 +439,15 @@
 /mob/living/carbon/Xenomorph/Queen/Destroy()
 	if(observed_xeno)
 		overwatch(observed_xeno, TRUE)
+
 	if(hive && hive.living_xeno_queen == src)
-		hive.set_living_xeno_queen(null)
+		var/mob/living/carbon/Xenomorph/Queen/next_queen
+		for(var/mob/living/carbon/Xenomorph/Queen/queen in hive.totalXenos)
+			if(!is_admin_level(queen.z) && queen != src && !QDELETED(queen))
+				next_queen = queen
+				break
+		hive.set_living_xeno_queen(next_queen) // either null or a queen
+
 	return ..()
 
 /mob/living/carbon/Xenomorph/Queen/Life(delta_time)

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -308,53 +308,53 @@
 	// So don't even bother trying updating UI here without large refactors
 
 // Removes the xeno from the hive
-/datum/hive_status/proc/remove_xeno(var/mob/living/carbon/Xenomorph/X, var/hard=FALSE, light_mode = FALSE)
-	if(!X || !istype(X))
+/datum/hive_status/proc/remove_xeno(var/mob/living/carbon/Xenomorph/xeno, var/hard = FALSE, light_mode = FALSE)
+	if(!xeno || !istype(xeno))
 		return
 
 	// Make sure the xeno was in the hive in the first place
-	if(!(X in totalXenos))
+	if(!(xeno in totalXenos))
 		return
 
-	if(isXenoQueen(X))
-		if(living_xeno_queen == X)
-			var/mob/living/carbon/Xenomorph/Queen/next_queen
-			for(var/mob/living/carbon/Xenomorph/Queen/Q in totalXenos)
-				if(!is_admin_level(Q.z))
-					next_queen = Q
-					break
+	// This might be a redundant check now that Queen/Destroy() checks, but doesn't hurt to double check
+	if(isXenoQueen(xeno) && living_xeno_queen == xeno)
+		var/mob/living/carbon/Xenomorph/Queen/next_queen
+		for(var/mob/living/carbon/Xenomorph/Queen/queen in totalXenos)
+			if(!is_admin_level(queen.z) && queen != src && !QDELETED(queen))
+				next_queen = queen
+				break
 
-			set_living_xeno_queen(next_queen) // either null or a queen
+		set_living_xeno_queen(next_queen) // either null or a queen
 
 	// We allow "soft" removals from the hive (the xeno still retains information about the hive)
 	// This is so that xenos can add themselves back to the hive if they should die or otherwise go "on leave" from the hive
 	if(hard)
-		X.hivenumber = 0
-		X.hive = null
+		xeno.hivenumber = 0
+		xeno.hive = null
 	else
-		totalDeadXenos += X
+		totalDeadXenos += xeno
 
-	totalXenos -= X
-	if(X.tier == 2)
-		tier_2_xenos -= X
-	else if(X.tier == 3)
-		tier_3_xenos -= X
+	totalXenos -= xeno
+	if(xeno.tier == 2)
+		tier_2_xenos -= xeno
+	else if(xeno.tier == 3)
+		tier_3_xenos -= xeno
 
 	if(!light_mode)
 		hive_ui.update_xeno_counts()
-		hive_ui.xeno_removed(X)
+		hive_ui.xeno_removed(xeno)
 
-/datum/hive_status/proc/set_living_xeno_queen(var/mob/living/carbon/Xenomorph/Queen/M)
-	if(M == null)
+/datum/hive_status/proc/set_living_xeno_queen(var/mob/living/carbon/Xenomorph/Queen/queen)
+	if(queen == null)
 		mutators.reset_mutators()
 		SStracking.delete_leader("hive_[hivenumber]")
 		SStracking.stop_tracking("hive_[hivenumber]", living_xeno_queen)
 		SShive_status.wait = 10 SECONDS
 	else
-		SStracking.set_leader("hive_[hivenumber]", M)
+		SStracking.set_leader("hive_[hivenumber]", queen)
 		SShive_status.wait = 2 SECONDS
 
-	living_xeno_queen = M
+	living_xeno_queen = queen
 
 	recalculate_hive()
 

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -318,7 +318,7 @@
 
 	// This might be a redundant check now that Queen/Destroy() checks, but doesn't hurt to double check
 	if(living_xeno_queen == xeno)
-		var/mob/living/carbon/Xenomorph/Queen/next_queen
+		var/mob/living/carbon/Xenomorph/Queen/next_queen = null
 		for(var/mob/living/carbon/Xenomorph/Queen/queen in totalXenos)
 			if(!is_admin_level(queen.z) && queen != src && !QDELETED(queen))
 				next_queen = queen
@@ -345,7 +345,7 @@
 		hive_ui.xeno_removed(xeno)
 
 /datum/hive_status/proc/set_living_xeno_queen(var/mob/living/carbon/Xenomorph/Queen/queen)
-	if(queen == null)
+	if(!queen)
 		mutators.reset_mutators()
 		SStracking.delete_leader("hive_[hivenumber]")
 		SStracking.stop_tracking("hive_[hivenumber]", living_xeno_queen)

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -317,7 +317,7 @@
 		return
 
 	// This might be a redundant check now that Queen/Destroy() checks, but doesn't hurt to double check
-	if(isXenoQueen(xeno) && living_xeno_queen == xeno)
+	if(living_xeno_queen == xeno)
 		var/mob/living/carbon/Xenomorph/Queen/next_queen
 		for(var/mob/living/carbon/Xenomorph/Queen/queen in totalXenos)
 			if(!is_admin_level(queen.z) && queen != src && !QDELETED(queen))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Fixes hive status and hivemind thinking there is no queen when a queen is transformed (e.g. Player Panel > Transform a young queen to mature queen).
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Less bugs for admin tools.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Drathek
fix: Fixes transformation of a queen breaking hive status and hivemind
refactor: Improves some variable readability
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
