### PR TITLE
Combat Synthetic helmet decap protection

### DIFF
--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -356,7 +356,7 @@
 			var/cut_prob = brute/max_damage * 5
 			if(prob(cut_prob))
 				var/obj/item/clothing/head/helmet/owner_helmet = owner.head
-				if(istype(owner_helmet) && !issynth(owner))
+				if(istype(owner_helmet) && owner.allow_gun_usage)
 					if(!(owner_helmet.flags_inventory & FULL_DECAP_PROTECTION))
 						owner.visible_message("[owner]'s [owner_helmet] goes flying off from the impact!", SPAN_USERDANGER("Your [owner_helmet] goes flying off from the impact!"))
 						owner.drop_inv_item_on_ground(owner_helmet)


### PR DESCRIPTION
# About the pull request

Changes the check from !issynth(owner) to owner.allow_gun_usage, meaning that synths can get helmet decap protection if they are a combat synthetic.

# Explain why it's good for the game

Gives a way for synths to not get decapped

# Changelog

:cl:
balance: Combat Synthetics can get decapitation protection from helmets
/:cl: