### PR TITLE
Fixes to Pressurized Canister behaviour and letting you remove the Canister from its pouch

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -128,6 +128,9 @@ directive is properly returned.
 /atom/proc/is_open_container()
 	return flags_atom & OPENCONTAINER
 
+/atom/proc/is_open_container_or_can_be_dispensed_into()
+	return flags_atom & OPENCONTAINER || flags_atom & CAN_BE_DISPENSED_INTO
+
 /atom/proc/can_be_syringed()
 	return flags_atom & CAN_BE_SYRINGED
 

--- a/code/game/objects/items/reagent_containers/glass.dm
+++ b/code/game/objects/items/reagent_containers/glass.dm
@@ -69,7 +69,6 @@
 		update_icon()
 
 /obj/item/reagent_container/glass/afterattack(obj/target, mob/user , flag)
-
 	if(!reagents)
 		create_reagents(volume)
 
@@ -525,7 +524,7 @@
 	volume = 480
 	splashable = FALSE
 	w_class = SIZE_MASSIVE
-	flags_atom = CAN_BE_DISPENSED_INTO|OPENCONTAINER
+	flags_atom = CAN_BE_DISPENSED_INTO
 	matter = list("glass" = 2000)
 
 /obj/item/reagent_container/glass/pressurized_canister/attackby(obj/item/I, mob/user)

--- a/code/game/objects/items/reagent_containers/glass.dm
+++ b/code/game/objects/items/reagent_containers/glass.dm
@@ -523,7 +523,7 @@
 	icon_state = "pressurized_reagent_container"
 	item_state = "anesthetic"
 	amount_per_transfer_from_this = 0
-	possible_transfer_amounts = list(0)
+	possible_transfer_amounts = null
 	volume = 480
 	splashable = FALSE
 	w_class = SIZE_MASSIVE

--- a/code/game/objects/items/reagent_containers/glass.dm
+++ b/code/game/objects/items/reagent_containers/glass.dm
@@ -118,7 +118,7 @@
 
 			to_chat(user, SPAN_NOTICE("You fill [src] with [trans] units of the contents of [target]."))
 		else
-			if(is_open_container())
+			if(is_open_container_or_can_be_dispensed_into())
 				if(reagents && !reagents.total_volume)
 					to_chat(user, SPAN_WARNING("[src] is empty."))
 					return

--- a/code/game/objects/items/reagent_containers/glass.dm
+++ b/code/game/objects/items/reagent_containers/glass.dm
@@ -72,14 +72,14 @@
 	if(!reagents)
 		create_reagents(volume)
 
-	if(!is_open_container() || !flag)
+	if(!is_open_container_or_can_be_dispensed_into() || !flag)
 		return
 
 	for(var/type in src.can_be_placed_into)
 		if(istype(target, type))
 			return
 
-	if(ismob(target) && target.reagents && reagents.total_volume && user.a_intent == INTENT_HARM && splashable)
+	if(is_open_container() && ismob(target) && target.reagents && reagents.total_volume && user.a_intent == INTENT_HARM && splashable)
 		to_chat(user, SPAN_NOTICE("You splash the solution onto [target]."))
 		playsound(target, 'sound/effects/slosh.ogg', 25, 1)
 
@@ -118,23 +118,26 @@
 
 			to_chat(user, SPAN_NOTICE("You fill [src] with [trans] units of the contents of [target]."))
 		else
-			if(reagents && !reagents.total_volume)
-				to_chat(user, SPAN_WARNING("[src] is empty."))
-				return
+			if(is_open_container())
+				if(reagents && !reagents.total_volume)
+					to_chat(user, SPAN_WARNING("[src] is empty."))
+					return
 
-			if(D.reagents.total_volume >= D.reagents.maximum_volume)
-				to_chat(user, SPAN_WARNING("[D] is full."))
-				return
+				if(D.reagents.total_volume >= D.reagents.maximum_volume)
+					to_chat(user, SPAN_WARNING("[D] is full."))
+					return
 
-			var/trans = reagents.trans_to(D, D:amount_per_transfer_from_this)
+				var/trans = reagents.trans_to(D, D:amount_per_transfer_from_this)
 
-			if(!trans)
-				to_chat(user, SPAN_DANGER("You fail to add reagents to [target]."))
-				return
+				if(!trans)
+					to_chat(user, SPAN_DANGER("You fail to add reagents to [target]."))
+					return
 
-			to_chat(user, SPAN_NOTICE("You fill [D] with [trans] units of the contents of [src]."))
+				to_chat(user, SPAN_NOTICE("You fill [D] with [trans] units of the contents of [src]."))
+			else
+				to_chat(user, SPAN_WARNING("You must open the container first!"))
 
-	else if(target.is_open_container() && target.reagents) //Something like a glass. Player probably wants to transfer TO it.
+	else if(is_open_container() && target.is_open_container() && target.reagents) //Something like a glass. Player probably wants to transfer TO it.
 
 		if(!reagents.total_volume)
 			to_chat(user, SPAN_WARNING("[src] is empty."))
@@ -155,7 +158,7 @@
 	else if(istype(target, /obj/structure/machinery/smartfridge))
 		return
 
-	else if((reagents.total_volume) && (user.a_intent == INTENT_HARM) && splashable)
+	else if(is_open_container() && (reagents.total_volume) && (user.a_intent == INTENT_HARM) && splashable)
 		to_chat(user, SPAN_NOTICE("You splash the solution onto [target]."))
 		playsound(target, 'sound/effects/slosh.ogg', 25, 1)
 		reagents.reaction(target, TOUCH)

--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -1001,6 +1001,19 @@
 			to_chat(usr, SPAN_NOTICE("You flush the [src]."))
 			inner.reagents.clear_reagents()
 
+/obj/item/storage/pouch/pressurized_reagent_canister/verb/remove_canister()
+	set category = "Weapons"
+	set name = "Remove Canister"
+	set desc = "Removes the Pressurized Canister from the pouch."
+	set src in usr
+	if(!inner)
+		to_chat(usr, SPAN_WARNING("There is no container inside this pouch!"))
+		return
+
+	usr.put_in_any_hand_if_possible(inner, disable_warning = TRUE)
+	inner = null
+	update_icon()
+
 /obj/item/storage/pouch/document
 	name = "large document pouch"
 	desc = "It can contain papers, folders, disks, technical manuals, and clipboards."

--- a/code/game/objects/structures/reagent_dispensers.dm
+++ b/code/game/objects/structures/reagent_dispensers.dm
@@ -388,6 +388,7 @@
 	desc = "A reagent tank, typically used to store large quantities of chemicals."
 
 	chemical = null
+	dispensing = FALSE //Empty fuel tanks start by accepting chemicals by default. Can't dispense nothing!
 	icon_state = "tank_normal"
 
 /obj/structure/reagent_dispensers/fueltank/custom/Initialize(mapload, volume)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Originally part of #1406

While messing with the Pressurized Reagent Pouch I realised the Pressurized Canister inside of it behaved a bit strangely. After reading the code I think I got to the gist of what was supposed to happen, fixed things and them improved the QoL of dealing with them.

First, now you can remove the Pressurized Canister from the pouch with a right click. It was really strange that they popped out so easily from the Pouch into the Dispenser but otherwise you couldn't get them out.

Secondly, made sure the Pressurized Canister's flags were properly respected. It's a SEALED container, BUT you can put reagents into it via a Dispenser or the Reagent Tank. So I had to fix the code around that to make it happen. Otherwise, you could pour things from beakers into the Pressurized Canister once you got it out which didn't seem intentional.

Thirdly, removed the invalid transfer amount list from the Pressurized Canister.

Fourthly, a final QoL - empty Reagent Tanks start by accepting chems rather than dispensing them to remove the unnecesary step when dealing with them.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Improves the QoL around Pressurized Canisters and Reagent Tanks, also fixes a bug resulting in broken behaviour for the Pressurized Canister which is always good.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->

## Changelog

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: You can now remove the Pressurized Canister from the Pressurized Reagent Canister Pouches by right-clicking on it.
fix: The Pressurized Canister can now only be filled through the chem dispensers and reagent tanks as it was intended.
fix: The Pressurized Canister doesn't have an invalid list of possible transfer amounts anymore.
qol: Empty reagent tanks are set by default to accept chems rather than try dispensing nothing.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
