### PR TITLE
De-adminned SEAs still get newbie messages

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -45,7 +45,7 @@
 
 		to_chat(possible_sea, msg)
 		if(possible_sea?.client.prefs?.toggles_sound & SOUND_ADMINHELP && !nosound)
-			sound_to(C, 'sound/effects/mhelp.ogg')
+			sound_to(possible_sea, 'sound/effects/mhelp.ogg')
 
 
 /proc/msg_admin_ff(var/text, var/alive = TRUE)

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -37,13 +37,15 @@
 			if(C.prefs.toggles_chat & CHAT_NICHELOGS)
 				to_chat(C, msg)
 
-/proc/msg_sea(var/msg, var/nosound = FALSE) //Only used for newplayer ticker message, hence no logging
+/proc/msg_sea(msg, nosound = FALSE) //Only used for newplayer ticker message, hence no logging
 	msg = FONT_SIZE_LARGE("<span class=\"admin\"><span class=\"prefix\">MENTOR ALERT:</span> <span class=\"message\">[msg]</span></span>")
-	for(var/client/C in GLOB.admins)
-		if((CLIENT_HAS_RIGHTS(C, R_MENTOR)) && C.admin_holder.rights && isSEA(C?.mob))
-			to_chat(C, msg)
-			if(C.prefs?.toggles_sound & SOUND_ADMINHELP && !nosound)
-				sound_to(C, 'sound/effects/mhelp.ogg')
+	for(var/mob/possible_sea as anything in GLOB.player_list)
+		if(!isSEA(possible_sea))
+			continue
+
+		to_chat(possible_sea, msg)
+		if(possible_sea?.client.prefs?.toggles_sound & SOUND_ADMINHELP && !nosound)
+			sound_to(C, 'sound/effects/mhelp.ogg')
 
 
 /proc/msg_admin_ff(var/text, var/alive = TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request
Non-adminned SEAs wouldn't get the newbie popups, which encourages you to stay adminned, even if there's no real reason for you to.

# Explain why it's good for the game
I don't want to stay adminned and be counted as "online" when I just want to chill and teach people as SEA


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
admin: You no longer need to stay adminned to get newbie popups as SEA
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
