### PR TITLE
WO job description XO reference fixes

### DIFF
--- a/code/game/gamemodes/colonialmarines/whiskey_outpost/equipping.dm
+++ b/code/game/gamemodes/colonialmarines/whiskey_outpost/equipping.dm
@@ -11,7 +11,7 @@
 The local population warned you about establishing a base in the jungles of LV-624...
 Hold the outpost for one hour until the distress beacon can be broadcast to the remaining Dust Raiders!
 Coordinate your team and prepare defenses, whatever wiped out the patrols is en-route!
-Count on your Gunnery Seargent, and your Honor Guard Squad Leader to assist you!
+Count on your Lieutenant Commander, and your Honor Guard Squad Leader to assist you!
 Stay alive, and Godspeed, commander!"}
 
 	announce_entry_message(mob/living/carbon/human/H)
@@ -62,7 +62,7 @@ Make the USCM proud!"}
 	gear_preset = /datum/equipment_preset/wo/cmp
 
 	generate_entry_message(mob/living/carbon/human/H)
-		. = {"The Commander is the best hope for this outpost! At least in your eyes. You two have saved each-other's asses enough times to testify to that, and have been together for longer than anyone cares to remember. You're his left-hand man, behind the Gunnery Sergeant. You two are men. Manly men.
+		. = {"The Commander is the best hope for this outpost! At least in your eyes. You two have saved each-other's asses enough times to testify to that, and have been together for longer than anyone cares to remember. You're his left-hand man, behind the Lieutenant Commander. You two are men. Manly men.
 Your veterans have lived enough years that they are able to command others using the overwatch consoles, but the young ones are still fresh out of boot camp - it's your job to shape 'em up into proper soldiers!
 You must lead his Honor guard, his elite unit of marines, to protect the commander, and ensure victory!
 "}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

The PR changes the job descriptions of the Whiskey Outpost Commander and Honor Guard Squad Leader who both reference a Gunnery Sergeant in place of the Lieutenant Commander to actually call them the Lieutenant Commander.


## Why It's Good For The Game

It clears up who is actually meant in place of Gunnery Sergeant, which was nowhere to be found in terms of rank or job name, now it fits the job name

## Changelog

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Googles_Hands
fix: Fixed WO job descriptions calling the Lt Commander a Gunnery Sergeant
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
