### PR TITLE
SL gets Signal Flare

### DIFF
--- a/code/game/machinery/vending/vendor_types/squad_prep/squad_leader.dm
+++ b/code/game/machinery/vending/vendor_types/squad_prep/squad_leader.dm
@@ -196,6 +196,7 @@ GLOBAL_LIST_INIT(cm_vending_clothing_leader, list(
 	spawned_gear_list = list(
 		/obj/item/explosive/plastic,
 		/obj/item/device/binoculars/range/designator,
+		/obj/item/storage/box/m94/signal,
 		/obj/item/map/current_map,
 		/obj/item/tool/extinguisher/mini,
 		/obj/item/storage/box/zipcuffs,


### PR DESCRIPTION
# About the pull request

Add 1 pack of signal flares to SL essential Kit

# Explain why it's good for the game

Turns out SL calling in CAS is good

I've also considered adding the Signal Flare pack as a purchasable point based item for SL however
It seems that the Signal Flare pack has intentional scarcity as no one can buy it even RTO/Fireteam Leads,

# Changelog

:cl: ghostsheet
add: Added a M89-S Signal Flare pack to SL essential kit.
/:cl:
