### PR TITLE
Cardiostabilizing Changes

### DIFF
--- a/code/modules/reagents/chemistry_properties/prop_positive.dm
+++ b/code/modules/reagents/chemistry_properties/prop_positive.dm
@@ -879,31 +879,27 @@
 	category = PROPERTY_TYPE_STIMULANT
 	value = 1
 
-/datum/chem_property/positive/cardiostabilizing/on_delete(mob/living/M)
-	..()
-
-	M.pain.reset_pain_reduction()
-
-/datum/chem_property/positive/cardiostabilizing/process(mob/living/M, potency = 1, delta_time)
+/datum/chem_property/positive/cardiostabilizing/process(mob/living/M, potency = 1)
 	if(!..())
 		return
+	if(M.health < 0 && M.stat)
+		M.heal_limb_damage(potency, potency)
+		holder.holder.remove_reagent("adrenaline", 1 * potency) //removes cardiac stimulants from the body.
+		if(M.losebreath >= 10)
+			M.losebreath = max(10, M.losebreath - 10 * potency)
 
-	M.pain.apply_pain_reduction(PAIN_REDUCTION_MULTIPLIER * potency)
-
-	if(M.losebreath >= 10)
-		M.losebreath = max(10, M.losebreath - 2.5 * potency * delta_time)
-
-/datum/chem_property/positive/cardiostabilizing/process_overdose(mob/living/M, potency = 1, delta_time)
-	M.make_jittery(5) //Overdose causes a spasm
-	M.apply_effect(20, PARALYZE)
-
-/datum/chem_property/positive/cardiostabilizing/process_critical(mob/living/M, potency = 1, delta_time)
+/datum/chem_property/positive/cardiostabilizing/process_overdose(mob/living/M, potency = 1)
+	M.make_jittery(8) //Overdose causes a spasm
+	M.apply_effect(6, PARALYZE)
+	M.apply_internal_damage(0.25 * potency, "heart")
+/datum/chem_property/positive/cardiostabilizing/process_critical(mob/living/M, potency = 1)
 	M.drowsyness = max(M.drowsyness, 20)
 	if(!ishuman(M)) //Critical overdose causes total blackout and heart damage. Too much stimulant
 		return
-	M.apply_internal_damage(0.25 * delta_time, "heart")
-	if(prob(5 * delta_time))
+	M.apply_internal_damage(0.5 * potency, "heart")
+	if(prob(10))
 		M.emote(pick("twitch","blink_r","shiver"))
+		M.make_jittery(10)
 
 /datum/chem_property/positive/cardiostabilizing/reaction_mob(mob/M, method=TOUCH, volume, potency)
 	if(!isxeno(M))

--- a/code/modules/reagents/chemistry_reagents/medical.dm
+++ b/code/modules/reagents/chemistry_reagents/medical.dm
@@ -12,7 +12,7 @@
 	overdose = HIGH_REAGENTS_OVERDOSE
 	overdose_critical = HIGH_REAGENTS_OVERDOSE_CRITICAL
 	chemclass = CHEM_CLASS_COMMON
-	properties = list(PROPERTY_CARDIOSTABILIZING = 3)
+	properties = list(PROPERTY_CARDIOSTABILIZING = 1)
 
 /datum/reagent/medical/ryetalyn
 	name = "Ryetalyn"


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->
Cardiostabilizing trait now only applies effects on Players that are in hardcritical condition
Inaprovaline changed from level 3 to level 1 cardiostabilizing.
Cardiostabilizing will SLOWLY heal Brute and Burns depending on the potency level while you are in critical condition.
tweaked cardiostabilizing Overdose effects values.
Cardiostabilizing will now Purge Epinephrine from the body when procesed. ( this wont affect revival mix)

# Explain why it's good for the game
First of all this reduces the level of roundstart chems to 1 . adding room for an upgraded version of inaprovaline in the future.

Inaprovaline will now be a chem usefull for Doctors and Non doctors to provide first AID to downed marines winout necesarily healing them to full heal . 

This PR also tweaks inaprovaline just being a substitute to Dexalin since it will now only work on Hardcritted people.

Inaprovaline Healing Wont affect current balance . the healing is VERY slow and its made with the intent of keeping the patient alive a little longer.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: Changed Inaprovaline Cardiostabilizing level from 3 to 1 
balance: Cardiostabilizers will now heal (potency) Brute / burn
balance: Cardiostabilizing only works on Hard-Critical patients.
balance: Reduced Cardiostabilizing Overdose Stun.
/:cl:
