### PR TITLE
Runner push exploit fix

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -352,7 +352,7 @@
 
 	if(isxeno(L) && !islarva(L))
 		var/mob/living/carbon/xenomorph/X = L
-		if(X.mob_size >= MOB_SIZE_BIG || (ishuman(src) && !isyautja(src))) // Small xenos can be pushed by other xenos or preds
+		if(X.mob_size >= MOB_SIZE_XENO_BIG || (ishuman(src) && !isyautja(src))) // Small xenos can be pushed by other xenos or preds
 			now_pushing = FALSE
 			return
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -375,7 +375,6 @@
 					to_chat(src, SPAN_WARNING("[L] is restraining [P], you cannot push past."))
 				now_pushing = FALSE
 				return
-
 	if(ishuman(L))
 		if(!(L.status_flags & CANPUSH))
 			now_pushing = FALSE

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -352,7 +352,7 @@
 
 	if(isxeno(L) && !islarva(L))
 		var/mob/living/carbon/xenomorph/X = L
-		if(X.mob_size >= MOB_SIZE_XENO_BIG || (ishuman(src) && !isyautja(src))) // Small xenos can be pushed by other xenos or preds
+		if(X.mob_size >= MOB_SIZE_BIG || (ishuman(src) && !isyautja(src))) // Small xenos can be pushed by other xenos or preds
 			now_pushing = FALSE
 			return
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -352,10 +352,13 @@
 
 	if(isxeno(L) && !islarva(L))
 		var/mob/living/carbon/xenomorph/X = L
-		if(X.mob_size >= MOB_SIZE_BIG || (ishuman(src) && !isyautja(src))) // Small xenos can be pushed by other xenos or preds
+		if(X.mob_size >= MOB_SIZE_BIG || (ishuman(src) && !isyautja(src)) || (isrunner(src))) // Small xenos can be pushed by other xenos or preds
 			now_pushing = FALSE
 			return
-
+	if(isrunner(src))
+		if(ishuman(L))
+			now_pushing = FALSE
+			return
 	if(L.pulling)
 		if(ismob(L.pulling))
 			var/mob/P = L.pulling

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -350,11 +350,19 @@
 		now_pushing = FALSE
 		return
 
+	//If who I collided into is a xeno that isn't a larva:
+ 	//Cast them into the xeno datum
+ 	//If they (not as a xeno datum) are big or bigger; OR I am a human that isn't a predator; OR I am a runner:
+    //set now_pushing to false and return
+	// - Code doc attributed to Drathek on the CM discord.
 	if(isxeno(L) && !islarva(L))
 		var/mob/living/carbon/xenomorph/X = L
 		if(X.mob_size >= MOB_SIZE_BIG || (ishuman(src) && !isyautja(src)) || (isrunner(src))) // Small xenos can be pushed by other xenos or preds
 			now_pushing = FALSE
 			return
+	//If I am a runner
+	//and my target is a human OR xeno
+	//I cannot push the target
 	if(isrunner(src))
 		if(ishuman(L) || isxeno(L))
 			now_pushing = FALSE

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -355,9 +355,6 @@
 		if(X.mob_size >= MOB_SIZE_BIG || (ishuman(src) && !isyautja(src))) // Small xenos can be pushed by other xenos or preds
 			now_pushing = FALSE
 			return
-		if(X.mob_size == MOB_SIZE_XENO_SMALL)
-			now_pushing = FALSE
-			return
 
 	if(L.pulling)
 		if(ismob(L.pulling))

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -355,6 +355,9 @@
 		if(X.mob_size >= MOB_SIZE_BIG || (ishuman(src) && !isyautja(src))) // Small xenos can be pushed by other xenos or preds
 			now_pushing = FALSE
 			return
+		if(X.mob_size == MOB_SIZE_XENO_SMALL)
+			now_pushing = FALSE
+			return
 
 	if(L.pulling)
 		if(ismob(L.pulling))

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -351,9 +351,9 @@
 		return
 
 	//If who I collided into is a xeno that isn't a larva:
- 	//Cast them into the xeno datum
- 	//If they (not as a xeno datum) are big or bigger; OR I am a human that isn't a predator; OR I am a runner:
-    //set now_pushing to false and return
+	//Cast them into the xeno datum
+	//If they (not as a xeno datum) are big or bigger; OR I am a human that isn't a predator; OR I am a runner:
+	//set now_pushing to false and return
 	// - Code doc attributed to Drathek on the CM discord.
 	if(isxeno(L) && !islarva(L))
 		var/mob/living/carbon/xenomorph/X = L

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -356,7 +356,7 @@
 			now_pushing = FALSE
 			return
 	if(isrunner(src))
-		if(ishuman(L))
+		if(ishuman(L) || isxeno(L))
 			now_pushing = FALSE
 			return
 	if(L.pulling)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request
Runners can no longer push other mobs, which was being used to exploit the movement speed debuff of grabbing mobs, (one xeno drags another while a runner pushes, moving all 3 at a high velocity,) and being used to push humans farther than the runner could drag in that same time frame, as well as not needing to disarm the human first in order to do so. (Runners pushing people 10+ tiles in a few seconds while they cannot react was a common issue.)

# Explain why it's good for the game

Runners being able to use their movement speed to push other mobs such as a runner grabbing a queen or a human to get around the grab speed debuff was frankly, widespread and well known, this PR eliminates that exploit in-order to lessen the amount of cheesing runners can do with the pushing mechanic (which, with this PR, is none, as they cannot push anymore).


# Testing Photographs and Procedure

[Testing video](https://youtu.be/1v7NYxwTmow)

# Changelog

:cl:LynxSolstice
fix: Runners can no longer push humans or other xenos which was being unfortunately exploited to moved grabbed items without delay or to push humans very fast without grabbing them.
/:cl: