### PR TITLE
Tweak: Boiler bombard cooldown

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/general_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/general_abilities.dm
@@ -408,7 +408,7 @@
 	macro_path = /datum/action/xeno_action/verb/verb_bombard
 	action_type = XENO_ACTION_CLICK
 	ability_primacy = XENO_PRIMARY_ACTION_1
-	xeno_cooldown = 245
+	xeno_cooldown = 230
 
 	// Range and other config
 	var/effect_range = 3

--- a/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
@@ -765,8 +765,6 @@
 	if (!X.can_bombard_turf(T, range, bombard_source))
 		return FALSE
 
-	apply_cooldown()
-
 	X.visible_message(SPAN_XENODANGER("[X] digs itself into place!"), SPAN_XENODANGER("You dig yourself into place!"))
 	if (!do_after(X, activation_delay, interrupt_flags, BUSY_ICON_HOSTILE))
 		to_chat(X, SPAN_XENODANGER("You decide to cancel your bombard."))
@@ -777,6 +775,8 @@
 
 	if (!check_and_use_plasma_owner())
 		return FALSE
+
+	apply_cooldown()
 
 	X.visible_message(SPAN_XENODANGER("[X] launches a massive ball of acid at [A]!"), SPAN_XENODANGER("You launch a massive ball of acid at [A]!"))
 	playsound(get_turf(X), 'sound/effects/blobattack.ogg', 25, 1)


### PR DESCRIPTION
# About the pull request

The cooldown for the bombard ability is applied before the shot actually fires. If the boiler moves / uses plasma / has no line-of-sight after the 1.5 second wind-up, the shot will not fire, but the cooldown will still apply. This makes no sense personally.

This PR simply makes it so the cooldown only applies if the shot actually fires. Note the cooldown duration is adjusted to compensate for the cooldown now being applied **after** the 1.5 second wind-up.

# Explain why it's good for the game

Getting put on cooldown for an ability that never actually got used seems like a bug?

# Testing Photographs and Procedure

Even with the delayed cooldown application, the ability still behaves like normal.

# Changelog

:cl: Casper
fix: boiler bombard cooldown now only applies if the shot actually fires
/:cl: