### PR TITLE
Say() and asterisks.

### DIFF
--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -75,7 +75,8 @@
 		return say_dead(message)
 
 	if(copytext(message,1,2) == "*")
-		return emote(lowertext(copytext(message,2)), 1, null, TRUE) //TRUE arg means emote was caused by player (e.g. no an auto scream when hurt).
+		if(!findtext(message, "*", 2)) //Second asterisk means it is markup for *bold*, not an *emote.
+			return emote(lowertext(copytext(message,2)), 1, null, TRUE) //TRUE arg means emote was caused by player (e.g. no an auto scream when hurt).
 
 	if(name != GetVoice())
 		alt_name = "(as [get_id_name("Unknown")])"

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -75,7 +75,7 @@
 		return say_dead(message)
 
 	if(copytext(message,1,2) == "*")
-		return emote(copytext(message,2), 1, null, TRUE) //TRUE arg means emote was caused by player (e.g. no an auto scream when hurt).
+		return emote(lowertext(copytext(message,2)), 1, null, TRUE) //TRUE arg means emote was caused by player (e.g. no an auto scream when hurt).
 
 	if(name != GetVoice())
 		alt_name = "(as [get_id_name("Unknown")])"

--- a/code/modules/mob/living/carbon/xenomorph/say.dm
+++ b/code/modules/mob/living/carbon/xenomorph/say.dm
@@ -21,7 +21,8 @@
 		return
 
 	if(copytext(message, 1, 2) == "*")
-		return emote(lowertext(copytext(message, 2)), player_caused = TRUE)
+		if(!findtext(message, "*", 2)) //Second asterisk means it is markup for *bold*, not an *emote.
+			return emote(lowertext(copytext(message, 2)), player_caused = TRUE)
 
 	var/datum/language/speaking = null
 	if(length(message) >= 2)

--- a/code/modules/mob/living/carbon/xenomorph/say.dm
+++ b/code/modules/mob/living/carbon/xenomorph/say.dm
@@ -21,7 +21,7 @@
 		return
 
 	if(copytext(message, 1, 2) == "*")
-		return emote(copytext(message, 2), player_caused = TRUE)
+		return emote(lowertext(copytext(message, 2)), player_caused = TRUE)
 
 	var/datum/language/speaking = null
 	if(length(message) >= 2)

--- a/code/modules/mob/living/silicon/say.dm
+++ b/code/modules/mob/living/silicon/say.dm
@@ -39,7 +39,8 @@
 		return say_dead(message)
 
 	if(copytext(message,1,2) == "*")
-		return emote(lowertext(copytext(message,2)))
+		if(!findtext(message, "*", 2)) //Second asterisk means it is markup for *bold*, not an *emote.
+			return emote(lowertext(copytext(message,2)))
 
 	var/bot_type = 0 //Let's not do a fuck ton of type checks, thanks.
 	if(isAI(src))

--- a/code/modules/mob/living/silicon/say.dm
+++ b/code/modules/mob/living/silicon/say.dm
@@ -39,7 +39,7 @@
 		return say_dead(message)
 
 	if(copytext(message,1,2) == "*")
-		return emote(copytext(message,2))
+		return emote(lowertext(copytext(message,2)))
 
 	var/bot_type = 0 //Let's not do a fuck ton of type checks, thanks.
 	if(isAI(src))

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -363,8 +363,9 @@
 		return
 
 	if(copytext(message,1,2) == "*")
-		INVOKE_ASYNC(src, PROC_REF(emote), lowertext(copytext(message,2)))
-		return
+		if(!findtext(message, "*", 2)) //Second asterisk means it is markup for *bold*, not an *emote.
+			INVOKE_ASYNC(src, PROC_REF(emote), lowertext(copytext(message,2)))
+			return
 
 	if(stat)
 		return

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -363,7 +363,7 @@
 		return
 
 	if(copytext(message,1,2) == "*")
-		INVOKE_ASYNC(src, PROC_REF(emote), copytext(message,2))
+		INVOKE_ASYNC(src, PROC_REF(emote), lowertext(copytext(message,2)))
 		return
 
 	if(stat)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

My Shift key sticks a bit, and I am tired of being told that "*Salute" is not a real emote.

# Explain why it's good for the game

Is QoL.


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: Markup for bold text can now be used for the first word or words in the spoken sentence without it being interpreted as a failed *emote.
qol: *emotes are no longer case sensitive (e.g. saying "*salute", "*Salute" and "*SALUTE" are equally valid ways to salute).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
