### PR TITLE
Synthetic Acid Blood Dodge

### DIFF
--- a/code/modules/mob/living/carbon/human/species/synthetic.dm
+++ b/code/modules/mob/living/carbon/human/species/synthetic.dm
@@ -87,7 +87,6 @@
 
 	knock_down_reduction = 3.5
 	stun_reduction = 3.5
-	acid_blood_dodge_chance = 35
 
 	inherent_verbs = list(
 		/mob/living/carbon/human/proc/toggle_inherent_nightvison,
@@ -135,7 +134,7 @@
 
 	knock_down_reduction = 5
 	stun_reduction = 5
-	acid_blood_dodge_chance = 35
+	
 
 	inherent_verbs = null
 

--- a/code/modules/mob/living/carbon/human/species/synthetic.dm
+++ b/code/modules/mob/living/carbon/human/species/synthetic.dm
@@ -40,7 +40,7 @@
 
 	knock_down_reduction = 5
 	stun_reduction = 5
-	acid_blood_dodge_chance = 35
+	acid_blood_dodge_chance = 25
 
 	inherent_verbs = list(
 		/mob/living/carbon/human/synthetic/proc/toggle_HUD,

--- a/code/modules/mob/living/carbon/human/species/synthetic.dm
+++ b/code/modules/mob/living/carbon/human/species/synthetic.dm
@@ -40,6 +40,7 @@
 
 	knock_down_reduction = 5
 	stun_reduction = 5
+	acid_blood_dodge_chance = 35
 
 	inherent_verbs = list(
 		/mob/living/carbon/human/synthetic/proc/toggle_HUD,
@@ -86,6 +87,7 @@
 
 	knock_down_reduction = 3.5
 	stun_reduction = 3.5
+	acid_blood_dodge_chance = 35
 
 	inherent_verbs = list(
 		/mob/living/carbon/human/proc/toggle_inherent_nightvison,
@@ -133,6 +135,7 @@
 
 	knock_down_reduction = 5
 	stun_reduction = 5
+	acid_blood_dodge_chance = 35
 
 	inherent_verbs = null
 

--- a/code/modules/mob/living/carbon/human/species/synthetic.dm
+++ b/code/modules/mob/living/carbon/human/species/synthetic.dm
@@ -134,7 +134,6 @@
 
 	knock_down_reduction = 5
 	stun_reduction = 5
-	
 
 	inherent_verbs = null
 


### PR DESCRIPTION

# About the pull request

Re-adds the acid blood dodge from before acid blood damage was reduced, used same values as it previously had.

Confirmed with Morrow about it being part of the circular return in council discord. Literally just un-does PR #3105 

# Explain why it's good for the game

Lets synthetics actually defend themselves a little instead of being punished more for self defense than just staring and tanking damage. 


# Testing Photographs and Procedure

</details>


# Changelog

:cl:
add: Synthetic gets a chance to dodge xeno acid blood spray
/:cl:

