### PR TITLE
Adds a warning to cryomarines about ghosting

### DIFF
--- a/code/datums/emergency_calls/cryo_marines.dm
+++ b/code/datums/emergency_calls/cryo_marines.dm
@@ -37,25 +37,30 @@
 		arm_equipment(H, /datum/equipment_preset/uscm/leader/cryo, TRUE, TRUE)
 		to_chat(H, SPAN_ROLE_HEADER("You are a Squad Leader in the USCM"))
 		to_chat(H, SPAN_ROLE_BODY("You are here to assist in the defence of the [SSmapping.configs[GROUND_MAP].map_name]. Listen to the chain of command."))
+		to_chat(H, SPAN_BOLDWARNING("If you wish to cryo or ghost upon spawning in, you must ahelp and inform staff so you can be replaced."))
 	else if (heavies < max_heavies && HAS_FLAG(H.client.prefs.toggles_ert, PLAY_HEAVY) && check_timelock(H.client, JOB_SQUAD_SPECIALIST, time_required_for_job))
 		heavies++
 		arm_equipment(H, /datum/equipment_preset/uscm/spec/cryo, TRUE, TRUE)
 		to_chat(H, SPAN_ROLE_HEADER("You are a Weapons Specialist in the USCM"))
 		to_chat(H, SPAN_ROLE_BODY("Your squad is here to assist in the defence of the [SSmapping.configs[GROUND_MAP].map_name]. Listen to the chain of command."))
+		to_chat(H, SPAN_BOLDWARNING("If you wish to cryo or ghost upon spawning in, you must ahelp and inform staff so you can be replaced."))
 	else if (medics < max_medics && HAS_FLAG(H.client.prefs.toggles_ert, PLAY_MEDIC) && check_timelock(H.client, JOB_SQUAD_MEDIC, time_required_for_job))
 		medics++
 		arm_equipment(H, /datum/equipment_preset/uscm/medic/cryo, TRUE, TRUE)
 		to_chat(H, SPAN_ROLE_HEADER("You are a Hospital Corpsman in the USCM"))
 		to_chat(H, SPAN_ROLE_BODY("You are here to assist in the defence of the [SSmapping.configs[GROUND_MAP].map_name]. Listen to the chain of command."))
+		to_chat(H, SPAN_BOLDWARNING("If you wish to cryo or ghost upon spawning in, you must ahelp and inform staff so you can be replaced."))
 	else if (engineers < max_engineers && HAS_FLAG(H.client.prefs.toggles_ert, PLAY_ENGINEER) && check_timelock(H.client, JOB_SQUAD_ENGI, time_required_for_job))
 		engineers++
 		arm_equipment(H, /datum/equipment_preset/uscm/engineer/cryo, TRUE, TRUE)
 		to_chat(H, SPAN_ROLE_HEADER("You are an Engineer in the USCM"))
 		to_chat(H, SPAN_ROLE_BODY("You are here to assist in the defence of the [SSmapping.configs[GROUND_MAP].map_name]. Listen to the chain of command."))
+		to_chat(H, SPAN_BOLDWARNING("If you wish to cryo or ghost upon spawning in, you must ahelp and inform staff so you can be replaced."))
 	else
 		arm_equipment(H, /datum/equipment_preset/uscm/pfc/cryo, TRUE, TRUE)
 		to_chat(H, SPAN_ROLE_HEADER("You are a Rifleman in the USCM"))
 		to_chat(H, SPAN_ROLE_BODY("You are here to assist in the defence of the [SSmapping.configs[GROUND_MAP].map_name]. Listen to the chain of command."))
+		to_chat(H, SPAN_BOLDWARNING("If you wish to cryo or ghost upon spawning in, you must ahelp and inform staff so you can be replaced."))
 
 	sleep(10)
 	to_chat(H, SPAN_BOLD("Objectives: [objectives]"))

--- a/code/datums/emergency_calls/tank_crew.dm
+++ b/code/datums/emergency_calls/tank_crew.dm
@@ -25,6 +25,7 @@
 	arm_equipment(H, /datum/equipment_preset/uscm/tank/full, TRUE, TRUE)
 	to_chat(H, SPAN_ROLE_HEADER("You are a Vehicle Crewman in the USCM"))
 	to_chat(H, SPAN_ROLE_BODY("You are here to assist in the defence of the [SSmapping.configs[GROUND_MAP].map_name]. Listen to the chain of command."))
+	to_chat(H, SPAN_BOLDWARNING("If you wish to cryo or ghost upon spawning in, you must ahelp and inform staff so you can be replaced."))
 
 	sleep(10)
 	to_chat(H, SPAN_BOLD("Objectives: [objectives]"))


### PR DESCRIPTION

# About the pull request
People keep spawning in as foxtrot and cryoing/ghosting if they don't get a free spec or special role. This can greatly impact the use of the ERT. If players ahelp as they're meant to, we can replace them.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Stops wasting the cryomarines.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Added a warning/reminder to cryomarine spawns to ahelp if they want to cryo/ghost upon spawning in, to stop people wasting the ERT call.
/:cl:
