### PR TITLE
Fix for tailstab verbs.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/ability_macro_framework.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/ability_macro_framework.dm
@@ -179,10 +179,7 @@
 			handle_xeno_macro_datum(src, xeno_action)
 			break
 
-/mob/living/carbon/Xenomorph/verb/xeno_tail_stab_action()
-	set category = "Alien"
-	set name = "Tail Stab"
-	set hidden = TRUE
+/mob/living/carbon/Xenomorph/proc/xeno_tail_stab_action()
 	var/mob/living/carbon/Xenomorph/xeno = src
 	if (!istype(xeno))
 		return

--- a/code/modules/mob/living/carbon/xenomorph/abilities/general_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/general_abilities.dm
@@ -420,7 +420,6 @@
 	name = "Tail Stab"
 	action_icon_state = "tail_attack"
 	ability_name = "tail stab"
-	macro_path = /datum/action/xeno_action/verb/verb_tail_stab
 	action_type = XENO_ACTION_CLICK
 	charge_time = 1 SECONDS
 	xeno_cooldown = 10 SECONDS

--- a/code/modules/mob/living/carbon/xenomorph/abilities/general_ability_macros.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/general_ability_macros.dm
@@ -209,10 +209,3 @@
 	set hidden = 1
 	var/action_name = "Order Construction (400)"
 	handle_xeno_macro(src, action_name)
-
-/datum/action/xeno_action/verb/verb_tail_stab()
-	set category = "Alien"
-	set name = "Tail Stab"
-	set hidden = 1
-	var/action_name = "Tail Stab"
-	handle_xeno_macro(src, action_name)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Followup to #1062.
Mixing together macros and keybinds was probably a bad idea to begin withal. Mostly because macros overall are not such a great idea.
Mixing the system meant to enable macroing the actions, though... that is where things started going astray. What was even worse is that having `/mob/living/carbon/Xenomorph/verb/xeno_tail_stab_action()` and `/datum/action/xeno_action/verb/verb_tail_stab()` on the same mob resulted in that mob having two verbs with the same name, and Byond _does not_ approve of that. Pressing a keybind for tailstab as, say, boiler is meant to result in calling `xeno_tail_stab_action()`, but something in probably Byond's own workings interprets that as calling a verb by name Tail Stab - and it so happens to instead call the _other_ verb named Tail Stab, the `verb_tail_stab()` which is defined on xeno action, but is given to the mob anyway for some arcane reason into which I dare not to dig. To make things worse, _that_ verb is defnied as trying to `handle_xeno_macro` with the `action_name` provided, and boilers do not _have_ action with name Tail Stab, they have Toxic Tail Stab. Using `xeno_tail_stab_action()` would have worked fine, because it finds the correct action by primacy check, but that cannot be accessed thanks to the same name problem.
So let us axe it entirely. `xeno_tail_stab_action()` does not need to be a verb with a name and a category - being a procedure callable by keybind suffices completely. And the action datum does not need a entire dedicated associated verb whose sole purpose is to call it while being macroable when same effect is much simpler achieved by existing keybind for the same effect. Keep it simple.
P.S. Similar logic can probably be applied to queen's screech (which, I suspect, got copypasted to make keybind-and-macro for tail stab). I do not play queen, though, so maybe at a later date.
P.P.S. And probably to many other things too. Say no to macros, keybinds are an excellent userfriendly thing that should be used more without requiring players to fiddle with arcane Byond settings.

## Why It's Good For The Game

Is fix.

## Changelog

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Tailstab keybind now actually works for boilers too.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
