### PR TITLE
Fix for doubling APCs.

### DIFF
--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -1175,13 +1175,13 @@ var/datum/controller/supply/supply_controller = new()
 		if(!VO) return
 		if(VO.has_vehicle_lock()) return
 
+		spent = TRUE
 		ordered_vehicle = new VO.ordered_vehicle(middle_turf)
 		SSshuttle.vehicle_elevator.request(SSshuttle.getDock("almayer vehicle"))
 
 		VO.on_created(ordered_vehicle)
 
 		SEND_GLOBAL_SIGNAL(COMSIG_GLOB_VEHICLE_ORDERED, ordered_vehicle)
-		spent = TRUE
 
 	add_fingerprint(usr)
 	updateUsrDialog()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

I do not know what dark sorcery is happening there. Timing issue, probably: spawning the interior map takes a short while, during which frantic clicking at the "vend APC" button can call the `Topic()` again and begin spawning the second APC. Moving the assignment of `spent` to before the APC starts spawning should close the window of opportunity during which it is already spawning, but the console is not yet expended and can start spawning another.

## Why It's Good For The Game

Closes #1100.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: APCs should no longer spawn in doubles.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
