### PR TITLE
Fix tackling infected resetting tackles

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
@@ -629,7 +629,7 @@
 		TC.tackle_reset_id = null
 
 	. = TC.attempt_tackle(tackle_bonus)
-	if (!.)
+	if (!. || (M.status_flags & XENO_HOST))
 		TC.tackle_reset_id = addtimer(CALLBACK(src, PROC_REF(reset_tackle), M), 4 SECONDS, TIMER_UNIQUE | TIMER_STOPPABLE)
 	else
 		reset_tackle(M)


### PR DESCRIPTION
# About the pull request

Tackles no longer reset instantly for infected other than the normal tackle reset if avoided tackles for 4 seconds.

# Explain why it's good for the game

![image](https://github.com/cmss13-devs/cmss13/assets/107966994/eab698ca-4134-4532-99e6-77c8206c2888)

Shows the tackle code and the signal handler code. As stated in the comments of the signal handler, infected mobs should not reset the tackle counter on knock down or getting up. In the current iteration, whenever someone is knocked down, their tackle counter is always reset when successfully tackled ( attempt tackle returning true ).

In this new iteration, tackling an infected mob successfully causes the reset_tackle to be called 4 seconds later and no longer instantly ( for non-infected mobs ).

# Changelog

:cl:
fix: Infected mobs tackle counters no longer reset instantly.
/:cl:
