### PR TITLE
Changes tables / racks to be deconstructed on all intents but help

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -282,7 +282,7 @@
 				SPAN_DANGER("You throw [M] on [src]."))
 		return
 
-	if(HAS_TRAIT(W, TRAIT_TOOL_WRENCH))
+	if(HAS_TRAIT(W, TRAIT_TOOL_WRENCH) && user.a_intent == INTENT_HARM)
 		user.visible_message(SPAN_NOTICE("[user] starts disassembling [src]."),
 		SPAN_NOTICE("You start disassembling [src]."))
 		playsound(src.loc, 'sound/items/Ratchet.ogg', 25, 1)
@@ -635,7 +635,7 @@
 		step(I, get_dir(I, src))
 
 /obj/structure/surface/rack/attackby(obj/item/W, mob/user, click_data)
-	if(HAS_TRAIT(W, TRAIT_TOOL_WRENCH))
+	if(HAS_TRAIT(W, TRAIT_TOOL_WRENCH) && user.a_intent == INTENT_HARM)
 		deconstruct(TRUE)
 		playsound(src.loc, 'sound/items/Ratchet.ogg', 25, 1)
 		return

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -282,7 +282,7 @@
 				SPAN_DANGER("You throw [M] on [src]."))
 		return
 
-	if(HAS_TRAIT(W, TRAIT_TOOL_WRENCH) && user.a_intent == INTENT_HARM)
+	if(HAS_TRAIT(W, TRAIT_TOOL_WRENCH) && !(user.a_intent == INTENT_HELP))
 		user.visible_message(SPAN_NOTICE("[user] starts disassembling [src]."),
 		SPAN_NOTICE("You start disassembling [src]."))
 		playsound(src.loc, 'sound/items/Ratchet.ogg', 25, 1)
@@ -541,7 +541,7 @@
 			return
 		return
 
-	if(HAS_TRAIT(W, TRAIT_TOOL_WRENCH))
+	if(HAS_TRAIT(W, TRAIT_TOOL_WRENCH) && !(user.a_intent == INTENT_HELP))
 		if(status == 2)
 			return
 	..()
@@ -635,7 +635,7 @@
 		step(I, get_dir(I, src))
 
 /obj/structure/surface/rack/attackby(obj/item/W, mob/user, click_data)
-	if(HAS_TRAIT(W, TRAIT_TOOL_WRENCH) && user.a_intent == INTENT_HARM)
+	if(HAS_TRAIT(W, TRAIT_TOOL_WRENCH) && !(user.a_intent == INTENT_HELP))
 		deconstruct(TRUE)
 		playsound(src.loc, 'sound/items/Ratchet.ogg', 25, 1)
 		return


### PR DESCRIPTION
# About the pull request

You couldn't place wrenches on tables, only throw them on

# Explain why it's good for the game

It lets you actually place wrenches on tables

# Changelog

:cl:
fix: Restricts deconstructing racks / tables to all intents but help, allowing you to place wrenches on tables and racks
/:cl: