### PR TITLE
Re-opens an MR fixing mini flamer dealing damage to Ravagers/Queens as well as their ammo type.

### DIFF
--- a/code/__DEFINES/conflict.dm
+++ b/code/__DEFINES/conflict.dm
@@ -36,8 +36,9 @@
 #define AMMO_NO_DEFLECT			(1<<21)
 ///Can only hit people with criminal status
 #define AMMO_MP					(1<<22)
+#define AMMO_FLAME				(1<<23) // Handles sentry flamers glob
 /// Can BE people with it
-#define AMMO_HIGHIMPACT			(1<<23)
+#define AMMO_HIGHIMPACT			(1<<24)
 
 
 //Gun defines for gun related thing. More in the projectile folder.

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -2957,7 +2957,7 @@
 	flamer_reagent_type = /datum/reagent/napalm/blue
 
 /datum/ammo/flamethrower/sentry_flamer
-	flags_ammo_behavior = AMMO_IGNORE_ARMOR|AMMO_IGNORE_COVER
+	flags_ammo_behavior = AMMO_IGNORE_ARMOR|AMMO_IGNORE_COVER|AMMO_FLAME
 	flamer_reagent_type = /datum/reagent/napalm/blue
 
 	accuracy = HIT_ACCURACY_TIER_8
@@ -2996,7 +2996,7 @@
 /datum/ammo/flamethrower/sentry_flamer/mini/drop_flame(turf/T, datum/cause_data/cause_data)
 	if(!istype(T))
 		return
-	var/datum/reagent/napalm/R = new()
+	var/datum/reagent/napalm/ut/R = new()
 	R.durationfire = BURN_TIME_INSTANT
 	new /obj/flamer_fire(T, cause_data, R, 0)
 

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -961,6 +961,10 @@
 
 	var/ammo_flags = P.ammo.flags_ammo_behavior | P.projectile_override_flags
 
+	if((ammo_flags & AMMO_FLAME) && (src.caste.fire_immunity & FIRE_IMMUNITY_NO_IGNITE|FIRE_IMMUNITY_NO_DAMAGE))
+		to_chat(src, SPAN_AVOIDHARM("You shrug off the glob of flame."))
+		return
+
 	if(isXeno(P.firer))
 		var/mob/living/carbon/Xenomorph/X = P.firer
 		if(X.can_not_harm(src))


### PR DESCRIPTION
## About The Pull Request

This PR reopens an old MR that was closed, and which fixed Mini Flamer sentries dealing damage to queens/ravagers/fire immune xenos. The ammo type was also incorrect, and this PR fixes it. All credits to TEDGamer, the MR which he made is this: https://gitlab.com/cmdevs/colonial-warfare/-/merge_requests/2386

## Why It's Good For The Game

Queens/ravagers being damaged by fire when they are immune to it makes no sense, even if it's a projectile. Even the Flamer Nozzle attachment projectile doesn't do damage to queens/ravagers. This is an unintended bug and this PR addresses it.

## Changelog
:cl:
fix: Mini-Flamer sentries no longer deal unintended damage to queens/ravagers/fire immune xenos
fix: Mini-Flamer sentries actually use the correct flame type.
/:cl:

