### PR TITLE
Patches

### DIFF
--- a/code/modules/clothing/under/ties.dm
+++ b/code/modules/clothing/under/ties.dm
@@ -347,7 +347,7 @@
 	name = "\improper USCM patch"
 	desc = "A fire-resistant shoulder patch, worn by the men and women of the United States Colonial Marines."
 	icon_state = "uscmpatch"
-	jumpsuit_hide_states = (UNIFORM_SLEEVE_ROLLED|UNIFORM_SLEEVE_CUT|UNIFORM_JACKET_REMOVED)
+	jumpsuit_hide_states = (UNIFORM_SLEEVE_CUT|UNIFORM_JACKET_REMOVED)
 
 /obj/item/clothing/accessory/patch/falcon
 	name = "\improper Falling Falcons patch"


### PR DESCRIPTION
# About the pull request

Adds back the ability to attach a patch onto a rolled uniform. I'm not sure why it was removed, but the sprites look fine.

# Explain why it's good for the game

More player customization, particularly requested by Bobby.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://user-images.githubusercontent.com/112246304/207498213-0db4f407-8803-48e0-961b-a0504a3240ae.png)
Formals

![image](https://user-images.githubusercontent.com/112246304/207498649-2e5968c2-2c73-4471-8a29-8a0338c0c09c.png)
USCM Uniform

</details>

# Changelog

:cl: Misty
add: Readded the ability for patches to be attached onto rolled uniforms.
/:cl: