### PR TITLE
Added Queen name based on prefix / postfix

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
@@ -418,9 +418,10 @@
 	var/name_client_prefix = ""
 	var/name_client_postfix = ""
 	if(client)
-		name_client_prefix = "[(client.xeno_prefix||client.xeno_postfix) ? client.xeno_prefix : "XX"]-"
+		name_client_prefix = "[(client.xeno_prefix||client.xeno_postfix) ? client.xeno_prefix : "XX"]"
 		name_client_postfix = client.xeno_postfix ? ("-"+client.xeno_postfix) : ""
-	full_designation = "[name_client_prefix][nicknumber][name_client_postfix]"
+		name += " [name_client_prefix][name_client_postfix]"
+	full_designation = "[name_client_prefix]-[nicknumber][name_client_postfix]"
 	color = in_hive.color
 
 	//Update linked data so they show up properly


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

It's fun knowing who you are playing with in the game. Marines can see Xeno names, Xenos can see Marine names even though neither side should because it's more interesting that way. Even preds can show their names with their bracers. So it's kind of sad that Queens don't get that kind of recognition. This PR addresses that - now the Queen gets a name based on the xeno prefix and postfix (with no random numbers since they don't matter as much):

![image](https://user-images.githubusercontent.com/964559/208602431-93daeb9b-a6e4-4085-b1b2-2216b66a5b12.png)

This way you can start getting familiar with Queens you see on the battlefield and so on. Heck, might even help people get their Whitelists if they Queen main!

Sure, the counterargument might be that someone would see a Queen they don't like and disobey, but if Marines can stand an XO they don't like, I think Xenos can handle it...

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

Gives the Queens the recognition they deserve.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
qol: Queens now have a longer name based on their xeno prefix and postfix preferences.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
