### PR TITLE
Fixes M2C users being stunned by crushers for an absurd amount of time

### DIFF
--- a/code/modules/cm_marines/smartgun_mount.dm
+++ b/code/modules/cm_marines/smartgun_mount.dm
@@ -7,7 +7,7 @@
 #define M2C_HIGH_COOLDOWN_ROLL 0.45
 #define M2C_PASSIVE_COOLDOWN_AMOUNT 4
 #define M2C_OVERHEAT_OVERLAY 14
-#define M2C_CRUSHER_STUN 3 SECONDS
+#define M2C_CRUSHER_STUN 3 //amount in ticks (roughly 3 seconds)
 
 //////////////////////////////////////////////////////////////
 //Mounted MG, Replacment for the current jury rig code.


### PR DESCRIPTION
## About The Pull Request

M2C users were being knocked down by a crusher charging at them for a stupidly long time, so long it takes at least 20 or so shakes from a marine to get up from. Turns out the define in charge of regulating how long you're knocked down for is measured in seconds, while being used in a knockdown proc, which meant you'd be stunned for a total of 300 ticks. This PR changes the define to be measured in ticks instead so you're stunned for the actual intended amount of time.

## Why It's Good For The Game

bug bad fix good coder social credit score go up

## Changelog

:cl:Kraso
fix: Fixes being knocked down for several minutes by being rammed by a crusher while manning a M2C. You should now be knocked down for the appropriate time of 3 seconds.
/:cl:
