### PR TITLE
Bugfix: Acid holes now ignite xenos who travel through them

### DIFF
--- a/code/game/objects/effects/acid_hole.dm
+++ b/code/game/objects/effects/acid_hole.dm
@@ -106,7 +106,12 @@
 				to_chat(user, SPAN_WARNING("You release what you're pulling to fit into the tunnel!"))
 			user.forceMove(T)
 
+			// If the wall is on fire, ignite the xeno.
+			var/turf/wall = get_turf(src)
+			var/obj/flamer_fire/fire = locate(/obj/flamer_fire) in wall
 
+			if (fire)
+				user.handle_flamer_fire_crossed(fire)
 
 
 //Throwing Shiet


### PR DESCRIPTION
# About the pull request

If the wall is ignited, any xenos who travels through an acid hole will be ignited too.

Resolves: https://github.com/cmss13-devs/cmss13/issues/1089

https://user-images.githubusercontent.com/59719612/209903116-aaa9a140-2d14-4491-9942-796fe72f8ae7.mp4


# Explain why it's good for the game

Seems logical.

# Changelog

:cl: Casper
fix: xenos are now set on fire if they travel through an acid hole which is on fire
/:cl:
