### PR TITLE
CMOs entry message no longer says the CMO is not in the chain of command

### DIFF
--- a/code/game/jobs/job/civilians/support/cmo.dm
+++ b/code/game/jobs/job/civilians/support/cmo.dm
@@ -6,7 +6,7 @@
 	selection_class = "job_cmo"
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT
 	gear_preset = /datum/equipment_preset/uscm_ship/uscm_medical/cmo
-	entry_message_body = "You're a commissioned officer of the USCM. You are not in the ship's chain of command, though you have authority over everything related to Medbay and Research, only able to be overriden by the XO and CO. You are in charge of medical staff, surgery, chemistry, stimulants and keeping the marines healthy overall."
+	entry_message_body = "You're a commissioned officer of the USCM. You have authority over everything related to Medbay and Research, only able to be overriden by the XO and CO. You are in charge of medical staff, surgery, chemistry, stimulants and keeping the marines healthy overall."
 
 AddTimelock(/datum/job/civilian/professor, list(
 	JOB_MEDIC_ROLES = 10 HOURS


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

CMO description said the CMO was not in the chain of command

## Changelog

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Description when joining as CMO no longer erroneously states the CMO is not part of the chain of command. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
