### PR TITLE
fix corpse spawner on big red medbay nightmare insert

### DIFF
--- a/maps/map_files/BigRed/standalone/medbay-v3.dmm
+++ b/maps/map_files/BigRed/standalone/medbay-v3.dmm
@@ -1807,7 +1807,7 @@
 "eH" = (
 /obj/structure/machinery/optable,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/corpsespawner,
+/obj/effect/landmark/corpsespawner/wygoon,
 /obj/item/reagent_container/food/snacks/margheritaslice,
 /turf/open/floor{
 	icon_state = "white"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

Fixes corpse spawner on nightmare insert

# Explain why it's good for the game

Corpse spawner is spawning live mobs which shouldn't be the case. The was a result of the wy goon corpse update. The update changed one of the corpse spawner to just an unknown default which shouldn't be the case.


# Testing Photographs and Procedure
![image](https://user-images.githubusercontent.com/103712112/211173925-e1c6acee-6428-437f-8ed1-3ff8bb433907.png)

![image](https://user-images.githubusercontent.com/103712112/211173930-0f9a35cd-9fa9-4b27-b54f-a1c98ad4b39a.png)


</details>


# Changelog

:cl: theflyingflail
fix: fixed broken spawner on big red nightmare insert
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
