### PR TITLE
Canceling for the hive now resets its slowdown

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/runner/runner_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/runner/runner_powers.dm
@@ -194,16 +194,21 @@
 	X.say(";FOR THE HIVE!!!")
 
 /datum/action/xeno_action/activable/acider_for_the_hive/proc/cancel_ability()
-	var/mob/living/carbon/xenomorph/X = owner
+	var/mob/living/carbon/xenomorph/xeno = owner
 
-	if(!istype(X))
+	if(!istype(xeno))
 		return
-	var/datum/behavior_delegate/runner_acider/BD = X.behavior_delegate
-	if(!istype(BD))
+	var/datum/behavior_delegate/runner_acider/behavior = xeno.behavior_delegate
+	if(!istype(behavior))
 		return
 
-	BD.caboom_trigger = FALSE
-	X.color = null
-	X.SetLuminosity(0)
-	BD.modify_acid(-BD.max_acid / 4)
-	to_chat(X, SPAN_XENOWARNING("You remove all your explosive acid before it combusted."))
+	behavior.caboom_trigger = FALSE
+	xeno.color = null
+	xeno.SetLuminosity(0)
+	behavior.modify_acid(-behavior.max_acid / 4)
+
+	// Done this way rather than setting to 0 in case something else slowed us
+	// -Original amount set - (time exploding + timer inaccuracy) * how much gets removed per tick / 2
+	xeno.adjust_effect(behavior.caboom_timer * -2 - (behavior.caboom_timer - behavior.caboom_left + 2) * xeno.life_slow_reduction * 0.5, SUPERSLOW)
+
+	to_chat(xeno, SPAN_XENOWARNING("You remove all your explosive acid before it combusted."))


### PR DESCRIPTION
# About the pull request

This PR clears the slowdown effect applied when for the hive is canceled.

# Explain why it's good for the game

Though we probably want it to be punishing canceling a for the hive, it still costs acid so it can feel bugged if you remain slowed for 26-40 seconds depending on when you cancel the ability. Closes #3446 

# Changelog
:cl: Drathek
balance: Acid Runner's For the Hive ability now clears its slowdown effect when canceled
/:cl:
