### PR TITLE
fixes mystical the appearing

### DIFF
--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -54,7 +54,7 @@
 
 /obj/item/proc/get_examine_line(mob/user)
 	if(blood_color)
-		. = SPAN_WARNING("[icon2html(src, user)] [gender==PLURAL?"some":"a"] <font color='[blood_color]'>stained</font> [src]")
+		. = SPAN_WARNING("[icon2html(src, user)] [gender==PLURAL?"some":"a"] <font color='[blood_color]'>stained</font> [src.name]")
 	else
 		. = "[icon2html(src, user)] \a [src]"
 


### PR DESCRIPTION
## About The Pull Request

this changes [src] to be [src.name] in the get_examine_line thing for when you have a stained item, this stops stuff like "he is wearing a stained the engineer's uniform" and now it'll just be "he is wearing a stained engineer's uniform" 

## Why It's Good For The Game

morrow wanted this fixed, it's a grammar fix, etc

## Changelog

:cl:
fix: fixed stained clothing having an extra "the"
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
