### PR TITLE
Sets up "short" fog blockers

### DIFF
--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -69,6 +69,7 @@ Additional game mode variables.
 	var/round_finished
 	var/round_started = 5 //This is a simple timer so we don't accidently check win conditions right in post-game
 	var/list/round_fog = list() //List of the fog locations.
+	var/list/short_round_fog = list() //list of the short fog locations for faster lowering.
 	var/list/round_toxic_river = list() //List of all toxic river locations
 	var/round_time_lobby //Base time for the lobby, for fog dispersal.
 	var/round_time_river

--- a/code/game/gamemodes/cm_process.dm
+++ b/code/game/gamemodes/cm_process.dm
@@ -142,6 +142,15 @@ of predators), but can be added to include variant game modes (like humans vs. h
 		CHECK_TICK
 	round_fog = null
 
+/datum/game_mode/proc/disperse_short_fog()
+	set waitfor = FALSE
+	var/i
+	for(i in short_round_fog)
+		short_round_fog -= i
+		qdel(i)
+		CHECK_TICK
+	short_round_fog = null
+
 // Open podlocks with the given ID if they aren't already opened.
 // DO NOT USE THIS WITH ID's CORRESPONDING TO SHUTTLES OR THEY WILL BREAK!
 /datum/game_mode/proc/open_podlocks(podlock_id)

--- a/code/game/gamemodes/cm_process.dm
+++ b/code/game/gamemodes/cm_process.dm
@@ -144,8 +144,7 @@ of predators), but can be added to include variant game modes (like humans vs. h
 
 /datum/game_mode/proc/disperse_short_fog()
 	set waitfor = FALSE
-	var/i
-	for(i in short_round_fog)
+	for(var/i in short_round_fog)
 		short_round_fog -= i
 		qdel(i)
 		CHECK_TICK

--- a/code/game/gamemodes/colonialmarines/colonialmarines.dm
+++ b/code/game/gamemodes/colonialmarines/colonialmarines.dm
@@ -44,6 +44,8 @@
 	GLOB.fog_blockers -= src
 	return ..()
 
+/obj/effect/landmark/lv624/fog_blocker/short
+
 /obj/effect/landmark/lv624/xeno_tunnel
 	name = "xeno tunnel"
 	icon_state = "spawn_event"
@@ -61,9 +63,14 @@
 /* Pre-setup */
 /datum/game_mode/colonialmarines/pre_setup()
 	for(var/i in GLOB.fog_blockers)
-		var/obj/effect/landmark/lv624/fog_blocker/FB = i
-		round_fog += new /obj/structure/blocker/fog(FB.loc)
-		qdel(FB)
+		if(istype(i, /obj/effect/landmark/lv624/fog_blocker/short))
+			var/obj/effect/landmark/lv624/fog_blocker/short/short_fog_blocker = i
+			short_round_fog += new /obj/structure/blocker/fog(short_fog_blocker.loc)
+			qdel(short_fog_blocker)
+		else
+			var/obj/effect/landmark/lv624/fog_blocker/fog_blocker = i
+			round_fog += new /obj/structure/blocker/fog(fog_blocker.loc)
+			qdel(fog_blocker)
 
 	QDEL_LIST(GLOB.hunter_primaries)
 	QDEL_LIST(GLOB.hunter_secondaries)
@@ -78,8 +85,9 @@
 			qdel(i)
 			new type_to_spawn(T)
 
-	if(!round_fog.len)
-		round_fog = null //No blockers?
+	if(!round_fog.len && !short_round_fog.len)
+		round_fog = null //No blockers? https://i.imgur.com/PMeeqMe.jpg
+		short_round_fog = null
 	else
 		flags_round_type |= MODE_FOG_ACTIVATED
 
@@ -153,6 +161,7 @@
 ////////////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////////////
 
+#define SHORT_FOG_DELAY_INTERVAL (15 MINUTES)
 #define FOG_DELAY_INTERVAL (25 MINUTES)
 #define PODLOCKS_OPEN_WAIT (45 MINUTES) // CORSAT pod doors drop at 12:45
 
@@ -188,8 +197,12 @@
 			bioscan_current_interval += bioscan_ongoing_interval //Add to the interval based on our set interval time.
 
 		if(++round_checkwin >= 5) //Only check win conditions every 5 ticks.
-			if(flags_round_type & MODE_FOG_ACTIVATED && SSmapping.configs[GROUND_MAP].environment_traits[ZTRAIT_FOG] && world.time >= (FOG_DELAY_INTERVAL + SSticker.round_start_time))
-				disperse_fog() //Some RNG thrown in.
+			if(flags_round_type & MODE_FOG_ACTIVATED && SSmapping.configs[GROUND_MAP].environment_traits[ZTRAIT_FOG])
+				if(world.time >= (SHORT_FOG_DELAY_INTERVAL + SSticker.round_start_time))
+					disperse_short_fog()
+				if(world.time >= (FOG_DELAY_INTERVAL + SSticker.round_start_time))
+					disperse_fog()
+
 			if(!(round_status_flags & ROUNDSTATUS_PODDOORS_OPEN))
 				if(SSmapping.configs[GROUND_MAP].environment_traits[ZTRAIT_LOCKDOWN])
 					if(world.time >= (PODLOCKS_OPEN_WAIT + round_time_lobby))
@@ -254,6 +267,7 @@
 
 	playsound_z(SSmapping.levels_by_any_trait(list(ZTRAIT_MARINE_MAIN_SHIP)), 'sound/effects/double_klaxon.ogg', volume = 10)
 
+#undef SHORT_FOG_DELAY_INTERVAL
 #undef FOG_DELAY_INTERVAL
 #undef PODLOCKS_OPEN_WAIT
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Sets up "short" fog blockers that drop at 15 minutes rather than 25.

# Explain why it's good for the game

Mapper tools.


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>
Basic test complete.  Fog went down at correct times and such.

</details>


# Changelog

:cl: Morrow
code: Sets up "short" fog blockers for mappers

/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
