### PR TITLE
M39 Rebirth

### DIFF
--- a/code/game/objects/items/storage/large_holster.dm
+++ b/code/game/objects/items/storage/large_holster.dm
@@ -119,7 +119,7 @@
 	icon_state = "m39_holster"
 	icon = 'icons/obj/items/clothing/belts.dmi'
 	flags_equip_slot = SLOT_WAIST
-	max_w_class = 5
+	max_w_class = 4
 	can_hold = list(
 		/obj/item/weapon/gun/smg/m39,
 		/obj/item/weapon/gun/smg/mp27,

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -1502,22 +1502,23 @@ Defined in conflicts.dm of the #defines folder.
 	attach_icon = "smgstock_a"
 	pixel_shift_x = 42
 	pixel_shift_y = 11
-	wield_delay_mod = WIELD_DELAY_FAST
 	hud_offset_mod = 5
 
 /obj/item/attachable/stock/smg/New()
 	..()
 	accuracy_mod = HIT_ACCURACY_MULT_TIER_7
-	recoil_mod = -RECOIL_AMOUNT_TIER_3
-	scatter_mod = -SCATTER_AMOUNT_TIER_6
+	recoil_mod = -RECOIL_AMOUNT_TIER_4
+	scatter_mod = -SCATTER_AMOUNT_TIER_8
+	burst_scatter_mod = -2
 	delay_mod = 0
+	wield_delay_mod = WIELD_DELAY_FAST
 	movement_onehanded_acc_penalty_mod = -MOVEMENT_ACCURACY_PENALTY_MULT_TIER_5
 	aim_speed_mod = CONFIG_GET(number/slowdown_low)
 
 
 /obj/item/attachable/stock/smg/collapsible
 	name = "submachinegun folding stock"
-	desc = "A Kirchner brand K2 M39 folding stock, standard issue in the USCM. The stock, when extended, reduces recoil and improves accuracy, but at a reduction to handling and agility. Seemingly a bit more effective in a brawl. This stock can collapse in, removing almost all positive and negative effects, however it slightly increases spread due to weapon being off-balanced by the collapsed stock."
+	desc = "A Kirchner brand K2 M39 folding stock, standard issue in the USCM. The stock, when extended, reduces recoil and improves accuracy, but at a reduction to handling and size. Seemingly a bit more effective in a brawl. This stock can collapse in, removing all positive and negative effects."
 	slot = "stock"
 	melee_mod = 10
 	size_mod = 1
@@ -1534,26 +1535,24 @@ Defined in conflicts.dm of the #defines folder.
 /obj/item/attachable/stock/smg/collapsible/New()
 	..()
 	//it makes stuff much better when two-handed
-	accuracy_mod = HIT_ACCURACY_MULT_TIER_3
+	accuracy_mod = HIT_ACCURACY_MULT_TIER_4
 	recoil_mod = -RECOIL_AMOUNT_TIER_4
 	scatter_mod = -SCATTER_AMOUNT_TIER_8
-	wield_delay_mod = WIELD_DELAY_FAST
+	wield_delay_mod = WIELD_DELAY_VERY_FAST
+	burst_scatter_mod = -1
 	delay_mod = 0
 	movement_onehanded_acc_penalty_mod = -MOVEMENT_ACCURACY_PENALTY_MULT_TIER_5
 	//it makes stuff much worse when one handed
 	accuracy_unwielded_mod = -HIT_ACCURACY_MULT_TIER_3
 	recoil_unwielded_mod = RECOIL_AMOUNT_TIER_4
 	scatter_unwielded_mod = SCATTER_AMOUNT_TIER_10
-	//but at the same time you are slowish when 2 handed
-	aim_speed_mod = CONFIG_GET(number/slowdown_low)
 
 
 /obj/item/attachable/stock/smg/collapsible/apply_on_weapon(obj/item/weapon/gun/gun)
 	if(stock_activated)
 		scatter_unwielded_mod = SCATTER_AMOUNT_TIER_10
 		size_mod = 1
-		aim_speed_mod = CONFIG_GET(number/slowdown_low)
-		wield_delay_mod = WIELD_DELAY_FAST
+		wield_delay_mod = WIELD_DELAY_VERY_FAST
 		movement_onehanded_acc_penalty_mod = -MOVEMENT_ACCURACY_PENALTY_MULT_TIER_5
 		accuracy_unwielded_mod = -HIT_ACCURACY_MULT_TIER_3
 		recoil_unwielded_mod = RECOIL_AMOUNT_TIER_4
@@ -1563,12 +1562,13 @@ Defined in conflicts.dm of the #defines folder.
 
 	else
 		scatter_unwielded_mod = 0
+		burst_scatter_mod = 0
 		size_mod = 0
 		aim_speed_mod = 0
 		wield_delay_mod = 0
 		movement_onehanded_acc_penalty_mod = 0
-		accuracy_unwielded_mod = -HIT_ACCURACY_MULT_TIER_1
-		recoil_unwielded_mod = RECOIL_AMOUNT_TIER_5
+		accuracy_unwielded_mod = 0
+		recoil_unwielded_mod = 0
 		hud_offset_mod = 3
 		icon_state = "smgstockcc"
 		attach_icon = "smgstockcc_a"

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -1493,8 +1493,8 @@ Defined in conflicts.dm of the #defines folder.
 	hud_offset_mod = 10 //A sprite long enough to touch the Moon.
 
 /obj/item/attachable/stock/smg
-	name = "submachinegun stock"
-	desc = "A rare ARMAT stock distributed in small numbers to USCM forces. Compatible with the M39, this stock reduces recoil and improves accuracy, but at a reduction to handling and agility. Seemingly a bit more effective in a brawl"
+	name = "submachinegun solid stock"
+	desc = "A rare ARMAT solid stock distributed in small numbers to USCM forces. Compatible with the M39, this stock reduces recoil and improves accuracy, but at a reduction to handling and agility. Seemingly a bit more effective in a brawl"
 	slot = "stock"
 	melee_mod = 15
 	size_mod = 1
@@ -1506,19 +1506,21 @@ Defined in conflicts.dm of the #defines folder.
 
 /obj/item/attachable/stock/smg/New()
 	..()
+	//buffs
 	accuracy_mod = HIT_ACCURACY_MULT_TIER_7
 	recoil_mod = -RECOIL_AMOUNT_TIER_4
 	scatter_mod = -SCATTER_AMOUNT_TIER_8
 	burst_scatter_mod = -2
-	delay_mod = 0
-	wield_delay_mod = WIELD_DELAY_FAST
-	movement_onehanded_acc_penalty_mod = -MOVEMENT_ACCURACY_PENALTY_MULT_TIER_5
+	//debuffs
+	wield_delay_mod = WIELD_DELAY_VERY_FAST
 	aim_speed_mod = CONFIG_GET(number/slowdown_low)
-
+	accuracy_unwielded_mod = -HIT_ACCURACY_MULT_TIER_10
+	recoil_unwielded_mod = RECOIL_AMOUNT_TIER_3
+	scatter_unwielded_mod = SCATTER_AMOUNT_TIER_10
 
 /obj/item/attachable/stock/smg/collapsible
 	name = "submachinegun folding stock"
-	desc = "A Kirchner brand K2 M39 folding stock, standard issue in the USCM. The stock, when extended, reduces recoil and improves accuracy, but at a reduction to handling and size. Seemingly a bit more effective in a brawl. This stock can collapse in, removing all positive and negative effects."
+	desc = "A Kirchner brand K2 M39 folding stock, standard issue in the USCM. The stock, when extended, reduces recoil and improves accuracy, but at a reduction to handling. Seemingly a bit more effective in a brawl. This stock can collapse in allowing it to fit on a belt."
 	slot = "stock"
 	melee_mod = 10
 	size_mod = 1
@@ -1540,7 +1542,6 @@ Defined in conflicts.dm of the #defines folder.
 	scatter_mod = -SCATTER_AMOUNT_TIER_8
 	wield_delay_mod = WIELD_DELAY_VERY_FAST
 	burst_scatter_mod = -1
-	delay_mod = 0
 	movement_onehanded_acc_penalty_mod = -MOVEMENT_ACCURACY_PENALTY_MULT_TIER_5
 	//it makes stuff much worse when one handed
 	accuracy_unwielded_mod = -HIT_ACCURACY_MULT_TIER_3

--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -48,6 +48,7 @@
 		/obj/item/attachable/reddot,
 		/obj/item/attachable/reflex,
 		/obj/item/attachable/angledgrip,
+		/obj/item/attachable/verticalgrip,
 		/obj/item/attachable/flashlight/grip,
 		/obj/item/attachable/stock/smg,
 		/obj/item/attachable/stock/smg/collapsible,

--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -81,7 +81,7 @@
 	accuracy_mult = BASE_ACCURACY_MULT
 	accuracy_mult_unwielded = BASE_ACCURACY_MULT - HIT_ACCURACY_MULT_TIER_5
 	scatter = SCATTER_AMOUNT_TIER_4
-	burst_scatter_mult = SCATTER_AMOUNT_TIER_4
+	burst_scatter_mult = SCATTER_AMOUNT_TIER_7
 	scatter_unwielded = SCATTER_AMOUNT_TIER_4
 	damage_mult = BASE_BULLET_DAMAGE_MULT
 	recoil_unwielded = RECOIL_AMOUNT_TIER_5

--- a/code/modules/projectiles/magazines/smgs.dm
+++ b/code/modules/projectiles/magazines/smgs.dm
@@ -14,7 +14,7 @@
 	caliber = "10x20mm"
 	icon_state = "m39_HV"
 	max_rounds = 48
-	w_class = SIZE_MEDIUM
+	w_class = SIZE_SMALL
 	gun_type = /obj/item/weapon/gun/smg/m39
 	default_ammo = /datum/ammo/bullet/smg/m39
 
@@ -70,6 +70,7 @@
 	name = "\improper M39 HV extended magazine (10x20mm)"
 	desc = "A 10x20mm caseless HV extended submachinegun magazine. Powerful propellant allows the bullet increased travel speed and minor penetration capabilities, noticeably improving its efficacy at long ranges, although it still suffers significantly compared to a rifle bullet."
 	max_rounds = 72
+	w_class = SIZE_MEDIUM // big ammo big size DUHH
 	icon_state = "m39_HV_extended"
 	bonus_overlay = "m39_ex"
 

--- a/code/modules/projectiles/magazines/smgs.dm
+++ b/code/modules/projectiles/magazines/smgs.dm
@@ -14,7 +14,7 @@
 	caliber = "10x20mm"
 	icon_state = "m39_HV"
 	max_rounds = 48
-	w_class = SIZE_SMALL
+	w_class = SIZE_MEDIUM
 	gun_type = /obj/item/weapon/gun/smg/m39
 	default_ammo = /datum/ammo/bullet/smg/m39
 
@@ -70,7 +70,6 @@
 	name = "\improper M39 HV extended magazine (10x20mm)"
 	desc = "A 10x20mm caseless HV extended submachinegun magazine. Powerful propellant allows the bullet increased travel speed and minor penetration capabilities, noticeably improving its efficacy at long ranges, although it still suffers significantly compared to a rifle bullet."
 	max_rounds = 72
-	w_class = SIZE_MEDIUM // big ammo big size DUHH
 	icon_state = "m39_HV_extended"
 	bonus_overlay = "m39_ex"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Changes some mechanics of how M39 works and puts it on pair with other primary weapons winout making it the best sidegun in the game.

**M39 Holster**
Reduced Maximun Weight class to 4 . which will now require you to fold your stock and not have any attachment like grips on your weapon in order to store it.

**Foldable and Solid stock**
Took away slowdown from foldable stock . reason ? currently M39 was SLOWER than L42 with stock( 0.35 and 0.45) . this should aleaviate the speed difference betwen the best chasing weapon and M39.

Folded M39 stock no longer makes your weapon worse than having it stockless. making it be in pair with the other folding stocks.

Solid M39 stock received some stats from Folded M39 stock to make it an "upgrade" in exchange of the inability to be stored in belts + extra Wield delay.

Folded M39 Stock wield delay changed from Fast to Very Fast to compensate the inability of using grips.

Foldable and Solid stock now provide -1 and -2 burst scatter reduction while active.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->
This PR aims to make M39 a Primary weapon that is actually worth using winout turning it into a laser beam of death like it used to be.

**Why the holdster nerf ?**
while it provides a cool mechanic for the weapon it also restricts the abuse of this weapon preventing 3 weapon builds and similars and rewards players that use a entire weapon slot for the use of the weapon.
(Will add an audio effect soon)

**slowdown and wield delay**
While this weapon was supposed to be a chasing weapon . it was somehow slower than a Marksman rifle thus making marines loose chases with the gun and eventually just discarting it as a valid option . this PR aims to fix that issue and instead transfer the slow to the Solid stock.

## Changelog

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: M39 Holster now requires the weapon to be folded and winout attachments that change its size.
balance: Adjusted Folding and Solid Stock stadistics to be in pair with other stocks.
balance: M39 is able to use vertical grips again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
