### PR TITLE
Flare guns can be unloaded now

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -2988,6 +2988,7 @@
 	shell_speed = AMMO_SPEED_TIER_3
 
 	var/flare_type = /obj/item/device/flashlight/flare/on/gun
+	handful_type = /obj/item/device/flashlight/flare
 
 /datum/ammo/flare/set_bullet_traits()
 	. = ..()
@@ -3018,6 +3019,7 @@
 	name = "signal flare"
 	icon_state = "flare_signal"
 	flare_type = /obj/item/device/flashlight/flare/signal/gun
+	handful_type = /obj/item/device/flashlight/flare/signal
 
 /datum/ammo/flare/signal/drop_flare(turf/T, mob/firer)
 	var/obj/item/device/flashlight/flare/signal/gun/G = ..()

--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -1035,7 +1035,7 @@ obj/item/weapon/gun/launcher/grenade/update_icon()
 	update_attachables()
 
 
-/obj/item/weapon/gun/flare/rocket/set_gun_attachment_offsets()
+/obj/item/weapon/gun/flare/set_gun_attachment_offsets()
 	attachable_offset = list("muzzle_x" = 33, "muzzle_y" = 18,"rail_x" = 12, "rail_y" = 20, "under_x" = 19, "under_y" = 14, "stock_x" = 19, "stock_y" = 14)
 
 /obj/item/weapon/gun/flare/set_gun_config_values()
@@ -1073,5 +1073,28 @@ obj/item/weapon/gun/launcher/grenade/update_icon()
 			current_mag.current_rounds++
 			qdel(I)
 			update_icon()
-		else to_chat(user, SPAN_WARNING("\The [src] is already loaded!"))
-	else to_chat(user, SPAN_WARNING("That's not a flare!"))
+		else 
+			to_chat(user, SPAN_WARNING("\The [src] is already loaded!"))
+	else 
+		to_chat(user, SPAN_WARNING("That's not a flare!"))
+		
+/obj/item/weapon/gun/flare/unload(mob/user)
+	unload_flare(user)
+	
+/obj/item/weapon/gun/flare/proc/unload_flare(mob/user)
+	if(!current_mag)
+		return
+	if(current_mag.current_rounds)
+		var/obj/item/device/flashlight/flare/unloaded_flare
+		if(istype(ammo, /datum/ammo/flare/signal))
+			var/obj/item/device/flashlight/flare/signal/temp_flare = new(get_turf(src))
+			unloaded_flare = temp_flare
+		else
+			var/obj/item/device/flashlight/flare/temp_flare = new(get_turf(src))
+			unloaded_flare = temp_flare
+		playsound(user, reload_sound, 25, TRUE)
+		current_mag.current_rounds--
+		if(user)
+			to_chat(user, SPAN_NOTICE("You unload \the [unloaded_flare] from [src]."))
+			user.put_in_hands(unloaded_flare)
+		update_icon()

--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -1079,6 +1079,8 @@ obj/item/weapon/gun/launcher/grenade/update_icon()
 		to_chat(user, SPAN_WARNING("That's not a flare!"))
 		
 /obj/item/weapon/gun/flare/unload(mob/user)
+	if(flags_gun_features & GUN_BURST_FIRING)
+		return
 	unload_flare(user)
 	
 /obj/item/weapon/gun/flare/proc/unload_flare(mob/user)
@@ -1089,6 +1091,6 @@ obj/item/weapon/gun/launcher/grenade/update_icon()
 		playsound(user, reload_sound, 25, TRUE)
 		current_mag.current_rounds--
 		if(user)
-			to_chat(user, SPAN_NOTICE("You unload \the [unloaded_flare] from [src]."))
+			to_chat(user, SPAN_NOTICE("You unload \the [unloaded_flare] from \the [src]."))
 			user.put_in_hands(unloaded_flare)
 		update_icon()

--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -1085,13 +1085,7 @@ obj/item/weapon/gun/launcher/grenade/update_icon()
 	if(!current_mag)
 		return
 	if(current_mag.current_rounds)
-		var/obj/item/device/flashlight/flare/unloaded_flare
-		if(istype(ammo, /datum/ammo/flare/signal))
-			var/obj/item/device/flashlight/flare/signal/temp_flare = new(get_turf(src))
-			unloaded_flare = temp_flare
-		else
-			var/obj/item/device/flashlight/flare/temp_flare = new(get_turf(src))
-			unloaded_flare = temp_flare
+		var/obj/item/device/flashlight/flare/unloaded_flare = new ammo.handful_type(get_turf(src))
 		playsound(user, reload_sound, 25, TRUE)
 		current_mag.current_rounds--
 		if(user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Flare guns can be unloaded now.

## Why It's Good For The Game

Being unable to unload the flare gun is an oversight.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Morrow
fix: Flare guns can be unloaded now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
