### PR TITLE
Adds an extremely simple ingame netspeak notifier.

### DIFF
--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -160,6 +160,11 @@ var/list/department_radio_keys = list(
 		for(var/obj/O as anything in listening_obj)
 			if(O) //It's possible that it could be deleted in the meantime.
 				O.hear_talk(src, message, verb, speaking, italics)
+				
+	var/static/regex/netspeak = regex("\\b(lol|brb|wtf|lmao|sus|kek|idk|omg)\\b", "i")
+	if(findtext(message, netspeak))
+		to_chat(src, "<span class='warning'>Netspeak is not permitted in character!</span>")
+		return
 
 	//used for STUI to stop logging of animal messages and radio
 	//if(!nolog)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Sends a notification to the player when they engage in netspeak.

## Why It's Good For The Game

It's better than nothing.

https://streamable.com/jqh8q3

## Changelog

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
server: Added an ingame netspeak notifier.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
