### PR TITLE
Fixes Ledges Dropping Bodies

### DIFF
--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -148,9 +148,9 @@
 	user.forceMove(TT)
 
 	var/list/grabbed_things = list()
-	for(var/obj/item/grab/G in list(user.l_hand, user.r_hand))
-		grabbed_things += G.grabbed_thing
-		G.grabbed_thing.forceMove(user.loc)
+	for(var/obj/item/grab/grab in list(user.l_hand, user.r_hand))
+		grabbed_things += grab.grabbed_thing
+		grab.grabbed_thing.forceMove(user.loc)
 	user.forceMove(TT)
 	for(var/atom/movable/thing as anything in grabbed_things) // grabbed things aren't moved to the tile immediately to: make the animation better, preserve the grab
 		thing.forceMove(TT)

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -151,7 +151,6 @@
 	for(var/obj/item/grab/grab in list(user.l_hand, user.r_hand))
 		grabbed_things += grab.grabbed_thing
 		grab.grabbed_thing.forceMove(user.loc)
-	user.forceMove(TT)
 	for(var/atom/movable/thing as anything in grabbed_things) // grabbed things aren't moved to the tile immediately to: make the animation better, preserve the grab
 		thing.forceMove(TT)
 

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -147,6 +147,14 @@
 
 	user.forceMove(TT)
 
+	var/list/grabbed_things = list()
+	for(var/obj/item/grab/G in list(user.l_hand, user.r_hand))
+		grabbed_things += G.grabbed_thing
+		G.grabbed_thing.forceMove(user.loc)
+	user.forceMove(TT)
+	for(var/atom/movable/thing as anything in grabbed_things) // grabbed things aren't moved to the tile immediately to: make the animation better, preserve the grab
+		thing.forceMove(TT)
+
 /obj/structure/proc/structure_shaken()
 
 	for(var/mob/living/M in get_turf(src))

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -299,9 +299,15 @@
 		return 0
 
 /mob/living/forceMove(atom/destination)
-	if(pulling && !destination.Adjacent(pulling))
-	if(pulledby && !destination.Adjacent(pulledby))
-		pulledby.stop_pulling()
+	if(pulling)
+		var/pull_dist = get_dist(pulling, destination)
+		if(pulling.z != destination?.z || pull_dist < 0 || pull_dist > 1)
+			stop_pulling()
+	if(pulledby) // This being doubled up screams misdesign
+		var/pull_dist = get_dist(pulledby, destination)
+		if(pulledby.z != destination?.z || pull_dist < 0 || pull_dist > 1)
+			pulledby.stop_pulling()
+
 	if(buckled && destination != buckled.loc)
 		buckled.unbuckle()
 	. = ..()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -299,8 +299,8 @@
 		return 0
 
 /mob/living/forceMove(atom/destination)
-	stop_pulling()
-	if(pulledby)
+	if(pulling && !destination.Adjacent(pulling))
+	if(pulledby && !destination.Adjacent(pulledby))
 		pulledby.stop_pulling()
 	if(buckled && destination != buckled.loc)
 		buckled.unbuckle()


### PR DESCRIPTION
## About The Pull Request

Changes it so you can fireman carry and pull bodies over ledges, windows and etc.

## Why It's Good For The Game

This beforehand was an unintentional bug wherein bodies were dropped going over windows due to how the code was written. This fixes that and removes a bit of jank from the game. Code done by Geeves originally, updated by Misty.

## Changelog
:cl: Geevies, Misty
add: Makes it so you can fireman carry/drag bodies over ledges.
fix: Refactored code in living mobs and structures to fix a bug wherein people couldn't carry over ledges or windows.
:cl:

