### PR TITLE
ensures that special keybinds are unbound & removes the kb validator

### DIFF
--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -124,21 +124,22 @@
 			if(is_blind(viewer) && isdeaf(viewer))
 				to_chat(viewer, msg)
 
-	if(emote_type & EMOTE_VISIBLE)
-		var/list/viewers = get_mobs_in_view(7, user)
-		for(var/mob/current_mob in viewers)
-			if(!(current_mob.client?.prefs.toggles_langchat & LANGCHAT_SEE_EMOTES))
-				viewers -= current_mob
-		run_langchat(user, viewers)
-	else if(emote_type & EMOTE_AUDIBLE)
-		var/list/heard = get_mobs_in_view(7, user)
-		for(var/mob/current_mob in heard)
-			if(current_mob.ear_deaf)
-				heard -= current_mob
-				continue
-			if(!(current_mob.client?.prefs.toggles_langchat & LANGCHAT_SEE_EMOTES))
-				heard -= current_mob
-		run_langchat(user, heard)
+	if(intentional)
+		if(emote_type & EMOTE_VISIBLE)
+			var/list/viewers = get_mobs_in_view(7, user)
+			for(var/mob/current_mob in viewers)
+				if(!(current_mob.client?.prefs.toggles_langchat & LANGCHAT_SEE_EMOTES))
+					viewers -= current_mob
+			run_langchat(user, viewers)
+		else if(emote_type & EMOTE_AUDIBLE)
+			var/list/heard = get_mobs_in_view(7, user)
+			for(var/mob/current_mob in heard)
+				if(current_mob.ear_deaf)
+					heard -= current_mob
+					continue
+				if(!(current_mob.client?.prefs.toggles_langchat & LANGCHAT_SEE_EMOTES))
+					heard -= current_mob
+			run_langchat(user, heard)
 
 	SEND_SIGNAL(user, COMSIG_MOB_EMOTED(key))
 

--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -127,9 +127,8 @@
 	if(emote_type & EMOTE_VISIBLE)
 		var/list/viewers = get_mobs_in_view(7, user)
 		for(var/mob/current_mob in viewers)
-			if(current_mob.client?.prefs.toggles_langchat)
-				if(!(current_mob.client?.prefs.toggles_langchat & LANGCHAT_SEE_EMOTES))
-					viewers -= current_mob
+			if(!(current_mob.client?.prefs.toggles_langchat & LANGCHAT_SEE_EMOTES))
+				viewers -= current_mob
 		run_langchat(user, viewers)
 	else if(emote_type & EMOTE_AUDIBLE)
 		var/list/heard = get_mobs_in_view(7, user)
@@ -137,9 +136,8 @@
 			if(current_mob.ear_deaf)
 				heard -= current_mob
 				continue
-			if(current_mob.client?.prefs.toggles_langchat)
-				if(!(current_mob.client?.prefs.toggles_langchat & LANGCHAT_SEE_EMOTES))
-					heard -= current_mob
+			if(!(current_mob.client?.prefs.toggles_langchat & LANGCHAT_SEE_EMOTES))
+				heard -= current_mob
 		run_langchat(user, heard)
 
 	SEND_SIGNAL(user, COMSIG_MOB_EMOTED(key))
@@ -304,7 +302,9 @@
 
 	log_emote(text)
 
-	var/ghost_text = "<b>[src]</b> [text]"
+	var/paygrade = get_paygrade()
+
+	var/rendered_text = "<b>[paygrade][src]</b> [text]"
 
 	var/origin_turf = get_turf(src)
 	if(client)
@@ -312,6 +312,11 @@
 			if(!ghost.client || isnewplayer(ghost))
 				continue
 			if(ghost.client.prefs.toggles_chat & CHAT_GHOSTSIGHT && !(ghost in viewers(origin_turf, null)))
-				ghost.show_message(ghost_text)
+				to_chat(ghost, rendered_text)
 
-	show_message(text)
+	visible_message(rendered_text)
+	var/list/viewers = get_mobs_in_view(7, src)
+	for(var/mob/current_mob in viewers)
+		if(!(current_mob.client?.prefs.toggles_langchat & LANGCHAT_SEE_EMOTES))
+			viewers -= current_mob
+	langchat_speech(text, viewers, GLOB.all_languages, skip_language_check = TRUE, additional_styles = list("emote", "langchat_small"))

--- a/code/datums/keybinding/admin.dm
+++ b/code/datums/keybinding/admin.dm
@@ -21,8 +21,8 @@
 	return TRUE
 
 /datum/keybinding/admin/mod_say
-	hotkey_keys = list("Unbound")
-	classic_keys = list("Unbound")
+	hotkey_keys = list()
+	classic_keys = list()
 	name = "mod_say"
 	full_name = "Mod say"
 	description = "Talk with other mods."
@@ -36,8 +36,8 @@
 	return TRUE
 
 /datum/keybinding/admin/mentor_say
-	hotkey_keys = list("Unbound")
-	classic_keys = list("Unbound")
+	hotkey_keys = list()
+	classic_keys = list()
 	name = "mentor_say"
 	full_name = "Mentor say"
 	description = "Talk with other mentors."
@@ -52,7 +52,7 @@
 
 /datum/keybinding/admin/admin_ghost
 	hotkey_keys = list("F5")
-	classic_keys = list("Unbound")
+	classic_keys = list()
 	name = "admin_ghost"
 	full_name = "Aghost"
 	description = "Go ghost"
@@ -82,7 +82,7 @@
 
 /datum/keybinding/admin/toggle_buildmode_self
 	hotkey_keys = list("F7")
-	classic_keys = list("Unbound")
+	classic_keys = list()
 	name = "toggle_buildmode_self"
 	full_name = "Toggle Buildmode Self"
 	description = "Toggles buildmode"
@@ -112,7 +112,7 @@
 
 /datum/keybinding/admin/deadsay
 	hotkey_keys = list("F10")
-	classic_keys = list("Unbound")
+	classic_keys = list()
 	name = "dsay"
 	full_name = "deadsay"
 	description = "Allows you to send a message to dead chat"
@@ -126,8 +126,8 @@
 	return TRUE
 
 /datum/keybinding/admin/deadmin
-	hotkey_keys = list("Unbound")
-	classic_keys = list("Unbound")
+	hotkey_keys = list()
+	classic_keys = list()
 	name = "deadmin"
 	full_name = "Deadmin"
 	description = "Shed your admin powers"
@@ -141,8 +141,8 @@
 	return TRUE
 
 /datum/keybinding/admin/readmin
-	hotkey_keys = list("Unbound")
-	classic_keys = list("Unbound")
+	hotkey_keys = list()
+	classic_keys = list()
 	name = "readmin"
 	full_name = "Readmin"
 	description = "Regain your admin powers"

--- a/code/datums/keybinding/carbon.dm
+++ b/code/datums/keybinding/carbon.dm
@@ -34,7 +34,7 @@
 	throw_mode = THROW_MODE_HIGH
 
 /datum/keybinding/carbon/cycle_intent
-	hotkey_keys = list("Unbound")
+	hotkey_keys = list()
 	classic_keys = list("Insert")
 	name = "cycle_intent"
 	full_name = "Cycle Intent"
@@ -118,7 +118,7 @@
 
 /datum/keybinding/carbon/give
 	hotkey_keys = list("G")
-	classic_keys = list("Unbound")
+	classic_keys = list()
 	name = "Give_Item"
 	full_name = "Give item"
 	description = "Give the item you're currently holding"

--- a/code/datums/keybinding/client.dm
+++ b/code/datums/keybinding/client.dm
@@ -21,7 +21,7 @@
 
 /datum/keybinding/client/screenshot
 	hotkey_keys = list("F2")
-	classic_keys = list("Unbound")
+	classic_keys = list()
 	name = "screenshot"
 	full_name = "Screenshot"
 	description = "Take a screenshot."

--- a/code/datums/keybinding/communication.dm
+++ b/code/datums/keybinding/communication.dm
@@ -17,7 +17,7 @@
 
 /datum/keybinding/client/communication/looc
 	hotkey_keys = list("L")
-	classic_keys = list("Unbound")
+	classic_keys = list()
 	name = LOOC_CHANNEL
 	full_name = "Local Out Of Character Say (OOC)"
 	keybind_signal = COMSIG_KB_CLIENT_LOOC_DOWN
@@ -30,8 +30,8 @@
 	keybind_signal = COMSIG_KB_CLIENT_ME_DOWN
 
 /datum/keybinding/client/communication/whisper
-	hotkey_keys = list("Unbound")
-	classic_keys = list("Unbound")
+	hotkey_keys = list()
+	classic_keys = list()
 	name = "Whisper"
 	full_name = "IC Whisper"
 	keybind_signal = COMSIG_KB_CLIENT_WHISPER_DOWN

--- a/code/datums/keybinding/emote.dm
+++ b/code/datums/keybinding/emote.dm
@@ -5,8 +5,8 @@
 	var/emote_key
 
 /datum/keybinding/emote/proc/link_to_emote(datum/emote/faketype)
-	hotkey_keys = list("Unbound")
-	classic_keys = list("Unbound")
+	hotkey_keys = list()
+	classic_keys = list()
 
 	emote_key = initial(faketype.key)
 	name = initial(faketype.key)

--- a/code/datums/keybinding/human.dm
+++ b/code/datums/keybinding/human.dm
@@ -59,8 +59,8 @@
 	return TRUE
 
 /datum/keybinding/human/quick_equip_quaternary
-	hotkey_keys = list("Unbound")
-	classic_keys = list("Unbound")
+	hotkey_keys = list()
+	classic_keys = list()
 	name = "quick_equip_quaternary"
 	full_name = "Unholster quaternary"
 	description = "Take out your quaternary item."
@@ -75,8 +75,8 @@
 	return TRUE
 
 /datum/keybinding/human/quick_equip_inventory
-	hotkey_keys = list("Unbound")
-	classic_keys = list("Unbound")
+	hotkey_keys = list()
+	classic_keys = list()
 	name = "quick_equip_inventory"
 	full_name = "Quick equip inventory"
 	description = "Quickly puts an item in the best slot available"
@@ -91,8 +91,8 @@
 	return TRUE
 
 /datum/keybinding/human/issue_order
-	hotkey_keys = list("Unbound")
-	classic_keys = list("Unbound")
+	hotkey_keys = list()
+	classic_keys = list()
 	name = "issue_order"
 	full_name = "Issue Order"
 	description = "Select an order to issue."
@@ -129,8 +129,8 @@
 	order = COMMAND_ORDER_FOCUS
 
 /datum/keybinding/human/specialist_one
-	hotkey_keys = list("Unbound")
-	classic_keys = list("Unbound")
+	hotkey_keys = list()
+	classic_keys = list()
 	name = "specialist_activation_one"
 	full_name = "Specialist Activation One"
 	keybind_signal = COMSIG_KB_HUMAN_SPECIALIST_ACTIVATION_ONE
@@ -144,8 +144,8 @@
 	return TRUE
 
 /datum/keybinding/human/specialist_two
-	hotkey_keys = list("Unbound")
-	classic_keys = list("Unbound")
+	hotkey_keys = list()
+	classic_keys = list()
 	name = "specialist_activation_two"
 	full_name = "Specialist Activation Two"
 	keybind_signal = COMSIG_KB_HUMAN_SPECIALIST_ACTIVATION_TWO

--- a/code/datums/keybinding/human_combat.dm
+++ b/code/datums/keybinding/human_combat.dm
@@ -10,8 +10,8 @@
 	return isgun(user_mob.get_held_item())
 
 /datum/keybinding/human/combat/field_strip_weapon
-	hotkey_keys = list("Unbound")
-	classic_keys = list("Unbound")
+	hotkey_keys = list()
+	classic_keys = list()
 	name = "field_strip_weapon"
 	full_name = "Field Strip Weapon"
 	keybind_signal = COMSIG_KB_HUMAN_WEAPON_FIELDSTRIP
@@ -28,7 +28,7 @@
 
 /datum/keybinding/human/combat/toggle_burst_fire
 	hotkey_keys = list("Ctrl+Space")
-	classic_keys = list("Unbound")
+	classic_keys = list()
 	name = "toggle_burst_fire"
 	full_name = "Toggle Burst Fire"
 	keybind_signal = COMSIG_KB_HUMAN_WEAPON_BURSTFIRE
@@ -44,7 +44,7 @@
 
 /datum/keybinding/human/combat/stock_attachment
 	hotkey_keys = list("Shift+X")
-	classic_keys = list("Unbound")
+	classic_keys = list()
 	name = "toggle_stock_attachment"
 	full_name = "Toggle Stock Attachment"
 	keybind_signal = COMSIG_KB_HUMAN_WEAPON_STOCKATTACHMENT
@@ -59,8 +59,8 @@
 	return TRUE
 
 /datum/keybinding/human/combat/auto_eject
-	hotkey_keys = list("Unbound")
-	classic_keys = list("Unbound")
+	hotkey_keys = list()
+	classic_keys = list()
 	name = "toggle_auto_eject"
 	full_name = "Toggle Auto Eject"
 	keybind_signal = COMSIG_KB_HUMAN_WEAPON_AUTOEJECT
@@ -76,7 +76,7 @@
 
 /datum/keybinding/human/combat/underbarrel
 	hotkey_keys = list("Shift+Space")
-	classic_keys = list("Unbound")
+	classic_keys = list()
 	name = "toggle_underbarrel_attachment"
 	full_name = "Toggle Underbarrel Attachment"
 	keybind_signal = COMSIG_KB_HUMAN_WEAPON_UNDERBARREL
@@ -92,7 +92,7 @@
 
 /datum/keybinding/human/combat/unique_action
 	hotkey_keys = list("Space")
-	classic_keys = list("Unbound")
+	classic_keys = list()
 	name = "unique_action"
 	full_name = "Unique Action"
 	keybind_signal = COMSIG_KB_HUMAN_WEAPON_UNIQUEACTION
@@ -108,7 +108,7 @@
 
 /datum/keybinding/human/combat/unload_gun
 	hotkey_keys = list("Shift+Z")
-	classic_keys = list("Unbound")
+	classic_keys = list()
 	name = "unload_weapon"
 	full_name = "Unload Weapon"
 	keybind_signal = COMSIG_KB_HUMAN_WEAPON_UNLOAD
@@ -124,7 +124,7 @@
 
 /datum/keybinding/human/combat/safety
 	hotkey_keys = list("Shift+V")
-	classic_keys = list("Unbound")
+	classic_keys = list()
 	name = "toggle_weapon_safety"
 	full_name = "Toggle Weapon Safety"
 	keybind_signal = COMSIG_KB_HUMAN_WEAPON_SAFETY
@@ -139,8 +139,8 @@
 	return TRUE
 
 /datum/keybinding/human/combat/attachment
-	hotkey_keys = list("Unbound")
-	classic_keys = list("Unbound")
+	hotkey_keys = list()
+	classic_keys = list()
 	name = "toggle_attachment"
 	full_name = "Toggle Attachment"
 	keybind_signal = COMSIG_KB_HUMAN_WEAPON_ATTACHMENT
@@ -156,7 +156,7 @@
 
 /datum/keybinding/human/combat/attachment_rail
 	hotkey_keys = list("Shift+G")
-	classic_keys = list("Unbound")
+	classic_keys = list()
 	name = "toggle_rail_attachment"
 	full_name = "Toggle Rail Attachment"
 	keybind_signal = COMSIG_KB_HUMAN_WEAPON_ATTACHMENT_RAIL
@@ -171,8 +171,8 @@
 	return TRUE
 
 /datum/keybinding/human/combat/toggle_iff
-	hotkey_keys = list("Unbound")
-	classic_keys = list("Unbound")
+	hotkey_keys = list()
+	classic_keys = list()
 	name = "toggle_iff"
 	full_name = "Toggle IFF"
 	keybind_signal = COMSIG_KB_HUMAN_WEAPON_TOGGLE_IFF

--- a/code/datums/keybinding/living.dm
+++ b/code/datums/keybinding/living.dm
@@ -7,7 +7,7 @@
 
 /datum/keybinding/living/resist
 	hotkey_keys = list("B")
-	classic_keys = list("Unbound")
+	classic_keys = list()
 	name = "resist"
 	full_name = "Resist"
 	description = "Break free of your current state. Handcuffed? on fire? Resist!"
@@ -23,7 +23,7 @@
 
 /datum/keybinding/living/rest
 	hotkey_keys = list("Shift+R")
-	classic_keys = list("Unbound")
+	classic_keys = list()
 	name = "rest"
 	full_name = "Rest"
 	description = "Lay down, or get up."
@@ -40,8 +40,8 @@
 /datum/keybinding/living/toggle_surgery
 	name = "toggle_surgery"
 	full_name = "Toggle Surgery Mode"
-	hotkey_keys = list("Unbound")
-	classic_keys = list("Unbound")
+	hotkey_keys = list()
+	classic_keys = list()
 	description = "Ready yourself to perform surgery, or not. Also activates or disables Help Intent Safety, if you didn't have that set originally."
 	keybind_signal = COMSIG_KB_SURGERY_INTENT_DOWN
 
@@ -56,7 +56,7 @@
 
 /datum/keybinding/living/mov_intent
 	hotkey_keys = list("/")
-	classic_keys = list("Unbound")
+	classic_keys = list()
 	name = "mov_intent"
 	full_name = "Move Intent"
 	description = "Toggles your current move intent."

--- a/code/datums/keybinding/mob.dm
+++ b/code/datums/keybinding/mob.dm
@@ -55,7 +55,7 @@
 
 /datum/keybinding/mob/drop_item
 	hotkey_keys = list("Q")
-	classic_keys = list("Unbound")
+	classic_keys = list()
 	name = "drop_item"
 	full_name = "Drop Item"
 	description = ""

--- a/code/datums/keybinding/xenomorph.dm
+++ b/code/datums/keybinding/xenomorph.dm
@@ -7,7 +7,7 @@
 
 /datum/keybinding/xenomorph/primary_attack_one
 	hotkey_keys = list("C")
-	classic_keys = list("Unbound")
+	classic_keys = list()
 	name = "primary_attack_one"
 	full_name = "Primary Attack One"
 	keybind_signal = COMSIG_KB_XENO_PRIMARY_ATTACK_ONE
@@ -22,7 +22,7 @@
 
 /datum/keybinding/xenomorph/primary_attack_two
 	hotkey_keys = list("V")
-	classic_keys = list("Unbound")
+	classic_keys = list()
 	name = "primary_attack_two"
 	full_name = "Primary Attack Two"
 	keybind_signal = COMSIG_KB_XENO_PRIMARY_ATTACK_TWO
@@ -37,7 +37,7 @@
 
 /datum/keybinding/xenomorph/primary_attack_three
 	hotkey_keys = list("G")
-	classic_keys = list("Unbound")
+	classic_keys = list()
 	name = "primary_attack_three"
 	full_name = "Primary Attack Three"
 	keybind_signal = COMSIG_KB_XENO_PRIMARY_ATTACK_THREE
@@ -52,7 +52,7 @@
 
 /datum/keybinding/xenomorph/primary_attack_four
 	hotkey_keys = list("B")
-	classic_keys = list("Unbound")
+	classic_keys = list()
 	name = "primary_attack_four"
 	full_name = "Primary Attack Four"
 	keybind_signal = COMSIG_KB_XENO_PRIMARY_ATTACK_FOUR
@@ -67,7 +67,7 @@
 
 /datum/keybinding/xenomorph/primary_attack_five
 	hotkey_keys = list("N")
-	classic_keys = list("Unbound")
+	classic_keys = list()
 	name = "primary_attack_five"
 	full_name = "Primary Attack Five"
 	keybind_signal = COMSIG_KB_XENO_PRIMARY_ATTACK_FIVE
@@ -81,8 +81,8 @@
 	return TRUE
 
 /datum/keybinding/xenomorph/emit_pheromones
-	hotkey_keys = list("Unbound")
-	classic_keys = list("Unbound")
+	hotkey_keys = list()
+	classic_keys = list()
 	name = "emit_pheromones"
 	full_name = "Emit Pheromones"
 	description = "Select a pheromone to emit or cease emitting pheromones."
@@ -120,7 +120,7 @@
 
 /datum/keybinding/xenomorph/corrosive_acid
 	hotkey_keys = list("Shift+C")
-	classic_keys = list("Unbound")
+	classic_keys = list()
 	name = "corrosive_acid"
 	full_name = "Corrosive Acid"
 	keybind_signal = COMSIG_KB_XENO_CORROSIVE_ACID
@@ -135,7 +135,7 @@
 
 /datum/keybinding/xenomorph/tech_secrete_resin
 	hotkey_keys = list("Shift+B")
-	classic_keys = list("Unbound")
+	classic_keys = list()
 	name = "tech_secrete_resin"
 	full_name = "Secrete Resin (Tech)"
 	keybind_signal = COMSIG_KB_XENO_TECH_SECRETE_RESIN
@@ -149,8 +149,8 @@
 	return TRUE
 
 /datum/keybinding/xenomorph/screech
-	hotkey_keys = list("Unbound")
-	classic_keys = list("Unbound")
+	hotkey_keys = list()
+	classic_keys = list()
 	name = "screech"
 	full_name = "Screech"
 	keybind_signal = COMSIG_KB_XENO_SCREECH
@@ -164,8 +164,8 @@
 	return TRUE
 
 /datum/keybinding/xenomorph/tail_stab
-	hotkey_keys = list("Unbound")
-	classic_keys = list("Unbound")
+	hotkey_keys = list()
+	classic_keys = list()
 	name = "tail_stab"
 	full_name = "Tail Stab"
 	keybind_signal = COMSIG_KB_TAIL_STAB

--- a/code/datums/keybinding/yautja.dm
+++ b/code/datums/keybinding/yautja.dm
@@ -10,8 +10,8 @@
 // mob \\
 
 /datum/keybinding/yautja/butcher
-	hotkey_keys = list("Unbound")
-	classic_keys = list("Unbound")
+	hotkey_keys = list()
+	classic_keys = list()
 	name = "butcher"
 	full_name = "Butcher"
 	keybind_signal = COMSIG_KB_YAUTJA_BUTCHER
@@ -26,8 +26,8 @@
 	H.butcher()
 
 /datum/keybinding/yautja/pred_buy
-	hotkey_keys = list("Unbound")
-	classic_keys = list("Unbound")
+	hotkey_keys = list()
+	classic_keys = list()
 	name = "pred_buy"
 	full_name = "Claim equipment"
 	keybind_signal = COMSIG_KB_YAUTJA_BUTCHER
@@ -42,8 +42,8 @@
 	H.pred_buy()
 
 /datum/keybinding/yautja/mark_panel
-	hotkey_keys = list("Unbound")
-	classic_keys = list("Unbound")
+	hotkey_keys = list()
+	classic_keys = list()
 	name = "mark_panel"
 	full_name = "Mark panel"
 	keybind_signal = COMSIG_KB_YAUTJA_MARK_PANEL
@@ -58,8 +58,8 @@
 	H.mark_panel()
 
 /datum/keybinding/yautja/mark_for_hunt
-	hotkey_keys = list("Unbound")
-	classic_keys = list("Unbound")
+	hotkey_keys = list()
+	classic_keys = list()
 	name = "mark_for_hunt"
 	full_name = "Mark for hunt"
 	keybind_signal = COMSIG_KB_YAUTJA_MARK_FOR_HUNT
@@ -74,8 +74,8 @@
 	H.mark_for_hunt()
 
 /datum/keybinding/yautja/remove_from_hunt
-	hotkey_keys = list("Unbound")
-	classic_keys = list("Unbound")
+	hotkey_keys = list()
+	classic_keys = list()
 	name = "remove_from_hunt"
 	full_name = "Remove from hunt"
 	keybind_signal = COMSIG_KB_YAUTJA_REMOVE_FROM_HUNT
@@ -104,8 +104,8 @@
 		return TRUE
 
 /datum/keybinding/yautja/bracer/toggle_notification_sound
-	hotkey_keys = list("Unbound")
-	classic_keys = list("Unbound")
+	hotkey_keys = list()
+	classic_keys = list()
 	name = "toggle_notification_sound"
 	full_name = "Toggle bracer notification sound"
 	keybind_signal = COMSIG_KB_YAUTJA_TOGGLE_NOTIFICATION_SOUND
@@ -127,8 +127,8 @@
 		return TRUE
 
 /datum/keybinding/yautja/bracer/bracer_message
-	hotkey_keys = list("Unbound")
-	classic_keys = list("Unbound")
+	hotkey_keys = list()
+	classic_keys = list()
 	name = "bracer_message"
 	full_name = "Bracer message"
 	keybind_signal = COMSIG_KB_YAUTJA_TOGGLE_NOTIFICATION_SOUND
@@ -162,8 +162,8 @@
 		return TRUE
 
 /datum/keybinding/yautja/bracer_hunter/wristblades
-	hotkey_keys = list("Unbound")
-	classic_keys = list("Unbound")
+	hotkey_keys = list()
+	classic_keys = list()
 	name = "wristblades"
 	full_name = "Toggle wristblades"
 	keybind_signal = COMSIG_KB_YAUTJA_WRISTBLADES
@@ -185,8 +185,8 @@
 		return TRUE
 
 /datum/keybinding/yautja/bracer_hunter/track_gear
-	hotkey_keys = list("Unbound")
-	classic_keys = list("Unbound")
+	hotkey_keys = list()
+	classic_keys = list()
 	name = "track_gear"
 	full_name = "Track gear"
 	keybind_signal = COMSIG_KB_YAUTJA_TRACK_GEAR
@@ -208,8 +208,8 @@
 		return TRUE
 
 /datum/keybinding/yautja/bracer_hunter/cloaker
-	hotkey_keys = list("Unbound")
-	classic_keys = list("Unbound")
+	hotkey_keys = list()
+	classic_keys = list()
 	name = "cloaker"
 	full_name = "Toggle cloak"
 	keybind_signal = COMSIG_KB_YAUTJA_CLOAKER
@@ -231,8 +231,8 @@
 		return TRUE
 
 /datum/keybinding/yautja/bracer_hunter/caster
-	hotkey_keys = list("Unbound")
-	classic_keys = list("Unbound")
+	hotkey_keys = list()
+	classic_keys = list()
 	name = "caster"
 	full_name = "Toggle plasma caster"
 	keybind_signal = COMSIG_KB_YAUTJA_CASTER
@@ -254,8 +254,8 @@
 		return TRUE
 
 /datum/keybinding/yautja/bracer_hunter/change_explosion_type
-	hotkey_keys = list("Unbound")
-	classic_keys = list("Unbound")
+	hotkey_keys = list()
+	classic_keys = list()
 	name = "change_explosion_type"
 	full_name = "Change explosion type"
 	keybind_signal = COMSIG_KB_YAUTJA_CHANGE_EXPLOSION_TYPE
@@ -277,8 +277,8 @@
 		return TRUE
 
 /datum/keybinding/yautja/bracer_hunter/activate_suicide
-	hotkey_keys = list("Unbound")
-	classic_keys = list("Unbound")
+	hotkey_keys = list()
+	classic_keys = list()
 	name = "activate_suicide"
 	full_name = "Self-destruct"
 	keybind_signal = COMSIG_KB_YAUTJA_ACTIVATE_SUICIDE
@@ -300,8 +300,8 @@
 		return TRUE
 
 /datum/keybinding/yautja/bracer_hunter/injectors
-	hotkey_keys = list("Unbound")
-	classic_keys = list("Unbound")
+	hotkey_keys = list()
+	classic_keys = list()
 	name = "injectors"
 	full_name = "Create Stabilising Crystal"
 	keybind_signal = COMSIG_KB_YAUTJA_INJECTORS
@@ -322,8 +322,8 @@
 		held.injectors()
 		return TRUE
 /datum/keybinding/yautja/bracer_hunter/healing_capsule
-	hotkey_keys = list("Unbound")
-	classic_keys = list("Unbound")
+	hotkey_keys = list()
+	classic_keys = list()
 	name = "capsule"
 	full_name = "Create Healing Capsule"
 	keybind_signal = COMSIG_KB_YAUTJA_CAPSULE
@@ -345,8 +345,8 @@
 		return TRUE
 
 /datum/keybinding/yautja/bracer_hunter/call_disk
-	hotkey_keys = list("Unbound")
-	classic_keys = list("Unbound")
+	hotkey_keys = list()
+	classic_keys = list()
 	name = "call_disk"
 	full_name = "Call smart-disc"
 	keybind_signal = COMSIG_KB_YAUTJA_CALL_DISK
@@ -368,8 +368,8 @@
 		return TRUE
 
 /datum/keybinding/yautja/bracer_hunter/remove_tracked_item
-	hotkey_keys = list("Unbound")
-	classic_keys = list("Unbound")
+	hotkey_keys = list()
+	classic_keys = list()
 	name = "remove_tracked_item"
 	full_name = "Remove item from tracker"
 	keybind_signal = COMSIG_KB_YAUTJA_REMOVE_TRACKED_ITEM
@@ -391,8 +391,8 @@
 		return TRUE
 
 /datum/keybinding/yautja/bracer_hunter/add_tracked_item
-	hotkey_keys = list("Unbound")
-	classic_keys = list("Unbound")
+	hotkey_keys = list()
+	classic_keys = list()
 	name = "add_tracked_item"
 	full_name = "Add item to tracker"
 	keybind_signal = COMSIG_KB_YAUTJA_ADD_TRACKED_ITEM
@@ -414,8 +414,8 @@
 		return TRUE
 
 /datum/keybinding/yautja/bracer_hunter/call_combi
-	hotkey_keys = list("Unbound")
-	classic_keys = list("Unbound")
+	hotkey_keys = list()
+	classic_keys = list()
 	name = "call_combi"
 	full_name = "Yank combi-stick"
 	keybind_signal = COMSIG_KB_YAUTJA_CALL_COMBI
@@ -437,8 +437,8 @@
 		return TRUE
 
 /datum/keybinding/yautja/bracer_hunter/translate
-	hotkey_keys = list("Unbound")
-	classic_keys = list("Unbound")
+	hotkey_keys = list()
+	classic_keys = list()
 	name = "translate"
 	full_name = "Translator"
 	keybind_signal = COMSIG_KB_YAUTJA_TRANSLATE
@@ -460,8 +460,8 @@
 		return TRUE
 
 /datum/keybinding/yautja/bracer_hunter/bracername
-	hotkey_keys = list("Unbound")
-	classic_keys = list("Unbound")
+	hotkey_keys = list()
+	classic_keys = list()
 	name = "bracername"
 	full_name = "Toggle bracer name"
 	keybind_signal = COMSIG_KB_YAUTJA_BRACERNAME
@@ -483,8 +483,8 @@
 		return TRUE
 
 /datum/keybinding/yautja/bracer_hunter/idchip
-	hotkey_keys = list("Unbound")
-	classic_keys = list("Unbound")
+	hotkey_keys = list()
+	classic_keys = list()
 	name = "idchip"
 	full_name = "Toggle ID chip"
 	keybind_signal = COMSIG_KB_YAUTJA_IDCHIP
@@ -506,8 +506,8 @@
 		return TRUE
 
 /datum/keybinding/yautja/bracer_hunter/link_bracer
-	hotkey_keys = list("Unbound")
-	classic_keys = list("Unbound")
+	hotkey_keys = list()
+	classic_keys = list()
 	name = "link_bracer"
 	full_name = "Link thrall bracer"
 	keybind_signal = COMSIG_KB_YAUTJA_LINK_BRACER
@@ -541,8 +541,8 @@
 		return TRUE
 
 /datum/keybinding/yautja/mask/toggle_zoom
-	hotkey_keys = list("Unbound")
-	classic_keys = list("Unbound")
+	hotkey_keys = list()
+	classic_keys = list()
 	name = "toggle_zoom"
 	full_name = "Toggle mask zoom"
 	keybind_signal = COMSIG_KB_YAUTJA_LINK_BRACER
@@ -557,8 +557,8 @@
 	return TRUE
 
 /datum/keybinding/yautja/mask/togglesight
-	hotkey_keys = list("Unbound")
-	classic_keys = list("Unbound")
+	hotkey_keys = list()
+	classic_keys = list()
 	name = "togglesight"
 	full_name = "Toggle mask visors"
 	keybind_signal = COMSIG_KB_YAUTJA_LINK_BRACER
@@ -581,8 +581,8 @@
 		return TRUE
 
 /datum/keybinding/yautja/tele_loc
-	hotkey_keys = list("Unbound")
-	classic_keys = list("Unbound")
+	hotkey_keys = list()
+	classic_keys = list()
 	name = "tele_loc"
 	full_name = "Add teleporter location"
 	keybind_signal = COMSIG_KB_YAUTJA_TELE_LOC

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -174,7 +174,6 @@
 	S["yautja_status"] >> yautja_status
 	S["synth_status"] >> synth_status
 	S["key_bindings"] >> key_bindings
-	check_keybindings()
 
 	S["preferred_survivor_variant"]	>> preferred_survivor_variant
 
@@ -588,45 +587,6 @@
 	S["exploit_record"] << exploit_record
 
 	return 1
-
-/datum/preferences/proc/check_keybindings()
-	if(!owner)
-		return
-	var/list/user_binds = list()
-	for (var/key in key_bindings)
-		for(var/kb_name in key_bindings[key])
-			user_binds[kb_name] += list(key)
-	var/list/notadded = list()
-	for (var/name in GLOB.keybindings_by_name)
-		var/datum/keybinding/kb = GLOB.keybindings_by_name[name]
-		if(length(user_binds[kb.name]))
-			continue // key is unbound and or bound to something
-		var/addedbind = FALSE
-		if(hotkeys)
-			for(var/hotkeytobind in kb.hotkey_keys)
-				if(!length(key_bindings[hotkeytobind]) || hotkeytobind == "Unbound") //Only bind to the key if nothing else is bound expect for Unbound
-					LAZYADD(key_bindings[hotkeytobind], kb.name)
-					addedbind = TRUE
-		else
-			for(var/classickeytobind in kb.classic_keys)
-				if(!length(key_bindings[classickeytobind]) || classickeytobind == "Unbound") //Only bind to the key if nothing else is bound expect for Unbound
-					LAZYADD(key_bindings[classickeytobind], kb.name)
-					addedbind = TRUE
-		if(!addedbind)
-			notadded += kb
-	save_preferences() //Save the players pref so that new keys that were set to Unbound as default are permanently stored
-	if(length(notadded))
-		addtimer(CALLBACK(src, PROC_REF(announce_conflict), notadded), 5 SECONDS)
-
-/datum/preferences/proc/announce_conflict(list/notadded)
-	to_chat(owner, "<span class='warningplain'><b><u>Keybinding Conflict</u></b></span>\n\
-					<span class='warningplain'><b>There are new <a href='?_src_=prefs;preference=tab;tab=3'>keybindings</a> that default to keys you've already bound. The new ones will be unbound.</b></span>")
-	for(var/item in notadded)
-		var/datum/keybinding/conflicted = item
-		to_chat(owner, SPAN_DANGER("[conflicted.category]: [conflicted.full_name] needs updating"))
-		LAZYADD(key_bindings["Unbound"], conflicted.name) // set it to unbound to prevent this from opening up again in the future
-		save_preferences()
-
 
 
 #undef SAVEFILE_VERSION_MAX

--- a/code/modules/client/tgui_macro.dm
+++ b/code/modules/client/tgui_macro.dm
@@ -110,6 +110,7 @@ GLOBAL_LIST_EMPTY(ui_data_keybindings)
 						kbinds -= key
 
 			prefs.save_preferences()
+			INVOKE_ASYNC(owner, /client/proc/set_macros)
 			return TRUE
 		if("clear_all_keybinds")
 			var/choice = tgui_alert(owner, "Would you prefer 'hotkey' or 'classic' defaults?", "Setup keybindings", list("Hotkey", "Classic", "Cancel"))

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -95,6 +95,11 @@
 	key_third_person = "frowns"
 	message = "frowns."
 
+/datum/emote/living/carbon/human/gasp
+	key = "gasp"
+	key_third_person = "gasps"
+	message = "gasps!"
+
 /datum/emote/living/carbon/human/giggle
 	key = "giggle"
 	key_third_person = "giggles"

--- a/code/modules/mob/living/carbon/xenomorph/emote.dm
+++ b/code/modules/mob/living/carbon/xenomorph/emote.dm
@@ -1,14 +1,18 @@
 /datum/emote/living/carbon/xeno
 	mob_type_allowed_typecache = list(/mob/living/carbon/xenomorph)
-	mob_type_blacklist_typecache = list(/mob/living/carbon/xenomorph/hellhound)
+	mob_type_blacklist_typecache = list(/mob/living/carbon/xenomorph/hellhound, /mob/living/carbon/xenomorph/facehugger, /mob/living/carbon/xenomorph/larva)
 	keybind_category = CATEGORY_XENO_EMOTE
 	var/predalien_sound
+	var/larva_sound
 
 /datum/emote/living/carbon/xeno/get_sound(mob/living/user)
 	. = ..()
 
-	if(ispredalien(user))
+	if(ispredalien(user) && predalien_sound)
 		. = predalien_sound
+
+	if(islarva(user) && larva_sound)
+		. = larva_sound
 
 /datum/emote/living/carbon/xeno/growl
 	key = "growl"
@@ -29,10 +33,13 @@
 	message = "needs help!"
 
 /datum/emote/living/carbon/xeno/roar
+	mob_type_blacklist_typecache = list()
+
 	key = "roar"
 	message = "roars!"
 	sound = "alien_roar"
 	predalien_sound = 'sound/voice/predalien_roar.ogg'
+	larva_sound = "alien_roar_larva"
 	emote_type = EMOTE_AUDIBLE|EMOTE_VISIBLE
 
 /datum/emote/living/carbon/xeno/tail

--- a/code/modules/mob/living/carbon/xenomorph/emote.dm
+++ b/code/modules/mob/living/carbon/xenomorph/emote.dm
@@ -31,6 +31,8 @@
 /datum/emote/living/carbon/xeno/needshelp
 	key = "needshelp"
 	message = "needs help!"
+	sound = "alien_help"
+	emote_type = EMOTE_AUDIBLE|EMOTE_VISIBLE
 
 /datum/emote/living/carbon/xeno/roar
 	mob_type_blacklist_typecache = list()

--- a/code/modules/mob/living/carbon/xenomorph/emote.dm
+++ b/code/modules/mob/living/carbon/xenomorph/emote.dm
@@ -1,6 +1,6 @@
 /datum/emote/living/carbon/xeno
-	mob_type_allowed_typecache = list(/mob/living/carbon/Xenomorph)
-	mob_type_blacklist_typecache = list(/mob/living/carbon/Xenomorph/Hellhound)
+	mob_type_allowed_typecache = list(/mob/living/carbon/xenomorph)
+	mob_type_blacklist_typecache = list(/mob/living/carbon/xenomorph/hellhound)
 	keybind_category = CATEGORY_XENO_EMOTE
 	var/predalien_sound
 
@@ -41,7 +41,7 @@
 	sound = "alien_tail_swipe"
 
 /datum/emote/living/carbon/xeno/hellhound
-	mob_type_allowed_typecache = list(/mob/living/carbon/Xenomorph/Hellhound)
+	mob_type_allowed_typecache = list(/mob/living/carbon/xenomorph/hellhound)
 	keybind = FALSE
 
 /datum/emote/living/carbon/xeno/hellhound/roar


### PR DESCRIPTION
title, also added a missed emote

:cl:
fix: you can now unbind special keybinds, and your keybind preferences won't be forgotten
/:cl:

fixes #2577 