### PR TITLE
Fixes missing space in death nettle

### DIFF
--- a/code/modules/hydroponics/grown_inedible.dm
+++ b/code/modules/hydroponics/grown_inedible.dm
@@ -128,7 +128,7 @@
 
 /obj/item/grown/nettle/death // -- Skie
 	plantname = "deathnettle"
-	desc = "The \red glowing \black nettle incites \red<B>rage</B>\black in you just from looking at it!"
+	desc = "The glowing nettle incites <B>rage</B> in you just from looking at it!"
 	name = "deathnettle"
 	icon_state = "deathnettle"
 


### PR DESCRIPTION
# About the pull request

Death nettles had `\red` and `\black` in them, which seem to have been meant to recolor the description. These tags are broken though and don't actually recolor the description, and it made a space in the description disappear for some reason.

# Explain why it's good for the game

typo bad

# Changelog

:cl:
spellcheck: Fixes a missing space in Death Nettle's description
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
