### PR TITLE
Warrior/Lurker Nerf

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/warrior/warrior_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/warrior/warrior_abilities.dm
@@ -20,7 +20,7 @@
 	macro_path = /datum/action/xeno_action/verb/verb_fling
 	action_type = XENO_ACTION_CLICK
 	ability_primacy = XENO_PRIMARY_ACTION_3
-	xeno_cooldown = 65
+	xeno_cooldown = 55
 
 	// Configurables
 	var/fling_distance = 4
@@ -53,7 +53,7 @@
 	macro_path = /datum/action/xeno_action/verb/verb_punch
 	action_type = XENO_ACTION_CLICK
 	ability_primacy = XENO_PRIMARY_ACTION_1
-	xeno_cooldown = 50
+	xeno_cooldown = 40
 
 	// Configurables
 	var/base_damage = 25

--- a/code/modules/mob/living/carbon/xenomorph/castes/Lurker.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Lurker.dm
@@ -76,7 +76,6 @@
 		to_chat(bound_xeno, SPAN_XENOHIGHDANGER("You significantly strengthen your attack, slowing [target_carbon]!"))
 		to_chat(target_carbon, SPAN_XENOHIGHDANGER("You feel a sharp pain as [bound_xeno] slashes you, slowing you down!"))
 		original_damage *= buffed_slash_damage_ratio
-		target_carbon.set_effect(get_xeno_stun_duration(target_carbon, 3), SUPERSLOW)
 		next_slash_buffed = FALSE
 		var/datum/action/xeno_action/onclick/lurker_assassinate/ability = get_xeno_action_by_type(bound_xeno, /datum/action/xeno_action/onclick/lurker_assassinate)
 		if (ability && istype(ability))

--- a/code/modules/mob/living/carbon/xenomorph/castes/Warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Warrior.dm
@@ -123,13 +123,6 @@
 	if (!cAction1.action_cooldown_check())
 		cAction1.reduce_cooldown(slash_charge_cdr)
 
-	var/datum/action/xeno_action/activable/fling/cAction2 = get_xeno_action_by_type(bound_xeno, /datum/action/xeno_action/activable/fling)
-	if (!cAction2.action_cooldown_check())
-		cAction2.reduce_cooldown(slash_charge_cdr)
-
-	var/datum/action/xeno_action/activable/warrior_punch/cAction3 = get_xeno_action_by_type(bound_xeno, /datum/action/xeno_action/activable/warrior_punch)
-	if (!cAction3.action_cooldown_check())
-		cAction3.reduce_cooldown(slash_charge_cdr)
 
 /datum/behavior_delegate/warrior_base/melee_attack_additional_effects_target(mob/living/carbon/A)
 	..()


### PR DESCRIPTION
# About the pull request

Purpose of this PR is to nerf some parts of warrior and lurkers kit. For warrior, fling and punch no longer gain benefits from slash CDR, and for lurker crippling slash no longer applies a slow. I've also reverted the cooldown change on punch/fling.

# Explain why it's good for the game

Warrior is too powerful with CDR on fling and punch. Both are very powerful abilities and with CDR they allow for repeated use to the point of unfairness. IE, stun locks. Removing it and leaving lunge (which is more of a skill check if a warrior can utilize the CDR for lunge) allows for better gameplay versus warriors and doesn't make entering a room with one impossible to fight against.

For lurker, Its a case of redundant slows. Crippling strike applies a 3 second superslow, which is entirely unnecessary. Lurker already has a much longer slow when slashing a resting mob, and crippling strike is almost always used on a pounced mob anyways, which leads me to believe that crippling strike is better off without a slow.


# Testing Photographs and Procedure
<!-- warrior doesnt gain cdr benefits when slashing, lurker doesnt slow with cripple strike -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: Lurkers crippling strike no longer slows.
balance: Warriors fling and punch are no longer affected by slash cooldown reduction.
balance: Reverted warriors fling and punch cooldown change.
/:cl:

