### PR TITLE
Fixes the morgue having no exit stun.

### DIFF
--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -114,7 +114,7 @@
 /obj/structure/morgue/relaymove(mob/user)
 	if(user.is_mob_incapacitated())
 		return
-	if(!(exit_stun == 0))
+	if(exit_stun)
 		user.stunned = max(user.stunned, exit_stun) //Action delay when going out of a closet (or morgue in this case)
 		user.update_canmove() //Force the delay to go in action immediately
 		if(!user.lying)

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -114,9 +114,8 @@
 /obj/structure/morgue/relaymove(mob/user)
 	if(user.is_mob_incapacitated())
 		return
-	else
-		if(!(exit_stun == 0))
-			user.stunned = max(user.stunned, exit_stun) //Action delay when going out of a closet (or morgue in this case)
+	if(!(exit_stun == 0))
+		user.stunned = max(user.stunned, exit_stun) //Action delay when going out of a closet (or morgue in this case)
 		user.update_canmove() //Force the delay to go in action immediately
 		if(!user.lying)
 			user.visible_message(SPAN_WARNING("[user] suddenly gets out of [src]!"),

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -12,6 +12,7 @@
 	var/morgue_type = "morgue"
 	var/tray_path = /obj/structure/morgue_tray
 	var/morgue_open = 0
+	var/exit_stun = 2
 	anchored = TRUE
 	throwpass = 1
 
@@ -111,9 +112,16 @@
 		. = ..()
 
 /obj/structure/morgue/relaymove(mob/user)
-	if(user.is_mob_incapacitated(TRUE))
+	if(user.is_mob_incapacitated())
 		return
-	toggle_morgue(user)
+	else
+		if(!(exit_stun == 0))
+			user.stunned = max(user.stunned, exit_stun) //Action delay when going out of a closet (or morgue in this case)
+		user.update_canmove() //Force the delay to go in action immediately
+		if(!user.lying)
+			user.visible_message(SPAN_WARNING("[user] suddenly gets out of [src]!"),
+			SPAN_WARNING("You get out of [src] and get your bearings!"))
+		toggle_morgue(user)
 
 
 /*


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request
This fixes  #1735 by adding code to the relaymove of morgues (the function that's called when someone inside something moves) to allow for an exit stun. I tested it and it works.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
People were apparently exploiting the fact that it had no delay whatsoever, and this fixes that. Exploits bad grrr.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: fixed exploits surrounding morgues having no exit delay
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
