### PR TITLE
Sentry Post Nerf(Remake)

### DIFF
--- a/code/modules/cm_marines/dropship_ammo.dm
+++ b/code/modules/cm_marines/dropship_ammo.dm
@@ -413,7 +413,7 @@
 
 /obj/structure/ship_ammo/sentry/detonate_on(turf/impact)
 	var/obj/structure/droppod/equipment/sentry/droppod = new(impact, /obj/structure/machinery/defenses/sentry/launchable, source_mob)
-	droppod.special_structures = breakeable_structures
+	droppod.special_structures_to_damage = breakeable_structures
 	droppod.special_structure_damage = 500
 	droppod.drop_time = 5 SECONDS
 	droppod.launch(impact)

--- a/code/modules/cm_marines/dropship_ammo.dm
+++ b/code/modules/cm_marines/dropship_ammo.dm
@@ -405,18 +405,22 @@
 	max_ammo_count = 1
 	ammo_name = "area denial sentry"
 	travelling_time = 0 // handled by droppod
-	point_cost = 600
+	point_cost = 800
 	accuracy_range = 0 // pinpoint
 	max_inaccuracy = 0
+	/// Special structures it needs to break with drop pod
+	var/list/breakeable_structures = list(/obj/structure/barricade, /obj/structure/surface/table)
 
 /obj/structure/ship_ammo/sentry/detonate_on(turf/impact)
 	var/obj/structure/droppod/equipment/sentry/droppod = new(impact, /obj/structure/machinery/defenses/sentry/launchable, source_mob)
+	droppod.special_structures = breakeable_structures
+	droppod.special_structure_damage = 500
 	droppod.drop_time = 5 SECONDS
 	droppod.launch(impact)
 	qdel(src)
 
 /obj/structure/ship_ammo/sentry/can_fire_at(turf/impact, mob/user)
-	for(var/obj/structure/machinery/defenses/def in urange(2, impact))
+	for(var/obj/structure/machinery/defenses/def in urange(4, impact))
 		to_chat(user, SPAN_WARNING("The selected drop site is too close to another deployed defense!"))
 		return FALSE
 	if(istype(impact, /turf/closed))

--- a/code/modules/cm_tech/droppod/droppod.dm
+++ b/code/modules/cm_tech/droppod/droppod.dm
@@ -15,7 +15,7 @@
 
 	var/land_damage = 5000
 	/// List of special structures drop pod will give damage to
-	var/list/special_structures = list()
+	var/list/special_structures_to_damage = list()
 	/// Amount of damage structures will take on landing
 	var/special_structure_damage = 0
 	var/tiles_to_take = 15
@@ -162,7 +162,7 @@
 		structure.update_health(-land_damage)
 
 		// Deal damage exclusively to special structures thats specified for the object on landing, currently used for sentry post
-		if(is_type_in_list(structure, special_structures))
+		if(is_type_in_list(structure, special_structures_to_damage))
 			structure.update_health(special_structure_damage)
 
 	for(var/obj/structure/machinery/defenses/def in loc)

--- a/code/modules/cm_tech/droppod/droppod.dm
+++ b/code/modules/cm_tech/droppod/droppod.dm
@@ -14,6 +14,10 @@
 	var/droppod_flags = NO_FLAGS
 
 	var/land_damage = 5000
+	/// List of special structures drop pod will give damage to
+	var/list/special_structures = list()
+	/// Amount of damage structures will take on landing
+	var/special_structure_damage = 0
 	var/tiles_to_take = 15
 
 	var/drop_time = 0
@@ -156,6 +160,10 @@
 
 	for(var/obj/structure/structure in loc)
 		structure.update_health(-land_damage)
+
+		// Deal damage exclusively to special structures thats specified for the object on landing, currently used for sentry post
+		if(is_type_in_list(structure, special_structures))
+			structure.update_health(special_structure_damage)
 
 	for(var/obj/structure/machinery/defenses/def in loc)
 		qdel(def)

--- a/code/modules/defenses/sentry.dm
+++ b/code/modules/defenses/sentry.dm
@@ -679,7 +679,7 @@
 	else
 		to_chat(user, SPAN_WARNING("You need at least [upgrade_cost] sheets of metal to upgrade this."))
 
-/obj/structure/machinery/defenses/sentry/launchable/attack_hand_checks(var/mob/user)
+/obj/structure/machinery/defenses/sentry/launchable/attack_hand_checks(mob/user)
 	// Reloads the sentry using inherent rounds
 	if(!turned_on && additional_rounds_stored && (ammo.current_rounds < ammo.max_rounds))
 		if(!do_after(user, 2 SECONDS * user.get_skill_duration_multiplier(SKILL_ENGINEER), INTERRUPT_ALL, BUSY_ICON_FRIENDLY))

--- a/code/modules/defenses/sentry.dm
+++ b/code/modules/defenses/sentry.dm
@@ -22,6 +22,8 @@
 	var/sentry_type = "sentry" //Used for the icon
 	display_additional_stats = TRUE
 
+	/// Check if they have been upgraded or not, used for sentry post
+	var/upgraded = FALSE
 	var/omni_directional = FALSE
 	var/additional_rounds_stored = FALSE
 	var/sentry_range = SENTRY_RANGE
@@ -164,11 +166,15 @@
 /obj/structure/machinery/defenses/sentry/get_examine_text(mob/user)
 	. = ..()
 	if(ammo)
-		. += SPAN_NOTICE("[src] has [ammo.current_rounds]/[ammo.max_rounds] round\s loaded.")
+		. += SPAN_NOTICE("\the [src] has [ammo.current_rounds]/[ammo.max_rounds] round\s loaded.")
 		if(additional_rounds_stored)
-			. += SPAN_NOTICE("[src] has [ammo.max_inherent_rounds] round\s left in storage.")
+			. += SPAN_NOTICE("\the [src] has [ammo.max_inherent_rounds] round\s left in storage.")
+		if(upgraded)
+			. += SPAN_NOTICE("\the [src] has been reinforced with metal sheets.")
 	else
-		. += SPAN_NOTICE("[src] is empty and needs to be refilled with ammo.")
+		. += SPAN_NOTICE("\the [src] is empty and needs to be refilled with ammo.")
+		if(additional_rounds_stored)
+			. += SPAN_HELPFUL("Click \the [src] while it's turned off to reload.")
 
 /obj/structure/machinery/defenses/sentry/power_on_action()
 	target = null
@@ -626,10 +632,8 @@
 	additional_rounds_stored = TRUE
 	immobile = TRUE
 	static = TRUE
-	/// Check if they have been upgraded or not
-	var/upgraded = FALSE
 	/// Cost to give sentry extra health
-	var/upgrade_cost = 10
+	var/upgrade_cost = 5
 	/// Amount of bonus health they get from upgrade
 	var/health_upgrade = 50
 	var/obj/structure/machinery/camera/cas/linked_cam
@@ -662,12 +666,12 @@
 		return
 
 	if(upgraded)
-		to_chat(user, SPAN_WARNING("[src] has already been upgraded."))
+		to_chat(user, SPAN_WARNING("\the [src] has already been upgraded."))
 		return
 
 	if(sheets.amount >= upgrade_cost)
 		if(!do_after(user, 4 SECONDS * user.get_skill_duration_multiplier(SKILL_CONSTRUCTION) , INTERRUPT_ALL, BUSY_ICON_FRIENDLY))
-			to_chat(user, SPAN_WARNING("You were interrupted! Try to stay still while you reload the sentry..."))
+			to_chat(user, SPAN_WARNING("You were interrupted! Try to stay still while you bolster the sentry with metal sheets..."))
 			return
 
 		src.health_max += health_upgrade
@@ -691,17 +695,18 @@
 		playsound(loc, 'sound/weapons/handling/m40sd_reload.ogg', 25, 1)
 		update_icon()
 		return FALSE
+	else
 
-	return TRUE // We want to be able to turn it on / off while keeping it immobile
+		return TRUE // We want to be able to turn it on / off while keeping it immobile
 
 /obj/structure/machinery/defenses/sentry/launchable/handle_empty()
 	// Checks if its completely dry or just needs reload, deconstruct if completely empty
 	if(ammo.max_inherent_rounds > 0)
-		visible_message("[icon2html(src, viewers(src))] <span class='warning'>The [name] beeps steadily and its ammo light blinks red. It still has rounds, requires manual reload!</span>")
+		visible_message(SPAN_WARNING("\the [name] beeps steadily and its ammo light blinks red. It still has rounds, requires manual reload!"))
 		playsound(loc, 'sound/weapons/smg_empty_alarm.ogg', 25, 1)
 		update_icon()
 	else
-		visible_message("[icon2html(src, viewers(src))] <span class='warning'>The [name] beeps steadily and its ammo light blinks red. It rapidly deconstructs itself!</span>")
+		visible_message(SPAN_WARNING("\the [name] beeps steadily and its ammo light blinks red. It rapidly deconstructs itself!"))
 		playsound(loc, 'sound/weapons/smg_empty_alarm.ogg', 25, 1)
 		deconstruct()
 

--- a/code/modules/defenses/sentry.dm
+++ b/code/modules/defenses/sentry.dm
@@ -21,7 +21,8 @@
 	var/obj/item/ammo_magazine/ammo = new /obj/item/ammo_magazine/sentry
 	var/sentry_type = "sentry" //Used for the icon
 	display_additional_stats = TRUE
-
+	/// Light strength when turned on
+	var/luminosity_strength = 7
 	/// Check if they have been upgraded or not, used for sentry post
 	var/upgraded = FALSE
 	var/omni_directional = FALSE
@@ -166,19 +167,19 @@
 /obj/structure/machinery/defenses/sentry/get_examine_text(mob/user)
 	. = ..()
 	if(ammo)
-		. += SPAN_NOTICE("\the [src] has [ammo.current_rounds]/[ammo.max_rounds] round\s loaded.")
+		. += SPAN_NOTICE("\The [src] has [ammo.current_rounds]/[ammo.max_rounds] round\s loaded.")
 		if(additional_rounds_stored)
-			. += SPAN_NOTICE("\the [src] has [ammo.max_inherent_rounds] round\s left in storage.")
+			. += SPAN_NOTICE("\The [src] has [ammo.max_inherent_rounds] round\s left in storage.")
 		if(upgraded)
-			. += SPAN_NOTICE("\the [src] has been reinforced with metal sheets.")
+			. += SPAN_NOTICE("\The [src] has been reinforced with metal sheets.")
 	else
-		. += SPAN_NOTICE("\the [src] is empty and needs to be refilled with ammo.")
+		. += SPAN_NOTICE("\The [src] is empty and needs to be refilled with ammo.")
 		if(additional_rounds_stored)
-			. += SPAN_HELPFUL("Click \the [src] while it's turned off to reload.")
+			. += SPAN_HELPFUL("Click \The [src] while it's turned off to reload.")
 
 /obj/structure/machinery/defenses/sentry/power_on_action()
 	target = null
-	SetLuminosity(7)
+	SetLuminosity(luminosity_strength)
 
 	visible_message("[icon2html(src, viewers(src))] [SPAN_NOTICE("The [name] hums to life and emits several beeps.")]")
 	visible_message("[icon2html(src, viewers(src))] [SPAN_NOTICE("The [name] buzzes in a monotone voice: 'Default systems initiated'")]")
@@ -639,6 +640,7 @@
 	var/obj/structure/machinery/camera/cas/linked_cam
 	var/static/sentry_count = 1
 	var/sentry_number
+	luminosity_strength = 9
 
 /obj/structure/machinery/defenses/sentry/launchable/Initialize()
 	. = ..()
@@ -666,7 +668,7 @@
 		return
 
 	if(upgraded)
-		to_chat(user, SPAN_WARNING("\the [src] has already been upgraded."))
+		to_chat(user, SPAN_WARNING("\The [src] has already been upgraded."))
 		return
 
 	if(sheets.amount >= upgrade_cost)
@@ -674,12 +676,13 @@
 			to_chat(user, SPAN_WARNING("You were interrupted! Try to stay still while you bolster the sentry with metal sheets..."))
 			return
 
-		src.health_max += health_upgrade
-		src.update_health(-health_upgrade)
-		sheets.use(upgrade_cost)
-		upgraded = TRUE
-
-		to_chat(user, SPAN_WARNING("You added some metal plating to the sentry, increasing its durability!"))
+		if(sheets.use(upgrade_cost))
+			src.health_max += health_upgrade
+			src.update_health(-health_upgrade)
+			upgraded = TRUE
+			to_chat(user, SPAN_WARNING("You added some metal plating to the sentry, increasing its durability!"))
+		else
+			to_chat(user, SPAN_WARNING("You need at least [upgrade_cost] sheets of metal to upgrade this."))
 	else
 		to_chat(user, SPAN_WARNING("You need at least [upgrade_cost] sheets of metal to upgrade this."))
 
@@ -702,11 +705,11 @@
 /obj/structure/machinery/defenses/sentry/launchable/handle_empty()
 	// Checks if its completely dry or just needs reload, deconstruct if completely empty
 	if(ammo.max_inherent_rounds > 0)
-		visible_message(SPAN_WARNING("\the [name] beeps steadily and its ammo light blinks red. It still has rounds, requires manual reload!"))
+		visible_message(SPAN_WARNING("\The [name] beeps steadily and its ammo light blinks red. It still has rounds, requires manual reload!"))
 		playsound(loc, 'sound/weapons/smg_empty_alarm.ogg', 25, 1)
 		update_icon()
 	else
-		visible_message(SPAN_WARNING("\the [name] beeps steadily and its ammo light blinks red. It rapidly deconstructs itself!"))
+		visible_message(SPAN_WARNING("\The [name] beeps steadily and its ammo light blinks red. It rapidly deconstructs itself!"))
 		playsound(loc, 'sound/weapons/smg_empty_alarm.ogg', 25, 1)
 		deconstruct()
 

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -22,6 +22,7 @@ They're all essentially identical when it comes to getting the job done.
 	var/caliber = null // This is used for matching handfuls to each other or whatever the mag is. Examples are" "12g" ".44" ".357" etc.
 	var/current_rounds = -1 //Set this to something else for it not to start with different initial counts.
 	var/max_rounds = 7 //How many rounds can it hold?
+	var/max_inherent_rounds = 0 //How many extra rounds the magazine has thats not in use? Used for Sentry Post, specifically for inherent reloading
 	var/gun_type = null //Path of the gun that it fits. Mags will fit any of the parent guns as well, so make sure you want this.
 	var/reload_delay = 1 //Set a timer for reloading mags. Higher is slower.
 	var/flags_magazine = AMMUNITION_REFILLABLE //flags specifically for magazines.
@@ -125,6 +126,18 @@ They're all essentially identical when it comes to getting the job done.
 
 	update_icon(S)
 	return S // We return the number transferred if it was successful.
+
+/// Proc to reload the current_ammo using the items existing inherent ammo, used for Sentry Post
+/obj/item/ammo_magazine/proc/inherent_reload(mob/user)
+	if(current_rounds == max_rounds) //Does the mag actually need reloading?
+		to_chat(user, SPAN_WARNING("[src] is already full."))
+		return 0
+
+	var/rounds_to_reload = max_rounds - current_rounds
+	current_rounds += rounds_to_reload
+	max_inherent_rounds -= rounds_to_reload
+
+	return rounds_to_reload // Returns the amount of ammo it reloaded
 
 //This will attempt to place the ammo in the user's hand if possible.
 /obj/item/ammo_magazine/proc/create_handful(mob/user, transfer_amount, obj_name = src)

--- a/code/modules/projectiles/magazines/sentries.dm
+++ b/code/modules/projectiles/magazines/sentries.dm
@@ -11,7 +11,8 @@
 	gun_type = null
 
 /obj/item/ammo_magazine/sentry/dropped
-	max_rounds = 1500
+	max_rounds = 100
+	max_inherent_rounds = 500
 
 /obj/item/ammo_magazine/sentry/premade
 	max_rounds = 99999


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Remake of #2474 cause I nuked it somehow :D

Added some new mechanics onto sentry post/omni sentry and nerfed it
Nerfs:
- Increased cost to buy from 600 -> 800
- Increased Range requirement for Sentry Post to be deployed away from another Sentry Post from 2 tiles away to 4 tiles away(please test and report if working right)

Buffs: 
- Increased Light emitted by omni sentries, just bonus to using them outside FOB

Addition: 
- Destroys all barricades on where it lands
- Upgrade the max health of the turret by 50 at the cost of 10 metal
- Sentry Post now requires manual reload, they hold a maximum of 500 rounds in storage with 100 round magazine in use, requires manual reloading.

# Explain why it's good for the game

My ultimate goal for Sentry Post is to discourage them to be used on the FOB, but rather focused on using it outside the FOB, specifically on the road to the front like hydro road or the road to bar, with the need of marines maintaining it. Originally I wanted to disable them from shooting past cades but stan thinks it might be too much so shrug

> Increased cost to buy from 600 -> 800

Decreases the amount of turrets that can be spammed, turrets are inherently strong as a static defense, they shouldn't be completely replacing marines.

> Increased Range requirement for Sentry Post to be deployed away from another Sentry Post from 2 tiles away to 4 tiles away(please test and report if working right)

Avoid spamming them and being used too close from one another, avoid 3 turrets being placed in one flank and be basically unbreakable when combined with marines, free HPR IFF PVT with slower click speed but with aimbot

> Destroys all barricades on where it lands

Gives them artificial extra health with the use of cades, also buggy due to xenos being able to claw them with RNG through cades, also forces engineers to use a lot more if they want to fortify it, needing to use 3x3 cade set up.

> Upgrade the max health of the turret by 50 at the cost of 10 metal

Alternative solution if they don't want to use a 3x3 cade set up to fortify this turret, gives a bit of health, thinking of making it cost less metal but the health buff is temporary. Currently just made it as bonus max health but more expensive.

> Sentry Post now requires manual reload, they hold a maximum of 500 rounds in storage with 100 round magazine in use, requires manual reloading when turned off.

Them being able to rotate should force them to require more maintenance, originally wanted to do 50, but that might be too much, lets go for 100 first and see how it goes.


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
balance: Increased cost of Sentry Post to 600 to 800
balance: Increased the distance required on how far apart they must be from another turret from 2 to 4
balance: Increased the light the omni sentry emits
add: Sentry Post now breaks barricades on where it lands
add: Sentry Post can be upgraded with 10 metal to give it extra maximum health
add: Sentry Post now requires a manual reload every 100 shots with a 500 rounds stored internally
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
