### PR TITLE
Allow all xenos to clear hatched eggs regardless of their hivenumber

### DIFF
--- a/code/modules/cm_aliens/structures/egg.dm
+++ b/code/modules/cm_aliens/structures/egg.dm
@@ -40,6 +40,14 @@
 		. += "Ctrl + Click egg to retrieve child into your empty hand if you can carry it."
 
 /obj/effect/alien/egg/attack_alien(mob/living/carbon/xenomorph/M)
+	if(status == EGG_BURST || status == EGG_DESTROYED)
+		M.animation_attack_on(src)
+		M.visible_message(SPAN_XENONOTICE("\The [M] clears the hatched egg."), \
+		SPAN_XENONOTICE("You clear the hatched egg."))
+		playsound(src.loc, "alien_resin_break", 25)
+		qdel(src)
+		return XENO_NONCOMBAT_ACTION
+
 	if(M.hivenumber != hivenumber)
 		M.animation_attack_on(src)
 		M.visible_message(SPAN_XENOWARNING("[M] crushes \the [src]"),
@@ -51,13 +59,6 @@
 		return attack_hand(M)
 
 	switch(status)
-		if(EGG_BURST, EGG_DESTROYED)
-			M.animation_attack_on(src)
-			M.visible_message(SPAN_XENONOTICE("\The [M] clears the hatched egg."), \
-			SPAN_XENONOTICE("You clear the hatched egg."))
-			playsound(src.loc, "alien_resin_break", 25)
-			qdel(src)
-			return XENO_NONCOMBAT_ACTION
 		if(EGG_GROWING)
 			to_chat(M, SPAN_XENOWARNING("The child is not developed yet."))
 			return XENO_NO_DELAY_ACTION

--- a/code/modules/cm_aliens/structures/egg.dm
+++ b/code/modules/cm_aliens/structures/egg.dm
@@ -42,7 +42,7 @@
 /obj/effect/alien/egg/attack_alien(mob/living/carbon/xenomorph/M)
 	if(status == EGG_BURST || status == EGG_DESTROYED)
 		M.animation_attack_on(src)
-		M.visible_message(SPAN_XENONOTICE("\The [M] clears the hatched egg."), \
+		M.visible_message(SPAN_XENONOTICE("[M] clears the hatched egg."), \
 		SPAN_XENONOTICE("You clear the hatched egg."))
 		playsound(src.loc, "alien_resin_break", 25)
 		qdel(src)


### PR DESCRIPTION
# About the pull request

Xenomorph eggs can be destroyed by aliens belonging to other hives, but they can't actually be removed once destroyed. The same goes for hatched eggs. This PR allows all xenos to clear hatched eggs regardless of their hivenumber.

# Explain why it's good for the game

By allowing xenos to clear enemy hatched eggs, we also allow them to place their own constructions/eggs over where the cleared eggs used to be, which currently cannot be done at all, making eggs the only xenomorph structure that acts this way to my knowledge for no good reason (for example, corrupted xenos inside a containment chamber almost always have at least one or two inoperable tiles because they're occupied by the eggs of the normal hive which can't be removed).

# Changelog

:cl:
add: Xenomorphs can now clear eggs from other hives
/:cl: