### PR TITLE
Enables ice_colony_v2 for staff

### DIFF
--- a/map_config/maps.txt
+++ b/map_config/maps.txt
@@ -37,7 +37,7 @@ endmap
 
 map ice_colony_v2
 	minplayers 130
-	disabled
+	voteweight 0
 endmap
 
 map shivas_snowball


### PR DESCRIPTION
## About The Pull Request
Enables the map **ice_colony_v2** and gives it voteweight 0 so admins can force it for events like old prison or CORSAT.
## Why It's Good For The Game
Allowing staff to load Old Ice for events and such would have no change for normal gameplay and only gives the staff team more options, it is in the code and works, so why keep it disabled. Considering we would only see it during heavily monitored events, like once in a month at best, it would be neat to experience from time to time.
## Changelog
:cl: Googles_Hands
config: Staff can now force ice_colony_v2
/:cl: