### PR TITLE
Randomizes the order of map, shipmap, and gamemode votes

### DIFF
--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -234,6 +234,8 @@ SUBSYSTEM_DEF(vote)
 /datum/controller/subsystem/vote/proc/initiate_vote(vote_type, initiator_key, datum/callback/on_end, send_clients_vote = FALSE)
 	var/vote_sound = 'sound/ambience/alarm4.ogg'
 	var/vote_sound_vol = 5
+	var/randomize_entries = FALSE
+
 	if(!mode)
 		var/admin = FALSE
 		var/ckey = ckey(initiator_key)
@@ -269,6 +271,7 @@ SUBSYSTEM_DEF(vote)
 				choices.Add("Restart Round", "Continue Playing")
 			if("gamemode")
 				question = "Gamemode vote"
+				randomize_entries = TRUE
 				for(var/mode_type in config.gamemode_cache)
 					var/datum/game_mode/M = initial(mode_type)
 					if(initial(M.config_tag))
@@ -279,6 +282,7 @@ SUBSYSTEM_DEF(vote)
 				question = "Ground map vote"
 				vote_sound = 'sound/voice/start_your_voting.ogg'
 				vote_sound_vol = 15
+				randomize_entries = TRUE
 				var/list/maps = list()
 				for(var/i in config.maplist[GROUND_MAP])
 					var/datum/map_config/VM = config.maplist[GROUND_MAP][i]
@@ -307,6 +311,7 @@ SUBSYSTEM_DEF(vote)
 					vote_adjustment_callback = CALLBACK(src, PROC_REF(map_vote_adjustment))
 			if("shipmap")
 				question = "Ship map vote"
+				randomize_entries = TRUE
 				var/list/maps = list()
 				for(var/i in config.maplist[SHIP_MAP])
 					var/datum/map_config/VM = config.maplist[SHIP_MAP][i]
@@ -331,8 +336,15 @@ SUBSYSTEM_DEF(vote)
 					if(!option || mode || !usr.client)
 						break
 					choices.Add(option)
+
+				if(tgui_input_list(usr, "Do you want to randomize the vote option order?", "Randomize", list("Yes", "No")) == "Yes")
+					randomize_entries = TRUE
+
 			else
 				return FALSE
+
+		if(randomize_entries)
+			choices = shuffle(choices)
 
 		for(var/i in choices)
 			choices[i] = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request
Randomizes the order of vote options for map, shipmap, and gamemode votes, while also adding the option for admin-created votes.


# Explain why it's good for the game
![image](https://user-images.githubusercontent.com/41448081/225451988-aef6f483-72e2-480e-826e-b71a36ec7eb2.png)

I have a funny suspicion that this might at least *partially* be because both of these maps are at the top of the map voting list, lending themselves to "open, click top option, close". Even if that's not true, this is nice to have.

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

![image](https://user-images.githubusercontent.com/41448081/225452356-2cbb9f80-a298-4bc7-b9ee-26b9c43f82d9.png)

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
add: Map, shipmap, and gamemode votes have their entries in a random order.
admin: Admin-created votes can now, optionally, have their entries in a random order.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
