### PR TITLE
Removal of PMC corpses from maps, Rise Of Goons

### DIFF
--- a/code/game/objects/effects/landmarks/corpsespawner.dm
+++ b/code/game/objects/effects/landmarks/corpsespawner.dm
@@ -96,7 +96,7 @@
 
 /obj/effect/landmark/corpsespawner/wygoon
 	name = "Weyland-Yutani Corporate Security Goon"
-	equip_path = /datum/equipment_preset/corpse/wysec
+	equip_path = /datum/equipment_preset/corpse/pmc/goon
 
 
 ///CM specific jobs///

--- a/code/game/objects/effects/landmarks/corpsespawner.dm
+++ b/code/game/objects/effects/landmarks/corpsespawner.dm
@@ -94,6 +94,11 @@
 	name = "Weyland-Yutani Corporate Security Guard"
 	equip_path = /datum/equipment_preset/corpse/wysec
 
+/obj/effect/landmark/corpsespawner/wygoon
+	name = "Weyland-Yutani Corporate Security Goon"
+	equip_path = /datum/equipment_preset/corpse/wysec
+
+
 ///CM specific jobs///
 
 /obj/effect/landmark/corpsespawner/colonist //default is a colonist

--- a/code/modules/gear_presets/corpses.dm
+++ b/code/modules/gear_presets/corpses.dm
@@ -831,6 +831,49 @@
 	name = "Corpse - Burst Weyland-Yutani PMC (Standard)"
 	xenovictim = TRUE
 
+/datum/equipment_preset/corpse/pmc/goon
+	name = "Corpse - Weyland-Yutani Corporate (Goon)"
+	languages = list(LANGUAGE_ENGLISH)
+	assignment = JOB_WY_GOON
+	rank = JOB_WY_GOON
+	paygrade = "WEY-GOON"
+	skills = /datum/skills/MP
+
+/datum/equipment_preset/corpse/pmc/goon/load_gear(mob/living/carbon/human/H)
+	H.equip_to_slot_or_del(new /obj/item/device/radio/headset/distress/goon, WEAR_L_EAR)
+	H.equip_to_slot_or_del(new /obj/item/clothing/under/marine/veteran/PMC/corporate, WEAR_BODY)
+	H.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/marine/veteran/PMC/light/corporate, WEAR_JACKET)
+	H.equip_to_slot_or_del(new /obj/item/clothing/gloves/marine/veteran, WEAR_HANDS)
+	H.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/marine/veteran/PMC/corporate, WEAR_HEAD)
+	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/marine/corporate, WEAR_FEET)
+
+	H.equip_to_slot_or_del(new /obj/item/storage/backpack/lightpack, WEAR_BACK)
+	H.equip_to_slot_or_del(new /obj/item/weapon/melee/baton, WEAR_IN_BACK)
+	H.equip_to_slot_or_del(new /obj/item/tool/crowbar, WEAR_IN_BACK)
+	H.equip_to_slot_or_del(new /obj/item/storage/belt/gun/m4a3/mod88_near_empty, WEAR_WAIST)
+	H.equip_to_slot_or_del(new /obj/item/storage/pouch/firstaid/full, WEAR_R_STORE)
+
+/datum/equipment_preset/corpse/pmc/goon/lead
+	name = "Weyland-Yutani Corporate Security Lead (Goon Lead)"
+	flags = EQUIPMENT_PRESET_EXTRA
+	assignment = JOB_WY_GOON_LEAD
+	rank = JOB_WY_GOON_LEAD
+	paygrade = "WEY-GOON-L"
+
+/datum/equipment_preset/corpse/pmc/goon/lead/load_gear(mob/living/carbon/human/H)
+	H.equip_to_slot_or_del(new /obj/item/device/radio/headset/distress/goon, WEAR_L_EAR)
+	H.equip_to_slot_or_del(new /obj/item/clothing/under/marine/veteran/PMC/corporate/lead, WEAR_BODY)
+	H.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/marine/veteran/PMC/light/corporate/lead, WEAR_JACKET)
+	H.equip_to_slot_or_del(new /obj/item/clothing/gloves/marine/veteran, WEAR_HANDS)
+	H.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/marine/veteran/PMC/corporate/lead, WEAR_HEAD)
+	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/marine/corporate, WEAR_FEET)
+
+	H.equip_to_slot_or_del(new /obj/item/storage/backpack/lightpack, WEAR_BACK)
+	H.equip_to_slot_or_del(new /obj/item/weapon/melee/baton, WEAR_IN_BACK)
+	H.equip_to_slot_or_del(new /obj/item/tool/crowbar, WEAR_IN_BACK)
+	H.equip_to_slot_or_del(new /obj/item/storage/belt/gun/m4a3/mod88_near_empty, WEAR_WAIST)
+	H.equip_to_slot_or_del(new /obj/item/storage/pouch/firstaid/full, WEAR_R_STORE)
+
 // Freelancer
 
 /datum/equipment_preset/corpse/freelancer

--- a/maps/map_files/BigRed/BigRed.dmm
+++ b/maps/map_files/BigRed/BigRed.dmm
@@ -7367,7 +7367,7 @@
 	tag = "icon-intact-supply (NORTH)"
 	},
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
-/obj/effect/landmark/corpsespawner/wysec,
+/obj/effect/landmark/corpsespawner/pmc,
 /turf/open/floor{
 	icon_state = "darkpurple2";
 	tag = "icon-darkpurple2"
@@ -26819,7 +26819,7 @@
 /area/bigredv2/caves/eta/research)
 "byt" = (
 /obj/structure/bed,
-/obj/effect/landmark/corpsespawner/wysec,
+/obj/effect/landmark/corpsespawner/pmc,
 /turf/open/floor{
 	icon_state = "wood"
 	},

--- a/maps/map_files/BigRed/BigRed.dmm
+++ b/maps/map_files/BigRed/BigRed.dmm
@@ -7362,12 +7362,12 @@
 	},
 /area/bigredv2/caves/lambda/breakroom)
 "ati" = (
-/obj/effect/landmark/corpsespawner/pmc,
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 1;
 	tag = "icon-intact-supply (NORTH)"
 	},
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
+/obj/effect/landmark/corpsespawner/wysec,
 /turf/open/floor{
 	icon_state = "darkpurple2";
 	tag = "icon-darkpurple2"
@@ -26819,7 +26819,7 @@
 /area/bigredv2/caves/eta/research)
 "byt" = (
 /obj/structure/bed,
-/obj/effect/landmark/corpsespawner/pmc,
+/obj/effect/landmark/corpsespawner/wysec,
 /turf/open/floor{
 	icon_state = "wood"
 	},

--- a/maps/map_files/BigRed/sprinkles/40.admin_pmc.dmm
+++ b/maps/map_files/BigRed/sprinkles/40.admin_pmc.dmm
@@ -73,6 +73,11 @@
 	icon_state = "metal_2";
 	dir = 4
 	},
+/obj/item/ammo_magazine/rifle{
+	current_rounds = 0;
+	pixel_x = -9;
+	pixel_y = -4
+	},
 /turf/open/floor,
 /area/bigredv2/outside/admin_building)
 "an" = (
@@ -129,8 +134,7 @@
 	},
 /area/bigredv2/outside/admin_building)
 "au" = (
-/obj/effect/landmark/corpsespawner/pmc,
-/obj/item/weapon/gun/rifle/nsg23/no_lock,
+/obj/effect/landmark/corpsespawner/wysec,
 /turf/open/floor{
 	tag = "icon-carpet11-12 (WEST)";
 	icon_state = "carpet11-12";
@@ -158,8 +162,10 @@
 	},
 /area/bigredv2/outside/admin_building)
 "aA" = (
-/obj/effect/landmark/corpsespawner/pmc,
-/obj/item/weapon/gun/rifle/nsg23/no_lock,
+/obj/effect/landmark/corpsespawner/wysec,
+/obj/item/weapon/gun/rifle/m41a/corporate{
+	pixel_x = -6
+	},
 /turf/open/floor{
 	tag = "icon-carpet7-3 (WEST)";
 	icon_state = "carpet7-3";
@@ -289,12 +295,14 @@
 /turf/open/floor,
 /area/bigredv2/outside/admin_building)
 "aS" = (
-/obj/structure/pipes/standard/simple/hidden/green,
-/obj/effect/landmark/corpsespawner/pmc,
-/obj/item/weapon/gun/rifle/nsg23/no_lock,
+/obj/item/ammo_magazine/rifle/rubber{
+	current_rounds = 3;
+	pixel_x = -3;
+	pixel_y = -6
+	},
 /turf/open/floor{
-	tag = "icon-darkred2 (WEST)";
-	icon_state = "darkred2";
+	tag = "icon-carpet11-12 (WEST)";
+	icon_state = "carpet11-12";
 	dir = 8
 	},
 /area/bigredv2/outside/admin_building)
@@ -318,6 +326,7 @@
 /area/bigredv2/outside/admin_building)
 "aV" = (
 /obj/structure/surface/table,
+/obj/item/ammo_magazine/rifle/rubber,
 /turf/open/floor{
 	tag = "icon-carpet15-15 (WEST)";
 	icon_state = "carpet15-15";
@@ -336,6 +345,12 @@
 "aX" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/effect/landmark/crap_item,
+/obj/item/weapon/gun/rifle/m41a/corporate{
+	current_mag = /obj/item/ammo_magazine/rifle/rubber;
+	name = "battered M41A pulse rifle MK2";
+	pixel_x = 4;
+	desc = "A Weyland-Yutani creation, this M41A MK2 comes equipped in corporate white. Uses 10x24mm caseless ammunition. It seems to be pretty battered and broken up.."
+	},
 /turf/open/floor{
 	tag = "icon-darkred2 (WEST)";
 	icon_state = "darkred2";
@@ -352,6 +367,11 @@
 "aZ" = (
 /obj/structure/machinery/light{
 	dir = 8
+	},
+/obj/item/ammo_magazine/rifle{
+	current_rounds = 0;
+	pixel_x = -2;
+	pixel_y = -10
 	},
 /turf/open/floor{
 	tag = "icon-carpet7-3 (WEST)";
@@ -378,8 +398,7 @@
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
 	},
-/obj/effect/landmark/corpsespawner/pmc,
-/obj/item/weapon/gun/rifle/nsg23/no_lock,
+/obj/effect/landmark/corpsespawner/wysec,
 /turf/open/floor{
 	tag = "icon-carpet15-15 (WEST)";
 	icon_state = "carpet15-15";
@@ -400,6 +419,11 @@
 "bd" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 10
+	},
+/obj/item/ammo_magazine/rifle{
+	current_rounds = 0;
+	pixel_x = -8;
+	pixel_y = 9
 	},
 /turf/open/floor,
 /area/bigredv2/outside/admin_building)
@@ -445,49 +469,8 @@
 	},
 /area/bigredv2/outside/admin_building)
 "bi" = (
-/obj/item/stack/sheet/cardboard{
-	pixel_x = 5;
-	pixel_y = 9
-	},
-/obj/item/ammo_magazine/rifle/nsg23,
-/obj/item/ammo_magazine/rifle/nsg23,
-/obj/item/ammo_magazine/rifle/nsg23{
-	pixel_y = -1;
-	pixel_x = -9
-	},
-/obj/item/ammo_magazine/rifle/nsg23{
-	pixel_y = 7;
-	pixel_x = 15
-	},
-/obj/item/ammo_magazine/rifle/nsg23{
-	pixel_x = 7
-	},
-/obj/item/ammo_magazine/rifle/nsg23{
-	pixel_y = -8
-	},
-/obj/item/ammo_magazine/rifle/nsg23{
-	pixel_y = -1;
-	pixel_x = -17
-	},
-/obj/item/ammo_magazine/rifle/nsg23{
-	pixel_x = -9;
-	pixel_y = -10
-	},
-/obj/item/ammo_magazine/rifle/nsg23{
-	pixel_y = 8;
-	pixel_x = -10
-	},
-/obj/item/ammo_magazine/rifle/nsg23{
-	pixel_y = -9;
-	pixel_x = 5
-	},
-/obj/item/ammo_magazine/rifle/nsg23{
-	pixel_y = 10;
-	pixel_x = -16
-	},
-/obj/item/ammo_magazine/rifle/nsg23{
-	pixel_y = -7;
-	pixel_x = 12
+/obj/item/ammo_box/magazine/ext{
+	num_of_magazines = 1
 	},
 /turf/open/floor{
 	tag = "icon-carpet5-1 (WEST)";
@@ -570,6 +553,110 @@
 	dir = 6
 	},
 /area/bigredv2/outside/admin_building)
+"dp" = (
+/obj/item/ammo_magazine/rifle/rubber{
+	current_rounds = 0;
+	pixel_x = -6;
+	pixel_y = -4
+	},
+/turf/open/floor{
+	tag = "icon-carpet15-15 (WEST)";
+	icon_state = "carpet15-15";
+	dir = 8
+	},
+/area/bigredv2/outside/admin_building)
+"is" = (
+/obj/item/weapon/gun/rifle/m41a/corporate{
+	current_mag = /obj/item/ammo_magazine/rifle/rubber;
+	name = "battered M41A pulse rifle MK2";
+	pixel_x = 4;
+	desc = "A Weyland-Yutani creation, this M41A MK2 comes equipped in corporate white. Uses 10x24mm caseless ammunition. It seems to be pretty battered and broken up.."
+	},
+/turf/open/floor,
+/area/bigredv2/outside/admin_building)
+"jq" = (
+/obj/item/weapon/gun/rifle/m41a/corporate{
+	current_mag = /obj/item/ammo_magazine/rifle/rubber;
+	name = "battered M41A pulse rifle MK2";
+	pixel_x = 4;
+	desc = "A Weyland-Yutani creation, this M41A MK2 comes equipped in corporate white. Uses 10x24mm caseless ammunition. It seems to be pretty battered and broken up.."
+	},
+/turf/open/floor{
+	tag = "icon-carpet15-15 (WEST)";
+	icon_state = "carpet15-15";
+	dir = 8
+	},
+/area/bigredv2/outside/admin_building)
+"lz" = (
+/obj/item/ammo_magazine/rifle/rubber{
+	current_rounds = 0;
+	pixel_y = 11
+	},
+/turf/open/floor{
+	tag = "icon-carpet7-3 (WEST)";
+	icon_state = "carpet7-3";
+	dir = 8
+	},
+/area/bigredv2/outside/admin_building)
+"rv" = (
+/obj/item/ammo_magazine/rifle{
+	current_rounds = 0
+	},
+/turf/open/floor{
+	tag = "icon-carpet7-3 (WEST)";
+	icon_state = "carpet7-3";
+	dir = 8
+	},
+/area/bigredv2/outside/admin_building)
+"si" = (
+/obj/item/ammo_box/magazine{
+	num_of_magazines = 2
+	},
+/obj/item/ammo_magazine/rifle{
+	current_rounds = 0;
+	pixel_x = -8;
+	pixel_y = 13
+	},
+/obj/item/ammo_magazine/rifle{
+	current_rounds = 0;
+	pixel_x = 14;
+	pixel_y = 17
+	},
+/turf/open/floor{
+	tag = "icon-carpet13-5 (WEST)";
+	icon_state = "carpet13-5";
+	dir = 8
+	},
+/area/bigredv2/outside/admin_building)
+"uv" = (
+/obj/item/ammo_magazine/rifle{
+	current_rounds = 0;
+	pixel_y = 7;
+	pixel_x = -9
+	},
+/turf/open/floor,
+/area/bigredv2/outside/admin_building)
+"Br" = (
+/obj/structure/surface/table,
+/obj/item/storage/firstaid/regular/empty,
+/turf/open/floor{
+	tag = "icon-carpet15-15 (WEST)";
+	icon_state = "carpet15-15";
+	dir = 8
+	},
+/area/bigredv2/outside/admin_building)
+"Sz" = (
+/obj/item/ammo_magazine/rifle/rubber{
+	current_rounds = 0;
+	pixel_x = 5;
+	pixel_y = -5
+	},
+/turf/open/floor{
+	tag = "icon-carpet15-15 (WEST)";
+	icon_state = "carpet15-15";
+	dir = 8
+	},
+/area/bigredv2/outside/admin_building)
 
 (1,1,1) = {"
 ab
@@ -588,9 +675,9 @@ ac
 aD
 ar
 aA
+lz
 aI
-aI
-aI
+rv
 aZ
 bi
 ab
@@ -598,13 +685,13 @@ ab
 (3,1,1) = {"
 aj
 ak
-as
+dp
 as
 aJ
 aO
 aJ
 as
-bj
+si
 bp
 "}
 (4,1,1) = {"
@@ -613,20 +700,20 @@ ak
 at
 aB
 aK
-aV
+Br
 aV
 ba
 bj
-aR
+uv
 "}
 (5,1,1) = {"
 aj
 ak
-as
+jq
 aC
 as
 aC
-as
+Sz
 bb
 bj
 aR
@@ -637,11 +724,11 @@ al
 au
 aW
 aL
-aQ
+aS
 aQ
 bc
 bk
-aR
+is
 "}
 (7,1,1) = {"
 ad
@@ -673,7 +760,7 @@ an
 an
 be
 aM
-aS
+an
 aX
 be
 bn

--- a/maps/map_files/BigRed/sprinkles/40.admin_pmc.dmm
+++ b/maps/map_files/BigRed/sprinkles/40.admin_pmc.dmm
@@ -163,9 +163,6 @@
 /area/bigredv2/outside/admin_building)
 "aA" = (
 /obj/effect/landmark/corpsespawner/wysec,
-/obj/item/weapon/gun/rifle/m41a/corporate{
-	pixel_x = -6
-	},
 /turf/open/floor{
 	tag = "icon-carpet7-3 (WEST)";
 	icon_state = "carpet7-3";
@@ -239,6 +236,10 @@
 /obj/structure/surface/table,
 /obj/item/device/radio/marine,
 /obj/effect/landmark/objective_landmark/medium,
+/obj/item/weapon/gun/pistol/m4a3/training{
+	name = "dented M4A3 service pistol"
+	},
+/obj/item/ammo_magazine/pistol/rubber,
 /turf/open/floor{
 	tag = "icon-carpet15-15 (WEST)";
 	icon_state = "carpet15-15";
@@ -345,12 +346,6 @@
 "aX" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/effect/landmark/crap_item,
-/obj/item/weapon/gun/rifle/m41a/corporate{
-	current_mag = /obj/item/ammo_magazine/rifle/rubber;
-	name = "battered M41A pulse rifle MK2";
-	pixel_x = 4;
-	desc = "A Weyland-Yutani creation, this M41A MK2 comes equipped in corporate white. Uses 10x24mm caseless ammunition. It seems to be pretty battered and broken up.."
-	},
 /turf/open/floor{
 	tag = "icon-darkred2 (WEST)";
 	icon_state = "darkred2";
@@ -372,6 +367,9 @@
 	current_rounds = 0;
 	pixel_x = -2;
 	pixel_y = -10
+	},
+/obj/item/ammo_box/magazine/m4a3{
+	num_of_magazines = 2
 	},
 /turf/open/floor{
 	tag = "icon-carpet7-3 (WEST)";
@@ -566,11 +564,8 @@
 	},
 /area/bigredv2/outside/admin_building)
 "is" = (
-/obj/item/weapon/gun/rifle/m41a/corporate{
-	current_mag = /obj/item/ammo_magazine/rifle/rubber;
-	name = "battered M41A pulse rifle MK2";
-	pixel_x = 4;
-	desc = "A Weyland-Yutani creation, this M41A MK2 comes equipped in corporate white. Uses 10x24mm caseless ammunition. It seems to be pretty battered and broken up.."
+/obj/item/ammo_magazine/pistol/rubber{
+	current_rounds = 0
 	},
 /turf/open/floor,
 /area/bigredv2/outside/admin_building)
@@ -636,6 +631,16 @@
 	},
 /turf/open/floor,
 /area/bigredv2/outside/admin_building)
+"AC" = (
+/obj/item/ammo_magazine/pistol/rubber{
+	current_rounds = 0
+	},
+/turf/open/floor{
+	tag = "icon-carpet15-15 (WEST)";
+	icon_state = "carpet15-15";
+	dir = 8
+	},
+/area/bigredv2/outside/admin_building)
 "Br" = (
 /obj/structure/surface/table,
 /obj/item/storage/firstaid/regular/empty,
@@ -644,6 +649,15 @@
 	icon_state = "carpet15-15";
 	dir = 8
 	},
+/area/bigredv2/outside/admin_building)
+"QR" = (
+/obj/structure/barricade/metal/wired{
+	dir = 4
+	},
+/obj/item/ammo_magazine/pistol/rubber{
+	current_rounds = 0
+	},
+/turf/open/floor,
 /area/bigredv2/outside/admin_building)
 "Sz" = (
 /obj/item/ammo_magazine/rifle/rubber{
@@ -686,7 +700,7 @@ ab
 aj
 ak
 dp
-as
+AC
 aJ
 aO
 aJ
@@ -736,7 +750,7 @@ am
 av
 aP
 aP
-aP
+QR
 aP
 bd
 bl

--- a/maps/map_files/BigRed/sprinkles/40.admin_pmc.dmm
+++ b/maps/map_files/BigRed/sprinkles/40.admin_pmc.dmm
@@ -134,7 +134,7 @@
 	},
 /area/bigredv2/outside/admin_building)
 "au" = (
-/obj/effect/landmark/corpsespawner/wysec,
+/obj/effect/landmark/corpsespawner/wygoon,
 /turf/open/floor{
 	tag = "icon-carpet11-12 (WEST)";
 	icon_state = "carpet11-12";
@@ -162,7 +162,7 @@
 	},
 /area/bigredv2/outside/admin_building)
 "aA" = (
-/obj/effect/landmark/corpsespawner/wysec,
+/obj/effect/landmark/corpsespawner/wygoon,
 /turf/open/floor{
 	tag = "icon-carpet7-3 (WEST)";
 	icon_state = "carpet7-3";
@@ -396,7 +396,7 @@
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
 	},
-/obj/effect/landmark/corpsespawner/wysec,
+/obj/effect/landmark/corpsespawner/wygoon,
 /turf/open/floor{
 	tag = "icon-carpet15-15 (WEST)";
 	icon_state = "carpet15-15";

--- a/maps/map_files/BigRed/standalone/crashlanding-eva.dmm
+++ b/maps/map_files/BigRed/standalone/crashlanding-eva.dmm
@@ -269,7 +269,7 @@
 /turf/open/floor/plating,
 /area/bigredv2/outside/general_offices)
 "bq" = (
-/obj/effect/landmark/corpsespawner/pmc,
+/obj/effect/landmark/corpsespawner/wysec,
 /turf/open/shuttle/dropship{
 	icon_state = "rasputin15";
 	tag = "icon-rasputin15"
@@ -291,7 +291,7 @@
 /area/bigredv2/outside/general_offices)
 "bt" = (
 /obj/effect/decal/cleanable/blood,
-/obj/effect/landmark/corpsespawner/pmc,
+/obj/effect/landmark/corpsespawner/wysec,
 /turf/open/shuttle/dropship{
 	icon_state = "rasputin3";
 	tag = "icon-rasputin3"
@@ -1279,7 +1279,7 @@
 /area/bigredv2/outside/general_offices)
 "Zt" = (
 /obj/structure/bed/chair/dropship/passenger,
-/obj/effect/landmark/corpsespawner/pmc,
+/obj/effect/landmark/corpsespawner/wysec,
 /turf/open/shuttle/dropship{
 	icon_state = "rasputin15";
 	tag = "icon-rasputin15"

--- a/maps/map_files/BigRed/standalone/crashlanding-eva.dmm
+++ b/maps/map_files/BigRed/standalone/crashlanding-eva.dmm
@@ -269,7 +269,7 @@
 /turf/open/floor/plating,
 /area/bigredv2/outside/general_offices)
 "bq" = (
-/obj/effect/landmark/corpsespawner/wysec,
+/obj/effect/landmark/corpsespawner/wygoon,
 /turf/open/shuttle/dropship{
 	icon_state = "rasputin15";
 	tag = "icon-rasputin15"
@@ -291,7 +291,7 @@
 /area/bigredv2/outside/general_offices)
 "bt" = (
 /obj/effect/decal/cleanable/blood,
-/obj/effect/landmark/corpsespawner/wysec,
+/obj/effect/landmark/corpsespawner/wygoon,
 /turf/open/shuttle/dropship{
 	icon_state = "rasputin3";
 	tag = "icon-rasputin3"
@@ -1279,7 +1279,7 @@
 /area/bigredv2/outside/general_offices)
 "Zt" = (
 /obj/structure/bed/chair/dropship/passenger,
-/obj/effect/landmark/corpsespawner/wysec,
+/obj/effect/landmark/corpsespawner/wygoon,
 /turf/open/shuttle/dropship{
 	icon_state = "rasputin15";
 	tag = "icon-rasputin15"

--- a/maps/map_files/BigRed/standalone/crashlanding-offices.dmm
+++ b/maps/map_files/BigRed/standalone/crashlanding-offices.dmm
@@ -1236,7 +1236,7 @@
 /area/bigredv2/outside/office_complex)
 "dH" = (
 /obj/effect/decal/cleanable/blood,
-/obj/effect/landmark/corpsespawner/wysec,
+/obj/effect/landmark/corpsespawner/wygoon,
 /turf/open/shuttle/dropship{
 	icon_state = "floor8";
 	tag = "icon-rasputin7"
@@ -1553,7 +1553,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/blood,
-/obj/effect/landmark/corpsespawner/wysec,
+/obj/effect/landmark/corpsespawner/wygoon,
 /turf/open/shuttle/dropship{
 	tag = "icon-rasputin15";
 	icon_state = "rasputin15"
@@ -1615,11 +1615,11 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/blood,
-/obj/effect/landmark/corpsespawner/wysec,
 /obj/item/limb/leg/r_leg,
 /obj/item/weapon/gun/pistol/m4a3/training{
 	name = "dented M4A3 service pistol"
 	},
+/obj/effect/landmark/corpsespawner/wygoon,
 /turf/open/shuttle/dropship{
 	tag = "icon-rasputin15";
 	icon_state = "rasputin15"

--- a/maps/map_files/BigRed/standalone/crashlanding-offices.dmm
+++ b/maps/map_files/BigRed/standalone/crashlanding-offices.dmm
@@ -810,7 +810,10 @@
 	},
 /area/bigredv2/outside/office_complex)
 "cw" = (
-/obj/item/weapon/gun/rifle/nsg23/no_lock/stripped,
+/obj/item/weapon/gun/rifle/nsg23/no_lock/stripped{
+	name = "smashed NSG 23 assault rifle";
+	desc = "A rare sight, this rifle is seen most commonly in the hands of Weyland-Yutani PMCs. Compared to the M41A MK2, it has noticeably improved handling and vastly improved performance at long and medium range, but compares similarly up close. This one seems to have been heavily damaged from impact, you can still see some debris that resembles a scope and underbarrel attachment point on it."
+	},
 /turf/open/shuttle/dropship{
 	tag = "icon-rasputin5";
 	icon_state = "rasputin12"
@@ -1242,8 +1245,6 @@
 "dI" = (
 /obj/structure/surface/rack,
 /obj/item/ammo_magazine/rifle/nsg23,
-/obj/item/ammo_magazine/rifle/nsg23,
-/obj/item/ammo_magazine/rifle/nsg23/extended,
 /obj/item/ammo_magazine/rifle/nsg23/extended,
 /turf/open/shuttle/dropship{
 	tag = "icon-rasputin15";
@@ -1276,7 +1277,6 @@
 /area/bigredv2/outside/office_complex)
 "dM" = (
 /obj/structure/surface/rack,
-/obj/item/storage/firstaid,
 /turf/open/shuttle/dropship{
 	tag = "icon-rasputin15";
 	icon_state = "rasputin15"
@@ -1285,7 +1285,9 @@
 "dN" = (
 /obj/structure/surface/rack,
 /obj/item/device/flashlight,
-/obj/item/weapon/gun/rifle/nsg23/no_lock,
+/obj/item/ammo_magazine/pistol/rubber,
+/obj/item/ammo_magazine/pistol/rubber,
+/obj/item/ammo_magazine/pistol/rubber,
 /turf/open/shuttle/dropship{
 	tag = "icon-rasputin15";
 	icon_state = "rasputin15"
@@ -1492,6 +1494,17 @@
 	icon_state = "rasputin15"
 	},
 /area/bigredv2/outside/office_complex)
+"jx" = (
+/obj/effect/decal/cleanable/blood{
+	icon_state = "gib6";
+	dir = 1
+	},
+/obj/item/limb/leg/l_leg,
+/turf/open/shuttle/dropship{
+	tag = "icon-rasputin3";
+	icon_state = "rasputin3"
+	},
+/area/bigredv2/outside/office_complex)
 "od" = (
 /obj/structure/bed/chair/dropship/passenger{
 	dir = 4
@@ -1526,11 +1539,9 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/blood,
-/obj/item/clothing/gloves/marine/veteran/PMC,
 /obj/effect/spawner/gibspawner/human,
-/obj/item/limb/arm/l_arm,
-/obj/item/limb/leg/l_leg,
-/obj/item/limb/hand/l_hand,
+/obj/item/clothing/head/helmet/marine/veteran/PMC,
+/obj/item/clothing/under/marine/veteran/PMC,
 /obj/item/clothing/head/helmet/marine/veteran/PMC,
 /turf/open/shuttle/dropship{
 	tag = "icon-rasputin15";
@@ -1555,6 +1566,13 @@
 	icon_state = "rasputin3"
 	},
 /area/bigredv2/outside/office_complex)
+"sR" = (
+/obj/item/storage/firstaid,
+/turf/open/shuttle/dropship{
+	tag = "icon-rasputin3";
+	icon_state = "rasputin3"
+	},
+/area/bigredv2/outside/office_complex)
 "uC" = (
 /obj/effect/spawner/gibspawner/human,
 /obj/item/weapon/gun/rifle/m41a/corporate{
@@ -1569,14 +1587,14 @@
 	},
 /area/bigredv2/outside/office_complex)
 "uL" = (
-/obj/item/weapon/gun/rifle/nsg23/no_lock/stripped,
+/obj/item/weapon/gun/rifle/nsg23/no_lock,
 /turf/open/shuttle/dropship{
 	tag = "icon-rasputin3";
 	icon_state = "rasputin3"
 	},
 /area/bigredv2/outside/office_complex)
 "vw" = (
-/obj/item/clothing/under/marine/veteran/PMC,
+/obj/item/limb/arm/l_arm,
 /turf/open/shuttle/dropship{
 	icon_state = "floor8";
 	tag = "icon-rasputin7"
@@ -1599,6 +1617,9 @@
 /obj/effect/decal/cleanable/blood,
 /obj/effect/landmark/corpsespawner/wysec,
 /obj/item/limb/leg/r_leg,
+/obj/item/weapon/gun/pistol/m4a3/training{
+	name = "dented M4A3 service pistol"
+	},
 /turf/open/shuttle/dropship{
 	tag = "icon-rasputin15";
 	icon_state = "rasputin15"
@@ -1613,6 +1634,16 @@
 /turf/open/shuttle/dropship{
 	tag = "icon-rasputin3";
 	icon_state = "rasputin3"
+	},
+/area/bigredv2/outside/office_complex)
+"EE" = (
+/obj/structure/bed/chair/dropship/passenger{
+	dir = 8
+	},
+/obj/item/limb/hand/l_hand,
+/turf/open/shuttle/dropship{
+	tag = "icon-rasputin15";
+	icon_state = "rasputin15"
 	},
 /area/bigredv2/outside/office_complex)
 "GG" = (
@@ -1647,7 +1678,6 @@
 /area/bigredv2/outside/office_complex)
 "NK" = (
 /obj/structure/surface/rack,
-/obj/item/ammo_magazine/rifle/rubber,
 /obj/item/ammo_magazine/rifle/rubber,
 /obj/item/ammo_magazine/rifle/rubber,
 /obj/item/ammo_magazine/rifle/rubber,
@@ -2005,7 +2035,7 @@ aT
 aO
 bl
 dz
-GG
+bc
 bc
 dB
 bc
@@ -2086,7 +2116,7 @@ aW
 uL
 bn
 rF
-dE
+jx
 dE
 dE
 bc
@@ -2112,7 +2142,7 @@ aQ
 aV
 aV
 vw
-bp
+EE
 dA
 bp
 bp
@@ -2170,7 +2200,7 @@ bc
 bc
 uC
 bc
-bc
+sR
 bc
 bc
 bc

--- a/maps/map_files/BigRed/standalone/crashlanding-offices.dmm
+++ b/maps/map_files/BigRed/standalone/crashlanding-offices.dmm
@@ -810,12 +810,17 @@
 	},
 /area/bigredv2/outside/office_complex)
 "cw" = (
+/obj/item/weapon/gun/rifle/nsg23/no_lock/stripped,
 /turf/open/shuttle/dropship{
 	tag = "icon-rasputin5";
 	icon_state = "rasputin12"
 	},
 /area/bigredv2/outside/office_complex)
 "cx" = (
+/obj/effect/spawner/gibspawner/human,
+/obj/item/limb/arm/l_arm,
+/obj/item/limb/leg/l_leg,
+/obj/item/limb/hand/r_hand,
 /turf/open/shuttle/dropship{
 	icon_state = "rasputin8";
 	tag = "icon-rasputin7"
@@ -1228,8 +1233,7 @@
 /area/bigredv2/outside/office_complex)
 "dH" = (
 /obj/effect/decal/cleanable/blood,
-/obj/effect/landmark/corpsespawner/pmc,
-/obj/item/weapon/gun/rifle/nsg23/no_lock,
+/obj/effect/landmark/corpsespawner/wysec,
 /turf/open/shuttle/dropship{
 	icon_state = "floor8";
 	tag = "icon-rasputin7"
@@ -1239,9 +1243,8 @@
 /obj/structure/surface/rack,
 /obj/item/ammo_magazine/rifle/nsg23,
 /obj/item/ammo_magazine/rifle/nsg23,
-/obj/item/ammo_magazine/rifle/nsg23,
-/obj/item/ammo_magazine/rifle/nsg23,
-/obj/item/ammo_magazine/rifle/nsg23,
+/obj/item/ammo_magazine/rifle/nsg23/extended,
+/obj/item/ammo_magazine/rifle/nsg23/extended,
 /turf/open/shuttle/dropship{
 	tag = "icon-rasputin15";
 	icon_state = "rasputin15"
@@ -1282,6 +1285,7 @@
 "dN" = (
 /obj/structure/surface/rack,
 /obj/item/device/flashlight,
+/obj/item/weapon/gun/rifle/nsg23/no_lock,
 /turf/open/shuttle/dropship{
 	tag = "icon-rasputin15";
 	icon_state = "rasputin15"
@@ -1478,6 +1482,36 @@
 	icon_state = "platingdmg1"
 	},
 /area/bigredv2/outside/office_complex)
+"fG" = (
+/obj/structure/bed/chair/dropship/passenger{
+	dir = 8
+	},
+/obj/item/device/radio/headset/distress/PMC,
+/turf/open/shuttle/dropship{
+	tag = "icon-rasputin15";
+	icon_state = "rasputin15"
+	},
+/area/bigredv2/outside/office_complex)
+"od" = (
+/obj/structure/bed/chair/dropship/passenger{
+	dir = 4
+	},
+/obj/item/clothing/gloves/marine/veteran/PMC,
+/turf/open/shuttle/dropship{
+	tag = "icon-rasputin15";
+	icon_state = "rasputin15"
+	},
+/area/bigredv2/outside/office_complex)
+"oF" = (
+/obj/structure/bed/chair/dropship/passenger{
+	dir = 4
+	},
+/obj/item/clothing/under/marine/veteran/PMC,
+/turf/open/shuttle/dropship{
+	tag = "icon-rasputin15";
+	icon_state = "rasputin15"
+	},
+/area/bigredv2/outside/office_complex)
 "qX" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/landmark/corpsespawner/pmc,
@@ -1492,11 +1526,60 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/blood,
-/obj/effect/landmark/corpsespawner/pmc,
-/obj/item/weapon/gun/rifle/nsg23/no_lock,
+/obj/item/clothing/gloves/marine/veteran/PMC,
+/obj/effect/spawner/gibspawner/human,
+/obj/item/limb/arm/l_arm,
+/obj/item/limb/leg/l_leg,
+/obj/item/limb/hand/l_hand,
+/obj/item/clothing/head/helmet/marine/veteran/PMC,
 /turf/open/shuttle/dropship{
 	tag = "icon-rasputin15";
 	icon_state = "rasputin15"
+	},
+/area/bigredv2/outside/office_complex)
+"rK" = (
+/obj/structure/bed/chair/dropship/passenger{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood,
+/obj/effect/landmark/corpsespawner/wysec,
+/turf/open/shuttle/dropship{
+	tag = "icon-rasputin15";
+	icon_state = "rasputin15"
+	},
+/area/bigredv2/outside/office_complex)
+"si" = (
+/obj/item/clothing/head/helmet/marine/veteran/PMC,
+/turf/open/shuttle/dropship{
+	tag = "icon-rasputin3";
+	icon_state = "rasputin3"
+	},
+/area/bigredv2/outside/office_complex)
+"uC" = (
+/obj/effect/spawner/gibspawner/human,
+/obj/item/weapon/gun/rifle/m41a/corporate{
+	current_mag = /obj/item/ammo_magazine/rifle/rubber;
+	name = "battered M41A pulse rifle MK2";
+	pixel_x = 4;
+	desc = "A Weyland-Yutani creation, this M41A MK2 comes equipped in corporate white. Uses 10x24mm caseless ammunition. It seems to be pretty battered and broken up.."
+	},
+/turf/open/shuttle/dropship{
+	tag = "icon-rasputin3";
+	icon_state = "rasputin3"
+	},
+/area/bigredv2/outside/office_complex)
+"uL" = (
+/obj/item/weapon/gun/rifle/nsg23/no_lock/stripped,
+/turf/open/shuttle/dropship{
+	tag = "icon-rasputin3";
+	icon_state = "rasputin3"
+	},
+/area/bigredv2/outside/office_complex)
+"vw" = (
+/obj/item/clothing/under/marine/veteran/PMC,
+/turf/open/shuttle/dropship{
+	icon_state = "floor8";
+	tag = "icon-rasputin7"
 	},
 /area/bigredv2/outside/office_complex)
 "yS" = (
@@ -1514,11 +1597,34 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/blood,
-/obj/effect/landmark/corpsespawner/pmc,
-/obj/item/weapon/gun/rifle/nsg23/no_lock,
+/obj/effect/landmark/corpsespawner/wysec,
+/obj/item/limb/leg/r_leg,
 /turf/open/shuttle/dropship{
 	tag = "icon-rasputin15";
 	icon_state = "rasputin15"
+	},
+/area/bigredv2/outside/office_complex)
+"Bu" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/spawner/gibspawner/human,
+/obj/item/limb/arm/l_arm,
+/obj/item/limb/leg/l_leg,
+/obj/item/limb/hand/r_hand,
+/turf/open/shuttle/dropship{
+	tag = "icon-rasputin3";
+	icon_state = "rasputin3"
+	},
+/area/bigredv2/outside/office_complex)
+"GG" = (
+/obj/item/weapon/gun/rifle/m41a/corporate{
+	current_mag = /obj/item/ammo_magazine/rifle/rubber;
+	name = "battered M41A pulse rifle MK2";
+	pixel_x = 4;
+	desc = "A Weyland-Yutani creation, this M41A MK2 comes equipped in corporate white. Uses 10x24mm caseless ammunition. It seems to be pretty battered and broken up.."
+	},
+/turf/open/shuttle/dropship{
+	tag = "icon-rasputin3";
+	icon_state = "rasputin3"
 	},
 /area/bigredv2/outside/office_complex)
 "Ha" = (
@@ -1529,6 +1635,27 @@
 	dir = 1
 	},
 /area/bigredv2/outside/se)
+"Lk" = (
+/obj/structure/bed/chair/dropship/passenger{
+	dir = 4
+	},
+/obj/item/device/radio/headset/distress/PMC,
+/turf/open/shuttle/dropship{
+	tag = "icon-rasputin15";
+	icon_state = "rasputin15"
+	},
+/area/bigredv2/outside/office_complex)
+"NK" = (
+/obj/structure/surface/rack,
+/obj/item/ammo_magazine/rifle/rubber,
+/obj/item/ammo_magazine/rifle/rubber,
+/obj/item/ammo_magazine/rifle/rubber,
+/obj/item/ammo_magazine/rifle/rubber,
+/turf/open/shuttle/dropship{
+	tag = "icon-rasputin15";
+	icon_state = "rasputin15"
+	},
+/area/bigredv2/outside/office_complex)
 "PR" = (
 /turf/open/floor{
 	tag = "icon-asteroidfloor (NORTH)";
@@ -1541,6 +1668,16 @@
 	dir = 8
 	},
 /obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
+/turf/open/shuttle/dropship{
+	tag = "icon-rasputin15";
+	icon_state = "rasputin15"
+	},
+/area/bigredv2/outside/office_complex)
+"Ra" = (
+/obj/structure/bed/chair/dropship/passenger{
+	dir = 8
+	},
+/obj/item/clothing/gloves/marine/veteran/PMC,
 /turf/open/shuttle/dropship{
 	tag = "icon-rasputin15";
 	icon_state = "rasputin15"
@@ -1849,7 +1986,7 @@ dP
 aV
 bk
 bk
-bk
+od
 cE
 cM
 cM
@@ -1868,16 +2005,16 @@ aT
 aO
 bl
 dz
-bc
+GG
 bc
 dB
 bc
 bc
 bc
 bc
-qX
+Bu
 dF
-bk
+oF
 cu
 bk
 bk
@@ -1904,8 +2041,8 @@ Qc
 bp
 bp
 dG
-bc
-bc
+si
+GG
 bc
 dz
 bc
@@ -1922,7 +2059,7 @@ aV
 aV
 Vg
 bk
-bk
+Lk
 yS
 bk
 cu
@@ -1946,7 +2083,7 @@ bt
 aD
 aP
 aW
-bc
+uL
 bn
 rF
 dE
@@ -1974,7 +2111,7 @@ aE
 aQ
 aV
 aV
-bm
+vw
 bp
 dA
 bp
@@ -1988,7 +2125,7 @@ bm
 dR
 dI
 dS
-bv
+NK
 cE
 dm
 dv
@@ -2002,7 +2139,7 @@ aN
 bv
 dL
 bm
-bk
+od
 bk
 bk
 cu
@@ -2010,7 +2147,7 @@ bk
 bk
 bk
 bk
-bk
+oF
 cv
 dz
 dJ
@@ -2031,7 +2168,7 @@ aQ
 bo
 bc
 bc
-dz
+uC
 bc
 bc
 bc
@@ -2040,7 +2177,7 @@ bc
 bc
 cx
 dA
-bp
+fG
 bp
 bp
 cF
@@ -2056,7 +2193,7 @@ dX
 dY
 aN
 bp
-rF
+rK
 bp
 aV
 dM
@@ -2065,7 +2202,7 @@ bv
 aV
 bp
 dA
-bp
+Ra
 cF
 cN
 cN

--- a/maps/map_files/BigRed/standalone/medbay-v3.dmm
+++ b/maps/map_files/BigRed/standalone/medbay-v3.dmm
@@ -269,7 +269,7 @@
 /area/bigredv2/outside/medical)
 "aN" = (
 /obj/effect/decal/cleanable/blood,
-/obj/effect/landmark/corpsespawner/wysec,
+/obj/effect/landmark/corpsespawner/wygoon,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -566,7 +566,7 @@
 /area/bigredv2/outside/medical)
 "bE" = (
 /obj/effect/decal/cleanable/blood,
-/obj/effect/landmark/corpsespawner/wysec,
+/obj/effect/landmark/corpsespawner/wygoon,
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
@@ -589,7 +589,7 @@
 "bH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood,
-/obj/effect/landmark/corpsespawner/wysec,
+/obj/effect/landmark/corpsespawner/wygoon,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -1136,7 +1136,7 @@
 "cZ" = (
 /obj/effect/decal/cleanable/blood,
 /obj/structure/pipes/standard/simple/hidden/green,
-/obj/effect/landmark/corpsespawner/wysec,
+/obj/effect/landmark/corpsespawner/wygoon,
 /turf/open/floor{
 	icon_state = "damaged5";
 	dir = 8
@@ -1145,7 +1145,7 @@
 "db" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood,
-/obj/effect/landmark/corpsespawner/wysec,
+/obj/effect/landmark/corpsespawner/wygoon,
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
@@ -1156,7 +1156,7 @@
 	},
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/corpsespawner/wysec,
+/obj/effect/landmark/corpsespawner/wygoon,
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},

--- a/maps/map_files/BigRed/standalone/medbay-v3.dmm
+++ b/maps/map_files/BigRed/standalone/medbay-v3.dmm
@@ -100,7 +100,6 @@
 "aq" = (
 /obj/structure/closet/secure_closet/CMO,
 /obj/item/device/healthanalyzer,
-
 /turf/open/floor{
 	tag = "icon-whitegreenfull";
 	icon_state = "whitegreenfull"
@@ -251,7 +250,6 @@
 /obj/item/stack/sheet/metal{
 	amount = 1
 	},
-
 /turf/open/floor{
 	icon_state = "damaged2";
 	dir = 8
@@ -271,7 +269,7 @@
 /area/bigredv2/outside/medical)
 "aN" = (
 /obj/effect/decal/cleanable/blood,
-/obj/effect/landmark/corpsespawner/pmc,
+/obj/effect/landmark/corpsespawner/wysec,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -359,7 +357,6 @@
 	tag = "icon-tube1 (EAST)";
 	dir = 4
 	},
-
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor{
 	tag = "icon-whitegreenfull";
@@ -569,7 +566,7 @@
 /area/bigredv2/outside/medical)
 "bE" = (
 /obj/effect/decal/cleanable/blood,
-/obj/effect/landmark/corpsespawner/pmc,
+/obj/effect/landmark/corpsespawner/wysec,
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
@@ -592,7 +589,7 @@
 "bH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood,
-/obj/effect/landmark/corpsespawner/pmc,
+/obj/effect/landmark/corpsespawner/wysec,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -1139,7 +1136,7 @@
 "cZ" = (
 /obj/effect/decal/cleanable/blood,
 /obj/structure/pipes/standard/simple/hidden/green,
-/obj/effect/landmark/corpsespawner/pmc,
+/obj/effect/landmark/corpsespawner/wysec,
 /turf/open/floor{
 	icon_state = "damaged5";
 	dir = 8
@@ -1148,7 +1145,7 @@
 "db" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood,
-/obj/effect/landmark/corpsespawner/pmc,
+/obj/effect/landmark/corpsespawner/wysec,
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
@@ -1159,7 +1156,7 @@
 	},
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/corpsespawner/pmc,
+/obj/effect/landmark/corpsespawner/wysec,
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
@@ -1541,7 +1538,6 @@
 /area/bigredv2/outside/medical)
 "ec" = (
 /obj/structure/closet/secure_closet/medical1,
-
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
@@ -1718,7 +1714,6 @@
 /area/bigredv2/outside/medical)
 "ew" = (
 /obj/structure/surface/table,
-
 /turf/open/floor{
 	tag = "icon-whitebluefull (NORTHEAST)";
 	icon_state = "whitebluefull";
@@ -2025,18 +2020,9 @@
 "fh" = (
 /obj/structure/surface/table/reinforced,
 /obj/item/trash/buritto,
-
 /turf/open/floor{
 	tag = "icon-whitegreenfull";
 	icon_state = "whitegreenfull"
-	},
-/area/bigredv2/outside/medical)
-"fi" = (
-
-/turf/open/floor{
-	tag = "icon-whitebluefull (NORTHEAST)";
-	icon_state = "whitebluefull";
-	dir = 5
 	},
 /area/bigredv2/outside/medical)
 "fj" = (
@@ -2196,7 +2182,7 @@ ap
 dD
 dS
 ef
-fi
+es
 eE
 aa
 eT

--- a/maps/map_files/Ice_Colony_v3/Shivas_Snowball.dmm
+++ b/maps/map_files/Ice_Colony_v3/Shivas_Snowball.dmm
@@ -13667,8 +13667,8 @@
 	},
 /area/shiva/interior/colony/botany)
 "iji" = (
-/obj/effect/landmark/corpsespawner/pmc,
 /obj/effect/decal/cleanable/blood/gibs/core,
+/obj/effect/landmark/corpsespawner/wysec,
 /turf/open/auto_turf/ice/layer1,
 /area/shiva/interior/colony/central)
 "ijq" = (

--- a/maps/map_files/Ice_Colony_v3/Shivas_Snowball.dmm
+++ b/maps/map_files/Ice_Colony_v3/Shivas_Snowball.dmm
@@ -13668,7 +13668,7 @@
 /area/shiva/interior/colony/botany)
 "iji" = (
 /obj/effect/decal/cleanable/blood/gibs/core,
-/obj/effect/landmark/corpsespawner/wysec,
+/obj/effect/landmark/corpsespawner/wygoon,
 /turf/open/auto_turf/ice/layer1,
 /area/shiva/interior/colony/central)
 "ijq" = (

--- a/maps/map_files/Kutjevo/Kutjevo.dmm
+++ b/maps/map_files/Kutjevo/Kutjevo.dmm
@@ -4235,7 +4235,7 @@
 /obj/structure/barricade/wooden{
 	dir = 4
 	},
-/obj/effect/landmark/corpsespawner/pmc,
+/obj/effect/landmark/corpsespawner/wysec,
 /turf/open/floor/kutjevo/multi_tiles{
 	dir = 4
 	},
@@ -5106,7 +5106,7 @@
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/complex/Northwest_Flight_Control)
 "gEc" = (
-/obj/effect/landmark/corpsespawner/pmc,
+/obj/effect/landmark/corpsespawner/wysec,
 /turf/open/floor/kutjevo/colors/cyan/inner_corner{
 	dir = 8
 	},
@@ -5519,7 +5519,7 @@
 /turf/open/auto_turf/sand/layer1,
 /area/kutjevo/interior/colony_north)
 "hkq" = (
-/obj/effect/landmark/corpsespawner/pmc,
+/obj/effect/landmark/corpsespawner/wysec,
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
 "hkO" = (
@@ -7645,7 +7645,7 @@
 /turf/open/floor/kutjevo/colors/red/tile,
 /area/kutjevo/exterior/Northwest_Colony)
 "kuL" = (
-/obj/effect/landmark/corpsespawner/pmc,
+/obj/effect/landmark/corpsespawner/wysec,
 /turf/open/floor/kutjevo/colors/purple/edge{
 	dir = 1
 	},
@@ -7766,7 +7766,6 @@
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/complex/botany/east_tech)
 "kBb" = (
-/obj/effect/landmark/corpsespawner/pmc,
 /obj/structure/machinery/door_control/brbutton{
 	health = null;
 	id = "kutjevo_medlock_west";
@@ -7776,6 +7775,7 @@
 	pixel_y = 22;
 	range = 15
 	},
+/obj/effect/landmark/corpsespawner/wysec,
 /turf/open/floor/kutjevo/tan/grey_edge{
 	dir = 1
 	},
@@ -9221,7 +9221,7 @@
 /turf/open/floor/kutjevo/tan/multi_tiles,
 /area/kutjevo/interior/complex/botany/east_tech)
 "mCf" = (
-/obj/effect/landmark/corpsespawner/pmc,
+/obj/effect/landmark/corpsespawner/wysec,
 /turf/open/floor/kutjevo/colors/cyan/tile,
 /area/kutjevo/interior/complex/med/operating)
 "mCo" = (
@@ -11695,7 +11695,7 @@
 	},
 /area/kutjevo/interior/complex/Northwest_Flight_Control)
 "pLS" = (
-/obj/effect/landmark/corpsespawner/pmc,
+/obj/effect/landmark/corpsespawner/wysec,
 /turf/open/floor/kutjevo/colors/red,
 /area/kutjevo/interior/complex/botany)
 "pMw" = (
@@ -13327,7 +13327,7 @@
 /turf/open/auto_turf/sand/layer2,
 /area/kutjevo/interior/colony_S_East)
 "scY" = (
-/obj/effect/landmark/corpsespawner/pmc,
+/obj/effect/landmark/corpsespawner/wysec,
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/complex/botany)
 "sdn" = (

--- a/maps/map_files/Kutjevo/Kutjevo.dmm
+++ b/maps/map_files/Kutjevo/Kutjevo.dmm
@@ -4235,7 +4235,7 @@
 /obj/structure/barricade/wooden{
 	dir = 4
 	},
-/obj/effect/landmark/corpsespawner/wysec,
+/obj/effect/landmark/corpsespawner/wygoon,
 /turf/open/floor/kutjevo/multi_tiles{
 	dir = 4
 	},
@@ -5106,7 +5106,7 @@
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/complex/Northwest_Flight_Control)
 "gEc" = (
-/obj/effect/landmark/corpsespawner/wysec,
+/obj/effect/landmark/corpsespawner/wygoon,
 /turf/open/floor/kutjevo/colors/cyan/inner_corner{
 	dir = 8
 	},
@@ -5519,7 +5519,7 @@
 /turf/open/auto_turf/sand/layer1,
 /area/kutjevo/interior/colony_north)
 "hkq" = (
-/obj/effect/landmark/corpsespawner/wysec,
+/obj/effect/landmark/corpsespawner/wygoon,
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
 "hkO" = (
@@ -7645,7 +7645,7 @@
 /turf/open/floor/kutjevo/colors/red/tile,
 /area/kutjevo/exterior/Northwest_Colony)
 "kuL" = (
-/obj/effect/landmark/corpsespawner/wysec,
+/obj/effect/landmark/corpsespawner/wygoon,
 /turf/open/floor/kutjevo/colors/purple/edge{
 	dir = 1
 	},
@@ -7775,7 +7775,7 @@
 	pixel_y = 22;
 	range = 15
 	},
-/obj/effect/landmark/corpsespawner/wysec,
+/obj/effect/landmark/corpsespawner/wygoon,
 /turf/open/floor/kutjevo/tan/grey_edge{
 	dir = 1
 	},
@@ -9221,7 +9221,7 @@
 /turf/open/floor/kutjevo/tan/multi_tiles,
 /area/kutjevo/interior/complex/botany/east_tech)
 "mCf" = (
-/obj/effect/landmark/corpsespawner/wysec,
+/obj/effect/landmark/corpsespawner/wygoon,
 /turf/open/floor/kutjevo/colors/cyan/tile,
 /area/kutjevo/interior/complex/med/operating)
 "mCo" = (
@@ -11695,7 +11695,7 @@
 	},
 /area/kutjevo/interior/complex/Northwest_Flight_Control)
 "pLS" = (
-/obj/effect/landmark/corpsespawner/wysec,
+/obj/effect/landmark/corpsespawner/wygoon,
 /turf/open/floor/kutjevo/colors/red,
 /area/kutjevo/interior/complex/botany)
 "pMw" = (
@@ -13327,7 +13327,7 @@
 /turf/open/auto_turf/sand/layer2,
 /area/kutjevo/interior/colony_S_East)
 "scY" = (
-/obj/effect/landmark/corpsespawner/wysec,
+/obj/effect/landmark/corpsespawner/wygoon,
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/complex/botany)
 "sdn" = (

--- a/maps/map_files/LV624/LV624.dmm
+++ b/maps/map_files/LV624/LV624.dmm
@@ -638,6 +638,9 @@
 /area/lv624/lazarus/crashed_ship_containers)
 "acW" = (
 /obj/effect/decal/cleanable/blood/drip,
+/obj/item/ammo_magazine/rifle/nsg23{
+	current_rounds = 0
+	},
 /turf/open/shuttle{
 	icon_state = "floor4"
 	},
@@ -661,6 +664,9 @@
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/tool/shovel,
 /obj/structure/machinery/computer/objective,
+/obj/item/stack/sheet/wood{
+	amount = 16
+	},
 /turf/open/shuttle{
 	icon_state = "floor4"
 	},
@@ -682,7 +688,7 @@
 	},
 /area/lv624/ground/caves/west_caves)
 "adf" = (
-/obj/effect/landmark/corpsespawner/pmc,
+/obj/effect/landmark/corpsespawner/wysec,
 /turf/open/shuttle{
 	icon_state = "floor4"
 	},
@@ -13320,6 +13326,12 @@
 	icon_state = "grassdirt_corner"
 	},
 /area/lv624/ground/jungle/south_west_jungle)
+"blC" = (
+/obj/item/stack/sheet/wood,
+/turf/open/shuttle{
+	icon_state = "floor4"
+	},
+/area/lv624/lazarus/crashed_ship_containers)
 "bnz" = (
 /obj/structure/machinery/door/airlock/almayer/generic{
 	dir = 1;
@@ -13697,7 +13709,7 @@
 "bXd" = (
 /obj/item/device/flashlight/on,
 /obj/effect/decal/cleanable/blood/drip,
-/obj/effect/landmark/corpsespawner/pmc,
+/obj/effect/landmark/corpsespawner/wysec,
 /turf/open/shuttle{
 	icon_state = "floor4"
 	},
@@ -14608,6 +14620,13 @@
 	icon_state = "vault"
 	},
 /area/lv624/lazarus/quartstorage)
+"dWa" = (
+/obj/effect/landmark/objective_landmark/science,
+/obj/structure/barricade/wooden,
+/turf/open/shuttle{
+	icon_state = "floor4"
+	},
+/area/lv624/lazarus/crashed_ship_containers)
 "dWM" = (
 /obj/effect/landmark/monkey_spawn,
 /turf/open/gm/dirt,
@@ -15447,6 +15466,12 @@
 	icon_state = "white"
 	},
 /area/lv624/lazarus/corporate_dome)
+"fNA" = (
+/obj/structure/barricade/wooden,
+/turf/open/shuttle{
+	icon_state = "floor4"
+	},
+/area/lv624/lazarus/crashed_ship_containers)
 "fPi" = (
 /turf/open/gm/coast,
 /area/lv624/ground/caves/sand_temple)
@@ -17653,6 +17678,10 @@
 /obj/effect/landmark/crap_item,
 /turf/open/floor,
 /area/lv624/lazarus/landing_zones/lz1)
+"lkj" = (
+/obj/structure/inflatable/popped/door,
+/turf/open/gm/dirt,
+/area/lv624/lazarus/crashed_ship_containers)
 "lkF" = (
 /obj/item/stack/sheet/wood{
 	amount = 2
@@ -18995,6 +19024,13 @@
 "nUy" = (
 /turf/closed/wall/r_wall/unmeltable,
 /area/lv624/lazarus/robotics)
+"nUC" = (
+/obj/structure/barricade/wooden{
+	dir = 4
+	},
+/obj/structure/barricade/wooden,
+/turf/open/gm/dirt,
+/area/lv624/lazarus/crashed_ship_containers)
 "nUI" = (
 /obj/item/weapon/gun/smg/mp5,
 /obj/item/ammo_casing/bullet{
@@ -19233,6 +19269,11 @@
 	},
 /turf/open/floor/sandstone/runed,
 /area/lv624/ground/caves/sand_temple)
+"ovw" = (
+/obj/structure/inflatable/popped,
+/obj/item/stack/sheet/wood,
+/turf/open/gm/dirt,
+/area/lv624/lazarus/crashed_ship_containers)
 "owQ" = (
 /turf/open/gm/coast{
 	dir = 8
@@ -19757,6 +19798,15 @@
 /obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
 /turf/open/floor/vault,
 /area/lv624/lazarus/quartstorage)
+"psZ" = (
+/obj/item/stack/sheet/wood,
+/obj/item/ammo_magazine/rifle/nsg23{
+	current_rounds = 0
+	},
+/turf/open/shuttle{
+	icon_state = "floor4"
+	},
+/area/lv624/lazarus/crashed_ship_containers)
 "ptr" = (
 /obj/structure/flora/bush/ausbushes/palebush,
 /turf/open/gm/grass,
@@ -20400,6 +20450,12 @@
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
 /turf/open/gm/dirt,
 /area/lv624/ground/barrens/north_east_barrens)
+"qSn" = (
+/obj/structure/barricade/wooden{
+	dir = 4
+	},
+/turf/open/gm/dirt,
+/area/lv624/lazarus/crashed_ship_containers)
 "qSZ" = (
 /obj/structure/flora/grass/tallgrass/jungle/corner{
 	dir = 10
@@ -20864,7 +20920,7 @@
 "sbt" = (
 /obj/effect/decal/cleanable/blood,
 /obj/structure/bed/roller,
-/obj/effect/landmark/corpsespawner/pmc,
+/obj/effect/landmark/corpsespawner/wysec,
 /turf/open/floor{
 	icon_state = "white"
 	},
@@ -22978,6 +23034,10 @@
 	icon_state = "grass2"
 	},
 /area/lv624/ground/jungle/south_west_jungle)
+"wSg" = (
+/obj/structure/inflatable/popped,
+/turf/open/gm/dirt,
+/area/lv624/lazarus/crashed_ship_containers)
 "wSi" = (
 /obj/structure/girder,
 /obj/effect/decal/cleanable/blood/oil,
@@ -23303,6 +23363,14 @@
 	icon_state = "whiteyellow"
 	},
 /area/lv624/lazarus/corporate_dome)
+"xyI" = (
+/obj/item/ammo_magazine/rifle/nsg23{
+	current_rounds = 0
+	},
+/turf/open/shuttle{
+	icon_state = "floor4"
+	},
+/area/lv624/lazarus/crashed_ship_containers)
 "xze" = (
 /obj/structure/flora/bush/ausbushes/reedbush,
 /turf/open/gm/grass,
@@ -51054,7 +51122,7 @@ acw
 acQ
 yfH
 gcI
-yfH
+xyI
 adf
 aYn
 kSs
@@ -51284,10 +51352,10 @@ kRr
 ada
 add
 aYn
-uya
+nUC
 sfH
 wcK
-sfH
+yhY
 pDt
 trs
 pDt
@@ -51510,12 +51578,12 @@ acN
 acW
 iKp
 qHC
-yfH
-yfH
+blC
+fNA
 gcI
-yhY
+lkj
 uya
-yhY
+wSg
 iZG
 iLL
 pDt
@@ -51741,9 +51809,9 @@ tlQ
 hfX
 bXd
 xPD
-sfH
-uya
-sfH
+ovw
+qSn
+wSg
 pDt
 acF
 pDt
@@ -51964,11 +52032,11 @@ jGo
 acD
 acw
 acL
-yfH
+xyI
 vuy
 dOf
-yfH
-aYn
+psZ
+dWa
 kSs
 ecy
 ecy

--- a/maps/map_files/LV624/LV624.dmm
+++ b/maps/map_files/LV624/LV624.dmm
@@ -617,7 +617,7 @@
 /area/lv624/ground/caves/west_caves)
 "acT" = (
 /obj/effect/decal/cleanable/blood,
-/obj/effect/landmark/corpsespawner/wysec,
+/obj/effect/landmark/corpsespawner/wygoon,
 /turf/open/shuttle{
 	icon_state = "floor4"
 	},
@@ -688,7 +688,7 @@
 	},
 /area/lv624/ground/caves/west_caves)
 "adf" = (
-/obj/effect/landmark/corpsespawner/wysec,
+/obj/effect/landmark/corpsespawner/wygoon,
 /turf/open/shuttle{
 	icon_state = "floor4"
 	},
@@ -13595,7 +13595,7 @@
 /area/lv624/ground/caves/sand_temple)
 "bJz" = (
 /obj/effect/decal/cleanable/blood,
-/obj/effect/landmark/corpsespawner/wysec,
+/obj/effect/landmark/corpsespawner/wygoon,
 /turf/open/floor/wood,
 /area/lv624/ground/caves/north_central_caves)
 "bLs" = (
@@ -13709,7 +13709,7 @@
 "bXd" = (
 /obj/item/device/flashlight/on,
 /obj/effect/decal/cleanable/blood/drip,
-/obj/effect/landmark/corpsespawner/wysec,
+/obj/effect/landmark/corpsespawner/wygoon,
 /turf/open/shuttle{
 	icon_state = "floor4"
 	},
@@ -20672,7 +20672,7 @@
 "rwx" = (
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_nest,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_nest,
-/obj/effect/landmark/corpsespawner/wysec,
+/obj/effect/landmark/corpsespawner/wygoon,
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/east_caves)
 "rwB" = (
@@ -20920,7 +20920,7 @@
 "sbt" = (
 /obj/effect/decal/cleanable/blood,
 /obj/structure/bed/roller,
-/obj/effect/landmark/corpsespawner/wysec,
+/obj/effect/landmark/corpsespawner/wygoon,
 /turf/open/floor{
 	icon_state = "white"
 	},

--- a/maps/map_files/LV624/hydro/30.destroyed.dmm
+++ b/maps/map_files/LV624/hydro/30.destroyed.dmm
@@ -17,6 +17,9 @@
 /area/lv624/lazarus/hydroponics)
 "bk" = (
 /obj/item/tool/extinguisher,
+/obj/effect/decal/cleanable/blood/tracks/footprints{
+	dir = 1
+	},
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
@@ -37,7 +40,7 @@
 "ck" = (
 /obj/effect/decal/cleanable/blood/xeno,
 /turf/open/floor/plating,
-/area/lv624/lazarus/medbay)
+/area/lv624/lazarus/hydroponics)
 "cQ" = (
 /obj/effect/decal/cleanable/blood/xeno,
 /turf/open/floor/plating{
@@ -64,6 +67,22 @@
 	icon_state = "grassdirt_corner2"
 	},
 /area/lv624/ground/colony/south_medbay_road)
+"ft" = (
+/obj/item/clothing/gloves/marine/veteran/PMC{
+	name = "damaged WY PMC gloves";
+	armor_bio = 10;
+	armor_bomb = 10;
+	armor_bullet = 15;
+	armor_energy = 15;
+	armor_internaldamage = 15;
+	armor_laser = 15;
+	armor_melee = 15;
+	armor_rad = 10
+	},
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/lv624/lazarus/hydroponics)
 "fX" = (
 /obj/item/device/analyzer/plant_analyzer,
 /obj/effect/spawner/random/claymore,
@@ -121,6 +140,14 @@
 /obj/structure/girder,
 /turf/open/floor,
 /area/lv624/lazarus/hydroponics)
+"km" = (
+/obj/effect/decal/cleanable/blood/tracks/footprints{
+	dir = 1
+	},
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/lv624/lazarus/hydroponics)
 "kD" = (
 /obj/item/reagent_container/glass/bucket,
 /turf/open/floor/plating{
@@ -139,6 +166,27 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
+/area/lv624/lazarus/hydroponics)
+"mK" = (
+/obj/item/clothing/suit/storage/marine/veteran/PMC/light/synth{
+	desc = "A modification of the standard Armat Systems M3 armor. This variant was designed for PMC Support Units in the field, offering protection and storage while not restricting movement. This set seems damaged...";
+	name = "damaged M4 synthetic PMC armor";
+	slowdown = 1;
+	pixel_x = -5;
+	pixel_y = -5
+	},
+/obj/effect/spawner/gibspawner/robot,
+/obj/item/limb/head/synth{
+	pixel_x = 9;
+	pixel_y = 3;
+	name = "shattered synthetic head";
+	desc = "This appears to be the head of a synthetic, though it it is so destroyed there is no way in hell anyone is going to bring it back to even basic functionality."
+	},
+/obj/item/robot_parts/arm/l_arm,
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
 /area/lv624/lazarus/hydroponics)
 "np" = (
 /obj/item/tool/weldingtool/simple,
@@ -172,7 +220,7 @@
 /turf/open/floor{
 	icon_state = "platingdmg1"
 	},
-/area/lv624/lazarus/medbay)
+/area/lv624/lazarus/hydroponics)
 "se" = (
 /obj/structure/fence,
 /turf/open/gm/dirtgrassborder,
@@ -186,17 +234,24 @@
 	},
 /obj/effect/decal/cleanable/blood,
 /obj/item/weapon/gun/smg/fp9000,
-/obj/item/ammo_magazine/smg/fp9000,
-/obj/item/ammo_magazine/smg/fp9000,
-/obj/effect/landmark/corpsespawner/wysec,
+/obj/item/clothing/under/marine/veteran/PMC/leader{
+	pixel_x = -7
+	},
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
 /area/lv624/lazarus/hydroponics)
 "vm" = (
-/obj/item/weapon/gun/rifle/m41a/corporate,
 /obj/item/stack/sheet/wood{
 	amount = 16
+	},
+/obj/item/ammo_magazine/rifle/nsg23{
+	current_rounds = 13
+	},
+/obj/effect/spawner/gibspawner/human,
+/obj/item/clothing/head/helmet/marine/veteran/PMC{
+	pixel_x = -6;
+	pixel_y = 8
 	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
@@ -204,8 +259,14 @@
 /area/lv624/lazarus/hydroponics)
 "xa" = (
 /obj/effect/decal/cleanable/blood,
-/obj/effect/landmark/corpsespawner/wysec,
-/obj/item/weapon/gun/rifle/m41a/corporate,
+/obj/item/ammo_magazine/rifle/nsg23{
+	current_rounds = 2
+	},
+/obj/effect/spawner/gibspawner/human,
+/obj/item/clothing/under/marine/veteran/PMC{
+	pixel_x = 6;
+	pixel_y = 8
+	},
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -217,6 +278,10 @@
 /area/lv624/lazarus/hydroponics)
 "xF" = (
 /obj/effect/decal/cleanable/blood,
+/obj/item/clothing/under/marine/veteran/PMC{
+	pixel_x = -7;
+	pixel_y = 9
+	},
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -243,9 +308,11 @@
 /area/lv624/lazarus/hydroponics)
 "zj" = (
 /obj/item/stack/folding_barricade,
-/obj/item/ammo_magazine/rifle{
-	current_rounds = 9
+/obj/item/ammo_magazine/rifle/nsg23{
+	current_rounds = 17
 	},
+/obj/effect/spawner/gibspawner/human,
+/obj/item/clothing/head/helmet/marine/veteran/PMC/leader,
 /turf/open/floor/plating,
 /area/lv624/lazarus/hydroponics)
 "zL" = (
@@ -262,8 +329,12 @@
 "zX" = (
 /obj/effect/decal/cleanable/blood,
 /obj/item/weapon/gun/smg/fp9000,
-/obj/item/ammo_magazine/smg/fp9000,
-/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/smg/fp9000{
+	pixel_x = 1
+	},
+/obj/item/ammo_magazine/smg/fp9000{
+	pixel_x = -3
+	},
 /obj/structure/barricade/wooden{
 	dir = 8
 	},
@@ -314,10 +385,12 @@
 	},
 /area/lv624/lazarus/hydroponics)
 "Fk" = (
-/turf/open/floor{
-	icon_state = "platingdmg1"
+/obj/item/clothing/head/helmet/marine/veteran/PMC{
+	pixel_x = -13;
+	pixel_y = 11
 	},
-/area/lv624/lazarus/medbay)
+/turf/open/floor/plating,
+/area/lv624/lazarus/hydroponics)
 "FJ" = (
 /obj/effect/decal/cleanable/blood/xeno,
 /turf/open/floor{
@@ -331,7 +404,18 @@
 	health = 245;
 	icon_state = "folding_1"
 	},
-/obj/effect/landmark/corpsespawner/wysec,
+/obj/effect/landmark/corpsespawner/wy/manager,
+/obj/item/weapon/gun/pistol/vp78{
+	current_mag = null;
+	name = "dented VP78 pistol";
+	pixel_x = -5;
+	pixel_y = -4
+	},
+/obj/item/ammo_magazine/pistol/vp78{
+	current_rounds = 4;
+	name = "scratched VP78 magazine (9mm)";
+	pixel_x = 6
+	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -345,6 +429,9 @@
 /area/lv624/lazarus/hydroponics)
 "Jc" = (
 /obj/item/stack/sheet/metal,
+/obj/effect/decal/cleanable/blood/tracks/footprints{
+	dir = 1
+	},
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -398,9 +485,9 @@
 	health = 50;
 	icon_state = "folding_3"
 	},
-/obj/item/ammo_magazine/rifle{
-	current_rounds = 19
-	},
+/obj/item/ammo_magazine/rifle/nsg23,
+/obj/item/ammo_magazine/rifle/nsg23,
+/obj/item/ammo_magazine/rifle/nsg23,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -424,7 +511,7 @@
 "NO" = (
 /obj/effect/landmark/crap_item,
 /turf/open/floor/plating,
-/area/lv624/lazarus/medbay)
+/area/lv624/lazarus/hydroponics)
 "On" = (
 /obj/structure/window_frame/colony,
 /turf/open/floor{
@@ -477,19 +564,29 @@
 	},
 /area/lv624/lazarus/hydroponics)
 "Px" = (
-/obj/item/stack/sheet/metal,
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
+/obj/effect/decal/cleanable/blood/tracks/footprints{
+	dir = 1
 	},
-/area/lv624/lazarus/medbay)
+/turf/open/floor{
+	icon_state = "platingdmg1"
+	},
+/area/lv624/lazarus/hydroponics)
 "Qd" = (
 /obj/item/stack/folding_barricade,
 /obj/item/ammo_magazine/smg/fp9000,
 /obj/item/ammo_magazine/smg/fp9000,
 /obj/item/ammo_magazine/smg/fp9000,
-/obj/item/ammo_magazine/rifle,
-/obj/item/ammo_magazine/rifle{
-	current_rounds = 37
+/obj/item/clothing/gloves/marine/veteran/PMC{
+	name = "damaged WY PMC gloves";
+	armor_bio = 10;
+	armor_bomb = 10;
+	armor_bullet = 15;
+	armor_energy = 15;
+	armor_internaldamage = 15;
+	armor_laser = 15;
+	armor_melee = 15;
+	armor_rad = 10;
+	pixel_y = 9
 	},
 /turf/open/floor/plating,
 /area/lv624/lazarus/hydroponics)
@@ -499,10 +596,25 @@
 	},
 /area/lv624/lazarus/hydroponics)
 "RT" = (
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
+/obj/item/clothing/shoes/veteran/PMC{
+	slowdown = 0.5;
+	name = "scuffed shoes";
+	armor_bio = 15;
+	armor_bomb = 5;
+	armor_bullet = 15;
+	armor_energy = 5;
+	armor_internaldamage = 5;
+	armor_laser = 5;
+	armor_melee = 15;
+	desc = "The height of fashion, but these look to be woven with protective fiber. This pair seems heavily damaged, especially around the soles...";
+	pixel_x = -14;
+	pixel_y = -10
 	},
-/area/lv624/lazarus/medbay)
+/turf/open/floor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/lv624/lazarus/hydroponics)
 "TC" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
@@ -522,7 +634,8 @@
 	health = 140;
 	icon_state = "folding_2"
 	},
-/obj/effect/landmark/corpsespawner/wysec,
+/obj/item/weapon/gun/rifle/nsg23/no_lock,
+/obj/item/ammo_magazine/rifle/nsg23,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -532,6 +645,7 @@
 /obj/structure/barricade/wooden{
 	dir = 4
 	},
+/obj/item/weapon/gun/rifle/nsg23/no_lock,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -554,10 +668,9 @@
 /area/lv624/ground/jungle/north_jungle)
 "YJ" = (
 /obj/item/storage/firstaid,
-/obj/item/ammo_magazine/rifle/nsg23/extended,
-/obj/item/ammo_magazine/smg/fp9000,
-/obj/item/ammo_magazine/smg/fp9000,
-/obj/item/ammo_magazine/smg/fp9000,
+/obj/item/explosive/grenade/HE/PMC{
+	pixel_x = 6
+	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -568,8 +681,12 @@
 	},
 /area/lv624/lazarus/hydroponics)
 "Zm" = (
-/turf/open/floor/plating,
-/area/lv624/lazarus/medbay)
+/obj/item/stack/sheet/metal,
+/obj/item/robot_parts/leg/l_leg,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/lv624/lazarus/hydroponics)
 "ZL" = (
 /obj/item/tool/minihoe{
 	pixel_x = 1;
@@ -648,7 +765,7 @@ se
 (5,1,1) = {"
 XA
 qe
-Fk
+YV
 TC
 FJ
 Wg
@@ -696,7 +813,7 @@ Xv
 (8,1,1) = {"
 YV
 Wg
-YV
+ft
 TC
 bm
 tK
@@ -710,12 +827,12 @@ ZL
 Xv
 "}
 (9,1,1) = {"
-YV
+Px
 bk
-YV
-JO
+Px
+km
 Jc
-JO
+km
 YJ
 Qd
 MM
@@ -726,11 +843,11 @@ Ed
 Xv
 "}
 (10,1,1) = {"
-Xv
+RT
 Xv
 QR
-QR
-Wg
+JO
+Fk
 xF
 Ha
 vm
@@ -762,11 +879,11 @@ Xv
 bd
 aO
 QR
-Xv
+mK
 DN
-RT
-Zm
-RT
+TC
+Wg
+TC
 TC
 lm
 OI
@@ -777,13 +894,13 @@ Cq
 XA
 On
 IO
-Jc
+Zm
 Lk
 TC
 NO
-Zm
-RT
-Px
+Wg
+TC
+lm
 ck
 CG
 YV

--- a/maps/map_files/LV624/hydro/30.destroyed.dmm
+++ b/maps/map_files/LV624/hydro/30.destroyed.dmm
@@ -141,7 +141,8 @@
 /turf/open/floor/plating,
 /area/lv624/lazarus/hydroponics)
 "np" = (
-/obj/item/tool/weldingtool,
+/obj/item/tool/weldingtool/simple,
+/obj/item/stack/sheet/wood,
 /turf/open/floor{
 	dir = 9;
 	icon_state = "green"
@@ -177,7 +178,6 @@
 /turf/open/gm/dirtgrassborder,
 /area/lv624/ground/colony/south_medbay_road)
 "tK" = (
-/obj/effect/landmark/corpsespawner/pmc,
 /obj/structure/barricade/deployable{
 	damage_state = 3;
 	dir = 1;
@@ -188,24 +188,24 @@
 /obj/item/weapon/gun/smg/fp9000,
 /obj/item/ammo_magazine/smg/fp9000,
 /obj/item/ammo_magazine/smg/fp9000,
+/obj/effect/landmark/corpsespawner/wysec,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
 /area/lv624/lazarus/hydroponics)
 "vm" = (
-/obj/item/weapon/gun/rifle/nsg23/no_lock,
+/obj/item/weapon/gun/rifle/m41a/corporate,
+/obj/item/stack/sheet/wood{
+	amount = 16
+	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
 /area/lv624/lazarus/hydroponics)
 "xa" = (
-/obj/effect/landmark/corpsespawner/pmc,
 /obj/effect/decal/cleanable/blood,
-/obj/item/ammo_magazine/rifle/nsg23,
-/obj/item/ammo_magazine/rifle/nsg23,
-/obj/item/ammo_magazine/rifle/nsg23,
-/obj/item/ammo_magazine/rifle/nsg23,
-/obj/item/ammo_magazine/rifle/nsg23,
+/obj/effect/landmark/corpsespawner/wysec,
+/obj/item/weapon/gun/rifle/m41a/corporate,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -243,6 +243,9 @@
 /area/lv624/lazarus/hydroponics)
 "zj" = (
 /obj/item/stack/folding_barricade,
+/obj/item/ammo_magazine/rifle{
+	current_rounds = 9
+	},
 /turf/open/floor/plating,
 /area/lv624/lazarus/hydroponics)
 "zL" = (
@@ -261,6 +264,9 @@
 /obj/item/weapon/gun/smg/fp9000,
 /obj/item/ammo_magazine/smg/fp9000,
 /obj/item/ammo_magazine/smg/fp9000,
+/obj/structure/barricade/wooden{
+	dir = 8
+	},
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -319,18 +325,13 @@
 	},
 /area/lv624/lazarus/hydroponics)
 "Ha" = (
-/obj/effect/landmark/corpsespawner/pmc,
 /obj/structure/barricade/deployable{
 	damage_state = 1;
 	dir = 1;
 	health = 245;
 	icon_state = "folding_1"
 	},
-/obj/item/ammo_magazine/rifle/nsg23,
-/obj/item/ammo_magazine/rifle/nsg23,
-/obj/item/ammo_magazine/rifle/nsg23,
-/obj/item/ammo_magazine/rifle/nsg23,
-/obj/item/ammo_magazine/rifle/nsg23,
+/obj/effect/landmark/corpsespawner/wysec,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -397,6 +398,9 @@
 	health = 50;
 	icon_state = "folding_3"
 	},
+/obj/item/ammo_magazine/rifle{
+	current_rounds = 19
+	},
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -460,6 +464,7 @@
 "OO" = (
 /obj/item/ammo_magazine/rifle/nsg23/extended,
 /obj/effect/landmark/objective_landmark/medium,
+/obj/item/stack/sheet/wood,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -482,6 +487,10 @@
 /obj/item/ammo_magazine/smg/fp9000,
 /obj/item/ammo_magazine/smg/fp9000,
 /obj/item/ammo_magazine/smg/fp9000,
+/obj/item/ammo_magazine/rifle,
+/obj/item/ammo_magazine/rifle{
+	current_rounds = 37
+	},
 /turf/open/floor/plating,
 /area/lv624/lazarus/hydroponics)
 "QR" = (
@@ -507,20 +516,22 @@
 	},
 /area/lv624/lazarus/hydroponics)
 "Ul" = (
-/obj/effect/landmark/corpsespawner/pmc,
 /obj/structure/barricade/deployable{
 	damage_state = 2;
 	dir = 8;
 	health = 140;
 	icon_state = "folding_2"
 	},
-/obj/item/weapon/gun/rifle/nsg23/no_lock,
+/obj/effect/landmark/corpsespawner/wysec,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
 /area/lv624/lazarus/hydroponics)
 "UG" = (
 /obj/effect/decal/cleanable/blood,
+/obj/structure/barricade/wooden{
+	dir = 4
+	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Removed almost all the PMC corpses from all the maps. Replaced them with W-Y Security Guards (goons)

Sprinkled some soul in some nightmare inserts that hosted these PMC corpses because i cannot help myself. For example the LV crash and hydro holds have some wooden barricades, the latter keeps some PMC stuff but nothing powerful. The big red admin hold got some mostly-empty M41 magazine boxes.

Almost all of the PMC corpse spawns' NSG 23s and magazines were replaced with corpo M41s equipped with rubber bullets. Where relevant, there are also normal magazines that can be picked up, such as the big red offices crashed ship. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

> Removed almost all the PMC corpses from all the maps. Replaced them with W-Y Security Guards (goons)

I am tired of seeing people rushing for PMC corpses to steal their gloves (and boots if intelligent), and sometimes even the rest of their armor because it has +10 resistance. Marines should usually look like marines, that drip is PMC reserved. It's way too easy a way to get drip and armor buffs, especially because xenos can't melt it!

The PMC crashed ship in big red offices has some gibs with misc. PMC loot like uniforms and gloves for lore.

I've kept some of the corpses in places where I don't think people rush to get gamer loot every round.

> Sprinkled some soul in some nightmare inserts that hosted these PMC corpses because i cannot help myself. For example the LV crash and hydro holds have some wooden barricades, the big red admin hold got some mostly-empty M41 magazine boxes.

It would have been odd to replace the corpses with goons outright. Crashed ship's supposed to have PMCs that died from the crash, so instead it's colony goons that set up a hold there. The m41 magazine boxes are because of the massive amount of NSG23 magazines with a cardboard sheet, which I assume was thrown there because the mapper was annoyed there was no NSG23 mag box. The boxes have very little ammo, and like one extended m41 mag inside.

> Almost all of the PMC corpse spawns' NSG 23s and magazines were replaced with corpo M41s equipped with rubber bullets. Where relevant, there are also normal magazines that can be picked up, such as the big red offices crashed ship. 

This is mainly intended so that survivors don't suddenly have access to a billion M41 magazines as the M41 is a significantly more versatile and well-used gun that the NSG-23, and more useful against harassers. Maybe if I get around to adding the storm rifle as a cheap m41 for goons they'll be replaced with it.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->

## Changelog

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: Removed almost all the PMC corpses from all the maps. Replaced them with W-Y Security Guards (goons)
add: Sprinkled some soul in some nightmare inserts that hosted these PMC corpses because i cannot help myself. For example the LV crash and hydro holds have some wooden barricades, the big red admin hold got some mostly-empty M41 magazine boxes.
add: Almost all of the PMC corpse spawns' NSG 23s and magazines were replaced with corpo M41s equipped with rubber bullets. Where relevant, there are also normal magazines that can be picked up, such as the big red offices crashed ship. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
