### PR TITLE
fixes a bug with yautja roaring

### DIFF
--- a/code/modules/mob/living/carbon/human/species/emote-yautja.dm
+++ b/code/modules/mob/living/carbon/human/species/emote-yautja.dm
@@ -99,7 +99,8 @@
 
 	for(var/mob/current_mob as anything in get_mobs_in_z_level_range(get_turf(user), 18) - user)
 		var/relative_dir = get_dir(current_mob, user)
-		to_chat(current_mob, SPAN_HIGHDANGER("You hear a loud roar coming from the [dir2text(relative_dir)]!"))
+		var/final_dir = dir2text(relative_dir)
+		to_chat(current_mob, SPAN_HIGHDANGER("You hear a loud roar coming from [final_dir ? "the [final_dir]" : "nearby"]!"))
 
 /datum/emote/living/carbon/human/yautja/turnaround
 	key = "turnaround"


### PR DESCRIPTION

# About the pull request
okay so sometimes in some specific circumstances if you're near a yautja when they *loudroar it displays it as You hear a loud roar coming from the !
this fixes that
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
funny bug
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: fixed yautja loudroars displaying nothing
/:cl:
