### PR TITLE
Fixes xeno trackers on some maps

### DIFF
--- a/code/game/area/IceColony.dm
+++ b/code/game/area/IceColony.dm
@@ -46,7 +46,6 @@
 
 /area/ice_colony/exterior/surface
 	name = "\improper Ice Colony - Exterior Surface"
-	fake_zlevel = 1 // above ground
 	soundscape_playlist = SCAPE_PL_WIND
 
 //Equivalent of space. None of this area should be accessible. If these are valleys, make separate areas
@@ -153,7 +152,6 @@
 	name = "\improper Ice Colony - Exterior Underground"
 	icon_state = "cave"
 	ceiling = CEILING_DEEP_UNDERGROUND
-	fake_zlevel = 2 // underground
 	ambience_exterior = null
 //
 // Caves
@@ -189,7 +187,6 @@
 	name = "\improper Ice Colony - Built Surface"
 	icon_state = "clear"
 	ceiling = CEILING_METAL
-	fake_zlevel = 1 // above ground
 
 /*
  * Surface - Bar
@@ -485,7 +482,6 @@
 	name = "\improper Ice Colony - Built Underground"
 	icon_state = "explored"
 	ceiling = CEILING_DEEP_UNDERGROUND_METAL
-	fake_zlevel = 2 // underground
 	ambience_exterior = AMBIENCE_ALMAYER
 	ceiling_muffle = FALSE
 	sound_environment = SOUND_ENVIRONMENT_ROOM

--- a/code/game/area/strata.dm
+++ b/code/game/area/strata.dm
@@ -27,16 +27,9 @@ EXTERIOR is FUCKING FREEZING, and refers to areas out in the open and or exposed
 	lighting_use_dynamic = 0
 	minimap_color = MINIMAP_AREA_LZ
 
-
-/*A WHOLE BUNCH OF PARENT ENTITIES
-fake_zlevel = 1 or 2. 1 is 'above' 2 is 'below', however ladders are flipped and think that 1 is below, and 2 is above.
-But, players don't actually care where they are so long as the ladders look correct going up and down. They shouldn't notice.
-However, this might break the tacmap. This entire system might be replaced by Slywater's fake-Z smooth transition anyway.*/
-
 /area/strata/ag
 	name = "Above Ground Area"
 	icon_state = "ag"
-	fake_zlevel = 1 //'Above' ground fake Z
 
 /area/strata/ag/exterior
 	name = "Exterior Above Ground Area"
@@ -67,7 +60,6 @@ However, this might break the tacmap. This entire system might be replaced by Sl
 /area/strata/ug
 	name = "Under Ground Area"
 	icon_state = "ug"
-	fake_zlevel = 2 //'Underground', because numbers are fun
 	ceiling = CEILING_UNDERGROUND_ALLOW_CAS
 
 /area/strata/ug/interior


### PR DESCRIPTION

# About the pull request

Old fake_z_level variables set in areas on some ground maps which seems to be leftover code no longer used correctly.

Removed should allow for trackers to work correctly from area to area.

# Explain why it's good for the game

Bug/old unused stuff bad

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
fix: Fixed xeno trackers on some maps
/:cl:
