### PR TITLE
Ammo boxes, attack_self and intent.

### DIFF
--- a/code/modules/projectiles/ammo_boxes/ammo_boxes.dm
+++ b/code/modules/projectiles/ammo_boxes/ammo_boxes.dm
@@ -22,10 +22,30 @@
 	SetLuminosity(0)
 	. = ..()
 
-/obj/item/ammo_box/proc/unfold_box(turf/T)
-	new /obj/item/stack/sheet/cardboard(T)
+/obj/item/ammo_box/attack_self(mob/living/user)
+	..()
+	if(burning)
+		to_chat(user, SPAN_DANGER("It's on fire and might explode!"))
+		return
+
+	if(user.a_intent == INTENT_HARM)
+		unfold_box(user)
+		return
+	deploy_ammo_box(user, user.loc)	
+
+/obj/item/ammo_box/proc/unfold_box(mob/user)
+	if(is_loaded())
+		to_chat(user, SPAN_WARNING("You need to empty the box before unfolding it!"))
+		return
+	new /obj/item/stack/sheet/cardboard(user.loc)
 	qdel(src)
 
+/obj/item/ammo_box/proc/is_loaded()
+	return FALSE
+
+/obj/item/ammo_box/proc/deploy_ammo_box(mob/user, turf/T)
+	user.drop_held_item()
+	
 //---------------------FIRE HANDLING PROCS
 /obj/item/ammo_box/flamer_fire_act(severity, datum/cause_data/flame_cause_data)
 	if(burning)
@@ -130,24 +150,13 @@
 	if(burning)
 		. += SPAN_DANGER("It's on fire and might explode!")
 
-/obj/item/ammo_box/magazine/attack_self(mob/living/user)
-	..()
-	if(burning)
-		to_chat(user, SPAN_DANGER("It's on fire and might explode!"))
-		return
+/obj/item/ammo_box/magazine/is_loaded()
+	if(handfuls)
+		var/obj/item/ammo_magazine/AM = locate(/obj/item/ammo_magazine) in contents
+		return AM?.current_rounds
+	return length(contents)
 
-	if(length(contents))
-		if(!handfuls)
-			deploy_ammo_box(user, user.loc)
-			return
-		else
-			var/obj/item/ammo_magazine/AM = locate(/obj/item/ammo_magazine) in contents
-			if(AM && AM.current_rounds)
-				deploy_ammo_box(user, user.loc)
-				return
-	unfold_box(user.loc)
-
-/obj/item/ammo_box/magazine/proc/deploy_ammo_box(mob/living/user, turf/T)
+/obj/item/ammo_box/magazine/deploy_ammo_box(mob/living/user, turf/T)
 	if(burning)
 		to_chat(user, SPAN_DANGER("It's on fire and might explode!"))
 		return
@@ -300,10 +309,10 @@
 	if(burning)
 		. += SPAN_DANGER("It's on fire and might explode!")
 
-/obj/item/ammo_box/rounds/attack_self(mob/living/user)
-	..()
-	if(bullet_amount < 1)
-		unfold_box(user.loc)
+
+
+/obj/item/ammo_box/rounds/is_loaded()
+	return bullet_amount
 
 /obj/item/ammo_box/rounds/attackby(obj/item/I, mob/user)
 	if(burning)

--- a/code/modules/projectiles/ammo_boxes/ammo_boxes.dm
+++ b/code/modules/projectiles/ammo_boxes/ammo_boxes.dm
@@ -31,7 +31,7 @@
 	if(user.a_intent == INTENT_HARM)
 		unfold_box(user)
 		return
-	deploy_ammo_box(user, user.loc)	
+	deploy_ammo_box(user, user.loc)
 
 /obj/item/ammo_box/proc/unfold_box(mob/user)
 	if(is_loaded())


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

I was going to do this for a long while, and a sudden bug preventing regular deployment of empty boxes only kicked it up the todolist.

# Explain why it's good for the game

Is fix. Is QoL.


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
qol: Activating ammo boxes in hand now unfolds them on harm intent and deploys them on any other intent, even if empty.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
