### PR TITLE
Throw Delay

### DIFF
--- a/code/__DEFINES/conflict.dm
+++ b/code/__DEFINES/conflict.dm
@@ -140,6 +140,9 @@
 #define WIELD_DELAY_VERY_SLOW 10
 #define WIELD_DELAY_HORRIBLE 12
 
+///This is how long you must wait after throwing something to throw again
+#define THROW_DELAY 0.25 SECONDS
+
 //Explosion level thresholds. Upper bounds
 #define EXPLOSION_THRESHOLD_VLOW 50
 #define EXPLOSION_THRESHOLD_LOW 100

--- a/code/__DEFINES/conflict.dm
+++ b/code/__DEFINES/conflict.dm
@@ -141,7 +141,7 @@
 #define WIELD_DELAY_HORRIBLE 12
 
 ///This is how long you must wait after throwing something to throw again
-#define THROW_DELAY 0.25 SECONDS
+#define THROW_DELAY (0.4 SECONDS)
 
 //Explosion level thresholds. Upper bounds
 #define EXPLOSION_THRESHOLD_VLOW 50

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -88,7 +88,9 @@
 
 	// Throwing stuff, can't throw on inventory items nor screen objects nor items inside storages.
 	if (throw_mode && A.loc != src && !isstorage(A.loc) && !istype(A, /atom/movable/screen))
-		throw_item(A)
+		if(throw_delay < world.time)
+			throw_item(A)
+			throw_delay = world.time + THROW_DELAY
 		return
 
 	// Last thing clicked is tracked for something somewhere.

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -88,9 +88,15 @@
 
 	// Throwing stuff, can't throw on inventory items nor screen objects nor items inside storages.
 	if (throw_mode && A.loc != src && !isstorage(A.loc) && !istype(A, /atom/movable/screen))
+		//if we're past the throw delay just throw, add the new delay time, and reset the buffer
 		if(throw_delay < world.time)
 			throw_item(A)
 			throw_delay = world.time + THROW_DELAY
+			throw_buffer = 0
+		//if we're still in the throw delay we check if the buffer is already used, if not then we throw the item and set the buffer as used
+		else if(!throw_buffer)
+			throw_item(A)
+			throw_buffer++
 		return
 
 	// Last thing clicked is tracked for something somewhere.

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -89,9 +89,9 @@
 	// Throwing stuff, can't throw on inventory items nor screen objects nor items inside storages.
 	if (throw_mode && A.loc != src && !isstorage(A.loc) && !istype(A, /atom/movable/screen))
 		//if we're past the throw delay just throw, add the new delay time, and reset the buffer
-		if(throw_delay < world.time)
+		if(COOLDOWN_FINISHED(src, throw_delay))
 			throw_item(A)
-			throw_delay = world.time + THROW_DELAY
+			COOLDOWN_START(src, throw_delay, THROW_DELAY)
 			throw_buffer = 0
 		//if we're still in the throw delay we check if the buffer is already used, if not then we throw the item and set the buffer as used
 		else if(!throw_buffer)

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -225,7 +225,11 @@
 	var/next_delay_delay = 10 // how much time we wait for next calc of move delay
 	var/move_delay
 
+	///Holds the time when a mob can throw an item next, only applies after two throws, reference /mob/proc/do_click()
 	var/throw_delay = 0
+
+	///holds the buffer to allow for throwing two things before the cooldown effects throwing, reference /mob/proc/do_click()
+	var/throw_buffer = 0
 
 	var/list/datum/action/actions = list()
 

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -225,6 +225,8 @@
 	var/next_delay_delay = 10 // how much time we wait for next calc of move delay
 	var/move_delay
 
+	var/throw_delay = 0
+
 	var/list/datum/action/actions = list()
 
 	can_block_movement = TRUE

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -226,7 +226,7 @@
 	var/move_delay
 
 	///Holds the time when a mob can throw an item next, only applies after two throws, reference /mob/proc/do_click()
-	var/throw_delay = 0
+	COOLDOWN_DECLARE(throw_delay)
 
 	///holds the buffer to allow for throwing two things before the cooldown effects throwing, reference /mob/proc/do_click()
 	var/throw_buffer = 0


### PR DESCRIPTION
# About the pull request

This adds a 0.4 second throw delay that takes effect after throwing twice,

I'm probably overengineering this at this point iunno.

# Explain why it's good for the game

People throwing a knife 20 times in less than a second is not intentional gameplay.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: Morrow
balance: Adds a throw delay of 0.4 seconds which takes effect after throwing twice. Two hands, two throws.
/:cl:
