### PR TITLE
M37 Needs Scabbard to be Placed on Back Again

### DIFF
--- a/code/game/objects/items/storage/large_holster.dm
+++ b/code/game/objects/items/storage/large_holster.dm
@@ -60,6 +60,7 @@
 	name = "\improper L44 M37A2 scabbard"
 	desc = "A large leather holster fitted for USCM-issue shotguns. It has harnesses that allow it to be secured to the back for easy storage."
 	icon_state = "m37_holster"
+	max_w_class = SIZE_HUGE
 	can_hold = list(
 		/obj/item/weapon/gun/shotgun/pump,
 		/obj/item/weapon/gun/shotgun/combat

--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -913,7 +913,6 @@ can cause issues with ammo types getting mixed up during the burst.
 	icon_state = "m37"
 	item_state = "m37"
 	current_mag = /obj/item/ammo_magazine/internal/shotgun
-	flags_equip_slot = SLOT_BACK
 	fire_sound = 'sound/weapons/gun_shotgun.ogg'
 	firesound_volume = 60
 	var/pump_sound = "shotgunpump"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Changes the M37A2 Pump Shotgun to now only fit on your back when slotted into the L44 M37A2 Scabbard. The scabbard now holds items one size larger so that the M37 can fit with more attachments on.

## Why It's Good For The Game

About two or so years ago the M37 was changed to fit on your back without the scabbard. This effectively killed the entire purpose of the scabbard even being in the game, and this change essentially just brings us back to the scabbard having a purpose in allowing you to slot the shotgun on your back. The M37's ability to slot onto your armour is unchanged.

Bonus points: It comes out of a scabbard in the movie.

## Changelog

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: The M37A2 Pump Shotgun now requires the appropriate scabbard (obtainable from your personal vendor and prep uniform vendors) to be slotted onto your back. The scabbard can now also fit the M37 with more attachments on it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
