### PR TITLE
Allows staff to use more non standard symbols in names

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -660,7 +660,7 @@ Parameters are passed from New.
 		SEND_SIGNAL(src, COMSIG_ATOM_VV_MODIFY_TRANSFORM)
 
 	if(href_list[VV_HK_AUTO_RENAME] && check_rights(R_VAREDIT))
-		var/newname = tgui_input_text(usr, "What do you want to rename this to?", "Automatic Rename", name)
+		var/newname = tgui_input_text(usr, "What do you want to rename this to?", "Automatic Rename", name, encode = FALSE)
 		if(newname)
 			name = newname
 


### PR DESCRIPTION
# About the pull request

removes encoding from another form of naming

# Changelog

:cl:
admin: Allows auto rename VV to not be encoded
/:cl: