### PR TITLE
Removes superslow and instant movement from the lurker's crippling strike ability

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/lurker/lurker_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/lurker/lurker_abilities.dm
@@ -29,22 +29,6 @@
 			if (istype(LIA))
 				LIA.invisibility_off()
 
-/datum/action/xeno_action/activable/pounce/lurker/additional_effects(mob/living/L)
-	var/mob/living/carbon/xenomorph/X = owner
-	if (!istype(X))
-		return
-
-	if (X.mutation_type == LURKER_NORMAL)
-		RegisterSignal(X, COMSIG_XENO_SLASH_ADDITIONAL_EFFECTS_SELF, PROC_REF(remove_freeze))
-
-/datum/action/xeno_action/activable/pounce/lurker/proc/remove_freeze(mob/living/carbon/xenomorph/X)
-	SIGNAL_HANDLER
-
-	var/datum/behavior_delegate/lurker_base/BD = X.behavior_delegate
-	if (istype(BD))
-		UnregisterSignal(X, COMSIG_XENO_SLASH_ADDITIONAL_EFFECTS_SELF)
-		end_pounce_freeze()
-
 /datum/action/xeno_action/onclick/lurker_invisibility
 	name = "Turn Invisible"
 	action_icon_state = "lurker_invisibility"

--- a/code/modules/mob/living/carbon/xenomorph/castes/Lurker.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Lurker.dm
@@ -63,6 +63,7 @@
 	var/invis_recharge_time = 150   // 15 seconds to recharge invisibility.
 	var/invis_start_time = -1 // Special value for when we're not invisible
 	var/invis_duration = 300  // so we can display how long the lurker is invisible to it
+	var/slash_slow_duration = 35
 	var/buffed_slash_damage_ratio = 1.4
 
 	// State
@@ -83,6 +84,15 @@
 			ability.button.icon_state = "template"
 
 	return original_damage
+
+/datum/behavior_delegate/lurker_base/melee_attack_additional_effects_target(mob/living/carbon/target_carbon)
+	if (!isxeno_human(target_carbon))
+		return
+
+	if (target_carbon.knocked_down)
+		new /datum/effects/xeno_slow(target_carbon, bound_xeno, null, null, get_xeno_stun_duration(target_carbon, slash_slow_duration))
+
+	return
 
 /datum/behavior_delegate/lurker_base/melee_attack_additional_effects_self()
 	..()

--- a/code/modules/mob/living/carbon/xenomorph/castes/Lurker.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Lurker.dm
@@ -75,25 +75,15 @@
 		return original_damage
 
 	if (next_slash_buffed)
-		to_chat(bound_xeno, SPAN_XENOHIGHDANGER("You significantly strengthen your attack, slowing [target_carbon]!"))
-		to_chat(target_carbon, SPAN_XENOHIGHDANGER("You feel a sharp pain as [bound_xeno] slashes you, slowing you down!"))
+		to_chat(bound_xeno, SPAN_XENOHIGHDANGER("You significantly strengthen your attack, slashing [target_carbon]!"))
+		to_chat(target_carbon, SPAN_XENOHIGHDANGER("You feel a sharp pain as [bound_xeno] slashes you!"))
 		original_damage *= buffed_slash_damage_ratio
-		target_carbon.set_effect(get_xeno_stun_duration(target_carbon, 3), SUPERSLOW)
 		next_slash_buffed = FALSE
 		var/datum/action/xeno_action/onclick/lurker_assassinate/ability = get_xeno_action_by_type(bound_xeno, /datum/action/xeno_action/onclick/lurker_assassinate)
 		if (ability && istype(ability))
 			ability.button.icon_state = "template"
 
 	return original_damage
-
-/datum/behavior_delegate/lurker_base/melee_attack_additional_effects_target(mob/living/carbon/target_carbon)
-	if (!isxeno_human(target_carbon))
-		return
-
-	if (target_carbon.knocked_down)
-		new /datum/effects/xeno_slow(target_carbon, bound_xeno, null, null, get_xeno_stun_duration(target_carbon, slash_slow_duration))
-
-	return
 
 /datum/behavior_delegate/lurker_base/melee_attack_additional_effects_self()
 	..()

--- a/code/modules/mob/living/carbon/xenomorph/castes/Lurker.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Lurker.dm
@@ -63,8 +63,7 @@
 	var/invis_recharge_time = 150   // 15 seconds to recharge invisibility.
 	var/invis_start_time = -1 // Special value for when we're not invisible
 	var/invis_duration = 300  // so we can display how long the lurker is invisible to it
-	var/buffed_slash_damage_ratio = 1.2
-	var/slash_slow_duration = 35
+	var/buffed_slash_damage_ratio = 1.4
 
 	// State
 	var/next_slash_buffed = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request
In this PR, I remove the superslow and instant movement that the base lurker's Crippling Strike provides for the simple fact that it's redundant. I however did also buff the damage multiplier you get to 1.4, with a successful crippling strike dealing a base 49 damage. I removed most of the superslow and instant movement code (slashing lets you move immediately with the latter), but I **kept in** the stun on a pounced target. If needed I can buff this damage more or add in a non-superslow. I've tested this and it causes no errors.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

Lurker is already a quite deadly caste, and as someone who plays both sides the crippling strike feels a little excessive. This still allows you to get kills, you just need to work harder for each kill. If slugs had their superslow removed, I believe that the lurker's crippling strike deserves the same. In addition, the fact that you can instantly move after slashing with this ability in addition to the aforementioned slug nerf means that you deal with hordes of lurkers- base lurkers, mind you -fighting in the open every round, using the slows and instant movement to fight with minimal risk. I do not believe an ambush caste should be able to fight in the open quite like normal lurkers can at the moment.

In addition as I said in the 'about' section, the slow is redundant- by doing damage and quite possibly breaking someone's foot, you're already slowing them down. It's just not needed. The instant movement also allows for overzealous lurker players to avoid punishment in situations where there are marines nearby to shoot, ie. PB with a shotgun. It's not as if the pounce locks you in place for a long time, either.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
balance: removed the superslow and instant movement from the base lurker's Crippling Strike.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
