### PR TITLE
Fix Tracked Mark and Second Pounce Runtimes

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/lurker/lurker_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/lurker/lurker_abilities.dm
@@ -35,7 +35,7 @@
 		return
 
 	if (X.mutation_type == LURKER_NORMAL)
-		RegisterSignal(X, COMSIG_XENO_SLASH_ADDITIONAL_EFFECTS_SELF, PROC_REF(remove_freeze))
+		RegisterSignal(X, COMSIG_XENO_SLASH_ADDITIONAL_EFFECTS_SELF, PROC_REF(remove_freeze), TRUE) // Suppresses runtime ever we pounce again before slashing
 
 /datum/action/xeno_action/activable/pounce/lurker/proc/remove_freeze(mob/living/carbon/xenomorph/X)
 	SIGNAL_HANDLER

--- a/code/modules/mob/living/carbon/xenomorph/mark_menu.dm
+++ b/code/modules/mob/living/carbon/xenomorph/mark_menu.dm
@@ -86,7 +86,8 @@
 	.["tracked_mark"] = null
 	if(X.tracked_marker)
 		var/datum/weakref/weak_reference = WEAKREF(X.tracked_marker)
-		.["tracked_mark"] = weak_reference.reference
+		if(weak_reference) // WEAKREF also tested QDELETED
+			.["tracked_mark"] = weak_reference.reference
 
 /datum/mark_menu_ui/tgui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)


### PR DESCRIPTION
# About the pull request

This PR fixes a couple xeno runtimes: Deleting a mark that is tracked, and the re-registration of a slash effect signal for unfreezing a lurker after a pounce if she hasn't slashed between pounces.

# Explain why it's good for the game

Fixes #1895 
![image](https://user-images.githubusercontent.com/76988376/235343485-2d491926-cab0-4c8b-ae9b-963a5e3e6023.png)
and 
> runtime error: xeno_slash_additional_effects_self overridden. Use override = TRUE to suppress this warning
proc name: stack trace (/proc/stack_trace)
  source file: unsorted.dm,1799
  usr: Lurker (DR-729) (/mob/living/carbon/xenomorph/lurker)
  src: null
  usr.loc: the catwalk (91,137,4) (/turf/open/floor/plating/plating_catwalk)
  call stack:
stack trace("xeno_slash_additional_effects_...")
Pounce (/datum/action/xeno_action/activable/pounce/lurker): RegisterSignal(Lurker (DR-729) (/mob/living/carbon/xenomorph/lurker), "xeno_slash_additional_effects_...", /datum/action/xeno_action/acti... (/datum/action/xeno_action/activable/pounce/lurker/proc/remove_freeze), 0)
Pounce (/datum/action/xeno_action/activable/pounce/lurker): additional effects(Mu Yuko (/mob/living/carbon/human))

# Changelog
:cl: Drathek
fix: Fixes a runtime when deleting a mark that is tracked.
fix: Fixes a runtime when a lurker pounces again but hasn't used her unfreeze slash between pounces.
/:cl:
