### PR TITLE
Removes Baton slugs from regular accessibility.

### DIFF
--- a/code/game/machinery/vending/vendor_types/requisitions.dm
+++ b/code/game/machinery/vending/vendor_types/requisitions.dm
@@ -54,7 +54,6 @@
 		list("M74 AGM-Smoke Airburst Grenade", round(scale * 4), /obj/item/explosive/grenade/smokebomb/airburst, VENDOR_ITEM_REGULAR),
 		list("M74 AGM-Star Shell", round(scale * 2), /obj/item/explosive/grenade/high_explosive/airburst/starshell, VENDOR_ITEM_REGULAR),
 		list("M74 AGM-Hornet Shell", round(scale * 4), /obj/item/explosive/grenade/high_explosive/airburst/hornet_shell, VENDOR_ITEM_REGULAR),
-		list("M40 HIRR Baton Slug", round(scale * 8), /obj/item/explosive/grenade/slug/baton, VENDOR_ITEM_REGULAR),
 		list("M40 MFHS Metal Foam Grenade", round(scale * 3), /obj/item/explosive/grenade/metal_foam, VENDOR_ITEM_REGULAR),
 		list("Plastic Explosives", round(scale * 3), /obj/item/explosive/plastic, VENDOR_ITEM_REGULAR),
 		list("Breaching Charge", round(scale * 2), /obj/item/explosive/plastic/breaching_charge, VENDOR_ITEM_REGULAR),

--- a/code/game/objects/structures/crates_lockers/closets/secure/guncabinet.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/guncabinet.dm
@@ -110,6 +110,12 @@
 	new /obj/item/clothing/suit/armor/riot/marine(src)
 	new /obj/item/clothing/suit/armor/riot/marine(src)
 	new /obj/item/storage/box/flashbangs(src)
+	new /obj/item/storage/box/packet/baton_slug (src)
+	new /obj/item/storage/box/packet/baton_slug (src)
+	new /obj/item/storage/box/packet/baton_slug (src)
+	new /obj/item/storage/box/packet/baton_slug (src)
+	new /obj/item/storage/box/packet/baton_slug (src)
+	new /obj/item/storage/box/packet/baton_slug (src)
 
 
 /obj/structure/closet/secure_closet/guncabinet/green

--- a/code/modules/cm_marines/equipment/guncases.dm
+++ b/code/modules/cm_marines/equipment/guncases.dm
@@ -89,7 +89,6 @@
 /obj/item/storage/box/guncase/m79/fill_preset_inventory()
 	new /obj/item/weapon/gun/launcher/grenade/m81/m79(src)
 	new /obj/item/storage/box/packet/flare(src)
-	new /obj/item/storage/box/packet/baton_slug(src)
 	new /obj/item/storage/box/packet/hornet(src)
 
 //------------

--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -965,9 +965,12 @@
 
 /obj/item/weapon/gun/launcher/grenade/m81/riot
 	name = "\improper M81 riot grenade launcher"
-	desc = "A lightweight, single-shot low-angle grenade launcher to launch tear gas grenades. Used by the Colonial Marines Military Police during riots."
-	valid_munitions = list(/obj/item/explosive/grenade/custom/teargas)
-	preload = /obj/item/explosive/grenade/custom/teargas
+	desc = "A lightweight, single-shot low-angle grenade launcher to launch tear gas grenades or baton slugs. Used by the Colonial Marines Military Police during riots."
+	valid_munitions = list(/obj/item/explosive/grenade/custom/teargas, /obj/item/explosive/grenade/slug/baton)
+	fire_sound = 'sound/weapons/handling/m79_shoot.ogg'
+	cocked_sound = 'sound/weapons/handling/m79_break_open.ogg'
+	reload_sound = 'sound/weapons/handling/m79_reload.ogg'
+	unload_sound = 'sound/weapons/handling/m79_unload.ogg'
 
 //-------------------------------------------------------
 //M79 Grenade Launcher subtype of the M81
@@ -979,7 +982,6 @@
 	icon_state = "m79"
 	item_state = "m79"
 	flags_equip_slot = SLOT_BACK
-	preload = /obj/item/explosive/grenade/slug/baton
 	is_lobbing = TRUE
 	actions_types = list(/datum/action/item_action/toggle_firing_level)
 

--- a/code/modules/vehicles/interior/interactable/vendors.dm
+++ b/code/modules/vehicles/interior/interactable/vendors.dm
@@ -203,7 +203,6 @@
 		list("M74 AGM-Smoke Airburst Grenade", 0, /obj/item/explosive/grenade/smokebomb/airburst, VENDOR_ITEM_REGULAR),
 		list("M74 AGM-Star Shell", 2, /obj/item/explosive/grenade/high_explosive/airburst/starshell, VENDOR_ITEM_REGULAR),
 		list("M74 AGM-Hornet Shell", 0, /obj/item/explosive/grenade/high_explosive/airburst/hornet_shell, VENDOR_ITEM_REGULAR),
-		list("M40 HIRR Baton Slug", round(scale * 2), /obj/item/explosive/grenade/slug/baton, VENDOR_ITEM_REGULAR),
 		list("M40 MFHS Metal Foam Grenade", 0, /obj/item/explosive/grenade/metal_foam, VENDOR_ITEM_REGULAR),
 		list("Breaching Charge", 0, /obj/item/explosive/plastic/breaching_charge, VENDOR_ITEM_REGULAR),
 		list("Plastic Explosives", 2, /obj/item/explosive/plastic, VENDOR_ITEM_REGULAR),


### PR DESCRIPTION

# About the pull request

Makes the riot control launcher able to launch HIRR Slugs and changes it to use the M79 sounds rather than the legacy ones. Adds packets to the riot control cabinets and removes them from the regular vendors.

# Explain why it's good for the game

Moves the baton slugs to a policing role, rather than a meme ammo type for the M79. 


# Testing Photographs and Procedure

Runs, compiles, the baton slugs can be fired out of the grenade launcher.

# Changelog
:cl:LynxSolstice
add: HIRR slugs moved to the MP armory, grenade launcher allowed to fire them now. M81 grenade launcher now uses the M79 handling and firing sounds.
balance: Removes the HIRR slugs from all vendors.
/:cl:
