### PR TITLE
Small fixes around Requisitions, Crates and Ammo

### DIFF
--- a/code/game/machinery/vending/vendor_types/requisitions.dm
+++ b/code/game/machinery/vending/vendor_types/requisitions.dm
@@ -309,7 +309,7 @@
 		list("Box Of Flechette Shells", round(scale * 2), /obj/item/ammo_magazine/shotgun/flechette, VENDOR_ITEM_REGULAR),
 		list("Box Of Shotgun Slugs", round(scale * 2), /obj/item/ammo_magazine/shotgun/slugs, VENDOR_ITEM_REGULAR),
 		list("L42A Magazine (10x24mm)", round(scale * 8), /obj/item/ammo_magazine/rifle/l42a, VENDOR_ITEM_REGULAR),
-		list("M41A MK2 Magazine (10x24mm", round(scale * 10), /obj/item/ammo_magazine/rifle, VENDOR_ITEM_REGULAR),
+		list("M41A MK2 Magazine (10x24mm)", round(scale * 10), /obj/item/ammo_magazine/rifle, VENDOR_ITEM_REGULAR),
 		list("M39 HV Magazine (10x20mm)", round(scale * 7.5), /obj/item/ammo_magazine/smg/m39, VENDOR_ITEM_REGULAR),
 		list("M44 Speed Loader (.44)", round(scale * 5.3), /obj/item/ammo_magazine/revolver, VENDOR_ITEM_REGULAR),
 		list("M4A3 Magazine (9mm)", round(scale * 6.1), /obj/item/ammo_magazine/pistol, VENDOR_ITEM_REGULAR),

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -71,7 +71,7 @@
 	for(var/obj/O in get_turf(src))
 		if(itemcount >= storage_capacity)
 			break
-		if(O.density || O.anchored || istype(O, /obj/structure/closet))
+		if(O.density || O.anchored || istype(O, /obj/structure/closet) || istype(O, /obj/effect))
 			continue
 		if(istype(O, /obj/structure/bed)) //This is only necessary because of rollerbeds and swivel chairs.
 			var/obj/structure/bed/B = O

--- a/code/modules/projectiles/ammo_boxes.dm
+++ b/code/modules/projectiles/ammo_boxes.dm
@@ -771,18 +771,18 @@
 		qdel(src)
 
 /obj/structure/magazine_box/get_examine_text(mob/user)
-	..()
+	. = ..()
 	if(get_dist(src,user) > 2 && !isobserver(user))
 		return
-	to_chat(user, SPAN_INFO("[SPAN_HELPFUL("Click")] on the box with an empty hand to take a magazine out. [SPAN_HELPFUL("Drag")] it onto yourself to pick it up."))
+	. += SPAN_INFO("[SPAN_HELPFUL("Click")] on the box with an empty hand to take a magazine out. [SPAN_HELPFUL("Drag")] it onto yourself to pick it up.")
 	if(item_box.handfuls)
 		var/obj/item/ammo_magazine/AM = locate(/obj/item/ammo_magazine) in item_box.contents
 		if(AM)
-			to_chat(user, SPAN_INFO("It has roughly [round(AM.current_rounds/5)] handfuls remaining."))
+			. +=  SPAN_INFO("It has roughly [round(AM.current_rounds/5)] handfuls remaining.")
 	else
-		to_chat(user, SPAN_INFO("It has [item_box.contents.len] magazines out of [item_box.num_of_magazines]."))
+		. +=  SPAN_INFO("It has [item_box.contents.len] magazines out of [item_box.num_of_magazines].")
 	if(burning)
-		to_chat(user, SPAN_DANGER("It's on fire and might explode!"))
+		. +=  SPAN_DANGER("It's on fire and might explode!")
 
 /obj/structure/magazine_box/attack_hand(mob/living/user)
 	if(burning)

--- a/code/modules/projectiles/ammo_boxes.dm
+++ b/code/modules/projectiles/ammo_boxes.dm
@@ -936,14 +936,14 @@
 //---------------------INTERACTION PROCS
 
 /obj/item/ammo_box/rounds/get_examine_text(mob/user)
-	..()
-	to_chat(user, SPAN_INFO("To refill a magazine click on the box with it in your hand. Being on [SPAN_HELPFUL("HARM")] intent will fill box from the magazine."))
+	. = ..()
+	. += SPAN_INFO("To refill a magazine click on the box with it in your hand. Being on [SPAN_HELPFUL("HARM")] intent will fill box from the magazine.")
 	if(bullet_amount)
-		to_chat(user, "It contains [bullet_amount] round\s.")
+		. +=  "It contains [bullet_amount] round\s."
 	else
-		to_chat(user, "It's empty.")
+		. +=  "It's empty."
 	if(burning)
-		to_chat(user, SPAN_DANGER("It's on fire and might explode!"))
+		. += SPAN_DANGER("It's on fire and might explode!")
 
 /obj/item/ammo_box/rounds/attack_self(mob/living/user)
 	..()

--- a/code/modules/projectiles/ammo_boxes.dm
+++ b/code/modules/projectiles/ammo_boxes.dm
@@ -17,6 +17,10 @@
 	SetLuminosity(0)
 	. = ..()
 
+/obj/item/ammo_box/proc/unfold_box(turf/T)
+	new /obj/item/stack/sheet/cardboard(T)
+	qdel(src)
+
 //---------------------FIRE HANDLING PROCS
 /obj/item/ammo_box/flamer_fire_act(var/severity, var/datum/cause_data/flame_cause_data)
 	if(burning)
@@ -136,10 +140,6 @@
 				deploy_ammo_box(user, user.loc)
 				return
 	unfold_box(user.loc)
-
-/obj/item/ammo_box/magazine/proc/unfold_box(turf/T)
-	new /obj/item/stack/sheet/cardboard(T)
-	qdel(src)
 
 /obj/item/ammo_box/magazine/proc/deploy_ammo_box(var/mob/living/user, var/turf/T)
 	if(burning)
@@ -949,10 +949,6 @@
 	..()
 	if(bullet_amount < 1)
 		unfold_box(user.loc)
-
-/obj/item/ammo_box/rounds/proc/unfold_box(turf/T)
-	new /obj/item/stack/sheet/cardboard(T)
-	qdel(src)
 
 /obj/item/ammo_box/rounds/attackby(obj/item/I, mob/user)
 	if(burning)

--- a/code/modules/projectiles/magazines/shotguns.dm
+++ b/code/modules/projectiles/magazines/shotguns.dm
@@ -28,6 +28,13 @@ var/list/shotgun_boxes_12g = list(
 	handful_state = "slug_shell"
 	transfer_handful_amount = 5
 
+/obj/item/ammo_magazine/shotgun/attack_self(mob/user)
+	if(current_rounds == 0)
+		new /obj/item/stack/sheet/cardboard(user.loc)
+		qdel(src)
+	else
+		return ..()
+
 /obj/item/ammo_magazine/shotgun/slugs//for distinction on weapons that can't take child objects but still take slugs.
 
 /obj/item/ammo_magazine/shotgun/incendiary

--- a/code/modules/vehicles/interior/interactable/vendors.dm
+++ b/code/modules/vehicles/interior/interactable/vendors.dm
@@ -251,7 +251,7 @@
 		list("Box Of Flechette Shells", round(scale * 2), /obj/item/ammo_magazine/shotgun/flechette, VENDOR_ITEM_REGULAR),
 		list("Box Of Shotgun Slugs", round(scale * 4), /obj/item/ammo_magazine/shotgun/slugs, VENDOR_ITEM_REGULAR),
 		list("L42A Magazine (10x24mm)", round(scale * 5), /obj/item/ammo_magazine/rifle/l42a, VENDOR_ITEM_REGULAR),
-		list("M41A MK2 Magazine (10x24mm", round(scale * 10), /obj/item/ammo_magazine/rifle, VENDOR_ITEM_REGULAR),
+		list("M41A MK2 Magazine (10x24mm)", round(scale * 10), /obj/item/ammo_magazine/rifle, VENDOR_ITEM_REGULAR),
 		list("M39 HV Magazine (10x20mm)", round(scale * 6), /obj/item/ammo_magazine/smg/m39, VENDOR_ITEM_REGULAR),
 		list("M44 Speed Loader (.44)", round(scale * 4), /obj/item/ammo_magazine/revolver, VENDOR_ITEM_REGULAR),
 		list("M4A3 Magazine (9mm)", round(scale * 10), /obj/item/ammo_magazine/pistol, VENDOR_ITEM_REGULAR),


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

I noticed a few niggles of things that could be fixed while working Requisitions, so here are the various fix and tweaks.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Less typos more good. Being able to pickup decals with a crate is just weird. Ammo boxes not giving descriptions like other items was a bit of snowflake functionality that made things a bit confusing during play. Less duplicate code more better, and being able to get rid of the endless shotgun shell boxes somehow will help keep a few areas a bit neater for people.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->

## Changelog

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Crates can no longer pick up decals.
spellcheck: Fixed two small typos in Requisitions (lacking closing brackets on ammo descriptions).
fix: Placed ammo boxes now give a proper description within a neat rectangle like all the other items.
refactor: Tiny code refactor around ammo boxes unfolding into cardboard.
qol: Empty shotgun shell boxes now unfold into cardboard when clicked.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
