### PR TITLE
Removes thermals from PMC sniper, moved wallpiercing element to 1 limited magazine.

### DIFF
--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -517,8 +517,9 @@
 		new /obj/item/ammo_magazine/rifle/lmg(src)
 
 /obj/item/storage/pouch/magazine/large/pmc_sniper/fill_preset_inventory()
-	for(var/i = 1 to storage_slots)
+	for(var/i = 1 to storage_slots - 1)
 		new /obj/item/ammo_magazine/sniper/elite(src)
+	new /obj/item/ammo_magazine/sniper/elite/penetrating(src)
 
 /obj/item/storage/pouch/magazine/large/pmc_rifle/fill_preset_inventory()
 	for(var/i = 1 to storage_slots)

--- a/code/modules/clothing/glasses/night.dm
+++ b/code/modules/clothing/glasses/night.dm
@@ -67,10 +67,9 @@
 
 /obj/item/clothing/glasses/night/m42_night_goggles/m42c
 	name = "\improper M42C special operations sight"
-	desc = "A specialized variation of the M42 scout sight system, intended for use with the high-power M42C anti-tank sniper rifle. Allows for highlighted imaging of surroundings, as well as detection of thermal signatures even from a great distance. Click it to toggle."
+	desc = "A specialized variation of the M42 scout sight system, intended for use with the high-power M42C anti-tank sniper rifle. Allows for highlighted imaging of surroundings. Click it to toggle."
 	icon_state = "m56_goggles"
 	deactive_state = "m56_goggles_0"
-	vision_flags = SEE_TURFS|SEE_MOBS
 
 /obj/item/clothing/glasses/night/m42_night_goggles/upp
 	name = "\improper Type 9 commando goggles"

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1645,12 +1645,6 @@
 	damage = 150
 	shell_speed = AMMO_SPEED_TIER_6 + AMMO_SPEED_TIER_2
 
-/datum/ammo/bullet/sniper/elite/set_bullet_traits()
-	. = ..()
-	LAZYADD(traits_to_give, list(
-	    BULLET_TRAIT_ENTRY(/datum/element/bullet_trait_penetrating)
-	))
-
 /datum/ammo/bullet/sniper/elite/on_hit_mob(mob/M,obj/item/projectile/P)
 	if(P.homing_target && M == P.homing_target)
 		var/mob/living/L = M
@@ -1666,6 +1660,17 @@
 			L.apply_armoured_damage(damage, ARMOR_BULLET, BRUTE, null, penetration)
 		// 150% damage to runners (225), 300% against Big xenos (450), and 200% against all others (300). -Kaga
 		to_chat(P.firer, SPAN_WARNING("Bullseye!"))
+
+/datum/ammo/bullet/sniper/elite/penetrating
+	name = "supersonic tungsten carbide sniper bullet"
+	penetration = ARMOR_PENETRATION_TIER_10 * 2 //i love tiers
+	shell_speed = AMMO_SPEED_TIER_6
+
+/datum/ammo/bullet/sniper/elite/penetrating/set_bullet_traits()
+	. = ..()
+	LAZYADD(traits_to_give, list(
+	    BULLET_TRAIT_ENTRY(/datum/element/bullet_trait_penetrating)
+	))
 
 /*
 //======

--- a/code/modules/projectiles/magazines/specialist.dm
+++ b/code/modules/projectiles/magazines/specialist.dm
@@ -44,6 +44,11 @@
 	icon_state = "m42c"
 	max_rounds = 6
 
+/obj/item/ammo_magazine/sniper/elite/penetrating
+	name = "\improper M42C penetrating marksman magazine (10x99mm)"
+	desc = "A magazine of specialized supersonic 10x99mm anti-tank rounds. These have been tipped with tungsten-carbide and given a custom, proprietary WY propellant, and as such, can completely penetrate through almost all hull. Use in spaceships not recommended."
+	icon_state = "m42c_flak"
+	default_ammo = /datum/ammo/bullet/sniper/elite/penetrating
 
 //SVD //Based on the actual Dragunov sniper rifle.
 


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Title. Adds a new bullet datum, more (meaningless) penetration, slightly less speed for flavor, moved wallpiercing element to it.
'NVG' goggles the PMC sniper gets no longer have free thermals. They still have meson sight.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Holy shit! How did this ever get in the game! 

_Thermals_ **AND** _wallpiercing_? **ON A SNIPER? _THE STRONGEST IN THE GAME?_** WHAT.

whining aside. This is completely, insanely, staggeringly and ludicrously overpowered, we've seen it before in the days of techwebs when a marine got wallpiercing they decimated the hive as no xenos could hide under cover, so badly they were quickly replaced with cluster rounds. When they had thermals they were literally power tripping harder than someone playing nightmare difficulty Doom Eternal dlc (one, not two)

Not only this, but all thermals have infinite range, and the PMC sniper can see really, REALLY REALLY far. This means, not only can he destroy ANY and ALL xeno hiding under ANY sort of cover on more than a screen's worth of range, he can also call out all the information he needs to his team: Any flanks, any rushes, whatever you need to. (He also gets a super m39 as a sidearm, so he's not even vulnerable at cqc.) He can single-handedly kill the entire hive if they're hiding on the dropship.

To put it in perspective: This weapon 4-shots queens, bypassing crit, killing them instantly, without aimed shot. It puts them at 5% health with one aimed shot. It puts every single t3, in fact, under 30% health with a single aimed shot. Imagine this, but these xenos are slightly damaged due to frontline fighting. They ALL die instantly.

If this was an event weapon, I would absolutely not complain at all. However, PMCs frequently spawn on distress signal, they can even be spawned in on any random normal round if researchers get the classified chemical. Such a strong loadout has no place on a normal round, or in fact, ever. There is no way giving a single human this much power would ever fly in an event.

Not only this, but PMCs are frequently spawned as part of staff minor events, to liven up the situation, and oftentimes in hijack they stay around to help the marines. This isn't bad, at all, but if a PMC is, let's say, twice as valuable as a normal marine, the PMC sniper, like this, is something like _fifteen_ times as valuable. It's not fair to admins, if they spawn PMCs for a roleplay event, hijack happens, and suddenly the roleplaying PMC team turns into the sole reason marines won. This causes endless (justified, from their perspective) deadchat salt, which is never enjoyable (especially if you know you caused it) and, you know, robs the xenomorphs of their deserved victory from a factor that was completely out of their control.

Instead of... this.... I've given them _one_ wallpiercing magazine, and completely removed the thermals. This lets them still use the fun and unique mechanic, but doesn't make them actually godlike hive destroyers.

https://streamable.com/gq5uxm

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->

## Changelog

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Removed PMC sniper's thermals. They only get one wall-piercing magazine now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
