### PR TITLE
BUGFIX: Fixes ballistic goggles causing runtime when equipped.

### DIFF
--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -425,6 +425,7 @@
 		return
 
 	UnregisterSignal(attached_item, COMSIG_PARENT_QDELETING)
+	UnregisterSignal(attached_item, COMSIG_ITEM_EQUIPPED)
 	qdel(activation)
 	attached_item = null
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request
A signal was being registered multiple times on repeated equip, causing a runtime. This PR unregisters the signal on unequip.
Resolves: https://github.com/cmss13-devs/cmss13/issues/1703

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

No more errors. The trouble signal continues to function correctly with eyesight.

https://user-images.githubusercontent.com/59719612/208530840-ce865e43-40d1-4508-a80d-804fa6f34f40.mp4

</details>

# Changelog

:cl:
fix: fixed a runtime with ballistic goggles
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
