### PR TITLE
Extra larva per burst non-integer fix

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -121,3 +121,4 @@
 ///Used to determine how many extra larva you want per burst. Supports fractions. See /datum/hive_status/proc/increase_larva_after_burst()
 /datum/config_entry/number/extra_larva_per_burst
 	config_entry_value = 1
+	integer = FALSE


### PR DESCRIPTION

# About the pull request

Somehow I removed this during testing and then forgot about it. I am a doofus.

# Explain why it's good for the game

Unintentional

# Testing Photographs and Procedure

Obviously I need to start filling this out.

# Changelog
:cl:
fix: Extra larva per burst non-integer fix
/:cl:
