### PR TITLE
Being stunned via slugs or buckshot will now decloak lurkers

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/Lurker.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Lurker.dm
@@ -137,6 +137,17 @@
 		if(LIA && istype(LIA))
 			LIA.end_cooldown()
 
+/mob/living/carbon/xenomorph/lurker/update_canmove()
+    . = ..()
+    if(!canmove && stealth)
+        var/datum/behavior_delegate/lurker_base/behavior = behavior_delegate
+        behavior.force_invisibility_off() // Being stunned will force invisibility off
+
+/datum/behavior_delegate/lurker_base/proc/force_invisibility_off()
+	var/datum/action/xeno_action/onclick/lurker_invisibility/LIA = get_xeno_action_by_type(bound_xeno, /datum/action/xeno_action/onclick/lurker_invisibility)
+	if (LIA && istype(LIA))
+		LIA.invisibility_off()
+
 /datum/behavior_delegate/lurker_base/append_to_stat()
 	. = list()
 	var/invis_message = (invis_start_time == -1) ? "N/A" : "[(invis_duration-(world.time - invis_start_time))/10] seconds."

--- a/code/modules/mob/living/carbon/xenomorph/castes/Lurker.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Lurker.dm
@@ -138,10 +138,10 @@
 			LIA.end_cooldown()
 
 /mob/living/carbon/xenomorph/lurker/update_canmove()
-    . = ..()
-    if(!canmove && stealth)
-        var/datum/behavior_delegate/lurker_base/behavior = behavior_delegate
-        behavior.force_invisibility_off() // Being stunned will force invisibility off
+	. = ..()
+	if(!canmove && stealth)
+		var/datum/behavior_delegate/lurker_base/behavior = behavior_delegate
+		behavior.force_invisibility_off() // Being stunned will force invisibility off
 
 /datum/behavior_delegate/lurker_base/proc/force_invisibility_off()
 	var/datum/action/xeno_action/onclick/lurker_invisibility/LIA = get_xeno_action_by_type(bound_xeno, /datum/action/xeno_action/onclick/lurker_invisibility)


### PR DESCRIPTION
# About the pull request

When stunned by ammo such as slugs, heavy revolver, or buckshot, lurkers will be uncloaked.

# Explain why it's good for the game

Previously, lurkers used to have their cloak be temporarily removed with their icon for being stunned and cloaked not having existed. This meant, when a lurker was slugged, buckshotted, etc they would be visible. This PR brings that back but in the scope of lurkers actually losing their invisibility instead of it being an icon bug. This will help with lurkers being stunned repeatedly and ignoring any punishment by continuing to speed away with their cloak. It also is inconsistent with all other forms of cloak (scout, predator) in which their cloak will deactivate if spotted/punished for being spotted.  Hopefully it'll also improve slug usage versus lurkers and make that ammo type a little more viable when having to fend off invisible lurkers.


# Changelog

:cl: Usnpeepoo, Drathek
balance: Lurkers now decloak when stunned by ammo such as slugs or buckshot
/:cl:

