### PR TITLE
Strong corrosive acid fix

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/general_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/general_abilities.dm
@@ -153,7 +153,7 @@
 			acid_type = /obj/effect/xenomorph/acid
 		if(3)
 			name = "Corrosive Acid (125)"
-			acid_plasma_cost = 100
+			acid_plasma_cost = 125
 			acid_type = /obj/effect/xenomorph/acid/strong
 
 /datum/action/xeno_action/activable/corrosive_acid/weak

--- a/code/modules/mob/living/carbon/xenomorph/abilities/general_ability_macros.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/general_ability_macros.dm
@@ -75,7 +75,7 @@
 		if(2)
 			action_name = "Corrosive Acid (100)"
 		if(3)
-			action_name = "Corrosive Acid (200)"
+			action_name = "Corrosive Acid (125)"
 
 	handle_xeno_macro(src, action_name)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request
Fixes strong corrosive acid plasma cost (oversight in original PR) #965.
Additionally, changes the action name of strong corrosive acid for the hotkey to work properly)

# Explain why it's good for the game
Typo fix + working hotkey = good

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: Strong corrosive acid plasma cost increased to 125
spellcheck: Action name of strong corrosive acid changed from (200) to (125)
/:cl: