### PR TITLE
InfluxDB Job Occupation Graphing

### DIFF
--- a/code/__DEFINES/subsystems.dm
+++ b/code/__DEFINES/subsystems.dm
@@ -161,6 +161,7 @@
 #define SS_INIT_OBJECTIVES -31
 #define SS_INIT_LOBBYART   -33
 #define SS_INIT_MINIMAP    -34
+#define SS_INIT_INFLUXSTATS -50
 #define SS_INIT_STATPANELS -98
 #define SS_INIT_CHAT    -100 //Should be last to ensure chat remains smooth during init.
 #define SS_INIT_EARLYRUNTIMES -500 // Post-init notifier
@@ -217,6 +218,7 @@
 #define SS_PRIORITY_TRACKING    19
 #define SS_PRIORITY_MINIMAPS 11
 #define SS_PRIORITY_PING    10
+#define SS_PRIORITY_INFLUXSTATS 8
 #define SS_PRIORITY_DATABASE    15
 #define SS_PRIORITY_PLAYTIME    5
 #define SS_PRIORITY_PERFLOGGING 4

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -529,6 +529,12 @@ This maintains a list of ip addresses that are able to bypass topic filtering.
 
 /datum/config_entry/string/round_results_webhook_url
 
+/datum/config_entry/string/round_results_influxdb_host
+/datum/config_entry/string/round_results_influxdb_org
+/datum/config_entry/string/round_results_influxdb_token
+/datum/config_entry/string/round_results_influxdb_bucket
+/datum/config_entry/string/round_results_influxdb_period
+
 /// logs all timers in buckets on automatic bucket reset (Useful for timer debugging)
 /datum/config_entry/flag/log_timers_on_bucket_reset
 

--- a/code/controllers/subsystem/influxstats.dm
+++ b/code/controllers/subsystem/influxstats.dm
@@ -1,0 +1,88 @@
+SUBSYSTEM_DEF(influxstats)
+	name       = "InfluxDB Statistics"
+	wait       = 60 SECONDS
+	priority   = SS_PRIORITY_INFLUXSTATS
+	init_order = SS_INIT_INFLUXSTATS
+	runlevels  = RUNLEVEL_GAME
+	flags      = SS_KEEP_TIMING
+	var/sent   = 0
+
+/datum/controller/subsystem/influxstats/Initialize()
+	var/period = CONFIG_GET(string/round_results_influxdb_period)
+	if(isnum(period))
+		wait = max(period * (1 SECONDS), 5 SECONDS)
+	return SS_INIT_SUCCESS
+
+/datum/controller/subsystem/influxstats/stat_entry(msg)
+	msg += "sent=[sent]"
+	return ..()
+
+/datum/controller/subsystem/influxstats/fire(resumed)
+	var/host = CONFIG_GET(string/round_results_influxdb_host)
+	var/token = CONFIG_GET(string/round_results_influxdb_token)
+	var/bucket = CONFIG_GET(string/round_results_influxdb_bucket)
+	var/org = CONFIG_GET(string/round_results_influxdb_org)
+	if(!host || !token || !bucket || !org)
+		can_fire = FALSE
+		return
+	if(!SSticker.mode)
+		return // That shouldn't happen with runlevels
+
+	var/url = "[host]/api/v2/write?org=[org]&bucket=[bucket]&precision=s"
+	var/list/headers = list()
+	headers["Authorization"] = "Token [token]"
+	headers["Content-Type"] = "text/plain; charset=utf-8"
+	headers["Accept"] = "application/json"
+
+	var/measurement = "round_results,round_id=[GLOB.round_id]"
+	var/timestamp = big_number_to_text(rustg_unix_timestamp())
+	var/data = "round_time=[(ROUND_TIME)/(1 SECONDS)]"
+
+	var/list/job_stats_others = list(JOB_OBSERVER = 0)
+
+	var/list/job_stats_humans = list()
+	for(var/job in (ROLES_MARINES|ROLES_USCM|ROLES_SPECIAL))
+		job_stats_humans[job] = 0
+
+	var/list/job_stats_xenos = list()
+	for(var/job in ALL_XENO_CASTES)
+		job_stats_xenos[job] = 0
+
+	for(var/client/client in GLOB.clients)
+		if(!client?.mob)
+			continue
+		else if(isobserver(client.mob))
+			job_stats_others[JOB_OBSERVER] += 1
+		else if(isxeno(client.mob))
+			job_stats_xenos[client.mob.job] += 1
+		else if(client?.mob && client.mob.stat != DEAD)
+			job_stats_humans[client.mob.job] += 1
+
+	var/datum/http_request/req
+	var/list/measurements = list()
+
+	var/others_data = data
+	for(var/job in job_stats_others)
+		var/short_job = replacetext(sanitize(job), " ", "")
+		others_data += ",[short_job]=[job_stats_others[job]]"
+	measurements += "[measurement],team=others [others_data] [timestamp]"
+
+	var/humans_data = data
+	for(var/job in job_stats_humans)
+		var/short_job = replacetext(sanitize(job), " ", "")
+		humans_data += ",[short_job]=[job_stats_humans[job]]"
+	measurements += "[measurement],team=humans [humans_data] [timestamp]"
+
+	var/xenos_data = data
+	for(var/job in job_stats_xenos)
+		var/short_job = replacetext(sanitize(job), " ", "")
+		xenos_data += ",[short_job]=[job_stats_xenos[job]]"
+	measurements += "[measurement],team=xenos [xenos_data] [timestamp]"
+
+	req = new
+	var/payload = ""
+	for(var/line in measurements)
+		payload += "[line]\n"
+	req.prepare(RUSTG_HTTP_METHOD_POST, url, payload, headers)
+	req.begin_async()
+	sent++

--- a/code/controllers/subsystem/influxstats.dm
+++ b/code/controllers/subsystem/influxstats.dm
@@ -36,7 +36,7 @@ SUBSYSTEM_DEF(influxstats)
 
 	var/measurement = "round_results,round_id=[GLOB.round_id]"
 	var/timestamp = big_number_to_text(rustg_unix_timestamp())
-	var/data = "round_time=[(ROUND_TIME)/(1 SECONDS)]"
+	var/data = ""
 
 	var/list/job_stats_others = list(JOB_OBSERVER = 0)
 

--- a/code/controllers/subsystem/influxstats.dm
+++ b/code/controllers/subsystem/influxstats.dm
@@ -40,7 +40,10 @@ SUBSYSTEM_DEF(influxstats)
 
 	for(var/client/client in GLOB.clients)
 		var/mob/mob = client.mob
-		if(!mob)
+		if(!mob || mob.statistic_exempt)
+			continue
+		var/area/area = get_ara(mob)
+		if(!area || area.statistic_exempt)
 			continue
 		var/job = mob.job
 		var/team

--- a/code/controllers/subsystem/influxstats.dm
+++ b/code/controllers/subsystem/influxstats.dm
@@ -42,7 +42,7 @@ SUBSYSTEM_DEF(influxstats)
 		var/mob/mob = client.mob
 		if(!mob || mob.statistic_exempt)
 			continue
-		var/area/area = get_ara(mob)
+		var/area/area = get_area(mob)
 		if(!area || area.statistic_exempt)
 			continue
 		var/job = mob.job

--- a/colonialmarines.dme
+++ b/colonialmarines.dme
@@ -239,6 +239,7 @@
 #include "code\controllers\subsystem\htmlui.dm"
 #include "code\controllers\subsystem\human.dm"
 #include "code\controllers\subsystem\inactivity.dm"
+#include "code\controllers\subsystem\influxstats.dm"
 #include "code\controllers\subsystem\input.dm"
 #include "code\controllers\subsystem\interior.dm"
 #include "code\controllers\subsystem\item_cleanup.dm"


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

Adds InfluxDB support to job statistics, as an alternative to Discord Webhooks.

This doesn't sent event markers such as Round Start, First Drop, etc, because they're not metrics. Logging / ElasitcSearch would be better suited to that.

No code reuse here, the Subsystem does its own count due to much higher frequency of measurements (10-60 seconds VS 10 minutes interval)

# Explain why it's good for the game
Allows graphing of job occupations per round, including breakdown by team (humans vs xenos), and indexed by round_id. This allows for aggregations that will let us easily see which jobs are occupied over longer periods of time, contrary to the discord webhooks which are hard to reuse.

# Testing Photographs and Procedure
![image](https://github.com/cmss13-devs/cmss13/assets/604624/1ee16e34-5cbd-4f1b-b888-c360d2eddac3)

# Changelog
:cl:
add: Added support of logging of job occupations via InfluxDB.
/:cl:
