### PR TITLE
Fix huggers dying while attached to a host before they can impregnate it

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
@@ -77,6 +77,9 @@
 	addtimer(CALLBACK(src, PROC_REF(check_turf)), 0.2 SECONDS)
 	if(stat == CONSCIOUS && loc) //Make sure we're conscious and not idle or dead.
 		go_idle()
+	if(attached == TRUE)
+		attached = FALSE
+		die()
 
 /obj/item/clothing/mask/facehugger/proc/check_turf()
 	var/count = 0
@@ -373,6 +376,9 @@
 
 /obj/item/clothing/mask/facehugger/proc/die()
 	if(stat == DEAD)
+		return
+
+	if(attached && !impregnated)
 		return
 
 	if(jump_timer)

--- a/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
@@ -77,7 +77,7 @@
 	addtimer(CALLBACK(src, PROC_REF(check_turf)), 0.2 SECONDS)
 	if(stat == CONSCIOUS && loc) //Make sure we're conscious and not idle or dead.
 		go_idle()
-	if(attached == TRUE)
+	if(attached)
 		attached = FALSE
 		die()
 

--- a/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
@@ -175,8 +175,7 @@
 
 /obj/item/clothing/mask/facehugger/equipped(mob/M)
 	SHOULD_CALL_PARENT(FALSE) // ugh equip sounds
-	// So getting hugged or picking up a hugger does not
-	// prematurely kill the hugger
+	// So picking up a hugger does not prematurely kill it
 	go_idle()
 
 /obj/item/clothing/mask/facehugger/Crossed(atom/target)
@@ -248,13 +247,14 @@
 
 	// This is always going to be valid because of the can_hug check above
 	var/mob/living/carbon/human/H = M
-	attached = TRUE
 	if(!silent)
 		H.visible_message(SPAN_DANGER("[src] leaps at [H]'s face!"))
 
 	if(isxeno(loc)) //Being carried? Drop it
 		var/mob/living/carbon/xenomorph/X = loc
 		X.drop_inv_item_on_ground(src)
+
+	attached = TRUE
 
 	if(isturf(H.loc))
 		forceMove(H.loc)//Just checkin


### PR DESCRIPTION
# About the pull request

Fixes huggers occasionaly dying while attached to a host before they can impregnate it by preventing them from dying at all while attached to the host until they have impregnated it.

# Explain why it's good for the game

Gets rid of those not-so-rare occurrences where hugging a human would result in the hugger not actually infecting it, requiring an additional hugger to finish the job.

# Changelog

:cl:
fix: Fixed huggers occasionally dying before they can impregnate a host.
/:cl: