### PR TITLE
Nerfs to the Scout Custom M4RA.

### DIFF
--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -570,7 +570,6 @@
 
 	flags_gun_features = GUN_AUTO_EJECTOR|GUN_SPECIALIST|GUN_CAN_POINTBLANK|GUN_AMMO_COUNTER
 	map_specific_decoration = TRUE
-	wield_delay = WIELD_DELAY_NORMAL
 	aim_slowdown = SLOWDOWN_ADS_QUICK
 	flags_item = TWOHANDED|NO_CRYO_STORE
 

--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -570,8 +570,7 @@
 
 	flags_gun_features = GUN_AUTO_EJECTOR|GUN_SPECIALIST|GUN_CAN_POINTBLANK|GUN_AMMO_COUNTER
 	map_specific_decoration = TRUE
-	wield_delay = WIELD_DELAY_VERY_FAST
-	aim_slowdown = SLOWDOWN_ADS_QUICK
+	wield_delay = WIELD_DELAY_NORMAL
 	flags_item = TWOHANDED|NO_CRYO_STORE
 
 /obj/item/weapon/gun/rifle/m4ra_custom/handle_starting_attachment()
@@ -587,13 +586,13 @@
 
 /obj/item/weapon/gun/rifle/m4ra_custom/set_gun_config_values()
 	..()
-	fire_delay = FIRE_DELAY_TIER_8
+	fire_delay = FIRE_DELAY_TIER_6
 	burst_amount = BURST_AMOUNT_TIER_2
 	burst_delay = FIRE_DELAY_TIER_10
-	accuracy_mult = BASE_ACCURACY_MULT + HIT_ACCURACY_MULT_TIER_5
+	accuracy_mult = BASE_ACCURACY_MULT + HIT_ACCURACY_MULT_TIER_1
 	scatter = SCATTER_AMOUNT_TIER_8
 	burst_scatter_mult = SCATTER_AMOUNT_TIER_8
-	damage_mult = BASE_BULLET_DAMAGE_MULT + BULLET_DAMAGE_MULT_TIER_4
+	damage_mult = BASE_BULLET_DAMAGE_MULT + BULLET_DAMAGE_MULT_TIER_1
 	recoil = RECOIL_AMOUNT_TIER_5
 	damage_falloff_mult = 0
 

--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -571,6 +571,7 @@
 	flags_gun_features = GUN_AUTO_EJECTOR|GUN_SPECIALIST|GUN_CAN_POINTBLANK|GUN_AMMO_COUNTER
 	map_specific_decoration = TRUE
 	wield_delay = WIELD_DELAY_NORMAL
+	aim_slowdown = SLOWDOWN_ADS_QUICK
 	flags_item = TWOHANDED|NO_CRYO_STORE
 
 /obj/item/weapon/gun/rifle/m4ra_custom/handle_starting_attachment()
@@ -589,10 +590,10 @@
 	fire_delay = FIRE_DELAY_TIER_6
 	burst_amount = BURST_AMOUNT_TIER_2
 	burst_delay = FIRE_DELAY_TIER_10
-	accuracy_mult = BASE_ACCURACY_MULT + HIT_ACCURACY_MULT_TIER_1
+	accuracy_mult = BASE_ACCURACY_MULT + HIT_ACCURACY_MULT_TIER_2
 	scatter = SCATTER_AMOUNT_TIER_8
 	burst_scatter_mult = SCATTER_AMOUNT_TIER_8
-	damage_mult = BASE_BULLET_DAMAGE_MULT + BULLET_DAMAGE_MULT_TIER_1
+	damage_mult = BASE_BULLET_DAMAGE_MULT + BULLET_DAMAGE_MULT_TIER_2
 	recoil = RECOIL_AMOUNT_TIER_5
 	damage_falloff_mult = 0
 


### PR DESCRIPTION
# About the pull request

This PR reverts undocumented changes to the M4RA custom scout rifle, which was recently merged. Namely, the instant wield, the fire rate delay decrease by 2, a damage multiplier of 0.30, and a accuracy multiplier as well.

# Explain why it's good for the game

Undocumented, balance changes in a PR that says "with less balance changes", which severely buffed the scout rifle to be an extremely quick and safe to say OP weapon. Not only does it have FULL AP (meaning no castes aside from max rage berserker can have a semblance of reduced damage), 66 damage on just the base ammo (which is given in abundance), it also have absolutely 0 fall off (which i did not change, as I believe scouts shouldn't have falloff but in the case of current scout rifle it is far too powerful with the other buffed stats). It absolutely shreds almost every caste, and is bad balancing. This PR reverts those changes.

![image](https://user-images.githubusercontent.com/125149403/223005863-5c233a7e-5a17-4220-a75c-4a74dd16b1a9.png)

This isn't documenting the insane buffs to the scout rifle, and I'd go so far as to say the author of the PR understood these changes would make the rifle extremely powerful. Also, the issue with "omega slime" with ammo switching on scout could be solved without the need for a full stat increase on damage, accuracy, fire rate. 

# Changelog
:cl:
balance: Nerfs to the Scout Custom M4RA.
/:cl:

