### PR TITLE
adds 1 hour human roles timelock to nurse

### DIFF
--- a/code/game/jobs/job/civilians/support/nurse.dm
+++ b/code/game/jobs/job/civilians/support/nurse.dm
@@ -11,3 +11,7 @@
 /obj/effect/landmark/start/nurse
 	name = JOB_NURSE
 	job = /datum/job/civilian/nurse
+
+AddTimelock(/datum/job/civilian/nurse, list(
+	JOB_HUMAN_ROLES = 1 HOURS
+))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

adds a 1hr human roles timelock to nurse

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

nurse has _somewhat_ higher responsibilities than a PFC or MT and should require at least a tiny tiny bit of game knowledge before you play it!

also it is mentioned NOWHERE in quickstart etc and is pretty hard for new players to learn

another reason to add this is that nurse is also very easy for multikeyers to grief with so this should stop them a bit

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
code: nurse now has a one hour human roles timelock
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
