### PR TITLE
BiMex Personal Shades

### DIFF
--- a/code/modules/client/preferences_gear.dm
+++ b/code/modules/client/preferences_gear.dm
@@ -135,13 +135,13 @@ var/global/list/gear_datums = list()
 	slot = WEAR_EYES
 
 /datum/gear/thugshades
-	display_name = "Shades"
+	display_name = "BiMex Personal Shades"
 	path = /obj/item/clothing/glasses/sunglasses/big
 	cost = 2
 	slot = WEAR_EYES
 
 /datum/gear/sunglasses
-	display_name = "Sunglasses"
+	display_name = "Cheap Sunglasses"
 	path = /obj/item/clothing/glasses/sunglasses
 	cost = 2
 	slot = WEAR_EYES

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -531,8 +531,8 @@
 //sunglasses
 
 /obj/item/clothing/glasses/sunglasses
-	desc = "Strangely ancient technology used to help provide rudimentary eye cover. Enhanced shielding blocks many flashes."
-	name = "sunglasses"
+	desc = "Generic off-brand eyewear, used to help provide rudimentary eye cover. Enhanced shielding blocks many flashes."
+	name = "cheap sunglasses"
 	icon_state = "sun"
 	item_state = "sunglasses"
 	darkness_view = -1
@@ -552,11 +552,12 @@
 	flags_equip_slot = SLOT_EYES|SLOT_FACE
 
 /obj/item/clothing/glasses/sunglasses/big
-	name = "shades"
-	desc = "Strangely ancient technology used to help provide rudimentary eye cover. Larger than average enhanced shielding blocks many flashes."
+	name = "bimex personal shades"
+	desc = "'Save the colonies and look cool doing it. Targeting lasers, atomic flash blasts, and solar radiation can cause instant blindness on the battlefield—but not while wearing a pair of BiMex sunglasses or goggles. The patented mirror refractory technology of BiMex lenses is even rumored to have reflected directed energy weapons back on their target!'"
 	icon_state = "bigsunglasses"
 	item_state = "bigsunglasses"
 	flags_equip_slot = SLOT_EYES|SLOT_FACE
+	armor_energy = CLOTHING_ARMOR_LOW
 
 /obj/item/clothing/glasses/sunglasses/aviator
 	name = "aviator shades"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

I was tired of trying to remember what glasses were what in custom loadout so I renamed 1 to Cheap SunGlasses and renamed the other to BiMex Personal shades from the Alien RPG book, I also gave the Bimex 10 energy armour to be inline with it's funny lore

## Why It's Good For The Game

https://i.imgur.com/oKKcXMJ.png

## Changelog

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:SpartanBobby
add: Renamed and gave a new description to "Sunglasses" now called "cheap sunglasses"
add: Renamed and gave a new description to "Shades" now called "bimex personal shades" from the Alien RPG rulebook
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
