### PR TITLE
Huggers can now scuttle resin doors

### DIFF
--- a/code/modules/cm_aliens/XenoStructures.dm
+++ b/code/modules/cm_aliens/XenoStructures.dm
@@ -374,8 +374,9 @@
 		var/mob/living/carbon/xenomorph/X = user
 		if (X.hivenumber == hivenumber)
 			if(X.scuttle(src))
-				return
-		return ..()
+				return // don't toggle door for small xenos
+			return ..() // toggles door for big xenos
+		return // enemy hive doesn't toggle door
 	if(iscarbon(user))
 		var/mob/living/carbon/C = user
 		if (C.ally_of_hivenumber(hivenumber))

--- a/code/modules/cm_aliens/XenoStructures.dm
+++ b/code/modules/cm_aliens/XenoStructures.dm
@@ -370,10 +370,15 @@
 		return attack_hand(user)
 
 /obj/structure/mineral_door/resin/TryToSwitchState(atom/user)
-	if(islarva(user) || isfacehugger(user))
+	if(islarva(user))
 		var/mob/living/carbon/xenomorph/larva/L = user
 		if (L.hivenumber == hivenumber)
 			L.scuttle(src)
+		return
+	if(isfacehugger(user))
+		var/mob/living/carbon/xenomorph/facehugger/F = user
+		if (F.hivenumber == hivenumber)
+			F.scuttle(src)
 		return
 	if(iscarbon(user))
 		var/mob/living/carbon/C = user

--- a/code/modules/cm_aliens/XenoStructures.dm
+++ b/code/modules/cm_aliens/XenoStructures.dm
@@ -370,7 +370,7 @@
 		return attack_hand(user)
 
 /obj/structure/mineral_door/resin/TryToSwitchState(atom/user)
-	if(islarva(user))
+	if(islarva(user) || isfacehugger(user))
 		var/mob/living/carbon/xenomorph/larva/L = user
 		if (L.hivenumber == hivenumber)
 			L.scuttle(src)

--- a/code/modules/cm_aliens/XenoStructures.dm
+++ b/code/modules/cm_aliens/XenoStructures.dm
@@ -371,12 +371,12 @@
 
 /obj/structure/mineral_door/resin/TryToSwitchState(atom/user)
 	if(isxeno(user))
-		var/mob/living/carbon/xenomorph/X = user
-		if (X.hivenumber == hivenumber)
-			if(X.scuttle(src))
-				return // don't toggle door for small xenos
-			return ..() // toggles door for big xenos
-		return // enemy hive doesn't toggle door
+		var/mob/living/carbon/xenomorph/xeno_user = user
+		if (xeno_user.hivenumber != hivenumber && !xeno_user.ally_of_hivenumber(hivenumber))
+			return
+		if(xeno_user.scuttle(src))
+			return
+		return ..()
 	if(iscarbon(user))
 		var/mob/living/carbon/C = user
 		if (C.ally_of_hivenumber(hivenumber))

--- a/code/modules/cm_aliens/XenoStructures.dm
+++ b/code/modules/cm_aliens/XenoStructures.dm
@@ -373,8 +373,9 @@
 	if(isxeno(user))
 		var/mob/living/carbon/xenomorph/X = user
 		if (X.hivenumber == hivenumber)
-			X.scuttle(src)
-		return
+			if(X.scuttle(src))
+				return
+		return ..()
 	if(iscarbon(user))
 		var/mob/living/carbon/C = user
 		if (C.ally_of_hivenumber(hivenumber))

--- a/code/modules/cm_aliens/XenoStructures.dm
+++ b/code/modules/cm_aliens/XenoStructures.dm
@@ -370,15 +370,10 @@
 		return attack_hand(user)
 
 /obj/structure/mineral_door/resin/TryToSwitchState(atom/user)
-	if(islarva(user))
-		var/mob/living/carbon/xenomorph/larva/L = user
-		if (L.hivenumber == hivenumber)
-			L.scuttle(src)
-		return
-	if(isfacehugger(user))
-		var/mob/living/carbon/xenomorph/facehugger/F = user
-		if (F.hivenumber == hivenumber)
-			F.scuttle(src)
+	if(isxeno(user))
+		var/mob/living/carbon/xenomorph/X = user
+		if (X.hivenumber == hivenumber)
+			X.scuttle(src)
 		return
 	if(iscarbon(user))
 		var/mob/living/carbon/C = user

--- a/code/modules/mob/living/carbon/xenomorph/Embryo.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Embryo.dm
@@ -289,20 +289,3 @@
 		victim.death(cause) // Certain species were still surviving bursting (predators), DEFINITELY kill them this time.
 		victim.chestburst = 2
 		victim.update_burst()
-
-// Squeeze thru dense objects as a larva, as airlocks
-/mob/living/carbon/xenomorph/larva/proc/scuttle(obj/structure/S)
-	var/move_dir = get_dir(src, loc)
-	for(var/atom/movable/AM in get_turf(S))
-		if(AM != S && AM.density && AM.BlockedPassDirs(src, move_dir))
-			to_chat(src, SPAN_WARNING("\The [AM] prevents you from squeezing under \the [S]!"))
-			return
-	// Is it an airlock?
-	if(istype(S, /obj/structure/machinery/door/airlock))
-		var/obj/structure/machinery/door/airlock/A = S
-		if(A.locked || A.welded) //Can't pass through airlocks that have been bolted down or welded
-			to_chat(src, SPAN_WARNING("\The [A] is locked down tight. You can't squeeze underneath!"))
-			return
-	visible_message(SPAN_WARNING("\The [src] scuttles underneath \the [S]!"), \
-	SPAN_WARNING("You squeeze and scuttle underneath \the [S]."), null, 5)
-	forceMove(S.loc)

--- a/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
@@ -1082,20 +1082,21 @@
 	new /obj/effect/temp_visual/dir_setting/bloodsplatter/xenosplatter(loc, splatter_dir, duration)
 
 /mob/living/carbon/xenomorph/proc/scuttle(obj/structure/current_structure)
-	if (mob_size == MOB_SIZE_SMALL) // huggers, larva
-		var/move_dir = get_dir(src, loc)
-		for(var/atom/movable/atom in get_turf(current_structure))
-			if(atom != current_structure && atom.density && atom.BlockedPassDirs(src, move_dir))
-				to_chat(src, SPAN_WARNING("[atom] prevents you from squeezing under [current_structure]!"))
-				return FALSE
-		// Is it an airlock?
-		if(istype(current_structure, /obj/structure/machinery/door/airlock))
-			var/obj/structure/machinery/door/airlock/current_airlock = current_structure
-			if(current_airlock.locked || current_airlock.welded) //Can't pass through airlocks that have been bolted down or welded
-				to_chat(src, SPAN_WARNING("[current_airlock] is locked down tight. You can't squeeze underneath!"))
-				return FALSE
-		visible_message(SPAN_WARNING("[src] scuttles underneath [current_structure]!"), \
-		SPAN_WARNING("You squeeze and scuttle underneath [current_structure]."), null, 5)
-		forceMove(current_structure.loc)
-		return TRUE
-	return FALSE
+	if (mob_size != MOB_SIZE_SMALL)
+		return FALSE
+
+	var/move_dir = get_dir(src, loc)
+	for(var/atom/movable/atom in get_turf(current_structure))
+		if(atom != current_structure && atom.density && atom.BlockedPassDirs(src, move_dir))
+			to_chat(src, SPAN_WARNING("[atom] prevents you from squeezing under [current_structure]!"))
+			return FALSE
+	// Is it an airlock?
+	if(istype(current_structure, /obj/structure/machinery/door/airlock))
+		var/obj/structure/machinery/door/airlock/current_airlock = current_structure
+		if(current_airlock.locked || current_airlock.welded) //Can't pass through airlocks that have been bolted down or welded
+			to_chat(src, SPAN_WARNING("[current_airlock] is locked down tight. You can't squeeze underneath!"))
+			return FALSE
+	visible_message(SPAN_WARNING("[src] scuttles underneath [current_structure]!"), \
+	SPAN_WARNING("You squeeze and scuttle underneath [current_structure]."), null, 5)
+	forceMove(current_structure.loc)
+	return TRUE

--- a/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
@@ -1087,13 +1087,15 @@
 		for(var/atom/movable/atom in get_turf(current_structure))
 			if(atom != current_structure && atom.density && atom.BlockedPassDirs(src, move_dir))
 				to_chat(src, SPAN_WARNING("\The [atom] prevents you from squeezing under \the [current_structure]!"))
-				return
+				return FALSE
 		// Is it an airlock?
 		if(istype(current_structure, /obj/structure/machinery/door/airlock))
 			var/obj/structure/machinery/door/airlock/current_airlock = current_structure
 			if(current_airlock.locked || current_airlock.welded) //Can't pass through airlocks that have been bolted down or welded
 				to_chat(src, SPAN_WARNING("\The [current_airlock] is locked down tight. You can't squeeze underneath!"))
-				return
+				return FALSE
 		visible_message(SPAN_WARNING("\The [src] scuttles underneath \the [current_structure]!"), \
 		SPAN_WARNING("You squeeze and scuttle underneath \the [current_structure]."), null, 5)
 		forceMove(current_structure.loc)
+		return TRUE
+	return FALSE

--- a/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
@@ -1097,6 +1097,6 @@
 			to_chat(src, SPAN_WARNING("[current_airlock] is locked down tight. You can't squeeze underneath!"))
 			return FALSE
 	visible_message(SPAN_WARNING("[src] scuttles underneath [current_structure]!"), \
-	SPAN_WARNING("You squeeze and scuttle underneath [current_structure]."), null, 5)
+	SPAN_WARNING("You squeeze and scuttle underneath [current_structure]."), max_distance = 5)
 	forceMove(current_structure.loc)
 	return TRUE

--- a/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
@@ -1080,3 +1080,20 @@
 
 /mob/living/carbon/xenomorph/handle_blood_splatter(splatter_dir, duration)
 	new /obj/effect/temp_visual/dir_setting/bloodsplatter/xenosplatter(loc, splatter_dir, duration)
+
+/mob/living/carbon/xenomorph/scuttle(obj/structure/current_structure)
+	if (mob_size == MOB_SIZE_SMALL) // huggers, larva
+		var/move_dir = get_dir(src, loc)
+		for(var/atom/movable/atom in get_turf(current_structure))
+			if(atom != current_structure && atom.density && atom.BlockedPassDirs(src, move_dir))
+				to_chat(src, SPAN_WARNING("\The [atom] prevents you from squeezing under \the [current_structure]!"))
+				return
+		// Is it an airlock?
+		if(istype(current_structure, /obj/structure/machinery/door/airlock))
+			var/obj/structure/machinery/door/airlock/current_airlock = current_structure
+			if(current_airlock.locked || current_airlock.welded) //Can't pass through airlocks that have been bolted down or welded
+				to_chat(src, SPAN_WARNING("\The [current_airlock] is locked down tight. You can't squeeze underneath!"))
+				return
+		visible_message(SPAN_WARNING("\The [src] scuttles underneath \the [current_structure]!"), \
+		SPAN_WARNING("You squeeze and scuttle underneath \the [current_structure]."), null, 5)
+		forceMove(current_structure.loc)

--- a/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
@@ -1086,16 +1086,16 @@
 		var/move_dir = get_dir(src, loc)
 		for(var/atom/movable/atom in get_turf(current_structure))
 			if(atom != current_structure && atom.density && atom.BlockedPassDirs(src, move_dir))
-				to_chat(src, SPAN_WARNING("\The [atom] prevents you from squeezing under \the [current_structure]!"))
+				to_chat(src, SPAN_WARNING("[atom] prevents you from squeezing under [current_structure]!"))
 				return FALSE
 		// Is it an airlock?
 		if(istype(current_structure, /obj/structure/machinery/door/airlock))
 			var/obj/structure/machinery/door/airlock/current_airlock = current_structure
 			if(current_airlock.locked || current_airlock.welded) //Can't pass through airlocks that have been bolted down or welded
-				to_chat(src, SPAN_WARNING("\The [current_airlock] is locked down tight. You can't squeeze underneath!"))
+				to_chat(src, SPAN_WARNING("[current_airlock] is locked down tight. You can't squeeze underneath!"))
 				return FALSE
-		visible_message(SPAN_WARNING("\The [src] scuttles underneath \the [current_structure]!"), \
-		SPAN_WARNING("You squeeze and scuttle underneath \the [current_structure]."), null, 5)
+		visible_message(SPAN_WARNING("[src] scuttles underneath [current_structure]!"), \
+		SPAN_WARNING("You squeeze and scuttle underneath [current_structure]."), null, 5)
 		forceMove(current_structure.loc)
 		return TRUE
 	return FALSE

--- a/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
@@ -1081,7 +1081,7 @@
 /mob/living/carbon/xenomorph/handle_blood_splatter(splatter_dir, duration)
 	new /obj/effect/temp_visual/dir_setting/bloodsplatter/xenosplatter(loc, splatter_dir, duration)
 
-/mob/living/carbon/xenomorph/scuttle(obj/structure/current_structure)
+/mob/living/carbon/xenomorph/proc/scuttle(obj/structure/current_structure)
 	if (mob_size == MOB_SIZE_SMALL) // huggers, larva
 		var/move_dir = get_dir(src, loc)
 		for(var/atom/movable/atom in get_turf(current_structure))

--- a/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
@@ -207,21 +207,5 @@
 /mob/living/carbon/xenomorph/facehugger/add_xeno_shield(added_amount, shield_source, type = /datum/xeno_shield, duration = -1, decay_amount_per_second = 1, add_shield_on = FALSE, max_shield = 200)
 	return
 
-/mob/living/carbon/xenomorph/facehugger/proc/scuttle(obj/structure/current_structure)
-	var/move_dir = get_dir(src, loc)
-	for(var/atom/movable/atom in get_turf(current_structure))
-		if(atom != current_structure && atom.density && atom.BlockedPassDirs(src, move_dir))
-			to_chat(src, SPAN_WARNING("\The [atom] prevents you from squeezing under \the [current_structure]!"))
-			return
-	// Is it an airlock?
-	if(istype(current_structure, /obj/structure/machinery/door/airlock))
-		var/obj/structure/machinery/door/airlock/current_airlock = current_structure
-		if(current_airlock.locked || current_airlock.welded) //Can't pass through airlocks that have been bolted down or welded
-			to_chat(src, SPAN_WARNING("\The [current_airlock] is locked down tight. You can't squeeze underneath!"))
-			return
-	visible_message(SPAN_WARNING("\The [src] scuttles underneath \the [current_structure]!"), \
-	SPAN_WARNING("You squeeze and scuttle underneath \the [current_structure]."), null, 5)
-	forceMove(current_structure.loc)
-
 /mob/living/carbon/xenomorph/facehugger/emote(act, m_type, message, intentional, force_silence)
 	playsound(loc, "alien_roar_larva", 15)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Facehuggers can scuttle through resin doors now

# Explain why it's good for the game

Scuttle code should be used. Same size as larva and exact same scuttle code. 

# Changelog

:cl:
fix: Huggers can now scuttle under resin doors
refactor: Removed duplicated scuttle code
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
