### PR TITLE
Datumizes `/obj/effect/datacore`

### DIFF
--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -1,6 +1,6 @@
-GLOBAL_DATUM_INIT(data_core, /obj/effect/datacore, new)
+GLOBAL_DATUM_INIT(data_core, /datum/datacore, new)
 
-/obj/effect/datacore
+/datum/datacore
 	name = "datacore"
 	var/medical[] = list()
 	var/general[] = list()
@@ -8,7 +8,7 @@ GLOBAL_DATUM_INIT(data_core, /obj/effect/datacore, new)
 	//This list tracks characters spawned in the world and cannot be modified in-game. Currently referenced by respawn_character().
 	var/locked[] = list()
 
-/obj/effect/datacore/proc/get_manifest(monochrome, OOC, nonHTML)
+/datum/datacore/proc/get_manifest(monochrome, OOC, nonHTML)
 	var/list/cic = ROLES_CIC.Copy()
 	var/list/auxil = ROLES_AUXIL_SUPPORT.Copy()
 	var/list/misc = ROLES_MISC.Copy()
@@ -198,7 +198,7 @@ GLOBAL_DATUM_INIT(data_core, /obj/effect/datacore, new)
 	dat = replacetext(dat, "\t", "")
 	return dat
 
-/obj/effect/datacore/proc/manifest(var/nosleep = 0)
+/datum/datacore/proc/manifest(var/nosleep = 0)
 	spawn()
 		if(!nosleep)
 			sleep(40)
@@ -210,7 +210,7 @@ GLOBAL_DATUM_INIT(data_core, /obj/effect/datacore, new)
 			if(H.job in jobs_to_check)
 				manifest_inject(H)
 
-/obj/effect/datacore/proc/manifest_modify(name, ref, assignment, rank, p_stat)
+/datum/datacore/proc/manifest_modify(name, ref, assignment, rank, p_stat)
 	var/datum/data/record/foundrecord
 
 	var/use_name = isnull(ref)
@@ -234,7 +234,7 @@ GLOBAL_DATUM_INIT(data_core, /obj/effect/datacore, new)
 		return TRUE
 	return FALSE
 
-/obj/effect/datacore/proc/manifest_inject(var/mob/living/carbon/human/H)
+/datum/datacore/proc/manifest_inject(var/mob/living/carbon/human/H)
 	var/assignment
 	if(H.job)
 		assignment = H.job

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -1,7 +1,6 @@
 GLOBAL_DATUM_INIT(data_core, /datum/datacore, new)
 
 /datum/datacore
-	name = "datacore"
 	var/medical[] = list()
 	var/general[] = list()
 	var/security[] = list()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Converts the datacore from an `/obj/effect` to a `/datum`, as instances that have no physical presence in the world should be doing

## Why It's Good For The Game
This is quite literally what datums exist for

## Changelog

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
refactor: The datacore now is a /datum, not /obj/effect
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
