### PR TITLE
Burrowed factor should affect t3 slots ( since it affects t2 slots )

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -769,15 +769,13 @@
 			if(2) slots[TIER_2][GUARANTEED_SLOTS][initial(C.caste_type)] = slot_count
 			if(3) slots[TIER_3][GUARANTEED_SLOTS][initial(C.caste_type)] = slot_count
 
-	var/total_xenos = 0
 	var/effective_total = burrowed_factor
 	for(var/mob/living/carbon/xenomorph/xeno as anything in totalXenos)
 		if(xeno.counts_for_slots)
-			total_xenos++
 			effective_total++
 
 	// Tier 3 slots are always 20% of the total xenos in the hive
-	slots[TIER_3][OPEN_SLOTS] = max(0, Ceiling(0.20*total_xenos/tier_slot_multiplier) - used_tier_3_slots)
+	slots[TIER_3][OPEN_SLOTS] = max(0, Ceiling(0.20*effective_total/tier_slot_multiplier) - used_tier_3_slots)
 	// Tier 2 slots are between 30% and 50% of the hive, depending
 	// on how many T3s there are.
 	slots[TIER_2][OPEN_SLOTS] = max(0, Ceiling(0.5*effective_total/tier_slot_multiplier) - used_tier_2_slots - used_tier_3_slots)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Burrowed factor ( a calculation on how much burrowed larva exists which is the minimum between the number of burrowed larva or 2 times the sqrt of burrowed larva ) will now affect T3 slots.

It already affects T2 slots.

I took a look at the history and this is what I saw:


An old balance pass where T3s were still affected by effective total ( which included burrowed factor / pooled factor originally called )
[Xeno balance pass and minor QOL](https://github.com/cmss13-devs/cmss13/commit/1e2751c2c6cb12d27adca2beabb10cd24d4c8a1b)

Accidental removal of the effective total in determining T3 slots. Made it so that there was only ever 1 T3 slot.
[Buffs barrel charger and buckshot](https://github.com/cmss13-devs/cmss13/commit/7a58b314d01e3066c7080d7d38fc3eb6eaa2b8fe)

Fix that didn't revert the balance properly
[Fixes an emberassing hive status bug](https://github.com/cmss13-devs/cmss13/commit/885d9f98ee8eac3a335387067e4b8e968ad97681)

![image](https://user-images.githubusercontent.com/107966994/233225251-93e0269a-9bda-4eb7-8587-0d76c1b41b6a.png)


Keep in mind, all I'm doing is adding the pooled factor / burrowed factor back into the calculation of how many slots are available. I am not reverting this back to the old 25% of hive can be T3 which all of these are based off of.

# Explain why it's good for the game

Balance and fixing something that doesn't make sense where it affects one lower tier and not the higher tier.

Here's what the balance would look like:

Pooled factor is the minimum of these two:

Number of burrowed larva

vs

2 * sqrt( burrowed larva )

If there's 7 burrowed larva, xenos will be able to get ~1 T3 slot from burrowed alone. ( 20% of hive can be a T3 so pooled factor needs to be around 5 to accomplish this )

If there's 25 burrowed larva, xenos will be able to get ~2 T3 slots from burrowed alone. ( This is where pooled factor hits 10 which would count for 2 T3 slots )

| Burrowed Larva  | Pooled Factor|
| ------------- | ------------- |
| 0|0 |
| 1|1|
| 2|2 |
| 3|3|
|4|4|
|5|4.47|
|6|4.89|
|7|5.29|
|...|...|
|25|10|


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
balance: Fix T3 slots not being affected by burrowed larva
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
