### PR TITLE
Removes knockback from certain ammo types.

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -113,11 +113,14 @@
 
 	shake_camera(living_mob, 3, 4)
 	knockback_effects(living_mob, fired_projectile)
-	slam_back(living_mob, fired_projectile)
 
 /datum/ammo/proc/slam_back(mob/living/living_mob, obj/item/projectile/fired_projectile)
 	//Either knockback or slam them into an obstacle.
 	var/direction = Get_Compass_Dir(fired_projectile.z ? fired_projectile : fired_projectile.firer, living_mob) //More precise than get_dir.
+
+	if(living_mob.mob_size >= MOB_SIZE_BIG)
+		return //Big xenos are not affected.
+
 	if(!direction) //Same tile.
 		return
 	if(!step(living_mob, direction))
@@ -1203,6 +1206,7 @@
 
 /datum/ammo/bullet/shotgun/slug/on_hit_mob(mob/M,obj/item/projectile/P)
 	knockback(M, P, 6)
+	slam_back(M, P)
 
 /datum/ammo/bullet/shotgun/slug/knockback_effects(mob/living/living_mob, obj/item/projectile/fired_projectile)
 	if(iscarbonsizexeno(living_mob))


### PR DESCRIPTION
# About the pull request

This PR removes the push back effect from certain ammo types, such as heavy revolver, buckshot, M4RA impact rounds, et cetera. This does not affect slugs however.  Note, that the push back effect only works within 2 tiles or on point blank, so this PR mainly affects ammo types such as the heavy revolver and buckshot.
Tested on a dev server with these ammo types.

# Explain why it's good for the game

The push back/knockback effect from stunning ammo types have been in the game for a while, however despite their visually appealing effect it is not good for the game. Not only does it provide a safe net for xenos that are punished by a PB with a shotgun, it also doesn't take into account in game factors such as being on weeds, slowed, thus punishing the player for utilizing a debuffing effect (the actual stuns they used) and can prevent follow up hits from other marines. The damage received by wall slams was also extremely low, to the point where its unnoticeable. 

I believe this should be test merged, to see the effect of "knockback" ammo types not pushing xenos away, and decide if it should truly stay.

# Changelog


:cl:
balance: Removed the push back effect from certain ammo types
/:cl:
