### PR TITLE
CHUNK boxes are no longer lethal

### DIFF
--- a/code/game/objects/items/reagent_containers/food/snacks.dm
+++ b/code/game/objects/items/reagent_containers/food/snacks.dm
@@ -3286,7 +3286,7 @@
 	bitesize = 20
 	wrapper = /obj/item/trash/chunk/hunk
 
-/obj/item/reagent_container/food/snacks/wrapped/chunk/Initialize()
+/obj/item/reagent_container/food/snacks/wrapped/chunk/hunk/Initialize()
 	. = ..()
 	reagents.add_reagent("nutriment", 5)
 	reagents.add_reagent("iron", 30)


### PR DESCRIPTION
# About the pull request

Somebody messed up the initialization, so you would get both 7u nutriment and 10u coco, AND, 5u nutriment, 5u coco, and 30u iron, in a CHUNK box. the 5u nutriment and coco, and 30u of iron were meant to be for the HUNK crate, as that is exclusive to the black market and dangerous

# Explain why it's good for the game

CHUNK boxes will no longer OD you on iron and kill you

# Changelog

:cl:
fix: Makes CHUNK boxes not lethal
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
