### PR TITLE
Stops the ability to grab or grab-throw simple animals with C4 on them.

### DIFF
--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -278,6 +278,7 @@
 
 	return
 
+/mob/living/simple_animal/can_be_pulled_by(var/mob/pulling_mob)
 	if(locate(/obj/item/explosive/plastic) in contents)
 		to_chat(pulling_mob, SPAN_WARNING("You leave [src] alone. It's got live explosives on it!"))
 		return FALSE

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -278,6 +278,9 @@
 
 	return
 
+	if(locate(/obj/item/explosive/plastic) in contents)
+		to_chat(pulling_mob, SPAN_WARNING("You leave [src] alone. It's got live explosives on it!"))
+		return FALSE
 
 /mob/living/simple_animal/attackby(var/obj/item/O as obj, var/mob/user as mob)  //Marker -Agouri
 	if(istype(O, /obj/item/stack/medical))

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -280,7 +280,7 @@
 
 /mob/living/simple_animal/can_be_pulled_by(var/mob/pulling_mob)
 	if(locate(/obj/item/explosive/plastic) in contents)
-		to_chat(pulling_mob, SPAN_WARNING("You leave [src] alone. It's got live explosives on it!"))
+		to_chat(pulling_mob, SPAN_WARNING("You leave \the [src] alone. It's got live explosives on it!"))
 		return FALSE
 
 /mob/living/simple_animal/attackby(var/obj/item/O as obj, var/mob/user as mob)  //Marker -Agouri

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -282,6 +282,7 @@
 	if(locate(/obj/item/explosive/plastic) in contents)
 		to_chat(pulling_mob, SPAN_WARNING("You leave \the [src] alone. It's got live explosives on it!"))
 		return FALSE
+	return ..()
 
 /mob/living/simple_animal/attackby(var/obj/item/O as obj, var/mob/user as mob)  //Marker -Agouri
 	if(istype(O, /obj/item/stack/medical))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Stops the ability to grab or grab-throw simple animals with C4 on them. I hope to god this is the final chapter in this exploit's saga.

## Why It's Good For The Game

Stops exploitation of mechanics.

## Changelog

:cl: Morrow
fix: Stops the ability to grab or grab-throw simple animals with C4 on them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
