### PR TITLE
Fixed get_xeno_action_by_type runtime

### DIFF
--- a/code/datums/xeno_shields/shield_types/vanguard_shield.dm
+++ b/code/datums/xeno_shields/shield_types/vanguard_shield.dm
@@ -4,7 +4,6 @@
 	var/explosive_armor_amount = XENO_EXPOSIVEARMOR_MOD_VERYLARGE
 	amount = 800
 
-
 /datum/xeno_shield/vanguard/on_hit(damage)
 	notify_xeno()
 
@@ -49,11 +48,10 @@
 			qdel(src)
 
 /datum/xeno_shield/vanguard/proc/notify_xeno()
-	var/mob/living/carbon/Xenomorph/X = linked_xeno
-	if (!istype(X))
+	if (!istype(linked_xeno))
 		return
 
-	if (X.mutation_type == PRAETORIAN_VANGUARD)
-		var/datum/behavior_delegate/praetorian_vanguard/BD = X.behavior_delegate
+	if (linked_xeno.mutation_type == PRAETORIAN_VANGUARD)
+		var/datum/behavior_delegate/praetorian_vanguard/BD = linked_xeno.behavior_delegate
 		if (istype(BD))
 			BD.last_combat_time = world.time

--- a/code/datums/xeno_shields/shield_types/vanguard_shield.dm
+++ b/code/datums/xeno_shields/shield_types/vanguard_shield.dm
@@ -16,10 +16,9 @@
 		return ..(damage)
 
 /datum/xeno_shield/vanguard/Destroy()
-	if (linked_xeno && istype(linked_xeno, /mob/living/carbon/Xenomorph))
-		var/mob/living/carbon/Xenomorph/X = linked_xeno
-		X.explosivearmor_modifier -= explosive_armor_amount
-		X.recalculate_armor()
+	if (linked_xeno)
+		linked_xeno.explosivearmor_modifier -= explosive_armor_amount
+		linked_xeno.recalculate_armor()
 
 	return ..()
 
@@ -39,18 +38,15 @@
 		sleep(0.4 SECONDS)
 
 	if (amount <= 0)
-		if (linked_xeno && istype(linked_xeno, /mob/living/carbon/Xenomorph))
-			var/mob/living/carbon/Xenomorph/X = linked_xeno
-
-			if (QDELETED(X) || !istype(X))
+		if (linked_xeno)
+			if (QDELETED(linked_xeno) || !istype(linked_xeno))
 				return
 
-			qdel(src)
-			X.overlay_shields()
-
+			linked_xeno.overlay_shields()
 			var/datum/action/xeno_action/activable/cleave/cAction = get_xeno_action_by_type(linked_xeno, /datum/action/xeno_action/activable/cleave)
 			if (istype(cAction))
 				addtimer(CALLBACK(cAction, /datum/action/xeno_action/activable/cleave.proc/remove_buff), 7, TIMER_UNIQUE)
+			qdel(src)
 
 /datum/xeno_shield/vanguard/proc/notify_xeno()
 	var/mob/living/carbon/Xenomorph/X = linked_xeno


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

We had a runtime due to a xeno shield qdelling itself and then trying to do something with its vars. Fixed it and refactored the code.

```
runtime error: xeno_action.dm: get_xeno_action_by_type invoked with non-xeno first argument.
proc name: get xeno action by type (/proc/get_xeno_action_by_type)
  source file: xeno_action.dm,360
  usr: (src)
  src: null
  call stack:
get xeno action by type(null, /datum/action/xeno_action/acti... (/datum/action/xeno_action/activable/cleave))
/datum/xeno_shield/vanguard (/datum/xeno_shield/vanguard): rapid decay()
```

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

Less runtimes more better

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: Fixed a Vanguard Praetorian runtime.
refactor: Refactored Vanguard shield code a bit to remove unnecesary typecasting.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
