### PR TITLE
adds the random event verbs to the correct lists

### DIFF
--- a/code/controllers/subsystem/events.dm
+++ b/code/controllers/subsystem/events.dm
@@ -114,7 +114,7 @@ SUBSYSTEM_DEF(events)
 
 	dat = normal
 
-	var/datum/browser/popup = new(usr, "force_event", "Force Random Event", 300, 750)
+	var/datum/browser/popup = new(usr, "force_event", "Force Random Event", nwidth = 300, nheight = 750)
 	popup.set_content(dat)
 	popup.open()
 

--- a/code/controllers/subsystem/events.dm
+++ b/code/controllers/subsystem/events.dm
@@ -97,7 +97,7 @@ SUBSYSTEM_DEF(events)
 //aka Badmin Central
 /client/proc/force_event()
 	set name = "Trigger Event"
-	set category = "Fun"
+	set category = "Admin.Events"
 
 	if(!admin_holder ||!check_rights(R_EVENT))
 		return
@@ -120,7 +120,7 @@ SUBSYSTEM_DEF(events)
 
 /client/proc/toggle_events()
 	set name = "Toggle Events Subsystem"
-	set category = "Fun"
+	set category = "Admin.Events"
 
 	if(!admin_holder ||!check_rights(R_EVENT))
 		return

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -120,6 +120,8 @@ var/list/admin_verbs_minor_event = list(
 	/client/proc/toggle_combat_cas,
 	/client/proc/toggle_lz_protection, //Mortar hitting LZ
 	/client/proc/cmd_admin_medals_panel, // Marine and Xeno medals editor panel
+	/client/proc/force_event,
+	/client/proc/toggle_events,
 	/client/proc/toggle_shipside_sd
 )
 var/list/admin_verbs_major_event = list(


### PR DESCRIPTION
whoops! made it a little annoying to debug adding new events

:cl:
fix: admins can now correctly mess with the random event verbs.
/:cl:
