### PR TITLE
Replaced Solaris Ridge M39B/2's

### DIFF
--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -136,6 +136,11 @@
 	starting_attachment_types = list(/obj/item/attachable/stock/smg, /obj/item/attachable/suppressor, /obj/item/attachable/angledgrip, /obj/item/attachable/magnetic_harness)
 	current_mag = /obj/item/ammo_magazine/smg/m39/heap
 
+/obj/item/weapon/gun/smg/m39/elite/unlocked
+	name = "modified M39B/2 submachinegun"
+	desc = "A modified version M-39 submachinegun, re-engineered for better weight, handling and accuracy. Given only to elite units. This one seems to have its Weyland-Yutani ID restrictions removed."
+	flags_gun_features = GUN_AUTO_EJECTOR|GUN_CAN_POINTBLANK|GUN_AMMO_COUNTER
+
 
 //-------------------------------------------------------
 //M5, a classic SMG used in a lot of action movies.

--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -136,11 +136,6 @@
 	starting_attachment_types = list(/obj/item/attachable/stock/smg, /obj/item/attachable/suppressor, /obj/item/attachable/angledgrip, /obj/item/attachable/magnetic_harness)
 	current_mag = /obj/item/ammo_magazine/smg/m39/heap
 
-/obj/item/weapon/gun/smg/m39/elite/unlocked
-	name = "modified M39B/2 submachinegun"
-	desc = "A modified version M-39 submachinegun, re-engineered for better weight, handling and accuracy. Given only to elite units. This one seems to have its Weyland-Yutani ID restrictions removed."
-	flags_gun_features = GUN_AUTO_EJECTOR|GUN_CAN_POINTBLANK|GUN_AMMO_COUNTER
-
 //-------------------------------------------------------
 //M5, a classic SMG used in a lot of action movies.
 

--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -141,7 +141,6 @@
 	desc = "A modified version M-39 submachinegun, re-engineered for better weight, handling and accuracy. Given only to elite units. This one seems to have its Weyland-Yutani ID restrictions removed."
 	flags_gun_features = GUN_AUTO_EJECTOR|GUN_CAN_POINTBLANK|GUN_AMMO_COUNTER
 
-
 //-------------------------------------------------------
 //M5, a classic SMG used in a lot of action movies.
 

--- a/maps/map_files/BigRed/BigRed.dmm
+++ b/maps/map_files/BigRed/BigRed.dmm
@@ -25288,7 +25288,7 @@
 	},
 /area/bigredv2/caves/eta/research)
 "bzJ" = (
-/obj/item/weapon/gun/smg/m39/elite/unlocked,
+/obj/item/weapon/gun/smg/m39,
 /obj/structure/closet/secure_closet/guncabinet/wy,
 /turf/open/floor{
 	dir = 9;

--- a/maps/map_files/BigRed/BigRed.dmm
+++ b/maps/map_files/BigRed/BigRed.dmm
@@ -25288,7 +25288,7 @@
 	},
 /area/bigredv2/caves/eta/research)
 "bzJ" = (
-/obj/item/weapon/gun/smg/m39/elite,
+/obj/item/weapon/gun/smg/m39/elite/unlocked,
 /obj/structure/closet/secure_closet/guncabinet/wy,
 /turf/open/floor{
 	dir = 9;


### PR DESCRIPTION
# About the pull request

~~Creates a subtype of the M39B/2 that does not have the WY lock~~
Replaces the Eta M39B/2's with regular M39's

# Explain why it's good for the game

fixes #2975 

# Changelog

:cl:
fix: The M39B/2's in Eta on Solaris Ridge are now regular M39's
/:cl: