### PR TITLE
Adds access requirement to CO's uniform vendor

### DIFF
--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -85644,7 +85644,9 @@
 /turf/open/floor/plating,
 /area/almayer/shipboard/brig/perma)
 "yeo" = (
-/obj/structure/machinery/cm_vending/clothing/dress,
+/obj/structure/machinery/cm_vending/clothing/dress{
+	req_access = list(1)
+	},
 /turf/open/floor/wood/ship,
 /area/almayer/living/commandbunks)
 "yev" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Adds access requirement to CO's uniform vendor.

# Explain why it's good for the game

Stops people from breaking the CO's wall every other round to get access to uniform vendor. Please stop. I like my wall where it is.

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>
https://user-images.githubusercontent.com/8919187/211514156-a7216962-25a2-4327-ac88-5a3cad92e158.png

This is a vendor. Thank you for expanding the testing section.

</details>


# Changelog

:cl: Morrow
maptweak: Adds access requirement to CO's uniform vendor.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
