### PR TITLE
Fix aimed shot cooldown

### DIFF
--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -93,7 +93,6 @@
 	if(!check_can_use(target))
 		return
 
-	sniper_rifle.aimed_shot_cooldown = world.time + sniper_rifle.aimed_shot_cooldown_delay
 	human.face_atom(target)
 
 	///Add a decisecond to the default 1.5 seconds for each two tiles to hit.
@@ -156,6 +155,7 @@
 	if(!check_can_use(target, TRUE))
 		return
 
+	sniper_rifle.aimed_shot_cooldown = world.time + sniper_rifle.aimed_shot_cooldown_delay
 	var/obj/item/projectile/aimed_proj = sniper_rifle.in_chamber
 	aimed_proj.projectile_flags |= PROJECTILE_BULLSEYE
 	aimed_proj.AddComponent(/datum/component/homing_projectile, target, human)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Aimed shot should cooldown just as your about to fire. Right now, it adds the cooldown, then aims ( which could be long dependent on distance and modifiers ) and they can basically start another aimed shot right after.

Also should apply after all the can_check_use since that also sets the aiming cooldown if cover check fails.

# Explain why it's good for the game

Cooldown should always be just as your about to take your action. Aiming time should not be factored in or else sniper basically continuously chain aim shots without factoring in the aim time and distance in the cooldown. 

How it's currently done:

Start aimed shot
Check if you can use
Start cooldown
Aiming time
Check if you can still use it and target not behind cover ( if not, cooldown is half aimed shot delay time )
Fire!

This makes it so cooldown would actually be the aimed shot delay time - aiming time. 

Instead I made it so:
Start aimed shot
Check if you can use
Aiming time
Check if you can still use it and target not behind cover ( if not, cooldown is half aimed shot delay time )
Start cooldown
Fire!

If losing focus resets cooldown, then using your focus to fire should start the cooldown imo.

# Changelog

:cl:
fix: Sniper's Aimed Shot cooldown is applied after aiming.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
