### PR TITLE
Re-adds roundstart Tank, adjusts it to be an IFV rather than MBT.

### DIFF
--- a/code/game/machinery/vending/vendor_types/crew/vehicle_crew.dm
+++ b/code/game/machinery/vending/vendor_types/crew/vehicle_crew.dm
@@ -50,8 +50,7 @@
 	SIGNAL_HANDLER
 	UnregisterSignal(SSdcs, COMSIG_GLOB_VEHICLE_ORDERED)
 
-	if(istype(V, /obj/vehicle/multitile/tank))
-		selected_vehicle = "TANK"
+	selected_vehicle = "TANK"
 
 	if(istype(V, /obj/vehicle/multitile/apc))
 		available_categories &= ~(VEHICLE_ARMOR_AVAILABLE|VEHICLE_INTEGRAL_AVAILABLE) //APC lacks these, so we need to remove these flags to be able to access spare parts section
@@ -70,7 +69,7 @@
 	if(selected_vehicle == "TANK")
 		if(available_categories)
 			display_list = GLOB.cm_vending_vehicle_crew_tank
-		else
+		else //Tank stuff was tweaked to be more expensive
 			display_list = GLOB.cm_vending_vehicle_crew_tank_spare
 
 	else if(selected_vehicle == "APC")

--- a/code/game/machinery/vending/vendor_types/crew/vehicle_crew.dm
+++ b/code/game/machinery/vending/vendor_types/crew/vehicle_crew.dm
@@ -50,11 +50,13 @@
 	SIGNAL_HANDLER
 	UnregisterSignal(SSdcs, COMSIG_GLOB_VEHICLE_ORDERED)
 
-	selected_vehicle = "TANK"
+	selected_vehicle = "APC"
+	available_categories &= ~(VEHICLE_ARMOR_AVAILABLE|VEHICLE_INTEGRAL_AVAILABLE) //APC lacks these, so we need to remove these flags to be able to access spare parts section
 
-	if(istype(V, /obj/vehicle/multitile/apc))
-		available_categories &= ~(VEHICLE_ARMOR_AVAILABLE|VEHICLE_INTEGRAL_AVAILABLE) //APC lacks these, so we need to remove these flags to be able to access spare parts section
-		selected_vehicle = "APC"
+	if(istype(V, /obj/effect/vehicle_spawner/tank))
+		selected_vehicle = "TANK"
+		available_categories = (VEHICLE_ALL_AVAILABLE)
+
 
 /obj/structure/machinery/cm_vending/gear/vehicle_crew/get_listed_products(mob/user)
 	var/list/display_list = list()

--- a/code/game/machinery/vending/vendor_types/crew/vehicle_crew.dm
+++ b/code/game/machinery/vending/vendor_types/crew/vehicle_crew.dm
@@ -50,8 +50,12 @@
 	SIGNAL_HANDLER
 	UnregisterSignal(SSdcs, COMSIG_GLOB_VEHICLE_ORDERED)
 
-	selected_vehicle = "APC"
-	available_categories &= ~(VEHICLE_ARMOR_AVAILABLE|VEHICLE_INTEGRAL_AVAILABLE) //APC lacks these, so we need to remove these flags to be able to access spare parts section
+	if(istype(V, /obj/vehicle/multitile/tank))
+		selected_vehicle = "TANK"
+
+	if(istype(V, /obj/vehicle/multitile/apc))
+		available_categories &= ~(VEHICLE_ARMOR_AVAILABLE|VEHICLE_INTEGRAL_AVAILABLE) //APC lacks these, so we need to remove these flags to be able to access spare parts section
+		selected_vehicle = "APC"
 
 /obj/structure/machinery/cm_vending/gear/vehicle_crew/get_listed_products(mob/user)
 	var/list/display_list = list()
@@ -130,73 +134,62 @@ GLOBAL_LIST_INIT(cm_vending_vehicle_crew_tank, list(
 	list("LTAA-AP Minigun", 0, /obj/effect/essentials_set/tank/gatling, VEHICLE_PRIMARY_AVAILABLE, VENDOR_ITEM_REGULAR),
 
 	list("SECONDARY WEAPON", 0, null, null, null),
-	list("M92T Grenade Launcher", 0, /obj/effect/essentials_set/tank/tankgl, VEHICLE_SECONDARY_AVAILABLE, VENDOR_ITEM_REGULAR),
 	list("M56 Cupola", 0, /obj/effect/essentials_set/tank/m56cupola, VEHICLE_SECONDARY_AVAILABLE, VENDOR_ITEM_REGULAR),
 	list("LZR-N Flamer Unit", 0, /obj/effect/essentials_set/tank/tankflamer, VEHICLE_SECONDARY_AVAILABLE, VENDOR_ITEM_RECOMMENDED),
 
 	list("SUPPORT MODULE", 0, null, null, null),
-	list("Artillery Module", 0, /obj/item/hardpoint/support/artillery_module, VEHICLE_SUPPORT_AVAILABLE, VENDOR_ITEM_REGULAR),
 	list("Integrated Weapons Sensor Array", 0, /obj/item/hardpoint/support/weapons_sensor, VEHICLE_SUPPORT_AVAILABLE, VENDOR_ITEM_REGULAR),
 	list("Overdrive Enhancer", 0, /obj/item/hardpoint/support/overdrive_enhancer, VEHICLE_SUPPORT_AVAILABLE, VENDOR_ITEM_RECOMMENDED),
 
 	list("ARMOR", 0, null, null, null),
-	list("Ballistic Armor", 0, /obj/item/hardpoint/armor/ballistic, VEHICLE_ARMOR_AVAILABLE, VENDOR_ITEM_RECOMMENDED),
-	list("Caustic Armor", 0, /obj/item/hardpoint/armor/caustic, VEHICLE_ARMOR_AVAILABLE, VENDOR_ITEM_REGULAR),
-	list("Concussive Armor", 0, /obj/item/hardpoint/armor/concussive, VEHICLE_ARMOR_AVAILABLE, VENDOR_ITEM_REGULAR),
-	list("Paladin Armor", 0, /obj/item/hardpoint/armor/paladin, VEHICLE_ARMOR_AVAILABLE, VENDOR_ITEM_REGULAR),
 	list("Snowplow", 0, /obj/item/hardpoint/armor/snowplow, VEHICLE_ARMOR_AVAILABLE, VENDOR_ITEM_REGULAR),
 
 	list("TREADS", 0, null, null, null),
-	list("Reinforced Treads", 0, /obj/item/hardpoint/locomotion/treads/robust, VEHICLE_TREADS_AVAILABLE, VENDOR_ITEM_REGULAR),
 	list("Treads", 0, /obj/item/hardpoint/locomotion/treads, VEHICLE_TREADS_AVAILABLE, VENDOR_ITEM_RECOMMENDED)))
 
 GLOBAL_LIST_INIT(cm_vending_vehicle_crew_tank_spare, list(
 	list("SPARE PARTS SELECTION:", 0, null, null, null),
 
 	list("INTEGRAL PARTS", 0, null, null, null),
-	list("M34A2-A Multipurpose Turret", 500, /obj/item/hardpoint/holder/tank_turret, null, VENDOR_ITEM_REGULAR),
+	list("M34A2-A Multipurpose Turret", 1000, /obj/item/hardpoint/holder/tank_turret, null, VENDOR_ITEM_REGULAR),
 
 	list("SUPPORT AMMUNITION", 0, null, null, null),
-	list("Turret Smoke Screen Magazine", 50, /obj/item/ammo_magazine/hardpoint/turret_smoke, null, VENDOR_ITEM_REGULAR),
 
 	list("PRIMARY WEAPON", 0, null, null, null),
-	list("AC3-E Autocannon", 200, /obj/item/hardpoint/primary/autocannon, null, VENDOR_ITEM_REGULAR),
-	list("DRG-N Offensive Flamer Unit", 200, /obj/item/hardpoint/primary/flamer, null, VENDOR_ITEM_REGULAR),
-	list("LTAA-AP Minigun", 200, /obj/item/hardpoint/primary/minigun, null, VENDOR_ITEM_REGULAR),
-	list("LTB Cannon", 400, /obj/item/hardpoint/primary/cannon, null, VENDOR_ITEM_RECOMMENDED),
+	list("AC3-E Autocannon", 600, /obj/item/hardpoint/primary/autocannon, null, VENDOR_ITEM_REGULAR),
+	list("DRG-N Offensive Flamer Unit", 400, /obj/item/hardpoint/primary/flamer, null, VENDOR_ITEM_REGULAR),
+	list("LTAA-AP Minigun", 500, /obj/item/hardpoint/primary/minigun, null, VENDOR_ITEM_REGULAR),
 
 	list("PRIMARY AMMUNITION", 0, null, null, null),
-	list("AC3-E Autocannon Magazine", 100, /obj/item/ammo_magazine/hardpoint/ace_autocannon, null, VENDOR_ITEM_REGULAR),
-	list("DRG-N Offensive Flamer Unit Fuel Tank", 100, /obj/item/ammo_magazine/hardpoint/primary_flamer, null, VENDOR_ITEM_REGULAR),
-	list("LTAA-AP Minigun Magazine", 100, /obj/item/ammo_magazine/hardpoint/ltaaap_minigun, null, VENDOR_ITEM_REGULAR),
-	list("LTB Cannon Magazine", 100, /obj/item/ammo_magazine/hardpoint/ltb_cannon, null, VENDOR_ITEM_REGULAR),
+	list("AC3-E Autocannon Magazine", 300, /obj/item/ammo_magazine/hardpoint/ace_autocannon, null, VENDOR_ITEM_REGULAR),
+	list("DRG-N Offensive Flamer Unit Fuel Tank", 200, /obj/item/ammo_magazine/hardpoint/primary_flamer, null, VENDOR_ITEM_REGULAR),
+	list("LTAA-AP Minigun Magazine", 200, /obj/item/ammo_magazine/hardpoint/ltaaap_minigun, null, VENDOR_ITEM_REGULAR),
 
 	list("SECONDARY WEAPON", 0, null, null, null),
-	list("M92T Grenade Launcher", 200, /obj/item/hardpoint/secondary/grenade_launcher, null, VENDOR_ITEM_REGULAR),
-	list("M56 Cupola", 200, /obj/item/hardpoint/secondary/m56cupola, null, VENDOR_ITEM_REGULAR),
-	list("LZR-N Flamer Unit", 200, /obj/item/hardpoint/secondary/small_flamer, null, VENDOR_ITEM_REGULAR),
-	list("TOW Launcher", 300, /obj/item/hardpoint/secondary/towlauncher, null, VENDOR_ITEM_REGULAR),
+	list("M92T Grenade Launcher", 800, /obj/item/hardpoint/secondary/grenade_launcher, null, VENDOR_ITEM_REGULAR),
+	list("M56 Cupola", 400, /obj/item/hardpoint/secondary/m56cupola, null, VENDOR_ITEM_REGULAR),
+	list("LZR-N Flamer Unit", 400, /obj/item/hardpoint/secondary/small_flamer, null, VENDOR_ITEM_REGULAR),
+	list("TOW Launcher", 1000, /obj/item/hardpoint/secondary/towlauncher, null, VENDOR_ITEM_REGULAR),
 
 	list("SECONDARY AMMUNITION", 0, null, null, null),
-	list("M92T Grenade Launcher Magazine", 50, /obj/item/ammo_magazine/hardpoint/tank_glauncher, null, VENDOR_ITEM_REGULAR),
-	list("M56 Cupola Magazine", 50, /obj/item/ammo_magazine/hardpoint/m56_cupola, null, VENDOR_ITEM_REGULAR),
-	list("LZR-N Flamer Unit Fuel Tank", 50, /obj/item/ammo_magazine/hardpoint/secondary_flamer, null, VENDOR_ITEM_REGULAR),
-	list("TOW Launcher Magazine", 50, /obj/item/ammo_magazine/hardpoint/towlauncher, null, VENDOR_ITEM_REGULAR),
+	list("M92T Grenade Launcher Magazine", 300, /obj/item/ammo_magazine/hardpoint/tank_glauncher, null, VENDOR_ITEM_REGULAR),
+	list("M56 Cupola Magazine", 100, /obj/item/ammo_magazine/hardpoint/m56_cupola, null, VENDOR_ITEM_REGULAR),
+	list("LZR-N Flamer Unit Fuel Tank", 100, /obj/item/ammo_magazine/hardpoint/secondary_flamer, null, VENDOR_ITEM_REGULAR),
+	list("TOW Launcher Magazine", 400, /obj/item/ammo_magazine/hardpoint/towlauncher, null, VENDOR_ITEM_REGULAR),
 
 	list("SUPPORT MODULE", 0, null, null, null),
-	list("Artillery Module", 300, /obj/item/hardpoint/support/artillery_module, null, VENDOR_ITEM_REGULAR),
-	list("Integrated Weapons Sensor Array", 200, /obj/item/hardpoint/support/weapons_sensor, null, VENDOR_ITEM_REGULAR),
-	list("Overdrive Enhancer", 200, /obj/item/hardpoint/support/overdrive_enhancer, null, VENDOR_ITEM_REGULAR),
+	list("Integrated Weapons Sensor Array", 400, /obj/item/hardpoint/support/weapons_sensor, null, VENDOR_ITEM_REGULAR),
+	list("Overdrive Enhancer", 400, /obj/item/hardpoint/support/overdrive_enhancer, null, VENDOR_ITEM_REGULAR),
 
 	list("ARMOR", 0, null, null, null),
-	list("Ballistic Armor", 300, /obj/item/hardpoint/armor/ballistic, null, VENDOR_ITEM_REGULAR),
-	list("Caustic Armor", 300, /obj/item/hardpoint/armor/caustic, null, VENDOR_ITEM_REGULAR),
-	list("Concussive Armor", 300, /obj/item/hardpoint/armor/concussive, null, VENDOR_ITEM_REGULAR),
-	list("Paladin Armor", 300, /obj/item/hardpoint/armor/paladin, null, VENDOR_ITEM_REGULAR),
-	list("Snowplow", 200, /obj/item/hardpoint/armor/snowplow, null, VENDOR_ITEM_REGULAR),
+	list("Ballistic Armor", 1000, /obj/item/hardpoint/armor/ballistic, null, VENDOR_ITEM_REGULAR),
+	list("Caustic Armor", 1000, /obj/item/hardpoint/armor/caustic, null, VENDOR_ITEM_REGULAR),
+	list("Concussive Armor", 1000, /obj/item/hardpoint/armor/concussive, null, VENDOR_ITEM_REGULAR),
+	list("Paladin Armor", 1000, /obj/item/hardpoint/armor/paladin, null, VENDOR_ITEM_REGULAR),
+	list("Snowplow", 400, /obj/item/hardpoint/armor/snowplow, null, VENDOR_ITEM_REGULAR),
 
 	list("TREADS", 0, null, null, null),
-	list("Reinforced Treads", 200, /obj/item/hardpoint/locomotion/treads/robust, null, VENDOR_ITEM_REGULAR),
+	list("Reinforced Treads", 400, /obj/item/hardpoint/locomotion/treads/robust, null, VENDOR_ITEM_REGULAR),
 	list("Treads", 200, /obj/item/hardpoint/locomotion/treads, null, VENDOR_ITEM_REGULAR)))
 
 GLOBAL_LIST_INIT(cm_vending_vehicle_crew_apc, list(

--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -987,7 +987,7 @@ var/datum/controller/supply/supply_controller = new()
 	circuit = /obj/item/circuitboard/computer/supplycomp/vehicle
 	// Can only retrieve one vehicle per round
 	var/spent = FALSE
-	var/tank_unlocked = FALSE
+	var/tank_unlocked = TRUE
 	var/list/allowed_roles = list(JOB_CREWMAN)
 
 	var/list/vehicles
@@ -1030,7 +1030,8 @@ var/datum/controller/supply/supply_controller = new()
 	vehicles = list(
 		new/datum/vehicle_order/apc(),
 		new/datum/vehicle_order/apc/med(),
-		new/datum/vehicle_order/apc/cmd()
+		new/datum/vehicle_order/apc/cmd(),
+		new/datum/vehicle_order/tank()
 	)
 
 	if(!VehicleElevatorConsole)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

This PR re-adds the tank in a heavily nerfed configuration, this is to bring it more in-line to beeing less an MBT and more a light tank, specifically an IFV, which, while an Infantry Fighting Vehicle, can be called a light tank. This PR removes the LTB cannon from being accessible, and moves many of the more high-tier weapons and armor into the spare parts section, as well as increasing the spare parts point prices considerably.

# Explain why it's good for the game

When Geeves TM'd the tank previously with access to only the autocannon, I personally thought it was interesting, and I thought it added a little bit of variety and better offensive (ie. Support by Fire) roles to the Vehicle Crewmen. Since Geeves is no longer developing for CMSS13, this idea of the tank being a more, IFV-like vehicle would have remained dead. My objective with this PR was to provide more variety to the VC role, and allow a new generation of tankers to learn and enjoy the vehicle as was possible in the older days of CM (which I myself never experienced.)

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>I had a few challenges with this code but as it stands now, the vehicle spawner is hardcoded with the selected_vehicle variable being connected to the APC as the way it checks to change the variable to the tank is using if(istype(V, /obj/effect/vehicle_spawner/tank)) which, if the inverse we done, I would need to make 3 separate checks for each APC variant as they are not sub-typed. The code works properly, when the tank is spawned the variable flips to be selected_vehicle = tank, which allows the tank parts to be seen, selected, and spawned.</summary>

https://i.imgur.com/JPSeuO4.png
https://i.imgur.com/EiXvEHv.png

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:LynxSolstice
add: Re-added the tank as a spawnable vehicle at roundstart.
del: Deleted the tank cannon from being spawnable.
balance: Moved many of the tank items to spare parts, increased the price of these objects in order to make them harder to access, will require a lot of points.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
