### PR TITLE
Fixes flashbangs permadeafening 

### DIFF
--- a/code/game/objects/items/explosives/grenades/flashbang.dm
+++ b/code/game/objects/items/explosives/grenades/flashbang.dm
@@ -105,24 +105,21 @@
 			M.Stun(10)
 			M.KnockDown(3)
 			M.SetEarDeafness(max(M.ear_deaf,15))
-			if(!no_damage)
-				if((prob(14) || (M == src.loc && prob(70))))
-					M.ear_damage += rand(1, 10)
-				else
-					M.ear_damage += rand(0, 5)
+
+
 
 	else if(get_dist(M, T) <= 5)
 		if(!trained_human)
 			M.Stun(8)
 			M.SetEarDeafness(max(M.ear_deaf,10))
-			if(!no_damage)
-				M.ear_damage += rand(0, 3)
+
+
 
 	else if(!trained_human)
 		M.Stun(4)
 		M.SetEarDeafness(max(M.ear_deaf,5))
-		if(!no_damage)
-			M.ear_damage += rand(0, 1)
+
+
 
 //This really should be in mob not every check
 	if(ishuman(M))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Flashbangs no longer cause ear damage, stopping marines from getting permanently deafened when there's no solution to it past ahealing.

## Why It's Good For The Game

Flashbangs only purpose is to stun crowds of marines and give MPs time to escape/take people in. Ear damage only causes round permanent damage to marines and can only be healed by aheals, this stops that.

## Changelog



:cl: memesky

fix: Flashbangs no longer cause ear damage.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
