### PR TITLE
fixed m56d zoom bug

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -845,11 +845,6 @@ cases. Override_icon_state should be a list.*/
 	user.visible_message(SPAN_NOTICE("[user] peers through \the [zoom_device]."),
 	SPAN_NOTICE("You peer through \the [zoom_device]."))
 	zoom = !zoom
-	// if(user.interactee)
-	// 	user.unset_interaction()
-	// else
-	// 	user.set_interaction(src)
-
 
 /obj/item/proc/get_icon_state(mob/user_mob, slot)
 	var/mob_state

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -809,7 +809,10 @@ cases. Override_icon_state should be a list.*/
 	if(world.time <= user.zoom_cooldown) //If we are spamming the zoom, cut it out
 		return
 	user.zoom_cooldown = world.time + 20
-
+	if(user.interactee)
+		user.unset_interaction()
+	else
+		user.set_interaction(src)
 	if(user.client)
 		user.client.change_view(viewsize, src)
 
@@ -842,10 +845,10 @@ cases. Override_icon_state should be a list.*/
 	user.visible_message(SPAN_NOTICE("[user] peers through \the [zoom_device]."),
 	SPAN_NOTICE("You peer through \the [zoom_device]."))
 	zoom = !zoom
-	if(user.interactee)
-		user.unset_interaction()
-	else
-		user.set_interaction(src)
+	// if(user.interactee)
+	// 	user.unset_interaction()
+	// else
+	// 	user.set_interaction(src)
 
 
 /obj/item/proc/get_icon_state(mob/user_mob, slot)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Fixes the the zoom bug with the m56d by making the unset interaction method happen earlier when zoom method is called. Closes https://github.com/cmss13-devs/cmss13/issues/1173
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
bug fix
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->

## Changelog

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Aceroy
fix: No more zoom glitches with binoculars and mounted turrets.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
