### PR TITLE
Torn Scarfs no longer cover your face details.

### DIFF
--- a/code/modules/client/preferences_gear.dm
+++ b/code/modules/client/preferences_gear.dm
@@ -306,37 +306,37 @@ var/global/list/gear_datums = list()
 //
 /datum/gear/tornscarfclassic
 	display_name = "Scarf (Grey)"
-	path = /obj/item/clothing/mask/rebreather/tornscarf
+	path = /obj/item/clothing/mask/tornscarf
 	slot = WEAR_FACE
 	cost = 2
 
 /datum/gear/tornscarfgreen
 	display_name = "Scarf (Green)"
-	path = /obj/item/clothing/mask/rebreather/tornscarf/green
+	path = /obj/item/clothing/mask/tornscarf/green
 	slot = WEAR_FACE
 	cost = 2
 
 /datum/gear/tornscarfwhite
 	display_name = "Scarf (White)"
-	path = /obj/item/clothing/mask/rebreather/tornscarf/snow
+	path = /obj/item/clothing/mask/tornscarf/snow
 	slot = WEAR_FACE
 	cost = 2
 
 /datum/gear/tornscarfdesert
 	display_name = "Scarf (Desert)"
-	path = /obj/item/clothing/mask/rebreather/tornscarf/desert
+	path = /obj/item/clothing/mask/tornscarf/desert
 	slot = WEAR_FACE
 	cost = 2
 
 /datum/gear/tornscarfurban
 	display_name = "Scarf (Urban)"
-	path = /obj/item/clothing/mask/rebreather/tornscarf/urban
+	path = /obj/item/clothing/mask/tornscarf/urban
 	slot = WEAR_FACE
 	cost = 2
 
 /datum/gear/tornscarfblack
 	display_name = "Scarf (Black)"
-	path = /obj/item/clothing/mask/rebreather/tornscarf/black
+	path = /obj/item/clothing/mask/tornscarf/black
 	slot = WEAR_FACE
 	cost = 2
 //

--- a/code/modules/clothing/masks/breath.dm
+++ b/code/modules/clothing/masks/breath.dm
@@ -200,7 +200,6 @@
 	icon_state = "torn_scarf_classic"
 	item_state = "torn_scarf_classic"
 	flags_inventory = COVERMOUTH|ALLOWREBREATH|ALLOWCPR
-	flags_inv_hide = HIDEFACE|HIDELOWHAIR
 	flags_cold_protection = BODY_FLAG_HEAD
 	min_cold_protection_temperature = ICE_PLANET_MIN_COLD_PROT
 

--- a/code/modules/clothing/masks/breath.dm
+++ b/code/modules/clothing/masks/breath.dm
@@ -194,31 +194,31 @@
 	item_state = replacetext("[initial(item_state)][pulled ? "_down" : ""]", "%SQUAD%", squad_color)
 
 
-/obj/item/clothing/mask/rebreather/tornscarf
+/obj/item/clothing/mask/tornscarf
 	name = "tactical scarf"
 	desc = "A tactical scarf used to keep warm in the cold."
 	icon_state = "torn_scarf_classic"
 	item_state = "torn_scarf_classic"
-	flags_inventory = COVERMOUTH|ALLOWREBREATH|ALLOWCPR
+	flags_inventory = ALLOWCPR
 	flags_cold_protection = BODY_FLAG_HEAD
 	min_cold_protection_temperature = ICE_PLANET_MIN_COLD_PROT
 
-/obj/item/clothing/mask/rebreather/tornscarf/green
+/obj/item/clothing/mask/tornscarf/green
 	icon_state = "torn_scarf_green"
 	item_state = "torn_scarf_green"
 
-/obj/item/clothing/mask/rebreather/tornscarf/snow
+/obj/item/clothing/mask/tornscarf/snow
 	icon_state = "torn_scarf_snow"
 	item_state = "torn_scarf_snow"
 
-/obj/item/clothing/mask/rebreather/tornscarf/desert
+/obj/item/clothing/mask/tornscarf/desert
 	icon_state = "torn_scarf_desert"
 	item_state = "torn_scarf_desert"
 
-/obj/item/clothing/mask/rebreather/tornscarf/urban
+/obj/item/clothing/mask/tornscarf/urban
 	icon_state = "torn_scarf_urban"
 	item_state = "torn_scarf_urban"
 
-/obj/item/clothing/mask/rebreather/tornscarf/black
+/obj/item/clothing/mask/tornscarf/black
 	icon_state = "torn_scarf_black"
 	item_state = "torn_scarf_black"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Changes the path of the torn scarf from mask/rebreather/tornscarf to mask/tornscarf. This fixes a bug where that the scarf that clearly did not cover face conceals your facial hair and identity.

# Explain why it's good for the game

Fixes a bug that annoyed me


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: Torn scarves no longer cover your facial hair or identity
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
