### PR TITLE
Set eggmorpher's range to be 2 tiles from center as stated previously

### DIFF
--- a/code/modules/cm_aliens/structures/special/egg_morpher.dm
+++ b/code/modules/cm_aliens/structures/special/egg_morpher.dm
@@ -1,4 +1,4 @@
-#define EGGMORPG_RANGE 2
+#define EGGMORPG_RANGE 5
 
 //Eggmorpher - Basically a big reusable egg
 /obj/effect/alien/resin/special/eggmorph


### PR DESCRIPTION
# About the pull request

Fixes eggmorpher range to 2 tiles radius from the center

# Explain why it's good for the game

Basically fixing the range of the eggmorpher based on this: 
[Last related eggmorpher PR and changelog that mentions 2 tile range](https://gitlab.com/cmdevs/colonial-warfare/-/merge_requests/261)
![image](https://github.com/cmss13-devs/cmss13/assets/107966994/fb930511-064f-4183-83fd-f14549cda056)
![image](https://github.com/cmss13-devs/cmss13/assets/107966994/e37a1216-1117-44d0-a993-88d4df6391d8)

Currently the rectangle is weird because its width of 2 and height of 2.

XX
XX

Doesn't really have a center. Codewise it does a radius of 1 / range of 1 from the morpher.

With a width and height of 5, with C as the center where the morpher is, this should have a radius of 2 tiles from the morpher including diagonals

XXXXX
XXXXX
XXCXX
XXXXX
XXXXX

Tested it and the eggmorphers properly shot at all the tiles above with any human mob. It doesn't affect 3 tiles away.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl:
fix: Eggmorpher range fixed to 2 tiles centered on the morpher
/:cl:
