### PR TITLE
Makes omnisentries act on battery life as well as makes them rotate

### DIFF
--- a/code/modules/defenses/sentry.dm
+++ b/code/modules/defenses/sentry.dm
@@ -21,7 +21,8 @@
 
 	var/omni_directional = FALSE
 	var/sentry_range = SENTRY_RANGE
-
+	var/has_lifespan = FALSE //Used for omnisentry lifespan.
+	var/lifespan = 0 //See above.
 	var/damage_mult = 1
 	var/accuracy_mult = 1
 	handheld_type = /obj/item/defenses/handheld/sentry
@@ -60,6 +61,10 @@
 
 	if(!target && targets.len)
 		target = pick(targets)
+	if(has_lifespan == TRUE)
+		src.lifespan = src.lifespan-1
+		if(src.lifespan <= 0)
+			handle_empty()
 
 	get_target(target)
 	return TRUE
@@ -107,6 +112,8 @@
 
 /obj/structure/machinery/defenses/sentry/get_examine_text(mob/user)
 	. = ..()
+	if(has_lifespan == TRUE)
+		. += SPAN_NOTICE("[src] has [lifespan] second\s remaining on its battery.")
 	if(ammo)
 		. += SPAN_NOTICE("[src] has [ammo.current_rounds]/[ammo.max_rounds] round\s loaded.")
 	else
@@ -228,6 +235,8 @@
 		addtimer(CALLBACK(src, PROC_REF(get_target)), fire_delay)
 
 /obj/structure/machinery/defenses/sentry/proc/actual_fire(var/atom/A)
+	if (has_lifespan == TRUE)
+		lifespan = lifespan - 5 //change this if need be
 	var/obj/item/projectile/P = new(src, create_cause_data(initial(name), owner_mob, src))
 	P.generate_bullet(new ammo.default_ammo)
 	P.damage *= damage_mult
@@ -519,10 +528,12 @@
 
 /obj/structure/machinery/defenses/sentry/launchable
 	name = "\improper UA 571-O sentry post"
-	desc = "A deployable, omni-directional automated turret with AI targeting capabilities. Armed with an M30 Autocannon and a 1500-round drum magazine.  Due to the deployment method it is incapable of being moved."
+	desc = "A deployable, omni-directional automated turret with AI targeting capabilities. Armed with an M30 Autocannon and a 500-round drum magazine.  Due to the deployment method it is incapable of being moved and has a 5-minute battery life."
 	ammo = new /obj/item/ammo_magazine/sentry/dropped
 	faction_group = FACTION_LIST_MARINE
 	omni_directional = TRUE
+	has_lifespan = TRUE
+	lifespan = 300
 	immobile = TRUE
 	static = TRUE
 	var/obj/structure/machinery/camera/cas/linked_cam

--- a/code/modules/defenses/sentry.dm
+++ b/code/modules/defenses/sentry.dm
@@ -217,9 +217,11 @@
 	if(QDELETED(owner_mob))
 		owner_mob = src
 
-	if(omni_directional)
-		setDir(get_dir(src, A))
-
+	if(omni_directional && (dir != get_cardinal_dir(src, A))) //thanks to carlarc for the bulk of this -newyearnearmeUWU
+		setDir(get_cardinal_dir(src, A))
+		playsound(loc, 'sound/mecha/mechturn.ogg', 50, 1)
+		last_fired = world.time + 0.5 SECONDS
+		return
 	actual_fire(A)
 
 	if(targets.len)

--- a/code/modules/defenses/sentry.dm
+++ b/code/modules/defenses/sentry.dm
@@ -18,11 +18,11 @@
 	var/obj/item/ammo_magazine/ammo = new /obj/item/ammo_magazine/sentry
 	var/sentry_type = "sentry" //Used for the icon
 	display_additional_stats = TRUE
-
 	var/omni_directional = FALSE
 	var/sentry_range = SENTRY_RANGE
 	var/has_lifespan = FALSE //Used for omnisentry lifespan.
 	var/lifespan = 0 //See above.
+	var/fire_drain = 3 //This drains 3 seconds per shot
 	var/damage_mult = 1
 	var/accuracy_mult = 1
 	handheld_type = /obj/item/defenses/handheld/sentry
@@ -62,8 +62,8 @@
 	if(!target && targets.len)
 		target = pick(targets)
 	if(has_lifespan == TRUE)
-		src.lifespan = src.lifespan-1
-		if(src.lifespan <= 0)
+		lifespan =- 1
+		if(lifespan <= 0)
 			handle_empty()
 
 	get_target(target)
@@ -236,7 +236,7 @@
 
 /obj/structure/machinery/defenses/sentry/proc/actual_fire(var/atom/A)
 	if (has_lifespan == TRUE)
-		lifespan = lifespan - 5 //change this if need be
+		lifespan =- fire_drain
 	var/obj/item/projectile/P = new(src, create_cause_data(initial(name), owner_mob, src))
 	P.generate_bullet(new ammo.default_ammo)
 	P.damage *= damage_mult
@@ -533,7 +533,7 @@
 	faction_group = FACTION_LIST_MARINE
 	omni_directional = TRUE
 	has_lifespan = TRUE
-	lifespan = 300
+	lifespan = 600 //10 minutes of *passive* lifetime
 	immobile = TRUE
 	static = TRUE
 	var/obj/structure/machinery/camera/cas/linked_cam

--- a/code/modules/projectiles/magazines/sentries.dm
+++ b/code/modules/projectiles/magazines/sentries.dm
@@ -11,7 +11,7 @@
 	gun_type = null
 
 /obj/item/ammo_magazine/sentry/dropped
-	max_rounds = 250
+	max_rounds = 500
 
 /obj/item/ammo_magazine/sentry/premade
 	max_rounds = 99999

--- a/code/modules/projectiles/magazines/sentries.dm
+++ b/code/modules/projectiles/magazines/sentries.dm
@@ -11,7 +11,7 @@
 	gun_type = null
 
 /obj/item/ammo_magazine/sentry/dropped
-	max_rounds = 1500
+	max_rounds = 250
 
 /obj/item/ammo_magazine/sentry/premade
 	max_rounds = 99999


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request
 
This PR nerfs omnisentries down to 500 rounds per sentry and makes them rotate. Each time they rotate, they have a delay, so that faster castes can outmaneuver it. Thanks to @carlarctg for da help with rotating.

It also adds a timed life for the sentries so that they are emphasized as _temporary_ field assets. Each shot reduces the battery life (10 minutes) by 3 seconds as of writing, and you can save battery by turning the sentry off. As they say, use it or lose it.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Omnisentries are a pain to fight for most castes because of the fact that they're usually hidden in 1x1 wired cade boxes. They also have an _absurd_ 1500 ammo pool, which makes no sense. Why are airdroppable sentries carrying 3x more than the default ones comtechs use? Plus, it looks really cool, and emphasizes their role as positional harassment vs instant death laser pillboxes that you need a T3 to deal with. The limited lifespan also incentivizes smart placement of them versus simply using them as the previously-stated instant death laser pillboxes, while providing a means of counterplay to xenos- each shot takes 5 seconds off the battery life.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
balance: omnisentries now rotate, have 500 rounds total, and have a 5 minute lifespan. Each shot reduces that lifespan by 5 seconds.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
