### PR TITLE
Machine Gun Bug Fix

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -166,7 +166,6 @@
 
 
 //Machine Guns (m56D, M2C)
-#define COMSIG_MOB_MG_ENTERED "mob_mg_enter"
 #define COMSIG_MOB_MG_EXIT "mob_mg_exit"
 
 // Return a nonzero value to cancel these actions

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -164,6 +164,11 @@
 
 #define COMSIG_MOB_POST_CLICK "mob_post_click"
 
+
+//Machine Guns (m56D, M2C)
+#define COMSIG_MOB_MG_ENTERED "mob_mg_enter"
+#define COMSIG_MOB_MG_EXIT "mob_mg_exit"
+
 // Return a nonzero value to cancel these actions
 #define COMSIG_BINOCULAR_ATTACK_SELF "binocular_attack_self"
 #define COMSIG_BINOCULAR_HANDLE_CLICK "binocular_handle_click"

--- a/code/modules/cm_marines/smartgun_mount.dm
+++ b/code/modules/cm_marines/smartgun_mount.dm
@@ -869,8 +869,6 @@
 /obj/structure/machinery/m56d_hmg/on_set_interaction(mob/user)
 	RegisterSignal(user, COMSIG_MOB_RESISTED, .proc/exit_interaction)
 	RegisterSignal(user, COMSIG_MOB_MG_EXIT, .proc/exit_interaction)
-
-	user.frozen = TRUE
 	flags_atom |= RELAY_CLICK
 	user.status_flags |= IMMOBILE_ACTION
 	user.visible_message(SPAN_NOTICE("[user] mans \the [src]."),SPAN_NOTICE("You man \the [src], locked and loaded!"))
@@ -886,6 +884,7 @@
 	flags_atom &= ~RELAY_CLICK
 	user.status_flags &= ~IMMOBILE_ACTION
 	user.visible_message(SPAN_NOTICE("[user] lets go of \the [src]."),SPAN_NOTICE("You let go of \the [src], letting the gun rest."))
+	user.unfreeze()
 	user.reset_view(null)
 	user.forceMove(get_step(src, reverse_direction(src.dir)))
 	user.setDir(dir) //set the direction of the player to the direction the gun is facing
@@ -895,14 +894,11 @@
 	if(operator == user) //We have no operator now
 		operator = null
 	remove_action(user, /datum/action/human_action/mg_exit)
-
 	UnregisterSignal(user, list(
 		COMSIG_MOB_MG_EXIT,
 		COMSIG_MOB_RESISTED
 	))
 
-	user.update_canmove()
-	user.unfreeze()
 
 /obj/structure/machinery/m56d_hmg/proc/update_pixels(var/mob/user, var/mounting = TRUE)
 	if(mounting)
@@ -1643,12 +1639,6 @@
 	update_pixels(user)
 	playsound(src.loc, 'sound/items/m56dauto_rotate.ogg', 25, 1)
 	to_chat(user, SPAN_NOTICE("You rotate [src], using the tripod to support your pivoting movement."))
-
-
-
-
-/obj/structure/machinery/m56d_hmg/auto/exit_interaction(mob/user)
-	..()
 
 
 /obj/structure/machinery/m56d_hmg/auto/proc/disable_interaction(mob/user, NewLoc, direction)

--- a/code/modules/cm_marines/smartgun_mount.dm
+++ b/code/modules/cm_marines/smartgun_mount.dm
@@ -613,6 +613,11 @@
 	update_health(severity)
 	return
 
+/obj/structure/machinery/m56d_hmg/proc/exit_interaction(mob/user)
+	SIGNAL_HANDLER
+
+	user.unset_interaction()
+
 /obj/structure/machinery/m56d_hmg/proc/update_damage_state()
 	var/health_percent = round(health/health_max * 100)
 	switch(health_percent)
@@ -827,40 +832,48 @@
 		return
 	var/mob/living/carbon/human/user = usr //this is us
 
-	if(!Adjacent(user))
-		return
-	src.add_fingerprint(usr)
-	if((over_object == user && (in_range(src, user) || locate(src) in user))) //Make sure its on ourselves
-		if(user.interactee == src)
-			user.unset_interaction()
-			user.visible_message("[icon2html(src, viewers(src))] [SPAN_NOTICE("[user] lets go of \the [src].")]", SPAN_NOTICE("You let go of \the [src]."))
-			return
-		if(operator) //If there is already a operator then they're manning it.
-			if(operator.interactee == null)
-				operator = null //this shouldn't happen, but just in case
-			else
-				to_chat(user, "Someone's already controlling it.")
-				return
+	var/user_turf = get_turf(user)
+
+	for(var/opp_dir in reverse_nearby_direction(src.dir))
+		if(get_step(src, opp_dir) == user_turf) //Players must be behind, or left or right of that back tile
+			src.add_fingerprint(usr)
+			if((over_object == user && (in_range(src, user) || locate(src) in user))) //Make sure its on ourselves
+				if(user.interactee == src)
+					user.unset_interaction()
+					user.visible_message("[icon2html(src, viewers(src))] [SPAN_NOTICE("[user] lets go of \the [src].")]", SPAN_NOTICE("You let go of \the [src]."))
+					return
+				if(operator) //If there is already a operator then they're manning it.
+					if(operator.interactee == null)
+						operator = null //this shouldn't happen, but just in case
+					else
+						to_chat(user, "Someone's already controlling it.")
+						return
+				else
+					if(user.interactee) //Make sure we're not manning two guns at once, tentacle arms.
+						to_chat(user, "You're already manning something!")
+						return
+					if(user.get_active_hand() != null)
+						to_chat(user, SPAN_WARNING("You need a free hand to man \the [src]."))
+
+					if(!user.allow_gun_usage)
+						to_chat(user, SPAN_WARNING("You aren't allowed to use firearms!"))
+						return
+					else
+						user.freeze()
+						user.set_interaction(src)
+						give_action(user, /datum/action/human_action/mg_exit)
+
 		else
-			if(user.interactee) //Make sure we're not manning two guns at once, tentacle arms.
-				to_chat(user, "You're already manning something!")
-				return
-			if(user.get_active_hand() != null)
-				to_chat(user, SPAN_WARNING("You need a free hand to man \the [src]."))
-
-			if(!user.allow_gun_usage)
-				to_chat(user, SPAN_WARNING("You aren't allowed to use firearms!"))
-				return
-
-			else
-				user.set_interaction(src)
+			to_chat(usr, SPAN_NOTICE("You are too far from the handles to man [src]!"))
 
 /obj/structure/machinery/m56d_hmg/on_set_interaction(mob/user)
+	RegisterSignal(user, COMSIG_MOB_RESISTED, .proc/exit_interaction)
+	RegisterSignal(user, COMSIG_MOB_MG_EXIT, .proc/exit_interaction)
+
 	user.frozen = TRUE
 	flags_atom |= RELAY_CLICK
 	user.status_flags |= IMMOBILE_ACTION
 	user.visible_message(SPAN_NOTICE("[user] mans \the [src]."),SPAN_NOTICE("You man \the [src], locked and loaded!"))
-	user.update_canmove()
 	user.forceMove(src.loc)
 	user.setDir(dir)
 	user_old_x = user.pixel_x
@@ -868,23 +881,28 @@
 	user.reset_view(src)
 	update_pixels(user)
 	operator = user
-	user.unfreeze()
 
 /obj/structure/machinery/m56d_hmg/on_unset_interaction(mob/user)
 	flags_atom &= ~RELAY_CLICK
 	user.status_flags &= ~IMMOBILE_ACTION
 	user.visible_message(SPAN_NOTICE("[user] lets go of \the [src]."),SPAN_NOTICE("You let go of \the [src], letting the gun rest."))
-	user.update_canmove()
 	user.reset_view(null)
-	var/grip_dir = reverse_direction(dir)
-	var/old_dir = dir
-	step(user, grip_dir)
-	user_old_x = 0
-	user_old_y = 0
-	user.setDir(old_dir)
+	user.forceMove(get_step(src, reverse_direction(src.dir)))
+	user.setDir(dir) //set the direction of the player to the direction the gun is facing
+	user_old_x = 0 //reset our x
+	user_old_y = 0 //reset our y
 	update_pixels(user, FALSE)
-	if(operator == user)
+	if(operator == user) //We have no operator now
 		operator = null
+	remove_action(user, /datum/action/human_action/mg_exit)
+
+	UnregisterSignal(user, list(
+		COMSIG_MOB_MG_EXIT,
+		COMSIG_MOB_RESISTED
+	))
+
+	user.update_canmove()
+	user.unfreeze()
 
 /obj/structure/machinery/m56d_hmg/proc/update_pixels(var/mob/user, var/mounting = TRUE)
 	if(mounting)
@@ -1095,6 +1113,7 @@
 	to_chat(user, SPAN_NOTICE("You deploy \the [M]."))
 	if((rounds > 0) && !user.get_inactive_hand())
 		user.set_interaction(M)
+		give_action(user, /datum/action/human_action/mg_exit)
 	M.rounds = rounds
 	M.overheat_value = overheat_value
 	M.health = health
@@ -1468,30 +1487,32 @@
 
 /obj/structure/machinery/m56d_hmg/auto/attack_hand(mob/user)
 	..()
-	grip_dir = reverse_direction(dir)
-	var/turf/T = get_step(src.loc, grip_dir)
-	if(user.loc == T)
-		if(operator) //If there is already a operator then they're manning it.
-			if(operator.interactee == null)
-				operator = null //this shouldn't happen, but just in case
+
+	var/turf/user_turf = get_turf(user)
+	for(var/opp_dir in reverse_nearby_direction(src.dir))
+		if(get_step(src, opp_dir) == user_turf)
+			if(operator) //If there is already a operator then they're manning it.
+				if(operator.interactee == null)
+					operator = null //this shouldn't happen, but just in case
+				else
+					to_chat(user, "Someone's already controlling it.")
+					return
+			if(!(user.alpha > 60))
+				to_chat(user, SPAN_WARNING("You aren't going to be setting up while cloaked."))
+				return
 			else
-				to_chat(user, "Someone's already controlling it.")
-				return
-		if(!(user.alpha > 60))
-			to_chat(user, SPAN_WARNING("You aren't going to be setting up while cloaked."))
-			return
-		else
-			if(user.interactee) //Make sure we're not manning two guns at once, tentacle arms.
-				to_chat(user, "You're already manning something!")
-				return
+				if(user.interactee) //Make sure we're not manning two guns at once, tentacle arms.
+					to_chat(user, "You're already manning something!")
+					return
 
-		if(user.get_active_hand() == null && user.get_inactive_hand() == null)
-			user.set_interaction(src)
+			if(user.get_active_hand() == null && user.get_inactive_hand() == null)
+				user.freeze()
+				user.set_interaction(src)
+				give_action(user, /datum/action/human_action/mg_exit)
+			else
+				to_chat(usr, SPAN_NOTICE("Your hands are too busy holding things to grab the handles!"))
 		else
-			to_chat(usr, SPAN_NOTICE("Your hands are too busy holding things to grab the handles!"))
-
-	else
-		to_chat(usr, SPAN_NOTICE("You are too far from the handles to man [src]!"))
+			to_chat(usr, SPAN_NOTICE("You are too far from the handles to man [src]!"))
 
 // DISASSEMBLY
 
@@ -1622,6 +1643,13 @@
 	update_pixels(user)
 	playsound(src.loc, 'sound/items/m56dauto_rotate.ogg', 25, 1)
 	to_chat(user, SPAN_NOTICE("You rotate [src], using the tripod to support your pivoting movement."))
+
+
+
+
+/obj/structure/machinery/m56d_hmg/auto/exit_interaction(mob/user)
+	..()
+
 
 /obj/structure/machinery/m56d_hmg/auto/proc/disable_interaction(mob/user, NewLoc, direction)
 	SIGNAL_HANDLER

--- a/code/modules/mob/living/carbon/human/human_abilities.dm
+++ b/code/modules/mob/living/carbon/human/human_abilities.dm
@@ -596,3 +596,23 @@ CULT
 	H.reset_view()
 	remove_from(H)
 
+
+/datum/action/human_action/mg_exit
+	name = "Exit MG"
+	action_icon_state = "cancel_view"
+
+/datum/action/human_action/mg_exit/give_to(user)
+	. = ..()
+	RegisterSignal(user, COMSIG_MOB_MG_ENTERED, .proc/remove_from)
+
+/datum/action/human_action/mg_exit/remove_from(mob/M)
+	. = ..()
+	UnregisterSignal(M, COMSIG_MOB_MG_ENTERED)
+
+/datum/action/human_action/mg_exit/action_activate()
+	if(!can_use_action())
+		return
+
+	var/mob/living/carbon/human/H = owner
+	SEND_SIGNAL(H, COMSIG_MOB_MG_EXIT)
+	remove_from(H)

--- a/code/modules/mob/living/carbon/human/human_abilities.dm
+++ b/code/modules/mob/living/carbon/human/human_abilities.dm
@@ -601,18 +601,9 @@ CULT
 	name = "Exit MG"
 	action_icon_state = "cancel_view"
 
-/datum/action/human_action/mg_exit/give_to(user)
-	. = ..()
-	RegisterSignal(user, COMSIG_MOB_MG_ENTERED, .proc/remove_from)
-
-/datum/action/human_action/mg_exit/remove_from(mob/M)
-	. = ..()
-	UnregisterSignal(M, COMSIG_MOB_MG_ENTERED)
-
 /datum/action/human_action/mg_exit/action_activate()
 	if(!can_use_action())
 		return
 
-	var/mob/living/carbon/human/H = owner
-	SEND_SIGNAL(H, COMSIG_MOB_MG_EXIT)
-	remove_from(H)
+	var/mob/living/carbon/human/human_user = owner
+	SEND_SIGNAL(human_user, COMSIG_MOB_MG_EXIT)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Removed the ability to vault over barricades (tables, cades, anything) or access the m56d MG from the outside of cades, both are considered game exploits. Players can no longer rotate their character while firing the machine gun, as this is not consistent with how you fire an actual MG. Players can enter a Machine gun(m56d/m2c) from behind (where the handles are) or to the left or right of that tile, refer to the image below: 
![image](https://user-images.githubusercontent.com/55922029/199626711-c25f4267-f6e1-439a-8f5e-f704d2dd59f2.png)

When the player exits a machine gun, they animate out, instead of just "walking" out either to the left, back, or right of the machine gun.

When a player "enters" a machine gun, they can either resist() out of the machine gun or press the UI button (Exit MG) located at the top left of their screen. 
![image](https://user-images.githubusercontent.com/55922029/199627288-93802353-e86d-452f-8090-52251bb373ce.png)

Fixes #556 

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->

The current state of the machine guns is that you can vault over cades inside or outside if you are adjacent to an m56d, with the exception of the m2c as it has anti-cade code.   You shouldn't be able to walk out from either direction while leaving a machine gun. This PR fixes that. Further, when "exiting" out of the machine gun, you simply walk out or under the MG. With this PR, you will animate out cleanly, adding a nice aesthetic. Also, when you're manning an MG, you're manning it, you're not "dancing" or shooting it backward, which doesn't make sense. Case in point:
![image](https://user-images.githubusercontent.com/55922029/199629013-9f69252a-e831-4069-98b0-171a9ce08bc0.png)


## Changelog

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: John_Rico
add: Added a UI button to exit a MG or you can resist 
add: Added an animation "exiting" an M2c or m56d w/ variant
fix: Can no long vault over cades or man a MG on the other side of a barricade
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
