### PR TITLE
A.C.I.D

### DIFF
--- a/code/modules/clothing/under/ties.dm
+++ b/code/modules/clothing/under/ties.dm
@@ -473,7 +473,7 @@
 /obj/item/clothing/accessory/storage/black_vest/attackby(obj/item/W, mob/living/user)
 	if(HAS_TRAIT(W, TRAIT_TOOL_WIRECUTTERS) && skillcheck(user, SKILL_RESEARCH, SKILL_RESEARCH_TRAINED))
 		var/components = 0
-		var/obj/item/reagent_container/glass/beaker/vial
+		var/obj/item/reagent_container/glass/beaker/beaker
 		var/obj/item/cell/battery
 		for(var/obj/item in hold.contents)
 			if(istype(item, /obj/item/device/radio) || istype(item, /obj/item/stack/cable_coil) || istype(item, /obj/item/device/healthanalyzer))
@@ -481,7 +481,7 @@
 			else if(istype(item, /obj/item/reagent_container/hypospray) && !istype(item, /obj/item/reagent_container/hypospray/autoinjector))
 				var/obj/item/reagent_container/hypospray/H = item
 				if(H.mag)
-					vial = H.mag
+					beaker = H.mag
 				components++
 			else if(istype(item, /obj/item/cell))
 				battery = item
@@ -494,9 +494,9 @@
 				AH = new /obj/item/clothing/accessory/storage/black_vest/acid_harness/brown(get_turf(loc))
 			else
 				AH = new /obj/item/clothing/accessory/storage/black_vest/acid_harness(get_turf(loc))
-			if(vial)
-				AH.vial = vial
-				AH.hold.handle_item_insertion(vial)
+			if(beaker)
+				AH.container = beaker
+				AH.hold.handle_item_insertion(beaker)
 			AH.battery = battery
 			AH.hold.handle_item_insertion(battery)
 			qdel(src)

--- a/code/modules/reagents/chemistry_machinery/acid_harness.dm
+++ b/code/modules/reagents/chemistry_machinery/acid_harness.dm
@@ -482,11 +482,11 @@
 	for(var/datum/reagent/R in acid_harness.container.reagents.reagent_list)
 		if(user.reagents.get_reagent_amount(R.id) + inject_amount > R.overdose) //Don't overdose our boi
 			voice("Notice: Injection trigger cancelled to avoid overdose.")
-			addtimer(CALLBACK(src, PROC_REF(recheck_conditions)), 20 SECONDS * inject_amount)
+			addtimer(CALLBACK(src, PROC_REF(recheck_conditions)), 20 SECONDS)
 			return
 	if(acid_harness.container.reagents.trans_to(user, inject_amount))
 		playsound_client(user.client, 'sound/items/hypospray.ogg', null, ITEM_EQUIP_VOLUME)
 		voice("Medicine administered. [acid_harness.container.reagents.total_volume] units remaining.")
-		addtimer(CALLBACK(src, PROC_REF(recheck_conditions)), 20 SECONDS * inject_amount)
+		addtimer(CALLBACK(src, PROC_REF(recheck_conditions)), 20 SECONDS)
 	if(!acid_harness.container.reagents.total_volume)
 		voice("Warning: Medicinal capsule is empty, resupply required.")

--- a/code/modules/reagents/chemistry_machinery/acid_harness.dm
+++ b/code/modules/reagents/chemistry_machinery/acid_harness.dm
@@ -42,7 +42,7 @@
 	can_hold = list(
 		/obj/item/reagent_container/glass/beaker,
 		/obj/item/cell,
-		)
+	)
 
 /obj/item/storage/internal/accessory/black_vest/acid_harness/can_be_inserted(obj/item/object)
 	. = ..()

--- a/code/modules/reagents/chemistry_machinery/acid_harness.dm
+++ b/code/modules/reagents/chemistry_machinery/acid_harness.dm
@@ -40,8 +40,8 @@
 /obj/item/storage/internal/accessory/black_vest/acid_harness
 	storage_slots = 2
 	can_hold = list(
-			/obj/item/reagent_container/glass/beaker,
-			/obj/item/cell)
+		/obj/item/reagent_container/glass/beaker,
+		/obj/item/cell)
 
 /obj/item/storage/internal/accessory/black_vest/acid_harness/can_be_inserted(obj/item/object)
 	. = ..()

--- a/code/modules/reagents/chemistry_machinery/acid_harness.dm
+++ b/code/modules/reagents/chemistry_machinery/acid_harness.dm
@@ -40,8 +40,8 @@
 /obj/item/storage/internal/accessory/black_vest/acid_harness
 	storage_slots = 2
 	can_hold = list(
-	/obj/item/reagent_container/glass/beaker,
-	/obj/item/cell)
+			/obj/item/reagent_container/glass/beaker,
+			/obj/item/cell)
 
 /obj/item/storage/internal/accessory/black_vest/acid_harness/can_be_inserted(obj/item/object)
 	. = ..()

--- a/code/modules/reagents/chemistry_machinery/acid_harness.dm
+++ b/code/modules/reagents/chemistry_machinery/acid_harness.dm
@@ -41,7 +41,8 @@
 	storage_slots = 2
 	can_hold = list(
 		/obj/item/reagent_container/glass/beaker,
-		/obj/item/cell)
+		/obj/item/cell
+		)
 
 /obj/item/storage/internal/accessory/black_vest/acid_harness/can_be_inserted(obj/item/object)
 	. = ..()

--- a/code/modules/reagents/chemistry_machinery/acid_harness.dm
+++ b/code/modules/reagents/chemistry_machinery/acid_harness.dm
@@ -39,8 +39,9 @@
 
 /obj/item/storage/internal/accessory/black_vest/acid_harness
 	storage_slots = 2
-	can_hold = list(/obj/item/reagent_container/glass/beaker,
-					/obj/item/cell)
+	can_hold = list(
+	/obj/item/reagent_container/glass/beaker,
+	/obj/item/cell)
 
 /obj/item/storage/internal/accessory/black_vest/acid_harness/can_be_inserted(obj/item/object)
 	. = ..()

--- a/code/modules/reagents/chemistry_machinery/acid_harness.dm
+++ b/code/modules/reagents/chemistry_machinery/acid_harness.dm
@@ -41,7 +41,7 @@
 	storage_slots = 2
 	can_hold = list(
 		/obj/item/reagent_container/glass/beaker,
-		/obj/item/cell
+		/obj/item/cell,
 		)
 
 /obj/item/storage/internal/accessory/black_vest/acid_harness/can_be_inserted(obj/item/object)


### PR DESCRIPTION
# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->
You can now add Beakers up to 60 units into ACID harnesses .
Cooldown for A.C.I.D health check reduced from 20 seconds X injection amount to a flat 20 seconds

# Explain why it's good for the game
ACID harness have been in the shadows for too long . this PR aims to give it more relevance and encourage research to create more of them acomplishing the objective of turning research into something more than a drug factory and instead giving them the option to provide marines with reliable gear.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: A.C.I.D vest can now hold beakers up to 60 units.
balance: Reduced cooldown betwen A.C.I.D health check to a flat 20 seconds.
fix: Added storage restrictions to A.C.I.D harness . now it can only hold  batteries and beakers as intended
/:cl:
