### PR TITLE
No more pushups while you shouldnt

### DIFF
--- a/code/modules/mob/living/carbon/human/exercise.dm
+++ b/code/modules/mob/living/carbon/human/exercise.dm
@@ -73,7 +73,7 @@ Verbs related to getting fucking jacked, bro
 	if(is_mob_incapacitated())
 		return FALSE
 
-	if(!resting)
+	if(!resting || buckled)
 		to_chat(src, SPAN_WARNING("How do you think you'll be able to do a pushup standing up? Get down to the floor!"))
 		return FALSE
 
@@ -91,6 +91,10 @@ Verbs related to getting fucking jacked, bro
 		to_chat(src, SPAN_WARNING("You feel far too weak to do a pushup!"))
 		return FALSE
 	return TRUE
+
+	if(!isturf(loc))
+		to_chat(src, SPAN_WARNING("You cannot do that here!"))
+		return FALSE
 
 /mob/living/carbon/human/proc/calculate_stamina_loss_per_pushup(var/on_knees = FALSE)
 	//humans have 100 stamina

--- a/code/modules/mob/living/carbon/human/exercise.dm
+++ b/code/modules/mob/living/carbon/human/exercise.dm
@@ -90,11 +90,13 @@ Verbs related to getting fucking jacked, bro
 	if(stamina.current_stamina < (stamina.max_stamina / 10))
 		to_chat(src, SPAN_WARNING("You feel far too weak to do a pushup!"))
 		return FALSE
-	return TRUE
 
 	if(!isturf(loc))
 		to_chat(src, SPAN_WARNING("You cannot do that here!"))
 		return FALSE
+
+	return TRUE
+
 
 /mob/living/carbon/human/proc/calculate_stamina_loss_per_pushup(var/on_knees = FALSE)
 	//humans have 100 stamina


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Stops being able to do pushups while in a xeno, or while buckled.

@morrowwolf 

https://user-images.githubusercontent.com/16618648/201210514-85c4b927-49d3-44eb-9606-5334d022d0ca.mp4

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->
Jank be gone.

## Changelog

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Removed ability to do pushups while in a xeno or while buckled.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
