### PR TITLE
Fixes Tripod Lamps and candelabras

### DIFF
--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -16,6 +16,9 @@
 	var/raillight_compatible = TRUE //Can this be turned into a rail light ?
 	var/toggleable = TRUE
 
+	var/can_be_broken = TRUE //can xenos swipe at this to break it/turn it off?
+	var/breaking_sound = 'sound/handling/click_2.ogg' //sound used when this happens
+
 /obj/item/device/flashlight/Initialize()
 	. = ..()
 	if(on)
@@ -30,7 +33,6 @@
 		else
 			SetLuminosity(0)
 	. = ..()
-
 
 /obj/item/device/flashlight/proc/update_brightness(var/mob/user = null)
 	if(on)
@@ -129,6 +131,14 @@
 	else
 		return ..()
 
+/obj/item/device/flashlight/attack_alien(mob/living/carbon/Xenomorph/M)
+	. = ..()
+
+	if(on && can_be_broken)
+		if(breaking_sound)
+			playsound(src.loc, breaking_sound, 25, 1)
+		on = FALSE
+		update_brightness()
 
 /obj/item/device/flashlight/pickup(mob/user)
 	if(on)
@@ -176,7 +186,15 @@
 	on = 0
 	raillight_compatible = 0
 
-/obj/item/device/flashlight/lamp/on/Initialize()
+	breaking_sound = 'sound/effects/Glasshit.ogg'
+
+/obj/item/device/flashlight/lamp/Initialize()
+	. = ..()
+
+	if(on)
+		update_brightness()
+
+/obj/item/device/flashlight/lamp/on/Initialize() //unused, but im leaving it here anyways :D
 	. = ..()
 	on = 1
 	update_brightness()
@@ -190,6 +208,7 @@
 	brightness_on = 2
 	w_class = SIZE_LARGE
 	on = 1
+	breaking_sound = null
 
 //Generic Candelabra
 /obj/item/device/flashlight/lamp/candelabra
@@ -197,6 +216,9 @@
 	desc = "A fire hazard that can be used to thwack things with impunity."
 	icon_state = "candelabra"
 	force = 15
+	on = TRUE
+
+	breaking_sound = null
 
 //Green-shaded desk lamp
 /obj/item/device/flashlight/lamp/green
@@ -212,10 +234,6 @@
 	brightness_on = 6//pretty good
 	w_class = SIZE_LARGE
 	on = 1
-
-//obj/item/device/flashlight/lamp/tripod/New() //start all tripod lamps as on.
-//	..()
-//	update_brightness()
 
 /obj/item/device/flashlight/lamp/tripod/grey
 	icon_state = "tripod_lamp_grey"
@@ -243,6 +261,7 @@
 	item_state = "flare"
 	actions = list()	//just pull it manually, neckbeard.
 	raillight_compatible = 0
+	can_be_broken = FALSE
 	var/fuel = 0
 	var/fuel_rate = AMOUNT_PER_TIME(1 SECONDS, 1 SECONDS)
 	var/on_damage = 7
@@ -321,7 +340,7 @@
 		var/mob/living/carbon/U = user
 		if(istype(U) && !U.throw_mode)
 			U.toggle_throw_mode(THROW_MODE_NORMAL)
-			
+
 /obj/item/device/flashlight/flare/proc/activate_signal(mob/living/carbon/human/user)
 	return
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

By request @Agameofscones this PR fixes Tripod lamps and candelabras not starting on. Also adds ability to break them as a xeno. Also added ability to break normal flashlights: bringing the existing functionality for guns and the rail-light to them.

![dreamseeker_v17JWIgabv](https://user-images.githubusercontent.com/16618648/201208376-706eb701-7755-476e-b64b-af621b799cbc.gif)

![dreamseeker_JpWW7FA5X0](https://user-images.githubusercontent.com/16618648/201208486-24d5d5f7-5181-44ad-8aeb-32aa74ac8f03.gif)

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->

These items have been in our maps for a long while now but have remained non-functional, having a game with working features is good. For turning them off: having the same mechanics for similar items is good game design, its snowflakey otherwise.

## Changelog

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixed tripod lights and candelabras not starting as on, fixed not being able to break these items and flashlights as xeno.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
