### PR TITLE
TGUI: Fixes Runtime After Admin Transform

### DIFF
--- a/code/controllers/subsystem/tgui.dm
+++ b/code/controllers/subsystem/tgui.dm
@@ -314,7 +314,7 @@ SUBSYSTEM_DEF(tgui)
 	// Remove it from the list of processing UIs.
 	open_uis.Remove(ui)
 	// If the user exists, remove it from them too.
-	if(ui.user)
+	if(ui.user && ui.user.tgui_open_uis)
 		ui.user.tgui_open_uis.Remove(ui)
 	var/list/uis = open_uis_by_src[key]
 	uis.Remove(ui)


### PR DESCRIPTION
# About the pull request

Fixes the following runtime:

https://user-images.githubusercontent.com/59719612/209578033-2f97d645-fe23-4c29-892d-ef7a9b9d64db.mp4

# Explain why it's good for the game

Runtimes.

# Testing Photographs and Procedure

TGUI continues to open / close correctly.
No more runtime on Transform.

# Changelog

:cl: Casper
fix: fixes TGUI runtime
/:cl: