### PR TITLE
Muted Armor Stripes

### DIFF
--- a/code/modules/clothing/suits/marine_armor.dm
+++ b/code/modules/clothing/suits/marine_armor.dm
@@ -39,25 +39,29 @@ var/list/squad_colors_chat = list(rgb(230,125,125), rgb(255,230,80), rgb(255,150
 /proc/initialize_marine_armor()
 	var/i
 	for(i=1, i<(length(squad_colors) + 1), i++)
+		var/squad_color = squad_colors[i]
+		var/armor_color = rgb(hex2num(copytext(squad_color, 2, 4)), hex2num(copytext(squad_color, 4, 6)), hex2num(copytext(squad_color, 6, 8)), 125)
+
 		var/image/armor
 		var/image/helmet
 		var/image/glove
+
 		armor = image('icons/mob/humans/onmob/suit_1.dmi',icon_state = "std-armor")
-		armor.color = squad_colors[i]
+		armor.color = armor_color
 		armormarkings += armor
 		armor = image('icons/mob/humans/onmob/suit_1.dmi',icon_state = "sql-armor")
-		armor.color = squad_colors[i]
+		armor.color = armor_color
 		armormarkings_sql += armor
 
 		helmet = image('icons/mob/humans/onmob/head_1.dmi',icon_state = "std-helmet")
-		helmet.color = squad_colors[i]
+		helmet.color = armor_color
 		helmetmarkings += helmet
 		helmet = image('icons/mob/humans/onmob/head_1.dmi',icon_state = "sql-helmet")
-		helmet.color = squad_colors[i]
+		helmet.color = armor_color
 		helmetmarkings_sql += helmet
 
 		glove = image('icons/mob/humans/onmob/hands_garb.dmi',icon_state = "std-gloves")
-		glove.color = squad_colors[i]
+		glove.color = armor_color
 		glovemarkings += glove
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Reduces the alpha value of squad colors applied to armor to 125 (down from max, 255), to give it a more muted look.

Before:
![image](https://user-images.githubusercontent.com/22774890/194599854-475a05b4-5c6d-4a18-8fc3-59e7cc3b5140.png)

After:
![image](https://user-images.githubusercontent.com/22774890/194599880-d5356aca-ea81-480b-8596-3a37a95a9d33.png)

Before:
![image](https://user-images.githubusercontent.com/22774890/194600000-64d7f2b4-b56a-40fc-a679-bc6d71c90945.png)

After:
![image](https://user-images.githubusercontent.com/22774890/194600035-17638305-43e7-4613-ad48-c29aa3a4467e.png)

Before:
![image](https://user-images.githubusercontent.com/22774890/194600072-32cf0284-8fdf-4da1-b911-e5da4372705f.png)

After:
![image](https://user-images.githubusercontent.com/22774890/194600100-87538060-b60c-42ff-b389-e615d8e90802.png)


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Looks cooler and also more immersive when the color is subdued rather than neon.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Made armor color sprites more muted.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
