### PR TITLE
Fix issues with clothing_traits (SADAR ear protection)

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -368,7 +368,7 @@
 				break
 
 /obj/item/clothing/equipped(mob/user, slot, silent)
-	if(is_valid_slot(slot, TRUE)) //is it going to an actual clothing slot rather than a pocket, hand, or backpack?
+	if(is_valid_slot(slot, TRUE)) //is it going to a matching clothing slot?
 		if(!silent && LAZYLEN(equip_sounds))
 			playsound_client(user.client, pick(equip_sounds), null, ITEM_EQUIP_VOLUME)
 		if(clothing_traits_active)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -368,17 +368,18 @@
 				break
 
 /obj/item/clothing/equipped(mob/user, slot, silent)
-	if(slot != WEAR_L_HAND && slot != WEAR_R_HAND && slot != WEAR_L_STORE && slot != WEAR_R_STORE  && slot != WEAR_J_STORE) //is it going to an actual clothing slot rather than a pocket, hand, or backpack?
+	if(is_valid_slot(slot, TRUE)) //is it going to an actual clothing slot rather than a pocket, hand, or backpack?
 		if(!silent && LAZYLEN(equip_sounds))
 			playsound_client(user.client, pick(equip_sounds), null, ITEM_EQUIP_VOLUME)
 		if(clothing_traits_active)
 			for(var/trait in clothing_traits)
-				ADD_TRAIT(user, trait, TRAIT_SOURCE_EQUIPMENT(flags_equip_slot))
+				ADD_TRAIT(user, trait, TRAIT_SOURCE_EQUIPMENT(slot))
 	..()
 
 /obj/item/clothing/unequipped(mob/user, slot)
-	for(var/trait in clothing_traits)
-		REMOVE_TRAIT(user, trait, TRAIT_SOURCE_EQUIPMENT(flags_equip_slot))
+	if(is_valid_slot(slot, TRUE))
+		for(var/trait in clothing_traits)
+			REMOVE_TRAIT(user, trait, TRAIT_SOURCE_EQUIPMENT(slot))
 	. = ..()
 
 /obj/item/clothing/proc/get_pockets()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

`clothing_traits` seem to have had issues as a RPG spec handling one of their M3T helmets while wearing the second would render it inoperative, by virtue of how item handling works.

This PR changes two things:
 * We use `is_valid_slot(slot, TRUE)` to validate we only add/remove traits if this is (un)equipped from a slot it's intended to go on. 
 * We ID the trait by the actual slot it's going on, and not possible slots. This matters for multiple slot equipables.

## Why It's Good For The Game

Less worries about clunky things like that.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->

## Changelog

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixes issues with clothing traits resulting in, eg, RPG spec losing ear protection by manipulating their spare helmet.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
