### PR TITLE
Fixes a to_chat for the canes

### DIFF
--- a/code/game/objects/items/misc.dm
+++ b/code/game/objects/items/misc.dm
@@ -134,7 +134,7 @@
 					return
 				stored_item = object
 				mobber.drop_inv_item_to_loc(object, src)
-				to_chat(mobber, SPAN_NOTICE("notice'>You slide the [object] into [src]."))
+				to_chat(mobber, SPAN_NOTICE("You slide the [object] into [src]."))
 				playsound(mobber, 'sound/weapons/gun_shotgun_shell_insert.ogg', 15, TRUE)
 				update_icon()
 				break


### PR DESCRIPTION
# About the pull request

" notice'>You slide the katana into the fancy cane. "

# Explain why it's good for the game

fixes a typo

# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
spellcheck: fixed the to_chat for the katana cane
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
