### PR TITLE
Landmine refractor

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -182,7 +182,7 @@
 #define TRAIT_TOOL_SIMPLE_BLOWTORCH "t_tool_simple_blowtorch"
 
 #define TRAIT_TOOL_PEN "t_tool_pen"
-
+#define TRAIT_TOOL_SHOVEL "t_tool_shovel"
 // GUN TRAITS
 #define TRAIT_GUN_SILENCED "t_gun_silenced"
 

--- a/code/game/objects/items/explosives/mine.dm
+++ b/code/game/objects/items/explosives/mine.dm
@@ -147,7 +147,7 @@
 
 //Disarming
 /obj/item/explosive/mine/attackby(obj/item/thing, mob/user)
-	if(needs_digging && istype(thing, /obj/item/tool/shovel) && !active && anchored)
+	if(needs_digging && HAS_TRAIT(thing,  TRAIT_TOOL_SHOVEL) && !active && anchored)
 		user.visible_message(SPAN_NOTICE("[user] starts burying \the [src]."), \
 			SPAN_NOTICE("You start burying \the [src]."))
 		playsound(user.loc, 'sound/effects/thud.ogg', 40, 1, 6)

--- a/code/game/objects/items/explosives/mine.dm
+++ b/code/game/objects/items/explosives/mine.dm
@@ -291,7 +291,7 @@
 	if(!customizable)
 		create_shrapnel(loc, 12, dir, angle, , cause_data)
 		//so that shrapnel has time to hit mobs before they are knocked over by the explosion
-		addtimer(CALLBACK(GLOBAL_PROC,GLOBAL_PROC_REF(cell_explosion), loc, explosive_power, 20, EXPLOSION_FALLOFF_SHAPE_LINEAR, dir, cause_data), 0.3 SECONDS, numticks = 3)
+		addtimer(CALLBACK(GLOBAL_PROC,GLOBAL_PROC_REF(cell_explosion), loc, explosive_power, 20, EXPLOSION_FALLOFF_SHAPE_LINEAR, dir, cause_data), 0.3 SECONDS)
 		qdel(src)
 	else
 		. = ..()

--- a/code/game/objects/items/stacks/sandbags.dm
+++ b/code/game/objects/items/stacks/sandbags.dm
@@ -16,7 +16,7 @@
 	stack_id = "empty sandbags"
 
 /obj/item/stack/sandbags_empty/attackby(obj/item/W, mob/user)
-	if (istype(W, /obj/item/tool/shovel))
+	if (HAS_TRAIT(W,  TRAIT_TOOL_SHOVEL))
 		var/obj/item/tool/shovel/ET = W
 		if(ET.dirt_amt)
 			ET.dirt_amt--

--- a/code/game/objects/items/stacks/snow.dm
+++ b/code/game/objects/items/stacks/snow.dm
@@ -23,7 +23,7 @@ GLOBAL_LIST_INIT(snow_recipes, list(
 	return ..()
 
 /obj/item/stack/snow/attackby(obj/item/W, mob/user)
-	if(istype(W, /obj/item/tool/shovel))
+	if(HAS_TRAIT(W,  TRAIT_TOOL_SHOVEL))
 		var/obj/item/tool/shovel/ET = W
 		if(isturf(loc))
 			if(ET.dirt_amt)

--- a/code/game/objects/items/tools/shovel_tools.dm
+++ b/code/game/objects/items/tools/shovel_tools.dm
@@ -22,6 +22,7 @@
 	var/shovelspeed = 30
 	var/dirt_amt = 0
 	var/dirt_amt_per_dig = 6
+	inherent_traits = list(TRAIT_TOOL_SHOVEL)
 
 
 /obj/item/tool/shovel/update_icon()

--- a/code/game/objects/structures/barricade/misc.dm
+++ b/code/game/objects/structures/barricade/misc.dm
@@ -30,7 +30,7 @@
 			to_chat(user, "You can't get near that, it's melting!")
 			return
 	//Removing the barricades
-	if(istype(W, /obj/item/tool/shovel) && user.a_intent != INTENT_HARM)
+	if(HAS_TRAIT(W,  TRAIT_TOOL_SHOVEL) && user.a_intent != INTENT_HARM)
 		var/obj/item/tool/shovel/ET = W
 		if(ET.folded)
 			return

--- a/code/game/objects/structures/barricade/sandbags.dm
+++ b/code/game/objects/structures/barricade/sandbags.dm
@@ -66,7 +66,7 @@
 			to_chat(user, "You can't get near that, it's melting!")
 			return
 
-	if(istype(W, /obj/item/tool/shovel) && user.a_intent != INTENT_HARM)
+	if(HAS_TRAIT(W,  TRAIT_TOOL_SHOVEL) && user.a_intent != INTENT_HARM)
 		var/obj/item/tool/shovel/ET = W
 		if(!ET.folded)
 			user.visible_message(SPAN_NOTICE("[user] starts disassembling [src]."), \

--- a/code/modules/hydroponics/hydro_tray.dm
+++ b/code/modules/hydroponics/hydro_tray.dm
@@ -741,7 +741,7 @@
 	draw_warnings = 0
 
 /obj/structure/machinery/portable_atmospherics/hydroponics/soil/attackby(obj/item/O as obj, mob/user as mob)
-	if(istype(O, /obj/item/tool/shovel))
+	if(HAS_TRAIT(O,  TRAIT_TOOL_SHOVEL))
 		to_chat(user, "You clear up [src]!")
 		qdel(src)
 	else if(istype(O,/obj/item/tool/shovel) || istype(O,/obj/item/tank))

--- a/html/changelogs/AutoChangeLog-pr-2334.yml
+++ b/html/changelogs/AutoChangeLog-pr-2334.yml
@@ -1,0 +1,13 @@
+author: "carlarctg"
+delete-after: True
+changes:
+  - balance: "Updates and buffs the following weapons: Basira-Armstrong Rifle, Model 12 Bolt-Action Rifle, M37-17 pump shotgun, Dragunov sniper rifle"
+  - imageadd: "The Basira rifle has been reflavored as the removed 'ceremonial' ABR-40, now a hunting-civilian version of the L42. It effectively has the same stats as the L42, just don't take the stock off!"
+  - rscadd: "Its magazines can only fit 12 bullets, but they still have the classic L42 kick to them. The magazines are completely compatible between both military and civilian gun types.\nadd:: Additionally, there are now holo-targeting magazines available for the ABR-40, for hunting target capture purposes."
+  - rscadd: "The Contractor ERT has a chance to spawn with a tacticool ABR-40 loadout, with three spare holotarget magazines on their webbing."
+  - balance: "Like the bolt-action rifle's sprite implies, this is now the new Basira-Armstrong rifle."
+  - rscadd: "Its stats have recieved an overhaul and it can now hold its own against a Xenomorph (or marine if you're CLF)"
+  - rscadd: "Additionally, its bullets will push back (not stun) targets within three meters, to increase viability for colony usage."
+  - balance: "Did you know that the 10% damage mod the M37-17 pump shotgun was supposed to have didn't work? Now it does! And it deals 15% more damage to make up for it."
+  - rscdel: "However, it can now be melted down."
+  - balance: "The dragunov has been revamped into a DMR, needing no skill to fire, dealing good damage, and having the same push-back feature the bolt-action now has."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
# About the pull request
Refractors landmines to be much more flexible, enabling the use of different mine types like buried mines,controlling triggers,arming time, etc

Parent type of buried mines has been added. All buried mines should be subtyped from this. This is NOT meant to be spawned in game.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Enables adding a variety of landmine content + typechecks bad
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos

</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

https://user-images.githubusercontent.com/42422230/219289516-970340cb-0c09-4769-8f34-d489a37902fe.mov

video of triggers being tested and mine being deployed

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:TotalEpicness5
refactor: Refractors mine code so it is more flexible and allows for different mine types like buried mines, controlling triggers ,arming time, etc
refractor: Nukes shovel typechecks in favor of a new shovel trait.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
