### PR TITLE
Fixes doctors without set job options spawning incorrectly

### DIFF
--- a/code/game/jobs/job/civilians/support/doctor.dm
+++ b/code/game/jobs/job/civilians/support/doctor.dm
@@ -13,6 +13,7 @@
 	supervisors = "the chief medical officer"
 	selection_class = "job_doctor"
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT
+	gear_preset = /datum/equipment_preset/uscm_ship/uscm_medical/doctor
 
 	// job option
 	job_options = list(DOCTOR_VARIANT, SURGEON_VARIANT)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Fixes doctors without set job options spawning incorrectly.

Default gear preset was not set.

# Explain why it's good for the game

Bug bad

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
fix: Fixed doctors without set job options spawning incorrectly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
