### PR TITLE
Jesse, we HAVE to cook - LV Nightmare Inserts

### DIFF
--- a/maps/map_files/LV624/LV624.dmm
+++ b/maps/map_files/LV624/LV624.dmm
@@ -15352,6 +15352,12 @@
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
 /turf/open/gm/dirt,
 /area/lv624/ground/barrens/south_west_barrens)
+"fFa" = (
+/obj/effect/landmark/nightmare{
+	insert_tag = "securesmuggler"
+	},
+/turf/open/gm/grass,
+/area/lv624/ground/jungle/south_west_jungle)
 "fFA" = (
 /obj/structure/machinery/cm_vending/sorted/tech/tool_storage,
 /turf/open/floor{
@@ -16953,6 +16959,9 @@
 "jHd" = (
 /obj/effect/landmark/nightmare{
 	insert_tag = "lv-science"
+	},
+/obj/effect/landmark/nightmare{
+	insert_tag = "shuttlecrash"
 	},
 /turf/open/gm/grass,
 /area/lv624/ground/jungle/north_west_jungle)
@@ -23261,6 +23270,9 @@
 "xJG" = (
 /obj/effect/landmark/nightmare{
 	insert_tag = "lv-skylight"
+	},
+/obj/effect/landmark/nightmare{
+	insert_tag = "methlab"
 	},
 /turf/closed/wall/strata_ice/jungle,
 /area/lv624/ground/caves/north_central_caves)
@@ -30110,7 +30122,7 @@ cWm
 aXh
 aXh
 hUs
-aXh
+fFa
 aKb
 aKb
 aKb

--- a/maps/map_files/LV624/sprinkles/20.shuttlecrash.dmm
+++ b/maps/map_files/LV624/sprinkles/20.shuttlecrash.dmm
@@ -1,0 +1,896 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ag" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 8
+	},
+/obj/effect/landmark/corpsespawner/scientist,
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor{
+	dir = 5;
+	icon_state = "whitepurple"
+	},
+/area/template_noop)
+"br" = (
+/turf/closed/wall/r_wall,
+/area/template_noop)
+"bG" = (
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/floor/plating,
+/area/template_noop)
+"ch" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 1
+	},
+/turf/open/floor{
+	dir = 5;
+	icon_state = "whitepurple"
+	},
+/area/template_noop)
+"cm" = (
+/obj/structure/surface/table,
+/obj/item/tool/surgery/scalpel{
+	pixel_y = 12
+	},
+/obj/structure/machinery/light,
+/obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
+/obj/effect/landmark/objective_landmark/science,
+/turf/open/floor{
+	dir = 5;
+	icon_state = "whitepurple"
+	},
+/area/template_noop)
+"cr" = (
+/obj/structure/shuttle/window,
+/turf/open/shuttle,
+/area/template_noop)
+"cz" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor{
+	dir = 5;
+	icon_state = "whitepurple"
+	},
+/area/template_noop)
+"cP" = (
+/obj/structure/girder/displaced,
+/turf/open/shuttle/plating,
+/area/template_noop)
+"cV" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/shuttle/plating,
+/area/template_noop)
+"dC" = (
+/obj/structure/window/framed/colony/reinforced,
+/obj/structure/machinery/door/poddoor/almayer{
+	dir = 4;
+	id = "science_blast";
+	layer = 3.3;
+	name = "\improper Science Wing Blast Door"
+	},
+/turf/open/floor/plating,
+/area/template_noop)
+"dM" = (
+/obj/structure/machinery/door/poddoor/almayer{
+	dir = 4;
+	id = "science_blast";
+	layer = 3.3;
+	name = "\improper Science Wing Blast Door"
+	},
+/obj/structure/machinery/door/airlock/almayer/research{
+	locked = 1;
+	name = "\improper Research Dome";
+	req_access_txt = "100"
+	},
+/turf/open/floor{
+	icon_state = "white"
+	},
+/area/template_noop)
+"dY" = (
+/obj/effect/decal/cleanable/blood/xeno,
+/turf/open/shuttle/plating,
+/area/template_noop)
+"dZ" = (
+/obj/structure/surface/table,
+/obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
+/obj/effect/landmark/objective_landmark/science,
+/obj/effect/landmark/good_item,
+/turf/open/shuttle/plating,
+/area/template_noop)
+"ee" = (
+/obj/effect/decal/remains/xeno,
+/turf/open/gm/dirt,
+/area/template_noop)
+"eE" = (
+/obj/structure/surface/table,
+/obj/effect/landmark/good_item,
+/obj/effect/landmark/objective_landmark/science,
+/turf/open/shuttle/plating,
+/area/template_noop)
+"eS" = (
+/obj/structure/machinery/chem_dispenser,
+/turf/open/floor{
+	dir = 5;
+	icon_state = "whitepurple"
+	},
+/area/template_noop)
+"ff" = (
+/obj/structure/machinery/door/unpowered/shuttle,
+/turf/open/shuttle,
+/area/template_noop)
+"fI" = (
+/obj/structure/machinery/colony_floodlight,
+/turf/open/gm/grass,
+/area/template_noop)
+"hA" = (
+/obj/structure/shuttle/diagonal{
+	dir = 6
+	},
+/turf/open/shuttle/plating,
+/area/template_noop)
+"jm" = (
+/obj/effect/decal/cleanable/blood/oil/streak,
+/turf/open/shuttle/plating,
+/area/template_noop)
+"jy" = (
+/obj/effect/decal/remains/human,
+/obj/structure/shuttle/engine/propulsion,
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/shuttle/plating,
+/area/template_noop)
+"kr" = (
+/obj/structure/machinery/door/poddoor/almayer/open{
+	dir = 4;
+	id = "";
+	name = "\improper Forced Blast Door"
+	},
+/obj/structure/machinery/door/airlock/almayer/research{
+	density = 0;
+	icon_state = "door_open";
+	name = "\improper Research Dome";
+	opacity = 0;
+	req_access_txt = "100"
+	},
+/turf/open/floor{
+	dir = 5;
+	icon_state = "whitepurple"
+	},
+/area/template_noop)
+"kX" = (
+/turf/open/gm/grass,
+/area/template_noop)
+"ln" = (
+/obj/structure/surface/table,
+/obj/effect/landmark/objective_landmark/science,
+/turf/open/shuttle/plating,
+/area/template_noop)
+"lp" = (
+/obj/effect/decal/cleanable/blood/oil,
+/turf/closed/shuttle,
+/area/template_noop)
+"ls" = (
+/obj/structure/surface/table,
+/obj/item/tool/crowbar,
+/obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
+/obj/effect/landmark/objective_landmark/science,
+/turf/open/floor{
+	dir = 5;
+	icon_state = "whitepurple"
+	},
+/area/template_noop)
+"lz" = (
+/obj/effect/decal/remains/human,
+/turf/open/shuttle/plating,
+/area/template_noop)
+"ot" = (
+/turf/open/gm/dirt,
+/area/template_noop)
+"pA" = (
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/shuttle/plating,
+/area/template_noop)
+"pR" = (
+/obj/structure/girder/displaced,
+/turf/open/floor{
+	dir = 5;
+	icon_state = "whitepurple"
+	},
+/area/template_noop)
+"qc" = (
+/obj/structure/lamarr{
+	density = 0;
+	destroyed = 1;
+	icon_state = "labcageb0";
+	occupied = 0
+	},
+/obj/item/shard,
+/turf/open/shuttle/plating,
+/area/template_noop)
+"rB" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor{
+	icon_state = "white"
+	},
+/area/template_noop)
+"rC" = (
+/obj/effect/landmark/monkey_spawn,
+/turf/open/shuttle/plating,
+/area/template_noop)
+"sj" = (
+/obj/structure/bed/chair/vehicle{
+	dir = 1
+	},
+/obj/effect/landmark/corpsespawner/colonist,
+/turf/open/shuttle,
+/area/template_noop)
+"sp" = (
+/obj/structure/fence,
+/turf/open/gm/dirtgrassborder{
+	dir = 1
+	},
+/area/template_noop)
+"tp" = (
+/obj/effect/decal/cleanable/blood/oil/streak,
+/obj/effect/landmark/monkey_spawn,
+/turf/open/shuttle/plating,
+/area/template_noop)
+"tC" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 1
+	},
+/turf/open/shuttle/plating,
+/area/template_noop)
+"tK" = (
+/obj/structure/machinery/light,
+/turf/open/shuttle/plating,
+/area/template_noop)
+"ur" = (
+/obj/effect/decal/cleanable/blood/oil/streak,
+/turf/open/floor{
+	dir = 5;
+	icon_state = "whitepurple"
+	},
+/area/template_noop)
+"ux" = (
+/obj/structure/shuttle/diagonal,
+/turf/open/shuttle/plating,
+/area/template_noop)
+"wh" = (
+/obj/effect/decal/cleanable/blood/oil/streak,
+/obj/structure/girder/reinforced,
+/turf/open/shuttle/plating,
+/area/template_noop)
+"wk" = (
+/obj/structure/machinery/power/apc{
+	dir = 1;
+	name = "Research APC";
+	pixel_y = 30;
+	start_charge = 0
+	},
+/obj/structure/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/surface/table,
+/obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
+/turf/open/floor{
+	dir = 5;
+	icon_state = "whitepurple"
+	},
+/area/template_noop)
+"wO" = (
+/turf/closed/wall/strata_ice/jungle,
+/area/template_noop)
+"xS" = (
+/obj/structure/bed/chair/vehicle{
+	dir = 1
+	},
+/obj/effect/landmark/corpsespawner/colonist,
+/obj/item/clothing/mask/facehugger{
+	desc = "It has some sort of a tube at the end of its tail. What the hell is this thing?";
+	icon_state = "facehugger_impregnated";
+	name = "????";
+	stat = 2
+	},
+/turf/open/shuttle,
+/area/template_noop)
+"yf" = (
+/obj/effect/landmark/objective_landmark/science,
+/turf/open/floor{
+	dir = 5;
+	icon_state = "whitepurple"
+	},
+/area/template_noop)
+"yq" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/structure/xenoautopsy/tank/broken,
+/turf/open/floor{
+	dir = 5;
+	icon_state = "whitepurple"
+	},
+/area/template_noop)
+"yt" = (
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor{
+	dir = 5;
+	icon_state = "whitepurple"
+	},
+/area/template_noop)
+"yA" = (
+/obj/structure/window/framed/colony/reinforced,
+/obj/structure/machinery/door/poddoor/almayer{
+	id = "science_blast";
+	layer = 3.3;
+	name = "\improper Science Wing Blast Door"
+	},
+/turf/open/floor/plating,
+/area/template_noop)
+"zF" = (
+/obj/structure/machinery/computer/shuttle_control/dropship1/onboard,
+/turf/open/shuttle,
+/area/template_noop)
+"zK" = (
+/obj/structure/machinery/door/poddoor/almayer{
+	id = "science_blast";
+	layer = 3.3;
+	name = "\improper Science Wing Blast Door"
+	},
+/obj/structure/machinery/door/airlock/almayer/research{
+	dir = 1;
+	locked = 1;
+	name = "\improper Research Dome";
+	req_access_txt = "100"
+	},
+/turf/open/floor{
+	icon_state = "white"
+	},
+/area/template_noop)
+"AN" = (
+/obj/structure/shuttle/diagonal{
+	dir = 4
+	},
+/turf/open/shuttle/plating,
+/area/template_noop)
+"AT" = (
+/obj/structure/xenoautopsy/jar_shelf,
+/turf/open/floor{
+	dir = 5;
+	icon_state = "whitepurple"
+	},
+/area/template_noop)
+"AZ" = (
+/obj/structure/flora/bush/ausbushes/var3/ywflowers,
+/turf/open/gm/grass,
+/area/template_noop)
+"Bv" = (
+/obj/effect/landmark/corpsespawner/scientist,
+/turf/open/floor{
+	dir = 5;
+	icon_state = "whitepurple"
+	},
+/area/template_noop)
+"By" = (
+/obj/structure/surface/table/holotable,
+/obj/structure/machinery/computer/objective{
+	dir = 5
+	},
+/turf/open/floor{
+	dir = 5;
+	icon_state = "whitepurple"
+	},
+/area/template_noop)
+"BD" = (
+/obj/structure/bed/chair/vehicle{
+	dir = 1
+	},
+/turf/open/shuttle,
+/area/template_noop)
+"Cm" = (
+/obj/structure/xenoautopsy/tank/broken,
+/turf/open/floor{
+	dir = 5;
+	icon_state = "whitepurple"
+	},
+/area/template_noop)
+"Df" = (
+/turf/open/floor/plating,
+/area/template_noop)
+"Eu" = (
+/obj/structure/surface/table,
+/obj/item/folder,
+/obj/effect/landmark/good_item,
+/turf/open/shuttle/plating,
+/area/template_noop)
+"EA" = (
+/obj/structure/surface/table,
+/obj/effect/decal/remains/human,
+/obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
+/turf/open/shuttle/plating,
+/area/template_noop)
+"FX" = (
+/obj/item/clothing/mask/facehugger{
+	desc = "It has some sort of a tube at the end of its tail. What the hell is this thing?";
+	icon_state = "facehugger_impregnated";
+	name = "????";
+	stat = 2
+	},
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/shuttle/plating,
+/area/template_noop)
+"Ge" = (
+/obj/item/clothing/mask/facehugger{
+	desc = "It has some sort of a tube at the end of its tail. What the hell is this thing?";
+	icon_state = "facehugger_impregnated";
+	name = "????";
+	stat = 2
+	},
+/obj/structure/machinery/door/poddoor/almayer/open{
+	dir = 4;
+	id = "";
+	name = "\improper Forced Blast Door"
+	},
+/obj/structure/machinery/door/airlock/almayer/research{
+	density = 0;
+	icon_state = "door_open";
+	name = "\improper Research Dome";
+	opacity = 0;
+	req_access_txt = "100"
+	},
+/turf/open/floor{
+	dir = 5;
+	icon_state = "whitepurple"
+	},
+/area/template_noop)
+"Gl" = (
+/obj/structure/xenoautopsy/tank/broken,
+/turf/open/shuttle/plating,
+/area/template_noop)
+"GH" = (
+/obj/structure/shuttle/engine/propulsion/burst/left{
+	dir = 1
+	},
+/turf/open/shuttle/plating,
+/area/template_noop)
+"Hw" = (
+/obj/structure/surface/table,
+/obj/item/alien_embryo{
+	pixel_y = 4
+	},
+/obj/effect/landmark/objective_landmark/science,
+/turf/open/shuttle/plating,
+/area/template_noop)
+"IU" = (
+/obj/structure/lamarr{
+	density = 0;
+	destroyed = 1;
+	icon_state = "labcageb0";
+	occupied = 0
+	},
+/obj/item/shard,
+/turf/open/floor{
+	dir = 5;
+	icon_state = "whitepurple"
+	},
+/area/template_noop)
+"Jd" = (
+/obj/effect/decal/cleanable/blood,
+/obj/structure/shuttle/diagonal{
+	dir = 8
+	},
+/turf/open/shuttle/plating,
+/area/template_noop)
+"Jn" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/shuttle/plating,
+/area/template_noop)
+"Jw" = (
+/obj/structure/machinery/light,
+/obj/effect/decal/cleanable/blood/xeno,
+/turf/open/shuttle/plating,
+/area/template_noop)
+"JG" = (
+/obj/structure/flora/bush/ausbushes/ausbush,
+/turf/open/gm/grass,
+/area/template_noop)
+"JK" = (
+/obj/structure/flora/bush/ausbushes/pointybush,
+/turf/open/gm/grass,
+/area/template_noop)
+"JV" = (
+/obj/effect/landmark/corpsespawner/ua_riot/burst,
+/obj/item/clothing/mask/facehugger{
+	desc = "It has some sort of a tube at the end of its tail. What the hell is this thing?";
+	icon_state = "facehugger_impregnated";
+	name = "????";
+	stat = 2
+	},
+/turf/open/shuttle/plating,
+/area/template_noop)
+"Ku" = (
+/obj/structure/surface/table,
+/obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
+/turf/open/shuttle/plating,
+/area/template_noop)
+"KU" = (
+/obj/effect/landmark/objective_landmark/science,
+/turf/open/floor{
+	icon_state = "white"
+	},
+/area/template_noop)
+"MW" = (
+/obj/structure/shuttle/diagonal{
+	dir = 8
+	},
+/turf/open/shuttle/plating,
+/area/template_noop)
+"NG" = (
+/obj/structure/machinery/door/airlock/almayer/research{
+	dir = 1;
+	locked = 1;
+	name = "\improper Research Dome";
+	req_access_txt = "100"
+	},
+/turf/open/floor{
+	dir = 5;
+	icon_state = "whitepurple"
+	},
+/area/template_noop)
+"Ok" = (
+/turf/open/shuttle,
+/area/template_noop)
+"Qr" = (
+/obj/structure/window_frame/colony/reinforced,
+/obj/structure/machinery/door/poddoor/almayer{
+	id = "science_blast";
+	layer = 3.3;
+	name = "\improper Science Wing Blast Door"
+	},
+/turf/open/floor/plating,
+/area/template_noop)
+"RI" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/item/clothing/mask/facehugger{
+	desc = "It has some sort of a tube at the end of its tail. What the hell is this thing?";
+	icon_state = "facehugger_impregnated";
+	name = "????";
+	stat = 2
+	},
+/obj/effect/landmark/corpsespawner/ua_riot/burst,
+/turf/open/shuttle/plating,
+/area/template_noop)
+"RJ" = (
+/obj/structure/flora/bush/ausbushes/var3/sunnybush,
+/turf/open/gm/grass,
+/area/template_noop)
+"Tp" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/structure/machinery/door_control{
+	id = "science_blast";
+	name = "Science Wing Lockdown";
+	pixel_x = 25
+	},
+/turf/open/shuttle/plating,
+/area/template_noop)
+"Tu" = (
+/turf/open/shuttle/plating,
+/area/template_noop)
+"UG" = (
+/obj/structure/surface/table,
+/obj/item/book/manual/research_and_development,
+/obj/item/cell/hyper,
+/obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
+/obj/effect/landmark/objective_landmark/science,
+/turf/open/shuttle/plating,
+/area/template_noop)
+"Vw" = (
+/obj/item/clothing/mask/facehugger{
+	desc = "It has some sort of a tube at the end of its tail. What the hell is this thing?";
+	icon_state = "facehugger_impregnated";
+	name = "????";
+	stat = 2
+	},
+/turf/open/floor{
+	dir = 5;
+	icon_state = "whitepurple"
+	},
+/area/template_noop)
+"VL" = (
+/obj/item/bananapeel,
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/shuttle/plating,
+/area/template_noop)
+"VX" = (
+/obj/structure/girder/reinforced,
+/turf/open/shuttle/plating,
+/area/template_noop)
+"Wg" = (
+/obj/structure/bed/chair/vehicle{
+	dir = 1
+	},
+/obj/effect/landmark/survivor_spawner/lv624_crashed_clf{
+	intro_text = list("<h2>You are a survivor of a crash landing!</h2>","<span class='notice'>You ARE aware of the xenomorph threat.</span>","<span class='danger'>Your primary objective is to heal up and survive. If you want to assault the hive - adminhelp.</span>");
+	story_text = "You are a soldier of Colonial Liberation Front. You  "
+	},
+/turf/open/shuttle,
+/area/template_noop)
+"WN" = (
+/turf/open/floor{
+	dir = 5;
+	icon_state = "whitepurple"
+	},
+/area/template_noop)
+"WO" = (
+/obj/structure/bed/chair/office/dark,
+/turf/open/shuttle/plating,
+/area/template_noop)
+"WS" = (
+/turf/closed/shuttle/transit/vertical,
+/area/template_noop)
+"Ze" = (
+/obj/structure/shuttle/engine/propulsion/burst/right{
+	dir = 4
+	},
+/turf/open/shuttle/plating,
+/area/template_noop)
+"ZL" = (
+/obj/effect/landmark/objective_landmark/science,
+/turf/open/shuttle/plating,
+/area/template_noop)
+
+(1,1,1) = {"
+kX
+wO
+kX
+kX
+kX
+br
+dC
+dM
+dC
+br
+kX
+kX
+kX
+JG
+kX
+"}
+(2,1,1) = {"
+fI
+br
+dC
+dC
+dC
+br
+eE
+Tu
+WN
+br
+dC
+dC
+dC
+br
+kX
+"}
+(3,1,1) = {"
+JK
+Qr
+Hw
+tp
+cm
+Tu
+EA
+tC
+Jw
+cP
+dZ
+VL
+Cm
+bG
+kX
+"}
+(4,1,1) = {"
+kX
+Qr
+IU
+ag
+WN
+cP
+Tu
+FX
+Tu
+NG
+Tu
+lz
+ZL
+bG
+kX
+"}
+(5,1,1) = {"
+kX
+Qr
+qc
+Vw
+Cm
+Tu
+WN
+pA
+Tu
+VX
+MW
+ux
+RI
+Df
+AZ
+"}
+(6,1,1) = {"
+br
+Tu
+Jd
+WS
+WS
+WS
+jm
+Tu
+Tu
+WS
+WS
+WS
+pA
+GH
+jm
+"}
+(7,1,1) = {"
+yA
+yf
+WS
+Ok
+Ok
+BD
+Tu
+Tu
+cV
+BD
+Ok
+ff
+pA
+pA
+yt
+"}
+(8,1,1) = {"
+zK
+cr
+zF
+sj
+Ok
+Ok
+Tu
+ur
+dY
+BD
+Ok
+lp
+jy
+pA
+rC
+"}
+(9,1,1) = {"
+bG
+cz
+WS
+Ok
+Ok
+xS
+Tp
+Tu
+Tu
+Wg
+Ok
+Ok
+pA
+FX
+Df
+"}
+(10,1,1) = {"
+br
+br
+hA
+WS
+WS
+WS
+Tu
+Tu
+pA
+WS
+WS
+WS
+Tu
+Ze
+pA
+"}
+(11,1,1) = {"
+ot
+Qr
+AT
+dY
+WN
+wh
+Bv
+Tu
+WN
+VX
+hA
+AN
+Tu
+WN
+kX
+"}
+(12,1,1) = {"
+ot
+Qr
+Gl
+ch
+WN
+pR
+Tu
+Jn
+cP
+NG
+pA
+WO
+Eu
+bG
+RJ
+"}
+(13,1,1) = {"
+ot
+yA
+By
+JV
+eS
+br
+wk
+KU
+yq
+br
+UG
+ln
+Ku
+yA
+kX
+"}
+(14,1,1) = {"
+ee
+br
+dC
+dC
+dC
+br
+ls
+rB
+tK
+br
+dC
+dC
+bG
+br
+kX
+"}
+(15,1,1) = {"
+ot
+sp
+kX
+kX
+kX
+br
+br
+kr
+Ge
+br
+kX
+AZ
+kX
+kX
+wO
+"}

--- a/maps/map_files/LV624/sprinkles/30.methlab.dmm
+++ b/maps/map_files/LV624/sprinkles/30.methlab.dmm
@@ -1,0 +1,739 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"bu" = (
+/obj/structure/surface/rack,
+/obj/item/tank/emergency_oxygen/engi,
+/obj/item/tank/emergency_oxygen/engi,
+/obj/item/tank/emergency_oxygen/engi,
+/turf/open/floor/plating,
+/area/template_noop)
+"bJ" = (
+/obj/structure/reagent_dispensers/ammoniatank,
+/turf/open/floor/plating,
+/area/template_noop)
+"cF" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plating,
+/area/template_noop)
+"ek" = (
+/obj/structure/surface/table/reinforced,
+/obj/item/ammo_magazine/shotgun/incendiary,
+/obj/item/ammo_magazine/shotgun/incendiary,
+/obj/item/ammo_magazine/shotgun/incendiary,
+/turf/open/floor/plating,
+/area/template_noop)
+"ew" = (
+/obj/structure/closet/cabinet,
+/obj/item/device/flashlight/lantern,
+/obj/item/device/flashlight/lantern,
+/obj/item/device/flashlight/lantern,
+/obj/item/device/flashlight/lantern,
+/obj/item/device/flashlight/lantern,
+/obj/item/device/flashlight/lantern,
+/obj/item/device/flashlight/lantern,
+/turf/open/floor/plating,
+/area/template_noop)
+"hs" = (
+/obj/item/trash/burger,
+/turf/open/floor/plating,
+/area/template_noop)
+"hY" = (
+/obj/structure/largecrate/random/barrel,
+/obj/effect/spawner/random/sentry/highchance,
+/turf/open/floor/plating,
+/area/template_noop)
+"ia" = (
+/obj/structure/barricade/metal/wired,
+/turf/open/floor/plating,
+/area/template_noop)
+"iA" = (
+/obj/structure/sink{
+	pixel_y = -8;
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/template_noop)
+"iG" = (
+/obj/structure/surface/table/reinforced,
+/obj/effect/spawner/random/goggles/highchance,
+/turf/open/floor/plating,
+/area/template_noop)
+"kw" = (
+/obj/structure/barricade/metal/wired{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/template_noop)
+"kZ" = (
+/obj/structure/largecrate/random/barrel/yellow,
+/obj/item/ammo_magazine/rifle/mar40/extended,
+/obj/item/ammo_magazine/rifle/mar40/extended,
+/turf/open/floor/plating,
+/area/template_noop)
+"lo" = (
+/obj/item/trash/waffles,
+/turf/open/floor/plating,
+/area/template_noop)
+"lv" = (
+/obj/item/trash/barcardine,
+/turf/open/floor/plating,
+/area/template_noop)
+"mk" = (
+/obj/item/trash/chunk,
+/turf/open/floor/plating,
+/area/template_noop)
+"nj" = (
+/obj/structure/surface/table/reinforced,
+/obj/effect/spawner/random/pills/highchance,
+/turf/open/floor/plating,
+/area/template_noop)
+"nE" = (
+/obj/item/trash/wy_chips_pepper,
+/turf/open/floor/plating,
+/area/template_noop)
+"oZ" = (
+/obj/structure/toilet,
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor/plating,
+/area/template_noop)
+"qi" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor/plating,
+/area/template_noop)
+"rK" = (
+/obj/effect/decal/cleanable/blood,
+/obj/structure/sign/poster/ad{
+	pixel_y = 62
+	},
+/obj/item/reagent_container/food/drinks/cans/souto,
+/turf/open/floor/plating,
+/area/template_noop)
+"sq" = (
+/turf/closed/wall,
+/area/template_noop)
+"tI" = (
+/obj/structure/surface/table/reinforced,
+/obj/item/weapon/gun/smg/mp5,
+/obj/item/weapon/gun/smg/mp5,
+/obj/item/weapon/gun/smg/mp5,
+/obj/item/ammo_magazine/smg/mp5,
+/obj/item/ammo_magazine/smg/mp5,
+/obj/item/ammo_magazine/smg/mp5,
+/obj/item/ammo_magazine/smg/mp5,
+/obj/item/ammo_magazine/smg/mp5,
+/obj/item/ammo_magazine/smg/mp5,
+/obj/item/ammo_magazine/smg/mp5,
+/obj/item/ammo_magazine/smg/mp5,
+/turf/open/floor/plating,
+/area/template_noop)
+"tT" = (
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor/plating,
+/area/template_noop)
+"uc" = (
+/obj/structure/curtain/shower,
+/turf/open/floor/plating,
+/area/template_noop)
+"ux" = (
+/obj/structure/window/framed/colony,
+/turf/open/floor/plating,
+/area/template_noop)
+"uz" = (
+/obj/structure/surface/rack,
+/obj/item/clothing/head/radiation,
+/obj/item/clothing/head/radiation,
+/obj/item/clothing/head/radiation,
+/turf/open/floor/plating,
+/area/template_noop)
+"vj" = (
+/obj/structure/reagent_dispensers/oxygentank,
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/plating,
+/area/template_noop)
+"wh" = (
+/obj/structure/surface/table/reinforced,
+/obj/item/storage/firstaid/toxin,
+/obj/effect/spawner/random/pills/highchance,
+/turf/open/floor/plating,
+/area/template_noop)
+"wS" = (
+/obj/structure/kitchenspike,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/landmark/corpsespawner/colonist,
+/turf/open/floor/plating,
+/area/template_noop)
+"wX" = (
+/obj/structure/curtain/red,
+/turf/open/floor/plating,
+/area/template_noop)
+"xd" = (
+/obj/effect/landmark/nightmare{
+	insert_tag = "lv-skylight"
+	},
+/turf/closed/wall/strata_ice/jungle,
+/area/template_noop)
+"xK" = (
+/obj/structure/surface/rack,
+/obj/item/clothing/suit/radiation{
+	pixel_y = -4;
+	pixel_x = -1
+	},
+/obj/item/clothing/suit/radiation{
+	pixel_y = -4;
+	pixel_x = -1
+	},
+/obj/item/clothing/suit/radiation{
+	pixel_y = -4;
+	pixel_x = -1
+	},
+/turf/open/floor/plating,
+/area/template_noop)
+"yh" = (
+/obj/structure/sign/poster/pinup{
+	pixel_y = 61
+	},
+/obj/item/reagent_container/food/drinks/cans/souto,
+/turf/open/floor/plating,
+/area/template_noop)
+"yy" = (
+/obj/structure/reagent_dispensers/fueltank,
+/obj/structure/sign/nosmoking_2{
+	pixel_y = 28
+	},
+/turf/open/floor/plating,
+/area/template_noop)
+"yH" = (
+/obj/item/trash/boonie,
+/turf/open/floor/plating,
+/area/template_noop)
+"yL" = (
+/obj/item/trash/crushed_cup,
+/turf/open/floor/plating,
+/area/template_noop)
+"yX" = (
+/obj/item/ammo_box/magazine/M16,
+/turf/open/floor/plating,
+/area/template_noop)
+"Aq" = (
+/obj/structure/reagent_dispensers/pacidtank,
+/obj/structure/sign/nosmoking_1{
+	pixel_y = 26
+	},
+/turf/open/floor/plating,
+/area/template_noop)
+"Cx" = (
+/obj/structure/barricade/metal/wired,
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/plating,
+/area/template_noop)
+"DA" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating,
+/area/template_noop)
+"EF" = (
+/turf/open/floor/plating,
+/area/template_noop)
+"EG" = (
+/obj/structure/largecrate/supply/supplies/metal,
+/turf/open/floor/plating,
+/area/template_noop)
+"EN" = (
+/obj/structure/surface/table/reinforced,
+/obj/item/weapon/gun/rifle/m16,
+/obj/item/weapon/gun/rifle/m16,
+/obj/item/weapon/gun/rifle/m16,
+/turf/open/floor/plating,
+/area/template_noop)
+"FF" = (
+/obj/item/reagent_container/food/drinks/cans/souto,
+/turf/open/floor/plating,
+/area/template_noop)
+"FH" = (
+/obj/structure/machinery/shower,
+/obj/item/defenses/handheld/sentry,
+/turf/open/floor/plating,
+/area/template_noop)
+"Gn" = (
+/turf/closed/wall/rock/brown,
+/area/template_noop)
+"GK" = (
+/obj/structure/largecrate/random/barrel/yellow,
+/obj/item/weapon/gun/rifle/mar40,
+/obj/item/ammo_magazine/rifle/mar40,
+/obj/item/ammo_magazine/rifle/mar40,
+/obj/item/ammo_magazine/rifle/mar40,
+/turf/open/floor/plating,
+/area/template_noop)
+"GR" = (
+/obj/structure/largecrate/random/barrel/yellow,
+/turf/open/floor/plating,
+/area/template_noop)
+"GS" = (
+/obj/structure/surface/table/reinforced,
+/obj/item/storage/box/gloves,
+/obj/structure/sign/poster/music{
+	pixel_y = 31
+	},
+/turf/open/floor/plating,
+/area/template_noop)
+"HB" = (
+/obj/structure/barricade/metal/wired{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/plating,
+/area/template_noop)
+"IJ" = (
+/obj/structure/reagent_dispensers/ammoniatank,
+/obj/structure/sign/nosmoking_1{
+	pixel_y = 26
+	},
+/turf/open/floor/plating,
+/area/template_noop)
+"JX" = (
+/obj/item/trash/eat,
+/turf/open/floor/plating,
+/area/template_noop)
+"Lp" = (
+/obj/structure/sink{
+	pixel_y = 16
+	},
+/turf/open/floor/plating,
+/area/template_noop)
+"LA" = (
+/obj/structure/reagent_dispensers/pacidtank,
+/turf/open/floor/plating,
+/area/template_noop)
+"LD" = (
+/obj/structure/largecrate/supply/medicine/medkits,
+/turf/open/floor/plating,
+/area/template_noop)
+"Mj" = (
+/obj/structure/surface/table/reinforced,
+/obj/item/storage/box/beakers,
+/turf/open/floor/plating,
+/area/template_noop)
+"MV" = (
+/obj/structure/surface/table/reinforced,
+/obj/item/storage/fancy/cigarettes/lucky_strikes{
+	pixel_x = 7
+	},
+/obj/item/tool/lighter/zippo{
+	pixel_x = -3
+	},
+/obj/item/ashtray/glass{
+	pixel_x = -4;
+	pixel_y = 6
+	},
+/turf/open/floor/plating,
+/area/template_noop)
+"NV" = (
+/obj/structure/surface/table/reinforced,
+/obj/effect/spawner/random/gun/special/highchance,
+/turf/open/floor/plating,
+/area/template_noop)
+"Ok" = (
+/obj/structure/surface/rack,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/plating,
+/area/template_noop)
+"PG" = (
+/obj/structure/reagent_dispensers/oxygentank,
+/turf/open/floor/plating,
+/area/template_noop)
+"PK" = (
+/obj/structure/barricade/plasteel/wired,
+/turf/open/floor/plating,
+/area/template_noop)
+"Qn" = (
+/obj/structure/bed,
+/obj/item/bedsheet/yellow,
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor/plating,
+/area/template_noop)
+"QB" = (
+/obj/structure/barricade/metal/wired,
+/obj/structure/sign/poster/clf{
+	pixel_y = 31
+	},
+/turf/open/floor/plating,
+/area/template_noop)
+"QD" = (
+/obj/structure/machinery/chem_master,
+/turf/open/floor/plating,
+/area/template_noop)
+"QK" = (
+/obj/structure/machinery/chem_dispenser,
+/turf/open/floor/plating,
+/area/template_noop)
+"QL" = (
+/obj/structure/machinery/cm_vending/sorted/medical/chemistry,
+/turf/open/floor/plating,
+/area/template_noop)
+"Sj" = (
+/turf/closed/wall/strata_ice/jungle,
+/area/template_noop)
+"Sp" = (
+/obj/structure/surface/table/reinforced,
+/obj/item/weapon/gun/smg/nailgun,
+/obj/item/weapon/gun/smg/nailgun,
+/obj/item/weapon/gun/smg/nailgun,
+/obj/item/ammo_magazine/smg/nailgun,
+/obj/item/ammo_magazine/smg/nailgun,
+/obj/item/ammo_magazine/smg/nailgun,
+/obj/item/ammo_magazine/smg/nailgun,
+/obj/item/ammo_magazine/smg/nailgun,
+/obj/item/ammo_magazine/smg/nailgun,
+/obj/item/ammo_magazine/smg/nailgun,
+/obj/item/ammo_magazine/smg/nailgun,
+/turf/open/floor/plating,
+/area/template_noop)
+"TS" = (
+/obj/structure/reagent_dispensers/ethanoltank,
+/turf/open/floor/plating,
+/area/template_noop)
+"WB" = (
+/obj/structure/largecrate/random/barrel,
+/turf/open/floor/plating,
+/area/template_noop)
+"Xc" = (
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/plating,
+/area/template_noop)
+"Xi" = (
+/obj/structure/largecrate/supply/supplies/mre,
+/turf/open/floor/plating,
+/area/template_noop)
+"Xr" = (
+/obj/effect/decal/cleanable/blood/oil,
+/obj/item/ammo_box/magazine/M16,
+/turf/open/floor/plating,
+/area/template_noop)
+"Ya" = (
+/obj/structure/surface/table/reinforced,
+/obj/item/clothing/head/bowlerhat{
+	pixel_y = 6;
+	desc = "We HAVE to cook."
+	},
+/obj/item/clothing/glasses/regular/hipster,
+/turf/open/floor/plating,
+/area/template_noop)
+"ZO" = (
+/obj/item/trash/snack_bowl,
+/turf/open/floor/plating,
+/area/template_noop)
+
+(1,1,1) = {"
+Gn
+sq
+sq
+sq
+sq
+sq
+sq
+sq
+Sj
+xd
+"}
+(2,1,1) = {"
+Gn
+sq
+EG
+WB
+Xi
+WB
+hY
+sq
+Sj
+Sj
+"}
+(3,1,1) = {"
+Gn
+sq
+WB
+WB
+WB
+WB
+WB
+sq
+Sj
+Sj
+"}
+(4,1,1) = {"
+Gn
+sq
+WB
+WB
+WB
+WB
+LD
+sq
+Sj
+Sj
+"}
+(5,1,1) = {"
+Gn
+sq
+wS
+rK
+WB
+WB
+WB
+sq
+sq
+sq
+"}
+(6,1,1) = {"
+Gn
+sq
+wS
+qi
+DA
+yL
+EF
+sq
+EF
+sq
+"}
+(7,1,1) = {"
+Gn
+sq
+sq
+sq
+sq
+sq
+wX
+sq
+QB
+ux
+"}
+(8,1,1) = {"
+sq
+sq
+uz
+xK
+Ok
+bu
+Xc
+yL
+ia
+ux
+"}
+(9,1,1) = {"
+sq
+wh
+yH
+Xc
+EF
+EF
+hs
+EF
+ia
+ux
+"}
+(10,1,1) = {"
+sq
+GS
+EF
+FF
+Sp
+NV
+EF
+mk
+EF
+sq
+"}
+(11,1,1) = {"
+sq
+Mj
+tT
+EF
+QL
+nj
+EF
+Xc
+PK
+wX
+"}
+(12,1,1) = {"
+sq
+Lp
+Xc
+EF
+QK
+iG
+EF
+EF
+EF
+sq
+"}
+(13,1,1) = {"
+sq
+Ya
+ZO
+EF
+QD
+tI
+nE
+FF
+ia
+ux
+"}
+(14,1,1) = {"
+sq
+nj
+EF
+EF
+EN
+ek
+EF
+EF
+ia
+ux
+"}
+(15,1,1) = {"
+sq
+MV
+EF
+hs
+yX
+Xr
+EF
+JX
+ia
+ux
+"}
+(16,1,1) = {"
+sq
+IJ
+bJ
+Xc
+yL
+EF
+EF
+EF
+EF
+sq
+"}
+(17,1,1) = {"
+sq
+TS
+TS
+lv
+GK
+GR
+kZ
+EF
+EF
+sq
+"}
+(18,1,1) = {"
+sq
+yy
+cF
+EF
+GR
+GR
+GR
+Xc
+ia
+ux
+"}
+(19,1,1) = {"
+sq
+vj
+PG
+Xc
+GR
+GR
+GK
+lo
+ia
+ux
+"}
+(20,1,1) = {"
+sq
+Aq
+LA
+EF
+EF
+EF
+EF
+EF
+Cx
+ux
+"}
+(21,1,1) = {"
+sq
+sq
+sq
+sq
+wX
+sq
+wX
+sq
+sq
+sq
+"}
+(22,1,1) = {"
+Gn
+sq
+FH
+uc
+EF
+sq
+Xc
+EF
+Cx
+ux
+"}
+(23,1,1) = {"
+Gn
+sq
+sq
+sq
+Xc
+sq
+Qn
+FF
+ia
+ux
+"}
+(24,1,1) = {"
+Gn
+sq
+Xc
+yh
+iA
+sq
+ew
+EF
+ia
+ux
+"}
+(25,1,1) = {"
+Gn
+sq
+oZ
+kw
+kw
+wX
+kw
+HB
+ia
+ux
+"}
+(26,1,1) = {"
+Gn
+sq
+sq
+ux
+ux
+sq
+ux
+ux
+sq
+sq
+"}

--- a/maps/map_files/LV624/sprinkles/30.securesmuggler.dmm
+++ b/maps/map_files/LV624/sprinkles/30.securesmuggler.dmm
@@ -1,0 +1,554 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/closed/wall/r_wall,
+/area/template_noop)
+"b" = (
+/obj/structure/largecrate/random/secure,
+/obj/effect/landmark/good_item,
+/turf/open/floor/wood,
+/area/template_noop)
+"c" = (
+/obj/structure/machinery/light{
+	dir = 1
+	},
+/obj/structure/largecrate/lisa,
+/turf/open/floor/wood,
+/area/template_noop)
+"d" = (
+/obj/structure/surface/table/gamblingtable,
+/obj/effect/spawner/random/gun/special/highchance,
+/obj/item/spacecash/c1000,
+/obj/item/moneybag,
+/obj/item/toy/deck/uno,
+/turf/open/floor/carpet,
+/area/template_noop)
+"e" = (
+/obj/structure/machinery/power/apc{
+	dir = 1;
+	name = "Secure Vault APC";
+	pixel_y = 30;
+	start_charge = 200
+	},
+/obj/structure/surface/table/woodentable/poor,
+/obj/item/clothing/head/beret/centcom/captain,
+/obj/item/clothing/suit/storage/bomber,
+/obj/item/clothing/shoes/dress,
+/obj/item/clothing/under/det/slob,
+/turf/open/floor/carpet,
+/area/template_noop)
+"f" = (
+/obj/structure/bed,
+/obj/item/bedsheet/orange,
+/obj/effect/landmark/corpsespawner/realpirate,
+/obj/effect/decal/cleanable/blood,
+/obj/item/weapon/gun/pistol/heavy,
+/turf/open/floor/carpet,
+/area/template_noop)
+"g" = (
+/obj/effect/decal/cleanable/blood/gibs/xeno,
+/turf/open/floor/wood,
+/area/template_noop)
+"h" = (
+/obj/structure/machinery/door/poddoor/almayer{
+	dir = 4;
+	id = "secure_blast";
+	layer = 3.3;
+	name = "\improper Secure Armory Blast Door";
+	unacidable = 1
+	},
+/turf/open/floor/greengrid,
+/area/template_noop)
+"i" = (
+/obj/structure/largecrate/random/barrel,
+/obj/effect/landmark/objective_landmark/science,
+/turf/open/floor/wood,
+/area/template_noop)
+"j" = (
+/obj/structure/surface/rack,
+/obj/effect/landmark/objective_landmark/medium,
+/turf/open/floor/wood,
+/area/template_noop)
+"k" = (
+/obj/structure/machinery/door/poddoor/almayer{
+	dir = 4;
+	id = "secure_blast";
+	layer = 3.3;
+	name = "\improper Secure Armory Blast Door";
+	unacidable = 1
+	},
+/turf/open/floor/plating{
+	icon_state = "platebotc"
+	},
+/area/template_noop)
+"l" = (
+/obj/structure/flora/jungle/vines{
+	icon_state = "light_2"
+	},
+/turf/open/gm/grass,
+/area/template_noop)
+"m" = (
+/obj/structure/flora/bush/ausbushes/lavendergrass,
+/turf/open/gm/grass,
+/area/template_noop)
+"n" = (
+/obj/structure/largecrate/random/barrel,
+/obj/effect/landmark/objective_landmark/science,
+/obj/structure/machinery/light,
+/turf/open/floor/wood,
+/area/template_noop)
+"o" = (
+/obj/structure/largecrate/random/barrel,
+/turf/open/floor/wood,
+/area/template_noop)
+"p" = (
+/obj/structure/bed/chair/comfy,
+/turf/open/floor/carpet,
+/area/template_noop)
+"q" = (
+/turf/closed/wall,
+/area/template_noop)
+"r" = (
+/obj/structure/computerframe{
+	anchored = 1
+	},
+/turf/open/floor/greengrid,
+/area/template_noop)
+"s" = (
+/obj/structure/largecrate/random/secure,
+/turf/open/floor/wood,
+/area/template_noop)
+"t" = (
+/turf/open/gm/grass{
+	icon_state = "grass2"
+	},
+/area/template_noop)
+"u" = (
+/turf/closed/wall/strata_ice/jungle,
+/area/template_noop)
+"v" = (
+/obj/structure/machinery/light{
+	dir = 1
+	},
+/obj/structure/sign/poster/clf{
+	pixel_y = 28
+	},
+/turf/open/floor/wood,
+/area/template_noop)
+"w" = (
+/obj/structure/largecrate/random/case/double,
+/obj/effect/landmark/objective_landmark/close,
+/turf/open/floor/wood,
+/area/template_noop)
+"x" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/carpet,
+/area/template_noop)
+"y" = (
+/obj/structure/flora/bush/ausbushes/var3/sparsegrass,
+/turf/open/gm/grass{
+	icon_state = "grass2"
+	},
+/area/template_noop)
+"z" = (
+/obj/structure/surface/table/woodentable/poor,
+/obj/structure/machinery/computer/security/wooden_tv/prop,
+/turf/open/floor/carpet,
+/area/template_noop)
+"A" = (
+/obj/structure/flora/jungle/vines{
+	icon_state = "light_3"
+	},
+/turf/open/gm/grass,
+/area/template_noop)
+"B" = (
+/obj/effect/decal/cleanable/blood,
+/obj/structure/machinery/light{
+	dir = 1
+	},
+/obj/structure/sign/poster/blacklight{
+	pixel_y = 30
+	},
+/turf/open/floor/carpet,
+/area/template_noop)
+"C" = (
+/obj/structure/machinery/light,
+/obj/structure/largecrate/random/case/double,
+/obj/effect/landmark/objective_landmark/close,
+/turf/open/floor/wood,
+/area/template_noop)
+"D" = (
+/obj/structure/bed/chair/comfy{
+	dir = 8
+	},
+/turf/open/floor/carpet,
+/area/template_noop)
+"E" = (
+/obj/structure/flora/bush/ausbushes/ausbush,
+/turf/open/gm/grass,
+/area/template_noop)
+"F" = (
+/turf/open/floor/wood,
+/area/template_noop)
+"G" = (
+/obj/structure/flora/jungle/vines,
+/turf/open/gm/grass,
+/area/template_noop)
+"H" = (
+/obj/effect/landmark/crap_item,
+/turf/open/gm/grass,
+/area/template_noop)
+"I" = (
+/obj/structure/machinery/cryopod,
+/obj/effect/landmark/corpsespawner/colonist/burst,
+/obj/item/clothing/mask/facehugger{
+	desc = "It has some sort of a tube at the end of its tail. What the hell is this thing?";
+	icon_state = "facehugger_impregnated";
+	name = "????";
+	stat = 2
+	},
+/turf/open/floor/wood,
+/area/template_noop)
+"J" = (
+/obj/structure/machinery/door_control{
+	id = "secure_blast";
+	name = "Dome Access";
+	pixel_x = 25
+	},
+/turf/open/floor/wood,
+/area/template_noop)
+"K" = (
+/turf/open/floor/greengrid,
+/area/template_noop)
+"L" = (
+/obj/structure/bed/chair/comfy{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/template_noop)
+"M" = (
+/obj/structure/largecrate/random/barrel,
+/obj/effect/landmark/objective_landmark/far,
+/obj/structure/sign/poster/pinup{
+	pixel_y = 28
+	},
+/turf/open/floor/wood,
+/area/template_noop)
+"N" = (
+/obj/structure/largecrate/random/case/double,
+/obj/effect/landmark/good_item,
+/turf/open/floor/wood,
+/area/template_noop)
+"O" = (
+/obj/structure/machinery/light{
+	dir = 8
+	},
+/obj/structure/largecrate/random/barrel,
+/turf/open/floor/wood,
+/area/template_noop)
+"P" = (
+/obj/structure/largecrate/supply/weapons/pistols,
+/turf/open/floor/wood,
+/area/template_noop)
+"Q" = (
+/obj/structure/largecrate/random/barrel,
+/obj/effect/landmark/objective_landmark/close,
+/turf/open/floor/wood,
+/area/template_noop)
+"R" = (
+/obj/structure/largecrate/supply/medicine/medkits,
+/turf/open/floor/wood,
+/area/template_noop)
+"S" = (
+/obj/structure/flora/jungle/vines/heavy,
+/obj/structure/flora/jungle/vines{
+	icon_state = "light_3"
+	},
+/obj/structure/flora/bush/ausbushes/lavendergrass,
+/turf/open/gm/grass,
+/area/template_noop)
+"T" = (
+/obj/structure/surface/rack,
+/turf/open/floor/wood,
+/area/template_noop)
+"U" = (
+/obj/structure/curtain/red,
+/turf/open/floor/wood,
+/area/template_noop)
+"V" = (
+/obj/structure/flora/bush/ausbushes/var3/ywflowers,
+/turf/open/gm/grass{
+	icon_state = "grass2"
+	},
+/area/template_noop)
+"W" = (
+/obj/structure/largecrate/random/case/double,
+/turf/open/floor/wood,
+/area/template_noop)
+"X" = (
+/obj/structure/bed/chair/comfy{
+	dir = 1
+	},
+/turf/open/floor/carpet,
+/area/template_noop)
+"Y" = (
+/turf/open/gm/grass,
+/area/template_noop)
+"Z" = (
+/turf/open/floor/carpet,
+/area/template_noop)
+
+(1,1,1) = {"
+Y
+Y
+Y
+Y
+Y
+a
+a
+a
+a
+a
+E
+Y
+Y
+t
+Y
+"}
+(2,1,1) = {"
+Y
+u
+u
+a
+a
+a
+a
+a
+a
+a
+a
+a
+Y
+t
+l
+"}
+(3,1,1) = {"
+u
+u
+a
+a
+a
+a
+M
+O
+I
+a
+a
+a
+a
+A
+G
+"}
+(4,1,1) = {"
+Y
+a
+a
+a
+b
+s
+o
+o
+g
+Q
+i
+a
+a
+a
+S
+"}
+(5,1,1) = {"
+Y
+a
+a
+q
+q
+T
+F
+F
+F
+o
+o
+n
+a
+a
+l
+"}
+(6,1,1) = {"
+a
+a
+a
+e
+q
+j
+F
+F
+F
+o
+Q
+o
+a
+a
+a
+"}
+(7,1,1) = {"
+a
+a
+f
+x
+q
+j
+Z
+L
+Z
+F
+F
+F
+W
+a
+a
+"}
+(8,1,1) = {"
+a
+a
+B
+Z
+q
+v
+p
+d
+X
+F
+F
+F
+R
+a
+a
+"}
+(9,1,1) = {"
+a
+a
+z
+Z
+U
+F
+Z
+D
+Z
+F
+F
+F
+P
+a
+a
+"}
+(10,1,1) = {"
+a
+a
+a
+q
+q
+v
+F
+F
+F
+F
+N
+W
+a
+a
+a
+"}
+(11,1,1) = {"
+m
+a
+a
+c
+s
+F
+F
+F
+F
+F
+W
+C
+a
+a
+A
+"}
+(12,1,1) = {"
+Y
+a
+a
+a
+s
+J
+F
+F
+F
+F
+w
+a
+a
+a
+Y
+"}
+(13,1,1) = {"
+Y
+u
+a
+a
+a
+a
+h
+h
+h
+a
+a
+a
+a
+Y
+y
+"}
+(14,1,1) = {"
+Y
+Y
+Y
+a
+a
+r
+K
+K
+K
+a
+a
+a
+E
+Y
+Y
+"}
+(15,1,1) = {"
+Y
+H
+Y
+Y
+a
+a
+k
+k
+k
+a
+Y
+Y
+Y
+V
+l
+"}


### PR DESCRIPTION
## About The Pull Request

This PR adds three new nightmare inserts to LV. 

**Jesse, where the fuck are we Jesse?**

![image](https://user-images.githubusercontent.com/103917106/187964018-f41d23f5-b7be-4d63-97e7-319a3239065c.png)

The insert is in lake house, which I think justifies the pretty high amount of loot. Hopefully this will have people try and hold lake house instead of trying to run, not that it particularly matters due to the relatively low chance of a gap.

**A local notorious smuggler has taken up refuge in the secure dome.**

![image](https://user-images.githubusercontent.com/103917106/187964055-74b44dbc-f451-48c3-adad-ac22bc0dfd67.png)


Just a relatively minor alteration to the secure dome. Biggest change lootwise is that the power weapon is now randomized, which means instead of a flamer you could just get an m41, nothing, or even a tac shotty. The m41 was also replaced with the pistols crate.

**Research suicide bombing**

![image](https://user-images.githubusercontent.com/103917106/187964072-8617b489-e196-4ba0-9d59-71555b110756.png)


Adds a CLF insert to LV, keeping in step with the crashed ship theme. A CLF operator hijacked a civilian shuttle and crashed it into the secure research facility on LV, expecting to die on impact and completely destroy the research efforts of WY on Lazarus landing. Only problem: he awoke hours later still strapped in his seat with bodies all around him with holes in their chests as though something burst out from them...

## Why It's Good For The Game

Variety is the spice of life, hopefully will slightly change how a very stagnant map is changed - at least for survs and the xenos fighting them.

## Changelog

:cl:
add: Added three new nightmare inserts to LV.
/:cl: