### PR TITLE
XM88 buff

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1443,10 +1443,6 @@
 	accurate_range = 14
 	handful_state = "boomslang_bullet"
 
-/// unused
-/datum/ammo/bullet/lever_action/xm88/pen10
-	penetration = ARMOR_PENETRATION_TIER_2
-
 /datum/ammo/bullet/lever_action/xm88/pen20
 	penetration = ARMOR_PENETRATION_TIER_4
 

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1437,12 +1437,13 @@
 	name = ".458 SOCOM round"
 
 	damage = 80
-	penetration = 0
+	penetration = ARMOR_PENETRATION_TIER_2
 	accuracy = HIT_ACCURACY_TIER_1
 	shell_speed = AMMO_SPEED_TIER_6
 	accurate_range = 14
 	handful_state = "boomslang_bullet"
 
+/// unused
 /datum/ammo/bullet/lever_action/xm88/pen10
 	penetration = ARMOR_PENETRATION_TIER_2
 
@@ -1454,6 +1455,9 @@
 
 /datum/ammo/bullet/lever_action/xm88/pen40
 	penetration = ARMOR_PENETRATION_TIER_8
+
+/datum/ammo/bullet/lever_action/xm88/pen50
+	penetration = ARMOR_PENETRATION_TIER_10
 
 /*
 //======

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -1161,7 +1161,7 @@ Defined in conflicts.dm of the #defines folder.
 	name = "\improper XM88 padded stock"
 	desc = "A specially made compound polymer stock reinforced with aluminum rods and thick rubber padding to shield the user from recoil. Fitted specifically for the XM88 Heavy Rifle."
 	icon_state = "boomslang-stock"
-	wield_delay_mod = WIELD_DELAY_SLOW
+	wield_delay_mod = WIELD_DELAY_NORMAL
 	hud_offset_mod = 6
 
 /obj/item/attachable/stock/xm88/New()

--- a/code/modules/projectiles/guns/lever_action.dm
+++ b/code/modules/projectiles/guns/lever_action.dm
@@ -439,13 +439,13 @@ their unique feature is that a direct hit will buff your damage and firerate
 		var/obj/item/projectile/P = in_chamber
 		switch(floating_penetration)
 			if(FLOATING_PENETRATION_TIER_1)
-				P.ammo = GLOB.ammo_list[/datum/ammo/bullet/lever_action/xm88/pen10]
-			if(FLOATING_PENETRATION_TIER_2)
 				P.ammo = GLOB.ammo_list[/datum/ammo/bullet/lever_action/xm88/pen20]
-			if(FLOATING_PENETRATION_TIER_3)
+			if(FLOATING_PENETRATION_TIER_2)
 				P.ammo = GLOB.ammo_list[/datum/ammo/bullet/lever_action/xm88/pen30]
-			if(FLOATING_PENETRATION_TIER_4)
+			if(FLOATING_PENETRATION_TIER_3)
 				P.ammo = GLOB.ammo_list[/datum/ammo/bullet/lever_action/xm88/pen40]
+			if(FLOATING_PENETRATION_TIER_4)
+				P.ammo = GLOB.ammo_list[/datum/ammo/bullet/lever_action/xm88/pen50]
 	return ..()
 
 /obj/item/weapon/gun/lever_action/xm88/unload(mob/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

The XM has been underperforming when compared to similar AP dealing weapons like the mod 88 and L42 with AP ammo so this PR seeks to make it a bit better. It'll be better at chasing, making it on a similar level to the L42, and it will have a bit of inherent AP so it'll hit a bit harder when starting its streak.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Makes a somewhat weak kit gun more viable and competitive

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: reduced the XM88 stock slowdown a bit
balance: gave XM88 10 ap ammo by default
balance: shifted the XM88 stack ap tiers up by 10 each to compensate for this
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
