### PR TITLE
Misc bino fixes

### DIFF
--- a/code/game/objects/items/devices/binoculars.dm
+++ b/code/game/objects/items/devices/binoculars.dm
@@ -106,7 +106,7 @@
 		return
 	if(mods["ctrl"])
 		if(user.stat != CONSCIOUS)
-			to_chat(user,SPAN_WARNING("You cannot use [src] while incapacitated."))
+			to_chat(user, SPAN_WARNING("You cannot use [src] while incapacitated."))
 			return FALSE
 		if(SEND_SIGNAL(user, COMSIG_BINOCULAR_HANDLE_CLICK, src))
 			return FALSE


### PR DESCRIPTION
# About the pull request

Binoculars now properly disable on death and being dropped

# Explain why it's good for the game

fixes #372 
(fixes potentially #1884, am unsure)

# Changelog

:cl:
fix: Removes some ways of using binos when you should not be able to
/:cl: