### PR TITLE
put the game panels verb under the panels menu

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -346,7 +346,7 @@ var/list/roundstart_mod_verbs = list(
 
 /client/proc/game_panel()
 	set name = "Game Panel"
-	set category = "Admin.Game"
+	set category = "Admin.Panels"
 	if(admin_holder)
 		admin_holder.Game()
 	return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

look at me, I'm the coder now
(this puts game panels under the panels menu)

## Why It's Good For The Game

dubszor says the game panel should be under panels

## Changelog

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
admin: moved game panels from the game category to the panels category in the admin tab
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
