### PR TITLE
gives vaipo the correct equipment preset flag

### DIFF
--- a/code/modules/gear_presets/contractor.dm
+++ b/code/modules/gear_presets/contractor.dm
@@ -6,6 +6,8 @@
 	idtype = /obj/item/card/id/data
 	faction = FACTION_CONTRACTOR
 
+	flags = EQUIPMENT_PRESET_EXTRA
+
 /datum/equipment_preset/contractor/New()
 	. = ..()
 	access = get_all_accesses() + get_all_centcom_access()


### PR DESCRIPTION
equipment presets need flags to be loaded into the global list correctly

:cl:
fix: the contractor ERT can spawn again, non-naked
/:cl:
