### PR TITLE
Fix for trapper's cause_data.

### DIFF
--- a/code/modules/cm_aliens/structures/xeno_structures_boilertrap.dm
+++ b/code/modules/cm_aliens/structures/xeno_structures_boilertrap.dm
@@ -52,7 +52,7 @@
 /obj/effect/alien/resin/boilertrap/proc/trigger_trap(mob/M)
 	if(!istype(M) || !istype(bound_xeno))
 		return
-	var/datum/effects/boiler_trap/F = new(M, bound_xeno)
+	var/datum/effects/boiler_trap/F = new(M, bound_xeno, name)
 	QDEL_IN(F, root_duration)
 	to_chat(bound_xeno, SPAN_XENOHIGHDANGER("You feel one of your traps capture a tallhost!"))
 	to_chat(M, SPAN_XENOHIGHDANGER("You are caught by a trap made of foul resin!"))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

`Cause_data` is a gift that keeps giving. Why is it even illegal to have a causedata with a mob, but without a named cause?..

## Why It's Good For The Game

Closes #1177.

## Changelog

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Trapper's acid shotgun is now boosted by traps as intended.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
