### PR TITLE
Introduces Sleen Reagent

### DIFF
--- a/code/modules/reagents/chemistry_reactions/other.dm
+++ b/code/modules/reagents/chemistry_reactions/other.dm
@@ -114,6 +114,13 @@
 	required_reagents = list("mercury" = 1, "sugar" = 1, "lithium" = 1)
 	result_amount = 3
 
+/datum/chemical_reaction/sleen
+	name = "Sleen"
+	id = "sleen"
+	result = "sleen"
+	required_reagents = list("oxycodone" = 1, "souto_lime" = 1)
+	result_amount = 2
+
 /datum/chemical_reaction/pacid
 	name = "Polytrinic acid"
 	id = "pacid"

--- a/code/modules/reagents/chemistry_reagents/medical.dm
+++ b/code/modules/reagents/chemistry_reagents/medical.dm
@@ -54,7 +54,7 @@
 	id = "oxycodone"
 	description = "Oxycodone is an opioid agonist with addiction potential similar to that of morphine. It is approved for the treatment of patients with moderate to severe pain who are expected to need continuous opioids for an extended period of time. Overdosing on oxycodone can cause hallucinations, brain damage and be highly toxic."
 	reagent_state = LIQUID
-	color = "#C805DC"
+	color = "#E01D25"
 	custom_metabolism = AMOUNT_PER_TIME(15, 5 MINUTES) // Lasts 5 minutes for 15 units
 	overdose = MED_REAGENTS_OVERDOSE
 	overdose_critical = MED_REAGENTS_OVERDOSE_CRITICAL

--- a/code/modules/reagents/chemistry_reagents/other.dm
+++ b/code/modules/reagents/chemistry_reagents/other.dm
@@ -159,6 +159,17 @@
 	chemclass = CHEM_CLASS_UNCOMMON
 	properties = list(PROPERTY_HALLUCINOGENIC = 2)
 
+/datum/reagent/sleen
+	name = "Sleen"
+	id = "sleen"
+	description = " A favorite of marine medics, it is an addictive, illicit mixture of name brand lime soda and oxycodone, known for it's distinct red hue. Overdosing can cause hallucinations, loss of coordination, seizures, brain damage, respiratory failure, and death."
+	reagent_state = LIQUID
+	color = "#C21D24" // rgb: 194, 29, 36
+	overdose = MED_REAGENTS_OVERDOSE
+	overdose_critical = MED_REAGENTS_OVERDOSE_CRITICAL
+	chemclass = CHEM_CLASS_UNCOMMON
+	properties = list(PROPERTY_PAINKILLING = 6, PROPERTY_ADDICTIVE = 2)
+
 /datum/reagent/serotrotium
 	name = "Serotrotium"
 	id = "serotrotium"


### PR DESCRIPTION
# About the pull request

Introduces sleen as an illicit mixture, made out of lime souto and oxycodone. Also corrects the color of oxycodone to a more red color that is typically used to dye liquid forms of it in comparison to say codeine purple. It has been tested by myself. It is less painkilling than straight oxy but a slightly more than tramadol still, and has a small addiction property.

# Explain why it's good for the game

Just a small addition to dip my toes into contributing, shouldn't affect balance or rounds at all, and is just merely a small bit of flavor added for anyone in the medical department or anyone who is slightly more crafty in acquiring items. For where there is such a large supply, ease of access, and minimal oversight of abusable meds, this creates a very small amount of further play with that idea where easy light abuse might happen, no different from where marines might try to acquire booze. This can create further roleplay with MPs or any CMOs or Doctors who might be paying more close attention to things.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/cmss13-devs/cmss13/assets/18384398/f8577ba2-c8a6-41df-9a02-53677aa4afcd)

</details>


# Changelog
:cl:
add: added sleen as a reagent, 1:1 lime souto and oxycodone. Slightly less painkilling than oxy, and slightly addictive.
add: corrects oxycodone color to red dye instead of purple.
/:cl:
