### PR TITLE
Lathe recipes - Pressurized Canister, Janitor Bucket

### DIFF
--- a/code/game/machinery/autolathe_datums.dm
+++ b/code/game/machinery/autolathe_datums.dm
@@ -17,6 +17,11 @@
 	path = /obj/item/reagent_container/glass/bucket/mopbucket
 	category = "General"
 
+/datum/autolathe/recipe/mopbucket
+	name = "janitorial bucket"
+	path = /obj/item/reagent_container/glass/bucket/janibucket
+	category = "General"
+
 /datum/autolathe/recipe/flashlight
 	name = "flashlight"
 	path = /obj/item/device/flashlight

--- a/code/game/machinery/autolathe_datums.dm
+++ b/code/game/machinery/autolathe_datums.dm
@@ -468,3 +468,8 @@ datum/autolathe/recipe/medilathe/autoinjector/s30x6
 	name = "Pressurized Reagent Container"
 	path = /obj/item/storage/pouch/pressurized_reagent_canister
 	category = "Medical Containers"
+
+/datum/autolathe/recipe/medilathe/pressurized_canister
+	name = "Pressurized canister"
+	path = /obj/item/reagent_container/glass/pressurized_canister
+	category = "Medical Containers"

--- a/code/game/objects/items/reagent_containers/glass.dm
+++ b/code/game/objects/items/reagent_containers/glass.dm
@@ -526,6 +526,7 @@
 	splashable = FALSE
 	w_class = SIZE_MASSIVE
 	flags_atom = CAN_BE_DISPENSED_INTO|OPENCONTAINER
+	matter = list("glass" = 2000)
 
 /obj/item/reagent_container/glass/pressurized_canister/attackby(obj/item/I, mob/user)
 	return

--- a/code/game/objects/items/reagent_containers/glass.dm
+++ b/code/game/objects/items/reagent_containers/glass.dm
@@ -622,6 +622,7 @@
 	name = "janitorial bucket"
 	desc = "It's a large bucket that fits in a janitorial cart. Holds 500 units."
 	icon_state = "janibucket"
+	matter = list("metal" = 8000)
 	volume = 500
 
 

--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -822,7 +822,7 @@
 	desc = "A pressurized reagent canister pouch. It is used to refill custom injectors, and can also store one. May be refilled with a reagent tank or a Chemical Dispenser."
 	can_hold = list(/obj/item/reagent_container/hypospray/autoinjector/empty)
 	var/obj/item/reagent_container/glass/pressurized_canister/inner
-	matter = list("plastic" = 3000)
+	matter = list("plastic" = 2000, "glass" = 2000)
 
 /obj/item/storage/pouch/pressurized_reagent_canister/Initialize()
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Originally part of #1406

Pressurized Canisters are pretty neat and sometimes you want to get them by themselves, so I added them separately to Medilathe. This should let people carry / drop a refill as needed (once other changes come in). Tweaked the print price of the pressurised pouch to reflect the interior cost as well.

I've noticed Research likes using Janitorial Buckets for doing some chemistry, and honestly there are 7 janibuckets and 6 janicarts with buckets on Almayer that they are not really a bottleneck for anything really. So figured might as well make them printable at a somewhat high cost.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It makes Research life a bit easier if they want to do more bucket chemistry or give people refills for their pouches.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->

## Changelog

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added the Pressurized Canister to medilathe. The price of the Pressurized Reagent Canister Pouch has been tweaked somewhat to reflect the price of the Pressurized Canister.
add: Added the janitorial bucket recipe to lathes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
