### PR TITLE
Ghost Langchat + Fixes

### DIFF
--- a/code/datums/langchat/langchat.dm
+++ b/code/datums/langchat/langchat.dm
@@ -66,6 +66,21 @@
 	if(appearance_flags & PIXEL_SCALE)
 		langchat_image.appearance_flags |= PIXEL_SCALE
 
+/mob/langchat_make_image(var/override_color = null)
+	var/new_image = FALSE
+	if(!langchat_image)
+		new_image = TRUE
+	. = ..()
+	// Recenter for icons more than 32 wide
+	if(new_image)
+		langchat_image.maptext_x += (icon_size - 32) / 2
+
+/mob/dead/observer/langchat_make_image(var/override_color = null)
+	if(!override_color)
+		override_color = "#c51fb7"
+	. = ..()
+	langchat_image.appearance_flags |= RESET_ALPHA
+
 /atom/proc/langchat_speech(message, var/list/listeners, language, var/override_color, var/skip_language_check = FALSE, var/animation_style = LANGCHAT_DEFAULT_POP, var/list/additional_styles = list("langchat"))
 	langchat_drop_image()
 	langchat_make_image(override_color)

--- a/code/modules/admin/tabs/server_tab.dm
+++ b/code/modules/admin/tabs/server_tab.dm
@@ -34,7 +34,7 @@
 	world.update_status()
 
 /datum/admins/proc/toggledsay()
-	set name = "Toggle Deadchat"
+	set name = "Toggle Server Deadchat"
 	set desc = "Globally Toggles Deadchat"
 	set category = "Server"
 

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -60,7 +60,7 @@
 		spawn_turf = get_turf(body)				//Where is the body located?
 		attack_log = body.attack_log	//preserve our attack logs by copying them to our ghost
 		life_kills_total = body.life_kills_total //kills also copy over
-    
+
 		appearance = body.appearance
 		base_transform = matrix(body.base_transform)
 		body.alter_ghost(src)
@@ -279,6 +279,13 @@ Works together with spawning an observer, noted above.
 	var/mob/dead/observer/ghost = new(loc, src)	//Transfer safety to observer spawning proc.
 	ghost.can_reenter_corpse = can_reenter_corpse
 	ghost.timeofdeath = timeofdeath //BS12 EDIT
+
+	// Carryover langchat settings since we kept the icon
+	ghost.langchat_height = langchat_height
+	ghost.icon_size = icon_size
+	ghost.langchat_image = null
+	ghost.langchat_make_image()
+
 	SStgui.on_transfer(src, ghost)
 	if(is_admin_level(z))
 		ghost.timeofdeath = 0 // Bypass respawn limit if you die on the admin zlevel

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -116,10 +116,13 @@
 			if(!(M?.client?.prefs?.toggles_chat & CHAT_DEAD))
 				continue
 
-			if(M.stat == DEAD || isobserver(M))
+			if(isobserver(M))
+				var/mob/dead/observer/observer = M
 				var/turf/their_turf = get_turf(M)
-				if(my_turf?.z && my_turf.z == their_turf.z && get_dist(my_turf, their_turf) <= M.client.view)
-					langchat_listeners += M
+				if(alpha && observer.ghostvision && my_turf.z == their_turf.z && get_dist(my_turf, their_turf) <= observer.client.view)
+					langchat_listeners += observer
+
+			if(M.stat == DEAD)
 				M.show_message(message, 2)
 
 			else if(M.client.admin_holder && AHOLD_IS_MOD(M.client.admin_holder)) // Show the emote to admins/mods

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -106,20 +106,27 @@
 	else
 		return
 
-
+	var/turf/my_turf = get_turf(src)
+	var/list/mob/langchat_listeners = list()
 	if(message)
 		log_emote("Ghost/[src.key] : [message]")
 		for(var/mob/M in GLOB.player_list)
 			if(istype(M, /mob/new_player))
 				continue
+			if(!(M?.client?.prefs?.toggles_chat & CHAT_DEAD))
+				continue
 
-			if(M.client && M.client.admin_holder && AHOLD_IS_MOD(M.client.admin_holder) && (M.client.prefs.toggles_chat & CHAT_DEAD)) // Show the emote to admins/mods
+			if(M.stat == DEAD || isobserver(M))
+				var/turf/their_turf = get_turf(M)
+				if(my_turf?.z && my_turf.z == their_turf.z && get_dist(my_turf, their_turf) <= M.client.view)
+					langchat_listeners += M
+				M.show_message(message, 2)
+
+			else if(M.client.admin_holder && AHOLD_IS_MOD(M.client.admin_holder)) // Show the emote to admins/mods
 				to_chat(M, message)
 
-			else if(M.stat == DEAD || isobserver(M))
-				if(M.client.prefs && !(M.client.prefs.toggles_chat & CHAT_DEAD))
-					continue
-				M.show_message(message, 2)
+		if(length(langchat_listeners))
+			langchat_speech(input, langchat_listeners, GLOB.all_languages, skip_language_check = TRUE, additional_styles = list("emote", "langchat_small"))
 
 /mob/living/carbon/verb/show_emotes()
 	set name = "Emotes"

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -109,11 +109,17 @@
 	for(var/mob/M in GLOB.player_list)
 		if(istype(M, /mob/new_player))
 			continue
-		if(M.client && (M.stat == DEAD || isobserver(M)) && M.client.prefs && (M.client.prefs.toggles_chat & CHAT_DEAD))
-			to_chat(M, "<span class='game deadsay'><span class='prefix'>DEAD:</span> <span class='name'>[name] (<a href='byond://?src=\ref[M];track=\ref[src]'>F</a>)</span> says, <span class='message'>\"[message]\"</span></span>")
+		if(!(M?.client?.prefs?.toggles_chat & CHAT_DEAD))
+			continue
+
+		if(isobserver(M))
+			var/mob/dead/observer/observer = M
 			var/turf/their_turf = get_turf(M)
-			if(my_turf?.z && my_turf.z == their_turf.z && get_dist(my_turf, their_turf) <= M.client.view)
-				langchat_listeners += M
+			if(alpha && observer.ghostvision && my_turf.z == their_turf.z && get_dist(my_turf, their_turf) <= observer.client.view)
+				langchat_listeners += observer
+
+		if(M.stat == DEAD)
+			to_chat(M, "<span class='game deadsay'><span class='prefix'>DEAD:</span> <span class='name'>[name] (<a href='byond://?src=\ref[M];track=\ref[src]'>F</a>)</span> says, <span class='message'>\"[message]\"</span></span>")
 
 		else if(M.client && M.client.admin_holder && (M.client.admin_holder.rights & R_MOD) && M.client.prefs && (M.client.prefs.toggles_chat & CHAT_DEAD) ) // Show the message to admins/mods with deadchat toggled on
 			to_chat(M, "<span class='game deadsay'><span class='prefix'>DEAD:</span> <span class='name'>[name]</span> says, <span class='message'>\"[message]\"</span></span>")	//Admins can hear deadchat, if they choose to, no matter if they're blind/deaf or not.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

![image](https://user-images.githubusercontent.com/604624/205656185-8063991e-2fa0-4223-9131-7b60042ea655.png)
Had a look, turns out it was much simpler than expected, so here we are. 

This displays abovehead chat for ghosts within view range when they use deadchat or emotes.

It can be disabled by one of: 
 - Toggling off Langchat entierly
 - Toggling off own ghost visibility will disable it for others while speaking
 - Toggling off Ghost Vision will disable text alongside the ghost visuals

Also fixes some bugs.

# Explain why it's good for the game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->

More tooling for ghost interaction and for observers to observe the round together.

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
Testing details:
 * Tested ghost to ghost langchat works closeby with 2 clients
 * Tested with one ghost outside regular range into zoom range
 * Tested offsets are correct and inherited when ghosting from Queen
 * Tested disabling self visibility disables outputting langchat locally
 * Tested disabling ghost vision disables outputting langchat locally
 * Tested langchat isn't leaked to living mobs (prevented by broadcast logic)
 * Tested emotes work similarly

# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
add: Observers now have overhead text! It can be toggled with the regular Langchat setting, or hiding your/others ghosts.
fix: Fixed an oversight which would prevent either own Toggle Dchat or server's from working (they had the same name).
fix: Fixed Overhead chat not aligning properly with mob icon size, eg. for large xenomorphs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
