### PR TITLE
Fix burrower being able to tail stab when burrowed

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
@@ -889,6 +889,10 @@
 /datum/action/xeno_action/activable/tail_stab/use_ability(atom/targetted_atom)
 	var/mob/living/carbon/xenomorph/stabbing_xeno = owner
 
+	if(stabbing_xeno.burrow || stabbing_xeno.is_ventcrawling)
+		to_chat(stabbing_xeno, SPAN_XENOWARNING("You must be above ground to do this."))
+		return
+
 	if(!stabbing_xeno.check_state())
 		return FALSE
 


### PR DESCRIPTION
# About the pull request

This PR fixes an unintended effect where a burrower could tailstab a target next to them when burrowed. Winding up is still allowed however.

# Explain why it's good for the game

A marine cannot retaliate or anticipate this attack in any way.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://user-images.githubusercontent.com/76988376/236652463-8a1ee89f-8c05-4558-825a-4f65abb0d561.png)
(Message was text changed from above to replicate what attempting to tremor in this situation says)
</details>


# Changelog
:cl: Drathek
fix: Fixed burrowers being able to tail stab when burrowed
/:cl:
