### PR TITLE
Fixes rank board/pin runtime

### DIFF
--- a/code/modules/clothing/under/rank_pins.dm
+++ b/code/modules/clothing/under/rank_pins.dm
@@ -5,7 +5,7 @@
 	desc = "A set of rank pins, used to denote the paygrade of someone within the military."
 	icon_state = "ranks_enlisted"
 	var/rank = "Private"
-	var/rank_short = "E1"
+	var/rank_short = "ME1"
 	slot = ACCESSORY_SLOT_RANK
 	high_visibility = TRUE
 	gender = PLURAL
@@ -14,131 +14,130 @@
 /obj/item/clothing/accessory/ranks/New()
 	..()
 	name = "[initial(name)] ([rank_short])"
-	desc = "[initial(desc)] This one is for the rank <b>[get_paygrades(rank_short, 1)]</b>"
+	desc = "[initial(desc)] This one is for the rank <b>[get_paygrades(rank_short)]</b>"
 
 /*################################################
 ################ MARINE  ###################
 ################################################*/
 //ENLISTED
 /obj/item/clothing/accessory/ranks/marine/e1
-	rank_short = "E1"
 
 /obj/item/clothing/accessory/ranks/marine/e2
-	rank_short = "E2"
+	rank_short = "ME2"
 
 /obj/item/clothing/accessory/ranks/marine/e3
-	rank_short = "E3"
+	rank_short = "ME3"
 
 /obj/item/clothing/accessory/ranks/marine/e4
-	rank_short = "E4"
+	rank_short = "ME4"
 	icon_state = "ranks_nco"
 
 /obj/item/clothing/accessory/ranks/marine/e5
-	rank_short = "E5"
+	rank_short = "ME5"
 	icon_state = "ranks_nco"
 
 /obj/item/clothing/accessory/ranks/marine/e6
-	rank_short = "E6"
+	rank_short = "ME6"
 	icon_state = "ranks_snco"
 
 /obj/item/clothing/accessory/ranks/marine/e7
-	rank_short = "E7"
+	rank_short = "ME7"
 	icon_state = "ranks_snco"
 
 /obj/item/clothing/accessory/ranks/marine/e8
-	rank_short = "E8"
+	rank_short = "ME8"
 	icon_state = "ranks_snco"
 
 /obj/item/clothing/accessory/ranks/marine/e8e
-	rank_short = "E8E"
+	rank_short = "ME8E"
 	icon_state = "ranks_snco"
 
 /obj/item/clothing/accessory/ranks/marine/e9
-	rank_short = "E9"
+	rank_short = "ME9"
 	icon_state = "ranks_snco"
 
 /obj/item/clothing/accessory/ranks/marine/e9e
-	rank_short = "E9E"
+	rank_short = "ME9E"
 	icon_state = "ranks_snco"
 
 /obj/item/clothing/accessory/ranks/marine/e9c
-	rank_short = "E9C"
+	rank_short = "ME9C"
 	icon_state = "ranks_snco"
 
 /obj/item/clothing/accessory/ranks/marine/e10c
-	rank_short = "E10C"
+	rank_short = "ME10C"
 	icon_state = "ranks_snco"
 	icon_state = "ranks_snco"
 
 //OFFICERS
 /obj/item/clothing/accessory/ranks/marine/o1
 	name = "rank boards"
-	rank_short = "O1"
+	rank_short = "MO1"
 	icon_state = "ranks_officer"
 
 /obj/item/clothing/accessory/ranks/marine/o2
 	name = "rank boards"
-	rank_short = "O2"
+	rank_short = "MO2"
 	icon_state = "ranks_officer"
 
 /obj/item/clothing/accessory/ranks/marine/o3
 	name = "rank boards"
-	rank_short = "O3"
+	rank_short = "MO3"
 	icon_state = "ranks_officer"
 
 /obj/item/clothing/accessory/ranks/marine/o4
 	name = "rank boards"
-	rank_short = "O4"
+	rank_short = "MO4"
 	icon_state = "ranks_seniorofficer"
 
 /obj/item/clothing/accessory/ranks/marine/o5
 	name = "rank boards"
-	rank_short = "O5"
+	rank_short = "MO5"
 	icon_state = "ranks_seniorofficer"
 
 /obj/item/clothing/accessory/ranks/marine/o6
 	name = "rank boards"
-	rank_short = "M6"
+	rank_short = "MO6"
 	icon_state = "ranks_seniorofficer"
 
 /obj/item/clothing/accessory/ranks/marine/o6e
 	name = "rank boards"
-	rank_short = "O6E"
+	rank_short = "MO6E"
 	icon_state = "ranks_seniorofficer"
 
 /obj/item/clothing/accessory/ranks/marine/o6c
 	name = "rank boards"
-	rank_short = "O6C"
+	rank_short = "MO6C"
 	icon_state = "ranks_flagofficer"
 
 /obj/item/clothing/accessory/ranks/marine/o7
 	name = "rank boards"
-	rank_short = "O7"
+	rank_short = "MO7"
 	icon_state = "ranks_flagofficer"
 
 /obj/item/clothing/accessory/ranks/marine/o8
 	name = "rank boards"
-	rank_short = "O8"
+	rank_short = "MO8"
 	icon_state = "ranks_flagofficer"
 
 /obj/item/clothing/accessory/ranks/marine/o9
 	name = "rank boards"
-	rank_short = "O9"
+	rank_short = "MO9"
 	icon_state = "ranks_flagofficer"
 
 /obj/item/clothing/accessory/ranks/marine/o10
 	name = "rank boards"
-	rank_short = "O10"
+	rank_short = "MO10"
 	icon_state = "ranks_flagofficer"
 
 /obj/item/clothing/accessory/ranks/marine/o10c
 	name = "rank boards"
-	rank_short = "O10C"
+	rank_short = "MO10C"
 	icon_state = "ranks_flagofficer"
 
 /obj/item/clothing/accessory/ranks/marine/o10s
 	name = "rank boards"
-	rank_short = "O10S"
+	rank_short = "MO10S"
 	icon_state = "ranks_flagofficer"
 
 /*################################################

--- a/code/modules/clothing/under/rank_pins.dm
+++ b/code/modules/clothing/under/rank_pins.dm
@@ -14,7 +14,7 @@
 /obj/item/clothing/accessory/ranks/New()
 	..()
 	name = "[initial(name)] ([rank_short])"
-	desc = "[initial(desc)] This one is for the rank <b>[get_paygrades(rank_short)]</b>"
+	desc = "[initial(desc)] This one is for the rank <b>[get_paygrades(rank_short)]</b>."
 
 /*################################################
 ################ MARINE  ###################


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Fixes rank board/pin runtime which was caused when internal paygrade codes were changed without changing the corresponding rank pins/boards and made finding the rank for the custom description impossible.

Also made it display the full name of the rank instead of just the prefix in the description.

# Explain why it's good for the game

Bug bad, clearly displayed information is good


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>
Tested (mostly)

</details>


# Changelog

:cl: Morrow
fix: Fixes rank board/pin runtime.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
