### PR TITLE
Fixes for boiler.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/ability_helper_procs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/ability_helper_procs.dm
@@ -224,11 +224,10 @@
 	client.pixel_x = 0
 	client.pixel_y = 0
 	is_zoomed = 0
-	// Since theres several ways we can get here, we need to update the ability button state
-	for (var/datum/action/xeno_action/action in actions)
-		if (istype(action, /datum/action/xeno_action/onclick/toggle_long_range))
-			action.button.icon_state = "template"
-			break;
+	// Since theres several ways we can get here, we need to update the ability button state and handle action's specific effects
+	for (var/datum/action/xeno_action/onclick/toggle_long_range/action in actions)
+		action.on_zoom_out()
+		return
 
 /mob/living/carbon/xenomorph/proc/do_acid_spray_cone(turf/T, spray_type = /obj/effect/xenomorph/spray, range = 3)
 	set waitfor = FALSE

--- a/code/modules/mob/living/carbon/xenomorph/abilities/general_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/general_abilities.dm
@@ -302,24 +302,30 @@
 		return
 
 	if(xeno.is_zoomed)
-		xeno.zoom_out() // will also handle icon_state
-		xeno.visible_message(SPAN_NOTICE("[xeno] stops looking off into the distance."), \
-		SPAN_NOTICE("You stop looking off into the distance."), null, 5)
-		if(movement_slowdown)
-			xeno.recalculate_speed()
-	else
-		xeno.visible_message(SPAN_NOTICE("[xeno] starts looking off into the distance."), \
-			SPAN_NOTICE("You start focusing your sight to look off into the distance."), null, 5)
-		if (should_delay)
-			if(!do_after(xeno, delay, INTERRUPT_NO_NEEDHAND, BUSY_ICON_GENERIC)) return
-		if(xeno.is_zoomed) return
-		if(handles_movement)
-			RegisterSignal(xeno, COMSIG_MOB_MOVE_OR_LOOK, PROC_REF(handle_mob_move_or_look))
-		if(movement_slowdown)
-			xeno.speed_modifier += movement_slowdown
-			xeno.recalculate_speed()
-		xeno.zoom_in()
-		button.icon_state = "template_active"
+		xeno.zoom_out() // will call on_zoom_out()
+		return
+	xeno.visible_message(SPAN_NOTICE("[xeno] starts looking off into the distance."), \
+		SPAN_NOTICE("You start focusing your sight to look off into the distance."), null, 5)
+	if (should_delay)
+		if(!do_after(xeno, delay, INTERRUPT_NO_NEEDHAND, BUSY_ICON_GENERIC)) return
+	if(xeno.is_zoomed)
+		return
+	if(handles_movement)
+		RegisterSignal(xeno, COMSIG_MOB_MOVE_OR_LOOK, PROC_REF(handle_mob_move_or_look))
+	if(movement_slowdown)
+		xeno.speed_modifier += movement_slowdown
+		xeno.recalculate_speed()
+	xeno.zoom_in()
+	button.icon_state = "template_active"
+
+/datum/action/xeno_action/onclick/toggle_long_range/proc/on_zoom_out()
+	var/mob/living/carbon/xenomorph/xeno = owner
+	xeno.visible_message(SPAN_NOTICE("[xeno] stops looking off into the distance."), \
+	SPAN_NOTICE("You stop looking off into the distance."), null, 5)
+	if(movement_slowdown)
+		xeno.speed_modifier -= movement_slowdown
+		xeno.recalculate_speed()
+	button.icon_state = "template"
 
 /datum/action/xeno_action/onclick/toggle_long_range/proc/handle_mob_move_or_look(mob/living/carbon/xenomorph/xeno, actually_moving, direction, specific_direction)
 	SIGNAL_HANDLER
@@ -330,7 +336,6 @@
 		movement_buffer = initial(movement_buffer)
 		xeno.zoom_out() // will also handle icon_state
 		UnregisterSignal(xeno, COMSIG_MOB_MOVE_OR_LOOK)
-		xeno.recalculate_speed()
 
 // General use acid spray, can be subtyped to customize behavior.
 // ... or mutated at runtime by another action that retrieves and edits these values

--- a/code/modules/mob/living/carbon/xenomorph/mutators/strains/boiler/trapper.dm
+++ b/code/modules/mob/living/carbon/xenomorph/mutators/strains/boiler/trapper.dm
@@ -12,6 +12,7 @@
 		/datum/action/xeno_action/activable/spray_acid/boiler,
 		/datum/action/xeno_action/onclick/dump_acid,
 		/datum/action/xeno_action/onclick/toggle_long_range/boiler,
+		/datum/action/xeno_action/onclick/acid_shroud,
 	)
 	mutator_actions_to_add = list(
 		/datum/action/xeno_action/activable/boiler_trap,
@@ -32,6 +33,7 @@
 	if(boiler.is_zoomed)
 		boiler.zoom_out()
 
+	boiler.tileoffset = 0
 	boiler.viewsize = TRAPPER_VIEWRANGE
 	boiler.mutation_type = BOILER_TRAPPER
 	boiler.plasma_types -= PLASMA_NEUROTOXIN


### PR DESCRIPTION

# About the pull request

If zooming with the action applied some effects, unzooming should cancel them out, whether the unzooming is caused by using the action again or by something else.
Trapper inheriting some things added to base boiler in globber update is simply an oversight. Its vision has always been centered on the trapper and should be, as it is lined exactly with its bombardment distance (and currently trying to use acid mine at the edge of offset range, which is outside of intended zoom range, gives a warning that "something is in the way" instead of saying that it is out of range, which makes it even worse for an unaware player).
Likewise, adding shroud for the globber should have been restricted to the globber - instead, it persists on trapper and hijacks its fourth keybind which is meant to be its zooming ability.

# Explain why it's good for the game

Fixes #3385.


# Changelog
:cl:
fix: Boiler's slowdown for zooming now properly resets on unzooming regardless of what causes it.
fix: Trapper's zoomed vision is no longer unintentionally offset.
fix: Trapper no longer gets globber's Acid Shroud ability messing its keybinds.
/:cl:
