### PR TITLE
Fix xenos not ending overwatch when target dies

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/XenoOverwatch.dm
+++ b/code/modules/mob/living/carbon/xenomorph/XenoOverwatch.dm
@@ -121,7 +121,7 @@
 // Called from xeno Life()
 // Makes sure that Xeno overwatch is reset when the overwatched Xeno dies.
 /mob/living/carbon/xenomorph/proc/handle_overwatch()
-	if (observed_xeno && (observed_xeno == DEAD || QDELETED(observed_xeno)))
+	if (observed_xeno && (observed_xeno.stat == DEAD || QDELETED(observed_xeno)))
 		overwatch(null, TRUE)
 
 /mob/living/carbon/xenomorph/proc/overwatch_handle_mob_move_or_look(mob/living/carbon/xenomorph/mover, actually_moving, direction, specific_direction)


### PR DESCRIPTION

# About the pull request

This PR fixes a logic error in code where non-queen xenos didn't properly test if their overwatched xeno was dead preventing the camera from resetting when they die.

# Explain why it's good for the game

Fixes #3445 

# Changelog
:cl: Drathek
fix: Fixed non-queen xeno overwatch persisting on a dead xeno
/:cl:
