### PR TITLE
Research Nerfs

### DIFF
--- a/code/game/objects/items/devices/portable_vendor.dm
+++ b/code/game/objects/items/devices/portable_vendor.dm
@@ -244,14 +244,14 @@
 	desc = "A suitcase-sized automated storage and retrieval system. Designed to efficiently store and selectively dispense small items. This one has the Weyland-Yutani logo stamped on its side."
 
 	special_prod_time_lock = CL_BRIEFCASE_TIME_LOCK
-	special_prods = list(/obj/item/implanter/neurostim, /obj/item/storage/pill_bottle/ultrazine)
+	special_prods = list(/obj/item/implanter/neurostim, /obj/item/reagent_container/hypospray/autoinjector/ultrazine)
 
 	req_access = list(ACCESS_WY_CORPORATE)
 	req_role = JOB_CORPORATE_LIAISON
 	listed_products = list(
 		list("INCENTIVES", 0, null, null, null),
 		list("Neurostimulator Implant", 30, /obj/item/implanter/neurostim, "white", "Implant which regulates nociception and sensory function. Benefits include pain reduction, improved balance, and improved resistance to overstimulation and disorientation. To encourage compliance, negative stimulus is applied if the implant hears a (non-radio) spoken codephrase. Implant will be degraded by the body's immune system over time, and thus malfunction with gradually increasing frequency. Personal use not recommended."),
-		list("Ultrazine Pills", 25, /obj/item/storage/pill_bottle/ultrazine, "white", "Highly-addictive stimulant. Enhances short-term physical performance, particularly running speed. Effects last approximately 10 minutes per pill. More than two pills at a time will result in overdose. Withdrawal causes extreme discomfort and hallucinations. Long-term use results in halluciations and organ failure. Conditional distribution secures subject compliance. Not for personal use."),
+		list("Ultrazine Injector", 25, /obj/item/reagent_container/hypospray/autoinjector/ultrazine, "white", "Highly-addictive stimulant. Enhances short-term physical performance, particularly running speed. Effects last approximately 10 minutes per injection. More than two injections at a time will result in overdose. Withdrawal causes extreme discomfort and hallucinations. Long-term use results in halluciations and organ failure. Conditional distribution secures subject compliance. Not for personal use."),
 		list("Ceramic Plate", 10, /obj/item/trash/ceramic_plate, "white", "A ceramic plate, useful in a variety of situations."),
 		list("Cash", 5, /obj/item/spacecash/c1000, "white", "$1000 USD, unmarked bills"),
 		list("WY Encryption Key", 5, /obj/item/device/encryptionkey/WY, "white", "WY private comms encryption key, for conducting private business."),

--- a/code/game/objects/items/devices/portable_vendor.dm
+++ b/code/game/objects/items/devices/portable_vendor.dm
@@ -244,14 +244,14 @@
 	desc = "A suitcase-sized automated storage and retrieval system. Designed to efficiently store and selectively dispense small items. This one has the Weyland-Yutani logo stamped on its side."
 
 	special_prod_time_lock = CL_BRIEFCASE_TIME_LOCK
-	special_prods = list(/obj/item/implanter/neurostim, /obj/item/reagent_container/hypospray/autoinjector/ultrazine)
+	special_prods = list(/obj/item/implanter/neurostim, /obj/item/reagent_container/hypospray/autoinjector/ultrazine/liaison)
 
 	req_access = list(ACCESS_WY_CORPORATE)
 	req_role = JOB_CORPORATE_LIAISON
 	listed_products = list(
 		list("INCENTIVES", 0, null, null, null),
 		list("Neurostimulator Implant", 30, /obj/item/implanter/neurostim, "white", "Implant which regulates nociception and sensory function. Benefits include pain reduction, improved balance, and improved resistance to overstimulation and disorientation. To encourage compliance, negative stimulus is applied if the implant hears a (non-radio) spoken codephrase. Implant will be degraded by the body's immune system over time, and thus malfunction with gradually increasing frequency. Personal use not recommended."),
-		list("Ultrazine Injector", 25, /obj/item/reagent_container/hypospray/autoinjector/ultrazine, "white", "Highly-addictive stimulant. Enhances short-term physical performance, particularly running speed. Effects last approximately 10 minutes per injection. More than two injections at a time will result in overdose. Withdrawal causes extreme discomfort and hallucinations. Long-term use results in halluciations and organ failure. Conditional distribution secures subject compliance. Not for personal use."),
+		list("Ultrazine Injector", 25, /obj/item/reagent_container/hypospray/autoinjector/ultrazine/liaison, "white", "Highly-addictive stimulant. Enhances short-term physical performance, particularly running speed. Effects last approximately 10 minutes per injection. More than two injections at a time will result in overdose. Withdrawal causes extreme discomfort and hallucinations. Long-term use results in halluciations and organ failure. Conditional distribution secures subject compliance. Not for personal use."),
 		list("Ceramic Plate", 10, /obj/item/trash/ceramic_plate, "white", "A ceramic plate, useful in a variety of situations."),
 		list("Cash", 5, /obj/item/spacecash/c1000, "white", "$1000 USD, unmarked bills"),
 		list("WY Encryption Key", 5, /obj/item/device/encryptionkey/WY, "white", "WY private comms encryption key, for conducting private business."),

--- a/code/game/objects/items/reagent_containers/autoinjectors.dm
+++ b/code/game/objects/items/reagent_containers/autoinjectors.dm
@@ -235,6 +235,12 @@
 	icon_state = "stimpack"
 	item_state = "stimpack"
 	skilllock = SKILL_MEDICAL_DEFAULT
+	display_maptext = TRUE
+	maptext_label = "??"
+
+/obj/item/reagent_container/hypospray/autoinjector/ultrazine/liaison
+	name = "white autoinjector"
+	desc = "You know what they say, don't jab yourself with suspicious syringes."
 
 /obj/item/reagent_container/hypospray/autoinjector/yautja
 	name = "unusual crystal"

--- a/code/game/objects/items/reagent_containers/autoinjectors.dm
+++ b/code/game/objects/items/reagent_containers/autoinjectors.dm
@@ -225,6 +225,17 @@
 	reagents.add_reagent("oxycodone", MED_REAGENTS_OVERDOSE-1)
 	update_icon()
 
+/obj/item/reagent_container/hypospray/autoinjector/ultrazine
+	name = "ultrazine autoinjector"
+	chemname = "ultrazine"
+	desc = "An auto-injector loaded with a special illegal muscle stimulant, Do not administer more than twice at a time. Highly addictive."
+	amount_per_transfer_from_this = 5
+	volume = 25
+	uses_left = 5
+	icon_state = "stimpack"
+	item_state = "stimpack"
+	skilllock = SKILL_MEDICAL_DEFAULT
+
 /obj/item/reagent_container/hypospray/autoinjector/yautja
 	name = "unusual crystal"
 	chemname = "thwei"

--- a/code/game/objects/items/reagent_containers/autoinjectors.dm
+++ b/code/game/objects/items/reagent_containers/autoinjectors.dm
@@ -228,7 +228,7 @@
 /obj/item/reagent_container/hypospray/autoinjector/ultrazine
 	name = "ultrazine autoinjector"
 	chemname = "ultrazine"
-	desc = "An auto-injector loaded with a special illegal muscle stimulant, Do not administer more than twice at a time. Highly addictive."
+	desc = "An auto-injector loaded with a special illegal muscle stimulant, do not administer more than twice at a time. Highly addictive."
 	amount_per_transfer_from_this = 5
 	volume = 25
 	uses_left = 5
@@ -236,12 +236,13 @@
 	item_state = "stimpack"
 	skilllock = SKILL_MEDICAL_DEFAULT
 	display_maptext = TRUE
-	maptext_label = "??"
+	maptext_label = "UZ"
 
 /obj/item/reagent_container/hypospray/autoinjector/ultrazine/liaison
 	name = "white autoinjector"
 	desc = "You know what they say, don't jab yourself with suspicious syringes."
-
+	maptext_label = "??"
+	
 /obj/item/reagent_container/hypospray/autoinjector/yautja
 	name = "unusual crystal"
 	chemname = "thwei"

--- a/code/modules/reagents/chemistry_properties/prop_positive.dm
+++ b/code/modules/reagents/chemistry_properties/prop_positive.dm
@@ -124,7 +124,7 @@
 	name = PROPERTY_NERVESTIMULATING
 	code = "NST"
 	description = "Increases neuron communication speed across synapses resulting in improved reaction time, awareness and muscular control."
-	rarity = PROPERTY_UNCOMMON
+	rarity = PROPERTY_RARE
 	category = PROPERTY_TYPE_STIMULANT
 	value = 3
 
@@ -157,7 +157,7 @@
 	name = PROPERTY_MUSCLESTIMULATING
 	code = "MST"
 	description = "Stimulates neuromuscular junctions increasing the force of muscle contractions, resulting in increased strength. High doses might exhaust the cardiac muscles."
-	rarity = PROPERTY_UNCOMMON
+	rarity = PROPERTY_RARE
 	category = PROPERTY_TYPE_STIMULANT
 
 /datum/chem_property/positive/musclestimulating/process(mob/living/M, var/potency = 1)

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -62418,9 +62418,6 @@
 	pixel_x = 7;
 	pixel_y = 7
 	},
-/obj/item/storage/box/monkeycubes{
-	pixel_x = 7
-	},
 /turf/open/floor/almayer{
 	dir = 8;
 	icon_state = "sterile_green_side";


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

This PR brings in some changes to cut down a few things.
one monkey cube box has been removed to cut down the maximum xenomorphs researchers can make (from 21 xenomorphs total to 11, excluding CL monkey cubes and including pooled).

 A corrupted hive's biggest advantage over the regular hive is that they are teamed up with the marines, so if a corrupted hive managed to get ALL the monkey cubes for their hive, they would effectively be 1:1 with the rival hive with the addition of being allied to the marines, an USCM allied hive still has the advantage over the regular hive by being allied to marines and being able to plan out their castes for XvX than XvH. 

This change will now make the regular hive atleast have a chance fighting off the corrupted hive in a scenario with marines and be slightly better when the corrupted are alone (if the regular hive has more xenos).

If you are upset that you lost more monkeys to "experiment" on that isnt just infecting them with huggers, keep in mind that there is no way you can permamently lose a monkey unless you decapitate them or leave them for dead instead of reviving them. No I will not make special monkeys that cannot be infected, use your monkeys as intended for experiments, they are not only for making a corrupted hive.

second change is increasing the rarity of Musclestimulating (MST) and Nervestimulating (NST) from Uncommon to Rare (1 tier up). Lately if not for a very long time, Research seems to only ever make stimulants, we have cut down a lot of ways to get them (by removing Synaptizine and Hyperzine and other changes etc.) and currently you can still obtain them quite easily and the whole research meta was to always make NST MST instead of utilizing literally any other beneficial property and now with anti xenomorph interactions, they still make stimulants only because it has been ingrained in their brain for too long.

Increasing their rarity makes the properties no longer appear in botany chems, so you will now have to wait for colony vials/papers, a xeno corpse and max your clearance or buy a C3+ paper.

The final change is replacing the Ultrazine Pill Bottle the CL has with an Ultrazine Auto-Injector, the pill bottle contained 5 pills with 5u each, the new injector contains 25u of the stimulant and gives 5u each injection. The only difference being is that the Ultrazine the CL has is now in a liquid injection than pill form, it will begin affecting you instantly and the main reason I made this change, you can no longer obtain the chemical from it as you could with pills by dissolving them which granted an easy scan for MST, since we are making MST rarer, the CL should not have pills but an auto-injector.


# Explain why it's good for the game

Cuts down corrupted numbers to prevent easy stomps whenever marines get them
An attempt to change the stim meta (by making it rarer) to encourage other properties to be used.


# Testing Photographs and Procedure
Checked on using the briefcase to spawn the new autoinjector to make sure it spawns, and tested it to make sure it has the correct values. Checked that the removed monkey cube box is actually gone. Checked that MST and NST are now actually Rare by scanning them and seeing their rarity type in the simulator.


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl: Unknownity
del: Removed one monkey cube box from Research.
balance: Increased rarity of MST and NST from Uncommon to Rare.
balance: Replaced the Ultrazine Pill Bottle with an Ultrazine auto-injector in the CL Vendor Briefcase.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
