### PR TITLE
Putting bursted bodies in morphers also disrupts grabs

### DIFF
--- a/code/modules/cm_aliens/structures/special/egg_morpher.dm
+++ b/code/modules/cm_aliens/structures/special/egg_morpher.dm
@@ -86,6 +86,7 @@
 			captured_mob.pixel_x = 16
 			captured_mob.pixel_y = 16
 			vis_contents += captured_mob
+			user.stop_pulling() // Automatically remove the grab
 			huggers_to_grow += huggers_per_corpse
 			update_icon()
 		return


### PR DESCRIPTION
## About The Pull Request

Epicness's PR fixed pools not disrupting grab, however it is still possible to dupe with an eggmorpher. This PR adds the piece of code necessary to fix it.

## Why It's Good For The Game

No dupes, consistency. Also, he forgot to add it to morpher so someone had to add it to morpher.
## Changelog

:cl:
fix: Pooling bodies into an eggmorpher disrupts grabs automatically
/:cl:
