### PR TITLE
Checks if you can fire guns before attempting to execute

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -1310,7 +1310,7 @@ and you're good to go.
 
 	if(EXECUTION_CHECK) //Execution
 		if(!able_to_fire(user)) //Can they actually use guns in the first place?
-			return
+			return ..()
 		user.visible_message(SPAN_DANGER("[user] puts [src] up to [attacked_mob], steadying their aim."), SPAN_WARNING("You put [src] up to [attacked_mob], steadying your aim."),null, null, CHAT_TYPE_COMBAT_ACTION)
 		if(!do_after(user, 3 SECONDS, INTERRUPT_ALL|INTERRUPT_DIFF_INTENT, BUSY_ICON_HOSTILE))
 			return TRUE

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -1309,6 +1309,8 @@ and you're good to go.
 		return TRUE
 
 	if(EXECUTION_CHECK) //Execution
+		if(!able_to_fire(user)) //Can they actually use guns in the first place?
+			return
 		user.visible_message(SPAN_DANGER("[user] puts [src] up to [attacked_mob], steadying their aim."), SPAN_WARNING("You put [src] up to [attacked_mob], steadying your aim."),null, null, CHAT_TYPE_COMBAT_ACTION)
 		if(!do_after(user, 3 SECONDS, INTERRUPT_ALL|INTERRUPT_DIFF_INTENT, BUSY_ICON_HOSTILE))
 			return TRUE


### PR DESCRIPTION
# About the pull request

If you are unable to fire guns, you will not _attempt_ to execute anymore.
You never could fire it, but the message and the interaction wheel would still appear.

# Explain why it's good for the game

You can't fire it, why would you try to execute?

# Changelog

:cl:
qol: If you are unable to fire guns, you are also unable to execute, and instead just melee
/:cl:
