### PR TITLE
removes crusty recommended extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,13 +1,5 @@
 {
     "recommendations": [
-        "gbasood.byond-dm-language-support",
-        "platymuus.dm-langclient",
-        "arcanis.vscode-zipfs",
-        "EditorConfig.EditorConfig",
-        "stylemistake.auto-comment-blocks",
-        "anturk.dmi-editor",
-        "dbaeumer.vscode-eslint",
-        "esbenp.prettier-vscode",
-        "donkie.vscode-tgstation-test-adapter"
+        "cmss13-devs.cm-extpack"
     ]
 }


### PR DESCRIPTION
moves us to using our own extension pack, which is a little easier to direct people towards to install

i included indent-rainbow in the extension pack because dm is such an indentation sensitive language, and being able to tell when people are messing up their indentation saves so much debugging