### PR TITLE
Fixes facehugger issues with being put on tables/racks

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
@@ -14,7 +14,7 @@
 	flags_inventory = COVEREYES|ALLOWINTERNALS|COVERMOUTH|ALLOWREBREATH|CANTSTRIP
 	flags_armor_protection = BODY_FLAG_FACE|BODY_FLAG_EYES
 	flags_atom = NO_FLAGS
-	flags_item = NOBLUDGEON
+	flags_item = NOBLUDGEON|NOTABLEMERGE
 	throw_range = 1
 	layer = FACEHUGGER_LAYER
 


### PR DESCRIPTION
## About The Pull Request

Fagehuggers had a number of issues when they were "merged" into a table upon being clicked (xeno clicks table with facehugger). They didn't go into resin holes, their dead sprite stayed on the table, they could be duped sprite wise, a whole lot of issues. All of this because it did not have one flag.

## Why It's Good For The Game

Fixes many issues with facehuggers and tables/racks, one line change too.

 closes#1216 

## Changelog
:cl:Usnpeepoo
fix: Facehuggers can now be put on a table/rack without causing a multitude of issues.
/:cl:

