### PR TITLE
Makes Liaison spawn in the correct place

### DIFF
--- a/code/game/jobs/job/civilians/other/liaison.dm
+++ b/code/game/jobs/job/civilians/other/liaison.dm
@@ -18,11 +18,6 @@
 	SIGNAL_HANDLER
 	active_liaison = null
 
-/datum/job/civilian/liaison/nightmare
-	flags_startup_parameters = NO_FLAGS
-	gear_preset = /datum/equipment_preset/uscm_ship/liaison/nightmare
-	entry_message_body = "It was just a regular day in the office when the higher up decided to send you in to this hot mess. If only you called in sick that day... The Wey-Yu mercs were hired to protect some important science experiment, and Wey-Yu expects you to keep them in line. These are hardened killers, and you write on paper for a living. It won't be easy, that's for damn sure. Best to let the mercs do the killing and the dying, but remind them who pays the bills."
-
 /obj/effect/landmark/start/liaison
 	name = JOB_CORPORATE_LIAISON
 	job = /datum/job/civilian/liaison

--- a/code/modules/gear_presets/uscm_ship.dm
+++ b/code/modules/gear_presets/uscm_ship.dm
@@ -94,14 +94,6 @@
 	return paygrade
 
 //*****************************************************************************************************/
-/datum/equipment_preset/uscm_ship/liaison/nightmare
-	name = "Nightmare USCM Corporate Liaison"
-	flags = EQUIPMENT_PRESET_START_OF_ROUND
-	faction_group = FACTION_LIST_MARINE_WY
-
-	access = list(ACCESS_WY_PMC_GREEN, ACCESS_WY_PMC_ORANGE, ACCESS_WY_PMC_RED, ACCESS_WY_PMC_BLACK, ACCESS_WY_PMC_WHITE, ACCESS_WY_CORPORATE)
-
-//*****************************************************************************************************/
 
 /datum/equipment_preset/uscm_ship/chief_engineer
 	name = "USCM Chief Engineer (CE)"


### PR DESCRIPTION
## About The Pull Request

Removed the “nightmare” section of the liaison's job.
It also removes its attached liaison nightmare equipment preset as it is unused without this.

hope I didn’t break something
This should fix: https://github.com/cmss13-devs/cmss13/issues/1352
## Changelog
:cl:
fix: Fixed CL incorrectly spawning at late join cryo room at round start
/:cl:

