### PR TITLE
Morgue Name Updates

### DIFF
--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -13,6 +13,7 @@
 	var/tray_path = /obj/structure/morgue_tray
 	var/morgue_open = 0
 	var/exit_stun = 2
+	var/update_name = TRUE
 	anchored = TRUE
 	throwpass = 1
 
@@ -57,19 +58,20 @@
 			if(!A.anchored)
 				A.forceMove(src)
 		connected.forceMove(src)
-		name = "morgue"
-		var/mob/living/L = locate(/mob/living) in contents
-		if(L)
-			name = "morgue ([L])"
-		else
-			var/obj/structure/closet/bodybag/B = locate(/obj/structure/closet/bodybag) in contents
-			if(B)
-				L = locate(/mob/living) in B.contents
-				if(L)
-					name = "morgue ([L])"
+		if(update_name)
+			name = initial(name)
+			var/mob/living/L = locate(/mob/living) in contents
+			if(L)
+				name = "[name] ([L])"
+			else
+				var/obj/structure/closet/bodybag/B = locate(/obj/structure/closet/bodybag) in contents
+				if(B)
+					L = locate(/mob/living) in B.contents
+					if(L)
+						name = "[name] ([L])"
 
 	else
-		name = "morgue"
+		name = initial(name)
 		connected.forceMove(loc)
 		if(step(connected, dir))
 			connected.setDir(dir)
@@ -282,10 +284,11 @@
 
 /obj/structure/morgue/sarcophagus
 	name = "sarcophagus"
-	desc = "Used to store predators."
+	desc = "Used to store fallen warriors."
 	icon_state = "sarcophagus1"
 	morgue_type = "sarcophagus"
 	tray_path = /obj/structure/morgue_tray/sarcophagus
+	update_name = FALSE
 
 
 /*


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request
Makes it so yautja morgues don't get renamed.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Stops Sarcophagi turning into Morgue
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
add: Added a var to decide if morgues update their names to reflect contents. Currently just used to protect Yautja sarcophagi.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
