### PR TITLE
Mechanical Medal Lock Option 3

### DIFF
--- a/code/datums/medal_awards.dm
+++ b/code/datums/medal_awards.dm
@@ -163,6 +163,16 @@ GLOBAL_LIST_EMPTY(jelly_awards)
 	if(!((card.paygrade in GLOB.co_paygrades) || (card.paygrade in GLOB.highcom_paygrades)))
 		to_chat(user, SPAN_WARNING("Only a Senior Officer can award medals!"))
 		return
+	
+	if(!card.registered_ref)
+		user.visible_message("ERROR: ID card not registered in USCM registry. Potential medal fraud detected.")
+		return
+	
+	var/real_owner_ref = card.registered_ref
+		
+	if(real_owner_ref != WEAKREF(user))
+		user.visible_message("ERROR: ID card not registered for [user.real_name] in USCM registry. Potential medal fraud detected.")
+		return
 
 	if(give_medal_award(get_turf(printer)))
 		user.visible_message(SPAN_NOTICE("[printer] prints a medal."))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Nobody tell him but Geeves was right and there is a weakref on the ID cards. This should make it impossible for anyone who is not spawned in with the ID to give out medals. Create_humans and change_equipment still work correctly so event shenanigans should be unaffected.

## Why It's Good For The Game

Bug bad.

## Changelog

:cl: Morrow
fix: Mechanical lock against unauthorized people giving medals.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
