### PR TITLE
Move the DATAbase to data

### DIFF
--- a/code/controllers/configuration/entries/dbconfig.dm
+++ b/code/controllers/configuration/entries/dbconfig.dm
@@ -29,5 +29,5 @@
 	protection = CONFIG_ENTRY_HIDDEN|CONFIG_ENTRY_LOCKED
 
 /datum/config_entry/string/db_filename
-	config_entry_value = "local.db"
+	config_entry_value = "data/local.db"
 	protection = CONFIG_ENTRY_HIDDEN|CONFIG_ENTRY_LOCKED


### PR DESCRIPTION
# About the pull request

This PR simply moves the local database file location from root into the data folder.

# Explain why it's good for the game

This came up as an issue for me because there's some weird issues with checking out old versions of the code vs the present which corrupts the database. Clearing out the data folder was insufficient to fix the issue because the database exists in the root some reason, so its just confusing that its there and not the data folder.

# Changelog
:cl: Drathek harryob
server: Moved the local.db database location from root to the data folder
/:cl:
