### PR TITLE
fix xenos being able to build over tunnels

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
@@ -434,6 +434,9 @@
 		if(istype(O, /obj/structure/fence))
 			has_obstacle = TRUE
 			break
+		if(istype(O, /obj/structure/tunnel))
+			has_obstacle = TRUE
+			break
 		if(istype(O, /obj/structure/bed))
 			if(istype(O, /obj/structure/bed/chair/dropship/passenger))
 				var/obj/structure/bed/chair/dropship/passenger/P = O


### PR DESCRIPTION

# About the pull request

xenos shouldnt be able to hide tunnels by building walls over them
fixes #3483 

# Explain why it's good for the game

fix good


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:Khadd
fix: fix xenos being able to build over tunnels
/:cl:
