### PR TITLE
Nurse intro description correction

### DIFF
--- a/code/game/jobs/job/civilians/support/nurse.dm
+++ b/code/game/jobs/job/civilians/support/nurse.dm
@@ -6,7 +6,7 @@
 	selection_class = "job_doctor"
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT
 	gear_preset = /datum/equipment_preset/uscm_ship/uscm_medical/nurse
-	entry_message_body = "<a href='"+URL_WIKI_NURSE_GUIDE+"'>You are tasked with keeping the Marines healthy and strong.</a> You are also an expert when it comes to medication and treatment, but you do not know anything about surgery. Focus on assisting doctors and triaging wounded marines."
+	entry_message_body = "<a href='"+URL_WIKI_NURSE_GUIDE+"'>You are tasked with keeping the Marines healthy and strong.</a> You are also an expert when it comes to medication and treatment, and can treat internal bleeds, but you do not know anything else about surgery. Focus on assisting doctors and triaging wounded marines."
 
 /obj/effect/landmark/start/nurse
 	name = JOB_NURSE

--- a/code/game/jobs/job/civilians/support/nurse.dm
+++ b/code/game/jobs/job/civilians/support/nurse.dm
@@ -6,7 +6,7 @@
 	selection_class = "job_doctor"
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT
 	gear_preset = /datum/equipment_preset/uscm_ship/uscm_medical/nurse
-	entry_message_body = "<a href='"+URL_WIKI_NURSE_GUIDE+"'>You are tasked with keeping the Marines healthy and strong.</a> You are also an expert when it comes to medication and treatment, and can treat internal bleeds, but you do not know anything else about surgery. Focus on assisting doctors and triaging wounded marines."
+	entry_message_body = "<a href='"+URL_WIKI_NURSE_GUIDE+"'>You are tasked with keeping the Marines healthy and strong.</a> You are also an expert when it comes to medication and treatment, and can do minor surgical procedures. Focus on assisting doctors and triaging wounded marines."
 
 /obj/effect/landmark/start/nurse
 	name = JOB_NURSE


### PR DESCRIPTION

Changes the wording of the intro desc for nurses as they can now do things such as fixing IB.

# Explain why it's good for the game

Corrects in game wording so that it is now up to date with a description of their abilities.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>
</details>

# Changelog

:cl:
fix: Corrected the nurse's starting descriptor in line with IB changes.
/:cl:
