### PR TITLE
fix for typo in tgui docs

### DIFF
--- a/tgui/docs/component-reference.md
+++ b/tgui/docs/component-reference.md
@@ -64,7 +64,7 @@ of styling options for all components, e.g. `color` and `opacity`, thus
 it is used a lot in this framework.
 
 **Event handlers.**
-Event handlers are callbacks that you can attack to various element to
+Event handlers are callbacks that you can attach to various elements to
 listen for browser events. Inferno supports camelcase (`onClick`) and
 lowercase (`onclick`) event names.
 

--- a/tgui/docs/tutorial-and-examples.md
+++ b/tgui/docs/tutorial-and-examples.md
@@ -250,7 +250,7 @@ If you need more examples of what you can do with React, see the
 
 #### Splitting UIs into smaller, modular components
 
-You interface will eventually get really, really big. The easiest thing
+Your interface will eventually get really, really big. The easiest thing
 you can do in this situation, is divide and conquer. Grab a chunk of your
 JSX code, and wrap it into a second, smaller React component:
 


### PR DESCRIPTION
# About the pull request

fix for a minor spelling error in the documentation for tgui.

# Changelog

:cl:
spellcheck: fixed tgui documentation typo 
/:cl: