### PR TITLE
Possible fix to evacuated personnel not ending the round

### DIFF
--- a/code/game/gamemodes/cm_self_destruct.dm
+++ b/code/game/gamemodes/cm_self_destruct.dm
@@ -82,7 +82,7 @@ var/global/datum/authority/branch/evacuation/EvacuationAuthority //This is initi
  */
 /datum/authority/branch/evacuation/proc/get_affected_zlevels()
 	//Nuke is not in progress, end the round on ship only.
-	if(dest_status < NUKE_EXPLOSION_IN_PROGRESS && SSticker.mode && SSticker.mode.is_in_endgame)
+	if(dest_status < NUKE_EXPLOSION_IN_PROGRESS && SSticker?.mode.is_in_endgame)
 		. = SSmapping.levels_by_any_trait(list(ZTRAIT_MARINE_MAIN_SHIP))
 		return
 

--- a/code/game/gamemodes/cm_self_destruct.dm
+++ b/code/game/gamemodes/cm_self_destruct.dm
@@ -81,13 +81,9 @@ var/global/datum/authority/branch/evacuation/EvacuationAuthority //This is initi
  * when an evac/self-destruct happens.
  */
 /datum/authority/branch/evacuation/proc/get_affected_zlevels()
-	//Nuke is not in progress and evacuation finished, end the round on ship and low orbit (dropships in transit) only.
-	if(dest_status < NUKE_EXPLOSION_IN_PROGRESS && evac_status == EVACUATION_STATUS_COMPLETE)
+	//Nuke is not in progress and evacuation finished, end the round on ship only.
+	if(dest_status < NUKE_EXPLOSION_IN_PROGRESS && evac_status == EVACUATION_STATUS_COMPLETE || SSticker.mode && SSticker.mode.is_in_endgame)
 		. = SSmapping.levels_by_any_trait(list(ZTRAIT_MARINE_MAIN_SHIP))
-		return
-
-	if(SSticker.mode && SSticker.mode.is_in_endgame)
-		. = SSmapping.levels_by_any_trait(list(ZTRAIT_MARINE_MAIN_SHIP, ZTRAIT_RESERVED))
 		return
 
 //=========================================================================================

--- a/code/game/gamemodes/cm_self_destruct.dm
+++ b/code/game/gamemodes/cm_self_destruct.dm
@@ -81,8 +81,8 @@ var/global/datum/authority/branch/evacuation/EvacuationAuthority //This is initi
  * when an evac/self-destruct happens.
  */
 /datum/authority/branch/evacuation/proc/get_affected_zlevels()
-	//Nuke is not in progress and evacuation finished, end the round on ship only.
-	if(dest_status < NUKE_EXPLOSION_IN_PROGRESS && evac_status == EVACUATION_STATUS_COMPLETE || SSticker.mode && SSticker.mode.is_in_endgame)
+	//Nuke is not in progress and evacuation finished, end the round on ship and low orbit (dropships in transit) only.
+	if(dest_status < NUKE_EXPLOSION_IN_PROGRESS && SSticker.mode && SSticker.mode.is_in_endgame)
 		. = SSmapping.levels_by_any_trait(list(ZTRAIT_MARINE_MAIN_SHIP))
 		return
 

--- a/code/game/gamemodes/cm_self_destruct.dm
+++ b/code/game/gamemodes/cm_self_destruct.dm
@@ -81,7 +81,7 @@ var/global/datum/authority/branch/evacuation/EvacuationAuthority //This is initi
  * when an evac/self-destruct happens.
  */
 /datum/authority/branch/evacuation/proc/get_affected_zlevels()
-	//Nuke is not in progress and evacuation finished, end the round on ship and low orbit (dropships in transit) only.
+	//Nuke is not in progress, end the round on ship only.
 	if(dest_status < NUKE_EXPLOSION_IN_PROGRESS && SSticker.mode && SSticker.mode.is_in_endgame)
 		. = SSmapping.levels_by_any_trait(list(ZTRAIT_MARINE_MAIN_SHIP))
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Possible fix to evacuated personnel not ending the round.

# Explain why it's good for the game

Rounds not ending properly is bad.


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>
I did not test this PR but I'm gonna TM it and see if it explodes.

</details>


# Changelog

:cl: Morrow
fix: Fix to evacuated personnel not ending the round
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
