### PR TITLE
reduces platform and handrail projectile coverage significantly

### DIFF
--- a/code/__DEFINES/conflict.dm
+++ b/code/__DEFINES/conflict.dm
@@ -168,6 +168,7 @@
 
 //Projectile block probabilities for different types of cover
 #define PROJECTILE_COVERAGE_NONE 0
+#define PROJECTILE_COVERAGE_MINIMAL 10
 #define PROJECTILE_COVERAGE_LOW 35
 #define PROJECTILE_COVERAGE_MEDIUM 60
 #define PROJECTILE_COVERAGE_HIGH 85

--- a/code/game/objects/structures/barricade/handrail.dm
+++ b/code/game/objects/structures/barricade/handrail.dm
@@ -14,7 +14,7 @@
 	crusher_resistant = FALSE
 	can_wire = FALSE
 	barricade_hitsound = 'sound/effects/metalhit.ogg'
-	projectile_coverage = PROJECTILE_COVERAGE_LOW
+	projectile_coverage = PROJECTILE_COVERAGE_MINIMAL
 	var/build_state = BARRICADE_BSTATE_SECURED
 	var/reinforced = FALSE //Reinforced to be a cade or not
 
@@ -188,6 +188,7 @@
 /obj/structure/barricade/handrail/sandstone
 	name = "sandstone handrail"
 	icon_state = "hr_sandstone"
+	projectile_coverage = PROJECTILE_COVERAGE_LOW
 	stack_type = /obj/item/stack/sheet/mineral/sandstone
 	debris = list(/obj/item/stack/sheet/mineral/sandstone)
 

--- a/code/game/objects/structures/platforms.dm
+++ b/code/game/objects/structures/platforms.dm
@@ -15,6 +15,7 @@
 	flags_atom = ON_BORDER
 	unacidable = TRUE
 	climb_delay = CLIMB_DELAY_SHORT
+	projectile_coverage = PROJECTILE_COVERAGE_NONE
 
 /obj/structure/platform/stair_cut
 	icon_state = "platform_stair"//icon will be honked in all dirs except (1), that's because the behavior breaks if it ain't (1)


### PR DESCRIPTION
# About the pull request

Does exactly what the title implies: reduces platform and handrail projectile coverage significantly.
Platforms 60% -> 0%
Handrails 35% -> 10%

# Explain why it's good for the game

When a platform and handrail are combined, that totals at a 95% chance of blocking a bullet passing through that tile. Platform corners also catch bullets. That's some hogwash if you ask me. It makes areas like Sorokyne's Mining platform entrance nearly un-defendable for marines since they can't shoot past what is effectively an invisible bullet wall. When I made Sorokyne, this was not the intent of the area. New Varadero has similar problems.

You may ask, why not change those areas instead? My answer: Sod off, they look awesome, and I don't want to code a check on projectiles to determine if you're shooting 'up' at a ledge which would be the logical simulationist fix. Also handrails aren't supposed to block bullets unless they're reinforced (not that anyone uses that mechanic though). How do I know this? I willed this mechanic into existence for Strata with shitcode.

Both xenos that spit and marines that shoot will benefit from this change.

# Changelog

:cl: Triiodine
balance: Reduced projectile coverage of platforms from 60% to 0%.
balance: Reduced projectile coverage on handrail types from 35% to 10%. Sandstone handrails are unaffected and remain at 35% projectile coverage.
balance: Sandstone handrails can no longer be reinforced.
/:cl:
