### PR TITLE
[fix] Prevent keybinds from registering a null signal

### DIFF
--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -96,7 +96,8 @@
 		remove_from(owner)
 	SEND_SIGNAL(src, COMSIG_ACTION_GIVEN, L)
 	L.handle_add_action(src)
-	RegisterSignal(L, listen_signal, PROC_REF(keybind_activation))
+	if(listen_signal)
+		RegisterSignal(L, listen_signal, PROC_REF(keybind_activation))
 	owner = L
 
 /mob/proc/handle_add_action(datum/action/action)


### PR DESCRIPTION
if there is no signal to listen to, it should not try to register a signal against nothing. it just makes annoying errors

:cl:
fix: fixed a very spammy runtime error
/:cl: