### PR TITLE
You can now use ; or :[key] for default frequencies

### DIFF
--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -36,6 +36,7 @@
 	var/locate_setting = TRACKER_SL
 	var/misc_tracking = FALSE
 	var/hud_type = MOB_HUD_FACTION_USCM
+	var/default_freq
 
 /obj/item/device/radio/headset/Initialize()
 	. = ..()
@@ -51,6 +52,11 @@
 		headset_hud_on = TRUE
 		verbs += /obj/item/device/radio/headset/proc/toggle_squadhud
 		verbs += /obj/item/device/radio/headset/proc/switch_tracker_target
+
+	if(frequency)
+		for(var/cycled_channel in radiochannels)
+			if(radiochannels[cycled_channel] == frequency)
+				default_freq = cycled_channel
 
 /obj/item/device/radio/headset/proc/set_volume_setting()
 	set name = "Set Headset Volume"
@@ -79,6 +85,9 @@
 			var/datum/language/hivemind = GLOB.all_languages[LANGUAGE_HIVEMIND]
 			hivemind.broadcast(M, message)
 		return null
+
+	if(default_freq && channel == default_freq)
+		return radio_connection
 
 	return ..()
 
@@ -200,6 +209,13 @@
 	for (var/ch_name in channels)
 		secure_radio_connections[ch_name] = SSradio.add_object(src, radiochannels[ch_name],  RADIO_CHAT)
 	SStgui.update_uis(src)
+
+/obj/item/device/radio/headset/set_frequency(new_frequency)
+	..()
+	if(frequency)
+		for(var/cycled_channel in radiochannels)
+			if(radiochannels[cycled_channel] == frequency)
+				default_freq = cycled_channel
 
 /obj/item/device/radio/headset/equipped(mob/living/carbon/human/user, slot)
 	. = ..()

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -201,11 +201,6 @@
 		if (channels[message_mode]) // only broadcast if the channel is set on
 			return secure_radio_connections[message_mode]
 
-	if(frequency)
-		for(var/cycled_channel in radiochannels)
-			if(radiochannels[cycled_channel] == frequency && cycled_channel == message_mode)
-				return radio_connection
-
 	// If we were to send to a channel we don't have, drop it.
 	return null
 

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -201,6 +201,11 @@
 		if (channels[message_mode]) // only broadcast if the channel is set on
 			return secure_radio_connections[message_mode]
 
+	if(frequency)
+		for(var/cycled_channel in radiochannels)
+			if(radiochannels[cycled_channel] == frequency && cycled_channel == message_mode)
+				return radio_connection
+
 	// If we were to send to a channel we don't have, drop it.
 	return null
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

You can now use ; or :[key] for default frequencies.

Alpha can now use ; or :A to send messages on alpha's channel. Same goes for other default channels/frequencies.

## Why It's Good For The Game

QOL, I will never lose a message again *pain

## Changelog

:cl: Morrow
qol: You can now use ; or :[key] for default frequencies.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
