### PR TITLE
Paygrade Display Fix

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -322,12 +322,12 @@
 		return ""
 
 	switch(species.name)
-		if("Human","Human Hero")
+		if("Horror","Yautja")
+			return ""
+		else
 			var/obj/item/card/id/id = wear_id
 			if(istype(id))
 				. = get_paygrades(id.paygrade, size, gender)
-		else
-			return ""
 
 
 //repurposed proc. Now it combines get_id_name() and get_face_name() to determine a mob's name variable. Made into a separate proc as it'll be useful elsewhere

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -318,16 +318,10 @@
 //gets paygrade from ID
 //paygrade is a user's actual rank, as defined on their ID.  size 1 returns an abbreviation, size 0 returns the full rank name, the third input is used to override what is returned if no paygrade is assigned.
 /mob/living/carbon/human/proc/get_paygrade(size = 1)
-	if(!species)
+	var/obj/item/card/id/id = wear_id
+	if(!species || !istype(id))
 		return ""
-
-	switch(species.name)
-		if("Horror","Yautja")
-			return ""
-		else
-			var/obj/item/card/id/id = wear_id
-			if(istype(id))
-				. = get_paygrades(id.paygrade, size, gender)
+	return species.handle_paygrades(id.paygrade, size, gender)
 
 
 //repurposed proc. Now it combines get_id_name() and get_face_name() to determine a mob's name variable. Made into a separate proc as it'll be useful elsewhere

--- a/code/modules/mob/living/carbon/human/species/human.dm
+++ b/code/modules/mob/living/carbon/human/species/human.dm
@@ -78,3 +78,6 @@
 /datum/species/human/spook/handle_post_spawn(mob/living/carbon/human/H)
 	H.set_languages(list("Drrrrrrr"))
 	return ..()
+
+/datum/species/human/spook/handle_paygrades()
+	return ""

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -472,3 +472,6 @@
 
 /datum/species/proc/handle_head_loss(var/mob/living/carbon/human/human)
 	return
+
+/datum/species/proc/handle_paygrades(var/paygrade, var/size, var/gender)
+	return get_paygrades(paygrade, size, gender)

--- a/code/modules/mob/living/carbon/human/species/yautja.dm
+++ b/code/modules/mob/living/carbon/human/species/yautja.dm
@@ -220,3 +220,6 @@
 /datum/species/yautja/handle_on_fire(humanoidmob)
 	. = ..()
 	INVOKE_ASYNC(humanoidmob, /mob.proc/emote, pick("pain", "scream"))
+
+/datum/species/yautja/handle_paygrades()
+	return ""


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Shows paygrade prefixes on synthetics as it's dead obvious if there are any stealth synthetics. Plus it never made sense to me that it didn't work properly. Altered so only Yautja and Horrors don't have rank prefixes.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Allows for more avenues of RP/Events, and does not detract from gameplay.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->

## Changelog

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Paygrades now display on non Yautja or Xeno mobs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
