### PR TITLE
Playable facehugger uses facehugger death sound

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/death.dm
+++ b/code/modules/mob/living/carbon/xenomorph/death.dm
@@ -72,6 +72,8 @@
 
 		else if(ispredalien(src))
 			playsound(loc,'sound/voice/predalien_death.ogg', 25, TRUE)
+		else if(isfacehugger(src))
+			playsound(loc, 'sound/voice/alien_facehugger_dies.ogg', 25, TRUE)
 		else
 			playsound(loc, prob(50) == 1 ? 'sound/voice/alien_death.ogg' : 'sound/voice/alien_death2.ogg', 25, 1)
 		var/area/A = get_area(src)


### PR DESCRIPTION
# About the pull request

Makes playable facehuggers use the same death sound as NPC facehuggers.

# Explain why it's good for the game

Facehuggers can easily accidentally die from their passive health loss or by being shot at from off-screen, meaning that marines who can't see what made the death sound can be misled into thinking that an actually relevant xenomorph has died, while in reality it was just a hugger. This PR fixes this problem while also making huggers as a whole a little bit more consistent regardless of who or what is controlling it.

# Changelog

🆑
add: Playable facehugger now has the same death sound as regular facehuggers
/🆑