### PR TITLE
Adaptive clientside zoom for pixel perfect display

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -328,8 +328,28 @@
 	apply_clickcatcher()
 	mob.reload_fullscreens()
 
-	if(prefs.auto_fit_viewport)
+	if(prefs.adaptive_zoom)
+		INVOKE_ASYNC(src, PROC_REF(adaptive_zoom))
+	else if(prefs.auto_fit_viewport)
 		INVOKE_ASYNC(src, .verb/fit_viewport)
+
+/client/proc/get_adaptive_zoom_factor()
+	if(!prefs.adaptive_zoom)
+		return 0
+	var/zoom = prefs.adaptive_zoom
+	if(view <= 8)
+		return zoom * 2
+	else if(view <= 15)
+		return zoom * 1
+	else
+		return 0
+
+/// Attempts to scale client zoom automatically to fill 1080p multiples. Best used with auto fit viewport.
+/client/proc/adaptive_zoom()
+	var/icon_size = world.icon_size * get_adaptive_zoom_factor()
+	winset(src, "mapwindow.map", "icon-size=[icon_size]")
+	if(prefs.auto_fit_viewport)
+		fit_viewport()
 
 /client/proc/create_clickcatcher()
 	if(!void)

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -191,7 +191,7 @@
 	var/aspect_ratio = view_size[1] / view_size[2]
 
 	var/desired_width = 0
-	var/sizes = params2list(winget(src, "mainwindow.split;mapwindow", "size"))
+	var/sizes = params2list(winget(src, "mainwindow.split;mapwindow;mainwindow", "size"))
 	var/map_size = splittext(sizes["mapwindow.size"], "x")
 
 	if(prefs.adaptive_zoom)
@@ -205,12 +205,15 @@
 		var/height = text2num(map_size[2])
 		desired_width = round(height * aspect_ratio)
 
+	var/split_size = splittext(sizes["mainwindow.split.size"], "x")
+	var/split_width = text2num(split_size[1])
+	// Always leave at least 240px of verb panel for the poor sod to switch back if they made a mistake
+	if(split_width - desired_width < 240)
+		desired_width = split_width - 240
+
 	if (text2num(map_size[1]) == desired_width)
 		// Nothing to do
 		return
-
-	var/split_size = splittext(sizes["mainwindow.split.size"], "x")
-	var/split_width = text2num(split_size[1])
 
 	// Calculate and apply a best estimate
 	// +4 pixels are for the width of the splitter's handle

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -190,11 +190,21 @@
 	var/view_size = getviewsize(view)
 	var/aspect_ratio = view_size[1] / view_size[2]
 
-	// Calculate desired pixel width using window size and aspect ratio
+	var/desired_width = 0
 	var/sizes = params2list(winget(src, "mainwindow.split;mapwindow", "size"))
 	var/map_size = splittext(sizes["mapwindow.size"], "x")
-	var/height = text2num(map_size[2])
-	var/desired_width = round(height * aspect_ratio)
+
+	if(prefs.adaptive_zoom)
+		// If using adaptive zoom, we directly use the intended horizontal map size to be pixel perfect
+		var/zoom_factor = get_adaptive_zoom_factor()
+		if(zoom_factor)
+			desired_width = view_size[1] * world.icon_size * zoom_factor + 4 // 4 pixels margin
+
+	if(!desired_width)
+		// Calculate desired pixel width using window size and aspect ratio
+		var/height = text2num(map_size[2])
+		desired_width = round(height * aspect_ratio)
+
 	if (text2num(map_size[1]) == desired_width)
 		// Nothing to do
 		return

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -53,6 +53,7 @@ var/const/MAX_SAVE_SLOTS = 10
 	var/be_special = 0 // Special role selection
 	var/toggle_prefs = TOGGLE_MIDDLE_MOUSE_CLICK|TOGGLE_DIRECTIONAL_ATTACK|TOGGLE_MEMBER_PUBLIC|TOGGLE_AMBIENT_OCCLUSION|TOGGLE_VEND_ITEM_TO_HAND // flags in #define/mode.dm
 	var/auto_fit_viewport = FALSE
+	var/adaptive_zoom = 0
 	var/UI_style = "midnight"
 	var/toggles_admin = TOGGLES_ADMIN_DEFAULT
 	var/toggles_chat = TOGGLES_CHAT_DEFAULT
@@ -571,6 +572,7 @@ var/const/MAX_SAVE_SLOTS = 10
 			dat += "<h2><b><u>Game Settings:</u></b></h2>"
 			dat += "<b>Ambient Occlusion:</b> <a href='?_src_=prefs;preference=ambientocclusion'><b>[toggle_prefs & TOGGLE_AMBIENT_OCCLUSION ? "Enabled" : "Disabled"]</b></a><br>"
 			dat += "<b>Fit Viewport:</b> <a href='?_src_=prefs;preference=auto_fit_viewport'>[auto_fit_viewport ? "Auto" : "Manual"]</a><br>"
+			dat += "<b>Adaptive Zoom:</b> <a href='?_src_=prefs;preference=adaptive_zoom'>[adaptive_zoom ? "[adaptive_zoom * 2]x" : "Disabled"]</a><br>"
 			dat += "<b>tgui Window Mode:</b> <a href='?_src_=prefs;preference=tgui_fancy'><b>[(tgui_fancy) ? "Fancy (default)" : "Compatible (slower)"]</b></a><br>"
 			dat += "<b>tgui Window Placement:</b> <a href='?_src_=prefs;preference=tgui_lock'><b>[(tgui_lock) ? "Primary monitor" : "Free (default)"]</b></a><br>"
 			dat += "<b>Play Admin Midis:</b> <a href='?_src_=prefs;preference=hear_midis'><b>[(toggles_sound & SOUND_MIDI) ? "Yes" : "No"]</b></a><br>"
@@ -1727,6 +1729,12 @@ var/const/MAX_SAVE_SLOTS = 10
 					auto_fit_viewport = !auto_fit_viewport
 					if(auto_fit_viewport && owner)
 						owner.fit_viewport()
+
+				if("adapative_zoom")
+					adaptive_zoom += 1
+					if(adaptive_zoom == 3)
+						adaptive_zoom = 0
+					owner?.adaptive_zoom()
 
 				if("inputstyle")
 					var/result = tgui_alert(user, "Which input style do you want?", "Input Style", list("Modern", "Legacy"))

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1730,7 +1730,7 @@ var/const/MAX_SAVE_SLOTS = 10
 					if(auto_fit_viewport && owner)
 						owner.fit_viewport()
 
-				if("adapative_zoom")
+				if("adaptive_zoom")
 					adaptive_zoom += 1
 					if(adaptive_zoom == 3)
 						adaptive_zoom = 0

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -191,6 +191,7 @@
 
 	S["custom_cursors"] >> custom_cursors
 	S["autofit_viewport"] >> auto_fit_viewport
+	S["adaptive_zoom"] >> adaptive_zoom
 
 	//Sanitize
 	ooccolor = sanitize_hexcolor(ooccolor, CONFIG_GET(string/ooc_color_default))
@@ -222,6 +223,7 @@
 	no_radials_preference = sanitize_integer(no_radials_preference, FALSE, TRUE, FALSE)
 	no_radial_labels_preference = sanitize_integer(no_radial_labels_preference, FALSE, TRUE, FALSE)
 	auto_fit_viewport = sanitize_integer(auto_fit_viewport, FALSE, TRUE, TRUE)
+	adaptive_zoom = sanitize_integer(adaptive_zoom, 0, 2, 0)
 
 	synthetic_name = synthetic_name ? sanitize_text(synthetic_name, initial(synthetic_name)) : initial(synthetic_name)
 	synthetic_type = sanitize_inlist(synthetic_type, PLAYER_SYNTHS, initial(synthetic_type))
@@ -358,6 +360,7 @@
 	S["hotkeys"] << hotkeys
 
 	S["autofit_viewport"] << auto_fit_viewport
+	S["adaptive_zoom"] << adaptive_zoom
 
 	S["hear_vox"] << hear_vox
 

--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -507,8 +507,28 @@
 	prefs.auto_fit_viewport = !prefs.auto_fit_viewport
 	if(prefs.auto_fit_viewport)
 		to_chat(src, SPAN_NOTICE("Now auto fitting viewport."))
+		fit_viewport()
 	else
 		to_chat(src, SPAN_NOTICE("No longer auto fitting viewport."))
+	prefs.save_preferences()
+
+/client/verb/toggle_adaptive_zooming()
+	set name = "Toggle Adaptive Zooming"
+	set category = "Preferences.UI"
+
+	switch(prefs.adaptive_zoom)
+		if(0)
+			prefs.adaptive_zoom = 1
+			to_chat(src, SPAN_BOLDNOTICE("Adaptive Zooming is now enabled, switching between x1 and x2 zoom. This is recommended for 1080p monitors."))
+			adaptive_zoom()
+		if(1)
+			prefs.adaptive_zoom = 2
+			to_chat(src, SPAN_BOLDNOTICE("Adaptive Zooming is now enabled, switching between x2 and x4 zoom."))
+			adaptive_zoom()
+		if(2)
+			prefs.adaptive_zoom = 0
+			to_chat(src, SPAN_BOLDNOTICE("Adaptive Zooming is now disabled."))
+			adaptive_zoom()
 	prefs.save_preferences()
 
 //------------ GHOST PREFERENCES ---------------------------------


### PR DESCRIPTION
# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

Have you never found weird that you basically have to enable "Stretch to Fit" mode in the game ?

The typical view range of (7*2+1) * 32 pixels is equal to 960 pixels. This is almost the height of a 1080p monitor. So why use Stretch to Fit? Where did my perfect pixel scaling go???

If you've ever had the fantasy to go pixel perfect and mess with 'Icons' menu at top of client, you probably noticed something: the moment you zoom through a scope or binoculars, the view range becomes 29x29 instead of 15x15. This, unsurprisingly, doesn't work well without stretching.

This PR introduces an (optional) automatic switch of client-side zoom to match changing view sizes. This means (by default) on 15x15 display icons will be x2 zoom to fit a 1080p screen, and 29x29 display will switch back to x1 zoom. This will display a small letterbox at top and bottom of screen in 1080p but be pixel perfect. It can also be toggled to double zoom size for bigger screens.

Because, as you might have noticed, 29 screen dimension is not double of 15 dimension, this is best used with Autofit feature, which was also modified to work together with it.

# Explain why it's good for the game
Less blurry sprites for those willing to lose a tiny bit of screen surface.


# Testing Photographs and Procedure
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

![image](https://github.com/cmss13-devs/cmss13/assets/604624/a4214ebd-6c62-4d72-928e-8d394c74fd85)

![image](https://github.com/cmss13-devs/cmss13/assets/604624/039aea97-7220-4853-8f1d-6318821fac2f)


# Changelog
:cl:
add: Added optional adaptive client zooming to match in-game zoom. This allows display to be pixel perfect on most monitors if enabled, it removes blurring of game introduced by Stretch to Fit mode, at the cost of slightly reduced vertical size. It is best used with Auto Fit viewport feature enabled.
/:cl:
