### PR TITLE
Fixes inconsistencies in the plasma caster "low power stun bolts" sounds

### DIFF
--- a/code/modules/cm_preds/yaut_weapons.dm
+++ b/code/modules/cm_preds/yaut_weapons.dm
@@ -972,7 +972,7 @@
 					strength = "low power stun bolts"
 					charge_cost = 30
 					fire_delay = FIRE_DELAY_TIER_6
-					fire_sound = 'sound/weapons/pred_lasercannon.ogg'
+					fire_sound = 'sound/weapons/pred_plasmacaster_fire.ogg'
 					to_chat(user, SPAN_NOTICE("[src] will now fire [strength]."))
 					ammo = GLOB.ammo_list[/datum/ammo/energy/yautja/caster/stun]
 		if("lethal")
@@ -1010,7 +1010,7 @@
 			strength = "low power stun bolts"
 			charge_cost = 30
 			fire_delay = FIRE_DELAY_TIER_6
-			fire_sound = 'sound/weapons/pred_lasercannon.ogg'
+			fire_sound = 'sound/weapons/pred_plasmacaster_fire.ogg'
 			to_chat(usr, SPAN_NOTICE("[src] will now fire [strength]."))
 			ammo = GLOB.ammo_list[/datum/ammo/energy/yautja/caster/stun]
 


### PR DESCRIPTION
# About the pull request

When first equipped, the plasma caster would default to "low power stun bolts" with the "pred_plasmacaster_fire.ogg", but after being switched to anything else and then back to "low power stun bolts", the sound switched to "pred_lasercannon.ogg" and would not use the original sound anymore.

# Explain why it's good for the game

Fixes inconsistencies in the guns sounds

# Changelog
:cl:
fix: Fixes inconsistent sounds for certain modes of the plasma caster
/:cl: