### PR TITLE
Removes pooling bursted bodies

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/Embryo.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Embryo.dm
@@ -267,6 +267,7 @@
 		victim.death(cause) // Certain species were still surviving bursting (predators), DEFINITELY kill them this time.
 		victim.chestburst = 2
 		victim.update_burst()
+		hive.stored_larva++
 
 // Squeeze thru dense objects as a larva, as airlocks
 /mob/living/carbon/Xenomorph/Larva/proc/scuttle(var/obj/structure/S)


### PR DESCRIPTION
Removes the pooling of chestbursted human bodies into the xenomorph spawn pool.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Removes the pooling of chestbursted human bodies into the xenomorph spawn pool. Chestbursts now simply give an extra pooled larva to depict the hivemind as being empowered by a host bursting after a very short moment. The delay's about as equivalent to as long as it took for someone to be unbuckled and pooled before.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Deleting chestbursted bodies by being pooled is very soul less. This was apparently very much discussed in the discord [here.](https://discord.com/channels/150315577943130112/1039081406615277618/1039081406615277618) (I'm not in the discord so not actually sure what's in it or what was talked about, link sent by a friend)

It adds soul because the pooling itself is a meaningless and hollow interaction to begin with. It's meaningless for both sides. For xenos, they have no reason to care other than the extra larva it gives, and all it becomes is a soul less chore of a thorn if every xenos are or needed at the front and one of them have to bother running back to the hive to pool a body they have no reason to and don't care about. For marines, being captured and pooled is one of the most meaningless things that can happen in their rounds, coupled with the fact finding your buddies remains if the hive ever does get cleared out was used to be one of the most meaningful and Aliens-like moments you can experience within the game.

## Changelog

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: Removes the pooling of chestbursted human bodies into the xenomorph spawn pool. Chestbursting now automatically grants an extra pooled larva that melting bodies down would formerly provide.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
