### PR TITLE
Disables sniper rifles' ability to scope in HvH

### DIFF
--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -307,7 +307,6 @@
 	var/obj/item/attachable/scope/variable_zoom/S = new(src)
 	S.hidden = TRUE
 	S.flags_attach_features &= ~ATTACH_REMOVABLE
-	S.ignore_clash_fog = TRUE
 	S.Attach(src)
 	update_attachable(S.slot)
 

--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -355,7 +355,6 @@
 	S.icon_state = "pmcscope"
 	S.attach_icon = "pmcscope"
 	S.flags_attach_features &= ~ATTACH_REMOVABLE
-	S.ignore_clash_fog = TRUE
 	S.Attach(src)
 	update_attachable(S.slot)
 
@@ -418,7 +417,6 @@
 	S.icon_state = "pmcscope"
 	S.attach_icon = "pmcscope"
 	S.flags_attach_features &= ~ATTACH_REMOVABLE
-	S.ignore_clash_fog = TRUE
 	S.Attach(src)
 	update_attachable(S.slot)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Disables the ability of M42A(uscm sniper), XM43E1(uscm admin-spawn AMR), and M42C(PMC AMR) to scope in HvH.

# Explain why it's good for the game

Offscreen combat in HvH is innately unfun, however before the scope disabling on other weapons, you could attempt to fight back against a sniper via a scoped DMR or rifle, however, since other weapons have had their ability to scope in HvH disabled, this means a sniper has free reign with essentially insta-kill weapons from range, and can't be taken out outside of a lucky flank, or something like a UPP Commando(which aren't balanced for regular HvH because of HEAP).
This definitely reduces the fun-level of HvH, as being offscreen sniped as OPFOR without a way to fight back is quite unfun, and therefore generally reduces the pop-level of OPFOR as no one wants to get instakilled from an offscreen sniper.

This solves this issue by disabling the scopes of the sniper rifles, solving the above issue.
Snipers will still be good, as they have a high damage still in CQC, cloak, and other such things, meaning while reduced in power(thankfully), they will still be a threat and not a wasted spec choice in HvH.


# Testing Photographs and Procedure

It compiled.


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
balance: M42A, M42C, and XM43E1 can no longer scope in faction clash.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
