### PR TITLE
Added a destructible terrain support for admin event panel

### DIFF
--- a/ColonialMarinesALPHA.dme
+++ b/ColonialMarinesALPHA.dme
@@ -1524,6 +1524,7 @@
 #include "code\modules\emoji\emoji_parse.dm"
 #include "code\modules\events\_events.dm"
 #include "code\modules\events\comms_blackout.dm"
+#include "code\modules\events\destructible_terrain.dm"
 #include "code\modules\fishing\bait\generic.dm"
 #include "code\modules\fishing\datums\generic.dm"
 #include "code\modules\fishing\datums\helpers.dm"

--- a/code/modules/admin/tabs/event_tab.dm
+++ b/code/modules/admin/tabs/event_tab.dm
@@ -705,6 +705,7 @@
 		<A href='?src=\ref[src];[HrefToken()];events=blackout'>Break all lights</A><BR>
 		<A href='?src=\ref[src];[HrefToken()];events=whiteout'>Repair all lights</A><BR>
 		<A href='?src=\ref[src];[HrefToken()];events=comms_blackout'>Trigger a Communication Blackout</A><BR>
+		<A href='?src=\ref[src];[HrefToken()];events=destructible_terrain'>Enable destructible terrain</A><BR>
 		<BR>
 		<B>Misc</B><BR>
 		<A href='?src=\ref[src];[HrefToken()];events=medal'>Award a medal</A><BR>

--- a/code/modules/admin/tabs/event_tab.dm
+++ b/code/modules/admin/tabs/event_tab.dm
@@ -705,7 +705,7 @@
 		<A href='?src=\ref[src];[HrefToken()];events=blackout'>Break all lights</A><BR>
 		<A href='?src=\ref[src];[HrefToken()];events=whiteout'>Repair all lights</A><BR>
 		<A href='?src=\ref[src];[HrefToken()];events=comms_blackout'>Trigger a Communication Blackout</A><BR>
-		<A href='?src=\ref[src];[HrefToken()];events=destructible_terrain'>Enable destructible terrain</A><BR>
+		<A href='?src=\ref[src];[HrefToken()];events=destructible_terrain'>Toggle destructible terrain</A><BR>
 		<BR>
 		<B>Misc</B><BR>
 		<A href='?src=\ref[src];[HrefToken()];events=medal'>Award a medal</A><BR>

--- a/code/modules/admin/topic/topic_events.dm
+++ b/code/modules/admin/topic/topic_events.dm
@@ -41,7 +41,7 @@
 			if(tgui_alert(usr, "Are you sure you want to toggle all ground-level terrain destructible?", "Confirmation", list("Yes", "No"), 20 SECONDS) != "Yes")
 				return
 			toggle_destructible_terrain()
-			message_staff("[key_name_admin(usr)] toggled destrictible terrain.")
+			message_staff("[key_name_admin(usr)] toggled destructible terrain.")
 		if("blackout")
 			if(alert(usr, "Are you sure you want to do this?", "Confirmation", "Yes", "No") != "Yes")
 				return

--- a/code/modules/admin/topic/topic_events.dm
+++ b/code/modules/admin/topic/topic_events.dm
@@ -38,10 +38,10 @@
 				communications_blackout(1)
 			message_staff("[key_name_admin(usr)] triggered a communications blackout.")
 		if("destructible_terrain")
-			if(alert(usr, "Are you sure you want to make all ground-level terrain destructible?", "Confirmation", "Yes", "No") != "Yes")
+			if(tgui_alert(usr, "Are you sure you want to toggle all ground-level terrain destructible?", "Confirmation", list("Yes", "No"), 20 SECONDS) != "Yes")
 				return
-			enable_destructible_terrain()
-			message_staff("[key_name_admin(usr)] enabled destrictible terrain.")
+			toggle_destructible_terrain()
+			message_staff("[key_name_admin(usr)] toggled destrictible terrain.")
 		if("blackout")
 			if(alert(usr, "Are you sure you want to do this?", "Confirmation", "Yes", "No") != "Yes")
 				return

--- a/code/modules/admin/topic/topic_events.dm
+++ b/code/modules/admin/topic/topic_events.dm
@@ -37,6 +37,11 @@
 			else
 				communications_blackout(1)
 			message_staff("[key_name_admin(usr)] triggered a communications blackout.")
+		if("destructible_terrain")
+			if(alert(usr, "Are you sure you want to make all ground-level terrain destructible?", "Confirmation", "Yes", "No") != "Yes")
+				return
+			enable_destructible_terrain()
+			message_staff("[key_name_admin(usr)] enabled destrictible terrain.")
 		if("blackout")
 			if(alert(usr, "Are you sure you want to do this?", "Confirmation", "Yes", "No") != "Yes")
 				return

--- a/code/modules/events/destructible_terrain.dm
+++ b/code/modules/events/destructible_terrain.dm
@@ -1,11 +1,13 @@
-//Enables destructible terrain on the ground level
-/proc/enable_destructible_terrain()
+//Toggles the destructible terrain on the ground level
+/proc/toggle_destructible_terrain()
 	var/list/turfs = get_all_of_type(/turf/closed/wall, TRUE)
 	for(var/turf/closed/wall/turf_for_editing in turfs)
-		if(turf_for_editing.z != 3)
+		if(!is_ground_level(turf_for_editing.z))
 			//We only want to edit ground turfs!
 			continue
-		if(istype(turf_for_editing, /turf/closed/shuttle))
-			//Don't edit the map boundary!
-			continue
-		turf_for_editing.hull = FALSE
+		//If the initial wall was indestructible, we toggle indestructability
+		if(initial(turf_for_editing.hull))
+			if(istype(turf_for_editing, /turf/closed/shuttle))
+				//But we don't edit the map boundary!
+				continue
+			turf_for_editing.hull = !turf_for_editing.hull

--- a/code/modules/events/destructible_terrain.dm
+++ b/code/modules/events/destructible_terrain.dm
@@ -1,0 +1,11 @@
+//Enables destructible terrain on the ground level
+/proc/enable_destructible_terrain()
+	var/list/turfs = get_all_of_type(/turf/closed/wall, TRUE)
+	for(var/turf/closed/wall/turf_for_editing in turfs)
+		if(turf_for_editing.z != 3)
+			//We only want to edit ground turfs!
+			continue
+		if(istype(turf_for_editing, /turf/closed/shuttle))
+			//Don't edit the map boundary!
+			continue
+		turf_for_editing.hull = FALSE

--- a/code/modules/events/destructible_terrain.dm
+++ b/code/modules/events/destructible_terrain.dm
@@ -7,7 +7,5 @@
 			continue
 		//If the initial wall was indestructible, we toggle indestructability
 		if(initial(turf_for_editing.hull))
-			if(istype(turf_for_editing, /turf/closed/shuttle))
-				//But we don't edit the map boundary!
-				continue
+			//Note: wall boundaries are safe since they are /turf/closed/shuttle, so not a subset of /turf/closed/wall!
 			turf_for_editing.hull = !turf_for_editing.hull


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

I've had fun a few times when the admins ran the destructible terrain event. Figured I'd make it so running the event would be really simple for anyone so we could have fun like this more often!

To use it simply go to the Event Panel and find it under Events. It converts all the ground-level walls (except the map boundaries) destructible.

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

It makes the admin job of setting up the event really simple.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
admin: Admins can now easily run the destructible terrain event using the Event Panel.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
