### PR TITLE
Berserker tweaks

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/ravager/ravager_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/ravager/ravager_abilities.dm
@@ -65,11 +65,11 @@
 	action_type = XENO_ACTION_CLICK
 	ability_primacy = XENO_PRIMARY_ACTION_1
 	plasma_cost = 0
-	xeno_cooldown = 17 SECONDS
+	xeno_cooldown = 18 SECONDS
 
 	// Config values
 	var/speed_buff = 0.75
-	var/buff_duration = 7 SECONDS
+	var/buff_duration = 5 SECONDS
 
 
 /datum/action/xeno_action/activable/clothesline
@@ -83,7 +83,7 @@
 	xeno_cooldown = 16 SECONDS
 
 	// Config values
-	var/base_heal = 100
+	var/base_heal = 75
 	var/additional_healing_enraged = 100
 	var/damage = 20
 	var/fling_dist_base = 4

--- a/code/modules/mob/living/carbon/xenomorph/abilities/ravager/ravager_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/ravager/ravager_powers.dm
@@ -254,6 +254,7 @@
 	X.recalculate_speed()
 
 	addtimer(CALLBACK(src, PROC_REF(apprehend_off)), buff_duration, TIMER_UNIQUE)
+	X.add_filter("apprehend_on", 1, list("type" = "outline", "color" = "#522020ff", "size" = 1)) // Dark red because the berserker is scary in this state
 
 	apply_cooldown()
 
@@ -261,6 +262,7 @@
 
 /datum/action/xeno_action/onclick/apprehend/proc/apprehend_off()
 	var/mob/living/carbon/xenomorph/X = owner
+	X.remove_filter("apprehend_on")
 	if (istype(X))
 		X.speed_modifier += speed_buff
 		X.recalculate_speed()
@@ -313,7 +315,7 @@
 	if (X.mutation_type == RAVAGER_BERSERKER)
 		var/datum/behavior_delegate/ravager_berserker/BD = X.behavior_delegate
 
-		if (BD.rage >= 1)
+		if (BD.rage >= 2)
 			BD.decrement_rage()
 			heal_amount += additional_healing_enraged
 		else

--- a/code/modules/mob/living/carbon/xenomorph/mutators/strains/ravager/berserker.dm
+++ b/code/modules/mob/living/carbon/xenomorph/mutators/strains/ravager/berserker.dm
@@ -52,7 +52,7 @@
 
 	// Eviscerate config
 	var/rage_lock_duration = 10 SECONDS   // 10 seconds of max rage
-	var/rage_cooldown_duration = 7 SECONDS  // 7 seconds of NO rage.
+	var/rage_cooldown_duration = 8 SECONDS  // 8 seconds of NO rage.
 
 	// State for tracking rage
 	var/rage = 0


### PR DESCRIPTION
# About the pull request

This PR tweaks parts of berserkers kit. 
Apprehend: CD increased by a second, glowy outline when it is enabled, speed buff timer lowered by 2 seconds
Clothesline: Base (no stack heal) reduced by 25 max heal is now 175 (with stacks). Rage stack requirement increased by 1.
Rage lock out: Increased by 1 second (7 to 8).

# Explain why it's good for the game

Berserker is outperforming its main caste, Base Ravager by a crazy margin. Its abilities compliment each other too well, and apprehend is reaching into eviscerate max rage speed buff territory when I have tried to prevent this in the past. Clothesline also has been an extremely easy "get out of jail" free card, and having a max 200 heal for 1 singular rage stack was simply too busted. Rage lock out is also too short, I believe 8 seconds is the sweet spot for not being too long, or too short for either side. Overall, these changes will not make or break the caste but rather ensure its balanced.

![image](https://user-images.githubusercontent.com/125149403/232170288-df6682c4-0688-41be-ab12-132490b8f007.png)


# Changelog Usnpeepoo


:cl:
balance: Berserker apprehend CD increased by a second, speed buff lowered by 2 seconds
balance:  Berserker clothesline max heal reduced by 25, rage stack requirement increased by 1
balance: Berserker rage lockout increased by 1 second
add: Berserkers apprehend now has an glowy outline for when it is activated
/:cl:

