### PR TITLE
Adds interactions with potted plants and fire alarms.

### DIFF
--- a/code/game/machinery/fire_alarm.dm
+++ b/code/game/machinery/fire_alarm.dm
@@ -139,8 +139,10 @@ FIRE ALARM
 	var/area/area = get_area(src)
 
 	if (area.flags_alarm_state & ALARM_WARNING_FIRE)
+		user.visible_message("[user] deactivates [src].", "You deactivate [src].")
 		reset()
 	else
+		user.visible_message("[user] activates [src].", "You activate [src].")
 		alarm()
 
 	return

--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -418,17 +418,29 @@ ICEY GRASS. IT LOOKS LIKE IT'S MADE OF ICE.
 	icon_state = "pottedplant_26"
 	density = FALSE
 	var/stashed_item
-	var/list/forbidden_items = list(/obj/item/device/cotablet, /obj/item/card/id) //For things that might affect someone/everyone's round if hidden.
+	var/static/possible_starting_items = list(/obj/item/clothing/mask/cigarette/weed, /obj/item/clothing/mask/cigarette, /obj/item/clothing/mask/cigarette/bcigarette) //breaking bad reference
+	var/static/blocked_atoms = list(/obj/item/device/cotablet, /obj/item/card/id) //For things that might affect someone/everyone's round if hidden.
+	var/static/blacklist_typecache
+
+/obj/structure/flora/pottedplant/Initialize()
+	. = ..()
+
+	if(!blacklist_typecache)
+		blacklist_typecache = typecacheof(blocked_atoms)
+
+	if(prob(5))
+		var/obj/prestashed_item = pick(possible_starting_items)
+		prestashed_item = new(src)
+		stashed_item = prestashed_item
 
 /obj/structure/flora/pottedplant/attackby(obj/item/stash, mob/user)
 	if(stashed_item)
 		to_chat(user, SPAN_WARNING("There's already something stashed here!"))
 		return
 
-	for(var/i in forbidden_items)
-		if(istype(stash, i))
-			to_chat(user, SPAN_WARNING("You probably shouldn't hide [stash] in [src]."))
-			return
+	if(is_type_in_typecache(stash, blacklist_typecache))
+		to_chat(user, SPAN_WARNING("You probably shouldn't hide [stash] in [src]."))
+		return
 
 	if(stash.w_class == SIZE_TINY)
 		user.drop_inv_item_to_loc(stash, src)

--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -423,7 +423,7 @@ ICEY GRASS. IT LOOKS LIKE IT'S MADE OF ICE.
 	var/static/blocked_atoms = list(/obj/item/device/cotablet, /obj/item/card/id)
 	var/static/blacklist_typecache
 
-/obj/structure/flora/pottedplant/Initialize()
+/obj/structure/flora/pottedplant/Initialize(mapload)
 	. = ..()
 
 	if(!blacklist_typecache)
@@ -446,9 +446,9 @@ ICEY GRASS. IT LOOKS LIKE IT'S MADE OF ICE.
 		user.drop_inv_item_to_loc(stash, src)
 		stashed_item = stash
 		user.visible_message("[user] puts something in [src].", "You hide [stash] in [src].")
+		return
 
-	else
-		to_chat(user, SPAN_WARNING("[stash] is too big to fit into [src]!"))
+	to_chat(user, SPAN_WARNING("[stash] is too big to fit into [src]!"))
 
 /obj/structure/flora/pottedplant/attack_hand(mob/user)
 	if(!stashed_item)

--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -457,6 +457,10 @@ ICEY GRASS. IT LOOKS LIKE IT'S MADE OF ICE.
 	user.visible_message( "[user] takes something out of [src].", "You take [stashed_item] from [src].")
 	stashed_item = null
 
+/obj/structure/flora/pottedplant/Destroy()
+	if(stashed_item)
+		QDEL_NULL(stashed_item)
+	return ..()
 /obj/structure/flora/pottedplant/random
 	icon_tag = "pottedplant"
 	variations = "30"

--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -417,6 +417,33 @@ ICEY GRASS. IT LOOKS LIKE IT'S MADE OF ICE.
 	icon = 'icons/obj/structures/props/plants.dmi'
 	icon_state = "pottedplant_26"
 	density = FALSE
+	var/stashed_item
+	var/list/forbidden_items = list(/obj/item/device/cotablet, /obj/item/card/id) //For things that might affect someone/everyone's round if hidden.
+
+/obj/structure/flora/pottedplant/attackby(obj/item/stash, mob/user)
+	if(stashed_item)
+		to_chat(user, SPAN_WARNING("There's already something stashed here!"))
+		return
+
+	for(var/i in forbidden_items)
+		if(istype(stash, i))
+			to_chat(user, SPAN_WARNING("You probably shouldn't hide [stash] in [src]."))
+			return
+
+	if(stash.w_class == SIZE_TINY)
+		user.drop_inv_item_to_loc(stash, src)
+		stashed_item = stash
+		to_chat(user, "You hide [stash] in [src].")
+
+	else
+		to_chat(user, SPAN_WARNING("[stash] is too big to fit into [src]!"))
+
+/obj/structure/flora/pottedplant/attack_hand(mob/user)
+	if(!stashed_item)
+		return
+	user.put_in_hands(contents[1])
+	to_chat(user, "You take [stashed_item] from [src].")
+	stashed_item = null
 
 /obj/structure/flora/pottedplant/random
 	icon_tag = "pottedplant"

--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -429,9 +429,8 @@ ICEY GRASS. IT LOOKS LIKE IT'S MADE OF ICE.
 		blacklist_typecache = typecacheof(blocked_atoms)
 
 	if(prob(5))
-		var/obj/prestashed_item = pick(possible_starting_items)
-		prestashed_item = new(src)
-		stashed_item = prestashed_item
+		var/prestashed_item = pick(possible_starting_items)
+		stashed_item = new prestashed_item(src)
 
 /obj/structure/flora/pottedplant/attackby(obj/item/stash, mob/user)
 	if(stashed_item)
@@ -445,7 +444,7 @@ ICEY GRASS. IT LOOKS LIKE IT'S MADE OF ICE.
 	if(stash.w_class == SIZE_TINY)
 		user.drop_inv_item_to_loc(stash, src)
 		stashed_item = stash
-		to_chat(user, "You hide [stash] in [src].")
+		user.visible_message("[user] puts something in [src].", "You hide [stash] in [src].")
 
 	else
 		to_chat(user, SPAN_WARNING("[stash] is too big to fit into [src]!"))
@@ -454,7 +453,7 @@ ICEY GRASS. IT LOOKS LIKE IT'S MADE OF ICE.
 	if(!stashed_item)
 		return
 	user.put_in_hands(contents[1])
-	to_chat(user, "You take [stashed_item] from [src].")
+	user.visible_message( "[user] takes something out of [src].", "You take [stashed_item] from [src].")
 	stashed_item = null
 
 /obj/structure/flora/pottedplant/random

--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -419,7 +419,8 @@ ICEY GRASS. IT LOOKS LIKE IT'S MADE OF ICE.
 	density = FALSE
 	var/stashed_item
 	var/static/possible_starting_items = list(/obj/item/clothing/mask/cigarette/weed, /obj/item/clothing/mask/cigarette, /obj/item/clothing/mask/cigarette/bcigarette) //breaking bad reference
-	var/static/blocked_atoms = list(/obj/item/device/cotablet, /obj/item/card/id) //For things that might affect someone/everyone's round if hidden.
+	/// For things that might affect someone/everyone's round if hidden.
+	var/static/blocked_atoms = list(/obj/item/device/cotablet, /obj/item/card/id)
 	var/static/blacklist_typecache
 
 /obj/structure/flora/pottedplant/Initialize()


### PR DESCRIPTION

# About the pull request
Fire alarms now announce who pulled them, and potted plants can now have small items hidden in them (barring important things like the command tablet and ID cards.)
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
It's funny and fire alarms currently don't show who pulled them.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: You can now hide small items in potted plants.
add: Fire alarms now announce who activates/deactivates them.
/:cl:
