### PR TITLE
Reverted changed M4RA Custom melee damage

### DIFF
--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -547,7 +547,7 @@
 	reload_sound = 'sound/weapons/handling/l42_reload.ogg'
 	unload_sound = 'sound/weapons/handling/l42_unload.ogg'
 	current_mag = /obj/item/ammo_magazine/rifle/m4ra/custom
-	force = 16
+	force = 26
 	attachable_allowed = list(
 		/obj/item/attachable/suppressor,
 		/obj/item/attachable/bayonet,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

With #2674 the melee damage of the M4RA Custom was nerfed unintentionally (confirmed by talking to the contributor).
This PR reverts that.
The original damage with a bayonet attached was 36, it went down to 26, now it will be back to 36 again.
Video showcasing the practical difference will be available below.

# Explain why it's good for the game

Melee damage is very important for Scouts for both flanking through resin fortified areas and as an emergency weapon when they get jumped, plus this nerf want unintended to begin with.


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

First section is the current damage, second section is the pre-rework damage and the third one is this PR's.
https://user-images.githubusercontent.com/15560820/225961415-01393c83-807f-4a14-9c76-21d3f21fe05a.mp4

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl: Jackie_Estegado
balance: Reverted the unintentionally nerfed melee damage of the M4RA Custom Battle Rifle.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
