### PR TITLE
Chair-Stacking Message Typo Fix

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -81,7 +81,7 @@
 		if(I.flags_item & WIELDED)
 			return ..()
 		if(locate(/mob/living) in loc)
-			to_chat(user, SPAN_NOTICE("There's someone is in the way!"))
+			to_chat(user, SPAN_NOTICE("There's someone in the way!"))
 			return FALSE
 		user.drop_inv_item_to_loc(I, src)
 		stacked_size++


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

This fixes a typo in the message someone gets when trying to stack a metal chair onto another metal chair but someone is in the way.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Typo fix.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Laser9
spellcheck: Fixed typo in message for when someone is in the way of chair-stacking.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
