### PR TITLE
Update metatips.txt

### DIFF
--- a/strings/metatips.txt
+++ b/strings/metatips.txt
@@ -6,7 +6,7 @@ Communication, be it from a marine to a marine, a drone to the queen, or command
 As an alien or marine, be careful of the flank, regardless of if the push is going well or stalling out.
 Half of getting good is knowing to be aggressive. The other half is knowing when not to be aggressive.
 Alt-click a storage item to draw the last item in it (last non-weapon if it's a weapon belt). Middle-click a storage item to inmediately open it, and middle-click structures to attempt to vault them.
-Use "North, South, East, West" when referring to locations in-game rather than "up, down, left, right".
+Use "North, South, West, East" when referring to locations in-game rather than "up, down, left, right".
 You shouldn't ignore what your allies are up to. Sometimes they can be organizing a flank in hivemind/radio, sometimes they can be walking up behind you with a slug-loaded shotgun. Either way, it pays to be alert to what they're doing, as much to as what the enemies are.
 The Wiki (https://cm-ss13.com/wiki) is a very useful repository of information about the game, such as weapons, equipment, xenomorph castes and their strains. It may not be fully up to date the majority of the time, but the basics are usually accurate.
 As an observer, you may see how much remaining hijack time is left in the status panel.


### PR DESCRIPTION

# About the pull request

West is on the left and east is on the right and should be in the same order.

# Explain why it's good for the game

Many people have already confused west and east, and this tip did not help the cause. 

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

I didn't properly test it, sorry...

</details>


# Changelog
:cl:
spellcheck: direction tip now uses the correct order.
/:cl:
