### PR TITLE
fun fact fix

### DIFF
--- a/code/datums/statistics/entities/death_stats.dm
+++ b/code/datums/statistics/entities/death_stats.dm
@@ -136,6 +136,8 @@
 
 /mob/living/carbon/Xenomorph/track_mob_death(var/cause, var/cause_mob)
 	var/datum/entity/statistic/death/new_death = ..(cause, cause_mob, caste_type)
+	if(!new_death)
+		return
 	new_death.is_xeno = TRUE // this was placed beneath the if below, which meant gibbing as a xeno wouldn't track properly in stats
 	if(statistic_exempt || !mind)
 		return

--- a/code/datums/statistics/entities/death_stats.dm
+++ b/code/datums/statistics/entities/death_stats.dm
@@ -136,9 +136,9 @@
 
 /mob/living/carbon/Xenomorph/track_mob_death(var/cause, var/cause_mob)
 	var/datum/entity/statistic/death/new_death = ..(cause, cause_mob, caste_type)
+	new_death.is_xeno = TRUE // this was placed beneath the if below, which meant gibbing as a xeno wouldn't track properly in stats
 	if(statistic_exempt || !mind)
 		return
-	new_death.is_xeno = TRUE // beneath the if, because new_death isn't generated if there's no mind
 	var/datum/entity/player_stats/xeno/xeno_stats = mind.setup_xeno_stats()
 	if(xeno_stats && xeno_stats.death_list)
 		xeno_stats.death_list.Insert(1, new_death)


### PR DESCRIPTION
## About The Pull Request

this fixes a xeno fact being used for human facts; the damage taken by a xeno that got gibbed will no longer show up as a human fun fact

the fix is done by moving a variable change a line before an if statement for (statistic_exempt || !mind), this fixes it because

## Why It's Good For The Game

geeves wanted this fixed

also i'm not too sure why there's a check for (statistic_exempt || !mind) to begin with, when track_mob_death already starts off with a check for (!mind || statistic_exempt), you'd think that if gibbing causes the later check to break this that this earlier check would also, but i'm guessing maybe this is because

## Changelog
:cl:
fix: fixed a xeno fun fact showing up in human fun facts
/:cl:
