### PR TITLE
Langchat popup for Show Held Item.

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -781,7 +781,9 @@ cases. Override_icon_state should be a list.*/
 
 
 /obj/item/proc/showoff(mob/user)
-	for (var/mob/M in view(user))
+	var/list/viewers = get_mobs_in_view(world_view_size, user)
+	user.langchat_speech("holds up [src].", viewers, GLOB.all_languages, skip_language_check = TRUE, animation_style = LANGCHAT_FAST_POP, additional_styles = list("langchat_small", "emote"))
+	for (var/mob/M in viewers)
 		M.show_message("[user] holds up [src]. <a HREF=?src=\ref[M];lookitem=\ref[src]>Take a closer look.</a>", SHOW_MESSAGE_VISIBLE)
 
 /mob/living/carbon/verb/showoff()


### PR DESCRIPTION

# About the pull request

Selfdescriptive.

# Explain why it's good for the game

`Show held item` is a very useful keybind. Making it easier to notice for everybody around should only help.


# Testing Photographs and Procedure
![image](https://github.com/cmss13-devs/cmss13/assets/4447185/ebbe8857-13af-41dc-bc6d-9e027982face)

# Changelog
:cl:
add: Using Show Held Item is now visible in abovehead popup.
/:cl:
