### PR TITLE
Pred Cloak Drain Change

### DIFF
--- a/code/modules/cm_preds/yaut_bracers.dm
+++ b/code/modules/cm_preds/yaut_bracers.dm
@@ -283,7 +283,7 @@
 	var/mob/living/carbon/human/human = loc
 
 	if(cloaked)
-		charge = max(charge - 10, 0)
+		charge = min(charge + 15, charge_max)
 		if(charge <= 0)
 			decloak(loc)
 		//Non-Yautja have a chance to get stunned with each power drain
@@ -520,7 +520,7 @@
 			to_chat(M, SPAN_WARNING("Your cloaking device is still recharging! Time left: <B>[max(round((cloak_timer - world.time) / 10), 1)]</b> seconds."))
 			return FALSE
 
-		if(!drain_power(M, 50))
+		if(!drain_power(M, 100))
 			return FALSE
 
 		cloaked = TRUE


### PR DESCRIPTION

# About the pull request

After discussing with the Yautja Council, I have changed how the cloak affects the energy drain.

Initial cloaking costs 100 now instead of 50.

The cloak no longer drains charge. Instead, you gain 15 charge per tic. (Default gain is 30 uncloaked)

# Explain why it's good for the game

Less preds standing around in the open. More spooky ghosts.

It was tested on Private Server. Works as intended.

# Changelog
:cl:
balance: Yautja initial cloak costs 100 charge instead of 50. Cloak no longer drains but charges by 15.
/:cl:
