### PR TITLE
Gives !localhost! rank whitelist perms

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -301,6 +301,7 @@ GLOBAL_LIST_INIT(whitelisted_client_procs, list(
 		if(isnull(address) || (address in localhost_addresses))
 			var/datum/admins/admin = new("!localhost!", R_EVERYTHING, ckey)
 			admin.associate(src)
+			RoleAuthority.roles_whitelist[ckey] = WHITELIST_EVERYTHING
 
 	//Admin Authorisation
 	admin_holder = admin_datums[ckey]


### PR DESCRIPTION
# About the pull request

Gives "!localhost!" rank all whitelists
It shouldn't affect anything on the server (hopefully?)

# Explain why it's good for the game

Makes it easier to test or experiment with whitelists on a localhost without needing to add yourself to whitelist.txt