### PR TITLE
Smartgun Variables for Harness, Powerpack, & Power

### DIFF
--- a/code/modules/projectiles/guns/smartgun.dm
+++ b/code/modules/projectiles/guns/smartgun.dm
@@ -20,7 +20,7 @@
 	aim_slowdown = SLOWDOWN_ADS_SPECIALIST
 	var/powerpack = null
 	var/requires_power = TRUE
-	var/requires_powerpack = TRUE
+	var/requires_powerpack = TRUE //If requires_powerpack is false, requires_power will be ignored
 	var/requires_harness = TRUE
 	ammo = /datum/ammo/bullet/smartgun
 	actions_types = list(
@@ -355,10 +355,8 @@
 
 /obj/item/weapon/gun/smartgun/Fire(atom/target, mob/living/user, params, reflex = 0, dual_wield)
 	if(!requires_powerpack)
-		if(requires_power)
-			to_chat(user, SPAN_BOLDWARNING("Smartgun Improperly Configured. Attempting to fix. Smartgun cannot require power without requiring a powerpack."))
-			requires_power = FALSE
 		..()
+		return
 
 	if(!powerpack || (powerpack && user.back != powerpack))
 		if(!link_powerpack(user))
@@ -366,14 +364,13 @@
 			unlink_powerpack()
 			return
 	if(powerpack)
+		if(!requires_power)
+			..()
+			return
 		var/obj/item/smartgun_powerpack/pp = user.back
 		if(istype(pp))
 			var/obj/item/cell/c = pp.pcell
 			var/d = drain
-			if(!requires_power)
-				..()
-				return
-
 			if(flags_gun_features & GUN_BURST_ON)
 				d = drain*burst_amount*1.5
 			if(pp.drain_powerpack(d, c))

--- a/code/modules/projectiles/guns/smartgun.dm
+++ b/code/modules/projectiles/guns/smartgun.dm
@@ -304,7 +304,7 @@
 			return FALSE
 		if(requires_harness)
 			if(!H.wear_suit || !(H.wear_suit.flags_inventory & SMARTGUN_HARNESS))
-				to_chat(H, SPAN_WARNING("You need a harness suit to be able to fire \the [src]..."))
+				to_chat(H, SPAN_WARNING("You need a harness suit to be able to fire [src]..."))
 				return FALSE
 		if(cover_open)
 			to_chat(H, SPAN_WARNING("You can't fire \the [src] with the feed cover open! (alt-click to close)"))

--- a/code/modules/projectiles/guns/smartgun.dm
+++ b/code/modules/projectiles/guns/smartgun.dm
@@ -19,8 +19,11 @@
 	wield_delay = WIELD_DELAY_FAST
 	aim_slowdown = SLOWDOWN_ADS_SPECIALIST
 	var/powerpack = null
+	/// Whether the smartgun drains the powerpack battery (Ignored if requires_powerpack is false)
 	var/requires_power = TRUE
-	var/requires_powerpack = TRUE //If requires_powerpack is false, requires_power will be ignored
+	/// Whether the smartgun requires a powerpack to be worn
+	var/requires_powerpack = TRUE
+	/// Whether the smartgun requires a harness to use
 	var/requires_harness = TRUE
 	ammo = /datum/ammo/bullet/smartgun
 	actions_types = list(


### PR DESCRIPTION
# About the pull request

Adds a variable to the smartgun to toggle whether you need to wear a powerpack or harness, or if the powerpack requires charge.

# Explain why it's good for the game

It is currently hardcoded to require these 3, might be better to mess with if you don't require the rest of the kit

# Changelog

:cl:
admin: Added vars to the smartgun to toggle requiring a harness, power, or a powerpack
/:cl: