### PR TITLE
Reagent Canister and Pouch overlays

### DIFF
--- a/code/game/objects/items/reagent_containers/glass.dm
+++ b/code/game/objects/items/reagent_containers/glass.dm
@@ -549,8 +549,10 @@
 	update_icon()
 
 /obj/item/reagent_container/glass/pressurized_canister/update_icon()
+	color = COLOR_WHITE
 	if(reagents)
 		color = mix_color_from_reagents(reagents.reagent_list)
+	..()
 
 /obj/item/reagent_container/glass/bucket
 	desc = "It's a bucket. Holds 120 units."

--- a/code/game/objects/items/reagent_containers/glass.dm
+++ b/code/game/objects/items/reagent_containers/glass.dm
@@ -308,6 +308,7 @@
 		filling.icon_state = "[icon_state][round_percent]"
 		filling.color = mix_color_from_reagents(reagents.reagent_list)
 		overlays += filling
+
 /obj/item/reagent_container/glass/beaker/large
 	name = "large beaker"
 	desc = "A large beaker. Can hold up to 120 units."
@@ -528,6 +529,10 @@
 	flags_atom = CAN_BE_DISPENSED_INTO|OPENCONTAINER
 	matter = list("glass" = 2000)
 
+/obj/item/reagent_container/glass/pressurized_canister/Initialize()
+	. = ..()
+	update_icon()
+
 /obj/item/reagent_container/glass/pressurized_canister/attackby(obj/item/I, mob/user)
 	return
 
@@ -539,6 +544,13 @@
 /obj/item/reagent_container/glass/pressurized_canister/set_APTFT()
 	to_chat(usr, SPAN_WARNING("[src] has no transfer control valve! Use a dispenser to fill it!"))
 	return
+
+/obj/item/reagent_container/glass/pressurized_canister/on_reagent_change()
+	update_icon()
+
+/obj/item/reagent_container/glass/pressurized_canister/update_icon()
+	if(reagents)
+		color = mix_color_from_reagents(reagents.reagent_list)
 
 /obj/item/reagent_container/glass/bucket
 	desc = "It's a bucket. Holds 120 units."

--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -902,7 +902,7 @@
 		autoinjector.update_uses_left()
 		autoinjector.update_icon()
 		playsound(loc, 'sound/effects/refill.ogg', 25, TRUE, 3)
-        A.update_icon()
+		autoinjector.update_icon()
 		update_icon()
 
 /obj/item/storage/pouch/pressurized_reagent_canister/afterattack(obj/target, mob/user, flag) //refuel at fueltanks & chem dispensers.

--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -902,6 +902,8 @@
 		autoinjector.update_uses_left()
 		autoinjector.update_icon()
 		playsound(loc, 'sound/effects/refill.ogg', 25, TRUE, 3)
+        A.update_icon()
+		update_icon()
 
 /obj/item/storage/pouch/pressurized_reagent_canister/afterattack(obj/target, mob/user, flag) //refuel at fueltanks & chem dispensers.
 	if(!inner)
@@ -1017,6 +1019,7 @@
 		if(inner)
 			to_chat(usr, SPAN_NOTICE("You flush the [src]."))
 			inner.reagents.clear_reagents()
+			update_icon()
 
 /obj/item/storage/pouch/document
 	name = "large document pouch"

--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -964,7 +964,11 @@
 	if(length(contents))
 		overlays += "+[icon_state]_full"
 	if(inner)
-		overlays += "+[icon_state]_loaded"
+		//tint the inner display based on what chemical is inside
+		var/image/I = image(icon, icon_state="+[icon_state]_loaded")
+		if(inner.reagents)
+			I.color = mix_color_from_reagents(inner.reagents.reagent_list)
+		overlays += I
 
 
 /obj/item/storage/pouch/pressurized_reagent_canister/empty(mob/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Originally part of #1406

I have tried going into the field with two separate Pressurized Reagent Canister Pouches (like Tricord and Revival), but what I found frustrating was that it was a bit hard to tell them apart at first glance. So I made the Pressurized Canister change its tint based on what's in it, and similarly let the Canister part of the Pouch change tint accordingly so now you can tell which chem is where more easily.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It makes it easier for doctors / medics to use the correct chems by just glancing at their pouches.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->

## Changelog

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: All Pressurized Reagent Canister Pouches now change their canister tint based on the colour of the chemicals stored therein (while still being mixed with the default blue-ish tint of the canister). Canisters themselves similarly change their tint based on contents.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
