### PR TITLE
ID Console Fixes

### DIFF
--- a/code/modules/cm_marines/marines_consoles.dm
+++ b/code/modules/cm_marines/marines_consoles.dm
@@ -85,8 +85,9 @@
 		if("PRG_print")
 			if(!printing)
 				if(params["mode"])
-					if(!authenticated)
+					if(!authenticated || !target_id_card)
 						return
+
 					printing = TRUE
 					playsound(src.loc, 'sound/machines/fax.ogg', 15, 1)
 					sleep(40)
@@ -164,7 +165,7 @@
 						return TRUE
 			return FALSE
 		if("PRG_terminate")
-			if(!authenticated)
+			if(!authenticated || !target_id_card)
 				return
 
 			target_id_card.assignment = "Terminated"
@@ -175,6 +176,7 @@
 		if("PRG_edit")
 			if(!authenticated || !target_id_card)
 				return
+
 			var/new_name = params["name"] // reject_bad_name() can be added here
 			if(!new_name)
 				visible_message(SPAN_NOTICE("[src] buzzes rudely."))
@@ -210,8 +212,9 @@
 			message_admins("[key_name_admin(usr)] gave the ID of [target_id_card.registered_name] the assignment '[target_id_card.assignment]'.")
 			return TRUE
 		if("PRG_access")
-			if(!authenticated)
+			if(!authenticated || !target_id_card)
 				return
+
 			var/access_type = params["access_target"]
 			if(params["access_target"] in factions)
 				if(!target_id_card.faction_group)
@@ -233,23 +236,26 @@
 					log_idmod(target_id_card, "<font color='green'> [key_name_admin(usr)] granted access '[access_type]'. </font>")
 				return TRUE
 		if("PRG_grantall")
-			if(!authenticated)
+			if(!authenticated || !target_id_card)
 				return
+
 			target_id_card.access |= (is_centcom ? get_all_centcom_access() : get_all_accesses())
 			target_id_card.faction_group |= factions
 			log_idmod(target_id_card, "<font color='green'> [key_name_admin(usr)] granted the ID all access and USCM IFF. </font>")
 			return TRUE
 		if("PRG_denyall")
-			if(!authenticated)
+			if(!authenticated || !target_id_card)
 				return
+
 			var/list/access = target_id_card.access
 			access.Cut()
 			target_id_card.faction_group -= factions
 			log_idmod(target_id_card, "<font color='red'> [key_name_admin(usr)] removed all accesses and USCM IFF. </font>")
 			return TRUE
 		if("PRG_grantregion")
-			if(!authenticated)
+			if(!authenticated || !target_id_card)
 				return
+
 			if(params["region"] == "Faction (IFF system)")
 				target_id_card.faction_group |= factions
 				log_idmod(target_id_card, "<font color='green'> [key_name_admin(usr)] granted USCM IFF. </font>")
@@ -262,8 +268,9 @@
 			log_idmod(target_id_card, "<font color='green'> [key_name_admin(usr)] granted all [additions] accesses. </font>")
 			return TRUE
 		if("PRG_denyregion")
-			if(!authenticated)
+			if(!authenticated || !target_id_card)
 				return
+
 			if(params["region"] == "Faction (IFF system)")
 				target_id_card.faction_group -= factions
 				log_idmod(target_id_card, "<font color='red'> [key_name_admin(usr)] revoked USCM IFF. </font>")
@@ -276,8 +283,9 @@
 			log_idmod(target_id_card, "<font color='red'> [key_name_admin(usr)] revoked all [additions] accesses. </font>")
 			return TRUE
 		if("PRG_account")
-			if(!authenticated)
+			if(!authenticated || !target_id_card)
 				return
+
 			var/account = text2num(params["account"])
 			target_id_card.associated_account_number = account
 			log_idmod(target_id_card, "<font color='orange'> [key_name_admin(usr)] changed the account number to '[account]'. </font>")

--- a/code/modules/economy/Accounts.dm
+++ b/code/modules/economy/Accounts.dm
@@ -35,7 +35,10 @@
 	T.date = "[num2text(rand(1,31))] [pick("January","February","March","April","May","June","July","August","September","October","November","December")], [game_year - rand(0, 10)]"
 	T.time = "[rand(0,24)]:[rand(11,59)]"
 	T.source_terminal = "Weyland-Yutani Terminal #[rand(111,1111)]"
-	M.account_number = rand(111111, 999999)
+	for(var/attempt in 1 to 100) // Make up to 100 attempts to get a unique account number
+		M.account_number = rand(111111, 999999)
+		if(!get_account(M.account_number))
+			break // Account number is unique!
 	//add the account
 	M.transaction_log.Add(T)
 	all_money_accounts.Add(M)

--- a/tgui/packages/tgui/interfaces/CardMod.js
+++ b/tgui/packages/tgui/interfaces/CardMod.js
@@ -1,6 +1,6 @@
 import { Fragment } from 'inferno';
 import { useBackend, useLocalState } from '../backend';
-import { Box, Button, Stack, Input, Section, Tabs, Table } from '../components';
+import { Box, Button, Stack, Input, Section, Tabs, Table, NumberInput } from '../components';
 import { Window } from '../layouts';
 import { AccessList } from './common/AccessList';
 import { map } from 'common/collections';
@@ -126,16 +126,22 @@ export const CardContent = (props, context) => {
           content={id_name}
           onClick={() => act('PRG_eject')}
         />
-        Linked Account:
-        <Input
-          value={id_account}
-          width="150px"
-          onInput={(e, value) =>
-            act('PRG_account', {
-              account: value,
-            })
-          }
-        />
+        {!!has_id && !!authenticated && (
+          <Fragment>
+            Linked Account:
+            <NumberInput
+              value={id_account}
+              minValue={1}
+              maxValue={9999999}
+              width="70px"
+              onChange={(e, value) =>
+                act('PRG_account', {
+                  account: value,
+                })
+              }
+            />
+          </Fragment>
+        )}
       </Section>
       {!!has_id && !!authenticated && (
         <Box>

--- a/tgui/packages/tgui/interfaces/CardMod.js
+++ b/tgui/packages/tgui/interfaces/CardMod.js
@@ -131,9 +131,9 @@ export const CardContent = (props, context) => {
             Linked Account:
             <NumberInput
               value={id_account}
-              minValue={1}
-              maxValue={9999999}
-              width="70px"
+              minValue={111111}
+              maxValue={999999}
+              width="60px"
               onChange={(e, value) =>
                 act('PRG_account', {
                   account: value,


### PR DESCRIPTION

# About the pull request

This PR fixes a couple runtimes with the ID Console trying to manipulate a non-existent target card. The linked account field is now hidden when there is no target card, is now a number field ranging from 111111 to 999999 (to match automatic generated accounts), and only submits the change after the field loses focus.

I have also mitigated the possibility of players getting the same account number, though this ID console makes no indication an account is unique.

# Explain why it's good for the game

Less runtimes, less number assignment spam, and a slightly more user friendly interface.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/cmss13-devs/cmss13/assets/76988376/8bf1fe24-fa3a-4fd3-861f-9dea392a92ea)

</details>


# Changelog
:cl: Drathek
fix: Fixed runtimes with the ID Console
fix: Account numbers are now far less likely to match another person's account
ui: Changed linked account field in the ID Console to a restricted input field
/:cl:
