### PR TITLE
Changes layer of the Big Tree on LV-624

### DIFF
--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -95,28 +95,21 @@ PLANT_CUT_MACHETE = 3 = Needs at least a machete to be cut down
 	unacidable = TRUE
 
 /obj/structure/flora/tree/jungle
+	name = "huge tree"
 	icon = 'icons/obj/structures/props/ground_map64.dmi'
 	desc = "What an enormous tree!"
 	density = FALSE
+	layer = ABOVE_XENO_LAYER
 
+// LV-624's Yggdrasil Tree
 /obj/structure/flora/tree/jungle/bigtreeTR
-	name = "huge tree"
 	icon_state = "bigtreeTR"
 
 /obj/structure/flora/tree/jungle/bigtreeTL
-	name = "huge tree"
 	icon_state = "bigtreeTL"
 
 /obj/structure/flora/tree/jungle/bigtreeBOT
-	name = "huge tree"
 	icon_state = "bigtreeBOT"
-
-/obj/structure/flora/tree/jungle/grasscarpet
-	name = "thick grass"
-	desc = "A thick mat of dense grass."
-	icon_state = "grasscarpet"
-	layer = BELOW_MOB_LAYER
-	density = FALSE
 
 //grass
 /obj/structure/flora/grass


### PR DESCRIPTION
Moves the Big Tree on LV-624 to a lower layer so the medical hud can see people under it
Removes `/obj/structure/flora/tree/jungle/grasscarpet` since it's icon wasn't even in the dmi and it was unused.

# Explain why it's good for the game

fixes #1080 
Removes a bit of unused code

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://user-images.githubusercontent.com/56142455/216224842-1c89ea88-aa9e-4078-86da-951a355f3f15.png)

</details>


# Changelog

:cl:
fix: Changed layer of LV-624's tree so you can see the medical hud if marines are hidden (dead) behind it
/:cl: