### PR TITLE
fixes windows not dropping the correct items after breaking

### DIFF
--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -144,7 +144,7 @@
 		SEND_SIGNAL(M, COMSIG_MOB_WINDOW_EXPLODED, src)
 
 	handle_debris(severity, explosion_direction)
-	qdel(src)
+	deconstruct(FALSE)
 	return
 
 /obj/structure/window/get_explosion_resistance(direction)
@@ -536,9 +536,9 @@
 
 /obj/structure/window/framed/deconstruct(disassembled = TRUE)
 	if(window_frame)
-			var/obj/structure/window_frame/new_window_frame = new window_frame(loc, TRUE)
-			new_window_frame.icon_state = "[new_window_frame.basestate][junction]_frame"
-			new_window_frame.setDir(dir)
+		var/obj/structure/window_frame/new_window_frame = new window_frame(loc, TRUE)
+		new_window_frame.icon_state = "[new_window_frame.basestate][junction]_frame"
+		new_window_frame.setDir(dir)
 	return ..()
 
 /obj/structure/window/framed/almayer

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -106,7 +106,7 @@
 				SSclues.create_print(get_turf(user), user, "A small glass piece is found on the fingerprint.")
 		if(make_shatter_sound)
 			playsound(src, "windowshatter", 50, 1)
-		deconstruct(FALSE)
+		shatter_window(create_debris)
 	else
 		if(make_hit_sound)
 			playsound(loc, 'sound/effects/Glasshit.ogg', 25, 1)
@@ -273,7 +273,7 @@
 			to_chat(user, (anchored ? SPAN_NOTICE("You have fastened the window to the floor.") : SPAN_NOTICE("You have unfastened the window.")))
 		else if(static_frame && state == 0)
 			SEND_SIGNAL(user, COMSIG_MOB_DISASSEMBLE_WINDOW, src)
-			deconstruct()
+			deconstruct(TRUE)
 	else if(HAS_TRAIT(W, TRAIT_TOOL_CROWBAR) && reinf && state <= 1 && !not_deconstructable)
 		state = 1 - state
 		playsound(loc, 'sound/items/Crowbar.ogg', 25, 1)
@@ -297,7 +297,7 @@
 		if(reinf)
 			new /obj/item/stack/sheet/glass/reinforced(loc, 2)
 		else
-			new /obj/item/stack/sheet/glass/reinforced(loc, 2)
+			new /obj/item/stack/sheet/glass(loc, 2)
 	return ..()
 
 
@@ -535,17 +535,12 @@
 
 
 /obj/structure/window/framed/deconstruct(disassembled = TRUE)
-	if(disassembled)
-		if(window_frame)
-			var/obj/structure/window_frame/WF = new window_frame(loc)
-			WF.icon_state = "[WF.basestate][junction]_frame"
-			WF.setDir(dir)
-	else
-		if(window_frame)
+	if(window_frame)
 			var/obj/structure/window_frame/new_window_frame = new window_frame(loc, TRUE)
 			new_window_frame.icon_state = "[new_window_frame.basestate][junction]_frame"
 			new_window_frame.setDir(dir)
 	return ..()
+
 /obj/structure/window/framed/almayer
 	name = "reinforced window"
 	desc = "A glass window with a special rod matrix inside a wall frame. It looks rather strong. Might take a few good hits to shatter it."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

i forgot to change a proc, this resulted in windows not shattering
also for some reason before i changed deconstruction code, it was already always giving reinforced glass? strange
similarly, there was duplicated code

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

fixy bug bad

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->

## Changelog

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: windows shatter appropriately, and drop what you'd expect if they are reinforced or not upon deconstruction
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
