### PR TITLE
prevents splints being applied when you put them away

### DIFF
--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -1220,7 +1220,7 @@ treat_grafted var tells it to apply to grafted but unsalved wounds, for burn kit
 			user.visible_message(SPAN_WARNING("[user] fumbles with [S]"), SPAN_WARNING("You fumble with [S]..."))
 			time_to_take = 15 SECONDS
 
-		if(do_after(user, time_to_take * user.get_skill_duration_multiplier(SKILL_MEDICAL), INTERRUPT_NO_NEEDHAND, BUSY_ICON_FRIENDLY, target, INTERRUPT_MOVED, BUSY_ICON_MEDICAL))
+		if(do_after(user, time_to_take * user.get_skill_duration_multiplier(SKILL_MEDICAL), INTERRUPT_NEEDHAND, BUSY_ICON_FRIENDLY, target, INTERRUPT_MOVED, BUSY_ICON_MEDICAL))
 			var/possessive = "[user == target ? "your" : "\the [target]'s"]"
 			var/possessive_their = "[user == target ? user.gender == MALE ? "his" : "her" : "\the [target]'s"]"
 			user.affected_message(target,


### PR DESCRIPTION
closes #1315 (splints)

# Explain why it's good for the game

someone asked for it i guess


# Testing Photographs and Procedure
i tested it on another human and myself, putting the splint back in the bag doesn't seem to instantly cancel the action, but it does after 1-2 seconds so it seems like a decent stopgap


</details>


# Changelog

🆑 thatoneyeeter
fix: Splints stop being applied when you put them away
/🆑 
