### PR TITLE
Fixes displaced APC in Sorokyne.

### DIFF
--- a/maps/map_files/Sorokyne_Strata/Sorokyne_Strata.dmm
+++ b/maps/map_files/Sorokyne_Strata/Sorokyne_Strata.dmm
@@ -33284,6 +33284,9 @@
 /turf/closed/wall/strata_outpost/reinforced,
 /area/strata/ag/interior/tcomms)
 "gSz" = (
+/obj/structure/machinery/power/apc{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/strata/ag/exterior/marsh/center)
 "gSR" = (
@@ -39916,14 +39919,6 @@
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/strata,
 /area/strata/ag/interior/tcomms)
-"rXQ" = (
-/obj/structure/machinery/power/apc{
-	dir = 1;
-	pixel_x = 29;
-	start_charge = 0
-	},
-/turf/open/auto_turf/snow/brown_base/layer2,
-/area/strata/ag/exterior/marsh/center)
 "sau" = (
 /obj/structure/machinery/power/terminal{
 	dir = 8;
@@ -54329,7 +54324,7 @@ aac
 aac
 aac
 bnj
-rXQ
+bnj
 bnj
 ble
 ble


### PR DESCRIPTION
## About The Pull Request

Title, APC was displaced on Sorokyne this fixes it.

## Why It's Good For The Game

No more floating APC's, should make the game a lot more balanced.
## Changelog


:cl:
fix: Misplaced APC on Sorokyne
/:cl:
