### PR TITLE
Fixed View Objective null bug

### DIFF
--- a/code/modules/objectives/data_retrieval.dm
+++ b/code/modules/objectives/data_retrieval.dm
@@ -48,7 +48,7 @@
 	initial_area = get_area(terminal)
 
 /datum/cm_objective/retrieve_data/terminal/Destroy()
-	terminal.objective = null
+	terminal?.objective = null
 	terminal = null
 	return ..()
 
@@ -243,6 +243,7 @@
 
 /obj/structure/machinery/computer/objective/Destroy()
 	objective?.terminal = null
+	qdel(objective)
 	objective = null
 	return ..()
 


### PR DESCRIPTION
Should fix #832 and maybe #1222

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Fixed the null-related "BSOD" that appears on View Objectives screen:

![image](https://user-images.githubusercontent.com/964559/199709241-8c8b5c00-fef5-49d5-b383-431f19d4cb09.png)
(this is after reading all the paper scraps, progress reports, folders and manuals, we have all 3/3 Terminal Objectives, while LV usually spawns with 5 Terminals)

It was caused by us trying to pass null Terminal to TGUI. We were passing a null Terminal because:
- Nightmare Inserts were deleting terminals in some areas, such as LV crashed ship and science nexus
- Deleted terminals nulled out the Terminals variable in their objective
- The deleted terminals never deleted the objectives they were relating to

Now the terminals call for their associated objective to be deleted when they are being deleted, which untangles the objective from all other objectives.

Fixes #832

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The BSOD was making it impossible for IOs to complete their work - they were unable to view other Terminal or Disk passwords. With this we shouldn't see those null errors and the game shouldn't break IOs' fun.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->

## Changelog

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: View Objectives Data "BSOD" problem should be fixed. It was caused by some Nightmare inserts deleting terminals.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
