### PR TITLE
Fix naming of Ext M4RA boxes from Black Market

### DIFF
--- a/code/modules/projectiles/ammo_boxes/magazine_boxes.dm
+++ b/code/modules/projectiles/ammo_boxes/magazine_boxes.dm
@@ -144,7 +144,7 @@
 	empty = TRUE
 
 /obj/item/ammo_box/magazine/m4ra/ext
-	name = "\improper magazine box (Ext M4RA x 16)"
+	name = "\improper magazine box (Ext M4RA x 12)"
 	overlay_ammo_type = "_ext"
 	num_of_magazines = 12
 	magazine_type = /obj/item/ammo_magazine/rifle/m4ra/ext


### PR DESCRIPTION
Self explanatory but very irky
