### PR TITLE
Removal of instanced content from the USS Almayer and added to props.dm

### DIFF
--- a/code/game/objects/prop.dm
+++ b/code/game/objects/prop.dm
@@ -94,7 +94,7 @@
 
 /obj/item/prop/almayer
 	name = "GENERIC USS ALMAYER PROP"
-	desc = "THIS SHOULDN'T BE VISIBLE, AHELP 'ART-P03' IF SEEN IN ROUND WITH LOCATION"
+	desc = "THIS SHOULDN'T BE VISIBLE, IF YOU SEE THIS THERE IS A PROBLEM IN THE PROP.DM FILE MAKE A BUG REPORT "
 	icon = 'icons/obj/structures/props/almayer_props.dmi'
 	icon_state = "hangarbox"
 

--- a/code/game/objects/prop.dm
+++ b/code/game/objects/prop.dm
@@ -196,7 +196,7 @@
 
 /obj/item/prop/magazine/book/starshiptroopers
 	name = "Starship Troopers"
-	desc = "Written by Robert A. Heinlein, this book really missed the mark when it comes to the individual equipment it depects 'troopers' having, but it's still issued to every marine in basic so it must have some value."
+	desc = "Written by Robert A. Heinlein, this book really missed the mark when it comes to the individual equipment it depicts 'troopers' having, but it's still issued to every marine in basic so it must have some value."
 
 /obj/item/prop/magazine/book/theartofwar
 	name = "The Art of War"

--- a/code/game/objects/prop.dm
+++ b/code/game/objects/prop.dm
@@ -88,3 +88,141 @@
 	desc = "It has some sort of a tube at the end of its tail. What the hell is this thing?"
 	icon = 'icons/mob/xenos/effects.dmi'
 	icon_state = "facehugger_impregnated"
+
+//-----USS Almayer Props -----//
+//Put any props that don't function properly, they could function in the future but for now are for looks. This system could be expanded for other maps too. ~Art
+
+/obj/item/prop/almayer
+	name = "GENERIC USS ALMAYER PROP"
+	desc = "THIS SHOULDN'T BE VISIBLE, AHELP 'ART-P03' IF SEEN IN ROUND WITH LOCATION"
+	icon = 'icons/obj/structures/props/almayer_props.dmi'
+	icon_state = "hangarbox"
+
+/obj/item/prop/almayer/box
+	name = "metal crate"
+	desc = "A metal crate used often for storing small electronics that go into dropships"
+	icon_state = "hangarbox"
+	w_class = SIZE_LARGE
+
+/obj/item/prop/almayer/flight_recorder
+	name = "\improper FR-112 flight recorder"
+	desc = "A small red box that contains flight data from a dropship while it's on mission. Usually referred to as the black box, although this one comes in bloody red."
+	icon_state = "flight_recorder"
+	w_class = SIZE_LARGE
+
+/obj/item/prop/almayer/flight_recorder/colony
+	name = "\improper CIR-60 colony information recorder"
+	desc = "A small red box that records colony announcements, colonist flatlines and other key readouts. Usually refered to the black box, although this one comes in bloody red."
+	icon_state = "flight_recorder"
+	w_class = SIZE_LARGE
+
+/obj/item/prop/almayer/flare_launcher
+	name = "\improper MJU-77/C case"
+	desc = "A flare launcher that usually gets mounted onto dropships to help survivability against infrared tracking missiles."
+	icon_state = "flare_launcher"
+	w_class = SIZE_SMALL
+
+/obj/item/prop/almayer/chaff_launcher
+	name = "\improper RR-247 Chaff case"
+	desc = "A chaff launcher that usually gets mounted onto dropships to help survivability against radar tracking missiles."
+	icon_state = "chaff_launcher"
+	w_class = SIZE_MEDIUM
+
+/obj/item/prop/almayer/handheld1
+	name = "small handheld"
+	desc = "A small piece of electronic doodads"
+	icon_state = "handheld1"
+	w_class = SIZE_SMALL
+
+/obj/item/prop/almayer/comp_closed
+	name = "dropship maintenance computer"
+	desc = "A closed dropship maintenance computer that technicians and pilots use to find out what's wrong with a dropship. It has various outlets for different systems."
+	icon_state = "hangar_comp"
+	w_class = SIZE_LARGE
+
+/obj/item/prop/almayer/comp_open
+	name = "dropship maintenance computer"
+	desc = "An opened dropship maintenance computer, it seems to be off however. It's used by technicians and pilots to find damaged or broken systems on a dropship. It has various outlets for different systems."
+	icon_state = "hangar_comp_open"
+	w_class = SIZE_LARGE
+
+//lore fluff books and magazines
+
+/obj/item/prop/magazine
+	name = "generic prop magazine"
+	desc = "A Magazine with a picture of a pretty girl on it..wait isn't that my mom?"
+	icon = 'icons/obj/structures/props/posters.dmi'
+	icon_state = "poster15"
+	throw_speed = SPEED_FAST
+	throw_range = 5
+	w_class = SIZE_MEDIUM
+	attack_verb = list("bashed", "whacked", "educated")
+	pickup_sound = "sound/handling/book_pickup.ogg"
+	drop_sound = "sound/handling/book_pickup.ogg"
+	black_market_value = 15
+
+//random magazines
+/obj/item/prop/magazine/dirty
+	name = "Dirty Magazine"
+	desc = "Wawaweewa."
+	icon_state = "poster17"
+
+/obj/item/prop/magazine/dirty/torn
+	name = "\improper torn magazine page"
+	desc = "Hubba hubba."
+
+/obj/item/prop/magazine/dirty/torn/alt
+	icon_state = "poster3"
+
+
+//books
+/obj/item/prop/magazine/book
+	name = "generic prop book"
+	desc = "some generic hardcover book, probably sucked"
+	icon = 'icons/obj/items/books.dmi'
+	icon_state = "bookSpaceLaw"
+
+/obj/item/prop/magazine/book/spacebeast
+	name = "\improper Space Beast, by Robert Morse"
+	desc = "An autobiography focusing on the events of 'Fury 161' in August 2179 following the arrival of 'Ellen Ripley' and an unknown alien creature known as 'The Dragon' the books writing is extremely crude and was book banned shorty after publication."
+
+/obj/item/prop/magazine/book/borntokill
+	name = "\improper Born to Kill"
+	desc = "An autobiography penned by Derik A.W. Tomahawk it recounts his service in the USCM. The book was harshly criticised for its bland and uncreative writing and wasn't well received by the general public or members of the UA military. However, artificial soldiers typically value the information contained within."
+
+/obj/item/prop/magazine/book/bladerunner
+	name = "\improper Bladerunner: A True Detectives Story"
+	desc = "In the dark undercity of Luna 2119, blade runner Richard Ford is called out of retirement to terminate a cult of replicants who have escaped Earth seeking the meaning of their existence."
+
+/obj/item/prop/magazine/book/starshiptroopers
+	name = "Starship Troopers"
+	desc = "Written by Robert A. Heinlein, this book really missed the mark when it comes to the individual equipment it depects 'troopers' having, but it's still issued to every marine in basic so it must have some value."
+
+/obj/item/prop/magazine/book/theartofwar
+	name = "The Art of War"
+	desc = "A treatise on war written by Sun Tzu a great general, strategist, and philosopher from ancient Earth. This book is on the Commandant of the United States Colonial Marine Corps reading list and most officers can be found in possession of a copy. Most officers who've read it claim to know a little bit more about fighting than most enlisted but results may vary. "
+
+//boots magazine
+/obj/item/prop/magazine/boots
+	name = "generic Boots! magazine"
+	desc = "The only official USCM magazine!"
+
+/obj/item/prop/magazine/boots/n117
+	name = "Boots!: Issue No.117"
+	desc = "The only official USCM magazine, the headline reads 'STOP CANNING' the short paragraph further explains the dangers of marines throwing CN-20 Nerve gas into bathrooms as a prank."
+
+/obj/item/prop/magazine/boots/n150
+	name = "Boots!: Issue No.150"
+	desc = "The only official USCM magazine, the headline reads 'UPP Rations, The truth.' the short paragraph further explains UPP field rations aren't standardized and are produced at a local level. Because of this, captured and confiscated UPP rations have included some odd choices such as duck liver, century eggs, lutefisk, pickled pig snout, canned tripe, and dehydrated candied radish snacks."
+
+/obj/item/prop/magazine/boots/n160
+	name = "Boots!: Issue No.160"
+	desc = "The only official USCM magazine, the headline reads 'Corporate Liaison 'emotionally exhausted' from screwing so many people over.'"
+
+/obj/item/prop/magazine/boots/n054
+	name = "Boots!: Issue No.54"
+	desc = "The only official USCM magazine, the headline reads 'ARMAT strikes back against litigants in M41A-MK2 self cleaning case'"
+
+/obj/item/prop/magazine/boots/n055
+	name = "Boots!: Issue No.55"
+	desc = "The only official USCM magazine, the headline reads 'TEN tips to keep your UD4 cockpit both safer and more relaxing.'"

--- a/code/modules/almayer/machinery.dm
+++ b/code/modules/almayer/machinery.dm
@@ -1,70 +1,12 @@
 //-----USS Almayer Machinery file -----//
 // Put any new machines in here before map is released and everything moved to their proper positions.
 
-
-
-//-----USS Almayer Props -----//
-//Put any props that don't function properly, they could function in the future but for now are for looks. This system could be expanded for other maps too. ~Art
-
-/obj/item/prop/almayer
-	name = "GENERIC USS ALMAYER PROP"
-	desc = "THIS SHOULDN'T BE VISIBLE, AHELP 'ART-P03' IF SEEN IN ROUND WITH LOCATION"
-	icon = 'icons/obj/structures/props/almayer_props.dmi'
-	icon_state = "hangarbox"
-
-/obj/item/prop/almayer/box
-	name = "metal crate"
-	desc = "A metal crate used often for storing small electronics that go into dropships"
-	icon_state = "hangarbox"
-	w_class = SIZE_LARGE
-
-/obj/item/prop/almayer/flight_recorder
-	name = "\improper FR-112 flight recorder"
-	desc = "A small red box that contains flight data from a dropship while it's on mission. Usually referred to as the black box, although this one comes in bloody red."
-	icon_state = "flight_recorder"
-	w_class = SIZE_LARGE
-
-/obj/item/prop/almayer/flight_recorder/colony
-	name = "\improper CIR-60 colony information recorder"
-	desc = "A small red box that records colony announcements, colonist flatlines and other key readouts. Usually refered to the black box, although this one comes in bloody red."
-	icon_state = "flight_recorder"
-	w_class = SIZE_LARGE
-
-/obj/item/prop/almayer/flare_launcher
-	name = "\improper MJU-77/C case"
-	desc = "A flare launcher that usually gets mounted onto dropships to help survivability against infrared tracking missiles."
-	icon_state = "flare_launcher"
-	w_class = SIZE_SMALL
-
-/obj/item/prop/almayer/chaff_launcher
-	name = "\improper RR-247 Chaff case"
-	desc = "A chaff launcher that usually gets mounted onto dropships to help survivability against radar tracking missiles."
-	icon_state = "chaff_launcher"
-	w_class = SIZE_MEDIUM
-
-/obj/item/prop/almayer/handheld1
-	name = "small handheld"
-	desc = "A small piece of electronic doodads"
-	icon_state = "handheld1"
-	w_class = SIZE_SMALL
-
-/obj/item/prop/almayer/comp_closed
-	name = "dropship maintenance computer"
-	desc = "A closed dropship maintenance computer that technicians and pilots use to find out what's wrong with a dropship. It has various outlets for different systems."
-	icon_state = "hangar_comp"
-	w_class = SIZE_LARGE
-
-/obj/item/prop/almayer/comp_open
-	name = "dropship maintenance computer"
-	desc = "An opened dropship maintenance computer, it seems to be off however. It's used by technicians and pilots to find damaged or broken systems on a dropship. It has various outlets for different systems."
-	icon_state = "hangar_comp_open"
-	w_class = SIZE_LARGE
-
 /obj/structure/machinery/prop/almayer
 	name = "GENERIC USS ALMAYER PROP"
 	desc = "THIS SHOULDN'T BE VISIBLE, AHELP 'ART-P01' IF SEEN IN ROUND WITH LOCATION"
 
 /obj/structure/machinery/prop/almayer/hangar/dropship_part_fabricator
+
 /obj/structure/machinery/prop/almayer/computer/PC
 	name = "personal desktop"
 	desc = "A small computer hooked up into the ship's computer network."

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -13463,19 +13463,16 @@
 /obj/structure/toilet{
 	pixel_y = 13
 	},
-/obj/structure/sign/poster{
-	desc = "Wawaweewa.";
-	icon_state = "poster17";
-	name = "magazine";
-	pixel_x = -6;
-	pixel_y = -7
-	},
 /obj/item/paper_bin/uscm{
 	pixel_x = 9;
 	pixel_y = -3
 	},
 /obj/structure/machinery/light/small{
 	dir = 4
+	},
+/obj/item/prop/magazine/dirty{
+	pixel_x = -6;
+	pixel_y = -10
 	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
@@ -25883,13 +25880,9 @@
 	pixel_x = -10;
 	pixel_y = 6
 	},
-/obj/item/prop/helmetgarb/spacejam_tickets{
-	desc = "The only official USCM magazine, the headline reads 'Corporate Liaison 'emotionally exhausted' from screwing so many people over.'";
-	icon = 'icons/obj/structures/props/posters.dmi';
-	icon_state = "poster15";
-	name = "Boots!: Issue No.160";
-	pixel_x = -5;
-	pixel_y = -7
+/obj/item/prop/magazine/boots/n160{
+	pixel_x = -6;
+	pixel_y = -5
 	},
 /obj/structure/transmitter/rotary{
 	name = "Flight Deck Telephone";
@@ -29477,12 +29470,9 @@
 	pixel_x = 1;
 	pixel_y = 25
 	},
-/obj/item/book{
-	desc = "An autobiography penned by Derik A.W. Tomahawk it recounts his service in the USCM. The book was harshly criticised for its bland and uncreative writing and wasn't well received by the general public or members of the UA military. However, artificial soldiers typically value the information contained within.";
-	icon_state = "bookSpaceLaw";
-	name = "\improper Born to Kill";
+/obj/item/prop/magazine/book/borntokill{
 	pixel_x = -6;
-	pixel_y = 6
+	pixel_y = 7
 	},
 /turf/open/floor/almayer{
 	dir = 1;
@@ -32110,9 +32100,7 @@
 /area/almayer/engineering/upper_engineering/port)
 "eiq" = (
 /obj/structure/surface/table/reinforced/prison,
-/obj/structure/sign/poster{
-	serial_number = 15
-	},
+/obj/item/prop/magazine/dirty,
 /turf/open/floor/almayer,
 /area/almayer/squads/charlie_delta_shared)
 "eiw" = (
@@ -32427,12 +32415,7 @@
 /area/almayer/hull/lower_hull/l_m_s)
 "eni" = (
 /obj/structure/surface/table/almayer,
-/obj/item/book{
-	desc = "An autobiography focusing on the events of 'Fury 161' in August 2179 following the arrival of 'Ellen Ripley' and an unknown alien creature known as 'The Dragon' the books writing is extremely crude and was book banned shorty after publication.";
-	icon_state = "bookSpaceLaw";
-	name = "\improper Space Beast, by Robert Morse";
-	pixel_y = 3
-	},
+/obj/item/prop/magazine/book/spacebeast,
 /turf/open/floor/almayer{
 	dir = 1;
 	icon_state = "red"
@@ -35532,12 +35515,8 @@
 /area/almayer/squads/req)
 "fIZ" = (
 /obj/structure/surface/table/almayer,
-/obj/item/prop/helmetgarb/spacejam_tickets{
-	desc = "The only official USCM magazine, the headline reads 'STOP CANNING' the short paragraph further explains the dangers of marines throwing CN-20 Nerve gas into bathrooms as a prank.";
-	icon = 'icons/obj/structures/props/posters.dmi';
-	icon_state = "poster15";
-	name = "Boots!: Issue No.117";
-	pixel_x = -5;
+/obj/item/prop/magazine/boots/n117{
+	pixel_x = -4;
 	pixel_y = 6
 	},
 /turf/open/floor/almayer{
@@ -39009,11 +38988,7 @@
 /area/almayer/living/briefing)
 "htL" = (
 /obj/structure/surface/table/almayer,
-/obj/item/prop/helmetgarb/spacejam_tickets{
-	desc = "The only official USCM magazine, the headline reads 'UPP Rations, The truth.' the short paragraph further explains UPP field rations aren't standardized and are produced at a local level. Because of this, captured and confiscated UPP rations have included some odd choices such as duck liver pâté, century eggs, lutefisk, pickled pig snout, canned tripe, and dehydrated candied radish snacks.";
-	icon = 'icons/obj/structures/props/posters.dmi';
-	icon_state = "poster15";
-	name = "Boots!: Issue No.150";
+/obj/item/prop/magazine/boots/n150{
 	pixel_x = -5;
 	pixel_y = 6
 	},
@@ -46198,21 +46173,10 @@
 /area/almayer/hull/lower_hull/l_m_p)
 "kRP" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
-/obj/item/prop/helmetgarb/spacejam_tickets{
-	desc = "Hubba hubba.";
-	icon = 'icons/obj/structures/props/posters.dmi';
-	icon_state = "poster17";
-	name = "\improper torn magazine page";
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/obj/item/prop/helmetgarb/spacejam_tickets{
-	desc = "Hubba hubba.";
-	icon = 'icons/obj/structures/props/posters.dmi';
-	icon_state = "poster3";
-	name = "\improper torn magazine page";
-	pixel_x = 5;
-	pixel_y = 14
+/obj/item/prop/magazine/dirty/torn,
+/obj/item/prop/magazine/dirty/torn/alt{
+	pixel_x = 7;
+	pixel_y = 11
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/hangar)
@@ -49955,12 +49919,9 @@
 /obj/structure/sign/safety/distribution_pipes{
 	pixel_x = -17
 	},
-/obj/item/book{
-	desc = "In the dark undercity of Luna 2119, blade runner Richard Ford is called out of retirement to terminate a cult of replicants who have escaped Earth seeking the meaning of their existence.";
-	icon_state = "bookSpaceLaw";
-	name = "\improper Bladerunner: A True Detectives Story";
-	pixel_x = -6;
-	pixel_y = 6
+/obj/item/prop/magazine/book/bladerunner{
+	pixel_x = -1;
+	pixel_y = 9
 	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
@@ -54927,17 +54888,13 @@
 "oZp" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/light,
-/obj/item/prop/helmetgarb/spacejam_tickets{
-	desc = "The only official USCM magazine, the headline reads 'TEN tips to keep your UD4 cockpit both safer and more relaxing.'";
-	icon = 'icons/obj/structures/props/posters.dmi';
-	icon_state = "poster15";
-	name = "Boots!: Issue No.55";
-	pixel_x = -5;
-	pixel_y = 5
-	},
 /obj/item/reagent_container/food/snacks/grilledcheese{
 	pixel_x = 6;
 	pixel_y = 8
+	},
+/obj/item/prop/magazine/boots/n055{
+	pixel_x = -9;
+	pixel_y = 5
 	},
 /turf/open/floor/almayer{
 	dir = 10;
@@ -63423,27 +63380,17 @@
 	pixel_x = 7;
 	pixel_y = 9
 	},
-/obj/item/prop/helmetgarb/spacejam_tickets{
-	desc = "Hubba hubba.";
-	icon = 'icons/obj/structures/props/posters.dmi';
-	icon_state = "poster17";
-	name = "\improper torn magazine page";
-	pixel_x = -5;
-	pixel_y = 5
-	},
 /obj/item/trash/semki{
 	layer = 2;
 	pixel_x = -13;
 	pixel_y = 14
 	},
-/obj/item/prop/helmetgarb/spacejam_tickets{
-	desc = "The only official USCM magazine, the headline reads 'ARMAT strikes back against litigants in M41A-MK2 self cleaning case'";
-	icon = 'icons/obj/structures/props/posters.dmi';
-	icon_state = "poster15";
-	layer = 3.6;
-	name = "Boots!: Issue No.54";
-	pixel_x = 27;
-	pixel_y = 4
+/obj/item/prop/magazine/boots/n054{
+	pixel_x = 29
+	},
+/obj/item/prop/magazine/dirty/torn{
+	pixel_x = -6;
+	pixel_y = 6
 	},
 /obj/item/clothing/glasses/disco_fever{
 	pixel_x = 5;
@@ -70159,14 +70106,11 @@
 	dir = 4
 	},
 /obj/structure/surface/table/reinforced/almayer_B,
-/obj/structure/sign/poster{
-	desc = "Wawaweewa.";
-	icon_state = "poster17";
-	name = "magazine";
-	pixel_x = 3;
-	pixel_y = 4
+/obj/item/tool/pen{
+	pixel_x = 9;
+	pixel_y = -5
 	},
-/obj/item/tool/pen,
+/obj/item/prop/magazine/book/theartofwar,
 /turf/open/floor/almayer,
 /area/almayer/living/bridgebunks)
 "vWB" = (
@@ -72006,16 +71950,9 @@
 "wNl" = (
 /obj/structure/surface/table/almayer,
 /obj/item/trash/USCMtray{
-	pixel_x = 5
-	},
-/obj/item/trash/USCMtray{
 	layer = 3.2;
 	pixel_x = 4;
 	pixel_y = 17
-	},
-/obj/item/reagent_container/food/snacks/bearmeat{
-	pixel_x = 4;
-	pixel_y = -1
 	},
 /obj/item/reagent_container/food/drinks/cans/souto{
 	pixel_x = -10;
@@ -72025,6 +71962,10 @@
 	layer = 3.3;
 	pixel_x = 1;
 	pixel_y = 13
+	},
+/obj/item/prop/magazine/book/starshiptroopers{
+	pixel_x = 8;
+	pixel_y = -3
 	},
 /turf/open/floor/almayer{
 	dir = 10;


### PR DESCRIPTION
# About the pull request

This PR removes the instanced magazines and books on the USS Almayer, replacing them with actual coded items people can use to their hearts content

This PR also moves some /item/props relating to the USS Almayer into the actual props file instead of the machinery file 

This PR also adds two new books
Starship Troopers (this is a reference to the actors of the colonial marines in Aliens being given the book as prep for their role) I had also heard it was available to people in basic training
The Art of War I had heard that this book is also available to people in the military during basic training

# Explain why it's good for the game

A coder would be much better suited to explain why instances suck I actually don't know why they hate them but I promised stan I'd one day do this for him


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:SpartanBobby
add: Added two books to the USS Almayer
maptweak: made instances of books and magazines on the USS Almayer into actual items
/:cl:
