### PR TITLE
Tablet beacon and CIC additions

### DIFF
--- a/code/game/jobs/job/command/cic/staffofficer.dm
+++ b/code/game/jobs/job/command/cic/staffofficer.dm
@@ -1,9 +1,9 @@
 /datum/job/command/bridge
 	title = JOB_SO
-	total_positions = 5
-	spawn_positions = 5
+	total_positions = 4
+	spawn_positions = 4
 	allow_additional = 1
-	scaled = 1
+	scaled = 0
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT
 	gear_preset = /datum/equipment_preset/uscm_ship/so
 	entry_message_body = "Your job is to monitor the Marines, man the CIC, and listen to your superior officers. You are in charge of logistics and the overwatch system. You are also in line to take command after other eligible superior commissioned officers."

--- a/code/game/jobs/job/command/cic/staffofficer.dm
+++ b/code/game/jobs/job/command/cic/staffofficer.dm
@@ -3,7 +3,7 @@
 	total_positions = 4
 	spawn_positions = 4
 	allow_additional = 1
-	scaled = 0
+	scaled = FALSE
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT
 	gear_preset = /datum/equipment_preset/uscm_ship/so
 	entry_message_body = "Your job is to monitor the Marines, man the CIC, and listen to your superior officers. You are in charge of logistics and the overwatch system. You are also in line to take command after other eligible superior commissioned officers."

--- a/code/game/objects/items/devices/cictablet.dm
+++ b/code/game/objects/items/devices/cictablet.dm
@@ -59,7 +59,7 @@
 	data["alert_level"] = security_level
 	data["evac_status"] = EvacuationAuthority.evac_status
 	data["endtime"] = announcement_cooldown
-	data["distresscd"] = distress_cooldown
+	data["distresstime"] = distress_cooldown
 	data["distresstimelock"] = DISTRESS_TIME_LOCK
 	data["worldtime"] = world.time
 

--- a/code/game/objects/items/devices/cictablet.dm
+++ b/code/game/objects/items/devices/cictablet.dm
@@ -17,7 +17,6 @@
 	var/announcement_title = COMMAND_ANNOUNCE
 	var/announcement_faction = FACTION_MARINE
 	var/add_pmcs = TRUE
-	var/cooldown_request = 0
 
 	var/tacmap_type = TACMAP_DEFAULT
 	var/tacmap_base_type = TACMAP_BASE_OCCLUDED
@@ -154,17 +153,8 @@
 			. = TRUE
 
 		if("distress")
-			//Comment block to test
-			if(world.time < DISTRESS_TIME_LOCK)
-				to_chat(usr, SPAN_WARNING("The distress beacon cannot be launched this early in the operation. Please wait another [time_left_until(DISTRESS_TIME_LOCK, world.time, 1 MINUTES)] minutes before trying again."))
-				return FALSE
-
 			if(!SSticker.mode)
 				return FALSE //Not a game mode?
-
-			if(SSticker.mode.force_end_at == 0)
-				to_chat(usr, SPAN_WARNING("ARES has denied your request for operational security reasons."))
-				return FALSE
 
 			if(security_level == SEC_LEVEL_DELTA)
 				to_chat(usr, SPAN_WARNING("The ship is already undergoing self destruct procedures!"))

--- a/code/modules/gear_presets/uscm_ship.dm
+++ b/code/modules/gear_presets/uscm_ship.dm
@@ -412,7 +412,7 @@
 	H.equip_to_slot_or_del(new backItem(H), WEAR_BACK)
 	H.equip_to_slot_or_del(new /obj/item/storage/pouch/general/large(H), WEAR_L_STORE)
 	H.equip_to_slot_or_del(new /obj/item/storage/pouch/general/large(H), WEAR_R_STORE)
-	H.equip_to_slot_or_del(new /obj/item/device/binoculars/range(H), WEAR_L_HAND)
+	H.equip_to_slot_or_del(new /obj/item/device/binoculars/range(H), WEAR_L_STORE)
 
 //*****************************************************************************************************/
 

--- a/code/modules/gear_presets/uscm_ship.dm
+++ b/code/modules/gear_presets/uscm_ship.dm
@@ -412,6 +412,7 @@
 	H.equip_to_slot_or_del(new backItem(H), WEAR_BACK)
 	H.equip_to_slot_or_del(new /obj/item/storage/pouch/general/large(H), WEAR_L_STORE)
 	H.equip_to_slot_or_del(new /obj/item/storage/pouch/general/large(H), WEAR_R_STORE)
+	H.equip_to_slot_or_del(new /obj/item/device/binoculars/range(H), WEAR_L_HAND)
 
 //*****************************************************************************************************/
 

--- a/tgui/packages/tgui/interfaces/CommandTablet.js
+++ b/tgui/packages/tgui/interfaces/CommandTablet.js
@@ -20,7 +20,7 @@ export const CommandTablet = (_props, context) => {
     AlertLevel >= 2);
 
   const canDistress = (
-    canEvac && data.distresscd && minimumTimeElapsed < data.worldtime);
+    AlertLevel >= 2 && !data.distresscd && minimumTimeElapsed);
 
   return (
     <Window

--- a/tgui/packages/tgui/interfaces/CommandTablet.js
+++ b/tgui/packages/tgui/interfaces/CommandTablet.js
@@ -20,7 +20,7 @@ export const CommandTablet = (_props, context) => {
     AlertLevel >= 2);
 
   const canDistress = (
-    AlertLevel >= 2 && !data.distresscd && minimumTimeElapsed);
+    AlertLevel === 2 && !data.distresscd && minimumTimeElapsed);
 
   return (
     <Window

--- a/tgui/packages/tgui/interfaces/CommandTablet.js
+++ b/tgui/packages/tgui/interfaces/CommandTablet.js
@@ -15,12 +15,25 @@ export const CommandTablet = (_props, context) => {
   const canAnnounce = (
     data.endtime < data.worldtime);
 
+  const roundends = data.roundends;
+
   const canEvac = (
     evacstatus === 0,
     AlertLevel >= 2);
 
   const canDistress = (
     AlertLevel === 2 && !data.distresscd && minimumTimeElapsed);
+
+  let distress_reason;
+  if (AlertLevel === 3) {
+    distress_reason = "Self-destruct in progress. Beacon disabled.";
+  } else if (AlertLevel !== 2) {
+    distress_reason = "Ship is not under an active emergency.";
+  } else if (!minimumTimeElapsed) {
+    distress_reason = "It's too early to launch a distress beacon.";
+  } else if (data.distresscd) {
+    distress_reason = "Beacon is currently on cooldown.";
+  }
 
   return (
     <Window
@@ -31,7 +44,7 @@ export const CommandTablet = (_props, context) => {
           <Flex height="100%" direction="column">
             <Flex.Item>
               {!canAnnounce && (
-                <Button color="bad" warning={1} fluid={1} icon="bullhorn">
+                <Button color="bad" warning={1} fluid={1} icon="ban">
                   Announcement on cooldown
                   : {Math.ceil((data.endtime - data.worldtime)/10)} secs
                 </Button>
@@ -71,16 +84,27 @@ export const CommandTablet = (_props, context) => {
                   </NoticeBox>
                 )}
                 <Flex.Item>
-                  <Button.Confirm
-                    fluid={1}
-                    color="orange"
-                    icon="phone-volume"
-                    content={"Send Distress Beacon"}
-                    confirmColor="bad"
-                    confirmContent="Confirm?"
-                    confirmIcon="question"
-                    onClick={() => act('distress')}
-                    disabled={!canDistress} />
+                  {!canDistress && (
+                    <Button
+                      disabled={1}
+                      content={"Distress Beacon disabled"}
+                      tooltip={distress_reason}
+                      fluid={1}
+                      icon="ban"
+                    />
+                  )}
+                  {canDistress && (
+                    <Button.Confirm
+                      fluid={1}
+                      color="orange"
+                      icon="phone-volume"
+                      content={"Send Distress Beacon"}
+                      confirmColor="bad"
+                      confirmContent="Confirm?"
+                      confirmIcon="question"
+                      onClick={() => act('distress')}
+                    />
+                  )}
                 </Flex.Item>
                 {evacstatus === 0 && (
                   <Flex.Item>

--- a/tgui/packages/tgui/interfaces/CommandTablet.js
+++ b/tgui/packages/tgui/interfaces/CommandTablet.js
@@ -64,10 +64,23 @@ export const CommandTablet = (_props, context) => {
                     evacuation procedures.
                   </NoticeBox>
                 )}
+                <Flex.Item>
+                  <Button.Confirm
+                    fluid={1}
+                    color="yellow"
+                    icon="phone-volume"
+                    content={"Send Distress Beacon"}
+                    confirmColor="bad"
+                    confirmContent="Confirm?"
+                    confirmIcon="question"
+                    onClick={() => act('distress')}
+                    disabled={!canEvac} />
+                </Flex.Item>
                 {evacstatus === 0 && (
                   <Flex.Item>
                     <Button.Confirm
                       fluid={1}
+                      color="yellow"
                       icon="door-open"
                       content={"Initiate Evacuation"}
                       confirmColor="bad"

--- a/tgui/packages/tgui/interfaces/CommandTablet.js
+++ b/tgui/packages/tgui/interfaces/CommandTablet.js
@@ -67,7 +67,7 @@ export const CommandTablet = (_props, context) => {
                 <Flex.Item>
                   <Button.Confirm
                     fluid={1}
-                    color="yellow"
+                    color="orange"
                     icon="phone-volume"
                     content={"Send Distress Beacon"}
                     confirmColor="bad"
@@ -80,7 +80,7 @@ export const CommandTablet = (_props, context) => {
                   <Flex.Item>
                     <Button.Confirm
                       fluid={1}
-                      color="yellow"
+                      color="orange"
                       icon="door-open"
                       content={"Initiate Evacuation"}
                       confirmColor="bad"

--- a/tgui/packages/tgui/interfaces/CommandTablet.js
+++ b/tgui/packages/tgui/interfaces/CommandTablet.js
@@ -15,6 +15,9 @@ export const CommandTablet = (_props, context) => {
   const canAnnounce = (
     data.endtime < data.worldtime);
 
+  const distressCooldown = (
+    data.worldtime < data.distresstime);
+
   const roundends = data.roundends;
 
   const canEvac = (
@@ -22,17 +25,17 @@ export const CommandTablet = (_props, context) => {
     AlertLevel >= 2);
 
   const canDistress = (
-    AlertLevel === 2 && !data.distresscd && minimumTimeElapsed);
+    AlertLevel === 2 && !distressCooldown && minimumTimeElapsed);
 
   let distress_reason;
   if (AlertLevel === 3) {
     distress_reason = "Self-destruct in progress. Beacon disabled.";
   } else if (AlertLevel !== 2) {
     distress_reason = "Ship is not under an active emergency.";
+  } else if (distressCooldown) {
+    distress_reason = "Beacon is currently on cooldown.";
   } else if (!minimumTimeElapsed) {
     distress_reason = "It's too early to launch a distress beacon.";
-  } else if (data.distresscd) {
-    distress_reason = "Beacon is currently on cooldown.";
   }
 
   return (

--- a/tgui/packages/tgui/interfaces/CommandTablet.js
+++ b/tgui/packages/tgui/interfaces/CommandTablet.js
@@ -9,12 +9,18 @@ export const CommandTablet = (_props, context) => {
 
   const AlertLevel = data.alert_level;
 
+  const minimumTimeElapsed = (
+    data.worldtime > data.distresstimelock);
+
   const canAnnounce = (
     data.endtime < data.worldtime);
 
   const canEvac = (
     evacstatus === 0,
     AlertLevel >= 2);
+
+  const canDistress = (
+    canEvac && data.distresscd && minimumTimeElapsed < data.worldtime);
 
   return (
     <Window
@@ -74,7 +80,7 @@ export const CommandTablet = (_props, context) => {
                     confirmContent="Confirm?"
                     confirmIcon="question"
                     onClick={() => act('distress')}
-                    disabled={!canEvac} />
+                    disabled={!canDistress} />
                 </Flex.Item>
                 {evacstatus === 0 && (
                   <Flex.Item>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Three different tweaks all affecting Command and general QOL (technically) stuff. Changes are listed in the CL below.

Done by popular demand. Enjoy!

## Why It's Good For The Game

In general, this PR should just make some aspects of command slightly less painful to deal with. 

- The tablet Distress Beacon allows for command to no longer have to force a CIC hold just for the sake of calling ERT, which is, in my opinion, poor practice. Should allow for commanders to have more leeway in choosing their holding position of choice, with ERT no longer being a problem.
-- Distress and evacuation buttons are now additionally highlighted in orange to give that visual separation from the normal command buttons.
-- **This touches TGUI**. It worked just fine, but this is an advisory for someone to look a little closer.
- 4 SO slots at roundstart is a no-brainer if you ask me, really; there will always be 4 squads regardless of the population and it doesn't hurt to add more manpower to the CIC, _especially_ during low-pop hours.
- XO getting a designator is just QOL. Makes them not have to forage or demand req for one. SOs and COs start with one, why not the XO?

## Changelog

:cl: nauticall
balance: The command tablet can now remotely call a Distress Beacon.
balance: All 4 Staff Officers can now spawn at round start. 5th SO slot had to be removed with this, unfortunately.
balance: Executive Officers now start with a laser designator.
/:cl:
