### PR TITLE
increases queen timelock

### DIFF
--- a/code/__DEFINES/job.dm
+++ b/code/__DEFINES/job.dm
@@ -79,7 +79,10 @@ var/global/list/job_command_roles = JOB_COMMAND_ROLES_LIST
 #define JOB_MARINE_RAIDER_ROLES_LIST list(JOB_MARINE_RAIDER, JOB_MARINE_RAIDER_SL, JOB_MARINE_RAIDER_CD)
 
 #define JOB_HUMAN_ROLES  /datum/timelock/human
+
 #define JOB_XENO_ROLES   /datum/timelock/xeno
+#define JOB_DRONE_ROLES /datum/timelock/drone
+#define JOB_T3_ROLES /datum/timelock/tier3
 
 #define JOB_STOWAWAY "Stowaway"
 

--- a/code/game/jobs/job/antag/antag.dm
+++ b/code/game/jobs/job/antag/antag.dm
@@ -14,7 +14,7 @@
 
 /// counts drone caste evo time as well
 /datum/timelock/drone
-	name = "Drone"
+	name = "Drone and drone evolutions"
 
 /datum/timelock/drone/can_play(client/C)
 	return C.get_total_drone_playtime() >= time_required
@@ -24,7 +24,7 @@
 
 /// t3 and queen time
 /datum/timelock/tier3
-	name = "Tier_three"
+	name = "Tier three castes"
 
 /datum/timelock/tier3/can_play(client/C)
 	return C.get_total_t3_playtime() >= time_required

--- a/code/game/jobs/job/antag/antag.dm
+++ b/code/game/jobs/job/antag/antag.dm
@@ -8,6 +8,26 @@
 
 /datum/timelock/xeno/can_play(client/C)
 	return C.get_total_xeno_playtime() >= time_required
-	
+
 /datum/timelock/xeno/get_role_requirement(client/C)
 	return time_required - C.get_total_xeno_playtime()
+
+/// counts drone caste evo time as well
+/datum/timelock/drone
+	name = "Drone"
+
+/datum/timelock/drone/can_play(client/C)
+	return C.get_total_drone_playtime() >= time_required
+
+/datum/timelock/drone/get_role_requirement(client/C)
+	return time_required - C.get_total_drone_playtime()
+
+/// t3 and queen time
+/datum/timelock/tier3
+	name = "Tier_three"
+
+/datum/timelock/tier3/can_play(client/C)
+	return C.get_total_t3_playtime() >= time_required
+
+/datum/timelock/tier3/get_role_requirement(client/C)
+	return time_required - C.get_total_t3_playtime()

--- a/code/game/jobs/job/antag/xeno/queen.dm
+++ b/code/game/jobs/job/antag/xeno/queen.dm
@@ -19,7 +19,7 @@
 	to_chat(new_queen, "Talk in Hivemind using <strong>;</strong> (e.g. ';Hello my children!')")
 
 AddTimelock(/datum/job/antag/xenos/queen, list(
-	JOB_XENO_ROLES = 20 HOURS,
+	JOB_XENO_ROLES = 10 HOURS,
 	JOB_DRONE_ROLES = 10 HOURS,
 	JOB_T3_ROLES = 5 HOURS,
 ))

--- a/code/game/jobs/job/antag/xeno/queen.dm
+++ b/code/game/jobs/job/antag/xeno/queen.dm
@@ -20,6 +20,6 @@
 
 AddTimelock(/datum/job/antag/xenos/queen, list(
 	JOB_XENO_ROLES = 10 HOURS,
-	JOB_DRONE_ROLES = 10 HOURS,
-	JOB_T3_ROLES = 5 HOURS,
+	JOB_DRONE_ROLES = 5 HOURS,
+	JOB_T3_ROLES = 3 HOURS,
 ))

--- a/code/game/jobs/job/antag/xeno/queen.dm
+++ b/code/game/jobs/job/antag/xeno/queen.dm
@@ -19,5 +19,7 @@
 	to_chat(new_queen, "Talk in Hivemind using <strong>;</strong> (e.g. ';Hello my children!')")
 
 AddTimelock(/datum/job/antag/xenos/queen, list(
-	JOB_XENO_ROLES = 10 HOURS
+	JOB_XENO_ROLES = 20 HOURS,
+	JOB_DRONE_ROLES = 10 HOURS,
+	JOB_T3_ROLES = 5 HOURS,
 ))

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -130,6 +130,7 @@
 
 /client/var/cached_xeno_playtime
 
+/// playtime for all castes
 /client/proc/get_total_xeno_playtime(var/skip_cache = FALSE)
 	if(cached_xeno_playtime && !skip_cache)
 		return cached_xeno_playtime
@@ -150,6 +151,30 @@
 	cached_xeno_playtime = total_xeno_playtime
 
 	return total_xeno_playtime
+
+/// playtime for drone and drone evolution castes
+/client/proc/get_total_drone_playtime()
+	var/total_drone_playtime = 0
+
+	var/list/drone_evo_castes = list(XENO_CASTE_DRONE, XENO_CASTE_CARRIER, XENO_CASTE_BURROWER, XENO_CASTE_HIVELORD, XENO_CASTE_QUEEN)
+
+	for(var/caste in RoleAuthority.castes_by_name)
+		if(!(caste in drone_evo_castes))
+			continue
+		total_drone_playtime += get_job_playtime(src, caste)
+
+	return total_drone_playtime
+
+/// playtime for t3 castes and queen
+/client/proc/get_total_t3_playtime()
+	var/total_t3_playtime = 0
+
+	for(var/datum/caste_datum/caste as anything in RoleAuthority.castes_by_name)
+		if(caste.tier < 3)
+			continue
+		total_t3_playtime += get_job_playtime(src, caste)
+
+	return total_t3_playtime
 
 /datum/caste_datum/proc/can_play_caste(var/client/client)
 	if(!CONFIG_GET(flag/use_timelocks))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

increased queen timelock from 10 hours xeno to -> 10 hours xeno, 10 hours drone/drone evos, 5 hours t3/queen

# Explain why it's good for the game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->

Bald queens ruin rounds. Many times has a player with only 10 hours of some random caste like runner rolled queen and been 100% bald, not knowing how to build or fight as t3.

The drone timelock ensures the player will have AT LEAST some experience with building and hive structures as this is FUNDAMENTAL to the role of Queen

the t3 timelock ensures the played will have at least some experience of big xeno combat so they won't just think they're invincible and die the moment they meet marines.

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
I DIDN'T TEST THIS ON LOCAL!!!! TOO MUCH OF A HASSLE!!!


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
balance: increased the queen timelock to 10 hours of xeno, 5 hours of drone, and 3 hours of t3
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
