### PR TITLE
Adds a preference for vendors vending directly into your hand.

### DIFF
--- a/code/__DEFINES/mode.dm
+++ b/code/__DEFINES/mode.dm
@@ -91,6 +91,7 @@
 #define TOGGLE_OOC_FLAG						(1<<12) // determines if your country flag appears by your name in ooc chat
 #define TOGGLE_MIDDLE_MOUSE_SWAP_HANDS		(1<<13) //Toggle whether middle click swaps your hands
 #define TOGGLE_AMBIENT_OCCLUSION            (1<<14) // toggles if ambient occlusion is turned on or off
+#define TOGGLE_VEND_ITEM_TO_HAND            (1<<15) // This toggles whether items from vendors will be automatically put into your hand.
 
 //=================================================
 #define SHOW_ITEM_ANIMATIONS_NONE				0 //Do not show any item pickup animations

--- a/code/game/machinery/vending/cm_vending.dm
+++ b/code/game/machinery/vending/cm_vending.dm
@@ -1023,8 +1023,8 @@ proc/vendor_successful_vend(var/obj/structure/machinery/cm_vending/vendor, var/l
 				else
 					user.equip_to_appropriate_slot(new_item)
 
-		if (user.client?.prefs && (user.client?.prefs?.toggle_prefs & TOGGLE_VEND_ITEM_TO_HAND))
-			if(vend_flags & VEND_TO_HAND)
+		if(vend_flags & VEND_TO_HAND)
+			if (user.client?.prefs && (user.client?.prefs?.toggle_prefs & TOGGLE_VEND_ITEM_TO_HAND))
 				user.put_in_any_hand_if_possible(new_item, disable_warning = TRUE)
 	else
 		to_chat(user, SPAN_WARNING("ERROR: itemspec is missing. Please report this to admins."))

--- a/code/game/machinery/vending/cm_vending.dm
+++ b/code/game/machinery/vending/cm_vending.dm
@@ -1023,8 +1023,9 @@ proc/vendor_successful_vend(var/obj/structure/machinery/cm_vending/vendor, var/l
 				else
 					user.equip_to_appropriate_slot(new_item)
 
-		if(vend_flags & VEND_TO_HAND)
-			user.put_in_any_hand_if_possible(new_item, disable_warning = TRUE)
+		if (user.client?.prefs && (user.client?.prefs?.toggle_prefs & TOGGLE_VEND_ITEM_TO_HAND))
+			if(vend_flags & VEND_TO_HAND)
+				user.put_in_any_hand_if_possible(new_item, disable_warning = TRUE)
 	else
 		to_chat(user, SPAN_WARNING("ERROR: itemspec is missing. Please report this to admins."))
 		sleep(15)

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -49,6 +49,7 @@ GLOBAL_LIST_INIT(whitelisted_client_procs, list(
 	/client/proc/toggle_clickdrag_override,
 	/client/proc/toggle_dualwield,
 	/client/proc/toggle_middle_mouse_swap_hands,
+	/client/proc/toggle_vend_item_to_hand,
 	/client/proc/switch_item_animations
 ))
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -588,6 +588,8 @@ var/const/MAX_SAVE_SLOTS = 10
 					</b> <a href='?_src_=prefs;preference=toggle_prefs;flag=[TOGGLE_ALTERNATING_DUAL_WIELD]'><b>[toggle_prefs & TOGGLE_ALTERNATING_DUAL_WIELD ? "On" : "Off"]</b></a><br>"
 			dat += "<b>Toggle Middle-Click Swap Hands: \
 					</b> <a href='?_src_=prefs;preference=toggle_prefs;flag=[TOGGLE_MIDDLE_MOUSE_SWAP_HANDS]'><b>[toggle_prefs & TOGGLE_MIDDLE_MOUSE_SWAP_HANDS ? "On" : "Off"]</b></a><br>"
+			dat += "<b>Toggle Vendors Vending to Hands: \
+					</b> <a href='?_src_=prefs;preference=toggle_prefs;flag=[TOGGLE_VEND_ITEM_TO_HAND]'><b>[toggle_prefs & TOGGLE_VEND_ITEM_TO_HAND ? "On" : "Off"]</b></a><br>"
 			dat += "<a href='?src=\ref[src];action=proccall;procpath=/client/proc/switch_item_animations'>Toggle Item Animations Detail Level</a><br>"
 		if(MENU_ERT) //wart
 			dat += "<div id='column1'>"

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -48,7 +48,7 @@ var/const/MAX_SAVE_SLOTS = 10
 	var/lastchangelog = ""				// Saved changlog filesize to detect if there was a change
 	var/ooccolor
 	var/be_special = 0				// Special role selection
-	var/toggle_prefs = TOGGLE_MIDDLE_MOUSE_CLICK|TOGGLE_DIRECTIONAL_ATTACK|TOGGLE_MEMBER_PUBLIC|TOGGLE_AMBIENT_OCCLUSION // flags in #define/mode.dm
+	var/toggle_prefs = TOGGLE_MIDDLE_MOUSE_CLICK|TOGGLE_DIRECTIONAL_ATTACK|TOGGLE_MEMBER_PUBLIC|TOGGLE_AMBIENT_OCCLUSION|TOGGLE_VEND_ITEM_TO_HAND // flags in #define/mode.dm
 	var/UI_style = "midnight"
 	var/toggles_admin = TOGGLES_ADMIN_DEFAULT
 	var/toggles_chat = TOGGLES_CHAT_DEFAULT

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -1,5 +1,5 @@
 #define SAVEFILE_VERSION_MIN	8
-#define SAVEFILE_VERSION_MAX	18
+#define SAVEFILE_VERSION_MAX	19
 
 //handles converting savefiles to new formats
 //MAKE SURE YOU KEEP THIS UP TO DATE!
@@ -67,6 +67,12 @@
 		S["toggle_prefs"] >> pref_toggles
 		pref_toggles |= TOGGLE_AMBIENT_OCCLUSION
 		S["toggle_prefs"] << pref_toggles
+
+	if(savefile_version < 19) // toggles vending to hand by default
+		var/pref_toggle_vend_item_tohand
+		S["toggle_prefs"] >> pref_toggle_vend_item_tohand
+		pref_toggle_vend_item_tohand |= TOGGLE_VEND_ITEM_TO_HAND
+		S["toggle_prefs"] << pref_toggle_vend_item_tohand
 	savefile_version = SAVEFILE_VERSION_MAX
 	return 1
 

--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -271,7 +271,7 @@
 		"<a href='?src=\ref[src];action=proccall;procpath=/client/proc/toggle_clickdrag_override'>Toggle Combat Click-Drag Override</a><br>",
 		"<a href='?src=\ref[src];action=proccall;procpath=/client/proc/toggle_dualwield'>Toggle Alternate-Fire Dual Wielding</a><br>",
 		"<a href='?src=\ref[src];action=proccall;procpath=/client/proc/toggle_middle_mouse_swap_hands'>Toggle Middle Mouse Swapping Hands</a><br>",
-		"<a href='?src=\ref[src];action=proccall;procpath=/client/proc/toggle_vend_item_to_hand'>Toggle Vendors Vending to Hand</a><br>",
+		"<a href='?src=\ref[src];action=proccall;procpath=/client/proc/toggle_vend_item_to_hand'>Toggle Vendors Vending to Hands</a><br>",
 		"<a href='?src=\ref[src];action=proccall;procpath=/client/proc/switch_item_animations'>Toggle Item Animations</a><br>"
 	)
 

--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -271,6 +271,7 @@
 		"<a href='?src=\ref[src];action=proccall;procpath=/client/proc/toggle_clickdrag_override'>Toggle Combat Click-Drag Override</a><br>",
 		"<a href='?src=\ref[src];action=proccall;procpath=/client/proc/toggle_dualwield'>Toggle Alternate-Fire Dual Wielding</a><br>",
 		"<a href='?src=\ref[src];action=proccall;procpath=/client/proc/toggle_middle_mouse_swap_hands'>Toggle Middle Mouse Swapping Hands</a><br>",
+		"<a href='?src=\ref[src];action=proccall;procpath=/client/proc/toggle_vend_item_to_hand'>Toggle Vendors Vending to Hand</a><br>",
 		"<a href='?src=\ref[src];action=proccall;procpath=/client/proc/switch_item_animations'>Toggle Item Animations</a><br>"
 	)
 
@@ -365,6 +366,14 @@
 /client/proc/toggle_middle_mouse_swap_hands() //Toggle whether middle click swaps your hands
 	prefs.toggle_prefs ^= TOGGLE_MIDDLE_MOUSE_SWAP_HANDS
 	to_chat(src, SPAN_BOLDNOTICE("Middle Click [(prefs.toggle_prefs & TOGGLE_MIDDLE_MOUSE_SWAP_HANDS) ? "will" : "will no longer"] swap your hands."))
+	prefs.save_preferences()
+
+/client/proc/toggle_vend_item_to_hand() //Toggle whether vendors automatically vend to your hands
+	prefs.toggle_prefs ^= TOGGLE_VEND_ITEM_TO_HAND
+	if(prefs.toggle_prefs & TOGGLE_VEND_ITEM_TO_HAND)
+		to_chat(src, SPAN_BOLDNOTICE("Most vendors will now automatically vend directly into your hands."))
+	else
+		to_chat(src, SPAN_BOLDNOTICE("Vendors will no longer vend into your hands."))
 	prefs.save_preferences()
 
 /client/proc/switch_item_animations() //Switches tg-style item animations on, not-on-same-tile, and off


### PR DESCRIPTION
## About The Pull Request

This adds a preference (should be on by default) for vendors vending items directly into your hand when applicable. Toggling it off means you no longer have items vend into your hands.

## Why It's Good For The Game

Originally I wasn't going to PR this, but Stan said he'd be fine with it. A few people were complaining about the recent QOL change by ThePiachu, which gave vendors the VEND_TO_HAND flag. This preference lets those people have the option of doing things the old way. This is consistent with other preferences, and it's nice to let people have the option.

## Changelog

:cl:
qol: added a "Toggle Vendors Vending to Hands" to preferences
/:cl:

