### PR TITLE
Fixes invisible defibrillator bug

### DIFF
--- a/code/game/objects/items/devices/defibrillator.dm
+++ b/code/game/objects/items/devices/defibrillator.dm
@@ -46,11 +46,11 @@
 			if(67 to INFINITY)
 				overlays += "+full"
 			if(34 to 66)
-				icon_state += "_half"
+				overlays += "+half"
 			if(3 to 33)
-				icon_state += "_low"
+				overlays += "+low"
 			if(0 to 3)
-				icon_state += "_empty"
+				overlays += "+empty"
 	else
 		overlays += "+empty"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Patches a bug where the defibrillator would turn invisible once it shifted to the yellow (<50%) level of charge and below.

## Why It's Good For The Game

With #614 came changes to defibrillator sounds as well as a change that made them properly flash empty when they were, well, empty. #739 came after the audio update was made and changed overlays, breaking the code in the former. When the former was merged it overrode 739's changes and, well, that's where we are now. This PR fixes this whole paper trail and makes defibs properly visible again.

Closes #1104 

Rejoice!

## Changelog

:cl:
fix: Patches a bug where the defibrillator would turn invisible once it shifted to the yellow (<50%) level of charge and below.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
