### PR TITLE
Introduces a new way to rename items, and cassette pouches now take regulation tapes.

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -201,6 +201,10 @@
 //This item will force clickdrag to work even if the preference to disable is enabled. (Full-auto items)
 #define TRAIT_OVERRIDE_CLICKDRAG "t_override_clickdrag"
 
+//This item will use special rename component behaviors.
+//ie. naming a regulation tape "example" will become regulation tape (example)
+#define TRAIT_ITEM_RENAME_SPECIAL "t_item_rename_special"
+
 //-- structure traits --
 // TABLE TRAITS
 /// If the table is being flipped, prevent any changes that will mess with adjacency handling
@@ -269,6 +273,7 @@ GLOBAL_LIST_INIT(traits_by_type, list(
 		"TRAIT_TOOL_PEN" = TRAIT_TOOL_PEN,
 		"TRAIT_ITEM_EAR_EXCLUSIVE" = TRAIT_ITEM_EAR_EXCLUSIVE,
 		"TRAIT_OVERRIDE_CLICKDRAG" = TRAIT_OVERRIDE_CLICKDRAG,
+		"TRAIT_ITEM_RENAME_SPECIAL" = TRAIT_ITEM_RENAME_SPECIAL,
 	),
 	/obj/item/weapon/gun = list(
 		"TRAIT_GUN_SILENCED" = TRAIT_GUN_SILENCED,

--- a/code/datums/components/rename.dm
+++ b/code/datums/components/rename.dm
@@ -47,7 +47,10 @@
 	var/atom/owner = parent
 	original_name = owner.name
 	original_desc = owner.desc
-	owner.name = custom_name
+	if(HAS_TRAIT(owner, TRAIT_ITEM_RENAME_SPECIAL))
+		owner.name = "[initial(owner.name)] ([custom_name])"
+	else
+		owner.name = custom_name
 	owner.desc = custom_desc
 
 ///Reverts the name and description to the state before they were changed.

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -370,6 +370,9 @@
 	var/radial_icon_file = 'icons/mob/radial_tape.dmi'
 	var/list/cassette_colours = list("blue", "gray", "green", "orange", "pink_stripe", "purple", "rainbow", "red_black", "red_stripe", "camo", "rising_sun", "orange", "blue", "ocean", "aesthetic")
 	var/list/cassette_map_themes = list("solaris", "ice", "lz", "dam", "worstmap")
+	inherent_traits = list(TRAIT_ITEM_RENAME_SPECIAL) //used to make the rename component work specially.
+	var/flipped_name //used to store the tape's name for one side
+	var/unflipped_name //see above
 
 
 /obj/item/tape/get_examine_text(mob/user)
@@ -409,6 +412,8 @@
 	initial_icon_state = icon_state //random tapes will set this after choosing their icon
 	if(prob(50))
 		tapeflip()
+	flipped_name = name
+	unflipped_name = name
 
 /obj/item/tape/proc/update_available_icons()
 	icons_available = list()
@@ -483,8 +488,12 @@
 
 	if(icon_state == initial_icon_state)
 		icon_state = "cassette_flip"
+		unflipped_name = name
+		name = flipped_name
 	else if(icon_state == "cassette_flip") //so flipping doesn't overwrite an unexpected icon_state (e.g. an admin's)
 		icon_state = initial_icon_state
+		flipped_name = name
+		name = unflipped_name
 
 //Random color tapes
 /obj/item/tape/random

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -371,8 +371,9 @@
 	var/list/cassette_colours = list("blue", "gray", "green", "orange", "pink_stripe", "purple", "rainbow", "red_black", "red_stripe", "camo", "rising_sun", "orange", "blue", "ocean", "aesthetic")
 	var/list/cassette_map_themes = list("solaris", "ice", "lz", "dam", "worstmap")
 	inherent_traits = list(TRAIT_ITEM_RENAME_SPECIAL) //used to make the rename component work specially.
-	var/flipped_name //used to store the tape's name for one side
-	var/unflipped_name //see above
+	///used to store the tape's name for one side and the other side
+	var/flipped_name
+	var/unflipped_name
 
 
 /obj/item/tape/get_examine_text(mob/user)

--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -1320,7 +1320,7 @@
 	icon_state = "cassette_pouch_closed"
 	var/base_icon_state = "cassette_pouch"
 	w_class = SIZE_SMALL
-	can_hold = list(/obj/item/device/cassette_tape)
+	can_hold = list(/obj/item/device/cassette_tape, /obj/item/tape/regulation)
 	storage_slots = 3
 
 /obj/item/storage/pouch/cassette/update_icon()


### PR DESCRIPTION
# About the pull request
This implements a way of renaming items using the rename component. In this case, it checks for a trait and if it has it the rename component will name an item the initial item name with the new name in parentheses. For example, if you rename a regulation tape "Interview 1", it's gonna show up as "regulation tape (Interview 1)".

Tapes now also store the name for each side of the component, so if you take the previously mentioned label of Interview 1 and then flip it, the other side will be unlabeled until you alter it.

Also, regulation tapes now fit in casette pouches for use by the reporter.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

This is a better way to handle tapes for tape recorders, makes things more immersive for Combat Correspondents and is more convenient.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
add: Cassette pouches now fit regulation tapes.
add: Flipping a previously labeled tape will store the label for that side and vice versa.
add: Tapes now have a unique renaming system.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
