### PR TITLE
Holo-Targeting Ammo Buff

### DIFF
--- a/code/datums/components/bonus_damage_stack.dm
+++ b/code/datums/components/bonus_damage_stack.dm
@@ -12,7 +12,7 @@
 	/// extra damage multiplier, divided by 1000
 	var/bonus_damage_stacks = 0
 	/// extra damage multiplier, divided by 1000
-	var/bonus_damage_cap = 100
+	var/bonus_damage_cap = 1000
 	/// Last world.time that the afflicted was hit by a holo-targeting round.
 	var/last_stack
 


### PR DESCRIPTION
# About the pull request
Bumps the cap of bonus damage stacks from 100 (10%) to 1000 (100%).  This still requires enough hits to stack that far (aka 100 Holo hits to reach 100%)


# Explain why it's good for the game
Holo rounds are instantly dropped by all HPR heroes.  This would incentivize them to be more of a support asset.

# Changelog
:cl:
balance: increased the maximum stacks of bonus damage from Holo-Targeting rounds from 10 to 100
/:cl: