### PR TITLE
Groundside Surgery Nerf

### DIFF
--- a/code/datums/effects/bleeding.dm
+++ b/code/datums/effects/bleeding.dm
@@ -77,7 +77,7 @@
 
 	return TRUE
 
-			
+
 /datum/effects/bleeding/internal
 	effect_name = "internal bleeding"
 	flags = INF_DURATION | NO_PROCESS_ON_DEATH | DEL_ON_UNDEFIBBABLE
@@ -93,10 +93,6 @@
 
 	if(affected_mob.bodytemperature < T0C && (affected_mob.reagents && affected_mob.reagents.get_reagent_amount("cryoxadone") || affected_mob.reagents.get_reagent_amount("clonexadone")))
 		blood_loss -= CRYO_BLOOD_REDUCTION
-
-	var/bicaridine = affected_mob.reagents?.get_reagent_amount("bicaridine")
-	if(bicaridine > REAGENTS_OVERDOSE && affected_mob.getBruteLoss() <= 0)
-		blood_loss -= BICAOD_BLOOD_REDUCTION
 
 	if(affected_mob.reagents) // Annoying QC check
 		if(affected_mob.reagents.get_reagent_amount("thwei"))

--- a/code/game/objects/items/devices/autopsy_scanner.dm
+++ b/code/game/objects/items/devices/autopsy_scanner.dm
@@ -179,7 +179,7 @@
 		return
 
 	var/table
-	for(var/obj/surface in get_turf(M)) //An autopsy needs a surgery table, or a field surgery bed.
+	for(var/obj/surface in get_turf(M)) //An autopsy needs a surgery table
 		if(surface.surgery_duration_multiplier <= SURGERY_SURFACE_MULT_ADEQUATE)
 			table = TRUE
 			break

--- a/code/game/objects/items/reagent_containers/pill.dm
+++ b/code/game/objects/items/reagent_containers/pill.dm
@@ -232,7 +232,7 @@
 
 /obj/item/reagent_container/pill/peridaxon
 	pill_desc = "A Peridaxon pill. Temporarily halts the effects of internal organ damage."
-	pill_initial_reagents = list("peridaxon" = 7)
+	pill_initial_reagents = list("peridaxon" = 5)
 	pill_icon_class = "peri"
 
 /obj/item/reagent_container/pill/imidazoline

--- a/code/game/objects/items/reagent_containers/pill.dm
+++ b/code/game/objects/items/reagent_containers/pill.dm
@@ -229,6 +229,7 @@
 	pill_desc = "A Russian Red pill. A very dangerous radiation-countering substance."
 	pill_initial_reagents = list("russianred" = 10)
 	pill_icon_class = "spac"
+
 /obj/item/reagent_container/pill/peridaxon
 	pill_desc = "A Peridaxon pill. Temporarily halts the effects of internal organ damage."
 	pill_initial_reagents = list("peridaxon" = 7)

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -169,4 +169,3 @@
 /obj/structure/closet/secure_closet/surgical/Initialize()
 	. = ..()
 	new /obj/item/storage/surgical_tray(src)
-	new /obj/item/roller/surgical(src)

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -265,28 +265,6 @@ obj/structure/bed/Destroy()
 	R.add_fingerprint(user)
 	QDEL_NULL(held)
 
-//////////////////////////////////////////////
-//			PORTABLE SURGICAL BED			//
-//////////////////////////////////////////////
-
-/obj/structure/bed/portable_surgery
-	name = "portable surgical bed"
-	desc = "A collapsible surgical bed. It's not perfect, but it's the best you'll get short of an actual surgical table."
-	icon = 'icons/obj/structures/rollerbed.dmi'
-	icon_state = "surgical_down"
-	buckling_y = 2
-	foldabletype = /obj/item/roller/surgical
-	base_bed_icon = "surgical"
-	accepts_bodybag = FALSE
-	surgery_duration_multiplier = SURGERY_SURFACE_MULT_ADEQUATE
-
-/obj/item/roller/surgical
-	name = "portable surgical bed"
-	desc = "A collapsed surgical bed that can be carried around."
-	icon_state = "surgical_folded"
-	rollertype = /obj/structure/bed/portable_surgery
-	matter = list("plastic" = 6000)
-
 ////////////////////////////////////////////
 			//MEDEVAC STRETCHER
 //////////////////////////////////////////////

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -822,7 +822,7 @@ GLOBAL_LIST_INIT(allowed_helmet_items, list(
 	name = "\improper Dutch's Dozen cap"
 	desc = "A protective cap worn by some seriously experienced mercs."
 	icon_state = "dutch_cap"
-	flags_inventory = BLOCKSHARPOBJ
+	flags_inventory = NO_FLAGS
 	flags_inv_hide = NO_FLAGS
 	flags_marine_helmet = NO_FLAGS
 
@@ -830,7 +830,7 @@ GLOBAL_LIST_INIT(allowed_helmet_items, list(
 	name = "\improper Dutch's Dozen band"
 	desc = "A protective band worn by some seriously experienced mercs."
 	icon_state = "dutch_band"
-	flags_inventory = BLOCKSHARPOBJ
+	flags_inventory = NO_FLAGS
 	flags_inv_hide = NO_FLAGS
 	flags_marine_helmet = NO_FLAGS
 
@@ -901,7 +901,7 @@ GLOBAL_LIST_INIT(allowed_helmet_items, list(
 	armor_internaldamage = CLOTHING_ARMOR_MEDIUM
 	flags_cold_protection = BODY_FLAG_HEAD
 	min_cold_protection_temperature = ICE_PLANET_min_cold_protection_temperature
-	flags_inventory = BLOCKSHARPOBJ
+	flags_inventory = NO_FLAGS
 	flags_inv_hide = HIDEEARS
 
 /obj/item/clothing/head/uppcap/civi
@@ -975,7 +975,7 @@ obj/item/clothing/head/helmet/marine/veteran/van_bandolier
 	armor_bio = CLOTHING_ARMOR_MEDIUMLOW
 	armor_rad = CLOTHING_ARMOR_MEDIUMLOW
 	armor_internaldamage = CLOTHING_ARMOR_MEDIUM
-	flags_inventory = BLOCKSHARPOBJ
+	flags_inventory = NO_FLAGS
 	flags_inv_hide = HIDEEARS|HIDETOPHAIR
 	item_icons = list(
 		WEAR_HEAD = 'icons/mob/humans/onmob/head_1.dmi'
@@ -998,7 +998,7 @@ obj/item/clothing/head/helmet/marine/veteran/van_bandolier
 	armor_bio = CLOTHING_ARMOR_MEDIUMLOW
 	armor_rad = CLOTHING_ARMOR_MEDIUMLOW
 	armor_internaldamage = CLOTHING_ARMOR_LOW
-	flags_inventory = BLOCKSHARPOBJ
+	flags_inventory = NO_FLAGS
 	flags_inv_hide = HIDEEARS|HIDETOPHAIR
 	item_icons = list(
 		WEAR_HEAD = 'icons/mob/humans/onmob/head_1.dmi'
@@ -1016,7 +1016,6 @@ obj/item/clothing/head/helmet/marine/veteran/van_bandolier
 	switch(icon_state)
 		if("s_skullcapm")
 			desc = "A hood meant to protect the wearer from both the cold and the guise of the enemy in the tundra."
-			flags_inventory = BLOCKSHARPOBJ
 			flags_inv_hide = HIDEEARS|HIDEALLHAIR
 
 //===========================//HELGHAST - MERCENARY\\================================\\

--- a/code/modules/clothing/suits/marine_armor.dm
+++ b/code/modules/clothing/suits/marine_armor.dm
@@ -78,6 +78,7 @@ var/list/squad_colors_chat = list(rgb(230,125,125), rgb(255,230,80), rgb(255,150
 		WEAR_JACKET = 'icons/mob/humans/onmob/suit_1.dmi'
 	)
 	flags_atom = FPRINT|CONDUCT
+	flags_inventory = BLOCKSHARPOBJ
 	flags_armor_protection = BODY_FLAG_CHEST|BODY_FLAG_GROIN|BODY_FLAG_ARMS|BODY_FLAG_LEGS
 	flags_cold_protection = BODY_FLAG_CHEST|BODY_FLAG_GROIN|BODY_FLAG_ARMS|BODY_FLAG_LEGS
 	flags_heat_protection = BODY_FLAG_CHEST|BODY_FLAG_GROIN|BODY_FLAG_ARMS|BODY_FLAG_LEGS
@@ -134,7 +135,7 @@ var/list/squad_colors_chat = list(rgb(230,125,125), rgb(255,230,80), rgb(255,150
 /obj/item/clothing/suit/storage/marine/Initialize()
 	. = ..()
 	if(!(flags_atom & NO_NAME_OVERRIDE))
-		name = "[specialty]"
+		name = "\improper [specialty]"
 		if(SSmapping.configs[GROUND_MAP].environment_traits[MAP_COLD])
 			name += " snow armor" //Leave marine out so that armors don't have to have "Marine" appended (see: generals).
 		else
@@ -415,7 +416,7 @@ var/list/squad_colors_chat = list(rgb(230,125,125), rgb(255,230,80), rgb(255,150
 	armor_bullet = CLOTHING_ARMOR_HIGH
 	storage_slots = 3
 	flags_atom = NO_SNOW_TYPE
-	flags_inventory = SMARTGUN_HARNESS
+	flags_inventory = BLOCKSHARPOBJ|SMARTGUN_HARNESS
 	uniform_restricted = list(/obj/item/clothing/under/marine, /obj/item/clothing/under/rank/ro_suit)
 	specialty = "M3 pattern captain"
 	item_state_slots = list(WEAR_JACKET = "co_officer")
@@ -441,7 +442,7 @@ var/list/squad_colors_chat = list(rgb(230,125,125), rgb(255,230,80), rgb(255,150
 	armor_rad = CLOTHING_ARMOR_MEDIUM
 	storage_slots = 2
 	slowdown = SLOWDOWN_ARMOR_LIGHT
-	flags_inventory = SMARTGUN_HARNESS
+	flags_inventory = BLOCKSHARPOBJ|SMARTGUN_HARNESS
 	allowed = list(/obj/item/tank/emergency_oxygen,
 					/obj/item/device/flashlight,
 					/obj/item/ammo_magazine,
@@ -578,7 +579,7 @@ var/list/squad_colors_chat = list(rgb(230,125,125), rgb(255,230,80), rgb(255,150
 	armor_rad = CLOTHING_ARMOR_MEDIUMHIGH
 	armor_internaldamage = CLOTHING_ARMOR_MEDIUMHIGH
 	storage_slots = 2
-	flags_inventory = BLOCK_KNOCKDOWN
+	flags_inventory = BLOCKSHARPOBJ|BLOCK_KNOCKDOWN
 	flags_armor_protection = BODY_FLAG_CHEST|BODY_FLAG_GROIN|BODY_FLAG_ARMS|BODY_FLAG_LEGS|BODY_FLAG_FEET
 	flags_cold_protection = BODY_FLAG_CHEST|BODY_FLAG_GROIN|BODY_FLAG_ARMS|BODY_FLAG_LEGS|BODY_FLAG_FEET
 	flags_heat_protection = BODY_FLAG_CHEST|BODY_FLAG_GROIN|BODY_FLAG_ARMS|BODY_FLAG_LEGS|BODY_FLAG_FEET
@@ -619,7 +620,7 @@ var/list/squad_colors_chat = list(rgb(230,125,125), rgb(255,230,80), rgb(255,150
 	armor_bomb = CLOTHING_ARMOR_VERYHIGH
 	armor_bio = CLOTHING_ARMOR_MEDIUMLOW
 	armor_internaldamage = CLOTHING_ARMOR_MEDIUMHIGH
-	flags_inventory = BLOCK_KNOCKDOWN
+	flags_inventory = BLOCKSHARPOBJ|BLOCK_KNOCKDOWN
 	flags_item = MOB_LOCK_ON_EQUIP|NO_CRYO_STORE
 	flags_armor_protection = BODY_FLAG_CHEST|BODY_FLAG_GROIN|BODY_FLAG_ARMS|BODY_FLAG_LEGS|BODY_FLAG_FEET
 	flags_cold_protection = BODY_FLAG_CHEST|BODY_FLAG_GROIN|BODY_FLAG_ARMS|BODY_FLAG_LEGS|BODY_FLAG_FEET
@@ -1043,7 +1044,6 @@ var/list/squad_colors_chat = list(rgb(230,125,125), rgb(255,230,80), rgb(255,150
 	armor_bomb = CLOTHING_ARMOR_MEDIUM
 	armor_rad = CLOTHING_ARMOR_MEDIUM
 	armor_internaldamage = CLOTHING_ARMOR_MEDIUM
-	flags_inventory = BLOCKSHARPOBJ
 	flags_inv_hide = HIDELOWHAIR
 	item_state_slots = list(WEAR_JACKET = "pmc_sniper")
 
@@ -1071,7 +1071,7 @@ var/list/squad_colors_chat = list(rgb(230,125,125), rgb(255,230,80), rgb(255,150
 	name = "\improper PMC gunner armor"
 	desc = "A modification of the standard Armat Systems M3 armor. Hooked up with harnesses and straps allowing the user to carry an M56 Smartgun."
 	icon_state = "heavy_armor"
-	flags_inventory = BLOCK_KNOCKDOWN|SMARTGUN_HARNESS
+	flags_inventory = BLOCKSHARPOBJ|BLOCK_KNOCKDOWN|SMARTGUN_HARNESS
 	flags_atom = NO_SNOW_TYPE|NO_NAME_OVERRIDE
 	armor_bullet = CLOTHING_ARMOR_MEDIUMHIGH
 	armor_laser = CLOTHING_ARMOR_MEDIUMLOW
@@ -1110,7 +1110,7 @@ var/list/squad_colors_chat = list(rgb(230,125,125), rgb(255,230,80), rgb(255,150
 	armor_bomb = CLOTHING_ARMOR_VERYHIGH
 	armor_rad = CLOTHING_ARMOR_MEDIUMHIGH
 	armor_internaldamage = CLOTHING_ARMOR_MEDIUMHIGH
-	flags_inventory = BLOCK_KNOCKDOWN
+	flags_inventory = BLOCKSHARPOBJ|BLOCK_KNOCKDOWN
 	flags_armor_protection = BODY_FLAG_CHEST|BODY_FLAG_GROIN|BODY_FLAG_ARMS|BODY_FLAG_LEGS|BODY_FLAG_FEET
 	uniform_restricted = list(/obj/item/clothing/under/marine/veteran/PMC/commando)
 	item_state_slots = list(WEAR_JACKET = "commando_armor")
@@ -1235,7 +1235,7 @@ var/list/squad_colors_chat = list(rgb(230,125,125), rgb(255,230,80), rgb(255,150
 	desc = "An extremely heavy-duty set of body armor in service with the UPP military, the UH7 (Union Heavy MK7) is known for having powerful ballistic protection, alongside a noticeable neck guard, fortified in order to allow the wearer to endure the stresses of the bulky helmet."
 	icon_state = "upp_armor_heavy"
 	slowdown = SLOWDOWN_ARMOR_HEAVY
-	flags_inventory = BLOCK_KNOCKDOWN
+	flags_inventory = BLOCKSHARPOBJ|BLOCK_KNOCKDOWN
 	flags_armor_protection = BODY_FLAG_ALL_BUT_HEAD
 	armor_melee = CLOTHING_ARMOR_MEDIUMHIGH
 	armor_bullet = CLOTHING_ARMOR_HIGHPLUS
@@ -1410,7 +1410,7 @@ var/list/squad_colors_chat = list(rgb(230,125,125), rgb(255,230,80), rgb(255,150
 /obj/item/clothing/suit/storage/militia/smartgun
 	name = "colonial militia harness"
 	desc = "The hauberk of a colonist militia member, created from boiled leather and some modern armored plates. While not the most powerful form of armor, and primitive compared to most modern suits of armor, it gives the wearer almost perfect mobility, which suits the needs of the local colonists. It is also quick to don, easy to hide, and cheap to produce in large workshops. This one has straps interweaved with the plates, that allow the user to fire a captured smartgun, if a bit uncomfortably."
-	flags_inventory = SMARTGUN_HARNESS
+	flags_inventory = BLOCKSHARPOBJ|SMARTGUN_HARNESS
 
 /obj/item/clothing/suit/storage/CMB
 	name = "\improper CMB jacket"
@@ -1466,7 +1466,7 @@ var/list/squad_colors_chat = list(rgb(230,125,125), rgb(255,230,80), rgb(255,150
 	name = "\improper K12 ceramic plated armor"
 	desc = "A set of grey, heavy ceramic armor with dark blue highlights. It is the standard uniform of an unknown mercenary group working in the sector."
 	icon_state = "mercenary_heavy_armor"
-	flags_inventory = BLOCK_KNOCKDOWN
+	flags_inventory = BLOCKSHARPOBJ|BLOCK_KNOCKDOWN
 	armor_melee = CLOTHING_ARMOR_VERYHIGH
 	armor_bullet = CLOTHING_ARMOR_VERYHIGH
 	armor_energy = CLOTHING_ARMOR_MEDIUMLOW

--- a/code/modules/gear_presets/clf.dm
+++ b/code/modules/gear_presets/clf.dm
@@ -315,7 +315,6 @@
 	H.equip_to_slot_or_del(new /obj/item/explosive/grenade/custom/ied(H), WEAR_IN_BACK)
 	H.equip_to_slot_or_del(new /obj/item/storage/firstaid/adv(H), WEAR_IN_BACK)
 	H.equip_to_slot_or_del(new /obj/item/storage/firstaid/adv(H), WEAR_IN_BACK)
-	H.equip_to_slot_or_del(new /obj/structure/bed/portable_surgery(H), WEAR_IN_BACK)
 	H.equip_to_slot_or_del(new /obj/item/storage/box/packet/smoke, WEAR_IN_BACK)
 	H.equip_to_slot_or_del(new /obj/item/tool/surgery/surgical_line, WEAR_IN_BACK)
 	H.equip_to_slot_or_del(new /obj/item/tool/surgery/synthgraft, WEAR_IN_BACK)

--- a/code/modules/gear_presets/contractor.dm
+++ b/code/modules/gear_presets/contractor.dm
@@ -320,7 +320,6 @@
 	H.equip_to_slot_or_del(new /obj/item/device/defibrillator, WEAR_IN_BACK)
 	H.equip_to_slot_or_del(new /obj/item/storage/firstaid/adv, WEAR_IN_BACK)
 	H.equip_to_slot_or_del(new /obj/item/roller, WEAR_IN_BACK)
-	H.equip_to_slot_or_del(new /obj/item/roller/surgical, WEAR_IN_BACK)
 	H.equip_to_slot_or_del(new /obj/item/tool/surgery/synthgraft, WEAR_IN_BACK) //Line in vest.
 	H.equip_to_slot_or_del(new /obj/item/device/healthanalyzer, WEAR_IN_BACK)
 	H.equip_to_slot_or_del(new /obj/item/storage/box/packet/smoke, WEAR_IN_BACK)
@@ -436,7 +435,6 @@
 	H.equip_to_slot_or_del(new /obj/item/device/defibrillator, WEAR_IN_BACK) //1
 	H.equip_to_slot_or_del(new /obj/item/storage/firstaid/adv, WEAR_IN_BACK) //2
 	H.equip_to_slot_or_del(new /obj/item/roller, WEAR_IN_BACK)
-	H.equip_to_slot_or_del(new /obj/item/roller/surgical, WEAR_IN_BACK)
 	H.equip_to_slot_or_del(new /obj/item/storage/box/packet/smoke, WEAR_IN_BACK)
 	//face
 	H.equip_to_slot_or_del(new /obj/item/device/radio/headset/distress/contractor, WEAR_L_EAR)
@@ -715,7 +713,6 @@
 	H.equip_to_slot_or_del(new /obj/item/device/defibrillator, WEAR_IN_BACK)
 	H.equip_to_slot_or_del(new /obj/item/storage/firstaid/adv, WEAR_IN_BACK)
 	H.equip_to_slot_or_del(new /obj/item/roller, WEAR_IN_BACK)
-	H.equip_to_slot_or_del(new /obj/item/roller/surgical, WEAR_IN_BACK)
 	H.equip_to_slot_or_del(new /obj/item/tool/surgery/synthgraft, WEAR_IN_BACK) //Line in vest.
 	H.equip_to_slot_or_del(new /obj/item/device/healthanalyzer, WEAR_IN_BACK)
 	H.equip_to_slot_or_del(new /obj/item/storage/box/packet/smoke, WEAR_IN_BACK)
@@ -832,7 +829,6 @@
 	H.equip_to_slot_or_del(new /obj/item/device/defibrillator, WEAR_IN_BACK) //1
 	H.equip_to_slot_or_del(new /obj/item/storage/firstaid/adv, WEAR_IN_BACK) //2
 	H.equip_to_slot_or_del(new /obj/item/roller, WEAR_IN_BACK)
-	H.equip_to_slot_or_del(new /obj/item/roller/surgical, WEAR_IN_BACK)
 	H.equip_to_slot_or_del(new /obj/item/storage/box/packet/smoke, WEAR_IN_BACK)
 	//face
 	H.equip_to_slot_or_del(new /obj/item/device/radio/headset/distress/contractor, WEAR_L_EAR)

--- a/code/modules/gear_presets/other.dm
+++ b/code/modules/gear_presets/other.dm
@@ -194,7 +194,6 @@
 	H.equip_to_slot_or_del(new /obj/item/device/defibrillator, WEAR_IN_BACK)
 	H.equip_to_slot_or_del(new /obj/item/storage/firstaid/adv, WEAR_IN_BACK)
 	H.equip_to_slot_or_del(new /obj/item/roller, WEAR_IN_BACK)
-	H.equip_to_slot_or_del(new /obj/item/roller/surgical, WEAR_IN_BACK)
 	H.equip_to_slot_or_del(new /obj/item/device/healthanalyzer, WEAR_IN_BACK)
 	H.equip_to_slot_or_del(new /obj/item/tool/surgery/synthgraft, WEAR_IN_BACK) //Line is in vest.
 	spawn_merc_rifle(H)
@@ -449,7 +448,6 @@
 	H.equip_to_slot_or_del(new /obj/item/device/defibrillator/upgraded, WEAR_IN_BACK)
 	H.equip_to_slot_or_del(new /obj/item/storage/firstaid/adv, WEAR_IN_BACK)
 	H.equip_to_slot_or_del(new /obj/item/roller, WEAR_IN_BACK)
-	H.equip_to_slot_or_del(new /obj/item/roller/surgical, WEAR_IN_BACK)
 	H.equip_to_slot_or_del(new /obj/item/tool/surgery/synthgraft, WEAR_IN_BACK) //Line in vest.
 	H.equip_to_slot_or_del(new /obj/item/device/healthanalyzer, WEAR_IN_BACK)
 	H.equip_to_slot_or_del(new /obj/item/storage/box/packet/smoke, WEAR_IN_BACK)

--- a/code/modules/gear_presets/pmc.dm
+++ b/code/modules/gear_presets/pmc.dm
@@ -543,7 +543,6 @@
 	H.equip_to_slot_or_del(new /obj/item/storage/backpack/lightpack, WEAR_BACK)
 	H.equip_to_slot_or_del(new /obj/item/device/defibrillator, WEAR_IN_BACK)
 	H.equip_to_slot_or_del(new /obj/item/storage/firstaid/adv, WEAR_IN_BACK)
-	H.equip_to_slot_or_del(new /obj/item/roller/surgical, WEAR_IN_BACK)
 	H.equip_to_slot_or_del(new /obj/item/tool/surgery/synthgraft, WEAR_IN_BACK)
 
 	H.equip_to_slot_or_del(new /obj/item/storage/pouch/firstaid/ert, WEAR_L_STORE)

--- a/code/modules/gear_presets/upp.dm
+++ b/code/modules/gear_presets/upp.dm
@@ -2675,7 +2675,6 @@
 	H.equip_to_slot_or_del(new /obj/item/storage/backpack/lightpack/upp, WEAR_BACK)
 	H.equip_to_slot_or_del(new /obj/item/device/defibrillator, WEAR_IN_BACK)
 	H.equip_to_slot_or_del(new /obj/item/storage/firstaid/adv, WEAR_IN_BACK)
-	H.equip_to_slot_or_del(new /obj/item/roller/surgical, WEAR_IN_BACK)
 	H.equip_to_slot_or_del(new /obj/item/reagent_container/food/snacks/upp, WEAR_IN_BACK)
 	H.equip_to_slot_or_del(new /obj/item/reagent_container/food/snacks/upp, WEAR_IN_BACK)
 	H.equip_to_slot_or_del(new /obj/item/reagent_container/food/snacks/upp, WEAR_IN_BACK)

--- a/code/modules/mob/living/carbon/carbon_helpers.dm
+++ b/code/modules/mob/living/carbon/carbon_helpers.dm
@@ -70,3 +70,6 @@
 		if(!ear_deaf)
 			AdjustEarDeafness(2)
 		to_chat(src, SPAN_DANGER("The roar shakes your body to the core, freezing you in place!"))
+
+/mob/living/carbon/proc/get_sharp_obj_blocker(var/obj/limb/limb)
+	return null

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -76,6 +76,13 @@ Contains most of the procs that are called when a mob is attacked by something
 				protection += C.get_armor(type)
 	return protection
 
+/mob/living/carbon/human/get_sharp_obj_blocker(var/obj/limb/limb)
+	var/list/protective_gear = list(head, wear_mask, wear_suit, w_uniform, gloves, shoes, glasses)
+	for(var/obj/item/gear in protective_gear)
+		if(HAS_FLAG(gear.flags_armor_protection, limb.body_part) && HAS_FLAG(gear.flags_inventory, BLOCKSHARPOBJ))
+			return gear
+	return null
+
 /mob/living/carbon/human/proc/check_head_coverage()
 
 	var/list/body_parts = list(head, wear_mask, wear_suit ) /* w_uniform, gloves, shoes*/ //We don't need to check these for heads.

--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -404,11 +404,6 @@
 	unbuckle()
 	return XENO_NONCOMBAT_ACTION
 
-//Portable surgical bed. Ditto, though it's meltable.
-/obj/structure/bed/portable_surgery/attack_alien(mob/living/carbon/Xenomorph/M)
-	unbuckle()
-	return XENO_NONCOMBAT_ACTION
-
 //Smashing lights
 /obj/structure/machinery/light/attack_alien(mob/living/carbon/Xenomorph/M)
 	if(is_broken()) //Ignore if broken. Note that we can't use defines here

--- a/code/modules/reagents/chemistry_reagents/medical.dm
+++ b/code/modules/reagents/chemistry_reagents/medical.dm
@@ -240,9 +240,9 @@
 	description = "Prevents symptoms caused by damaged internal organs while in the bloodstream, but does not fix the organ damage. Recommended for patients awaiting internal organ surgery. Overdosing on peridaxon will cause internal tissue damage."
 	reagent_state = LIQUID
 	color = "#C845DC"
-	overdose = LOWH_REAGENTS_OVERDOSE
-	overdose_critical = LOWH_REAGENTS_OVERDOSE_CRITICAL
-	custom_metabolism = AMOUNT_PER_TIME(1, 40 SECONDS)
+	overdose = LOWM_REAGENTS_OVERDOSE
+	overdose_critical = LOWM_REAGENTS_OVERDOSE_CRITICAL
+	custom_metabolism = AMOUNT_PER_TIME(1, 20 SECONDS)
 	chemclass = CHEM_CLASS_COMMON
 	properties = list(PROPERTY_ORGANSTABILIZE = 4)
 

--- a/code/modules/surgery/bones.dm
+++ b/code/modules/surgery/bones.dm
@@ -7,7 +7,7 @@
 /datum/surgery/bone_repair
 	name = "Bone Repair Surgery"
 	possible_locs = ALL_LIMBS
-	invasiveness = list(SURGERY_DEPTH_SHALLOW)
+	invasiveness = list(SURGERY_DEPTH_SHALLOW, SURGERY_DEPTH_DEEP)
 	required_surgery_skill = SKILL_SURGERY_TRAINED
 	pain_reduction_required = PAIN_REDUCTION_HEAVY
 	steps = list(

--- a/code/modules/surgery/bones.dm
+++ b/code/modules/surgery/bones.dm
@@ -7,9 +7,10 @@
 /datum/surgery/bone_repair
 	name = "Bone Repair Surgery"
 	possible_locs = ALL_LIMBS
-	invasiveness = list(SURGERY_DEPTH_SHALLOW, SURGERY_DEPTH_DEEP)
+	invasiveness = list(SURGERY_DEPTH_SHALLOW)
 	required_surgery_skill = SKILL_SURGERY_TRAINED
 	pain_reduction_required = PAIN_REDUCTION_HEAVY
+	surgical_table_required = TRUE
 	steps = list(
 		/datum/surgery_step/mend_bones,
 		/datum/surgery_step/set_bones

--- a/code/modules/surgery/brainrepair.dm
+++ b/code/modules/surgery/brainrepair.dm
@@ -9,6 +9,7 @@
 	invasiveness = list(SURGERY_DEPTH_DEEP)
 	required_surgery_skill = SKILL_SURGERY_TRAINED
 	pain_reduction_required = PAIN_REDUCTION_MEDIUM //Brain doesn't actually have much in the way of nerve endings.
+	surgical_table_required = TRUE
 	steps = list(/datum/surgery_step/remove_bone_chips)
 	var/dmg_min = 0
 	var/dmg_max = BONECHIPS_MAX_DAMAGE
@@ -17,7 +18,7 @@
 	var/datum/internal_organ/brain/B = patient.internal_organs_by_name["brain"]
 	if(!B || B.damage <= dmg_min || B.robotic == ORGAN_ROBOT)
 		return FALSE
-	if(dmg_max && B.damage > dmg_max)	
+	if(dmg_max && B.damage > dmg_max)
 		return FALSE
 	return TRUE
 

--- a/code/modules/surgery/chestburster.dm
+++ b/code/modules/surgery/chestburster.dm
@@ -9,6 +9,7 @@
 	priority = SURGERY_PRIORITY_MAXIMUM
 	possible_locs = list("chest")
 	invasiveness = list(SURGERY_DEPTH_DEEP)
+	surgical_table_required = TRUE
 	pain_reduction_required = PAIN_REDUCTION_FULL
 	required_surgery_skill = SKILL_SURGERY_TRAINED
 	steps = list(

--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -475,6 +475,7 @@ datum/surgery_step/open_encased_step/skip_step_criteria(mob/user, mob/living/car
 	possible_locs = list("chest","head")
 	invasiveness = list(SURGERY_DEPTH_DEEP)
 	required_surgery_skill = SKILL_SURGERY_TRAINED
+	surgical_table_required = TRUE
 	steps = list(
 		/datum/surgery_step/close_encased_step,
 		/datum/surgery_step/open_encased_step,

--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -11,6 +11,7 @@
 	possible_locs = list("chest", "head")
 	invasiveness = list(SURGERY_DEPTH_DEEP)
 	pain_reduction_required = PAIN_REDUCTION_HEAVY
+	surgical_table_required = TRUE
 	required_surgery_skill = SKILL_SURGERY_TRAINED
 	steps = list(
 		/datum/surgery_step/create_cavity,

--- a/code/modules/surgery/internal_bleeding.dm
+++ b/code/modules/surgery/internal_bleeding.dm
@@ -8,6 +8,7 @@
 	possible_locs = ALL_LIMBS
 	invasiveness = list(SURGERY_DEPTH_SHALLOW, SURGERY_DEPTH_DEEP)
 	required_surgery_skill = SKILL_SURGERY_TRAINED
+	surgical_table_required = TRUE
 	pain_reduction_required = PAIN_REDUCTION_HEAVY
 	steps = list(/datum/surgery_step/fix_vein)
 

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -10,6 +10,7 @@ and organ transplant code which may come in handy in future but haven't been edi
 	possible_locs = list("chest")
 	invasiveness = list(SURGERY_DEPTH_DEEP)
 	required_surgery_skill = SKILL_SURGERY_TRAINED
+	surgical_table_required = TRUE
 	pain_reduction_required = PAIN_REDUCTION_HEAVY
 	steps = list(/datum/surgery_step/repair_organs)
 
@@ -80,7 +81,7 @@ datum/surgery_step/repair_organs/repeat_step_criteria(mob/user, mob/living/carbo
 			user.affected_message(target,
 				SPAN_NOTICE("You finish treating [target]'s damaged [I.name]."),
 				SPAN_NOTICE("[user] finishes treating your damaged [I.name]."),
-				SPAN_NOTICE("[user] finishes treating [target]'s damaged [I.name]."))		
+				SPAN_NOTICE("[user] finishes treating [target]'s damaged [I.name]."))
 
 			user.count_niche_stat(STATISTICS_NICHE_SURGERY_ORGAN_REPAIR)
 			I.rejuvenate()
@@ -92,8 +93,8 @@ datum/surgery_step/repair_organs/repeat_step_criteria(mob/user, mob/living/carbo
 		SPAN_WARNING("Your hand slips, bruising [target]'s organs and contaminating \his [surgery.affected_limb.cavity]!"),
 		SPAN_WARNING("[user]'s hand slips, bruising your organs and contaminating your [surgery.affected_limb.cavity]!"),
 		SPAN_WARNING("[user]'s hand slips, bruising [target]'s organs and contaminating \his [surgery.affected_limb.cavity]!"))
-	
-	var/dam_amt = 2	
+
+	var/dam_amt = 2
 	switch(tool_type)
 		if(/obj/item/stack/medical/bruise_pack)
 			dam_amt = 5

--- a/code/modules/surgery/surgery_procedure.dm
+++ b/code/modules/surgery/surgery_procedure.dm
@@ -47,6 +47,8 @@
 
 /datum/surgery/New(surgery_target, surgery_location, surgery_limb)
 	..()
+	if(surgical_table_required)
+		lying_required = TRUE
 	if(surgery_target)
 		target = surgery_target
 		if(surgery_location)

--- a/code/modules/surgery/surgery_procedure.dm
+++ b/code/modules/surgery/surgery_procedure.dm
@@ -27,6 +27,8 @@
 	var/requires_bodypart = TRUE
 	///Does the victim needs to be lying down? Surgeries that can be performed while standing aren't affected by the surface the patient is on.
 	var/lying_required = TRUE
+	/// Does the victim need to be on an actual surgical table?
+	var/surgical_table_required = FALSE
 	///Can the surgery be performed on yourself?
 	var/self_operable = FALSE
 	///How strong a level of anesthesia is needed to avoid risking pain causing a step to fail?

--- a/code/modules/surgery/surgery_steps.dm
+++ b/code/modules/surgery/surgery_steps.dm
@@ -75,6 +75,13 @@ datum/surgery_step/proc/repeat_step_criteria(mob/user, mob/living/carbon/target,
 	if(!extra_checks(user, target, target_zone, tool, surgery, repeating, skipped))
 		return FALSE // you must put the failure to_chat inside the checks
 
+	var/obj/limb/surgery_limb = target.get_limb(target_zone)
+	if(surgery_limb)
+		var/obj/item/blocker = target.get_sharp_obj_blocker(surgery_limb)
+		if(blocker)
+			to_chat(user, SPAN_WARNING("\The [blocker] \the [target] is wearing restricts your access to the surgical site, take it off!"))
+			return
+
 	surgery.step_in_progress = TRUE
 
 	var/step_duration = time
@@ -103,7 +110,7 @@ datum/surgery_step/proc/repeat_step_criteria(mob/user, mob/living/carbon/target,
 
 		step_duration *= surface_modifier
 
-		if(surgery.surgical_table_required && surface_modifier < SURGERY_SURFACE_MULT_IDEAL)
+		if(surgery.surgical_table_required && surface_modifier > SURGERY_SURFACE_MULT_IDEAL)
 			to_chat(user, SPAN_WARNING("You need a better surgical theatre for a procedure that's this invasive!"))
 			return
 

--- a/code/modules/surgery/surgery_steps.dm
+++ b/code/modules/surgery/surgery_steps.dm
@@ -82,8 +82,6 @@ datum/surgery_step/proc/repeat_step_criteria(mob/user, mob/living/carbon/target,
 			to_chat(user, SPAN_WARNING("\The [blocker] \the [target] is wearing restricts your access to the surgical site, take it off!"))
 			return
 
-	surgery.step_in_progress = TRUE
-
 	var/step_duration = time
 	var/self_surgery
 	var/tool_modifier
@@ -112,8 +110,9 @@ datum/surgery_step/proc/repeat_step_criteria(mob/user, mob/living/carbon/target,
 
 		if(surgery.surgical_table_required && surface_modifier > SURGERY_SURFACE_MULT_IDEAL)
 			to_chat(user, SPAN_WARNING("You need a better surgical theatre for a procedure that's this invasive!"))
-			return
+			return FALSE
 
+	surgery.step_in_progress = TRUE
 	var/try_to_fail
 	if(user.a_intent != INTENT_HELP)
 		try_to_fail = TRUE

--- a/code/modules/surgery/surgery_steps.dm
+++ b/code/modules/surgery/surgery_steps.dm
@@ -103,6 +103,10 @@ datum/surgery_step/proc/repeat_step_criteria(mob/user, mob/living/carbon/target,
 
 		step_duration *= surface_modifier
 
+		if(surface_modifier < SURGERY_SURFACE_MULT_IDEAL && (SURGERY_DEPTH_DEEP in surgery.invasiveness))
+			to_chat(user, SPAN_WARNING("You need a better surgical theatre for a procedure that's this invasive!"))
+			return
+
 	var/try_to_fail
 	if(user.a_intent != INTENT_HELP)
 		try_to_fail = TRUE

--- a/code/modules/surgery/surgery_steps.dm
+++ b/code/modules/surgery/surgery_steps.dm
@@ -103,7 +103,7 @@ datum/surgery_step/proc/repeat_step_criteria(mob/user, mob/living/carbon/target,
 
 		step_duration *= surface_modifier
 
-		if(surface_modifier < SURGERY_SURFACE_MULT_IDEAL && (SURGERY_DEPTH_DEEP in surgery.invasiveness))
+		if(surgery.surgical_table_required && surface_modifier < SURGERY_SURFACE_MULT_IDEAL)
 			to_chat(user, SPAN_WARNING("You need a better surgical theatre for a procedure that's this invasive!"))
 			return
 

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -18956,9 +18956,6 @@
 /area/almayer/hull/upper_hull)
 "biF" = (
 /obj/structure/surface/table/reinforced/prison,
-/obj/item/roller/surgical,
-/obj/item/roller/surgical,
-/obj/item/roller/surgical,
 /obj/item/reagent_container/spray/cleaner{
 	desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back.";
 	name = "Surgery Cleaner"

--- a/maps/map_files/Whiskey_Outpost_v2/Whiskey_Outpost_v2.dmm
+++ b/maps/map_files/Whiskey_Outpost_v2/Whiskey_Outpost_v2.dmm
@@ -5126,8 +5126,6 @@
 /obj/structure/machinery/light/small{
 	dir = 1
 	},
-/obj/item/roller/surgical,
-/obj/item/roller/surgical,
 /turf/open/floor{
 	dir = 1;
 	icon_state = "whitegreen";


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Removed portable surgical beds, made it so that surgeries with 'deep' level invasiveness require a proper surgical table. The list of surgeries requiring a proper surgical table is as follows:
 - Bone Repair Surgery
 - Brain Repair Surgery
 - Larva Removal
 - Clamping Bleeders
 - Closing Bone (Skull, Ribs)
 - Implant Surgery
 - Internal Bleeding Repair
 - Organ Rejuvenation Surgery (only organic)

Bicaridine ODs no longer heal internal bleeding.

Peridaxon overdose has been lowered to 10.5 units (down from 15), with 20 units (down from 25) being the critical overdose. Peridaxon now metabolizes at one unit every twenty seconds (up from one every fourty seconds). To accomodate the lowered overdose level, Peridaxon pills now only contain 5u of the chem.

Armor and items with the BLOCKSHARPOBJ flag now prevents surgery in the areas they cover.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Currently, marines don't really suffer from attrition from damage caused by xenos, simply because fixing a marine only takes two minutes when you can plop down a portable surgery bed wherever and fix them up instantly.

With the removal of portable surgery beds, marines are forced to secure the colony medbay or be forced to evac to shipside to get healed up.

With Bicard no longer healing internal bleeds, marines have another reason to go get surgery and get off the front. Additionally, squad medics have to note down where a marine took damage and guess where the internal bleeding could be, and notify the surgeon or synth about their guess.

With Peridaxon just being less useful, marines would be less eager to use it to stay in the fight, and rather use it to retreat to a place they can get healed up.

All of this serves to give xenos a way to cause marine attrition, give marines a reason to secure the colony medbay, and give shipside medbay a reason to exist again.

Lastly, being able to do surgery through armor just didn't make sense to me.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->

## Changelog

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Removed portable surgical beds.
balance: Invasive surgeries now need a proper surgical table.
balance: Bicaridine no longer repairs internal bleeding.
balance: Peridaxon overdose has been lowered to 10.5 units, and metabolizes at one unit every 20 seconds now. To accomodate the lowered overdose level, Peridaxon pills now only contain 5u of the chem.
balance: Armor now restricts access to surgical sites.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
