### PR TITLE
Acid Runner and Hedgehog now get an overlay for their acid / shards

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/mutators/strains/ravager/hedgehog.dm
+++ b/code/modules/mob/living/carbon/xenomorph/mutators/strains/ravager/hedgehog.dm
@@ -109,6 +109,12 @@
 	bound_xeno.armor_modifier += armor_buff_count * armor_buff_per_fifty_shards
 	bound_xeno.recalculate_armor()
 	times_armor_buffed = armor_buff_count
+
+	var/image/holder = bound_xeno.hud_list[PLASMA_HUD]
+	holder.overlays.Cut()
+	var/percentage_shards = round((shards / max_shards) * 100, 10)
+	if(percentage_shards)
+		holder.overlays += image('icons/mob/hud/hud.dmi', "xenoenergy[percentage_shards]")
 	return
 
 /datum/behavior_delegate/ravager_hedgehog/on_hitby_projectile()

--- a/code/modules/mob/living/carbon/xenomorph/mutators/strains/runner/acid.dm
+++ b/code/modules/mob/living/carbon/xenomorph/mutators/strains/runner/acid.dm
@@ -105,6 +105,12 @@
 		do_caboom()
 		return
 
+	var/image/holder = bound_xeno.hud_list[PLASMA_HUD]
+	holder.overlays.Cut()
+	var/percentage_acid = round((acid_amount / max_acid) * 100, 10)
+	if(percentage_acid)
+		holder.overlays += image('icons/mob/hud/hud.dmi', "xenoenergy[percentage_acid]")
+
 /datum/behavior_delegate/runner_acider/proc/do_caboom()
 	if(!bound_xeno)
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Acid Runner and Hedgehog didn't have a visual HUD representation of their acid / shards, so I gave them one.

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

It's easier to track something in the centre of the screen than reading it in the status window.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

![image](https://user-images.githubusercontent.com/964559/208366641-a4c47c61-894a-42ba-9371-2a23cb87d52c.png)

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
qol: Acid Runner and Hedgehog Ravager now get a HUD bar representing how much acid and how many shards they have stored.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
