### PR TITLE
Fix for contractors presets' flags.

### DIFF
--- a/code/modules/gear_presets/contractor.dm
+++ b/code/modules/gear_presets/contractor.dm
@@ -109,6 +109,7 @@
 	name = "Military Contractor (Standard)"
 	paygrade = "VAI"
 	role_comm_title = "Merc"
+	flags = EQUIPMENT_PRESET_EXTRA
 	assignment = "VAIPO Mercenary"
 	rank = JOB_CONTRACTOR_ST
 	skills = /datum/skills/contractor
@@ -195,6 +196,7 @@
 	name = "Military Contractor (Machinegunner)"
 	paygrade = "VAI-G"
 	role_comm_title = "MG"
+	flags = EQUIPMENT_PRESET_EXTRA
 
 	assignment = "VAIPO Automatic Rifleman"
 	rank = JOB_CONTRACTOR_MG
@@ -240,6 +242,7 @@
 	paygrade = "VAI-E"
 
 	role_comm_title = "Eng"
+	flags = EQUIPMENT_PRESET_EXTRA
 
 	assignment = "VAIPO Engineering Specialist"
 	rank = JOB_CONTRACTOR_ENGI
@@ -285,6 +288,7 @@
 	name = "Military Contractor (Medic)"
 	paygrade = "VAI-M"
 	role_comm_title = "Med"
+	flags = EQUIPMENT_PRESET_EXTRA
 
 	assignment = "VAIMS Medical Specialist"
 	rank = JOB_CONTRACTOR_MEDIC
@@ -330,6 +334,7 @@
 	name = "Military Contractor (Leader)"
 	paygrade = "VAI-L"
 	role_comm_title = "TL"
+	flags = EQUIPMENT_PRESET_EXTRA
 
 	assignment = "VAIPO Team Leader"
 	rank = JOB_CONTRACTOR_TL
@@ -379,6 +384,7 @@
 	name = "Military Contractor (Synthetic)"
 	paygrade = "VAI-S"
 	role_comm_title = "Syn"
+	flags = EQUIPMENT_PRESET_EXTRA
 
 	assignment = "VAIPO Support Synthetic"
 	rank = JOB_CONTRACTOR_SYN
@@ -469,6 +475,7 @@
 	name = "Military Contractor (Covert Standard)"
 	paygrade = "VAI"
 	role_comm_title = "Merc"
+	flags = EQUIPMENT_PRESET_EXTRA
 
 	assignment = "VAISO Mercenary"
 	rank = JOB_CONTRACTOR_COVST
@@ -557,6 +564,7 @@
 	name = "Military Contractor (Covert Machinegunner)"
 	paygrade = "VAI-G"
 	role_comm_title = "MG"
+	flags = EQUIPMENT_PRESET_EXTRA
 
 	assignment = "VAISO Automatic Rifleman"
 	rank = JOB_CONTRACTOR_COVMG
@@ -609,6 +617,7 @@
 	paygrade = "VAI-E"
 
 	role_comm_title = "Eng"
+	flags = EQUIPMENT_PRESET_EXTRA
 
 	assignment = "VAISO Engineering Specialist"
 	rank = JOB_CONTRACTOR_COVENG
@@ -660,6 +669,7 @@
 	name = "Military Contractor (Covert Medic)"
 	paygrade = "VAI-M"
 	role_comm_title = "Med"
+	flags = EQUIPMENT_PRESET_EXTRA
 
 	assignment = "VAIMS Medical Specialist"
 	rank = JOB_CONTRACTOR_COVMED
@@ -711,6 +721,7 @@
 	name = "Military Contractor (Covert Leader)"
 	paygrade = "VAI-L"
 	role_comm_title = "TL"
+	flags = EQUIPMENT_PRESET_EXTRA
 
 	assignment = "VAISO Team Leader"
 	rank = JOB_CONTRACTOR_COVTL
@@ -761,6 +772,7 @@
 	name = "Military Contractor (Covert Synthetic)"
 	paygrade = "VAI-S"
 	role_comm_title = "Syn"
+	flags = EQUIPMENT_PRESET_EXTRA
 
 	assignment = "VAISO Support Synthetic"
 	rank = JOB_CONTRACTOR_COVSYN


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Followup to #1380. With null for flags presets do not get added to the global list of presets and thus cannot be accessed later.
#2105 beat me to it, but root typepaths that are not actually full presets probably do not need to be given any flags, so that they do not appear in the list themselves to the confusion of somebody trying to use Create Humans / Select Equipment / etc.

# Explain why it's good for the game

Is fix.


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: Contractors ERT once again gets its proper equipment.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
