### PR TITLE
Fix Evolve Ability when Resting

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/general_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/general_abilities.dm
@@ -461,5 +461,12 @@
 
 /datum/action/xeno_action/onclick/evolve/action_activate()
 	var/mob/living/carbon/xenomorph/xeno = owner
-
 	xeno.do_evolve()
+
+/datum/action/xeno_action/onclick/evolve/can_use_action()
+	if(!owner)
+		return FALSE
+	var/mob/living/carbon/xenomorph/xeno = owner
+	// Perform check_state(TRUE) silently:
+	if(xeno && !xeno.is_mob_incapacitated() || !xeno.buckled || !xeno.evolving && xeno.plasma_stored >= plasma_cost)
+		return TRUE


### PR DESCRIPTION
# About the pull request

This PR overrides the can_use_action for the Evolve ability so it can be used when resting.

# Explain why it's good for the game

Fixes #3195 

# Changelog
:cl: Drathek
fix: Fix evolve button not working when resting
/:cl:
