### PR TITLE
Opens up 2 spots in Trijent's sand temple area.

### DIFF
--- a/maps/map_files/DesertDam/Desert_Dam.dmm
+++ b/maps/map_files/DesertDam/Desert_Dam.dmm
@@ -38930,12 +38930,6 @@
 	icon_state = "greencorner"
 	},
 /area/desert_dam/building/substation/west)
-"cnl" = (
-/obj/structure/machinery/door/airlock/almayer/engineering/colony{
-	name = "\improper Telecommunications";
-	},
-/turf/open/floor/prison,
-/area/desert_dam/building/substation/west)
 "cnp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -63966,6 +63960,14 @@
 /obj/effect/decal/cleanable/liquid_fuel,
 /turf/open/asphalt,
 /area/desert_dam/exterior/valley/valley_medical)
+"fFw" = (
+/obj/structure/prop/dam/boulder/boulder2{
+	desc = "A large rock. It looks very hard to get around."
+	},
+/turf/open/desert/rock/deep{
+	icon_state = "rock3"
+	},
+/area/desert_dam/interior/caves/temple)
 "fHg" = (
 /turf/open/desert/dirt{
 	icon_state = "desert_transition_edge1"
@@ -64463,12 +64465,6 @@
 	icon_state = "tile"
 	},
 /area/desert_dam/exterior/valley/south_valley_dam)
-"hdF" = (
-/obj/structure/prop/dam/large_boulder/boulder2,
-/turf/open/desert/rock/deep{
-	icon_state = "rock3"
-	},
-/area/desert_dam/interior/caves/temple)
 "het" = (
 /obj/structure/surface/table,
 /obj/structure/machinery/computer/objective,
@@ -73414,14 +73410,14 @@ cgm
 cgm
 cgm
 cgm
-cnl
+cpS
 cgm
 cmm
 cmm
 cmm
 cmm
 cgm
-cnl
+cpS
 cgm
 cgm
 cgm
@@ -124803,7 +124799,7 @@ dTs
 aBL
 aBL
 ayH
-hdF
+ayH
 qJU
 aAv
 aCk
@@ -125037,7 +125033,7 @@ aBL
 axw
 xmH
 ayH
-ayH
+fFw
 dTs
 dTs
 aBE
@@ -125508,8 +125504,8 @@ mHf
 dTs
 dTs
 rvd
+ayH
 trZ
-dTs
 dTs
 dTs
 dTs
@@ -125742,8 +125738,8 @@ aBS
 aCk
 aBS
 ayH
+ayH
 aBL
-dTs
 dTs
 dTs
 aBL
@@ -125975,9 +125971,9 @@ ayH
 aBV
 aBU
 aCk
+ayH
 nFh
 aBL
-dTs
 dTs
 dTs
 aBL
@@ -126209,8 +126205,8 @@ dTs
 aBL
 aBL
 aCk
+aCk
 aBL
-dTs
 dTs
 dTs
 dTs


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request
This PR fixes the issue of an impassable rock blocking two sections of the Trijent map's sand temple that marines _must_ C4, and opens up the area to its direct south. I also added a little fun description for the smaller boulder I turned the large 2x2 into referencing how in the way it is.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Here's the before-
![image](https://user-images.githubusercontent.com/70115628/218394201-9c65c885-730f-40e6-a40e-abc3c931db85.png)
Note how inconvenient this is for both sides.
Here's the after-
![image](https://user-images.githubusercontent.com/70115628/218394339-85bcabfd-7ece-40bf-a62e-179b898068c1.png)

This is a pretty big improvement, and it makes this area easier for marines and xenos to use and fight in. I've seen this artificially extend hive assaults which doesn't seem fun for either side.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

![image](https://user-images.githubusercontent.com/70115628/218395888-476274c6-eb0b-45f7-9955-b3359c69bcd3.png)
more movement to fight changes everything


</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
maptweak: opened up 2 spots in Trijent's sand temple area
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
