### PR TITLE
Ultrazine and stims survivor nerf

### DIFF
--- a/code/game/objects/effects/spawners/random.dm
+++ b/code/game/objects/effects/spawners/random.dm
@@ -201,11 +201,14 @@
 	icon_state = "loot_pills"
 
 /obj/effect/spawner/random/pills/item_to_spawn()
-	return pick(prob(4);/obj/item/storage/pill_bottle/ultrazine/skillless,\
+	return pick(prob(4);/obj/item/storage/pill_bottle/inaprovaline/skillless,\
 				prob(4);/obj/item/storage/pill_bottle/mystery/skillless,\
-				prob(4);/obj/item/storage/pill_bottle/stimulant/skillless,\
 				prob(3);/obj/item/storage/pill_bottle/alkysine/skillless,\
 				prob(3);/obj/item/storage/pill_bottle/imidazoline/skillless,\
+				prob(3);/obj/item/storage/pill_bottle/tramadol/skillless,\
+				prob(3);/obj/item/storage/pill_bottle/bicaridine/skillless,\
+				prob(3);/obj/item/storage/pill_bottle/kelotane/skillless,\
+				prob(3);/obj/item/storage/pill_bottle/peridaxon/skillless,\
 				prob(2);/obj/item/storage/pill_bottle/packet/oxycodone)
 
 /obj/effect/spawner/random/pills/lowchance

--- a/maps/map_files/CORSAT/Corsat.dmm
+++ b/maps/map_files/CORSAT/Corsat.dmm
@@ -57375,7 +57375,6 @@
 /area/corsat/gamma/engineering)
 "roj" = (
 /obj/structure/safe,
-/obj/item/storage/pill_bottle/ultrazine/skillless,
 /turf/open/floor/corsat{
 	dir = 1;
 	icon_state = "squareswood"

--- a/maps/map_files/Ice_Colony_v3/Shivas_Snowball.dmm
+++ b/maps/map_files/Ice_Colony_v3/Shivas_Snowball.dmm
@@ -5815,7 +5815,6 @@
 /obj/item/spacecash/c1000,
 /obj/item/spacecash/c500,
 /obj/effect/landmark/good_item,
-/obj/item/storage/pill_bottle/ultrazine/skillless,
 /turf/open/floor/shiva{
 	dir = 8;
 	icon_state = "redfull"

--- a/maps/map_files/Sorokyne_Strata/Sorokyne_Strata.dmm
+++ b/maps/map_files/Sorokyne_Strata/Sorokyne_Strata.dmm
@@ -509,7 +509,6 @@
 /obj/structure/closet/wardrobe/grey,
 /obj/effect/landmark/wo_supplies/storage/mines,
 /obj/effect/landmark/wo_supplies/storage/mines,
-/obj/item/storage/pill_bottle/ultrazine/skillless,
 /obj/effect/landmark/objective_landmark/close,
 /turf/open/floor/strata{
 	dir = 10;


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

This PR reduces the chances of finding ultrazine or antag stims as well as removes guaranteed ultrazine spawns on some maps.

# Explain why it's good for the game

I would like to move survivors away from the try hard and anti-RP focus it currently resides in by necessity. Some nerfs are going to be required before we can start buffing it in other ways.

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>
It compiled, that's about it.

</details>


# Changelog

:cl: Morrow
balance: Removes ultrazine spawns on maps.
balance: Removes ultrazine and antag stims as explicit random loot items.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
