### PR TITLE
removes start up errors in relation to projectiles/teleporter subsystem

### DIFF
--- a/code/controllers/subsystem/projectiles.dm
+++ b/code/controllers/subsystem/projectiles.dm
@@ -34,7 +34,7 @@ SUBSYSTEM_DEF(projectiles)
 	projectiles = list()
 	flying = list()
 	sleepers = list()
-	return ..()
+	return SS_INIT_SUCCESS
 
 /datum/controller/subsystem/projectiles/fire(resumed = FALSE)
 	if(!resumed)

--- a/code/controllers/subsystem/teleporter.dm
+++ b/code/controllers/subsystem/teleporter.dm
@@ -2,9 +2,9 @@
 SUBSYSTEM_DEF(teleporter)
 	name = "Teleporter"
 	wait = 5 SECONDS
-	init_order =     SS_INIT_TELEPORTER
-	priority =       SS_PRIORITY_TELEPORTER
-	flags =          SS_NO_FIRE
+	init_order = SS_INIT_TELEPORTER
+	priority = SS_PRIORITY_TELEPORTER
+	flags = SS_NO_FIRE|SS_NO_INIT
 
 	var/list/teleporters_by_id = list() // Associative list of teleporters by ID, master list of teleporters to process
 	var/list/teleporters = list()       // Process list (identical contents to teleporters_by_id)


### PR DESCRIPTION
teleporter has no initialize anymore, so needs SS_NO_INIT, and calling parent on ss init will make it fail

:cl:
fix: a couple subsystems now report their initialisation correctly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
