### PR TITLE
Money Rework

### DIFF
--- a/code/datums/paygrades/factions/civillian/civilian.dm
+++ b/code/datums/paygrades/factions/civillian/civilian.dm
@@ -1,26 +1,30 @@
 /datum/paygrade/civilian
-    name = "Civilian Paygrade"
+	name = "Civilian Paygrade"
+	pay_multiplier = 0.5 // civvies are poor
 
 /datum/paygrade/civilian/civilian
-    paygrade = "C"
-    name = "Civilian"
+	paygrade = "C"
+	name = "Civilian"
 
 /datum/paygrade/civilian/nurse
-    paygrade = "CN"
-    name = "Nurse"
-    prefix = "Nrs."
+	paygrade = "CN"
+	name = "Nurse"
+	prefix = "Nrs."
 
 /datum/paygrade/civilian/doctor
-    paygrade = "CD"
-    name = "Doctor"
-    prefix = "Dr."
+	paygrade = "CD"
+	name = "Doctor"
+	prefix = "Dr."
+	pay_multiplier = 0.75
 
 /datum/paygrade/civilian/professor
-    paygrade = "CCMO"
-    name = "Professor"
-    prefix = "Prof."
+	paygrade = "CCMO"
+	name = "Professor"
+	prefix = "Prof."
+	pay_multiplier = 1
 
 /datum/paygrade/civillian/representative
 	paygrade = "CR"
 	name = "Representative"
 	prefix = "Rep."
+	pay_multiplier = 1

--- a/code/datums/paygrades/factions/other/contractors.dm
+++ b/code/datums/paygrades/factions/other/contractors.dm
@@ -1,5 +1,6 @@
 /datum/paygrade/contractors
 	name = "Contractor Paygrade"
+	pay_multiplier = 1.5
 
 /datum/paygrade/contractors/standard
 	paygrade = "VAI"
@@ -10,23 +11,28 @@
 	paygrade = "VAI-M"
 	name = "VAI Medical Specialist"
 	prefix = "VAI MED"
+	pay_multiplier = 1.75
 
 /datum/paygrade/contractors/mg
 	paygrade = "VAI-G"
 	name = "VAI Machinegunner"
 	prefix = "VAI MG"
+	pay_multiplier = 1.75
 
 /datum/paygrade/contractors/engi
 	paygrade = "VAI-E"
 	name = "VAI Engineering Specialist"
 	prefix = "VAI ENG"
+	pay_multiplier = 1.75
 
 /datum/paygrade/contractors/syn
 	paygrade = "VAI-S"
 	name = "VAI Synthetic"
 	prefix = "VAI SYN"
+	pay_multiplier = 0
 
 /datum/paygrade/contractors/lead
 	paygrade = "VAI-L"
 	name = "VAI Team Leader"
 	prefix = "VAI TL"
+	pay_multiplier = 2.25

--- a/code/datums/paygrades/factions/other/dutch_dozen.dm
+++ b/code/datums/paygrades/factions/other/dutch_dozen.dm
@@ -1,5 +1,6 @@
 /datum/paygrade/dutch
 	name = "Dutch Paygrade"
+	pay_multiplier = 5
 
 /datum/paygrade/dutch/standard
 	paygrade = "DTC"
@@ -10,18 +11,23 @@
 	paygrade = "DTCM"
 	name = "Dutch's Dozen Medic"
 	prefix = "DTC MED."
+	pay_multiplier = 6
 
 /datum/paygrade/dutch/specialist_flamer
 	paygrade = "DTCF"
 	name = "Dutch's Dozen Flamethrower Specialist"
 	prefix = "DTC SPC."
+	pay_multiplier = 6
 
 /datum/paygrade/dutch/specialist_minigunner
 	paygrade = "DTCMG"
 	name = "Dutch's Dozen Medic"
 	prefix = "DTC SPC."
+	pay_multiplier = 6
 
 /datum/paygrade/dutch/arnold
 	paygrade = "ARN"
 	name = "Arnold"
 	prefix = "DTC LDR."
+	pay_multiplier = 9
+

--- a/code/datums/paygrades/factions/other/freelancer.dm
+++ b/code/datums/paygrades/factions/other/freelancer.dm
@@ -1,5 +1,6 @@
 /datum/paygrade/freelancer
 	name = "Freelancer Paygrade"
+	pay_multiplier = 0.75 //these are shitty mercs.
 
 /datum/paygrade/freelancer/standard
 	paygrade = "Freelancer Standard"
@@ -15,9 +16,11 @@
 	paygrade = "Freelancer Leader"
 	name = "Freelancer Leader"
 	prefix = "Warlord"
+	pay_multiplier = 1
 
 /datum/paygrade/freelancer/elite
 	name = "Elite Freelancer Paygrade"
+	pay_multiplier = 1.25
 
 /datum/paygrade/freelancer/elite/standard
 	paygrade = "Elite Freelancer Standard"
@@ -43,3 +46,4 @@
 	paygrade = "Elite Freelancer Leader"
 	name = "Elite Freelancer Leader"
 	prefix = "Warlord"
+	pay_multiplier = 1.5

--- a/code/datums/paygrades/factions/other/misc.dm
+++ b/code/datums/paygrades/factions/other/misc.dm
@@ -1,3 +1,4 @@
 /datum/paygrade/misc/operator
 	name = "Operative"
 	paygrade = "O"
+	pay_multiplier = 1 //????

--- a/code/datums/paygrades/factions/ress/ress.dm
+++ b/code/datums/paygrades/factions/ress/ress.dm
@@ -1,6 +1,6 @@
 /datum/paygrade/ress
-    name = "RESS Paygrade"
-
+	name = "RESS Paygrade"
+	pay_multiplier = 2 // less people = more to pay them
 
 //RESS RMC
 /datum/paygrade/ress/rc1
@@ -12,16 +12,19 @@
 	paygrade = "RC2"
 	name = "Santo"
 	prefix = "St."
+	pay_multiplier = 2.1
 
 /datum/paygrade/ress/rc3
 	paygrade = "RC3"
 	name = "Nito"
 	prefix = "Nt."
+	pay_multiplier = 2.2
 
 /datum/paygrade/ress/rc4
 	paygrade = "RC4"
 	name = "Itto"
 	prefix = "It."
+	pay_multiplier = 2.3
 
 
 //RESS Naval Officers
@@ -29,38 +32,46 @@
 	paygrade = "RO1"
 	name = "Seaman"
 	prefix = "SN."
+	pay_multiplier = 3
 
 /datum/paygrade/ress/ro2
 	paygrade = "RO2"
 	name = "Leading Seaman"
 	prefix = "LR."
+	pay_multiplier = 3.25
 
 /datum/paygrade/ress/ro3
 	paygrade = "RO3"
 	name = "Standing Officer"
 	prefix = "SO."
+	pay_multiplier = 3.5
 
 /datum/paygrade/ress/ro3e
 	paygrade = "RO3E"
 	name = "Warrant Officer"
 	prefix = "WO."
+	pay_multiplier = 3.5
 
 /datum/paygrade/ress/ro4
 	paygrade = "RO4"
 	name = "Captain"
 	prefix = "Cpt."
+	pay_multiplier = 5
 
 /datum/paygrade/ress/ro5
 	paygrade = "RO5"
 	name = "Admiral"
 	prefix = "ADM."
+	pay_multiplier = 7
 
 /datum/paygrade/ress/ro6
 	paygrade = "RO6"
 	name = "Grand Admiral"
 	prefix = "GADM."
+	pay_multiplier = 9
 
 /datum/paygrade/ress/ro7
 	paygrade = "RO7"
 	name = "Emperor"
 	prefix = "ER."
+	pay_multiplier = 1000

--- a/code/datums/paygrades/factions/upp/upp.dm
+++ b/code/datums/paygrades/factions/upp/upp.dm
@@ -1,11 +1,13 @@
 /datum/paygrade/upp
-    name = "UPP Paygrade"
+	name = "UPP Paygrade"
+	pay_multiplier = 0.1 //lol. lmao
 
 
 //UPP Enlisted
 /datum/paygrade/upp/ue0
 	paygrade = "UE0"
 	name = "Conscript"
+	pay_multiplier = 0.05
 
 /datum/paygrade/upp/ue1
 	paygrade = "UE1"
@@ -21,90 +23,108 @@
 	paygrade = "UE3M"
 	name = "Korporal Medic"
 	prefix = "Kpl."
+	pay_multiplier = 0.3
 
 /datum/paygrade/upp/ue3s
 	paygrade = "UE3S"
 	name = "Korporal Sapper"
 	prefix = "Kpl."
+	pay_multiplier = 0.3
 
 /datum/paygrade/upp/ue4
 	paygrade = "UE4"
 	name = "Junior Serzhant"
 	prefix = "JrSzh."
+	pay_multiplier = 0.5
 
 /datum/paygrade/upp/ue5
 	paygrade = "UE5"
 	name = "Serzhant"
 	prefix = "Szh."
+	pay_multiplier = 0.7
 
 /datum/paygrade/upp/ue6
 	paygrade = "UE6"
 	name = "Master Serzhant"
 	prefix = "MSzh."
+	pay_multiplier = 0.9
 
 //UPP Commandos
 /datum/paygrade/upp/uc1
 	paygrade = "UC1"
 	name = "Junior Kommando"
 	prefix = "JKdo."
+	pay_multiplier = 1.5
 
 /datum/paygrade/upp/uc2
 	paygrade = "UC2"
 	name = "2nd Kommando"
 	prefix = "2ndKdo."
+	pay_multiplier = 2
 
 /datum/paygrade/upp/uc3
 	paygrade = "UC3"
 	name = "1st Kommando"
 	prefix = "1stKdo."
+	pay_multiplier = 2.5
 
 //UPP Officers
 /datum/paygrade/upp/uo1
 	paygrade = "UO1"
 	name = "Leytenant"
 	prefix = "Lt."
+	pay_multiplier = 1.25
 
 /datum/paygrade/upp/uo1m
 	paygrade = "UO1M"
 	name = "Leytenant Medic"
 	prefix = "Lt. Med."
+	pay_multiplier = 1.25
 
 /datum/paygrade/upp/uo1e
 	paygrade = "UO1E"
 	name = "Senior Leytenant"
 	prefix = "Sr. LT."
+	pay_multiplier = 1.5
 
 
 /datum/paygrade/upp/uo2
 	paygrade = "UO2"
 	name = "Kapitan"
 	prefix = "Kpt."
+	pay_multiplier = 2
 
 /datum/paygrade/upp/uo3
 	paygrade = "UO3"
 	name = "Mayjor."
 	prefix = "May."
+	pay_multiplier = 2.5
 
 /datum/paygrade/upp/uo4
 	paygrade = "UO4"
 	name = "Leytenant Kolonel"
+	pay_multiplier = 3
 
 /datum/paygrade/upp/uo5
 	paygrade = "UO5"
 	name = "Kolonel"
 	prefix = "Kol."
+	pay_multiplier = 4
 
 /datum/paygrade/upp/uo6
 	paygrade = "UO6"
 	name = "Mayjor General"
 	prefix = "MayGen."
+	pay_multiplier = 5
 
 /datum/paygrade/upp/uo7
 	paygrade = "UO7"
 	name = "Leytenant General"
 	prefix = "LtGen."
+	pay_multiplier = 6
 
 /datum/paygrade/upp/uo8
 	paygrade = "UO8"
 	name = "Army General"
 	prefix = "ArmGen."
+	pay_multiplier = 7

--- a/code/datums/paygrades/factions/uscm/marine.dm
+++ b/code/datums/paygrades/factions/uscm/marine.dm
@@ -1,6 +1,7 @@
 /datum/paygrade/marine
 	name = "Marine Paygrade"
 	rank_pin = /obj/item/clothing/accessory/ranks/marine
+	pay_multiplier = 1
 
 // ENLISTED PAYGRADES
 
@@ -10,6 +11,7 @@
 	prefix = "PVT"
 	rank_pin = /obj/item/clothing/accessory/ranks/marine/e1
 	ranking = 0
+	pay_multiplier = 0.8
 
 /datum/paygrade/marine/e2
 	paygrade = "ME2"
@@ -17,6 +19,7 @@
 	prefix = "PFC"
 	rank_pin = /obj/item/clothing/accessory/ranks/marine/e2
 	ranking = 1
+	pay_multiplier = 1 // the default.
 
 /datum/paygrade/marine/e3
 	paygrade = "ME3"
@@ -24,6 +27,7 @@
 	prefix = "LCpl"
 	rank_pin = /obj/item/clothing/accessory/ranks/marine/e3
 	ranking = 2
+	pay_multiplier = 1.4
 
 /datum/paygrade/marine/e4
 	paygrade = "ME4"
@@ -31,6 +35,7 @@
 	prefix = "Cpl"
 	rank_pin = /obj/item/clothing/accessory/ranks/marine/e4
 	ranking = 3
+	pay_multiplier = 1.6
 
 /datum/paygrade/marine/e5
 	paygrade = "ME5"
@@ -38,6 +43,7 @@
 	prefix = "Sgt"
 	rank_pin = /obj/item/clothing/accessory/ranks/marine/e5
 	ranking = 4
+	pay_multiplier = 1.8
 
 /datum/paygrade/marine/e6
 	paygrade = "ME6"
@@ -45,6 +51,7 @@
 	prefix = "SSgt"
 	rank_pin = /obj/item/clothing/accessory/ranks/marine/e6
 	ranking = 5
+	pay_multiplier = 2
 
 /datum/paygrade/marine/e7
 	paygrade = "ME7"
@@ -52,6 +59,7 @@
 	prefix = "GySgt"
 	rank_pin = /obj/item/clothing/accessory/ranks/marine/e7
 	ranking = 6
+	pay_multiplier = 2.75
 
 /datum/paygrade/marine/e8
 	paygrade = "ME8"
@@ -59,6 +67,7 @@
 	prefix = "MSgt"
 	rank_pin = /obj/item/clothing/accessory/ranks/marine/e8
 	ranking = 7
+	pay_multiplier = 2.75
 
 /datum/paygrade/marine/e8e
 	paygrade = "ME8E"
@@ -66,6 +75,7 @@
 	prefix = "1Sgt"
 	rank_pin = /obj/item/clothing/accessory/ranks/marine/e8e
 	ranking = 8
+	pay_multiplier = 2.75
 
 /datum/paygrade/marine/e9
 	paygrade = "ME9"
@@ -73,6 +83,7 @@
 	prefix = "MGySgt"
 	rank_pin = /obj/item/clothing/accessory/ranks/marine/e9
 	ranking = 9
+	pay_multiplier = 3
 
 /datum/paygrade/marine/e9e
 	paygrade = "ME9E"
@@ -80,6 +91,7 @@
 	prefix = "SgtMaj"
 	rank_pin = /obj/item/clothing/accessory/ranks/marine/e9e
 	ranking = 10
+	pay_multiplier = 3
 
 /datum/paygrade/marine/e9s
 	paygrade = "ME9S"
@@ -87,6 +99,7 @@
 	prefix = "SMCMC"
 	rank_pin = /obj/item/clothing/accessory/ranks/marine/e10c
 	ranking = 11
+	pay_multiplier = 3
 
 // COMMISSIONED PAYGRADES
 
@@ -96,6 +109,7 @@
 	prefix = "2ndLt"
 	rank_pin = /obj/item/clothing/accessory/ranks/marine/o1
 	ranking = 12
+	pay_multiplier = 3
 
 /datum/paygrade/marine/o2
 	paygrade = "MO2"
@@ -103,6 +117,7 @@
 	prefix = "1stLt"
 	rank_pin = /obj/item/clothing/accessory/ranks/marine/o2
 	ranking = 13
+	pay_multiplier = 3.2
 
 /datum/paygrade/marine/o3
 	paygrade = "MO3"
@@ -110,6 +125,7 @@
 	prefix = "Capt"
 	rank_pin = /obj/item/clothing/accessory/ranks/marine/o3
 	ranking = 14
+	pay_multiplier = 4
 
 /datum/paygrade/marine/o4
 	paygrade = "MO4"
@@ -117,6 +133,7 @@
 	prefix = "Maj"
 	rank_pin = /obj/item/clothing/accessory/ranks/marine/o4
 	ranking = 15
+	pay_multiplier = 4
 
 /datum/paygrade/marine/o5
 	paygrade = "MO5"
@@ -124,6 +141,7 @@
 	prefix = "LtCol"
 	rank_pin = /obj/item/clothing/accessory/ranks/marine/o5
 	ranking = 16
+	pay_multiplier = 4.2
 
 //Platoon Commander
 /datum/paygrade/marine/o6
@@ -132,6 +150,7 @@
 	prefix = "Col"
 	rank_pin = /obj/item/clothing/accessory/ranks/marine/o6
 	ranking = 17
+	pay_multiplier = 4.4
 
 /datum/paygrade/marine/o6e
 	paygrade = "MO6E"
@@ -139,6 +158,7 @@
 	prefix = "Snr Col."
 	rank_pin = /obj/item/clothing/accessory/ranks/marine/o6e
 	ranking = 18
+	pay_multiplier = 4.6
 
 /datum/paygrade/marine/o6c
 	paygrade = "MO6C"
@@ -146,6 +166,7 @@
 	prefix = "Div Col."
 	rank_pin = /obj/item/clothing/accessory/ranks/marine/o6c
 	ranking = 19
+	pay_multiplier = 4.8
 
 //High Command
 /datum/paygrade/marine/o7
@@ -154,6 +175,7 @@
 	prefix = "BGen"
 	rank_pin = /obj/item/clothing/accessory/ranks/marine/o7
 	ranking = 20
+	pay_multiplier = 6
 
 /datum/paygrade/marine/o8
 	paygrade = "MO8"
@@ -161,6 +183,7 @@
 	prefix = "MajGen"
 	rank_pin = /obj/item/clothing/accessory/ranks/marine/o8
 	ranking = 21
+	pay_multiplier = 6.2
 
 /datum/paygrade/marine/o9
 	paygrade = "MO9"
@@ -168,6 +191,7 @@
 	prefix = "LtGen"
 	rank_pin = /obj/item/clothing/accessory/ranks/marine/o9
 	ranking = 22
+	pay_multiplier = 6.4
 
 /datum/paygrade/marine/o10
 	paygrade = "MO10"
@@ -175,6 +199,7 @@
 	prefix = "Gen"
 	rank_pin = /obj/item/clothing/accessory/ranks/marine/o10
 	ranking = 23
+	pay_multiplier = 6.6
 
 /datum/paygrade/marine/o10c
 	paygrade = "MO10C"
@@ -182,6 +207,7 @@
 	prefix = "ACMC"
 	rank_pin = /obj/item/clothing/accessory/ranks/marine/o10c
 	ranking = 24
+	pay_multiplier = 6.8
 
 /datum/paygrade/marine/o10s
 	paygrade = "MO10S"
@@ -189,3 +215,4 @@
 	prefix = "CMC"
 	rank_pin = /obj/item/clothing/accessory/ranks/marine/o10c
 	ranking = 25
+	pay_multiplier = 7

--- a/code/datums/paygrades/factions/uscm/navy.dm
+++ b/code/datums/paygrades/factions/uscm/navy.dm
@@ -1,6 +1,7 @@
 /datum/paygrade/navy
 	name = "Navy Paygrade"
 	rank_pin = /obj/item/clothing/accessory/ranks/navy
+	//someone else can do the multipliers for this one
 
 // ENLISTED PAYGRADES
 

--- a/code/datums/paygrades/factions/uscm/provost.dm
+++ b/code/datums/paygrades/factions/uscm/provost.dm
@@ -1,5 +1,6 @@
 /datum/paygrade/provost
 	name = "Provost Paygrade"
+	pay_multiplier = 2
 
 /datum/paygrade/provost/officer
 	paygrade = "PvE7"

--- a/code/datums/paygrades/factions/wy/goons.dm
+++ b/code/datums/paygrades/factions/wy/goons.dm
@@ -1,5 +1,6 @@
 /datum/paygrade/goon
 	name = "WY Goon Paygrade"
+	pay_multiplier = 0.66 // better than colonists. barely.
 
 //Standard PMCs
 /datum/paygrade/goon/standard
@@ -11,3 +12,4 @@
 	paygrade = "WEY-GOON-L"
 	name = "Senior Officer"
 	prefix = "Sr. Off."
+	pay_multiplier = 0.8

--- a/code/datums/paygrades/factions/wy/pmc.dm
+++ b/code/datums/paygrades/factions/wy/pmc.dm
@@ -1,6 +1,7 @@
 /datum/paygrade/pmc
 	name = "PMC Paygrade"
 	fprefix = "PMC."
+	pay_multiplier = 2.5 // they have money. but they sold their soul to the company. is it really worth it
 
 //Standard PMCs
 /datum/paygrade/pmc/standard
@@ -12,71 +13,85 @@
 	paygrade = "PMC-EN"
 	name = "Enforcer"
 	prefix = "ENF."
+	pay_multiplier = 2.6
 
 //PMC Field Specialists
 /datum/paygrade/pmc/vehicle
 	paygrade = "PMC-VS"
 	name = "Vehicle Specialist"
 	prefix = "CRW."
+	pay_multiplier = 2.8
 
 /datum/paygrade/pmc/support
 	paygrade = "PMC-SS"
 	name = "Support Specialist"
 	prefix = "SPS."
+	pay_multiplier = 2.8
 
 /datum/paygrade/pmc/medic
 	paygrade = "PMC-MS"
 	name = "Medical Specialist"
 	prefix = "SPM."
+	pay_multiplier = 2.8
 
 /datum/paygrade/pmc/spec
 	paygrade = "PMC-WS"
 	name = "Weapon Specialist"
 	prefix = "SPW."
+	pay_multiplier = 3
 
 /datum/paygrade/pmc/handler
 	paygrade = "PMC-XS"
 	name = "Xeno Specialist"
 	prefix = "SPX."
+	pay_multiplier = 4
 
 //PMC Elite
 /datum/paygrade/pmc/elite
 	paygrade = "PMC-ELR"
 	name = "Elite Responder"
 	prefix = "ELR."
+	pay_multiplier = 4
 
 /datum/paygrade/pmc/medic/elite
 	paygrade = "PMC-ELM"
 	name = "Elite Medic"
 	prefix = "ELM."
+	pay_multiplier = 4.5
 
 /datum/paygrade/pmc/spec/elite
 	paygrade = "PMC-ELG"
 	name = "Elite Gunner"
 	prefix = "ELG."
+	pay_multiplier = 5
 
 //PMC Command
 /datum/paygrade/pmc/teamlead
 	paygrade = "PMC-TL"
 	name = "Team Leader"
 	prefix = "TML."
+	pay_multiplier = 3.5
 
 /datum/paygrade/pmc/elitelead
 	paygrade = "PMC-ETL"
 	name = "Elite Team Leader"
 	prefix = "ETML."
+	pay_multiplier = 5.5
 
 /datum/paygrade/pmc/doctor
 	paygrade = "PMC-DOC"
 	name = "Trauma Surgeon"
 	prefix = "TRI."
+	pay_multiplier = 4
 
 /datum/paygrade/pmc/engineer
 	paygrade = "PMC-TECH"
 	name = "Corporate Technician"
 	prefix = "TEC."
+	pay_multiplier = 4
 
 /datum/paygrade/pmc/director
 	paygrade = "PMC-DIR"
 	name = "Site Director"
 	prefix = "DIR."
+	pay_multiplier = 10 //it's a corpo director. money is what they care about.

--- a/code/datums/paygrades/helper.dm
+++ b/code/datums/paygrades/helper.dm
@@ -30,7 +30,7 @@
 				else if(gender && gender == "male")
 					NP = "Mr. "
 				else
-					NP = ""
+					NP = "Mx. " //inclusivity win!
 		return NP
 	else
 		return P.name

--- a/code/datums/paygrades/paygrade.dm
+++ b/code/datums/paygrades/paygrade.dm
@@ -10,6 +10,9 @@ GLOBAL_LIST_INIT_TYPED(paygrades, /datum/paygrade, setup_paygrades())
 	var/rank_pin
 	var/ranking = 0
 
+	 /// Actually gives you the fucking money from your paygrade in your ATM account. Multiplier of 1 equals PFC pay.
+	var/pay_multiplier = 1
+
 /proc/setup_paygrades()
 	. = list()
 	for(var/I in subtypesof(/datum/paygrade))

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -155,10 +155,11 @@
 	//Give them an account in the database.
 	if(!(flags_startup_parameters & ROLE_NO_ACCOUNT))
 		var/obj/item/card/id/card = account_user.wear_id
-		var/has_account = account_user.mind?.initial_account
-		if(card && !has_account)
+		var/user_has_preexisting_account = account_user.mind?.initial_account
+		if(card && !user_has_preexisting_account)
 			var/datum/paygrade/account_paygrade = GLOB.paygrades[card.paygrade]
 			generated_account = create_account(account_user.real_name, rand(30, 50), null, account_paygrade)
+			card.associated_account_number = generated_account.account_number
 			if(account_user.mind)
 				var/remembered_info = ""
 				remembered_info += "<b>Your account number is:</b> #[generated_account.account_number]<br>"

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -148,6 +148,30 @@
 /datum/job/proc/spawn_and_equip(var/mob/new_player/player)
 	CRASH("A job without a set spawn_and_equip proc has handle_spawn_and_equip set to TRUE!")
 
+/datum/job/proc/generate_money_account(mob/living/carbon/human/account_user)
+	account_user.job = title //TODO Why is this a mob variable at all?
+
+	var/datum/money_account/generated_account
+	//Give them an account in the database.
+	if(!(flags_startup_parameters & ROLE_NO_ACCOUNT))
+		var/obj/item/card/id/card = account_user.wear_id
+		var/has_account = account_user.mind?.initial_account
+		if(card && !has_account)
+			var/datum/paygrade/account_paygrade = GLOB.paygrades[card.paygrade]
+			generated_account = create_account(account_user.real_name, rand(30, 50), null, account_paygrade)
+			if(account_user.mind)
+				var/remembered_info = ""
+				remembered_info += "<b>Your account number is:</b> #[generated_account.account_number]<br>"
+				remembered_info += "<b>Your account pin is:</b> [generated_account.remote_access_pin]<br>"
+				remembered_info += "<b>Your account funds are:</b> $[generated_account.money]<br>"
+
+				if(generated_account.transaction_log.len)
+					var/datum/transaction/T = generated_account.transaction_log[1]
+					remembered_info += "<b>Your account was created:</b> [T.time], [T.date] at [T.source_terminal]<br>"
+				account_user.mind.store_memory(remembered_info)
+				account_user.mind.initial_account = generated_account
+	return generated_account
+
 /datum/job/proc/generate_entry_message()
 	if(!entry_message_intro)
 		entry_message_intro = "You are the [title]!"
@@ -167,7 +191,7 @@
 			[SPAN_ROLE_BODY("|______________________|")] \n\
 			[SPAN_ROLE_HEADER("You are \a [title_given]")] \n\
 			[flags_startup_parameters & ROLE_ADMIN_NOTIFY ? SPAN_ROLE_HEADER("You are playing a job that is important for game progression. If you have to disconnect, please notify the admins via adminhelp.") : ""] \n\
-			[SPAN_ROLE_BODY("[generate_entry_message(H)]<br>[M ? "Your account number is: <b>[M.account_number]</b>. Your account pin is: <b>[M.remote_access_pin]</b>." : ""]")] \n\
+			[SPAN_ROLE_BODY("[generate_entry_message(H)]<br>[M ? "Your account number is: <b>[M.account_number]</b>. Your account pin is: <b>[M.remote_access_pin]</b>." : "You do not have a bank account."]")] \n\
 			[SPAN_ROLE_BODY("|______________________|")] \
 		"
 		to_chat_spaced(H, html = entrydisplay)
@@ -222,23 +246,6 @@
 
 	if(ishuman(M))
 		var/mob/living/carbon/human/human = M
-		human.job = title
-
-		var/datum/money_account/A
-		//Give them an account in the database.
-		if(!(flags_startup_parameters & ROLE_NO_ACCOUNT))
-			A = create_account(human.real_name, rand(50,500)*10, null)
-			if(human.mind)
-				var/remembered_info = ""
-				remembered_info += "<b>Your account number is:</b> #[A.account_number]<br>"
-				remembered_info += "<b>Your account pin is:</b> [A.remote_access_pin]<br>"
-				remembered_info += "<b>Your account funds are:</b> $[A.money]<br>"
-
-				if(A.transaction_log.len)
-					var/datum/transaction/T = A.transaction_log[1]
-					remembered_info += "<b>Your account was created:</b> [T.time], [T.date] at [T.source_terminal]<br>"
-				human.mind.store_memory(remembered_info)
-				human.mind.initial_account = A
 
 		var/job_whitelist = title
 		var/whitelist_status = get_whitelist_status(RoleAuthority.roles_whitelist, human.client)
@@ -248,11 +255,13 @@
 
 		if(gear_preset_whitelist[job_whitelist])
 			arm_equipment(human, gear_preset_whitelist[job_whitelist], FALSE, TRUE)
-			announce_entry_message(human, A, whitelist_status) //Tell them their spawn info.
+			var/generated_account = generate_money_account(human)
+			announce_entry_message(human, generated_account, whitelist_status) //Tell them their spawn info.
 			generate_entry_conditions(human, whitelist_status) //Do any other thing that relates to their spawn.
 		else
 			arm_equipment(human, gear_preset, FALSE, TRUE) //After we move them, we want to equip anything else they should have.
-			announce_entry_message(human, A) //Tell them their spawn info.
+			var/generated_account = generate_money_account(human)
+			announce_entry_message(human, generated_account) //Tell them their spawn info.
 			generate_entry_conditions(human) //Do any other thing that relates to their spawn.
 
 		if(flags_startup_parameters & ROLE_ADD_TO_SQUAD) //Are we a muhreen? Randomize our squad. This should go AFTER IDs. //TODO Robust this later.

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -149,7 +149,6 @@
 	CRASH("A job without a set spawn_and_equip proc has handle_spawn_and_equip set to TRUE!")
 
 /datum/job/proc/generate_money_account(mob/living/carbon/human/account_user)
-	account_user.job = title //TODO Why is this a mob variable at all?
 
 	var/datum/money_account/generated_account
 	//Give them an account in the database.
@@ -253,6 +252,8 @@
 
 		if(whitelist_status)
 			job_whitelist = "[title][whitelist_status]"
+
+		human.job = title //TODO Why is this a mob variable at all?
 
 		if(gear_preset_whitelist[job_whitelist])
 			arm_equipment(human, gear_preset_whitelist[job_whitelist], FALSE, TRUE)

--- a/code/game/jobs/role_authority.dm
+++ b/code/game/jobs/role_authority.dm
@@ -504,26 +504,7 @@ var/global/players_preassigned = 0
 	if(!ishuman(M))
 		return
 
-	var/mob/living/carbon/H = M
-
-	H.job = J.title //TODO Why is this a mob variable at all?
-
-	var/datum/money_account/A
-
-	//Give them an account in the database.
-	if(!(J.flags_startup_parameters & ROLE_NO_ACCOUNT))
-		A = create_account(H.real_name, rand(50,500)*10, null)
-		if(H.mind)
-			var/remembered_info = ""
-			remembered_info += "<b>Your account number is:</b> #[A.account_number]<br>"
-			remembered_info += "<b>Your account pin is:</b> [A.remote_access_pin]<br>"
-			remembered_info += "<b>Your account funds are:</b> $[A.money]<br>"
-
-			if(A.transaction_log.len)
-				var/datum/transaction/T = A.transaction_log[1]
-				remembered_info += "<b>Your account was created:</b> [T.time], [T.date] at [T.source_terminal]<br>"
-			H.mind.store_memory(remembered_info)
-			H.mind.initial_account = A
+	var/mob/living/carbon/human/H = M
 
 	var/job_whitelist = J.title
 	var/whitelist_status = J.get_whitelist_status(roles_whitelist, H.client)
@@ -533,11 +514,13 @@ var/global/players_preassigned = 0
 
 	if(J.gear_preset_whitelist[job_whitelist])
 		arm_equipment(H, J.gear_preset_whitelist[job_whitelist], FALSE, TRUE)
-		J.announce_entry_message(H, A, whitelist_status) //Tell them their spawn info.
+		var/generated_account = J.generate_money_account(H)
+		J.announce_entry_message(H, generated_account, whitelist_status) //Tell them their spawn info.
 		J.generate_entry_conditions(H, whitelist_status) //Do any other thing that relates to their spawn.
 	else
 		arm_equipment(H, J.gear_preset, FALSE, TRUE) //After we move them, we want to equip anything else they should have.
-		J.announce_entry_message(H, A) //Tell them their spawn info.
+		var/generated_account = J.generate_money_account(H)
+		J.announce_entry_message(H, generated_account) //Tell them their spawn info.
 		J.generate_entry_conditions(H) //Do any other thing that relates to their spawn.
 
 	if(J.flags_startup_parameters & ROLE_ADD_TO_SQUAD) //Are we a muhreen? Randomize our squad. This should go AFTER IDs. //TODO Robust this later.

--- a/code/game/jobs/role_authority.dm
+++ b/code/game/jobs/role_authority.dm
@@ -512,6 +512,8 @@ var/global/players_preassigned = 0
 	if(whitelist_status)
 		job_whitelist = "[J.title][whitelist_status]"
 
+	H.job = J.title //TODO Why is this a mob variable at all?
+
 	if(J.gear_preset_whitelist[job_whitelist])
 		arm_equipment(H, J.gear_preset_whitelist[job_whitelist], FALSE, TRUE)
 		var/generated_account = J.generate_money_account(H)

--- a/code/game/machinery/vending/vending_types.dm
+++ b/code/game/machinery/vending/vending_types.dm
@@ -133,18 +133,18 @@
 	product_ads = "Real men smoke Lucky Strikes!;Serving the US Armed Forces for over two-hundred years!;Life's short, smoke a Lucky!;L.S./M.F.T.!;Lucky Strike is first again!;You just can't beat a Lucky Strike!;The preferred cigarette of Carlos Hathcock!;First again with tobacco-men!"
 	vend_delay = 14
 	icon_state = "cigs"
-	products = list(/obj/item/storage/fancy/cigarettes/lucky_strikes = 50,
-					/obj/item/storage/fancy/cigar/tarbacktube = 20,
-					/obj/item/storage/box/matches = 15,
-					/obj/item/tool/lighter/random = 25,
-					/obj/item/tool/lighter/zippo = 10)
+	products = list(/obj/item/storage/fancy/cigarettes/lucky_strikes = 40,
+					/obj/item/storage/fancy/cigar/tarbacktube = 35,
+					/obj/item/storage/box/matches = 1,
+					/obj/item/tool/lighter/random = 10,
+					/obj/item/tool/lighter/zippo = 25)
 
 	premium = list(/obj/item/storage/fancy/cigar = 25)
-	prices = list(/obj/item/storage/fancy/cigarettes/lucky_strikes = 15,
-					/obj/item/storage/fancy/cigar/tarbacktube = 5,
+	prices = list(/obj/item/storage/fancy/cigarettes/lucky_strikes = 40,
+					/obj/item/storage/fancy/cigar/tarbacktube = 35,
 					/obj/item/storage/box/matches = 1,
 					/obj/item/tool/lighter/random = 2,
-					/obj/item/tool/lighter/zippo = 20)
+					/obj/item/tool/lighter/zippo = 25)
 
 /obj/structure/machinery/vending/cigarette/free
 	product_slogans = ""
@@ -153,7 +153,7 @@
 					/obj/item/storage/fancy/cigar/tarbacktube = 20,
 					/obj/item/storage/box/matches = 15,
 					/obj/item/tool/lighter/random = 25,
-					/obj/item/tool/lighter/zippo = 10)
+					/obj/item/tool/lighter/zippo = 25)
 	premium = list()
 	prices = list()
 
@@ -170,16 +170,16 @@
 					/obj/item/storage/box/matches = 10,
 					/obj/item/tool/lighter/random = 20,
 					/obj/item/tool/lighter/zippo = 5)
-	prices = list(/obj/item/storage/fancy/cigarettes/kpack = 20,
+	prices = list(/obj/item/storage/fancy/cigarettes/kpack = 40,
 					/obj/item/storage/fancy/cigarettes/arcturian_ace = 25,
-					/obj/item/storage/fancy/cigarettes/emeraldgreen = 40,
-					/obj/item/storage/fancy/cigarettes/wypacket = 20,
+					/obj/item/storage/fancy/cigarettes/emeraldgreen = 35,
+					/obj/item/storage/fancy/cigarettes/wypacket = 35,
 					/obj/item/storage/fancy/cigarettes/lady_finger = 30,
-					/obj/item/storage/fancy/cigarettes/blackpack = 50,
-					/obj/item/storage/fancy/cigar/tarbacks = 40,
+					/obj/item/storage/fancy/cigarettes/blackpack = 75,
+					/obj/item/storage/fancy/cigar/tarbacks = 35,
 					/obj/item/storage/box/matches = 1,
-					/obj/item/tool/lighter/random = 2,
-					/obj/item/tool/lighter/zippo = 20)
+					/obj/item/tool/lighter/random = 10,
+					/obj/item/tool/lighter/zippo = 25)
 
 /obj/structure/machinery/vending/security
 	name = "SecTech"

--- a/code/game/machinery/vending/vending_types.dm
+++ b/code/game/machinery/vending/vending_types.dm
@@ -25,11 +25,13 @@
 	vend_delay = 34
 	idle_power_usage = 211 //refrigerator - believe it or not, this is actually the average power consumption of a refrigerated vending machine according to NRCan.
 	vend_power_usage = 85000 //85 kJ to heat a 250 mL cup of coffee
-	products = list(/obj/item/reagent_container/food/drinks/coffee = 25,
+	products = list(/obj/item/reagent_container/food/drinks/coffee/marine = 25,
 					/obj/item/reagent_container/food/drinks/tea = 25,
 					/obj/item/reagent_container/food/drinks/h_chocolate = 25)
 	contraband = list(/obj/item/reagent_container/food/drinks/ice = 10)
-	prices = list()
+	prices = list(/obj/item/reagent_container/food/drinks/coffee/marine = 1.5,
+					/obj/item/reagent_container/food/drinks/tea = 3,
+					/obj/item/reagent_container/food/drinks/h_chocolate = 15)
 
 /obj/structure/machinery/vending/coffee/simple
 	name = "Hot Coffee Machine"
@@ -53,7 +55,15 @@
 					/obj/item/reagent_container/food/snacks/wrapped/chunk = 6,
 					/obj/item/reagent_container/food/snacks/wrapped/barcardine = 6)
 
-	prices = list()
+	prices = list(/obj/item/reagent_container/food/snacks/packaged_burger = 5,
+					/obj/item/reagent_container/food/snacks/packaged_burrito = 5,
+					/obj/item/reagent_container/food/snacks/packaged_hdogs = 5,
+					/obj/item/reagent_container/food/snacks/kepler_crisps = 3,
+					/obj/item/reagent_container/food/snacks/wy_chips/pepper = 3,
+					/obj/item/reagent_container/food/snacks/eat_bar = 4,
+					/obj/item/reagent_container/food/snacks/wrapped/booniebars = 4,
+					/obj/item/reagent_container/food/snacks/wrapped/chunk = 4,
+					/obj/item/reagent_container/food/snacks/wrapped/barcardine = 4)
 
 /obj/structure/machinery/vending/snack/packaged
 	product_slogans = ""
@@ -67,8 +77,8 @@
 	name = "Souto Softdrinks"
 	desc = "A softdrink vendor provided by Souto Soda Company, Havana."
 	icon_state = "Cola_Machine"
-	product_slogans = "Souto Soda: Have a Souto and be taken away to a tropical paradise!;Souto Classic. You can't beat that tangerine goodness!;Souto Cherry. The sweet flavor of a cool winter morning!;Souto Lime. For that sweet and sour flavor that you know and love!;Souto Grape. There's nothing better than a grape soda.;Weyland-Yutani Fruit Beer. Nothing came from that lawsuit!;Weyland-Yutani Spring Water. It came from a spring!"
-	product_ads = "Souto Classic. You can't beat that tangerine goodness!;Souto Cherry. The sweet flavor of a cool winter morning!;Souto Lime. For that sweet and sour flavor that you know and love!;Souto Grape. There's nothing better than a grape soda.;Weyland-Yutani Fruit Beer. Nothing came from that lawsuit!;Weyland-Yutani Spring Water. It technically came from a spring!"
+	product_slogans = "Souto Soda: Have a Souto and be taken away to a tropical paradise!;Souto Classic. You can't beat that tangerine goodness!;Souto Cherry. The sweet flavor of a cool winter morning!;Souto Lime. For that sweet and sour flavor that you know and love!;Souto Grape. There's nothing better than a grape soda.;Weyland-Yutani Fruit Beer. Nothing came from that lawsuit!"
+	product_ads = "Souto Classic. You can't beat that tangerine goodness!;Souto Cherry. The sweet flavor of a cool winter morning!;Souto Lime. For that sweet and sour flavor that you know and love!;Souto Grape. There's nothing better than a grape soda.;Weyland-Yutani Fruit Beer. Nothing came from that lawsuit!"
 	products = list(/obj/item/reagent_container/food/drinks/cans/souto/classic = 10,
 					/obj/item/reagent_container/food/drinks/cans/souto/diet/classic = 10,
 					/obj/item/reagent_container/food/drinks/cans/souto/cherry = 10,
@@ -87,29 +97,27 @@
 					/obj/item/reagent_container/food/drinks/cans/souto/diet/vanilla = 10,
 					/obj/item/reagent_container/food/drinks/cans/souto/pineapple = 10,
 					/obj/item/reagent_container/food/drinks/cans/souto/diet/pineapple = 10,
-					/obj/item/reagent_container/food/drinks/cans/waterbottle = 10,
 					/obj/item/reagent_container/food/drinks/cans/cola = 10)
 
-	prices = list(/obj/item/reagent_container/food/drinks/cans/souto/classic = 5,
-					/obj/item/reagent_container/food/drinks/cans/souto/diet/classic = 5,
-					/obj/item/reagent_container/food/drinks/cans/souto/cherry = 5,
-					/obj/item/reagent_container/food/drinks/cans/souto/diet/cherry = 5,
-					/obj/item/reagent_container/food/drinks/cans/souto/lime = 5,
-					/obj/item/reagent_container/food/drinks/cans/souto/diet/lime = 5,
-					/obj/item/reagent_container/food/drinks/cans/souto/grape = 5,
-					/obj/item/reagent_container/food/drinks/cans/souto/diet/grape = 5,
-					/obj/item/reagent_container/food/drinks/cans/souto/blue = 5,
-					/obj/item/reagent_container/food/drinks/cans/souto/diet/blue = 5,
-					/obj/item/reagent_container/food/drinks/cans/souto/peach = 5,
-					/obj/item/reagent_container/food/drinks/cans/souto/diet/peach = 5,
-					/obj/item/reagent_container/food/drinks/cans/souto/cranberry = 5,
-					/obj/item/reagent_container/food/drinks/cans/souto/diet/cranberry = 5,
-					/obj/item/reagent_container/food/drinks/cans/souto/vanilla = 5,
-					/obj/item/reagent_container/food/drinks/cans/souto/diet/vanilla = 5,
-					/obj/item/reagent_container/food/drinks/cans/souto/pineapple = 5,
-					/obj/item/reagent_container/food/drinks/cans/souto/diet/pineapple = 5,
-					/obj/item/reagent_container/food/drinks/cans/waterbottle = 2,
-					/obj/item/reagent_container/food/drinks/cans/cola = 10)
+	prices = list(/obj/item/reagent_container/food/drinks/cans/souto/classic = 8,
+					/obj/item/reagent_container/food/drinks/cans/souto/diet/classic = 12,
+					/obj/item/reagent_container/food/drinks/cans/souto/cherry = 9,
+					/obj/item/reagent_container/food/drinks/cans/souto/diet/cherry = 12,
+					/obj/item/reagent_container/food/drinks/cans/souto/lime = 9,
+					/obj/item/reagent_container/food/drinks/cans/souto/diet/lime = 12,
+					/obj/item/reagent_container/food/drinks/cans/souto/grape = 9,
+					/obj/item/reagent_container/food/drinks/cans/souto/diet/grape = 12,
+					/obj/item/reagent_container/food/drinks/cans/souto/blue = 9,
+					/obj/item/reagent_container/food/drinks/cans/souto/diet/blue = 12,
+					/obj/item/reagent_container/food/drinks/cans/souto/peach = 9,
+					/obj/item/reagent_container/food/drinks/cans/souto/diet/peach = 12,
+					/obj/item/reagent_container/food/drinks/cans/souto/cranberry = 9,
+					/obj/item/reagent_container/food/drinks/cans/souto/diet/cranberry = 12,
+					/obj/item/reagent_container/food/drinks/cans/souto/vanilla = 9,
+					/obj/item/reagent_container/food/drinks/cans/souto/diet/vanilla = 12,
+					/obj/item/reagent_container/food/drinks/cans/souto/pineapple = 9,
+					/obj/item/reagent_container/food/drinks/cans/souto/diet/pineapple = 12,
+					/obj/item/reagent_container/food/drinks/cans/cola = 20)
 	idle_power_usage = 211 //refrigerator - believe it or not, this is actually the average power consumption of a refrigerated vending machine according to NRCan.
 
 /obj/structure/machinery/vending/cola/research
@@ -133,17 +141,17 @@
 	product_ads = "Real men smoke Lucky Strikes!;Serving the US Armed Forces for over two-hundred years!;Life's short, smoke a Lucky!;L.S./M.F.T.!;Lucky Strike is first again!;You just can't beat a Lucky Strike!;The preferred cigarette of Carlos Hathcock!;First again with tobacco-men!"
 	vend_delay = 14
 	icon_state = "cigs"
-	products = list(/obj/item/storage/fancy/cigarettes/lucky_strikes = 40,
+	products = list(/obj/item/storage/fancy/cigarettes/lucky_strikes = 50,
+					/obj/item/storage/fancy/cigar/tarbacktube = 20,
+					/obj/item/storage/box/matches = 15,
+					/obj/item/tool/lighter/random = 25,
+					/obj/item/tool/lighter/zippo = 10)
+
+	premium = list(/obj/item/storage/fancy/cigar = 25)
+	prices = list(/obj/item/storage/fancy/cigarettes/lucky_strikes = 35,
 					/obj/item/storage/fancy/cigar/tarbacktube = 35,
 					/obj/item/storage/box/matches = 1,
 					/obj/item/tool/lighter/random = 10,
-					/obj/item/tool/lighter/zippo = 25)
-
-	premium = list(/obj/item/storage/fancy/cigar = 25)
-	prices = list(/obj/item/storage/fancy/cigarettes/lucky_strikes = 40,
-					/obj/item/storage/fancy/cigar/tarbacktube = 35,
-					/obj/item/storage/box/matches = 1,
-					/obj/item/tool/lighter/random = 2,
 					/obj/item/tool/lighter/zippo = 25)
 
 /obj/structure/machinery/vending/cigarette/free
@@ -153,7 +161,7 @@
 					/obj/item/storage/fancy/cigar/tarbacktube = 20,
 					/obj/item/storage/box/matches = 15,
 					/obj/item/tool/lighter/random = 25,
-					/obj/item/tool/lighter/zippo = 25)
+					/obj/item/tool/lighter/zippo = 10)
 	premium = list()
 	prices = list()
 
@@ -170,6 +178,7 @@
 					/obj/item/storage/box/matches = 10,
 					/obj/item/tool/lighter/random = 20,
 					/obj/item/tool/lighter/zippo = 5)
+
 	prices = list(/obj/item/storage/fancy/cigarettes/kpack = 40,
 					/obj/item/storage/fancy/cigarettes/arcturian_ace = 25,
 					/obj/item/storage/fancy/cigarettes/emeraldgreen = 35,
@@ -366,16 +375,16 @@
 
 	contraband = list(/obj/item/toy/sword = 2)
 
-	prices = list(/obj/item/device/cassette_tape/pop1 = 3,
-		/obj/item/device/cassette_tape/hiphop = 3,
-		/obj/item/device/cassette_tape/nam = 3,
-		/obj/item/device/cassette_tape/ocean = 4,
-		/obj/item/device/cassette_tape/pop3 = 3,
-		/obj/item/device/cassette_tape/pop4 = 3,
-		/obj/item/device/cassette_tape/pop2 = 3,
-		/obj/item/device/cassette_tape/heavymetal = 3,
-		/obj/item/device/cassette_tape/hairmetal = 3,
-		/obj/item/device/cassette_tape/indie = 3,
+	prices = list(/obj/item/device/cassette_tape/pop1 = 5,
+		/obj/item/device/cassette_tape/hiphop = 5,
+		/obj/item/device/cassette_tape/nam = 5,
+		/obj/item/device/cassette_tape/ocean = 6,
+		/obj/item/device/cassette_tape/pop3 = 5,
+		/obj/item/device/cassette_tape/pop4 = 5,
+		/obj/item/device/cassette_tape/pop2 = 5,
+		/obj/item/device/cassette_tape/heavymetal = 5,
+		/obj/item/device/cassette_tape/hairmetal = 5,
+		/obj/item/device/cassette_tape/indie = 5,
 		/obj/item/device/walkman = 15,
 		/obj/item/storage/pouch/cassette = 10,
 		/obj/item/toy/deck = 20,

--- a/code/game/objects/items/reagent_containers/food/drinks.dm
+++ b/code/game/objects/items/reagent_containers/food/drinks.dm
@@ -211,6 +211,9 @@
 	. = ..()
 	reagents.add_reagent("coffee", 20)
 
+/obj/item/reagent_container/food/drinks/coffee/marine
+	desc = "Recycled water, lab-grown coffee plants genetically designed for minimum expense and maximum production, and re-recycled coffee grounds have mixed together to create this insultingly cheap USCM culinary 'wonder'. You're just glad the troops get issued water for free."
+
 /obj/item/reagent_container/food/drinks/tea
 	name = "\improper Duke Purple Tea"
 	desc = "An insult to Duke Purple is an insult to the Space Queen! Any proper gentleman will fight you, if you sully this tea."

--- a/code/modules/economy/Accounts.dm
+++ b/code/modules/economy/Accounts.dm
@@ -18,19 +18,19 @@
 	var/time = ""
 	var/source_terminal = ""
 
-/proc/create_account(var/new_owner_name = "Default user", var/starting_funds = 0, var/obj/structure/machinery/account_database/source_db)
+/proc/create_account(var/new_owner_name = "Default user", var/starting_funds = 0, var/obj/structure/machinery/account_database/source_db, var/datum/paygrade/id_paygrade)
 
 	//create a new account
 	var/datum/money_account/M = new()
 	M.owner_name = new_owner_name
 	M.remote_access_pin = rand(1111, 111111)
-	M.money = starting_funds
+	M.money = starting_funds * id_paygrade.pay_multiplier
 
 	//create an entry in the account transaction log for when it was created
 	var/datum/transaction/T = new()
 	T.target_name = new_owner_name
 	T.purpose = "Account creation"
-	T.amount = starting_funds
+	T.amount = starting_funds * id_paygrade.pay_multiplier
 	if(!source_db)
 		//set a random date, time and location some time over the past few decades
 		T.date = "[num2text(rand(1,31))] [pick("January","February","March","April","May","June","July","August","September","October","November","December")], [game_year]"

--- a/code/modules/economy/cash.dm
+++ b/code/modules/economy/cash.dm
@@ -1,6 +1,6 @@
 /obj/item/spacecash
-	name = "0 dollars"
-	desc = "You have no dollars."
+	name = "15 dollars"
+	desc = "You have 15 dollars."
 	gender = PLURAL
 	icon = 'icons/obj/items/items.dmi'
 	icon_state = "spacecash1"
@@ -12,9 +12,7 @@
 	throw_speed = SPEED_FAST
 	throw_range = 2
 	w_class = SIZE_TINY
-	var/access = list()
-	access = ACCESS_MARINE_COMMANDER
-	var/worth = 0
+	var/worth = 15
 
 /obj/item/spacecash/attackby(obj/item/W as obj, mob/user as mob)
 	if(istype(W, /obj/item/spacecash))

--- a/code/modules/gear_presets/_select_equipment.dm
+++ b/code/modules/gear_presets/_select_equipment.dm
@@ -125,8 +125,7 @@
 	H.faction_group = faction_group.Copy()
 	if(H.mind)
 		H.mind.name = H.real_name
-		if(H.mind.initial_account)
-			W.associated_account_number = H.mind.initial_account.account_number
+		// Bank account details handled in generate_money_account()
 	H.job = rank
 	H.comm_title = role_comm_title
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Added a variable to paygrades called pay_multiplier. This multiplies the starting amount of money from bank accounts.

Refactored how bank accounts are created so the above could work.

Drastically nuked the amount of money people start with. People can no longer start with thousands of dollars.... they now get 30-50. This value is multiplied by the pay_multiplier below.

Added pay_multiplier to all paygrades. The higher your rank, the more money you'll start with, based on this multiplier. (For example, a Major will have a pay multiplier of 4.) Includes strange roles like VAIPO, UPP, PMCs, RESS...

Non-binary WY executives may now spawn with 'Mx.' as their communications prefix.

Altered the prices of cigarette vending machines around to overall make them more expensive. PFCs will not be able to buy Executive Select with their starting cash.

Made cassetes and Souto from vendors more expensive. Buying food from Hot Foods now costs money. Marine coffee now has an appropiate description. Souto vendors no longer vend water bottles.

Fixed default parent type dollar items being worth 0 money...

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

> Drastically nuked the amount of money people start with. People can no longer start with thousands of dollars.... they now get 30-50. This value is multiplied by the pay_multiplier below.

Lore. The live of a private sucks. Monkeysfist suggested this value. Still enough to buy all essentials, scavenge some money if you want to buy the good cigarette packs down in the colony.

> Added pay_multiplier to all paygrades. The higher your rank, the more money you'll start with, based on this multiplier. (For example, a Major will have a pay multiplier of 4.) Includes strange roles like VAIPO, UPP, PMCs, RESS...

Why were paygrades added without affecting pay. Why could PFCs start with 3 thousand dollars and COs with 50 dollars total.

> Non-binary WY executives may now spawn with 'Mx.' as their communications prefix.

Inclusivity win! Doesn't actually do anything as we do not have nonbinary characters.

> Altered the prices of cigarette vending machines around to overall make them more expensive. PFCs will not be able to buy Executive Select with their starting cash.

> Made cassetes and Souto from vendors more expensive. Buying food from Hot Foods now costs money. Marine coffee now has an appropiate description. Souto vendors no longer vend water bottles.

It's funny to make the lives of marines miserable.

> Fixed default parent type dollar items being worth 0 money...

This will let marines money scrounge.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

Irrelevant.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
add: Added pay_multiplier to all paygrades. The higher your rank, the more money you'll start with, based on this multiplier. (For example, a Major will have a pay multiplier of 4.) Includes strange roles like VAIPO, UPP, PMCs, RESS...
del: Drastically nuked the amount of money people start with. People can no longer start with thousands of dollars.... they now get 30-50 dollars total. This value is multiplied by the pay_multiplier above.
spellcheck: Non-binary WY executives may now spawn with 'Mx.' as their communications prefix.
balance: Altered the prices of cigarette vending machines around to overall make them more expensive. PFCs will not be able to buy Executive Select with their starting cash.
del: Made cassetes and Souto from vendors more expensive. Buying food from Hot Foods now costs money. Marine coffee now has an appropiate description. Souto vendors no longer vend water bottles.
fix: Fixed default parent type dollar items being worth 0 money...
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
