### PR TITLE
Fixes Fiorina repair panel nightmare areas

### DIFF
--- a/maps/map_files/FOP_v3_Sciannex/sprinkles/30.repairpanelslz.dmm
+++ b/maps/map_files/FOP_v3_Sciannex/sprinkles/30.repairpanelslz.dmm
@@ -5,13 +5,13 @@
 	},
 /obj/item/stack/sheet/metal,
 /turf/open/space,
-/area/space)
+/area/fiorina/oob)
 "b" = (
 /obj/item/stock_parts/subspace/filter{
 	pixel_y = 6
 	},
 /turf/open/space,
-/area/space)
+/area/fiorina/oob)
 "c" = (
 /obj/structure/cargo_container{
 	desc = "A huge industrial shipping container. This one is in space.";
@@ -19,24 +19,24 @@
 	tag = "icon-red 0,0"
 	},
 /turf/open/space,
-/area/space)
+/area/fiorina/oob)
 "d" = (
 /obj/item/clothing/head/helmet/space{
 	pixel_x = -7;
 	pixel_y = -8
 	},
 /turf/open/space/basic,
-/area/space)
+/area/fiorina/oob)
 "e" = (
 /turf/open/floor/prison{
 	icon_state = "floor_plate";
 	tag = "icon-floor_plate"
 	},
-/area/space)
+/area/fiorina/lz/near_lzI)
 "f" = (
 /obj/item/stack/sandbags_empty/half,
 /turf/open/floor/prison,
-/area/space)
+/area/fiorina/lz/near_lzI)
 "g" = (
 /obj/structure/platform/kutjevo/smooth{
 	dir = 1
@@ -47,22 +47,25 @@
 	name = "solar lattice"
 	},
 /turf/open/space,
-/area/space)
+/area/fiorina/oob)
 "h" = (
 /obj/structure/platform/kutjevo/smooth,
 /obj/item/stack/sheet/metal,
 /turf/open/space,
-/area/space)
+/area/fiorina/oob)
 "i" = (
 /obj/structure/platform_decoration/kutjevo{
 	dir = 8
 	},
 /turf/open/space,
-/area/space)
+/area/fiorina/oob)
 "j" = (
 /obj/item/stack/sandbags/large_stack,
 /turf/open/floor/plating/prison,
-/area/space)
+/area/fiorina/lz/near_lzI)
+"k" = (
+/turf/closed/wall/r_wall/prison_unmeltable,
+/area/fiorina/station/flight_deck)
 "l" = (
 /obj/item/limb/head/synth{
 	pixel_x = -9
@@ -71,10 +74,10 @@
 	dir = 1
 	},
 /turf/open/space/basic,
-/area/space)
+/area/fiorina/oob)
 "m" = (
 /turf/open/floor/almayer_hull,
-/area/space)
+/area/fiorina/oob)
 "n" = (
 /obj/structure/cargo_container{
 	desc = "A huge industrial shipping container. You're not sure how it got here.";
@@ -82,37 +85,40 @@
 	tag = "icon-red 2,0"
 	},
 /turf/open/space,
-/area/space)
+/area/fiorina/oob)
+"o" = (
+/turf/open/floor/prison,
+/area/fiorina/station/flight_deck)
 "p" = (
 /turf/open/floor/prison,
-/area/space)
+/area/fiorina/lz/near_lzI)
 "q" = (
 /turf/open/floor/plating/prison,
-/area/space)
+/area/fiorina/lz/near_lzI)
 "r" = (
 /turf/closed/wall/r_wall/prison_unmeltable,
-/area/space)
+/area/fiorina/lz/near_lzI)
 "s" = (
 /obj/structure/platform/kutjevo/smooth{
 	dir = 4
 	},
 /turf/open/space,
-/area/space)
+/area/fiorina/oob)
 "t" = (
 /obj/structure/platform/kutjevo/smooth,
 /obj/structure/platform/kutjevo/smooth{
 	dir = 4
 	},
 /turf/open/space,
-/area/space)
+/area/fiorina/oob)
 "u" = (
 /turf/open/space,
-/area/space)
+/area/fiorina/oob)
 "v" = (
 /obj/structure/platform/kutjevo/smooth,
 /obj/item/book/manual/engineering_construction,
 /turf/open/space/basic,
-/area/space)
+/area/fiorina/oob)
 "w" = (
 /obj/structure/bedsheetbin{
 	icon_state = "linenbin-empty";
@@ -120,71 +126,71 @@
 	pixel_y = 6
 	},
 /turf/open/floor/almayer_hull,
-/area/space)
+/area/fiorina/oob)
 "x" = (
 /obj/structure/window/framed/prison/reinforced/hull,
 /turf/open/floor/prison{
 	icon_state = "floor_plate";
 	tag = "icon-floor_plate"
 	},
-/area/space)
+/area/fiorina/lz/near_lzI)
 "y" = (
 /obj/item/stack/sandbags_empty/half,
 /turf/open/floor/prison{
 	dir = 8;
 	icon_state = "darkyellow2"
 	},
-/area/space)
+/area/fiorina/lz/near_lzI)
 "z" = (
 /obj/structure/platform/kutjevo/smooth{
 	dir = 1
 	},
 /obj/item/clothing/head/cardborg,
 /turf/open/space,
-/area/space)
+/area/fiorina/oob)
 "A" = (
 /obj/structure/platform_decoration/kutjevo,
 /turf/open/space/basic,
-/area/space)
+/area/fiorina/oob)
 "B" = (
 /obj/structure/platform_decoration/kutjevo{
 	dir = 4
 	},
 /turf/open/space,
-/area/space)
+/area/fiorina/oob)
 "C" = (
 /obj/structure/window/framed/prison/reinforced/hull,
 /obj/structure/window/framed/prison/reinforced/hull,
 /turf/open/floor/plating/prison,
-/area/space)
+/area/fiorina/station/flight_deck)
 "D" = (
 /obj/item/trash/used_stasis_bag{
 	desc = "Wow, instant sand. They really have everything in space.";
 	name = "Insta-Sand! bag"
 	},
 /turf/open/floor/plating/prison,
-/area/space)
+/area/fiorina/lz/near_lzI)
 "E" = (
 /obj/item/trash/used_stasis_bag{
 	desc = "Wow, instant sand. They really have everything in space.";
 	name = "Insta-Sand! bag"
 	},
 /turf/open/floor/prison,
-/area/space)
+/area/fiorina/lz/near_lzI)
 "F" = (
 /obj/structure/window/framed/prison/reinforced/hull,
 /turf/open/floor/plating/prison,
-/area/space)
+/area/fiorina/lz/near_lzI)
 "G" = (
 /turf/open/floor/prison{
 	dir = 1;
 	icon_state = "darkyellow2"
 	},
-/area/space)
+/area/fiorina/lz/near_lzI)
 "H" = (
 /obj/structure/reagent_dispensers/oxygentank,
 /turf/open/space,
-/area/space)
+/area/fiorina/oob)
 "I" = (
 /obj/structure/platform/kutjevo/smooth{
 	dir = 4
@@ -197,7 +203,7 @@
 	pixel_x = 9
 	},
 /turf/open/space,
-/area/space)
+/area/fiorina/oob)
 "J" = (
 /obj/structure/platform/kutjevo/smooth{
 	dir = 1
@@ -207,76 +213,80 @@
 	},
 /obj/item/stack/sheet/metal,
 /turf/open/space,
-/area/space)
+/area/fiorina/oob)
+"K" = (
+/obj/structure/window/framed/prison/reinforced/hull,
+/turf/open/floor/plating/prison,
+/area/fiorina/station/flight_deck)
 "L" = (
 /turf/open/floor/prison{
 	dir = 8;
 	icon_state = "darkyellow2"
 	},
-/area/space)
+/area/fiorina/lz/near_lzI)
 "M" = (
 /obj/structure/platform/kutjevo/smooth,
 /turf/open/space,
-/area/space)
+/area/fiorina/oob)
 "N" = (
 /turf/open/floor{
 	desc = "A sophisticated device that captures and converts light from the system's star into energy for the station.";
 	icon_state = "solarpanel";
 	name = "solarpanel"
 	},
-/area/space)
+/area/fiorina/oob)
 "O" = (
 /obj/structure/platform/kutjevo/smooth,
 /obj/structure/platform/kutjevo/smooth{
 	dir = 8
 	},
 /turf/open/space,
-/area/space)
+/area/fiorina/oob)
 "P" = (
 /obj/structure/platform/kutjevo/smooth{
 	dir = 8
 	},
 /turf/open/floor/almayer_hull,
-/area/space)
+/area/fiorina/oob)
 "Q" = (
 /turf/open/auto_turf/sand/layer1,
-/area/space)
+/area/fiorina/lz/near_lzI)
 "R" = (
 /obj/structure/platform/kutjevo/smooth,
 /turf/open/space/basic,
-/area/space)
+/area/fiorina/oob)
 "S" = (
 /turf/open/space/basic,
-/area/space)
+/area/fiorina/oob)
 "T" = (
 /obj/item/stack/sandbags_empty/half,
 /turf/open/floor/prison{
 	icon_state = "darkyellow2"
 	},
-/area/space)
+/area/fiorina/lz/near_lzI)
 "U" = (
 /obj/item/stack/sheet/metal,
 /turf/open/space,
-/area/space)
+/area/fiorina/oob)
 "V" = (
 /obj/structure/platform/kutjevo/smooth{
 	dir = 8
 	},
 /obj/item/circuitboard/solar_tracker,
 /turf/open/space,
-/area/space)
+/area/fiorina/oob)
 "W" = (
 /obj/structure/platform/kutjevo/smooth{
 	dir = 4
 	},
 /turf/open/floor/almayer_hull,
-/area/space)
+/area/fiorina/oob)
 "X" = (
 /turf/open/floor/prison{
 	dir = 9;
 	icon_state = "darkyellow2"
 	},
-/area/space)
+/area/fiorina/lz/near_lzI)
 "Y" = (
 /obj/structure/platform/kutjevo/smooth{
 	dir = 1
@@ -285,24 +295,24 @@
 	dir = 8
 	},
 /turf/open/space,
-/area/space)
+/area/fiorina/oob)
 "Z" = (
 /obj/structure/platform/kutjevo/smooth{
 	dir = 1
 	},
 /turf/open/space,
-/area/space)
+/area/fiorina/oob)
 
 (1,1,1) = {"
 r
 C
-F
-F
-F
-F
-F
-F
-p
+K
+K
+K
+K
+K
+K
+o
 "}
 (2,1,1) = {"
 x
@@ -312,8 +322,8 @@ M
 m
 Z
 u
-r
-F
+k
+K
 "}
 (3,1,1) = {"
 x
@@ -324,7 +334,7 @@ W
 J
 s
 i
-F
+K
 "}
 (4,1,1) = {"
 x
@@ -335,7 +345,7 @@ w
 N
 N
 g
-F
+K
 "}
 (5,1,1) = {"
 x
@@ -346,7 +356,7 @@ m
 N
 N
 g
-F
+K
 "}
 (6,1,1) = {"
 x
@@ -357,7 +367,7 @@ w
 N
 N
 g
-F
+K
 "}
 (7,1,1) = {"
 x
@@ -368,7 +378,7 @@ P
 Y
 a
 B
-r
+k
 "}
 (8,1,1) = {"
 x
@@ -379,7 +389,7 @@ m
 z
 u
 b
-r
+k
 "}
 (9,1,1) = {"
 x


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Fixes repair panel LZ nightmare areas. They were all set to space which was causing people to freeze to death in the SW corner of the LZ.

## Why It's Good For The Game

People should not be randomly freezing to death.

## Changelog

:cl: Morrow
fix: Fixes Fiorina repair panel nightmare areas
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
