### PR TITLE
Makes the Crew Monitor deconstructible

### DIFF
--- a/code/modules/cm_marines/marines_consoles.dm
+++ b/code/modules/cm_marines/marines_consoles.dm
@@ -665,6 +665,7 @@
 	name = "crew monitoring computer"
 	desc = "Used to monitor active health sensors built into the wearer's uniform.  You can see that the console highlights ship areas with BLUE and remote locations with RED."
 	icon_state = "crew"
+	circuit = /obj/item/circuitboard/computer/crew
 	density = TRUE
 	use_power = USE_POWER_IDLE
 	idle_power_usage = 250


### PR DESCRIPTION
# About the pull request

It gives the crew monitor a proper circuit so it can be deconstructed again.

# Explain why it's good for the game

It allows the marines to deconstruct computers, as MTs get two boards, and they can block a passage, their being indestructible can block paths accidentally or on purpose.

fixes #769 
(Doesn't change it being unslashable as xenos can melt through it)
# Changelog

:cl:
fix: Crew Monitoring computers can now be deconstructed the same way as any computer
/:cl: