### PR TITLE
Rank Var Change

### DIFF
--- a/code/datums/paygrades/factions/uscm/marine.dm
+++ b/code/datums/paygrades/factions/uscm/marine.dm
@@ -5,84 +5,84 @@
 // ENLISTED PAYGRADES
 
 /datum/paygrade/marine/e1
-	paygrade = "ME1"
+	paygrade = "E-1"
 	name = "Private"
 	prefix = "PVT"
 	rank_pin = /obj/item/clothing/accessory/ranks/marine/e1
 	ranking = 0
 
 /datum/paygrade/marine/e2
-	paygrade = "ME2"
+	paygrade = "E-2"
 	name = "Private First Class"
 	prefix = "PFC"
 	rank_pin = /obj/item/clothing/accessory/ranks/marine/e2
 	ranking = 1
 
 /datum/paygrade/marine/e3
-	paygrade = "ME3"
+	paygrade = "E-3"
 	name = "Lance Corporal"
 	prefix = "LCpl"
 	rank_pin = /obj/item/clothing/accessory/ranks/marine/e3
 	ranking = 2
 
 /datum/paygrade/marine/e4
-	paygrade = "ME4"
+	paygrade = "E-4"
 	name = "Corporal"
 	prefix = "Cpl"
 	rank_pin = /obj/item/clothing/accessory/ranks/marine/e4
 	ranking = 3
 
 /datum/paygrade/marine/e5
-	paygrade = "ME5"
+	paygrade = "E-5"
 	name = "Sergeant"
 	prefix = "Sgt"
 	rank_pin = /obj/item/clothing/accessory/ranks/marine/e5
 	ranking = 4
 
 /datum/paygrade/marine/e6
-	paygrade = "ME6"
+	paygrade = "E-6"
 	name = "Staff Sergeant"
 	prefix = "SSgt"
 	rank_pin = /obj/item/clothing/accessory/ranks/marine/e6
 	ranking = 5
 
 /datum/paygrade/marine/e7
-	paygrade = "ME7"
+	paygrade = "E-7"
 	name = "Gunnery Sergeant"
 	prefix = "GySgt"
 	rank_pin = /obj/item/clothing/accessory/ranks/marine/e7
 	ranking = 6
 
 /datum/paygrade/marine/e8
-	paygrade = "ME8"
+	paygrade = "E-8"
 	name = "Master Sergeant"
 	prefix = "MSgt"
 	rank_pin = /obj/item/clothing/accessory/ranks/marine/e8
 	ranking = 7
 
 /datum/paygrade/marine/e8e
-	paygrade = "ME8E"
+	paygrade = "E-8E"
 	name = "First Sergeant"
 	prefix = "1Sgt"
 	rank_pin = /obj/item/clothing/accessory/ranks/marine/e8e
 	ranking = 8
 
 /datum/paygrade/marine/e9
-	paygrade = "ME9"
+	paygrade = "E-9"
 	name = "Master Gunnery Sergeant"
 	prefix = "MGySgt"
 	rank_pin = /obj/item/clothing/accessory/ranks/marine/e9
 	ranking = 9
 
 /datum/paygrade/marine/e9e
-	paygrade = "ME9E"
+	paygrade = "E-9E"
 	name = "Sergeant Major"
 	prefix = "SgtMaj"
 	rank_pin = /obj/item/clothing/accessory/ranks/marine/e9e
 	ranking = 10
 
 /datum/paygrade/marine/e9s
-	paygrade = "ME9S"
+	paygrade = "E-9S"
 	name = "Sergeant Major of the Colonial Marine Corps"
 	prefix = "SMCMC"
 	rank_pin = /obj/item/clothing/accessory/ranks/marine/e10c
@@ -91,35 +91,35 @@
 // COMMISSIONED PAYGRADES
 
 /datum/paygrade/marine/o1
-	paygrade = "MO1"
+	paygrade = "O-1"
 	name = "Second Lieutenant"
 	prefix = "2ndLt"
 	rank_pin = /obj/item/clothing/accessory/ranks/marine/o1
 	ranking = 12
 
 /datum/paygrade/marine/o2
-	paygrade = "MO2"
+	paygrade = "O-2"
 	name = "First Lieutenant"
 	prefix = "1stLt"
 	rank_pin = /obj/item/clothing/accessory/ranks/marine/o2
 	ranking = 13
 
 /datum/paygrade/marine/o3
-	paygrade = "MO3"
+	paygrade = "O-3"
 	name = "Captain"
 	prefix = "Capt"
 	rank_pin = /obj/item/clothing/accessory/ranks/marine/o3
 	ranking = 14
 
 /datum/paygrade/marine/o4
-	paygrade = "MO4"
+	paygrade = "O-4"
 	name = "Major"
 	prefix = "Maj"
 	rank_pin = /obj/item/clothing/accessory/ranks/marine/o4
 	ranking = 15
 
 /datum/paygrade/marine/o5
-	paygrade = "MO5"
+	paygrade = "O-5"
 	name = "Lieutenant Colonel"
 	prefix = "LtCol"
 	rank_pin = /obj/item/clothing/accessory/ranks/marine/o5
@@ -127,21 +127,21 @@
 
 //Platoon Commander
 /datum/paygrade/marine/o6
-	paygrade = "MO6"
+	paygrade = "O-6"
 	name = "Colonel"
 	prefix = "Col"
 	rank_pin = /obj/item/clothing/accessory/ranks/marine/o6
 	ranking = 17
 
 /datum/paygrade/marine/o6e
-	paygrade = "MO6E"
+	paygrade = "O-6E"
 	name = "Senior Colonel"
 	prefix = "Snr Col."
 	rank_pin = /obj/item/clothing/accessory/ranks/marine/o6e
 	ranking = 18
 
 /datum/paygrade/marine/o6c
-	paygrade = "MO6C"
+	paygrade = "O-6C"
 	name = "Division Colonel"
 	prefix = "Div Col."
 	rank_pin = /obj/item/clothing/accessory/ranks/marine/o6c
@@ -149,42 +149,42 @@
 
 //High Command
 /datum/paygrade/marine/o7
-	paygrade = "MO7"
+	paygrade = "O-7"
 	name = "Brigadier General"
 	prefix = "BGen"
 	rank_pin = /obj/item/clothing/accessory/ranks/marine/o7
 	ranking = 20
 
 /datum/paygrade/marine/o8
-	paygrade = "MO8"
+	paygrade = "O-8"
 	name = "Major General"
 	prefix = "MajGen"
 	rank_pin = /obj/item/clothing/accessory/ranks/marine/o8
 	ranking = 21
 
 /datum/paygrade/marine/o9
-	paygrade = "MO9"
+	paygrade = "O-9"
 	name = "Lieutenant General"
 	prefix = "LtGen"
 	rank_pin = /obj/item/clothing/accessory/ranks/marine/o9
 	ranking = 22
 
 /datum/paygrade/marine/o10
-	paygrade = "MO10"
+	paygrade = "O-10"
 	name = "General"
 	prefix = "Gen"
 	rank_pin = /obj/item/clothing/accessory/ranks/marine/o10
 	ranking = 23
 
 /datum/paygrade/marine/o10c
-	paygrade = "MO10C"
+	paygrade = "O-10C"
 	name = "Assistant Commandant of the Marine Corps"
 	prefix = "ACMC"
 	rank_pin = /obj/item/clothing/accessory/ranks/marine/o10c
 	ranking = 24
 
 /datum/paygrade/marine/o10s
-	paygrade = "MO10S"
+	paygrade = "O-10S"
 	name = "Commandant of the Marine Corps"
 	prefix = "CMC"
 	rank_pin = /obj/item/clothing/accessory/ranks/marine/o10c

--- a/code/datums/paygrades/paygrade.dm
+++ b/code/datums/paygrades/paygrade.dm
@@ -23,15 +23,15 @@ GLOBAL_LIST_INIT_TYPED(paygrades, /datum/paygrade, setup_paygrades())
 
 GLOBAL_LIST_INIT(highcom_paygrades, list(
 	"NO7",
-	"MO7",
+	"O-7",
 	"NO8",
-	"MO8",
+	"O-8",
 	"NO9",
-	"MO9",
+	"O-9",
 	"NO10",
-	"MO10",
+	"O-10",
 	"NO10C",
-	"MO10C",
+	"O-10C",
 	"PvO8",
 	"PvO9",
 	"PvCM"
@@ -43,9 +43,9 @@ GLOBAL_LIST_INIT(co_paygrades, list(
 	"NO6C",
 	"NO5",
 	"NO4",
-	"MO6",
-	"MO6E",
-	"MO6C",
-	"MO5",
-	"MO4"
+	"O-6",
+	"O-6E",
+	"O-6C",
+	"O-5",
+	"O-4"
 ))

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -74,7 +74,7 @@
 	//alt titles are handled a bit weirdly in order to unobtrusively integrate into existing ID system
 	var/assignment = null	//can be alt title or the actual job
 	var/rank = null			//actual job
-	var/paygrade = "ME1"  // Marine's paygrade
+	var/paygrade = "E-1"  // Marine's paygrade
 	var/claimedgear = 1 // For medics and engineers to 'claim' a locker
 
 	var/list/uniform_sets = null

--- a/code/modules/gear_presets/dust_raider.dm
+++ b/code/modules/gear_presets/dust_raider.dm
@@ -24,7 +24,7 @@
 	access = list(ACCESS_MARINE_PREP)
 	assignment = "Squad Rifleman"
 	rank = "Squad Rifleman"
-	paygrade = "ME2"
+	paygrade = "E-2"
 	role_comm_title = "RFN"
 	skills = /datum/skills/pfc/crafty
 
@@ -46,7 +46,7 @@
 	access = list(ACCESS_MARINE_PREP)
 	assignment = "Squad Leader"
 	rank = "Squad Leader"
-	paygrade = "ME5"
+	paygrade = "E-5"
 	role_comm_title = "SL"
 	skills = /datum/skills/SL
 
@@ -75,7 +75,7 @@
 	access = list(ACCESS_MARINE_PREP, ACCESS_MARINE_SMARTPREP)
 	assignment = "Squad Smartgunner"
 	rank = "Squad Smartgunner"
-	paygrade = "ME3"
+	paygrade = "E-3"
 	role_comm_title = "SG"
 	skills = /datum/skills/smartgunner
 
@@ -101,7 +101,7 @@
 	access = list(ACCESS_MARINE_PREP, ACCESS_MARINE_ENGPREP, ACCESS_CIVILIAN_ENGINEERING)
 	assignment = "Squad Combat Technician"
 	rank = "Squad Combat Technician"
-	paygrade = "ME3"
+	paygrade = "E-3"
 	role_comm_title = "Eng"
 	skills = /datum/skills/combat_engineer
 
@@ -130,7 +130,7 @@
 	access = list(ACCESS_MARINE_PREP, ACCESS_MARINE_MEDPREP, ACCESS_MARINE_MEDBAY)
 	assignment = "Squad Hospital Corpsman"
 	rank = "Squad Hospital Corpsman"
-	paygrade = "ME3"
+	paygrade = "E-3"
 	role_comm_title = "HM"
 	skills = /datum/skills/combat_medic
 
@@ -165,7 +165,7 @@
 	access = list(ACCESS_MARINE_PREP, ACCESS_MARINE_SPECPREP)
 	assignment = "Squad Weapons Specialist"
 	rank = "Squad Weapons Specialist"
-	paygrade = "ME3"
+	paygrade = "E-3"
 	role_comm_title = "Spc"
 	skills = /datum/skills/specialist
 

--- a/code/modules/gear_presets/forcon_survivors.dm
+++ b/code/modules/gear_presets/forcon_survivors.dm
@@ -2,7 +2,7 @@
 //Nanu told me to put them here so they dont clutter up survivors.dm
 
 /datum/equipment_preset/survivor/forecon
-	paygrade = "ME5"
+	paygrade = "E-5"
 	idtype = /obj/item/card/id/dogtag
 	role_comm_title = "FORECON"
 	rank = JOB_SURVIVOR
@@ -188,7 +188,7 @@
 	name = "Survivor - USCM Reconnaissance Squad Leader"
 	assignment = "Reconnaissance Squad Leader"
 	skills = /datum/skills/military/survivor/forecon_squad_leader
-	paygrade = "MO1"
+	paygrade = "0-1"
 
 /datum/equipment_preset/survivor/forecon/squad_leader/load_gear(mob/living/carbon/human/H)
 	var/obj/item/clothing/under/marine/reconnaissance/uniform = new()
@@ -212,7 +212,7 @@
 	name = "Survivor - USCM Reconnaissance Major"
 	assignment = "Reconnaissance Commander"
 	skills = /datum/skills/commander
-	paygrade = "MO4"
+	paygrade = "O-4"
 	idtype = /obj/item/card/id/gold
 	role_comm_title = "FORECON CO"
 

--- a/code/modules/gear_presets/fun.dm
+++ b/code/modules/gear_presets/fun.dm
@@ -639,7 +639,7 @@
 
 	assignment = "Monkey Marine"
 	rank = "Monkey Marine"
-	paygrade = "ME2"
+	paygrade = "E-2"
 
 /datum/equipment_preset/fun/monkey/marine/load_gear(mob/living/carbon/human/H)
 	H.equip_to_slot_or_del(new /obj/item/clothing/under/marine(H), WEAR_BODY)

--- a/code/modules/gear_presets/uscm.dm
+++ b/code/modules/gear_presets/uscm.dm
@@ -61,7 +61,7 @@
 	access = list(ACCESS_MARINE_PREP)
 	assignment = JOB_SQUAD_MARINE
 	rank = JOB_SQUAD_MARINE
-	paygrade = "ME2"
+	paygrade = "E-2"
 	role_comm_title = "RFN"
 	skills = /datum/skills/pfc
 
@@ -75,7 +75,7 @@
 /datum/equipment_preset/uscm/pfc/load_rank(mob/living/carbon/human/H)
 	if(H.client)
 		if(get_job_playtime(H.client, rank) < JOB_PLAYTIME_TIER_1)
-			return "ME1"
+			return "E-1"
 	return paygrade
 
 /datum/equipment_preset/uscm/pfc/cryo
@@ -95,7 +95,7 @@
 	access = list(ACCESS_MARINE_PREP, ACCESS_MARINE_SMARTPREP)
 	assignment = JOB_SQUAD_SMARTGUN
 	rank = JOB_SQUAD_SMARTGUN
-	paygrade = "ME3"
+	paygrade = "E-3"
 	role_comm_title = "SG"
 	skills = /datum/skills/smartgunner
 
@@ -150,7 +150,7 @@
 	)
 	assignment = JOB_CREWMAN
 	rank = JOB_CREWMAN
-	paygrade = "ME4"
+	paygrade = "E-4"
 	role_comm_title = "CRMN"
 	minimum_age = 30
 	skills = /datum/skills/tank_crew
@@ -210,7 +210,7 @@
 	)
 	assignment = JOB_INTEL
 	rank = JOB_INTEL
-	paygrade = "MO1"
+	paygrade = "0-1"
 	role_comm_title = "IO"
 	skills = /datum/skills/intel
 
@@ -265,7 +265,7 @@
 	access = list(ACCESS_MARINE_PREP, ACCESS_MARINE_SPECPREP)
 	assignment = JOB_SQUAD_SPECIALIST
 	rank = JOB_SQUAD_SPECIALIST
-	paygrade = "ME3"
+	paygrade = "E-3"
 	role_comm_title = "Spc"
 	skills = /datum/skills/specialist
 
@@ -319,7 +319,7 @@
 	access = list(ACCESS_MARINE_PREP, ACCESS_MARINE_MEDPREP, ACCESS_MARINE_MEDBAY)
 	assignment = JOB_SQUAD_MEDIC
 	rank = JOB_SQUAD_MEDIC
-	paygrade = "ME3"
+	paygrade = "E-3"
 	role_comm_title = "HM"
 	skills = /datum/skills/combat_medic
 
@@ -349,7 +349,7 @@
 	access = list(ACCESS_MARINE_PREP, ACCESS_MARINE_RTO_PREP)
 	assignment = JOB_SQUAD_RTO
 	rank = JOB_SQUAD_RTO
-	paygrade = "ME4"
+	paygrade = "E-4"
 	role_comm_title = "RTO"
 	skills = /datum/skills/rto
 
@@ -377,7 +377,7 @@
 	access = list(ACCESS_MARINE_PREP, ACCESS_MARINE_ENGPREP, ACCESS_CIVILIAN_ENGINEERING)
 	assignment = JOB_SQUAD_ENGI
 	rank = JOB_SQUAD_ENGI
-	paygrade = "ME3"
+	paygrade = "E-3"
 	role_comm_title = "ComTech"
 	skills = /datum/skills/combat_engineer
 
@@ -407,7 +407,7 @@
 	access = list(ACCESS_MARINE_PREP, ACCESS_MARINE_LEADER, ACCESS_MARINE_DROPSHIP)
 	assignment = JOB_SQUAD_LEADER
 	rank = JOB_SQUAD_LEADER
-	paygrade = "ME5"
+	paygrade = "E-5"
 	role_comm_title = "SL"
 	minimum_age = 27
 	skills = /datum/skills/SL
@@ -438,14 +438,14 @@
 	access = list(ACCESS_MARINE_PREP)
 	assignment = JOB_SQUAD_MARINE
 	rank = JOB_SQUAD_MARINE
-	paygrade = "ME2"
+	paygrade = "E-2"
 	role_comm_title = "RFN"
 	skills = /datum/skills/pfc/crafty
 
 /datum/equipment_preset/uscm/private_equipped/load_rank(mob/living/carbon/human/H)
 	if(H.client)
 		if(get_job_playtime(H.client, rank) < JOB_PLAYTIME_TIER_1)
-			return "ME1"
+			return "E-1"
 	return paygrade
 
 /datum/equipment_preset/uscm/private_equipped/load_gear(mob/living/carbon/human/H)
@@ -481,7 +481,7 @@
 	access = list(ACCESS_MARINE_PREP, ACCESS_MARINE_LEADER, ACCESS_MARINE_DROPSHIP)
 	assignment = JOB_SQUAD_LEADER
 	rank = JOB_SQUAD_LEADER
-	paygrade = "ME5"
+	paygrade = "E-5"
 	role_comm_title = "SL"
 	minimum_age = 27
 	skills = /datum/skills/SL
@@ -517,7 +517,7 @@
 	access = list(ACCESS_MARINE_PREP, ACCESS_MARINE_SMARTPREP)
 	assignment = JOB_SQUAD_SMARTGUN
 	rank = JOB_SQUAD_SMARTGUN
-	paygrade = "ME3"
+	paygrade = "E-3"
 	role_comm_title = "SG"
 	skills = /datum/skills/smartgunner
 
@@ -553,7 +553,7 @@
 	access = list(ACCESS_MARINE_PREP, ACCESS_MARINE_ENGPREP, ACCESS_CIVILIAN_ENGINEERING)
 	assignment = JOB_SQUAD_ENGI
 	rank = JOB_SQUAD_ENGI
-	paygrade = "ME3"
+	paygrade = "E-3"
 	role_comm_title = "ComTech"
 	skills = /datum/skills/combat_engineer
 
@@ -597,7 +597,7 @@
 	access = list(ACCESS_MARINE_PREP, ACCESS_MARINE_MEDPREP, ACCESS_MARINE_MEDBAY)
 	assignment = JOB_SQUAD_MEDIC
 	rank = JOB_SQUAD_MEDIC
-	paygrade = "ME3"
+	paygrade = "E-3"
 	role_comm_title = "HM"
 	skills = /datum/skills/combat_medic
 
@@ -647,7 +647,7 @@
 	access = list(ACCESS_MARINE_PREP, ACCESS_MARINE_SPECPREP)
 	assignment = JOB_SQUAD_SPECIALIST
 	rank = JOB_SQUAD_SPECIALIST
-	paygrade = "ME3"
+	paygrade = "E-3"
 	role_comm_title = "Spc"
 	skills = /datum/skills/specialist
 
@@ -712,7 +712,7 @@
 	access = list(ACCESS_MARINE_PREP, ACCESS_MARINE_RTO_PREP)
 	assignment = JOB_SQUAD_RTO
 	rank = JOB_SQUAD_RTO
-	paygrade = "ME4"
+	paygrade = "E-4"
 	role_comm_title = "RTO"
 	skills = /datum/skills/rto
 
@@ -749,7 +749,7 @@
 	languages = list(LANGUAGE_ENGLISH, LANGUAGE_TSL)
 	skills = /datum/skills/commando/deathsquad
 	auto_squad_name = SQUAD_SOF
-	paygrade = "ME6"
+	paygrade = "E-6"
 
 /datum/equipment_preset/uscm/marsoc/New()
 	. = ..()
@@ -798,7 +798,7 @@
 /datum/equipment_preset/uscm/marsoc/load_rank(mob/living/carbon/human/H)
 	if(H.client)
 		if(get_job_playtime(H.client, rank) > JOB_PLAYTIME_TIER_2)
-			return "ME7"
+			return "E-7"
 	return paygrade
 
 //Covert Raiders
@@ -818,13 +818,13 @@
 	assignment = JOB_MARINE_RAIDER_SL
 	rank = JOB_MARINE_RAIDER_SL
 	role_comm_title = "TL."
-	paygrade = "MO1"
+	paygrade = "0-1"
 	skills = /datum/skills/commando/deathsquad/leader
 
 /datum/equipment_preset/uscm/marsoc/sl/load_rank(mob/living/carbon/human/H)
 	if(H.client)
 		if(get_job_playtime(H.client, rank) > JOB_PLAYTIME_TIER_2)
-			return "MO2"
+			return "O-2"
 	return paygrade
 
 //Codenamed Team Leader
@@ -843,11 +843,11 @@
 	assignment = JOB_MARINE_RAIDER_CMD
 	rank = JOB_MARINE_RAIDER_CMD
 	role_comm_title = "CMD."
-	paygrade = "MO3"
+	paygrade = "O-3"
 	skills = /datum/skills/commando/deathsquad/officer
 
 /datum/equipment_preset/uscm/marsoc/cmd/load_rank(mob/living/carbon/human/H)
 	if(H.client)
 		if(get_job_playtime(H.client, rank) > JOB_PLAYTIME_TIER_3)
-			return "MO4"
+			return "O-4"
 	return paygrade

--- a/code/modules/gear_presets/uscm_dress.dm
+++ b/code/modules/gear_presets/uscm_dress.dm
@@ -5,7 +5,7 @@
 	rank = JOB_MARINE
 	access = list(ACCESS_MARINE_PREP)
 	minimum_age = 18
-	paygrade = "ME2"
+	paygrade = "E-2"
 	role_comm_title = "Mar"
 	skills = /datum/skills/pfc
 
@@ -25,13 +25,13 @@
 
 /datum/equipment_preset/uscm_event/dress/lcpl
 	name = "Dress Blues - (E-3) Lance Corporal"
-	paygrade = "ME3"
+	paygrade = "E-3"
 
 //NCOs/SNCOs//
 
 /datum/equipment_preset/uscm_event/dress/nco
 	name = "Dress Blues - (E-4) Corporal"
-	paygrade = "ME4"
+	paygrade = "E-4"
 	skills = /datum/skills/SL
 
 	dress_under = list(/obj/item/clothing/under/marine/dress/blues/senior)
@@ -44,11 +44,11 @@
 
 /datum/equipment_preset/uscm_event/dress/nco/sgt
 	name = "Dress Blues - (E-5) Sergeant"
-	paygrade = "ME5"
+	paygrade = "E-5"
 
 /datum/equipment_preset/uscm_event/dress/nco/snco
 	name = "Dress Blues - (E-6) Staff Sergeant"
-	paygrade = "ME6"
+	paygrade = "E-6"
 	skills = /datum/skills/SEA
 	access = list(ACCESS_MARINE_COMMANDER, ACCESS_MARINE_BRIDGE, ACCESS_MARINE_BRIG, ACCESS_MARINE_DROPSHIP, ACCESS_MARINE_LOGISTICS)
 
@@ -58,29 +58,29 @@
 
 /datum/equipment_preset/uscm_event/dress/nco/snco/gysgt
 	name = "Dress Blues - (E-7) Gunnery Sergeant"
-	paygrade = "ME7"
+	paygrade = "E-7"
 
 /datum/equipment_preset/uscm_event/dress/nco/snco/msgt
 	name = "Dress Blues - (E-8) Master Sergeant"
-	paygrade = "ME8"
+	paygrade = "E-8"
 
 /datum/equipment_preset/uscm_event/dress/nco/snco/firstsgt
 	name = "Dress Blues - (E-8E) First Sergeant"
-	paygrade = "ME8E"
+	paygrade = "E-8E"
 
 /datum/equipment_preset/uscm_event/dress/nco/snco/mgysgt
 	name = "Dress Blues - (E-9) Master Gunnery Sergeant"
-	paygrade = "ME9"
+	paygrade = "E-9"
 
 /datum/equipment_preset/uscm_event/dress/nco/snco/sgtmaj
 	name = "Dress Blues - (E-9E) Sergeant Major"
-	paygrade = "ME9E"
+	paygrade = "E-9E"
 
 //FIELD OFFICERS//
 
 /datum/equipment_preset/uscm_event/dress/officer
 	name = "Dress Blues - (O-1) 2nd Lieutenant"
-	paygrade = "MO1"
+	paygrade = "0-1"
 	idtype = /obj/item/card/id/silver
 	skills = /datum/skills/SO
 	access = list(ACCESS_MARINE_COMMANDER, ACCESS_MARINE_BRIDGE, ACCESS_MARINE_BRIG, ACCESS_MARINE_DROPSHIP, ACCESS_MARINE_LOGISTICS)
@@ -100,11 +100,11 @@
 
 /datum/equipment_preset/uscm_event/dress/officer/firstlt
 	name = "Dress Blues - (O-2) 1st Lieutenant"
-	paygrade = "MO2"
+	paygrade = "O-2"
 
 /datum/equipment_preset/uscm_event/dress/officer/capt
 	name = "Dress Blues - (O-3) Captain"
-	paygrade = "MO3"
+	paygrade = "O-3"
 	idtype = /obj/item/card/id/gold
 	skills = /datum/skills/XO
 
@@ -115,7 +115,7 @@
 
 /datum/equipment_preset/uscm_event/dress/officer/co
 	name = "Dress Blues - (O-4) Major"
-	paygrade = "MO4"
+	paygrade = "O-4"
 	idtype = /obj/item/card/id/gold
 	skills = /datum/skills/commander
 
@@ -125,19 +125,19 @@
 
 /datum/equipment_preset/uscm_event/dress/officer/co/ltcol
 	name = "Dress Blues - (O-5) Lieutenant Colonel"
-	paygrade = "MO5"
+	paygrade = "O-5"
 	idtype = /obj/item/card/id/gold/council
 
 /datum/equipment_preset/uscm_event/dress/officer/co/col
 	name = "Dress Blues - (O-6) Colonel"
-	paygrade = "MO6"
+	paygrade = "O-6"
 	idtype = /obj/item/card/id/general
 
 //GENERAL OFFICERS//
 
 /datum/equipment_preset/uscm_event/dress/officer/general
 	name = "Dress Blues - (O-8) Major General"
-	paygrade = "MO8"
+	paygrade = "O-8"
 	idtype = /obj/item/card/id/general
 	skills = /datum/skills/general
 
@@ -155,8 +155,8 @@
 
 /datum/equipment_preset/uscm_event/dress/officer/general/ltgen
 	name = "Dress Blues - (O-9) Lieutenant General"
-	paygrade = "MO9"
+	paygrade = "O-9"
 
 /datum/equipment_preset/uscm_event/dress/officer/general/gen
 	name = "Dress Blues - (O-10) General"
-	paygrade = "MO10"
+	paygrade = "O-10"

--- a/code/modules/gear_presets/uscm_event.dm
+++ b/code/modules/gear_presets/uscm_event.dm
@@ -16,7 +16,7 @@
 	access = list(ACCESS_MARINE_MEDBAY, ACCESS_MARINE_CHEMISTRY, ACCESS_MARINE_MORGUE)
 	assignment = JOB_COLONEL
 	rank = JOB_COLONEL
-	paygrade = "MO6"
+	paygrade = "O-6"
 	role_comm_title = "COL"
 	minimum_age = 40
 	skills = /datum/skills/general
@@ -61,7 +61,7 @@
 	access = list(ACCESS_MARINE_MEDBAY, ACCESS_MARINE_CHEMISTRY, ACCESS_MARINE_MORGUE)
 	assignment = JOB_GENERAL
 	rank = JOB_GENERAL
-	paygrade = "MO7"
+	paygrade = "O-7"
 	role_comm_title = "GEN"
 	minimum_age = 50
 	skills = /datum/skills/general
@@ -102,27 +102,27 @@
 
 /datum/equipment_preset/uscm_event/general/o7
 		name = "USCM O-7 - Brigadier General (High Command)"
-		paygrade = "MO7"
+		paygrade = "O-7"
 
 /datum/equipment_preset/uscm_event/general/o8
 		name = "USCM O-8 - Major General (High Command)"
-		paygrade = "MO8"
+		paygrade = "O-8"
 
 /datum/equipment_preset/uscm_event/general/o9
 		name = "USCM O-9 - Lieutenant General (High Command)"
-		paygrade = "MO9"
+		paygrade = "O-9"
 
 /datum/equipment_preset/uscm_event/general/o10
 		name = "USCM O-10 - General (High Command)"
-		paygrade = "MO10"
+		paygrade = "O-10"
 
 /datum/equipment_preset/uscm_event/general/o10c
 		name = "USCM O-10C - Assistant Commandant of the Marine Corps (High Command)"
-		paygrade = "MO10C"
+		paygrade = "O-10C"
 
 /datum/equipment_preset/uscm_event/general/
 		name = "USCM O-10S - Commandant of the Marine Corps (High Command)"
-		paygrade = "MO10S"
+		paygrade = "O-10S"
 
 /*****************************************************************************************************/
 
@@ -134,7 +134,7 @@
 	access = list(ACCESS_MARINE_MEDBAY, ACCESS_MARINE_CHEMISTRY, ACCESS_MARINE_MORGUE)
 	assignment = JOB_ORDNANCE_TECH
 	rank = "UPP"
-	paygrade = "ME5"
+	paygrade = "E-5"
 	role_comm_title = "OT"
 	skills = /datum/skills/spy
 
@@ -196,7 +196,7 @@
 
 	assignment = JOB_PROVOST_ENFORCER
 	rank = "Provost Enforcer"
-	paygrade = "ME5"
+	paygrade = "E-5"
 	role_comm_title = "PvE"
 	flags = EQUIPMENT_PRESET_EXTRA
 
@@ -238,7 +238,7 @@
 
 	assignment = JOB_PROVOST_TML
 	rank = "Provost Team Leader"
-	paygrade = "ME6"
+	paygrade = "E-6"
 	role_comm_title = "PvTML"
 	flags = EQUIPMENT_PRESET_EXTRA
 
@@ -282,7 +282,7 @@
 
 	assignment = JOB_PROVOST_ADVISOR
 	rank = "Provost Advisor"
-	paygrade = "ME6"
+	paygrade = "E-6"
 	role_comm_title = "PvA"
 	flags = EQUIPMENT_PRESET_EXTRA
 
@@ -352,7 +352,7 @@
 
 	assignment = JOB_PROVOST_MARSHAL
 	rank = "Provost Marshal"
-	paygrade = "MO6"
+	paygrade = "O-6"
 	role_comm_title = "PvM"
 	flags = EQUIPMENT_PRESET_EXTRA
 
@@ -385,7 +385,7 @@
 
 	assignment = JOB_PROVOST_SMARSHAL
 	rank = "Provost Sector Marshal"
-	paygrade = "MO7"
+	paygrade = "O-7"
 	role_comm_title = "PvSM"
 
 /datum/equipment_preset/uscm_event/provost/marshal/sector/load_gear(mob/living/carbon/human/H)

--- a/code/modules/gear_presets/uscm_medical.dm
+++ b/code/modules/gear_presets/uscm_medical.dm
@@ -14,7 +14,7 @@
 	)
 	assignment = JOB_CMO
 	rank = JOB_CMO
-	paygrade = "MO2"
+	paygrade = "O-2"
 	role_comm_title = "CMO"
 	skills = /datum/skills/CMO
 
@@ -68,7 +68,7 @@
 	access = list(ACCESS_MARINE_MEDBAY, ACCESS_MARINE_CHEMISTRY, ACCESS_MARINE_MORGUE)
 	assignment = JOB_DOCTOR
 	rank = JOB_DOCTOR
-	paygrade = "MO1"
+	paygrade = "0-1"
 	role_comm_title = "Doc"
 	skills = /datum/skills/doctor
 
@@ -121,7 +121,7 @@
 	access = list(ACCESS_MARINE_MEDBAY, ACCESS_MARINE_CHEMISTRY, ACCESS_MARINE_MORGUE)
 	assignment = JOB_NURSE
 	rank = JOB_NURSE
-	paygrade = "ME5"
+	paygrade = "E-5"
 	role_comm_title = "Nurse"
 	skills = /datum/skills/nurse
 
@@ -172,7 +172,7 @@
 	access = list(ACCESS_MARINE_MEDBAY, ACCESS_MARINE_RESEARCH, ACCESS_MARINE_CHEMISTRY, ACCESS_MARINE_MORGUE)
 	assignment = JOB_RESEARCHER
 	rank = JOB_RESEARCHER
-	paygrade = "MO1"
+	paygrade = "0-1"
 	role_comm_title = "Rsr"
 	skills = /datum/skills/researcher
 

--- a/code/modules/gear_presets/uscm_police.dm
+++ b/code/modules/gear_presets/uscm_police.dm
@@ -27,7 +27,7 @@
 	)
 	assignment = JOB_POLICE
 	rank = JOB_POLICE
-	paygrade = "ME5"
+	paygrade = "E-5"
 	role_comm_title = "MP"
 	skills = /datum/skills/MP
 
@@ -81,7 +81,7 @@
 	)
 	assignment = JOB_POLICE_CADET
 	rank = JOB_POLICE_CADET
-	paygrade = "ME4"
+	paygrade = "E-4"
 	role_comm_title = "MPC"
 	skills = /datum/skills/MP
 
@@ -140,7 +140,7 @@
 	)
 	assignment = JOB_WARDEN
 	rank = JOB_WARDEN
-	paygrade = "MO1"
+	paygrade = "0-1"
 	role_comm_title = "MW"
 	skills = /datum/skills/MW
 
@@ -198,7 +198,7 @@
 	)
 	assignment = JOB_CHIEF_POLICE
 	rank = JOB_CHIEF_POLICE
-	paygrade = "MO2"
+	paygrade = "O-2"
 	role_comm_title = "CMP"
 	skills = /datum/skills/CMP
 
@@ -238,7 +238,7 @@
 	access = list()
 	assignment = "Riot Control"
 	rank = "Riot"
-	paygrade = "ME5"
+	paygrade = "E-5"
 	role_comm_title = "RMP"
 	skills = /datum/skills/CMP
 
@@ -286,6 +286,6 @@
 
 	assignment = "Chief Riot Control"
 	rank = "CRMP"
-	paygrade = "MO1"
+	paygrade = "0-1"
 	role_comm_title = "CRMP"
 	skills = /datum/skills/CMP

--- a/code/modules/gear_presets/uscm_ship.dm
+++ b/code/modules/gear_presets/uscm_ship.dm
@@ -113,7 +113,7 @@
 	)
 	assignment = JOB_CHIEF_ENGINEER
 	rank = JOB_CHIEF_ENGINEER
-	paygrade = "MO2"
+	paygrade = "O-2"
 	role_comm_title = "CE"
 	minimum_age = 27
 	skills = /datum/skills/CE
@@ -146,7 +146,7 @@
 	)
 	assignment = JOB_MAINT_TECH
 	rank = JOB_MAINT_TECH
-	paygrade = "ME2"
+	paygrade = "E-2"
 	role_comm_title = "MT"
 	skills = /datum/skills/MT
 
@@ -183,7 +183,7 @@
 	)
 	assignment = JOB_ORDNANCE_TECH
 	rank = JOB_ORDNANCE_TECH
-	paygrade = "ME2"
+	paygrade = "E-2"
 	role_comm_title = "OT"
 	skills = /datum/skills/OT
 
@@ -225,7 +225,7 @@
 	)
 	assignment = JOB_CHIEF_REQUISITION
 	rank = JOB_CHIEF_REQUISITION
-	paygrade = "MO2"
+	paygrade = "O-2"
 	role_comm_title = "RO"
 	minimum_age = 27
 	skills = /datum/skills/RO
@@ -255,7 +255,7 @@
 	access = list(ACCESS_MARINE_CARGO, ACCESS_MARINE_PREP)
 	assignment = JOB_CARGO_TECH
 	rank = JOB_CARGO_TECH
-	paygrade = "ME2"
+	paygrade = "E-2"
 	role_comm_title = "CT"
 	skills = /datum/skills/CT
 
@@ -284,7 +284,7 @@
 	idtype = /obj/item/card/id/gold
 	assignment = JOB_CO
 	rank = JOB_CO
-	paygrade = "MO4"
+	paygrade = "O-4"
 	role_comm_title = "CO"
 	minimum_age = 30
 	skills = /datum/skills/commander
@@ -353,7 +353,7 @@
 
 	idtype = /obj/item/card/id/gold/council
 	rank = JOB_CO
-	paygrade = "MO5"
+	paygrade = "O-5"
 	role_comm_title = "CO"
 	minimum_age = 35
 
@@ -365,7 +365,7 @@
 /datum/equipment_preset/uscm_ship/commander/council/plus
 	name = "USCM Commanding Officer (CO++)"
 	idtype = /obj/item/card/id/general
-	paygrade = "MO6"
+	paygrade = "O-6"
 
 /datum/equipment_preset/uscm_ship/commander/council/plus/load_gear(mob/living/carbon/human/H)
 	H.equip_to_slot_or_del(new /obj/item/clothing/head/beret/marine/commander/councilchief(H), WEAR_HEAD)
@@ -380,7 +380,7 @@
 	idtype = /obj/item/card/id/silver
 	assignment = JOB_XO
 	rank = JOB_XO
-	paygrade = "MO3"
+	paygrade = "O-3"
 	role_comm_title = "XO"
 	minimum_age = 35
 	skills = /datum/skills/XO
@@ -416,7 +416,7 @@
 	access = list(ACCESS_MARINE_COMMANDER, ACCESS_MARINE_BRIDGE, ACCESS_MARINE_BRIG, ACCESS_MARINE_DROPSHIP, ACCESS_MARINE_LOGISTICS)
 	assignment = JOB_SO
 	rank = JOB_SO
-	paygrade = "MO1"
+	paygrade = "0-1"
 	role_comm_title = "SO"
 	minimum_age = 25
 	skills = /datum/skills/SO
@@ -446,7 +446,7 @@
 	access
 	assignment = JOB_SEA
 	rank = JOB_SEA
-	paygrade = "ME7"
+	paygrade = "E-7"
 	role_comm_title = "SEA"
 	minimum_age = 40
 	skills = /datum/skills/SEA
@@ -475,14 +475,14 @@
 
 /datum/equipment_preset/uscm_ship/sea/load_rank(mob/living/carbon/human/H)
 	if(H.client)
-		var/grade8 = "ME8E"
-		var/grade9 = "ME9E"
+		var/grade8 = "E-8E"
+		var/grade9 = "E-9E"
 
 		if(H.client && H.client.prefs)
 			var/path = H.client.prefs.sea_path
 			if(path == "Technical")
-				grade8 = "ME8"
-				grade9 = "ME9"
+				grade8 = "E-8"
+				grade9 = "E-9"
 
 		if(!H.client.prefs.playtime_perks)
 			return paygrade
@@ -502,7 +502,7 @@
 	access = list(ACCESS_MARINE_BRIDGE, ACCESS_MARINE_DROPSHIP, ACCESS_MARINE_LOGISTICS, ACCESS_MARINE_PILOT)
 	assignment = JOB_PILOT
 	rank = JOB_PILOT
-	paygrade = "MO1"
+	paygrade = "0-1"
 	role_comm_title = "DP"
 	skills = /datum/skills/pilot
 
@@ -550,7 +550,7 @@
 	access = list(ACCESS_MARINE_BRIDGE, ACCESS_MARINE_DROPSHIP, ACCESS_MARINE_LOGISTICS, ACCESS_MARINE_PILOT)
 	assignment = JOB_DROPSHIP_CREW_CHIEF
 	rank = JOB_DROPSHIP_CREW_CHIEF
-	paygrade = "ME5"
+	paygrade = "E-5"
 	role_comm_title = "DCC"
 	skills = /datum/skills/crew_chief
 
@@ -598,7 +598,7 @@
 	access = list(ACCESS_MARINE_MEDBAY, ACCESS_MARINE_CHEMISTRY, ACCESS_MARINE_MORGUE)
 	assignment = "USCM Officer"
 	rank = "USCM Officer"
-	paygrade = "MO3"
+	paygrade = "O-3"
 	role_comm_title = "Cpt"
 	minimum_age = 40
 	skills = /datum/skills/commander
@@ -638,7 +638,7 @@
 	access = list(ACCESS_MARINE_KITCHEN)
 	assignment = JOB_MESS_SERGEANT
 	rank = JOB_MESS_SERGEANT
-	paygrade = "ME2"
+	paygrade = "E-2"
 	role_comm_title = "MST"
 	skills = /datum/skills/mess_technician
 

--- a/code/modules/gear_presets/wo.dm
+++ b/code/modules/gear_presets/wo.dm
@@ -17,7 +17,7 @@
 
 	assignment = JOB_WO_CO
 	rank = JOB_WO_CO
-	paygrade = "MO4"
+	paygrade = "O-4"
 	role_comm_title = "CO"
 	skills = /datum/skills/commander
 	idtype = /obj/item/card/id/gold
@@ -96,7 +96,7 @@
 
 	assignment = JOB_WO_XO
 	rank = JOB_WO_XO
-	paygrade = "MO3"
+	paygrade = "O-3"
 	role_comm_title = "XO"
 	skills = /datum/skills/XO
 	idtype = /obj/item/card/id/silver
@@ -138,7 +138,7 @@
 	access = list(ACCESS_MARINE_BRIG, ACCESS_MARINE_BRIDGE, ACCESS_MARINE_DROPSHIP, ACCESS_MARINE_LOGISTICS, ACCESS_MARINE_PREP, ACCESS_MARINE_WO, ACCESS_MARINE_MEDBAY)
 	assignment = JOB_WO_CHIEF_POLICE
 	rank = JOB_WO_CHIEF_POLICE
-	paygrade = "ME5"
+	paygrade = "E-5"
 	role_comm_title = "HGSL"
 	skills = /datum/skills/honor_guard/lead
 	idtype = /obj/item/card/id/silver
@@ -174,7 +174,7 @@
 	access = list(ACCESS_MARINE_BRIDGE, ACCESS_MARINE_BRIG, ACCESS_MARINE_DROPSHIP, ACCESS_MARINE_LOGISTICS)
 	assignment = JOB_WO_SO
 	rank = JOB_WO_SO
-	paygrade = "ME4"
+	paygrade = "E-4"
 	role_comm_title = "VHG"
 	skills = /datum/skills/honor_guard/vet
 	idtype = /obj/item/card/id/silver
@@ -214,7 +214,7 @@
 	access = list(ACCESS_MARINE_BRIDGE, ACCESS_MARINE_DROPSHIP, ACCESS_MARINE_LOGISTICS)
 	assignment = JOB_WO_CREWMAN
 	rank = JOB_WO_CREWMAN
-	paygrade = "ME3"
+	paygrade = "E-3"
 	role_comm_title = "HGS"
 	skills = /datum/skills/honor_guard/spec
 	idtype = /obj/item/card/id/gold
@@ -252,7 +252,7 @@
 	access = list(ACCESS_MARINE_BRIG, ACCESS_MARINE_BRIDGE, ACCESS_MARINE_DROPSHIP, ACCESS_MARINE_LOGISTICS, ACCESS_MARINE_PREP, ACCESS_MARINE_MEDBAY)
 	assignment = JOB_WO_POLICE
 	rank = JOB_WO_POLICE
-	paygrade = "ME2"
+	paygrade = "E-2"
 	role_comm_title = "HG"
 	skills = /datum/skills/honor_guard
 
@@ -284,7 +284,7 @@
 	access = list(ACCESS_MARINE_BRIDGE, ACCESS_MARINE_DROPSHIP, ACCESS_MARINE_LOGISTICS, ACCESS_MARINE_PILOT)
 	assignment = JOB_WO_PILOT
 	rank = JOB_WO_PILOT
-	paygrade = "ME2"
+	paygrade = "E-2"
 	role_comm_title = "MC"
 	skills = /datum/skills/mortar_crew
 
@@ -317,7 +317,7 @@
 	access = list(ACCESS_MARINE_CARGO, ACCESS_MARINE_RO, ACCESS_MARINE_BRIDGE)
 	assignment = JOB_WO_CHIEF_REQUISITION
 	rank = JOB_WO_CHIEF_REQUISITION
-	paygrade = "MO2"
+	paygrade = "O-2"
 	role_comm_title = "QM"
 	skills = /datum/skills/RO
 	idtype = /obj/item/card/id/silver
@@ -345,7 +345,7 @@
 	access = list(ACCESS_MARINE_ENGINEERING, ACCESS_CIVILIAN_ENGINEERING, ACCESS_MARINE_CARGO)
 	assignment = JOB_WO_REQUISITION
 	rank = JOB_WO_REQUISITION
-	paygrade = "ME4"
+	paygrade = "E-4"
 	role_comm_title = "BCL"
 	skills = /datum/skills/CE
 	idtype = /obj/item/card/id
@@ -494,7 +494,7 @@
 	access = list(ACCESS_MARINE_CE, ACCESS_MARINE_ENGINEERING, ACCESS_MARINE_BRIDGE, ACCESS_CIVILIAN_ENGINEERING, ACCESS_MARINE_LOGISTICS)
 	assignment = JOB_WO_CHIEF_ENGINEER
 	rank = JOB_WO_CHIEF_ENGINEER
-	paygrade = "ME5"
+	paygrade = "E-5"
 	role_comm_title = "BCM"
 	skills = /datum/skills/CE
 	idtype = /obj/item/card/id/silver
@@ -526,7 +526,7 @@
 	access = list(ACCESS_MARINE_CE, ACCESS_MARINE_ENGINEERING, ACCESS_MARINE_BRIDGE, ACCESS_CIVILIAN_ENGINEERING, ACCESS_MARINE_LOGISTICS)
 	assignment = JOB_WO_ORDNANCE_TECH
 	rank = JOB_WO_ORDNANCE_TECH
-	paygrade = "ME4"
+	paygrade = "E-4"
 	role_comm_title = "BC"
 	skills = /datum/skills/OT
 	idtype = /obj/item/card/id
@@ -598,7 +598,7 @@
 	access = list(ACCESS_MARINE_PREP, ACCESS_MARINE_LEADER, ACCESS_MARINE_DROPSHIP)
 	assignment = JOB_SQUAD_LEADER
 	rank = JOB_SQUAD_LEADER
-	paygrade = "ME5"
+	paygrade = "E-5"
 	role_comm_title = "SL"
 	skills = /datum/skills/SL
 
@@ -633,7 +633,7 @@
 	access = list(ACCESS_MARINE_PREP, ACCESS_MARINE_SPECPREP)
 	assignment = JOB_SQUAD_SPECIALIST
 	rank = JOB_SQUAD_SPECIALIST
-	paygrade = "ME3"
+	paygrade = "E-3"
 	role_comm_title = "Spc"
 	skills = /datum/skills/specialist
 
@@ -668,7 +668,7 @@
 	access = list(ACCESS_MARINE_PREP, ACCESS_MARINE_SMARTPREP)
 	assignment = JOB_SQUAD_SMARTGUN
 	rank = JOB_SQUAD_SMARTGUN
-	paygrade = "ME3"
+	paygrade = "E-3"
 	role_comm_title = "SG"
 	skills = /datum/skills/smartgunner
 
@@ -694,7 +694,7 @@
 	access = list(ACCESS_MARINE_PREP, ACCESS_MARINE_ENGPREP, ACCESS_CIVILIAN_ENGINEERING)
 	assignment = JOB_SQUAD_ENGI
 	rank = JOB_SQUAD_ENGI
-	paygrade = "ME3"
+	paygrade = "E-3"
 	role_comm_title = "ComTech"
 	skills = /datum/skills/combat_engineer
 
@@ -729,7 +729,7 @@
 	access = list(ACCESS_MARINE_PREP, ACCESS_MARINE_MEDPREP, ACCESS_MARINE_MEDBAY)
 	assignment = JOB_SQUAD_MEDIC
 	rank = JOB_SQUAD_MEDIC
-	paygrade = "ME3"
+	paygrade = "E-3"
 	role_comm_title = "HM"
 	skills = /datum/skills/combat_medic
 
@@ -767,7 +767,8 @@
 	access = list(ACCESS_MARINE_PREP)
 	assignment = JOB_SQUAD_MARINE
 	rank = JOB_SQUAD_MARINE
-	paygrade = "ME2"
+	paygrade = "E-2"
+
 	role_comm_title = "RFN"
 	skills = /datum/skills/pfc
 


### PR DESCRIPTION


## About The Pull Request

This just changes some internal code to reflect accurate terms to make things a little easier to find.

MO1 is changed to E-1 for Private - Stuff like that all around. Makes things a lil neater.

## Why It's Good For The Game

Cleaner code that's easier to search through and understand from a developer perspective.

## Changelog

:cl: Mistfrag
refactor: Changed internal varnames for paygrades to use militarily accurate versions. 
:cl:


