### PR TITLE
Stops Janitoral Carts from eating buckets

### DIFF
--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -83,7 +83,7 @@
 		else
 			to_chat(user, SPAN_NOTICE("[src] can't hold any more signs."))
 
-	else if(istype(I, /obj/item/reagent_container/glass/bucket/janibucket))
+	else if(istype(I, /obj/item/reagent_container/glass/bucket/janibucket) && !mybucket)
 		user.drop_held_item()
 		mybucket = I
 		I.forceMove(src)


### PR DESCRIPTION
# About the pull request

The cart would keep taking buckets but it could only hold one so any buckets after the first would disappear.

# Explain why it's good for the game

Bug bad

# Changelog

:cl:
fix: Stops Janitorial Cart from deleting buckets
/:cl: