### PR TITLE
Minor Xeno Backend Tweaks

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -131,6 +131,10 @@
 // HIVE TRAITS
  /// If the Hive is a Xenonid Hive
 #define TRAIT_XENONID "t_xenonid"
+ /// If the Hive delays round end (this is overriden for some hives). Does not occur naturally. Must be applied in events.
+#define TRAIT_NO_HIVE_DELAY "t_no_hive_delay"
+ /// If the Hive uses it's colors on the mobs. Does not occur naturally, excepting the Mutated hive.
+#define TRAIT_NO_COLOR "t_no_color"
 
 // MISC MOB TRAITS
  /// If the mob is nested.

--- a/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
@@ -562,7 +562,8 @@
 		name_client_postfix = client.xeno_postfix ? ("-"+client.xeno_postfix) : ""
 		age_xeno()
 	full_designation = "[name_client_prefix][nicknumber][name_client_postfix]"
-	color = in_hive.color
+	if(!HAS_TRAIT(src, TRAIT_NO_COLOR))
+		color = in_hive.color
 
 	var/age_display = show_age_prefix ? age_prefix : ""
 	var/name_display = ""
@@ -646,7 +647,7 @@
 	if(isXeno(user))
 		var/mob/living/carbon/Xenomorph/xeno = user
 		if(hivenumber != xeno.hivenumber)
-			. += "It appears to belong to [hive?.prefix ? "the [hive.prefix]" : "a different "]hive."
+			. += "It appears to belong to [hive?.name ? "the [hive.name]" : "a different hive"]."
 
 	if(isXeno(user) || isobserver(user))
 		if(mutation_type != "Normal")

--- a/code/modules/mob/living/carbon/xenomorph/egg_item.dm
+++ b/code/modules/mob/living/carbon/xenomorph/egg_item.dm
@@ -31,7 +31,7 @@
 		. += "A queen egg, it needs to be planted on weeds to start growing."
 		if(hivenumber != XENO_HIVE_NORMAL)
 			var/datum/hive_status/hive = GLOB.hive_datum[hivenumber]
-			. += "This one appears to belong to the [hive.prefix]hive"
+			. += "This one appears to belong to the [hive.name]"
 
 /obj/item/xeno_egg/afterattack(atom/target, mob/user, proximity)
 	if(isXeno(user))

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -826,6 +826,8 @@
 	return allies[faction]
 
 /datum/hive_status/proc/can_delay_round_end(var/mob/living/carbon/Xenomorph/xeno)
+	if(HAS_TRAIT(src, TRAIT_NO_HIVE_DELAY))
+		return FALSE
 	return TRUE
 
 /datum/hive_status/corrupted
@@ -917,7 +919,7 @@
 	return FALSE
 
 /datum/hive_status/yautja
-	name = "Yautja Hive"
+	name = "Hellhound Pack"
 	hivenumber = XENO_HIVE_YAUTJA
 	internal_faction = FACTION_YAUTJA
 
@@ -938,7 +940,7 @@
 	color = "#6abd99"
 	ui_color = "#6abd99"
 
-	hive_inherant_traits = list(TRAIT_XENONID)
+	hive_inherant_traits = list(TRAIT_XENONID, TRAIT_NO_COLOR)
 
 /datum/hive_status/corrupted/tamed
 	name = "Tamed Hive"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Changes xeno hive round delay to a hive trait to allow for adding or removing from hives in events (currently no way to add hive traits though)
Adds a trait to alter if a hive uses it's colours on the xenos or not. Currently this is exclusive to the mutated hive so they retain plain coloured xenonid sprites while having coloured weeds and structures.
Changes examine for what hive xenos belong to, now showing the hive name rather than "Prefix Hive" which didn't make much sense to me.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes things nice and tidy, and allows for more flexibility.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->

## Changelog

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
code: Adds two new hive traits. NO_HVE_DELAY and NO_COLOR. Delay regards to round end and if they need to be wiped out or not. Color regards to xeno colours, not weeds or anything else.
code: Examining xenos or structures now show the name of the hive they belong to, rather than bastardising it by using [Hive.prefix] Hive
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
