### PR TITLE
Phone Networks (5G?)

### DIFF
--- a/code/__DEFINES/equipment.dm
+++ b/code/__DEFINES/equipment.dm
@@ -546,3 +546,9 @@ var/global/list/uniform_categories = list(
 #define RADIO_FILTER_TYPE_INTERCOM 1
 #define RADIO_FILTER_TYPE_INTERCOM_AND_BOUNCER 2
 #define RADIO_FILTER_TYPE_ANTAG_RADIOS 3
+//=================================================
+
+//=================================================
+#define PHONE_RTO "RTO"
+#define PHONE_MARINE "Marine"
+#define PHONE_UPP_SOLDIER "Soldier"

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -462,6 +462,9 @@ GLOBAL_LIST_EMPTY_TYPED(radio_packs, /obj/item/storage/backpack/marine/satchel/r
 	uniform_restricted = list(/obj/item/clothing/under/marine/rto)
 	var/obj/structure/transmitter/internal/internal_transmitter
 
+	var/phone_category = "RTO"
+	var/network_receive = FACTION_MARINE
+	var/list/networks_transmit = list(FACTION_MARINE)
 	var/base_icon
 
 /datum/action/item_action/rto_pack/use_phone/New(var/mob/living/user, var/obj/item/holder)
@@ -487,8 +490,10 @@ GLOBAL_LIST_EMPTY_TYPED(radio_packs, /obj/item/storage/backpack/marine/satchel/r
 	. = ..()
 	internal_transmitter = new(src)
 	internal_transmitter.relay_obj = src
-	internal_transmitter.phone_category = "RTO"
+	internal_transmitter.phone_category = phone_category
 	internal_transmitter.enabled = FALSE
+	internal_transmitter.network_receive = network_receive
+	internal_transmitter.networks_transmit = networks_transmit
 	RegisterSignal(internal_transmitter, COMSIG_TRANSMITTER_UPDATE_ICON, PROC_REF(check_for_ringing))
 	GLOB.radio_packs += src
 
@@ -564,15 +569,22 @@ GLOBAL_LIST_EMPTY_TYPED(radio_packs, /obj/item/storage/backpack/marine/satchel/r
 	else
 		. = ..()
 
+/obj/item/storage/backpack/marine/satchel/rto/upp_net
+	network_receive = FACTION_UPP
+	networks_transmit = list(FACTION_UPP)
+
 /obj/item/storage/backpack/marine/satchel/rto/small
 	name = "\improper USCM Small Radio Telephone Pack"
 	max_storage_space = 10
 
 	uniform_restricted = null
+	phone_category = "Marine"
 
-/obj/item/storage/backpack/marine/satchel/rto/small/Initialize()
-	. = ..()
-	internal_transmitter.phone_category = "Marine"
+
+/obj/item/storage/backpack/marine/satchel/rto/small/upp_net
+	network_receive = FACTION_UPP
+	networks_transmit = list(FACTION_UPP)
+	phone_category = "Soldier"
 
 /obj/item/storage/backpack/marine/satchel/rto/io
 	uniform_restricted = list(/obj/item/clothing/under/marine/officer/intel)

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -462,7 +462,7 @@ GLOBAL_LIST_EMPTY_TYPED(radio_packs, /obj/item/storage/backpack/marine/satchel/r
 	uniform_restricted = list(/obj/item/clothing/under/marine/rto)
 	var/obj/structure/transmitter/internal/internal_transmitter
 
-	var/phone_category = "RTO"
+	var/phone_category = PHONE_RTO
 	var/network_receive = FACTION_MARINE
 	var/list/networks_transmit = list(FACTION_MARINE)
 	var/base_icon
@@ -578,13 +578,13 @@ GLOBAL_LIST_EMPTY_TYPED(radio_packs, /obj/item/storage/backpack/marine/satchel/r
 	max_storage_space = 10
 
 	uniform_restricted = null
-	phone_category = "Marine"
+	phone_category = PHONE_MARINE
 
 
 /obj/item/storage/backpack/marine/satchel/rto/small/upp_net
 	network_receive = FACTION_UPP
 	networks_transmit = list(FACTION_UPP)
-	phone_category = "Soldier"
+	phone_category = PHONE_UPP_SOLDIER
 
 /obj/item/storage/backpack/marine/satchel/rto/io
 	uniform_restricted = list(/obj/item/clothing/under/marine/officer/intel)

--- a/code/modules/cm_phone/phone.dm
+++ b/code/modules/cm_phone/phone.dm
@@ -78,21 +78,21 @@ GLOBAL_LIST_EMPTY_TYPED(transmitters, /obj/structure/transmitter)
 /obj/structure/transmitter/proc/get_transmitters()
 	var/list/phone_list = list()
 
-	for(var/t in GLOB.transmitters)
-		var/obj/structure/transmitter/T = t
-		if(TRANSMITTER_UNAVAILABLE(T) || !T.callable) // Phone not available
+	for(var/possible_phone in GLOB.transmitters)
+		var/obj/structure/transmitter/target_phone = possible_phone
+		if(TRANSMITTER_UNAVAILABLE(target_phone) || !target_phone.callable) // Phone not available
 			continue
-		if(!(T.network_receive in networks_transmit))
+		if(!(target_phone.network_receive in networks_transmit))
 			continue
 
-		var/id = T.phone_id
+		var/id = target_phone.phone_id
 		var/num_id = 1
 		while(id in phone_list)
-			id = "[T.phone_id] [num_id]"
+			id = "[target_phone.phone_id] [num_id]"
 			num_id++
 
-		T.phone_id = id
-		phone_list[id] = T
+		target_phone.phone_id = id
+		phone_list[id] = target_phone
 
 	return phone_list
 

--- a/code/modules/cm_phone/phone.dm
+++ b/code/modules/cm_phone/phone.dm
@@ -31,6 +31,9 @@ GLOBAL_LIST_EMPTY_TYPED(transmitters, /obj/structure/transmitter)
 	var/timeout_timer_id
 	var/timeout_duration = 30 SECONDS
 
+	var/network_receive = FACTION_MARINE
+	var/list/networks_transmit = list(FACTION_MARINE)
+
 /obj/structure/transmitter/hidden
 	callable = FALSE
 
@@ -72,12 +75,14 @@ GLOBAL_LIST_EMPTY_TYPED(transmitters, /obj/structure/transmitter)
 	|| !T.enabled\
 )
 
-/proc/get_transmitters()
+/obj/structure/transmitter/proc/get_transmitters()
 	var/list/phone_list = list()
 
 	for(var/t in GLOB.transmitters)
 		var/obj/structure/transmitter/T = t
 		if(TRANSMITTER_UNAVAILABLE(T) || !T.callable) // Phone not available
+			continue
+		if(!(T.network_receive in networks_transmit))
 			continue
 
 		var/id = T.phone_id
@@ -532,6 +537,10 @@ GLOBAL_LIST_EMPTY_TYPED(transmitters, /obj/structure/transmitter)
 	UnregisterSignal(attached_to, COMSIG_MOVABLE_MOVED)
 	reset_tether()
 
+
+/obj/structure/transmitter/colony_net
+	network_receive = FACTION_COLONIST
+	networks_transmit = list(FACTION_COLONIST)
 
 //rotary desk phones (need a touch tone handset at some point)
 /obj/structure/transmitter/rotary


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request
Adds Phone Networks, by default this won't have any impact whatsoever, but it allows for mappers to use phones on colonies without giving free access to call the almayer.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Adds a little bit of realism to the phones, they're a great communicator, but I think it odd that a colony phone would be able to call the almayer. It also opens the opportunity for phones that can call eachother, and another network, but the other network can't call them.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
Tested locally, works as intended. Phones don't show up in the lists unless they share receiving network with the transmitting network.
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
add: Adds networks to phones. Phone A can only call other phones who receive one of Phone A's transmit networks.
add: RTO packs set their category on initialize via a variable rather than hardcode, allowing for customisation in maps.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
