### PR TITLE
Fixes our rendering for 514.1587

### DIFF
--- a/code/_onclick/hud/rendering/plane_master.dm
+++ b/code/_onclick/hud/rendering/plane_master.dm
@@ -53,7 +53,6 @@
 	name = "darkness plane master"
 	plane = BLACKNESS_PLANE
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
-	color = list(null, null, null, "#0000", "#000f")
 	blend_mode = BLEND_MULTIPLY
 	appearance_flags = PLANE_MASTER | NO_CLIENT_COLOR | PIXEL_SCALE
 //byond internal end

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -13,8 +13,6 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 	"1408" = "bug preventing client display overrides from working leads to clients being able to see things/mobs they shouldn't be able to see",
 	"1428" = "bug causing right-click menus to show too many verbs that's been fixed in version 1429",
 	"1548" = "bug breaking the \"alpha\" functionality in the game, allowing clients to be able to see things/mobs they should not be able to see.",
-	"1586" = "bug breaking the display of all icons in its entirety, can't be exploited but the game is unplayable on this version.",
-	"1588" = "bug breaking the display of all icons in its entirety, can't be exploited but the game is unplayable on this version.",
 	))
 
 #define LIMITER_SIZE	5


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Ports rendering fix from https://github.com/tgstation/tgstation/pull/69778

Also removes affected blacklisted versions from the blacklist.

## Why It's Good For The Game

Bug bad

## Changelog

:cl: Morrow
fix: Ported fix for the entire screen being black on newer versions of byond
server: Removed blacklisted versions 1586 and 1588
/:cl:
