### PR TITLE
Changes M2C deploy time to be the same as other turrets

### DIFF
--- a/code/modules/cm_marines/smartgun_mount.dm
+++ b/code/modules/cm_marines/smartgun_mount.dm
@@ -136,7 +136,7 @@
 		return
 
 
-	if(!do_after(user, 1 SECONDS, INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD))
+	if(!do_after(user, 4 SECONDS, INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD))
 		return
 
 	var/obj/structure/machinery/m56d_post/M = new /obj/structure/machinery/m56d_post(user.loc)


### PR DESCRIPTION
This is an observation I had during a round where I watched an m2c gunner use his turret instead of a gun since it had a quick deploy time.
T m2c deploy time is currently 1 second vs the 4 it usually takes for all other turrets.
This looks like an oversight to be able to use it like a normal gun with that small deployment delay

:cl: Hopek
balance: rebalanced something
/:cl:
