### PR TITLE
Barbed Wire & Cade Health Rework

### DIFF
--- a/code/game/objects/structures/barricade/barricade.dm
+++ b/code/game/objects/structures/barricade/barricade.dm
@@ -109,9 +109,8 @@
 		if(iscarbon(AM))
 			var/mob/living/carbon/C = AM
 			if(C.mob_size <= MOB_SIZE_XENO)
-				C.visible_message(SPAN_DANGER("The barbed wire slices into [C]!"),
-				SPAN_DANGER("The barbed wire slices into you!"))
-				C.apply_damage(10)
+				C.visible_message(SPAN_DANGER("The barbed wire stuns [C]!"),
+				SPAN_DANGER("The barbed wire stuns you!"))
 				C.apply_effect(2, WEAKEN) //Leaping into barbed wire is VERY bad
 				playsound(C, "bonk", 75, FALSE)
 	..()
@@ -127,7 +126,6 @@
 
 		if(crusher_resistant)
 			visible_message(SPAN_DANGER("[C] smashes into [src]!"))
-			take_damage(150)
 			playsound(src, barricade_hitsound, 25, TRUE)
 
 		else if(!C.stat)
@@ -206,8 +204,8 @@
 				user.visible_message(SPAN_NOTICE("[user] sets up [W.name] on [src]."),
 				SPAN_NOTICE("You set up [W.name] on [src]."))
 
-				maxhealth += 50
-				update_health(-50)
+				maxhealth += 100
+				update_health(-100)
 				can_wire = FALSE
 				is_wired = TRUE
 				flags_can_pass_front_temp &= ~PASS_OVER_THROW_MOB
@@ -227,8 +225,8 @@
 				playsound(src.loc, 'sound/items/Wirecutter.ogg', 25, 1)
 				user.visible_message(SPAN_NOTICE("[user] removes the barbed wire on [src]."),
 				SPAN_NOTICE("You remove the barbed wire on [src]."))
-				maxhealth -= 50
-				update_health(50)
+				maxhealth -= 100
+				update_health(100)
 				can_wire = TRUE
 				is_wired = FALSE
 				flags_can_pass_front_temp &= ~PASS_OVER_THROW_MOB

--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -346,10 +346,6 @@
 	else
 		M.visible_message(SPAN_DANGER("[M] [M.slashes_verb] [src]!"), \
 		SPAN_DANGER("You [M.slash_verb] [src]!"), null, 5, CHAT_TYPE_XENO_COMBAT)
-	if(is_wired)
-		M.visible_message(SPAN_DANGER("The barbed wire slices into [M]!"),
-		SPAN_DANGER("The barbed wire slices into you!"), null, 5, CHAT_TYPE_XENO_COMBAT)
-		M.apply_damage(10)
 	return XENO_ATTACK_ACTION
 
 /obj/structure/barricade/handle_tail_stab(mob/living/carbon/Xenomorph/xeno)


### PR DESCRIPTION
# About the pull request

 This PR is meant to rework barbed wires purpose and make FOB sieges a little more interesting by removing damage taken from slashing barbed wire and repurposing barbed wire to prevent pounces and increase health. This is meant too make FOB sieges a little more fun on the Xeno side, as at the moment almost every caste outside a T3 cannot directly attack cades without getting melted by marines.

# Explain why it's good for the game

As explained above, I believe this'll make FOB sieges more engaging on both sides of the spectrum. Without the constant damage from attacking marine cades, more T1s-T2s will be willing to push forward and attack. In turn, marines get to shoot more and participate more in the FOB siege, making it more engaging for the average riflemen. 

IMO, our melee focused faction shouldn't be punished for playing the game and doing something such as attacking a cade unless a marine is there - This encourages Bravo in that regard to be more active and patrol more frequently. With the increase in cade health, this shouldn't upset balance too much, but hopefully make the game more enjoyable in sieges. At current, they're heavily reliant on T3s and feel very sedimentary, this PR should shifts the onus more onto the average Xeno player.

Hopefully should lead to some more engaging gameplay.


# Testing Photographs and Procedure
Tested on local and it all worked, slashing barbed wire no longer does damage.
# Changelog

:cl:
balance: Barbed wire health increase upon being added too cades adjusted from 50 too 100. Slashing barbed wire no longer does damage, however it still retains its slow effect/stun.
del: Slashing barbed wire no longer does damage as Xeno.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
