### PR TITLE
Whiskey Outpost fixes and rank changes

### DIFF
--- a/code/game/gamemodes/colonialmarines/whiskey_outpost/equipping.dm
+++ b/code/game/gamemodes/colonialmarines/whiskey_outpost/equipping.dm
@@ -11,7 +11,7 @@
 The local population warned you about establishing a base in the jungles of LV-624...
 Hold the outpost for one hour until the distress beacon can be broadcast to the remaining Dust Raiders!
 Coordinate your team and prepare defenses, whatever wiped out the patrols is en-route!
-Count on your Gunnery Seargent, and your Honor Guard Squad Leader to assist you!
+Count on your Lieutenant Commander, and your Honor Guard Squad Leader to assist you!
 Stay alive, and Godspeed, commander!"}
 
 	announce_entry_message(mob/living/carbon/human/H)
@@ -62,7 +62,7 @@ Make the USCM proud!"}
 	gear_preset = /datum/equipment_preset/wo/cmp
 
 	generate_entry_message(mob/living/carbon/human/H)
-		. = {"The Commander is the best hope for this outpost! At least in your eyes. You two have saved each-other's asses enough times to testify to that, and have been together for longer than anyone cares to remember. You're his left-hand man, behind the Gunnery Sergeant. You two are men. Manly men.
+		. = {"The Commander is the best hope for this outpost! At least in your eyes. You two have saved each-other's asses enough times to testify to that, and have been together for longer than anyone cares to remember. You're his left-hand man, behind the Lieutenant Commander. You two are men. Manly men.
 Your veterans have lived enough years that they are able to command others using the overwatch consoles, but the young ones are still fresh out of boot camp - it's your job to shape 'em up into proper soldiers!
 You must lead his Honor guard, his elite unit of marines, to protect the commander, and ensure victory!
 "}

--- a/code/game/gamemodes/colonialmarines/whiskey_outpost/whiskey_output_waves.dm
+++ b/code/game/gamemodes/colonialmarines/whiskey_outpost/whiskey_output_waves.dm
@@ -120,7 +120,7 @@
 	wave_number = 1
 	wave_castes = list(XENO_CASTE_RUNNER)
 	sound_effect = list('sound/effects/siren.ogg')
-	command_announcement = list("We're tracking the creatures that wiped out our patrols heading towards your outpost, Multiple small life-signs detected enroute to the outpost.. Stand-by while we attempt to establish a signal with the USS Alistoun to alert them of these creatures.", "Captain Naich, 3rd Battalion Command, LV-624 Garrison")
+	command_announcement = list("We're tracking the creatures that wiped out our patrols heading towards your outpost, Multiple small life-signs detected enroute to the outpost.. Stand-by while we attempt to establish a signal with the USS Alistoun to alert them of these creatures.", "Captain Naiche, 3rd Battalion Command, LV-624 Garrison")
 	scaling_factor = 0.3
 	wave_delay = 1 MINUTES //Early, quick waves
 
@@ -188,7 +188,7 @@
 	wave_number = 7
 	wave_type = WO_STATIC_WAVE
 	number_of_xenos = 0
-	command_announcement = list("Major Ike Saker speaking, The Captain is still trying to try and get off world contact. An engineer platoon managed to destroy the main entrance into this valley this should give you a short break while the aliens find another way in. I have also received word that the 2nd 'Falling Falcons' Battalion. Should be near. I used to be stationed with them they are top notch!", "Major Ike Saker, 3rd Battalion Command, LV-624 Garrison")
+	command_announcement = list("First Lieutenant Ike Saker, Executive Officer of Captain Naiche, speaking. The Captain is still trying to try and get off world contact. An engineer platoon managed to destroy the main entrance into this valley this should give you a short break while the aliens find another way in. I have also received word that marines from an overrun outpost are evacuating to you and will help you. I used to be stationed with them, they are top notch!", "First Lieutenant Ike Saker, 3rd Battalion Command, LV-624 Garrison")
 
 /datum/whiskey_outpost_wave/wave8
 	wave_number = 8
@@ -202,7 +202,7 @@
 					XENO_CASTE_DRONE,
 					XENO_CASTE_WARRIOR)
 	sound_effect = list()
-	command_announcement = list("Captain Naiche speaking, we've been unsuccessful in establishing offworld communication for the moment. We're prepping our M402 mortars to destroy the inbound xeno force on the main road. Standby for fire support.", "Captain Naich, 3rd Battalion Command, LV-624 Garrison")
+	command_announcement = list("Captain Naiche speaking, we've been unsuccessful in establishing offworld communication for the moment. We're prepping our M402 mortars to destroy the inbound xeno force on the main road. Standby for fire support.", "Captain Naiche, 3rd Battalion Command, LV-624 Garrison")
 
 /datum/whiskey_outpost_wave/wave9 //Ravager and Praetorian Added, Tier II more common, Tier I less common
 	wave_number = 9
@@ -223,7 +223,7 @@
 					XENO_CASTE_DRONE,
 					XENO_CASTE_WARRIOR)
 	sound_effect = list('sound/voice/alien_queen_command.ogg')
-	command_announcement = list("Our garrison forces are reaching seventy percent casualties, we are losing our grip on LV-624. It appears that vanguard of the hostile force is still approaching, and most of the other Dust Raider platoons have been shattered. We're counting on you to keep holding.", "Captain Naich, 3rd Battalion Command, LV-624 Garrison")
+	command_announcement = list("Our garrison forces are reaching seventy percent casualties, we are losing our grip on LV-624. It appears that vanguard of the hostile force is still approaching, and most of the other Dust Raider platoons have been shattered. We're counting on you to keep holding.", "Captain Naiche, 3rd Battalion Command, LV-624 Garrison")
 
 /datum/whiskey_outpost_wave/wave10
 	wave_number = 10
@@ -287,7 +287,7 @@
 					XENO_CASTE_RAVAGER,
 					XENO_CASTE_PRAETORIAN,
 					XENO_CASTE_PRAETORIAN)
-	command_announcement = list("This is Captain Naiche, we are picking up large signatures inbound, we'll see what we can do to delay them.", "Captain Naich, 3rd Battalion Command, LV-624")
+	command_announcement = list("This is Captain Naiche, we are picking up large signatures inbound, we'll see what we can do to delay them.", "Captain Naiche, 3rd Battalion Command, LV-624")
 
 /datum/whiskey_outpost_wave/wave13
 	wave_number = 13
@@ -351,7 +351,7 @@
 					XENO_CASTE_HIVELORD)
 	wave_type = WO_STATIC_WAVE
 	number_of_xenos = 50
-	command_announcement = list("This is Captain Naiche, we've established our distress beacon for the USS Alistoun and the remaining Dust Raiders. Hold on for a bit longer while we trasmit our coordinates!", "Captain Naich, 3rd Battalion Command, LV-624 Garrison")
+	command_announcement = list("This is Captain Naiche, we've established our distress beacon for the USS Alistoun and the remaining Dust Raiders. Hold on for a bit longer while we trasmit our coordinates!", "Captain Naiche, 3rd Battalion Command, LV-624 Garrison")
 
 /datum/whiskey_outpost_wave/random
 	wave_type = WO_STATIC_WAVE

--- a/code/modules/gear_presets/wo.dm
+++ b/code/modules/gear_presets/wo.dm
@@ -713,7 +713,6 @@
 	H.equip_to_slot_or_del(new /obj/item/device/binoculars/range(H), WEAR_IN_BACK)
 	H.equip_to_slot_or_del(new /obj/item/tool/shovel/etool/folded(H), WEAR_IN_BACK)
 	H.equip_to_slot_or_del(new /obj/item/storage/belt/utility/full(H), WEAR_WAIST)
-	H.equip_to_slot_or_del(new /obj/item/clothing/glasses/welding(H), WEAR_EYES)
 	H.equip_to_slot_or_del(new /obj/item/storage/pouch/construction/full(H), WEAR_R_STORE)
 	H.equip_to_slot_or_del(new /obj/item/storage/pouch/construction/full(H), WEAR_L_STORE)
 

--- a/code/modules/gear_presets/wo.dm
+++ b/code/modules/gear_presets/wo.dm
@@ -317,7 +317,7 @@
 	access = list(ACCESS_MARINE_CARGO, ACCESS_MARINE_RO, ACCESS_MARINE_BRIDGE)
 	assignment = JOB_WO_CHIEF_REQUISITION
 	rank = JOB_WO_CHIEF_REQUISITION
-	paygrade = "ME7"
+	paygrade = "ME8"
 	role_comm_title = "QM"
 	skills = /datum/skills/RO
 	idtype = /obj/item/card/id/silver

--- a/code/modules/gear_presets/wo.dm
+++ b/code/modules/gear_presets/wo.dm
@@ -17,7 +17,7 @@
 
 	assignment = JOB_WO_CO
 	rank = JOB_WO_CO
-	paygrade = "MO4"
+	paygrade = "MO2"
 	role_comm_title = "CO"
 	skills = /datum/skills/commander
 	idtype = /obj/item/card/id/gold
@@ -96,7 +96,7 @@
 
 	assignment = JOB_WO_XO
 	rank = JOB_WO_XO
-	paygrade = "MO3"
+	paygrade = "MO1"
 	role_comm_title = "XO"
 	skills = /datum/skills/XO
 	idtype = /obj/item/card/id/silver
@@ -284,7 +284,7 @@
 	access = list(ACCESS_MARINE_BRIDGE, ACCESS_MARINE_DROPSHIP, ACCESS_MARINE_LOGISTICS, ACCESS_MARINE_PILOT)
 	assignment = JOB_WO_PILOT
 	rank = JOB_WO_PILOT
-	paygrade = "ME2"
+	paygrade = "ME3"
 	role_comm_title = "MC"
 	skills = /datum/skills/mortar_crew
 
@@ -317,7 +317,7 @@
 	access = list(ACCESS_MARINE_CARGO, ACCESS_MARINE_RO, ACCESS_MARINE_BRIDGE)
 	assignment = JOB_WO_CHIEF_REQUISITION
 	rank = JOB_WO_CHIEF_REQUISITION
-	paygrade = "MO2"
+	paygrade = "ME7"
 	role_comm_title = "QM"
 	skills = /datum/skills/RO
 	idtype = /obj/item/card/id/silver


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
This adds to a small PR of mine and makes it into a larger one which contains the following: spelling fixes, changes to two job descriptions and a minor shuffle in the ranks of four jobs (Ground Commander, Lieutenant Commander, Quartermaster and Mortar Crew).
Fixes: #1682
removes the welding goggles from the Squad Engineers, as they already have welding helmets
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
### Spelling fixes
Always good to have
### description changes
Changes a reference to the Lieutenant Command who was called a "Gunnery Sergeant" when that is not his current rank (Captain) or the rank that I am changing him to (Second Lieutenant). He is just now referenced as his job title, Lieutenant Commander
### Rank changes
As I've explained in a discord post, the CO having the rank of Major while Captain Naiche, the canonical Commander of all marine forces on LV, is giving them orders.
This a leftover from the rank rework when the Ground Commander just had the rank of Commander, which put him one rank below the Captain. Dropping the CO to the difference from before, which in this case is First Lieutenant remedies this lore conflict.
Entailing this also forces me to drop the XO (who was a captain) to Second Lieutenant and the QM (who was a First Lieutenant) to First Sergeant. I don't think these changes are a detriment to the game as all marines besides the CO, XO and QM were enlisted men anyhow, which means it doesn't really matter if the CO is a Captain or First Lieutenant. The QM is still the third highest ranking marine, just no longer an officer.
I am also elevating the Mortar Crew from PFC to Lance Corporal as I think a man that went through specialized training which is now his dedicated assignment ought to outrank a rifleman, like a squad engie or medic.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->

## Changelog
:cl: Googles_Hands
fix: Changed the WO CO, XO, QM and Mortar Crew ranks to be more lore friendly
fix: Changed the WO reinforcement announcement to be more lore friendly
fix: Fixed the description of the WO XO and CMP in reference to the XO's title
spellcheck: Fixed a few misspellings in WO announcements
fix: removes redundant welding protection from squad engies
/:cl:
