### PR TITLE
Adding new ammo boxes

### DIFF
--- a/ColonialMarinesALPHA.dme
+++ b/ColonialMarinesALPHA.dme
@@ -1941,6 +1941,7 @@
 #include "code\modules\projectiles\ammo_boxes\magazine_boxes.dm"
 #include "code\modules\projectiles\ammo_boxes\misc_boxes.dm"
 #include "code\modules\projectiles\ammo_boxes\round_boxes.dm"
+#include "code\modules\projectiles\ammo_boxes\spec_packets.dm"
 #include "code\modules\projectiles\guns\boltaction.dm"
 #include "code\modules\projectiles\guns\energy.dm"
 #include "code\modules\projectiles\guns\lever_action.dm"

--- a/code/modules/projectiles/ammo_boxes/magazine_boxes.dm
+++ b/code/modules/projectiles/ammo_boxes/magazine_boxes.dm
@@ -423,6 +423,20 @@
 /obj/item/ammo_box/magazine/mortar/empty
 	empty = TRUE
 
+/obj/item/mortar_shell/frag
+
+/obj/item/ammo_box/magazine/mortar/frag
+	name = "M402 mortar fragmentation shells box (F x6)"
+	//icon_state = ""
+	flags_equip_slot = SLOT_BACK
+	overlay_ammo_type = ""
+	overlay_gun_type = ""
+	num_of_magazines = 6
+	magazine_type = /obj/item/mortar_shell/frag
+
+/obj/item/ammo_box/magazine/mortar/frag/empty
+	empty = TRUE
+
 /obj/item/ammo_box/magazine/mortar/incend
 	name = "M402 mortar incendiary shells box (I x6)"
 	//icon_state = ""

--- a/code/modules/projectiles/ammo_boxes/magazine_boxes.dm
+++ b/code/modules/projectiles/ammo_boxes/magazine_boxes.dm
@@ -324,3 +324,125 @@
 
 /obj/item/ammo_box/magazine/smg/nailgun/empty
 	empty = TRUE
+
+//-----------------------SHOTGUN SHELL BOXES-----------------------
+
+/obj/item/ammo_box/magazine/shotgun_box
+	name = "shotgun shell boxes (Slugs 25x4)"
+	icon_state = "base_slug"
+	flags_equip_slot = SLOT_BACK
+	overlay_ammo_type = ""
+	overlay_gun_type = "_shells"
+	overlay_content = "_slug"
+	magazine_type = /obj/item/ammo_magazine/shotgun/slugs
+	num_of_magazines = 4
+
+/obj/item/ammo_box/magazine/shotgun_box/update_icon()
+	if(overlays)
+		overlays.Cut()
+	overlays += image(icon, icon_state = "[icon_state]_lid")				//adding lid
+	overlays += image(icon, icon_state = "text[overlay_gun_type]")		//adding text
+
+/obj/item/ammo_box/magazine/shotgun_box/empty
+	empty = TRUE
+
+/obj/item/ammo_box/magazine/shotgun_box/buckshot
+	name = "shotgun shell boxes (Buckshot 25x4)"
+	icon_state = "base_buck"
+	overlay_content = "_buck"
+	magazine_type = /obj/item/ammo_magazine/shotgun/buckshot
+
+/obj/item/ammo_box/magazine/shotgun_box/buckshot/empty
+	empty = TRUE
+
+/obj/item/ammo_box/magazine/shotgun_box/flechette
+	name = "shotgun shell boxes (Flechette 25x4)"
+	icon_state = "base_flech"
+	overlay_content = "_flech"
+	magazine_type = /obj/item/ammo_magazine/shotgun/flechette
+
+/obj/item/ammo_box/magazine/shotgun_box/flechette/empty
+	empty = TRUE
+
+/obj/item/ammo_box/magazine/shotgun/incendiary
+	name = "shotgun shell boxes (Incendiary slug 25x4)"
+	icon_state = "base_inc"
+	overlay_content = "_incen"
+	magazine_type = /obj/item/ammo_magazine/shotgun/incendiary
+
+/obj/item/ammo_box/magazine/shotgun_box/incendiary/empty
+	empty = TRUE
+
+/obj/item/ammo_box/magazine/shotgun_box/beanbag
+	name = "shotgun shell boxes (Beanbag 25x4)"
+	icon_state = "base_bean"
+	overlay_content = "_bean"
+	magazine_type = /obj/item/ammo_magazine/shotgun/beanbag
+	can_explode = FALSE
+
+/obj/item/ammo_box/magazine/shotgun_box/beanbag/empty
+	empty = TRUE
+
+//-----------------------Flamethrower Canister Box-----------------------
+
+/obj/item/ammo_box/magazine/napalm
+	name = "M240 UT-Napthal Fuel (UT x 4)"
+	//icon_state = ""
+	flags_equip_slot = SLOT_BACK
+	overlay_ammo_type = ""
+	overlay_gun_type = ""
+	num_of_magazines = 4
+	magazine_type = /obj/item/ammo_magazine/flamer_tank
+
+/obj/item/ammo_box/magazine/napalm/empty
+	empty = TRUE
+
+/obj/item/ammo_box/magazine/napalm/b_gel
+	name = "M240 Napthal B-Gel (B x 4)"
+	//icon_state = ""
+	flags_equip_slot = SLOT_BACK
+	overlay_ammo_type = ""
+	overlay_gun_type = ""
+	num_of_magazines = 4
+	magazine_type = /obj/item/ammo_magazine/flamer_tank/gellied
+
+/obj/item/ammo_box/magazine/napalm/b_gel/empty
+	empty = TRUE
+
+//-----------------------Mortar Shells Box-----------------------
+
+/obj/item/ammo_box/magazine/mortar
+	name = "M402 mortar shells box (HE x6)"
+	//icon_state = ""
+	flags_equip_slot = SLOT_BACK
+	overlay_ammo_type = ""
+	overlay_gun_type = ""
+	num_of_magazines = 6
+	magazine_type = /obj/item/mortar_shell/he
+
+/obj/item/ammo_box/magazine/mortar/empty
+	empty = TRUE
+
+/obj/item/ammo_box/magazine/mortar/incend
+	name = "M402 mortar incendiary shells box (I x6)"
+	//icon_state = ""
+	flags_equip_slot = SLOT_BACK
+	overlay_ammo_type = ""
+	overlay_gun_type = ""
+	num_of_magazines = 6
+	magazine_type = /obj/item/mortar_shell/incendiary
+
+/obj/item/ammo_box/magazine/mortar/incend/empty
+	empty = TRUE
+
+/obj/item/ammo_box/magazine/mortar/flare
+	name = "M402 mortar flare-camera shells box (FC x6)"
+	//icon_state = ""
+	flags_equip_slot = SLOT_BACK
+	overlay_ammo_type = ""
+	overlay_gun_type = ""
+	num_of_magazines = 6
+	magazine_type = /obj/item/mortar_shell/flare
+
+/obj/item/ammo_box/magazine/mortar/flare/empty
+	empty = TRUE

--- a/code/modules/projectiles/ammo_boxes/magazine_boxes.dm
+++ b/code/modules/projectiles/ammo_boxes/magazine_boxes.dm
@@ -50,6 +50,70 @@
 /obj/item/ammo_box/magazine/explosive/empty
 	empty = TRUE
 
+//-----------------------M41A MK1 Rifle Mag Boxes-----------------------
+
+/obj/item/ammo_box/magazine/mk1
+	name = "\improper magazine box (M41A MK1 x 10)"
+	flags_equip_slot = SLOT_BACK
+	//icon_state = "base_m41_mk1"
+	//overlay_gun_type = "_m41_mk1"
+	overlay_ammo_type = "_reg"
+	overlay_content = "_reg"
+	magazine_type = /obj/item/ammo_magazine/rifle/m41aMK1
+
+/obj/item/ammo_box/magazine/mk1/empty
+	empty = TRUE
+
+/obj/item/ammo_box/magazine/mk1/ap
+	name = "\improper magazine box (AP M41A MK1 x 10)"
+	flags_equip_slot = SLOT_BACK
+	overlay_ammo_type = "_ap"
+	overlay_content = "_ap"
+	magazine_type = /obj/item/ammo_magazine/rifle/m41aMK1/ap
+
+/obj/item/ammo_box/magazine/mk1/ap/empty
+	empty = TRUE
+
+/obj/item/ammo_box/magazine/mk1/incen
+	name = "\improper magazine box (Incen M41A MK1 x 10)"
+	flags_equip_slot = SLOT_BACK
+	overlay_ammo_type = "_incen"
+	overlay_content = "_incen"
+	magazine_type = /obj/item/ammo_magazine/rifle/m41aMK1/incendiary
+
+/obj/item/ammo_box/magazine/mk1/incen/empty
+	empty = TRUE
+
+/obj/item/ammo_box/magazine/mk1/toxin
+	name = "\improper magazine box (Toxin M41A MK1 x 10)"
+	flags_equip_slot = SLOT_BACK
+	//overlay_ammo_type = "_toxin"
+	//overlay_content = "_toxin"
+	magazine_type = /obj/item/ammo_magazine/rifle/m41aMK1/toxin
+
+/obj/item/ammo_box/magazine/mk1/toxin/empty
+	empty = TRUE
+
+/obj/item/ammo_box/magazine/mk1/penetrating
+	name = "\improper magazine box (Wall-Piercing M41A MK1 x 10)"
+	flags_equip_slot = SLOT_BACK
+	//overlay_ammo_type = "_penetrating"
+	//overlay_content = "_penetrating"
+	magazine_type = /obj/item/ammo_magazine/rifle/m41aMK1/penetrating
+
+/obj/item/ammo_box/magazine/mk1/penetrating/empty
+	empty = TRUE
+
+/obj/item/ammo_box/magazine/mk1/cluster
+	name = "\improper magazine box (Cluster M41A MK1 x 10)"
+	flags_equip_slot = SLOT_BACK
+	//overlay_ammo_type = "_cluster"
+	//overlay_content = "_cluster"
+	magazine_type = /obj/item/ammo_magazine/rifle/m41aMK1/cluster
+
+/obj/item/ammo_box/magazine/mk1/cluster/empty
+	empty = TRUE
+
 //-----------------------M39 Rifle Mag Boxes-----------------------
 
 /obj/item/ammo_box/magazine/m39

--- a/code/modules/projectiles/ammo_boxes/magazine_boxes.dm
+++ b/code/modules/projectiles/ammo_boxes/magazine_boxes.dm
@@ -386,11 +386,11 @@
 //-----------------------Flamethrower Canister Box-----------------------
 
 /obj/item/ammo_box/magazine/napalm
-	name = "M240 UT-Napthal Fuel (UT x 4)"
-	//icon_state = ""
+	name = "\improper M240 UT-Napthal Fuel (UT x 4)"
+	//icon_state = "napalm"
 	flags_equip_slot = SLOT_BACK
-	overlay_ammo_type = ""
-	overlay_gun_type = ""
+	//overlay_ammo_type = "_ut"
+	//overlay_gun_type = "_ut"
 	num_of_magazines = 4
 	magazine_type = /obj/item/ammo_magazine/flamer_tank
 
@@ -398,11 +398,10 @@
 	empty = TRUE
 
 /obj/item/ammo_box/magazine/napalm/b_gel
-	name = "M240 Napthal B-Gel (B x 4)"
-	//icon_state = ""
+	name = "\improper M240 Napthal B-Gel (B x 4)"
 	flags_equip_slot = SLOT_BACK
-	overlay_ammo_type = ""
-	overlay_gun_type = ""
+	//overlay_ammo_type = "_b"
+	//overlay_gun_type = "_b"
 	num_of_magazines = 4
 	magazine_type = /obj/item/ammo_magazine/flamer_tank/gellied
 
@@ -412,11 +411,11 @@
 //-----------------------Mortar Shells Box-----------------------
 
 /obj/item/ammo_box/magazine/mortar
-	name = "M402 mortar shells box (HE x6)"
-	//icon_state = ""
+	name = "\improper M402 mortar shells box (HE x6)"
+	//icon_state = "base_mortar"
 	flags_equip_slot = SLOT_BACK
-	overlay_ammo_type = ""
-	overlay_gun_type = ""
+	//overlay_ammo_type = "_he"
+	//overlay_content = "_he"
 	num_of_magazines = 6
 	magazine_type = /obj/item/mortar_shell/he
 
@@ -429,8 +428,8 @@
 	name = "M402 mortar fragmentation shells box (F x6)"
 	//icon_state = ""
 	flags_equip_slot = SLOT_BACK
-	overlay_ammo_type = ""
-	overlay_gun_type = ""
+	//overlay_ammo_type = "_frag"
+	//overlay_content = "_frag"
 	num_of_magazines = 6
 	magazine_type = /obj/item/mortar_shell/frag
 
@@ -441,8 +440,8 @@
 	name = "M402 mortar incendiary shells box (I x6)"
 	//icon_state = ""
 	flags_equip_slot = SLOT_BACK
-	overlay_ammo_type = ""
-	overlay_gun_type = ""
+	//overlay_ammo_type = "_inc"
+	//overlay_content = "_inc"
 	num_of_magazines = 6
 	magazine_type = /obj/item/mortar_shell/incendiary
 
@@ -453,8 +452,8 @@
 	name = "M402 mortar flare-camera shells box (FC x6)"
 	//icon_state = ""
 	flags_equip_slot = SLOT_BACK
-	overlay_ammo_type = ""
-	overlay_gun_type = ""
+	//overlay_ammo_type = "_flare"
+	//overlay_content = "_flare"
 	num_of_magazines = 6
 	magazine_type = /obj/item/mortar_shell/flare
 

--- a/code/modules/projectiles/ammo_boxes/misc_boxes.dm
+++ b/code/modules/projectiles/ammo_boxes/misc_boxes.dm
@@ -146,7 +146,7 @@
 	desc = "A box of flashlights to brighten your day!"
 	magazine_type = /obj/item/device/flashlight
 	num_of_magazines = 8
-	overlay_content = ""
+	overlay_content = "_flashlight"
 
 /obj/item/ammo_box/magazine/misc/flashlight/empty
 	empty = TRUE
@@ -158,7 +158,7 @@
 	desc = "A box of High-Capacity Power Cell to keep your electronics going all night long!"
 	magazine_type = /obj/item/cell/high
 	num_of_magazines = 8
-	overlay_content = ""
+	overlay_content = "_power_cell"
 
 /obj/item/ammo_box/magazine/misc/power_cell/empty
 	empty = TRUE
@@ -170,7 +170,7 @@
 	desc = "A box of handheld radios, for staying in touch."
 	magazine_type = /obj/item/device/radio/off
 	num_of_magazines = 8
-	overlay_content = ""
+	overlay_content = "_radio"
 
 /obj/item/ammo_box/magazine/misc/radio/empty
 	empty = TRUE

--- a/code/modules/projectiles/ammo_boxes/misc_boxes.dm
+++ b/code/modules/projectiles/ammo_boxes/misc_boxes.dm
@@ -151,6 +151,18 @@
 /obj/item/ammo_box/magazine/misc/flashlight/empty
 	empty = TRUE
 
+//------------------------Battery Box--------------------------
+
+/obj/item/ammo_box/magazine/misc/power_cell
+	name = "\improper box of High-Capacity Power Cells"
+	desc = "A box of High-Capacity Power Cell to keep your electronics going all night long!"
+	magazine_type = /obj/item/cell/high
+	num_of_magazines = 8
+	overlay_content = ""
+
+/obj/item/ammo_box/magazine/misc/power_cell/empty
+	empty = TRUE
+
 //------------------------Radio Box--------------------------
 
 /obj/item/ammo_box/magazine/misc/radio

--- a/code/modules/projectiles/ammo_boxes/misc_boxes.dm
+++ b/code/modules/projectiles/ammo_boxes/misc_boxes.dm
@@ -138,3 +138,27 @@
 
 /obj/item/ammo_box/magazine/misc/flares/empty
 	empty = TRUE
+
+//------------------------Flashlight Box--------------------------
+
+/obj/item/ammo_box/magazine/misc/flashlight
+	name = "box of flashlights"
+	desc = "A box of flashlights to brighten your day!"
+	magazine_type = /obj/item/device/flashlight
+	num_of_magazines = 8
+	overlay_content = ""
+
+/obj/item/ammo_box/magazine/misc/flashlight/empty
+	empty = TRUE
+
+//------------------------Radio Box--------------------------
+
+/obj/item/ammo_box/magazine/misc/radio
+	name = "box of handheld radios"
+	desc = "A box of handheld radios, for staying in touch."
+	magazine_type = /obj/item/device/radio/off
+	num_of_magazines = 8
+	overlay_content = ""
+
+/obj/item/ammo_box/magazine/misc/radio/empty
+	empty = TRUE

--- a/code/modules/projectiles/ammo_boxes/spec_packets.dm
+++ b/code/modules/projectiles/ammo_boxes/spec_packets.dm
@@ -1,0 +1,131 @@
+//Packets of spec ammo, for easier Requisitions delivery
+/obj/item/storage/box/packet/spec
+	w_class = SIZE_LARGE //Not very useful in a bag, but good for crate delivery
+
+//Sniper
+/obj/item/storage/box/packet/spec/sniper
+	name = "\improper M42A marksman magazine packet (10x28mm Caseless)"
+	desc = "It contains five M42A marksman magazines."
+	storage_slots = 5
+	can_hold = list(/obj/item/ammo_magazine/sniper)
+	content_type = /obj/item/ammo_magazine/sniper
+
+/obj/item/storage/box/packet/spec/sniper/incendiary
+	name = "\improper M42A incendiary magazine packet (10x28mm)"
+	desc = "It contains five M42A incendiary magazines."
+	content_type = /obj/item/ammo_magazine/sniper/incendiary
+
+/obj/item/storage/box/packet/spec/sniper/flak
+	name = "\improper M42A flak magazine packet (10x28mm)"
+	desc = "It contains five M42A flak magazines."
+	content_type = /obj/item/ammo_magazine/sniper/flak
+
+/obj/item/storage/box/packet/spec/sniper/mixed
+	name = "\improper M42A mixed magazine packet (10x28mm)"
+	desc = "It contains six mixed M42A magazines."
+	storage_slots = 6
+	content_type = null //Null because we don't want it indexed
+
+/obj/item/storage/box/packet/spec/sniper/mixed/fill_preset_inventory()
+	new /obj/item/ammo_magazine/sniper(src)
+	new /obj/item/ammo_magazine/sniper(src)
+	new /obj/item/ammo_magazine/sniper/flak(src)
+	new /obj/item/ammo_magazine/sniper/flak(src)
+	new /obj/item/ammo_magazine/sniper/incendiary(src)
+	new /obj/item/ammo_magazine/sniper/incendiary(src)
+
+//Scout
+/obj/item/storage/box/packet/spec/scout
+	name = "\improper A19 high velocity magazine packet (10x24mm)"
+	desc = "It contains five A19 high velocity magazines."
+	storage_slots = 5
+	can_hold = list(/obj/item/ammo_magazine/rifle/m4ra)
+	content_type = /obj/item/ammo_magazine/rifle/m4ra
+
+/obj/item/storage/box/packet/spec/scout/incendiary
+	name = "\improper A19 high velocity incendiary magazine packet (10x24mm)"
+	desc = "It contains five A19 high velocity incendiary magazines."
+	content_type = /obj/item/ammo_magazine/rifle/m4ra/incendiary
+
+/obj/item/storage/box/packet/spec/scout/impact
+	name = "\improper A19 high velocity impact magazine packet (10x24mm)"
+	desc = "It contains five A19 high velocity impact magazines."
+	content_type = /obj/item/ammo_magazine/rifle/m4ra/impact
+
+/obj/item/storage/box/packet/spec/scout/mixed
+	name = "\improper A19 mixed high velocity magazine packet (10x24mm)"
+	desc = "It contains six mixed A19 high velocity impact magazines."
+	storage_slots = 6
+	content_type = null //Null because we don't want it indexed
+
+/obj/item/storage/box/packet/spec/scout/mixed/fill_preset_inventory()
+	new /obj/item/ammo_magazine/rifle/m4ra(src)
+	new /obj/item/ammo_magazine/rifle/m4ra(src)
+	new /obj/item/ammo_magazine/rifle/m4ra/incendiary(src)
+	new /obj/item/ammo_magazine/rifle/m4ra/incendiary(src)
+	new /obj/item/ammo_magazine/rifle/m4ra/impact(src)
+	new /obj/item/ammo_magazine/rifle/m4ra/impact(src)
+
+//Demolitionist
+/obj/item/storage/box/packet/spec/demo
+	name = "\improper M5 RPG Rocket packet (HE)"
+	desc = "It contains three M5 RPG HE rockets."
+	storage_slots = 3
+	can_hold = list(/obj/item/ammo_magazine/rocket)
+	content_type = /obj/item/ammo_magazine/rocket
+
+/obj/item/storage/box/packet/spec/demo/ap
+	name = "\improper M5 RPG Rocket packet (AP)"
+	desc = "It contains three M5 RPG AP rockets."
+	content_type = /obj/item/ammo_magazine/rocket/ap
+
+/obj/item/storage/box/packet/spec/demo/wp
+	name = "\improper M5 RPG Rocket packet (WP)"
+	desc = "It contains three M5 RPG WP rockets."
+	content_type = /obj/item/ammo_magazine/rocket/wp
+
+/obj/item/storage/box/packet/spec/demo/mixed
+	name = "\improper M5 RPG Rocket packet (Mixed)"
+	desc = "It contains three mixed M5 RPG rockets."
+	content_type = null
+
+/obj/item/storage/box/packet/spec/demo/mixed/fill_preset_inventory()
+	new /obj/item/ammo_magazine/rocket(src)
+	new /obj/item/ammo_magazine/rocket/ap(src)
+	new /obj/item/ammo_magazine/rocket/wp(src)
+
+//Pyrotechnician
+/obj/item/storage/box/packet/spec/pyro
+	name = "\improper M240-T Extended Fuel Tank packet"
+	desc = "It contains three M5 RPG HE rockets."
+	storage_slots = 3
+	can_hold = list(/obj/item/ammo_magazine/flamer_tank/large)
+	content_type = /obj/item/ammo_magazine/flamer_tank/large
+
+/obj/item/storage/box/packet/spec/pyro/B
+	name = "\improper M240-T Type-B Fuel Tank packet"
+	desc = "It contains three M240-T Type-B Fuel Tanks."
+	content_type = /obj/item/ammo_magazine/flamer_tank/large/B
+
+/obj/item/storage/box/packet/spec/pyro/X
+	name = "\improper M240-T Type-X Fuel Tank packet"
+	desc = "It contains three M240-T Type-X Fuel Tanks."
+	content_type = /obj/item/ammo_magazine/flamer_tank/large/X
+
+/obj/item/storage/box/packet/spec/pyro/mixed
+	name = "\improper M240-T Mixed Fuel Tank packet"
+	desc = "It contains three mixed M240-T Fuel Tanks."
+	content_type = null
+
+/obj/item/storage/box/packet/spec/pyro/mixed/fill_preset_inventory()
+	new /obj/item/ammo_magazine/flamer_tank/large(src)
+	new /obj/item/ammo_magazine/flamer_tank/large/B(src)
+	new /obj/item/ammo_magazine/flamer_tank/large/X(src)
+
+//Smartgunner
+/obj/item/storage/box/packet/spec/smartgunner
+	name = "\improper M56 smartgun drum packet"
+	desc = "It contains two M56 smartgun drums."
+	storage_slots = 2
+	can_hold = list(/obj/item/ammo_magazine/smartgun)
+	content_type = /obj/item/ammo_magazine/smartgun

--- a/code/modules/projectiles/ammo_boxes/spec_packets.dm
+++ b/code/modules/projectiles/ammo_boxes/spec_packets.dm
@@ -1,6 +1,7 @@
 //Packets of spec ammo, for easier Requisitions delivery
 /obj/item/storage/box/packet/spec
 	w_class = SIZE_LARGE //Not very useful in a bag, but good for crate delivery
+	max_w_class = SIZE_LARGE //We don't care about the size of things since we will only hold one type of item
 
 //Sniper
 /obj/item/storage/box/packet/spec/sniper

--- a/code/modules/projectiles/ammo_boxes/spec_packets.dm
+++ b/code/modules/projectiles/ammo_boxes/spec_packets.dm
@@ -6,6 +6,7 @@
 /obj/item/storage/box/packet/spec/sniper
 	name = "\improper M42A marksman magazine packet (10x28mm Caseless)"
 	desc = "It contains five M42A marksman magazines."
+	//icon_state = "sniper_basic_packet"
 	storage_slots = 5
 	can_hold = list(/obj/item/ammo_magazine/sniper)
 	content_type = /obj/item/ammo_magazine/sniper
@@ -13,16 +14,19 @@
 /obj/item/storage/box/packet/spec/sniper/incendiary
 	name = "\improper M42A incendiary magazine packet (10x28mm)"
 	desc = "It contains five M42A incendiary magazines."
+	//icon_state = "sniper_incendiary_packet"
 	content_type = /obj/item/ammo_magazine/sniper/incendiary
 
 /obj/item/storage/box/packet/spec/sniper/flak
 	name = "\improper M42A flak magazine packet (10x28mm)"
 	desc = "It contains five M42A flak magazines."
+	//icon_state = "sniper_flak_packet"
 	content_type = /obj/item/ammo_magazine/sniper/flak
 
 /obj/item/storage/box/packet/spec/sniper/mixed
 	name = "\improper M42A mixed magazine packet (10x28mm)"
 	desc = "It contains six mixed M42A magazines."
+	//icon_state = "sniper_mixed_packet"
 	storage_slots = 6
 	content_type = null //Null because we don't want it indexed
 
@@ -38,6 +42,7 @@
 /obj/item/storage/box/packet/spec/scout
 	name = "\improper A19 high velocity magazine packet (10x24mm)"
 	desc = "It contains five A19 high velocity magazines."
+	//icon_state = "scout_basic_packet"
 	storage_slots = 5
 	can_hold = list(/obj/item/ammo_magazine/rifle/m4ra)
 	content_type = /obj/item/ammo_magazine/rifle/m4ra
@@ -45,16 +50,19 @@
 /obj/item/storage/box/packet/spec/scout/incendiary
 	name = "\improper A19 high velocity incendiary magazine packet (10x24mm)"
 	desc = "It contains five A19 high velocity incendiary magazines."
+	//icon_state = "scout_incendiary_packet"
 	content_type = /obj/item/ammo_magazine/rifle/m4ra/incendiary
 
 /obj/item/storage/box/packet/spec/scout/impact
 	name = "\improper A19 high velocity impact magazine packet (10x24mm)"
 	desc = "It contains five A19 high velocity impact magazines."
+	//icon_state = "scout_impact_packet"
 	content_type = /obj/item/ammo_magazine/rifle/m4ra/impact
 
 /obj/item/storage/box/packet/spec/scout/mixed
 	name = "\improper A19 mixed high velocity magazine packet (10x24mm)"
 	desc = "It contains six mixed A19 high velocity impact magazines."
+	//icon_state = "scout_mixed_packet"
 	storage_slots = 6
 	content_type = null //Null because we don't want it indexed
 
@@ -70,6 +78,7 @@
 /obj/item/storage/box/packet/spec/demo
 	name = "\improper M5 RPG Rocket packet (HE)"
 	desc = "It contains three M5 RPG HE rockets."
+	//icon_state = "demo_he_packet"
 	storage_slots = 3
 	can_hold = list(/obj/item/ammo_magazine/rocket)
 	content_type = /obj/item/ammo_magazine/rocket
@@ -77,16 +86,19 @@
 /obj/item/storage/box/packet/spec/demo/ap
 	name = "\improper M5 RPG Rocket packet (AP)"
 	desc = "It contains three M5 RPG AP rockets."
+	//icon_state = "demo_ap_packet"
 	content_type = /obj/item/ammo_magazine/rocket/ap
 
 /obj/item/storage/box/packet/spec/demo/wp
 	name = "\improper M5 RPG Rocket packet (WP)"
 	desc = "It contains three M5 RPG WP rockets."
+	//icon_state = "demo_wp_packet"
 	content_type = /obj/item/ammo_magazine/rocket/wp
 
 /obj/item/storage/box/packet/spec/demo/mixed
 	name = "\improper M5 RPG Rocket packet (Mixed)"
 	desc = "It contains three mixed M5 RPG rockets."
+	//icon_state = "demo_mixed_packet"
 	content_type = null
 
 /obj/item/storage/box/packet/spec/demo/mixed/fill_preset_inventory()
@@ -98,6 +110,7 @@
 /obj/item/storage/box/packet/spec/pyro
 	name = "\improper M240-T Extended Fuel Tank packet"
 	desc = "It contains three M5 RPG HE rockets."
+	//icon_state = "pyro_basic_packet"
 	storage_slots = 3
 	can_hold = list(/obj/item/ammo_magazine/flamer_tank/large)
 	content_type = /obj/item/ammo_magazine/flamer_tank/large
@@ -105,16 +118,19 @@
 /obj/item/storage/box/packet/spec/pyro/B
 	name = "\improper M240-T Type-B Fuel Tank packet"
 	desc = "It contains three M240-T Type-B Fuel Tanks."
+	//icon_state = "pyro_b_packet"
 	content_type = /obj/item/ammo_magazine/flamer_tank/large/B
 
 /obj/item/storage/box/packet/spec/pyro/X
 	name = "\improper M240-T Type-X Fuel Tank packet"
 	desc = "It contains three M240-T Type-X Fuel Tanks."
+	//icon_state = "pyro_x_packet"
 	content_type = /obj/item/ammo_magazine/flamer_tank/large/X
 
 /obj/item/storage/box/packet/spec/pyro/mixed
 	name = "\improper M240-T Mixed Fuel Tank packet"
 	desc = "It contains three mixed M240-T Fuel Tanks."
+	//icon_state = "pyro_mixed_packet"
 	content_type = null
 
 /obj/item/storage/box/packet/spec/pyro/mixed/fill_preset_inventory()
@@ -126,6 +142,7 @@
 /obj/item/storage/box/packet/spec/smartgunner
 	name = "\improper M56 smartgun drum packet"
 	desc = "It contains two M56 smartgun drums."
+	//icon_state = "sg_basic_packet"
 	storage_slots = 2
 	can_hold = list(/obj/item/ammo_magazine/smartgun)
 	content_type = /obj/item/ammo_magazine/smartgun


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

To further make the life of cargo and other people easier, I'm adding a few new ammo boxes for items that are missing them.

We probably ought to have the sprites all finished before these things appear in the game, so I'm not yet replacing the various Requisition crates with them.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fewer items in backpacks and more items in boxes give clarity to what's being sent.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->

## Changelog

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added new ammo boxes to the game. These include boxes of shotgun shell boxes (the 25 packs), Mk1 boxes, flamethrower canisters and mortar shells.
add: Added new misc equipment boxes to the game. These include a box of flashlights, high-capacity power cells and handeld radios.
add: Added new ammo packets (boxes you don't place for specialised ammo) to the game for sniper, scout and smartgunner ammo, as well as pyro tanks (grenadiers already have grenade packets!). Should make that ammo more noticeable than being in a backpack somewhere.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
