### PR TITLE
fixes the goofy out of LOS typing indicators

### DIFF
--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -72,8 +72,6 @@ var/list/department_radio_keys = list(
 /mob/living/proc/remove_speech_bubble(var/mutable_appearance/speech_bubble, var/list_of_mobs)
 	overlays -= speech_bubble
 
-	speech_bubble = null
-
 /mob/living/say(message, datum/language/speaking = null, verb="says", alt_name="", italics=0, message_range = world_view_size, sound/speech_sound, sound_vol, nolog = 0, message_mode = null, bubble_type = bubble_icon)
 	var/turf/T
 
@@ -126,18 +124,16 @@ var/list/department_radio_keys = list(
 					listening |= M
 
 		var/speech_bubble_test = say_test(message)
-		var/image/speech_bubble = image(icon = 'icons/mob/effects/talk.dmi', loc = src, icon_state = "[bubble_type][speech_bubble_test]")
-		speech_bubble.plane = ABOVE_GAME_PLANE
+		var/image/speech_bubble = image('icons/mob/effects/talk.dmi', src, "[bubble_type][speech_bubble_test]", FLY_LAYER)
 
 		var/not_dead_speaker = (stat != DEAD)
 		if(not_dead_speaker)
 			langchat_speech(message, listening, speaking)
 		for(var/mob/M as anything in listening)
-			if(not_dead_speaker)
-				M << speech_bubble
 			M.hear_say(message, verb, speaking, alt_name, italics, src, speech_sound, sound_vol)
+		overlays += speech_bubble
 
-		addtimer(CALLBACK(src, PROC_REF(remove_speech_bubble), speech_bubble, listening), 30)
+		addtimer(CALLBACK(src, PROC_REF(remove_speech_bubble), speech_bubble), 3 SECONDS)
 
 		for(var/obj/O as anything in listening_obj)
 			if(O) //It's possible that it could be deleted in the meantime.

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -255,8 +255,8 @@
 	var/datum/click_intercept
 
 	///the icon currently used for the typing indicator's bubble
-	var/mutable_appearance/active_typing_indicator
+	var/image/active_typing_indicator
 	///the icon currently used for the thinking indicator's bubble
-	var/mutable_appearance/active_thinking_indicator
+	var/image/active_thinking_indicator
 	/// User is thinking in character. Used to revert to thinking state after stop_typing
 	var/thinking_IC = FALSE

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -255,8 +255,8 @@
 	var/datum/click_intercept
 
 	///the icon currently used for the typing indicator's bubble
-	var/image/active_typing_indicator
+	var/mutable_appearance/active_typing_indicator
 	///the icon currently used for the thinking indicator's bubble
-	var/image/active_thinking_indicator
+	var/mutable_appearance/active_thinking_indicator
 	/// User is thinking in character. Used to revert to thinking state after stop_typing
 	var/thinking_IC = FALSE

--- a/code/modules/tgui/tgui-say/typing.dm
+++ b/code/modules/tgui/tgui-say/typing.dm
@@ -73,9 +73,8 @@
 /mob/living/create_thinking_indicator()
 	if(active_thinking_indicator || active_typing_indicator || !thinking_IC || stat != CONSCIOUS )
 		return FALSE
-	active_thinking_indicator = mutable_appearance('icons/mob/effects/talk.dmi', "[bubble_icon]3", TYPING_LAYER)
-	active_thinking_indicator.pixel_x = bubble_icon_x_offset
-	active_thinking_indicator.pixel_y = bubble_icon_y_offset
+	active_thinking_indicator = image('icons/mob/effects/talk.dmi', icon_state = "[bubble_icon]3", layer = TYPING_LAYER, pixel_x = bubble_icon_x_offset, pixel_y = bubble_icon_y_offset)
+	active_thinking_indicator.appearance_flags = KEEP_APART
 	overlays += active_thinking_indicator
 
 /mob/living/remove_thinking_indicator()
@@ -89,9 +88,8 @@
 		return FALSE
 	if(!thinking_IC && !override_thinking)
 		return FALSE
-	active_typing_indicator = mutable_appearance('icons/mob/effects/talk.dmi', "[bubble_icon]0", TYPING_LAYER)
-	active_typing_indicator.pixel_x = bubble_icon_x_offset
-	active_typing_indicator.pixel_y = bubble_icon_y_offset
+	active_typing_indicator = image('icons/mob/effects/talk.dmi', icon_state = "[bubble_icon]0", layer = TYPING_LAYER, pixel_x = bubble_icon_x_offset, pixel_y = bubble_icon_y_offset)
+	active_thinking_indicator.appearance_flags = KEEP_APART
 	overlays += active_typing_indicator
 
 /mob/living/remove_typing_indicator()

--- a/code/modules/tgui/tgui-say/typing.dm
+++ b/code/modules/tgui/tgui-say/typing.dm
@@ -77,7 +77,6 @@
 	active_thinking_indicator.pixel_x = bubble_icon_x_offset
 	active_thinking_indicator.pixel_y = bubble_icon_y_offset
 	overlays += active_thinking_indicator
-	addtimer(CALLBACK(src, PROC_REF(remove_thinking_indicator)), 30 SECONDS, TIMER_OVERRIDE|TIMER_UNIQUE|TIMER_STOPPABLE)
 
 /mob/living/remove_thinking_indicator()
 	if(!active_thinking_indicator)
@@ -94,7 +93,6 @@
 	active_typing_indicator.pixel_x = bubble_icon_x_offset
 	active_typing_indicator.pixel_y = bubble_icon_y_offset
 	overlays += active_typing_indicator
-	addtimer(CALLBACK(src, PROC_REF(remove_typing_indicator)), 30 SECONDS, TIMER_OVERRIDE|TIMER_UNIQUE|TIMER_STOPPABLE)
 
 /mob/living/remove_typing_indicator()
 	if(!active_typing_indicator)

--- a/code/modules/tgui/tgui-say/typing.dm
+++ b/code/modules/tgui/tgui-say/typing.dm
@@ -73,9 +73,11 @@
 /mob/living/create_thinking_indicator()
 	if(active_thinking_indicator || active_typing_indicator || !thinking_IC || stat != CONSCIOUS )
 		return FALSE
-	active_thinking_indicator = image('icons/mob/effects/talk.dmi', icon_state = "[bubble_icon]3", layer = TYPING_LAYER, pixel_x = bubble_icon_x_offset, pixel_y = bubble_icon_y_offset)
-	active_thinking_indicator.appearance_flags = KEEP_APART
+	active_thinking_indicator = mutable_appearance('icons/mob/effects/talk.dmi', icon_state = "[bubble_icon]3", layer = TYPING_LAYER)
+	active_thinking_indicator.pixel_x = bubble_icon_x_offset
+	active_thinking_indicator.pixel_y = bubble_icon_y_offset
 	overlays += active_thinking_indicator
+	addtimer(CALLBACK(src, PROC_REF(remove_thinking_indicator)), 30 SECONDS, TIMER_OVERRIDE|TIMER_UNIQUE|TIMER_STOPPABLE)
 
 /mob/living/remove_thinking_indicator()
 	if(!active_thinking_indicator)
@@ -88,9 +90,11 @@
 		return FALSE
 	if(!thinking_IC && !override_thinking)
 		return FALSE
-	active_typing_indicator = image('icons/mob/effects/talk.dmi', icon_state = "[bubble_icon]0", layer = TYPING_LAYER, pixel_x = bubble_icon_x_offset, pixel_y = bubble_icon_y_offset)
-	active_thinking_indicator.appearance_flags = KEEP_APART
+	active_typing_indicator = mutable_appearance('icons/mob/effects/talk.dmi', icon_state = "[bubble_icon]0", layer = TYPING_LAYER)
+	active_thinking_indicator.pixel_x = bubble_icon_x_offset
+	active_thinking_indicator.pixel_y = bubble_icon_y_offset
 	overlays += active_typing_indicator
+	addtimer(CALLBACK(src, PROC_REF(remove_typing_indicator)), 30 SECONDS, TIMER_OVERRIDE|TIMER_UNIQUE|TIMER_STOPPABLE)
 
 /mob/living/remove_typing_indicator()
 	if(!active_typing_indicator)
@@ -102,4 +106,3 @@
 	thinking_IC = FALSE
 	remove_thinking_indicator()
 	remove_typing_indicator()
-

--- a/code/modules/tgui/tgui-say/typing.dm
+++ b/code/modules/tgui/tgui-say/typing.dm
@@ -91,8 +91,8 @@
 	if(!thinking_IC && !override_thinking)
 		return FALSE
 	active_typing_indicator = mutable_appearance('icons/mob/effects/talk.dmi', "[bubble_icon]0", TYPING_LAYER)
-	active_thinking_indicator.pixel_x = bubble_icon_x_offset
-	active_thinking_indicator.pixel_y = bubble_icon_y_offset
+	active_typing_indicator.pixel_x = bubble_icon_x_offset
+	active_typing_indicator.pixel_y = bubble_icon_y_offset
 	overlays += active_typing_indicator
 	addtimer(CALLBACK(src, PROC_REF(remove_typing_indicator)), 30 SECONDS, TIMER_OVERRIDE|TIMER_UNIQUE|TIMER_STOPPABLE)
 

--- a/code/modules/tgui/tgui-say/typing.dm
+++ b/code/modules/tgui/tgui-say/typing.dm
@@ -73,7 +73,7 @@
 /mob/living/create_thinking_indicator()
 	if(active_thinking_indicator || active_typing_indicator || !thinking_IC || stat != CONSCIOUS )
 		return FALSE
-	active_thinking_indicator = mutable_appearance('icons/mob/effects/talk.dmi', icon_state = "[bubble_icon]3", layer = TYPING_LAYER)
+	active_thinking_indicator = mutable_appearance('icons/mob/effects/talk.dmi', "[bubble_icon]3", TYPING_LAYER)
 	active_thinking_indicator.pixel_x = bubble_icon_x_offset
 	active_thinking_indicator.pixel_y = bubble_icon_y_offset
 	overlays += active_thinking_indicator
@@ -90,7 +90,7 @@
 		return FALSE
 	if(!thinking_IC && !override_thinking)
 		return FALSE
-	active_typing_indicator = mutable_appearance('icons/mob/effects/talk.dmi', icon_state = "[bubble_icon]0", layer = TYPING_LAYER)
+	active_typing_indicator = mutable_appearance('icons/mob/effects/talk.dmi', "[bubble_icon]0", TYPING_LAYER)
 	active_thinking_indicator.pixel_x = bubble_icon_x_offset
 	active_thinking_indicator.pixel_y = bubble_icon_y_offset
 	overlays += active_typing_indicator


### PR DESCRIPTION
i HATE << so much!!!!

🆑 
fix: indicators disappear correctly on people our of your line of sight
/:cl:
