### PR TITLE
prevents people spacewalking

### DIFF
--- a/code/game/turfs/transit.dm
+++ b/code/game/turfs/transit.dm
@@ -5,21 +5,17 @@
 	baseturfs = /turf/open/space/transit
 	var/auto_space_icon = TRUE
 
-/turf/open/space/transit/Crossed(atom/movable/crosser)
+/turf/open/space/transit/Entered(atom/movable/crosser, atom/old_loc)
 	. = ..()
 
 	if(isobserver(crosser) || crosser.anchored)
 		return
 
-	var/neighbours = list()
-	for(var/dir in GLOB.cardinals)
-		neighbours += get_step(loc, dir)
+	var/turf/open/floor/floor = old_loc
+	if(istype(floor))
+		var/fling_dir = get_dir(floor, crosser.loc)
 
-	var/turf/open/floor/floor = locate() in neighbours
-	if(floor)
-		var/fling_dir = get_dir(floor, loc)
-
-		var/turf/near_turf = get_step(loc, get_step(loc, fling_dir))
+		var/turf/near_turf = get_step(crosser.loc, get_step(crosser.loc, fling_dir))
 		var/turf/projected = get_ranged_target_turf(near_turf, fling_dir, 50)
 
 		INVOKE_ASYNC(crosser, TYPE_PROC_REF(/atom/movable, throw_atom), projected, 50, SPEED_FAST, null, TRUE)

--- a/code/game/turfs/transit.dm
+++ b/code/game/turfs/transit.dm
@@ -101,48 +101,48 @@
 	icon_state = "speedspace_ns_4"
 
 /turf/open/space/transit/north/shuttlespace_ns5
-		auto_space_icon = FALSE
-		icon_state = "speedspace_ns_5"
+	auto_space_icon = FALSE
+	icon_state = "speedspace_ns_5"
 
 /turf/open/space/transit/north/shuttlespace_ns6
-		auto_space_icon = FALSE
-		icon_state = "speedspace_ns_6"
+	auto_space_icon = FALSE
+	icon_state = "speedspace_ns_6"
 
 /turf/open/space/transit/north/shuttlespace_ns7
-		auto_space_icon = FALSE
-		icon_state = "speedspace_ns_7"
+	auto_space_icon = FALSE
+	icon_state = "speedspace_ns_7"
 
 /turf/open/space/transit/north/shuttlespace_ns8
-		auto_space_icon = FALSE
-		icon_state = "speedspace_ns_8"
+	auto_space_icon = FALSE
+	icon_state = "speedspace_ns_8"
 
 /turf/open/space/transit/north/shuttlespace_ns9
-		auto_space_icon = FALSE
-		icon_state = "speedspace_ns_9"
+	auto_space_icon = FALSE
+	icon_state = "speedspace_ns_9"
 
 /turf/open/space/transit/north/shuttlespace_ns10
-		auto_space_icon = FALSE
-		icon_state = "speedspace_ns_10"
+	auto_space_icon = FALSE
+	icon_state = "speedspace_ns_10"
 
 /turf/open/space/transit/north/shuttlespace_ns11
-		auto_space_icon = FALSE
-		icon_state = "speedspace_ns_11"
+	auto_space_icon = FALSE
+	icon_state = "speedspace_ns_11"
 
 /turf/open/space/transit/north/shuttlespace_ns12
-		auto_space_icon = FALSE
-		icon_state = "speedspace_ns_12"
+	auto_space_icon = FALSE
+	icon_state = "speedspace_ns_12"
 
 /turf/open/space/transit/north/shuttlespace_ns13
-		auto_space_icon = FALSE
-		icon_state = "speedspace_ns_13"
+	auto_space_icon = FALSE
+	icon_state = "speedspace_ns_13"
 
 /turf/open/space/transit/north/shuttlespace_ns14
-		auto_space_icon = FALSE
-		icon_state = "speedspace_ns_14"
+	auto_space_icon = FALSE
+	icon_state = "speedspace_ns_14"
 
 /turf/open/space/transit/north/shuttlespace_ns15
-		auto_space_icon = FALSE
-		icon_state = "speedspace_ns_15"
+	auto_space_icon = FALSE
+	icon_state = "speedspace_ns_15"
 
 /turf/open/space/transit/east/shuttlespace_ew1
 	auto_space_icon = FALSE

--- a/code/game/turfs/transit.dm
+++ b/code/game/turfs/transit.dm
@@ -11,6 +11,9 @@
 	if(isobserver(crosser) || crosser.anchored)
 		return
 
+	if(!(isitem(crosser) || isliving(crosser)))
+		return
+
 	var/turf/open/floor/floor = old_loc
 	if(istype(floor))
 		var/fling_dir = get_dir(floor, crosser.loc)

--- a/code/game/turfs/transit.dm
+++ b/code/game/turfs/transit.dm
@@ -5,6 +5,27 @@
 	baseturfs = /turf/open/space/transit
 	var/auto_space_icon = TRUE
 
+/turf/open/space/transit/Crossed(atom/movable/crosser)
+	. = ..()
+
+	if(isobserver(crosser) || crosser.anchored)
+		return
+
+	var/neighbours = list()
+	for(var/dir in GLOB.cardinals)
+		neighbours += get_step(loc, dir)
+
+	var/turf/open/floor/floor = locate() in neighbours
+	if(floor)
+		var/fling_dir = get_dir(floor, loc)
+
+		var/turf/near_turf = get_step(loc, get_step(loc, fling_dir))
+		var/turf/projected = get_ranged_target_turf(near_turf, fling_dir, 50)
+
+		INVOKE_ASYNC(crosser, TYPE_PROC_REF(/atom/movable, throw_atom), projected, 50, SPEED_FAST, null, TRUE)
+
+	QDEL_IN(crosser, 0.5 SECONDS)
+
 /turf/open/space/transit/south
 	dir = SOUTH
 


### PR DESCRIPTION
this used to be controlled via mapped teleport triggers in loworbit, but since we detonated a nuke in low orbit people have been going for joyrides in space. no longer

:cl:
fix: space is now uninhabitable again
/:cl:

![dreamseeker_txgZEIxrXZ](https://github.com/cmss13-devs/cmss13/assets/55142896/c6081ec3-2741-4a35-a94a-58be999d50c4)
