### PR TITLE
ensures people always have at least a set of keybinds

### DIFF
--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -90,7 +90,7 @@
 
 /proc/sanitize_keybindings(value)
 	var/list/base_bindings = sanitize_islist(value, list())
-	if(!base_bindings)
+	if(!length(base_bindings))
 		base_bindings = deepCopyList(GLOB.hotkey_keybinding_list_by_key)
 	for(var/key in base_bindings)
 		base_bindings[key] = base_bindings[key] & GLOB.keybindings_by_name


### PR DESCRIPTION
privates keep getting immobilized because they don't have any keybinds and not realising they can reset them in the hotkeys menu - i do not need to tell anyone that this is not ideal new player experience

:cl:
fix: new players will now no longer have no hotkeys, and be unable to move or talk, because that sucks
/:cl: