### PR TITLE
Xenos can now slash and fully destroy vehicle chairs

### DIFF
--- a/code/modules/vehicles/interior/interactable/seats.dm
+++ b/code/modules/vehicles/interior/interactable/seats.dm
@@ -409,7 +409,7 @@
 		if(!broken)
 			break_seat()
 		else
-			qdel(src)
+			deconstruct()
 
 
 /obj/structure/bed/chair/vehicle/attackby(obj/item/W, mob/living/user)

--- a/code/modules/vehicles/interior/interactable/seats.dm
+++ b/code/modules/vehicles/interior/interactable/seats.dm
@@ -402,11 +402,15 @@
 //attack handling
 
 /obj/structure/bed/chair/vehicle/attack_alien(mob/living/user)
-	if(!broken && !unslashable)
+	if(!unslashable)
 		user.visible_message(SPAN_WARNING("[user] smashes \the [src]!"),
 		SPAN_WARNING("You smash \the [src]!"))
 		playsound(loc, pick('sound/effects/metalhit.ogg', 'sound/weapons/alien_claw_metal1.ogg', 'sound/weapons/alien_claw_metal2.ogg', 'sound/weapons/alien_claw_metal3.ogg'), 25, 1)
-		break_seat()
+		if(!broken)
+			break_seat()
+		else
+			qdel(src)
+
 
 /obj/structure/bed/chair/vehicle/attackby(obj/item/W, mob/living/user)
 	if((iswelder(W) && broken))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Xenos can now slash and fully destroy vehicle chairs.

# Explain why it's good for the game

The new dropships make it incredibly difficult for xenos to build a decent hive.

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
iunno sorta
</details>


# Changelog

:cl: Morrow
add: Xenos can now slash and fully destroy vehicle chairs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
