### PR TITLE
Enables the use of arrival message announcements.

### DIFF
--- a/code/datums/emergency_calls/big_game_hunter.dm
+++ b/code/datums/emergency_calls/big_game_hunter.dm
@@ -10,7 +10,7 @@
 
 /datum/emergency_call/van_bandolier/New()
 	. = ..()
-	arrival_message = "Incoming Transmission: 'Heard your distress call, [MAIN_SHIP_NAME]. It had best be something which will look good on my wall, eh? Tally ho!'"
+	arrival_message = "'Heard your distress call, [MAIN_SHIP_NAME]. It had best be something which will look good on my wall, eh? Tally ho!'"
 
 /datum/emergency_call/van_bandolier/create_member(datum/mind/M, turf/override_spawn_loc)
 	var/turf/spawn_loc = override_spawn_loc ? override_spawn_loc : get_spawn_point()

--- a/code/datums/emergency_calls/clf.dm
+++ b/code/datums/emergency_calls/clf.dm
@@ -4,7 +4,7 @@
 /datum/emergency_call/clf
 	name = "Colonial Liberation Front (Squad)"
 	mob_max = 10
-	arrival_message = "Incoming Transmission: 'Attention, you are tresspassing on our soverign territory. Expect no forgiveness.'"
+	arrival_message = "'Attention, you are tresspassing on our soverign territory. Expect no forgiveness.'"
 	objectives = "Assault the USCM, and sabotage as much as you can. Ensure any survivors escape in your custody."
 	probability = 20
 	hostility = TRUE

--- a/code/datums/emergency_calls/cmb.dm
+++ b/code/datums/emergency_calls/cmb.dm
@@ -112,7 +112,7 @@
 
 /datum/emergency_call/cmb/anchorpoint/New()
 	..()
-	arrival_message = "Incoming Transmission: [MAIN_SHIP_NAME], this is Anchorpoint Station. Be advised, a QRF Team of our Colonial Marines is currently attempting to board you. Open your ports, transmitting docking codes now. Standby."
+	arrival_message = "[MAIN_SHIP_NAME], this is Anchorpoint Station. Be advised, a QRF Team of our Colonial Marines is currently attempting to board you. Open your ports, transmitting docking codes now. Standby."
 	objectives = "QRF Team. You are here to reinforce the cmb team we deployed earlier. Make contact and work with the CMB Marshal and their deputies. Facilitate their protection and evacuation if necessary. Secondary Objective: Investigate the reason for distress aboard the [MAIN_SHIP_NAME], and assist the crew if possible."
 
 /datum/emergency_call/cmb/anchorpoint/create_member(datum/mind/M, turf/override_spawn_loc)

--- a/code/datums/emergency_calls/colonist.dm
+++ b/code/datums/emergency_calls/colonist.dm
@@ -5,7 +5,7 @@
 	name = "Colonists"
 	mob_max = 8
 	mob_min = 1
-	arrival_message = "Incoming Transmission: 'This is the *static*. We are *static*.'"
+	arrival_message = "'This is the *static*. We are *static*.'"
 	objectives = "Follow the orders given to you."
 	probability = 0
 	var/preset = /datum/equipment_preset/colonist

--- a/code/datums/emergency_calls/deathsquad.dm
+++ b/code/datums/emergency_calls/deathsquad.dm
@@ -6,7 +6,7 @@
 	name = "Weyland Whiteout Operators"
 	mob_max = 8
 	mob_min = 5
-	arrival_message = "Intercepted Transmission: '!`2*%slau#*jer t*h$em a!l%. le&*ve n(o^ w&*nes%6es.*v$e %#d ou^'"
+	arrival_message = "'!`2*%slau#*jer t*h$em a!l%. le&*ve n(o^ w&*nes%6es.*v$e %#d ou^'"
 	objectives = "Whiteout protocol is in effect for the target. Ensure there are no traces of the infestation or any witnesses."
 	probability = 0
 	shuttle_id = "Distress_PMC"

--- a/code/datums/emergency_calls/deus_vult.dm
+++ b/code/datums/emergency_calls/deus_vult.dm
@@ -5,7 +5,7 @@
 	mob_max = 35
 	mob_min = 10
 	max_heavies = 10
-	arrival_message = "Intercepted Transmission: 'Deus le volt. Deus le volt! DEUS LE VOLT!!'"
+	arrival_message = "'Deus le volt. Deus le volt! DEUS LE VOLT!!'"
 	objectives = "Clense the place of all that is unholy! Die in glory!"
 	probability = 0
 	hostility = TRUE

--- a/code/datums/emergency_calls/dutch.dm
+++ b/code/datums/emergency_calls/dutch.dm
@@ -9,7 +9,7 @@
 	max_heavies = 1
 	max_medics = 1
 
-	arrival_message = "Intercepted Transmission: 'We're here to kick ass and kill Yautja. Mainly kill Yautja."
+	arrival_message = "'We're here to kick ass and kill Yautja. Mainly kill Yautja."
 	objectives = "Hunt down and kill all Yautja without mercy. Retrieve the gear and leave."
 	probability = 0
 
@@ -44,6 +44,6 @@
 	mob_min = 8
 	max_heavies = 2
 	max_medics = 2
-	arrival_message = "Intercepted Transmission: 'We're here to kick ass and kill Yautja. Mainly kill Yautja."
+	arrival_message = "'We're here to kick ass and kill Yautja. Mainly kill Yautja."
 	objectives = "Hunt down and kill all Yautja without mercy. Retrieve the gear and leave."
 	probability = 0

--- a/code/datums/emergency_calls/emergency_call.dm
+++ b/code/datums/emergency_calls/emergency_call.dm
@@ -292,6 +292,8 @@
 			create_member(null, override_spawn_loc)
 
 	candidates = list()
+	if(arrival_message && announce)
+		marine_announcement(arrival_message, "Intercepted Tranmission:")
 
 /datum/emergency_call/proc/add_candidate(mob/M)
 	if(!M.client || (M.mind && (M.mind in candidates)) || istype(M, /mob/living/carbon/xenomorph))

--- a/code/datums/emergency_calls/hefa_knight.dm
+++ b/code/datums/emergency_calls/hefa_knight.dm
@@ -3,7 +3,7 @@
 	name = "HEFA knights"
 	mob_max = 15
 	mob_min = 3
-	arrival_message = "Intercepted Transmission: 'Prepaerth to surrender thine HEFAs unto the order!'"
+	arrival_message = "'Prepaerth to surrender thine HEFAs unto the order!'"
 	objectives = "You are a Brother of the Order of HEFA! You and your fellow brothers must retrieve as many HEFAs as possible!"
 	probability = 0
 	hostility = TRUE

--- a/code/datums/emergency_calls/inspection.dm
+++ b/code/datums/emergency_calls/inspection.dm
@@ -183,7 +183,7 @@
 
 /datum/emergency_call/inspection_cmb/New()
 	..()
-	arrival_message = "Incoming Transmission: [MAIN_SHIP_NAME], This is Anchorpoint Station with the Colonial Marshal Bureau. Be advised, a CMB transport vessel is preparing to board you, submitting Federal docking clearances now. Standby."
+	arrival_message = "[MAIN_SHIP_NAME], This is Anchorpoint Station with the Colonial Marshal Bureau. Be advised, a CMB transport vessel is preparing to board you, submitting Federal docking clearances now. Standby."
 	objectives = "Get your instructions from the CMB Office at Anchorpoint Station, and carry out your orders. Ensure that Colonial assets are safe and in your custody. Do not enforce or override Marine Law on a Marine Ship unless requested, as it's outside of your juristiction."
 
 	will_spawn_icc_liaison = prob(90)

--- a/code/datums/emergency_calls/pirates.dm
+++ b/code/datums/emergency_calls/pirates.dm
@@ -4,7 +4,7 @@
 	name = "Fun - Pirates"
 	mob_max = 35
 	mob_min = 10
-	arrival_message = "Intercepted Transmission: 'What shall we do with a drunken sailor? What shall we do with a drunken sailor? What shall we do with a drunken sailor early in the morning?'"
+	arrival_message = "'What shall we do with a drunken sailor? What shall we do with a drunken sailor? What shall we do with a drunken sailor early in the morning?'"
 	objectives = "Pirate! Loot! Ransom!"
 	probability = 0
 	hostility = TRUE

--- a/code/datums/emergency_calls/pizza.dm
+++ b/code/datums/emergency_calls/pizza.dm
@@ -4,7 +4,7 @@
 	name = "Pizza Delivery"
 	mob_max = 1
 	mob_min = 1
-	arrival_message = "Incoming Transmission: 'That'll be... sixteen orders of cheesy fries, eight large double topping pizzas, nine bottles of Four Loko... hello? Is anyone on this ship? Your pizzas are getting cold.'"
+	arrival_message = "'That'll be... sixteen orders of cheesy fries, eight large double topping pizzas, nine bottles of Four Loko... hello? Is anyone on this ship? Your pizzas are getting cold.'"
 	objectives = "Make sure you get a tip!"
 	shuttle_id = "Distress_Small"
 	name_of_spawn = /obj/effect/landmark/ert_spawns/distress_pizza

--- a/code/datums/emergency_calls/souto.dm
+++ b/code/datums/emergency_calls/souto.dm
@@ -4,7 +4,7 @@
 	name = "Souto Man"
 	mob_max = 1
 	mob_min = 1
-	arrival_message = "Incoming Transmission: Give a round of applause for the marine who sent in ten-thousand Souto tabs to get me here! USS Almayer, Souto Man's here to party with YOU!"
+	arrival_message = "Give a round of applause for the marine who sent in ten-thousand Souto tabs to get me here! USS Almayer, Souto Man's here to party with YOU!"
 	objectives = "Party like it's 1999!"
 	probability = 0
 

--- a/code/datums/emergency_calls/xeno_cultists.dm
+++ b/code/datums/emergency_calls/xeno_cultists.dm
@@ -2,7 +2,7 @@
 /datum/emergency_call/xeno_cult
 	name = "Xeno Cultists"
 	mob_max = 6
-	arrival_message = "Incoming Transmission: 'Ia! Ia!'"
+	arrival_message = "'Ia! Ia!'"
 	objectives = "Support the Xenomorphs in any way, up to and including giving your life for them!"
 	probability = 0
 	hostility = TRUE


### PR DESCRIPTION

# About the pull request
Fixes #3377. We can add different titles for the message announcements in the future if we'd like.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Fixes an oversight, and there's tons of flavor messages being wasted.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: ERTs now use their arrivals messages.
/:cl:
