### PR TITLE
Fixes a runtime with vehicles

### DIFF
--- a/code/modules/vehicles/hardpoints/hardpoint.dm
+++ b/code/modules/vehicles/hardpoints/hardpoint.dm
@@ -529,6 +529,8 @@
 
 //doing last preparation before actually firing gun
 /obj/item/hardpoint/proc/fire(mob/user, atom/A)
+	if(!ammo) //The gun doesn't have ammo, and doesn't do anything when fired. Prevents a runtime
+		return
 	if(ammo.current_rounds <= 0)
 		return
 

--- a/code/modules/vehicles/hardpoints/hardpoint.dm
+++ b/code/modules/vehicles/hardpoints/hardpoint.dm
@@ -529,7 +529,7 @@
 
 //doing last preparation before actually firing gun
 /obj/item/hardpoint/proc/fire(mob/user, atom/A)
-	if(!ammo) //The gun doesn't have ammo, and doesn't do anything when fired. Prevents a runtime
+	if(!ammo) //Prevents a runtime
 		return
 	if(ammo.current_rounds <= 0)
 		return


### PR DESCRIPTION
# About the pull request

If a vehicle's hardpoints doesn't have ammo, due to not being a gun, it would runtime if attempted to fire.

# Explain why it's good for the game

Bugs bad

# Changelog

:cl:
fix: Fixes a runtime involving vehicle hardpoints
/:cl: