### PR TITLE
Issue 2466 WIP

### DIFF
--- a/code/modules/defenses/sentry.dm
+++ b/code/modules/defenses/sentry.dm
@@ -407,7 +407,7 @@
 				continue
 
 
-		var/list/turf/path = getline2(src, A, include_from_atom = TRUE)
+		var/list/turf/path = getline2(src, A, include_from_atom = FALSE)
 		if(!path.len || get_dist(src, A) > sentry_range)
 			if(A == target)
 				target = null

--- a/code/modules/defenses/sentry.dm
+++ b/code/modules/defenses/sentry.dm
@@ -406,7 +406,8 @@
 				targets.Remove(A)
 				continue
 
-		var/list/turf/path = getline2(src, A, include_from_atom = FALSE)
+
+		var/list/turf/path = getline2(src, A, include_from_atom = TRUE)
 		if(!path.len || get_dist(src, A) > sentry_range)
 			if(A == target)
 				target = null
@@ -445,6 +446,23 @@
 			for(var/obj/vehicle/multitile/V in F)
 				blocked = TRUE
 				break
+
+		// Rare edge case for diagonal lines through blocked terrain in a checkerboard pattern
+		if (abs(src.x - target.x) == abs(src.y - target.y))
+			// Get the tiles to the left and right of the firing path
+			var/turf/left = get_step(target, turn(target.dir, -45))
+			var/turf/right = get_step(target, turn(target.dir, 45))
+			// Loop through each tile in the firing path
+			var/turf/tile = src
+			while (tile != target)
+				tile = get_step(tile, src.dir)
+				// Check if the tile is obstructed
+				if (tile.density || tile.opacity)
+					blocked = TRUE
+					break
+			// Check if the tiles to the left and right of the firing path are obstructed
+			if ((left.density || left.opacity) && (right.density || right.opacity))
+				blocked = TRUE
 
 		if(blocked)
 			if(A == target)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Do not merge. Working on fixing issue 2466 reported at: https://github.com/cmss13-devs/cmss13/issues/2466

# Explain why it's good for the game

The problem affects all turrets globally, not just omnidirectional turrets.

I believe the issue is that the current algorithm does not recognize emergent barriers that arise from checkerboarded obstacles. 

The provided code is currently nonfunctional, and universally prohibits any perfectly diagonal target acquisition. I suspect the original issue is deep-rooted and having to do with the pathfinding algorithm at
410: var/list/turf/path = getline2(src, A, include_from_atom = TRUE) which references getline2() at 
code/__HELPERS/unsorted.dm

I believe the pathfinding there allows for diagonal tile traversal. Actual ballistics account for checkerboarded barriers, but sentry target acquisition does not. I've tried multiple solutions in-file. Making a more deep-rooted change (like changing getline2() behavior to something more akin to "hitscan") may adversely impact "accepted" turret logic, such as shooting at a target behind a solid tile from a slight angle. It would probably also adversely affect the other systems which reference it, and may additionally impact game performance.

Regardless, actual barriers in game rarely checkerboard outside of intentional resin wall construction, which is probably the reason no one has bothered to fix this bug for so long. Video provided.

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

https://user-images.githubusercontent.com/71449229/233758228-d4433133-8182-4dde-8473-b7c21e9f0d85.mp4

</details>

:cl:
code: changed some code
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
