### PR TITLE
LV522 Changes: Edits to LZ1 adding short fog along with removal of redundent area and addition of W-Y Vault

### DIFF
--- a/code/modules/gear_presets/forcon_survivors.dm
+++ b/code/modules/gear_presets/forcon_survivors.dm
@@ -233,6 +233,7 @@
 	uniform.attach_accessory(H,pin)
 	uniform.attach_accessory(H,patch_forecon)
 	H.equip_to_slot_or_del(uniform, WEAR_BODY)
+	H.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/windbreaker/windbreaker_green(H), WEAR_JACKET)
 	..()
 	H.equip_to_slot_or_del(new /obj/item/storage/belt/gun/mateba/cmateba(H), WEAR_WAIST)
 	H.equip_to_slot_or_del(new /obj/item/weapon/gun/revolver/mateba/cmateba(H), WEAR_R_HAND)

--- a/maps/lv522_chances_claim.json
+++ b/maps/lv522_chances_claim.json
@@ -29,6 +29,7 @@
         "neaera",
         "stok"
     ],
+    "environment_traits": { "Fog": true },
     "traits": [{ "Ground": true }],
     "xvx_hives": {
         "xeno_hive_alpha": 0,

--- a/maps/map_files/LV522_Chances_Claim/LV522_Chances_Claim.dmm
+++ b/maps/map_files/LV522_Chances_Claim/LV522_Chances_Claim.dmm
@@ -238,11 +238,14 @@
 	},
 /area/lv522/indoors/c_block/bridge)
 "ahH" = (
-/obj/structure/prop/dam/truck/cargo{
-	layer = 3.1
+/obj/structure/machinery/door/poddoor/almayer{
+	id = "E_B_Door";
+	name = "\improper Emergency Blast Door";
+	unacidable = 1
 	},
+/obj/structure/blocker/invisible_wall,
 /turf/open/floor/corsat{
-	icon_state = "plate"
+	icon_state = "marked"
 	},
 /area/lv522/atmos/east_reactor/east)
 "ahP" = (
@@ -403,9 +406,10 @@
 /turf/open/floor/plating,
 /area/lv522/indoors/c_block/cargo)
 "ana" = (
-/obj/structure/largecrate/random/barrel/white,
+/obj/structure/pipes/vents/pump,
 /turf/open/floor/corsat{
-	icon_state = "squares"
+	dir = 8;
+	icon_state = "brown"
 	},
 /area/lv522/atmos/east_reactor/east)
 "ann" = (
@@ -1361,7 +1365,9 @@
 /turf/open/auto_turf/shale/layer0,
 /area/lv522/outdoors/nw_rockies)
 "aTK" = (
-/obj/structure/largecrate/random/barrel,
+/obj/structure/prop/dam/truck/cargo{
+	layer = 3.1
+	},
 /turf/open/floor/corsat{
 	icon_state = "squares"
 	},
@@ -1433,10 +1439,11 @@
 	},
 /area/lv522/atmos/east_reactor/north)
 "aVs" = (
-/turf/open/asphalt/cement{
-	icon_state = "cement14"
+/obj/structure/cargo_container/horizontal/blue/top,
+/turf/open/floor/corsat{
+	icon_state = "squares"
 	},
-/area/lv522/outdoors/nw_rockies)
+/area/lv522/atmos/east_reactor/east)
 "aVt" = (
 /obj/item/pamphlet/skill/powerloader,
 /obj/structure/surface/table/almayer,
@@ -3972,8 +3979,8 @@
 /obj/effect/decal/warning_stripes{
 	icon_state = "SW-out"
 	},
-/turf/open/auto_turf/shale/layer0,
-/area/lv522/outdoors/nw_rockies)
+/turf/closed/wall/strata_ice/dirty,
+/area/lv522/oob)
 "cte" = (
 /obj/structure/stairs/perspective{
 	dir = 8;
@@ -4259,14 +4266,9 @@
 	},
 /area/lv522/indoors/c_block/casino)
 "cAy" = (
-/obj/structure/machinery/door/poddoor/almayer{
-	id = "E_B_Door";
-	name = "\improper Emergency Blast Door";
-	unacidable = 1
-	},
-/obj/structure/blocker/invisible_wall,
+/obj/structure/cargo_container/horizontal/blue/middle,
 /turf/open/floor/corsat{
-	icon_state = "marked"
+	icon_state = "squares"
 	},
 /area/lv522/atmos/east_reactor/east)
 "cAW" = (
@@ -4581,11 +4583,9 @@
 /turf/open/floor/corsat,
 /area/lv522/atmos/east_reactor)
 "cIs" = (
-/obj/structure/prop/invuln/overhead/flammable_pipe/fly{
-	icon_state = "flammable_pipe_2"
-	},
+/obj/structure/cargo_container/horizontal/blue/bottom,
 /turf/open/floor/corsat{
-	icon_state = "plate"
+	icon_state = "squares"
 	},
 /area/lv522/atmos/east_reactor/east)
 "cIA" = (
@@ -4600,11 +4600,13 @@
 /turf/open/floor/prison,
 /area/lv522/indoors/c_block/garage)
 "cIC" = (
-/obj/structure/pipes/vents/pump,
-/turf/open/floor/corsat{
-	icon_state = "plate"
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
 	},
-/area/lv522/atmos/east_reactor/east)
+/turf/open/floor/corsat{
+	icon_state = "brown"
+	},
+/area/lv522/atmos/cargo_intake)
 "cIQ" = (
 /obj/structure/surface/table/almayer,
 /obj/item/trash/plate{
@@ -4758,14 +4760,7 @@
 	},
 /area/lv522/indoors/a_block/security)
 "cKG" = (
-/obj/structure/fence,
-/obj/effect/decal/warning_stripes{
-	icon_state = "W"
-	},
-/turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
-	},
+/turf/closed/wall/strata_ice/dirty,
 /area/lv522/outdoors/nw_rockies)
 "cKQ" = (
 /obj/effect/decal/cleanable/blood/oil/streak,
@@ -4885,9 +4880,11 @@
 /turf/open/floor/corsat,
 /area/lv522/atmos/east_reactor)
 "cNQ" = (
-/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
-/turf/closed/wall/mineral/bone_resin,
-/area/lv522/oob)
+/turf/open/floor/corsat{
+	dir = 8;
+	icon_state = "browncorner"
+	},
+/area/lv522/atmos/filt)
 "cNU" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
@@ -4920,27 +4917,24 @@
 /turf/open/auto_turf/shale/layer0,
 /area/lv522/outdoors/nw_rockies)
 "cPx" = (
-/obj/structure/prop/invuln/overhead/flammable_pipe/fly{
-	dir = 5
-	},
+/obj/structure/blocker/forcefield/vehicles,
 /turf/open/floor/corsat{
-	icon_state = "plate"
+	icon_state = "marked"
 	},
-/area/lv522/atmos/east_reactor/east)
+/area/lv522/atmos/filt)
 "cPy" = (
-/obj/structure/prop/invuln/overhead/flammable_pipe/fly{
-	dir = 1
-	},
 /turf/open/floor/corsat{
-	icon_state = "plate"
-	},
-/area/lv522/atmos/east_reactor/east)
-"cPH" = (
-/turf/open/floor/corsat{
-	dir = 9;
+	dir = 10;
 	icon_state = "brown"
 	},
-/area/lv522/atmos/east_reactor/east)
+/area/lv522/atmos/filt)
+"cPH" = (
+/obj/structure/blocker/forcefield/vehicles,
+/turf/open/floor/corsat{
+	dir = 8;
+	icon_state = "brown"
+	},
+/area/lv522/atmos/filt)
 "cPN" = (
 /obj/structure/prop/invuln/overhead/flammable_pipe/fly{
 	dir = 1;
@@ -5236,11 +5230,11 @@
 	},
 /area/lv522/outdoors/colony_streets/north_street)
 "cWc" = (
-/obj/structure/cargo_container/horizontal/blue/top,
+/obj/structure/blocker/forcefield/vehicles,
 /turf/open/floor/corsat{
-	icon_state = "plate"
+	icon_state = "squares"
 	},
-/area/lv522/atmos/east_reactor/east)
+/area/lv522/atmos/filt)
 "cWf" = (
 /turf/open/auto_turf/shale/layer0,
 /area/lv522/atmos/cargo_intake)
@@ -5312,12 +5306,12 @@
 	},
 /area/lv522/indoors/b_block/hydro)
 "cWZ" = (
-/obj/structure/pipes/standard/simple/hidden/green,
+/obj/structure/blocker/forcefield/vehicles,
 /turf/open/floor/corsat{
 	dir = 4;
-	icon_state = "browncorner"
+	icon_state = "brown"
 	},
-/area/lv522/atmos/east_reactor/east)
+/area/lv522/atmos/filt)
 "cXf" = (
 /turf/open/floor/prison{
 	icon_state = "darkbrownfull2";
@@ -5354,11 +5348,9 @@
 	},
 /area/lv522/indoors/a_block/kitchen)
 "cYn" = (
-/turf/open/floor/corsat{
-	dir = 1;
-	icon_state = "brown"
-	},
-/area/lv522/atmos/east_reactor/east)
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
+/turf/open/auto_turf/shale/layer0,
+/area/lv522/outdoors/colony_streets/north_east_street)
 "cYE" = (
 /obj/structure/surface/table/almayer,
 /obj/item/trash/plate{
@@ -5543,12 +5535,11 @@
 	},
 /area/lv522/oob)
 "dbs" = (
-/turf/open/floor/prison{
-	dir = 1;
-	icon_state = "cell_stripe";
-	tag = null
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/corsat{
+	icon_state = "plate"
 	},
-/area/lv522/outdoors/nw_rockies)
+/area/lv522/atmos/filt)
 "dbt" = (
 /obj/item/reagent_container/food/snacks/meat/human,
 /turf/open/floor/corsat{
@@ -6078,10 +6069,7 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/lv522/landing_zone_2/ceiling)
 "dkL" = (
-/obj/structure/cargo_container/horizontal/blue/middle,
-/turf/open/floor/corsat{
-	icon_state = "plate"
-	},
+/turf/closed/wall/r_wall/biodome/biodome_unmeltable,
 /area/lv522/atmos/east_reactor/east)
 "dkP" = (
 /obj/structure/prop/invuln/overhead/flammable_pipe/fly{
@@ -6219,11 +6207,9 @@
 	},
 /area/lv522/indoors/a_block/dorms)
 "dnA" = (
-/turf/open/floor/corsat{
-	dir = 8;
-	icon_state = "brown"
-	},
-/area/lv522/oob)
+/obj/structure/girder,
+/turf/open/auto_turf/shale/layer0,
+/area/lv522/outdoors/colony_streets/north_east_street)
 "dnB" = (
 /obj/item/clothing/head/helmet/marine/pilot,
 /turf/open/floor/corsat{
@@ -7146,11 +7132,10 @@
 /turf/open/floor/corsat,
 /area/lv522/atmos/east_reactor)
 "dJt" = (
-/obj/structure/cargo_container/horizontal/blue/bottom,
-/turf/open/floor/corsat{
-	icon_state = "plate"
-	},
-/area/lv522/atmos/east_reactor/east)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/girder,
+/turf/open/auto_turf/shale/layer0,
+/area/lv522/outdoors/colony_streets/north_east_street)
 "dJB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/surface/table/reinforced/prison,
@@ -9178,12 +9163,9 @@
 	},
 /area/lv522/atmos/east_reactor)
 "eCe" = (
-/obj/structure/pipes/standard/simple/hidden/green,
-/turf/open/floor/corsat{
-	dir = 5;
-	icon_state = "brown"
-	},
-/area/lv522/atmos/east_reactor/east)
+/obj/effect/alien/resin/sticky,
+/turf/open/auto_turf/shale/layer0,
+/area/lv522/outdoors/colony_streets/north_east_street)
 "eCO" = (
 /obj/structure/largecrate/random,
 /obj/effect/decal/warning_stripes{
@@ -13033,11 +13015,9 @@
 	},
 /area/lv522/outdoors/colony_streets/south_west_street)
 "gpM" = (
-/obj/effect/decal/cleanable/blood/drip,
-/turf/open/floor/corsat{
-	icon_state = "plate"
-	},
-/area/lv522/oob)
+/obj/structure/girder/displaced,
+/turf/open/auto_turf/shale/layer0,
+/area/lv522/outdoors/colony_streets/north_east_street)
 "gpN" = (
 /obj/effect/spawner/gibspawner/xeno,
 /turf/open/auto_turf/shale/layer1,
@@ -14124,14 +14104,9 @@
 /turf/open/floor/prison,
 /area/lv522/indoors/c_block/cargo)
 "gOX" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "S"
-	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "W"
-	},
+/obj/structure/girder/reinforced,
 /turf/open/auto_turf/shale/layer0,
-/area/lv522/outdoors/nw_rockies)
+/area/lv522/outdoors/colony_streets/north_east_street)
 "gOZ" = (
 /obj/structure/platform_decoration{
 	dir = 8
@@ -14217,13 +14192,12 @@
 /turf/open/floor/prison,
 /area/lv522/indoors/c_block/mining)
 "gRj" = (
-/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
-/obj/structure/prop/turbine_extras,
-/obj/structure/prop/invuln/fusion_reactor,
-/turf/open/floor/corsat{
-	icon_state = "plate"
+/obj/structure/platform{
+	dir = 4
 	},
-/area/lv522/atmos/east_reactor)
+/obj/item/prop/colony/used_flare,
+/turf/open/auto_turf/shale/layer0,
+/area/lv522/outdoors/colony_streets/north_east_street)
 "gRp" = (
 /obj/structure/machinery/floodlight/landing,
 /turf/open/floor/prison{
@@ -15028,11 +15002,6 @@
 	icon_state = "greenfull"
 	},
 /area/lv522/indoors/b_block/bridge)
-"hfY" = (
-/turf/open/floor/corsat{
-	icon_state = "marked"
-	},
-/area/lv522/oob)
 "hgo" = (
 /obj/structure/stairs/perspective{
 	dir = 9;
@@ -18027,13 +17996,6 @@
 	icon_state = "plate"
 	},
 /area/lv522/atmos/cargo_intake)
-"isv" = (
-/obj/structure/pipes/standard/simple/hidden/green,
-/turf/open/floor/corsat{
-	dir = 8;
-	icon_state = "browncorner"
-	},
-/area/lv522/atmos/east_reactor/east)
 "isA" = (
 /obj/structure/window/framed/strata/reinforced,
 /obj/structure/machinery/door/poddoor/shutters/almayer{
@@ -25472,9 +25434,6 @@
 	},
 /turf/open/auto_turf/shale/layer1,
 /area/lv522/outdoors/nw_rockies)
-"llZ" = (
-/turf/closed/wall/r_wall/biodome/biodome_unmeltable,
-/area/lv522/atmos/outdoor)
 "lmo" = (
 /obj/structure/bed/chair/comfy{
 	dir = 8
@@ -25612,12 +25571,6 @@
 	icon_state = "brown"
 	},
 /area/lv522/atmos/filt)
-"lnW" = (
-/obj/structure/surface/table/almayer,
-/turf/open/floor/corsat{
-	icon_state = "plate"
-	},
-/area/lv522/oob)
 "lot" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
@@ -25684,9 +25637,8 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/lv522/indoors/a_block/security/glass)
 "lqb" = (
-/obj/structure/girder/reinforced,
 /obj/structure/blocker/forcefield/vehicles,
-/turf/open/floor/corsat,
+/turf/closed/wall/r_wall/biodome/biodome_unmeltable,
 /area/lv522/atmos/cargo_intake)
 "lqL" = (
 /obj/structure/pipes/standard/simple/hidden/green,
@@ -26521,12 +26473,6 @@
 	icon_state = "greenfull"
 	},
 /area/lv522/landing_zone_1/ceiling)
-"lJV" = (
-/turf/open/floor/corsat{
-	dir = 1;
-	icon_state = "brown"
-	},
-/area/lv522/oob)
 "lKi" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/structure/fence,
@@ -26568,7 +26514,7 @@
 	dir = 1;
 	icon_state = "brown"
 	},
-/area/lv522/oob)
+/area/lv522/atmos/filt)
 "lKF" = (
 /obj/structure/barricade/deployable{
 	dir = 4
@@ -26731,24 +26677,6 @@
 	},
 /turf/open/floor/prison,
 /area/lv522/indoors/a_block/admin)
-"lOw" = (
-/obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
-/turf/open/floor/corsat{
-	icon_state = "plate"
-	},
-/area/lv522/oob)
-"lOB" = (
-/obj/item/clothing/mask/facehugger{
-	desc = "It has some sort of a tube at the end of its tail. What the hell is this thing?";
-	icon_state = "facehugger_impregnated";
-	layer = 3;
-	name = "????";
-	stat = 2
-	},
-/turf/open/floor/corsat{
-	icon_state = "plate"
-	},
-/area/lv522/oob)
 "lPa" = (
 /obj/structure/machinery/optable,
 /obj/structure/pipes/vents/pump,
@@ -27386,7 +27314,7 @@
 "mee" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
 /turf/open/floor/plating/plating_catwalk/prison,
-/area/lv522/oob)
+/area/lv522/atmos/filt)
 "meq" = (
 /turf/open/floor/prison{
 	icon_state = "floor_plate";
@@ -28030,12 +27958,6 @@
 	icon_state = "plate"
 	},
 /area/lv522/atmos/filt)
-"mug" = (
-/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
-/turf/open/floor/corsat{
-	icon_state = "plate"
-	},
-/area/lv522/oob)
 "mum" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 5
@@ -29618,9 +29540,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
 /area/lv522/indoors/c_block/mining)
-"ncN" = (
-/turf/closed/wall/strata_outpost/reinforced,
-/area/lv522/outdoors/colony_streets/north_street)
 "ncS" = (
 /obj/structure/fence,
 /obj/effect/decal/warning_stripes{
@@ -29892,7 +29811,7 @@
 	dir = 4
 	},
 /turf/open/floor/corsat{
-	icon_state = "squares"
+	icon_state = "brown"
 	},
 /area/lv522/atmos/cargo_intake)
 "njd" = (
@@ -30453,8 +30372,8 @@
 /obj/structure/platform{
 	dir = 4
 	},
-/turf/open/gm/river,
-/area/lv522/atmos/filt)
+/turf/closed/wall/mineral/bone_resin,
+/area/lv522/oob)
 "ntS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/machinery/camera/autoname,
@@ -31002,7 +30921,7 @@
 "nJV" = (
 /obj/structure/noticeboard,
 /turf/closed/wall/solaris/reinforced/hull/lv522,
-/area/lv522/outdoors/colony_streets/windbreaker/observation)
+/area/lv522/oob)
 "nKh" = (
 /obj/structure/machinery/camera/autoname{
 	dir = 8
@@ -31387,9 +31306,6 @@
 	icon_state = "darkredfull2"
 	},
 /area/lv522/indoors/a_block/security)
-"nPy" = (
-/turf/closed/wall/solaris/reinforced/hull/lv522,
-/area/lv522/outdoors/colony_streets/north_street)
 "nPL" = (
 /obj/structure/stairs/perspective{
 	dir = 8;
@@ -33368,14 +33284,6 @@
 	tag = null
 	},
 /area/lv522/indoors/lone_buildings/outdoor_bot)
-"oEa" = (
-/obj/structure/largecrate/random,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
-	},
-/area/lv522/outdoors/nw_rockies)
 "oEw" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
@@ -34141,10 +34049,6 @@
 	tag = null
 	},
 /area/lv522/indoors/lone_buildings/storage_blocks)
-"oVe" = (
-/obj/item/prop/colony/used_flare,
-/turf/open/auto_turf/shale/layer0,
-/area/lv522/outdoors/colony_streets/north_east_street)
 "oVk" = (
 /obj/structure/largecrate/random{
 	pixel_x = 1;
@@ -38269,7 +38173,7 @@
 	pixel_x = 4;
 	pixel_y = -3
 	},
-/turf/closed/wall/strata_ice/dirty,
+/turf/closed/wall/solaris/reinforced/hull/lv522,
 /area/lv522/oob)
 "qBR" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/generic{
@@ -39886,7 +39790,7 @@
 	pixel_x = -4;
 	pixel_y = -3
 	},
-/turf/closed/wall/strata_ice/dirty,
+/turf/closed/wall/solaris/reinforced/hull/lv522,
 /area/lv522/oob)
 "rdz" = (
 /obj/structure/surface/table/almayer,
@@ -40805,7 +40709,7 @@
 	pixel_y = 9
 	},
 /obj/item/reagent_container/food/drinks/bottle/sake{
-	pixel_x = 8;
+	pixel_x = -4;
 	pixel_y = 9
 	},
 /turf/open/auto_turf/shale/layer1,
@@ -53519,13 +53423,6 @@
 "wrC" = (
 /turf/closed/wall/strata_outpost,
 /area/lv522/indoors/a_block/corpo)
-"wrQ" = (
-/obj/structure/pipes/standard/simple/hidden/green,
-/turf/open/floor/corsat{
-	dir = 4;
-	icon_state = "brown"
-	},
-/area/lv522/atmos/cargo_intake)
 "wrY" = (
 /obj/structure/platform,
 /turf/open/asphalt/cement,
@@ -55206,15 +55103,6 @@
 /obj/structure/bed/sofa/south/grey/right,
 /turf/open/floor/prison,
 /area/lv522/indoors/a_block/dorms)
-"xeD" = (
-/obj/structure/pipes/standard/manifold/hidden/green{
-	dir = 1
-	},
-/turf/open/floor/corsat{
-	dir = 4;
-	icon_state = "brown"
-	},
-/area/lv522/atmos/cargo_intake)
 "xeG" = (
 /turf/open/floor/corsat{
 	dir = 1;
@@ -55826,9 +55714,6 @@
 	icon_state = "radiator_tile2"
 	},
 /area/lv522/indoors/c_block/cargo)
-"xrC" = (
-/turf/closed/wall/solaris/reinforced/hull/lv522,
-/area/lv522/outdoors/colony_streets/windbreaker/observation)
 "xrF" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
 /turf/open/floor/corsat{
@@ -56707,9 +56592,6 @@
 /obj/effect/landmark/objective_landmark/close,
 /turf/open/floor/prison,
 /area/lv522/indoors/b_block/hydro)
-"xNq" = (
-/turf/closed/wall/mineral/bone_resin,
-/area/lv522/atmos/outdoor)
 "xNu" = (
 /obj/structure/platform_decoration{
 	dir = 8
@@ -61728,8 +61610,8 @@ uWO
 gEB
 uWO
 uWO
-uWO
-uWO
+cpy
+cpy
 uWO
 uWO
 uWO
@@ -61954,13 +61836,13 @@ vtc
 uWO
 gEB
 lfS
-xXV
-xXV
-xXV
-xXV
-xXV
-aVs
-aTA
+cpy
+cpy
+cpy
+cpy
+uWO
+uWO
+cpy
 bIJ
 ddo
 eaE
@@ -62182,12 +62064,12 @@ xXV
 gJD
 acq
 tiQ
-cKG
-cKG
-bkE
-bkE
-mWc
-aTA
+cpy
+cpy
+cpy
+cpy
+cpy
+cpy
 bIJ
 cQS
 eaE
@@ -62409,12 +62291,12 @@ kxh
 gYM
 kqr
 lqb
-sDS
-dLh
-oEa
-bkE
-mWc
-aTA
+cpy
+cpy
+cpy
+cpy
+cpy
+cpy
 bIJ
 bIJ
 nZF
@@ -62634,15 +62516,15 @@ fTS
 fTS
 fTS
 hkT
-fTS
-oJS
-dbs
-sDS
-oEa
-ncS
-mWc
-csU
-gOX
+bzC
+bzC
+tiQ
+cpy
+cpy
+cpy
+cpy
+cpy
+cpy
 bIJ
 bIJ
 dRn
@@ -62854,23 +62736,23 @@ saC
 saC
 saC
 saC
-cNQ
 saC
 saC
-fTS
+saC
+tKb
 xuU
 hAk
-hkY
-hAk
-lrh
-dbs
-sDS
+kQR
+fTS
+bzC
+cpy
+cKG
 sDS
 ncS
 mWc
-uWO
+cpy
 csU
-bQG
+cpy
 bQG
 bQG
 bQG
@@ -63088,9 +62970,9 @@ hAk
 txs
 xZw
 niU
-xZw
-lrh
-dbs
+fTS
+bzC
+cpy
 sDS
 eqE
 xmj
@@ -63314,10 +63196,10 @@ xeG
 xZw
 oiW
 xZw
-uHn
-oiW
-lrh
-dbs
+cIC
+bzC
+bzC
+tiQ
 sDS
 eqE
 xmj
@@ -63541,10 +63423,10 @@ xeG
 xZw
 xZw
 bgc
-xeD
-wrQ
-nWl
-dbs
+mjs
+nvd
+bzC
+ajm
 sDS
 sDS
 xmj
@@ -63770,8 +63652,8 @@ xZw
 xrA
 hkT
 fTS
-lrh
-dbs
+bzC
+ajm
 sDS
 eqE
 xmj
@@ -64224,7 +64106,7 @@ xZw
 kxm
 hkT
 fTS
-irx
+bzC
 jPI
 sDS
 mGH
@@ -64451,7 +64333,7 @@ xZw
 xrA
 kOE
 lgf
-irx
+bzC
 ajm
 sDS
 eqE
@@ -64678,7 +64560,7 @@ xZw
 xrF
 fTS
 fTS
-irx
+bzC
 sxV
 sDS
 sDS
@@ -65132,7 +65014,7 @@ uQI
 pLj
 kOJ
 lhD
-irx
+bzC
 uzk
 sDS
 eqE
@@ -65359,7 +65241,7 @@ jsD
 tCh
 kOQ
 lhD
-irx
+bzC
 sxV
 sDS
 sDS
@@ -65586,7 +65468,7 @@ mdZ
 tCh
 isu
 lhD
-irx
+bzC
 sxV
 sDS
 eqE
@@ -67587,7 +67469,7 @@ cpy
 cpy
 cpy
 tiQ
-saC
+tiQ
 vAi
 bcP
 ssn
@@ -68268,7 +68150,7 @@ cpy
 cpy
 cpy
 cpy
-tiQ
+cpy
 tiQ
 tiQ
 vAi
@@ -71057,7 +70939,7 @@ yim
 yim
 yim
 yim
-yim
+cpy
 yim
 yim
 yim
@@ -71283,9 +71165,9 @@ pjJ
 pjJ
 yim
 yim
-yim
-yim
-yim
+cpy
+cpy
+cpy
 yim
 yim
 rNM
@@ -71511,7 +71393,7 @@ pjJ
 yim
 yim
 yim
-yim
+cpy
 yim
 yim
 yim
@@ -75364,7 +75246,7 @@ saC
 saC
 saC
 saC
-llZ
+tiQ
 gWI
 gWI
 sQu
@@ -75591,12 +75473,12 @@ xZw
 saC
 saC
 saC
-llZ
-llZ
-xNq
-xNq
-llZ
-llZ
+tiQ
+tiQ
+saC
+saC
+tiQ
+tiQ
 ylm
 pjJ
 pjJ
@@ -76726,7 +76608,7 @@ tiQ
 saC
 saC
 saC
-tiQ
+saC
 saC
 saC
 saC
@@ -76953,9 +76835,9 @@ saC
 saC
 saC
 saC
-tiQ
-tiQ
-cNQ
+saC
+saC
+saC
 saC
 saC
 saC
@@ -77181,8 +77063,8 @@ saC
 saC
 saC
 saC
-tiQ
-tiQ
+saC
+saC
 saC
 saC
 saC
@@ -77409,7 +77291,7 @@ saC
 saC
 saC
 saC
-tiQ
+saC
 saC
 saC
 saC
@@ -77425,7 +77307,7 @@ uKD
 uKD
 uKD
 mwv
-ncN
+uKD
 ugV
 ugV
 ugV
@@ -77637,7 +77519,7 @@ saC
 saC
 saC
 saC
-tiQ
+saC
 saC
 saC
 saC
@@ -77864,7 +77746,7 @@ saC
 saC
 saC
 saC
-tiQ
+saC
 saC
 saC
 saC
@@ -79913,7 +79795,7 @@ saC
 saC
 saC
 iTI
-pjl
+xED
 xED
 xED
 xED
@@ -82195,9 +82077,9 @@ ien
 rxI
 ien
 rxI
-nPy
-nPy
-nPy
+ien
+ien
+ien
 jXQ
 vwi
 vwi
@@ -82622,14 +82504,14 @@ jWr
 qJE
 tiQ
 tiQ
-tiQ
-tiQ
-tiQ
-tiQ
-tiQ
-tiQ
-tiQ
-tiQ
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
 saC
 saC
 saC
@@ -82849,14 +82731,14 @@ mPY
 qJE
 qJE
 tiQ
-tiQ
-tiQ
-tiQ
-tiQ
-tiQ
-tiQ
-tiQ
-tiQ
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
 saC
 saC
 saC
@@ -83077,13 +82959,6 @@ jWr
 qJE
 tiQ
 tiQ
-tiQ
-tiQ
-tiQ
-tiQ
-tiQ
-tiQ
-tiQ
 saC
 saC
 saC
@@ -83098,7 +82973,14 @@ saC
 saC
 saC
 saC
-cpy
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
 saC
 saC
 saC
@@ -83304,13 +83186,6 @@ mMj
 qJE
 qJE
 tiQ
-tiQ
-tiQ
-tiQ
-tiQ
-tiQ
-tiQ
-tiQ
 saC
 saC
 saC
@@ -83325,7 +83200,14 @@ saC
 saC
 saC
 saC
-cpy
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
 saC
 saC
 saC
@@ -83531,13 +83413,6 @@ jef
 jWr
 qJE
 tiQ
-tiQ
-tiQ
-tiQ
-tiQ
-tiQ
-tiQ
-tiQ
 saC
 saC
 saC
@@ -83552,7 +83427,14 @@ saC
 saC
 saC
 saC
-cpy
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
 saC
 saC
 saC
@@ -83759,12 +83641,6 @@ nmX
 qJE
 tiQ
 tiQ
-tiQ
-tiQ
-tiQ
-tiQ
-tiQ
-tiQ
 saC
 saC
 saC
@@ -83778,9 +83654,15 @@ saC
 saC
 saC
 saC
-cpy
-cpy
-cpy
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
 saC
 saC
 saC
@@ -83986,12 +83868,6 @@ nno
 qJE
 qJE
 tiQ
-tiQ
-tiQ
-tiQ
-tiQ
-tiQ
-tiQ
 saC
 saC
 saC
@@ -84005,10 +83881,16 @@ saC
 saC
 saC
 saC
-cpy
-cpy
-cpy
-cpy
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
 saC
 saC
 saC
@@ -84213,12 +84095,6 @@ jef
 pfj
 nwR
 tiQ
-tiQ
-tiQ
-tiQ
-tiQ
-tiQ
-tiQ
 saC
 saC
 saC
@@ -84231,11 +84107,17 @@ saC
 saC
 saC
 saC
-cpy
-cpy
-cpy
-cpy
-cpy
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
 saC
 saC
 saC
@@ -84458,11 +84340,11 @@ saC
 saC
 saC
 saC
-cpy
-cpy
-cpy
-cpy
-cpy
+saC
+saC
+saC
+saC
+saC
 saC
 saC
 ien
@@ -84685,10 +84567,10 @@ saC
 saC
 saC
 saC
-cpy
-cpy
-cpy
-cpy
+saC
+saC
+saC
+saC
 saC
 saC
 saC
@@ -84912,10 +84794,10 @@ saC
 saC
 saC
 saC
-cpy
-cpy
-cpy
-cpy
+saC
+saC
+saC
+saC
 saC
 saC
 saC
@@ -85139,8 +85021,8 @@ saC
 saC
 saC
 saC
-cpy
-cpy
+saC
+saC
 saC
 saC
 saC
@@ -85366,8 +85248,8 @@ saC
 saC
 saC
 saC
-cpy
-cpy
+saC
+saC
 saC
 saC
 saC
@@ -85594,14 +85476,14 @@ saC
 saC
 saC
 saC
-cpy
 saC
 saC
 saC
 saC
 saC
 saC
-xrC
+saC
+ien
 tNQ
 qSH
 qSH
@@ -85826,13 +85708,13 @@ saC
 saC
 saC
 saC
-xrC
-xrC
-xrC
+ien
+ien
+ien
 wPA
 wPA
-xrC
-xrC
+ien
+ien
 pZo
 vGp
 vGp
@@ -86052,14 +85934,14 @@ saC
 saC
 saC
 saC
-xrC
+ien
 nJV
 elX
 hll
 hKu
 ksa
 kOz
-xrC
+ien
 lVZ
 vGp
 vGp
@@ -86279,7 +86161,7 @@ saC
 saC
 saC
 saC
-xrC
+ien
 aJS
 ezo
 eJR
@@ -86506,7 +86388,7 @@ saC
 saC
 saC
 saC
-xrC
+ien
 rgW
 eJR
 gok
@@ -86679,7 +86561,7 @@ fzz
 hwt
 hRy
 ifh
-gRj
+gPQ
 aCQ
 lXC
 lXC
@@ -86740,7 +86622,7 @@ gok
 iJE
 kvM
 kYL
-xrC
+ien
 lYg
 qSH
 qSH
@@ -86965,9 +86847,9 @@ btP
 eJR
 eJR
 iMQ
-xrC
-xrC
-xrC
+ien
+ien
+ien
 pRv
 xSv
 xSv
@@ -87191,8 +87073,8 @@ saC
 bUN
 gjA
 rtX
-xrC
-xrC
+ien
+ien
 vGp
 vGp
 pZo
@@ -87641,7 +87523,7 @@ cpy
 cpy
 cpy
 cpy
-xrC
+ien
 cGd
 rtI
 hKu
@@ -87868,11 +87750,11 @@ cpy
 cpy
 cpy
 cpy
-xrC
+ien
 rhh
 rtX
 xjU
-xrC
+ien
 nff
 oxT
 pgG
@@ -88095,11 +87977,11 @@ cpy
 cpy
 cpy
 ien
-xrC
-xrC
+ien
+ien
 wPA
-xrC
-xrC
+ien
+ien
 qSH
 qSH
 qSH
@@ -88323,10 +88205,10 @@ cpy
 cpy
 cpy
 ien
-lyP
-vGp
-vGp
-vGp
+qSH
+qSH
+qSH
+qSH
 qSH
 qSH
 qSH
@@ -88550,11 +88432,11 @@ saC
 cpy
 cpy
 ien
-vGp
-vGp
-vGp
-vGp
-vGp
+qSH
+qSH
+qSH
+qSH
+qSH
 qSH
 qSH
 umR
@@ -88778,9 +88660,9 @@ saC
 ien
 ien
 ien
-vGp
-vGp
-vGp
+qSH
+qSH
+qSH
 cpy
 qSH
 qSH
@@ -88973,10 +88855,10 @@ mbM
 xUx
 xUx
 pNo
-xSN
+cPx
 mQd
 mZU
-sZq
+saC
 tiQ
 saC
 saC
@@ -89004,10 +88886,10 @@ saC
 saC
 saC
 ien
-vGp
-vGp
-vGp
-vGp
+qSH
+qSH
+qSH
+qSH
 cpy
 cpy
 cpy
@@ -89200,7 +89082,7 @@ mcE
 xUx
 xUx
 pNo
-xSN
+cPx
 mQw
 sZq
 sZq
@@ -89231,9 +89113,9 @@ saC
 saC
 saC
 ien
-lyP
-vGp
-vGp
+qSH
+qSH
+qSH
 cpy
 cpy
 cpy
@@ -89427,13 +89309,13 @@ mdD
 woG
 xWz
 pNo
-xSN
+cPx
 mQw
 sZq
 sZq
-saC
 sZq
-sZq
+saC
+saC
 tiQ
 tiQ
 tiQ
@@ -89449,20 +89331,20 @@ saC
 saC
 saC
 saC
-saC
-saC
-saC
-saC
+qSH
+qSH
+qSH
+cYn
 saC
 saC
 saC
 ien
 ien
 ien
-lyP
-vGp
-vGp
-vGp
+qSH
+qSH
+qSH
+qSH
 cpy
 qSH
 umR
@@ -89661,8 +89543,8 @@ sZq
 sZq
 sZq
 sZq
-sZq
-sZq
+saC
+saC
 tiQ
 tiQ
 saC
@@ -89675,21 +89557,21 @@ saC
 saC
 saC
 saC
-saC
-saC
-saC
-saC
-saC
-saC
-saC
-saC
-saC
-saC
-vGp
-vGp
-vGp
-vGp
-vGp
+cYn
+qSH
+qSH
+qSH
+qSH
+qSH
+qSH
+cYn
+ecq
+qSH
+ecq
+qSH
+qSH
+qSH
+qSH
 qSH
 qSH
 umR
@@ -89890,7 +89772,7 @@ sZq
 sZq
 sZq
 sZq
-sZq
+saC
 tiQ
 tiQ
 saC
@@ -89900,23 +89782,23 @@ saC
 saC
 saC
 saC
-saC
-saC
-saC
-saC
-saC
-saC
-saC
-saC
-saC
-saC
-saC
-lyP
-vGp
-vGp
-vGp
-vGp
-vGp
+qSH
+qSH
+qSH
+qSH
+qSH
+qSH
+qSH
+qSH
+qSH
+qSH
+ecq
+qSH
+ecq
+qSH
+qSH
+qSH
+qSH
 qSH
 qSH
 umR
@@ -90118,7 +90000,6 @@ mZW
 sZq
 sZq
 sZq
-sZq
 saC
 saC
 saC
@@ -90128,21 +90009,22 @@ saC
 saC
 saC
 saC
-saC
-saC
-saC
-saC
-saC
-saC
-saC
-saC
-saC
-saC
-vGp
-vGp
-vGp
-vGp
-vGp
+qSH
+qSH
+qSH
+qSH
+qSH
+qSH
+qSH
+qSH
+qSH
+qSH
+ecq
+qSH
+ecq
+qSH
+qSH
+qSH
 qSH
 qSH
 qSH
@@ -90292,9 +90174,9 @@ saC
 saC
 saC
 saC
-tiQ
-cIs
-cPx
+saC
+saC
+saC
 tiQ
 tiQ
 tiQ
@@ -90335,7 +90217,7 @@ mcE
 xUx
 xUx
 saC
-xSN
+cPx
 mQw
 mZW
 sZq
@@ -90353,23 +90235,23 @@ saC
 saC
 saC
 saC
-saC
-saC
-saC
-saC
-saC
-saC
-saC
-saC
-saC
-saC
-saC
-lyP
-vGp
-vGp
-vGp
-vGp
-lyP
+cYn
+qSH
+qSH
+qSH
+qSH
+qSH
+qSH
+qSH
+qSH
+qSH
+qSH
+ecq
+qSH
+ecq
+qSH
+qSH
+qSH
 cpy
 qSH
 qSH
@@ -90519,13 +90401,13 @@ saC
 saC
 saC
 saC
-cAy
-uMP
-cPy
-cWc
+saC
+saC
+saC
+saC
 dkL
-dJt
-ahH
+uMP
+uMP
 jEu
 oSX
 oSX
@@ -90562,7 +90444,7 @@ mcE
 xUx
 xUx
 pNo
-xSN
+cPx
 mQw
 mZW
 mZW
@@ -90580,20 +90462,20 @@ tiQ
 saC
 saC
 saC
+qSH
+qSH
+qSH
+qSH
+cYn
 saC
 saC
-saC
-saC
-saC
-saC
-saC
-saC
-saC
-saC
-saC
-saC
-saC
-saC
+qSH
+qSH
+qSH
+qSH
+ien
+ien
+ien
 vTx
 vTx
 cpy
@@ -90746,14 +90628,14 @@ saC
 saC
 saC
 saC
-cAy
-uMP
-cPH
-cWL
-cWL
-dJN
-uMP
-uMP
+saC
+saC
+saC
+saC
+ahH
+kca
+kca
+cIV
 uMP
 uMP
 uMP
@@ -90789,7 +90671,7 @@ mdD
 woG
 xUx
 pNo
-xSN
+cPx
 mSl
 mZX
 mZW
@@ -90801,30 +90683,30 @@ sZq
 sZq
 sZq
 sZq
-sZq
+saC
 tiQ
 tiQ
 saC
 saC
 saC
+qSH
+qSH
+qSH
+qSH
 saC
 saC
 saC
 saC
+qSH
+cYn
 saC
 saC
-saC
-saC
-saC
-saC
-saC
-saC
-saC
+ien
 dRL
 dRL
 dRL
-cpy
-cpy
+dRL
+dRL
 dRL
 dEu
 qhA
@@ -90973,15 +90855,15 @@ saC
 saC
 saC
 saC
-cAy
-cIC
-eCe
-cWZ
-hTk
-isv
-dSt
-dSt
-dSt
+saC
+saC
+saC
+saC
+ahH
+uMP
+uMP
+cIW
+ana
 dSt
 dSt
 dSt
@@ -91028,17 +90910,17 @@ sZq
 sZq
 sZq
 sZq
-sZq
+saC
 tiQ
 tiQ
 saC
 saC
 saC
-saC
-saC
-saC
-saC
-saC
+qSH
+qSH
+qSH
+qSH
+qSH
 saC
 saC
 saC
@@ -91199,15 +91081,15 @@ saC
 saC
 saC
 saC
-tiQ
-tiQ
-tiQ
-uMP
-cYn
-kca
-kca
-dSy
-kca
+saC
+saC
+saC
+saC
+saC
+dkL
+dkL
+dkL
+dkL
 kca
 kca
 kca
@@ -91256,16 +91138,16 @@ sZq
 nGc
 sZq
 sZq
-sZq
+saC
 tiQ
 tiQ
 saC
 saC
-saC
-saC
-saC
-saC
-saC
+qSH
+qSH
+qSH
+qSH
+cYn
 saC
 saC
 saC
@@ -91426,14 +91308,14 @@ saC
 saC
 saC
 saC
-cpn
+saC
+saC
+saC
+saC
+saC
+ahH
 uMP
 cIV
-uMP
-cYn
-kca
-mNm
-mNm
 mNm
 mNm
 kca
@@ -91443,7 +91325,7 @@ kca
 fmv
 fuf
 tiQ
-fCE
+tiQ
 get
 get
 gXB
@@ -91483,16 +91365,16 @@ sZq
 mZW
 sZq
 sZq
-sZq
-sZq
+saC
+saC
 tiQ
 saC
 saC
-saC
-saC
-saC
-saC
-saC
+qSH
+qSH
+qSH
+qSH
+dnA
 saC
 saC
 saC
@@ -91653,14 +91535,14 @@ saC
 saC
 saC
 saC
-cpn
+saC
+saC
+saC
+saC
+saC
+ahH
 uMP
 cIW
-uMP
-cYn
-kca
-mNm
-mNm
 kca
 kca
 kca
@@ -91669,8 +91551,8 @@ kca
 kca
 kca
 haR
+kca
 tiQ
-fCE
 ggM
 fCE
 tiQ
@@ -91715,10 +91597,10 @@ ntN
 tiQ
 saC
 saC
-saC
-saC
-saC
-saC
+qSH
+qSH
+qSH
+dnA
 saC
 saC
 saC
@@ -91880,23 +91762,23 @@ saC
 saC
 saC
 saC
-tiQ
-tiQ
-tiQ
+saC
+saC
+saC
 tiQ
 cYQ
-cYQ
-cYQ
+dkL
+dkL
 tiQ
 kca
 kca
 kca
-kca
-kca
-kca
+aVs
+cAy
+cIs
 kca
 haR
-tiQ
+kca
 tiQ
 ghr
 tiQ
@@ -91942,10 +91824,10 @@ tiQ
 tiQ
 saC
 saC
-saC
-saC
-saC
-saC
+qSH
+cYn
+dnA
+dnA
 saC
 saC
 saC
@@ -92150,30 +92032,30 @@ xUx
 mdD
 woG
 xUx
-saC
-saC
-tiQ
-akM
-saC
-tiQ
-saC
-vrV
-vrV
-vrV
-vrV
-vrV
-vrV
-vrV
-vrV
-tiQ
-tiQ
+cNQ
+cPy
 tiQ
 saC
 saC
+tiQ
+xSN
+xSN
+xSN
+xSN
+xSN
+xSN
+xSN
+xSN
+xSN
+tiQ
+tiQ
+tiQ
 saC
-saC
-saC
-saC
+dnA
+dnA
+gpM
+eCe
+gOX
 saC
 saC
 saC
@@ -92378,30 +92260,30 @@ mdD
 woG
 xUx
 xUx
-saC
+cNQ
+cPH
+rza
+rza
+rza
+rza
+rza
+rza
+rza
+rza
+rza
+rza
+rza
+rza
 ybd
-dnA
 saC
 saC
 saC
 saC
-dnA
-dnA
-dnA
-dnA
-dnA
-dnA
-dnA
-hfY
-ybd
-saC
-saC
-saC
-saC
-saC
-saC
-saC
-saC
+dJt
+eCe
+cYn
+eCe
+eCe
 saC
 saC
 saC
@@ -92569,7 +92451,7 @@ vEw
 dXN
 dKM
 cYQ
-ana
+kca
 mNm
 mNm
 kca
@@ -92606,29 +92488,29 @@ mua
 woG
 xUx
 xUx
+cWc
+xUx
+xUx
+xUx
+xUx
+xUx
+xUx
+xUx
+xUx
+xUx
+xUx
+xUx
+xUx
 ybd
-xcU
-xcU
-xcU
-xcU
-xcU
-xcU
-xcU
-xcU
-xcU
-xcU
-xcU
-xcU
-hfY
-ybd
 saC
 saC
 saC
 saC
-saC
-saC
-saC
-saC
+eCe
+eCe
+qSH
+qSH
+eCe
 saC
 saC
 saC
@@ -92796,7 +92678,7 @@ tiQ
 tiQ
 dKO
 cYQ
-aTK
+kca
 mNm
 mNm
 mNm
@@ -92833,30 +92715,30 @@ xUx
 xUx
 woG
 woG
+cWc
+xUx
+xUx
+woG
+woG
+woG
+xUx
+xUx
+xUx
+woG
+woG
+woG
+mHP
 ybd
-xcU
-xcU
-akM
-akM
-akM
-xcU
-xcU
-xcU
-akM
-akM
-akM
-gpM
-hfY
-ybd
 saC
 saC
 saC
 saC
 saC
-saC
-saC
-saC
-saC
+eCe
+qSH
+qSH
+qSH
+eCe
 saC
 saC
 saC
@@ -93025,7 +92907,7 @@ tiQ
 tiQ
 tiQ
 tiQ
-kca
+aTK
 kca
 kca
 mNm
@@ -93060,31 +92942,31 @@ saC
 xUx
 woG
 woG
+cWc
+xUx
+xUx
+woG
+woG
+woG
+xUx
+xUx
+xUx
+woG
+woG
+woG
+xUx
 ybd
-xcU
-xcU
-akM
-akM
-akM
-xcU
-xcU
-xcU
-akM
-akM
-akM
-xcU
-hfY
-ybd
 saC
 saC
 saC
 saC
 saC
-saC
-saC
-saC
-saC
-saC
+qSH
+qSH
+qSH
+qSH
+cYn
+eCe
 saC
 saC
 saC
@@ -93093,8 +92975,8 @@ saC
 dRL
 dRL
 dRL
-xFp
-xFp
+dRL
+dRL
 dRL
 dEu
 qhA
@@ -93287,21 +93169,31 @@ xUx
 woG
 xUx
 xUx
+cWc
+xUx
+xUx
+xUx
+xUx
+xUx
+mHP
+xUx
+xUx
+xUx
+xUx
+dbs
+xWz
 ybd
-xcU
-xcU
-xcU
-xcU
-xcU
-gpM
-xcU
-xcU
-xcU
-xcU
-xcU
-mug
-hfY
-ybd
+saC
+saC
+saC
+saC
+saC
+qSH
+qSH
+qSH
+qSH
+qSH
+eCe
 saC
 saC
 saC
@@ -93309,19 +93201,9 @@ saC
 saC
 saC
 saC
-saC
-saC
-saC
-saC
-saC
-saC
-saC
-saC
-saC
-saC
-dHF
-dHF
-dHF
+ien
+ien
+ien
 dHF
 dHF
 dHF
@@ -93514,21 +93396,30 @@ woG
 xUx
 xUx
 mEg
+cWZ
+aCJ
+aCJ
+aCJ
+aCJ
+aCJ
+aCJ
+aCJ
+aCJ
+aCJ
+aCJ
+aCJ
+aCJ
 ybd
-dci
-dci
-dci
-dci
-dci
-dci
-dci
-dci
-dci
-dci
-dci
-dci
-hfY
-ybd
+saC
+saC
+bUN
+saC
+saC
+cYn
+qSH
+qSH
+qSH
+qSH
 saC
 saC
 saC
@@ -93538,16 +93429,7 @@ saC
 saC
 saC
 saC
-saC
-saC
-cpy
-saC
-saC
-saC
-saC
-saC
-saC
-saC
+ien
 lyP
 vGp
 vGp
@@ -93745,20 +93627,26 @@ tiQ
 saC
 saC
 tiQ
-saC
-saC
-vrV
-vrV
-vrV
-vrV
-vrV
-vrV
-vrV
+xSN
+xSN
+xSN
+xSN
+xSN
+xSN
+xSN
+xSN
+xSN
 tiQ
 tiQ
 tiQ
 saC
 saC
+bUN
+eCe
+qSH
+qSH
+qSH
+qSH
 saC
 saC
 saC
@@ -93766,18 +93654,12 @@ saC
 saC
 saC
 saC
-cpy
-cpy
 saC
 saC
-saC
-saC
-saC
-saC
-saC
+ien
 mbx
-mRs
 vGp
+mRs
 vGp
 vGp
 vGp
@@ -93960,13 +93842,13 @@ vrV
 vrV
 tiQ
 tiQ
-vrV
-owC
-owC
-owC
-owC
-owC
-vrV
+xSN
+xSN
+xSN
+xSN
+xSN
+xSN
+xSN
 tiQ
 tiQ
 tiQ
@@ -93987,14 +93869,11 @@ saC
 saC
 saC
 saC
-saC
-saC
-saC
-saC
-saC
-saC
-cpy
-saC
+eCe
+cYn
+qSH
+qSH
+qSH
 saC
 saC
 saC
@@ -94002,7 +93881,10 @@ saC
 saC
 saC
 saC
-lyP
+saC
+ien
+ien
+ien
 lyP
 gpN
 vGp
@@ -94187,13 +94069,13 @@ kbM
 jGm
 mPz
 tiQ
-lnW
-lJV
-xcU
-xcU
-mug
-xcU
-pYP
+iIt
+lFt
+xUx
+xUx
+xWz
+xUx
+pNo
 tiQ
 jPw
 jPw
@@ -94214,11 +94096,11 @@ saC
 saC
 saC
 saC
-saC
-saC
-saC
-saC
-saC
+eCe
+eCe
+qSH
+qSH
+qSH
 saC
 saC
 saC
@@ -94414,13 +94296,13 @@ kco
 kti
 kKh
 vrV
-xcU
-lJV
-lOw
-xcU
-xcU
-xcU
-pYP
+iIt
+lFt
+hOH
+xUx
+xUx
+xUx
+pNo
 tiQ
 jPw
 jPw
@@ -94442,10 +94324,10 @@ saC
 saC
 saC
 saC
-saC
-saC
-saC
-saC
+eCe
+qSH
+qSH
+qSH
 saC
 saC
 saC
@@ -94641,13 +94523,13 @@ jPw
 ktp
 kKh
 vrV
-xcU
-lJV
-lOw
+xUx
+lFt
+hOH
 mee
-akM
-xcU
-pYP
+woG
+xUx
+pNo
 tiQ
 jPw
 jPw
@@ -94669,11 +94551,11 @@ saC
 saC
 saC
 saC
-saC
-saC
-saC
-saC
-saC
+qSH
+qSH
+qSH
+cYn
+eCe
 saC
 saC
 saC
@@ -94868,13 +94750,13 @@ jPw
 ktp
 kKh
 vrV
-xcU
-lJV
-xcU
+xUx
+lFt
+xUx
 mee
-akM
-xcU
-pYP
+woG
+xUx
+pNo
 tiQ
 tiQ
 ndP
@@ -94889,21 +94771,21 @@ wbR
 wbR
 wbR
 wbR
-tiQ
+qSH
 saC
 saC
 saC
 saC
 saC
 saC
-saC
+cYn
+qSH
+qSH
+eCe
 cpy
 cpy
 cpy
 cpy
-saC
-saC
-saC
 saC
 saC
 cpy
@@ -95095,14 +94977,14 @@ jPw
 ktp
 kKh
 vrV
-xcU
-lJV
-xcU
-akM
-akM
-xcU
-pYP
-vrV
+xUx
+lFt
+xUx
+woG
+woG
+xUx
+pNo
+xSN
 mUh
 ngo
 wbR
@@ -95115,18 +94997,18 @@ wbR
 wbR
 wbR
 wbR
-tiQ
-tiQ
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
+qSH
+cYn
+saC
+saC
+saC
+saC
+saC
+saC
+eCe
+qSH
+eCe
+eCe
 cpy
 cpy
 cpy
@@ -95322,14 +95204,14 @@ jPw
 ktp
 kKh
 vrV
-xcU
+xUx
 lKC
-xcU
-xcU
-xcU
-xcU
-pYP
-vrV
+xUx
+xUx
+xUx
+xUx
+pNo
+xSN
 mUl
 wbR
 wbR
@@ -95341,19 +95223,19 @@ wbR
 wbR
 wbR
 wbR
-tiQ
-tiQ
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
+qSH
+qSH
+qSH
+saC
+saC
+saC
+saC
+saC
+saC
+eCe
+eCe
+eCe
+uwF
 cpy
 cpy
 cpy
@@ -95365,7 +95247,7 @@ cpy
 ien
 ien
 ien
-vGp
+mRs
 rMR
 qfL
 qxB
@@ -95549,14 +95431,14 @@ jPw
 ktp
 kKh
 vrV
-xcU
-lJV
-lOB
-xcU
-xcU
-lOw
-pYP
-vrV
+xUx
+lFt
+kLs
+xUx
+xUx
+hOH
+pNo
+xSN
 mUl
 wbR
 wbR
@@ -95568,18 +95450,18 @@ wbR
 wbR
 wbR
 wbR
-tiQ
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
+qSH
+qSH
+qSH
+qSH
+saC
+saC
+saC
+saC
+qSH
+qSH
+eCe
+qSH
 cpy
 cpy
 cpy
@@ -95776,14 +95658,14 @@ jPw
 ktp
 kKh
 vrV
-xcU
-lJV
-xcU
-xcU
-lOw
-lOw
-pYP
-vrV
+xUx
+lFt
+xUx
+xUx
+hOH
+hOH
+pNo
+xSN
 mUl
 wbR
 wbR
@@ -95794,19 +95676,19 @@ wbR
 wbR
 wbR
 wbR
-tiQ
-tiQ
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
+qSH
+qSH
+qSH
+qSH
+qSH
+cYn
+saC
+saC
+cYn
+qSH
+qSH
+qSH
+qSH
 cpy
 cpy
 cpy
@@ -95821,11 +95703,11 @@ ien
 poZ
 qSH
 qSH
-oVe
 qSH
 qSH
 qSH
-oVe
+qSH
+qSH
 qSH
 qnb
 krH
@@ -96003,14 +95885,14 @@ kdL
 kwt
 kKh
 vrV
-xcU
-lJV
-xcU
-akM
+xUx
+lFt
+xUx
+woG
 mee
-xcU
-pYP
-vrV
+xUx
+pNo
+xSN
 mUl
 wbR
 wbR
@@ -96020,21 +95902,21 @@ wbR
 wbR
 wbR
 wbR
-tiQ
-tiQ
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
+qSH
+qSH
+qSH
+qSH
+qSH
+qSH
+qSH
+qSH
+qSH
+qSH
+qSH
+qSH
+qSH
+qSH
+cYn
 cpy
 cpy
 cpy
@@ -96052,7 +95934,7 @@ qSH
 qSH
 qSH
 oQC
-lzU
+gRj
 qnb
 krH
 krH
@@ -96230,14 +96112,14 @@ kel
 jJj
 mLp
 vrV
-xcU
-lJV
-xcU
-akM
-akM
-xcU
-pYP
-vrV
+xUx
+lFt
+xUx
+woG
+woG
+xUx
+pNo
+xSN
 mUl
 wbR
 wbR
@@ -96246,21 +96128,21 @@ wbR
 wbR
 wbR
 wbR
-tiQ
-tiQ
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
+cYn
+qSH
+qSH
+qSH
+qSH
+qSH
+qSH
+qSH
+qSH
+qSH
+qSH
+qSH
+qSH
+qSH
+qSH
 cpy
 cpy
 cpy
@@ -96457,14 +96339,14 @@ saC
 yjL
 kJV
 vrV
-xcU
-lJV
-xcU
-akM
-akM
-xcU
-pYP
-vrV
+xUx
+lFt
+xUx
+woG
+woG
+xUx
+pNo
+xSN
 mUl
 wbR
 wbR
@@ -96477,17 +96359,17 @@ tiQ
 cpy
 cpy
 cpy
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
+cYn
+qSH
+qSH
+qSH
+qSH
+qSH
+qSH
+qSH
+qSH
+qSH
+cYn
 cpy
 cpy
 cpy
@@ -96684,14 +96566,14 @@ saC
 yjL
 yjL
 vrV
-xcU
-lJV
-xcU
-xcU
-xcU
-mug
-pYP
-vrV
+xUx
+lFt
+xUx
+xUx
+xUx
+xWz
+pNo
+xSN
 mUl
 nhb
 wbR
@@ -96705,15 +96587,15 @@ cpy
 cpy
 cpy
 cpy
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
+qSH
+qSH
+qSH
+qSH
+cYn
+qSH
+qSH
+qSH
+qSH
 cpy
 cpy
 cpy
@@ -96933,13 +96815,13 @@ cpy
 cpy
 cpy
 cpy
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
+qSH
+qSH
+qSH
+qSH
+qSH
+qSH
+qSH
 cpy
 cpy
 cpy
@@ -97160,13 +97042,13 @@ cpy
 cpy
 cpy
 cpy
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
+cYn
+qSH
+qSH
+qSH
+qSH
+qSH
+qSH
 cpy
 cpy
 cpy
@@ -97389,10 +97271,10 @@ cpy
 cpy
 cpy
 cpy
-cpy
-cpy
-cpy
-cpy
+qSH
+qSH
+qSH
+cYn
 cpy
 cpy
 cpy

--- a/maps/map_files/LV522_Chances_Claim/LV522_Chances_Claim.dmm
+++ b/maps/map_files/LV522_Chances_Claim/LV522_Chances_Claim.dmm
@@ -173,12 +173,13 @@
 /turf/open/floor/prison,
 /area/lv522/indoors/b_block/bridge)
 "afs" = (
-/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
-/obj/structure/pipes/standard/simple/hidden/green,
-/turf/open/floor/corsat{
-	icon_state = "squares"
+/obj/structure/machinery/power/apc/weak{
+	dir = 1
 	},
-/area/lv522/atmos/east_reactor/south/cas)
+/turf/open/floor/corsat{
+	icon_state = "plate"
+	},
+/area/lv522/atmos/filt)
 "aft" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 5
@@ -284,6 +285,7 @@
 	},
 /area/lv522/indoors/b_block/bar)
 "ait" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/gm/river,
 /area/lv522/landing_zone_1/tunnel)
 "aiw" = (
@@ -908,6 +910,7 @@
 	id = "LZ1_Lockdown_Lo";
 	name = "Emergency Lockdown"
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/corsat{
 	icon_state = "marked"
 	},
@@ -1257,6 +1260,15 @@
 	tag = null
 	},
 /area/lv522/indoors/lone_buildings/outdoor_bot)
+"aQH" = (
+/obj/structure/machinery/door/airlock/almayer/maint{
+	dir = 1;
+	welded = 1
+	},
+/turf/open/floor/corsat{
+	icon_state = "marked"
+	},
+/area/lv522/landing_zone_1/tunnel)
 "aQU" = (
 /obj/structure/machinery/door/airlock/almayer/maint,
 /obj/structure/pipes/standard/simple/hidden/green{
@@ -1281,12 +1293,12 @@
 	},
 /area/lv522/indoors/c_block/mining)
 "aRH" = (
-/obj/structure/stairs/perspective{
-	dir = 6;
-	icon_state = "p_stair_full"
+/obj/effect/decal/warning_stripes{
+	icon_state = "SE-out";
+	pixel_x = 1
 	},
-/turf/open/floor/prison,
-/area/lv522/atmos/outdoor)
+/turf/open/auto_turf/shale/layer0,
+/area/lv522/outdoors/nw_rockies)
 "aRM" = (
 /obj/structure/stairs/perspective{
 	dir = 4;
@@ -1343,20 +1355,11 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/lv522/landing_zone_2/ceiling)
 "aTA" = (
-/obj/structure/platform{
-	dir = 1
-	},
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
 	},
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 4
-	},
-/turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
-	},
-/area/lv522/outdoors/colony_streets/north_street)
+/turf/open/auto_turf/shale/layer0,
+/area/lv522/outdoors/nw_rockies)
 "aTK" = (
 /obj/structure/largecrate/random/barrel,
 /turf/open/floor/corsat{
@@ -1776,7 +1779,6 @@
 /area/lv522/outdoors/colony_streets/south_street)
 "bel" = (
 /obj/structure/machinery/computer/crew/colony,
-/obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor/prison{
 	icon_state = "floor_plate";
 	tag = null
@@ -2886,14 +2888,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/lv522/atmos/filt)
-"bOG" = (
-/obj/structure/closet/firecloset/full,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
-	},
-/area/lv522/outdoors/colony_streets/windbreaker/observation)
 "bOM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/pipes/vents/pump,
@@ -3096,14 +3090,9 @@
 	},
 /area/lv522/oob)
 "bUN" = (
-/obj/structure/surface/table/almayer,
-/obj/effect/landmark/objective_landmark/far,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
-	},
-/area/lv522/outdoors/colony_streets/windbreaker/observation)
+/turf/closed/wall/mineral/bone_resin,
+/area/lv522/oob)
 "bUO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/chair{
@@ -3837,6 +3826,14 @@
 	icon_state = "greenfull"
 	},
 /area/lv522/indoors/b_block/hydro)
+"cpU" = (
+/obj/structure/machinery/floodlight/landing,
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "greenfull"
+	},
+/area/lv522/landing_zone_1)
 "cpX" = (
 /obj/item/toy/beach_ball/holoball,
 /obj/item/shard{
@@ -3972,17 +3969,11 @@
 	},
 /area/lv522/atmos/north_command_centre)
 "csU" = (
-/obj/structure/surface/rack,
-/obj/item/stack/sheet/mineral/diamond{
-	amount = 2
+/obj/effect/decal/warning_stripes{
+	icon_state = "SW-out"
 	},
-/obj/effect/landmark/objective_landmark/science,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
-	},
-/area/lv522/atmos/cargo_intake)
+/turf/open/auto_turf/shale/layer0,
+/area/lv522/outdoors/nw_rockies)
 "cte" = (
 /obj/structure/stairs/perspective{
 	dir = 8;
@@ -3994,6 +3985,10 @@
 	tag = null
 	},
 /area/lv522/indoors/a_block/dorms)
+"ctE" = (
+/obj/structure/foamed_metal,
+/turf/open/floor/plating,
+/area/lv522/oob)
 "cuk" = (
 /obj/structure/cargo_container/horizontal/blue/top,
 /turf/open/floor/prison{
@@ -4546,6 +4541,7 @@
 /obj/structure/platform_decoration{
 	dir = 8
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/gm/river,
 /area/lv522/landing_zone_1/tunnel)
 "cIe" = (
@@ -4689,13 +4685,22 @@
 /turf/open/auto_turf/shale/layer0,
 /area/lv522/outdoors/nw_rockies)
 "cJA" = (
-/obj/structure/machinery/door/airlock/almayer/maint{
-	dir = 1
+/obj/structure/pipes/standard/simple/hidden/green,
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 1
 	},
-/turf/open/floor/corsat{
-	icon_state = "marked"
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
 	},
-/area/lv522/indoors/a_block/dorm_north)
+/obj/structure/fence{
+	layer = 2.9
+	},
+/turf/open/floor/strata{
+	dir = 4;
+	icon_state = "floor3"
+	},
+/area/lv522/outdoors/nw_rockies)
 "cJW" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 10
@@ -4835,15 +4840,10 @@
 /area/lv522/atmos/east_reactor)
 "cMq" = (
 /obj/structure/surface/rack,
-/obj/item/stack/sheet/metal{
-	amount = 50;
-	pixel_x = 4;
-	pixel_y = 4
+/obj/item/stack/sheet/mineral/diamond{
+	amount = 2
 	},
-/obj/item/stack/sheet/metal{
-	amount = 30
-	},
-/obj/effect/landmark/objective_landmark/close,
+/obj/effect/landmark/objective_landmark/science,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "floor_marked";
@@ -5478,6 +5478,7 @@
 /area/lv522/oob)
 "das" = (
 /obj/structure/machinery/landinglight/ds1/delaythree,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1)
 "daz" = (
@@ -5659,11 +5660,22 @@
 	},
 /area/lv522/indoors/a_block/admin)
 "ddo" = (
-/obj/structure/blocker/forcefield/vehicles,
-/turf/open/floor/corsat{
-	icon_state = "marked"
+/obj/structure/surface/rack,
+/obj/item/stack/sheet/metal{
+	amount = 50;
+	pixel_x = 4;
+	pixel_y = 4
 	},
-/area/lv522/atmos/east_reactor/south/cas)
+/obj/item/stack/sheet/metal{
+	amount = 30
+	},
+/obj/effect/landmark/objective_landmark/close,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "floor_marked";
+	tag = null
+	},
+/area/lv522/atmos/cargo_intake)
 "ddq" = (
 /obj/structure/surface/rack,
 /obj/item/device/analyzer,
@@ -5771,6 +5783,7 @@
 	icon_state = "E";
 	pixel_x = 1
 	},
+/obj/structure/cargo_container/ferret/right,
 /turf/open/auto_turf/shale/layer0,
 /area/lv522/outdoors/nw_rockies)
 "del" = (
@@ -6206,16 +6219,11 @@
 	},
 /area/lv522/indoors/a_block/dorms)
 "dnA" = (
-/obj/structure/platform,
-/obj/effect/decal/warning_stripes{
-	icon_state = "N";
-	pixel_y = 1
+/turf/open/floor/corsat{
+	dir = 8;
+	icon_state = "brown"
 	},
-/turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
-	},
-/area/lv522/outdoors/colony_streets/north_street)
+/area/lv522/oob)
 "dnB" = (
 /obj/item/clothing/head/helmet/marine/pilot,
 /turf/open/floor/corsat{
@@ -6353,6 +6361,7 @@
 	dir = 4;
 	icon_state = "p_stair_full"
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "drz" = (
@@ -7047,11 +7056,11 @@
 	},
 /area/lv522/outdoors/colony_streets/north_east_street)
 "dHR" = (
-/obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
-/turf/open/floor/corsat{
-	icon_state = "squares"
+/obj/structure/cargo_container/horizontal/blue/top{
+	pixel_x = 16
 	},
-/area/lv522/atmos/east_reactor/south/cas)
+/turf/open/auto_turf/shale/layer0,
+/area/lv522/outdoors/nw_rockies)
 "dIi" = (
 /obj/structure/cargo_container/horizontal/blue/middle,
 /turf/open/floor/prison,
@@ -7152,22 +7161,11 @@
 	},
 /area/lv522/indoors/a_block/medical)
 "dJJ" = (
-/obj/structure/platform_decoration{
-	dir = 1
+/obj/structure/cargo_container/horizontal/blue/middle{
+	pixel_x = 16
 	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "N";
-	pixel_y = 1
-	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "E";
-	pixel_x = 1
-	},
-/turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
-	},
-/area/lv522/outdoors/colony_streets/north_street)
+/turf/open/auto_turf/shale/layer0,
+/area/lv522/outdoors/nw_rockies)
 "dJN" = (
 /turf/open/floor/corsat{
 	dir = 10;
@@ -8298,6 +8296,7 @@
 	pixel_y = -6
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -8421,7 +8420,7 @@
 /area/lv522/outdoors/colony_streets/windbreaker/observation)
 "emb" = (
 /obj/item/ammo_magazine/smartgun{
-	current_rounds = 117
+	current_rounds = 249
 	},
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/lv522/indoors/a_block/dorms)
@@ -8622,6 +8621,7 @@
 /area/lv522/atmos/north_command_centre)
 "epN" = (
 /obj/structure/closet/emcloset,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "epS" = (
@@ -8893,6 +8893,7 @@
 /area/lv522/atmos/east_reactor)
 "ewn" = (
 /obj/structure/platform,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt/cement{
 	icon_state = "cement4"
 	},
@@ -8957,6 +8958,17 @@
 	icon_state = "plate"
 	},
 /area/lv522/atmos/east_reactor)
+"exQ" = (
+/obj/structure/prop/maintenance_hatch{
+	pixel_y = 6
+	},
+/obj/structure/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/barricade/handrail,
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/plating,
+/area/lv522/landing_zone_1/tunnel)
 "exZ" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
 /obj/structure/pipes/standard/simple/hidden/green{
@@ -8988,6 +9000,7 @@
 /area/lv522/outdoors/colony_streets/central_streets)
 "eyy" = (
 /obj/structure/machinery/landinglight/ds1/delaytwo,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1)
 "eyM" = (
@@ -9204,6 +9217,15 @@
 	icon_state = "darkredfull2"
 	},
 /area/lv522/indoors/a_block/kitchen/glass)
+"eDq" = (
+/obj/structure/platform{
+	dir = 1
+	},
+/obj/structure/platform{
+	dir = 4
+	},
+/turf/open/gm/river,
+/area/lv522/outdoors/colony_streets/south_street)
 "eDt" = (
 /obj/vehicle/train/cargo/trolley,
 /obj/effect/landmark/objective_landmark/medium,
@@ -9840,6 +9862,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/lv522/indoors/c_block/cargo)
+"eTu" = (
+/obj/structure/stairs/perspective{
+	icon_state = "p_stair_full"
+	},
+/obj/structure/platform{
+	dir = 4
+	},
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/plating,
+/area/lv522/landing_zone_1/tunnel)
 "eTw" = (
 /obj/structure/stairs/perspective{
 	icon_state = "p_stair_full"
@@ -9847,9 +9879,9 @@
 /obj/structure/platform{
 	dir = 8
 	},
-/obj/structure/machinery/door/poddoor/shutters/almayer/open{
+/obj/structure/machinery/door/poddoor/shutters/almayer{
 	id = "UD6 East";
-	name = "Shutters"
+	indestructible = 1
 	},
 /turf/open/floor/plating,
 /area/lv522/landing_zone_forecon/UD6_Tornado)
@@ -10020,13 +10052,11 @@
 /turf/open/auto_turf/shale/layer1,
 /area/lv522/outdoors/nw_rockies)
 "eXV" = (
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 4
+/obj/structure/cargo_container/horizontal/blue/bottom{
+	pixel_x = 16
 	},
-/turf/open/asphalt/cement{
-	icon_state = "cement12"
-	},
-/area/lv522/outdoors/n_rockies)
+/turf/open/auto_turf/shale/layer0,
+/area/lv522/outdoors/nw_rockies)
 "eYh" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
@@ -10108,6 +10138,7 @@
 	phone_id = "LZ1 Service Tunnel";
 	pixel_y = 24
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "eZY" = (
@@ -10156,11 +10187,11 @@
 /turf/open/floor/grass,
 /area/lv522/indoors/a_block/garden)
 "fbh" = (
-/obj/effect/landmark/xeno_spawn,
-/turf/open/floor/corsat{
-	icon_state = "plate"
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/asphalt/cement{
+	icon_state = "cement1"
 	},
-/area/lv522/atmos/west_reactor)
+/area/lv522/outdoors/colony_streets/south_west_street)
 "fbA" = (
 /obj/structure/prop/invuln/ice_prefab/standalone{
 	icon_state = "white"
@@ -10195,9 +10226,9 @@
 /obj/structure/stairs/perspective{
 	icon_state = "p_stair_full"
 	},
-/obj/structure/machinery/door/poddoor/shutters/almayer/open{
+/obj/structure/machinery/door/poddoor/shutters/almayer{
 	id = "UD6 East";
-	name = "Shutters"
+	indestructible = 1
 	},
 /turf/open/floor/plating,
 /area/lv522/landing_zone_forecon/UD6_Tornado)
@@ -10258,13 +10289,9 @@
 /turf/open/floor/plating,
 /area/shuttle/drop2/lv522)
 "fdE" = (
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 5
-	},
-/turf/open/asphalt/cement{
-	icon_state = "cement12"
-	},
-/area/lv522/outdoors/n_rockies)
+/obj/structure/blocker/invisible_wall,
+/turf/closed/wall/mineral/bone_resin,
+/area/lv522/oob)
 "fdR" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 5
@@ -10871,7 +10898,6 @@
 /obj/structure/bed/chair{
 	dir = 1
 	},
-/obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/lv522/outdoors/colony_streets/windbreaker/observation)
 "ftl" = (
@@ -11078,6 +11104,10 @@
 	icon_state = "marked"
 	},
 /area/lv522/atmos/east_reactor/west)
+"fxZ" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/plating,
+/area/lv522/landing_zone_1/tunnel)
 "fyl" = (
 /obj/structure/pipes/vents/pump,
 /obj/effect/decal/cleanable/dirt,
@@ -11249,6 +11279,7 @@
 /area/lv522/outdoors/colony_streets/east_central_street)
 "fBL" = (
 /obj/structure/machinery/landinglight/ds1,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -11356,6 +11387,7 @@
 /obj/item/tool/pen/blue/clicky,
 /obj/effect/landmark/objective_landmark/close,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -11401,6 +11433,7 @@
 	pixel_x = 5;
 	registered_name = "John Forklift"
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -11546,6 +11579,10 @@
 	icon_state = "blue_plate"
 	},
 /area/lv522/indoors/c_block/mining)
+"fHB" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/asphalt/cement,
+/area/lv522/outdoors/colony_streets/south_west_street)
 "fHC" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 5
@@ -11692,6 +11729,7 @@
 	id = "LZ1_Lockdown_Lo";
 	name = "Emergency Lockdown"
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/corsat{
 	icon_state = "marked"
 	},
@@ -11709,6 +11747,7 @@
 	pixel_x = 8;
 	pixel_y = 12
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "fLP" = (
@@ -11864,10 +11903,11 @@
 /turf/open/floor/prison,
 /area/lv522/indoors/lone_buildings/outdoor_bot)
 "fPt" = (
-/turf/open/floor/corsat{
-	icon_state = "squares"
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/asphalt/cement{
+	icon_state = "cement2"
 	},
-/area/lv522/atmos/east_reactor)
+/area/lv522/outdoors/colony_streets/south_west_street)
 "fPB" = (
 /obj/structure/bed/chair,
 /obj/effect/decal/cleanable/dirt,
@@ -11966,6 +12006,7 @@
 /area/lv522/atmos/east_reactor/east)
 "fSo" = (
 /obj/structure/machinery/landinglight/ds1/delaytwo,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -12235,6 +12276,15 @@
 	tag = null
 	},
 /area/lv522/indoors/c_block/mining)
+"fYD" = (
+/obj/structure/stairs/perspective{
+	icon_state = "p_stair_full"
+	},
+/obj/structure/platform{
+	dir = 4
+	},
+/turf/open/gm/river,
+/area/lv522/landing_zone_1/tunnel)
 "fYP" = (
 /obj/structure/largecrate/random/barrel,
 /turf/open/floor/corsat{
@@ -12434,16 +12484,9 @@
 /turf/open/floor/carpet,
 /area/lv522/indoors/a_block/executive)
 "gcY" = (
-/obj/structure/fence,
-/obj/effect/decal/warning_stripes{
-	icon_state = "E";
-	pixel_x = 1
-	},
-/turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
-	},
-/area/lv522/atmos/outdoor)
+/obj/structure/cargo_container/ferret/left,
+/turf/open/auto_turf/shale/layer0,
+/area/lv522/outdoors/nw_rockies)
 "gdk" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/prop/almayer/computer/PC{
@@ -12487,6 +12530,7 @@
 /area/lv522/atmos/east_reactor/west)
 "gej" = (
 /obj/structure/platform,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt/cement{
 	icon_state = "cement4"
 	},
@@ -12577,9 +12621,14 @@
 	},
 /area/lv522/atmos/east_reactor/east)
 "gfL" = (
-/obj/structure/cryofeed,
-/turf/open/floor/bluegrid,
-/area/lv522/atmos/east_reactor/south/cas)
+/obj/effect/decal/warning_stripes{
+	icon_state = "NE-out";
+	pixel_x = 1;
+	pixel_y = 1
+	},
+/obj/structure/cargo_container/ferret/mid,
+/turf/open/auto_turf/shale/layer0,
+/area/lv522/outdoors/nw_rockies)
 "gfU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/sofa/vert/white/top,
@@ -12632,6 +12681,7 @@
 	},
 /area/lv522/indoors/a_block/hallway)
 "ggS" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -12833,6 +12883,12 @@
 	icon_state = "squares"
 	},
 /area/lv522/atmos/west_reactor)
+"gmu" = (
+/obj/structure/platform{
+	dir = 1
+	},
+/turf/open/gm/river,
+/area/lv522/outdoors/colony_streets/south_street)
 "gnd" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
 /turf/open/floor/corsat{
@@ -12977,10 +13033,11 @@
 	},
 /area/lv522/outdoors/colony_streets/south_west_street)
 "gpM" = (
-/turf/open/asphalt/cement{
-	icon_state = "cement1"
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/corsat{
+	icon_state = "plate"
 	},
-/area/lv522/atmos/outdoor)
+/area/lv522/oob)
 "gpN" = (
 /obj/effect/spawner/gibspawner/xeno,
 /turf/open/auto_turf/shale/layer1,
@@ -13090,8 +13147,9 @@
 /turf/open/auto_turf/shale/layer0,
 /area/lv522/outdoors/colony_streets/north_west_street)
 "gsZ" = (
-/turf/open/asphalt/cement,
-/area/lv522/atmos/outdoor)
+/obj/structure/cargo_container/horizontal/blue/top,
+/turf/open/auto_turf/shale/layer0,
+/area/lv522/outdoors/nw_rockies)
 "gtr" = (
 /obj/structure/machinery/light{
 	dir = 1
@@ -13802,7 +13860,11 @@
 	pixel_x = -6;
 	pixel_y = 6
 	},
-/turf/open/floor/plating,
+/obj/structure/platform{
+	dir = 4
+	},
+/obj/structure/platform,
+/turf/open/gm/river,
 /area/lv522/landing_zone_1/tunnel)
 "gJD" = (
 /obj/structure/pipes/standard/simple/hidden/green{
@@ -13838,6 +13900,7 @@
 	id = "LZ1_Lockdown_Lo";
 	name = "Emergency Lockdown"
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/corsat{
 	icon_state = "marked"
 	},
@@ -13950,6 +14013,11 @@
 	icon_state = "cement4"
 	},
 /area/lv522/outdoors/colony_streets/north_east_street)
+"gMQ" = (
+/turf/open/asphalt/cement{
+	icon_state = "cement9"
+	},
+/area/lv522/outdoors/colony_streets/south_west_street)
 "gMV" = (
 /obj/structure/machinery/light{
 	dir = 1
@@ -14002,11 +14070,9 @@
 	},
 /area/lv522/indoors/b_block/hydro)
 "gOj" = (
-/obj/structure/pipes/standard/simple/hidden/green,
-/turf/open/floor/corsat{
-	icon_state = "squares"
-	},
-/area/lv522/atmos/east_reactor/south/cas)
+/obj/structure/cargo_container/horizontal/blue/middle,
+/turf/open/auto_turf/shale/layer0,
+/area/lv522/outdoors/nw_rockies)
 "gOo" = (
 /obj/structure/prop/invuln/fusion_reactor,
 /obj/structure/prop/turbine_extras,
@@ -14059,7 +14125,10 @@
 /area/lv522/indoors/c_block/cargo)
 "gOX" = (
 /obj/effect/decal/warning_stripes{
-	icon_state = "SW-out"
+	icon_state = "S"
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "W"
 	},
 /turf/open/auto_turf/shale/layer0,
 /area/lv522/outdoors/nw_rockies)
@@ -14121,6 +14190,7 @@
 	pixel_y = 6
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -14399,6 +14469,7 @@
 /obj/structure/machinery/light/small{
 	dir = 4
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "gXc" = (
@@ -14582,6 +14653,7 @@
 /area/lv522/indoors/b_block/bridge)
 "haf" = (
 /obj/structure/machinery/landinglight/ds1,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1)
 "hag" = (
@@ -14601,17 +14673,9 @@
 	},
 /area/lv522/atmos/command_centre)
 "han" = (
-/obj/structure/platform{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "W"
-	},
-/turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
-	},
-/area/lv522/outdoors/colony_streets/north_street)
+/obj/structure/cargo_container/horizontal/blue/bottom,
+/turf/open/auto_turf/shale/layer0,
+/area/lv522/outdoors/nw_rockies)
 "haq" = (
 /turf/open/floor/strata{
 	icon_state = "white_cyan3"
@@ -14965,12 +15029,10 @@
 	},
 /area/lv522/indoors/b_block/bridge)
 "hfY" = (
-/obj/structure/pipes/standard/simple/hidden/green,
-/obj/structure/blocker/forcefield/vehicles,
 /turf/open/floor/corsat{
 	icon_state = "marked"
 	},
-/area/lv522/atmos/east_reactor/south/cas)
+/area/lv522/oob)
 "hgo" = (
 /obj/structure/stairs/perspective{
 	dir = 9;
@@ -15501,7 +15563,7 @@
 /area/lv522/landing_zone_1)
 "hqZ" = (
 /obj/structure/bed/chair/wheelchair,
-/turf/open/auto_turf/shale/layer0,
+/turf/open/auto_turf/shale/layer1,
 /area/lv522/outdoors/colony_streets/north_east_street)
 "hre" = (
 /obj/structure/flora/jungle/planttop1,
@@ -16261,11 +16323,24 @@
 	},
 /area/lv522/indoors/a_block/dorms/glass)
 "hJq" = (
+/obj/structure/fence{
+	layer = 2.9
+	},
 /obj/effect/decal/warning_stripes{
-	icon_state = "SE-out";
+	icon_state = "N";
+	pixel_y = 1
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "E";
 	pixel_x = 1
 	},
-/turf/open/auto_turf/shale/layer0,
+/turf/open/floor/strata{
+	dir = 4;
+	icon_state = "floor3"
+	},
 /area/lv522/outdoors/nw_rockies)
 "hJB" = (
 /turf/open/floor/corsat{
@@ -16761,6 +16836,9 @@
 	tag = null
 	},
 /area/lv522/atmos/command_centre)
+"hTe" = (
+/turf/open/gm/river,
+/area/lv522/landing_zone_1/tunnel)
 "hTg" = (
 /obj/structure/surface/table/almayer,
 /turf/open/floor/corsat{
@@ -16808,6 +16886,7 @@
 /area/lv522/atmos/east_reactor)
 "hTW" = (
 /obj/structure/largecrate/random/secure,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/auto_turf/shale/layer0,
 /area/lv522/landing_zone_1)
 "hTX" = (
@@ -16858,6 +16937,7 @@
 	pixel_x = 7;
 	pixel_y = 7
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "hUY" = (
@@ -17289,24 +17369,22 @@
 	},
 /area/lv522/indoors/a_block/medical)
 "idH" = (
-/obj/structure/platform_decoration{
-	dir = 4
+/obj/structure/fence{
+	layer = 2.9
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 1
 	},
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
 	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "E";
-	pixel_x = 1
+/obj/structure/pipes/standard/simple/hidden/green,
+/turf/open/floor/strata{
+	dir = 4;
+	icon_state = "floor3"
 	},
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 4
-	},
-/turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
-	},
-/area/lv522/outdoors/colony_streets/north_street)
+/area/lv522/outdoors/nw_rockies)
 "idL" = (
 /turf/closed/wall/shiva/prefabricated/reinforced/hull,
 /area/lv522/oob)
@@ -17604,6 +17682,7 @@
 /area/lv522/indoors/c_block/mining)
 "ikb" = (
 /obj/structure/surface/rack,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "ikr" = (
@@ -17734,6 +17813,7 @@
 	pixel_y = 6
 	},
 /obj/item/tool/pen/blue/clicky,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -17757,30 +17837,13 @@
 	},
 /area/lv522/outdoors/n_rockies)
 "iod" = (
-/obj/structure/pipes/standard/simple/hidden/green,
-/turf/open/floor/corsat{
-	dir = 1;
-	icon_state = "brown"
-	},
-/area/lv522/atmos/east_reactor/south/cas)
+/obj/structure/cargo_container/ferret/mid,
+/turf/open/auto_turf/shale/layer0,
+/area/lv522/outdoors/nw_rockies)
 "ioA" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "S"
-	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "W"
-	},
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 4
-	},
-/turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
-	},
-/area/lv522/outdoors/colony_streets/north_street)
+/obj/structure/cargo_container/ferret/right,
+/turf/open/auto_turf/shale/layer0,
+/area/lv522/outdoors/nw_rockies)
 "ioD" = (
 /obj/structure/prop/structure_lattice,
 /obj/structure/platform,
@@ -17921,6 +17984,13 @@
 	icon_state = "wood"
 	},
 /area/lv522/indoors/b_block/bar)
+"irR" = (
+/obj/structure/platform_decoration{
+	dir = 4
+	},
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/asphalt/cement,
+/area/lv522/outdoors/colony_streets/south_west_street)
 "isa" = (
 /obj/structure/largecrate,
 /turf/open/auto_turf/shale/layer1,
@@ -18111,6 +18181,7 @@
 /obj/structure/machinery/light/small{
 	dir = 1
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "ivj" = (
@@ -18678,7 +18749,6 @@
 /area/lv522/indoors/c_block/mining)
 "iHD" = (
 /obj/item/prop/alien/hugger,
-/obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor/prison,
 /area/lv522/outdoors/colony_streets/windbreaker/observation)
 "iIa" = (
@@ -18692,6 +18762,7 @@
 	pixel_x = -6;
 	pixel_y = 6
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "iIs" = (
@@ -19195,11 +19266,10 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/lv522/indoors/a_block/admin)
 "iTI" = (
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 4
-	},
-/turf/open/floor/corsat,
-/area/lv522/atmos/outdoor)
+/obj/effect/landmark/lv624/fog_blocker/short,
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/closed/wall/mineral/bone_resin,
+/area/lv522/oob)
 "iTS" = (
 /obj/structure/prop/invuln/ice_prefab{
 	dir = 10
@@ -19501,14 +19571,17 @@
 /turf/open/floor/corsat,
 /area/lv522/atmos/east_reactor)
 "iZS" = (
-/obj/structure/cargo_container/wy/mid{
-	layer = 3.3;
-	unacidable = 0
+/obj/structure/safe{
+	spawnkey = 0
 	},
-/turf/open/asphalt/cement{
-	icon_state = "cement12"
+/obj/item/stack/sheet/mineral/gold{
+	amount = 60
 	},
-/area/lv522/outdoors/n_rockies)
+/turf/open/floor/strata{
+	dir = 4;
+	icon_state = "white_cyan1"
+	},
+/area/lv522/oob)
 "jab" = (
 /obj/structure/window/framed/strata/reinforced,
 /turf/open/floor/corsat{
@@ -19577,6 +19650,16 @@
 	icon_state = "kitchen"
 	},
 /area/lv522/indoors/a_block/fitness)
+"jba" = (
+/obj/structure/stairs/perspective{
+	dir = 1;
+	icon_state = "p_stair_full"
+	},
+/obj/structure/platform{
+	dir = 8
+	},
+/turf/open/gm/river,
+/area/lv522/landing_zone_1/tunnel)
 "jbd" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
@@ -19595,11 +19678,17 @@
 	},
 /area/lv522/indoors/c_block/cargo)
 "jbn" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "S"
+/obj/structure/safe,
+/obj/item/spacecash/c1000,
+/obj/item/spacecash/c1000,
+/obj/item/spacecash/c1000,
+/obj/item/spacecash/c1000,
+/obj/item/spacecash/c1000,
+/turf/open/floor/strata{
+	dir = 4;
+	icon_state = "white_cyan1"
 	},
-/turf/open/auto_turf/shale/layer0,
-/area/lv522/outdoors/nw_rockies)
+/area/lv522/oob)
 "jbs" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor/corsat{
@@ -19979,8 +20068,20 @@
 /turf/open/floor/carpet,
 /area/lv522/indoors/a_block/executive)
 "jiW" = (
-/obj/effect/spawner/gibspawner/xeno,
-/turf/open/auto_turf/shale/layer1,
+/obj/structure/fence{
+	layer = 2.9
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 1
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
+	},
+/turf/open/floor/strata{
+	dir = 4;
+	icon_state = "floor3"
+	},
 /area/lv522/outdoors/nw_rockies)
 "jiY" = (
 /obj/effect/decal/cleanable/blood/oil,
@@ -20087,6 +20188,13 @@
 "jkp" = (
 /obj/structure/fence{
 	layer = 2.9
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 1
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
 	},
 /turf/open/floor/strata{
 	dir = 4;
@@ -20704,6 +20812,7 @@
 /area/lv522/landing_zone_2)
 "jxF" = (
 /obj/structure/largecrate/guns/russian,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "jxI" = (
@@ -20846,14 +20955,11 @@
 	},
 /area/lv522/indoors/b_block/bridge)
 "jBr" = (
-/obj/effect/decal/cleanable/blood,
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 10
+/turf/open/floor/strata{
+	dir = 4;
+	icon_state = "white_cyan1"
 	},
-/turf/open/floor/corsat{
-	icon_state = "squares"
-	},
-/area/lv522/atmos/east_reactor/south)
+/area/lv522/oob)
 "jBs" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
@@ -20929,6 +21035,7 @@
 /area/lv522/outdoors/nw_rockies)
 "jCh" = (
 /obj/structure/machinery/door/airlock/almayer/maint,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/corsat{
 	icon_state = "marked"
 	},
@@ -21017,9 +21124,11 @@
 /turf/open/auto_turf/shale/layer1,
 /area/lv522/outdoors/colony_streets/north_street)
 "jEa" = (
-/obj/structure/cargo_container/kelland/left,
-/turf/open/asphalt/cement,
-/area/lv522/atmos/outdoor)
+/turf/open/floor{
+	dir = 4;
+	icon_state = "whiteyellowfull"
+	},
+/area/lv522/oob)
 "jEk" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_nest,
@@ -21072,6 +21181,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
 /area/lv522/indoors/a_block/dorms)
+"jFl" = (
+/obj/structure/stairs/perspective{
+	dir = 1;
+	icon_state = "p_stair_full"
+	},
+/turf/open/gm/river,
+/area/lv522/landing_zone_1/tunnel)
 "jFr" = (
 /obj/structure/cargo_container/arious/rightmid,
 /turf/open/floor/prison,
@@ -21558,6 +21674,7 @@
 	dir = 5;
 	icon_state = "p_stair_full"
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/auto_turf/shale/layer0,
 /area/lv522/landing_zone_1)
 "jPj" = (
@@ -21627,6 +21744,7 @@
 "jQC" = (
 /obj/structure/machinery/light,
 /obj/structure/machinery/disposal,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -22012,6 +22130,7 @@
 	dir = 6;
 	icon_state = "p_stair_full"
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/auto_turf/shale/layer0,
 /area/lv522/landing_zone_1)
 "jYZ" = (
@@ -22051,6 +22170,7 @@
 	},
 /area/lv522/indoors/a_block/hallway)
 "jZD" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt/cement{
 	icon_state = "cement3"
 	},
@@ -22121,6 +22241,7 @@
 "kbo" = (
 /obj/structure/surface/rack,
 /obj/item/stack/sheet/metal/medium_stack,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "kbu" = (
@@ -22366,17 +22487,13 @@
 	},
 /area/lv522/indoors/c_block/casino)
 "kfu" = (
-/obj/structure/platform{
-	dir = 1
-	},
-/obj/structure/platform,
 /obj/structure/prop/invuln/overhead_pipe{
 	dir = 4;
 	name = "overhead pipe";
-	pixel_x = -10;
+	pixel_x = -24;
 	pixel_y = -6
 	},
-/turf/open/gm/river,
+/turf/closed/wall,
 /area/lv522/atmos/cargo_intake)
 "kfv" = (
 /turf/closed/wall/shiva/prefabricated,
@@ -23111,8 +23228,8 @@
 /turf/open/auto_turf/shale/layer1,
 /area/lv522/outdoors/nw_rockies)
 "ksk" = (
-/obj/structure/pipes/standard/manifold/hidden/green{
-	dir = 8
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 6
 	},
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/lv522/outdoors/colony_streets/windbreaker/observation)
@@ -23388,11 +23505,16 @@
 	},
 /area/lv522/atmos/cargo_intake)
 "kzd" = (
-/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
-/turf/open/floor/corsat{
-	icon_state = "squares"
+/obj/structure/machinery/door_control{
+	id = "Corpo Vault";
+	name = "Cargo Shutter Control";
+	pixel_y = 29
 	},
-/area/lv522/atmos/east_reactor/south/cas)
+/turf/open/floor{
+	dir = 4;
+	icon_state = "whiteyellowfull"
+	},
+/area/lv522/oob)
 "kze" = (
 /obj/structure/pipes/vents/pump,
 /turf/open/floor/prison{
@@ -23682,6 +23804,12 @@
 	tag = null
 	},
 /area/lv522/indoors/a_block/admin)
+"kEl" = (
+/obj/structure/platform_decoration{
+	dir = 4
+	},
+/turf/open/gm/river,
+/area/lv522/landing_zone_1/tunnel)
 "kEo" = (
 /obj/structure/machinery/colony_floodlight{
 	layer = 4.3
@@ -23819,11 +23947,12 @@
 /turf/open/auto_turf/shale/layer0,
 /area/lv522/outdoors/colony_streets/north_street)
 "kHd" = (
-/obj/structure/cargo_container/kelland/right,
-/turf/open/asphalt/cement{
-	icon_state = "cement12"
+/obj/effect/landmark/corpsespawner/wy/manager,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "whiteyellowfull"
 	},
-/area/lv522/atmos/outdoor)
+/area/lv522/oob)
 "kHy" = (
 /obj/structure/surface/table/almayer,
 /obj/item/storage/box/flashbangs{
@@ -23913,10 +24042,18 @@
 /turf/open/auto_turf/shale/layer0,
 /area/lv522/outdoors/colony_streets/south_east_street)
 "kIY" = (
-/turf/open/asphalt/cement{
-	icon_state = "cement12"
+/obj/structure/platform,
+/obj/structure/safe,
+/obj/item/spacecash/c1000,
+/obj/item/spacecash/c1000,
+/obj/item/spacecash/c1000,
+/obj/item/spacecash/c1000,
+/obj/item/spacecash/c1000,
+/turf/open/floor/strata{
+	dir = 4;
+	icon_state = "white_cyan1"
 	},
-/area/lv522/atmos/outdoor)
+/area/lv522/oob)
 "kIZ" = (
 /obj/structure/machinery/door/poddoor/shutters/almayer/open{
 	dir = 4;
@@ -24019,19 +24156,14 @@
 	},
 /area/lv522/indoors/a_block/dorms)
 "kLk" = (
-/obj/structure/fence,
-/obj/effect/decal/warning_stripes{
-	icon_state = "S"
+/obj/structure/platform_decoration{
+	dir = 1
 	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "E";
-	pixel_x = 1
+/turf/open/floor/strata{
+	dir = 4;
+	icon_state = "white_cyan1"
 	},
-/turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
-	},
-/area/lv522/atmos/outdoor)
+/area/lv522/oob)
 "kLs" = (
 /obj/item/clothing/mask/facehugger{
 	desc = "It has some sort of a tube at the end of its tail. What the hell is this thing?";
@@ -24238,6 +24370,7 @@
 	id = "LZ1_Lockdown_Lo";
 	name = "Emergency Lockdown"
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/corsat{
 	icon_state = "marked"
 	},
@@ -24666,6 +24799,13 @@
 	tag = null
 	},
 /area/lv522/indoors/a_block/dorms)
+"kWp" = (
+/obj/structure/window/framed/strata/reinforced,
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/corsat{
+	icon_state = "marked"
+	},
+/area/lv522/landing_zone_1/ceiling)
 "kWD" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/structure/prop/vehicles/crawler{
@@ -24748,11 +24888,12 @@
 /turf/open/auto_turf/shale/layer0,
 /area/lv522/outdoors/w_rockies)
 "kXY" = (
-/obj/structure/blocker/forcefield/vehicles,
-/turf/open/floor/corsat{
-	icon_state = "plate"
+/obj/structure/platform_decoration,
+/turf/open/floor/strata{
+	dir = 4;
+	icon_state = "white_cyan1"
 	},
-/area/lv522/atmos/cargo_intake)
+/area/lv522/oob)
 "kYm" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 5
@@ -24805,6 +24946,7 @@
 /obj/structure/platform_decoration{
 	dir = 8
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "kZs" = (
@@ -24816,6 +24958,18 @@
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/prison,
 /area/lv522/indoors/a_block/admin)
+"kZJ" = (
+/obj/structure/window/framed/strata/reinforced,
+/obj/structure/machinery/door/poddoor/almayer/closed{
+	id = "LZ1_Lockdown_Lo";
+	name = "Emergency Lockdown"
+	},
+/obj/effect/landmark/lv624/fog_blocker/short,
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/corsat{
+	icon_state = "marked"
+	},
+/area/lv522/landing_zone_1/ceiling)
 "kZX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal{
@@ -24886,15 +25040,18 @@
 	},
 /area/lv522/indoors/a_block/dorms)
 "lbo" = (
-/obj/structure/fence,
-/obj/effect/decal/warning_stripes{
-	icon_state = "S"
+/obj/structure/stairs/perspective{
+	dir = 1;
+	icon_state = "p_stair_full"
 	},
-/turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+/obj/structure/platform{
+	dir = 8
 	},
-/area/lv522/atmos/outdoor)
+/turf/open/floor/strata{
+	dir = 4;
+	icon_state = "white_cyan1"
+	},
+/area/lv522/oob)
 "lbA" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 10
@@ -25122,6 +25279,7 @@
 /obj/structure/platform_decoration{
 	dir = 1
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/auto_turf/shale/layer0,
 /area/lv522/landing_zone_1)
 "lhb" = (
@@ -25284,8 +25442,15 @@
 	},
 /area/lv522/indoors/a_block/kitchen)
 "llJ" = (
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/lv522/atmos/east_reactor/south/cas)
+/obj/structure/stairs/perspective{
+	dir = 1;
+	icon_state = "p_stair_full"
+	},
+/turf/open/floor/strata{
+	dir = 4;
+	icon_state = "white_cyan1"
+	},
+/area/lv522/oob)
 "llM" = (
 /obj/item/tool/kitchen/knife/butcher,
 /obj/effect/decal/cleanable/dirt,
@@ -25821,14 +25986,18 @@
 	},
 /area/lv522/indoors/a_block/admin)
 "lzb" = (
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 9
+/obj/structure/stairs/perspective{
+	dir = 1;
+	icon_state = "p_stair_full"
 	},
-/turf/open/floor/corsat{
+/obj/structure/platform{
+	dir = 4
+	},
+/turf/open/floor/strata{
 	dir = 4;
-	icon_state = "brown"
+	icon_state = "white_cyan1"
 	},
-/area/lv522/atmos/east_reactor/south/cas)
+/area/lv522/oob)
 "lze" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/effect/decal/warning_stripes{
@@ -25871,7 +26040,6 @@
 /area/lv522/indoors/c_block/garage)
 "lzB" = (
 /obj/structure/surface/rack,
-/obj/item/stack/sheet/metal/medium_stack,
 /turf/open/floor/prison,
 /area/lv522/indoors/c_block/mining)
 "lzP" = (
@@ -25961,6 +26129,10 @@
 	tag = null
 	},
 /area/lv522/indoors/a_block/dorms)
+"lBl" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/auto_turf/shale/layer0,
+/area/lv522/landing_zone_1)
 "lBu" = (
 /obj/structure/machinery/light{
 	dir = 4
@@ -26129,10 +26301,9 @@
 	},
 /area/lv522/indoors/a_block/bridges/dorms_fitness)
 "lER" = (
-/turf/open/floor/corsat{
-	icon_state = "marked"
-	},
-/area/lv522/atmos/outdoor)
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/closed/wall/solaris/reinforced/hull/lv522,
+/area/lv522/oob)
 "lFt" = (
 /turf/open/floor/corsat{
 	dir = 1;
@@ -26311,11 +26482,14 @@
 /turf/open/floor/prison,
 /area/lv522/indoors/lone_buildings/engineering)
 "lIM" = (
-/obj/structure/cargo_container/wy/right,
-/turf/open/asphalt/cement{
-	icon_state = "cement15"
+/obj/structure/machinery/door/poddoor/almayer/closed{
+	id = "Corpo Vault";
+	name = "Vault Lockdown"
 	},
-/area/lv522/outdoors/n_rockies)
+/turf/open/floor/corsat{
+	icon_state = "marked"
+	},
+/area/lv522/oob)
 "lIR" = (
 /obj/structure/prop/invuln/ice_prefab/trim{
 	dir = 8
@@ -26331,6 +26505,7 @@
 /area/lv522/atmos/filt)
 "lJq" = (
 /obj/structure/largecrate/random/secure,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/auto_turf/shale/layer1,
 /area/lv522/landing_zone_1)
 "lJU" = (
@@ -26340,6 +26515,7 @@
 	pixel_y = 6
 	},
 /obj/item/tool/pen/blue/clicky,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -26509,8 +26685,8 @@
 /turf/open/floor/prison,
 /area/lv522/indoors/a_block/kitchen/glass)
 "lNA" = (
-/obj/structure/pipes/standard/manifold/hidden/green{
-	dir = 1
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
 	},
 /turf/open/floor/corsat,
 /area/lv522/atmos/east_reactor/south)
@@ -26864,7 +27040,7 @@
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
 	},
-/turf/open/auto_turf/shale/layer0,
+/turf/open/auto_turf/shale/layer1,
 /area/lv522/outdoors/colony_streets/north_east_street)
 "lWa" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
@@ -26888,6 +27064,7 @@
 /area/lv522/indoors/a_block/kitchen/glass)
 "lWj" = (
 /obj/structure/platform,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/auto_turf/shale/layer0,
 /area/lv522/landing_zone_1)
 "lWm" = (
@@ -27467,14 +27644,10 @@
 /turf/open/floor/prison,
 /area/lv522/indoors/c_block/cargo)
 "mlp" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "S"
-	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "W"
-	},
-/turf/open/auto_turf/shale/layer0,
-/area/lv522/outdoors/nw_rockies)
+/obj/effect/landmark/lv624/fog_blocker/short,
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/auto_turf/shale/layer2,
+/area/lv522/outdoors/colony_streets/north_street)
 "mly" = (
 /obj/structure/closet/firecloset/full,
 /obj/effect/decal/cleanable/dirt,
@@ -27573,6 +27746,7 @@
 /obj/structure/machinery/light/small{
 	dir = 8
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt/cement{
 	icon_state = "cement1"
 	},
@@ -27643,6 +27817,7 @@
 /obj/structure/machinery/light{
 	dir = 8
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -27660,6 +27835,7 @@
 	pixel_x = 8;
 	pixel_y = 20
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -27886,6 +28062,7 @@
 	pixel_x = -8;
 	pixel_y = 4
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/lv522/landing_zone_1/ceiling)
 "muP" = (
@@ -27922,6 +28099,7 @@
 /area/lv522/indoors/a_block/security)
 "mvP" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/lv522/landing_zone_1/ceiling)
 "mvR" = (
@@ -27963,13 +28141,9 @@
 /turf/open/auto_turf/shale/layer0,
 /area/lv522/outdoors/nw_rockies)
 "mwv" = (
-/obj/item/tool/weldpack,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
-	},
-/area/lv522/atmos/outdoor)
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/closed/wall/strata_outpost/reinforced,
+/area/lv522/oob)
 "mwT" = (
 /obj/structure/prop/dam/truck,
 /obj/structure/prop/holidays/wreath{
@@ -28026,6 +28200,7 @@
 /obj/structure/bed/chair{
 	dir = 4
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/lv522/landing_zone_1/ceiling)
 "mxO" = (
@@ -28083,6 +28258,7 @@
 	dir = 8;
 	pixel_y = 5
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -28102,6 +28278,7 @@
 /obj/item/device/flashlight/lamp{
 	pixel_x = 6
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -28279,6 +28456,7 @@
 	},
 /obj/effect/landmark/objective_landmark/close,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -28363,9 +28541,9 @@
 /turf/open/floor/grass,
 /area/lv522/indoors/a_block/garden)
 "mHZ" = (
-/obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
-/turf/open/floor/corsat,
-/area/lv522/atmos/east_reactor/south/cas)
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/asphalt/cement,
+/area/lv522/outdoors/colony_streets/north_street)
 "mIa" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
@@ -28581,6 +28759,7 @@
 /area/lv522/atmos/filt)
 "mMX" = (
 /obj/structure/powerloader_wreckage,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "mNc" = (
@@ -28641,6 +28820,7 @@
 /obj/item/device/flashlight/lamp{
 	pixel_x = -8
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -28714,6 +28894,7 @@
 	name = "remote door-control";
 	pixel_y = 4
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -28904,10 +29085,10 @@
 /turf/open/floor/wood,
 /area/lv522/indoors/a_block/executive)
 "mSc" = (
-/obj/structure/pipes/standard/simple/hidden/green,
-/obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
-/turf/open/floor/corsat,
-/area/lv522/atmos/outdoor)
+/obj/effect/landmark/lv624/fog_blocker/short,
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/closed/wall/strata_outpost/reinforced,
+/area/lv522/oob)
 "mSe" = (
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/lv522/indoors/a_block/bridges/garden_bridge)
@@ -29315,6 +29496,7 @@
 /area/lv522/indoors/a_block/hallway)
 "naS" = (
 /obj/structure/machinery/landinglight/ds1/delayone,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1)
 "naZ" = (
@@ -29437,11 +29619,8 @@
 /turf/open/floor/prison,
 /area/lv522/indoors/c_block/mining)
 "ncN" = (
-/obj/structure/machinery/power/apc/weak{
-	dir = 1
-	},
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/lv522/atmos/filt)
+/turf/closed/wall/strata_outpost/reinforced,
+/area/lv522/outdoors/colony_streets/north_street)
 "ncS" = (
 /obj/structure/fence,
 /obj/effect/decal/warning_stripes{
@@ -29630,6 +29809,13 @@
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
 /turf/open/floor/plating,
 /area/lv522/atmos/filt)
+"nhi" = (
+/obj/structure/machinery/landinglight/ds1/delaythree{
+	dir = 4
+	},
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/plating,
+/area/lv522/landing_zone_1)
 "nhs" = (
 /obj/item/weapon/twohanded/folded_metal_chair,
 /obj/effect/decal/cleanable/dirt,
@@ -29678,6 +29864,7 @@
 /area/lv522/atmos/filt)
 "niA" = (
 /obj/structure/largecrate/random/barrel/green,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt/cement{
 	icon_state = "cement12"
 	},
@@ -29923,6 +30110,7 @@
 	pixel_y = -8
 	},
 /obj/effect/decal/strata_decals/grime/grime3,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison,
 /area/lv522/landing_zone_1/ceiling)
 "nnz" = (
@@ -29959,6 +30147,7 @@
 /obj/item/weapon/twohanded/folded_metal_chair,
 /obj/item/prop/alien/hugger,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison,
 /area/lv522/landing_zone_1/ceiling)
 "noD" = (
@@ -29983,9 +30172,6 @@
 /area/lv522/outdoors/colony_streets/south_east_street)
 "noV" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 9
-	},
 /turf/open/floor/corsat{
 	icon_state = "brown"
 	},
@@ -30155,13 +30341,19 @@
 /turf/open/floor/prison,
 /area/lv522/atmos/outdoor)
 "nri" = (
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 10
+/obj/structure/platform_decoration,
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 1
 	},
-/turf/open/asphalt/cement{
-	icon_state = "cement12"
+/obj/effect/decal/warning_stripes{
+	icon_state = "W"
 	},
-/area/lv522/outdoors/n_rockies)
+/turf/open/floor/prison{
+	icon_state = "floor_plate";
+	tag = null
+	},
+/area/lv522/outdoors/colony_streets/north_street)
 "nru" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N";
@@ -30210,6 +30402,7 @@
 	pixel_y = 5
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison,
 /area/lv522/landing_zone_1/ceiling)
 "nsv" = (
@@ -30275,6 +30468,7 @@
 "ntT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/largecrate/random/barrel/white,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "nud" = (
@@ -30336,6 +30530,7 @@
 /obj/structure/machinery/light{
 	dir = 1
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -30364,6 +30559,13 @@
 	},
 /turf/open/floor/prison,
 /area/lv522/indoors/lone_buildings/outdoor_bot)
+"nvV" = (
+/obj/structure/platform{
+	dir = 1
+	},
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/gm/river,
+/area/lv522/landing_zone_1/tunnel)
 "nwj" = (
 /turf/closed/wall/strata_outpost,
 /area/lv522/indoors/a_block/dorms/glass)
@@ -30406,6 +30608,7 @@
 /area/lv522/indoors/a_block/admin)
 "nxF" = (
 /obj/structure/machinery/light/small,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "nxO" = (
@@ -30454,12 +30657,6 @@
 	tag = null
 	},
 /area/lv522/indoors/a_block/dorms)
-"nzj" = (
-/obj/structure/pipes/standard/simple/hidden/green,
-/turf/open/floor/corsat{
-	icon_state = "marked"
-	},
-/area/lv522/atmos/east_reactor/south)
 "nzt" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor{
@@ -30500,12 +30697,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet,
 /area/lv522/indoors/b_block/bar)
-"nAf" = (
-/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
-/turf/open/floor/corsat{
-	icon_state = "marked"
-	},
-/area/lv522/atmos/east_reactor/south)
 "nAu" = (
 /obj/structure/machinery/door/poddoor/shutters/almayer/open{
 	dir = 4;
@@ -30628,6 +30819,7 @@
 /turf/open/gm/river,
 /area/lv522/atmos/cargo_intake)
 "nEq" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/lv522/landing_zone_1/ceiling)
 "nEX" = (
@@ -30639,19 +30831,13 @@
 "nFj" = (
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1)
-"nFo" = (
-/obj/structure/blocker/forcefield/vehicles,
-/obj/structure/pipes/standard/simple/hidden/green,
-/turf/open/floor/corsat{
-	icon_state = "plate"
-	},
-/area/lv522/atmos/east_reactor/south)
 "nFt" = (
 /obj/structure/blocker/forcefield/vehicles,
+/obj/structure/blocker/invisible_wall,
 /turf/open/floor/corsat{
 	icon_state = "plate"
 	},
-/area/lv522/atmos/east_reactor/south)
+/area/lv522/oob)
 "nFM" = (
 /obj/effect/landmark/objective_landmark/science,
 /obj/effect/decal/cleanable/dirt,
@@ -30693,6 +30879,7 @@
 /area/lv522/atmos/filt)
 "nGe" = (
 /obj/structure/cargo_container/kelland/left,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/auto_turf/shale/layer0,
 /area/lv522/landing_zone_1)
 "nGq" = (
@@ -30728,21 +30915,20 @@
 /area/lv522/atmos/filt)
 "nGJ" = (
 /obj/structure/cargo_container/kelland/right,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/auto_turf/shale/layer1,
 /area/lv522/landing_zone_1)
 "nGU" = (
-/obj/structure/cargo_container/horizontal/blue/top,
-/turf/open/floor/corsat{
-	icon_state = "plate"
+/obj/structure/platform,
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 1
 	},
-/area/lv522/atmos/east_reactor/south/cas)
-"nGW" = (
-/obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
-/obj/structure/pipes/standard/simple/hidden/green,
-/turf/open/floor/corsat{
-	icon_state = "marked"
+/turf/open/floor/prison{
+	icon_state = "floor_plate";
+	tag = null
 	},
-/area/lv522/atmos/east_reactor/south)
+/area/lv522/outdoors/colony_streets/north_street)
 "nHi" = (
 /turf/open/floor/prison{
 	dir = 10;
@@ -30756,12 +30942,6 @@
 	tag = null
 	},
 /area/lv522/indoors/c_block/cargo)
-"nHM" = (
-/obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
-/turf/open/floor/corsat{
-	icon_state = "marked"
-	},
-/area/lv522/atmos/east_reactor/south)
 "nHT" = (
 /obj/structure/bed/chair,
 /obj/structure/machinery/light{
@@ -30920,13 +31100,22 @@
 /turf/open/floor/prison,
 /area/lv522/indoors/a_block/security)
 "nLF" = (
-/obj/structure/pipes/standard/manifold/hidden/green{
-	dir = 8
+/obj/structure/platform_decoration{
+	dir = 1
 	},
-/turf/open/floor/corsat{
-	icon_state = "plate"
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 1
 	},
-/area/lv522/atmos/cargo_intake)
+/obj/effect/decal/warning_stripes{
+	icon_state = "E";
+	pixel_x = 1
+	},
+/turf/open/floor/prison{
+	icon_state = "floor_plate";
+	tag = null
+	},
+/area/lv522/outdoors/colony_streets/north_street)
 "nLW" = (
 /obj/item/tool/weldingtool/simple,
 /obj/structure/pipes/standard/manifold/hidden/green{
@@ -30938,6 +31127,7 @@
 /area/lv522/indoors/a_block/dorm_north)
 "nMc" = (
 /obj/structure/largecrate,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/auto_turf/shale/layer1,
 /area/lv522/landing_zone_1)
 "nMd" = (
@@ -30977,11 +31167,17 @@
 	},
 /area/lv522/indoors/a_block/dorms)
 "nMC" = (
-/obj/structure/cargo_container/horizontal/blue/middle,
-/turf/open/floor/corsat{
-	icon_state = "plate"
+/obj/structure/platform{
+	dir = 4
 	},
-/area/lv522/atmos/east_reactor/south/cas)
+/obj/effect/decal/warning_stripes{
+	icon_state = "W"
+	},
+/turf/open/floor/prison{
+	icon_state = "floor_plate";
+	tag = null
+	},
+/area/lv522/outdoors/colony_streets/north_street)
 "nMP" = (
 /obj/structure/largecrate/random/secure,
 /obj/effect/decal/warning_stripes{
@@ -30992,19 +31188,27 @@
 	},
 /area/lv522/outdoors/colony_streets/north_street)
 "nMT" = (
-/obj/structure/window/framed/solaris/reinforced,
-/obj/structure/pipes/standard/simple/hidden/green,
+/obj/structure/machinery/colony_floodlight{
+	layer = 4.3;
+	pixel_y = 9
+	},
 /turf/open/floor/corsat{
 	icon_state = "marked"
 	},
-/area/lv522/outdoors/colony_streets/windbreaker/observation)
+/area/lv522/outdoors/colony_streets/north_street)
 "nNf" = (
-/obj/structure/pipes/vents/pump,
-/turf/open/floor/corsat{
-	dir = 5;
-	icon_state = "brown"
+/obj/structure/platform{
+	dir = 8
 	},
-/area/lv522/atmos/east_reactor/south/cas)
+/obj/effect/decal/warning_stripes{
+	icon_state = "E";
+	pixel_x = 1
+	},
+/turf/open/floor/prison{
+	icon_state = "floor_plate";
+	tag = null
+	},
+/area/lv522/outdoors/colony_streets/north_street)
 "nNh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/machinery/space_heater/radiator/red{
@@ -31019,9 +31223,20 @@
 	},
 /area/lv522/indoors/a_block/dorms)
 "nNi" = (
-/obj/structure/prop/dam/crane/damaged,
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/lv522/atmos/east_reactor/south/cas)
+/obj/structure/platform_decoration{
+	dir = 8
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "W"
+	},
+/turf/open/floor/prison{
+	icon_state = "floor_plate";
+	tag = null
+	},
+/area/lv522/outdoors/colony_streets/north_street)
 "nNA" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
@@ -31073,14 +31288,17 @@
 	},
 /area/lv522/indoors/a_block/security)
 "nOg" = (
-/obj/structure/prop/invuln/overhead_pipe{
-	dir = 4;
-	name = "overhead pipe";
-	pixel_x = -10;
-	pixel_y = -6
+/obj/structure/platform{
+	dir = 1
 	},
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/lv522/atmos/cargo_intake)
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
+	},
+/turf/open/floor/prison{
+	icon_state = "floor_plate";
+	tag = null
+	},
+/area/lv522/outdoors/colony_streets/north_street)
 "nOl" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/structure/pipes/standard/simple/hidden/green{
@@ -31108,20 +31326,21 @@
 	},
 /area/lv522/indoors/b_block/bar)
 "nOS" = (
-/obj/structure/prop/invuln/overhead_pipe{
-	dir = 9;
-	name = "overhead pipe";
-	pixel_x = -10;
-	pixel_y = -6
+/obj/structure/platform_decoration{
+	dir = 4
 	},
-/obj/structure/prop/invuln/overhead_pipe{
-	dir = 1;
-	name = "overhead pipe";
-	pixel_x = -10;
-	pixel_y = 16
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
 	},
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/lv522/atmos/cargo_intake)
+/obj/effect/decal/warning_stripes{
+	icon_state = "E";
+	pixel_x = 1
+	},
+/turf/open/floor/prison{
+	icon_state = "floor_plate";
+	tag = null
+	},
+/area/lv522/outdoors/colony_streets/north_street)
 "nOT" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
@@ -31169,12 +31388,8 @@
 	},
 /area/lv522/indoors/a_block/security)
 "nPy" = (
-/obj/structure/platform{
-	dir = 1
-	},
-/obj/structure/platform,
-/turf/open/gm/river,
-/area/lv522/atmos/cargo_intake)
+/turf/closed/wall/solaris/reinforced/hull/lv522,
+/area/lv522/outdoors/colony_streets/north_street)
 "nPL" = (
 /obj/structure/stairs/perspective{
 	dir = 8;
@@ -31209,9 +31424,11 @@
 /turf/open/floor/plating,
 /area/lv522/indoors/c_block/mining)
 "nQx" = (
-/obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
-/turf/open/floor/bluegrid,
-/area/lv522/atmos/east_reactor/south/cas)
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 5
+	},
+/turf/open/auto_turf/shale/layer1,
+/area/lv522/outdoors/colony_streets/north_street)
 "nQz" = (
 /obj/structure/platform_decoration,
 /turf/open/auto_turf/shale/layer0,
@@ -31227,20 +31444,21 @@
 	},
 /area/lv522/outdoors/colony_streets/north_west_street)
 "nQQ" = (
-/obj/structure/cargo_container/horizontal/blue/bottom,
-/turf/open/floor/corsat{
-	icon_state = "plate"
+/obj/item/storage/backpack/marine/satchel{
+	desc = "It's the heavy-duty black polymer kind. Time to take out the trash!";
+	icon = 'icons/obj/janitor.dmi';
+	icon_state = "trashbag3";
+	name = "trash bag";
+	pixel_x = 4;
+	pixel_y = 21
 	},
-/area/lv522/atmos/east_reactor/south/cas)
+/turf/open/auto_turf/shale/layer0,
+/area/lv522/outdoors/colony_streets/north_east_street)
 "nQT" = (
 /obj/structure/machinery/door/airlock/almayer/maint,
 /turf/open/floor/plating,
 /area/lv522/indoors/c_block/mining)
 "nQY" = (
-/obj/structure/machinery/door_control{
-	id = "UD6 East";
-	name = "Cargo Shutter Control"
-	},
 /turf/closed/shuttle/dropship2/tornado{
 	icon_state = "53"
 	},
@@ -31294,6 +31512,7 @@
 /obj/structure/machinery/light/small{
 	dir = 1
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "nSA" = (
@@ -31411,9 +31630,9 @@
 /turf/open/floor/plating,
 /area/lv522/indoors/c_block/mining)
 "nUO" = (
-/obj/structure/cryofeed/right,
-/turf/open/floor/bluegrid,
-/area/lv522/atmos/east_reactor/south/cas)
+/obj/structure/closet/crate/trashcart,
+/turf/open/auto_turf/shale/layer1,
+/area/lv522/outdoors/colony_streets/north_east_street)
 "nUV" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor/corsat{
@@ -31528,9 +31747,16 @@
 	},
 /area/lv522/indoors/lone_buildings/outdoor_bot)
 "nWq" = (
-/obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/lv522/atmos/east_reactor/south/cas)
+/obj/item/storage/backpack/marine/satchel{
+	desc = "It's the heavy-duty black polymer kind. Time to take out the trash!";
+	icon = 'icons/obj/janitor.dmi';
+	icon_state = "trashbag3";
+	name = "trash bag";
+	pixel_x = -4;
+	pixel_y = 6
+	},
+/turf/open/auto_turf/shale/layer1,
+/area/lv522/outdoors/colony_streets/north_east_street)
 "nWD" = (
 /obj/structure/machinery/door/airlock/almayer/generic{
 	dir = 1;
@@ -31643,11 +31869,9 @@
 	},
 /area/lv522/indoors/c_block/casino)
 "nXO" = (
-/obj/structure/pipes/standard/simple/hidden/green,
-/turf/open/floor/corsat{
-	icon_state = "marked"
-	},
-/area/lv522/atmos/outdoor)
+/obj/item/ammo_box/magazine/misc/flares,
+/turf/open/floor/prison,
+/area/lv522/indoors/lone_buildings/storage_blocks)
 "nXV" = (
 /obj/structure/surface/table/reinforced/almayer_B,
 /obj/structure/machinery/chem_dispenser/soda{
@@ -31704,6 +31928,10 @@
 	tag = null
 	},
 /area/lv522/outdoors/colony_streets/south_east_street)
+"nYU" = (
+/obj/effect/acid_hole,
+/turf/closed/wall/strata_outpost,
+/area/lv522/landing_zone_1/tunnel)
 "nYW" = (
 /obj/structure/machinery/space_heater/radiator/red{
 	dir = 1;
@@ -31806,19 +32034,19 @@
 /turf/open/floor/prison,
 /area/lv522/indoors/c_block/casino)
 "oaK" = (
-/obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
-/turf/open/floor/corsat{
-	dir = 4;
-	icon_state = "brown"
+/obj/structure/cargo_container/kelland/left{
+	layer = 2.9
 	},
-/area/lv522/atmos/east_reactor/south/cas)
+/turf/open/asphalt/cement{
+	icon_state = "cement2"
+	},
+/area/lv522/outdoors/colony_streets/south_street)
 "oaN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 6
+/obj/structure/cargo_container/kelland/right{
+	layer = 3.5
 	},
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/lv522/outdoors/colony_streets/windbreaker/observation)
+/turf/open/asphalt/cement,
+/area/lv522/outdoors/colony_streets/south_street)
 "obb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/machinery/camera/autoname{
@@ -31942,13 +32170,6 @@
 	icon_state = "greenfull"
 	},
 /area/lv522/indoors/a_block/fitness)
-"oep" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 9
-	},
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/lv522/outdoors/colony_streets/windbreaker/observation)
 "oet" = (
 /obj/structure/prop/dam/crane/cargo{
 	dir = 1
@@ -32061,6 +32282,7 @@
 	pixel_x = -9;
 	pixel_y = 12
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "ofZ" = (
@@ -32087,11 +32309,6 @@
 	tag = null
 	},
 /area/lv522/indoors/a_block/security)
-"ogh" = (
-/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
-/obj/structure/surface/table/almayer,
-/turf/open/floor/prison,
-/area/lv522/atmos/outdoor)
 "ogA" = (
 /obj/effect/decal/cleanable/blood/xeno,
 /obj/effect/decal/cleanable/dirt,
@@ -32176,14 +32393,6 @@
 	icon_state = "darkredfull2"
 	},
 /area/lv522/indoors/a_block/kitchen)
-"ohF" = (
-/obj/structure/cargo_container/horizontal/blue/top,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
-	},
-/area/lv522/atmos/outdoor)
 "ohL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/machinery/space_heater/radiator/red{
@@ -32223,16 +32432,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/lv522/indoors/a_block/bridges/op_centre)
-"oii" = (
-/obj/structure/stairs/perspective{
-	dir = 8;
-	icon_state = "p_stair_full"
-	},
-/obj/structure/platform/stair_cut{
-	icon_state = "platform_stair_alt"
-	},
-/turf/open/floor/prison,
-/area/lv522/atmos/east_reactor/south/cas)
 "oik" = (
 /obj/structure/machinery/colony_floodlight{
 	layer = 4.3;
@@ -32258,6 +32457,7 @@
 	dir = 9;
 	icon_state = "p_stair_full"
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/auto_turf/shale/layer0,
 /area/lv522/landing_zone_1)
 "oiD" = (
@@ -32302,6 +32502,7 @@
 	},
 /area/lv522/atmos/cargo_intake)
 "oiY" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt/cement{
 	icon_state = "cement14"
 	},
@@ -32320,6 +32521,7 @@
 /obj/structure/machinery/space_heater/radiator/red{
 	dir = 4
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -32361,14 +32563,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/lv522/indoors/c_block/cargo)
-"ojD" = (
-/obj/item/clothing/head/welding,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
-	},
-/area/lv522/atmos/outdoor)
 "ojW" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/effect/decal/cleanable/dirt,
@@ -32377,11 +32571,6 @@
 	tag = null
 	},
 /area/lv522/indoors/a_block/hallway)
-"okn" = (
-/obj/structure/surface/table/almayer,
-/obj/item/clothing/head/hardhat,
-/turf/open/floor/prison,
-/area/lv522/atmos/outdoor)
 "okA" = (
 /obj/structure/surface/rack,
 /obj/structure/machinery/camera/autoname{
@@ -32413,14 +32602,6 @@
 	tag = null
 	},
 /area/lv522/indoors/a_block/dorms)
-"oly" = (
-/obj/structure/cargo_container/horizontal/blue/middle,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
-	},
-/area/lv522/atmos/outdoor)
 "olz" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/effect/decal/cleanable/dirt,
@@ -32451,6 +32632,7 @@
 	pixel_x = 9;
 	pixel_y = 4
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -32477,14 +32659,6 @@
 	icon_state = "cement4"
 	},
 /area/lv522/outdoors/colony_streets/north_east_street)
-"onE" = (
-/obj/structure/cargo_container/watatsumi/rightmid,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
-	},
-/area/lv522/atmos/outdoor)
 "onT" = (
 /obj/structure/largecrate/random,
 /obj/effect/decal/cleanable/dirt,
@@ -32498,14 +32672,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
 /area/lv522/indoors/c_block/cargo)
-"ood" = (
-/obj/structure/cargo_container/watatsumi/right,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
-	},
-/area/lv522/atmos/outdoor)
 "ooe" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/closed/wall/strata_ice/dirty,
@@ -32541,13 +32707,6 @@
 	icon_state = "radiator_tile2"
 	},
 /area/lv522/indoors/a_block/bridges)
-"opg" = (
-/obj/structure/blocker/forcefield/vehicles,
-/obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
-/turf/open/floor/corsat{
-	icon_state = "marked"
-	},
-/area/lv522/atmos/east_reactor/south/cas)
 "opl" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/effect/decal/cleanable/dirt,
@@ -32578,6 +32737,7 @@
 	},
 /obj/structure/machinery/light,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -32645,14 +32805,6 @@
 	},
 /turf/open/floor/carpet,
 /area/lv522/indoors/c_block/garage)
-"oqG" = (
-/obj/structure/pipes/standard/simple/hidden/green,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
-	},
-/area/lv522/atmos/outdoor)
 "oqJ" = (
 /obj/effect/decal/cleanable/generic,
 /obj/structure/pipes/standard/simple/hidden/green{
@@ -32716,10 +32868,6 @@
 	icon_state = "blue"
 	},
 /area/lv522/indoors/a_block/admin)
-"orO" = (
-/obj/item/stool,
-/turf/open/floor/prison,
-/area/lv522/atmos/outdoor)
 "orP" = (
 /obj/structure/prop/invuln/ice_prefab/trim{
 	dir = 4
@@ -32760,6 +32908,11 @@
 	tag = null
 	},
 /area/lv522/outdoors/colony_streets/north_west_street)
+"osN" = (
+/turf/open/asphalt/cement{
+	icon_state = "cement4"
+	},
+/area/lv522/outdoors/colony_streets/south_west_street)
 "osU" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/effect/decal/cleanable/dirt,
@@ -32819,14 +32972,6 @@
 	icon_state = "marked"
 	},
 /area/lv522/atmos/north_command_centre)
-"otR" = (
-/obj/structure/cargo_container/horizontal/blue/bottom,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
-	},
-/area/lv522/atmos/outdoor)
 "otS" = (
 /obj/structure/stairs/perspective{
 	icon_state = "p_stair_full"
@@ -32858,6 +33003,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
 /area/lv522/indoors/a_block/kitchen)
+"ouj" = (
+/obj/structure/platform{
+	dir = 1
+	},
+/obj/structure/platform{
+	dir = 8
+	},
+/turf/open/gm/river,
+/area/lv522/outdoors/colony_streets/south_street)
 "ouG" = (
 /obj/structure/barricade/deployable{
 	dir = 8
@@ -32933,10 +33087,6 @@
 	icon_state = "marked"
 	},
 /area/lv522/oob)
-"owK" = (
-/obj/structure/cargo_container/kelland/left,
-/turf/open/floor/prison,
-/area/lv522/atmos/outdoor)
 "owQ" = (
 /turf/open/floor/corsat{
 	icon_state = "marked"
@@ -33020,6 +33170,7 @@
 /area/lv522/indoors/a_block/dorms)
 "oyY" = (
 /obj/structure/largecrate,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/auto_turf/shale/layer0,
 /area/lv522/landing_zone_1)
 "ozk" = (
@@ -33135,6 +33286,7 @@
 /obj/structure/machinery/light/small{
 	dir = 1
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "oBx" = (
@@ -33200,11 +33352,7 @@
 	pixel_x = -6;
 	pixel_y = 6
 	},
-/obj/structure/platform{
-	dir = 8
-	},
-/obj/structure/platform,
-/turf/open/gm/river,
+/turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "oDu" = (
 /obj/structure/machinery/door/airlock/almayer/maint,
@@ -33369,13 +33517,6 @@
 	tag = null
 	},
 /area/lv522/indoors/a_block/hallway)
-"oHy" = (
-/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
-/turf/open/floor/corsat{
-	dir = 4;
-	icon_state = "brown"
-	},
-/area/lv522/atmos/east_reactor/south/cas)
 "oHB" = (
 /obj/structure/machinery/optable{
 	density = 0;
@@ -33393,12 +33534,6 @@
 	icon_state = "blue"
 	},
 /area/lv522/indoors/a_block/admin)
-"oIm" = (
-/obj/structure/prop/dam/crane{
-	icon_state = "tractor_damaged"
-	},
-/turf/open/floor/prison,
-/area/lv522/atmos/outdoor)
 "oIr" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
@@ -33481,15 +33616,6 @@
 "oJS" = (
 /turf/closed/wall/mineral/bone_resin,
 /area/lv522/atmos/cargo_intake)
-"oJT" = (
-/obj/structure/surface/table/almayer,
-/obj/item/storage/pouch/tools/full,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
-	},
-/area/lv522/atmos/outdoor)
 "oJU" = (
 /obj/structure/largecrate/random,
 /obj/effect/decal/warning_stripes{
@@ -33513,15 +33639,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/lv522/indoors/c_block/mining)
-"oKk" = (
-/obj/structure/surface/table/almayer,
-/obj/item/tool/crowbar/red,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
-	},
-/area/lv522/atmos/outdoor)
 "oKm" = (
 /obj/structure/machinery/power/apc/weak{
 	dir = 1
@@ -33540,6 +33657,7 @@
 /obj/structure/platform_decoration{
 	dir = 10
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/auto_turf/shale/layer0,
 /area/lv522/landing_zone_1)
 "oKI" = (
@@ -33633,15 +33751,6 @@
 	icon_state = "cement1"
 	},
 /area/lv522/outdoors/colony_streets/north_street)
-"oLD" = (
-/obj/structure/surface/table/almayer,
-/obj/item/clothing/head/hardhat,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
-	},
-/area/lv522/atmos/outdoor)
 "oLG" = (
 /turf/open/floor/strata{
 	dir = 8;
@@ -33694,11 +33803,6 @@
 /obj/effect/decal/cleanable/blood/xeno,
 /turf/open/floor/prison,
 /area/lv522/indoors/a_block/admin)
-"oNj" = (
-/obj/structure/surface/table/almayer,
-/obj/item/newspaper,
-/turf/open/floor/prison,
-/area/lv522/atmos/outdoor)
 "oNl" = (
 /obj/effect/spawner/gibspawner/xeno,
 /obj/structure/pipes/standard/simple/hidden/green{
@@ -33729,10 +33833,6 @@
 	icon_state = "cement4"
 	},
 /area/lv522/outdoors/colony_streets/north_west_street)
-"oOd" = (
-/obj/structure/platform_decoration,
-/turf/open/floor/prison,
-/area/lv522/atmos/outdoor)
 "oOe" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/auto_turf/shale/layer2,
@@ -33788,6 +33888,7 @@
 /obj/structure/bed/chair{
 	dir = 4
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -33874,6 +33975,7 @@
 /obj/structure/machinery/light{
 	dir = 4
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -33906,12 +34008,6 @@
 	},
 /turf/open/auto_turf/shale/layer1,
 /area/lv522/outdoors/colony_streets/south_street)
-"oSG" = (
-/obj/structure/platform{
-	dir = 4
-	},
-/turf/open/floor/prison,
-/area/lv522/atmos/outdoor)
 "oSH" = (
 /turf/open/floor/prison{
 	icon_state = "darkpurplefull2";
@@ -34075,6 +34171,7 @@
 /obj/structure/machinery/space_heater/radiator/red{
 	dir = 8
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -34133,6 +34230,7 @@
 	name = "High Pressure Door";
 	unacidable = 1
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/corsat{
 	icon_state = "marked"
 	},
@@ -34218,16 +34316,11 @@
 /obj/structure/platform,
 /turf/open/auto_turf/shale/layer0,
 /area/lv522/indoors/a_block/bridges/dorms_fitness)
-"oYD" = (
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 4
-	},
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
-	},
-/area/lv522/atmos/outdoor)
+"oYM" = (
+/obj/structure/platform_decoration,
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/auto_turf/shale/layer0,
+/area/lv522/landing_zone_1)
 "oYO" = (
 /obj/structure/platform{
 	dir = 1
@@ -34244,16 +34337,6 @@
 	icon_state = "darkredfull2"
 	},
 /area/lv522/indoors/a_block/bridges/op_centre)
-"oZq" = (
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 10
-	},
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
-	},
-/area/lv522/atmos/outdoor)
 "oZC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/pipes/standard/simple/hidden/green,
@@ -34262,28 +34345,10 @@
 	icon_state = "greenfull"
 	},
 /area/lv522/indoors/a_block/fitness)
-"oZF" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
-/turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
-	},
-/area/lv522/atmos/outdoor)
 "oZN" = (
 /obj/structure/platform,
 /turf/open/auto_turf/shale/layer0,
 /area/lv522/outdoors/colony_streets/north_east_street)
-"oZP" = (
-/obj/structure/platform{
-	dir = 1
-	},
-/turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
-	},
-/area/lv522/atmos/outdoor)
 "pag" = (
 /obj/structure/largecrate/random/secure,
 /obj/structure/largecrate/random/secure{
@@ -34312,6 +34377,7 @@
 /area/lv522/indoors/a_block/admin)
 "paT" = (
 /obj/structure/cargo_container/kelland/right,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/auto_turf/shale/layer0,
 /area/lv522/landing_zone_1)
 "pbb" = (
@@ -34323,13 +34389,6 @@
 	icon_state = "cement12"
 	},
 /area/lv522/outdoors/colony_streets/south_street)
-"pbk" = (
-/obj/structure/stairs/perspective{
-	icon_state = "p_stair_full"
-	},
-/obj/structure/pipes/standard/simple/hidden/green,
-/turf/open/floor/prison,
-/area/lv522/atmos/outdoor)
 "pbp" = (
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/lv522/indoors/a_block/dorms/glass)
@@ -34394,13 +34453,19 @@
 /obj/item/weapon/twohanded/fireaxe,
 /turf/open/floor/prison,
 /area/lv522/indoors/a_block/security/glass)
-"pcY" = (
-/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
-/obj/structure/stairs/perspective{
-	icon_state = "p_stair_full"
+"pdp" = (
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 8;
+	pixel_x = -6;
+	pixel_y = 6
 	},
-/turf/open/floor/prison,
-/area/lv522/atmos/outdoor)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/platform,
+/obj/structure/platform{
+	dir = 8
+	},
+/turf/open/gm/river,
+/area/lv522/landing_zone_1/tunnel)
 "pdr" = (
 /obj/structure/curtain/red,
 /obj/effect/decal/cleanable/dirt,
@@ -34483,8 +34548,15 @@
 /area/lv522/outdoors/colony_streets/north_east_street)
 "pez" = (
 /obj/structure/cargo_container/horizontal/blue/top,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/auto_turf/shale/layer0,
 /area/lv522/landing_zone_1)
+"peM" = (
+/obj/structure/platform_decoration{
+	dir = 1
+	},
+/turf/open/gm/river,
+/area/lv522/landing_zone_1/tunnel)
 "peS" = (
 /obj/structure/surface/table/almayer{
 	dir = 1;
@@ -34576,12 +34648,6 @@
 	icon_state = "blue_plate"
 	},
 /area/lv522/indoors/a_block/bridges/garden_bridge)
-"pfM" = (
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 5
-	},
-/turf/open/floor/prison,
-/area/lv522/atmos/outdoor)
 "pfN" = (
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/lv522/indoors/a_block/hallway)
@@ -34606,12 +34672,6 @@
 /obj/effect/landmark/survivor_spawner,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/lv522/indoors/a_block/admin)
-"pgg" = (
-/obj/structure/pipes/standard/manifold/hidden/green{
-	dir = 4
-	},
-/turf/open/floor/prison,
-/area/lv522/atmos/outdoor)
 "pgl" = (
 /obj/structure/bed/chair/comfy{
 	dir = 1;
@@ -34717,11 +34777,6 @@
 	tag = null
 	},
 /area/lv522/indoors/a_block/dorms)
-"phm" = (
-/obj/structure/surface/table/almayer,
-/obj/item/storage/toolbox/mechanical,
-/turf/open/floor/prison,
-/area/lv522/atmos/outdoor)
 "phn" = (
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/lv522/indoors/b_block/hydro)
@@ -34743,6 +34798,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/lv522/indoors/c_block/cargo)
+"pid" = (
+/obj/structure/machinery/door/airlock/almayer/generic,
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/corsat{
+	icon_state = "marked"
+	},
+/area/lv522/landing_zone_1/ceiling)
 "pit" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
 /turf/open/auto_turf/shale/layer0,
@@ -34774,6 +34836,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/lv522/indoors/c_block/cargo)
+"pjl" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/closed/wall/strata_ice/dirty,
+/area/lv522/oob)
 "pjm" = (
 /obj/structure/platform{
 	dir = 8
@@ -34795,16 +34861,6 @@
 	tag = null
 	},
 /area/lv522/indoors/a_block/dorms)
-"pjN" = (
-/obj/structure/pipes/standard/simple/hidden/green,
-/obj/effect/decal/warning_stripes{
-	icon_state = "S"
-	},
-/turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
-	},
-/area/lv522/atmos/outdoor)
 "pjT" = (
 /obj/structure/surface/table/almayer,
 /obj/item/paper{
@@ -34842,17 +34898,18 @@
 	tag = null
 	},
 /area/lv522/indoors/c_block/cargo)
-"pke" = (
-/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
-/turf/open/asphalt/cement{
-	icon_state = "cement12"
-	},
-/area/lv522/outdoors/n_rockies)
 "pkB" = (
 /turf/closed/shuttle/dropship2/tornado{
 	icon_state = "9"
 	},
 /area/lv522/landing_zone_forecon/UD6_Tornado)
+"pkH" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "greenfull"
+	},
+/area/lv522/landing_zone_1)
 "plb" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/structure/machinery/door/airlock/multi_tile/almayer/generic,
@@ -35288,6 +35345,7 @@
 /obj/structure/machinery/landinglight/ds1/delaythree{
 	dir = 4
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -35356,6 +35414,7 @@
 /obj/structure/machinery/landinglight/ds1/delayone{
 	dir = 8
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -35855,10 +35914,12 @@
 /obj/structure/platform_decoration{
 	dir = 4
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "pFw" = (
 /obj/structure/cargo_container/horizontal/blue/middle,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/auto_turf/shale/layer0,
 /area/lv522/landing_zone_1)
 "pFF" = (
@@ -36097,6 +36158,17 @@
 	},
 /turf/open/floor/corsat,
 /area/lv522/atmos/cargo_intake)
+"pLm" = (
+/obj/structure/platform,
+/obj/structure/platform{
+	dir = 4
+	},
+/obj/structure/platform_decoration{
+	dir = 6
+	},
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/auto_turf/shale/layer0,
+/area/lv522/landing_zone_1)
 "pLs" = (
 /obj/structure/barricade/wooden{
 	dir = 4
@@ -36373,6 +36445,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -36787,6 +36860,7 @@
 /obj/structure/stairs/perspective{
 	icon_state = "p_stair_full"
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "pYu" = (
@@ -36884,8 +36958,15 @@
 	tag = null
 	},
 /area/lv522/indoors/a_block/dorms)
+"qaT" = (
+/obj/structure/stairs/perspective{
+	icon_state = "p_stair_full"
+	},
+/turf/open/gm/river,
+/area/lv522/landing_zone_1/tunnel)
 "qbf" = (
 /obj/structure/cargo_container/horizontal/blue/bottom,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/auto_turf/shale/layer0,
 /area/lv522/landing_zone_1)
 "qbi" = (
@@ -37415,12 +37496,17 @@
 	pixel_x = -12;
 	pixel_y = 1
 	},
-/obj/item/clothing/head/headset{
-	pixel_x = 4
-	},
 /obj/item/storage/backpack/marine/satchel/rto/small{
 	pixel_x = 7;
 	pixel_y = 19
+	},
+/obj/structure/machinery/door_control{
+	id = "UD6 East";
+	name = "Cargo Shutter Control";
+	pixel_y = -4
+	},
+/obj/item/clothing/head/headset{
+	pixel_x = 4
 	},
 /turf/open/floor/strata{
 	dir = 8;
@@ -37914,6 +38000,12 @@
 	icon_state = "greenfull"
 	},
 /area/lv522/indoors/a_block/fitness/glass)
+"qxk" = (
+/obj/structure/platform_decoration{
+	dir = 8
+	},
+/turf/open/gm/river,
+/area/lv522/landing_zone_1/tunnel)
 "qxm" = (
 /obj/structure/largecrate/random/case/double,
 /turf/open/floor/plating,
@@ -38213,6 +38305,11 @@
 	icon_state = "marked"
 	},
 /area/lv522/indoors/a_block/bridges/corpo)
+"qCs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/plating,
+/area/lv522/landing_zone_1/tunnel)
 "qCB" = (
 /obj/structure/surface/rack,
 /obj/item/clothing/shoes/blue{
@@ -38280,6 +38377,7 @@
 	dir = 1;
 	icon_state = "p_stair_full"
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/auto_turf/shale/layer0,
 /area/lv522/landing_zone_1)
 "qDw" = (
@@ -38291,6 +38389,7 @@
 	dir = 5;
 	icon_state = "p_stair_full"
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/auto_turf/shale/layer0,
 /area/lv522/landing_zone_1)
 "qDL" = (
@@ -38644,10 +38743,12 @@
 /area/lv522/outdoors/w_rockies)
 "qLk" = (
 /obj/structure/closet/firecloset/full,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "qLu" = (
 /obj/structure/platform,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt/cement,
 /area/lv522/outdoors/colony_streets/south_west_street)
 "qLy" = (
@@ -38713,6 +38814,13 @@
 	icon_state = "70"
 	},
 /area/lv522/landing_zone_forecon/UD6_Typhoon)
+"qMJ" = (
+/obj/structure/platform{
+	dir = 8
+	},
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/auto_turf/shale/layer0,
+/area/lv522/landing_zone_1)
 "qMX" = (
 /obj/structure/cargo_container/horizontal/blue/middle{
 	layer = 3.1
@@ -39359,6 +39467,7 @@
 /obj/structure/machinery/light/small{
 	dir = 4
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "qWf" = (
@@ -39399,6 +39508,7 @@
 "qXs" = (
 /obj/structure/closet/firecloset/full,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "qXz" = (
@@ -39689,14 +39799,6 @@
 	tag = null
 	},
 /area/lv522/indoors/c_block/mining)
-"rbR" = (
-/obj/structure/cargo_container/wy/left{
-	layer = 3.3
-	},
-/turf/open/asphalt/cement{
-	icon_state = "cement12"
-	},
-/area/lv522/outdoors/n_rockies)
 "rbV" = (
 /obj/structure/prop/vehicles/crawler{
 	density = 1;
@@ -39718,11 +39820,6 @@
 /obj/structure/barricade/deployable,
 /turf/open/auto_turf/shale/layer0,
 /area/lv522/outdoors/colony_streets/north_east_street)
-"rcI" = (
-/turf/open/floor/corsat{
-	icon_state = "plate"
-	},
-/area/lv522/atmos/east_reactor/south/cas)
 "rcO" = (
 /obj/structure/prop/ice_colony/ground_wire{
 	dir = 1;
@@ -39764,6 +39861,7 @@
 /area/lv522/indoors/a_block/fitness/glass)
 "rcR" = (
 /obj/structure/largecrate/random/barrel/white,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "rcV" = (
@@ -40234,6 +40332,7 @@
 /obj/structure/bed/chair{
 	dir = 1
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "rmD" = (
@@ -40302,6 +40401,7 @@
 /turf/open/auto_turf/shale/layer1,
 /area/lv522/outdoors/colony_streets/north_west_street)
 "rnT" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt/cement{
 	icon_state = "cement12"
 	},
@@ -40862,6 +40962,7 @@
 	dir = 4;
 	icon_state = "p_stair_full"
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/auto_turf/shale/layer0,
 /area/lv522/landing_zone_1)
 "ryu" = (
@@ -40923,6 +41024,7 @@
 /area/lv522/atmos/filt)
 "rzz" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -40968,31 +41070,19 @@
 /obj/structure/platform{
 	dir = 4
 	},
-/obj/structure/machinery/door/poddoor/shutters/almayer/open{
+/obj/structure/machinery/door/poddoor/shutters/almayer{
 	id = "UD6 East";
-	name = "Shutters"
+	indestructible = 1
 	},
 /turf/open/floor/plating,
 /area/lv522/landing_zone_forecon/UD6_Tornado)
 "rAu" = (
 /obj/structure/platform_decoration,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt/cement{
 	icon_state = "cement2"
 	},
 /area/lv522/landing_zone_1)
-"rAz" = (
-/obj/structure/platform{
-	dir = 8
-	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "E";
-	pixel_x = 1
-	},
-/turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
-	},
-/area/lv522/outdoors/colony_streets/north_street)
 "rAK" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
@@ -41187,18 +41277,11 @@
 	},
 /area/lv522/landing_zone_forecon/UD6_Typhoon)
 "rFw" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt/cement{
 	icon_state = "cement4"
 	},
 /area/lv522/outdoors/colony_streets/south_west_street)
-"rFH" = (
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 4
-	},
-/turf/open/floor/corsat{
-	icon_state = "squares"
-	},
-/area/lv522/atmos/east_reactor/south/cas)
 "rFT" = (
 /obj/structure/machinery/landinglight/ds2,
 /turf/open/floor/plating,
@@ -41343,6 +41426,7 @@
 	id = "LZ1_Lockdown_Lo";
 	name = "Emergency Lockdown"
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/corsat{
 	icon_state = "marked"
 	},
@@ -41374,6 +41458,12 @@
 	tag = null
 	},
 /area/lv522/outdoors/colony_streets/north_east_street)
+"rJv" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/asphalt/cement{
+	icon_state = "cement15"
+	},
+/area/lv522/outdoors/colony_streets/south_west_street)
 "rJz" = (
 /obj/structure/machinery/door/airlock/almayer/generic,
 /turf/open/floor/corsat{
@@ -41580,15 +41670,7 @@
 /turf/open/asphalt/cement,
 /area/lv522/outdoors/colony_streets/east_central_street)
 "rME" = (
-/obj/item/storage/backpack/marine/satchel{
-	desc = "It's the heavy-duty black polymer kind. Time to take out the trash!";
-	icon = 'icons/obj/janitor.dmi';
-	icon_state = "trashbag3";
-	name = "trash bag";
-	pixel_x = 4;
-	pixel_y = 21
-	},
-/turf/open/auto_turf/shale/layer0,
+/turf/closed/wall/solaris/reinforced/hull/lv522,
 /area/lv522/outdoors/colony_streets/north_east_street)
 "rMF" = (
 /turf/open/asphalt/cement,
@@ -41678,6 +41760,7 @@
 	layer = 3.51;
 	tag = null
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt/cement,
 /area/lv522/landing_zone_1)
 "rOD" = (
@@ -41718,6 +41801,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
 /area/lv522/indoors/c_block/t_comm)
+"rPQ" = (
+/obj/structure/platform_decoration{
+	dir = 4
+	},
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/auto_turf/shale/layer0,
+/area/lv522/landing_zone_1)
 "rQd" = (
 /obj/structure/closet/secure_closet/quartermaster,
 /turf/open/floor/prison{
@@ -41878,6 +41968,7 @@
 /area/lv522/indoors/a_block/admin)
 "rSh" = (
 /obj/structure/largecrate/random/barrel/white,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -42071,6 +42162,7 @@
 /obj/structure/platform_decoration{
 	dir = 10
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt/cement,
 /area/lv522/outdoors/colony_streets/south_west_street)
 "rYD" = (
@@ -42190,6 +42282,7 @@
 /area/lv522/oob)
 "saL" = (
 /obj/structure/platform,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt/cement,
 /area/lv522/landing_zone_1)
 "saQ" = (
@@ -42269,12 +42362,6 @@
 	tag = null
 	},
 /area/lv522/indoors/c_block/mining)
-"sbE" = (
-/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
-/turf/open/asphalt/cement{
-	icon_state = "cement1"
-	},
-/area/lv522/atmos/outdoor)
 "sbG" = (
 /turf/closed/shuttle/dropship2/tornado/typhoon{
 	icon_state = "28"
@@ -42378,6 +42465,7 @@
 /area/lv522/indoors/a_block/dorms)
 "sdN" = (
 /obj/structure/largecrate,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "sec" = (
@@ -42433,6 +42521,7 @@
 /obj/structure/platform_decoration{
 	dir = 1
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt/cement{
 	icon_state = "cement9"
 	},
@@ -42546,14 +42635,6 @@
 	icon_state = "cement9"
 	},
 /area/lv522/outdoors/colony_streets/east_central_street)
-"sic" = (
-/obj/structure/surface/table/almayer,
-/obj/item/storage/toolbox/electrical,
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 4
-	},
-/turf/open/floor/prison,
-/area/lv522/atmos/outdoor)
 "sid" = (
 /obj/structure/stairs/perspective{
 	dir = 8;
@@ -42600,6 +42681,7 @@
 /obj/item/key/cargo_train{
 	icon_state = "keys"
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -42810,16 +42892,6 @@
 	icon_state = "cyan2"
 	},
 /area/lv522/indoors/a_block/medical/glass)
-"smN" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "S"
-	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "E";
-	pixel_x = 1
-	},
-/turf/open/auto_turf/shale/layer0,
-/area/lv522/outdoors/nw_rockies)
 "smR" = (
 /turf/open/floor/corsat{
 	icon_state = "marked"
@@ -42900,6 +42972,10 @@
 	},
 /turf/open/auto_turf/shale/layer0,
 /area/lv522/outdoors/colony_streets/north_street)
+"spj" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/closed/wall/strata_outpost/reinforced,
+/area/lv522/landing_zone_1/tunnel)
 "spm" = (
 /obj/structure/bed/chair/comfy,
 /obj/effect/decal/cleanable/dirt,
@@ -43072,6 +43148,7 @@
 	},
 /area/lv522/landing_zone_forecon/UD6_Tornado)
 "std" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt/cement{
 	icon_state = "cement9"
 	},
@@ -43294,6 +43371,7 @@
 /obj/structure/machinery/door/airlock/almayer/generic{
 	dir = 2
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/corsat{
 	icon_state = "marked"
 	},
@@ -43308,6 +43386,7 @@
 /obj/structure/platform{
 	dir = 8
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt/cement{
 	icon_state = "cement1"
 	},
@@ -43424,20 +43503,6 @@
 /obj/structure/machinery/squeezer,
 /turf/open/floor/plating,
 /area/lv522/indoors/c_block/cargo)
-"sBD" = (
-/obj/structure/platform_decoration,
-/obj/effect/decal/warning_stripes{
-	icon_state = "N";
-	pixel_y = 1
-	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "W"
-	},
-/turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
-	},
-/area/lv522/outdoors/colony_streets/north_street)
 "sCb" = (
 /obj/structure/platform_decoration{
 	dir = 8
@@ -43446,6 +43511,7 @@
 	dir = 9;
 	icon_state = "p_stair_full"
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt/cement{
 	icon_state = "cement3"
 	},
@@ -43465,6 +43531,13 @@
 	tag = null
 	},
 /area/lv522/indoors/c_block/mining)
+"sCk" = (
+/obj/structure/machinery/landinglight/ds1/delayone{
+	dir = 8
+	},
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/plating,
+/area/lv522/landing_zone_1)
 "sCp" = (
 /turf/closed/shuttle/dropship2/tornado{
 	icon_state = "75"
@@ -43683,6 +43756,16 @@
 	icon_state = "greenfull"
 	},
 /area/lv522/indoors/b_block/bridge)
+"sHd" = (
+/obj/structure/stairs/perspective{
+	dir = 1;
+	icon_state = "p_stair_full"
+	},
+/obj/structure/platform{
+	dir = 4
+	},
+/turf/open/gm/river,
+/area/lv522/landing_zone_1/tunnel)
 "sHg" = (
 /obj/structure/barricade/deployable,
 /turf/open/shuttle/dropship{
@@ -43751,6 +43834,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -44382,6 +44466,7 @@
 	id = "LZ1_Lockdown_Lo";
 	name = "Emergency Lockdown"
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/corsat{
 	icon_state = "marked"
 	},
@@ -44684,6 +44769,7 @@
 /obj/structure/stairs/perspective{
 	icon_state = "p_stair_full"
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/auto_turf/shale/layer0,
 /area/lv522/landing_zone_1)
 "tbl" = (
@@ -44906,6 +44992,7 @@
 	icon_state = "p_stair_full"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt/cement{
 	icon_state = "cement3"
 	},
@@ -44919,6 +45006,7 @@
 "tfl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/railgun_camera_pos,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	icon_state = "floor_plate";
 	tag = null
@@ -45136,7 +45224,7 @@
 	layer = 3.3;
 	pixel_y = 16
 	},
-/turf/open/auto_turf/shale/layer0,
+/turf/open/auto_turf/shale/layer1,
 /area/lv522/outdoors/colony_streets/north_east_street)
 "tkM" = (
 /obj/structure/bed/chair{
@@ -45186,9 +45274,6 @@
 	pixel_y = 6
 	},
 /obj/structure/platform,
-/obj/structure/platform{
-	dir = 4
-	},
 /turf/open/gm/river,
 /area/lv522/landing_zone_1/tunnel)
 "tlM" = (
@@ -45269,6 +45354,7 @@
 	pixel_x = -1;
 	pixel_y = 1
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -45404,9 +45490,6 @@
 	},
 /turf/open/floor/plating,
 /area/lv522/indoors/a_block/security)
-"tpc" = (
-/turf/open/auto_turf/shale/layer2,
-/area/lv522/atmos/outdoor)
 "tpl" = (
 /obj/structure/surface/table/almayer,
 /obj/item/clipboard,
@@ -45627,6 +45710,7 @@
 	dir = 1;
 	icon_state = "p_stair_full"
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/auto_turf/shale/layer0,
 /area/lv522/landing_zone_1)
 "tue" = (
@@ -45840,13 +45924,6 @@
 	icon_state = "darkredfull2"
 	},
 /area/lv522/indoors/a_block/security)
-"tyw" = (
-/obj/structure/stairs/perspective{
-	dir = 10;
-	icon_state = "p_stair_full"
-	},
-/turf/open/floor/prison,
-/area/lv522/atmos/outdoor)
 "tyy" = (
 /obj/structure/desertdam/decals/road_edge{
 	pixel_x = 2;
@@ -46410,7 +46487,7 @@
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
 	},
-/turf/open/auto_turf/shale/layer0,
+/turf/open/auto_turf/shale/layer1,
 /area/lv522/outdoors/colony_streets/north_east_street)
 "tJG" = (
 /obj/structure/stairs/perspective{
@@ -46480,6 +46557,7 @@
 /area/lv522/indoors/c_block/garage)
 "tKS" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	icon_state = "floor_plate";
 	tag = null
@@ -46565,6 +46643,7 @@
 /turf/open/floor/prison,
 /area/lv522/indoors/a_block/dorm_north)
 "tMq" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt/cement{
 	icon_state = "cement2"
 	},
@@ -46575,6 +46654,7 @@
 	dir = 10;
 	icon_state = "p_stair_full"
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt/cement{
 	icon_state = "cement3"
 	},
@@ -46814,6 +46894,7 @@
 	pixel_y = 4
 	},
 /obj/structure/machinery/light,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -46936,6 +47017,7 @@
 /obj/structure/surface/table/almayer,
 /obj/item/trash/plate,
 /obj/item/reagent_container/food/snacks/mushroompizzaslice,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -46956,6 +47038,7 @@
 /area/lv522/indoors/a_block/dorms)
 "tVj" = (
 /obj/structure/largecrate/random/barrel/white,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "floor_marked";
@@ -47004,14 +47087,6 @@
 	icon_state = "greenfull"
 	},
 /area/lv522/indoors/a_block/fitness)
-"tWD" = (
-/obj/structure/stairs/perspective{
-	dir = 8;
-	icon_state = "p_stair_full"
-	},
-/obj/structure/platform,
-/turf/open/floor/prison,
-/area/lv522/atmos/east_reactor/south/cas)
 "tWE" = (
 /obj/structure/pipes/standard/manifold/hidden/green,
 /turf/open/auto_turf/shale/layer0,
@@ -47073,24 +47148,13 @@
 	tag = null
 	},
 /area/lv522/indoors/a_block/dorms)
-"tXt" = (
-/turf/open/floor/corsat{
-	dir = 9;
-	icon_state = "brown"
-	},
-/area/lv522/atmos/east_reactor/south/cas)
-"tXz" = (
-/turf/open/floor/corsat{
-	dir = 4;
-	icon_state = "brown"
-	},
-/area/lv522/atmos/east_reactor/south/cas)
 "tXG" = (
 /obj/structure/bed/chair{
 	dir = 8
 	},
 /obj/item/prop/alien/hugger,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	icon_state = "floor_plate";
 	tag = null
@@ -47204,6 +47268,13 @@
 	icon_state = "greenfull"
 	},
 /area/lv522/indoors/a_block/fitness)
+"tZM" = (
+/obj/structure/platform{
+	dir = 4
+	},
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/auto_turf/shale/layer0,
+/area/lv522/landing_zone_1)
 "tZP" = (
 /obj/item/prop/alien/hugger,
 /obj/effect/decal/cleanable/dirt,
@@ -47530,6 +47601,7 @@
 	pixel_y = 6
 	},
 /obj/structure/machinery/light,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -47597,7 +47669,6 @@
 /area/lv522/landing_zone_2)
 "ugN" = (
 /obj/item/storage/backpack/marine/satchel/scout_cloak,
-/obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor/corsat,
 /area/lv522/atmos/east_reactor/south)
 "ugR" = (
@@ -47892,6 +47963,7 @@
 /obj/structure/platform{
 	dir = 4
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt/cement{
 	icon_state = "cement3"
 	},
@@ -47969,6 +48041,7 @@
 	pixel_x = -8;
 	pixel_y = 4
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -47986,10 +48059,12 @@
 /area/lv522/indoors/c_block/cargo)
 "uol" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison,
 /area/lv522/landing_zone_1/ceiling)
 "uom" = (
 /obj/structure/machinery/disposal,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -48035,6 +48110,7 @@
 	pixel_x = 6;
 	pixel_y = 16
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -48060,6 +48136,7 @@
 /area/lv522/indoors/b_block/hydro)
 "upX" = (
 /obj/structure/machinery/disposal,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/lv522/landing_zone_1/ceiling)
 "upZ" = (
@@ -48079,6 +48156,7 @@
 /obj/structure/machinery/power/apc/weak{
 	dir = 1
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "uqo" = (
@@ -48218,6 +48296,7 @@
 	pixel_y = 4
 	},
 /obj/effect/landmark/objective_landmark/close,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -48236,6 +48315,7 @@
 /obj/item/trash/cigbutt{
 	pixel_x = 4
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -48272,6 +48352,7 @@
 /obj/structure/machinery/light/small{
 	dir = 8
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "uur" = (
@@ -48734,6 +48815,7 @@
 	dir = 1
 	},
 /obj/structure/largecrate,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "uEX" = (
@@ -48768,6 +48850,7 @@
 /obj/structure/platform_decoration{
 	dir = 8
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt/cement{
 	icon_state = "cement14"
 	},
@@ -48948,6 +49031,7 @@
 /area/lv522/indoors/c_block/garage)
 "uIF" = (
 /obj/structure/barricade/handrail,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "uIJ" = (
@@ -49048,14 +49132,8 @@
 	},
 /area/lv522/indoors/a_block/bridges/op_centre)
 "uKD" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "S"
-	},
-/turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
-	},
-/area/lv522/atmos/outdoor)
+/turf/closed/wall/strata_outpost/reinforced,
+/area/lv522/oob)
 "uKE" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 5
@@ -49091,6 +49169,7 @@
 /obj/structure/platform_decoration{
 	dir = 9
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt/cement,
 /area/lv522/landing_zone_1)
 "uLk" = (
@@ -49282,6 +49361,7 @@
 /obj/structure/platform_decoration{
 	dir = 5
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt/cement,
 /area/lv522/outdoors/colony_streets/south_west_street)
 "uOD" = (
@@ -49325,6 +49405,7 @@
 /area/lv522/indoors/c_block/cargo)
 "uPo" = (
 /obj/structure/largecrate/guns/russian,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "floor_marked";
@@ -49489,6 +49570,7 @@
 /obj/structure/platform{
 	dir = 4
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/gm/river,
 /area/lv522/landing_zone_1/tunnel)
 "uSn" = (
@@ -49558,14 +49640,6 @@
 	},
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1)
-"uTf" = (
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 6
-	},
-/turf/open/floor/corsat{
-	icon_state = "brown"
-	},
-/area/lv522/atmos/east_reactor/south)
 "uTh" = (
 /obj/structure/barricade/wooden{
 	dir = 8
@@ -49582,12 +49656,6 @@
 /obj/structure/window_frame/strata,
 /turf/open/floor/plating,
 /area/lv522/indoors/a_block/corpo)
-"uTw" = (
-/obj/structure/stairs/perspective{
-	icon_state = "p_stair_full"
-	},
-/turf/open/floor/prison,
-/area/lv522/atmos/outdoor)
 "uTI" = (
 /obj/structure/machinery/light{
 	dir = 8
@@ -49602,8 +49670,9 @@
 /obj/structure/platform_decoration{
 	dir = 4
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt/cement{
-	icon_state = "cement15"
+	icon_state = "cement1"
 	},
 /area/lv522/outdoors/colony_streets/south_west_street)
 "uTS" = (
@@ -49826,6 +49895,7 @@
 /obj/structure/platform{
 	dir = 8
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/ceiling)
 "uXO" = (
@@ -49940,6 +50010,7 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/lv522/atmos/cargo_intake)
 "vbu" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison,
 /area/lv522/landing_zone_1/ceiling)
 "vbF" = (
@@ -50084,6 +50155,7 @@
 /obj/structure/platform_decoration{
 	dir = 4
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/ceiling)
 "vdV" = (
@@ -50102,6 +50174,10 @@
 	},
 /turf/open/floor/wood,
 /area/lv522/indoors/c_block/casino)
+"veq" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/auto_turf/shale/layer1,
+/area/lv522/landing_zone_1)
 "ves" = (
 /obj/structure/machinery/light{
 	dir = 8
@@ -50147,13 +50223,6 @@
 	icon_state = "darkredfull2"
 	},
 /area/lv522/indoors/a_block/bridges/corpo)
-"vfc" = (
-/obj/structure/blocker/forcefield/vehicles,
-/obj/structure/pipes/standard/simple/hidden/green,
-/turf/open/floor/corsat{
-	icon_state = "squares"
-	},
-/area/lv522/atmos/cargo_intake)
 "vfj" = (
 /obj/structure/bed/stool{
 	buckling_y = 14;
@@ -50166,12 +50235,6 @@
 	icon_state = "2"
 	},
 /area/lv522/landing_zone_forecon/UD6_Typhoon)
-"vfn" = (
-/obj/structure/blocker/forcefield/vehicles,
-/turf/open/floor/corsat{
-	icon_state = "squares"
-	},
-/area/lv522/atmos/cargo_intake)
 "vfC" = (
 /obj/item/storage/backpack/marine/satchel{
 	desc = "It's the heavy-duty black polymer kind. Time to take out the trash!";
@@ -50419,6 +50482,7 @@
 /turf/open/floor/prison,
 /area/lv522/indoors/a_block/dorms)
 "vjC" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/ceiling)
 "vjF" = (
@@ -50489,14 +50553,6 @@
 	tag = null
 	},
 /area/lv522/indoors/a_block/fitness)
-"vlu" = (
-/obj/structure/largecrate/random,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
-	},
-/area/lv522/atmos/outdoor)
 "vlv" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/device/radio/off{
@@ -50585,10 +50641,19 @@
 	},
 /area/lv522/indoors/a_block/dorms)
 "vne" = (
-/obj/structure/fence,
-/turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+/obj/structure/fence{
+	layer = 2.9
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 1
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
+	},
+/turf/open/floor/strata{
+	dir = 4;
+	icon_state = "floor3"
 	},
 /area/lv522/outdoors/colony_streets/north_west_street)
 "vni" = (
@@ -50655,6 +50720,13 @@
 "voI" = (
 /obj/structure/fence{
 	layer = 2.9
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "E";
+	pixel_x = 1
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "W"
 	},
 /turf/open/floor/strata{
 	dir = 4;
@@ -50748,6 +50820,10 @@
 	},
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/lv522/indoors/a_block/admin)
+"vqw" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/auto_turf/shale/layer2,
+/area/lv522/landing_zone_1)
 "vqH" = (
 /obj/structure/machinery/light{
 	dir = 1
@@ -50840,6 +50916,7 @@
 /area/lv522/indoors/c_block/mining)
 "vso" = (
 /obj/structure/largecrate/random/barrel/yellow,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "floor_marked";
@@ -50907,6 +50984,7 @@
 	},
 /area/lv522/indoors/a_block/kitchen)
 "vtN" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt/cement{
 	icon_state = "cement4"
 	},
@@ -50938,12 +51016,14 @@
 /obj/structure/machinery/door/airlock/almayer/maint{
 	dir = 1
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/corsat{
 	icon_state = "marked"
 	},
 /area/lv522/landing_zone_1/ceiling)
 "vuH" = (
 /obj/structure/largecrate,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "floor_marked";
@@ -51027,7 +51107,7 @@
 /area/lv522/indoors/c_block/mining)
 "vxg" = (
 /obj/structure/cargo_container/watatsumi/right,
-/turf/open/auto_turf/shale/layer0,
+/turf/open/auto_turf/shale/layer1,
 /area/lv522/outdoors/colony_streets/north_east_street)
 "vxv" = (
 /obj/structure/surface/table/woodentable/fancy,
@@ -51210,6 +51290,7 @@
 /turf/open/floor/prison,
 /area/lv522/indoors/a_block/kitchen/glass)
 "vAW" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "floor_marked";
@@ -51246,6 +51327,7 @@
 /obj/structure/platform_decoration{
 	dir = 9
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/gm/river,
 /area/lv522/landing_zone_1/tunnel)
 "vBx" = (
@@ -51334,6 +51416,7 @@
 	pixel_y = 19;
 	serial_number = 16
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/lv522/landing_zone_1/ceiling)
 "vCG" = (
@@ -51450,12 +51533,6 @@
 	},
 /turf/open/auto_turf/shale/layer0,
 /area/lv522/outdoors/colony_streets/north_east_street)
-"vFy" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
-/turf/open/floor/prison,
-/area/lv522/atmos/outdoor)
 "vFH" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/item/lightstick/red/spoke/planted{
@@ -51503,6 +51580,7 @@
 /turf/open/auto_turf/shale/layer1,
 /area/lv522/outdoors/colony_streets/central_streets)
 "vGo" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt/cement,
 /area/lv522/landing_zone_1)
 "vGp" = (
@@ -51643,12 +51721,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
 /area/lv522/indoors/lone_buildings/engineering)
-"vIG" = (
-/obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
-/turf/open/floor/corsat{
-	icon_state = "plate"
-	},
-/area/lv522/atmos/east_reactor/south/cas)
 "vIS" = (
 /turf/open/floor/corsat{
 	dir = 8;
@@ -51890,8 +51962,12 @@
 /area/lv522/indoors/a_block/corpo/glass)
 "vMX" = (
 /obj/structure/surface/rack,
-/obj/item/explosive/plastic,
 /obj/structure/machinery/light,
+/obj/item/ammo_box/magazine/misc/flares{
+	pixel_x = -3;
+	pixel_y = 11
+	},
+/obj/item/ammo_box/magazine/misc/flares,
 /turf/open/floor/prison{
 	icon_state = "darkbrownfull2";
 	tag = null
@@ -51928,6 +52004,8 @@
 	id = "LZ1_Lockdown_Lo";
 	name = "Emergency Lockdown"
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/corsat{
 	icon_state = "marked"
 	},
@@ -52229,9 +52307,11 @@
 "vTQ" = (
 /obj/structure/barricade/handrail,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "vTT" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/corsat{
 	icon_state = "marked"
 	},
@@ -52301,6 +52381,7 @@
 /area/lv522/indoors/a_block/admin)
 "vUX" = (
 /obj/structure/powerloader_wreckage/ft,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	icon_state = "floor_plate";
 	tag = null
@@ -52329,6 +52410,7 @@
 /area/lv522/indoors/a_block/kitchen)
 "vVi" = (
 /obj/structure/largecrate,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -52481,6 +52563,7 @@
 /obj/structure/machinery/computer/cameras/wooden_tv{
 	pixel_y = 6
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "vZm" = (
@@ -52512,6 +52595,7 @@
 /area/lv522/indoors/toilet)
 "vZv" = (
 /obj/structure/cargo_container/kelland/left,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -52573,6 +52657,7 @@
 	dir = 4
 	},
 /obj/structure/largecrate,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "waD" = (
@@ -52761,6 +52846,7 @@
 /area/lv522/outdoors/colony_streets/central_streets)
 "wdI" = (
 /obj/structure/cargo_container/kelland/right,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "floor_marked";
@@ -53191,6 +53277,7 @@
 /area/lv522/indoors/c_block/cargo)
 "wlY" = (
 /obj/structure/largecrate/random/secure,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "floor_marked";
@@ -53262,6 +53349,7 @@
 /obj/structure/machinery/space_heater/radiator/red{
 	dir = 4
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -53325,13 +53413,6 @@
 	tag = null
 	},
 /area/lv522/indoors/lone_buildings/outdoor_bot)
-"wpb" = (
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 4
-	},
-/obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
-/turf/open/floor/corsat,
-/area/lv522/atmos/outdoor)
 "wpd" = (
 /obj/structure/surface/table/gamblingtable,
 /obj/structure/pipes/standard/simple/hidden/green,
@@ -53518,13 +53599,6 @@
 	tag = null
 	},
 /area/lv522/indoors/lone_buildings/outdoor_bot)
-"wtl" = (
-/obj/structure/fence,
-/turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
-	},
-/area/lv522/atmos/filt)
 "wtH" = (
 /obj/structure/pipes/vents/pump,
 /turf/open/floor/corsat{
@@ -53865,14 +53939,6 @@
 	tag = null
 	},
 /area/lv522/indoors/a_block/dorms)
-"wzK" = (
-/obj/structure/largecrate/random/barrel/red,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
-	},
-/area/lv522/atmos/outdoor)
 "wzS" = (
 /obj/structure/platform_decoration,
 /obj/effect/decal/warning_stripes{
@@ -53904,11 +53970,6 @@
 	tag = null
 	},
 /area/lv522/outdoors/colony_streets/north_east_street)
-"wAQ" = (
-/turf/open/floor/corsat{
-	icon_state = "squares"
-	},
-/area/lv522/atmos/east_reactor/south/cas)
 "wBp" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
@@ -54062,14 +54123,6 @@
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/lv522/indoors/a_block/dorms)
-"wEf" = (
-/obj/structure/cargo_container/kelland/right,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
-	},
-/area/lv522/atmos/outdoor)
 "wEi" = (
 /obj/structure/machinery/light{
 	dir = 1
@@ -54231,6 +54284,7 @@
 	},
 /obj/item/clothing/head/hardhat/white,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -54337,13 +54391,6 @@
 	icon_state = "cement1"
 	},
 /area/lv522/outdoors/colony_streets/north_west_street)
-"wKU" = (
-/obj/structure/blocker/forcefield/vehicles,
-/obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
-/turf/open/floor/corsat{
-	icon_state = "squares"
-	},
-/area/lv522/atmos/filt)
 "wKV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/surface/rack,
@@ -54770,13 +54817,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet,
 /area/lv522/indoors/a_block/executive)
-"wWh" = (
-/obj/structure/blocker/forcefield/vehicles,
-/obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
-/turf/open/floor/corsat{
-	icon_state = "plate"
-	},
-/area/lv522/atmos/filt)
 "wWV" = (
 /turf/open/floor/prison{
 	dir = 1;
@@ -55101,6 +55141,7 @@
 	pixel_x = -13;
 	pixel_y = 2
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -55580,13 +55621,6 @@
 	icon_state = "greenfull"
 	},
 /area/lv522/indoors/a_block/fitness)
-"xmz" = (
-/obj/structure/stairs/perspective{
-	dir = 8;
-	icon_state = "p_stair_full"
-	},
-/turf/open/floor/prison,
-/area/lv522/atmos/east_reactor/south/cas)
 "xmD" = (
 /turf/open/floor/corsat{
 	icon_state = "plate"
@@ -55606,6 +55640,7 @@
 /obj/structure/bed/chair{
 	dir = 1
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	icon_state = "floor_plate";
 	tag = null
@@ -56080,6 +56115,7 @@
 	pixel_y = 9
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -56102,9 +56138,6 @@
 	},
 /turf/open/auto_turf/shale/layer0,
 /area/lv522/outdoors/colony_streets/north_east_street)
-"xzP" = (
-/turf/open/auto_turf/shale/layer1,
-/area/lv522/atmos/outdoor)
 "xzV" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
@@ -56355,13 +56388,9 @@
 /turf/open/floor/prison,
 /area/lv522/indoors/a_block/dorms)
 "xED" = (
-/obj/structure/largecrate/random/barrel/yellow,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
-	},
-/area/lv522/atmos/outdoor)
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/closed/wall/mineral/bone_resin,
+/area/lv522/oob)
 "xEH" = (
 /obj/structure/machinery/landinglight/ds1/delayone{
 	dir = 1
@@ -56434,6 +56463,7 @@
 	pixel_y = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/item/stack/sheet/metal/medium_stack,
 /turf/open/floor/prison,
 /area/lv522/indoors/c_block/mining)
 "xHr" = (
@@ -56460,6 +56490,7 @@
 "xIK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/largecrate,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "xIW" = (
@@ -56747,6 +56778,7 @@
 /obj/structure/machinery/power/apc/weak{
 	dir = 1
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt/cement{
 	icon_state = "cement12"
 	},
@@ -56873,14 +56905,6 @@
 	tag = null
 	},
 /area/lv522/indoors/a_block/hallway)
-"xQV" = (
-/obj/structure/pipes/standard/manifold/hidden/green{
-	dir = 8
-	},
-/turf/open/floor/corsat{
-	icon_state = "squares"
-	},
-/area/lv522/atmos/east_reactor/south/cas)
 "xRg" = (
 /obj/structure/bed/chair/comfy{
 	dir = 1;
@@ -56989,10 +57013,10 @@
 	dir = 8;
 	locked = 0
 	},
-/obj/structure/machinery/door/poddoor/shutters/almayer/open{
+/obj/structure/machinery/door/poddoor/shutters/almayer{
 	dir = 4;
 	id = "UD6 East";
-	name = "Shutters"
+	indestructible = 1
 	},
 /turf/open/shuttle/dropship{
 	icon_state = "rasputin3";
@@ -57148,6 +57172,15 @@
 	},
 /turf/open/floor/corsat,
 /area/lv522/atmos/cargo_intake)
+"xVH" = (
+/obj/structure/stairs/perspective{
+	icon_state = "p_stair_full"
+	},
+/obj/structure/platform{
+	dir = 8
+	},
+/turf/open/gm/river,
+/area/lv522/landing_zone_1/tunnel)
 "xVI" = (
 /obj/effect/spawner/gibspawner/xeno,
 /obj/structure/pipes/standard/simple/hidden/green,
@@ -57340,12 +57373,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/lv522/indoors/a_block/bridges/corpo)
-"xZC" = (
-/turf/open/floor/corsat{
-	dir = 1;
-	icon_state = "brown"
-	},
-/area/lv522/atmos/east_reactor/south/cas)
 "xZL" = (
 /obj/structure/machinery/conveyor{
 	dir = 5;
@@ -57357,6 +57384,7 @@
 /area/lv522/atmos/cargo_intake)
 "xZN" = (
 /obj/structure/largecrate/random/secure,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "xZP" = (
@@ -57366,12 +57394,6 @@
 	},
 /turf/open/asphalt/cement,
 /area/lv522/outdoors/colony_streets/north_east_street)
-"yac" = (
-/turf/open/floor/corsat{
-	dir = 8;
-	icon_state = "brown"
-	},
-/area/lv522/atmos/east_reactor/south/cas)
 "yae" = (
 /obj/structure/surface/table/almayer,
 /obj/item/paper_bin{
@@ -57447,11 +57469,16 @@
 /area/lv522/indoors/c_block/cargo)
 "ybd" = (
 /obj/structure/blocker/forcefield/vehicles,
-/obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
-/turf/open/floor/corsat{
-	icon_state = "plate"
+/obj/structure/machinery/door/poddoor/almayer{
+	id = "E_B_Door";
+	name = "\improper Emergency Blast Door";
+	unacidable = 1
 	},
-/area/lv522/atmos/filt)
+/obj/structure/blocker/invisible_wall,
+/turf/open/floor/corsat{
+	icon_state = "squares"
+	},
+/area/lv522/oob)
 "ybj" = (
 /obj/item/prop/alien/hugger,
 /turf/open/auto_turf/shale/layer0,
@@ -57488,15 +57515,6 @@
 	icon_state = "marked"
 	},
 /area/lv522/indoors/lone_buildings/storage_blocks)
-"yco" = (
-/obj/structure/machinery/colony_floodlight{
-	layer = 4.3;
-	pixel_y = 9
-	},
-/turf/open/floor/corsat{
-	icon_state = "marked"
-	},
-/area/lv522/outdoors/colony_streets/north_street)
 "yct" = (
 /obj/structure/surface/rack,
 /obj/effect/decal/cleanable/dirt,
@@ -57746,6 +57764,7 @@
 	},
 /area/lv522/outdoors/colony_streets/south_street)
 "yhU" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	icon_state = "floor_plate";
 	tag = null
@@ -57980,6 +57999,7 @@
 	pixel_x = -7
 	},
 /obj/effect/landmark/objective_landmark/close,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -58022,6 +58042,10 @@
 	icon_state = "marked"
 	},
 /area/lv522/landing_zone_1/ceiling)
+"ymf" = (
+/obj/structure/platform_decoration,
+/turf/open/gm/river,
+/area/lv522/landing_zone_1/tunnel)
 
 (1,1,1) = {"
 bMX
@@ -59114,7 +59138,7 @@ nGe
 pez
 pFw
 qbf
-pxb
+lBl
 paT
 pxb
 pxb
@@ -59338,11 +59362,11 @@ cpy
 cpy
 oyY
 paT
-pxb
-pxb
-pxb
-pxb
-pxb
+lBl
+lBl
+lBl
+lBl
+lBl
 pxb
 nQz
 tPf
@@ -59440,18 +59464,18 @@ cpy
 auG
 auG
 vtc
+jiW
 vtc
 vtc
 vtc
 vtc
-vtc
 uWO
 uWO
 uWO
-uWO
-uWO
-uWO
-uWO
+lQS
+gsZ
+gOj
+han
 cpy
 cpy
 cpy
@@ -59564,12 +59588,12 @@ cpy
 cpy
 cpy
 hTW
-pxb
-xqp
-pxb
-pxb
-pxb
-nQz
+lBl
+vqw
+lBl
+lBl
+lBl
+oYM
 tPf
 oKc
 uZc
@@ -59667,7 +59691,7 @@ vtc
 vtc
 vtc
 vtc
-vtc
+jiW
 vtc
 vtc
 vtc
@@ -59790,13 +59814,13 @@ cpy
 cpy
 cpy
 nGe
-pwa
-pwa
-xqp
-xqp
-xqp
-nQz
-oKc
+veq
+veq
+vqw
+vqw
+vqw
+oYM
+pLm
 ryU
 ryU
 ryU
@@ -59894,7 +59918,7 @@ vtc
 vtc
 vtc
 vtc
-uWO
+jiW
 uWO
 vtc
 vtc
@@ -59911,7 +59935,7 @@ uWO
 vtc
 vtc
 auG
-auG
+jiW
 cpy
 cpy
 cpy
@@ -60017,12 +60041,12 @@ cpy
 cpy
 cpy
 nGJ
-pwa
-pwa
-pxb
-nQz
-tPf
-oKc
+veq
+veq
+lBl
+oYM
+tZM
+pLm
 ryU
 ryU
 uiM
@@ -60121,24 +60145,24 @@ uWO
 uWO
 uWO
 uWO
-uWO
-uWO
-uWO
-vtc
-vtc
-vtc
-vtc
-vtc
-uWO
-uWO
-uWO
-uWO
-uWO
+jiW
 uWO
 uWO
 vtc
 vtc
 vtc
+vtc
+vtc
+uWO
+uWO
+uWO
+uWO
+uWO
+uWO
+uWO
+vtc
+vtc
+jiW
 auG
 vtc
 vtc
@@ -60244,10 +60268,10 @@ cpy
 cpy
 cpy
 nMc
-pxb
-nQz
-tPf
-oKc
+lBl
+oYM
+tZM
+pLm
 ryU
 ryU
 ryU
@@ -60348,24 +60372,24 @@ uWO
 uWO
 uWO
 uWO
-uWO
-uWO
-uWO
-uWO
-uWO
-vtc
-vtc
-vtc
-vtc
-uWO
-uWO
-uWO
+jiW
 uWO
 uWO
 uWO
 uWO
 vtc
 vtc
+vtc
+vtc
+uWO
+uWO
+uWO
+uWO
+uWO
+uWO
+uWO
+vtc
+jiW
 vtc
 jrT
 vtc
@@ -60470,11 +60494,11 @@ cpy
 cpy
 cpy
 lJq
-pxb
-nQz
-oKc
-ryU
-ryU
+lBl
+oYM
+pLm
+pkH
+pkH
 ryU
 wuK
 xfW
@@ -60575,7 +60599,7 @@ hIZ
 hIZ
 mAW
 hIZ
-hIZ
+cJA
 hIZ
 hIZ
 hIZ
@@ -60592,7 +60616,7 @@ jXT
 hIZ
 ivz
 hIZ
-hIZ
+idH
 hSi
 vtc
 uWO
@@ -60697,11 +60721,11 @@ cpy
 cpy
 cpy
 lJq
-nQz
-oKc
-ryU
+oYM
+pLm
+pkH
 pvd
-oyf
+nhi
 tns
 fOc
 uTd
@@ -60802,13 +60826,13 @@ uWO
 uWO
 mwp
 uWO
+jiW
 uWO
+dHR
+dJJ
+eXV
 uWO
-uWO
-uWO
-uWO
-uWO
-uWO
+gcY
 uWO
 uWO
 vtc
@@ -60923,9 +60947,9 @@ cpy
 cpy
 cpy
 cpy
-pwa
+veq
 lWj
-uZc
+cpU
 fSo
 nFj
 pRg
@@ -61029,13 +61053,13 @@ mgJ
 mwp
 uWO
 uWO
-uWO
-hJq
+jiW
 vPk
 vPk
 vPk
 vPk
-bsz
+vPk
+gfL
 uWO
 uWO
 uWO
@@ -61046,7 +61070,7 @@ dXa
 auG
 vtc
 vtc
-vtc
+jiW
 lMH
 jrT
 vtc
@@ -61150,9 +61174,9 @@ tFx
 tFx
 tFx
 niA
-pwa
+veq
 oiC
-ryU
+pkH
 naS
 nFj
 nFj
@@ -61255,9 +61279,9 @@ uWO
 uWO
 uWO
 uWO
-uWO
+aRH
 hJq
-smN
+bIJ
 bIJ
 bIJ
 bIJ
@@ -61273,7 +61297,7 @@ jus
 eXO
 emm
 vtc
-jrT
+jiW
 lMH
 vtc
 uWO
@@ -61377,9 +61401,9 @@ wnP
 rzz
 syM
 rnT
-pxb
+lBl
 ttT
-ryU
+pkH
 haf
 nFj
 nFj
@@ -61482,10 +61506,10 @@ uWO
 uWO
 uWO
 uWO
-uWO
-jbn
+aTA
 bIJ
 bIJ
+fXS
 dsq
 eHX
 bIJ
@@ -61604,9 +61628,9 @@ mvP
 ggS
 tFx
 xOS
-pxb
+lBl
 ttT
-ryU
+pkH
 das
 sYH
 sYH
@@ -61709,10 +61733,10 @@ uWO
 uWO
 uWO
 uWO
-uWO
-jbn
+aTA
 bIJ
-csU
+cMq
+nZF
 nZF
 nZF
 eIn
@@ -61829,11 +61853,11 @@ tFx
 moI
 mxD
 uom
-ymc
+kWp
 rnT
-pxb
+lBl
 ttT
-ryU
+pkH
 eyy
 sYH
 sYH
@@ -61869,11 +61893,11 @@ cpy
 eYM
 eYM
 eYM
-wfP
-wfP
-wfP
+fxZ
+fxZ
+fxZ
 eYM
-sRM
+nvV
 eYM
 eYM
 cpy
@@ -61936,10 +61960,10 @@ xXV
 xXV
 xXV
 aVs
-uWO
-jbn
+aTA
 bIJ
-cMq
+ddo
+eaE
 eaE
 eaE
 cQS
@@ -62056,11 +62080,11 @@ tFx
 inm
 myQ
 myZ
-ymc
+kWp
 rnT
-pxb
+lBl
 ttT
-ryU
+pkH
 naS
 sYH
 sYH
@@ -62096,11 +62120,11 @@ eYM
 eYM
 uqe
 pNa
-wfP
-wfP
-wfP
+fxZ
+fxZ
+fxZ
 pNa
-sRM
+nvV
 ait
 eYM
 cpy
@@ -62163,10 +62187,10 @@ cKG
 bkE
 bkE
 mWc
-uWO
-jbn
+aTA
 bIJ
 cQS
+eaE
 eaE
 eaE
 fhY
@@ -62285,9 +62309,9 @@ rIM
 rIM
 tFx
 rnT
-pxb
+lBl
 ttT
-ryU
+pkH
 haf
 sYH
 sYH
@@ -62320,14 +62344,14 @@ pxb
 cpy
 eYM
 eYM
-jJF
-wfP
+qCs
+fxZ
 eYM
-wfP
-wfP
-wfP
+fxZ
+fxZ
+fxZ
 eYM
-sRM
+nvV
 ait
 eYM
 cpy
@@ -62390,10 +62414,10 @@ dLh
 oEa
 bkE
 mWc
-uWO
-jbn
+aTA
 bIJ
 bIJ
+nZF
 nZF
 nZF
 bIJ
@@ -62507,14 +62531,14 @@ qJy
 aRN
 ien
 mmw
-veQ
-veQ
-fnA
+fbh
+fbh
+fHB
 sSQ
 rnT
-pxb
+lBl
 ttT
-ryU
+pkH
 das
 sYH
 sYH
@@ -62547,14 +62571,14 @@ pxb
 cpy
 eYM
 hUM
-jJF
-wfP
+qCs
+fxZ
 eYM
-wfP
-wfP
-wfP
+fxZ
+fxZ
+fxZ
 eYM
-sRM
+nvV
 ait
 eYM
 cpy
@@ -62617,9 +62641,9 @@ sDS
 oEa
 ncS
 mWc
-uWO
+csU
 gOX
-mlp
+bIJ
 bIJ
 dRn
 bIJ
@@ -62739,9 +62763,9 @@ max
 rFw
 sSQ
 rnT
-pxb
+lBl
 ttT
-ryU
+pkH
 eyy
 nFj
 nFj
@@ -62774,14 +62798,14 @@ cpy
 cpy
 eYM
 vYY
-wfP
-wfP
+fxZ
+fxZ
 eYM
-jJF
-wfP
-wfP
+qCs
+fxZ
+fxZ
 eYM
-sRM
+nvV
 ait
 eYM
 cpy
@@ -62845,8 +62869,8 @@ sDS
 ncS
 mWc
 uWO
-uWO
-gOX
+csU
+bQG
 bQG
 bQG
 bQG
@@ -62966,9 +62990,9 @@ max
 rFw
 sSQ
 rnT
-pxb
+lBl
 jPg
-ryU
+pkH
 naS
 nFj
 nFj
@@ -63002,13 +63026,13 @@ cpy
 eYM
 ofX
 rmC
-wfP
+fxZ
 eYM
-jJF
-wfP
-wfP
+qCs
+fxZ
+fxZ
 eYM
-sRM
+nvV
 ait
 eYM
 cpy
@@ -63193,9 +63217,9 @@ max
 ien
 ien
 ien
-pxb
+lBl
 lWj
-uZc
+cpU
 fBL
 nFj
 pRg
@@ -63229,13 +63253,13 @@ cpy
 eYM
 fLM
 rmC
-wfP
+fxZ
 eYM
-jJF
-wfP
-wfP
+qCs
+fxZ
+fxZ
 eYM
-sRM
+nvV
 ait
 eYM
 cpy
@@ -63420,12 +63444,12 @@ max
 rFw
 sSQ
 rnT
-pxb
+lBl
 lgY
 oKG
-ryU
+pkH
 pwH
-dhP
+sCk
 vJj
 nFj
 aGS
@@ -63456,13 +63480,13 @@ cpy
 eYM
 eYM
 ivb
-wfP
+fxZ
 eYM
-wfP
-wfP
-wfP
+fxZ
+fxZ
+fxZ
 eYM
-sRM
+nvV
 ait
 eYM
 cpy
@@ -63647,12 +63671,12 @@ max
 rFw
 sSQ
 rnT
-pxb
-pxb
+lBl
+lBl
 lgY
 oKG
-ryU
-ryU
+pkH
+pkH
 ryU
 tgq
 qcO
@@ -63681,15 +63705,15 @@ pwa
 pxb
 cpy
 eYM
-evu
-wfP
-wfP
+exQ
+fxZ
+fxZ
 eYM
-wfP
-wfP
-wfP
+fxZ
+fxZ
+fxZ
 eYM
-sRM
+nvV
 ait
 eYM
 eYM
@@ -63874,11 +63898,11 @@ max
 ien
 ien
 ien
-pwa
-pxb
-pxb
+veq
+lBl
+lBl
 lgY
-udi
+qMJ
 oKG
 ryU
 ryU
@@ -63909,14 +63933,14 @@ cpy
 cpy
 eYM
 eYM
-wfP
-wfP
+fxZ
+fxZ
 eYM
-wfP
-wfP
-wfP
+fxZ
+fxZ
+fxZ
 eYM
-sRM
+nvV
 ait
 ait
 eYM
@@ -64101,13 +64125,13 @@ max
 rFw
 sSQ
 rnT
-pwa
-pwa
-pxb
-pxb
-pxb
+veq
+veq
+lBl
+lBl
+lBl
 lgY
-udi
+qMJ
 oKG
 ryU
 ryU
@@ -64136,14 +64160,14 @@ cpy
 cpy
 eYM
 jxF
-wfP
+fxZ
 xZN
 eYM
-wfP
-wfP
+fxZ
+fxZ
 nxF
 eYM
-sRM
+nvV
 ait
 ait
 eYM
@@ -64328,13 +64352,13 @@ max
 rFw
 sSQ
 rnT
-pwa
-pwa
-pwa
-pxb
-pxb
-pxb
-pxb
+veq
+veq
+veq
+lBl
+lBl
+lBl
+lBl
 lgY
 oKG
 ryU
@@ -64367,8 +64391,8 @@ jCh
 eYM
 eYM
 ivb
-wfP
-wfP
+fxZ
+fxZ
 eYM
 vBm
 cHY
@@ -64405,7 +64429,7 @@ vAi
 vAi
 vAi
 vAi
-fbh
+fTO
 uIW
 uIW
 uIW
@@ -64560,11 +64584,11 @@ jZD
 jZD
 jZD
 oiY
-pxb
-pxb
-pxb
+lBl
+lBl
+lBl
 lgY
-udi
+qMJ
 oKG
 uZc
 ryU
@@ -64589,16 +64613,16 @@ pxb
 cpy
 eYM
 eYM
-wfP
-wfP
-wfP
+fxZ
+fxZ
+fxZ
 eYM
-wfP
-wfP
-jJF
+fxZ
+fxZ
+qCs
 eYM
 eYM
-sRM
+nvV
 ait
 eYM
 cpy
@@ -64781,51 +64805,51 @@ max
 max
 rFw
 tFx
-ymc
+kWp
 tFx
 tFx
-ymc
+kWp
 tFx
 rnT
-pxb
-pxb
-pxb
-pxb
-pxb
+lBl
+lBl
+lBl
+lBl
+lBl
 lgY
-udi
+qMJ
 qDt
-ryU
-ryU
-ryU
+pkH
+pkH
+pkH
 taW
-udi
-gVn
-pxb
-pxb
-pxb
-pxb
-pxb
-pxb
-pwa
-pwa
-pwa
-xqp
-xqp
+qMJ
+rPQ
+lBl
+lBl
+lBl
+lBl
+lBl
+lBl
+veq
+veq
+veq
+vqw
+vqw
 cpy
 cpy
 eYM
 mMX
-wfP
-wfP
-wfP
+fxZ
+fxZ
+fxZ
 eYM
-wfP
-wfP
-jJF
+fxZ
+fxZ
+qCs
 xIK
 eYM
-sRM
+nvV
 ait
 eYM
 cpy
@@ -65012,47 +65036,47 @@ wHo
 xzp
 ojb
 uom
-ymc
+kWp
 rnT
-pxb
-pxb
-pxb
-pwa
-pwa
-pxb
-pxb
+lBl
+lBl
+lBl
+veq
+veq
+lBl
+lBl
 qDD
 rys
 rys
 rys
 jYK
-pxb
-pxb
-pxb
-pxb
-pwa
-pwa
-pxb
-pwa
-pwa
-pwa
-pxb
-xqp
-xqp
+lBl
+lBl
+lBl
+lBl
+veq
+veq
+lBl
+veq
+veq
+veq
+lBl
+vqw
+vqw
 cpy
 cpy
 eYM
 mMX
-wfP
-wfP
-wfP
+fxZ
+fxZ
+fxZ
 eYM
-wfP
-wfP
-wfP
-jJF
+fxZ
+fxZ
+fxZ
+qCs
 eYM
-sRM
+nvV
 ait
 eYM
 cpy
@@ -65234,52 +65258,52 @@ max
 max
 ofi
 rFw
-aFf
+kZJ
 ggS
 uol
 uol
 rzz
-ymc
+kWp
 rnT
-pxb
-pxb
-pwa
-pwa
-pwa
-pwa
-pwa
-pwa
-pxb
-pxb
-pxb
-pxb
-pxb
-pxb
-pxb
-pwa
-pwa
-pwa
-pwa
-pwa
-pwa
-pxb
-pxb
-pwa
-xqp
+lBl
+lBl
+veq
+veq
+veq
+veq
+veq
+veq
+lBl
+lBl
+lBl
+lBl
+lBl
+lBl
+lBl
+veq
+veq
+veq
+veq
+veq
+veq
+lBl
+lBl
+veq
+vqw
 cpy
 cpy
 eYM
 oBw
-wfP
-wfP
-wfP
+fxZ
+fxZ
+fxZ
 eYM
 xZN
-wfP
-wfP
-jJF
+fxZ
+fxZ
+qCs
 eYM
-sRM
+nvV
 ait
 eYM
 cpy
@@ -65468,45 +65492,45 @@ nEq
 rzz
 syM
 rnT
-pxb
-pwa
-pwa
-pwa
-xqp
-pwa
-pwa
-pwa
-pwa
-pwa
-pwa
-pwa
-pxb
-pxb
-pwa
-pwa
-pwa
-pwa
-pwa
-pwa
-pxb
-pxb
-pxb
-pxb
-pxb
+lBl
+veq
+veq
+veq
+vqw
+veq
+veq
+veq
+veq
+veq
+veq
+veq
+lBl
+lBl
+veq
+veq
+veq
+veq
+veq
+veq
+lBl
+lBl
+lBl
+lBl
+lBl
 cpy
 cpy
 eYM
 sdN
-wfP
-wfP
-jJF
+fxZ
+fxZ
+qCs
 eYM
 xIK
-wfP
-wfP
+fxZ
+fxZ
 rcR
 eYM
-sRM
+nvV
 ait
 eYM
 cpy
@@ -65586,7 +65610,7 @@ eaE
 uWO
 uWO
 uWO
-uWO
+gcY
 nkv
 uWO
 uWO
@@ -65693,25 +65717,25 @@ lJU
 uol
 vbu
 oPR
-ymc
+kWp
 rnT
-pwa
-pwa
-pwa
-pxb
-xqp
-xqp
-pwa
-pwa
-xqp
-xqp
-xqp
-pwa
-pwa
-pwa
-pwa
-pwa
-pwa
+veq
+veq
+veq
+lBl
+vqw
+vqw
+veq
+veq
+vqw
+vqw
+vqw
+veq
+veq
+veq
+veq
+veq
+veq
 tMq
 jZD
 jZD
@@ -65724,16 +65748,16 @@ cpy
 cpy
 eYM
 kbo
-wfP
-jJF
-jJF
+fxZ
+qCs
+qCs
 eYM
 xIK
-jJF
-wfP
+qCs
+fxZ
 rcR
 eYM
-sRM
+nvV
 ait
 eYM
 cpy
@@ -65813,7 +65837,7 @@ eaE
 eaE
 uWO
 uWO
-uWO
+iod
 uWO
 uWO
 uWO
@@ -65920,16 +65944,16 @@ xdn
 rzz
 omG
 oRS
-ymc
+kWp
 rnT
-pwa
-pwa
-pxb
+veq
+veq
+lBl
 cpy
-pxb
-pxb
-pxb
-pwa
+lBl
+lBl
+lBl
+veq
 rAu
 umK
 sCb
@@ -65937,8 +65961,8 @@ tfb
 tMt
 umK
 uFp
-pwa
-pwa
+veq
+veq
 vtN
 tFx
 tFx
@@ -65951,16 +65975,16 @@ cpy
 cpy
 eYM
 ikb
-wfP
-jJF
+fxZ
+qCs
 eYM
 eYM
 eYM
 ntT
-wfP
-wfP
+fxZ
+fxZ
 eYM
-sRM
+nvV
 ait
 eYM
 cpy
@@ -66040,7 +66064,7 @@ eaE
 eaE
 uWO
 uWO
-uWO
+ioA
 uWO
 uWO
 uWO
@@ -66140,22 +66164,22 @@ max
 max
 max
 tZh
-pAj
-fnA
+fPt
+fHB
 tFx
-ymc
-xXO
-ymc
+kWp
+pid
+kWp
 tFx
 tFx
 rnT
-pxb
-pxb
+lBl
+lBl
 cpy
 cpy
-pxb
-pxb
-pxb
+lBl
+lBl
+lBl
 rAu
 rOw
 tFx
@@ -66164,7 +66188,7 @@ xXO
 tFx
 tFx
 uKY
-vGo
+jZD
 jZD
 vGo
 tFx
@@ -66187,7 +66211,7 @@ eYM
 jCh
 eYM
 eYM
-sRM
+nvV
 ait
 eYM
 cpy
@@ -66219,7 +66243,7 @@ vAi
 vAi
 vAi
 vAi
-fbh
+fTO
 vAi
 fwj
 fGh
@@ -66376,13 +66400,13 @@ jQC
 tFx
 tFx
 rnT
-pxb
-pxb
-pxb
-pxb
-pxb
-pxb
-pwa
+lBl
+lBl
+lBl
+lBl
+lBl
+lBl
+veq
 gej
 tFx
 tFx
@@ -66404,17 +66428,17 @@ tFx
 eYM
 uEV
 sdN
-wfP
-jJF
-jJF
+fxZ
+qCs
+qCs
 eYM
 eYM
 eYM
 nSq
-wfP
-jJF
+fxZ
+qCs
 vTQ
-sRM
+nvV
 eYM
 eYM
 cpy
@@ -66601,15 +66625,15 @@ nnv
 vbu
 vbu
 rzz
-ymc
+kWp
 rnT
-pxb
-pxb
-pxb
-pxb
-pxb
-pxb
-pwa
+lBl
+lBl
+lBl
+lBl
+lBl
+lBl
+veq
 gej
 tFx
 ykU
@@ -66630,18 +66654,18 @@ ggS
 tFx
 eZW
 pET
-wfP
-wfP
-wfP
-jJF
+fxZ
+fxZ
+fxZ
+qCs
 xIK
 eYM
 qXs
-jJF
-wfP
-wfP
+qCs
+fxZ
+fxZ
 vTQ
-sRM
+nvV
 eYM
 cpy
 cpy
@@ -66830,13 +66854,13 @@ uol
 rzz
 syM
 rnT
-pxb
-pxb
-pxb
-pxb
-pxb
-pwa
-pwa
+lBl
+lBl
+lBl
+lBl
+lBl
+veq
+veq
 gej
 ymc
 gQy
@@ -66856,19 +66880,19 @@ ggS
 rSh
 vNW
 pYj
-wfP
-wfP
-wfP
-wfP
-wfP
+fxZ
+fxZ
+fxZ
+fxZ
+fxZ
 waz
 eYM
 qLk
-wfP
-wfP
-wfP
+fxZ
+fxZ
+fxZ
 uIF
-sRM
+nvV
 eYM
 cpy
 cpy
@@ -67055,7 +67079,7 @@ nsr
 uol
 uol
 oVK
-ymc
+kWp
 vGo
 jZD
 ien
@@ -67082,20 +67106,20 @@ nEq
 ggS
 tVj
 tFx
-cLB
+eTu
 kZq
-jJF
+qCs
 qVQ
-jJF
+qCs
 xIK
 eYM
 eYM
 epN
-wfP
-jJF
-jJF
+fxZ
+qCs
+qCs
 uIF
-sRM
+nvV
 eYM
 cpy
 cpy
@@ -67318,11 +67342,11 @@ eYM
 eYM
 eYM
 epN
-wfP
-wfP
-wfP
+fxZ
+fxZ
+fxZ
 vTQ
-sRM
+nvV
 eYM
 cpy
 cpy
@@ -67503,21 +67527,21 @@ hpq
 max
 max
 std
-fnA
+fHB
 tFx
 rIM
 rIM
 rIM
 tFx
-fnA
-veQ
-veQ
+fHB
+fbh
+fbh
 ien
-veQ
-veQ
-veQ
+fbh
+fbh
+fbh
 ien
-veQ
+fbh
 qLu
 aFf
 fDF
@@ -67536,25 +67560,25 @@ vAW
 tVj
 tFx
 tFx
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
+pjl
+pjl
+pjl
+pjl
+pjl
+pjl
+pjl
 eYM
 eYM
-jJF
+qCs
 gXb
-jJF
-jJF
+qCs
+qCs
 eYM
 eYM
-cpy
-cpy
-cpy
-cpy
+pjl
+pjl
+pjl
+pjl
 bMX
 "}
 (43,1,1) = {"
@@ -67731,12 +67755,12 @@ max
 max
 max
 std
-veQ
-veQ
-veQ
-veQ
-veQ
-xVV
+fbh
+fbh
+fbh
+fbh
+fbh
+rJv
 ofi
 max
 max
@@ -67762,23 +67786,23 @@ tFx
 tFx
 tFx
 tFx
+pjl
+pjl
 cpy
 cpy
 cpy
 cpy
 cpy
-cpy
-cpy
-cpy
-cpy
-eYM
+pjl
+pjl
+spj
 eYM
 eYM
 oWK
 eYM
 eYM
-cpy
-cpy
+pjl
+pjl
 cpy
 cpy
 cpy
@@ -67981,16 +68005,16 @@ ufS
 tFx
 tFx
 cpy
-ofi
-tZh
-tZh
-ofi
-max
-max
-ofi
-ofi
-tZh
-tZh
+fHB
+fbh
+fbh
+fbh
+fbh
+fbh
+fbh
+fbh
+fbh
+fHB
 cpy
 cpy
 cpy
@@ -67998,13 +68022,13 @@ cpy
 cpy
 cpy
 cpy
-cpy
-eYM
+pjl
+spj
 iIa
 drd
 uug
-eYM
-cpy
+spj
+pjl
 cpy
 cpy
 cpy
@@ -68207,8 +68231,8 @@ rIM
 rIM
 tFx
 uOA
-uTK
-max
+irR
+xVV
 ofi
 ofi
 ofi
@@ -68217,15 +68241,15 @@ ofi
 ofi
 ofi
 ofi
-ofi
-ofi
-tZh
-tZh
-cpy
-cpy
-cpy
-cpy
-cpy
+gMQ
+veQ
+veQ
+fnA
+bPJ
+bPJ
+bPJ
+bPJ
+bPJ
 bPJ
 pMc
 wfP
@@ -68434,7 +68458,7 @@ szo
 szo
 szo
 uTK
-max
+xVV
 ofi
 ofi
 max
@@ -68447,12 +68471,12 @@ ofi
 ofi
 ofi
 ofi
-ofi
-tZh
-cpy
-cpy
-cpy
-cpy
+osN
+bPJ
+xVH
+kEl
+peM
+jba
 bPJ
 mJs
 wfP
@@ -68674,13 +68698,13 @@ ofi
 max
 ofi
 ofi
-ofi
-tZh
-cpy
-cpy
-cpy
-cpy
-bPJ
+osN
+aQH
+qaT
+hTe
+hTe
+jFl
+aQH
 mJs
 wfP
 wfP
@@ -68901,12 +68925,12 @@ ofi
 ofi
 tZh
 ofi
-ofi
-tZh
-cpy
-cpy
-cpy
-cpy
+osN
+bPJ
+fYD
+qxk
+ymf
+sHd
 bPJ
 eeb
 wfP
@@ -69128,12 +69152,12 @@ max
 ofi
 tZh
 ofi
-ofi
-cpy
-cpy
-cpy
-cpy
-cpy
+osN
+bPJ
+bPJ
+bPJ
+bPJ
+bPJ
 bPJ
 bPJ
 wfP
@@ -69355,8 +69379,8 @@ max
 max
 ofi
 ofi
-ofi
-cpy
+gMQ
+veQ
 cpy
 cpy
 cpy
@@ -71178,9 +71202,9 @@ max
 max
 max
 max
-cpy
-cpy
-cpy
+osN
+bPJ
+bPJ
 bPJ
 qKV
 jJF
@@ -71405,8 +71429,8 @@ max
 max
 max
 max
-cpy
-cpy
+gMQ
+fnA
 bPJ
 bPJ
 fCb
@@ -71631,9 +71655,9 @@ max
 max
 max
 max
-cpy
-cpy
-cpy
+max
+max
+osN
 bPJ
 oeN
 bLA
@@ -71859,8 +71883,8 @@ max
 max
 max
 max
-cpy
-cpy
+max
+osN
 bPJ
 awm
 wfP
@@ -72087,7 +72111,7 @@ max
 max
 max
 max
-max
+osN
 pNa
 awm
 wfP
@@ -72314,7 +72338,7 @@ ofi
 max
 max
 max
-max
+osN
 bPJ
 cLB
 esx
@@ -72483,10 +72507,10 @@ fXx
 vjP
 rMF
 rMF
-voI
+jbv
 rMF
 rMF
-voI
+jbv
 rMF
 rMF
 jkp
@@ -72540,8 +72564,8 @@ aYO
 ofi
 ofi
 max
-max
-max
+pAj
+fnA
 bPJ
 bPJ
 fCb
@@ -72767,9 +72791,9 @@ erA
 ofi
 ofi
 ofi
-max
-cpy
-cpy
+osN
+bPJ
+bPJ
 bPJ
 bLA
 jJF
@@ -72994,7 +73018,7 @@ qdO
 uOd
 uOd
 uOd
-uOd
+fnA
 cpy
 cpy
 bPJ
@@ -75943,8 +75967,8 @@ oIu
 oIu
 owe
 oIu
-oIu
-cpy
+tOo
+bPJ
 bPJ
 oCW
 wfP
@@ -76043,8 +76067,8 @@ fjr
 fjr
 fjr
 fjr
-ugV
-ugV
+fjr
+fjr
 fjr
 fjr
 fjr
@@ -76170,10 +76194,10 @@ mPr
 kOa
 jyM
 nax
-nax
-cpy
+mnb
+ouj
 bPJ
-geT
+pdp
 wfP
 wfP
 wfP
@@ -76264,15 +76288,15 @@ saC
 cpy
 saC
 cpy
-cpy
-cpy
+ien
+fjr
 rxI
 fjr
 fjr
+fjr
 ugV
 ugV
-ugV
-ugV
+fjr
 fjr
 fjr
 crH
@@ -76397,9 +76421,9 @@ mPr
 tKB
 nax
 nax
-nax
-cpy
-bPJ
+mnb
+gmu
+nYU
 geT
 wfP
 jJF
@@ -76491,16 +76515,16 @@ saC
 saC
 saC
 saC
-saC
-cpy
-cpy
+ien
+fjr
+fjr
+fjr
 fjr
 ugV
 ugV
 ugV
 ugV
-ugV
-ugV
+fjr
 rxI
 crH
 uep
@@ -76620,12 +76644,12 @@ mPr
 mPr
 mPr
 mPr
+nax
+pCv
+nax
 mPr
-tKB
-nax
-nax
-nax
-cpy
+mnb
+gmu
 bPJ
 tlB
 wfP
@@ -76717,12 +76741,12 @@ saC
 saC
 saC
 saC
-saC
-saC
-saC
-cpy
-cpy
-ugV
+ien
+ien
+ien
+fjr
+fjr
+fjr
 ugV
 ugV
 ugV
@@ -76850,9 +76874,9 @@ nax
 nax
 pCv
 nax
-nax
-cpy
-cpy
+mPr
+mnb
+eDq
 bPJ
 gJr
 wfP
@@ -76945,11 +76969,11 @@ saC
 saC
 saC
 saC
-saC
-saC
-saC
+ien
+rxI
 fjr
-ugV
+fjr
+fjr
 ugV
 ugV
 xRK
@@ -77078,8 +77102,8 @@ yhR
 nkX
 yhR
 yhR
-cpy
-cpy
+tOo
+bPJ
 bPJ
 pHi
 wfP
@@ -77164,17 +77188,17 @@ saC
 saC
 saC
 saC
-saC
-saC
-saC
-saC
-saC
-saC
-saC
-saC
-saC
-saC
-saC
+iTI
+xED
+xED
+xED
+xED
+xED
+xED
+xED
+lER
+mlp
+rxI
 fjr
 ugV
 ugV
@@ -77291,7 +77315,7 @@ uXp
 ylo
 fCW
 yfu
-yfu
+nXO
 hJQ
 ylo
 hdG
@@ -77390,18 +77414,18 @@ saC
 saC
 saC
 saC
-saC
-saC
-saC
-saC
-saC
-saC
-saC
-saC
-saC
-cpy
-saC
-rxI
+iTI
+iTI
+uKD
+uKD
+uKD
+uKD
+uKD
+uKD
+uKD
+uKD
+mwv
+ncN
 ugV
 ugV
 ugV
@@ -77617,18 +77641,18 @@ tiQ
 saC
 saC
 saC
-saC
-cpy
-cpy
-cpy
-cpy
-saC
-cpy
-saC
-saC
-cpy
-saC
-fjr
+xED
+uKD
+uKD
+abo
+abo
+abo
+abo
+abo
+abo
+uKD
+mwv
+tvO
 ugV
 ugV
 ugV
@@ -77844,18 +77868,18 @@ tiQ
 saC
 saC
 saC
-cpy
-cpy
-saC
-cpy
-cpy
-saC
-cpy
-cpy
-cpy
-cpy
-cpy
-ugV
+xED
+uKD
+abo
+abo
+jbn
+jbn
+jbn
+kIY
+abo
+abo
+mwv
+tvO
 ugV
 ugV
 ugV
@@ -78071,18 +78095,18 @@ saC
 saC
 saC
 saC
-cpy
-cpy
-saC
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
-ugV
+xED
+uKD
+abo
+iZS
+jBr
+jEa
+jEa
+kLk
+lbo
+abo
+mwv
+tvO
 ugV
 ugV
 ugV
@@ -78298,18 +78322,18 @@ saC
 saC
 saC
 saC
-saC
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
-fjr
-ugV
+xED
+uKD
+abo
+iZS
+jEa
+kHd
+jEa
+jEa
+llJ
+lIM
+mHZ
+tvO
 ugV
 ugV
 ugV
@@ -78523,20 +78547,20 @@ saC
 saC
 saC
 saC
-tjR
 saC
 saC
-saC
-saC
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
-fjr
-ugV
+xED
+uKD
+abo
+abo
+kzd
+jEa
+jEa
+jEa
+llJ
+lIM
+mHZ
+tvO
 ugV
 ugV
 ugV
@@ -78749,21 +78773,21 @@ saC
 saC
 saC
 saC
-tjR
-xzn
-xzn
 saC
 saC
 saC
-saC
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
-fjr
-ugV
+xED
+uKD
+abo
+iZS
+jEa
+jEa
+jEa
+jEa
+llJ
+lIM
+mHZ
+tvO
 ugV
 ugV
 ugV
@@ -78972,25 +78996,25 @@ xZw
 xZw
 xrA
 fTS
+tiQ
+tiQ
+tiQ
 saC
-tiQ
-tiQ
-mwv
-vlu
-xzn
-xkB
+saC
+saC
+saC
 xED
-saC
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
-rxI
-fjr
+uKD
+abo
+iZS
+jBr
+jEa
+jEa
+kXY
+lzb
+abo
+mwv
+tvO
 ugV
 ugV
 ugV
@@ -79200,24 +79224,24 @@ xZw
 xrA
 fTS
 uxf
-kXY
-lER
-ojD
-xkB
-xzn
+cpn
+saC
+saC
+saC
+saC
+saC
 xED
-wzK
-xzn
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
-rxI
-fjr
+uKD
+abo
+abo
+jbn
+jbn
+jbn
+kIY
+abo
+abo
+mwv
+tvO
 ugV
 ugV
 ugV
@@ -79427,27 +79451,27 @@ oiW
 xrA
 tKb
 uxf
-vfn
-lER
-xkB
-xkB
-xzn
-xkB
-wzK
-xzn
+ybd
 saC
-cpy
-cpy
-ylm
-yim
-cpy
-cpy
-cpy
-cpy
-rxI
+saC
+saC
+saC
+saC
+xED
+uKD
+uKD
+abo
+abo
+abo
+abo
+abo
+abo
+uKD
+mSc
+tvO
+ugV
+ugV
 fjr
-ugV
-ugV
 xhd
 ahP
 yjp
@@ -79564,8 +79588,8 @@ nax
 mPr
 mPr
 mPr
-fDv
-rot
+oaK
+oaN
 jas
 jas
 jas
@@ -79654,27 +79678,27 @@ xZw
 xrA
 fTS
 uxf
-vfn
-lER
-xzn
-xzn
-xzn
-xzn
+ybd
 saC
-dvO
 saC
-cpy
+saC
+saC
+saC
+iTI
+iTI
 uKD
-pke
-yim
-cpy
-yim
-cpy
-cpy
-cpy
+uKD
+uKD
+uKD
+uKD
+uKD
+uKD
+uKD
+mwv
+uKD
+ugV
+ugV
 fjr
-ugV
-ugV
 jDO
 crH
 wrC
@@ -79803,7 +79827,7 @@ vjr
 aRi
 eHu
 eSO
-tuK
+hzc
 tuK
 jas
 lzP
@@ -79877,32 +79901,32 @@ hXt
 tso
 tso
 tso
-nLF
-rTh
-tLQ
-uxi
-vfc
-nXO
-jxI
-oqG
-jxI
-mSc
-mSc
-dvO
-cpy
-xzn
-uKD
-ylm
-yim
-yim
-yim
-cpy
-cpy
-cpy
+iQb
+xrA
+fTS
+uxf
+ybd
+saC
+saC
+saC
+saC
+saC
+saC
+iTI
+pjl
+xED
+xED
+xED
+xED
+xED
+xED
+lER
+mlp
 fjr
 ugV
 ugV
-hNR
+ugV
+jDO
 crH
 wrC
 sNU
@@ -80031,7 +80055,7 @@ eso
 eso
 uMl
 vWI
-tuK
+hzc
 aAI
 iTb
 wIu
@@ -80108,28 +80132,28 @@ uHn
 xrA
 fTS
 uxf
-vfn
-lER
-xzn
-xkB
-xzn
+ybd
 saC
 saC
-wpb
 saC
-xzn
-uKD
-ylm
-yim
-yim
-yim
 saC
-cpy
 saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+ien
+rxI
+fjr
 fjr
 ugV
 ugV
-hNR
+jDO
 crH
 wrC
 izT
@@ -80258,7 +80282,7 @@ eso
 eso
 eso
 vWI
-tuK
+hzc
 aAI
 ykn
 vpe
@@ -80335,28 +80359,28 @@ nMw
 xrA
 fTS
 uxf
-vfn
-lER
-xzn
-xzn
-vZP
-xzn
-saC
-wpb
-saC
-xzn
-uKD
-ylm
-yim
-yim
-yim
+ybd
 saC
 saC
 saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+ien
+ien
+ien
+fjr
 fjr
 ugV
-ugV
-hNR
+fjr
+jDO
 crH
 wrC
 wrC
@@ -80562,28 +80586,28 @@ uHn
 xrA
 fTS
 saC
-saC
-lER
-xzn
-xzn
-xzn
-xzn
-xzn
-wpb
-xzn
-vlu
-uKD
-ylm
-yim
-yim
-yim
+ybd
 saC
 saC
 saC
 saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+ien
 fjr
-ugV
-hNR
+fjr
+fjr
+fjr
+fjr
+jDO
 crH
 wrC
 sOe
@@ -80789,28 +80813,28 @@ iKw
 wEz
 saC
 saC
-saC
-saC
-xzn
-xzn
-xzn
-xzn
-xzn
-iTI
-xzn
-vlu
-uKD
-ylm
-yim
-yim
-yim
-yim
+ybd
 saC
 saC
 saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+ien
 fjr
 fjr
-hNR
+fjr
+fjr
+fjr
+jDO
 crH
 wrC
 sOe
@@ -81016,25 +81040,25 @@ lgf
 tfW
 tfW
 saC
+ybd
 saC
 saC
-xzn
-xzn
-xzn
-xzn
-xzn
-sQN
-xzn
-xzn
-lbo
-ylm
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
 cpy
-yim
-yim
-yim
 saC
-saC
-saC
+ien
+ien
+ien
+fjr
+fjr
 rxI
 fjr
 jDO
@@ -81245,23 +81269,23 @@ saC
 saC
 tiQ
 tiQ
-okn
-orO
-tjR
-xkB
-xzn
-sQN
-xkB
-xkB
-cpy
-cpy
-cpy
-yim
-yim
-yim
-yim
+saC
+saC
+saC
+saC
+saC
+saC
+saC
 saC
 cpy
+cpy
+cpy
+saC
+saC
+ien
+rxI
+fjr
+fjr
 rxI
 fjr
 jXQ
@@ -81471,28 +81495,28 @@ fTS
 irx
 tiQ
 tiQ
-ogh
-okn
-oNj
-xzn
-xzn
-xzn
-sQN
-wzK
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
 cpy
 cpy
 cpy
 cpy
 cpy
-yim
-yim
-yim
-cpy
-cpy
+saC
+ien
+rxI
+nri
+nMC
+nNi
 fjr
-sBD
-han
-ioA
+fjr
+jDO
 sSn
 ahP
 wrC
@@ -81698,29 +81722,29 @@ vbm
 irx
 tiQ
 tiQ
-ohF
-oly
-otR
-xzn
-oJT
-vlu
-sQN
-cpy
-cpy
-cpy
-cpy
-cpy
-yim
-yim
-yim
-yim
-cpy
 saC
 saC
-dnA
-yco
-aTA
-ugV
+saC
+saC
+saC
+saC
+saC
+cpy
+cpy
+cpy
+cpy
+cpy
+saC
+ien
+ien
+ien
+nGU
+nMT
+nOg
+fjr
+fjr
+jDO
+fjr
 sSn
 hhD
 hhD
@@ -81925,30 +81949,30 @@ xBL
 irx
 tiQ
 tiQ
-xkB
-xkB
-xkB
-xzn
-oKk
-vlu
-sQN
-xzn
-cpy
-cpy
-ylm
-cpy
-yim
-yim
-yim
-yim
 saC
 saC
 saC
-dJJ
-rAz
-idH
-ugV
-ugV
+saC
+saC
+saC
+saC
+saC
+cpy
+cpy
+saC
+cpy
+saC
+saC
+ien
+rxI
+nLF
+nNf
+nOS
+fjr
+fjr
+jXQ
+nQx
+fjr
 ugV
 ugV
 ugV
@@ -82152,29 +82176,29 @@ kfu
 irx
 tiQ
 tiQ
-xzn
-ufA
-owK
-xzn
-oLD
-oLD
-sQN
-xzn
-xzn
-lbo
-ylm
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
 cpy
-yim
-yim
-yim
-yim
-yim
 saC
-saC
-ugV
-ugV
-spe
-vwi
+ien
+ien
+ien
+rxI
+ien
+rxI
+nPy
+nPy
+nPy
+jXQ
 vwi
 vwi
 vpa
@@ -82374,30 +82398,30 @@ tiQ
 tiQ
 tiQ
 tiQ
-irx
-kfu
-irx
 tiQ
 tiQ
-xkB
-onE
-wEf
-xzn
-vZP
-xzn
-sQN
-xzn
-xzn
-lbo
-ylm
-yim
-yim
-yim
-yim
-yim
-yim
-yim
+tiQ
+tiQ
+tiQ
 saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+ien
+ien
+ien
+ien
+ien
+ien
 ien
 ien
 ien
@@ -82601,34 +82625,34 @@ tiQ
 tiQ
 tiQ
 tiQ
-irx
-kfu
-irx
-irx
-irx
-xkB
-ood
-xkB
-xzn
-xkB
-xkB
-oYD
-xzn
-xzn
-lbo
-ylm
-yim
-yim
-yim
-yim
-yim
-yim
-yim
-yim
-yim
+tiQ
+tiQ
+tiQ
+tiQ
+tiQ
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+ien
+ien
+ien
+saC
+ien
+saC
+ien
 ien
 rME
-qSH
+nQQ
 qSH
 trV
 umR
@@ -82828,31 +82852,31 @@ tiQ
 tiQ
 tiQ
 tiQ
-irx
-nOg
-qVN
-tKb
-mXA
-vDw
-vDw
-xzn
-xzn
-xkB
-xkB
-oZq
-pfM
-xzn
-lbo
-ylm
-yim
-yim
-yim
-yim
-yim
-yim
-yim
-yim
-yim
+tiQ
+tiQ
+tiQ
+tiQ
+tiQ
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
 ien
 rMR
 jGa
@@ -83055,30 +83079,30 @@ tiQ
 tiQ
 tiQ
 tiQ
-irx
-nOS
-irx
-irx
-irx
-vDw
-xzn
-xzn
-xzn
-xzn
-xzn
-xzn
-sic
-phm
-lbo
-ylm
-yim
-yim
-yim
+tiQ
+tiQ
+tiQ
+tiQ
+tiQ
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
 cpy
-yim
-yim
-yim
-yim
+saC
+saC
+saC
+saC
 ien
 ien
 ien
@@ -83282,31 +83306,31 @@ qJE
 tiQ
 tiQ
 tiQ
-irx
-nPy
-irx
 tiQ
 tiQ
-xzn
-xzn
-xzn
-xzn
-xzn
-xzn
-xzn
-sQN
-xzn
-lbo
-ylm
-yim
-yim
-yim
+tiQ
+tiQ
+tiQ
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
 cpy
-yim
-yim
-yim
-yim
-yim
+saC
+saC
+saC
+saC
+saC
 ien
 tNQ
 qSH
@@ -83509,31 +83533,31 @@ qJE
 tiQ
 tiQ
 tiQ
-irx
-nPy
-irx
 tiQ
 tiQ
-xzn
-vZP
-xzn
-xzn
-xzn
-xzn
-xzn
-sQN
-xzn
-lbo
-ylm
-yim
-yim
-yim
+tiQ
+tiQ
+tiQ
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
 cpy
-cpy
-yim
-yim
-yim
-yim
+saC
+saC
+saC
+saC
+saC
 ien
 rNm
 jOw
@@ -83736,30 +83760,30 @@ qJE
 tiQ
 tiQ
 tiQ
-irx
-fTS
-irx
 tiQ
 tiQ
-vFy
-xzn
-xzn
-xzn
-oOd
-oSG
-oZF
-sQN
-xzn
-lbo
-ylm
-yim
-yim
+tiQ
+tiQ
+tiQ
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
 cpy
 cpy
 cpy
-yim
-yim
-yim
+saC
+saC
+saC
 ien
 ien
 ien
@@ -83963,31 +83987,31 @@ qJE
 qJE
 tiQ
 tiQ
-irx
-nNL
-irx
 tiQ
 tiQ
-oii
-xmz
-xmz
-xmz
-tWD
 tiQ
-oZP
-sQN
-xzn
-lbo
-ylm
-yim
-yim
+tiQ
+tiQ
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
 cpy
 cpy
 cpy
 cpy
-yim
-yim
-yim
+saC
+saC
+saC
 ien
 iqb
 kdx
@@ -84189,32 +84213,32 @@ jef
 pfj
 nwR
 tiQ
-gfL
-gfL
-nQx
-nQx
-nQx
 tiQ
 tiQ
-opg
-opg
-opg
 tiQ
 tiQ
-xNq
-sQN
-vZP
-lbo
-ylm
-yim
+tiQ
+tiQ
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
 cpy
 cpy
 cpy
 cpy
 cpy
-yim
-yim
-yim
+saC
+saC
+saC
 ien
 isa
 svK
@@ -84416,31 +84440,31 @@ noD
 jWB
 nxQ
 tiQ
-nGU
-nMC
-nQQ
-vIG
-vIG
 saC
-rcI
-rcI
-rcI
-rcI
-rcI
-tiQ
-tyw
-sQN
-xzn
-lbo
-ylm
-yim
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
 cpy
 cpy
 cpy
 cpy
 cpy
-yim
-yim
+saC
+saC
 ien
 ien
 ien
@@ -84643,38 +84667,38 @@ hLY
 saC
 saC
 tiQ
-rcI
-llJ
-llJ
-llJ
-llJ
-llJ
-llJ
-llJ
-llJ
-llJ
-llJ
-tiQ
-uTw
-sQN
-xzn
-uKD
-ylm
-yim
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
 cpy
 cpy
 cpy
 cpy
-yim
-yim
-yim
-yim
+saC
+saC
+saC
+saC
 ien
 iel
 iel
 iel
 trV
-umR
+pZo
 qSH
 uRb
 xjF
@@ -84871,38 +84895,38 @@ saC
 tiQ
 tiQ
 tiQ
-tXt
-yac
-yac
-yac
-yac
-yac
-yac
-yac
-yac
-yac
-tiQ
-uTw
-sQN
-xzn
-uKD
-ylm
-yim
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
 cpy
 cpy
 cpy
 cpy
-yim
-yim
-yim
-yim
+saC
+saC
+saC
+saC
 ien
 iel
 iel
 iel
 trV
-umR
-qSH
+pZo
+vGp
 uRb
 xjF
 vuc
@@ -85088,48 +85112,48 @@ lDr
 lNI
 lNA
 ugN
-pHT
-wXA
-wXA
-lXQ
+qjG
 yiu
-uTf
-hef
-nzj
-nFo
-nGW
-iod
-xQV
-afs
-gOj
-gOj
-gOj
-gOj
-gOj
-gOj
-gOj
-hfY
-pbk
-pgg
-jxI
-pjN
-fdE
-yim
+yiu
+yiu
+yiu
+hLY
+xmD
+ybd
+nFt
+ybd
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
 cpy
 cpy
-cpy
-yim
-yim
-yim
-yim
+saC
+saC
+saC
+saC
+saC
 ien
 ien
 ien
 khG
 isa
 trV
-umR
-qSH
+pZo
+vGp
 uRb
 xjF
 dFn
@@ -85318,45 +85342,45 @@ saC
 qjG
 qjG
 yiu
-jBr
-wXA
+kEL
+yiu
 noV
 xmD
-jFt
+ybd
 nFt
-nHM
-xZC
-rFH
-wAQ
-wAQ
-wAQ
-wAQ
-kzd
-wAQ
-wAQ
-wAQ
-ddo
-uTw
-xzn
-xzn
-uKD
-eXV
-yim
+ybd
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
 cpy
 cpy
-cpy
-yim
-yim
-yim
-yim
-yim
+saC
+saC
+saC
+saC
+saC
+saC
 ien
 ssh
 tNQ
-qSH
+vGp
 trV
-umR
-qSH
+pZo
+vGp
 uRb
 xjF
 xjF
@@ -85510,7 +85534,7 @@ hRW
 dQv
 ccg
 egD
-fPt
+swu
 eRN
 swu
 swu
@@ -85549,41 +85573,41 @@ yiu
 yiu
 hLY
 xmD
-jFt
+ybd
 nFt
-nHM
-xZC
-rFH
-wAQ
-wAQ
-wAQ
+ybd
 saC
-wAQ
-wAQ
-wAQ
-wAQ
-ddo
-uTw
-xzn
-xzn
-uKD
-eXV
-yim
-yim
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
 cpy
-cpy
-yim
-yim
-yim
-yim
-yim
+saC
+saC
+saC
+saC
+saC
+saC
 xrC
 tNQ
 qSH
 qSH
 trV
-umR
-qSH
+pZo
+vGp
 eKe
 xFp
 xjF
@@ -85776,32 +85800,32 @@ juw
 yiu
 hLY
 xmD
-jFt
+ybd
 nFt
-nHM
-xZC
-rFH
-wAQ
-wAQ
+ybd
 saC
 saC
 saC
-wAQ
-wAQ
-wAQ
-ddo
-pcY
-xzn
-xzn
-uKD
-eXV
-yim
-yim
-cpy
-yim
-yim
-yim
-yim
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
 xrC
 xrC
 xrC
@@ -85809,9 +85833,9 @@ wPA
 wPA
 xrC
 xrC
-umR
-qSH
-qSH
+pZo
+vGp
+vGp
 eKe
 dHF
 dHF
@@ -86003,31 +86027,31 @@ yiu
 yiu
 hLY
 xmD
-jFt
+ybd
 nFt
-saC
-xZC
-rFH
-wAQ
+ybd
 saC
 saC
 saC
 saC
 saC
-wAQ
-wAQ
-tiQ
-uTw
-xzn
-xzn
-llZ
-eXV
-yim
-yim
-yim
-yim
-yim
-yim
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
 xrC
 nJV
 elX
@@ -86037,16 +86061,16 @@ ksa
 kOz
 xrC
 lVZ
-qSH
-qSH
-qSH
-qSH
-qSH
+vGp
+vGp
+vGp
+vGp
+vGp
 ecq
-qSH
+vGp
 vxg
-qSH
-qSH
+vGp
+vGp
 aAN
 qSH
 qSH
@@ -86230,31 +86254,31 @@ yiu
 yiu
 hLY
 xmD
-jFt
-saC
-saC
-xZC
-rFH
-wAQ
+ybd
+fdE
+ybd
 saC
 saC
 saC
 saC
 saC
-wAQ
-wAQ
-tiQ
-uTw
-xzn
-xzn
-llZ
-eXV
-yim
-yim
-yim
-yim
-yim
-yim
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
 xrC
 aJS
 ezo
@@ -86264,21 +86288,21 @@ eJR
 rtX
 lUy
 tJm
-qSH
-qSH
-qSH
-qSH
-qSH
+vGp
+vGp
+vGp
+vGp
+vGp
 ecq
-ssh
+nUO
 hqZ
-qSH
+vGp
 qSH
 kdm
 rMR
 qSH
 qSH
-qSH
+vGp
 onj
 pKX
 pKX
@@ -86457,55 +86481,55 @@ yiu
 yiu
 hLY
 xmD
-jFt
-saC
-saC
-xZC
-rFH
-wAQ
+ybd
+fdE
+ybd
 saC
 saC
 saC
 saC
 saC
-wAQ
-wAQ
-ddo
-uTw
-xzn
-xzn
-uKD
-eXV
-yim
-yim
-yim
-yim
-yim
-yim
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
 xrC
 rgW
 eJR
-oaN
+gok
 iHD
 ksk
 kQc
 ttp
 tJG
 qSH
-qSH
-qSH
-qSH
-qSH
+vGp
+vGp
+vGp
+vGp
 ecq
-jGa
+nWq
+vGp
 qSH
 qSH
 qSH
 qSH
 qSH
-qSH
-qSH
-qSH
+vGp
+vGp
 onj
 uNB
 xUQ
@@ -86609,7 +86633,7 @@ sjA
 eso
 goO
 jas
-cpy
+ctE
 jas
 aEF
 nQu
@@ -86684,35 +86708,35 @@ yiu
 yiu
 hLY
 xmD
-nAf
+ybd
 nFt
-saC
-xZC
-rFH
-wAQ
-wAQ
+ybd
 saC
 saC
 saC
-wAQ
-wAQ
-wAQ
-ddo
-uTw
-xzn
-xzn
-uKD
-nri
-qyG
-qyG
-qyG
-qyG
-qyG
-qyG
-nMT
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
 bel
 ftd
-oep
+gok
 iJE
 kvM
 kYL
@@ -86720,19 +86744,19 @@ xrC
 lYg
 qSH
 qSH
-qSH
-qSH
-qSH
+vGp
+vGp
+vGp
 ecq
 tkL
+vGp
 qSH
 qSH
 qSH
 qSH
 qSH
-qSH
-qSH
-qSH
+vGp
+vGp
 onj
 uNB
 xUQ
@@ -86836,7 +86860,7 @@ jas
 jas
 jas
 jas
-cpy
+ctE
 jas
 kFd
 nQu
@@ -86911,32 +86935,32 @@ yiu
 yiu
 hLY
 xmD
-jFt
+ybd
 nFt
-nHM
-xZC
-rFH
-wAQ
-wAQ
-dHR
-wAQ
-wAQ
-wAQ
-wAQ
-wAQ
-ddo
-uTw
-xzn
-xzn
-uKD
-ylm
-yim
+ybd
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
 cpy
-yim
-yim
-yim
-yim
-wPA
+saC
+saC
+saC
+saC
+saC
 btP
 eJR
 eJR
@@ -86948,18 +86972,18 @@ pRv
 xSv
 xSv
 xSv
-xSv
-xSv
+lTV
+lTV
 ssj
-xSv
+lTV
 dCY
 qSH
 qSH
 qSH
 qSH
-qSH
-qSH
-qSH
+vGp
+vGp
+vGp
 onj
 uNB
 pTl
@@ -87058,12 +87082,12 @@ cpy
 cpy
 cpy
 cpy
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
+abo
+ctE
+ctE
+ctE
+ctE
+ctE
 jas
 aEF
 nQu
@@ -87138,33 +87162,33 @@ yiu
 yiu
 hLY
 saC
-jFt
+ybd
 nFt
-nHM
-xZC
-rFH
-kzd
-wAQ
-dHR
-wAQ
-wAQ
-wAQ
-wAQ
-wAQ
-ddo
-uTw
-xzn
-xzn
-uKD
-ylm
+ybd
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
 cpy
 cpy
 cpy
-yim
-yim
-yim
-wPA
-bOG
+saC
+saC
+saC
+saC
+bUN
 gjA
 rtX
 xrC
@@ -87176,16 +87200,16 @@ qSH
 qSH
 qSH
 qSH
-qSH
+vGp
 ecq
-qSH
+vGp
 umR
 qSH
 qSH
 qSH
 qSH
-qSH
-qSH
+vGp
+vGp
 kqp
 sYk
 uNB
@@ -87284,13 +87308,13 @@ wQa
 wQa
 cpy
 cpy
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
+abo
+ctE
+ctE
+ctE
+ctE
+ctE
+ctE
 jas
 aEF
 nQu
@@ -87368,29 +87392,29 @@ saC
 tiQ
 tiQ
 tiQ
-nNf
-lzb
-tXz
-tXz
-oaK
-tXz
-tXz
-tXz
-oHy
-tXz
-tiQ
-uTw
-xzn
-xzn
-uKD
-ylm
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
 cpy
 cpy
 cpy
 cpy
 cpy
-yim
-wPA
+saC
+saC
 bUN
 gok
 hHj
@@ -87403,15 +87427,15 @@ qSH
 qSH
 qSH
 qSH
-qSH
+vGp
 ecq
 qSH
 umR
 qSH
 qSH
 qSH
-qSH
-qSH
+vGp
+vGp
 kqp
 xFp
 xAw
@@ -87511,13 +87535,13 @@ wQa
 wQa
 wQa
 cpy
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
+abo
+ctE
+ctE
+ctE
+ctE
+ctE
+ctE
 jas
 jGe
 nQu
@@ -87594,24 +87618,24 @@ hLY
 saC
 saC
 tiQ
-rcI
-nNi
-llJ
-llJ
-nWq
-saC
-llJ
-llJ
-llJ
 saC
 saC
-tiQ
-uTw
-xzn
-xzn
-uKD
-ylm
-yim
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
 cpy
 cpy
 cpy
@@ -87739,12 +87763,12 @@ wQa
 wQa
 cpy
 cpy
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
+ctE
+ctE
+ctE
+ctE
+ctE
+ctE
 jas
 jGe
 nQu
@@ -87821,25 +87845,25 @@ jef
 saC
 saC
 tiQ
-rcI
-rcI
-rcI
-vIG
-vIG
-saC
-rcI
 saC
 saC
 saC
 saC
-tiQ
-aRH
-xzn
-xzn
-lbo
-ylm
-yim
-yim
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
 cpy
 cpy
 cpy
@@ -87966,12 +87990,12 @@ wQa
 wQa
 cpy
 cpy
-cpy
-cpy
-cpy
-cpy
-cpy
-cpy
+abo
+ctE
+ctE
+ctE
+ctE
+ctE
 jas
 lYG
 nQu
@@ -88048,25 +88072,25 @@ saC
 saC
 saC
 tiQ
-nUO
-nUO
-nUO
-nUO
-nUO
-saC
-mHZ
 saC
 saC
 saC
 saC
-tiQ
-xzn
-xzn
-xzn
-lbo
-ylm
-yim
-yim
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
 cpy
 cpy
 cpy
@@ -88194,11 +88218,11 @@ cpy
 cpy
 cpy
 cpy
-cpy
-cpy
-cpy
-cpy
-cpy
+ctE
+ctE
+ctE
+ctE
+ctE
 jas
 uCo
 sid
@@ -88275,34 +88299,34 @@ saC
 saC
 saC
 tiQ
-tiQ
-tiQ
-tiQ
-tiQ
-tiQ
 saC
-mHZ
-tiQ
-tiQ
-tiQ
-tiQ
-tiQ
-xzn
-xzn
-vZP
-lbo
-ylm
-yim
-yim
-yim
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
 cpy
 cpy
 cpy
 ien
-qSH
-qSH
-qSH
-qSH
+lyP
+vGp
+vGp
+vGp
 qSH
 qSH
 qSH
@@ -88422,10 +88446,10 @@ cpy
 cpy
 cpy
 cpy
-cpy
-cpy
-cpy
-cpy
+abo
+abo
+ctE
+ctE
 jas
 jas
 ogT
@@ -88514,23 +88538,23 @@ saC
 saC
 saC
 saC
-xzn
-xzn
-xzn
-lbo
-ylm
-yim
-yim
-yim
-yim
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
 cpy
 cpy
 ien
-qSH
-qSH
-qSH
-qSH
-qSH
+vGp
+vGp
+vGp
+vGp
+vGp
 qSH
 qSH
 umR
@@ -88650,8 +88674,8 @@ cpy
 cpy
 cpy
 cpy
-cpy
-cpy
+abo
+abo
 jas
 jas
 xln
@@ -88741,22 +88765,22 @@ saC
 saC
 saC
 saC
-xzn
-xzn
-xzn
-lbo
-ylm
-yim
-yim
-yim
-yim
-yim
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
 ien
 ien
 ien
-qSH
-qSH
-qSH
+vGp
+vGp
+vGp
 cpy
 qSH
 qSH
@@ -88878,7 +88902,7 @@ cpy
 cpy
 cpy
 cpy
-cpy
+abo
 jas
 bUx
 vpe
@@ -88967,23 +88991,23 @@ saC
 saC
 saC
 saC
-xzn
-xzn
-xzn
-xzn
-uKD
-ylm
-yim
-yim
-yim
-yim
-yim
-yim
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
 ien
-qSH
-qSH
-qSH
-qSH
+vGp
+vGp
+vGp
+vGp
 cpy
 cpy
 cpy
@@ -89194,22 +89218,22 @@ saC
 saC
 saC
 saC
-xzn
-xzn
-xzn
-xzn
-uKD
-ylm
-yim
-yim
-yim
-yim
-yim
-yim
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
 ien
-qSH
-qSH
-qSH
+lyP
+vGp
+vGp
 cpy
 cpy
 cpy
@@ -89418,27 +89442,27 @@ saC
 saC
 saC
 saC
-tiQ
-tiQ
 saC
-xzn
-xzn
-xzn
-xzn
-uKD
-ylm
-yim
-yim
-yim
-yim
-yim
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
 ien
 ien
 ien
-qSH
-qSH
-qSH
-qSH
+lyP
+vGp
+vGp
+vGp
 cpy
 qSH
 umR
@@ -89629,8 +89653,8 @@ xUx
 mdD
 woG
 xUx
+pNo
 saC
-xSN
 mQw
 sZq
 sZq
@@ -89647,25 +89671,25 @@ saC
 saC
 saC
 saC
-xkB
-xkB
-xkB
-xzn
-xzn
-uKD
-ylm
-yim
-yim
-yim
-yim
 saC
 saC
 saC
-qSH
-qSH
-qSH
-qSH
-qSH
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+vGp
+vGp
+vGp
+vGp
+vGp
 qSH
 qSH
 umR
@@ -89855,9 +89879,9 @@ lFt
 xUx
 mdD
 woG
+xUx
 saC
 saC
-xSN
 mQw
 sZq
 sZq
@@ -89874,25 +89898,25 @@ saC
 saC
 saC
 saC
-xkB
-xkB
-xkB
-xzn
-xzn
-uKD
-ylm
-yim
-yim
-yim
 saC
 saC
 saC
-qSH
-qSH
-qSH
-qSH
-qSH
-qSH
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+lyP
+vGp
+vGp
+vGp
+vGp
+vGp
 qSH
 qSH
 umR
@@ -90082,9 +90106,9 @@ saC
 xUx
 mcE
 xUx
+xUx
 saC
 saC
-xSN
 mQw
 sZq
 sZq
@@ -90101,24 +90125,24 @@ saC
 saC
 saC
 saC
-xzn
-xzn
-xzn
-xzn
-xzn
-uKD
-ylm
-yim
-yim
-yim
 saC
 saC
 saC
-qSH
-qSH
-qSH
-qSH
-qSH
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+vGp
+vGp
+vGp
+vGp
+vGp
 qSH
 qSH
 qSH
@@ -90309,8 +90333,8 @@ lFt
 xWz
 mcE
 xUx
+xUx
 saC
-pNo
 xSN
 mQw
 mZW
@@ -90328,24 +90352,24 @@ saC
 saC
 saC
 saC
-xkB
-xkB
-xkB
-xzn
-xzn
-lbo
-ylm
-yim
-yim
-yim
 saC
 saC
-qSH
-qSH
-qSH
-qSH
-qSH
-qSH
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+lyP
+vGp
+vGp
+vGp
+vGp
+lyP
 cpy
 qSH
 qSH
@@ -90358,11 +90382,11 @@ qSH
 qSH
 qSH
 qSH
-qSH
-qSH
-qSH
-qSH
-umR
+vGp
+vGp
+vGp
+vGp
+pZo
 uRb
 tDS
 dEy
@@ -90555,16 +90579,16 @@ tiQ
 tiQ
 saC
 saC
-xkB
-xkB
-xkB
-xzn
-xzn
-lbo
-ylm
-yim
-yim
-yim
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
 saC
 saC
 saC
@@ -90585,11 +90609,11 @@ qSH
 qSH
 qSH
 qSH
-qSH
-qSH
+vGp
+vGp
 cpy
-qSH
-umR
+vGp
+pZo
 uRb
 tDS
 kEW
@@ -90782,17 +90806,17 @@ tiQ
 tiQ
 saC
 saC
-xzn
-xzn
-xzn
-xzn
-xzn
-lbo
-ylm
-yim
-yim
-yim
-yim
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
 saC
 saC
 saC
@@ -90813,10 +90837,10 @@ qSH
 qSH
 qSH
 qSH
-qSH
+vGp
 cpy
 cpy
-umR
+pZo
 uRb
 tDS
 nLe
@@ -91009,17 +91033,17 @@ tiQ
 tiQ
 saC
 saC
-xzn
-xzn
-xzn
-xzn
-xzn
-lbo
-ylm
-yim
-yim
-yim
-yim
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
 saC
 saC
 dRL
@@ -91040,10 +91064,10 @@ nQa
 qSH
 qSH
 qSH
-qSH
-qSH
+vGp
+vGp
 cpy
-umR
+pZo
 tWt
 nSE
 tDS
@@ -91236,17 +91260,17 @@ sZq
 tiQ
 tiQ
 saC
-xzn
-xzn
-xzn
-xzn
-xzn
-lbo
-ylm
-yim
-yim
-yim
-yim
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
 saC
 saC
 dRL
@@ -91268,9 +91292,9 @@ nQa
 qSH
 qSH
 qSH
-qSH
-qSH
-umR
+vGp
+vGp
+pZo
 onj
 tDS
 bTF
@@ -91440,7 +91464,7 @@ jHb
 kKh
 vrV
 saC
-saC
+lFt
 xUx
 mcE
 xUx
@@ -91462,19 +91486,19 @@ sZq
 sZq
 sZq
 tiQ
-tjR
-xkB
-xzn
-xzn
-xzn
-xzn
-uKD
-ylm
-yim
-yim
-yim
-yim
-yim
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
 saC
 dRL
 dRL
@@ -91495,9 +91519,9 @@ fKf
 qSH
 qSH
 qSH
-qSH
-qSH
-umR
+vGp
+vGp
+pZo
 onj
 svf
 lHa
@@ -91666,7 +91690,7 @@ jJj
 jJj
 mLp
 tiQ
-saC
+xUx
 lFt
 xUx
 mcE
@@ -91689,19 +91713,19 @@ sZq
 lJl
 ntN
 tiQ
-oIm
-vlu
-xkB
-xkB
-xzn
-xzn
-uKD
-ylm
-yim
-yim
-yim
-yim
-yim
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
 saC
 dRL
 imA
@@ -91723,8 +91747,8 @@ qSH
 qSH
 qSH
 qSH
-qSH
-umR
+vGp
+pZo
 onj
 fRk
 ibk
@@ -91893,7 +91917,7 @@ vrV
 vrV
 tiQ
 tiQ
-saC
+afs
 lFt
 xUx
 mcE
@@ -91916,20 +91940,20 @@ kBK
 mqA
 tiQ
 tiQ
-xzn
-xzn
-xzn
-xzn
-xzn
-xzn
-uKD
-ylm
-yim
-yim
-yim
-yim
-yim
-hxu
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
 dRL
 ipf
 jjF
@@ -91950,8 +91974,8 @@ qSH
 qSH
 qSH
 qSH
-qSH
-umR
+vGp
+pZo
 onj
 fRk
 lHa
@@ -92129,35 +92153,35 @@ xUx
 saC
 saC
 tiQ
-ncN
+akM
 saC
 tiQ
 saC
-xSN
-xSN
-xSN
-xSN
-xSN
-xSN
-xSN
-xSN
+vrV
+vrV
+vrV
+vrV
+vrV
+vrV
+vrV
+vrV
 tiQ
 tiQ
 tiQ
-tyw
-xzn
-xzn
-xzn
-xzn
-uKD
-ylm
-yim
-yim
-yim
-yim
-yim
-hxu
-cJA
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+dRL
 iDO
 jAV
 hXy
@@ -92178,7 +92202,7 @@ qSH
 qSH
 qSH
 qSH
-umR
+pZo
 onj
 fRk
 ibk
@@ -92332,7 +92356,7 @@ kca
 dKF
 saC
 saC
-xUx
+saC
 xSN
 rza
 rza
@@ -92355,35 +92379,35 @@ woG
 xUx
 xUx
 saC
-rza
-rza
+ybd
+dnA
 saC
 saC
 saC
 saC
-rza
-rza
-rza
-rza
-rza
-rza
-rza
-xSN
-wKU
-lER
-uTw
-xkB
-xzn
-xzn
-vZP
-lbo
-ylm
-yim
-yim
-yim
-yim
-pjJ
-hxu
+dnA
+dnA
+dnA
+dnA
+dnA
+dnA
+dnA
+hfY
+ybd
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
 dRL
 dRL
 rqT
@@ -92559,7 +92583,7 @@ kca
 hhu
 kca
 saC
-saC
+xUx
 xSN
 xUx
 iam
@@ -92582,35 +92606,35 @@ mua
 woG
 xUx
 xUx
-xWz
-xUx
-xUx
-xUx
-xUx
-xUx
-xUx
-xUx
-xUx
-xUx
-xUx
-xUx
-xUx
-xSN
-wWh
-lER
-uTw
-xkB
-xzn
-xzn
-xzn
-lbo
-ylm
-yim
-yim
-yim
-yim
-pjJ
-hxu
+ybd
+xcU
+xcU
+xcU
+xcU
+xcU
+xcU
+xcU
+xcU
+xcU
+xcU
+xcU
+xcU
+hfY
+ybd
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
 dRL
 hXy
 xCT
@@ -92809,35 +92833,35 @@ xUx
 xUx
 woG
 woG
-xUx
-xUx
-xUx
-woG
-woG
-woG
-xUx
-xUx
-xUx
-woG
-woG
-woG
-mHP
-xSN
 ybd
-lER
-uTw
-xzn
-xzn
-xkB
-xkB
-lbo
-ylm
-yim
-yim
-yim
-pjJ
-pjJ
-hxu
+xcU
+xcU
+akM
+akM
+akM
+xcU
+xcU
+xcU
+akM
+akM
+akM
+gpM
+hfY
+ybd
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
 dRL
 dRL
 gMV
@@ -93036,36 +93060,36 @@ saC
 xUx
 woG
 woG
-mHP
-xUx
-xUx
-woG
-woG
-woG
-xUx
-xUx
-xUx
-woG
-woG
-woG
-xUx
-xSN
 ybd
-lER
-uTw
-xzn
-xzn
-pgL
-pgL
-lbo
-ylm
-yim
-yim
-yim
-pjJ
-pjJ
-mZN
-gWI
+xcU
+xcU
+akM
+akM
+akM
+xcU
+xcU
+xcU
+akM
+akM
+akM
+xcU
+hfY
+ybd
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
 dRL
 dRL
 dRL
@@ -93247,7 +93271,7 @@ xUx
 xUx
 xUx
 iWy
-saC
+xUx
 xUx
 jKo
 kbu
@@ -93263,36 +93287,36 @@ xUx
 woG
 xUx
 xUx
-xUx
-xUx
-xUx
-xUx
-xUx
-xUx
-mHP
-xUx
-xUx
-xUx
-xUx
-xUx
-xWz
-xSN
-wWh
-lER
-uTw
-xkB
-xzn
-xzn
-vDw
-lbo
-ylm
-yim
-yim
-yim
-pjJ
-pjJ
-pjJ
-mZN
+ybd
+xcU
+xcU
+xcU
+xcU
+xcU
+gpM
+xcU
+xcU
+xcU
+xcU
+xcU
+mug
+hfY
+ybd
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
 saC
 saC
 dHF
@@ -93473,10 +93497,10 @@ hOG
 aCJ
 aCJ
 aCJ
+aCJ
 saC
 saC
-saC
-saC
+aCJ
 kbJ
 aCJ
 aCJ
@@ -93490,36 +93514,36 @@ woG
 xUx
 xUx
 mEg
-aCJ
-aCJ
-aCJ
-aCJ
-aCJ
-aCJ
-aCJ
-aCJ
-aCJ
-aCJ
-aCJ
-aCJ
-aCJ
-xSN
-wKU
-lER
-uTw
-xkB
-xzn
-xkB
-xkB
-lbo
-ylm
-yim
-yim
-yim
+ybd
+dci
+dci
+dci
+dci
+dci
+dci
+dci
+dci
+dci
+dci
+dci
+dci
+hfY
+ybd
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
 cpy
-vjW
-pjJ
-pjJ
+saC
+saC
+saC
 saC
 saC
 saC
@@ -93703,7 +93727,7 @@ iIt
 saC
 saC
 saC
-xUx
+saC
 xUx
 xUx
 xUx
@@ -93723,31 +93747,31 @@ saC
 tiQ
 saC
 saC
-xSN
-xSN
-xSN
-xSN
-xSN
-xSN
-xSN
+vrV
+vrV
+vrV
+vrV
+vrV
+vrV
+vrV
 tiQ
 tiQ
 tiQ
-aRH
-xzn
-vDw
-xzn
-xzn
-lbo
-rbR
-yim
-yim
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
 cpy
 cpy
-vjW
-pjJ
-pjJ
-pjJ
+saC
+saC
+saC
+saC
 saC
 saC
 saC
@@ -93959,22 +93983,22 @@ nGC
 oiA
 tiQ
 tiQ
-wtl
-gcY
-gcY
-gcY
-gcY
-gcY
-kLk
-iZS
-yim
-pjJ
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
 cpy
-vjW
-pjJ
-pjJ
-vjW
-pjJ
+saC
+saC
+saC
+saC
+saC
 saC
 saC
 saC
@@ -94186,23 +94210,23 @@ wbR
 oiP
 opp
 tiQ
-jEa
-sbE
-gpM
-gpM
-gpM
-gpM
-gpM
-lIM
-pjJ
-pjJ
-pjJ
-pjJ
-pjJ
-vjW
-vjW
-pjJ
-vjW
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
 saC
 qBQ
 kyH
@@ -94413,23 +94437,23 @@ nhb
 wbR
 wbR
 tiQ
-kHd
-xzP
-xzP
-xzP
-xzP
-xzP
-xzP
-pjJ
-pjJ
-pjJ
-pjJ
-pjJ
-pjJ
-pjJ
-pjJ
-pjJ
-vjW
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
 cpy
 rdq
 saY
@@ -94640,23 +94664,23 @@ wbR
 wbR
 tiQ
 tiQ
-kIY
-tpc
-xzP
-xzP
-xzP
-xzP
-xzP
-pjJ
-vjW
-vjW
-pjJ
-pjJ
-pjJ
-pjJ
-pjJ
-pjJ
-vjW
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
+saC
 ien
 ien
 ien
@@ -94866,22 +94890,22 @@ wbR
 wbR
 wbR
 tiQ
-gsZ
-kIY
-tpc
-tpc
-tpc
-xzP
-xzP
+saC
+saC
+saC
+saC
+saC
+saC
+saC
 cpy
 cpy
 cpy
 cpy
-vjW
-pjJ
-pjJ
-vjW
-vjW
+saC
+saC
+saC
+saC
+saC
 cpy
 cpy
 cpy


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

This PR makes changes to the LZ1 area of LV522 along with the south reactor flank being removed and the addition of a W-Y Vault as an optional RP objective for corporate-aligned COs or greedy marines

This PR also gives the FORECON CO a Windbreaker jacket to make him more recognizable to his men

# Explain why it's good for the game

LZ1: With my last LV522 PR I placed blast doors around LZ1 with the intent being to deny survs and xenos from getting inside, this did not work and I accidentally created a very strong hold area for FORECON this PR aims to fix my blunder with the newly added short fog

South Filt: The area south of reactor filt was removed because I felt it was redundant and made the map too large while adding nothing making it harder for aliens to build in a centralized spot without fear of a flanking route that completely bypasses it, a future planned reactor rework aims to address multiple problems with LV522 but this is a stopgap until then

At the request of nanu a new route has been added from north colony command to south reactor filt

The Vault: I've added a W-Y vault north of Corpo dome east of fitness, this area will likely not see use outside of the possibility of greedy marines raiding it for a more corpo aligned CO wanting to secure the money and gold inside

Tornado: I forgot to add this at first but the UD6 tornado has been changed to require a button pressed from the Typhoon to open it up to get the loot, this was added to require FORECON to move around more to get good loot items instead of holding one spot

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:SpartanBobby
maptweak: added short fog around LZ1 on LV522 marines will not see this as it will be gone by the time they land
maptweak: heavily edited a flanking route south of reactor filt on LV522
maptweak: Added a W-Y Corpo vault filled with gold and money to LV522 marines are encouraged to raid it Weyland aligned COs are encouraged to secure it for their corporate overlords
maptweak: Removed some ways into the western reactor and some another route lightly longer to get to
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
