### PR TITLE
Makes the leaky pipe effect into a proper object.

### DIFF
--- a/code/game/objects/structures/props.dm
+++ b/code/game/objects/structures/props.dm
@@ -892,7 +892,7 @@
 
 /obj/structure/prop/invuln/leaky_pipe/Initialize(mapload)
 	. = ..()
-	if(is_mainship_level(src.z))
+	if(is_mainship_level(z))
 		desc += "The Almayer has sprung a leak!"
 	else
 		desc += "The colony has sprung a leak!"

--- a/code/game/objects/structures/props.dm
+++ b/code/game/objects/structures/props.dm
@@ -893,7 +893,7 @@
 /obj/structure/prop/invuln/leaky_pipe/Initialize(mapload)
 	. = ..()
 	if(is_mainship_level(z))
-		desc += "The [MAIN_SHIP_NAME] has sprung a leak!"
+		desc += "The [copytext(MAIN_SHIP_NAME, 5)] has sprung a leak!"
 	else
 		desc += "The colony has sprung a leak!"
 

--- a/code/game/objects/structures/props.dm
+++ b/code/game/objects/structures/props.dm
@@ -883,6 +883,16 @@
 	layer = ABOVE_MOB_LAYER
 	density = FALSE
 
+/obj/structure/prop/invuln/leaky_pipe
+	name = "pipe water"
+	icon = 'icons/obj/structures/props/watercloset.dmi'
+	icon_state = "water"
+	desc = "The Almayer has sprung a leak!"
+	density = FALSE
+
+/obj/structure/prop/invuln/leaky_pipe/colony
+	desc = "The colony's sprung a leak!"
+
 /obj/structure/prop/wooden_cross
 	name = "wooden cross"
 	desc = "A wooden grave marker. Is it more respectful because someone made it by hand, or less, because it's crude and misshapen?"

--- a/code/game/objects/structures/props.dm
+++ b/code/game/objects/structures/props.dm
@@ -887,11 +887,15 @@
 	name = "pipe water"
 	icon = 'icons/obj/structures/props/watercloset.dmi'
 	icon_state = "water"
-	desc = "The Almayer has sprung a leak!"
+	desc = ""
 	density = FALSE
 
-/obj/structure/prop/invuln/leaky_pipe/colony
-	desc = "The colony's sprung a leak!"
+/obj/structure/prop/invuln/leaky_pipe/Initialize(mapload)
+	. = ..()
+	if(is_mainship_level(src.z))
+		desc += "The Almayer has sprung a leak!"
+	else
+		desc += "The colony has sprung a leak!"
 
 /obj/structure/prop/wooden_cross
 	name = "wooden cross"

--- a/code/game/objects/structures/props.dm
+++ b/code/game/objects/structures/props.dm
@@ -893,7 +893,7 @@
 /obj/structure/prop/invuln/leaky_pipe/Initialize(mapload)
 	. = ..()
 	if(is_mainship_level(z))
-		desc += "The Almayer has sprung a leak!"
+		desc += "The [MAIN_SHIP_NAME] has sprung a leak!"
 	else
 		desc += "The colony has sprung a leak!"
 

--- a/maps/map_files/LV522_Chances_Claim/LV522_Chances_Claim.dmm
+++ b/maps/map_files/LV522_Chances_Claim/LV522_Chances_Claim.dmm
@@ -2967,12 +2967,7 @@
 	pixel_x = -4;
 	pixel_y = 24
 	},
-/obj/structure/prop/invuln{
-	density = 0;
-	desc = "The Almayer has sprung a leak!";
-	icon = 'icons/obj/structures/props/watercloset.dmi';
-	icon_state = "water";
-	name = "pipe water";
+/obj/structure/prop/invuln/leaky_pipe/colony{
 	pixel_x = -4;
 	pixel_y = 1
 	},
@@ -4717,12 +4712,7 @@
 	pixel_x = 11;
 	pixel_y = 24
 	},
-/obj/structure/prop/invuln{
-	density = 0;
-	desc = "The Almayer has sprung a leak!";
-	icon = 'icons/obj/structures/props/watercloset.dmi';
-	icon_state = "water";
-	name = "pipe water";
+/obj/structure/prop/invuln/leaky_pipe/colony{
 	pixel_x = -7;
 	pixel_y = 4
 	},
@@ -11004,13 +10994,8 @@
 /area/lv522/indoors/c_block/cargo)
 "fuc" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/prop/invuln{
-	density = 0;
-	desc = "The Almayer has sprung a leak!";
+/obj/structure/prop/invuln/leaky_pipe/colony{
 	dir = 8;
-	icon = 'icons/obj/structures/props/watercloset.dmi';
-	icon_state = "water";
-	name = "pipe water";
 	pixel_x = -31
 	},
 /turf/open/floor/prison,
@@ -20769,12 +20754,7 @@
 	pixel_x = -2;
 	pixel_y = 24
 	},
-/obj/structure/prop/invuln{
-	density = 0;
-	desc = "The Almayer has sprung a leak!";
-	icon = 'icons/obj/structures/props/watercloset.dmi';
-	icon_state = "water";
-	name = "pipe water";
+/obj/structure/prop/invuln/leaky_pipe/colony{
 	pixel_x = 4;
 	pixel_y = 6
 	},
@@ -23962,12 +23942,7 @@
 	projectile_coverage = 0;
 	unacidable = 1
 	},
-/obj/structure/prop/invuln{
-	density = 0;
-	desc = "The Almayer has sprung a leak!";
-	icon = 'icons/obj/structures/props/watercloset.dmi';
-	icon_state = "water";
-	name = "pipe water";
+/obj/structure/prop/invuln/leaky_pipe/colony{
 	pixel_x = 17;
 	pixel_y = -2
 	},
@@ -30093,12 +30068,7 @@
 	pixel_x = 11;
 	pixel_y = 16
 	},
-/obj/structure/prop/invuln{
-	density = 0;
-	desc = "The Almayer has sprung a leak!";
-	icon = 'icons/obj/structures/props/watercloset.dmi';
-	icon_state = "water";
-	name = "pipe water";
+/obj/structure/prop/invuln/leaky_pipe/colony{
 	pixel_x = 4;
 	pixel_y = -6
 	},
@@ -30967,12 +30937,7 @@
 	projectile_coverage = 0;
 	unacidable = 1
 	},
-/obj/structure/prop/invuln{
-	density = 0;
-	desc = "The Almayer has sprung a leak!";
-	icon = 'icons/obj/structures/props/watercloset.dmi';
-	icon_state = "water";
-	name = "pipe water";
+/obj/structure/prop/invuln/leaky_pipe/colony{
 	pixel_y = 17
 	},
 /turf/open/gm/river,
@@ -32527,12 +32492,7 @@
 "ogA" = (
 /obj/effect/decal/cleanable/blood/xeno,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/prop/invuln{
-	density = 0;
-	desc = "The Almayer has sprung a leak!";
-	icon = 'icons/obj/structures/props/watercloset.dmi';
-	icon_state = "water";
-	name = "pipe water";
+/obj/structure/prop/invuln/leaky_pipe/colony{
 	pixel_y = 28
 	},
 /turf/open/floor/prison,
@@ -42575,12 +42535,7 @@
 	pixel_x = 6;
 	pixel_y = 19
 	},
-/obj/structure/prop/invuln{
-	density = 0;
-	desc = "The Almayer has sprung a leak!";
-	icon = 'icons/obj/structures/props/watercloset.dmi';
-	icon_state = "water";
-	name = "pipe water";
+/obj/structure/prop/invuln/leaky_pipe/colony{
 	pixel_x = -5;
 	pixel_y = 10
 	},
@@ -45651,12 +45606,7 @@
 	pixel_x = -3;
 	pixel_y = -1
 	},
-/obj/structure/prop/invuln{
-	density = 0;
-	desc = "The Almayer has sprung a leak!";
-	icon = 'icons/obj/structures/props/watercloset.dmi';
-	icon_state = "water";
-	name = "pipe water";
+/obj/structure/prop/invuln/leaky_pipe/colony{
 	pixel_y = 11
 	},
 /turf/open/gm/river,

--- a/maps/map_files/LV522_Chances_Claim/LV522_Chances_Claim.dmm
+++ b/maps/map_files/LV522_Chances_Claim/LV522_Chances_Claim.dmm
@@ -2967,7 +2967,7 @@
 	pixel_x = -4;
 	pixel_y = 24
 	},
-/obj/structure/prop/invuln/leaky_pipe/colony{
+/obj/structure/prop/invuln/leaky_pipe{
 	pixel_x = -4;
 	pixel_y = 1
 	},
@@ -4712,7 +4712,7 @@
 	pixel_x = 11;
 	pixel_y = 24
 	},
-/obj/structure/prop/invuln/leaky_pipe/colony{
+/obj/structure/prop/invuln/leaky_pipe{
 	pixel_x = -7;
 	pixel_y = 4
 	},
@@ -10994,7 +10994,7 @@
 /area/lv522/indoors/c_block/cargo)
 "fuc" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/prop/invuln/leaky_pipe/colony{
+/obj/structure/prop/invuln/leaky_pipe{
 	dir = 8;
 	pixel_x = -31
 	},
@@ -20754,7 +20754,7 @@
 	pixel_x = -2;
 	pixel_y = 24
 	},
-/obj/structure/prop/invuln/leaky_pipe/colony{
+/obj/structure/prop/invuln/leaky_pipe{
 	pixel_x = 4;
 	pixel_y = 6
 	},
@@ -23942,7 +23942,7 @@
 	projectile_coverage = 0;
 	unacidable = 1
 	},
-/obj/structure/prop/invuln/leaky_pipe/colony{
+/obj/structure/prop/invuln/leaky_pipe{
 	pixel_x = 17;
 	pixel_y = -2
 	},
@@ -30068,7 +30068,7 @@
 	pixel_x = 11;
 	pixel_y = 16
 	},
-/obj/structure/prop/invuln/leaky_pipe/colony{
+/obj/structure/prop/invuln/leaky_pipe{
 	pixel_x = 4;
 	pixel_y = -6
 	},
@@ -30937,7 +30937,7 @@
 	projectile_coverage = 0;
 	unacidable = 1
 	},
-/obj/structure/prop/invuln/leaky_pipe/colony{
+/obj/structure/prop/invuln/leaky_pipe{
 	pixel_y = 17
 	},
 /turf/open/gm/river,
@@ -32492,7 +32492,7 @@
 "ogA" = (
 /obj/effect/decal/cleanable/blood/xeno,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/prop/invuln/leaky_pipe/colony{
+/obj/structure/prop/invuln/leaky_pipe{
 	pixel_y = 28
 	},
 /turf/open/floor/prison,
@@ -42535,7 +42535,7 @@
 	pixel_x = 6;
 	pixel_y = 19
 	},
-/obj/structure/prop/invuln/leaky_pipe/colony{
+/obj/structure/prop/invuln/leaky_pipe{
 	pixel_x = -5;
 	pixel_y = 10
 	},
@@ -45606,7 +45606,7 @@
 	pixel_x = -3;
 	pixel_y = -1
 	},
-/obj/structure/prop/invuln/leaky_pipe/colony{
+/obj/structure/prop/invuln/leaky_pipe{
 	pixel_y = 11
 	},
 /turf/open/gm/river,

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -37419,13 +37419,7 @@
 	},
 /area/almayer/shipboard/brig/cells)
 "dCh" = (
-/obj/structure/prop/invuln{
-	density = 0;
-	desc = "The Almayer has sprung a leak!";
-	icon = 'icons/obj/structures/props/watercloset.dmi';
-	icon_state = "water";
-	name = "pipe water"
-	},
+/obj/structure/prop/invuln/leaky_pipe,
 /obj/structure{
 	dir = 4;
 	health = 150;
@@ -40304,12 +40298,7 @@
 	projectile_coverage = 0;
 	unacidable = 1
 	},
-/obj/structure/prop/invuln{
-	density = 0;
-	desc = "The Almayer has sprung a leak!";
-	icon = 'icons/obj/structures/props/watercloset.dmi';
-	icon_state = "water";
-	name = "pipe water";
+/obj/structure/prop/invuln/leaky_pipe{
 	pixel_x = 17
 	},
 /turf/open/floor/plating/plating_catwalk,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request
This takes the 'leaky pipe' effect as seen here and makes it a proper object.
![image](https://user-images.githubusercontent.com/70115628/218974204-2edc9362-3d42-4de4-a7d6-f8da763f9321.png)
It also changes the colony-side (so far limited to Chance's Claim, since no other maps use this effect) to say 'colony' rather than 'Almayer' with a proper subtype.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

Previously, it was defined using /obj/structure/prop/invuln and then manually assigning all the things like name, icon, etc. This is a super efficient way to do things and I may or may not have ideas about implementing these onto the Almayer as fixable messes that MTs can handle. Also, it's very movielike and makes the Almayer feel more alive.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
code: leaky pipes are now under a proper type. please use this in the future, mappers.
maptweak: all of the Chance's Claim leaky pipes now no longer reference the Almayer.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
