### PR TITLE
Fixes Mob Emote Runtimes

### DIFF
--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -55,7 +55,7 @@
 	keybind = FALSE
 
 /datum/emote/custom/run_emote(mob/user, params, type_override, intentional = FALSE, prefix)
-	if(user.client.prefs.muted & MUTE_IC)
+	if(user.client && user.client.prefs.muted & MUTE_IC)
 		to_chat(user, SPAN_DANGER("You cannot emote (muted)."))
 		return
 	message = params


### PR DESCRIPTION
# About the pull request

This PR fixes the runtime thrown whenever a non-player mob (specifically any mob without a client) because of a new mute setting check from #2873 

# Explain why it's good for the game

Fixes 
![image](https://user-images.githubusercontent.com/76988376/235402325-d393022e-890f-472e-b533-ae07c224e766.png)


# Testing Photographs and Procedure
<details>
<summary>Reproduction</summary>

1. Spawn a human
2. Spawn a monkey cube
3. Unwrap and feed to the human (they will immediately gasp for air as a monkey tries to grow inside their chest)

</details>


# Changelog
:cl: Drathek
fix: Fix runtimes cause by non-player mobs emoting
/:cl:
