### PR TITLE
Fix for splitting stacks.

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -310,7 +310,7 @@ Also change the icon to reflect the amount of sheets, if possible.*/
 		newstack.add_fingerprint(user)
 		if(src && usr.interactee==src)
 			INVOKE_ASYNC(src, TYPE_PROC_REF(/obj/item/stack, interact), usr)
-		return
+		return TRUE
 	else
 		return ..()
 

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -298,6 +298,8 @@ Also change the icon to reflect the amount of sheets, if possible.*/
 
 /obj/item/stack/clicked(mob/user, list/mods)
 	if(mods["alt"])
+		if(!CAN_PICKUP(user, src))
+			return
 		var/desired = tgui_input_number(user, "How much would you like to split off from this stack?", "How much?", 1, amount-1, 1)
 		if(!desired)
 			return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Followup to #2186.

# Explain why it's good for the game

Without this return, `click()` proceeds as normal after creating the split stack, which results in `attackby()` on remains of old stack by new stack, which results in consuming old stack into new stack entirely, which results in no splitting at all.
Also a sanity check to prevent certain black sorcery tricks.

# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: Splitting stacks actually works now.
fix: Aliens and telekinetics no longer can abuse splitting stacks.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
