### PR TITLE
Zombie Death Refactor and Tweaks

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -392,6 +392,7 @@ var/list/default_onmob_icons = list(
 #define SPECIES_YAUTJA "Yautja"
 #define SPECIES_SYNTHETIC "Synthetic"
 #define SPECIES_MONKEY "Monkey"
+#define SPECIES_ZOMBIE "Zombie"
 
 #define ALL_LIMBS list("head","chest","groin","l_leg","l_foot","r_leg","r_foot","l_arm","l_hand","r_arm","r_hand")
 #define MOVEMENT_LIMBS list("l_leg", "l_foot", "r_leg", "r_foot")

--- a/code/datums/diseases/black_goo.dm
+++ b/code/datums/diseases/black_goo.dm
@@ -146,7 +146,10 @@
 				target.AddDisease(new /datum/disease/black_goo)
 				to_chat(user, SPAN_XENOWARNING("<b>You sense your target is now infected.</b>"))
 
-	target.SetSuperslowed(max(2, target.superslowed)) // Make them slower
+	if(isSynth(target))
+		target.Slow(2)
+	else
+		target.Superslow(2) // Make them slower
 
 /obj/item/weapon/zombie_claws/afterattack(obj/O as obj, mob/user as mob, proximity)
 	if(get_dist(src, O) > 1)

--- a/code/datums/diseases/black_goo.dm
+++ b/code/datums/diseases/black_goo.dm
@@ -81,7 +81,7 @@
 		if(5)
 			if(H.stat == DEAD && stage_counter != stage)
 				stage_counter = stage
-				if(H.species.name != "Zombie" && !zombie_transforming)
+				if(H.species.name != SPECIES_ZOMBIE && !zombie_transforming)
 					to_chat(H, SPAN_CENTERBOLD("Your zombie infection is now at Stage Five! Your transformation should have happened already, but will be forced now."))
 					zombie_transform(H)
 			if(!zombie_transforming && prob(50))
@@ -95,22 +95,24 @@
 				H.nutrition = NUTRITION_MAX //never hungry
 
 
-/datum/disease/black_goo/proc/zombie_transform(mob/living/carbon/human/H)
+/datum/disease/black_goo/proc/zombie_transform(mob/living/carbon/human/human)
 	set waitfor = 0
 	zombie_transforming = TRUE
-	H.vomit_on_floor()
-	H.AdjustStunned(5)
+	human.vomit_on_floor()
+	human.AdjustStunned(5)
 	sleep(20)
-	H.make_jittery(500)
+	human.make_jittery(500)
 	sleep(30)
-	if(H && H.loc)
-		if(H.stat == DEAD)
-			H.revive(TRUE)
-		playsound(H.loc, 'sound/hallucinations/wail.ogg', 25, 1)
-		H.jitteriness = 0
-		H.set_species("Zombie")
+	if(human && human.loc)
+		if(human.stat == DEAD)
+			human.revive(TRUE)
+			var/datum/species/zombie/zombie_species = GLOB.all_species[SPECIES_ZOMBIE]
+			zombie_species.handle_alert_ghost(human)
+		playsound(human.loc, 'sound/hallucinations/wail.ogg', 25, 1)
+		human.jitteriness = 0
+		human.set_species(SPECIES_ZOMBIE)
 		stage = 5
-		H.faction = FACTION_ZOMBIE
+		human.faction = FACTION_ZOMBIE
 		zombie_transforming = FALSE
 
 
@@ -122,31 +124,29 @@
 	force = 40
 	w_class = SIZE_MASSIVE
 	sharp = 1
-	attack_verb = list("slashed", "bitten", "torn", "scraped", "nibbled")
+	attack_verb = list("slashed", "torn", "scraped", "gashed", "ripped")
 	pry_capable = IS_PRY_CAPABLE_FORCE
 
-/obj/item/weapon/zombie_claws/attack(mob/living/M, mob/living/carbon/human/user)
-	if(iszombie(M))
+/obj/item/weapon/zombie_claws/attack(mob/living/target, mob/living/carbon/human/user)
+	if(iszombie(target))
 		return FALSE
 
 	. = ..()
 	if(.)
 		playsound(loc, 'sound/weapons/bladeslice.ogg', 25, 1, 5)
 
-	if(isHumanStrict(M))
-		var/mob/living/carbon/human/H = M
+	if(isHumanStrict(target))
+		var/mob/living/carbon/human/human = target
 
-		for(var/datum/disease/black_goo/BG in H.viruses)
-			user.show_message(text(SPAN_XENOWARNING(" <B>You sense your target is infected</B>")))
-			return .
+		if(locate(/datum/disease/black_goo) in human.viruses)
+			to_chat(user, SPAN_XENOWARNING("<b>You sense your target is infected.</b>"))
+		else
+			var/bio_protected = max(CLOTHING_ARMOR_HARDCORE - human.getarmor(user.zone_selected, ARMOR_BIO), 0)
+			if(prob(bio_protected))
+				target.AddDisease(new /datum/disease/black_goo)
+				to_chat(user, SPAN_XENOWARNING("<b>You sense your target is now infected.</b>"))
 
-		var/bio_protected = max(CLOTHING_ARMOR_HARDCORE - H.getarmor(user.zone_selected, ARMOR_BIO), 0)
-
-		if(prob(bio_protected))
-			M.AddDisease(new /datum/disease/black_goo())
-			user.show_message(text(SPAN_XENOWARNING(" <B>You sense your target is now infected</B>")))
-
-	M.SetSuperslowed(max(2, M.superslowed)) // Make them slower
+	target.SetSuperslowed(max(2, target.superslowed)) // Make them slower
 
 /obj/item/weapon/zombie_claws/afterattack(obj/O as obj, mob/user as mob, proximity)
 	if(get_dist(src, O) > 1)
@@ -193,8 +193,8 @@
 	garbage = FALSE
 
 /obj/item/reagent_container/food/drinks/bottle/black_goo/Initialize()
-		..()
-		reagents.add_reagent("blackgoo", 30)
+	. = ..()
+	reagents.add_reagent("blackgoo", 30)
 
 
 /obj/item/reagent_container/food/drinks/bottle/black_goo_cure
@@ -222,7 +222,8 @@
 
 /obj/item/clothing/glasses/zombie_eyes
 	name = "zombie eyes"
-	icon = null
+	icon_state = "stub"
+	item_state = "BLANK"
 	w_class = SIZE_SMALL
 	vision_flags = SEE_MOBS
 	darkness_view = 7

--- a/code/game/objects/items/devices/defibrillator.dm
+++ b/code/game/objects/items/devices/defibrillator.dm
@@ -92,7 +92,7 @@
 
 /mob/living/carbon/human/proc/get_ghost(var/check_client = TRUE, var/check_can_reenter = TRUE)
 	if(client)
-		return FALSE
+		return null
 
 	for(var/mob/dead/observer/G in GLOB.observer_list)
 		if(G.mind && G.mind.original == src)

--- a/code/modules/admin/player_panel/actions/physical.dm
+++ b/code/modules/admin/player_panel/actions/physical.dm
@@ -17,7 +17,7 @@
 			continue
 
 		var/obj/limb/L = H.get_limb(limb)
-		L.droplimb(cause = user.key)
+		L.droplimb(create_cause_data("adminbus"))
 
 	playsound(target, "bone_break", 45, TRUE)
 	target.emote("scream")

--- a/code/modules/gear_presets/other.dm
+++ b/code/modules/gear_presets/other.dm
@@ -674,9 +674,8 @@
 	return ..()
 
 /datum/equipment_preset/other/zombie/load_race(mob/living/carbon/human/H)
-	H.set_species("Human") // Set back, so that we can get our claws again
-
-	H.set_species("Zombie")
+	H.set_species(SPECIES_HUMAN) // Set back, so that we can get our claws again
+	H.set_species(SPECIES_ZOMBIE)
 
 /datum/equipment_preset/other/zombie/load_gear(mob/living/carbon/human/H)
 	var/uniform_path = pick(/obj/item/clothing/under/colonist, /obj/item/clothing/under/colonist/ua_civvies, /obj/item/clothing/under/colonist/wy_davisone, /obj/item/clothing/under/colonist/wy_joliet_shopsteward, /obj/item/clothing/under/marine/ua_riot, /obj/item/clothing/under/suit_jacket/manager, /obj/item/clothing/under/suit_jacket/director)

--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -259,7 +259,7 @@
 		return "greenblood"
 	if(species.flags & IS_SYNTHETIC)
 		return "whiteblood"
-	if(species.name == "Zombie")
+	if(species.name == SPECIES_ZOMBIE)
 		return "greyblood"
 	return "blood"
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -80,6 +80,11 @@
 	. += ""
 	. += "Security Level: [uppertext(get_security_level())]"
 
+	if(species?.has_species_tab_items)
+		var/list/species_tab_items = species.get_status_tab_items(src)
+		for(var/tab_item in species_tab_items)
+			. += tab_item
+
 	if(faction == FACTION_MARINE & !isnull(SSticker) && !isnull(SSticker.mode) && !isnull(SSticker.mode.active_lz) && !isnull(SSticker.mode.active_lz.loc) && !isnull(SSticker.mode.active_lz.loc.loc))
 		. += "Primary LZ: [SSticker.mode.active_lz.loc.loc.name]"
 
@@ -1223,6 +1228,8 @@
 
 
 /mob/living/carbon/human/proc/vomit_on_floor()
+	if(stat)
+		return
 	var/turf/T = get_turf(src)
 	visible_message(SPAN_DANGER("[src] vomits on the floor!"), null, null, 5)
 	nutrition -= 20

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -27,7 +27,7 @@
 	//update the current life tick, can be used to e.g. only do something every 4 ticks
 	life_tick++
 
-	if(stat == DEAD && species.name == "Zombie")
+	if(stat == DEAD && species.name == SPECIES_ZOMBIE)
 		handle_chemicals_in_body(delta_time)
 		return
 

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -109,6 +109,8 @@
 
 	var/ignores_stripdrag_flag = FALSE
 
+	var/has_species_tab_items = FALSE
+
 /datum/species/New()
 	if(unarmed_type)
 		unarmed = new unarmed_type()
@@ -464,3 +466,9 @@
 /datum/species/proc/handle_blood_splatter(var/mob/living/carbon/human/human, var/splatter_dir)
 	var/obj/effect/temp_visual/dir_setting/bloodsplatter/bloodsplatter = new bloodsplatter_type(human.loc, splatter_dir)
 	return bloodsplatter
+
+/datum/species/proc/get_status_tab_items()
+	return list()
+
+/datum/species/proc/handle_head_loss(var/mob/living/carbon/human/human)
+	return

--- a/code/modules/mob/living/carbon/human/species/zombie.dm
+++ b/code/modules/mob/living/carbon/human/species/zombie.dm
@@ -1,11 +1,12 @@
 /datum/species/zombie
 	group = SPECIES_HUMAN
-	name = "Zombie"
+	name = SPECIES_ZOMBIE
 	name_plural = "Zombies"
 	slowdown = 1
 	blood_color = "#333333"
 	icobase = 'icons/mob/humans/species/r_goo_zed.dmi'
 	deform = 'icons/mob/humans/species/r_goo_zed.dmi'
+	eyes = "blank_s"
 	pain_type = /datum/pain/zombie
 	stamina_type = /datum/stamina/none
 	death_message = "seizes up and falls limp..."
@@ -24,84 +25,124 @@
 	knock_out_reduction = 5
 	has_organ = list()
 
+	has_species_tab_items = TRUE
+
 	var/list/to_revive = list()
+	var/list/revive_times = list()
 
-/datum/species/zombie/handle_post_spawn(var/mob/living/carbon/human/H)
-	H.set_languages(list("Zombie"))
+/datum/species/zombie/handle_post_spawn(var/mob/living/carbon/human/zombie)
+	zombie.set_languages(list("Zombie"))
 
-	H.faction = FACTION_ZOMBIE
-	H.faction_group = list(FACTION_ZOMBIE)
+	zombie.faction = FACTION_ZOMBIE
+	zombie.faction_group = list(FACTION_ZOMBIE)
 
-	if(H.l_hand) H.drop_inv_item_on_ground(H.l_hand, FALSE, TRUE)
-	if(H.r_hand) H.drop_inv_item_on_ground(H.r_hand, FALSE, TRUE)
-	if(H.wear_id) qdel(H.wear_id)
-	if(H.gloves) H.drop_inv_item_on_ground(H.gloves, FALSE, TRUE)
-	if(H.head) H.drop_inv_item_on_ground(H.head, FALSE, TRUE)
-	if(H.glasses) H.drop_inv_item_on_ground(H.glasses, FALSE, TRUE)
-	if(H.wear_mask) H.drop_inv_item_on_ground(H.wear_mask, FALSE, TRUE)
+	if(zombie.l_hand) zombie.drop_inv_item_on_ground(zombie.l_hand, FALSE, TRUE)
+	if(zombie.r_hand) zombie.drop_inv_item_on_ground(zombie.r_hand, FALSE, TRUE)
+	if(zombie.wear_id) qdel(zombie.wear_id)
+	if(zombie.gloves) zombie.drop_inv_item_on_ground(zombie.gloves, FALSE, TRUE)
+	if(zombie.head) zombie.drop_inv_item_on_ground(zombie.head, FALSE, TRUE)
+	if(zombie.glasses) zombie.drop_inv_item_on_ground(zombie.glasses, FALSE, TRUE)
+	if(zombie.wear_mask) zombie.drop_inv_item_on_ground(zombie.wear_mask, FALSE, TRUE)
 
-	var/obj/item/weapon/zombie_claws/ZC = new(H)
+	if(zombie.lying)
+		zombie.lying = FALSE
+
+	var/obj/item/weapon/zombie_claws/ZC = new(zombie)
 	ZC.icon_state = "claw_r"
-	H.equip_to_slot_or_del(ZC, WEAR_R_HAND, TRUE)
-	H.equip_to_slot_or_del(new /obj/item/weapon/zombie_claws(H), WEAR_L_HAND, TRUE)
-	H.equip_to_slot_or_del(new /obj/item/clothing/glasses/zombie_eyes(H), WEAR_EYES, TRUE)
+	zombie.equip_to_slot_or_del(ZC, WEAR_R_HAND, TRUE)
+	zombie.equip_to_slot_or_del(new /obj/item/weapon/zombie_claws(zombie), WEAR_L_HAND, TRUE)
+	zombie.equip_to_slot_or_del(new /obj/item/clothing/glasses/zombie_eyes(zombie), WEAR_EYES, TRUE)
 
-	var/datum/disease/D
-
-	for(var/datum/disease/black_goo/DD in H.viruses)
-		D = DD
-
+	var/datum/disease/black_goo/D = locate() in zombie.viruses
 	if(!D)
-		D = H.AddDisease(new /datum/disease/black_goo())
-
+		D = zombie.AddDisease(new /datum/disease/black_goo())
 	D.stage = 5
 
 	var/datum/mob_hud/Hu = huds[MOB_HUD_MEDICAL_OBSERVER]
-	Hu.add_hud_to(H)
+	Hu.add_hud_to(zombie)
 
 	return ..()
 
 
-/datum/species/zombie/post_species_loss(mob/living/carbon/human/H)
+/datum/species/zombie/post_species_loss(mob/living/carbon/human/zombie)
 	..()
-	remove_from_revive(H)
+	remove_from_revive(zombie)
 	var/datum/mob_hud/Hu = huds[MOB_HUD_MEDICAL_OBSERVER]
-	Hu.remove_hud_from(H)
+	Hu.remove_hud_from(zombie)
 
 
-/datum/species/zombie/handle_unique_behavior(var/mob/living/carbon/human/H)
+/datum/species/zombie/handle_unique_behavior(var/mob/living/carbon/human/zombie)
 	if(prob(5))
-		playsound(H.loc, 'sound/hallucinations/far_noise.ogg', 15, 1)
+		playsound(zombie.loc, 'sound/hallucinations/far_noise.ogg', 15, 1)
 	else if(prob(5))
-		playsound(H.loc, 'sound/hallucinations/veryfar_noise.ogg', 15, 1)
+		playsound(zombie.loc, 'sound/hallucinations/veryfar_noise.ogg', 15, 1)
 
-/datum/species/zombie/handle_death(var/mob/living/carbon/human/H, gibbed)
+/datum/species/zombie/handle_death(var/mob/living/carbon/human/zombie, gibbed)
 	set waitfor = 0
 
 	if(gibbed)
-		remove_from_revive(H)
+		remove_from_revive(zombie)
 		return
 
-	if(H)
-		to_chat(H, SPAN_XENOWARNING("You fall... but your body is slowly regenerating itself."))
-		to_revive[H] = addtimer(CALLBACK(src, .proc/revive_from_death, H), 1 MINUTES, TIMER_STOPPABLE|TIMER_OVERRIDE|TIMER_UNIQUE)
+	if(zombie)
+		var/obj/limb/head/head = zombie.get_limb("head")
+		if(!QDELETED(head) && !(head.status & LIMB_DESTROYED))
+			if(zombie.client)
+				zombie.play_screen_text("<span class='langchat' style=font-size:16pt;text-align:center valign='top'><u>You are dead...</u></span><br>You will rise again in one minute.", /atom/movable/screen/text/screen_text/command_order, rgb(155, 0, 200))
+			to_chat(zombie, SPAN_XENOWARNING("You fall... but your body is slowly regenerating itself."))
+			to_revive[WEAKREF(zombie)] = addtimer(CALLBACK(src, .proc/revive_from_death, zombie), 1 MINUTES, TIMER_STOPPABLE|TIMER_OVERRIDE|TIMER_UNIQUE)
+			revive_times[WEAKREF(zombie)] = world.time + 1 MINUTES
+		else
+			if(zombie.client)
+				zombie.play_screen_text("<span class='langchat' style=font-size:16pt;text-align:center valign='top'><u>You are dead...</u></span><br>You lost your head. No reviving for you.", /atom/movable/screen/text/screen_text/command_order, rgb(155, 0, 200))
+			to_chat(zombie, SPAN_XENOWARNING("You fall... headless, you will no longer rise."))
 
-/datum/species/zombie/handle_dead_death(var/mob/living/carbon/human/H, gibbed)
+/datum/species/zombie/handle_dead_death(var/mob/living/carbon/human/zombie, gibbed)
 	if(gibbed)
-		remove_from_revive(H)
+		remove_from_revive(zombie)
 
-/datum/species/zombie/proc/revive_from_death(var/mob/living/carbon/human/H)
-	if(H && H.loc && H.stat == DEAD)
-		H.revive(TRUE)
-		H.stunned = 4
+/datum/species/zombie/proc/revive_from_death(var/mob/living/carbon/human/zombie)
+	if(zombie && zombie.loc && zombie.stat == DEAD)
+		zombie.revive(TRUE)
+		zombie.stunned = 4
 
-		H.make_jittery(500)
-		H.visible_message(SPAN_WARNING("[H] rises from the ground!"))
-		remove_from_revive(H)
+		zombie.make_jittery(500)
+		zombie.visible_message(SPAN_WARNING("[zombie] rises from the ground!"))
+		remove_from_revive(zombie)
 
-		addtimer(CALLBACK(H, /mob/.proc/remove_jittery), 3 SECONDS)
+		handle_alert_ghost(zombie)
 
-/datum/species/zombie/proc/remove_from_revive(var/mob/living/carbon/human/H)
-	if(H in to_revive)
-		deltimer(to_revive[H])
-		to_revive -= H
+		addtimer(CALLBACK(zombie, /mob/.proc/remove_jittery), 3 SECONDS)
+
+/datum/species/zombie/proc/handle_alert_ghost(var/mob/living/carbon/human/zombie)
+	var/mob/dead/observer/ghost = zombie.get_ghost()
+	if(ghost?.client)
+		playsound_client(ghost.client, 'sound/effects/adminhelp_new.ogg')
+		to_chat(ghost, SPAN_BOLDNOTICE(FONT_SIZE_LARGE("Your body has risen! (Verbs -> Ghost -> Re-enter corpse, or <a href='?src=\ref[ghost];reentercorpse=1'>click here!</a>)")))
+
+/datum/species/zombie/proc/remove_from_revive(var/mob/living/carbon/human/zombie)
+	if(WEAKREF(zombie) in to_revive)
+		deltimer(to_revive[WEAKREF(zombie)])
+		to_revive -= WEAKREF(zombie)
+	revive_times -= WEAKREF(zombie)
+
+/datum/species/zombie/get_status_tab_items(var/mob/living/carbon/human/zombie)
+	var/list/static_tab_items = list()
+	if(zombie.stat == DEAD)
+		var/revive_time = revive_times[WEAKREF(zombie)]
+		if(revive_time)
+			var/revive_time_left = revive_time - world.time
+			static_tab_items += ""
+			static_tab_items += "Time Till Revive: [duration2text_sec(revive_time_left)]"
+	return static_tab_items
+
+/datum/species/zombie/handle_head_loss(var/mob/living/carbon/human/zombie)
+	if(WEAKREF(zombie) in to_revive)
+		remove_from_revive(zombie)
+		var/client/receiving_client = zombie.client
+		if(!receiving_client)
+			var/mob/dead/observer/ghost = zombie.get_ghost()
+			if(ghost) receiving_client = ghost.client
+		if(receiving_client)
+			receiving_client.mob.play_screen_text("<span class='langchat' style=font-size:16pt;text-align:center valign='top'><u>Beheaded...</u></span><br>Your corpse will no longer rise.", /atom/movable/screen/text/screen_text/command_order, rgb(155, 0, 200))
+			to_chat(receiving_client, SPAN_BOLDNOTICE(FONT_SIZE_LARGE("You've been beheaded! Your body will no longer rise.")))

--- a/code/modules/mob/living/carbon/human/species/zombie.dm
+++ b/code/modules/mob/living/carbon/human/species/zombie.dm
@@ -30,6 +30,11 @@
 	var/list/to_revive = list()
 	var/list/revive_times = list()
 
+	var/basic_moan = 'sound/hallucinations/far_noise.ogg'
+	var/basic_variance = TRUE
+	var/rare_moan = 'sound/hallucinations/veryfar_noise.ogg'
+	var/rare_variance = TRUE
+
 /datum/species/zombie/handle_post_spawn(var/mob/living/carbon/human/zombie)
 	zombie.set_languages(list("Zombie"))
 
@@ -73,9 +78,9 @@
 
 /datum/species/zombie/handle_unique_behavior(var/mob/living/carbon/human/zombie)
 	if(prob(5))
-		playsound(zombie.loc, 'sound/hallucinations/far_noise.ogg', 15, 1)
+		playsound(zombie.loc, basic_moan, 15, basic_variance)
 	else if(prob(5))
-		playsound(zombie.loc, 'sound/hallucinations/veryfar_noise.ogg', 15, 1)
+		playsound(zombie.loc, rare_moan, 15, rare_variance)
 
 /datum/species/zombie/handle_death(var/mob/living/carbon/human/zombie, gibbed)
 	set waitfor = 0

--- a/code/modules/organs/limb_objects.dm
+++ b/code/modules/organs/limb_objects.dm
@@ -130,7 +130,7 @@ obj/item/limb/New(loc, mob/living/carbon/human/H)
 	brainmob.name = H.real_name
 	brainmob.real_name = H.real_name
 	brainmob.blood_type = H.blood_type
-	if(H.mind)
+	if(H.mind && !iszombie(H))
 		H.mind.transfer_to(brainmob)
 	brainmob.container = src
 

--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -864,6 +864,7 @@ This function completely restores a damaged organ to perfect condition.
 				owner.drop_inv_item_on_ground(owner.wear_r_ear, null, TRUE)
 				owner.drop_inv_item_on_ground(owner.wear_mask, null, TRUE)
 				owner.update_hair()
+				if(owner.species) owner.species.handle_head_loss(owner)
 			if(BODY_FLAG_ARM_RIGHT)
 				if(status & (LIMB_ROBOT|LIMB_SYNTHSKIN))
 					organ = new /obj/item/robot_parts/arm/r_arm(owner.loc)

--- a/code/modules/reagents/chemistry_properties/prop_special.dm
+++ b/code/modules/reagents/chemistry_properties/prop_special.dm
@@ -227,7 +227,7 @@
 	max_level = 4
 
 /datum/chem_property/special/curing/process(mob/living/M, var/potency = 1, delta_time)
-	var/datum/species/zombie/zs = GLOB.all_species["Zombie"]
+	var/datum/species/zombie/zs = GLOB.all_species[SPECIES_ZOMBIE]
 
 	if(!ishuman(M))
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Refactors some bits of Zombie code to be better, and also adds:
 - A Revive timer to the Zombie Stat Panel
 - Alerts for Ghosted Zombies that tells them when their body has revived
 - Make zombie claw attacks have sensical attack names, and also apply super slow even if the target is infected
 - Synths only get normal slowdown, not a super slowdown
 - Zombie glasses now render correctly by not rendering at all
 - Zombies that got zombified while lying down now properly get their equipment

And lastly, as a gameplay change: Beheaded zombies cannot revive, so get to dismemberin'.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

While zombies exist in the codebase, admins will run zombie events, so we might as well make them actually have some level of user experience.

All the additions are self-explanatory, while the last needs some explanation. Currently, the only way to defeat a zombie is to gib it, which seems... kind of boring? Now, you can defeat a zombie by killing it, and then going further by blasting its head off after it's down. That should be more engaging, and offer a way to finish them off permanently if you have a chance to do so.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->

## Changelog

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Added a revive timer for zombies, as well as an alert for ghosts when their bodies revive.
balance: Zombie claws now apply a slowdown even if the slashed target is already infected. Synths only get a regular slowdown, not a super slowdown.
balance: You can now permanently kill zombies by decapitating them.
fix: Fixes zombie eyes rendering incorrectly.
fix: Zombies that zombify while lying down now get their equipment correctly.
spellcheck: Zombie claw attacks now have sensical attack names.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
