### PR TITLE
death to multitiles (3 kinds)

### DIFF
--- a/code/game/objects/structures/cargo_container.dm
+++ b/code/game/objects/structures/cargo_container.dm
@@ -10,13 +10,6 @@
 	opacity = TRUE
 	anchored = TRUE
 
-/obj/structure/cargo_container/Initialize()
-	. = ..()
-	///death to multitiles
-	if(icon_state == "gorg 0,0" || icon_state == "gorg 2,0")
-		layer = ABOVE_MOB_LAYER
-		bound_height = 32
-
 /obj/structure/cargo_container/attack_hand(mob/user as mob)
 
 	playsound(loc, 'sound/effects/clang.ogg', 25, 1)

--- a/code/game/objects/structures/cargo_container.dm
+++ b/code/game/objects/structures/cargo_container.dm
@@ -10,6 +10,13 @@
 	opacity = TRUE
 	anchored = TRUE
 
+/obj/structure/cargo_container/Initialize()
+	. = ..()
+	///death to multitiles
+	if(icon_state == "gorg 0,0" || icon_state == "gorg 2,0")
+		layer = ABOVE_MOB_LAYER
+		bound_height = 32
+
 /obj/structure/cargo_container/attack_hand(mob/user as mob)
 
 	playsound(loc, 'sound/effects/clang.ogg', 25, 1)

--- a/code/game/objects/structures/landing_signs.dm
+++ b/code/game/objects/structures/landing_signs.dm
@@ -3,8 +3,9 @@
 	desc = "Woah nelly, report this on GITLAB and ping a Spriter."
 	icon = 'icons/obj/structures/props/landing_signs.dmi'
 	icon_state = "laz_sign"
+	layer = ABOVE_MOB_LAYER
 	bound_width = 64
-	bound_height = 64
+	bound_height = 32
 	density = TRUE
 
 /obj/structure/lz_sign/lazarus_sign

--- a/code/game/objects/structures/props.dm
+++ b/code/game/objects/structures/props.dm
@@ -7,7 +7,7 @@
 	unacidable = TRUE
 	density = TRUE
 	layer = ABOVE_FLY_LAYER
-	bound_height = 96
+	bound_height = 32
 
 /obj/structure/prop/dam
 	density = TRUE
@@ -17,7 +17,8 @@
 	desc = "An old mining drill, seemingly used for mining. And possibly drilling."
 	icon = 'icons/obj/structures/props/drill.dmi'
 	icon_state = "drill"
-	bound_height = 96
+	layer = ABOVE_MOB_LAYER
+	bound_height = 64
 	var/on = FALSE//if this is set to on by default, the drill will start on, doi
 
 /obj/structure/prop/dam/drill/attackby(obj/item/W, mob/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request
This removes the extra boundheight provided to 3 types of objects. This means you can walk past the point they spawn (the base of the object, so to speak.)

- destroyed comms towers
- colony landing signs
- mining drills

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

These are mostly being changed for consistency's sake, in addition to the fact that impassable, unmeltable structures are probably longterm unhealthy for defensive gameplay.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
code: mining drills, LZ signs, and comms towers are now all 1-2 tiles high, allowing you to walk 'above' them in places you'd logically fit.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
