### PR TITLE
Fixes Xenonid Facehuggers being invisible

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
@@ -38,7 +38,7 @@
 	var/jumps_left = 2
 
 	var/icon_xeno = 'icons/mob/xenos/effects.dmi'
-	var/icon_xenonid = 'icons/mob/xenonids/facehugger.dmi'
+	var/icon_xenonid = 'icons/mob/xenonids/xenonid_crab.dmi'
 
 /obj/item/clothing/mask/facehugger/Initialize(mapload, hive)
 	. = ..()

--- a/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
@@ -38,7 +38,7 @@
 	var/jumps_left = 2
 
 	var/icon_xeno = 'icons/mob/xenos/effects.dmi'
-	var/icon_xenonid = 'icons/mob/xenonids/xenonid_crab.dmi'
+	var/icon_xenonid = 'icons/mob/xenonids/facehugger.dmi'
 
 /obj/item/clothing/mask/facehugger/Initialize(mapload, hive)
 	. = ..()

--- a/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
@@ -48,7 +48,7 @@
 	mutation_type = "Normal"
 
 	icon_xeno = 'icons/mob/xenos/facehugger.dmi'
-	icon_xenonid = 'icons/mob/xenonids/xenonid_crab.dmi'
+	icon_xenonid = 'icons/mob/xenonids/facehugger.dmi'
 
 /mob/living/carbon/Xenomorph/Facehugger/initialize_pass_flags(var/datum/pass_flags_container/PF)
 	..()


### PR DESCRIPTION
## About The Pull Request

Xenonid facehuggers (playable) were using Xenonid facehugger (mutated egg) sprites. This caused them to be invisible.

## Changelog
:cl:
fix: Xenonid (Mutant) playable Facehuggers are no longer invisible again
/:cl: