### PR TITLE
Fix Distress Beacon Automatic Shuttle Handling

### DIFF
--- a/code/datums/emergency_calls/emergency_call.dm
+++ b/code/datums/emergency_calls/emergency_call.dm
@@ -33,7 +33,7 @@
 	var/max_engineers = 1
 	var/max_heavies = 1
 	var/max_smartgunners = 1
-	var/shuttle_id = "Distress" //Empty shuttle ID means we're not using shuttles (aka spawn straight into cryo)
+	var/shuttle_id = MOBILE_SHUTTLE_ID_ERT1 //Empty shuttle ID means we're not using shuttles (aka spawn straight into cryo)
 	var/auto_shuttle_launch = FALSE
 	var/spawn_max_amount = FALSE
 
@@ -257,7 +257,7 @@
 		var/obj/structure/machinery/computer/shuttle/ert/comp = shuttle.getControlConsole()
 		var/list/lzs = comp.get_landing_zones()
 		if(!length(lzs))
-			warning("Auto shuttle launch set for ert [name] but no lzs allowed.")
+			message_admins("Auto shuttle launch set for ert [name] but no lzs allowed.")
 			return
 
 		var/list/active_lzs = list()
@@ -267,9 +267,13 @@
 			if(!(dock.z in z_levels))
 				continue
 			// filter for free lzs
-			if(shuttle.canDock(dock) != DOCKING_SUCCESS)
+			if(shuttle.canDock(dock) != SHUTTLE_CAN_DOCK)
 				continue
 			active_lzs += list(dock)
+
+		if(!length(active_lzs))
+			message_admins("Auto shuttle launch set for ert [name] but no lzs available.")
+			return
 
 		SSshuttle.moveShuttleToDock(shuttle, pick(active_lzs), TRUE)
 


### PR DESCRIPTION
# About the pull request

This PR changes the default shuttle_id and fixes an error in the launch checks for distress beacons. Many distress signals such as the xeno erts do not override the value but need an automatic launch procedure. This also tweaks the logging sent to admins in case of an automatic launch failure.

# Explain why it's good for the game

Fixes #2283 

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![ert](https://user-images.githubusercontent.com/76988376/235391585-18648827-3e38-472d-a1d7-ea3de1f42ab7.gif)

</details>


# Changelog
:cl: Drathek
fix: Fixes automatic shuttle launching for distress signals that require it (Xeno & Zombie ERTs)
/:cl:
