### PR TITLE
Lighting Nerf

### DIFF
--- a/code/game/machinery/vending/vendor_types/requisitions.dm
+++ b/code/game/machinery/vending/vendor_types/requisitions.dm
@@ -182,7 +182,7 @@
 				else
 					flare_type = /obj/item/device/flashlight/flare
 				for(var/obj/item/device/flashlight/flare/F in flare_pack.contents)
-					if(F.fuel < 1)
+					if(F.burned_out)
 						to_chat(user, SPAN_WARNING("Some flares in \the [F] are used."))
 						return
 					if(F.type != flare_type)

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -250,6 +250,10 @@
 	var/on_damage = 7
 	var/ammo_datum = /datum/ammo/flare
 
+/obj/item/device/flashlight/flare/Destroy()
+	deltimer(burnout_timer_id)
+	return ..()
+
 /obj/item/device/flashlight/flare/dropped(mob/user)
 	. = ..()
 	if(iscarbon(user) && on)

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -243,7 +243,7 @@
 	item_state = "flare"
 	actions = list()	//just pull it manually, neckbeard.
 	raillight_compatible = 0
-	var/flare_time = 1 MINUTES
+	var/flare_time = 3 MINUTES
 	var/flare_variance = 15 SECONDS // 15 seconds one way, 15 seconds the other way
 	var/burned_out = FALSE
 	var/burnout_timer_id

--- a/code/modules/clothing/suits/marine_armor.dm
+++ b/code/modules/clothing/suits/marine_armor.dm
@@ -114,7 +114,7 @@ var/list/squad_colors_chat = list(rgb(230,125,125), rgb(255,230,80), rgb(255,150
 	)
 	valid_accessory_slots = list(ACCESSORY_SLOT_MEDAL, ACCESSORY_SLOT_PONCHO)
 
-	var/brightness_on = 6 //Average attachable pocket light
+	var/brightness_on = 5 //Average attachable pocket light
 	var/flashlight_cooldown = 0 //Cooldown for toggling the light
 	var/locate_cooldown = 0 //Cooldown for SL locator
 	var/armor_overlays[]
@@ -283,7 +283,7 @@ var/list/squad_colors_chat = list(rgb(230,125,125), rgb(255,230,80), rgb(255,150
 	armor_bio = CLOTHING_ARMOR_MEDIUMHIGH
 	armor_rad = CLOTHING_ARMOR_MEDIUM
 	storage_slots = 4
-	brightness_on = 7 //slightly higher
+	brightness_on = 6 //slightly higher
 	specialty = "M4 pattern marine"
 
 /obj/item/clothing/suit/storage/marine/rto/intel

--- a/code/modules/projectiles/ammo_boxes.dm
+++ b/code/modules/projectiles/ammo_boxes.dm
@@ -819,7 +819,7 @@
 				else
 					flare_type = /obj/item/device/flashlight/flare
 				for(var/obj/item/device/flashlight/flare/F in flare_pack.contents)
-					if(F.fuel < 1)
+					if(F.burned_out)
 						to_chat(user, SPAN_WARNING("Some flares in \the [F] are used."))
 						return
 					if(F.type != flare_type)

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -575,10 +575,10 @@ Defined in conflicts.dm of the #defines folder.
 
 /obj/item/attachable/flashlight
 	name = "rail flashlight"
-	desc = "A flashlight, for rails, on guns. Can be toggled on and off. A better light source than standard M3 pattern armor lights."
+	desc = "A flashlight, for rails, on guns. Can be toggled on and off."
 	icon_state = "flashlight"
 	attach_icon = "flashlight_a"
-	light_mod = 7
+	light_mod = 5
 	slot = "rail"
 	matter = list("metal" = 50,"glass" = 20)
 	flags_attach_features = ATTACH_REMOVABLE|ATTACH_ACTIVATION

--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -1216,7 +1216,7 @@ obj/item/weapon/gun/launcher/grenade/update_icon()
 		if(F.on)
 			to_chat(user, SPAN_WARNING("You can't put a lit flare in [src]!"))
 			return
-		if(!F.fuel)
+		if(F.burned_out)
 			to_chat(user, SPAN_WARNING("You can't put a burnt out flare in [src]!"))
 			return
 		if(current_mag && current_mag.current_rounds == 0)

--- a/code/modules/vehicles/interior/interactable/vendors.dm
+++ b/code/modules/vehicles/interior/interactable/vendors.dm
@@ -463,7 +463,7 @@
 				else
 					flare_type = /obj/item/device/flashlight/flare
 				for(var/obj/item/device/flashlight/flare/F in flare_pack.contents)
-					if(F.fuel < 1)
+					if(F.burned_out)
 						if(user)
 							to_chat(user, SPAN_WARNING("Some flares in \the [F] are used."))
 						return FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Nerfs flares to have less brightness and burn out quicker. Also changes them to not process but to use a timer instead.

Standard Flare | 4 Tiles (Orig: 5) | 165 - 195 Seconds (Orig: 1600 - 2000)
Flare-gun Flare | 5 Tiles (Orig: 7) | 165 - 195 Seconds (Orig: 1600 - 2000)
Signal Flare | 4 Tiles (Orig: 5) | 150 - 210 Seconds (Orig: 160 - 200)
Illumination Flare (Mortar) | 7 Tiles (Unchanged) | 480 - 720 Seconds (Orig: 800 - 1000)
Starshell Ash (M79) | 7 Tiles (Unchanged) | 20 - 60 Seconds (Orig: 5 - 60)
Chemical Light | Depends on Amount | Depends on Amount (Completely Unchanged)

![image](https://user-images.githubusercontent.com/22774890/198723909-8b750ead-6826-45d7-8e3b-c49d2f3c1f19.png)

Additionally, nerfs suit and rail lights.

Suit Light | 5 Tiles (Orig: 6)
RTO Suit Light | 6 Tiles (Orig: 7)

Rail Light | 5 Tiles (Orig: 7)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It's an attempt to make the game more atmospheric, much like the AvP games of the past with their low life flares. Light is an extremely powerful tool, and being able to toss it around and have it last 30 minutes (one third of a good round) is waaaaay too powerful. This also makes mortar flares way more useful in comparison.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->

## Changelog

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Nerfed flare brightness and burn time across the board.
balance: Nerfed suit light and raill light brightness.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
