### PR TITLE
Hive core requirements for stored larva from latejoin and bursts

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/Embryo.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Embryo.dm
@@ -170,7 +170,7 @@
 
 	if(hive)
 		hive.add_xeno(new_xeno)
-		if(!affected_mob.first_xeno)
+		if(!affected_mob.first_xeno && hive.hive_location)
 			hive.increase_larva_after_burst()
 			hive.hive_ui.update_burrowed_larva()
 

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -266,7 +266,7 @@
 		for(var/hivenumber in GLOB.hive_datum)
 			hive = GLOB.hive_datum[hivenumber]
 			if(hive.latejoin_burrowed == TRUE)
-				if(length(hive.totalXenos) && hive.hive_location)
+				if(length(hive.totalXenos) && (hive.hive_location || world.time < (SSticker.mode.round_time_lobby + XENO_ROUNDSTART_PROGRESS_TIME_2)))
 					hive.stored_larva++
 					hive.hive_ui.update_burrowed_larva()
 

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -266,7 +266,7 @@
 		for(var/hivenumber in GLOB.hive_datum)
 			hive = GLOB.hive_datum[hivenumber]
 			if(hive.latejoin_burrowed == TRUE)
-				if(length(hive.totalXenos) && (hive.hive_location || ROUND_TIME > XENO_ROUNDSTART_PROGRESS_TIME_2))
+				if(length(hive.totalXenos) && (hive.hive_location || ROUND_TIME < XENO_ROUNDSTART_PROGRESS_TIME_2))
 					hive.stored_larva++
 					hive.hive_ui.update_burrowed_larva()
 

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -266,7 +266,7 @@
 		for(var/hivenumber in GLOB.hive_datum)
 			hive = GLOB.hive_datum[hivenumber]
 			if(hive.latejoin_burrowed == TRUE)
-				if(length(hive.totalXenos))
+				if(length(hive.totalXenos) && hive.hive_location)
 					hive.stored_larva++
 					hive.hive_ui.update_burrowed_larva()
 

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -266,7 +266,7 @@
 		for(var/hivenumber in GLOB.hive_datum)
 			hive = GLOB.hive_datum[hivenumber]
 			if(hive.latejoin_burrowed == TRUE)
-				if(length(hive.totalXenos) && (hive.hive_location || ROUND_TIME >  XENO_ROUNDSTART_PROGRESS_TIME_2)))
+				if(length(hive.totalXenos) && (hive.hive_location || ROUND_TIME > XENO_ROUNDSTART_PROGRESS_TIME_2))
 					hive.stored_larva++
 					hive.hive_ui.update_burrowed_larva()
 

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -266,7 +266,7 @@
 		for(var/hivenumber in GLOB.hive_datum)
 			hive = GLOB.hive_datum[hivenumber]
 			if(hive.latejoin_burrowed == TRUE)
-				if(length(hive.totalXenos) && (hive.hive_location || world.time < (SSticker.mode.round_time_lobby + XENO_ROUNDSTART_PROGRESS_TIME_2)))
+				if(length(hive.totalXenos) && (hive.hive_location || ROUND_TIME >  XENO_ROUNDSTART_PROGRESS_TIME_2)))
 					hive.stored_larva++
 					hive.hive_ui.update_burrowed_larva()
 


### PR DESCRIPTION

# About the pull request

This PR makes it so you must have a hive core to get extra larva for:
bursts
latejoin marines

Latejoin marine requirement is waived for the first 15 minutes after roundstart.

# Explain why it's good for the game

Nomad hive should not have larva waiting for them ready to go after they put the hive core down again. Losing your hive should be a horrific loss.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
balance: Without a hive core Xenos no longer get stored larva from latejoin marines or bursts
/:cl:
