### PR TITLE
Fix for paygrades.

### DIFF
--- a/code/datums/paygrades/factions/other/contractors.dm
+++ b/code/datums/paygrades/factions/other/contractors.dm
@@ -7,26 +7,26 @@
 	prefix = "VAI"
 
 /datum/paygrade/contractors/med
-	paygrade = "VAI"
+	paygrade = "VAI-M"
 	name = "VAI Medical Specialist"
 	prefix = "VAI MED"
 
 /datum/paygrade/contractors/mg
-	paygrade = "VAI"
+	paygrade = "VAI-G"
 	name = "VAI Machinegunner"
 	prefix = "VAI MG"
 
 /datum/paygrade/contractors/engi
-	paygrade = "VAI"
+	paygrade = "VAI-E"
 	name = "VAI Engineering Specialist"
 	prefix = "VAI ENG"
 
 /datum/paygrade/contractors/syn
-	paygrade = "VAI"
+	paygrade = "VAI-S"
 	name = "VAI Synthetic"
 	prefix = "VAI SYN"
 
 /datum/paygrade/contractors/lead
-	paygrade = "VAI"
+	paygrade = "VAI-L"
 	name = "VAI Team Leader"
 	prefix = "VAI TL"

--- a/code/datums/paygrades/paygrade.dm
+++ b/code/datums/paygrades/paygrade.dm
@@ -14,8 +14,12 @@ GLOBAL_LIST_INIT_TYPED(paygrades, /datum/paygrade, setup_paygrades())
 	. = list()
 	for(var/I in subtypesof(/datum/paygrade))
 		var/datum/paygrade/PG = I
-		if(initial(PG.paygrade))
-			.[initial(PG.paygrade)] += new PG
+		var/pg_id = initial(PG.paygrade)
+		if(pg_id)
+			if(pg_id in .)
+				log_debug("Duplicate paygrade: '[pg_id]'.")
+			else
+				.[pg_id] = new PG
 
 GLOBAL_LIST_INIT(highcom_paygrades, list(
 	"NO7",

--- a/code/modules/gear_presets/contractor.dm
+++ b/code/modules/gear_presets/contractor.dm
@@ -107,7 +107,7 @@
 
 /datum/equipment_preset/contractor/duty/standard
 	name = "Military Contractor (Standard)"
-	paygrade = "VAI-MERC "
+	paygrade = "VAI"
 	role_comm_title = "Merc"
 	flags = EQUIPMENT_PRESET_EXTRA
 
@@ -200,7 +200,7 @@
 
 /datum/equipment_preset/contractor/duty/heavy
 	name = "Military Contractor (Machinegunner)"
-	paygrade = "VAI-MG "
+	paygrade = "VAI-G"
 	role_comm_title = "MG"
 	flags = EQUIPMENT_PRESET_EXTRA
 
@@ -250,7 +250,7 @@
 //*****************************************************************************************************/
 /datum/equipment_preset/contractor/duty/engi
 	name = "Military Contractor (Engineer)"
-	paygrade = "VAI-ENG "
+	paygrade = "VAI-E"
 
 	role_comm_title = "Eng"
 	flags = EQUIPMENT_PRESET_EXTRA
@@ -302,7 +302,7 @@
 
 /datum/equipment_preset/contractor/duty/medic
 	name = "Military Contractor (Medic)"
-	paygrade = "VAI-MED "
+	paygrade = "VAI-M"
 	role_comm_title = "Med"
 	flags = EQUIPMENT_PRESET_EXTRA
 
@@ -353,7 +353,7 @@
 
 /datum/equipment_preset/contractor/duty/leader
 	name = "Military Contractor (Leader)"
-	paygrade = "VAI-TL "
+	paygrade = "VAI-L"
 	role_comm_title = "TL"
 	flags = EQUIPMENT_PRESET_EXTRA
 
@@ -408,7 +408,7 @@
 //*****************************************************************************************************/
 /datum/equipment_preset/contractor/duty/synth
 	name = "Military Contractor (Synthetic)"
-	paygrade = "VAI-SYN "
+	paygrade = "VAI-S"
 	role_comm_title = "Syn"
 	flags = EQUIPMENT_PRESET_EXTRA
 
@@ -501,7 +501,7 @@
 
 /datum/equipment_preset/contractor/covert/standard
 	name = "Military Contractor (Covert Standard)"
-	paygrade = "VAI-MERC "
+	paygrade = "VAI"
 	role_comm_title = "Merc"
 	flags = EQUIPMENT_PRESET_EXTRA
 
@@ -595,7 +595,7 @@
 
 /datum/equipment_preset/contractor/covert/heavy
 	name = "Military Contractor (Covert Machinegunner)"
-	paygrade = "VAI-MG "
+	paygrade = "VAI-G"
 	role_comm_title = "MG"
 	flags = EQUIPMENT_PRESET_EXTRA
 
@@ -648,7 +648,7 @@
 //*****************************************************************************************************/
 /datum/equipment_preset/contractor/covert/engi
 	name = "Military Contractor (Covert Engineer)"
-	paygrade = "VAI-ENG "
+	paygrade = "VAI-E"
 
 	role_comm_title = "Eng"
 	flags = EQUIPMENT_PRESET_EXTRA
@@ -702,7 +702,7 @@
 
 /datum/equipment_preset/contractor/covert/medic
 	name = "Military Contractor (Covert Medic)"
-	paygrade = "VAI-MED "
+	paygrade = "VAI-M"
 	role_comm_title = "Med"
 	flags = EQUIPMENT_PRESET_EXTRA
 
@@ -755,7 +755,7 @@
 
 /datum/equipment_preset/contractor/covert/leader
 	name = "Military Contractor (Covert Leader)"
-	paygrade = "VAI-TL "
+	paygrade = "VAI-L"
 	role_comm_title = "TL"
 	flags = EQUIPMENT_PRESET_EXTRA
 
@@ -811,7 +811,7 @@
 //*****************************************************************************************************/
 /datum/equipment_preset/contractor/covert/synth
 	name = "Military Contractor (Covert Synthetic)"
-	paygrade = "VAI-SYN "
+	paygrade = "VAI-S"
 	role_comm_title = "Syn"
 	flags = EQUIPMENT_PRESET_EXTRA
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Followup to #1339. Paygrade datums should not have duplicate IDs.
The ERT presets were not even _using_ their paygrades anyway. Fixed that too.

## Why It's Good For The Game

Is fix.

## Changelog

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Paygrades once again yield correct ranks and rank pins.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
