### PR TITLE
Makes egg morpher not be hidden behind tallgrass

### DIFF
--- a/code/modules/cm_aliens/structures/special/egg_morpher.dm
+++ b/code/modules/cm_aliens/structures/special/egg_morpher.dm
@@ -17,7 +17,7 @@
 	var/datum/shape/rectangle/range_bounds
 
 	appearance_flags = KEEP_TOGETHER
-	layer = LYING_BETWEEN_MOB_LAYER
+	layer = FACEHUGGER_LAYER
 
 /obj/effect/alien/resin/special/eggmorph/Initialize(mapload, hive_ref)
 	. = ..()


### PR DESCRIPTION
# About the pull request

Spot the egg morpher
![image](https://user-images.githubusercontent.com/129427825/228923531-dfbe5f08-a43f-4b0c-b5f7-564d41a0fc0b.png)


# Explain why it's good for the game

Don't think it's particularly fun to play against fully invisible frontline egg morphers honestly, I might be wrong though and this might be intentional idk


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
balance: Egg morpher now on a higher layer than tall grass
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
