### PR TITLE
Nerfs omnisentries by reducing their ammo capacity, damage and cost.

### DIFF
--- a/code/modules/cm_marines/dropship_ammo.dm
+++ b/code/modules/cm_marines/dropship_ammo.dm
@@ -405,7 +405,7 @@
 	max_ammo_count = 1
 	ammo_name = "area denial sentry"
 	travelling_time = 0 // handled by droppod
-	point_cost = 600
+	point_cost = 500
 	accuracy_range = 0 // pinpoint
 	max_inaccuracy = 0
 

--- a/code/modules/defenses/sentry.dm
+++ b/code/modules/defenses/sentry.dm
@@ -519,6 +519,7 @@
 	name = "\improper UA 571-O sentry post"
 	desc = "A deployable, omni-directional automated turret with AI targeting capabilities. Armed with an M30 Autocannon and a 1500-round drum magazine.  Due to the deployment method it is incapable of being moved."
 	ammo = new /obj/item/ammo_magazine/sentry/dropped
+	damage_mult = 0.85
 	faction_group = FACTION_LIST_MARINE
 	omni_directional = TRUE
 	immobile = TRUE

--- a/code/modules/projectiles/magazines/sentries.dm
+++ b/code/modules/projectiles/magazines/sentries.dm
@@ -11,7 +11,7 @@
 	gun_type = null
 
 /obj/item/ammo_magazine/sentry/dropped
-	max_rounds = 1500
+	max_rounds = 300
 
 /obj/item/ammo_magazine/sentry/premade
 	max_rounds = 99999


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Omnisentries are barely used right now, but when they are used they are immensely spammable death beams with 1500 ammo. This change will make them slightly weaker, have far less ammo but will also be overall cheaper. 
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

This should let more people enjoy the omnisentry- xenos and marines. Most omnisentries are already surrounded by wired metal cades, so this should reduce their overall uptime as well as making them what they were meant to be: a _temporary_ defense tool rather than an unkillable pillbox.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
balance: nerfed the omnisentry's damage and ammo pool, made it slightly cheaper
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
