### PR TITLE
Fixes PMC (and others) backup SMG from being put back in the holster once drawn

### DIFF
--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -100,7 +100,7 @@
 	current_mag = /obj/item/ammo_magazine/smg/m39/ap
 	flags_gun_features = GUN_AUTO_EJECTOR|GUN_CAN_POINTBLANK|GUN_AMMO_COUNTER|GUN_WY_RESTRICTED
 	map_specific_decoration = FALSE
-	starting_attachment_types = list(/obj/item/attachable/stock/smg)
+	starting_attachment_types = null // This used to be a stock but it makes the gun too large to put back in to the m39 holster
 
 	random_spawn_chance = 100
 	random_spawn_rail = list(

--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -100,7 +100,7 @@
 	current_mag = /obj/item/ammo_magazine/smg/m39/ap
 	flags_gun_features = GUN_AUTO_EJECTOR|GUN_CAN_POINTBLANK|GUN_AMMO_COUNTER|GUN_WY_RESTRICTED
 	map_specific_decoration = FALSE
-	starting_attachment_types = null // This used to be a stock but it makes the gun too large to put back in to the m39 holster
+	starting_attachment_types = /obj/item/attachable/stock/smg/collapsible
 
 	random_spawn_chance = 100
 	random_spawn_rail = list(

--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -100,7 +100,7 @@
 	current_mag = /obj/item/ammo_magazine/smg/m39/ap
 	flags_gun_features = GUN_AUTO_EJECTOR|GUN_CAN_POINTBLANK|GUN_AMMO_COUNTER|GUN_WY_RESTRICTED
 	map_specific_decoration = FALSE
-	starting_attachment_types = /obj/item/attachable/stock/smg/collapsible
+	starting_attachment_types = list(/obj/item/attachable/stock/smg/collapsible)
 
 	random_spawn_chance = 100
 	random_spawn_rail = list(


### PR DESCRIPTION
With the gun drawn the SMG becomes too large to put back in the holster so you can take it out but not have a place to put it back.

This bug occurred to me when I spawned in as the sniper PMC and when I drew my SMG I had no way to put it back except until after I took the stock off or collapsed it.

:cl: Hopek
fix: The m39 elite variant sub machine gun can now be put back in your holster if you spawn with it as a PMC (and whoever else uses them)
/:cl:
