### PR TITLE
Restores Previous Poplocks for Highpop Maps

### DIFF
--- a/map_config/maps.txt
+++ b/map_config/maps.txt
@@ -24,21 +24,21 @@ map prison_station_fop
 endmap
 
 map fiorina_sciannex
-	minplayers 100
+	minplayers 130
 endmap
 
 map corsat
-	minplayers 100
+	minplayers 130
 	voteweight 0
 	disabled
 endmap
 
 map desert_dam
-	minplayers 100
+	minplayers 130
 endmap
 
 map ice_colony_v2
-	minplayers 100
+	minplayers 130
 	voteweight 0
 	disabled
 endmap
@@ -50,11 +50,11 @@ map kutjevo
 endmap
 
 map sorokyne_strata
-	minplayers 100
+	minplayers 130
 endmap
 
 map LV522_Chances_Claim
-	minplayers 100
+	minplayers 130
 endmap
 
 map new_varadero


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

In the New Varadero PR, an experiment was included to reduce the population lock for all the highpop maps down from 130 to 100, as a test due to the server's average player count at the time being lower. This PR simply reverts that experiment, as it has been live long enough for its effects to be properly observed.

# Explain why it's good for the game

Regardless of what population the server regularly reaches, the maps were designed, and are still designed, to be played on a much higher player count than the experimental 100. At these pops a lot of these maps feel very weak in terms of gameplay and their pop requirement has really been shown over the last few weeks.


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl: ChainsawMullet
qol: Highpop maps have had their poplocks returned to 130 from 100
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
