### PR TITLE
Fix And Tweak Admin Log Verbs

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -66,15 +66,15 @@ var/list/admin_verbs_default = list(
 	/datum/admins/proc/subtlemessageall,
 	/datum/admins/proc/alertall,
 	/datum/admins/proc/imaginary_friend,
-	/client/proc/getserverlog, /*allows us to fetch server logs (diary) for other days*/
 	)
 
 var/list/admin_verbs_admin = list(
 	/datum/admins/proc/togglejoin, /*toggles whether people can join the current game*/
 	/datum/admins/proc/announce, /*priority announce something to all clients.*/
-	/datum/admins/proc/view_txt_log, /*shows the server log (diary) for today*/
+	/datum/admins/proc/view_game_log, /*shows the server game log (diary) for today*/
+	/datum/admins/proc/view_attack_log, /*shows the server attack log for today*/
+	/client/proc/giveruntimelog, /*allows us to give access to all runtime logs to somebody*/
 	/client/proc/cmd_admin_delete, /*delete an instance/object/mob/etc*/
-	/client/proc/giveruntimelog, /*allows us to give access to runtime logs to somebody*/
 	/client/proc/toggleprayers, /*toggles prayers on/off*/
 	/client/proc/toggle_hear_radio, /*toggles whether we hear the radio*/
 	/client/proc/event_panel,
@@ -90,10 +90,12 @@ var/list/admin_verbs_admin = list(
 	/client/proc/matrix_editor,
 	/datum/admins/proc/open_shuttlepanel
 )
+
 var/list/admin_verbs_ban = list(
 	/client/proc/unban_panel
 	// /client/proc/jobbans // Disabled temporarily due to 15-30 second lag spikes. Don't forget the comma in the line above when uncommenting this!
 )
+
 var/list/admin_verbs_sounds = list(
 	/client/proc/play_web_sound,
 	/client/proc/play_sound,
@@ -101,6 +103,7 @@ var/list/admin_verbs_sounds = list(
 	/client/proc/stop_sound,
 	/client/proc/cmd_admin_vox_panel
 )
+
 var/list/admin_verbs_minor_event = list(
 	/client/proc/cmd_admin_change_custom_event,
 	/datum/admins/proc/admin_force_distress,
@@ -129,6 +132,7 @@ var/list/admin_verbs_minor_event = list(
 	/client/proc/adminpanelweapons,
 	/client/proc/adminpanelgq
 )
+
 var/list/admin_verbs_major_event = list(
 	/client/proc/enable_event_mob_verbs,
 	/client/proc/cmd_admin_dress_all,
@@ -148,12 +152,14 @@ var/list/admin_verbs_major_event = list(
 	/client/proc/change_taskbar_icon,
 	/client/proc/change_weather
 )
+
 var/list/admin_verbs_spawn = list(
 	/datum/admins/proc/spawn_atom,
 	/client/proc/game_panel,
 	/client/proc/create_humans,
 	/client/proc/create_xenos
 )
+
 var/list/admin_verbs_server = list(
 	/datum/admins/proc/startnow,
 	/datum/admins/proc/restart,
@@ -166,10 +172,9 @@ var/list/admin_verbs_server = list(
 	/client/proc/cmd_admin_delete, /*delete an instance/object/mob/etc*/
 	/client/proc/cmd_debug_del_all,
 	/datum/admins/proc/togglejoin,
-	/datum/admins/proc/view_txt_log
 )
+
 var/list/admin_verbs_debug = list(
-	/client/proc/getruntimelog,  /*allows us to access runtime logs to somebody*/
 	/client/proc/debug_role_authority,
 	/client/proc/cmd_debug_make_powernets,
 	/client/proc/cmd_debug_list_processing_items,
@@ -193,6 +198,13 @@ var/list/admin_verbs_debug = list(
 	/client/proc/enter_tree,
 	/client/proc/set_tree_points,
 	/client/proc/purge_data_tab,
+	/client/proc/getserverlog, /*allows us to fetch any server logs (diary) for other days*/
+	/client/proc/getruntimelog,  /*allows us to access any runtime logs (can be granted by giveruntimelog)*/
+	/datum/admins/proc/view_game_log, /*shows the server game log (diary) for today*/
+	/datum/admins/proc/view_attack_log, /*shows the server attack log for today*/
+	/datum/admins/proc/view_runtime_log, /*shows the server runtime log for today*/
+	/datum/admins/proc/view_href_log, /*shows the server HREF log for today*/
+	/datum/admins/proc/view_tgui_log, /*shows the server TGUI log for today*/
 )
 
 var/list/admin_verbs_debug_advanced = list(
@@ -220,9 +232,11 @@ var/list/admin_verbs_possess = list(
 	/client/proc/possess,
 	/client/proc/release
 )
+
 var/list/admin_verbs_permissions = list(
 	/client/proc/ToRban
 )
+
 var/list/admin_verbs_color = list(
 	/client/proc/set_ooc_color_self
 )

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -71,8 +71,8 @@ var/list/admin_verbs_default = list(
 var/list/admin_verbs_admin = list(
 	/datum/admins/proc/togglejoin, /*toggles whether people can join the current game*/
 	/datum/admins/proc/announce, /*priority announce something to all clients.*/
-	/datum/admins/proc/view_game_log, /*shows the server game log (diary) for today*/
-	/datum/admins/proc/view_attack_log, /*shows the server attack log for today*/
+	/datum/admins/proc/view_game_log, /*shows the server game log (diary) for this round*/
+	/datum/admins/proc/view_attack_log, /*shows the server attack log for this round*/
 	/client/proc/giveruntimelog, /*allows us to give access to all runtime logs to somebody*/
 	/client/proc/cmd_admin_delete, /*delete an instance/object/mob/etc*/
 	/client/proc/toggleprayers, /*toggles prayers on/off*/
@@ -200,10 +200,10 @@ var/list/admin_verbs_debug = list(
 	/client/proc/purge_data_tab,
 	/client/proc/getserverlog, /*allows us to fetch any server logs (diary) for other days*/
 	/client/proc/getruntimelog,  /*allows us to access any runtime logs (can be granted by giveruntimelog)*/
-	/datum/admins/proc/view_game_log, /*shows the server game log (diary) for today*/
-	/datum/admins/proc/view_runtime_log, /*shows the server runtime log for today*/
-	/datum/admins/proc/view_href_log, /*shows the server HREF log for today*/
-	/datum/admins/proc/view_tgui_log, /*shows the server TGUI log for today*/
+	/datum/admins/proc/view_game_log, /*shows the server game log (diary) for this round*/
+	/datum/admins/proc/view_runtime_log, /*shows the server runtime log for this round*/
+	/datum/admins/proc/view_href_log, /*shows the server HREF log for this round*/
+	/datum/admins/proc/view_tgui_log, /*shows the server TGUI log for this round*/
 )
 
 var/list/admin_verbs_debug_advanced = list(

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -201,7 +201,6 @@ var/list/admin_verbs_debug = list(
 	/client/proc/getserverlog, /*allows us to fetch any server logs (diary) for other days*/
 	/client/proc/getruntimelog,  /*allows us to access any runtime logs (can be granted by giveruntimelog)*/
 	/datum/admins/proc/view_game_log, /*shows the server game log (diary) for today*/
-	/datum/admins/proc/view_attack_log, /*shows the server attack log for today*/
 	/datum/admins/proc/view_runtime_log, /*shows the server runtime log for today*/
 	/datum/admins/proc/view_href_log, /*shows the server HREF log for today*/
 	/datum/admins/proc/view_tgui_log, /*shows the server TGUI log for today*/

--- a/code/modules/admin/verbs/getlogs.dm
+++ b/code/modules/admin/verbs/getlogs.dm
@@ -77,10 +77,10 @@
 
 //Other log stuff put here for the sake of organisation
 
-//Shows today's server log
+/**Shows this round's server log*/
 /datum/admins/proc/view_game_log()
 	set name = "Show Server Game Log"
-	set desc = "Shows today's server game log."
+	set desc = "Shows this round's server game log."
 	set category = "Server"
 
 	if(!check_rights(R_MOD|R_DEBUG))
@@ -98,10 +98,10 @@
 	to_chat(src, "Attempting to send file, this may take a fair few minutes if the file is very large.")
 	src << run(file(path))
 
-//Shows today's attack log
+/**Shows this round's attack log*/
 /datum/admins/proc/view_attack_log()
 	set name = "Show Server Attack Log"
-	set desc = "Shows today's server attack log."
+	set desc = "Shows this round's server attack log."
 	set category = "Server"
 
 	if(!check_rights(R_MOD))
@@ -119,10 +119,10 @@
 	to_chat(src, "Attempting to send file, this may take a fair few minutes if the file is very large.")
 	src << run(file(path))
 
-//Shows today's runtime log
+/**Shows this round's runtime log*/
 /datum/admins/proc/view_runtime_log()
 	set name = "Show Server Runtime Log"
-	set desc = "Shows today's server runtime log."
+	set desc = "Shows this round's server runtime log."
 	set category = "Server"
 
 	if(!check_rights(R_DEBUG))
@@ -140,10 +140,10 @@
 	to_chat(src, "Attempting to send file, this may take a fair few minutes if the file is very large.")
 	src << run(file(path))
 
-//Shows today's href log
+/**Shows this round's href log*/
 /datum/admins/proc/view_href_log()
 	set name = "Show Server HREF Log"
-	set desc = "Shows today's server HREF log."
+	set desc = "Shows this round's server HREF log."
 	set category = "Server"
 
 	if(!check_rights(R_DEBUG))
@@ -161,10 +161,10 @@
 	to_chat(src, "Attempting to send file, this may take a fair few minutes if the file is very large.")
 	src << run(file(path))
 
-//Shows today's tgui log
+/**Shows this round's tgui log*/
 /datum/admins/proc/view_tgui_log()
 	set name = "Show Server TGUI Log"
-	set desc = "Shows today's server TGUI log."
+	set desc = "Shows this round's server TGUI log."
 	set category = "Server"
 
 	if(!check_rights(R_DEBUG))

--- a/code/modules/admin/verbs/getlogs.dm
+++ b/code/modules/admin/verbs/getlogs.dm
@@ -13,7 +13,6 @@
 	codebase for the entire /TG/station commuity a TONNE easier :3 Thanks for your help!
 */
 
-
 //This proc allows Game Masters to grant a client access to the .getruntimelog verb
 //Permissions expire at the end of each round.
 //Runtimes can be used to meta or spot game-crashing exploits so it's advised to only grant coders that
@@ -23,25 +22,24 @@
 	set desc = "Give somebody access to any session logfiles saved to the /log/runtime/ folder."
 	set category = null
 
-	if(!src.admin_holder || !(admin_holder.rights & R_MOD))
-		to_chat(src, "<font color='red'>Only Admins may use this command.</font>")
+	if(!src.admin_holder || !(admin_holder.rights & R_MOD) || !(admin_holder.rights & R_DEBUG))
+		to_chat(src, "<font color='red'>Access denied.</font>")
 		return
 
 	var/client/target = tgui_input_list(src,"Choose somebody to grant access to the server's runtime logs (permissions expire at the end of each round):","Grant Permissions", GLOB.clients)
-	if(!istype(target,/client))
+	if(!istype(target, /client))
 		to_chat(src, "<font color='red'>Error: giveruntimelog(): Client not found.</font>")
 		return
 
+	message_admins("[key_name_admin(src)] granted [key_name_admin(target)] access to runtime logs this round.")
 	target.verbs |= /client/proc/getruntimelog
 	to_chat(target, "<font color='red'>You have been granted access to runtime logs. Please use them responsibly or risk being banned.</font>")
-	return
-
 
 //This proc allows download of runtime logs saved within the data/logs/ folder by dreamdeamon.
 //It works similarly to show-server-log.
 /client/proc/getruntimelog()
 	set name = ".getruntimelog"
-	set desc = "Retrieve any session logfiles saved by dreamdeamon."
+	set desc = "Pick a logfile from data/logs/runtime to view."
 	set category = null
 
 	var/path = browse_files("data/logs/runtime/")
@@ -52,17 +50,19 @@
 		return
 
 	message_admins("[key_name_admin(src)] accessed file: [path]")
-	src << run( file(path) )
 	to_chat(src, "Attempting to send file, this may take a fair few minutes if the file is very large.")
-	return
-
+	src << run(file(path))
 
 //This proc allows download of past server logs saved within the data/logs/ folder.
 //It works similarly to show-server-log.
 /client/proc/getserverlog()
 	set name = ".getserverlog"
-	set desc = "Fetch logfiles from data/logs"
+	set desc = "Pick a logfile from data/logs to view."
 	set category = null
+
+	if(!src.admin_holder || !(admin_holder.rights & (R_MOD) || !(admin_holder.rights & R_DEBUG)))
+		to_chat(src, "<font color='red'>Access denied.</font>")
+		return
 
 	var/path = browse_files("data/logs/")
 	if(!path)
@@ -72,44 +72,112 @@
 		return
 
 	message_admins("[key_name_admin(src)] accessed file: [path]")
-	src << run( file(path) )
 	to_chat(src, "Attempting to send file, this may take a fair few minutes if the file is very large.")
-	return
-
+	src << run(file(path))
 
 //Other log stuff put here for the sake of organisation
 
 //Shows today's server log
-/datum/admins/proc/view_txt_log()
-	set name = "Show Server Log"
-	set desc = "Shows today's server log."
+/datum/admins/proc/view_game_log()
+	set name = "Show Server Game Log"
+	set desc = "Shows today's server game log."
 	set category = "Server"
 
-	var/path = "data/logs/[time2text(world.realtime,"YYYY/MM-Month/DD-Day")].log"
-	if( fexists(path) )
-		src << run( file(path) )
-	else
-		var/pathyesteday = "data/logs/[time2text(world.realtime-400000,"YYYY/MM-Month/DD-Day")].log" // roughly 12 hours before this, should cover for most issues
-		if( fexists(pathyesteday) )
-			src << run( file(pathyesteday) )
-		else
-			to_chat(src, "<font color='red'>Error: view_txt_log(): File not found/Invalid path([path]) or path([pathyesteday]).</font>")
-			return
+	if(!check_rights(R_MOD|R_DEBUG))
+		return
 
-	return
+	var/path = GLOB.world_game_log
+	if(!fexists(path))
+		to_chat(src, "<font color='red'>Error: view_log(): File not found/Invalid path([path]).</font>")
+		return
+
+	if(usr.client.file_spam_check())
+		return
+
+	message_admins("[key_name_admin(src)] accessed file: [path]")
+	to_chat(src, "Attempting to send file, this may take a fair few minutes if the file is very large.")
+	src << run(file(path))
 
 //Shows today's attack log
-/datum/admins/proc/view_atk_log()
-	set category = "Admin"
+/datum/admins/proc/view_attack_log()
 	set name = "Show Server Attack Log"
 	set desc = "Shows today's server attack log."
+	set category = "Server"
 
-	var/path = "data/logs/[time2text(world.realtime,"YYYY/MM-Month/DD-Day")] Attack.log"
-	if( fexists(path) )
-		src << run( file(path) )
-	else
-		to_chat(src, "<font color='red'>Error: view_atk_log(): File not found/Invalid path([path]).</font>")
+	if(!check_rights(R_MOD))
 		return
-	usr << run( file(path) )
 
-	return
+	var/path = GLOB.world_attack_log
+	if(!fexists(path))
+		to_chat(src, "<font color='red'>Error: view_log(): File not found/Invalid path([path]).</font>")
+		return
+
+	if(usr.client.file_spam_check())
+		return
+
+	message_admins("[key_name_admin(src)] accessed file: [path]")
+	to_chat(src, "Attempting to send file, this may take a fair few minutes if the file is very large.")
+	src << run(file(path))
+
+//Shows today's runtime log
+/datum/admins/proc/view_runtime_log()
+	set name = "Show Server Runtime Log"
+	set desc = "Shows today's server runtime log."
+	set category = "Server"
+
+	if(!check_rights(R_DEBUG))
+		return
+
+	var/path = GLOB.world_runtime_log
+	if(!fexists(path))
+		to_chat(src, "<font color='red'>Error: view_log(): File not found/Invalid path([path]).</font>")
+		return
+
+	if(usr.client.file_spam_check())
+		return
+
+	message_admins("[key_name_admin(src)] accessed file: [path]")
+	to_chat(src, "Attempting to send file, this may take a fair few minutes if the file is very large.")
+	src << run(file(path))
+
+//Shows today's href log
+/datum/admins/proc/view_href_log()
+	set name = "Show Server HREF Log"
+	set desc = "Shows today's server HREF log."
+	set category = "Server"
+
+	if(!check_rights(R_DEBUG))
+		return
+
+	var/path = GLOB.world_href_log
+	if(!fexists(path))
+		to_chat(src, "<font color='red'>Error: view_log(): File not found/Invalid path([path]).</font>")
+		return
+
+	if(usr.client.file_spam_check())
+		return
+
+	message_admins("[key_name_admin(src)] accessed file: [path]")
+	to_chat(src, "Attempting to send file, this may take a fair few minutes if the file is very large.")
+	src << run(file(path))
+
+//Shows today's tgui log
+/datum/admins/proc/view_tgui_log()
+	set name = "Show Server TGUI Log"
+	set desc = "Shows today's server TGUI log."
+	set category = "Server"
+
+	if(!check_rights(R_DEBUG))
+		return
+
+	var/path = GLOB.tgui_log
+	if(!fexists(path))
+		to_chat(src, "<font color='red'>Error: view_log(): File not found/Invalid path([path]).</font>")
+		return
+
+	if(usr.client.file_spam_check())
+		return
+
+	message_admins("[key_name_admin(src)] accessed file: [path]")
+	to_chat(src, "Attempting to send file, this may take a fair few minutes if the file is very large.")
+	src << run(file(path))


### PR DESCRIPTION
# About the pull request

This PR fixes the incorrect path for view_txt_log (now is view_game_log) from #3069, adds the view_attack_log verb to possible admin verbs (was previously unreferenced), and adds verbs to view the current runtime, href, and tgui logs. More checks and logging is performed when accessing these files such as spam prevention and rights access (rights are based off of what STUI currently requires but whether the verb is added is not necessarily one to one with its rights check).

# Explain why it's good for the game

More working admin verbs and accountability.

# Changelog
:cl: Drathek
admin: Tweaked and added more server log verbs
/:cl:
