### PR TITLE
Allows Xenos to pat ground fire

### DIFF
--- a/code/_onclick/xeno.dm
+++ b/code/_onclick/xeno.dm
@@ -40,7 +40,7 @@
 			if(!tile_attack) // Patting flames for Xenos
 				var/firepatted = FALSE
 				if(src.a_intent == INTENT_HELP)
-					var/fire_level_to_extinguish = 13
+					var/fire_level_to_extinguish = 5
 					var/turf/T = target
 					for(var/obj/flamer_fire/FF in T)
 						firepatted = TRUE
@@ -54,6 +54,8 @@
 										firepatted = TRUE
 										FF.firelevel -= 2*fire_level_to_extinguish
 										FF.update_flame()
+									else qdel(FF)
+								else qdel(FF)
 				xeno_miss_delay(src)
 				animation_attack_on(target)
 				playsound(loc, 'sound/weapons/alien_claw_swipe.ogg', 10, 1) //Quiet to limit spam/nuisance.

--- a/code/_onclick/xeno.dm
+++ b/code/_onclick/xeno.dm
@@ -41,30 +41,32 @@
 				var/firepatted = FALSE
 				if(src.a_intent == INTENT_HELP)
 					var/fire_level_to_extinguish = 5
-					var/turf/T = target
-					for(var/obj/flamer_fire/FF in T)
+					var/turf/target_turf = target
+					for(var/obj/flamer_fire/fire in target_turf)
 						firepatted = TRUE
-						if((FF.firelevel > fire_level_to_extinguish) && (!FF.fire_variant)) //If fire_variant = 0, default fire extinguish behavior.
-							FF.firelevel -= fire_level_to_extinguish
-							FF.update_flame()
+						if((fire.firelevel > fire_level_to_extinguish) && (!fire.fire_variant)) //If fire_variant = 0, default fire extinguish behavior.
+							fire.firelevel -= fire_level_to_extinguish
+							fire.update_flame()
 						else
-							switch(FF.fire_variant)
+							switch(fire.fire_variant)
 								if(FIRE_VARIANT_TYPE_B) //Armor Shredding Greenfire, extinguishes faster.
-									if(FF.firelevel > 2*fire_level_to_extinguish)
+									if(fire.firelevel > 2*fire_level_to_extinguish)
 										firepatted = TRUE
-										FF.firelevel -= 2*fire_level_to_extinguish
-										FF.update_flame()
-									else qdel(FF)
-								else qdel(FF)
+										fire.firelevel -= 2*fire_level_to_extinguish
+										fire.update_flame()
+									else 
+										qdel(fire)
+								else 
+									qdel(fire)
 				xeno_miss_delay(src)
 				animation_attack_on(target)
 				playsound(loc, 'sound/weapons/alien_claw_swipe.ogg', 10, 1) //Quiet to limit spam/nuisance.
 				if(firepatted)
-					visible_message(SPAN_DANGER("[src] pats at the fire!"), \
+					visible_message(SPAN_DANGER("\The [src] pats at the fire!"), \
 					SPAN_DANGER("You pat the fire!"), null, 5, CHAT_TYPE_XENO_COMBAT)
 				else
-					visible_message(SPAN_DANGER("[src] swipes at [target]!"), \
-					SPAN_DANGER("You swipe at [target]!"), null, 5, CHAT_TYPE_XENO_COMBAT)
+					visible_message(SPAN_DANGER("\The [src] swipes at \the [target]!"), \
+					SPAN_DANGER("You swipe at \the [target]!"), null, 5, CHAT_TYPE_XENO_COMBAT)
 	return TRUE
 
 /mob/living/carbon/Xenomorph/RangedAttack(var/atom/A)

--- a/code/_onclick/xeno.dm
+++ b/code/_onclick/xeno.dm
@@ -37,7 +37,32 @@
 		if(XENO_NO_DELAY_ACTION)
 			next_move = world.time
 		else
-			if(!tile_attack)
+			if(!tile_attack && src.a_intent == INTENT_HELP) // Patting flames for Xenos
+				var/fire_level_to_extinguish = 13
+				var/turf/T = target
+				for(var/obj/flamer_fire/FF in T)
+					if((FF.firelevel > fire_level_to_extinguish) && (!FF.fire_variant)) //If fire_variant = 0, default fire extinguish behavior.
+						FF.firelevel -= fire_level_to_extinguish
+						FF.update_flame()
+					else
+						switch(FF.fire_variant)
+							if(FIRE_VARIANT_TYPE_B) //Armor Shredding Greenfire, extinguishes faster.
+								if(FF.firelevel > 2*fire_level_to_extinguish)
+									FF.firelevel -= 2*fire_level_to_extinguish
+									FF.update_flame()
+
+					xeno_miss_delay(src)
+					animation_attack_on(target)
+					playsound(loc, 'sound/weapons/alien_claw_swipe.ogg', 10, 1) //Quiet to limit spam/nuisance.
+					visible_message(SPAN_DANGER("[src] pats at the fire!"), \
+					SPAN_DANGER("You pat the fire!"), null, 5, CHAT_TYPE_XENO_COMBAT)
+					return TRUE
+				xeno_miss_delay(src)
+				animation_attack_on(target)
+				playsound(loc, 'sound/weapons/alien_claw_swipe.ogg', 10, 1) //Quiet to limit spam/nuisance.
+				visible_message(SPAN_DANGER("[src] swipes at [target]!"), \
+				SPAN_DANGER("You swipe at [target]!"), null, 5, CHAT_TYPE_XENO_COMBAT)
+			else if(!tile_attack)
 				xeno_miss_delay(src)
 				animation_attack_on(target)
 				playsound(loc, 'sound/weapons/alien_claw_swipe.ogg', 10, 1) //Quiet to limit spam/nuisance.

--- a/code/_onclick/xeno.dm
+++ b/code/_onclick/xeno.dm
@@ -37,37 +37,31 @@
 		if(XENO_NO_DELAY_ACTION)
 			next_move = world.time
 		else
-			if(!tile_attack && src.a_intent == INTENT_HELP) // Patting flames for Xenos
-				var/fire_level_to_extinguish = 13
-				var/turf/T = target
-				for(var/obj/flamer_fire/FF in T)
-					if((FF.firelevel > fire_level_to_extinguish) && (!FF.fire_variant)) //If fire_variant = 0, default fire extinguish behavior.
-						FF.firelevel -= fire_level_to_extinguish
-						FF.update_flame()
-					else
-						switch(FF.fire_variant)
-							if(FIRE_VARIANT_TYPE_B) //Armor Shredding Greenfire, extinguishes faster.
-								if(FF.firelevel > 2*fire_level_to_extinguish)
-									FF.firelevel -= 2*fire_level_to_extinguish
-									FF.update_flame()
-
-					xeno_miss_delay(src)
-					animation_attack_on(target)
-					playsound(loc, 'sound/weapons/alien_claw_swipe.ogg', 10, 1) //Quiet to limit spam/nuisance.
+			if(!tile_attack) // Patting flames for Xenos
+				var/firepatted = FALSE
+				if(src.a_intent == INTENT_HELP)
+					var/fire_level_to_extinguish = 13
+					var/turf/T = target
+					for(var/obj/flamer_fire/FF in T)
+						firepatted = TRUE
+						if((FF.firelevel > fire_level_to_extinguish) && (!FF.fire_variant)) //If fire_variant = 0, default fire extinguish behavior.
+							FF.firelevel -= fire_level_to_extinguish
+							FF.update_flame()
+						else
+							switch(FF.fire_variant)
+								if(FIRE_VARIANT_TYPE_B) //Armor Shredding Greenfire, extinguishes faster.
+									if(FF.firelevel > 2*fire_level_to_extinguish)
+										FF.firelevel -= 2*fire_level_to_extinguish
+										FF.update_flame()
+				xeno_miss_delay(src)
+				animation_attack_on(target)
+				playsound(loc, 'sound/weapons/alien_claw_swipe.ogg', 10, 1) //Quiet to limit spam/nuisance.
+				if(firepatted)
 					visible_message(SPAN_DANGER("[src] pats at the fire!"), \
 					SPAN_DANGER("You pat the fire!"), null, 5, CHAT_TYPE_XENO_COMBAT)
-					return TRUE
-				xeno_miss_delay(src)
-				animation_attack_on(target)
-				playsound(loc, 'sound/weapons/alien_claw_swipe.ogg', 10, 1) //Quiet to limit spam/nuisance.
-				visible_message(SPAN_DANGER("[src] swipes at [target]!"), \
-				SPAN_DANGER("You swipe at [target]!"), null, 5, CHAT_TYPE_XENO_COMBAT)
-			else if(!tile_attack)
-				xeno_miss_delay(src)
-				animation_attack_on(target)
-				playsound(loc, 'sound/weapons/alien_claw_swipe.ogg', 10, 1) //Quiet to limit spam/nuisance.
-				visible_message(SPAN_DANGER("[src] swipes at [target]!"), \
-				SPAN_DANGER("You swipe at [target]!"), null, 5, CHAT_TYPE_XENO_COMBAT)
+				else
+					visible_message(SPAN_DANGER("[src] swipes at [target]!"), \
+					SPAN_DANGER("You swipe at [target]!"), null, 5, CHAT_TYPE_XENO_COMBAT)
 	return TRUE
 
 /mob/living/carbon/Xenomorph/RangedAttack(var/atom/A)

--- a/code/_onclick/xeno.dm
+++ b/code/_onclick/xeno.dm
@@ -62,10 +62,10 @@
 				animation_attack_on(target)
 				playsound(loc, 'sound/weapons/alien_claw_swipe.ogg', 10, 1) //Quiet to limit spam/nuisance.
 				if(firepatted)
-					visible_message(SPAN_DANGER("\The [src] pats at the fire!"), \
+					src.visible_message(SPAN_DANGER("\The [src] pats at the fire!"), \
 					SPAN_DANGER("You pat the fire!"), null, 5, CHAT_TYPE_XENO_COMBAT)
 				else
-					visible_message(SPAN_DANGER("\The [src] swipes at \the [target]!"), \
+					src.visible_message(SPAN_DANGER("\The [src] swipes at \the [target]!"), \
 					SPAN_DANGER("You swipe at \the [target]!"), null, 5, CHAT_TYPE_XENO_COMBAT)
 	return TRUE
 

--- a/code/_onclick/xeno.dm
+++ b/code/_onclick/xeno.dm
@@ -51,6 +51,7 @@
 							switch(FF.fire_variant)
 								if(FIRE_VARIANT_TYPE_B) //Armor Shredding Greenfire, extinguishes faster.
 									if(FF.firelevel > 2*fire_level_to_extinguish)
+										firepatted = TRUE
 										FF.firelevel -= 2*fire_level_to_extinguish
 										FF.update_flame()
 				xeno_miss_delay(src)

--- a/html/changelogs/archive/2022-09.yml
+++ b/html/changelogs/archive/2022-09.yml
@@ -146,3 +146,6 @@
 2022-09-11:
   Geevies:
   - rscadd: You can now see who's playing the Queen / her hive leaders from the lobby.
+  Nanu:
+  - bugfix: Fixes the TP function so you can now choose between the Colony chapel
+      and Almayer.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Allows xenos to pat fire on the ground, better than sitting at a flank waiting for it to go away I suppose, worth a TM.
Theoretic numbers: 4 pats for normal fire, 5 pats for green fire, 8 pats for blue fire.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Current number is fairly weak, can be adjusted easily later.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Allows Xenos to pat out fires on the ground while on help intent.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
