### PR TITLE
better commit descriptions

### DIFF
--- a/.github/workflows/remove_guide_comments.yml
+++ b/.github/workflows/remove_guide_comments.yml
@@ -1,0 +1,18 @@
+# Removes guide comments from PRs when opened, so that when we merge them
+# and reuse the pull request description, the clutter is not left behind
+name: Remove guide comments
+on:
+  pull_request_target:
+    types: [opened]
+jobs:
+  remove_guide_comments:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Remove guide comments
+      uses: actions/github-script@v6
+      with:
+        script: |
+          const { removeGuideComments } = await import('${{ github.workspace }}/tools/pull_request_hooks/removeGuideComments.js')
+          await removeGuideComments({ github, context })


### PR DESCRIPTION
they're currently polluted with the template's guide comments, the stuff in the \<!--->s, we may as well get rid of this so when a pr is merged, the commit description is neater

(no player facing changes)