### PR TITLE
Changes evilution to evolution in hive status.

### DIFF
--- a/code/controllers/subsystem/x_evolution.dm
+++ b/code/controllers/subsystem/x_evolution.dm
@@ -3,7 +3,7 @@
 #define EVOLUTION_INCREMENT_TIME (30 MINUTES) // Evolution increases by 1 every 25 minutes.
 
 SUBSYSTEM_DEF(xevolution)
-	name = "Evilution"
+	name = "Evolution"
 	wait = 1 MINUTES
 	priority = SS_PRIORITY_INACTIVITY
 
@@ -49,7 +49,7 @@ SUBSYSTEM_DEF(xevolution)
 		if(!force_boost_power)
 			boost_power[HS.hivenumber] = boost_power_new
 
-		//Update displayed Evilution, which is under larva apparently
+		//Update displayed Evolution, which is under larva apparently
 		HS.hive_ui.update_pooled_larva()
 
 /datum/controller/subsystem/xevolution/proc/get_evolution_boost_power(var/hivenumber)

--- a/code/modules/mob/living/carbon/xenomorph/hive_status.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_status.dm
@@ -10,7 +10,7 @@
 	var/list/xeno_info
 	var/hive_location
 	var/pooled_larva
-	var/evilution_level
+	var/evolution_level
 
 	var/data_initialized = FALSE
 
@@ -92,9 +92,9 @@
 /datum/hive_status_ui/proc/update_pooled_larva(send_update = TRUE)
 	pooled_larva = assoc_hive.stored_larva
 	if(SSxevolution)
-		evilution_level = SSxevolution.get_evolution_boost_power(assoc_hive.hivenumber)
+		evolution_level = SSxevolution.get_evolution_boost_power(assoc_hive.hivenumber)
 	else
-		evilution_level = 1
+		evolution_level = 1
 
 	if(send_update)
 		SStgui.update_uis(src)
@@ -135,7 +135,7 @@
 	.["queen_location"] = get_area_name(assoc_hive.living_xeno_queen)
 	.["hive_location"] = hive_location
 	.["pooled_larva"] = pooled_larva
-	.["evilution_level"] = evilution_level
+	.["evolution_level"] = evolution_level
 
 	var/mob/living/carbon/Xenomorph/Queen/Q = user
 	.["is_in_ovi"] = istype(Q) && Q.ovipositor

--- a/tgui/packages/tgui/interfaces/HiveStatus.js
+++ b/tgui/packages/tgui/interfaces/HiveStatus.js
@@ -121,7 +121,7 @@ const GeneralInformation = (props, context) => {
     hive_location,
     total_xenos,
     pooled_larva,
-    evilution_level,
+    evolution_level,
   } = data;
 
   return (
@@ -143,7 +143,7 @@ const GeneralInformation = (props, context) => {
         <i>Pooled larvae: {pooled_larva}</i>
       </Flex.Item>
       <Flex.Item>
-        <i>Evilution: {evilution_level}</i>
+        <i>Evolution: {evolution_level}</i>
       </Flex.Item>
     </Flex>
   );


### PR DESCRIPTION
## About The Pull Request

Title, evilution isn't even a word. This pr changes it to evolution

## Why It's Good For The Game

Consistency, and grammar. It should be an actual word and not just "evilution"

## Changelog

:cl:
spellcheck: Evilution is now shown as Evolution in hive status.
/:cl:
