### PR TITLE
Laptop pickup fix

### DIFF
--- a/code/modules/defenses/sentry_computer.dm
+++ b/code/modules/defenses/sentry_computer.dm
@@ -124,9 +124,10 @@
 	STOP_PROCESSING(SSobj, src)
 	playsound(src,  'sound/machines/terminal_off.ogg', 25, FALSE)
 
-/obj/item/device/sentry_computer/MouseDrop(atom/dropping, mob/user)
-	teardown()
-	user.put_in_any_hand_if_possible(src, disable_warning = TRUE)
+/obj/item/device/sentry_computer/MouseDrop(over_object)
+	if(over_object == usr && Adjacent(usr))
+		teardown()
+		usr.put_in_any_hand_if_possible(src, disable_warning = TRUE)
 
 /obj/item/device/sentry_computer/emp_act(severity)
 	return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Added missing adjacency check for picking up sentry laptops, plus checking that over_location is the person doing the pickup to avoid a runtime error.

# Explain why it's good for the game

Bugs bad.


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
![SentryLaptopPickupFix](https://user-images.githubusercontent.com/15560820/213938441-7172ac9a-4e23-4327-8fa4-a0149af3b6e5.gif)


Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: Laptops can no longer be picked up from afar, plus runtime fix.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
