### PR TITLE
Repairing property fix

### DIFF
--- a/code/modules/reagents/chemistry_properties/prop_positive.dm
+++ b/code/modules/reagents/chemistry_properties/prop_positive.dm
@@ -80,7 +80,7 @@
 	var/mob/living/carbon/human/C = M
 	var/obj/limb/L = pick(C.limbs)
 	if(L && (L.status & (LIMB_ROBOT|LIMB_SYNTHSKIN)))
-		L.heal_damage(POTENCY_MULTIPLIER_MEDIUM * potency, POTENCY_MULTIPLIER_MEDIUM * potency, TRUE)
+		L.heal_damage(POTENCY_MULTIPLIER_MEDIUM * potency, POTENCY_MULTIPLIER_MEDIUM * potency, robo_repair = TRUE)
 
 /datum/chem_property/positive/repairing/process_overdose(mob/living/M, var/potency = 1)
 	M.apply_damage(potency, TOX)
@@ -95,7 +95,7 @@
 	for(var/obj/limb/T in H.limbs)
 		if(!(T.status & (LIMB_ROBOT|LIMB_SYNTHSKIN)))
 			continue
-		T.heal_damage(potency * volume,potency * volume, TRUE)
+		T.heal_damage(potency * volume,potency * volume, robo_repair = TRUE)
 
 /datum/chem_property/positive/hemogenic
 	name = PROPERTY_HEMOGENIC

--- a/code/modules/reagents/chemistry_properties/prop_positive.dm
+++ b/code/modules/reagents/chemistry_properties/prop_positive.dm
@@ -80,7 +80,7 @@
 	var/mob/living/carbon/human/C = M
 	var/obj/limb/L = pick(C.limbs)
 	if(L && (L.status & (LIMB_ROBOT|LIMB_SYNTHSKIN)))
-		L.heal_damage(POTENCY_MULTIPLIER_MEDIUM * potency, POTENCY_MULTIPLIER_MEDIUM * potency,0,1)
+		L.heal_damage(POTENCY_MULTIPLIER_MEDIUM * potency, POTENCY_MULTIPLIER_MEDIUM * potency, TRUE)
 
 /datum/chem_property/positive/repairing/process_overdose(mob/living/M, var/potency = 1)
 	M.apply_damage(potency, TOX)
@@ -91,11 +91,11 @@
 /datum/chem_property/positive/repairing/reaction_mob(var/mob/M, var/method=TOUCH, var/volume, var/potency)
 	if(!ishuman(M) || method != TOUCH) //heals when sprayed on limbs
 		return
-	var/mob/living/carbon/human/H
+	var/mob/living/carbon/human/H = M
 	for(var/obj/limb/T in H.limbs)
 		if(!(T.status & (LIMB_ROBOT|LIMB_SYNTHSKIN)))
 			continue
-		T.heal_damage(potency * volume,potency * volume,0,1)
+		T.heal_damage(potency * volume,potency * volume, TRUE)
 
 /datum/chem_property/positive/hemogenic
 	name = PROPERTY_HEMOGENIC


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

the warcrimes pr made an oopsie and rendered the entire property Repairing acting as if it didn't exist and caused multiple runtimes, this PR fixes that and unintentonally but also intentionally at the same time allows synths to be affected by it through TOUCH since a robo limb damage repairing chem should honestly work on them too

## Why It's Good For The Game

bugfix and synths could get another way of repairing them

## Changelog

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:Unknownity
fix: The property Repairing now works again and also on synthetics via TOUCH
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
