### PR TITLE
Increases the chat's maximum font size

### DIFF
--- a/tgui/packages/tgui-panel/settings/SettingsPanel.js
+++ b/tgui/packages/tgui-panel/settings/SettingsPanel.js
@@ -119,7 +119,7 @@ export const SettingsGeneral = (props, context) => {
             step={1}
             stepPixelSize={10}
             minValue={8}
-            maxValue={32}
+            maxValue={48}
             value={fontSize}
             unit="px"
             format={(value) => toFixed(value)}


### PR DESCRIPTION
# About the pull request
This pull request increases the maximum font size from 32 px to 48 px. The maximum px size has been tested and it still has some room to edit it back in case of an accidental input.

# Explain why it's good for the game

More customization is always good. The option for a larger font size should make it easier to read for people that could use it.

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl: memesky
qol: Increased the maximum font size of the chat from 32px to 48px.
/:cl:


