### PR TITLE
Fix TGS rustg Cross-Compile Dependencies Error

### DIFF
--- a/tools/tgs4_scripts/PreCompile.sh
+++ b/tools/tgs4_scripts/PreCompile.sh
@@ -46,7 +46,7 @@ if ! ( [ -x "$has_git" ] && [ -x "$has_grep" ] && [ -f "/usr/lib/i386-linux-gnu/
 fi
 dpkg --add-architecture i386
 apt-get update
-apt-get install -y lib32z1 pkg-config libssl-dev:i386 libssl-dev libssl1.1:i386 gcc-multilib
+apt-get install -y zlib1g:i386 zlib1g-dev:i386 pkg-config libssl-dev:i386 libssl-dev libssl1.1:i386 gcc-multilib
 # update rust-g
 if [ ! -d "rust-g" ]; then
 	echo "Cloning rust-g..."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Some setups seem to fail to link rustg to zlib because they're unable to find the library.

Why exactly using the newer multiarch packages instead of legacy lib32 one makes a difference is unclear, probably residing in pkg-config or rustg crosscompile quirks...

How the live server booted up just fine the first time despite this is also anyone's guess...
