### PR TITLE
Adds a Spec to the Foxtrot Cryo Squad.

### DIFF
--- a/code/datums/emergency_calls/cryo_marines.dm
+++ b/code/datums/emergency_calls/cryo_marines.dm
@@ -37,6 +37,11 @@
 		arm_equipment(H, /datum/equipment_preset/uscm/leader/cryo, TRUE, TRUE)
 		to_chat(H, SPAN_ROLE_HEADER("You are a Squad Leader in the USCM"))
 		to_chat(H, SPAN_ROLE_BODY("You are here to assist in the defence of the [SSmapping.configs[GROUND_MAP].map_name]. Listen to the chain of command."))
+	else if (heavies < max_heavies && HAS_FLAG(H.client.prefs.toggles_ert, PLAY_HEAVY) && check_timelock(H.client, JOB_SQUAD_SPECIALIST, time_required_for_job))
+		heavies++
+		arm_equipment(H, /datum/equipment_preset/uscm/spec/cryo, TRUE, TRUE)
+		to_chat(H, SPAN_ROLE_HEADER("You are a Weapons Specialist in the USCM"))
+		to_chat(H, SPAN_ROLE_BODY("Your squad is here to assist in the defence of the [SSmapping.configs[GROUND_MAP].map_name]. Listen to the chain of command."))
 	else if (medics < max_medics && HAS_FLAG(H.client.prefs.toggles_ert, PLAY_MEDIC) && check_timelock(H.client, JOB_SQUAD_MEDIC, time_required_for_job))
 		medics++
 		arm_equipment(H, /datum/equipment_preset/uscm/medic/cryo, TRUE, TRUE)

--- a/code/datums/emergency_calls/cryo_marines.dm
+++ b/code/datums/emergency_calls/cryo_marines.dm
@@ -39,7 +39,7 @@
 		to_chat(H, SPAN_ROLE_BODY("You are here to assist in the defence of the [SSmapping.configs[GROUND_MAP].map_name]. Listen to the chain of command."))
 	else if (heavies < max_heavies && HAS_FLAG(H.client.prefs.toggles_ert, PLAY_HEAVY) && check_timelock(H.client, JOB_SQUAD_SPECIALIST, time_required_for_job))
 		heavies++
-		arm_equipment(H, /datum/equipment_preset/uscm/specialist_equipped/cryo, TRUE, TRUE)
+		arm_equipment(H, /datum/equipment_preset/uscm/spec/cryo, TRUE, TRUE)
 		to_chat(H, SPAN_ROLE_HEADER("You are a Weapons Specialist in the USCM"))
 		to_chat(H, SPAN_ROLE_BODY("Your squad is here to assist in the defence of the [SSmapping.configs[GROUND_MAP].map_name]. Listen to the chain of command."))
 	else if (medics < max_medics && HAS_FLAG(H.client.prefs.toggles_ert, PLAY_MEDIC) && check_timelock(H.client, JOB_SQUAD_MEDIC, time_required_for_job))

--- a/code/datums/emergency_calls/cryo_marines.dm
+++ b/code/datums/emergency_calls/cryo_marines.dm
@@ -39,7 +39,7 @@
 		to_chat(H, SPAN_ROLE_BODY("You are here to assist in the defence of the [SSmapping.configs[GROUND_MAP].map_name]. Listen to the chain of command."))
 	else if (heavies < max_heavies && HAS_FLAG(H.client.prefs.toggles_ert, PLAY_HEAVY) && check_timelock(H.client, JOB_SQUAD_SPECIALIST, time_required_for_job))
 		heavies++
-		arm_equipment(H, /datum/equipment_preset/uscm/specialist_equipped, TRUE, TRUE)
+		arm_equipment(H, /datum/equipment_preset/uscm/specialist_equipped/cryo, TRUE, TRUE)
 		to_chat(H, SPAN_ROLE_HEADER("You are a Weapons Specialist in the USCM"))
 		to_chat(H, SPAN_ROLE_BODY("Your squad is here to assist in the defence of the [SSmapping.configs[GROUND_MAP].map_name]. Listen to the chain of command."))
 	else if (medics < max_medics && HAS_FLAG(H.client.prefs.toggles_ert, PLAY_MEDIC) && check_timelock(H.client, JOB_SQUAD_MEDIC, time_required_for_job))

--- a/code/datums/emergency_calls/cryo_marines.dm
+++ b/code/datums/emergency_calls/cryo_marines.dm
@@ -39,7 +39,7 @@
 		to_chat(H, SPAN_ROLE_BODY("You are here to assist in the defence of the [SSmapping.configs[GROUND_MAP].map_name]. Listen to the chain of command."))
 	else if (heavies < max_heavies && HAS_FLAG(H.client.prefs.toggles_ert, PLAY_HEAVY) && check_timelock(H.client, JOB_SQUAD_SPECIALIST, time_required_for_job))
 		heavies++
-		arm_equipment(H, /datum/equipment_preset/uscm/spec/cryo, TRUE, TRUE)
+		arm_equipment(H, /datum/equipment_preset/uscm/specialist_equipped, TRUE, TRUE)
 		to_chat(H, SPAN_ROLE_HEADER("You are a Weapons Specialist in the USCM"))
 		to_chat(H, SPAN_ROLE_BODY("Your squad is here to assist in the defence of the [SSmapping.configs[GROUND_MAP].map_name]. Listen to the chain of command."))
 	else if (medics < max_medics && HAS_FLAG(H.client.prefs.toggles_ert, PLAY_MEDIC) && check_timelock(H.client, JOB_SQUAD_MEDIC, time_required_for_job))

--- a/code/modules/cm_marines/equipment/kit_boxes.dm
+++ b/code/modules/cm_marines/equipment/kit_boxes.dm
@@ -161,9 +161,15 @@
 	icon_state = "spec_kit"
 	var/list/allowed_roles_list = list(JOB_SQUAD_SPECIALIST, JOB_WO_SQUAD_SPECIALIST, JOB_WO_CREWMAN)
 
+	///Used for cryo specs who already have "foxtrot" appended to their ID assignments
+	var/squad_assignment_update = TRUE
+
 //this one is delivered via ASRS as a reward for DEFCON/techwebs/whatever else we will have
 /obj/item/spec_kit/asrs
 	allowed_roles_list = list(JOB_SQUAD_MARINE, JOB_WO_SQUAD_MARINE)
+
+/obj/item/spec_kit/cryo
+	squad_assignment_update = FALSE
 
 /obj/item/spec_kit/get_examine_text(mob/user)
 	. = ..()
@@ -252,7 +258,7 @@
 				user.skills.set_skill(SKILL_ENGINEER, SKILL_ENGINEER_TRAINED)
 	if(specialist_assignment)
 		user.put_in_hands(spec_box)
-		ID.set_assignment((user.assigned_squad ? (user.assigned_squad.name + " ") : "") + ID.assignment + " ([specialist_assignment])")
+		ID.set_assignment((user.assigned_squad && squad_assignment_update ? (user.assigned_squad.name + " ") : "") + ID.assignment + " ([specialist_assignment])")
 		GLOB.data_core.manifest_modify(user.real_name, WEAKREF(user), ID.assignment)
 		return TRUE
 	return FALSE

--- a/code/modules/gear_presets/uscm.dm
+++ b/code/modules/gear_presets/uscm.dm
@@ -292,7 +292,7 @@
 /datum/equipment_preset/uscm/spec/cryo/load_gear(mob/living/carbon/human/H)
 	..()
 	H.equip_to_slot_or_del(new /obj/item/device/radio/headset/almayer/marine/cryo(H), WEAR_L_EAR)
-	H.equip_to_slot_or_del(new /obj/item/spec_kit, WEAR_R_HAND)
+	H.equip_to_slot_or_del(new /obj/item/spec_kit/cryo, WEAR_R_HAND)
 
 //*****************************************************************************************************/
 

--- a/code/modules/gear_presets/uscm.dm
+++ b/code/modules/gear_presets/uscm.dm
@@ -698,9 +698,13 @@
 	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/marine/knife(H), WEAR_FEET)
 	H.equip_to_slot_or_del(new /obj/item/storage/box/MRE(H), WEAR_IN_BACK)
 
+//*****************************************************************************************************/
+
 /datum/equipment_preset/uscm/specialist_equipped/cryo
 	name = "USCM Cryo Squad Weapons Specialist (Equipped)"
 	auto_squad_name = SQUAD_MARINE_CRYO
+/datum/equipment_preset/uscm/specialist_equipped/cryo/load_gear(mob/living/carbon/human/H)
+	H.equip_to_slot_or_del(new /obj/item/spec_kit, WEAR_R_HAND)
 
 //*****************************************************************************************************/
 

--- a/code/modules/gear_presets/uscm.dm
+++ b/code/modules/gear_presets/uscm.dm
@@ -292,6 +292,7 @@
 /datum/equipment_preset/uscm/spec/cryo/load_gear(mob/living/carbon/human/H)
 	..()
 	H.equip_to_slot_or_del(new /obj/item/device/radio/headset/almayer/marine/cryo(H), WEAR_L_EAR)
+	H.equip_to_slot_or_del(new /obj/item/spec_kit, WEAR_R_HAND)
 
 //*****************************************************************************************************/
 
@@ -698,13 +699,9 @@
 	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/marine/knife(H), WEAR_FEET)
 	H.equip_to_slot_or_del(new /obj/item/storage/box/MRE(H), WEAR_IN_BACK)
 
-//*****************************************************************************************************/
-
 /datum/equipment_preset/uscm/specialist_equipped/cryo
 	name = "USCM Cryo Squad Weapons Specialist (Equipped)"
 	auto_squad_name = SQUAD_MARINE_CRYO
-/datum/equipment_preset/uscm/specialist_equipped/cryo/load_gear(mob/living/carbon/human/H)
-	H.equip_to_slot_or_del(new /obj/item/spec_kit, WEAR_R_HAND)
 
 //*****************************************************************************************************/
 


### PR DESCRIPTION
# About the pull request
Adds a Squad Weapons Specialist to the Foxtrot ERT bought through DEFCON.

# Explain why it's good for the game
Foxtrot as it currently stands is in a poor spot, hence the meme "Foxtrot gets called, it's 3 guys, 2 of which cryo immediately", hopefully the inclusion of a Foxtrot Spec will increase the number of people signing up for it, as it is a pretty big incentive.

# Testing Photographs and Procedure
Compiles and runs, ERT can trigger fine, still.

# Changelog

:cl:LynxSolstice
balance: Adds a Squad Weapons Specialist to the Cryorines.
/:cl:
