### PR TITLE
Extra larva per burst config option

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -116,3 +116,8 @@
 
 /datum/config_entry/flag/events_disallowed
 	config_entry_value = FALSE
+
+
+///Used to determine how many extra larva you want per burst. Supports fractions. See /datum/hive_status/proc/increase_larva_after_burst()
+/datum/config_entry/number/extra_larva_per_burst
+	config_entry_value = 1

--- a/code/modules/mob/living/carbon/xenomorph/Embryo.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Embryo.dm
@@ -171,7 +171,7 @@
 	if(hive)
 		hive.add_xeno(new_xeno)
 		if(!affected_mob.first_xeno)
-			hive.stored_larva++
+			hive.increase_larva_after_burst()
 			hive.hive_ui.update_burrowed_larva()
 
 	new_xeno.update_icons()

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -252,6 +252,9 @@
 	var/list/open_xeno_leader_positions = list(1, 2) // Ordered list of xeno leader positions (indexes in xeno_leader_list) that are not occupied
 	var/list/xeno_leader_list[2] // Ordered list (i.e. index n holds the nth xeno leader)
 	var/stored_larva = 0
+
+	///used by /datum/hive_status/proc/increase_larva_after_burst() to support non-integer increases to larva
+	var/partial_larva = 0
 	/// Assoc list of free slots available to specific castes
 	var/list/free_slots = list(
 		/datum/caste_datum/burrower = 1,
@@ -1007,6 +1010,14 @@
 	hugger.visible_message(SPAN_XENODANGER("A facehugger suddenly emerges out of \the [A]!"), SPAN_XENODANGER("You emerge out of \the [A] and awaken from your slumber. For the Hive!"))
 	playsound(hugger, 'sound/effects/xeno_newlarva.ogg', 25, TRUE)
 	hugger.generate_name()
+
+///Called by /obj/item/alien_embryo when a host is bursting to determine extra larva per burst
+/datum/hive_status/proc/increase_larva_after_burst()
+	var/extra_per_burst = CONFIG_GET(number/extra_larva_per_burst)
+	partial_larva += extra_per_burst
+	for(var/i = 1 to partial_larva)
+		partial_larva--
+		stored_larva++
 
 /datum/hive_status/corrupted
 	name = "Corrupted Hive"


### PR DESCRIPTION

# About the pull request

Adds a config option for larva per burst.

# Explain why it's good for the game

Server customization good

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl:
config: Extra larva per burst config option
/:cl:
