### PR TITLE
Fixes various structures not breaking properly

### DIFF
--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -185,14 +185,14 @@ Class Procs:
 	switch(severity)
 		if(0 to EXPLOSION_THRESHOLD_LOW)
 			if (prob(25))
-				deconstruct()
+				deconstruct(FALSE)
 				return
 		if(EXPLOSION_THRESHOLD_LOW to EXPLOSION_THRESHOLD_MEDIUM)
 			if (prob(50))
-				deconstruct()
+				deconstruct(FALSE)
 				return
 		if(EXPLOSION_THRESHOLD_MEDIUM to INFINITY)
-			deconstruct()
+			deconstruct(FALSE)
 			return
 	return
 

--- a/code/game/objects/structures/barricade/barricade.dm
+++ b/code/game/objects/structures/barricade/barricade.dm
@@ -132,7 +132,7 @@
 
 		else if(!C.stat)
 			visible_message(SPAN_DANGER("[C] smashes through [src]!"))
-			deconstruct()
+			deconstruct(FALSE)
 			playsound(src, barricade_hitsound, 25, TRUE)
 
 /*
@@ -341,7 +341,7 @@
 	if(!health)
 		if(!nomessage)
 			visible_message(SPAN_DANGER("[src] falls apart!"))
-		deconstruct()
+		deconstruct(FALSE)
 		return
 
 	update_damage_state()

--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -112,12 +112,12 @@
 		visible_message("[src] rapidly deflates!")
 		flick("wall_popping", src)
 		sleep(10)
-		deconstruct(TRUE)
+		deconstruct(FALSE)
 	else
 		visible_message("[src] slowly deflates.")
 		flick("wall_deflating", src)
 		spawn(50)
-			deconstruct(FALSE)
+			deconstruct(TRUE)
 
 
 /obj/structure/inflatable/deconstruct(disassembled = TRUE)

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -80,7 +80,7 @@
 		var/mob/living/carbon/xenomorph/M = O
 		if(!M.stat) //No dead xenos jumpin on the bed~
 			visible_message(SPAN_DANGER("[O] plows straight through [src]!"))
-			deconstruct()
+			deconstruct(FALSE)
 
 /obj/structure/surface/table/Destroy()
 	var/tableloc = loc
@@ -307,7 +307,7 @@
 			playsound(src.loc, 'sound/weapons/wristblades_hit.ogg', 25, 1)
 			user.visible_message(SPAN_DANGER("[user] slices [src] apart!"),
 				SPAN_DANGER("You slice [src] apart!"))
-			deconstruct()
+			deconstruct(FALSE)
 		else
 			to_chat(user, SPAN_WARNING("You slice at the table, but only claw it up a little."))
 		return
@@ -675,7 +675,7 @@
 		var/mob/living/carbon/xenomorph/M = O
 		if(!M.stat) //No dead xenos jumpin on the bed~
 			visible_message(SPAN_DANGER("[O] plows straight through [src]!"))
-			deconstruct()
+			deconstruct(FALSE)
 
 /obj/structure/surface/rack/deconstruct(disassembled = TRUE)
 	if(disassembled)

--- a/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
@@ -344,7 +344,7 @@
 		if(istype(O, /obj/structure/surface/table) || istype(O, /obj/structure/surface/rack) || istype(O, /obj/structure/window_frame))
 			var/obj/structure/S = O
 			visible_message(SPAN_DANGER("[src] plows straight through [S]!"), null, null, 5)
-			S.deconstruct() //We want to continue moving, so we do not reset throwing.
+			S.deconstruct(FALSE) //We want to continue moving, so we do not reset throwing.
 		else
 			O.hitby(src) //This resets throwing.
 	else

--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -328,7 +328,7 @@
 		if(health <= 0)
 			M.visible_message(SPAN_DANGER("[M] slices [src] apart!"), \
 			SPAN_DANGER("You slice [src] apart!"), null, 5, CHAT_TYPE_XENO_COMBAT)
-			deconstruct()
+			deconstruct(FALSE)
 		else
 			M.visible_message(SPAN_DANGER("[M] [M.slashes_verb] [src]!"), \
 			SPAN_DANGER("You [M.slash_verb] [src]!"), null, 5, CHAT_TYPE_XENO_COMBAT)
@@ -370,7 +370,7 @@
 	playsound(src, 'sound/effects/metalhit.ogg', 25, 1)
 	M.visible_message(SPAN_DANGER("[M] slices [src] apart!"), \
 	SPAN_DANGER("You slice [src] apart!"), null, 5, CHAT_TYPE_XENO_COMBAT)
-	deconstruct()
+	deconstruct(FALSE)
 	return XENO_ATTACK_ACTION
 
 //Default "structure" proc. This should be overwritten by sub procs.
@@ -392,7 +392,7 @@
 		M.visible_message(SPAN_DANGER("[M] slices [src] apart!"),
 		SPAN_DANGER("You slice [src] apart!"), null, 5, CHAT_TYPE_XENO_COMBAT)
 		unbuckle()
-		deconstruct()
+		deconstruct(FALSE)
 		return XENO_ATTACK_ACTION
 	else
 		attack_hand(M)

--- a/code/modules/vehicles/interior/interactable/seats.dm
+++ b/code/modules/vehicles/interior/interactable/seats.dm
@@ -409,7 +409,7 @@
 		if(!broken)
 			break_seat()
 		else
-			deconstruct()
+			deconstruct(FALSE)
 
 
 /obj/structure/bed/chair/vehicle/attackby(obj/item/W, mob/living/user)


### PR DESCRIPTION
# About the pull request

It all started with https://github.com/cmss13-devs/cmss13/pull/1285

I noticed for a while that inflatable walls and tables were dropping their parts like slashing them neatly folded/disassembled them. This is the single most important issue CM has ever had and its unforgivable that the memetainers ever let this happen. I expect a full apology in the mail POST HENCE!!! 👿 👿 👿 🤯 🤯 🤯 😭 

# Explain why it's good for the game

Unintended change, return to normalcy.

# Testing Photographs and Procedure
BEFORE:
![dreamseeker_V7AI5rBrre](https://user-images.githubusercontent.com/16618648/227645671-6c49a4d5-388c-4cfa-b99b-1303b2d163b1.gif)

AFTER:
![dreamseeker_X103ecIslg](https://user-images.githubusercontent.com/16618648/227645680-bba69536-504e-4559-adfe-e46221b02c05.gif)

BEFORE:
![dreamseeker_1ckKJQJxk7](https://user-images.githubusercontent.com/16618648/227645709-4a66acda-a20b-4736-8a01-526730204c61.gif)

AFTER:
![dreamseeker_vQfT7XaU7N](https://user-images.githubusercontent.com/16618648/227645716-d2142cad-0bde-48c3-a4d5-2d7b1937bab0.gif)


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: Fixed certain structures dropping parts when they should have been destroyed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
