### PR TITLE
removes debug world.log << in playtime

### DIFF
--- a/code/modules/mob/mob_verbs.dm
+++ b/code/modules/mob/mob_verbs.dm
@@ -30,6 +30,7 @@
 
 	to_chat(usr, SPAN_DANGER("This mob type cannot throw items."))
 	return
+
 /mob/verb/view_stats()
 	set category = "OOC"
 	set name = "View Playtimes"
@@ -37,9 +38,7 @@
 	if(!SSentity_manager.ready)
 		to_chat(src, "DB is still starting up, please wait")
 		return
-	world.log << "view stats"
 	if(client && client.player_entity)
-		world.log << "client check good"
 		client.player_data.tgui_interact(src)
 
 /mob/verb/toggle_high_toss()


### PR DESCRIPTION
this was annoying for parsing through runtime logs

:cl:
fix: removed unnecessary debug from runtime logs
/:cl: