### PR TITLE
Fixed a Crusher Charger runtime

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/crusher/crusher_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/crusher/crusher_abilities.dm
@@ -130,6 +130,13 @@
 		else
 			Xeno.stop_pulling()
 
+	if(Xeno.is_mob_incapacitated())
+		if(!momentum)
+			return
+		var/lol = get_ranged_target_turf(Xeno, charge_dir, momentum/2)
+		INVOKE_ASYNC(Xeno, /atom/movable.proc/throw_atom, lol, momentum/2, SPEED_FAST, null, TRUE)
+		stop_momentum()
+		return
 	if(!isturf(Xeno.loc))
 		stop_momentum()
 		return

--- a/code/modules/mob/living/carbon/xenomorph/abilities/crusher/crusher_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/crusher/crusher_abilities.dm
@@ -130,11 +130,6 @@
 		else
 			Xeno.stop_pulling()
 
-	if(Xeno.is_mob_incapacitated())
-		var/lol = get_ranged_target_turf(charge_dir,momentum/2)
-		INVOKE_ASYNC(Xeno, /atom/movable.proc/throw_atom, lol, momentum/2, SPEED_FAST, null, TRUE)
-		stop_momentum()
-		return
 	if(!isturf(Xeno.loc))
 		stop_momentum()
 		return

--- a/code/modules/mob/living/carbon/xenomorph/abilities/crusher/crusher_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/crusher/crusher_powers.dm
@@ -223,6 +223,7 @@
 	to_chat(Xeno, SPAN_XENONOTICE("You will [will_charge] charge when moving."))
 	if(activated)
 		RegisterSignal(Xeno, COMSIG_MOVABLE_MOVED, .proc/handle_movement)
+		RegisterSignal(Xeno, COMSIG_MOB_KNOCKED_DOWN, .proc/handle_movement)
 		RegisterSignal(Xeno, COMSIG_ATOM_DIR_CHANGE, .proc/handle_dir_change)
 		RegisterSignal(Xeno, COMSIG_XENO_RECALCULATE_SPEED, .proc/update_speed)
 		RegisterSignal(Xeno, COMSIG_XENO_STOP_MOMENTUM, .proc/stop_momentum)
@@ -234,6 +235,7 @@
 		stop_momentum()
 		UnregisterSignal(Xeno, list(
 			COMSIG_MOVABLE_MOVED,
+			COMSIG_MOB_KNOCKED_DOWN,
 			COMSIG_ATOM_DIR_CHANGE,
 			COMSIG_XENO_RECALCULATE_SPEED,
 			COMSIG_MOVABLE_ENTERED_RIVER,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Fixes #1896 

The runtime was caused by a missing variable. When I fixed it by fixing the variable each time you'd pull the Charger it would do a weird twirl and stop you from pulling it. So I tweaked the code to do what I think the code was intended to do - make the Crusher barrel down whenever they'd get knocked down as if they would be conserving their momentum.

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

Less runtimes more better.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

https://youtu.be/_Z3diQ7njYY
The part that was fixed was the Crusher doing a twirl when they get KOd. The last hitch when they got gibbed was due to an unrelated runtime.

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: Fixed a runtime created when a Crusher Charger with the Charge ability on was being dragged.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
