### PR TITLE
Fix for lobby spam.

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -359,7 +359,7 @@ cases. Override_icon_state should be a list.*/
 // slot uses the slot_X defines found in setup.dm
 // for items that can be placed in multiple slots
 // note this isn't called during the initial dressing of a player
-/obj/item/proc/equipped(mob/user, slot)
+/obj/item/proc/equipped(mob/user, slot, silent)
 	SHOULD_CALL_PARENT(TRUE)
 
 	SEND_SIGNAL(src, COMSIG_ITEM_EQUIPPED, user, slot)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -314,11 +314,11 @@ cases. Override_icon_state should be a list.*/
 	appearance_flags &= ~NO_CLIENT_COLOR //So saturation/desaturation etc. effects affect it.
 
 // called just as an item is picked up (loc is not yet changed)
-/obj/item/proc/pickup(mob/user)
+/obj/item/proc/pickup(mob/user, silent)
 	SHOULD_CALL_PARENT(TRUE)
 	SEND_SIGNAL(src, COMSIG_ITEM_PICKUP, user)
 	setDir(SOUTH)//Always rotate it south. This resets it to default position, so you wouldn't be putting things on backwards
-	if((pickupsound) && src.loc.z)
+	if(pickupsound && !silent && src.loc?.z)
 		playsound(src, pickupsound, pickupvol, pickup_vary)
 
 // called when this item is removed from a storage item, which is passed on as S. The loc variable is already set to the new destination before this is called.

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -39,10 +39,10 @@
 			to_chat(H, SPAN_NOTICE("The ID lock rejects your ID"))
 	update_icon()
 
-/obj/item/storage/backpack/equipped(mob/user, slot)
+/obj/item/storage/backpack/equipped(mob/user, slot, silent)
 	if(slot == WEAR_BACK)
 		mouse_opacity = 2 //so it's easier to click when properly equipped.
-		if(use_sound)
+		if(use_sound && !silent)
 			playsound(loc, use_sound, 15, TRUE, 6)
 		if(!worn_accessible) //closes it if it's open.
 			storage_close(user)

--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -469,7 +469,7 @@ W is always an item. stop_warning prevents messaging. user may be null.**/
 		add_fingerprint(user)
 		if(!prevent_warning)
 			var/visidist = W.w_class >= 3 ? 3 : 1
-			user.visible_message(SPAN_NOTICE("[usr] puts [W] into [src]."),\
+			user.visible_message(SPAN_NOTICE("[user] puts [W] into [src]."),\
 								SPAN_NOTICE("You put \the [W] into [src]."),\
 								null, visidist)
 	orient2hud()

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -366,9 +366,9 @@
 				desc = initial(desc) + "\nIt is storing \a [stored_item]."
 				break
 
-/obj/item/clothing/equipped(mob/user, slot)
+/obj/item/clothing/equipped(mob/user, slot, silent)
 	if(slot != WEAR_L_HAND && slot != WEAR_R_HAND && slot != WEAR_L_STORE && slot != WEAR_R_STORE  && slot != WEAR_J_STORE) //is it going to an actual clothing slot rather than a pocket, hand, or backpack?
-		if(LAZYLEN(equip_sounds))
+		if(!silent && LAZYLEN(equip_sounds))
 			playsound_client(user.client, pick(equip_sounds), null, ITEM_EQUIP_VOLUME)
 		if(clothing_traits_active)
 			for(var/trait in clothing_traits)

--- a/code/modules/gear_presets/_select_equipment.dm
+++ b/code/modules/gear_presets/_select_equipment.dm
@@ -213,7 +213,7 @@
 			else if(H.w_uniform && H.w_uniform.can_attach_accessory(medal))
 				H.w_uniform.attach_accessory(H, medal)
 			else
-				if(!H.equip_to_slot_if_possible(medal, WEAR_IN_BACK))
+				if(!H.equip_to_slot_if_possible(medal, WEAR_IN_BACK, disable_warning = TRUE))
 					if(!H.equip_to_slot_if_possible(medal, WEAR_L_HAND))
 						if(!H.equip_to_slot_if_possible(medal, WEAR_R_HAND))
 							medal.forceMove(H.loc)

--- a/code/modules/gear_presets/_select_equipment.dm
+++ b/code/modules/gear_presets/_select_equipment.dm
@@ -180,9 +180,9 @@
 		if(rankpath)
 			var/obj/item/clothing/accessory/ranks/R = new rankpath()
 			if(H.wear_suit && H.wear_suit.can_attach_accessory(R))
-				H.wear_suit.attach_accessory(H, R)
+				H.wear_suit.attach_accessory(H, R, TRUE)
 			else if(H.w_uniform && H.w_uniform.can_attach_accessory(R))
-				H.w_uniform.attach_accessory(H, R)
+				H.w_uniform.attach_accessory(H, R, TRUE)
 			else
 				qdel(R)
 
@@ -209,9 +209,9 @@
 			medal.recipient_rank = current_rank
 
 			if(H.wear_suit && H.wear_suit.can_attach_accessory(medal))
-				H.wear_suit.attach_accessory(H, medal)
+				H.wear_suit.attach_accessory(H, medal, TRUE)
 			else if(H.w_uniform && H.w_uniform.can_attach_accessory(medal))
-				H.w_uniform.attach_accessory(H, medal)
+				H.w_uniform.attach_accessory(H, medal, TRUE)
 			else
 				if(!H.equip_to_slot_if_possible(medal, WEAR_IN_BACK, disable_warning = TRUE))
 					if(!H.equip_to_slot_if_possible(medal, WEAR_L_HAND))

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -240,11 +240,11 @@
 	switch(slot)
 		if(WEAR_BACK)
 			back = W
-			W.equipped(src, slot)
+			W.equipped(src, slot, disable_warning)
 			update_inv_back()
 		if(WEAR_FACE)
 			wear_mask = W
-			W.equipped(src, slot)
+			W.equipped(src, slot, disable_warning)
 			sec_hud_set_ID()
 			wear_mask_update(W, TRUE)
 			update_inv_wear_mask()
@@ -253,44 +253,44 @@
 			handcuff_update()
 		if(WEAR_LEGCUFFS)
 			legcuffed = W
-			W.equipped(src, slot)
+			W.equipped(src, slot, disable_warning)
 			legcuff_update()
 		if(WEAR_L_HAND)
 			l_hand = W
-			W.equipped(src, slot)
+			W.equipped(src, slot, disable_warning)
 			update_inv_l_hand()
 		if(WEAR_R_HAND)
 			r_hand = W
-			W.equipped(src, slot)
+			W.equipped(src, slot, disable_warning)
 			update_inv_r_hand()
 		if(WEAR_WAIST)
 			belt = W
-			W.equipped(src, slot)
+			W.equipped(src, slot, disable_warning)
 			update_inv_belt()
 		if(WEAR_ID)
 			wear_id = W
-			W.equipped(src, slot)
+			W.equipped(src, slot, disable_warning)
 			sec_hud_set_ID()
 			hud_set_squad()
 			update_inv_wear_id()
 			name = get_visible_name()
 		if(WEAR_L_EAR)
 			wear_l_ear = W
-			W.equipped(src, slot)
+			W.equipped(src, slot, disable_warning)
 			update_inv_ears()
 		if(WEAR_R_EAR)
 			wear_r_ear = W
-			W.equipped(src, slot)
+			W.equipped(src, slot, disable_warning)
 			update_inv_ears()
 		if(WEAR_EYES)
 			glasses = W
-			W.equipped(src, slot)
+			W.equipped(src, slot, disable_warning)
 			update_tint()
 			update_glass_vision(W)
 			update_inv_glasses()
 		if(WEAR_HANDS)
 			gloves = W
-			W.equipped(src, slot)
+			W.equipped(src, slot, disable_warning)
 			update_inv_gloves()
 		if(WEAR_HEAD)
 			head = W
@@ -304,12 +304,12 @@
 				update_inv_wear_mask()
 			if(head.flags_inv_hide & HIDEEYES)
 				update_inv_glasses()
-			W.equipped(src, slot)
+			W.equipped(src, slot, disable_warning)
 			update_tint()
 			update_inv_head()
 		if(WEAR_FEET)
 			shoes = W
-			W.equipped(src, slot)
+			W.equipped(src, slot, disable_warning)
 			update_inv_shoes()
 		if(WEAR_JACKET)
 			wear_suit = W
@@ -319,20 +319,20 @@
 				update_inv_w_uniform()
 			if( wear_suit.flags_inv_hide & (HIDEALLHAIR|HIDETOPHAIR|HIDELOWHAIR) )
 				update_hair()
-			W.equipped(src, slot)
+			W.equipped(src, slot, disable_warning)
 			update_inv_wear_suit()
 		if(WEAR_BODY)
 			w_uniform = W
-			W.equipped(src, slot)
+			W.equipped(src, slot, disable_warning)
 			update_suit_sensors()
 			update_inv_w_uniform()
 		if(WEAR_L_STORE)
 			l_store = W
-			W.equipped(src, slot)
+			W.equipped(src, slot, disable_warning)
 			update_inv_pockets()
 		if(WEAR_R_STORE)
 			r_store = W
-			W.equipped(src, slot)
+			W.equipped(src, slot, disable_warning)
 			update_inv_pockets()
 		if(WEAR_ACCESSORY)
 			var/obj/item/clothing/accessory/A = W
@@ -344,7 +344,7 @@
 			update_inv_wear_suit()
 		if(WEAR_J_STORE)
 			s_store = W
-			W.equipped(src, slot)
+			W.equipped(src, slot, disable_warning)
 			update_inv_s_store()
 		if(WEAR_IN_BACK)
 			var/obj/item/storage/S = back

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -205,7 +205,7 @@
 
 //This is an UNSAFE proc. Use mob_can_equip() before calling this one! Or rather use equip_to_slot_if_possible() or advanced_equip_to_slot_if_possible()
 //set redraw_mob to 0 if you don't wish the hud to be updated - if you're doing it manually in your own proc.
-/mob/living/carbon/human/equip_to_slot(obj/item/W as obj, slot)
+/mob/living/carbon/human/equip_to_slot(obj/item/W as obj, slot, disable_warning)
 	if(!slot) return
 	if(!istype(W)) return
 	if(!has_limb_for_slot(slot)) return
@@ -348,25 +348,25 @@
 			update_inv_s_store()
 		if(WEAR_IN_BACK)
 			var/obj/item/storage/S = back
-			S.attempt_item_insertion(W, FALSE, src)
+			S.attempt_item_insertion(W, disable_warning, src)
 			back.update_icon()
 		if(WEAR_IN_SHOES)
 			shoes.attackby(W,src)
 			shoes.update_icon()
 		if(WEAR_IN_SCABBARD)
 			var/obj/item/storage/S = back
-			S.attempt_item_insertion(W, FALSE, src)
+			S.attempt_item_insertion(W, disable_warning, src)
 			back.update_icon()
 		if(WEAR_IN_JACKET)
 			var/obj/item/clothing/suit/storage/S = wear_suit
 			if(istype(S) && S.pockets.storage_slots)
-				S.pockets.attempt_item_insertion(W, FALSE, src)
+				S.pockets.attempt_item_insertion(W, disable_warning, src)
 				wear_suit.update_icon()
 
 		if(WEAR_IN_HELMET)
 			var/obj/item/clothing/head/helmet/marine/HM = src.head
 			if(istype(HM) && HM.pockets.storage_slots)
-				HM.pockets.attempt_item_insertion(W, FALSE, src)
+				HM.pockets.attempt_item_insertion(W, disable_warning, src)
 				HM.update_icon()
 
 		if(WEAR_IN_ACCESSORY)
@@ -382,19 +382,19 @@
 
 		if(WEAR_IN_BELT)
 			var/obj/item/storage/S = belt
-			S.attempt_item_insertion(W, FALSE, src)
+			S.attempt_item_insertion(W, disable_warning, src)
 			belt.update_icon()
 		if(WEAR_IN_J_STORE)
 			var/obj/item/storage/S = s_store
-			S.attempt_item_insertion(W, FALSE, src)
+			S.attempt_item_insertion(W, disable_warning, src)
 			s_store.update_icon()
 		if(WEAR_IN_L_STORE)
 			var/obj/item/storage/S = l_store
-			S.attempt_item_insertion(W, FALSE, src)
+			S.attempt_item_insertion(W, disable_warning, src)
 			l_store.update_icon()
 		if(WEAR_IN_R_STORE)
 			var/obj/item/storage/S = r_store
-			S.attempt_item_insertion(W, FALSE, src)
+			S.attempt_item_insertion(W, disable_warning, src)
 			r_store.update_icon()
 
 		else

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -232,7 +232,7 @@
 
 	W.screen_loc = null
 	if(W.loc != src)
-		W.pickup(src)
+		W.pickup(src, disable_warning)
 	W.forceMove(src)
 	W.layer = ABOVE_HUD_LAYER
 	W.plane = ABOVE_HUD_PLANE

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -241,7 +241,7 @@
 		INVOKE_ASYNC(src, .proc/equip_to_slot_timed, W, slot, redraw_mob, permanent, start_loc, del_on_fail, disable_warning)
 		return TRUE
 
-	equip_to_slot(W, slot) //This proc should not ever fail.
+	equip_to_slot(W, slot, disable_warning) //This proc should not ever fail.
 	if(permanent)
 		W.flags_inventory |= CANTSTRIP
 		W.flags_item |= NODROP
@@ -277,7 +277,7 @@
 
 //This is an UNSAFE proc. It merely handles the actual job of equipping. All the checks on whether you can or can't eqip need to be done before! Use mob_can_equip() for that task.
 //In most cases you will want to use equip_to_slot_if_possible()
-/mob/proc/equip_to_slot(obj/item/W as obj, slot)
+/mob/proc/equip_to_slot(obj/item/W as obj, slot, disable_warning = FALSE)
 	return
 
 //This is just a commonly used configuration for the equip_to_slot_if_possible() proc, used to equip people when the rounds tarts and when events happen and such.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

I still have no idea since when spawning new players has had its messages moved to the lobby screen, but that spam is both annoying and leaking ckeys. And creating mobs with gear presets results in such a massive spam that ERT members have to scroll up to even find their objectives (which they probably never do).
`equip_to_slot_or_del()` is _supposed_ to make use of `disable_warning`, but somehow it has never been passed all the way down the calls. Fixed, and added a few more silencing variables everywhere around. Also fixed a runtime involving pickup sounds for things being picked up from nonexistent loc (because they are being spawned along with the mobs).

## Why It's Good For The Game

Closes #1142.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Spawning humans no longer spam messages and sounds for being equipped.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
