### PR TITLE
modernizes poor eyesight to use eyeblur

### DIFF
--- a/code/modules/mob/living/carbon/human/life/handle_regular_hud_updates.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_regular_hud_updates.dm
@@ -64,11 +64,11 @@
 			overlay_fullscreen("eye_blurry", /atom/movable/screen/fullscreen/impaired, 5)
 		else
 			clear_fullscreen("eye_blurry")
-		///Pain should override the SetEyeBlur(0) should the pain be painful enough to cause eyeblur in the first place.
-
-		if((disabilities & NEARSIGHTED) && !HAS_TRAIT(src, TRAIT_NEARSIGHTED_EQUIPMENT) && pain.current_pain < 80)
+		///Pain should override the SetEyeBlur(0) should the pain be painful enough to cause eyeblur in the first place. Also, peepers is essential to make sure eye damage isn't overriden.
+		var/datum/internal_organ/eyes/peepers = internal_organs_by_name["eyes"]
+		if((disabilities & NEARSIGHTED) && !HAS_TRAIT(src, TRAIT_NEARSIGHTED_EQUIPMENT) && pain.current_pain < 80 && peepers.organ_status == ORGAN_HEALTHY)
 			EyeBlur(2)
-		else if((disabilities & NEARSIGHTED) && HAS_TRAIT(src, TRAIT_NEARSIGHTED_EQUIPMENT) && pain.current_pain < 80)
+		else if((disabilities & NEARSIGHTED) && HAS_TRAIT(src, TRAIT_NEARSIGHTED_EQUIPMENT) && pain.current_pain < 80 && peepers.organ_status == ORGAN_HEALTHY)
 			SetEyeBlur(0)
 
 		if(druggy)

--- a/code/modules/mob/living/carbon/human/life/handle_regular_hud_updates.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_regular_hud_updates.dm
@@ -62,6 +62,8 @@
 
 		if(dazed)
 			overlay_fullscreen("eye_blurry", /atom/movable/screen/fullscreen/impaired, 5)
+		else
+			clear_fullscreen("eye_blurry")
 		///Pain should override the SetEyeBlur(0) should the pain be painful enough to cause eyeblur in the first place.
 		else if((disabilities & NEARSIGHTED) && !HAS_TRAIT(src, TRAIT_NEARSIGHTED_EQUIPMENT) && pain.current_pain < 80)
 			EyeBlur(2)

--- a/code/modules/mob/living/carbon/human/life/handle_regular_hud_updates.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_regular_hud_updates.dm
@@ -62,10 +62,11 @@
 
 		if(dazed)
 			overlay_fullscreen("eye_blurry", /atom/movable/screen/fullscreen/impaired, 5)
-		else if((disabilities & NEARSIGHTED) && !HAS_TRAIT(src, TRAIT_NEARSIGHTED_EQUIPMENT))
-			overlay_fullscreen("eye_blurry", /atom/movable/screen/fullscreen/impaired, 2)
-		else
-			clear_fullscreen("eye_blurry")
+		///Pain should override the SetEyeBlur(0) should the pain be painful enough to cause eyeblur in the first place.
+		else if((disabilities & NEARSIGHTED) && !HAS_TRAIT(src, TRAIT_NEARSIGHTED_EQUIPMENT) && src.pain.current_pain < 80)
+			src.EyeBlur(2)
+		else if((disabilities & NEARSIGHTED) && HAS_TRAIT(src, TRAIT_NEARSIGHTED_EQUIPMENT) && src.pain.current_pain < 80)
+			src.SetEyeBlur(0)
 
 		if(druggy)
 			overlay_fullscreen("high", /atom/movable/screen/fullscreen/high)

--- a/code/modules/mob/living/carbon/human/life/handle_regular_hud_updates.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_regular_hud_updates.dm
@@ -63,10 +63,10 @@
 		if(dazed)
 			overlay_fullscreen("eye_blurry", /atom/movable/screen/fullscreen/impaired, 5)
 		///Pain should override the SetEyeBlur(0) should the pain be painful enough to cause eyeblur in the first place.
-		else if((disabilities & NEARSIGHTED) && !HAS_TRAIT(src, TRAIT_NEARSIGHTED_EQUIPMENT) && src.pain.current_pain < 80)
-			src.EyeBlur(2)
-		else if((disabilities & NEARSIGHTED) && HAS_TRAIT(src, TRAIT_NEARSIGHTED_EQUIPMENT) && src.pain.current_pain < 80)
-			src.SetEyeBlur(0)
+		else if((disabilities & NEARSIGHTED) && !HAS_TRAIT(src, TRAIT_NEARSIGHTED_EQUIPMENT) && pain.current_pain < 80)
+			EyeBlur(2)
+		else if((disabilities & NEARSIGHTED) && HAS_TRAIT(src, TRAIT_NEARSIGHTED_EQUIPMENT) && pain.current_pain < 80)
+			SetEyeBlur(0)
 
 		if(druggy)
 			overlay_fullscreen("high", /atom/movable/screen/fullscreen/high)

--- a/code/modules/mob/living/carbon/human/life/handle_regular_hud_updates.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_regular_hud_updates.dm
@@ -64,6 +64,7 @@
 			overlay_fullscreen("eye_blurry", /atom/movable/screen/fullscreen/impaired, 5)
 		else
 			clear_fullscreen("eye_blurry")
+
 		///Pain should override the SetEyeBlur(0) should the pain be painful enough to cause eyeblur in the first place.
 		else if((disabilities & NEARSIGHTED) && !HAS_TRAIT(src, TRAIT_NEARSIGHTED_EQUIPMENT) && pain.current_pain < 80)
 			EyeBlur(2)

--- a/code/modules/mob/living/carbon/human/life/handle_regular_hud_updates.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_regular_hud_updates.dm
@@ -64,9 +64,9 @@
 			overlay_fullscreen("eye_blurry", /atom/movable/screen/fullscreen/impaired, 5)
 		else
 			clear_fullscreen("eye_blurry")
-
 		///Pain should override the SetEyeBlur(0) should the pain be painful enough to cause eyeblur in the first place.
-		else if((disabilities & NEARSIGHTED) && !HAS_TRAIT(src, TRAIT_NEARSIGHTED_EQUIPMENT) && pain.current_pain < 80)
+
+		if((disabilities & NEARSIGHTED) && !HAS_TRAIT(src, TRAIT_NEARSIGHTED_EQUIPMENT) && pain.current_pain < 80)
 			EyeBlur(2)
 		else if((disabilities & NEARSIGHTED) && HAS_TRAIT(src, TRAIT_NEARSIGHTED_EQUIPMENT) && pain.current_pain < 80)
 			SetEyeBlur(0)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request
This PR changes it so that the poor eyesight/nearsighted trait uses the modern eyeblur code. It also makes sure that the eyeblur reduction (to 0) from wearing prescription glasses items does _not_ override any potential eyeblur from pain.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

Currently I don't see a ton of people use poor eyesight but I think that's because the current implementation of it is LAME. It uses the old-ass impaired screen effect and should now work with all blur/impair preferences given that eyeblur code works with them all.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
code: modernizes the poor eyesight trait to use eyeblur
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
