### PR TITLE
Revert synth blood dodge due to revert of acid blood changes

### DIFF
--- a/code/modules/mob/living/carbon/human/species/synthetic.dm
+++ b/code/modules/mob/living/carbon/human/species/synthetic.dm
@@ -41,8 +41,6 @@
 	knock_down_reduction = 5
 	stun_reduction = 5
 
-	acid_blood_dodge_chance = 35
-
 	inherent_verbs = list(
 		/mob/living/carbon/human/synthetic/proc/toggle_HUD,
 	)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Think stan forgot to revert this since it was a follow up PR after the acid blood changes.

Simply reverts the acid blood dodge chance for synths

# Explain why it's good for the game

What happened:

Geevies buffed acid blood damage
https://github.com/cmss13-devs/cmss13/pull/197

Geevies buffed synth dodge chance due to how punishing it was
https://github.com/cmss13-devs/cmss13/pull/484

Stan reverted the acid blood damage buff
https://github.com/cmss13-devs/cmss13/pull/2260


Now this PR will revert 484 only in regards to synth blood dodge chance. Predator unaffected and the rest of the refactor remains fine if this wants to be revisited for other species.

# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
balance: Reverts synth acid blood dodge chance due to revert in acid blood damage
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
