### PR TITLE
Added beaker and bottle UI buttons for Setting Transfer Amount, added more Bluespace Beaker transfer options

### DIFF
--- a/code/game/objects/items/reagent_containers/glass.dm
+++ b/code/game/objects/items/reagent_containers/glass.dm
@@ -343,7 +343,7 @@
 	matter = list("glass" = 10000)
 	volume = 300
 	amount_per_transfer_from_this = 10
-	possible_transfer_amounts = list(5,10,15,25,30,60,120,300)
+	possible_transfer_amounts = list(5,10,15,20,25,30,40,60,80,120,300)
 
 
 /obj/item/reagent_container/glass/beaker/vial

--- a/code/game/objects/items/reagent_containers/glass.dm
+++ b/code/game/objects/items/reagent_containers/glass.dm
@@ -191,6 +191,7 @@
 	item_state = "beaker"
 	matter = list("glass" = 500)
 	attack_speed = 4
+	actions_types = list(/datum/action/item_action/glass_beaker/set_transfer_amount)
 
 /obj/item/reagent_container/glass/beaker/on_reagent_change()
 	update_icon()
@@ -229,6 +230,21 @@
 	if(!is_open_container())
 		var/image/lid = image(icon, src, "lid_[initial(icon_state)]")
 		overlays += lid
+
+
+/datum/action/item_action/glass_beaker/set_transfer_amount
+
+/datum/action/item_action/glass_beaker/set_transfer_amount/New(var/mob/living/user, var/obj/item/holder)
+	..()
+	name = "Set Transfer Amount"
+	button.name = name
+	button.overlays.Cut()
+	var/image/IMG = image('icons/obj/items/chemistry.dmi', button, "beaker")
+	button.overlays += IMG
+
+/datum/action/item_action/glass_beaker/set_transfer_amount/action_activate()
+	var/obj/item/reagent_container/glass/beaker/beak = holder_item
+	beak.set_APTFT()
 
 /obj/item/reagent_container/glass/minitank
 	name = "MS-11 Smart Refill Tank"

--- a/code/game/objects/items/reagent_containers/glass.dm
+++ b/code/game/objects/items/reagent_containers/glass.dm
@@ -191,7 +191,6 @@
 	item_state = "beaker"
 	matter = list("glass" = 500)
 	attack_speed = 4
-	actions_types = list(/datum/action/item_action/glass_beaker/set_transfer_amount)
 
 /obj/item/reagent_container/glass/beaker/on_reagent_change()
 	update_icon()
@@ -230,21 +229,6 @@
 	if(!is_open_container())
 		var/image/lid = image(icon, src, "lid_[initial(icon_state)]")
 		overlays += lid
-
-
-/datum/action/item_action/glass_beaker/set_transfer_amount
-
-/datum/action/item_action/glass_beaker/set_transfer_amount/New(var/mob/living/user, var/obj/item/holder)
-	..()
-	name = "Set Transfer Amount"
-	button.name = name
-	button.overlays.Cut()
-	var/image/IMG = image('icons/obj/items/chemistry.dmi', button, "beaker")
-	button.overlays += IMG
-
-/datum/action/item_action/glass_beaker/set_transfer_amount/action_activate()
-	var/obj/item/reagent_container/glass/beaker/beak = holder_item
-	beak.set_APTFT()
 
 /obj/item/reagent_container/glass/minitank
 	name = "MS-11 Smart Refill Tank"

--- a/code/game/objects/items/reagent_containers/glass/bottle.dm
+++ b/code/game/objects/items/reagent_containers/glass/bottle.dm
@@ -11,6 +11,7 @@
 	flags_atom = FPRINT|OPENCONTAINER
 	volume = 60
 	attack_speed = 4
+	actions_types = list(/datum/action/item_action/glass_bottle/set_transfer_amount)
 
 /obj/item/reagent_container/glass/bottle/on_reagent_change()
 	update_icon()
@@ -54,6 +55,23 @@
 	if (!is_open_container())
 		var/image/lid = image(icon, src, "lid_bottle")
 		overlays += lid
+
+
+
+/datum/action/item_action/glass_bottle/set_transfer_amount
+
+/datum/action/item_action/glass_bottle/set_transfer_amount/New(var/mob/living/user, var/obj/item/holder)
+	..()
+	name = "Set Transfer Amount"
+	button.name = name
+	button.overlays.Cut()
+	var/image/IMG = image('icons/obj/items/chemistry.dmi', button, "bottle-1")
+	button.overlays += IMG
+
+/datum/action/item_action/glass_bottle/set_transfer_amount/action_activate()
+	var/obj/item/reagent_container/glass/bottle/bot = holder_item
+	bot.set_APTFT()
+
 
 /obj/item/reagent_container/glass/bottle/inaprovaline
 	name = "\improper Inaprovaline bottle"

--- a/code/game/objects/items/reagent_containers/glass/bottle.dm
+++ b/code/game/objects/items/reagent_containers/glass/bottle.dm
@@ -11,7 +11,6 @@
 	flags_atom = FPRINT|OPENCONTAINER
 	volume = 60
 	attack_speed = 4
-	actions_types = list(/datum/action/item_action/glass_bottle/set_transfer_amount)
 
 /obj/item/reagent_container/glass/bottle/on_reagent_change()
 	update_icon()
@@ -55,23 +54,6 @@
 	if (!is_open_container())
 		var/image/lid = image(icon, src, "lid_bottle")
 		overlays += lid
-
-
-
-/datum/action/item_action/glass_bottle/set_transfer_amount
-
-/datum/action/item_action/glass_bottle/set_transfer_amount/New(var/mob/living/user, var/obj/item/holder)
-	..()
-	name = "Set Transfer Amount"
-	button.name = name
-	button.overlays.Cut()
-	var/image/IMG = image('icons/obj/items/chemistry.dmi', button, "bottle-1")
-	button.overlays += IMG
-
-/datum/action/item_action/glass_bottle/set_transfer_amount/action_activate()
-	var/obj/item/reagent_container/glass/bottle/bot = holder_item
-	bot.set_APTFT()
-
 
 /obj/item/reagent_container/glass/bottle/inaprovaline
 	name = "\improper Inaprovaline bottle"

--- a/code/game/objects/items/reagent_containers/reagent_container.dm
+++ b/code/game/objects/items/reagent_containers/reagent_container.dm
@@ -15,6 +15,14 @@
 	var/reagent_desc_override = FALSE //does it have a special examining mechanic that should override the normal /reagent_containers examine proc?
 	actions_types = list(/datum/action/item_action/reagent_container/set_transfer_amount)
 
+/obj/item/reagent_container/Initialize()
+	if(!possible_transfer_amounts)
+		actions_types -= /datum/action/item_action/reagent_container/set_transfer_amount
+	. = ..()
+	if(!possible_transfer_amounts)
+		verbs -= /obj/item/reagent_container/verb/set_APTFT //which objects actually uses it?
+	create_reagents(volume)
+
 /obj/item/reagent_container/get_examine_text(mob/user)
 	. = ..()
 	var/reagent_info = show_reagent_info(user)
@@ -104,6 +112,6 @@
 	var/image/IMG = image(holder_item.icon, button, holder_item.icon_state)
 	button.overlays += IMG
 
-/datum/action/item_action/glass_bottle/set_transfer_amount/action_activate()
+/datum/action/item_action/reagent_container/set_transfer_amount/action_activate()
 	var/obj/item/reagent_container/cont = holder_item
 	cont.set_APTFT()

--- a/code/game/objects/items/reagent_containers/reagent_container.dm
+++ b/code/game/objects/items/reagent_containers/reagent_container.dm
@@ -13,6 +13,7 @@
 	var/volume = 30
 	var/transparent = FALSE //can we see what's in it?
 	var/reagent_desc_override = FALSE //does it have a special examining mechanic that should override the normal /reagent_containers examine proc?
+	actions_types = list(/datum/action/item_action/reagent_container/set_transfer_amount)
 
 /obj/item/reagent_container/get_examine_text(mob/user)
 	. = ..()
@@ -91,3 +92,18 @@
 			. += "; [R.name]([R.volume]u)"
 	else
 		. = "No reagents"
+
+
+/datum/action/item_action/reagent_container/set_transfer_amount
+
+/datum/action/item_action/reagent_container/set_transfer_amount/New(var/mob/living/user, var/obj/item/holder)
+	..()
+	name = "Set Transfer Amount"
+	button.name = name
+	button.overlays.Cut()
+	var/image/IMG = image(holder_item.icon, button, holder_item.icon_state)
+	button.overlays += IMG
+
+/datum/action/item_action/glass_bottle/set_transfer_amount/action_activate()
+	var/obj/item/reagent_container/cont = holder_item
+	cont.set_APTFT()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

I got a bit frustrated with chemistry and finally did an old fix I wanted to implement - adding UI buttons to let you set transfer amounts! Now whenever you hold a bottle or a beaker you get the UI button to set the desired transfer rates. Very useful for chemistry when you need to do 60u, 40u, etc.

![Transfer amount icons](https://user-images.githubusercontent.com/964559/199195906-41341c31-8897-41a5-8c35-efe82940d25c.png)
(note the last two buttons)

Code is similar but not the same - bottles and beakers have different UI sprites, and also didn't want to make it a generic thing for all containers since it matters a lot less for other containers to be constantly adjusting those.

Also added some extra options for Bluespace Beaker for transfer rates since I ran into a situation where I needed to do 40 and I couldn't.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It improves the life of doctors / nurses / whoever does chemistry on the regular. Way faster to click an UI button than to right click and select the option.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->

## Changelog

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added UI buttons that will let you Set Transfer Amounts all reagent containers (bottles, beakers, etc.). This should make chemistry work a bit more enjoyable.
qol: Added extra transfer amounts for Bluespace Beakers - 20, 40, 80, for those transfer edge cases.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
