### PR TITLE
Marine Major announcement delay

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -486,6 +486,3 @@ SUBSYSTEM_DEF(ticker)
 	if(mode)
 		mode.is_in_endgame = TRUE
 		mode.force_end_at = (world.time + 25 MINUTES)
-
-/datum/controller/subsystem/ticker/proc/toggle_roundend_check()
-	roundend_check_paused = !roundend_check_paused

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -486,3 +486,6 @@ SUBSYSTEM_DEF(ticker)
 	if(mode)
 		mode.is_in_endgame = TRUE
 		mode.force_end_at = (world.time + 25 MINUTES)
+
+/datum/controller/subsystem/ticker/proc/toggle_roundend_check()
+	roundend_check_paused = !roundend_check_paused

--- a/code/game/gamemodes/colonialmarines/colonialmarines.dm
+++ b/code/game/gamemodes/colonialmarines/colonialmarines.dm
@@ -288,7 +288,7 @@
 			else
 				SSticker.roundend_check_paused = TRUE
 				round_finished = MODE_INFESTATION_M_MAJOR //Humans destroyed the xenomorphs.
-				addtimer(CALLBACK(SSticker, TYPE_PROC_REF(/datum/controller/subsystem/ticker, toggle_roundend_check)), MARINE_MAJOR_ROUND_END_DELAY)
+				addtimer(VARSET_CALLBACK(SSticker, roundend_check_paused, FALSE), MARINE_MAJOR_ROUND_END_DELAY)
 		else if(!num_humans && !num_xenos)
 			round_finished = MODE_INFESTATION_DRAW_DEATH //Both were somehow destroyed.
 

--- a/code/game/gamemodes/colonialmarines/colonialmarines.dm
+++ b/code/game/gamemodes/colonialmarines/colonialmarines.dm
@@ -1,4 +1,5 @@
 #define HIJACK_EXPLOSION_COUNT 5
+#define MARINE_MAJOR_ROUND_END_DELAY 3 MINUTES
 
 /datum/game_mode/colonialmarines
 	name = "Distress Signal"
@@ -285,7 +286,10 @@
 			if(SSticker.mode && SSticker.mode.is_in_endgame)
 				round_finished = MODE_INFESTATION_X_MINOR //Evacuation successfully took place.
 			else
+				SSticker.roundend_check_paused = TRUE
 				round_finished = MODE_INFESTATION_M_MAJOR //Humans destroyed the xenomorphs.
+				addtimer(CALLBACK(SSticker, TYPE_PROC_REF(/datum/controller/subsystem/ticker, toggle_roundend_check)), MARINE_MAJOR_ROUND_END_DELAY)
+				marine_announcement("Bioscan complete.\n\nALL CLEAR\nALL CLEAR\nALL CLEAR", "[MAIN_AI_SYSTEM] Bioscan Status", 'sound/AI/bioscan.ogg')
 		else if(!num_humans && !num_xenos)
 			round_finished = MODE_INFESTATION_DRAW_DEATH //Both were somehow destroyed.
 
@@ -541,3 +545,4 @@
 		incrementer++
 
 #undef HIJACK_EXPLOSION_COUNT
+#undef MARINE_MAJOR_ROUND_END_DELAY

--- a/code/game/gamemodes/colonialmarines/colonialmarines.dm
+++ b/code/game/gamemodes/colonialmarines/colonialmarines.dm
@@ -289,7 +289,6 @@
 				SSticker.roundend_check_paused = TRUE
 				round_finished = MODE_INFESTATION_M_MAJOR //Humans destroyed the xenomorphs.
 				addtimer(CALLBACK(SSticker, TYPE_PROC_REF(/datum/controller/subsystem/ticker, toggle_roundend_check)), MARINE_MAJOR_ROUND_END_DELAY)
-				marine_announcement("Bioscan complete.\n\nNo more unknown life signatures detected in the area of operations.\n\nAll clear.", "[MAIN_AI_SYSTEM] Bioscan Status", 'sound/AI/bioscan.ogg')
 		else if(!num_humans && !num_xenos)
 			round_finished = MODE_INFESTATION_DRAW_DEATH //Both were somehow destroyed.
 

--- a/code/game/gamemodes/colonialmarines/colonialmarines.dm
+++ b/code/game/gamemodes/colonialmarines/colonialmarines.dm
@@ -289,7 +289,7 @@
 				SSticker.roundend_check_paused = TRUE
 				round_finished = MODE_INFESTATION_M_MAJOR //Humans destroyed the xenomorphs.
 				addtimer(CALLBACK(SSticker, TYPE_PROC_REF(/datum/controller/subsystem/ticker, toggle_roundend_check)), MARINE_MAJOR_ROUND_END_DELAY)
-				marine_announcement("Bioscan complete.\n\nALL CLEAR\nALL CLEAR\nALL CLEAR", "[MAIN_AI_SYSTEM] Bioscan Status", 'sound/AI/bioscan.ogg')
+				marine_announcement("Bioscan complete.\n\nNo more unknown life signatures detected in the area of operations.\n\nAll clear.", "[MAIN_AI_SYSTEM] Bioscan Status", 'sound/AI/bioscan.ogg')
 		else if(!num_humans && !num_xenos)
 			round_finished = MODE_INFESTATION_DRAW_DEATH //Both were somehow destroyed.
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

This PR makes it so when a marine major occurs (no xenos left) it will hold for X minutes before it does the "credits" and song and dance.

The way I did this is probably cursed.

Time open for discussion. Currently at three minutes.

# Explain why it's good for the game

This should allow for a bit more RP time at the end of the round and potentially some time for medals, congratulations, etc.

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
add: Added delay to end of round announcement when it is a Marine Major.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
