### PR TITLE
Sensical M40 naming

### DIFF
--- a/code/game/objects/items/explosives/grenades/marines.dm
+++ b/code/game/objects/items/explosives/grenades/marines.dm
@@ -10,7 +10,7 @@
 
 /obj/item/explosive/grenade/HE
 	name = "\improper M40 HEDP grenade"
-	desc = "High-Explosive Dual-Purpose. A small, but deceptively strong blast grenade that has been phasing out the M15 HE grenades alongside the M40 HEFA. Capable of being loaded in the M92 Launcher, or thrown by hand."
+	desc = "High-Explosive Dual-Purpose. A small, but powerful blast grenade that has been phasing out the M15 HE grenades alongside the M40 HEFA. Capable of being loaded in the M92 Launcher, or thrown by hand."
 	icon_state = "grenade"
 	det_time = 40
 	item_state = "grenade_hedp"
@@ -197,8 +197,8 @@
 */
 
 /obj/item/explosive/grenade/incendiary
-	name = "\improper M40 HIDP incendiary grenade"
-	desc = "The M40 High Incendiary Dual-Purpose (HIDP) is a small, but deceptively strong incendiary grenade designed to disrupt enemy mobility with long-lasting Type B napalm. It is set to detonate in 4 seconds."
+	name = "\improper U4-B incendiary grenade"
+	desc = "The U4-B firebomb is an incendiary grenade designed to disrupt enemy mobility with a long-lasting Type B napalm, based on the same platform as the M40 HEDP. It is set to detonate in 4 seconds."
 	icon_state = "grenade_fire"
 	det_time = 40
 	item_state = "grenade_fire"
@@ -305,8 +305,8 @@
 */
 
 /obj/item/explosive/grenade/smokebomb
-	name = "\improper M40 TSDP smoke grenade"
-	desc = "The M40 Tactical Smoke Dual-Purpose (TSDP) is a small, but powerful smoke grenade. Based off the same platform as the M40 HEDP. It is set to detonate in 2 seconds."
+	name = "\improper M48 TSDP smoke grenade"
+	desc = "The M48 Tactical Smoke Dual-Purpose (TSDP) is a small, but powerful smoke grenade based on the same platform as the M40 HEDP. It is set to detonate in 2 seconds."
 	icon_state = "grenade_smoke"
 	det_time = 20
 	item_state = "grenade_smoke"
@@ -328,8 +328,8 @@
 	qdel(src)
 
 /obj/item/explosive/grenade/phosphorus
-	name = "\improper M40 WPDP grenade"
-	desc = "The M40 White-Phospherous Dual-Purpose (WPDP) is a small, but powerful phosphorus grenade. It is set to detonate in 2 seconds."
+	name = "\improper M60 WPI grenade"
+	desc = "The M60 White Phosphorus Incendiary (WPI) is a small, but powerful phosphorus grenade based on the same platform as the M40 HEDP. It is set to detonate in 2 seconds."
 	icon_state = "grenade_phos"
 	det_time = 20
 	item_state = "grenade_phos"
@@ -340,7 +340,7 @@
 	var/smoke_radius = 3
 
 /obj/item/explosive/grenade/phosphorus/weak
-	desc = "The M40 White-Phospherous Dual-Purpose (WPDP) is a small, but powerful phosphorus grenade. This one appears to be the newer version. Word on the block says that these doesn't actually release White Phosphorus, but some other chemical developed in W-Y labs."
+	desc = "The M60 White Phosphorus Incendiary (WPI) is a small, but powerful phosphorus grenade based on the same platform as the M40 HEDP. This one has a bit of a hollower sound to it. May not actually release white phosphorus, but some other, unknown chemical. Use at your own risk."
 
 /obj/item/explosive/grenade/phosphorus/Initialize()
 	..()

--- a/code/game/objects/items/explosives/grenades/marines.dm
+++ b/code/game/objects/items/explosives/grenades/marines.dm
@@ -198,7 +198,7 @@
 
 /obj/item/explosive/grenade/incendiary
 	name = "\improper M40 HIDP incendiary grenade"
-	desc = "The M40 HIDP is a small, but deceptively strong incendiary grenade designed to disrupt enemy mobility with long-lasting Type B napalm. It is set to detonate in 4 seconds."
+	desc = "The M40 High Incendiary Dual-Purpose (HIDP) is a small, but deceptively strong incendiary grenade designed to disrupt enemy mobility with long-lasting Type B napalm. It is set to detonate in 4 seconds."
 	icon_state = "grenade_fire"
 	det_time = 40
 	item_state = "grenade_fire"
@@ -305,8 +305,8 @@
 */
 
 /obj/item/explosive/grenade/smokebomb
-	name = "\improper M40 HSDP smoke grenade"
-	desc = "The M40 HSDP is a small, but powerful smoke grenade. Based off the same platform as the M40 HEDP. It is set to detonate in 2 seconds."
+	name = "\improper M40 TSDP smoke grenade"
+	desc = "The M40 Tactical Smoke Dual-Purpose (TSDP) is a small, but powerful smoke grenade. Based off the same platform as the M40 HEDP. It is set to detonate in 2 seconds."
 	icon_state = "grenade_smoke"
 	det_time = 20
 	item_state = "grenade_smoke"
@@ -328,8 +328,8 @@
 	qdel(src)
 
 /obj/item/explosive/grenade/phosphorus
-	name = "\improper M40 HPDP grenade"
-	desc = "The M40 HPDP is a small, but powerful phosphorus grenade. It is set to detonate in 2 seconds."
+	name = "\improper M40 WPDP grenade"
+	desc = "The M40 White-Phospherous Dual-Purpose (WPDP) is a small, but powerful phosphorus grenade. It is set to detonate in 2 seconds."
 	icon_state = "grenade_phos"
 	det_time = 20
 	item_state = "grenade_phos"
@@ -340,7 +340,7 @@
 	var/smoke_radius = 3
 
 /obj/item/explosive/grenade/phosphorus/weak
-	desc = "The M40 HPDP is a small, but powerful phosphorus grenade. Word on the block says that the HPDP doesn't actually release White Phosphorus, but some other chemical developed in W-Y labs."
+	desc = "The M40 White-Phospherous Dual-Purpose (WPDP) is a small, but powerful phosphorus grenade. This one appears to be the newer version. Word on the block says that these doesn't actually release White Phosphorus, but some other chemical developed in W-Y labs."
 
 /obj/item/explosive/grenade/phosphorus/Initialize()
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Renames the weird naming schema M40 nades have.

HPDP? What is that supposed to stand for? Heavy Phosphorous Dual Purpose? High Phosphorous?  Worst one out of all of them and doesn't make sense at all so it has been renamed to M60 WPI (White Phosphorous incendiary) , a much more fitting and lore-friendly name

Same HSDP. Heavy smoke Dual Purpose? High smoke? Doesn't make much sense, it smokes yes but Heavy? High? Does it have cannabis in it? 
Renamed to M48 Tactical Smoke Dual Purpose (TSDP)

HIDP has been renamed to the U4-B Incendiary grenade to match lore

Also updated the descriptions to reflect the changes and updated HIDP's description
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Less confusing + lore friendly names. More descriptive descriptions that detail the acronyms
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->

## Changelog

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: totalepicness5
spellcheck: Renamed HPDP grenades > White-Phospherous Dual-Purpose (WPDP)
spellcheck: Renamed HSDP grenades > Tactical Smoke Dual-Purpose (TSDP)
spellcheck: Updated HIDP description to be aligned with the other grenades
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
