### PR TITLE
Increases rounds needed to vote for WO, and brings back its minimum pop limit.

### DIFF
--- a/code/game/gamemodes/colonialmarines/whiskey_outpost.dm
+++ b/code/game/gamemodes/colonialmarines/whiskey_outpost.dm
@@ -76,7 +76,7 @@
 	hardcore = TRUE
 
 	votable = TRUE
-	vote_cycle = 25 // approx. once every 5 days, if it wins the vote
+	vote_cycle = 45 // Every 45 rounds
 
 	taskbar_icon = 'icons/taskbar/gml_wo.png'
 

--- a/map_config/maps.txt
+++ b/map_config/maps.txt
@@ -62,4 +62,5 @@ map new_varadero
 endmap
 
 map whiskey_outpost_v2
+	minplayers 130
 endmap


### PR DESCRIPTION


# About the pull request

This PR increases the minimum amount of rounds needed for WO to appear in gamemode voting by 20, and reverts the change that removed its 130 pop limit.

# Explain why it's good for the game

WO appears far too much, I highly doubt it was intended to appear at least once a day, sometimes more so if the rounds end too fast.  Also, the MR that changed WO into a voteable gamemode mentioned it to be a gamemode in which it would once every 5 days, this is clearly not the case. 
![image](https://user-images.githubusercontent.com/125149403/220192722-fe29690e-1dcb-435f-8150-f4bcae63638b.png)


This will increase the rarity of WO, and make it more appealing to play (and more fun, as there will be more players on each side with the pop limit).


# Changelog

:cl:
add: Increased the amount of rounds needed to vote for WO by 20, and brought back the 130 pop limit for the map
/:cl:

