### PR TITLE
Warrior Nerf  {no gpb update}

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/warrior/warrior_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/warrior/warrior_abilities.dm
@@ -20,7 +20,7 @@
 	macro_path = /datum/action/xeno_action/verb/verb_fling
 	action_type = XENO_ACTION_CLICK
 	ability_primacy = XENO_PRIMARY_ACTION_3
-	xeno_cooldown = 55
+	xeno_cooldown = 65
 
 	// Configurables
 	var/fling_distance = 4
@@ -53,7 +53,7 @@
 	macro_path = /datum/action/xeno_action/verb/verb_punch
 	action_type = XENO_ACTION_CLICK
 	ability_primacy = XENO_PRIMARY_ACTION_1
-	xeno_cooldown = 40
+	xeno_cooldown = 50
 
 	// Configurables
 	var/base_damage = 25

--- a/code/modules/mob/living/carbon/xenomorph/castes/Warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Warrior.dm
@@ -108,11 +108,11 @@
 /datum/behavior_delegate/warrior_base
 	name = "Base Warrior Behavior Delegate"
 
-	var/slash_charge_cdr = 0.30 SECONDS // Amount to reduce charge cooldown by per slash
+	var/slash_charge_cdr = 0.20 SECONDS // Amount to reduce charge cooldown by per slash
 	var/lifesteal_percent = 7
 	var/max_lifesteal = 9
-	var/lifesteal_range =  3
-	var/lifesteal_lock_duration = 20
+	var/lifesteal_range =  3 // Marines within 3 tiles of range will give the warrior extra health
+	var/lifesteal_lock_duration = 20 // This will remove the glow effect on warrior after 2 seconds
 	var/color = "#6c6f24"
 	var/emote_cooldown = 0
 


### PR DESCRIPTION
## About The Pull Request

This PR nerfs warrior. I believe it is a little bit too powerful compared to when it had shields. The rework intended it the caste to fit in more as a side/frontline ambusher however it allowed the caste to get away with very nasty cooldown reductions due to the inherently low cooldown of Fling and Punch. I've also reduced the amount of CDR gained as a way to curb the issue with current warrior.

## Why It's Good For The Game

Fine tuning, has been left alone for far too long. Although current warrior is very fun and actually fits in with its role, the rework did not take into account the cooldowns of fling/punch which is far too small for the caste along with the slash CDR. This PR will fix it, and hopefully stop people from whining.

## Changelog usnpeepoo
:cl:
balance: Warriors slash cooldown reduction has been reduced by 0.10 seconds
balance: Warriors Fling, and Punch have their cooldowns increased by 1 second
/:cl:

