### PR TITLE
Acid Hole (the wall ones) QOL

### DIFF
--- a/code/game/objects/effects/acid_hole.dm
+++ b/code/game/objects/effects/acid_hole.dm
@@ -40,9 +40,14 @@
 
 
 /obj/effect/acid_hole/attack_alien(mob/living/carbon/Xenomorph/user)
-	if(holed_wall && user.mob_size >= MOB_SIZE_BIG)
-		expand_hole(user)
-		return XENO_NO_DELAY_ACTION
+	if (!holed_wall)
+		qdel(src)		//no wall?! then cease existence...
+		return
+
+	if(!use_wall_hole(user))
+		if(user.mob_size >= MOB_SIZE_BIG)
+			expand_hole(user)
+			return XENO_NO_DELAY_ACTION
 
 /obj/effect/acid_hole/proc/expand_hole(mob/living/carbon/Xenomorph/user)
 	if(user.action_busy || user.lying)
@@ -57,7 +62,7 @@
 /obj/effect/acid_hole/proc/use_wall_hole(mob/user)
 
 	if(user.mob_size >= MOB_SIZE_BIG || user.is_mob_incapacitated() || user.lying || user.buckled || user.anchored)
-		return
+		return FALSE
 
 	var/mob_dir = get_dir(user, src)
 	var/crawl_dir = dir & mob_dir


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Lets xenos move through acid holes without the click and drag (still possible), making them more intuitive to use.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->

Click drag interaction is rather convoluted and annoying especially when it isnt necessary.

## Changelog

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Clicking on acid holes in walls will start you climbing through as xeno if possible.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
