### PR TITLE
Berserker re-tweaking (NO GPB UPDATE)

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/ravager/ravager_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/ravager/ravager_abilities.dm
@@ -68,7 +68,7 @@
 	xeno_cooldown = 15 SECONDS
 
 	// Config values
-	var/speed_buff = 0.6
+	var/speed_buff = 0.7
 	var/buff_duration = 6 SECONDS
 
 

--- a/code/modules/mob/living/carbon/xenomorph/abilities/ravager/ravager_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/ravager/ravager_abilities.dm
@@ -65,11 +65,11 @@
 	action_type = XENO_ACTION_CLICK
 	ability_primacy = XENO_PRIMARY_ACTION_1
 	plasma_cost = 0
-	xeno_cooldown = 17 SECONDS
+	xeno_cooldown = 15 SECONDS
 
 	// Config values
-	var/speed_buff = 0.75
-	var/buff_duration = 8 SECONDS
+	var/speed_buff = 0.6
+	var/buff_duration = 6 SECONDS
 
 
 /datum/action/xeno_action/activable/clothesline

--- a/code/modules/mob/living/carbon/xenomorph/mutators/strains/ravager/berserker.dm
+++ b/code/modules/mob/living/carbon/xenomorph/mutators/strains/ravager/berserker.dm
@@ -29,6 +29,7 @@
 	R.health_modifier -= XENO_HEALTH_MOD_MED
 	R.armor_modifier += XENO_ARMOR_MOD_VERYSMALL
 	R.speed_modifier += XENO_SPEED_FASTMOD_TIER_3
+	R.ignore_aura = "frenzy" // Berserker should only rely on its own speed from slashes, also fucks with apprehend
 
 	mutator_update_actions(R)
 	MS.recalculate_actions(description, flavor_description)
@@ -52,7 +53,7 @@
 
 	// Eviscerate config
 	var/rage_lock_duration = 10 SECONDS      // 10 seconds of max rage
-	var/rage_cooldown_duration = 6 SECONDS  // 6 seconds of NO rage.
+	var/rage_cooldown_duration = 8 SECONDS  // 8 seconds of NO rage.
 
 	// State for tracking rage
 	var/rage = 0


### PR DESCRIPTION
## About The Pull Request

Turns out, berserker is too powerful. It's speed with apprehend stacked with frenzy pheros, and it's normal rage speed boost which made it almost identical to a runner but even more powerful. In order to fix this, I removed the ability for berserkers to gain any frenzy aura buff, i've made the rage lock out 8 seconds instead of 6 (too damn low), i've also reduced the speed buff greatly.

## Why It's Good For The Game

Berserker shouldn't be a runner, and it's lock out proved to be too low. This PR fixes it's issues and makes it balanced.

## Changelog


balance: Berserkers can no longer use frenzy auras
balance: Berserkers speed buff has been lowered, it's rage lockout 2 seconds longer.
/:cl: