### PR TITLE
adds a keybinding for showing held item

### DIFF
--- a/code/__DEFINES/keybinding.dm
+++ b/code/__DEFINES/keybinding.dm
@@ -59,6 +59,8 @@
 
 #define COMSIG_KG_HUMAN_PICK_UP "keybinding_human_pick_up"
 
+#define COMSIG_KB_HUMAN_SHOW_HELD_ITEM "keybinding_human_show_held_item"
+
 // Human Combat
 #define COMSIG_KB_HUMAN_WEAPON_FIELDSTRIP "keybinding_human_weapon_fieldstrip"
 #define COMSIG_KB_HUMAN_WEAPON_BURSTFIRE "keybinding_human_weapon_burstfire"

--- a/code/datums/keybinding/human.dm
+++ b/code/datums/keybinding/human.dm
@@ -192,7 +192,6 @@
 		shown_item.showoff(human_user)
 	return TRUE
 
-
 #undef QUICK_EQUIP_PRIMARY
 #undef QUICK_EQUIP_SECONDARY
 #undef QUICK_EQUIP_TERTIARY

--- a/code/datums/keybinding/human.dm
+++ b/code/datums/keybinding/human.dm
@@ -181,7 +181,7 @@
 	full_name = "Show Held Item"
 	keybind_signal = COMSIG_KB_HUMAN_SHOW_HELD_ITEM
 
-/datum/keybinding/human/pick_up/down(client/user)
+/datum/keybinding/human/show_held_item/down(client/user)
 	. = ..()
 	if(.)
 		return

--- a/code/datums/keybinding/human.dm
+++ b/code/datums/keybinding/human.dm
@@ -174,6 +174,25 @@
 	human_user.pickup_recent()
 	return TRUE
 
+/datum/keybinding/human/show_held_item
+	hotkey_keys = list()
+	classic_keys = list()
+	name = "show_held_item"
+	full_name = "Show Held Item"
+	keybind_signal = COMSIG_KB_HUMAN_SHOW_HELD_ITEM
+
+/datum/keybinding/human/pick_up/down(client/user)
+	. = ..()
+	if(.)
+		return
+
+	var/mob/living/carbon/human/human_user = user.mob
+	var/obj/item/shown_item = human_user.get_active_hand()
+	if(shown_item && !(shown_item.flags_item & ITEM_ABSTRACT))
+		shown_item.showoff(human_user)
+	return TRUE
+
+
 #undef QUICK_EQUIP_PRIMARY
 #undef QUICK_EQUIP_SECONDARY
 #undef QUICK_EQUIP_TERTIARY


### PR DESCRIPTION
qol also this one was egregiously hidden in the object menu with other hits like pull and pick up

:cl:
qol: you can now keybind showing held item
/:cl: