### PR TITLE
Visual+ Staffwho

### DIFF
--- a/code/game/verbs/who.dm
+++ b/code/game/verbs/who.dm
@@ -183,6 +183,9 @@
 		dat += "<BR><B>Current [category] ([length(listings[category])]):<BR></B>\n"
 		for(var/client/entry in listings[category])
 			dat += "\t[entry.key] is a [entry.admin_holder.rank]"
+			if(entry.admin_holder.sranks?.len)
+				for(var/srank in entry.admin_holder.sranks)
+					dat += " & [srank]"
 			if(CLIENT_IS_STAFF(src))
 				if(entry.admin_holder?.fakekey)
 					dat += " <i>(HIDDEN)</i>"

--- a/code/game/verbs/who.dm
+++ b/code/game/verbs/who.dm
@@ -183,8 +183,8 @@
 		dat += "<BR><B>Current [category] ([length(listings[category])]):<BR></B>\n"
 		for(var/client/entry in listings[category])
 			dat += "\t[entry.key] is a [entry.admin_holder.rank]"
-			if(entry.admin_holder.sranks?.len)
-				for(var/srank in entry.admin_holder.sranks)
+			if(entry.admin_holder.extra_titles?.len)
+				for(var/srank in entry.admin_holder.extra_titles)
 					dat += " & [srank]"
 			if(CLIENT_IS_STAFF(src))
 				if(entry.admin_holder?.fakekey)

--- a/code/modules/admin/admin_ranks.dm
+++ b/code/modules/admin/admin_ranks.dm
@@ -104,6 +104,12 @@ var/list/admin_ranks = list()								//list of all ranks with associated rights
 	if(List.len >= 2)
 		rank = ckeyEx(List[2])
 
+	var/list/sranks = list()
+	if(List.len >= 3)
+		List -= List[2]
+		List -= List[1]
+		sranks = List
+
 	if(mentor)
 		if(!(LAZYISIN(MentorRanks, rank)))
 			log_admin("ADMIN LOADER: WARNING: Mentors.txt attempted to override staff ranks!")
@@ -114,7 +120,7 @@ var/list/admin_ranks = list()								//list of all ranks with associated rights
 	var/rights = admin_ranks[rank]
 
 	//create the admin datum and store it for later use
-	var/datum/admins/D = new /datum/admins(rank, rights, ckey)
+	var/datum/admins/D = new /datum/admins(rank, rights, ckey, sranks)
 
 	//find the client for a ckey if they are connected and associate them with the new admin datum
 	D.associate(GLOB.directory[ckey])

--- a/code/modules/admin/admin_ranks.dm
+++ b/code/modules/admin/admin_ranks.dm
@@ -104,11 +104,9 @@ var/list/admin_ranks = list()								//list of all ranks with associated rights
 	if(List.len >= 2)
 		rank = ckeyEx(List[2])
 
-	var/list/sranks = list()
+	var/list/extra_titles = list()
 	if(List.len >= 3)
-		List -= List[2]
-		List -= List[1]
-		sranks = List
+		extra_titles = List.Copy(3)
 
 	if(mentor)
 		if(!(LAZYISIN(MentorRanks, rank)))
@@ -120,7 +118,7 @@ var/list/admin_ranks = list()								//list of all ranks with associated rights
 	var/rights = admin_ranks[rank]
 
 	//create the admin datum and store it for later use
-	var/datum/admins/D = new /datum/admins(rank, rights, ckey, sranks)
+	var/datum/admins/D = new /datum/admins(rank, rights, ckey, extra_titles)
 
 	//find the client for a ckey if they are connected and associate them with the new admin datum
 	D.associate(GLOB.directory[ckey])

--- a/code/modules/admin/holder2.dm
+++ b/code/modules/admin/holder2.dm
@@ -5,7 +5,7 @@ GLOBAL_PROTECT(href_token)
 
 /datum/admins
 	var/rank			= "Temporary Admin"
-	var/list/sranks		= null
+	var/list/extra_titles		= null
 	var/client/owner	= null
 	var/rights = 0
 	var/fakekey			= null
@@ -22,7 +22,7 @@ GLOBAL_PROTECT(href_token)
 	///Whether this admin is invisiminning
 	var/invisimined = FALSE
 
-/datum/admins/New(initial_rank = "Temporary Admin", initial_rights = 0, ckey, new_sranks)
+/datum/admins/New(initial_rank = "Temporary Admin", initial_rights = 0, ckey, list/new_extra_titles)
 	if(!ckey)
 		error("Admin datum created without a ckey argument. Datum has been deleted")
 		qdel(src)
@@ -32,7 +32,7 @@ GLOBAL_PROTECT(href_token)
 	rights = initial_rights
 	href_token = GenerateToken()
 	admin_datums[ckey] = src
-	sranks = new_sranks
+	extra_titles = new_extra_titles
 
 /datum/admins/proc/associate(client/C)
 	if(istype(C))

--- a/code/modules/admin/holder2.dm
+++ b/code/modules/admin/holder2.dm
@@ -5,6 +5,7 @@ GLOBAL_PROTECT(href_token)
 
 /datum/admins
 	var/rank			= "Temporary Admin"
+	var/list/sranks		= null
 	var/client/owner	= null
 	var/rights = 0
 	var/fakekey			= null
@@ -21,7 +22,7 @@ GLOBAL_PROTECT(href_token)
 	///Whether this admin is invisiminning
 	var/invisimined = FALSE
 
-/datum/admins/New(initial_rank = "Temporary Admin", initial_rights = 0, ckey)
+/datum/admins/New(initial_rank = "Temporary Admin", initial_rights = 0, ckey, new_sranks)
 	if(!ckey)
 		error("Admin datum created without a ckey argument. Datum has been deleted")
 		qdel(src)
@@ -31,6 +32,7 @@ GLOBAL_PROTECT(href_token)
 	rights = initial_rights
 	href_token = GenerateToken()
 	admin_datums[ckey] = src
+	sranks = new_sranks
 
 /datum/admins/proc/associate(client/C)
 	if(istype(C))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request
Adds aesthetic ranks to staff who, so staff with multiple roles can be displayed. They only inherit the rights of their first one however.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Clarity for staff with multiple roles.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
add: StaffWho can now show multiple roles per staff member. This is purely aesthetical.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
