### PR TITLE
Fixes UI icon for hiding not resetting after a pounce

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
@@ -391,6 +391,9 @@
 	if(X.layer == XENO_HIDING_LAYER) //Xeno is currently hiding, unhide him
 		X.layer = MOB_LAYER
 		X.update_wounds()
+		var/datum/action/hide_ability = get_xeno_action_by_type(X, /datum/action/xeno_action/onclick/xenohide)
+		if(hide_ability)
+			hide_ability.button.icon_state = "template"
 
 	if(isravager(X))
 		X.emote("roar")


### PR DESCRIPTION

# About the pull request

This PR fixes an issue where the hide icon will remain highlighted in purple as if it was active after a pounce. Pouncing resets the hiding layer, but did not reset the icon.

# Explain why it's good for the game

Fixes #1784 

# Changelog
:cl: Drathek
ui: Fixed xeno hide icon not resetting after a pounce
/:cl:
