### PR TITLE
Fixes a runtime with tape recorder

### DIFF
--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -845,7 +845,7 @@ W is always an item. stop_warning prevents messaging. user may be null.**/
 	if(isturf(target) && get_dist(src, target) <= 1 && storage_flags & STORAGE_CLICK_EMPTY)
 		empty(user, target)
 
-/obj/item/storage/hear_talk(mob/living/M as mob, msg, verb="says", datum/language/speaking, italics = 0)
+/obj/item/storage/hear_talk(mob/living/M, msg, verb, datum/language/speaking, italics)
 	// Whatever is stored in /storage/ substypes should ALWAYS be an item
 	for (var/obj/item/I as anything in hearing_items)
 		I.hear_talk(M, msg, verb, speaking, italics)

--- a/code/modules/clothing/suits/storage.dm
+++ b/code/modules/clothing/suits/storage.dm
@@ -36,8 +36,8 @@
 	pockets.emp_act(severity)
 	..()
 
-/obj/item/clothing/suit/storage/hear_talk(mob/M, msg)
-	pockets.hear_talk(M, msg)
+/obj/item/clothing/suit/storage/hear_talk(mob/living/M, msg, verb, datum/language/speaking, italics)
+	pockets.hear_talk(M, msg, verb, speaking, italics)
 	..()
 
 /obj/item/clothing/suit/storage/verb/toggle_draw_mode()


### PR DESCRIPTION
# About the pull request

If the recorder were in suit storage, it would not be able to read the language and runtime when trying to scramble it.

# Explain why it's good for the game

Bug Bad

# Changelog

:cl:
fix: Fixes a tape recorder runtime
/:cl: