### PR TITLE
Fixes bad deletion of structure spawners due to stack bleed

### DIFF
--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -99,8 +99,7 @@ var/global/cas_tracking_id_increment = 0	//this var used to assign unique tracki
 	for(var/obj/effect/landmark/structure_spawner/SS in GLOB.structure_spawners)
 		SS.post_setup()
 	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_MODE_POSTSETUP)
-	spawn (ROUNDSTART_LOGOUT_REPORT_TIME)
-		display_roundstart_logout_report()
+	addtimer(CALLBACK(GLOBAL_PROC, /proc/display_roundstart_logout_report), ROUNDSTART_LOGOUT_REPORT_TIME)
 
 	for(var/mob/new_player/np in GLOB.new_player_list)
 		np.new_player_panel_proc()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

`/obj/effect/landmark/structure_spawner`s have been failing to delete properly for years, causing 500+ fails on roundstart, and could never find why. 

Apparently the reason this proc implicitly copies `GLOB.structure_spawners` for iterating, and this call stack gets passed down for the next 10 minutes due to the `spawn`. This is long enough for `SSgarbage` to assume deletion failed.

# Explain why it's good for the game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->

Future-performance, accountability, one more example of why `spawn` is bad

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

![image](https://user-images.githubusercontent.com/604624/205453391-021db329-198a-45a6-abc0-2194aac8a88b.png)

Couple minutes post roundstart, flushed Queue, TGR 99.84% - if you ever looked at readouts it's usually 92-95% due to failed deletions



# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
code: Fixed deletion issues with structure spawners.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
