### PR TITLE
M4RA handling sound stolen from l42A

### DIFF
--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -1052,7 +1052,7 @@
 
 /obj/item/weapon/gun/rifle/lmg
 	name = "\improper M41AE2 heavy pulse rifle"
-	desc = "A large squad support weapon capable of laying down sustained suppressing fire from a mounted position. While unstable and less accurate, it can be lugged and shot with two hands. Like it's smaller brothers, the M41A MK2 and L42 MK1, the M41AE2 is chambered in 10mm."
+	desc = "A large squad support weapon capable of laying down sustained suppressing fire from a mounted position. While unstable and less accurate, it can be lugged and shot with two hands. Like it's smaller brothers, the M41A MK2 and M4RA, the M41AE2 is chambered in 10mm."
 	icon = 'icons/obj/items/weapons/guns/guns_by_faction/uscm.dmi'
 	icon_state = "m41ae2"
 	item_state = "m41ae2"
@@ -1343,6 +1343,8 @@
 	icon_state = "m4ra"
 	item_state = "m4ra"
 	fire_sound = 'sound/weapons/gun_m4ra.ogg'
+	reload_sound = 'sound/weapons/handling/l42_reload.ogg'
+	unload_sound = 'sound/weapons/handling/l42_unload.ogg'
 	current_mag = /obj/item/ammo_magazine/rifle/m4ra
 	attachable_allowed = list(
 		/obj/item/attachable/suppressor,

--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -544,6 +544,8 @@
 	)
 
 	fire_sound = 'sound/weapons/gun_m4ra.ogg'
+	reload_sound = 'sound/weapons/handling/l42_reload.ogg'
+	unload_sound = 'sound/weapons/handling/l42_unload.ogg'
 	current_mag = /obj/item/ammo_magazine/rifle/m4ra/custom
 	force = 16
 	attachable_allowed = list(


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Gives l42 handling sounds(loading, unloading, chambering) to M4RA

Changes L42A mention to M4RA in HPR desc.

ITS NOT THE FIRING SOUND

# Explain why it's good for the game

I meant to do this but I forgot to and I logged onto CM and heard the shitty base sound effects and went like 😭 😭 😭 so I'm fixing it with the L42 sounds because those sound really good and it has l42 stats mostly 😄 

also fixes an error in hpr desc which is good because fixing things is good

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

I didn't test it but it compiled.

</details>


# Changelog


:cl:
add: M4RA now uses L42A handling effects for loading/unloading and chambering
spellcheck: HPR now says M4RA instead of L42A when going over the other 10x24 marine weapons
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
