### PR TITLE
Weather's effect on fire is lessened + Weather now effects acid >:)

### DIFF
--- a/code/datums/effects/acid.dm
+++ b/code/datums/effects/acid.dm
@@ -100,15 +100,15 @@
 /datum/effects/acid/proc/handle_weather()
 	SIGNAL_HANDLER
 
-	var/area/A = get_area(src)
-	if(!A)
+	var/area/acids_area = get_area(src)
+	if(!acids_area)
 		return
 
-	if(SSweather.is_weather_event && locate(A.master) in SSweather.weather_areas)
+	if(SSweather.is_weather_event && locate(acids_area.master) in SSweather.weather_areas)
 		//smothering_strength is 1-10, we use this to take a proportional amount off the stats
-		duration = duration - (duration * (SSweather.weather_event_instance.fire_smothering_strength / 10))
-		damage_in_total_human = damage_in_total_human - (damage_in_total_human * (SSweather.weather_event_instance.fire_smothering_strength / 10))
-		damage_in_total_obj = damage_in_total_obj - (damage_in_total_obj * (SSweather.weather_event_instance.fire_smothering_strength / 10))
+		duration = duration - (duration * (SSweather.weather_event_instance.fire_smothering_strength * 0.1))
+		damage_in_total_human = damage_in_total_human - (damage_in_total_human * (SSweather.weather_event_instance.fire_smothering_strength * 0.1))
+		damage_in_total_obj = damage_in_total_obj - (damage_in_total_obj * (SSweather.weather_event_instance.fire_smothering_strength * 0.1))
 		//ideally this would look like the rain dilutting the acid
 		//but since we dont want to check every process if we're in weather etc...
 		//its just a one permenant time stat change

--- a/code/datums/effects/acid.dm
+++ b/code/datums/effects/acid.dm
@@ -28,6 +28,10 @@
 
 	original_duration = duration
 
+	handle_weather()
+
+	RegisterSignal(SSdcs, COMSIG_GLOB_WEATHER_CHANGE, .proc/handle_weather)
+
 /datum/effects/acid/validate_atom(var/atom/A)
 	if(istype(A, /obj/structure/barricade))
 		return TRUE
@@ -92,3 +96,20 @@
 	if(acid_goopiness <= 0)
 		return TRUE
 	else return FALSE
+
+/datum/effects/acid/handle_weather()
+	SIGNAL_HANDLER
+
+	var/area/A = get_area(src)
+	if(!A)
+		return
+
+	if(SSweather.is_weather_event && locate(A.master) in SSweather.weather_areas)
+		//smothering_strength is 1-10, we use this to take a proportional amount off the stats
+		duration = duration - (duration * (SSweather.weather_event_instance.fire_smothering_strength / 10))
+		damage_in_total_human = damage_in_total_human - (damage_in_total_human * (SSweather.weather_event_instance.fire_smothering_strength / 10))
+		damage_in_total_obj = damage_in_total_obj - (damage_in_total_obj * (SSweather.weather_event_instance.fire_smothering_strength / 10))
+		//ideally this would look like the rain dilutting the acid
+		//but since we dont want to check every process if we're in weather etc...
+		//its just a one permenant time stat change
+

--- a/code/datums/effects/acid.dm
+++ b/code/datums/effects/acid.dm
@@ -97,7 +97,7 @@
 		return TRUE
 	else return FALSE
 
-/datum/effects/acid/handle_weather()
+/datum/effects/acid/proc/handle_weather()
 	SIGNAL_HANDLER
 
 	var/area/A = get_area(src)

--- a/code/datums/weather/weather_events/big_red.dm
+++ b/code/datums/weather/weather_events/big_red.dm
@@ -11,7 +11,7 @@
 
 	ambience = 'sound/ambience/strata/strata_snow.ogg'
 
-	fire_smothering_strength = 2
+	fire_smothering_strength = 1
 
 /datum/weather_event/sand
 	name = "Sandstorm"
@@ -26,7 +26,7 @@
 
 	ambience = 'sound/ambience/strata/strata_snowstorm.ogg'
 
-	fire_smothering_strength = 3
+	fire_smothering_strength = 2
 
 /datum/weather_event/rock
 	name = "Rockstorm"
@@ -41,4 +41,4 @@
 
 	ambience = 'sound/ambience/strata/strata_blizzard.ogg'
 
-	fire_smothering_strength = 4
+	fire_smothering_strength = 3

--- a/code/datums/weather/weather_events/lv522_chances_claim.dm
+++ b/code/datums/weather/weather_events/lv522_chances_claim.dm
@@ -1,3 +1,5 @@
 /datum/weather_event/light_rain/lv522
 	length = 3 MINUTES
 	lightning_chance = 4
+
+	fire_smothering_strength = 2

--- a/code/datums/weather/weather_events/lv624.dm
+++ b/code/datums/weather/weather_events/lv624.dm
@@ -12,7 +12,7 @@
 
 	ambience = 'sound/ambience/rainforest.ogg'
 
-	fire_smothering_strength = 2
+	fire_smothering_strength = 1
 
 /datum/weather_event/heavy_rain
 	name = "Heavy Rain"
@@ -31,4 +31,4 @@
 	has_process = TRUE
 	lightning_chance = 2
 
-	fire_smothering_strength = 6
+	fire_smothering_strength = 4

--- a/code/datums/weather/weather_events/sorokyne.dm
+++ b/code/datums/weather/weather_events/sorokyne.dm
@@ -11,7 +11,7 @@
 
 	ambience = 'sound/ambience/strata/strata_snow.ogg'
 
-	fire_smothering_strength = 4
+	fire_smothering_strength = 3
 
 /datum/weather_event/snowstorm
 	name = "Snowstorm"
@@ -25,7 +25,7 @@
 
 	ambience = 'sound/ambience/strata/strata_snowstorm.ogg'
 
-	fire_smothering_strength = 6
+	fire_smothering_strength = 4
 
 /datum/weather_event/blizzard
 	name = "Blizzard"
@@ -39,4 +39,4 @@
 
 	ambience = 'sound/ambience/strata/strata_blizzard.ogg'
 
-	fire_smothering_strength = 8
+	fire_smothering_strength = 6

--- a/code/game/objects/effects/aliens.dm
+++ b/code/game/objects/effects/aliens.dm
@@ -324,12 +324,12 @@
 /obj/effect/xenomorph/acid/proc/handle_weather()
 	SIGNAL_HANDLER
 
-	var/area/A = get_area(src)
-	if(!A)
+	var/area/acids_area = get_area(src)
+	if(!acids_area)
 		return
 
-	if(SSweather.is_weather_event && locate(A.master) in SSweather.weather_areas)
-		acid_strength = acid_strength + (SSweather.weather_event_instance.fire_smothering_strength / 3) //smothering_strength is 1-10, acid strench is a multiplier
+	if(SSweather.is_weather_event && locate(acids_area.master) in SSweather.weather_areas)
+		acid_strength = acid_strength + (SSweather.weather_event_instance.fire_smothering_strength * 0.33) //smothering_strength is 1-10, acid strength is a multiplier
 		in_weather = SSweather.weather_event_instance.fire_smothering_strength
 	else
 		acid_strength = initial(acid_strength)

--- a/code/game/objects/effects/aliens.dm
+++ b/code/game/objects/effects/aliens.dm
@@ -321,7 +321,7 @@
 	acid_t = null
 	. = ..()
 
-/obj/effect/xenomorph/acid/handle_weather()
+/obj/effect/xenomorph/acid/proc/handle_weather()
 	SIGNAL_HANDLER
 
 	var/area/A = get_area(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

The numbers behind different weather events smothering fire has been nerfed across the board. While still strong, blizzards for example shouldn't INSTANTLY put out fires (this is the strongest weather on soro). Its more subtle now.

Xenos' acid is effected by weather events too now: damaging less, lasting shorter, and with a very small chance to disappear on cades.

# Explain why it's good for the game

Expands weather effects disadvantages to actions of xenos when before it only hurt marines. B A L A N C E :0)

Muh environmental realism.

# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
add: Weather now effects acid, lasting shorter and damaging less.
balance: Weather's effects on fires have been nerfed by a few points.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
