### PR TITLE
Minor fixes to the combi-stick

### DIFF
--- a/code/modules/cm_preds/yaut_bracers.dm
+++ b/code/modules/cm_preds/yaut_bracers.dm
@@ -950,6 +950,8 @@
 		return
 
 	for(var/obj/item/weapon/yautja/combistick/C in range(7))
+		if(C in caller.contents) //Can't yank if they are wearing it
+			return FALSE
 		if(caller.put_in_active_hand(C))//Try putting it in our active hand, or, if it's full...
 			if(!drain_power(caller, 70)) //We should only drain power if we actually yank the chain back. Failed attempts can quickly drain the charge away.
 				return TRUE

--- a/code/modules/cm_preds/yaut_weapons.dm
+++ b/code/modules/cm_preds/yaut_weapons.dm
@@ -257,6 +257,7 @@
 		return FALSE
 	charged = FALSE
 	remove_filter("combistick_charge")
+	unwield(user) //Otherwise stays wielded even when thrown
 	return TRUE
 
 


### PR DESCRIPTION
# About the pull request

Stops you from yanking the combi-stick if it is on your person
Unwields the combi-stick when you throw it

# Explain why it's good for the game

If you yanked the combi-stick on your person, it would duplicate it, giving you two combi-sticks that are the same item.
The combi-stick wouldn't un-wield when you threw it, causing the "offhand" object to stay in your hand even when thrown.

# Changelog

:cl:
fix: Fixes combi-stick duplicating and not un-wielding properly
/:cl: