### PR TITLE
Marine Raiders aren't starving anymore.

### DIFF
--- a/code/modules/gear_presets/uscm.dm
+++ b/code/modules/gear_presets/uscm.dm
@@ -783,6 +783,9 @@
 
 	minimap_icon = "private"
 
+/datum/equipment_preset/uscm/marsoc/load_status(mob/living/carbon/human/H)
+	H.nutrition = NUTRITION_NORMAL
+
 /datum/equipment_preset/uscm/marsoc/New()
 	. = ..()
 	access = get_all_accesses() + get_all_centcom_access()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Makes Marine Raiders spawn with nutrition level normal, meaning they aren't literally starving on spawn(without any food to fix that) and massively slowed(even with speed stim).

# Explain why it's good for the game

Bug, raiders spawning max slowdown from being literally starving made them less of a threat.


# Testing Photographs and Procedure

It works



# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: Marine Raiders spawn not starving again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
