### PR TITLE
Shotgun and buckshot tweaks

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1197,10 +1197,10 @@
 	accuracy_var_high = PROJECTILE_VARIANCE_TIER_5
 	accurate_range = 4
 	max_range = 4
-	damage = 65
+	damage = 125
 	damage_var_low = PROJECTILE_VARIANCE_TIER_8
 	damage_var_high = PROJECTILE_VARIANCE_TIER_8
-	penetration = ARMOR_PENETRATION_TIER_1
+	penetration = ARMOR_PENETRATION_TIER_2
 	bonus_projectiles_amount = EXTRA_PROJECTILES_TIER_3
 	shell_speed = AMMO_SPEED_TIER_2
 	damage_armor_punch = 0

--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -1112,7 +1112,7 @@ can cause issues with ammo types getting mixed up during the burst.
 /obj/item/weapon/gun/shotgun/pump/set_gun_config_values()
 	..()
 	burst_amount = BURST_AMOUNT_TIER_1
-	fire_delay = FIRE_DELAY_TIER_7 * 5
+	fire_delay = FIRE_DELAY_TIER_5 * 5
 	accuracy_mult = BASE_ACCURACY_MULT + HIT_ACCURACY_MULT_TIER_3
 	accuracy_mult_unwielded = BASE_ACCURACY_MULT - HIT_ACCURACY_MULT_TIER_10
 	scatter = SCATTER_AMOUNT_TIER_6

--- a/code/modules/projectiles/magazines/shotguns.dm
+++ b/code/modules/projectiles/magazines/shotguns.dm
@@ -90,7 +90,7 @@ also doesn't really matter. You can only reload them with handfuls.
 	desc = "An internal magazine. It is not supposed to be seen or removed."
 	default_ammo = /datum/ammo/bullet/shotgun/slug
 	caliber = "12g"
-	max_rounds = 9
+	max_rounds = 4 // Accounting for an extra round being loaded after pumping
 	chamber_closed = 0
 
 /obj/item/ammo_magazine/internal/shotgun/double //For a double barrel.


### PR DESCRIPTION
# About the pull request

This PR increases buckshots damage from 65, to 125 and gives it 5 more AP. Shotgun has also been tweaked to have a longer fire delay and a reduction from 9, to 4 rounds (5 when pumped and another shell is loaded).

# Explain why it's good for the game

Shotguns are in a weird place ever since the double shotgun removal. Buckshot had been its main purpose, and was basically balanced around a person using two shotguns. I believe this PR would put shotguns into a specific role, where constant usage isn't encouraged, but it would remain as a powerful side choice that can either be used as slugs or through powerful point blanks. By removing the excessive amounts of shells (which isn't lore accurate), lowering the fire delay, and making buckshot hit harder, I believe shotguns would fit their role better instead of being in a limbo state where it isn't really useful aside being normally used against 3-4 castes. 
Basically, this lowers the PB requirement for most kills on xenos by 1~. IE a warrior will die in 2 PBs instead of 3.

# Changelog

:cl:
balance: Shotguns have a lowered fire delay and maximum shells
balance: Buckshots damage and AP have been increased
/:cl:

