### PR TITLE
Resin Whisperers can now interact with resin doors with Coerce Resin

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/mutators/strains/hivelord/resin_whisperer.dm
+++ b/code/modules/mob/living/carbon/xenomorph/mutators/strains/hivelord/resin_whisperer.dm
@@ -77,6 +77,16 @@
 	if(!target_turf)
 		return
 
+	/// Check if the target is a resin door and open or close it
+	if(istype(target_atom, /obj/structure/mineral_door/resin))
+		var/obj/structure/mineral_door/resin/resin_door = target_atom
+		resin_door.TryToSwitchState(owner)
+		if(resin_door.state)
+			to_chat(owner, SPAN_XENONOTICE("You focus your connection to the resin and remotely close the resin door."))
+		else
+			to_chat(owner, SPAN_XENONOTICE("You focus your connection to the resin and remotely open the resin door."))
+		return
+
 	// since actions are instanced per hivelord, and only one construction can be made at a time, tweaking the datum on the fly here is fine. you're going to have to figure something out if these conditions change, though
 	if(care_about_adjacency)
 		if(owner.Adjacent(target_turf))


### PR DESCRIPTION
Resin Whisperers can now remotely interact with resin doors.
Just press the middle mouse button on them with the "Coerce Resin" mode.

![dreamseeker_eDGE5ycfNT](https://user-images.githubusercontent.com/24533979/232377890-59c7de16-9b3b-4d06-a615-7b369ab186e8.gif)


:cl: Hopek
add: Resin Whisperers can now use Coerce Resin to open and close resin doors.
/:cl:
