### PR TITLE
Fix snack labeling

### DIFF
--- a/code/datums/recipe.dm
+++ b/code/datums/recipe.dm
@@ -94,9 +94,7 @@
 			O.reagents.trans_to(result_obj, O.reagents.total_volume)
 		if(!name_finalized && O.made_from_player)
 			result_obj.name = O.made_from_player + result_obj.name
-			if (istype(result_obj, /obj/item/reagent_container/food/snacks))
-				var/obj/item/reagent_container/food/snacks/snack = result_obj
-				snack.made_from_player = O.made_from_player
+			result_obj.set_origin_name_prefix(O.made_from_player)
 			name_finalized = TRUE
 	container.contents = null
 	container.reagents.clear_reagents()

--- a/code/datums/recipe.dm
+++ b/code/datums/recipe.dm
@@ -94,6 +94,9 @@
 			O.reagents.trans_to(result_obj, O.reagents.total_volume)
 		if(!name_finalized && O.made_from_player)
 			result_obj.name = O.made_from_player + result_obj.name
+			if (istype(result_obj, /obj/item/reagent_container/food/snacks))
+				var/obj/item/reagent_container/food/snacks/snack = result_obj
+				snack.made_from_player = O.made_from_player
 			name_finalized = TRUE
 	container.contents = null
 	container.reagents.clear_reagents()

--- a/code/game/objects/items/reagent_containers/food/snacks.dm
+++ b/code/game/objects/items/reagent_containers/food/snacks.dm
@@ -131,6 +131,12 @@
 	else
 		. += SPAN_NOTICE("\The [src] was bitten multiple times!")
 
+/obj/item/reagent_container/food/snacks/set_name_label(var/new_label)
+	name_label = new_label
+	name = made_from_player + initial(name)
+	if(name_label)
+		name += " ([name_label])"
+
 /obj/item/reagent_container/food/snacks/attackby(obj/item/W as obj, mob/user as mob)
 	if(istype(W,/obj/item/storage))
 		..() // -> item/attackby()

--- a/code/game/objects/items/reagent_containers/food/snacks.dm
+++ b/code/game/objects/items/reagent_containers/food/snacks.dm
@@ -137,6 +137,9 @@
 	if(name_label)
 		name += " ([name_label])"
 
+/obj/item/reagent_container/food/snacks/set_origin_name_prefix(var/name_prefix)
+	made_from_player = name_prefix
+
 /obj/item/reagent_container/food/snacks/attackby(obj/item/W as obj, mob/user as mob)
 	if(istype(W,/obj/item/storage))
 		..() // -> item/attackby()

--- a/code/game/objects/items/tools/misc_tools.dm
+++ b/code/game/objects/items/tools/misc_tools.dm
@@ -7,11 +7,7 @@
 
 /atom/proc/set_name_label(var/new_label)
 	name_label = new_label
-	if (istype(src, /obj/item/reagent_container/food/snacks))
-		var/obj/item/reagent_container/food/snacks/snack = src
-		name = snack.made_from_player + initial(name)
-	else
-		name = initial(name)
+	name = initial(name)
 	if(name_label)
 		name += " ([name_label])"
 

--- a/code/game/objects/items/tools/misc_tools.dm
+++ b/code/game/objects/items/tools/misc_tools.dm
@@ -7,7 +7,11 @@
 
 /atom/proc/set_name_label(var/new_label)
 	name_label = new_label
-	name = initial(name)
+	if (istype(src, /obj/item/reagent_container/food/snacks))
+		var/obj/item/reagent_container/food/snacks/snack = src
+		name = snack.made_from_player + initial(name)
+	else
+		name = initial(name)
 	if(name_label)
 		name += " ([name_label])"
 

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -377,3 +377,6 @@
 		return 4 SECONDS
 
 	return 1 SECONDS
+
+/obj/proc/set_origin_name_prefix(var/name_prefix)
+	return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

This allows you to label snacks without losing the prefixes generated from the `made_from_player` variable.

This fixes #360.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bugfix. (plus you can now label burgers that have custom meat names)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->

## Changelog

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Laser9
fix: Burgers can now be labeled without losing custom meat names.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
