### PR TITLE
Fixes ASRS attempting to buy non-existant L42A ammo crates, bugging it out

### DIFF
--- a/code/datums/ASRS.dm
+++ b/code/datums/ASRS.dm
@@ -54,12 +54,13 @@
 	buyable = 0
 	group = "ASRS"
 
-/datum/supply_packs/ammo_l42_mag_box/asrs
+/datum/supply_packs/ammo_m4ra_mag_box/asrs
 	buyable = 0
 	group = "ASRS"
 	cost = ASRS_VERY_LOW_WEIGHT
 
 /datum/supply_packs/ammo_l42_mag_box_ap/asrs
+/datum/supply_packs/ammo_m4ra_mag_box_ap/asrs
 	buyable = 0
 	group = "ASRS"
 

--- a/code/datums/ASRS.dm
+++ b/code/datums/ASRS.dm
@@ -59,7 +59,6 @@
 	group = "ASRS"
 	cost = ASRS_VERY_LOW_WEIGHT
 
-/datum/supply_packs/ammo_l42_mag_box_ap/asrs
 /datum/supply_packs/ammo_m4ra_mag_box_ap/asrs
 	buyable = 0
 	group = "ASRS"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request
Apparently whoever made M4RA forgot to replace the ASRS L42 definitions, resulting in it bugging out and spawning in "basic supply pack" which only spawns a paper
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Funny oversight + M4RA ammo should actually spawn in ASRS now
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl: Totalepicness
fix: Fixed an oversight that resulted in ASRS attempting to spawn in deprecated L42A ammo crates, causing it to spawn nothing.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
