### PR TITLE
Fixed runtime error around gibbing a mob with autopsy data

### DIFF
--- a/code/__HELPERS/qdel.dm
+++ b/code/__HELPERS/qdel.dm
@@ -3,6 +3,7 @@
 #define QDEL_IN_CLIENT_TIME(item, time) addtimer(CALLBACK(GLOBAL_PROC, .proc/qdel, item), time, TIMER_STOPPABLE | TIMER_CLIENT_TIME)
 #define QDEL_NULL(item) qdel(item); item = null
 #define QDEL_LIST(L) for(var/I in L) qdel(I); L?.Cut();
+#define QDEL_NULL_LIST(x) if(x) { for(var/y in x) { qdel(y) }}; if(x) {x.Cut(); x = null } // Second x check to handle items that LAZYREMOVE on qdel.
 #define QDEL_LIST_IN(L, time) addtimer(CALLBACK(GLOBAL_PROC, .proc/______qdel_list_wrapper, L), time, TIMER_STOPPABLE)
 #define QDEL_LIST_ASSOC(L) for(var/I in L) { qdel(L[I]); qdel(I); } L?.Cut();
 #define QDEL_LIST_ASSOC_VAL(L) for(var/I in L) qdel(L[I]); L?.Cut();

--- a/code/_macros.dm
+++ b/code/_macros.dm
@@ -20,6 +20,7 @@
 #define CanPhysicallyInteractWith(user, target) CanInteractWith(user, target, GLOB.physical_state)
 
 #define QDEL_NULL_LIST(x) if(x) { for(var/y in x) { qdel(y) }}; if(x) {x.Cut(); x = null } // Second x check to handle items that LAZYREMOVE on qdel.
+#define QDEL_NULL_MAP(x) if(x) { for(var/y in x) { if(x[y]) {qdel(x[y]); x[y] = null }}}; if(x) {x.Cut(); x = null } // Second x check to handle items that LAZYREMOVE on qdel.
 
 #define DROP_NULL(x) if(x) { x.dropInto(loc); x = null; }
 

--- a/code/_macros.dm
+++ b/code/_macros.dm
@@ -19,9 +19,6 @@
 
 #define CanPhysicallyInteractWith(user, target) CanInteractWith(user, target, GLOB.physical_state)
 
-#define QDEL_NULL_LIST(x) if(x) { for(var/y in x) { qdel(y) }}; if(x) {x.Cut(); x = null } // Second x check to handle items that LAZYREMOVE on qdel.
-#define QDEL_NULL_MAP(x) if(x) { for(var/y in x) { if(x[y]) {qdel(x[y]); x[y] = null }}}; if(x) {x.Cut(); x = null } // Second x check to handle items that LAZYREMOVE on qdel.
-
 #define DROP_NULL(x) if(x) { x.dropInto(loc); x = null; }
 
 #define ARGS_DEBUG log_debug("[__FILE__] - [__LINE__]") ; for(var/arg in args) { log_debug("\t[log_info_line(arg)]") }

--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -111,7 +111,7 @@
 	QDEL_NULL(hidden)
 	QDEL_NULL_LIST(internal_organs)
 	QDEL_NULL_LIST(implants)
-	QDEL_NULL_LIST(autopsy_data)
+	QDEL_NULL_MAP(autopsy_data)
 
 	if(bleeding_effects_list)
 		for(var/datum/effects/bleeding/B in bleeding_effects_list)

--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -111,7 +111,7 @@
 	QDEL_NULL(hidden)
 	QDEL_NULL_LIST(internal_organs)
 	QDEL_NULL_LIST(implants)
-	QDEL_NULL_MAP(autopsy_data)
+	QDEL_LIST_ASSOC_VAL(autopsy_data)
 
 	if(bleeding_effects_list)
 		for(var/datum/effects/bleeding/B in bleeding_effects_list)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Fixes #1808

We had a good deal of runtime errors each time a mob with autopsy data (aka most people) would get gibbed. Turns out it was caused by the autopsy data list being a map and us trying to delete it wrong. So I fixed that.

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

Less runtimes more good.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: Fixed an error causing a lot of runtime error logs whenever a mob with autopsy data would get gibbed.
code: Moved QDEL_NULL_LIST in along with other qdel procs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
