### PR TITLE
adds motion detector for PMC faction

### DIFF
--- a/code/game/objects/items/devices/motion_detector.dm
+++ b/code/game/objects/items/devices/motion_detector.dm
@@ -309,6 +309,11 @@
 	name = "hacked motion detector"
 	desc = "A device that usually picks up non-USCM signals, but this one's been hacked to detect all non-freelancer movement instead. Fight fire with fire!"
 	iff_signal = FACTION_MERCENARY
+	
+/obj/item/device/motiondetector/hacked/pmc
+	name = "corporate motion detector"
+	desc = "A device that usually picks up non-USCM signals, but this one's been reprogrammed to detect all non-PMC movement instead. Very corporate."
+	iff_signal = FACTION_PMC
 
 /obj/item/device/motiondetector/hacked/dutch
 	name = "hacked motion detector"


### PR DESCRIPTION
Adds a modified motion detector to detect signals not affiliated with FACTION_PMC. 


# About the pull request

Gives the PMCs a faction-aligned motion detector. 

# Explain why it's good for the game

The other factions like the UPP, Dutch's Dozen, etc., have a motion detector to call their own; let us have one, too! Will allow PMCs to potentially have motion detectors of their own without having to worry about their own squadmates making them go off. 




# Changelog

modified motion_detector.dm

