### PR TITLE
Better info when deferring to mhelps

### DIFF
--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -519,7 +519,8 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 
 	AddInteraction("Deferred to Mentors by [key_name_admin(usr)].", player_message = "Deferred to Mentors.")
 	to_chat(initiator, SPAN_ADMINHELP("Your ticket has been deferred to Mentors."))
-	Resolve()
+	log_ahelp(id, "Defer", "Deferred to mentors by [usr.key]", null,  usr.ckey)
+	Close(silent = TRUE)
 
 /datum/admin_help/proc/mark_ticket()
 	if(marked_admin)


### PR DESCRIPTION
# About the pull request

Deferring to mentorhelp now specifies that, instead of generic resolution.

# Explain why it's good for the game

A bit better readability

# Changelog

:cl:
admin: Deferring to mentorhelp gives a specific message instead of a generic resolution message
/:cl: