### PR TITLE
Fix for setting status effects to zero.

### DIFF
--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -145,9 +145,6 @@
 	if(SEND_SIGNAL(src, COMSIG_LIVING_SET_EFFECT, effect, effect_type, effect_flags) & COMPONENT_CANCEL_EFFECT)
 		return
 
-	if(!effect)
-		return FALSE
-
 	switch(effect_type)
 		if(STUN)
 			SetStun(effect)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Another followup to #1482. Making a new procedure by copypasting a precedent, some usage cases got overlooked. Trying to adjust an effect by zero is something that deserves early return with no further consideration, but trying to set an effect _to_ zero is definitely a valid thing to do.
Technically affects some other cure-it-all things besides wardens, but nobody cares about those.

## Why It's Good For The Game

Is fix.

## Changelog

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Warden's rejuvenation ability once again works.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
