### PR TITLE
Adds janitorial closet to northwest maintenance

### DIFF
--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -13050,8 +13050,11 @@
 	},
 /area/almayer/evacuation/pod10)
 "aLk" = (
-/obj/structure/sign/poster/safety,
-/turf/closed/wall/almayer,
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/almayer{
+	icon_state = "plate";
+	tag = "icon-sterile"
+	},
 /area/almayer/hull/lower_hull/l_f_s)
 "aLl" = (
 /obj/structure/machinery/light/small{
@@ -27552,9 +27555,6 @@
 	dir = 4;
 	tag = "icon-intact-supply (EAST)"
 	},
-/obj/structure/sign/nosmoking_2{
-	pixel_y = 30
-	},
 /turf/open/floor/almayer{
 	dir = 1;
 	icon_state = "red";
@@ -27772,6 +27772,9 @@
 	},
 /area/almayer/squads/req)
 "bPC" = (
+/obj/structure/sign/nosmoking_2{
+	pixel_x = 28
+	},
 /turf/open/floor/almayer{
 	icon_state = "cargo_arrow"
 	},
@@ -39086,6 +39089,13 @@
 	tag = "icon-sterile"
 	},
 /area/almayer/hull/lower_hull/l_a_s)
+"eqk" = (
+/mob/living/simple_animal/mouse/brown,
+/turf/open/floor/almayer{
+	icon_state = "plate";
+	tag = "icon-sterile"
+	},
+/area/almayer/hull/lower_hull/l_f_s)
 "eqv" = (
 /turf/closed/shuttle/escapepod{
 	icon_state = "wall11";
@@ -39379,13 +39389,6 @@
 /obj/structure/machinery/cryopod/evacuation,
 /turf/open/shuttle/escapepod,
 /area/almayer/evacuation/pod18)
-"evw" = (
-/mob/living/simple_animal/mouse/brown,
-/turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
-	},
-/area/almayer/hull/lower_hull/l_f_s)
 "evX" = (
 /obj/structure/pipes/standard/manifold/hidden/supply,
 /turf/open/floor/plating/plating_catwalk,
@@ -46809,11 +46812,8 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/upper_hull/u_f_s)
 "hKe" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
-	},
+/obj/structure/sign/poster/safety,
+/turf/closed/wall/almayer,
 /area/almayer/hull/lower_hull/l_f_s)
 "hKi" = (
 /obj/structure/largecrate/random/barrel/yellow,
@@ -52377,6 +52377,12 @@
 	tag = "icon-sterile"
 	},
 /area/almayer/command/corporateliason)
+"kmM" = (
+/obj/structure/sink{
+	pixel_y = 24
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_f_s)
 "knH" = (
 /obj/structure/machinery/vending/coffee,
 /obj/structure/sign/safety/coffee{
@@ -56258,21 +56264,6 @@
 	tag = "icon-red (NORTHWEST)"
 	},
 /area/almayer/lifeboat_pumps/south1)
-"lXf" = (
-/obj/structure/closet,
-/obj/item/stack/sheet/glass/large_stack,
-/obj/item/device/lightreplacer,
-/obj/item/reagent_container/spray/cleaner,
-/obj/item/stack/rods{
-	amount = 40
-	},
-/obj/item/tool/weldingtool,
-/obj/item/clothing/glasses/welding,
-/turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
-	},
-/area/almayer/hull/lower_hull/l_f_s)
 "lXg" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/recharger,
@@ -66451,6 +66442,21 @@
 /obj/effect/landmark/late_join/bravo,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/squads/bravo)
+"qDv" = (
+/obj/structure/closet,
+/obj/item/stack/sheet/glass/large_stack,
+/obj/item/device/lightreplacer,
+/obj/item/reagent_container/spray/cleaner,
+/obj/item/stack/rods{
+	amount = 40
+	},
+/obj/item/tool/weldingtool,
+/obj/item/clothing/glasses/welding,
+/turf/open/floor/almayer{
+	icon_state = "plate";
+	tag = "icon-sterile"
+	},
+/area/almayer/hull/lower_hull/l_f_s)
 "qDz" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer{
@@ -66904,12 +66910,6 @@
 "qMu" = (
 /turf/closed/wall/almayer/outer,
 /area/almayer/hull/upper_hull/u_a_p)
-"qMG" = (
-/obj/structure/sink{
-	pixel_y = 24
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/hull/lower_hull/l_f_s)
 "qMP" = (
 /obj/structure/surface/table/almayer,
 /obj/item/storage/box/pillbottles{
@@ -98789,8 +98789,8 @@ nXP
 mGL
 hJp
 uNL
-lXf
-hKe
+qDv
+aLk
 uNL
 xCR
 bSv
@@ -98992,8 +98992,8 @@ nXP
 tRV
 mGL
 uNL
-qMG
-evw
+kmM
+eqk
 uNL
 hJp
 bSv
@@ -99194,7 +99194,7 @@ aag
 nXP
 hJp
 mGL
-aLk
+hKe
 hJp
 hJp
 uNL

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -13050,8 +13050,8 @@
 	},
 /area/almayer/evacuation/pod10)
 "aLk" = (
-/obj/structure/largecrate/random/case,
-/turf/open/floor/plating/plating_catwalk,
+/obj/structure/sign/poster/safety,
+/turf/closed/wall/almayer,
 /area/almayer/hull/lower_hull/l_f_s)
 "aLl" = (
 /obj/structure/machinery/light/small{
@@ -14950,6 +14950,12 @@
 	dir = 4;
 	tag = "icon-bulb1 (EAST)"
 	},
+/obj/item/reagent_container/glass/bucket/mopbucket,
+/obj/item/tool/mop{
+	pixel_x = -6;
+	pixel_y = 14
+	},
+/obj/structure/janitorialcart,
 /turf/open/floor/almayer{
 	icon_state = "plate";
 	tag = "icon-sterile"
@@ -27546,6 +27552,9 @@
 	dir = 4;
 	tag = "icon-intact-supply (EAST)"
 	},
+/obj/structure/sign/nosmoking_2{
+	pixel_y = 30
+	},
 /turf/open/floor/almayer{
 	dir = 1;
 	icon_state = "red";
@@ -39370,6 +39379,13 @@
 /obj/structure/machinery/cryopod/evacuation,
 /turf/open/shuttle/escapepod,
 /area/almayer/evacuation/pod18)
+"evw" = (
+/mob/living/simple_animal/mouse/brown,
+/turf/open/floor/almayer{
+	icon_state = "plate";
+	tag = "icon-sterile"
+	},
+/area/almayer/hull/lower_hull/l_f_s)
 "evX" = (
 /obj/structure/pipes/standard/manifold/hidden/supply,
 /turf/open/floor/plating/plating_catwalk,
@@ -46793,11 +46809,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/upper_hull/u_f_s)
 "hKe" = (
-/obj/structure/surface/rack,
-/obj/item/device/lightreplacer,
-/obj/item/device/lightreplacer{
-	pixel_x = 6
-	},
+/obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/almayer{
 	icon_state = "plate";
 	tag = "icon-sterile"
@@ -56246,6 +56258,21 @@
 	tag = "icon-red (NORTHWEST)"
 	},
 /area/almayer/lifeboat_pumps/south1)
+"lXf" = (
+/obj/structure/closet,
+/obj/item/stack/sheet/glass/large_stack,
+/obj/item/device/lightreplacer,
+/obj/item/reagent_container/spray/cleaner,
+/obj/item/stack/rods{
+	amount = 40
+	},
+/obj/item/tool/weldingtool,
+/obj/item/clothing/glasses/welding,
+/turf/open/floor/almayer{
+	icon_state = "plate";
+	tag = "icon-sterile"
+	},
+/area/almayer/hull/lower_hull/l_f_s)
 "lXg" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/recharger,
@@ -66877,6 +66904,12 @@
 "qMu" = (
 /turf/closed/wall/almayer/outer,
 /area/almayer/hull/upper_hull/u_a_p)
+"qMG" = (
+/obj/structure/sink{
+	pixel_y = 24
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_f_s)
 "qMP" = (
 /obj/structure/surface/table/almayer,
 /obj/item/storage/box/pillbottles{
@@ -98144,7 +98177,7 @@ aaa
 aad
 aag
 nXP
-hKe
+mGL
 mGL
 hJp
 mGL
@@ -98756,8 +98789,8 @@ nXP
 mGL
 hJp
 uNL
-sAm
-dNB
+lXf
+hKe
 uNL
 xCR
 bSv
@@ -98959,8 +98992,8 @@ nXP
 tRV
 mGL
 uNL
-mNf
-mGL
+qMG
+evw
 uNL
 hJp
 bSv
@@ -99161,8 +99194,8 @@ aag
 nXP
 hJp
 mGL
-uNL
 aLk
+hJp
 hJp
 uNL
 hJp


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

There was a small room in the northwest maintenance area, above Navigations. It had a few crates, so I reworked it into a janitorial closet so I could learn how to make pull requests and hopefully help any janitor who needs a localized spot for cleaning supplies. Contains glass, some metal rods, mop & bucket, etc. Nothing too major. Also added a no smoking sign to OB chambering room, because we value safety.

## Why It's Good For The Game

Well, we've got random cleaning supplies all around the ship, but when I've been playing Working Joe recently I figured something like this, in the middle of maintenance, could be very handy. A sort of one-stop-shop for all your janitorial needs.

## Changelog

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added janitorial closet to northwest maintenance above navigation. Contains generic cleaning/repair equipment such as glass, metal rods, mop & bucket, space cleaner, etc
add: Adds a no smoking sign to OB chambering room. Probably shouldn't have an open flame in there...
/:cl: