### PR TITLE
Recharge stations now properly update their icons

### DIFF
--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -18,7 +18,6 @@
 
 /obj/structure/machinery/recharge_station/Initialize(mapload, ...)
 	. = ..()
-	build_icon()
 	update_icon()
 	flags_atom |= USES_HEARING
 
@@ -118,6 +117,13 @@
 
 /obj/structure/machinery/recharge_station/update_icon()
 	..()
+	if(!inoperable())
+		if(src.occupant)
+			icon_state = "borgcharger1"
+		else
+			icon_state = "borgcharger0"
+	else
+		icon_state = "borgcharger0"
 	overlays.Cut()
 	switch(round(chargepercentage()))
 		if(1 to 20)
@@ -132,16 +138,6 @@
 			overlays += image('icons/obj/objects.dmi', "statn_c80")
 		if(99 to 110)
 			overlays += image('icons/obj/objects.dmi', "statn_c100")
-
-/obj/structure/machinery/recharge_station/proc/build_icon()
-	if(!inoperable())
-		if(src.occupant)
-			icon_state = "borgcharger1"
-		else
-			icon_state = "borgcharger0"
-	else
-		icon_state = "borgcharger0"
-	update_icon()
 
 /obj/structure/machinery/recharge_station/proc/process_occupant()
 	if(src.occupant)
@@ -189,10 +185,9 @@
 		src.occupant.client.perspective = MOB_PERSPECTIVE
 	src.occupant.forceMove(loc)
 	src.occupant = null
-	build_icon()
+	update_icon()
 	update_use_power(1)
 	return
-
 
 /obj/structure/machinery/recharge_station/verb/move_eject()
 	set category = "Object"
@@ -225,7 +220,7 @@
 	src.occupant = M
 	start_processing()
 	src.add_fingerprint(usr)
-	build_icon()
+	update_icon()
 	update_use_power(1)
 	return TRUE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Recently I noticed the Recharge Stations didn't update their icons while someone was being repaired in them, or if you'd move someone else into them rather than go in yourself. Fixed that.

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

Makes the Recharge Station appear less confusing, which is always good.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: Recharge Stations now properly update their icons when moving someone into them and to show the proper power drain.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
