### PR TITLE
All fueltank dispensers are wrenchable

### DIFF
--- a/code/game/objects/structures/reagent_dispensers.dm
+++ b/code/game/objects/structures/reagent_dispensers.dm
@@ -15,6 +15,7 @@
 	var/dispensing = TRUE
 
 /obj/structure/reagent_dispensers/attackby(obj/item/W as obj, mob/user as mob)
+	. = ..()
 	return
 
 /obj/structure/reagent_dispensers/Initialize(mapload, reagent_amount = 1000)
@@ -208,12 +209,6 @@
 
 /obj/structure/reagent_dispensers/fueltank/attackby(obj/item/W as obj, mob/user as mob)
 	src.add_fingerprint(user)
-
-	if(HAS_TRAIT(W, TRAIT_TOOL_WRENCH))
-		if(user.action_busy)
-			return TRUE
-		toggle_anchored(W, user)
-		return TRUE
 
 	if(user.action_busy)
 		to_chat(user, SPAN_WARNING("You're already peforming an action!"))
@@ -470,6 +465,7 @@
 	icon_state = "virusfoodtank"
 	amount_per_transfer_from_this = 10
 	anchored = 1
+	wrenchable = FALSE
 	density = 0
 	chemical = "virusfood"
 

--- a/code/game/objects/structures/reagent_dispensers.dm
+++ b/code/game/objects/structures/reagent_dispensers.dm
@@ -14,9 +14,6 @@
 	var/chemical = ""
 	var/dispensing = TRUE
 
-/obj/structure/reagent_dispensers/attackby(obj/item/W as obj, mob/user as mob)
-	. = ..()
-	return
 
 /obj/structure/reagent_dispensers/Initialize(mapload, reagent_amount = 1000)
 	. = ..()

--- a/code/game/objects/structures/reagent_dispensers.dm
+++ b/code/game/objects/structures/reagent_dispensers.dm
@@ -14,6 +14,8 @@
 	var/chemical = ""
 	var/dispensing = TRUE
 
+/obj/structure/reagent_dispensers/attackby(obj/item/W as obj, mob/user as mob)
+	return
 
 /obj/structure/reagent_dispensers/Initialize(mapload, reagent_amount = 1000)
 	. = ..()
@@ -206,6 +208,12 @@
 
 /obj/structure/reagent_dispensers/fueltank/attackby(obj/item/W as obj, mob/user as mob)
 	src.add_fingerprint(user)
+
+	if(HAS_TRAIT(W, TRAIT_TOOL_WRENCH))
+		if(user.action_busy)
+			return TRUE
+		toggle_anchored(W, user)
+		return TRUE
 
 	if(user.action_busy)
 		to_chat(user, SPAN_WARNING("You're already peforming an action!"))
@@ -423,6 +431,7 @@
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "peppertank"
 	anchored = 1
+	wrenchable =  FALSE
 	density = 0
 	amount_per_transfer_from_this = 45
 	chemical = "condensedcapsaicin"

--- a/code/game/objects/structures/reagent_dispensers.dm
+++ b/code/game/objects/structures/reagent_dispensers.dm
@@ -15,6 +15,7 @@
 	var/dispensing = TRUE
 
 /obj/structure/reagent_dispensers/attackby(obj/item/W as obj, mob/user as mob)
+	. = ..()
 	return
 
 /obj/structure/reagent_dispensers/Initialize(mapload, reagent_amount = 1000)

--- a/code/game/objects/structures/reagent_dispensers.dm
+++ b/code/game/objects/structures/reagent_dispensers.dm
@@ -14,10 +14,6 @@
 	var/chemical = ""
 	var/dispensing = TRUE
 
-/obj/structure/reagent_dispensers/attackby(obj/item/W as obj, mob/user as mob)
-	. = ..()
-	return
-
 /obj/structure/reagent_dispensers/Initialize(mapload, reagent_amount = 1000)
 	. = ..()
 	create_reagents(reagent_amount)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Makes all fueltanks wrenchable to those with the skill. Closes https://github.com/cmss13-devs/cmss13/issues/1097 an issue marked as a bug meaning it is unintended.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Give player control over where reagent tanks are locked down to. No more getting shoved around by marines.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->

## Changelog

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: aceroy
fix: All fueltank dispensers are now wrenchable
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
