### PR TITLE
Fixed Boiler Dump Acid Exploit (Gas Gas Gas)

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/boiler/boiler_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/boiler/boiler_abilities.dm
@@ -44,6 +44,7 @@
 	var/cooldown_duration = 350
 
 	var/speed_buff_amount = 0.5
+	var/movespeed_buff_applied = FALSE
 
 	// List of types of actions to place on 20-second CD
 	// if you ever want to subtype this for a strain or whatever, just change this var on the subtype

--- a/code/modules/mob/living/carbon/xenomorph/abilities/boiler/boiler_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/boiler/boiler_powers.dm
@@ -153,7 +153,7 @@
 
 /datum/action/xeno_action/onclick/dump_acid/remove_from(mob/L)
 	remove_speed_buff()
-	. = ..()
+	..()
 
 /////////////////////////////// Trapper boiler powers
 

--- a/code/modules/mob/living/carbon/xenomorph/abilities/boiler/boiler_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/boiler/boiler_powers.dm
@@ -151,7 +151,7 @@
 	S.time_to_live = 3
 	S.spread_speed = 1000000
 
-/datum/action/xeno_action/onclick/dump_acid/remove_from(mob/L)
+/datum/action/xeno_action/onclick/dump_acid/remove_from()
 	remove_speed_buff()
 	..()
 

--- a/code/modules/mob/living/carbon/xenomorph/abilities/boiler/boiler_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/boiler/boiler_powers.dm
@@ -117,6 +117,7 @@
 	RegisterSignal(X, COMSIG_MOB_MOVE_OR_LOOK, .proc/handle_mob_move_or_look)
 	addtimer(CALLBACK(src, .proc/remove_speed_buff), buffs_duration)
 	X.speed_modifier -= speed_buff_amount
+	movespeed_buff_applied = TRUE
 	X.recalculate_speed()
 
 	to_chat(X, SPAN_XENOHIGHDANGER("You dump your acid, disabling your offensive abilities to escape!"))
@@ -133,10 +134,11 @@
 	return
 
 /datum/action/xeno_action/onclick/dump_acid/proc/remove_speed_buff()
-	if (isXeno(owner))
-		var/mob/living/carbon/Xenomorph/X = owner
-		X.speed_modifier += speed_buff_amount
-		X.recalculate_speed()
+	if (movespeed_buff_applied && isXeno(owner))
+		var/mob/living/carbon/Xenomorph/xeno = owner
+		xeno.speed_modifier += speed_buff_amount
+		xeno.recalculate_speed()
+		movespeed_buff_applied = FALSE
 		UnregisterSignal(owner, COMSIG_MOB_MOVE_OR_LOOK)
 
 /datum/action/xeno_action/onclick/dump_acid/proc/handle_mob_move_or_look(mob/living/carbon/Xenomorph/mover, var/actually_moving, var/direction, var/specific_direction)
@@ -148,6 +150,10 @@
 	var/obj/effect/particle_effect/smoke/S = new /obj/effect/particle_effect/smoke/xeno_burn(get_turf(mover), 1, create_cause_data(initial(mover.caste_type), mover))
 	S.time_to_live = 3
 	S.spread_speed = 1000000
+
+/datum/action/xeno_action/onclick/dump_acid/remove_from(mob/L)
+	remove_speed_buff()
+	. = ..()
 
 /////////////////////////////// Trapper boiler powers
 

--- a/code/modules/mob/living/carbon/xenomorph/abilities/xeno_action.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/xeno_action.dm
@@ -152,7 +152,7 @@
 		if(charges != NO_ACTION_CHARGES)
 			to_chat(X, SPAN_INFO("It has [charges] uses left."))
 
-/datum/action/xeno_action/activable/remove_from(mob/living/carbon/Xenomorph/X)
+/datum/action/xeno_action/remove_from(mob/living/carbon/Xenomorph/X)
 	..()
 	if(X.selected_ability == src)
 		X.selected_ability = null


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Fixes Boiler's Dump Acid ability never ending when mutating to Trapper before it has ended.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
[![Gas Gas Gas](https://img.youtube.com/vi/WGoUL46Wan8/0.jpg)](https://youtu.be/WGoUL46Wan8 "Gas Gas Gas Video")
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Drathek
fix: Fixed Boiler Dump Acid exploit.
fix: Fixed onclick actions not removing their macro verb.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
