### PR TITLE
Hivemind available first 5 minutes of round

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/say.dm
+++ b/code/modules/mob/living/carbon/xenomorph/say.dm
@@ -104,7 +104,7 @@
 	if(!message || stat || !hive)
 		return
 
-	if(!hive.living_xeno_queen && !SSticker?.mode?.hardcore && !hive.allow_no_queen_actions && world.time > SSticker.round_start_time + SSticker.mode.round_time_evolution_ovipositor)
+	if(!hive.living_xeno_queen && !SSticker?.mode?.hardcore && !hive.allow_no_queen_actions && ROUND_TIME > SSticker.mode.round_time_evolution_ovipositor)
 		to_chat(src, SPAN_WARNING("There is no Queen. You are alone."))
 		return
 

--- a/code/modules/mob/living/carbon/xenomorph/say.dm
+++ b/code/modules/mob/living/carbon/xenomorph/say.dm
@@ -104,7 +104,7 @@
 	if(!message || stat || !hive)
 		return
 
-	if(!hive.living_xeno_queen && !SSticker?.mode?.hardcore && !hive.allow_no_queen_actions)
+	if(!hive.living_xeno_queen && !SSticker?.mode?.hardcore && !hive.allow_no_queen_actions && world.time > SSticker.round_start_time + SSticker.mode.round_time_evolution_ovipositor)
 		to_chat(src, SPAN_WARNING("There is no Queen. You are alone."))
 		return
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Makes Hivemind available for the first 5 minutes of round even without a queen.

# Explain why it's good for the game

When a queen doesn't spawn at roundstart it is not enjoyable not being able to coordinate with fellow larva on who is taking over. This should have zero impact on overall balance.

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>
yuh

</details>


# Changelog

:cl: Morrow
qol: Made Hivemind available for the first 5 minutes of round even without a queen.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
