### PR TITLE
Non-standard marine gloves no longer use squad color overlay.

### DIFF
--- a/code/modules/clothing/gloves/marine_gloves.dm
+++ b/code/modules/clothing/gloves/marine_gloves.dm
@@ -158,6 +158,7 @@
 	armor_rad = CLOTHING_ARMOR_HARDCORE
 	armor_internaldamage = CLOTHING_ARMOR_HARDCORE
 	unacidable = TRUE
+	adopts_squad_color = FALSE
 
 /obj/item/clothing/gloves/marine/veteran/insulated/van_bandolier
 	name = "custom shooting gloves"

--- a/code/modules/clothing/gloves/marine_gloves.dm
+++ b/code/modules/clothing/gloves/marine_gloves.dm
@@ -45,6 +45,7 @@
 	desc = "Shiny and impressive. They look expensive."
 	icon_state = "black"
 	item_state = "bgloves"
+	adopts_squad_color = FALSE
 
 /obj/item/clothing/gloves/marine/officer/chief
 	name = "chief officer gloves"
@@ -57,6 +58,7 @@
 	item_state = "ygloves"
 	siemens_coefficient = 0
 	permeability_coefficient = 0.01
+	adopts_squad_color = FALSE
 
 /obj/item/clothing/gloves/marine/techofficer/commander
 	name = "commanding officer's gloves"
@@ -105,6 +107,7 @@
 	armor_bomb = CLOTHING_ARMOR_MEDIUM
 	armor_rad = CLOTHING_ARMOR_MEDIUM
 	armor_internaldamage = CLOTHING_ARMOR_HIGH
+	adopts_squad_color = FALSE
 
 /obj/item/clothing/gloves/marine/veteran/insulated
 	name = "insulated armored gloves"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

All gloves/marine subtypes that are not B18, standard marine glove, and GL spec now do not adapt to squad color. This means armored, PMC, techofficer, CO, officer, whiteout, souto, and van bandolier.
This is a long-standing bug intoduced in 2021.


# Explain why it's good for the game

This bug was added to the game September 19, 2021 in [this](https://gitlab.com/cmdevs/colonial-warfare/-/merge_requests/1954), and it has bugged me ever since(I'm a comedic genius, in case you aren't and don't know what I did: I made a pun with it being a **bug** that **bugged** me).

It does not make sense for gloves not made for marines, to magically change to squad color when put on by a squad role, ruins my immersion as IC-wise its meant to be a literal sewn or dyed in patch of squad color, with the changing color being for mechanical purposes only. I left out B18 and GL spec gloves as those are technically squad role gloves(specialist), so it makes sense for them to retain this.


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: Most non-standard armored gloves no longer take on squad color.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
