### PR TITLE
Prevents floodlight from being wrenchable

### DIFF
--- a/code/game/machinery/floodlight.dm
+++ b/code/game/machinery/floodlight.dm
@@ -77,14 +77,6 @@
 	if(!ishuman(user))
 		return
 
-	if (HAS_TRAIT(W, TRAIT_TOOL_WRENCH))
-		if (!anchored)
-			anchored = 1
-			to_chat(user, "You anchor the [src] in place.")
-		else
-			anchored = 0
-			to_chat(user, "You remove the bolts from the [src].")
-
 	if (HAS_TRAIT(W, TRAIT_TOOL_SCREWDRIVER))
 		if (!open)
 			if(unlocked)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Floodlights can currently be used to form an impenetrable barricade for Xenos (apart from melting them via boiler/spitter - given that they don't block bullets, a machine gun emplacement can make doing so needlessly difficult at particular chokes). No other object in the game is capable of doing so with such a simple setup, and so floodlights should either be unmovable, or movable but slashable. I am happy to accomodate either in this PR.

Another alternative is that the admin team revises their ruling about floodlight barricades not being an exploit.

![image](https://user-images.githubusercontent.com/9812271/195967945-8ec4dbda-b1bf-477c-b989-27ef77b9507a.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Stops exploits such as

![image](https://user-images.githubusercontent.com/9812271/195967917-ccfd9622-6213-490d-99d6-0c0ae0ec2a65.png)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->

## Changelog

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Youbar
del: Floodlights can no longer be unanchored
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
