### PR TITLE
removed MP timelock from XO, CE, RO + reverted SL timelock

### DIFF
--- a/code/game/jobs/job/command/cic/executive.dm
+++ b/code/game/jobs/job/command/cic/executive.dm
@@ -19,7 +19,6 @@
 
 AddTimelock(/datum/job/command/executive, list(
 	JOB_COMMAND_ROLES = 5 HOURS,
-	JOB_POLICE_ROLES = 3 HOURS
 ))
 
 /obj/effect/landmark/start/executive

--- a/code/game/jobs/job/logistics/cargo/chief_req.dm
+++ b/code/game/jobs/job/logistics/cargo/chief_req.dm
@@ -8,7 +8,6 @@
 
 AddTimelock(/datum/job/logistics/requisition, list(
 	JOB_REQUISITION_ROLES = 10 HOURS,
-	JOB_POLICE_ROLES = 1 HOURS
 ))
 
 /obj/effect/landmark/start/requisition

--- a/code/game/jobs/job/logistics/engi/chief_engineer.dm
+++ b/code/game/jobs/job/logistics/engi/chief_engineer.dm
@@ -7,7 +7,6 @@
 
 AddTimelock(/datum/job/logistics/engineering, list(
 	JOB_ENGINEER_ROLES = 10 HOURS,
-	JOB_POLICE_ROLES = 1 HOURS
 ))
 
 /obj/effect/landmark/start/engineering

--- a/code/game/jobs/job/marine/squad/leader.dm
+++ b/code/game/jobs/job/marine/squad/leader.dm
@@ -13,7 +13,7 @@
 	gear_preset = /datum/equipment_preset/wo/marine/sl
 
 AddTimelock(/datum/job/marine/leader, list(
-	JOB_SQUAD_RTO = 3 HOURS
+	JOB_SQUAD_ROLES = 10 HOURS
 ))
 
 /obj/effect/landmark/start/marine/leader


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

title

# Explain why it's good for the game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->

these timelocks are unimportant (all these jobs don't engage much with ML other than XO which only does so marginally), ineffective (people just afk), and restrictive (forces you to play as a job you may be very uninterested in, discouraging you from getting into xo/heads of department)

same logic for SL/RTO, I don't want to force people to play RTO, a role that is quite different from SL.


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
del: removed the MP timelock requirement from XO, CE, and RO
del: removed the RTO timelock requirement from SL, instead you now need 10 hours of squad roles
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
