### PR TITLE
Fix huggers unable to hug unconscious people

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
@@ -273,7 +273,7 @@
 		return
 
 	var/mob/living/carbon/M = L
-	if(M.stat || M.mob_size >= MOB_SIZE_BIG || can_not_harm(L) || M == src)
+	if(M.stat == DEAD || M.mob_size >= MOB_SIZE_BIG || can_not_harm(L) || M == src)
 		throwing = FALSE
 		return
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Facehuggers can now pounce hug unconscious people.

This will need to be test merged as I am editing the pounced_mob, which will likely affect runners and lurkers. 

It doesn't seem to have any side effects on runner when I tried this but never hurts to test it. I think it freezes lurkers now when they pounce unconscious people as if they pounced a conscious person. That could be looked into.

# Explain why it's good for the game

It's a weird bug that if someone is sleeping, they can't be pounce hugged so you need to use the longer attach method. They're asleep for crying out loud! That's a coup de grâce waiting to happen.

Here's a good way to replicate the bug with the current non-fixed code:
1. Spawn a human
2. Toggle sleeping the human ( context menu -> toggle sleeping )
3. Spawn as playable hugger
4. Hug the unconscious human

This is a perfectly healthy sleeping human. Huggers should be able to pounce them.

All it does is cause them to leap at the human and not hug them. 

# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: Pouncing unconscious people will no longer stop the pounce effects ( such as hugging )
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
