### PR TITLE
Research Grenade Assembly addition

### DIFF
--- a/code/game/machinery/vending/vendor_types/engineering.dm
+++ b/code/game/machinery/vending/vendor_types/engineering.dm
@@ -149,6 +149,23 @@
 /obj/structure/machinery/cm_vending/sorted/tech/comp_storage/antag
 	req_access = list(ACCESS_ILLEGAL_PIRATE)
 
+/obj/structure/machinery/cm_vending/sorted/tech/research_assembly
+	name = "\improper Research Chemical Assembly Vendor"
+	desc = "A large storage machine containing custom chemical explosives and assembly components."
+	icon_state = "robotics"
+	req_access = list(ACCESS_MARINE_RESEARCH)
+
+/obj/structure/machinery/cm_vending/sorted/tech/research_assembly/populate_product_list(var/scale)
+	listed_products = list(
+		list("ASSEMBLY COMPONENTS", -1, null, null),
+		list("Igniter", 5, /obj/item/device/assembly/igniter, VENDOR_ITEM_REGULAR),
+		list("Timer", 5, /obj/item/device/assembly/timer, VENDOR_ITEM_REGULAR),
+
+		list("CUSTOM GRENADES", -1, null, null),
+		list("Custom Large Grenade", 10, /obj/item/explosive/grenade/custom/research, VENDOR_ITEM_REGULAR),
+		list("Custom Chemical Smoke Grenade", 5, /obj/item/explosive/grenade/custom/research/chemsmoke, VENDOR_ITEM_REGULAR)
+	)
+
 //------COLONY-SPECIFIC VENDORS-------
 
 /obj/structure/machinery/cm_vending/sorted/tech/science

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -4349,15 +4349,7 @@
 /obj/structure/machinery/light{
 	dir = 1
 	},
-/obj/structure/surface/rack,
-/obj/item/stack/sheet/mineral/plastic{
-	amount = 15
-	},
-/obj/item/stack/sheet/glass{
-	amount = 20;
-	pixel_x = 3;
-	pixel_y = 3
-	},
+/obj/structure/machinery/cm_vending/sorted/tech/research_assembly,
 /turf/open/floor/almayer{
 	dir = 1;
 	icon_state = "sterile_green_side";
@@ -37374,6 +37366,21 @@
 	tag = "icon-sterile"
 	},
 /area/almayer/engineering/upper_engineering)
+"dEu" = (
+/obj/structure/surface/rack,
+/obj/item/stack/sheet/mineral/plastic{
+	amount = 15
+	},
+/obj/item/stack/sheet/glass{
+	amount = 20;
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/turf/open/floor/almayer{
+	icon_state = "sterile_green_side";
+	tag = "icon-sterile"
+	},
+/area/almayer/medical/testlab)
 "dEC" = (
 /obj/structure/sign/safety/escapepod{
 	pixel_x = 8;
@@ -120593,7 +120600,7 @@ eNT
 anF
 anF
 taH
-aBe
+dEu
 cJM
 vHO
 jNc


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

This PR includes three new features for the Research Department, first one is a new vendor which contains assembly components and limited (not pop scaled) custom grenades. The other two features is a large custom grenade variant that can be assembled by Researchers and a custom chemical smoke grenade designed specifically to be used for custom smoke mixes and can only be assembled by researchers. Both of these grenades are found in the new vendor which is located in the storage room of Research (alongside the autolathes and such). The research variant of the large custom grenade is basically the same as the original, with the only difference being who can assemble it. the custom chemical smoke grenade is a special custom grenade with a maximum capacity of 240u which is best for 2 120u containers, the reccomended goto mix being 50/50/50 of the ingredients for the smoke and 90u for the desired chemical (an upgrade to the reccomended mix of a M15 being 40/40/40 and 60)
As a prevention measure to not make people take advantage of the 240u capacity on the grenade, its OT capabilities have been severely limited to be even worse than a standard custom M40 grenade, making it only good for smoke mixes.

These grenades have been added as a way for Research to create custom smoke mixes and custom explosive/incendiary OT M15 grenades during times where Ordnance Technicians are unavailable or simply refuse cooperation to create custom smokes and/or explosives with a custom generated chemical, while still in limited numbers (10 M15s and 5 custom chem smokes) so you cannot act as another OT and to encourage cooperation with the two departments when you ever run out.

## Why It's Good For The Game

Provides Research an independent way to create custom chem explosives and smoke mixes whenever Ordnance Technicians are unavailable (for whatever reasons) as currently despite new additions from Warcrimes, the two departments hardly ever cooperate to make custom smoke grenades due to one side showing no interest over it which leaves Research still doing the old regular stims only meta, by making Research being able to make grenades by themselves (albeit limited), it can help with them being used more and in the future strengthen cooperation between the two departments as everyone knows how good the smokes can be.

## Changelog

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:Unknownity
add: Added a new vendor named Research Chemical Assembly Vendor, it can be found in the Research Department Workshop room. It features assembly components and limited custom grenades.
add: Added two new custom grenades which can be found in the aforementioned vendor. The two being the research variant of the M15 custom grenade which serves as a near identical version of the custom M15 grenade and a custom chemical smoke grenade with a maximum capacity of 240u with severely limited explosive/incendiary capabilities. Both can only be assembled if you have the Research skill.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
