### PR TITLE
FORECON Tech survivor now has spawn priority

### DIFF
--- a/code/game/objects/effects/landmarks/survivor_spawner.dm
+++ b/code/game/objects/effects/landmarks/survivor_spawner.dm
@@ -70,7 +70,7 @@
 
 /obj/effect/landmark/survivor_spawner/lv522_forecon_tech
 	equipment = /datum/equipment_preset/survivor/forecon/tech
-	spawn_priority = SPAWN_PRIORITY_MEDIUM
+	spawn_priority = SPAWN_PRIORITY_HIGH
 
 /obj/effect/landmark/survivor_spawner/lv522_forecon_marksman
 	equipment = /datum/equipment_preset/survivor/forecon/marksman


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

FORECON Tech survivor now has spawn priority.

# Explain why it's good for the game

Not spawning with anyone who can do medical/engineering skills leaves FORECON in a rough place sometimes. This should ameliorate that.


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
add: FORECON Tech survivor now has spawn priority
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
