### PR TITLE
Xeno directional attack no longer friendly fires their own resin walls and doors

### DIFF
--- a/code/_onclick/xeno.dm
+++ b/code/_onclick/xeno.dm
@@ -2,7 +2,7 @@
 	Xenomorph
 */
 
-/mob/living/carbon/xenomorph/UnarmedAttack(atom/target, proximity, click_parameters, tile_attack = FALSE)
+/mob/living/carbon/xenomorph/UnarmedAttack(atom/target, proximity, click_parameters, tile_attack = FALSE, ignores_resin = FALSE)
 	if(lying || burrow) //No attacks while laying down
 		return FALSE
 	var/mob/alt
@@ -28,6 +28,12 @@
 			break
 		if (target == T && alt)
 			target = alt
+		if (T && ignores_resin) // Will not target resin walls and doors if this is set to true. This is normally only set to true through a directional attack.
+			if(istype(T, /obj/structure/mineral_door/resin))
+				return FALSE
+			if(istype(T, /turf/closed/wall/resin))
+				return FALSE
+
 	target = target.handle_barriers(src, , (PASS_MOB_THRU_XENO|PASS_TYPE_CRAWLER)) // Checks if target will be attacked by the current alien OR if the blocker will be attacked
 	switch(target.attack_alien(src))
 		if(XENO_ATTACK_ACTION)
@@ -75,7 +81,7 @@
 		return
 	if (client && client.prefs && client.prefs.toggle_prefs & TOGGLE_DIRECTIONAL_ATTACK)
 		next_move += 0.25 SECONDS //Slight delay on missed directional attacks. If it finds a mob in the target tile, this will be overwritten by the attack delay.
-		return UnarmedAttack(get_step(src, Get_Compass_Dir(src, A)), tile_attack = TRUE)
+		return UnarmedAttack(get_step(src, Get_Compass_Dir(src, A)), tile_attack = TRUE, ignores_resin = TRUE)
 	return FALSE
 
 /**The parent proc, will default to UnarmedAttack behaviour unless overriden

--- a/code/_onclick/xeno.dm
+++ b/code/_onclick/xeno.dm
@@ -30,9 +30,13 @@
 			target = alt
 		if (T && ignores_resin) // Will not target resin walls and doors if this is set to true. This is normally only set to true through a directional attack.
 			if(istype(T, /obj/structure/mineral_door/resin))
-				return FALSE
+				var/obj/structure/mineral_door/resin/attacked_door = T
+				if(hivenumber == attacked_door.hivenumber)
+					return FALSE
 			if(istype(T, /turf/closed/wall/resin))
-				return FALSE
+				var/turf/closed/wall/resin/attacked_wall = T
+				if(hivenumber == attacked_wall.hivenumber)
+					return FALSE
 
 	target = target.handle_barriers(src, , (PASS_MOB_THRU_XENO|PASS_TYPE_CRAWLER)) // Checks if target will be attacked by the current alien OR if the blocker will be attacked
 	switch(target.attack_alien(src))

--- a/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
@@ -95,7 +95,7 @@
 /mob/living/carbon/xenomorph/facehugger/pull_response(mob/puller)
 	return TRUE
 
-/mob/living/carbon/xenomorph/facehugger/UnarmedAttack(atom/A, proximity, click_parameters, tile_attack)
+/mob/living/carbon/xenomorph/facehugger/UnarmedAttack(atom/A, proximity, click_parameters, tile_attack, ignores_resin = FALSE)
 	a_intent = INTENT_HELP //Forces help intent for all interactions.
 	if(!caste)
 		return FALSE

--- a/code/modules/mob/living/carbon/xenomorph/castes/Larva.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Larva.dm
@@ -146,7 +146,7 @@
 /mob/living/carbon/xenomorph/larva/pull_response(mob/puller)
 	return TRUE
 
-/mob/living/carbon/xenomorph/larva/UnarmedAttack(atom/A, proximity, click_parameters, tile_attack)
+/mob/living/carbon/xenomorph/larva/UnarmedAttack(atom/A, proximity, click_parameters, tile_attack, ignores_resin = FALSE)
 	a_intent = INTENT_HELP //Forces help intent for all interactions.
 	if(!caste)
 		return FALSE


### PR DESCRIPTION

![dreamseeker_M0U60T6yV6](https://github.com/cmss13-devs/cmss13/assets/24533979/288f233d-58ae-4afd-835d-3deefebd2f92)


:cl: Hopek
fix: Xeno Directional attack no longer friendly fires their own walls and doors. You need to actually click on the sprite if you mean to destroy it
/:cl:
