### PR TITLE
Slug Nerf

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -135,8 +135,7 @@
 		var/mob/living/carbon/Xenomorph/target = L
 		to_chat(target, SPAN_XENODANGER("You are shaken and slowed by the sudden impact!"))
 		target.apply_effect(0.5, WEAKEN)
-		target.apply_effect(2, SUPERSLOW)
-		target.apply_effect(5, SLOW)
+		target.apply_effect(4.5, SLOW)
 	else
 		if(!isYautja(L)) //Not predators.
 			L.apply_effect(1, SUPERSLOW)
@@ -1101,7 +1100,7 @@
 
 	accurate_range = 6
 	max_range = 8
-	damage = 70
+	damage = 110
 	penetration = ARMOR_PENETRATION_TIER_4
 	damage_armor_punch = 2
 	handful_state = "slug_shell"

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1100,7 +1100,7 @@
 
 	accurate_range = 6
 	max_range = 8
-	damage = 110
+	damage = 80
 	penetration = ARMOR_PENETRATION_TIER_4
 	damage_armor_punch = 2
 	handful_state = "slug_shell"

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -135,7 +135,7 @@
 		var/mob/living/carbon/Xenomorph/target = L
 		to_chat(target, SPAN_XENODANGER("You are shaken and slowed by the sudden impact!"))
 		target.apply_effect(0.5, WEAKEN)
-		target.apply_effect(4.5, SLOW)
+		target.apply_effect(5, SLOW)
 	else
 		if(!isYautja(L)) //Not predators.
 			L.apply_effect(1, SUPERSLOW)


### PR DESCRIPTION
# About the pull request

This PR nerfs slugs by removing the 2 second super slow. It also increases the damage by 10. This is to reduce the insane potential slugs have with their slow, and to even out slugs a little more.

# Explain why it's good for the game

Slugs are very powerful, and the fact that it has a 7 second slow (2 of which are superslow seconds) is insane. It knocks down as well, which leaves time to quickly equip another weapon and is simply too much. This PR would fix that issue, however it will not leave slugs in a terrible state as it still has the slow, and marines could possibly still kill the slugged xeno within the time frame (without the need for a 7 second slow).


# Testing Photographs and Procedure
i made a private server, tested the damage and slow on both runner/lurker/warrior/other t1s. It feels like a reasonable amount.

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: Slugs now longer superslow.
balance: Slugs have their damage increased by 10.
/:cl:

