### PR TITLE
fix beam tracing to account for icon offsets / sizes

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -71,14 +71,39 @@
 	if(A > upper) return 0
 	return 1
 
+/// Gives X position on pixel grid of an object, accounting for offsets
+/proc/get_pixel_position_x(atom/subject, relative = FALSE)
+	. = subject.pixel_x + subject.base_pixel_x
+	if(!relative)
+		. += world.icon_size * subject.x
+
+	if(ismob(subject)) // Mobs use baked in icon_size due to eg. Xenos only using a visual size
+		var/mob/mob_subject = subject
+		. += (mob_subject.icon_size - world.icon_size) / 2
+
+	else if(ismovable(subject)) // Other movables we assume use bound_height/width collision boxes
+		var/atom/movable/big_subject = subject
+		. += (big_subject.bound_width  - world.icon_size) / 2
+
+/// Gives Y position on pixel grid of an object, accounting for offsets
+/proc/get_pixel_position_y(atom/subject, relative = FALSE)
+	. = subject.pixel_y + subject.base_pixel_y
+	if(!relative)
+		. += world.icon_size * subject.y
+
+	if(ismob(subject)) // Mobs use baked in icon_size due to eg. Xenos only using a visual size
+		var/mob/mob_subject = subject
+		. += (mob_subject.icon_size - world.icon_size) / 2
+
+	else if(ismovable(subject)) // Other movables we assume use bound_height/width collision boxes
+		var/atom/movable/big_subject = subject
+		. += (big_subject.bound_height  - world.icon_size) / 2
 
 /proc/Get_Angle(atom/start,atom/end)//For beams.
 	if(!start || !end) return 0
 	if(!start.z || !end.z) return 0 //Atoms are not on turfs.
-	var/dy
-	var/dx
-	dy=(32*end.y+end.pixel_y)-(32*start.y+start.pixel_y)
-	dx=(32*end.x+end.pixel_x)-(32*start.x+start.pixel_x)
+	var/dy = get_pixel_position_y(end) - get_pixel_position_y(start)
+	var/dx = get_pixel_position_x(end) - get_pixel_position_x(start)
 	if(!dy)
 		return (dx>=0)?90:270
 	.=arctan(dx/dy)

--- a/code/datums/beam.dm
+++ b/code/datums/beam.dm
@@ -88,12 +88,12 @@
 	rot_matrix.Turn(Angle)
 
 	//Translation vector for origin and target
-	var/DX = (32*target.x+target.pixel_x)-(32*origin.x+origin.pixel_x)
-	var/DY = (32*target.y+target.pixel_y)-(32*origin.y+origin.pixel_y)
+	var/DX = get_pixel_position_x(target) - get_pixel_position_x(origin)
+	var/DY = get_pixel_position_y(target) - get_pixel_position_y(origin)
 	var/N = 0
 	var/length = round(sqrt((DX)**2+(DY)**2)) //hypotenuse of the triangle formed by target and origin's displacement
 
-	for(N in 0 to length-1 step 32)//-1 as we want < not <=, but we want the speed of X in Y to Z and step X
+	for(N in 0 to length-1 step world.icon_size)//-1 as we want < not <=, but we want the speed of X in Y to Z and step X
 		if(QDELETED(src))
 			break
 		var/obj/effect/ebeam/X = new beam_type(origin_turf)
@@ -102,9 +102,9 @@
 
 		//Assign our single visual ebeam to each ebeam's vis_contents
 		//ends are cropped by a transparent box icon of length-N pixel size laid over the visuals obj
-		if(N+32>length) //went past the target, we draw a box of space to cut away from the beam sprite so the icon actually ends at the center of the target sprite
+		if(N + world.icon_size > length) //went past the target, we draw a box of space to cut away from the beam sprite so the icon actually ends at the center of the target sprite
 			var/icon/II = new(icon, icon_state)//this means we exclude the overshooting object from the visual contents which does mean those visuals don't show up for the final bit of the beam...
-			II.DrawBox(null,1,(length-N),32,32)//in the future if you want to improve this, remove the drawbox and instead use a 513 filter to cut away at the final object's icon
+			II.DrawBox(null,1,(length-N), world.icon_size, world.icon_size)//in the future if you want to improve this, remove the drawbox and instead use a 513 filter to cut away at the final object's icon
 			X.icon = II
 		else
 			X.vis_contents += visuals
@@ -116,25 +116,26 @@
 		if(DX == 0)
 			Pixel_x = 0
 		else
-			Pixel_x = round(sin(Angle)+32*sin(Angle)*(N+16)/32)
+			Pixel_x = round(sin(Angle) + world.icon_size*sin(Angle)*(N+world.icon_size/2) / world.icon_size)
 		if(DY == 0)
 			Pixel_y = 0
 		else
-			Pixel_y = round(cos(Angle)+32*cos(Angle)*(N+16)/32)
+			Pixel_y = round(cos(Angle) + world.icon_size*cos(Angle)*(N+world.icon_size/2) / world.icon_size)
 
 		//Position the effect so the beam is one continous line
 		var/a
-		if(abs(Pixel_x)>32)
-			a = Pixel_x > 0 ? round(Pixel_x/32) : CEILING(Pixel_x/32, 1)
+		if(abs(Pixel_x)>world.icon_size)
+			a = Pixel_x > 0 ? round(Pixel_x/32) : CEILING(Pixel_x/world.icon_size, 1)
 			X.x += a
-			Pixel_x %= 32
-		if(abs(Pixel_y)>32)
-			a = Pixel_y > 0 ? round(Pixel_y/32) : CEILING(Pixel_y/32, 1)
+			Pixel_x %= world.icon_size
+		if(abs(Pixel_y)>world.icon_size)
+			a = Pixel_y > 0 ? round(Pixel_y/32) : CEILING(Pixel_y/world.icon_size, 1)
 			X.y += a
-			Pixel_y %= 32
+			Pixel_y %= world.icon_size
 
-		X.pixel_x = Pixel_x + origin.pixel_x
-		X.pixel_y = Pixel_y + origin.pixel_y
+		X.pixel_x = Pixel_x + get_pixel_position_x(origin, relative = TRUE)
+		X.pixel_y = Pixel_y + get_pixel_position_y(origin, relative = TRUE)
+
 		CHECK_TICK
 
 /obj/effect/ebeam

--- a/code/modules/mob/living/carbon/xenomorph/castes/Crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Crusher.dm
@@ -42,6 +42,8 @@
 	pixel_y = -3
 	old_x = -16
 	old_y = -3
+	base_pixel_x = 0
+	base_pixel_y = -16
 
 	rebounds = FALSE // no more fucking pinball crooshers
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/Runner.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Runner.dm
@@ -36,6 +36,8 @@
 	tier = 1
 	pixel_x = -16  //Needed for 2x2
 	old_x = -16
+	base_pixel_x = -4
+	base_pixel_y = -20
 	pull_speed = -0.5
 	viewsize = 9
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

After fixing source beam offsets in #1439, it's now apparent there are more issues with beam code, namely:
 * The beam tracing doesn't account for pixel placement, mainly due to different icon sizes
 * The beam doesn't offset based on source icon size
 * There is no way to define an "attachment offset" for the beam, so once fixed it flies in the air above runners
 * The beam code doesn't account for world icon size (bonus)

This fixes all of this, or should. It piggybacks on base_pixel_x/y for attachment offset, which were added in a previous PR (thanks Stan) but never actually used for some reason (it's useful!)

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->

Carlarc (or anyone using beams and xenos together) can stop whining about odd looking beam placement, and get back to codin'.

## Changelog

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
code: Refactored part of pixel placement calculations for beams.
fix: Beams from/to xenos in particular should now properly attach to them visually.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
