### PR TITLE
Adds flamer kits to the rifleman vendor

### DIFF
--- a/code/game/machinery/vending/vendor_types/squad_prep/squad_prep.dm
+++ b/code/game/machinery/vending/vendor_types/squad_prep/squad_prep.dm
@@ -142,6 +142,8 @@ GLOBAL_LIST_INIT(cm_vending_clothing_marine, list(
 		list("SU-6 Smart Pistol", 15, /obj/item/storage/box/guncase/smartpistol, null, VENDOR_ITEM_REGULAR),
 		list("M41AE2 Heavy Pulse Rifle", 30, /obj/item/storage/box/guncase/lmg, null, VENDOR_ITEM_REGULAR),
 		list("M79 Grenade Launcher", 30, /obj/item/storage/box/guncase/m79, null, VENDOR_ITEM_REGULAR),
+		list("M240 Incinerator Unit", 30, /obj/item/storage/box/guncase/flamer, null, VENDOR_ITEM_REGULAR),
+
 
 		list("EXPLOSIVES", 0, null, null, null),
 		list("M40 HEDP High Explosive Packet (x3 grenades)", 20, /obj/item/storage/box/packet/high_explosive, null, VENDOR_ITEM_REGULAR),


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Adds flamer kits back to the rifleman vendor, for 30 points.
## Why It's Good For The Game
Flamers are currently very limited, and I feel like putting them in the vendor would make marines push better

## Changelog

:cl:
add: Flamer kits are now in the rifleman vendor, for 30 points

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
