### PR TITLE
Removes R-1NG bell from map spawns and engi vendor

### DIFF
--- a/code/game/machinery/vending/vendor_types/squad_prep/squad_engineer.dm
+++ b/code/game/machinery/vending/vendor_types/squad_prep/squad_engineer.dm
@@ -7,7 +7,6 @@ GLOBAL_LIST_INIT(cm_vending_gear_engi, list(
 		list("HANDHELD DEFENSE (CHOOSE 1)", 0, null, null, null),
 		list("21S Tesla Coil", 0, /obj/item/defenses/handheld/tesla_coil, MARINE_CAN_BUY_ATTACHMENT, VENDOR_ITEM_MANDATORY),
 		list("JIMA Planted Flag", 0, /obj/item/defenses/handheld/planted_flag, MARINE_CAN_BUY_ATTACHMENT, VENDOR_ITEM_MANDATORY),
-		list("R-1NG Bell Tower", 0, /obj/item/defenses/handheld/bell_tower, MARINE_CAN_BUY_ATTACHMENT, VENDOR_ITEM_MANDATORY),
 		list("UA 42-F Sentry Flamer", 0, /obj/item/defenses/handheld/sentry/flamer, MARINE_CAN_BUY_ATTACHMENT, VENDOR_ITEM_MANDATORY),
 		list("UA 571-C Sentry Gun", 0, /obj/item/defenses/handheld/sentry, MARINE_CAN_BUY_ATTACHMENT, VENDOR_ITEM_MANDATORY),
 		list("Sentry Upgrade kit", 15, /obj/item/engi_upgrade_kit, null, VENDOR_ITEM_REGULAR),

--- a/code/game/objects/effects/spawners/random.dm
+++ b/code/game/objects/effects/spawners/random.dm
@@ -241,7 +241,6 @@
 	item_to_spawn()
 		return pick(/obj/item/defenses/handheld/tesla_coil,\
 					/obj/item/defenses/handheld/planted_flag,\
-					/obj/item/defenses/handheld/bell_tower,\
 					/obj/item/defenses/handheld/sentry,\
 					/obj/item/defenses/handheld/sentry/flamer)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

This PR removes the R-1NG bell from being purchased from engi vendors and generated by random map spawns.

# Explain why it's good for the game

The R-1NG Bell Tower has been a polarising engineering structure since its first iteration, through the backpack bell era, and into the cloak bell era. 

Even at present the R-1NG has not managed to justify its place in the game and fill out a proper purpose beyond contributing to the overwhelming slow bloat present, which it ends up competing with the Tesla for. Two engineer structures available to the same role for the same cost should not do the same thing with varying levels of effectiveness but with a different skin.

The R-1NG remains a buggy, bloated mess that continues to cause problems in rounds, such as:

- Continuing to function while in a broken state
- Continuing to remain invisible AND function while in a broken state (whilst not triggering the self-revealing aspect)
- Audio overlapping issues
- Alpha adjustment issues where its cloak overrides itself and prevents it from triggering its "decloak"

Pending a future rework or removal at the discretion of the development team, I believe it best for the game moving forward if the R-1NG is removed from regular roundflow for the time being.

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl: ChainsawMullet
del: Removed R-1NG bell from Engineer vendors and map spawns.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
