### PR TITLE
Refactor eyesight into trait as well as adds opiate receptor deficiency trait

### DIFF
--- a/ColonialMarinesALPHA.dme
+++ b/ColonialMarinesALPHA.dme
@@ -1295,6 +1295,7 @@
 #include "code\modules\buildmode\submodes\outfit.dm"
 #include "code\modules\buildmode\submodes\throwing.dm"
 #include "code\modules\buildmode\submodes\variable_edit.dm"
+#include "code\modules\character_traits\biology_traits.dm"
 #include "code\modules\character_traits\character_trait.dm"
 #include "code\modules\character_traits\hair_dye.dm"
 #include "code\modules\character_traits\languages.dm"

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -50,6 +50,7 @@
 #define COUGHING		4
 #define TOURETTES		8
 #define NERVOUS			16
+#define OPIATE_RECEPTOR_DEFICIENCY 32
 //=================================================
 
 //sdisabilities

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -203,9 +203,6 @@
 	new_character.name = NP.real_name
 	new_character.voice = NP.real_name
 
-	if(NP.client.prefs.disabilities)
-		new_character.disabilities |= NEARSIGHTED
-
 	if(NP.mind)
 		NP.mind_initialize()
 		NP.mind.transfer_to(new_character, TRUE)

--- a/code/modules/character_traits/biology_traits.dm
+++ b/code/modules/character_traits/biology_traits.dm
@@ -1,0 +1,34 @@
+/datum/character_trait_group/biology
+	trait_group_name = "Biology"
+
+/datum/character_trait/biology
+	applyable = FALSE
+	trait_group = /datum/character_trait_group/biology
+
+/datum/character_trait/biology/bad_eyesight
+	trait_name = "Bad Eyesight"
+	trait_desc = "A condition in which close objects appear clearly, but far ones don't."
+	applyable = TRUE
+	cost = 1
+
+/datum/character_trait/biology/bad_eyesight/apply_trait(mob/living/carbon/human/target)
+	..()
+	ENABLE_BITFIELD(target.disabilities, NEARSIGHTED)
+
+/datum/character_trait/biology/bad_eyesight/unapply_trait(mob/living/carbon/human/target)
+	..()
+	DISABLE_BITFIELD(target.disabilities, NEARSIGHTED)
+
+/datum/character_trait/biology/opiate_receptor_deficiency
+	trait_name = "Opiate Receptor Deficiency"
+	trait_desc = "Due to overuse of opiates or a genetic fluke, this condition reduces the potency of all basic painkilling drugs."
+	applyable = TRUE
+	cost = 1
+
+/datum/character_trait/biology/opiate_receptor_deficiency/apply_trait(mob/living/carbon/human/target)
+	..()
+	ENABLE_BITFIELD(target.disabilities, OPIATE_RECEPTOR_DEFICIENCY)
+
+/datum/character_trait/biology/opiate_receptor_deficiency/unapply_trait(mob/living/carbon/human/target)
+	..()
+	DISABLE_BITFIELD(target.disabilities, OPIATE_RECEPTOR_DEFICIENCY)

--- a/code/modules/character_traits/character_trait.dm
+++ b/code/modules/character_traits/character_trait.dm
@@ -3,7 +3,7 @@
 /datum/preferences/var/list/traits
 /// State var for preferences to track trait points
 /// Change this value to set the amount of trait points you start with
-/datum/preferences/var/trait_points = 1
+/datum/preferences/var/trait_points = 2
 /// State var to check if traits have been read in to modify
 /// trait points
 /datum/preferences/var/read_traits = FALSE

--- a/code/modules/character_traits/robotic_limbs.dm
+++ b/code/modules/character_traits/robotic_limbs.dm
@@ -1,5 +1,5 @@
 /datum/character_trait_group/robo_limb
-	trait_group_name = "Robotic Limb (Commissioned Officers)"
+	trait_group_name = "Robotic Limb"
 	mutually_exclusive = TRUE
 	base_type = /datum/character_trait_group/robo_limb
 
@@ -9,6 +9,7 @@
 	var/additional_description = "Only usable by 2ndLts and up."
 	applyable = FALSE
 	trait_group = /datum/character_trait_group/robo_limb
+	cost = 1
 	var/minimum_ranking = 12 // MO1, so SO and up
 
 /datum/character_trait/robo_limb/New()

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -169,7 +169,6 @@ var/const/MAX_SAVE_SLOTS = 10
 	var/sec_record = ""
 	var/gen_record = ""
 	var/exploit_record = ""
-	var/disabilities = 0
 
 	var/nanotrasen_relation = "Neutral"
 
@@ -312,7 +311,6 @@ var/const/MAX_SAVE_SLOTS = 10
 			dat += "<b>Gender:</b> <a href='?_src_=prefs;preference=gender'><b>[gender == MALE ? "Male" : "Female"]</b></a><br>"
 			dat += "<b>Ethnicity:</b> <a href='?_src_=prefs;preference=ethnicity;task=input'><b>[ethnicity]</b></a><br>"
 			dat += "<b>Body Type:</b> <a href='?_src_=prefs;preference=body_type;task=input'><b>[body_type]</b></a><br>"
-			dat += "<b>Poor Eyesight:</b> <a href='?_src_=prefs;preference=disabilities'><b>[disabilities == 0 ? "No" : "Yes"]</b></a><br>"
 			dat += "<b>Traits:</b> <a href='byond://?src=\ref[user];preference=traits;task=open'><b>Character Traits</b></a>"
 			dat += "<br>"
 
@@ -1552,9 +1550,6 @@ var/const/MAX_SAVE_SLOTS = 10
 						gender = MALE
 					underwear = sanitize_inlist(underwear, gender == MALE ? GLOB.underwear_m : GLOB.underwear_f, initial(underwear))
 					undershirt = sanitize_inlist(undershirt, gender == MALE ? GLOB.undershirt_m : GLOB.undershirt_f, initial(undershirt))
-
-				if("disabilities")				//please note: current code only allows nearsightedness as a disability
-					disabilities = !disabilities//if you want to add actual disabilities, code that selects them should be here
 
 				if("hear_adminhelps")
 					toggles_sound ^= SOUND_ADMINHELP

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -398,7 +398,6 @@
 	S["sec_record"]			>> sec_record
 	S["gen_record"]			>> gen_record
 	S["be_special"]			>> be_special
-	S["disabilities"]		>> disabilities
 	S["organ_data"]			>> organ_data
 	S["gear"]				>> gear
 	S["origin"] 			>> origin
@@ -465,8 +464,6 @@
 		for(var/job in job_preference_list)
 			job_preference_list[job] = sanitize_integer(job_preference_list[job], 0, 3, initial(job_preference_list[job]))
 
-	if(isnull(disabilities))
-		disabilities = 0
 	if(!organ_data)
 		organ_data = list()
 
@@ -543,7 +540,6 @@
 	S["sec_record"]			<< sec_record
 	S["gen_record"]			<< gen_record
 	S["be_special"]			<< be_special
-	S["disabilities"]		<< disabilities
 	S["organ_data"]			<< organ_data
 	S["gear"]				<< gear
 	S["origin"] 			<< origin

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -385,9 +385,6 @@
 	new_character.name = real_name
 	new_character.voice = real_name
 
-	if(client.prefs.disabilities)
-		new_character.disabilities |= NEARSIGHTED
-
 	// Update the character icons
 	// This is done in set_species when the mob is created as well, but
 	INVOKE_ASYNC(new_character, /mob/living/carbon/human.proc/regenerate_icons)

--- a/code/modules/reagents/chemistry_properties/prop_positive.dm
+++ b/code/modules/reagents/chemistry_properties/prop_positive.dm
@@ -196,20 +196,21 @@
 /datum/chem_property/positive/painkilling/process(mob/living/M, var/potency = 1, delta_time)
 	if(!..())
 		return
-
-	M.pain.apply_pain_reduction(PAIN_REDUCTION_MULTIPLIER * potency)
+	var/effective_potency = (CHECK_BITFIELD(M.disabilities, OPIATE_RECEPTOR_DEFICIENCY) ? potency * 0.25 : potency)
+	M.pain.apply_pain_reduction(PAIN_REDUCTION_MULTIPLIER * effective_potency)
 
 /datum/chem_property/positive/painkilling/process_overdose(mob/living/M, var/potency = 1, delta_time)
 	if(!..())
 		return
-
-	M.pain.apply_pain_reduction(PAIN_REDUCTION_MULTIPLIER * potency)
-	M.hallucination = max(M.hallucination, potency) //Hallucinations and tox damage
-	M.apply_damage(0.5 *  potency * delta_time, TOX)
+	var/effective_potency = (CHECK_BITFIELD(M.disabilities, OPIATE_RECEPTOR_DEFICIENCY) ? potency * 0.25 : potency)
+	M.pain.apply_pain_reduction(PAIN_REDUCTION_MULTIPLIER * effective_potency)
+	M.hallucination = max(M.hallucination, effective_potency) //Hallucinations and tox damage
+	M.apply_damage(0.5 *  effective_potency * delta_time, TOX)
 
 /datum/chem_property/positive/painkilling/process_critical(mob/living/M, var/potency = 1)
-	M.apply_internal_damage(POTENCY_MULTIPLIER_HIGH * potency, "liver")
-	M.apply_damage(potency, BRAIN)
+	var/effective_potency = (CHECK_BITFIELD(M.disabilities, OPIATE_RECEPTOR_DEFICIENCY) ? potency * 0.25 : potency)
+	M.apply_internal_damage(POTENCY_MULTIPLIER_HIGH * effective_potency, "liver")
+	M.apply_damage(effective_potency, BRAIN)
 	M.apply_damage(3, OXY)
 
 /datum/chem_property/positive/hepatopeutic


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

This PR refactors poor eyesight into the trait system as well as adding a new trait called "opiate receptor deficiency". Both are in a new "biology" section under traits. 

Opiate receptor deficiency traits multiplies the potency of the "painkilling" effect of drugs by 0.25 (1/4th of the effect). It should almost always be a detriment to the user so as to not have balance concerns. **TO BE CLEAR: THIS TRAIT WAS A COMMISSION**

People now have two trait points to spend as poor eyesight has been moved over to it and robotic limbs cost one point now. This should not overly effect how traits function as robotic limbs are already mutually exclusive from one another and there are enough options to warrant it now.

Robotic limb preference group name was also reduced in size as the warning is clearly in the description of the trait and the name was too large/clunky/out of place.

## Why It's Good For The Game

Refactoring code into common systems makes them easier to manage and creates a system to be built off of in the future.

## Changelog

:cl: Morrow
add: Adds new trait "opiate receptor deficiency" which reduces potency of painkilling effects.
add: Adds a trait point (now at two) for use in character creation.
refactor: Refactors the poor eyesight preference into the trait system.
spellcheck: Removes extraneous wording around robotic limb preferences.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
