### PR TITLE
Wiki Guide Integration

### DIFF
--- a/code/__DEFINES/urls.dm
+++ b/code/__DEFINES/urls.dm
@@ -1,10 +1,10 @@
-///////////////////////// Changelog /////////////////////////////////////////
+/// Changelog ///
 #define URL_CHANGELOG				"https://cm-ss13.com/changelog"
 
-///////////////////////// Issue Tracker /////////////////////////////////////////
+/// Issue Tracker ///
 #define URL_ISSUE_TRACKER			"https://github.com/cmss13-devs/cmss13/issues"
 
-///////////////////////// Misc Wiki Links /////////////////////////////////////////
+/// Misc Wiki Links ///
 #define URL_WIKI_RULES				"https://cm-ss13.com/wiki/Rules"
 
 #define URL_WIKI_LANDING			"https://cm-ss13.com/wiki/Main_Page"
@@ -22,7 +22,7 @@
 #define URL_WIKI_SURGERY			"https://cm-ss13.com/wiki/Surgery"
 #define URL_WIKI_MEDICAL			"https://cm-ss13.com/wiki/Guide_to_Medicine"
 
-///////////////////////// Guides For Start /////////////////////////////////////////
+/// Guides For Start ///
 
 #define URL_WIKI_CO_GUIDE			"https://cm-ss13.com/wiki/Commanding_Officer" // Command //
 #define URL_WIKI_XO_GUIDE			"https://cm-ss13.com/wiki/Executive_Officer"
@@ -56,7 +56,7 @@
 #define URL_WIKI_CL_GUIDE			"https://cm-ss13.com/wiki/Corporate_Liaison" // Misc //
 #define URL_WIKI_SURV_GUIDE			"https://cm-ss13.com/wiki/Survivor"
 
-///////////////////////// Forum Documents /////////////////////////////////////////
+/// Forum Documents ///
 #define URL_FORUM					"https://cm-ss13.com/forums"
 #define URL_FORUM_APPEALS			"https://cm-ss13.com/forums/forms.php?do=form&fid=6"
 #define URL_FORUM_PLAYER_REPORT			"https://cm-ss13.com/forums/forms.php?do=form&fid=10"

--- a/code/__DEFINES/urls.dm
+++ b/code/__DEFINES/urls.dm
@@ -1,13 +1,10 @@
-// ------ CHANGE LOG ------ \\
-
+// ------ CHANGE LOG ------ //
 #define URL_CHANGELOG				"https://cm-ss13.com/changelog"
 
-// ------ ISSUE TRACKER ------ \\
-
+// ------ ISSUE TRACKER ------ //
 #define URL_ISSUE_TRACKER			"https://github.com/cmss13-devs/cmss13/issues"
 
-// ------ MISC WIKI LINKS ------ \\
-
+// ------ MISC WIKI LINKS ------ //
 #define URL_WIKI_RULES				"https://cm-ss13.com/wiki/Rules"
 #define URL_WIKI_LANDING			"https://cm-ss13.com/wiki/Main_Page"
 #define URL_WIKI_COC			"https://cm-ss13.com/wiki/Rank"
@@ -24,8 +21,7 @@
 #define URL_WIKI_SURGERY			"https://cm-ss13.com/wiki/Surgery"
 #define URL_WIKI_MEDICAL			"https://cm-ss13.com/wiki/Guide_to_Medicine"
 
-// ------  SPAWN GUIDES------ \\
-
+// ------  SPAWN GUIDES------ //
 #define URL_WIKI_CO_GUIDE			"https://cm-ss13.com/wiki/Commanding_Officer" // Command //
 #define URL_WIKI_XO_GUIDE			"https://cm-ss13.com/wiki/Executive_Officer"
 #define URL_WIKI_SO_GUIDE			"https://cm-ss13.com/wiki/Staff_Officer"
@@ -58,8 +54,7 @@
 #define URL_WIKI_CL_GUIDE			"https://cm-ss13.com/wiki/Corporate_Liaison" // Misc //
 #define URL_WIKI_SURV_GUIDE			"https://cm-ss13.com/wiki/Survivor"
 
-// ------ FORUM LINKS ------ \\
-
+// ------ FORUM LINKS ------ //
 #define URL_FORUM					"https://cm-ss13.com/forums"
 #define URL_FORUM_APPEALS			"https://cm-ss13.com/forums/forms.php?do=form&fid=6"
 #define URL_FORUM_PLAYER_REPORT			"https://cm-ss13.com/forums/forms.php?do=form&fid=10"

--- a/code/__DEFINES/urls.dm
+++ b/code/__DEFINES/urls.dm
@@ -1,12 +1,14 @@
-/// Changelog ///
+// ------ CHANGE LOG ------ \\
+
 #define URL_CHANGELOG				"https://cm-ss13.com/changelog"
 
-/// Issue Tracker ///
+// ------ ISSUE TRACKER ------ \\
+
 #define URL_ISSUE_TRACKER			"https://github.com/cmss13-devs/cmss13/issues"
 
-/// Misc Wiki Links ///
-#define URL_WIKI_RULES				"https://cm-ss13.com/wiki/Rules"
+// ------ MISC WIKI LINKS ------ \\
 
+#define URL_WIKI_RULES				"https://cm-ss13.com/wiki/Rules"
 #define URL_WIKI_LANDING			"https://cm-ss13.com/wiki/Main_Page"
 #define URL_WIKI_COC			"https://cm-ss13.com/wiki/Rank"
 #define URL_WIKI_LAW			"https://cm-ss13.com/wiki/Marine_Law"
@@ -22,7 +24,7 @@
 #define URL_WIKI_SURGERY			"https://cm-ss13.com/wiki/Surgery"
 #define URL_WIKI_MEDICAL			"https://cm-ss13.com/wiki/Guide_to_Medicine"
 
-/// Guides For Start ///
+// ------  SPAWN GUIDES------ \\
 
 #define URL_WIKI_CO_GUIDE			"https://cm-ss13.com/wiki/Commanding_Officer" // Command //
 #define URL_WIKI_XO_GUIDE			"https://cm-ss13.com/wiki/Executive_Officer"
@@ -56,7 +58,8 @@
 #define URL_WIKI_CL_GUIDE			"https://cm-ss13.com/wiki/Corporate_Liaison" // Misc //
 #define URL_WIKI_SURV_GUIDE			"https://cm-ss13.com/wiki/Survivor"
 
-/// Forum Documents ///
+// ------ FORUM LINKS ------ \\
+
 #define URL_FORUM					"https://cm-ss13.com/forums"
 #define URL_FORUM_APPEALS			"https://cm-ss13.com/forums/forms.php?do=form&fid=6"
 #define URL_FORUM_PLAYER_REPORT			"https://cm-ss13.com/forums/forms.php?do=form&fid=10"

--- a/code/__DEFINES/urls.dm
+++ b/code/__DEFINES/urls.dm
@@ -1,10 +1,10 @@
-// Changelog
+///////////////////////// Changelog /////////////////////////////////////////
 #define URL_CHANGELOG				"https://cm-ss13.com/changelog"
 
-// Issue tracker
+///////////////////////// Issue Tracker /////////////////////////////////////////
 #define URL_ISSUE_TRACKER			"https://github.com/cmss13-devs/cmss13/issues"
 
-// Wiki links
+///////////////////////// Misc Wiki Links /////////////////////////////////////////
 #define URL_WIKI_RULES				"https://cm-ss13.com/wiki/Rules"
 
 #define URL_WIKI_LANDING			"https://cm-ss13.com/wiki/Main_Page"
@@ -15,7 +15,6 @@
 #define URL_WIKI_MACROS				"https://cm-ss13.com/wiki/Macros"
 #define URL_WIKI_SOP				"https://cm-ss13.com/wiki/Standard_Operating_Procedure"
 #define URL_WIKI_CO_RULES			"https://cm-ss13.com/wiki/CO_Council_Rulings"
-
 #define URL_WIKI_CONSTRUCTION		"https://cm-ss13.com/wiki/Guide_to_construction"
 #define URL_WIKI_ENGINEERING		"https://cm-ss13.com/wiki/Guide_to_Engineering"
 #define URL_WIKI_HACKING			"https://cm-ss13.com/wiki/Guide_to_Engineering#Hacking"
@@ -23,7 +22,41 @@
 #define URL_WIKI_SURGERY			"https://cm-ss13.com/wiki/Surgery"
 #define URL_WIKI_MEDICAL			"https://cm-ss13.com/wiki/Guide_to_Medicine"
 
-// Forum links
+///////////////////////// Guides For Start /////////////////////////////////////////
+
+#define URL_WIKI_CO_GUIDE			"https://cm-ss13.com/wiki/Commanding_Officer" // Command Guides Start here //
+#define URL_WIKI_XO_GUIDE			"https://cm-ss13.com/wiki/Executive_Officer"
+#define URL_WIKI_SO_GUIDE			"https://cm-ss13.com/wiki/Staff_Officer"
+#define URL_WIKI_SEA_GUIDE			"https://cm-ss13.com/wiki/Senior_Enlisted_Advisor"
+#define URL_WIKI_SL_GUIDE			"https://cm-ss13.com/wiki/Squad_Leader"
+#define URL_WIKI_RTO_GUIDE			"https://cm-ss13.com/wiki/Squad_Radio_Telephone_Operator" // Squad Roles //
+#define URL_WIKI_SPEC_GUIDE			"https://cm-ss13.com/wiki/Squad_Specialist"
+#define URL_WIKI_SG_GUIDE			"https://cm-ss13.com/wiki/Squad_Smartgunner"
+#define URL_WIKI_MEDIC_GUIDE			"https://cm-ss13.com/wiki/Squad_Hospital_Corpsman"
+#define URL_WIKI_COMTECH_GUIDE			"https://cm-ss13.com/wiki/Squad_Combat_Technician"
+#define URL_WIKI_CMP_GUIDE			"https://cm-ss13.com/wiki/Chief_MP" // MP Roles //
+#define URL_WIKI_MW_GUIDE			"https://cm-ss13.com/wiki/Warden"
+#define URL_WIKI_MP_GUIDE			"https://cm-ss13.com/wiki/Military_Police"
+#define URL_WIKI_MPC_GUIDE			"https://cm-ss13.com/wiki/Military_Police_Cadet"
+#define URL_WIKI_PO_GUIDE			"https://cm-ss13.com/wiki/Pilot_Officer" // Auxiliary Support
+#define URL_WIKI_DCC_GUIDE			"https://cm-ss13.com/wiki/Dropship_Crew_Chief"
+#define URL_WIKI_VC_GUIDE			"https://cm-ss13.com/wiki/Vehicle_Crewman"
+#define URL_WIKI_IO_GUIDE			"https://cm-ss13.com/wiki/Intelligence_Officer"
+#define URL_WIKI_SYN_GUIDE			"https://cm-ss13.com/wiki/Synthetic"
+#define URL_WIKI_CE_GUIDE			"https://cm-ss13.com/wiki/Chief_Engineer" // Engineering
+#define URL_WIKI_OT_GUIDE			"https://cm-ss13.com/wiki/Ordnance_Technician"
+#define URL_WIKI_MT_GUIDE			"https://cm-ss13.com/wiki/Maintenance_Technician"
+#define URL_WIKI_CMO_GUIDE			"https://cm-ss13.com/wiki/Chief_Medical_Officer" // Medical //
+#define URL_WIKI_DOC_GUIDE			"https://cm-ss13.com/wiki/Doctor"
+#define URL_WIKI_NURSE_GUIDE			"https://cm-ss13.com/wiki/Nurse"
+#define URL_WIKI_RSR_GUIDE			"https://cm-ss13.com/wiki/Researcher"
+#define URL_WIKI_RO_GUIDE			"https://cm-ss13.com/wiki/Requisitions_Officer" // Supply //
+#define URL_WIKI_CT_GUIDE			"https://cm-ss13.com/wiki/Cargo_Technician"
+#define URL_WIKI_MST_GUIDE			"https://cm-ss13.com/wiki/Mess_Technician"
+#define URL_WIKI_CL_GUIDE			"https://cm-ss13.com/wiki/Corporate_Liaison" // Misc //
+#define URL_WIKI_SURV_GUIDE			"https://cm-ss13.com/wiki/Survivor"
+
+///////////////////////// Forum Documents /////////////////////////////////////////
 #define URL_FORUM					"https://cm-ss13.com/forums"
 #define URL_FORUM_APPEALS			"https://cm-ss13.com/forums/forms.php?do=form&fid=6"
 #define URL_FORUM_PLAYER_REPORT		"https://cm-ss13.com/forums/forms.php?do=form&fid=10"

--- a/code/__DEFINES/urls.dm
+++ b/code/__DEFINES/urls.dm
@@ -8,23 +8,23 @@
 #define URL_WIKI_RULES				"https://cm-ss13.com/wiki/Rules"
 
 #define URL_WIKI_LANDING			"https://cm-ss13.com/wiki/Main_Page"
-#define URL_WIKI_COC				"https://cm-ss13.com/wiki/Rank"
-#define URL_WIKI_LAW				"https://cm-ss13.com/wiki/Marine_Law"
-#define URL_WIKI_XENO_QUICKSTART	"https://cm-ss13.com/wiki/Xeno_Quickstart_Guide"
-#define URL_WIKI_MARINE_QUICKSTART	"https://cm-ss13.com/wiki/Marine_Quickstart_Guide"
+#define URL_WIKI_COC			"https://cm-ss13.com/wiki/Rank"
+#define URL_WIKI_LAW			"https://cm-ss13.com/wiki/Marine_Law"
+#define URL_WIKI_XENO_QUICKSTART			"https://cm-ss13.com/wiki/Xeno_Quickstart_Guide"
+#define URL_WIKI_MARINE_QUICKSTART			"https://cm-ss13.com/wiki/Marine_Quickstart_Guide"
 #define URL_WIKI_MACROS				"https://cm-ss13.com/wiki/Macros"
-#define URL_WIKI_SOP				"https://cm-ss13.com/wiki/Standard_Operating_Procedure"
+#define URL_WIKI_SOP			"https://cm-ss13.com/wiki/Standard_Operating_Procedure"
 #define URL_WIKI_CO_RULES			"https://cm-ss13.com/wiki/CO_Council_Rulings"
-#define URL_WIKI_CONSTRUCTION		"https://cm-ss13.com/wiki/Guide_to_construction"
-#define URL_WIKI_ENGINEERING		"https://cm-ss13.com/wiki/Guide_to_Engineering"
+#define URL_WIKI_CONSTRUCTION			"https://cm-ss13.com/wiki/Guide_to_construction"
+#define URL_WIKI_ENGINEERING			"https://cm-ss13.com/wiki/Guide_to_Engineering"
 #define URL_WIKI_HACKING			"https://cm-ss13.com/wiki/Guide_to_Engineering#Hacking"
-#define URL_WIKI_APC				"https://cm-ss13.com/wiki/Guide_to_Engineering#APC_Maintenance"
+#define URL_WIKI_APC			"https://cm-ss13.com/wiki/Guide_to_Engineering#APC_Maintenance"
 #define URL_WIKI_SURGERY			"https://cm-ss13.com/wiki/Surgery"
 #define URL_WIKI_MEDICAL			"https://cm-ss13.com/wiki/Guide_to_Medicine"
 
 ///////////////////////// Guides For Start /////////////////////////////////////////
 
-#define URL_WIKI_CO_GUIDE			"https://cm-ss13.com/wiki/Commanding_Officer" // Command Guides Start here //
+#define URL_WIKI_CO_GUIDE			"https://cm-ss13.com/wiki/Commanding_Officer" // Command //
 #define URL_WIKI_XO_GUIDE			"https://cm-ss13.com/wiki/Executive_Officer"
 #define URL_WIKI_SO_GUIDE			"https://cm-ss13.com/wiki/Staff_Officer"
 #define URL_WIKI_SEA_GUIDE			"https://cm-ss13.com/wiki/Senior_Enlisted_Advisor"
@@ -59,5 +59,6 @@
 ///////////////////////// Forum Documents /////////////////////////////////////////
 #define URL_FORUM					"https://cm-ss13.com/forums"
 #define URL_FORUM_APPEALS			"https://cm-ss13.com/forums/forms.php?do=form&fid=6"
-#define URL_FORUM_PLAYER_REPORT		"https://cm-ss13.com/forums/forms.php?do=form&fid=10"
-#define URL_FORUM_STAFF_REPORT		"https://cm-ss13.com/forums/forms.php?do=form&fid=12"
+#define URL_FORUM_PLAYER_REPORT			"https://cm-ss13.com/forums/forms.php?do=form&fid=10"
+#define URL_FORUM_STAFF_REPORT			"https://cm-ss13.com/forums/forms.php?do=form&fid=12"
+#define URL_QUEEN_GUIDE			"https://cm-ss13.com/forums/showthread.php?8404-Ultimate-Queen-Guide-Rip-amp-amp-Tear-(Image-Heavy)"

--- a/code/game/jobs/job/civilians/other/liaison.dm
+++ b/code/game/jobs/job/civilians/other/liaison.dm
@@ -6,7 +6,7 @@
 	selection_class = "job_cl"
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT
 	gear_preset = /datum/equipment_preset/uscm_ship/liaison
-	entry_message_body = "As a <a href='"+URL_WIKI_CL_GUIDE+">representative of Weyland-Yutani Corporation</a>, your job requires you to stay in character at all times. You are not required to follow military orders; however, you cannot give military orders. Your primary job is to observe and report back your findings to Weyland-Yutani. Follow regular game rules unless told otherwise by your superiors. Use your office fax machine to communicate with corporate headquarters or to acquire new directives. You may not receive anything back, and this is normal."
+	entry_message_body = "As a <a href='"+URL_WIKI_CL_GUIDE+"'>representative of Weyland-Yutani Corporation</a>, your job requires you to stay in character at all times. You are not required to follow military orders; however, you cannot give military orders. Your primary job is to observe and report back your findings to Weyland-Yutani. Follow regular game rules unless told otherwise by your superiors. Use your office fax machine to communicate with corporate headquarters or to acquire new directives. You may not receive anything back, and this is normal."
 	var/mob/living/carbon/human/active_liaison
 
 /datum/job/civilian/liaison/generate_entry_conditions(mob/living/liaison, whitelist_status)

--- a/code/game/jobs/job/civilians/other/liaison.dm
+++ b/code/game/jobs/job/civilians/other/liaison.dm
@@ -6,7 +6,7 @@
 	selection_class = "job_cl"
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT
 	gear_preset = /datum/equipment_preset/uscm_ship/liaison
-	entry_message_body = "As a representative of Weyland-Yutani Corporation, your job requires you to stay in character at all times. You are not required to follow military orders; however, you cannot give military orders. Your primary job is to observe and report back your findings to Weyland-Yutani. Follow regular game rules unless told otherwise by your superiors. Use your office fax machine to communicate with corporate headquarters or to acquire new directives. You may not receive anything back, and this is normal."
+	entry_message_body = "As a <a href='"+URL_WIKI_CL_GUIDE+">representative of Weyland-Yutani Corporation</a>, your job requires you to stay in character at all times. You are not required to follow military orders; however, you cannot give military orders. Your primary job is to observe and report back your findings to Weyland-Yutani. Follow regular game rules unless told otherwise by your superiors. Use your office fax machine to communicate with corporate headquarters or to acquire new directives. You may not receive anything back, and this is normal."
 	var/mob/living/carbon/human/active_liaison
 
 /datum/job/civilian/liaison/generate_entry_conditions(mob/living/liaison, whitelist_status)

--- a/code/game/jobs/job/civilians/other/mess_seargent.dm
+++ b/code/game/jobs/job/civilians/other/mess_seargent.dm
@@ -6,7 +6,7 @@
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT
 	supervisors = "the acting commanding officer"
 	gear_preset = /datum/equipment_preset/uscm_ship/chef
-	entry_message_body = "Your job is to service the marines with excellent food, drinks and entertaining the shipside crew when needed. You have a lot of freedom and it is up to you, to decide what to do with it. Good luck!"
+	entry_message_body = "<a href='"+URL_WIKI_MST_GUIDE+"'>Your job is to service the marines with excellent food</a>, drinks and entertaining the shipside crew when needed. You have a lot of freedom and it is up to you, to decide what to do with it. Good luck!"
 
 /obj/effect/landmark/start/chef
 	name = JOB_MESS_SERGEANT

--- a/code/game/jobs/job/civilians/support/cmo.dm
+++ b/code/game/jobs/job/civilians/support/cmo.dm
@@ -6,7 +6,7 @@
 	selection_class = "job_cmo"
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT
 	gear_preset = /datum/equipment_preset/uscm_ship/uscm_medical/cmo
-	entry_message_body = "You're a commissioned officer of the USCM. <a href='"+URL_WIKI_GUIDE_CMO+"'>You have authority over everything related to Medbay and Research</a>, only able to be overriden by the XO and CO. You are in charge of medical staff, surgery, chemistry, stimulants and keeping the marines healthy overall."
+	entry_message_body = "You're a commissioned officer of the USCM. <a href='"+URL_WIKI_CMO_GUIDE+"'>You have authority over everything related to Medbay and Research</a>, only able to be overriden by the XO and CO. You are in charge of medical staff, surgery, chemistry, stimulants and keeping the marines healthy overall."
 
 AddTimelock(/datum/job/civilian/professor, list(
 	JOB_MEDIC_ROLES = 10 HOURS

--- a/code/game/jobs/job/civilians/support/cmo.dm
+++ b/code/game/jobs/job/civilians/support/cmo.dm
@@ -6,7 +6,7 @@
 	selection_class = "job_cmo"
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT
 	gear_preset = /datum/equipment_preset/uscm_ship/uscm_medical/cmo
-	entry_message_body = "You're a commissioned officer of the USCM. You have authority over everything related to Medbay and Research, only able to be overriden by the XO and CO. You are in charge of medical staff, surgery, chemistry, stimulants and keeping the marines healthy overall."
+	entry_message_body = "You're a commissioned officer of the USCM. <a href='"+URL_WIKI_GUIDE_CMO+"'>You have authority over everything related to Medbay and Research</a>, only able to be overriden by the XO and CO. You are in charge of medical staff, surgery, chemistry, stimulants and keeping the marines healthy overall."
 
 AddTimelock(/datum/job/civilian/professor, list(
 	JOB_MEDIC_ROLES = 10 HOURS

--- a/code/game/jobs/job/civilians/support/doctor.dm
+++ b/code/game/jobs/job/civilians/support/doctor.dm
@@ -9,7 +9,7 @@
 	selection_class = "job_doctor"
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT
 	gear_preset = /datum/equipment_preset/uscm_ship/uscm_medical/doctor
-	entry_message_body = "You're a commissioned officer of the USCM, though you are not in the ship's chain of command. You are tasked with keeping the marines healthy and strong, usually in the form of surgery. You are also an expert when it comes to medication and treatment. If you do not know what you are doing, mentorhelp so a mentor can assist you."
+	entry_message_body = "You're a commissioned officer of the USCM, though you are not in the ship's chain of command. <a href='"+URL_WIKI_DOC_GUIDE+"'>You are tasked with keeping the marines healthy and strong, usually in the form of surgery.</a> You are also an expert when it comes to medication and treatment. If you do not know what you are doing, mentorhelp so a mentor can assist you."
 
 /datum/job/civilian/doctor/set_spawn_positions(var/count)
 	spawn_positions = doc_slot_formula(count)

--- a/code/game/jobs/job/civilians/support/nurse.dm
+++ b/code/game/jobs/job/civilians/support/nurse.dm
@@ -6,7 +6,7 @@
 	selection_class = "job_doctor"
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT
 	gear_preset = /datum/equipment_preset/uscm_ship/uscm_medical/nurse
-	entry_message_body = "You are tasked with keeping the Marines healthy and strong. You are also an expert when it comes to medication and treatment, but you do not know anything about surgery. Focus on assisting doctors and triaging wounded marines."
+	entry_message_body = "<a href='"+URL_WIKI_NURSE_GUIDE+"'>You are tasked with keeping the Marines healthy and strong.</a> You are also an expert when it comes to medication and treatment, but you do not know anything about surgery. Focus on assisting doctors and triaging wounded marines."
 
 /obj/effect/landmark/start/nurse
 	name = JOB_NURSE

--- a/code/game/jobs/job/civilians/support/researcher.dm
+++ b/code/game/jobs/job/civilians/support/researcher.dm
@@ -10,7 +10,7 @@
 	selection_class = "job_researcher"
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT
 	gear_preset = /datum/equipment_preset/uscm_ship/uscm_medical/researcher
-	entry_message_body = "You're a commissioned officer of the USCM, though you are not in the ship's chain of command. You are tasked with researching and developing new medical treatments, helping your fellow doctors, and generally learning new things. Your role involves a lot of roleplaying, but you can perform the function of a regular doctor. Do not hand out things to Marines without getting permission from your supervisor."
+	entry_message_body = "You're a commissioned officer of the USCM, though you are not in the ship's chain of command. You are tasked with <a href='"+URL_WIKI_RSR_GUIDE+"'>researching</a> and developing new medical treatments, helping your fellow doctors, and generally learning new things. Your role involves a lot of roleplaying, but you can perform the function of a regular doctor. Do not hand out things to Marines without getting permission from your supervisor."
 
 /datum/job/civilian/researcher/set_spawn_positions(var/count)
 	spawn_positions = rsc_slot_formula(count)

--- a/code/game/jobs/job/civilians/support/synthetic.dm
+++ b/code/game/jobs/job/civilians/support/synthetic.dm
@@ -9,7 +9,7 @@
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT|ROLE_ADMIN_NOTIFY|ROLE_WHITELISTED|ROLE_CUSTOM_SPAWN
 	flags_whitelist = WHITELIST_SYNTHETIC
 	gear_preset = /datum/equipment_preset/synth/uscm
-	entry_message_body = "You are a Synthetic! You are held to a higher standard and are required to obey not only the Server Rules but Marine Law and Synthetic Rules. Failure to do so may result in your White-list Removal. Your primary job is to support and assist all USCM Departments and Personnel on-board. In addition, being a Synthetic gives you knowledge in every field and specialization possible on-board the ship. As a Synthetic you answer to the acting commanding officer. Special circumstances may change this!"
+	entry_message_body = "You are a <a href='"+URL_WIKI_SYN_GUIDE+"'>Synthetic!</a> You are held to a higher standard and are required to obey not only the Server Rules but Marine Law and Synthetic Rules. Failure to do so may result in your White-list Removal. Your primary job is to support and assist all USCM Departments and Personnel on-board. In addition, being a Synthetic gives you knowledge in every field and specialization possible on-board the ship. As a Synthetic you answer to the acting commanding officer. Special circumstances may change this!"
 
 /datum/job/civilian/synthetic/New()
 	. = ..()

--- a/code/game/jobs/job/command/auxiliary/crew_chief.dm
+++ b/code/game/jobs/job/command/auxiliary/crew_chief.dm
@@ -6,7 +6,7 @@
 	scaled = TRUE
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT
 	gear_preset = /datum/equipment_preset/uscm_ship/dcc
-	entry_message_body = "Your job is to assist the pilot officer maintain the ship's dropship. You have authority only on the dropship, but you are expected to maintain order, as not to disrupt the pilot."
+	entry_message_body = "<a href='"+URL_WIKI_DCC_GUIDE+"'>Your job is to assist</a> the pilot officer maintain the ship's dropship. You have authority only on the dropship, but you are expected to maintain order, as not to disrupt the pilot."
 
 AddTimelock(/datum/job/command/crew_chief, list(
 	JOB_SQUAD_ROLES = 5 HOURS

--- a/code/game/jobs/job/command/auxiliary/intel.dm
+++ b/code/game/jobs/job/command/auxiliary/intel.dm
@@ -7,7 +7,7 @@
 	scaled = 1
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT
 	gear_preset = "USCM Intelligence Officer (IO) (Cryo)"
-	entry_message_body = "Your job is to assist the marines in collecting intelligence related to the current operation to better inform command of their opposition. You are in charge of gathering any data disks, folders, and notes you may find on the operational grounds and decrypt them to grant the USCM additional resources."
+	entry_message_body = "<a href='"+URL_WIKI_IO_GUIDE"'>Your job is to assist the marines in collecting intelligence related</a> to the current operation to better inform command of their opposition. You are in charge of gathering any data disks, folders, and notes you may find on the operational grounds and decrypt them to grant the USCM additional resources."
 
 /datum/job/command/intel/set_spawn_positions(var/count)
 	spawn_positions = int_slot_formula(count)

--- a/code/game/jobs/job/command/auxiliary/intel.dm
+++ b/code/game/jobs/job/command/auxiliary/intel.dm
@@ -7,7 +7,7 @@
 	scaled = 1
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT
 	gear_preset = "USCM Intelligence Officer (IO) (Cryo)"
-	entry_message_body = "<a href='"+URL_WIKI_IO_GUIDE"'>Your job is to assist the marines in collecting intelligence related</a> to the current operation to better inform command of their opposition. You are in charge of gathering any data disks, folders, and notes you may find on the operational grounds and decrypt them to grant the USCM additional resources."
+	entry_message_body = "<a href='"+URL_WIKI_IO_GUIDE+"'>Your job is to assist the marines in collecting intelligence related</a> to the current operation to better inform command of their opposition. You are in charge of gathering any data disks, folders, and notes you may find on the operational grounds and decrypt them to grant the USCM additional resources."
 
 /datum/job/command/intel/set_spawn_positions(var/count)
 	spawn_positions = int_slot_formula(count)

--- a/code/game/jobs/job/command/auxiliary/pilot.dm
+++ b/code/game/jobs/job/command/auxiliary/pilot.dm
@@ -6,7 +6,7 @@
 	scaled = TRUE
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT
 	gear_preset = /datum/equipment_preset/uscm_ship/po
-	entry_message_body = "Your job is to fly, protect, and maintain the ship's dropship. While you are an officer, your authority is limited to the dropship, where you have authority over the enlisted personnel. If you are not piloting, there is an autopilot fallback for command, but don't leave the dropship without reason."
+	entry_message_body = "<a href='"+URL_WIKI_PO_GUIDE+"'>Your job is to fly, protect, and maintain the ship's dropship.</a> While you are an officer, your authority is limited to the dropship, where you have authority over the enlisted personnel. If you are not piloting, there is an autopilot fallback for command, but don't leave the dropship without reason."
 
 AddTimelock(/datum/job/command/pilot, list(
 	JOB_SQUAD_ROLES = 5 HOURS

--- a/code/game/jobs/job/command/auxiliary/senior.dm
+++ b/code/game/jobs/job/command/auxiliary/senior.dm
@@ -3,7 +3,7 @@
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT|ROLE_ADMIN_NOTIFY|ROLE_WHITELISTED
 	flags_whitelist = WHITELIST_MENTOR
 	gear_preset = /datum/equipment_preset/uscm_ship/sea
-	entry_message_body = "You are held to a higher standard and are required to obey not only the Server Rules but <a href='"+URL_WIKI_LAW+"'>Marine Law</a> and <a href='"+URL_WIKI_SOP+"'>Standard Operating Procedure</a>. Failure to do so may result in your Mentorship Removal. Your primary job is to teach others the game and its mechanics, and offer advice to all USCM Departments and Personnel on-board."
+	entry_message_body = "<a href='"+URL_WIKI_SEA_GUIDE+"'>You are</a> held to a higher standard and are required to obey not only the Server Rules but <a href='"+URL_WIKI_LAW+"'>Marine Law</a> and <a href='"+URL_WIKI_SOP+"'>Standard Operating Procedure</a>. Failure to do so may result in your Mentorship Removal. Your primary job is to teach others the game and its mechanics, and offer advice to all USCM Departments and Personnel on-board."
 
 /datum/job/command/senior/announce_entry_message(mob/living/carbon/human/H)
 	addtimer(CALLBACK(GLOBAL_PROC, .proc/all_hands_on_deck, "Attention all hands, [H.get_paygrade(0)] [H.real_name] on deck!"), 1.5 SECONDS)

--- a/code/game/jobs/job/command/auxiliary/tankcrew.dm
+++ b/code/game/jobs/job/command/auxiliary/tankcrew.dm
@@ -6,7 +6,7 @@
 	scaled = 0
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT
 	gear_preset = /datum/equipment_preset/uscm/tank
-	entry_message_body = "Your job is to operate and maintain the ship's armored vehicles. You are in charge of representing the armored presence amongst the marines during the operation, as well as maintaining and repairing your own vehicles."
+	entry_message_body = "<a href='"+URL_WIKI_VC_GUIDE+"'>Your job is to operate and maintain the ship's armored vehicles.</a> You are in charge of representing the armored presence amongst the marines during the operation, as well as maintaining and repairing your own vehicles."
 
 AddTimelock(/datum/job/command/tank_crew, list(
 	JOB_SQUAD_ROLES = 10 HOURS,

--- a/code/game/jobs/job/command/cic/captain.dm
+++ b/code/game/jobs/job/command/cic/captain.dm
@@ -6,7 +6,7 @@
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT|ROLE_ADMIN_NOTIFY|ROLE_WHITELISTED
 	flags_whitelist = WHITELIST_COMMANDER
 	gear_preset = /datum/equipment_preset/uscm_ship/commander
-	entry_message_body = "You are the Commanding Officer of the USS Almayer as well as the operation. Your goal is to lead the Marines on their mission as well as protect and command the ship and her crew. Your job involves heavy roleplay and requires you to behave like a high-ranking officer and to stay in character at all times. As the Commanding Officer your only superior is High Command itself. You must abide by the <a href='"+URL_WIKI_CO_RULES+"'>Captain's Code of Conduct</a>. Failure to do so may result in punitive action against you. Godspeed."
+	entry_message_body = "<a href='"+URL_WIKI_CO_GUIDE+"'>You are the Commanding Officer of the USS Almayer as well as the operation.</a> Your goal is to lead the Marines on their mission as well as protect and command the ship and her crew. Your job involves heavy roleplay and requires you to behave like a high-ranking officer and to stay in character at all times. As the Commanding Officer your only superior is High Command itself. You must abide by the <a href='"+URL_WIKI_CO_RULES+"'>Captain's Code of Conduct</a>. Failure to do so may result in punitive action against you. Godspeed."
 
 /datum/job/command/commander/New()
 	. = ..()

--- a/code/game/jobs/job/command/cic/executive.dm
+++ b/code/game/jobs/job/command/cic/executive.dm
@@ -3,7 +3,7 @@
 	title = JOB_XO
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT|ROLE_ADMIN_NOTIFY
 	gear_preset = /datum/equipment_preset/uscm_ship/xo
-	entry_message_body = "You are second in command aboard the ship, and are in next in the chain of command after the commanding officer. You may need to fill in for other duties if areas are understaffed, and you are given access to do so. Make the USCM proud!"
+	entry_message_body = "<a href='"+URL_WIKI_XO_GUIDE"'>You are second in command aboard the ship,</a> and are in next in the chain of command after the commanding officer. You may need to fill in for other duties if areas are understaffed, and you are given access to do so. Make the USCM proud!"
 
 /datum/job/command/executive/generate_entry_message(mob/living/carbon/human/H)
 	return ..()

--- a/code/game/jobs/job/command/cic/executive.dm
+++ b/code/game/jobs/job/command/cic/executive.dm
@@ -3,7 +3,7 @@
 	title = JOB_XO
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT|ROLE_ADMIN_NOTIFY
 	gear_preset = /datum/equipment_preset/uscm_ship/xo
-	entry_message_body = "<a href='"+URL_WIKI_XO_GUIDE"'>You are second in command aboard the ship,</a> and are in next in the chain of command after the commanding officer. You may need to fill in for other duties if areas are understaffed, and you are given access to do so. Make the USCM proud!"
+	entry_message_body = "<a href='"+URL_WIKI_XO_GUIDE+"'>You are second in command aboard the ship,</a> and are in next in the chain of command after the commanding officer. You may need to fill in for other duties if areas are understaffed, and you are given access to do so. Make the USCM proud!"
 
 /datum/job/command/executive/generate_entry_message(mob/living/carbon/human/H)
 	return ..()

--- a/code/game/jobs/job/command/cic/staffofficer.dm
+++ b/code/game/jobs/job/command/cic/staffofficer.dm
@@ -6,7 +6,7 @@
 	scaled = FALSE
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT
 	gear_preset = /datum/equipment_preset/uscm_ship/so
-	entry_message_body = "man the CIC, and listen to your superior officers. You are in charge of logistics and the overwatch system. You are also in line to take command after other eligible superior commissioned officers."
+	entry_message_body = "<a href='"+URL_WIKI_SO_GUIDE+"'>Your job is to monitor the Marines, man the CIC, and listen to your superior officers.</a> You are in charge of logistics and the overwatch system. You are also in line to take command after other eligible superior commissioned officers."
 
 /datum/job/command/bridge/set_spawn_positions(var/count)
 	spawn_positions = so_slot_formula(count)

--- a/code/game/jobs/job/command/cic/staffofficer.dm
+++ b/code/game/jobs/job/command/cic/staffofficer.dm
@@ -6,7 +6,7 @@
 	scaled = FALSE
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT
 	gear_preset = /datum/equipment_preset/uscm_ship/so
-	entry_message_body = "Your job is to monitor the Marines, man the CIC, and listen to your superior officers. You are in charge of logistics and the overwatch system. You are also in line to take command after other eligible superior commissioned officers."
+	entry_message_body = "man the CIC, and listen to your superior officers. You are in charge of logistics and the overwatch system. You are also in line to take command after other eligible superior commissioned officers."
 
 /datum/job/command/bridge/set_spawn_positions(var/count)
 	spawn_positions = so_slot_formula(count)

--- a/code/game/jobs/job/command/police/cadet_police.dm
+++ b/code/game/jobs/job/command/police/cadet_police.dm
@@ -7,7 +7,7 @@
 	selection_class = "job_mp"
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT
 	gear_preset = /datum/equipment_preset/uscm_ship/uscm_police/mp_cadet
-	entry_message_body = "You are held by a higher standard and are required to obey not only the server rules but the <a href='"+URL_WIKI_LAW+"'>Marine Law</a>. Failure to do so may result in a job ban or server ban. Your primary job is to maintain peace and stability aboard the ship. Marines can get rowdy after a few weeks of cryosleep!"
+	entry_message_body = "<a href='"+URL_WIKI_MPC_GUIDE+"'>You</a> are held by a higher standard and are required to obey not only the server rules but the <a href='"+URL_WIKI_LAW+"'>Marine Law</a>. Failure to do so may result in a job ban or server ban. Your primary job is to maintain peace and stability aboard the ship. Marines can get rowdy after a few weeks of cryosleep!"
 
 
 

--- a/code/game/jobs/job/command/police/chief_police.dm
+++ b/code/game/jobs/job/command/police/chief_police.dm
@@ -4,7 +4,7 @@
 	selection_class = "job_cmp"
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT
 	gear_preset = /datum/equipment_preset/uscm_ship/uscm_police/cmp
-	entry_message_body = "You are held by a higher standard and are required to obey not only the server rules but the <a href='"+URL_WIKI_LAW+"'>Marine Law</a>. Failure to do so may result in a job ban or server ban. You lead the Military Police, ensure your officers maintain peace and stability aboard the ship. Marines can get rowdy after a few weeks of cryosleep! In addition, you are tasked with the security of high-ranking personnel, including the command staff. Keep them safe!"
+	entry_message_body = "<a href='"+URL_WIKI_CMP_GUIDE+"'>You</a> are held by a higher standard and are required to obey not only the server rules but the <a href='"+URL_WIKI_LAW+"'>Marine Law</a>. Failure to do so may result in a job ban or server ban. You lead the Military Police, ensure your officers maintain peace and stability aboard the ship. Marines can get rowdy after a few weeks of cryosleep! In addition, you are tasked with the security of high-ranking personnel, including the command staff. Keep them safe!"
 
 AddTimelock(/datum/job/command/warrant, list(
 	JOB_POLICE_ROLES = 15 HOURS,

--- a/code/game/jobs/job/command/police/police.dm
+++ b/code/game/jobs/job/command/police/police.dm
@@ -8,7 +8,7 @@
 	selection_class = "job_mp"
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT
 	gear_preset = /datum/equipment_preset/uscm_ship/uscm_police/mp
-	entry_message_body = "You are held by a higher standard and are required to obey not only the server rules but the <a href='"+URL_WIKI_LAW+"'>Marine Law</a>. Failure to do so may result in a job ban or server ban. Your primary job is to maintain peace and stability aboard the ship. Marines can get rowdy after a few weeks of cryosleep! In addition, you are tasked with the security of high-ranking personnel, including the command staff. Keep them safe!"
+	entry_message_body = "<a href='"+URL_WIKI_MP_GUIDE+"'>You</a> are held by a higher standard and are required to obey not only the server rules but the <a href='"+URL_WIKI_LAW+"'>Marine Law</a>. Failure to do so may result in a job ban or server ban. Your primary job is to maintain peace and stability aboard the ship. Marines can get rowdy after a few weeks of cryosleep! In addition, you are tasked with the security of high-ranking personnel, including the command staff. Keep them safe!"
 
 /datum/job/command/police/set_spawn_positions(var/count)
 	spawn_positions = mp_slot_formula(count)

--- a/code/game/jobs/job/command/police/warden.dm
+++ b/code/game/jobs/job/command/police/warden.dm
@@ -4,7 +4,7 @@
 	selection_class = "job_mp"
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT
 	gear_preset = /datum/equipment_preset/uscm_ship/uscm_police/warden
-	entry_message_body = "You are held by a higher standard and are required to obey not only the server rules but the <a href='"+URL_WIKI_LAW+"'>Marine Law</a>. Failure to do so may result in a job ban or server ban. Your primary job is to maintain peace and stability aboard the ship. Marines can get rowdy after a few weeks of cryosleep! In addition, you are tasked with the mainting security records and overwatching any prisoners in Brig."
+	entry_message_body = "<a href='"+URL_WIKI_MW_GUIDE+"'>You</a> are held by a higher standard and are required to obey not only the server rules but the <a href='"+URL_WIKI_LAW+"'>Marine Law</a>. Failure to do so may result in a job ban or server ban. Your primary job is to maintain peace and stability aboard the ship. Marines can get rowdy after a few weeks of cryosleep! In addition, you are tasked with the mainting security records and overwatching any prisoners in Brig."
 
 AddTimelock(/datum/job/command/warden, list(
 	JOB_POLICE_ROLES = 10 HOURS

--- a/code/game/jobs/job/logistics/cargo/cargo_tech.dm
+++ b/code/game/jobs/job/logistics/cargo/cargo_tech.dm
@@ -8,7 +8,7 @@
 	selection_class = "job_ct"
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT
 	gear_preset = /datum/equipment_preset/uscm_ship/cargo
-	entry_message_body = "Your job is to dispense supplies to the marines, including weapon attachments. Stay in your department when possible to ensure the marines have full access to the supplies they may require. Listen to the radio in case someone requests a supply drop via the overwatch system."
+	entry_message_body = "<a href='"+URL_WIKI_CT_GUIDE+"'>Your job</a> is to dispense supplies to the marines, including weapon attachments. Stay in your department when possible to ensure the marines have full access to the supplies they may require. Listen to the radio in case someone requests a supply drop via the overwatch system."
 
 /datum/job/logistics/cargo/set_spawn_positions(var/count)
 	spawn_positions = ct_slot_formula(count)

--- a/code/game/jobs/job/logistics/cargo/chief_req.dm
+++ b/code/game/jobs/job/logistics/cargo/chief_req.dm
@@ -4,7 +4,7 @@
 	selection_class = "job_ro"
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT
 	gear_preset = /datum/equipment_preset/uscm_ship/ro
-	entry_message_body = "Your job is to dispense supplies to the marines, including weapon attachments. Your cargo techs can help you out, but you have final say in your department. Make sure they're not goofing off. While you may request paperwork for supplies, do not go out of your way to screw with marines, unless you want to get deposed. A happy ship is a well-functioning ship."
+	entry_message_body = "<a href='"+URL_WIKI_RO_GUIDE+"'>Your job</a> is to dispense supplies to the marines, including weapon attachments. Your cargo techs can help you out, but you have final say in your department. Make sure they're not goofing off. While you may request paperwork for supplies, do not go out of your way to screw with marines, unless you want to get deposed. A happy ship is a well-functioning ship."
 
 AddTimelock(/datum/job/logistics/requisition, list(
 	JOB_REQUISITION_ROLES = 10 HOURS,

--- a/code/game/jobs/job/logistics/engi/chief_engineer.dm
+++ b/code/game/jobs/job/logistics/engi/chief_engineer.dm
@@ -3,7 +3,7 @@
 	selection_class = "job_ce"
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT
 	gear_preset = /datum/equipment_preset/uscm_ship/chief_engineer
-	entry_message_body = "Your job is to maintain your department and keep your technicians in check. You are responsible for engineering, power, ordnance, and the orbital cannon. Should the commanding and executive officer be unavailable, you are next in the chain of command."
+	entry_message_body = "<a href='"+URL_WIKI_CE_GUIDE+"'>Your job</a> is to maintain your department and keep your technicians in check. You are responsible for engineering, power, ordnance, and the orbital cannon. Should the commanding and executive officer be unavailable, you are next in the chain of command."
 
 AddTimelock(/datum/job/logistics/engineering, list(
 	JOB_ENGINEER_ROLES = 10 HOURS,

--- a/code/game/jobs/job/logistics/engi/maint_tech.dm
+++ b/code/game/jobs/job/logistics/engi/maint_tech.dm
@@ -6,7 +6,7 @@
 	selection_class = "job_ot"
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT
 	gear_preset = /datum/equipment_preset/uscm_ship/maint
-	entry_message_body = "Your job is to maintain the integrity of the ship, including the orbital cannon. You remain one of the more flexible roles on the ship and as such may receive other menial tasks from your superiors."
+	entry_message_body = "<a href='"+URL_WIKI_MT_GUIDE+"'>Your job is to maintain the integrity of the ship, including the orbital cannon.</a> You remain one of the more flexible roles on the ship and as such may receive other menial tasks from your superiors."
 
 /obj/effect/landmark/start/maint
 	name = JOB_MAINT_TECH

--- a/code/game/jobs/job/logistics/engi/ordnance_tech.dm
+++ b/code/game/jobs/job/logistics/engi/ordnance_tech.dm
@@ -9,7 +9,7 @@
 	selection_class = "job_ot"
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT
 	gear_preset = /datum/equipment_preset/uscm_ship/ordn
-	entry_message_body = "Your job is to maintain the integrity of the USCM weapons, munitions and equipment, including the orbital cannon. You can use the workshop in the portside hangar to construct new armaments for the marines. However you remain one of the more flexible roles on the ship and as such may receive other menial tasks from your superiors."
+	entry_message_body = "<a href='"+URL_WIKI_OT_GUIDE+"'>Your job</a> is to maintain the integrity of the USCM weapons, munitions and equipment, including the orbital cannon. You can use the workshop in the portside hangar to construct new armaments for the marines. However you remain one of the more flexible roles on the ship and as such may receive other menial tasks from your superiors."
 
 /datum/job/logistics/tech/set_spawn_positions(var/count)
 	spawn_positions = ot_slot_formula(count)

--- a/code/game/jobs/job/marine/squad/engineer.dm
+++ b/code/game/jobs/job/marine/squad/engineer.dm
@@ -5,7 +5,7 @@
 	allow_additional = 1
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT|ROLE_ADD_TO_SQUAD
 	gear_preset = /datum/equipment_preset/uscm/engineer
-	entry_message_body = "You have the equipment and skill to build fortifications, reroute power lines, and bunker down. Your squaddies will look to you when it comes to construction in the field of battle."
+	entry_message_body = "You have the <a href='"+URL_WIKI_COMTECH_GUIDE+"'>equipment and skill</a> to build fortifications, reroute power lines, and bunker down. Your squaddies will look to you when it comes to construction in the field of battle."
 
 /datum/job/marine/engineer/set_spawn_positions(var/count)
 	for(var/datum/squad/sq in RoleAuthority.squads)

--- a/code/game/jobs/job/marine/squad/leader.dm
+++ b/code/game/jobs/job/marine/squad/leader.dm
@@ -5,7 +5,7 @@
 	supervisors = "the acting commanding officer"
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT|ROLE_ADD_TO_SQUAD
 	gear_preset = /datum/equipment_preset/uscm/leader
-	entry_message_body = "You are responsible for the men and women of your squad. Make sure they are on task, working together, and communicating. You are also in charge of communicating with command and letting them know about the situation first hand. Keep out of harm's way."
+	entry_message_body = "<a href='"+URL_WIKI_SL_GUIDE+"'>You are responsible for the men and women of your squad.</a> Make sure they are on task, working together, and communicating. You are also in charge of communicating with command and letting them know about the situation first hand. Keep out of harm's way."
 
 /datum/job/marine/leader/whiskey
 	title = JOB_WO_SQUAD_LEADER

--- a/code/game/jobs/job/marine/squad/medic.dm
+++ b/code/game/jobs/job/marine/squad/medic.dm
@@ -5,7 +5,7 @@
 	allow_additional = 1
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT|ROLE_ADD_TO_SQUAD
 	gear_preset = /datum/equipment_preset/uscm/medic
-	entry_message_body = "You must tend the wounds of your squad mates and make sure they are healthy and active. You may not be a fully-fledged doctor, but you stand between life and death when it matters."
+	entry_message_body = "<a href='"+URL_WIKI_MEDIC_GUIDE+"'>You tend the wounds of your squad mates</a> and make sure they are healthy and active. You may not be a fully-fledged doctor, but you stand between life and death when it matters."
 
 /datum/job/marine/medic/set_spawn_positions(var/count)
 	for(var/datum/squad/sq in RoleAuthority.squads)

--- a/code/game/jobs/job/marine/squad/rto.dm
+++ b/code/game/jobs/job/marine/squad/rto.dm
@@ -5,7 +5,7 @@
 	allow_additional = 1
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT|ROLE_ADD_TO_SQUAD
 	gear_preset = /datum/equipment_preset/uscm/rto
-	entry_message_body = "You are the Radio Telegraph Operator. Your task is to work as a forward observer for overwatch, dropship pilots and mortar operators to provide fire support, and facilitate communications between groundside marines and shipside departments such as CIC and Requisitions."
+	entry_message_body = "You are the <a href='"+Radio Telegraph Operator. Your task is to work as a forward observer for overwatch, dropship pilots and mortar operators to provide fire support, and facilitate communications between groundside marines and shipside departments such as CIC and Requisitions."
 
 /datum/job/marine/rto/generate_entry_conditions(mob/living/carbon/human/H)
 	. = ..()

--- a/code/game/jobs/job/marine/squad/rto.dm
+++ b/code/game/jobs/job/marine/squad/rto.dm
@@ -5,7 +5,7 @@
 	allow_additional = 1
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT|ROLE_ADD_TO_SQUAD
 	gear_preset = /datum/equipment_preset/uscm/rto
-	entry_message_body = "You are the <a href='"+Radio Telegraph Operator. Your task is to work as a forward observer for overwatch, dropship pilots and mortar operators to provide fire support, and facilitate communications between groundside marines and shipside departments such as CIC and Requisitions."
+	entry_message_body = "You are the <a href='"+URL_WIKI_RTO_GUIDE+"'>Radio Telegraph Operator.</a>Your task is to work as a forward observer for overwatch, dropship pilots and mortar operators to provide fire support, and facilitate communications between groundside marines and shipside departments such as CIC and Requisitions."
 
 /datum/job/marine/rto/generate_entry_conditions(mob/living/carbon/human/H)
 	. = ..()

--- a/code/game/jobs/job/marine/squad/smartgunner.dm
+++ b/code/game/jobs/job/marine/squad/smartgunner.dm
@@ -6,7 +6,7 @@
 	scaled = 1
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT|ROLE_ADD_TO_SQUAD
 	gear_preset = /datum/equipment_preset/uscm/sg
-	entry_message_body = "You are the smartgunner. Your task is to provide heavy weapons support."
+	entry_message_body = "<a href='"+URL_WIKI_SG_GUIDE"'>You are the smartgunner.</a> Your task is to provide heavy weapons support."
 
 /datum/job/marine/smartgunner/set_spawn_positions(var/count)
 	spawn_positions = sg_slot_formula(count)

--- a/code/game/jobs/job/marine/squad/smartgunner.dm
+++ b/code/game/jobs/job/marine/squad/smartgunner.dm
@@ -6,7 +6,7 @@
 	scaled = 1
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT|ROLE_ADD_TO_SQUAD
 	gear_preset = /datum/equipment_preset/uscm/sg
-	entry_message_body = "<a href='"+URL_WIKI_SG_GUIDE"'>You are the smartgunner.</a> Your task is to provide heavy weapons support."
+	entry_message_body = "<a href='"+URL_WIKI_SG_GUIDE+"'>You are the smartgunner.</a> Your task is to provide heavy weapons support."
 
 /datum/job/marine/smartgunner/set_spawn_positions(var/count)
 	spawn_positions = sg_slot_formula(count)

--- a/code/game/jobs/job/marine/squad/specialist.dm
+++ b/code/game/jobs/job/marine/squad/specialist.dm
@@ -6,7 +6,7 @@
 	scaled = 1
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT|ROLE_ADD_TO_SQUAD
 	gear_preset = /datum/equipment_preset/uscm/spec
-	entry_message_body = "You are the very rare and valuable weapon expert, trained to use special equipment. You can serve a variety of roles, so choose carefully."
+	entry_message_body = "<a href='"+URL_WIKI_SPEC_GUIDE_+"'>You are the very rare and valuable weapon expert</a>, trained to use special equipment. You can serve a variety of roles, so choose carefully."
 
 /datum/job/marine/specialist/set_spawn_positions(var/count)
 	spawn_positions = spec_slot_formula(count)

--- a/code/game/jobs/job/marine/squad/specialist.dm
+++ b/code/game/jobs/job/marine/squad/specialist.dm
@@ -6,7 +6,7 @@
 	scaled = 1
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT|ROLE_ADD_TO_SQUAD
 	gear_preset = /datum/equipment_preset/uscm/spec
-	entry_message_body = "<a href='"+URL_WIKI_SPEC_GUIDE_+"'>You are the very rare and valuable weapon expert</a>, trained to use special equipment. You can serve a variety of roles, so choose carefully."
+	entry_message_body = "<a href='"+URL_WIKI_SPEC_GUIDE+"'>You are the very rare and valuable weapon expert</a>, trained to use special equipment. You can serve a variety of roles, so choose carefully."
 
 /datum/job/marine/specialist/set_spawn_positions(var/count)
 	spawn_positions = spec_slot_formula(count)

--- a/code/game/jobs/job/marine/squad/standard.dm
+++ b/code/game/jobs/job/marine/squad/standard.dm
@@ -6,7 +6,7 @@
 	spawn_positions = -1
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT|ROLE_ADD_TO_SQUAD
 	gear_preset = /datum/equipment_preset/uscm/pfc
-	entry_message_body = "You are a rank-and-file Marine of the USCM, and that is your strength. What you lack alone, you gain standing shoulder to shoulder with the men and women of the corps. Ooh-rah!"
+	entry_message_body = "You are a rank-and-file <a href='"+URL_WIKI_MARINE_QUICKSTART+"'>Marine of the USCM</a>, and that is your strength. What you lack alone, you gain standing shoulder to shoulder with the men and women of the corps. Ooh-rah!"
 
 /datum/job/marine/standard/set_spawn_positions(var/count)
 	spawn_positions = max((round(count * STANDARD_MARINE_TO_TOTAL_SPAWN_RATIO)), 8)

--- a/code/modules/mob/living/carbon/xenomorph/castes/Larva.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Larva.dm
@@ -8,6 +8,7 @@
 	melee_vehicle_damage = 0
 	max_health = XENO_HEALTH_LARVA
 	caste_desc = "D'awwwww, so cute!"
+	entry_message_body "<a href='"+URL_WIKI_XENO_QUICKSTART+">You are a larva!</a> You can grow into a stronger Xenomorph of your choice! Remain in the hive until you've grown into a Tier One Caste, and follow the orders of your Queen! For the hive!"
 	speed = XENO_SPEED_TIER_10
 	innate_healing = TRUE //heals even outside weeds so you're not stuck unable to evolve when hiding on the ship wounded.
 	evolves_to = XENO_T1_CASTES

--- a/code/modules/mob/living/carbon/xenomorph/castes/Larva.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Larva.dm
@@ -8,7 +8,6 @@
 	melee_vehicle_damage = 0
 	max_health = XENO_HEALTH_LARVA
 	caste_desc = "D'awwwww, so cute!"
-	entry_message_body = "<a href='"+URL_WIKI_XENO_QUICKSTART+">You are a larva!</a> You can grow into a stronger Xenomorph of your choice! Remain in the hive until you've grown into a Tier One Caste, and follow the orders of your Queen! For the hive!"
 	speed = XENO_SPEED_TIER_10
 	innate_healing = TRUE //heals even outside weeds so you're not stuck unable to evolve when hiding on the ship wounded.
 	evolves_to = XENO_T1_CASTES

--- a/code/modules/mob/living/carbon/xenomorph/castes/Larva.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Larva.dm
@@ -8,7 +8,7 @@
 	melee_vehicle_damage = 0
 	max_health = XENO_HEALTH_LARVA
 	caste_desc = "D'awwwww, so cute!"
-	entry_message_body "<a href='"+URL_WIKI_XENO_QUICKSTART+">You are a larva!</a> You can grow into a stronger Xenomorph of your choice! Remain in the hive until you've grown into a Tier One Caste, and follow the orders of your Queen! For the hive!"
+	entry_message_body = "<a href='"+URL_WIKI_XENO_QUICKSTART+">You are a larva!</a> You can grow into a stronger Xenomorph of your choice! Remain in the hive until you've grown into a Tier One Caste, and follow the orders of your Queen! For the hive!"
 	speed = XENO_SPEED_TIER_10
 	innate_healing = TRUE //heals even outside weeds so you're not stuck unable to evolve when hiding on the ship wounded.
 	evolves_to = XENO_T1_CASTES

--- a/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
@@ -238,6 +238,7 @@
 	caste_type = XENO_CASTE_QUEEN
 	name = XENO_CASTE_QUEEN
 	desc = "A huge, looming alien creature. The biggest and the baddest."
+	spit_types = list(/datum/ammo/xeno/toxin/queen, /datum/ammo/xeno/acid/medium)
 	icon_size = 64
 	icon_state = "Queen Walking"
 	plasma_types = list(PLASMA_ROYAL,PLASMA_CHITIN,PLASMA_PHEROMONE,PLASMA_NEUROTOXIN)

--- a/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
@@ -23,7 +23,8 @@
 	is_intelligent = 1
 	evolution_allowed = FALSE
 	fire_immunity = FIRE_IMMUNITY_NO_DAMAGE|FIRE_IMMUNITY_NO_IGNITE
-	caste_desc = "The biggest and baddest xeno. The Queen controls the hive and plants eggs. Lead your hive"
+	caste_desc = "The biggest and baddest xeno. The Queen controls the hive and plants eggs"
+	spit_types = list(/datum/ammo/xeno/toxin/queen, /datum/ammo/xeno/acid/medium)
 	can_hold_facehuggers = 0
 	can_hold_eggs = CAN_HOLD_ONE_HAND
 	acid_level = 2
@@ -238,7 +239,6 @@
 	caste_type = XENO_CASTE_QUEEN
 	name = XENO_CASTE_QUEEN
 	desc = "A huge, looming alien creature. The biggest and the baddest."
-	spit_types = list(/datum/ammo/xeno/toxin/queen, /datum/ammo/xeno/acid/medium)
 	icon_size = 64
 	icon_state = "Queen Walking"
 	plasma_types = list(PLASMA_ROYAL,PLASMA_CHITIN,PLASMA_PHEROMONE,PLASMA_NEUROTOXIN)

--- a/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
@@ -23,7 +23,8 @@
 	is_intelligent = 1
 	evolution_allowed = FALSE
 	fire_immunity = FIRE_IMMUNITY_NO_DAMAGE|FIRE_IMMUNITY_NO_IGNITE
-	caste_desc = "The biggest and baddest xeno. The Queen controls the hive and plants eggs"
+	caste_desc = "The biggest and baddest xeno. The Queen controls the hive and plants eggs. Lead your hive"
+	entry_message_body = "<a href='"+URL_QUEEN_GUIDE+"'>Lead your Hive to victory over the Marines.</a> Use your powerful pheromones and your command abilities to organise the Hive. Lay eggs to create facehuggers and accumulate more Larvae. Use your screech to defend yourself and signal pushes. Use your acid to melt into places."
 	spit_types = list(/datum/ammo/xeno/toxin/queen, /datum/ammo/xeno/acid/medium)
 	can_hold_facehuggers = 0
 	can_hold_eggs = CAN_HOLD_ONE_HAND

--- a/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
@@ -24,8 +24,6 @@
 	evolution_allowed = FALSE
 	fire_immunity = FIRE_IMMUNITY_NO_DAMAGE|FIRE_IMMUNITY_NO_IGNITE
 	caste_desc = "The biggest and baddest xeno. The Queen controls the hive and plants eggs. Lead your hive"
-	entry_message_body = "<a href='"+URL_QUEEN_GUIDE+"'>Lead your Hive to victory over the Marines.</a> Use your powerful pheromones and your command abilities to organise the Hive. Lay eggs to create facehuggers and accumulate more Larvae. Use your screech to defend yourself and signal pushes. Use your acid to melt into places."
-	spit_types = list(/datum/ammo/xeno/toxin/queen, /datum/ammo/xeno/acid/medium)
 	can_hold_facehuggers = 0
 	can_hold_eggs = CAN_HOLD_ONE_HAND
 	acid_level = 2

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -6,7 +6,6 @@
 	var/tier = 0
 	var/dead_icon = "Drone Dead"
 	var/language = LANGUAGE_XENOMORPH
-	var/entry_message_intro
 	var/melee_damage_lower = 10
 	var/melee_damage_upper = 20
 	var/melee_vehicle_damage = 10	//allows fine tuning melee damage to vehicles per caste.

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -6,7 +6,7 @@
 	var/tier = 0
 	var/dead_icon = "Drone Dead"
 	var/language = LANGUAGE_XENOMORPH
-
+	var/entry_message_intro
 	var/melee_damage_lower = 10
 	var/melee_damage_upper = 20
 	var/melee_vehicle_damage = 10	//allows fine tuning melee damage to vehicles per caste.


### PR DESCRIPTION
## About The Pull Request

This PR adds new defines for every marine role I could find on the wiki that leads to them -- Expanding from this, every entry text for every marine role has had a wiki link to its respective page added. 
## Why It's Good For The Game

Our wiki maintainer and contributors work hard. This should make it far easier for the average player to get to see their work and make a more enjoyable experience overall.

## Changelog

:cl: Mistfrag
qol: Linked respective wiki page to all Marine roles.
code: Added defines for every wiki page on marines.
/:cl:


