### PR TITLE
Revert "Fixes the contents showing under crates/barrels when you disassemble them"

### DIFF
--- a/code/game/objects/structures/crates_lockers/largecrate.dm
+++ b/code/game/objects/structures/crates_lockers/largecrate.dm
@@ -18,32 +18,16 @@
 	return
 
 /obj/structure/largecrate/proc/unpack()
-	var/turf/current_turf = get_turf(src) // Get the turf the crate is on
-
-	var/list/temp_contents = contents.Copy() // Temporarily store the contents of the crate
+	for(var/atom/movable/A in contents)
+		A.forceMove(loc)
 	playsound(src, unpacking_sound, 35)
 	deconstruct(TRUE)
 
-	var/obj/item/stack/sheet/material_sheet // Variable to store the reference of the crate material
-	if(parts_type) // Create the crate material and store its reference
-		material_sheet = new parts_type(current_turf, 2)
-
-	for(var/atom/movable/current_atom in temp_contents) // Move the objects back to the turf, above the crate material
-		current_atom.forceMove(current_turf)
-
-	if(material_sheet) // Move the crate material to the bottom of the turf's contents
-		move_to_bottom(material_sheet, current_turf)
-
-/// Custom proc to move an object to the bottom of the turf's contents
-/obj/structure/largecrate/proc/move_to_bottom(obj/moving_down, turf/current_turf)
-	if(!istype(moving_down) || !istype(current_turf))
-		return
-	for(var/atom/movable/checking_atom in current_turf.contents)
-		if(checking_atom != moving_down)
-			checking_atom.layer = max(checking_atom.layer, moving_down.layer + 0.1)
-
 /obj/structure/largecrate/deconstruct(disassembled = TRUE)
-	if(!disassembled)
+	if(disassembled)
+		if(parts_type)
+			new parts_type(loc, 2)
+	else
 		new /obj/item/stack/sheet/wood(loc)
 	return ..()
 


### PR DESCRIPTION
Reverts cmss13-devs/cmss13#3043


closes https://github.com/cmss13-devs/cmss13/issues/3059

Fix it and then re-PR.

:cl:
fix: Reverts crate/barrel disassemble change
/:cl: