### PR TITLE
Fixes LV-522 gamemodes

### DIFF
--- a/maps/LV522_Chances_Claim.json
+++ b/maps/LV522_Chances_Claim.json
@@ -29,5 +29,12 @@
         "xeno_hive_bravo": 0,
         "xeno_hive_charlie": 0,
         "xeno_hive_delta": 0
-    }
+    },
+	"gamemodes": [
+        "Distress Signal",
+        "Hunter Games",
+        "Hive Wars",
+        "Faction Clash",
+        "Infection"
+    ]
 }


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

LV-522 is not an approved map for whiskey outpost.

## Why It's Good For The Game

Bug bad.

## Changelog

:cl: Morrow
fix: Fixes LV-522 showing up for whiskey outpost.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
