### PR TITLE
Nailgun no longer superslows on hit, its repair rate has been increased.

### DIFF
--- a/code/game/objects/structures/barricade/deployable.dm
+++ b/code/game/objects/structures/barricade/deployable.dm
@@ -15,7 +15,7 @@
 	climbable = FALSE
 	unacidable = TRUE
 	anchored = TRUE
-	repair_materials = list("metal" = 0.3, "plasteel" = 0.45)
+	repair_materials = list("metal" = 0.4, "plasteel" = 0.55)
 	var/build_state = BARRICADE_BSTATE_SECURED //Look at __game.dm for barricade defines
 	var/source_type = /obj/item/stack/folding_barricade	//had to add this here, cause mapped in porta cades were unfoldable.
 

--- a/code/game/objects/structures/barricade/metal.dm
+++ b/code/game/objects/structures/barricade/metal.dm
@@ -15,7 +15,7 @@
 	barricade_hitsound = 'sound/effects/metalhit.ogg'
 	barricade_type = "metal"
 	can_wire = TRUE
-	repair_materials = list("metal" = 0.3, "plasteel" = 0.45)
+	repair_materials = list("metal" = 0.4, "plasteel" = 0.55)
 	var/build_state = BARRICADE_BSTATE_SECURED //Look at __game.dm for barricade defines
 	var/upgrade = null
 

--- a/code/game/objects/structures/barricade/plasteel.dm
+++ b/code/game/objects/structures/barricade/plasteel.dm
@@ -283,6 +283,6 @@
 	stack_amount = 6
 	destroyed_stack_amount = 3
 	barricade_type = "folding_metal"
-	repair_materials = list("metal" = 0.3, "plasteel" = 0.45)
+	repair_materials = list("metal" = 0.4, "plasteel" = 0.55)
 
 	linkable = FALSE

--- a/code/game/turfs/walls/walls.dm
+++ b/code/game/turfs/walls/walls.dm
@@ -29,7 +29,7 @@
 	var/list/wall_connections = list("0", "0", "0", "0")
 	var/neighbors_list = 0
 	var/max_temperature = 1800 //K, walls will take damage if they're next to a fire hotter than this
-	var/repair_materials = list("wood"= 0.075, "metal" = 0.15, "plasteel" = 0.3) //Max health % recovered on a nailgun repair
+	var/repair_materials = list("wood"= 0.090, "metal" = 0.35, "plasteel" = 0.6) //Max health % recovered on a nailgun repair
 
 	var/d_state = 0 //Normal walls are now as difficult to remove as reinforced walls
 

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -800,27 +800,6 @@
 	L.update_canmove()
 	addtimer(CALLBACK(L, /mob.proc/unfreeze), 3 SECONDS)
 
-/datum/ammo/bullet/smg/nail/on_hit_mob(mob/living/L, obj/item/projectile/P)
-	if(!L || L == P.firer || L.lying)
-		return
-
-	L.AdjustSlowed(1) //Slow on hit.
-	L.recalculate_move_delay = TRUE
-	var/super_slowdown_duration = 3
-	//If there's an obstacle on the far side, superslow and do extra damage.
-	if(isCarbonSizeXeno(L)) //Unless they're a strong xeno, in which case the slowdown is drastically reduced
-		var/mob/living/carbon/Xenomorph/X = L
-		if(X.tier != 1) // 0 is queen!
-			super_slowdown_duration = 0.5
-	else if(HAS_TRAIT(L, TRAIT_SUPER_STRONG))
-		super_slowdown_duration = 0.5
-
-	var/atom/movable/thick_surface = LinkBlocked(L, get_turf(L), get_step(L, get_dir(P.loc ? P : P.firer, L)))
-	if(!thick_surface || ismob(thick_surface) && !thick_surface.anchored)
-		return
-
-	L.apply_armoured_damage(damage*0.5, ARMOR_BULLET, BRUTE, null, penetration)
-	L.AdjustSuperslowed(super_slowdown_duration)
 
 /datum/ammo/bullet/smg/incendiary
 	name = "incendiary submachinegun bullet"


### PR DESCRIPTION
## About The Pull Request

Reverted Aladruns buffs to the nail gun through superslows, and increased the repair rate on all cades/walls with the nailgun.

## Why It's Good For The Game

A utility weapon such as the nail gun being used simply for it's slow effect and not for repairing cades, is terrible balancing. Not only is it completely ignored with potentially being a quick fixer for cades, it's almost entirely used either to superslow Predators, or xeno's which I believe is a wrongful mechanic and shouldn't be put on a utility based tool such as the nail gun. By increasing the repair rate, and removing the slowdown on hit (on a 48 mag mini SMG) I believe the nail gun would have a much better place in CM rather than being an easy way to get slow effects on mobs. I haven't touched the PB code either, so I believe this change will be healthy for CM.

Approval for this PR was given by Geeves (architect).

## Changelog

:cl: Usnpeepoo
balance: Reverted nail guns slow on hit mechanic
balance: Nailgun repair rate for cades, and walls have been buffed.
/:cl:
