### PR TITLE
Colony door fix

### DIFF
--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -401,11 +401,14 @@
 	req_access = list()
 	req_one_access = list(ACCESS_MARINE_LOGISTICS, ACCESS_MARINE_MAINT)
 
+/obj/structure/machinery/door/airlock/almayer/maint/autoname
+	autoname = TRUE
+
 /obj/structure/machinery/door/airlock/almayer/maint/colony
 	req_access = null
 	req_one_access = list(ACCESS_CIVILIAN_PUBLIC)
 
-/obj/structure/machinery/door/airlock/almayer/maint/autoname
+/obj/structure/machinery/door/airlock/almayer/maint/colony/autoname
 	autoname = TRUE
 
 /obj/structure/machinery/door/airlock/almayer/maint/reinforced

--- a/code/game/machinery/doors/multi_tile.dm
+++ b/code/game/machinery/doors/multi_tile.dm
@@ -17,7 +17,7 @@
 	glass = 1
 	assembly_type = /obj/structure/airlock_assembly/multi_tile
 
-/obj/structure/machinery/door/airlock/multi_tile/glass
+/obj/structure/machinery/door/airlock/multi_tile/glass/colony
 	req_access = null
 	req_one_access = list(ACCESS_CIVILIAN_PUBLIC)
 
@@ -47,7 +47,7 @@
 	opacity = FALSE
 	glass = 1
 
-/obj/structure/machinery/door/airlock/multi_tile/medical
+/obj/structure/machinery/door/airlock/multi_tile/medical/colony
 	req_access = null
 	req_one_access = list(ACCESS_CIVILIAN_MEDBAY, ACCESS_CIVILIAN_RESEARCH, ACCESS_CIVILIAN_COMMAND, ACCESS_CIVILIAN_PUBLIC)
 
@@ -472,10 +472,6 @@
 	req_access = null
 	req_one_access = list(ACCESS_CIVILIAN_COMMAND, ACCESS_CIVILIAN_ENGINEERING, ACCESS_CIVILIAN_LOGISTICS)
 
-/obj/structure/machinery/door/airlock/multi_tile/almayer/engidoor
-	req_access = null
-	req_one_access = list(ACCESS_MARINE_LOGISTICS, ACCESS_MARINE_ENGINEERING)
-
 /obj/structure/machinery/door/airlock/multi_tile/almayer/engidoor/autoname
 	autoname = TRUE
 
@@ -487,10 +483,6 @@
 /obj/structure/machinery/door/airlock/multi_tile/almayer/engidoor/glass/colony
 	req_access = null
 	req_one_access = list(ACCESS_CIVILIAN_COMMAND, ACCESS_CIVILIAN_ENGINEERING, ACCESS_CIVILIAN_LOGISTICS)
-
-/obj/structure/machinery/door/airlock/multi_tile/almayer/engidoor/glass
-	req_access = null
-	req_one_access = list(ACCESS_MARINE_LOGISTICS, ACCESS_MARINE_ENGINEERING)
 
 /obj/structure/machinery/door/airlock/multi_tile/almayer/engidoor/glass/autoname
 	autoname = TRUE

--- a/maps/map_files/FOP_v3_Sciannex/Fiorina_SciAnnex.dmm
+++ b/maps/map_files/FOP_v3_Sciannex/Fiorina_SciAnnex.dmm
@@ -309,9 +309,8 @@
 /turf/open/floor/plating/prison,
 /area/fiorina/lz/near_lzI)
 "aif" = (
-/obj/structure/machinery/door/airlock/almayer/maint/colony{
+/obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	dir = 1;
-	name = "\improper Null Hatch REPLACE ME";
 	req_access = null;
 	req_one_access = null
 	},
@@ -916,9 +915,8 @@
 	},
 /area/fiorina/station/medbay)
 "ayX" = (
-/obj/structure/machinery/door/airlock/almayer/maint/colony{
+/obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	dir = 1;
-	name = "\improper Null Hatch REPLACE ME";
 	req_access = null;
 	req_one_access = null
 	},
@@ -1529,9 +1527,8 @@
 	},
 /area/fiorina/station/power_ring)
 "aMM" = (
-/obj/structure/machinery/door/airlock/almayer/maint/colony{
+/obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	dir = 1;
-	name = "\improper Null Hatch REPLACE ME";
 	req_access = null;
 	req_one_access = null
 	},
@@ -4548,8 +4545,7 @@
 	},
 /area/fiorina/station/civres_blue)
 "cDl" = (
-/obj/structure/machinery/door/airlock/almayer/maint/colony{
-	name = "\improper Null Hatch REPLACE ME";
+/obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	req_access = null;
 	req_one_access = null
 	},
@@ -4689,8 +4685,7 @@
 /turf/open/floor/prison,
 /area/fiorina/station/security)
 "cHD" = (
-/obj/structure/machinery/door/airlock/almayer/maint/colony{
-	name = "\improper Null Hatch REPLACE ME";
+/obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	req_access = null;
 	req_one_access = null
 	},
@@ -5984,8 +5979,7 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/fiorina/tumor/fiberbush)
 "dwT" = (
-/obj/structure/machinery/door/airlock/almayer/maint/colony{
-	name = "\improper Null Hatch REPLACE ME";
+/obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	req_access = null;
 	req_one_access = null
 	},
@@ -10350,9 +10344,8 @@
 	},
 /area/fiorina/tumor/aux_engi)
 "gfh" = (
-/obj/structure/machinery/door/airlock/almayer/maint/colony{
+/obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	dir = 1;
-	name = "\improper Null Hatch REPLACE ME";
 	req_access = null;
 	req_one_access = null
 	},
@@ -13404,9 +13397,8 @@
 	},
 /area/fiorina/station/security)
 "hVG" = (
-/obj/structure/machinery/door/airlock/almayer/maint/colony{
+/obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	dir = 1;
-	name = "\improper Null Hatch REPLACE ME";
 	req_access = null;
 	req_one_access = null
 	},
@@ -15397,8 +15389,7 @@
 /turf/open/floor/plating/prison,
 /area/fiorina/station/transit_hub)
 "jjs" = (
-/obj/structure/machinery/door/airlock/almayer/maint/colony{
-	name = "\improper Null Hatch REPLACE ME";
+/obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	req_access = null;
 	req_one_access = null
 	},
@@ -15942,9 +15933,8 @@
 	},
 /area/fiorina/station/medbay)
 "jwc" = (
-/obj/structure/machinery/door/airlock/almayer/maint/colony{
+/obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	dir = 1;
-	name = "\improper Null Hatch REPLACE ME";
 	req_access = null;
 	req_one_access = null
 	},
@@ -20381,10 +20371,9 @@
 	},
 /area/fiorina/station/medbay)
 "mbp" = (
-/obj/structure/machinery/door/airlock/almayer/maint/colony{
+/obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	dir = 1;
 	locked = 0;
-	name = "\improper Null Hatch REPLACE ME";
 	},
 /turf/open/floor/plating/prison,
 /area/fiorina/oob)
@@ -20656,9 +20645,8 @@
 /turf/open/space,
 /area/fiorina/oob)
 "mhM" = (
-/obj/structure/machinery/door/airlock/almayer/maint/colony{
+/obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	dir = 1;
-	name = "\improper Null Hatch REPLACE ME";
 	req_access = null;
 	req_one_access = null
 	},
@@ -25768,8 +25756,7 @@
 /turf/open/floor/plating/prison,
 /area/fiorina/lz/near_lzII)
 "ppI" = (
-/obj/structure/machinery/door/airlock/almayer/maint/colony{
-	name = "\improper Null Hatch REPLACE ME";
+/obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	req_access = null;
 	req_one_access = null
 	},
@@ -30159,9 +30146,8 @@
 	},
 /area/fiorina/station/research_cells)
 "rSr" = (
-/obj/structure/machinery/door/airlock/almayer/maint/colony{
+/obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	dir = 1;
-	name = "\improper Null Hatch REPLACE ME";
 	req_access = null;
 	req_one_access = null
 	},
@@ -31153,9 +31139,8 @@
 	},
 /area/fiorina/station/telecomm/lz1_cargo)
 "sBA" = (
-/obj/structure/machinery/door/airlock/almayer/maint/colony{
+/obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	dir = 1;
-	name = "\improper Null Hatch REPLACE ME";
 	req_access = null;
 	req_one_access = null
 	},
@@ -31218,9 +31203,8 @@
 	},
 /area/fiorina/station/power_ring)
 "sDL" = (
-/obj/structure/machinery/door/airlock/almayer/maint/colony{
+/obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	dir = 1;
-	name = "\improper Null Hatch REPLACE ME";
 	req_access = null;
 	req_one_access = null
 	},
@@ -32314,8 +32298,7 @@
 	},
 /area/fiorina/station/security)
 "tpa" = (
-/obj/structure/machinery/door/airlock/almayer/maint/colony{
-	name = "\improper Null Hatch REPLACE ME";
+/obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	req_access = null;
 	req_one_access = null
 	},
@@ -36276,9 +36259,8 @@
 	},
 /area/fiorina/station/civres_blue)
 "vFs" = (
-/obj/structure/machinery/door/airlock/almayer/maint/colony{
+/obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	dir = 1;
-	name = "\improper Null Hatch REPLACE ME";
 	req_access = null;
 	req_one_access = null
 	},
@@ -38035,8 +38017,7 @@
 	},
 /area/fiorina/tumor/servers)
 "wMi" = (
-/obj/structure/machinery/door/airlock/almayer/maint/colony{
-	name = "\improper Null Hatch REPLACE ME";
+/obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	req_access = null;
 	req_one_access = null
 	},
@@ -38250,9 +38231,8 @@
 	},
 /area/fiorina/station/power_ring)
 "wRP" = (
-/obj/structure/machinery/door/airlock/almayer/maint/colony{
+/obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	dir = 1;
-	name = "\improper Null Hatch REPLACE ME";
 	req_access = null;
 	req_one_access = null
 	},
@@ -38698,8 +38678,7 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/fiorina/station/security)
 "xja" = (
-/obj/structure/machinery/door/airlock/almayer/maint/colony{
-	name = "\improper Null Hatch REPLACE ME";
+/obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	req_access = null;
 	req_one_access = null
 	},

--- a/maps/map_files/Ice_Colony_v3/Shivas_Snowball.dmm
+++ b/maps/map_files/Ice_Colony_v3/Shivas_Snowball.dmm
@@ -6202,9 +6202,8 @@
 /turf/open/floor/wood,
 /area/shiva/interior/colony/central)
 "aSa" = (
-/obj/structure/machinery/door/airlock/almayer/maint/colony{
+/obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	dir = 1;
-	name = "\improper Null Hatch REPLACE ME";
 	},
 /turf/open/floor/plating,
 /area/shiva/interior/colony/medseceng)
@@ -6239,9 +6238,8 @@
 /turf/closed/wall/shiva/prefabricated/white,
 /area/shiva/exterior/cp_lz2)
 "aSz" = (
-/obj/structure/machinery/door/airlock/almayer/maint/colony{
+/obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	dir = 8;
-	name = "\improper Null Hatch REPLACE ME";
 	},
 /turf/open/floor/plating,
 /area/shiva/interior/colony/medseceng)
@@ -8059,9 +8057,8 @@
 	},
 /area/shiva/interior/colony/n_admin)
 "bUe" = (
-/obj/structure/machinery/door/airlock/almayer/maint/colony{
+/obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	dir = 1;
-	name = "\improper Null Hatch REPLACE ME";
 	},
 /turf/open/floor/shiva,
 /area/shiva/interior/colony/research_hab)
@@ -8134,9 +8131,8 @@
 /turf/open/auto_turf/snow/layer3,
 /area/shiva/exterior/junkyard)
 "bXo" = (
-/obj/structure/machinery/door/airlock/almayer/maint/colony{
+/obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	dir = 1;
-	name = "\improper Null Hatch REPLACE ME";
 	req_access = null;
 	req_one_access = null
 	},
@@ -10148,9 +10144,8 @@
 /turf/open/auto_turf/snow/layer2,
 /area/shiva/exterior/lz1_valley)
 "esf" = (
-/obj/structure/machinery/door/airlock/almayer/maint/colony{
+/obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	dir = 1;
-	name = "\improper Null Hatch REPLACE ME";
 	req_access = null;
 	req_one_access = null
 	},
@@ -14605,9 +14600,8 @@
 /turf/open/floor/wood,
 /area/shiva/interior/bar)
 "jis" = (
-/obj/structure/machinery/door/airlock/almayer/maint/colony{
+/obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	dir = 8;
-	name = "\improper Null Hatch REPLACE ME";
 	},
 /turf/open/floor/plating,
 /area/shiva/interior/colony/research_hab)
@@ -14654,9 +14648,8 @@
 /turf/open/floor/shiva,
 /area/shiva/interior/bar)
 "jlQ" = (
-/obj/structure/machinery/door/airlock/almayer/maint/colony{
+/obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	dir = 1;
-	name = "\improper Null Hatch REPLACE ME";
 	},
 /turf/open/floor/plating,
 /area/shiva/interior/bar)
@@ -15275,9 +15268,8 @@
 	},
 /area/shiva/interior/lz2_habs)
 "kap" = (
-/obj/structure/machinery/door/airlock/almayer/maint/colony{
+/obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	dir = 1;
-	name = "\improper Null Hatch REPLACE ME";
 	},
 /turf/open/floor/shiva{
 	icon_state = "floor3"
@@ -21753,9 +21745,8 @@
 /turf/open/auto_turf/ice/layer0,
 /area/shiva/interior/caves/cp_camp)
 "qLA" = (
-/obj/structure/machinery/door/airlock/almayer/maint/colony{
+/obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	dir = 8;
-	name = "\improper Null Hatch REPLACE ME";
 	},
 /turf/open/floor/plating,
 /area/shiva/interior/aerodrome)

--- a/maps/map_files/Ice_Colony_v3/sprinkles/33.labs-entrance.dmm
+++ b/maps/map_files/Ice_Colony_v3/sprinkles/33.labs-entrance.dmm
@@ -64,9 +64,8 @@
 	},
 /area/shiva/interior/colony/research_hab)
 "jW" = (
-/obj/structure/machinery/door/airlock/almayer/maint/colony{
+/obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	dir = 1;
-	name = "\improper Null Hatch REPLACE ME";
 	req_access = null;
 	req_one_access = null
 	},

--- a/maps/map_files/Kutjevo/Kutjevo.dmm
+++ b/maps/map_files/Kutjevo/Kutjevo.dmm
@@ -339,9 +339,8 @@
 /turf/open/floor/kutjevo/tan/multi_tiles,
 /area/kutjevo/interior/complex/botany)
 "avP" = (
-/obj/structure/machinery/door/airlock/almayer/maint/colony{
+/obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	dir = 1;
-	name = "\improper Null Hatch REPLACE ME";
 	req_access = null;
 	req_one_access = null
 	},
@@ -367,9 +366,8 @@
 /turf/open/floor/almayer/research/containment/floor2,
 /area/kutjevo/interior/power)
 "awu" = (
-/obj/structure/machinery/door/airlock/almayer/maint/colony{
+/obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	dir = 1;
-	name = "\improper Null Hatch REPLACE ME";
 	req_access = null;
 	req_one_access = null
 	},
@@ -675,8 +673,7 @@
 /turf/open/floor/kutjevo/multi_tiles,
 /area/kutjevo/exterior/Northwest_Colony)
 "aUZ" = (
-/obj/structure/machinery/door/airlock/almayer/maint/colony{
-	name = "\improper Null Hatch REPLACE ME";
+/obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	req_access = null;
 	req_one_access = null
 	},
@@ -2002,8 +1999,7 @@
 /turf/open/asphalt/cement_sunbleached,
 /area/kutjevo/interior/power)
 "cKM" = (
-/obj/structure/machinery/door/airlock/almayer/maint/colony{
-	name = "\improper Null Hatch REPLACE ME";
+/obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	req_access = null;
 	req_one_access = null
 	},
@@ -2615,8 +2611,7 @@
 /turf/open/floor/plating/kutjevo,
 /area/kutjevo/interior/complex/med)
 "dvT" = (
-/obj/structure/machinery/door/airlock/almayer/maint/colony{
-	name = "\improper Null Hatch REPLACE ME";
+/obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	req_access = null;
 	req_one_access = null;
 	welded = 1
@@ -3454,8 +3449,7 @@
 /turf/open/gm/river/desert/deep/covered,
 /area/kutjevo/interior/power/comms)
 "esO" = (
-/obj/structure/machinery/door/airlock/almayer/maint/colony{
-	name = "\improper Null Hatch REPLACE ME";
+/obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	req_access = null;
 	req_one_access = null
 	},
@@ -4871,9 +4865,8 @@
 	},
 /area/kutjevo/exterior/scrubland)
 "gof" = (
-/obj/structure/machinery/door/airlock/almayer/maint/colony{
+/obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	dir = 1;
-	name = "\improper Null Hatch REPLACE ME";
 	req_access = null;
 	req_one_access = null
 	},
@@ -5252,8 +5245,7 @@
 /turf/open/floor/kutjevo/colors/cyan/tile,
 /area/kutjevo/interior/complex/med/operating)
 "gOK" = (
-/obj/structure/machinery/door/airlock/almayer/maint/colony{
-	name = "\improper Null Hatch REPLACE ME";
+/obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	req_access = null;
 	req_one_access = null
 	},
@@ -6112,9 +6104,8 @@
 /turf/open/floor/kutjevo/multi_tiles,
 /area/kutjevo/interior/complex/med/locks)
 "iea" = (
-/obj/structure/machinery/door/airlock/almayer/maint/colony{
+/obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	dir = 1;
-	name = "\improper Null Hatch REPLACE ME";
 	req_access = null;
 	req_one_access = null
 	},
@@ -6449,8 +6440,7 @@
 	},
 /area/kutjevo/interior/construction)
 "iJj" = (
-/obj/structure/machinery/door/airlock/almayer/maint/colony{
-	name = "\improper Null Hatch REPLACE ME";
+/obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	req_access = null;
 	req_one_access = null
 	},
@@ -6801,9 +6791,8 @@
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
 "jjM" = (
-/obj/structure/machinery/door/airlock/almayer/maint/colony{
+/obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	dir = 1;
-	name = "\improper Null Hatch REPLACE ME";
 	req_access = null;
 	req_one_access = null
 	},
@@ -7128,8 +7117,7 @@
 /turf/open/floor/plating/kutjevo,
 /area/kutjevo/interior/complex/botany)
 "jCN" = (
-/obj/structure/machinery/door/airlock/almayer/maint/colony{
-	name = "\improper Null Hatch REPLACE ME";
+/obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	req_access = null;
 	req_one_access = null
 	},
@@ -7324,8 +7312,7 @@
 /turf/open/gm/grass/weedable,
 /area/kutjevo/exterior/complex_border/med_park)
 "jVi" = (
-/obj/structure/machinery/door/airlock/almayer/maint/colony{
-	name = "\improper Null Hatch REPLACE ME";
+/obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	req_access = null;
 	req_one_access = null
 	},
@@ -7890,9 +7877,8 @@
 /obj/structure/platform_decoration/kutjevo{
 	dir = 8
 	},
-/obj/structure/machinery/door/airlock/almayer/maint/colony{
+/obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	dir = 1;
-	name = "\improper Null Hatch REPLACE ME";
 	req_access = null;
 	req_one_access = null
 	},
@@ -8179,9 +8165,8 @@
 	},
 /area/kutjevo/exterior/runoff_bridge)
 "lcE" = (
-/obj/structure/machinery/door/airlock/almayer/maint/colony{
+/obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	dir = 1;
-	name = "\improper Null Hatch REPLACE ME";
 	req_access = null;
 	req_one_access = null
 	},
@@ -8559,8 +8544,7 @@
 /turf/open/floor/plating/kutjevo,
 /area/kutjevo/interior/complex/botany)
 "lIz" = (
-/obj/structure/machinery/door/airlock/almayer/maint/colony{
-	name = "\improper Null Hatch REPLACE ME";
+/obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	req_access = null;
 	req_one_access = null
 	},
@@ -8981,9 +8965,8 @@
 	},
 /area/kutjevo/exterior/runoff_river)
 "mjv" = (
-/obj/structure/machinery/door/airlock/almayer/maint/colony{
+/obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	dir = 1;
-	name = "\improper Null Hatch REPLACE ME";
 	req_access = null;
 	req_one_access = null
 	},
@@ -9051,9 +9034,8 @@
 /turf/open/floor/kutjevo/colors,
 /area/kutjevo/interior/power/comms)
 "moM" = (
-/obj/structure/machinery/door/airlock/almayer/maint/colony{
+/obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	dir = 1;
-	name = "\improper Null Hatch REPLACE ME";
 	req_access = null;
 	req_one_access = null
 	},
@@ -9508,9 +9490,8 @@
 /turf/open/desert/desert_shore/desert_shore1,
 /area/kutjevo/exterior/lz_river)
 "mRp" = (
-/obj/structure/machinery/door/airlock/almayer/maint/colony{
+/obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	dir = 1;
-	name = "\improper Null Hatch REPLACE ME";
 	req_access = null;
 	req_one_access = null
 	},
@@ -9701,8 +9682,7 @@
 /turf/open/floor/plating/kutjevo,
 /area/kutjevo/exterior/construction)
 "nhg" = (
-/obj/structure/machinery/door/airlock/almayer/maint/colony{
-	name = "\improper Null Hatch REPLACE ME";
+/obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	req_access = null;
 	req_one_access = null
 	},
@@ -10416,9 +10396,8 @@
 /turf/open/floor/kutjevo/colors/cyan,
 /area/kutjevo/interior/complex/med)
 "oal" = (
-/obj/structure/machinery/door/airlock/almayer/maint/colony{
+/obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	dir = 1;
-	name = "\improper Null Hatch REPLACE ME";
 	req_access = null;
 	req_one_access = null
 	},
@@ -12484,8 +12463,7 @@
 	},
 /area/kutjevo/interior/complex/Northwest_Flight_Control)
 "qVb" = (
-/obj/structure/machinery/door/airlock/almayer/maint/colony{
-	name = "\improper Null Hatch REPLACE ME";
+/obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	req_access = null;
 	req_one_access = null
 	},
@@ -12658,9 +12636,8 @@
 /turf/open/floor/kutjevo/tiles,
 /area/kutjevo/interior/oob/dev_room)
 "riD" = (
-/obj/structure/machinery/door/airlock/almayer/maint/colony{
+/obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	dir = 1;
-	name = "\improper Null Hatch REPLACE ME";
 	req_access = null;
 	req_one_access = null
 	},
@@ -13533,9 +13510,8 @@
 	},
 /area/kutjevo/interior/power)
 "spV" = (
-/obj/structure/machinery/door/airlock/almayer/maint/colony{
+/obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	dir = 1;
-	name = "\improper Null Hatch REPLACE ME";
 	req_access = null;
 	req_one_access = null
 	},
@@ -16056,8 +16032,7 @@
 /turf/open/floor/almayer/research/containment/floor2,
 /area/kutjevo/interior/power)
 "vFL" = (
-/obj/structure/machinery/door/airlock/almayer/maint/colony{
-	name = "\improper Null Hatch REPLACE ME";
+/obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	req_access = null;
 	req_one_access = null
 	},
@@ -16906,9 +16881,8 @@
 /turf/open/floor/kutjevo/grey/plate,
 /area/kutjevo/interior/construction)
 "wPu" = (
-/obj/structure/machinery/door/airlock/almayer/maint/colony{
+/obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	dir = 1;
-	name = "\improper Null Hatch REPLACE ME";
 	req_access = null;
 	req_one_access = null
 	},
@@ -17139,8 +17113,7 @@
 	},
 /area/kutjevo/exterior/lz_river)
 "xjN" = (
-/obj/structure/machinery/door/airlock/almayer/maint/colony{
-	name = "\improper Null Hatch REPLACE ME";
+/obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	req_access = null;
 	req_one_access = null
 	},


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request
Fixes an issue from #2164 where previously autonamed doors lost the autoname due to repathing and were left with REPLACE ME names.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
No longer will you force open "Null hatch REPLACE ME"
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: Fixes unnamed doors on colonies.
fix: Fixes duplicate definitions from #2164
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
