### PR TITLE
Fixed #1352 - wrong CL gear preset

### DIFF
--- a/code/game/jobs/job/civilians/other/liaison.dm
+++ b/code/game/jobs/job/civilians/other/liaison.dm
@@ -18,11 +18,6 @@
 	SIGNAL_HANDLER
 	active_liaison = null
 
-/datum/job/civilian/liaison/nightmare
-	flags_startup_parameters = NO_FLAGS
-	gear_preset = /datum/equipment_preset/uscm_ship/liaison/nightmare
-	entry_message_body = "It was just a regular day in the office when the higher up decided to send you in to this hot mess. If only you called in sick that day... The Wey-Yu mercs were hired to protect some important science experiment, and Wey-Yu expects you to keep them in line. These are hardened killers, and you write on paper for a living. It won't be easy, that's for damn sure. Best to let the mercs do the killing and the dying, but remind them who pays the bills."
-
 /obj/effect/landmark/start/liaison
 	name = JOB_CORPORATE_LIAISON
 	job = /datum/job/civilian/liaison

--- a/code/modules/gear_presets/uscm_ship.dm
+++ b/code/modules/gear_presets/uscm_ship.dm
@@ -94,14 +94,6 @@
 	return paygrade
 
 //*****************************************************************************************************/
-/datum/equipment_preset/uscm_ship/liaison/nightmare
-	name = "Nightmare USCM Corporate Liaison"
-	flags = EQUIPMENT_PRESET_START_OF_ROUND
-	faction_group = FACTION_LIST_MARINE_WY
-
-	access = list(ACCESS_WY_PMC_GREEN, ACCESS_WY_PMC_ORANGE, ACCESS_WY_PMC_RED, ACCESS_WY_PMC_BLACK, ACCESS_WY_PMC_WHITE, ACCESS_WY_CORPORATE)
-
-//*****************************************************************************************************/
 
 /datum/equipment_preset/uscm_ship/chief_engineer
 	name = "USCM Chief Engineer (CE)"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Fixed bug #1352 . CLs were getting wrong presets - a Nightmare variant which had wrong ID access and wrong starting text. Fixed it by removing the preset - it doesn't seem to be used anywhere.

I think the bug was caused by one of those global variables that holds all the job / gear datums. It was probably indexed based on some field that was not altered between /datum/equipment_preset/uscm_ship/liaison and /datum/equipment_preset/uscm_ship/liaison/nightmare . I tried figuring out what it was indexed by but it would probably take much more time than this is worth...

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It lets CLs access the doors they need and spawn at their office, otherwise they have to ahelp or get crafty to get back into where they need to go.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->

## Changelog

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: CLs should start with proper access and start location now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->