### PR TITLE
Apc slash and doorcontrol button fix

### DIFF
--- a/code/game/machinery/door_control.dm
+++ b/code/game/machinery/door_control.dm
@@ -270,5 +270,3 @@
 
 	desiredstate = !desiredstate
 
-/obj/structure/machinery/door_control/power_change()
-	return

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -924,6 +924,7 @@ GLOBAL_LIST_INIT(apc_wire_descriptions, list(
 	switch(wire)
 		if(APC_WIRE_MAIN_POWER)
 			if(!isWireCut(APC_WIRE_MAIN_POWER))
+				beenhit = 0
 				shorted = 0
 				shock(usr, 50)
 


### PR DESCRIPTION

# About the pull request

APCs became unslashable if someone fixed a previously slashed one by mending the power wire, but then never screwdrivered the panel back on.

Doorcontrol buttons were some why allowed to remain always powered on, no idea why, cause it allows them and connected shutters to work when they shouldn't.

# Explain why it's good for the game

...

# Testing Photographs and Procedure
Yes.


# Changelog
:cl:Jackie_Estegado
fix: APCs no longer become unslashable in specific cases.
fix: Doorcontrol buttons no longer stay powered despite their area losing power.
/:cl:
