### PR TITLE
Burrowers can't burrow onto or off of a dropship anymore.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/burrower/burrower_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/burrower/burrower_powers.dm
@@ -15,6 +15,10 @@
 		to_chat(src, SPAN_XENOWARNING("You can't escape this cell!"))
 		return
 
+	if(istype(T, /turf/open/shuttle/dropship))
+		to_chat(src, SPAN_XENOWARNING("The bird's metal is too tough for you to burrow into."))
+		return
+
 	if(clone) //Prevents burrowing on stairs
 		to_chat(src, SPAN_XENOWARNING("You can't burrow here!"))
 		return

--- a/code/modules/mob/living/carbon/xenomorph/abilities/burrower/burrower_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/burrower/burrower_powers.dm
@@ -100,7 +100,6 @@
 		to_chat(src, SPAN_XENOWARNING("The bird's metal is too tough for you to burrow into."))
 		return
 
-
 	if(!target)
 		to_chat(src, SPAN_NOTICE("You can't tunnel there!"))
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request
See title. This fixes #1695. Burrowers can no longer tunnel into a DS with their burrowing nor can they tunnel out. Tested.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
This seems like an obvious oversight and it means burrowers can't just get onto a DS without consequences. If they want to leave they can't burrow out.  Also how does it fly with all the holes in the DS from the burrowing..
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: burrowers can no longer burrow onto or off of a dropship
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
