### PR TITLE
Adjusts Marine Paygrades for Playercounts above 120

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -540,3 +540,7 @@ This maintains a list of ip addresses that are able to bypass topic filtering.
 /datum/config_entry/number/hard_deletes_overrun_limit
 	default = 0
 	min_val = 0
+
+/datum/config_entry/number/highpop_min
+	default = 120
+	min_val = 0

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -78,7 +78,7 @@ GLOBAL_VAR_INIT(ishighpop, FALSE)
 		generate_corpses()
 	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_MODE_PRESETUP)
 
-//Set up some things to check playercount at the beginning of the round
+	//Set up some things to check playercount at the beginning of the round
 	var/highpop_check = CONFIG_GET(number/highpop_min)
 	var/players = length(GLOB.clients)
 	if(players < highpop_check)

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -14,6 +14,8 @@
 var/global/datum/entity/statistic/round/round_statistics
 var/global/list/datum/entity/player_entity/player_entities = list()
 var/global/cas_tracking_id_increment = 0 //this var used to assign unique tracking_ids to tacbinos and signal flares
+GLOBAL_VAR_INIT(ishighpop, FALSE)
+
 /datum/game_mode
 	var/name = "invalid"
 	var/config_tag = null
@@ -75,6 +77,13 @@ var/global/cas_tracking_id_increment = 0 //this var used to assign unique tracki
 	if(corpses_to_spawn)
 		generate_corpses()
 	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_MODE_PRESETUP)
+
+//Set up some things to check playercount at the beginning of the round
+	var/highpop_check = CONFIG_GET(number/highpop_min)
+	var/players = length(GLOB.clients)
+	if(players < highpop_check)
+		GLOB.ishighpop = TRUE
+
 	return 1
 
 ///Triggered partway through the first drop, based on DROPSHIP_DROP_MSG_DELAY. Marines are underway but haven't yet landed.

--- a/code/modules/gear_presets/uscm.dm
+++ b/code/modules/gear_presets/uscm.dm
@@ -1,3 +1,8 @@
+GLOBAL_VAR_INIT(ishighpop, FALSE)
+GLOBAL_VAR_INIT(checkedhighpop, FALSE)
+
+#define HIGHPOP_MIN 120
+
 /datum/equipment_preset/uscm
 	name = "USCM"
 	faction = FACTION_MARINE
@@ -56,23 +61,26 @@
 			equipped_headset.add_hud_tracker(H)
 
 /datum/equipment_preset/uscm/load_rank(mob/living/carbon/human/H)
-	check_players()
+	if(!GLOB.checkedhighpop)
+		check_players()
 	..()
 	//Is it highpop, and does it have either a highpop or playtime rank?
-	if(highpop && (highpop_paygrade || playtime_rank))
+	if(GLOB.ishighpop && (highpop_paygrade || playtime_rank))
 		if(!playtime_rank)
 			return highpop_paygrade
 
 		//All the silver+ LCPLs get to me CPLs on highpop.
-		else if (highpop && get_job_playtime(H.client, rank) < JOB_PLAYTIME_TIER_2)
+		else if (GLOB.ishighpop && get_job_playtime(H.client, rank) < JOB_PLAYTIME_TIER_2)
 			return playtime_rank
 
 /datum/equipment_preset/uscm/proc/check_players()
 	var/players = length(GLOB.clients)
 	//Oh god, I do need to know if there is a config value for the # of players for highpop
-	if(players < 120)
-		highpop = TRUE
+	if(players < HIGHPOP_MIN)
+		GLOB.ishighpop = TRUE
+	GLOB.checkedhighpop = TRUE
 
+#undef HIGHPOP_MIN
 
 //*****************************************************************************************************/
 /datum/equipment_preset/uscm/pfc

--- a/code/modules/gear_presets/uscm.dm
+++ b/code/modules/gear_presets/uscm.dm
@@ -62,7 +62,7 @@
 			return highpop_paygrade
 
 		//All the gold+ LCPLs get to be CPLs on highpop.
-		else if (GLOB.ishighpop && get_job_playtime(H.client, rank) < JOB_PLAYTIME_TIER_3)
+		if(get_job_playtime(H.client, rank) < JOB_PLAYTIME_TIER_3)
 			return playtime_rank
 
 

--- a/code/modules/gear_presets/uscm.dm
+++ b/code/modules/gear_presets/uscm.dm
@@ -64,7 +64,7 @@
 			return highpop_paygrade
 
 		//All the silver+ LCPLs get to me CPLs on highpop.
-		else if (highpop && get_job_playtime(H.client, rank) < JOB_PLAYTIME_TIER_3)
+		else if (highpop && get_job_playtime(H.client, rank) < JOB_PLAYTIME_TIER_2)
 			return playtime_rank
 
 /datum/equipment_preset/uscm/proc/check_players()
@@ -101,7 +101,7 @@
 		if(get_job_playtime(H.client, rank) < JOB_PLAYTIME_TIER_1)
 			return "ME1"
 		//Only for highpop, I think that this is for plat?
-		if(highpop && get_job_playtime(H.client, rank) < JOB_PLAYTIME_TIER_5)
+		if(highpop && get_job_playtime(H.client, rank) < JOB_PLAYTIME_TIER_4)
 			return "ME3"
 	return paygrade
 

--- a/code/modules/gear_presets/uscm.dm
+++ b/code/modules/gear_presets/uscm.dm
@@ -23,7 +23,7 @@
 	dress_shoes = list(/obj/item/clothing/shoes/dress)
 	var/auto_squad_name
 	var/highpop_paygrade
-	//Only used for Highpop
+	///Only used for Highpop
 	var/playtime_rank
 
 /datum/equipment_preset/uscm/load_status(mob/living/carbon/human/H)
@@ -55,14 +55,14 @@
 			var/obj/item/device/radio/headset/almayer/marine/equipped_headset = H.wear_r_ear
 			equipped_headset.add_hud_tracker(H)
 
-/datum/equipment_preset/uscm/load_rank(mob/living/carbon/human/H)
+/datum/equipment_preset/uscm/load_rank(mob/living/carbon/human/Player)
 	//Is it highpop, and does it have either a highpop or playtime rank?
 	if(GLOB.ishighpop && (highpop_paygrade || playtime_rank))
 		if(!playtime_rank)
 			return highpop_paygrade
 
 		//All the gold+ LCPLs get to be CPLs on highpop.
-		if(get_job_playtime(H.client, rank) < JOB_PLAYTIME_TIER_3)
+		if(get_job_playtime(Player.client, rank) < JOB_PLAYTIME_TIER_3)
 			return playtime_rank
 	return paygrade
 

--- a/code/modules/gear_presets/uscm.dm
+++ b/code/modules/gear_presets/uscm.dm
@@ -1,8 +1,3 @@
-GLOBAL_VAR_INIT(ishighpop, FALSE)
-GLOBAL_VAR_INIT(checkedhighpop, FALSE)
-
-#define HIGHPOP_MIN 120
-
 /datum/equipment_preset/uscm
 	name = "USCM"
 	faction = FACTION_MARINE
@@ -28,9 +23,7 @@ GLOBAL_VAR_INIT(checkedhighpop, FALSE)
 	dress_shoes = list(/obj/item/clothing/shoes/dress)
 	var/auto_squad_name
 	var/highpop_paygrade
-	/// Only used for Highpop
-	var/playtime_rank	
-	var/highpop
+	var/playtime_rank	//Only used for Highpop
 
 /datum/equipment_preset/uscm/load_status(mob/living/carbon/human/H)
 	H.nutrition = rand(NUTRITION_VERYLOW, NUTRITION_LOW)
@@ -62,26 +55,16 @@ GLOBAL_VAR_INIT(checkedhighpop, FALSE)
 			equipped_headset.add_hud_tracker(H)
 
 /datum/equipment_preset/uscm/load_rank(mob/living/carbon/human/H)
-	if(!GLOB.checkedhighpop)
-		check_players()
 	..()
 	//Is it highpop, and does it have either a highpop or playtime rank?
 	if(GLOB.ishighpop && (highpop_paygrade || playtime_rank))
 		if(!playtime_rank)
 			return highpop_paygrade
 
-		//All the silver+ LCPLs get to me CPLs on highpop.
-		else if (GLOB.ishighpop && get_job_playtime(H.client, rank) < JOB_PLAYTIME_TIER_2)
+		//All the gold+ LCPLs get to be CPLs on highpop.
+		else if (GLOB.ishighpop && get_job_playtime(H.client, rank) < JOB_PLAYTIME_TIER_3)
 			return playtime_rank
 
-/datum/equipment_preset/uscm/proc/check_players()
-	var/players = length(GLOB.clients)
-	//Oh god, I do need to know if there is a config value for the # of players for highpop
-	if(players < HIGHPOP_MIN)
-		GLOB.ishighpop = TRUE
-	GLOB.checkedhighpop = TRUE
-
-#undef HIGHPOP_MIN
 
 //*****************************************************************************************************/
 /datum/equipment_preset/uscm/pfc
@@ -104,13 +87,11 @@ GLOBAL_VAR_INIT(checkedhighpop, FALSE)
 	H.equip_to_slot_or_del(new backItem(H), WEAR_BACK)
 
 /datum/equipment_preset/uscm/pfc/load_rank(mob/living/carbon/human/H)
-	check_players()
-
 	if(H.client)
 		if(get_job_playtime(H.client, rank) < JOB_PLAYTIME_TIER_1)
 			return "ME1"
 		//Only for highpop, I think that this is for plat?
-		if(highpop && get_job_playtime(H.client, rank) < JOB_PLAYTIME_TIER_4)
+		if(GLOB.ishighpop && get_job_playtime(H.client, rank) < JOB_PLAYTIME_TIER_4)
 			return "ME3"
 	return paygrade
 

--- a/code/modules/gear_presets/uscm.dm
+++ b/code/modules/gear_presets/uscm.dm
@@ -22,6 +22,9 @@
 	dress_gloves = list(/obj/item/clothing/gloves/marine/dress)
 	dress_shoes = list(/obj/item/clothing/shoes/dress)
 	var/auto_squad_name
+	var/highpop_paygrade
+	var/playtime_rank	//Only used for Highpop
+	var/highpop
 
 /datum/equipment_preset/uscm/load_status(mob/living/carbon/human/H)
 	H.nutrition = rand(NUTRITION_VERYLOW, NUTRITION_LOW)
@@ -52,6 +55,24 @@
 			var/obj/item/device/radio/headset/almayer/marine/equipped_headset = H.wear_r_ear
 			equipped_headset.add_hud_tracker(H)
 
+/datum/equipment_preset/uscm/load_rank(mob/living/carbon/human/H)
+	check_players()
+	..()
+	//Is it highpop, and does it have either a highpop or playtime rank?
+	if(highpop && (highpop_paygrade || playtime_rank))
+		if(!playtime_rank)
+			return highpop_paygrade
+
+		//All the silver+ LCPLs get to me CPLs on highpop.
+		else if (highpop && get_job_playtime(H.client, rank) < JOB_PLAYTIME_TIER_3)
+			return playtime_rank
+
+/datum/equipment_preset/uscm/proc/check_players()
+	var/players = length(GLOB.clients)
+	//Oh god, I do need to know if there is a config value for the # of players for highpop
+	if(players < 120)
+		highpop = TRUE
+
 
 //*****************************************************************************************************/
 /datum/equipment_preset/uscm/pfc
@@ -64,7 +85,6 @@
 	paygrade = "ME2"
 	role_comm_title = "RFN"
 	skills = /datum/skills/pfc
-
 	minimap_icon = "private"
 
 /datum/equipment_preset/uscm/pfc/load_gear(mob/living/carbon/human/H)
@@ -75,9 +95,14 @@
 	H.equip_to_slot_or_del(new backItem(H), WEAR_BACK)
 
 /datum/equipment_preset/uscm/pfc/load_rank(mob/living/carbon/human/H)
+	check_players()
+
 	if(H.client)
 		if(get_job_playtime(H.client, rank) < JOB_PLAYTIME_TIER_1)
 			return "ME1"
+		//Only for highpop, I think that this is for plat?
+		if(highpop && get_job_playtime(H.client, rank) < JOB_PLAYTIME_TIER_5)
+			return "ME3"
 	return paygrade
 
 /datum/equipment_preset/uscm/pfc/cryo
@@ -98,6 +123,7 @@
 	assignment = JOB_SQUAD_SMARTGUN
 	rank = JOB_SQUAD_SMARTGUN
 	paygrade = "ME3"
+	playtime_rank = "ME4"
 	role_comm_title = "SG"
 	skills = /datum/skills/smartgunner
 
@@ -272,6 +298,7 @@
 	assignment = JOB_SQUAD_SPECIALIST
 	rank = JOB_SQUAD_SPECIALIST
 	paygrade = "ME3"
+	playtime_rank = "ME4"
 	role_comm_title = "Spc"
 	skills = /datum/skills/specialist
 
@@ -328,6 +355,7 @@
 	assignment = JOB_SQUAD_MEDIC
 	rank = JOB_SQUAD_MEDIC
 	paygrade = "ME3"
+	playtime_rank = "ME4"
 	role_comm_title = "HM"
 	skills = /datum/skills/combat_medic
 
@@ -360,9 +388,9 @@
 	assignment = JOB_SQUAD_RTO
 	rank = JOB_SQUAD_RTO
 	paygrade = "ME4"
+	highpop_paygrade = "ME5"
 	role_comm_title = "RTO"
 	skills = /datum/skills/rto
-
 	minimap_icon = "rto"
 
 /datum/equipment_preset/uscm/rto/load_gear(mob/living/carbon/human/H)
@@ -390,6 +418,7 @@
 	assignment = JOB_SQUAD_ENGI
 	rank = JOB_SQUAD_ENGI
 	paygrade = "ME3"
+	playtime_rank = "ME4"
 	role_comm_title = "ComTech"
 	skills = /datum/skills/combat_engineer
 
@@ -422,6 +451,7 @@
 	assignment = JOB_SQUAD_LEADER
 	rank = JOB_SQUAD_LEADER
 	paygrade = "ME5"
+	highpop_paygrade = "ME6"
 	role_comm_title = "SL"
 	minimum_age = 27
 	skills = /datum/skills/SL

--- a/code/modules/gear_presets/uscm.dm
+++ b/code/modules/gear_presets/uscm.dm
@@ -23,7 +23,8 @@
 	dress_shoes = list(/obj/item/clothing/shoes/dress)
 	var/auto_squad_name
 	var/highpop_paygrade
-	var/playtime_rank	//Only used for Highpop
+	//Only used for Highpop
+	var/playtime_rank
 
 /datum/equipment_preset/uscm/load_status(mob/living/carbon/human/H)
 	H.nutrition = rand(NUTRITION_VERYLOW, NUTRITION_LOW)
@@ -55,7 +56,6 @@
 			equipped_headset.add_hud_tracker(H)
 
 /datum/equipment_preset/uscm/load_rank(mob/living/carbon/human/H)
-	..()
 	//Is it highpop, and does it have either a highpop or playtime rank?
 	if(GLOB.ishighpop && (highpop_paygrade || playtime_rank))
 		if(!playtime_rank)
@@ -64,6 +64,7 @@
 		//All the gold+ LCPLs get to be CPLs on highpop.
 		if(get_job_playtime(H.client, rank) < JOB_PLAYTIME_TIER_3)
 			return playtime_rank
+	return paygrade
 
 
 //*****************************************************************************************************/

--- a/code/modules/gear_presets/uscm.dm
+++ b/code/modules/gear_presets/uscm.dm
@@ -22,8 +22,9 @@
 	dress_gloves = list(/obj/item/clothing/gloves/marine/dress)
 	dress_shoes = list(/obj/item/clothing/shoes/dress)
 	var/auto_squad_name
+	///What paygrade this role gets on highpop
 	var/highpop_paygrade
-	///Only used for Highpop
+	///Only used for Highpop, what paygrade gold medal roles gets
 	var/playtime_rank
 
 /datum/equipment_preset/uscm/load_status(mob/living/carbon/human/H)

--- a/code/modules/gear_presets/uscm.dm
+++ b/code/modules/gear_presets/uscm.dm
@@ -63,7 +63,7 @@
 			return highpop_paygrade
 
 		//Specs & SGs get their playtime rank on highpop
-		if(get_job_playtime(Player.client, rank) < JOB_PLAYTIME_TIER_1)
+		if(get_job_playtime(Player.client, rank) >= JOB_PLAYTIME_TIER_1)
 			return playtime_rank
 	return paygrade
 
@@ -92,9 +92,6 @@
 	if(H.client)
 		if(get_job_playtime(H.client, rank) < JOB_PLAYTIME_TIER_1)
 			return "ME1"
-		//Only for highpop, I think that this is for plat?
-		if(GLOB.ishighpop && get_job_playtime(H.client, rank) < JOB_PLAYTIME_TIER_4)
-			return "ME3"
 	return paygrade
 
 /datum/equipment_preset/uscm/pfc/cryo

--- a/code/modules/gear_presets/uscm.dm
+++ b/code/modules/gear_presets/uscm.dm
@@ -62,8 +62,8 @@
 		if(!playtime_rank)
 			return highpop_paygrade
 
-		//All the gold+ LCPLs get to be CPLs on highpop.
-		if(get_job_playtime(Player.client, rank) < JOB_PLAYTIME_TIER_3)
+		//Specs & SGs get their playtime rank on highpop
+		if(get_job_playtime(Player.client, rank) < JOB_PLAYTIME_TIER_1)
 			return playtime_rank
 	return paygrade
 
@@ -347,7 +347,6 @@
 	assignment = JOB_SQUAD_MEDIC
 	rank = JOB_SQUAD_MEDIC
 	paygrade = "ME3"
-	playtime_rank = "ME4"
 	role_comm_title = "HM"
 	skills = /datum/skills/combat_medic
 
@@ -410,7 +409,6 @@
 	assignment = JOB_SQUAD_ENGI
 	rank = JOB_SQUAD_ENGI
 	paygrade = "ME3"
-	playtime_rank = "ME4"
 	role_comm_title = "ComTech"
 	skills = /datum/skills/combat_engineer
 

--- a/code/modules/gear_presets/uscm.dm
+++ b/code/modules/gear_presets/uscm.dm
@@ -28,7 +28,8 @@ GLOBAL_VAR_INIT(checkedhighpop, FALSE)
 	dress_shoes = list(/obj/item/clothing/shoes/dress)
 	var/auto_squad_name
 	var/highpop_paygrade
-	var/playtime_rank	//Only used for Highpop
+	/// Only used for Highpop
+	var/playtime_rank	
 	var/highpop
 
 /datum/equipment_preset/uscm/load_status(mob/living/carbon/human/H)

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -164,6 +164,9 @@ USEALIENWHITELIST
 ##Remove the # to let ghosts spin chairs
 #GHOST_INTERACTION
 
+##Sets the amount of players required for highpop ranks to kick in
+HIGHPOP_MIN 120
+
 ## Path to the python2 executable on the system.  Leave blank for default.
 ## Default is "python" on Windows, "/usr/bin/env python2" on UNIX.
 #PYTHON_PATH


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request
This increases the ranks of the following roles at highpop (120 Players):
SL - Always set to SSGT
RTO - Always set to SGT
Engi, Medic, Spec, SG - Set to LCPL, If they have a gold medal they're a CPL. 
They're specialists, after all!

Marines - if they have 175 hours and there's more than 120 players, they have access to LCPL, as high as low-playtime ""trained"" role

Todo: Check playercount at roundstart, rather than when ranks are chosen, so that ranks don't increase as time goes on. I was going to put this in an initialization subsystem, but I couldn't find any good one. Please direct me to where I can put the check code.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Kinda strange how one Sergeant is in charge is in charge of 15-20 people, in the army it's usually 4-12.
This remedies that.

Ive seen squads as large as 30+ and still manned by a Sergeant.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->


# Testing Photographs and Procedure
For obvious reasons (I do not have 120 players to get on my test server) I cannot test this, but will try to bruteforce some tests on a local, If I am specifically asked to.


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
add: Marine paygrades increase for playercounts above 120.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
