### PR TITLE
Adds a variable to allow camera terminals to be used from the admin z level

### DIFF
--- a/code/game/machinery/computer/camera_console.dm
+++ b/code/game/machinery/computer/camera_console.dm
@@ -21,6 +21,7 @@
 	var/list/range_turfs = list()
 
 	var/colony_camera_mapload = TRUE
+	var/admin_console = FALSE
 
 /obj/structure/machinery/computer/security/Initialize(mapload)
 	. = ..()
@@ -51,7 +52,7 @@
 	return attack_hand(user)
 
 /obj/structure/machinery/computer/security/attack_hand(mob/user)
-	if(is_admin_level(z))
+	if(!admin_console && is_admin_level(z))
 		to_chat(user, SPAN_DANGER("<b>Unable to establish a connection</b>: \black You're too far away from the ship!"))
 		return
 	if(inoperable())


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

As it says on the tin, currently camera consoles cannot be used off the admin z level via a hard code lock.

This PR adds a variable called admin_console that when enabled bypasses this check. It adds it, disabled by default, to all camera terminal subtypes.

Forest came up with the actual code, I just put it in and made sure it works as intended.

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

This is meant for event map inserts that utilize camera consoles for either their original use, or say as a non-invasive, backup helmet cam or whatever else the event runner may decide they want to use them for. Being able to use terminals off the admin level minimizes the chances of accidental intrusion into the event area whatever it may be.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:silencer_pl, forest2001
admin: Adds a variable called admin_console that allows the use of camera consoles from the admin z level.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
