### PR TITLE
Fix huggers never passively dying if they fail to attach to a target

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
@@ -254,13 +254,13 @@
 		var/mob/living/carbon/xenomorph/X = loc
 		X.drop_inv_item_on_ground(src)
 
-	attached = TRUE
-
 	if(isturf(H.loc))
 		forceMove(H.loc)//Just checkin
 
 	if(!H.handle_hugger_attachment(src))
 		return FALSE
+
+	attached = TRUE
 
 	forceMove(H)
 	icon_state = initial(icon_state)


### PR DESCRIPTION
# About the pull request

Fixes huggers not passively dying if they fail to attach to a target by making them count as attached only after we're sure there's no anti-hug helmets / masks in the way of the host's face.

# Explain why it's good for the game

Doesn't leave bugged facehuggers laying around.

# Changelog

:cl:
fix: Fixed huggers not passively dying if they fail to attach to a target.
/:cl: