### PR TITLE
fix damage taken fun fact

### DIFF
--- a/code/datums/statistics/random_facts/damage_fact.dm
+++ b/code/datums/statistics/random_facts/damage_fact.dm
@@ -1,6 +1,6 @@
 /datum/random_fact/damage
 	statistic_name = "damage"
-	statistic_verb = "did"
+	statistic_verb = "took"
 
 /datum/random_fact/damage/life_grab_stat(mob/fact_mob)
 	return fact_mob.life_damage_taken_total


### PR DESCRIPTION

# About the pull request

It's damage taken, not done.

# Explain why it's good for the game

It's correct and not misleading.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>
I DIDN'T TEST IT, SORRY!!!


# Changelog
:cl:
spellcheck: damage taken fun fact now correctly states that player "took" so many damage instead of "did".
/:cl:
