### PR TITLE
Marine Major, Ares Announcement

### DIFF
--- a/code/game/gamemodes/colonialmarines/colonialmarines.dm
+++ b/code/game/gamemodes/colonialmarines/colonialmarines.dm
@@ -153,6 +153,11 @@
 		var/rendered_announce_text = replacetext(SSmapping.configs[GROUND_MAP].announce_text, "###SHIPNAME###", MAIN_SHIP_NAME)
 		marine_announcement(rendered_announce_text, "[MAIN_SHIP_NAME]")
 
+/datum/game_mode/colonialmarines/proc/ares_conclude()
+	var/name = "[MAIN_AI_SYSTEM] Bioscan Status"
+	var/input = "Bioscan complete.\n\nNo unknown lifeform signature detected.\n\nSaving operational report to archive.\nCommencing final systems scan in 2 minutes."
+	marine_announcement(input, name, 'sound/AI/bioscan.ogg')
+
 ////////////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////////////
 
@@ -288,6 +293,7 @@
 			else
 				SSticker.roundend_check_paused = TRUE
 				round_finished = MODE_INFESTATION_M_MAJOR //Humans destroyed the xenomorphs.
+				ares_conclude()
 				addtimer(VARSET_CALLBACK(SSticker, roundend_check_paused, FALSE), MARINE_MAJOR_ROUND_END_DELAY)
 		else if(!num_humans && !num_xenos)
 			round_finished = MODE_INFESTATION_DRAW_DEATH //Both were somehow destroyed.

--- a/code/game/gamemodes/colonialmarines/colonialmarines.dm
+++ b/code/game/gamemodes/colonialmarines/colonialmarines.dm
@@ -154,9 +154,9 @@
 		marine_announcement(rendered_announce_text, "[MAIN_SHIP_NAME]")
 
 /datum/game_mode/colonialmarines/proc/ares_conclude()
-	var/name = "[MAIN_AI_SYSTEM] Bioscan Status"
-	var/input = "Bioscan complete.\n\nNo unknown lifeform signature detected.\n\nSaving operational report to archive.\nCommencing final systems scan in 2 minutes."
-	marine_announcement(input, name, 'sound/AI/bioscan.ogg')
+	ai_silent_announcement("Bioscan complete. No unknown lifeform signature detected.", ".V")
+	ai_silent_announcement("Saving operational report to archive.", ".V")
+	ai_silent_announcement("Commencing final systems scan in 3 minutes.", ".V")
 
 ////////////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
# About the pull request

Adds an Ares Announcement when a marine major happens.

Adding onto Morrow's Cursed PR, blame Morrow for how he did it in #3118, not me

# Explain why it's good for the game

Currently marines don't know when they've won, therefore adding the 3 extra minutes is pointless as they spend that time hunting for a supposed last xeno that doesn't even exist.

With this Announcement, Marines will know they don't need to hunt the last xeno down anymore and can RP a conclusion and
Even award medals before the final Marine Major declaration happens.

# Testing Photographs and Procedure

![ARES conclusion 2](https://github.com/cmss13-devs/cmss13/assets/43085828/6a52a772-35d5-4f3a-9058-7e20ca9c85c1)

# Changelog

:cl: ghostsheet
add: Added ARES conclusion announcement for marine major.
/:cl:
