### PR TITLE
Supply drops now use Drop Pods

### DIFF
--- a/ColonialMarinesALPHA.dme
+++ b/ColonialMarinesALPHA.dme
@@ -1428,6 +1428,7 @@
 #include "code\modules\cm_tech\droppod\gear_access_point.dm"
 #include "code\modules\cm_tech\droppod\lz_effect.dm"
 #include "code\modules\cm_tech\droppod\marine.dm"
+#include "code\modules\cm_tech\droppod\supply.dm"
 #include "code\modules\cm_tech\implements\adv_weapon.dm"
 #include "code\modules\cm_tech\implements\ammo_kits.dm"
 #include "code\modules\cm_tech\implements\armor.dm"

--- a/code/game/jobs/job/marine/squads.dm
+++ b/code/game/jobs/job/marine/squads.dm
@@ -320,6 +320,42 @@
 		SSsound.queue(sfx, targets)
 	to_chat(targets, html = message, type = MESSAGE_TYPE_RADIO)
 
+/// Displays a message to squad members directly on the game map
+/datum/squad/proc/send_maptext(var/text = "", var/title_text = "", var/only_leader = 0)
+	var/message_colour = squad_colors_chat[color]
+	if(only_leader)
+		if(squad_leader)
+			var/mob/living/carbon/human/SL = squad_leader
+			if(!SL.stat && SL.client)
+				SL.play_screen_text("<span class='langchat' style=font-size:16pt;text-align:center valign='top'><u>[title_text]</u></span><br>" + text, /atom/movable/screen/text/screen_text/command_order, message_colour)
+	else
+		for(var/mob/living/carbon/human/M in marines_list)
+			if(!M.stat && M.client) //Only living and connected people in our squad
+				M.play_screen_text("<span class='langchat' style=font-size:16pt;text-align:center valign='top'><u>[title_text]</u></span><br>" + text, /atom/movable/screen/text/screen_text/command_order, message_colour)
+
+/// Displays a message to the squad members in chat
+/datum/squad/proc/send_message(var/text = "", var/plus_name = 0, var/only_leader = 0)
+	var/nametext = ""
+	if(plus_name)
+		nametext = "[usr.name] transmits: "
+		text = "[FONT_SIZE_LARGE("<b>[text]<b>")]"
+
+	if(only_leader)
+		if(squad_leader)
+			var/mob/living/carbon/human/SL = squad_leader
+			if(!SL.stat && SL.client)
+				if(plus_name)
+					SL << sound('sound/effects/tech_notification.ogg')
+				to_chat(SL, "[SPAN_BLUE("<B>SL Overwatch:</b> [nametext][text]")]")
+				return
+	else
+		for(var/mob/living/carbon/human/M in marines_list)
+			if(!M.stat && M.client) //Only living and connected people in our squad
+				if(plus_name)
+					M << sound('sound/effects/tech_notification.ogg')
+				to_chat(M, "[SPAN_BLUE("<B>Overwatch:</b> [nametext][text]")]")
+
+
 
 //Straight-up insert a marine into a squad.
 //This sets their ID, increments the total count, and so on. Everything else is done in job_controller.dm.

--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -175,7 +175,6 @@ var/datum/controller/supply/supply_controller = new()
 	data["worldtime"] = world.time
 	data["x_offset"] = x_supply
 	data["y_offset"] = y_supply
-	data["active"] = FALSE
 	data["loaded"] = loaded_crate
 	if(loaded_crate)
 		data["crate_name"] = loaded_crate.name

--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -128,7 +128,6 @@ var/datum/controller/supply/supply_controller = new()
 	var/x_supply = 0
 	var/y_supply = 0
 	var/datum/squad/current_squad = null
-	var/busy = FALSE //The computer is busy launching a drop, lock controls
 	var/drop_cooldown = 1 MINUTES
 	var/can_pick_squad = TRUE
 	var/faction = FACTION_MARINE
@@ -176,7 +175,7 @@ var/datum/controller/supply/supply_controller = new()
 	data["worldtime"] = world.time
 	data["x_offset"] = x_supply
 	data["y_offset"] = y_supply
-	data["active"] = busy
+	data["active"] = FALSE
 	data["loaded"] = loaded_crate
 	if(loaded_crate)
 		data["crate_name"] = loaded_crate.name
@@ -251,10 +250,7 @@ var/datum/controller/supply/supply_controller = new()
 		return FALSE
 
 /obj/structure/machinery/computer/supply_drop_console/proc/handle_supplydrop()
-	if(busy)
-		to_chat(usr, "[icon2html(src, usr)] [SPAN_WARNING("\The [name] is busy processing another action!")]")
-		return
-
+	SHOULD_NOT_SLEEP(TRUE)
 	var/obj/structure/closet/crate/C = check_pad()
 	if(!C)
 		to_chat(usr, "[icon2html(src, usr)] [SPAN_WARNING("No crate was detected on the drop pad. Get Requisitions on the line!")]")
@@ -282,57 +278,19 @@ var/datum/controller/supply/supply_controller = new()
 		to_chat(usr, "[icon2html(src, usr)] [SPAN_WARNING("The landing zone appears to be obstructed or out of bounds. Package would be lost on drop.")]")
 		return
 
-	busy = TRUE
+	C.visible_message(SPAN_WARNING("\The [C] loads into a launch tube. Stand clear!"))
+	current_squad.send_message("'[C.name]' supply drop incoming. Heads up!")
+	current_squad.send_maptext(C.name, "Incoming Supply Drop:")
+	COOLDOWN_START(src, next_fire, drop_cooldown)
+	if(ismob(usr))
+		var/mob/M = usr
+		M.count_niche_stat(STATISTICS_NICHE_CRATES)
 
-	visible_message("[icon2html(src, viewers(src))] [SPAN_BOLDNOTICE("'[C.name]' supply drop is now loading into the launch tube! Stand by!")]")
-	C.visible_message(SPAN_WARNING("\The [C] begins to load into a launch tube. Stand clear!"))
-	C.anchored = TRUE //To avoid accidental pushes
-	send_to_squad("'[C.name]' supply drop incoming. Heads up!")
-	var/datum/squad/S = current_squad //in case the operator changes the overwatched squad mid-drop
-	spawn(100)
-		if(!C || C.loc != S.drop_pad.loc) //Crate no longer on pad somehow, abort.
-			if(C)
-				C.anchored = FALSE
-			to_chat(usr, "[icon2html(src, usr)] [SPAN_WARNING("Launch aborted! No crate detected on the drop pad.")]")
-			return
-		COOLDOWN_START(src, next_fire, drop_cooldown)
-		if(ismob(usr))
-			var/mob/M = usr
-			M.count_niche_stat(STATISTICS_NICHE_CRATES)
-
-		playsound(C.loc,'sound/effects/bamf.ogg', 50, 1)  //Ehh
-		C.anchored = FALSE
-		C.forceMove(T)
-		var/turf/TC = get_turf(C)
-		TC.ceiling_debris_check(3)
-		playsound(C.loc,'sound/effects/bamf.ogg', 50, 1)  //Ehhhhhhhhh.
-		C.visible_message("[icon2html(C, viewers(src))] [SPAN_BOLDNOTICE("The '[C.name]' supply drop falls from the sky!")]")
-		visible_message("[icon2html(src, viewers(src))] [SPAN_BOLDNOTICE("'[C.name]' supply drop launched! Another launch will be available in five minutes.")]")
-		busy = FALSE
-
-
-//Sends a string to our currently selected squad.
-/obj/structure/machinery/computer/supply_drop_console/proc/send_to_squad(var/txt = "", var/plus_name = 0, var/only_leader = 0)
-	if(txt == "" || !current_squad) return //Logic
-
-	var/text = strip_html(txt)
-	var/nametext = ""
-	if(plus_name)
-		nametext = "[usr.name] transmits: "
-		text = "<font size='3'><b>[text]<b></font>"
-
-	for(var/mob/living/carbon/human/M in current_squad.marines_list)
-		if(!M.stat && M.client) //Only living and connected people in our squad
-			if(!only_leader)
-				if(plus_name)
-					M << sound('sound/effects/radiostatic.ogg')
-				to_chat(M, "[icon2html(src, M)] [SPAN_BLUE("<B>\[Overwatch\]:</b> [nametext][text]")]")
-			else
-				if(current_squad.squad_leader == M)
-					if(plus_name)
-						M << sound('sound/effects/radiostatic.ogg')
-					to_chat(M, "[icon2html(src, M)] [SPAN_BLUE("<B>\[SL Overwatch\]:</b> [nametext][text]</font>")]")
-					return
+	playsound(C.loc,'sound/effects/bamf.ogg', 50, 1)  //Ehh
+	var/obj/structure/droppod/supply/pod = new()
+	C.forceMove(pod)
+	pod.launch(T)
+	visible_message("[icon2html(src, viewers(src))] [SPAN_BOLDNOTICE("'[C.name]' supply drop launched! Another launch will be available in five minutes.")]")
 
 //A limited version of the above console
 //Can't pick squads, drops less often

--- a/code/modules/cm_marines/overwatch.dm
+++ b/code/modules/cm_marines/overwatch.dm
@@ -922,6 +922,7 @@
 	C.visible_message(SPAN_WARNING("\The [C] loads into a launch tube. Stand clear!"))
 	C.anchored = TRUE //To avoid accidental pushes
 	current_squad.send_message("'[C.name]' supply drop incoming. Heads up!")
+	current_squad.send_maptext(C.name, "Incoming Supply Drop:")
 	var/datum/squad/S = current_squad //in case the operator changes the overwatched squad mid-drop
 	COOLDOWN_START(S, next_supplydrop, 500 SECONDS)
 	if(ismob(usr))

--- a/code/modules/cm_marines/overwatch.dm
+++ b/code/modules/cm_marines/overwatch.dm
@@ -481,16 +481,16 @@
 			if(current_squad && operator == usr)
 				var/input = sanitize_control_chars(stripped_input(usr, "Please write a message to announce to the squad:", "Squad Message"))
 				if(input)
-					send_to_squad(input, 1) //message, adds username
-					send_maptext_to_squad(input, "Squad Message:")
+					current_squad.send_message(input, 1) //message, adds username
+					current_squad.send_maptext(input, "Squad Message:")
 					visible_message("[icon2html(src, viewers(src))] [SPAN_BOLDNOTICE("Message '[input]' sent to all Marines of squad '[current_squad]'.")]")
 					log_overwatch("[key_name(usr)] sent '[input]' to squad [current_squad].")
 		if("sl_message")
 			if(current_squad && operator == usr)
 				var/input = sanitize_control_chars(stripped_input(usr, "Please write a message to announce to the squad leader:", "SL Message"))
 				if(input)
-					send_to_squad(input, 1, 1) //message, adds username, only to leader
-					send_maptext_to_squad(input, "Squad Leader Message:", 1)
+					current_squad.send_message(input, 1, 1) //message, adds username, only to leader
+					current_squad.send_maptext(input, "Squad Leader Message:", 1)
 					visible_message("[icon2html(src, viewers(src))] [SPAN_BOLDNOTICE("Message '[input]' sent to Squad Leader [current_squad.squad_leader] of squad '[current_squad]'.")]")
 					log_overwatch("[key_name(usr)] sent '[input]' to Squad Leader [current_squad.squad_leader] of squad [current_squad].")
 		if("check_primary")
@@ -507,16 +507,16 @@
 			var/input = sanitize_control_chars(stripped_input(usr, "What will be the squad's primary objective?", "Primary Objective"))
 			if(current_squad && input)
 				current_squad.primary_objective = "[input] ([worldtime2text()])"
-				send_to_squad("Your primary objective has been changed to '[input]'. See Status pane for details.")
-				send_maptext_to_squad(input, "Primary Objective Updated:")
+				current_squad.send_message("Your primary objective has been changed to '[input]'. See Status pane for details.")
+				current_squad.send_maptext(input, "Primary Objective Updated:")
 				visible_message("[icon2html(src, viewers(src))] [SPAN_BOLDNOTICE("Primary objective of squad '[current_squad]' set to '[input]'.")]")
 				log_overwatch("[key_name(usr)] set [current_squad]'s primary objective to '[input]'.")
 		if("set_secondary")
 			var/input = sanitize_control_chars(stripped_input(usr, "What will be the squad's secondary objective?", "Secondary Objective"))
 			if(input)
 				current_squad.secondary_objective = input + " ([worldtime2text()])"
-				send_to_squad("Your secondary objective has been changed to '[input]'. See Status pane for details.")
-				send_maptext_to_squad(input, "Secondary Objective Updated:")
+				current_squad.send_message("Your secondary objective has been changed to '[input]'. See Status pane for details.")
+				current_squad.send_maptext(input, "Secondary Objective Updated:")
 				visible_message("[icon2html(src, viewers(src))] [SPAN_BOLDNOTICE("Secondary objective of squad '[current_squad]' set to '[input]'.")]")
 				log_overwatch("[key_name(usr)] set [current_squad]'s secondary objective to '[input]'.")
 		if("supply_x")
@@ -637,48 +637,6 @@
 			var/obj/item/clothing/head/helmet/marine/helm = H.head
 			return helm.camera
 
-//Sends a string to our currently selected squad.
-/obj/structure/machinery/computer/overwatch/proc/send_to_squad(var/text = "", var/plus_name = 0, var/only_leader = 0)
-	if(text == "" || !current_squad || !operator)
-		return //Logic
-
-	var/nametext = ""
-	if(plus_name)
-		nametext = "[usr.name] transmits: "
-		text = "[FONT_SIZE_LARGE("<b>[text]<b>")]"
-
-	if(only_leader)
-		if(current_squad.squad_leader)
-			var/mob/living/carbon/human/SL = current_squad.squad_leader
-			if(!SL.stat && SL.client)
-				if(plus_name)
-					SL << sound('sound/effects/tech_notification.ogg')
-				to_chat(SL, "[icon2html(src, SL)] [SPAN_BLUE("<B>SL Overwatch:</b> [nametext][text]")]")
-				return
-	else
-		for(var/mob/living/carbon/human/M in current_squad.marines_list)
-			if(!M.stat && M.client) //Only living and connected people in our squad
-				if(plus_name)
-					M << sound('sound/effects/tech_notification.ogg')
-				to_chat(M, "[icon2html(src, M)] [SPAN_BLUE("<B>Overwatch:</b> [nametext][text]")]")
-
-//Sends a maptext alert to our currently selected squad. Does not make sound.
-/obj/structure/machinery/computer/overwatch/proc/send_maptext_to_squad(var/text = "", var/title_text = "", var/only_leader = 0)
-	if(text == "" || !current_squad || !operator)
-		return //Logic
-
-	var/message_colour = squad_colors_chat[current_squad.color]
-
-	if(only_leader)
-		if(current_squad.squad_leader)
-			var/mob/living/carbon/human/SL = current_squad.squad_leader
-			if(!SL.stat && SL.client)
-				SL.play_screen_text("<span class='langchat' style=font-size:16pt;text-align:center valign='top'><u>[title_text]</u></span><br>" + text, /atom/movable/screen/text/screen_text/command_order, message_colour)
-	else
-		for(var/mob/living/carbon/human/M in current_squad.marines_list)
-			if(!M.stat && M.client) //Only living and connected people in our squad
-				M.play_screen_text("<span class='langchat' style=font-size:16pt;text-align:center valign='top'><u>[title_text]</u></span><br>" + text, /atom/movable/screen/text/screen_text/command_order, message_colour)
-
 
 // Alerts all groundside marines about the incoming OB
 /obj/structure/machinery/computer/overwatch/proc/alert_ob(var/turf/target)
@@ -723,13 +681,13 @@
 		to_chat(usr, "[icon2html(src, usr)] [SPAN_WARNING("[H] is unfit to lead!")]")
 		return
 	if(current_squad.squad_leader)
-		send_to_squad("Attention: [current_squad.squad_leader] is [current_squad.squad_leader.stat == DEAD ? "stepping down" : "demoted"]. A new Squad Leader has been set: [H.real_name].")
+		current_squad.send_message("Attention: [current_squad.squad_leader] is [current_squad.squad_leader.stat == DEAD ? "stepping down" : "demoted"]. A new Squad Leader has been set: [H.real_name].")
 		visible_message("[icon2html(src, viewers(src))] [SPAN_BOLDNOTICE("Squad Leader [current_squad.squad_leader] of squad '[current_squad]' has been [current_squad.squad_leader.stat == DEAD ? "replaced" : "demoted and replaced"] by [H.real_name]! Logging to enlistment files.")]")
 		var/old_lead = current_squad.squad_leader
 		current_squad.demote_squad_leader(current_squad.squad_leader.stat != DEAD)
 		SStracking.start_tracking(current_squad.tracking_id, old_lead)
 	else
-		send_to_squad("Attention: A new Squad Leader has been set: [H.real_name].")
+		current_squad.send_message("Attention: A new Squad Leader has been set: [H.real_name].")
 		visible_message("[icon2html(src, viewers(src))] [SPAN_BOLDNOTICE("[H.real_name] is the new Squad Leader of squad '[current_squad]'! Logging to enlistment file.")]")
 
 	to_chat(H, "[icon2html(src, H)] <font size='3' color='blue'><B>Overwatch: You've been promoted to \'[H.job == JOB_SQUAD_LEADER ? "SQUAD LEADER" : "ACTING SQUAD LEADER"]\' for [current_squad.name]. Your headset has access to the command channel (:v).</B></font>")
@@ -907,7 +865,7 @@
 			if(H.client)
 				shake_camera(H, 10, 1)
 	visible_message("[icon2html(src, viewers(src))] [SPAN_BOLDNOTICE("Orbital bombardment for squad '[current_squad]' has fired! Impact imminent!")]")
-	send_to_squad("WARNING! Ballistic trans-atmospheric launch detected! Get outside of Danger Close!")
+	current_squad.send_message("WARNING! Ballistic trans-atmospheric launch detected! Get outside of Danger Close!")
 
 /obj/structure/machinery/computer/overwatch/proc/fire_bombard(mob/user, area/A, turf/T)
 	if(!A || !T)
@@ -925,6 +883,7 @@
 		user.count_niche_stat(STATISTICS_NICHE_OB)
 
 /obj/structure/machinery/computer/overwatch/proc/handle_supplydrop()
+	SHOULD_NOT_SLEEP(TRUE)
 	if(!usr || usr != operator)
 		return
 
@@ -960,31 +919,19 @@
 		return
 
 	busy = TRUE
-
-	visible_message("[icon2html(src, viewers(src))] [SPAN_BOLDNOTICE("'[C.name]' supply drop is now loading into the launch tube! Stand by!")]")
-	C.visible_message(SPAN_WARNING("\The [C] begins to load into a launch tube. Stand clear!"))
+	C.visible_message(SPAN_WARNING("\The [C] loads into a launch tube. Stand clear!"))
 	C.anchored = TRUE //To avoid accidental pushes
-	send_to_squad("'[C.name]' supply drop incoming. Heads up!")
+	current_squad.send_message("'[C.name]' supply drop incoming. Heads up!")
 	var/datum/squad/S = current_squad //in case the operator changes the overwatched squad mid-drop
-	addtimer(CALLBACK(src, /obj/structure/machinery/computer/overwatch.proc/finish_supplydrop, C, S, T), 10 SECONDS)
-
-/obj/structure/machinery/computer/overwatch/proc/finish_supplydrop(obj/structure/closet/crate/C, datum/squad/S, turf/T)
-	if(!C || C.loc != S.drop_pad.loc) //Crate no longer on pad somehow, abort.
-		if(C) C.anchored = FALSE
-		to_chat(usr, "[icon2html(src, usr)] [SPAN_WARNING("Launch aborted! No crate detected on the drop pad.")]")
-		return
 	COOLDOWN_START(S, next_supplydrop, 500 SECONDS)
 	if(ismob(usr))
 		var/mob/M = usr
 		M.count_niche_stat(STATISTICS_NICHE_CRATES)
 
 	playsound(C.loc,'sound/effects/bamf.ogg', 50, 1)  //Ehh
-	C.anchored = FALSE
-	C.forceMove(T)
-	var/turf/TC = get_turf(C)
-	TC.ceiling_debris_check(3)
-	playsound(C.loc,'sound/effects/bamf.ogg', 50, 1)  //Ehhhhhhhhh.
-	C.visible_message("[icon2html(C)] [SPAN_BOLDNOTICE("The '[C.name]' supply drop falls from the sky!")]")
+	var/obj/structure/droppod/supply/pod = new()
+	C.forceMove(pod)
+	pod.launch(T)
 	visible_message("[icon2html(src, viewers(src))] [SPAN_BOLDNOTICE("'[C.name]' supply drop launched! Another launch will be available in five minutes.")]")
 	busy = FALSE
 

--- a/code/modules/cm_tech/droppod/supply.dm
+++ b/code/modules/cm_tech/droppod/supply.dm
@@ -1,0 +1,12 @@
+/obj/structure/droppod/supply
+	name = "\improper USCM requisitions droppod"
+	drop_time = 10 SECONDS
+	dropping_time = 2 SECONDS
+	open_time = 2 SECONDS
+
+/obj/structure/droppod/supply/open()
+	. = ..()
+	for(var/atom/movable/content as anything in contents)
+		content.forceMove(loc)
+	qdel(src)
+

--- a/tgui/packages/tgui/interfaces/SupplyDropConsole.js
+++ b/tgui/packages/tgui/interfaces/SupplyDropConsole.js
@@ -6,8 +6,6 @@ import {
   ProgressBar,
   Divider,
   NumberInput,
-  Dimmer,
-  Icon,
   NoticeBox,
   Box,
   Tabs,
@@ -16,8 +14,6 @@ import { Window } from '../layouts';
 
 export const SupplyDropConsole = (_props, context) => {
   const { act, data } = useBackend(context);
-
-  const active = data.active;
 
   const can_pick_squad = data.can_pick_squad;
 
@@ -121,12 +117,6 @@ export const SupplyDropConsole = (_props, context) => {
               content="Launch Supply Drop"
               onClick={() => act('send_beacon')}
             />
-            {active === 1 && (
-              <Dimmer fontSize="32px">
-                <Icon name="cog" spin />
-                {'Launching...'}
-              </Dimmer>
-            )}
           </Section>
         </Section>
       </Window.Content>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Supply drops now go through droppods instead of just appearing out of thin air.

USCM personnel is advised not to stand below the drop pods landing locations. Hopefully there is an ample warning of about 12 seconds to ensure this won't be an issue.

Refactored some code on the way and added a maptext notify to supply drops. You can also now fire OBs and Supply at Overwatch at the same time, in the offchance this ever matters.

Thanks to Jayne Hightower on Discord for the too-obvious-to-think-about yet simple and effective idea.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->

Visual feedback. Also visual feedback. But also, visual feedback.

Some would say immersion.

## Changelog

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Supply drops now use drop pods. USCM advises personnel not to stand below them.
qol: Squads will now get a text notification if a supply pad is launched for them, on top of just the chat one.
refactor: Refactored message sending code in squads/overwatch.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
