### PR TITLE
QoL for snipers.

### DIFF
--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -709,7 +709,7 @@ GLOBAL_LIST_INIT(allowed_helmet_items, list(
 	armor_internaldamage = CLOTHING_ARMOR_MEDIUMLOW
 	flags_inventory = BLOCKSHARPOBJ
 	flags_inv_hide = HIDEEARS|HIDETOPHAIR
-	flags_marine_helmet = NO_FLAGS
+	flags_marine_helmet = HELMET_GARB_OVERLAY
 	flags_item = MOB_LOCK_ON_EQUIP
 	specialty = "M45 ghillie"
 

--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -218,7 +218,6 @@
 
 // Snipers may enable or disable their laser tracker at will.
 /datum/action/item_action/specialist/toggle_laser
-	ability_primacy = SPEC_PRIMARY_ACTION_2
 
 /datum/action/item_action/specialist/toggle_laser/New(var/mob/living/user, var/obj/item/holder)
 	..()
@@ -256,11 +255,22 @@
 	if(owner.get_held_item() != sniper_rifle)
 		to_chat(owner, SPAN_WARNING("How do you expect to do this without the sniper rifle in your hand?"))
 		return FALSE
+	sniper_rifle.toggle_laser(owner, src)
 
-	sniper_rifle.enable_aimed_shot_laser = !sniper_rifle.enable_aimed_shot_laser
-	owner.visible_message(SPAN_NOTICE("[owner] flips a switch on \the [sniper_rifle] and [sniper_rifle.enable_aimed_shot_laser ? "enables" : "disables"] its targeting laser."))
-	playsound(owner, 'sound/machines/click.ogg', 15, TRUE)
-	update_button_icon()
+/obj/item/weapon/gun/rifle/sniper/proc/toggle_laser(mob/user, var/datum/action/toggling_action)
+	enable_aimed_shot_laser = !enable_aimed_shot_laser
+	to_chat(user, SPAN_NOTICE("You flip a switch on \the [src] and [enable_aimed_shot_laser ? "enable" : "disable"] its targeting laser."))
+	playsound(user, 'sound/machines/click.ogg', 15, TRUE)
+	if(!toggling_action)
+		toggling_action = locate(/datum/action/item_action/specialist/toggle_laser) in actions
+	if(toggling_action)
+		toggling_action.update_button_icon()
+
+/obj/item/weapon/gun/rifle/sniper/toggle_burst(mob/user)
+	if(has_aimed_shot)
+		toggle_laser(user)
+	else
+		..()
 
 //Pow! Headshot.
 /obj/item/weapon/gun/rifle/sniper/M42A


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

`Spec_primary_action_2` is already taken on sniper rifle. In fact, it is taken by the very Aimed Shot that Toggle Laser modifies. You really should not be turning your laser off or on again every time you try to reenable the actual shot.
It would have made sense to introduce a `spec_primary_action_3` for it, but as it happens, no sniper rifle in code currently has both aiming laser and burst mode (SVD is technically a `/sniper` and has burst for 2, but no aimed shot/laser), so it can be conveniently bound to a spare hotkey lying around.
Also, made toggling laser a `to_chat(user)` instead of `user.visible_message()`, because when you are cloaked and enemy draws near and you want to disable giant "I AM HERE" laser beam pointing at you, you probably do not want to alert everybody around to you doing so. (Sound is still there for particularly sharpeared xenos.)
Also, somebody complained that sniper's helmet does not have a cosmetic slot. Apparently it outright does not accept cosmetics, and wherefore not? No harm done by having them, I suppose.

# Explain why it's good for the game

Is QoL.


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: Ghillie helmet is no longer exempt from having cosmetic accessories.
fix: Sniper rifle's "toggle laser" action is no longer bound to the same key as "aimed shot" action.
qol: Sniper rifle's laser can now be toggled by pressing the "toggle burst" button.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
