### PR TITLE
Vampire lurker tail stab can no longer hit dead humans

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/lurker/lurker_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/lurker/lurker_powers.dm
@@ -213,7 +213,7 @@
 				apply_cooldown(cooldown_modifier = 0.5)
 				return
 
-	if(!isxeno_human(hit_target) || xeno.can_not_harm(hit_target))
+	if(!isxeno_human(hit_target) || xeno.can_not_harm(hit_target) || hit_target.stat == DEAD)
 		xeno.visible_message(SPAN_XENOWARNING("\The [xeno] swipes their tail through the air!"), SPAN_XENOWARNING("You swipe your tail through the air!"))
 		apply_cooldown(cooldown_modifier = 0.2)
 		playsound(xeno, 'sound/effects/alien_tail_swipe1.ogg', 50, TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Vampire lurker tail stab can no longer hit dead humans.

# Explain why it's good for the game

Unintentional to allow xenos to hit corpses.

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
fix: Vampire lurker tail stab can no longer hit dead humans
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
