### PR TITLE
add back the ability to open secure dome.

### DIFF
--- a/maps/map_files/LV624/LV624.dmm
+++ b/maps/map_files/LV624/LV624.dmm
@@ -2275,15 +2275,15 @@
 /area/lv624/ground/river/east_river)
 "akh" = (
 /obj/item/trash/candy,
-/obj/structure/machinery/door_control{
-	dir = 1;
-	id = "nexus_blast";
-	name = "Nexus Lockdown";
-	pixel_x = 25
-	},
 /obj/structure/machinery/power/apc{
 	dir = 1;
 	name = "Corporate Lobby APC"
+	},
+/obj/structure/machinery/door_control{
+	id = "secure_outter_blast";
+	name = "Outter Blast Door";
+	pixel_x = 25;
+	pixel_y = -5
 	},
 /turf/open/floor/wood,
 /area/lv624/lazarus/hop)
@@ -4919,6 +4919,12 @@
 /obj/effect/decal/remains/human,
 /obj/structure/machinery/light{
 	dir = 4
+	},
+/obj/structure/machinery/door_control{
+	id = "secure_inner_blast";
+	name = "Inner Blast Door";
+	pixel_x = 25;
+	pixel_y = 5
 	},
 /turf/open/floor{
 	icon_state = "white"
@@ -9932,6 +9938,12 @@
 /obj/effect/landmark/crap_item,
 /obj/effect/landmark/crap_item,
 /obj/item/clothing/suit/armor/vest/security,
+/obj/structure/machinery/door_control{
+	id = "secure_inner_blast";
+	name = "Inner Blast Door";
+	pixel_x = 25;
+	pixel_y = 5
+	},
 /turf/open/floor{
 	icon_state = "cult"
 	},
@@ -11998,15 +12010,28 @@
 /area/lv624/lazarus/secure_storage)
 "aWb" = (
 /obj/structure/machinery/door_control{
-	id = "secure_blast";
-	name = "Dome Access";
-	pixel_x = 25
+	id = "secure_outter_blast";
+	name = "Outter Blast Door";
+	pixel_x = 25;
+	pixel_y = -5
+	},
+/obj/structure/machinery/door_control{
+	id = "secure_inner_blast";
+	name = "Inner Blast Door";
+	pixel_x = 25;
+	pixel_y = 5
 	},
 /turf/open/floor/greengrid,
 /area/lv624/lazarus/secure_storage)
 "aWc" = (
 /obj/structure/computerframe{
 	anchored = 1
+	},
+/obj/structure/machinery/door_control{
+	id = "secure_outter_blast";
+	name = "Outter Blast Door";
+	pixel_x = 25;
+	pixel_y = -5
 	},
 /turf/open/floor/greengrid,
 /area/lv624/lazarus/secure_storage)
@@ -12133,7 +12158,7 @@
 "aWu" = (
 /obj/structure/machinery/door/poddoor/almayer{
 	dir = 4;
-	id = "secure_blast";
+	id = "secure_inner_blast";
 	layer = 3.3;
 	name = "\improper Secure Armory Blast Door";
 	unacidable = 1
@@ -12143,7 +12168,7 @@
 "aWv" = (
 /obj/structure/machinery/door/poddoor/almayer{
 	dir = 4;
-	id = "secure_blast";
+	id = "secure_outter_blast";
 	layer = 3.3;
 	name = "\improper Secure Armory Blast Door";
 	unacidable = 1
@@ -18911,17 +18936,6 @@
 	icon_state = "grassdirt_corner"
 	},
 /area/lv624/ground/colony/west_nexus_road)
-"nOw" = (
-/obj/structure/machinery/door_control{
-	id = "garage_blast";
-	name = "Garage Shutters";
-	pixel_x = -26;
-	range = 200
-	},
-/turf/open/floor{
-	icon_state = "cult"
-	},
-/area/lv624/lazarus/armory)
 "nOD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -19972,6 +19986,12 @@
 /area/lv624/lazarus/corporate_dome)
 "pRe" = (
 /obj/item/storage/firstaid/adv/empty,
+/obj/structure/machinery/door_control{
+	id = "secure_outter_blast";
+	name = "Outter Blast Door";
+	pixel_x = 25;
+	pixel_y = -5
+	},
 /turf/open/floor{
 	dir = 5;
 	icon_state = "whiteyellow"
@@ -46839,7 +46859,7 @@ aLk
 aMY
 aMZ
 aOy
-nOw
+aMZ
 aLk
 aQx
 aQx

--- a/maps/map_files/LV624/armory/10.cheese.dmm
+++ b/maps/map_files/LV624/armory/10.cheese.dmm
@@ -187,6 +187,12 @@
 	pixel_x = 8;
 	pixel_y = -4
 	},
+/obj/structure/machinery/door_control{
+	id = "secure_inner_blast";
+	name = "Inner Blast Door";
+	pixel_x = 25;
+	pixel_y = 5
+	},
 /turf/open/floor{
 	icon_state = "cult"
 	},

--- a/maps/map_files/LV624/armory/10.extra.dmm
+++ b/maps/map_files/LV624/armory/10.extra.dmm
@@ -192,6 +192,12 @@
 /obj/effect/landmark/crap_item,
 /obj/item/ammo_magazine/smg/m39/extended,
 /obj/item/weapon/gun/smg/m39,
+/obj/structure/machinery/door_control{
+	id = "secure_inner_blast";
+	name = "Inner Blast Door";
+	pixel_x = 25;
+	pixel_y = 5
+	},
 /turf/open/floor{
 	icon_state = "cult"
 	},

--- a/maps/map_files/LV624/armory/10.looted.dmm
+++ b/maps/map_files/LV624/armory/10.looted.dmm
@@ -187,6 +187,18 @@
 	icon_state = "cult"
 	},
 /area/lv624/lazarus/armory)
+"K" = (
+/obj/item/stack/sheet/metal,
+/obj/structure/machinery/door_control{
+	id = "secure_inner_blast";
+	name = "Inner Blast Door";
+	pixel_x = 25;
+	pixel_y = 5
+	},
+/turf/open/floor{
+	icon_state = "cult"
+	},
+/area/lv624/lazarus/armory)
 "T" = (
 /obj/structure/machinery/door_control{
 	id = "garage_blast";
@@ -261,7 +273,7 @@ i
 w
 w
 w
-w
+K
 p
 i
 "}

--- a/maps/map_files/LV624/science/10.yautja.dmm
+++ b/maps/map_files/LV624/science/10.yautja.dmm
@@ -349,6 +349,12 @@
 	dir = 4
 	},
 /obj/effect/landmark/crap_item,
+/obj/structure/machinery/door_control{
+	id = "secure_inner_blast";
+	name = "Inner Blast Door";
+	pixel_x = 25;
+	pixel_y = 5
+	},
 /turf/open/floor{
 	icon_state = "white"
 	},

--- a/maps/map_files/LV624/science/40.fullylocked.dmm
+++ b/maps/map_files/LV624/science/40.fullylocked.dmm
@@ -260,6 +260,12 @@
 /obj/structure/machinery/light{
 	dir = 4
 	},
+/obj/structure/machinery/door_control{
+	id = "secure_inner_blast";
+	name = "Inner Blast Door";
+	pixel_x = 25;
+	pixel_y = 5
+	},
 /turf/open/floor{
 	icon_state = "white"
 	},


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request
Long time ago survivors could open secure storage with a button in corporate dome.
The idea is to reimplement the possibility of opening but in a more complexe way.
First now Secure storage as is two blast door seperate Outer and inner.
location for the button for outer blast door are corporate office, Commander office.
Location for inner blast door button are in research and Armory in nexus.
Survivors will need to coordinate for this to work.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Make LV-624 more coherent by adding a possibility to get in secure storage without breaking the walls...

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>


<summary>Screenshots & Videos</summary>

![image](https://user-images.githubusercontent.com/117036822/206397346-e7737e3f-d4a5-42a4-b87b-3f1e002c5e46.png)

![image](https://user-images.githubusercontent.com/117036822/206397530-9be7d9e0-b8a4-433a-8059-d2256bb0da46.png)

![image](https://user-images.githubusercontent.com/117036822/206397635-06662d2d-9dbb-468e-9fcb-4d0cde595c0c.png)

![image](https://user-images.githubusercontent.com/117036822/206397738-935400e4-8c64-4055-9306-5f33cd41abb8.png)

![image](https://user-images.githubusercontent.com/117036822/206397839-b21e999c-9faa-414d-81d2-fdf1c1409bd6.png)


Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
add: add buttons for Inner and Outer Blast door of secure storage    for you to find out where.
del: Nexus lockdown button in armory but it's still in mapping data.
balance: adding the ability for survivor to get in secure storage on LV-624.
code: separated Inner and outer blast door instead of being a single entity.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
