### PR TITLE
M79 Rail attachment sprite fix

### DIFF
--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -940,7 +940,7 @@
 	update_attachable(S.slot)
 
 /obj/item/weapon/gun/launcher/grenade/m81/m79/set_gun_attachment_offsets()
-	attachable_offset = list("muzzle_x" = 33, "muzzle_y" = 18,"rail_x" = 14, "rail_y" = 22, "under_x" = 19, "under_y" = 14, "stock_x" = 14, "stock_y" = 14)
+	attachable_offset = list("muzzle_x" = 33, "muzzle_y" = 18,"rail_x" = 9, "rail_y" = 22, "under_x" = 19, "under_y" = 14, "stock_x" = 14, "stock_y" = 14)
 
 /obj/item/weapon/gun/launcher/grenade/m81/m79/set_bullet_traits()
 	LAZYADD(traits_to_give, list(


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Moves the rail attachments sprite on the M79 farther back to be more flush with the weapon and also not utterly destroy muh immersion when opening the breach of the weapon and watching as the rail attachment via some form of black magic is able to ghost through the massive breach of the M79.  

# Explain why it's good for the game

Muh immersion at long last will no longer be broken every time I open the breach of a M79 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Before: https://gyazo.com/60b031139ad19846195260f7be241465
https://gyazo.com/060eb228d8b55b34af88b00db38484d9
https://gyazo.com/46bfdeca58285902dae5f0b9d7f890d3

After: https://gyazo.com/4418f7f566637423ac1af0ee4c370f09
https://gyazo.com/f0b7beecd609aecf0c69b4384c023c78
https://gyazo.com/255519b881359d6089638737e3e06a71


</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl: Tisx

fix: Moved the sprites of the M79's rail attachments back a few pixels to make it more flush with the weapon. 

/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
