### PR TITLE
Bugfix: Dropship attachment point layers

### DIFF
--- a/code/modules/dropships/attach_points/templates.dm
+++ b/code/modules/dropships/attach_points/templates.dm
@@ -83,6 +83,7 @@
 /obj/effect/attach_point/crew_weapon
 	name = "crew compartment attach point"
 	base_category = DROPSHIP_CREW_WEAPON
+	plane = FLOOR_PLANE
 
 /obj/effect/attach_point/crew_weapon/dropship1
 	ship_tag = DROPSHIP_ALAMO


### PR DESCRIPTION
# About the pull request

Dropship attachment points for (medevac etc.)
No longer goes over weed and resin structure

# Explain why it's good for the game

![attachment points](https://github.com/cmss13-devs/cmss13/assets/43085828/6b60e7fe-7f74-4ced-b0ce-bc7c13ce5527)

# Changelog

:cl: ghostsheet
fix: Dropship attachment points now goes under weed and resin.
/:cl: