### PR TITLE
Autodocs now show metal amount

### DIFF
--- a/code/game/machinery/autodoc.dm
+++ b/code/game/machinery/autodoc.dm
@@ -28,6 +28,10 @@
 	var/stored_metal = 125 // starts with 125 metal loaded
 	var/max_metal = 500
 
+/obj/structure/machinery/autodoc/get_examine_text(mob/user)
+	. = ..()
+	if(ishuman(user))
+		. += SPAN_NOTICE("It has [stored_metal] metal avalible for limb replacements.")
 
 /obj/structure/machinery/autodoc/Initialize()
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
You can now check how much metal an autodoc has before it's out.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Quality of life. Now you can check it and see when it is low, needs replenishment, full, etc from a glance
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->

## Changelog

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: TotalEpicness
qol: You can now check how much metal an autodoc has before it's out.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
