### PR TITLE
Revert bludgeon flag changes

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -128,9 +128,6 @@
 	if(flags_item & ITEM_PREDATOR)
 		AddElement(/datum/element/yautja_tracked_item)
 
-	if(!force) 
-		flags_item |= NOBLUDGEON
-
 /obj/item/Destroy()
 	flags_item &= ~DELONDROP //to avoid infinite loop of unequip, delete, unequip, delete.
 	flags_item &= ~NODROP //so the item is properly unequipped if on a mob.

--- a/code/game/objects/items/tools/surgery_tools.dm
+++ b/code/game/objects/items/tools/surgery_tools.dm
@@ -237,7 +237,6 @@
 
 /obj/item/tool/surgery/surgical_line/Initialize(mapload, ...)
 	. = ..()
-	flags_item &= ~NOBLUDGEON
 	AddElement(/datum/element/suturing, TRUE, FALSE, 2.5, "suture", "suturing", "being stabbed with needles", "wounds")
 
 /*
@@ -257,7 +256,6 @@
 
 /obj/item/tool/surgery/synthgraft/Initialize(mapload, ...)
 	. = ..()
-	flags_item &= ~NOBLUDGEON
 	AddElement(/datum/element/suturing, FALSE, TRUE, 2.5, "graft", "grafting", "being burnt away all over again", "burns")
 
 /*


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

This reverts commits bd8c0af3d9691751ce0b310adcc0473dd2fd94dc and 1e2e7d39ff81b4b6afc8090b33d9c7ed9a97aac9.

PR #1129 has broken the attack functionality for all 0-force objects. It makes it no longer possible to do things like honk people with the rubber ducky or challenge people with gloves. There are likely several other 0-force items with custom attack verbs that are now useless. This PR reverts the offending change.

PR #1150 was a fix for behavior introduced by #1129, therefore reverting #1129 would also mean #1150 should be reverted.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

PR #1129 may have fixed a bug in a very specific situation (0-force item, attack on self, harm intent, and specific preference set), but it has totally removed general functionality from other items. A different fix should be made to fix the bug #1129 was addressing.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Laser9
fix: Attacks with force 0 objects work again (e.g. honking someone with a bike horn or challenging them with gloves).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
