### PR TITLE
Fix for launching hijack.

### DIFF
--- a/code/modules/shuttles/shuttle_console.dm
+++ b/code/modules/shuttles/shuttle_console.dm
@@ -272,7 +272,7 @@ GLOBAL_LIST_EMPTY(shuttle_controls)
 				if(crash_target == "Cancel")
 					return
 
-				var/i = tgui_alert("Warning: Once you launch the shuttle you will not be able to bring it back. Confirm anyways?", "WARNING", list("Yes", "No"))
+				var/i = tgui_alert(Q, "Warning: Once you launch the shuttle you will not be able to bring it back. Confirm anyways?", "WARNING", list("Yes", "No"))
 				if(i != "Yes")
 					return
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Followup to #2205. Byond's own `alert()` might be smart enough to open its definition with `(Usr = usr`, but the fancy UI alert you kids have these days will not be that smart without explicitly named arguments.

# Explain why it's good for the game

This precept explains itself.

# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: Queen once again can actually launch a hijacked dropship on crash course.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
