### PR TITLE
Unloading with underbarrels.

### DIFF
--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -212,8 +212,9 @@ Defined in conflicts.dm of the #defines folder.
 /obj/item/attachable/proc/unique_action(mob/user)
 	return
 
+///Returns TRUE if its functionality is successfully used, FALSE if gun's own unloading should proceed instead.
 /obj/item/attachable/proc/unload_attachment(mob/user, reload_override = 0, drop_override = 0, loc_override = 0)
-	return
+	return FALSE
 
 /obj/item/attachable/proc/fire_attachment(atom/target, obj/item/weapon/gun/gun, mob/user) //For actually shooting those guns.
 	SHOULD_CALL_PARENT(TRUE)
@@ -1877,6 +1878,7 @@ Defined in conflicts.dm of the #defines folder.
 			user.drop_inv_item_to_loc(G, src)
 
 /obj/item/attachable/attached_gun/grenade/unload_attachment(mob/user, reload_override = FALSE, drop_override = FALSE, loc_override = FALSE)
+	. = TRUE //Always uses special unloading.
 	if(!breech_open)
 		to_chat(user, SPAN_WARNING("\The [src] is closed! You must open it to take out grenades!"))
 		return

--- a/code/modules/projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/gun_helpers.dm
@@ -125,8 +125,8 @@ DEFINES in setup.dm, referenced here.
 
 	if(in_hand == src && (flags_item & TWOHANDED))
 		if(active_attachable)
-			active_attachable.unload_attachment(user)
-			return
+			if(active_attachable.unload_attachment(user))
+				return
 		unload(user)//It has to be held if it's a two hander.
 		return
 	else
@@ -746,8 +746,8 @@ As sniper rifles have both and weapon mods can change them as well. ..() deals w
 		if(user.client && user.client.prefs && user.client.prefs.toggle_prefs & TOGGLE_EJECT_MAGAZINE_TO_HAND)
 			drop_to_ground = FALSE
 			unwield(user)
-		G.active_attachable.unload_attachment(usr, FALSE, drop_to_ground)
-		return
+		if(G.active_attachable.unload_attachment(usr, FALSE, drop_to_ground))
+			return
 
 	//unloading a regular gun
 	var/drop_to_ground = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Is QOL. Underbarrel flamers cannot be unloaded at all, shotguns do not really need unloading functionality when they can only take one type of shells anyway and nozzles are actively fed with main flamer's tank, so they actually need to have the tank unloaded and refilled to "reload" the attachment itself, so it is only good to not need to turn them off.

## Why It's Good For The Game

Closes #1072.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Underbarrel weapon (masterkey, flamer nozzle etc) being active no longer prevents unloading the main gun itself unless the attachment has its own unloading functionality (as underbarrel grenade launchers do).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
