### PR TITLE
Adds regulation tape to SecTech vendors.

### DIFF
--- a/code/game/machinery/vending/vending_types.dm
+++ b/code/game/machinery/vending/vending_types.dm
@@ -215,7 +215,8 @@
 					/obj/item/storage/belt/security/MP = 6,
 					/obj/item/clothing/head/beret/marine/mp = 6,
 					/obj/item/clothing/glasses/sunglasses/sechud = 3,
-					/obj/item/device/radio/headset = 6)
+					/obj/item/device/radio/headset = 6,
+					/obj/item/tape/regulation = 5)
 	contraband = list(/obj/item/clothing/glasses/sunglasses = 2,/obj/item/storage/donut_box = 2)
 
 /obj/structure/machinery/vending/sea


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Adds 5 regulation tapes to each SecTech vendor. Tested.

# Explain why it's good for the game

Currently, the only way I know that you can get extra tapes is through the **one** box in the brig processing or to extract tapes from other recorders. This alleviates that.
Approved by harryob.
![image](https://user-images.githubusercontent.com/42235601/214838629-c299b17e-7368-43d9-b21d-e480149079f0.png)


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
add: SecTech vendors can now vend regulation tape.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
