### PR TITLE
fixes coffins making metal out of wood

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/coffin.dm
+++ b/code/game/objects/structures/crates_lockers/closets/coffin.dm
@@ -4,6 +4,7 @@
 	icon_state = "coffin"
 	icon_closed = "coffin"
 	icon_opened = "coffin_open"
+	material = MATERIAL_WOOD
 	anchored = 0
 
 /obj/structure/closet/coffin/update_icon()
@@ -29,6 +30,7 @@
 	icon_state = "closed_woodcrate"
 	icon_opened = "open_woodcrate"
 	icon_closed = "closed_woodcrate"
+	material = MATERIAL_WOOD
 	store_mobs = FALSE
 	climbable = TRUE
 	throwpass = 1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

adds a variable on closets to control the deconstruction material, either MATERIAL_WOOD or MATERIAL_METAL (two rarely used defines). MATERIAL_METAL requires a welder, MATERIAL_WOOD uses a crowbar

closes #392

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->

no more magical transmutation of materials

## Changelog

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: coffin's no longer transmutate wood into metal, and require a crowbar to break.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
