### PR TITLE
Ghost Hijack Timer

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -944,10 +944,20 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		if(client.admin_holder)
 			. += "Players Ready: [SSticker.totalPlayersReady]"
 
+	. += ""
+
+	if(SSticker.mode?.force_end_at)
+		var/time_left = SSticker.mode.force_end_at - world.time
+		if(time_left >= 0)
+			. += "Hijack Time Left: [DisplayTimeText(time_left, 1)]"
+		else
+			. += "Hijack Over"
+
 	if(EvacuationAuthority)
 		var/eta_status = EvacuationAuthority.get_status_panel_eta()
 		if(eta_status)
-			. += eta_status
+			. += "Evacuation: [eta_status]"
+
 
 #undef MOVE_INTENT_WALK
 #undef MOVE_INTENT_RUN

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -106,7 +106,7 @@
 	if(EvacuationAuthority)
 		var/eta_status = EvacuationAuthority.get_status_panel_eta()
 		if(eta_status)
-			. += eta_status
+			. += "Evacuation: [eta_status]"
 
 /mob/living/carbon/human/ex_act(var/severity, var/direction, var/datum/cause_data/cause_data)
 	if(lying)

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -86,7 +86,7 @@
 	if(EvacuationAuthority)
 		var/eta_status = EvacuationAuthority.get_status_panel_eta()
 		if(eta_status)
-			stat(null, eta_status)
+			stat(null, "Evacuation: [eta_status]")
 
 
 // this function displays the stations manifest in a separate window


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Displays to ghosts in status pane when hijack will end.

![image](https://user-images.githubusercontent.com/604624/201502397-6b2a46a8-a390-4189-b9f1-0d469418f167.png)

By request of podrick

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->

Transparency

## Changelog

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Ghosts now have a timer displaying time left to hijack end in Statpanel.
fix: Evac timer in Status pane will now display as such.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
