### PR TITLE
Lets Xeno's unbuckle from Operating Tables

### DIFF
--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -77,6 +77,13 @@
 		to_chat(user, SPAN_NOTICE("You remove \the [anes_tank] from \the [src]."))
 		anes_tank = null
 
+// Removing marines connected to anesthetic
+/obj/structure/machinery/optable/attack_alien(mob/living/carbon/xenomorph/alien, mob/living/user)
+	if(buckled_mob)
+		to_chat(alien, SPAN_XENONOTICE("You rip the tubes off of the host, releasing it!"))
+		playsound(alien.loc, "alien_claw_flesh", 25, 1)
+		unbuckle(user)
+		return
 
 /obj/structure/machinery/optable/buckle_mob(mob/living/carbon/human/H, mob/living/user)
 	if(!istype(H) || !ishuman(user) || H == user || H.buckled || user.action_busy || user.is_mob_incapacitated() || buckled_mob)
@@ -135,7 +142,10 @@
 		var/obj/item/M = H.wear_mask
 		H.drop_inv_item_on_ground(M)
 		qdel(M)
-		H.visible_message(SPAN_NOTICE("[user] turns off the anesthetic and removes the mask from [H]."))
+		if(ishuman(user)) //Checks for whether a xeno is unbuckling from the operating table
+			H.visible_message(SPAN_NOTICE("[user] turns off the anesthetic and removes the mask from [H]."))
+		else
+			H.visible_message(SPAN_WARNING("The anesthesia mask is ripped off of [H]'s face!"))
 		stop_processing()
 		patient_exam = 0
 		..()

--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -142,10 +142,10 @@
 		var/obj/item/M = H.wear_mask
 		H.drop_inv_item_on_ground(M)
 		qdel(M)
-		if(ishuman(user)) //Checks for whether a xeno is unbuckling from the operating table
-			H.visible_message(SPAN_NOTICE("[user] turns off the anesthetic and removes the mask from [H]."))
-		else
+		if(!(ishuman(user))) //Checks for whether a xeno is unbuckling from the operating table
 			H.visible_message(SPAN_WARNING("The anesthesia mask is ripped off of [H]'s face!"))
+		else
+			H.visible_message(SPAN_NOTICE("[user] turns off the anesthetic and removes the mask from [H]."))
 		stop_processing()
 		patient_exam = 0
 		..()

--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -80,7 +80,7 @@
 // Removing marines connected to anesthetic
 /obj/structure/machinery/optable/attack_alien(mob/living/carbon/xenomorph/alien, mob/living/user)
 	if(buckled_mob)
-		to_chat(alien, SPAN_XENONOTICE("You rip the tubes off of the host, releasing it!"))
+		to_chat(alien, SPAN_XENONOTICE("You rip the tubes away from the host, releasing it!"))
 		playsound(alien.loc, "alien_claw_flesh", 25, 1)
 		unbuckle(user)
 		return
@@ -143,7 +143,7 @@
 		H.drop_inv_item_on_ground(M)
 		qdel(M)
 		if(!(ishuman(user))) //Checks for whether a xeno is unbuckling from the operating table
-			H.visible_message(SPAN_WARNING("The anesthesia mask is ripped off of [H]'s face!"))
+			H.visible_message(SPAN_WARNING("The anesthesia mask is ripped away from [H]'s face!"))
 		else
 			H.visible_message(SPAN_NOTICE("[user] turns off the anesthetic and removes the mask from [H]."))
 		stop_processing()

--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -142,10 +142,10 @@
 		var/obj/item/M = H.wear_mask
 		H.drop_inv_item_on_ground(M)
 		qdel(M)
-		if(!(ishuman(user))) //Checks for whether a xeno is unbuckling from the operating table
-			H.visible_message(SPAN_WARNING("The anesthesia mask is ripped away from [H]'s face!"))
-		else
+		if(ishuman(user)) //Checks for whether a xeno is unbuckling from the operating table
 			H.visible_message(SPAN_NOTICE("[user] turns off the anesthetic and removes the mask from [H]."))
+		else
+			H.visible_message(SPAN_WARNING("The anesthesia mask is ripped off of [H]'s face!"))
 		stop_processing()
 		patient_exam = 0
 		..()

--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -81,9 +81,8 @@
 /obj/structure/machinery/optable/attack_alien(mob/living/carbon/xenomorph/alien, mob/living/user)
 	if(buckled_mob)
 		to_chat(alien, SPAN_XENONOTICE("You rip the tubes away from the host, releasing it!"))
-		playsound(alien.loc, "alien_claw_flesh", 25, 1)
+		playsound(alien, "alien_claw_flesh", 25, 1)
 		unbuckle(user)
-		return
 
 /obj/structure/machinery/optable/buckle_mob(mob/living/carbon/human/H, mob/living/user)
 	if(!istype(H) || !ishuman(user) || H == user || H.buckled || user.action_busy || user.is_mob_incapacitated() || buckled_mob)

--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -83,6 +83,8 @@
 		to_chat(alien, SPAN_XENONOTICE("You rip the tubes away from the host, releasing it!"))
 		playsound(alien, "alien_claw_flesh", 25, 1)
 		unbuckle(user)
+	else
+		. = ..()
 
 /obj/structure/machinery/optable/buckle_mob(mob/living/carbon/human/H, mob/living/user)
 	if(!istype(H) || !ishuman(user) || H == user || H.buckled || user.action_busy || user.is_mob_incapacitated() || buckled_mob)

--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -145,7 +145,7 @@
 		if(ishuman(user)) //Checks for whether a xeno is unbuckling from the operating table
 			H.visible_message(SPAN_NOTICE("[user] turns off the anesthetic and removes the mask from [H]."))
 		else
-			H.visible_message(SPAN_WARNING("The anesthesia mask is ripped off of [H]'s face!"))
+			H.visible_message(SPAN_WARNING("The anesthesia mask is ripped away from [H]'s face!"))
 		stop_processing()
 		patient_exam = 0
 		..()


### PR DESCRIPTION
# About the pull request

Xenos attacking the Operating Table causes them to rip the anesthetic system away from the marine, unbuckling them, allowing them to either capture if alive or drag away chestbursted marines if dead.

# Explain why it's good for the game

Fixes issue #2453 and allows Xenos to actually cap people on operating tables

(I don't know if this is a fix or a feature, I asked and was told to just go with fix)
# Changelog

:cl:
fix: Xenos can unbuckle marines from Operating Tables
/:cl: