### PR TITLE
Fixes runtime with pre-mapped decapitated heads

### DIFF
--- a/code/modules/organs/limb_objects.dm
+++ b/code/modules/organs/limb_objects.dm
@@ -79,6 +79,10 @@
 	if(istype(H))
 		src.icon_state = H.gender == MALE? "head_m" : "head_f"
 	..()
+
+	if(!H)
+		return
+
 	//Add (facial) hair.
 	if(H.f_style)
 		var/datum/sprite_accessory/facial_hair_style = GLOB.facial_hair_styles_list[H.f_style]


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Fixes runtime with pre-mapped decapitated heads. Pre-mapped decapitated heads don't have a human body set for them and so it would runtime.

# Explain why it's good for the game

Runtimes at start up bad.

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>
YUP
</details>


# Changelog

:cl: Morrow
fix: Fixes runtime with pre-mapped decapitated heads
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
