### PR TITLE
[Experimental] Smartgun IFF removal and rebalance

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1839,7 +1839,7 @@
 
 	max_range = 12
 	accuracy = HIT_ACCURACY_TIER_4
-	damage = 30
+	damage = 50
 	penetration = 0
 
 /datum/ammo/bullet/smartgun/armor_piercing
@@ -1848,7 +1848,7 @@
 
 	accurate_range = 12
 	accuracy = HIT_ACCURACY_TIER_2
-	damage = 20
+	damage = 35
 	penetration = ARMOR_PENETRATION_TIER_8
 	damage_armor_punch = 1
 
@@ -1859,7 +1859,7 @@
 	shrapnel_chance = SHRAPNEL_CHANCE_TIER_7
 	accurate_range = 32
 	accuracy = HIT_ACCURACY_TIER_3
-	damage = 40
+	damage = 60
 	penetration = 0
 
 /datum/ammo/bullet/smartgun/dirty/armor_piercing
@@ -1867,7 +1867,7 @@
 
 	accurate_range = 22
 	accuracy = HIT_ACCURACY_TIER_3
-	damage = 30
+	damage = 45
 	penetration = ARMOR_PENETRATION_TIER_7
 	damage_armor_punch = 3
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Removes IFF and autofire from smartguns. Increases damages to compensate.

This is something I'd like to try and if it doesn't work out well then it doesn't work out. 

# Explain why it's good for the game

IFF is incredibly difficult to balance around and metas forming around smartgun deathballs is unfun for xenos as well as reinforcing cave/corner hugging. This should allow for the role to still be powerful and impactful while solving the perceived issue.

If you don't put the word "BANANAS" at the beginning of your PR feedback comment I'm not reading it good luck.

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
balance: Removes IFF and autofire from smartguns. Increases damages to compensate.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
