### PR TITLE
fixes more stuns (tail swipe, plasma immobilizer, vehicle ramming)

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/defender/defender_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/defender/defender_powers.dm
@@ -139,7 +139,7 @@
 		shake_camera(H, 2, 1)
 
 		if(H.mob_size < MOB_SIZE_BIG)
-			H.apply_effect(get_xeno_stun_duration(H, 1), 1, WEAKEN)
+			H.apply_effect(get_xeno_stun_duration(H, 1), WEAKEN)
 
 		to_chat(H, SPAN_XENOWARNING("You are struck by [src]'s tail sweep!"))
 		playsound(H,'sound/weapons/alien_claw_block.ogg', 50, 1)

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -2201,7 +2201,7 @@
 			stun_time++
 			H.apply_effect(stun_time, WEAKEN)
 		else
-			M.apply_effect(stun_time, 1, WEAKEN)
+			M.apply_effect(stun_time, WEAKEN)
 
 		C.apply_effect(stun_time, STUN)
 	..()
@@ -2278,7 +2278,7 @@
 			var/mob/living/carbon/human/H = M
 			H.apply_effect(stun_time, WEAKEN)
 		else
-			M.apply_effect(stun_time, 1, WEAKEN)
+			M.apply_effect(stun_time, WEAKEN)
 
 
 

--- a/code/modules/vehicles/multitile/multitile_bump.dm
+++ b/code/modules/vehicles/multitile/multitile_bump.dm
@@ -533,25 +533,25 @@
 				playsound(V, 'sound/effects/metal_crash.ogg', 35)
 				return FALSE
 		else if(driver && get_target_lock(driver.faction))
-			apply_effect(0.5, 1, WEAKEN)
+			apply_effect(0.5, WEAKEN)
 		else
-			apply_effect(1, 1, WEAKEN)
+			apply_effect(1, WEAKEN)
 
 	else if(V.vehicle_flags & VEHICLE_CLASS_LIGHT)
 		if(get_target_lock(driver.faction))
-			apply_effect(0.5, 1, WEAKEN)
+			apply_effect(0.5, WEAKEN)
 		else
-			apply_effect(2, 1, WEAKEN)
+			apply_effect(2, WEAKEN)
 			apply_damage(5 + rand(0, 10), BRUTE)
 			dmg = TRUE
 
 	else if(V.vehicle_flags & VEHICLE_CLASS_MEDIUM)
-		apply_effect(3, 1, WEAKEN)
+		apply_effect(3, WEAKEN)
 		apply_damage(10 + rand(0, 10), BRUTE)
 		dmg = TRUE
 
 	else if(V.vehicle_flags & VEHICLE_CLASS_HEAVY)
-		apply_effect(5, 1, WEAKEN)
+		apply_effect(5, WEAKEN)
 		apply_damage(15 + rand(0, 10), BRUTE)
 		dmg = TRUE
 
@@ -562,7 +562,7 @@
 			continue
 		H.livingmob_interact(src)
 
-	apply_effect(3, 1, WEAKEN)
+	apply_effect(3, WEAKEN)
 	apply_damage(7 + rand(0, 5), BRUTE)
 	var/mob_moved = step(src, V.last_move_dir)
 
@@ -586,26 +586,26 @@
 
 	if(V.vehicle_flags & VEHICLE_CLASS_WEAK)
 		if(driver && get_target_lock(driver.faction))
-			apply_effect(0.5, 1, WEAKEN)
+			apply_effect(0.5, WEAKEN)
 		else
-			apply_effect(1, 1, WEAKEN)
+			apply_effect(1, WEAKEN)
 	else if(V.vehicle_flags & VEHICLE_CLASS_LIGHT)
 		dmg = TRUE
 		if(get_target_lock(driver.faction))
-			apply_effect(0.5, 1, WEAKEN)
+			apply_effect(0.5, WEAKEN)
 			apply_damage(5 + rand(0, 5), BRUTE, no_limb_loss = TRUE)
 			to_chat(V.seats[VEHICLE_DRIVER], SPAN_WARNING(SPAN_BOLD("*YOU RAMMED AN ALLY AND HURT THEM!*")))
 		else
-			apply_effect(2, 1, WEAKEN)
+			apply_effect(2, WEAKEN)
 			apply_damage(10 + rand(0, 10), BRUTE)
 
 	else if(V.vehicle_flags & VEHICLE_CLASS_MEDIUM)
-		apply_effect(3, 1, WEAKEN)
+		apply_effect(3, WEAKEN)
 		apply_damage(10 + rand(0, 10), BRUTE)
 		dmg = TRUE
 
 	else if(V.vehicle_flags & VEHICLE_CLASS_HEAVY)
-		apply_effect(5, 1, WEAKEN)
+		apply_effect(5, WEAKEN)
 		apply_damage(15 + rand(0, 10), BRUTE)
 		dmg = TRUE
 
@@ -679,7 +679,7 @@
 
 	visible_message(SPAN_DANGER("\The [V] rams \the [src]!"), SPAN_DANGER("\The [V] rams you! Get out of the way!"))
 	if(is_knocked_down)
-		apply_effect(3, 1, WEAKEN)
+		apply_effect(3, WEAKEN)
 
 	var/mob_moved = FALSE
 	var/mob_knocked_down = is_mob_incapacitated()


### PR DESCRIPTION
## About The Pull Request

this fixes more stuns broken from the stun refactor, specifically defender tail swipe, plasma immobilizers and vehicle ramming - this was done by removing a leftover value used for force (before this would override mobs that do not have knockdown and force them to get knocked down, however I believe outside of admins editing a mob to have no knockdown, there are no mobs that use this, and therefore somewhat defeats the point of an admin disabling knockdown for a mob)

## Why It's Good For The Game

this fixes problems that weren't there before the stun refactor

however this fix does not incorporate a previous element that would have mobs with the canknockdown flag disabled knocked down anyway, maybe it'd be worth removing force altogether from the KnockDown proc (as nothing would use it anymore) or adding a new arg to apply_effect to restore this functionality instead, as irrelevant as it may be

## Changelog

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fixed stuns for tail swipes, plasma casters and vehicle ramming
/:cl:
