### PR TITLE
Resin walls kill nodes under them

### DIFF
--- a/code/game/turfs/walls/wall_types.dm
+++ b/code/game/turfs/walls/wall_types.dm
@@ -702,6 +702,12 @@
 	var/datum/cause_data/construction_data
 	flags_turf = TURF_ORGANIC
 
+/turf/closed/wall/resin/Initialize(mapload)
+	. = ..()
+
+	for(var/obj/effect/alien/weeds/node/weed_node in loc)
+		qdel(weed_node)
+
 /turf/closed/wall/resin/pillar
 	name = "resin pillar segment"
 	hull = TRUE

--- a/code/game/turfs/walls/wall_types.dm
+++ b/code/game/turfs/walls/wall_types.dm
@@ -705,7 +705,7 @@
 /turf/closed/wall/resin/Initialize(mapload)
 	. = ..()
 
-	for(var/obj/effect/alien/weeds/node/weed_node in loc)
+	for(var/obj/effect/alien/weeds/node/weed_node in contents)
 		qdel(weed_node)
 
 /turf/closed/wall/resin/pillar


### PR DESCRIPTION
# About the pull request

This PR removes resin nodes when a resin wall is placed on them.

Fixes #1330 

# Explain why it's good for the game

Resin walls should not be being used as shields for resin nodes.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: Morrow
balance: Placed resin walls now destroy nodes underneath them.
/:cl:
