### PR TITLE
Fixes abusing old code to make mortars into grenades

### DIFF
--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -151,9 +151,13 @@
 			to_chat(user, SPAN_DANGER("Assembly part missing!"))
 			return
 		if(istype(a_left,a_right.type))//If they are the same type it causes issues due to window code
-			switch(alert("Which side would you like to use?",,"Left","Right"))
-				if("Left") a_left.attack_self(user)
-				if("Right") a_right.attack_self(user)
+			var/response = tgui_alert(user, "Which side would you like to use?", "Side selection", list("Left","Right"))
+			if(response && (user.l_hand == src || user.r_hand == src))
+				switch(response)
+					if("Left")
+						a_left.attack_self(user)
+					if("Right")
+						a_right.attack_self(user)
 			return
 		else
 			if(!istype(a_left,/obj/item/device/assembly/igniter))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Fixes abusing old code to make mortars into grenades. You know who you are.

# Explain why it's good for the game

Mortars are not supposed to be used as grenades.

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
fix: Fixes abusing old code to make mortars into grenades
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
