### PR TITLE
Flayed ghosts can no longer have offsets

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -113,6 +113,10 @@
 			name = body.real_name
 	change_real_name(src, name)
 
+	if(pixel_x != 0 || pixel_y != 0) //To prevent weirdly offset ghosts.
+		pixel_x = 0
+		pixel_y = 0
+
 	minimap = new
 	minimap.give_to(src)
 

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -113,9 +113,9 @@
 			name = body.real_name
 	change_real_name(src, name)
 
-	if(pixel_x != 0 || pixel_y != 0) //To prevent weirdly offset ghosts.
-		pixel_x = 0
-		pixel_y = 0
+	//To prevent weirdly offset ghosts.
+	pixel_x = 0
+	pixel_y = 0
 
 	minimap = new
 	minimap.give_to(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request
This makes sure that ghosts (usually ones who have been flayed) cannot become a ghost with offset on. Otherwise you have a pixel_x of about 6 and a pixel_y of about 9 if you're flayed and ghost.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Bugs bad and it looks ugly.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: Ghosts can no longer become offset.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
