### PR TITLE
Fixes ABR fire delay

### DIFF
--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -1273,7 +1273,7 @@
 	wield_delay = WIELD_DELAY_FAST
 	starting_attachment_types = list(/obj/item/attachable/stock/carbine/wood/drill)
 	map_specific_decoration = FALSE
-	
+
 /obj/item/weapon/gun/rifle/l42a/abr40/set_gun_config_values()
 	..()
 	fire_delay = FIRE_DELAY_TIER_7

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -1273,8 +1273,10 @@
 	wield_delay = WIELD_DELAY_FAST
 	starting_attachment_types = list(/obj/item/attachable/stock/carbine/wood/drill)
 	map_specific_decoration = FALSE
-
-
+	
+/obj/item/weapon/gun/rifle/l42a/abr40/set_gun_config_values()
+	..()
+	fire_delay = FIRE_DELAY_TIER_7
 
 // Essentially L42 Custom, though more of a sidegrade due to 0 attachments, higher weild delay and the fact that you have to find better magazines.
 /obj/item/weapon/gun/rifle/l42a/abr40/drill

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -1274,9 +1274,6 @@
 	starting_attachment_types = list(/obj/item/attachable/stock/carbine/wood/drill)
 	map_specific_decoration = FALSE
 
-/obj/item/weapon/gun/rifle/l42a/abr40/set_gun_config_values()
-	..()
-	fire_delay = FIRE_DELAY_TIER_7
 
 
 // Essentially L42 Custom, though more of a sidegrade due to 0 attachments, higher weild delay and the fact that you have to find better magazines.
@@ -1289,9 +1286,6 @@
 						/obj/item/attachable/bayonet/c02
 						)
 
-/obj/item/weapon/gun/rifle/l42a/abr40/drill/set_gun_config_values()
-	..()
-	fire_delay = FIRE_DELAY_TIER_9 // Polished parts
 
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Turns out giving the ceremonial rifle that takes regular l42 ammo fire delay that's drastically lower than the base gun is not a great idea. Especially if the drill variant has a fire delay effectively 3 times lower of its normal counterpart.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bugged OP guns bad.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:Silencer_pl
fix: Fixed fire delay values for the ABR rifle that made them fire several times faster than intended.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
