### PR TITLE
fixes power load values

### DIFF
--- a/code/game/machinery/computer/camera_console.dm
+++ b/code/game/machinery/computer/camera_console.dm
@@ -81,7 +81,7 @@
 			concurrent_users += user_ref
 		// Turn on the console
 		if(length(concurrent_users) == 1 && is_living)
-			use_power(active_power_usage)
+			update_use_power(2)
 		// Register map objects
 		user.client.register_map_obj(cam_screen)
 		user.client.register_map_obj(cam_background)
@@ -207,7 +207,8 @@
 		current = null
 		last_camera_turf = null
 		range_turfs = list()
-		use_power(0)
+		if(use_power)
+			update_use_power(1)
 		STOP_PROCESSING(SSfastobj, src)
 	user.unset_interaction()
 

--- a/code/game/machinery/computer/computer.dm
+++ b/code/game/machinery/computer/computer.dm
@@ -17,9 +17,6 @@
 	. = ..()
 	if(processing)
 		start_processing()
-
-/obj/structure/machinery/computer/Initialize()
-	. = ..()
 	power_change()
 
 /obj/structure/machinery/computer/initialize_pass_flags(var/datum/pass_flags_container/PF)

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -134,7 +134,7 @@
 	desc = "A bright fluorescent tube light. Looking at it for too long makes your eyes go watery."
 	anchored = 1
 	layer = FLY_LAYER
-	use_power = 2
+	use_power = 1
 	idle_power_usage = 2
 	active_power_usage = 20
 	power_channel = POWER_CHANNEL_LIGHT //Lights are calc'd via area so they dont need to be in the machine list
@@ -214,6 +214,7 @@
 			if(prob(5))
 				broken(1)
 
+	active_power_usage = (brightness * 10)
 	addtimer(CALLBACK(src, .proc/update, 0), 1)
 
 	set_pixel_location()
@@ -289,10 +290,9 @@
 				update_use_power(2)
 				SetLuminosity(brightness)
 	else
-		update_use_power(1)
+		update_use_power(0)
 		SetLuminosity(0)
 
-	active_power_usage = (luminosity * 10)
 	if(on != on_gs)
 		on_gs = on
 

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -83,11 +83,13 @@
 			if(stat & NOPOWER)
 				addToListNoDupe(processing_machines, src) // power interupted us, start processing again
 		stat &= ~NOPOWER
+		src.update_use_power(1)
 
 	else
 		if(machine_processing)
 			processing_machines -= src // no power, can't process.
 		stat |= NOPOWER
+		src.update_use_power(0)
 
 // the powernet datum
 // each contiguous network of cables & nodes

--- a/code/modules/shuttles/shuttle_console.dm
+++ b/code/modules/shuttles/shuttle_console.dm
@@ -312,7 +312,7 @@ GLOBAL_LIST_EMPTY(shuttle_controls)
 						almayer_aa_cannon.is_disabled = TRUE
 				else
 					if(shuttle.require_link)
-						update_use_power(4080)
+						use_power(4080)
 					shuttle.launch(src)
 
 			else if(!onboard && isXenoQueen(M) && shuttle.location == 1 && !shuttle.iselevator)


### PR DESCRIPTION
## About The Pull Request

added two calls for update_use_power in power_change in power.dm

changes active_power_usage for lights to be based off brightness instead of luminosity and places it in initialize, as active_power_usage realistically shouldn't be fluctuating

there were two initialize procs for computers, I combined them into one because why not, security consoles now use update_use_power

## Why It's Good For The Game

this fixes #1688 - now if you turn off the power in an area, the total load will go to 0 W, things should use the proper amount of power when initializing (i.e. you shouldn't get any mystery extra power draw), lights won't magically go into the negative and more

## Changelog

:cl:
fix: fixed power load values
/:cl:
