### PR TITLE
Sniper / Spotter Cooldowns are handled in check_can_use

### DIFF
--- a/code/game/objects/items/devices/binoculars.dm
+++ b/code/game/objects/items/devices/binoculars.dm
@@ -438,7 +438,6 @@
 	if(!check_can_use(target))
 		return
 
-	COOLDOWN_START(designator, spotting_cooldown, designator.spotting_cooldown_delay)
 	human.face_atom(target)
 
 	///Add a decisecond to the default 1.5 seconds for each two tiles to hit.
@@ -474,7 +473,6 @@
 		REMOVE_TRAIT(target, TRAIT_SPOTTER_LAZED, TRAIT_SOURCE_EQUIPMENT(designator.tracking_id))
 		return
 
-	COOLDOWN_START(designator, spotting_cooldown, designator.spotting_cooldown_delay)
 	target.overlays -= I
 	designator.is_spotting = FALSE
 	designator.update_icon()
@@ -496,6 +494,7 @@
 		to_chat(human, SPAN_WARNING("\The [target] is too close to laze!"))
 		return FALSE
 
+	COOLDOWN_START(designator, spotting_cooldown, designator.spotting_cooldown_delay)
 	return TRUE
 
 //ADVANCED LASER DESIGNATER, was used for WO.

--- a/code/game/objects/items/devices/binoculars.dm
+++ b/code/game/objects/items/devices/binoculars.dm
@@ -473,6 +473,8 @@
 		qdel(laser_beam)
 		REMOVE_TRAIT(target, TRAIT_SPOTTER_LAZED, TRAIT_SOURCE_EQUIPMENT(designator.tracking_id))
 		return
+
+	COOLDOWN_START(designator, spotting_cooldown, designator.spotting_cooldown_delay)
 	target.overlays -= I
 	designator.is_spotting = FALSE
 	designator.update_icon()

--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -93,6 +93,7 @@
 	if(!check_can_use(target))
 		return
 
+	COOLDOWN_START(sniper_rifle, aimed_shot_cooldown, sniper_rifle.aimed_shot_cooldown_delay)
 	human.face_atom(target)
 
 	///Add a decisecond to the default 1.5 seconds for each two tiles to hit.
@@ -155,7 +156,7 @@
 	if(!check_can_use(target, TRUE))
 		return
 
-	sniper_rifle.aimed_shot_cooldown = world.time + sniper_rifle.aimed_shot_cooldown_delay
+	COOLDOWN_START(sniper_rifle, aimed_shot_cooldown, sniper_rifle.aimed_shot_cooldown_delay)
 	var/obj/item/projectile/aimed_proj = sniper_rifle.in_chamber
 	aimed_proj.projectile_flags |= PROJECTILE_BULLSEYE
 	aimed_proj.AddComponent(/datum/component/homing_projectile, target, human)

--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -93,7 +93,6 @@
 	if(!check_can_use(target))
 		return
 
-	sniper_rifle.aimed_shot_cooldown = world.time + sniper_rifle.aimed_shot_cooldown_delay
 	human.face_atom(target)
 
 	///Add a decisecond to the default 1.5 seconds for each two tiles to hit.
@@ -156,6 +155,7 @@
 	if(!check_can_use(target, TRUE))
 		return
 
+	sniper_rifle.aimed_shot_cooldown = world.time + sniper_rifle.aimed_shot_cooldown_delay
 	var/obj/item/projectile/aimed_proj = sniper_rifle.in_chamber
 	aimed_proj.projectile_flags |= PROJECTILE_BULLSEYE
 	aimed_proj.AddComponent(/datum/component/homing_projectile, target, human)

--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -189,7 +189,7 @@
 		to_chat(H, SPAN_WARNING("Something is in the way, or you're out of range!"))
 		if(cover_lose_focus)
 			to_chat(H, SPAN_WARNING("You lose focus."))
-			sniper_rifle.aimed_shot_cooldown = world.time + sniper_rifle.aimed_shot_cooldown_delay * 0.5
+			COOLDOWN_START(sniper_rifle, aimed_shot_cooldown, sniper_rifle.aimed_shot_cooldown_delay * 0.5)
 		return FALSE
 
 	COOLDOWN_START(sniper_rifle, aimed_shot_cooldown, sniper_rifle.aimed_shot_cooldown_delay)

--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -93,7 +93,6 @@
 	if(!check_can_use(target))
 		return
 
-	COOLDOWN_START(sniper_rifle, aimed_shot_cooldown, sniper_rifle.aimed_shot_cooldown_delay)
 	human.face_atom(target)
 
 	///Add a decisecond to the default 1.5 seconds for each two tiles to hit.
@@ -156,7 +155,6 @@
 	if(!check_can_use(target, TRUE))
 		return
 
-	COOLDOWN_START(sniper_rifle, aimed_shot_cooldown, sniper_rifle.aimed_shot_cooldown_delay)
 	var/obj/item/projectile/aimed_proj = sniper_rifle.in_chamber
 	aimed_proj.projectile_flags |= PROJECTILE_BULLSEYE
 	aimed_proj.AddComponent(/datum/component/homing_projectile, target, human)
@@ -194,6 +192,7 @@
 			sniper_rifle.aimed_shot_cooldown = world.time + sniper_rifle.aimed_shot_cooldown_delay * 0.5
 		return FALSE
 
+	COOLDOWN_START(sniper_rifle, aimed_shot_cooldown, sniper_rifle.aimed_shot_cooldown_delay)
 	return TRUE
 
 /datum/action/item_action/specialist/aimed_shot/proc/check_shot_is_blocked(mob/firer, mob/target, obj/item/projectile/P)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Aimed shot and spotting should cooldown after they're actually used.

For the sniper, the can_use_check resets the cooldown based on the world time after aiming if the target moves into cover. By that logic, the sniper's cooldown should apply AFTER the shot takes effect or just as the shot is about to take effect.

The same logic applies to spotters.

The cooldown is based on the world time after aiming. The first cooldown add remains so we don't have a double aim similar to defender double headbutt issues. The cooldown is calculated at the world time after aiming so the first one doesn't increase the delay.

Refactored it so that can check use handles the cooldown proccing. So if you failed to use it ( like when the xenos move behind cover), it does its normal half cooldown. But if you can use it, procs the cooldown start. 


# Explain why it's good for the game

Cooldown should always be just as your about to take your action. Aiming time should not be factored in or else sniper basically continuously chain aim shots without factoring in the aim time and distance in the cooldown. 

How it's currently done:

Start aimed shot
Check if you can use
Start cooldown
Aiming time
Check if you can still use it and target not behind cover ( if they are, cooldown is half aimed shot delay time )
Fire!

This makes it so cooldown would actually be the aimed shot delay time - aiming time.  If aiming was as long as cooldown, the sniper could continuously keep sniping one after another with aimed shot.

Instead I made it so:
Start aimed shot
Check if you can use
Add cooldown to know that you are currently using the ability
Aiming time
Check if you can still use it and target not behind cover ( if they are, cooldown is half aimed shot delay time )
Start cooldown ( current world time plus the delay )
Fire!

If losing focus resets cooldown, then using your focus to fire should start the cooldown. can_check_use for sniper rifle handles the cooldown now.

# Changelog

:cl:
fix: Sniper's Aimed Shot and Spotter's Target cooldown is applied consistently in can_check_use.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
