### PR TITLE
Revamp light floor tiles

### DIFF
--- a/code/game/objects/items/stacks/tiles/light.dm
+++ b/code/game/objects/items/stacks/tiles/light.dm
@@ -8,23 +8,10 @@
 	attack_verb = list("bashed", "battered", "bludgeoned", "thrashed", "smashed")
 	stack_id = "light floor tile"
 	turf_type = /turf/open/floor/light
-	var/on = 1
-	var/state //0 = fine, 1 = flickering, 2 = breaking, 3 = broken
 
-/obj/item/stack/tile/light/New(var/loc, var/amount=null)
+/obj/item/stack/tile/light/attackby(obj/item/item_in_hand as obj, mob/user as mob)
 	..()
-	if(prob(5))
-		state = 3 //broken
-	else if(prob(5))
-		state = 2 //breaking
-	else if(prob(10))
-		state = 1 //flickering occasionally
-	else
-		state = 0 //fine
-
-/obj/item/stack/tile/light/attackby(var/obj/item/O as obj, var/mob/user as mob)
-	..()
-	if(istype(O,/obj/item/tool/crowbar))
+	if(istype(item_in_hand,/obj/item/tool/crowbar))
 		new/obj/item/stack/sheet/metal(user.loc)
 		amount--
 		new/obj/item/stack/light_w(user.loc)

--- a/code/game/objects/items/stacks/tiles/light.dm
+++ b/code/game/objects/items/stacks/tiles/light.dm
@@ -11,7 +11,7 @@
 
 /obj/item/stack/tile/light/attackby(obj/item/item_in_hand as obj, mob/user as mob)
 	..()
-	if(istype(item_in_hand,/obj/item/tool/crowbar))
+	if (HAS_TRAIT(item_in_hand, TRAIT_TOOL_CROWBAR))
 		new/obj/item/stack/sheet/metal(user.loc)
 		amount--
 		new/obj/item/stack/light_w(user.loc)

--- a/code/game/turfs/floor.dm
+++ b/code/game/turfs/floor.dm
@@ -96,6 +96,7 @@
 	else if(is_light_floor())
 		icon_state = "light_broken"
 		broken = 1
+		SetLuminosity(0)
 	else if(is_plating())
 		icon_state = "platingdmg[pick(1, 2, 3)]"
 		broken = 1
@@ -186,18 +187,6 @@
 				overlays -= wet_overlay
 				wet_overlay = null
 
-
-
-/turf/open/floor/attack_alien(mob/living/carbon/Xenomorph/M)
-	if(is_light_floor())
-		M.animation_attack_on(src)
-		playsound(src, 'sound/effects/glasshit.ogg', 25, 1)
-		M.visible_message(SPAN_DANGER("\The [M] smashes \the [src]!"), \
-		SPAN_DANGER("You smash \the [src]!"), \
-		SPAN_DANGER("You hear broken glass!"), 5)
-		icon_state = "light_off"
-		SetLuminosity(0)
-		return XENO_ATTACK_ACTION
 
 /turf/open/floor/sandstone
 	name = "sandstone floor"

--- a/code/game/turfs/light.dm
+++ b/code/game/turfs/light.dm
@@ -65,14 +65,10 @@
 
 
 /turf/open/floor/light/attack_hand(mob/user as mob) //turning the light on and off
-	if(!broken && on)
-		on = FALSE
+	if(!broken)
+		on = !on
 		update_icon()
-		to_chat(user, SPAN_NOTICE("You turn the light off."))
-	else if(!broken && !on)
-		on = TRUE
-		update_icon()
-		to_chat(user, SPAN_NOTICE("You turn the light on."))
+		to_chat(user, SPAN_NOTICE("You turn the light [on ? "on" : "off"]."))
 	else
 		to_chat(user, SPAN_NOTICE("It looks like the bulb inside has been shattered, you should think about replacing it.")) //if the light is broken and you try to turn it off and on
 

--- a/code/game/turfs/light.dm
+++ b/code/game/turfs/light.dm
@@ -10,33 +10,81 @@
 
 /turf/open/floor/light/update_icon()
 	. = ..()
-	if(on)
+	if(on && !broken) //manages color, I feel like this switch is a sin.
 		switch(state)
 			if(0)
 				icon_state = "light_on"
 				SetLuminosity(5)
 			if(1)
-				var/num = pick("1", "2", "3", "4")
-				icon_state = "light_on_flicker[num]"
+				icon_state = "light_on-r"
 				SetLuminosity(5)
 			if(2)
-				icon_state = "light_on_broken"
+				icon_state = "light_on-g"
 				SetLuminosity(5)
 			if(3)
-				icon_state = "light_off"
-				SetLuminosity(0)
-	else
-		SetLuminosity(0)
-		icon_state = "light_off"
+				icon_state = "light_on-y"
+				SetLuminosity(5)
+			if(4)
+				icon_state = "light_on-p"
+				SetLuminosity(5)
+			if(5,-1)
+				icon_state = "light_on-w"
+				SetLuminosity(5)
+				state = -1
+			else
+				return //Should never happen ever but what if... returns into the other else which close the light
 
-/turf/open/floor/light/attackby(obj/item/C, mob/user)
-	if(istype(C, /obj/item/light_bulb/bulb))
-		if(state)
-			qdel(C)
-			state = C //Fixing it by bashing it with a light bulb, fun eh?
+	else if(broken)
+		icon_state = "light_broken" //It's the same sprite as light off, my artistic skill stops at stickmans anyone feel free to make a better one!
+		SetLuminosity(0)
+	else
+		icon_state = "light_off"
+		SetLuminosity(0)
+		on = FALSE
+
+/turf/open/floor/light/attackby(obj/item/item_in_hand, mob/user)
+	. = ..()
+	if(istype(item_in_hand, /obj/item/light_bulb/bulb)) //changing the light by smacking a bulb on it, voices in my head told me to be kind and not reset the state
+		if(broken)
+			qdel(item_in_hand)
+			broken = FALSE
 			update_icon()
+			playsound(src, 'sound/machines/click.ogg', 25, 1)
 			to_chat(user, SPAN_NOTICE("You replace the light bulb."))
 		else
 			to_chat(user, SPAN_NOTICE("The lightbulb seems fine, no need to replace it."))
 		return
+
+	if(istype(item_in_hand, /obj/item/device/multitool)) //changing the light color with multitool, can't do if bulb broken, can do while it's off
+		if(!broken)
+			state++
+			update_icon()
+			to_chat(user, SPAN_NOTICE("You alter the glass panel's settings, changing its color."))
+		else
+			to_chat(user, SPAN_NOTICE("The bulb inside is shattered, you should get a new one before tuning it."))
+
+
+/turf/open/floor/light/attack_hand(mob/user as mob) //turning the light on and off
+	if(!broken && on)
+		on = FALSE
+		update_icon()
+		to_chat(user, SPAN_NOTICE("You turn the light off."))
+	else if(!broken && !on)
+		on = TRUE
+		update_icon()
+		to_chat(user, SPAN_NOTICE("You turn the light on."))
+	else
+		to_chat(user, SPAN_NOTICE("It looks like the bulb inside has been shattered, you should think about replacing it.")) //if the light is broken and you try to turn it off and on
+
 	return ..()
+
+/turf/open/floor/light/attack_alien(mob/living/carbon/Xenomorph/xeno_attacker) //Xeno breaking light, this makes them basically flashlight that needs a new bulb to go back on
+	if(!broken)
+		playsound(src, "windowshatter", 25, 1)
+		xeno_attacker.animation_attack_on(src)
+		xeno_attacker.visible_message(SPAN_DANGER("\The [xeno_attacker] smashes \the [src]!"), \
+		SPAN_DANGER("You smash \the [src]!"), \
+		SPAN_DANGER("You hear broken glass!"), 5)
+		broken = TRUE
+		update_icon()
+		return XENO_ATTACK_ACTION


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request
When I initially fixed the light tiles, I found many unused sprite of different colors, decided to add them and change a bit how it works.
Here are the different options:
![lights](https://user-images.githubusercontent.com/53326609/206292023-632e6188-f172-476b-9f64-b681ea3dc23a.png)


- Multitools now change the color by clicking on the tile
- Click on them to turn on/off
- Tiles can now be broken by xenos and environment (tested with grenades)
- To repair the floor tile, put a normal light bulb in it 
![lightbulb](https://user-images.githubusercontent.com/53326609/206291879-e612c41c-ce2a-44c8-b77d-9b2fad3f940b.png)
- Use a crowbar to remove the tile, if it's broken it'll simply destroy it
- Build one by using wire on glass and then one metal (unchanged)
- Their current light emission is the same as a flashlight, may be tweaked eventually to be less
- Currently the broken sprite and the off sprite is the same, should get a broken sprite eventually...
- Most of the old code wasn't used at all or didn't work, rewrote most of it



<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
I think it's a good addition in the toolbelts of Maintenance Technicians, they can decorate rooms and use them for signalization instead of drawing with crayons on the floor. There shouldn't be any balance issues since it's basically a costly flashlight, light bulbs are, as far as I know, only obtainable from the autolathe making it not very reliable. Auto-light replacer doesn't work purposely so it doesn't get weaponized, their purpose is solely to embellish rooms.

It's hardly something that is used, and if it gets abused I'll simply nerf them down to ashes (can't have nice things) 
![arroww](https://user-images.githubusercontent.com/53326609/206297351-4f082a63-2237-40de-b5b6-f8ea30167c74.png)


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
I've tested everything I could think of, everything should work.
<details>
<summary>Screenshots & Videos</summary>

Nade breaking some of the tiles
![beforenade](https://user-images.githubusercontent.com/53326609/206292733-4dc3576a-d55b-43eb-a50b-3483238f88b1.png)

![nade destroy](https://user-images.githubusercontent.com/53326609/206292761-a31c5fde-702f-4aac-8c10-109d32ac5231.png)




</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl: Molto
add: Readded the different light floor colors, use multitool to cycle through them
fix: Fixed light tiles being indestructible unless using a crowbar
code: Moved some part of the code that were only used by light tiles in floors.dm into light.dm directly 
refactor: Made one letter variables more lettered
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
