### PR TITLE
Added more EZ Autoinjector sizes to medilathe

### DIFF
--- a/code/game/machinery/autolathe_datums.dm
+++ b/code/game/machinery/autolathe_datums.dm
@@ -375,7 +375,7 @@ datum/autolathe/recipe/medilathe/autoinjector/s60x3
 	name = "EZ autoinjector (E-U) (1x1)"
 	path = /obj/item/reagent_container/hypospray/autoinjector/empty/skillless/unit
 
-datum/autolathe/recipe/medilathe/autoinjector/s5x1
+/datum/autolathe/recipe/medilathe/autoinjector/s5x1
 	name = "EZ autoinjector (E-VS) (5x1)"
 	path = /obj/item/reagent_container/hypospray/autoinjector/empty/skillless/verysmall
 

--- a/code/game/machinery/autolathe_datums.dm
+++ b/code/game/machinery/autolathe_datums.dm
@@ -387,7 +387,7 @@ datum/autolathe/recipe/medilathe/autoinjector/s15x1
 	name = "EZ autoinjector (E-T) (15x1)"
 	path = /obj/item/reagent_container/hypospray/autoinjector/empty/skillless
 
-datum/autolathe/recipe/medilathe/autoinjector/s30x1
+/datum/autolathe/recipe/medilathe/autoinjector/s30x1
 	name = "EZ autoinjector (E-M) (30x1)"
 	path = /obj/item/reagent_container/hypospray/autoinjector/empty/skillless/medium
 

--- a/code/game/machinery/autolathe_datums.dm
+++ b/code/game/machinery/autolathe_datums.dm
@@ -395,7 +395,7 @@ datum/autolathe/recipe/medilathe/autoinjector/s45x1
 	name = "EZ autoinjector (E-L) (45x1)"
 	path = /obj/item/reagent_container/hypospray/autoinjector/empty/skillless/large
 
-datum/autolathe/recipe/medilathe/autoinjector/s60x1
+/datum/autolathe/recipe/medilathe/autoinjector/s60x1
 	name = "EZ autoinjector (E-XL) (60x1)"
 	path = /obj/item/reagent_container/hypospray/autoinjector/empty/skillless/extralarge
 

--- a/code/game/machinery/autolathe_datums.dm
+++ b/code/game/machinery/autolathe_datums.dm
@@ -371,13 +371,33 @@ datum/autolathe/recipe/medilathe/autoinjector/s60x3
 	name = "autoinjector (C-L) (60x3)"
 	path = /obj/item/reagent_container/hypospray/autoinjector/empty/large
 
+datum/autolathe/recipe/medilathe/autoinjector/s1x1
+	name = "EZ autoinjector (E-U) (1x1)"
+	path = /obj/item/reagent_container/hypospray/autoinjector/empty/skillless/unit
+
+datum/autolathe/recipe/medilathe/autoinjector/s5x1
+	name = "EZ autoinjector (E-VS) (5x1)"
+	path = /obj/item/reagent_container/hypospray/autoinjector/empty/skillless/verysmall
+
+datum/autolathe/recipe/medilathe/autoinjector/s10x1
+	name = "EZ autoinjector (E-S) (10x1)"
+	path = /obj/item/reagent_container/hypospray/autoinjector/empty/skillless/small
+
 datum/autolathe/recipe/medilathe/autoinjector/s15x1
 	name = "EZ autoinjector (E-T) (15x1)"
 	path = /obj/item/reagent_container/hypospray/autoinjector/empty/skillless
 
+datum/autolathe/recipe/medilathe/autoinjector/s30x1
+	name = "EZ autoinjector (E-M) (30x1)"
+	path = /obj/item/reagent_container/hypospray/autoinjector/empty/skillless/medium
+
 datum/autolathe/recipe/medilathe/autoinjector/s45x1
-	name = "EZ autoinjector (E-S) (45x1)"
-	path = /obj/item/reagent_container/hypospray/autoinjector/empty/skillless/small
+	name = "EZ autoinjector (E-L) (45x1)"
+	path = /obj/item/reagent_container/hypospray/autoinjector/empty/skillless/large
+
+datum/autolathe/recipe/medilathe/autoinjector/s60x1
+	name = "EZ autoinjector (E-XL) (60x1)"
+	path = /obj/item/reagent_container/hypospray/autoinjector/empty/skillless/extralarge
 
 datum/autolathe/recipe/medilathe/autoinjector/s15x6
 	name = "Medic autoinjector (M-M) (15x6)"

--- a/code/game/machinery/autolathe_datums.dm
+++ b/code/game/machinery/autolathe_datums.dm
@@ -379,7 +379,7 @@ datum/autolathe/recipe/medilathe/autoinjector/s60x3
 	name = "EZ autoinjector (E-VS) (5x1)"
 	path = /obj/item/reagent_container/hypospray/autoinjector/empty/skillless/verysmall
 
-datum/autolathe/recipe/medilathe/autoinjector/s10x1
+/datum/autolathe/recipe/medilathe/autoinjector/s10x1
 	name = "EZ autoinjector (E-S) (10x1)"
 	path = /obj/item/reagent_container/hypospray/autoinjector/empty/skillless/small
 

--- a/code/game/machinery/autolathe_datums.dm
+++ b/code/game/machinery/autolathe_datums.dm
@@ -367,7 +367,7 @@
 	name = "autoinjector (C-M) (30x3)"
 	path = /obj/item/reagent_container/hypospray/autoinjector/empty/medium
 
-datum/autolathe/recipe/medilathe/autoinjector/s60x3
+/datum/autolathe/recipe/medilathe/autoinjector/s60x3
 	name = "autoinjector (C-L) (60x3)"
 	path = /obj/item/reagent_container/hypospray/autoinjector/empty/large
 
@@ -383,7 +383,7 @@ datum/autolathe/recipe/medilathe/autoinjector/s60x3
 	name = "EZ autoinjector (E-S) (10x1)"
 	path = /obj/item/reagent_container/hypospray/autoinjector/empty/skillless/small
 
-datum/autolathe/recipe/medilathe/autoinjector/s15x1
+/datum/autolathe/recipe/medilathe/autoinjector/s15x1
 	name = "EZ autoinjector (E-T) (15x1)"
 	path = /obj/item/reagent_container/hypospray/autoinjector/empty/skillless
 
@@ -391,7 +391,7 @@ datum/autolathe/recipe/medilathe/autoinjector/s15x1
 	name = "EZ autoinjector (E-M) (30x1)"
 	path = /obj/item/reagent_container/hypospray/autoinjector/empty/skillless/medium
 
-datum/autolathe/recipe/medilathe/autoinjector/s45x1
+/datum/autolathe/recipe/medilathe/autoinjector/s45x1
 	name = "EZ autoinjector (E-L) (45x1)"
 	path = /obj/item/reagent_container/hypospray/autoinjector/empty/skillless/large
 
@@ -399,11 +399,11 @@ datum/autolathe/recipe/medilathe/autoinjector/s45x1
 	name = "EZ autoinjector (E-XL) (60x1)"
 	path = /obj/item/reagent_container/hypospray/autoinjector/empty/skillless/extralarge
 
-datum/autolathe/recipe/medilathe/autoinjector/s15x6
+/datum/autolathe/recipe/medilathe/autoinjector/s15x6
 	name = "Medic autoinjector (M-M) (15x6)"
 	path = /obj/item/reagent_container/hypospray/autoinjector/empty/medic
 
-datum/autolathe/recipe/medilathe/autoinjector/s30x6
+/datum/autolathe/recipe/medilathe/autoinjector/s30x6
 	name = "Medic Autoinjector (M-L) (30x6)"
 	path = /obj/item/reagent_container/hypospray/autoinjector/empty/medic/large
 

--- a/code/game/machinery/autolathe_datums.dm
+++ b/code/game/machinery/autolathe_datums.dm
@@ -371,7 +371,7 @@ datum/autolathe/recipe/medilathe/autoinjector/s60x3
 	name = "autoinjector (C-L) (60x3)"
 	path = /obj/item/reagent_container/hypospray/autoinjector/empty/large
 
-datum/autolathe/recipe/medilathe/autoinjector/s1x1
+/datum/autolathe/recipe/medilathe/autoinjector/s1x1
 	name = "EZ autoinjector (E-U) (1x1)"
 	path = /obj/item/reagent_container/hypospray/autoinjector/empty/skillless/unit
 

--- a/code/game/objects/items/reagent_containers/autoinjectors.dm
+++ b/code/game/objects/items/reagent_containers/autoinjectors.dm
@@ -322,17 +322,38 @@
 	item_state = "empty_ez"
 	skilllock = SKILL_MEDICAL_DEFAULT
 	amount_per_transfer_from_this = 15
+	volume = 15
 	uses_left = 0
+
+/obj/item/reagent_container/hypospray/autoinjector/empty/skillless/unit
+	name = "Autoinjector (E-U)"
+	volume = 1
+	amount_per_transfer_from_this = 1
 
 /obj/item/reagent_container/hypospray/autoinjector/empty/skillless/verysmall
 	name = "Autoinjector (E-VS)"
-	volume = 30
-	amount_per_transfer_from_this = 10
+	volume = 5
+	amount_per_transfer_from_this = 5
 
 /obj/item/reagent_container/hypospray/autoinjector/empty/skillless/small
 	name = "Autoinjector (E-S)"
+	volume = 10
+	amount_per_transfer_from_this = 10
+
+/obj/item/reagent_container/hypospray/autoinjector/empty/skillless/medium
+	name = "Autoinjector (E-M)"
+	volume = 30
+	amount_per_transfer_from_this = 30
+
+/obj/item/reagent_container/hypospray/autoinjector/empty/skillless/large
+	name = "Autoinjector (E-L)"
 	volume = 45
 	amount_per_transfer_from_this = 45
+
+/obj/item/reagent_container/hypospray/autoinjector/empty/skillless/extralarge
+	name = "Autoinjector (E-XL)"
+	volume = 60
+	amount_per_transfer_from_this = 60
 
 /obj/item/reagent_container/hypospray/autoinjector/empty/medic/
 	name = "Medic Autoinjector (M-M)"

--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -851,7 +851,7 @@
 	fill_with("kelotane")
 
 /obj/item/storage/pouch/pressurized_reagent_canister/oxycodone/Initialize()
-	new /obj/item/reagent_container/hypospray/autoinjector/empty/skillless/verysmall/(src)
+	new /obj/item/reagent_container/hypospray/autoinjector/empty/skillless/small/(src)
 	. = ..()
 	fill_with("oxycodone")
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Originally part of #1406

The existing EZ Autoinjector sizes were a bit lacking, so I added a few more and made them printable in the medilathe. This will make deploying stims and other chems with really really low OD thresholds easier. Then I also had to tweak the Elite Mercenary's Oxycodone Pressurized Reagent Canister Pouch to come with an 10x1 autoinjector rather than 10x3 to standardise how the EZ Autoinjectors work (plus the sprite overlay for the original one was broken).

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Gives Research more fine-tuned control over injector amounts, which is really useful when you need to dose something with 1u / 5u overdose chemicals.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->

## Changelog

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added more E-Z autoinjector sizes to medilathe. They now come with a single shot each of 1, 5, 10, 15, 30, 45 and 60 units. Perfect for both large mixes of healing chemicals as well as very tiny doses of low OD custom chems.
del: Elite Mercenary's Oxycodone Pressurized Reagent Canister Pouch now comes with a 10x1 autoinjector rather than 10x3 to standardise how those E-Z autoinjectors worked.
code: Refactored Autoinjector lathe recipe paths to be consistent with our code style.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
