### PR TITLE
Tweaks squad access to restrict squad vendors to squads.

### DIFF
--- a/code/game/machinery/vending/vendor_types/requisitions.dm
+++ b/code/game/machinery/vending/vendor_types/requisitions.dm
@@ -201,13 +201,32 @@
 /obj/structure/machinery/cm_vending/sorted/cargo_guns/squad
 	name = "\improper ColMarTech Automated Armaments Squad Vendor"
 	desc = "An automated supply rack hooked up to a small storage of various firearms and explosives. Can be accessed by any Marine Rifleman."
-	req_access = list(ACCESS_MARINE_ALPHA)
+	req_access = list()
 	req_one_access = list(ACCESS_MARINE_LEADER, ACCESS_MARINE_SPECPREP, ACCESS_MARINE_RO)
 	hackable = TRUE
 
 	vend_x_offset = 2
 	vend_y_offset = 1
 	vend_flags = VEND_CLUTTER_PROTECTION | VEND_LIMITED_INVENTORY | VEND_TO_HAND
+/obj/structure/machinery/cm_vending/sorted/cargo_guns/squad/alpha
+	req_one_access = list(ACCESS_MARINE_LEADER, ACCESS_MARINE_SPECPREP, ACCESS_MARINE_RO, ACCESS_MARINE_ALPHA)
+	vend_x_offset = 0
+	vend_y_offset = 0
+
+/obj/structure/machinery/cm_vending/sorted/cargo_guns/squad/bravo
+	req_one_access = list(ACCESS_MARINE_LEADER, ACCESS_MARINE_SPECPREP, ACCESS_MARINE_RO, ACCESS_MARINE_BRAVO)
+	vend_x_offset = 0
+	vend_y_offset = 0
+
+/obj/structure/machinery/cm_vending/sorted/cargo_guns/squad/charlie
+	req_one_access = list(ACCESS_MARINE_LEADER, ACCESS_MARINE_SPECPREP, ACCESS_MARINE_RO, ACCESS_MARINE_CHARLIE)
+	vend_x_offset = 0
+	vend_y_offset = 0
+
+/obj/structure/machinery/cm_vending/sorted/cargo_guns/squad/delta
+	req_one_access = list(ACCESS_MARINE_LEADER, ACCESS_MARINE_SPECPREP, ACCESS_MARINE_RO, ACCESS_MARINE_DELTA)
+	vend_x_offset = 0
+	vend_y_offset = 0
 
 /obj/structure/machinery/cm_vending/sorted/cargo_guns/squad/ui_state(mob/user)
 	return GLOB.not_incapacitated_and_adjacent_strict_state
@@ -371,12 +390,32 @@
 /obj/structure/machinery/cm_vending/sorted/cargo_ammo/squad
 	name = "\improper ColMarTech Automated Munition Squad Vendor"
 	desc = "An automated supply rack hooked up to a small storage of various ammunition types. Can be accessed by any Marine Rifleman."
-	req_access = list(ACCESS_MARINE_ALPHA)
+	req_access = list()
 	req_one_access = list(ACCESS_MARINE_LEADER, ACCESS_MARINE_SPECPREP, ACCESS_MARINE_RO)
 	hackable = TRUE
 	vend_flags = VEND_CLUTTER_PROTECTION | VEND_LIMITED_INVENTORY | VEND_TO_HAND
 
 	vend_x_offset = 2
+
+/obj/structure/machinery/cm_vending/sorted/cargo_ammo/squad/alpha
+	req_one_access = list(ACCESS_MARINE_LEADER, ACCESS_MARINE_SPECPREP, ACCESS_MARINE_RO, ACCESS_MARINE_ALPHA)
+	vend_x_offset = 0
+	vend_y_offset = 0
+
+/obj/structure/machinery/cm_vending/sorted/cargo_ammo/squad/bravo
+	req_one_access = list(ACCESS_MARINE_LEADER, ACCESS_MARINE_SPECPREP, ACCESS_MARINE_RO, ACCESS_MARINE_BRAVO)
+	vend_x_offset = 0
+	vend_y_offset = 0
+
+/obj/structure/machinery/cm_vending/sorted/cargo_ammo/squad/charlie
+	req_one_access = list(ACCESS_MARINE_LEADER, ACCESS_MARINE_SPECPREP, ACCESS_MARINE_RO, ACCESS_MARINE_CHARLIE)
+	vend_x_offset = 0
+	vend_y_offset = 0
+
+/obj/structure/machinery/cm_vending/sorted/cargo_ammo/squad/delta
+	req_one_access = list(ACCESS_MARINE_LEADER, ACCESS_MARINE_SPECPREP, ACCESS_MARINE_RO, ACCESS_MARINE_DELTA)
+	vend_x_offset = 0
+	vend_y_offset = 0
 
 /obj/structure/machinery/cm_vending/sorted/cargo_ammo/squad/ui_state(mob/user)
 	return GLOB.not_incapacitated_and_adjacent_strict_state
@@ -516,11 +555,31 @@
 /obj/structure/machinery/cm_vending/sorted/attachments/squad
 	name = "\improper Armat Systems Squad Attachments Vendor"
 	desc = "An automated supply rack hooked up to a small storage of weapons attachments. Can be accessed by any Marine Rifleman."
-	req_access = list(ACCESS_MARINE_ALPHA)
+	req_access = list()
 	req_one_access = list(ACCESS_MARINE_LEADER, ACCESS_MARINE_SPECPREP, ACCESS_MARINE_RO)
 	hackable = TRUE
 
 	vend_y_offset = 1
+
+/obj/structure/machinery/cm_vending/sorted/attachments/squad/alpha
+	req_one_access = list(ACCESS_MARINE_LEADER, ACCESS_MARINE_SPECPREP, ACCESS_MARINE_RO, ACCESS_MARINE_ALPHA)
+	vend_x_offset = 0
+	vend_y_offset = 0
+
+/obj/structure/machinery/cm_vending/sorted/attachments/squad/bravo
+	req_one_access = list(ACCESS_MARINE_LEADER, ACCESS_MARINE_SPECPREP, ACCESS_MARINE_RO, ACCESS_MARINE_BRAVO)
+	vend_x_offset = 0
+	vend_y_offset = 0
+
+/obj/structure/machinery/cm_vending/sorted/attachments/squad/charlie
+	req_one_access = list(ACCESS_MARINE_LEADER, ACCESS_MARINE_SPECPREP, ACCESS_MARINE_RO, ACCESS_MARINE_CHARLIE)
+	vend_x_offset = 0
+	vend_y_offset = 0
+
+/obj/structure/machinery/cm_vending/sorted/attachments/squad/delta
+	req_one_access = list(ACCESS_MARINE_LEADER, ACCESS_MARINE_SPECPREP, ACCESS_MARINE_RO, ACCESS_MARINE_DELTA)
+	vend_x_offset = 0
+	vend_y_offset = 0
 
 /obj/structure/machinery/cm_vending/sorted/attachments/squad/ui_state(mob/user)
 	return GLOB.not_incapacitated_and_adjacent_strict_state

--- a/code/game/machinery/vending/vendor_types/squad_prep/squad_prep.dm
+++ b/code/game/machinery/vending/vendor_types/squad_prep/squad_prep.dm
@@ -9,6 +9,26 @@
 	hackable = TRUE
 	vend_flags = VEND_CLUTTER_PROTECTION | VEND_LIMITED_INVENTORY | VEND_TO_HAND
 
+/obj/structure/machinery/cm_vending/sorted/cargo_guns/squad_prep/alpha
+	req_one_access = list(ACCESS_MARINE_DATABASE, ACCESS_MARINE_ALPHA, ACCESS_MARINE_CARGO)
+	vend_x_offset = 0
+	vend_y_offset = 0
+
+/obj/structure/machinery/cm_vending/sorted/cargo_guns/squad_prep/bravo
+	req_one_access = list(ACCESS_MARINE_DATABASE, ACCESS_MARINE_BRAVO, ACCESS_MARINE_CARGO)
+	vend_x_offset = 0
+	vend_y_offset = 0
+
+/obj/structure/machinery/cm_vending/sorted/cargo_guns/squad_prep/charlie
+	req_one_access = list(ACCESS_MARINE_DATABASE, ACCESS_MARINE_CHARLIE, ACCESS_MARINE_CARGO)
+	vend_x_offset = 0
+	vend_y_offset = 0
+
+/obj/structure/machinery/cm_vending/sorted/cargo_guns/squad_prep/delta
+	req_one_access = list(ACCESS_MARINE_DATABASE, ACCESS_MARINE_DELTA, ACCESS_MARINE_CARGO)
+	vend_x_offset = 0
+	vend_y_offset = 0
+
 /obj/structure/machinery/cm_vending/sorted/cargo_guns/squad_prep/ui_state(mob/user)
 	return GLOB.not_incapacitated_and_adjacent_strict_state
 

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -5860,7 +5860,7 @@
 	},
 /area/almayer/hallways/aft_hallway)
 "asX" = (
-/obj/structure/machinery/cm_vending/sorted/cargo_guns/squad_prep,
+/obj/structure/machinery/cm_vending/sorted/cargo_guns/squad_prep/delta,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -11214,16 +11214,10 @@
 	},
 /area/almayer/engineering/upper_engineering)
 "aMx" = (
-/obj/structure/machinery/cm_vending/sorted/cargo_guns/squad{
-	req_access = null;
-	req_one_access = null;
-	req_one_access_txt = "15;16;21";
-	vend_x_offset = 0;
-	vend_y_offset = 0
-	},
 /obj/structure/machinery/light{
 	dir = 1
 	},
+/obj/structure/machinery/cm_vending/sorted/cargo_guns/squad/alpha,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -21725,10 +21719,10 @@
 	},
 /area/almayer/squads/req)
 "bMq" = (
-/obj/structure/machinery/cm_vending/sorted/cargo_guns/squad_prep,
 /obj/structure/machinery/light{
 	dir = 1
 	},
+/obj/structure/machinery/cm_vending/sorted/cargo_guns/squad_prep/charlie,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -21740,16 +21734,10 @@
 	},
 /area/almayer/hallways/port_hallway)
 "bMu" = (
-/obj/structure/machinery/cm_vending/sorted/cargo_guns/squad{
-	req_access = null;
-	req_one_access = null;
-	req_one_access_txt = "17;18;21";
-	vend_x_offset = 0;
-	vend_y_offset = 0
-	},
 /obj/structure/machinery/light{
 	dir = 1
 	},
+/obj/structure/machinery/cm_vending/sorted/cargo_guns/squad/charlie,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -37491,12 +37479,7 @@
 	},
 /area/almayer/engineering/engine_core)
 "gNq" = (
-/obj/structure/machinery/cm_vending/sorted/cargo_ammo/squad{
-	req_access = null;
-	req_one_access = null;
-	req_one_access_txt = "17;18;21";
-	vend_x_offset = 0
-	},
+/obj/structure/machinery/cm_vending/sorted/cargo_ammo/squad/delta,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -40452,12 +40435,7 @@
 	},
 /area/almayer/hull/lower_hull/l_f_p)
 "iow" = (
-/obj/structure/machinery/cm_vending/sorted/attachments/squad{
-	req_access = null;
-	req_one_access = null;
-	req_one_access_txt = "15;16;21";
-	vend_y_offset = 0
-	},
+/obj/structure/machinery/cm_vending/sorted/attachments/squad/bravo,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -45017,6 +44995,12 @@
 	icon_state = "plate"
 	},
 /area/almayer/hull/lower_hull/l_f_p)
+"kAM" = (
+/obj/structure/machinery/cm_vending/sorted/cargo_guns/squad_prep/charlie,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/squads/charlie_delta_shared)
 "kAU" = (
 /obj/structure/platform{
 	dir = 4
@@ -51247,14 +51231,8 @@
 /turf/open/floor/almayer,
 /area/almayer/squads/req)
 "nBa" = (
-/obj/structure/machinery/cm_vending/sorted/cargo_guns/squad{
-	req_access = null;
-	req_one_access = null;
-	req_one_access_txt = "15;16;21";
-	vend_x_offset = 0;
-	vend_y_offset = 0
-	},
 /obj/structure/machinery/light,
+/obj/structure/machinery/cm_vending/sorted/cargo_guns/squad/bravo,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -52259,10 +52237,10 @@
 	},
 /area/almayer/engineering/port_atmos)
 "obE" = (
-/obj/structure/machinery/cm_vending/sorted/cargo_guns/squad_prep,
 /obj/structure/machinery/light{
 	dir = 1
 	},
+/obj/structure/machinery/cm_vending/sorted/cargo_guns/squad_prep/alpha,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -54855,8 +54833,8 @@
 	},
 /area/almayer/medical/upper_medical)
 "ptj" = (
-/obj/structure/machinery/cm_vending/sorted/cargo_guns/squad_prep,
 /obj/structure/machinery/light,
+/obj/structure/machinery/cm_vending/sorted/cargo_guns/squad_prep/delta,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -55778,14 +55756,8 @@
 /turf/open/floor/plating,
 /area/almayer/living/bridgebunks)
 "pQF" = (
-/obj/structure/machinery/cm_vending/sorted/cargo_guns/squad{
-	req_access = null;
-	req_one_access = null;
-	req_one_access_txt = "17;18;21";
-	vend_x_offset = 0;
-	vend_y_offset = 0
-	},
 /obj/structure/machinery/light,
+/obj/structure/machinery/cm_vending/sorted/cargo_guns/squad/delta,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -56783,6 +56755,12 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/living/pilotbunks)
+"qnM" = (
+/obj/structure/machinery/cm_vending/sorted/cargo_ammo/squad/alpha,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/squads/alpha_bravo_shared)
 "qnP" = (
 /obj/structure/prop/invuln/overhead_pipe{
 	pixel_x = 12
@@ -59640,8 +59618,8 @@
 /turf/open/floor/carpet,
 /area/almayer/command/cichallway)
 "rHf" = (
-/obj/structure/machinery/cm_vending/sorted/cargo_guns/squad_prep,
 /obj/structure/machinery/light,
+/obj/structure/machinery/cm_vending/sorted/cargo_guns/squad_prep/bravo,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -62942,12 +62920,7 @@
 /turf/open/floor/almayer,
 /area/almayer/shipboard/weapon_room)
 "tkN" = (
-/obj/structure/machinery/cm_vending/sorted/cargo_ammo/squad{
-	req_access = null;
-	req_one_access = null;
-	req_one_access_txt = "15;16;21";
-	vend_x_offset = 0
-	},
+/obj/structure/machinery/cm_vending/sorted/cargo_ammo/squad/bravo,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -67516,7 +67489,7 @@
 	},
 /area/almayer/shipboard/port_missiles)
 "vlX" = (
-/obj/structure/machinery/cm_vending/sorted/cargo_guns/squad_prep,
+/obj/structure/machinery/cm_vending/sorted/cargo_guns/squad_prep/bravo,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -68389,6 +68362,12 @@
 	icon_state = "red"
 	},
 /area/almayer/shipboard/navigation)
+"vJx" = (
+/obj/structure/machinery/cm_vending/sorted/attachments/squad/alpha,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/squads/alpha_bravo_shared)
 "vJy" = (
 /obj/structure/machinery/vending/cigarette{
 	density = 0;
@@ -68589,6 +68568,12 @@
 "vOy" = (
 /turf/closed/wall/almayer/white/reinforced,
 /area/almayer/medical/medical_science)
+"vOW" = (
+/obj/structure/machinery/cm_vending/sorted/cargo_guns/squad_prep/alpha,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/squads/alpha_bravo_shared)
 "vPj" = (
 /obj/structure/surface/table/reinforced/almayer_B,
 /obj/item/device/flashlight/lamp{
@@ -69795,6 +69780,12 @@
 	icon_state = "cargo"
 	},
 /area/almayer/living/bridgebunks)
+"wmX" = (
+/obj/structure/machinery/cm_vending/sorted/attachments/squad/charlie,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/squads/charlie_delta_shared)
 "wnL" = (
 /obj/item/stack/tile/carpet{
 	amount = 12
@@ -71009,12 +71000,7 @@
 	},
 /area/almayer/living/briefing)
 "wTw" = (
-/obj/structure/machinery/cm_vending/sorted/attachments/squad{
-	req_access = null;
-	req_one_access = null;
-	req_one_access_txt = "17;18;21";
-	vend_y_offset = 0
-	},
+/obj/structure/machinery/cm_vending/sorted/attachments/squad/delta,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -72658,6 +72644,12 @@
 	icon_state = "silver"
 	},
 /area/almayer/command/securestorage)
+"xDO" = (
+/obj/structure/machinery/cm_vending/sorted/cargo_ammo/squad/charlie,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/squads/charlie_delta_shared)
 "xEc" = (
 /turf/open/floor/almayer{
 	dir = 9;
@@ -111641,7 +111633,7 @@ dEC
 aNO
 qHl
 jeb
-vlX
+vOW
 aNx
 qGc
 jhD
@@ -111685,7 +111677,7 @@ bHT
 bHa
 deH
 vra
-asX
+kAM
 chf
 wDJ
 tJz
@@ -112047,7 +112039,7 @@ rlG
 aNO
 nFy
 jeb
-vlX
+vOW
 thA
 gAA
 gAA
@@ -112091,7 +112083,7 @@ bHT
 bHa
 rKy
 vra
-asX
+kAM
 drj
 cgo
 cgo
@@ -112250,7 +112242,7 @@ enx
 aQt
 xPg
 jeb
-vlX
+vOW
 tdE
 qGc
 rth
@@ -112294,7 +112286,7 @@ bHT
 bHa
 bIR
 vra
-asX
+kAM
 qUq
 wDJ
 nyQ
@@ -112656,7 +112648,7 @@ aLG
 aNO
 jJs
 jeb
-vlX
+vOW
 tdE
 qGc
 rth
@@ -112700,7 +112692,7 @@ bHV
 bHa
 rbX
 vra
-asX
+kAM
 qUq
 wDJ
 nyQ
@@ -113062,7 +113054,7 @@ ahj
 ahj
 ahj
 jeb
-tkN
+qnM
 qHg
 gAA
 beP
@@ -113106,7 +113098,7 @@ bHX
 bHa
 buH
 vra
-gNq
+xDO
 hXb
 cgo
 fwY
@@ -113468,7 +113460,7 @@ ahj
 ahj
 ahj
 jeb
-iow
+vJx
 aMO
 qGc
 hxe
@@ -113512,7 +113504,7 @@ bHW
 bHa
 vMx
 vra
-wTw
+wmX
 bNE
 wDJ
 ivs


### PR DESCRIPTION
# About the pull request

Adds specific squad locked variants of the squad prep vendors, cleans up the older access code slightly (A few squad vendors were still looking for ACCESS_SQUAD_ALPHA). 

# Explain why it's good for the game

It makes the vendors more consistent, allows squads to have an even spread of their gear throughout, cuts down on the "theft" of items, although the vendors *are* still hackable, so if you have a multitool you can just remove the restrictions. Should cut down on soft-grief like for example, people stealing all the AP mags of another squad.

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>

[Testing Video](https://youtu.be/68oyLAnKQjQ)

</details>


# Changelog

:cl:LynxSolstice
code: Cleans up some minor lingering code oddities in the process of fucking with the vendor access.
maptweak: Vendors in prep are now squad locked. (Squad locked variants are subtyped.)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
