### PR TITLE
Readds the autodoc, in a nerfed state

### DIFF
--- a/code/game/machinery/medical_pod/autodoc.dm
+++ b/code/game/machinery/medical_pod/autodoc.dm
@@ -1,8 +1,8 @@
 //Autodoc
 /obj/structure/machinery/medical_pod/autodoc
-	name = "\improper autodoc medical system"
-	desc = "A fancy machine developed to be capable of operating on people with minimal human intervention. The interface is rather complex and would only be useful to trained Doctors however."
-	icon_state = "autodoc"
+	name = "\improper autodoc emergency medical system"
+	desc = "An emergency surgical device designed to perform life-saving treatments and basic surgeries on patients automatically, without the need of a surgeon. <br>It still requires someone with medical knowledge to program the treatments correctly; for this reason, colonies that use these often have paramedics trained in autodoc operation."
+	icon_state = "autodoc_open"
 
 	entry_timer = 2 SECONDS
 	skilllock = SKILL_SURGERY_NOVICE
@@ -24,8 +24,8 @@
 	idle_power_usage = 15
 	active_power_usage = 450 //Capable of doing various activities
 
-	var/stored_metal = 125 // starts with 125 metal loaded
-	var/max_metal = 500
+var/stored_metal = 125 // starts with 125 metal loaded
+var/max_metal = 500
 
 /obj/structure/machinery/medical_pod/autodoc/update_icon()
 	if(occupant)
@@ -36,10 +36,10 @@
 	else
 		icon_state = "autodoc_open"
 
-/obj/structure/machinery/medical_pod/autodoc/get_examine_text(mob/user)
-	. = ..()
-	if(ishuman(user))
-		. += SPAN_NOTICE("It has [stored_metal] metal available for limb replacements.")
+///obj/structure/machinery/medical_pod/autodoc/get_examine_text(mob/user)
+//	. = ..()
+//	if(ishuman(user))
+//		. += SPAN_NOTICE("It has [stored_metal] metal available for limb replacements.")
 
 /obj/structure/machinery/medical_pod/autodoc/Initialize()
 	. = ..()
@@ -156,14 +156,14 @@
 				if(occupant.blood_volume < BLOOD_VOLUME_NORMAL)
 					if(blood_pack.reagents.get_reagent_amount("blood") < 4)
 						blood_pack.reagents.add_reagent("blood", 195, list("viruses"=null,"blood_type"="O-","resistances"=null))
-						visible_message("[icon2html(src, viewers(src))] \The <b>[src]</b> speaks: Blood reserves depleted, switching to fresh bag.")
+						visible_message("[icon2html(src, viewers(src))] \The <b>[src]</b> speaks: Blood reserves depleted, switching to fresh container.")
 					occupant.inject_blood(blood_pack, 8) // double iv stand rate
 					if(prob(10))
 						visible_message("\The [src] whirrs and gurgles as it transfuses blood.")
 						to_chat(occupant, SPAN_INFO("You feel slightly less faint."))
 				else
 					blood_transfer = 0
-					visible_message("[icon2html(src, viewers(src))] \The <b>[src]</b> speaks: Blood transfer complete.")
+					visible_message("[icon2html(src, viewers(src))] \The <b>[src]</b> speaks: Blood transfusion complete.")
 			if(heal_brute)
 				if(occupant.getBruteLoss() > 0)
 					heal_limb(occupant, 3, 0)
@@ -190,7 +190,7 @@
 						to_chat(occupant, SPAN_INFO("You feel slightly less ill."))
 				else
 					heal_toxin = 0
-					visible_message("[icon2html(src, viewers(src))] \The <b>[src]</b> speaks: Chelation complete.")
+					visible_message("[icon2html(src, viewers(src))] \The <b>[src]</b> speaks: Toxin removal complete.")
 
 
 #define LIMB_SURGERY 1
@@ -585,6 +585,7 @@
 //Auto Doc console that links up to it.
 /obj/structure/machinery/autodoc_console
 	name = "\improper autodoc medical system control console"
+	desc = "The control interface used to operate the adjoining autodoc. Requires training to use properly."
 	icon = 'icons/obj/structures/machinery/cryogenics.dmi'
 	icon_state = "sleeperconsole"
 	var/obj/structure/machinery/medical_pod/autodoc/connected = null
@@ -689,13 +690,13 @@
 									dat += "Burn Damage Treatment"
 								if("toxin")
 									surgeryqueue["toxin"] = 1
-									dat += "Toxin Damage Chelation"
+									dat += "Bloodstream Toxin Removal"
 								if("dialysis")
 									surgeryqueue["dialysis"] = 1
 									dat += "Dialysis"
 								if("blood")
 									surgeryqueue["blood"] = 1
-									dat += "Blood Transfer"
+									dat += "Emergency Blood Transfusion"
 						if(ORGAN_SURGERY)
 							switch(A.surgery_procedure)
 								if("damage")
@@ -711,7 +712,7 @@
 									dat += "Internal Bleeding Surgery"
 								if("broken")
 									surgeryqueue["broken"] = 1
-									dat += "Broken Bone Surgery"
+									dat += "Bone Repair Treatment"
 								if("missing")
 									surgeryqueue["missing"] = 1
 									dat += "Limb Replacement Surgery"
@@ -723,7 +724,7 @@
 									dat += "Facial Reconstruction Surgery"
 								if("open")
 									surgeryqueue["open"] = 1
-									dat += "Close Open Incision"
+									dat += "Close Open Incisions"
 					dat += "<br>"
 
 			dat += "<hr><a href='?src=\ref[src];surgery=1'>Begin Surgery</a> - <a href='?src=\ref[src];refresh=1'>Refresh Menu</a> - <a href='?src=\ref[src];clear=1'>Clear Queue</a><hr>"
@@ -734,38 +735,39 @@
 					dat += "<a href='?src=\ref[src];brute=1'>Brute Damage Treatment</a><br>"
 				if(isnull(surgeryqueue["burn"]))
 					dat += "<a href='?src=\ref[src];burn=1'>Burn Damage Treatment</a><br>"
-				dat += "<b>Orthopedic Surgeries</b>"
-				dat += "<br>"
+				if(isnull(surgeryqueue["open"]))
+					dat += "<a href='?src=\ref[src];open=1'>Close Open Incisions</a><br>"
+				//dat += "<b>Orthopedic Surgeries</b>"
+				//dat += "<br>"
 				if(isnull(surgeryqueue["broken"]))
-					dat += "<a href='?src=\ref[src];broken=1'>Broken Bone Surgery</a><br>"
-				if(isnull(surgeryqueue["internal"]))
-					dat += "<a href='?src=\ref[src];internal=1'>Internal Bleeding Surgery</a><br>"
-				if(isnull(surgeryqueue["shrapnel"]))
-					dat += "<a href='?src=\ref[src];shrapnel=1'>Shrapnel Removal Surgery</a><br>"
-				dat += "<b>Organ Surgeries</b>"
-				dat += "<br>"
-				if(isnull(surgeryqueue["eyes"]))
-					dat += "<a href='?src=\ref[src];eyes=1'>Corrective Eye Surgery</a><br>"
-				if(isnull(surgeryqueue["organdamage"]))
-					dat += "<a href='?src=\ref[src];organdamage=1'>Organ Damage Treatment</a><br>"
+					dat += "<a href='?src=\ref[src];broken=1'>Bone Repair Treatment</a><br>"
+				//if(isnull(surgeryqueue["internal"]))
+				//	dat += "<a href='?src=\ref[src];internal=1'>Internal Bleeding Surgery</a><br>"
+				//if(isnull(surgeryqueue["shrapnel"]))
+				//	dat += "<a href='?src=\ref[src];shrapnel=1'>Shrapnel Removal Surgery</a><br>"
+				//dat += "<b>Organ Surgeries</b>"
+				//dat += "<br>"
+				//if(isnull(surgeryqueue["eyes"]))
+				//	dat += "<a href='?src=\ref[src];eyes=1'>Corrective Eye Surgery</a><br>"
+				//if(isnull(surgeryqueue["organdamage"]))
+				//	dat += "<a href='?src=\ref[src];organdamage=1'>Organ Damage Treatment</a><br>"
 				dat += "<b>Hematology Treatments</b>"
 				dat += "<br>"
 				if(isnull(surgeryqueue["blood"]))
-					dat += "<a href='?src=\ref[src];blood=1'>Blood Transfer</a><br>"
+					dat += "<a href='?src=\ref[src];blood=1'>Emergency Blood Transfusion</a><br>"
 				if(isnull(surgeryqueue["dialysis"]))
 					dat += "<a href='?src=\ref[src];dialysis=1'>Dialysis</a><br>"
 				if(isnull(surgeryqueue["toxin"]))
-					dat += "<a href='?src=\ref[src];toxin=1'>Toxin Damage Chelation</a><br>"
-				dat += "<b>Special Surgeries</b>"
+					dat += "<a href='?src=\ref[src];toxin=1'>Bloodstream Toxin Removal</a><br>"
+				//dat += "<b>Special Surgeries</b>"
+				//dat += "<br>"
+				//if(isnull(surgeryqueue["facial"]))
+				//	dat += "<a href='?src=\ref[src];facial=1'>Facial Reconstruction Surgery</a><br>"
+				//if(isnull(surgeryqueue["missing"]))
+				//	dat += "<a href='?src=\ref[src];missing=1'>Limb Replacement Surgery</a><hr>"
 				dat += "<br>"
-				if(isnull(surgeryqueue["open"]))
-					dat += "<a href='?src=\ref[src];open=1'>Close Open Incision</a><br>"
-				if(isnull(surgeryqueue["facial"]))
-					dat += "<a href='?src=\ref[src];facial=1'>Facial Reconstruction Surgery</a><br>"
-				if(isnull(surgeryqueue["missing"]))
-					dat += "<a href='?src=\ref[src];missing=1'>Limb Replacement Surgery</a><hr>"
 		else
-			dat += "The Auto-Doc is empty."
+			dat += "The autodoc is empty."
 	dat += text("<a href='?src=\ref[];mach_close=sleeper'>Close</a>", user)
 	show_browser(user, dat, "Auto-Doc Medical System", "sleeper", "size=300x400")
 	onclose(user, "sleeper")
@@ -903,5 +905,6 @@
 		add_fingerprint(usr)
 
 /obj/structure/machinery/medical_pod/autodoc/unskilled
-	desc = "This autodoc has been loaded with extra programming so that it can be used without training. Neat!"
+	name = "advanced autodoc emergency medical system"
+	desc = "A much more expensive model of autodoc modified with an A.I. diagnostic unit. The result is a much simpler, point-and-click interface that anyone, regardless of training, can use. Often employed in autodoc systems deployed to military front lines for soldiers to use."
 	skilllock = null

--- a/code/game/machinery/medical_pod/bodyscanner.dm
+++ b/code/game/machinery/medical_pod/bodyscanner.dm
@@ -3,7 +3,7 @@
 
 /obj/structure/machinery/medical_pod/bodyscanner
 	name = "body scanner"
-	icon_state = "body_scanner"
+	icon_state = "body_scanner_open"
 
 
 	use_power = USE_POWER_IDLE

--- a/code/game/machinery/medical_pod/sleeper.dm
+++ b/code/game/machinery/medical_pod/sleeper.dm
@@ -230,7 +230,7 @@
 
 /obj/structure/machinery/medical_pod/sleeper
 	name = "sleeper"
-	icon_state = "sleeper"
+	icon_state = "sleeper_open"
 	desc = "A fancy bed with built-in injectors, a dialysis machine, and a limited health scanner."
 
 	entry_timer = 2 SECONDS

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -40979,6 +40979,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_m_s)
 "izY" = (
+/obj/structure/machinery/autodoc_console,
 /turf/open/floor/almayer{
 	dir = 8;
 	icon_state = "sterile_green_side"
@@ -57172,7 +57173,7 @@
 	},
 /area/almayer/living/grunt_rnr)
 "qxL" = (
-/obj/structure/flora/pottedplant/random,
+/obj/structure/machinery/medical_pod/autodoc,
 /turf/open/floor/almayer{
 	icon_state = "sterile_green"
 	},


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Readds the autodoc back to the Almayer with its capabilities neutered; it can now only do emergency treatments and cannot do advanced surgeries like organ repair or limb replacement.

The autodoc is now only capable of the following surgeries:

- Brute and burn damage treatment
- Toxin damage treatment
- Closing open incisions
- Blood transfusions
- Dialysis

The following procedures have been **removed** from the autodoc and can no longer be used:

- Internal bleeding surgery
- Shrapnel removal
- Corrective eye surgery
- Organ damage treatment
- Facial reconstruction
- Limb replacement

If the bone repair thing is also an issue that, too, can be removed from the code, just let me know.

While we're at it, also fixed the broken icon states for the sleeper, autodoc, and body scanner in the mapping view.

# Explain why it's good for the game

If memory serves me right, the autodoc was initially removed because it basically acted as a doctor in and of itself, and docs would rather shove someone inside it to do their work rather than getting their hands dirty. This helps to change that.

This PR lets the autodoc reprise its role on the Almayer while being restricted to an "emergency" medical system that can be used to take some work off doctors' hands by fixing up a patient and doing, as stated, emergency medical procedures to save their life. It can't do complex surgeries anymore, so doctors will still need to fix patients up for that.

# Screenshots
![image](https://user-images.githubusercontent.com/55491249/226556862-46b53693-8ca0-4f86-ba89-cdc93c2298a6.png)

# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
mapadd: Readds the autodoc back to the Almayer.
balance: Neuters the autodoc so that it can only perform emergency treatments and life-saving procedures; it can no longer do complex surgeries.
fix: Fixed broken icon states on the autodoc, sleeper, and body scanner console when using a map editor.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
