### PR TITLE
Fix for ChemERT objectives.

### DIFF
--- a/code/datums/emergency_calls/goons.dm
+++ b/code/datums/emergency_calls/goons.dm
@@ -78,7 +78,7 @@
 
 	print_backstory(mob)
 
-	addtimer(CALLBACK(GLOBAL_PROC, PROC_REF(to_chat), mob, SPAN_BOLD("Objectives:</b> [objectives]")), 1 SECONDS)
+	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(to_chat), mob, SPAN_BOLD("Objectives:</b> [objectives]")), 1 SECONDS)
 
 /datum/emergency_call/goon/chem_retrieval/print_backstory(mob/living/carbon/human/backstory_human)
 	if(backstory_human.job == JOB_WY_GOON_RESEARCHER)
@@ -87,7 +87,7 @@
 		to_chat(backstory_human, SPAN_BOLD("You have a very in depth understanding of xenomorphs."))
 		to_chat(backstory_human, SPAN_BOLD("You are a well educated scientist employed by Weyland-Yutani to study various non-humans."))
 		to_chat(backstory_human, SPAN_BOLD("You heard about the original distress signal ages ago, but you have only just gotten permission from corporate to enter the area."))
-		to_chat(backstory_human, SPAN_BOLD("Your only goal is to recover the chemicals aboard the Almayer. Do whatever you have to"))
+		to_chat(backstory_human, SPAN_BOLD("Your only goal is to recover the chemical aboard the Almayer. Do whatever you have to do."))
 	else
 		to_chat(backstory_human, SPAN_BOLD("You were born [pick(75;"in Europe", 15;"in Asia", 10;"on Mars")] to a poor family."))
 		to_chat(backstory_human, SPAN_BOLD("Joining the ranks of Weyland-Yutani was all you could do to keep yourself and your loved ones fed."))


### PR DESCRIPTION

# About the pull request

Followup to #3011.
This was brought to my attention after the chemical goons somehow did not receive their proper objective and the resulting raid escalated a lot. Once again, my gratitude to the player who sent me the screenshots.
Although I am honestly baffled by how this works. When tested locally, present setup works just fine. On live server, see next section. Is it a stable/beta Byond difference at work, maybe?
Still, this seems like an obvious thing to fix. Also, slightly modified the text to emphasise that there is (most likely) a _singular_ chemical that is the objective.

# Explain why it's good for the game

![image](https://user-images.githubusercontent.com/4447185/236807210-dec71fc5-02db-4b73-bae9-30d5afd6c5db.png)
![image](https://user-images.githubusercontent.com/4447185/236807270-7015da4c-1448-48b3-be9d-20ea9d19c080.png)


# Changelog
:cl:
fix: Chemical Investigation Goons should now properly be shown their actual objective.
/:cl:
