### PR TITLE
Spell checks "huggers" to "facehugger", makes playable hugger join message clearer.

### DIFF
--- a/code/datums/medal_awards.dm
+++ b/code/datums/medal_awards.dm
@@ -163,13 +163,13 @@ GLOBAL_LIST_EMPTY(jelly_awards)
 	if(!((card.paygrade in GLOB.co_paygrades) || (card.paygrade in GLOB.highcom_paygrades)))
 		to_chat(user, SPAN_WARNING("Only a Senior Officer can award medals!"))
 		return
-	
+
 	if(!card.registered_ref)
 		user.visible_message("ERROR: ID card not registered in USCM registry. Potential medal fraud detected.")
 		return
-	
+
 	var/real_owner_ref = card.registered_ref
-		
+
 	if(real_owner_ref != WEAKREF(user))
 		user.visible_message("ERROR: ID card not registered for [user.real_name] in USCM registry. Potential medal fraud detected.")
 		return
@@ -191,7 +191,7 @@ GLOBAL_LIST_EMPTY(jelly_awards)
 	for(var/mob/living/carbon/Xenomorph/xeno in hive.totalXenos)
 		if (xeno.persistent_ckey == usr.persistent_ckey) // Don't award self
 			continue
-		if (xeno.tier == 0) // Don't award larva or huggers
+		if (xeno.tier == 0) // Don't award larva or facehuggers
 			continue
 		if (!as_admin && istype(xeno.caste, /datum/caste_datum/queen)) // Don't award queens unless admin
 			continue
@@ -202,7 +202,7 @@ GLOBAL_LIST_EMPTY(jelly_awards)
 	for(var/mob/living/carbon/Xenomorph/xeno in hive.totalDeadXenos)
 		if (xeno.persistent_ckey == usr.persistent_ckey) // Don't award previous selves
 			continue
-		if (xeno.tier == 0) // Don't award larva or huggers
+		if (xeno.tier == 0) // Don't award larva or facehuggers
 			continue
 		if (!as_admin && istype(xeno.caste, /datum/caste_datum/queen)) // Don't award previous queens unless admin
 			continue

--- a/code/modules/cm_aliens/structures/egg.dm
+++ b/code/modules/cm_aliens/structures/egg.dm
@@ -109,7 +109,7 @@
 		var/obj/effect/egg_trigger/ET = trigger
 		ET.moveToNullspace()
 
-/obj/effect/alien/egg/proc/Burst(var/kill = TRUE, var/instant_trigger = FALSE, var/mob/living/carbon/Xenomorph/X = null) //drops and kills the hugger if any is remaining
+/obj/effect/alien/egg/proc/Burst(var/kill = TRUE, var/instant_trigger = FALSE, var/mob/living/carbon/Xenomorph/X = null) //drops and kills the facehugger if any is remaining
 	if(kill && status != EGG_DESTROYED)
 		hide_egg_triggers()
 		status = EGG_DESTROYED

--- a/code/modules/cm_aliens/structures/special/egg_morpher.dm
+++ b/code/modules/cm_aliens/structures/special/egg_morpher.dm
@@ -214,7 +214,7 @@
 
 	var/mob/living/carbon/Xenomorph/Facehugger/hugger = new /mob/living/carbon/Xenomorph/Facehugger(loc, null, linked_hive.hivenumber)
 	user.mind.transfer_to(hugger, TRUE)
-	hugger.visible_message(SPAN_XENODANGER("A child suddenly emerges out of \the [src]!"), SPAN_XENODANGER("You emerge out of \the [src] and awaken from your slumber. For the Hive!"))
+	hugger.visible_message(SPAN_XENODANGER("A facehugger suddenly emerges out of \the [src]!"), SPAN_XENODANGER("You emerge out of \the [src] and awaken from your slumber. For the Hive!"))
 	playsound(hugger, 'sound/effects/xeno_newlarva.ogg', 25, TRUE)
 	hugger.generate_name()
 	stored_huggers--

--- a/code/modules/cm_aliens/structures/special/egg_morpher.dm
+++ b/code/modules/cm_aliens/structures/special/egg_morpher.dm
@@ -184,14 +184,14 @@
 
 /obj/effect/alien/resin/special/eggmorph/attack_ghost(mob/dead/observer/user)
 	if(world.time < hugger_timelock)
-		to_chat(user, SPAN_WARNING("The hive cannot support huggers yet..."))
+		to_chat(user, SPAN_WARNING("The hive cannot support facehuggers yet..."))
 		return
 	if(world.time - user.timeofdeath < 3 MINUTES)
 		var/time_left = round((user.timeofdeath + 3 MINUTES - world.time) / 10)
-		to_chat(user, SPAN_WARNING("You ghosted too recently. ([time_left] seconds left)"))
+		to_chat(user, SPAN_WARNING("You ghosted too recently. You cannot become a facehugger until ([time_left] seconds has passed)"))
 		return
 	if(!stored_huggers)
-		to_chat(user, SPAN_WARNING("\The [src] doesn't have any huggers to inhabit."))
+		to_chat(user, SPAN_WARNING("\The [src] doesn't have any facehuggers to inhabit."))
 		return
 
 	if(world.time > last_marine_count + marine_count_cooldown)
@@ -206,7 +206,7 @@
 		if(isXenoFacehugger(mob))
 			current_hugger_count++
 	if(playable_hugger_limit <= current_hugger_count)
-		to_chat(user, SPAN_WARNING("\The [src] cannot support more huggers! Limit: <b>[current_hugger_count]/[playable_hugger_limit]</b>"))
+		to_chat(user, SPAN_WARNING("\The [src] cannot support more facehuggers! Limit: <b>[current_hugger_count]/[playable_hugger_limit]</b>"))
 		return
 
 	if(alert(user, "Are you sure you want to become a facehugger?", "Confirmation", "Yes", "No") == "No")
@@ -214,7 +214,7 @@
 
 	var/mob/living/carbon/Xenomorph/Facehugger/hugger = new /mob/living/carbon/Xenomorph/Facehugger(loc, null, linked_hive.hivenumber)
 	user.mind.transfer_to(hugger, TRUE)
-	hugger.visible_message(SPAN_XENODANGER("A facehugger suddenly emerges out of \the [src]!"), SPAN_XENODANGER("You emerge out of \the [src] and awaken from your slumber. For the Hive!"))
+	hugger.visible_message(SPAN_XENODANGER("A child suddenly emerges out of \the [src]!"), SPAN_XENODANGER("You emerge out of \the [src] and awaken from your slumber. For the Hive!"))
 	playsound(hugger, 'sound/effects/xeno_newlarva.ogg', 25, TRUE)
 	hugger.generate_name()
 	stored_huggers--

--- a/code/modules/cm_aliens/structures/trap.dm
+++ b/code/modules/cm_aliens/structures/trap.dm
@@ -135,7 +135,7 @@
 	clear_tripwires()
 	for(var/mob/living/carbon/Xenomorph/X in GLOB.living_xeno_list)
 		if(X.hivenumber == hivenumber)
-			to_chat(X, SPAN_XENOMINORWARNING("You sense one of your Hive's hugger traps at [A.name] has been burnt!"))
+			to_chat(X, SPAN_XENOMINORWARNING("You sense one of your Hive's facehugger traps at [A.name] has been burnt!"))
 
 /obj/effect/alien/resin/trap/proc/get_spray_type(var/level)
 	switch(level)

--- a/code/modules/mob/living/carbon/xenomorph/mutators/strains/carrier/shaman.dm
+++ b/code/modules/mob/living/carbon/xenomorph/mutators/strains/carrier/shaman.dm
@@ -1,6 +1,6 @@
 /datum/xeno_mutator/shaman
 	name = "STRAIN: Carrier - Shaman"
-	description = "In exchange for your ability to store huggers, you can cheat the adrenaline mechanism of nearby xenos by violently killing little ones while they are still in a small egg form."
+	description = "In exchange for your ability to store facehuggers, you can cheat the adrenaline mechanism of nearby xenos by violently killing little ones while they are still in a small egg form."
 	cost = MUTATOR_COST_EXPENSIVE
 	individual_only = TRUE
 	caste_whitelist = list(XENO_CASTE_CARRIER)


### PR DESCRIPTION
## About The Pull Request

This PR adds "face" to huggers in the code. Huggers sounds really dumb, and it's a lot more consistent to call them "facehugger" and not just "huggers". Also, the spawn message for playable huggers was really short. This PR makes it more clearer.

## Why It's Good For The Game

Good spelling, consistency with "facehugger".

## Changelog

:cl:
spellcheck: Playable hugger join message is more clearer
code: Hugger is now called "facehugger" in the code
/:cl:

