### PR TITLE
Player Panel human name reset and ban

### DIFF
--- a/code/modules/admin/player_panel/actions/punish.dm
+++ b/code/modules/admin/player_panel/actions/punish.dm
@@ -260,7 +260,7 @@
 	notes_add(target.ckey, "Human Name Banned by [user.ckey]", user.mob)
 
 	to_chat(target, SPAN_HIGHDANGER("Warning: You were banned from using human names by [user.ckey]."))
-	playsound_client(target_mob.client, sound('sound/effects/adminhelp_new.ogg'), src, 50)
+	playsound_client(target_client, sound('sound/effects/adminhelp_new.ogg'), src, 50)
 
 	var/new_name = random_name(target.gender)
 	target_client.prefs.real_name = new_name

--- a/code/modules/admin/player_panel/actions/punish.dm
+++ b/code/modules/admin/player_panel/actions/punish.dm
@@ -168,6 +168,9 @@
 		to_chat(user, SPAN_WARNING("[target.name] is a xeno!"))
 		return
 
+	if(!target_mob.client)
+		to_chat(user, SPAN_WARNING("[target.name] does not have a client!"))
+
 	if(!target_mob.ckey)
 		to_chat(user, SPAN_DANGER("Warning: Mob ckey for [target_mob.name] not found."))
 		return
@@ -188,8 +191,15 @@
 		to_chat(user, SPAN_NOTICE("Invalid name. The name should be at least 2 and at most [MAX_NAME_LEN] characters long. It may only contain the characters A-Z, a-z, -, ' and ."))
 		return
 
+	if(!target_mob.client)
+		to_chat(user, SPAN_WARNING("[target.name] does not have a client!"))
+
+	if(!target_mob.ckey)
+		to_chat(user, SPAN_DANGER("Warning: Mob ckey for [target_mob.name] not found."))
+		return
+
 	target_mob.change_real_name(target_mob, new_name)
-	if(istype(target_mob, /mob/living/carbon/human))
+	if(ishuman(target_mob))
 		var/mob/living/carbon/human/target_human = target_mob
 		if(target_human.wear_id)
 			target_human.wear_id.name = "[target_human.real_name]'s ID Card"
@@ -200,10 +210,10 @@
 	target_mob.client.prefs.real_name = new_name
 	target_mob.client.prefs.save_character()
 
-	message_staff("[user.ckey] has reset [target_mob.ckey] name")
+	message_staff("[user.ckey] has reset [target_mob.ckey]'s name.")
 
-	to_chat(target_mob, SPAN_DANGER("Warning: Your name has been reset by [user.ckey]."))
-
+	to_chat(target_mob, SPAN_HIGHDANGER("Warning: Your name has been reset by [user.ckey]."))
+	playsound_client(target_mob.client, sound('sound/effects/adminhelp_new.ogg'), src, 50)
 
 /datum/player_action/ban_human_name
 	action_tag = "ban_human_name"
@@ -221,6 +231,11 @@
 	if(target_client.human_name_ban)
 		if(alert(user, "Are you sure you want to UNBAN [target.ckey] and let them use human names?", ,"Yes", "No") == "No")
 			return
+
+		if(!target.client || !target.ckey)
+			to_chat(user, SPAN_NOTICE("Target is lacking either client or ckey. Aborting."))
+			return
+
 		target_client.human_name_ban = FALSE
 		target_client.prefs.human_name_ban = FALSE
 
@@ -229,18 +244,23 @@
 
 		notes_add(target.ckey, "Human Name Unbanned by [user.ckey]", user.mob)
 
-		to_chat(target, SPAN_DANGER("Warning: You can use human names again."))
+		to_chat(target, SPAN_HIGHDANGER("Warning: You can use human names again."))
 		return
 
 
 	if(alert("Are you sure you want to BAN [target.ckey] from ever using any human names?", , "Yes", "No") == "No")
 		return
 
+	if(!target.client || !target.ckey)
+		to_chat(user, SPAN_NOTICE("Target is lacking either client or ckey. Aborting."))
+		return
+
 	message_staff("[user.ckey] has banned [target.ckey] from using human names.")
 
 	notes_add(target.ckey, "Human Name Banned by [user.ckey]", user.mob)
 
-	to_chat(target, SPAN_DANGER("Warning: You were banned from using human names by [user.ckey]."))
+	to_chat(target, SPAN_HIGHDANGER("Warning: You were banned from using human names by [user.ckey]."))
+	playsound_client(target_mob.client, sound('sound/effects/adminhelp_new.ogg'), src, 50)
 
 	var/new_name = random_name(target.gender)
 	target_client.prefs.real_name = new_name

--- a/code/modules/admin/player_panel/actions/punish.dm
+++ b/code/modules/admin/player_panel/actions/punish.dm
@@ -175,12 +175,12 @@
 		to_chat(user, SPAN_DANGER("Warning: Mob ckey for [target_mob.name] not found."))
 		return
 
-	if(alert(user, "Are you sure you want to reset name for [target_mob.ckey]?", , "Yes", "No") == "No")
+	if(alert(user, "Are you sure you want to reset name for [target_mob.ckey]?", "Confirmation", "Yes", "No") == "No")
 		return
 
 	var/new_name
 
-	if(alert(user, "Do you want to manually set the name for [target_mob.ckey]?", , "Yes", "No") == "No")
+	if(alert(user, "Do you want to manually set the name for [target_mob.ckey]?", "Confirmation", "Yes", "No") == "No")
 		new_name = random_name(target_mob.gender)
 	else
 		var/raw_name = input(user, "Choose the new name:", "Name Input")  as text|null
@@ -201,7 +201,7 @@
 	target_mob.change_real_name(target_mob, new_name)
 	if(ishuman(target_mob))
 		var/mob/living/carbon/human/target_human = target_mob
-		if(target_human.wear_id)
+		if(target_human.wear_id && target_human.wear_id.registered_ref == WEAKREF(target_human))
 			target_human.wear_id.name = "[target_human.real_name]'s ID Card"
 			target_human.wear_id.registered_name = "[target_human.real_name]"
 			if(target_human.wear_id.assignment)
@@ -212,7 +212,8 @@
 
 	message_staff("[user.ckey] has reset [target_mob.ckey]'s name.")
 
-	to_chat(target_mob, SPAN_HIGHDANGER("Warning: Your name has been reset by [user.ckey]."))
+	to_chat(target_mob, FONT_SIZE_HUGE(SPAN_ADMINHELP("Warning: Your name has been reset by [user.ckey].")))
+
 	playsound_client(target_mob.client, sound('sound/effects/adminhelp_new.ogg'), src, 50)
 
 /datum/player_action/ban_human_name
@@ -229,7 +230,7 @@
 	var/client/target_client = target.client
 
 	if(target_client.human_name_ban)
-		if(alert(user, "Are you sure you want to UNBAN [target.ckey] and let them use human names?", ,"Yes", "No") == "No")
+		if(alert(user, "Are you sure you want to UNBAN [target.ckey] and let them use human names?", "Confirmation", "Yes", "No") == "No")
 			return
 
 		if(!target.client || !target.ckey)
@@ -244,11 +245,11 @@
 
 		notes_add(target.ckey, "Human Name Unbanned by [user.ckey]", user.mob)
 
-		to_chat(target, SPAN_HIGHDANGER("Warning: You can use human names again."))
+		to_chat(target, FONT_SIZE_HUGE(SPAN_ADMINHELP("Warning: You can use human names again.")))
 		return
 
 
-	if(alert("Are you sure you want to BAN [target.ckey] from ever using any human names?", , "Yes", "No") == "No")
+	if(alert("Are you sure you want to BAN [target.ckey] from ever using any human names?", "Confirmation", "Yes", "No") == "No")
 		return
 
 	if(!target.client || !target.ckey)
@@ -259,7 +260,7 @@
 
 	notes_add(target.ckey, "Human Name Banned by [user.ckey]", user.mob)
 
-	to_chat(target, SPAN_HIGHDANGER("Warning: You were banned from using human names by [user.ckey]."))
+	to_chat(target, FONT_SIZE_HUGE(SPAN_ADMINHELP("Warning: You were banned from using human names by [user.ckey].")))
 	playsound_client(target_client, sound('sound/effects/adminhelp_new.ogg'), src, 50)
 
 	var/new_name = random_name(target.gender)

--- a/code/modules/admin/player_panel/actions/punish.dm
+++ b/code/modules/admin/player_panel/actions/punish.dm
@@ -170,6 +170,7 @@
 
 	if(!target_mob.client)
 		to_chat(user, SPAN_WARNING("[target.name] does not have a client!"))
+		return
 
 	if(!target_mob.ckey)
 		to_chat(user, SPAN_DANGER("Warning: Mob ckey for [target_mob.name] not found."))
@@ -180,12 +181,15 @@
 
 	var/new_name
 
-	if(alert(user, "Do you want to manually set the name for [target_mob.ckey]?", "Confirmation", "Yes", "No") == "No")
-		new_name = random_name(target_mob.gender)
-	else
-		var/raw_name = input(user, "Choose the new name:", "Name Input")  as text|null
-		if(!isnull(raw_name)) // Check to ensure that the user entered text (rather than cancel.)
-			new_name = reject_bad_name(raw_name)
+	switch(alert(user, "Do you want to manually set the name for [target_mob.ckey]?", "Confirmation", "Yes", "No", "Cancel"))
+		if("Cancel")
+			return
+		if("No")
+			new_name = random_name(target_mob.gender)
+		if("Yes")
+			var/raw_name = input(user, "Choose the new name:", "Name Input")  as text|null
+			if(!isnull(raw_name)) // Check to ensure that the user entered text (rather than cancel.)
+				new_name = reject_bad_name(raw_name)
 
 	if(!new_name)
 		to_chat(user, SPAN_NOTICE("Invalid name. The name should be at least 2 and at most [MAX_NAME_LEN] characters long. It may only contain the characters A-Z, a-z, -, ' and ."))
@@ -193,6 +197,7 @@
 
 	if(!target_mob.client)
 		to_chat(user, SPAN_WARNING("[target.name] does not have a client!"))
+		return
 
 	if(!target_mob.ckey)
 		to_chat(user, SPAN_DANGER("Warning: Mob ckey for [target_mob.name] not found."))

--- a/code/modules/admin/player_panel/player_panel.dm
+++ b/code/modules/admin/player_panel/player_panel.dm
@@ -508,6 +508,8 @@
 		.["client_rank"] = targetClient.admin_holder ? targetClient.admin_holder.rank : "Player"
 		.["client_muted"] = targetClient.prefs.muted
 
+		.["client_name_banned_status"] = targetMob.client.human_name_ban
+
 /datum/player_panel/ui_state(mob/user)
 	return GLOB.admin_state
 

--- a/code/modules/admin/player_panel/player_panel.dm
+++ b/code/modules/admin/player_panel/player_panel.dm
@@ -508,7 +508,7 @@
 		.["client_rank"] = targetClient.admin_holder ? targetClient.admin_holder.rank : "Player"
 		.["client_muted"] = targetClient.prefs.muted
 
-		.["client_name_banned_status"] = targetMob.client.human_name_ban
+		.["client_name_banned_status"] = targetClient.human_name_ban
 
 /datum/player_panel/ui_state(mob/user)
 	return GLOB.admin_state

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -61,6 +61,8 @@
 	var/related_accounts_ip = "Requires database"	//So admins know why it isn't working - Used to determine what other accounts previously logged in from this ip
 	var/related_accounts_cid = "Requires database"	//So admins know why it isn't working - Used to determine what other accounts previously logged in from this computer id
 
+	var/human_name_ban = FALSE
+
 	var/xeno_prefix = "XX"
 	var/xeno_postfix = ""
 	var/xeno_name_ban = FALSE

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -315,6 +315,8 @@ GLOBAL_LIST_INIT(whitelisted_client_procs, list(
 	if(!xeno_postfix || xeno_name_ban)
 		xeno_postfix = ""
 
+	human_name_ban = prefs.human_name_ban
+
 	var/full_version = "[byond_version].[byond_build ? byond_build : "xxx"]"
 
 	if(GLOB.player_details[ckey])

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -101,7 +101,10 @@ var/const/MAX_SAVE_SLOTS = 10
 
 	//character preferences
 	var/real_name						//our character's name
-	var/be_random_name = 0				//whether we are a random name every round
+	var/be_random_name = FALSE				//whether we are a random name every round
+	var/human_name_ban = FALSE
+
+
 	var/be_random_body = 0				//whether we have a random appearance every round
 	var/gender = MALE					//gender of character (well duh)
 	var/age = 19						//age of character
@@ -1008,6 +1011,9 @@ var/const/MAX_SAVE_SLOTS = 10
 		if("input")
 			switch(href_list["preference"])
 				if("name")
+					if(human_name_ban)
+						to_chat(user, SPAN_NOTICE("You are banned from custom human names."))
+						return
 					var/raw_name = input(user, "Choose your character's name:", "Character Preference")  as text|null
 					if (!isnull(raw_name)) // Check to ensure that the user entered text (rather than cancel.)
 						var/new_name = reject_bad_name(raw_name)

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -118,6 +118,8 @@
 	S["ghost_vision_pref"]	>> ghost_vision_pref
 	S["ghost_orbit"]		>> ghost_orbit
 
+	S["human_name_ban"] >> human_name_ban
+
 	S["xeno_prefix"]		>> xeno_prefix
 	S["xeno_postfix"]		>> xeno_postfix
 	S["xeno_name_ban"]		>> xeno_name_ban
@@ -267,6 +269,8 @@
 	S["fps"]				<< fps
 	S["ghost_vision_pref"]	<< ghost_vision_pref
 	S["ghost_orbit"]		<< ghost_orbit
+
+	S["human_name_ban"] << human_name_ban
 
 	S["xeno_prefix"]		<< xeno_prefix
 	S["xeno_postfix"]		<< xeno_postfix

--- a/tgui/packages/tgui/interfaces/PlayerPanel.js
+++ b/tgui/packages/tgui/interfaces/PlayerPanel.js
@@ -415,6 +415,30 @@ const PunishmentActions = (props, context) => {
         </Stack>
       </Section>
 
+      <Section level={2} title="Human Name">
+        <Stack
+          align="right"
+          grow={1}
+        >
+          <Button
+            width="100%"
+            icon="clipboard-list"
+            color="average"
+            content="Human name reset"
+            disabled={!hasPermission(data, "reset_human_name")}
+            onClick={() => act("reset_human_name")}
+          />
+          <Button
+            width="100%"
+            height="100%"
+            icon="clipboard-list"
+            color="bad"
+            content="Human name ban"
+            disabled={!hasPermission(data, "ban_human_name")}
+            onClick={() => act("ban_human_name")}
+          />
+        </Stack>
+      </Section>
       <Section level={2} title="Xenomorph Name">
         <Stack
           align="right"

--- a/tgui/packages/tgui/interfaces/PlayerPanel.js
+++ b/tgui/packages/tgui/interfaces/PlayerPanel.js
@@ -433,7 +433,7 @@ const PunishmentActions = (props, context) => {
             height="100%"
             icon="clipboard-list"
             color="bad"
-            content="Human name ban"
+            content={!data?.client_name_banned_status ? ("Human name ban") : ("Human name unban")}
             disabled={!hasPermission(data, "ban_human_name")}
             onClick={() => act("ban_human_name")}
           />


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

This adds a section to handle human names in the player panel punish panel. 
Human name reset will allow you to change the name manually or have a random name selected and will set the preference name correctly.
Human name ban will disallow people from using custom names but they can still randomize until they find something they like.

## Why It's Good For The Game

Admins no longer have to tell "BEST MARINE" to change their name preferences four rounds in a row.

## Changelog

:cl: Morrow
admin: Added human name reset and human name ban to player panel.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
