### PR TITLE
Added admin commands to teleport items, corpses

### DIFF
--- a/code/modules/admin/tabs/admin_tab.dm
+++ b/code/modules/admin/tabs/admin_tab.dm
@@ -516,6 +516,8 @@
 		<A href='?src=\ref[src];[HrefToken()];teleport=teleport_mob_to_area'>Teleport Mob to Area</A><BR>
 		<A href='?src=\ref[src];[HrefToken()];teleport=teleport_mobs_in_range'>Mass Teleport Mobs in Range</A><BR>
 		<A href='?src=\ref[src];[HrefToken()];teleport=teleport_mobs_by_faction'>Mass Teleport Mobs to You by Faction</A><BR>
+		<A href='?src=\ref[src];[HrefToken()];teleport=teleport_corpses'>Mass Teleport Corpses to You</A><BR>
+		<A href='?src=\ref[src];[HrefToken()];teleport=teleport_items_by_type'>Mass Teleport Items to You by Type</A><BR>
 		<BR>
 		"}
 

--- a/code/modules/admin/topic/topic_teleports.dm
+++ b/code/modules/admin/topic/topic_teleports.dm
@@ -155,3 +155,57 @@
 			else
 				to_chat(owner, SPAN_ALERT("Mobs choice error. Aborting."))
 				return
+
+		if("teleport_corpses")
+			if(alert(owner, "[GLOB.dead_mob_list.len] corpses are marked for teleportation. Pressing \"TELEPORT\" will teleport them to your location at the moment of pressing button.", "Confirmation", "Teleport", "Cancel") == "Cancel")
+				return
+			for(var/mob/M in GLOB.dead_mob_list)
+				if(!M)
+					continue
+				M.on_mob_jump()
+				M.forceMove(get_turf(owner.mob))
+			message_staff(WRAP_STAFF_LOG(owner.mob, "mass-teleported [GLOB.dead_mob_list.len] corpses to themselves in [get_area(owner.mob)] ([owner.mob.x],[owner.mob.y],[owner.mob.z])."), owner.mob.x, owner.mob.y, owner.mob.z)
+		
+		if("teleport_items_by_type")
+			var/item = input(owner,"What item?", "Item Fetcher","") as text|null
+			if(!item)
+				return
+
+			var/list/types = typesof(/atom)
+			var/list/matches = new()
+
+			//Figure out which object they might be trying to fetch
+			for(var/path in types)
+				if(findtext("[path]", item))
+					matches += path
+
+			if(matches.len==0)
+				return
+
+			var/chosen
+			if(matches.len==1)
+				chosen = matches[1]
+			else
+				//If we have multiple options, let them select which one they meant
+				chosen = tgui_input_list(usr, "Select an atom type", "Spawn Atom", matches)
+
+			if(!chosen)
+				return
+
+			//Find all items in the world
+			var/list/targets = list()
+			for(var/obj/item/M in GLOB.item_list)
+				if(istype(M, chosen))
+					to_world("YES")
+					targets += M
+
+			if(alert(owner, "[targets.len] items are marked for teleportation. Pressing \"TELEPORT\" will teleport them to your location at the moment of pressing button.", "Confirmation", "Teleport", "Cancel") == "Cancel")
+				return
+
+			//Fetch the items
+			for(var/obj/item/M in targets)
+				if(!M)
+					continue
+				M.forceMove(get_turf(owner.mob))
+
+			message_staff(WRAP_STAFF_LOG(owner.mob, "mass-teleported [targets.len] items of type [chosen] to themselves in [get_area(owner.mob)] ([owner.mob.x],[owner.mob.y],[owner.mob.z])."), owner.mob.x, owner.mob.y, owner.mob.z)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Added options to Admin Teleport menu to mass teleport all the corpses and specified items to them.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Those two options really helpful for debugging Intel / Objectives stuff - being able to fetch all the corpses and put them in Research, fetching specific Intel pieces and being able to just process them all, etc. I'm sure Admins might find some other uses for it, like removing all the Light Replacers when they want to do a spooky game, or removing all guns for some event, etc.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->

## Changelog

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
admin: Added more options to Admins' teleport menu - grabbing all the corpses or specific items from the entire map. Very useful for devs debugging Intel, but could find some other uses as well.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
