### PR TITLE
Staff Sergeant Warden

### DIFF
--- a/code/game/jobs/job/command/police/warden.dm
+++ b/code/game/jobs/job/command/police/warden.dm
@@ -3,6 +3,7 @@
 	title = JOB_WARDEN
 	selection_class = "job_mp"
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT
+	supervisors = "the Chief MP"
 	gear_preset = /datum/equipment_preset/uscm_ship/uscm_police/warden
 	entry_message_body = "<a href='"+URL_WIKI_MW_GUIDE+"'>You</a> are held by a higher standard and are required to obey not only the server rules but the <a href='"+URL_WIKI_LAW+"'>Marine Law</a>. Failure to do so may result in a job ban or server ban. Your primary job is to maintain peace and stability aboard the ship. Marines can get rowdy after a few weeks of cryosleep! In addition, you are tasked with the mainting security records and overwatching any prisoners in Brig."
 

--- a/code/modules/gear_presets/uscm_police.dm
+++ b/code/modules/gear_presets/uscm_police.dm
@@ -90,7 +90,7 @@
 	)
 	assignment = JOB_WARDEN
 	rank = JOB_WARDEN
-	paygrade = "MO1"
+	paygrade = "ME6"
 	role_comm_title = "MW"
 	skills = /datum/skills/MW
 


### PR DESCRIPTION
# About the pull request

This PR makes the Warden a staff sergeant/E6.

This PR designates the Warden reports to the CMP rather than the aCO (which caused some weird situations yesterday).

# Explain why it's good for the game

Alright let's be real, rank changes are incredibly annoying, mostly arbitrary, and everyone argues about them forever. At the same time, I want some senior NCOs and the warden's job functions as both a senior NCO and a junior officer without much change. Having some senior NCO representation (outside of a whitelisted role) aboard the ship is interesting.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
add: Wardens are now staff sergeants
/:cl:
