### PR TITLE
Sets up point blank signal and refactors battlefield executions to use it

### DIFF
--- a/code/__DEFINES/conflict.dm
+++ b/code/__DEFINES/conflict.dm
@@ -36,8 +36,6 @@
 ///Can only hit people with criminal status
 #define AMMO_MP					(1<<21)
 #define AMMO_FLAME				(1<<22) // Handles sentry flamers glob
-/// Can BE people with it
-#define AMMO_HIGHIMPACT			(1<<23)
 
 
 //Gun defines for gun related thing. More in the projectile folder.

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -392,6 +392,10 @@
 #define COMSIG_BULLET_CHECK_MOB_SKIPPING "bullet_check_mob_skipping"
 	#define COMPONENT_SKIP_MOB (1<<0)
 
+/// Called on point blank for ammo effects
+#define COMSIG_AMMO_POINT_BLANK "ammo_point_blank"
+	#define COMPONENT_CANCEL_AMMO_POINT_BLANK (1<<0)
+
 /// From /obj/item/projectile/handle_mob(): (mob/living/target)
 #define COMSIG_BULLET_PRE_HANDLE_MOB "bullet_pre_handle_mob"
 /// From /obj/item/projectile/handle_mob(): (mob/living/target)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -1305,6 +1305,10 @@ and you're good to go.
 			click_empty(user)
 			break
 
+		if(SEND_SIGNAL(projectile_to_fire.ammo, COMSIG_AMMO_POINT_BLANK, M, projectile_to_fire, user, src) & COMPONENT_CANCEL_AMMO_POINT_BLANK)
+			flags_gun_features &= ~GUN_BURST_FIRING
+			return TRUE
+
 		//We actually have a projectile, let's move on. We're going to simulate the fire cycle.
 		if(projectile_to_fire.ammo.on_pointblank(M, projectile_to_fire, user, src))
 			flags_gun_features &= ~GUN_BURST_FIRING


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Sets up point blank signal and refactors battlefield executions to use it. I've left the on_pointblank() proc and call as other things are still using it.

## Why It's Good For The Game

The overuse of flags on the ammo datum has us at our byond limit for bitflags. This removes one of those bitflags to free up space and also allows for future applications for overriding point blank functions via signals.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Morrow
refactor: Refactored battlefield executions using a new point blank signal
/:cl:
