### PR TITLE
The ASRS will no longer steal your limbs

### DIFF
--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -560,10 +560,6 @@ var/datum/controller/supply/supply_controller = new()
 	shake_camera(mauled_human, 20, 1)
 	mauled_human.apply_armoured_damage(60, ARMOR_MELEE, BRUTE, rand_zone())
 
-	if(prob(4))
-		var/obj/limb/dropped_limb = pick(mauled_human.limbs)
-		dropped_limb.droplimb(FALSE, FALSE, "machinery")
-
 //Buyin
 /datum/controller/supply/proc/buy()
 	var/area/area_shuttle = shuttle?.get_location_area()


### PR DESCRIPTION
# About the pull request

Removes the 4% chance for the ASRS to remove limbs, as it can still delimb from the damage dealt.

# Explain why it's good for the game

The delimb chance could remove any limb, and as a result could remove the groin, torso, or head. While the head and torso would instantly perma-kill you, losing your groin causes you to lose your legs. As you are not meant to lose these limbs there is no way to replace them.

fixes #2552 
# Changelog

:cl:
fix: The ASRS can no longer steal your groin.
/:cl: