### PR TITLE
Alamo and Normandy now have a Reinforced Metal Ceiling

### DIFF
--- a/code/game/area/Sulaco.dm
+++ b/code/game/area/Sulaco.dm
@@ -23,30 +23,36 @@
 	name = "\improper Dropship Alamo"
 	icon_state = "shuttlered"
 	base_muffle = MUFFLE_HIGH
+	ceiling = CEILING_REINFORCED_METAL
 
 /area/shuttle/drop1/LV624
 	name = "\improper Dropship Alamo"
 	ambience_exterior = AMBIENCE_LV624
 	icon_state = "shuttle"
+	ceiling = CEILING_REINFORCED_METAL
 
 /area/shuttle/drop1/prison
 	name = "\improper Dropship Alamo"
 	ambience_exterior = AMBIENCE_PRISON
 	icon_state = "shuttle"
+	ceiling = CEILING_REINFORCED_METAL
 
 /area/shuttle/drop1/BigRed
 	name = "\improper Dropship Alamo"
 	ambience_exterior = AMBIENCE_BIGRED
 	icon_state = "shuttle"
+	ceiling = CEILING_REINFORCED_METAL
 
 /area/shuttle/drop1/ice_colony
 	name = "\improper Dropship Alamo"
 	icon_state = "shuttle"
+	ceiling = CEILING_REINFORCED_METAL
 
 /area/shuttle/drop1/DesertDam
 	name = "\improper Dropship Alamo"
 	ambience_exterior = AMBIENCE_TRIJENT
 	icon_state = "shuttle"
+	ceiling = CEILING_REINFORCED_METAL
 
 /area/shuttle/drop1/transit
 	ambience_exterior = 'sound/ambience/dropship_ambience_loop.ogg'
@@ -74,30 +80,36 @@
 	name = "\improper Dropship Normandy"
 	icon_state = "shuttle"
 	base_muffle = MUFFLE_HIGH
+	ceiling = CEILING_REINFORCED_METAL
 
 /area/shuttle/drop2/LV624
 	name = "\improper Dropship Normandy"
 	ambience_exterior = AMBIENCE_LV624
 	icon_state = "shuttle2"
+	ceiling = CEILING_REINFORCED_METAL
 
 /area/shuttle/drop2/prison
 	name = "\improper Dropship Normandy"
 	ambience_exterior = AMBIENCE_PRISON
 	icon_state = "shuttle2"
+	ceiling = CEILING_REINFORCED_METAL
 
 /area/shuttle/drop2/BigRed
 	name = "\improper Dropship Normandy"
 	ambience_exterior = AMBIENCE_BIGRED
 	icon_state = "shuttle2"
+	ceiling = CEILING_REINFORCED_METAL
 
 /area/shuttle/drop2/ice_colony
 	name = "\improper Dropship Normandy"
 	icon_state = "shuttle2"
+	ceiling = CEILING_REINFORCED_METAL
 
 /area/shuttle/drop2/DesertDam
 	name = "\improper Dropship Normandy"
 	ambience_exterior = AMBIENCE_TRIJENT
 	icon_state = "shuttle2"
+	ceiling = CEILING_REINFORCED_METAL
 
 /area/shuttle/drop2/transit
 	ambience_exterior = 'sound/ambience/dropship_ambience_loop.ogg'


### PR DESCRIPTION
Stops this kind of stuff from happening and weird tactics like CAS/OB'ing the dropship because people know it can't be destroyed:

https://user-images.githubusercontent.com/24533979/236336813-8ecd8ba1-ba8e-4834-9acc-52814f466aec.mp4





The whole thing is indestructible might as well make the ceiling indestructible as well.

![image](https://user-images.githubusercontent.com/24533979/236337629-32dc934f-d0c5-4f92-8885-2f45cd748236.png)
![image](https://user-images.githubusercontent.com/24533979/236337707-f047543b-0294-4301-b496-afcf90e6398a.png)


:cl: Hopek
balance: Alamo and Normandy now have a Reinforced Metal Ceiling meaning that CAS and OB's can't penetrate it.
/:cl:
