### PR TITLE
Randomizes Local Operation Time

### DIFF
--- a/code/__HELPERS/_time.dm
+++ b/code/__HELPERS/_time.dm
@@ -33,7 +33,7 @@ var/rollovercheck_last_timeofday = 0
 	rollovercheck_last_timeofday = world.timeofday
 	return midnight_rollovers
 
-///Returns the world time in english. Do not use to get date information - starts at 0 + a random time offset from 10 minutes to 4 hours.
+///Returns the world time in english. Do not use to get date information - starts at 0 + a random time offset from 10 minutes to 23 hours.
 /proc/worldtime2text(format = "hh:mm", time = world.time)
 	return gameTimestamp(format, time + GLOB.time_offset)
 

--- a/code/__HELPERS/_time.dm
+++ b/code/__HELPERS/_time.dm
@@ -33,9 +33,9 @@ var/rollovercheck_last_timeofday = 0
 	rollovercheck_last_timeofday = world.timeofday
 	return midnight_rollovers
 
-///Returns the world time in english. Do not use to get date information - starts at 0 + 12 hours.
+///Returns the world time in english. Do not use to get date information - starts at 0 + a random time offset from 10 minutes to 4 hours.
 /proc/worldtime2text(format = "hh:mm", time = world.time)
-	return gameTimestamp(format, time + 12 HOURS)
+	return gameTimestamp(format, time + GLOB.time_offset)
 
 /proc/gameTimestamp(format = "hh:mm:ss", wtime=null)
 	if(!wtime)

--- a/code/__HELPERS/_time.dm
+++ b/code/__HELPERS/_time.dm
@@ -33,7 +33,7 @@ var/rollovercheck_last_timeofday = 0
 	rollovercheck_last_timeofday = world.timeofday
 	return midnight_rollovers
 
-///Returns the world time in english. Do not use to get date information - starts at 0 + a random time offset from 10 minutes to 23 hours.
+///Returns the world time in english. Do not use to get date information - starts at 0 + a random time offset from 10 minutes to 24 hours.
 /proc/worldtime2text(format = "hh:mm", time = world.time)
 	return gameTimestamp(format, time + GLOB.time_offset)
 

--- a/code/_globalvars/misc.dm
+++ b/code/_globalvars/misc.dm
@@ -25,4 +25,4 @@ GLOBAL_DATUM_INIT(item_to_box_mapping, /datum/item_to_box_mapping, init_item_to_
 GLOBAL_VAR_INIT(time_offset, setup_offset())
 
 /proc/setup_offset()
-	return rand(10 MINUTES, 4 HOURS)
+	return rand(10 MINUTES, 23 HOURS)

--- a/code/_globalvars/misc.dm
+++ b/code/_globalvars/misc.dm
@@ -20,3 +20,8 @@ GLOBAL_LIST_INIT(gamemode_roles, list())
 GLOBAL_VAR_INIT(minimum_exterior_lighting_alpha, 255)
 
 GLOBAL_DATUM_INIT(item_to_box_mapping, /datum/item_to_box_mapping, init_item_to_box_mapping())
+
+GLOBAL_VAR_INIT(time_offset, setup_offset())
+
+/proc/setup_offset()
+	return rand(10 MINUTES, 4 HOURS)

--- a/code/_globalvars/misc.dm
+++ b/code/_globalvars/misc.dm
@@ -24,5 +24,6 @@ GLOBAL_DATUM_INIT(item_to_box_mapping, /datum/item_to_box_mapping, init_item_to_
 /// Offset for the Operation time
 GLOBAL_VAR_INIT(time_offset, setup_offset())
 
+/// Sets the offset 2 lines above.
 /proc/setup_offset()
-	return rand(10 MINUTES, 23 HOURS)
+	return rand(10 MINUTES, 24 HOURS)

--- a/code/_globalvars/misc.dm
+++ b/code/_globalvars/misc.dm
@@ -21,6 +21,7 @@ GLOBAL_VAR_INIT(minimum_exterior_lighting_alpha, 255)
 
 GLOBAL_DATUM_INIT(item_to_box_mapping, /datum/item_to_box_mapping, init_item_to_box_mapping())
 
+/// Offset for the Operation time
 GLOBAL_VAR_INIT(time_offset, setup_offset())
 
 /proc/setup_offset()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

This PR randomizes the local operation time.

# Explain why it's good for the game

I thought it was silly the rounds always start at say, noon or marines would always drop at the same times on different planets without accounting for local time, every planet was always the same time! However with this PR that changes, now you can have an operation briefing at 03:42, or maybe 02:28. It adds some minor immersion for me personally.


# Testing Photographs and Procedure

Functions properly when compared to the master branch (both start at 23:00 for round time? Not sure why but doesn't seem to be an issue.)

</details>


# Changelog

:cl:LynxSolstice, Harryob
code: Changed the worldtime2text offset to be between 10 minutes and 4 hours.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
