### PR TITLE
YATGUIINF: Yet another TGUI input number fix

### DIFF
--- a/code/modules/tgui/tgui_number_input.dm
+++ b/code/modules/tgui/tgui_number_input.dm
@@ -31,7 +31,7 @@
 		qdel(number_input)
 
 ///A clone of tgui_input_number that defaults to accepting negative inputs too.
-/proc/tgui_input_real_number(mob/user, message, title = "Number Input", default = 0, max_value = 10000, min_value = -10000, timeout = 0)
+/proc/tgui_input_real_number(mob/user, message, title = "Number Input", default = 0, max_value = 16777216, min_value = -16777216, timeout = 0)
 	return tgui_input_number(user, message, title, default, max_value, min_value, timeout)
 /**
  * Creates an asynchronous TGUI number input window with an associated callback.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
When editing vars, they can actually be over or need to be set to values over 10,000. This PR changes the default limits for tgui_input_real_number to be the Byond limits. See https://www.byond.com/docs/ref/#/{notes}/numbers
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
CRASH("Default value is greater than max value.") is bad.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Drathek
fix: Increased TGUI input real number default values to integer limits to fix editing vars.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
