### PR TITLE
Removes skull balaclava and skull facepaint from loadout, places them hidden on the Almayer.

### DIFF
--- a/code/game/objects/effects/spawners/random.dm
+++ b/code/game/objects/effects/spawners/random.dm
@@ -136,6 +136,33 @@
 				prob(1);/obj/item/attachable/heavy_barrel,\
 				prob(1);/obj/item/attachable/scope/mini)
 
+/obj/effect/spawner/random/balaclavas
+	name = "Random Balaclava"
+	desc = "This is a randomly chosen balaclava."
+	icon_state = "loot_goggles"
+
+/obj/effect/spawner/random/balaclavas/item_to_spawn()
+	return pick(prob(100);/obj/item/clothing/mask/balaclava,\
+				prob(50);/obj/item/clothing/mask/balaclava/tactical,\
+				prob(25);/obj/item/clothing/mask/rebreather/scarf/green,\
+				prob(25);/obj/item/clothing/mask/rebreather/scarf/gray,\
+				prob(25);/obj/item/clothing/mask/rebreather/scarf/tan,\
+				prob(10);/obj/item/clothing/mask/rebreather/skull,\
+				prob(10);/obj/item/clothing/mask/rebreather/skull/black)
+
+///If anyone wants to make custom sprites for this and the bala random spawner, be my guest.
+/obj/effect/spawner/random/facepaint
+	name = "Random Facepaint"
+	desc = "This is a randomly chosen facepaint."
+	icon_state = "loot_goggles"
+
+/obj/effect/spawner/random/facepaint/item_to_spawn()
+	return pick(prob(100);/obj/item/facepaint/black,\
+				prob(50);/obj/item/facepaint/green,\
+				prob(25);/obj/item/facepaint/brown,\
+				prob(25);/obj/item/facepaint/sunscreen_stick,\
+				prob(10);/obj/item/facepaint/sniper,\
+				prob(10);/obj/item/facepaint/skull)
 
 /obj/effect/spawner/random/supply_kit
 	name = "Random Supply Kit"

--- a/code/game/objects/effects/spawners/random.dm
+++ b/code/game/objects/effects/spawners/random.dm
@@ -140,6 +140,7 @@
 	name = "Random Balaclava"
 	desc = "This is a randomly chosen balaclava."
 	icon_state = "loot_goggles"
+	spawn_nothing_percentage = 50
 
 /obj/effect/spawner/random/balaclavas/item_to_spawn()
 	return pick(prob(100);/obj/item/clothing/mask/balaclava,\
@@ -155,6 +156,7 @@
 	name = "Random Facepaint"
 	desc = "This is a randomly chosen facepaint."
 	icon_state = "loot_goggles"
+	spawn_nothing_percentage = 50
 
 /obj/effect/spawner/random/facepaint/item_to_spawn()
 	return pick(prob(100);/obj/item/facepaint/black,\

--- a/code/modules/client/preferences_gear.dm
+++ b/code/modules/client/preferences_gear.dm
@@ -358,12 +358,6 @@ var/global/list/gear_datums = list()
 	slot = WEAR_IN_BACK
 	cost = 2
 
-/datum/gear/skullfacepaint
-	display_name = "Skull Facepaint"
-	path = /obj/item/facepaint/skull
-	slot = WEAR_IN_BACK
-	cost = 4 //there needs to be some reason to NOT use this badass facepaint or every marine will have it
-
 /datum/gear/fullbodyfacepaint
 	display_name = "Fullbody Paint"
 	path = /obj/item/facepaint/sniper
@@ -498,18 +492,6 @@ var/global/list/gear_datums = list()
 	display_name = "Gas Mask"
 	path = /obj/item/clothing/mask/gas
 	cost = 2
-	slot = WEAR_FACE
-
-/datum/gear/skull_balaclava_blue
-	display_name = "Blue Skull Balaclava"
-	path = /obj/item/clothing/mask/rebreather/skull
-	cost = 4 //same as skull facepaint
-	slot = WEAR_FACE
-
-/datum/gear/skull_balaclava_black
-	display_name = "Black Skull Balaclava"
-	path = /obj/item/clothing/mask/rebreather/skull/black
-	cost = 4
 	slot = WEAR_FACE
 
 /datum/gear/gunoil

--- a/code/modules/client/preferences_gear.dm
+++ b/code/modules/client/preferences_gear.dm
@@ -362,7 +362,7 @@ var/global/list/gear_datums = list()
 	display_name = "Fullbody Paint"
 	path = /obj/item/facepaint/sniper
 	slot = WEAR_IN_BACK
-	cost = 4 //To match with the skull paint amount of point, gave this amount of point for the same reason of the skull facepaint
+	cost = 4 //To match with the skull paint amount of point, gave this amount of point for the same reason of the skull facepaint (too cool for everyone to be able to constantly use)
 
 /datum/gear/aceofspades
 	display_name = "Ace of Spades"

--- a/code/modules/clothing/masks/breath.dm
+++ b/code/modules/clothing/masks/breath.dm
@@ -55,7 +55,7 @@
 
 /obj/item/clothing/mask/rebreather/skull
 	name = "skull balaclava"
-	desc = "The face of your nightmares. Heed the call of duty as the ghost in the night with this metal 'clava. Additionally protects against the cold."
+	desc = "The face of your nightmares. Or at least that's how you imagined it'd be. Additionally protects against the cold."
 	icon_state = "blue_skull_balaclava"
 	item_state = "blue_skull_balaclava"
 	flags_inventory = COVERMOUTH|ALLOWREBREATH|ALLOWCPR
@@ -64,7 +64,7 @@
 	min_cold_protection_temperature = ICE_PLANET_min_cold_protection_temperature
 
 /obj/item/clothing/mask/rebreather/skull/black
-	desc = "The face of your nightmares. Heed the call of duty as the ghost in the night with this metal 'clava. Additionally protects against the cold. Now in black!"
+	desc = "The face of your nightmares. Or at least that's how you imagined it'd be. Now in black!"
 	icon_state = "black_skull_balaclava"
 	item_state = "black_skull_balaclava"
 

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -71495,7 +71495,6 @@
 /area/almayer/shipboard/navigation)
 "sti" = (
 /obj/structure/closet/crate/trashcart,
-/obj/item/clothing/mask/rebreather/skull/black,
 /turf/open/floor/plating,
 /area/almayer/hull/lower_hull/l_f_p)
 "str" = (

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -65534,6 +65534,10 @@
 	tag = "icon-containment_corner_variant_1 (EAST)"
 	},
 /area/almayer/medical/containment/cell/cl)
+"pRB" = (
+/obj/item/clothing/mask/rebreather/skull/black,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_p)
 "pRL" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer,
 /obj/structure/pipes/standard/simple/hidden/supply{
@@ -71492,6 +71496,7 @@
 /area/almayer/shipboard/navigation)
 "sti" = (
 /obj/structure/closet/crate/trashcart,
+/obj/item/clothing/mask/rebreather/skull/black,
 /turf/open/floor/plating,
 /area/almayer/hull/lower_hull/l_f_p)
 "str" = (
@@ -75831,6 +75836,14 @@
 	tag = "icon-test_floor4"
 	},
 /area/almayer/shipboard/brig/evidence_storage)
+"uli" = (
+/obj/structure/surface/rack,
+/obj/item/facepaint/skull,
+/turf/open/floor/almayer{
+	icon_state = "plate";
+	tag = "icon-sterile"
+	},
+/area/almayer/hull/upper_hull/u_m_s)
 "uly" = (
 /obj/structure/bed/stool,
 /turf/open/floor/almayer{
@@ -118487,7 +118500,7 @@ uaZ
 aar
 arI
 aaQ
-aao
+uli
 aar
 aap
 aar
@@ -122505,7 +122518,7 @@ kMU
 fBx
 fiq
 hRg
-oDf
+pRB
 xMh
 fiq
 rNW

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -35737,6 +35737,7 @@
 	pixel_x = 8;
 	pixel_y = 32
 	},
+/obj/effect/spawner/random/facepaint,
 /turf/open/floor/almayer{
 	icon_state = "plate";
 	tag = "icon-sterile"
@@ -51795,7 +51796,6 @@
 	req_access = null
 	},
 /obj/item/clothing/mask/rebreather/scarf/tacticalmask/red,
-/obj/item/clothing/mask/rebreather/skull/black,
 /turf/open/floor/almayer{
 	icon_state = "plate";
 	tag = "icon-sterile"
@@ -61710,6 +61710,9 @@
 	req_access = null
 	},
 /obj/item/clothing/mask/rebreather/scarf,
+/obj/structure/closet/secure_closet/personal/cabinet{
+	req_access = null
+	},
 /turf/open/floor/almayer{
 	icon_state = "plate";
 	tag = "icon-sterile"
@@ -63736,7 +63739,6 @@
 	},
 /obj/item/clothing/suit/chef/classic,
 /obj/item/tool/kitchen/knife/butcher,
-/obj/item/facepaint/black,
 /turf/open/floor/almayer{
 	icon_state = "plate";
 	tag = "icon-sterile"
@@ -65534,10 +65536,6 @@
 	tag = "icon-containment_corner_variant_1 (EAST)"
 	},
 /area/almayer/medical/containment/cell/cl)
-"pRB" = (
-/obj/item/clothing/mask/rebreather/skull/black,
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/hull/lower_hull/l_m_p)
 "pRL" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer,
 /obj/structure/pipes/standard/simple/hidden/supply{
@@ -65713,6 +65711,7 @@
 	pixel_x = -5;
 	pixel_y = 14
 	},
+/obj/effect/spawner/random/balaclavas,
 /turf/open/floor/almayer{
 	icon_state = "plate";
 	tag = "icon-sterile"
@@ -75838,7 +75837,7 @@
 /area/almayer/shipboard/brig/evidence_storage)
 "uli" = (
 /obj/structure/surface/rack,
-/obj/item/facepaint/skull,
+/obj/effect/spawner/random/facepaint,
 /turf/open/floor/almayer{
 	icon_state = "plate";
 	tag = "icon-sterile"
@@ -122518,7 +122517,7 @@ kMU
 fBx
 fiq
 hRg
-pRB
+oDf
 xMh
 fiq
 rNW

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -71495,6 +71495,7 @@
 /area/almayer/shipboard/navigation)
 "sti" = (
 /obj/structure/closet/crate/trashcart,
+/obj/effect/spawner/random/balaclavas,
 /turf/open/floor/plating,
 /area/almayer/hull/lower_hull/l_f_p)
 "str" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

This removes the skull balaclavas and the facepaints from the loadout menu and instead places them in 2 places hidden around the Almayer. The reason I  have done this is that they are almost exclusively used by people who who are referencing a character- usually Ghost from MW2 (either version) or the characters from COD Ghosts. See below for more details.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

This is an OOC meme item that doesn't fit the tone of CM, particularly because we _already_ have an item with a skull on it in case you want to use it: Armor! They wrote things on armor in the movie, including a skull!
![image](https://user-images.githubusercontent.com/70115628/215395714-4aa1c9a2-7621-4f82-8e4b-6d7ed4905f89.png)

Instead, we have these types of people, running a skull 'clava in every round even as command or medical characters. This is a modern 'operator' look, not a Space 'Nam-esque look and not an Aliens look. If you want something that'd remind you of Space 'nam, just look at the classic 'born to kill' helmet. Now, look at these CALL OF DUTY CHARACTERS THAT THIS ITEM REFERENCES!

![image](https://user-images.githubusercontent.com/70115628/215396029-290063ae-cd96-4929-b6f0-ae2f1c517887.png)
![image](https://user-images.githubusercontent.com/70115628/215396040-0eb9e31f-71ed-408a-8248-152916427bdd.png)
![image](https://user-images.githubusercontent.com/70115628/215396561-f4493f24-2405-4b8d-8034-02a96ea6919f.png)

This is goofy as hell and kind of an outlier among the customization options since it is _very clearly_ a reference to COD. Look at its description: 

"The face of your nightmares. Heed the call of duty as the ghost in the night with this metal 'clava. Additionally protects against the cold. Now in black!"

You'd get laughed off a real marine base for wearing this, let alone wearing one on an op. We don't need more people running this every round, and this gives them something to fight over between eachother- if _you_ want to larp as Simon 'Ghost' Riley from hit video game COD MW2 (either version) then you'll have to hunt it down.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
del: Removed skull balaclavas and skull facepaint from the loadout options
maptweak: adds a single skull facepaint and balaclava, each hidden in their own locations on the Almayer.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
