### PR TITLE
Removes surv spawns at LV624 lake house

### DIFF
--- a/code/game/objects/effects/landmarks/survivor_spawner.dm
+++ b/code/game/objects/effects/landmarks/survivor_spawner.dm
@@ -26,18 +26,6 @@
 		return FALSE
 	return TRUE
 
-/obj/effect/landmark/survivor_spawner/lv624_skylight
-	intro_text = list("<h2>You are a survivor!</h2>",\
-	"<span class='notice'>You are a survivor of the attack on the colony. You worked or lived in the archaeology colony, and managed to avoid the alien attacks...until now.</span>",\
-	"<span class='notice'>You are fully aware of the xenomorph threat and are able to use this knowledge as you see fit.</span>",\
-	"<span class='danger'>Your primary objective is to heal up and survive until marines rescue you. If you want to assault the hive - adminhelp.</span>")
-	story_text = "You with a small group made a run for the caves after an attack on the colony. Unfortunately during the escape you all got ambushed by one of the xenomorphs. Limping away, you and your friends found a shelter in the caves, in a place with a nice skylight above. You mustered a defence, ignoring wounds that creature dealt to you. It will be a good idea to heal up, before you attempt anything."
-	roundstart_damage_min = 3
-	roundstart_damage_max = 10
-	roundstart_damage_times = 3
-
-	spawn_priority = SPAWN_PRIORITY_VERY_HIGH
-
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf
 	equipment = /datum/equipment_preset/survivor/clf
 	synth_equipment = /datum/equipment_preset/clf/synth

--- a/maps/map_files/LV624/standalone/laststand.dmm
+++ b/maps/map_files/LV624/standalone/laststand.dmm
@@ -145,10 +145,6 @@
 /obj/structure/bed/chair/wood/normal,
 /turf/open/floor/wood,
 /area/lv624/ground/caves/north_central_caves)
-"aH" = (
-/obj/effect/landmark/survivor_spawner/lv624_skylight,
-/turf/open/floor/wood,
-/area/lv624/ground/caves/north_central_caves)
 "aI" = (
 /obj/structure/bed/chair/wheelchair,
 /turf/open/floor/wood,
@@ -170,7 +166,6 @@
 /area/lv624/ground/caves/north_central_caves)
 "aM" = (
 /obj/structure/bed/alien,
-/obj/effect/landmark/survivor_spawner/lv624_skylight,
 /turf/open/floor/wood,
 /area/lv624/ground/caves/north_central_caves)
 "aN" = (
@@ -272,12 +267,6 @@
 /obj/item/ammo_magazine/rifle/m41aMK1,
 /turf/open/floor/wood,
 /area/lv624/ground/caves/north_central_caves)
-"hY" = (
-/obj/effect/landmark/survivor_spawner/lv624_skylight,
-/turf/open/floor/wood{
-	icon_state = "wood-broken4"
-	},
-/area/lv624/ground/caves/north_central_caves)
 "jP" = (
 /obj/item/weapon/gun/rifle/m41aMK1,
 /obj/item/ammo_magazine/rifle/m41aMK1,
@@ -363,12 +352,6 @@
 /obj/structure/barricade/plasteel/wired,
 /turf/open/floor/wood,
 /area/lv624/ground/caves/north_central_caves)
-"En" = (
-/obj/effect/landmark/survivor_spawner/lv624_skylight,
-/turf/open/floor/wood{
-	icon_state = "wood-broken"
-	},
-/area/lv624/ground/caves/north_central_caves)
 "EY" = (
 /obj/structure/surface/table/woodentable/poor,
 /obj/item/ammo_magazine/shotgun/buckshot,
@@ -380,11 +363,6 @@
 /obj/structure/bed/chair/wood/normal{
 	dir = 1
 	},
-/turf/open/floor/wood,
-/area/lv624/ground/caves/north_central_caves)
-"KK" = (
-/obj/effect/decal/cleanable/blood/drip,
-/obj/effect/landmark/survivor_spawner/lv624_skylight,
 /turf/open/floor/wood,
 /area/lv624/ground/caves/north_central_caves)
 "Lu" = (
@@ -407,13 +385,6 @@
 	icon_state = "wood-broken6"
 	},
 /area/lv624/ground/caves/north_central_caves)
-"OB" = (
-/obj/effect/decal/cleanable/blood/drip,
-/obj/effect/landmark/survivor_spawner/lv624_skylight,
-/turf/open/floor/wood{
-	icon_state = "wood-broken6"
-	},
-/area/lv624/ground/caves/north_central_caves)
 "OT" = (
 /obj/structure/kitchenspike,
 /obj/effect/decal/cleanable/blood,
@@ -430,7 +401,6 @@
 "UM" = (
 /obj/structure/bed/alien,
 /obj/structure/barricade/sandbags/wired,
-/obj/effect/landmark/survivor_spawner/lv624_skylight,
 /turf/open/floor/wood,
 /area/lv624/ground/caves/north_central_caves)
 "Yc" = (
@@ -483,7 +453,7 @@ aa
 ah
 ao
 bf
-hY
+aC
 bf
 lP
 ah
@@ -541,7 +511,7 @@ aZ
 (9,1,1) = {"
 ah
 ae
-aH
+bf
 aP
 bf
 bb
@@ -556,7 +526,7 @@ ac
 bf
 bf
 bf
-OB
+bc
 oj
 bf
 bf
@@ -606,7 +576,7 @@ aG
 aR
 at
 Ic
-KK
+aV
 aA
 aZ
 "}
@@ -649,9 +619,9 @@ ah
 (18,1,1) = {"
 ah
 Yc
-En
+ak
 bf
-KK
+aV
 jQ
 bc
 bf


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Removes surv spawns at LV624 lake house.

# Explain why it's good for the game

It's just surv grief to be forced to spawn back there. Survivor should be difficult and unfair but not almost impossible.


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
del: Removes surv spawns at LV624 lake house
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
