### PR TITLE
Stealth Typing

### DIFF
--- a/code/modules/mob/typing_indicator.dm
+++ b/code/modules/mob/typing_indicator.dm
@@ -26,7 +26,8 @@ var/global/list/image/typed_typing_indicators
 			overlays -= indicator
 		else
 			if(state)
-				if(stat == CONSCIOUS) overlays += indicator
+				if(stat == CONSCIOUS && alpha == 255)
+					overlays += indicator
 			else
 				overlays -= indicator
 			return state
@@ -74,26 +75,6 @@ var/global/list/image/typed_typing_indicators
 		return
 	hud_typing = NONE
 	set_typing_indicator(FALSE)
-
-/mob/proc/handle_typing_indicator()
-	if(client)
-		if(!(client.prefs.toggles_chat & SHOW_TYPING) && !hud_typing)
-			var/temp = winget(client, "input", "text")
-
-			if (temp != last_typed)
-				last_typed = temp
-				last_typed_time = world.time
-
-			if (world.time > last_typed_time + TYPING_INDICATOR_LIFETIME)
-				set_typing_indicator(0)
-				return
-			if(length(temp) > 5 && findtext(temp, "Say \"", 1, 7))
-				set_typing_indicator(1)
-			else if(length(temp) > 3 && findtext(temp, "Me ", 1, 5))
-				set_typing_indicator(1)
-
-			else
-				set_typing_indicator(0)
 
 /client/verb/typing_indicator()
 	set name = "Show/Hide Typing Indicator"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Made the typing indicator only appear if you have full alpha. Also removed an unused proc.

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

Same as https://github.com/cmss13-devs/cmss13/pull/1842 but in this case the change is even lesser because you can actually disable typing indicators as a preference.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->


# Testing Photographs and Procedure

Believe it or not, but I tried typing while cloaked.

# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
balance: You no longer have a typing indicator while cloaked. The regular speech bubble when speaking still pops up, though.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
