### PR TITLE
Screwdrivers don't open airlocks again

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -602,6 +602,7 @@ GLOBAL_LIST_INIT(airlock_wire_descriptions, list(
 		panel_open = !panel_open
 		to_chat(user, SPAN_NOTICE("You [panel_open ? "open" : "close"] [src]'s panel."))
 		update_icon()
+		return
 
 	else if(HAS_TRAIT(C, TRAIT_TOOL_WIRECUTTERS))
 		return attack_hand(user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Old functionality returned.

## Why It's Good For The Game

I believe this change was unintentional

## Changelog

:cl: Morrow
fix: Screwdrivers don't open airlocks again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
