### PR TITLE
Airlock Shock fixes and consistency

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -508,7 +508,7 @@
 /obj/structure/machinery/door/airlock/attack_alien(mob/living/carbon/Xenomorph/M)
 	var/turf/cur_loc = M.loc
 	if(isElectrified())
-		if(shock(M, 70))
+		if(shock(M, 100))
 			return XENO_NO_DELAY_ACTION
 
 	if(!density)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Alright so I investigated the shocking issue.

First, areas without real power sources that still have pseudo power would not shock people. This fixes that.

Second, there is a probability attached to whether mobs get shocked when messing with shocked stuff. Xenos had a 70% chance to get shocked when attempting to open shocked airlocks but 100% chance when bumping into the door to open it. I've made this a consistent 100% across the board for sanity's sake.

## Why It's Good For The Game

Bugs bad, consistency good

## Changelog

:cl: Morrow
fix: Shocked doors without a real power source will now shock correctly.
fix: Xeno shock chances made consistent across ways to open airlocks.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
