### PR TITLE
Makes a few special structures unslashable/unacidable

### DIFF
--- a/code/modules/cm_marines/vehicle_part_fabricator.dm
+++ b/code/modules/cm_marines/vehicle_part_fabricator.dm
@@ -119,6 +119,9 @@
 	valid_parts = /obj/structure/dropship_equipment
 	valid_ammo = /obj/structure/ship_ammo
 
+	unslashable = TRUE
+	unacidable = TRUE
+
 /obj/structure/machinery/part_fabricator/dropship/get_point_store()
 	return supply_controller.dropship_points
 

--- a/code/modules/reagents/chemistry_machinery/chem_simulator.dm
+++ b/code/modules/reagents/chemistry_machinery/chem_simulator.dm
@@ -48,6 +48,9 @@
 	var/min_creation_cost = 0
 	var/creation_od_level = 10 //a cache for new_od_level when switching between modes
 
+	unslashable = TRUE
+	unacidable = TRUE
+
 /obj/structure/machinery/chem_simulator/Initialize()
 	. = ..()
 	LAZYINITLIST(simulations)

--- a/code/modules/reagents/chemistry_machinery/chem_storage.dm
+++ b/code/modules/reagents/chemistry_machinery/chem_storage.dm
@@ -14,6 +14,9 @@
 	var/energy = 50
 	var/max_energy = 50
 
+	unslashable = TRUE
+	unacidable = TRUE
+
 /obj/structure/machinery/chem_storage/medbay
 	name = "Chemical Storage System (Medbay)"
 	network = "Medbay"


### PR DESCRIPTION
# About the pull request

DS part fabricator, chem simulator, chem storage are now unslashable/unacidable.

Closes #3365 

# Explain why it's good for the game

A role shouldn't be completely turned off by a shipside xeno.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: DS part fabricator, chem simulator, chem storage are now unslashable/unacidable
/:cl:
