### PR TITLE
Fixes a spot being inaccesible in a nightmare insert

### DIFF
--- a/maps/map_files/LV624/standalone/sandtemple-jungle.dmm
+++ b/maps/map_files/LV624/standalone/sandtemple-jungle.dmm
@@ -340,10 +340,6 @@
 	},
 /turf/closed/wall/strata_ice/jungle,
 /area/lv624/ground/jungle/south_west_jungle)
-"Wc" = (
-/obj/structure/flora/jungle/vines,
-/turf/closed/wall/strata_ice/jungle,
-/area/lv624/ground/jungle/south_west_jungle)
 "Wp" = (
 /obj/structure/flora/grass/tallgrass/jungle/corner{
 	dir = 3
@@ -416,7 +412,7 @@ oA
 aq
 "}
 (4,1,1) = {"
-Wc
+vt
 vt
 LV
 LV


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

a nightmare insert in LV managed to wall off a spot used by predators that they teleport to and made burrowers use it as a inaccessible safe spot marines cant get to. This PR fixes that by removing the wall that is blocking off the tile in the nightmare insert
Fixes #1957 
# Explain why it's good for the game

map oversight fix


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: Fixed a spot from being inaccessible by marines in a LV nightmare insert.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
