### PR TITLE
World/Error Hotfix

### DIFF
--- a/code/game/objects/effects/spawners/random.dm
+++ b/code/game/objects/effects/spawners/random.dm
@@ -401,18 +401,18 @@
 	mags_min = 1
 	mags_max = 2
 	guns = list(
-		/obj/item/weapon/gun/shotgun/pump/cmb,
-		/obj/item/weapon/gun/shotgun/pump/cmb,
-		/obj/item/weapon/gun/shotgun/pump/cmb,
-		/obj/item/weapon/gun/shotgun/pump/cmb,
-		/obj/item/weapon/gun/shotgun/pump/cmb,
-		/obj/item/weapon/gun/shotgun/pump/cmb,
+		/obj/item/weapon/gun/shotgun/pump/cmb = /obj/item/weapon/gun/shotgun/pump/cmb,
+		/obj/item/weapon/gun/shotgun/pump/cmb = /obj/item/weapon/gun/shotgun/pump/cmb,
+		/obj/item/weapon/gun/shotgun/pump/cmb = /obj/item/weapon/gun/shotgun/pump/cmb,
+		/obj/item/weapon/gun/shotgun/pump/cmb = /obj/item/weapon/gun/shotgun/pump/cmb,
+		/obj/item/weapon/gun/shotgun/pump/cmb = /obj/item/weapon/gun/shotgun/pump/cmb,
+		/obj/item/weapon/gun/shotgun/pump/cmb = /obj/item/weapon/gun/shotgun/pump/cmb,
 		/obj/item/weapon/gun/lever_action/r4t = /obj/item/ammo_magazine/lever_action,
 		/obj/item/weapon/gun/lever_action/r4t = /obj/item/ammo_magazine/lever_action,
 		/obj/item/weapon/gun/lever_action/r4t = /obj/item/ammo_magazine/lever_action,
-		/obj/item/weapon/gun/shotgun/merc,
-		/obj/item/weapon/gun/shotgun/pump/cmb/m3717,
-		/obj/item/weapon/gun/shotgun/double
+		/obj/item/weapon/gun/shotgun/merc = /obj/item/weapon/gun/shotgun/merc,
+		/obj/item/weapon/gun/shotgun/pump/cmb/m3717 = /obj/item/weapon/gun/shotgun/pump/cmb/m3717,
+		/obj/item/weapon/gun/shotgun/double = /obj/item/weapon/gun/shotgun/double
 	) //no ammotypes needed as it spawns random 12g boxes. Apart from the r4t. why is the r4t in the shotgun pool? fuck you, that's why.
 
 /obj/effect/spawner/random/gun/shotgun/lowchance
@@ -467,12 +467,12 @@
 	guns = list(
 		/obj/item/weapon/gun/rifle/mar40/lmg = /obj/item/ammo_magazine/rifle/mar40/lmg,
 		/obj/item/weapon/gun/m60 = /obj/item/ammo_magazine/m60,
-		/obj/item/weapon/gun/shotgun/merc,
+		/obj/item/weapon/gun/shotgun/merc = /obj/item/weapon/gun/shotgun/merc,
 		/obj/item/weapon/gun/launcher/rocket/anti_tank/disposable = /obj/item/prop/folded_anti_tank_sadar,
 		/obj/item/weapon/gun/rifle/m41a = /obj/item/ammo_magazine/rifle,
-		/obj/item/weapon/gun/shotgun/combat,
+		/obj/item/weapon/gun/shotgun/combat = /obj/item/weapon/gun/shotgun/combat,
 		/obj/item/weapon/gun/pistol/vp78 = /obj/item/ammo_magazine/pistol/vp78,
-		/obj/item/weapon/gun/launcher/grenade/m81/m79
+		/obj/item/weapon/gun/launcher/grenade/m81/m79 = /obj/item/weapon/gun/launcher/grenade/m81/m79
 		)
 
 /obj/effect/spawner/random/gun/special/lowchance

--- a/code/game/objects/effects/spawners/random.dm
+++ b/code/game/objects/effects/spawners/random.dm
@@ -401,18 +401,18 @@
 	mags_min = 1
 	mags_max = 2
 	guns = list(
-		/obj/item/weapon/gun/shotgun/pump/cmb = /obj/item/weapon/gun/shotgun/pump/cmb,
-		/obj/item/weapon/gun/shotgun/pump/cmb = /obj/item/weapon/gun/shotgun/pump/cmb,
-		/obj/item/weapon/gun/shotgun/pump/cmb = /obj/item/weapon/gun/shotgun/pump/cmb,
-		/obj/item/weapon/gun/shotgun/pump/cmb = /obj/item/weapon/gun/shotgun/pump/cmb,
-		/obj/item/weapon/gun/shotgun/pump/cmb = /obj/item/weapon/gun/shotgun/pump/cmb,
-		/obj/item/weapon/gun/shotgun/pump/cmb = /obj/item/weapon/gun/shotgun/pump/cmb,
+		/obj/item/weapon/gun/shotgun/pump/cmb = null,
+		/obj/item/weapon/gun/shotgun/pump/cmb = null,
+		/obj/item/weapon/gun/shotgun/pump/cmb = null,
+		/obj/item/weapon/gun/shotgun/pump/cmb = null,
+		/obj/item/weapon/gun/shotgun/pump/cmb = null,
+		/obj/item/weapon/gun/shotgun/pump/cmb = null,
 		/obj/item/weapon/gun/lever_action/r4t = /obj/item/ammo_magazine/lever_action,
 		/obj/item/weapon/gun/lever_action/r4t = /obj/item/ammo_magazine/lever_action,
 		/obj/item/weapon/gun/lever_action/r4t = /obj/item/ammo_magazine/lever_action,
-		/obj/item/weapon/gun/shotgun/merc = /obj/item/weapon/gun/shotgun/merc,
-		/obj/item/weapon/gun/shotgun/pump/cmb/m3717 = /obj/item/weapon/gun/shotgun/pump/cmb/m3717,
-		/obj/item/weapon/gun/shotgun/double = /obj/item/weapon/gun/shotgun/double
+		/obj/item/weapon/gun/shotgun/merc = null,
+		/obj/item/weapon/gun/shotgun/pump/cmb/m3717 = null,
+		/obj/item/weapon/gun/shotgun/double = null
 	) //no ammotypes needed as it spawns random 12g boxes. Apart from the r4t. why is the r4t in the shotgun pool? fuck you, that's why.
 
 /obj/effect/spawner/random/gun/shotgun/lowchance
@@ -467,12 +467,12 @@
 	guns = list(
 		/obj/item/weapon/gun/rifle/mar40/lmg = /obj/item/ammo_magazine/rifle/mar40/lmg,
 		/obj/item/weapon/gun/m60 = /obj/item/ammo_magazine/m60,
-		/obj/item/weapon/gun/shotgun/merc = /obj/item/weapon/gun/shotgun/merc,
+		/obj/item/weapon/gun/shotgun/merc = null,
 		/obj/item/weapon/gun/launcher/rocket/anti_tank/disposable = /obj/item/prop/folded_anti_tank_sadar,
 		/obj/item/weapon/gun/rifle/m41a = /obj/item/ammo_magazine/rifle,
-		/obj/item/weapon/gun/shotgun/combat = /obj/item/weapon/gun/shotgun/combat,
+		/obj/item/weapon/gun/shotgun/combat = null,
 		/obj/item/weapon/gun/pistol/vp78 = /obj/item/ammo_magazine/pistol/vp78,
-		/obj/item/weapon/gun/launcher/grenade/m81/m79 = /obj/item/weapon/gun/launcher/grenade/m81/m79
+		/obj/item/weapon/gun/launcher/grenade/m81/m79 = null
 		)
 
 /obj/effect/spawner/random/gun/special/lowchance


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Fixes 
`runtime error: list index out of bounds
proc name:
source file: random.dm,403
usr: null
src:
call stack:
: ()`
which seems to allow more initialization to occur including world/Error.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
You can get runtimes in STUI again (for example a queen gib runtime): 
![image](https://user-images.githubusercontent.com/76988376/189322415-720331a8-481d-4a15-8983-0794b910334c.png)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixed index out of bounds runtime that was preventing runtime logging.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
