### PR TITLE
"Bottomless Magazine" variable

### DIFF
--- a/code/modules/defenses/defenses.dm
+++ b/code/modules/defenses/defenses.dm
@@ -22,6 +22,7 @@
 	var/locked = FALSE
 	var/composite_icon = TRUE
 	var/display_additional_stats = FALSE
+	var/bottomless_mag = FALSE //If the mag has atleast 1 ammo in it, it won't consume ammo to fire
 
 	var/defense_check_range = 2
 	var/can_be_near_defense = FALSE

--- a/code/modules/defenses/sentry.dm
+++ b/code/modules/defenses/sentry.dm
@@ -314,7 +314,8 @@
 	GIVE_BULLET_TRAIT(new_projectile, /datum/element/bullet_trait_iff, faction_group)
 	new_projectile.fire_at(target, src, owner_mob, new_projectile.ammo.max_range, new_projectile.ammo.shell_speed, null, FALSE)
 	muzzle_flash(Get_Angle(get_turf(src), target))
-	ammo.current_rounds--
+	if(!bottomless_mag)
+		ammo.current_rounds--
 	track_shot()
 	if(ammo.current_rounds == 0)
 		handle_empty()

--- a/code/modules/defenses/sentry_flamer.dm
+++ b/code/modules/defenses/sentry_flamer.dm
@@ -33,7 +33,8 @@
 	P.generate_bullet(new ammo.default_ammo)
 	GIVE_BULLET_TRAIT(P, /datum/element/bullet_trait_iff, faction_group)
 	P.fire_at(A, src, owner_mob, P.ammo.max_range, P.ammo.shell_speed, null)
-	ammo.current_rounds--
+	if(!bottomless_mag)
+		ammo.current_rounds--
 	track_shot()
 	if(ammo.current_rounds == 0)
 		visible_message("[icon2html(src, viewers(src))] [SPAN_WARNING("The [name] beeps steadily and its ammo light blinks red.")]")

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -58,6 +58,7 @@
 	on those unique vars. This is done for quicker pathing. Just keep in mind most mags aren't internal, though some are.
 	This is also the default magazine path loaded into a projectile weapon for reverse lookups on New(). Leave this null to do your own thing.*/
 	var/obj/item/ammo_magazine/internal/current_mag = null
+	var/bottomless_mag = FALSE //If the mag has atleast 1 ammo in it, it won't consume ammo to fire
 
 	//Basic stats.
 	///Multiplier. Increased and decreased through attachments. Multiplies the projectile's accuracy by this number.
@@ -938,7 +939,8 @@ and you're good to go.
 	//Let's check on the active attachable. It loads ammo on the go, so it never chambers anything
 	if(active_attachable)
 		if(active_attachable.current_rounds > 0) //If it's still got ammo and stuff.
-			active_attachable.current_rounds--
+			if(!bottomless_mag)
+				active_attachable.current_rounds--
 			var/obj/item/projectile/bullet = create_bullet(active_attachable.ammo, initial(name))
 			// For now, only bullet traits from the attachment itself will apply to its projectiles
 			for(var/entry in active_attachable.traits_to_give_attached)
@@ -992,7 +994,8 @@ and you're good to go.
 	if(current_mag && current_mag.current_rounds > 0)
 		in_chamber = create_bullet(ammo, initial(name))
 		apply_traits(in_chamber)
-		current_mag.current_rounds-- //Subtract the round from the mag.
+		if(!bottomless_mag)
+			current_mag.current_rounds-- //Subtract the round from the mag.
 		return in_chamber
 
 

--- a/code/modules/projectiles/guns/lever_action.dm
+++ b/code/modules/projectiles/guns/lever_action.dm
@@ -216,9 +216,10 @@ their unique feature is that a direct hit will buff your damage and firerate
 	if(current_mag.current_rounds > 0)
 		ammo = GLOB.ammo_list[current_mag.chamber_contents[current_mag.chamber_position]]
 		in_chamber = create_bullet(ammo, initial(name))
-		current_mag.current_rounds--
-		current_mag.chamber_contents[current_mag.chamber_position] = "empty"
-		current_mag.chamber_position--
+		if(!bottomless_mag)
+			current_mag.current_rounds--
+			current_mag.chamber_contents[current_mag.chamber_position] = "empty"
+			current_mag.chamber_position--
 		return in_chamber
 
 /obj/item/weapon/gun/lever_action/ready_in_chamber()

--- a/code/modules/projectiles/guns/revolvers.dm
+++ b/code/modules/projectiles/guns/revolvers.dm
@@ -163,7 +163,8 @@
 	if(current_mag)
 		if(current_mag.current_rounds > 0)
 			if(current_mag.chamber_contents[current_mag.chamber_position] == "bullet")
-				current_mag.current_rounds-- //Subtract the round from the mag.
+				if(!bottomless_mag)
+					current_mag.current_rounds-- //Subtract the round from the mag.
 				in_chamber = create_bullet(ammo, initial(name))
 				apply_traits(in_chamber)
 				return in_chamber
@@ -178,7 +179,8 @@
 /obj/item/weapon/gun/revolver/reload_into_chamber(mob/user)
 	in_chamber = null
 	if(current_mag)
-		current_mag.chamber_contents[current_mag.chamber_position] = "blank" //We shot the bullet.
+		if(!bottomless_mag)
+			current_mag.chamber_contents[current_mag.chamber_position] = "blank" //We shot the bullet.
 		rotate_cylinder()
 		return 1
 

--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -148,9 +148,10 @@ can cause issues with ammo types getting mixed up during the burst.
 	if(current_mag.current_rounds > 0)
 		ammo = GLOB.ammo_list[current_mag.chamber_contents[current_mag.chamber_position]]
 		in_chamber = create_bullet(ammo, initial(name))
-		current_mag.current_rounds--
-		current_mag.chamber_contents[current_mag.chamber_position] = "empty"
-		current_mag.chamber_position--
+		if(!bottomless_mag)
+			current_mag.current_rounds--
+			current_mag.chamber_contents[current_mag.chamber_position] = "empty"
+			current_mag.chamber_position--
 		return in_chamber
 
 
@@ -585,7 +586,8 @@ can cause issues with ammo types getting mixed up during the burst.
 	if(current_mag.current_rounds > 0)
 		ammo = GLOB.ammo_list[current_mag.chamber_contents[current_mag.chamber_position]]
 		in_chamber = create_bullet(ammo, initial(name))
-		current_mag.current_rounds--
+		if(!bottomless_mag)
+			current_mag.current_rounds--
 		return in_chamber
 	//We can't make a projectile without a mag or active attachable.
 

--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -1448,7 +1448,8 @@
 	if(!do_after(user, 1 SECONDS, INTERRUPT_ALL, BUSY_ICON_GENERIC))
 		return
 
-	current_mag.current_rounds--
+	if(!bottomless_mag)
+		current_mag.current_rounds--
 
 	flare_turf.ceiling_debris()
 

--- a/code/modules/vehicles/hardpoints/hardpoint.dm
+++ b/code/modules/vehicles/hardpoints/hardpoint.dm
@@ -101,6 +101,7 @@
 	/// An assoc list in the format list(/datum/element/bullet_trait_to_give = list(...args))
 	/// that will be given to a projectile fired from the hardpoint
 	var/list/list/traits_to_give
+	var/bottomless_mag = FALSE //If the mag has atleast 1 ammo in it, it won't consume ammo to fire
 
 //-----------------------------
 //------GENERAL PROCS----------
@@ -557,7 +558,8 @@
 	if(use_muzzle_flash)
 		muzzle_flash(Get_Angle(origin_turf, A))
 
-	ammo.current_rounds--
+	if(!bottomless_mag)
+		ammo.current_rounds--
 
 //-----------------------------
 //------ICON PROCS----------

--- a/code/modules/vehicles/hardpoints/holder/tank_turret.dm
+++ b/code/modules/vehicles/hardpoints/holder/tank_turret.dm
@@ -226,4 +226,5 @@
 	var/obj/item/projectile/P = generate_bullet(user, origin_turf)
 	SEND_SIGNAL(P, COMSIG_BULLET_USER_EFFECTS, owner.seats[VEHICLE_GUNNER])
 	P.fire_at(A, owner.seats[VEHICLE_GUNNER], src, get_dist(origin_turf, A) + 1, P.ammo.shell_speed)
-	ammo.current_rounds--
+	if(!bottomless_mag)
+		ammo.current_rounds--

--- a/code/modules/vehicles/hardpoints/primary/flamer.dm
+++ b/code/modules/vehicles/hardpoints/primary/flamer.dm
@@ -58,4 +58,5 @@
 	if(use_muzzle_flash)
 		muzzle_flash(Get_Angle(owner, A))
 
-	ammo.current_rounds--
+	if(!bottomless_mag)
+		ammo.current_rounds--

--- a/code/modules/vehicles/hardpoints/secondary/flamer.dm
+++ b/code/modules/vehicles/hardpoints/secondary/flamer.dm
@@ -45,7 +45,8 @@
 		if(distance >= max_range) break
 		if(prev_T && LinkBlocked(prev_T, T))
 			break
-		ammo.current_rounds--
+		if(!bottomless_mag)
+			ammo.current_rounds--
 		flame_turf(T, user)
 		distance++
 		prev_T = T

--- a/code/modules/vehicles/hardpoints/secondary/grenade_launcher.dm
+++ b/code/modules/vehicles/hardpoints/secondary/grenade_launcher.dm
@@ -63,4 +63,5 @@
 	if(use_muzzle_flash)
 		muzzle_flash(Get_Angle(owner, A))
 
-	ammo.current_rounds--
+	if(!bottomless_mag)
+		ammo.current_rounds--


### PR DESCRIPTION
# About the pull request

Adds a var for a bottomless magazine to guns, sentry's, and vehicle hardpoints.
As long as the magazine has at least 1 bullet, it'll keep firing that type of bullet.

# Explain why it's good for the game

More funny vars to grief with

# Changelog

:cl:
admin: Adds a variable for a "bottomless mag" for guns
/:cl: