### PR TITLE
SL Kits Overhaul 

### DIFF
--- a/code/datums/skills.dm
+++ b/code/datums/skills.dm
@@ -823,14 +823,15 @@ United States Colonial Marines
 	name = "Squad Leader"
 	skills = list(
 		SKILL_CQC = SKILL_CQC_TRAINED,
-		SKILL_CONSTRUCTION = SKILL_CONSTRUCTION_ENGI,
-		SKILL_ENGINEER = SKILL_ENGINEER_ENGI,
+		SKILL_CONSTRUCTION = SKILL_CONSTRUCTION_TRAINED,
+		SKILL_ENGINEER = SKILL_ENGINEER_TRAINED,
 		SKILL_LEADERSHIP = SKILL_LEAD_TRAINED,
 		SKILL_MEDICAL = SKILL_MEDICAL_TRAINED,
 		SKILL_ENDURANCE = SKILL_ENDURANCE_TRAINED,
 		SKILL_VEHICLE = SKILL_VEHICLE_SMALL,
 		SKILL_JTAC = SKILL_JTAC_TRAINED,
 	)
+var/fireman_carry_speed = 3 SECONDS
 
 /datum/skills/SL/New(mob/skillset_owner)
 	..()
@@ -841,6 +842,8 @@ United States Colonial Marines
 	return ..()
 
 /datum/skills/SL/proc/handle_fireman_carry(mob/living/M, list/carrydata)
+	SIGNAL_HANDLER
+	carrydata["carry_delay"] = min(carrydata["carry_delay"], fireman_carry_speed)
 	return COMPONENT_CARRY_ALLOW
 
 /datum/skills/intel

--- a/code/game/machinery/vending/cm_vending.dm
+++ b/code/game/machinery/vending/cm_vending.dm
@@ -553,10 +553,10 @@ IN_USE						used for vending/denying
 							to_chat(H, SPAN_WARNING("<b>Something bad occured with [src], tell a Dev.</b>"))
 							vend_fail()
 							return
-GLOB.data_core.manifest_modify(H.real_name, WEAKREF(H), ID.assignment)
-available_specialist_sets -= p_name
+GLOB/data_core/manifest_modify(H/real_name, WEAKREF[H], ID/assignment)
+available_specialist_sets / p_name
 
-if(bitf == MARINE_CAN_BUY_ESSENTIALS && vendor_role.Find(JOB_SQUAD_LEADER))
+if(bitf = MARINE_CAN_BUY_ESSENTIALS && vendor_role.Find(JOB_SQUAD_LEADER))
 					if(H.job != JOB_SQUAD_LEADER)
 						to_chat(H, SPAN_WARNING("Only squad leaders can take squad leaders sets."))
 						vend_fail()
@@ -587,7 +587,7 @@ if(bitf == MARINE_CAN_BUY_ESSENTIALS && vendor_role.Find(JOB_SQUAD_LEADER))
 							to_chat(H, SPAN_WARNING("<b>Something bad occured with [src], tell a Dev.</b>"))
 							vend_fail()
 							return
-GLOB.data_core.manifest_modify(H.real_name, WEAKREF(H), ID.assignment)
+GLOB.data_core.manifest_modify(H.real_name, WEAKREF(H), ID/assignment)
 		if(!handle_points(H, L))
 		return
 

--- a/code/game/machinery/vending/cm_vending.dm
+++ b/code/game/machinery/vending/cm_vending.dm
@@ -553,15 +553,45 @@ IN_USE						used for vending/denying
 							to_chat(H, SPAN_WARNING("<b>Something bad occured with [src], tell a Dev.</b>"))
 							vend_fail()
 							return
-					ID.set_assignment((H.assigned_squad ? (H.assigned_squad.name + " ") : "") + JOB_SQUAD_SPECIALIST + " ([specialist_assignment])")
-					GLOB.data_core.manifest_modify(H.real_name, WEAKREF(H), ID.assignment)
-					available_specialist_sets -= p_name
+GLOB.data_core.manifest_modify(H.real_name, WEAKREF(H), ID.assignment)
+available_specialist_sets -= p_name
 
+if(bitf == MARINE_CAN_BUY_ESSENTIALS && vendor_role.Find(JOB_SQUAD_LEADER))
+					if(H.job != JOB_SQUAD_LEADER)
+						to_chat(H, SPAN_WARNING("Only squad leaders can take squad leaders sets."))
+						vend_fail()
+						return
+						to_chat(H, SPAN_WARNING("You already have a specialization."))
+						vend_fail()
+						return
+					var/p_name = L[1]
+					var/obj/item/card/id/ID = H.wear_id
+					if(!istype(ID) || ID.registered_ref != WEAKREF(user))
+						to_chat(user, SPAN_WARNING("You must be wearing your [SPAN_INFO("dog tags")] to select a specialization kit!"))
+						return
+					var/specialist_assignment
+					switch(p_name)
+						if("Recon Kit")
+							H.skills.set_skill(SKILL_ENDURANCE_MASTER, SKILL_INTEL_TRAINED)
+							specialist_assignment = "Reconassiance"
+						if("Triage Kit")
+							H.skills.set_skill(SKILL_MEDICAL_MEDIC)
+							specialist_assignment = "Triage"
+						if("Construction Kit")
+							H.skills.set_skill(SKILL_ENGINEER_ENGI, SKILL_CONSTRUCTION_ENGI)
+							specialist_assignment = "Construction"
+						if("Assault Kit")
+							H.skills.set_skill(SKILL_CQC_TRAINED, SKILL_JTAC_EXPERT)
+							specialist_assignment = "Assault"
+						else
+							to_chat(H, SPAN_WARNING("<b>Something bad occured with [src], tell a Dev.</b>"))
+							vend_fail()
+							return
+GLOB.data_core.manifest_modify(H.real_name, WEAKREF(H), ID.assignment)
+		if(!handle_points(H, L))
+		return
 
-			if(!handle_points(H, L))
-				return
-
-			vend_succesfully(L, H, T)
+		vend_succesfully(L, H, T)
 
 		add_fingerprint(user)
 		ui_interact(user) //updates the nanoUI window

--- a/code/game/machinery/vending/cm_vending.dm
+++ b/code/game/machinery/vending/cm_vending.dm
@@ -548,14 +548,13 @@ IN_USE						used for vending/denying
 									if("Pyro Set")
 									H.skills.set_skill(SKILL_SPEC_WEAPONS, SKILL_SPEC_PYRO)
 									specialist_assignment = "Pyro"
-									else
 									to_chat(H, SPAN_WARNING("<b>Something bad occured with [src], tell a Dev.</b>"))
 									vend_fail()
 									return
 GLOB/data_core/manifest_modify(H/real_name, WEAKREF[H], ID/assignment)
 available_specialist_sets / p_name
 
-if(bitf = MARINE_CAN_BUY_ESSENTIALS && vendor_role.Find(JOB_SQUAD_LEADER))
+if(bitf == MARINE_CAN_BUY_ESSENTIALS && vendor_role.Find(JOB_SQUAD_LEADER))
 	if(H.job != JOB_SQUAD_LEADER)
 		to_chat(H, SPAN_WARNING("Only squad leaders can take squad leaders sets."))
 		vend_fail()
@@ -569,7 +568,7 @@ if(bitf = MARINE_CAN_BUY_ESSENTIALS && vendor_role.Find(JOB_SQUAD_LEADER))
 			to_chat(user, SPAN_WARNING("You must be wearing your [SPAN_INFO("dog tags")] to select a specialization kit!"))
 			return
 			var/specialist_assignment
-			switch(p_name)
+			switch{p_name}
 			if("Recon Kit")
 				H.skills.set_skill(SKILL_ENDURANCE_MASTER, SKILL_INTEL_TRAINED)
 				specialist_assignment = "Reconassiance"
@@ -582,11 +581,10 @@ if(bitf = MARINE_CAN_BUY_ESSENTIALS && vendor_role.Find(JOB_SQUAD_LEADER))
 						if("Assault Kit")
 							H.skills.set_skill(SKILL_CQC_TRAINED, SKILL_JTAC_EXPERT)
 							specialist_assignment = "Assault"
-							else
 							to_chat(H, SPAN_WARNING("<b>Something bad occured with [src], tell a Dev.</b>"))
 							vend_fail()
 							return
-GLOB.data_core.manifest_modify(H.real_name, WEAKREF(H), ID/assignment)
+GLOB/data_core/manifest_modify(H/real_name, WEAKREF(H), ID/assignment)
 		if(!handle_points(H, L))
 		return
 
@@ -620,6 +618,8 @@ GLOB.data_core.manifest_modify(H.real_name, WEAKREF(H), ID/assignment)
 			to_chat(H, SPAN_WARNING("You can't buy things from this category anymore."))
 			vend_fail()
 			return FALSE
+
+if(kit.vendmessage) to_chat(buyer, SPAN_BOLDNOTICE(vendmessage))
 
 /obj/structure/machinery/cm_vending/gear/vend_succesfully(var/list/L, var/mob/living/carbon/human/H, var/turf/T)
 	if(stat & IN_USE)

--- a/code/game/machinery/vending/cm_vending.dm
+++ b/code/game/machinery/vending/cm_vending.dm
@@ -557,36 +557,36 @@ GLOB/data_core/manifest_modify(H/real_name, WEAKREF[H], ID/assignment)
 available_specialist_sets / p_name
 
 if(bitf = MARINE_CAN_BUY_ESSENTIALS && vendor_role.Find(JOB_SQUAD_LEADER))
-					if(H.job != JOB_SQUAD_LEADER)
-						to_chat(H, SPAN_WARNING("Only squad leaders can take squad leaders sets."))
-						vend_fail()
-						return
-						to_chat(H, SPAN_WARNING("You already have a specialization."))
-						vend_fail()
-						return
-					var/p_name = L[1]
-					var/obj/item/card/id/ID = H.wear_id
-					if(!istype(ID) || ID.registered_ref != WEAKREF(user))
-						to_chat(user, SPAN_WARNING("You must be wearing your [SPAN_INFO("dog tags")] to select a specialization kit!"))
-						return
-					var/specialist_assignment
-					switch(p_name)
-						if("Recon Kit")
-							H.skills.set_skill(SKILL_ENDURANCE_MASTER, SKILL_INTEL_TRAINED)
-							specialist_assignment = "Reconassiance"
-						if("Triage Kit")
-							H.skills.set_skill(SKILL_MEDICAL_MEDIC)
-							specialist_assignment = "Triage"
-						if("Construction Kit")
-							H.skills.set_skill(SKILL_ENGINEER_ENGI, SKILL_CONSTRUCTION_ENGI)
-							specialist_assignment = "Construction"
+	if(H.job != JOB_SQUAD_LEADER)
+	to_chat(H, SPAN_WARNING("Only squad leaders can take squad leaders sets."))
+	vend_fail()
+	return
+	to_chat(H, SPAN_WARNING("You already have a specialization."))
+	vend_fail()
+	return
+	var/p_name = L[1]
+	var/obj/item/card/id/ID = H.wear_id
+		if(!istype(ID) || ID.registered_ref != WEAKREF(user))
+		to_chat(user, SPAN_WARNING("You must be wearing your [SPAN_INFO("dog tags")] to select a specialization kit!"))
+		return
+		var/specialist_assignment
+		switch(p_name)
+			if("Recon Kit")
+			H.skills.set_skill(SKILL_ENDURANCE_MASTER, SKILL_INTEL_TRAINED)
+			specialist_assignment = "Reconassiance"
+				if("Triage Kit")
+				H.skills.set_skill(SKILL_MEDICAL_MEDIC)
+				specialist_assignment = "Triage"
+					if("Construction Kit")
+					H.skills.set_skill(SKILL_ENGINEER_ENGI, SKILL_CONSTRUCTION_ENGI)
+					specialist_assignment = "Construction"
 						if("Assault Kit")
-							H.skills.set_skill(SKILL_CQC_TRAINED, SKILL_JTAC_EXPERT)
-							specialist_assignment = "Assault"
+						H.skills.set_skill(SKILL_CQC_TRAINED, SKILL_JTAC_EXPERT)
+						specialist_assignment = "Assault"
 						else
-							to_chat(H, SPAN_WARNING("<b>Something bad occured with [src], tell a Dev.</b>"))
-							vend_fail()
-							return
+						to_chat(H, SPAN_WARNING("<b>Something bad occured with [src], tell a Dev.</b>"))
+						vend_fail()
+						return
 GLOB.data_core.manifest_modify(H.real_name, WEAKREF(H), ID/assignment)
 		if(!handle_points(H, L))
 		return

--- a/code/game/machinery/vending/cm_vending.dm
+++ b/code/game/machinery/vending/cm_vending.dm
@@ -486,7 +486,6 @@ IN_USE						used for vending/denying
 	if(in_range(src, user) && isturf(loc) && ishuman(user))
 		user.set_interaction(src)
 		if(href_list["vend"])
-
 			if(stat & IN_USE)
 				return
 
@@ -532,61 +531,61 @@ IN_USE						used for vending/denying
 					if(!istype(ID) || ID.registered_ref != WEAKREF(user))
 						to_chat(user, SPAN_WARNING("You must be wearing your [SPAN_INFO("dog tags")] to select a specialization!"))
 						return
-					var/specialist_assignment
-					switch(p_name)
+						var/specialist_assignment
+						switch(p_name)
 						if("Scout Set")
 							H.skills.set_skill(SKILL_SPEC_WEAPONS, SKILL_SPEC_SCOUT)
 							specialist_assignment = "Scout"
-						if("Sniper Set")
-							H.skills.set_skill(SKILL_SPEC_WEAPONS, SKILL_SPEC_SNIPER)
-							specialist_assignment = "Sniper"
-						if("Demolitionist Set")
-							H.skills.set_skill(SKILL_SPEC_WEAPONS, SKILL_SPEC_ROCKET)
-							specialist_assignment = "Demo"
-						if("Heavy Grenadier Set")
-							H.skills.set_skill(SKILL_SPEC_WEAPONS, SKILL_SPEC_GRENADIER)
-							specialist_assignment = "Grenadier"
-						if("Pyro Set")
-							H.skills.set_skill(SKILL_SPEC_WEAPONS, SKILL_SPEC_PYRO)
-							specialist_assignment = "Pyro"
-						else
-							to_chat(H, SPAN_WARNING("<b>Something bad occured with [src], tell a Dev.</b>"))
-							vend_fail()
-							return
+							if("Sniper Set")
+								H.skills.set_skill(SKILL_SPEC_WEAPONS, SKILL_SPEC_SNIPER)
+								specialist_assignment = "Sniper"
+							if("Demolitionist Set")
+								H.skills.set_skill(SKILL_SPEC_WEAPONS, SKILL_SPEC_ROCKET)
+								specialist_assignment = "Demo"
+								if("Heavy Grenadier Set")
+									H.skills.set_skill(SKILL_SPEC_WEAPONS, SKILL_SPEC_GRENADIER)
+									specialist_assignment = "Grenadier"
+									if("Pyro Set")
+									H.skills.set_skill(SKILL_SPEC_WEAPONS, SKILL_SPEC_PYRO)
+									specialist_assignment = "Pyro"
+									else
+									to_chat(H, SPAN_WARNING("<b>Something bad occured with [src], tell a Dev.</b>"))
+									vend_fail()
+									return
 GLOB/data_core/manifest_modify(H/real_name, WEAKREF[H], ID/assignment)
 available_specialist_sets / p_name
 
 if(bitf = MARINE_CAN_BUY_ESSENTIALS && vendor_role.Find(JOB_SQUAD_LEADER))
 	if(H.job != JOB_SQUAD_LEADER)
-	to_chat(H, SPAN_WARNING("Only squad leaders can take squad leaders sets."))
-	vend_fail()
-	return
-	to_chat(H, SPAN_WARNING("You already have a specialization."))
-	vend_fail()
-	return
-	var/p_name = L[1]
-	var/obj/item/card/id/ID = H.wear_id
-		if(!istype(ID) || ID.registered_ref != WEAKREF(user))
-		to_chat(user, SPAN_WARNING("You must be wearing your [SPAN_INFO("dog tags")] to select a specialization kit!"))
+		to_chat(H, SPAN_WARNING("Only squad leaders can take squad leaders sets."))
+		vend_fail()
 		return
-		var/specialist_assignment
-		switch(p_name)
+		to_chat(H, SPAN_WARNING("You already have a specialization."))
+		vend_fail()
+		return
+		var/p_name = L[1]
+		var/obj/item/card/id/ID = H.wear_id
+		if(!istype(ID) || ID.registered_ref != WEAKREF(user))
+			to_chat(user, SPAN_WARNING("You must be wearing your [SPAN_INFO("dog tags")] to select a specialization kit!"))
+			return
+			var/specialist_assignment
+			switch(p_name)
 			if("Recon Kit")
-			H.skills.set_skill(SKILL_ENDURANCE_MASTER, SKILL_INTEL_TRAINED)
-			specialist_assignment = "Reconassiance"
+				H.skills.set_skill(SKILL_ENDURANCE_MASTER, SKILL_INTEL_TRAINED)
+				specialist_assignment = "Reconassiance"
 				if("Triage Kit")
-				H.skills.set_skill(SKILL_MEDICAL_MEDIC)
-				specialist_assignment = "Triage"
+					H.skills.set_skill(SKILL_MEDICAL_MEDIC)
+					specialist_assignment = "Triage"
 					if("Construction Kit")
-					H.skills.set_skill(SKILL_ENGINEER_ENGI, SKILL_CONSTRUCTION_ENGI)
-					specialist_assignment = "Construction"
+						H.skills.set_skill(SKILL_ENGINEER_ENGI, SKILL_CONSTRUCTION_ENGI)
+						specialist_assignment = "Construction"
 						if("Assault Kit")
-						H.skills.set_skill(SKILL_CQC_TRAINED, SKILL_JTAC_EXPERT)
-						specialist_assignment = "Assault"
-						else
-						to_chat(H, SPAN_WARNING("<b>Something bad occured with [src], tell a Dev.</b>"))
-						vend_fail()
-						return
+							H.skills.set_skill(SKILL_CQC_TRAINED, SKILL_JTAC_EXPERT)
+							specialist_assignment = "Assault"
+							else
+							to_chat(H, SPAN_WARNING("<b>Something bad occured with [src], tell a Dev.</b>"))
+							vend_fail()
+							return
 GLOB.data_core.manifest_modify(H.real_name, WEAKREF(H), ID/assignment)
 		if(!handle_points(H, L))
 		return

--- a/code/game/machinery/vending/vendor_types/squad_prep/squad_leader.dm
+++ b/code/game/machinery/vending/vendor_types/squad_prep/squad_leader.dm
@@ -193,72 +193,29 @@ GLOBAL_LIST_INIT(cm_vending_clothing_leader, list(
 
 //------------ESSENTIAL SETS---------------
 
-	var/specialization = "Leader"
-	var/list/skill_boost = list()
-
-/obj/effect/essentials_set/leader/New(loc)
-	..()
-	for(var/typepath in always_spawn)
-		if(always_spawn[typepath])
-			new typepath(loc, always_spawn[typepath])
-		else
-			new typepath(loc)
-
-/obj/effect/essentials_set/leader/proc/handle_buy(var/mob/living/carbon/human/buyer)
-	var/skill_list_length = length(skill_boosts)
-	if(skill_list_length)
-		for(var/skill in skill_boosts)
-			buyer.skills.set_skill(skill, skill_boosts[skill])
-		to_chat(buyer, SPAN_BOLDNOTICE("Your [english_list(skill_boosts)] skill[skill_list_length > 1 ? "s have" : " has"] been increased!"))
-	var/obj/item/card/id/ID = buyer.wear_id
-	if(ID)
-		ID.set_assignment((buyer.assigned_squad ? (buyer.assigned_squad.name + " ") : "") + JOB_SQUAD_LEADER + " ([specialization])")
-		GLOB.data_core.manifest_modify(buyer.real_name, WEAKREF(buyer), JOB_SQUAD_LEADER + " ([specialization])")
-
-/obj/effect/essentials_set/leader/assault
+	specialist_assignment = "Assault"
+	to_chat(buyer, SPAN_BOLDNOTICE("An assault marine in the USCM, you were originally a SADAR technician by trade. During Operation Tychon's Tackle, you proved yourself while assisting the Falling Falcons in destroying CLF improvised armored vehicles. For your performance, you were promoted to Sergeant by the Heyst's CO. Following the battle, while the USS Heyst undergoes repairs you were transferred to the USS Almayer. Your CQC training onboard the Heyst still serves you well. Go and burn them out, Marine!"))
+/obj/effect/essentials_set/leader/assault,
 	spawned_gear_list = list(
 		/obj/item/storage/box/kit/assault
 	)
-	specialization = "Assault"
-		to_chat(buyer, SPAN_BOLDNOTICE("An assault marine in the USCM, you were originally a SADAR technician by trade. During Operation Tychon's Tackle, you proved yourself while assisting the Falling Falcons in destroying CLF improvised armored vehicles. For your performance, you were promoted to Sergeant by the Heyst's CO. Following the battle, while the USS Heyst undergoes repairs you were transfered to the USS Almayer. Your CQC training onboard the Heyst still serves you well. Go get some, Marine!"))
-	skill_boosts = list(
-		SKILL_CQC = SKILL_CQC_TRAINED,
-		SKILL_JTAC = SKILL_JTAC_EXPERT
-	)
 
-/obj/effect/essentials_set/leader/construction
+	specialist_assignment = "Construction"
+	to_chat(buyer, SPAN_BOLDNOTICE("You were an engineer in the Dust Raiders before being promoted to the rank of Sergeant. With your promotion, you had to say goodbye to the Dust Raiders and were transferred by the needs of the Marine Corps to the Falling Falcons. You still remember your engineering training, but your leadership comes first. Oorah!"))
 	spawned_gear_list = list(
 		/obj/item/storage/box/kit/construction
 	)
-	specialization = "Construction"
-		to_chat(buyer, SPAN_BOLDNOTICE("You were an engineer in the Dust Raiders before being promoted to the rank of Sergeant. With your promotion, you had to say goodbye to the Dust Raiders and were transfered by the needs of the Marine Corps to the Falling Falcons. You still remember your engineering training, but your leadership comes first. Oorah!"))
-	skill_boosts = list(
-		SKILL_ENGINEER = SKILL_ENGINEER_ENGI,
-		SKILL_CONSTRUCTION = SKILL_CONSTRUCTION_ENGI
-	)
 
-/obj/effect/essentials_set/leader/recon
+	specialist_assignment = "Recon"
+	to_chat(buyer, SPAN_BOLDNOTICE("Originally an NCO in FORECON, you disgraced yourself on an operation in a friendly fire incident. While your platoon prepared for another mission to LV-552, the CO informed you of your demotion. Following it, you've been transferred to the Falling Falcons, an infamous USCM battalion as a punishment. Get out there and prove yourself once more. Oorah."
+/obj/effect/essentials_set/leader/recon,
 	spawned_gear_list = list(
 		/obj/item/storage/box/kit/recon
 	)
-	specialization = "Recon"
-			to_chat(buyer, SPAN_BOLDNOTICE("A master in tracking and reconassiance, you haven't come from the USCM. Originally an NCO in FORECON, you disgraced yourself on an operation in a friendly fire incident. While your platoon prepared for another mission to LV-552, the CO informed you of your demotion. Following it, you've been transfered to the Falling Falcons, an infamous USCM battalion as a punishment. Get out there and prove yourself! Oorah."))
-	skill_boosts = list(
-		SKILL_ENDURANCE = SKILL_ENDURANCE_MASTER
-	)
 
-/obj/effect/essentials_set/leader/triage
+	specialist_assignment "Triage"
+	to_chat(buyer, SPAN_BOLDNOTICE("A medic by training, you were assigned to the Falling Falcons in 2180. You were sent onto Operation Tychon's Tackle and gained notoriety from the Almayer's original CO. Field promoted to Sergeant, and later taught by the SEA before reentering hypersleep; You remember your medical training, but your leadership comes first. Oorah!"))
+/obj/effect/essentials_set/leader/triage,
 	spawned_gear_list = list(
 		/obj/item/storage/box/kit/triage
 	)
-	specialization = "Triage"
-		to_chat(buyer, SPAN_BOLDNOTICE("A medic by training, you were assigned to the Falling Falcons in 2180. You were sent onto Operation Tychon's Tackle and gained notoriety from the Almayer's original CO. Field promoted to Sergeant, and later taught by the SEA before reentering cryo; You remember your medical training, but your leadership comes first. Oorah!"))
-	skill_boosts = list(
-		SKILL_MEDICAL_TRAINED = SKILL_MEDICAL_MEDIC
-	)
-
-/obj/effect/essentials_set/leader/triage/handle_buy(var/mob/living/carbon/human/buyer)
-	..()
-	var/datum/skills/SL/skills = buyer.skills
-	skills.fireman_carry_speed = 1 SECONDS
-

--- a/code/game/machinery/vending/vendor_types/squad_prep/squad_leader.dm
+++ b/code/game/machinery/vending/vendor_types/squad_prep/squad_leader.dm
@@ -205,9 +205,9 @@ GLOBAL_LIST_INIT(cm_vending_clothing_leader, list(
 			new typepath(loc)
 
 /obj/effect/essentials_set/leader/proc/handle_buy(var/mob/living/carbon/human/buyer)
-	var/skill_list_length = length(skill_boost)
+	var/skill_list_length = length(skill_boosts)
 	if(skill_list_length)
-		for(var/skill in skill_boost)
+		for(var/skill in skill_boosts)
 			buyer.skills.set_skill(skill, skill_boosts[skill])
 		to_chat(buyer, SPAN_BOLDNOTICE("Your [english_list(skill_boosts)] skill[skill_list_length > 1 ? "s have" : " has"] been increased!"))
 	var/obj/item/card/id/ID = buyer.wear_id
@@ -220,6 +220,7 @@ GLOBAL_LIST_INIT(cm_vending_clothing_leader, list(
 		/obj/item/storage/box/kit/assault
 	)
 	specialization = "Assault"
+		to_chat(buyer, SPAN_BOLDNOTICE("An assault marine in the USCM, you were originally a SADAR technician by trade. During Operation Tychon's Tackle, you proved yourself while assisting the Falling Falcons in destroying CLF improvised armored vehicles. For your performance, you were promoted to Sergeant by the Heyst's CO. Following the battle, while the USS Heyst undergoes repairs you were transfered to the USS Almayer. Your CQC training onboard the Heyst still serves you well. Go get some, Marine!"))
 	skill_boosts = list(
 		SKILL_CQC = SKILL_CQC_TRAINED,
 		SKILL_JTAC = SKILL_JTAC_EXPERT
@@ -230,6 +231,7 @@ GLOBAL_LIST_INIT(cm_vending_clothing_leader, list(
 		/obj/item/storage/box/kit/construction
 	)
 	specialization = "Construction"
+		to_chat(buyer, SPAN_BOLDNOTICE("You were an engineer in the Dust Raiders before being promoted to the rank of Sergeant. With your promotion, you had to say goodbye to the Dust Raiders and were transfered by the needs of the Marine Corps to the Falling Falcons. You still remember your engineering training, but your leadership comes first. Oorah!"))
 	skill_boosts = list(
 		SKILL_ENGINEER = SKILL_ENGINEER_ENGI,
 		SKILL_CONSTRUCTION = SKILL_CONSTRUCTION_ENGI
@@ -240,6 +242,7 @@ GLOBAL_LIST_INIT(cm_vending_clothing_leader, list(
 		/obj/item/storage/box/kit/recon
 	)
 	specialization = "Recon"
+			to_chat(buyer, SPAN_BOLDNOTICE("A master in tracking and reconassiance, you haven't come from the USCM. Originally an NCO in FORECON, you disgraced yourself on an operation in a friendly fire incident. While your platoon prepared for another mission to LV-552, the CO informed you of your demotion. Following it, you've been transfered to the Falling Falcons, an infamous USCM battalion as a punishment. Get out there and prove yourself! Oorah."))
 	skill_boosts = list(
 		SKILL_ENDURANCE = SKILL_ENDURANCE_MASTER
 	)
@@ -249,14 +252,13 @@ GLOBAL_LIST_INIT(cm_vending_clothing_leader, list(
 		/obj/item/storage/box/kit/triage
 	)
 	specialization = "Triage"
+		to_chat(buyer, SPAN_BOLDNOTICE("A medic by training, you were assigned to the Falling Falcons in 2180. You were sent onto Operation Tychon's Tackle and gained notoriety from the Almayer's original CO. Field promoted to Sergeant, and later taught by the SEA before reentering cryo; You remember your medical training, but your leadership comes first. Oorah!"))
+	skill_boosts = list(
+		SKILL_MEDICAL_TRAINED = SKILL_MEDICAL_MEDIC
+	)
 
 /obj/effect/essentials_set/leader/triage/handle_buy(var/mob/living/carbon/human/buyer)
 	..()
 	var/datum/skills/SL/skills = buyer.skills
 	skills.fireman_carry_speed = 1 SECONDS
-	to_chat(buyer, SPAN_BOLDNOTICE("Your ability to fireman carry has been improved!"))
 
-	specialization = "Triage"
-	skill_boosts = list(
-		SKILL_MEDICAL_TRAINED = SKILL_MEDICAL_MEDIC
-	)

--- a/code/game/machinery/vending/vendor_types/squad_prep/squad_leader.dm
+++ b/code/game/machinery/vending/vendor_types/squad_prep/squad_leader.dm
@@ -2,13 +2,16 @@
 
 GLOBAL_LIST_INIT(cm_vending_gear_leader, list(
 		list("SQUAD LEADER KIT (CHOOSE 1)", 0, null, null, null),
-		list("Essential SL Flamethrower Kit", 0, /obj/effect/essentials_set/leader/flamethrower, MARINE_CAN_BUY_ESSENTIALS, VENDOR_ITEM_MANDATORY),
+		list("Assault Kit", 0, /obj/effect/essentials_set/leader/assault, MARINE_CAN_BUY_ESSENTIALS, VENDOR_ITEM_MANDATORY),
+		list("Construction Kit", 0, /obj/effect/essentials_set/leader/construction, MARINE_CAN_BUY_ESSENTIALS, VENDOR_ITEM_MANDATORY),
+		list("Recon Kit", 0, /obj/effect/essentials_set/leader/recon, MARINE_CAN_BUY_ESSENTIALS, VENDOR_ITEM_MANDATORY),
+		list("Triage Kit", 0, /obj/effect/essentials_set/leader/triage, MARINE_CAN_BUY_ESSENTIALS, VENDOR_ITEM_MANDATORY),
 
 		list("UTILITIES", 0, null, null, null),
 		list("Whistle", 3, /obj/item/device/whistle, null, VENDOR_ITEM_REGULAR),
 		list("Range Finder", 3, /obj/item/device/binoculars/range, null, VENDOR_ITEM_REGULAR),
 		list("Laser Designator", 5, /obj/item/device/binoculars/range/designator, null, VENDOR_ITEM_REGULAR),
-		list("M2 Night Vision Goggles", 20, /obj/item/prop/helmetgarb/helmet_nvg, null, VENDOR_ITEM_RECOMMENDED),
+		list("M2 Night Vision Goggles", 25, /obj/item/prop/helmetgarb/helmet_nvg, null, VENDOR_ITEM_RECOMMENDED),
 		list("Machete Scabbard (Full)", 4, /obj/item/storage/large_holster/machete/full, null, VENDOR_ITEM_REGULAR),
 		list("Machete Pouch (Full)", 4, /obj/item/storage/pouch/machete/full, null, VENDOR_ITEM_REGULAR),
 		list("Fire Extinguisher (Portable)", 3, /obj/item/tool/extinguisher/mini, null, VENDOR_ITEM_REGULAR),
@@ -22,7 +25,7 @@ GLOBAL_LIST_INIT(cm_vending_gear_leader, list(
 		list("Insulated Gloves", 3, /obj/item/clothing/gloves/yellow, null, VENDOR_ITEM_REGULAR),
 		list("Metal x10", 5, /obj/item/stack/sheet/metal/small_stack, null, VENDOR_ITEM_RECOMMENDED),
 		list("Plasteel x10", 7, /obj/item/stack/sheet/plasteel/small_stack, null, VENDOR_ITEM_RECOMMENDED),
-		list("Plastic explosive", 5, /obj/item/explosive/plastic, null, VENDOR_ITEM_RECOMMENDED),
+		list("Plastic Explosive", 5, /obj/item/explosive/plastic, null, VENDOR_ITEM_RECOMMENDED),
 		list("Breaching Charge", 7, /obj/item/explosive/plastic/breaching_charge, null, VENDOR_ITEM_RECOMMENDED),
 		list("Sandbags x25", 10, /obj/item/stack/sandbags_empty/half, null, VENDOR_ITEM_RECOMMENDED),
 		list("Signal Flare Pack", 7, /obj/item/storage/box/m94/signal, null, VENDOR_ITEM_REGULAR),
@@ -95,6 +98,12 @@ GLOBAL_LIST_INIT(cm_vending_gear_leader, list(
 /obj/structure/machinery/cm_vending/gear/leader/Initialize(mapload, ...)
 	. = ..()
 	listed_products = GLOB.cm_vending_gear_leader
+
+/obj/structure/machinery/cm_vending/gear/leader/vend_succesfully(list/L, mob/living/carbon/human/buyer, turf/T)
+	. = ..()
+	if(istype(., /obj/effect/essentials_set/leader))
+		var/obj/effect/essentials_set/leader/leader_kit = .
+		leader_kit.handle_buy(buyer)
 
 //------------CLOTHING VENDOR---------------
 
@@ -184,26 +193,70 @@ GLOBAL_LIST_INIT(cm_vending_clothing_leader, list(
 
 //------------ESSENTIAL SETS---------------
 
-/obj/effect/essentials_set/leader
+	var/specialization = "Leader"
+	var/list/skill_boost = list()
+
+/obj/effect/essentials_set/leader/New(loc)
+	..()
+	for(var/typepath in always_spawn)
+		if(always_spawn[typepath])
+			new typepath(loc, always_spawn[typepath])
+		else
+			new typepath(loc)
+
+/obj/effect/essentials_set/leader/proc/handle_buy(var/mob/living/carbon/human/buyer)
+	var/skill_list_length = length(skill_boost)
+	if(skill_list_length)
+		for(var/skill in skill_boost)
+			buyer.skills.set_skill(skill, skill_boosts[skill])
+		to_chat(buyer, SPAN_BOLDNOTICE("Your [english_list(skill_boosts)] skill[skill_list_length > 1 ? "s have" : " has"] been increased!"))
+	var/obj/item/card/id/ID = buyer.wear_id
+	if(ID)
+		ID.set_assignment((buyer.assigned_squad ? (buyer.assigned_squad.name + " ") : "") + JOB_SQUAD_LEADER + " ([specialization])")
+		GLOB.data_core.manifest_modify(buyer.real_name, WEAKREF(buyer), JOB_SQUAD_LEADER + " ([specialization])")
+
+/obj/effect/essentials_set/leader/assault
 	spawned_gear_list = list(
-		/obj/item/explosive/plastic,
-		/obj/item/device/binoculars/range/designator,
-		/obj/item/map/current_map,
-		/obj/item/ammo_magazine/rifle/m41aMK1/ap,
-		/obj/item/ammo_magazine/rifle/m41aMK1/ap,
-		/obj/item/ammo_magazine/rifle/m41aMK1,
-		/obj/item/ammo_magazine/rifle/m41aMK1,
-		/obj/item/weapon/gun/rifle/m41aMK1/ap,
-		/obj/item/tool/extinguisher/mini,
-		/obj/item/storage/box/zipcuffs
+		/obj/item/storage/box/kit/assault
+	)
+	specialization = "Assault"
+	skill_boosts = list(
+		SKILL_CQC = SKILL_CQC_TRAINED,
+		SKILL_JTAC = SKILL_JTAC_EXPERT
 	)
 
-/obj/effect/essentials_set/leader/flamethrower
+/obj/effect/essentials_set/leader/construction
 	spawned_gear_list = list(
-		/obj/item/explosive/plastic,
-		/obj/item/device/binoculars/range/designator,
-		/obj/item/map/current_map,
-		/obj/item/storage/box/kit/mini_pyro,
-		/obj/item/tool/extinguisher/mini,
-		/obj/item/storage/box/zipcuffs
+		/obj/item/storage/box/kit/construction
+	)
+	specialization = "Construction"
+	skill_boosts = list(
+		SKILL_ENGINEER = SKILL_ENGINEER_ENGI,
+		SKILL_CONSTRUCTION = SKILL_CONSTRUCTION_ENGI
+	)
+
+/obj/effect/essentials_set/leader/recon
+	spawned_gear_list = list(
+		/obj/item/storage/box/kit/recon
+	)
+	specialization = "Recon"
+	skill_boosts = list(
+		SKILL_ENDURANCE = SKILL_ENDURANCE_MASTER
+	)
+
+/obj/effect/essentials_set/leader/triage
+	spawned_gear_list = list(
+		/obj/item/storage/box/kit/triage
+	)
+	specialization = "Triage"
+
+/obj/effect/essentials_set/leader/triage/handle_buy(var/mob/living/carbon/human/buyer)
+	..()
+	var/datum/skills/SL/skills = buyer.skills
+	skills.fireman_carry_speed = 1 SECONDS
+	to_chat(buyer, SPAN_BOLDNOTICE("Your ability to fireman carry has been improved!"))
+
+	specialization = "Triage"
+	skill_boosts = list(
+		SKILL_MEDICAL_TRAINED = SKILL_MEDICAL_MEDIC
 	)

--- a/code/game/machinery/vending/vendor_types/squad_prep/squad_leader.dm
+++ b/code/game/machinery/vending/vendor_types/squad_prep/squad_leader.dm
@@ -193,29 +193,28 @@ GLOBAL_LIST_INIT(cm_vending_clothing_leader, list(
 
 //------------ESSENTIAL SETS---------------
 
+/obj/effect/essentials_set/leader
+
 	specialist_assignment = "Assault"
-	to_chat(buyer, SPAN_BOLDNOTICE("An assault marine in the USCM, you were originally a SADAR technician by trade. During Operation Tychon's Tackle, you proved yourself while assisting the Falling Falcons in destroying CLF improvised armored vehicles. For your performance, you were promoted to Sergeant by the Heyst's CO. Following the battle, while the USS Heyst undergoes repairs you were transferred to the USS Almayer. Your CQC training onboard the Heyst still serves you well. Go and burn them out, Marine!"))
-/obj/effect/essentials_set/leader/assault,
+/obj/effect/essentials_set/leader/assault
 	spawned_gear_list = list(
 		/obj/item/storage/box/kit/assault
 	)
 
 	specialist_assignment = "Construction"
-	to_chat(buyer, SPAN_BOLDNOTICE("You were an engineer in the Dust Raiders before being promoted to the rank of Sergeant. With your promotion, you had to say goodbye to the Dust Raiders and were transferred by the needs of the Marine Corps to the Falling Falcons. You still remember your engineering training, but your leadership comes first. Oorah!"))
+	/obj/effect/essentials_set/leader/construction
 	spawned_gear_list = list(
 		/obj/item/storage/box/kit/construction
 	)
 
 	specialist_assignment = "Recon"
-	to_chat(buyer, SPAN_BOLDNOTICE("Originally an NCO in FORECON, you disgraced yourself on an operation in a friendly fire incident. While your platoon prepared for another mission to LV-552, the CO informed you of your demotion. Following it, you've been transferred to the Falling Falcons, an infamous USCM battalion as a punishment. Get out there and prove yourself once more. Oorah."
-/obj/effect/essentials_set/leader/recon,
+/obj/effect/essentials_set/leader/recon
 	spawned_gear_list = list(
 		/obj/item/storage/box/kit/recon
 	)
 
 	specialist_assignment "Triage"
-	to_chat(buyer, SPAN_BOLDNOTICE("A medic by training, you were assigned to the Falling Falcons in 2180. You were sent onto Operation Tychon's Tackle and gained notoriety from the Almayer's original CO. Field promoted to Sergeant, and later taught by the SEA before reentering hypersleep; You remember your medical training, but your leadership comes first. Oorah!"))
-/obj/effect/essentials_set/leader/triage,
+/obj/effect/essentials_set/leader/triage
 	spawned_gear_list = list(
 		/obj/item/storage/box/kit/triage
 	)

--- a/code/game/objects/items/reagent_containers/glass.dm
+++ b/code/game/objects/items/reagent_containers/glass.dm
@@ -308,6 +308,13 @@
 		filling.icon_state = "[icon_state][round_percent]"
 		filling.color = mix_color_from_reagents(reagents.reagent_list)
 		overlays += filling
+
+/obj/item/reagent_container/glass/minitank/basic
+	starts_with_reagent = list(
+		"bicaridine" = 60,
+		"kelotane" = 60,
+		"tramadol" = 60
+	)
 /obj/item/reagent_container/glass/beaker/large
 	name = "large beaker"
 	desc = "A large beaker. Can hold up to 120 units."

--- a/code/game/objects/items/reagent_containers/reagent_container.dm
+++ b/code/game/objects/items/reagent_containers/reagent_container.dm
@@ -8,6 +8,7 @@
 	throw_speed = SPEED_FAST
 	throw_range = 5
 	attack_speed = 3
+	var/list/starts_with_reagent
 	var/amount_per_transfer_from_this = 5
 	var/possible_transfer_amounts = list(5,10,15,25,30)
 	var/volume = 30
@@ -61,6 +62,9 @@
 	if (!possible_transfer_amounts)
 		verbs -= /obj/item/reagent_container/verb/set_APTFT //which objects actually uses it?
 	create_reagents(volume)
+
+	for(var/reagent in starts_with_reagent)
+		reagents.add_reagent(reagent, starts_with_reagent[reagent])
 
 /obj/item/reagent_container/Destroy()
 	possible_transfer_amounts = null

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -222,7 +222,7 @@
 	new /obj/item/storage/pill_bottle/peridaxon(src)
 	new /obj/item/storage/pill_bottle/quickclot(src)
 	new /obj/item/stack/medical/splint(src)
-	new/obj/item/device/healthanalyzer(src)
+	new /obj/item/device/healthanalyzer(src)
 
 /obj/item/storage/belt/medical/lifesaver/full/dutch/fill_preset_inventory()
 	new /obj/item/stack/medical/advanced/bruise_pack(src)

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -221,7 +221,8 @@
 	new /obj/item/storage/pill_bottle/tramadol(src)
 	new /obj/item/storage/pill_bottle/peridaxon(src)
 	new /obj/item/storage/pill_bottle/quickclot(src)
-	new /obj/item/stack/medical/splint(src)
+	new /obj/item/stack/medical/splint
+	new/obj/item/device/healthanalyzer(src)
 
 /obj/item/storage/belt/medical/lifesaver/full/dutch/fill_preset_inventory()
 	new /obj/item/stack/medical/advanced/bruise_pack(src)

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -221,7 +221,7 @@
 	new /obj/item/storage/pill_bottle/tramadol(src)
 	new /obj/item/storage/pill_bottle/peridaxon(src)
 	new /obj/item/storage/pill_bottle/quickclot(src)
-	new /obj/item/stack/medical/splint
+	new /obj/item/stack/medical/splint(src)
 	new/obj/item/device/healthanalyzer(src)
 
 /obj/item/storage/belt/medical/lifesaver/full/dutch/fill_preset_inventory()

--- a/code/game/objects/items/tools/extinguisher.dm
+++ b/code/game/objects/items/tools/extinguisher.dm
@@ -49,6 +49,13 @@
 	max_water = 500
 	power = PYRO_EXTINGUISHER_PWR
 
+/obj/item/tool/extinguisher/sl
+	name = "squad leader fire extinguisher"
+	desc = "A longer lasting fire extinguisher meant for squad leaders."
+	w_class = SIZE_MEDIUM
+	force = 3.0
+	max_water = 200
+
 /obj/item/tool/extinguisher/pyro/atmos_tank
 	max_water = 500000 //so it never runs out, theoretically
 

--- a/code/modules/cm_marines/equipment/kit_boxes.dm
+++ b/code/modules/cm_marines/equipment/kit_boxes.dm
@@ -340,7 +340,7 @@
 
 /obj/item/storage/box/kit/mini_pyro/fill_preset_inventory()
 	new /obj/item/storage/backpack/marine/engineerpack/flamethrower/kit(src)
-	new /obj/item/weapon/gun/flamer/underextinguisher(src)
+	new /obj/item/tool/extinguisher/mini(src)
 	new /obj/item/ammo_magazine/flamer_tank(src)
 	new /obj/item/ammo_magazine/flamer_tank(src)
 	new /obj/item/ammo_magazine/flamer_tank/gellied(src)
@@ -520,3 +520,82 @@
 	new /obj/item/storage/backpack/marine/smock(src)
 	new /obj/item/device/binoculars/range/designator/spotter(src)
 	new /obj/item/pamphlet/skill/spotter(src)
+
+/obj/item/storage/box/kit/spotter
+	name = "\improper Recon Kit" // Meant for SLs only
+	pro_case_overlay = "recon"
+
+/obj/item/storage/box/kit/recon/fill_preset_inventory()
+	new	/obj/item/explosive/plastic/breaching_charge(src)
+	new	/obj/item/explosive/plastic/breaching_charge
+	new	/obj/item/device/binoculars/range/designator(src)
+	new	/obj/item/map/current_map(src)
+	new	/obj/item/storage/box/zipcuffs(src)
+	new	/obj/item/device/motiondetector(src)
+	new	/obj/item/ammo_magazine/pistol(src)
+	new	/obj/item/ammo_magazine/pistol(src)
+	new	/obj/item/storage/pouch/general/large(src)
+	new	/obj/item/storage/large_holster/machete/full(src)
+	new	/obj/item/weapon/gun/lever_action/xm88_suppressed(src)
+	new	/obj/item/ammo_magazine/lever_action/xm88(src)
+	new	/obj/item/ammo_magazine/lever_action/xm88(src)
+	new	/obj/item/storage/belt/shotgun/xm88(src)
+
+/obj/item/storage/box/kit/assault
+	name = "\improper Assault Kit" // Meant for SLs only
+	pro_case_overlay = "assault"
+
+/obj/item/storage/box/kit/assault/fill_preset_inventory()
+	new	/obj/item/explosive/plastic/breaching_charge(src)
+	new	/obj/item/explosive/plastic/breaching_charge(src)
+	new	/obj/item/explosive/plastic/breaching_charge(src)
+	new	/obj/item/device/binoculars/range/designator(src)
+	new	/obj/item/map/current_map(src)
+	new	/obj/item/storage/box/zipcuffs(src)
+	new	/obj/item/storage/box/packet/incendiary(src)
+	new	/obj/item/storage/box/packet/incendiary(src)
+	new /obj/item/storage/backpack/marine/engineerpack/flamethrower/kit(src)
+	new /obj/item/tool/extinguisher/sl(src)
+	new /obj/item/ammo_magazine/flamer_tank(src)
+	new /obj/item/ammo_magazine/flamer_tank(src)
+	new /obj/item/ammo_magazine/flamer_tank/gellied(src)
+	new /obj/item/tool/extinguisher/mini(src)
+
+/obj/item/storage/box/kit/triage
+	name = "\improper Triage Kit" // Meant for SLs only, this turns an SL into a mini-medic as an option when they may have no medics on lower pop.
+	pro_case_overlay = "triage"
+
+/obj/item/storage/box/kit/triage/fill_preset_inventory()
+
+	new	/obj/item/explosive/plastic/breaching_charge(src)
+	new	/obj/item/device/binoculars/range/designator(src)
+	new	/obj/item/map/current_map(src)
+	new	/obj/item/storage/box/zipcuffs(src)
+	new	/obj/item/reagent_container/glass/minitank/basic(src)
+	new	/obj/item/storage/pouch/pressurized_reagent_canister/revival(src)
+	new	/obj/item/storage/pouch/autoinjector/full(src)
+	new	/obj/item/clothing/glasses/hud/sensor(src)
+	new	/obj/item/storage/belt/medical(src)
+	new	/obj/item/device/defibrillator(src)
+	new	/obj/item/device/healthanalyzer(src)
+
+/obj/item/storage/box/kit/construction
+	name = "\improper Construction Kit" // Meant for SLs only, this turns an SL into a mini-engie as an option when they may have no engie on lower pop.
+	pro_case_overlay = "construction"
+
+/obj/item/storage/box/kit/construction/fill_preset_inventory()
+
+	new	/obj/item/explosive/plastic/breaching_charge(src)
+	new	/obj/item/explosive/plastic/breaching_charge(src)
+	new	/obj/item/device/binoculars/range/designator(src)
+	new	/obj/item/map/current_map(src)
+	new	/obj/item/storage/box/zipcuffs(src)
+	new	/obj/item/explosive/plastic(src)
+	new	/obj/item/explosive/plastic(src)
+	new	/obj/item/storage/belt/utility/full(src)
+	new	/obj/item/tool/weldpack/minitank(src)
+	new	/obj/item/stack/sandbags_empty/half(src)
+	new	/obj/item/stack/sheet/metal/large_stack(src)
+	new	/obj/item/stack/sheet/plasteel/medium_stack(src)
+	new	/obj/item/stack/barbed_wire/full_stack(src)
+	new	/obj/item/tool/shovel/etool/folded(src)

--- a/code/modules/cm_marines/equipment/kit_boxes.dm
+++ b/code/modules/cm_marines/equipment/kit_boxes.dm
@@ -360,7 +360,7 @@
 	new /obj/item/ammo_magazine/flamer_tank(src)
 	new /obj/item/ammo_magazine/flamer_tank(src)
 	new /obj/item/ammo_magazine/flamer_tank/gellied(src)
-	new /obj/item/tool/extinguisher/mini(src)
+	new /obj/item/weapon/gun/flamer/underextinguisher(src)
 
 
 /obj/item/storage/box/kit/mini_sniper
@@ -540,6 +540,7 @@
 /obj/item/storage/box/kit/spotter
 	name = "\improper Recon Kit" // Meant for SLs only
 	pro_case_overlay = "recon"
+	to_chat(buyer, SPAN_BOLDNOTICE("Originally an NCO in FORECON, you disgraced yourself on an operation in a friendly fire incident. While your platoon prepared for another mission to LV-552, the CO informed you of your demotion. Following it, you've been transferred to the Falling Falcons, an infamous USCM battalion as a punishment. Get out there and prove yourself once more. Oorah."
 
 /obj/item/storage/box/kit/recon/fill_preset_inventory()
 	new	/obj/item/explosive/plastic/breaching_charge(src)
@@ -557,6 +558,7 @@
 /obj/item/storage/box/kit/assault
 	name = "\improper Assault Kit" // Overhaul of Pyrotechnic SL Kit
 	pro_case_overlay = "assault"
+	to_chat(buyer, SPAN_BOLDNOTICE("An assault marine in the USCM, you were originally a SADAR technician by trade. During Operation Tychon's Tackle, you proved yourself while assisting the Falling Falcons in destroying CLF improvised armored vehicles. For your performance, you were promoted to Sergeant by the Heyst's CO. Following the battle, while the USS Heyst undergoes repairs you were transferred to the USS Almayer. Your CQC training onboard the Heyst still serves you well. Go and burn them out, Marine!"))
 
 /obj/item/storage/box/kit/assault/fill_preset_inventory()
 	new	/obj/item/explosive/plastic/breaching_charge(src)
@@ -578,6 +580,7 @@
 /obj/item/storage/box/kit/triage
 	name = "\improper Triage Kit" // Meant for SLs only, this turns an SL into a mini-medic as an option when they may have no medics on lower pop.
 	pro_case_overlay = "triage"
+	to_chat(buyer, SPAN_BOLDNOTICE("A medic by training, you were assigned to the Falling Falcons in 2180. You were sent onto Operation Tychon's Tackle and gained notoriety from the Almayer's original CO. Field promoted to Sergeant, and later taught by the SEA before reentering hypersleep; You remember your medical training, but your leadership comes first. Oorah!"))
 
 /obj/item/storage/box/kit/triage/fill_preset_inventory()
 
@@ -587,7 +590,6 @@
 	new	/obj/item/storage/box/zipcuffs(src)
 	new	/obj/item/reagent_container/glass/minitank/basic(src)
 	new	/obj/item/storage/pouch/pressurized_reagent_canister/revival(src)
-	new	/obj/item/storage/pouch/autoinjector/full(src)
 	new	/obj/item/clothing/glasses/hud/sensor(src)
 	new	/obj/item/storage/belt/medical(src)
 	new	/obj/item/device/defibrillator(src)
@@ -597,6 +599,7 @@
 /obj/item/storage/box/kit/construction
 	name = "\improper Construction Kit" // Meant for SLs only, this turns an SL into a mini-engie as an option when they may have no engie on lower pop.
 	pro_case_overlay = "construction"
+to_chat(buyer, SPAN_BOLDNOTICE("You were an engineer in the Dust Raiders before being promoted to the rank of Sergeant. With your promotion, you had to say goodbye to the Dust Raiders and were transferred by the needs of the Marine Corps to the Falling Falcons. You still remember your engineering training, but your leadership comes first. Oorah!"))
 
 /obj/item/storage/box/kit/construction/fill_preset_inventory()
 

--- a/code/modules/cm_marines/equipment/kit_boxes.dm
+++ b/code/modules/cm_marines/equipment/kit_boxes.dm
@@ -538,9 +538,11 @@
 	new /obj/item/pamphlet/skill/spotter(src)
 
 /obj/item/storage/box/kit/spotter
+
+/obj/item/storage/box/kit/recon
 	name = "\improper Recon Kit" // Meant for SLs only
 	pro_case_overlay = "recon"
-	to_chat(buyer, SPAN_BOLDNOTICE("Originally an NCO in FORECON, you disgraced yourself on an operation in a friendly fire incident. While your platoon prepared for another mission to LV-552, the CO informed you of your demotion. Following it, you've been transferred to the Falling Falcons, an infamous USCM battalion as a punishment. Get out there and prove yourself once more. Oorah."
+	to_chat(buyer, SPAN_BOLDNOTICE("Originally an NCO in FORECON, you disgraced yourself on an operation in a friendly fire incident. While your platoon prepared for another mission to LV-552, the CO informed you of your demotion. Following it, you've been transferred to the Falling Falcons, an infamous USCM battalion as a punishment. Get out there and prove yourself once more. Oorah."))
 
 /obj/item/storage/box/kit/recon/fill_preset_inventory()
 	new	/obj/item/explosive/plastic/breaching_charge(src)
@@ -555,10 +557,12 @@
 	new	/obj/item/storage/belt/shotgun/xm88(src)
 	new /obj/item/device/encryptionkey/intel(src)
 
+/obj/item/storage/box/kit/recon
+
 /obj/item/storage/box/kit/assault
 	name = "\improper Assault Kit" // Overhaul of Pyrotechnic SL Kit
 	pro_case_overlay = "assault"
-	to_chat(buyer, SPAN_BOLDNOTICE("An assault marine in the USCM, you were originally a SADAR technician by trade. During Operation Tychon's Tackle, you proved yourself while assisting the Falling Falcons in destroying CLF improvised armored vehicles. For your performance, you were promoted to Sergeant by the Heyst's CO. Following the battle, while the USS Heyst undergoes repairs you were transferred to the USS Almayer. Your CQC training onboard the Heyst still serves you well. Go and burn them out, Marine!"))
+	var/vendmesssage("An assault marine in the USCM, you were originally a SADAR technician by trade. During Operation Tychon's Tackle, you proved yourself while assisting the Falling Falcons in destroying CLF improvised armored vehicles. For your performance, you were promoted to Sergeant by the Heyst's CO. Following the battle, while the USS Heyst undergoes repairs you were transferred to the USS Almayer. Your CQC training onboard the Heyst still serves you well. Go and burn them out, Marine!"))
 
 /obj/item/storage/box/kit/assault/fill_preset_inventory()
 	new	/obj/item/explosive/plastic/breaching_charge(src)
@@ -577,10 +581,12 @@
 	new /obj/item/tool/extinguisher/mini(src)
 	new /obj/item/device/encryptionkey/jtac(src)
 
+/obj/item/storage/box/kit/assault
+
 /obj/item/storage/box/kit/triage
 	name = "\improper Triage Kit" // Meant for SLs only, this turns an SL into a mini-medic as an option when they may have no medics on lower pop.
 	pro_case_overlay = "triage"
-	to_chat(buyer, SPAN_BOLDNOTICE("A medic by training, you were assigned to the Falling Falcons in 2180. You were sent onto Operation Tychon's Tackle and gained notoriety from the Almayer's original CO. Field promoted to Sergeant, and later taught by the SEA before reentering hypersleep; You remember your medical training, but your leadership comes first. Oorah!"))
+	var/vendmesssage("A medic by training, you were assigned to the Falling Falcons in 2180. You were sent onto Operation Tychon's Tackle and gained notoriety from the Almayer's original CO. Field promoted to Sergeant, and later taught by the SEA before reentering hypersleep; You remember your medical training, but your leadership comes first. Oorah!"))
 
 /obj/item/storage/box/kit/triage/fill_preset_inventory()
 
@@ -596,10 +602,12 @@
 	new	/obj/item/device/healthanalyzer(src)
 	new /obj/item/device/encryptionkey/med(src)
 
+/obj/item/storage/box/kit/triage
+
 /obj/item/storage/box/kit/construction
 	name = "\improper Construction Kit" // Meant for SLs only, this turns an SL into a mini-engie as an option when they may have no engie on lower pop.
 	pro_case_overlay = "construction"
-	to_chat(buyer, SPAN_BOLDNOTICE("You were an engineer in the Dust Raiders before being promoted to the rank of Sergeant. With your promotion, you had to say goodbye to the Dust Raiders and were transferred by the needs of the Marine Corps to the Falling Falcons. You still remember your engineering training, but your leadership comes first. Oorah!"))
+	var/vendmesssage("You were an engineer in the Dust Raiders before being promoted to the rank of Sergeant. With your promotion, you had to say goodbye to the Dust Raiders and were transferred by the needs of the Marine Corps to the Falling Falcons. You still remember your engineering training, but your leadership comes first. Oorah!"))
 
 /obj/item/storage/box/kit/construction/fill_preset_inventory()
 
@@ -618,3 +626,5 @@
 	new	/obj/item/stack/barbed_wire/full_stack(src)
 	new	/obj/item/tool/shovel/etool/folded(src)
 	new /obj/item/device/encryptionkey/engi(src)
+
+/obj/item/storage/box/kit/construction

--- a/code/modules/cm_marines/equipment/kit_boxes.dm
+++ b/code/modules/cm_marines/equipment/kit_boxes.dm
@@ -599,7 +599,7 @@
 /obj/item/storage/box/kit/construction
 	name = "\improper Construction Kit" // Meant for SLs only, this turns an SL into a mini-engie as an option when they may have no engie on lower pop.
 	pro_case_overlay = "construction"
-to_chat(buyer, SPAN_BOLDNOTICE("You were an engineer in the Dust Raiders before being promoted to the rank of Sergeant. With your promotion, you had to say goodbye to the Dust Raiders and were transferred by the needs of the Marine Corps to the Falling Falcons. You still remember your engineering training, but your leadership comes first. Oorah!"))
+	to_chat(buyer, SPAN_BOLDNOTICE("You were an engineer in the Dust Raiders before being promoted to the rank of Sergeant. With your promotion, you had to say goodbye to the Dust Raiders and were transferred by the needs of the Marine Corps to the Falling Falcons. You still remember your engineering training, but your leadership comes first. Oorah!"))
 
 /obj/item/storage/box/kit/construction/fill_preset_inventory()
 

--- a/code/modules/cm_marines/equipment/kit_boxes.dm
+++ b/code/modules/cm_marines/equipment/kit_boxes.dm
@@ -249,6 +249,22 @@
 			//this is to be able to use C4s that are coming with the kit
 			if(!skillcheck(user, SKILL_ENGINEER, SKILL_ENGINEER_TRAINED))
 				user.skills.set_skill(SKILL_ENGINEER, SKILL_ENGINEER_TRAINED)
+		if("Assault")
+			box = new /obj/item/storage/box/kit/assault(T)
+			specialist_assignment = "Assault"
+			user.skills.set_skill(SKILL_CQC_TRAINED, SKILL_JTAC_EXPERT)
+		if("Recon")
+			box = new /obj/item/storage/box/kit/recon(T)
+			specialist_assignment = "Recon"
+			user.skills.set_skill(SKILL_ENDURANCE_MASTER, SKILL_INTEL_TRAINED)
+		if("Triage")
+			box = new /obj/item/storage/box/kit/triage(T)
+			specialist_assignment = "Triage"
+			user.skills.set_skill(SKILL_MEDICAL_MEDIC)
+		if("Construction")
+			box = new /obj/item/storage/box/kit/construction(T)
+			specialist_assignment = "Construction"
+			user.skills.set_skill(SKILL_ENGINEER_ENGI, SKILL_CONSTRUCTION_ENGI)
 	if(specialist_assignment)
 		user.put_in_hands(spec_box)
 		ID.set_assignment((user.assigned_squad ? (user.assigned_squad.name + " ") : "") + ID.assignment + " ([specialist_assignment])")
@@ -532,17 +548,14 @@
 	new	/obj/item/map/current_map(src)
 	new	/obj/item/storage/box/zipcuffs(src)
 	new	/obj/item/device/motiondetector(src)
-	new	/obj/item/ammo_magazine/pistol(src)
-	new	/obj/item/ammo_magazine/pistol(src)
-	new	/obj/item/storage/pouch/general/large(src)
-	new	/obj/item/storage/large_holster/machete/full(src)
 	new	/obj/item/weapon/gun/lever_action/xm88_suppressed(src)
 	new	/obj/item/ammo_magazine/lever_action/xm88(src)
 	new	/obj/item/ammo_magazine/lever_action/xm88(src)
 	new	/obj/item/storage/belt/shotgun/xm88(src)
+	new /obj/item/device/encryptionkey/intel(src)
 
 /obj/item/storage/box/kit/assault
-	name = "\improper Assault Kit" // Meant for SLs only
+	name = "\improper Assault Kit" // Overhaul of Pyrotechnic SL Kit
 	pro_case_overlay = "assault"
 
 /obj/item/storage/box/kit/assault/fill_preset_inventory()
@@ -560,6 +573,7 @@
 	new /obj/item/ammo_magazine/flamer_tank(src)
 	new /obj/item/ammo_magazine/flamer_tank/gellied(src)
 	new /obj/item/tool/extinguisher/mini(src)
+	new /obj/item/device/encryptionkey/jtac(src)
 
 /obj/item/storage/box/kit/triage
 	name = "\improper Triage Kit" // Meant for SLs only, this turns an SL into a mini-medic as an option when they may have no medics on lower pop.
@@ -578,6 +592,7 @@
 	new	/obj/item/storage/belt/medical(src)
 	new	/obj/item/device/defibrillator(src)
 	new	/obj/item/device/healthanalyzer(src)
+	new /obj/item/device/encryptionkey/med(src)
 
 /obj/item/storage/box/kit/construction
 	name = "\improper Construction Kit" // Meant for SLs only, this turns an SL into a mini-engie as an option when they may have no engie on lower pop.
@@ -599,3 +614,4 @@
 	new	/obj/item/stack/sheet/plasteel/medium_stack(src)
 	new	/obj/item/stack/barbed_wire/full_stack(src)
 	new	/obj/item/tool/shovel/etool/folded(src)
+	new /obj/item/device/encryptionkey/engi(src)

--- a/code/modules/projectiles/guns/lever_action.dm
+++ b/code/modules/projectiles/guns/lever_action.dm
@@ -481,3 +481,10 @@ their unique feature is that a direct hit will buff your damage and firerate
 #undef FLOATING_PENETRATION_TIER_2
 #undef FLOATING_PENETRATION_TIER_3
 #undef FLOATING_PENETRATION_TIER_4
+
+/obj/item/weapon/gun/lever_action/xm88_suppressed // Recon kit
+	starting_attachment_types = list(
+		/obj/item/attachable/suppressor,
+		/obj/item/attachable/stock/xm88,
+		/obj/item/attachable/scope/mini/xm88
+	)


### PR DESCRIPTION
## About The Pull Request

I've been asked by Geeves to revive his SL kits. SLs retain a basic construction skill - Each separate kit gives different items and skills, alongside a flavor text background:

**Recon**

- Breaching Charge 2x
- Laser Designator
- Map
- Zipcuffs
- Motion Detector
- Suppressed XM88
- Intel Key

**Skills:** Endurance Master, Intel Trained

Flavortext:
"Originally an NCO in FORECON, you disgraced yourself on an operation in a friendly fire incident. While your platoon prepared for another mission to LV-552, the CO informed you of your demotion. Following it, you've been transferred to the Falling Falcons, an infamous USCM battalion as a punishment. Get out there and prove yourself once more. Oorah."

**Assault**

- Breaching Charge 3x
- Laser Designator
- Map 
- Zipcuffs
- 2x Incendiary Packets
- 2x Napalm Tanks
- Napalm B-Gel
- Mini Extinguisher
- Flamethrower Pack/Flamethrower
- Buffed SL Extinguisher
- JTAC Key

 **Skills:** CQC Trained, JTAC Expert

Flavortext:
"An assault marine in the USCM, you were originally a SADAR technician by trade. During Operation Tychon's Tackle, you proved yourself while assisting the Falling Falcons in destroying CLF improvised armored vehicles. For your performance, you were promoted to Sergeant by the Heyst's CO. Following the battle, while the USS Heyst undergoes repairs you were transferred to the USS Almayer. Your CQC training onboard the Heyst still serves you well. Go and burn them out, Marine!"

**Triage**

- Breaching Charge
- Laser Designator
- Map
- Zipcuffs
- Basic Minitank (Bicardine, Kelotane, Tramadol)
- Revival Mix (Epinephrine, Tricordazine, Inaprovaline)
- SensorHud
- Medical Storage Rig
- Defibrillator 
- Handheld Health Analyzer 
- Medical Key

**Skills:** Medical: Medic

Flavortext:
("A medic by training, you were assigned to the Falling Falcons in 2180. You were sent onto Operation Tychon's Tackle and gained notoriety from the Almayer's original CO. Field promoted to Sergeant, and later taught by the SEA before reentering hypersleep; You remember your medical training, but your leadership comes first. Oorah!"

**Construction**
- Breaching Charge 2x
- Plastic Explosive 2x
- Laser Designator
- Map
- Zipcuffs
- Engineering Toolbelt
- Weldertank
- Empty Sandbags 25x
- Metal Sheets 50x
- Plasteel Sheets 30x 
- Barbed Wire 20x
- Folded E-Tool

**Skills:** Engineering: Engi, Construction: Engi

Flavortext:
"You were an engineer in the Dust Raiders before being promoted to the rank of Sergeant. With your promotion, you had to say goodbye to the Dust Raiders and were transferred by the needs of the Marine Corps to the Falling Falcons. You still remember your engineering training, but your leadership comes first. Oorah!"

## Why It's Good For The Game

Since the removal of the Mark One, Squad Leaders have long been left with the pyrotechnician kit, a recycle from the time of PFC Kits. While not bad, many SLs take it and feel forced to use it - This PR aims to return more options to Squad Lead players, incentivizing unique play styles. As well, this PR aims to make low pop more bearable by allowing Squad Leads to fill gaps within their squad.

## Changelog
:cl: Mistfrag
add: Chosen SL kit displays on ID.
add: Added 4 SL Kits. Assault, an overhaul of pyro SL kit meant to lead on the frontline and call in fire support. Recon, a squad leader meant to stay back behind and coordinate their squad from behind the front. Triage, a kit meant to make up for a lack of medics on low pop. Construction, a kit meant to make up for a lack of engineers on low pop.
add: Flavortexts to all SL kits giving them a prompt for roleplay with others to encourage roleplay within an HRP role.
qol: Repackaged SL Kits to spawn in actual kits akin to spec kits, rather than dumping a mound of items onto the floor.
balance: Squad Leaders now get 4 different kits that spawn equipment and edit skills.
Balance: Squad Leaders NVGs upped to 25 points to prevent them from getting more than one pair of NVGs.
balance: Added a middle of the line underbarrel extinguisher for assault SL Kit. 200 extinguisher units (less than half of pyro) and without the instant-extinguish.
fix: fixed a few things
/:cl:

