### PR TITLE
PMC Survivor weapon lock fix

### DIFF
--- a/code/modules/gear_presets/survivors.dm
+++ b/code/modules/gear_presets/survivors.dm
@@ -1178,7 +1178,7 @@
 	name = "Survivor - PMC"
 	flags = EQUIPMENT_PRESET_START_OF_ROUND
 	assignment = "Weyland-Yutani PMC (Standard)"
-	faction = FACTION_SURVIVOR
+	faction = FACTION_PMC
 	faction_group = list(FACTION_WY, FACTION_MARINE, FACTION_SURVIVOR, FACTION_PMC)
 	rank = JOB_PMC
 	paygrade = "PMC-OP"

--- a/code/modules/gear_presets/survivors.dm
+++ b/code/modules/gear_presets/survivors.dm
@@ -1179,7 +1179,7 @@
 	flags = EQUIPMENT_PRESET_START_OF_ROUND
 	assignment = "Weyland-Yutani PMC (Standard)"
 	faction = FACTION_SURVIVOR
-	faction_group = list(FACTION_WY, FACTION_MARINE, FACTION_SURVIVOR)
+	faction_group = list(FACTION_WY, FACTION_MARINE, FACTION_SURVIVOR, FACTION_PMC)
 	rank = JOB_PMC
 	paygrade = "PMC-OP"
 	idtype = /obj/item/card/id/pmc

--- a/code/modules/gear_presets/survivors.dm
+++ b/code/modules/gear_presets/survivors.dm
@@ -1178,7 +1178,7 @@
 	name = "Survivor - PMC"
 	flags = EQUIPMENT_PRESET_START_OF_ROUND
 	assignment = "Weyland-Yutani PMC (Standard)"
-	faction = FACTION_PMC
+	faction = FACTION_SURVIVOR
 	faction_group = list(FACTION_WY, FACTION_MARINE, FACTION_SURVIVOR, FACTION_PMC)
 	rank = JOB_PMC
 	paygrade = "PMC-OP"

--- a/code/modules/projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/gun_helpers.dm
@@ -210,6 +210,11 @@ As sniper rifles have both and weapon mods can change them as well. ..() deals w
 				FACTION_MERCENARY,
 				FACTION_FREELANCER,
 			) return TRUE
+
+		for(var/faction in user.faction_group)
+			if(faction in FACTION_LIST_WY)
+				return TRUE
+
 		if(user.faction in FACTION_LIST_WY)
 			return TRUE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Fixed PMC Survivors being locked out of using PMC weapons.
Alright faction code is a mess, I tried 4-5 different ways so the weapon lock also checks for faction_group but it never worked, the only solution left was switching their main faction of survivor to PMC. they should still have survivor in the faction_group list. Unless someone has a better idea on how to make the code check for faction_group too (because I couldn't make it work with 4 different ways I did it) then this is the only way.
Fixes #2310

# Explain why it's good for the game
it's a bug fix.



# Testing Photographs and Procedure
spawned as surv pmc, gave myself NSG and checked if I could shoot, i could shoot





# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl: Unknownity
fix: PMC Survivors can now use PMC weapons.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
