### PR TITLE
"Hardcore" Trait

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -171,6 +171,8 @@
 #define TRAIT_HOLDS_CANE "t_holds_cane"
 /// If the mob is buckled to a wheelchair.
 #define TRAIT_USING_WHEELCHAIR "t_using_wheelchair"
+/// If the mob will instantly go permadead upon death
+#define TRAIT_HARDCORE "t_hardcore"
 
 // -- ability traits --
 /// Xenos with this trait cannot have plasma transfered to them

--- a/code/modules/character_traits/biology_traits.dm
+++ b/code/modules/character_traits/biology_traits.dm
@@ -113,3 +113,21 @@
 	..()
 
 //datum/character_trait/biology/bad_leg/unapply_trait(mob/living/carbon/human/target) // IMPOSSIBLE
+
+/datum/character_trait/biology/hardcore
+	trait_name = "Hardcore"
+	trait_desc = "One life. One chance. (Rifleman Only)"
+	applyable = TRUE
+	cost = 1
+
+/datum/character_trait/biology/hardcore/apply_trait(mob/living/carbon/human/target, datum/equipment_preset/preset)
+	if(target.job != JOB_SQUAD_MARINE)
+		to_chat(target, SPAN_WARNING("Only riflemen can have the Hardcore trait."))
+		return
+
+	ADD_TRAIT(target, TRAIT_HARDCORE, TRAIT_SOURCE_QUIRK)
+	..()
+
+/datum/character_trait/biology/hardcore/unapply_trait(mob/living/carbon/human/target)
+	REMOVE_TRAIT(target, TRAIT_HARDCORE, TRAIT_SOURCE_QUIRK)
+	..()

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -43,6 +43,8 @@
 		return
 	GLOB.alive_human_list -= src
 	if(!gibbed)
+		if(HAS_TRAIT(src, TRAIT_HARDCORE))
+			status_flags |= PERMANENTLY_DEAD
 		disable_special_flags()
 		disable_lights()
 		disable_special_items()
@@ -95,4 +97,9 @@
 				to_chat(delayer, SPAN_WARNING("Your [delayer_armour]'s camo system breaks!"))
 			//tell the ghosts
 			announce_dchat("There is only one person left: [last_living_human.real_name].", last_living_human)
-	return ..(cause, gibbed, species.death_message)
+
+	var/death_message = species.death_message
+	if(HAS_TRAIT(src, TRAIT_HARDCORE))
+		death_message = "valiantly falls to the ground, dead, unable to continue."
+
+	return ..(cause, gibbed, death_message)


### PR DESCRIPTION
# About the pull request

If a rifleman has the "Hardcore" trait, they will instantly perma upon death.

# Explain why it's good for the game

It allows marines to practice and show confidence in their skills, by knowing that if they die they cannot get revived. Many marines already do this by DNRing, the only difference is that they could be revived soulless.
It is limited to riflemen only so a limited role that would actually matter if it went perma dead quickly won't lose slots.

# Changelog

:cl:
add: Adds the "Hardcore" trait for Riflemen
/:cl: