### PR TITLE
Medical vendors limited supplies

### DIFF
--- a/code/datums/supply_packs/medical.dm
+++ b/code/datums/supply_packs/medical.dm
@@ -95,3 +95,47 @@
 	containertype = /obj/structure/closet/crate/medical
 	containername = "upgraded medical equipment crate"
 	group = "Medical"
+
+/datum/supply_packs/medical_vendor_weymed
+	name = "weymed crate"
+	contains = list(
+		/obj/structure/machinery/cm_vending/sorted/medical
+	)
+	cost = 5000
+	buyable = TRUE
+	containertype = /obj/structure/closet/crate/medical
+	containername = "weymed crate"
+	group = "Medical"
+
+/datum/supply_packs/medical_vendor_chemistry
+	name = "chem vendor crate"
+	contains = list(
+		/obj/structure/machinery/cm_vending/sorted/medical/chemistry
+	)
+	cost = 5000
+	buyable = TRUE
+	containertype = /obj/structure/closet/crate/medical
+	containername = "chem vendor crate"
+	group = "Medical"
+
+/datum/supply_packs/medical_vendor_marinemed
+	name = "marinemed vendor crate"
+	contains = list(
+		/obj/structure/machinery/cm_vending/sorted/medical/marinemed
+	)
+	cost = 5000
+	buyable = TRUE
+	containertype = /obj/structure/closet/crate/medical
+	containername = "marinemed vendor crate"
+	group = "Medical"
+
+/datum/supply_packs/medical_vendor_blood
+	name = "blood dispenser crate"
+	contains = list(
+		/obj/structure/machinery/cm_vending/sorted/medical/blood
+	)
+	cost = 5000
+	buyable = TRUE
+	containertype = /obj/structure/closet/crate/medical
+	containername = "blood dispenser crate"
+	group = "Medical"

--- a/code/datums/supply_packs/medical.dm
+++ b/code/datums/supply_packs/medical.dm
@@ -98,44 +98,24 @@
 
 /datum/supply_packs/medical_vendor_weymed
 	name = "weymed crate"
-	contains = list(
-		/obj/structure/machinery/cm_vending/sorted/medical
-	)
-	cost = 5000
-	buyable = TRUE
-	containertype = /obj/structure/closet/crate/medical
-	containername = "weymed crate"
+	cost = 50
+	containertype = /obj/structure/largecrate/supply/medicine/medivend
 	group = "Medical"
 
 /datum/supply_packs/medical_vendor_chemistry
 	name = "chem vendor crate"
-	contains = list(
-		/obj/structure/machinery/cm_vending/sorted/medical/chemistry
-	)
-	cost = 5000
-	buyable = TRUE
-	containertype = /obj/structure/closet/crate/medical
-	containername = "chem vendor crate"
+	cost = 50
+	containertype = /obj/structure/largecrate/supply/medicine/chemistry
 	group = "Medical"
 
 /datum/supply_packs/medical_vendor_marinemed
 	name = "marinemed vendor crate"
-	contains = list(
-		/obj/structure/machinery/cm_vending/sorted/medical/marinemed
-	)
-	cost = 5000
-	buyable = TRUE
-	containertype = /obj/structure/closet/crate/medical
-	containername = "marinemed vendor crate"
+	cost = 50
+	containertype = /obj/structure/largecrate/supply/medicine/marinemed
 	group = "Medical"
 
 /datum/supply_packs/medical_vendor_blood
 	name = "blood dispenser crate"
-	contains = list(
-		/obj/structure/machinery/cm_vending/sorted/medical/blood
-	)
-	cost = 5000
-	buyable = TRUE
-	containertype = /obj/structure/closet/crate/medical
-	containername = "blood dispenser crate"
+	cost = 50
+	containertype = /obj/structure/largecrate/supply/medicine/blood
 	group = "Medical"

--- a/code/datums/supply_packs/medical.dm
+++ b/code/datums/supply_packs/medical.dm
@@ -104,18 +104,18 @@
 
 /datum/supply_packs/medical_vendor_chemistry
 	name = "chem vendor crate"
-	cost = 50
+	cost = 10
 	containertype = /obj/structure/largecrate/supply/medicine/chemistry
 	group = "Medical"
 
 /datum/supply_packs/medical_vendor_marinemed
 	name = "marinemed vendor crate"
-	cost = 50
+	cost = 5
 	containertype = /obj/structure/largecrate/supply/medicine/marinemed
 	group = "Medical"
 
 /datum/supply_packs/medical_vendor_blood
 	name = "blood dispenser crate"
-	cost = 50
+	cost = 30
 	containertype = /obj/structure/largecrate/supply/medicine/blood
 	group = "Medical"

--- a/code/datums/supply_packs/medical.dm
+++ b/code/datums/supply_packs/medical.dm
@@ -17,7 +17,7 @@
 		/obj/item/storage/pill_bottle/peridaxon,
 		/obj/item/storage/box/pillbottles,
 	)
-	cost = 20
+	cost = 10
 	containertype = /obj/structure/closet/crate/medical
 	containername = "medical crate"
 	group = "Medical"
@@ -36,7 +36,7 @@
 		/obj/item/storage/firstaid/adv,
 		/obj/item/storage/firstaid/adv,
 	)
-	cost = 20
+	cost = 10
 	containertype = /obj/structure/closet/crate/medical
 	containername = "medical crate"
 	group = "Medical"
@@ -55,13 +55,16 @@
 	group = "Medical"
 
 /datum/supply_packs/cryobag
-	name = "stasis bag crate (x3)"
+	name = "stasis bag crate (x6)"
 	contains = list(
 		/obj/item/bodybag/cryobag,
 		/obj/item/bodybag/cryobag,
 		/obj/item/bodybag/cryobag,
+		/obj/item/bodybag/cryobag,
+		/obj/item/bodybag/cryobag,
+		/obj/item/bodybag/cryobag,
 	)
-	cost = 40
+	cost = 10
 	containertype = /obj/structure/closet/crate/medical
 	containername = "stasis bag crate"
 	group = "Medical"
@@ -110,7 +113,7 @@
 
 /datum/supply_packs/medical_vendor_marinemed
 	name = "marinemed vendor crate"
-	cost = 5
+	cost = 10
 	containertype = /obj/structure/largecrate/supply/medicine/marinemed
 	group = "Medical"
 

--- a/code/game/machinery/vending/cm_vending.dm
+++ b/code/game/machinery/vending/cm_vending.dm
@@ -854,6 +854,10 @@ GLOBAL_LIST_EMPTY(vending_products)
 		stock(I, user)
 
 /obj/structure/machinery/cm_vending/sorted/proc/stock(obj/item/item_to_stock, mob/user)
+	if (istype(src, /obj/structure/machinery/cm_vending/sorted/medical))
+		to_chat(user, SPAN_WARNING("[src] cannot be restocked!"))
+		return
+
 	var/list/R
 	var/list/stock_listed_products = get_listed_products(user)
 	for(R in (stock_listed_products))

--- a/code/game/machinery/vending/cm_vending.dm
+++ b/code/game/machinery/vending/cm_vending.dm
@@ -854,10 +854,6 @@ GLOBAL_LIST_EMPTY(vending_products)
 		stock(I, user)
 
 /obj/structure/machinery/cm_vending/sorted/proc/stock(obj/item/item_to_stock, mob/user)
-	if (istype(src, /obj/structure/machinery/cm_vending/sorted/medical))
-		to_chat(user, SPAN_WARNING("[src] cannot be restocked!"))
-		return
-
 	var/list/R
 	var/list/stock_listed_products = get_listed_products(user)
 	for(R in (stock_listed_products))

--- a/code/game/machinery/vending/vendor_types/medical.dm
+++ b/code/game/machinery/vending/vendor_types/medical.dm
@@ -177,10 +177,6 @@
 		list("Syringe", round(scale * 7), /obj/item/reagent_container/syringe, VENDOR_ITEM_REGULAR)
 	)
 
-/obj/structure/machinery/cm_vending/sorted/medical/proc/stock(obj/item/item_to_stock, mob/user)
-	SPAN_NOTICE('You cannot restock this machine')
-	return
-
 /obj/structure/machinery/cm_vending/sorted/medical/no_access
 	req_access = list()
 

--- a/code/game/machinery/vending/vendor_types/medical.dm
+++ b/code/game/machinery/vending/vendor_types/medical.dm
@@ -177,6 +177,10 @@
 		list("Syringe", round(scale * 7), /obj/item/reagent_container/syringe, VENDOR_ITEM_REGULAR)
 	)
 
+/obj/structure/machinery/cm_vending/sorted/medical/proc/stock(obj/item/item_to_stock, mob/user)
+	SPAN_NOTICE('You cannot restock this machine')
+	return
+
 /obj/structure/machinery/cm_vending/sorted/medical/no_access
 	req_access = list()
 

--- a/code/game/machinery/vending/vendor_types/medical.dm
+++ b/code/game/machinery/vending/vendor_types/medical.dm
@@ -148,6 +148,10 @@
 		list("Syringe", round(scale * 7), /obj/item/reagent_container/syringe, VENDOR_ITEM_REGULAR)
 	)
 
+/obj/structure/machinery/cm_vending/sorted/medical/stock(obj/item/item_to_stock, mob/user)
+	to_chat(user, SPAN_WARNING("[src] cannot be restocked!"))
+	return
+
 /obj/structure/machinery/cm_vending/sorted/medical/chemistry
 	name = "\improper Wey-Chem Plus"
 	desc = "Medical chemistry dispenser. Provided by Wey-Yu Pharmaceuticals Division(TM)."

--- a/code/game/machinery/vending/vendor_types/medical.dm
+++ b/code/game/machinery/vending/vendor_types/medical.dm
@@ -17,40 +17,8 @@
 	var/datum/health_scan/last_health_display
 
 	var/healthscan = TRUE
-	var/list/chem_refill = list(
-		/obj/item/reagent_container/hypospray/autoinjector/bicaridine,
-		/obj/item/reagent_container/hypospray/autoinjector/dexalinp,
-		/obj/item/reagent_container/hypospray/autoinjector/adrenaline,,
-		/obj/item/reagent_container/hypospray/autoinjector/inaprovaline,
-		/obj/item/reagent_container/hypospray/autoinjector/kelotane,
-		/obj/item/reagent_container/hypospray/autoinjector/oxycodone,
-		/obj/item/reagent_container/hypospray/autoinjector/tramadol,
-		/obj/item/reagent_container/hypospray/autoinjector/tricord,
-		/obj/item/reagent_container/hypospray/autoinjector/emergency,
-		/obj/item/reagent_container/hypospray/autoinjector/skillless,
-		/obj/item/reagent_container/hypospray/autoinjector/skillless/tramadol,
-
-		/obj/item/reagent_container/hypospray/autoinjector/bicaridine/skillless,
-		/obj/item/reagent_container/hypospray/autoinjector/kelotane/skillless,
-		/obj/item/reagent_container/hypospray/autoinjector/tramadol/skillless,
-		/obj/item/reagent_container/hypospray/autoinjector/tricord/skillless,
-
-		/obj/item/reagent_container/glass/bottle/bicaridine,
-		/obj/item/reagent_container/glass/bottle/antitoxin,
-		/obj/item/reagent_container/glass/bottle/dexalin,
-		/obj/item/reagent_container/glass/bottle/inaprovaline,
-		/obj/item/reagent_container/glass/bottle/kelotane,
-		/obj/item/reagent_container/glass/bottle/oxycodone,
-		/obj/item/reagent_container/glass/bottle/peridaxon,
-		/obj/item/reagent_container/glass/bottle/tramadol,
-		)
-	var/list/stack_refill = list(
-		/obj/item/stack/medical/advanced/ointment,
-		/obj/item/stack/medical/advanced/bruise_pack,
-		/obj/item/stack/medical/ointment,
-		/obj/item/stack/medical/bruise_pack,
-		/obj/item/stack/medical/splint
-		)
+	var/list/chem_refill = null
+	var/list/stack_refill = null
 
 /obj/structure/machinery/cm_vending/sorted/medical/Destroy()
 	QDEL_NULL(last_health_display)
@@ -186,16 +154,7 @@
 	icon_state = "chem"
 
 	healthscan = FALSE
-	chem_refill = list(
-		/obj/item/reagent_container/glass/bottle/bicaridine,
-		/obj/item/reagent_container/glass/bottle/antitoxin,
-		/obj/item/reagent_container/glass/bottle/dexalin,
-		/obj/item/reagent_container/glass/bottle/inaprovaline,
-		/obj/item/reagent_container/glass/bottle/kelotane,
-		/obj/item/reagent_container/glass/bottle/oxycodone,
-		/obj/item/reagent_container/glass/bottle/peridaxon,
-		/obj/item/reagent_container/glass/bottle/tramadol,
-	)
+	chem_refill = null
 	stack_refill = null
 
 /obj/structure/machinery/cm_vending/sorted/medical/chemistry/populate_product_list(scale)
@@ -238,15 +197,8 @@
 	req_one_access = list()
 	vendor_theme = VENDOR_THEME_USCM
 
-	chem_refill = list(
-		/obj/item/reagent_container/hypospray/autoinjector/skillless,
-		/obj/item/reagent_container/hypospray/autoinjector/skillless/tramadol,
-	)
-	stack_refill = list(
-		/obj/item/stack/medical/ointment,
-		/obj/item/stack/medical/bruise_pack,
-		/obj/item/stack/medical/splint,
-	)
+	chem_refill = null
+	stack_refill = null
 
 /obj/structure/machinery/cm_vending/sorted/medical/marinemed/populate_product_list(scale)
 	listed_products = list(
@@ -325,31 +277,14 @@
 
 	appearance_flags = TILE_BOUND
 
-	chem_refill = list(
-		/obj/item/reagent_container/hypospray/autoinjector/skillless,
-		/obj/item/reagent_container/hypospray/autoinjector/skillless/tramadol,
-		/obj/item/reagent_container/hypospray/autoinjector/tricord/skillless,
-		/obj/item/reagent_container/hypospray/autoinjector/bicaridine/skillless,
-		/obj/item/reagent_container/hypospray/autoinjector/kelotane/skillless,
-		/obj/item/reagent_container/hypospray/autoinjector/tramadol/skillless,
-	)
-	stack_refill = list(
-		/obj/item/stack/medical/bruise_pack,
-		/obj/item/stack/medical/splint,
-		/obj/item/stack/medical/ointment,
-	)
+	chem_refill = null
+	stack_refill = null
 
 /obj/structure/machinery/cm_vending/sorted/medical/wall_med/limited
 	desc = "Wall-mounted Medical Equipment Dispenser. This version is more limited than standard USCM NanoMeds."
 
-	chem_refill = list(
-		/obj/item/reagent_container/hypospray/autoinjector/skillless,
-		/obj/item/reagent_container/hypospray/autoinjector/skillless/tramadol,
-	)
-	stack_refill = list(
-		/obj/item/stack/medical/bruise_pack,
-		/obj/item/stack/medical/ointment,
-	)
+	chem_refill = null
+	stack_refill = null
 
 /obj/structure/machinery/cm_vending/sorted/medical/wall_med/lifeboat
 	name = "Lifeboat Medical Cabinet"
@@ -371,11 +306,7 @@
 		list("Roll of Gauze", 8, /obj/item/stack/medical/bruise_pack, VENDOR_ITEM_REGULAR),
 		list("Splints", 8, /obj/item/stack/medical/splint, VENDOR_ITEM_REGULAR)
 	)
-	stack_refill = list(
-		/obj/item/stack/medical/ointment,
-		/obj/item/stack/medical/bruise_pack,
-		/obj/item/stack/medical/splint,
-	)
+	stack_refill = null
 
 	unacidable = TRUE
 	unslashable = TRUE

--- a/code/game/objects/structures/crates_lockers/largecrate.dm
+++ b/code/game/objects/structures/crates_lockers/largecrate.dm
@@ -31,6 +31,11 @@
 	for(var/atom/movable/moving_atom in contents)
 		var/atom/movable/current_atom = contents[1]
 		current_atom.forceMove(current_turf)
+		if(istype(current_atom, /obj/structure/machinery))
+			var/obj/structure/machinery/machine = current_atom
+			var/area/A = get_area(machine)
+			if(A)
+				A.add_machine(machine)
 
 	deconstruct(TRUE)
 

--- a/code/game/objects/structures/crates_lockers/largecrate_supplies.dm
+++ b/code/game/objects/structures/crates_lockers/largecrate_supplies.dm
@@ -324,6 +324,20 @@
 	desc = "A crate containing one Weyland Plus medical vendor."
 	supplies = list(/obj/structure/machinery/cm_vending/sorted/medical = 1)
 
+/obj/structure/largecrate/supply/medicine/chemistry
+	name = "\improper Wey-Chem Plus crate (x1)"
+	desc = "A crate containing one Weyland Chem medical vendor."
+	supplies = list(/obj/structure/machinery/cm_vending/sorted/medical/chemistry = 1)
+
+/obj/structure/largecrate/supply/medicine/marinemed
+	name = "\improper ColMarTech MarineMed crate (x1)"
+	desc = "A crate containing one ColMarTech MarineMed medical vendor."
+	supplies = list(/obj/structure/machinery/cm_vending/sorted/medical/marinemed = 1)
+
+/obj/structure/largecrate/supply/medicine/blood
+	name = "\improper MM Blood Dispenser crate (x1)"
+	desc = "A crate containing one MM Blood Dispenser medical vendor."
+	supplies = list(/obj/structure/machinery/cm_vending/sorted/medical/blood = 1)
 
 /obj/structure/largecrate/machine
 	name = "machine crate"

--- a/code/modules/vehicles/interior/interactable/vendors.dm
+++ b/code/modules/vehicles/interior/interactable/vendors.dm
@@ -13,14 +13,8 @@
 	indestructible = TRUE
 	hackable = FALSE
 
-	chem_refill = list(
-		/obj/item/reagent_container/hypospray/autoinjector/skillless,
-		/obj/item/reagent_container/hypospray/autoinjector/skillless/tramadol,
-	)
-	stack_refill = list(
-		/obj/item/stack/medical/bruise_pack,
-		/obj/item/stack/medical/ointment,
-	)
+	chem_refill = null
+	stack_refill = null
 
 //MED APC version of WY Med, provides resupply for basic stuff. Provides a decent amount of cryobags for evacuating hugged marines.
 /obj/structure/machinery/cm_vending/sorted/medical/vehicle
@@ -39,32 +33,9 @@
 	req_access = list()
 
 	healthscan = TRUE
-	chem_refill = list(
-		/obj/item/reagent_container/hypospray/autoinjector/bicaridine,
-		/obj/item/reagent_container/hypospray/autoinjector/dexalinp,
-		/obj/item/reagent_container/hypospray/autoinjector/adrenaline,,
-		/obj/item/reagent_container/hypospray/autoinjector/inaprovaline,
-		/obj/item/reagent_container/hypospray/autoinjector/kelotane,
-		/obj/item/reagent_container/hypospray/autoinjector/oxycodone,
-		/obj/item/reagent_container/hypospray/autoinjector/tramadol,
-		/obj/item/reagent_container/hypospray/autoinjector/tricord,
-		/obj/item/reagent_container/hypospray/autoinjector/emergency,
-		/obj/item/reagent_container/hypospray/autoinjector/skillless,
-		/obj/item/reagent_container/hypospray/autoinjector/skillless/tramadol,
 
-		/obj/item/reagent_container/hypospray/autoinjector/bicaridine/skillless,
-		/obj/item/reagent_container/hypospray/autoinjector/kelotane/skillless,
-		/obj/item/reagent_container/hypospray/autoinjector/tramadol/skillless,
-		/obj/item/reagent_container/hypospray/autoinjector/tricord/skillless,
-		)
-
-	stack_refill = list(
-		/obj/item/stack/medical/advanced/ointment,
-		/obj/item/stack/medical/advanced/bruise_pack,
-		/obj/item/stack/medical/ointment,
-		/obj/item/stack/medical/bruise_pack,
-		/obj/item/stack/medical/splint,
-	)
+	chem_refill = null
+	stack_refill = null
 
 /obj/structure/machinery/cm_vending/sorted/medical/vehicle/populate_product_list(scale)
 	listed_products = list(


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

An attempt to remove infinite medical supply restocking.

Morrow told me not to revive Stan's attempt with the supply chain working on the ship but not groundside, but to implement it like this. 

Will need to be tested and values adjusted ( such as vendor prices) to see what fits the gameplay loop.

# Explain why it's good for the game

Medical attrition and preventing infinite medical supplies

# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
balance: All medical vendors can no longer restock or refill.
add: Medical vendors are now purchasable by requisitions.
/:cl: