### PR TITLE
Fix organs showing up as broken at low damages

### DIFF
--- a/code/modules/mob/living/living_healthscan.dm
+++ b/code/modules/mob/living/living_healthscan.dm
@@ -264,7 +264,7 @@ GLOBAL_LIST_INIT(known_implants, subtypesof(/obj/item/implant))
 			var/current_organ = list(
 				"name" = organ.name,
 				"damage" = organ.damage,
-				"status" = organ.organ_status == ORGAN_BRUISED ? "Bruised" : "Broken",
+				"status" = organ.organ_status == ORGAN_BROKEN ? "Broken" : "Bruised",
 				"robotic" = organ.robotic
 			)
 			damaged_organs += list(current_organ)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request
Fixes low organ damage being shown as broken. Previously, organ damage below 10 showed up as broken, when it should be bruised.
Changes tested (see pictures).
Fixes #3113

# Explain why it's good for the game
Organs showing as broken below 10 damage is confusing
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Previous behavior:
![health scan bad](https://user-images.githubusercontent.com/40726633/233414486-72e2f2bf-4d6a-41c0-929f-e30d1b998bb9.png)

Fixed behavior:
![health scan correct](https://user-images.githubusercontent.com/40726633/233414698-277ae21e-2bd4-445a-8295-396e3314d947.png)

Still shows as broken above 30 damage:
![health scan broken correct](https://user-images.githubusercontent.com/40726633/233414800-58dd4839-612c-4fa1-9d76-4610a815f339.png)

</details>

# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: low organ damage will now show as bruised instead of broken in health scan
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
