### PR TITLE
QoL improvements to Pressurized Reagent Canister Pouch initialization

### DIFF
--- a/code/game/objects/items/reagent_containers/autoinjectors.dm
+++ b/code/game/objects/items/reagent_containers/autoinjectors.dm
@@ -31,6 +31,11 @@
 		verbs += /obj/item/storage/pill_bottle/verb/set_maptext
 	update_icon()
 
+/obj/item/reagent_container/hypospray/autoinjector/proc/update_uses_left()
+	var/UL = reagents.total_volume / amount_per_transfer_from_this
+	UL = round(UL) == UL ? UL : round(UL) + 1
+	uses_left = UL
+
 /obj/item/reagent_container/hypospray/autoinjector/attack(mob/M, mob/user)
 	if(uses_left <= 0)
 		return

--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -827,39 +827,51 @@
 /obj/item/storage/pouch/pressurized_reagent_canister/Initialize()
 	. = ..()
 	inner = new /obj/item/reagent_container/glass/pressurized_canister()
+	//Only add an autoinjector if the canister is empty
+	//Important for the snowflake /obj/item/storage/pouch/pressurized_reagent_canister/oxycodone
+	if(contents.len == 0)
+		new /obj/item/reagent_container/hypospray/autoinjector/empty/medic(src)
+	update_icon()
+
+/obj/item/storage/pouch/pressurized_reagent_canister/proc/fill_with(var/ragent)
+	inner.reagents.add_reagent(ragent, inner.volume)
+	if(contents.len > 0)
+		var/obj/item/reagent_container/hypospray/autoinjector/empty/medic/A = contents[1]
+		A.reagents.add_reagent(ragent, A.volume)
+		A.update_uses_left()
+		A.update_icon()
 	update_icon()
 
 /obj/item/storage/pouch/pressurized_reagent_canister/bicaridine/Initialize()
 	. = ..()
-	inner.reagents.add_reagent("bicaridine", inner.volume)
-	new /obj/item/reagent_container/hypospray/autoinjector/empty/medic(src)
-	update_icon()
+	fill_with("bicaridine")
 
 /obj/item/storage/pouch/pressurized_reagent_canister/kelotane/Initialize()
 	. = ..()
-	inner.reagents.add_reagent("kelotane", inner.volume)
-	new /obj/item/reagent_container/hypospray/autoinjector/empty/medic/(src)
-	update_icon()
+	fill_with("kelotane")
 
 /obj/item/storage/pouch/pressurized_reagent_canister/oxycodone/Initialize()
-	. = ..()
-	inner.reagents.add_reagent("oxycodone", inner.volume)
 	new /obj/item/reagent_container/hypospray/autoinjector/empty/skillless/verysmall/(src)
-	update_icon()
+	. = ..()
+	fill_with("oxycodone")
 
 /obj/item/storage/pouch/pressurized_reagent_canister/revival/Initialize()
 	. = ..()
 	inner.reagents.add_reagent("adrenaline", inner.volume/3)
 	inner.reagents.add_reagent("inaprovaline", inner.volume/3)
 	inner.reagents.add_reagent("tricordrazine", inner.volume/3)
-	new /obj/item/reagent_container/hypospray/autoinjector/empty/medic(src)
+	if(contents.len > 0)
+		var/obj/item/reagent_container/hypospray/autoinjector/empty/medic/A = contents[1]
+		A.reagents.add_reagent("adrenaline", A.volume/3)
+		A.reagents.add_reagent("inaprovaline", A.volume/3)
+		A.reagents.add_reagent("tricordrazine", A.volume/3)
+		A.update_uses_left()
+		A.update_icon()
 	update_icon()
 
 /obj/item/storage/pouch/pressurized_reagent_canister/tricordrazine/Initialize()
 	. = ..()
-	inner.reagents.add_reagent("tricordrazine", inner.volume)
-	new /obj/item/reagent_container/hypospray/autoinjector/empty/medic/(src)
-	update_icon()
+	fill_with("tricordrazine")
 
 /obj/item/storage/pouch/pressurized_reagent_canister/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/reagent_container/glass/pressurized_canister))
@@ -879,9 +891,7 @@
 		max_uses = round(max_uses) == max_uses ? max_uses : round(max_uses) + 1
 		if(inner && inner.reagents.total_volume > 0 && (A.uses_left < max_uses))
 			inner.reagents.trans_to(A, A.volume)
-			var/uses_left = A.reagents.total_volume / A.amount_per_transfer_from_this
-			uses_left = round(uses_left) == uses_left ? uses_left : round(uses_left) + 1
-			A.uses_left = uses_left
+			A.update_uses_left()
 			playsound(loc, 'sound/effects/refill.ogg', 25, TRUE, 3)
 			A.update_icon()
 		return ..()

--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -857,6 +857,7 @@
 
 /obj/item/storage/pouch/pressurized_reagent_canister/revival/Initialize()
 	. = ..()
+	//we don't call fill_with because of the complex mix of chemicals we have
 	inner.reagents.add_reagent("adrenaline", inner.volume/3)
 	inner.reagents.add_reagent("inaprovaline", inner.volume/3)
 	inner.reagents.add_reagent("tricordrazine", inner.volume/3)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Originally part of #1406

The Pressurized Reagent Canister Pouch is great, but the empty one has been a noob trap since it didn't come with an autoinjector. So I fixed that. I also made sure all the Pressurized Reagent Canister Pouches that come with reagents pre-fill their autoinjectors with the correct reagents so you don't have to take the autoinjector in and out just to use it. Plus a small code refactor.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->

## Changelog

Less noob traps are better, and pre-filled canister pouches being actually full is also what you'd expect them to be.

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Empty Pressurized Reagent Canister Pouch now comes with an empty Autoinjector.
qol: All Pressurized Reagent Canister Pouches now have their Autoinjectors pre-filled.
code: Did a small refactor on how pre-filled Pressurized Reagent Canister Pouches initialize their chems.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
