### PR TITLE
zombie disease rework

### DIFF
--- a/code/modules/reagents/chemistry_reagents/other.dm
+++ b/code/modules/reagents/chemistry_reagents/other.dm
@@ -653,7 +653,7 @@
 	color = "#604030" // rgb: 96, 64, 48
 	chemclass = CHEM_CLASS_UNCOMMON
 
-/datum/reagent/blackgoo
+/datum/reagent/blackgoo //This is the version that quickly causes a person to be infected
 	name = "Black goo"
 	id = "blackgoo"
 	description = "A strange dark liquid of unknown origin and effect."
@@ -666,13 +666,26 @@
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		if(H.species.name == "Human")
-			H.contract_disease(new /datum/disease/black_goo)
+			var/datum/disease/black_goo/transform_to_zombie = new /datum/disease/black_goo()
+			transform_to_zombie.stage = 4
+			H.contract_disease(transform_to_zombie)
 
 /datum/reagent/blackgoo/reaction_turf(var/turf/T, var/volume)
 	if(!istype(T)) return
 	if(volume < 3) return
 	if(!(locate(/obj/effect/decal/cleanable/blackgoo) in T))
 		new /obj/effect/decal/cleanable/blackgoo(T)
+
+/datum/reagent/blackgoo/weak //This is the reagent that zombies will inflict with
+	name = "Weak Black goo"
+	id = "blackgooweak"
+	custom_metabolism = REAGENTS_METABOLISM
+
+/datum/reagent/blackgoo/weak/reaction_mob()
+	return
+
+
+
 
 
 // Chemfire supplements


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
It reworks the zombie disease to not be an immediate death sentence upon contraction. Instead now, it progresses based on whether or not it has a reagent in the body that is administered by zombie claw attacks. Once humans start coughing up black bile, that is when the disease no longer needs the zombie reagent.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
No more will people be systematically slaughtered like animals when the infection starts. No more will zombies just run around trying to slash as many people as they can before they get downed, now they have to actually focus targets, which makes the slowdown all the better since there is actually a point to it other than getting another chance for the disease to proc. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->

## Changelog

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: aceroy
add: Added new zombie reagent that affects the progression of the zombie Virus
balance: Zombie virus now progress based on different criteria. Zombie slashes now apply a new reagent to the target (15u a slash), at 30 units of the reagent the disease is able to progress. If the virus reaches stage 3 it will progress no matter what. And if the target is dead, the virus will progress.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
