### PR TITLE
sensortowers can now be broken by xenos

### DIFF
--- a/code/modules/desert_dam/motion_sensor/sensortower.dm
+++ b/code/modules/desert_dam/motion_sensor/sensortower.dm
@@ -1,19 +1,23 @@
 //sensor tower for deser dam. It is there to add the xeno's to the tactical map for marines.
 
+#define SENSORTOWER_BUILDSTATE_WORKING		0
+#define SENSORTOWER_BUILDSTATE_BLOWTORCH	1
+#define SENSORTOWER_BUILDSTATE_WIRECUTTERS	2
+#define SENSORTOWER_BUILDSTATE_WRENCH		3
 
 /obj/structure/machinery/sensortower
 	name = "\improper experimental sensor tower"
 	icon = 'icons/obj/structures/machinery/motion_sensor_v2.dmi'
 	icon_state = "sensor_broken"
 	desc = "A tower with a lot of delicate sensors made to track weather conditions. This one has been adjusted to track biosignatures. This one is heavily damaged. Use a blowtorch, wirecutters, then a wrench to repair it."
-	anchored = 1
-	density = 1
+	anchored = TRUE
+	density = TRUE
 	unslashable = TRUE
 	unacidable = TRUE	  //NOPE.jpg
-	use_power = 1
+	use_power = TRUE
 	idle_power_usage = 1000
-	var/buildstate = 1 //What state of building it are we on, 0-3, 1 is "broken", the default
-	var/is_on = 0  //Is this damn thing on or what?
+	var/buildstate = SENSORTOWER_BUILDSTATE_BLOWTORCH //What state of building it are we on, 0-3, 1 is "broken", the default
+	var/is_on = FALSE  //Is this damn thing on or what?
 	var/fail_rate = 15 //% chance of failure each fail_tick check
 	var/fail_check_ticks = 50 //Check for failure every this many ticks
 	//The sensor tower fails more often since it is experimental.
@@ -28,144 +32,179 @@
 	else if (!buildstate && !is_on)
 		desc = "A tower with a lot of delicate sensors made to track weather conditions. This one has been adjusted to track biosignatures. It looks like it is offline."
 		icon_state = "sensor_off"
-	else if(buildstate == 1)
+	else if(buildstate == SENSORTOWER_BUILDSTATE_BLOWTORCH)
 		desc = "A tower with a lot of delicate sensors made to track weather conditions. This one has been adjusted to track biosignatures. This one is heavily damaged. Use a blowtorch, wirecutters, then a wrench to repair it."
 		icon_state = "sensor_broken"
-	else if(buildstate == 2)
+	else if(buildstate == SENSORTOWER_BUILDSTATE_WIRECUTTERS)
 		desc = "A tower with a lot of delicate sensors made to track weather conditions. This one has been adjusted to track biosignatures. This one is heavily damaged. Use wirecutters, then a wrench to repair it."
 		icon_state = "sensor_broken"
-	else if(buildstate == 3)
+	else if(buildstate == SENSORTOWER_BUILDSTATE_WRENCH)
 		desc = "A tower with a lot of delicate sensors made to track weather conditions. This one has been adjusted to track biosignatures. This one is heavily damaged. Use a wrench to repair it."
 		icon_state = "sensor_broken"
 
 /obj/structure/machinery/sensortower/process()
 	if(!is_on || buildstate || !anchored) //Default logic checking
-		return 0
+		return FALSE
 	if(inoperable())
-		return 0
+		return FALSE
 	checkfailure()
 
 /obj/structure/machinery/sensortower/proc/checkfailure()
 	cur_tick++
 	if(cur_tick < fail_check_ticks) //Nope, not time for it yet
-		return 0
+		return FALSE
 	else if(cur_tick > fail_check_ticks) //Went past with no fail, reset the timer
 		cur_tick = 0
-		return 0
+		return FALSE
 	if(rand(1,100) < fail_rate) //Oh snap, we failed! Shut it down!
-		if(rand(0,3) == 0)
-			visible_message("[icon2html(src, viewers(src))] [SPAN_NOTICE("<b>[src]</b> beeps wildly and a fuse blows! Use wirecutters, then a wrench to repair it.")]")
-			buildstate = 2
+		if(prob(25))
+			visible_message("[icon2html(src, viewers(src))] [SPAN_NOTICE("<b>\The [src]</b> beeps wildly and a fuse blows! Use wirecutters, then a wrench to repair it.")]")
+			buildstate = SENSORTOWER_BUILDSTATE_WIRECUTTERS
 		else
-			visible_message("[icon2html(src, viewers(src))] [SPAN_NOTICE("<b>[src]</b> beeps wildly and sprays random pieces everywhere! Use a wrench to repair it.")]")
-			buildstate = 3
-		is_on = 0
+			visible_message("[icon2html(src, viewers(src))] [SPAN_NOTICE("<b>\The [src]</b> beeps wildly and sprays random pieces everywhere! Use a wrench to repair it.")]")
+			buildstate = SENSORTOWER_BUILDSTATE_WRENCH
+		is_on = FALSE
 		update_icon()
 		cur_tick = 0
 		stop_processing()
-		return 1
-	return 0
+		return TRUE
+	return FALSE
 
 /obj/structure/machinery/sensortower/attack_hand(mob/user as mob)
-	if(!anchored) return 0 //Shouldn't actually be possible
-	if(user.is_mob_incapacitated()) return 0
+	if(!anchored) return FALSE //Shouldn't actually be possible
+	if(user.is_mob_incapacitated()) return FALSE
 	if(!ishuman(user))
 		to_chat(user, SPAN_DANGER("You have no idea how to use that.")) //No xenos or mankeys
-		return 0
+		return FALSE
 
 	add_fingerprint(user)
 
 	if(!skillcheck(user, SKILL_ENGINEER, SKILL_ENGINEER_ENGI))
 		to_chat(user, SPAN_WARNING("You have no clue how this thing works..."))
-		return 0
+		return FALSE
 
-	if(buildstate == 1)
+	if(buildstate == SENSORTOWER_BUILDSTATE_BLOWTORCH)
 		to_chat(usr, SPAN_INFO("Use a blowtorch, then wirecutters, then wrench to repair it."))
-		return 0
-	else if (buildstate == 2)
-		to_chat(usr, SPAN_INFO("Use a wirecutters, then wrench to repair it."))
-		return 0
-	else if (buildstate == 3)
+		return FALSE
+	else if (buildstate == SENSORTOWER_BUILDSTATE_WIRECUTTERS)
+		to_chat(usr, SPAN_INFO("Use some wirecutters, then wrench to repair it."))
+		return FALSE
+	else if (buildstate == SENSORTOWER_BUILDSTATE_WRENCH)
 		to_chat(usr, SPAN_INFO("Use a wrench to repair it."))
-		return 0
+		return FALSE
 	if(is_on)
-		visible_message("[icon2html(src, viewers(src))] [SPAN_WARNING("<b>[src]</b> goes dark as [usr] shuts the power off.")]")
-		is_on = 0
+		visible_message("[icon2html(src, viewers(src))] [SPAN_WARNING("<b>\The [src]</b> goes dark as [usr] shuts the power off.")]")
+		is_on = FALSE
 		cur_tick = 0
 		update_icon()
 		stop_processing()
-		return 1
-	visible_message("[icon2html(src, viewers(src))] [SPAN_WARNING("<b>[src]</b> lights up as [usr] turns the power on.")]")
-	is_on = 1
+		return TRUE
+	visible_message("[icon2html(src, viewers(src))] [SPAN_WARNING("<b>\The [src]</b> lights up as [usr] turns the power on.")]")
+	is_on = TRUE
 	cur_tick = 0
 	update_icon()
 	start_processing()
-	return 1
+	return TRUE
 
 /obj/structure/machinery/sensortower/attackby(var/obj/item/O as obj, var/mob/user as mob)
 	if(iswelder(O))
 		if(!HAS_TRAIT(O, TRAIT_TOOL_BLOWTORCH))
 			to_chat(user, SPAN_WARNING("You need a stronger blowtorch!"))
 			return
-		if(buildstate == 1 && !is_on)
+		if(buildstate == SENSORTOWER_BUILDSTATE_BLOWTORCH && !is_on)
 			if(!skillcheck(user, SKILL_ENGINEER, SKILL_ENGINEER_ENGI))
 				to_chat(user, SPAN_WARNING("You have no clue how to repair this thing."))
-				return 0
+				return FALSE
 			var/obj/item/tool/weldingtool/WT = O
 			if(WT.remove_fuel(1, user))
 
 				playsound(loc, 'sound/items/weldingtool_weld.ogg', 25)
-				user.visible_message(SPAN_NOTICE("[user] starts welding [src]'s internal damage."),
-				SPAN_NOTICE("You start welding [src]'s internal damage."))
+				user.visible_message(SPAN_NOTICE("[user] starts welding \the [src]'s internal damage."),
+				SPAN_NOTICE("You start welding \the [src]'s internal damage."))
 				if(do_after(user, 200 * user.get_skill_duration_multiplier(SKILL_ENGINEER), INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD))
-					if(buildstate != 1 || is_on || !WT.isOn())
+					if(buildstate != SENSORTOWER_BUILDSTATE_BLOWTORCH || is_on || !WT.isOn())
 						return FALSE
 					playsound(loc, 'sound/items/Welder2.ogg', 25, 1)
-					buildstate = 2
-					user.visible_message(SPAN_NOTICE("[user] welds [src]'s internal damage."),
-					SPAN_NOTICE("You weld [src]'s internal damage."))
+					buildstate = SENSORTOWER_BUILDSTATE_WIRECUTTERS
+					user.visible_message(SPAN_NOTICE("[user] welds \the [src]'s internal damage."),
+					SPAN_NOTICE("You weld \the [src]'s internal damage."))
 					update_icon()
 					return TRUE
 			else
 				to_chat(user, SPAN_WARNING("You need more welding fuel to complete this task."))
 				return
+
 	else if(HAS_TRAIT(O, TRAIT_TOOL_WIRECUTTERS))
-		if(buildstate == 2 && !is_on)
+		if(buildstate == SENSORTOWER_BUILDSTATE_WIRECUTTERS && !is_on)
 			if(!skillcheck(user, SKILL_ENGINEER, SKILL_ENGINEER_ENGI))
 				to_chat(user, SPAN_WARNING("You have no clue how to repair this thing."))
-				return 0
+				return FALSE
 			playsound(loc, 'sound/items/Wirecutter.ogg', 25, 1)
-			user.visible_message(SPAN_NOTICE("[user] starts securing [src]'s wiring."),
-			SPAN_NOTICE("You start securing [src]'s wiring."))
+			user.visible_message(SPAN_NOTICE("[user] starts securing \the [src]'s wiring."),
+			SPAN_NOTICE("You start securing \the [src]'s wiring."))
 			if(do_after(user, 120 * user.get_skill_duration_multiplier(SKILL_ENGINEER), INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD, numticks = 12))
-				if(buildstate != 2 || is_on)
+				if(buildstate != SENSORTOWER_BUILDSTATE_WIRECUTTERS || is_on)
 					return FALSE
 				playsound(loc, 'sound/items/Wirecutter.ogg', 25, 1)
-				buildstate = 3
-				user.visible_message(SPAN_NOTICE("[user] secures [src]'s wiring."),
-				SPAN_NOTICE("You secure [src]'s wiring."))
+				buildstate = SENSORTOWER_BUILDSTATE_WRENCH
+				user.visible_message(SPAN_NOTICE("[user] secures \the [src]'s wiring."),
+				SPAN_NOTICE("You secure \the [src]'s wiring."))
 				update_icon()
 				return TRUE
 	else if(HAS_TRAIT(O, TRAIT_TOOL_WRENCH))
-		if(buildstate == 3 && !is_on)
+		if(buildstate == SENSORTOWER_BUILDSTATE_WRENCH && !is_on)
 			if(!skillcheck(user, SKILL_ENGINEER, SKILL_ENGINEER_ENGI))
 				to_chat(user, SPAN_WARNING("You have no clue how to repair this thing."))
-				return 0
+				return FALSE
 			playsound(loc, 'sound/items/Ratchet.ogg', 25, 1)
-			user.visible_message(SPAN_NOTICE("[user] starts repairing [src]'s tubing and plating."),
-			SPAN_NOTICE("You start repairing [src]'s tubing and plating."))
+			user.visible_message(SPAN_NOTICE("[user] starts repairing \the [src]'s tubing and plating."),
+			SPAN_NOTICE("You start repairing \the [src]'s tubing and plating."))
 			if(do_after(user, 150 * user.get_skill_duration_multiplier(SKILL_ENGINEER), INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD))
-				if(buildstate != 3 || is_on)
+				if(buildstate != SENSORTOWER_BUILDSTATE_WRENCH || is_on)
 					return FALSE
 				playsound(loc, 'sound/items/Ratchet.ogg', 25, 1)
-				buildstate = 0
-				user.visible_message(SPAN_NOTICE("[user] repairs [src]'s tubing and plating."),
-				SPAN_NOTICE("You repair [src]'s tubing and plating."))
+				buildstate = SENSORTOWER_BUILDSTATE_WORKING
+				user.visible_message(SPAN_NOTICE("[user] repairs \the [src]'s tubing and plating."),
+				SPAN_NOTICE("You repair \the [src]'s tubing and plating."))
 				update_icon()
 				return TRUE
 	else
 		return ..() //Deal with everything else, like hitting with stuff
 
+/obj/structure/machinery/sensortower/attack_alien(mob/living/carbon/Xenomorph/M)
+	if(buildstate == SENSORTOWER_BUILDSTATE_BLOWTORCH)
+		to_chat(M, SPAN_WARNING("You stare at \the [src] cluelessly."))
+		return XENO_NO_DELAY_ACTION
+
+	if(M.action_busy)
+		return XENO_NO_DELAY_ACTION
+
+	var/turf/cur_loc = M.loc
+
+	playsound(loc, 'sound/effects/metal_creaking.ogg', 25, TRUE)
+	M.visible_message(SPAN_DANGER("[M] starts wrenching apart \the [src]'s panels and reaching inside it!"), \
+	SPAN_DANGER("You start wrenching apart \the [src]'s panels and reaching inside it!"), null, 5, CHAT_TYPE_XENO_COMBAT)
+	xeno_attack_delay(M)
+	if(do_after(M, 40, INTERRUPT_ALL, BUSY_ICON_HOSTILE))
+		if(M.loc != cur_loc)
+			return XENO_NO_DELAY_ACTION //Make sure we're still there
+		if(M.lying)
+			return XENO_NO_DELAY_ACTION
+		if(buildstate == SENSORTOWER_BUILDSTATE_BLOWTORCH)
+			return XENO_NO_DELAY_ACTION
+		buildstate = SENSORTOWER_BUILDSTATE_BLOWTORCH
+		if(is_on)
+			is_on = FALSE
+			cur_tick = 0
+			stop_processing()
+		update_icon()
+		M.visible_message(SPAN_DANGER("[M] pulls apart \the [src]'s panels and breaks all its internal wiring and tubing!"), \
+		SPAN_DANGER("You pull apart \the [src]'s panels and break all its internal wiring and tubing!"), null, 5, CHAT_TYPE_XENO_COMBAT)
+		playsound(loc, 'sound/effects/meteorimpact.ogg', 25, 1)
+	else
+		M.visible_message(SPAN_DANGER("[M] stops destroying \the [src]'s internal machinery!"), \
+		SPAN_DANGER("You stop destroying \the [src]'s internal machinery!"), null, 5, CHAT_TYPE_XENO_COMBAT)
+	return XENO_NO_DELAY_ACTION
 
 /obj/structure/machinery/sensortower/stop_processing()
 	SSticker.toweractive = FALSE
@@ -178,3 +217,8 @@
 /obj/structure/machinery/sensortower/power_change()
 	..()
 	update_icon()
+
+#undef SENSORTOWER_BUILDSTATE_WORKING
+#undef SENSORTOWER_BUILDSTATE_BLOWTORCH
+#undef SENSORTOWER_BUILDSTATE_WIRECUTTERS
+#undef SENSORTOWER_BUILDSTATE_WRENCH


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

xenos can now break the trijent/kutjevo sensortower

plus code cleanup

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

it is not good to rely on RNG for these to break if they are in xeno territory

very bullshit that xenos can retake the ground they are on but not break them

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: xenos can now break the trijent/kutjevo sensor tower, it can still be repaired after being broken
code: improved the sensor tower's code for readability
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
