### PR TITLE
Fix for calculating T3 playtime.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -168,11 +168,12 @@
 /// playtime for t3 castes and queen
 /client/proc/get_total_t3_playtime()
 	var/total_t3_playtime = 0
-
-	for(var/datum/caste_datum/caste as anything in RoleAuthority.castes_by_name)
+	var/datum/caste_datum/caste
+	for(var/caste_name in RoleAuthority.castes_by_name)
+		caste = RoleAuthority.castes_by_name[caste_name]
 		if(caste.tier < 3)
 			continue
-		total_t3_playtime += get_job_playtime(src, caste)
+		total_t3_playtime += get_job_playtime(src, caste_name)
 
 	return total_t3_playtime
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Followup to #2211.
> ![image](https://user-images.githubusercontent.com/4447185/212133588-a4228bc6-cba7-4ebb-a984-2b28d55c8942.png)


# Explain why it's good for the game

> ![image](https://user-images.githubusercontent.com/4447185/212133666-8c1c271f-644a-44ac-9dc1-8c9d878f186e.png)

# Testing Photographs and Procedure
> ![image](https://user-images.githubusercontent.com/4447185/212133447-b9462eff-3234-4fd6-a507-0830d01500d6.png)

# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: Queen timelock now correctly calculates playtime as T3 castes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
