### PR TITLE
Fix a start now error and add the ability of queuing the start of the game

### DIFF
--- a/code/modules/admin/tabs/round_tab.dm
+++ b/code/modules/admin/tabs/round_tab.dm
@@ -165,12 +165,13 @@
 	set name = "Start Round"
 	set desc = "Start the round RIGHT NOW"
 	set category = "Server.Round"
-
-	if (!SSticker)
-		alert("Unable to start the game as it is not set up.")
-		return
 	if (alert("Are you sure you want to start the round early?",,"Yes","No") != "Yes")
 		return
+	if (SSticker.current_state == GAME_STATE_STARTUP)
+		alert("Game is setting up and will launch as soon as it is ready.")
+		message_admins(SPAN_BLUE("[usr.key] has started the process to start the game when loading is finished."))
+		while (SSticker.current_state == GAME_STATE_STARTUP)
+			sleep(50) // it patiently waits for the game to be ready here before moving on.
 	if (SSticker.current_state == GAME_STATE_PREGAME)
 		SSticker.request_start()
 		message_admins(SPAN_BLUE("[usr.key] has started the game."))

--- a/code/modules/admin/tabs/round_tab.dm
+++ b/code/modules/admin/tabs/round_tab.dm
@@ -169,7 +169,7 @@
 		return
 	if (SSticker.current_state == GAME_STATE_STARTUP)
 		alert("Game is setting up and will launch as soon as it is ready.")
-		message_admins(SPAN_BLUE("[usr.key] has started the process to start the game when loading is finished."))
+		message_admins(SPAN_ADMINNOTICE("[usr.key] has started the process to start the game when loading is finished."))
 		while (SSticker.current_state == GAME_STATE_STARTUP)
 			sleep(50) // it patiently waits for the game to be ready here before moving on.
 	if (SSticker.current_state == GAME_STATE_PREGAME)

--- a/code/modules/admin/tabs/round_tab.dm
+++ b/code/modules/admin/tabs/round_tab.dm
@@ -168,7 +168,7 @@
 	if (alert("Are you sure you want to start the round early?",,"Yes","No") != "Yes")
 		return
 	if (SSticker.current_state == GAME_STATE_STARTUP)
-		alert("Game is setting up and will launch as soon as it is ready.")
+		message_admins("Game is setting up and will launch as soon as it is ready.")
 		message_admins(SPAN_ADMINNOTICE("[usr.key] has started the process to start the game when loading is finished."))
 		while (SSticker.current_state == GAME_STATE_STARTUP)
 			sleep(50) // it patiently waits for the game to be ready here before moving on.


### PR DESCRIPTION
This PR does two things.

Fixes this error when trying to start early
![dreamseeker_lIUnkd0lFZ](https://user-images.githubusercontent.com/24533979/232609965-5cf94825-0671-420b-8625-16f505f26d63.png)


And adds queuing meaning that if an admin wants to start a game early during loading; it will now tell them that the game will launch as soon as it is available then waits for the game to be ready before starting.

Before this PR it just tells you that the game isn't ready then you have to wait for it to load and launch the "start now" command again.

Does not bypass the "are you sure?" check because it has been moved to the front.

Honestly made this PR because I hate waiting for the start I just want to do it once when I see the game window then step away for like a minute instead of having to wait for it.


:cl: Hopek
add: Adds the support for queuing the round start meaning that if an admin pressed "start now" it will actually wait until the game is loaded then immediately start the game as expected versus telling you to try later.
fix: fixed the "start now" verb displaying that the game has already started when it is loading because it didn't understand how to read the game state properly.
/:cl:

