### PR TITLE
Goonify chemical retrieval

### DIFF
--- a/code/__DEFINES/job.dm
+++ b/code/__DEFINES/job.dm
@@ -155,6 +155,7 @@ var/global/list/job_command_roles = JOB_COMMAND_ROLES_LIST
 //-------- WY Goons --------//
 #define JOB_WY_GOON "WY Corporate Security"
 #define JOB_WY_GOON_LEAD "WY Corporate Security Lead"
+#define JOB_WY_GOON_RESEARCHER "WY Research Consultant"
 
 //---- Contractors ----//
 #define JOB_CONTRACTOR "VAIPO Mercenary"

--- a/code/datums/emergency_calls/goons.dm
+++ b/code/datums/emergency_calls/goons.dm
@@ -40,6 +40,23 @@
 	to_chat(M, SPAN_BOLD("You heard about the original distress signal ages ago, but you have only just gotten permission from corporate to enter the area."))
 	to_chat(M, SPAN_BOLD("Ensure no damage is incurred against Weyland-Yutani. Make sure the CL is safe."))
 
+/datum/emergency_call/goon/chem_retrieval
+	name = "Weyland-Yutani Goon (Chemical Investigation Squad)"
+	mob_max = 6
+	mob_min = 2
+	var/checked_objective = FALSE
+
+/datum/emergency_call/goon/chem_retrieval/New()
+	..()
+	dispatch_message = "[MAIN_SHIP_NAME], this is USCSS Royce. Our squad is boarding to retrieve all samples of a chemical recently scanned from your research department. You should already have received a significant sum of money for your department's discovery. In return we ask that you cooperate and provide everything related to the chemical to our retrieval team. If you do not cooperate, the team is authorized to use lethal force and terminate the research department."
+	objectives = "Secure all documents, samples and chemicals containing the property DNA_Disintegrating from [MAIN_SHIP_NAME] research department."
+
+/datum/emergency_call/goon/chem_retrieval/proc/check_objective_info()
+	if(objective_info)
+		objectives = "Secure all documents, samples and chemicals related to [objective_info] from [MAIN_SHIP_NAME] research department."
+	objectives += "Assume at least 30 units are located within the department. If they can not make more that should be all. Cooperate with the onboard CL to ensure all who know the complete recipe are kept silenced with a contract of confidentiality. All humans who have ingested the chemical must be brought back dead or alive. Viral scan is required for any humans who is suspected of ingestion. Full termination of the department is authorized if they do not cooperate, but this should be avoided UNLESS ABSOLUTELY NECESSARY. Assisting with [MAIN_SHIP_NAME] current operation is only allowed after successful retrieval and with a signed contract between the CL and acting commander of [MAIN_SHIP_NAME]."
+	checked_objective = TRUE
+
 /datum/emergency_call/goon/platoon
 	name = "Weyland-Yutani Corporate Security (Platoon)"
 	mob_min = 8

--- a/code/datums/emergency_calls/pmc.dm
+++ b/code/datums/emergency_calls/pmc.dm
@@ -58,7 +58,6 @@
 
 	addtimer(CALLBACK(GLOBAL_PROC, PROC_REF(to_chat), mob, SPAN_BOLD("Objectives:</b> [objectives]")), 1 SECONDS)
 
-
 /datum/emergency_call/pmc/print_backstory(mob/living/carbon/human/M)
 	if(isHumanStrict(M))
 		to_chat(M, SPAN_BOLD("You were born [pick(75;"in Europe", 15;"in Asia", 10;"on Mars")] to a [pick(75;"well-off", 15;"well-established", 10;"average")] family."))
@@ -88,59 +87,6 @@
 	max_smartgunners = 2
 	max_synths = 1
 
-/datum/emergency_call/pmc/chem_retrieval
-	name = "Weyland-Yutani PMC (Chemical Investigation Squad)"
-	mob_max = 6
-	mob_min = 2
-	probability = 0
-	max_medics = 2
-	max_smartgunners = 1
-	var/checked_objective = FALSE
-
-/datum/emergency_call/pmc/chem_retrieval/New()
-	..()
-	dispatch_message = "[MAIN_SHIP_NAME], this is USCSS Royce. Our squad is boarding to retrieve all samples of a chemical recently scanned from your research department. You should already have received a significant sum of money for your department's discovery. In return we ask that you cooperate and provide everything related to the chemical to our retrieval team. If you do not cooperate, the team is authorized to use lethal force and terminate the research department."
-	objectives = "Secure all documents, samples and chemicals containing the property DNA_Disintegrating from [MAIN_SHIP_NAME] research department."
-
-/datum/emergency_call/pmc/chem_retrieval/proc/check_objective_info()
-	if(objective_info)
-		objectives = "Secure all documents, samples and chemicals related to [objective_info] from [MAIN_SHIP_NAME] research department."
-	objectives += "Assume at least 30 units are located within the department. If they can not make more that should be all. Cooperate with the onboard CL to ensure all who know the complete recipe are kept silenced with a contract of confidentiality. All humans who have ingested the chemical must be brought back dead or alive. Viral scan is required for any humans who is suspected of ingestion. Full termination of the department is authorized if they do not cooperate, but this should be avoided UNLESS ABSOLUTELY NECESSARY. Assisting with [MAIN_SHIP_NAME] current operation is only allowed after successful retrieval and with a signed contract between the CL and acting commander of [MAIN_SHIP_NAME]."
-	checked_objective = TRUE
-
-/datum/emergency_call/pmc/chem_retrieval/create_member(datum/mind/M, var/turf/override_spawn_loc)
-	var/turf/spawn_loc = override_spawn_loc ? override_spawn_loc : get_spawn_point()
-
-	if(!istype(spawn_loc))
-		return //Didn't find a useable spawn point.
-
-	if(!checked_objective)
-		check_objective_info()
-
-	var/mob/living/carbon/human/H = new(spawn_loc)
-	H.key = M.key
-	if(H.client)
-		H.client.change_view(world_view_size)
-
-	if(!leader && HAS_FLAG(H.client.prefs.toggles_ert, PLAY_LEADER) && check_timelock(H.client, JOB_SQUAD_LEADER, time_required_for_job))    //First one spawned is always the leader.
-		leader = H
-		to_chat(H, SPAN_ROLE_HEADER("You are a Weyland-Yutani PMC Squad Leader!"))
-		arm_equipment(H, /datum/equipment_preset/pmc/pmc_lead_investigator, TRUE, TRUE)
-	else if(medics < max_medics && HAS_FLAG(H.client.prefs.toggles_ert, PLAY_MEDIC) && check_timelock(H.client, JOB_SQUAD_MEDIC, time_required_for_job))
-		medics++
-		to_chat(H, SPAN_ROLE_HEADER("You are a Weyland-Yutani PMC Medical Investigator!"))
-		arm_equipment(H, /datum/equipment_preset/pmc/pmc_med_investigator, TRUE, TRUE)
-	else if(heavies < max_heavies && HAS_FLAG(H.client.prefs.toggles_ert, PLAY_SMARTGUNNER) && check_timelock(H.client, JOB_SQUAD_SMARTGUN, time_required_for_job))
-		heavies++
-		to_chat(H, SPAN_ROLE_HEADER("You are a Weyland-Yutani PMC Heavy Gunner!"))
-		arm_equipment(H, /datum/equipment_preset/pmc/pmc_gunner, TRUE, TRUE)
-	else
-		to_chat(H, SPAN_ROLE_HEADER("You are a Weyland-Yutani PMC Detainer!"))
-		arm_equipment(H, /datum/equipment_preset/pmc/pmc_detainer, TRUE, TRUE)
-
-	print_backstory(H)
-
-	addtimer(CALLBACK(GLOBAL_PROC, PROC_REF(to_chat), H, SPAN_BOLD("Objectives:</b> [objectives]")), 1 SECONDS)
 /obj/effect/landmark/ert_spawns/distress_pmc
 	name = "Distress_PMC"
 

--- a/code/modules/gear_presets/wy_goons.dm
+++ b/code/modules/gear_presets/wy_goons.dm
@@ -74,6 +74,10 @@
 
 	H.equip_to_slot_or_del(new /obj/item/storage/backpack/lightpack, WEAR_BACK)
 	H.equip_to_slot_or_del(new /obj/item/weapon/melee/baton, WEAR_IN_BACK)
+	H.equip_to_slot_or_del(new /obj/item/handcuffs/zip, WEAR_IN_BACK)
+	H.equip_to_slot_or_del(new /obj/item/handcuffs/zip, WEAR_IN_BACK)
+	H.equip_to_slot_or_del(new /obj/item/handcuffs/zip, WEAR_IN_BACK)
+	H.equip_to_slot_or_del(new /obj/item/handcuffs/zip, WEAR_IN_BACK)
 	H.equip_to_slot_or_del(new /obj/item/tool/crowbar, WEAR_IN_BACK)
 	H.equip_to_slot_or_del(new /obj/item/storage/belt/gun/m4a3/mod88, WEAR_WAIST)
 	H.equip_to_slot_or_del(new /obj/item/storage/pouch/firstaid/full, WEAR_R_STORE)
@@ -103,6 +107,10 @@
 
 	H.equip_to_slot_or_del(new /obj/item/storage/backpack/lightpack, WEAR_BACK)
 	H.equip_to_slot_or_del(new /obj/item/weapon/melee/baton, WEAR_IN_BACK)
+	H.equip_to_slot_or_del(new /obj/item/handcuffs/zip, WEAR_IN_BACK)
+	H.equip_to_slot_or_del(new /obj/item/handcuffs/zip, WEAR_IN_BACK)
+	H.equip_to_slot_or_del(new /obj/item/handcuffs/zip, WEAR_IN_BACK)
+	H.equip_to_slot_or_del(new /obj/item/handcuffs/zip, WEAR_IN_BACK)
 	H.equip_to_slot_or_del(new /obj/item/tool/crowbar, WEAR_IN_BACK)
 	H.equip_to_slot_or_del(new /obj/item/storage/belt/gun/m4a3/mod88, WEAR_WAIST)
 	H.equip_to_slot_or_del(new /obj/item/storage/pouch/firstaid/full, WEAR_R_STORE)
@@ -111,3 +119,29 @@
 	H.equip_to_slot_or_del(new /obj/item/storage/pouch/magazine/large/nsg_ap, WEAR_L_STORE)
 	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/rifle/nsg23/ap, WEAR_IN_BACK)
 	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/rifle/nsg23/ap, WEAR_IN_BACK)
+
+/datum/equipment_preset/goon/researcher
+	name = "Weyland-Yutani Corporate Research Consultant (Goon Researcher)"
+	flags = EQUIPMENT_PRESET_EXTRA
+
+	assignment = JOB_WY_GOON_RESEARCHER
+	rank = JOB_WY_GOON_RESEARCHER
+	paygrade = "CCMO"
+	skills = /datum/skills/researcher
+
+/datum/equipment_preset/goon/researcher/load_gear(mob/living/carbon/human/H)
+	H.equip_to_slot_or_del(new /obj/item/device/radio/headset/distress/WY, WEAR_L_EAR)
+	H.equip_to_slot_or_del(new /obj/item/clothing/under/liaison_suit, WEAR_BODY)
+	H.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/labcoat, WEAR_JACKET)
+	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/marine/corporate, WEAR_FEET)
+
+	H.equip_to_slot_or_del(new /obj/item/storage/backpack/lightpack, WEAR_BACK)
+
+	H.equip_to_slot_or_del(new /obj/item/storage/belt/medical/lifesaver/full, WEAR_WAIST)
+
+	H.equip_to_slot_or_del(new /obj/item/storage/belt/gun/m4a3/mod88, WEAR_J_STORE)
+	H.equip_to_slot_or_del(new /obj/item/storage/pouch/medical, WEAR_R_STORE)
+	H.equip_to_slot_or_del(new /obj/item/tool/surgery/surgical_line, WEAR_IN_R_STORE)
+	H.equip_to_slot_or_del(new /obj/item/tool/surgery/synthgraft, WEAR_IN_R_STORE)
+	H.equip_to_slot_or_del(new /obj/item/device/healthanalyzer, WEAR_IN_R_STORE)
+	H.equip_to_slot_or_del(new /obj/item/storage/pouch/medkit/full_advanced, WEAR_L_STORE)

--- a/code/modules/reagents/chemistry_properties/prop_special.dm
+++ b/code/modules/reagents/chemistry_properties/prop_special.dm
@@ -96,7 +96,7 @@
 		H.contract_disease(new /datum/disease/xeno_transformation(0),1) //This is the real reason PMCs are being sent to retrieve it.
 
 /datum/chem_property/special/DNA_Disintegrating/trigger()
-	SSticker.mode.get_specific_call("Weyland-Yutani PMC (Chemical Investigation Squad)", TRUE, FALSE, holder.name)
+	SSticker.mode.get_specific_call("Weyland-Yutani Goon (Chemical Investigation Squad)", TRUE, FALSE, holder.name)
 	chemical_data.update_credits(10)
 	message_staff("The research department has discovered DNA_Disintegrating in [holder.name] adding 10 bonus tech points.")
 	var/datum/techtree/tree = GET_TREE(TREE_MARINE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Changes chemical retrieval to use goons and a new wey-yu research consultant. 

# Explain why it's good for the game

Goons have decent non-lethals and don't have huge guns that make people want to go to war instead of being normal human beings and not starting a lethal incident between the USCM and Wey-Yu. Going "loud" should be scary and having a dedicated Wey-Yu researcher come to make sure the chemicals were actually handled correctly makes sense in my brain.

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>
I did not test this.
</details>

# Changelog

:cl: Morrow
balance: Changes chemical retrieval to use goons and a wey-yu research consultant rather than PMCs.
add: Wey-yu goon presets now have zip ties.
add: Added wey-yu research consultant equipment.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
