### PR TITLE
M276 Combat Toolbelt for SEAs

### DIFF
--- a/code/game/machinery/vending/vendor_types/crew/sea.dm
+++ b/code/game/machinery/vending/vendor_types/crew/sea.dm
@@ -39,6 +39,7 @@ GLOBAL_LIST_INIT(cm_vending_clothing_sea, list(
 		list("G8-A General Utility Pouch", 0, /obj/item/storage/backpack/general_belt, MARINE_CAN_BUY_BELT, VENDOR_ITEM_REGULAR),
 		list("M276 Lifesaver Bag (Full)", 0, /obj/item/storage/belt/medical/lifesaver/full, MARINE_CAN_BUY_BELT, VENDOR_ITEM_RECOMMENDED),
 		list("M276 Toolbelt Rig (Full)", 0, /obj/item/storage/belt/utility/full, MARINE_CAN_BUY_BELT, VENDOR_ITEM_REGULAR),
+		list("M276 Combat Toolbelt Rig (Full)", 0, /obj/item/storage/belt/gun/utility, MARINE_CAN_BUY_BELT, VENDOR_ITEM_REGULAR),
 
 		list("POUCHES (CHOOSE 2)", 0, null, null, null),
 		list("Autoinjector Pouch", 0, /obj/item/storage/pouch/autoinjector/full, (MARINE_CAN_BUY_R_POUCH|MARINE_CAN_BUY_L_POUCH), VENDOR_ITEM_REGULAR),


### PR DESCRIPTION
# About the pull request

Adds the pistol toolbelt rig to the SEA's vendor.

# Explain why it's good for the game

An SEA player asked me to implement this, and Morrow said it was fine, so I'm PRing it.


# Testing Photographs and Procedure
Added the item to the vendor, runs and compiles.

# Changelog

:cl:LynxSolstice
add: Added an M276 Pattern Combat Toolbelt rig to the SEA's vendor machine.
/:cl:
