### PR TITLE
Fix for ordering ammo.

### DIFF
--- a/code/datums/ASRS.dm
+++ b/code/datums/ASRS.dm
@@ -11,119 +11,115 @@
 #define ASRS_VERY_LOW_WEIGHT	50
 #define ASRS_LOWEST_WEIGHT		100
 
-/datum/supply_packs/asrs
-	cost = ASRS_LOWEST_WEIGHT
-	buyable = 0
-
 /datum/supply_packs/gun/ammo_hpr/asrs
 	buyable = 0
-	group = "Munition"
+	group = "ASRS"
 	cost = ASRS_LOWEST_WEIGHT
 
 /datum/supply_packs/ammo_rounds_box_smg/asrs
 	buyable = 0
-	group = "Munition"
+	group = "ASRS"
 	cost = ASRS_MEDIUM_WEIGHT
 
 /datum/supply_packs/ammo_rounds_box_smg_ap/asrs
 	buyable = 0
-	group = "Munition"
+	group = "ASRS"
 	cost = ASRS_LOW_WEIGHT
 
 /datum/supply_packs/ammo_rounds_box_rifle/asrs
 	buyable = 0
-	group = "Munition"
+	group = "ASRS"
 	cost = ASRS_MEDIUM_WEIGHT
 
 /datum/supply_packs/ammo_rounds_box_rifle_ap/asrs
 	buyable = 0
-	group = "Munition"
+	group = "ASRS"
 	cost = ASRS_LOW_WEIGHT
 
 /datum/supply_packs/ammo_rounds_box_xm88/asrs
 	buyable = 0
-	group = "Munition"
+	group = "ASRS"
 	cost = ASRS_LOW_WEIGHT
 
 /datum/supply_packs/ammo_m4a3_mag_box/asrs
 	buyable = 0
-	group = "Munition"
+	group = "ASRS"
 	cost = ASRS_LOW_WEIGHT
 
 /datum/supply_packs/ammo_m4a3_mag_box_ap/asrs
 	buyable = 0
-	group = "Munition"
+	group = "ASRS"
 	cost = ASRS_VERY_LOW_WEIGHT
 
 /datum/supply_packs/ammo_smg_mag_box/asrs
 	buyable = 0
-	group = "Munition"
+	group = "ASRS"
 	cost = ASRS_VERY_LOW_WEIGHT
 
 /datum/supply_packs/ammo_smg_mag_box_ap/asrs
 	buyable = 0
-	group = "Munition"
+	group = "ASRS"
 
 /datum/supply_packs/ammo_mag_box/asrs
 	buyable = 0
-	group = "Munition"
+	group = "ASRS"
 	cost = ASRS_VERY_LOW_WEIGHT
 
 /datum/supply_packs/ammo_mag_box_ap/asrs
 	buyable = 0
-	group = "Munition"
+	group = "ASRS"
 
 /datum/supply_packs/ammo_l42_mag_box/asrs
 	buyable = 0
-	group = "Munition"
+	group = "ASRS"
 	cost = ASRS_VERY_LOW_WEIGHT
 
 /datum/supply_packs/ammo_l42_mag_box_ap/asrs
 	buyable = 0
-	group = "Munition"
+	group = "ASRS"
 
 /datum/supply_packs/ammo_shell_box/asrs
 	buyable = 0
-	group = "Munition"
+	group = "ASRS"
 	cost = ASRS_VERY_LOW_WEIGHT
 
 /datum/supply_packs/ammo_shell_box_buck/asrs
 	buyable = 0
-	group = "Munition"
+	group = "ASRS"
 	cost = ASRS_VERY_LOW_WEIGHT
 
 /datum/supply_packs/ammo_shell_box_flechette/asrs
 	buyable = 0
-	group = "Munition"
+	group = "ASRS"
 	cost = ASRS_VERY_LOW_WEIGHT
 
 /datum/supply_packs/ammo_smartgun/asrs
 	buyable = 0
-	group = "Munition"
+	group = "ASRS"
 
 /datum/supply_packs/ammo_sentry/asrs
 	buyable = 0
-	group = "Munition"
+	group = "ASRS"
 	cost = ASRS_VERY_LOW_WEIGHT
 
 /datum/supply_packs/ammo_sentry_flamer/asrs
 	buyable = 0
-	group = "Munition"
+	group = "ASRS"
 	cost = ASRS_VERY_LOW_WEIGHT
 
 /datum/supply_packs/ammo_napalm/asrs
 	buyable = 0
-	group = "Munition"
+	group = "ASRS"
 	cost = ASRS_VERY_LOW_WEIGHT
 
 /datum/supply_packs/ammo_napalm_gel/asrs
 	buyable = 0
-	group = "Munition"
+	group = "ASRS"
 	cost = ASRS_VERY_LOW_WEIGHT
 
 /datum/supply_packs/ammo_flamer_mixed/asrs
 	buyable = 0
-	group = "Munition"
+	group = "ASRS"
 	cost = ASRS_VERY_LOW_WEIGHT
 
 
@@ -131,24 +127,24 @@
 // Mortar ammo
 /datum/supply_packs/ammo_mortar_he/asrs
 	buyable = 0
-	group = "Munition"
+	group = "ASRS"
 
 /datum/supply_packs/ammo_mortar_incend/asrs
 	buyable = 0
-	group = "Munition"
+	group = "ASRS"
 
 /datum/supply_packs/ammo_mortar_flare/asrs
 	buyable = 0
-	group = "Munition"
+	group = "ASRS"
 
 //===================================
 //speciality armor
 /datum/supply_packs/armor_leader/asrs
 	buyable = 0
-	group = "Munition"
+	group = "ASRS"
 	cost = ASRS_LOWEST_WEIGHT
 
 /datum/supply_packs/armor_rto/asrs
 	buyable = 0
-	group = "Munition"
+	group = "ASRS"
 	cost = ASRS_LOWEST_WEIGHT

--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -398,7 +398,7 @@ var/datum/controller/supply/supply_controller = new()
 	for(var/typepath in subtypesof(/datum/supply_packs))
 		var/datum/supply_packs/P = new typepath()
 		if(P.group == "ASRS")
-			random_supply_packs[P.name] = P
+			random_supply_packs += P
 		else
 			supply_packs[P.name] = P
 	spawn(0)
@@ -434,10 +434,7 @@ var/datum/controller/supply/supply_controller = new()
 //This is a weighted pick based upon their cost.
 //Their cost will go up if the crate is picked
 /datum/controller/supply/proc/add_random_crate()
-	var/list/pickfrom = list()
-	for(var/supply_name in supply_controller.random_supply_packs)
-		pickfrom += supply_controller.random_supply_packs[supply_name]
-	var/datum/supply_packs/C = supply_controller.pick_weighted_crate(pickfrom)
+	var/datum/supply_packs/C = supply_controller.pick_weighted_crate(random_supply_packs)
 	if(C == null)
 		return
 	C.cost = round(C.cost * ASRS_COST_MULTIPLIER) //We still do this to raise the weight

--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -395,13 +395,12 @@ var/datum/controller/supply/supply_controller = new()
 
 //Supply shuttle ticker - handles supply point regenertion and shuttle travelling between centcomm and the station
 /datum/controller/supply/process()
-	for(var/typepath in (typesof(/datum/supply_packs) - /datum/supply_packs - /datum/supply_packs/asrs))
+	for(var/typepath in subtypesof(/datum/supply_packs))
 		var/datum/supply_packs/P = new typepath()
-		supply_packs[P.name] = P
-	for(var/typepath in (typesof(/datum/supply_packs) - /datum/supply_packs - /datum/supply_packs/asrs))
-		var/datum/supply_packs/P = new typepath()
-		if(P.cost > 1 && P.buyable == 0)
+		if(P.group == "ASRS")
 			random_supply_packs[P.name] = P
+		else
+			supply_packs[P.name] = P
 	spawn(0)
 		set background = 1
 		while(1)
@@ -432,25 +431,12 @@ var/datum/controller/supply/supply_controller = new()
 	return crate_amount
 
 //Here we pick what crate type to send to the marines.
-/datum/controller/supply/proc/add_random_crate()
-	var/randpick = rand(1,100)
-	switch(randpick)
-		if(1 to 40)
-			pickcrate("Munition")
-		if(41 to 81)
-			pickcrate("Utility")
-		if(81 to 100)
-			pickcrate("Everything")
-
-//Here we pick the exact crate from the crate types to send to the marines.
 //This is a weighted pick based upon their cost.
 //Their cost will go up if the crate is picked
-/datum/controller/supply/proc/pickcrate(var/T = "Everything")
+/datum/controller/supply/proc/add_random_crate()
 	var/list/pickfrom = list()
 	for(var/supply_name in supply_controller.random_supply_packs)
-		var/datum/supply_packs/N = supply_controller.random_supply_packs[supply_name]
-		if((T == "Everything" || N.group == T)  && !N.buyable)
-			pickfrom += N
+		pickfrom += supply_controller.random_supply_packs[supply_name]
 	var/datum/supply_packs/C = supply_controller.pick_weighted_crate(pickfrom)
 	if(C == null)
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

I am not surprised that it recently suddenly ceased working. I am confused how has had it been working _at all_ until now.
All the ASRS supply datums are subtypes of actual orderable datums, but with buyability turned off, special category that cannot be picked on the console so they are never seen and a mildly complicated system that checks for that buyability and adds them to a special list, from which controller then regularly picks random crates to send via ASRS. The issue is, they keep the same name as their immediate parents, so `supply_packs[P.name] = P` in controller's setup results in ASRS subtype overriding the actual orderable datum's entry instead of being in addition to it - thus, all the crates that have ASRS subtypes cannot be manually ordered. For some mysterious reason, it only started being an observed issue very recently instead of having being a problem for years as it at first glance should.
Also, CM dev strikes again: `"Utility"` category of crates (which is where ASRS random metal/plasteel/sandbags crates were grouped) had been deleted _two years ago_. Picking a random crate does not need to randomly choose between munitions, utility and either when all it _has_ is munitions. Setting them to `"ASRS"` group and assembling the lists of orderable and random crates separately based on that group apparently solves everything, including the stray comms parts crate occasionally showing up from ASRS (presumably because it is not buyable since static comms, and that was the only thing that mattered for ASRS to pick it).

## Why It's Good For The Game

Is important fix.

## Changelog

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Requisitions once again can properly order all ammunition boxes and mortar shells.
fix: ASRS should no longer randomly deliver crate of components for communications tower.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
