### PR TITLE
makes the join pred ghost button only appear during pred rounds

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_global.dm
+++ b/code/__DEFINES/dcs/signals/signals_global.dm
@@ -47,3 +47,6 @@
 
 // Used for smothering fires upon weather event start/stop
 #define COMSIG_GLOB_WEATHER_CHANGE "!weather_event_changed"
+
+/// From /datum/admins/proc/force_predator_round()
+#define COMSIG_GLOB_PREDATOR_ROUND_TOGGLED "!predator_round_toglged"

--- a/code/modules/admin/tabs/round_tab.dm
+++ b/code/modules/admin/tabs/round_tab.dm
@@ -46,6 +46,7 @@
 		predator_round.flags_round_type &= ~MODE_PREDATOR
 
 	message_admins("[key_name_admin(usr)] has [(predator_round.flags_round_type & MODE_PREDATOR) ? "allowed predators to spawn" : "prevented predators from spawning"].")
+	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_PREDATOR_ROUND_TOGGLED)
 
 /client/proc/free_slot()
 	set name = "Free Job Slots"

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -201,7 +201,7 @@
 /mob/dead/observer/Login()
 	..()
 
-	if(!(locate(/datum/action/join_predator) in actions) && RoleAuthority.roles_whitelist[src.ckey] & WHITELIST_PREDATOR)
+	if(!(locate(/datum/action/join_predator) in actions) && RoleAuthority.roles_whitelist[src.ckey] & WHITELIST_PREDATOR && SSticker.mode.flags_round_type & MODE_PREDATOR)
 		var/datum/action/join_predator/new_action = new()
 		new_action.give_to(src)
 

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -1054,6 +1054,9 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 	var/key_to_use = ckey || persistent_ckey
 
+	if(!key_to_use)
+		return
+
 	if(!(RoleAuthority.roles_whitelist[key_to_use] & WHITELIST_PREDATOR))
 		return
 

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -207,25 +207,6 @@
 
 	client.move_delay = MINIMAL_MOVEMENT_INTERVAL
 
-/mob/dead/observer/proc/toggle_predator_action()
-	var/key_to_use = ckey || persistent_ckey
-
-	if(!(RoleAuthority.roles_whitelist[key_to_use] & WHITELIST_PREDATOR))
-		return
-
-	if(SSticker.mode.flags_round_type & MODE_PREDATOR)
-		if(locate(/datum/action/join_predator) in actions)
-			return
-
-		var/datum/action/join_predator/new_action = new()
-		new_action.give_to(src)
-		return
-
-	var/datum/action/join_predator/old_action = locate() in actions
-	if(old_action)
-		qdel(old_action)
-
-
 /mob/dead/observer/Destroy()
 	QDEL_NULL(orbit_menu)
 	QDEL_NULL(last_health_display)
@@ -1066,3 +1047,24 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 			&& src.z == nearby_observer.z && get_dist(src, nearby_observer) <= observer_client.view)
 			to_chat(observer_client, SPAN_DEADSAY("<b>[src]</b> points to [A] [nearby_observer.format_jump(A)]"))
 	return TRUE
+
+/// This proc is called when a predator round is toggled by the admin verb, as well as when a ghost logs in
+/mob/dead/observer/proc/toggle_predator_action()
+	SIGNAL_HANDLER
+
+	var/key_to_use = ckey || persistent_ckey
+
+	if(!(RoleAuthority.roles_whitelist[key_to_use] & WHITELIST_PREDATOR))
+		return
+
+	if(SSticker.mode.flags_round_type & MODE_PREDATOR)
+		if(locate(/datum/action/join_predator) in actions)
+			return
+
+		var/datum/action/join_predator/new_action = new()
+		new_action.give_to(src)
+		return
+
+	var/datum/action/join_predator/old_action = locate() in actions
+	if(old_action)
+		qdel(old_action)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -127,6 +127,8 @@
 		var/datum/action/observer_action/new_action = new path()
 		new_action.give_to(src)
 
+	RegisterSignal(SSdcs, COMSIG_GLOB_PREDATOR_ROUND_TOGGLED, PROC_REF(toggle_predator_action))
+
 	if(SSticker.mode && SSticker.mode.flags_round_type & MODE_PREDATOR)
 		addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(to_chat), src, "<span style='color: red;'>This is a <B>PREDATOR ROUND</B>! If you are whitelisted, you may Join the Hunt!</span>"), 2 SECONDS)
 
@@ -201,11 +203,27 @@
 /mob/dead/observer/Login()
 	..()
 
-	if(!(locate(/datum/action/join_predator) in actions) && RoleAuthority.roles_whitelist[src.ckey] & WHITELIST_PREDATOR && SSticker.mode.flags_round_type & MODE_PREDATOR)
-		var/datum/action/join_predator/new_action = new()
-		new_action.give_to(src)
+	toggle_predator_action()
 
 	client.move_delay = MINIMAL_MOVEMENT_INTERVAL
+
+/mob/dead/observer/proc/toggle_predator_action()
+	var/key_to_use = ckey || persistent_ckey
+
+	if(!(RoleAuthority.roles_whitelist[key_to_use] & WHITELIST_PREDATOR))
+		return
+
+	if(SSticker.mode.flags_round_type & MODE_PREDATOR)
+		if(locate(/datum/action/join_predator) in actions)
+			return
+
+		var/datum/action/join_predator/new_action = new()
+		new_action.give_to(src)
+		return
+
+	var/datum/action/join_predator/old_action = locate() in actions
+	if(old_action)
+		qdel(old_action)
 
 
 /mob/dead/observer/Destroy()


### PR DESCRIPTION
i forgot this from the original pr after refactoring it into /Login()

:cl:
qol: whitelisted predators now only see the option to join pred rounds as a ghost in the top left when it is a pred round
/:cl: