### PR TITLE
You can now join in as a buried larva without a pool at roundstart

### DIFF
--- a/code/__DEFINES/xeno.dm
+++ b/code/__DEFINES/xeno.dm
@@ -562,8 +562,8 @@
 // HIVECORE COOLDOWN TIME
 #define HIVECORE_COOLDOWN 5 MINUTES
 
-// The round time where the xenos will no longer be able to move hivecore without cooldowns
-#define HIVECORE_COOLDOWN_CUTOFF 20 MINUTES
+// Xeno 'pre-setup' duration, round time where the xenos will no longer be able to move hivecore without cooldowns or burrow up as larvae from the ground without a pool.
+#define XENOMORPH_PRE_SETUP_CUTOFF 20 MINUTES
 
 // Xeno shield HUD scale factor (1.5x so its easier to see, most times)
 #define XENO_SHIELD_HUD_SCALE_FACTOR 1.5

--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -382,7 +382,7 @@ Additional game mode variables.
 
 				for(var/mob_name in picked_hive.banished_ckeys)
 					if(picked_hive.banished_ckeys[mob_name] == xeno_candidate.ckey)
-						to_chat(xeno_candidate, SPAN_WARNING("You are banished from this picked_hive, You may not rejoin unless the Queen re-admits you or dies."))
+						to_chat(xeno_candidate, SPAN_WARNING("You are banished from the [picked_hive], You may not rejoin unless the Queen re-admits you or dies."))
 						return
 				if(isnewplayer(xeno_candidate))
 					var/mob/new_player/noob = xeno_candidate

--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -350,13 +350,12 @@ Additional game mode variables.
 	var/datum/hive_status/hive
 	for(var/hivenumber in GLOB.hive_datum)
 		hive = GLOB.hive_datum[hivenumber]
-		var/obj/effect/alien/resin/special/pool/SP = hive.spawn_pool
-		if(!isnull(SP) && SP.can_spawn_larva())
+		if(!hive.hardcore && hive.stored_larva && (hive.spawn_pool || (world.time < 30 MINUTES + SSticker.round_start_time)))
 			if(SSticker.mode && (SSticker.mode.flags_round_type & MODE_RANDOM_HIVE))
-				available_xenos |= "pooled larva"
-				LAZYADD(available_xenos["pooled larva"], hive)
+				available_xenos |= "any buried larva"
+				LAZYADD(available_xenos["any buried larva"], hive)
 			else
-				var/larva_option = "pooled larva ([hive])"
+				var/larva_option = "buried larva ([hive])"
 				available_xenos += larva_option
 				available_xenos[larva_option] = list(hive)
 
@@ -369,9 +368,8 @@ Additional game mode variables.
 		var/userInput = tgui_input_list(usr, "Available Xenomorphs", "Join as Xeno", available_xenos, theme="hive_status")
 
 		if(available_xenos[userInput]) //Free xeno mobs have no associated value and skip this. "Pooled larva" strings have a list of hives.
-			var/datum/hive_status/H = pick(available_xenos[userInput]) //The list contains all available hives if we are to choose at random, only one element if we already chose a hive by its name.
-			var/obj/effect/alien/resin/special/pool/SP = H.spawn_pool
-			if(!isnull(SP) && SP.can_spawn_larva()) //isnull() is checked here, in case the spawn pool gets destroyed while the menu is open.
+			var/datum/hive_status/picked_hive = pick(available_xenos[userInput]) //The list contains all available hives if we are to choose at random, only one element if we already chose a hive by its name.
+			if(picked_hive.stored_larva)
 				if(!xeno_bypass_timer)
 					var/deathtime = world.time - xeno_candidate.timeofdeath
 					if(isnewplayer(xeno_candidate))
@@ -379,20 +377,26 @@ Additional game mode variables.
 					if(deathtime < 2.5 MINUTES && !check_client_rights(xeno_candidate.client, R_ADMIN, FALSE))
 						var/message = SPAN_WARNING("You have been dead for [DisplayTimeText(deathtime)].")
 						to_chat(xeno_candidate, message)
-						to_chat(xeno_candidate, SPAN_WARNING("You must wait 2.5 minutes before rejoining the game!"))
+						to_chat(xeno_candidate, SPAN_WARNING("You must wait 2.5 minutes before rejoining the game as a buried larva!"))
 						return FALSE
 
-				for(var/mob_name in SP.linked_hive.banished_ckeys)
-					if(SP.linked_hive.banished_ckeys[mob_name] == xeno_candidate.ckey)
-						to_chat(xeno_candidate, SPAN_WARNING("You are banished from this hive, You may not rejoin unless the Queen re-admits you or dies."))
+				for(var/mob_name in picked_hive.banished_ckeys)
+					if(picked_hive.banished_ckeys[mob_name] == xeno_candidate.ckey)
+						to_chat(xeno_candidate, SPAN_WARNING("You are banished from this picked_hive, You may not rejoin unless the Queen re-admits you or dies."))
 						return
 				if(isnewplayer(xeno_candidate))
-					var/mob/new_player/N = xeno_candidate
-					N.close_spawn_windows()
-				SP.spawn_pooled_larva(xeno_candidate)
+					var/mob/new_player/noob = xeno_candidate
+					noob.close_spawn_windows()
+				if(picked_hive.spawn_pool)
+					picked_hive.spawn_pool.spawn_pooled_larva(xeno_candidate)
+				else if((world.time < 30 MINUTES + SSticker.round_start_time))
+					picked_hive.do_buried_larva_spawn(xeno_candidate)
+				else
+					to_chat(xeno_candidate, SPAN_WARNING("Seems like something went wrong. Try again?"))
+					return FALSE
 				return TRUE
 			else
-				to_chat(xeno_candidate, SPAN_WARNING("Seems like something went wrong. Try again"))
+				to_chat(xeno_candidate, SPAN_WARNING("Seems like something went wrong. Try again?"))
 				return FALSE
 
 		if(!isXeno(userInput) || !xeno_candidate)

--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -382,7 +382,7 @@ Additional game mode variables.
 
 				for(var/mob_name in picked_hive.banished_ckeys)
 					if(picked_hive.banished_ckeys[mob_name] == xeno_candidate.ckey)
-						to_chat(xeno_candidate, SPAN_WARNING("You are banished from the [picked_hive], You may not rejoin unless the Queen re-admits you or dies."))
+						to_chat(xeno_candidate, SPAN_WARNING("You are banished from the [picked_hive], you may not rejoin unless the Queen re-admits you or dies."))
 						return
 				if(isnewplayer(xeno_candidate))
 					var/mob/new_player/noob = xeno_candidate

--- a/code/modules/cm_aliens/structures/special/pylon_core.dm
+++ b/code/modules/cm_aliens/structures/special/pylon_core.dm
@@ -130,14 +130,14 @@
 			to_chat(M,SPAN_WARNING("You have attempted to destroy \the [src] too recently! Wait a bit!")) // no spammy
 			return XENO_NO_DELAY_ACTION
 
-		else if(warn && world.time > HIVECORE_COOLDOWN_CUTOFF)
+		else if(warn && world.time > XENOMORPH_PRE_SETUP_CUTOFF)
 			if((alert(M, "Are you sure that you want to destroy the hive core? (There will be a 5 minute cooldown before you can build another one.)", , "Yes", "No") == "No"))
 				return XENO_NO_DELAY_ACTION
 
 			INVOKE_ASYNC(src, .proc/startDestroying,M)
 			return XENO_NO_DELAY_ACTION
 
-		else if(world.time < HIVECORE_COOLDOWN_CUTOFF)
+		else if(world.time < XENOMORPH_PRE_SETUP_CUTOFF)
 			if((alert(M, "Are you sure that you want to remove the hive core? No cooldown will be applied.", , "Yes", "No") == "No"))
 				return XENO_NO_DELAY_ACTION
 
@@ -162,7 +162,7 @@
 	if(linked_hive)
 		visible_message(SPAN_XENOHIGHDANGER("The resin roof withers away as \the [src] dies!"), max_distance = WEED_RANGE_CORE)
 		linked_hive.hive_location = null
-		if(world.time < HIVECORE_COOLDOWN_CUTOFF && !hardcore)
+		if(world.time < XENOMORPH_PRE_SETUP_CUTOFF && !hardcore)
 			. = ..()
 			return
 		linked_hive.hivecore_cooldown = TRUE

--- a/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
@@ -628,7 +628,7 @@
 		return FALSE
 
 	if((choice == XENO_STRUCTURE_CORE) && isXenoQueen(X) && X.hive.has_structure(XENO_STRUCTURE_CORE))
-		if(X.hive.hive_location.hardcore || world.time > HIVECORE_COOLDOWN_CUTOFF)
+		if(X.hive.hive_location.hardcore || world.time > XENOMORPH_PRE_SETUP_CUTOFF)
 			to_chat(X, SPAN_WARNING("You can't rebuild this structure!"))
 			return
 		if(alert(X, "Are you sure that you want to move the hive and destroy the old hive core?", , "Yes", "No") == "No")

--- a/code/modules/mob/living/carbon/xenomorph/abilities/queen/queen_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/queen/queen_abilities.dm
@@ -91,7 +91,7 @@
 	UnregisterSignal(owner, COMSIG_XENO_THICK_RESIN_BYPASS)
 
 	if(owner)
-		to_chat(owner, SPAN_XENODANGER("Your boosted building has been disabled!"))
+		to_chat(owner, SPAN_XENOHIGHDANGER("Your boosted building has been disabled!"))
 
 /datum/action/xeno_action/activable/secrete_resin/remote/queen/proc/override_secrete_thick_resin()
 	return COMPONENT_THICK_BYPASS

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -829,7 +829,7 @@
 	playsound(new_xeno, 'sound/effects/xeno_newlarva.ogg', 50, 1)
 	to_chat(new_xeno, SPAN_XENOANNOUNCE("You are a xenomorph larva awakened from slumber!"))
 	if(new_xeno.client)
-		if(new_xeno.client?.prefs.toggles_flashing & FLASH_POOLSPAWN)
+		if(new_xeno.client?.prefs?.toggles_flashing & FLASH_POOLSPAWN)
 			window_flash(new_xeno.client)
 
 	stored_larva--

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -800,6 +800,41 @@
 	else
 		hive_ui.update_pooled_larva()
 
+/datum/hive_status/proc/do_buried_larva_spawn(mob/xeno_candidate)
+	var/spawning_area
+	if(hive_location)
+		spawning_area = hive_location
+	else if(living_xeno_queen)
+		spawning_area = living_xeno_queen
+	else for(var/mob/living/carbon/xenomorpheus as anything in totalXenos)
+		if(isXenoLarva(xenomorpheus) || isXenoBuilder(xenomorpheus)) //next to xenos that should be in a safe spot
+			spawning_area = xenomorpheus
+	if(!spawning_area)
+		spawning_area = pick(totalXenos) // FUCK IT JUST GO ANYWHERE
+	var/list/turf_list
+	for(var/turf/open/open_turf in orange(3, spawning_area))
+		LAZYADD(turf_list, open_turf)
+	var/turf/open/spawning_turf = pick(turf_list)
+
+	var/mob/living/carbon/Xenomorph/Larva/new_xeno = spawn_hivenumber_larva(spawning_turf, hivenumber)
+	if(isnull(new_xeno))
+		return FALSE
+
+	if(!SSticker.mode.transfer_xeno(xeno_candidate, new_xeno))
+		qdel(new_xeno)
+		return FALSE
+	new_xeno.visible_message(SPAN_XENODANGER("A larva suddenly burrows out of \the [spawning_turf]!"),
+	SPAN_XENODANGER("You burrow out of \the [spawning_turf] and awaken from your slumber. For the Hive!"))
+	msg_admin_niche("[key_name(new_xeno)] burrowed out from \a [spawning_turf]. (<A HREF='?_src_=admin_holder;[HrefToken(forceGlobal = TRUE)];adminplayerobservecoodjump=1;X=[spawning_turf.x];Y=[spawning_turf.y];Z=[spawning_turf.z]'>JMP</a>)")
+	playsound(new_xeno, 'sound/effects/xeno_newlarva.ogg', 50, 1)
+	to_chat(new_xeno, SPAN_XENOANNOUNCE("You are a xenomorph larva awakened from slumber!"))
+	if(new_xeno.client)
+		if(new_xeno.client?.prefs.toggles_flashing & FLASH_POOLSPAWN)
+			window_flash(new_xeno.client)
+
+	stored_larva--
+	hive_ui.update_pooled_larva()
+
 /mob/living/carbon/proc/ally_of_hivenumber(var/hivenumber)
 	var/datum/hive_status/H = GLOB.hive_datum[hivenumber]
 	if(!H)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request
Larvae can now pop out from the ground nearby the hive core, the queen, builder castes, larvae, or any xeno in that order, during the first 20 minutes of the round.

Changed the span of a queen announcement.

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

> Larvae can now pop out from the ground nearby the hive core, the queen, builder castes, larvae, or any xeno in that order, during the first 20 minutes of the round.

This is intended to let people quickly join in as xeno even if the pool wasn't built, preventing things like forgetting to build it from absolutely crippling the hive early on.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
add: Larvae can now pop out from the ground nearby the hive core, the queen, builder castes, larvae, or any xeno in that order, during the first 20 minutes of the round.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
