### PR TITLE
Fix debugging with aux tools

### DIFF
--- a/code/__DEFINES/__spacemandmm.dm
+++ b/code/__DEFINES/__spacemandmm.dm
@@ -34,6 +34,9 @@
 /proc/enable_debugging(mode, port)
 	CRASH("auxtools not loaded")
 
+/proc/auxtools_expr_stub()
+	CRASH("auxtools not loaded")
+
 /world/Del()
 	var/debug_server = world.GetConfig("env", "AUXTOOLS_DEBUG_DLL")
 	if (debug_server)


### PR DESCRIPTION

# About the pull request
This PR fixes the inability to watch variables or evaluate expressions in the debug console at runtime. The language server must have changed at some point to require this new stub proc.

# Explain why it's good for the game
Instead of: 
![image](https://user-images.githubusercontent.com/76988376/235112211-15fbc82a-bd48-4208-b795-5680913b7a3d.png)
You can once again: 
![image](https://user-images.githubusercontent.com/76988376/235112327-263d28df-7590-4bb0-bc42-923d9d58a50c.png)
(Though you still can't evaluate procs that are define macros.)
# Changelog
:cl: Drathek
fix: Fixed auxtools debugging.
/:cl:
