### PR TITLE
IO Oversight Fix

### DIFF
--- a/code/game/jobs/job/command/auxiliary/intel.dm
+++ b/code/game/jobs/job/command/auxiliary/intel.dm
@@ -22,6 +22,11 @@
 			total_positions_so_far = positions
 	return positions
 
+/datum/job/command/intel/generate_entry_conditions(mob/living/carbon/human/H)
+	..()
+	if(!Check_WO())
+		H.nutrition = rand(NUTRITION_VERYLOW, NUTRITION_LOW)
+
 AddTimelock(/datum/job/command/intel, list(
 	JOB_SQUAD_ROLES = 5 HOURS
 ))

--- a/code/game/machinery/vending/vendor_types/intelligence_officer.dm
+++ b/code/game/machinery/vending/vendor_types/intelligence_officer.dm
@@ -55,7 +55,7 @@ GLOBAL_LIST_INIT(cm_vending_clothing_intelligence_officer, list(
 		list("Armor", 0, /obj/item/clothing/suit/storage/marine/rto/intel, MARINE_CAN_BUY_ARMOR, VENDOR_ITEM_MANDATORY),
 		list("Expedition Pack", 0, /obj/item/storage/backpack/marine/satchel/intel, MARINE_CAN_BUY_BACKPACK, VENDOR_ITEM_MANDATORY),
 		list("Gloves", 0, /obj/item/clothing/gloves/marine/insulated, MARINE_CAN_BUY_GLOVES, VENDOR_ITEM_MANDATORY),
-		list("Headset", 0, /obj/item/device/radio/headset/almayer/mcom, MARINE_CAN_BUY_EAR, VENDOR_ITEM_MANDATORY),
+		list("Headset", 0, /obj/item/device/radio/headset/almayer/intel, MARINE_CAN_BUY_EAR, VENDOR_ITEM_MANDATORY),
 		list("MRE", 0, /obj/item/storage/box/MRE, MARINE_CAN_BUY_MRE, VENDOR_ITEM_MANDATORY),
 
 		list("HELMET (CHOOSE 1)", 0, null, null, null),

--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -105,6 +105,11 @@
 	icon_state = "cap_key"
 	channels = list(RADIO_CHANNEL_COMMAND = 1, SQUAD_MARINE_1 = 1, SQUAD_MARINE_2 = 1, SQUAD_MARINE_3 = 1, SQUAD_MARINE_4 = 1, SQUAD_MARINE_5 = 1, SQUAD_MARINE_CRYO = 0, RADIO_CHANNEL_ENGI = 1, RADIO_CHANNEL_MEDSCI = 1, RADIO_CHANNEL_REQ = 1, RADIO_CHANNEL_JTAC = 1, RADIO_CHANNEL_INTEL = 1)
 
+/obj/item/device/encryptionkey/iofficer
+	name = "\improper Marine intelligence Officer Radio Encryption Key"
+	icon_state = "cap_key"
+	channels = list(RADIO_CHANNEL_INTEL = 1, RADIO_CHANNEL_COMMAND = 1, SQUAD_MARINE_1 = 1, SQUAD_MARINE_2 = 1, SQUAD_MARINE_3 = 1, SQUAD_MARINE_4 = 1, SQUAD_MARINE_5 = 1, SQUAD_MARINE_CRYO = 0, RADIO_CHANNEL_ENGI = 1, RADIO_CHANNEL_MEDSCI = 1, RADIO_CHANNEL_REQ = 1, RADIO_CHANNEL_JTAC = 1, RADIO_CHANNEL_ALMAYER = 1)
+
 /obj/item/device/encryptionkey/mcom/cl
 	name = "\improper Corporate Liaison radio encryption key"
 	icon_state = "cap_key"
@@ -119,11 +124,6 @@
 	name = "\improper Marine Pilot Officer Radio Encryption Key"
 	icon_state = "cap_key"
 	channels = list(RADIO_CHANNEL_COMMAND = 1, SQUAD_MARINE_1 = 0, SQUAD_MARINE_2 = 0, SQUAD_MARINE_3 = 0, SQUAD_MARINE_4 = 0, SQUAD_MARINE_5 = 0, SQUAD_MARINE_CRYO = 0, RADIO_CHANNEL_JTAC = 1, RADIO_CHANNEL_INTEL = 1)
-
-/obj/item/device/encryptionkey/io
-	name = "\improper Marine Intelligence Officer Radio Encryption Key"
-	icon_state = "cap_key"
-	channels = list(RADIO_CHANNEL_COMMAND = 1, SQUAD_MARINE_1 = 0, SQUAD_MARINE_2 = 0, SQUAD_MARINE_3 = 0, SQUAD_MARINE_4 = 0, SQUAD_MARINE_5 = 0, SQUAD_MARINE_CRYO = 0, RADIO_CHANNEL_INTEL = 1)
 
 /obj/item/device/encryptionkey/mcom/ai //AI only.
 	channels = list(RADIO_CHANNEL_COMMAND = 1, RADIO_CHANNEL_MP = 1, SQUAD_MARINE_1 = 1, SQUAD_MARINE_2 = 1, SQUAD_MARINE_3 = 1, SQUAD_MARINE_4 = 1, SQUAD_MARINE_5 = 1, SQUAD_MARINE_CRYO = 0, RADIO_CHANNEL_ENGI = 1, RADIO_CHANNEL_MEDSCI = 1, RADIO_CHANNEL_REQ = 1, RADIO_CHANNEL_JTAC = 1, RADIO_CHANNEL_INTEL = 1)

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -447,8 +447,9 @@
 
 /obj/item/device/radio/headset/almayer/intel
 	name = "marine intel radio headset"
-	desc = "Used by Intelligence Officers. Channels are as follows: :v - marine command, :a - alpha squad, :b - bravo squad, :c - charlie squad, :d - delta squad, :j - JTAC, :t - intel."
-	initial_keys = list(/obj/item/device/encryptionkey/po)
+	desc = "Used by Intelligence Officers. Channels are as follows: ; - intel, :v - marine command, :a - alpha squad, :b - bravo squad, :c - charlie squad, :d - delta squad, :e = echo, :f = foxtrot, :j - JTAC, :u = req, :n = engineering, :m = medical."
+	frequency = INTEL_FREQ
+	initial_keys = list(/obj/item/device/encryptionkey/iofficer)
 
 /obj/item/device/radio/headset/almayer/mcl
 	name = "corporate liaison radio headset"


### PR DESCRIPTION
## About The Pull Request

This fixes a couple small oversight. The IOs had a radio before, but it wasn't actually accessible ingame, IOs started with irregular hunger and their ; on radios went to public.

## Why It's Good For The Game

These are a couple small oversights I believe from when I.O. was readded. Should made the role a little easier to get into.

## Changelog

:cl: Mistfrag
fix: IOs now start with low nutrition, rather than half. IOs have their proper headset integrated into gameplay and their default ; now = intel.
spellcheck: IO headset description updated to include missing channels.
/:cl:


