### PR TITLE
GAU buff. 

### DIFF
--- a/code/modules/cm_marines/dropship_ammo.dm
+++ b/code/modules/cm_marines/dropship_ammo.dm
@@ -166,7 +166,7 @@
 	var/soundplaycooldown = 0
 	var/debriscooldown = 0
 	for(var/i = 1 to ammo_used_per_firing)
-		var/turf/U = pick(turf_list)
+		var/turf/U = pick(turf_list) // Center of a single impact configs
 		sleep(1)
 		var/datum/cause_data/cause_data = create_cause_data(initial(name), source_mob)
 		U.ex_act(EXPLOSION_THRESHOLD_VLOW, pick(alldirs), cause_data)
@@ -176,9 +176,14 @@
 				AM.ex_act(EXPLOSION_THRESHOLD_VLOW, null, cause_data)
 			else
 				AM.ex_act(EXPLOSION_THRESHOLD_VLOW)
-		for(var/turf/A in orange(bullet_accuracy_range, U))
+		for(var/turf/A in orange(bullet_accuracy_range, U))// Outer ring(s) of a single impact configs
 			create_shrapnel(A,1,0,0,shrapnel_type,cause_data,FALSE,100)
 			A.ex_act(EXPLOSION_THRESHOLD_VLOW, pick(alldirs), cause_data)
+			for(var/atom/movable/AM in U)
+				if(iscarbon(AM))
+					AM.ex_act(EXPLOSION_THRESHOLD_VLOW, null, cause_data)
+				else
+					AM.ex_act(EXPLOSION_THRESHOLD_VLOW)
 			new /obj/effect/particle_effect/expl_particles(A)
 		if(!soundplaycooldown) //so we don't play the same sound 20 times very fast.
 			playsound(U, 'sound/effects/gauimpact.ogg',40,1,20)
@@ -202,6 +207,7 @@
 	max_ammo_count = 400
 	ammo_used_per_firing = 40
 	bullet_scatter_range = 4
+	bullet_accuracy_range = 1
 	point_cost = 325
 	fire_mission_delay = 2
 	shrapnel_type = /datum/ammo/bullet/shrapnel/gau/at

--- a/code/modules/cm_marines/dropship_ammo.dm
+++ b/code/modules/cm_marines/dropship_ammo.dm
@@ -146,7 +146,7 @@
 	fire_mission_delay = 2
 	var/bullet_scatter_range = 4 //how far from the real impact turf can bullets land.
 	var/bullet_accuracy_range = 1 //how far from a BULLET impact turf additional impacts can land.
-	var/shrapnel_type = /datum/ammo/bullet/shrapnel/gau //For siming 30mm bullet impacts.
+	var/shrapnel_type = /datum/ammo/bullet/shrapnel/gau //For siming 30mm bullet impacts. also the shrapnel type for the center of a 3x3 impact
 	var/outerring_shrap_type = /datum/ammo/bullet/shrapnel/gau/whiplash //shrapnel type for the outer ring of the 3x3
 
 /obj/structure/ship_ammo/heavygun/get_examine_text(mob/user)

--- a/code/modules/cm_marines/dropship_ammo.dm
+++ b/code/modules/cm_marines/dropship_ammo.dm
@@ -40,7 +40,7 @@
 	var/combat_equipment = TRUE
 
 /obj/structure/ship_ammo/attack_alien(mob/living/carbon/xenomorph/current_xenomorph)
-	if(unslashable) 
+	if(unslashable)
 		return XENO_NO_DELAY_ACTION
 	current_xenomorph.animation_attack_on(src)
 	playsound(src, 'sound/effects/metalhit.ogg', 25, 1)
@@ -144,7 +144,8 @@
 	ammo_used_per_firing = 40
 	point_cost = 275
 	fire_mission_delay = 2
-	var/bullet_spread_range = 4 //how far from the real impact turf can bullets land
+	var/bullet_scatter_range = 4 //how far from the real impact turf can bullets land.
+	var/bullet_accuracy_range = 1 //how far from a BULLET impact turf additional impacts can land.
 	var/shrapnel_type = /datum/ammo/bullet/shrapnel/gau //For siming 30mm bullet impacts.
 
 /obj/structure/ship_ammo/heavygun/get_examine_text(mob/user)
@@ -160,7 +161,7 @@
 /obj/structure/ship_ammo/heavygun/detonate_on(turf/impact)
 	set waitfor = 0
 	var/list/turf_list = list()
-	for(var/turf/T in range(bullet_spread_range, impact))
+	for(var/turf/T in range(bullet_scatter_range, impact))
 		turf_list += T
 	var/soundplaycooldown = 0
 	var/debriscooldown = 0
@@ -169,12 +170,16 @@
 		sleep(1)
 		var/datum/cause_data/cause_data = create_cause_data(initial(name), source_mob)
 		U.ex_act(EXPLOSION_THRESHOLD_VLOW, pick(alldirs), cause_data)
-		create_shrapnel(U,1,0,0,shrapnel_type,cause_data,FALSE,100) //simulates a bullet
+		create_shrapnel(U,1,0,0,shrapnel_type,cause_data,FALSE,100)
 		for(var/atom/movable/AM in U)
 			if(iscarbon(AM))
 				AM.ex_act(EXPLOSION_THRESHOLD_VLOW, null, cause_data)
 			else
 				AM.ex_act(EXPLOSION_THRESHOLD_VLOW)
+		for(var/turf/A in orange(bullet_accuracy_range, U))
+			create_shrapnel(A,1,0,0,shrapnel_type,cause_data,FALSE,100)
+			A.ex_act(EXPLOSION_THRESHOLD_VLOW, pick(alldirs), cause_data)
+			new /obj/effect/particle_effect/expl_particles(A)
 		if(!soundplaycooldown) //so we don't play the same sound 20 times very fast.
 			playsound(U, 'sound/effects/gauimpact.ogg',40,1,20)
 			soundplaycooldown = 3
@@ -196,7 +201,7 @@
 	ammo_count = 400
 	max_ammo_count = 400
 	ammo_used_per_firing = 40
-	bullet_spread_range = 4
+	bullet_scatter_range = 4
 	point_cost = 325
 	fire_mission_delay = 2
 	shrapnel_type = /datum/ammo/bullet/shrapnel/gau/at

--- a/code/modules/cm_marines/dropship_ammo.dm
+++ b/code/modules/cm_marines/dropship_ammo.dm
@@ -138,16 +138,18 @@
 	icon_state = "30mm_crate"
 	desc = "A crate full of PGU-100 30mm Multi-Purpose ammo designed to penetrate light (non reinforced) structures, as well as shred infantry, IAVs, LAVs, IMVs, and MRAPs. Works in large areas for use on Class 4 and superior alien insectoid infestations, as well as fitting within the armaments allowed for use against a tier 4 insurgency as well as higher tiers. However, it lacks armor penetrating capabilities, for which Anti-Tank 30mm ammo is needed."
 	equipment_type = /obj/structure/dropship_equipment/weapon/heavygun
-	ammo_count = 300
-	max_ammo_count = 300
+	ammo_count = 200
+	max_ammo_count = 200
 	transferable_ammo = TRUE
-	ammo_used_per_firing = 30
+	ammo_used_per_firing = 20
 	point_cost = 275
 	fire_mission_delay = 2
 	var/bullet_scatter_range = 4 //how far from the real impact turf can bullets land.
 	var/bullet_accuracy_range = 1 //how far from a BULLET impact turf additional impacts can land.
 	var/shrapnel_type = /datum/ammo/bullet/shrapnel/gau //For siming 30mm bullet impacts. also the shrapnel type for the center of a 3x3 impact
 	var/outerring_shrap_type = /datum/ammo/bullet/shrapnel/gau/whiplash //shrapnel type for the outer ring of the 3x3
+	var/directhit_damage = 99 //how much damage is to be inficted to a mob, this is here so that we can hit resting mobs.
+	var/penetration = 40 //AP value pretty much
 
 /obj/structure/ship_ammo/heavygun/get_examine_text(mob/user)
 	. = ..()
@@ -174,7 +176,9 @@
 		create_shrapnel(U,1,0,0,shrapnel_type,cause_data,FALSE,100)
 		for(var/atom/movable/AM in U)
 			if(iscarbon(AM))
+				var/mob/living/M = AM
 				AM.ex_act(EXPLOSION_THRESHOLD_VLOW, null, cause_data)
+				M.apply_armoured_damage(directhit_damage,ARMOR_BULLET,BRUTE,null,penetration) // So we can hit a mob that is resting in the turf.
 			else
 				AM.ex_act(EXPLOSION_THRESHOLD_VLOW)
 		for(var/turf/A in orange(bullet_accuracy_range, U))// Outer ring(s) of a single impact configs
@@ -204,14 +208,16 @@
 	icon_state = "30mm_crate_hv"
 	desc = "A crate full of PGU-105 Specialized 30mm APFSDS Titanium-Tungsten alloy penetrators, made for countering peer and near peer APCs, IFVs, and MBTs in CAS support. It's designed to penetrate up to the equivalent 1350mm of RHA when launched from a GAU-21. It is much less effective against soft targets however, in which case 30mm ball ammunition is recommended. WARNING: discarding petals from the ammunition can be harmful if the dropship does not pull out at the needed speeds. Please consult page 3574 of the manual, available for order at any ARMAT store."
 	travelling_time = 60
-	ammo_count = 300
-	max_ammo_count = 300
-	ammo_used_per_firing = 30
+	ammo_count = 200
+	max_ammo_count = 200
+	ammo_used_per_firing = 20
 	bullet_scatter_range = 4
 	bullet_accuracy_range = 1
 	point_cost = 325
 	fire_mission_delay = 2
 	shrapnel_type = /datum/ammo/bullet/shrapnel/gau/at
+	directhit_damage = 64
+	penetration = 90
 
 //laser battery
 

--- a/code/modules/cm_marines/dropship_ammo.dm
+++ b/code/modules/cm_marines/dropship_ammo.dm
@@ -138,10 +138,10 @@
 	icon_state = "30mm_crate"
 	desc = "A crate full of PGU-100 30mm Multi-Purpose ammo designed to penetrate light (non reinforced) structures, as well as shred infantry, IAVs, LAVs, IMVs, and MRAPs. Works in large areas for use on Class 4 and superior alien insectoid infestations, as well as fitting within the armaments allowed for use against a tier 4 insurgency as well as higher tiers. However, it lacks armor penetrating capabilities, for which Anti-Tank 30mm ammo is needed."
 	equipment_type = /obj/structure/dropship_equipment/weapon/heavygun
-	ammo_count = 100
-	max_ammo_count = 100
+	ammo_count = 150
+	max_ammo_count = 150
 	transferable_ammo = TRUE
-	ammo_used_per_firing = 10
+	ammo_used_per_firing = 15
 	point_cost = 275
 	fire_mission_delay = 2
 	var/bullet_scatter_range = 4 //how far from the real impact turf can bullets land.
@@ -208,9 +208,9 @@
 	icon_state = "30mm_crate_hv"
 	desc = "A crate full of PGU-105 Specialized 30mm APFSDS Titanium-Tungsten alloy penetrators, made for countering peer and near peer APCs, IFVs, and MBTs in CAS support. It's designed to penetrate up to the equivalent 1350mm of RHA when launched from a GAU-21. It is much less effective against soft targets however, in which case 30mm ball ammunition is recommended. WARNING: discarding petals from the ammunition can be harmful if the dropship does not pull out at the needed speeds. Please consult page 3574 of the manual, available for order at any ARMAT store."
 	travelling_time = 60
-	ammo_count = 100
-	max_ammo_count = 100
-	ammo_used_per_firing = 10
+	ammo_count = 150
+	max_ammo_count = 150
+	ammo_used_per_firing = 150
 	bullet_scatter_range = 4
 	bullet_accuracy_range = 1
 	point_cost = 325

--- a/code/modules/cm_marines/dropship_ammo.dm
+++ b/code/modules/cm_marines/dropship_ammo.dm
@@ -138,10 +138,10 @@
 	icon_state = "30mm_crate"
 	desc = "A crate full of PGU-100 30mm Multi-Purpose ammo designed to penetrate light (non reinforced) structures, as well as shred infantry, IAVs, LAVs, IMVs, and MRAPs. Works in large areas for use on Class 4 and superior alien insectoid infestations, as well as fitting within the armaments allowed for use against a tier 4 insurgency as well as higher tiers. However, it lacks armor penetrating capabilities, for which Anti-Tank 30mm ammo is needed."
 	equipment_type = /obj/structure/dropship_equipment/weapon/heavygun
-	ammo_count = 400
-	max_ammo_count = 400
+	ammo_count = 300
+	max_ammo_count = 300
 	transferable_ammo = TRUE
-	ammo_used_per_firing = 40
+	ammo_used_per_firing = 30
 	point_cost = 275
 	fire_mission_delay = 2
 	var/bullet_scatter_range = 4 //how far from the real impact turf can bullets land.
@@ -204,9 +204,9 @@
 	icon_state = "30mm_crate_hv"
 	desc = "A crate full of PGU-105 Specialized 30mm APFSDS Titanium-Tungsten alloy penetrators, made for countering peer and near peer APCs, IFVs, and MBTs in CAS support. It's designed to penetrate up to the equivalent 1350mm of RHA when launched from a GAU-21. It is much less effective against soft targets however, in which case 30mm ball ammunition is recommended. WARNING: discarding petals from the ammunition can be harmful if the dropship does not pull out at the needed speeds. Please consult page 3574 of the manual, available for order at any ARMAT store."
 	travelling_time = 60
-	ammo_count = 400
-	max_ammo_count = 400
-	ammo_used_per_firing = 40
+	ammo_count = 300
+	max_ammo_count = 300
+	ammo_used_per_firing = 30
 	bullet_scatter_range = 4
 	bullet_accuracy_range = 1
 	point_cost = 325

--- a/code/modules/cm_marines/dropship_ammo.dm
+++ b/code/modules/cm_marines/dropship_ammo.dm
@@ -138,10 +138,10 @@
 	icon_state = "30mm_crate"
 	desc = "A crate full of PGU-100 30mm Multi-Purpose ammo designed to penetrate light (non reinforced) structures, as well as shred infantry, IAVs, LAVs, IMVs, and MRAPs. Works in large areas for use on Class 4 and superior alien insectoid infestations, as well as fitting within the armaments allowed for use against a tier 4 insurgency as well as higher tiers. However, it lacks armor penetrating capabilities, for which Anti-Tank 30mm ammo is needed."
 	equipment_type = /obj/structure/dropship_equipment/weapon/heavygun
-	ammo_count = 150
-	max_ammo_count = 150
+	ammo_count = 130
+	max_ammo_count = 130
 	transferable_ammo = TRUE
-	ammo_used_per_firing = 15
+	ammo_used_per_firing = 13
 	point_cost = 275
 	fire_mission_delay = 2
 	var/bullet_scatter_range = 4 //how far from the real impact turf can bullets land.
@@ -208,9 +208,9 @@
 	icon_state = "30mm_crate_hv"
 	desc = "A crate full of PGU-105 Specialized 30mm APFSDS Titanium-Tungsten alloy penetrators, made for countering peer and near peer APCs, IFVs, and MBTs in CAS support. It's designed to penetrate up to the equivalent 1350mm of RHA when launched from a GAU-21. It is much less effective against soft targets however, in which case 30mm ball ammunition is recommended. WARNING: discarding petals from the ammunition can be harmful if the dropship does not pull out at the needed speeds. Please consult page 3574 of the manual, available for order at any ARMAT store."
 	travelling_time = 60
-	ammo_count = 150
-	max_ammo_count = 150
-	ammo_used_per_firing = 150
+	ammo_count = 130
+	max_ammo_count = 130
+	ammo_used_per_firing = 13
 	bullet_scatter_range = 4
 	bullet_accuracy_range = 1
 	point_cost = 325

--- a/code/modules/cm_marines/dropship_ammo.dm
+++ b/code/modules/cm_marines/dropship_ammo.dm
@@ -138,10 +138,10 @@
 	icon_state = "30mm_crate"
 	desc = "A crate full of PGU-100 30mm Multi-Purpose ammo designed to penetrate light (non reinforced) structures, as well as shred infantry, IAVs, LAVs, IMVs, and MRAPs. Works in large areas for use on Class 4 and superior alien insectoid infestations, as well as fitting within the armaments allowed for use against a tier 4 insurgency as well as higher tiers. However, it lacks armor penetrating capabilities, for which Anti-Tank 30mm ammo is needed."
 	equipment_type = /obj/structure/dropship_equipment/weapon/heavygun
-	ammo_count = 200
-	max_ammo_count = 200
+	ammo_count = 100
+	max_ammo_count = 100
 	transferable_ammo = TRUE
-	ammo_used_per_firing = 20
+	ammo_used_per_firing = 10
 	point_cost = 275
 	fire_mission_delay = 2
 	var/bullet_scatter_range = 4 //how far from the real impact turf can bullets land.
@@ -208,9 +208,9 @@
 	icon_state = "30mm_crate_hv"
 	desc = "A crate full of PGU-105 Specialized 30mm APFSDS Titanium-Tungsten alloy penetrators, made for countering peer and near peer APCs, IFVs, and MBTs in CAS support. It's designed to penetrate up to the equivalent 1350mm of RHA when launched from a GAU-21. It is much less effective against soft targets however, in which case 30mm ball ammunition is recommended. WARNING: discarding petals from the ammunition can be harmful if the dropship does not pull out at the needed speeds. Please consult page 3574 of the manual, available for order at any ARMAT store."
 	travelling_time = 60
-	ammo_count = 200
-	max_ammo_count = 200
-	ammo_used_per_firing = 20
+	ammo_count = 100
+	max_ammo_count = 100
+	ammo_used_per_firing = 10
 	bullet_scatter_range = 4
 	bullet_accuracy_range = 1
 	point_cost = 325

--- a/code/modules/cm_marines/dropship_ammo.dm
+++ b/code/modules/cm_marines/dropship_ammo.dm
@@ -147,6 +147,7 @@
 	var/bullet_scatter_range = 4 //how far from the real impact turf can bullets land.
 	var/bullet_accuracy_range = 1 //how far from a BULLET impact turf additional impacts can land.
 	var/shrapnel_type = /datum/ammo/bullet/shrapnel/gau //For siming 30mm bullet impacts.
+	var/outerring_shrap_type = /datum/ammo/bullet/shrapnel/gau/whiplash //shrapnel type for the outer ring of the 3x3
 
 /obj/structure/ship_ammo/heavygun/get_examine_text(mob/user)
 	. = ..()
@@ -177,7 +178,7 @@
 			else
 				AM.ex_act(EXPLOSION_THRESHOLD_VLOW)
 		for(var/turf/A in orange(bullet_accuracy_range, U))// Outer ring(s) of a single impact configs
-			create_shrapnel(A,1,0,0,shrapnel_type,cause_data,FALSE,100)
+			create_shrapnel(A,1,0,0,outerring_shrap_type,cause_data,FALSE,100)
 			A.ex_act(EXPLOSION_THRESHOLD_VLOW, pick(alldirs), cause_data)
 			for(var/atom/movable/AM in U)
 				if(iscarbon(AM))

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -3047,9 +3047,30 @@
 /datum/ammo/bullet/shrapnel/gau/whiplash
 	name = "30mm shell whiplash"
 
-	damage = 60
-	penetration = ARMOR_PENETRATION_TIER_5
+	damage = 35
+	penetration = ARMOR_PENETRATION_TIER_3
 	accuracy = HIT_ACCURACY_TIER_MAX
+
+/datum/ammo/bullet/shrapnel/gau/on_hit_mob(mob/M, obj/item/projectile/P)
+	M.apply_effect(2, SUPERSLOW)
+	M.apply_effect(4, SLOW)
+	M.apply_effect(8, DAZE)
+	if(isxeno(M))
+		to_chat(M, SPAN_XENOHIGHDANGER("You screech in horror as the 30mm shell rips through you!"))
+	else
+		to_chat(M, SPAN_HIGHDANGER("You scream in pain as the 30mm shell rips through you!"))
+/datum/ammo/bullet/shrapnel/gau/whiplash/on_hit_mob(mob/M, obj/item/projectile/P)
+	M.apply_effect(2, SLOW)
+	M.apply_effect(4, DAZE)
+	if(isxeno(M))
+		to_chat(M, SPAN_XENODANGER("You are shaken by the near miss 30mm impact!"))
+	else
+		to_chat(M, SPAN_DANGER("You are shaken by the near miss 30mm impact"))
+
+
+
+
+
 
 /*
 //======

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -3030,16 +3030,17 @@
 /datum/ammo/bullet/shrapnel/gau  //for the GAU to have a impact bullet instead of firecrackers
 	name = "30mm Multi-Purpose shell"
 
-	damage = 100 // More damage, less AP
+	damage = 1 // ALL DAMAGE IS IN dropship_ammo SO WE CAN DEAL DAMAGE TO RESTING MOBS, these will still remain however so that we can get cause_data and status effects.
+	damage_type = BRUTE
 	penetration = ARMOR_PENETRATION_TIER_2
 	accuracy = HIT_ACCURACY_TIER_MAX
 	max_range = 0
 	shrapnel_chance = 100 //the least of your problems
 
 /datum/ammo/bullet/shrapnel/gau/at
-	name = "30mm Anti-Tank shell" // More AP, Less damage
+	name = "30mm Anti-Tank shell" // ALL DAMAGE IS IN dropship_ammo SO WE CAN DEAL DAMAGE TO RESTING MOBS
 
-	damage = 65
+	damage = 1
 	penetration = ARMOR_PENETRATION_TIER_8
 	accuracy = HIT_ACCURACY_TIER_MAX
 
@@ -3069,7 +3070,6 @@
 		to_chat(M, SPAN_XENODANGER("You are shaken by the near miss 30mm impact!"))
 	else
 		to_chat(M, SPAN_DANGER("You are shaken by the near miss 30mm impact"))
-
 
 /*
 //======

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -3047,8 +3047,8 @@
 /datum/ammo/bullet/shrapnel/gau/whiplash
 	name = "30mm shell whiplash"
 
-	damage = 35
-	penetration = ARMOR_PENETRATION_TIER_3
+	damage = 40
+	penetration = ARMOR_PENETRATION_TIER_4
 	accuracy = HIT_ACCURACY_TIER_MAX
 
 /datum/ammo/bullet/shrapnel/gau/on_hit_mob(mob/M, obj/item/projectile/P)

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -3030,21 +3030,26 @@
 /datum/ammo/bullet/shrapnel/gau  //for the GAU to have a impact bullet instead of firecrackers
 	name = "30mm Multi-Purpose shell"
 
-	damage = 100 //More damaging, but 2x less shells and low AP
+	damage = 100 // More damage, less AP
 	penetration = ARMOR_PENETRATION_TIER_2
 	accuracy = HIT_ACCURACY_TIER_MAX
 	max_range = 0
 	shrapnel_chance = 100 //the least of your problems
 
 /datum/ammo/bullet/shrapnel/gau/at
-	name = "30mm Anti-Tank shell"
+	name = "30mm Anti-Tank shell" // More AP, Less damage
 
-	damage = 65 //Standard AP vs standard. (more AP for less damage)
+	damage = 65
 	penetration = ARMOR_PENETRATION_TIER_8
 	accuracy = HIT_ACCURACY_TIER_MAX
 
 
-/datum/ammo/bullet/shrapnel/gau/whiplash
+/datum/ammo/bullet/shrapnel/gau/whiplash // For the outer ring of the 3x3
+/*
+	Please for the love of unga be careful if you decide to edit this.
+	The math on these adds up INSANELY quickly. there are going to be 320 of these per single burst of the GAU
+	or 6400 of these per full 4X GAU FM. So this shit adds up quick.
+*/
 	name = "30mm shell whiplash"
 
 	damage = 30
@@ -3052,7 +3057,7 @@
 	accuracy = HIT_ACCURACY_TIER_MAX
 	shrapnel_chance = 0
 
-/datum/ammo/bullet/shrapnel/gau/on_hit_mob(mob/M, obj/item/projectile/P)
+/datum/ammo/bullet/shrapnel/gau/on_hit_mob(mob/M, obj/item/projectile/P) // ATMOSPHERE GOOD.
 	M.apply_effect(8, DAZE)
 	if(isxeno(M))
 		to_chat(M, SPAN_XENOHIGHDANGER("You screech in horror as the 30mm shell rips through you!"))

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -3030,7 +3030,7 @@
 /datum/ammo/bullet/shrapnel/gau  //for the GAU to have a impact bullet instead of firecrackers
 	name = "30mm Multi-Purpose shell"
 
-	damage = 115 //More damaging, but 2x less shells and low AP
+	damage = 100 //More damaging, but 2x less shells and low AP
 	penetration = ARMOR_PENETRATION_TIER_2
 	accuracy = HIT_ACCURACY_TIER_MAX
 	max_range = 0
@@ -3039,7 +3039,7 @@
 /datum/ammo/bullet/shrapnel/gau/at
 	name = "30mm Anti-Tank shell"
 
-	damage = 80 //Standard AP vs standard. (more AP for less damage)
+	damage = 65 //Standard AP vs standard. (more AP for less damage)
 	penetration = ARMOR_PENETRATION_TIER_8
 	accuracy = HIT_ACCURACY_TIER_MAX
 
@@ -3047,29 +3047,23 @@
 /datum/ammo/bullet/shrapnel/gau/whiplash
 	name = "30mm shell whiplash"
 
-	damage = 40
+	damage = 30
 	penetration = ARMOR_PENETRATION_TIER_4
 	accuracy = HIT_ACCURACY_TIER_MAX
+	shrapnel_chance = 0
 
 /datum/ammo/bullet/shrapnel/gau/on_hit_mob(mob/M, obj/item/projectile/P)
-	M.apply_effect(2, SUPERSLOW)
-	M.apply_effect(4, SLOW)
 	M.apply_effect(8, DAZE)
 	if(isxeno(M))
 		to_chat(M, SPAN_XENOHIGHDANGER("You screech in horror as the 30mm shell rips through you!"))
 	else
 		to_chat(M, SPAN_HIGHDANGER("You scream in pain as the 30mm shell rips through you!"))
 /datum/ammo/bullet/shrapnel/gau/whiplash/on_hit_mob(mob/M, obj/item/projectile/P)
-	M.apply_effect(2, SLOW)
 	M.apply_effect(4, DAZE)
 	if(isxeno(M))
 		to_chat(M, SPAN_XENODANGER("You are shaken by the near miss 30mm impact!"))
 	else
 		to_chat(M, SPAN_DANGER("You are shaken by the near miss 30mm impact"))
-
-
-
-
 
 
 /*

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -3042,6 +3042,15 @@
 	damage = 80 //Standard AP vs standard. (more AP for less damage)
 	penetration = ARMOR_PENETRATION_TIER_8
 	accuracy = HIT_ACCURACY_TIER_MAX
+
+
+/datum/ammo/bullet/shrapnel/gau/whiplash
+	name = "30mm shell whiplash"
+
+	damage = 60
+	penetration = ARMOR_PENETRATION_TIER_5
+	accuracy = HIT_ACCURACY_TIER_MAX
+
 /*
 //======
 					Misc Ammo


### PR DESCRIPTION

# About the pull request
For too long the GAU has been the joke of the CAS weapons, due to it's RNG and somewhat mediocre damage numbers, people tend to either ignore or hell even laugh at a GAU strike, as seen here: https://cdn.discordapp.com/attachments/458150341742166017/1052649816179626035/GAU.mp4

The goal of this buff, is simple; punish players who think they stand in a hellstorm of 30mm bullets and get away with it. Or in a more technical sense, actually make the GAU do what it is designed to do, area denial and suppression, you shouldn't be able to walk through the center of an active GAU fire mission and live to tell the tale, regardless of caste, armor, or species. 

The changes made are simple: instead of hitting a single tile per bullet, a single bullet will now affect a 3x3 area, as seen in the testing footage below. 
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

For POs, it will make the GAU worth it's price tag, as nothing will be able to match it's short term area denial and area suppression ability.

This buff will also give the GAU the atmosphere of fear that the other CAS weapons bring, no longer will immersion be broken by people literally standing in 30mm hell rain. 
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>
https://youtu.be/ZBrymhLBUNY


</details>

# Changelog
:cl:Tisx

balance: Turned a single GAU impact from 1x1 to 3x3. 

/:cl:
