### PR TITLE
COs no longer have emote cooldown

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -305,6 +305,8 @@ GLOBAL_LIST(trait_name_map)
 #define TRAIT_SOURCE_QUIRK "t_s_quirk"
 ///Status trait coming from being assigned as [acting] squad leader.
 #define TRAIT_SOURCE_SQUAD_LEADER "t_s_squad_leader"
+///Status trait coming from their job
+#define TRAIT_SOURCE_JOB "t_s_job"
 ///Status trait forced by staff
 #define TRAIT_SOURCE_ADMIN "t_s_admin"
 ///Status trait coming from equipment

--- a/code/modules/gear_presets/uscm_ship.dm
+++ b/code/modules/gear_presets/uscm_ship.dm
@@ -337,6 +337,10 @@
 	. = ..()
 	access = get_all_marine_access()
 
+/datum/equipment_preset/uscm_ship/commander/load_race(mob/living/carbon/human/H, client/mob_client)
+	..()
+	ADD_TRAIT(H, TRAIT_EMOTE_CD_EXEMPT, TRAIT_SOURCE_SPECIES)
+
 /datum/equipment_preset/uscm_ship/commander/load_gear(mob/living/carbon/human/H)
 	var/sidearm = "Mateba"
 	var/kit = null

--- a/code/modules/gear_presets/uscm_ship.dm
+++ b/code/modules/gear_presets/uscm_ship.dm
@@ -339,7 +339,7 @@
 
 /datum/equipment_preset/uscm_ship/commander/load_race(mob/living/carbon/human/H, client/mob_client)
 	..()
-	ADD_TRAIT(H, TRAIT_EMOTE_CD_EXEMPT, TRAIT_SOURCE_SPECIES)
+	ADD_TRAIT(H, TRAIT_EMOTE_CD_EXEMPT, TRAIT_SOURCE_JOB)
 
 /datum/equipment_preset/uscm_ship/commander/load_gear(mob/living/carbon/human/H)
 	var/sidearm = "Mateba"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

COs no longer have emote cooldown. This may be the cursed way to do it I did this in approximately two minutes while being rezzed by a bald medic.

# Explain why it's good for the game

When I'm leading I can't be having EMOTE COOLDOWNS slow down my OOOO-FUCKING-RAH. (I will take this away if people are dumb I swear to god)


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>
Yeah a little bit

</details>


# Changelog

:cl: Morrow
add: COs no longer have emote cooldown
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
