### PR TITLE
Fixes a double name var in a surgery file

### DIFF
--- a/code/modules/surgery/eye.dm
+++ b/code/modules/surgery/eye.dm
@@ -143,7 +143,7 @@
 
 /datum/surgery_step/cauterize/eyes
 	name = "Cauterize Eye Incisions"
-	name = "cauterize the incisions"
+	desc = "cauterize the incisions"
 	time = 3 SECONDS
 
 /datum/surgery_step/cauterize/eyes/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, tool_type, datum/surgery/surgery)


### PR DESCRIPTION
# About the pull request

it was doubling on "name" and was missing the "desc"

(Are these even visible from in the game?)
# Explain why it's good for the game

Minor spelling mistake...

# Changelog

:cl:
spellcheck: Fixes a missing desc in the eye cauterization surgery step
/:cl: