### PR TITLE
Charger Crusher Balance/Fixes

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/crusher/crusher_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/crusher/crusher_abilities.dm
@@ -180,7 +180,6 @@
 			Xeno.visible_message(SPAN_DANGER("[Xeno] runs [Mob] over!"),
 				SPAN_DANGER("You run [Mob] over!")
 			)
-			var/list/ram_dirs = get_perpen_dir(Xeno.dir)
 			var/ram_dir = pick(get_perpen_dir(Xeno.dir))
 			var/dist = 1
 			if(momentum == max_momentum)

--- a/code/modules/mob/living/carbon/xenomorph/abilities/crusher/crusher_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/crusher/crusher_abilities.dm
@@ -181,7 +181,7 @@
 				SPAN_DANGER("You run [Mob] over!")
 			)
 			var/list/ram_dirs = get_perpen_dir(Xeno.dir)
-			var/ram_dir = pick(ram_dirs)
+			var/ram_dir = pick(get_perpen_dir(Xeno.dir))
 			var/dist = 1
 			if(momentum == max_momentum)
 				dist = momentum * 0.25

--- a/code/modules/mob/living/carbon/xenomorph/abilities/crusher/crusher_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/crusher/crusher_abilities.dm
@@ -72,18 +72,20 @@
 	var/shield_amount = 200
 
 /datum/action/xeno_action/activable/fling/charger
-	name = "Ram"
+	name = "Headbutt"
 	action_icon_state = "ram"
-	ability_name = "Ram"
+	ability_name = "Headbutt"
 	macro_path = /datum/action/xeno_action/verb/verb_fling
 	action_type = XENO_ACTION_CLICK
 	ability_primacy = XENO_PRIMARY_ACTION_4
 	xeno_cooldown = 10 SECONDS
-
+	plasma_cost = 10
 	// Configurables
 	fling_distance = 3
-	stun_power = 0
-	weaken_power = 1
+	stun_power = FALSE
+	weaken_power = FALSE
+	slowdown = 8
+
 
 /datum/action/xeno_action/onclick/charger_charge
 	name = "Toggle Charging"
@@ -178,8 +180,16 @@
 			Xeno.visible_message(SPAN_DANGER("[Xeno] runs [Mob] over!"),
 				SPAN_DANGER("You run [Mob] over!")
 			)
-
-			Mob.apply_damage(momentum * 10)
+			var/list/ram_dirs = get_perpen_dir(Xeno.dir)
+			var/ram_dir = pick(ram_dirs)
+			var/dist = 1
+			if(momentum == max_momentum)
+				dist = momentum * 0.25
+			step(Mob, ram_dir, dist)
+			Mob.take_overall_armored_damage(momentum * 6)
+			INVOKE_ASYNC(Mob, /mob/living/carbon/human.proc/emote,"pain")
+			//Mob.emote("pain")
+			shake_camera(Mob, 7,3)
 			animation_flash_color(Mob)
 
 	Xeno.recalculate_speed()

--- a/code/modules/mob/living/carbon/xenomorph/abilities/crusher/crusher_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/crusher/crusher_abilities.dm
@@ -82,8 +82,8 @@
 	plasma_cost = 10
 	// Configurables
 	fling_distance = 3
-	stun_power = FALSE
-	weaken_power = FALSE
+	stun_power = 0
+	weaken_power = 0
 	slowdown = 8
 
 

--- a/code/modules/mob/living/carbon/xenomorph/abilities/crusher/crusher_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/crusher/crusher_abilities.dm
@@ -188,7 +188,6 @@
 			step(Mob, ram_dir, dist)
 			Mob.take_overall_armored_damage(momentum * 6)
 			INVOKE_ASYNC(Mob, /mob/living/carbon/human.proc/emote,"pain")
-			//Mob.emote("pain")
 			shake_camera(Mob, 7,3)
 			animation_flash_color(Mob)
 

--- a/code/modules/mob/living/carbon/xenomorph/abilities/crusher/crusher_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/crusher/crusher_powers.dm
@@ -132,7 +132,7 @@
 
 		new effect_type_base(Human, Xeno, , , get_xeno_stun_duration(Human, effect_duration))
 		to_chat(Human, SPAN_XENOHIGHDANGER("You are BRUTALLY crushed and stomped on by [Xeno]!!!"))
-
+		shake_camera(Human, 10, 2)
 		if(Human.mob_size < MOB_SIZE_BIG)
 			Human.KnockDown(get_xeno_stun_duration(Human, 0.2))
 
@@ -145,7 +145,8 @@
 		if (Human.stat == DEAD || Xeno.can_not_harm(Human))
 			continue
 		if(Human.client)
-			shake_camera(Human, 2, 2)
+			shake_camera(Human, 10, 2)
+			playsound(Human,"bone_break",50,TRUE)
 		if(Targeted)
 			to_chat(Human, SPAN_XENOHIGHDANGER("You watch as [Targeted] gets crushed by [Xeno]!"))
 		to_chat(Human, SPAN_XENOHIGHDANGER("You are shaken as [Xeno] quakes the earth!"))

--- a/code/modules/mob/living/carbon/xenomorph/abilities/crusher/crusher_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/crusher/crusher_powers.dm
@@ -146,7 +146,6 @@
 			continue
 		if(Human.client)
 			shake_camera(Human, 10, 2)
-			playsound(Human,"bone_break",50,TRUE)
 		if(Targeted)
 			to_chat(Human, SPAN_XENOHIGHDANGER("You watch as [Targeted] gets crushed by [Xeno]!"))
 		to_chat(Human, SPAN_XENOHIGHDANGER("You are shaken as [Xeno] quakes the earth!"))

--- a/code/modules/mob/living/carbon/xenomorph/abilities/warrior/warrior_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/warrior/warrior_abilities.dm
@@ -26,6 +26,7 @@
 	var/fling_distance = 4
 	var/stun_power = 1
 	var/weaken_power = 1
+	var/slowdown = FALSE
 
 
 // Warrior Lunge

--- a/code/modules/mob/living/carbon/xenomorph/abilities/warrior/warrior_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/warrior/warrior_powers.dm
@@ -96,7 +96,11 @@
 	playsound(H,'sound/weapons/alien_claw_block.ogg', 75, 1)
 	if(stun_power)
 		H.apply_effect(get_xeno_stun_duration(H, stun_power), STUN)
-	H.apply_effect(weaken_power, WEAKEN)
+	if(weaken_power)
+		H.apply_effect(weaken_power, WEAKEN)
+	if(slowdown)
+		if(H.slowed < slowdown)
+			H.Slow(slowdown)
 	H.last_damage_data = create_cause_data(initial(X.caste_type), X)
 	shake_camera(H, 2, 1)
 

--- a/code/modules/mob/living/carbon/xenomorph/mutators/strains/crusher/charger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/mutators/strains/crusher/charger.dm
@@ -44,8 +44,9 @@
 	C.mutation_type = CRUSHER_CHARGER
 	C.small_explosives_stun = FALSE
 	C.health_modifier += XENO_HEALTH_MOD_LARGE
-	C.speed_modifier += XENO_SPEED_FASTMOD_TIER_3
+	C.speed_modifier +=	XENO_SPEED_FASTMOD_TIER_3
 	C.armor_modifier -= XENO_ARMOR_MOD_SMALL
+	C.damage_modifier -= XENO_DAMAGE_MOD_SMALL
 	C.ignore_aura = "frenzy" // no funny crushers going 7 morbillion kilometers per second
 	C.phero_modifier = -C.caste.aura_strength
 	C.recalculate_pheromones()
@@ -342,7 +343,7 @@
 	var/momentum_mult = 5
 	if(CCA.momentum == CCA.max_momentum)
 		momentum_mult = 8
-	take_overall_armored_damage(CCA.momentum * momentum_mult, ARMOR_MELEE, BRUTE, 50, 13) // Giving AP because this spreads damage out and then applies armor to them
+	take_overall_armored_damage(CCA.momentum * momentum_mult, ARMOR_MELEE, BRUTE, 60, 13) // Giving AP because this spreads damage out and then applies armor to them
 	apply_armoured_damage(CCA.momentum * momentum_mult/4,ARMOR_MELEE, BRUTE,"chest")
 	X.visible_message(
 		SPAN_DANGER("[X] rams \the [src]!"),
@@ -377,6 +378,9 @@
 			apply_damage(CCA.momentum * 10, BRUTE) // half damage to avoid sillyness
 		if(anchored) //Ovipositor queen can't be pushed
 			CCA.stop_momentum()
+			return
+		if(isXenoQueen(src) || IS_XENO_LEADER(src) ||  isXenoBoiler(src)) // boilers because they have long c/d and warmups, get griefed hard if stunned
+			CCA.stop_momentum() // antigrief
 			return
 		if(HAS_TRAIT(src, TRAIT_CHARGING))
 			KnockDown(2)
@@ -432,24 +436,6 @@
 	step(src, ram_dir, CCA.momentum * 0.5)
 	CCA.lose_momentum(CCA_MOMENTUM_LOSS_MIN)
 	return XENO_CHARGE_TRY_MOVE
-
-/*
-notes
-
-new collision procs for:
-rollerbeds,	[d]
-fences,	[d]
-, computers [d] (handled with /obj/machinery )
-, filecabinets, [d]
-m56 & m2c 	[d] ( find better solution )
-
-buff health a bit [d]
-
-change the proc pushing xenos to something that pushes them in a random direction rather than away [d]
-
-bell immunity [d]
-
-*/
 
 // Walls
 
@@ -516,7 +502,6 @@ bell immunity [d]
 		playsound(src, "sound/effects/metal_crash.ogg", 25, TRUE)
 		if(istype(src,/obj/structure/machinery/m56d_hmg/auto)) // we don't want to charge it to the point of downgrading it (:
 			var/obj/item/device/m2c_gun/HMG = new(src.loc)
-			HMG = new(src.loc)
 			HMG.health = src.health
 			HMG.set_name_label(name_label)
 			HMG.rounds = src.rounds //Inherent the amount of ammo we had.
@@ -524,7 +509,6 @@ bell immunity [d]
 			qdel(src)
 		else
 			var/obj/item/device/m56d_gun/HMG = new(src.loc) // note: find a better way than a copy pasted else statement
-			HMG = new(src.loc)
 			HMG.health = src.health
 			HMG.set_name_label(name_label)
 			HMG.rounds = src.rounds //Inherent the amount of ammo we had.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
This PR aims to fix a multitude of bugs and balance issues that have surfaced since the charger's merging.

Issue: Too much damage
- Nerfed slash damage from 40 to 30. This also nerfs stomp damage as it is slash damage + 15
- Nerfed runover damage from momentum * 10 to momentum * 6.
- Runover damage now takes armor into consideration and uses overall damage procs
- Charge now spreads to more limbs, 50% spread chance to 60%

Ram reworked
- Ram does not damage nor stun anymore, instead it knocks mobs back and slows them down for 4 seconds.
- Ram has been renamed to "Headbutt" to avoid confusion

Issue: Charger griefs the hive by charging
- Fixed by making charger immediately stop charging if they hit leaders/queen/boiler. They aren't stunned and it is now just as bad as normal body block instead of mowing down friendly xenos + queen.
- Boiler because they have long warmups/cd and can get griefed hard


Bugfixes/misc
- Fixes stomp not screen shaking properly.
- Fixes #990 
- Further cleans up code



<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: totalepicness
balance: Reworked charger's RAM, it is now renamed to "headbutt" and slows down instead of stuns.
balance: Nerfed chargers slash damage and stomp damage 40 > 30.
fix: Fixed chargers duplicating machineguns.
fix: Fixed ram ignoring armor.
fix: Fixed charger stomp screenshake not working
fix: Charger will now stop charging to Queens,Leaders, and Boilers. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
