### PR TITLE
Corporate Presets + Radios

### DIFF
--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -749,9 +749,9 @@
 	desc = "A standard headset used by colonists."
 	frequency = COLONY_FREQ
 
-/obj/item/device/radio/headset/distress/goon
-	name = "WY corporate security headset"
-	desc = "A headset commonly worn by WY corporate security."
+/obj/item/device/radio/headset/distress/WY
+	name = "WY corporate headset"
+	desc = "A headset commonly worn by WY corporate personnel."
 	frequency = WY_FREQ
 	initial_keys = list(/obj/item/device/encryptionkey/colony, /obj/item/device/encryptionkey/WY)
 

--- a/code/modules/gear_presets/survivors.dm
+++ b/code/modules/gear_presets/survivors.dm
@@ -1130,7 +1130,7 @@
 	)
 
 /datum/equipment_preset/survivor/goon/load_gear(mob/living/carbon/human/H)
-	H.equip_to_slot_or_del(new /obj/item/device/radio/headset/distress/goon, WEAR_L_EAR)
+	H.equip_to_slot_or_del(new /obj/item/device/radio/headset/distress/WY, WEAR_L_EAR)
 	H.equip_to_slot_or_del(new /obj/item/clothing/under/marine/veteran/PMC/corporate, WEAR_BODY)
 	H.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/marine/veteran/PMC/light/corporate, WEAR_JACKET)
 	H.equip_to_slot_or_del(new /obj/item/clothing/gloves/marine/veteran, WEAR_HANDS)

--- a/code/modules/gear_presets/survivors.dm
+++ b/code/modules/gear_presets/survivors.dm
@@ -289,6 +289,7 @@
 		ACCESS_WY_CORPORATE,
 		ACCESS_CIVILIAN_COMMAND
 	)
+	languages = list(LANGUAGE_ENGLISH, LANGUAGE_JAPANESE)
 
 /datum/equipment_preset/survivor/corporate/load_gear(mob/living/carbon/human/H)
 	H.equip_to_slot_or_del(new /obj/item/clothing/under/liaison_suit/formal(H), WEAR_BODY)
@@ -396,6 +397,7 @@
 /datum/equipment_preset/survivor/security/corsat
 	name = "Survivor - CORSAT Security Guard"
 	assignment = "Weyland-Yutani Corporate Security Guard"
+	languages = list(LANGUAGE_ENGLISH, LANGUAGE_JAPANESE)
 
 /datum/equipment_preset/survivor/security/corsat/load_gear(mob/living/carbon/human/H)
 	H.equip_to_slot_or_del(new /obj/item/clothing/under/marine/officer/formal/servicedress(H), WEAR_BODY)
@@ -442,6 +444,7 @@
 /datum/equipment_preset/survivor/security/lv
 	name = "Survivor - LV-624 Security Guard"
 	assignment = "Weyland-Yutani Corporate Security Guard"
+	languages = list(LANGUAGE_ENGLISH, LANGUAGE_JAPANESE)
 
 /datum/equipment_preset/survivor/security/lv/load_gear(mob/living/carbon/human/H)
 	H.equip_to_slot_or_del(new /obj/item/clothing/under/marine/officer/formal/servicedress(H), WEAR_BODY)
@@ -1121,7 +1124,7 @@
 	paygrade = "WEY-GOON"
 	idtype = /obj/item/card/id/silver/cl
 	skills = /datum/skills/civilian/survivor/goon
-	languages = list(LANGUAGE_ENGLISH)
+	languages = list(LANGUAGE_ENGLISH, LANGUAGE_JAPANESE)
 	access = list(
 		ACCESS_CIVILIAN_PUBLIC,
 		ACCESS_CIVILIAN_ENGINEERING,
@@ -1204,6 +1207,7 @@
 		ACCESS_MARINE_RESEARCH,
 		ACCESS_MARINE_MEDBAY
 	)
+	languages = list(LANGUAGE_ENGLISH, LANGUAGE_JAPANESE)
 /datum/equipment_preset/survivor/wy/manager/load_gear(mob/living/carbon/human/H)
 
 	H.equip_to_slot_or_del(new /obj/item/clothing/under/suit_jacket/manager(H), WEAR_BODY)

--- a/code/modules/gear_presets/wy.dm
+++ b/code/modules/gear_presets/wy.dm
@@ -16,6 +16,7 @@
 		ACCESS_MARINE_MEDBAY
 	)
 	skills = /datum/skills/civilian
+	languages = list(LANGUAGE_ENGLISH, LANGUAGE_JAPANESE)
 	var/headset_type = /obj/item/device/radio/headset/distress/WY
 
 /datum/equipment_preset/wy/New()

--- a/code/modules/gear_presets/wy.dm
+++ b/code/modules/gear_presets/wy.dm
@@ -16,6 +16,7 @@
 		ACCESS_MARINE_MEDBAY
 	)
 	skills = /datum/skills/civilian
+	var/headset_type = /obj/item/device/radio/headset/distress/WY
 
 /datum/equipment_preset/wy/New()
 	. = ..()
@@ -26,7 +27,7 @@
 	H.apply_wy_rank_code(load_rank(), assignment, role_comm_title)
 
 /datum/equipment_preset/wy/load_gear(mob/living/carbon/human/H)
-	H.equip_to_slot_or_del(new /obj/item/device/radio/headset/distress/PMC(H), WEAR_L_EAR)
+	H.equip_to_slot_or_del(new headset_type(H), WEAR_L_EAR)
 	H.equip_to_slot_or_del(new /obj/item/clothing/under/liaison_suit(H), WEAR_BODY)
 	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/centcom(H), WEAR_FEET)
 	H.equip_to_slot_or_del(new /obj/item/storage/backpack/satchel(H), WEAR_BACK)
@@ -73,6 +74,7 @@
 	access = list()
 	skills = /datum/skills/civilian/manager
 	idtype = /obj/item/card/id/silver/clearance_badge/manager
+	headset_type = /obj/item/device/radio/headset/distress/PMC
 
 /datum/equipment_preset/wy/manager/New()
 	. = ..()

--- a/code/modules/gear_presets/wy_goons.dm
+++ b/code/modules/gear_presets/wy_goons.dm
@@ -65,7 +65,7 @@
 	skills = /datum/skills/MP
 
 /datum/equipment_preset/goon/standard/load_gear(mob/living/carbon/human/H)
-	H.equip_to_slot_or_del(new /obj/item/device/radio/headset/distress/goon, WEAR_L_EAR)
+	H.equip_to_slot_or_del(new /obj/item/device/radio/headset/distress/WY, WEAR_L_EAR)
 	H.equip_to_slot_or_del(new /obj/item/clothing/under/marine/veteran/PMC/corporate, WEAR_BODY)
 	H.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/marine/veteran/PMC/light/corporate, WEAR_JACKET)
 	H.equip_to_slot_or_del(new /obj/item/clothing/gloves/marine/veteran, WEAR_HANDS)
@@ -94,7 +94,7 @@
 	skills = /datum/skills/MP
 
 /datum/equipment_preset/goon/lead/load_gear(mob/living/carbon/human/H)
-	H.equip_to_slot_or_del(new /obj/item/device/radio/headset/distress/goon, WEAR_L_EAR)
+	H.equip_to_slot_or_del(new /obj/item/device/radio/headset/distress/WY, WEAR_L_EAR)
 	H.equip_to_slot_or_del(new /obj/item/clothing/under/marine/veteran/PMC/corporate/lead, WEAR_BODY)
 	H.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/marine/veteran/PMC/light/corporate/lead, WEAR_JACKET)
 	H.equip_to_slot_or_del(new /obj/item/clothing/gloves/marine/veteran, WEAR_HANDS)

--- a/code/modules/gear_presets/wy_goons.dm
+++ b/code/modules/gear_presets/wy_goons.dm
@@ -5,7 +5,7 @@
 	idtype = /obj/item/card/id/silver/cl
 	faction = FACTION_WY
 	faction_group = list(FACTION_WY)
-	languages = list(LANGUAGE_ENGLISH)
+	languages = list(LANGUAGE_ENGLISH, LANGUAGE_JAPANESE)
 
 /datum/equipment_preset/goon/New()
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request
Renames the WY Goon headset to be a generic corporate one. Gives this to the corporate employee presets, rather than having a corporate trainee spawning with a PMC headset. Corporate Managers still spawn with PMC headsets.
Also gives WY Employees Japanese by default for same reason PMCs have it.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Tidies up the corporate presets to be more realistic. Also didn't make sense that the only radio that had WY comms other than PMC and CL was corporate security exclusive.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
add: Corporate Security radio renamed to Corporate, changed corporate equipment presets to use it also.
add: Added Japanese to all corporate presets, including survivors.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
