### PR TITLE
"Reset Human Name" now updates the crew manifest too

### DIFF
--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -226,10 +226,13 @@ GLOBAL_DATUM_INIT(data_core, /datum/datacore, new)
 	if(foundrecord)
 		if(assignment)
 			foundrecord.fields["rank"] = assignment
-		if (rank)
+		if(rank)
 			foundrecord.fields["real_rank"] = rank
-		if (p_stat)
+		if(p_stat)
 			foundrecord.fields["p_stat"] = p_stat
+		if(!use_name)
+			if(name)
+				foundrecord.fields["name"] = name
 		return TRUE
 	return FALSE
 

--- a/code/modules/admin/player_panel/actions/punish.dm
+++ b/code/modules/admin/player_panel/actions/punish.dm
@@ -186,10 +186,12 @@
 			return
 		if("No")
 			new_name = random_name(target_mob.gender)
+			GLOB.data_core.manifest_modify(new_name, WEAKREF(target_mob))
 		if("Yes")
 			var/raw_name = input(user, "Choose the new name:", "Name Input")  as text|null
 			if(!isnull(raw_name)) // Check to ensure that the user entered text (rather than cancel.)
 				new_name = reject_bad_name(raw_name)
+				GLOB.data_core.manifest_modify(new_name, WEAKREF(target_mob))
 
 	if(!new_name)
 		to_chat(user, SPAN_NOTICE("Invalid name. The name should be at least 2 and at most [MAX_NAME_LEN] characters long. It may only contain the characters A-Z, a-z, -, ' and ."))

--- a/code/modules/admin/player_panel/actions/punish.dm
+++ b/code/modules/admin/player_panel/actions/punish.dm
@@ -190,7 +190,6 @@
 			var/raw_name = input(user, "Choose the new name:", "Name Input")  as text|null
 			if(!isnull(raw_name)) // Check to ensure that the user entered text (rather than cancel.)
 				new_name = reject_bad_name(raw_name)
-				
 
 	if(!new_name)
 		to_chat(user, SPAN_NOTICE("Invalid name. The name should be at least 2 and at most [MAX_NAME_LEN] characters long. It may only contain the characters A-Z, a-z, -, ' and ."))

--- a/code/modules/admin/player_panel/actions/punish.dm
+++ b/code/modules/admin/player_panel/actions/punish.dm
@@ -186,12 +186,11 @@
 			return
 		if("No")
 			new_name = random_name(target_mob.gender)
-			GLOB.data_core.manifest_modify(new_name, WEAKREF(target_mob))
 		if("Yes")
 			var/raw_name = input(user, "Choose the new name:", "Name Input")  as text|null
 			if(!isnull(raw_name)) // Check to ensure that the user entered text (rather than cancel.)
 				new_name = reject_bad_name(raw_name)
-				GLOB.data_core.manifest_modify(new_name, WEAKREF(target_mob))
+				
 
 	if(!new_name)
 		to_chat(user, SPAN_NOTICE("Invalid name. The name should be at least 2 and at most [MAX_NAME_LEN] characters long. It may only contain the characters A-Z, a-z, -, ' and ."))
@@ -206,6 +205,7 @@
 		return
 
 	target_mob.change_real_name(target_mob, new_name)
+	GLOB.data_core.manifest_modify(new_name, WEAKREF(target_mob))
 	if(ishuman(target_mob))
 		var/mob/living/carbon/human/target_human = target_mob
 		if(target_human.wear_id && target_human.wear_id.registered_ref == WEAKREF(target_human))


### PR DESCRIPTION
# About the pull request

When randomizing or picking a new name on human name reset, it will update the crew manifest as well, always good to have it up to date.

# Explain why it's good for the game

People keep asking about weird names in the manifest that have already been changed

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://user-images.githubusercontent.com/56142455/212803744-b02aadbe-6dbd-47a8-b01e-d7ceed07d3be.png)
![image](https://user-images.githubusercontent.com/56142455/212803754-eed1083b-dd57-4f75-9ad6-18b23f8fd1d1.png)
![image](https://user-images.githubusercontent.com/56142455/212803832-62031b47-655d-495c-8df9-02a0a19ab2bf.png)

</details>

# Changelog
:cl:
admin: Resetting Human Names from the player panel updates the crew manifest
/:cl: