### PR TITLE
Fixes the contents showing under crates/barrels when you disassemble them V2

### DIFF
--- a/code/game/objects/structures/crates_lockers/largecrate.dm
+++ b/code/game/objects/structures/crates_lockers/largecrate.dm
@@ -18,16 +18,35 @@
 	return
 
 /obj/structure/largecrate/proc/unpack()
-	for(var/atom/movable/A in contents)
-		A.forceMove(loc)
+	var/turf/current_turf = get_turf(src) // Get the turf the crate is on
+
 	playsound(src, unpacking_sound, 35)
+
+	var/obj/item/stack/sheet/material_sheet // Variable to store the reference of the crate material
+	if(parts_type) // Create the crate material and store its reference
+		material_sheet = new parts_type(current_turf, 2)
+
+	// Move the objects back to the turf, above the crate material
+	while(contents.len)
+		var/atom/movable/current_atom = contents[1]
+		current_atom.forceMove(current_turf)
+
 	deconstruct(TRUE)
 
+	// Move the crate material to the bottom of the turf's contents
+	if(material_sheet)
+		move_to_bottom(material_sheet, current_turf)
+
+/// Custom proc to move an object to the bottom of the turf's contents
+/obj/structure/largecrate/proc/move_to_bottom(obj/moving_down, turf/current_turf)
+	if(!istype(moving_down) || !istype(current_turf))
+		return
+	for(var/atom/movable/checking_atom in current_turf.contents)
+		if(checking_atom != moving_down)
+			checking_atom.layer = max(checking_atom.layer, moving_down.layer + 0.1)
+
 /obj/structure/largecrate/deconstruct(disassembled = TRUE)
-	if(disassembled)
-		if(parts_type)
-			new parts_type(loc, 2)
-	else
+	if(!disassembled)
 		new /obj/item/stack/sheet/wood(loc)
 	return ..()
 

--- a/code/game/objects/structures/crates_lockers/largecrate.dm
+++ b/code/game/objects/structures/crates_lockers/largecrate.dm
@@ -28,7 +28,7 @@
 		material_sheet = new parts_type(current_turf, 2)
 
 	// Move the objects back to the turf, above the crate material
-	while(contents.len)
+	for(var/atom/movable/moving_atom in contents)
 		var/atom/movable/current_atom = contents[1]
 		current_atom.forceMove(current_turf)
 

--- a/code/game/objects/structures/crates_lockers/largecrate.dm
+++ b/code/game/objects/structures/crates_lockers/largecrate.dm
@@ -22,7 +22,8 @@
 
 	playsound(src, unpacking_sound, 35)
 
-	var/obj/item/stack/sheet/material_sheet // Variable to store the reference of the crate material
+	/// Store the reference of the crate material
+	var/obj/item/stack/sheet/material_sheet
 	if(parts_type) // Create the crate material and store its reference
 		material_sheet = new parts_type(current_turf, 2)
 


### PR DESCRIPTION
Fixed edition of #3043

### Original PR description:
I hate this bug so much I don't know why it wasn't fixed until now it makes maintenance/planetside looting so much more of a hastle than it needs to be (you need to right click on everything you disassemble or alt click the turf to see the stack? Who thought this was a good idea?)

The code takes the material of the crate and reorganizes the stack using a new proc to ensure it is on the bottom of the list meaning that the contents will show up on the top.

![image](https://user-images.githubusercontent.com/24533979/232187069-a0c074c5-6bd1-4483-8273-f952756620e4.png)

:cl: Hopek
fix: Disassembled crates/barrels will now correctly show their contents above the deconstruction material meaning that you don't have to right click or alt click the turf to see what you looted. Doesn't make the contents break reality this time.
fix: Fixed duplicate crate/barrel disassembly material spawning because it was being created in two places. If people want 2 material per crate/barrel they'll have to intentionally code it in this time vs it being a bug.
/:cl:
