### PR TITLE
fixes uniform vendor shutters being breakable

### DIFF
--- a/code/game/machinery/doors/shutters.dm
+++ b/code/game/machinery/doors/shutters.dm
@@ -128,10 +128,10 @@
 	unacidable = TRUE
 	unslashable = TRUE
 
-	ex_act(severity)
+/obj/structure/machinery/door/poddoor/shutters/almayer/uniform_vendors/ex_act(severity)
 		return
 
-/obj/structure/machinery/door/poddoor/shutters/almayer/uniform_vendors/attackby(obj/item/C as obj, mob/user as mob)
-	if(HAS_TRAIT(C, TRAIT_TOOL_CROWBAR))
+/obj/structure/machinery/door/poddoor/shutters/almayer/uniform_vendors/attackby(obj/item/attacking_item, mob/user)
+	if(HAS_TRAIT(attacking_item, TRAIT_TOOL_CROWBAR))
 		return
 	..()

--- a/code/game/machinery/doors/shutters.dm
+++ b/code/game/machinery/doors/shutters.dm
@@ -121,3 +121,17 @@
 	closed_layer = PODDOOR_CLOSED_LAYER
 	ex_act(severity)
 		return
+
+/obj/structure/machinery/door/poddoor/shutters/almayer/uniform_vendors
+	name = "\improper Uniform Vendor Shutters"
+	id = "bot_uniforms"
+	unacidable = TRUE
+	unslashable = TRUE
+
+	ex_act(severity)
+		return
+
+/obj/structure/machinery/door/poddoor/shutters/almayer/uniform_vendors/attackby(obj/item/C as obj, mob/user as mob)
+	if(HAS_TRAIT(C, TRAIT_TOOL_CROWBAR))
+		return
+	..()

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -9834,11 +9834,6 @@
 	},
 /area/almayer/command/cic)
 "aAl" = (
-/obj/structure/machinery/door/poddoor/almayer/open{
-	dir = 4;
-	id = "CIC Lockdown";
-	name = "\improper Combat Information Center Blast Door"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -9848,7 +9843,13 @@
 	tag = "icon-intact-supply (EAST)"
 	},
 /obj/structure/machinery/door/airlock/almayer/command/reinforced{
-	name = "\improper Combat Information Center"
+	name = "\improper Combat Information Center";
+	id = "cic_exterior"
+	},
+/obj/structure/machinery/door/poddoor/almayer/open{
+	dir = 4;
+	id = "CIC Lockdown";
+	name = "\improper Combat Information Center Blast Door"
 	},
 /turf/open/floor/almayer{
 	icon_state = "plate";
@@ -36767,6 +36768,26 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/living/chapel)
+"dum" = (
+/obj/structure/machinery/door/firedoor/border_only/almayer,
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4;
+	tag = "icon-intact-supply (EAST)"
+	},
+/obj/structure/machinery/door/airlock/almayer/command/reinforced{
+	name = "\improper Combat Information Center";
+	id = "cic_exterior"
+	},
+/obj/structure/machinery/door/poddoor/almayer/open{
+	dir = 4;
+	id = "CIC Lockdown";
+	name = "\improper Combat Information Center Blast Door"
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate";
+	tag = "icon-sterile"
+	},
+/area/almayer/command/cic)
 "duo" = (
 /obj/structure/machinery/power/apc/almayer{
 	dir = 8
@@ -107571,7 +107592,7 @@ wVW
 wVW
 aAl
 jnX
-hzL
+dum
 wVW
 wVW
 wVW

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -36112,11 +36112,7 @@
 	},
 /area/almayer/living/briefing)
 "dhU" = (
-/obj/structure/machinery/door/poddoor/shutters/almayer{
-	dir = 2;
-	id = "bot_uniforms";
-	name = "\improper Uniform Vendor Shutters"
-	},
+/obj/structure/machinery/door/poddoor/shutters/almayer/uniform_vendors,
 /turf/open/floor/almayer{
 	icon_state = "plate";
 	tag = "icon-sterile"
@@ -61525,11 +61521,7 @@
 	},
 /area/almayer/squads/delta)
 "oqA" = (
-/obj/structure/machinery/door/poddoor/shutters/almayer{
-	dir = 2;
-	id = "bot_uniforms";
-	name = "\improper Uniform Vendor Shutters"
-	},
+/obj/structure/machinery/door/poddoor/shutters/almayer/uniform_vendors,
 /turf/open/floor/almayer{
 	dir = 1;
 	icon_state = "cargo_arrow"
@@ -78015,10 +78007,8 @@
 	},
 /area/almayer/hallways/repair_bay)
 "vwV" = (
-/obj/structure/machinery/door/poddoor/shutters/almayer{
-	dir = 4;
-	id = "bot_uniforms";
-	name = "\improper Uniform Vendor Shutters"
+/obj/structure/machinery/door/poddoor/shutters/almayer/uniform_vendors{
+	dir = 4
 	},
 /turf/open/floor/almayer{
 	icon_state = "plate";


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

These shutters are meant to be unbreachable, alongside the heavy r-walls around the vendors.

also closes #1253 

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

stops marines from accessing the larp vendors without the button being pressed

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fixed an oversight with uniform vendor shutters that was allowing marines to break into them
fix: fixed the cic doors release button
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
