### PR TITLE
Fixed the weapon examine strength message being wrong in some cases

### DIFF
--- a/code/game/objects/items/weapons/weapon.dm
+++ b/code/game/objects/items/weapons/weapon.dm
@@ -7,7 +7,7 @@
 /obj/item/get_examine_text(mob/user)
 	. = ..()
 	var/strong_text = "a weak"
-	if(force >= MELEE_FORCE_WEAK)
+	if(force > MELEE_FORCE_TIER_1)
 		switch(force)
 			if(MELEE_FORCE_WEAK to MELEE_FORCE_NORMAL)
 				strong_text = "a normal"
@@ -19,7 +19,8 @@
 				strong_text = "an inhumanely strong"
 		. += SPAN_INFO("[src] would be [strong_text] weapon if you were to hit someone with it.")
 
-	if(force != throwforce && throwforce >= MELEE_FORCE_WEAK)
+	if(force != throwforce && throwforce > MELEE_FORCE_TIER_1)
+		strong_text = "a weak"
 		switch(throwforce)
 			if(MELEE_FORCE_WEAK to MELEE_FORCE_NORMAL)
 				strong_text = "a normal"

--- a/code/game/objects/items/weapons/weapon.dm
+++ b/code/game/objects/items/weapons/weapon.dm
@@ -9,25 +9,25 @@
 	var/strong_text = "a weak"
 	if(force >= MELEE_FORCE_TIER_1)
 		switch(force)
-			if(MELEE_FORCE_WEAK to MELEE_FORCE_NORMAL)
+			if((MELEE_FORCE_WEAK + 1) to MELEE_FORCE_NORMAL)
 				strong_text = "a normal"
-			if(MELEE_FORCE_NORMAL to MELEE_FORCE_STRONG)
+			if((MELEE_FORCE_NORMAL + 1) to MELEE_FORCE_STRONG)
 				strong_text = "a strong"
-			if(MELEE_FORCE_STRONG to MELEE_FORCE_VERY_STRONG)
+			if((MELEE_FORCE_STRONG + 1) to MELEE_FORCE_VERY_STRONG)
 				strong_text = "a very strong"
-			if(MELEE_FORCE_VERY_STRONG to INFINITY)
+			if((MELEE_FORCE_VERY_STRONG + 1) to INFINITY)
 				strong_text = "an inhumanely strong"
 		. += SPAN_INFO("[src] would be [strong_text] weapon if you were to hit someone with it.")
 
 	if(force != throwforce && throwforce >= MELEE_FORCE_TIER_1)
 		strong_text = "a weak"
 		switch(throwforce)
-			if(MELEE_FORCE_WEAK to MELEE_FORCE_NORMAL)
+			if((MELEE_FORCE_WEAK + 1) to MELEE_FORCE_NORMAL)
 				strong_text = "a normal"
-			if(MELEE_FORCE_NORMAL to MELEE_FORCE_STRONG)
+			if((MELEE_FORCE_NORMAL + 1) to MELEE_FORCE_STRONG)
 				strong_text = "a strong"
-			if(MELEE_FORCE_STRONG to MELEE_FORCE_VERY_STRONG)
+			if((MELEE_FORCE_STRONG + 1) to MELEE_FORCE_VERY_STRONG)
 				strong_text = "a very strong"
-			if(MELEE_FORCE_VERY_STRONG to INFINITY)
+			if((MELEE_FORCE_VERY_STRONG + 1) to INFINITY)
 				strong_text = "an inhumanely strong"
 		. += SPAN_INFO("[src] would be [strong_text] weapon if you were to throw it at someone.")

--- a/code/game/objects/items/weapons/weapon.dm
+++ b/code/game/objects/items/weapons/weapon.dm
@@ -7,9 +7,9 @@
 /obj/item/get_examine_text(mob/user)
 	. = ..()
 	var/strong_text = "a weak"
-	if(force >= MELEE_FORCE_TIER_1)
+	if(force >= MELEE_FORCE_WEAK)
 		switch(force)
-			if((MELEE_FORCE_WEAK + 1) to MELEE_FORCE_NORMAL)
+			if(MELEE_FORCE_WEAK to MELEE_FORCE_NORMAL)
 				strong_text = "a normal"
 			if(MELEE_FORCE_NORMAL to MELEE_FORCE_STRONG)
 				strong_text = "a strong"
@@ -19,9 +19,9 @@
 				strong_text = "an inhumanely strong"
 		. += SPAN_INFO("[src] would be [strong_text] weapon if you were hit someone with it.")
 
-	if(force != throwforce && throwforce >= MELEE_FORCE_TIER_1)
+	if(force != throwforce && throwforce >= MELEE_FORCE_WEAK)
 		switch(throwforce)
-			if((MELEE_FORCE_WEAK + 1) to MELEE_FORCE_NORMAL)
+			if(MELEE_FORCE_WEAK to MELEE_FORCE_NORMAL)
 				strong_text = "a normal"
 			if(MELEE_FORCE_NORMAL to MELEE_FORCE_STRONG)
 				strong_text = "a strong"

--- a/code/game/objects/items/weapons/weapon.dm
+++ b/code/game/objects/items/weapons/weapon.dm
@@ -19,7 +19,7 @@
 				strong_text = "an inhumanely strong"
 		. += SPAN_INFO("[src] would be [strong_text] weapon if you were to hit someone with it.")
 
-	if(force != throwforce && throwforce >= MELEE_FORCE_TIER_1)
+	if(throwforce >= MELEE_FORCE_TIER_1)
 		strong_text = "a weak"
 		switch(throwforce)
 			if((MELEE_FORCE_WEAK + 1) to MELEE_FORCE_NORMAL)

--- a/code/game/objects/items/weapons/weapon.dm
+++ b/code/game/objects/items/weapons/weapon.dm
@@ -7,7 +7,7 @@
 /obj/item/get_examine_text(mob/user)
 	. = ..()
 	var/strong_text = "a weak"
-	if(force > MELEE_FORCE_TIER_1)
+	if(force >= MELEE_FORCE_TIER_1)
 		switch(force)
 			if(MELEE_FORCE_WEAK to MELEE_FORCE_NORMAL)
 				strong_text = "a normal"
@@ -19,7 +19,7 @@
 				strong_text = "an inhumanely strong"
 		. += SPAN_INFO("[src] would be [strong_text] weapon if you were to hit someone with it.")
 
-	if(force != throwforce && throwforce > MELEE_FORCE_TIER_1)
+	if(force != throwforce && throwforce >= MELEE_FORCE_TIER_1)
 		strong_text = "a weak"
 		switch(throwforce)
 			if(MELEE_FORCE_WEAK to MELEE_FORCE_NORMAL)

--- a/code/game/objects/items/weapons/weapon.dm
+++ b/code/game/objects/items/weapons/weapon.dm
@@ -17,7 +17,7 @@
 				strong_text = "a very strong"
 			if(MELEE_FORCE_VERY_STRONG to INFINITY)
 				strong_text = "an inhumanely strong"
-		. += SPAN_INFO("[src] would be [strong_text] weapon if you were hit someone with it.")
+		. += SPAN_INFO("[src] would be [strong_text] weapon if you were to hit someone with it.")
 
 	if(force != throwforce && throwforce >= MELEE_FORCE_WEAK)
 		switch(throwforce)
@@ -29,4 +29,4 @@
 				strong_text = "a very strong"
 			if(MELEE_FORCE_VERY_STRONG to INFINITY)
 				strong_text = "an inhumanely strong"
-		. += SPAN_INFO("[src] would be [strong_text] weapon if you were throw it at someone.")
+		. += SPAN_INFO("[src] would be [strong_text] weapon if you were to throw it at someone.")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

When checking the throw force the default message was never set back to "weak", so it would end up showing throw force the same strength as the melee force if throwing force was at least 5 but lower than 10.

Also made the checks more consistent and not overlap.

# Explain why it's good for the game

No.


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: Fixed an edge case that caused the melee strength's value to be shown as the throwing strength, when examining a weapon.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
