### PR TITLE
Makes the festivizer less intense color-wise

### DIFF
--- a/code/game/objects/items/toys/toys.dm
+++ b/code/game/objects/items/toys/toys.dm
@@ -522,7 +522,8 @@
 	if(target.color)
 		to_chat(user, SPAN_NOTICE("\The [target] is already colored, don't be greedy!"))
 		return
-	target.color = (pick("red", "green"))
+	var/red = prob(50)
+	target.color = list(1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1, red? 0.2 : 0,!red? 0.2 : 0,0,0)
 	target.visible_message(SPAN_GREEN("\The [target] has been festivized by [user]! Merry Christmas!"))
 	to_chat(user, SPAN_GREEN("You festivize \the [target]! Merry Christmas!"))
 	if(prob(5))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Makes the festivizer less intense color-wise

# Explain why it's good for the game

The color right now is... too much.

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>
Yup

</details>


# Changelog

:cl: Morrow, WalterMeldron
fix: Makes the festivizer less intense color-wise
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
