### PR TITLE
Added directional armor to Defender fortify. Fixed crit bug.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/defender/defender_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/defender/defender_abilities.dm
@@ -37,7 +37,7 @@
 	macro_path = /datum/action/xeno_action/verb/verb_fortify
 	action_type = XENO_ACTION_ACTIVATE
 	ability_primacy = XENO_PRIMARY_ACTION_4
-	xeno_cooldown = 5
+	xeno_cooldown = 5 SECONDS
 
 	 /// Extra armor when fortified and facing bullets.
 	var/frontal_armor = 5

--- a/code/modules/mob/living/carbon/xenomorph/abilities/defender/defender_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/defender/defender_abilities.dm
@@ -37,7 +37,12 @@
 	macro_path = /datum/action/xeno_action/verb/verb_fortify
 	action_type = XENO_ACTION_ACTIVATE
 	ability_primacy = XENO_PRIMARY_ACTION_4
-	xeno_cooldown = 100
+	xeno_cooldown = 5
+
+	 /// Extra armor when fortified and facing bullets.
+	var/frontal_armor = 5
+	 /// Extra armor when steelcrest, fortified, and facing bullets.
+	var/steelcrest_frontal_armor = 15
 
 /datum/action/xeno_action/activable/tail_stab/slam
 	name = "Tail Slam"

--- a/code/modules/mob/living/carbon/xenomorph/abilities/defender/defender_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/defender/defender_powers.dm
@@ -215,6 +215,7 @@
 			X.anchored = TRUE
 			X.small_explosives_stun = FALSE
 			X.update_canmove()
+		RegisterSignal(owner, COMSIG_XENO_PRE_CALCULATE_ARMOURED_DAMAGE_PROJECTILE, .proc/check_directional_armor)
 		X.mob_size = MOB_SIZE_IMMOBILE //knockback immune
 		X.mob_flags &= ~SQUEEZE_UNDER_VEHICLES
 		X.update_icons()
@@ -232,11 +233,21 @@
 			X.armor_deflection_buff -= 30
 			X.armor_explosive_buff -= 60
 			X.small_explosives_stun = TRUE
+		UnregisterSignal(owner, COMSIG_XENO_PRE_CALCULATE_ARMOURED_DAMAGE_PROJECTILE)
 		X.mob_size = MOB_SIZE_XENO //no longer knockback immune
 		X.mob_flags |= SQUEEZE_UNDER_VEHICLES
 		X.update_canmove()
 		X.update_icons()
 		X.fortify = FALSE
+
+/datum/action/xeno_action/activable/fortify/proc/check_directional_armor(var/mob/living/carbon/Xenomorph/defendy, list/damagedata)
+	SIGNAL_HANDLER
+	var/projectile_direction = damagedata["direction"]
+	if(defendy.dir & REVERSE_DIR(projectile_direction))
+		if(defendy.mutation_type == DEFENDER_STEELCREST)
+			damagedata["armor"] += steelcrest_frontal_armor
+		else
+			damagedata["armor"] += frontal_armor
 
 /datum/action/xeno_action/activable/fortify/proc/death_check()
 	SIGNAL_HANDLER

--- a/code/modules/mob/living/carbon/xenomorph/castes/Defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Defender.dm
@@ -70,9 +70,9 @@
 	if(bound_xeno.stat == DEAD)
 		return
 
-	if(bound_xeno.fortify)
+	if(bound_xeno.fortify && bound_xeno.health > 0)
 		bound_xeno.icon_state = "[bound_xeno.mutation_icon_state || bound_xeno.mutation_type] Defender Fortify"
 		return TRUE
-	if(bound_xeno.crest_defense)
+	if(bound_xeno.crest_defense && bound_xeno.health > 0)
 		bound_xeno.icon_state = "[bound_xeno.mutation_icon_state || bound_xeno.mutation_type] Defender Crest"
 		return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

Added 15 frontal armor to steelcrest defenders and 5 to normal defenders, The directional armor in total will be 50 and 70 respectively.

Halved Fortify cooldown.

Fixed the bug in which crested or fortified defenders didn't have crit sprites.

# Explain why it's good for the game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->

> Added 15 frontal armor to steelcrest defenders and 5 to normal defenders, The directional armor in total will be 50 and 70 respectively.

Steelcrest, and fortify as a whole, have been known to be pretty much a total joke ever since their initial additions, barring some funny steamroll rounds in which the former were invincible.

I strongly believe these abilities need a buff, and think it would be very interesting to make said buff be frontal armor. This way,  fortified defenders have both a strong defence buff and great counterplay due to the possibility of the marines circling around and shooting from the back. Sure, steelcrest could move or change direction, but it still takes away options from them, and they don't have any counter to two marines going different directions even so. Fortified base defenders cannot change direction.

> Halved Fortify cooldown.

I think this will help make it a more dynamic ability. Right now, fortifying is basically signalling 'I AM AN IDIOT AND A FREE KILL!!!' to the entire marine side. Even steelcrest, with its largely reduced movement. Halving the cooldown will allow you to utilize it in interesting strategies like blocking off hallways and protecting the queen without making yourself a completely useless sitting duck for TEN seconds.

I understand if someone thinks one or the other is fine but both together are too much, in that case I'll take away the halved cooldown for now.

But, personally, I think we should be looking into ways to make T1s stronger and T3s weaker, as having more than half the hive's power be centralized in T3s is quite bad; It's like if marines were completely reliant on specialists. This is a great way to make T1s stronger.

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
add: Added 15 frontal armor to steelcrest defenders and 5 to normal defenders, The directional armor in total will be 50 and 70 respectively.
balance: Halved Fortify cooldown.
fix: Fixed the bug in which crested or fortified defenders didn't have crit sprites.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
