### PR TITLE
LOOC Nerf

### DIFF
--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -98,7 +98,7 @@
 			to_chat(src, SPAN_DANGER("LOOC is globally muted"))
 			return
 		if(!dlooc_allowed && (mob.stat != CONSCIOUS || isobserver(mob)))
-			to_chat(usr, SPAN_DANGER("LOOC for dead or incapacitated mobs has been turned off."))
+			to_chat(usr, SPAN_DANGER("Sorry, you cannot utilize LOOC while dead or incapacitated."))
 			return
 		if(prefs.muted & MUTE_OOC)
 			to_chat(src, SPAN_DANGER("You cannot use LOOC (muted)."))

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -97,8 +97,8 @@
 		if(!looc_allowed)
 			to_chat(src, SPAN_DANGER("LOOC is globally muted"))
 			return
-		if(!dlooc_allowed && (mob.stat == DEAD || isobserver(mob)))
-			to_chat(usr, SPAN_DANGER("LOOC for dead mobs has been turned off."))
+		if(!dlooc_allowed && (mob.stat != CONSCIOUS || isobserver(mob)))
+			to_chat(usr, SPAN_DANGER("LOOC for dead or incapacitated mobs has been turned off."))
 			return
 		if(prefs.muted & MUTE_OOC)
 			to_chat(src, SPAN_DANGER("You cannot use LOOC (muted)."))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

LOOC can no longer be used by incapacitated mobs.

# Explain why it's good for the game

This should stop some of the daily heated gamer moments. It's rare LOOC while incapacitated is used in a positive manner.

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>
Yes
</details>


# Changelog

:cl: Morrow
admin: LOOC is no longer usable by people who are incapacitated.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
