### PR TITLE
Overwatch Signals for QDEL: Less client disconnection?

### DIFF
--- a/code/game/machinery/computer/groundside_operations.dm
+++ b/code/game/machinery/computer/groundside_operations.dm
@@ -273,13 +273,17 @@
 					to_chat(usr, "[icon2html(src, usr)] [SPAN_WARNING("Searching for helmet cam. No helmet cam found for this marine! Tell your squad to put their helmets on!")]")
 				else if(cam && cam == new_cam)//click the camera you're watching a second time to stop watching.
 					visible_message("[icon2html(src, viewers(src))] [SPAN_BOLDNOTICE("Stopping helmet cam view of [cam_target].")]")
+					usr.UnregisterSignal(cam, COMSIG_PARENT_QDELETING)
 					cam = null
 					usr.reset_view(null)
 				else if(usr.client.view != world_view_size)
 					to_chat(usr, SPAN_WARNING("You're too busy peering through binoculars."))
 				else
+					if(cam)
+						usr.UnregisterSignal(cam, COMSIG_PARENT_QDELETING)
 					cam = new_cam
 					usr.reset_view(cam)
+					usr.RegisterSignal(cam, COMSIG_PARENT_QDELETING, TYPE_PROC_REF(/mob, reset_observer_view_on_deletion))
 
 		if("activate_echo")
 			var/reason = input(usr, "What is the purpose of Echo Squad?", "Activation Reason")
@@ -306,6 +310,8 @@
 	..()
 
 	if(!isRemoteControlling(user))
+		if(cam)
+			user.UnregisterSignal(cam, COMSIG_PARENT_QDELETING)
 		cam = null
 		user.reset_view(null)
 

--- a/code/modules/cm_marines/overwatch.dm
+++ b/code/modules/cm_marines/overwatch.dm
@@ -427,10 +427,10 @@
 					current_squad.send_squad_message("Attention. [ID ? "[ID.rank] ":""][operator ? "[operator.name]":"sysadmin"] is no longer your Overwatch officer. Overwatch functions deactivated.", displayed_icon = src)
 					visible_message("[icon2html(src, viewers(src))] [SPAN_BOLDNOTICE("Overwatch systems deactivated. Goodbye, [ID ? "[ID.rank] ":""][operator ? "[operator.name]":"sysadmin"].")]")
 			operator = null
+			current_squad = null
 			if(cam && !ishighersilicon(usr))
 				usr.reset_view(null)
 				usr.UnregisterSignal(cam, COMSIG_PARENT_QDELETING)
-			current_squad = null
 			cam = null
 			state = 0
 		if("pick_squad")

--- a/code/modules/cm_marines/overwatch.dm
+++ b/code/modules/cm_marines/overwatch.dm
@@ -427,9 +427,10 @@
 					current_squad.send_squad_message("Attention. [ID ? "[ID.rank] ":""][operator ? "[operator.name]":"sysadmin"] is no longer your Overwatch officer. Overwatch functions deactivated.", displayed_icon = src)
 					visible_message("[icon2html(src, viewers(src))] [SPAN_BOLDNOTICE("Overwatch systems deactivated. Goodbye, [ID ? "[ID.rank] ":""][operator ? "[operator.name]":"sysadmin"].")]")
 			operator = null
-			current_squad = null
 			if(cam && !ishighersilicon(usr))
 				usr.reset_view(null)
+				usr.UnregisterSignal(cam, COMSIG_PARENT_QDELETING)
+			current_squad = null
 			cam = null
 			state = 0
 		if("pick_squad")
@@ -593,13 +594,17 @@
 					to_chat(usr, "[icon2html(src, usr)] [SPAN_WARNING("Searching for helmet cam. No helmet cam found for this marine! Tell your squad to put their helmets on!")]")
 				else if(cam && cam == new_cam)//click the camera you're watching a second time to stop watching.
 					visible_message("[icon2html(src, viewers(src))] [SPAN_BOLDNOTICE("Stopping helmet cam view of [cam_target].")]")
+					usr.UnregisterSignal(cam, COMSIG_PARENT_QDELETING)
 					cam = null
 					usr.reset_view(null)
 				else if(usr.client.view != world_view_size)
 					to_chat(usr, SPAN_WARNING("You're too busy peering through binoculars."))
 				else
+					if(cam)
+						usr.UnregisterSignal(cam, COMSIG_PARENT_QDELETING)
 					cam = new_cam
 					usr.reset_view(cam)
+					usr.RegisterSignal(cam, COMSIG_PARENT_QDELETING, TYPE_PROC_REF(/mob, reset_observer_view_on_deletion))
 	attack_hand(usr) //The above doesn't ever seem to work.
 
 /obj/structure/machinery/computer/overwatch/check_eye(mob/user)
@@ -611,6 +616,8 @@
 /obj/structure/machinery/computer/overwatch/on_unset_interaction(mob/user)
 	..()
 	if(!isRemoteControlling(user))
+		if(cam)
+			user.UnregisterSignal(cam, COMSIG_PARENT_QDELETING)
 		cam = null
 		user.reset_view(null)
 

--- a/code/modules/mob/living/carbon/xenomorph/XenoOverwatch.dm
+++ b/code/modules/mob/living/carbon/xenomorph/XenoOverwatch.dm
@@ -123,7 +123,6 @@
 
 /mob/living/carbon/xenomorph/proc/overwatch_handle_deletion(mob/living/carbon/xenomorph/deleted, forced)
 	SIGNAL_HANDLER
-	UnregisterSignal(deleted, COMSIG_PARENT_QDELETING)
 	overwatch(deleted, TRUE)
 
 // Called from xeno Life()

--- a/code/modules/mob/living/carbon/xenomorph/XenoOverwatch.dm
+++ b/code/modules/mob/living/carbon/xenomorph/XenoOverwatch.dm
@@ -71,6 +71,7 @@
 
 		SEND_SIGNAL(src, COMSIG_XENO_STOP_OVERWATCH, oldXeno)
 		UnregisterSignal(src, COMSIG_MOB_MOVE_OR_LOOK)
+		UnregisterSignal(oldXeno, COMSIG_PARENT_QDELETING)
 
 		if(oldXeno)
 			to_chat(src, SPAN_XENOWARNING("You stop watching [oldXeno]."))
@@ -109,14 +110,21 @@
 			SEND_SIGNAL(src, COMSIG_XENO_STOP_OVERWATCH_XENO, oldXeno)
 			oldXeno.hud_set_queen_overwatch()
 			UnregisterSignal(src, COMSIG_MOB_MOVE_OR_LOOK)
+			UnregisterSignal(oldXeno, COMSIG_PARENT_QDELETING)
 
 		observed_xeno = targetXeno
 
 		observed_xeno.hud_set_queen_overwatch()
 		SEND_SIGNAL(src, COMSIG_XENO_OVERWATCH_XENO, observed_xeno)
 		RegisterSignal(src, COMSIG_MOB_MOVE_OR_LOOK, PROC_REF(overwatch_handle_mob_move_or_look))
+		RegisterSignal(observed_xeno, COMSIG_PARENT_QDELETING, PROC_REF(overwatch_handle_deletion))
 
 	src.reset_view()
+
+/mob/living/carbon/xenomorph/proc/overwatch_handle_deletion(mob/living/carbon/xenomorph/deleted, forced)
+	SIGNAL_HANDLER
+	UnregisterSignal(deleted, COMSIG_PARENT_QDELETING)
+	overwatch(deleted, TRUE)
 
 // Called from xeno Life()
 // Makes sure that Xeno overwatch is reset when the overwatched Xeno dies.

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -358,7 +358,6 @@
 
 /mob/proc/reset_observer_view_on_deletion(atom/deleted, force)
 	SIGNAL_HANDLER
-	UnregisterSignal(deleted, COMSIG_PARENT_QDELETING)
 	reset_view(null)
 
 /mob/proc/show_inv(mob/user)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -356,6 +356,10 @@
 		SEND_SIGNAL(client, COMSIG_CLIENT_RESET_VIEW, A)
 	return
 
+/mob/proc/reset_observer_view_on_deletion(atom/deleted, force)
+	SIGNAL_HANDLER
+	UnregisterSignal(deleted, COMSIG_PARENT_QDELETING)
+	reset_view(null)
 
 /mob/proc/show_inv(mob/user)
 	user.set_interaction(src)


### PR DESCRIPTION

# About the pull request

This PR is sort of a stab in the dark to fix #3444 by making marine and xeno overwatching register a signal for qdeletion to end the overwatch faster. The actual source of this issue is apparently that the multithreaded map tick beta has an issue with crashing clients, so the changes made in this PR don't need to be permanent if the effect isn't as desirable when the beta is fixed.

Locally testing has not been able to reproduce the problem, but I can confirm I do not get the momentary blank screen when overwatching something that gets deleted.

# Explain why it's good for the game

Hopefully no more (or less) client disconnections when overwatching something that gets deleted.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![qdel](https://github.com/cmss13-devs/cmss13/assets/76988376/2d9af325-3959-40ae-a36c-1fc8b2d950cf)

</details>

# Changelog
:cl: Drathek
fix: Clients should hopefully avoid disconnection when observing someone that is deleted.
/:cl:
