### PR TITLE
Vehicle broadcaster

### DIFF
--- a/code/__DEFINES/cooldowns.dm
+++ b/code/__DEFINES/cooldowns.dm
@@ -5,6 +5,9 @@
 
 #define COOLDOWN_DECLARE(cd_index) var/##cd_index = 0
 
+//cd_source is an atom that is uses this cooldown
+//cd_index is the var that we declared where next use time (current world.time + cd_time) is stored
+//cd_time is the actual time of cooldown
 #define COOLDOWN_START(cd_source, cd_index, cd_time) (cd_source.cd_index = world.time + (cd_time))
 
 //Returns true if the cooldown has run its course, false otherwise

--- a/code/__DEFINES/vehicle.dm
+++ b/code/__DEFINES/vehicle.dm
@@ -55,3 +55,5 @@
 #define VEHICLE_CLASS_HEAVY		(1<<4)		//heavy class armor (tank)
 
 #define TANK_POPLOCK				90
+
+#define COOLDOWN_VEHICLE_BROADCASTER	5 SECONDS

--- a/code/datums/langchat/langchat.dm
+++ b/code/datums/langchat/langchat.dm
@@ -151,6 +151,48 @@
 	else
 		addtimer(CALLBACK(src, /atom.proc/langchat_drop_image, language), timer, TIMER_OVERRIDE|TIMER_UNIQUE|TIMER_NO_HASH_WAIT)
 
+//used for broadcasting from a vehicle
+/mob/proc/langchat_vehicle_broadcast(message, var/list/listeners, language, var/obj/vehicle/multitile/V)
+
+	//uncomment before finishing
+	//if(!V || interactee != V)
+	//	return
+
+	langchat_drop_image()
+	langchat_make_image()
+
+	var/text_left = null
+	var/text_to_display = message
+
+	if(length(message) > LANGCHAT_LONGEST_TEXT)
+		text_to_display = copytext_char(message, 1, LANGCHAT_LONGEST_TEXT - 5) + "..."
+		text_left = "..." + copytext_char(message, LANGCHAT_LONGEST_TEXT - 5)
+	var/timer = 6 SECONDS
+	if(text_left)
+		timer = 4 SECONDS
+	text_to_display = "<span class='center [langchat_styles] langchat_announce langchat'>[text_to_display]</span>"
+
+	langchat_image.maptext = text_to_display
+	langchat_image.maptext_width = LANGCHAT_WIDTH * 2
+
+	langchat_listeners = listeners
+	for(var/mob/M in langchat_listeners)
+		if(langchat_client_enabled(M) && !M.ear_deaf && M.say_understands(src, language))
+			M.client.images += langchat_image
+
+	//uncomment before finishing
+	//if(!isVehicleMultitile(interactee))
+	//	return
+
+	langchat_image.loc = interactee
+	langchat_image.maptext_y += 32
+
+	animate(langchat_image, pixel_y = langchat_image.pixel_y + LANGCHAT_MESSAGE_POP_Y_SINK, alpha = LANGCHAT_MAX_ALPHA, time = LANGCHAT_MESSAGE_POP_TIME)
+	if(text_left)
+		addtimer(CALLBACK(src, /mob.proc/langchat_long_speech, text_left, listeners, language), timer, TIMER_OVERRIDE|TIMER_UNIQUE|TIMER_NO_HASH_WAIT)
+	else
+		addtimer(CALLBACK(src, /mob.proc/langchat_drop_image, language), timer, TIMER_OVERRIDE|TIMER_UNIQUE|TIMER_NO_HASH_WAIT)
+
 /** Displays image to a single listener after it was built above eg. for chaining different game logic than speech code
 This does just that, doesn't check deafness or language! Do what you will in that regard **/
 /atom/proc/langchat_display_image(var/mob/M)

--- a/code/datums/langchat/langchat.dm
+++ b/code/datums/langchat/langchat.dm
@@ -154,9 +154,8 @@
 //used for broadcasting from a vehicle
 /mob/proc/langchat_vehicle_broadcast(message, var/list/listeners, language, var/obj/vehicle/multitile/V)
 
-	//uncomment before finishing
-	//if(!V || interactee != V)
-	//	return
+	if(!V || interactee != V)
+		return
 
 	langchat_drop_image()
 	langchat_make_image()
@@ -179,10 +178,6 @@
 	for(var/mob/M in langchat_listeners)
 		if(langchat_client_enabled(M) && !M.ear_deaf && M.say_understands(src, language))
 			M.client.images += langchat_image
-
-	//uncomment before finishing
-	//if(!isVehicleMultitile(interactee))
-	//	return
 
 	langchat_image.loc = interactee
 	langchat_image.maptext_y += 32

--- a/code/datums/langchat/langchat.dm
+++ b/code/datums/langchat/langchat.dm
@@ -90,9 +90,9 @@
 	langchat_image.maptext_width = LANGCHAT_WIDTH
 
 	langchat_listeners = listeners
-	for(var/mob/M in langchat_listeners)
-		if(langchat_client_enabled(M) && !M.ear_deaf && (skip_language_check || M.say_understands(src, language)))
-			M.client.images += langchat_image
+	for(var/mob/Listener in langchat_listeners)
+		if(langchat_client_enabled(Listener) && !Listener.ear_deaf && (skip_language_check || Listener.say_understands(src, language)))
+			Listener.client.images += langchat_image
 
 	if(isturf(loc))
 		langchat_image.loc = src
@@ -136,9 +136,9 @@
 	langchat_image.maptext_width = LANGCHAT_WIDTH * 2
 
 	langchat_listeners = listeners
-	for(var/mob/M in langchat_listeners)
-		if(langchat_client_enabled(M) && !M.ear_deaf && M.say_understands(src, language))
-			M.client.images += langchat_image
+	for(var/mob/Listener in langchat_listeners)
+		if(langchat_client_enabled(Listener) && !Listener.ear_deaf && Listener.say_understands(src, language))
+			Listener.client.images += langchat_image
 
 	if(isturf(loc))
 		langchat_image.loc = src
@@ -175,9 +175,9 @@
 	langchat_image.maptext_width = LANGCHAT_WIDTH * 2
 
 	langchat_listeners = listeners
-	for(var/mob/M in langchat_listeners)
-		if(langchat_client_enabled(M) && !M.ear_deaf && M.say_understands(src, language))
-			M.client.images += langchat_image
+	for(var/mob/Listener in langchat_listeners)
+		if(langchat_client_enabled(Listener) && !Listener.ear_deaf && Listener.say_understands(src, language))
+			Listener.client.images += langchat_image
 
 	langchat_image.loc = interactee
 	langchat_image.maptext_y += 32

--- a/code/datums/langchat/langchat.dm
+++ b/code/datums/langchat/langchat.dm
@@ -185,8 +185,14 @@
 	animate(langchat_image, pixel_y = langchat_image.pixel_y + LANGCHAT_MESSAGE_POP_Y_SINK, alpha = LANGCHAT_MAX_ALPHA, time = LANGCHAT_MESSAGE_POP_TIME)
 	if(text_left)
 		addtimer(CALLBACK(src, /atom.proc/langchat_long_speech, text_left, listeners, language), timer, TIMER_OVERRIDE|TIMER_UNIQUE|TIMER_NO_HASH_WAIT)
+		addtimer(CALLBACK(src, /mob.proc/restore_maptext_offset), timer, TIMER_OVERRIDE|TIMER_UNIQUE|TIMER_NO_HASH_WAIT)
 	else
 		addtimer(CALLBACK(src, /atom.proc/langchat_drop_image, language), timer, TIMER_OVERRIDE|TIMER_UNIQUE|TIMER_NO_HASH_WAIT)
+		addtimer(CALLBACK(src, /mob.proc/restore_maptext_offset), timer, TIMER_OVERRIDE|TIMER_UNIQUE|TIMER_NO_HASH_WAIT)
+
+//negates mob's maptext offset done in vehicle broadcasting
+/mob/proc/restore_maptext_offset()
+	langchat_image.maptext_y -= 32
 
 /** Displays image to a single listener after it was built above eg. for chaining different game logic than speech code
 This does just that, doesn't check deafness or language! Do what you will in that regard **/

--- a/code/datums/langchat/langchat.dm
+++ b/code/datums/langchat/langchat.dm
@@ -152,9 +152,9 @@
 		addtimer(CALLBACK(src, /atom.proc/langchat_drop_image, language), timer, TIMER_OVERRIDE|TIMER_UNIQUE|TIMER_NO_HASH_WAIT)
 
 //used for broadcasting from a vehicle
-/mob/proc/langchat_vehicle_broadcast(message, var/list/listeners, language, var/obj/vehicle/multitile/V)
+/mob/proc/langchat_vehicle_broadcast(message, var/list/listeners, language, var/obj/vehicle/multitile/Vehicle)
 
-	if(!V || interactee != V)
+	if(!Vehicle || interactee != Vehicle)
 		return
 
 	langchat_drop_image()

--- a/code/datums/langchat/langchat.dm
+++ b/code/datums/langchat/langchat.dm
@@ -184,9 +184,9 @@
 
 	animate(langchat_image, pixel_y = langchat_image.pixel_y + LANGCHAT_MESSAGE_POP_Y_SINK, alpha = LANGCHAT_MAX_ALPHA, time = LANGCHAT_MESSAGE_POP_TIME)
 	if(text_left)
-		addtimer(CALLBACK(src, /mob.proc/langchat_long_speech, text_left, listeners, language), timer, TIMER_OVERRIDE|TIMER_UNIQUE|TIMER_NO_HASH_WAIT)
+		addtimer(CALLBACK(src, /atom.proc/langchat_long_speech, text_left, listeners, language), timer, TIMER_OVERRIDE|TIMER_UNIQUE|TIMER_NO_HASH_WAIT)
 	else
-		addtimer(CALLBACK(src, /mob.proc/langchat_drop_image, language), timer, TIMER_OVERRIDE|TIMER_UNIQUE|TIMER_NO_HASH_WAIT)
+		addtimer(CALLBACK(src, /atom.proc/langchat_drop_image, language), timer, TIMER_OVERRIDE|TIMER_UNIQUE|TIMER_NO_HASH_WAIT)
 
 /** Displays image to a single listener after it was built above eg. for chaining different game logic than speech code
 This does just that, doesn't check deafness or language! Do what you will in that regard **/

--- a/code/modules/vehicles/apc/apc.dm
+++ b/code/modules/vehicles/apc/apc.dm
@@ -96,21 +96,23 @@ GLOBAL_LIST_EMPTY(command_apc_list)
 		return
 	add_verb(M.client, list(
 		/obj/vehicle/multitile/proc/get_status_info,
-		/obj/vehicle/multitile/proc/open_controls_guide
+		/obj/vehicle/multitile/proc/open_controls_guide,
 	))
 	if(seat == VEHICLE_DRIVER)
 		add_verb(M.client, list(
 			/obj/vehicle/multitile/proc/toggle_door_lock,
 			/obj/vehicle/multitile/proc/activate_horn,
-			/obj/vehicle/multitile/proc/name_vehicle
+			/obj/vehicle/multitile/proc/name_vehicle,
+			/obj/vehicle/multitile/proc/use_broadcaster,
 		))
 	else if(seat == VEHICLE_GUNNER)
 		add_verb(M.client, list(
 			/obj/vehicle/multitile/proc/switch_hardpoint,
 			/obj/vehicle/multitile/proc/cycle_hardpoint,
 			/obj/vehicle/multitile/proc/toggle_shift_click,
-			/obj/vehicle/multitile/proc/name_vehicle
-		))
+			/obj/vehicle/multitile/proc/name_vehicle,
+			/obj/vehicle/multitile/proc/use_broadcaster,
+	))
 
 	else if(seat == VEHICLE_SUPPORT_GUNNER_ONE || seat == VEHICLE_SUPPORT_GUNNER_TWO)
 		add_verb(M.client, list(
@@ -129,14 +131,16 @@ GLOBAL_LIST_EMPTY(command_apc_list)
 			/obj/vehicle/multitile/proc/toggle_door_lock,
 			/obj/vehicle/multitile/proc/activate_horn,
 			/obj/vehicle/multitile/proc/name_vehicle,
-		))
+			/obj/vehicle/multitile/proc/use_broadcaster,
+	))
 	else if(seat == VEHICLE_GUNNER)
 		remove_verb(M.client, list(
 			/obj/vehicle/multitile/proc/switch_hardpoint,
 			/obj/vehicle/multitile/proc/cycle_hardpoint,
 			/obj/vehicle/multitile/proc/toggle_shift_click,
 			/obj/vehicle/multitile/proc/name_vehicle,
-		))
+			/obj/vehicle/multitile/proc/use_broadcaster,
+	))
 	else if(seat == VEHICLE_SUPPORT_GUNNER_ONE || seat == VEHICLE_SUPPORT_GUNNER_TWO)
 		remove_verb(M.client, list(
 			/obj/vehicle/multitile/proc/reload_firing_port_weapon

--- a/code/modules/vehicles/apc/apc_command.dm
+++ b/code/modules/vehicles/apc/apc_command.dm
@@ -63,6 +63,8 @@
 		/obj/vehicle/multitile/proc/get_status_info,
 		/obj/vehicle/multitile/proc/open_controls_guide,
 		/obj/vehicle/multitile/proc/name_vehicle,
+		/obj/vehicle/multitile/proc/use_broadcaster,
+
 	))
 	if(seat == VEHICLE_DRIVER)
 		add_verb(M.client, list(
@@ -83,6 +85,7 @@
 		/obj/vehicle/multitile/proc/get_status_info,
 		/obj/vehicle/multitile/proc/open_controls_guide,
 		/obj/vehicle/multitile/proc/name_vehicle,
+		/obj/vehicle/multitile/proc/use_broadcaster,
 	))
 	if(seat == VEHICLE_DRIVER)
 		remove_verb(M.client, list(

--- a/code/modules/vehicles/apc/apc_medical.dm
+++ b/code/modules/vehicles/apc/apc_medical.dm
@@ -7,7 +7,6 @@
 
 	interior_map = "apc_med"
 
-
 	passengers_slots = 8
 	//MED APC can store additional 6 dead revivable bodies for the triage
 	//but interior won't allow more revivable dead if passengers_taken_slots >= passengers_slots + revivable_dead_slots
@@ -49,6 +48,7 @@
 		/obj/vehicle/multitile/proc/get_status_info,
 		/obj/vehicle/multitile/proc/open_controls_guide,
 		/obj/vehicle/multitile/proc/name_vehicle,
+		/obj/vehicle/multitile/proc/use_broadcaster,
 	))
 	if(seat == VEHICLE_DRIVER)
 		add_verb(M.client, list(
@@ -69,6 +69,7 @@
 		/obj/vehicle/multitile/proc/get_status_info,
 		/obj/vehicle/multitile/proc/open_controls_guide,
 		/obj/vehicle/multitile/proc/name_vehicle,
+		/obj/vehicle/multitile/proc/use_broadcaster,
 	))
 	if(seat == VEHICLE_DRIVER)
 		remove_verb(M.client, list(

--- a/code/modules/vehicles/multitile/multitile.dm
+++ b/code/modules/vehicles/multitile/multitile.dm
@@ -31,7 +31,7 @@
 	var/next_honk = 0	//to prevent spamming
 
 	//broadcaster
-	var/broadcaster_available = TRUE
+	COOLDOWN_DECLARE(next_broadcasting)
 
 	// List of verbs to give when a mob is seated in each seat type
 	var/list/seat_verbs

--- a/code/modules/vehicles/multitile/multitile.dm
+++ b/code/modules/vehicles/multitile/multitile.dm
@@ -30,6 +30,9 @@
 	var/honk_sound = 'sound/vehicles/honk_4_light.ogg'
 	var/next_honk = 0	//to prevent spamming
 
+	//broadcaster
+	var/broadcaster_available = TRUE
+
 	// List of verbs to give when a mob is seated in each seat type
 	var/list/seat_verbs
 

--- a/code/modules/vehicles/multitile/multitile_verbs.dm
+++ b/code/modules/vehicles/multitile/multitile_verbs.dm
@@ -385,10 +385,6 @@
 
 	log_admin("[key_name(user)] used \a [V]'s broadcaster to say: >[message]<")
 
-	//remove before finishing, this is for testing
-	for(var/i=1,i<5,i++)
-		sleep (1 SECONDS)
-
 	if(user.stat == CONSCIOUS)
 		var/list/mob/living/carbon/human/recipients = viewers(8, V) // slow but we need it
 		for(var/mob/living/carbon/human/O in recipients)

--- a/code/modules/vehicles/tank/tank.dm
+++ b/code/modules/vehicles/tank/tank.dm
@@ -105,6 +105,7 @@
 		/obj/vehicle/multitile/proc/get_status_info,
 		/obj/vehicle/multitile/proc/open_controls_guide,
 		/obj/vehicle/multitile/proc/name_vehicle,
+		/obj/vehicle/multitile/proc/use_broadcaster,
 	))
 	if(seat == VEHICLE_DRIVER)
 		add_verb(M.client, list(
@@ -127,6 +128,7 @@
 		/obj/vehicle/multitile/proc/open_controls_guide,
 		/obj/vehicle/multitile/proc/name_vehicle,
 		/obj/vehicle/multitile/proc/switch_hardpoint,
+		/obj/vehicle/multitile/proc/use_broadcaster,
 	))
 	if(seat == VEHICLE_DRIVER)
 		remove_verb(M.client, list(


### PR DESCRIPTION
## About The Pull Request

1. Added Use Broadcaster verb to armored vehicles, has 5 seconds recharge.
2. Added vehicle specific long langchat proc that needs finishing.
3. Added categories to vehicle verbs.

## Why It's Good For The Game

VCs finally get a way to communicate with marines directly around them.

## Changelog

:cl: Jeser
add: Added Use Broadcaster verb to armored vehicles. Allows VCs to directly address marines near vehicle. Has 5 seconds recharge.
qol: Vehicle verbs now have more compact names and received categories.
/:cl:
