### PR TITLE
Fixes an unintended bug with the M2C that let you shoot a gun and a weapon at the same time.

### DIFF
--- a/code/modules/cm_marines/smartgun_mount.dm
+++ b/code/modules/cm_marines/smartgun_mount.dm
@@ -1093,7 +1093,7 @@
 	M.anchored = TRUE
 	playsound(M, 'sound/items/m56dauto_setup.ogg', 75, TRUE)
 	to_chat(user, SPAN_NOTICE("You deploy \the [M]."))
-	if((rounds > 0) && user.get_active_hand() || user.get_inactive_hand())
+	if((rounds > 0) && !user.get_inactive_hand())
 		user.set_interaction(M)
 	M.rounds = rounds
 	M.overheat_value = overheat_value

--- a/code/modules/cm_marines/smartgun_mount.dm
+++ b/code/modules/cm_marines/smartgun_mount.dm
@@ -745,7 +745,7 @@
 	if(user.lying || get_dist(user,src) > 1 || user.is_mob_incapacitated())
 		user.unset_interaction()
 		return HANDLE_CLICK_UNHANDLED
-	if(user.get_active_hand())
+	if(user.get_active_hand() || user.get_inactive_hand())
 		to_chat(usr, SPAN_WARNING("You need a free hand to shoot \the [src]."))
 		return HANDLE_CLICK_UNHANDLED
 	if(!user.allow_gun_usage)
@@ -1093,7 +1093,7 @@
 	M.anchored = TRUE
 	playsound(M, 'sound/items/m56dauto_setup.ogg', 75, TRUE)
 	to_chat(user, SPAN_NOTICE("You deploy \the [M]."))
-	if((rounds > 0) && !user.get_inactive_hand())
+	if((rounds > 0) && user.get_active_hand() || user.get_inactive_hand())
 		user.set_interaction(M)
 	M.rounds = rounds
 	M.overheat_value = overheat_value

--- a/code/modules/cm_marines/smartgun_mount.dm
+++ b/code/modules/cm_marines/smartgun_mount.dm
@@ -746,7 +746,7 @@
 		user.unset_interaction()
 		return HANDLE_CLICK_UNHANDLED
 	if(user.get_active_hand() || user.get_inactive_hand())
-		to_chat(usr, SPAN_WARNING("You need a free hand to shoot \the [src]."))
+		to_chat(usr, SPAN_WARNING("You need two free hands to shoot \the [src]."))
 		return HANDLE_CLICK_UNHANDLED
 	if(!user.allow_gun_usage)
 		to_chat(user, SPAN_WARNING("You aren't allowed to use firearms!"))


### PR DESCRIPTION
## About The Pull Request

Title, this was an unintended feature of the M2C that let you increase your DPS/utility by shooting two guns (and wielding!) at the same time. This PR fixes it.

## Why It's Good For The Game

No stupid combos with slugs, flamers, etc with the M2C and following up on a year old comment on optimisticdudes fix PR.
![image](https://user-images.githubusercontent.com/72160946/197369572-f3ccd097-cf9c-4ef6-9ad2-240a3c79fc5d.png)

## Changelog

:cl:Usnpeepoo
fix: M2C can no longer be shot at with an item/gun in your active hand.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
