### PR TITLE
Gives CLF Hostile Survivors Colony IFF

### DIFF
--- a/code/modules/gear_presets/survivors.dm
+++ b/code/modules/gear_presets/survivors.dm
@@ -1300,7 +1300,7 @@
 	skills = /datum/skills/civilian/survivor/clf
 	languages = list(LANGUAGE_ENGLISH, LANGUAGE_JAPANESE)
 	faction = FACTION_CLF
-	faction_group = list(FACTION_CLF) //they were not a part of the colony and as such do not have survivor or marine IFF
+	faction_group = list(FACTION_CLF, FACTION_SURVIVOR)
 	access = list(ACCESS_CIVILIAN_PUBLIC)
 	survivor_variant = HOSTILE_SURVIVOR
 


### PR DESCRIPTION
# About the pull request

Gives the CLF Survivors the "Survivor" IFF

# Explain why it's good for the game

Fixes CLF survivors not having IFF
(I was told it was an oversight)

# Changelog

:cl:
fix: Hostile Survivors get Survivor IFF
/:cl: