### PR TITLE
Fix for attack chain, again.

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -10,12 +10,12 @@
 // No comment
 /atom/proc/attackby(obj/item/W, mob/living/user,list/mods)
 	if(SEND_SIGNAL(src, COMSIG_PARENT_ATTACKBY, W, user, mods) & COMPONENT_NO_AFTERATTACK)
-		return FALSE
-	return TRUE
+		return TRUE
+	return FALSE
 
 /atom/movable/attackby(obj/item/W, mob/living/user)
 	. = ..()
-	if(!.)
+	if(.)
 		return
 
 	if(W)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -308,7 +308,7 @@ cases. Override_icon_state should be a list.*/
 // I have cleaned it up a little, but it could probably use more.  -Sayu
 /obj/item/attackby(obj/item/W, mob/user)
 	. = ..()
-	if(!.)
+	if(.)
 		return
 
 	if(istype(W,/obj/item/storage))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Followup to #2710 and probably an alternative to #2952. One day we will have some `#define`s like `ATTACKBY_NO_AFTERATTACK` instead of trying to remember whether this or that or yonder thing should return true or false...

# Explain why it's good for the game

Is fix.


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: Items doing things by clicking on floors can do those things again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
