### PR TITLE
Fix re-zooming when observing a mark or xeno

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/general_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/general_abilities.dm
@@ -298,6 +298,9 @@
 	var/mob/living/carbon/xenomorph/xeno = owner
 	xeno.speed_modifier = initial(xeno.speed_modifier)// Reset the speed modifier should you be disrupted while zooming or whatnot
 
+	if(xeno.observed_xeno)
+		return
+
 	if(xeno.is_zoomed)
 		xeno.zoom_out() // will also handle icon_state
 		xeno.visible_message(SPAN_NOTICE("[xeno] stops looking off into the distance."), \


### PR DESCRIPTION

# About the pull request

This PR prevents using the toggle_long_range ability when observing a xeno or mark. There is already behavior that causes the zoom effect to end on observation, but nothing was preventing zooming again while still in that state.

Entering a tunnel, and traveling to other locations in the tunnel does not reset any zoom, nor prevents zooming. I think this is fine because you are actually in that location and are using your own senses to view further.

# Explain why it's good for the game

Fixes #356 

# Changelog
:cl: Drathek
fix: Fixed xeno toggle_long_range ability from being used when observing a xeno or mark
/:cl:
