### PR TITLE
Adds the basis for CO (and other) factions

### DIFF
--- a/code/__DEFINES/mode.dm
+++ b/code/__DEFINES/mode.dm
@@ -286,6 +286,9 @@ var/global/list/whitelist_hierarchy = list(WHITELIST_NORMAL, WHITELIST_COUNCIL, 
 
 #define FACTION_LIST_XENOMORPH list(FACTION_XENOMORPH, FACTION_XENOMORPH_CORRPUTED, FACTION_XENOMORPH_ALPHA, FACTION_XENOMORPH_BRAVO, FACTION_XENOMORPH_CHARLIE, FACTION_XENOMORPH_DELTA)
 
+// Faction allegiances within a certain faction.
+
+#define FACTION_ALLEGIANCE_USCM_COMMANDER list("Doves", "Hawks", "Magpies", "Unaligned")
 
 // global vars to prevent spam of the "one xyz alive" messages
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -99,6 +99,7 @@ var/const/MAX_SAVE_SLOTS = 10
 	var/predator_flavor_text = ""
 	//CO-specific preferences
 	var/commander_sidearm = "Mateba"
+	var/affiliation = "Unaligned"
 	//SEA specific preferences
 
 	///holds our preferred job options for jobs
@@ -474,6 +475,7 @@ var/const/MAX_SAVE_SLOTS = 10
 				dat += "<h2><b><u>Commander Settings:</u></b></h2>"
 				dat += "<b>Commander Whitelist Status:</b> <a href='?_src_=prefs;preference=commander_status;task=input'><b>[commander_status]</b></a><br>"
 				dat += "<b>Commander Sidearm:</b> <a href='?_src_=prefs;preference=co_sidearm;task=input'><b>[commander_sidearm]</b></a><br>"
+				dat += "<b>Commander Affiliation:</b> <a href='?_src_=prefs;preference=co_affiliation;task=input'><b>[affiliation]</b></a><br>"
 				dat += "</div>"
 			else
 				dat += "<b>You do not have the whitelist for this role.</b>"
@@ -1197,6 +1199,14 @@ var/const/MAX_SAVE_SLOTS = 10
 					if(!new_co_sidearm)
 						return
 					commander_sidearm = new_co_sidearm
+
+				if("co_affiliation")
+					var/list/options = list("Doves", "Hawks", "Magpies", "Unaligned")
+					var/new_co_affiliation = tgui_input_list(user, "Choose your faction affiliation.", "Commanding Officer's Affiliation", options)
+					if(!new_co_affiliation)
+						return
+					affiliation = new_co_affiliation
+
 
 				if("yautja_status")
 					var/list/options = list("Normal" = WHITELIST_NORMAL)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1201,8 +1201,7 @@ var/const/MAX_SAVE_SLOTS = 10
 					commander_sidearm = new_co_sidearm
 
 				if("co_affiliation")
-					var/list/options = list("Doves", "Hawks", "Magpies", "Unaligned")
-					var/new_co_affiliation = tgui_input_list(user, "Choose your faction affiliation.", "Commanding Officer's Affiliation", options)
+					var/new_co_affiliation = tgui_input_list(user, "Choose your faction affiliation.", "Commanding Officer's Affiliation", FACTION_ALLEGIANCE_USCM_COMMANDER)
 					if(!new_co_affiliation)
 						return
 					affiliation = new_co_affiliation

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -243,7 +243,7 @@
 	predator_flavor_text = predator_flavor_text ? sanitize_text(predator_flavor_text, initial(predator_flavor_text)) : initial(predator_flavor_text)
 	commander_status = sanitize_inlist(commander_status, whitelist_hierarchy, initial(commander_status))
 	commander_sidearm   = sanitize_inlist(commander_sidearm, list("Mateba","Colonel's Mateba","Golden Desert Eagle","Desert Eagle"), initial(commander_sidearm))
-	affiliation = sanitize_inlist(affiliation, list("Doves", "Hawks", "Magpies", "Unaligned"), initial(affiliation))
+	affiliation = sanitize_inlist(affiliation, FACTION_ALLEGIANCE_USCM_COMMANDER, initial(affiliation))
 	yautja_status = sanitize_inlist(yautja_status, whitelist_hierarchy + list("Elder"), initial(yautja_status))
 	synth_status = sanitize_inlist(synth_status, whitelist_hierarchy, initial(synth_status))
 	key_bindings = sanitize_keybindings(key_bindings)

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -172,6 +172,7 @@
 
 	S["commander_status"] >> commander_status
 	S["co_sidearm"] >> commander_sidearm
+	S["co_affiliation"] >> affiliation
 	S["yautja_status"] >> yautja_status
 	S["synth_status"] >> synth_status
 	S["key_bindings"] >> key_bindings
@@ -242,6 +243,7 @@
 	predator_flavor_text = predator_flavor_text ? sanitize_text(predator_flavor_text, initial(predator_flavor_text)) : initial(predator_flavor_text)
 	commander_status = sanitize_inlist(commander_status, whitelist_hierarchy, initial(commander_status))
 	commander_sidearm   = sanitize_inlist(commander_sidearm, list("Mateba","Colonel's Mateba","Golden Desert Eagle","Desert Eagle"), initial(commander_sidearm))
+	affiliation = sanitize_inlist(affiliation, list("Doves", "Hawks", "Magpies", "Unaligned"), initial(affiliation))
 	yautja_status = sanitize_inlist(yautja_status, whitelist_hierarchy + list("Elder"), initial(yautja_status))
 	synth_status = sanitize_inlist(synth_status, whitelist_hierarchy, initial(synth_status))
 	key_bindings = sanitize_keybindings(key_bindings)
@@ -346,6 +348,7 @@
 
 	S["commander_status"] << commander_status
 	S["co_sidearm"] << commander_sidearm
+	S["co_affiliation"] << affiliation
 	S["yautja_status"] << yautja_status
 	S["synth_status"] << synth_status
 


### PR DESCRIPTION

# About the pull request
Adds code to the preferences files to allow for COs to select their faction (Doves, Hawks, Magpies, Unaligned). This currently has no effect.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Lore..?
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Adds the basis for CO (and other) faction preferences

/:cl:
