### PR TITLE
Replaces warden's hook with weeds

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/general_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/general_abilities.dm
@@ -20,6 +20,10 @@
 	var/plant_on_semiweedable = FALSE
 	var/node_type = /obj/effect/alien/weeds/node
 
+/datum/action/xeno_action/onclick/plant_weeds/warden
+	name = "Plant Weeds (150)"
+	plasma_cost = 150
+
 // Resting
 /datum/action/xeno_action/onclick/xeno_resting
 	name = "Rest"

--- a/code/modules/mob/living/carbon/xenomorph/mutators/strains/praetorian/warden.dm
+++ b/code/modules/mob/living/carbon/xenomorph/mutators/strains/praetorian/warden.dm
@@ -14,9 +14,9 @@
 	mutator_actions_to_add = list(
 		/datum/action/xeno_action/activable/spray_acid/prae_warden,
 		/datum/action/xeno_action/activable/warden_heal,
-		/datum/action/xeno_action/activable/prae_retrieve,
 		/datum/action/xeno_action/onclick/prae_switch_heal_type,
 		/datum/action/xeno_action/onclick/emit_pheromones,
+		/datum/action/xeno_action/onclick/plant_weeds/warden,
 	)
 	behavior_delegate_type = /datum/behavior_delegate/praetorian_warden
 	keystone = TRUE


### PR DESCRIPTION

# About the pull request
Removes Warden praetorian's hook ability and replaces it with the ability to plant weeds, for double the plasma cost.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Allows Warden to live up to its gimmick of a support caste.
As for the hook itself, It was rarely used and even more rarely useful due to how it works and just ended up being an extra ability, Weeds on the other hand allow them to support flanks or replenish weeds at the front though with a smaller plasma pool (800) and double the plasma cost for making weeds (150) this should make it so they don't overshadow drones.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: Replaced Warden Praetorian's hook with the ability to plant weeds for double the normal plasma cost.
/:cl:
