### PR TITLE
Fix Radio Signaling Frequencies breaking down

### DIFF
--- a/code/controllers/subsystem/communications.dm
+++ b/code/controllers/subsystem/communications.dm
@@ -368,6 +368,9 @@ SUBSYSTEM_DEF(radio)
 	for(var/datum/weakref/device_ref as anything in devices[filter])
 		var/obj/device = device_ref.resolve()
 
+		if(!device)
+			continue
+
 		if(device == source)
 			continue
 

--- a/code/controllers/subsystem/communications.dm
+++ b/code/controllers/subsystem/communications.dm
@@ -400,12 +400,9 @@ SUBSYSTEM_DEF(radio)
 /datum/radio_frequency/proc/remove_listener(obj/device)
 	for (var/devices_filter in devices)
 		var/list/devices_line = devices[devices_filter]
-		devices_line -= WEAKREF(device)
-		while (null in devices_line)
-			devices_line -= null
-		if (devices_line.len==0)
+		devices_line -= device.weak_reference
+		if (!length(devices_line))
 			devices -= devices_filter
-			qdel(devices_line)
 
 /datum/signal
 	var/obj/source


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

This corrects a bug introduced by porting of newer /tg/ radio code a few months back.

Due to improper handling of the weakrefs of radio devices, not only removing a device wouldn't work as expected, the dangling weakref of a deleted device would cause the transmit code to crash.

This came twofold:
 * The weakref is not checked as resolving successfully before being used
 * Removing a device would remove its WEAKREF(), but if done during deletion, it is already invalidated (we sidestep that by grabbing the weakref ref directly)

In effect this meant signallers in particular would only work under "clean" conditions, eg. being assigned to an unused frequency without moving stuff around too much.

I'm sure it explains a bunch of other excessively niche bug interactions but I'm too lazy to find out.

# Explain why it's good for the game
Shenanigans.


# Changelog
:cl:
fix: Fixed a bug in radio signaling cleanup that was notably preventing signallers from working as intended, and likely caused issues for other devices.
/:cl:
