### PR TITLE
Fixes defender crest defense not blocking rest

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
@@ -84,6 +84,10 @@
 		to_chat(src, SPAN_WARNING("You cannot rest while burrowed!"))
 		return
 
+	if(crest_defense)
+		to_chat(src, SPAN_WARNING("You cannot rest while your crest is down!"))
+		return
+
 	return ..()
 
 /datum/action/xeno_action/onclick/xeno_resting/use_ability(atom/target)


### PR DESCRIPTION
## About The Pull Request

When a defender used their crest defense, they could rest but it didn't update their sprites. This PR blocks them from resting while their crest is down, thus being consistent with fortify blocking and fixing the sprite issue.

closes #1056 

## Why It's Good For The Game

Defender won't look weird standing still but resting, and the player won't be confused either. A fix.

## Changelog

:cl: Usnpepoo
fix: Defenders crest down now blocks rest similar to fortify
/:cl:

