### PR TITLE
Fix runtime preventing thrown weapon attack logs that gib the target

### DIFF
--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -76,7 +76,10 @@
 			src.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been hit with a [O], thrown by [key_name(M)]</font>")
 			M.attack_log += text("\[[time_stamp()]\] <font color='red'>Hit [key_name(src)] with a thrown [O]</font>")
 			if(!istype(src,/mob/living/simple_animal/mouse))
-				msg_admin_attack("[key_name(src)] was hit by a [O], thrown by [key_name(M)] in [get_area(src)] ([src.loc.x],[src.loc.y],[src.loc.z]).", src.loc.x, src.loc.y, src.loc.z)
+				if(src.loc)
+					msg_admin_attack("[key_name(src)] was hit by a [O], thrown by [key_name(M)] in [get_area(src)] ([src.loc.x],[src.loc.y],[src.loc.z]).", src.loc.x, src.loc.y, src.loc.z)
+				else
+					msg_admin_attack("[key_name(src)] was hit by a [O], thrown by [key_name(M)] in [get_area(M)] ([M.loc.x],[M.loc.y],[M.loc.z]).", M.loc.x, M.loc.y, M.loc.z)
 	if(last_damage_source)
 		last_damage_data = create_cause_data(last_damage_source, M)
 


### PR DESCRIPTION

# About the pull request

This PR simply fixes a runtime that would prevent an attack log being created when a thrown weapon gibs its target. Since the gibbed target has no loc, it will fall back to the thrower's loc instead.

# Explain why it's good for the game

Attack logs should always work.

# Changelog
:cl: Drathek
fix: Fixed attack log not occuring when a thrown weapon gibs its target
/:cl:
