### PR TITLE
typo fix for the spawn pool

### DIFF
--- a/code/modules/cm_aliens/structures/special/spawn_pool.dm
+++ b/code/modules/cm_aliens/structures/special/spawn_pool.dm
@@ -160,8 +160,8 @@
 		if(isnull(new_xeno))
 			return FALSE
 
-		new_xeno.visible_message(SPAN_XENODANGER("A larva suddenly emerges out of from \the [src]!"),
-		SPAN_XENODANGER("You emerge out of \the [src] and awaken from your slumber. For the Hive!"))
+		new_xeno.visible_message(SPAN_XENODANGER("A larva suddenly emerges from \the [src]!"),
+		SPAN_XENODANGER("You emerge from \the [src] and awaken from your slumber. For the Hive!"))
 		msg_admin_niche("[key_name(new_xeno)] emerged from \a [src]. (<A HREF='?_src_=admin_holder;[HrefToken(forceGlobal = TRUE)];adminplayerobservecoodjump=1;X=[src.x];Y=[src.y];Z=[src.z]'>JMP</a>)")
 		playsound(new_xeno, 'sound/effects/xeno_newlarva.ogg', 50, 1)
 		if(!SSticker.mode.transfer_xeno(xeno_candidate, new_xeno))


### PR DESCRIPTION
# About the pull request

fixes a typo when a larva spawns

# Explain why it's good for the game

typos are bad and uncool

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: Stalkerino
spellcheck: fixed a typo when a larva spawns in the spawn pool
/:cl:

