### PR TITLE
Fix bug that didn't remove luminosity after the object that emit them was destroy.

### DIFF
--- a/code/game/objects/effects/decals/cleanable/misc.dm
+++ b/code/game/objects/effects/decals/cleanable/misc.dm
@@ -31,6 +31,16 @@
 	icon_state = "dirt"
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 
+/obj/effect/decal/cleanable/dirt/greenglow
+	name = "glowing goo"
+	acid_damage = 1
+	icon_state = "greenglow"
+	luminosity = 1
+
+/obj/effect/decal/cleanable/dirt/greenglow/Destroy()
+	SetLuminosity(0)
+	return ..()
+
 /obj/effect/decal/cleanable/flour
 	name = "flour"
 	desc = "It's still good. Four second rule!"

--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -448,6 +448,16 @@ ICEY GRASS. IT LOOKS LIKE IT'S MADE OF ICE.
 	desc = "Some kind of bizarre alien tree. It oozes with a sickly yellow sap."
 	icon_state = "plantbot1"
 
+/obj/structure/flora/jungle/bioluminescent
+	name = "strange tree"
+	desc = "Some kind of bizarre alien tree. It oozes with a sickly yellow sap."
+	icon_state = "alienplant1";
+	luminosity = 2
+
+/obj/structure/flora/jungle/bioluminescent/Destroy()
+	SetLuminosity(0)
+	return ..()
+
 /obj/structure/flora/jungle/planttop1
 	name = "strange tree"
 	desc = "Some kind of bizarre alien tree. It oozes with a sickly yellow sap."

--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -458,7 +458,7 @@ ICEY GRASS. IT LOOKS LIKE IT'S MADE OF ICE.
 	icon_state = "alienplant1"
 	luminosity = 2
 
-/obj/structure/flora/jungle/bioluminescent/Destroy()
+/obj/structure/flora/jungle/alienplant1/Destroy()
 	SetLuminosity(0)
 	return ..()
 

--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -438,7 +438,6 @@ ICEY GRASS. IT LOOKS LIKE IT'S MADE OF ICE.
 	layer = ABOVE_XENO_LAYER
 	projectile_coverage = PROJECTILE_COVERAGE_NONE
 
-
 /obj/structure/flora/jungle/shrub
 	desc = "Pretty thick scrub, it'll take something sharp and a lot of determination to clear away."
 	icon_state = "grass4"
@@ -448,10 +447,15 @@ ICEY GRASS. IT LOOKS LIKE IT'S MADE OF ICE.
 	desc = "Some kind of bizarre alien tree. It oozes with a sickly yellow sap."
 	icon_state = "plantbot1"
 
+/obj/structure/flora/jungle/cart_wreck
+	name = "old janicart"
+	desc = "Doesn't look like it'll do much cleaning any more."
+	icon_state = "cart_wreck"
+
 /obj/structure/flora/jungle/alienplant1
 	name = "strange tree"
 	desc = "Some kind of bizarre alien tree. It oozes with a sickly yellow sap."
-	icon_state = "alienplant1";
+	icon_state = "alienplant1"
 	luminosity = 2
 
 /obj/structure/flora/jungle/bioluminescent/Destroy()

--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -448,7 +448,7 @@ ICEY GRASS. IT LOOKS LIKE IT'S MADE OF ICE.
 	desc = "Some kind of bizarre alien tree. It oozes with a sickly yellow sap."
 	icon_state = "plantbot1"
 
-/obj/structure/flora/jungle/bioluminescent
+/obj/structure/flora/jungle/alienplant1
 	name = "strange tree"
 	desc = "Some kind of bizarre alien tree. It oozes with a sickly yellow sap."
 	icon_state = "alienplant1";

--- a/code/game/objects/structures/props.dm
+++ b/code/game/objects/structures/props.dm
@@ -691,6 +691,10 @@
 	density = FALSE
 	luminosity = 5
 
+/obj/structure/prop/brazier/torch/Destroy()
+	SetLuminosity(0)
+	return ..()
+
 /obj/structure/prop/brazier/torch/frame
 	name = "unlit torch"
 	desc = "It's a torch, but it's not lit.  Use something hot to ignite it, like a welding tool."

--- a/code/game/objects/structures/props.dm
+++ b/code/game/objects/structures/props.dm
@@ -648,6 +648,10 @@
 	health = 150
 	luminosity = 6
 
+/obj/structure/prop/brazier/Destroy()
+	SetLuminosity(0)
+	return ..()
+
 /obj/structure/prop/brazier/Initialize()
 	. = ..()
 	if(luminosity)
@@ -690,10 +694,6 @@
 	icon_state = "torch"
 	density = FALSE
 	luminosity = 5
-
-/obj/structure/prop/brazier/torch/Destroy()
-	SetLuminosity(0)
-	return ..()
 
 /obj/structure/prop/brazier/torch/frame
 	name = "unlit torch"

--- a/maps/map_files/BigRed/sprinkles/15.reactor_meltdown.dmm
+++ b/maps/map_files/BigRed/sprinkles/15.reactor_meltdown.dmm
@@ -658,12 +658,7 @@
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
 "dj" = (
-/obj/effect/decal/cleanable/dirt{
-	acid_damage = 1;
-	icon_state = "greenglow";
-	luminosity = 1;
-	name = "glowing goo"
-	},
+/obj/effect/decal/cleanable/dirt/greenglow,
 /turf/open/gm/river,
 /area/bigredv2/outside/engineering)
 "dk" = (
@@ -693,12 +688,7 @@
 /area/bigredv2/outside/engineering)
 "dq" = (
 /obj/item/bananapeel,
-/obj/effect/decal/cleanable/dirt{
-	acid_damage = 1;
-	icon_state = "greenglow";
-	luminosity = 1;
-	name = "glowing goo"
-	},
+/obj/effect/decal/cleanable/dirt/greenglow,
 /turf/open/floor/plating,
 /area/bigredv2/outside/engineering)
 "dr" = (
@@ -718,12 +708,7 @@
 /turf/open/floor/plating,
 /area/bigredv2/outside/engineering)
 "dx" = (
-/obj/effect/decal/cleanable/dirt{
-	acid_damage = 1;
-	icon_state = "greenglow";
-	luminosity = 1;
-	name = "glowing goo"
-	},
+/obj/effect/decal/cleanable/dirt/greenglow,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -815,33 +800,18 @@
 /turf/open/floor/plating,
 /area/bigredv2/outside/engineering)
 "dY" = (
-/obj/effect/decal/cleanable/dirt{
-	acid_damage = 1;
-	icon_state = "greenglow";
-	luminosity = 1;
-	name = "glowing goo"
-	},
+/obj/effect/decal/cleanable/dirt/greenglow,
 /turf/open/floor{
 	icon_state = "wall_thermite"
 	},
 /area/bigredv2/outside/engineering)
 "dZ" = (
-/obj/effect/decal/cleanable/dirt{
-	acid_damage = 1;
-	icon_state = "greenglow";
-	luminosity = 1;
-	name = "glowing goo"
-	},
+/obj/effect/decal/cleanable/dirt/greenglow,
 /turf/open/floor/plating,
 /area/bigredv2/outside/engineering)
 "eb" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	acid_damage = 1;
-	icon_state = "greenglow";
-	luminosity = 1;
-	name = "glowing goo"
-	},
+/obj/effect/decal/cleanable/dirt/greenglow,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -862,12 +832,7 @@
 /area/bigredv2/outside/engineering)
 "eh" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	acid_damage = 1;
-	icon_state = "greenglow";
-	luminosity = 1;
-	name = "glowing goo"
-	},
+/obj/effect/decal/cleanable/dirt/greenglow,
 /turf/open/floor/plating,
 /area/bigredv2/outside/engineering)
 "ei" = (
@@ -913,12 +878,7 @@
 /turf/open/floor/plating,
 /area/bigredv2/outside/engineering)
 "eo" = (
-/obj/effect/decal/cleanable/dirt{
-	acid_damage = 1;
-	icon_state = "greenglow";
-	luminosity = 1;
-	name = "glowing goo"
-	},
+/obj/effect/decal/cleanable/dirt/greenglow,
 /obj/structure/blocker/forcefield/multitile_vehicles,
 /turf/open/mars_cave{
 	icon_state = "mars_cave_7"
@@ -958,12 +918,7 @@
 /area/bigredv2/outside/engineering)
 "ex" = (
 /obj/effect/decal/cleanable/molten_item,
-/obj/effect/decal/cleanable/dirt{
-	acid_damage = 1;
-	icon_state = "greenglow";
-	luminosity = 1;
-	name = "glowing goo"
-	},
+/obj/effect/decal/cleanable/dirt/greenglow,
 /turf/open/floor{
 	icon_state = "wall_thermite"
 	},
@@ -990,12 +945,7 @@
 	},
 /area/bigredv2/outside/engineering)
 "eB" = (
-/obj/effect/decal/cleanable/dirt{
-	acid_damage = 1;
-	icon_state = "greenglow";
-	luminosity = 1;
-	name = "glowing goo"
-	},
+/obj/effect/decal/cleanable/dirt/greenglow,
 /obj/structure/blocker/forcefield/multitile_vehicles,
 /turf/open/mars_cave,
 /area/bigredv2/outside/lz2_south_cas)
@@ -1028,12 +978,7 @@
 /area/bigredv2/outside/telecomm/engi)
 "eG" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	acid_damage = 1;
-	icon_state = "greenglow";
-	luminosity = 1;
-	name = "glowing goo"
-	},
+/obj/effect/decal/cleanable/dirt/greenglow,
 /turf/open/floor{
 	icon_state = "wall_thermite"
 	},
@@ -1056,12 +1001,7 @@
 /area/bigredv2/outside/engineering)
 "eK" = (
 /obj/effect/decal/cleanable/molten_item,
-/obj/effect/decal/cleanable/dirt{
-	acid_damage = 1;
-	icon_state = "greenglow";
-	luminosity = 1;
-	name = "glowing goo"
-	},
+/obj/effect/decal/cleanable/dirt/greenglow,
 /turf/open/gm/river,
 /area/bigredv2/outside/engineering)
 "eL" = (
@@ -1071,22 +1011,12 @@
 	},
 /area/bigredv2/outside/engineering)
 "eM" = (
-/obj/effect/decal/cleanable/dirt{
-	acid_damage = 1;
-	icon_state = "greenglow";
-	luminosity = 1;
-	name = "glowing goo"
-	},
+/obj/effect/decal/cleanable/dirt/greenglow,
 /obj/effect/decal/cleanable/molten_item,
 /turf/open/gm/river,
 /area/bigredv2/outside/engineering)
 "eN" = (
-/obj/effect/decal/cleanable/dirt{
-	acid_damage = 1;
-	icon_state = "greenglow";
-	luminosity = 1;
-	name = "glowing goo"
-	},
+/obj/effect/decal/cleanable/dirt/greenglow,
 /turf/open/mars_cave{
 	icon_state = "mars_cave_5"
 	},

--- a/maps/map_files/CORSAT/Corsat.dmm
+++ b/maps/map_files/CORSAT/Corsat.dmm
@@ -14993,7 +14993,7 @@
 	},
 /area/corsat/gamma/hangar/checkpoint)
 "aPJ" = (
-/obj/structure/flora/jungle/bioluminescent,
+/obj/structure/flora/jungle/alienplant1,
 /obj/structure/flora/jungle/vines,
 /turf/open/gm/dirtgrassborder{
 	dir = 4;
@@ -20801,7 +20801,7 @@
 /turf/open/gm/dirt,
 /area/corsat/theta/biodome)
 "bem" = (
-/obj/structure/flora/jungle/bioluminescent,
+/obj/structure/flora/jungle/alienplant1,
 /turf/open/gm/grass/weedable,
 /area/corsat/theta/biodome)
 "ben" = (
@@ -20826,7 +20826,7 @@
 	},
 /area/corsat/sigma/biodome/gunrange)
 "ber" = (
-/obj/structure/flora/jungle/bioluminescent,
+/obj/structure/flora/jungle/alienplant1,
 /turf/open/gm/dirt,
 /area/corsat/theta/biodome)
 "bes" = (
@@ -20880,7 +20880,7 @@
 /turf/open/gm/river,
 /area/corsat/theta/biodome)
 "beB" = (
-/obj/structure/flora/jungle/bioluminescent,
+/obj/structure/flora/jungle/alienplant1,
 /turf/open/gm/river,
 /area/corsat/theta/biodome)
 "beD" = (
@@ -42185,7 +42185,7 @@
 	},
 /area/corsat/gamma/airlock/control)
 "gFh" = (
-/obj/structure/flora/jungle/bioluminescent,
+/obj/structure/flora/jungle/alienplant1,
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
 	},
@@ -53162,7 +53162,7 @@
 	},
 /area/corsat/sigma/biodome/gunrange)
 "oLe" = (
-/obj/structure/flora/jungle/bioluminescent,
+/obj/structure/flora/jungle/alienplant1,
 /turf/open/gm/dirtgrassborder{
 	dir = 4
 	},
@@ -60718,7 +60718,7 @@
 	},
 /area/corsat/sigma/checkpoint)
 "usK" = (
-/obj/structure/flora/jungle/bioluminescent,
+/obj/structure/flora/jungle/alienplant1,
 /turf/open/gm/dirtgrassborder{
 	dir = 1
 	},

--- a/maps/map_files/CORSAT/Corsat.dmm
+++ b/maps/map_files/CORSAT/Corsat.dmm
@@ -14993,10 +14993,7 @@
 	},
 /area/corsat/gamma/hangar/checkpoint)
 "aPJ" = (
-/obj/structure/flora/jungle/plantbot1{
-	icon_state = "alienplant1";
-	luminosity = 2
-	},
+/obj/structure/flora/jungle/bioluminescent,
 /obj/structure/flora/jungle/vines,
 /turf/open/gm/dirtgrassborder{
 	dir = 4;
@@ -20804,10 +20801,7 @@
 /turf/open/gm/dirt,
 /area/corsat/theta/biodome)
 "bem" = (
-/obj/structure/flora/jungle/plantbot1{
-	icon_state = "alienplant1";
-	luminosity = 2
-	},
+/obj/structure/flora/jungle/bioluminescent,
 /turf/open/gm/grass/weedable,
 /area/corsat/theta/biodome)
 "ben" = (
@@ -20832,10 +20826,7 @@
 	},
 /area/corsat/sigma/biodome/gunrange)
 "ber" = (
-/obj/structure/flora/jungle/plantbot1{
-	icon_state = "alienplant1";
-	luminosity = 2
-	},
+/obj/structure/flora/jungle/bioluminescent,
 /turf/open/gm/dirt,
 /area/corsat/theta/biodome)
 "bes" = (
@@ -20889,10 +20880,7 @@
 /turf/open/gm/river,
 /area/corsat/theta/biodome)
 "beB" = (
-/obj/structure/flora/jungle/plantbot1{
-	icon_state = "alienplant1";
-	luminosity = 2
-	},
+/obj/structure/flora/jungle/bioluminescent,
 /turf/open/gm/river,
 /area/corsat/theta/biodome)
 "beD" = (
@@ -23718,10 +23706,6 @@
 	icon_state = "red"
 	},
 /area/corsat/gamma/hangar/arrivals)
-"bmQ" = (
-/obj/structure/lattice,
-/turf/open/space,
-/area/space)
 "bmS" = (
 /obj/structure/window/framed/corsat,
 /turf/open/floor/plating,
@@ -42201,10 +42185,7 @@
 	},
 /area/corsat/gamma/airlock/control)
 "gFh" = (
-/obj/structure/flora/jungle/plantbot1{
-	icon_state = "alienplant1";
-	luminosity = 2
-	},
+/obj/structure/flora/jungle/bioluminescent,
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
 	},
@@ -53181,10 +53162,7 @@
 	},
 /area/corsat/sigma/biodome/gunrange)
 "oLe" = (
-/obj/structure/flora/jungle/plantbot1{
-	icon_state = "alienplant1";
-	luminosity = 2
-	},
+/obj/structure/flora/jungle/bioluminescent,
 /turf/open/gm/dirtgrassborder{
 	dir = 4
 	},
@@ -59830,9 +59808,6 @@
 	icon_state = "whitetan"
 	},
 /area/corsat/gamma/residential/west)
-"tJe" = (
-/turf/open/ice,
-/area/corsat/gamma/biodome)
 "tJf" = (
 /obj/structure/flora/bush/ausbushes/var3/ywflowers,
 /turf/open/gm/dirtgrassborder{
@@ -60743,10 +60718,7 @@
 	},
 /area/corsat/sigma/checkpoint)
 "usK" = (
-/obj/structure/flora/jungle/plantbot1{
-	icon_state = "alienplant1";
-	luminosity = 2
-	},
+/obj/structure/flora/jungle/bioluminescent,
 /turf/open/gm/dirtgrassborder{
 	dir = 1
 	},
@@ -62018,12 +61990,6 @@
 	icon_state = "retrosquareslight"
 	},
 /area/corsat/gamma/biodome/virology)
-"vkS" = (
-/obj/effect/landmark/xeno_spawn,
-/turf/open/floor/corsat{
-	icon_state = "plate"
-	},
-/area/corsat/omega/biodome)
 "vkW" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
@@ -67475,7 +67441,7 @@ bfc
 bfc
 bfc
 sFF
-tJe
+bfc
 bfc
 sFF
 bfc
@@ -69280,7 +69246,7 @@ aFe
 hwe
 avX
 aFe
-vkS
+aFe
 aFe
 aFe
 avX

--- a/maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
+++ b/maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
@@ -124,11 +124,7 @@
 /turf/open/ice,
 /area/ice_colony/exterior/surface/clearing/north)
 "aaA" = (
-/obj/item/lightstick{
-	anchored = 1;
-	icon_state = "lightstick_blue1";
-	luminosity = 2
-	},
+/obj/item/lightstick/planted,
 /turf/open/auto_turf/snow/layer2,
 /area/ice_colony/exterior/surface/clearing/north)
 "aaB" = (
@@ -546,11 +542,7 @@
 /turf/open/floor/plating/icefloor,
 /area/ice_colony/surface/requesitions)
 "acl" = (
-/obj/item/lightstick{
-	anchored = 1;
-	icon_state = "lightstick_blue1";
-	luminosity = 2
-	},
+/obj/item/lightstick/planted,
 /turf/open/auto_turf/snow/layer3,
 /area/ice_colony/exterior/surface/valley/northwest)
 "acm" = (
@@ -753,11 +745,7 @@
 /turf/open/floor/plating/icefloor,
 /area/ice_colony/surface/requesitions)
 "acV" = (
-/obj/item/lightstick{
-	anchored = 1;
-	icon_state = "lightstick_blue1";
-	luminosity = 2
-	},
+/obj/item/lightstick/planted,
 /obj/structure/machinery/power/apc{
 	dir = 1;
 	pixel_y = 24;
@@ -790,11 +778,7 @@
 	},
 /area/ice_colony/surface/requesitions)
 "ada" = (
-/obj/item/lightstick{
-	anchored = 1;
-	icon_state = "lightstick_blue1";
-	luminosity = 2
-	},
+/obj/item/lightstick/planted,
 /obj/structure/machinery/computer/shuttle_control/ice_colony/elevator4{
 	pixel_y = 30
 	},
@@ -1325,11 +1309,7 @@
 	},
 /area/ice_colony/surface/engineering/generator)
 "aey" = (
-/obj/item/lightstick{
-	anchored = 1;
-	icon_state = "lightstick_blue1";
-	luminosity = 2
-	},
+/obj/item/lightstick/planted,
 /turf/open/auto_turf/snow/layer1,
 /area/ice_colony/exterior/surface/valley/northwest)
 "aez" = (
@@ -1375,11 +1355,7 @@
 /turf/open/floor/plating/icefloor,
 /area/ice_colony/surface/requesitions)
 "aeF" = (
-/obj/item/lightstick{
-	anchored = 1;
-	icon_state = "lightstick_blue1";
-	luminosity = 2
-	},
+/obj/item/lightstick/planted,
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
 	},
@@ -1814,11 +1790,7 @@
 /turf/open/floor/plating/icefloor,
 /area/ice_colony/surface/requesitions)
 "afN" = (
-/obj/item/lightstick{
-	anchored = 1;
-	icon_state = "lightstick_blue1";
-	luminosity = 2
-	},
+/obj/item/lightstick/planted,
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
 	},
@@ -1993,11 +1965,7 @@
 /turf/closed/wall,
 /area/ice_colony/surface/engineering)
 "agj" = (
-/obj/item/lightstick{
-	anchored = 1;
-	icon_state = "lightstick_blue1";
-	luminosity = 2
-	},
+/obj/item/lightstick/planted,
 /turf/open/auto_turf/snow/layer2,
 /area/ice_colony/exterior/surface/valley/northwest)
 "agk" = (
@@ -2116,11 +2084,7 @@
 /turf/open/floor/plating/icefloor,
 /area/ice_colony/surface/requesitions)
 "agA" = (
-/obj/item/lightstick{
-	anchored = 1;
-	icon_state = "lightstick_blue1";
-	luminosity = 2
-	},
+/obj/item/lightstick/planted,
 /turf/open/floor/plating/icefloor,
 /area/ice_colony/surface/requesitions)
 "agB" = (
@@ -2348,19 +2312,11 @@
 /turf/open/auto_turf/snow/layer1,
 /area/ice_colony/exterior/surface/clearing/north)
 "ahh" = (
-/obj/item/lightstick{
-	anchored = 1;
-	icon_state = "lightstick_blue1";
-	luminosity = 2
-	},
+/obj/item/lightstick/planted,
 /turf/open/auto_turf/snow/layer3,
 /area/ice_colony/exterior/surface/clearing/north)
 "ahi" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/auto_turf/snow/layer1,
 /area/ice_colony/exterior/surface/clearing/north)
 "ahj" = (
@@ -2382,11 +2338,7 @@
 	},
 /area/ice_colony/surface/engineering/generator)
 "ahn" = (
-/obj/item/lightstick{
-	anchored = 1;
-	icon_state = "lightstick_blue1";
-	luminosity = 2
-	},
+/obj/item/lightstick/planted,
 /turf/open/auto_turf/snow/layer1,
 /area/ice_colony/exterior/surface/clearing/north)
 "aho" = (
@@ -2521,11 +2473,7 @@
 /turf/open/floor/plating,
 /area/ice_colony/surface/hydroponics/north)
 "ahJ" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/auto_turf/snow/layer2,
 /area/ice_colony/exterior/surface/clearing/north)
 "ahK" = (
@@ -2858,11 +2806,7 @@
 	},
 /area/ice_colony/surface/substation/smes)
 "aiC" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/auto_turf/snow/layer0,
 /area/ice_colony/exterior/surface/clearing/north)
 "aiD" = (
@@ -3069,11 +3013,7 @@
 	},
 /area/ice_colony/surface/substation/smes)
 "ajf" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/auto_turf/snow/layer3,
 /area/ice_colony/exterior/surface/clearing/north)
 "ajg" = (
@@ -3084,11 +3024,7 @@
 /turf/open/auto_turf/snow/layer3,
 /area/ice_colony/exterior/surface/valley/northeast)
 "ajj" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/auto_turf/snow/layer3,
 /area/ice_colony/exterior/surface/valley/northeast)
 "ajl" = (
@@ -3319,11 +3255,7 @@
 	},
 /area/ice_colony/surface/engineering)
 "ajM" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/auto_turf/snow/layer1,
 /area/ice_colony/exterior/surface/clearing/north)
@@ -3617,11 +3549,7 @@
 /turf/open/auto_turf/snow/layer1,
 /area/ice_colony/exterior/surface/clearing/north)
 "akB" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -3991,11 +3919,7 @@
 /turf/open/ice,
 /area/ice_colony/surface/mining)
 "alI" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/auto_turf/snow/layer3,
 /area/ice_colony/exterior/surface/valley/southeast)
 "alJ" = (
@@ -4189,11 +4113,7 @@
 	},
 /area/ice_colony/surface/dorms/restroom_e)
 "aml" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/auto_turf/snow/layer2,
 /area/ice_colony/exterior/surface/valley/southeast)
 "amm" = (
@@ -4219,11 +4139,7 @@
 /turf/open/auto_turf/snow/layer3,
 /area/ice_colony/exterior/surface/valley/southeast)
 "amq" = (
-/obj/item/lightstick{
-	anchored = 1;
-	icon_state = "lightstick_blue1";
-	luminosity = 2
-	},
+/obj/item/lightstick/planted,
 /turf/open/auto_turf/snow/layer0,
 /area/ice_colony/exterior/surface/clearing/north)
 "amr" = (
@@ -5065,11 +4981,7 @@
 /turf/open/auto_turf/snow/layer0,
 /area/ice_colony/exterior/surface/clearing/pass)
 "aoK" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/auto_turf/snow/layer2,
 /area/ice_colony/exterior/surface/clearing/pass)
 "aoL" = (
@@ -6676,11 +6588,7 @@
 	},
 /area/ice_colony/surface/dorms)
 "asV" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/auto_turf/snow/layer0,
 /area/ice_colony/exterior/surface/clearing/pass)
 "asW" = (
@@ -7050,11 +6958,7 @@
 /turf/open/auto_turf/snow/layer2,
 /area/ice_colony/exterior/surface/clearing/south)
 "atW" = (
-/obj/item/lightstick{
-	anchored = 1;
-	icon_state = "lightstick_blue1";
-	luminosity = 2
-	},
+/obj/item/lightstick/planted,
 /turf/open/auto_turf/snow/layer2,
 /area/ice_colony/exterior/surface/clearing/south)
 "atX" = (
@@ -7237,11 +7141,7 @@
 /turf/open/floor/wood,
 /area/ice_colony/surface/dorms)
 "auu" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/auto_turf/snow/layer0,
 /area/ice_colony/exterior/surface/clearing/south)
 "auw" = (
@@ -7402,11 +7302,7 @@
 /turf/open/auto_turf/snow/layer1,
 /area/ice_colony/exterior/surface/clearing/south)
 "auQ" = (
-/obj/item/lightstick{
-	anchored = 1;
-	icon_state = "lightstick_blue1";
-	luminosity = 2
-	},
+/obj/item/lightstick/planted,
 /turf/open/auto_turf/snow/layer0,
 /area/ice_colony/exterior/surface/valley/southwest)
 "auR" = (
@@ -7665,11 +7561,7 @@
 /turf/open/auto_turf/snow/layer3,
 /area/ice_colony/exterior/surface/clearing/south)
 "avx" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/auto_turf/snow/layer1,
 /area/ice_colony/exterior/surface/valley/southwest)
 "avy" = (
@@ -7809,11 +7701,7 @@
 	},
 /area/ice_colony/surface/hydroponics/lobby)
 "avO" = (
-/obj/item/lightstick{
-	anchored = 1;
-	icon_state = "lightstick_blue1";
-	luminosity = 2
-	},
+/obj/item/lightstick/planted,
 /turf/open/auto_turf/snow/layer1,
 /area/ice_colony/exterior/surface/valley/southwest)
 "avP" = (
@@ -7943,11 +7831,7 @@
 /turf/open/auto_turf/snow/layer0,
 /area/ice_colony/exterior/surface/valley/southwest)
 "awd" = (
-/obj/item/lightstick{
-	anchored = 1;
-	icon_state = "lightstick_blue1";
-	luminosity = 2
-	},
+/obj/item/lightstick/planted,
 /turf/open/auto_turf/snow/layer1,
 /area/ice_colony/exterior/surface/clearing/south)
 "awe" = (
@@ -8156,11 +8040,7 @@
 	},
 /area/ice_colony/surface/hydroponics/lobby)
 "awJ" = (
-/obj/item/lightstick{
-	anchored = 1;
-	icon_state = "lightstick_blue1";
-	luminosity = 2
-	},
+/obj/item/lightstick/planted,
 /obj/structure/disposalpipe/segment,
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/auto_turf/snow/layer1,
@@ -8240,11 +8120,7 @@
 /turf/open/auto_turf/snow/layer3,
 /area/ice_colony/exterior/surface/clearing/south)
 "awY" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/auto_turf/snow/layer3,
 /area/ice_colony/exterior/surface/clearing/south)
 "awZ" = (
@@ -8608,11 +8484,7 @@
 /turf/open/auto_turf/snow/layer0,
 /area/ice_colony/exterior/surface/valley/southwest)
 "ayb" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/auto_turf/snow/layer0,
 /area/ice_colony/exterior/surface/valley/southwest)
 "ayc" = (
@@ -8620,11 +8492,7 @@
 /turf/open/auto_turf/snow/layer3,
 /area/ice_colony/exterior/surface/valley/southwest)
 "ayd" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /obj/structure/disposalpipe/segment,
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/auto_turf/snow/layer1,
@@ -8747,11 +8615,7 @@
 	},
 /area/ice_colony/surface/dorms/lavatory)
 "ayv" = (
-/obj/item/lightstick{
-	anchored = 1;
-	icon_state = "lightstick_blue1";
-	luminosity = 2
-	},
+/obj/item/lightstick/planted,
 /turf/open/auto_turf/snow/layer0,
 /area/ice_colony/exterior/surface/clearing/south)
 "ayw" = (
@@ -8772,11 +8636,7 @@
 	},
 /area/ice_colony/surface/dorms/canteen)
 "ayy" = (
-/obj/item/lightstick{
-	anchored = 1;
-	icon_state = "lightstick_blue1";
-	luminosity = 2
-	},
+/obj/item/lightstick/planted,
 /turf/open/auto_turf/snow/layer3,
 /area/ice_colony/exterior/surface/valley/southwest)
 "ayz" = (
@@ -8823,11 +8683,7 @@
 /turf/open/auto_turf/snow/layer0,
 /area/ice_colony/exterior/surface/clearing/south)
 "ayF" = (
-/obj/item/lightstick{
-	anchored = 1;
-	icon_state = "lightstick_blue1";
-	luminosity = 2
-	},
+/obj/item/lightstick/planted,
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
 	},
@@ -8837,11 +8693,7 @@
 /turf/open/auto_turf/snow/layer0,
 /area/ice_colony/exterior/surface/clearing/south)
 "ayG" = (
-/obj/item/lightstick{
-	anchored = 1;
-	icon_state = "lightstick_blue1";
-	luminosity = 2
-	},
+/obj/item/lightstick/planted,
 /turf/open/auto_turf/snow/layer2,
 /area/ice_colony/exterior/surface/valley/south)
 "ayH" = (
@@ -9077,11 +8929,7 @@
 /turf/open/auto_turf/snow/layer1,
 /area/ice_colony/exterior/surface/valley/south)
 "azp" = (
-/obj/item/lightstick{
-	anchored = 1;
-	icon_state = "lightstick_blue1";
-	luminosity = 2
-	},
+/obj/item/lightstick/planted,
 /turf/open/auto_turf/snow/layer1,
 /area/ice_colony/exterior/surface/valley/south)
 "azq" = (
@@ -9172,11 +9020,7 @@
 /turf/open/auto_turf/snow/layer2,
 /area/ice_colony/exterior/surface/valley/south)
 "azH" = (
-/obj/item/lightstick{
-	anchored = 1;
-	icon_state = "lightstick_blue1";
-	luminosity = 2
-	},
+/obj/item/lightstick/planted,
 /turf/open/auto_turf/snow/layer0,
 /area/ice_colony/exterior/surface/valley/south)
 "azI" = (
@@ -9535,11 +9379,7 @@
 /turf/open/auto_turf/snow/layer0,
 /area/ice_colony/exterior/surface/valley/south/excavation)
 "aAE" = (
-/obj/item/lightstick{
-	anchored = 1;
-	icon_state = "lightstick_blue1";
-	luminosity = 2
-	},
+/obj/item/lightstick/planted,
 /turf/open/auto_turf/snow/layer0,
 /area/ice_colony/exterior/surface/valley/south/excavation)
 "aAF" = (
@@ -9964,11 +9804,7 @@
 	},
 /area/ice_colony/surface/garage/repair)
 "aBM" = (
-/obj/item/lightstick{
-	anchored = 1;
-	icon_state = "lightstick_blue1";
-	luminosity = 2
-	},
+/obj/item/lightstick/planted,
 /turf/open/auto_turf/snow/layer1,
 /area/ice_colony/exterior/surface/valley/south/excavation)
 "aBN" = (
@@ -16403,11 +16239,7 @@
 	},
 /area/ice_colony/exterior/surface/cliff)
 "aVf" = (
-/obj/item/lightstick{
-	anchored = 1;
-	icon_state = "lightstick_blue1";
-	luminosity = 2
-	},
+/obj/item/lightstick/planted,
 /turf/open/ice,
 /area/ice_colony/exterior/surface/landing_pad_external)
 "aVg" = (
@@ -17794,11 +17626,7 @@
 /turf/open/floor/plating/icefloor,
 /area/ice_colony/exterior/surface/container_yard)
 "aZt" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/floor/plating/icefloor,
 /area/ice_colony/exterior/surface/container_yard)
 "aZu" = (

--- a/maps/map_files/Ice_Colony_v3/Shivas_Snowball.dmm
+++ b/maps/map_files/Ice_Colony_v3/Shivas_Snowball.dmm
@@ -18,11 +18,7 @@
 /turf/open/auto_turf/ice/layer1,
 /area/shiva/interior/colony/medseceng)
 "aaf" = (
-/obj/item/lightstick{
-	anchored = 1;
-	icon_state = "lightstick_blue1";
-	luminosity = 2
-	},
+/obj/item/lightstick/planted,
 /turf/open/auto_turf/snow/layer2,
 /area/shiva/exterior/cp_s_research)
 "aag" = (
@@ -633,11 +629,7 @@
 /turf/open/auto_turf/ice/layer1,
 /area/shiva/interior/colony/research_hab)
 "abZ" = (
-/obj/item/lightstick{
-	anchored = 1;
-	icon_state = "lightstick_blue1";
-	luminosity = 2
-	},
+/obj/item/lightstick/planted,
 /turf/open/auto_turf/snow/layer3,
 /area/shiva/exterior/cp_s_research)
 "aca" = (
@@ -1560,11 +1552,7 @@
 	},
 /area/shiva/interior/colony/central)
 "agy" = (
-/obj/item/lightstick{
-	anchored = 1;
-	icon_state = "lightstick_blue1";
-	luminosity = 2
-	},
+/obj/item/lightstick/planted,
 /turf/open/auto_turf/snow/layer1,
 /area/shiva/exterior/cp_s_research)
 "agz" = (
@@ -2033,11 +2021,7 @@
 	},
 /area/shiva/interior/colony/research_hab)
 "aiW" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/auto_turf/snow/layer1,
 /area/shiva/exterior/cp_lz2)
 "aiZ" = (
@@ -2182,11 +2166,7 @@
 /turf/open/floor/plating,
 /area/shiva/interior/colony/medseceng)
 "ajT" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/auto_turf/snow/layer2,
 /area/shiva/interior/colony/medseceng)
 "ajU" = (
@@ -2239,11 +2219,7 @@
 	},
 /area/shiva/interior/colony/medseceng)
 "akf" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/auto_turf/snow/layer0,
 /area/shiva/exterior/cp_s_research)
 "akh" = (
@@ -2707,11 +2683,7 @@
 	},
 /area/shiva/interior/colony/medseceng)
 "amQ" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/auto_turf/snow/layer3,
 /area/shiva/exterior/cp_colony_grounds)
 "amR" = (
@@ -3671,11 +3643,7 @@
 /turf/open/auto_turf/snow/layer3,
 /area/shiva/exterior/cp_lz2)
 "atv" = (
-/obj/item/lightstick{
-	anchored = 1;
-	icon_state = "lightstick_blue1";
-	luminosity = 2
-	},
+/obj/item/lightstick/planted,
 /turf/open/auto_turf/snow/layer0,
 /area/shiva/exterior/cp_lz2)
 "aty" = (
@@ -7347,11 +7315,7 @@
 	},
 /area/shiva/interior/colony/medseceng)
 "bnD" = (
-/obj/item/lightstick{
-	anchored = 1;
-	icon_state = "lightstick_blue1";
-	luminosity = 2
-	},
+/obj/item/lightstick/planted,
 /turf/open/auto_turf/snow/layer2,
 /area/shiva/exterior/junkyard)
 "bnS" = (
@@ -9839,11 +9803,7 @@
 /turf/open/floor/wood,
 /area/shiva/interior/bar)
 "ejX" = (
-/obj/item/lightstick{
-	anchored = 1;
-	icon_state = "lightstick_blue1";
-	luminosity = 2
-	},
+/obj/item/lightstick/planted,
 /turf/open/auto_turf/snow/layer0,
 /area/shiva/exterior/cp_colony_grounds)
 "ekH" = (
@@ -11273,11 +11233,7 @@
 	},
 /area/shiva/interior/bar)
 "fUZ" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/auto_turf/snow/layer2,
 /area/shiva/exterior/junkyard/cp_bar)
 "fVl" = (
@@ -12282,11 +12238,7 @@
 	},
 /area/shiva/interior/lz2_habs)
 "gYu" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/auto_turf/snow/layer0,
 /area/shiva/exterior/cp_colony_grounds)
 "gZG" = (
@@ -12396,11 +12348,7 @@
 	},
 /area/shiva/exterior/lz2_fortress)
 "hkC" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/auto_turf/snow/layer2,
 /area/shiva/exterior/cp_colony_grounds)
 "hkS" = (
@@ -12927,11 +12875,7 @@
 /turf/open/asphalt/cement,
 /area/shiva/interior/warehouse)
 "hIz" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/auto_turf/snow/layer1,
 /area/shiva/exterior/cp_colony_grounds)
 "hIC" = (
@@ -13801,11 +13745,7 @@
 	},
 /area/shiva/interior/colony/botany)
 "iCF" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/auto_turf/snow/layer4,
 /area/shiva/exterior/cp_colony_grounds)
 "iCJ" = (
@@ -14292,11 +14232,7 @@
 	},
 /area/shiva/interior/colony/medseceng)
 "jaF" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/auto_turf/snow/layer3,
 /area/shiva/exterior/valley)
 "jaU" = (
@@ -14615,11 +14551,7 @@
 /turf/open/auto_turf/snow/layer3,
 /area/shiva/exterior/cp_colony_grounds)
 "jxh" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/auto_turf/snow/layer1,
 /area/shiva/exterior/valley)
 "jxJ" = (
@@ -15381,11 +15313,7 @@
 	},
 /area/shiva/interior/colony/s_admin)
 "kri" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/auto_turf/snow/layer2,
 /area/shiva/exterior/valley)
 "krm" = (
@@ -25749,11 +25677,7 @@
 	},
 /area/shiva/interior/colony/research_hab)
 "vjy" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/auto_turf/snow/layer2,
 /area/shiva/exterior/cp_lz2)
 "vjH" = (

--- a/maps/map_files/LV624/LV624.dmm
+++ b/maps/map_files/LV624/LV624.dmm
@@ -246,7 +246,7 @@
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/central_caves)
 "abh" = (
-/obj/structure/flora/jungle/bioluminescent,
+/obj/structure/flora/jungle/alienplant1,
 /turf/open/gm/river,
 /area/lv624/ground/caves/north_central_caves)
 "abi" = (
@@ -2501,7 +2501,7 @@
 	},
 /area/lv624/ground/river/east_river)
 "alw" = (
-/obj/structure/flora/jungle/bioluminescent,
+/obj/structure/flora/jungle/alienplant1,
 /turf/open/gm/river,
 /area/lv624/ground/river/east_river)
 "alx" = (
@@ -2659,7 +2659,7 @@
 	},
 /area/lv624/ground/river/east_river)
 "amh" = (
-/obj/structure/flora/jungle/bioluminescent,
+/obj/structure/flora/jungle/alienplant1,
 /turf/open/gm/grass,
 /area/lv624/ground/barrens/south_eastern_jungle_barrens)
 "aml" = (
@@ -2727,7 +2727,7 @@
 	},
 /area/lv624/ground/jungle/north_east_jungle)
 "amG" = (
-/obj/structure/flora/jungle/bioluminescent,
+/obj/structure/flora/jungle/alienplant1,
 /turf/open/gm/river,
 /area/lv624/ground/river/west_river)
 "amK" = (
@@ -15141,7 +15141,7 @@
 	},
 /area/lv624/lazarus/landing_zones/lz1)
 "fDO" = (
-/obj/structure/flora/jungle/bioluminescent,
+/obj/structure/flora/jungle/alienplant1,
 /turf/open/gm/river,
 /area/lv624/ground/barrens/west_barrens)
 "fEn" = (
@@ -15282,7 +15282,7 @@
 /turf/open/gm/dirt,
 /area/lv624/ground/colony/south_nexus_road)
 "fXD" = (
-/obj/structure/flora/jungle/bioluminescent,
+/obj/structure/flora/jungle/alienplant1,
 /turf/open/gm/coast{
 	dir = 8
 	},
@@ -17796,7 +17796,7 @@
 	},
 /area/lv624/lazarus/landing_zones/lz1)
 "mbp" = (
-/obj/structure/flora/jungle/bioluminescent{
+/obj/structure/flora/jungle/alienplant1{
 	layer = 4.13;
 	pixel_y = 18
 	},
@@ -20133,7 +20133,7 @@
 	},
 /area/lv624/ground/jungle/north_east_jungle)
 "qMX" = (
-/obj/structure/flora/jungle/bioluminescent,
+/obj/structure/flora/jungle/alienplant1,
 /turf/open/gm/river,
 /area/lv624/ground/jungle/west_jungle)
 "qNQ" = (
@@ -20741,7 +20741,7 @@
 	},
 /area/lv624/lazarus/armory)
 "spm" = (
-/obj/structure/flora/jungle/bioluminescent,
+/obj/structure/flora/jungle/alienplant1,
 /turf/open/gm/river,
 /area/lv624/ground/barrens/east_barrens)
 "sqj" = (
@@ -20988,7 +20988,7 @@
 	},
 /area/lv624/ground/jungle/west_jungle)
 "sTX" = (
-/obj/structure/flora/jungle/bioluminescent,
+/obj/structure/flora/jungle/alienplant1,
 /turf/open/gm/river,
 /area/lv624/ground/river/central_river)
 "sUc" = (

--- a/maps/map_files/LV624/LV624.dmm
+++ b/maps/map_files/LV624/LV624.dmm
@@ -9483,11 +9483,7 @@
 	},
 /area/lv624/lazarus/yggdrasil)
 "aND" = (
-/obj/structure/flora/jungle/plantbot1{
-	desc = "Doesn't look like it'll do much cleaning any more.";
-	icon_state = "cart_wreck";
-	name = "old janicart"
-	},
+/obj/structure/flora/jungle/cart_wreck,
 /turf/open/gm/river,
 /area/lv624/lazarus/yggdrasil)
 "aNE" = (

--- a/maps/map_files/LV624/LV624.dmm
+++ b/maps/map_files/LV624/LV624.dmm
@@ -246,10 +246,7 @@
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/central_caves)
 "abh" = (
-/obj/structure/flora/jungle/plantbot1{
-	icon_state = "alienplant1";
-	luminosity = 2
-	},
+/obj/structure/flora/jungle/bioluminescent,
 /turf/open/gm/river,
 /area/lv624/ground/caves/north_central_caves)
 "abi" = (
@@ -2504,10 +2501,7 @@
 	},
 /area/lv624/ground/river/east_river)
 "alw" = (
-/obj/structure/flora/jungle/plantbot1{
-	icon_state = "alienplant1";
-	luminosity = 2
-	},
+/obj/structure/flora/jungle/bioluminescent,
 /turf/open/gm/river,
 /area/lv624/ground/river/east_river)
 "alx" = (
@@ -2665,10 +2659,7 @@
 	},
 /area/lv624/ground/river/east_river)
 "amh" = (
-/obj/structure/flora/jungle/plantbot1{
-	icon_state = "alienplant1";
-	luminosity = 2
-	},
+/obj/structure/flora/jungle/bioluminescent,
 /turf/open/gm/grass,
 /area/lv624/ground/barrens/south_eastern_jungle_barrens)
 "aml" = (
@@ -2736,10 +2727,7 @@
 	},
 /area/lv624/ground/jungle/north_east_jungle)
 "amG" = (
-/obj/structure/flora/jungle/plantbot1{
-	icon_state = "alienplant1";
-	luminosity = 2
-	},
+/obj/structure/flora/jungle/bioluminescent,
 /turf/open/gm/river,
 /area/lv624/ground/river/west_river)
 "amK" = (
@@ -15153,10 +15141,7 @@
 	},
 /area/lv624/lazarus/landing_zones/lz1)
 "fDO" = (
-/obj/structure/flora/jungle/plantbot1{
-	icon_state = "alienplant1";
-	luminosity = 2
-	},
+/obj/structure/flora/jungle/bioluminescent,
 /turf/open/gm/river,
 /area/lv624/ground/barrens/west_barrens)
 "fEn" = (
@@ -15297,10 +15282,7 @@
 /turf/open/gm/dirt,
 /area/lv624/ground/colony/south_nexus_road)
 "fXD" = (
-/obj/structure/flora/jungle/plantbot1{
-	icon_state = "alienplant1";
-	luminosity = 2
-	},
+/obj/structure/flora/jungle/bioluminescent,
 /turf/open/gm/coast{
 	dir = 8
 	},
@@ -17814,10 +17796,8 @@
 	},
 /area/lv624/lazarus/landing_zones/lz1)
 "mbp" = (
-/obj/structure/flora/jungle/plantbot1{
-	icon_state = "alienplant1";
+/obj/structure/flora/jungle/bioluminescent{
 	layer = 4.13;
-	luminosity = 2;
 	pixel_y = 18
 	},
 /turf/open/gm/dirtgrassborder,
@@ -20153,10 +20133,7 @@
 	},
 /area/lv624/ground/jungle/north_east_jungle)
 "qMX" = (
-/obj/structure/flora/jungle/plantbot1{
-	icon_state = "alienplant1";
-	luminosity = 2
-	},
+/obj/structure/flora/jungle/bioluminescent,
 /turf/open/gm/river,
 /area/lv624/ground/jungle/west_jungle)
 "qNQ" = (
@@ -20764,10 +20741,7 @@
 	},
 /area/lv624/lazarus/armory)
 "spm" = (
-/obj/structure/flora/jungle/plantbot1{
-	icon_state = "alienplant1";
-	luminosity = 2
-	},
+/obj/structure/flora/jungle/bioluminescent,
 /turf/open/gm/river,
 /area/lv624/ground/barrens/east_barrens)
 "sqj" = (
@@ -21014,10 +20988,7 @@
 	},
 /area/lv624/ground/jungle/west_jungle)
 "sTX" = (
-/obj/structure/flora/jungle/plantbot1{
-	icon_state = "alienplant1";
-	luminosity = 2
-	},
+/obj/structure/flora/jungle/bioluminescent,
 /turf/open/gm/river,
 /area/lv624/ground/river/central_river)
 "sUc" = (

--- a/maps/map_files/LV624/maintemple/2.flooded.dmm
+++ b/maps/map_files/LV624/maintemple/2.flooded.dmm
@@ -1184,7 +1184,7 @@
 /turf/open/gm/dirtgrassborder,
 /area/lv624/ground/caves/sand_temple)
 "Ds" = (
-/obj/structure/flora/jungle/bioluminescent{
+/obj/structure/flora/jungle/alienplant1{
 	layer = 4.13;
 	pixel_y = 18
 	},

--- a/maps/map_files/LV624/maintemple/2.flooded.dmm
+++ b/maps/map_files/LV624/maintemple/2.flooded.dmm
@@ -1184,10 +1184,8 @@
 /turf/open/gm/dirtgrassborder,
 /area/lv624/ground/caves/sand_temple)
 "Ds" = (
-/obj/structure/flora/jungle/plantbot1{
-	icon_state = "alienplant1";
+/obj/structure/flora/jungle/bioluminescent{
 	layer = 4.13;
-	luminosity = 2;
 	pixel_y = 18
 	},
 /turf/open/gm/dirtgrassborder,

--- a/maps/map_files/LV624/standalone/leftsidepass.dmm
+++ b/maps/map_files/LV624/standalone/leftsidepass.dmm
@@ -26,7 +26,7 @@
 /turf/open/gm/dirt,
 /area/lv624/ground/barrens/south_west_barrens)
 "ah" = (
-/obj/structure/flora/jungle/bioluminescent,
+/obj/structure/flora/jungle/alienplant1,
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/gm/river,
 /area/lv624/ground/river/west_river)
@@ -279,7 +279,7 @@
 	},
 /area/lv624/ground/jungle/west_jungle)
 "Ok" = (
-/obj/structure/flora/jungle/bioluminescent,
+/obj/structure/flora/jungle/alienplant1,
 /turf/open/gm/river,
 /area/lv624/ground/river/west_river)
 "Oz" = (

--- a/maps/map_files/LV624/standalone/leftsidepass.dmm
+++ b/maps/map_files/LV624/standalone/leftsidepass.dmm
@@ -26,10 +26,7 @@
 /turf/open/gm/dirt,
 /area/lv624/ground/barrens/south_west_barrens)
 "ah" = (
-/obj/structure/flora/jungle/plantbot1{
-	icon_state = "alienplant1";
-	luminosity = 2
-	},
+/obj/structure/flora/jungle/bioluminescent,
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/gm/river,
 /area/lv624/ground/river/west_river)
@@ -282,10 +279,7 @@
 	},
 /area/lv624/ground/jungle/west_jungle)
 "Ok" = (
-/obj/structure/flora/jungle/plantbot1{
-	icon_state = "alienplant1";
-	luminosity = 2
-	},
+/obj/structure/flora/jungle/bioluminescent,
 /turf/open/gm/river,
 /area/lv624/ground/river/west_river)
 "Oz" = (

--- a/maps/map_files/LV624/standalone/lv-bridge-east.dmm
+++ b/maps/map_files/LV624/standalone/lv-bridge-east.dmm
@@ -285,7 +285,7 @@
 /turf/open/gm/grass,
 /area/lv624/ground/jungle/north_jungle)
 "cp" = (
-/obj/structure/flora/jungle/bioluminescent,
+/obj/structure/flora/jungle/alienplant1,
 /turf/open/gm/coast,
 /area/lv624/ground/river/central_river)
 "gh" = (
@@ -330,7 +330,7 @@
 	},
 /area/lv624/ground/river/central_river)
 "wu" = (
-/obj/structure/flora/jungle/bioluminescent,
+/obj/structure/flora/jungle/alienplant1,
 /turf/open/gm/river,
 /area/lv624/ground/river/central_river)
 "Bv" = (

--- a/maps/map_files/LV624/standalone/lv-bridge-east.dmm
+++ b/maps/map_files/LV624/standalone/lv-bridge-east.dmm
@@ -285,10 +285,7 @@
 /turf/open/gm/grass,
 /area/lv624/ground/jungle/north_jungle)
 "cp" = (
-/obj/structure/flora/jungle/plantbot1{
-	icon_state = "alienplant1";
-	luminosity = 2
-	},
+/obj/structure/flora/jungle/bioluminescent,
 /turf/open/gm/coast,
 /area/lv624/ground/river/central_river)
 "gh" = (
@@ -333,10 +330,7 @@
 	},
 /area/lv624/ground/river/central_river)
 "wu" = (
-/obj/structure/flora/jungle/plantbot1{
-	icon_state = "alienplant1";
-	luminosity = 2
-	},
+/obj/structure/flora/jungle/bioluminescent,
 /turf/open/gm/river,
 /area/lv624/ground/river/central_river)
 "Bv" = (

--- a/maps/map_files/LV624/standalone/rightsidepass.dmm
+++ b/maps/map_files/LV624/standalone/rightsidepass.dmm
@@ -172,10 +172,7 @@
 /turf/open/gm/river,
 /area/lv624/ground/river/east_river)
 "Fj" = (
-/obj/structure/flora/jungle/plantbot1{
-	icon_state = "alienplant1";
-	luminosity = 2
-	},
+/obj/structure/flora/jungle/bioluminescent,
 /turf/open/gm/coast{
 	dir = 8
 	},

--- a/maps/map_files/LV624/standalone/rightsidepass.dmm
+++ b/maps/map_files/LV624/standalone/rightsidepass.dmm
@@ -172,7 +172,7 @@
 /turf/open/gm/river,
 /area/lv624/ground/river/east_river)
 "Fj" = (
-/obj/structure/flora/jungle/bioluminescent,
+/obj/structure/flora/jungle/alienplant1,
 /turf/open/gm/coast{
 	dir = 8
 	},

--- a/maps/map_files/Sorokyne_Strata/Sorokyne_Strata.dmm
+++ b/maps/map_files/Sorokyne_Strata/Sorokyne_Strata.dmm
@@ -1293,11 +1293,7 @@
 	},
 /area/strata/ug/interior/jungle/deep/minehead)
 "adN" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/auto_turf/snow/brown_base/layer1,
 /area/strata/ug/interior/jungle/deep/minehead)
 "adO" = (
@@ -1748,11 +1744,7 @@
 	},
 /area/strata/ug/interior/jungle/deep/structures/res)
 "aff" = (
-/obj/item/lightstick{
-	anchored = 1;
-	icon_state = "lightstick_blue1";
-	luminosity = 2
-	},
+/obj/item/lightstick/planted,
 /turf/closed/wall/strata_ice/dirty,
 /area/strata/ag/exterior)
 "afg" = (
@@ -4232,30 +4224,18 @@
 /turf/open/auto_turf/snow/brown_base/layer0,
 /area/strata/ag/interior/restricted/devroom)
 "aml" = (
-/obj/item/lightstick{
-	anchored = 1;
-	icon_state = "lightstick_blue1";
-	luminosity = 2
-	},
+/obj/item/lightstick/planted,
 /obj/structure/platform/strata/metal{
 	dir = 4
 	},
 /turf/open/auto_turf/snow/brown_base/layer4,
 /area/strata/ag/interior/restricted/devroom)
 "amm" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/auto_turf/snow/brown_base/layer1,
 /area/strata/ag/exterior/paths/cabin_area)
 "amn" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/auto_turf/snow/brown_base/layer0,
 /area/strata/ag/exterior/paths/cabin_area)
 "amo" = (
@@ -4888,11 +4868,7 @@
 	},
 /area/strata/ag/interior/research_decks/security)
 "aoA" = (
-/obj/item/lightstick{
-	anchored = 1;
-	icon_state = "lightstick_blue1";
-	luminosity = 2
-	},
+/obj/item/lightstick/planted,
 /turf/open/auto_turf/snow/brown_base/layer0,
 /area/strata/ag/interior/restricted/devroom)
 "aoB" = (
@@ -5073,11 +5049,7 @@
 /area/strata/ug/interior/jungle/deep/structures/res)
 "ape" = (
 /obj/effect/decal/cleanable/blood,
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/auto_turf/snow/brown_base/layer1,
 /area/strata/ag/exterior/paths/cabin_area)
 "apf" = (
@@ -5490,11 +5462,7 @@
 /turf/closed/wall/strata_outpost/reinforced,
 /area/strata/ag/interior/research_decks/security)
 "aqq" = (
-/obj/item/lightstick{
-	anchored = 1;
-	icon_state = "lightstick_blue1";
-	luminosity = 2
-	},
+/obj/item/lightstick/planted,
 /turf/open/auto_turf/snow/brown_base/layer1,
 /area/strata/ag/interior/restricted/devroom)
 "aqr" = (
@@ -5637,11 +5605,7 @@
 	},
 /area/strata/ag/interior/outpost/canteen/personal_storage)
 "aqN" = (
-/obj/item/lightstick{
-	anchored = 1;
-	icon_state = "lightstick_blue1";
-	luminosity = 2
-	},
+/obj/item/lightstick/planted,
 /obj/structure/largecrate/random,
 /turf/open/auto_turf/snow/brown_base/layer1,
 /area/strata/ag/interior/restricted/devroom)
@@ -7469,11 +7433,7 @@
 	},
 /area/strata/ag/interior/outpost/security)
 "awb" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/auto_turf/snow/brown_base/layer3,
 /area/strata/ag/exterior/paths/cabin_area)
 "awc" = (
@@ -7653,11 +7613,7 @@
 /turf/open/gm/dirt,
 /area/strata/ug/interior/jungle/deep/south_res)
 "awA" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/auto_turf/snow/brown_base/layer1,
 /area/strata/ag/exterior/paths/north_outpost)
 "awB" = (
@@ -8298,11 +8254,7 @@
 /turf/open/auto_turf/snow/brown_base/layer3,
 /area/strata/ag/exterior/paths/cabin_area)
 "ayv" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/auto_turf/snow/brown_base/layer0,
 /area/strata/ag/exterior/paths/north_outpost)
 "ayw" = (
@@ -11228,11 +11180,7 @@
 /turf/open/floor/strata,
 /area/strata/ag/interior/outpost/engi)
 "aHy" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /obj/structure/platform/strata/metal{
 	dir = 1
 	},
@@ -11254,11 +11202,7 @@
 /turf/open/auto_turf/snow/brown_base/layer3,
 /area/strata/ag/exterior/paths/adminext)
 "aHC" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /obj/structure/platform/strata/metal{
 	dir = 1
 	},
@@ -11922,11 +11866,7 @@
 /turf/open/asphalt/cement,
 /area/strata/ag/exterior/paths/adminext)
 "aKf" = (
-/obj/item/lightstick{
-	anchored = 1;
-	icon_state = "lightstick_blue1";
-	luminosity = 2
-	},
+/obj/item/lightstick/planted,
 /obj/structure/platform_decoration/strata/metal{
 	dir = 8
 	},
@@ -12194,11 +12134,7 @@
 	},
 /area/strata/ag/interior/outpost/canteen/bar)
 "aKV" = (
-/obj/item/lightstick{
-	anchored = 1;
-	icon_state = "lightstick_blue1";
-	luminosity = 2
-	},
+/obj/item/lightstick/planted,
 /turf/open/auto_turf/snow/brown_base/layer1,
 /area/strata/ag/exterior/paths/adminext)
 "aKW" = (
@@ -12415,11 +12351,7 @@
 	},
 /area/strata/ag/interior/outpost/engi)
 "aLL" = (
-/obj/item/lightstick{
-	anchored = 1;
-	icon_state = "lightstick_blue1";
-	luminosity = 2
-	},
+/obj/item/lightstick/planted,
 /turf/open/auto_turf/snow/brown_base/layer2,
 /area/strata/ag/exterior/paths/adminext)
 "aLM" = (
@@ -12731,11 +12663,7 @@
 /turf/closed/wall/strata_outpost/reinforced,
 /area/strata/ag/interior/dorms)
 "aMG" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /obj/structure/platform/strata/metal{
 	dir = 1
 	},
@@ -12831,11 +12759,7 @@
 /turf/open/auto_turf/snow/brown_base/layer2,
 /area/strata/ag/exterior/paths/dorms_quad)
 "aMU" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /obj/structure/platform/strata/metal{
 	dir = 1
 	},
@@ -12927,11 +12851,7 @@
 /turf/closed/wall/strata_outpost,
 /area/strata/ag/interior/outpost/admin)
 "aNj" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/auto_turf/snow/brown_base/layer2,
 /area/strata/ag/exterior/paths/dorms_quad)
 "aNl" = (
@@ -13177,11 +13097,7 @@
 	},
 /area/strata/ag/exterior/research_decks)
 "aNU" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /obj/structure/platform/strata/metal,
 /turf/open/auto_turf/snow/brown_base/layer2,
 /area/strata/ag/exterior/paths/dorms_quad)
@@ -13420,11 +13336,7 @@
 	},
 /area/strata/ag/interior/outpost/canteen/lower_cafeteria)
 "aOz" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /obj/structure/platform/strata/metal,
 /turf/open/auto_turf/snow/brown_base/layer0,
 /area/strata/ag/exterior/paths/dorms_quad)
@@ -13444,11 +13356,7 @@
 /turf/open/auto_turf/ice/layer1,
 /area/strata/ag/interior/outpost/gen/bball/nest)
 "aOE" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /obj/structure/platform/strata/metal,
 /turf/open/auto_turf/snow/brown_base/layer1,
 /area/strata/ag/exterior/paths/dorms_quad)
@@ -13556,11 +13464,7 @@
 /turf/open/auto_turf/snow/brown_base/layer2,
 /area/strata/ag/exterior/paths/dorms_quad)
 "aOZ" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /obj/structure/platform/strata/metal{
 	dir = 4
 	},
@@ -13666,11 +13570,7 @@
 /turf/open/auto_turf/snow/brown_base/layer0,
 /area/strata/ag/exterior/paths/dorms_quad)
 "aPs" = (
-/obj/item/lightstick{
-	anchored = 1;
-	icon_state = "lightstick_blue1";
-	luminosity = 2
-	},
+/obj/item/lightstick/planted,
 /obj/structure/barricade/snow{
 	dir = 4
 	},
@@ -13879,11 +13779,7 @@
 "aPT" = (
 /obj/effect/decal/cleanable/generic,
 /obj/structure/platform_decoration/strata/metal,
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/auto_turf/snow/brown_base/layer2,
 /area/strata/ag/exterior/paths/dorms_quad)
 "aPW" = (
@@ -14734,11 +14630,7 @@
 	},
 /area/strata/ag/interior/landingzone_1)
 "aSJ" = (
-/obj/item/lightstick{
-	anchored = 1;
-	icon_state = "lightstick_blue1";
-	luminosity = 2
-	},
+/obj/item/lightstick/planted,
 /obj/structure/pipes/standard/simple/hidden/cyan,
 /turf/open/auto_turf/snow/brown_base/layer1,
 /area/strata/ag/exterior/paths/adminext)
@@ -14858,11 +14750,7 @@
 /turf/open/auto_turf/snow/brown_base/layer1,
 /area/strata/ag/exterior/paths/adminext)
 "aTh" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /obj/structure/pipes/standard/simple/hidden/cyan,
 /obj/structure/flora/grass/ice/brown,
 /turf/open/auto_turf/snow/brown_base/layer2,
@@ -15668,11 +15556,7 @@
 /turf/open/auto_turf/snow/brown_base/layer1,
 /area/strata/ag/interior/administration)
 "aWa" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /obj/structure/platform/strata/metal{
 	dir = 8
 	},
@@ -15695,19 +15579,11 @@
 /turf/open/auto_turf/snow/brown_base/layer3,
 /area/strata/ag/exterior/paths/adminext)
 "aWf" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/auto_turf/snow/brown_base/layer1,
 /area/strata/ag/exterior/marsh/river)
 "aWg" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/auto_turf/snow/brown_base/layer4,
 /area/strata/ag/exterior/marsh/river)
 "aWi" = (
@@ -16185,11 +16061,7 @@
 /turf/open/auto_turf/snow/brown_base/layer2,
 /area/strata/ag/exterior/north_lz_caves)
 "aYe" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/auto_turf/snow/brown_base/layer2,
 /area/strata/ag/exterior/north_lz_caves)
 "aYh" = (
@@ -16394,19 +16266,11 @@
 /turf/open/auto_turf/snow/brown_base/layer2,
 /area/strata/ag/exterior/north_lz_caves)
 "aYY" = (
-/obj/item/lightstick{
-	anchored = 1;
-	icon_state = "lightstick_blue1";
-	luminosity = 2
-	},
+/obj/item/lightstick/planted,
 /turf/open/auto_turf/snow/brown_base/layer1,
 /area/strata/ag/exterior/north_lz_caves)
 "aYZ" = (
-/obj/item/lightstick{
-	anchored = 1;
-	icon_state = "lightstick_blue1";
-	luminosity = 2
-	},
+/obj/item/lightstick/planted,
 /turf/open/auto_turf/snow/brown_base/layer2,
 /area/strata/ag/exterior/north_lz_caves)
 "aZb" = (
@@ -16449,11 +16313,7 @@
 /turf/open/auto_turf/snow/brown_base/layer0,
 /area/strata/ag/exterior/paths/adminext)
 "aZj" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /obj/structure/barricade/snow{
 	dir = 1
 	},
@@ -16883,11 +16743,7 @@
 	},
 /area/strata/ag/interior/outpost/gen/foyer)
 "bav" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/auto_turf/snow/brown_base/layer1,
 /area/strata/ag/exterior/paths/adminext)
 "baw" = (
@@ -17343,11 +17199,7 @@
 /turf/open/floor/strata,
 /area/strata/ag/interior/nearlz1)
 "bcg" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /obj/structure/barricade/snow{
 	dir = 1
 	},
@@ -17372,11 +17224,7 @@
 	},
 /area/strata/ag/interior/nearlz1)
 "bcm" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/auto_turf/snow/brown_base/layer2,
 /area/strata/ag/exterior/paths/adminext)
 "bco" = (
@@ -17726,11 +17574,7 @@
 /area/strata/ag/exterior/paths/adminext)
 "bdB" = (
 /obj/structure/platform/strata,
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/auto_turf/snow/brown_base/layer2,
 /area/strata/ag/exterior/marsh/river)
 "bdC" = (
@@ -17801,11 +17645,7 @@
 /turf/open/auto_turf/snow/brown_base/layer1,
 /area/strata/ag/exterior/paths/adminext)
 "bdQ" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/auto_turf/snow/brown_base/layer4,
 /area/strata/ag/exterior/paths/adminext)
 "bdS" = (
@@ -18101,11 +17941,7 @@
 /turf/open/auto_turf/snow/brown_base/layer2,
 /area/strata/ag/exterior/marsh)
 "beQ" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/auto_turf/snow/brown_base/layer1,
 /area/strata/ag/exterior/marsh)
 "beS" = (
@@ -18713,11 +18549,7 @@
 /turf/open/auto_turf/snow/brown_base/layer1,
 /area/strata/ag/exterior/marsh/crash)
 "bgT" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/auto_turf/snow/brown_base/layer3,
 /area/strata/ag/exterior/marsh)
 "bgV" = (
@@ -18751,11 +18583,7 @@
 /turf/open/auto_turf/snow/brown_base/layer1,
 /area/strata/ag/exterior/marsh)
 "bhb" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/auto_turf/snow/brown_base/layer2,
 /area/strata/ag/exterior/marsh)
 "bhd" = (
@@ -19048,11 +18876,7 @@
 	},
 /area/strata/ag/interior/outpost/gen/foyer)
 "bia" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/auto_turf/snow/brown_base/layer2,
 /area/strata/ag/exterior/marsh/crash)
 "bib" = (
@@ -19062,11 +18886,7 @@
 	},
 /area/strata/ag/interior/outpost/gen/foyer)
 "bic" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/auto_turf/snow/brown_base/layer1,
 /area/strata/ag/exterior/marsh/crash)
 "bif" = (
@@ -19246,11 +19066,7 @@
 /turf/open/auto_turf/snow/brown_base/layer0,
 /area/strata/ag/exterior/marsh)
 "biQ" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /obj/structure/platform/strata{
 	dir = 1
 	},
@@ -19515,11 +19331,7 @@
 /turf/open/auto_turf/snow/brown_base/layer3,
 /area/strata/ag/exterior/marsh)
 "bjL" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/auto_turf/snow/brown_base/layer0,
 /area/strata/ag/exterior/marsh)
 "bjM" = (
@@ -19641,11 +19453,7 @@
 /turf/open/gm/river,
 /area/strata/ag/exterior/marsh/water)
 "bkp" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /obj/structure/platform/strata,
 /turf/open/auto_turf/snow/brown_base/layer1,
 /area/strata/ag/exterior/vanyard)
@@ -19847,11 +19655,7 @@
 	},
 /area/strata/ag/interior/outpost/canteen/personal_storage)
 "bla" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/auto_turf/snow/brown_base/layer3,
 /area/strata/ag/exterior/marsh/crash)
 "blb" = (
@@ -20400,11 +20204,7 @@
 /turf/open/auto_turf/snow/brown_base/layer2,
 /area/strata/ag/exterior/paths/southresearch)
 "bnu" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/auto_turf/snow/brown_base/layer2,
 /area/strata/ag/exterior/paths/southresearch)
 "bnv" = (
@@ -20432,11 +20232,7 @@
 /area/strata/ag/interior/administration)
 "bnA" = (
 /obj/item/reagent_container/food/drinks/cans/souto/classic,
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/auto_turf/snow/brown_base/layer0,
 /area/strata/ag/exterior/paths/southresearch)
 "bnB" = (
@@ -20460,11 +20256,7 @@
 /area/strata/ag/interior/outpost/canteen)
 "bnF" = (
 /obj/structure/bed/roller,
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/auto_turf/snow/brown_base/layer1,
 /area/strata/ag/exterior/paths/southresearch)
 "bnG" = (
@@ -20572,11 +20364,7 @@
 /turf/open/auto_turf/snow/brown_base/layer0,
 /area/strata/ag/exterior/paths/southresearch)
 "bnX" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/auto_turf/snow/brown_base/layer0,
 /area/strata/ag/exterior/paths/southresearch)
 "bnY" = (
@@ -20696,11 +20484,7 @@
 /area/strata/ug/interior/jungle/deep/structures/res)
 "boq" = (
 /obj/item/stack/medical/splint,
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/auto_turf/snow/brown_base/layer0,
 /area/strata/ag/exterior/paths/southresearch)
 "bos" = (
@@ -21222,11 +21006,7 @@
 	},
 /area/strata/ag/interior/administration)
 "bpT" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/auto_turf/snow/brown_base/layer1,
 /area/strata/ag/exterior/paths/southresearch)
 "bpU" = (
@@ -21520,11 +21300,7 @@
 /obj/structure/platform_decoration/strata{
 	dir = 1
 	},
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/auto_turf/snow/brown_base/layer4,
 /area/strata/ag/exterior/paths/southresearch)
 "brn" = (
@@ -21931,11 +21707,7 @@
 /area/strata/ag/interior/outpost/admin)
 "bsM" = (
 /obj/structure/platform/strata/metal,
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/auto_turf/snow/brown_base/layer0,
 /area/strata/ag/exterior/paths/southresearch)
 "bsN" = (
@@ -22112,11 +21884,7 @@
 /turf/open/auto_turf/snow/brown_base/layer4,
 /area/strata/ag/exterior/marsh/center)
 "btu" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/auto_turf/snow/brown_base/layer1,
 /area/strata/ag/exterior/tcomms/tcomms_deck)
 "btv" = (
@@ -22310,11 +22078,7 @@
 /turf/open/auto_turf/snow/brown_base/layer1,
 /area/strata/ag/exterior/marsh/crash)
 "buf" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/auto_turf/snow/brown_base/layer4,
 /area/strata/ag/exterior/marsh/center)
 "bug" = (
@@ -22432,11 +22196,7 @@
 /turf/open/auto_turf/snow/brown_base/layer0,
 /area/strata/ag/exterior/marsh)
 "buF" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/auto_turf/snow/brown_base/layer2,
 /area/strata/ag/exterior/tcomms/tcomms_deck)
 "buG" = (
@@ -22722,11 +22482,7 @@
 	},
 /area/strata/ag/interior/outpost/engi/drome)
 "bvM" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/auto_turf/snow/brown_base/layer0,
 /area/strata/ag/exterior/nearlz2)
 "bvN" = (
@@ -23061,11 +22817,7 @@
 /turf/open/auto_turf/snow/brown_base/layer0,
 /area/strata/ag/exterior/marsh)
 "bxd" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /obj/effect/decal/cleanable/blood,
 /turf/open/auto_turf/snow/brown_base/layer0,
 /area/strata/ag/exterior/marsh)
@@ -23116,11 +22868,7 @@
 	},
 /area/strata/ug/interior/jungle/deep/minehead)
 "bxo" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/auto_turf/snow/brown_base/layer1,
 /area/strata/ag/exterior/nearlz2)
 "bxr" = (
@@ -23406,11 +23154,7 @@
 /obj/structure/barricade/snow{
 	dir = 4
 	},
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/auto_turf/snow/brown_base/layer1,
 /area/strata/ag/interior/restricted)
 "byn" = (
@@ -23426,11 +23170,7 @@
 /turf/open/auto_turf/snow/brown_base/layer1,
 /area/strata/ag/exterior/nearlz2)
 "byr" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/auto_turf/snow/brown_base/layer2,
 /area/strata/ag/exterior/nearlz2)
 "bys" = (
@@ -30107,11 +29847,7 @@
 	},
 /area/strata/ug/interior/jungle/deep/structures/engi)
 "cDL" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/auto_turf/ice/layer1,
 /area/strata/ag/exterior/marsh)
 "cEu" = (
@@ -30175,11 +29911,7 @@
 	},
 /area/strata/ag/interior/tcomms)
 "cJf" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/auto_turf/ice/layer1,
 /area/strata/ag/exterior/marsh/center)
 "cKc" = (
@@ -33217,11 +32949,7 @@
 /turf/open/floor/strata,
 /area/strata/ag/interior/outpost/maint/canteen_e_1)
 "ibh" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/auto_turf/ice/layer2,
 /area/strata/ag/exterior/nearlz2)
 "ibE" = (

--- a/maps/map_files/Whiskey_Outpost_v2/Whiskey_Outpost_v2.dmm
+++ b/maps/map_files/Whiskey_Outpost_v2/Whiskey_Outpost_v2.dmm
@@ -1628,10 +1628,7 @@
 /turf/open/gm/dirt,
 /area/whiskey_outpost/outside/north/beach)
 "fJ" = (
-/obj/structure/flora/jungle/plantbot1{
-	icon_state = "alienplant1";
-	luminosity = 2
-	},
+/obj/structure/flora/jungle/bioluminescent,
 /turf/open/gm/river,
 /area/whiskey_outpost/outside/lane/one_south)
 "fL" = (
@@ -2544,10 +2541,7 @@
 /turf/open/floor/plating,
 /area/whiskey_outpost/inside/hospital)
 "iD" = (
-/obj/structure/flora/jungle/plantbot1{
-	icon_state = "alienplant1";
-	luminosity = 2
-	},
+/obj/structure/flora/jungle/bioluminescent,
 /turf/open/gm/river,
 /area/whiskey_outpost/outside/lane/four_south)
 "iF" = (
@@ -6376,10 +6370,7 @@
 	},
 /area/whiskey_outpost/inside/bunker)
 "wb" = (
-/obj/structure/flora/jungle/plantbot1{
-	icon_state = "alienplant1";
-	luminosity = 2
-	},
+/obj/structure/flora/jungle/bioluminescent,
 /turf/open/gm/coast{
 	icon_state = "beachcorner2"
 	},
@@ -9085,10 +9076,7 @@
 /turf/open/gm/coast,
 /area/whiskey_outpost/outside/lane/four_north)
 "FH" = (
-/obj/structure/flora/jungle/plantbot1{
-	icon_state = "alienplant1";
-	luminosity = 2
-	},
+/obj/structure/flora/jungle/bioluminescent,
 /turf/open/gm/river,
 /area/whiskey_outpost/outside/river/west)
 "FI" = (
@@ -9245,12 +9233,6 @@
 	icon_state = "grassbeach"
 	},
 /area/whiskey_outpost/outside/south)
-"Gj" = (
-/turf/open/jungle{
-	bushes_spawn = 0;
-	icon_state = "grass_impenetrable"
-	},
-/area/whiskey_outpost/outside/lane/two_north)
 "Gl" = (
 /turf/open/gm/dirtgrassborder{
 	dir = 1;
@@ -10830,10 +10812,7 @@
 /turf/open/gm/dirt,
 /area/whiskey_outpost/outside/north/beach)
 "MR" = (
-/obj/structure/flora/jungle/plantbot1{
-	icon_state = "alienplant1";
-	luminosity = 2
-	},
+/obj/structure/flora/jungle/bioluminescent,
 /turf/open/gm/river,
 /area/whiskey_outpost/outside/lane/two_north)
 "MU" = (
@@ -10968,10 +10947,7 @@
 /turf/open/jungle/impenetrable,
 /area/whiskey_outpost/outside/south/very_far)
 "Nv" = (
-/obj/structure/flora/jungle/plantbot1{
-	icon_state = "alienplant1";
-	luminosity = 2
-	},
+/obj/structure/flora/jungle/bioluminescent,
 /turf/open/gm/grass{
 	icon_state = "grassbeach"
 	},
@@ -11120,10 +11096,7 @@
 	},
 /area/whiskey_outpost/inside/bunker/bunker/front)
 "Ob" = (
-/obj/structure/flora/jungle/plantbot1{
-	icon_state = "alienplant1";
-	luminosity = 2
-	},
+/obj/structure/flora/jungle/bioluminescent,
 /turf/open/gm/river,
 /area/whiskey_outpost/outside/lane/one_north)
 "Oc" = (
@@ -11244,10 +11217,7 @@
 	},
 /area/whiskey_outpost/outside/river/east)
 "OA" = (
-/obj/structure/flora/jungle/plantbot1{
-	icon_state = "alienplant1";
-	luminosity = 2
-	},
+/obj/structure/flora/jungle/bioluminescent,
 /turf/open/gm/river,
 /area/whiskey_outpost/outside/lane/four_north)
 "OD" = (
@@ -11428,10 +11398,7 @@
 /turf/open/gm/dirt,
 /area/whiskey_outpost/outside/north/northwest)
 "Pr" = (
-/obj/structure/flora/jungle/plantbot1{
-	icon_state = "alienplant1";
-	luminosity = 2
-	},
+/obj/structure/flora/jungle/bioluminescent,
 /turf/open/gm/river,
 /area/whiskey_outpost/outside/river)
 "Ps" = (
@@ -11581,10 +11548,7 @@
 /turf/open/gm/dirt,
 /area/whiskey_outpost/outside/lane/four_north)
 "Qa" = (
-/obj/structure/flora/jungle/plantbot1{
-	icon_state = "alienplant1";
-	luminosity = 2
-	},
+/obj/structure/flora/jungle/bioluminescent,
 /turf/open/gm/river,
 /area/whiskey_outpost/outside/river/east)
 "Qc" = (
@@ -22254,7 +22218,7 @@ Zf
 Zf
 Zf
 mT
-Gj
+CE
 GJ
 GJ
 mT
@@ -22457,8 +22421,8 @@ Zf
 Zf
 mT
 GJ
-Gj
-Gj
+CE
+CE
 mT
 Zf
 Zf
@@ -22661,7 +22625,7 @@ mT
 GJ
 GJ
 GJ
-Gj
+CE
 Zf
 Zf
 mT
@@ -22860,7 +22824,7 @@ Zf
 mT
 mT
 mT
-Gj
+CE
 GJ
 GJ
 GJ
@@ -23061,10 +23025,10 @@ Zf
 Zf
 mT
 mT
-Gj
-Gj
+CE
+CE
 GJ
-Gj
+CE
 GJ
 Oq
 Oq
@@ -23265,9 +23229,9 @@ mT
 mT
 GJ
 GJ
-Gj
-Gj
-Gj
+CE
+CE
+CE
 Oq
 Qw
 Qw
@@ -23459,20 +23423,20 @@ mT
 Db
 OD
 gu
-Gj
+CE
 mT
 mT
 mT
-Gj
-Gj
+CE
+CE
 cY
 GJ
-Gj
-Gj
+CE
+CE
 GJ
 GJ
-Gj
-Gj
+CE
+CE
 GJ
 GJ
 GJ
@@ -23667,15 +23631,15 @@ GJ
 GJ
 GJ
 GJ
-Gj
+CE
 GJ
 GJ
 GJ
-Gj
+CE
 GJ
 GJ
 GJ
-Gj
+CE
 GJ
 GJ
 QB
@@ -23866,19 +23830,19 @@ gu
 GJ
 GJ
 GJ
-Gj
+CE
 GJ
 GJ
-Gj
-Gj
+CE
+CE
 GJ
 GJ
-Gj
-Gj
+CE
+CE
 GJ
 GJ
-Gj
-Gj
+CE
+CE
 GJ
 QB
 CG
@@ -24065,22 +24029,22 @@ QO
 Db
 OD
 gu
-Gj
-Gj
-Gj
-Gj
+CE
+CE
+CE
+CE
 GJ
-Gj
-Gj
-Gj
+CE
+CE
+CE
 GJ
-Gj
-Gj
-Gj
+CE
+CE
+CE
 GJ
-Gj
-Gj
-Gj
+CE
+CE
+CE
 GJ
 QB
 CG
@@ -24267,23 +24231,23 @@ QO
 Db
 OD
 gu
-Gj
-Gj
-Gj
+CE
+CE
+CE
 GJ
-Gj
-Gj
+CE
+CE
 GJ
 GJ
-Gj
-Gj
+CE
+CE
 AE
 In
-Gj
-Gj
+CE
+CE
 GJ
 GJ
-Gj
+CE
 QB
 VH
 CN
@@ -24469,23 +24433,23 @@ Pu
 Db
 OD
 gu
-Gj
-Gj
-Gj
-Gj
-Gj
-Gj
-Gj
-Gj
-Gj
-Gj
-Gj
-Gj
-Gj
-Gj
-Gj
-Gj
-Gj
+CE
+CE
+CE
+CE
+CE
+CE
+CE
+CE
+CE
+CE
+CE
+CE
+CE
+CE
+CE
+CE
+CE
 QB
 CG
 CN
@@ -25684,20 +25648,20 @@ Db
 eG
 QL
 rw
-Gj
-Gj
-Gj
+CE
+CE
+CE
 GJ
 QB
 Db
 Db
 Db
 gu
-Gj
-Gj
+CE
+CE
 GJ
-Gj
-Gj
+CE
+CE
 QB
 CG
 CN
@@ -25895,11 +25859,11 @@ IB
 IB
 sb
 gu
-Gj
+CE
 GJ
 GJ
 GJ
-Gj
+CE
 QB
 VH
 CN
@@ -26097,11 +26061,11 @@ Db
 Db
 ky
 gu
-Gj
-Gj
+CE
+CE
 GJ
 GJ
-Gj
+CE
 QB
 CG
 CN
@@ -26303,7 +26267,7 @@ GJ
 GJ
 GJ
 GJ
-Gj
+CE
 QB
 CG
 mT

--- a/maps/map_files/Whiskey_Outpost_v2/Whiskey_Outpost_v2.dmm
+++ b/maps/map_files/Whiskey_Outpost_v2/Whiskey_Outpost_v2.dmm
@@ -1628,7 +1628,7 @@
 /turf/open/gm/dirt,
 /area/whiskey_outpost/outside/north/beach)
 "fJ" = (
-/obj/structure/flora/jungle/bioluminescent,
+/obj/structure/flora/jungle/alienplant1,
 /turf/open/gm/river,
 /area/whiskey_outpost/outside/lane/one_south)
 "fL" = (
@@ -2541,7 +2541,7 @@
 /turf/open/floor/plating,
 /area/whiskey_outpost/inside/hospital)
 "iD" = (
-/obj/structure/flora/jungle/bioluminescent,
+/obj/structure/flora/jungle/alienplant1,
 /turf/open/gm/river,
 /area/whiskey_outpost/outside/lane/four_south)
 "iF" = (
@@ -6370,7 +6370,7 @@
 	},
 /area/whiskey_outpost/inside/bunker)
 "wb" = (
-/obj/structure/flora/jungle/bioluminescent,
+/obj/structure/flora/jungle/alienplant1,
 /turf/open/gm/coast{
 	icon_state = "beachcorner2"
 	},
@@ -9076,7 +9076,7 @@
 /turf/open/gm/coast,
 /area/whiskey_outpost/outside/lane/four_north)
 "FH" = (
-/obj/structure/flora/jungle/bioluminescent,
+/obj/structure/flora/jungle/alienplant1,
 /turf/open/gm/river,
 /area/whiskey_outpost/outside/river/west)
 "FI" = (
@@ -10812,7 +10812,7 @@
 /turf/open/gm/dirt,
 /area/whiskey_outpost/outside/north/beach)
 "MR" = (
-/obj/structure/flora/jungle/bioluminescent,
+/obj/structure/flora/jungle/alienplant1,
 /turf/open/gm/river,
 /area/whiskey_outpost/outside/lane/two_north)
 "MU" = (
@@ -10947,7 +10947,7 @@
 /turf/open/jungle/impenetrable,
 /area/whiskey_outpost/outside/south/very_far)
 "Nv" = (
-/obj/structure/flora/jungle/bioluminescent,
+/obj/structure/flora/jungle/alienplant1,
 /turf/open/gm/grass{
 	icon_state = "grassbeach"
 	},
@@ -11096,7 +11096,7 @@
 	},
 /area/whiskey_outpost/inside/bunker/bunker/front)
 "Ob" = (
-/obj/structure/flora/jungle/bioluminescent,
+/obj/structure/flora/jungle/alienplant1,
 /turf/open/gm/river,
 /area/whiskey_outpost/outside/lane/one_north)
 "Oc" = (
@@ -11217,7 +11217,7 @@
 	},
 /area/whiskey_outpost/outside/river/east)
 "OA" = (
-/obj/structure/flora/jungle/bioluminescent,
+/obj/structure/flora/jungle/alienplant1,
 /turf/open/gm/river,
 /area/whiskey_outpost/outside/lane/four_north)
 "OD" = (
@@ -11398,7 +11398,7 @@
 /turf/open/gm/dirt,
 /area/whiskey_outpost/outside/north/northwest)
 "Pr" = (
-/obj/structure/flora/jungle/bioluminescent,
+/obj/structure/flora/jungle/alienplant1,
 /turf/open/gm/river,
 /area/whiskey_outpost/outside/river)
 "Ps" = (
@@ -11548,7 +11548,7 @@
 /turf/open/gm/dirt,
 /area/whiskey_outpost/outside/lane/four_north)
 "Qa" = (
-/obj/structure/flora/jungle/bioluminescent,
+/obj/structure/flora/jungle/alienplant1,
 /turf/open/gm/river,
 /area/whiskey_outpost/outside/river/east)
 "Qc" = (

--- a/maps/map_files/Whiskey_Outpost_v2/Whiskey_Outpost_v2.dmm
+++ b/maps/map_files/Whiskey_Outpost_v2/Whiskey_Outpost_v2.dmm
@@ -1674,11 +1674,7 @@
 	},
 /area/whiskey_outpost/inside/living)
 "fU" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/jungle{
 	bushes_spawn = 0;
 	icon_state = "grass_impenetrable"
@@ -2146,11 +2142,7 @@
 	},
 /area/whiskey_outpost/inside/hospital)
 "hy" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/gm/dirtgrassborder{
 	dir = 8
 	},
@@ -3014,11 +3006,7 @@
 	},
 /area/whiskey_outpost/inside/living)
 "ke" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/gm/dirt,
 /area/whiskey_outpost/outside/south/far)
 "kg" = (
@@ -3340,11 +3328,7 @@
 	},
 /area/whiskey_outpost)
 "lp" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/gm/dirt,
 /area/whiskey_outpost/outside/south/very_far)
 "lq" = (
@@ -5689,11 +5673,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/gm/dirt,
 /area/whiskey_outpost/outside/north/beach)
 "tK" = (
@@ -6255,11 +6235,7 @@
 	},
 /area/whiskey_outpost/inside/bunker)
 "vF" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/gm/dirt,
 /area/whiskey_outpost/outside/north/beach)
 "vG" = (
@@ -6850,11 +6826,7 @@
 	},
 /area/whiskey_outpost/inside/bunker)
 "xK" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/gm/dirtgrassborder{
 	dir = 4
 	},
@@ -7444,11 +7416,7 @@
 /turf/open/floor/prison,
 /area/whiskey_outpost/inside/bunker)
 "zK" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/gm/dirt,
 /area/whiskey_outpost/inside/caves/caverns)
 "zM" = (
@@ -8581,11 +8549,7 @@
 	},
 /area/whiskey_outpost/inside/bunker/bunker/front)
 "DU" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/gm/dirt,
 /area/whiskey_outpost/outside/lane/four_south)
 "DV" = (
@@ -9301,11 +9265,7 @@
 /area/whiskey_outpost/outside/north/beach)
 "GA" = (
 /obj/structure/flora/bush/ausbushes/var3/sparsegrass,
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/gm/dirt,
 /area/whiskey_outpost/outside/north/beach)
 "GB" = (
@@ -9678,11 +9638,7 @@
 /turf/open/gm/river,
 /area/whiskey_outpost/outside/lane/one_north)
 "HX" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /obj/effect/decal/cleanable/blood/writing,
 /turf/open/jungle,
 /area/whiskey_outpost/outside/south/very_far)
@@ -9858,11 +9814,7 @@
 /turf/open/gm/dirt,
 /area/whiskey_outpost/outside/lane/two_north)
 "IC" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/jungle,
 /area/whiskey_outpost/outside/north/northwest)
 "IF" = (
@@ -9886,11 +9838,7 @@
 /turf/open/floor,
 /area/whiskey_outpost/outside/south/far)
 "IK" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/gm/dirtgrassborder{
 	dir = 8
 	},
@@ -10424,11 +10372,7 @@
 	},
 /area/whiskey_outpost/inside/hospital/triage)
 "Lp" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /obj/structure/disposalpipe/segment,
 /turf/open/gm/grass,
 /area/whiskey_outpost/outside/north/northwest)
@@ -10556,11 +10500,7 @@
 	},
 /area/whiskey_outpost/outside/lane/three_south)
 "LR" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /obj/structure/disposalpipe/segment,
 /turf/open/gm/dirt,
 /area/whiskey_outpost/outside/north/beach)
@@ -10847,11 +10787,7 @@
 /turf/open/gm/coast,
 /area/whiskey_outpost/outside/lane/four_north)
 "Nc" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/jungle{
 	bushes_spawn = 0;
 	icon_state = "grass_impenetrable"
@@ -11231,11 +11167,7 @@
 	},
 /area/whiskey_outpost/outside/lane/three_north)
 "OF" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/jungle,
 /area/whiskey_outpost/outside/south)
 "OG" = (
@@ -11579,11 +11511,7 @@
 	},
 /area/whiskey_outpost/outside/south)
 "Ql" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/floor{
 	dir = 1;
 	icon_state = "asteroidfloor"
@@ -11745,11 +11673,7 @@
 /turf/open/gm/dirt,
 /area/whiskey_outpost/outside/north)
 "QV" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/gm/dirt,
 /area/whiskey_outpost/outside/lane/two_north)
 "QW" = (
@@ -12296,11 +12220,7 @@
 	},
 /area/whiskey_outpost/inside/bunker/bunker/front)
 "Th" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /obj/structure/barricade/plasteel/wired,
 /turf/open/gm/dirt,
 /area/whiskey_outpost/outside/lane/one_north)
@@ -12725,19 +12645,11 @@
 /turf/open/gm/dirt,
 /area/whiskey_outpost/outside/north/beach)
 "UO" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/gm/grass,
 /area/whiskey_outpost/outside/north/northwest)
 "UP" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/jungle{
 	bushes_spawn = 0;
 	icon_state = "grass_impenetrable"
@@ -13981,11 +13893,7 @@
 	},
 /area/whiskey_outpost/inside/bunker/pillbox/two)
 "ZT" = (
-/obj/item/lightstick/red{
-	anchored = 1;
-	icon_state = "lightstick_red1";
-	luminosity = 2
-	},
+/obj/item/lightstick/red/planted,
 /turf/open/gm/dirtgrassborder{
 	dir = 4
 	},


### PR DESCRIPTION
# About the pull request

fixes https://github.com/cmss13-devs/cmss13/issues/3371

added a check if the entity is destroy that reset luminosity to 0.
adding to the code their own entity instead of doing change in dmm file for :
the cart and the bio luminescent tree also did it for glow goo that give acid damage.
give the proper entity name instead of doing change in dmm files for the light stick 

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
remove a bug.
less useless code in dmm files...

# Testing Photographs and Procedure
i tested on local server it work very fine.
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:

fix: remove the luminosity when torch and plant that produce the light are destroy.

/:cl:
