### PR TITLE
Remove wrong max_w_class comment

### DIFF
--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -15,7 +15,7 @@
 	var/list/click_border_start = new/list() 		//In slotless storage, stores areas where clicking will refer to the associated item
 	var/list/click_border_end = new/list()
 	var/list/hearing_items							//A list of items that use hearing for the purpose of performance
-	var/max_w_class = SIZE_SMALL 					//Max size of objects that this object can store (in effect only if can_hold isn't set)
+	var/max_w_class = SIZE_SMALL 					//Max size of objects that this object can store
 	var/max_storage_space = 14 						//The sum of the storage costs of all the items in this storage item.
 	var/storage_slots = 7 							//The number of storage slots in this container.
 	var/atom/movable/screen/storage/boxes = null

--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -414,18 +414,11 @@ var/list/global/item_storage_box_cache = list()
 			to_chat(usr, SPAN_NOTICE("[src] cannot hold [W]."))
 		return
 
-	var/w_limit_bypassed = FALSE
-
-	//can_hold explicidly bypasses w_class limit
-	if(length(can_hold))
-		for(var/A in can_hold)
-			if(istype(W, A))
-				w_limit_bypassed = TRUE
-
+	var/w_limit_bypassed = 0
 	if(bypass_w_limit.len)
 		for(var/A in bypass_w_limit)
 			if(istype(W, A))
-				w_limit_bypassed = TRUE
+				w_limit_bypassed = 1
 				break
 
 	if (!w_limit_bypassed && W.w_class > max_w_class)

--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -414,11 +414,18 @@ var/list/global/item_storage_box_cache = list()
 			to_chat(usr, SPAN_NOTICE("[src] cannot hold [W]."))
 		return
 
-	var/w_limit_bypassed = 0
+	var/w_limit_bypassed = FALSE
+
+	//can_hold explicidly bypasses w_class limit
+	if(length(can_hold))
+		for(var/A in can_hold)
+			if(istype(W, A))
+				w_limit_bypassed = TRUE
+
 	if(bypass_w_limit.len)
 		for(var/A in bypass_w_limit)
 			if(istype(W, A))
-				w_limit_bypassed = 1
+				w_limit_bypassed = TRUE
 				break
 
 	if (!w_limit_bypassed && W.w_class > max_w_class)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

As per `/obj/item/storage`'s `max_w_class` - `//Max size of objects that this object can store (in effect only if can_hold isn't set)`. However, the last part is not the case, and some code uses that functionality - you can't store guns in specific gun holsters if they get too big. So I removed the misleading part of the comment.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Comments should reflect what's going on in the code not to mislead programmers.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->

## Changelog

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixed a misleading comment around storage items' max_w_class
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
