### PR TITLE
Cleaned up table code and bugfix

### DIFF
--- a/code/__DEFINES/objects.dm
+++ b/code/__DEFINES/objects.dm
@@ -160,3 +160,7 @@ var/list/RESTRICTED_CAMERA_NETWORKS = list( //Those networks can only be accesse
 #define OBJ_IS_HELMET_GARB (1<<2)
 /// can you customize the description/name of the thing?
 #define OBJ_UNIQUE_RENAME (1<<3)
+
+// For reinforced table status
+#define RTABLE_WEAKENED 1
+#define RTABLE_NORMAL 2

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -197,6 +197,11 @@
 //This item will force clickdrag to work even if the preference to disable is enabled. (Full-auto items)
 #define TRAIT_OVERRIDE_CLICKDRAG "t_override_clickdrag"
 
+//-- structure traits --
+// TABLE TRAITS
+/// If the table is being flipped, prevent any changes that will mess with adjacency handling
+#define TRAIT_TABLE_FLIPPING "t_table_flipping"
+
 //List of all traits
 GLOBAL_LIST_INIT(mob_traits, list(
 	TRAIT_YAUTJA_TECH,
@@ -263,6 +268,9 @@ GLOBAL_LIST_INIT(traits_by_type, list(
 	/obj/item/weapon/gun = list(
 		"TRAIT_GUN_SILENCED" = TRAIT_GUN_SILENCED,
 	),
+	/obj/structure/surface/table = list(
+		"TRAIT_STRUCTURE_FLIPPING" = TRAIT_TABLE_FLIPPING,
+	)
 ))
 
 /// value -> trait name, generated on use from trait_by_type global
@@ -304,6 +312,9 @@ GLOBAL_LIST(trait_name_map)
 #define TRAIT_SOURCE_ABILITY(ability) "t_s_ability_[ability]"
 ///Status trait forced by the xeno action charge
 #define TRAIT_SOURCE_XENO_ACTION_CHARGE "t_s_xeno_action_charge"
+//-- structure traits --
+///Status trait coming from being flipped or unflipped.
+#define TRAIT_SOURCE_FLIP_TABLE "t_s_flip_table"
 
 ///Status trait from weapons?? buh
 #define TRAIT_SOURCE_WEAPON "t_s_weapon"

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -66,7 +66,9 @@
 	return ..()
 
 /obj/structure/surface/table/proc/update_adjacent(location)
-	if(!location) location = src //location arg is used to correctly update neighbour tables when deleting a table.
+	if(!location)
+		location = src //location arg is used to correctly update neighbour tables when deleting a table.
+
 	for(var/direction in CARDINAL_ALL_DIRS)
 		var/obj/structure/surface/table/T = locate(/obj/structure/surface/table, get_step(location,direction))
 		if(T && !HAS_TRAIT(T, TRAIT_TABLE_FLIPPING))
@@ -321,20 +323,23 @@
 		return
 	..()
 
+/// Checks whether a table is a straight line along a given axis
 /obj/structure/surface/table/proc/straight_table_check(direction)
-	var/obj/structure/surface/table/T
-	for(var/angle in list(-90, 90))
-		T = locate() in get_step(loc, turn(direction, angle))
-		if(T && !T.flipped)
-			return 0
-	T = locate() in get_step(src.loc,direction)
-	if(!T || T.flipped)
-		return 1
-	if(istype(T, /obj/structure/surface/table/reinforced/))
-		var/obj/structure/surface/table/reinforced/R = T
-		if(R.status == 2)
-			return 0
-	return T.straight_table_check(direction)
+	var/obj/structure/surface/table/table = src
+	while(table)
+		// Check whether there are connected tables perpendicular to the axis
+		for(var/angle in list(-90, 90))
+			table = locate() in get_step(loc, turn(direction, angle))
+			if(table && !table.flipped)
+				return FALSE
+		table = locate() in get_step(table, direction)
+		if(!table || table.flipped)
+			return TRUE
+		if(istype(table, /obj/structure/surface/table/reinforced))
+			var/obj/structure/surface/table/reinforced/reinforced_table = table
+			if(reinforced_table.status == RTABLE_NORMAL)
+				return FALSE
+	return TRUE
 
 /obj/structure/surface/table/verb/do_flip()
 	set name = "Flip table"
@@ -349,8 +354,11 @@
 		to_chat(usr, SPAN_WARNING("You're not angry enough to flip [src]."))
 		return
 
+	if(get_turf(usr) == get_turf(src))
+		to_chat(usr, SPAN_WARNING("You need to get off [src] in order to flip it."))
+		return
+
 	if(!flip(get_cardinal_dir(usr, src)))
-		to_chat(usr, SPAN_WARNING("[src] won't budge."))
 		return
 
 	usr.visible_message(SPAN_WARNING("[usr] flips [src]!"),
@@ -360,30 +368,34 @@
 	if(climbable)
 		structure_shaken()
 
-	flip_cooldown = world.time + 50
+	flip_cooldown = world.time + 5 SECONDS
 
 /obj/structure/surface/table/proc/unflipping_check(direction)
 	if(world.time < flip_cooldown)
-		return 0
+		to_chat(usr, SPAN_WARNING("You have moved a table too recently."))
+		return FALSE
 
-	for(var/mob/M in oview(src, 0))
-		return 0
+	for(var/mob/mob_behind_table in oview(src, 0))
+		to_chat(usr, SPAN_WARNING("[mob_behind_table] is in the way of [src]."))
+		return FALSE
 
-	var/list/L = list()
+	var/list/directions = list()
 	if(direction)
-		L.Add(direction)
+		directions.Add(direction)
 	else
-		L.Add(turn(src.dir,-90))
-		L.Add(turn(src.dir,90))
-	for(var/new_dir in L)
-		var/obj/structure/surface/table/T = locate() in get_step(loc, new_dir)
-		if(T)
-			if(T.flipped && T.dir == src.dir && !T.unflipping_check(new_dir))
-				return 0
-	for(var/obj/structure/S in loc)
-		if((S.flags_atom & ON_BORDER) && S.density && S != src) //We would put back on a structure that wouldn't allow it
-			return 0
-	return 1
+		directions.Add(turn(src.dir,-90))
+		directions.Add(turn(src.dir,90))
+	for(var/new_dir in directions)
+		var/obj/structure/surface/table/adjacent_table = locate() in get_step(loc, new_dir)
+		if(!adjacent_table)
+			continue
+		if(adjacent_table.flipped && adjacent_table.dir == src.dir && !adjacent_table.unflipping_check(new_dir))
+			return FALSE
+	for(var/obj/structure/structure_behind_table in get_turf(src))
+		if((structure_behind_table.flags_atom & ON_BORDER) && structure_behind_table.density && structure_behind_table != src) //We would put back on a structure that wouldn't allow it
+			to_chat(usr, SPAN_WARNING("[structure_behind_table] is in the way of [src]."))
+			return FALSE
+	return TRUE
 
 /obj/structure/surface/table/proc/do_put()
 	set name = "Put table back"
@@ -395,18 +407,22 @@
 		return
 
 	if(!unflipping_check())
-		to_chat(usr, SPAN_WARNING("[src] won't budge."))
 		return
 
 	unflip()
 
-	flip_cooldown = world.time + 50
+	flip_cooldown = world.time + 5 SECONDS
 
-/obj/structure/surface/table/proc/flip(direction)
+/**
+ * Flip a table along a certain direction. By default checks whether table is flippable along axis perpendicular to flip direction.
+ */
+/obj/structure/surface/table/proc/flip(direction, skip_straight_check=FALSE)
 	if(world.time < flip_cooldown)
+		to_chat(usr, SPAN_WARNING("You have moved a table too recently."))
 		return FALSE
 
-	if(!straight_table_check(turn(direction, 90)) || !straight_table_check(turn(direction, -90)))
+	if(!skip_straight_check && (!straight_table_check(turn(direction, 90)) || !straight_table_check(turn(direction, -90))))
+		to_chat(usr, SPAN_WARNING("[src] is too wide to be flipped."))
 		return FALSE
 
 	ADD_TRAIT(src, TRAIT_TABLE_FLIPPING, TRAIT_SOURCE_FLIP_TABLE)
@@ -416,24 +432,26 @@
 
 	detach_all()
 
-	var/list/targets = list(get_step(src,dir),get_step(src, turn(dir, 45)),get_step(src, turn(dir, -45)))
-	for(var/atom/movable/A in get_turf(src))
-		if(!A.anchored)
-			spawn(0)
-				A.throw_atom(pick(targets), 1, SPEED_FAST)
+	var/list/targets = list(get_step(src, dir), get_step(src, turn(dir, 45)), get_step(src, turn(dir, -45)))
+	for(var/atom/movable/movable_on_table in get_turf(src))
+		if(!movable_on_table.anchored)
+			INVOKE_ASYNC(movable_on_table, TYPE_PROC_REF(/atom/movable, throw_atom), pick(targets), 1, SPEED_FAST)
 
 	projectile_coverage = flipped_projectile_coverage
 
 	setDir(direction)
 	if(dir != NORTH)
 		layer = FLY_LAYER
-	flipped = 1
+	flipped = TRUE
 	flags_can_pass_all_temp &= ~PASS_UNDER
 	flags_atom |= ON_BORDER
-	for(var/D in list(turn(direction, 90), turn(direction, -90)))
-		var/obj/structure/surface/table/T = locate() in get_step(src,D)
-		if(T && !T.flipped)
-			T.flip(direction)
+
+	for(var/adjacent_dir in list(turn(direction, 90), turn(direction, -90)))
+		var/obj/structure/surface/table/adjacent_table = locate() in get_step(src, adjacent_dir)
+		if(adjacent_table && !adjacent_table.flipped)
+			// Can skip straight check because we already iterated through all the tables that are connected to this table
+			adjacent_table.flip(direction, TRUE)
+
 	update_icon()
 	update_adjacent()
 
@@ -512,7 +530,7 @@
 	desc = "A square metal surface resting on four legs. This one has side panels, making it useful as a desk, but impossible to flip."
 	icon_state = "reinftable"
 	health = 140
-	var/status = 2
+	var/status = RTABLE_NORMAL
 	reinforced = TRUE
 	table_prefix = "reinf"
 	parts = /obj/item/frame/table/reinforced
@@ -527,7 +545,7 @@
 			return
 		var/obj/item/tool/weldingtool/WT = W
 		if(WT.remove_fuel(0, user))
-			if(status == 2)
+			if(status == RTABLE_NORMAL)
 				user.visible_message(SPAN_NOTICE("[user] starts weakening [src]."),
 				SPAN_NOTICE("You start weakening [src]"))
 				playsound(src.loc, 'sound/items/Welder.ogg', 25, 1)
@@ -535,7 +553,7 @@
 					if(!src || !WT.isOn()) return
 					user.visible_message(SPAN_NOTICE("[user] weakens [src]."),
 					SPAN_NOTICE("You weaken [src]"))
-					src.status = 1
+					src.status = RTABLE_WEAKENED
 			else
 				user.visible_message(SPAN_NOTICE("[user] starts welding [src] back together."),
 				SPAN_NOTICE("You start welding [src] back together."))
@@ -544,13 +562,13 @@
 					if(!src || !WT.isOn()) return
 					user.visible_message(SPAN_NOTICE("[user] welds [src] back together."),
 					SPAN_NOTICE("You weld [src] back together."))
-					status = 2
+					status = RTABLE_NORMAL
 			return
 		return
 
-	if(HAS_TRAIT(W, TRAIT_TOOL_WRENCH) && !(user.a_intent == INTENT_HELP))
-		if(status == 2)
-			return
+	if(HAS_TRAIT(W, TRAIT_TOOL_WRENCH) && !(user.a_intent == INTENT_HELP) && status == RTABLE_NORMAL)
+		return
+
 	..()
 
 /obj/structure/surface/table/reinforced/prison

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -69,7 +69,7 @@
 	if(!location) location = src //location arg is used to correctly update neighbour tables when deleting a table.
 	for(var/direction in CARDINAL_ALL_DIRS)
 		var/obj/structure/surface/table/T = locate(/obj/structure/surface/table, get_step(location,direction))
-		if(T)
+		if(T && !HAS_TRAIT(T, TRAIT_TABLE_FLIPPING))
 			T.update_icon()
 
 /obj/structure/surface/table/Crossed(atom/movable/O)
@@ -404,10 +404,12 @@
 
 /obj/structure/surface/table/proc/flip(direction)
 	if(world.time < flip_cooldown)
-		return 0
+		return FALSE
 
 	if(!straight_table_check(turn(direction, 90)) || !straight_table_check(turn(direction, -90)))
-		return 0
+		return FALSE
+
+	ADD_TRAIT(src, TRAIT_TABLE_FLIPPING, TRAIT_SOURCE_FLIP_TABLE)
 
 	verbs -= /obj/structure/surface/table/verb/do_flip
 	verbs += /obj/structure/surface/table/proc/do_put
@@ -435,9 +437,12 @@
 	update_icon()
 	update_adjacent()
 
-	return 1
+	REMOVE_TRAIT(src, TRAIT_TABLE_FLIPPING, TRAIT_SOURCE_FLIP_TABLE)
+
+	return TRUE
 
 /obj/structure/surface/table/proc/unflip()
+	ADD_TRAIT(src, TRAIT_TABLE_FLIPPING, TRAIT_SOURCE_FLIP_TABLE)
 	verbs -= /obj/structure/surface/table/proc/do_put
 	verbs += /obj/structure/surface/table/verb/do_flip
 
@@ -456,7 +461,9 @@
 	update_icon()
 	update_adjacent()
 
-	return 1
+	REMOVE_TRAIT(src, TRAIT_TABLE_FLIPPING, TRAIT_SOURCE_FLIP_TABLE)
+
+	return TRUE
 
 /*
  * Wooden tables


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Tries to fix https://github.com/cmss13-devs/cmss13/issues/371. There is still a weird issue where the flip cooldown is updated before the other tables are flipped. No idea why this is happening.

Also updated the warning messages related to flipping tables to be more specific.

# Explain why it's good for the game

Bugfix


# Testing Photographs and Procedure

n/a


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl: TheDonkified
fix: Table flipping and unflipping is now more descriptive and less buggy. You can no longer flip table that you are on top of.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
