### PR TITLE
fixes sandbags being fully built with just one bag

### DIFF
--- a/code/game/objects/structures/barricade/sandbags.dm
+++ b/code/game/objects/structures/barricade/sandbags.dm
@@ -90,7 +90,7 @@
 		user.visible_message(SPAN_NOTICE("[user] starts adding more [SB] to [src]."), \
 			SPAN_NOTICE("You start adding sandbags to [src]."))
 		for(var/i = build_stage to BARRICADE_SANDBAG_5)
-			if(build_stage >= BARRICADE_SANDBAG_5 || !do_after(user, 5, INTERRUPT_NO_NEEDHAND, BUSY_ICON_FRIENDLY, src) || build_stage >= BARRICADE_SANDBAG_5)
+			if(build_stage >= BARRICADE_SANDBAG_5 || !do_after(user, 5, INTERRUPT_NO_NEEDHAND, BUSY_ICON_FRIENDLY, src) || build_stage >= BARRICADE_SANDBAG_5 || SB.amount == 0)
 				break
 			SB.use(1)
 			increment_build_stage()


### PR DESCRIPTION

# About the pull request

sandbags no longer get built up to the max stage from just a singular sandbag
fixes #3492 

# Explain why it's good for the game

fix good


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:Khadd
fix: sandbags cant be fully built up with just one bag anymore
/:cl:
