### PR TITLE
Shortens preference title of Commanding Officer Survivor

### DIFF
--- a/code/__DEFINES/job.dm
+++ b/code/__DEFINES/job.dm
@@ -28,7 +28,7 @@ var/global/list/job_squad_roles = JOB_SQUAD_ROLES_LIST
 #define JOB_PASSENGER					"Passenger"
 #define JOB_SURVIVOR					"Survivor"
 #define JOB_SYNTH_SURVIVOR				"Synth Survivor"
-#define JOB_CO_SURVIVOR				"Commanding Officer Survivor"
+#define JOB_CO_SURVIVOR				"CO Survivor"
 
 #define JOB_CMO							"Chief Medical Officer"
 #define JOB_DOCTOR						"Doctor"


### PR DESCRIPTION
# About the pull request

Shortens the title of the Commanding Officer Survivor to CO Survivor in the role preferences so it only takes up one line

# Explain why it's good for the game

Some people get confused about it being on two lines and believe that it means survivor is whitelisted.
Also, it just looks nicer on one line.

I am not fixing the fact that it is misaligned.

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>
Wow an image
</summary>

![image](https://user-images.githubusercontent.com/56142455/209513980-db5fd99e-b1a4-4bbd-b9ad-e1b3aed48064.png)

</details>


# Changelog

:cl:
spellcheck: Shortened Commanding Officer Survivor in job preferences to only take one line
/:cl:
