### PR TITLE
new brig remap stuff

### DIFF
--- a/code/game/machinery/doors/brig_system.dm
+++ b/code/game/machinery/doors/brig_system.dm
@@ -390,6 +390,14 @@
 	name = "Cell 4"
 	id = "Cell 4"
 
+/obj/structure/machinery/brig_cell/cell_5
+	name = "Cell 5"
+	id = "Cell 5"
+
+/obj/structure/machinery/brig_cell/cell_6
+	name = "Cell 6"
+	id = "Cell 6"
+
 /obj/structure/machinery/brig_cell/perma_1
 	name = "Perma 1"
 	id = "Perma 1"

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -6969,12 +6969,9 @@
 	},
 /area/almayer/lifeboat_pumps/north1)
 "avz" = (
-/obj/structure/machinery/light,
-/obj/structure/machinery/vending/security,
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/shipboard/brig/general_equipment)
+/obj/structure/pipes/standard/simple/hidden/supply,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/brig/cryo)
 "avA" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -9563,29 +9560,14 @@
 	},
 /area/almayer/living/offices/flight)
 "aEk" = (
-/obj/structure/surface/table/almayer,
-/obj/structure/machinery/computer/secure_data{
-	dir = 4;
-	pixel_y = 17
-	},
-/obj/structure/machinery/computer/cameras/almayer_network{
-	dir = 4
-	},
-/obj/structure/machinery/computer/card{
-	dir = 4;
-	pixel_y = -16
-	},
-/obj/structure/machinery/light{
-	dir = 8
-	},
-/obj/structure/sign/safety/terminal{
-	pixel_x = -17;
-	pixel_y = 7
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_x = -30
 	},
 /turf/open/floor/almayer{
-	icon_state = "plate"
+	dir = 8;
+	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/main_office)
+/area/almayer/shipboard/brig/perma)
 "aEm" = (
 /obj/structure/surface/table/almayer,
 /turf/open/floor/almayer{
@@ -10760,11 +10742,8 @@
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
 	},
-/turf/open/floor/almayer{
-	dir = 4;
-	icon_state = "redcorner"
-	},
-/area/almayer/shipboard/brig/main_office)
+/turf/open/floor/almayer,
+/area/almayer/shipboard/brig/perma)
 "aJG" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 8;
@@ -12704,13 +12683,13 @@
 /turf/open/floor/wood/ship,
 /area/almayer/command/corporateliason)
 "aSS" = (
-/obj/structure/sink{
-	pixel_y = 24
+/obj/effect/decal/warning_stripes{
+	icon_state = "W";
+	layer = 2.5
 	},
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/shipboard/brig/perma)
+/obj/effect/landmark/start/warrant,
+/turf/open/floor/almayer,
+/area/almayer/shipboard/brig/cryo)
 "aSY" = (
 /obj/structure/machinery/light/small{
 	dir = 4
@@ -15837,12 +15816,16 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/aft_hallway)
 "bja" = (
-/obj/structure/surface/table/almayer,
-/obj/structure/machinery/computer/secure_data{
-	dir = 1
+/obj/structure/bed,
+/obj/structure/machinery/flasher{
+	id = "Cell 3";
+	pixel_x = -24
 	},
-/turf/open/floor/almayer,
-/area/almayer/shipboard/brig/main_office)
+/turf/open/floor/almayer{
+	dir = 8;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/cells)
 "bjb" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/plating_catwalk,
@@ -18083,12 +18066,18 @@
 	},
 /area/almayer/engineering/engine_core)
 "buX" = (
-/obj/effect/landmark/crap_item,
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "red"
+/obj/structure/surface/table/almayer,
+/obj/item/storage/box/flashbangs,
+/obj/item/storage/box/flashbangs{
+	pixel_x = 5;
+	pixel_y = 9
 	},
-/area/almayer/shipboard/brig/main_office)
+/obj/item/storage/box/flashbangs{
+	pixel_x = -8;
+	pixel_y = 5
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/brig/armory)
 "bvb" = (
 /obj/structure/machinery/light{
 	dir = 8
@@ -18146,11 +18135,14 @@
 	},
 /area/almayer/living/briefing)
 "bvx" = (
-/turf/open/floor/almayer{
-	dir = 10;
-	icon_state = "red"
+/obj/structure/window/framed/almayer,
+/obj/structure/machinery/door/poddoor/almayer/locked{
+	dir = 2;
+	id = "Perma 1L";
+	name = "\improper cell shutter"
 	},
-/area/almayer/shipboard/brig/main_office)
+/turf/open/floor/plating,
+/area/almayer/shipboard/brig/perma)
 "bvz" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/structure/closet/secure_closet/surgical{
@@ -19114,18 +19106,6 @@
 	icon_state = "red"
 	},
 /area/almayer/shipboard/weapon_room)
-"bAM" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 26
-	},
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/general_equipment)
 "bAN" = (
 /obj/structure/machinery/light{
 	dir = 1
@@ -22193,9 +22173,19 @@
 	},
 /area/almayer/squads/delta)
 "bND" = (
-/obj/structure/bed/chair,
-/turf/open/floor/almayer,
-/area/almayer/shipboard/brig/perma)
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/structure/machinery/light/small,
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/turf/open/floor/almayer{
+	icon_state = "dark_sterile"
+	},
+/area/almayer/shipboard/brig/chief_mp_office)
 "bNE" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 26
@@ -23137,8 +23127,14 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_f_p)
 "bRH" = (
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/shipboard/brig/cryo)
+/obj/structure/surface/rack,
+/obj/item/stack/sheet/glass/reinforced{
+	amount = 50
+	},
+/turf/open/floor/almayer{
+	icon_state = "orange"
+	},
+/area/almayer/shipboard/brig/main_office)
 "bRK" = (
 /obj/structure/machinery/light/small{
 	dir = 1
@@ -23474,11 +23470,17 @@
 	},
 /area/almayer/medical/lower_medical_medbay)
 "bTw" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 6
+/obj/structure/machinery/light{
+	dir = 1
 	},
-/turf/open/floor/almayer,
-/area/almayer/shipboard/brig/main_office)
+/obj/structure/machinery/flasher{
+	id = "Perma 2";
+	pixel_y = 24
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/shipboard/brig/perma)
 "bTx" = (
 /turf/open/floor/wood/ship,
 /area/almayer/shipboard/sea_office)
@@ -24005,18 +24007,16 @@
 	},
 /area/almayer/command/corporateliason)
 "bVC" = (
+/obj/structure/window/framed/almayer,
 /obj/structure/machinery/door/poddoor/shutters/almayer{
 	dir = 8;
-	id = "cmp_armory";
+	id = "bot_armory";
 	name = "\improper Armory Shutters"
 	},
-/obj/structure/machinery/door/firedoor/border_only/almayer,
-/obj/structure/machinery/door/airlock/almayer/security/glass/reinforced{
-	name = "\improper Armory"
+/obj/structure/machinery/door/firedoor/border_only/almayer{
+	dir = 8
 	},
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
+/turf/open/floor/plating,
 /area/almayer/shipboard/brig/armory)
 "bVE" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/medidoor{
@@ -24904,13 +24904,9 @@
 /turf/open/floor/almayer,
 /area/almayer/hallways/vehiclehangar)
 "bZN" = (
-/obj/structure/machinery/door/airlock/almayer/generic{
-	name = "Bathroom"
-	},
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/shipboard/brig/chief_mp_office)
+/obj/structure/pipes/standard/manifold/hidden/supply,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/brig/perma)
 "bZO" = (
 /obj/structure/machinery/light{
 	dir = 8
@@ -25775,10 +25771,7 @@
 /obj/structure/pipes/standard/manifold/hidden/supply{
 	dir = 1
 	},
-/turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "redcorner"
-	},
+/turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/main_office)
 "cdm" = (
 /obj/effect/landmark/ert_spawns/distress_cryo,
@@ -26586,15 +26579,15 @@
 	},
 /area/almayer/lifeboat_pumps/north2)
 "ciF" = (
-/obj/structure/sign/safety/cryo{
-	pixel_x = 8;
-	pixel_y = -26
+/obj/structure/surface/table/almayer,
+/obj/structure/machinery/computer/secure_data{
+	dir = 4
 	},
 /turf/open/floor/almayer{
-	dir = 6;
+	dir = 8;
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/main_office)
+/area/almayer/shipboard/brig/chief_mp_office)
 "ciN" = (
 /turf/open/floor/almayer{
 	dir = 6;
@@ -27747,8 +27740,7 @@
 "cos" = (
 /obj/structure/machinery/light/small,
 /obj/effect/decal/warning_stripes{
-	icon_state = "N";
-	pixel_y = 1
+	icon_state = "N"
 	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
@@ -27862,17 +27854,12 @@
 	},
 /area/almayer/hallways/starboard_hallway)
 "cqn" = (
-/obj/structure/window/framed/almayer,
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 1
+/obj/structure/surface/table/almayer,
+/obj/structure/machinery/recharger,
+/turf/open/floor/almayer{
+	icon_state = "plate"
 	},
-/obj/structure/machinery/door/poddoor/shutters/almayer{
-	dir = 2;
-	id = "bot_armory";
-	name = "\improper Armory Shutters"
-	},
-/turf/open/floor/plating,
-/area/almayer/shipboard/brig/armory)
+/area/almayer/shipboard/brig/general_equipment)
 "cqz" = (
 /obj/structure/surface/table/almayer,
 /obj/item/facepaint/black,
@@ -28021,7 +28008,7 @@
 /area/almayer/command/computerlab)
 "ctn" = (
 /turf/open/floor/almayer{
-	icon_state = "redcorner"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/brig/lobby)
 "cts" = (
@@ -28067,16 +28054,9 @@
 	},
 /area/almayer/hallways/stern_hallway)
 "cuk" = (
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 2
-	},
-/obj/structure/machinery/door/airlock/multi_tile/almayer/secdoor/glass/reinforced{
-	name = "\improper Cryogenics Bay"
-	},
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/shipboard/brig/cryo)
+/obj/structure/machinery/cm_vending/clothing/military_police_warden,
+/turf/open/floor/wood/ship,
+/area/almayer/shipboard/brig/chief_mp_office)
 "cus" = (
 /obj/docking_port/stationary/lifeboat_dock/starboard,
 /turf/open/floor/almayer_hull{
@@ -28230,11 +28210,13 @@
 /turf/closed/wall/almayer/outer,
 /area/almayer/hull/upper_hull/u_m_p)
 "czB" = (
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/almayer{
-	icon_state = "redcorner"
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
 	},
-/area/almayer/shipboard/brig/execution)
+/turf/open/floor/almayer{
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/chief_mp_office)
 "czJ" = (
 /obj/structure/sign/safety/restrictedarea{
 	pixel_x = 8;
@@ -28561,11 +28543,17 @@
 /area/almayer/hull/upper_hull/u_a_p)
 "cFO" = (
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "redcorner"
+/obj/structure/pipes/standard/simple/hidden/supply,
+/obj/structure/bed,
+/obj/structure/machinery/flasher{
+	id = "Cell 6";
+	pixel_x = -24
 	},
-/area/almayer/shipboard/brig/main_office)
+/turf/open/floor/almayer{
+	dir = 8;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/cells)
 "cFP" = (
 /obj/structure/sign/safety/outpatient{
 	pixel_x = -17;
@@ -28579,6 +28567,11 @@
 /obj/effect/decal/warning_stripes{
 	icon_state = "SE-out"
 	},
+/obj/structure/machinery/camera/autoname/almayer{
+	dir = 4;
+	name = "ship-grade camera"
+	},
+/obj/structure/closet/emcloset,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/upper_hull/u_f_p)
 "cFZ" = (
@@ -28687,13 +28680,14 @@
 	},
 /area/almayer/hull/lower_hull/l_a_p)
 "cIK" = (
-/obj/structure/janitorialcart,
-/obj/item/tool/mop,
-/obj/structure/machinery/light/small,
-/turf/open/floor/almayer{
-	icon_state = "redcorner"
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 26
 	},
-/area/almayer/shipboard/brig/execution)
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/main_office)
 "cIU" = (
 /obj/structure/sign/safety/hvac_old{
 	pixel_x = 8;
@@ -28890,10 +28884,12 @@
 /turf/open/floor/almayer,
 /area/almayer/living/grunt_rnr)
 "cNY" = (
-/obj/structure/machinery/computer/crew,
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/machinery/door/firedoor/border_only/almayer,
 /turf/open/floor/almayer{
-	dir = 9;
-	icon_state = "red"
+	icon_state = "test_floor4"
 	},
 /area/almayer/shipboard/brig/main_office)
 "cOi" = (
@@ -29229,24 +29225,14 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/upper_hull/u_a_s)
 "cWN" = (
-/obj/structure/filingcabinet{
-	density = 0;
-	pixel_x = -8;
-	pixel_y = 18
+/obj/structure/window/reinforced/ultra{
+	pixel_y = -12
 	},
-/obj/structure/machinery/light{
-	dir = 8
-	},
-/obj/structure/filingcabinet/security{
-	density = 0;
-	pixel_x = 8;
-	pixel_y = 18
-	},
+/obj/structure/bed/chair/bolted,
 /turf/open/floor/almayer{
-	dir = 9;
-	icon_state = "red"
+	icon_state = "plating_striped"
 	},
-/area/almayer/shipboard/brig/chief_mp_office)
+/area/almayer/shipboard/brig/execution)
 "cXi" = (
 /obj/structure/machinery/light{
 	unacidable = 1;
@@ -29334,7 +29320,7 @@
 /area/almayer/hallways/aft_hallway)
 "cZs" = (
 /turf/closed/wall/almayer/outer,
-/area/almayer/shipboard/brig/chief_mp_office)
+/area/almayer/shipboard/brig/perma)
 "cZJ" = (
 /obj/structure/machinery/door/airlock/almayer/maint{
 	name = "\improper Core Hatch"
@@ -29477,12 +29463,19 @@
 /turf/open/floor/almayer,
 /area/almayer/living/briefing)
 "dci" = (
-/obj/structure/pipes/standard/simple/hidden/supply,
-/turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "redcorner"
+/obj/structure/machinery/door/poddoor/almayer/locked{
+	dir = 2;
+	id = "Perma 1L";
+	name = "\improper cell shutter"
 	},
-/area/almayer/shipboard/brig/main_office)
+/obj/structure/machinery/door/airlock/almayer/security/glass/reinforced{
+	name = "\improper Isolation Cell";
+	dir = 2
+	},
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/shipboard/brig/perma)
 "dck" = (
 /obj/structure/bed/stool,
 /turf/open/floor/almayer{
@@ -29555,15 +29548,18 @@
 	},
 /area/almayer/engineering/engine_core)
 "deb" = (
-/obj/structure/bed,
-/obj/structure/machinery/flasher{
-	id = "Perma 2";
-	pixel_y = -24
+/obj/structure/machinery/cryopod,
+/obj/structure/machinery/light{
+	dir = 8;
+	invisibility = 101
+	},
+/obj/structure/machinery/status_display{
+	pixel_x = -32
 	},
 /turf/open/floor/almayer{
-	icon_state = "plate"
+	icon_state = "cargo"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/cryo)
 "deg" = (
 /obj/structure/platform_decoration{
 	dir = 1
@@ -29613,11 +29609,17 @@
 	},
 /area/almayer/shipboard/brig/cells)
 "dfp" = (
-/obj/structure/machinery/keycard_auth{
-	pixel_y = 25
+/obj/structure/window/reinforced/ultra{
+	pixel_y = -12
 	},
-/turf/open/floor/almayer,
-/area/almayer/shipboard/brig/chief_mp_office)
+/obj/structure/machinery/light{
+	dir = 1
+	},
+/obj/structure/bed/chair/bolted,
+/turf/open/floor/almayer{
+	icon_state = "plating_striped"
+	},
+/area/almayer/shipboard/brig/execution)
 "dfC" = (
 /obj/structure/machinery/light,
 /turf/open/floor/almayer{
@@ -29757,15 +29759,13 @@
 	},
 /area/almayer/hull/upper_hull/u_a_p)
 "djm" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "E";
-	pixel_x = 1
+/obj/structure/toilet{
+	dir = 8
 	},
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
+/turf/open/floor/almayer{
+	icon_state = "plate"
 	},
-/turf/open/floor/almayer,
-/area/almayer/shipboard/brig/execution)
+/area/almayer/shipboard/brig/perma)
 "djp" = (
 /obj/structure/closet/crate,
 /obj/item/stack/sheet/mineral/plastic{
@@ -30167,27 +30167,14 @@
 	},
 /area/almayer/hallways/aft_hallway)
 "dqV" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/machinery/vending/coffee,
 /obj/structure/machinery/light{
 	dir = 1
-	},
-/obj/structure/machinery/door_control{
-	id = "perma_lockdown";
-	name = "\improper Perma Cells Lockdown";
-	pixel_y = 24;
-	req_access_txt = "3"
-	},
-/obj/structure/sign/safety/coffee{
-	pixel_y = 32
 	},
 /turf/open/floor/almayer{
 	dir = 1;
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/processing)
 "drj" = (
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -30249,14 +30236,13 @@
 	},
 /area/almayer/hull/upper_hull/u_a_p)
 "dsw" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "E";
-	pixel_x = 2
-	},
+/obj/structure/machinery/power/apc/almayer,
+/obj/structure/surface/rack,
+/obj/effect/spawner/random/toolbox,
 /turf/open/floor/almayer{
-	icon_state = "plate"
+	icon_state = "orange"
 	},
-/area/almayer/shipboard/brig/cryo)
+/area/almayer/shipboard/brig/main_office)
 "dtH" = (
 /obj/structure/bed/chair/comfy{
 	dir = 8
@@ -30408,8 +30394,12 @@
 /turf/open/floor/almayer,
 /area/almayer/engineering/engineering_workshop/hangar)
 "dvT" = (
-/turf/closed/wall/almayer,
-/area/almayer/shipboard/brig/general_equipment)
+/obj/structure/machinery/door/firedoor/border_only/almayer{
+	dir = 2
+	},
+/obj/structure/window/framed/almayer,
+/turf/open/floor/plating,
+/area/almayer/shipboard/brig/cryo)
 "dwl" = (
 /obj/structure/machinery/light,
 /turf/open/floor/almayer,
@@ -30439,13 +30429,6 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/engineering/upper_engineering/starboard)
-"dxm" = (
-/obj/structure/window/framed/almayer,
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 2
-	},
-/turf/open/floor/plating,
-/area/almayer/shipboard/brig/general_equipment)
 "dxu" = (
 /obj/structure/sink{
 	dir = 1;
@@ -30770,6 +30753,9 @@
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
 	},
+/obj/structure/machinery/light/small{
+	dir = 1
+	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -30847,8 +30833,17 @@
 /obj/structure/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/shipboard/brig/cryo)
+/obj/structure/machinery/power/apc/almayer{
+	dir = 1
+	},
+/obj/structure/surface/rack,
+/obj/effect/spawner/random/powercell,
+/obj/effect/spawner/random/powercell,
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "orange"
+	},
+/area/almayer/shipboard/brig/execution)
 "dFF" = (
 /obj/structure/flora/pottedplant{
 	icon_state = "pottedplant_21"
@@ -30985,19 +30980,12 @@
 /turf/open/floor/wood/ship,
 /area/almayer/living/basketball)
 "dHv" = (
-/obj/structure/surface/table/reinforced/prison,
-/obj/item/storage/firstaid/toxin{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/firstaid/adv,
-/obj/item/device/defibrillator,
-/obj/item/reagent_container/spray/cleaner,
+/obj/structure/janitorialcart,
+/obj/item/tool/mop,
 /turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "sterile_green_side"
+	icon_state = "plate"
 	},
-/area/almayer/shipboard/brig/surgery)
+/area/almayer/shipboard/brig/execution)
 "dHZ" = (
 /obj/structure/window/framed/almayer,
 /obj/structure/machinery/door/poddoor/almayer/open{
@@ -31181,9 +31169,12 @@
 	},
 /area/almayer/living/captain_mess)
 "dOL" = (
-/obj/structure/bed/chair/comfy/black,
+/obj/effect/decal/warning_stripes{
+	icon_state = "SW-out";
+	layer = 2.5
+	},
 /turf/open/floor/almayer,
-/area/almayer/shipboard/brig/chief_mp_office)
+/area/almayer/shipboard/brig/execution)
 "dPU" = (
 /obj/structure/sign/safety/nonpress_ag{
 	pixel_x = 32
@@ -31269,13 +31260,13 @@
 /turf/open/floor/almayer,
 /area/almayer/hull/upper_hull/u_f_s)
 "dSc" = (
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 1
+/obj/effect/decal/warning_stripes{
+	icon_state = "W";
+	layer = 2.5
 	},
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/shipboard/brig/main_office)
+/obj/effect/landmark/start/warden,
+/turf/open/floor/almayer,
+/area/almayer/shipboard/brig/cryo)
 "dSn" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer{
@@ -31433,22 +31424,15 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/squads/req)
 "dWk" = (
-/obj/structure/surface/table/almayer,
-/obj/structure/machinery/door_control{
-	id = "CMP Office Shutters";
-	name = "CMP Office Shutters";
-	pixel_y = 32;
-	req_one_access_txt = "24;31"
+/obj/structure/window/reinforced/ultra{
+	pixel_y = -12
 	},
-/obj/structure/machinery/door_control{
-	id = "Brig Lockdown Shutters";
-	name = "Brig Lockdown Shutters";
-	pixel_y = 24;
-	req_access_txt = "3"
+/obj/structure/bed/chair/bolted,
+/turf/open/floor/almayer{
+	dir = 5;
+	icon_state = "plating"
 	},
-/obj/structure/machinery/faxmachine/uscm/brig/chief,
-/turf/open/floor/almayer,
-/area/almayer/shipboard/brig/chief_mp_office)
+/area/almayer/shipboard/brig/execution)
 "dWm" = (
 /obj/structure/surface/table/almayer,
 /obj/item/storage/firstaid/o2,
@@ -31517,7 +31501,7 @@
 "dXy" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer,
-/area/almayer/shipboard/brig/main_office)
+/area/almayer/shipboard/brig/perma)
 "dXG" = (
 /obj/structure/pipes/vents/scrubber{
 	dir = 1
@@ -31881,43 +31865,14 @@
 /turf/open/floor/almayer,
 /area/almayer/living/port_emb)
 "efh" = (
-/obj/structure/surface/table/almayer,
-/obj/structure/machinery/door_control{
-	id = "courtyard_cells";
-	name = "\improper Courtyard Lockdown Shutters";
-	pixel_x = -8;
-	pixel_y = -6;
-	req_access_txt = "3"
+/obj/structure/window/framed/almayer,
+/obj/structure/machinery/door/poddoor/shutters/almayer/open{
+	dir = 8;
+	id = "Warden Office Shutters";
+	name = "\improper Privacy Shutters"
 	},
-/obj/structure/machinery/door_control{
-	id = "Brig Lockdown Shutters";
-	name = "Brig Lockdown Shutters";
-	pixel_x = -8;
-	pixel_y = 2;
-	req_access_txt = "3"
-	},
-/obj/structure/machinery/door_control{
-	id = "courtyard window";
-	name = "Courtyard Window Shutters";
-	pixel_x = -8;
-	pixel_y = 10;
-	req_access_txt = "3"
-	},
-/obj/structure/machinery/door_control{
-	id = "Cell Privacy Shutters";
-	name = "Cell Privacy Shutters";
-	pixel_x = 2;
-	pixel_y = 10;
-	req_access_txt = "3"
-	},
-/obj/structure/machinery/recharger{
-	pixel_x = 6;
-	pixel_y = -2
-	},
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/shipboard/brig/main_office)
+/turf/open/floor/plating,
+/area/almayer/shipboard/brig/cells)
 "efK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -31983,15 +31938,12 @@
 	},
 /area/almayer/hull/upper_hull/u_a_s)
 "egR" = (
-/obj/structure/bed/chair{
-	dir = 8;
-	pixel_y = 3
+/obj/structure/machinery/light{
+	unacidable = 1;
+	unslashable = 1
 	},
-/turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/main_office)
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/brig/chief_mp_office)
 "egS" = (
 /obj/structure/closet,
 /obj/item/clothing/ears/earmuffs,
@@ -32123,12 +32075,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/living/port_emb)
-"eiO" = (
-/turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "redcorner"
-	},
-/area/almayer/shipboard/brig/main_office)
 "eiP" = (
 /obj/structure/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
@@ -32190,9 +32136,9 @@
 "ekg" = (
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "red"
+	icon_state = "redcorner"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/chief_mp_office)
 "eko" = (
 /obj/structure/largecrate/random/secure,
 /turf/open/floor/plating/plating_catwalk,
@@ -32254,7 +32200,7 @@
 	dir = 4;
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/processing)
 "elA" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer{
@@ -32374,18 +32320,13 @@
 	},
 /area/almayer/hull/lower_hull/l_m_s)
 "eni" = (
-/obj/structure/surface/table/almayer,
-/obj/item/book{
-	desc = "An autobiography focusing on the events of 'Fury 161' in August 2179 following the arrival of 'Ellen Ripley' and an unknown alien creature known as 'The Dragon' the books writing is extremely crude and was book banned shorty after publication.";
-	icon_state = "bookSpaceLaw";
-	name = "\improper Space Beast, by Robert Morse";
-	pixel_y = 3
+/obj/structure/machinery/sleep_console{
+	dir = 8
 	},
 /turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "red"
+	icon_state = "dark_sterile"
 	},
-/area/almayer/shipboard/brig/evidence_storage)
+/area/almayer/shipboard/brig/surgery)
 "enx" = (
 /obj/structure/pipes/vents/pump,
 /turf/open/floor/almayer{
@@ -32394,17 +32335,22 @@
 	},
 /area/almayer/hallways/starboard_hallway)
 "enz" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/machinery/door/poddoor/shutters/almayer{
+	dir = 2;
+	id = "bot_armory";
+	name = "\improper Armory Shutters"
 	},
-/obj/structure/machinery/vending/snack,
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
+/obj/structure/machinery/door/firedoor/border_only/almayer{
+	dir = 2
+	},
+/obj/structure/machinery/door/airlock/almayer/security/glass/reinforced{
+	name = "\improper Armory";
+	dir = 2
 	},
 /turf/open/floor/almayer{
-	icon_state = "red"
+	icon_state = "test_floor4"
 	},
-/area/almayer/shipboard/brig/main_office)
+/area/almayer/shipboard/brig/armory)
 "eoz" = (
 /turf/open/floor/almayer{
 	dir = 4;
@@ -32419,14 +32365,8 @@
 /turf/open/floor/almayer,
 /area/almayer/engineering/upper_engineering/port)
 "eoP" = (
-/obj/structure/bed,
-/obj/structure/machinery/flasher{
-	id = "Perma 1";
-	pixel_y = 24
-	},
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
+/obj/structure/pipes/standard/simple/hidden/supply,
+/turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/perma)
 "eoT" = (
 /obj/effect/decal/warning_stripes{
@@ -32572,19 +32512,6 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/squads/delta)
-"erx" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "E";
-	pixel_x = 2
-	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "N";
-	pixel_y = 1
-	},
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/shipboard/brig/cryo)
 "erG" = (
 /obj/structure/disposalpipe/junction{
 	dir = 2;
@@ -32724,17 +32651,12 @@
 	},
 /area/almayer/medical/testlab)
 "euO" = (
-/obj/structure/window/framed/almayer,
-/obj/structure/machinery/door/poddoor/shutters/almayer/open{
-	dir = 2;
-	id = "Warden Office Shutters";
-	name = "\improper Privacy Shutters"
+/obj/structure/machinery/brig_cell/cell_3{
+	pixel_x = 32;
+	pixel_y = -32
 	},
-/turf/open/floor/almayer{
-	dir = 5;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/main_office)
+/turf/open/floor/almayer,
+/area/almayer/shipboard/brig/processing)
 "euV" = (
 /turf/open/floor/almayer/uscm/directional{
 	dir = 8;
@@ -32824,9 +32746,6 @@
 	},
 /area/almayer/hull/lower_hull/l_f_s)
 "exr" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 5
-	},
 /obj/structure/machinery/light{
 	unacidable = 1;
 	unslashable = 1
@@ -32867,13 +32786,16 @@
 	},
 /area/almayer/hull/upper_hull/u_f_p)
 "eyg" = (
-/obj/structure/machinery/cryopod/right{
-	pixel_y = 6
+/obj/structure/machinery/power/apc/almayer{
+	dir = 1
 	},
+/obj/structure/surface/rack,
+/obj/item/book/manual/marine_law,
 /turf/open/floor/almayer{
-	icon_state = "cargo"
+	dir = 5;
+	icon_state = "orange"
 	},
-/area/almayer/shipboard/brig/cryo)
+/area/almayer/shipboard/brig/lobby)
 "eyG" = (
 /obj/structure/platform,
 /turf/open/floor/almayer{
@@ -33043,15 +32965,9 @@
 	},
 /area/almayer/squads/charlie_delta_shared)
 "eBW" = (
-/obj/structure/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/evidence_storage)
+/obj/structure/largecrate/random/barrel/blue,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/upper_hull/u_f_p)
 "eBZ" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/storage/firstaid/fire{
@@ -33532,9 +33448,9 @@
 "eOh" = (
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "redcorner"
+	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/evidence_storage)
+/area/almayer/shipboard/brig/perma)
 "eOk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -33557,14 +33473,15 @@
 	},
 /area/almayer/hull/lower_hull/l_f_p)
 "eOR" = (
-/obj/structure/machinery/light{
-	dir = 4
+/obj/structure/surface/table/almayer,
+/obj/structure/machinery/computer/cameras/almayer_network{
+	dir = 8
 	},
 /turf/open/floor/almayer{
 	dir = 4;
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/main_office)
+/area/almayer/shipboard/brig/perma)
 "eOW" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/computer/sentencing,
@@ -33591,11 +33508,14 @@
 	},
 /area/almayer/hallways/starboard_hallway)
 "ePB" = (
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "redcorner"
+/obj/structure/machinery/brig_cell/cell_2{
+	pixel_x = 32;
+	pixel_y = -32
 	},
-/area/almayer/shipboard/brig/general_equipment)
+/turf/open/floor/almayer{
+	allow_construction = 0
+	},
+/area/almayer/shipboard/brig/processing)
 "ePY" = (
 /obj/structure/pipes/vents/pump{
 	dir = 8;
@@ -33730,15 +33650,11 @@
 /turf/open/floor/almayer,
 /area/almayer/living/briefing)
 "eTo" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
 	},
-/obj/structure/sign/safety/bathunisex{
-	pixel_x = 8;
-	pixel_y = 25
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 5
 	},
 /turf/open/floor/almayer,
 /area/almayer/shipboard/brig/cells)
@@ -34013,12 +33929,15 @@
 	},
 /area/almayer/hallways/port_hallway)
 "eZj" = (
-/obj/structure/closet/secure_closet/guncabinet,
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "red"
+/obj/structure/machinery/light{
+	dir = 1
 	},
-/area/almayer/shipboard/brig/main_office)
+/obj/structure/sign/safety/cryo{
+	pixel_x = 7;
+	pixel_y = 25
+	},
+/turf/open/floor/almayer,
+/area/almayer/shipboard/brig/cryo)
 "eZz" = (
 /obj/structure/sign/safety/water{
 	pixel_x = 8;
@@ -34138,24 +34057,7 @@
 	},
 /area/almayer/medical/upper_medical)
 "fbY" = (
-/obj/structure/window/framed/almayer,
-/obj/structure/machinery/door/poddoor/shutters/almayer/open{
-	dir = 2;
-	id = "Execution Shutters";
-	name = "\improper Privacy Shutters"
-	},
-/obj/structure/machinery/door/poddoor/almayer/open{
-	id = "Brig Lockdown Shutters";
-	name = "\improper Brig Lockdown Shutter"
-	},
-/obj/structure/machinery/door/poddoor/almayer/open{
-	id = "perma_lockdown";
-	name = "\improper Perma Lockdown Shutter"
-	},
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 1
-	},
-/turf/open/floor/plating,
+/turf/closed/wall/almayer/outer,
 /area/almayer/shipboard/brig/execution)
 "fcf" = (
 /obj/structure/pipes/vents/pump{
@@ -34442,9 +34344,15 @@
 /turf/open/floor/plating,
 /area/almayer/hull/lower_hull/l_f_p)
 "fkn" = (
-/obj/structure/machinery/photocopier,
+/obj/structure/machinery/door/airlock/multi_tile/almayer/secdoor/glass/reinforced{
+	dir = 2;
+	name = "Brig";
+	req_one_access_txt = "1;3";
+	req_access = null
+	},
+/obj/structure/machinery/door/firedoor/border_only/almayer,
 /turf/open/floor/almayer{
-	icon_state = "red"
+	icon_state = "test_floor4"
 	},
 /area/almayer/shipboard/brig/main_office)
 "fkW" = (
@@ -34521,20 +34429,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/hull/lower_hull/l_f_s)
-"fnl" = (
-/obj/structure/surface/rack,
-/obj/item/clothing/suit/straight_jacket,
-/obj/item/clothing/glasses/sunglasses/blindfold,
-/obj/item/clothing/mask/muzzle,
-/obj/structure/machinery/camera/autoname/almayer{
-	dir = 8;
-	name = "ship-grade camera"
-	},
-/turf/open/floor/almayer{
-	dir = 4;
-	icon_state = "redcorner"
-	},
-/area/almayer/shipboard/brig/execution)
 "fnA" = (
 /obj/structure/surface/rack,
 /obj/item/tool/crowbar,
@@ -34707,28 +34601,16 @@
 	},
 /area/almayer/shipboard/starboard_missiles)
 "frJ" = (
-/obj/structure/closet/secure_closet/guncabinet/red,
-/obj/item/ammo_magazine/shotgun,
-/obj/item/ammo_magazine/shotgun,
-/obj/item/ammo_magazine/shotgun,
-/obj/item/ammo_magazine/shotgun/buckshot,
-/obj/item/ammo_magazine/shotgun/buckshot,
-/obj/item/ammo_magazine/shotgun/buckshot,
-/obj/item/weapon/gun/shotgun/combat,
-/obj/item/weapon/gun/shotgun/combat,
-/obj/item/weapon/gun/shotgun/combat,
-/obj/effect/decal/warning_stripes{
-	icon_state = "S"
+/obj/structure/surface/rack,
+/obj/item/storage/firstaid/adv{
+	pixel_x = 6;
+	pixel_y = 6
 	},
-/obj/structure/sign/safety/ammunition{
-	pixel_x = 15;
-	pixel_y = 32
+/obj/item/storage/firstaid/regular,
+/turf/open/floor/almayer{
+	icon_state = "plate"
 	},
-/obj/structure/sign/safety/hazard{
-	pixel_y = 32
-	},
-/turf/open/floor/plating/almayer,
-/area/almayer/shipboard/brig/armory)
+/area/almayer/shipboard/brig/execution)
 "fsd" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
@@ -34738,19 +34620,6 @@
 	icon_state = "plating"
 	},
 /area/almayer/hallways/vehiclehangar)
-"fso" = (
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 2
-	},
-/obj/structure/machinery/door/airlock/multi_tile/almayer/secdoor/glass/reinforced{
-	name = "\improper Cryogenics Bay";
-	req_access = null;
-	req_one_access_txt = "1;3"
-	},
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/shipboard/brig/cryo)
 "fsp" = (
 /obj/structure/barricade/handrail{
 	dir = 1;
@@ -34762,22 +34631,11 @@
 	},
 /area/almayer/living/gym)
 "fsz" = (
-/obj/structure/machinery/firealarm{
-	dir = 1;
-	pixel_y = -28
+/obj/structure/machinery/computer/crew,
+/turf/open/floor/almayer{
+	icon_state = "plate"
 	},
-/obj/structure/surface/table/almayer,
-/obj/item/storage/box/flashbangs,
-/obj/item/storage/box/flashbangs{
-	pixel_x = 5;
-	pixel_y = 9
-	},
-/obj/item/storage/box/flashbangs{
-	pixel_x = -8;
-	pixel_y = 5
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/shipboard/brig/armory)
+/area/almayer/shipboard/brig/general_equipment)
 "fsH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -34788,11 +34646,11 @@
 	},
 /area/almayer/hallways/port_hallway)
 "fsT" = (
-/turf/open/floor/almayer{
-	dir = 5;
-	icon_state = "plating"
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
 	},
-/area/almayer/shipboard/brig/armory)
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/brig/general_equipment)
 "fsV" = (
 /obj/structure/target,
 /turf/open/floor/almayer{
@@ -34873,14 +34731,8 @@
 	},
 /area/almayer/engineering/laundry)
 "fuX" = (
-/obj/structure/window/framed/almayer,
-/obj/structure/machinery/door/poddoor/almayer/locked{
-	dir = 8;
-	id = "Perma 2L";
-	name = "\improper cell shutter"
-	},
-/turf/open/floor/plating,
-/area/almayer/shipboard/brig/perma)
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/brig/execution)
 "fvd" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/almayer{
@@ -35190,14 +35042,12 @@
 	},
 /area/almayer/medical/lower_medical_medbay)
 "fDn" = (
-/obj/structure/machinery/cm_vending/sorted/medical/wall_med{
-	pixel_y = -25
-	},
+/obj/structure/machinery/vending/security,
+/obj/structure/machinery/vending/security,
 /turf/open/floor/almayer{
-	dir = 5;
-	icon_state = "plating"
+	icon_state = "plate"
 	},
-/area/almayer/shipboard/brig/armory)
+/area/almayer/shipboard/brig/general_equipment)
 "fDG" = (
 /obj/structure/machinery/vending/coffee,
 /obj/structure/machinery/light{
@@ -35440,18 +35290,11 @@
 	},
 /area/almayer/hull/upper_hull/u_f_s)
 "fHS" = (
-/obj/structure/sign/safety/rewire{
-	pixel_y = -32
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 10
 	},
-/obj/structure/machinery/door_control{
-	id = "perma_lockdown";
-	name = "\improper Perma Cells Lockdown";
-	pixel_x = 6;
-	pixel_y = -24;
-	req_access_txt = "3"
-	},
-/turf/open/floor/almayer,
-/area/almayer/shipboard/brig/processing)
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/brig/general_equipment)
 "fIf" = (
 /obj/structure/sign/safety/bulkhead_door{
 	pixel_x = 8;
@@ -35638,13 +35481,13 @@
 	},
 /area/almayer/living/grunt_rnr)
 "fLn" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
+/obj/effect/decal/warning_stripes{
+	icon_state = "W";
+	layer = 2.5
 	},
-/turf/open/floor/almayer{
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/general_equipment)
+/obj/effect/landmark/start/police,
+/turf/open/floor/almayer,
+/area/almayer/shipboard/brig/cryo)
 "fLX" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N";
@@ -35696,14 +35539,19 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/hangar)
 "fNA" = (
-/obj/structure/closet/fireaxecabinet{
-	pixel_y = 32
+/obj/structure/surface/table/almayer,
+/obj/item/storage/box/bodybags{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/item/storage/box/bodybags,
+/obj/structure/machinery/light/small{
+	dir = 4
 	},
 /turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "red"
+	icon_state = "plate"
 	},
-/area/almayer/shipboard/brig/general_equipment)
+/area/almayer/shipboard/brig/execution)
 "fOk" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 9
@@ -36079,15 +35927,12 @@
 	},
 /area/almayer/engineering/engine_core)
 "fYX" = (
-/obj/structure/surface/table/almayer,
-/obj/structure/machinery/computer/secure_data{
-	dir = 8
+/obj/structure/machinery/light{
+	dir = 4;
+	invisibility = 101
 	},
-/turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "redcorner"
-	},
-/area/almayer/shipboard/brig/chief_mp_office)
+/turf/open/floor/almayer,
+/area/almayer/shipboard/brig/execution)
 "fYZ" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
@@ -36221,11 +36066,14 @@
 /obj/structure/machinery/light{
 	dir = 1
 	},
+/obj/structure/machinery/status_display{
+	pixel_y = 30
+	},
 /turf/open/floor/almayer{
 	dir = 1;
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/general_equipment)
+/area/almayer/shipboard/brig/main_office)
 "gdp" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -36313,20 +36161,6 @@
 /obj/structure/surface/table/woodentable/fancy,
 /turf/open/floor/wood/ship,
 /area/almayer/living/commandbunks)
-"geX" = (
-/obj/structure/pipes/vents/scrubber,
-/obj/structure/sign/safety/ammunition{
-	pixel_x = 15;
-	pixel_y = 32
-	},
-/obj/structure/sign/safety/hazard{
-	pixel_y = 32
-	},
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/general_equipment)
 "gfh" = (
 /obj/structure/closet/crate/freezer{
 	desc = "A freezer crate. There is a note attached, it reads: Do not open, property of Pvt. Mendoza."
@@ -36462,15 +36296,8 @@
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 10
 	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "N";
-	pixel_y = 1
-	},
-/obj/effect/landmark/start/warden,
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/shipboard/brig/cryo)
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/brig/main_office)
 "gjm" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N";
@@ -36680,16 +36507,12 @@
 	},
 /area/almayer/shipboard/weapon_room)
 "goD" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/machinery/door/airlock/almayer/generic{
+	name = "Bathroom";
+	dir = 1
 	},
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/turf/open/floor/almayer{
-	icon_state = "redcorner"
-	},
-/area/almayer/shipboard/brig/processing)
+/turf/open/floor/wood/ship,
+/area/almayer/shipboard/brig/chief_mp_office)
 "goL" = (
 /turf/open/floor/almayer{
 	dir = 10;
@@ -36752,18 +36575,13 @@
 	},
 /area/almayer/lifeboat_pumps/north1)
 "gqW" = (
-/obj/structure/surface/table/almayer,
-/turf/open/floor/almayer{
-	icon_state = "plate"
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_y = 26
 	},
-/area/almayer/shipboard/brig/main_office)
-"grl" = (
-/obj/effect/landmark/crap_item,
 /turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "red"
+	icon_state = "plating_striped"
 	},
-/area/almayer/shipboard/brig/main_office)
+/area/almayer/shipboard/brig/armory)
 "grG" = (
 /obj/structure/sign/safety/restrictedarea{
 	pixel_x = -17
@@ -37346,16 +37164,12 @@
 /turf/open/floor/almayer,
 /area/almayer/hallways/hangar)
 "gCI" = (
-/obj/structure/machinery/light{
-	dir = 4
+/obj/structure/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
 	},
-/obj/structure/machinery/cryopod/right{
-	pixel_y = 6
-	},
-/turf/open/floor/almayer{
-	icon_state = "cargo"
-	},
-/area/almayer/shipboard/brig/cryo)
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/brig/evidence_storage)
 "gCP" = (
 /obj/structure/surface/table/reinforced/almayer_B,
 /obj/item/device/flashlight/lamp,
@@ -37737,15 +37551,13 @@
 	},
 /area/almayer/hallways/aft_hallway)
 "gMf" = (
-/obj/structure/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
+/obj/effect/decal/warning_stripes{
+	icon_state = "E";
+	pixel_x = 1
 	},
-/turf/open/floor/almayer{
-	dir = 4;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/perma)
+/obj/effect/landmark/start/police,
+/turf/open/floor/almayer,
+/area/almayer/shipboard/brig/cryo)
 "gMx" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating/plating_catwalk,
@@ -37865,9 +37677,6 @@
 "gSi" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/computer/cameras/almayer_network,
-/obj/item/storage/box/tapes{
-	pixel_x = -16
-	},
 /turf/open/floor/almayer,
 /area/almayer/shipboard/brig/processing)
 "gSj" = (
@@ -37917,17 +37726,21 @@
 /obj/structure/pipes/vents/pump{
 	dir = 8
 	},
+/obj/structure/machinery/power/apc/almayer,
 /turf/open/floor/almayer{
-	icon_state = "red"
+	icon_state = "orange"
 	},
-/area/almayer/shipboard/brig/cryo)
+/area/almayer/shipboard/brig/processing)
 "gTx" = (
-/obj/structure/machinery/vending/security,
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "red"
+/obj/structure/surface/table/almayer,
+/obj/item/storage/toolbox/mechanical/green{
+	pixel_y = 8
 	},
-/area/almayer/shipboard/brig/main_office)
+/obj/item/storage/toolbox/mechanical,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/shipboard/brig/general_equipment)
 "gUf" = (
 /obj/structure/machinery/portable_atmospherics/hydroponics,
 /turf/open/floor/almayer{
@@ -38363,8 +38176,8 @@
 	pixel_y = 27
 	},
 /turf/open/floor/almayer{
-	dir = 4;
-	icon_state = "redcorner"
+	dir = 1;
+	icon_state = "red"
 	},
 /area/almayer/shipboard/brig/processing)
 "heV" = (
@@ -38482,20 +38295,17 @@
 	},
 /area/almayer/command/computerlab)
 "hgF" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "E";
-	pixel_x = 1
-	},
 /obj/structure/machinery/light{
 	unacidable = 1;
 	unslashable = 1
 	},
-/obj/structure/machinery/camera/autoname/almayer{
-	dir = 4;
-	name = "ship-grade camera"
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
 	},
-/turf/open/floor/almayer,
-/area/almayer/shipboard/brig/execution)
+/turf/open/floor/almayer{
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/chief_mp_office)
 "hgH" = (
 /obj/structure/machinery/camera/autoname/almayer{
 	dir = 1;
@@ -39024,21 +38834,21 @@
 	},
 /area/almayer/engineering/upper_engineering)
 "hwQ" = (
-/obj/structure/window/framed/almayer,
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/almayer/shipboard/brig/execution)
-"hwS" = (
 /obj/structure/bed/chair/comfy/black{
-	dir = 1
-	},
-/obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
 	},
-/turf/open/floor/almayer,
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "redcorner"
+	},
 /area/almayer/shipboard/brig/chief_mp_office)
+"hwS" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "W";
+	layer = 2.5
+	},
+/turf/open/floor/almayer,
+/area/almayer/shipboard/brig/execution)
 "hxe" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -39128,15 +38938,12 @@
 	},
 /area/almayer/living/offices)
 "hyz" = (
-/obj/structure/disposalpipe/junction{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
-/obj/structure/pipes/standard/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/structure/machinery/light{
-	unacidable = 1;
-	unslashable = 1
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 5
 	},
 /turf/open/floor/almayer{
 	allow_construction = 0
@@ -39176,24 +38983,11 @@
 	},
 /area/almayer/squads/delta)
 "hzx" = (
-/obj/structure/machinery/door/airlock/almayer/security/glass{
-	name = "\improper Chief MP's Office";
-	req_access = null;
-	req_one_access_txt = "1;3"
-	},
-/obj/structure/machinery/door/firedoor/border_only/almayer,
-/obj/structure/machinery/door/poddoor/shutters/almayer/open{
-	dir = 4;
-	id = "CMP Office Shutters";
-	name = "\improper Privacy Shutters"
-	},
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
+/obj/structure/closet/emcloset,
 /turf/open/floor/almayer{
-	icon_state = "test_floor4"
+	icon_state = "sterile_green_side"
 	},
-/area/almayer/shipboard/brig/chief_mp_office)
+/area/almayer/shipboard/brig/surgery)
 "hzJ" = (
 /obj/structure/machinery/door/airlock/almayer/generic{
 	dir = 1
@@ -39711,21 +39505,17 @@
 /turf/open/floor/plating,
 /area/almayer/squads/charlie)
 "hND" = (
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 1
+/obj/structure/machinery/door_control{
+	id = "CMP Office Shutters";
+	name = "CMP Office Shutters";
+	req_one_access_txt = "24;31";
+	pixel_y = -20
 	},
-/obj/structure/machinery/door/poddoor/almayer/open{
-	id = "Brig Lockdown Shutters";
-	name = "\improper Brig Lockdown Shutter"
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
 	},
-/obj/structure/machinery/door/airlock/almayer/security/glass/reinforced{
-	dir = 1;
-	name = "\improper Brig"
-	},
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/shipboard/brig/main_office)
+/turf/open/floor/almayer,
+/area/almayer/shipboard/brig/perma)
 "hNL" = (
 /obj/structure/machinery/firealarm{
 	pixel_y = 28
@@ -39911,17 +39701,11 @@
 /turf/open/floor/almayer,
 /area/almayer/hull/upper_hull/u_f_p)
 "hRy" = (
-/obj/structure/surface/rack,
-/obj/item/storage/firstaid/adv{
-	pixel_x = 6;
-	pixel_y = 6
-	},
-/obj/item/storage/firstaid/regular,
-/turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "redcorner"
-	},
-/area/almayer/shipboard/brig/execution)
+/obj/structure/surface/table/almayer,
+/obj/structure/surface/table/almayer,
+/obj/structure/machinery/faxmachine/uscm/brig/chief,
+/turf/open/floor/wood/ship,
+/area/almayer/shipboard/brig/chief_mp_office)
 "hSk" = (
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/engineering/upper_engineering/port)
@@ -40240,17 +40024,11 @@
 	},
 /area/almayer/medical/lower_medical_medbay)
 "hZU" = (
-/obj/structure/transmitter{
-	name = "Brig Offices Telephone";
-	phone_category = "Almayer";
-	phone_id = "Brig Main Offices";
-	pixel_y = 32
+/obj/structure/bed/chair/comfy/black{
+	dir = 8
 	},
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/main_office)
+/turf/open/floor/almayer,
+/area/almayer/shipboard/brig/chief_mp_office)
 "iag" = (
 /obj/structure/surface/table/almayer,
 /obj/item/tool/hand_labeler,
@@ -40347,22 +40125,11 @@
 /turf/closed/wall/almayer/research/containment/wall/north,
 /area/almayer/medical/containment/cell)
 "icX" = (
-/obj/structure/machinery/brig_cell/perma_2{
-	pixel_x = -32;
-	pixel_y = -4
+/obj/structure/machinery/keycard_auth{
+	pixel_x = 25
 	},
-/obj/structure/machinery/door_control{
-	id = "Perma 2L";
-	name = "Perma 2 Lockdown";
-	pixel_x = -24;
-	pixel_y = 12;
-	req_access_txt = "3"
-	},
-/turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/perma)
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/brig/chief_mp_office)
 "idx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -40385,11 +40152,14 @@
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 26
+	},
 /turf/open/floor/almayer{
 	dir = 1;
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/general_equipment)
+/area/almayer/shipboard/brig/main_office)
 "ieu" = (
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -40512,6 +40282,13 @@
 	icon_state = "red"
 	},
 /area/almayer/shipboard/brig/main_office)
+"ihi" = (
+/obj/structure/machinery/brig_cell/cell_6{
+	pixel_x = 32;
+	pixel_y = -32
+	},
+/turf/open/floor/almayer,
+/area/almayer/shipboard/brig/processing)
 "ihn" = (
 /obj/structure/surface/table/almayer,
 /obj/item/reagent_container/food/drinks/cans/souto/blue{
@@ -40667,25 +40444,21 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/upper_hull/u_m_s)
 "ikM" = (
-/obj/structure/surface/table/almayer,
-/obj/structure/machinery/computer/cameras/almayer_network,
-/obj/structure/machinery/computer/secure_data{
-	pixel_x = 17
+/obj/structure/machinery/vending/security,
+/obj/structure/sign/safety/hazard{
+	pixel_y = 32
 	},
-/obj/structure/machinery/computer/card{
-	pixel_x = -16
+/obj/structure/sign/safety/ammunition{
+	pixel_x = 15;
+	pixel_y = 32
 	},
 /obj/structure/machinery/light{
 	dir = 1
 	},
-/obj/structure/sign/safety/terminal{
-	pixel_x = 8;
-	pixel_y = 32
-	},
 /turf/open/floor/almayer{
-	icon_state = "plate"
+	icon_state = "plating_striped"
 	},
-/area/almayer/shipboard/brig/main_office)
+/area/almayer/shipboard/brig/armory)
 "ils" = (
 /obj/structure/window/framed/almayer/hull,
 /turf/open/floor/plating,
@@ -40771,9 +40544,12 @@
 	},
 /area/almayer/hull/upper_hull/u_f_p)
 "inG" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/pipes/standard/manifold/hidden/supply{
-	dir = 4
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/cells)
@@ -40784,10 +40560,13 @@
 /area/almayer/medical/containment)
 "inN" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/pipes/standard/manifold/hidden/supply{
-	dir = 4
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 10
 	},
-/turf/open/floor/almayer,
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "red"
+	},
 /area/almayer/shipboard/brig/main_office)
 "ioj" = (
 /obj/structure/largecrate/random/barrel/green,
@@ -40868,9 +40647,12 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/upper_hull/u_f_p)
 "iqn" = (
-/obj/structure/pipes/standard/manifold/hidden/supply,
-/turf/open/floor/almayer,
-/area/almayer/shipboard/brig/main_office)
+/obj/structure/machinery/vending/security,
+/obj/structure/machinery/light,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/shipboard/brig/general_equipment)
 "iqo" = (
 /obj/structure/flora/pottedplant{
 	icon_state = "pottedplant_22"
@@ -40894,6 +40676,7 @@
 /obj/structure/machinery/light/small{
 	dir = 4
 	},
+/obj/structure/closet/firecloset,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -40945,9 +40728,9 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red"
+	icon_state = "redcorner"
 	},
-/area/almayer/shipboard/brig/general_equipment)
+/area/almayer/shipboard/brig/main_office)
 "irS" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/structure/cable/heavyduty{
@@ -40968,18 +40751,14 @@
 	},
 /area/almayer/command/airoom)
 "isH" = (
-/obj/structure/reagent_dispensers/water_cooler/stacks{
-	density = 0;
-	pixel_y = 17
-	},
-/obj/structure/pipes/standard/manifold/hidden/supply{
-	dir = 1
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 6
 	},
 /turf/open/floor/almayer{
 	dir = 1;
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/general_equipment)
+/area/almayer/shipboard/brig/main_office)
 "isN" = (
 /obj/structure/sink{
 	dir = 8;
@@ -41223,22 +41002,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/squads/req)
-"iyq" = (
-/obj/structure/machinery/door/poddoor/shutters/almayer/open{
-	dir = 2;
-	id = "Warden Office Shutters";
-	name = "\improper Privacy Shutters"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/pipes/standard/simple/hidden/supply,
-/obj/structure/machinery/door/airlock/almayer/security/glass/reinforced{
-	dir = 1;
-	name = "\improper Warden Office"
-	},
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/shipboard/brig/main_office)
 "iyQ" = (
 /turf/open/floor/almayer{
 	dir = 5;
@@ -41718,9 +41481,10 @@
 	dir = 8
 	},
 /turf/open/floor/almayer{
-	icon_state = "redcorner"
+	dir = 6;
+	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/general_equipment)
+/area/almayer/shipboard/brig/main_office)
 "iLd" = (
 /obj/structure/stairs/perspective{
 	dir = 1;
@@ -41827,12 +41591,13 @@
 	},
 /area/almayer/hull/lower_hull/l_f_s)
 "iOh" = (
-/obj/structure/machinery/light/small,
-/obj/structure/machinery/status_display{
-	pixel_y = -32
+/obj/structure/machinery/firealarm{
+	pixel_y = -28
 	},
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/shipboard/brig/armory)
+/turf/open/floor/almayer{
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/main_office)
 "iOp" = (
 /obj/structure/pipes/vents/pump,
 /obj/structure/machinery/camera/autoname/almayer{
@@ -42297,7 +42062,7 @@
 /obj/structure/window/framed/almayer/hull,
 /obj/structure/machinery/door/firedoor/border_only/almayer,
 /turf/open/floor/plating,
-/area/almayer/shipboard/brig/chief_mp_office)
+/area/almayer/shipboard/brig/execution)
 "iZH" = (
 /obj/structure/sign/safety/distribution_pipes{
 	pixel_x = -17
@@ -42359,18 +42124,16 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/upper_hull/u_a_p)
 "jaP" = (
-/obj/structure/surface/table/almayer,
-/obj/structure/machinery/computer/cameras/almayer_network{
-	dir = 1
+/obj/structure/machinery/door/airlock/almayer/security/glass/reinforced{
+	name = "\improper Warden's Office"
 	},
-/obj/structure/machinery/light{
-	unacidable = 1;
-	unslashable = 1
+/obj/structure/machinery/door/firedoor/border_only/almayer{
+	dir = 8
 	},
 /turf/open/floor/almayer{
-	icon_state = "red"
+	icon_state = "test_floor4"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/chief_mp_office)
 "jaR" = (
 /obj/structure/largecrate/random/mini/small_case/b{
 	pixel_x = 8;
@@ -42553,11 +42316,17 @@
 /obj/structure/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "cargo_arrow"
+/obj/structure/machinery/cryopod/right{
+	layer = 3.1;
+	pixel_y = 13
 	},
-/area/almayer/shipboard/brig/general_equipment)
+/obj/structure/machinery/status_display{
+	pixel_x = 32
+	},
+/turf/open/floor/almayer{
+	icon_state = "cargo"
+	},
+/area/almayer/shipboard/brig/cryo)
 "jeO" = (
 /obj/structure/machinery/light{
 	dir = 4
@@ -42834,11 +42603,17 @@
 	},
 /area/almayer/living/grunt_rnr)
 "jjM" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 5
+/obj/item/storage/box/nade_box/tear_gas,
+/obj/item/storage/box/nade_box/tear_gas{
+	pixel_x = 3;
+	pixel_y = 5
 	},
-/turf/open/floor/almayer,
-/area/almayer/shipboard/brig/main_office)
+/obj/structure/surface/table/almayer,
+/turf/open/floor/almayer{
+	dir = 5;
+	icon_state = "plating"
+	},
+/area/almayer/shipboard/brig/armory)
 "jjT" = (
 /obj/structure/machinery/light,
 /obj/effect/projector{
@@ -42912,25 +42687,31 @@
 	},
 /area/almayer/living/briefing)
 "jkS" = (
-/obj/structure/window/framed/almayer/hull/hijack_bustable,
-/obj/structure/machinery/door/poddoor/shutters/almayer/open{
-	dir = 2;
-	id = "Warden Office Shutters";
-	name = "\improper Privacy Shutters"
-	},
-/turf/open/floor/plating,
-/area/almayer/shipboard/brig/main_office)
-"jkV" = (
-/obj/structure/machinery/light{
-	dir = 1
-	},
-/obj/structure/bed/chair/bolted{
-	dir = 4
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
 	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
 /area/almayer/shipboard/brig/perma)
+"jkV" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "NW-out"
+	},
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 5
+	},
+/obj/structure/sign/safety/ammunition{
+	pixel_x = 15;
+	pixel_y = -32
+	},
+/obj/structure/sign/safety/hazard{
+	pixel_y = -32
+	},
+/turf/open/floor/almayer,
+/area/almayer/shipboard/brig/execution)
 "jlA" = (
 /obj/structure/window/framed/almayer/white,
 /obj/structure/machinery/door/firedoor/border_only/almayer,
@@ -43070,8 +42851,9 @@
 /turf/open/floor/plating,
 /area/almayer/command/cic)
 "jox" = (
-/obj/structure/machinery/brig_cell/cell_3{
-	pixel_x = -32
+/obj/structure/machinery/brig_cell/cell_4{
+	pixel_x = 32;
+	pixel_y = -32
 	},
 /turf/open/floor/almayer,
 /area/almayer/shipboard/brig/processing)
@@ -43239,13 +43021,15 @@
 	},
 /area/almayer/medical/lower_medical_medbay)
 "jvc" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 5
+/obj/structure/reagent_dispensers/water_cooler/stacks{
+	density = 0;
+	pixel_y = 17
 	},
 /turf/open/floor/almayer{
-	allow_construction = 0
+	dir = 1;
+	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/general_equipment)
+/area/almayer/shipboard/brig/main_office)
 "jvp" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/pipes/standard/simple/hidden/supply{
@@ -43454,13 +43238,20 @@
 	},
 /area/almayer/medical/hydroponics)
 "jCa" = (
-/obj/structure/machinery/disposal,
-/obj/structure/disposalpipe/trunk,
-/turf/open/floor/almayer{
-	dir = 9;
-	icon_state = "red"
+/obj/structure/closet/secure_closet/guncabinet/riot_control,
+/obj/item/weapon/shield/riot,
+/obj/item/weapon/shield/riot,
+/obj/item/weapon/shield/riot,
+/obj/effect/decal/warning_stripes{
+	icon_state = "SW-out";
+	pixel_x = -1;
+	pixel_y = -1
 	},
-/area/almayer/shipboard/brig/main_office)
+/turf/open/floor/almayer{
+	dir = 5;
+	icon_state = "plating"
+	},
+/area/almayer/shipboard/brig/armory)
 "jCG" = (
 /turf/closed/wall/almayer/research/containment/wall/connect_w,
 /area/almayer/medical/containment/cell)
@@ -43638,16 +43429,15 @@
 	},
 /area/almayer/hallways/port_hallway)
 "jJq" = (
-/obj/structure/surface/rack,
-/obj/item/storage/firstaid/regular,
-/obj/item/storage/firstaid/toxin{
-	pixel_x = 8;
-	pixel_y = -2
+/obj/structure/surface/table/almayer,
+/obj/item/folder/red{
+	pixel_x = -4
 	},
-/turf/open/floor/almayer{
-	icon_state = "red"
+/obj/item/folder/blue{
+	pixel_x = 4
 	},
-/area/almayer/shipboard/brig/general_equipment)
+/turf/open/floor/plating/almayer,
+/area/almayer/shipboard/brig/evidence_storage)
 "jJs" = (
 /turf/open/floor/almayer{
 	icon_state = "green"
@@ -44259,11 +44049,14 @@
 	},
 /area/almayer/medical/operating_room_four)
 "jZm" = (
-/obj/structure/machinery/brig_cell/cell_4{
-	pixel_x = -32;
-	pixel_y = -32
+/obj/structure/machinery/light{
+	dir = 1
 	},
-/turf/open/floor/almayer,
+/obj/structure/bed/chair,
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "red"
+	},
 /area/almayer/shipboard/brig/processing)
 "jZs" = (
 /obj/structure/surface/table/almayer,
@@ -44293,23 +44086,13 @@
 	},
 /area/almayer/squads/charlie)
 "jZL" = (
-/obj/structure/surface/table/almayer,
-/obj/structure/machinery/computer/cameras/almayer_network{
-	dir = 1
+/obj/effect/decal/warning_stripes{
+	icon_state = "E";
+	pixel_x = 1
 	},
-/obj/structure/machinery/light{
-	unacidable = 1;
-	unslashable = 1
-	},
-/obj/structure/transmitter{
-	dir = 1;
-	name = "Brig Warden's Office Telephone";
-	phone_category = "Offices";
-	phone_id = "Brig Warden's Office";
-	pixel_x = -16
-	},
-/turf/open/floor/almayer,
-/area/almayer/shipboard/brig/main_office)
+/obj/effect/landmark/start/police,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/brig/cryo)
 "jZO" = (
 /obj/structure/largecrate/random/barrel/blue,
 /turf/open/floor/almayer{
@@ -44662,10 +44445,17 @@
 	},
 /area/almayer/hull/lower_hull/l_f_s)
 "kif" = (
-/turf/open/floor/almayer{
-	icon_state = "plate"
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
 	},
-/area/almayer/shipboard/brig/main_office)
+/obj/structure/machinery/camera/autoname/almayer{
+	name = "ship-grade camera";
+	dir = 1
+	},
+/turf/open/floor/almayer{
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/chief_mp_office)
 "kij" = (
 /obj/structure/sign/safety/distribution_pipes{
 	pixel_x = -17
@@ -44716,11 +44506,23 @@
 	},
 /area/almayer/squads/alpha)
 "kjN" = (
-/obj/structure/machinery/power/apc/almayer{
-	dir = 4
+/obj/structure/machinery/door_control{
+	id = "CMP Office Shutters";
+	name = "CMP Office Shutters";
+	pixel_y = 32;
+	req_one_access_txt = "24;31"
 	},
-/turf/open/floor/almayer,
-/area/almayer/shipboard/brig/surgery)
+/obj/structure/machinery/door_control{
+	id = "Brig Lockdown Shutters";
+	name = "Brig Lockdown Shutters";
+	pixel_y = 24;
+	req_access_txt = "3"
+	},
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/chief_mp_office)
 "kjV" = (
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -45165,30 +44967,22 @@
 /turf/open/floor/plating,
 /area/almayer/hull/lower_hull/l_f_p)
 "kta" = (
+/obj/structure/surface/table/almayer,
+/obj/structure/surface/table/almayer,
+/obj/structure/machinery/computer/cameras/almayer_network{
+	dir = 4
+	},
 /turf/open/floor/almayer{
-	dir = 4;
+	dir = 8;
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/evidence_storage)
+/area/almayer/shipboard/brig/processing)
 "ktn" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "N"
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 6
 	},
-/obj/structure/closet/secure_closet/guncabinet/red,
-/obj/item/weapon/gun/rifle/m4ra,
-/obj/item/weapon/gun/rifle/m4ra,
-/obj/item/ammo_magazine/rifle/m4ra,
-/obj/item/ammo_magazine/rifle/m4ra,
-/obj/item/ammo_magazine/rifle/m4ra,
-/obj/item/ammo_magazine/rifle/m4ra,
-/obj/item/ammo_magazine/rifle/m4ra,
-/obj/item/ammo_magazine/rifle/m4ra,
-/obj/item/ammo_magazine/rifle/m4ra,
-/turf/open/floor/almayer{
-	dir = 5;
-	icon_state = "plating"
-	},
-/area/almayer/shipboard/brig/armory)
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/brig/general_equipment)
 "ktB" = (
 /obj/structure/largecrate/random/barrel/white,
 /turf/open/floor/almayer{
@@ -45344,14 +45138,18 @@
 	},
 /area/almayer/shipboard/brig/processing)
 "kyI" = (
-/obj/structure/machinery/light{
-	dir = 8
+/obj/structure/machinery/door/airlock/multi_tile/almayer/secdoor/glass/reinforced{
+	name = "\improper Brig";
+	req_one_access_txt = "1;3";
+	req_access = null
 	},
-/obj/structure/sign/safety/bathunisex{
-	pixel_x = 32
+/obj/structure/machinery/door/firedoor/border_only/almayer{
+	dir = 2
 	},
-/turf/open/floor/wood/ship,
-/area/almayer/shipboard/brig/chief_mp_office)
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/shipboard/brig/main_office)
 "kyN" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/sign/safety/distribution_pipes{
@@ -45363,18 +45161,16 @@
 	},
 /area/almayer/shipboard/navigation)
 "kyP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
 	},
 /obj/structure/machinery/cm_vending/sorted/marine_food,
-/obj/structure/machinery/camera/autoname/almayer{
-	name = "ship-grade camera"
-	},
 /turf/open/floor/almayer{
-	dir = 1;
+	dir = 5;
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/processing)
 "kyX" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 5
@@ -45568,9 +45364,7 @@
 /area/almayer/lifeboat_pumps/south1)
 "kDA" = (
 /obj/structure/pipes/vents/scrubber,
-/turf/open/floor/almayer{
-	icon_state = "red"
-	},
+/turf/open/floor/almayer,
 /area/almayer/shipboard/brig/processing)
 "kDR" = (
 /obj/structure/disposalpipe/junction{
@@ -45735,12 +45529,14 @@
 	},
 /area/almayer/medical/medical_science)
 "kHK" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
+/obj/structure/pipes/vents/pump{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/almayer,
-/area/almayer/shipboard/brig/execution)
+/turf/open/floor/almayer{
+	dir = 4;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/chief_mp_office)
 "kHT" = (
 /turf/open/floor/almayer{
 	dir = 5;
@@ -45797,10 +45593,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/hull/upper_hull/u_a_p)
-"kJK" = (
-/obj/structure/bed/chair/comfy/orange,
-/turf/open/floor/almayer,
-/area/almayer/shipboard/brig/main_office)
 "kJV" = (
 /obj/structure/machinery/light,
 /turf/open/floor/almayer{
@@ -45916,8 +45708,7 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "redcorner"
+	allow_construction = 0
 	},
 /area/almayer/shipboard/brig/processing)
 "kNl" = (
@@ -45972,14 +45763,21 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_m_s)
 "kOi" = (
-/obj/structure/sink{
-	dir = 1;
-	pixel_y = -10
+/obj/structure/machinery/door/airlock/almayer/security/glass/reinforced{
+	name = "\improper Warden's Office"
+	},
+/obj/structure/machinery/door/poddoor/shutters/almayer/open{
+	dir = 4;
+	id = "Warden Office Shutters";
+	name = "\improper Privacy Shutters"
+	},
+/obj/structure/machinery/door/firedoor/border_only/almayer{
+	dir = 8
 	},
 /turf/open/floor/almayer{
-	icon_state = "plate"
+	icon_state = "test_floor4"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/cells)
 "kOk" = (
 /obj/structure/sign/safety/maint{
 	pixel_x = 32
@@ -46026,12 +45824,14 @@
 	},
 /area/almayer/living/port_emb)
 "kPo" = (
-/obj/structure/machinery/camera/autoname/almayer{
-	dir = 4;
-	name = "ship-grade camera"
+/obj/structure/disposalpipe/segment{
+	dir = 8
 	},
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/hull/upper_hull/u_f_p)
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/turf/open/floor/almayer,
+/area/almayer/shipboard/brig/cells)
 "kPx" = (
 /obj/structure/surface/table/almayer,
 /obj/item/device/mass_spectrometer,
@@ -46201,27 +46001,30 @@
 	},
 /area/almayer/hallways/aft_hallway)
 "kTc" = (
-/obj/structure/closet/secure_closet/guncabinet/red,
-/obj/item/ammo_magazine/shotgun,
-/obj/item/ammo_magazine/shotgun,
-/obj/item/ammo_magazine/shotgun,
-/obj/item/ammo_magazine/shotgun/buckshot,
-/obj/item/ammo_magazine/shotgun/buckshot,
-/obj/item/ammo_magazine/shotgun/buckshot,
-/obj/item/weapon/gun/shotgun/combat,
-/obj/item/weapon/gun/shotgun/combat,
-/obj/structure/machinery/light/small{
-	dir = 8
+/obj/structure/surface/table/almayer,
+/obj/item/storage/box/evidence{
+	pixel_x = 7;
+	pixel_y = 6
 	},
-/obj/item/weapon/gun/shotgun/combat,
-/obj/item/vehicle_clamp,
-/obj/item/vehicle_clamp,
-/obj/item/vehicle_clamp,
-/obj/effect/decal/warning_stripes{
-	icon_state = "S"
+/obj/item/tool/hand_labeler{
+	pixel_x = -8;
+	pixel_y = 3
 	},
-/turf/open/floor/plating/almayer,
-/area/almayer/shipboard/brig/armory)
+/obj/item/storage/box/evidence{
+	pixel_x = 1;
+	pixel_y = 1
+	},
+/obj/structure/sign/safety/security{
+	pixel_x = 15;
+	pixel_y = 32
+	},
+/obj/structure/sign/safety/restrictedarea{
+	pixel_y = 32
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/shipboard/brig/general_equipment)
 "kTq" = (
 /obj/structure/largecrate/supply/supplies/mre,
 /turf/open/floor/almayer{
@@ -46644,7 +46447,7 @@
 	dir = 2
 	},
 /turf/open/floor/plating,
-/area/almayer/shipboard/brig/general_equipment)
+/area/almayer/shipboard/brig/main_office)
 "ldN" = (
 /obj/structure/platform{
 	dir = 1
@@ -46715,17 +46518,27 @@
 	},
 /area/almayer/engineering/engine_core)
 "lfW" = (
-/obj/structure/sign/safety/high_voltage{
-	pixel_y = -32
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
 	},
-/obj/structure/sign/safety/maint{
-	pixel_x = 14;
-	pixel_y = -32
+/obj/structure/machinery/door_control{
+	id = "cmp_armory";
+	name = "Armory Lockdown";
+	req_access_txt = "4";
+	pixel_y = 24
+	},
+/obj/structure/sign/safety/ammunition{
+	pixel_y = 32
+	},
+/obj/structure/sign/safety/restrictedarea{
+	pixel_x = 15;
+	pixel_y = 32
 	},
 /turf/open/floor/almayer{
+	dir = 1;
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/processing)
+/area/almayer/shipboard/brig/main_office)
 "lgy" = (
 /obj/structure/window/framed/almayer,
 /obj/structure/machinery/door/firedoor/border_only/almayer{
@@ -47183,17 +46996,24 @@
 	icon_state = "plate"
 	},
 /area/almayer/living/port_emb)
+"lrM" = (
+/obj/structure/machinery/brig_cell/cell_5{
+	pixel_x = 32;
+	pixel_y = -32
+	},
+/turf/open/floor/almayer,
+/area/almayer/shipboard/brig/processing)
 "lrT" = (
 /obj/structure/bed/chair,
 /turf/open/floor/almayer,
 /area/almayer/squads/charlie_delta_shared)
 "lrV" = (
-/obj/structure/machinery/door/window/brigdoor/southright{
-	id = "Cell 3";
-	name = "Cell 3"
+/obj/structure/sign/safety/four{
+	pixel_x = -17
 	},
-/obj/structure/sign/safety/three{
-	pixel_x = 31
+/obj/structure/machinery/door/window/brigdoor/southright{
+	id = "Cell 4";
+	name = "Cell 4"
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/cells)
@@ -47295,10 +47115,21 @@
 	},
 /area/almayer/command/combat_correspondent)
 "ltX" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/pipes/standard/simple/hidden/supply,
-/turf/closed/wall/almayer/reinforced,
-/area/almayer/shipboard/brig/main_office)
+/obj/structure/machinery/door/airlock/almayer/generic{
+	dir = 1
+	},
+/obj/structure/machinery/door/poddoor/almayer/open{
+	id = "courtyard_cells";
+	name = "\improper Courtyard Lockdown Shutter"
+	},
+/obj/structure/machinery/door/poddoor/almayer/locked{
+	id = "Cell 5";
+	name = "\improper Courtyard Divider"
+	},
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/shipboard/brig/cells)
 "lue" = (
 /obj/structure/surface/table/almayer,
 /obj/item/folder/yellow,
@@ -47315,12 +47146,20 @@
 	},
 /area/almayer/hull/lower_hull/l_a_p)
 "lut" = (
-/obj/structure/machinery/computer/crew,
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "red"
+/obj/structure/filingcabinet{
+	density = 0;
+	pixel_x = 8;
+	pixel_y = 18
 	},
-/area/almayer/shipboard/brig/main_office)
+/obj/structure/filingcabinet{
+	density = 0;
+	pixel_x = -8;
+	pixel_y = 18
+	},
+/turf/open/floor/almayer{
+	icon_state = "cargo"
+	},
+/area/almayer/shipboard/brig/evidence_storage)
 "luu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -47354,16 +47193,8 @@
 	},
 /area/almayer/hallways/starboard_hallway)
 "luC" = (
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 1
-	},
-/obj/structure/machinery/door/poddoor/almayer/open{
-	id = "perma_lockdown";
-	name = "\improper Perma Lockdown Shutter"
-	},
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
+/obj/structure/pipes/standard/simple/hidden/supply,
+/turf/open/floor/almayer,
 /area/almayer/shipboard/brig/perma)
 "luH" = (
 /obj/structure/disposalpipe/segment{
@@ -47420,14 +47251,41 @@
 	},
 /area/almayer/lifeboat_pumps/north1)
 "lvZ" = (
-/obj/structure/window/framed/almayer,
-/obj/structure/machinery/door/poddoor/almayer/locked{
-	dir = 8;
-	id = "Perma 1L";
-	name = "\improper cell shutter"
+/obj/structure/surface/table/almayer,
+/obj/structure/machinery/door_control{
+	id = "courtyard_cells";
+	name = "\improper Courtyard Lockdown Shutters";
+	req_access_txt = "3";
+	pixel_x = 6
 	},
-/turf/open/floor/plating,
-/area/almayer/shipboard/brig/perma)
+/obj/structure/machinery/door_control{
+	id = "Brig Lockdown Shutters";
+	name = "Brig Lockdown Shutters";
+	pixel_x = -6;
+	req_access_txt = "3"
+	},
+/obj/structure/machinery/door_control{
+	id = "courtyard window";
+	name = "Courtyard Window Shutters";
+	pixel_x = -6;
+	pixel_y = 9;
+	req_access_txt = "3"
+	},
+/obj/structure/machinery/door_control{
+	id = "Cell Privacy Shutters";
+	name = "Cell Privacy Shutters";
+	pixel_x = 6;
+	pixel_y = 9;
+	req_access_txt = "3"
+	},
+/obj/structure/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/chief_mp_office)
 "lwi" = (
 /obj/structure/machinery/door/airlock/almayer/maint{
 	dir = 1;
@@ -47572,11 +47430,22 @@
 /turf/open/floor/almayer,
 /area/almayer/squads/charlie_delta_shared)
 "lzx" = (
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "redcorner"
+/obj/structure/machinery/door/poddoor/shutters/almayer{
+	dir = 2;
+	id = "cmp_armory";
+	name = "\improper Armory Shutters"
 	},
-/area/almayer/shipboard/brig/main_office)
+/obj/structure/machinery/door/firedoor/border_only/almayer{
+	dir = 2
+	},
+/obj/structure/machinery/door/airlock/almayer/security/glass/reinforced{
+	name = "\improper Armory";
+	dir = 2
+	},
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/shipboard/brig/armory)
 "lzH" = (
 /obj/structure/machinery/cm_vending/sorted/medical/wall_med{
 	pixel_y = -25
@@ -47887,18 +47756,15 @@
 	},
 /area/almayer/medical/morgue)
 "lFs" = (
-/obj/structure/disposalpipe/segment{
+/obj/structure/disposalpipe/junction{
 	dir = 1;
-	icon_state = "pipe-c"
+	icon_state = "pipe-j2"
 	},
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 1
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
+/obj/structure/pipes/standard/manifold/hidden/supply{
+	dir = 4
 	},
 /turf/open/floor/almayer,
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/processing)
 "lFt" = (
 /obj/structure/machinery/portable_atmospherics/powered/pump,
 /obj/structure/sign/safety/maint{
@@ -48230,26 +48096,15 @@
 	},
 /area/almayer/hallways/stern_hallway)
 "lNs" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/sign/safety/ammunition{
-	pixel_x = 32;
-	pixel_y = 7
-	},
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 10
-	},
-/obj/structure/machinery/door_control{
-	id = "cmp_armory";
-	name = "Armory Lockdown";
-	pixel_x = 24;
-	pixel_y = -6;
-	req_access_txt = "4"
-	},
+/obj/structure/closet/secure_closet/guncabinet/riot_control,
+/obj/item/weapon/shield/riot,
+/obj/item/weapon/shield/riot,
+/obj/item/weapon/shield/riot,
 /turf/open/floor/almayer{
-	dir = 4;
-	icon_state = "redcorner"
+	dir = 8;
+	icon_state = "plating_striped"
 	},
-/area/almayer/shipboard/brig/main_office)
+/area/almayer/shipboard/brig/armory)
 "lNw" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/pipes/standard/simple/hidden/supply,
@@ -48275,18 +48130,11 @@
 	},
 /area/almayer/hull/lower_hull/l_m_p)
 "lNF" = (
-/obj/structure/closet/secure_closet{
-	name = "\improper Lethal Injection Locker"
-	},
-/obj/item/reagent_container/ld50_syringe/choral,
-/obj/item/reagent_container/ld50_syringe/choral,
-/obj/item/reagent_container/ld50_syringe/choral,
-/obj/item/reagent_container/ld50_syringe/choral,
-/obj/item/reagent_container/ld50_syringe/choral,
 /turf/open/floor/almayer{
-	icon_state = "redcorner"
+	dir = 10;
+	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/execution)
+/area/almayer/shipboard/brig/processing)
 "lOl" = (
 /obj/structure/machinery/light{
 	dir = 8
@@ -48595,14 +48443,12 @@
 	},
 /area/almayer/hallways/hangar)
 "lYZ" = (
-/obj/structure/surface/table/almayer,
-/obj/item/storage/toolbox/mechanical/green{
-	pixel_y = 8
+/obj/structure/machinery/vending/coffee,
+/obj/structure/machinery/light{
+	dir = 4
 	},
-/obj/item/storage/toolbox/mechanical,
 /turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "red"
+	icon_state = "plate"
 	},
 /area/almayer/shipboard/brig/general_equipment)
 "lZs" = (
@@ -48649,12 +48495,22 @@
 	},
 /area/almayer/medical/containment/cell)
 "maa" = (
-/obj/structure/closet/emcloset,
+/obj/structure/machinery/light{
+	dir = 4
+	},
+/obj/structure/surface/table/almayer,
+/obj/structure/machinery/computer/sentencing{
+	dir = 8
+	},
+/obj/structure/sign/safety/terminal{
+	pixel_x = 32;
+	pixel_y = -8
+	},
 /turf/open/floor/almayer{
-	dir = 10;
+	dir = 4;
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/general_equipment)
+/area/almayer/shipboard/brig/perma)
 "mab" = (
 /turf/open/floor/almayer/research/containment/entrance{
 	dir = 4
@@ -48750,21 +48606,20 @@
 	},
 /area/almayer/squads/alpha)
 "mdJ" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 10
-	},
-/turf/open/floor/almayer,
-/area/almayer/shipboard/brig/perma)
-"mdS" = (
-/obj/structure/sign/safety/ammunition{
-	pixel_x = 32;
-	pixel_y = 7
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/almayer{
-	dir = 4;
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/main_office)
+/area/almayer/shipboard/brig/processing)
+"mdS" = (
+/obj/structure/closet/secure_closet/brig,
+/turf/open/floor/almayer{
+	dir = 8;
+	icon_state = "redcorner"
+	},
+/area/almayer/shipboard/brig/processing)
 "meu" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -49509,8 +49364,7 @@
 "myT" = (
 /obj/structure/closet/firecloset,
 /obj/effect/decal/warning_stripes{
-	icon_state = "NE-out";
-	pixel_y = 1
+	icon_state = "NE-out"
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/upper_hull/u_f_s)
@@ -49581,29 +49435,21 @@
 /turf/open/floor/almayer,
 /area/almayer/lifeboat_pumps/south1)
 "mAr" = (
-/obj/structure/closet/secure_closet/guncabinet/riot_control,
-/obj/item/weapon/shield/riot,
-/obj/item/weapon/shield/riot,
-/obj/item/weapon/shield/riot,
-/obj/effect/decal/warning_stripes{
-	icon_state = "S"
+/obj/structure/surface/table/almayer,
+/obj/item/storage/box/tapes{
+	pixel_x = 7;
+	pixel_y = 6
+	},
+/obj/item/storage/box/tapes{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/item/storage/box/tapes{
+	pixel_x = 1;
+	pixel_y = 1
 	},
 /turf/open/floor/plating/almayer,
-/area/almayer/shipboard/brig/armory)
-"mAT" = (
-/obj/structure/machinery/door/poddoor/shutters/almayer{
-	dir = 8;
-	id = "bot_armory";
-	name = "\improper Armory Shutters"
-	},
-/obj/structure/machinery/door/firedoor/border_only/almayer,
-/obj/structure/machinery/door/airlock/almayer/security/glass/reinforced{
-	name = "\improper Armory"
-	},
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/shipboard/brig/armory)
+/area/almayer/shipboard/brig/evidence_storage)
 "mAV" = (
 /obj/structure/machinery/cryopod,
 /turf/open/floor/almayer{
@@ -49784,11 +49630,15 @@
 /turf/open/floor/almayer,
 /area/almayer/command/cichallway)
 "mGn" = (
-/obj/structure/machinery/cm_vending/clothing/military_police_warden,
-/turf/open/floor/almayer{
-	icon_state = "plate"
+/obj/structure/bed/chair,
+/obj/structure/machinery/cm_vending/sorted/medical/wall_med{
+	pixel_y = 25
 	},
-/area/almayer/shipboard/brig/main_office)
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/processing)
 "mGL" = (
 /turf/open/floor/almayer{
 	icon_state = "plate"
@@ -49971,14 +49821,8 @@
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "N";
-	pixel_y = 1
-	},
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/shipboard/brig/cryo)
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/brig/main_office)
 "mKq" = (
 /turf/closed/wall/almayer/reinforced,
 /area/almayer/living/bridgebunks)
@@ -50089,13 +49933,10 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/squads/alpha)
 "mLI" = (
-/obj/structure/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/almayer{
-	allow_construction = 0
-	},
-/area/almayer/shipboard/brig/perma)
+/obj/structure/bed,
+/obj/item/bedsheet/red,
+/turf/open/floor/wood/ship,
+/area/almayer/shipboard/brig/chief_mp_office)
 "mLJ" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -50468,10 +50309,12 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/engineering/lower_engineering)
 "mVi" = (
+/obj/structure/machinery/power/apc/almayer,
 /turf/open/floor/almayer{
-	icon_state = "red"
+	dir = 10;
+	icon_state = "orange"
 	},
-/area/almayer/shipboard/brig/cryo)
+/area/almayer/shipboard/brig/main_office)
 "mVE" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "NW-out";
@@ -50499,13 +50342,14 @@
 	dir = 8;
 	name = "ship-grade camera"
 	},
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 30
+/obj/structure/machinery/cryopod/right,
+/obj/structure/sign/safety/cryo{
+	pixel_x = 32
 	},
 /turf/open/floor/almayer{
-	icon_state = "red"
+	icon_state = "cargo"
 	},
-/area/almayer/shipboard/brig/general_equipment)
+/area/almayer/shipboard/brig/cryo)
 "mWw" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
@@ -51146,10 +50990,14 @@
 	},
 /area/almayer/living/briefing)
 "nlH" = (
-/turf/open/floor/almayer{
-	dir = 4;
-	icon_state = "red"
+/obj/structure/machinery/door/window/brigdoor/southright{
+	id = "Cell 6";
+	name = "Cell 6"
 	},
+/obj/structure/sign/safety/six{
+	pixel_x = -17
+	},
+/turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/cells)
 "nlV" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer{
@@ -51260,16 +51108,11 @@
 /turf/open/floor/almayer,
 /area/almayer/squads/alpha_bravo_shared)
 "nnz" = (
-/obj/structure/sign/safety/maint{
-	pixel_x = 32;
-	pixel_y = -8
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
 	},
-/obj/structure/sign/safety/firingrange{
-	pixel_x = 32;
-	pixel_y = 4
-	},
-/turf/open/floor/almayer,
-/area/almayer/shipboard/brig/perma)
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/brig/chief_mp_office)
 "nnD" = (
 /obj/effect/step_trigger/teleporter_vector{
 	name = "Almayer_Down4";
@@ -51306,15 +51149,11 @@
 	},
 /area/almayer/squads/req)
 "noo" = (
-/obj/structure/window/framed/almayer,
-/obj/structure/machinery/door/poddoor/shutters/almayer{
-	dir = 8;
-	id = "bot_armory";
-	name = "\improper Armory Shutters"
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_y = 26
 	},
-/obj/structure/machinery/door/firedoor/border_only/almayer,
-/turf/open/floor/plating,
-/area/almayer/shipboard/brig/armory)
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/brig/general_equipment)
 "nos" = (
 /turf/closed/wall/almayer/research/containment/wall/corner{
 	dir = 1
@@ -51363,16 +51202,6 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/lifeboat_pumps/north2)
-"nqZ" = (
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 30;
-	pixel_y = -6
-	},
-/turf/open/floor/almayer{
-	dir = 4;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/perma)
 "nrt" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
@@ -51460,19 +51289,11 @@
 	},
 /area/almayer/squads/req)
 "ntm" = (
-/obj/structure/sign/safety/maint{
-	pixel_x = -17;
-	pixel_y = -8
+/turf/open/floor/almayer{
+	dir = 8;
+	icon_state = "red"
 	},
-/obj/structure/machinery/door_control{
-	id = "CMP Office Shutters";
-	name = "CMP Office Shutters";
-	pixel_x = -24;
-	pixel_y = 8;
-	req_one_access_txt = "24;31"
-	},
-/turf/open/floor/almayer,
-/area/almayer/shipboard/brig/main_office)
+/area/almayer/shipboard/brig/perma)
 "ntr" = (
 /obj/structure/machinery/portable_atmospherics/hydroponics,
 /obj/item/seeds/goldappleseed,
@@ -51493,11 +51314,14 @@
 	},
 /area/almayer/hallways/vehiclehangar)
 "ntu" = (
-/obj/structure/machinery/light/small{
-	dir = 8
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
 	},
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/shipboard/brig/cells)
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/shipboard/brig/perma)
 "ntx" = (
 /obj/structure/machinery/door/airlock/almayer/generic{
 	id = "Alpha_2";
@@ -51686,17 +51510,16 @@
 	},
 /area/almayer/squads/req)
 "nxq" = (
-/obj/structure/machinery/door/airlock/almayer/security/glass/reinforced{
-	dir = 1;
-	name = "\improper Warden Office"
+/obj/structure/machinery/door/firedoor/border_only/almayer{
+	dir = 8
 	},
-/obj/structure/machinery/door/poddoor/shutters/almayer/open{
-	dir = 2;
-	id = "Warden Office Shutters";
-	name = "\improper Privacy Shutters"
+/obj/structure/machinery/door/airlock/almayer/security/reinforced{
+	name = "\improper Chief MP's Bedroom"
 	},
-/turf/open/floor/plating,
-/area/almayer/shipboard/brig/main_office)
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/shipboard/brig/chief_mp_office)
 "nxK" = (
 /obj/structure/sign/safety/high_voltage{
 	pixel_y = -32
@@ -51805,11 +51628,15 @@
 	},
 /area/almayer/squads/alpha_bravo_shared)
 "nBb" = (
-/turf/open/floor/almayer{
-	dir = 5;
-	icon_state = "red"
+/obj/structure/surface/table/almayer,
+/obj/item/storage/fancy/cigarettes/lucky_strikes,
+/obj/item/tool/lighter,
+/obj/item/clothing/glasses/sunglasses/blindfold,
+/obj/structure/machinery/light/small{
+	dir = 8
 	},
-/area/almayer/shipboard/brig/main_office)
+/turf/open/floor/almayer,
+/area/almayer/shipboard/brig/execution)
 "nBc" = (
 /obj/structure/largecrate/random,
 /turf/open/floor/almayer{
@@ -51817,28 +51644,30 @@
 	},
 /area/almayer/hull/upper_hull/u_f_s)
 "nBo" = (
+/obj/structure/machinery/door/firedoor/border_only/almayer,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
 	},
-/turf/open/floor/almayer,
-/area/almayer/shipboard/brig/general_equipment)
+/obj/structure/machinery/door/airlock/multi_tile/almayer/secdoor/glass/reinforced{
+	dir = 2;
+	name = "Brig";
+	req_one_access_txt = "1;3";
+	req_access = null
+	},
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/shipboard/brig/main_office)
 "nBu" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 1
 	},
-/obj/structure/sign/safety/restrictedarea{
-	pixel_x = -17;
-	pixel_y = -8
-	},
-/turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/perma)
+/turf/open/floor/almayer,
+/area/almayer/shipboard/brig/processing)
 "nBw" = (
 /turf/open/floor/almayer{
 	dir = 1;
@@ -52115,9 +51944,10 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
+	dir = 6;
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/main_office)
+/area/almayer/shipboard/brig/perma)
 "nHF" = (
 /turf/open/floor/plating,
 /area/almayer/hull/lower_hull/l_m_s)
@@ -52131,17 +51961,12 @@
 	},
 /area/almayer/living/cryo_cells)
 "nHV" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/machinery/light{
-	dir = 1
-	},
+/obj/structure/pipes/standard/manifold/hidden/supply,
 /turf/open/floor/almayer{
 	dir = 1;
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/general_equipment)
+/area/almayer/shipboard/brig/main_office)
 "nIj" = (
 /turf/open/floor/almayer{
 	icon_state = "green"
@@ -52193,11 +52018,6 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/living/basketball)
-"nJo" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/pipes/standard/simple/hidden/supply,
-/turf/open/floor/almayer,
-/area/almayer/shipboard/brig/main_office)
 "nJs" = (
 /obj/structure/largecrate/random/case,
 /turf/open/floor/almayer{
@@ -52301,11 +52121,12 @@
 	},
 /area/almayer/living/briefing)
 "nMu" = (
+/obj/structure/closet/emcloset,
 /turf/open/floor/almayer{
 	dir = 9;
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/general_equipment)
+/area/almayer/shipboard/brig/main_office)
 "nMz" = (
 /obj/structure/sign/safety/cryo{
 	pixel_x = 35
@@ -52356,15 +52177,11 @@
 	},
 /area/almayer/living/briefing)
 "nNQ" = (
-/obj/structure/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
+/obj/structure/bed/chair/comfy/orange{
+	dir = 8
 	},
-/turf/open/floor/almayer{
-	dir = 4;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/main_office)
+/turf/open/floor/almayer,
+/area/almayer/shipboard/brig/chief_mp_office)
 "nNT" = (
 /obj/structure/pipes/vents/pump,
 /obj/structure/mirror{
@@ -52410,17 +52227,9 @@
 	},
 /area/almayer/engineering/upper_engineering)
 "nOe" = (
-/obj/structure/window/framed/almayer/hull/hijack_bustable,
-/obj/structure/machinery/door/poddoor/almayer/open{
-	dir = 4;
-	id = "perma_lockdown";
-	name = "\improper Perma Lockdown Shutter"
-	},
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/almayer/shipboard/brig/perma)
+/obj/structure/closet/secure_closet/warden,
+/turf/open/floor/wood/ship,
+/area/almayer/shipboard/brig/chief_mp_office)
 "nOG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -52549,12 +52358,20 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/command/telecomms)
 "nSM" = (
-/obj/structure/surface/table/almayer,
-/obj/item/device/taperecorder,
+/obj/structure/closet/secure_closet/guncabinet/red,
+/obj/item/weapon/gun/rifle/m4ra,
+/obj/item/weapon/gun/rifle/m4ra,
+/obj/item/ammo_magazine/rifle/m4ra,
+/obj/item/ammo_magazine/rifle/m4ra,
+/obj/item/ammo_magazine/rifle/m4ra,
+/obj/item/ammo_magazine/rifle/m4ra,
+/obj/item/ammo_magazine/rifle/m4ra,
+/obj/item/ammo_magazine/rifle/m4ra,
 /turf/open/floor/almayer{
-	icon_state = "plate"
+	dir = 4;
+	icon_state = "plating_striped"
 	},
-/area/almayer/shipboard/brig/main_office)
+/area/almayer/shipboard/brig/armory)
 "nSU" = (
 /obj/structure/machinery/vending/snack{
 	density = 0;
@@ -53160,19 +52977,14 @@
 	},
 /area/space)
 "okM" = (
-/obj/structure/machinery/door/airlock/almayer/security/glass{
-	name = "\improper Execution Room"
+/obj/structure/window/framed/almayer,
+/obj/structure/machinery/door/poddoor/almayer/locked{
+	dir = 2;
+	id = "Perma 2L";
+	name = "\improper cell shutter"
 	},
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 8
-	},
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/shipboard/brig/execution)
+/turf/open/floor/plating,
+/area/almayer/shipboard/brig/perma)
 "olk" = (
 /obj/structure/machinery/door/airlock/almayer/generic{
 	name = "\improper Bathroom"
@@ -53185,22 +52997,17 @@
 	},
 /area/almayer/engineering/upper_engineering/port)
 "olv" = (
-/obj/structure/surface/table/almayer,
-/obj/item/tool/hand_labeler{
-	pixel_x = -8;
-	pixel_y = 3
+/obj/structure/machinery/cm_vending/sorted/marine_food,
+/obj/structure/sign/safety/security{
+	pixel_x = 32;
+	pixel_y = -8
 	},
-/obj/item/storage/box/evidence{
-	pixel_x = 7;
-	pixel_y = 6
-	},
-/obj/item/storage/box/evidence{
-	pixel_x = 1;
-	pixel_y = 1
+/obj/structure/sign/safety/restrictedarea{
+	pixel_x = 32;
+	pixel_y = 7
 	},
 /turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "red"
+	icon_state = "plate"
 	},
 /area/almayer/shipboard/brig/general_equipment)
 "olM" = (
@@ -53254,21 +53061,15 @@
 /turf/open/floor/wood/ship,
 /area/almayer/shipboard/brig/cells)
 "omu" = (
-/obj/structure/closet/secure_closet/guncabinet/red,
-/obj/item/ammo_magazine/shotgun,
-/obj/item/ammo_magazine/shotgun,
-/obj/item/ammo_magazine/shotgun,
-/obj/item/ammo_magazine/shotgun/buckshot,
-/obj/item/ammo_magazine/shotgun/buckshot,
-/obj/item/ammo_magazine/shotgun/buckshot,
-/obj/item/weapon/gun/shotgun/combat,
-/obj/item/weapon/gun/shotgun/combat,
-/obj/item/weapon/gun/shotgun/combat,
-/obj/effect/decal/warning_stripes{
-	icon_state = "S"
+/obj/structure/machinery/cm_vending/sorted/medical/wall_med{
+	pixel_y = 25
 	},
-/turf/open/floor/plating/almayer,
-/area/almayer/shipboard/brig/armory)
+/obj/structure/machinery/light{
+	dir = 1
+	},
+/obj/structure/bed/chair,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/brig/general_equipment)
 "omy" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -53355,24 +53156,21 @@
 	},
 /area/almayer/medical/lower_medical_medbay)
 "ooR" = (
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 1
 	},
-/obj/structure/machinery/door/poddoor/almayer/open{
-	id = "perma_lockdown";
-	name = "\improper Perma Lockdown Shutter"
+/obj/structure/machinery/door/airlock/almayer/security/glass/reinforced{
+	dir = 1;
+	name = "\improper Brig"
 	},
-/obj/structure/machinery/door/airlock/multi_tile/almayer/secdoor/reinforced{
-	name = "\improper Perma Cells"
+/obj/structure/machinery/door/firedoor/border_only/almayer{
+	dir = 2
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/processing)
 "opj" = (
 /obj/structure/surface/table/almayer,
 /obj/effect/spawner/random/powercell,
@@ -53585,20 +53383,11 @@
 	},
 /area/almayer/hull/lower_hull/l_a_p)
 "osJ" = (
-/obj/structure/surface/table/almayer,
-/obj/item/folder/white{
-	pixel_x = 5;
-	pixel_y = 5
+/obj/structure/bed,
+/turf/open/floor/almayer{
+	icon_state = "plate"
 	},
-/obj/item/paper,
-/obj/item/handcuffs,
-/obj/item/clothing/mask/cigarette/cigar/classic,
-/obj/item/coin/silver{
-	desc = "A small coin, bearing the falling falcons insignia.";
-	name = "falling falcons challenge coin"
-	},
-/turf/open/floor/wood/ship,
-/area/almayer/shipboard/brig/chief_mp_office)
+/area/almayer/shipboard/brig/perma)
 "osT" = (
 /obj/structure/surface/table/reinforced/almayer_B,
 /obj/structure/prop/ice_colony/hula_girl{
@@ -53653,15 +53442,17 @@
 	},
 /area/almayer/lifeboat_pumps/south1)
 "ouV" = (
-/obj/structure/sign/safety/cryo{
-	pixel_x = 1;
-	pixel_y = 26
+/obj/structure/machinery/light{
+	dir = 1
+	},
+/obj/structure/machinery/flasher{
+	id = "Perma 1";
+	pixel_y = 24
 	},
 /turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "red"
+	icon_state = "plate"
 	},
-/area/almayer/shipboard/brig/main_office)
+/area/almayer/shipboard/brig/perma)
 "ouW" = (
 /obj/structure/sign/safety/storage{
 	pixel_x = 8;
@@ -53763,13 +53554,22 @@
 /turf/open/floor/almayer,
 /area/almayer/living/cafeteria_officer)
 "oxn" = (
-/obj/structure/pipes/vents/pump{
-	dir = 1
+/obj/structure/machinery/door/firedoor/border_only/almayer,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/machinery/door/poddoor/almayer/open{
+	id = "perma_lockdown";
+	name = "\improper Perma Lockdown Shutter";
+	dir = 4
 	},
 /turf/open/floor/almayer{
-	icon_state = "red"
+	icon_state = "test_floor4"
 	},
-/area/almayer/shipboard/brig/chief_mp_office)
+/area/almayer/shipboard/brig/perma)
 "oxp" = (
 /obj/structure/largecrate/random/case,
 /turf/open/floor/almayer{
@@ -53954,11 +53754,11 @@
 /turf/open/floor/almayer,
 /area/almayer/command/lifeboat)
 "oCX" = (
+/obj/structure/machinery/power/apc/almayer,
 /turf/open/floor/almayer{
-	dir = 6;
-	icon_state = "red"
+	icon_state = "orange"
 	},
-/area/almayer/shipboard/brig/cryo)
+/area/almayer/shipboard/brig/surgery)
 "oDf" = (
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_m_p)
@@ -54174,15 +53974,11 @@
 	},
 /area/almayer/engineering/laundry)
 "oIc" = (
-/obj/structure/machinery/power/apc/almayer{
-	dir = 4
-	},
-/obj/structure/machinery/light/small,
+/obj/structure/machinery/cryopod/right,
 /turf/open/floor/almayer{
-	dir = 6;
-	icon_state = "orange"
+	icon_state = "cargo"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/cryo)
 "oIn" = (
 /obj/structure/bed/chair{
 	dir = 8;
@@ -54710,16 +54506,15 @@
 /turf/open/floor/almayer,
 /area/almayer/lifeboat_pumps/south1)
 "oWI" = (
-/obj/structure/machinery/cryopod/right{
-	pixel_y = 6
-	},
 /obj/structure/sign/safety/cryo{
 	pixel_x = 32
 	},
+/obj/structure/closet/toolcloset,
 /turf/open/floor/almayer{
-	icon_state = "cargo"
+	dir = 6;
+	icon_state = "orange"
 	},
-/area/almayer/shipboard/brig/cryo)
+/area/almayer/shipboard/brig/main_office)
 "oWX" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/generic{
 	dir = 1;
@@ -54830,12 +54625,15 @@
 	},
 /area/almayer/medical/lower_medical_medbay)
 "paq" = (
-/obj/structure/surface/table/almayer,
-/obj/structure/machinery/faxmachine/uscm/brig,
-/turf/open/floor/almayer{
-	icon_state = "plate"
+/obj/structure/sign/safety/three{
+	pixel_x = -17
 	},
-/area/almayer/shipboard/brig/main_office)
+/obj/structure/machinery/door/window/brigdoor/southright{
+	id = "Cell 3";
+	name = "Cell 3"
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/brig/cells)
 "paL" = (
 /turf/open/floor/almayer/uscm/directional{
 	dir = 1
@@ -54846,17 +54644,9 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/living/offices)
 "pbh" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/pipes/standard/simple/hidden/supply,
-/obj/structure/closet/secure_closet/warden,
-/obj/structure/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/almayer{
-	dir = 5;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/main_office)
+/obj/structure/machinery/photocopier,
+/turf/open/floor/plating/almayer,
+/area/almayer/shipboard/brig/evidence_storage)
 "pbp" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer{
@@ -54873,10 +54663,14 @@
 	},
 /area/almayer/command/cic)
 "pbC" = (
-/obj/item/bedsheet/red,
-/obj/structure/bed,
-/turf/open/floor/wood/ship,
-/area/almayer/shipboard/brig/chief_mp_office)
+/obj/structure/machinery/cryopod/right{
+	layer = 3.1;
+	pixel_y = 13
+	},
+/turf/open/floor/almayer{
+	icon_state = "cargo"
+	},
+/area/almayer/shipboard/brig/cryo)
 "pbV" = (
 /turf/open/floor/almayer{
 	dir = 1;
@@ -54951,6 +54745,12 @@
 /obj/structure/machinery/light{
 	dir = 1
 	},
+/obj/structure/transmitter{
+	name = "Brig Offices Telephone";
+	phone_category = "Almayer";
+	phone_id = "Brig Main Offices";
+	pixel_y = 32
+	},
 /turf/open/floor/almayer{
 	dir = 1;
 	icon_state = "red"
@@ -54978,17 +54778,25 @@
 	},
 /area/almayer/living/grunt_rnr)
 "pdG" = (
-/obj/structure/machinery/door/airlock/almayer/security{
-	dir = 2;
-	name = "\improper Chief MP's Bedroom"
-	},
 /obj/structure/machinery/door/firedoor/border_only/almayer{
 	dir = 1
+	},
+/obj/structure/machinery/door/poddoor/almayer/open{
+	id = "Brig Lockdown Shutters";
+	name = "\improper Brig Lockdown Shutter"
+	},
+/obj/structure/machinery/door/airlock/almayer/security/glass/reinforced{
+	dir = 1;
+	name = "\improper Brig"
+	},
+/obj/structure/machinery/door/poddoor/almayer/open{
+	id = "perma_lockdown";
+	name = "\improper Perma Lockdown Shutter"
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
 	},
-/area/almayer/shipboard/brig/chief_mp_office)
+/area/almayer/shipboard/brig/cells)
 "pef" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer,
 /obj/structure/sign/safety/maint{
@@ -55210,21 +55018,12 @@
 	},
 /area/almayer/shipboard/brig/surgery)
 "plZ" = (
-/obj/structure/machinery/door/firedoor/border_only/almayer,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/machinery/door/airlock/multi_tile/almayer/secdoor/glass/reinforced{
-	dir = 2;
-	name = "Brig";
-	req_access = null;
-	req_one_access_txt = "1;3"
-	},
+/obj/structure/pipes/standard/manifold/hidden/supply,
 /turf/open/floor/almayer{
-	icon_state = "test_floor4"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/brig/main_office)
 "pmk" = (
@@ -55295,17 +55094,17 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_f_s)
 "poZ" = (
-/obj/structure/machinery/light{
-	unacidable = 1;
-	unslashable = 1
+/obj/structure/window/framed/almayer/hull/hijack_bustable,
+/obj/structure/machinery/door/poddoor/shutters/almayer/open{
+	dir = 4;
+	id = "Warden Office Shutters";
+	name = "\improper Privacy Shutters"
 	},
-/obj/structure/bed/chair/bolted{
-	dir = 4
+/obj/structure/machinery/door/firedoor/border_only/almayer{
+	dir = 8
 	},
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/shipboard/brig/perma)
+/turf/open/floor/plating,
+/area/almayer/shipboard/brig/cells)
 "ppc" = (
 /obj/structure/largecrate/supply/generator,
 /obj/structure/machinery/light/small{
@@ -55584,12 +55383,12 @@
 	},
 /area/almayer/shipboard/starboard_missiles)
 "pwt" = (
-/obj/structure/machinery/cm_vending/sorted/medical/wall_med{
-	pixel_y = -25
+/obj/structure/sign/safety/restrictedarea{
+	pixel_x = -17;
+	pixel_y = 7
 	},
 /turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "redcorner"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/brig/processing)
 "pwG" = (
@@ -55730,12 +55529,16 @@
 	},
 /area/almayer/shipboard/weapon_room)
 "pzc" = (
-/obj/structure/pipes/vents/pump,
-/obj/structure/bed/chair{
-	dir = 1
+/obj/structure/sign/safety/restrictedarea{
+	pixel_x = 32;
+	pixel_y = 7
+	},
+/obj/structure/sign/safety/storage{
+	pixel_x = 32;
+	pixel_y = -8
 	},
 /turf/open/floor/almayer{
-	dir = 1;
+	dir = 4;
 	icon_state = "red"
 	},
 /area/almayer/shipboard/brig/main_office)
@@ -55981,19 +55784,11 @@
 	},
 /area/almayer/shipboard/brig/lobby)
 "pFg" = (
-/obj/structure/window/framed/almayer/hull/hijack_bustable,
-/obj/structure/machinery/door/poddoor/almayer/locked{
-	dir = 8;
-	id = "Perma 1";
-	name = "\improper isolation shutter"
+/turf/open/floor/almayer{
+	dir = 6;
+	icon_state = "red"
 	},
-/obj/structure/machinery/door/poddoor/almayer/open{
-	dir = 4;
-	id = "courtyard_cells";
-	name = "\improper Courtyard Lockdown Shutter"
-	},
-/turf/open/floor/plating,
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/main_office)
 "pFA" = (
 /obj/structure/pipes/standard/simple/visible{
 	dir = 4
@@ -56016,21 +55811,21 @@
 	},
 /area/almayer/hull/lower_hull/l_a_p)
 "pGG" = (
-/obj/structure/surface/table/almayer,
-/obj/item/storage/fancy/cigarettes/lucky_strikes,
-/obj/item/tool/lighter,
-/obj/item/clothing/glasses/sunglasses/blindfold,
 /obj/structure/machinery/firealarm{
 	pixel_y = 28
 	},
-/obj/structure/machinery/door_control{
-	id = "Execution Shutters";
-	name = "Privacy Shutters";
-	pixel_y = 12;
-	req_access_txt = "3"
+/obj/structure/surface/table/almayer,
+/obj/structure/machinery/computer/cameras/almayer_network{
+	dir = 4
 	},
-/turf/open/floor/almayer,
-/area/almayer/shipboard/brig/execution)
+/obj/structure/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/chief_mp_office)
 "pGK" = (
 /obj/structure/machinery/flasher{
 	alpha = 1;
@@ -56121,17 +55916,27 @@
 /turf/open/floor/plating/almayer,
 /area/almayer/hull/lower_hull/l_a_s)
 "pIH" = (
-/obj/structure/machinery/door_control{
-	id = "perma_exit";
-	name = "\improper Exit Shutters";
-	pixel_y = -22;
-	req_access_txt = "3"
+/obj/structure/machinery/door/airlock/almayer/security/glass{
+	name = "\improper Chief MP's Office"
+	},
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/machinery/door/firedoor/border_only/almayer{
+	dir = 8
+	},
+/obj/structure/machinery/door/poddoor/shutters/almayer/open{
+	dir = 4;
+	id = "CMP Office Shutters";
+	name = "\improper Privacy Shutters"
+	},
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
 	},
 /turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "redcorner"
+	icon_state = "test_floor4"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/chief_mp_office)
 "pIU" = (
 /obj/structure/pipes/standard/manifold/hidden/supply{
 	dir = 4
@@ -56162,33 +55967,35 @@
 	},
 /area/almayer/living/grunt_rnr)
 "pJi" = (
-/obj/structure/closet/firecloset,
-/turf/open/floor/almayer{
-	dir = 6;
-	icon_state = "red"
+/obj/structure/window/reinforced/ultra{
+	pixel_y = -12
 	},
-/area/almayer/shipboard/brig/general_equipment)
-"pJE" = (
-/obj/structure/closet/secure_closet{
-	name = "\improper Execution Firearms"
-	},
-/obj/item/ammo_magazine/rifle/m4ra,
-/obj/item/ammo_magazine/rifle/m4ra,
-/obj/item/ammo_magazine/rifle/m4ra,
-/obj/item/ammo_magazine/rifle/m4ra,
-/obj/item/ammo_magazine/rifle/m4ra,
-/obj/item/ammo_magazine/rifle/m4ra,
-/obj/item/weapon/gun/rifle/m4ra,
-/obj/item/weapon/gun/rifle/m4ra,
-/obj/item/weapon/gun/rifle/m4ra,
-/obj/structure/machinery/light/small{
-	dir = 1
+/obj/structure/bed/chair/bolted,
+/obj/structure/machinery/status_display{
+	pixel_y = 30
 	},
 /turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "redcorner"
+	icon_state = "plating_striped"
 	},
 /area/almayer/shipboard/brig/execution)
+"pJE" = (
+/obj/structure/surface/table/almayer,
+/obj/item/folder/white{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/paper,
+/obj/item/handcuffs,
+/obj/item/clothing/mask/cigarette/cigar/classic,
+/obj/item/coin/silver{
+	desc = "A small coin, bearing the falling falcons insignia.";
+	name = "falling falcons challenge coin"
+	},
+/obj/structure/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/wood/ship,
+/area/almayer/shipboard/brig/chief_mp_office)
 "pJJ" = (
 /turf/open/floor/almayer{
 	dir = 1;
@@ -56717,18 +56524,6 @@
 	icon_state = "green"
 	},
 /area/almayer/squads/req)
-"pWG" = (
-/obj/structure/bed/chair{
-	dir = 1
-	},
-/obj/structure/machinery/light{
-	unacidable = 1;
-	unslashable = 1
-	},
-/turf/open/floor/almayer{
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/main_office)
 "pWN" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer,
@@ -56829,9 +56624,6 @@
 /turf/open/floor/almayer,
 /area/almayer/lifeboat_pumps/north1)
 "pYF" = (
-/obj/structure/bed/chair{
-	dir = 1
-	},
 /obj/structure/machinery/camera/autoname/almayer{
 	dir = 1;
 	name = "ship-grade camera"
@@ -56866,31 +56658,20 @@
 	},
 /area/almayer/shipboard/brig/cic_hallway)
 "pZV" = (
-/obj/structure/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/turf/open/floor/almayer{
+	allow_construction = 0
 	},
-/obj/structure/machinery/status_display{
-	pixel_x = 32
+/area/almayer/shipboard/brig/main_office)
+"qau" = (
+/obj/structure/machinery/power/apc/almayer,
+/obj/structure/machinery/light{
+	unacidable = 1;
+	unslashable = 1
 	},
 /turf/open/floor/almayer{
-	dir = 5;
-	icon_state = "red"
+	icon_state = "orange"
 	},
 /area/almayer/shipboard/brig/perma)
-"qau" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "N";
-	pixel_y = 1
-	},
-/obj/effect/landmark/start/warrant,
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/shipboard/brig/cryo)
 "qaD" = (
 /obj/structure/largecrate/random/case/double,
 /turf/open/floor/almayer{
@@ -57114,14 +56895,12 @@
 	},
 /area/almayer/command/cichallway)
 "qfR" = (
-/obj/structure/machinery/light{
-	dir = 1
+/obj/structure/bed/chair{
+	can_buckle = 0;
+	dir = 4
 	},
-/turf/open/floor/almayer{
-	dir = 9;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/main_office)
+/turf/open/floor/almayer,
+/area/almayer/shipboard/brig/perma)
 "qga" = (
 /obj/structure/machinery/space_heater,
 /obj/structure/sign/safety/maint{
@@ -57359,30 +57138,24 @@
 	},
 /area/almayer/shipboard/brig/main_office)
 "qmE" = (
-/obj/structure/sign/safety/restrictedarea{
-	pixel_x = 32;
-	pixel_y = -8
-	},
-/obj/structure/machinery/door_control{
-	id = "perma_lockdown";
-	name = "\improper Perma Cells Lockdown";
-	pixel_x = 24;
-	pixel_y = 6;
-	req_access_txt = "3"
+/obj/structure/machinery/camera/autoname/almayer{
+	dir = 8;
+	name = "ship-grade camera"
 	},
 /turf/open/floor/almayer{
 	dir = 4;
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/processing)
 "qmX" = (
-/obj/structure/toilet{
-	dir = 1
-	},
+/obj/structure/surface/table/almayer,
+/obj/item/device/camera,
+/obj/item/device/camera_film,
 /turf/open/floor/almayer{
-	icon_state = "plate"
+	dir = 8;
+	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/main_office)
 "qnh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -57435,14 +57208,18 @@
 	},
 /area/almayer/hull/lower_hull/l_a_s)
 "qof" = (
-/obj/structure/window/framed/almayer,
-/obj/structure/machinery/door/poddoor/shutters/almayer/open{
-	dir = 8;
-	id = "Warden Office Shutters";
-	name = "\improper Privacy Shutters"
+/obj/structure/machinery/door_control{
+	id = "perma_lockdown";
+	name = "\improper Perma Cells Lockdown";
+	pixel_x = -24;
+	pixel_y = 6;
+	req_access_txt = "3"
 	},
-/turf/open/floor/plating,
-/area/almayer/shipboard/brig/main_office)
+/turf/open/floor/almayer{
+	dir = 8;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/perma)
 "qom" = (
 /obj/structure/surface/table/reinforced/almayer_B,
 /obj/structure/machinery/chem_dispenser/soda{
@@ -57559,14 +57336,10 @@
 	},
 /area/almayer/medical/lower_medical_medbay)
 "qqN" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
 /turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "red"
+	icon_state = "plate"
 	},
-/area/almayer/shipboard/brig/main_office)
+/area/almayer/shipboard/brig/cells)
 "qqQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -57594,11 +57367,15 @@
 /obj/structure/machinery/status_display{
 	pixel_x = 32
 	},
+/obj/structure/surface/table/almayer,
+/obj/structure/machinery/computer/secure_data{
+	dir = 8
+	},
 /turf/open/floor/almayer{
-	dir = 4;
+	dir = 5;
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/main_office)
+/area/almayer/shipboard/brig/perma)
 "qrv" = (
 /turf/open/floor/almayer{
 	icon_state = "silver"
@@ -57719,13 +57496,11 @@
 	},
 /area/almayer/living/grunt_rnr)
 "qvf" = (
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 2
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
 	},
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/shipboard/brig/cryo)
+/turf/open/floor/almayer,
+/area/almayer/shipboard/brig/execution)
 "qvC" = (
 /obj/structure/machinery/power/apc/almayer{
 	dir = 4
@@ -57817,10 +57592,20 @@
 /turf/open/floor/wood/ship,
 /area/almayer/medical/medical_science)
 "qyd" = (
-/turf/open/floor/almayer{
-	allow_construction = 0
+/obj/structure/machinery/door/poddoor/shutters/almayer/open{
+	dir = 2;
+	id = "Warden Office Shutters";
+	name = "\improper Privacy Shutters"
 	},
-/area/almayer/shipboard/brig/perma)
+/obj/structure/pipes/standard/simple/hidden/supply,
+/obj/structure/machinery/door/airlock/almayer/security/glass/reinforced{
+	dir = 1;
+	name = "\improper Warden's Office"
+	},
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/shipboard/brig/chief_mp_office)
 "qyi" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -58164,16 +57949,23 @@
 	},
 /area/almayer/lifeboat_pumps/south1)
 "qHF" = (
-/obj/structure/surface/table/almayer,
-/obj/item/storage/box/bodybags{
-	pixel_x = 6;
+/obj/structure/machinery/camera/autoname/almayer{
+	dir = 4;
+	name = "ship-grade camera"
+	},
+/obj/structure/sign/safety/medical{
+	pixel_x = -17;
 	pixel_y = 6
 	},
-/obj/item/storage/box/bodybags,
-/turf/open/floor/almayer{
-	icon_state = "redcorner"
+/obj/structure/sign/safety/restrictedarea{
+	pixel_x = -17;
+	pixel_y = -9
 	},
-/area/almayer/shipboard/brig/execution)
+/turf/open/floor/almayer{
+	dir = 8;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/lobby)
 "qHM" = (
 /obj/structure/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -58542,13 +58334,12 @@
 	},
 /area/almayer/lifeboat_pumps/south1)
 "qQM" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
 /obj/structure/machinery/light{
 	unacidable = 1;
 	unslashable = 1
 	},
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/reagent_container/spray/cleaner,
 /turf/open/floor/almayer{
 	icon_state = "sterile_green_side"
 	},
@@ -58586,29 +58377,26 @@
 /obj/structure/pipes/vents/pump{
 	dir = 8
 	},
-/turf/open/floor/almayer{
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/general_equipment)
-"qRT" = (
 /obj/effect/decal/warning_stripes{
-	icon_state = "SE-out";
+	icon_state = "E";
 	pixel_x = 1
 	},
+/obj/effect/landmark/start/police,
 /turf/open/floor/almayer,
-/area/almayer/shipboard/brig/execution)
-"qSl" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
+/area/almayer/shipboard/brig/cryo)
+"qRT" = (
+/obj/structure/surface/table/almayer,
+/obj/structure/machinery/computer/secure_data{
 	dir = 4
 	},
-/obj/structure/machinery/power/apc/almayer{
-	dir = 1
-	},
+/turf/open/floor/almayer,
+/area/almayer/shipboard/brig/chief_mp_office)
+"qSl" = (
 /turf/open/floor/almayer{
-	dir = 1;
+	dir = 8;
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/general_equipment)
+/area/almayer/shipboard/brig/processing)
 "qSm" = (
 /obj/structure/pipes/vents/pump{
 	dir = 4
@@ -58846,19 +58634,17 @@
 	},
 /area/almayer/command/lifeboat)
 "qYH" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "SW-out"
-	},
+/obj/structure/window/framed/almayer,
 /obj/structure/machinery/door/firedoor/border_only/almayer{
 	dir = 8
 	},
-/obj/structure/machinery/door/airlock/almayer/security/reinforced{
-	name = "\improper Execution Equipment"
+/obj/structure/machinery/door/poddoor/shutters/almayer/open{
+	dir = 4;
+	id = "CMP Office Shutters";
+	name = "\improper Privacy Shutters"
 	},
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/shipboard/brig/execution)
+/turf/open/floor/plating,
+/area/almayer/shipboard/brig/chief_mp_office)
 "qYN" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/pipes/standard/simple/hidden/supply{
@@ -58930,7 +58716,7 @@
 	pixel_x = -17
 	},
 /turf/open/floor/almayer{
-	dir = 8;
+	dir = 10;
 	icon_state = "red"
 	},
 /area/almayer/shipboard/brig/main_office)
@@ -59335,18 +59121,11 @@
 	},
 /area/almayer/engineering/upper_engineering)
 "rkh" = (
-/obj/structure/machinery/door/poddoor/almayer/locked{
-	dir = 8;
-	id = "Perma 1L";
-	name = "\improper cell shutter"
+/obj/structure/pipes/standard/manifold/hidden/supply{
+	dir = 8
 	},
-/obj/structure/machinery/door/airlock/almayer/security/glass/reinforced{
-	name = "\improper Isolation Cell"
-	},
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/shipboard/brig/perma)
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/brig/cryo)
 "rku" = (
 /obj/structure/surface/table/reinforced/almayer_B,
 /obj/item/tool/wrench{
@@ -59366,19 +59145,21 @@
 /turf/open/floor/almayer,
 /area/almayer/living/gym)
 "rkK" = (
+/obj/structure/machinery/power/apc/almayer{
+	dir = 1
+	},
 /turf/open/floor/almayer{
-	dir = 4;
-	icon_state = "redcorner"
+	dir = 1;
+	icon_state = "orange"
 	},
-/area/almayer/shipboard/brig/execution)
+/area/almayer/shipboard/brig/cells)
 "rkL" = (
-/obj/structure/window/framed/almayer,
-/obj/structure/machinery/door/poddoor/shutters/almayer/open{
-	dir = 2;
-	id = "Warden Office Shutters";
-	name = "\improper Privacy Shutters"
+/obj/structure/machinery/door/firedoor/border_only/almayer{
+	dir = 2
 	},
-/turf/open/floor/plating,
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
 /area/almayer/shipboard/brig/main_office)
 "rlf" = (
 /obj/structure/machinery/cm_vending/clothing/synth/snowflake,
@@ -59593,18 +59374,22 @@
 	},
 /area/almayer/squads/delta)
 "rra" = (
-/obj/structure/machinery/door/poddoor/almayer/locked{
-	dir = 8;
-	id = "Perma 2L";
-	name = "\improper cell shutter"
+/obj/structure/closet/secure_closet{
+	name = "\improper Execution Firearms"
 	},
-/obj/structure/machinery/door/airlock/almayer/security/glass/reinforced{
-	name = "\improper Isolation Cell"
-	},
+/obj/item/ammo_magazine/rifle/m4ra,
+/obj/item/ammo_magazine/rifle/m4ra,
+/obj/item/ammo_magazine/rifle/m4ra,
+/obj/item/ammo_magazine/rifle/m4ra,
+/obj/item/ammo_magazine/rifle/m4ra,
+/obj/item/ammo_magazine/rifle/m4ra,
+/obj/item/weapon/gun/rifle/m4ra,
+/obj/item/weapon/gun/rifle/m4ra,
+/obj/item/weapon/gun/rifle/m4ra,
 /turf/open/floor/almayer{
-	icon_state = "test_floor4"
+	icon_state = "plate"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/execution)
 "rri" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -59790,13 +59575,18 @@
 /turf/closed/wall/almayer/research/containment/wall/divide,
 /area/almayer/medical/containment/cell)
 "rvo" = (
-/obj/structure/machinery/power/apc/almayer{
-	dir = 4
+/obj/structure/surface/rack,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/glasses/sunglasses/blindfold,
+/obj/item/clothing/mask/muzzle,
+/obj/structure/machinery/camera/autoname/almayer{
+	dir = 8;
+	name = "ship-grade camera"
 	},
 /turf/open/floor/almayer{
-	icon_state = "orangecorner"
+	icon_state = "plate"
 	},
-/area/almayer/shipboard/brig/evidence_storage)
+/area/almayer/shipboard/brig/execution)
 "rvA" = (
 /turf/open/floor/almayer,
 /area/almayer/living/numbertwobunks)
@@ -59890,22 +59680,11 @@
 	},
 /area/almayer/command/cic)
 "rzj" = (
-/obj/structure/pipes/standard/simple/hidden/supply,
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 1
+/obj/structure/machinery/brig_cell/perma_1{
+	pixel_x = 32
 	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "NW-out"
-	},
-/obj/structure/machinery/door/airlock/multi_tile/almayer/secdoor/glass/reinforced{
-	name = "\improper Brig";
-	req_access = null;
-	req_one_access_txt = "1;3"
-	},
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/shipboard/brig/main_office)
+/turf/open/floor/almayer,
+/area/almayer/shipboard/brig/perma)
 "rzM" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 1
@@ -60741,27 +60520,30 @@
 /turf/open/floor/almayer,
 /area/almayer/lifeboat_pumps/south1)
 "rQY" = (
-/obj/structure/bed,
-/obj/structure/machinery/flasher{
-	id = "Cell 3";
-	pixel_x = 24
+/obj/structure/sign/safety/security{
+	pixel_x = 15;
+	pixel_y = 32
+	},
+/obj/structure/sign/safety/restrictedarea{
+	pixel_y = 32
 	},
 /turf/open/floor/almayer{
-	dir = 6;
+	dir = 1;
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/cells)
+/area/almayer/shipboard/brig/main_office)
 "rRq" = (
 /turf/closed/wall/almayer,
 /area/almayer/lifeboat_pumps/south2)
 "rRQ" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/pipes/standard/simple/hidden/supply,
+/obj/structure/flora/pottedplant{
+	icon_state = "pottedplant_18"
+	},
 /turf/open/floor/almayer{
-	dir = 4;
+	dir = 9;
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/main_office)
+/area/almayer/shipboard/brig/chief_mp_office)
 "rRU" = (
 /obj/structure/machinery/light{
 	dir = 8
@@ -60823,17 +60605,9 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/living/port_emb)
 "rSH" = (
-/obj/structure/machinery/power/apc/almayer{
-	dir = 8
-	},
-/obj/structure/surface/rack,
-/obj/effect/spawner/random/tool,
-/obj/effect/spawner/random/powercell,
-/turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "orange"
-	},
-/area/almayer/shipboard/brig/lobby)
+/obj/structure/pipes/vents/scrubber,
+/turf/open/floor/almayer,
+/area/almayer/shipboard/brig/general_equipment)
 "rSK" = (
 /obj/structure/machinery/light/small,
 /turf/open/floor/almayer{
@@ -60853,14 +60627,15 @@
 /turf/open/floor/almayer,
 /area/almayer/shipboard/brig/cic_hallway)
 "rTt" = (
+/obj/structure/sign/safety/maint{
+	pixel_x = -17;
+	pixel_y = -34
+	},
 /obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
+	dir = 9
 	},
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "redcorner"
-	},
-/area/almayer/shipboard/brig/chief_mp_office)
+/turf/open/floor/almayer,
+/area/almayer/shipboard/brig/perma)
 "rTB" = (
 /obj/structure/pipes/standard/manifold/hidden/supply{
 	dir = 4
@@ -61011,7 +60786,7 @@
 	dir = 4
 	},
 /turf/open/floor/almayer,
-/area/almayer/shipboard/brig/general_equipment)
+/area/almayer/shipboard/brig/main_office)
 "rXS" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer,
 /obj/structure/disposalpipe/segment{
@@ -61094,11 +60869,11 @@
 	},
 /area/almayer/shipboard/starboard_point_defense)
 "rZR" = (
+/obj/structure/machinery/cryopod,
 /turf/open/floor/almayer{
-	dir = 4;
-	icon_state = "red"
+	icon_state = "cargo"
 	},
-/area/almayer/shipboard/brig/general_equipment)
+/area/almayer/shipboard/brig/cryo)
 "saB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -61189,7 +60964,7 @@
 	},
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer,
-/area/almayer/shipboard/brig/general_equipment)
+/area/almayer/shipboard/brig/main_office)
 "scH" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
@@ -61226,19 +61001,23 @@
 	},
 /area/almayer/medical/upper_medical)
 "sdq" = (
-/obj/structure/flora/pottedplant{
-	icon_state = "pottedplant_21";
-	layer = 3.1;
-	pixel_x = -8
+/obj/structure/pipes/vents/pump{
+	dir = 1
 	},
-/obj/structure/machinery/power/apc/almayer{
-	dir = 8
+/obj/structure/machinery/light{
+	unacidable = 1;
+	unslashable = 1
+	},
+/obj/structure/machinery/camera/autoname/almayer{
+	dir = 4;
+	name = "ship-grade camera";
+	pixel_y = 6
 	},
 /turf/open/floor/almayer{
-	dir = 10;
-	icon_state = "red"
+	dir = 1;
+	icon_state = "redcorner"
 	},
-/area/almayer/shipboard/brig/chief_mp_office)
+/area/almayer/shipboard/brig/execution)
 "sdu" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/pipes/standard/simple/hidden/supply,
@@ -61262,15 +61041,14 @@
 	},
 /area/almayer/squads/delta)
 "sdF" = (
-/obj/structure/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
+/obj/structure/machinery/keycard_auth{
+	pixel_y = 25
 	},
 /turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "redcorner"
+	dir = 5;
+	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/processing)
+/area/almayer/shipboard/brig/chief_mp_office)
 "sdO" = (
 /obj/structure/ladder{
 	height = 1;
@@ -61320,7 +61098,7 @@
 /area/almayer/squads/req)
 "sgi" = (
 /turf/closed/wall/almayer,
-/area/almayer/shipboard/brig/processing)
+/area/almayer/shipboard/brig/perma)
 "sgj" = (
 /obj/item/storage/belt/medical/full,
 /obj/item/storage/belt/medical/full,
@@ -61433,14 +61211,15 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/upper_hull/u_f_p)
 "sip" = (
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = -30
+/obj/structure/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
 	},
 /turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "redcorner"
+	dir = 8;
+	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/main_office)
+/area/almayer/shipboard/brig/perma)
 "siz" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/computer/cameras/hangar{
@@ -61678,11 +61457,7 @@
 /area/almayer/living/gym)
 "soD" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
-/obj/effect/landmark/crap_item,
-/turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "red"
-	},
+/turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/main_office)
 "soK" = (
 /obj/item/storage/firstaid/fire/empty,
@@ -61794,29 +61569,21 @@
 	},
 /area/almayer/shipboard/brig/cells)
 "srV" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/structure/surface/table/almayer,
-/obj/item/toy/deck{
-	pixel_x = 8;
-	pixel_y = 8
-	},
-/obj/item/paper_bin/uscm{
-	pixel_x = -6;
-	pixel_y = 7
-	},
-/obj/item/tool/pen{
-	pixel_x = -6
-	},
-/obj/structure/pipes/standard/simple/hidden/supply,
+/obj/structure/closet/secure_closet/guncabinet/red,
+/obj/effect/landmark/wo_supplies/guns/common/m39,
+/obj/effect/landmark/wo_supplies/guns/common/m39,
+/obj/item/ammo_magazine/smg/m39,
+/obj/item/ammo_magazine/smg/m39,
+/obj/item/ammo_magazine/smg/m39,
+/obj/item/ammo_magazine/smg/m39,
+/obj/item/ammo_magazine/smg/m39,
+/obj/item/ammo_magazine/smg/m39,
+/obj/item/ammo_magazine/smg/m39,
 /turf/open/floor/almayer{
-	dir = 4;
-	icon_state = "red"
+	dir = 8;
+	icon_state = "plating_striped"
 	},
-/area/almayer/shipboard/brig/main_office)
+/area/almayer/shipboard/brig/armory)
 "ssa" = (
 /obj/structure/machinery/door/poddoor/almayer/open{
 	id = "Hangar Lockdown";
@@ -61951,15 +61718,14 @@
 /turf/open/floor/plating,
 /area/almayer/shipboard/brig/surgery)
 "swo" = (
-/obj/structure/machinery/vending/security,
-/obj/structure/machinery/light{
-	dir = 1
+/obj/structure/bed/chair/wood/normal{
+	dir = 4
 	},
+/obj/effect/decal/cleanable/blood,
 /turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "red"
+	icon_state = "cargo"
 	},
-/area/almayer/shipboard/brig/main_office)
+/area/almayer/shipboard/brig/execution)
 "swt" = (
 /turf/open/floor/almayer{
 	icon_state = "greencorner"
@@ -62067,11 +61833,18 @@
 /turf/open/floor/almayer,
 /area/almayer/squads/delta)
 "syM" = (
-/obj/structure/machinery/light/small{
-	dir = 8
+/obj/structure/closet/secure_closet{
+	name = "\improper Lethal Injection Locker"
 	},
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/hull/upper_hull/u_f_p)
+/obj/item/reagent_container/ld50_syringe/choral,
+/obj/item/reagent_container/ld50_syringe/choral,
+/obj/item/reagent_container/ld50_syringe/choral,
+/obj/item/reagent_container/ld50_syringe/choral,
+/obj/item/reagent_container/ld50_syringe/choral,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/shipboard/brig/execution)
 "szm" = (
 /obj/structure/machinery/power/fusion_engine{
 	name = "\improper S-52 fusion reactor 10"
@@ -62084,14 +61857,17 @@
 	},
 /area/almayer/engineering/engine_core)
 "szy" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 9
+/obj/structure/transmitter{
+	name = "Brig Warden's Office Telephone";
+	phone_category = "Offices";
+	phone_id = "Brig Warden's Office";
+	pixel_y = 32
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "redcorner"
+	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/main_office)
+/area/almayer/shipboard/brig/chief_mp_office)
 "szE" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "NE-out";
@@ -62178,13 +61954,17 @@
 	},
 /area/almayer/living/commandbunks)
 "sBH" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 10
+/obj/structure/sign/safety/hazard{
+	pixel_x = 32;
+	pixel_y = -8
 	},
-/obj/structure/machinery/status_display{
-	pixel_x = 32
+/obj/structure/sign/safety/firingrange{
+	pixel_x = 32;
+	pixel_y = 6
 	},
-/turf/open/floor/plating/plating_catwalk,
+/turf/open/floor/almayer{
+	icon_state = "cargo"
+	},
 /area/almayer/shipboard/brig/execution)
 "sBL" = (
 /obj/structure/machinery/portable_atmospherics/hydroponics,
@@ -62297,11 +62077,6 @@
 	icon_state = "emeraldcorner"
 	},
 /area/almayer/hallways/port_hallway)
-"sEa" = (
-/turf/open/floor/almayer{
-	icon_state = "redcorner"
-	},
-/area/almayer/shipboard/brig/chief_mp_office)
 "sEd" = (
 /obj/structure/machinery/cryopod/right,
 /obj/structure/machinery/light{
@@ -62527,10 +62302,22 @@
 	},
 /area/almayer/hull/upper_hull/u_f_p)
 "sIw" = (
-/turf/open/floor/almayer{
-	icon_state = "redfull"
+/obj/structure/machinery/door/airlock/almayer/security/glass/reinforced{
+	name = "\improper Brig"
 	},
-/area/almayer/shipboard/brig/evidence_storage)
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/machinery/door/firedoor/border_only/almayer{
+	dir = 8
+	},
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/shipboard/brig/processing)
 "sIx" = (
 /obj/effect/landmark/yautja_teleport,
 /turf/open/floor/plating/plating_catwalk,
@@ -62572,25 +62359,15 @@
 	},
 /area/almayer/hull/lower_hull/l_a_p)
 "sIY" = (
-/obj/structure/machinery/brig_cell/perma_1{
-	pixel_x = -32;
-	pixel_y = 4
-	},
-/obj/structure/machinery/door_control{
-	id = "Perma 1L";
-	name = "Perma 1 Lockdown";
-	pixel_x = -24;
-	pixel_y = -12;
-	req_access_txt = "3"
-	},
 /obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 5
+	dir = 1
 	},
-/turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "redcorner"
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
-/area/almayer/shipboard/brig/perma)
+/turf/open/floor/almayer,
+/area/almayer/shipboard/brig/processing)
 "sJC" = (
 /obj/structure/surface/table/almayer,
 /obj/item/trash/USCMtray{
@@ -62801,16 +62578,13 @@
 /turf/open/floor/wood/ship,
 /area/almayer/command/corporateliason)
 "sQS" = (
-/obj/structure/surface/table/almayer,
-/obj/item/tool/stamp{
-	pixel_x = 3;
-	pixel_y = 10
+/obj/structure/machinery/cm_vending/sorted/medical/wall_med{
+	pixel_y = 25
 	},
-/obj/item/device/taperecorder,
 /turf/open/floor/almayer{
-	icon_state = "plate"
+	icon_state = "plating_striped"
 	},
-/area/almayer/shipboard/brig/main_office)
+/area/almayer/shipboard/brig/armory)
 "sQU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -62872,9 +62646,11 @@
 	},
 /area/almayer/lifeboat_pumps/south2)
 "sSm" = (
-/obj/structure/reagent_dispensers/water_cooler/stacks{
-	density = 0;
-	pixel_y = 17
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/cells)
@@ -63016,8 +62792,11 @@
 /obj/structure/machinery/power/apc/almayer{
 	dir = 1
 	},
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/shipboard/brig/cryo)
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "orange"
+	},
+/area/almayer/shipboard/brig/armory)
 "sWW" = (
 /obj/structure/machinery/seed_extractor,
 /obj/structure/machinery/light{
@@ -63146,21 +62925,8 @@
 	},
 /area/almayer/lifeboat_pumps/south2)
 "sYB" = (
-/obj/structure/closet/secure_closet/guncabinet/red,
-/obj/effect/decal/warning_stripes{
-	icon_state = "N"
-	},
-/obj/effect/landmark/wo_supplies/guns/common/m39,
-/obj/effect/landmark/wo_supplies/guns/common/m39,
-/obj/item/ammo_magazine/smg/m39,
-/obj/item/ammo_magazine/smg/m39,
-/obj/item/ammo_magazine/smg/m39,
-/obj/item/ammo_magazine/smg/m39,
-/obj/item/ammo_magazine/smg/m39,
-/obj/item/ammo_magazine/smg/m39,
-/obj/item/ammo_magazine/smg/m39,
-/turf/open/floor/plating/almayer,
-/area/almayer/shipboard/brig/armory)
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/brig/general_equipment)
 "sYC" = (
 /obj/structure/machinery/door/airlock/almayer/maint,
 /obj/structure/machinery/door/poddoor/almayer/open{
@@ -63314,22 +63080,11 @@
 	},
 /area/almayer/hull/lower_hull/l_a_s)
 "tcP" = (
-/obj/structure/machinery/door/firedoor/border_only/almayer{
+/obj/structure/bed/chair/bolted{
 	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 1
-	},
-/obj/structure/machinery/door/poddoor/almayer/open{
-	id = "perma_lockdown";
-	name = "\improper Perma Lockdown Shutter"
-	},
-/obj/structure/machinery/door/airlock/multi_tile/almayer/secdoor/glass/reinforced{
-	name = "\improper Perma Cells"
 	},
 /turf/open/floor/almayer{
-	icon_state = "test_floor4"
+	icon_state = "plate"
 	},
 /area/almayer/shipboard/brig/perma)
 "tdc" = (
@@ -63346,12 +63101,18 @@
 	},
 /area/almayer/hallways/hangar)
 "tdv" = (
-/obj/structure/pipes/standard/simple/hidden/supply,
-/turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "red"
+/obj/structure/reagent_dispensers/water_cooler/stacks{
+	density = 0;
+	pixel_y = 17
 	},
-/area/almayer/shipboard/brig/main_office)
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/brig/cells)
 "tdx" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 9
@@ -63481,20 +63242,16 @@
 	},
 /area/almayer/medical/hydroponics)
 "tfO" = (
-/obj/structure/machinery/power/apc/almayer{
-	dir = 4
+/obj/structure/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
 	},
-/obj/item/storage/box/nade_box/tear_gas,
-/obj/item/storage/box/nade_box/tear_gas{
-	pixel_x = 3;
-	pixel_y = 5
+/obj/structure/machinery/camera/autoname/almayer{
+	dir = 8;
+	name = "ship-grade camera"
 	},
-/obj/structure/surface/table/almayer,
-/turf/open/floor/almayer{
-	dir = 5;
-	icon_state = "plating"
-	},
-/area/almayer/shipboard/brig/armory)
+/turf/open/floor/almayer,
+/area/almayer/shipboard/brig/general_equipment)
 "tgS" = (
 /obj/effect/step_trigger/clone_cleaner,
 /obj/structure/sign/safety/maint{
@@ -63688,8 +63445,8 @@
 "tkV" = (
 /obj/structure/bed/chair,
 /turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "redcorner"
+	dir = 5;
+	icon_state = "red"
 	},
 /area/almayer/shipboard/brig/processing)
 "tld" = (
@@ -63736,20 +63493,15 @@
 /area/almayer/medical/lower_medical_lobby)
 "tmy" = (
 /obj/structure/surface/table/almayer,
-/obj/item/handcuffs{
-	pixel_y = 12
-	},
-/obj/item/handcuffs{
-	pixel_y = 6
-	},
-/obj/item/handcuffs,
-/obj/item/weapon/baton{
-	pixel_x = -12
+/obj/structure/machinery/faxmachine/uscm/brig,
+/obj/structure/machinery/camera/autoname/almayer{
+	name = "ship-grade camera";
+	dir = 1
 	},
 /turf/open/floor/almayer{
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/main_office)
+/area/almayer/shipboard/brig/perma)
 "tmA" = (
 /obj/structure/machinery/light{
 	dir = 8
@@ -63905,8 +63657,11 @@
 	},
 /area/almayer/hull/upper_hull/u_a_p)
 "tqe" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
+/obj/structure/surface/rack,
+/obj/item/storage/firstaid/regular,
+/obj/item/storage/firstaid/toxin{
+	pixel_x = 8;
+	pixel_y = -2
 	},
 /turf/open/floor/almayer{
 	icon_state = "sterile_green_side"
@@ -63965,14 +63720,11 @@
 	},
 /area/almayer/command/lifeboat)
 "tqV" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 26
+/obj/structure/machinery/brig_cell/perma_2{
+	pixel_x = -32
 	},
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/general_equipment)
+/turf/open/floor/almayer,
+/area/almayer/shipboard/brig/perma)
 "trb" = (
 /obj/structure/window/framed/almayer/hull,
 /turf/open/floor/plating,
@@ -64196,8 +63948,8 @@
 	},
 /area/almayer/lifeboat_pumps/south1)
 "tvA" = (
-/obj/structure/machinery/sleep_console{
-	dir = 8
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
 	},
 /turf/open/floor/almayer{
 	dir = 8;
@@ -64557,11 +64309,12 @@
 	},
 /area/almayer/command/airoom)
 "tFv" = (
-/obj/structure/pipes/standard/manifold/hidden/supply{
-	dir = 8
+/obj/structure/machinery/light{
+	unacidable = 1;
+	unslashable = 1
 	},
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/shipboard/brig/general_equipment)
+/turf/open/floor/wood/ship,
+/area/almayer/shipboard/brig/chief_mp_office)
 "tFS" = (
 /obj/structure/machinery/computer/supplycomp,
 /obj/structure/sign/safety/terminal{
@@ -64604,12 +64357,20 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/upper_hull/u_f_s)
 "tGg" = (
-/obj/structure/pipes/standard/simple/hidden/supply,
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "redcorner"
+/obj/structure/machinery/door/firedoor/border_only/almayer,
+/obj/structure/machinery/door/airlock/multi_tile/almayer/secdoor/reinforced{
+	dir = 2;
+	name = "\improper Perma Brig"
 	},
-/area/almayer/shipboard/brig/main_office)
+/obj/structure/machinery/door/poddoor/almayer/open{
+	id = "perma_lockdown";
+	name = "\improper Perma Lockdown Shutter";
+	dir = 4
+	},
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/shipboard/brig/perma)
 "tGh" = (
 /obj/structure/sign/nosmoking_2{
 	pixel_x = -28
@@ -64704,18 +64465,9 @@
 	},
 /area/almayer/living/briefing)
 "tHB" = (
-/obj/structure/surface/table/almayer,
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = -30
-	},
-/obj/structure/machinery/recharger{
-	layer = 3.1;
-	pixel_y = 8
-	},
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/shipboard/brig/main_office)
+/obj/structure/closet/secure_closet/warrant_officer,
+/turf/open/floor/wood/ship,
+/area/almayer/shipboard/brig/chief_mp_office)
 "tHS" = (
 /obj/structure/window/framed/almayer,
 /turf/open/floor/plating,
@@ -64814,30 +64566,36 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/upper_hull/u_f_p)
 "tJp" = (
-/obj/structure/surface/table/almayer,
-/obj/item/tool/crowbar/red,
-/obj/item/clipboard{
+/obj/structure/closet/secure_closet/guncabinet/red,
+/obj/item/ammo_magazine/shotgun,
+/obj/item/ammo_magazine/shotgun,
+/obj/item/ammo_magazine/shotgun,
+/obj/item/ammo_magazine/shotgun/buckshot,
+/obj/item/ammo_magazine/shotgun/buckshot,
+/obj/item/ammo_magazine/shotgun/buckshot,
+/obj/item/weapon/gun/shotgun/combat,
+/obj/item/weapon/gun/shotgun/combat,
+/obj/structure/machinery/light/small{
+	dir = 8
+	},
+/obj/item/weapon/gun/shotgun/combat,
+/obj/item/vehicle_clamp,
+/obj/item/vehicle_clamp,
+/obj/item/vehicle_clamp,
+/obj/effect/decal/warning_stripes{
+	icon_state = "SE-out";
 	pixel_x = 1;
-	pixel_y = 4
+	pixel_y = -1
 	},
-/obj/item/storage/box/handcuffs{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/item/reagent_container/spray/cleaner,
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/shipboard/brig/main_office)
+/turf/open/floor/plating/almayer,
+/area/almayer/shipboard/brig/armory)
 "tJy" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
+/obj/structure/machinery/camera/autoname/almayer{
+	dir = 1;
+	name = "ship-grade camera"
 	},
-/turf/open/floor/almayer{
-	dir = 4;
-	icon_state = "redcorner"
-	},
-/area/almayer/shipboard/brig/main_office)
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/brig/armory)
 "tJz" = (
 /obj/structure/machinery/firealarm{
 	pixel_y = -28
@@ -64944,30 +64702,18 @@
 	},
 /area/almayer/living/briefing)
 "tNj" = (
-/obj/structure/surface/table/almayer,
-/obj/structure/machinery/computer/sentencing{
-	dir = 4
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 1
 	},
-/obj/structure/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/perma)
-"tNF" = (
-/obj/structure/window/framed/almayer,
-/obj/structure/machinery/door/poddoor/shutters/almayer/open{
-	dir = 4;
-	id = "CMP Office Shutters";
-	name = "\improper Privacy Shutters"
-	},
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 8
-	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/chief_mp_office)
+"tNF" = (
+/obj/structure/machinery/door/window/ultra{
+	dir = 8;
+	req_access_txt = "3"
+	},
+/turf/open/floor/almayer,
+/area/almayer/shipboard/brig/perma)
 "tNR" = (
 /obj/structure/machinery/firealarm{
 	pixel_y = 28
@@ -65251,13 +64997,17 @@
 	},
 /area/almayer/hull/lower_hull/l_m_p)
 "tWg" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
+/obj/structure/machinery/cryopod{
+	layer = 3.1;
+	pixel_y = 13
+	},
+/obj/structure/sign/safety/cryo{
+	pixel_x = -16
 	},
 /turf/open/floor/almayer{
-	icon_state = "redcorner"
+	icon_state = "cargo"
 	},
-/area/almayer/shipboard/brig/general_equipment)
+/area/almayer/shipboard/brig/cryo)
 "tWi" = (
 /obj/structure/pipes/standard/manifold/hidden/supply{
 	dir = 8
@@ -65309,15 +65059,6 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/squads/req)
-"tXs" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "N";
-	pixel_y = 1
-	},
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/shipboard/brig/cryo)
 "tXG" = (
 /obj/structure/surface/table/reinforced/almayer_B,
 /obj/structure/machinery/door/window/eastright{
@@ -65635,13 +65376,17 @@
 	},
 /area/almayer/hull/lower_hull/l_f_p)
 "ueo" = (
-/obj/structure/machinery/door/airlock/almayer/security/glass{
-	name = "Evidence Room"
+/obj/structure/surface/table/almayer,
+/obj/item/device/toner{
+	pixel_y = 8
 	},
-/obj/structure/machinery/door/firedoor/border_only/almayer,
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
+/obj/item/device/toner{
+	pixel_y = -2
 	},
+/obj/item/device/toner{
+	pixel_y = 3
+	},
+/turf/open/floor/plating/almayer,
 /area/almayer/shipboard/brig/evidence_storage)
 "ueG" = (
 /obj/item/bedsheet/orange,
@@ -65697,28 +65442,16 @@
 	},
 /area/almayer/squads/req)
 "ugs" = (
-/obj/structure/surface/table/almayer,
-/obj/item/book/manual/marine_law{
-	pixel_x = -3;
-	pixel_y = 1
-	},
-/obj/structure/machinery/camera/autoname/almayer{
-	dir = 4;
-	name = "ship-grade camera"
-	},
-/obj/structure/sign/safety/medical{
-	pixel_x = -17;
-	pixel_y = 6
-	},
-/obj/structure/sign/safety/restrictedarea{
-	pixel_x = -17;
-	pixel_y = -9
+/obj/structure/bed,
+/obj/structure/machinery/flasher{
+	id = "Cell 4";
+	pixel_x = -24
 	},
 /turf/open/floor/almayer{
 	dir = 8;
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/lobby)
+/area/almayer/shipboard/brig/cells)
 "ugu" = (
 /obj/structure/machinery/cm_vending/sorted/marine_food,
 /turf/open/floor/almayer,
@@ -65846,8 +65579,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/almayer,
-/area/almayer/shipboard/brig/general_equipment)
+/turf/open/floor/almayer{
+	icon_state = "redcorner"
+	},
+/area/almayer/shipboard/brig/main_office)
 "ukU" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 1
@@ -66020,15 +65755,11 @@
 	},
 /area/almayer/living/starboard_garden)
 "uoY" = (
-/obj/structure/surface/table/almayer,
-/obj/item/paper_bin/uscm{
-	pixel_y = 7
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 6
 	},
-/obj/item/tool/pen,
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/shipboard/brig/main_office)
+/turf/open/floor/almayer,
+/area/almayer/shipboard/brig/perma)
 "upe" = (
 /obj/structure/machinery/cm_vending/sorted/tech/electronics_storage,
 /turf/open/floor/almayer{
@@ -66152,17 +65883,12 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/squads/charlie)
 "ush" = (
-/obj/structure/surface/table/almayer,
-/obj/structure/machinery/computer/cameras/almayer_network{
-	dir = 8
-	},
-/obj/structure/machinery/light{
-	dir = 4
-	},
+/obj/effect/decal/cleanable/blood,
 /turf/open/floor/almayer{
-	allow_construction = 0
+	dir = 8;
+	icon_state = "redcorner"
 	},
-/area/almayer/shipboard/brig/chief_mp_office)
+/area/almayer/shipboard/brig/execution)
 "usi" = (
 /obj/structure/largecrate/random/case/double,
 /turf/open/floor/almayer{
@@ -66181,14 +65907,14 @@
 /area/almayer/lifeboat_pumps/south1)
 "usr" = (
 /obj/structure/surface/table/almayer,
-/obj/structure/machinery/computer/secure_data{
-	dir = 1
+/obj/structure/machinery/computer/cameras/almayer_network{
+	dir = 4
 	},
 /turf/open/floor/almayer{
-	dir = 6;
+	dir = 8;
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/chief_mp_office)
 "usw" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -66250,15 +65976,17 @@
 	},
 /area/almayer/hull/upper_hull/u_f_p)
 "uue" = (
+/obj/structure/machinery/door/airlock/almayer/security/glass{
+	name = "\improper Execution Room"
+	},
 /obj/structure/machinery/door/firedoor/border_only/almayer,
-/obj/structure/machinery/door/airlock/multi_tile/almayer/secdoor/glass/reinforced{
-	dir = 1;
-	name = "\improper Cryogenics Bay"
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
 	},
-/area/almayer/shipboard/brig/cryo)
+/area/almayer/shipboard/brig/execution)
 "uuj" = (
 /obj/structure/surface/table/almayer,
 /obj/item/trash/USCMtray{
@@ -66271,16 +65999,14 @@
 /turf/open/floor/almayer,
 /area/almayer/squads/bravo)
 "uuq" = (
-/obj/structure/bed,
-/obj/structure/machinery/flasher{
-	id = "Cell 4";
-	pixel_x = 24
+/obj/structure/closet/fireaxecabinet{
+	pixel_y = 32
 	},
 /turf/open/floor/almayer{
-	dir = 6;
+	dir = 1;
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/cells)
+/area/almayer/shipboard/brig/main_office)
 "uuu" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -66557,10 +66283,16 @@
 	pixel_x = 1;
 	pixel_y = 1
 	},
+/obj/structure/machinery/door/airlock/almayer/maint{
+	name = "\improper Power Control Room";
+	req_access = null;
+	req_one_access = null;
+	req_one_access_txt = "3;6"
+	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
 	},
-/area/almayer/shipboard/brig/cryo)
+/area/almayer/shipboard/brig/main_office)
 "uzy" = (
 /obj/item/reagent_container/glass/bucket,
 /obj/effect/decal/cleanable/blood/oil,
@@ -66619,34 +66351,23 @@
 	},
 /area/almayer/living/port_emb)
 "uzU" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/surface/table/almayer,
-/obj/item/ashtray/bronze{
-	pixel_x = 5;
-	pixel_y = 3
+/obj/structure/closet/secure_closet/guncabinet/red,
+/obj/structure/machinery/light/small{
+	dir = 8
 	},
-/obj/item/trash/cigbutt/cigarbutt{
-	pixel_x = 10;
-	pixel_y = 15
-	},
-/obj/item/clothing/mask/cigarette{
-	pixel_x = -5;
-	pixel_y = 3
-	},
-/obj/item/clothing/mask/cigarette{
-	pixel_x = -5;
-	pixel_y = 6
-	},
-/obj/item/clothing/mask/cigarette{
-	pixel_x = -5;
-	pixel_y = 9
-	},
-/obj/structure/pipes/standard/simple/hidden/supply,
+/obj/item/vehicle_clamp,
+/obj/item/vehicle_clamp,
+/obj/item/vehicle_clamp,
+/obj/effect/landmark/wo_supplies/guns/common/m39,
+/obj/effect/landmark/wo_supplies/guns/common/m39,
+/obj/item/ammo_magazine/smg/m39,
+/obj/item/ammo_magazine/smg/m39,
+/obj/item/ammo_magazine/smg/m39,
 /turf/open/floor/almayer{
-	dir = 4;
-	icon_state = "redcorner"
+	dir = 8;
+	icon_state = "plating_striped"
 	},
-/area/almayer/shipboard/brig/main_office)
+/area/almayer/shipboard/brig/armory)
 "uAj" = (
 /obj/structure/bed/chair,
 /turf/open/floor/almayer{
@@ -66807,12 +66528,13 @@
 	},
 /area/almayer/shipboard/navigation)
 "uDp" = (
-/obj/structure/closet/secure_closet/brig,
-/turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "red"
+/obj/structure/pipes/standard/manifold/hidden/supply{
+	dir = 8
 	},
-/area/almayer/shipboard/brig/perma)
+/turf/open/floor/almayer{
+	icon_state = "redcorner"
+	},
+/area/almayer/shipboard/brig/chief_mp_office)
 "uDA" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 9
@@ -66878,11 +66600,12 @@
 	},
 /area/almayer/medical/lockerroom)
 "uFp" = (
+/obj/structure/closet/firecloset,
 /turf/open/floor/almayer{
 	dir = 8;
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/general_equipment)
+/area/almayer/shipboard/brig/main_office)
 "uFt" = (
 /obj/structure/largecrate/random/case/double,
 /turf/open/floor/almayer{
@@ -67149,18 +66872,9 @@
 /turf/open/floor/almayer,
 /area/almayer/hallways/starboard_hallway)
 "uLJ" = (
-/obj/structure/machinery/light{
-	dir = 4;
-	invisibility = 101
-	},
-/obj/structure/sign/safety/ammunition{
-	pixel_x = 32;
-	pixel_y = -7
-	},
-/turf/open/floor/almayer{
-	icon_state = "cargo"
-	},
-/area/almayer/shipboard/brig/execution)
+/obj/structure/pipes/vents/scrubber,
+/turf/open/floor/almayer,
+/area/almayer/shipboard/brig/cryo)
 "uLN" = (
 /obj/structure/closet/secure_closet/engineering_welding,
 /turf/open/floor/almayer{
@@ -67219,11 +66933,8 @@
 	},
 /area/almayer/squads/delta)
 "uNe" = (
-/obj/structure/pipes/standard/manifold/hidden/supply{
-	dir = 8
-	},
-/turf/open/floor/almayer,
-/area/almayer/shipboard/brig/perma)
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/brig/chief_mp_office)
 "uNg" = (
 /obj/structure/machinery/cryopod,
 /turf/open/floor/almayer{
@@ -67231,14 +66942,9 @@
 	},
 /area/almayer/living/bridgebunks)
 "uNl" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 6
-	},
-/turf/open/floor/almayer{
-	dir = 4;
-	icon_state = "redcorner"
-	},
-/area/almayer/shipboard/brig/chief_mp_office)
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/almayer,
+/area/almayer/shipboard/brig/execution)
 "uNB" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/pipes/standard/simple/hidden/supply,
@@ -67551,14 +67257,6 @@
 	icon_state = "emerald"
 	},
 /area/almayer/squads/charlie)
-"uUs" = (
-/obj/structure/pipes/vents/pump{
-	dir = 1
-	},
-/turf/open/floor/almayer{
-	icon_state = "redcorner"
-	},
-/area/almayer/shipboard/brig/perma)
 "uUt" = (
 /obj/structure/surface/table/almayer,
 /obj/effect/spawner/random/technology_scanner,
@@ -67644,14 +67342,20 @@
 	},
 /area/almayer/living/cryo_cells)
 "uVF" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/decal/warning_stripes{
+	icon_state = "SW-out"
+	},
+/obj/structure/machinery/door/firedoor/border_only/almayer{
+	dir = 2
+	},
+/obj/structure/machinery/door/airlock/almayer/security/reinforced{
+	name = "\improper Execution Equipment";
+	dir = 2
 	},
 /turf/open/floor/almayer{
-	dir = 4;
-	icon_state = "redcorner"
+	icon_state = "test_floor4"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/execution)
 "uVX" = (
 /obj/structure/machinery/light{
 	dir = 1
@@ -67774,19 +67478,6 @@
 /obj/structure/window/framed/almayer,
 /turf/open/floor/plating,
 /area/almayer/hallways/repair_bay)
-"uZY" = (
-/obj/structure/closet/secure_closet/guncabinet/riot_control,
-/obj/item/weapon/shield/riot,
-/obj/item/weapon/shield/riot,
-/obj/item/weapon/shield/riot,
-/obj/effect/decal/warning_stripes{
-	icon_state = "S"
-	},
-/obj/structure/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plating/almayer,
-/area/almayer/shipboard/brig/armory)
 "uZZ" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/generic{
 	name = "\improper Basketball Court"
@@ -67885,15 +67576,12 @@
 	},
 /area/almayer/lifeboat_pumps/south2)
 "vcG" = (
-/obj/structure/surface/table/almayer,
-/obj/structure/machinery/recharger,
-/obj/item/device/flash,
-/obj/structure/machinery/cm_vending/sorted/medical/wall_med{
-	pixel_y = 25
+/obj/structure/machinery/vending/snack,
+/obj/structure/machinery/status_display{
+	pixel_x = 32
 	},
 /turf/open/floor/almayer{
-	dir = 9;
-	icon_state = "red"
+	icon_state = "plate"
 	},
 /area/almayer/shipboard/brig/general_equipment)
 "vcV" = (
@@ -67992,12 +67680,15 @@
 /area/almayer/living/briefing)
 "vez" = (
 /obj/structure/surface/table/almayer,
-/obj/item/device/camera,
-/obj/item/device/camera_film,
-/turf/open/floor/almayer{
-	icon_state = "plate"
+/obj/structure/machinery/recharger,
+/obj/structure/sign/safety/terminal{
+	pixel_y = 32
 	},
-/area/almayer/shipboard/brig/main_office)
+/turf/open/floor/almayer{
+	dir = 9;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/chief_mp_office)
 "veI" = (
 /obj/structure/pipes/standard/manifold/hidden/supply{
 	dir = 8
@@ -68031,14 +67722,14 @@
 	},
 /area/almayer/powered)
 "vfv" = (
-/obj/structure/pipes/vents/pump{
+/obj/structure/machinery/power/apc/almayer{
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "redcorner"
+	dir = 1;
+	icon_state = "orange"
 	},
-/area/almayer/shipboard/brig/execution)
+/area/almayer/shipboard/brig/chief_mp_office)
 "vfx" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -68401,19 +68092,13 @@
 	},
 /area/almayer/shipboard/brig/cic_hallway)
 "vli" = (
-/obj/structure/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/machinery/power/apc/almayer/hardened{
+/obj/structure/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/obj/structure/surface/rack,
-/obj/item/stack/sheet/glass/reinforced{
-	amount = 50
-	},
 /turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "orange"
+	dir = 6;
+	icon_state = "red"
 	},
 /area/almayer/shipboard/brig/processing)
 "vln" = (
@@ -68534,9 +68219,8 @@
 	},
 /area/almayer/lifeboat_pumps/south1)
 "vpI" = (
-/obj/effect/landmark/start/police,
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/shipboard/brig/cryo)
+/area/almayer/shipboard/brig/evidence_storage)
 "vpV" = (
 /turf/open/floor/almayer{
 	dir = 10;
@@ -68608,26 +68292,18 @@
 	},
 /area/almayer/shipboard/brig/evidence_storage)
 "vrQ" = (
-/obj/structure/machinery/door/poddoor/shutters/almayer{
-	dir = 2;
-	id = "perma_exit";
-	name = "\improper Exit Shutters"
+/obj/structure/machinery/door/airlock/almayer/security/glass{
+	dir = 1;
+	name = "\improper Cryo Room"
 	},
-/obj/structure/machinery/door/poddoor/almayer/open{
-	id = "perma_lockdown";
-	name = "\improper Perma Lockdown Shutter"
-	},
+/obj/structure/pipes/standard/simple/hidden/supply,
 /obj/structure/machinery/door/firedoor/border_only/almayer{
 	dir = 1
-	},
-/obj/structure/machinery/door/airlock/almayer/security/glass/reinforced{
-	dir = 1;
-	name = "\improper Brig"
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/cryo)
 "vrW" = (
 /turf/open/floor/almayer{
 	dir = 8;
@@ -68654,30 +68330,20 @@
 	},
 /area/almayer/hallways/hangar)
 "vsI" = (
-/obj/structure/closet/secure_closet/guncabinet/riot_control,
-/obj/item/weapon/shield/riot,
-/obj/item/weapon/shield/riot,
-/obj/item/weapon/shield/riot,
-/obj/effect/decal/warning_stripes{
-	icon_state = "S"
-	},
-/obj/structure/machinery/camera/autoname/almayer{
-	name = "ship-grade camera"
-	},
-/turf/open/floor/plating/almayer,
-/area/almayer/shipboard/brig/armory)
-"vsJ" = (
-/obj/structure/machinery/door/airlock/almayer/maint{
-	dir = 1;
-	name = "\improper Power Control Room";
-	req_access = null;
-	req_one_access = null;
-	req_one_access_txt = "3;6"
+/obj/structure/machinery/power/apc/almayer{
+	dir = 1
 	},
 /turf/open/floor/almayer{
-	icon_state = "orangefull"
+	dir = 9;
+	icon_state = "orange"
 	},
-/area/almayer/shipboard/brig/processing)
+/area/almayer/shipboard/brig/general_equipment)
+"vsJ" = (
+/obj/structure/pipes/vents/pump{
+	dir = 8
+	},
+/turf/open/floor/almayer,
+/area/almayer/shipboard/brig/general_equipment)
 "vsV" = (
 /obj/structure/prop/invuln/overhead_pipe{
 	pixel_x = 12
@@ -68835,9 +68501,9 @@
 	},
 /area/almayer/hull/lower_hull/l_f_p)
 "vwO" = (
-/obj/structure/pipes/standard/simple/hidden/supply,
+/obj/structure/closet/secure_closet/brig,
 /turf/open/floor/almayer,
-/area/almayer/shipboard/brig/general_equipment)
+/area/almayer/shipboard/brig/perma)
 "vwP" = (
 /obj/structure/surface/table/almayer,
 /obj/item/prop/helmetgarb/prescription_bottle{
@@ -68874,10 +68540,18 @@
 /turf/open/floor/almayer,
 /area/almayer/hallways/hangar)
 "vxC" = (
+/obj/structure/sign/safety/high_voltage{
+	pixel_x = 32;
+	pixel_y = 7
+	},
+/obj/structure/sign/safety/hazard{
+	pixel_x = 32;
+	pixel_y = -8
+	},
 /turf/open/floor/almayer{
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/general_equipment)
+/area/almayer/shipboard/brig/main_office)
 "vxM" = (
 /turf/closed/wall/almayer/reinforced,
 /area/almayer/shipboard/brig/cryo)
@@ -69100,17 +68774,19 @@
 	},
 /area/almayer/shipboard/brig/cells)
 "vCG" = (
-/obj/structure/toilet{
-	dir = 8
+/obj/structure/machinery/door/poddoor/almayer/locked{
+	dir = 2;
+	id = "Perma 2L";
+	name = "\improper cell shutter"
 	},
-/obj/structure/sink{
-	pixel_y = 24
+/obj/structure/machinery/door/airlock/almayer/security/glass/reinforced{
+	name = "\improper Isolation Cell";
+	dir = 2
 	},
-/obj/structure/machinery/light/small,
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile"
+	icon_state = "test_floor4"
 	},
-/area/almayer/shipboard/brig/chief_mp_office)
+/area/almayer/shipboard/brig/perma)
 "vCO" = (
 /obj/effect/landmark/start/bridge,
 /turf/open/floor/plating/plating_catwalk,
@@ -69814,12 +69490,13 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/upper_hull/u_f_p)
 "vUL" = (
-/obj/structure/surface/table/almayer,
-/obj/item/device/flash,
+/obj/structure/disposalpipe/segment,
+/obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer{
-	icon_state = "plate"
+	dir = 8;
+	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/main_office)
+/area/almayer/shipboard/brig/cells)
 "vUU" = (
 /obj/structure/machinery/camera/autoname/almayer{
 	dir = 8;
@@ -69883,11 +69560,25 @@
 	},
 /area/almayer/living/offices/flight)
 "vWo" = (
-/turf/open/floor/almayer{
-	dir = 4;
-	icon_state = "redcorner"
+/obj/structure/surface/table/almayer,
+/obj/structure/machinery/computer/card{
+	dir = 4
 	},
-/area/almayer/shipboard/brig/evidence_storage)
+/obj/structure/machinery/computer/secure_data{
+	dir = 4;
+	pixel_y = 17
+	},
+/obj/structure/machinery/light{
+	dir = 8
+	},
+/obj/structure/sign/safety/terminal{
+	pixel_x = -17
+	},
+/turf/open/floor/almayer{
+	dir = 8;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/processing)
 "vWt" = (
 /obj/structure/sink{
 	dir = 8;
@@ -69980,11 +69671,14 @@
 /turf/open/floor/plating,
 /area/almayer/engineering/upper_engineering/port)
 "vXQ" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 1
+/obj/structure/machinery/firealarm{
+	pixel_y = 28
 	},
-/turf/open/floor/almayer,
-/area/almayer/shipboard/brig/perma)
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "redcorner"
+	},
+/area/almayer/shipboard/brig/chief_mp_office)
 "vXX" = (
 /obj/structure/surface/rack,
 /obj/effect/spawner/random/tool,
@@ -70250,10 +69944,8 @@
 /turf/open/floor/almayer,
 /area/almayer/living/tankerbunks)
 "wdr" = (
-/obj/structure/machinery/power/apc/almayer,
-/turf/open/floor/almayer{
-	icon_state = "red"
-	},
+/obj/structure/pipes/vents/scrubber,
+/turf/open/floor/almayer,
 /area/almayer/shipboard/brig/main_office)
 "wdz" = (
 /obj/effect/landmark/start/marine/engineer/charlie,
@@ -70357,14 +70049,18 @@
 /turf/closed/wall/almayer,
 /area/almayer/living/gym)
 "wfL" = (
-/obj/structure/bed/chair/wood/normal{
-	dir = 1
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 9
 	},
-/obj/effect/decal/cleanable/blood,
+/obj/structure/machinery/camera/autoname/almayer{
+	dir = 8;
+	name = "ship-grade camera"
+	},
 /turf/open/floor/almayer{
-	icon_state = "cargo"
+	dir = 6;
+	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/execution)
+/area/almayer/shipboard/brig/chief_mp_office)
 "wfZ" = (
 /obj/structure/desertdam/decals/road_edge{
 	pixel_x = -12
@@ -70663,14 +70359,15 @@
 	},
 /area/almayer/hull/lower_hull/l_m_p)
 "wly" = (
-/obj/structure/machinery/light{
-	unacidable = 1;
-	unslashable = 1
+/obj/effect/decal/warning_stripes{
+	icon_state = "W";
+	layer = 2.5
 	},
-/turf/open/floor/almayer{
-	icon_state = "red"
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 10
 	},
-/area/almayer/shipboard/brig/chief_mp_office)
+/turf/open/floor/almayer,
+/area/almayer/shipboard/brig/execution)
 "wlE" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -70714,11 +70411,11 @@
 /area/almayer/shipboard/starboard_missiles)
 "wmE" = (
 /obj/structure/machinery/door/window/brigdoor/southright{
-	id = "Cell 4";
-	name = "Cell 4"
+	id = "Cell 5";
+	name = "Cell 5"
 	},
-/obj/structure/sign/safety/four{
-	pixel_x = 32
+/obj/structure/sign/safety/five{
+	pixel_x = -17
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/cells)
@@ -71239,8 +70936,7 @@
 /area/almayer/hull/lower_hull/l_a_s)
 "wzx" = (
 /obj/effect/decal/warning_stripes{
-	icon_state = "NW-out";
-	pixel_y = 1
+	icon_state = "NW-out"
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/upper_hull/u_f_s)
@@ -71297,20 +70993,11 @@
 	},
 /area/almayer/living/briefing)
 "wCM" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/machinery/light{
+/obj/structure/pipes/vents/pump{
 	dir = 1
 	},
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/processing)
+/turf/open/floor/almayer,
+/area/almayer/shipboard/brig/perma)
 "wCT" = (
 /obj/structure/machinery/power/apc/almayer/hardened{
 	dir = 1
@@ -71786,14 +71473,18 @@
 /turf/open/floor/almayer,
 /area/almayer/living/briefing)
 "wNU" = (
-/obj/structure/machinery/door/airlock/almayer/maint{
-	dir = 2;
-	req_one_access = list(2,34,30)
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/storage/firstaid/toxin{
+	pixel_x = 3;
+	pixel_y = 3
 	},
+/obj/item/storage/firstaid/adv,
+/obj/item/device/defibrillator,
 /turf/open/floor/almayer{
-	icon_state = "test_floor4"
+	dir = 1;
+	icon_state = "sterile_green_side"
 	},
-/area/almayer/hull/upper_hull/u_f_p)
+/area/almayer/shipboard/brig/surgery)
 "wOh" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer{
@@ -71817,11 +71508,16 @@
 	},
 /area/almayer/lifeboat_pumps/south1)
 "wPk" = (
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "redcorner"
+/obj/structure/surface/table/almayer,
+/obj/item/paper_bin/uscm{
+	pixel_y = 7
 	},
-/area/almayer/shipboard/brig/execution)
+/obj/item/tool/pen,
+/turf/open/floor/almayer{
+	dir = 8;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/main_office)
 "wPz" = (
 /turf/open/floor/almayer/research/containment/corner{
 	dir = 1
@@ -71862,7 +71558,6 @@
 /obj/structure/machinery/status_display{
 	pixel_y = -32
 	},
-/obj/structure/machinery/vending/coffee,
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 5
 	},
@@ -72121,23 +71816,13 @@
 /turf/closed/wall/almayer/outer,
 /area/almayer/hull/lower_hull/l_a_s)
 "wVw" = (
-/obj/structure/closet/secure_closet/guncabinet/red,
-/obj/structure/machinery/light/small{
-	dir = 8
+/obj/structure/surface/table/almayer,
+/obj/structure/machinery/recharger,
+/obj/item/device/flash,
+/turf/open/floor/almayer{
+	icon_state = "plate"
 	},
-/obj/item/vehicle_clamp,
-/obj/item/vehicle_clamp,
-/obj/item/vehicle_clamp,
-/obj/effect/decal/warning_stripes{
-	icon_state = "N"
-	},
-/obj/effect/landmark/wo_supplies/guns/common/m39,
-/obj/effect/landmark/wo_supplies/guns/common/m39,
-/obj/item/ammo_magazine/smg/m39,
-/obj/item/ammo_magazine/smg/m39,
-/obj/item/ammo_magazine/smg/m39,
-/turf/open/floor/plating/almayer,
-/area/almayer/shipboard/brig/armory)
+/area/almayer/shipboard/brig/general_equipment)
 "wVy" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -72194,13 +71879,16 @@
 /turf/open/floor/almayer,
 /area/almayer/hull/upper_hull/u_f_p)
 "wVV" = (
-/obj/structure/machinery/cryopod{
-	pixel_y = 6
+/obj/structure/machinery/power/apc/almayer{
+	dir = 1
 	},
+/obj/structure/surface/rack,
+/obj/effect/spawner/random/tool,
 /turf/open/floor/almayer{
-	icon_state = "cargo"
+	dir = 1;
+	icon_state = "orange"
 	},
-/area/almayer/shipboard/brig/cryo)
+/area/almayer/shipboard/brig/evidence_storage)
 "wVW" = (
 /turf/closed/wall/almayer/reinforced,
 /area/almayer/command/cic)
@@ -72360,10 +72048,11 @@
 /turf/open/floor/plating,
 /area/almayer/engineering/ce_room)
 "wZa" = (
+/obj/structure/machinery/light,
 /turf/open/floor/almayer{
-	icon_state = "redcorner"
+	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/general_equipment)
+/area/almayer/shipboard/brig/main_office)
 "wZy" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
@@ -73014,29 +72703,11 @@
 	},
 /area/almayer/shipboard/port_point_defense)
 "xoS" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "N"
+/obj/structure/pipes/standard/manifold/hidden/supply{
+	dir = 1
 	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "E"
-	},
-/obj/structure/closet/secure_closet/guncabinet/red,
-/obj/item/weapon/gun/rifle/m4ra,
-/obj/item/weapon/gun/rifle/m4ra,
-/obj/item/ammo_magazine/rifle/m4ra,
-/obj/item/ammo_magazine/rifle/m4ra,
-/obj/item/ammo_magazine/rifle/m4ra,
-/obj/item/ammo_magazine/rifle/m4ra,
-/obj/item/ammo_magazine/rifle/m4ra,
-/obj/item/ammo_magazine/rifle/m4ra,
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_y = -30
-	},
-/turf/open/floor/almayer{
-	dir = 5;
-	icon_state = "plating"
-	},
-/area/almayer/shipboard/brig/armory)
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/brig/general_equipment)
 "xpd" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/pipes/standard/manifold/hidden/supply{
@@ -73067,8 +72738,8 @@
 	},
 /obj/structure/machinery/door/airlock/multi_tile/almayer/secdoor/glass/reinforced{
 	name = "\improper Brig";
-	req_access = null;
-	req_one_access_txt = "1;3"
+	req_one_access_txt = "1;3";
+	req_access = null
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -73143,13 +72814,21 @@
 /turf/open/floor/almayer,
 /area/almayer/engineering/engineering_workshop/hangar)
 "xro" = (
-/obj/structure/toilet{
-	pixel_y = 13
+/obj/structure/surface/table/almayer,
+/obj/item/storage/box/ids{
+	pixel_y = 8;
+	pixel_x = -6
+	},
+/obj/item/device/flash,
+/obj/structure/machinery/light{
+	dir = 8;
+	invisibility = 101
 	},
 /turf/open/floor/almayer{
-	icon_state = "plate"
+	dir = 8;
+	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/main_office)
 "xrr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -73164,12 +72843,14 @@
 	},
 /area/almayer/hull/upper_hull/u_a_p)
 "xrP" = (
-/obj/structure/window/framed/almayer,
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 2
+/obj/structure/machinery/cm_vending/sorted/medical/wall_med{
+	pixel_x = -30
 	},
-/turf/open/floor/plating,
-/area/almayer/shipboard/brig/evidence_storage)
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "redcorner"
+	},
+/area/almayer/shipboard/brig/processing)
 "xsl" = (
 /obj/structure/machinery/alarm/almayer{
 	dir = 1
@@ -73294,18 +72975,26 @@
 	},
 /area/almayer/shipboard/brig/cic_hallway)
 "xvr" = (
-/turf/closed/wall/almayer,
-/area/almayer/shipboard/brig/chief_mp_office)
+/obj/structure/toilet{
+	dir = 4
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/shipboard/brig/perma)
 "xvw" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 1
+/obj/structure/pipes/standard/simple/hidden/supply,
+/obj/structure/bed,
+/obj/structure/machinery/flasher{
+	id = "Cell 5";
+	pixel_x = -24
 	},
 /turf/open/floor/almayer{
 	dir = 8;
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/cells)
 "xvE" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer,
 /obj/structure/machinery/door/airlock/multi_tile/almayer/marine/charlie{
@@ -73558,11 +73247,12 @@
 /turf/open/floor/plating,
 /area/almayer/hull/upper_hull/u_a_p)
 "xzu" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 5
-	},
 /obj/effect/decal/warning_stripes{
 	icon_state = "SE-out"
+	},
+/obj/structure/sign/safety/bathunisex{
+	pixel_y = 25;
+	pixel_x = 8
 	},
 /turf/open/floor/almayer,
 /area/almayer/shipboard/brig/cells)
@@ -73659,7 +73349,7 @@
 	pixel_x = 30
 	},
 /turf/open/floor/almayer{
-	icon_state = "redcorner"
+	allow_construction = 0
 	},
 /area/almayer/shipboard/brig/processing)
 "xCj" = (
@@ -73719,20 +73409,14 @@
 	},
 /area/almayer/command/securestorage)
 "xEc" = (
-/turf/open/floor/almayer{
-	dir = 9;
-	icon_state = "red"
+/obj/structure/disposalpipe/segment{
+	dir = 8
 	},
-/area/almayer/shipboard/brig/main_office)
-"xEe" = (
-/obj/structure/bed,
-/obj/structure/machinery/status_display{
-	pixel_x = -32
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
 	},
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/shipboard/brig/perma)
+/turf/open/floor/almayer,
+/area/almayer/shipboard/brig/processing)
 "xEz" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/book/manual/surgery,
@@ -73763,19 +73447,11 @@
 	unacidable = 1;
 	unslashable = 1
 	},
-/obj/structure/surface/table/almayer,
-/obj/item/storage/box/handcuffs{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/item/device/flash{
-	pixel_y = -8
-	},
+/obj/structure/machinery/computer/crew,
 /turf/open/floor/almayer{
-	dir = 10;
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/main_office)
+/area/almayer/shipboard/brig/perma)
 "xFw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -73879,7 +73555,8 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	icon_state = "red"
+	dir = 8;
+	icon_state = "redcorner"
 	},
 /area/almayer/shipboard/brig/main_office)
 "xHp" = (
@@ -73953,11 +73630,13 @@
 	},
 /area/almayer/medical/lower_medical_medbay)
 "xIw" = (
-/obj/structure/machinery/brig_cell/cell_2{
-	pixel_x = 32
+/obj/structure/machinery/light{
+	unacidable = 1;
+	unslashable = 1
 	},
+/obj/structure/closet/secure_closet/brig,
 /turf/open/floor/almayer{
-	allow_construction = 0
+	icon_state = "red"
 	},
 /area/almayer/shipboard/brig/processing)
 "xIQ" = (
@@ -74137,6 +73816,12 @@
 	density = 0;
 	pixel_y = 16
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/cells)
 "xMR" = (
@@ -74248,19 +73933,11 @@
 	},
 /area/almayer/medical/medical_science)
 "xQD" = (
-/obj/structure/surface/table/almayer,
 /obj/structure/machinery/cm_vending/sorted/medical/wall_med{
 	pixel_y = -25
 	},
-/obj/item/paper_bin/uscm{
-	pixel_y = 7
-	},
-/obj/item/tool/pen,
-/turf/open/floor/almayer{
-	dir = 10;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/perma)
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/brig/chief_mp_office)
 "xQV" = (
 /obj/effect/landmark/start/working_joe,
 /turf/open/floor/almayer{
@@ -74666,14 +74343,19 @@
 	},
 /area/almayer/shipboard/sea_office)
 "xYj" = (
-/obj/structure/machinery/power/apc/almayer{
-	dir = 8
+/obj/structure/machinery/door/airlock/almayer/generic{
+	dir = 1
 	},
-/obj/structure/surface/rack,
-/obj/effect/spawner/random/toolbox,
+/obj/structure/machinery/door/poddoor/almayer/open{
+	id = "courtyard_cells";
+	name = "\improper Courtyard Lockdown Shutter"
+	},
+/obj/structure/machinery/door/poddoor/almayer/locked{
+	id = "Cell 6";
+	name = "\improper Courtyard Divider"
+	},
 /turf/open/floor/almayer{
-	dir = 10;
-	icon_state = "orange"
+	icon_state = "test_floor4"
 	},
 /area/almayer/shipboard/brig/cells)
 "xYB" = (
@@ -74765,19 +74447,21 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_m_s)
 "ybb" = (
-/obj/structure/surface/table/almayer,
-/obj/item/storage/box/ids{
-	pixel_x = -4;
-	pixel_y = 14
-	},
-/obj/item/device/flash{
-	pixel_y = -8
-	},
-/obj/structure/machinery/faxmachine/uscm/brig,
+/obj/structure/closet/secure_closet/guncabinet/red,
+/obj/item/ammo_magazine/shotgun,
+/obj/item/ammo_magazine/shotgun,
+/obj/item/ammo_magazine/shotgun,
+/obj/item/ammo_magazine/shotgun/buckshot,
+/obj/item/ammo_magazine/shotgun/buckshot,
+/obj/item/ammo_magazine/shotgun/buckshot,
+/obj/item/weapon/gun/shotgun/combat,
+/obj/item/weapon/gun/shotgun/combat,
+/obj/item/weapon/gun/shotgun/combat,
 /turf/open/floor/almayer{
-	icon_state = "plate"
+	dir = 4;
+	icon_state = "plating_striped"
 	},
-/area/almayer/shipboard/brig/main_office)
+/area/almayer/shipboard/brig/armory)
 "ybf" = (
 /obj/structure/machinery/cm_vending/sorted/medical/wall_med{
 	pixel_y = 25
@@ -74900,19 +74584,19 @@
 	},
 /area/almayer/living/cryo_cells)
 "ydU" = (
-/obj/structure/window/framed/almayer/hull/hijack_bustable,
-/obj/structure/machinery/door/poddoor/almayer/locked{
-	dir = 8;
-	id = "Perma 2";
-	name = "\improper isolation shutter"
+/obj/structure/sign/safety/high_voltage{
+	pixel_x = 32;
+	pixel_y = 7
 	},
-/obj/structure/machinery/door/poddoor/almayer/open{
+/obj/structure/sign/safety/hazard{
+	pixel_x = 32;
+	pixel_y = -8
+	},
+/turf/open/floor/almayer{
 	dir = 4;
-	id = "courtyard_cells";
-	name = "\improper Courtyard Lockdown Shutter"
+	icon_state = "orange"
 	},
-/turf/open/floor/plating,
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/main_office)
 "yeo" = (
 /obj/structure/machinery/cm_vending/clothing/dress{
 	req_access = list(1)
@@ -79315,18 +78999,18 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aaa
 aaa
 aaa
@@ -79518,18 +79202,18 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
 bdH
 bdH
 bdH
 bdH
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aaa
 aaa
 aaa
@@ -79721,18 +79405,18 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
 bdH
 bdH
 bdH
 bdH
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aaa
 aaa
 aaa
@@ -79924,18 +79608,18 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
 bdH
 bdH
 bdH
 bdH
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aaa
 aaa
 aaa
@@ -80127,18 +79811,18 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
 bdH
 bdH
 bdH
 bdH
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aaa
 aaa
 aaa
@@ -80330,18 +80014,18 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
 bdH
 bdH
 bdH
 bdH
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aaa
 aaa
 aaa
@@ -80533,18 +80217,18 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
 bdH
 bdH
 bdH
 bdH
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aaa
 aaa
 aaa
@@ -80736,18 +80420,18 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
 bdH
 bdH
 bdH
 bdH
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aaa
 aaa
 aaa
@@ -80939,18 +80623,18 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aaa
 aaa
 aaa
@@ -81142,18 +80826,18 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aaa
 aaa
 aaa
@@ -81345,18 +81029,18 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aaa
 aaa
 aaa
@@ -81950,10 +81634,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
 aaa
 aaa
 aac
@@ -82160,13 +81844,13 @@ aaa
 aaa
 aaa
 aad
-cZs
-cZs
+fbY
+fbY
 iZG
 iZG
 iZG
-cZs
-cZs
+fbY
+fbY
 ajZ
 aaa
 aaa
@@ -82363,13 +82047,13 @@ aaf
 aaf
 aaf
 aag
-cZs
+fbY
 cWN
-dgx
-dgx
-dgx
+oog
+ush
+swo
 sdq
-cZs
+fbY
 aag
 aaf
 aaf
@@ -82566,18 +82250,18 @@ cZs
 cZs
 cZs
 cZs
-cZs
+fbY
 dfp
-sEa
-vBJ
+oog
+fuX
 uNl
-oxn
-cZs
-xEF
-xEF
-xEF
-xEF
-xEF
+qaJ
+fbY
+fbY
+fbY
+fbY
+fbY
+fbY
 ajZ
 aaa
 aaa
@@ -82765,22 +82449,22 @@ aac
 aaf
 aag
 cZs
-yeR
-aTg
-kyI
-aTg
-pdG
-vAG
+naB
+naB
+naB
+naB
+mtl
+pJi
 dOL
-jfY
+hwS
 hwS
 wly
-wIC
-dtN
+jkV
+mtl
 syM
-irr
-dAb
-xEF
+nBb
+frJ
+fbY
 aag
 aaf
 ajY
@@ -82969,21 +82653,21 @@ pCi
 pCi
 cZs
 osJ
-aTg
+jkS
 xvr
-bZN
-wIC
+naB
+mtl
 dWk
 fYX
-ush
-rTt
-vAG
-wIC
-fGN
-kIV
-kIV
-shw
-xEF
+qVF
+qVF
+sBH
+qvf
+uVF
+fuX
+fuX
+dHv
+fbY
 xEF
 xEF
 ajZ
@@ -83170,23 +82854,23 @@ aaf
 pCi
 pCi
 myT
-wIC
-lcW
-pbC
-xvr
+naB
+bTw
+pHp
+fgl
 vCG
-wIC
+tqV
 tNF
-tNF
-wIC
-hzx
-wIC
-wIC
-vBm
-vBm
-bIi
-mnm
-kPo
+mtl
+mtl
+mtl
+mtl
+uue
+mtl
+rra
+fNA
+rvo
+mtl
 cFX
 xEF
 xEF
@@ -83373,23 +83057,23 @@ pCi
 pCi
 cpf
 cos
-wIC
-wIC
-wIC
-wIC
-wIC
-wIC
-cNY
-tak
+naB
+osJ
+tcP
+wvI
+okM
+vwO
+qPD
+aEk
 sip
-mLJ
+qof
 ntm
 hND
-kif
-hND
-mnm
-wVz
-kIV
+mtl
+mtl
+mtl
+mtl
+mtl
 dDQ
 sGe
 xEF
@@ -83576,22 +83260,22 @@ wcn
 tng
 hGD
 wzx
-vBm
-paq
+naB
+naB
+naB
+naB
+naB
+eOh
+qPD
+qPD
+qPD
 uoY
-vUL
-vez
-xys
-swo
-eRL
-eRL
-mLJ
-bua
-vBm
-xkd
-xkd
-xkd
-xkd
+luC
+rTt
+pdG
+qqN
+pdG
+wVz
 kIV
 iYi
 gSs
@@ -83779,26 +83463,26 @@ dPY
 rTV
 wcn
 tYB
-vBm
-qfR
-tak
-tak
+naB
+osJ
+tcP
+wvI
 bvx
-xys
-ldu
-eRL
-eRL
-mLJ
-eiO
+vwO
+qPD
+wCM
+eoP
+bZN
+qPD
 xFs
 xkd
-eiH
-aTV
 xkd
 xkd
 xkd
-mnm
-mnm
+xkd
+xkd
+shw
+eBW
 iqx
 qFl
 vUI
@@ -83982,22 +83666,22 @@ vBm
 vBm
 qmC
 vBm
-vBm
+naB
 ouV
-bTw
-sjc
+pHp
+fgl
 dci
 rzj
-tGg
-sjc
-sjc
-iqn
-eRL
+qPD
+qfR
+qPD
+uQm
+qPD
 tmy
 xkd
-rUB
-dSn
-soa
+eiH
+aTV
+xkd
 xzu
 xkd
 xkd
@@ -84185,22 +83869,22 @@ mqo
 vBm
 eRL
 rag
-qqN
-lzx
-mLJ
-bua
-gcT
-dSc
+naB
+osJ
+ntu
+djm
+naB
+naB
 qre
-eRL
+maa
 eOR
 aJz
 dXy
 nHg
 xkd
-ghX
-rAv
-xkd
+rUB
+dSn
+soa
 eTo
 iHG
 dCe
@@ -84387,22 +84071,22 @@ wgi
 wgi
 ckS
 eRL
-bua
-gcT
-gcT
-tJy
-fnC
-tpn
-tpn
-tpn
-ula
-tpn
-wvT
-luw
+iOh
+naB
+naB
+naB
+naB
+naB
+naB
+sgi
+sgi
+sgi
+oxn
+tGg
 sgi
 xkd
-xkd
-xkd
+ghX
+rAv
 xkd
 kmd
 tUx
@@ -84591,21 +84275,21 @@ sFC
 vBm
 pcQ
 xHe
-gqW
-gqW
-lCM
-ugT
-tpn
-vrM
+tak
+tak
+wPk
+xro
+qmX
+xys
 kta
 vWo
 xrP
-xTp
+cMl
 pyj
 pwt
 xkd
-uvY
-oBq
+xkd
+xkd
 xkd
 rPh
 iOD
@@ -84795,21 +84479,21 @@ vBm
 hKq
 cdk
 soD
-tdv
-szy
+soD
+soD
 wdr
-tpn
-aeo
-sIw
-eni
-xrP
-xTp
+pZV
+kyI
+wdF
+wdF
+wdF
+cMl
 pyj
-hTt
-kMH
-tUx
-iTI
-hzJ
+mdS
+xkd
+uvY
+oBq
+xkd
 cyZ
 jVa
 jVa
@@ -84998,21 +84682,21 @@ rmv
 eRL
 mLJ
 bua
-nNQ
 gcT
-ciF
-tpn
-vrM
-eBW
-eOh
-xrP
-xTp
+pzc
+eRL
+gcT
+rkL
+bqp
+wdF
+wdF
+cMl
 pyj
-kfN
-xkd
-qFu
-xkd
-xkd
+hTt
+kMH
+tUx
+iTI
+hzJ
 qJZ
 jVa
 jVa
@@ -85192,29 +84876,29 @@ aag
 ahE
 nBc
 wcn
-vBm
-vBm
-vBm
-vBm
-vBm
-vBm
-hZU
-mLJ
+lrq
+lrq
+lrq
+lrq
+lrq
+lrq
+lrq
+cNY
 fkn
-gaJ
-gaJ
-gaJ
-gaJ
 tpn
 tpn
-ueo
+ula
 tpn
-wCM
+tpn
+jZm
+wdF
+wdF
+cMl
 pyj
-opN
+lMc
 xkd
-uvY
-duT
+qFu
+xkd
 xkd
 vdM
 jVa
@@ -85395,30 +85079,30 @@ aag
 pCi
 mUQ
 aou
-vBm
+lrq
 tJp
 ybb
-tHB
-aEk
+ybb
 nSM
-ldu
-mLJ
+nSM
+lrq
+lCM
 pYF
-gaJ
-wVV
-wVV
-wVV
-gaJ
+tpn
+lut
+vpI
+pbh
+tpn
 aOY
 wdF
-sdF
+wdF
 kNi
 pyj
 xIw
-kVZ
-tUx
-iTI
-nXm
+xkd
+uvY
+duT
+xkd
 eZH
 jVa
 jVa
@@ -85598,30 +85282,30 @@ aag
 pCi
 hKi
 rPC
-vBm
+lrq
 sQS
-xEc
-grl
-egR
-tak
+uqo
+uqo
+uqo
+uqo
 lzx
 mLJ
 ugT
-fso
+tpn
+vrM
 vpI
-vpI
-vpI
-cuk
-tkV
+jJq
+tpn
+eeN
 jFR
 oRk
 kxM
-jSw
-vBm
-vBm
-qof
-vBm
-vBm
+pyj
+ePB
+kVZ
+tUx
+iTI
+nXm
 wRm
 tUx
 vrx
@@ -85801,30 +85485,30 @@ aag
 ahE
 nnF
 rPC
-vBm
+lrq
 ikM
-pzc
+uqo
 jjM
-eRL
-eRL
-eRL
-mLJ
+buX
+tJy
+lrq
+lfW
 ugT
-qvf
+tpn
+aeo
 vpI
-vpI
-vpI
-qvf
-wdF
+mAr
+tpn
+mGn
 lMc
 ycr
 kge
 kDA
-rkL
-eZj
+jSw
+xkd
 efh
-mGn
-jkS
+xkd
+xkd
 cyZ
 thL
 thL
@@ -86004,30 +85688,30 @@ aag
 ahE
 hUg
 wcn
-vBm
+lrq
 gqW
-buX
+uqo
+uqo
+uqo
+uqo
+enz
 mLJ
-eRL
-eRL
-eRL
-mLJ
-pWG
-gaJ
-eyg
+fnC
+tpn
+vrM
 gCI
-eyg
-gaJ
+ueo
+tpn
 heQ
 lMc
 eOW
 cMl
-lMc
-nxq
-ldu
-kJK
+pyj
+kfN
+xkd
+uvY
 bja
-jkS
+xkd
 eZH
 ohJ
 thL
@@ -86207,30 +85891,30 @@ aag
 ahE
 rPC
 wcn
-vBm
+lrq
 jCa
-cFO
+lNs
 lNs
 srV
 uzU
-nJo
+lrq
 inN
 wQk
-gaJ
-gaJ
-gaJ
-gaJ
-gaJ
+tpn
+tpn
+tpn
+tpn
+tpn
 tRA
 lMc
 gjL
 cMl
-oeB
+pyj
 euO
-ldu
-eRL
-jZL
-vBm
+paq
+tUx
+iTI
+nYP
 qJZ
 ohJ
 thL
@@ -86411,14 +86095,14 @@ pCi
 wcn
 wcn
 lrq
-lrq
+bVC
+bVC
+bVC
 bVC
 lrq
 lrq
-lut
-eRL
-eRL
-enz
+uuq
+igt
 swn
 vOd
 uCl
@@ -86429,11 +86113,11 @@ rCL
 xHM
 jxK
 hyz
-ltX
-pbh
-rRQ
-rRQ
-iyq
+cqM
+xkd
+efh
+xkd
+xkd
 inG
 omt
 omt
@@ -86613,14 +86297,14 @@ aag
 pCi
 rPC
 rwS
-lrq
+cQv
 kTc
-uqo
+cqn
 wVw
 cqn
 gTx
-eRL
-eRL
+cQv
+cIK
 igt
 swn
 daj
@@ -86631,12 +86315,12 @@ luH
 lMc
 ycr
 bju
-goD
-vBm
-vBm
-qof
-vBm
-vBm
+wSm
+kfN
+xkd
+uvY
+ugs
+xkd
 sSm
 thL
 thL
@@ -86816,19 +86500,19 @@ aag
 ahE
 rPC
 nfI
-lrq
+cQv
 omu
-uqo
 sYB
-cqn
-ldu
-eRL
-eRL
-cWs
+sYB
+ajj
+iqn
+cQv
+rQY
+igt
 swn
 dcP
 tvA
-dQv
+eni
 swn
 xTp
 lMc
@@ -86838,9 +86522,9 @@ wSm
 jox
 lrV
 tUx
-ntu
-nYP
-tUx
+iTI
+vQN
+tdv
 thL
 oXp
 thL
@@ -87019,29 +86703,29 @@ aag
 ahE
 rPC
 heV
-lrq
-frJ
-uqo
+cQv
+eaf
+bEv
 ktn
-cqn
-nBb
-mdS
-eRL
-uJs
+rSH
+rXd
+cqJ
+ldu
+igt
 swn
 dfO
-doj
 dQv
+doj
 swn
 fYn
 qZg
 iXt
 gBi
 wSm
-opN
+lMc
 xkd
-nlH
-rQY
+qFu
+xkd
 xkd
 xMQ
 ezX
@@ -87222,31 +86906,31 @@ aag
 ahE
 wcn
 nBc
-lrq
-vsI
-uqo
+cQv
+eaf
+bEv
 xoS
-lrq
-mAT
-lrq
-cxA
+pGT
+pGT
+vkM
+sjc
 plZ
 kHa
 qPO
-qPO
 wuc
+qPO
 qPO
 oRZ
 wdF
 xCd
-bqp
+wdF
 wSm
-kfN
+opN
 xkd
-qFu
+vUL
+xvw
 xkd
-xkd
-jVa
+kPo
 ezX
 prY
 rUk
@@ -87425,38 +87109,38 @@ aag
 pCi
 wcn
 wcn
-lrq
-mAr
-uqo
+cQv
+eaf
+bEv
 fsT
-fsT
+ajj
 fDn
-lrq
-tqV
-nBo
-maa
+cqJ
+ldu
+igt
 swn
 plI
-tqe
+dQv
+hzx
 qPO
 wvT
 luw
 emp
 uUO
 wSm
-jZm
+lrM
 wmE
 tUx
-ntu
-vQN
-jVa
-rjw
+iTI
+ltX
+kPo
+thL
+thL
+thL
+thL
+thL
+thL
 tUx
-lnJ
-rjw
-tUx
-jVa
-oEE
 xkd
 kIV
 hFW
@@ -87628,18 +87312,18 @@ aag
 pCi
 oCL
 wcn
-lrq
-uZY
-uqo
-uqo
-uqo
-iOh
-lrq
+cQv
+eaf
+bEv
+fHS
+vsJ
+rXd
+cQv
 gdo
-nBo
-jJq
+igt
 swn
-dHv
+wNU
+dQv
 qQM
 qPO
 xTp
@@ -87647,20 +87331,20 @@ lMc
 jcf
 qUb
 wSm
-jSw
+cqM
 xkd
-nlH
-uuq
+qFu
 xkd
-naB
-naB
-pFg
-naB
-naB
-naB
-ydU
-naB
-naB
+xkd
+kPo
+thL
+thL
+thL
+thL
+thL
+thL
+tUx
+xkd
 kIV
 mnm
 xEF
@@ -87831,18 +87515,18 @@ aag
 pCi
 rPC
 aou
-lrq
-mAr
-uqo
-fsT
+cQv
+bop
+bEv
+sYB
 tfO
 fsz
-lrq
+cQv
 irJ
-nBo
-pJi
+cWs
 swn
 jAG
+dQv
 tqe
 qPO
 xTp
@@ -87850,20 +87534,20 @@ lMc
 jcf
 eUU
 wSm
-cqM
+kfN
 xkd
+vUL
+cFO
 xkd
+kPo
+tUx
+lnJ
+tUx
+tUx
+tUx
+jVa
+oEE
 xkd
-xkd
-naB
-eoP
-fgl
-xEe
-naB
-xEe
-fgl
-deb
-naB
 lmk
 kIV
 xEF
@@ -88034,39 +87718,39 @@ pCi
 pCi
 wcn
 tYB
-lrq
-noo
-noo
-noo
-lrq
-lrq
-lrq
-fNA
-nBo
 cQv
+noo
+sYB
+sYB
+cQv
+cQv
+cQv
+cxA
+nBo
 qPO
 qPO
 wuc
+qPO
 qPO
 wvT
 luw
 emp
 dGD
 wSm
-lfW
-emp
-vli
-rSH
+ihi
+nlH
+tUx
+iTI
 xYj
-naB
-aSS
-pHp
+kPo
+rjw
+xkd
 poZ
-naB
-jkV
-pHp
+poZ
+poZ
+xkd
 kOi
-naB
+xkd
 xCj
 kIV
 xEF
@@ -88241,35 +87925,35 @@ cQv
 vcG
 lYZ
 olv
-dxm
+cQv
 nMu
 uFp
-ePB
-nBo
+eRL
+uJs
 tsX
 xSA
-ugs
 wVY
+qHF
 lEv
 iQg
 jpQ
 tsX
 jOu
 wSm
-pyj
-vsJ
-kjN
-rvo
-oIc
-naB
-xro
-fgl
-wvI
-naB
-wvI
-fgl
-qmX
-naB
+jSw
+emp
+emp
+emp
+emp
+sIw
+emp
+wIC
+vez
+ciF
+usr
+dgx
+uNe
+wIC
 lTK
 mnm
 kIV
@@ -88439,41 +88123,41 @@ aad
 pCi
 dSA
 rPC
-cQv
-cQv
-geX
-tFv
-pGT
-vkM
+vxM
+vxM
+vxM
+vxM
+vxM
+vxM
 jvc
-ajj
-ajj
-nBo
+eRL
+eRL
+uJs
 xps
 jpQ
-jpQ
 wVY
+jpQ
 eOk
 pFa
 ctn
 wqu
 eeN
 cMl
-fHS
-naB
-naB
-naB
-naB
-naB
-naB
-rkh
+oeB
+emp
+qSl
+qSl
+qSl
+xEc
+lNF
+wIC
 lvZ
-naB
-fuX
-rra
-naB
-naB
-naB
+nNQ
+vAG
+vAG
+egR
+wIC
+wIC
 mnm
 kIV
 xEF
@@ -88642,20 +88326,20 @@ aad
 pCi
 wcn
 rPC
-cQv
-eaf
-bEv
+vxM
+rZR
+deb
 tWg
 rZR
-cqJ
+dvT
 isH
-vwO
+sjc
 scD
 rXC
 vyE
 nwz
-nwz
 mkk
+nwz
 wir
 jnT
 qNv
@@ -88664,19 +88348,19 @@ eeN
 cMW
 qEy
 ooR
-xvw
 nBu
-tcP
+nBu
+nBu
 lFs
 sIY
 qyd
-uDp
+tNj
 tNj
 uDp
-qyd
+kHK
 icX
 xQD
-naB
+wIC
 kIV
 lre
 xEF
@@ -88845,16 +88529,16 @@ aag
 pCi
 mNR
 wcn
-cQv
-eaf
-bEv
+vxM
+aSS
 fLn
-rXd
+fLn
+dSc
 dvT
-qSl
-ajj
+lCM
+eRL
 ukS
-wZa
+pFg
 tsX
 ezU
 dxT
@@ -88864,22 +88548,22 @@ bRm
 ecq
 tsX
 tkV
-pyj
-pyj
-luC
+oRk
+oRk
+emp
 elq
 qmE
-luC
-uVF
-uQm
-qPD
-qPD
-qPD
-qPD
-qPD
-bND
+oRk
+bqp
+mdJ
+wIC
+szy
+uNe
+kif
+wIC
+wIC
 jaP
-naB
+wIC
 kIV
 rQU
 xEF
@@ -89048,16 +88732,16 @@ aag
 pCi
 tCb
 aou
-cQv
-eaf
-bEv
-fLn
+vxM
+eZj
+uLJ
+rkh
 avz
-dvT
+vrQ
 nHV
-ajj
+bua
 iKX
-cQv
+vBm
 tsX
 tsX
 tsX
@@ -89069,20 +88753,20 @@ tsX
 vyi
 vyi
 vyi
-naB
-naB
-naB
-naB
+emp
+emp
+emp
+emp
 dqV
 mdJ
-vXQ
+wIC
 vXQ
 uNe
-uUs
-nqZ
-ekg
-usr
-naB
+nnz
+wIC
+cuk
+aTg
+wIC
 inC
 mKf
 xEF
@@ -89251,16 +88935,16 @@ aag
 pCi
 oCL
 wcn
-cQv
-eaf
-bEv
+vxM
+gMf
+gMf
 qRo
-rXd
+jZL
 dvT
-bAM
+lCM
 wZa
-cQv
-cQv
+vBm
+vBm
 tHr
 mqg
 eiK
@@ -89275,17 +88959,17 @@ xuZ
 rCU
 rEY
 gxU
-naB
+emp
 kyP
-qPD
-qPD
-qPD
-uQm
+vli
+wIC
+qYH
+qYH
 pIH
-naB
+wIC
 nOe
-nOe
-naB
+tFv
+wIC
 bIi
 fQk
 xEF
@@ -89454,14 +89138,14 @@ aag
 pCi
 wcn
 rPC
-cQv
-bop
+vxM
+oIc
 jeK
 mWe
-rXd
+pbC
 dvT
-ieo
-vxC
+lCM
+ugT
 ldD
 ceZ
 jnD
@@ -89478,17 +89162,17 @@ rWs
 rQt
 cgT
 xuc
-naB
-pZV
-gMf
+emp
+emp
+wIC
+wIC
 ekg
-ekg
-uQm
+uNe
 nnz
-vrQ
+wIC
 mLI
-qyd
-vrQ
+aTg
+wIC
 mnm
 sIk
 xEF
@@ -89657,12 +89341,12 @@ aag
 pCi
 nfI
 rPC
-cQv
-cQv
-cQv
-cQv
-cQv
-dvT
+vxM
+vxM
+vxM
+vxM
+vxM
+gaJ
 ieo
 vxC
 ldD
@@ -89681,17 +89365,17 @@ uVA
 wIQ
 xWv
 aQb
-naB
-naB
-mtl
+emp
+emp
+wIC
+rRQ
 hwQ
-hwQ
-okM
-mtl
-mtl
-naB
-naB
-naB
+vAG
+czB
+wIC
+wIC
+wIC
+wIC
 mnm
 hPT
 xEF
@@ -89864,11 +89548,11 @@ aFN
 wcn
 cXZ
 jIV
-vxM
-gaJ
+vBm
+xys
 uzx
-uue
-vxM
+xys
+vBm
 iuE
 uwN
 vka
@@ -89886,15 +89570,15 @@ wIQ
 mPj
 omy
 xpo
-mtl
+wIC
 pGG
 qRT
-djm
+jfY
 hgF
-mtl
+wIC
 kIV
 hUc
-wNU
+mnm
 mnm
 fwF
 xEF
@@ -90067,11 +89751,11 @@ akC
 rPC
 rPC
 kDb
-vxM
-wVV
-qau
+vBm
+vsI
+mKh
 mVi
-vxM
+vBm
 udK
 mwA
 lnt
@@ -90089,12 +89773,12 @@ mgj
 wIQ
 jHh
 jUY
-fbY
-qVF
-oog
-qaJ
+wIC
+kjN
+hZU
+vBJ
 czB
-mtl
+wIC
 mnm
 kIV
 kCi
@@ -90270,11 +89954,11 @@ akC
 cVJ
 rPC
 rPC
-vxM
+vBm
 sVy
 mKh
-mVi
-vxM
+qau
+vBm
 bmz
 wSR
 mMV
@@ -90292,12 +89976,12 @@ awz
 woy
 laO
 nRH
-fbY
-qVF
-oog
+wIC
+sdF
+vAG
 kHK
 wfL
-mtl
+wIC
 mnm
 kIV
 kCi
@@ -90473,11 +90157,11 @@ akC
 cRc
 rPC
 wcn
-vxM
-eyg
+vBm
+rkK
 giZ
 gTl
-vxM
+vBm
 pZS
 pEB
 jUY
@@ -90495,12 +90179,12 @@ qwp
 pZS
 jHh
 jUY
-fbY
-uLJ
-oog
-sBH
-vfv
-mtl
+wIC
+wIC
+nxq
+wIC
+wIC
+wIC
 mnm
 kIV
 kCi
@@ -90676,11 +90360,11 @@ akC
 oCL
 rPC
 wcn
-vxM
-vxM
-tXs
+vBm
+vfv
+wgi
 oCX
-vxM
+vBm
 vkR
 wsD
 jUY
@@ -90698,12 +90382,12 @@ qwp
 vGA
 uwN
 uVd
-mtl
-mtl
-qYH
-mtl
-mtl
-mtl
+wIC
+tHB
+aTg
+goD
+bND
+wIC
 kIV
 kIV
 kCi
@@ -90879,11 +90563,11 @@ akC
 dDC
 rPC
 wcn
-vxM
+vBm
 wVV
-erx
+wgi
 dsw
-vxM
+vBm
 kfE
 wsD
 jUY
@@ -90901,12 +90585,12 @@ qwp
 cDn
 uwN
 jUY
-mtl
-lNF
-rkK
-cIK
-mtl
-mnm
+wIC
+lcW
+aTg
+wIC
+wIC
+wIC
 kIV
 bbR
 kCi
@@ -91082,11 +90766,11 @@ akC
 eKM
 ake
 rPC
-vxM
+vBm
 dFC
+wgi
 bRH
-bRH
-vxM
+vBm
 xDn
 pEB
 jUY
@@ -91104,11 +90788,11 @@ awz
 gGr
 jHh
 sCQ
-mtl
+wIC
 pJE
-wPk
+aTg
 hRy
-mtl
+wIC
 mnm
 kIV
 bVT
@@ -91285,11 +90969,11 @@ akC
 akC
 tRX
 uzm
-vxM
+vBm
 eyg
-eyg
+ydU
 oWI
-vxM
+vBm
 nNv
 pEB
 jUY
@@ -91307,11 +90991,11 @@ qwp
 ora
 laO
 rKQ
-mtl
-qHF
-fnl
-mtl
-mtl
+wIC
+yeR
+aTg
+mLI
+wIC
 utZ
 pUJ
 pUJ
@@ -91488,11 +91172,11 @@ akC
 avl
 qkn
 wcn
-vxM
-vxM
-vxM
-vxM
-vxM
+vBm
+vBm
+vBm
+vBm
+vBm
 xSz
 pEB
 jUY
@@ -91510,11 +91194,11 @@ qwp
 pZS
 jHh
 vCx
-mtl
-mtl
-mtl
-mtl
-qFl
+wIC
+wIC
+wIC
+wIC
+wIC
 mnm
 xyz
 gpe


### PR DESCRIPTION

# About the pull request

Fully remaps the brig to feel more interconnected and better use up unused space.

Cryo Room: One room to fit all
APC Room: Hub of all brig APCs - larger
CMP Office: Moved
Warden Office: Moved next to CMP's office - new bedroom - oversees courtyard and can check if maint breach happens
Execution: Isolated viewing room, next to perma.
Evidence: Expanded evidence room, with printer, file storage and other detectivey needs.
Armory: Larger in size, added sectech
Equipment room: Larger - more chargers - food machines
Medical room: tiny expansion
Cells: Two new cells

# Explain why it's good for the game

Makes it easier to navigate brig (in theory) adds more cells for use, and better uses up empty space in the brig. Interconnects the brig to feel more wholesome.


# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: LTNTS
maptweak: remapped brig to be more concise, more interconnected and easier to navigate.
/:cl:

