### PR TITLE
Carrier QoL improvements - grab multiple eggs, grab huggers from morpher, restock morpher with eggs

### DIFF
--- a/code/modules/cm_aliens/structures/special/egg_morpher.dm
+++ b/code/modules/cm_aliens/structures/special/egg_morpher.dm
@@ -118,6 +118,7 @@
 				SPAN_XENONOTICE("You place the child from an egg into \the [src]."))
 			user.temp_drop_inv_item(egg)
 		stored_huggers = min(huggers_to_grow_max, stored_huggers + 1)
+		playsound(src.loc, "sound/effects/alien_egg_move.ogg", 25)
 		qdel(egg)
 		return
 	return ..(I, user)

--- a/code/modules/cm_aliens/structures/special/egg_morpher.dm
+++ b/code/modules/cm_aliens/structures/special/egg_morpher.dm
@@ -107,6 +107,19 @@
 			qdel(F)
 		else to_chat(user, SPAN_XENOWARNING("This child is dead."))
 		return
+	//refill egg morpher from an egg
+	if(istype(I, /obj/item/xeno_egg))
+		var/obj/item/xeno_egg/egg = I
+		if(stored_huggers >= huggers_to_grow_max)
+			to_chat(user, SPAN_XENOWARNING("\The [src] is full of children."))
+			return
+		if(user)
+			visible_message(SPAN_XENOWARNING("[user] slides a facehugger out of \the [egg] into \the [src]."), \
+				SPAN_XENONOTICE("You place the child from an egg into \the [src]."))
+			user.temp_drop_inv_item(egg)
+		stored_huggers = min(huggers_to_grow_max, stored_huggers + 1)
+		qdel(egg)
+		return
 	return ..(I, user)
 
 /obj/effect/alien/resin/special/eggmorph/update_icon()

--- a/code/modules/mob/living/carbon/xenomorph/castes/Carrier.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Carrier.dm
@@ -152,6 +152,27 @@
 	else
 		to_chat(src, SPAN_WARNING("You can't carry more facehuggers on you."))
 
+/mob/living/carbon/Xenomorph/Carrier/proc/store_huggers_from_egg_morpher(obj/effect/alien/resin/special/eggmorph/morpher)
+	if(morpher.linked_hive && (morpher.linked_hive.hivenumber != hivenumber))
+		to_chat(src, SPAN_WARNING("That egg morpher is tainted!"))
+		return
+
+	if(morpher.stored_huggers == 0)
+		to_chat(src, SPAN_WARNING("The egg morpher is empty!"))
+		return
+
+	if(huggers_max > 0 && huggers_cur < huggers_max)
+		var/huggers_to_transfer = min(morpher.stored_huggers, huggers_max-huggers_cur)
+		huggers_cur += huggers_to_transfer
+		morpher.stored_huggers -= huggers_to_transfer
+		if(huggers_to_transfer == 1)
+			to_chat(src, SPAN_NOTICE("You store the facehugger and carry it for safekeeping. Now sheltering: [huggers_cur] / [huggers_max]."))
+		else
+			to_chat(src, SPAN_NOTICE("You store [huggers_to_transfer] facehuggers and carry them for safekeeping. Now sheltering: [huggers_cur] / [huggers_max]."))
+		update_icons()
+	else
+		to_chat(src, SPAN_WARNING("You can't carry more facehuggers on you."))
+
 
 /mob/living/carbon/Xenomorph/Carrier/proc/throw_hugger(atom/T)
 	if(!T)
@@ -172,6 +193,19 @@
 				to_chat(src, SPAN_WARNING("Touching \the [F] while you're on fire would burn it!"))
 				return
 			store_hugger(F)
+			return
+
+	//target an egg morpher to top up on huggers
+	if(istype(T, /obj/effect/alien/resin/special/eggmorph))
+		var/obj/effect/alien/resin/special/eggmorph/morpher = T
+		if(Adjacent(morpher))
+			if(morpher.linked_hive && (morpher.linked_hive.hivenumber != hivenumber))
+				to_chat(src, SPAN_WARNING("That egg morpher is tainted!"))
+				return
+			if(on_fire)
+				to_chat(src, SPAN_WARNING("Touching \the [morpher] while you're on fire would burn the facehuggers in it!"))
+				return
+			store_huggers_from_egg_morpher(morpher)
 			return
 
 	var/obj/item/clothing/mask/facehugger/F = get_active_hand()

--- a/code/modules/mob/living/carbon/xenomorph/castes/Carrier.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Carrier.dm
@@ -166,7 +166,7 @@
 		huggers_cur += huggers_to_transfer
 		morpher.stored_huggers -= huggers_to_transfer
 		if(huggers_to_transfer == 1)
-			to_chat(src, SPAN_NOTICE("You store the facehugger and carry it for safekeeping. Now sheltering: [huggers_cur] / [huggers_max]."))
+			to_chat(src, SPAN_NOTICE("You store one facehugger and carry it for safekeeping. Now sheltering: [huggers_cur] / [huggers_max]."))
 		else
 			to_chat(src, SPAN_NOTICE("You store [huggers_to_transfer] facehuggers and carry them for safekeeping. Now sheltering: [huggers_cur] / [huggers_max]."))
 		update_icons()
@@ -258,7 +258,6 @@
 			to_chat(src, SPAN_WARNING("This [E.name] looks too unhealthy."))
 	else
 		to_chat(src, SPAN_WARNING("You can't carry more eggs on you."))
-
 
 /mob/living/carbon/Xenomorph/Carrier/proc/retrieve_egg(atom/T)
 	if(!T) return

--- a/code/modules/mob/living/carbon/xenomorph/castes/Carrier.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Carrier.dm
@@ -236,7 +236,13 @@
 	if(istype(T, /obj/item/xeno_egg))
 		var/obj/item/xeno_egg/E = T
 		if(isturf(E.loc) && Adjacent(E))
+			var/turf/egg_turf = E.loc
 			store_egg(E)
+			//Grab all the eggs from the turf
+			if(eggs_cur < eggs_max)
+				for(E in egg_turf)
+					if(eggs_cur < eggs_max)
+						store_egg(E)
 			return
 
 	var/obj/item/xeno_egg/E = get_active_hand()

--- a/code/modules/mob/living/carbon/xenomorph/egg_item.dm
+++ b/code/modules/mob/living/carbon/xenomorph/egg_item.dm
@@ -34,6 +34,8 @@
 			. += "This one appears to belong to the [hive.prefix]hive"
 
 /obj/item/xeno_egg/afterattack(atom/target, mob/user, proximity)
+	if(istype(target, /obj/effect/alien/resin/special/eggmorph))
+		return //We tried storing the hugger from the egg, no need to try to plant it (we know the turf is occupied!)
 	if(isXeno(user))
 		var/turf/T = get_turf(target)
 		plant_egg(user, T, proximity)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

After playing the Carrier for a bit I noticed its gameplay could be improved a bit in terms of QoL.

First, sometimes it's hard clicking all the eggs the queen has laid, especially when some other sprite like a bush or a potted plant get in the way. So I let them grab all the eggs from a given turf when they try storing any one egg.

Secondly, refilling from an egg morpher was a bit fiddly (click on morpher to make hugger appear, middle-click on the hugger to take it, try not to misclick or you will be trying to slap one hugger with another), so I let Carriers just top themselves up from the egg morpher by using their hugger ability.

Thirdly, it tends to get a bit hard to restock the egg morphers far away from the hive, especially later in the round, even though there are like 50 eggs sitting by the queen nobody is taking, so I let xenos use an egg on the morpher to restock it with the facehugger from the egg directly.

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

It makes the life of hive janitors a lot more pleasant, which should result in more eggs being used rather than lying there doing nothing.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
add: You can now refill an Egg Morpher directly with an egg by clicking on it with the egg.
qol: Carriers can now take facehuggers directly from the Egg Morpher with their facehugger ability.
qol: Carriers now attempt to pick up all the eggs on a turf if they use their egg ability on an egg lying on the ground.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
