### PR TITLE
Bugfix: Sling pouch not retrieving items while moving.

### DIFF
--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -1232,7 +1232,7 @@
 	can_hold = list(/obj/item/device, /obj/item/tool)
 	bypass_w_limit = list(/obj/item/tool/shovel/etool)
 	storage_flags = STORAGE_FLAGS_POUCH|STORAGE_USING_DRAWING_METHOD
-	var/sling_range = 1
+	var/sling_range = 2
 	var/obj/item/slung
 
 /obj/item/storage/pouch/sling/get_examine_text(mob/user)


### PR DESCRIPTION
# About the pull request

The sling has a range limit of 1 tile. Human move speed means half of the time, the sling will be out of range while moving, defeating the purpose of it. This PR increases the range to 2 tiles.

Resolves: https://github.com/cmss13-devs/cmss13/issues/1736

Issue shown here:

https://user-images.githubusercontent.com/59719612/209679281-293270a3-5de5-46c4-9aa2-90ff989f59cd.mp4

# Explain why it's good for the game

Makes the sling more reliable at its job.

# Changelog

:cl: Casper
fix: sling pouch is now more reliable while moving
/:cl: