### PR TITLE
Unused Var

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -1136,7 +1136,6 @@
 /mob/proc/bullet_message(obj/item/projectile/P)
 	if(!P)
 		return
-	var/ammo_flags = P.ammo.flags_ammo_behavior | P.projectile_override_flags
 	visible_message(SPAN_DANGER("[src] is hit by the [P.name] in the [parse_zone(P.def_zone)]!"), \
 		SPAN_HIGHDANGER("You are hit by the [P.name] in the [parse_zone(P.def_zone)]!"), null, 4, CHAT_TYPE_TAKING_HIT)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

I left an a unused var when removing the silenced ammo code.

## Why It's Good For The Game

Unused vars bad.

## Changelog

:cl: Morrow
fix: Removes an unused variable
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
