### PR TITLE
Staff Officer timelock change

### DIFF
--- a/code/game/jobs/job/command/cic/staffofficer.dm
+++ b/code/game/jobs/job/command/cic/staffofficer.dm
@@ -28,8 +28,7 @@
 
 AddTimelock(/datum/job/command/bridge, list(
 	JOB_SQUAD_LEADER = 1 HOURS,
-	JOB_HUMAN_ROLES = 15 HOURS,
-	JOB_POLICE_ROLES = 1 HOURS
+	JOB_HUMAN_ROLES = 15 HOURS
 ))
 
 /obj/effect/landmark/start/bridge


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

This PR removes the required MP hours for staff officer.

## Why It's Good For The Game

I feel the MP timelock for SOs scares people away from trying CIC out. This would allow people to dip their feet in without having the perceived stain of MP hours on their hands.

## Changelog

:cl: Morrow
del: Removed MP timelocks from Staff Officer.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
