### PR TITLE
Lets you use more symbols in var edits

### DIFF
--- a/code/modules/admin/view_variables/get_variables.dm
+++ b/code/modules/admin/view_variables/get_variables.dm
@@ -121,12 +121,12 @@
 
 	switch(.["class"])
 		if(VV_TEXT)
-			.["value"] = tgui_input_text(usr, "Enter new text:", "Text", current_value)
+			.["value"] = tgui_input_text(usr, "Enter new text:", "Text", current_value, encode = FALSE)
 			if(.["value"] == null)
 				.["class"] = null
 				return
 		if(VV_MESSAGE)
-			.["value"] = tgui_input_text(usr, "Enter new text:", "Text", current_value)
+			.["value"] = tgui_input_text(usr, "Enter new text:", "Text", current_value, encode = FALSE)
 			if(.["value"] == null)
 				.["class"] = null
 				return


### PR DESCRIPTION
# About the pull request

Allows you to use symbols such as ' without the var edited text completely breaking

# Explain why it's good for the game

it gives more options for var editing

# Changelog

:cl:
admin: Allows staff to use more symbols in var editing
/:cl: