### PR TITLE
Bugfix: Bipod applying endless slow

### DIFF
--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -2393,7 +2393,6 @@ Defined in conflicts.dm of the #defines folder.
 
 	if(bipod_deployed)
 		undeploy_bipod(G)
-		playsound(user,'sound/items/m56dauto_rotate.ogg', 55, 1)
 		user.apply_effect(1, SUPERSLOW)
 		user.apply_effect(2, SLOW)
 
@@ -2409,10 +2408,13 @@ Defined in conflicts.dm of the #defines folder.
 	if(isliving(G.loc))
 		user = G.loc
 		UnregisterSignal(user, COMSIG_MOB_MOVE_OR_LOOK)
-	playsound(user,'sound/items/m56dauto_rotate.ogg', 55, 1)
+
 	if(G.flags_gun_features & GUN_SUPPORT_PLATFORM)
 		G.remove_bullet_trait("iff")
-	update_icon()
+
+	if(!QDELETED(G))
+		playsound(user,'sound/items/m56dauto_rotate.ogg', 55, 1)
+		update_icon()
 
 /obj/item/attachable/bipod/activate_attachment(obj/item/weapon/gun/G,mob/living/user, turn_off)
 	if(turn_off)

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -2360,7 +2360,14 @@ Defined in conflicts.dm of the #defines folder.
 	scatter_mod = SCATTER_AMOUNT_TIER_9
 	recoil_mod = RECOIL_AMOUNT_TIER_5
 
+/obj/item/attachable/bipod/Attach(obj/item/weapon/gun/G)
+	..()
+
+	RegisterSignal(G, COMSIG_ITEM_DROPPED, PROC_REF(handle_drop))
+
 /obj/item/attachable/bipod/Detach(var/mob/user, var/obj/item/weapon/gun/detaching_gub)
+	UnregisterSignal(detaching_gub, COMSIG_ITEM_DROPPED)
+
 	if(bipod_deployed)
 		undeploy_bipod(detaching_gub)
 	..()
@@ -2378,6 +2385,17 @@ Defined in conflicts.dm of the #defines folder.
 		gun.update_attachable(slot)
 		for(var/datum/action/A as anything in gun.actions)
 			A.update_button_icon()
+
+/obj/item/attachable/bipod/proc/handle_drop(obj/item/weapon/gun/G, mob/living/carbon/human/user)
+	SIGNAL_HANDLER
+
+	UnregisterSignal(user, COMSIG_MOB_MOVE_OR_LOOK)
+
+	if(bipod_deployed)
+		undeploy_bipod(G)
+		playsound(user,'sound/items/m56dauto_rotate.ogg', 55, 1)
+		user.apply_effect(1, SUPERSLOW)
+		user.apply_effect(2, SLOW)
 
 /obj/item/attachable/bipod/proc/undeploy_bipod(obj/item/weapon/gun/G)
 	bipod_deployed = FALSE


### PR DESCRIPTION
# About the pull request

The bipod applies a slow when it is being 'undeployed' via a signal. This signal is never removed if the weapon is dropped somehow, meaning even with no weapon in hand, the user will keep getting the 'undeploy' signal slow every time they move forever. This PR removes the signal on drop.

Resolves: https://github.com/cmss13-devs/cmss13/issues/700
Resolves: https://github.com/cmss13-devs/cmss13/issues/949

Issue shown here:

https://user-images.githubusercontent.com/59719612/209681920-f5721c29-f966-4b07-a286-6b8f8e9224f0.mp4

# Changelog

:cl: Casper
fix: fixed bipod slow never being removed on weapon drop
/:cl: