### PR TITLE
Working Joe head reattachment fix

### DIFF
--- a/code/modules/surgery/headreattach.dm
+++ b/code/modules/surgery/headreattach.dm
@@ -27,7 +27,8 @@
 		SYNTH_GEN_ONE,
 		SYNTH_GEN_TWO,
 		SYNTH_GEN_THREE,
-		SYNTH_INFILTRATOR
+		SYNTH_INFILTRATOR,
+		SYNTH_WORKING_JOE
 		)
 
 /datum/surgery/head_reattach/can_start(mob/user, mob/living/carbon/human/patient, obj/limb/L, obj/item/tool)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Fixes working joes being unable to recieve the head reattachment surgery.

# Explain why it's good for the game

it's a fix of an oversight


# Testing Photographs and Procedure
not needed.

# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl: Unknownity
fix: Working Joes can now have their head re-attached back.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
