### PR TITLE
Metal cades are no longer invisible when when in the same tile as a north/south plasteel cade while facing east/west.

### DIFF
--- a/code/game/objects/structures/barricade/metal.dm
+++ b/code/game/objects/structures/barricade/metal.dm
@@ -19,6 +19,11 @@
 	var/build_state = BARRICADE_BSTATE_SECURED //Look at __game.dm for barricade defines
 	var/upgrade = null
 
+/obj/structure/barricade/metal/update_icon()
+	. = ..()
+	if(dir > 2)
+		layer = OBJ_LAYER //This prevents cades from becoming invisible under a north/south facing plasteel cade.
+
 /obj/structure/barricade/metal/get_examine_text(mob/user)
 	. = ..()
 	switch(build_state)

--- a/code/game/objects/structures/barricade/sandbags.dm
+++ b/code/game/objects/structures/barricade/sandbags.dm
@@ -35,7 +35,7 @@
 
 	icon_state = "sandbag[build_stage]"
 	if(dir > 2)
-		layer = OBJ_LAYER
+		layer = OBJ_LAYER //This prevents cades from becoming invisible under a north/south facing plasteel cade.
 
 /obj/structure/barricade/sandbags/update_damage_state()
 	var/changed = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request
I swear I fixed this. Also added a little codedoc for it.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Bugs bad, consistency good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: Metal cades are no longer invisible when when in the same tile as a north/south plasteel cade while facing east/west.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
