### PR TITLE
fix synth names being incorrect

### DIFF
--- a/code/modules/gear_presets/_select_equipment.dm
+++ b/code/modules/gear_presets/_select_equipment.dm
@@ -149,9 +149,9 @@
 	load_skills(new_human, mob_client) //skills are set before equipment because of skill restrictions on certain clothes.
 	load_languages(new_human, mob_client)
 	load_age(new_human, mob_client)
-	load_id(new_human, mob_client)
 	if(show_job_gear)
 		load_gear(new_human, mob_client)
+	load_id(new_human, mob_client)
 	load_status(new_human, mob_client)
 	load_vanity(new_human, mob_client)
 	load_traits(new_human, mob_client)

--- a/code/modules/gear_presets/clf.dm
+++ b/code/modules/gear_presets/clf.dm
@@ -858,6 +858,7 @@
 	new_human.set_species(SYNTH_COLONY_GEN_ONE)
 
 /datum/equipment_preset/clf/synth/load_gear(mob/living/carbon/human/new_human)
+	load_name(H)
 	var/obj/item/clothing/under/colonist/clf/CLF = new()
 	var/obj/item/clothing/accessory/storage/webbing/W = new()
 	CLF.attach_accessory(new_human, W)

--- a/code/modules/gear_presets/clf.dm
+++ b/code/modules/gear_presets/clf.dm
@@ -858,7 +858,7 @@
 	new_human.set_species(SYNTH_COLONY_GEN_ONE)
 
 /datum/equipment_preset/clf/synth/load_gear(mob/living/carbon/human/new_human)
-	load_name(H)
+	load_name(new_human)
 	var/obj/item/clothing/under/colonist/clf/CLF = new()
 	var/obj/item/clothing/accessory/storage/webbing/W = new()
 	CLF.attach_accessory(new_human, W)


### PR DESCRIPTION

# About the pull request

upp synths no longer have a different name on their id
if someone is turned into a clf synth their name now updates

fixes #3408 

# Explain why it's good for the game

fix good


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl:Khadd
fix: fixed upp synths having 2 different names and clf synths now get a name when they're given the equipment preset
/:cl:
