### PR TITLE
Fixes sandbag duplication bug

### DIFF
--- a/code/game/objects/structures/barricade/sandbags.dm
+++ b/code/game/objects/structures/barricade/sandbags.dm
@@ -105,7 +105,8 @@
 			new /obj/item/stack/barbed_wire(loc)
 		if(stack_type && health > 0)
 			new stack_type(loc, stack_amount)
-	return ..()
+	density = 0
+	qdel(src)
 
 /obj/structure/barricade/sandbags/proc/increment_build_stage()
 	switch(build_stage)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

The deconstruct refactor (https://github.com/cmss13-devs/cmss13/pull/1285) accidentally was double deconstructing sandbags because of their snowflake code around stack amounts.

## Why It's Good For The Game

Bug bad.

## Changelog

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Morrow
fix: Fixes sandbag duplication bug.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
