### PR TITLE
Point blanks with bonus projectile ammo types are no longer forced to aim at chest

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -1402,6 +1402,7 @@ and you're good to go.
 							SPAN_AVOIDHARM("[BP] narrowly misses you!"), null, 4, CHAT_TYPE_TAKING_HIT)
 				else
 					BP.ammo.on_hit_mob(attacked_mob, BP, user)
+					BP.def_zone = user.zone_selected // On pointblanks this means that the targetted limb will always hit similar to burst fire point blanks
 					attacked_mob.bullet_act(BP)
 				qdel(BP)
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -1402,7 +1402,7 @@ and you're good to go.
 							SPAN_AVOIDHARM("[BP] narrowly misses you!"), null, 4, CHAT_TYPE_TAKING_HIT)
 				else
 					BP.ammo.on_hit_mob(attacked_mob, BP, user)
-					BP.def_zone = user.zone_selected // On pointblanks this means that the targetted limb will always hit similar to burst fire point blanks
+					BP.def_zone = user.zone_selected
 					attacked_mob.bullet_act(BP)
 				qdel(BP)
 


### PR DESCRIPTION


# About the pull request

When point blanking with an ammo type such as buckshot or flechete, on human mobs the main projectile (for example buckshot) will always hit the targeted limb and all other additional spawn ammo will be forced to aim chest. This does not happen with point blank burst firing, but for some reason applies to single fire, bonus projectile ammos. What this PR does is allows for bonus projectiles to hit targeted limbs on point blanks.

# Explain why it's good for the game

Consistency for weapons such as the shotgun where point blanks count. On human mobs point blanks are rare but by this phenomenon where your limb targeted is not taken completely accounted for simply does not make any sense. Point blanks mean you are right next to a mob, if the main shell is hitting the exact targeted limb it really makes no sense that subsequent projectiles will not. However i will say that this will affect predator versus human combat, as limb targeting does not matter when it comes to xenos.

To elaborate on that, without the changes introduced by this PR, a one on one duel between a predator and a marine using only shotguns would see that the shotgun would need 8-13 point blanks in order to crit the predator. This is because (as stated) only the first, main shell will hit and all subsequent shells will be forcibly aimed at chest. Predators have extremely high armor values on chest, and as such shotgun is rarely ever used against predators.

With this PR introduced, it would reduce the amount of pbs down towards 4-6 PBs (depending on zone selected). I don't believe this will majorly affect how combat interactions aside from shotguns hitting harder than what is used to, and in comparison to other marine weapons still worse than its ranged counter parts. Arguably, risking yourself in CQC against a predator is far more difficult than simply using ranged weaponry (which has both more DPS, and safety).

I ask that this PR be testmerged to see if it seriously affects predator engagements and if its far too severe, deny this. But as it stands it just doesn't make sense why additional projectiles magically teleport away from a leg pointblank to chest.

# Testing Photographs and Procedure
tested in private server

# Changelog

:cl:
fix: Point blanks with ammo types that spawn additional projectiles will now hit targeted limbs instead of only chest
/:cl:

