### PR TITLE
shuttle server crash fix

### DIFF
--- a/code/game/machinery/doors/airlock_control.dm
+++ b/code/game/machinery/doors/airlock_control.dm
@@ -127,6 +127,16 @@
 	. = ..()
 	if(!surpress_send) send_status()
 
+/obj/structure/machinery/door/airlock/dropship_hatch/close(forced = FALSE)
+	if(forced)
+		for(var/mob/living/current_living in loc)
+			step(current_living, pick(CARDINAL_DIRS))
+		safe = FALSE
+		..()
+		safe = TRUE
+	else
+		..()
+
 
 /obj/structure/machinery/door/airlock/close(surpress_send)
 	. = ..()

--- a/code/modules/shuttle/helpers.dm
+++ b/code/modules/shuttle/helpers.dm
@@ -130,8 +130,7 @@
 	air.safe = 0
 	air.operating = 0
 	air.unlock(TRUE)
-	while(!air.density)
-		air.close(TRUE)
+	air.close(TRUE)
 	air.lock(TRUE)
 	air.safe = 1
 


### PR DESCRIPTION
infinite while loop if something dense is in the doors is probably bad

:cl:
fix: server crashes caused by dense objects in shuttle doors
/:cl: