### PR TITLE
Fixes power issues for shuttle consoles

### DIFF
--- a/code/modules/shuttle/computers/dropship_computer.dm
+++ b/code/modules/shuttle/computers/dropship_computer.dm
@@ -6,6 +6,7 @@
 	req_access = list(ACCESS_MARINE_LEADER, ACCESS_MARINE_DROPSHIP, ACCESS_WY_CORPORATE_DS)
 	unacidable = TRUE
 	exproof = TRUE
+	needs_power = FALSE
 
 	// True if we are doing a flyby
 	var/is_set_flyby = FALSE
@@ -443,3 +444,4 @@
 	icon = 'icons/obj/structures/machinery/computer.dmi'
 	icon_state = "shuttle"
 	is_remote = TRUE
+	needs_power = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Shuttle consoles at LZs were losing power and making it impossible for xenos to hijack without admin intervention. This makes it so shuttle consoles do not need power other than remote control consoles aboard the Almayer.

# Explain why it's good for the game

The gameplay loop should be possible without admin intervention.

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
Yeah sorta

</details>


# Changelog

:cl: Morrow
fix: Fixes power issues for shuttle consoles
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
