### PR TITLE
Removes the ability for the festivizer to work on mobs or vehicles

### DIFF
--- a/code/game/objects/items/toys/toys.dm
+++ b/code/game/objects/items/toys/toys.dm
@@ -519,6 +519,9 @@
 	. = ..()
 	if(!target.Adjacent(user))
 		return
+	if(ismob(target) || isVehicle(target))
+		to_chat(user, SPAN_NOTICE("\The [src] is not able to festivize lifeforms or vehicles for safety concerns."))
+		return
 	if(target.color)
 		to_chat(user, SPAN_NOTICE("\The [target] is already colored, don't be greedy!"))
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Removes the ability for the festivizer to work on mobs or vehicles

# Explain why it's good for the game

Christmas decorators? Good.

Christmas decorators that cause issues with gameplay and proper friend or foe identification? Bad.

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>
Yup
</details>


# Changelog

:cl: Morrow
del: Removes the ability for the festivizer to work on mobs or vehicles
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
