### PR TITLE
prevents runtimes accessing non-existent assets

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -613,7 +613,10 @@
 
 	// weapon info
 
-	data["icon"] = SSassets.transport.get_asset_url("[base_gun_icon].png")
+	data["icon"] = SSassets.transport.get_asset_url("no_name.png")
+
+	if(SSassets.cache["[base_gun_icon].png"])
+		data["icon"] = SSassets.transport.get_asset_url("[base_gun_icon].png")
 
 	data["name"] = name
 	data["desc"] = desc


### PR DESCRIPTION
prevents the morbillions of assets when you look at a gun tgui without a fancy lil lineart

:cl:
fix: fixed runtimes when accessing gun stat interfaces
/:cl: