### PR TITLE
Fix vendor malfunctioning runtime

### DIFF
--- a/code/game/machinery/vending/vending.dm
+++ b/code/game/machinery/vending/vending.dm
@@ -606,7 +606,10 @@
 /obj/structure/machinery/vending/proc/release_item(var/datum/data/vending_product/R, var/delay_vending = 0, var/mob/living/carbon/human/user)
 	set waitfor = 0
 
-	ui_interact(user)
+	//We interact with the UI only if a user is present
+	//(This function can be called with no user if the machine gets blown up / malfunctions)
+	if(user)
+		ui_interact(user)
 
 	if (delay_vending)
 		use_power(vend_power_usage)	//actuators and stuff


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

We used to get these runtimes whenever a vendor would malfunction / get exploded:

```
runtime error: Invalid argument: client: ``
proc name: send assets (/datum/asset_transport/proc/send_assets)
  source file: asset_transport.dm,83
  usr: null
  src: Simple browse_rsc asset transp... (/datum/asset_transport)
  call stack:
Simple browse_rsc asset transp... (/datum/asset_transport): send assets(null, /list (/list))
/datum/asset/simple/nanoui_ima... (/datum/asset/simple/nanoui_images): send(null)
/datum/nanoui (/datum/nanoui): New(null, Hot Foods Machine (/obj/structure/machinery/vending/snack), "main", "vending_machine.tmpl", "Hot Foods Machine", 450, 600, null, 0)
Hot Foods Machine (/obj/structure/machinery/vending/snack): ui interact(null, "main", null, 0)
Hot Foods Machine (/obj/structure/machinery/vending/snack): release item(data (/datum/data/vending_product), 0, null)
Hot Foods Machine (/obj/structure/machinery/vending/snack): malfunction()
ImmediateInvokeAsync(Hot Foods Machine (/obj/structure/machinery/vending/snack), /obj/structure/machinery/vendi... (/obj/structure/machinery/vending/proc/malfunction))
Hot Foods Machine (/obj/structure/machinery/vending/snack): ex act(36.892, 10, /datum/cause_data (/datum/cause_data))
ImmediateInvokeAsync(Hot Foods Machine (/obj/structure/machinery/vending/snack), /atom/proc/ex_act (/atom/proc/ex_act), 36.892, 10, /datum/cause_data (/datum/cause_data))
/datum/automata_cell/explosion (/datum/automata_cell/explosion): update state(null)
Cellular Automata (/datum/controller/subsystem/cellauto): fire(0)
Cellular Automata (/datum/controller/subsystem/cellauto): ignite(0)
Master (/datum/controller/master): RunQueue()
Master (/datum/controller/master): Loop()
Master (/datum/controller/master): StartProcessing(0)
```

So fixed it.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Less runtime errors make the log file smaller and neater.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->

## Changelog

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixed a runtime around vending machines malfunctioning / getting exploded.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
