### PR TITLE
Fix for Steelcrest sprites not appearing

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/mutators/strains/defender/steel_crest.dm
+++ b/code/modules/mob/living/carbon/xenomorph/mutators/strains/defender/steel_crest.dm
@@ -17,6 +17,7 @@
 
 	var/mob/living/carbon/Xenomorph/Defender/D = MS.xeno
 	D.mutation_type = DEFENDER_STEELCREST
+	D.mutation_icon_state = DEFENDER_STEELCREST
 	D.damage_modifier -= XENO_DAMAGE_MOD_VERYSMALL
 	D.steelcrest = TRUE
 	if(D.fortify)
@@ -33,8 +34,8 @@
 		return
 
 	if(bound_xeno.fortify)
-		bound_xeno.icon_state = "[bound_xeno.mutation_icon_state || bound_xeno.mutation_type] Defender Fortify"
+		bound_xeno.icon_state = "[bound_xeno.mutation_icon_state || bound_xeno.mutation_type] Steelcrest Defender Fortify"
 		return TRUE
 	if(bound_xeno.crest_defense)
-		bound_xeno.icon_state = "[bound_xeno.mutation_icon_state || bound_xeno.mutation_type] Defender Crest"
+		bound_xeno.icon_state = "[bound_xeno.mutation_icon_state || bound_xeno.mutation_type] Steelcrest Defender Crest"
 		return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Didn't realize that Steelcrest was missing its own mutation_icon_state and the sprite wasn't changing in-game. Sorry

## Why It's Good For The Game

Sprite should change properly now

## Changelog

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Sleepynecrons
fix: fixed defender sprite not changing to steelcrest when purchased
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
