### PR TITLE
Tweaks to Vehicle Ammo in Requisitions

### DIFF
--- a/code/datums/supply_packs/_supply_packs.dm
+++ b/code/datums/supply_packs/_supply_packs.dm
@@ -18,7 +18,7 @@
 var/list/all_supply_groups = list(
 	"Operations",
 	"Weapons",
-	"Vehicle Modules and Ammo",
+	"Vehicle Ammo",
 	"Attachments",
 	"Ammo",
 	"Weapons Specialist Ammo",

--- a/code/datums/supply_packs/hardpoint_modules.dm
+++ b/code/datums/supply_packs/hardpoint_modules.dm
@@ -14,7 +14,7 @@
 	cost = RO_PRICE_CHEAP
 	containertype = /obj/structure/closet/crate/ammo
 	containername = "LTB cannon ammo crate"
-	group = "Vehicle Modules and Ammo"
+	group = "Vehicle Ammo"
 
 /datum/supply_packs/ammo_ltaaap_minigun
 	name = "LTAA-AP Minigun magazines (x3)"
@@ -25,7 +25,7 @@
 	cost = RO_PRICE_CHEAP
 	containertype = /obj/structure/closet/crate/ammo
 	containername = "LTAA minigun ammo crate"
-	group = "Vehicle Modules and Ammo"
+	group = "Vehicle Ammo"
 
 /datum/supply_packs/ammo_ace_autocannon
 	name = "AC3-E Autocannon magazines (x5)"
@@ -38,7 +38,7 @@
 	cost = RO_PRICE_CHEAP
 	containertype = /obj/structure/closet/crate/ammo
 	containername = "AC3-E autocannon ammo crate"
-	group = "Vehicle Modules and Ammo"
+	group = "Vehicle Ammo"
 
 /datum/supply_packs/ammo_drgn_flamer
 	name = "DRG-N Offensive Flamer Unit fuel tanks (x3)"
@@ -49,7 +49,7 @@
 	cost = RO_PRICE_CHEAP
 	containertype = /obj/structure/closet/crate/ammo/alt/flame
 	containername = "Primary Flamer fuel tanks crate"
-	group = "Vehicle Modules and Ammo"
+	group = "Vehicle Ammo"
 
 /datum/supply_packs/ammo_dualcannon
 	name = "PARS-159 Boyars Dualcannon magazines (x5)"
@@ -62,7 +62,7 @@
 	cost = RO_PRICE_CHEAP
 	containertype = /obj/structure/closet/crate/ammo
 	containername = "PARS-159 Boyars Dualcannon ammo crate"
-	group = "Vehicle Modules and Ammo"
+	group = "Vehicle Ammo"
 
 /datum/supply_packs/ammo_glauncher
 	name = "M92T Grenade Launcher magazines (x5)"
@@ -75,7 +75,7 @@
 	cost = RO_PRICE_VERY_CHEAP
 	containertype = /obj/structure/closet/crate/ammo
 	containername = "M92T Grenade Launcher ammo crate"
-	group = "Vehicle Modules and Ammo"
+	group = "Vehicle Ammo"
 
 /datum/supply_packs/ammo_slauncher
 	name = "M34A2-A Multipurpose Turret smoke screen magazines (x4)"
@@ -86,7 +86,7 @@
 	cost = RO_PRICE_VERY_CHEAP
 	containertype = /obj/structure/closet/crate/ammo
 	containername = "M34A2-A Multipurpose Turret smoke screen ammo crate"
-	group = "Vehicle Modules and Ammo"
+	group = "Vehicle Ammo"
 
 /datum/supply_packs/ammo_towlauncher
 	name = "TOW Launcher magazines (x3)"
@@ -95,7 +95,7 @@
 	cost = RO_PRICE_CHEAP
 	containertype = /obj/structure/closet/crate/ammo
 	containername = "TOW launcher ammo crate"
-	group = "Vehicle Modules and Ammo"
+	group = "Vehicle Ammo"
 
 /datum/supply_packs/ammo_m56_cupola
 	name = "M56 Cupola magazines (x2)"
@@ -105,7 +105,7 @@
 	cost = RO_PRICE_VERY_CHEAP
 	containertype = /obj/structure/closet/crate/ammo
 	containername = "M56 Cupola ammo crate"
-	group = "Vehicle Modules and Ammo"
+	group = "Vehicle Ammo"
 
 /datum/supply_packs/tank_flamer_ammo
 	name = "LZR-N Flamer Unit fuel tanks (x2)"
@@ -115,7 +115,7 @@
 	cost = RO_PRICE_VERY_CHEAP
 	containertype = /obj/structure/closet/crate/ammo/alt/flame
 	containername = "LZR-N Flamer Unit fuel tanks crate"
-	group = "Vehicle Modules and Ammo"
+	group = "Vehicle Ammo"
 
 /datum/supply_packs/ammo_frontalcannon
 	name = "Bleihagel RE-RE700 Frontal Cannon magazines (x2)"
@@ -125,7 +125,7 @@
 	cost = RO_PRICE_VERY_CHEAP
 	containertype = /obj/structure/closet/crate/ammo
 	containername = "Bleihagel RE-RE700 Frontal Cannon ammo crate"
-	group = "Vehicle Modules and Ammo"
+	group = "Vehicle Ammo"
 
 /datum/supply_packs/ammo_flarelauncher
 	name = "M-87F Flare Launcher magazines (x4)"
@@ -137,4 +137,4 @@
 	cost = RO_PRICE_VERY_CHEAP
 	containertype = /obj/structure/closet/crate/ammo
 	containername = "M-87F Flare Launcher ammo crate"
-	group = "Vehicle Modules and Ammo"
+	group = "Vehicle Ammo"

--- a/code/datums/supply_packs/hardpoint_modules.dm
+++ b/code/datums/supply_packs/hardpoint_modules.dm
@@ -1,9 +1,9 @@
 //*******************************************************************************
-//Vehicle Modules and Ammo
+//Vehicle Ammo
 //*******************************************************************************/
 
 /datum/supply_packs/ammo_ltb_cannon
-	name = "LTB cannon magazines (x6)"
+	name = "LTB Cannon magazines (x6)"
 	contains = list(
 					/obj/item/ammo_magazine/hardpoint/ltb_cannon,
 					/obj/item/ammo_magazine/hardpoint/ltb_cannon,
@@ -17,7 +17,7 @@
 	group = "Vehicle Modules and Ammo"
 
 /datum/supply_packs/ammo_ltaaap_minigun
-	name = "LTAA AP minigun magazines (x3)"
+	name = "LTAA-AP Minigun magazines (x3)"
 	contains = list(
 					/obj/item/ammo_magazine/hardpoint/ltaaap_minigun,
 					/obj/item/ammo_magazine/hardpoint/ltaaap_minigun,
@@ -28,7 +28,7 @@
 	group = "Vehicle Modules and Ammo"
 
 /datum/supply_packs/ammo_ace_autocannon
-	name = "AC3-E autocannon magazines (x5)"
+	name = "AC3-E Autocannon magazines (x5)"
 	contains = list(
 					/obj/item/ammo_magazine/hardpoint/ace_autocannon,
 					/obj/item/ammo_magazine/hardpoint/ace_autocannon,
@@ -41,18 +41,18 @@
 	group = "Vehicle Modules and Ammo"
 
 /datum/supply_packs/ammo_drgn_flamer
-	name = "DRG-N offensive flamer unit fuel tanks (x3)"
+	name = "DRG-N Offensive Flamer Unit fuel tanks (x3)"
 	contains = list(
 					/obj/item/ammo_magazine/hardpoint/primary_flamer,
 					/obj/item/ammo_magazine/hardpoint/primary_flamer,
 					/obj/item/ammo_magazine/hardpoint/primary_flamer)
 	cost = RO_PRICE_CHEAP
-	containertype = /obj/structure/closet/crate/ammo
+	containertype = /obj/structure/closet/crate/ammo/alt/flame
 	containername = "Primary Flamer fuel tanks crate"
 	group = "Vehicle Modules and Ammo"
 
 /datum/supply_packs/ammo_dualcannon
-	name = "PARS-159 Boyars dualcannon magazines (x5)"
+	name = "PARS-159 Boyars Dualcannon magazines (x5)"
 	contains = list(
 					/obj/item/ammo_magazine/hardpoint/boyars_dualcannon,
 					/obj/item/ammo_magazine/hardpoint/boyars_dualcannon,
@@ -65,7 +65,7 @@
 	group = "Vehicle Modules and Ammo"
 
 /datum/supply_packs/ammo_glauncher
-	name = "M92T grenade launcher magazines (x5)"
+	name = "M92T Grenade Launcher magazines (x5)"
 	contains = list(
 					/obj/item/ammo_magazine/hardpoint/tank_glauncher,
 					/obj/item/ammo_magazine/hardpoint/tank_glauncher,
@@ -74,26 +74,24 @@
 					/obj/item/ammo_magazine/hardpoint/tank_glauncher)
 	cost = RO_PRICE_VERY_CHEAP
 	containertype = /obj/structure/closet/crate/ammo
-	containername = "grenade launcher ammo crate"
+	containername = "M92T Grenade Launcher ammo crate"
 	group = "Vehicle Modules and Ammo"
 
 /datum/supply_packs/ammo_slauncher
-	name = "Tank turret smoke screen magazines (x4)"
+	name = "M34A2-A Multipurpose Turret smoke screen magazines (x4)"
 	contains = list(
 					/obj/item/ammo_magazine/hardpoint/turret_smoke,
 					/obj/item/ammo_magazine/hardpoint/turret_smoke,
 					/obj/item/ammo_magazine/hardpoint/turret_smoke)
 	cost = RO_PRICE_VERY_CHEAP
 	containertype = /obj/structure/closet/crate/ammo
-	containername = "smoke launcher ammo crate"
+	containername = "M34A2-A Multipurpose Turret smoke screen ammo crate"
 	group = "Vehicle Modules and Ammo"
 
 /datum/supply_packs/ammo_towlauncher
-	name = "TOW launcher magazines (x3)"
+	name = "TOW Launcher magazines (x3)"
 	contains = list(
-					/obj/item/ammo_magazine/hardpoint/towlauncher,
-					/obj/item/ammo_magazine/hardpoint/towlauncher,
-					/obj/item/ammo_magazine/hardpoint/towlauncher)
+					/obj/item/hardpoint/secondary/towlauncher)
 	cost = RO_PRICE_CHEAP
 	containertype = /obj/structure/closet/crate/ammo
 	containername = "TOW launcher ammo crate"
@@ -110,27 +108,27 @@
 	group = "Vehicle Modules and Ammo"
 
 /datum/supply_packs/tank_flamer_ammo
-	name = "LZR-N flamer unit fuel tanks (x2)"
+	name = "LZR-N Flamer Unit fuel tanks (x2)"
 	contains = list(
 					/obj/item/ammo_magazine/hardpoint/secondary_flamer,
 					/obj/item/ammo_magazine/hardpoint/secondary_flamer)
 	cost = RO_PRICE_VERY_CHEAP
-	containertype = /obj/structure/closet/crate/ammo
-	containername = "secondary flamer fuel tanks crate"
+	containertype = /obj/structure/closet/crate/ammo/alt/flame
+	containername = "LZR-N Flamer Unit fuel tanks crate"
 	group = "Vehicle Modules and Ammo"
 
 /datum/supply_packs/ammo_frontalcannon
-	name = "Bleihagel RE-RE700 frontal cannon magazines (x2)"
+	name = "Bleihagel RE-RE700 Frontal Cannon magazines (x2)"
 	contains = list(
 					/obj/item/ammo_magazine/hardpoint/m56_cupola/frontal_cannon,
 					/obj/item/ammo_magazine/hardpoint/m56_cupola/frontal_cannon)
 	cost = RO_PRICE_VERY_CHEAP
 	containertype = /obj/structure/closet/crate/ammo
-	containername = "frontal cannon ammo crate"
+	containername = "Bleihagel RE-RE700 Frontal Cannon ammo crate"
 	group = "Vehicle Modules and Ammo"
 
 /datum/supply_packs/ammo_flarelauncher
-	name = "M-87F flare launcher magazines (x4)"
+	name = "M-87F Flare Launcher magazines (x4)"
 	contains = list(
 					/obj/item/ammo_magazine/hardpoint/flare_launcher,
 					/obj/item/ammo_magazine/hardpoint/flare_launcher,
@@ -138,5 +136,5 @@
 					/obj/item/ammo_magazine/hardpoint/flare_launcher)
 	cost = RO_PRICE_VERY_CHEAP
 	containertype = /obj/structure/closet/crate/ammo
-	containername = "flare launcher ammo crate"
+	containername = "M-87F Flare Launcher ammo crate"
 	group = "Vehicle Modules and Ammo"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

While I was working on the original version of this PR I have made a few tweaks to package descriptions, capitalisation and so on for Vehicle Ammo in Requisitions. Figured those changes were good on their own and they can be merged to the code proper even if the rest of that PR got rejected.

None of these changes are that groundbreaking, but they are a neat tweak.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Consistent capitalisation and naming of crates draws less attention to itself. Consistency with putting flammable ammo into boxes that label them as such helps with immersion. Removing the "Modules" part of the category name prevents players from being confused when they don't see any modules listed in the category.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->

## Changelog

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Renamed the "Vehicle Modules and Ammo" category to "Vehicle Ammo" (since it doesn't contain actual Vehicle Modules) to avoid confusion.
fix: Vehicle flamethrower ammo now comes in crates designated for flamable contents
spellcheck: Fixed spelling on TAA-AP Minigun magazine crate
fix: Made some vehicle crates a bit more accurate as to their content description
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
