### PR TITLE
Bugfix prevent fuel backpacks to be filled via reagent tank with improper chemical

### DIFF
--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -900,13 +900,13 @@ GLOBAL_LIST_EMPTY_TYPED(radio_packs, /obj/item/storage/backpack/marine/satchel/r
 	if (istype(O, /obj/structure/reagent_dispensers/fueltank))
 		if(reagents.total_volume < max_fuel)
 			O.reagents.trans_to(src, max_fuel)
-			to_chat(user, SPAN_NOTICE(" You crack the cap off the top of the pack and fill it back up again from the tank."))
+			to_chat(user, SPAN_NOTICE("You crack the cap off the top of the pack and fill it back up again from the tank."))
 			playsound(loc, 'sound/effects/refill.ogg', 25, TRUE, 3)
 			return
 		if (src.reagents.total_volume == max_fuel)
-			to_chat(user, SPAN_NOTICE(" The pack is already full!"))
+			to_chat(user, SPAN_NOTICE("The pack is already full!"))
 			return
-	..()
+	return ..()
 
 /obj/item/storage/backpack/marine/engineerpack/flamethrower/attackby(obj/item/W, mob/living/user)
 	if (istype(W, /obj/item/ammo_magazine/flamer_tank))

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -894,22 +894,22 @@ GLOBAL_LIST_EMPTY_TYPED(radio_packs, /obj/item/storage/backpack/marine/satchel/r
 	has_gamemode_skin = TRUE
 
 /obj/item/storage/backpack/marine/engineerpack/flamethrower/verb/remove_reagents()
-	set name = "Empty canister"
-	set category = "Object"
+    set name = "Empty canister"
+    set category = "Object"
 
-	set src in usr
+    set src in usr
 
-	if(usr.get_active_hand() != src)
-		return
+    if(usr.get_active_hand() != src)
+        return
 
-	if(alert(usr, "Do you really want to empty out [src]?", "Empty canister", "Yes", "No") != "Yes")
-		return
+    if(alert(usr, "Do you really want to empty out [src]?", "Empty canister", "Yes", "No") != "Yes")
+        return
 
-	reagents.clear_reagents()
+    reagents.clear_reagents()
 
-	playsound(loc, 'sound/effects/refill.ogg', 25, 1, 3)
-	to_chat(usr, SPAN_NOTICE("You empty out [src]"))
-	update_icon()
+    playsound(loc, 'sound/effects/refill.ogg', 25, 1, 3)
+    to_chat(usr, SPAN_NOTICE("You empty out [src]"))
+    update_icon()
 
 //this is to revert change for the backpack that are for flametrower usage.
 // so that they can use custom mix to refill those backpack

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -858,6 +858,7 @@ GLOBAL_LIST_EMPTY_TYPED(radio_packs, /obj/item/storage/backpack/marine/satchel/r
 		return
 	//excluding the dispenser that contain gaz or custom to only leave fuel tank.
 	if (istype(O, /obj/structure/reagent_dispensers/fueltank/custom)||istype(O, /obj/structure/reagent_dispensers/fueltank/gas))
+		to_chat(user, SPAN_NOTICE(" You can't fill this with anything but with a fuel tank."))
 		return
 	if (istype(O, /obj/structure/reagent_dispensers/fueltank))
 		if(src.reagents.total_volume < max_fuel)

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -894,22 +894,22 @@ GLOBAL_LIST_EMPTY_TYPED(radio_packs, /obj/item/storage/backpack/marine/satchel/r
 	has_gamemode_skin = TRUE
 
 /obj/item/storage/backpack/marine/engineerpack/flamethrower/verb/remove_reagents()
-    set name = "Empty canister"
-    set category = "Object"
+	set name = "Empty canister"
+	set category = "Object"
 
-    set src in usr
+	set src in usr
 
-    if(usr.get_active_hand() != src)
-        return
+	if(usr.get_active_hand() != src)
+		return
 
-    if(alert(usr, "Do you really want to empty out [src]?", "Empty canister", "Yes", "No") != "Yes")
-        return
+	if(alert(usr, "Do you really want to empty out [src]?", "Empty canister", "Yes", "No") != "Yes")
+		return
 
-    reagents.clear_reagents()
+	reagents.clear_reagents()
 
-    playsound(loc, 'sound/effects/refill.ogg', 25, 1, 3)
-    to_chat(usr, SPAN_NOTICE("You empty out [src]"))
-    update_icon()
+	playsound(loc, 'sound/effects/refill.ogg', 25, 1, 3)
+	to_chat(usr, SPAN_NOTICE("You empty out [src]"))
+	update_icon()
 
 //this is to revert change for the backpack that are for flametrower usage.
 // so that they can use custom mix to refill those backpack

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -857,7 +857,7 @@ GLOBAL_LIST_EMPTY_TYPED(radio_packs, /obj/item/storage/backpack/marine/satchel/r
 	if(!proximity)
 		return
 	if(istype(target, /obj/structure/reagent_dispensers))
-		if(!istypestrict(target, /obj/structure/reagent_dispensers/fueltank))
+		if(!(istypestrict(target, /obj/structure/reagent_dispensers/fueltank)))
 			to_chat(user, SPAN_NOTICE("This must be filled with a fuel tank."))
 			return
 		if(reagents.total_volume < max_fuel)
@@ -911,6 +911,23 @@ GLOBAL_LIST_EMPTY_TYPED(radio_packs, /obj/item/storage/backpack/marine/satchel/r
 		playsound(loc, 'sound/effects/refill.ogg', 25, TRUE, 3)
 		return
 
+/obj/item/storage/backpack/marine/engineerpack/flamethrower/verb/remove_reagents()
+    set name = "Empty canister"
+    set category = "Object"
+
+    set src in usr
+
+    if(usr.get_active_hand() != src)
+        return
+
+    if(alert(usr, "Do you really want to empty out [src]?", "Empty canister", "Yes", "No") != "Yes")
+        return
+
+    reagents.clear_reagents()
+
+    playsound(loc, 'sound/effects/refill.ogg', 25, 1, 3)
+    to_chat(usr, SPAN_NOTICE("You empty out [src]"))
+    update_icon()
 /obj/item/storage/backpack/marine/engineerpack/flamethrower/attackby(obj/item/W, mob/living/user)
 	if (istype(W, /obj/item/ammo_magazine/flamer_tank))
 		var/obj/item/ammo_magazine/flamer_tank/FTL = W

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -856,17 +856,16 @@ GLOBAL_LIST_EMPTY_TYPED(radio_packs, /obj/item/storage/backpack/marine/satchel/r
 /obj/item/storage/backpack/marine/engineerpack/afterattack(obj/target, mob/user, proximity)
 	if(!proximity)
 		return
-	//excluding the dispenser that contain gaz or custom to only leave fuel tank.
-	if (istype(target, /obj/structure/reagent_dispensers/fueltank/custom) || istype(target, /obj/structure/reagent_dispensers/fueltank/gas))
-		to_chat(user, SPAN_NOTICE("This must be filled with a fuel tank."))
-		return
-	if (istype(target, /obj/structure/reagent_dispensers/fueltank))
+	if(istype(target, /obj/structure/reagent_dispensers))
+		if(!istypestrict(target, /obj/structure/reagent_dispensers/fueltank))
+			to_chat(user, SPAN_NOTICE("This must be filled with a fuel tank."))
+			return
 		if(reagents.total_volume < max_fuel)
 			target.reagents.trans_to(src, max_fuel)
 			to_chat(user, SPAN_NOTICE("You crack the cap off the top of the pack and fill it back up again from the tank."))
 			playsound(loc, 'sound/effects/refill.ogg', 25, TRUE, 3)
 			return
-		if (reagents.total_volume == max_fuel)
+		if(reagents.total_volume == max_fuel)
 			to_chat(user, SPAN_NOTICE("The pack is already full!"))
 			return
 	..()

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -210,8 +210,8 @@
 		to_chat(user, SPAN_DANGER("The Bluespace portal resists your attempt to add another item.")) //light failure
 	else
 		to_chat(user, SPAN_DANGER("The Bluespace generator malfunctions!"))
-		for (var/obj/localbackpack in src.contents) //it broke, delete what was in it
-			qdel(localbackpack)
+		for (var/obj/thing in contents) //it broke, delete what was in it
+			qdel(thing)
 		crit_fail = 1
 		icon_state = "brokenpack"
 
@@ -853,16 +853,16 @@ GLOBAL_LIST_EMPTY_TYPED(radio_packs, /obj/item/storage/backpack/marine/satchel/r
 					return
 	. = ..()
 
-/obj/item/storage/backpack/marine/engineerpack/afterattack(obj/localbackpack as obj, mob/user as mob, proximity)
+/obj/item/storage/backpack/marine/engineerpack/afterattack(obj/target, mob/user, proximity)
 	if(!proximity) // this replaces and improves the get_dist(src,localbackpack) <= 1 checks used previously
 		return
 	//excluding the dispenser that contain gaz or custom to only leave fuel tank.
-	if (istype(localbackpack, /obj/structure/reagent_dispensers/fueltank/custom) || istype(localbackpack, /obj/structure/reagent_dispensers/fueltank/gas))
-		to_chat(user, SPAN_NOTICE("You can't fill this with anything but with a fuel tank."))
+	if (istype(target, /obj/structure/reagent_dispensers/fueltank/custom) || istype(target, /obj/structure/reagent_dispensers/fueltank/gas))
+		to_chat(user, SPAN_NOTICE("This must be filled with a fuel tank."))
 		return
-	if (istype(localbackpack, /obj/structure/reagent_dispensers/fueltank))
+	if (istype(target, /obj/structure/reagent_dispensers/fueltank))
 		if(reagents.total_volume < max_fuel)
-			localbackpack.reagents.trans_to(src, max_fuel)
+			target.reagents.trans_to(src, max_fuel)
 			to_chat(user, SPAN_NOTICE("You crack the cap off the top of the pack and fill it back up again from the tank."))
 			playsound(loc, 'sound/effects/refill.ogg', 25, TRUE, 3)
 			return
@@ -894,18 +894,21 @@ GLOBAL_LIST_EMPTY_TYPED(radio_packs, /obj/item/storage/backpack/marine/satchel/r
 	fuel_type = "utnapthal"
 	has_gamemode_skin = TRUE
 
-/obj/item/storage/backpack/marine/engineerpack/flamethrower/afterattack(obj/localbackpack as obj, mob/user, proximity)
+/obj/item/storage/backpack/marine/engineerpack/flamethrower/afterattack(obj/target, mob/user, proximity)
 	if(!proximity) // this replaces and improves the get_dist(src,localbackpack) <= 1 checks used previously
 		return
-	if (istype(localbackpack, /obj/structure/reagent_dispensers/fueltank))
-		if(reagents.total_volume < max_fuel)
-			localbackpack.reagents.trans_to(src, max_fuel)
-			to_chat(user, SPAN_NOTICE("You crack the cap off the top of the pack and fill it back up again from the tank."))
-			playsound(loc, 'sound/effects/refill.ogg', 25, TRUE, 3)
-			return
-		if (src.reagents.total_volume == max_fuel)
-			to_chat(user, SPAN_NOTICE("The pack is already full!"))
-			return
+	if (!(istype(target, /obj/structure/reagent_dispensers/fueltank)))
+		return
+	
+	if (reagents.total_volume >= max_fuel)
+		to_chat(user, SPAN_NOTICE("The pack is already full!"))
+		return
+	
+	if(reagents.total_volume < max_fuel)
+		localbackpack.reagents.trans_to(src, max_fuel)
+		to_chat(user, SPAN_NOTICE("You crack the cap off the top of the pack and fill it back up again from the tank."))
+		playsound(loc, 'sound/effects/refill.ogg', 25, TRUE, 3)
+		return
 	return ..()
 
 /obj/item/storage/backpack/marine/engineerpack/flamethrower/attackby(obj/item/W, mob/living/user)

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -866,8 +866,8 @@ GLOBAL_LIST_EMPTY_TYPED(radio_packs, /obj/item/storage/backpack/marine/satchel/r
 			to_chat(user, SPAN_NOTICE("You crack the cap off the top of the pack and fill it back up again from the tank."))
 			playsound(loc, 'sound/effects/refill.ogg', 25, TRUE, 3)
 			return
-		else if (src.reagents.total_volume == max_fuel)
-			to_chat(user, SPAN_NOTICE(" The pack is already full!"))
+		if (reagents.total_volume == max_fuel)
+			to_chat(user, SPAN_NOTICE("The pack is already full!"))
 			return
 	..()
 

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -910,7 +910,6 @@ GLOBAL_LIST_EMPTY_TYPED(radio_packs, /obj/item/storage/backpack/marine/satchel/r
 		to_chat(user, SPAN_NOTICE("You crack the cap off the top of the pack and fill it back up again from the tank."))
 		playsound(loc, 'sound/effects/refill.ogg', 25, TRUE, 3)
 		return
-	return ..()
 
 /obj/item/storage/backpack/marine/engineerpack/flamethrower/attackby(obj/item/W, mob/living/user)
 	if (istype(W, /obj/item/ammo_magazine/flamer_tank))

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -911,23 +911,6 @@ GLOBAL_LIST_EMPTY_TYPED(radio_packs, /obj/item/storage/backpack/marine/satchel/r
 		playsound(loc, 'sound/effects/refill.ogg', 25, TRUE, 3)
 		return
 
-/obj/item/storage/backpack/marine/engineerpack/flamethrower/verb/remove_reagents()
-    set name = "Empty canister"
-    set category = "Object"
-
-    set src in usr
-
-    if(usr.get_active_hand() != src)
-        return
-
-    if(alert(usr, "Do you really want to empty out [src]?", "Empty canister", "Yes", "No") != "Yes")
-        return
-
-    reagents.clear_reagents()
-
-    playsound(loc, 'sound/effects/refill.ogg', 25, 1, 3)
-    to_chat(usr, SPAN_NOTICE("You empty out [src]"))
-    update_icon()
 /obj/item/storage/backpack/marine/engineerpack/flamethrower/attackby(obj/item/W, mob/living/user)
 	if (istype(W, /obj/item/ammo_magazine/flamer_tank))
 		var/obj/item/ammo_magazine/flamer_tank/FTL = W

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -861,7 +861,7 @@ GLOBAL_LIST_EMPTY_TYPED(radio_packs, /obj/item/storage/backpack/marine/satchel/r
 		to_chat(user, SPAN_NOTICE("You can't fill this with anything but with a fuel tank."))
 		return
 	if (istype(O, /obj/structure/reagent_dispensers/fueltank))
-		if(src.reagents.total_volume < max_fuel)
+		if(reagents.total_volume < max_fuel)
 			O.reagents.trans_to(src, max_fuel)
 			to_chat(user, SPAN_NOTICE(" You crack the cap off the top of the pack and fill it back up again from the tank."))
 			playsound(loc, 'sound/effects/refill.ogg', 25, TRUE, 3)

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -856,14 +856,18 @@ GLOBAL_LIST_EMPTY_TYPED(radio_packs, /obj/item/storage/backpack/marine/satchel/r
 /obj/item/storage/backpack/marine/engineerpack/afterattack(obj/O as obj, mob/user as mob, proximity)
 	if(!proximity) // this replaces and improves the get_dist(src,O) <= 1 checks used previously
 		return
-	if (istype(O, /obj/structure/reagent_dispensers/fueltank) && src.reagents.total_volume < max_fuel)
-		O.reagents.trans_to(src, max_fuel)
-		to_chat(user, SPAN_NOTICE(" You crack the cap off the top of the pack and fill it back up again from the tank."))
-		playsound(loc, 'sound/effects/refill.ogg', 25, TRUE, 3)
+	//excluding the dispenser that contain gaz or custom to only leave fuel tank.
+	if (istype(O, /obj/structure/reagent_dispensers/fueltank/custom)||istype(O, /obj/structure/reagent_dispensers/fueltank/gas))
 		return
-	else if (istype(O, /obj/structure/reagent_dispensers/fueltank) && src.reagents.total_volume == max_fuel)
-		to_chat(user, SPAN_NOTICE(" The pack is already full!"))
-		return
+	if (istype(O, /obj/structure/reagent_dispensers/fueltank))
+		if(src.reagents.total_volume < max_fuel)
+			O.reagents.trans_to(src, max_fuel)
+			to_chat(user, SPAN_NOTICE(" You crack the cap off the top of the pack and fill it back up again from the tank."))
+			playsound(loc, 'sound/effects/refill.ogg', 25, TRUE, 3)
+			return
+		else if (src.reagents.total_volume == max_fuel)
+			to_chat(user, SPAN_NOTICE(" The pack is already full!"))
+			return
 	..()
 
 /obj/item/storage/backpack/marine/engineerpack/get_examine_text(mob/user)

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -857,7 +857,7 @@ GLOBAL_LIST_EMPTY_TYPED(radio_packs, /obj/item/storage/backpack/marine/satchel/r
 	if(!proximity) // this replaces and improves the get_dist(src,O) <= 1 checks used previously
 		return
 	//excluding the dispenser that contain gaz or custom to only leave fuel tank.
-	if (istype(O, /obj/structure/reagent_dispensers/fueltank/custom)||istype(O, /obj/structure/reagent_dispensers/fueltank/gas))
+	if (istype(O, /obj/structure/reagent_dispensers/fueltank/custom) || istype(O, /obj/structure/reagent_dispensers/fueltank/gas))
 		to_chat(user, SPAN_NOTICE("You can't fill this with anything but with a fuel tank."))
 		return
 	if (istype(O, /obj/structure/reagent_dispensers/fueltank))

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -905,7 +905,7 @@ GLOBAL_LIST_EMPTY_TYPED(radio_packs, /obj/item/storage/backpack/marine/satchel/r
 		return
 	
 	if(reagents.total_volume < max_fuel)
-		localbackpack.reagents.trans_to(src, max_fuel)
+		target.reagents.trans_to(src, max_fuel)
 		to_chat(user, SPAN_NOTICE("You crack the cap off the top of the pack and fill it back up again from the tank."))
 		playsound(loc, 'sound/effects/refill.ogg', 25, TRUE, 3)
 		return

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -863,7 +863,7 @@ GLOBAL_LIST_EMPTY_TYPED(radio_packs, /obj/item/storage/backpack/marine/satchel/r
 	if (istype(O, /obj/structure/reagent_dispensers/fueltank))
 		if(reagents.total_volume < max_fuel)
 			O.reagents.trans_to(src, max_fuel)
-			to_chat(user, SPAN_NOTICE(" You crack the cap off the top of the pack and fill it back up again from the tank."))
+			to_chat(user, SPAN_NOTICE("You crack the cap off the top of the pack and fill it back up again from the tank."))
 			playsound(loc, 'sound/effects/refill.ogg', 25, TRUE, 3)
 			return
 		else if (src.reagents.total_volume == max_fuel)

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -893,6 +893,24 @@ GLOBAL_LIST_EMPTY_TYPED(radio_packs, /obj/item/storage/backpack/marine/satchel/r
 	fuel_type = "utnapthal"
 	has_gamemode_skin = TRUE
 
+/obj/item/storage/backpack/marine/engineerpack/flamethrower/verb/remove_reagents()
+	set name = "Empty canister"
+	set category = "Object"
+
+	set src in usr
+
+	if(usr.get_active_hand() != src)
+		return
+
+	if(alert(usr, "Do you really want to empty out [src]?", "Empty canister", "Yes", "No") != "Yes")
+		return
+
+	reagents.clear_reagents()
+
+	playsound(loc, 'sound/effects/refill.ogg', 25, 1, 3)
+	to_chat(usr, SPAN_NOTICE("You empty out [src]"))
+	update_icon()
+
 //this is to revert change for the backpack that are for flametrower usage.
 // so that they can use custom mix to refill those backpack
 /obj/item/storage/backpack/marine/engineerpack/flamethrower/afterattack(obj/target, mob/user, proximity)

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -898,7 +898,7 @@ GLOBAL_LIST_EMPTY_TYPED(radio_packs, /obj/item/storage/backpack/marine/satchel/r
 	if(!proximity) // this replaces and improves the get_dist(src,O) <= 1 checks used previously
 		return
 	if (istype(O, /obj/structure/reagent_dispensers/fueltank))
-		if(src.reagents.total_volume < max_fuel)
+		if(reagents.total_volume < max_fuel)
 			O.reagents.trans_to(src, max_fuel)
 			to_chat(user, SPAN_NOTICE(" You crack the cap off the top of the pack and fill it back up again from the tank."))
 			playsound(loc, 'sound/effects/refill.ogg', 25, TRUE, 3)

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -210,8 +210,8 @@
 		to_chat(user, SPAN_DANGER("The Bluespace portal resists your attempt to add another item.")) //light failure
 	else
 		to_chat(user, SPAN_DANGER("The Bluespace generator malfunctions!"))
-		for (var/obj/O in src.contents) //it broke, delete what was in it
-			qdel(O)
+		for (var/obj/localbackpack in src.contents) //it broke, delete what was in it
+			qdel(localbackpack)
 		crit_fail = 1
 		icon_state = "brokenpack"
 
@@ -853,16 +853,16 @@ GLOBAL_LIST_EMPTY_TYPED(radio_packs, /obj/item/storage/backpack/marine/satchel/r
 					return
 	. = ..()
 
-/obj/item/storage/backpack/marine/engineerpack/afterattack(obj/O as obj, mob/user as mob, proximity)
-	if(!proximity) // this replaces and improves the get_dist(src,O) <= 1 checks used previously
+/obj/item/storage/backpack/marine/engineerpack/afterattack(obj/localbackpack as obj, mob/user as mob, proximity)
+	if(!proximity) // this replaces and improves the get_dist(src,localbackpack) <= 1 checks used previously
 		return
 	//excluding the dispenser that contain gaz or custom to only leave fuel tank.
-	if (istype(O, /obj/structure/reagent_dispensers/fueltank/custom) || istype(O, /obj/structure/reagent_dispensers/fueltank/gas))
+	if (istype(localbackpack, /obj/structure/reagent_dispensers/fueltank/custom) || istype(localbackpack, /obj/structure/reagent_dispensers/fueltank/gas))
 		to_chat(user, SPAN_NOTICE("You can't fill this with anything but with a fuel tank."))
 		return
-	if (istype(O, /obj/structure/reagent_dispensers/fueltank))
+	if (istype(localbackpack, /obj/structure/reagent_dispensers/fueltank))
 		if(reagents.total_volume < max_fuel)
-			O.reagents.trans_to(src, max_fuel)
+			localbackpack.reagents.trans_to(src, max_fuel)
 			to_chat(user, SPAN_NOTICE("You crack the cap off the top of the pack and fill it back up again from the tank."))
 			playsound(loc, 'sound/effects/refill.ogg', 25, TRUE, 3)
 			return
@@ -894,12 +894,12 @@ GLOBAL_LIST_EMPTY_TYPED(radio_packs, /obj/item/storage/backpack/marine/satchel/r
 	fuel_type = "utnapthal"
 	has_gamemode_skin = TRUE
 
-/obj/item/storage/backpack/marine/engineerpack/flamethrower/afterattack(obj/O as obj, mob/user as mob, proximity)
-	if(!proximity) // this replaces and improves the get_dist(src,O) <= 1 checks used previously
+/obj/item/storage/backpack/marine/engineerpack/flamethrower/afterattack(obj/localbackpack as obj, mob/user, proximity)
+	if(!proximity) // this replaces and improves the get_dist(src,localbackpack) <= 1 checks used previously
 		return
-	if (istype(O, /obj/structure/reagent_dispensers/fueltank))
+	if (istype(localbackpack, /obj/structure/reagent_dispensers/fueltank))
 		if(reagents.total_volume < max_fuel)
-			O.reagents.trans_to(src, max_fuel)
+			localbackpack.reagents.trans_to(src, max_fuel)
 			to_chat(user, SPAN_NOTICE("You crack the cap off the top of the pack and fill it back up again from the tank."))
 			playsound(loc, 'sound/effects/refill.ogg', 25, TRUE, 3)
 			return

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -894,6 +894,20 @@ GLOBAL_LIST_EMPTY_TYPED(radio_packs, /obj/item/storage/backpack/marine/satchel/r
 	fuel_type = "utnapthal"
 	has_gamemode_skin = TRUE
 
+/obj/item/storage/backpack/marine/engineerpack/flamethrower/afterattack(obj/O as obj, mob/user as mob, proximity)
+	if(!proximity) // this replaces and improves the get_dist(src,O) <= 1 checks used previously
+		return
+	if (istype(O, /obj/structure/reagent_dispensers/fueltank))
+		if(src.reagents.total_volume < max_fuel)
+			O.reagents.trans_to(src, max_fuel)
+			to_chat(user, SPAN_NOTICE(" You crack the cap off the top of the pack and fill it back up again from the tank."))
+			playsound(loc, 'sound/effects/refill.ogg', 25, TRUE, 3)
+			return
+		else if (src.reagents.total_volume == max_fuel)
+			to_chat(user, SPAN_NOTICE(" The pack is already full!"))
+			return
+	..()
+
 /obj/item/storage/backpack/marine/engineerpack/flamethrower/attackby(obj/item/W, mob/living/user)
 	if (istype(W, /obj/item/ammo_magazine/flamer_tank))
 		var/obj/item/ammo_magazine/flamer_tank/FTL = W

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -858,7 +858,7 @@ GLOBAL_LIST_EMPTY_TYPED(radio_packs, /obj/item/storage/backpack/marine/satchel/r
 		return
 	//excluding the dispenser that contain gaz or custom to only leave fuel tank.
 	if (istype(O, /obj/structure/reagent_dispensers/fueltank/custom)||istype(O, /obj/structure/reagent_dispensers/fueltank/gas))
-		to_chat(user, SPAN_NOTICE(" You can't fill this with anything but with a fuel tank."))
+		to_chat(user, SPAN_NOTICE("You can't fill this with anything but with a fuel tank."))
 		return
 	if (istype(O, /obj/structure/reagent_dispensers/fueltank))
 		if(src.reagents.total_volume < max_fuel)

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -903,7 +903,7 @@ GLOBAL_LIST_EMPTY_TYPED(radio_packs, /obj/item/storage/backpack/marine/satchel/r
 			to_chat(user, SPAN_NOTICE(" You crack the cap off the top of the pack and fill it back up again from the tank."))
 			playsound(loc, 'sound/effects/refill.ogg', 25, TRUE, 3)
 			return
-		else if (src.reagents.total_volume == max_fuel)
+		if (src.reagents.total_volume == max_fuel)
 			to_chat(user, SPAN_NOTICE(" The pack is already full!"))
 			return
 	..()

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -854,7 +854,7 @@ GLOBAL_LIST_EMPTY_TYPED(radio_packs, /obj/item/storage/backpack/marine/satchel/r
 	. = ..()
 
 /obj/item/storage/backpack/marine/engineerpack/afterattack(obj/target, mob/user, proximity)
-	if(!proximity) // this replaces and improves the get_dist(src,localbackpack) <= 1 checks used previously
+	if(!proximity)
 		return
 	//excluding the dispenser that contain gaz or custom to only leave fuel tank.
 	if (istype(target, /obj/structure/reagent_dispensers/fueltank/custom) || istype(target, /obj/structure/reagent_dispensers/fueltank/gas))
@@ -894,16 +894,18 @@ GLOBAL_LIST_EMPTY_TYPED(radio_packs, /obj/item/storage/backpack/marine/satchel/r
 	fuel_type = "utnapthal"
 	has_gamemode_skin = TRUE
 
+//this is to revert change for the backpack that are for flametrower usage.
+// so that they can use custom mix to refill those backpack
 /obj/item/storage/backpack/marine/engineerpack/flamethrower/afterattack(obj/target, mob/user, proximity)
-	if(!proximity) // this replaces and improves the get_dist(src,localbackpack) <= 1 checks used previously
+	if(!proximity)
 		return
 	if (!(istype(target, /obj/structure/reagent_dispensers/fueltank)))
 		return
-	
+
 	if (reagents.total_volume >= max_fuel)
 		to_chat(user, SPAN_NOTICE("The pack is already full!"))
 		return
-	
+
 	if(reagents.total_volume < max_fuel)
 		target.reagents.trans_to(src, max_fuel)
 		to_chat(user, SPAN_NOTICE("You crack the cap off the top of the pack and fill it back up again from the tank."))

--- a/code/game/objects/items/tools/maintenance_tools.dm
+++ b/code/game/objects/items/tools/maintenance_tools.dm
@@ -658,7 +658,7 @@ Welding backpack
 	if (istype(O, /obj/structure/reagent_dispensers/fueltank/custom) || istype(O, /obj/structure/reagent_dispensers/fueltank/gas))
 		return
 	if (istype(O, /obj/structure/reagent_dispensers/fueltank))
-		if(src.reagents.total_volume < max_fuel)
+		if(reagents.total_volume < max_fuel)
 			O.reagents.trans_to(src, max_fuel)
 			to_chat(user, SPAN_NOTICE(" You crack the cap off the top of \the [src] and fill it back up again from the tank."))
 			playsound(src.loc, 'sound/effects/refill.ogg', 25, 1, 3)

--- a/code/game/objects/items/tools/maintenance_tools.dm
+++ b/code/game/objects/items/tools/maintenance_tools.dm
@@ -655,7 +655,7 @@ Welding backpack
 	if(!proximity) // this replaces and improves the get_dist(src,O) <= 1 checks used previously
 		return
 	//excluding the dispenser that contain gaz or custom to only leave fuel tank.
-	if (istype(O, /obj/structure/reagent_dispensers/fueltank/custom)||istype(O, /obj/structure/reagent_dispensers/fueltank/gas))
+	if (istype(O, /obj/structure/reagent_dispensers/fueltank/custom) || istype(O, /obj/structure/reagent_dispensers/fueltank/gas))
 		return
 	if (istype(O, /obj/structure/reagent_dispensers/fueltank))
 		if(src.reagents.total_volume < max_fuel)

--- a/code/game/objects/items/tools/maintenance_tools.dm
+++ b/code/game/objects/items/tools/maintenance_tools.dm
@@ -664,7 +664,7 @@ Welding backpack
 			playsound(src.loc, 'sound/effects/refill.ogg', 25, 1, 3)
 			return
 		else if (src.reagents.total_volume == max_fuel)
-			to_chat(user, SPAN_NOTICE(" \The [src] is already full!"))
+			to_chat(user, SPAN_NOTICE(" [src] is already full!"))
 			return
 	..()
 

--- a/code/game/objects/items/tools/maintenance_tools.dm
+++ b/code/game/objects/items/tools/maintenance_tools.dm
@@ -654,14 +654,19 @@ Welding backpack
 /obj/item/tool/weldpack/afterattack(obj/O as obj, mob/user as mob, proximity)
 	if(!proximity) // this replaces and improves the get_dist(src,O) <= 1 checks used previously
 		return
-	if (istype(O, /obj/structure/reagent_dispensers/fueltank) && src.reagents.total_volume < max_fuel)
-		O.reagents.trans_to(src, max_fuel)
-		to_chat(user, SPAN_NOTICE(" You crack the cap off the top of \the [src] and fill it back up again from the tank."))
-		playsound(src.loc, 'sound/effects/refill.ogg', 25, 1, 3)
+	//excluding the dispenser that contain gaz or custom to only leave fuel tank.
+	if (istype(O, /obj/structure/reagent_dispensers/fueltank/custom)||istype(O, /obj/structure/reagent_dispensers/fueltank/gas))
 		return
-	else if (istype(O, /obj/structure/reagent_dispensers/fueltank) && src.reagents.total_volume == max_fuel)
-		to_chat(user, SPAN_NOTICE(" \The [src] is already full!"))
-		return
+	if (istype(O, /obj/structure/reagent_dispensers/fueltank))
+		if(src.reagents.total_volume < max_fuel)
+			O.reagents.trans_to(src, max_fuel)
+			to_chat(user, SPAN_NOTICE(" You crack the cap off the top of \the [src] and fill it back up again from the tank."))
+			playsound(src.loc, 'sound/effects/refill.ogg', 25, 1, 3)
+			return
+		else if (src.reagents.total_volume == max_fuel)
+			to_chat(user, SPAN_NOTICE(" \The [src] is already full!"))
+			return
+	..()
 
 /obj/item/tool/weldpack/get_examine_text(mob/user)
 	. = ..()

--- a/code/game/objects/items/tools/maintenance_tools.dm
+++ b/code/game/objects/items/tools/maintenance_tools.dm
@@ -666,7 +666,7 @@ Welding backpack
 		if (reagents.total_volume == max_fuel)
 			to_chat(user, SPAN_NOTICE(" [src] is already full!"))
 			return
-	..()
+	return ..()
 
 /obj/item/tool/weldpack/get_examine_text(mob/user)
 	. = ..()

--- a/code/game/objects/items/tools/maintenance_tools.dm
+++ b/code/game/objects/items/tools/maintenance_tools.dm
@@ -663,7 +663,7 @@ Welding backpack
 			to_chat(user, SPAN_NOTICE(" You crack the cap off the top of \the [src] and fill it back up again from the tank."))
 			playsound(src.loc, 'sound/effects/refill.ogg', 25, 1, 3)
 			return
-		else if (src.reagents.total_volume == max_fuel)
+		if (reagents.total_volume == max_fuel)
 			to_chat(user, SPAN_NOTICE(" [src] is already full!"))
 			return
 	..()

--- a/code/game/objects/items/tools/maintenance_tools.dm
+++ b/code/game/objects/items/tools/maintenance_tools.dm
@@ -655,7 +655,7 @@ Welding backpack
 	if(!proximity) // this replaces and improves the get_dist(src,target) <= 1 checks used previously
 		return
 	if(istype(target, /obj/structure/reagent_dispensers))
-		if(!istypestrict(target, /obj/structure/reagent_dispensers/fueltank))
+		if(!(istypestrict(target, /obj/structure/reagent_dispensers/fueltank)))
 			to_chat(user, SPAN_NOTICE("This must be filled with a fuel tank."))
 			return
 		if(reagents.total_volume < max_fuel)

--- a/code/game/objects/items/tools/maintenance_tools.dm
+++ b/code/game/objects/items/tools/maintenance_tools.dm
@@ -256,7 +256,7 @@
 	else
 		return ..()
 
-/obj/item/tool/weldingtool/afterattack(obj/target as obj, mob/user as mob, proximity)
+/obj/item/tool/weldingtool/afterattack(obj/target, mob/user, proximity)
 	if(!proximity)
 		return
 	if (istype(target, /obj/structure/reagent_dispensers/fueltank) && get_dist(src,target) <= 1)
@@ -654,10 +654,10 @@ Welding backpack
 /obj/item/tool/weldpack/afterattack(obj/target as obj, mob/user as mob, proximity)
 	if(!proximity) // this replaces and improves the get_dist(src,target) <= 1 checks used previously
 		return
-	//excluding the dispenser that contain gaz or custom to only leave fuel tank.
-	if (istype(target, /obj/structure/reagent_dispensers/fueltank/custom) || istype(target, /obj/structure/reagent_dispensers/fueltank/gas))
-		return
-	if (istype(target, /obj/structure/reagent_dispensers/fueltank))
+	if(istype(target, /obj/structure/reagent_dispensers))
+		if(!istypestrict(target, /obj/structure/reagent_dispensers/fueltank))
+			to_chat(user, SPAN_NOTICE("This must be filled with a fuel tank."))
+			return
 		if(reagents.total_volume < max_fuel)
 			target.reagents.trans_to(src, max_fuel)
 			to_chat(user, SPAN_NOTICE("You crack the cap off the top of \the [src] and fill it back up again from the tank."))
@@ -666,7 +666,7 @@ Welding backpack
 		if (reagents.total_volume >= max_fuel)
 			to_chat(user, SPAN_NOTICE("[src] is already full!"))
 			return
-	return ..()
+	..()
 
 /obj/item/tool/weldpack/get_examine_text(mob/user)
 	. = ..()

--- a/code/game/objects/items/tools/maintenance_tools.dm
+++ b/code/game/objects/items/tools/maintenance_tools.dm
@@ -660,11 +660,11 @@ Welding backpack
 	if (istype(O, /obj/structure/reagent_dispensers/fueltank))
 		if(reagents.total_volume < max_fuel)
 			O.reagents.trans_to(src, max_fuel)
-			to_chat(user, SPAN_NOTICE(" You crack the cap off the top of \the [src] and fill it back up again from the tank."))
-			playsound(src.loc, 'sound/effects/refill.ogg', 25, 1, 3)
+			to_chat(user, SPAN_NOTICE("You crack the cap off the top of \the [src] and fill it back up again from the tank."))
+			playsound(loc, 'sound/effects/refill.ogg', 25, 1, 3)
 			return
-		if (reagents.total_volume == max_fuel)
-			to_chat(user, SPAN_NOTICE(" [src] is already full!"))
+		if (reagents.total_volume >= max_fuel)
+			to_chat(user, SPAN_NOTICE("[src] is already full!"))
 			return
 	return ..()
 

--- a/code/game/objects/items/tools/maintenance_tools.dm
+++ b/code/game/objects/items/tools/maintenance_tools.dm
@@ -256,12 +256,12 @@
 	else
 		return ..()
 
-/obj/item/tool/weldingtool/afterattack(obj/O as obj, mob/user as mob, proximity)
+/obj/item/tool/weldingtool/afterattack(obj/target as obj, mob/user as mob, proximity)
 	if(!proximity)
 		return
-	if (istype(O, /obj/structure/reagent_dispensers/fueltank) && get_dist(src,O) <= 1)
+	if (istype(target, /obj/structure/reagent_dispensers/fueltank) && get_dist(src,target) <= 1)
 		if(!welding)
-			O.reagents.trans_to(src, max_fuel)
+			target.reagents.trans_to(src, max_fuel)
 			weld_tick = 0
 			user.visible_message(SPAN_NOTICE("[user] refills [src]."), \
 			SPAN_NOTICE("You refill [src]."))
@@ -270,14 +270,14 @@
 			message_admins("[key_name_admin(user)] triggered a fueltank explosion with a blowtorch.")
 			log_game("[key_name(user)] triggered a fueltank explosion with a blowtorch.")
 			to_chat(user, SPAN_DANGER("You begin welding on the fueltank, and in a last moment of lucidity realize this might not have been the smartest thing you've ever done."))
-			var/obj/structure/reagent_dispensers/fueltank/tank = O
+			var/obj/structure/reagent_dispensers/fueltank/tank = target
 			tank.explode()
 		return
 	if (welding)
 		remove_fuel(1)
 
-		if(isliving(O))
-			var/mob/living/L = O
+		if(isliving(target))
+			var/mob/living/L = target
 			L.IgniteMob()
 
 
@@ -651,15 +651,15 @@ Welding backpack
 	to_chat(user, SPAN_NOTICE("You cannot figure out how to use \the [W] with [src]."))
 	return
 
-/obj/item/tool/weldpack/afterattack(obj/O as obj, mob/user as mob, proximity)
-	if(!proximity) // this replaces and improves the get_dist(src,O) <= 1 checks used previously
+/obj/item/tool/weldpack/afterattack(obj/target as obj, mob/user as mob, proximity)
+	if(!proximity) // this replaces and improves the get_dist(src,target) <= 1 checks used previously
 		return
 	//excluding the dispenser that contain gaz or custom to only leave fuel tank.
-	if (istype(O, /obj/structure/reagent_dispensers/fueltank/custom) || istype(O, /obj/structure/reagent_dispensers/fueltank/gas))
+	if (istype(target, /obj/structure/reagent_dispensers/fueltank/custom) || istype(target, /obj/structure/reagent_dispensers/fueltank/gas))
 		return
-	if (istype(O, /obj/structure/reagent_dispensers/fueltank))
+	if (istype(target, /obj/structure/reagent_dispensers/fueltank))
 		if(reagents.total_volume < max_fuel)
-			O.reagents.trans_to(src, max_fuel)
+			target.reagents.trans_to(src, max_fuel)
 			to_chat(user, SPAN_NOTICE("You crack the cap off the top of \the [src] and fill it back up again from the tank."))
 			playsound(loc, 'sound/effects/refill.ogg', 25, 1, 3)
 			return

--- a/html/changelogs/AutoChangeLog-pr-3319.yml
+++ b/html/changelogs/AutoChangeLog-pr-3319.yml
@@ -1,0 +1,5 @@
+author: "harryob"
+delete-after: True
+changes:
+  - qol: "observer hud buttons for view crew manifest, hive status and joining the hunt (if you're a pred), along with keybinds for joining the hunt"
+  - bugfix: "you can now hide the buttons at the bottom of the ghost hud with f12"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

the idea is to prevent the refill of standard engi backpack with anything but welding fuel.
so i added a check to exclude custom tank and gaz tank from being use to refill those backpacks.
flamer backpack will still use the old check to allow them to use custom fuel to refill their 

fixes https://github.com/cmss13-devs/cmss13/issues/264

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

avoid confusion and avoid making fuel backpack being unusable because they got the wrong chem in them...

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->


# Testing Photographs and Procedure

i tested it on local server everything worked fine.
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
add: Added a Empty canister verb to the Pyrotechnician fuel tanks
fix: prevent fuel backpacks to be filled via reagent tank with improper chemical(welding fuel).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
