### PR TITLE
sanity check against non-cliented ert spawns

### DIFF
--- a/code/datums/emergency_calls/emergency_call.dm
+++ b/code/datums/emergency_calls/emergency_call.dm
@@ -211,6 +211,9 @@
 				if(!istype(M))//Something went horrifically wrong
 					candidates.Remove(M)
 					continue //Lets try this again
+				if(!M.ghost_mob.client)
+					candidates -= M
+					continue
 				if(M.current && M.current.stat != DEAD)
 					candidates.Remove(M) //Strip them from the list, they aren't dead anymore.
 					if(!candidates.len)

--- a/code/datums/emergency_calls/emergency_call.dm
+++ b/code/datums/emergency_calls/emergency_call.dm
@@ -211,7 +211,7 @@
 				if(!istype(M))//Something went horrifically wrong
 					candidates.Remove(M)
 					continue //Lets try this again
-				if(!M.ghost_mob.client)
+				if(!GLOB.directory[M.ckey])
 					candidates -= M
 					continue
 				if(M.current && M.current.stat != DEAD)


### PR DESCRIPTION
no more freaky unknowns when you leave after joining an ERT

:cl:
fix: prevented ert spawns causing unknown demons if you disconnect after becoming a candidate
/:cl: