### PR TITLE
stack qol and vehicle entry speed fix

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -296,6 +296,23 @@ Also change the icon to reflect the amount of sheets, if possible.*/
 		if(!oldsrc)
 			break
 
+/obj/item/stack/clicked(mob/user, list/mods)
+	if(mods["alt"])
+		var/desired = tgui_input_number(user, "How much would you like to split off from this stack?", "How much?", 1, amount-1, 1)
+		if(!desired)
+			return
+		var/obj/item/stack/newstack = new src.type(user, desired)
+		transfer_fingerprints_to(newstack)
+		user.put_in_hands(newstack)
+		src.add_fingerprint(user)
+		newstack.add_fingerprint(user)
+		use(desired)
+		if(src && usr.interactee==src)
+			INVOKE_ASYNC(src, TYPE_PROC_REF(/obj/item/stack, interact), usr)
+		return
+	else
+		return ..()
+
 /obj/item/stack/attack_hand(mob/user as mob)
 	if (user.get_inactive_hand() == src)
 		var/obj/item/stack/F = new src.type(user, 1)
@@ -311,20 +328,13 @@ Also change the icon to reflect the amount of sheets, if possible.*/
 	return
 
 /obj/item/stack/attackby(obj/item/W as obj, mob/user as mob)
-	if (istype(W, /obj/item/stack))
+	if(istype(W, /obj/item/stack))
 		var/obj/item/stack/S = W
 		if(S.stack_id == stack_id) //same stack type
 			if(S.amount >= max_amount)
-				to_chat(user, SPAN_NOTICE("The stack is full!"))
+				to_chat(user, SPAN_WARNING("The stack is full!"))
 				return TRUE
-			var/to_transfer
-			if(user.get_inactive_hand() == src)
-				var/desired = tgui_input_number(user, "How much would you like to transfer from this stack?", "How much?", 1, amount, 1)
-				if(!desired)
-					return
-				to_transfer = Clamp(desired, 0, min(amount, S.max_amount-S.amount))
-			else
-				to_transfer = min(src.amount, S.max_amount-S.amount)
+			var/to_transfer = min(src.amount, S.max_amount-S.amount)
 			if(to_transfer <= 0)
 				return
 			to_chat(user, SPAN_INFO("You transfer [to_transfer] between the stacks."))

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -262,14 +262,14 @@ Also change the icon to reflect the amount of sheets, if possible.*/
 
 /obj/item/stack/proc/use(used)
 	if(used > amount) //If it's larger than what we have, no go.
-		return 0
+		return FALSE
 	amount -= used
 	update_icon()
 	if(amount <= 0)
 		if(usr && loc == usr)
 			usr.temp_drop_inv_item(src)
 		qdel(src)
-	return 1
+	return TRUE
 
 /obj/item/stack/proc/add(var/extra)
 	if(amount + extra > max_amount)
@@ -301,12 +301,13 @@ Also change the icon to reflect the amount of sheets, if possible.*/
 		var/desired = tgui_input_number(user, "How much would you like to split off from this stack?", "How much?", 1, amount-1, 1)
 		if(!desired)
 			return
+		if(!use(desired))
+			return
 		var/obj/item/stack/newstack = new src.type(user, desired)
 		transfer_fingerprints_to(newstack)
 		user.put_in_hands(newstack)
 		src.add_fingerprint(user)
 		newstack.add_fingerprint(user)
-		use(desired)
 		if(src && usr.interactee==src)
 			INVOKE_ASYNC(src, TYPE_PROC_REF(/obj/item/stack, interact), usr)
 		return

--- a/code/modules/vehicles/apc/apc.dm
+++ b/code/modules/vehicles/apc/apc.dm
@@ -28,7 +28,7 @@ GLOBAL_LIST_EMPTY(command_apc_list)
 		"rear right" = list(-1, 2)
 	)
 
-	entrance_speed = 0.5
+	entrance_speed = 0.5 SECONDS
 
 	required_skill = SKILL_VEHICLE_LARGE
 

--- a/code/modules/vehicles/interior/interactable/doors.dm
+++ b/code/modules/vehicles/interior/interactable/doors.dm
@@ -29,7 +29,7 @@
 		dragged_atom = G.grabbed_thing
 
 	var/obj/vehicle/multitile/V = interior.exterior
-	var/exit_time = V.entrance_speed SECONDS
+	var/exit_time = V.entrance_speed
 	if(dragged_atom)
 		exit_time = 2 SECONDS
 
@@ -103,7 +103,7 @@
 		dragged_atom = G.grabbed_thing
 
 	var/obj/vehicle/multitile/V = interior.exterior
-	var/exit_time = V.entrance_speed SECONDS
+	var/exit_time = V.entrance_speed
 	if(dragged_atom)
 		exit_time = 2 SECONDS
 

--- a/code/modules/vehicles/multitile/multitile_interaction.dm
+++ b/code/modules/vehicles/multitile/multitile_interaction.dm
@@ -453,7 +453,7 @@
 		dragged_atom = G.grabbed_thing
 
 	if(!enter_time)
-		enter_time = entrance_speed SECONDS
+		enter_time = entrance_speed
 		if(dragged_atom)
 			enter_time = 2 SECONDS
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

removes the annoying "merge sheets" popup that happened when you clicked a stack in your offhand

now you can split off stacks with altclick

also fixed carlarc vehicle entry speed bug

Fixes https://github.com/cmss13-devs/cmss13/issues/2182

# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: vehicle entry speeds will no longer be extraneously multiplied
qol: you can now alt-click stacks to split off items from them. As a result of this, attacking a stack in your offhand with one of the same type will no longer ask you how many you want to merge into it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
