### PR TITLE
Lower possible PMC snipers

### DIFF
--- a/code/datums/emergency_calls/pmc.dm
+++ b/code/datums/emergency_calls/pmc.dm
@@ -9,8 +9,8 @@
 	item_spawn = /obj/effect/landmark/ert_spawns/distress_pmc/item
 
 	max_smartgunners = 1
-	max_medics = 1
-	max_heavies = 2
+	max_medics = 2
+	max_heavies = 1
 	var/max_synths = 1
 	var/synths = 0
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request
Sets the max amount of PMC snipers to 1, increases the max medics to 2.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
It can be said without a doubt, pmc sniper is crazy powerful, especially in xeno combat, dealing 450 damage to large xenos on aimed shots. This leaves the queen open to being killed in 2 aimed shots and 1 unaimed shot which can be achieved very easily with 2 snipers, not even mentioning how every other xeno gets straight up deleted. Considering the amount of people that already hate PMC sniper for their power, i feel like this will improve balance. To make up for the removed possible sniper, i have increased the medic count by 1.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
balance: changed amount of possible PMC snipers to 1, amount of possible PMC medics to 2
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
