### PR TITLE
Remove Dead Code for Lurker Rush

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/lurker/lurker_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/lurker/lurker_powers.dm
@@ -109,7 +109,6 @@
 	target.apply_armoured_damage(get_xeno_damage_slash(target, xeno.caste.melee_damage_upper), ARMOR_MELEE, BRUTE, "chest")
 	playsound(get_turf(target), 'sound/weapons/alien_claw_flesh3.ogg', 30, TRUE)
 	shake_camera(target, 2, 1)
-	apply_cooldown(0.65)
 
 /datum/action/xeno_action/activable/flurry/use_ability(atom/targeted_atom) //flurry ability
 	var/mob/living/carbon/xenomorph/xeno = owner


### PR DESCRIPTION

# About the pull request

This PR simply removes a line in lurker rush code that is currently doing nothing (it just hits the return statement because a timer for the cooldown is already active). See #2938 on how it should have been, but it currently fits fine in balance. If it were to be a thing, this ability would likely need to only work *at all* on a valid sprite click. Wiki page has already been updated to remove mention that a successful attack reduces the cooldown.

# Explain why it's good for the game

Code should convey what it is doing, not suggest it is doing something else.

# Changelog
:cl: Drathek
code: Removed dead code in lurker rush suggesting it lowered cooldown on a successful hit
/:cl:
