### PR TITLE
Flares land with offset when thrown

### DIFF
--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -289,7 +289,7 @@
 // Causes flares to stop with a rotation offset for visual purposes
 /obj/item/device/flashlight/flare/animation_spin(speed = 5, loop_amount = -1, clockwise = TRUE, sections = 3, angular_offset = 0, pixel_fuzz = 0)
 	clockwise = pick(TRUE, FALSE)
-	angular_offset = rand(360)
+	angular_offset = rand(180)-90
 	pixel_fuzz = 16
 	return ..()
 /obj/item/device/flashlight/flare/pickup()

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -286,6 +286,19 @@
 	if(fuel <= 0 || !on)
 		burn_out()
 
+// Causes flares to stop with a rotation offset for visual purposes
+/obj/item/device/flashlight/flare/animation_spin(speed = 5, loop_amount = -1, clockwise = TRUE, sections = 3, angular_offset = 0, pixel_fuzz = 0)
+	clockwise = pick(TRUE, FALSE)
+	angular_offset = rand(360)
+	pixel_fuzz = 16
+	return ..()
+/obj/item/device/flashlight/flare/pickup()
+	if(transform)
+		apply_transform(matrix()) // reset rotation
+	pixel_x = 0
+	pixel_y = 0
+	return ..()
+
 /obj/item/device/flashlight/flare/proc/burn_out()
 	turn_off()
 	fuel = 0

--- a/code/modules/animations/animation_library.dm
+++ b/code/modules/animations/animation_library.dm
@@ -207,23 +207,32 @@ proc/animation_destruction_long_fade(atom/A, speed = 4, x_n = 4, y_n = 4)
 	animate(pixel_x = initial(pixel_x), pixel_y = initial(pixel_y), time = 2)
 
 
-/atom/proc/animation_spin(speed = 5, loop_amount = -1, clockwise = TRUE, sections = 3)
+/atom/proc/animation_spin(speed = 5, loop_amount = -1, clockwise = TRUE, sections = 3, angular_offset = 0, pixel_fuzz = 0)
 	if(!sections)
 		return
 	var/section = 360/sections
 	if(!clockwise)
 		section = -section
+	if(angular_offset)
+		var/matrix/initial_matrix = matrix(transform)
+		initial_matrix.Turn(angular_offset)
+		apply_transform(initial_matrix)
+	var/dx = 0
+	var/dy = 0
+	if(pixel_fuzz)
+		dx = (rand()-0.5)*pixel_fuzz / sections
+		dy = (rand()-0.5)*pixel_fuzz / sections
 	var/list/matrix_list = list()
 	for(var/i in 1 to sections-1)
 		var/matrix/M = matrix(transform)
-		M.Turn(section*i)
+		M.Turn(section*i + angular_offset)
 		matrix_list += M
 	var/matrix/last = matrix(transform)
 	matrix_list += last
 	speed /= sections
-	animate(src, transform = matrix_list[1], time = speed, loop_amount)
+	animate(src, transform = matrix_list[1], pixel_x = pixel_x + dx, pixel_y = pixel_y + dy, time = speed, loop_amount)
 	for(var/i in 2 to sections)
-		animate(transform = matrix_list[i], time = speed)
+		animate(transform = matrix_list[i], pixel_x = pixel_x + dx*i, pixel_y = pixel_y + dy*i, time = speed)
 
 /atom/proc/animation_cancel()
 	animate(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

This adds support for pixel/rotation offsets in throws, and makes flares use them. Only flares right now.

# Explain why it's good for the game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->

![image](https://user-images.githubusercontent.com/604624/206200035-b3ad7933-e612-4428-955c-dc91b47faa50.png)

Once you've seen it, horizontal pixel perfect flares look just dumb.

# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
add: Flares now land spinning when thrown, rather than always in the same spot.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
