### PR TITLE
Fixes crates being anchored when they land.

### DIFF
--- a/code/modules/cm_tech/droppod/supply.dm
+++ b/code/modules/cm_tech/droppod/supply.dm
@@ -7,6 +7,8 @@
 /obj/structure/droppod/supply/open()
 	. = ..()
 	for(var/atom/movable/content as anything in contents)
+		if(istype(content, /obj/structure/closet/crate))
+			content.anchored = FALSE
 		content.forceMove(loc)
 	qdel(src)
 

--- a/code/modules/cm_tech/droppod/supply.dm
+++ b/code/modules/cm_tech/droppod/supply.dm
@@ -7,6 +7,8 @@
 /obj/structure/droppod/supply/open()
 	. = ..()
 	for(var/atom/movable/content as anything in contents)
+		///Crates are anchored when launched to avoid pushing them while launching and this created issues with them being anchored when they landed groundside.
+		///This unanchors them before moving them out to make sure that crates are able to be moved when groundside.
 		if(istype(content, /obj/structure/closet/crate))
 			content.anchored = FALSE
 		content.forceMove(loc)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request
I did a typo in the commit's title but this should fix the issue we have wherein sometimes crates are not movable when they land. They get anchored when they launch.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Bugs bad gr.. I didn't actually test this but it should work.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: crates are now always unanchored when they land
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
