### PR TITLE
LV522 OB Changes

### DIFF
--- a/code/game/area/LV522_Chances_Claim.dm
+++ b/code/game/area/LV522_Chances_Claim.dm
@@ -409,10 +409,12 @@
 /area/lv522/atmos/east_reactor/north
 	name = "Atmospheric Processor - Outer East Reactor - North"
 	icon_state = "yellow"
+	ceiling = CEILING_UNDERGROUND_METAL_BLOCK_CAS
 
 /area/lv522/atmos/east_reactor/south
 	name = "Atmospheric Processor - Outer East Reactor - south"
 	icon_state = "red"
+	ceiling = CEILING_UNDERGROUND_METAL_BLOCK_CAS
 
 /area/lv522/atmos/east_reactor/south/cas
 	ceiling = CEILING_UNDERGROUND_METAL_BLOCK_CAS
@@ -420,10 +422,13 @@
 /area/lv522/atmos/east_reactor/east
 	name = "Atmospheric Processor - Outer East Reactor - east"
 	icon_state = "green"
+	ceiling = CEILING_UNDERGROUND_METAL_BLOCK_CAS
 
 /area/lv522/atmos/east_reactor/west
 	name = "Atmospheric Processor - Outer East Reactor - west"
 	icon_state = "purple"
+	ceiling = CEILING_UNDERGROUND_METAL_BLOCK_CAS
+
 /area/lv522/atmos/west_reactor
 	name = "Atmospheric Processor - Western Reactor"
 	icon_state = "blue"
@@ -441,6 +446,7 @@
 /area/lv522/atmos/north_command_centre
 	name = "Atmospheric Processor - North Command Centre Checkpoint"
 	icon_state = "green"
+	ceiling = CEILING_UNDERGROUND_METAL_BLOCK_CAS
 
 /area/lv522/atmos/filt
 	name = "Atmospheric Processor - Filtration System"


### PR DESCRIPTION

# About the pull request

This PR allows every area but the cylindrical hive areas to be OB'd.

# Explain why it's good for the game

Due to changes to the map you have to dive deep to some hive locations and it makes it incredibly difficult without effective OBs.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
balance: Made more areas in LV522 reactor OB-able
/:cl:
