### PR TITLE
Fixed a runtime caused by xenos getting gibbed by fire

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -497,7 +497,8 @@ Make sure their actual health updates immediately.*/
 				else
 					handle_crit()
 				next_grace_time = world.time + grace_time
-	med_hud_set_health()
+	if(!gibbing)
+		med_hud_set_health()
 
 /mob/living/carbon/Xenomorph/proc/handle_crit()
 	if(stat == DEAD || gibbing)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

While testing another bug I noticed there is a runtime caused by us updating a xeno hud after it's been gibbed by a fire which tries dereferencing a null list. So I fixed it.

To test it - spawn a runner, create a fire that does like 1000 damage and run into the fire causing instagib.

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

Less runtimes more better.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: Fixed a runtime caused by the server trying to update a xeno's hud overlays after it has been gibbed by fire.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
