### PR TITLE
Berserker re tweakening: The rebalanced [NO GPB UPDATE]

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
@@ -197,6 +197,7 @@
 	var/regeneration_multiplier = 1
 	var/speed_modifier = 0
 	var/phero_modifier = 0
+	var/received_phero_caps = list()
 	var/acid_modifier = 0
 	var/weed_modifier = 0
 	var/evasion_modifier = 0
@@ -293,7 +294,6 @@
 	var/warding_aura = 0
 	var/recovery_aura = 0
 	var/ignore_aura = FALSE // ignore a specific pherom, input type
-
 
 	//////////////////////////////////////////////////////////////////
 	//
@@ -943,6 +943,15 @@
 		current_aura = null
 		to_chat(src, SPAN_XENOWARNING("You lose your pheromones."))
 
+	// Also recalculate received pheros now
+	for(var/capped_aura in received_phero_caps)
+		switch(capped_aura)
+			if("frenzy")
+				frenzy_new = min(frenzy_new, received_phero_caps[capped_aura])
+			if("warding")
+				warding_new = min(warding_new, received_phero_caps[capped_aura])
+			if("recovery")
+				recovery_new = min(recovery_new, received_phero_caps[capped_aura])
 
 /mob/living/carbon/Xenomorph/proc/recalculate_maturation()
 	evolution_threshold =  caste.evolution_threshold

--- a/code/modules/mob/living/carbon/xenomorph/abilities/ravager/ravager_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/ravager/ravager_abilities.dm
@@ -68,7 +68,7 @@
 	xeno_cooldown = 15 SECONDS
 
 	// Config values
-	var/speed_buff = 0.6
+	var/speed_buff = 0.7
 	var/buff_duration = 6 SECONDS
 
 

--- a/code/modules/mob/living/carbon/xenomorph/abilities/ravager/ravager_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/ravager/ravager_abilities.dm
@@ -68,7 +68,7 @@
 	xeno_cooldown = 16 SECONDS
 
 	// Config values
-	var/speed_buff = 0.8
+	var/speed_buff = 0.75
 	var/buff_duration = 7 SECONDS
 
 

--- a/code/modules/mob/living/carbon/xenomorph/abilities/ravager/ravager_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/ravager/ravager_abilities.dm
@@ -65,11 +65,11 @@
 	action_type = XENO_ACTION_CLICK
 	ability_primacy = XENO_PRIMARY_ACTION_1
 	plasma_cost = 0
-	xeno_cooldown = 17 SECONDS
+	xeno_cooldown = 15 SECONDS
 
 	// Config values
-	var/speed_buff = 0.75
-	var/buff_duration = 8 SECONDS
+	var/speed_buff = 0.6
+	var/buff_duration = 6 SECONDS
 
 
 /datum/action/xeno_action/activable/clothesline

--- a/code/modules/mob/living/carbon/xenomorph/abilities/ravager/ravager_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/ravager/ravager_abilities.dm
@@ -68,7 +68,7 @@
 	xeno_cooldown = 16 SECONDS
 
 	// Config values
-	var/speed_buff = 0.7
+	var/speed_buff = 0.85
 	var/buff_duration = 7 SECONDS
 
 

--- a/code/modules/mob/living/carbon/xenomorph/abilities/ravager/ravager_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/ravager/ravager_abilities.dm
@@ -65,11 +65,11 @@
 	action_type = XENO_ACTION_CLICK
 	ability_primacy = XENO_PRIMARY_ACTION_1
 	plasma_cost = 0
-	xeno_cooldown = 15 SECONDS
+	xeno_cooldown = 16 SECONDS
 
 	// Config values
 	var/speed_buff = 0.7
-	var/buff_duration = 6 SECONDS
+	var/buff_duration = 7 SECONDS
 
 
 /datum/action/xeno_action/activable/clothesline

--- a/code/modules/mob/living/carbon/xenomorph/abilities/ravager/ravager_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/ravager/ravager_abilities.dm
@@ -68,7 +68,7 @@
 	xeno_cooldown = 16 SECONDS
 
 	// Config values
-	var/speed_buff = 0.85
+	var/speed_buff = 0.8
 	var/buff_duration = 7 SECONDS
 
 

--- a/code/modules/mob/living/carbon/xenomorph/abilities/ravager/ravager_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/ravager/ravager_abilities.dm
@@ -65,7 +65,7 @@
 	action_type = XENO_ACTION_CLICK
 	ability_primacy = XENO_PRIMARY_ACTION_1
 	plasma_cost = 0
-	xeno_cooldown = 16 SECONDS
+	xeno_cooldown = 17 SECONDS
 
 	// Config values
 	var/speed_buff = 0.75

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -140,6 +140,17 @@
 			if(strength > recovery_new)
 				recovery_new = strength
 
+	// Also cap the auras
+	for(var/capped_aura in received_phero_caps)
+		switch(capped_aura)
+			if("frenzy")
+				frenzy_new = min(frenzy_new, received_phero_caps[capped_aura])
+			if("warding")
+				warding_new = min(warding_new, received_phero_caps[capped_aura])
+			if("recovery")
+				recovery_new = min(recovery_new, received_phero_caps[capped_aura])
+
+
 /mob/living/carbon/Xenomorph/handle_regular_status_updates(regular_update = TRUE)
 	if(regular_update && health <= 0 && (!caste || (caste.fire_immunity & FIRE_IMMUNITY_NO_IGNITE) || !on_fire)) //Sleeping Xenos are also unconscious, but all crit Xenos are under 0 HP. Go figure
 		var/turf/T = loc

--- a/code/modules/mob/living/carbon/xenomorph/mutators/strains/ravager/berserker.dm
+++ b/code/modules/mob/living/carbon/xenomorph/mutators/strains/ravager/berserker.dm
@@ -29,8 +29,7 @@
 	R.health_modifier -= XENO_HEALTH_MOD_MED
 	R.armor_modifier += XENO_ARMOR_MOD_VERYSMALL
 	R.speed_modifier += XENO_SPEED_FASTMOD_TIER_3
-	R.ignore_aura = "frenzy" // Berserker should only rely on its own speed from slashes, also fucks with apprehend
-
+	R.received_phero_caps["frenzy"] = 2.9 // Moderate
 	mutator_update_actions(R)
 	MS.recalculate_actions(description, flavor_description)
 

--- a/code/modules/mob/living/carbon/xenomorph/mutators/strains/ravager/berserker.dm
+++ b/code/modules/mob/living/carbon/xenomorph/mutators/strains/ravager/berserker.dm
@@ -29,6 +29,7 @@
 	R.health_modifier -= XENO_HEALTH_MOD_MED
 	R.armor_modifier += XENO_ARMOR_MOD_VERYSMALL
 	R.speed_modifier += XENO_SPEED_FASTMOD_TIER_3
+	R.ignore_aura = "frenzy" // Berserker should only rely on its own speed from slashes, also fucks with apprehend
 
 	mutator_update_actions(R)
 	MS.recalculate_actions(description, flavor_description)
@@ -52,7 +53,7 @@
 
 	// Eviscerate config
 	var/rage_lock_duration = 10 SECONDS      // 10 seconds of max rage
-	var/rage_cooldown_duration = 6 SECONDS  // 6 seconds of NO rage.
+	var/rage_cooldown_duration = 8 SECONDS  // 8 seconds of NO rage.
 
 	// State for tracking rage
 	var/rage = 0

--- a/code/modules/mob/living/carbon/xenomorph/mutators/strains/ravager/berserker.dm
+++ b/code/modules/mob/living/carbon/xenomorph/mutators/strains/ravager/berserker.dm
@@ -52,7 +52,7 @@
 
 	// Eviscerate config
 	var/rage_lock_duration = 10 SECONDS      // 10 seconds of max rage
-	var/rage_cooldown_duration = 8 SECONDS  // 8 seconds of NO rage.
+	var/rage_cooldown_duration = 7 SECONDS  // 7 seconds of NO rage.
 
 	// State for tracking rage
 	var/rage = 0


### PR DESCRIPTION
## About The Pull Request

Berserker is too powerful with 3 stackable buffs. This PR fixes it. Also, the rage lockout duration was way too short so i've increased it by 1 second. I've also tuned apprehend to have a shorter duration. The reason for this is that I've introduced a pheromone cap system for each possible pheros, and gave berserker a maximum capable frenzy of 2.9 (or moderate pheromone). This is to curb strong/very strong frenzy making berserkers run like a fucking mach speed train, and without the band aid fix of removing frenzy from being used on berserker all together. Huge thanks to drathek, who showed me how to do this (and pretty much did the aura capping himself).

## Why It's Good For The Game

Berserker needed fine tuning again, it's fun now but at the cost of having some pieces of its kit overtuned. Namely, the 3 stackable speed buffs from frenzy pheros, apprehend, and its base slash increase which all together made berserker look like a runner that slowed on the first hit, dealt 45 damage, and quickly racked up a ton of armor. Also, the rage lockout being so low meant that it had too little downtime, especially mid combat. 

## Changelog

:cl: Usnpeepoo, Drathek
add: Pheromones can be capped on xenomorphs, and you can cap specific pheromones at specific values
balance: Berserkers are capped to Moderate pheromones with frenzy, other pheromones are not capped
balance: Berserkers apprehend is now a second shorter.
balance: Berserkers rage lockout has been increased by a second
/:cl:
