### PR TITLE
Slight Survivor Loot Nerf

### DIFF
--- a/maps/map_files/DesertDam/Desert_Dam.dmm
+++ b/maps/map_files/DesertDam/Desert_Dam.dmm
@@ -34131,7 +34131,7 @@
 /area/desert_dam/building/security/armory)
 "bYr" = (
 /obj/structure/surface/rack,
-/obj/item/ammo_magazine/shotgun/incendiary,
+/obj/item/ammo_magazine/shotgun/buckshot,
 /turf/open/floor/prison,
 /area/desert_dam/building/security/armory)
 "bYs" = (

--- a/maps/map_files/FOP_v3_Sciannex/Fiorina_SciAnnex.dmm
+++ b/maps/map_files/FOP_v3_Sciannex/Fiorina_SciAnnex.dmm
@@ -8188,13 +8188,6 @@
 /obj/item/prop/helmetgarb/riot_shield,
 /turf/open/floor/prison,
 /area/fiorina/station/security)
-"eSH" = (
-/obj/effect/spawner/random/sentry/midchance,
-/turf/open/floor/prison{
-	dir = 6;
-	icon_state = "yellow"
-	},
-/area/fiorina/station/lowsec)
 "eSZ" = (
 /obj/structure/bed/roller,
 /turf/open/floor/prison{
@@ -8714,7 +8707,6 @@
 /area/fiorina/station/park)
 "fgU" = (
 /obj/structure/surface/table/reinforced/prison,
-/obj/effect/spawner/random/sentry/midchance,
 /turf/open/floor/plating/prison,
 /area/fiorina/station/power_ring)
 "fhc" = (
@@ -23413,7 +23405,6 @@
 /area/fiorina/tumor/ice_lab)
 "nNJ" = (
 /obj/structure/surface/rack,
-/obj/effect/spawner/random/sentry/midchance,
 /turf/open/floor/plating/prison,
 /area/fiorina/maintenance)
 "nOw" = (
@@ -27011,17 +27002,6 @@
 	},
 /turf/open/floor/prison,
 /area/fiorina/station/security/wardens)
-"qet" = (
-/obj/structure/machinery/light/double/blue{
-	dir = 4;
-	pixel_x = 10;
-	pixel_y = 13
-	},
-/obj/effect/spawner/random/sentry/midchance,
-/turf/open/floor/corsat{
-	icon_state = "plate"
-	},
-/area/fiorina/station/flight_deck)
 "qeu" = (
 /obj/structure/toilet{
 	pixel_y = 4
@@ -76052,7 +76032,7 @@ mcc
 avl
 kqC
 avl
-eSH
+iUy
 kqC
 ggp
 xri
@@ -85322,7 +85302,7 @@ roY
 roY
 mPW
 vvM
-qet
+tet
 eyz
 qGn
 tet

--- a/maps/map_files/Ice_Colony_v3/Shivas_Snowball.dmm
+++ b/maps/map_files/Ice_Colony_v3/Shivas_Snowball.dmm
@@ -2958,7 +2958,7 @@
 /area/shiva/interior/colony/n_admin)
 "anY" = (
 /obj/structure/surface/rack,
-/obj/item/ammo_magazine/shotgun/incendiary,
+/obj/item/ammo_magazine/shotgun/buckshot,
 /turf/open/floor/shiva{
 	dir = 8;
 	icon_state = "redfull"

--- a/maps/map_files/LV624/LV624.dmm
+++ b/maps/map_files/LV624/LV624.dmm
@@ -18335,10 +18335,13 @@
 /area/lv624/ground/jungle/north_east_jungle)
 "mMv" = (
 /obj/structure/surface/rack,
-/obj/item/ammo_magazine/shotgun/incendiary,
 /obj/item/explosive/grenade/incendiary/molotov{
 	pixel_x = -5;
 	pixel_y = -1
+	},
+/obj/item/ammo_magazine/shotgun/buckshot{
+	pixel_x = 6;
+	pixel_y = -2
 	},
 /turf/open/floor{
 	dir = 8;


### PR DESCRIPTION
## About The Pull Request

Nerfs surv loot on fiorina, LV, and trijent

## Why It's Good For The Game

Survivors should not have access to this type of thing, it makes the role more about fragging rather then what it should be, surviving.

## Changelog
:cl:
balance: incendiary slugs are replaced with normal buckshot on all maps 
balance: a few of the sentry spawners on annex have been removed 
/:cl:


