### PR TITLE
Fix for slowdown stacked tile movement when flung or dragged onto tile.

### DIFF
--- a/code/modules/cm_aliens/XenoStructures.dm
+++ b/code/modules/cm_aliens/XenoStructures.dm
@@ -158,12 +158,12 @@
 /obj/effect/alien/resin/sticky/Crossed(atom/movable/AM)
 	. = ..()
 	var/mob/living/carbon/human/H = AM
-	if(istype(H) && !H.lying && !H.ally_of_hivenumber(hivenumber))
-		H.next_move_slowdown = H.next_move_slowdown + slow_amt
+	if(istype(H) && !H.lying && !H.ally_of_hivenumber(hivenumber) && !H.pulledby)
+		H.next_move_slowdown += slow_amt
 		return .
 	var/mob/living/carbon/Xenomorph/X = AM
-	if(istype(X) && !X.ally_of_hivenumber(hivenumber))
-		X.next_move_slowdown = X.next_move_slowdown + slow_amt
+	if(istype(X) && !X.ally_of_hivenumber(hivenumber) && !X.pulledby)
+		X.next_move_slowdown += slow_amt
 		return .
 
 /obj/effect/alien/resin/spike

--- a/code/modules/cm_aliens/weeds.dm
+++ b/code/modules/cm_aliens/weeds.dm
@@ -171,7 +171,9 @@
 	SEND_SIGNAL(crossing_mob, COMSIG_MOB_WEEDS_CROSSED, slowdata, src)
 	var/final_slowdown = slowdata["movement_slowdown"]
 
-	crossing_mob.next_move_slowdown += POSITIVE(final_slowdown)
+	// if the mob is getting pulled then the slowdown speed will be stacked.
+	if(!crossing_mob.pulledby)
+		crossing_mob.next_move_slowdown += POSITIVE(final_slowdown)
 
 // Uh oh, we might be dying!
 // I know this is bad proc naming but it was too good to pass on and it's only used in this file anyways

--- a/code/modules/mob/living/carbon/xenomorph/abilities/warrior/warrior_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/warrior/warrior_powers.dm
@@ -64,7 +64,6 @@
 
 /datum/action/xeno_action/activable/fling/use_ability(atom/target_atom)
 	var/mob/living/carbon/Xenomorph/woyer = owner
-
 	if (!action_cooldown_check())
 		return
 
@@ -78,6 +77,7 @@
 		return
 
 	var/mob/living/carbon/carbone = target_atom
+	var/temp_carbone_slowdown = carbone.next_move_slowdown
 	if(carbone.stat == DEAD) return
 	if(HAS_TRAIT(carbone, TRAIT_NESTED))
 		return
@@ -101,6 +101,7 @@
 	if(slowdown)
 		if(carbone.slowed < slowdown)
 			carbone.apply_effect(slowdown, SLOW)
+			temp_carbone_slowdown = carbone.next_move_slowdown
 	carbone.last_damage_data = create_cause_data(initial(woyer.caste_type), woyer)
 	shake_camera(carbone, 2, 1)
 
@@ -119,6 +120,10 @@
 	woyer.animation_attack_on(carbone)
 	woyer.flick_attack_overlay(carbone, "disarm")
 	carbone.throw_atom(throw_turf, fling_distance, SPEED_VERY_FAST, woyer, TRUE)
+
+	// if the mob is flung over a slowdown tile (weeds, sticky resin, snow etc..) then the slowdown effect will be stacked.
+	// to prevent this, we just use the slowdown speed of the carbone before it was flung.
+	carbone.next_move_slowdown = temp_carbone_slowdown
 
 	apply_cooldown()
 	..()


### PR DESCRIPTION


# About the pull request
Fix for a few issues outlined in #2227, basically, for combat scenarios where there are weeds the slowdown tiles should no longer be stacked if a mob is dragged onto the weeds by another mob, as well as if the warrior flings a mob over some stacked tiles. The issue with the harm intent push has yet to be solved though. This is my first attempt at a bug fix and I learned dm 2 days ago so please don't bully me.

# Explain why it's good for the game
It would be ideal if slowdown tiles didn't stack.

# Testing Photographs and Procedure
Did some manual testing and it seemed to work, going to do more in-depth testing in the following few days (I have a strong feeling there might be some performance issues with my implementation but we will see). 

# Changelog

:cl:
fix: fix for the stacked slowdown tiles
/:cl:

