### PR TITLE
Fixes Statpanel Loading (not really, but mostly prevent error)

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -357,10 +357,9 @@ GLOBAL_LIST_INIT(whitelisted_client_procs, list(
 		to_chat(src, FONT_SIZE_HUGE(SPAN_BOLDNOTICE("YOUR BYOND VERSION IS NOT WELL SUITED FOR THIS SERVER. Download latest BETA build or you may suffer random crashes or disconnects.")))
 
 	// Initialize tgui panel
-	src << browse(file('html/statbrowser.html'), "window=statbrowser")
-	addtimer(CALLBACK(src, .proc/check_panel_loaded), 10 SECONDS)
+	src << browse('html/statbrowser.html', "window=statbrowser")
+	init_statbrowser()
 	tgui_panel.initialize()
-	client.init_statbrowser()
 
 	var/datum/custom_event_info/CEI = GLOB.custom_event_info_list["Global"]
 	CEI.show_player_event_info(src)
@@ -569,6 +568,7 @@ GLOBAL_LIST_INIT(whitelisted_client_procs, list(
 /client/proc/init_statbrowser()
 	if(IsAdminAdvancedProcCall())
 		return
+	addtimer(CALLBACK(src, .proc/check_panel_loaded), 10 SECONDS)
 	var/list/verblist = list()
 	var/list/verbstoprocess = verbs.Copy()
 	if(mob)

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -360,6 +360,7 @@ GLOBAL_LIST_INIT(whitelisted_client_procs, list(
 	src << browse(file('html/statbrowser.html'), "window=statbrowser")
 	addtimer(CALLBACK(src, .proc/check_panel_loaded), 10 SECONDS)
 	tgui_panel.initialize()
+	client.init_statbrowser()
 
 	var/datum/custom_event_info/CEI = GLOB.custom_event_info_list["Global"]
 	CEI.show_player_event_info(src)

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -358,7 +358,7 @@ GLOBAL_LIST_INIT(whitelisted_client_procs, list(
 
 	// Initialize tgui panel
 	src << browse(file('html/statbrowser.html'), "window=statbrowser")
-	addtimer(CALLBACK(src, .proc/check_panel_loaded), 30 SECONDS)
+	addtimer(CALLBACK(src, .proc/check_panel_loaded), 10 SECONDS)
 	tgui_panel.initialize()
 
 	var/datum/custom_event_info/CEI = GLOB.custom_event_info_list["Global"]
@@ -477,12 +477,11 @@ GLOBAL_LIST_INIT(whitelisted_client_procs, list(
 
 //send resources to the client. It's here in its own proc so we can move it around easiliy if need be
 /client/proc/send_assets()
-	spawn (10) //removing this spawn causes all clients to not get verbs.
-		//load info on what assets the client has
-		src << browse('code/modules/asset_cache/validate_assets.html', "window=asset_cache_browser")
+	//load info on what assets the client has
+	src << browse('code/modules/asset_cache/validate_assets.html', "window=asset_cache_browser")
 
-		//Precache the client with all other assets slowly, so as to not block other browse() calls
-		addtimer(CALLBACK(SSassets.transport, /datum/asset_transport.proc/send_assets_slow, src, SSassets.transport.preload), 5 SECONDS)
+	//Precache the client with all other assets slowly, so as to not block other browse() calls
+	SSassets.transport.send_assets_slow(src, SSassets.transport.preload)
 
 /proc/setup_player_entity(var/ckey)
 	if(!ckey)

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -56,7 +56,5 @@
 			var/datum/callback/CB = foo
 			CB.Invoke()
 
-	client.init_statbrowser()
-
 	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_MOB_LOGIN, src)
 	SEND_SIGNAL(src, COMSIG_MOB_LOGIN)

--- a/code/modules/tgui_panel/tgui_panel.dm
+++ b/code/modules/tgui_panel/tgui_panel.dm
@@ -37,9 +37,7 @@
  * Initializes tgui panel.
  */
 /datum/tgui_panel/proc/initialize(force = FALSE)
-	set waitfor = FALSE
 	// Minimal sleep to defer initialization to after client constructor
-	sleep(1)
 	initialized_at = world.time
 	// Perform a clean initialization
 	window.initialize(inline_assets = list(

--- a/html/statbrowser.html
+++ b/html/statbrowser.html
@@ -993,6 +993,7 @@
 			}
 
 			window.onload = function () {
+				alert("Statpanel onload")
 				NotifyByondOnload();
 			};
 

--- a/html/statbrowser.html
+++ b/html/statbrowser.html
@@ -992,10 +992,10 @@
 				tab_change("Status");
 			}
 
-			window.onload = function () {
-				alert("Statpanel onload")
-				NotifyByondOnload();
-			};
+			window.addEventListener('load', _ => {
+				NotifyByondOnload()
+				document.getElementById("statcontent").appendChild(document.createElement("... Loaded!"));
+			})
 
 			function NotifyByondOnload() {
 				window.location.href = "byond://winset?command=Panel-Ready";

--- a/html/statbrowser.html
+++ b/html/statbrowser.html
@@ -571,7 +571,7 @@
 				}
 				createOptionsButton();
 				SendTabsToByond();
-
+				tab_change("Status", true);
 			}
 
 			function SendTabsToByond() {

--- a/html/statbrowser.html
+++ b/html/statbrowser.html
@@ -337,7 +337,7 @@
 			}); */
 
 			// Status panel implementation ------------------------------------------------
-			var status_tab_parts = ["Loading..."];
+			var status_tab_parts = ["<a href='byond://winset?command=Panel-Ready'>Loading.</a>"];
 			var current_tab = null;
 			var local_fontsize
 			// Per `storage.js` for tgui:
@@ -350,7 +350,7 @@
 				local_fontsize = 11;
 			}
 			var current_fontsize = local_fontsize ? parseInt(local_fontsize) : 11; // in px, also determines line height and category header sizes for the verb menus
-			var mc_tab_parts = [["Loading...", ""]];
+			var mc_tab_parts = [["<a href='byond://winset?command=Panel-Ready'>Loading...</a>", ""]];
 			var tickets = [];
 			var href_token = null;
 			var verb_tabs = [];
@@ -653,7 +653,7 @@
 				} else if (tab == turfname) {
 					draw_listedturf();
 				} else {
-					statcontentdiv[textContentKey] = "Loading...";
+					statcontentdiv[textContentKey] = "<a href='byond://winset?command=Panel-Ready'>Loading.....</a>";
 				}
 				window.location.href = "byond://winset?statbrowser.is-visible=true";
 			}
@@ -993,12 +993,13 @@
 			}
 
 			window.onload = function () {
+				document.getElementById("statcontent").innerText = "<a href='byond://winset?command=Panel-Ready'>Onload done</a>";
 				NotifyByondOnload();
-				document.getElementById("statcontent").appendChild(document.createElement("... Loaded!"));
 			};
 
 			function NotifyByondOnload() {
 				window.location.href = "byond://winset?command=Panel-Ready";
+				document.getElementById("statcontent").innerText = "<a href='byond://winset?command=Panel-Ready'>Sent</a>";
 			}
 
 			function create_debug() {

--- a/html/statbrowser.html
+++ b/html/statbrowser.html
@@ -548,7 +548,7 @@
 			// example entry from 2D vector: (IC, Say)
 			function init_statbrowser(c, v) {
 				document.getElementById("statcontent").style.fontSize = current_fontsize + "px";
-
+				initDone = true;
 				wipe_verbs(); // remove all verb categories so we can replace them
 				checkStatusTab(); // remove all status tabs
 				verb_tabs = JSON.parse(c);
@@ -571,7 +571,7 @@
 				}
 				createOptionsButton();
 				SendTabsToByond();
-				initDone = true;
+
 			}
 
 			function SendTabsToByond() {

--- a/html/statbrowser.html
+++ b/html/statbrowser.html
@@ -992,10 +992,10 @@
 				tab_change("Status");
 			}
 
-			window.addEventListener('load', _ => {
-				NotifyByondOnload()
+			window.onload = function () {
+				NotifyByondOnload();
 				document.getElementById("statcontent").appendChild(document.createElement("... Loaded!"));
-			})
+			};
 
 			function NotifyByondOnload() {
 				window.location.href = "byond://winset?command=Panel-Ready";

--- a/html/statbrowser.html
+++ b/html/statbrowser.html
@@ -337,7 +337,7 @@
 			}); */
 
 			// Status panel implementation ------------------------------------------------
-			var status_tab_parts = ["<a href='byond://winset?command=Panel-Ready'>Loading.</a>"];
+			var status_tab_parts = ["Loading..."];
 			var current_tab = null;
 			var local_fontsize
 			// Per `storage.js` for tgui:
@@ -350,7 +350,7 @@
 				local_fontsize = 11;
 			}
 			var current_fontsize = local_fontsize ? parseInt(local_fontsize) : 11; // in px, also determines line height and category header sizes for the verb menus
-			var mc_tab_parts = [["<a href='byond://winset?command=Panel-Ready'>Loading...</a>", ""]];
+			var mc_tab_parts = [["Loading...", ""]];
 			var tickets = [];
 			var href_token = null;
 			var verb_tabs = [];
@@ -358,6 +358,7 @@
 			var permanent_tabs = []; // tabs that won't be cleared by wipes
 			var turfcontents = [];
 			var turfname = "";
+			var initDone = false;
 			var imageRetryDelay = 500;
 			var imageRetryLimit = 50;
 			var menu = document.querySelector('#menu');
@@ -570,6 +571,7 @@
 				}
 				createOptionsButton();
 				SendTabsToByond();
+				initDone = true;
 			}
 
 			function SendTabsToByond() {
@@ -653,7 +655,7 @@
 				} else if (tab == turfname) {
 					draw_listedturf();
 				} else {
-					statcontentdiv[textContentKey] = "<a href='byond://winset?command=Panel-Ready'>Loading.....</a>";
+					statcontentdiv[textContentKey] = "Loading...";
 				}
 				window.location.href = "byond://winset?statbrowser.is-visible=true";
 			}
@@ -993,13 +995,13 @@
 			}
 
 			window.onload = function () {
-				document.getElementById("statcontent").innerText = "<a href='byond://winset?command=Panel-Ready'>Onload done</a>";
 				NotifyByondOnload();
 			};
 
 			function NotifyByondOnload() {
+				if (initDone) { return; }
+				setTimeout(NotifyByondOnload, 2000)
 				window.location.href = "byond://winset?command=Panel-Ready";
-				document.getElementById("statcontent").innerText = "<a href='byond://winset?command=Panel-Ready'>Sent</a>";
 			}
 
 			function create_debug() {

--- a/html/statbrowser.html
+++ b/html/statbrowser.html
@@ -567,11 +567,12 @@
 					sortVerbs(); // sort them
 					if (do_update) {
 						draw_verbs(current_tab);
+					} else {
+						draw_status()
 					}
 				}
 				createOptionsButton();
 				SendTabsToByond();
-				tab_change("Status", true);
 			}
 
 			function SendTabsToByond() {


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This half-fixes Statpanel loading issues.

1. It removes the arbitrary delays added by c0ders of the past that seem to do nothing at all in practice
2. It adds a dummy loop check in statpanel main script to retry initialization
3. This causes the panel to load, although still display 'Loading...'

How initialization works to begin with, you may ask ?
It's VERY SIMPLE, let's take as example a client reconnect, which exhibits our dreaded issue:

1. In /client/New, the statpanel window is opened
2. In /client/New, we attempt statpanel init by serializing it relevant data (THIS DOESN'T WORK)
3. JS side statpanel loads and notifies BYOND via winset that it has loaded (THIS DOESN'T WORK EITHER)
4. (30 SECONDS ELAPSE)
5. Statpanel failed to load, click here to reload the panel

This doesn't seem to actually be an assets problem. Having either side retry init fixes this. "Fixes" because the status tab remains on "Loading..." until you click something.

Frankly this whole thing needs to be put on-standard with the /tg/ one which uses their JS BYOND lib and probably (hopefully) doesn't have this issue. I very highly suspect thedonkified initially added these three-way loading fallbacks due to having problems aswell.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->

It's less pain for everyone involved, including me

## Changelog

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Half fixed statpanel failing to load. It might still behave erratically.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
