### PR TITLE
Bugfix: Announcements are included in Radio Chat Filter

### DIFF
--- a/code/defines/procs/announcement.dm
+++ b/code/defines/procs/announcement.dm
@@ -140,5 +140,5 @@
 		if(istype(T, /mob/new_player))
 			continue
 
-		to_chat_spaced(T, html = "[SPAN_ANNOUNCEMENT_HEADER(title)]<br><br>[SPAN_ANNOUNCEMENT_BODY(message)]")
+		to_chat_spaced(T, html = "[SPAN_ANNOUNCEMENT_HEADER(title)]<br><br>[SPAN_ANNOUNCEMENT_BODY(message)]", type = MESSAGE_TYPE_RADIO)
 		playsound_client(T.client, sound_to_play, T, vol = 45)


### PR DESCRIPTION
# About the pull request

Tired of missing Announcements when you switch over to your Radio Chat Tab?
Worry no more

# Explain why it's good for the game

SL LISTEN TO ANNOUNCEMENTS NOW!
BANISH ALL XENOS WHO DISOBEY THE QUEEN!

# Testing Photographs and Procedure

![Announcement Radio](https://github.com/cmss13-devs/cmss13/assets/43085828/67bfa2ae-f290-4af3-af55-bd644c4e0de6)

# Changelog

:cl: ghostsheet
fix: Announcement are included in 'Radio' chat filter
/:cl:
