### PR TITLE
prevents corrupted node installs

### DIFF
--- a/tools/bootstrap/node_.ps1
+++ b/tools/bootstrap/node_.ps1
@@ -20,7 +20,8 @@ function Download-Node {
 	Write-Output "Downloading Node v$NodeVersion (may take a while)"
 	New-Item $NodeTargetDir -ItemType Directory -ErrorAction silentlyContinue | Out-Null
 	$WebClient = New-Object Net.WebClient
-	$WebClient.DownloadFile($NodeSource, $NodeTarget)
+	$WebClient.DownloadFile($NodeSource, "$NodeTarget.downloading")
+	Rename-Item "$NodeTarget.downloading" $NodeTarget
 }
 
 ## Convenience variables


### PR DESCRIPTION
if people cancelled out of CBT while it was downloading, it would permanently trash your bootstrapped node install. this is better

no playerfacing changes

see: https://github.com/tgstation/tgstation/pull/73586