### PR TITLE
fixes the ahelp fallback button

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -108,6 +108,11 @@ GLOBAL_LIST_INIT(whitelisted_client_procs, list(
 	if(href_list["reload_statbrowser"])
 		stat_panel.reinitialize()
 
+	// TGUIless adminhelp
+	if(href_list["tguiless_adminhelp"])
+		no_tgui_adminhelp(input(src, "Enter your ahelp", "Ahelp") as null|message)
+		return
+
 	//byond bug ID:2256651
 	if (asset_cache_job && (asset_cache_job in completed_asset_jobs))
 		to_chat(src, "<span class='danger'>An error has been detected in how your client is receiving resources. Attempting to correct.... (If you keep seeing these messages you might want to close byond and reconnect)</span>")


### PR DESCRIPTION
when browsers die for whatever reason, this button is presented to chat - but it doesn't have a topic to execute. this fixes that

:cl:
fix: fixes the ahelp fallback chat button
/:cl:

