### PR TITLE
Fix Paper Maps wrecking hotkeys

### DIFF
--- a/code/modules/cm_marines/equipment/maps.dm
+++ b/code/modules/cm_marines/equipment/maps.dm
@@ -23,8 +23,11 @@
 	var/wikiurl = CONFIG_GET(string/wikiurl)
 	if(wikiurl)
 		dat = {"
+				<!DOCTYPE html>
 				<html>
 				<head>
+					<meta http-equiv="X-UA-Compatible" content="IE=edge">
+					<meta charset="utf-8">
 					<style>
 						img {
 							display: none;
@@ -51,7 +54,7 @@
 
 				</html>
 			"}
-	show_browser(usr, dat, name, "map", "size=[window_size]")
+	show_browser(usr, dat, name, "papermap", "size=[window_size]")
 
 /obj/item/map/lazarus_landing_map
 	name = "\improper Lazarus Landing Map"


### PR DESCRIPTION
# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

fixes #3310 

Paper map opened as "map" which is the map view from BYOND. Conflicts.

# Changelog
:cl:
fix: Fixed opening paper maps breaking some hotkey usage.
/:cl:
