### PR TITLE
Fix inconsistent permissions requirements for STUI

### DIFF
--- a/code/modules/admin/STUI.dm
+++ b/code/modules/admin/STUI.dm
@@ -88,17 +88,16 @@ GLOBAL_DATUM_INIT(STUI, /datum/STUI, new)
 		if(attack.len > stui_length+1)
 			attack.Cut(,attack.len-stui_length)
 		.["logs"][STUI_TEXT_ATTACK] = attack
-		if(ooc.len > stui_length+1)
-			ooc.Cut(,ooc.len-stui_length)
-		.["logs"][STUI_TEXT_OOC] = ooc
-	if(user.client.admin_holder.rights & R_ADMIN)
 		if(admin.len > stui_length+1)
 			admin.Cut(,admin.len-stui_length)
 		.["logs"][STUI_TEXT_STAFF] = admin
 		if(staff.len > stui_length+1)
 			staff.Cut(,staff.len-stui_length)
 		.["logs"][STUI_TEXT_STAFF_CHAT] = staff
-	if((user.client.admin_holder.rights & R_ADMIN) || (user.client.admin_holder.rights & R_DEBUG))
+		if(ooc.len > stui_length+1)
+			ooc.Cut(,ooc.len-stui_length)
+		.["logs"][STUI_TEXT_OOC] = ooc
+	if((user.client.admin_holder.rights & R_MOD) || (user.client.admin_holder.rights & R_DEBUG))
 		if(game.len > stui_length+1)
 			game.Cut(,game.len-stui_length)
 		.["logs"][STUI_TEXT_GAME] = game


### PR DESCRIPTION

# About the pull request

This PR fixes inconsistent permissions requirements to view data in the STUI admin panel. Tabs should only appear now if there is sufficient permission to receive that log. Ultimately this will allow MOD permission to now view staff, staff chat, and game.

# Explain why it's good for the game

Fixes the panel blowing up like it does for me: 
![image](https://user-images.githubusercontent.com/76988376/235325259-178de90c-6f0f-46aa-a4bf-d3e2d707f835.png)

# Changelog
:cl: Drathek
admin: Fix permissions for MOD to receive staff, staff chat, and game logs in STUI.
/:cl:
