### PR TITLE
removes a goofylooking default SS13 door on big red

### DIFF
--- a/maps/map_files/BigRed/BigRed.dmm
+++ b/maps/map_files/BigRed/BigRed.dmm
@@ -12272,7 +12272,7 @@
 	},
 /area/bigredv2/outside/medical)
 "aFK" = (
-/obj/structure/machinery/door/airlock/almayer/medical/glass/colony{}
+/obj/structure/machinery/door/airlock/almayer/medical/glass/colony{
 	id_tag = "mbayexit";
 	name = "Medbay Reception";
 	req_one_access_txt = "2;8;19"

--- a/maps/map_files/BigRed/BigRed.dmm
+++ b/maps/map_files/BigRed/BigRed.dmm
@@ -1572,7 +1572,9 @@
 	},
 /area/bigredv2/outside/telecomm)
 "aec" = (
-/obj/structure/machinery/door/airlock/maintenance,
+/obj/structure/machinery/door/airlock/almayer/engineering/colony{
+	name = "\improper Telecommunications";
+	},
 /turf/open/floor{
 	icon_state = "dark"
 	},

--- a/maps/map_files/BigRed/BigRed.dmm
+++ b/maps/map_files/BigRed/BigRed.dmm
@@ -12272,7 +12272,7 @@
 	},
 /area/bigredv2/outside/medical)
 "aFK" = (
-/obj/structure/machinery/door/airlock/glass_medical{
+/obj/structure/machinery/door/airlock/almayer/medical/glass/colony{}
 	id_tag = "mbayexit";
 	name = "Medbay Reception";
 	req_one_access_txt = "2;8;19"

--- a/maps/map_files/BigRed/BigRed.dmm
+++ b/maps/map_files/BigRed/BigRed.dmm
@@ -12275,6 +12275,7 @@
 /obj/structure/machinery/door/airlock/almayer/medical/glass/colony{
 	id_tag = "mbayexit";
 	name = "Medbay Reception";
+	dir = 1;
 	req_one_access_txt = "2;8;19"
 	},
 /turf/open/floor{


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

This replaces a goofylooking default door in big red tcomms with a nice, shiny CM-aesthetic colony engineering door.
![image](https://user-images.githubusercontent.com/70115628/217389804-244b83c9-f30b-44bb-a9bf-68aa9f95f6ad.png)

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
It's ugly and makes tcomms more consistent-looking. You also don't have to shoot it down, which is a plus.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
maptweak: changes the default ss13 airlock in big red tcomms to a cm airlock
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
