### PR TITLE
Leadership orders shout phrases again

### DIFF
--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -243,11 +243,11 @@
 	var/message = ""
 	switch(order)
 		if(COMMAND_ORDER_MOVE)
-			message = pick(";GET MOVING!", ";GO, GO, GO!", ";WE ARE ON THE MOVE!", ";MOVE IT!", ";DOUBLE TIME!")
+			message = pick("GET MOVING!", "GO, GO, GO!", "WE ARE ON THE MOVE!", "MOVE IT!", "DOUBLE TIME!")
 		if(COMMAND_ORDER_HOLD)
-			message = pick(";DUCK AND COVER!", ";HOLD THE LINE!", ";HOLD POSITION!", ";STAND YOUR GROUND!", ";STAND AND FIGHT!")
+			message = pick("DUCK AND COVER!", "HOLD THE LINE!", "HOLD POSITION!", "STAND YOUR GROUND!", "STAND AND FIGHT!")
 		if(COMMAND_ORDER_FOCUS)
-			message = pick(";FOCUS FIRE!", ";PICK YOUR TARGETS!", ";CENTER MASS!", ";CONTROLLED BURSTS!", ";AIM YOUR SHOTS!")
+			message = pick("FOCUS FIRE!", "PICK YOUR TARGETS!", "CENTER MASS!", "CONTROLLED BURSTS!", "AIM YOUR SHOTS!")
 	say(message)
 
 /mob/living/carbon/human/proc/make_aura_available()

--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -240,7 +240,15 @@
 	// 1min cooldown on orders
 	addtimer(CALLBACK(src, .proc/make_aura_available), COMMAND_ORDER_COOLDOWN)
 
-	visible_message(SPAN_BOLDNOTICE("[src] gives an order to [order]!"), SPAN_BOLDNOTICE("You give an order to [order]!"))
+	var/message = ""
+	switch(order)
+		if(COMMAND_ORDER_MOVE)
+			message = pick(";GET MOVING!", ";GO, GO, GO!", ";WE ARE ON THE MOVE!", ";MOVE IT!", ";DOUBLE TIME!")
+		if(COMMAND_ORDER_HOLD)
+			message = pick(";DUCK AND COVER!", ";HOLD THE LINE!", ";HOLD POSITION!", ";STAND YOUR GROUND!", ";STAND AND FIGHT!")
+		if(COMMAND_ORDER_FOCUS)
+			message = pick(";FOCUS FIRE!", ";PICK YOUR TARGETS!", ";CENTER MASS!", ";CONTROLLED BURSTS!", ";AIM YOUR SHOTS!")
+	say(message)
 
 /mob/living/carbon/human/proc/make_aura_available()
 	to_chat(src, SPAN_NOTICE("You can issue an order again."))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

https://gitlab.com/cmdevs/colonial-warfare/-/merge_requests/2806 removed the phrases when someone gave orders, this PR readds them back into the game but without having the orders said over the radio.

https://user-images.githubusercontent.com/16618648/202879931-fc39a020-2f74-42a8-a4ea-a01de1abf068.mp4

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->

These were awesome, its strange behavior to suddenly get a buff without any apparent cause. At least these phrases had a continuance of cause and effect with them, even if their exact meaning isnt up to the player. Really should have been refactored so a phrase could be input instead of just a complete removal if devs wanted to give leaders more autonomy imho. 

For me these phrases grant leaderships roles accessibility to acting the role without any hurdles, and they really add to the battlefield/command atmosphere in a cool and impactful way thats sorely missed by alot of players.

Gladly will give my hard earned GBP for this.

## Changelog

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Readded back shouting phrases when issuing leadership orders but without radio broadcast of them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->



