### PR TITLE
Acid tower now hits enemies / xenos on top of it.

### DIFF
--- a/code/modules/cm_aliens/XenoStructures.dm
+++ b/code/modules/cm_aliens/XenoStructures.dm
@@ -567,7 +567,7 @@
 	if(info.distance_travelled > range)
 		return FALSE
 
-	if(info.distance_travelled > 0 && info.current_turf == info.target_turf )
+	if(info.distance_travelled && info.current_turf == info.target_turf )
 		return FALSE
 
 	var/turf/next_turf = get_step_towards(info.current_turf, info.target_turf)

--- a/code/modules/cm_aliens/XenoStructures.dm
+++ b/code/modules/cm_aliens/XenoStructures.dm
@@ -567,7 +567,7 @@
 	if(info.distance_travelled > range)
 		return FALSE
 
-	if(!info.distance_travelled == 0 && info.current_turf == info.target_turf )
+	if(info.distance_travelled > 0 && info.current_turf == info.target_turf )
 		return FALSE
 
 	var/turf/next_turf = get_step_towards(info.current_turf, info.target_turf)

--- a/code/modules/cm_aliens/XenoStructures.dm
+++ b/code/modules/cm_aliens/XenoStructures.dm
@@ -564,7 +564,10 @@
 	if(QDELETED(src))
 		return FALSE
 
-	if(info.distance_travelled > range || info.current_turf == info.target_turf)
+	if(info.distance_travelled > range)
+		return FALSE
+
+	if(!info.distance_travelled == 0 && info.current_turf == info.target_turf )
 		return FALSE
 
 	var/turf/next_turf = get_step_towards(info.current_turf, info.target_turf)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
standing on top of acid pillars made the sound but the spit tracking was bugged . this PR fixes it

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->

bug bad 

## Changelog

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Acid Pillar now properly spits acid to Enemies or xenos on fire that are located on top of it .
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
