### PR TITLE
thick nest balance changes and fixes

### DIFF
--- a/code/datums/construction/xenomorph/construction_template_xenomorph.dm
+++ b/code/datums/construction/xenomorph/construction_template_xenomorph.dm
@@ -75,10 +75,10 @@
 	build_type = /obj/effect/alien/resin/special/nest
 	build_icon_state = "reinforced_nest"
 
-	block_range = 2
+	block_range = 0
 
 	pixel_y = -8
 	pixel_x = -8
 
 /datum/construction_template/xenomorph/nest/set_structure_image()
-	build_icon = 'icons/mob/hostiles/structures.dmi'
+	build_icon = 'icons/mob/hostiles/structures48x48.dmi'

--- a/code/modules/cm_aliens/structures/special/pred_nest.dm
+++ b/code/modules/cm_aliens/structures/special/pred_nest.dm
@@ -11,7 +11,7 @@
 	health = 400
 	var/obj/structure/bed/nest/structure/pred_nest
 
-	block_range = 2
+	block_range = 0
 
 /obj/effect/alien/resin/special/nest/get_examine_text(mob/user)
 	. = ..()

--- a/code/modules/mob/living/carbon/human/species/yautja.dm
+++ b/code/modules/mob/living/carbon/human/species/yautja.dm
@@ -112,9 +112,9 @@
 	hive.hive_structure_types[XENO_STRUCTURE_NEST] = /datum/construction_template/xenomorph/nest
 	hive.hive_structures_limit[XENO_STRUCTURE_NEST]++
 
-	for(var/mob/living/carbon/Xenomorph/X in GLOB.living_xeno_list)
-		if(X.hive == hive)
-			to_chat(X, SPAN_XENOANNOUNCE("The hive senses that a headhunter has been infected! The thick resin nest is now available in the special structures list!"))
+	for(var/mob/living/carbon/Xenomorph/Xeno in GLOB.living_xeno_list)
+		if(Xeno.hive == hive)
+			to_chat(Xeno, SPAN_XENOANNOUNCE("The hive senses that a headhunter has been infected! The thick resin nest is now available in the special structures list!"))
 
 /datum/species/yautja/handle_death(var/mob/living/carbon/human/H, gibbed)
 	if(gibbed)

--- a/code/modules/mob/living/carbon/human/species/yautja.dm
+++ b/code/modules/mob/living/carbon/human/species/yautja.dm
@@ -112,9 +112,7 @@
 	hive.hive_structure_types[XENO_STRUCTURE_NEST] = /datum/construction_template/xenomorph/nest
 	hive.hive_structures_limit[XENO_STRUCTURE_NEST]++
 
-	for(var/mob/living/carbon/Xenomorph/Xeno in GLOB.living_xeno_list)
-		if(Xeno.hive == hive)
-			to_chat(Xeno, SPAN_XENOANNOUNCE("The hive senses that a headhunter has been infected! The thick resin nest is now available in the special structures list!"))
+	xeno_message(SPAN_XENOANNOUNCE("The hive senses that a headhunter has been infected! The thick resin nest is now available in the special structures list!"),hivenumber = hive.hivenumber)
 
 /datum/species/yautja/handle_death(var/mob/living/carbon/human/H, gibbed)
 	if(gibbed)

--- a/code/modules/mob/living/carbon/human/species/yautja.dm
+++ b/code/modules/mob/living/carbon/human/species/yautja.dm
@@ -112,6 +112,10 @@
 	hive.hive_structure_types[XENO_STRUCTURE_NEST] = /datum/construction_template/xenomorph/nest
 	hive.hive_structures_limit[XENO_STRUCTURE_NEST]++
 
+	for(var/mob/living/carbon/Xenomorph/X in GLOB.living_xeno_list)
+		if(X.hive == hive)
+			to_chat(X, SPAN_XENOANNOUNCE("The hive senses that a headhunter has been infected! The thick resin nest is now available in the special structures list!"))
+
 /datum/species/yautja/handle_death(var/mob/living/carbon/human/H, gibbed)
 	if(gibbed)
 		GLOB.yautja_mob_list -= H


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

This PR brings in a balance change to the not so well known thick resin nest special structure, tldr its a nest that becomes unlocked if a predator gets infected. The space required to build the nest has been removed to provide more freedom and the construction template's icon has been fixed to actually work and be seen by xenos so they know where the construction is to fill it with their plasma. Another welcoming change is giving the hive an announcement that this nest has been unlocked whenever a pred gets infected so xenos know that this thing exists and where it is located.

some images:
![Screenshot_3](https://user-images.githubusercontent.com/83834638/200808087-7d56c288-970d-4261-bcf5-40340455a7be.png)
stan's balance approval

![Screenshot_4](https://user-images.githubusercontent.com/83834638/200808144-f864a265-551e-44a2-8d62-b5632317336f.png)
how nests will now look in the future (no more space restriction!)

![Screenshot_5](https://user-images.githubusercontent.com/83834638/200808274-9f7cac7d-fce8-4968-bd8d-ce14a1b22914.png)
the hive being notified

![Screenshot_6](https://user-images.githubusercontent.com/83834638/200808342-a6897a8c-d71e-4b73-bd21-f7f143dbd7a8.png)
the fixed construction template



## Why It's Good For The Game

More freedom for xenos on building protection around the nest and providing information about this rare feature.

## Changelog

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Unknownity
balance: The thick resin nest's space for construction requirements has been removed.
balance: The hive is now notified that the thick resin nest is now available whenever a predator is infected.
fix: The thick resin nest's construction template has been fixed to actually appear now so xenomorphs know where it is to fill it with plasma.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
