### PR TITLE
Acid splash damage nerf

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
@@ -237,7 +237,7 @@
 	var/list/tackle_counter
 	var/evolving = FALSE // Whether the xeno is in the process of evolving
 	/// The damage dealt by a xeno whenever they take damage near someone
-	var/acid_blood_damage = 25
+	var/acid_blood_damage = 12
 	var/nocrit = FALSE
 	var/deselect_timer = 0 // Much like Carbon.last_special is a short tick record to prevent accidental deselects of abilities
 

--- a/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
@@ -257,12 +257,10 @@
 		var/distance = 0 //Distance, decreases splash chance.
 		var/i = 0 //Tally up our victims.
 
-		for(var/mob/living/carbon/human/victim in orange(radius,src)) //Loop through all nearby victims, including the tile.
-			distance = get_dist(src,victim)
-
-			splash_chance = 80 - (i * 5)
-			if(victim.loc == loc) splash_chance += 30 //Same tile? BURN
-			splash_chance += distance * -15
+		for(var/mob/living/carbon/human/victim in orange(radius, src)) //Loop through all nearby victims, including the tile.
+			splash_chance = 65 - (i * 5)
+			if(victim.loc == loc)
+				splash_chance += 30 //Same tile? BURN
 			if(victim.species?.acid_blood_dodge_chance)
 				splash_chance -= victim.species.acid_blood_dodge_chance
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

nerfed acid blood splash damage back to 12

# Explain why it's good for the game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->

The change to acid blood, coupled with the introduction of other mechanics that make xenos stronger up close like tailstab, has led to a large reduction in the power of PBing - also leading to buck becoming underused and considered the weaker of the pair compared to slugs. 

PBing being harder encourages marines to sit in cades and discourages pushing, which contributes to stagnant rounds that nobody enjoys.

Therefore this PR is good for the game as it makes the comparatively weak buckshot more viable and encourages some more aggression in combat. Plus, now that xenos have tailstab, they can actively defend against PBers, rather than relying on passive acid blood damage to do it.

@ malders er marines learned how 2 dodge 

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
balance: reduced acid blood splash damage to 12 from 25
code: cleaned up a bit of code to avoid an unneeded proc call in the code that handled acid blood splashes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
