### PR TITLE
ammo boxes can no longer be carried on your back

### DIFF
--- a/code/modules/projectiles/ammo_boxes.dm
+++ b/code/modules/projectiles/ammo_boxes.dm
@@ -245,7 +245,6 @@
 /obj/item/ammo_box/magazine/shotgun
 	name = "shotgun shell box (Slugs x 100)"
 	icon_state = "base_slug"
-	flags_equip_slot = SLOT_BACK
 	overlay_ammo_type = ""
 	overlay_gun_type = "_shells"
 	overlay_content = "_slug"
@@ -304,7 +303,6 @@
 
 /obj/item/ammo_box/magazine/ap
 	name = "magazine box (AP M41A x 10)"
-	flags_equip_slot = SLOT_BACK
 	overlay_ammo_type = "_ap"
 	overlay_content = "_ap"
 	magazine_type = /obj/item/ammo_magazine/rifle/ap
@@ -314,7 +312,6 @@
 
 /obj/item/ammo_box/magazine/le
 	name = "magazine box (LE M41A x 10)"
-	flags_equip_slot = SLOT_BACK
 	overlay_ammo_type = "_le"
 	overlay_content = "_le"
 	magazine_type = /obj/item/ammo_magazine/rifle/le
@@ -324,7 +321,6 @@
 
 /obj/item/ammo_box/magazine/ext
 	name = "magazine box (Ext M41A x 8)"
-	flags_equip_slot = SLOT_BACK
 	overlay_ammo_type = "_ext"
 	num_of_magazines = 8
 	magazine_type = /obj/item/ammo_magazine/rifle/extended
@@ -334,7 +330,6 @@
 
 /obj/item/ammo_box/magazine/incen
 	name = "magazine box (Incen M41A x 10)"
-	flags_equip_slot = SLOT_BACK
 	overlay_ammo_type = "_incen"
 	overlay_content = "_incen"
 	magazine_type = /obj/item/ammo_magazine/rifle/incendiary
@@ -344,7 +339,6 @@
 
 /obj/item/ammo_box/magazine/explosive
 	name = "magazine box (Explosive M41A x 10)"
-	flags_equip_slot = SLOT_BACK
 	overlay_ammo_type = "_expl"
 	overlay_content = "_expl"
 	magazine_type = /obj/item/ammo_magazine/rifle/explosive
@@ -357,7 +351,6 @@
 /obj/item/ammo_box/magazine/m39
 	name = "magazine box (M39 x 12)"
 	icon_state = "base_m39"
-	flags_equip_slot = SLOT_BACK
 	overlay_ammo_type = "_reg"
 	overlay_gun_type = "_m39"
 	overlay_content = "_hv"
@@ -409,7 +402,6 @@
 /obj/item/ammo_box/magazine/l42a
 	name = "magazine box (L42A x 16)"
 	icon_state = "base_l42"
-	flags_equip_slot = SLOT_BACK
 	overlay_gun_type = "_l42"
 	num_of_magazines = 16
 	magazine_type = /obj/item/ammo_magazine/rifle/l42a
@@ -459,7 +451,6 @@
 /obj/item/ammo_box/magazine/M16
 	name = "magazine box (M16 x 12)"
 	icon_state = "base_m16"
-	flags_equip_slot = SLOT_BACK
 	overlay_ammo_type = "_reg"
 	overlay_gun_type = "_m16"
 	num_of_magazines = 12
@@ -535,7 +526,6 @@
 /obj/item/ammo_box/magazine/m4a3
 	name = "magazine box (M4A3 x 16)"
 	icon_state = "base_m4a3"
-	flags_equip_slot = SLOT_BACK
 	overlay_ammo_type = "_reg"
 	overlay_gun_type = "_m4a3"
 	num_of_magazines = 16
@@ -567,7 +557,6 @@
 /obj/item/ammo_box/magazine/m44
 	name = "speed loaders box (M44 x 16)"
 	icon_state = "base_m44"
-	flags_equip_slot = SLOT_BACK
 	overlay_ammo_type = "_m44_reg"
 	overlay_gun_type = "_m44"
 	overlay_content = "_speed"
@@ -598,7 +587,6 @@
 /obj/item/ammo_box/magazine/su6
 	name = "magazine box (SU-6 x 16)"
 	icon_state = "base_su6"
-	flags_equip_slot = SLOT_BACK
 	overlay_ammo_type = "_reg"
 	overlay_gun_type = "_su6"
 	num_of_magazines = 16
@@ -612,7 +600,6 @@
 /obj/item/ammo_box/magazine/mod88
 	name = "magazine box (88 Mod 4 AP x 16)"
 	icon_state = "base_mod88"
-	flags_equip_slot = SLOT_BACK
 	overlay_ammo_type = "_ap"
 	overlay_gun_type = "_mod88"
 	overlay_content = "_ap"
@@ -627,7 +614,6 @@
 /obj/item/ammo_box/magazine/vp78
 	name = "magazine box (VP78 x 16)"
 	icon_state = "base_vp78"
-	flags_equip_slot = SLOT_BACK
 	overlay_ammo_type = "_reg"
 	overlay_gun_type = "_vp78"
 	num_of_magazines = 16
@@ -641,7 +627,6 @@
 /obj/item/ammo_box/magazine/type71
 	name = "magazine box (Type71 x 10)"
 	icon_state = "base_type71"
-	flags_equip_slot = SLOT_BACK
 	overlay_ammo_type = "_type71_reg"
 	overlay_gun_type = "_type71"
 	overlay_content = "_type71_reg"
@@ -898,7 +883,6 @@
 	desc = "A 10x24mm ammunition box. Used to refill M41A MK1, MK2, L42A and M41AE2 HPR magazines. It comes with a leather strap allowing to wear it on the back."
 	icon_state = "base_m41"
 	item_state = "base_m41"
-	flags_equip_slot = SLOT_BACK
 	var/overlay_gun_type = "_rounds"		//used for ammo type color overlay
 	var/overlay_content = "_reg"
 	var/default_ammo = /datum/ammo/bullet/rifle


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

this PR removes the ability to carry ammo boxes on your back.

The ability of marines to do this has significantly simplified ammo transport and storage for them to the point that supply dumps such as hydro and the fob are rarely returned to for restocking

in order to make the murderball less self-sufficient, the ability of marines to be walking ammo dumps must be nerfed somewhat, and as such I am making this PR

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

This PR is good for the game because it will make the role of req more important in ensuring that marines will not be able to easily transport around all the ammo they could ever use in a round on their backs. It will also make the backline more populated and interesting as marines will more frequently need to resupply, as they cannot carry 600 rounds / like 15 mags on their backs at all times. This will reduce the individual self-sufficiency of marines and make them require the assistance of req and logistics more, rather than only needing to ask for a cardboard sheet at the start of the round and not worrying at all about resupply from that point forth.

The game is improved by increased interaction between shipside and groundside, increased importance of req, and increased movement around the map as well as increased importance of forwards firebases such as hydro.

As such this PR is good for the game.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: ammo boxes can no longer be carried on your back
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
