### PR TITLE
Medics now get to buy the EZ Autoinjectors if they want

### DIFF
--- a/code/game/machinery/vending/vendor_types/squad_prep/squad_medic.dm
+++ b/code/game/machinery/vending/vendor_types/squad_prep/squad_medic.dm
@@ -28,6 +28,7 @@ GLOBAL_LIST_INIT(cm_vending_gear_medic, list(
 		list("Autoinjector (Oxycodone)", 2, /obj/item/reagent_container/hypospray/autoinjector/oxycodone, null, VENDOR_ITEM_REGULAR),
 		list("Autoinjector (Tramadol)", 1, /obj/item/reagent_container/hypospray/autoinjector/tramadol, null, VENDOR_ITEM_REGULAR),
 		list("Autoinjector (Tricord)", 1, /obj/item/reagent_container/hypospray/autoinjector/tricord, null, VENDOR_ITEM_REGULAR),
+		list("Autoinjector (Emergency)", 2, /obj/item/reagent_container/hypospray/autoinjector/emergency, null, VENDOR_ITEM_REGULAR),
 
 		list("PILL BOTTLES", 0, null, null, null),
 		list("Pill Bottle (Bicaridine)", 5, /obj/item/storage/pill_bottle/bicaridine, null, VENDOR_ITEM_RECOMMENDED),


### PR DESCRIPTION
The only way to get these injectors at the moment is going through the auto injector pouches in preparations so I've just been watching medics go through like 12+ pouches on their own for weeks just to get that single injector out of it. 
Just let them buy the injector so they don't have to ruin 12+ autoinjector medical pouches for everyone else.

Was not 100% sure what the price should be so I set it at the higher amount of 2 because that's what the premium injectors go for currently.

:cl: Hopek
add: Medics can now just purchase the EZ Autoinjectors so they don't have to go through 12+ injector pouches to take them out specifically.
/:cl:
