### PR TITLE
Fluff: Acid Runner BOOM Visual FX

### DIFF
--- a/code/game/objects/effects/effect_system/smoke.dm
+++ b/code/game/objects/effects/effect_system/smoke.dm
@@ -257,6 +257,17 @@
 	smokeranking = SMOKE_RANK_MED
 
 /////////////////////////////////////////
+// Acid Runner Smoke, Harmless Visuals only
+/////////////////////////////////////////
+/obj/effect/particle_effect/smoke/acid_runner_harmless
+	color = "#86B028"
+	time_to_live = 2
+	opacity = FALSE
+	alpha = 200
+	smokeranking = SMOKE_RANK_HARMLESS
+	amount = 0
+
+/////////////////////////////////////////
 // BOILER SMOKES
 /////////////////////////////////////////
 

--- a/code/modules/mob/living/carbon/xenomorph/mutators/strains/runner/acid.dm
+++ b/code/modules/mob/living/carbon/xenomorph/mutators/strains/runner/acid.dm
@@ -147,6 +147,8 @@
 			damage *= XVX_ACID_DAMAGEMULT
 
 		target_living.apply_damage(damage, BURN)
+	for(var/turf/T in view(bound_xeno, acid_range))
+		new /obj/effect/particle_effect/smoke/acid_runner_harmless(T)
 	playsound(bound_xeno, 'sound/effects/blobattack.ogg', 75)
 	if(bound_xeno.client && bound_xeno.hive)
 		addtimer(CALLBACK(bound_xeno.hive, TYPE_PROC_REF(/datum/hive_status, free_respawn), bound_xeno.client), 5 SECONDS)


### PR DESCRIPTION
# About the pull request

Added a harmless smoke cloud to Acid runner's Boom

# Explain why it's good for the game

This adds a much needed visual indication of where an Acid runner explodes, 
plus it gives it more PUNCH/feedback for the runner

The smoke is harmless, see-through, low alpha and disappears fast but it's more than enough to tell


# Testing Photographs and Procedure

Same Vid, take a look: https://streamable.com/ix63cp

https://github.com/cmss13-devs/cmss13/assets/43085828/484faa97-fe8b-46ac-8178-44d8345289f9

# Changelog

:cl: ghostsheet
add: Added a harmless smoke cloud to Acid Runner's "For the Hive" ability.
/:cl:
