### PR TITLE
queen eye runtime fix

### DIFF
--- a/code/modules/cm_aliens/weeds.dm
+++ b/code/modules/cm_aliens/weeds.dm
@@ -155,7 +155,7 @@
 
 
 /obj/effect/alien/weeds/Crossed(atom/movable/atom_movable)
-	if(!ismob(atom_movable))
+	if(!isliving(atom_movable))
 		return
 	var/mob/living/crossing_mob = atom_movable
 


### PR DESCRIPTION
ismob is not a safe check for typecasting to /mob/living


:cl:
fix: fixes a runtime relating to the queen eye crossing over weeds
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
