### PR TITLE
Fixes deploying a M2C backwards to jump through dense objects

### DIFF
--- a/code/modules/cm_marines/smartgun_mount.dm
+++ b/code/modules/cm_marines/smartgun_mount.dm
@@ -1067,6 +1067,10 @@
 	if(rotate_check.density)
 		to_chat(user, SPAN_WARNING("You can't set up \the [src] that way, there's a wall behind you!"))
 		return FALSE
+	for(var/obj/structure/potential_blocker in rotate_check)
+		if(potential_blocker.density)
+			to_chat(user, SPAN_WARNING("You can't set up \the [src] that way, there's \a [potential_blocker] behind you!"))
+			return FALSE
 	if((locate(/obj/structure/barricade) in ACR) || (locate(/obj/structure/window_frame) in ACR) || (locate(/obj/structure/window) in ACR) || (locate(/obj/structure/windoor_assembly) in ACR))
 		to_chat(user, SPAN_WARNING("There are barriers nearby, you can't set up \the [src] here!"))
 		return FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Fixes deploying a M2C backwards to jump through dense objects. I'll get around to fixing the other way.

# Explain why it's good for the game

Bug abuse bad


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>
Yup

</details>


# Changelog

:cl: Morrow
fix: Fixed deploying a M2C backwards to jump through dense objects
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
