### PR TITLE
Let crushers, chargers, and castes capable of spraying acid plow/melt snow layers

### DIFF
--- a/code/game/objects/effects/aliens.dm
+++ b/code/game/objects/effects/aliens.dm
@@ -123,6 +123,25 @@
 			V.handle_acidic_environment(src)
 			continue
 
+	// Melt two layers of snow
+	// Placed after for loop to prevent interference with INITIALIZE_HINT_QDEL
+	if (istype(loc, /turf/open/snow))
+		var/turf/open/snow/ST = loc
+
+		if(ST && ST.bleed_layer)
+			if(ST.bleed_layer > 2)
+				ST.bleed_layer -= 2
+			else
+				ST.bleed_layer = 0
+			ST.update_icon(1, 0)
+
+	if (istype(loc, /turf/open/auto_turf/snow))
+		var/turf/open/auto_turf/snow/S = loc
+
+		if(S && S.bleed_layer)
+			var/new_layer = S.bleed_layer - 2
+			S.changing_layer(new_layer)
+
 	START_PROCESSING(SSobj, src)
 	addtimer(CALLBACK(src, .proc/die), time_to_live)
 	animate(src, time_to_live, alpha = 128)

--- a/code/game/objects/effects/aliens.dm
+++ b/code/game/objects/effects/aliens.dm
@@ -69,7 +69,6 @@
 
 	// check what's in our turf
 	for(var/atom/atm in loc)
-
 		// Other acid sprays? delete ourself
 		if (atm != src && istype(atm, /obj/effect/xenomorph/spray))
 			return INITIALIZE_HINT_QDEL
@@ -102,23 +101,6 @@
 			if( !W.linked_hive || W.linked_hive.hivenumber != hivenumber )
 				W.acid_spray_act()
 				continue
-
-		// Melt all layers of snow
-		if (istype(get_turf(atm), /turf/open/snow))
-			var/turf/open/snow/ST = get_turf(atm)
-
-			if(ST && ST.bleed_layer)
-				if(ST.bleed_layer > 2)
-					ST.bleed_layer -= 2
-				else
-					ST.bleed_layer = 0
-
-		else if (istype(get_turf(atm), /turf/open/auto_turf/snow))
-			var/turf/open/auto_turf/snow/S = get_turf(atm)
-
-			if(S && S.bleed_layer)
-				var/new_layer = S.bleed_layer - 2
-				S.changing_layer(new_layer)
 
 		// Humans?
 		if(isliving(atm)) //For extinguishing mobs on fire

--- a/code/game/objects/effects/aliens.dm
+++ b/code/game/objects/effects/aliens.dm
@@ -103,6 +103,23 @@
 				W.acid_spray_act()
 				continue
 
+		// Melt all layers of snow
+		if (istype(get_turf(atm), /turf/open/snow))
+			var/turf/open/snow/ST = get_turf(atm)
+
+			if(ST && ST.bleed_layer)
+				if(ST.bleed_layer > 2)
+					ST.bleed_layer -= 2
+				else
+					ST.bleed_layer = 0
+
+		else if (istype(get_turf(atm), /turf/open/auto_turf/snow))
+			var/turf/open/auto_turf/snow/S = get_turf(atm)
+
+			if(S && S.bleed_layer)
+				var/new_layer = S.bleed_layer - 2
+				S.changing_layer(new_layer)
+
 		// Humans?
 		if(isliving(atm)) //For extinguishing mobs on fire
 			var/mob/living/M = atm

--- a/code/modules/mob/living/carbon/xenomorph/abilities/crusher/crusher_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/crusher/crusher_abilities.dm
@@ -169,6 +169,22 @@
 	if(momentum > 0)
 		Xeno.use_plasma(plasma_per_step) // take plasma when you have momentum
 
+		var/turf/turf_ahead = get_step(get_turf(Xeno.loc), dir)
+
+		if(istype(turf_ahead, /turf/open/snow))
+			var/turf/open/snow/ST = turf_ahead
+			if(ST && ST.bleed_layer)
+				if(ST.bleed_layer > 2)
+					ST.bleed_layer -= 2
+				else
+					ST.bleed_layer = 0
+
+		else if(istype(turf_ahead, /turf/open/auto_turf/snow))
+			var/turf/open/auto_turf/snow/S = turf_ahead
+			if(S && S.bleed_layer)
+				var/new_layer = S.bleed_layer - 2
+				S.changing_layer(new_layer)
+
 	noise_timer = noise_timer ? --noise_timer : 3
 	if(noise_timer == 3)
 		playsound(Xeno, 'sound/effects/alien_footstep_charge1.ogg', 50)

--- a/code/modules/mob/living/carbon/xenomorph/abilities/crusher/crusher_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/crusher/crusher_abilities.dm
@@ -178,6 +178,7 @@
 					ST.bleed_layer -= 2
 				else
 					ST.bleed_layer = 0
+				ST.update_icon(1, 0)
 
 		else if(istype(turf_ahead, /turf/open/auto_turf/snow))
 			var/turf/open/auto_turf/snow/S = turf_ahead

--- a/code/modules/mob/living/carbon/xenomorph/castes/Crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Crusher.dm
@@ -108,7 +108,7 @@
 			var/turf/open/snow/ST = T
 			if(ST && ST.bleed_layer)
 				ST.bleed_layer = 0
-				ST.update_icon(1, ST.bleed_layer)
+				ST.update_icon(1, 0)
 		else if(istype(T, /turf/open/auto_turf/snow))
 			var/turf/open/auto_turf/snow/S = T
 			if(S && S.bleed_layer)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

As per the title:
- Crushers can strip 3/3 snow layers with their charge ability
- Chargers can strip 2/3 snow layers with their charge ability
- Spitters can strip 2/3 snow layers with their spray acid ability

The implementation is a bit hacky so I do encourage criticism or ways in which the code can be improved (particularly directly copy and pasting the throw_atom() proc which applies to pounces to create a crusher-specific override that checks for snow turf on the way). I also feel that the amount of snow layers to strip might be up for debate so I'll be happy to change that around as needed.

Note that in creating this PR I've discovered that there is a Shivas-specific 'bad del' error popping up with the latest set of code. It is not related to this PR as I've tested it with a clean build and had the same outcome.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Increasing the ability of Xenos to clear snow in an engaging way helps with maps such as Shivas or Sorokyne which are largely dreaded by Xeno players. Originally conceived as a QOL improvement as per #1220, I've instead swapped it out to apply snow plowing/melting to apply to caste-specific abilities.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->

## Changelog

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Youbar
balance: Crushers, chargers, and castes capable of spraying acid can plow/melt snow layers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
