### PR TITLE
Reflective walls no longer care about IFF

### DIFF
--- a/code/game/turfs/walls/wall_types.dm
+++ b/code/game/turfs/walls/wall_types.dm
@@ -1096,7 +1096,7 @@
 			P.damage *= brute_multiplier
 		return ..()
 	if(P.ammo.flags_ammo_behavior & AMMO_NO_DEFLECT)
-		// Bullet gets absorbed if it has IFF or can't be reflected.
+		// Bullet gets absorbed if it can't be reflected.
 		return
 
 	var/obj/item/projectile/new_proj = new(src, construction_data ? construction_data : create_cause_data(initial(name)))

--- a/code/game/turfs/walls/wall_types.dm
+++ b/code/game/turfs/walls/wall_types.dm
@@ -1095,7 +1095,7 @@
 		if(P.ammo.damage_type == BRUTE)
 			P.damage *= brute_multiplier
 		return ..()
-	if(P.runtime_iff_group || P.ammo.flags_ammo_behavior & AMMO_NO_DEFLECT)
+	if(P.ammo.flags_ammo_behavior & AMMO_NO_DEFLECT)
 		// Bullet gets absorbed if it has IFF or can't be reflected.
 		return
 


### PR DESCRIPTION
Why:
IFF isn't in the bullet but the gun sighting system.
The wall redirects the bullet back; therefore the bullet would no longer be IFF sighted.


:cl: Hopek
balance: The resin reflective walls no longer recognize IFF bullets and send them back as if they were regular bullets because an alien wall shouldn't know the difference because it is just a wall.
/:cl:
