### PR TITLE
Adds the IB check status function to the examine menu.

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -380,6 +380,9 @@
 	if (display_head)
 		msg += SPAN_WARNING("[t_He] has blood dripping from [t_his] <b>face</b>!\n")
 
+	if(skillcheck(usr, SKILL_SURGERY, SKILL_SURGERY_NOVICE))
+		for(var/datum/effects/bleeding/internal/internal_bleed in effects_list)
+			msg += SPAN_WARNING("They have bloating and discoloration on their [internal_bleed.limb.display_name]!\n")
 	if (display_chest && display_groin && display_arm_left && display_arm_right && display_hand_left && display_hand_right && display_leg_left && display_leg_right && display_foot_left && display_foot_right)
 		msg += SPAN_WARNING("[t_He] has blood soaking through [t_his] clothes from [t_his] <b>entire body</b>!\n")
 	else


### PR DESCRIPTION
# About the pull request

Adds the Internal Bleeding check to the examine menu, increasing ease of use.

# Explain why it's good for the game

Having to go through the right click menu, can at times be cumbersome, now, this allows medical personnel to see both internal and external bleeds through the examine menu.

# Testing Photographs and Procedure

Compiles, runs, works properly. Riflemen cannot see the IB examine text as they do not have the necessary skills for the check. 
![image](https://user-images.githubusercontent.com/112824777/234681225-01a106c3-7b75-4800-af39-eec745decb79.png)


# Changelog

:cl:LynxSolstice
qol: Trained personnel can now see the internal bleeding check-status verb text in the shiftclick/rightclick examine gui.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
