### PR TITLE
Dropship seats are once again destroyable via slashing

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -51,7 +51,7 @@
 
 /obj/structure/bed/deconstruct(disassembled = TRUE)
 	if(!disassembled)
-		if(!isnull(buildstacktype))
+		if(!isnull(buildstacktype) && buildstackamount)
 			new buildstacktype(get_turf(src), buildstackamount)
 	return ..()
 

--- a/code/modules/vehicles/interior/interactable/seats.dm
+++ b/code/modules/vehicles/interior/interactable/seats.dm
@@ -302,7 +302,7 @@
 	icon_state = "vehicle_seat"
 	var/image/chairbar = null
 	var/broken = FALSE
-	buildstacktype = 0
+	buildstackamount = 0
 	can_rotate = FALSE
 	picked_up_item = null
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Dropship seats are once again destroyable via slashing. I'm sure I'll be fixing this again next week.

# Explain why it's good for the game

Dropship seats block vital area for hives during hijack.

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
fix: Dropship seats are once again destroyable via slashing
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
