### PR TITLE
Fixes Object Narrate admin verb not returning after hiding admin verbs

### DIFF
--- a/code/modules/admin/tabs/admin_tab.dm
+++ b/code/modules/admin/tabs/admin_tab.dm
@@ -410,8 +410,6 @@
 	if(!(admin_holder.rights & R_POSSESS))
 		remove_verb(src, /client/proc/release)
 		remove_verb(src, /client/proc/possess)
-	if(!(admin_holder.rights & R_EVENT))
-		remove_verb(src, /client/proc/cmd_admin_object_narrate)
 
 /client/proc/hide_admin_verbs()
 	set name = "Admin Verbs - Hide"


### PR DESCRIPTION
# About the pull request

Object narrate is in the default admin verbs list, so all staff are able to use it. However, after hiding admin verbs and showing them again, it checks if you have the minor event verb list, and only re-adds it if you do. This would mean if you do not have the minor event verbs list, after hiding and showing admin verbs, you cannot object narrate until you relog.
This PR removes the check for if you can do minor events so it will properly return after hiding and showing again.

Also, I'm not sure if this is meant to be a fix or an admin change sooo
# Explain why it's good for the game

Bug bad

# Changelog

:cl:
admin: Fixes "Object Narrate" not returning properly sometimes
/:cl: