### PR TITLE
Explosion stun is reduced by bomb armor. Xenos are now Knocked down instead of KO'd when exploded.

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -122,15 +122,15 @@
 	if(lying)
 		severity *= EXPLOSION_PRONE_MULTIPLIER
 
-	if(severity >= 30)
-		flash_eyes()
+
 
 	var/b_loss = 0
 	var/f_loss = 0
 
 	var/damage = severity
+	var/bomb_armor = getarmor(null, ARMOR_BOMB)
 
-	damage = armor_damage_reduction(GLOB.marine_explosive, damage, getarmor(null, ARMOR_BOMB))
+	damage = armor_damage_reduction(GLOB.marine_explosive, damage, bomb_armor)
 
 	last_damage_data = istype(cause_data) ? cause_data : create_cause_data(cause_data)
 
@@ -147,20 +147,28 @@
 		ear_damage += severity * 0.15
 		AdjustEarDeafness(severity * 0.5)
 
-	var/knockdown_value = min( round( severity*0.1  ,1) ,10)
-	if(knockdown_value > 0)
-		var/obj/item/Item1 = get_active_hand()
-		var/obj/item/Item2 = get_inactive_hand()
-		apply_effect(knockdown_value, WEAKEN)
-		var/knockout_value = min( round( damage*0.1  ,1) ,10)
-		apply_effect( knockout_value , PARALYZE)
-		apply_effect( knockout_value*2 , DAZE)
-		explosion_throw(severity, direction)
+	 /// Reduces effects by armor value.
+	var/bomb_armor_mult = ((CLOTHING_ARMOR_HARDCORE - bomb_armor) * 0.01)
 
-		if(Item1 && isturf(Item1.loc))
-			Item1.explosion_throw(severity, direction)
-		if(Item2 && isturf(Item2.loc))
-			Item2.explosion_throw(severity, direction)
+	if(severity >= 30)
+		flash_eyes(flash_timer = 4 SECONDS * bomb_armor_mult)
+
+	// Stuns are multiplied by 1 reduced by their medium armor value. So a medium of 30 would mean a 30% reduction.
+	var/knockdown_value = severity * 0.1
+	var/knockdown_minus_armor = min(knockdown_value * bomb_armor_mult, 1 SECONDS)
+	var/obj/item/Item1 = get_active_hand()
+	var/obj/item/Item2 = get_inactive_hand()
+	apply_effect(round(knockdown_minus_armor), WEAKEN)
+	var/knockout_value = damage * 0.1
+	var/knockout_minus_armor = min(knockout_value * bomb_armor_mult * 0.5, 0.5 SECONDS) // the KO time is halved from the knockdown timer. basically same stun time, you just spend less time KO'd.
+	apply_effect(round(knockout_minus_armor), PARALYZE)
+	apply_effect(round(knockout_minus_armor) * 2, DAZE)
+	explosion_throw(severity, direction)
+
+	if(Item1 && isturf(Item1.loc))
+		Item1.explosion_throw(severity, direction)
+	if(Item2 && isturf(Item2.loc))
+		Item2.explosion_throw(severity, direction)
 
 	if(damage >= 0)
 		b_loss += damage * 0.5

--- a/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
@@ -78,7 +78,7 @@
 		var/powerfactor_value = round( damage * 0.05 ,1)
 		powerfactor_value = min(powerfactor_value,20)
 		if(powerfactor_value > 0 && small_explosives_stun)
-			KnockOut(powerfactor_value/5)
+			KnockDown(powerfactor_value/5)
 			if(mob_size < MOB_SIZE_BIG)
 				Slow(powerfactor_value)
 				Superslow(powerfactor_value/2)
@@ -87,7 +87,7 @@
 			explosion_throw(severity, direction)
 		else if(powerfactor_value > 10)
 			powerfactor_value /= 5
-			KnockOut(powerfactor_value/5)
+			KnockDown(powerfactor_value/5)
 			if(mob_size < MOB_SIZE_BIG)
 				Slow(powerfactor_value)
 				Superslow(powerfactor_value/2)


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

As title says.

Knockdowns are multiplied by 1 - bomb armor. Grenadier armor will roughly halve stun times, normal armor reduces them by roughly 12% due to preexisting armor values.
Knockouts are the same, but the total time has been halvedd, so marines spend some time KO'd, some time stunned, instead of inmediately getting up the second they wake up from unconsciousness.
The white-flash effect is also affected by the bomb armor multiplier.

Xenomorphs will now be able to see their surroundings while being juggled by grenades.

<!-- Describe Theasd Pull Request. Please be sure every change is documented or this can delay review and even discoewrintainers from merging your PR! -->

## Why It's Good For The Game

Explosions are very annoying, stupidly so at this point. It is genuinely a bad idea to carry grenadier armor as _the grenadier_ because it means that you will spend 10 years sleeping from an explosion while a runner tackle-drags you to hive, even if it wasn't you that caused the boom. I don't think any other servers have explosions as annoying as ours, and CM is probably the server with the most explosions per minute.

> Knockdowns are multiplied by 1 - bomb armor. Grenadier armor will roughly halve stun times, normal armor reduces them by roughly 12% due to preexisting armor values.
> Knockouts are the same, but the total time has been halved, so marines spend some time KO'd, some time stunned, instead of inmediately getting up the second they wake up from unconsciousness.
> The white-flash effect is also affected by the bomb armor multiplier.

Bomb armor should not be worse than no bomb armor because it'll mean getting captured. This is **insane.** This PR will hopefully lessen the amount of armorless grenadiers.

Grenadier aside, explosions are so, _so_ punishing as a marine, I don't see the issue with slightly reducing the stun times as a byproduct of actually having them be affected by armor. You already spend precious moments completely vulnerable on the ground knocked away from any help by several tiles, limping if you manage to actually get up, all of these things usually happening through no fault of your own, by a SADAR that misclicked, a backpack alpha throwing OT nades into a wall, a CAS pilot firing a direct lase minirocket without looking. 

Additionally, this paves the way for future marine bomb armor buffs. I have plans, when this is merged, to create a rework for heavy armor that lets it soak FF damage (bullets, explosions).

> Xenomorphs will now be able to see their surroundings while being juggled by grenades.

Being juggled by grenades as a Xenomorph is already intensely annoying, but having your vision completely removed is very, very frustrating as they cannot analyze the battlefield to decide their next action, especially when thanks to our wonderful codebase and tech debt the KO screen persists for seconds after waking up. I think it makes a lot of sense for the perfect biomechanical weapon not to take a nap every time a grenade nicks it.

I do see some possible issues arising from this, though. Warriors inmediately lunging after an explosion, Lurkers pouncing, etc. None of these are anything that wouldn't have happened from a normal slug stun, so I don't really see the problem. If absolutely necessary, being dazed could weaken the abilities to curb this, but I don't think it is required.

This PR isn't necessarily meant to buff either side, but more so just... reduce the frustration and annoyance caused by explosions, for every player.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->

## Changelog

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Explosion knockout is now half that of explosion knockdowns.
add: Bomb armor now reduces the stun and flash timer on explosions for marines. For grenadier armor, this means it's roughly halved.
add: Xenomorphs are no longer slept by explosions.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
