### PR TITLE
Fixes xenos being able to be cocooned

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -109,7 +109,7 @@
 			if(!busy && prob(30))
 				//first, check for potential food nearby to cocoon
 				for(var/mob/living/carbon/human/C in can_see)
-					if(C.stat && !istype(C, /mob/living/simple_animal/hostile/giant_spider))
+					if(C.stat)
 						cocoon_target = C
 						busy = MOVING_TO_TARGET
 						walk_to(src, C, 1, move_to_delay)

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -108,7 +108,7 @@
 			//30% chance to stop wandering and do something
 			if(!busy && prob(30))
 				//first, check for potential food nearby to cocoon
-				for(var/mob/living/C in can_see)
+				for(var/mob/living/carbon/human/C in can_see)
 					if(C.stat && !istype(C, /mob/living/simple_animal/hostile/giant_spider))
 						cocoon_target = C
 						busy = MOVING_TO_TARGET


### PR DESCRIPTION
# About the pull request

Xenos should not be able to get cocooned at all, plus it leads to a multitude of bugs such as the xeno being unrecoverable by any other xeno.

# Explain why it's good for the game

No spiders critting a poor runner and the runner being unsaveable and forced to have admin intervention.

closes: #3157 

# Testing Photographs and Procedure
Tested with spawned spider mobs, they didnt cocoon crit xenos.

# Changelog

:cl:
fix: Xenos are no longer able to be cocooned by spiders
/:cl:
