### PR TITLE
Adds a tracker for how many hugs a player facehugger has

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
@@ -241,7 +241,7 @@
 				next_facehug_goal = FACEHUG_TIER_1
 			if(FACEHUG_TIER_1 to FACEHUG_TIER_2)
 				next_facehug_goal = FACEHUG_TIER_2
-			if(FACEHUG_TIER_2 to FACEHUG_TIER_3) // 25 - 99
+			if(FACEHUG_TIER_2 to FACEHUG_TIER_3)
 				next_facehug_goal = FACEHUG_TIER_3
 			if(FACEHUG_TIER_3 to FACEHUG_TIER_4) // 100 - 999
 				next_facehug_goal = FACEHUG_TIER_4

--- a/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
@@ -41,6 +41,10 @@
 	counts_for_roundend = FALSE
 	refunds_larva_if_banished = FALSE
 	can_hivemind_speak = FALSE
+	/// The lifetime hugs from this hugger
+	var/total_facehugs = 0
+	/// How many hugs the hugger needs to age
+	var/next_facehug_goal = FACEHUG_TIER_1
 	base_actions = list(
 		/datum/action/xeno_action/onclick/xeno_resting,
 		/datum/action/xeno_action/watch_xeno,
@@ -49,7 +53,6 @@
 	)
 	inherent_verbs = list(
 		/mob/living/carbon/xenomorph/proc/vent_crawl,
-		/mob/living/carbon/xenomorph/facehugger/proc/check_hugs,
 	)
 	mutation_type = "Normal"
 
@@ -169,12 +172,16 @@
 	switch(total_facehugs)
 		if(FACEHUG_TIER_1 to FACEHUG_TIER_2)
 			age = XENO_MATURE
+			next_facehug_goal = FACEHUG_TIER_2
 		if(FACEHUG_TIER_2 to FACEHUG_TIER_3)
 			age = XENO_ELDER
+			next_facehug_goal = FACEHUG_TIER_3
 		if(FACEHUG_TIER_3 to FACEHUG_TIER_4)
 			age = XENO_ANCIENT
+			next_facehug_goal = FACEHUG_TIER_4
 		if(FACEHUG_TIER_4 to INFINITY)
 			age = XENO_PRIME
+			next_facehug_goal = null
 
 	// For people who wish to remain anonymous
 	if(!client.prefs.playtime_perks)
@@ -227,26 +234,9 @@
 /mob/living/carbon/xenomorph/facehugger/emote(act, m_type, message, intentional, force_silence)
 	playsound(loc, "alien_roar_larva", 15)
 
-/mob/living/carbon/xenomorph/facehugger/proc/check_hugs()
-	set name = "Check Hugs"
-	set desc = "Check how many talls you have hugged in total."
-	set category = "Alien"
-
-
-	var/total_facehugs = get_client_stat(client, PLAYER_STAT_FACEHUGS)
-	var/next_facehug_goal = "no more, you are already Royal!"
-	if(total_facehugs < FACEHUG_TIER_4)
-		switch(total_facehugs)
-			if(0 to FACEHUG_TIER_1)
-				next_facehug_goal = FACEHUG_TIER_1
-			if(FACEHUG_TIER_1 to FACEHUG_TIER_2)
-				next_facehug_goal = FACEHUG_TIER_2
-			if(FACEHUG_TIER_2 to FACEHUG_TIER_3)
-				next_facehug_goal = FACEHUG_TIER_3
-			if(FACEHUG_TIER_3 to FACEHUG_TIER_4)
-				next_facehug_goal = FACEHUG_TIER_4
-		next_facehug_goal = "[next_facehug_goal - total_facehugs] more talls to age."
-
-	to_chat(src, SPAN_BOLDNOTICE("You have hugged [total_facehugs] talls. You need to hug [next_facehug_goal]"))
-
-
+/mob/living/carbon/xenomorph/facehugger/get_status_tab_items()
+	. = ..()
+	if(next_facehug_goal)
+		. += "Lifetime Hugs: [total_facehugs] / [next_facehug_goal]"
+	else
+		. += "Lifetime Hugs: [total_facehugs]"

--- a/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
@@ -239,7 +239,7 @@
 		switch(total_facehugs)
 			if(0 to FACEHUG_TIER_1)
 				next_facehug_goal = FACEHUG_TIER_1
-			if(FACEHUG_TIER_1 to FACEHUG_TIER_2) // 5 - 24
+			if(FACEHUG_TIER_1 to FACEHUG_TIER_2)
 				next_facehug_goal = FACEHUG_TIER_2
 			if(FACEHUG_TIER_2 to FACEHUG_TIER_3) // 25 - 99
 				next_facehug_goal = FACEHUG_TIER_3

--- a/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
@@ -237,7 +237,7 @@
 	var/next_facehug_goal = "no more, you are already Royal!"
 	if(total_facehugs < FACEHUG_TIER_4)
 		switch(total_facehugs)
-			if(0 to FACEHUG_TIER_1) // 0 - 4
+			if(0 to FACEHUG_TIER_1)
 				next_facehug_goal = FACEHUG_TIER_1
 			if(FACEHUG_TIER_1 to FACEHUG_TIER_2) // 5 - 24
 				next_facehug_goal = FACEHUG_TIER_2

--- a/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
@@ -168,7 +168,7 @@
 
 	age = XENO_NORMAL
 
-	var/total_facehugs = get_client_stat(client, PLAYER_STAT_FACEHUGS)
+	total_facehugs = get_client_stat(client, PLAYER_STAT_FACEHUGS)
 	switch(total_facehugs)
 		if(FACEHUG_TIER_1 to FACEHUG_TIER_2)
 			age = XENO_MATURE

--- a/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
@@ -243,7 +243,7 @@
 				next_facehug_goal = FACEHUG_TIER_2
 			if(FACEHUG_TIER_2 to FACEHUG_TIER_3)
 				next_facehug_goal = FACEHUG_TIER_3
-			if(FACEHUG_TIER_3 to FACEHUG_TIER_4) // 100 - 999
+			if(FACEHUG_TIER_3 to FACEHUG_TIER_4)
 				next_facehug_goal = FACEHUG_TIER_4
 		next_facehug_goal = "[next_facehug_goal - total_facehugs] more talls to age."
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
@@ -49,6 +49,7 @@
 	)
 	inherent_verbs = list(
 		/mob/living/carbon/xenomorph/proc/vent_crawl,
+		/mob/living/carbon/xenomorph/facehugger/proc/check_hugs,
 	)
 	mutation_type = "Normal"
 
@@ -225,3 +226,27 @@
 
 /mob/living/carbon/xenomorph/facehugger/emote(act, m_type, message, intentional, force_silence)
 	playsound(loc, "alien_roar_larva", 15)
+
+/mob/living/carbon/xenomorph/facehugger/proc/check_hugs()
+	set name = "Check Hugs"
+	set desc = "Check how many talls you have hugged in total."
+	set category = "Alien"
+
+
+	var/total_facehugs = get_client_stat(client, PLAYER_STAT_FACEHUGS)
+	var/next_facehug_goal = "no more, you are already Royal!"
+	if(total_facehugs < FACEHUG_TIER_4)
+		switch(total_facehugs)
+			if(0 to FACEHUG_TIER_1) // 0 - 4
+				next_facehug_goal = FACEHUG_TIER_1
+			if(FACEHUG_TIER_1 to FACEHUG_TIER_2) // 5 - 24
+				next_facehug_goal = FACEHUG_TIER_2
+			if(FACEHUG_TIER_2 to FACEHUG_TIER_3) // 25 - 99
+				next_facehug_goal = FACEHUG_TIER_3
+			if(FACEHUG_TIER_3 to FACEHUG_TIER_4) // 100 - 999
+				next_facehug_goal = FACEHUG_TIER_4
+		next_facehug_goal = "[next_facehug_goal - total_facehugs] more talls to age."
+
+	to_chat(src, SPAN_BOLDNOTICE("You have hugged [total_facehugs] talls. You need to hug [next_facehug_goal]"))
+
+


### PR DESCRIPTION
# About the pull request

Adds total facehugs / facehugs to next age to status panel

(Note: I was unable to test this locally due to player_stats just not existing for me)
# Explain why it's good for the game

Better than them needing to manually record it

# Changelog

:cl:
qol: lets player facehuggers see their lifetime hugs on the status panel
/:cl: