### PR TITLE
Fix for accuracy falloff.

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -551,7 +551,7 @@
 		if(distance_travelled <= ammo.accurate_range_min) // If bullet stays within max accurate range + random variance
 			effective_accuracy -= (ammo.accurate_range_min - distance_travelled) * 10 // Snipers have accuracy falloff at closer range before point blank
 	else
-		effective_accuracy -= (ammo_flags & AMMO_SNIPER) ? (distance_travelled * 1.5) : (distance_travelled * 10) // Snipers have a smaller falloff constant due to longer max range
+		effective_accuracy -= (distance_travelled - ammo.accurate_range) * ((ammo_flags & AMMO_SNIPER) ? 1.5 : 10) // Snipers have a smaller falloff constant due to longer max range
 
 	effective_accuracy = max(5, effective_accuracy) //default hit chance is at least 5%.
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Followup to #1541, in the sense that all the complaints about spitters being unable to land any hits at intended 7 tile range finally made me clear this single line off my todolist. Discovered more weirdness in need of fixing in the process, but that is a story for another day.

# Explain why it's good for the game

![image](https://user-images.githubusercontent.com/4447185/206509415-b3d7d042-563f-4cba-9fa5-213b70030190.png)


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: Projectiles no longer experience an unintended massive drop in accuracy immediately past their maximum accurate range.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
