### PR TITLE
prevents running emote bubbles when unconscious or on cooldown

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -155,6 +155,9 @@
 
 /datum/emote/living/carbon/human/medic/run_emote(mob/living/user, params, type_override, intentional)
 	. = ..()
+	if(!.)
+		return FALSE
+
 	user.show_speech_bubble("medic")
 
 /datum/emote/living/carbon/human/medic/run_langchat(mob/user, group)
@@ -197,6 +200,8 @@
 
 /datum/emote/living/carbon/human/pain/run_emote(mob/living/user, params, type_override, intentional)
 	. = ..()
+	if(!.)
+		return FALSE
 
 	user.show_speech_bubble("pain")
 
@@ -234,6 +239,9 @@
 
 /datum/emote/living/carbon/human/scream/run_emote(mob/living/user, params, type_override, intentional)
 	. = ..()
+	if(!.)
+		return FALSE
+
 	user.show_speech_bubble("scream")
 
 /datum/emote/living/carbon/human/scream/run_langchat(mob/user, group)
@@ -321,6 +329,8 @@
 
 /datum/emote/living/carbon/human/warcry/run_emote(mob/living/user, params, type_override, intentional)
 	. = ..()
+	if(!.)
+		return FALSE
 
 	user.show_speech_bubble("warcry")
 


### PR DESCRIPTION
whoops

:cl:
fix: prevents silly bubbles appearing after death or unconsciousness
/:cl: