### PR TITLE
Observer Pointing

### DIFF
--- a/code/_onclick/observer.dm
+++ b/code/_onclick/observer.dm
@@ -14,6 +14,10 @@
 	if(..())
 		return 1
 
+	if (mods["shift"] && mods["middle"])
+		point_to(A)
+		return TRUE
+
 	if(mods["ctrl"])
 		if(A == src)
 			if(!can_reenter_corpse || !mind || !mind.current)

--- a/code/game/objects/effects/overlays.dm
+++ b/code/game/objects/effects/overlays.dm
@@ -85,7 +85,7 @@
 
 /obj/effect/overlay/temp/point/big/observer
 	icon_state = "big_arrow_grey"
-	color = "#5c00e6"
+	color = "#1c00f6"
 	invisibility = INVISIBILITY_OBSERVER
 	plane = GHOST_PLANE
 

--- a/code/game/objects/effects/overlays.dm
+++ b/code/game/objects/effects/overlays.dm
@@ -83,8 +83,11 @@
 /obj/effect/overlay/temp/point/big/greyscale
 	icon_state = "big_arrow_grey"
 
-/obj/effect/overlay/temp/point/big/greyscale
+/obj/effect/overlay/temp/point/big/observer
 	icon_state = "big_arrow_grey"
+	color = "#5c00e6"
+	invisibility = INVISIBILITY_OBSERVER
+	plane = GHOST_PLANE
 
 /obj/effect/overlay/temp/point/big/queen
 	icon_state = "big_arrow_grey"

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -946,6 +946,8 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	return "(<a href='?src=\ref[src];jumptocoord=1;X=[turf.x];Y=[turf.y];Z=[turf.z]'>[jump_tag]</a>)"
 
 /mob/dead/observer/point_to(atom/A in view())
+	if(!(client?.prefs?.toggles_chat & CHAT_DEAD))
+		return FALSE
 	if(A?.z != src.z || !A.mouse_opacity || get_dist(src, A) > client.view)
 		return FALSE
 	var/turf/turf = get_turf(A)
@@ -960,6 +962,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	for(var/mob/dead/observer/nearby_observer as anything in GLOB.observer_list)
 		var/client/observer_client = nearby_observer.client
 		// We check observer view range specifically to also show the message to zoomed out ghosts. Double check Z as get_dist goes thru levels.
-		if(observer_client && src.z == nearby_observer.z && get_dist(src, nearby_observer) <= observer_client.view)
+		if((observer_client?.prefs?.toggles_chat & CHAT_DEAD) \
+			&& src.z == nearby_observer.z && get_dist(src, nearby_observer) <= observer_client.view)
 			to_chat(observer_client, SPAN_DEADSAY("<b>[src]</b> points to [A] [nearby_observer.format_jump(A)]"))
 	return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

This just adds the pointing action for observers. You can use it via shift + middle click in same way as living people do.

Could have it broadcast to all ghosts for attention grabbing but this takes the simpler route of displaying to closeby ones.

Turning off Deadchat disables pointing and receiving messages, turning off Ghost Vision prevents seeing the pointers.

# Explain why it's good for the game

Sometimes when observing you might want to either direct attention to something, or eg. point to something for an explanation. This enables doing it in a straightforward and familiar manner.


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
Tested:
 * Basic pointing functionality
 * Pointer is not seen by living mobs due to plane/invis
 * Pointer is not seen by ghosts without Ghost Vision
 * Pointer works at all view ranges (ghost zoom out)
 * Pointer displays chat message both zoomed out and not
 * Pointer Jump/Follow orbit works as intended

# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
add: Ghosts can now point at things too, using SHIFT+Middle Click.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
