### PR TITLE
Comm limit nanu

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -506,3 +506,6 @@
 
 // Used for smothering fires upon weather event start/stop
 #define COMSIG_GLOB_WEATHER_CHANGE "!weather_event_changed"
+/// Called when a radio is getting mobs in range to hear a radio message
+#define COMSIG_RADIO_GET_MOB_IN_RANGE "radio_get_mob_in_range"
+	#define COMPONENT_SKIP_RADIO_CHECK (1<<0)

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -146,28 +146,27 @@
 	return hear
 
 /proc/get_mobs_in_radio_ranges(var/list/obj/item/device/radio/radios)
-
-	set background = 1
-
 	. = list()
 	// Returns a list of mobs who can hear any of the radios given in @radios
 	var/list/speaker_coverage = list()
 	for(var/obj/item/device/radio/R in radios)
-		if(R)
-			//Cyborg checks. Receiving message uses a bit of cyborg's charge.
-			var/obj/item/device/radio/borg/BR = R
-			if(istype(BR) && BR.myborg)
-				var/mob/living/silicon/robot/borg = BR.myborg
-				var/datum/robot_component/CO = borg.get_component("radio")
-				if(!CO)
-					continue //No radio component (Shouldn't happen)
-				if(!borg.is_component_functioning("radio") || !borg.cell_use_power(CO.active_usage))
-					continue //No power.
+		if(SEND_SIGNAL(R, COMSIG_RADIO_GET_MOB_IN_RANGE, .) & COMPONENT_SKIP_RADIO_CHECK)
+			continue
 
-			var/turf/speaker = get_turf(R)
-			if(speaker)
-				for(var/turf/T in hear(R.canhear_range,speaker))
-					speaker_coverage[T] = T
+		//Cyborg checks. Receiving message uses a bit of cyborg's charge.
+		var/obj/item/device/radio/borg/BR = R
+		if(istype(BR) && BR.myborg)
+			var/mob/living/silicon/robot/borg = BR.myborg
+			var/datum/robot_component/CO = borg.get_component("radio")
+			if(!CO)
+				continue //No radio component (Shouldn't happen)
+			if(!borg.is_component_functioning("radio") || !borg.cell_use_power(CO.active_usage))
+				continue //No power.
+
+		var/turf/speaker = get_turf(R)
+		if(speaker)
+			for(var/turf/T in hear(R.canhear_range,speaker))
+				speaker_coverage[T] = T
 
 
 	// Try to find all the players who can hear the message

--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -54,6 +54,7 @@
 	name = "Chief Engineer's Encryption Key"
 	icon_state = "ce_key"
 	channels = list(RADIO_CHANNEL_ENGI = 1, RADIO_CHANNEL_COMMAND = 1, RADIO_CHANNEL_MEDSCI = 0, RADIO_CHANNEL_REQ = 0, SQUAD_MARINE_1 = 0, SQUAD_MARINE_2 = 0, SQUAD_MARINE_3 = 0, SQUAD_MARINE_4 = 0, SQUAD_MARINE_5 = 0, SQUAD_MARINE_CRYO = 0)
+	max_channels_on = 3
 
 /obj/item/device/encryptionkey/cmo
 	name = "Chief Medical Officer's Encryption Key"
@@ -69,6 +70,7 @@
 	name = "Requisition Officer's Encryption Key"
 	icon_state = "ce_key"
 	channels = list(RADIO_CHANNEL_REQ = 1, RADIO_CHANNEL_COMMAND = 1, RADIO_CHANNEL_ENGI = 0, RADIO_CHANNEL_MEDSCI = 0, SQUAD_MARINE_1 = 0, SQUAD_MARINE_2 = 0, SQUAD_MARINE_3 = 0, SQUAD_MARINE_4 = 0, SQUAD_MARINE_5 = 0, SQUAD_MARINE_CRYO = 0)
+	max_channels_on = 3
 
 /obj/item/device/encryptionkey/req
 	name = "Supply Radio Encryption Key"
@@ -84,6 +86,7 @@
 	name = "\improper Military Police Radio Encryption Key"
 	icon_state = "sec_key"
 	channels = list(RADIO_CHANNEL_COMMAND = 1, RADIO_CHANNEL_MP = 1, SQUAD_MARINE_1 = 0, SQUAD_MARINE_2 = 0, SQUAD_MARINE_3 = 0, SQUAD_MARINE_4 = 0, SQUAD_MARINE_5 = 0, SQUAD_MARINE_CRYO = 0, RADIO_CHANNEL_ENGI = 1, RADIO_CHANNEL_MEDSCI = 0,)
+	max_channels_on = 3
 
 //MARINE ENCRYPTION KEYS
 
@@ -91,10 +94,12 @@
 	name = "\improper Marine Chief MP Radio Encryption Key"
 	icon_state = "cmp_key"
 	channels = list(RADIO_CHANNEL_COMMAND = 1, RADIO_CHANNEL_MP = 1, RADIO_CHANNEL_ENGI = 0, RADIO_CHANNEL_MEDSCI = 0, RADIO_CHANNEL_REQ = 0, SQUAD_MARINE_1 = 0, SQUAD_MARINE_2 = 0, SQUAD_MARINE_3 = 0, SQUAD_MARINE_4 = 0, SQUAD_MARINE_5 = 0, SQUAD_MARINE_CRYO = 0)
+	max_channels_on = 3
 
 /obj/item/device/encryptionkey/cmpcom/cdrcom
 	name = "\improper Marine Senior Command Radio Encryption Key"
 	channels = list(RADIO_CHANNEL_COMMAND = 1, RADIO_CHANNEL_MP = 1, SQUAD_MARINE_1 = 0, SQUAD_MARINE_2 = 0, SQUAD_MARINE_3 = 0, SQUAD_MARINE_4 = 0, SQUAD_MARINE_5 = 0, SQUAD_MARINE_CRYO = 0, RADIO_CHANNEL_ENGI = 0, RADIO_CHANNEL_MEDSCI = 0, RADIO_CHANNEL_REQ = 0, RADIO_CHANNEL_JTAC = 0, RADIO_CHANNEL_INTEL = 0)
+	max_channels_on = 3
 
 /obj/item/device/encryptionkey/cmpcom/synth
 	name = "\improper Marine Synth Radio Encryption Key"
@@ -104,6 +109,7 @@
 	name = "\improper Marine Command Radio Encryption Key"
 	icon_state = "cap_key"
 	channels = list(RADIO_CHANNEL_COMMAND = 1, SQUAD_MARINE_1 = 0, SQUAD_MARINE_2 = 0, SQUAD_MARINE_3 = 0, SQUAD_MARINE_4 = 0, SQUAD_MARINE_5 = 0, SQUAD_MARINE_CRYO = 0, RADIO_CHANNEL_ENGI = 0, RADIO_CHANNEL_MEDSCI = 0, RADIO_CHANNEL_REQ = 0, RADIO_CHANNEL_JTAC = 0, RADIO_CHANNEL_INTEL = 0)
+	max_channels_on = 3
 
 /obj/item/device/encryptionkey/mcom/cl
 	name = "\improper Corporate Liaison radio encryption key"
@@ -119,11 +125,13 @@
 	name = "\improper Marine Pilot Officer Radio Encryption Key"
 	icon_state = "cap_key"
 	channels = list(RADIO_CHANNEL_COMMAND = 1, SQUAD_MARINE_1 = 0, SQUAD_MARINE_2 = 0, SQUAD_MARINE_3 = 0, SQUAD_MARINE_4 = 0, SQUAD_MARINE_5 = 0, SQUAD_MARINE_CRYO = 0, RADIO_CHANNEL_JTAC = 1, RADIO_CHANNEL_INTEL = 0)
+	max_channels_on = 3
 
 /obj/item/device/encryptionkey/io
 	name = "\improper Marine Intelligence Officer Radio Encryption Key"
 	icon_state = "cap_key"
 	channels = list(RADIO_CHANNEL_COMMAND = 1, SQUAD_MARINE_1 = 0, SQUAD_MARINE_2 = 0, SQUAD_MARINE_3 = 0, SQUAD_MARINE_4 = 0, SQUAD_MARINE_5 = 0, SQUAD_MARINE_CRYO = 0, RADIO_CHANNEL_INTEL = 1)
+	max_channels_on = 3
 
 /obj/item/device/encryptionkey/mcom/ai //AI only.
 	channels = list(RADIO_CHANNEL_COMMAND = 1, RADIO_CHANNEL_MP = 1, SQUAD_MARINE_1 = 1, SQUAD_MARINE_2 = 1, SQUAD_MARINE_3 = 1, SQUAD_MARINE_4 = 1, SQUAD_MARINE_5 = 1, SQUAD_MARINE_CRYO = 0, RADIO_CHANNEL_ENGI = 1, RADIO_CHANNEL_MEDSCI = 1, RADIO_CHANNEL_REQ = 1, RADIO_CHANNEL_JTAC = 1, RADIO_CHANNEL_INTEL = 1)

--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -11,12 +11,12 @@
 	var/list/channels = list()
 	var/list/tracking_options
 	var/abstract = FALSE
+	/// The maximum number of channels this encryption key gives. Takes from the highest giving encryption key.
+	var/max_channels_on = 2
 
 /obj/item/device/encryptionkey/binary
 	icon_state = "binary_key"
 	translate_binary = 1
-
-
 
 /obj/item/device/encryptionkey/public
 	name = "Public Radio Encryption Key"
@@ -33,7 +33,7 @@
 	name = "AI Integrated Encryption Key"
 	desc = "Integrated encryption key"
 	icon_state = "cap_key"
-	channels = list(RADIO_CHANNEL_ALMAYER = 1, RADIO_CHANNEL_COMMAND = 1, RADIO_CHANNEL_MP = 1, RADIO_CHANNEL_ENGI = 1, RADIO_CHANNEL_MEDSCI = 1, RADIO_CHANNEL_REQ = 1, SQUAD_MARINE_1 = 1, SQUAD_MARINE_2 = 1, SQUAD_MARINE_3 = 1, SQUAD_MARINE_4 = 1, SQUAD_MARINE_5 = 1, SQUAD_MARINE_CRYO = 0, RADIO_CHANNEL_JTAC = 1, RADIO_CHANNEL_INTEL = 1)
+	channels = list(RADIO_CHANNEL_ALMAYER = 1, RADIO_CHANNEL_COMMAND = 1, RADIO_CHANNEL_MP = 0, RADIO_CHANNEL_ENGI = 0, RADIO_CHANNEL_MEDSCI = 0, RADIO_CHANNEL_REQ = 0, SQUAD_MARINE_1 = 0, SQUAD_MARINE_2 = 0, SQUAD_MARINE_3 = 0, SQUAD_MARINE_4 = 0, SQUAD_MARINE_5 = 0, SQUAD_MARINE_CRYO = 0, RADIO_CHANNEL_JTAC = 0, RADIO_CHANNEL_INTEL = 0)
 
 /obj/item/device/encryptionkey/engi
 	name = "Engineering Radio Encryption Key"
@@ -53,7 +53,7 @@
 /obj/item/device/encryptionkey/ce
 	name = "Chief Engineer's Encryption Key"
 	icon_state = "ce_key"
-	channels = list(RADIO_CHANNEL_ENGI = 1, RADIO_CHANNEL_COMMAND = 1, RADIO_CHANNEL_MEDSCI = 1, RADIO_CHANNEL_REQ = 1, SQUAD_MARINE_1 = 0, SQUAD_MARINE_2 = 0, SQUAD_MARINE_3 = 0, SQUAD_MARINE_4 = 0, SQUAD_MARINE_5 = 0, SQUAD_MARINE_CRYO = 0)
+	channels = list(RADIO_CHANNEL_ENGI = 1, RADIO_CHANNEL_COMMAND = 1, RADIO_CHANNEL_MEDSCI = 0, RADIO_CHANNEL_REQ = 0, SQUAD_MARINE_1 = 0, SQUAD_MARINE_2 = 0, SQUAD_MARINE_3 = 0, SQUAD_MARINE_4 = 0, SQUAD_MARINE_5 = 0, SQUAD_MARINE_CRYO = 0)
 
 /obj/item/device/encryptionkey/cmo
 	name = "Chief Medical Officer's Encryption Key"
@@ -78,37 +78,37 @@
 /obj/item/device/encryptionkey/req/ct
 	name = "Supply Radio Encryption Key"
 	icon_state = "req_key"
-	channels = list(RADIO_CHANNEL_REQ = 1, RADIO_CHANNEL_COMMAND = 0, RADIO_CHANNEL_ENGI = 0, SQUAD_MARINE_1 = 0, SQUAD_MARINE_2 = 0, SQUAD_MARINE_3 = 0, SQUAD_MARINE_4 = 0, SQUAD_MARINE_5 = 0, SQUAD_MARINE_CRYO = 0)
+	channels = list(RADIO_CHANNEL_REQ = 1, SQUAD_MARINE_CRYO = 0)
 
 /obj/item/device/encryptionkey/mmpo
 	name = "\improper Military Police Radio Encryption Key"
 	icon_state = "sec_key"
-	channels = list(RADIO_CHANNEL_COMMAND = 1, RADIO_CHANNEL_MP = 1, SQUAD_MARINE_1 = 1, SQUAD_MARINE_2 = 1, SQUAD_MARINE_3 = 1, SQUAD_MARINE_4 = 1, SQUAD_MARINE_5 = 1, SQUAD_MARINE_CRYO = 0, RADIO_CHANNEL_ENGI = 1, RADIO_CHANNEL_MEDSCI = 1,)
+	channels = list(RADIO_CHANNEL_COMMAND = 1, RADIO_CHANNEL_MP = 1, SQUAD_MARINE_1 = 0, SQUAD_MARINE_2 = 0, SQUAD_MARINE_3 = 0, SQUAD_MARINE_4 = 0, SQUAD_MARINE_5 = 0, SQUAD_MARINE_CRYO = 0, RADIO_CHANNEL_ENGI = 1, RADIO_CHANNEL_MEDSCI = 0,)
 
 //MARINE ENCRYPTION KEYS
 
 /obj/item/device/encryptionkey/cmpcom
 	name = "\improper Marine Chief MP Radio Encryption Key"
 	icon_state = "cmp_key"
-	channels = list(RADIO_CHANNEL_COMMAND = 1, RADIO_CHANNEL_MP = 1, RADIO_CHANNEL_ENGI = 1, RADIO_CHANNEL_MEDSCI = 1, RADIO_CHANNEL_REQ = 1, SQUAD_MARINE_1 = 0, SQUAD_MARINE_2 = 0, SQUAD_MARINE_3 = 0, SQUAD_MARINE_4 = 0, SQUAD_MARINE_5 = 0, SQUAD_MARINE_CRYO = 0)
+	channels = list(RADIO_CHANNEL_COMMAND = 1, RADIO_CHANNEL_MP = 1, RADIO_CHANNEL_ENGI = 0, RADIO_CHANNEL_MEDSCI = 0, RADIO_CHANNEL_REQ = 0, SQUAD_MARINE_1 = 0, SQUAD_MARINE_2 = 0, SQUAD_MARINE_3 = 0, SQUAD_MARINE_4 = 0, SQUAD_MARINE_5 = 0, SQUAD_MARINE_CRYO = 0)
 
 /obj/item/device/encryptionkey/cmpcom/cdrcom
 	name = "\improper Marine Senior Command Radio Encryption Key"
-	channels = list(RADIO_CHANNEL_COMMAND = 1, RADIO_CHANNEL_MP = 1, SQUAD_MARINE_1 = 1, SQUAD_MARINE_2 = 1, SQUAD_MARINE_3 = 1, SQUAD_MARINE_4 = 1, SQUAD_MARINE_5 = 1, SQUAD_MARINE_CRYO = 0, RADIO_CHANNEL_ENGI = 1, RADIO_CHANNEL_MEDSCI = 1, RADIO_CHANNEL_REQ = 1, RADIO_CHANNEL_JTAC = 1, RADIO_CHANNEL_INTEL = 1)
+	channels = list(RADIO_CHANNEL_COMMAND = 1, RADIO_CHANNEL_MP = 1, SQUAD_MARINE_1 = 0, SQUAD_MARINE_2 = 0, SQUAD_MARINE_3 = 0, SQUAD_MARINE_4 = 0, SQUAD_MARINE_5 = 0, SQUAD_MARINE_CRYO = 0, RADIO_CHANNEL_ENGI = 0, RADIO_CHANNEL_MEDSCI = 0, RADIO_CHANNEL_REQ = 0, RADIO_CHANNEL_JTAC = 0, RADIO_CHANNEL_INTEL = 0)
 
 /obj/item/device/encryptionkey/cmpcom/synth
 	name = "\improper Marine Synth Radio Encryption Key"
-	channels = list(RADIO_CHANNEL_COMMAND = 1, RADIO_CHANNEL_MP = 1, SQUAD_MARINE_1 = 1, SQUAD_MARINE_2 = 1, SQUAD_MARINE_3 = 1, SQUAD_MARINE_4 = 1, SQUAD_MARINE_5 = 1, SQUAD_MARINE_CRYO = 0, RADIO_CHANNEL_ENGI = 1, RADIO_CHANNEL_MEDSCI = 1, RADIO_CHANNEL_REQ = 1, RADIO_CHANNEL_JTAC = 1, RADIO_CHANNEL_INTEL = 1)
+	channels = list(RADIO_CHANNEL_COMMAND = 1, RADIO_CHANNEL_MP = 1, SQUAD_MARINE_1 = 0, SQUAD_MARINE_2 = 0, SQUAD_MARINE_3 = 0, SQUAD_MARINE_4 = 0, SQUAD_MARINE_5 = 0, SQUAD_MARINE_CRYO = 0, RADIO_CHANNEL_ENGI = 0, RADIO_CHANNEL_MEDSCI = 0, RADIO_CHANNEL_REQ = 0, RADIO_CHANNEL_JTAC = 0, RADIO_CHANNEL_INTEL = 0)
 
 /obj/item/device/encryptionkey/mcom
 	name = "\improper Marine Command Radio Encryption Key"
 	icon_state = "cap_key"
-	channels = list(RADIO_CHANNEL_COMMAND = 1, SQUAD_MARINE_1 = 1, SQUAD_MARINE_2 = 1, SQUAD_MARINE_3 = 1, SQUAD_MARINE_4 = 1, SQUAD_MARINE_5 = 1, SQUAD_MARINE_CRYO = 0, RADIO_CHANNEL_ENGI = 1, RADIO_CHANNEL_MEDSCI = 1, RADIO_CHANNEL_REQ = 1, RADIO_CHANNEL_JTAC = 1, RADIO_CHANNEL_INTEL = 1)
+	channels = list(RADIO_CHANNEL_COMMAND = 1, SQUAD_MARINE_1 = 0, SQUAD_MARINE_2 = 0, SQUAD_MARINE_3 = 0, SQUAD_MARINE_4 = 0, SQUAD_MARINE_5 = 0, SQUAD_MARINE_CRYO = 0, RADIO_CHANNEL_ENGI = 0, RADIO_CHANNEL_MEDSCI = 0, RADIO_CHANNEL_REQ = 0, RADIO_CHANNEL_JTAC = 0, RADIO_CHANNEL_INTEL = 0)
 
 /obj/item/device/encryptionkey/mcom/cl
 	name = "\improper Corporate Liaison radio encryption key"
 	icon_state = "cap_key"
-	channels = list(RADIO_CHANNEL_COMMAND = 1, SQUAD_MARINE_1 = 0, SQUAD_MARINE_2 = 0, SQUAD_MARINE_3 = 0, SQUAD_MARINE_4 = 0, SQUAD_MARINE_5 = 0, SQUAD_MARINE_CRYO = 0, RADIO_CHANNEL_ENGI = 1, RADIO_CHANNEL_MEDSCI = 1, RADIO_CHANNEL_REQ = 1, RADIO_CHANNEL_JTAC = 1, RADIO_CHANNEL_INTEL = 1, RADIO_CHANNEL_WY = 1)
+	channels = list(RADIO_CHANNEL_COMMAND = 1, SQUAD_MARINE_1 = 0, SQUAD_MARINE_2 = 0, SQUAD_MARINE_3 = 0, SQUAD_MARINE_4 = 0, SQUAD_MARINE_5 = 0, SQUAD_MARINE_CRYO = 0, RADIO_CHANNEL_ENGI = 0, RADIO_CHANNEL_MEDSCI = 0, RADIO_CHANNEL_REQ = 0, RADIO_CHANNEL_JTAC = 0, RADIO_CHANNEL_INTEL = 0, RADIO_CHANNEL_WY = 1)
 
 /obj/item/device/encryptionkey/mcom/rep
 	name = "\improper Representative radio encryption key"
@@ -118,7 +118,7 @@
 /obj/item/device/encryptionkey/po
 	name = "\improper Marine Pilot Officer Radio Encryption Key"
 	icon_state = "cap_key"
-	channels = list(RADIO_CHANNEL_COMMAND = 1, SQUAD_MARINE_1 = 0, SQUAD_MARINE_2 = 0, SQUAD_MARINE_3 = 0, SQUAD_MARINE_4 = 0, SQUAD_MARINE_5 = 0, SQUAD_MARINE_CRYO = 0, RADIO_CHANNEL_JTAC = 1, RADIO_CHANNEL_INTEL = 1)
+	channels = list(RADIO_CHANNEL_COMMAND = 1, SQUAD_MARINE_1 = 0, SQUAD_MARINE_2 = 0, SQUAD_MARINE_3 = 0, SQUAD_MARINE_4 = 0, SQUAD_MARINE_5 = 0, SQUAD_MARINE_CRYO = 0, RADIO_CHANNEL_JTAC = 1, RADIO_CHANNEL_INTEL = 0)
 
 /obj/item/device/encryptionkey/io
 	name = "\improper Marine Intelligence Officer Radio Encryption Key"
@@ -127,6 +127,7 @@
 
 /obj/item/device/encryptionkey/mcom/ai //AI only.
 	channels = list(RADIO_CHANNEL_COMMAND = 1, RADIO_CHANNEL_MP = 1, SQUAD_MARINE_1 = 1, SQUAD_MARINE_2 = 1, SQUAD_MARINE_3 = 1, SQUAD_MARINE_4 = 1, SQUAD_MARINE_5 = 1, SQUAD_MARINE_CRYO = 0, RADIO_CHANNEL_ENGI = 1, RADIO_CHANNEL_MEDSCI = 1, RADIO_CHANNEL_REQ = 1, RADIO_CHANNEL_JTAC = 1, RADIO_CHANNEL_INTEL = 1)
+	max_channels_on = 999
 
 /obj/item/device/encryptionkey/jtac
 	name = "\improper JTAC Radio Encryption Key"
@@ -146,7 +147,7 @@
 /obj/item/device/encryptionkey/squadlead
 	name = "\improper Squad Leader Radio Encryption Key"
 	icon_state = "sl_key"
-	channels = list(RADIO_CHANNEL_COMMAND = 1, RADIO_CHANNEL_JTAC = 1)
+	channels = list(RADIO_CHANNEL_COMMAND = 1, RADIO_CHANNEL_JTAC = 0)
 
 /obj/item/device/encryptionkey/squadlead/acting
 	abstract = TRUE
@@ -184,7 +185,7 @@
 /obj/item/device/encryptionkey/soc
 	name = "\improper SOF Radio Encryption Key"
 	icon_state = "binary_key"
-	channels = list(RADIO_CHANNEL_COMMAND = 1, RADIO_CHANNEL_REQ = 1, RADIO_CHANNEL_MEDSCI = 1, RADIO_CHANNEL_ENGI = 1, RADIO_CHANNEL_INTEL = 1, RADIO_CHANNEL_JTAC = 1, SQUAD_MARINE_1 = 0, SQUAD_MARINE_2 = 0, SQUAD_MARINE_3 = 0, SQUAD_MARINE_4 = 0, SQUAD_MARINE_5 = 0, SQUAD_MARINE_CRYO = 0)
+	channels = list(RADIO_CHANNEL_COMMAND = 1, RADIO_CHANNEL_REQ = 0, RADIO_CHANNEL_MEDSCI = 0, RADIO_CHANNEL_ENGI = 0, RADIO_CHANNEL_INTEL = 1, RADIO_CHANNEL_JTAC = 0, SQUAD_MARINE_1 = 0, SQUAD_MARINE_2 = 0, SQUAD_MARINE_3 = 0, SQUAD_MARINE_4 = 0, SQUAD_MARINE_5 = 0, SQUAD_MARINE_CRYO = 0)
 
 //For CL and their Marine goons
 /obj/item/device/encryptionkey/WY
@@ -197,7 +198,7 @@
 /obj/item/device/encryptionkey/ert
 	name = "Wey-Yu Radio Encryption Key"
 	icon_state = "cypherkey"
-	channels = list(RADIO_CHANNEL_ERT = 1, RADIO_CHANNEL_COMMAND = 1, RADIO_CHANNEL_MEDSCI = 1, RADIO_CHANNEL_ENGI = 1, RADIO_CHANNEL_WY = 1)
+	channels = list(RADIO_CHANNEL_ERT = 0, RADIO_CHANNEL_COMMAND = 1, RADIO_CHANNEL_MEDSCI = 0, RADIO_CHANNEL_ENGI = 0, RADIO_CHANNEL_WY = 1)
 
 /obj/item/device/encryptionkey/dutch
 	name = "\improper Dutch's Dozen Radio Encryption Key"
@@ -224,13 +225,15 @@
 	name = "\improper USCM High Command Radio Encryption Key"
 	icon_state = "binary_key"
 	channels = list(RADIO_CHANNEL_HIGHCOM = 1, SQUAD_SOF = 1, RADIO_CHANNEL_COMMAND = 1, RADIO_CHANNEL_MP = 1, SQUAD_MARINE_1 = 1, SQUAD_MARINE_2 = 1, SQUAD_MARINE_3 = 1, SQUAD_MARINE_4 = 1, SQUAD_MARINE_5 = 1, SQUAD_MARINE_CRYO = 0, RADIO_CHANNEL_ENGI = 1, RADIO_CHANNEL_MEDSCI = 1, RADIO_CHANNEL_REQ = 1, RADIO_CHANNEL_JTAC = 1, RADIO_CHANNEL_INTEL = 1)
+	max_channels_on = 999
 
 /obj/item/device/encryptionkey/contractor
 	name = "\improper Vanguard's Arrow Incorporated Radio Encryption Key"
 	icon_state = "sl_key"
-	channels = list("Command" = 1, "Engi" = 1, "MedSci" = 1, "Req" = 1, "JTAC" = 1, "Intel" = 1, "Almayer" = 1)
+	channels = list(RADIO_CHANNEL_COMMAND = 1, RADIO_CHANNEL_ENGI = 0, RADIO_CHANNEL_MEDSCI = 0, RADIO_CHANNEL_REQ = 0, RADIO_CHANNEL_JTAC = 0, RADIO_CHANNEL_INTEL = 0, RADIO_CHANNEL_ALMAYER = 1)
+
 /// Used by the Mortar Crew in WO game mode - intently has no squad radio access
 /obj/item/device/encryptionkey/mortar
 	name = "\improper Mortar Crew Radio Encryption Key"
 	icon_state = "eng_key"
-	channels = list(RADIO_CHANNEL_ENGI = 1, RADIO_CHANNEL_JTAC = 1, RADIO_CHANNEL_INTEL = 1, RADIO_CHANNEL_REQ = 1)
+	channels = list(RADIO_CHANNEL_ENGI = 1, RADIO_CHANNEL_JTAC = 1, RADIO_CHANNEL_INTEL = 0, RADIO_CHANNEL_REQ = 0)

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -188,7 +188,7 @@
 	syndie = FALSE
 
 	tracking_options = length(inbuilt_tracking_options) ? inbuilt_tracking_options.Copy() : list()
-	max_channels_on = 0
+	max_channels_on = initial(max_channels_on)
 	last_activated_channels = list()
 	for(var/i in keys)
 		var/obj/item/device/encryptionkey/key = i

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -17,6 +17,10 @@
 	var/ignore_z = FALSE
 	var/freerange = 0 // 0 - Sanitize frequencies, 1 - Full range
 	var/list/channels = list() //see communications.dm for full list. First channes is a "default" for :h
+	/// Queue of channels that have been activated in the order they were activated in.
+	var/list/last_activated_channels = list()
+	/// The maximum number of channels you can have at once
+	var/max_channels_on = 2
 	var/subspace_transmission = 0
 	/// If true, subspace_transmission can be toggled at will.
 	var/subspace_switchable = FALSE
@@ -149,8 +153,13 @@
 				return
 			if(channels[channel] & FREQ_LISTENING)
 				channels[channel] &= ~FREQ_LISTENING
+				last_activated_channels -= channel
 			else
 				channels[channel] |= FREQ_LISTENING
+				last_activated_channels += channel
+				ui.user.visible_message(SPAN_NOTICE("[ui.user] fiddles with [src]."), SPAN_NOTICE("You tune [src] into the '[channel]' channel."))
+			while(max_channels_on > 0 && length(last_activated_channels) > max_channels_on)
+				channels[popleft(last_activated_channels)] &= ~FREQ_LISTENING
 			. = TRUE
 		if("command")
 			use_volume = !use_volume

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -5,30 +5,6 @@
 		.["modes"] += "headset"
 		return
 
-	if(length(message) >= 2 && message[1] == ",")
-		// Radio multibroadcast functionality.
-		// If a message starts with , we assume that up to MULTIBROADCAST_MAX_CHANNELS
-		// next symbols are channel names. If we run into a space we stop looking for more channels.
-		var/i
-		for(i in 2 to 1 + MULTIBROADCAST_MAX_CHANNELS)
-			var/current_channel = message[i]
-			if(current_channel == " " || current_channel == ":" || current_channel == ".")
-				i--
-				break
-			.["modes"] += department_radio_keys[":[current_channel]"]
-		.["message_and_language"] = copytext(message, i+1)
-		var/multibroadcast_cooldown = 0
-		for(var/obj/item/device/radio/headset/headset in list(wear_l_ear, wear_r_ear))
-			if(world.time - headset.last_multi_broadcast < headset.multibroadcast_cooldown)
-				var/cooldown_remaining = (headset.last_multi_broadcast + headset.multibroadcast_cooldown) - world.time
-				if(cooldown_remaining > multibroadcast_cooldown)
-					multibroadcast_cooldown = cooldown_remaining
-			else
-				headset.last_multi_broadcast = world.time
-		if(multibroadcast_cooldown)
-			.["fail_with"] = "You've used the multi-broadcast system too recently, wait [round(multibroadcast_cooldown / 10)] more seconds."
-		return
-
 	if(length(message) >= 2 && (message[1] == "." || message[1] == ":"))
 		var/channel_prefix = copytext(message, 1, 3)
 		if(channel_prefix in department_radio_keys)


### PR DESCRIPTION
## About The Pull Request
First of all, I'm fairly pissed at people coming with personal attacks on a change they do not agree with and then proceeding to attack Walter without taking a second to think for themselves rather than scream about it.

I'll be taking over this PR https://github.com/cmss13-devs/cmss13/pull/1780 and re-opening it. Concerns, issues etc. should be put in the Discord Feedback thread in a respectable format.

This limits the amount of radio channels you can have enabled at the same time depending on your role.

## Why It's Good For The Game
_My interest in this PR is primarily two things:_

> 
> 1. Establish a more proper CoC for sending information up and down the chain.
> 
> 2. Hinder communication "powergaming" where one person is on every channel. IC you are not required to know every single tidbit of information.
> 
> However, there are some proper issues that would need to be addressed if this was to make it through.
> 
> 1. Look at impact on lowpop rounds. And how command staff/lack of command staff will handle coordination between squads.
> 
> 2. How do you if implemented alleviate people just using one "common" channel such as the command one for everything, leading to more clutter in a single channel.
> 

## Changelog
:cl: Nanu
balance: Limits the amount of communication channels you can be on at once to 2 for most roles. Auxiliary roles such as CO/XO/IO/PO and such can access 3 channels at once.
balance: Removes sending one message to a bunch of radio channels at once.
balance: Removes command channel access from CTs
/:cl:
