### PR TITLE
Disables shipside IFF 

### DIFF
--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -12,7 +12,7 @@
 			return
 		if(!CONFIG_GET(flag/mentor_tools))
 			to_chat(src, "Mentors do not have permission to use this.")
-	
+
 	var/age = alert(src, "Age check", "Show accounts up to how many days old ?", "7", "30" , "All")
 
 	if(age == "All")
@@ -105,7 +105,7 @@
 		to_chat(usr, SPAN_WARNING("You need to be a ghost in order to use this."))
 
 // bite me
-var/global/explosive_antigrief_on = TRUE
+var/global/explosive_antigrief_on = FALSE
 /client/proc/toggle_explosive_antigrief()
 	set name = "Toggle Explosive Antigrief"
 	set category = "Admin.Game"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

 Requested by Frozentbgg. Disables shipside IFF by default. Admins can still turn it on in the admin tab if they wish.  

## Why It's Good For The Game

 Shipside IFF has been added a year ago or so to counter a multikeying griefer, who has long since stopped trying to do so. Shipside IFF included grenades, the RPG and C4 placement on the ship until code red, for context. Making mistakes is part of SS13 and can bring interesting scenarios to the ship when some new guy accidentally triggers a HEDP. I'm aware that grief may still be possible this way but there are many other ways to grief as is.  

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: memesky
admin: Disabled shipside IFF by default. Admins can still turn it on in the admin tab.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
