### PR TITLE
fixes omnisentry stacking glitch

### DIFF
--- a/code/modules/cm_tech/droppod/droppod.dm
+++ b/code/modules/cm_tech/droppod/droppod.dm
@@ -157,6 +157,9 @@
 	for(var/obj/structure/structure in loc)
 		structure.update_health(-land_damage)
 
+	for(var/obj/structure/machinery/defenses/sentry/launchable in loc)
+		qdel(launchable)
+
 	for(var/mob/mob in view(7, loc))
 		shake_camera(mob, 4, 5)
 

--- a/code/modules/cm_tech/droppod/droppod.dm
+++ b/code/modules/cm_tech/droppod/droppod.dm
@@ -157,8 +157,8 @@
 	for(var/obj/structure/structure in loc)
 		structure.update_health(-land_damage)
 
-	for(var/obj/structure/machinery/defenses/sentry/launchable in loc)
-		qdel(launchable)
+	for(var/obj/structure/machinery/defenses/def in loc)
+		qdel(def)
 
 	for(var/mob/mob in view(7, loc))
 		shake_camera(mob, 4, 5)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

This should fix the exploit of stacking multiple omnisentries on the same spot. If any issues crop up or it doesn't work like I intended, please let me know.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

Omnisentry stacking bad! It's an incredibly blatant exploit that makes certain areas straightup instant death for anyone who wants to be in it.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->


# Testing Photographs and Procedure

Spawned in some launch bays, launched 2 sentries at the same flare, only 1 sentry remained.


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: fixed omnisentry stacking
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
