### PR TITLE
Research chem fire fix

### DIFF
--- a/code/modules/reagents/chemistry_machinery/chem_simulator.dm
+++ b/code/modules/reagents/chemistry_machinery/chem_simulator.dm
@@ -638,7 +638,7 @@
 	C.properties = list()
 	C.custom_metabolism = REAGENTS_METABOLISM
 	C.color = text("#[][][]",num2hex(rand(0,255)),num2hex(rand(0,255)),num2hex(rand(0,255)))
-	C.burncolor = color
+	C.burncolor = C.color
 	for(var/datum/chem_property/P in creation_template)
 		C.insert_property(P.name, P.level)
 	creation_name = "" //reset it


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request
Fixes Issue #1706 
Burn color was not being set correctly for chems created by the research Synthesizer, which was causing runtime errors that broke OT nades that used them.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Bugs are bad
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->


# Testing Photographs and Procedure
Using the research Synthesizer create from scratch (not relate) a chem with Oxidising (or other fire chems as long as it has positive intensity). Then use that chem in an OT nade and observe that it now works properly
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->



# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: Research chems created via the synthesizer now work properly in chemical fires
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
