### PR TITLE
Electrical APC Maintenance Link Return

### DIFF
--- a/code/__DEFINES/urls.dm
+++ b/code/__DEFINES/urls.dm
@@ -17,6 +17,7 @@
 #define URL_WIKI_CONSTRUCTION "https://cm-ss13.com/wiki/Guide_to_construction"
 #define URL_WIKI_ENGINEERING "https://cm-ss13.com/wiki/Guide_to_Engineering"
 #define URL_WIKI_HACKING "https://cm-ss13.com/wiki/Guide_to_Engineering#Hacking"
+#define URL_WIKI_APC "https://cm-ss13.com/wiki/Guide_to_Engineering#APC_Maintenance"
 #define URL_WIKI_SURGERY "https://cm-ss13.com/wiki/Surgery"
 #define URL_WIKI_MEDICAL "https://cm-ss13.com/wiki/Guide_to_Medicine"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

The link to the electrical APC maintenance guide was erroneously removed when it came to removing the APC. This rectifies that.

# Explain why it's good for the game

Fixes mistake made in #2320.


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl: TopHatPenguin
fix: returns the guide to electrical apc maintenance link.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
