### PR TITLE
Fourth unholster keybind and unholstering refactor

### DIFF
--- a/code/__DEFINES/keybinding.dm
+++ b/code/__DEFINES/keybinding.dm
@@ -45,6 +45,7 @@
 #define COMSIG_KB_HUMAN_QUICKEQUIP_DOWN "keybinding_human_quickequip_down"
 #define COMSIG_KB_HUMAN_SECONDARY_DOWN "keybinding_human_secondary_down"
 #define COMSIG_KB_HUMAN_TERTIARY_DOWN "keybinding_human_tertiary_down"
+#define COMSIG_KB_HUMAN_QUATERNARY_DOWN "keybinding_human_quaternary_down"
 #define COMSIG_KB_HUMAN_QUICK_EQUIP_DOWN "keybinding_human_quick_equip_down"
 
 #define COMSIG_KB_HUMAN_ISSUE_ORDER "keybinding_human_issue_order"

--- a/code/datums/keybinding/human.dm
+++ b/code/datums/keybinding/human.dm
@@ -1,3 +1,8 @@
+#define QUICK_EQUIP_PRIMARY 1
+#define QUICK_EQUIP_SECONDARY 2
+#define QUICK_EQUIP_TERTIARY 3
+#define QUICK_EQUIP_QUATERNARY 4
+
 /datum/keybinding/human
 	category = CATEGORY_HUMAN
 	weight = WEIGHT_MOB
@@ -18,7 +23,7 @@
 	if(.)
 		return
 	var/mob/living/carbon/human/H = user.mob
-	H.holster_verb("none")
+	H.holster_verb(QUICK_EQUIP_PRIMARY)
 	return TRUE
 
 /datum/keybinding/human/quick_equip_secondary
@@ -34,7 +39,7 @@
 	if(.)
 		return
 	var/mob/living/carbon/human/H = user.mob
-	H.holster_verb("shift")
+	H.holster_verb(QUICK_EQUIP_SECONDARY)
 	return TRUE
 
 /datum/keybinding/human/quick_equip_tertiary
@@ -50,7 +55,23 @@
 	if(.)
 		return
 	var/mob/living/carbon/human/H = user.mob
-	H.holster_verb("ctrl")
+	H.holster_verb(QUICK_EQUIP_TERTIARY)
+	return TRUE
+	
+/datum/keybinding/human/quick_equip_quaternary
+	hotkey_keys = list()
+	classic_keys = list()
+	name = "quick_equip_quaternary"
+	full_name = "Unholster quaternary"
+	description = "Take out your quaternary item."
+	keybind_signal = COMSIG_KB_HUMAN_QUATERNARY_DOWN
+
+/datum/keybinding/human/quick_equip_quaternary/down(client/user)
+	. = ..()
+	if(.)
+		return
+	var/mob/living/carbon/human/H = user.mob
+	H.holster_verb(QUICK_EQUIP_QUATERNARY)
 	return TRUE
 
 /datum/keybinding/human/quick_equip_inventory
@@ -136,3 +157,8 @@
 	var/mob/living/carbon/human/H = user.mob
 	H.spec_activation_two()
 	return TRUE
+	
+#undef QUICK_EQUIP_PRIMARY
+#undef QUICK_EQUIP_SECONDARY
+#undef QUICK_EQUIP_TERTIARY
+#undef QUICK_EQUIP_QUATERNARY

--- a/code/modules/projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/gun_helpers.dm
@@ -506,74 +506,44 @@ As sniper rifles have both and weapon mods can change them as well. ..() deals w
 					//				   \\
 					//				   \\
 //----------------------------------------------------------
-/mob/living/carbon/human/
-	var/static/list/holster_default = list(
-		"s_store",
-		"belt",
-		"back",
-		"l_store",
-		"r_store",
-		"w_uniform",
-		"shoes",
-		)
 
-	var/static/list/holster_shift = list(
-		"back",
-		"belt",
-		"l_store",
-		"r_store",
-		"w_uniform",
-		"shoes",
-		"s_store",
-		)
 
-	var/static/list/holster_ctrl =  list(
-		"w_uniform",
-		"belt",
-		"l_store",
-		"r_store",
-		"shoes",
-		"s_store",
-		"back",
-		)
 
-/mob/living/carbon/human/proc/holster_unholster_from_storage_slot(var/obj/item/storage/slot)
-	if(isnull(slot)) return
+/mob/living/carbon/human/proc/can_unholster_from_storage_slot(var/obj/item/storage/slot)
+	if(isnull(slot)) 
+		return FALSE
 	if(slot == shoes)//Snowflakey check for shoes and uniform
 		if(shoes.stored_item && isweapon(shoes.stored_item))
-			shoes.attack_hand(src)
-			return TRUE
-		return
+			return shoes
+		return FALSE
 
 	if(slot == w_uniform)
 		for(var/obj/item/storage/internal/accessory/holster/T in w_uniform.accessories)
 			if(T.current_gun)
-				w_uniform.attack_hand(src)
-				return TRUE
+				return w_uniform
 		for(var/obj/item/clothing/accessory/storage/holster/H in w_uniform.accessories)
 			var/obj/item/storage/internal/accessory/holster/HS = H.hold
 			if(HS.current_gun)
-				HS.current_gun.attack_hand(src)
-				return TRUE
-		return
+				return HS.current_gun
+		return FALSE
 
 	if(istype(slot) && (slot.storage_flags & STORAGE_ALLOW_QUICKDRAW))
 		for(var/obj/wep in slot.return_inv())
 			if(isweapon(wep))
-				slot.attack_hand(src)
-				return TRUE
+				return slot
 
 	if(isweapon(slot)) //then check for weapons
-		slot.attack_hand(src)
-		return TRUE
+		return slot
+		
+	return FALSE
 
 //For the holster hotkey
-/mob/living/silicon/robot/verb/holster_verb(var/keymod = "none" as text)
+/mob/living/silicon/robot/verb/holster_verb(var/unholster_number_offset = 1 as num)
 	set name = "holster"
 	set hidden = 1
 	uneq_active()
 
-/mob/living/carbon/human/verb/holster_verb(var/keymod = "none" as text)
+/mob/living/carbon/human/verb/holster_verb(var/unholster_number_offset = 1 as num)
 	set name = "holster"
 	set hidden = 1
 	if(usr.is_mob_incapacitated(TRUE) || usr.is_mob_restrained())
@@ -598,20 +568,32 @@ As sniper rifles have both and weapon mods can change them as well. ..() deals w
 
 		quick_equip()
 	else //empty hand, start checking slots and holsters
-		var/list/slot_order
-		switch(keymod)
-			if("none")
-				slot_order = holster_default	//default order: suit, belt, back, pockets, uniform, shoes
-
-			if("shift")			//shift keymod, do common secondary weapon locations first.
-				slot_order = holster_shift		//order: back, belt, pockets, uniform, shoes, suit.
-
-			if("ctrl", "alt")	//control and alt keymods, do common tertiary weapon locations first. In case ctrl is awkward for some people but alt is not.
-				slot_order = holster_ctrl		//order: uniform, belt, pockets, shoes, back, suit.
+		
+		//default order: suit, belt, back, pockets, uniform, shoes
+		var/list/slot_order = list(
+		"s_store",
+		"belt",
+		"back",
+		"l_store",
+		"r_store",
+		"w_uniform",
+		"shoes",
+		)
+		
+		var/obj/item/slot_selected
 
 		for(var/slot in slot_order)
-			if(holster_unholster_from_storage_slot(vars[slot]))
-				return
+			var/slot_type = can_unholster_from_storage_slot(vars[slot])
+			if(slot_type)
+				slot_selected = slot_type
+				if(unholster_number_offset == 1)
+					break
+				else
+					unholster_number_offset--
+		
+		if(slot_selected)
+			slot_selected.attack_hand(src)
+
 
 /obj/item/weapon/gun/verb/field_strip()
 	set category = "Weapons"

--- a/code/modules/projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/gun_helpers.dm
@@ -518,18 +518,18 @@ As sniper rifles have both and weapon mods can change them as well. ..() deals w
 		return FALSE
 
 	if(slot == w_uniform)
-		for(var/obj/item/storage/internal/accessory/holster/T in w_uniform.accessories)
-			if(T.current_gun)
+		for(var/obj/item/storage/internal/accessory/holster/cycled_holster in w_uniform.accessories)
+			if(cycled_holster.current_gun)
 				return w_uniform
-		for(var/obj/item/clothing/accessory/storage/holster/H in w_uniform.accessories)
-			var/obj/item/storage/internal/accessory/holster/HS = H.hold
-			if(HS.current_gun)
-				return HS.current_gun
+		for(var/obj/item/clothing/accessory/storage/holster/cycled_holster in w_uniform.accessories)
+			var/obj/item/storage/internal/accessory/holster/holster = cycled_holster.hold
+			if(holster.current_gun)
+				return holster.current_gun
 		return FALSE
 
 	if(istype(slot) && (slot.storage_flags & STORAGE_ALLOW_QUICKDRAW))
-		for(var/obj/wep in slot.return_inv())
-			if(isweapon(wep))
+		for(var/obj/cycled_weapon in slot.return_inv())
+			if(isweapon(cycled_weapon))
 				return slot
 
 	if(isweapon(slot)) //then check for weapons
@@ -570,15 +570,7 @@ As sniper rifles have both and weapon mods can change them as well. ..() deals w
 	else //empty hand, start checking slots and holsters
 		
 		//default order: suit, belt, back, pockets, uniform, shoes
-		var/list/slot_order = list(
-		"s_store",
-		"belt",
-		"back",
-		"l_store",
-		"r_store",
-		"w_uniform",
-		"shoes",
-		)
+		var/list/slot_order = list("s_store", "belt", "back", "l_store", "r_store", "w_uniform", "shoes")
 		
 		var/obj/item/slot_selected
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Refactors the unholstering code to be less bad. Now should cycle through slots without things like secondary and tertiary both picking up the same pouch weapon when you have a knife in your boot you want to draw with tertiary.

Also adds quaternary unholster for the insane people (like myself) who take way too many guns. This is left unbound by default.

Order for checks is suit, belt, back, pockets, uniform, shoes. This has not been changed from before.

## Why It's Good For The Game

Better QoL is good.

## Changelog

:cl: Morrow
qol: Adds fourth unholster keybind option
refactor: Makes the unholster code better.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
