### PR TITLE
Fixes character trait points not being reset when loading a different character

### DIFF
--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -507,6 +507,8 @@
 	gear = sanitize_list(gear)
 
 	traits = sanitize_list(traits)
+	read_traits = FALSE
+	trait_points = initial(trait_points)
 
 	//if(!skin_style) skin_style = "Default"
 

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -509,8 +509,7 @@
 	traits = sanitize_list(traits)
 	read_traits = FALSE
 	trait_points = initial(trait_points)
-
-	//if(!skin_style) skin_style = "Default"
+	close_browser(owner, "character_traits")
 
 	if(!origin) origin = ORIGIN_USCM
 	if(!faction)  faction =  "None"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Fixes https://github.com/cmss13-devs/cmss13/issues/660

# Explain why it's good for the game 

Bugfix


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Tested with 3 character slots. Just loaded and updated character traits and saved them.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl: TheDonkified
fix: Loading a new character slot will properly update your character trait points. You can now modify multiple human characters' character traits without having to reload.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
