### PR TITLE
Makes Crew Manifest Inline & UGLY for DEBUG

### DIFF
--- a/code/datums/browser.dm
+++ b/code/datums/browser.dm
@@ -133,7 +133,6 @@
 			SSassets.transport.send_assets(user, scripts)
 
 	user << browse(get_content(), "window=[window_id];[window_size][window_options]")
-	log_debug("Opened DUMB Crew Manifest for user: [key_name(user)]")
 
 	if (use_onclose)
 		setup_onclose()

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -646,7 +646,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 	var/dat = GLOB.data_core.get_manifest()
 
-	show_browser(src, dat, "Crew Manifest", "manifest", "size=450x750")
+	show_browser(src, dat, "Crew Manifest", "manifest", "size=450x750", dumb = TRUE)
 
 /mob/dead/verb/hive_status()
 	set name = "Hive Status"

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -647,6 +647,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	var/dat = GLOB.data_core.get_manifest()
 
 	show_browser(src, dat, "Crew Manifest (UGLY DEBUG EDITION)", "manifest", "size=450x750", dumb = TRUE)
+	log_debug("Opened DUMB Crew Manifest for user: [key_name(src)]")
 
 /mob/dead/verb/hive_status()
 	set name = "Hive Status"

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -646,7 +646,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 	var/dat = GLOB.data_core.get_manifest()
 
-	show_browser(src, dat, "Crew Manifest", "manifest", "size=450x750", dumb = TRUE)
+	show_browser(src, dat, "Crew Manifest (UGLY DEBUG EDITION)", "manifest", "size=450x750", dumb = TRUE)
 
 /mob/dead/verb/hive_status()
 	set name = "Hive Status"

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1100,7 +1100,7 @@
 		return
 	var/dat = GLOB.data_core.get_manifest()
 
-	show_browser(src, dat, "Crew Manifest", "manifest", "size=400x750")
+	show_browser(src, dat, "Crew Manifest", "manifest", "size=400x750", dumb = TRUE)
 
 /mob/living/carbon/human/verb/view_objective_memory()
     set name = "View objectives"

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1101,6 +1101,7 @@
 	var/dat = GLOB.data_core.get_manifest()
 
 	show_browser(src, dat, "Crew Manifest (UGLY DEBUG EDITION)", "manifest", "size=400x750", dumb = TRUE)
+	log_debug("Opened DUMB Crew Manifest for user: [key_name(src)]")
 
 /mob/living/carbon/human/verb/view_objective_memory()
     set name = "View objectives"

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1100,7 +1100,7 @@
 		return
 	var/dat = GLOB.data_core.get_manifest()
 
-	show_browser(src, dat, "Crew Manifest", "manifest", "size=400x750", dumb = TRUE)
+	show_browser(src, dat, "Crew Manifest (UGLY DEBUG EDITION)", "manifest", "size=400x750", dumb = TRUE)
 
 /mob/living/carbon/human/verb/view_objective_memory()
     set name = "View objectives"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

This turns Crew Manifest into an ugly pure-inline HTML interface with absolutely ZERO assets involved.

This maximizes chance of it working. Point is to Testmerge and allow to isolate resource failures from potential failures in very basic browse queue.

_Okay but can't you just make a new button for that?_
It's easier to reuse a button people already know the location of, is easier to convey, and increases chance of getting that info after-the-fact.

_Why Crew Manifest?_
Humans/Ghosts have it (sorry Xenos), there'll alredy be substantial text in it, and it updates over course of round.

_Uh..._
Look I don't have a ton of ideas to track this down.

# Explain why it's good for the game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->

I'm sick of these UI bugs.
