### PR TITLE
weapon name HRP

### DIFF
--- a/code/datums/supply_packs/black_market.dm
+++ b/code/datums/supply_packs/black_market.dm
@@ -996,9 +996,9 @@ This is where the RO can reclaim their lost honor and purchase the M44 custom, t
 	dollar_cost = 10
 	containertype = /obj/structure/largecrate/black_market
 
-/datum/supply_packs/contraband/deep_storage/m43_holdout
-	name = "M43 Holdout Pistol"
-	contains = list(/obj/item/storage/box/m43)
+/datum/supply_packs/contraband/deep_storage/clf_holdout
+	name = "D18 Holdout Pistol"
+	contains = list(/obj/item/storage/box/clf)
 	dollar_cost = 10
 	containertype = /obj/structure/largecrate/black_market
 

--- a/code/game/machinery/vending/vendor_types/crew/commanding_officer.dm
+++ b/code/game/machinery/vending/vendor_types/crew/commanding_officer.dm
@@ -2,7 +2,7 @@
 
 GLOBAL_LIST_INIT(cm_vending_gear_commanding_officer, list(
 		list("CAPTAIN'S PRIMARY (CHOOSE 1)", 0, null, null, null),
-		list("M46C pulse rifle", 0, /obj/effect/essentials_set/co/riflepreset, MARINE_CAN_BUY_ESSENTIALS, VENDOR_ITEM_MANDATORY),
+		list("XM46E3 pulse rifle", 0, /obj/effect/essentials_set/co/riflepreset, MARINE_CAN_BUY_ESSENTIALS, VENDOR_ITEM_MANDATORY),
 		list("M56C Smartgun", 0, /obj/item/storage/box/m56c_system, MARINE_CAN_BUY_ESSENTIALS, VENDOR_ITEM_MANDATORY),
 
 		list("PRIMARY AMMUNITION", 0, null, null, null),

--- a/code/game/machinery/vending/vendor_types/crew/commanding_officer.dm
+++ b/code/game/machinery/vending/vendor_types/crew/commanding_officer.dm
@@ -2,7 +2,7 @@
 
 GLOBAL_LIST_INIT(cm_vending_gear_commanding_officer, list(
 		list("CAPTAIN'S PRIMARY (CHOOSE 1)", 0, null, null, null),
-		list("XM46E3 pulse rifle", 0, /obj/effect/essentials_set/co/riflepreset, MARINE_CAN_BUY_ESSENTIALS, VENDOR_ITEM_MANDATORY),
+		list("M46C pulse rifle", 0, /obj/effect/essentials_set/co/riflepreset, MARINE_CAN_BUY_ESSENTIALS, VENDOR_ITEM_MANDATORY),
 		list("M56C Smartgun", 0, /obj/item/storage/box/m56c_system, MARINE_CAN_BUY_ESSENTIALS, VENDOR_ITEM_MANDATORY),
 
 		list("PRIMARY AMMUNITION", 0, null, null, null),

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -1021,7 +1021,7 @@
 	new /obj/item/ammo_magazine/pistol/m1911(src)
 
 /obj/item/storage/belt/gun/m4a3/m1911/socom/fill_preset_inventory()
-	handle_item_insertion(new /obj/item/weapon/gun/pistol/m1911/socom())
+	handle_item_insertion(new /obj/item/weapon/gun/pistol/m1911/socom/equipped())
 	new /obj/item/ammo_magazine/pistol/m1911(src)
 	new /obj/item/ammo_magazine/pistol/m1911(src)
 	new /obj/item/ammo_magazine/pistol/m1911(src)

--- a/code/game/objects/items/storage/misc.dm
+++ b/code/game/objects/items/storage/misc.dm
@@ -111,18 +111,18 @@
 	else
 		icon_state = "6_pack_[contents.len]"
 
-/obj/item/storage/box/m43
-	name = "M43-storing box"
-	desc = "A fairly decorated and ceremonial box containing a CLF M43 and a single additional magazine for it. I guess those CLF folk really care about their craftsmanship and prose rather than practicality, eh?"
+/obj/item/storage/box/clf
+	name = "D18-storing box"
+	desc = "A fairly decorated and ceremonial box containing a CLF D18 and a single additional magazine for it. I guess those CLF folk really care about their craftsmanship and prose rather than practicality, eh?"
 	icon = 'icons/obj/items/storage.dmi'
 	icon_state = "m43case"
 	w_class = SIZE_SMALL
 	max_w_class = SIZE_TINY
 	storage_slots = 2
 
-/obj/item/storage/box/m43/fill_preset_inventory()
-	new /obj/item/weapon/gun/pistol/m43pistol(src)
-	new /obj/item/ammo_magazine/pistol/m43pistol(src)
+/obj/item/storage/box/clf/fill_preset_inventory()
+	new /obj/item/weapon/gun/pistol/clfpistol(src)
+	new /obj/item/ammo_magazine/pistol/clfpistol(src)
 
 /obj/item/storage/box/c02_knife
 	name = "M8 cartridge bayonet packaging"

--- a/code/modules/client/preferences_gear.dm
+++ b/code/modules/client/preferences_gear.dm
@@ -400,9 +400,9 @@ var/global/list/gear_datums = list()
 	slot = WEAR_IN_BACK
 	cost = 4
 
-/datum/gear/m43pistol
-	display_name = "M43 Holdout Pistol"
-	path = /obj/item/storage/box/m43
+/datum/gear/clfpistol
+	display_name = "D18 Holdout Pistol"
+	path = /obj/item/storage/box/clf
 	slot = WEAR_IN_BACK
 	cost = 4
 

--- a/code/modules/clothing/shoes/marine_shoes.dm
+++ b/code/modules/clothing/shoes/marine_shoes.dm
@@ -19,7 +19,7 @@
 	max_heat_protection_temperature = SHOE_MAX_HEAT_PROT
 	siemens_coefficient = 0.7
 	var/armor_stage = 0
-	items_allowed = list(/obj/item/attachable/bayonet, /obj/item/weapon/melee/throwing_knife, /obj/item/weapon/gun/pistol/holdout, /obj/item/weapon/gun/pistol/m43pistol, /obj/item/tool/screwdriver)
+	items_allowed = list(/obj/item/attachable/bayonet, /obj/item/weapon/melee/throwing_knife, /obj/item/weapon/gun/pistol/holdout, /obj/item/weapon/gun/pistol/clfpistol, /obj/item/tool/screwdriver)
 	var/knife_type
 
 /obj/item/clothing/shoes/marine/Initialize(mapload, ...)
@@ -101,7 +101,7 @@
 	flags_heat_protection = BODY_FLAG_FEET
 	flags_inventory = FPRINT|NOSLIPPING
 	siemens_coefficient = 0.6
-	items_allowed = list(/obj/item/attachable/bayonet, /obj/item/weapon/melee/throwing_knife, /obj/item/weapon/gun/pistol/holdout, /obj/item/weapon/gun/pistol/m43pistol)
+	items_allowed = list(/obj/item/attachable/bayonet, /obj/item/weapon/melee/throwing_knife, /obj/item/weapon/gun/pistol/holdout, /obj/item/weapon/gun/pistol/clfpistol)
 
 /obj/item/clothing/shoes/veteran/pmc/update_icon()
 	if(stored_item)
@@ -169,7 +169,7 @@
 	flags_heat_protection = BODY_FLAG_FEET
 	flags_inventory = FPRINT|NOSLIPPING
 	siemens_coefficient = 0.6
-	items_allowed = list(/obj/item/attachable/bayonet, /obj/item/weapon/melee/throwing_knife, /obj/item/weapon/gun/pistol/holdout, /obj/item/weapon/gun/pistol/m43pistol)
+	items_allowed = list(/obj/item/attachable/bayonet, /obj/item/weapon/melee/throwing_knife, /obj/item/weapon/gun/pistol/holdout, /obj/item/weapon/gun/pistol/clfpistol)
 	var/weed_slowdown_mult = 0.5
 
 /obj/item/clothing/shoes/hiking/equipped(mob/user, slot, silent)

--- a/code/modules/cm_preds/thrall_items.dm
+++ b/code/modules/cm_preds/thrall_items.dm
@@ -39,7 +39,7 @@
 		/obj/item/attachable/bayonet,
 		/obj/item/weapon/melee/throwing_knife,
 		/obj/item/weapon/gun/pistol/holdout,
-		/obj/item/weapon/gun/pistol/m43pistol,
+		/obj/item/weapon/gun/pistol/clfpistol,
 	)
 
 /obj/item/clothing/shoes/yautja/thrall/New(mapload, greaves_number = 1, armor_material = pick("cloth", "bare"))

--- a/code/modules/gear_presets/uscm.dm
+++ b/code/modules/gear_presets/uscm.dm
@@ -818,8 +818,8 @@
 	var/obj/item/clothing/suit/storage/marine/sof/armor = new()
 	H.equip_to_slot_or_del(armor, WEAR_JACKET)
 	for(var/i in 1 to armor.storage_slots)
-		H.equip_to_slot_or_del(new /obj/item/ammo_magazine/rifle/m40_sd/heap, WEAR_IN_JACKET)
-	H.equip_to_slot_or_del(new /obj/item/weapon/gun/rifle/m41a/elite/m40_sd, WEAR_J_STORE)
+		H.equip_to_slot_or_del(new /obj/item/ammo_magazine/rifle/xm40/heap, WEAR_IN_JACKET)
+	H.equip_to_slot_or_del(new /obj/item/weapon/gun/rifle/m41a/elite/xm40, WEAR_J_STORE)
 	//waist
 	H.equip_to_slot_or_del(new /obj/item/weapon/gun/shotgun/combat/marsoc, WEAR_WAIST)
 	//limbs

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -269,12 +269,12 @@ Defined in conflicts.dm of the #defines folder.
 	scatter_unwielded_mod = -SCATTER_AMOUNT_TIER_10
 	damage_falloff_mod = 0.4
 
-/obj/item/attachable/suppressor/m40_integral
-	name = "\improper M40SD integral suppressor"
+/obj/item/attachable/suppressor/xm40_integral
+	name = "\improper XM40 integral suppressor"
 	icon_state = "m40sd_suppressor"
 	attach_icon = "m40sd_suppressor_a"
 
-/obj/item/attachable/suppressor/m40_integral/New()
+/obj/item/attachable/suppressor/xm40_integral/New()
 	..()
 	accuracy_mod = HIT_ACCURACY_MULT_TIER_3
 	damage_mod = -BULLET_DAMAGE_MULT_TIER_1

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -1009,7 +1009,7 @@ Defined in conflicts.dm of the #defines folder.
 	name = "B8 Smart-Scope"
 	icon_state = "iffbarrel"
 	attach_icon = "iffbarrel_a"
-	desc = "An experimental B8 Smart-Scope. Based on the technologies used in the Smart Gun by ARMAT, this sight has integrated IFF systems. It can only attach to the L42A Battle Rifle, M44 Combat Revolver, and M46C Pulse Rifle."
+	desc = "An experimental B8 Smart-Scope. Based on the technologies used in the Smart Gun by ARMAT, this sight has integrated IFF systems. It can only attach to the L42A Battle Rifle and M44 Combat Revolver."
 	slot = "rail"
 	zoom_offset = 6
 	zoom_viewsize = 7

--- a/code/modules/projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/guns/pistols.dm
@@ -129,11 +129,10 @@
 
 
 /obj/item/weapon/gun/pistol/m1911/socom
-	name = "\improper SOCOM M1911 service pistol"
-	desc = "A timeless classic since the first World War. Chambered in .45 ACP. This one has a darkened grip and appears especially well-kept. "
+	name = "\improper M48A4 service pistol"
+	desc = "A timeless classic since the first World War, the M1911A1 has limited use with the USCM, and is often used as a sidearm by non-governmental bodies due to its reliability. This is a modernized version with an ammo counter and a polymer grip, designated M48A4. Chambered in .45 ACP."
 	icon_state = "m4a345_s"
 	item_state = "m4a3"
-	starting_attachment_types = list(/obj/item/attachable/suppressor, /obj/item/attachable/lasersight, /obj/item/attachable/reflex)
 	flags_gun_features = GUN_AUTO_EJECTOR|GUN_CAN_POINTBLANK|GUN_ONE_HAND_WIELDED|GUN_AMMO_COUNTER
 
 /obj/item/weapon/gun/pistol/m1911/socom/set_gun_config_values()
@@ -146,6 +145,8 @@
 	scatter_unwielded = SCATTER_AMOUNT_TIER_6
 	damage_mult = BASE_BULLET_DAMAGE_MULT + BULLET_DAMAGE_MULT_TIER_2
 
+/obj/item/weapon/gun/pistol/m1911/socom/equipped
+	starting_attachment_types = list(/obj/item/attachable/suppressor, /obj/item/attachable/lasersight, /obj/item/attachable/reflex)
 
 //-------------------------------------------------------
 //Beretta 92FS, the gun McClane carries around in Die Hard. Very similar to the service pistol, all around.
@@ -380,8 +381,8 @@
 //-------------------------------------------------------
 //CLF HOLDOUT PISTOL
 /obj/item/weapon/gun/pistol/m43pistol
-	name = "M43 Hummingbird Pistol"
-	desc = "The M43 Hummingbird Pistol was produced in the mid-2170s as a cheap and concealable firearm for CLF Sleeper Cell agents for assassinations and ambushes, and is able to be concealed in shoes and workboots."
+	name = "D18 Hummingbird Pistol"
+	desc = "The D18 Hummingbird Pistol was produced in the mid-2170s as a cheap and concealable firearm for CLF Sleeper Cell agents for assassinations and ambushes, and is able to be concealed in shoes and workboots."
 	icon_state = "m43"
 	item_state = "m43"
 	flags_gun_features = GUN_CAN_POINTBLANK|GUN_ONE_HAND_WIELDED

--- a/code/modules/projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/guns/pistols.dm
@@ -380,14 +380,14 @@
 
 //-------------------------------------------------------
 //CLF HOLDOUT PISTOL
-/obj/item/weapon/gun/pistol/m43pistol
+/obj/item/weapon/gun/pistol/clfpistol
 	name = "D18 Hummingbird Pistol"
 	desc = "The D18 Hummingbird Pistol was produced in the mid-2170s as a cheap and concealable firearm for CLF Sleeper Cell agents for assassinations and ambushes, and is able to be concealed in shoes and workboots."
 	icon_state = "m43"
 	item_state = "m43"
 	flags_gun_features = GUN_CAN_POINTBLANK|GUN_ONE_HAND_WIELDED
 	fire_sound = 'sound/weapons/gun_m43.ogg'
-	current_mag = /obj/item/ammo_magazine/pistol/m43pistol
+	current_mag = /obj/item/ammo_magazine/pistol/clfpistol
 	w_class = SIZE_TINY
 	force = 5
 	attachable_allowed = list(
@@ -395,10 +395,10 @@
 		/obj/item/attachable/flashlight,
 	)
 
-/obj/item/weapon/gun/pistol/m43pistol/set_gun_attachment_offsets()
+/obj/item/weapon/gun/pistol/clfpistol/set_gun_attachment_offsets()
 	attachable_offset = list("muzzle_x" = 28, "muzzle_y" = 20,"rail_x" = 10, "rail_y" = 21, "under_x" = 21, "under_y" = 17, "stock_x" = 21, "stock_y" = 17)
 
-/obj/item/weapon/gun/pistol/m43pistol/set_gun_config_values()
+/obj/item/weapon/gun/pistol/clfpistol/set_gun_config_values()
 	..()
 	fire_delay = FIRE_DELAY_TIER_10
 	accuracy_mult = BASE_ACCURACY_MULT

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -275,7 +275,7 @@
 //-------------------------------------------------------
 //M40-SD AKA SOF RIFLE FROM HELL (It's actually an M41A, don't tell!)
 
-/obj/item/weapon/gun/rifle/m41a/elite/m40_sd
+/obj/item/weapon/gun/rifle/m41a/elite/xm40
 	name = "\improper XM40 pulse rifle"
 	desc = "One of the experimental predecessors to the M41 line that never saw widespread adoption beyond elite marine units. Of the rifles in the USCM inventory that are still in production, this is the only one to feature an integrated suppressor. It can accept M41A MK2 magazines, but also features its own proprietary magazine system. Extremely lethal in burstfire mode."
 	icon_state = "m40sd"
@@ -285,7 +285,7 @@
 	unacidable = TRUE
 	indestructible = TRUE
 
-	current_mag = /obj/item/ammo_magazine/rifle/m40_sd/heap
+	current_mag = /obj/item/ammo_magazine/rifle/xm40/heap
 	flags_gun_features = GUN_AUTO_EJECTOR|GUN_CAN_POINTBLANK|GUN_AMMO_COUNTER|GUN_BURST_ON
 	aim_slowdown = SLOWDOWN_ADS_QUICK
 	wield_delay = WIELD_DELAY_FAST
@@ -298,11 +298,11 @@
 		/obj/item/ammo_magazine/rifle/explosive,
 		/obj/item/ammo_magazine/rifle/le,
 		/obj/item/ammo_magazine/rifle/ap,
-		/obj/item/ammo_magazine/rifle/m40_sd,
-		/obj/item/ammo_magazine/rifle/m40_sd/heap,
+		/obj/item/ammo_magazine/rifle/xm40,
+		/obj/item/ammo_magazine/rifle/xm40/heap,
 	)
 	attachable_allowed = list(
-		/obj/item/attachable/suppressor/m40_integral,//no rail attachies
+		/obj/item/attachable/suppressor/xm40_integral,//no rail attachies
 		/obj/item/attachable/verticalgrip,
 		/obj/item/attachable/angledgrip,
 		/obj/item/attachable/flashlight/grip,
@@ -320,9 +320,9 @@
 
 	random_spawn_chance = 0
 
-/obj/item/weapon/gun/rifle/m41a/elite/m40_sd/handle_starting_attachment()
+/obj/item/weapon/gun/rifle/m41a/elite/xm40/handle_starting_attachment()
 	..()
-	var/obj/item/attachable/suppressor/m40_integral/S = new(src)
+	var/obj/item/attachable/suppressor/xm40_integral/S = new(src)
 	S.flags_attach_features &= ~ATTACH_REMOVABLE
 	S.hidden = FALSE
 	S.Attach(src)
@@ -334,10 +334,10 @@
 	H.Attach(src)
 	update_attachable(H.slot)
 
-/obj/item/weapon/gun/rifle/m41a/elite/m40_sd/set_gun_attachment_offsets()
+/obj/item/weapon/gun/rifle/m41a/elite/xm40/set_gun_attachment_offsets()
 	attachable_offset = list("muzzle_x" = 32, "muzzle_y" = 17,"rail_x" = 12, "rail_y" = 23, "under_x" = 24, "under_y" = 13, "stock_x" = 24, "stock_y" = 13)
 
-/obj/item/weapon/gun/rifle/m41a/elite/m40_sd/set_gun_config_values()
+/obj/item/weapon/gun/rifle/m41a/elite/xm40/set_gun_config_values()
 	..()
 	fire_delay = FIRE_DELAY_TIER_9
 	burst_amount = BURST_AMOUNT_TIER_3

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -276,8 +276,8 @@
 //M40-SD AKA SOF RIFLE FROM HELL (It's actually an M41A, don't tell!)
 
 /obj/item/weapon/gun/rifle/m41a/elite/m40_sd
-	name = "\improper M40-SD pulse rifle"
-	desc = "One of the experimental predecessors to the M41A line that never saw widespread adoption beyond elite marine units. Of the rifles in the USCM inventory that are still in production, this is the only one to feature an integrated suppressor. It can accept M41A MK2 magazines, but also features its own proprietary magazine system. Extremely lethal in burstfire mode."
+	name = "\improper XM40 pulse rifle"
+	desc = "One of the experimental predecessors to the M41 line that never saw widespread adoption beyond elite marine units. Of the rifles in the USCM inventory that are still in production, this is the only one to feature an integrated suppressor. It can accept M41A MK2 magazines, but also features its own proprietary magazine system. Extremely lethal in burstfire mode."
 	icon_state = "m40sd"
 	item_state = "m40sd"
 	reload_sound = 'sound/weapons/handling/m40sd_reload.ogg'
@@ -403,8 +403,8 @@
 //Special gun for the CO to replace the smartgun
 
 /obj/item/weapon/gun/rifle/m46c
-	name = "\improper M46C pulse rifle"
-	desc = "A prototype M46C, an experimental rifle platform built to outperform the standard M41A. Back issue only. Uses standard MK1 & MK2 rifle magazines."
+	name = "\improper XM46E3 pulse rifle"
+	desc = "A prototype XM46E3, an experimental rifle platform built to outperform the standard M41A. Back issue only. Uses standard MK1 & MK2 rifle magazines."
 	icon_state = "m46c"
 	item_state = "m46c"
 	fire_sound = "gun_pulse"

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -403,8 +403,8 @@
 //Special gun for the CO to replace the smartgun
 
 /obj/item/weapon/gun/rifle/m46c
-	name = "\improper XM46E3 pulse rifle"
-	desc = "A prototype XM46E3, an experimental rifle platform built to outperform the standard M41A. Back issue only. Uses standard MK1 & MK2 rifle magazines."
+	name = "\improper M46C pulse rifle"
+	desc = "A prototype M46C, an experimental rifle platform built to outperform the standard M41A. Back issue only. Uses standard MK1 & MK2 rifle magazines."
 	icon_state = "m46c"
 	item_state = "m46c"
 	fire_sound = "gun_pulse"

--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -314,8 +314,8 @@ can cause issues with ammo types getting mixed up during the burst.
 
 //SOF MK210, an earlier developmental variant of the MK211 tactical used by USCM SOF.
 /obj/item/weapon/gun/shotgun/combat/marsoc
-	name = "\improper MK210 tactical shotgun"
-	desc = "Way back in 2168, Wey-Yu began testing the MK221. The USCM picked up an early prototype, and later adopted it with a limited military contract. But the USCM Special Operations Forces wasn't satisfied, and iterated on the early prototypes they had access to; eventually, their internal armorers and tinkerers produced the MK210, a lightweight folding shotgun that snaps to the belt. And to boot, it's fully automatic, made of stamped medal, and keeps the UGL. Truly an engineering marvel."
+	name = "\improper XM38 tactical shotgun"
+	desc = "Way back in 2168, Wey-Yu began testing the MK221. The USCM picked up an early prototype, and later adopted it with a limited military contract. But the USCM Special Operations Forces wasn't satisfied, and iterated on the early prototypes they had access to; eventually, their internal armorers and tinkerers produced the MK210, designated XM38, a lightweight folding shotgun that snaps to the belt. And to boot, it's fully automatic, made of stamped medal, and keeps the UGL. Truly an engineering marvel."
 	icon_state = "mk210"
 	item_state = "mk210"
 

--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -327,7 +327,7 @@
 	damage_mult = BASE_BULLET_DAMAGE_MULT
 	recoil = RECOIL_AMOUNT_TIER_5
 
-/obj/item/weapon/gun/rifle/sniper/XM42B
+/obj/item/weapon/gun/rifle/sniper/xm43e1
 	name = "\improper XM43E1 experimental anti-materiel rifle"
 	desc = "An experimental anti-materiel rifle produced by Armat Systems, recently reacquired from the deep storage of an abandoned prototyping facility. This one in particular is currently undergoing field testing. Chambered in 10x99mm Caseless."
 	icon_state = "xm42b"

--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -394,7 +394,7 @@
 */
 
 /obj/item/weapon/gun/rifle/sniper/elite
-	name = "\improper MK43 anti-tank sniper rifle"
+	name = "\improper M42C anti-tank sniper rifle"
 	desc = "A high-end superheavy magrail sniper rifle from Weyland-Armat chambered in a specialized variant of the heaviest ammo available, 10x99mm Caseless. This weapon requires a specialized armor rig for recoil mitigation in order to be used effectively."
 	icon_state = "m42c"
 	item_state = "m42c" //NEEDS A TWOHANDED STATE

--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -328,7 +328,7 @@
 	recoil = RECOIL_AMOUNT_TIER_5
 
 /obj/item/weapon/gun/rifle/sniper/XM42B
-	name = "\improper XM42B experimental anti-materiel rifle"
+	name = "\improper XM43E1 experimental anti-materiel rifle"
 	desc = "An experimental anti-materiel rifle produced by Armat Systems, recently reacquired from the deep storage of an abandoned prototyping facility. This one in particular is currently undergoing field testing. Chambered in 10x99mm Caseless."
 	icon_state = "xm42b"
 	item_state = "xm42b"
@@ -394,7 +394,7 @@
 */
 
 /obj/item/weapon/gun/rifle/sniper/elite
-	name = "\improper M42C anti-tank sniper rifle"
+	name = "\improper MK43 anti-tank sniper rifle"
 	desc = "A high-end superheavy magrail sniper rifle from Weyland-Armat chambered in a specialized variant of the heaviest ammo available, 10x99mm Caseless. This weapon requires a specialized armor rig for recoil mitigation in order to be used effectively."
 	icon_state = "m42c"
 	item_state = "m42c" //NEEDS A TWOHANDED STATE

--- a/code/modules/projectiles/magazines/pistols.dm
+++ b/code/modules/projectiles/magazines/pistols.dm
@@ -218,15 +218,15 @@
 
 //-------------------------------------------------------
 //CLF HOLDOUT PISTOL
-/obj/item/ammo_magazine/pistol/m43pistol
-	name = "M43 magazine (9mm)"
-	desc = "A small M43 magazine storing 7 9mm bullets. How is it even this small?"
+/obj/item/ammo_magazine/pistol/clfpistol
+	name = "D18 magazine (9mm)"
+	desc = "A small D18 magazine storing 7 9mm bullets. How is it even this small?"
 	default_ammo = /datum/ammo/bullet/pistol
 	caliber = "9mm"
 	icon_state = "m4a3"
 	max_rounds = 7
 	w_class = SIZE_TINY
-	gun_type = /obj/item/weapon/gun/pistol/m43pistol
+	gun_type = /obj/item/weapon/gun/pistol/clfpistol
 
 
 //-------------------------------------------------------

--- a/code/modules/projectiles/magazines/rifles.dm
+++ b/code/modules/projectiles/magazines/rifles.dm
@@ -125,21 +125,21 @@
 
 
 //-------------------------------------------------------
-//M40-SD AKA SOF RIFLE FROM HELL (It's an EM-2, a prototype of the real world L85A1 way back from the 1940s. We've given it a blue plastic shell and an integral suppressor)
-/obj/item/ammo_magazine/rifle/m40_sd
-	name = "\improper M40-SD magazine (10x24mm)"
-	desc = "A stubby and wide, high-capacity double stack magazine used in the M40-SD pulse rifle. Fires 10x24mm Armor Piercing rounds, holding up to 60 + 1 in the chamber."
+//XM40 AKA SOF RIFLE FROM HELL (It's an EM-2, a prototype of the real world L85A1 way back from the 1940s. We've given it a blue plastic shell and an integral suppressor)
+/obj/item/ammo_magazine/rifle/xm40
+	name = "\improper xm40 magazine (10x24mm)"
+	desc = "A stubby and wide, high-capacity double stack magazine used in the xm40 pulse rifle. Fires 10x24mm Armor Piercing rounds, holding up to 60 + 1 in the chamber."
 	icon_state = "m40_sd"
 	max_rounds = 60
-	gun_type = /obj/item/weapon/gun/rifle/m41a/elite/m40_sd
+	gun_type = /obj/item/weapon/gun/rifle/m41a/elite/xm40
 	default_ammo = /datum/ammo/bullet/rifle/ap
 
-/obj/item/ammo_magazine/rifle/m40_sd/heap
-	name = "\improper M40-SD HEAP magazine (10x24mm)"
-	desc = "A stubby and wide, high-capacity double stack magazine used in the M40-SD pulse rifle. Fires 10x24mm High Explosive Armor Piercing rounds, holding up to 60 + 1 in the chamber."
+/obj/item/ammo_magazine/rifle/xm40/heap
+	name = "\improper XM40 HEAP magazine (10x24mm)"
+	desc = "A stubby and wide, high-capacity double stack magazine used in the XM40 pulse rifle. Fires 10x24mm High Explosive Armor Piercing rounds, holding up to 60 + 1 in the chamber."
 	icon_state = "m40_sd_heap"
 	max_rounds = 60
-	gun_type = /obj/item/weapon/gun/rifle/m41a/elite/m40_sd
+	gun_type = /obj/item/weapon/gun/rifle/m41a/elite/xm40
 	default_ammo = /datum/ammo/bullet/rifle/heap
 
 //-------------------------------------------------------


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Changes the following weapon names to fit with a more realistic model designation:
XM42B > XM43E1
M1911 SOCOM > M48A4
M43(CLF pistol) > D18
M40-SD > XM40
MK210 > XM38

Also changes m1911 SOCOM from having attachments on base to a separate version with attachies for use outside fully equipped loadouts

If maintainer no like something i can remove. 🙂 

# Explain why it's good for the game

Makes gun names match closer to their realistic depiction.
Per change:

XM42B > XM43E1: XM42B is clearly not the same weapon as the M42A, and therefore would not share the same number designation, shifts it up a number to 43(possible replacement to M42) and changes the B to E1 so it makes a bit more sense.(I would also do this to PMC sniper M42C but thats the lore name so I can't.)

M1911 SOCOM > M48A4: military designation M1911s haven't been used since WW1(M1911A1 then more later on), current modern M1911 designation is M45A3 or something, also having SOCOM in name is bad, also I brought this gun into this world and I want to change the name.

M43 > D18: Its not a military weapon, its a homemade assassination weapon used by the CLF, D18 could presumably be a designation used by militaries of it, but its not an adopted or considered weapon so its not M[numbers].

M40-SD > XM40: not a fully adopted weapon, desc says its a predecessor that was considered but not widely used outside elite units(MARSOC), M40 implies its a prior design, SD as far as I can tell means literally nothing, so XM40 would be the correct designation.

MK210 > XM38: MK210 description says that it is not an official weyland weapon, but a USCM armorer edit off early MK221 prototypes to have full auto capability, therefore the Mk designation that I assume is WY designation would not fit, it is also not a fully adopted USCM weapon so it therefore is also not M38.  However it is a shotgun so it would come after the M37 adoption-wise, as a note the Mk221 would also probably be M39 or M40 combat shotgun ICly but thats confusing so I'm not going to touch it, also its mk221 in lore.


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

It works.

</details>


# Changelog

praying for allah for the tweak changelog option to be readded it was so useful I swear.

:cl:
spellcheck: Changes the following weapon names. XM42B to XM43E1, M1911 SOCOM > M48A4, M43 Hummingbird > D18 Hummingbird, M40-SD > XM40, Mk210 > XM38
spellcheck: B8 smartscope now doesn't say it fits on the M46C.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
