### PR TITLE
Sorokyne crashed ship double APC fix

### DIFF
--- a/maps/map_files/Sorokyne_Strata/Sorokyne_Strata.dmm
+++ b/maps/map_files/Sorokyne_Strata/Sorokyne_Strata.dmm
@@ -22467,11 +22467,6 @@
 /obj/structure/platform/strata{
 	dir = 8
 	},
-/obj/structure/machinery/power/apc{
-	dir = 1;
-	pixel_x = -29;
-	start_charge = 0
-	},
 /turf/open/auto_turf/snow/brown_base/layer2,
 /area/strata/ag/exterior/marsh/crash)
 "bsU" = (
@@ -33426,10 +33421,10 @@
 "haU" = (
 /obj/structure/machinery/power/apc{
 	dir = 4;
-	pixel_x = 28;
+	pixel_x = -28;
 	start_charge = 0
 	},
-/turf/open/auto_turf/snow/brown_base/layer1,
+/turf/open/floor/plating,
 /area/strata/ag/exterior/marsh/crash)
 "haZ" = (
 /obj/structure/surface/table/reinforced/prison,
@@ -47293,7 +47288,7 @@ aVq
 aVq
 bgS
 bgS
-haU
+bgS
 bgS
 bgS
 bhO
@@ -47683,7 +47678,7 @@ aVq
 aVq
 bgS
 bgS
-xzR
+haU
 xzR
 bgS
 bhN


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Removes an extra APC at the crashed ship on sorokyne and also offsets correctly off of plating.

## Why It's Good For The Game

Bug bad.

## Changelog

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Morrow
fix: Removes an extra APC at the crashed ship on sorokyne and also offsets correctly off of plating.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
