### PR TITLE
Make Morgues, Crematoriums, and Hydro Trays Slashable/Acidable

### DIFF
--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -14,12 +14,17 @@
 	var/morgue_open = 0
 	anchored = 1
 	throwpass = 1
+	var/buildstacktype = /obj/item/stack/sheet/metal
+	var/buildstackamount = 2
 
 /obj/structure/morgue/Initialize()
 	. = ..()
 	connected = new tray_path(src)
 
 /obj/structure/morgue/Destroy()
+	new buildstacktype(loc, buildstackamount)
+	for(var/atom/movable/A in src)
+		A.forceMove(loc)
 	. = ..()
 	QDEL_NULL(connected)
 

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -12,10 +12,10 @@
 	var/morgue_type = "morgue"
 	var/tray_path = /obj/structure/morgue_tray
 	var/morgue_open = 0
-	anchored = 1
-	throwpass = 1
 	var/buildstacktype = /obj/item/stack/sheet/metal
 	var/buildstackamount = 2
+	anchored = 1
+	throwpass = 1
 
 /obj/structure/morgue/Initialize()
 	. = ..()
@@ -23,8 +23,8 @@
 
 /obj/structure/morgue/Destroy()
 	new buildstacktype(loc, buildstackamount)
-	for(var/atom/movable/A in src)
-		A.forceMove(loc)
+	for(var/atom/movable/object in contents)
+		object.forceMove(loc)
 	. = ..()
 	QDEL_NULL(connected)
 

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -12,8 +12,6 @@
 	var/morgue_type = "morgue"
 	var/tray_path = /obj/structure/morgue_tray
 	var/morgue_open = 0
-	var/buildstacktype = /obj/item/stack/sheet/metal
-	var/buildstackamount = 2
 	anchored = 1
 	throwpass = 1
 
@@ -22,7 +20,6 @@
 	connected = new tray_path(src)
 
 /obj/structure/morgue/Destroy()
-	new buildstacktype(loc, buildstackamount)
 	for(var/atom/movable/object in contents)
 		object.forceMove(loc)
 	. = ..()

--- a/code/modules/hydroponics/hydro_tray.dm
+++ b/code/modules/hydroponics/hydro_tray.dm
@@ -6,8 +6,8 @@
 	icon_state = "hydrotray3"
 	density = 1
 	anchored = 1
-	unslashable = TRUE
-	health = 0
+	unslashable = FALSE
+	health = 100
 	flags_atom = OPENCONTAINER
 	throwpass = 1
 	layer = BELOW_OBJ_LAYER

--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -667,96 +667,96 @@
 //Exception is Queen and shuttles, because plot power
 /obj/structure/machinery/attack_alien(mob/living/carbon/Xenomorph/M)
 	if(unslashable || health <= 0)
-		to_chat(M, SPAN_WARNING("You stare at [src] cluelessly."))
+		to_chat(M, SPAN_WARNING("You stare at \the [src] cluelessly."))
 		return XENO_NO_DELAY_ACTION
 
 	M.animation_attack_on(src)
 	playsound(src, 'sound/effects/metalhit.ogg', 25, 1)
 	update_health(rand(M.melee_damage_lower, M.melee_damage_upper))
 	if(health <= 0)
-		M.visible_message(SPAN_DANGER("[M] slices [src] apart!"), \
-		SPAN_DANGER("You slice [src] apart!"), null, 5, CHAT_TYPE_XENO_COMBAT)
+		M.visible_message(SPAN_DANGER("[M] slices \the [src] apart!"), \
+		SPAN_DANGER("You slice \the [src] apart!"), null, 5, CHAT_TYPE_XENO_COMBAT)
 		if(!unacidable)
 			qdel(src)
 	else
-		M.visible_message(SPAN_DANGER("[M] [M.slashes_verb] [src]!"), \
-		SPAN_DANGER("You [M.slash_verb] [src]!"), null, 5, CHAT_TYPE_XENO_COMBAT)
+		M.visible_message(SPAN_DANGER("[M] [M.slashes_verb] \the [src]!"), \
+		SPAN_DANGER("You [M.slash_verb] \the [src]!"), null, 5, CHAT_TYPE_XENO_COMBAT)
 	return XENO_ATTACK_ACTION
 
 // Destroying reagent dispensers
 /obj/structure/reagent_dispensers/attack_alien(mob/living/carbon/Xenomorph/M)
 	if(unslashable || health <= 0)
-		to_chat(M, SPAN_WARNING("You stare at [src] cluelessly."))
+		to_chat(M, SPAN_WARNING("You stare at \the [src] cluelessly."))
 		return XENO_NO_DELAY_ACTION
 
 	M.animation_attack_on(src)
 	playsound(src, 'sound/effects/metalhit.ogg', 25, 1)
 	update_health(rand(M.melee_damage_lower, M.melee_damage_upper))
 	if(health <= 0)
-		M.visible_message(SPAN_DANGER("[M] slices [src] apart!"), \
-		SPAN_DANGER("You slice [src] apart!"), null, 5, CHAT_TYPE_XENO_COMBAT)
+		M.visible_message(SPAN_DANGER("[M] slices \the [src] apart!"), \
+		SPAN_DANGER("You slice \the [src] apart!"), null, 5, CHAT_TYPE_XENO_COMBAT)
 		if(!unacidable)
 			qdel(src)
 	else
-		M.visible_message(SPAN_DANGER("[M] [M.slashes_verb] [src]!"), \
-		SPAN_DANGER("You [M.slash_verb] [src]!"), null, 5, CHAT_TYPE_XENO_COMBAT)
+		M.visible_message(SPAN_DANGER("[M] [M.slashes_verb] \the [src]!"), \
+		SPAN_DANGER("You [M.slash_verb] \the [src]!"), null, 5, CHAT_TYPE_XENO_COMBAT)
 	return XENO_ATTACK_ACTION
 
 // Destroying filing cabinets
 /obj/structure/filingcabinet/attack_alien(mob/living/carbon/Xenomorph/M)
 	if(unslashable || health <= 0)
-		to_chat(M, SPAN_WARNING("You stare at [src] cluelessly."))
+		to_chat(M, SPAN_WARNING("You stare at \the [src] cluelessly."))
 		return XENO_NO_DELAY_ACTION
 
 	M.animation_attack_on(src)
 	playsound(src, 'sound/effects/metalhit.ogg', 25, 1)
 	update_health(rand(M.melee_damage_lower, M.melee_damage_upper))
 	if(health <= 0)
-		M.visible_message(SPAN_DANGER("[M] slices [src] apart!"), \
-		SPAN_DANGER("You slice [src] apart!"), null, 5, CHAT_TYPE_XENO_COMBAT)
+		M.visible_message(SPAN_DANGER("[M] slices \the [src] apart!"), \
+		SPAN_DANGER("You slice \the [src] apart!"), null, 5, CHAT_TYPE_XENO_COMBAT)
 		if(!unacidable)
 			qdel(src)
 	else
-		M.visible_message(SPAN_DANGER("[M] [M.slashes_verb] [src]!"), \
-		SPAN_DANGER("You [M.slash_verb] [src]!"), null, 5, CHAT_TYPE_XENO_COMBAT)
+		M.visible_message(SPAN_DANGER("[M] [M.slashes_verb] \the [src]!"), \
+		SPAN_DANGER("You [M.slash_verb] \the [src]!"), null, 5, CHAT_TYPE_XENO_COMBAT)
 	return XENO_ATTACK_ACTION
 
 // Destroying morgues & crematoriums
 /obj/structure/morgue/attack_alien(mob/living/carbon/Xenomorph/M)
 	if(unslashable || health <= 0)
-		to_chat(M, SPAN_WARNING("You stare at [src] cluelessly."))
+		to_chat(M, SPAN_WARNING("You stare at \the [src] cluelessly."))
 		return XENO_NO_DELAY_ACTION
 
 	M.animation_attack_on(src)
 	playsound(src, 'sound/effects/metalhit.ogg', 25, 1)
 	update_health(rand(M.melee_damage_lower, M.melee_damage_upper))
 	if(health <= 0)
-		M.visible_message(SPAN_DANGER("[M] slices [src] apart!"), \
-		SPAN_DANGER("You slice [src] apart!"), null, 5, CHAT_TYPE_XENO_COMBAT)
+		M.visible_message(SPAN_DANGER("[M] slices \the [src] apart!"), \
+		SPAN_DANGER("You slice \the [src] apart!"), null, 5, CHAT_TYPE_XENO_COMBAT)
 		if(!unacidable)
 			qdel(src)
 	else
-		M.visible_message(SPAN_DANGER("[M] [M.slashes_verb] [src]!"), \
-		SPAN_DANGER("You [M.slash_verb] [src]!"), null, 5, CHAT_TYPE_XENO_COMBAT)
+		M.visible_message(SPAN_DANGER("[M] [M.slashes_verb] \the [src]!"), \
+		SPAN_DANGER("You [M.slash_verb] \the [src]!"), null, 5, CHAT_TYPE_XENO_COMBAT)
 	return XENO_ATTACK_ACTION
 
 // Destroying hydroponics trays
 /obj/structure/machinery/portable_atmospherics/hydroponics/attack_alien(mob/living/carbon/Xenomorph/M)
 	if(unslashable || health <= 0)
-		to_chat(M, SPAN_WARNING("You stare at [src] cluelessly."))
+		to_chat(M, SPAN_WARNING("You stare at \the [src] cluelessly."))
 		return XENO_NO_DELAY_ACTION
 
 	M.animation_attack_on(src)
 	playsound(src, 'sound/effects/metalhit.ogg', 25, 1)
 	update_health(rand(M.melee_damage_lower, M.melee_damage_upper))
 	if(health <= 0)
-		M.visible_message(SPAN_DANGER("[M] slices [src] apart!"), \
-		SPAN_DANGER("You slice [src] apart!"), null, 5, CHAT_TYPE_XENO_COMBAT)
+		M.visible_message(SPAN_DANGER("[M] slices \the [src] apart!"), \
+		SPAN_DANGER("You slice \the [src] apart!"), null, 5, CHAT_TYPE_XENO_COMBAT)
 		if(!unacidable)
 			qdel(src)
 	else
-		M.visible_message(SPAN_DANGER("[M] [M.slashes_verb] [src]!"), \
-		SPAN_DANGER("You [M.slash_verb] [src]!"), null, 5, CHAT_TYPE_XENO_COMBAT)
+		M.visible_message(SPAN_DANGER("[M] [M.slashes_verb] \the [src]!"), \
+		SPAN_DANGER("You [M.slash_verb] \the [src]!"), null, 5, CHAT_TYPE_XENO_COMBAT)
 	return XENO_ATTACK_ACTION
 
 /datum/shuttle/ferry/marine/proc/hijack(mob/living/carbon/Xenomorph/M, shuttle_tag)

--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -722,41 +722,41 @@
 	return XENO_ATTACK_ACTION
 
 // Destroying morgues & crematoriums
-/obj/structure/morgue/attack_alien(mob/living/carbon/Xenomorph/M)
+/obj/structure/morgue/attack_alien(mob/living/carbon/Xenomorph/alien)
 	if(unslashable || health <= 0)
-		to_chat(M, SPAN_WARNING("You stare at \the [src] cluelessly."))
+		to_chat(alien, SPAN_WARNING("You stare at \the [src] cluelessly."))
 		return XENO_NO_DELAY_ACTION
 
-	M.animation_attack_on(src)
+	alien.animation_attack_on(src)
 	playsound(src, 'sound/effects/metalhit.ogg', 25, 1)
-	update_health(rand(M.melee_damage_lower, M.melee_damage_upper))
+	update_health(rand(alien.melee_damage_lower, alien.melee_damage_upper))
 	if(health <= 0)
-		M.visible_message(SPAN_DANGER("[M] slices \the [src] apart!"), \
+		alien.visible_message(SPAN_DANGER("[alien] slices \the [src] apart!"), \
 		SPAN_DANGER("You slice \the [src] apart!"), null, 5, CHAT_TYPE_XENO_COMBAT)
 		if(!unacidable)
 			qdel(src)
 	else
-		M.visible_message(SPAN_DANGER("[M] [M.slashes_verb] \the [src]!"), \
-		SPAN_DANGER("You [M.slash_verb] \the [src]!"), null, 5, CHAT_TYPE_XENO_COMBAT)
+		alien.visible_message(SPAN_DANGER("[alien] [alien.slashes_verb] \the [src]!"), \
+		SPAN_DANGER("You [alien.slash_verb] \the [src]!"), null, 5, CHAT_TYPE_XENO_COMBAT)
 	return XENO_ATTACK_ACTION
 
 // Destroying hydroponics trays
-/obj/structure/machinery/portable_atmospherics/hydroponics/attack_alien(mob/living/carbon/Xenomorph/M)
+/obj/structure/machinery/portable_atmospherics/hydroponics/attack_alien(mob/living/carbon/Xenomorph/alien)
 	if(unslashable || health <= 0)
-		to_chat(M, SPAN_WARNING("You stare at \the [src] cluelessly."))
+		to_chat(alien, SPAN_WARNING("You stare at \the [src] cluelessly."))
 		return XENO_NO_DELAY_ACTION
 
-	M.animation_attack_on(src)
+	alien.animation_attack_on(src)
 	playsound(src, 'sound/effects/metalhit.ogg', 25, 1)
-	update_health(rand(M.melee_damage_lower, M.melee_damage_upper))
+	update_health(rand(alien.melee_damage_lower, alien.melee_damage_upper))
 	if(health <= 0)
-		M.visible_message(SPAN_DANGER("[M] slices \the [src] apart!"), \
+		alien.visible_message(SPAN_DANGER("[alien] slices \the [src] apart!"), \
 		SPAN_DANGER("You slice \the [src] apart!"), null, 5, CHAT_TYPE_XENO_COMBAT)
 		if(!unacidable)
 			qdel(src)
 	else
-		M.visible_message(SPAN_DANGER("[M] [M.slashes_verb] \the [src]!"), \
-		SPAN_DANGER("You [M.slash_verb] \the [src]!"), null, 5, CHAT_TYPE_XENO_COMBAT)
+		alien.visible_message(SPAN_DANGER("[alien] [alien.slashes_verb] \the [src]!"), \
+		SPAN_DANGER("You [alien.slash_verb] \the [src]!"), null, 5, CHAT_TYPE_XENO_COMBAT)
 	return XENO_ATTACK_ACTION
 
 /datum/shuttle/ferry/marine/proc/hijack(mob/living/carbon/Xenomorph/M, shuttle_tag)

--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -683,7 +683,7 @@
 		SPAN_DANGER("You [M.slash_verb] [src]!"), null, 5, CHAT_TYPE_XENO_COMBAT)
 	return XENO_ATTACK_ACTION
 
-
+// Destroying reagent dispensers
 /obj/structure/reagent_dispensers/attack_alien(mob/living/carbon/Xenomorph/M)
 	if(unslashable || health <= 0)
 		to_chat(M, SPAN_WARNING("You stare at [src] cluelessly."))
@@ -702,7 +702,7 @@
 		SPAN_DANGER("You [M.slash_verb] [src]!"), null, 5, CHAT_TYPE_XENO_COMBAT)
 	return XENO_ATTACK_ACTION
 
-
+// Destroying filing cabinets
 /obj/structure/filingcabinet/attack_alien(mob/living/carbon/Xenomorph/M)
 	if(unslashable || health <= 0)
 		to_chat(M, SPAN_WARNING("You stare at [src] cluelessly."))
@@ -721,6 +721,43 @@
 		SPAN_DANGER("You [M.slash_verb] [src]!"), null, 5, CHAT_TYPE_XENO_COMBAT)
 	return XENO_ATTACK_ACTION
 
+// Destroying morgues & crematoriums
+/obj/structure/morgue/attack_alien(mob/living/carbon/Xenomorph/M)
+	if(unslashable || health <= 0)
+		to_chat(M, SPAN_WARNING("You stare at [src] cluelessly."))
+		return XENO_NO_DELAY_ACTION
+
+	M.animation_attack_on(src)
+	playsound(src, 'sound/effects/metalhit.ogg', 25, 1)
+	update_health(rand(M.melee_damage_lower, M.melee_damage_upper))
+	if(health <= 0)
+		M.visible_message(SPAN_DANGER("[M] slices [src] apart!"), \
+		SPAN_DANGER("You slice [src] apart!"), null, 5, CHAT_TYPE_XENO_COMBAT)
+		if(!unacidable)
+			qdel(src)
+	else
+		M.visible_message(SPAN_DANGER("[M] [M.slashes_verb] [src]!"), \
+		SPAN_DANGER("You [M.slash_verb] [src]!"), null, 5, CHAT_TYPE_XENO_COMBAT)
+	return XENO_ATTACK_ACTION
+
+// Destroying hydroponics trays
+/obj/structure/machinery/portable_atmospherics/hydroponics/attack_alien(mob/living/carbon/Xenomorph/M)
+	if(unslashable || health <= 0)
+		to_chat(M, SPAN_WARNING("You stare at [src] cluelessly."))
+		return XENO_NO_DELAY_ACTION
+
+	M.animation_attack_on(src)
+	playsound(src, 'sound/effects/metalhit.ogg', 25, 1)
+	update_health(rand(M.melee_damage_lower, M.melee_damage_upper))
+	if(health <= 0)
+		M.visible_message(SPAN_DANGER("[M] slices [src] apart!"), \
+		SPAN_DANGER("You slice [src] apart!"), null, 5, CHAT_TYPE_XENO_COMBAT)
+		if(!unacidable)
+			qdel(src)
+	else
+		M.visible_message(SPAN_DANGER("[M] [M.slashes_verb] [src]!"), \
+		SPAN_DANGER("You [M.slash_verb] [src]!"), null, 5, CHAT_TYPE_XENO_COMBAT)
+	return XENO_ATTACK_ACTION
 
 /datum/shuttle/ferry/marine/proc/hijack(mob/living/carbon/Xenomorph/M, shuttle_tag)
 	if(!queen_locked) //we have not hijacked it yet

--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -723,7 +723,7 @@
 
 // Destroying morgues & crematoriums
 /obj/structure/morgue/attack_alien(mob/living/carbon/Xenomorph/alien)
-	if(unslashable || health <= 0)
+	if(unslashable)
 		to_chat(alien, SPAN_WARNING("You stare at \the [src] cluelessly."))
 		return XENO_NO_DELAY_ACTION
 
@@ -742,7 +742,7 @@
 
 // Destroying hydroponics trays
 /obj/structure/machinery/portable_atmospherics/hydroponics/attack_alien(mob/living/carbon/Xenomorph/alien)
-	if(unslashable || health <= 0)
+	if(unslashable)
 		to_chat(alien, SPAN_WARNING("You stare at \the [src] cluelessly."))
 		return XENO_NO_DELAY_ACTION
 

--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -727,14 +727,14 @@
 		to_chat(alien, SPAN_WARNING("You stare at \the [src] cluelessly."))
 		return XENO_NO_DELAY_ACTION
 
+	var destroyloc = loc
 	alien.animation_attack_on(src)
 	playsound(src, 'sound/effects/metalhit.ogg', 25, 1)
 	update_health(rand(alien.melee_damage_lower, alien.melee_damage_upper))
 	if(health <= 0)
 		alien.visible_message(SPAN_DANGER("[alien] slices \the [src] apart!"), \
 		SPAN_DANGER("You slice \the [src] apart!"), null, 5, CHAT_TYPE_XENO_COMBAT)
-		if(!unacidable)
-			qdel(src)
+		new /obj/item/stack/sheet/metal(destroyloc, 2)
 	else
 		alien.visible_message(SPAN_DANGER("[alien] [alien.slashes_verb] \the [src]!"), \
 		SPAN_DANGER("You [alien.slash_verb] \the [src]!"), null, 5, CHAT_TYPE_XENO_COMBAT)

--- a/maps/map_files/Kutjevo/Kutjevo.dmm
+++ b/maps/map_files/Kutjevo/Kutjevo.dmm
@@ -64,17 +64,6 @@
 "adD" = (
 /turf/open/floor/almayer/research/containment/floor1,
 /area/kutjevo/exterior/lz_dunes)
-"adR" = (
-/obj/structure/flora/bush/desert{
-	icon_state = "tree_2";
-	pixel_y = 14
-	},
-/obj/structure/machinery/portable_atmospherics/hydroponics{
-	draw_warnings = 0;
-	icon_state = "hydrotray4"
-	},
-/turf/open/floor/kutjevo/colors/green,
-/area/kutjevo/interior/complex/botany)
 "adX" = (
 /obj/item/stack/sheet/wood,
 /obj/structure/machinery/light,
@@ -1817,16 +1806,6 @@
 	},
 /turf/open/auto_turf/sand/layer0,
 /area/kutjevo/exterior/scrubland)
-"cxx" = (
-/obj/structure/machinery/portable_atmospherics/hydroponics{
-	draw_warnings = 0;
-	icon_state = "hydrotray4"
-	},
-/obj/structure/flora/bush/desert/cactus{
-	pixel_y = -4
-	},
-/turf/open/floor/kutjevo/colors/green/tile,
-/area/kutjevo/interior/complex/botany)
 "cyc" = (
 /turf/closed/wall/kutjevo/colony/reinforced,
 /area/kutjevo/interior/colony_central/mine_elevator)
@@ -2081,17 +2060,6 @@
 	},
 /turf/open/floor/plating/kutjevo,
 /area/kutjevo/exterior/lz_river)
-"cNW" = (
-/obj/structure/machinery/portable_atmospherics/hydroponics{
-	draw_warnings = 0;
-	icon_state = "hydrotray4"
-	},
-/obj/structure/flora/bush/snow{
-	icon_state = "snowbush_4";
-	pixel_y = 11
-	},
-/turf/open/floor/kutjevo/colors/green,
-/area/kutjevo/interior/complex/botany)
 "cOh" = (
 /obj/effect/decal/cleanable/blood/xeno{
 	icon_state = "xgib2"
@@ -4717,16 +4685,6 @@
 /obj/structure/prop/dam/gravestone,
 /turf/open/auto_turf/sand/layer0,
 /area/kutjevo/interior/colony_N_East)
-"fYl" = (
-/obj/structure/machinery/portable_atmospherics/hydroponics{
-	draw_warnings = 0;
-	icon_state = "hydrotray4"
-	},
-/obj/structure/flora/bush/ausbushes/var3/stalkybush{
-	pixel_y = 14
-	},
-/turf/open/floor/kutjevo/colors/green,
-/area/kutjevo/interior/complex/botany)
 "fYE" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/computer/shuttle_control/dropship2,
@@ -5422,16 +5380,6 @@
 	},
 /turf/open/auto_turf/sand/layer1,
 /area/kutjevo/exterior/Northwest_Colony)
-"gXy" = (
-/obj/structure/machinery/portable_atmospherics/hydroponics{
-	draw_warnings = 0;
-	icon_state = "hydrotray4"
-	},
-/obj/structure/flora/bush/snow{
-	pixel_y = 10
-	},
-/turf/open/floor/kutjevo/colors/green/tile,
-/area/kutjevo/interior/complex/botany)
 "gXF" = (
 /obj/structure/machinery/door/poddoor/shutters/almayer{
 	dir = 8;
@@ -5903,16 +5851,6 @@
 	},
 /turf/open/floor/kutjevo/colors/orange,
 /area/kutjevo/interior/power/comms)
-"hFj" = (
-/obj/structure/machinery/portable_atmospherics/hydroponics{
-	draw_warnings = 0;
-	icon_state = "hydrotray4"
-	},
-/obj/structure/flora/bush/ausbushes/var3/sunnybush{
-	pixel_y = 15
-	},
-/turf/open/floor/kutjevo/colors/green/tile,
-/area/kutjevo/interior/complex/botany)
 "hFH" = (
 /obj/structure/barricade/wooden{
 	dir = 1;
@@ -6464,17 +6402,6 @@
 /obj/item/tool/pickaxe,
 /turf/open/auto_turf/sand/layer0,
 /area/kutjevo/interior/complex/botany/east_tech)
-"iGF" = (
-/obj/structure/machinery/portable_atmospherics/hydroponics{
-	draw_warnings = 0;
-	icon_state = "hydrotray4";
-	},
-/obj/structure/flora/bush/desert{
-	icon_state = "tree_2";
-	pixel_y = 14
-	},
-/turf/open/floor/kutjevo/colors/green,
-/area/kutjevo/interior/complex/botany)
 "iGS" = (
 /obj/structure/platform/kutjevo/rock{
 	dir = 8
@@ -8260,16 +8187,6 @@
 "lcS" = (
 /turf/open/floor/kutjevo/colors,
 /area/kutjevo/interior/complex/med/pano)
-"ldt" = (
-/obj/structure/machinery/portable_atmospherics/hydroponics{
-	draw_warnings = 0;
-	icon_state = "hydrotray4"
-	},
-/obj/structure/flora/bush/ausbushes/reedbush{
-	pixel_y = 14
-	},
-/turf/open/floor/kutjevo/colors/green,
-/area/kutjevo/interior/complex/botany)
 "ldM" = (
 /obj/effect/decal/medical_decals{
 	icon_state = "triagedecalbottomleft"
@@ -8285,17 +8202,6 @@
 	},
 /turf/open/floor/kutjevo/colors/cyan,
 /area/kutjevo/interior/complex/med)
-"leR" = (
-/obj/structure/machinery/portable_atmospherics/hydroponics{
-	draw_warnings = 0;
-	icon_state = "hydrotray4"
-	},
-/obj/structure/flora/bush/desert{
-	icon_state = "tree_2";
-	pixel_y = 14
-	},
-/turf/open/floor/kutjevo/colors/green/tile,
-/area/kutjevo/interior/complex/botany)
 "lfm" = (
 /obj/item/stack/sheet/wood,
 /turf/open/floor/kutjevo/tan,
@@ -9266,16 +9172,6 @@
 /obj/item/frame/rack,
 /turf/open/floor/kutjevo/tan/multi_tiles,
 /area/kutjevo/interior/complex/botany/east_tech)
-"mza" = (
-/obj/structure/flora/bush/ausbushes/var3/sunnybush{
-	pixel_y = 15
-	},
-/obj/structure/machinery/portable_atmospherics/hydroponics{
-	draw_warnings = 0;
-	icon_state = "hydrotray4"
-	},
-/turf/open/floor/kutjevo/colors/green,
-/area/kutjevo/interior/complex/botany)
 "mzn" = (
 /obj/structure/platform/kutjevo{
 	dir = 1
@@ -9780,16 +9676,6 @@
 	dir = 1
 	},
 /area/kutjevo/interior/complex/med/triage)
-"nfN" = (
-/obj/structure/flora/bush/ausbushes/var3/fernybush{
-	pixel_y = 14
-	},
-/obj/structure/machinery/portable_atmospherics/hydroponics{
-	draw_warnings = 0;
-	icon_state = "hydrotray4"
-	},
-/turf/open/floor/kutjevo/colors/green,
-/area/kutjevo/interior/complex/botany)
 "ngp" = (
 /obj/structure/platform_decoration/kutjevo{
 	dir = 1
@@ -10543,16 +10429,6 @@
 	},
 /turf/open/floor/kutjevo/tan/alt_inner_edge,
 /area/kutjevo/interior/complex/Northwest_Flight_Control)
-"obN" = (
-/obj/structure/flora/bush/ausbushes/pointybush{
-	pixel_y = 14
-	},
-/obj/structure/machinery/portable_atmospherics/hydroponics{
-	draw_warnings = 0;
-	icon_state = "hydrotray4"
-	},
-/turf/open/floor/kutjevo/colors/green,
-/area/kutjevo/interior/complex/botany)
 "oca" = (
 /obj/structure/surface/table/almayer,
 /obj/item/device/flashlight/lamp,
@@ -10947,16 +10823,6 @@
 	dir = 8
 	},
 /area/kutjevo/exterior/runoff_river)
-"oGR" = (
-/obj/structure/machinery/portable_atmospherics/hydroponics{
-	draw_warnings = 0;
-	icon_state = "hydrotray4"
-	},
-/obj/structure/flora/bush/ausbushes/reedbush{
-	pixel_y = 14
-	},
-/turf/open/floor/kutjevo/colors/green/tile,
-/area/kutjevo/interior/complex/botany)
 "oIb" = (
 /obj/structure/stairs/perspective/kutjevo{
 	dir = 4;
@@ -13042,16 +12908,6 @@
 	},
 /turf/open/auto_turf/sand/layer0,
 /area/kutjevo/interior/colony_South)
-"rzu" = (
-/obj/structure/flora/bush/snow{
-	pixel_y = 10
-	},
-/obj/structure/machinery/portable_atmospherics/hydroponics{
-	draw_warnings = 0;
-	icon_state = "hydrotray4"
-	},
-/turf/open/floor/kutjevo/colors/green,
-/area/kutjevo/interior/complex/botany)
 "rzE" = (
 /obj/structure/flora/bush/ausbushes/reedbush,
 /turf/open/gm/river/desert/shallow_edge,
@@ -13941,16 +13797,6 @@
 /obj/structure/machinery/power/geothermal,
 /turf/open/floor/kutjevo/colors/orange,
 /area/kutjevo/interior/power)
-"sIH" = (
-/obj/structure/flora/bush/ausbushes/ausbush{
-	pixel_y = 12
-	},
-/obj/structure/machinery/portable_atmospherics/hydroponics{
-	draw_warnings = 0;
-	icon_state = "hydrotray4"
-	},
-/turf/open/floor/kutjevo/colors/green,
-/area/kutjevo/interior/complex/botany)
 "sJj" = (
 /obj/structure/bed/chair/office/light{
 	dir = 1
@@ -14205,9 +14051,6 @@
 /turf/open/auto_turf/sand/layer0,
 /area/kutjevo/exterior/complex_border/med_rec)
 "sYA" = (
-/obj/structure/flora/bush/ausbushes/reedbush{
-	pixel_y = 14
-	},
 /obj/structure/machinery/portable_atmospherics/hydroponics{
 	draw_warnings = 0;
 	icon_state = "hydrotray4"
@@ -14635,9 +14478,6 @@
 /obj/structure/machinery/portable_atmospherics/hydroponics{
 	draw_warnings = 0;
 	icon_state = "hydrotray4"
-	},
-/obj/structure/flora/bush/ausbushes/ausbush{
-	pixel_y = 12
 	},
 /turf/open/floor/kutjevo/colors/green/tile,
 /area/kutjevo/interior/complex/botany)
@@ -16905,16 +16745,6 @@
 	},
 /turf/open/auto_turf/sand/layer1,
 /area/kutjevo/exterior/lz_river)
-"wBv" = (
-/obj/structure/machinery/portable_atmospherics/hydroponics{
-	draw_warnings = 0;
-	icon_state = "hydrotray4"
-	},
-/obj/structure/flora/bush/ausbushes/palebush{
-	pixel_y = 10
-	},
-/turf/open/floor/kutjevo/colors/green,
-/area/kutjevo/interior/complex/botany)
 "wCe" = (
 /obj/structure/platform_decoration/kutjevo{
 	dir = 8
@@ -32840,9 +32670,9 @@ eXm
 crL
 kVv
 pJL
-rzu
+sYA
 kDS
-wBv
+sYA
 dJk
 mbS
 jwR
@@ -33166,7 +32996,7 @@ hkO
 cEE
 qgW
 eSP
-sIH
+sYA
 kDS
 eSP
 vDS
@@ -33174,9 +33004,9 @@ qgW
 aYr
 oDC
 hVg
-nfN
+sYA
 kDS
-sIH
+sYA
 kDS
 rTL
 vDS
@@ -33500,7 +33330,7 @@ eXm
 eXm
 pJa
 kDS
-adR
+sYA
 kDS
 qgW
 vDS
@@ -33667,17 +33497,17 @@ kfF
 eXm
 qgW
 kDS
-mza
+sYA
 kDS
 qgW
 vDS
 qgW
 kDS
-adR
+sYA
 kDS
-obN
+sYA
 kDS
-ldt
+sYA
 kDS
 qgW
 vDS
@@ -34007,11 +33837,11 @@ aRh
 mGE
 qgW
 kDS
-mza
+sYA
 kDS
-fYl
+sYA
 kDS
-cNW
+sYA
 kDS
 qgW
 vDS
@@ -34862,8 +34692,8 @@ lHs
 hzB
 gYr
 lHs
-oGR
-hFj
+tEa
+tEa
 tEa
 lHs
 lcv
@@ -36365,9 +36195,9 @@ cAt
 kDS
 vDS
 pZx
-leR
-gXy
-cxx
+tEa
+tEa
+tEa
 mwh
 bAe
 fyD

--- a/maps/map_files/Kutjevo/Kutjevo.dmm
+++ b/maps/map_files/Kutjevo/Kutjevo.dmm
@@ -6464,6 +6464,17 @@
 /obj/item/tool/pickaxe,
 /turf/open/auto_turf/sand/layer0,
 /area/kutjevo/interior/complex/botany/east_tech)
+"iGF" = (
+/obj/structure/machinery/portable_atmospherics/hydroponics{
+	draw_warnings = 0;
+	icon_state = "hydrotray4";
+	},
+/obj/structure/flora/bush/desert{
+	icon_state = "tree_2";
+	pixel_y = 14
+	},
+/turf/open/floor/kutjevo/colors/green,
+/area/kutjevo/interior/complex/botany)
 "iGS" = (
 /obj/structure/platform/kutjevo/rock{
 	dir = 8

--- a/maps/map_files/Kutjevo/Kutjevo.dmm
+++ b/maps/map_files/Kutjevo/Kutjevo.dmm
@@ -71,10 +71,7 @@
 	},
 /obj/structure/machinery/portable_atmospherics/hydroponics{
 	draw_warnings = 0;
-	health = null;
-	icon_state = "hydrotray4";
-	indestructible = 1;
-	unacidable = 1
+	icon_state = "hydrotray4"
 	},
 /turf/open/floor/kutjevo/colors/green,
 /area/kutjevo/interior/complex/botany)
@@ -2087,10 +2084,7 @@
 "cNW" = (
 /obj/structure/machinery/portable_atmospherics/hydroponics{
 	draw_warnings = 0;
-	health = null;
-	icon_state = "hydrotray4";
-	indestructible = 1;
-	unacidable = 1
+	icon_state = "hydrotray4"
 	},
 /obj/structure/flora/bush/snow{
 	icon_state = "snowbush_4";
@@ -4726,10 +4720,7 @@
 "fYl" = (
 /obj/structure/machinery/portable_atmospherics/hydroponics{
 	draw_warnings = 0;
-	health = null;
-	icon_state = "hydrotray4";
-	indestructible = 1;
-	unacidable = 1
+	icon_state = "hydrotray4"
 	},
 /obj/structure/flora/bush/ausbushes/var3/stalkybush{
 	pixel_y = 14
@@ -6473,20 +6464,6 @@
 /obj/item/tool/pickaxe,
 /turf/open/auto_turf/sand/layer0,
 /area/kutjevo/interior/complex/botany/east_tech)
-"iGF" = (
-/obj/structure/machinery/portable_atmospherics/hydroponics{
-	draw_warnings = 0;
-	health = null;
-	icon_state = "hydrotray4";
-	indestructible = 1;
-	unacidable = 1
-	},
-/obj/structure/flora/bush/desert{
-	icon_state = "tree_2";
-	pixel_y = 14
-	},
-/turf/open/floor/kutjevo/colors/green,
-/area/kutjevo/interior/complex/botany)
 "iGS" = (
 /obj/structure/platform/kutjevo/rock{
 	dir = 8
@@ -8275,10 +8252,7 @@
 "ldt" = (
 /obj/structure/machinery/portable_atmospherics/hydroponics{
 	draw_warnings = 0;
-	health = null;
-	icon_state = "hydrotray4";
-	indestructible = 1;
-	unacidable = 1
+	icon_state = "hydrotray4"
 	},
 /obj/structure/flora/bush/ausbushes/reedbush{
 	pixel_y = 14
@@ -9282,15 +9256,12 @@
 /turf/open/floor/kutjevo/tan/multi_tiles,
 /area/kutjevo/interior/complex/botany/east_tech)
 "mza" = (
-/obj/structure/machinery/portable_atmospherics/hydroponics{
-	draw_warnings = 0;
-	health = null;
-	icon_state = "hydrotray4";
-	indestructible = 1;
-	unacidable = 1
-	},
 /obj/structure/flora/bush/ausbushes/var3/sunnybush{
 	pixel_y = 15
+	},
+/obj/structure/machinery/portable_atmospherics/hydroponics{
+	draw_warnings = 0;
+	icon_state = "hydrotray4"
 	},
 /turf/open/floor/kutjevo/colors/green,
 /area/kutjevo/interior/complex/botany)
@@ -9799,15 +9770,12 @@
 	},
 /area/kutjevo/interior/complex/med/triage)
 "nfN" = (
-/obj/structure/machinery/portable_atmospherics/hydroponics{
-	draw_warnings = 0;
-	health = null;
-	icon_state = "hydrotray4";
-	indestructible = 1;
-	unacidable = 1
-	},
 /obj/structure/flora/bush/ausbushes/var3/fernybush{
 	pixel_y = 14
+	},
+/obj/structure/machinery/portable_atmospherics/hydroponics{
+	draw_warnings = 0;
+	icon_state = "hydrotray4"
 	},
 /turf/open/floor/kutjevo/colors/green,
 /area/kutjevo/interior/complex/botany)
@@ -10565,15 +10533,12 @@
 /turf/open/floor/kutjevo/tan/alt_inner_edge,
 /area/kutjevo/interior/complex/Northwest_Flight_Control)
 "obN" = (
-/obj/structure/machinery/portable_atmospherics/hydroponics{
-	draw_warnings = 0;
-	health = null;
-	icon_state = "hydrotray4";
-	indestructible = 1;
-	unacidable = 1
-	},
 /obj/structure/flora/bush/ausbushes/pointybush{
 	pixel_y = 14
+	},
+/obj/structure/machinery/portable_atmospherics/hydroponics{
+	draw_warnings = 0;
+	icon_state = "hydrotray4"
 	},
 /turf/open/floor/kutjevo/colors/green,
 /area/kutjevo/interior/complex/botany)
@@ -13067,15 +13032,12 @@
 /turf/open/auto_turf/sand/layer0,
 /area/kutjevo/interior/colony_South)
 "rzu" = (
-/obj/structure/machinery/portable_atmospherics/hydroponics{
-	draw_warnings = 0;
-	health = null;
-	icon_state = "hydrotray4";
-	indestructible = 1;
-	unacidable = 1
-	},
 /obj/structure/flora/bush/snow{
 	pixel_y = 10
+	},
+/obj/structure/machinery/portable_atmospherics/hydroponics{
+	draw_warnings = 0;
+	icon_state = "hydrotray4"
 	},
 /turf/open/floor/kutjevo/colors/green,
 /area/kutjevo/interior/complex/botany)
@@ -13969,15 +13931,12 @@
 /turf/open/floor/kutjevo/colors/orange,
 /area/kutjevo/interior/power)
 "sIH" = (
-/obj/structure/machinery/portable_atmospherics/hydroponics{
-	draw_warnings = 0;
-	health = null;
-	icon_state = "hydrotray4";
-	indestructible = 1;
-	unacidable = 1
-	},
 /obj/structure/flora/bush/ausbushes/ausbush{
 	pixel_y = 12
+	},
+/obj/structure/machinery/portable_atmospherics/hydroponics{
+	draw_warnings = 0;
+	icon_state = "hydrotray4"
 	},
 /turf/open/floor/kutjevo/colors/green,
 /area/kutjevo/interior/complex/botany)
@@ -14240,10 +14199,7 @@
 	},
 /obj/structure/machinery/portable_atmospherics/hydroponics{
 	draw_warnings = 0;
-	health = null;
-	icon_state = "hydrotray4";
-	indestructible = 1;
-	unacidable = 1
+	icon_state = "hydrotray4"
 	},
 /turf/open/floor/kutjevo/colors/green,
 /area/kutjevo/interior/complex/botany)
@@ -16941,10 +16897,7 @@
 "wBv" = (
 /obj/structure/machinery/portable_atmospherics/hydroponics{
 	draw_warnings = 0;
-	health = null;
-	icon_state = "hydrotray4";
-	indestructible = 1;
-	unacidable = 1
+	icon_state = "hydrotray4"
 	},
 /obj/structure/flora/bush/ausbushes/palebush{
 	pixel_y = 10
@@ -33709,7 +33662,7 @@ qgW
 vDS
 qgW
 kDS
-iGF
+adR
 kDS
 obN
 kDS


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Morgues, crematoriums, and hydro trays can now be broken by Xenos. Morgues and crematoriums will drop 2 metal sheets upon destruction owing to their large volume of metal. Items stored within morgues and crematoriums will not be deleted but instead ejected upon destruction. Testing also shows open morgues will delete both the tongue and the morgue itself.

Hydro trays on Kutjevo were hardcoded to be unbreakable and unacidable so the trays have also been replaced.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Allows Xenos to break a wider variety of objects that maintains consistency with other parts of the game (i.e. machine frames, tables, chairs, window frames, filing cabinets, and others can be broken by Xenos - why not the above?).

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->

## Changelog

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Youbar
balance: Xenos can now slash morgues, crematoriums, and hydro trays
fix: Removed hardcoding on hydro trays on Kutjevo to be unslashable/unacidable
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
