### PR TITLE
Removes survsynth marine IFF

### DIFF
--- a/code/modules/gear_presets/forcon_survivors.dm
+++ b/code/modules/gear_presets/forcon_survivors.dm
@@ -249,6 +249,7 @@
 /datum/equipment_preset/synth/survivor/forecon
 	name = "Survivor - USCM Synthetic"
 	assignment = "Reconnaissance Synthetic"
+	faction_group = list(FACTION_MARINE, FACTION_SURVIVOR)
 	idtype = /obj/item/card/id/gold
 
 /datum/equipment_preset/synth/survivor/forecon/load_gear(mob/living/carbon/human/preset_human) //Bishop from Aliens

--- a/code/modules/gear_presets/synths.dm
+++ b/code/modules/gear_presets/synths.dm
@@ -106,7 +106,7 @@
 	name = "Survivor - Synthetic - Classic Joe"
 	flags = EQUIPMENT_PRESET_EXTRA
 	faction = FACTION_SURVIVOR
-	faction_group = list(FACTION_MARINE, FACTION_SURVIVOR)
+	faction_group = list(FACTION_SURVIVOR)
 	idtype = /obj/item/card/id/lanyard
 	assignment = JOB_SYNTH
 	rank = JOB_SYNTH_SURVIVOR


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Unintentionally forgot about survsynth IFF removal in #2521.

FORECON synth still has IFF.

# Explain why it's good for the game

IFF consistency for survivors is good and given announcement changes to allow those with USCM faction in faction_group this is allowing survsynths to hear announcements unintentionally.

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>
Completely untested.

</details>


# Changelog

:cl: Morrow
fix: Removes unintentional survsynth USCM IFF.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
