### PR TITLE
Negative Traits are free

### DIFF
--- a/code/modules/character_traits/biology_traits.dm
+++ b/code/modules/character_traits/biology_traits.dm
@@ -9,7 +9,7 @@
 	trait_name = "Bad Eyesight"
 	trait_desc = "A condition in which close objects appear clearly, but far ones don't."
 	applyable = TRUE
-	cost = 1
+	cost = 0
 
 /datum/character_trait/biology/bad_eyesight/apply_trait(mob/living/carbon/human/target)
 	..()
@@ -23,7 +23,7 @@
 	trait_name = "Opiate Receptor Deficiency"
 	trait_desc = "Due to overuse of opiates or a genetic fluke, this condition reduces the potency of all basic painkilling drugs."
 	applyable = TRUE
-	cost = 1
+	cost = 0
 
 /datum/character_trait/biology/opiate_receptor_deficiency/apply_trait(mob/living/carbon/human/target)
 	..()
@@ -37,7 +37,7 @@
 	trait_name = "Lisping"
 	trait_desc = "You have difficulty with pronouncing 'S' sounds (and similar). Expect to be mocked mercilessly."
 	applyable = TRUE
-	cost = 1
+	cost = 0
 	/// Roles that will not allow the trait to be added
 	var/list/inapplicable_roles = list(JOB_COMMAND_ROLES_LIST)
 	/// Species that will not allow the trait to be added.
@@ -70,7 +70,7 @@
 	trait_name = "Bad Leg"
 	trait_desc = "Your left (or right, if the left's robotic) leg suffered an undetermined wound a long time ago that never fully healed. Walking around without a cane will eventually cause you to freeze in pain, but you start with one."
 	applyable = TRUE
-	cost = 1
+	cost = 0
 	/// Roles that will not allow the trait to be added. (Due to being designed for combat, heavy physical duty, or just being too junior to be worth keeping around as a cripple.)
 	var/list/inapplicable_roles
 	/// Roles that get the shitty wooden pole.


### PR DESCRIPTION
# About the pull request

Changes the cost of negative biology traits to 0.

# Explain why it's good for the game

Soul. If you're a masochist you can load yourself up on all the bad traits. When more bad traits get added you can make life hell for yourself. Could be fun.
I know it's a strawman but I'm gonna say it again. Having bad eyesight doesn't stop you from learning a new language. I mean maybe if you're blind it might stop you from learning how to read and write it but it wont stop you from speaking it.

# Testing Photographs and Procedure

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
balance: go ham on negative traits. They don't give you more points, they just don't take a point now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
