### PR TITLE
Mechanical medal lock

### DIFF
--- a/code/datums/medal_awards.dm
+++ b/code/datums/medal_awards.dm
@@ -164,6 +164,10 @@ GLOBAL_LIST_EMPTY(jelly_awards)
 		to_chat(user, SPAN_WARNING("Only a Senior Officer can award medals!"))
 		return
 
+	if(!skillcheck(user, SKILL_EXECUTION, SKILL_EXECUTION_TRAINED))
+		to_chat(user, SPAN_WARNING("You don't seem to know how the award system works."))
+		return
+		
 	if(give_medal_award(get_turf(printer)))
 		user.visible_message(SPAN_NOTICE("[printer] prints a medal."))
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Only people with execution skill can give medals now. Anyone who has CO whitelist and should be able to give out medals should have execution training. I can split it to another trait if requested.

## Why It's Good For The Game

Non-COs giving medals is not intended.

## Changelog

:cl: Morrow
fix: Mechanical lock against non-COs giving medals.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
