### PR TITLE
TGUI: Corrects signaller format

### DIFF
--- a/code/game/objects/items/devices/radio/electropack.dm
+++ b/code/game/objects/items/devices/radio/electropack.dm
@@ -91,7 +91,7 @@
 	var/dat = {"<TT>
 <A href='?src=\ref[src];power=1'>Turn [on ? "Off" : "On"]</A><BR>
 <B>Frequency/Code</B> for electropack:<BR>
-Frequency: [format_frequency(frequency)]<BR>
+Frequency: [format_frequency(frequency)] kHz<BR>
 
 Code:
 <A href='byond://?src=\ref[src];code=-5'>-</A>

--- a/tgui/packages/tgui/interfaces/Signaller.js
+++ b/tgui/packages/tgui/interfaces/Signaller.js
@@ -1,3 +1,4 @@
+import { toFixed } from 'common/math';
 import { useBackend } from '../backend';
 import { Button, Section, LabeledList, Slider } from '../components';
 import { Window } from '../layouts';
@@ -27,11 +28,13 @@ export const Signaller = (props, context) => {
                 minValue={min_freq}
                 value={data.current_freq}
                 onChange={(e, value) => act('set_freq', { value: value })}
+                format={(value) => toFixed(value / 10, 1)}
+                unit="kHz"
                 mt={1}
                 stepPixelSize={2}
               />
             </LabeledList.Item>
-            <LabeledList.Item label="Signal">
+            <LabeledList.Item label="Code">
               <Slider
                 inline
                 maxValue={max_signal}


### PR DESCRIPTION
# About the pull request

Frequency slider now shows the correct format.
Electropack now shows the kHz units.
Standardizes signal / code labels to code / code.

Resolves: https://github.com/cmss13-devs/cmss13/issues/252

![image](https://user-images.githubusercontent.com/59719612/209580574-e69d7cf0-3d8a-4e8a-90c1-4015605555f3.png)

# Explain why it's good for the game

Less confusion.

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

https://user-images.githubusercontent.com/59719612/209580266-e848cea3-6fdc-40c2-94f3-bd916688dd0c.mp4

</details>


# Changelog

:cl: Casper
fix: corrects signaller frequency UI
/:cl: