### PR TITLE
allows mods to access the view combat logs button

### DIFF
--- a/code/modules/admin/view_variables/topic.dm
+++ b/code/modules/admin/view_variables/topic.dm
@@ -99,17 +99,17 @@
 				admin_ticket_log(L, "<font color='blue'>[log_msg]</font>")
 				vv_update_display(L, Text, "[newamt]")
 
-		else if(href_list["view_combat_logs"])
-			if(!check_rights(R_MOD))
-				return
+	if(href_list["view_combat_logs"])
+		if(!check_rights(R_MOD))
+			return
 
-			var/mob/A = locate(href_list["view_combat_logs"])
+		var/mob/A = locate(href_list["view_combat_logs"])
 
-			var/list/logs = list("<html><head><meta http-equiv='Content-Type' content='text/html; charset=UTF-8'><title>Combat Logs</title></head>")
-			for(var/entry in A.attack_log)
-				logs += "[entry]<br>"
+		var/list/logs = list("<html><head><meta http-equiv='Content-Type' content='text/html; charset=UTF-8'><title>Combat Logs</title></head>")
+		for(var/entry in A.attack_log)
+			logs += "[entry]<br>"
 
-			show_browser(usr, logs.Join(), "Combat Logs", "logs_\ref[src]", "size=600x480")
+		show_browser(usr, logs.Join(), "Combat Logs", "logs_\ref[src]", "size=600x480")
 
 
 	//Finally, refresh if something modified the list.


### PR DESCRIPTION
anti-mod discrimination is over (they should be able to press VV buttons that don't actually do anything

:cl:
admin: mods can now access the view combat logs button
/:cl: