### PR TITLE
Mapping: Adds a bush to LV

### DIFF
--- a/maps/map_files/LV624/LV624.dmm
+++ b/maps/map_files/LV624/LV624.dmm
@@ -15022,6 +15022,10 @@
 	icon_state = "grassdirt_corner2"
 	},
 /area/lv624/ground/jungle/south_east_jungle)
+"ePx" = (
+/obj/structure/flora/bush/ausbushes/var3/sunnybush,
+/turf/open/gm/grass,
+/area/lv624/ground/jungle/north_jungle)
 "ePV" = (
 /obj/structure/flora/bush/ausbushes/ppflowers,
 /turf/open/gm/dirtgrassborder{
@@ -39938,7 +39942,7 @@ cfN
 vqT
 ldZ
 tyG
-tyG
+ePx
 tyG
 tyG
 tyG


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

This PR aims to add a bush to LV on the tile X: 72 Y: 85

## Why It's Good For The Game

Personally I think it's a nice bush, sir.

## Changelog

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: SpartanBobby
add: Added a bush to LV on the tile X: 72 Y: 85
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
