### PR TITLE
removes redundant proc overrides for walls

### DIFF
--- a/code/game/turfs/walls/wall_types.dm
+++ b/code/game/turfs/walls/wall_types.dm
@@ -91,7 +91,6 @@
 /turf/closed/wall/almayer/research/containment/wall/ex_act(severity, explosion_direction)
 	if(severity <= EXPLOSION_THRESHOLD_MEDIUM) // Wall is resistant to explosives (and also crusher charge)
 		return
-
 	. = ..()
 
 /turf/closed/wall/almayer/research/containment/wall/take_damage(dam, mob/M)
@@ -397,9 +396,6 @@
 /turf/closed/wall/mineral/bone/is_weedable()
 	return NOT_WEEDABLE
 
-/turf/closed/wall/mineral/bone/ex_act(severity, explosion_direction, source, mob/source_mob)
-	return
-
 //Misc walls
 
 /turf/closed/wall/cult
@@ -497,9 +493,6 @@
 	desc = "An absolutely massive collection of columns made of ice. The longer you stare, the deeper the ice seems to go."
 	walltype = WALL_STRATA_ICE //Not a metal wall
 	hull = 1 //Can't break this ice.
-
-/turf/closed/wall/strata_ice/ex_act(severity)
-	return
 
 /turf/closed/wall/strata_ice/dirty
 	icon_state = "strata_ice_dirty"
@@ -639,9 +632,6 @@
 	desc = "Slabs on slabs of dirty black ice crusted over ancient rock formations. The permafrost fluctuates between 20in and 12in during the summer months."
 	walltype = WALL_SHIVA_ICE //Not a metal wall
 	hull = 1 //Can't break this ice.
-
-/turf/closed/wall/strata_ice/ex_act(severity)
-	return
 
 /turf/closed/wall/shiva/prefabricated
 	name = "prefabricated structure wall"


### PR DESCRIPTION
## About The Pull Request

this removes a few walls overriding the ex_act proc to do something it already does (it returns if hull is set to 1, which all of these already are)

## Why It's Good For The Game

podrick equus wanted this; reduces redundancy

## Changelog

:cl:
code: removed redundant behavior in walls
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
