### PR TITLE
Nerfs lurker pounce movement and adds a cooldown for headbite.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/lurker/lurker_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/lurker/lurker_abilities.dm
@@ -29,21 +29,7 @@
 			if (istype(LIA))
 				LIA.invisibility_off()
 
-/datum/action/xeno_action/activable/pounce/lurker/additional_effects(mob/living/L)
-	var/mob/living/carbon/xenomorph/X = owner
-	if (!istype(X))
-		return
 
-	if (X.mutation_type == LURKER_NORMAL)
-		RegisterSignal(X, COMSIG_XENO_SLASH_ADDITIONAL_EFFECTS_SELF, PROC_REF(remove_freeze), TRUE) // Suppresses runtime ever we pounce again before slashing
-
-/datum/action/xeno_action/activable/pounce/lurker/proc/remove_freeze(mob/living/carbon/xenomorph/X)
-	SIGNAL_HANDLER
-
-	var/datum/behavior_delegate/lurker_base/BD = X.behavior_delegate
-	if (istype(BD))
-		UnregisterSignal(X, COMSIG_XENO_SLASH_ADDITIONAL_EFFECTS_SELF)
-		end_pounce_freeze()
 
 /datum/action/xeno_action/onclick/lurker_invisibility
 	name = "Turn Invisible"
@@ -116,4 +102,4 @@
 	macro_path = /datum/action/xeno_action/verb/verb_headbite
 	ability_primacy = XENO_PRIMARY_ACTION_4
 	action_type = XENO_ACTION_CLICK
-	xeno_cooldown = 0 SECONDS
+	xeno_cooldown = 10 SECONDS

--- a/code/modules/mob/living/carbon/xenomorph/abilities/lurker/lurker_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/lurker/lurker_abilities.dm
@@ -29,7 +29,21 @@
 			if (istype(LIA))
 				LIA.invisibility_off()
 
+/datum/action/xeno_action/activable/pounce/lurker/additional_effects(mob/living/L)
+	var/mob/living/carbon/xenomorph/X = owner
+	if (!istype(X))
+		return
 
+	if (X.mutation_type == LURKER_NORMAL)
+		RegisterSignal(X, COMSIG_XENO_SLASH_ADDITIONAL_EFFECTS_SELF, PROC_REF(remove_freeze), TRUE) // Suppresses runtime ever we pounce again before slashing
+
+/datum/action/xeno_action/activable/pounce/lurker/proc/remove_freeze(mob/living/carbon/xenomorph/X)
+	SIGNAL_HANDLER
+
+	var/datum/behavior_delegate/lurker_base/BD = X.behavior_delegate
+	if (istype(BD))
+		UnregisterSignal(X, COMSIG_XENO_SLASH_ADDITIONAL_EFFECTS_SELF)
+		end_pounce_freeze()
 
 /datum/action/xeno_action/onclick/lurker_invisibility
 	name = "Turn Invisible"

--- a/code/modules/mob/living/carbon/xenomorph/abilities/lurker/lurker_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/lurker/lurker_powers.dm
@@ -308,4 +308,5 @@
 	xeno.flick_heal_overlay(3 SECONDS, "#00B800")
 	xeno.emote("roar")
 	log_attack("[key_name(xeno)] was executed by [key_name(target_carbon)] with a headbite!")
+	apply_cooldown()
 	return TRUE


### PR DESCRIPTION
# About the pull request
I removed the fact that slashing as lurker allows you to move immediately after pouncing someone while in cloak, and headbite now has a 10 second CD. Both of these things have balance approval from Morrow.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
The free movement thing was kind of ridicilous and headbite is an ability that seriously hurts whoever you use it against, so having a CD makes sense.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: Headbite has a 10 second cooldown.
/:cl:
