### PR TITLE
Typo: Corrects Tech Tree Initialization Text

### DIFF
--- a/code/__DEFINES/techtree.dm
+++ b/code/__DEFINES/techtree.dm
@@ -7,8 +7,8 @@
 
 // Trees
 #define TREE_NONE "Undefined"
-#define TREE_MARINE "Marine Tech Tree"
-#define TREE_XENO "Xenomorph Tech Tree"
+#define TREE_MARINE "Marine"
+#define TREE_XENO "Xenomorph"
 
 #define INITIAL_STARTING_POINTS 0
 

--- a/code/__DEFINES/techtree.dm
+++ b/code/__DEFINES/techtree.dm
@@ -7,8 +7,8 @@
 
 // Trees
 #define TREE_NONE "Undefined"
-#define TREE_MARINE "Marine"
-#define TREE_XENO "Xenomorph"
+#define TREE_MARINE "Marine Tech Tree"
+#define TREE_XENO "Xenomorph Tech Tree"
 
 #define INITIAL_STARTING_POINTS 0
 

--- a/code/controllers/subsystem/techtree.dm
+++ b/code/controllers/subsystem/techtree.dm
@@ -68,7 +68,7 @@ SUBSYSTEM_DEF(techtree)
 				node.on_tree_insertion(tree)
 
 		tree.generate_tree()
-		var/msg = "Loaded [tree.name] tech tree!"
+		var/msg = "Loaded [tree.name]!"
 		to_chat(world, "<span class='boldannounce'>[msg]</span>")
 
 	return SS_INIT_SUCCESS

--- a/code/controllers/subsystem/techtree.dm
+++ b/code/controllers/subsystem/techtree.dm
@@ -68,7 +68,7 @@ SUBSYSTEM_DEF(techtree)
 				node.on_tree_insertion(tree)
 
 		tree.generate_tree()
-		var/msg = "Loaded [tree.name] Techtree!"
+		var/msg = "Loaded [tree.name] tech tree!"
 		to_chat(world, "<span class='boldannounce'>[msg]</span>")
 
 	return SS_INIT_SUCCESS


### PR DESCRIPTION
# About the pull request

Simply renames the tech trees to fix this start-up text:

![image](https://user-images.githubusercontent.com/59719612/209569679-551c8e19-523e-447b-b79e-7f4fb59172e1.png)

# Explain why it's good for the game

Typos bad.

# Testing Photographs and Procedure

The tech tree / objectives system functionality is unaffected by the change.

# Changelog

:cl: Casper
spellcheck: fixes tech tree start-up text
/:cl:
