### PR TITLE
Fixes dropship attachment point layering

### DIFF
--- a/code/modules/dropships/attach_points/attach_point.dm
+++ b/code/modules/dropships/attach_points/attach_point.dm
@@ -6,7 +6,7 @@
 	icon_state = "equip_base"
 	unacidable = TRUE
 	anchored = TRUE
-
+	layer = ABOVE_TURF_LAYER
 	/// The currently installed equipment, if any
 	var/obj/structure/dropship_equipment/installed_equipment
 	/// What kind of equipment this base accepts


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Attachment points on dropship lack any sort of layering var, which is an oversight as it allows for objects and mobs to be hidden under it

This is notably abused by dropship rushers to near completely hide their sprite, letting them get away in what should be plain view to everyone around as it is a FLOOR mounted attachment point. This fixes it by making it the above turf layer so not even the hide verb can obscure them.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes an oversight & cheese.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:totalepicness
fix: Fixes crew compartment attachment points being able to hide objects and mobs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
