### PR TITLE
Spitter Weakrefs

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/Spitter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Spitter.dm
@@ -75,7 +75,7 @@
 			return
 
 		if(WEAKREF(A) in dot_cooldown_atoms)
-		return
+			return
 
 	dot_cooldown_atoms += WEAKREF(A)
 	addtimer(CALLBACK(src, .proc/dot_cooldown_up, A), dot_cooldown_duration)

--- a/code/modules/mob/living/carbon/xenomorph/castes/Spitter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Spitter.dm
@@ -74,12 +74,8 @@
 		if (H.stat == DEAD)
 			return
 
-<<<<<<< refs/remotes/origin/Weakrefs
-	if(WEAKREF(A) in dot_cooldown_atoms)
-=======
 		if(WEAKREF(A) in dot_cooldown_atoms)
->>>>>>> Fixing Weakrefs
-		return
+			return
 
 	dot_cooldown_atoms += WEAKREF(A)
 	addtimer(CALLBACK(src, .proc/dot_cooldown_up, A), dot_cooldown_duration)

--- a/code/modules/mob/living/carbon/xenomorph/castes/Spitter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Spitter.dm
@@ -74,10 +74,10 @@
 		if (H.stat == DEAD)
 			return
 
-	if(WEAKREF (A) in dot_cooldown_atoms)
+	if(WEAKREF(A) in dot_cooldown_atoms)
 		return
 
-	dot_cooldown_atoms += WEAKREF (A)
+	dot_cooldown_atoms += WEAKREF(A)
 	addtimer(CALLBACK(src, .proc/dot_cooldown_up, A), dot_cooldown_duration)
 
 	new /datum/effects/acid(A, bound_xeno, initial(bound_xeno.caste_type))

--- a/code/modules/mob/living/carbon/xenomorph/castes/Spitter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Spitter.dm
@@ -74,11 +74,10 @@
 		if (H.stat == DEAD)
 			return
 
-	for (var/atom/dotA in dot_cooldown_atoms)
-		if (dotA == A)
-			return
+	if(WEAKREF (A) in dot_cooldown_atoms)
+		return
 
-	dot_cooldown_atoms += A
+	dot_cooldown_atoms += WEAKREF (A)
 	addtimer(CALLBACK(src, .proc/dot_cooldown_up, A), dot_cooldown_duration)
 
 	new /datum/effects/acid(A, bound_xeno, initial(bound_xeno.caste_type))

--- a/code/modules/mob/living/carbon/xenomorph/castes/Spitter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Spitter.dm
@@ -74,7 +74,11 @@
 		if (H.stat == DEAD)
 			return
 
+<<<<<<< refs/remotes/origin/Weakrefs
 	if(WEAKREF(A) in dot_cooldown_atoms)
+=======
+		if(WEAKREF(A) in dot_cooldown_atoms)
+>>>>>>> Fixing Weakrefs
 		return
 
 	dot_cooldown_atoms += WEAKREF(A)
@@ -89,6 +93,6 @@
 
 /datum/behavior_delegate/spitter_base/proc/dot_cooldown_up(var/atom/A)
 	if (A != null && !QDELETED(src))
-		dot_cooldown_atoms -= A
+		dot_cooldown_atoms -= WEAKREF(A)
 		if (istype(bound_xeno))
 			to_chat(bound_xeno, SPAN_XENOWARNING("You can soak [A] in acid again!"))

--- a/html/changelogs/archive/2022-10.yml
+++ b/html/changelogs/archive/2022-10.yml
@@ -136,5 +136,7 @@
 2022-10-12:
   Geevies:
   - rscadd: Made armor color sprites more muted.
+  Laser9:
+  - spellcheck: A lot of spelling and grammar mistakes have been fixed.
   Youbar:
   - qol: Cryosleep announcements now include job title


### PR DESCRIPTION


## About The Pull Request

Changes Spitter Hardrefs to Weakrefs

## Why It's Good For The Game

Cleaner code, less HardDels, less HardRefs. Helps me learn refactoring on a basic scale

## Changelog

:cl: Mistfrag
refactor: Spitters no longer use HardRefs for their abilities, now use WeakRefs.
:cl:

