### PR TITLE
Fixes berserker buffed slashes slowing for over a minute

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/mutators/strains/ravager/berserker.dm
+++ b/code/modules/mob/living/carbon/xenomorph/mutators/strains/ravager/berserker.dm
@@ -64,7 +64,7 @@
 
 	// State
 	var/next_slash_buffed = FALSE
-	var/slash_slow_duration = 2	//measured in server ticks
+	var/slash_slow_duration = 2	//measured in life ticks
 
 /datum/behavior_delegate/ravager_berserker/melee_attack_additional_effects_self()
 	..()

--- a/code/modules/mob/living/carbon/xenomorph/mutators/strains/ravager/berserker.dm
+++ b/code/modules/mob/living/carbon/xenomorph/mutators/strains/ravager/berserker.dm
@@ -64,7 +64,7 @@
 
 	// State
 	var/next_slash_buffed = FALSE
-	var/slash_slow_duration = 2	//~3.5 seconds
+	var/slash_slow_duration = 2	//measured in server ticks
 
 /datum/behavior_delegate/ravager_berserker/melee_attack_additional_effects_self()
 	..()

--- a/code/modules/mob/living/carbon/xenomorph/mutators/strains/ravager/berserker.dm
+++ b/code/modules/mob/living/carbon/xenomorph/mutators/strains/ravager/berserker.dm
@@ -64,7 +64,7 @@
 
 	// State
 	var/next_slash_buffed = FALSE
-	var/slash_slow_duration = 3.5 SECONDS
+	var/slash_slow_duration = 2	//~3.5 seconds
 
 /datum/behavior_delegate/ravager_berserker/melee_attack_additional_effects_self()
 	..()


### PR DESCRIPTION
# About the pull request

As title says, fixes berserker slash applying slowed for 35 ticks as opposed to the 3.5 seconds it's supposed to slow for.

# Explain why it's good for the game

bug bad

# Testing Photographs and Procedure

yup it works

# Changelog

:cl:Kraso
fix: Berserker ravager's Apprehend ability no longer slows you down for an absurd amount of time.
/:cl:
