### PR TITLE
asset log antispam

### DIFF
--- a/code/game/objects/effects/overlays.dm
+++ b/code/game/objects/effects/overlays.dm
@@ -284,4 +284,4 @@
 	name = "acid splash"
 	icon = 'icons/mob/xenos/effects.dmi'
 	icon_state = "pool_splash"
-	effect_duration = 10 SECONDS
+	effect_duration = 3 SECONDS

--- a/code/modules/asset_cache/transports/asset_transport.dm
+++ b/code/modules/asset_cache/transports/asset_transport.dm
@@ -120,7 +120,7 @@
 				|| (ACI.namespace && !ACI.namespace_parent)
 			if (!keep_local_name)
 				new_asset_name = "asset.[ACI.hash][ACI.ext]"
-			log_asset("Sending asset `[asset_name]` to client `[client]` as `[new_asset_name]`")
+			//log_asset("Sending asset `[asset_name]` to client `[client]` as `[new_asset_name]`")
 			client << browse_rsc(ACI.resource, new_asset_name)
 
 			client.sent_assets[new_asset_name] = ACI.hash

--- a/code/modules/cm_aliens/structures/special/spawn_pool.dm
+++ b/code/modules/cm_aliens/structures/special/spawn_pool.dm
@@ -85,7 +85,7 @@
 	if(melting_body)
 		to_chat(user, SPAN_XENOWARNING("\The [src] is already processing a host! Using this one now would be a waste..."))
 		return
-	if(!do_after(user, 10, INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_GENERIC))
+	if(!do_after(user, 1 SECONDS, INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_GENERIC))
 		return
 	visible_message(SPAN_DANGER("\The [src] splashes loudly as \the [M] is tossed in, bubbling uncontrollably!"))
 	melting_body = M

--- a/code/modules/tgui/tgui.dm
+++ b/code/modules/tgui/tgui.dm
@@ -55,9 +55,9 @@
  * return datum/tgui The requested UI.
  */
 /datum/tgui/New(mob/user, datum/src_object, interface, title, ui_x, ui_y)
-	log_tgui(user,
-		"new [interface] fancy [user?.client?.prefs.tgui_fancy]",
-		src_object = src_object)
+//	log_tgui(user,
+//		"new [interface] fancy [user?.client?.prefs.tgui_fancy]",
+//		src_object = src_object)
 	src.user = user
 	src.src_object = src_object
 	src.window_key = "[REF(src_object)]-main"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

prevents asset log from taking up 50 quadribillion mbs of log space

the tgui log i commented out is irrelevant, already handled by the opening log


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
admin: asset sending and tgui making is no longer logged to save space 
fix: fixes the spawn pool splash overlay sticking around for ages
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
