### PR TITLE
fix point markers, aimed shot and spot target reticles not being centered

### DIFF
--- a/code/game/objects/effects/overlays.dm
+++ b/code/game/objects/effects/overlays.dm
@@ -69,8 +69,8 @@
 		pixel_x = dist_x * 32
 		pixel_y = dist_y * 32
 
-		var/offset_x = actual_pointed_atom?.pixel_x || 0
-		var/offset_y = actual_pointed_atom?.pixel_y || 0
+		var/offset_x = actual_pointed_atom ? get_pixel_position_x(actual_pointed_atom, relative = TRUE) : 0
+		var/offset_y = actual_pointed_atom ? get_pixel_position_y(actual_pointed_atom, relative = TRUE) : 0
 
 		animate(src, pixel_x = offset_x, pixel_y = offset_y, time = glide_time, easing = QUAD_EASING)
 

--- a/code/game/objects/items/devices/binoculars.dm
+++ b/code/game/objects/items/devices/binoculars.dm
@@ -412,6 +412,8 @@
 	var/f_spotting_time = designator.spotting_time + distance
 
 	var/image/I = image(icon = 'icons/effects/Targeted.dmi', icon_state = "locking-spotter", dir = get_cardinal_dir(target, human))
+	I.pixel_x = -target.pixel_x + target.base_pixel_x
+	I.pixel_y = (target.icon_size - world.icon_size) * 0.5 - target.pixel_y + target.base_pixel_y
 	target.overlays += I
 	ADD_TRAIT(target, TRAIT_SPOTTER_LAZED, TRAIT_SOURCE_EQUIPMENT(designator.tracking_id))
 	if(human.client)

--- a/code/modules/mob/living/carbon/xenomorph/castes/Burrower.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Burrower.dm
@@ -46,6 +46,8 @@
 	plasma_types = list(PLASMA_PURPLE)
 	pixel_x = -12
 	old_x = -12
+	base_pixel_x = 0
+	base_pixel_y = -20
 	tier = 2
 	base_actions = list(
 		/datum/action/xeno_action/onclick/xeno_resting,

--- a/code/modules/mob/living/carbon/xenomorph/castes/Runner.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Runner.dm
@@ -36,7 +36,7 @@
 	tier = 1
 	pixel_x = -16  //Needed for 2x2
 	old_x = -16
-	base_pixel_x = -4
+	base_pixel_x = 0
 	base_pixel_y = -20
 	pull_speed = -0.5
 	viewsize = 9

--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -90,6 +90,8 @@
 		f_aiming_time *= 0.5
 
 	var/image/I = image(icon = 'icons/effects/Targeted.dmi', icon_state = "locking-sniper", dir = get_cardinal_dir(M, H))
+	I.pixel_x = -M.pixel_x + M.base_pixel_x
+	I.pixel_y = (M.icon_size - world.icon_size) * 0.5 - M.pixel_y + M.base_pixel_y
 	M.overlays += I
 	if(H.client)
 		playsound_client(H.client, 'sound/weapons/TargetOn.ogg', H, 50)


### PR DESCRIPTION
## About The Pull Request

this centers pointing markers (the thing when you point at something), aimed shots and spot target reticles
also adjusts base_pixel_x for runners and adjusts base_pixel_y for burrowers

## Why It's Good For The Game

currently when you point at a xeno, the point marker goes off to its side and doesn't get centered, same with aimed shots and spot target - this changes it so that it works

my only issue is that I don't like my implementation for fixing this for the aimed shot and spot target, I would've liked to use get_pixel_position_x/y but it doesn't work for overlays (either that or I'm stupid and missed something very obvious when doing the numbers in my head)

## Changelog

:cl:
fix: fixes pointing markers, aimed shot and spot target reticles not being centered
/:cl:

