### PR TITLE
Radio backpack tweaks and fixes

### DIFF
--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -477,12 +477,9 @@ GLOBAL_LIST_EMPTY_TYPED(radio_packs, /obj/item/storage/backpack/marine/satchel/r
 	button.overlays += IMG
 
 /datum/action/item_action/rto_pack/use_phone/action_activate()
-	if(!istype(owner, /mob/living/carbon/human))
+	for(var/obj/item/storage/backpack/marine/satchel/rto/radio_backpack in owner)
+		radio_backpack.use_phone(owner)
 		return
-	var/mob/living/carbon/human/user = owner
-	if(istype(user.back, /obj/item/storage/backpack/marine/satchel/rto))
-		var/obj/item/storage/backpack/marine/satchel/rto/R = user.back
-		R.use_phone(user)
 
 /obj/item/storage/backpack/marine/satchel/rto/post_skin_selection()
 	base_icon = icon_state
@@ -516,11 +513,6 @@ GLOBAL_LIST_EMPTY_TYPED(radio_packs, /obj/item/storage/backpack/marine/satchel/r
 		icon_state = "[base_icon]_ring"
 	else
 		icon_state = base_icon
-
-/obj/item/storage/backpack/marine/satchel/rto/item_action_slot_check(mob/user, slot)
-	if(slot == WEAR_BACK)
-		return TRUE
-	return FALSE
 
 /obj/item/storage/backpack/marine/satchel/rto/forceMove(atom/dest)
 	. = ..()
@@ -558,10 +550,7 @@ GLOBAL_LIST_EMPTY_TYPED(radio_packs, /obj/item/storage/backpack/marine/satchel/r
 	internal_transmitter.enabled = FALSE
 
 /obj/item/storage/backpack/marine/satchel/rto/proc/use_phone(mob/user)
-	if(user.back == src)
-		internal_transmitter.attack_hand(user)
-	else if(internal_transmitter.get_calling_phone())
-		internal_transmitter.attack_hand(user)
+	internal_transmitter.attack_hand(user)
 
 
 /obj/item/storage/backpack/marine/satchel/rto/attackby(obj/item/W, mob/user)

--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -301,7 +301,10 @@ var/list/global/item_storage_box_cache = list()
 
 		for(var/i in 1 to length(S.click_border_start))
 			if(S.click_border_start[i] <= click_x && click_x <= S.click_border_end[i])
-				I = LAZYACCESS(S.contents, i)
+				var/list/content_items = list()
+				for(var/obj/item/content_item in S.contents)
+					content_items += content_item
+				I = LAZYACCESS(content_items, i)
 				if(I && I.Adjacent(user)) //Catches pulling items out of nested storage.
 					if(I.clicked(user, mods)) //Examine, alt-click etc.
 						return TRUE
@@ -670,6 +673,8 @@ W is always an item. stop_warning prevents messaging. user may be null.**/
 		item_obj = contents[1]
 	else
 		item_obj = contents[contents.len]
+	if(!istype(item_obj))
+		return
 	remove_from_storage(item_obj, tile)
 	user.visible_message(SPAN_NOTICE("[user] shakes \the [src] and \a [item_obj] falls out."),
 		SPAN_NOTICE("You shake \the [src] and \a [item_obj] falls out."))

--- a/code/modules/cm_phone/phone.dm
+++ b/code/modules/cm_phone/phone.dm
@@ -165,7 +165,7 @@ GLOBAL_LIST_EMPTY_TYPED(transmitters, /obj/structure/transmitter)
 	START_PROCESSING(SSobj, src)
 	START_PROCESSING(SSobj, T)
 
-	user.put_in_active_hand(attached_to)
+	user.put_in_hands(attached_to)
 
 /obj/structure/transmitter/attack_hand(mob/user)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

This PR allows for making phone calls or answering phone calls while holding the backpack in hands.

This PR stops the shake verb from shaking non-items out of storages.

This PR fixes a content offset for non-items in storages. This fixes the off by one error when trying to grab things out of a radio backpack. Fixes #2233

More radio backpack stuff to come as motivation waxes and wanes.


# Explain why it's good for the game

With the upcoming removal of RTO uniform requirements for the backpacks they should be made easier to use outside of needing to be on your back.

Bugs bad.

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
add: Radio backpacks can now be used in hand
fix: Fixed the off by one error in radio backpack item removal
fix: Shaking a bag no longer drops non-items
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
