### PR TITLE
Mapped damaged barricades have correct sprites

### DIFF
--- a/code/game/objects/structures/barricade/barricade.dm
+++ b/code/game/objects/structures/barricade/barricade.dm
@@ -35,6 +35,8 @@
 
 /obj/structure/barricade/Initialize(mapload, mob/user)
 	. = ..()
+	if(health != maxhealth) //Update cades mapped with a custom health
+		update_health(0, TRUE)
 	if(user)
 		user.count_niche_stat(STATISTICS_NICHE_CADES)
 	addtimer(CALLBACK(src, PROC_REF(update_icon)), 0)


### PR DESCRIPTION
# About the pull request

Barricades take 0 damage on initialization causing them to update their info

# Explain why it's good for the game

fixes #2960 

# Changelog

:cl:
fix: Barricades that are mapped to started damage correctly show the damage
/:cl: