### PR TITLE
Firing flares into the air and signal flare QoL

### DIFF
--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -321,6 +321,9 @@
 		var/mob/living/carbon/U = user
 		if(istype(U) && !U.throw_mode)
 			U.toggle_throw_mode(THROW_MODE_NORMAL)
+			
+/obj/item/device/flashlight/flare/proc/activate_signal(mob/living/carbon/human/user)
+	return
 
 /obj/item/device/flashlight/flare/on/Initialize()
 	. = ..()
@@ -433,7 +436,8 @@
 		faction = user.faction
 		addtimer(CALLBACK(src, .proc/activate_signal, user), 5 SECONDS)
 
-/obj/item/device/flashlight/flare/signal/proc/activate_signal(mob/living/carbon/human/user)
+/obj/item/device/flashlight/flare/signal/activate_signal(mob/living/carbon/human/user)
+	..()
 	if(faction && cas_groups[faction])
 		signal = new(src)
 		signal.target_id = ++cas_tracking_id_increment
@@ -446,6 +450,7 @@
 			visible_message(SPAN_DANGER("[src]'s flame reaches full strength. It's fully active now."), null, 5)
 		msg_admin_niche("Flare target [src] has been activated by [key_name(user, 1)] at ([x], [y], [z]). (<A HREF='?_src_=admin_holder;[HrefToken(forceGlobal = TRUE)];adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP LOC</a>)")
 		log_game("Flare target [src] has been activated by [key_name(user, 1)] at ([x], [y], [z]).")
+		return TRUE
 
 /obj/item/device/flashlight/flare/signal/attack_hand(mob/user)
 	if (!user) return

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -2998,33 +2998,38 @@
 	))
 
 /datum/ammo/flare/on_hit_mob(mob/M,obj/item/projectile/P)
-	drop_flare(get_turf(P), P.firer)
+	drop_flare(get_turf(P), P, P.firer)
 
 /datum/ammo/flare/on_hit_obj(obj/O,obj/item/projectile/P)
-	drop_flare(get_turf(P), P.firer)
+	drop_flare(get_turf(P), P, P.firer)
 
 /datum/ammo/flare/on_hit_turf(turf/T, obj/item/projectile/P)
 	if(T.density && isturf(P.loc))
-		drop_flare(P.loc, P.firer)
+		drop_flare(P.loc, P, P.firer)
 	else
-		drop_flare(T, P.firer)
+		drop_flare(T, P, P.firer)
 
 /datum/ammo/flare/do_at_max_range(obj/item/projectile/P, var/mob/firer)
-	drop_flare(get_turf(P), P.firer)
+	drop_flare(get_turf(P), P, P.firer)
 
-/datum/ammo/flare/proc/drop_flare(var/turf/T, var/mob/firer)
+/datum/ammo/flare/proc/drop_flare(var/turf/T, obj/item/projectile/fired_projectile, var/mob/firer)
 	var/obj/item/device/flashlight/flare/G = new flare_type(T)
 	G.visible_message(SPAN_WARNING("\A [G] bursts into brilliant light nearby!"))
 	return G
+
 /datum/ammo/flare/signal
 	name = "signal flare"
 	icon_state = "flare_signal"
 	flare_type = /obj/item/device/flashlight/flare/signal/gun
 	handful_type = /obj/item/device/flashlight/flare/signal
 
-/datum/ammo/flare/signal/drop_flare(turf/T, mob/firer)
-	var/obj/item/device/flashlight/flare/signal/gun/G = ..()
-	G.activate_signal(firer)
+/datum/ammo/flare/signal/drop_flare(turf/T, obj/item/projectile/fired_projectile, mob/firer)
+	var/obj/item/device/flashlight/flare/signal/gun/signal_flare = ..()
+	signal_flare.activate_signal(firer)
+	if(istype(fired_projectile.shot_from, /obj/item/weapon/gun/flare))
+		var/obj/item/weapon/gun/flare/flare_gun_fired_from = fired_projectile.shot_from
+		flare_gun_fired_from.last_signal_flare_name = signal_flare.name
+
 /datum/ammo/flare/starshell
 	name = "starshell ash"
 	icon_state = "starshell_bullet"

--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -1279,6 +1279,7 @@ obj/item/weapon/gun/launcher/grenade/update_icon()
 	to_chat(user, SPAN_NOTICE("You fire \the [fired_flare] into the air!"))
 	fired_flare.visible_message(SPAN_WARNING("\A [fired_flare] bursts into brilliant light in the sky!"))
 	fired_flare.invisibility = INVISIBILITY_MAXIMUM
+	fired_flare.mouse_opacity = FALSE
 	playsound(user.loc, fire_sound, 50, 1)
 	
 	if(fired_flare.activate_signal(user))

--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -1249,7 +1249,7 @@ obj/item/weapon/gun/launcher/grenade/update_icon()
 		update_icon()
 
 /obj/item/weapon/gun/flare/unique_action(mob/user)
-	if(!user || !istype(user.loc, /turf/) || !current_mag || !current_mag.current_rounds)
+	if(!user || !isturf(user.loc) || !current_mag || !current_mag.current_rounds)
 		return
 		
 	var/turf/flare_turf = user.loc
@@ -1258,11 +1258,11 @@ obj/item/weapon/gun/launcher/grenade/update_icon()
 	if(flare_area.ceiling > CEILING_GLASS)
 		to_chat(user, SPAN_NOTICE("The roof above you is too dense."))
 		return
-	
-	if(!do_after(user, 1 SECONDS, INTERRUPT_ALL, BUSY_ICON_GENERIC))
+		
+	if(user.action_busy)
 		return
 	
-	if(!current_mag.current_rounds) //they fired! Nice try!
+	if(!do_after(user, 1 SECONDS, INTERRUPT_ALL, BUSY_ICON_GENERIC))
 		return
 	
 	current_mag.current_rounds--
@@ -1270,7 +1270,7 @@ obj/item/weapon/gun/launcher/grenade/update_icon()
 	flare_turf.ceiling_debris()
 		
 	if(!istype(ammo, /datum/ammo/flare))
-		to_chat(user, SPAN_NOTICE("The [src] jams as it is somehow loaded with incorrect ammo!"))
+		to_chat(user, SPAN_NOTICE("\The [src] jams as it is somehow loaded with incorrect ammo!"))
 		return
 		
 	var/datum/ammo/flare/explicit_ammo = ammo
@@ -1281,10 +1281,8 @@ obj/item/weapon/gun/launcher/grenade/update_icon()
 	fired_flare.invisibility = INVISIBILITY_MAXIMUM
 	playsound(user.loc, fire_sound, 50, 1)
 	
-	if(istype(fired_flare, /obj/item/device/flashlight/flare/signal))
-		var/obj/item/device/flashlight/flare/signal/signal_flare = fired_flare
-		signal_flare.activate_signal(user)
-		last_signal_flare_name = signal_flare.name
+	if(fired_flare.activate_signal(user))
+		last_signal_flare_name = fired_flare.name
 	
 	update_icon()
 	

--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -1259,6 +1259,10 @@ obj/item/weapon/gun/launcher/grenade/update_icon()
 		to_chat(user, SPAN_NOTICE("The roof above you is too dense."))
 		return
 		
+	if(!istype(ammo, /datum/ammo/flare))
+		to_chat(user, SPAN_NOTICE("\The [src] jams as it is somehow loaded with incorrect ammo!"))
+		return
+		
 	if(user.action_busy)
 		return
 	
@@ -1268,10 +1272,6 @@ obj/item/weapon/gun/launcher/grenade/update_icon()
 	current_mag.current_rounds--
 	
 	flare_turf.ceiling_debris()
-		
-	if(!istype(ammo, /datum/ammo/flare))
-		to_chat(user, SPAN_NOTICE("\The [src] jams as it is somehow loaded with incorrect ammo!"))
-		return
 		
 	var/datum/ammo/flare/explicit_ammo = ammo
 		


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Flare guns can fire flares into the air now. It takes a one second wind up to fire into the air. It can only be fired in the open or places with glass ceilings.

The flare gun description is expanded to show the last fired signal flare's designation.

## Why It's Good For The Game

Neat functionality and QoL. Plus Nanu said it would be fine in a town hall: https://imgur.com/V3N8CZj

## Changelog

:cl: Morrow
add: Flare guns can now be fired into the air via unique action
qol: Signal flares fired by flare guns now show their designation in the flare gun's description.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
