### PR TITLE
fixes runtimes on anything the WO combat reporter/supervisor surv does

### DIFF
--- a/code/modules/gear_presets/survivors.dm
+++ b/code/modules/gear_presets/survivors.dm
@@ -1213,7 +1213,7 @@
 /datum/equipment_preset/survivor/wy/manager
 	name = "Survivor - Corporate Supervisor"
 	flags = EQUIPMENT_PRESET_EXTRA
-	paygrade = "WY-5G"
+	paygrade = "WYC7"
 	skills = /datum/skills/civilian/manager_survivor
 	assignment = "Colony Supervisor"
 	role_comm_title = "Supervisor"

--- a/code/modules/gear_presets/wo.dm
+++ b/code/modules/gear_presets/wo.dm
@@ -561,7 +561,7 @@
 		ACCESS_CIVILIAN_RESEARCH, ACCESS_CIVILIAN_ENGINEERING, ACCESS_CIVILIAN_LOGISTICS)
 	assignment = JOB_WO_CORPORATE_LIAISON
 	rank = JOB_WO_CORPORATE_LIAISON
-	paygrade = "WY-XB-X"
+	paygrade = "WYC2"
 	role_comm_title = "PRESS"
 	skills = /datum/skills/civilian
 	idtype = /obj/item/card/id/silver/cl


### PR DESCRIPTION
they weren't updated with the PR changing the paygrades. oh, paygrades

:cl:
fix: fixes paygrade runtime for the combat reporter and corporate supervisor survivor
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
