### PR TITLE
Automatic forsaken spawns groundside during hijack

### DIFF
--- a/code/__DEFINES/cooldowns.dm
+++ b/code/__DEFINES/cooldowns.dm
@@ -1,6 +1,7 @@
 #define COOLDOWN_MOB_AUDIO "mob_audio_cooldown"
 #define COOLDOWN_IDLOCK_TEXTALERT "mob_idlock_textalert"
 #define COOLDOWN_HIJACK_BARRAGE "gamemode_explosive_barrage"
+#define COOLDOWN_HIJACK_GROUND_CHECK "gamemode_ground_check"
 #define COOLDOWN_ITEM_HOOD_SOUND "item_hood_sound"
 
 //Define for ship alt

--- a/code/datums/emergency_calls/forsaken_xenos.dm
+++ b/code/datums/emergency_calls/forsaken_xenos.dm
@@ -12,13 +12,13 @@
 		//drop some weeds for xeno plasma regen.
 		new /obj/effect/alien/weeds/node/forsaken(drop_spawn)
 
-/datum/emergency_call/forsaken_xenos/create_member(datum/mind/M, turf/override_spawn_loc)
+/datum/emergency_call/forsaken_xenos/create_member(datum/mind/new_member, turf/override_spawn_loc)
 	var/turf/spawn_loc = override_spawn_loc ? override_spawn_loc : get_spawn_point()
 
 	if(!istype(spawn_loc))
 		return //Didn't find a useable spawn point.
 
-	var/mob/current_mob = M.current
+	var/mob/current_mob = new_member.current
 
 	var/picked
 	var/mob/living/carbon/xenomorph/new_xeno
@@ -30,7 +30,7 @@
 
 	new_xeno = new picked(spawn_loc)
 
-	M.transfer_to(new_xeno, TRUE)
+	new_member.transfer_to(new_xeno, TRUE)
 
 	new_xeno.set_hive_and_update(XENO_HIVE_FORSAKEN)
 	new_xeno.lock_evolve = TRUE

--- a/code/datums/emergency_calls/forsaken_xenos.dm
+++ b/code/datums/emergency_calls/forsaken_xenos.dm
@@ -33,7 +33,7 @@
 		picked = pick(/mob/living/carbon/xenomorph/drone, /mob/living/carbon/xenomorph/runner)
 
 	new_xeno = new picked(spawn_loc)
-	new_xeno.lock_evolve = FALSE
+	new_xeno.lock_evolve = TRUE
 
 	M.transfer_to(new_xeno, TRUE)
 	new_xeno.set_hive_and_update(XENO_HIVE_FORSAKEN)

--- a/code/datums/emergency_calls/forsaken_xenos.dm
+++ b/code/datums/emergency_calls/forsaken_xenos.dm
@@ -2,7 +2,7 @@
 /datum/emergency_call/forsaken_xenos
 	name = "Xenomorphs Groundside (Forsaken)"
 	mob_min = 1
-	mob_max = 3
+	mob_max = 4
 	hostility = TRUE
 	name_of_spawn = /obj/effect/landmark/ert_spawns/groundside_xeno
 

--- a/code/datums/emergency_calls/forsaken_xenos.dm
+++ b/code/datums/emergency_calls/forsaken_xenos.dm
@@ -1,13 +1,9 @@
-
 /datum/emergency_call/forsaken_xenos
 	name = "Xenomorphs Groundside (Forsaken)"
 	mob_min = 1
 	mob_max = 4
 	hostility = TRUE
 	name_of_spawn = /obj/effect/landmark/ert_spawns/groundside_xeno
-
-/datum/emergency_call/forsaken_xenos/New()
-	..()
 	objectives = "You have been left behind to safeguard the abandoned colony. Do not allow trespassers."
 
 /datum/emergency_call/forsaken_xenos/spawn_items()

--- a/code/datums/emergency_calls/forsaken_xenos.dm
+++ b/code/datums/emergency_calls/forsaken_xenos.dm
@@ -1,0 +1,41 @@
+
+/datum/emergency_call/forsaken_xenos
+	name = "Xenomorphs Groundside (Forsaken)"
+	mob_min = 1
+	mob_max = 3
+	hostility = TRUE
+	name_of_spawn = /obj/effect/landmark/ert_spawns/groundside_xeno
+
+/datum/emergency_call/forsaken_xenos/New()
+	..()
+	objectives = "You have been left behind to safeguard the abandoned colony. Do not allow trespassers."
+
+/datum/emergency_call/forsaken_xenos/spawn_items()
+	var/turf/drop_spawn = get_spawn_point(TRUE)
+	if(istype(drop_spawn))
+		//drop some weeds for xeno plasma regen.
+		new /obj/effect/alien/weeds/node/forsaken(drop_spawn)
+
+/datum/emergency_call/forsaken_xenos/create_member(datum/mind/M, turf/override_spawn_loc)
+	var/turf/spawn_loc = override_spawn_loc ? override_spawn_loc : get_spawn_point()
+
+	if(!istype(spawn_loc))
+		return //Didn't find a useable spawn point.
+
+	var/mob/current_mob = M.current
+
+	var/picked
+	var/mob/living/carbon/xenomorph/new_xeno
+	if(!leader)
+		picked = pick(/mob/living/carbon/xenomorph/warrior, /mob/living/carbon/xenomorph/lurker, /mob/living/carbon/xenomorph/spitter)
+		leader = new_xeno
+	else
+		picked = pick(/mob/living/carbon/xenomorph/drone, /mob/living/carbon/xenomorph/runner)
+
+	new_xeno = new picked(spawn_loc)
+	new_xeno.lock_evolve = FALSE
+
+	M.transfer_to(new_xeno, TRUE)
+	new_xeno.set_hive_and_update(XENO_HIVE_FORSAKEN)
+
+	QDEL_NULL(current_mob)

--- a/code/datums/emergency_calls/forsaken_xenos.dm
+++ b/code/datums/emergency_calls/forsaken_xenos.dm
@@ -29,9 +29,10 @@
 		picked = pick(/mob/living/carbon/xenomorph/drone, /mob/living/carbon/xenomorph/runner)
 
 	new_xeno = new picked(spawn_loc)
-	new_xeno.lock_evolve = TRUE
 
 	M.transfer_to(new_xeno, TRUE)
+
 	new_xeno.set_hive_and_update(XENO_HIVE_FORSAKEN)
+	new_xeno.lock_evolve = TRUE
 
 	QDEL_NULL(current_mob)

--- a/code/game/gamemodes/colonialmarines/colonialmarines.dm
+++ b/code/game/gamemodes/colonialmarines/colonialmarines.dm
@@ -274,9 +274,6 @@
 	if(groundside_humans >= (groundside_xenos * GROUNDSIDE_XENO_MULTIPLIER))
 		SSticker.mode.get_specific_call("Xenomorphs Groundside (Forsaken)", FALSE, FALSE)
 
-		for(var/mob/groundside_mob in groundside_humans)
-			to_chat(groundside_mob, SPAN_INFO("You feel fear down your spine... you are not alone..."))
-
 	TIMER_COOLDOWN_START(src, COOLDOWN_HIJACK_GROUND_CHECK, 1 MINUTES)
 
 #undef GROUNDSIDE_XENO_MULTIPLIER

--- a/code/game/gamemodes/colonialmarines/colonialmarines.dm
+++ b/code/game/gamemodes/colonialmarines/colonialmarines.dm
@@ -249,7 +249,7 @@
 	addtimer(CALLBACK(src, PROC_REF(shake_ship)), 5 SECONDS)
 	TIMER_COOLDOWN_START(src, COOLDOWN_HIJACK_BARRAGE, 15 SECONDS)
 
-#define GROUNDSIDE_XENO_MULTIPLIER 1.5
+#define GROUNDSIDE_XENO_MULTIPLIER 1.0
 
 ///Checks for humans groundside after hijack, spawns forsaken if requirements met
 /datum/game_mode/colonialmarines/proc/check_ground_humans()
@@ -260,7 +260,7 @@
 	var/groundside_xenos = 0
 
 	for(var/mob/current_mob in GLOB.player_list)
-		if(!is_ground_level(current_mob.z) || !current_mob.client)
+		if(!is_ground_level(current_mob.z) || !current_mob.client || curent_mob.stat == DEAD)
 			continue
 
 		if(ishuman_strict(current_mob))

--- a/code/game/gamemodes/colonialmarines/colonialmarines.dm
+++ b/code/game/gamemodes/colonialmarines/colonialmarines.dm
@@ -274,8 +274,8 @@
 	if(groundside_humans >= (groundside_xenos * GROUNDSIDE_XENO_MULTIPLIER))
 		SSticker.mode.get_specific_call("Xenomorphs Groundside (Forsaken)", FALSE, FALSE)
 
-	for(var/mob/groundside_mob in groundside_humans)
-		to_chat(groundside_mob, SPAN_INFO("You feel fear down your spine... you are not alone..."))
+		for(var/mob/groundside_mob in groundside_humans)
+			to_chat(groundside_mob, SPAN_INFO("You feel fear down your spine... you are not alone..."))
 
 	TIMER_COOLDOWN_START(src, COOLDOWN_HIJACK_GROUND_CHECK, 1 MINUTES)
 

--- a/code/game/gamemodes/colonialmarines/colonialmarines.dm
+++ b/code/game/gamemodes/colonialmarines/colonialmarines.dm
@@ -260,7 +260,7 @@
 	var/groundside_xenos = 0
 
 	for(var/mob/current_mob in GLOB.player_list)
-		if(!is_ground_level(current_mob.z) || !current_mob.client || curent_mob.stat == DEAD)
+		if(!is_ground_level(current_mob.z) || !current_mob.client || current_mob.stat == DEAD)
 			continue
 
 		if(ishuman_strict(current_mob))

--- a/code/game/gamemodes/colonialmarines/colonialmarines.dm
+++ b/code/game/gamemodes/colonialmarines/colonialmarines.dm
@@ -171,6 +171,7 @@
 
 	if(is_in_endgame)
 		check_hijack_explosions()
+		check_ground_humans()
 
 	if(next_research_allocation < world.time)
 		chemical_data.update_credits(chemical_data.research_allocation_amount)
@@ -247,6 +248,38 @@
 
 	addtimer(CALLBACK(src, PROC_REF(shake_ship)), 5 SECONDS)
 	TIMER_COOLDOWN_START(src, COOLDOWN_HIJACK_BARRAGE, 15 SECONDS)
+
+#define GROUNDSIDE_XENO_MULTIPLIER 1.5
+
+///Checks for humans groundside after hijack, spawns forsaken if requirements met
+/datum/game_mode/colonialmarines/proc/check_ground_humans()
+	if(TIMER_COOLDOWN_CHECK(src, COOLDOWN_HIJACK_GROUND_CHECK))
+		return
+
+	var/groundside_humans = 0
+	var/groundside_xenos = 0
+
+	for(var/mob/current_mob in GLOB.player_list)
+		if(!is_ground_level(current_mob.z) || !current_mob.client)
+			continue
+
+		if(ishuman_strict(current_mob))
+			groundside_humans++
+			continue
+
+		if(isxeno(current_mob))
+			groundside_xenos++
+			continue
+
+	if(groundside_humans >= (groundside_xenos * GROUNDSIDE_XENO_MULTIPLIER))
+		SSticker.mode.get_specific_call("Xenomorphs Groundside (Forsaken)", FALSE, FALSE)
+
+	for(var/mob/groundside_mob in groundside_humans)
+		to_chat(groundside_mob, SPAN_INFO("You feel fear down your spine... you are not alone..."))
+
+	TIMER_COOLDOWN_START(src, COOLDOWN_HIJACK_GROUND_CHECK, 1 MINUTES)
+
+#undef GROUNDSIDE_XENO_MULTIPLIER
 
 /**
  * Makes the mainship shake, along with playing a klaxon sound effect.

--- a/code/game/gamemodes/colonialmarines/colonialmarines.dm
+++ b/code/game/gamemodes/colonialmarines/colonialmarines.dm
@@ -271,7 +271,7 @@
 			groundside_xenos++
 			continue
 
-	if(groundside_humans >= (groundside_xenos * GROUNDSIDE_XENO_MULTIPLIER))
+	if(groundside_humans > (groundside_xenos * GROUNDSIDE_XENO_MULTIPLIER))
 		SSticker.mode.get_specific_call("Xenomorphs Groundside (Forsaken)", FALSE, FALSE)
 
 	TIMER_COOLDOWN_START(src, COOLDOWN_HIJACK_GROUND_CHECK, 1 MINUTES)

--- a/code/game/objects/effects/landmarks/landmarks.dm
+++ b/code/game/objects/effects/landmarks/landmarks.dm
@@ -104,6 +104,9 @@
 /obj/effect/landmark/ert_spawns/distress_wo
 	name = "distress_wo"
 
+/obj/effect/landmark/ert_spawns/groundside_xeno
+	name = "distress_groundside_xeno"
+
 /obj/effect/landmark/monkey_spawn
 	name = "monkey_spawn"
 	icon_state = "monkey_spawn"

--- a/colonialmarines.dme
+++ b/colonialmarines.dme
@@ -455,6 +455,7 @@
 #include "code\datums\emergency_calls\dutch.dm"
 #include "code\datums\emergency_calls\emergency_call.dm"
 #include "code\datums\emergency_calls\feral_xenos.dm"
+#include "code\datums\emergency_calls\forsaken_xenos.dm"
 #include "code\datums\emergency_calls\goons.dm"
 #include "code\datums\emergency_calls\hefa_knight.dm"
 #include "code\datums\emergency_calls\inspection.dm"

--- a/maps/map_files/BigRed/BigRed.dmm
+++ b/maps/map_files/BigRed/BigRed.dmm
@@ -29879,6 +29879,7 @@
 /area/bigredv2/caves/mining)
 "hYI" = (
 /obj/effect/landmark/xeno_hive_spawn,
+/obj/effect/landmark/ert_spawns/groundside_xeno,
 /turf/open/floor{
 	icon_state = "white"
 	},
@@ -30298,6 +30299,7 @@
 /area/bigredv2/caves/eta/research)
 "iRG" = (
 /obj/effect/landmark/xeno_hive_spawn,
+/obj/effect/landmark/ert_spawns/groundside_xeno,
 /turf/open/mars_cave{
 	icon_state = "mars_cave_2"
 	},
@@ -33034,6 +33036,7 @@
 /area/bigredv2/caves_virology)
 "ozQ" = (
 /obj/effect/landmark/xeno_hive_spawn,
+/obj/effect/landmark/ert_spawns/groundside_xeno,
 /turf/open/mars_cave{
 	icon_state = "mars_cave_2"
 	},
@@ -36825,6 +36828,7 @@
 /area/bigredv2/caves/eta/research)
 "wfC" = (
 /obj/effect/landmark/xeno_hive_spawn,
+/obj/effect/landmark/ert_spawns/groundside_xeno,
 /obj/effect/landmark/queen_spawn,
 /turf/open/mars_cave{
 	icon_state = "mars_cave_2"

--- a/maps/map_files/CORSAT/Corsat.dmm
+++ b/maps/map_files/CORSAT/Corsat.dmm
@@ -37825,6 +37825,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/xeno_hive_spawn,
+/obj/effect/landmark/ert_spawns/groundside_xeno,
 /turf/open/floor/corsat{
 	icon_state = "squares"
 	},
@@ -38351,6 +38352,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/xeno_hive_spawn,
+/obj/effect/landmark/ert_spawns/groundside_xeno,
 /turf/open/floor/corsat{
 	icon_state = "squares"
 	},
@@ -38938,6 +38940,7 @@
 /area/corsat/gamma/airlock/south/id)
 "elG" = (
 /obj/effect/landmark/xeno_hive_spawn,
+/obj/effect/landmark/ert_spawns/groundside_xeno,
 /turf/open/floor/corsat{
 	icon_state = "plate"
 	},
@@ -40487,6 +40490,7 @@
 /area/corsat/gamma/hallwaysouth)
 "fst" = (
 /obj/effect/landmark/xeno_hive_spawn,
+/obj/effect/landmark/ert_spawns/groundside_xeno,
 /turf/open/floor/almayer{
 	dir = 5;
 	icon_state = "plating"
@@ -44868,6 +44872,7 @@
 "iuD" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/effect/landmark/xeno_hive_spawn,
+/obj/effect/landmark/ert_spawns/groundside_xeno,
 /turf/open/floor/corsat{
 	icon_state = "retrosquareslight"
 	},
@@ -46399,6 +46404,7 @@
 /area/corsat/omega/hallways)
 "jJm" = (
 /obj/effect/landmark/xeno_hive_spawn,
+/obj/effect/landmark/ert_spawns/groundside_xeno,
 /turf/open/floor/plating{
 	dir = 8;
 	icon_state = "platingdmg3"
@@ -50742,6 +50748,7 @@
 "mTz" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/effect/landmark/xeno_hive_spawn,
+/obj/effect/landmark/ert_spawns/groundside_xeno,
 /obj/effect/landmark/queen_spawn,
 /turf/open/floor/corsat{
 	icon_state = "retrosquareslight"
@@ -55709,6 +55716,7 @@
 /area/corsat/omega/airlocknorth)
 "qIr" = (
 /obj/effect/landmark/xeno_hive_spawn,
+/obj/effect/landmark/ert_spawns/groundside_xeno,
 /turf/open/floor/corsat{
 	icon_state = "squares"
 	},
@@ -57114,6 +57122,7 @@
 /area/corsat/omega/maint)
 "rMq" = (
 /obj/effect/landmark/xeno_hive_spawn,
+/obj/effect/landmark/ert_spawns/groundside_xeno,
 /turf/open/ice,
 /area/corsat/gamma/biodome)
 "rMD" = (
@@ -61227,6 +61236,7 @@
 /area/corsat/sigma/dorms)
 "uLV" = (
 /obj/effect/landmark/xeno_hive_spawn,
+/obj/effect/landmark/ert_spawns/groundside_xeno,
 /turf/open/floor/corsat{
 	icon_state = "squares"
 	},

--- a/maps/map_files/DesertDam/Desert_Dam.dmm
+++ b/maps/map_files/DesertDam/Desert_Dam.dmm
@@ -14608,6 +14608,7 @@
 /area/desert_dam/exterior/valley/valley_crashsite)
 "aRV" = (
 /obj/effect/landmark/xeno_hive_spawn,
+/obj/effect/landmark/ert_spawns/groundside_xeno,
 /turf/open/desert/dirt{
 	icon_state = "desert_transition_corner1"
 	},
@@ -60937,6 +60938,7 @@
 "fHX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/xeno_hive_spawn,
+/obj/effect/landmark/ert_spawns/groundside_xeno,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean"
@@ -61603,6 +61605,7 @@
 /area/desert_dam/interior/caves/temple)
 "hRU" = (
 /obj/effect/landmark/xeno_hive_spawn,
+/obj/effect/landmark/ert_spawns/groundside_xeno,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean"
@@ -61784,6 +61787,7 @@
 /area/desert_dam/interior/dam_interior/garage)
 "isZ" = (
 /obj/effect/landmark/xeno_hive_spawn,
+/obj/effect/landmark/ert_spawns/groundside_xeno,
 /turf/open/floor/prison{
 	icon_state = "bright_clean2"
 	},
@@ -64506,6 +64510,7 @@
 /area/desert_dam/exterior/valley/valley_hydro)
 "smJ" = (
 /obj/effect/landmark/xeno_hive_spawn,
+/obj/effect/landmark/ert_spawns/groundside_xeno,
 /obj/effect/landmark/queen_spawn,
 /turf/open/floor/prison{
 	dir = 10;
@@ -64730,6 +64735,7 @@
 "tai" = (
 /obj/effect/decal/sand_overlay/sand1,
 /obj/effect/landmark/xeno_hive_spawn,
+/obj/effect/landmark/ert_spawns/groundside_xeno,
 /turf/open/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached12"
 	},

--- a/maps/map_files/FOP_v2_Cellblocks/Prison_Station_FOP.dmm
+++ b/maps/map_files/FOP_v2_Cellblocks/Prison_Station_FOP.dmm
@@ -42247,6 +42247,7 @@
 	dir = 10
 	},
 /obj/effect/landmark/xeno_hive_spawn,
+/obj/effect/landmark/ert_spawns/groundside_xeno,
 /turf/open/floor/plating,
 /area/prison/pirate)
 "cwm" = (
@@ -43520,6 +43521,7 @@
 /area/prison/storage/vip)
 "dqf" = (
 /obj/effect/landmark/xeno_hive_spawn,
+/obj/effect/landmark/ert_spawns/groundside_xeno,
 /turf/open/floor/plating,
 /area/prison/hanger/main)
 "duu" = (
@@ -44094,6 +44096,7 @@
 /area/prison/cellblock/mediumsec/east)
 "fGf" = (
 /obj/effect/landmark/xeno_hive_spawn,
+/obj/effect/landmark/ert_spawns/groundside_xeno,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "sterile_white"
@@ -48821,6 +48824,7 @@
 	icon_state = "wood_siding2"
 	},
 /obj/effect/landmark/xeno_hive_spawn,
+/obj/effect/landmark/ert_spawns/groundside_xeno,
 /turf/open/floor{
 	icon_state = "asteroid"
 	},

--- a/maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
+++ b/maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
@@ -34849,6 +34849,7 @@
 "qEB" = (
 /obj/structure/pipes/standard/manifold/fourway/hidden/green,
 /obj/effect/landmark/xeno_hive_spawn,
+/obj/effect/landmark/ert_spawns/groundside_xeno,
 /turf/open/floor/plating/icefloor,
 /area/ice_colony/surface/requesitions)
 "qRy" = (
@@ -34876,6 +34877,7 @@
 /area/ice_colony/exterior/surface/valley/northwest)
 "rAm" = (
 /obj/effect/landmark/xeno_hive_spawn,
+/obj/effect/landmark/ert_spawns/groundside_xeno,
 /turf/open/floor{
 	icon_state = "dark2"
 	},
@@ -34958,6 +34960,7 @@
 /area/ice_colony/underground/hangar)
 "tEG" = (
 /obj/effect/landmark/xeno_hive_spawn,
+/obj/effect/landmark/ert_spawns/groundside_xeno,
 /obj/effect/landmark/queen_spawn,
 /turf/open/ice,
 /area/ice_colony/exterior/underground/caves/open)
@@ -35021,10 +35024,12 @@
 "uUv" = (
 /obj/effect/alien/weeds/node,
 /obj/effect/landmark/xeno_hive_spawn,
+/obj/effect/landmark/ert_spawns/groundside_xeno,
 /turf/open/ice,
 /area/ice_colony/exterior/underground/caves/open)
 "vcU" = (
 /obj/effect/landmark/xeno_hive_spawn,
+/obj/effect/landmark/ert_spawns/groundside_xeno,
 /turf/open/ice,
 /area/ice_colony/exterior/underground/caves/open)
 "vhS" = (
@@ -35093,6 +35098,7 @@
 /area/ice_colony/surface/tcomms)
 "xWm" = (
 /obj/effect/landmark/xeno_hive_spawn,
+/obj/effect/landmark/ert_spawns/groundside_xeno,
 /turf/open/ice,
 /area/ice_colony/exterior/surface/landing_pad_external)
 "ygw" = (

--- a/maps/map_files/Ice_Colony_v3/Shivas_Snowball.dmm
+++ b/maps/map_files/Ice_Colony_v3/Shivas_Snowball.dmm
@@ -1687,6 +1687,7 @@
 /area/shiva/interior/colony/medseceng)
 "ahy" = (
 /obj/effect/landmark/xeno_hive_spawn,
+/obj/effect/landmark/ert_spawns/groundside_xeno,
 /turf/open/floor/shiva{
 	dir = 1
 	},
@@ -3973,6 +3974,7 @@
 /area/shiva/exterior/cp_lz2)
 "axd" = (
 /obj/effect/landmark/xeno_hive_spawn,
+/obj/effect/landmark/ert_spawns/groundside_xeno,
 /turf/open/floor/shiva{
 	icon_state = "wredfull"
 	},
@@ -7522,6 +7524,7 @@
 /area/shiva/interior/colony/research_hab)
 "byr" = (
 /obj/effect/landmark/xeno_hive_spawn,
+/obj/effect/landmark/ert_spawns/groundside_xeno,
 /turf/open/floor/shiva,
 /area/shiva/interior/colony/research_hab)
 "byG" = (
@@ -10442,6 +10445,7 @@
 /area/shiva/interior/warehouse)
 "faM" = (
 /obj/effect/landmark/xeno_hive_spawn,
+/obj/effect/landmark/ert_spawns/groundside_xeno,
 /turf/open/auto_turf/ice/layer1,
 /area/shiva/interior/caves/medseceng_caves)
 "faR" = (
@@ -13075,6 +13079,7 @@
 /area/shiva/exterior/cp_lz2)
 "hUG" = (
 /obj/effect/landmark/xeno_hive_spawn,
+/obj/effect/landmark/ert_spawns/groundside_xeno,
 /turf/open/floor/shiva{
 	dir = 8;
 	icon_state = "multi_tiles"

--- a/maps/map_files/Kutjevo/Kutjevo.dmm
+++ b/maps/map_files/Kutjevo/Kutjevo.dmm
@@ -2102,6 +2102,7 @@
 /area/kutjevo/interior/foremans_office)
 "cSJ" = (
 /obj/effect/landmark/xeno_hive_spawn,
+/obj/effect/landmark/ert_spawns/groundside_xeno,
 /turf/open/auto_turf/sand/layer1,
 /area/kutjevo/interior/colony_South)
 "cTj" = (
@@ -14201,6 +14202,7 @@
 /area/kutjevo/exterior/lz_dunes)
 "tzQ" = (
 /obj/effect/landmark/xeno_hive_spawn,
+/obj/effect/landmark/ert_spawns/groundside_xeno,
 /turf/open/auto_turf/sand/layer1,
 /area/kutjevo/interior/colony_S_East)
 "tAQ" = (
@@ -16708,6 +16710,7 @@
 /area/kutjevo/interior/construction)
 "wTr" = (
 /obj/effect/landmark/xeno_hive_spawn,
+/obj/effect/landmark/ert_spawns/groundside_xeno,
 /turf/open/auto_turf/sand/layer0,
 /area/kutjevo/interior/colony_N_East)
 "wTt" = (
@@ -17570,6 +17573,7 @@
 /area/kutjevo/interior/colony_South/power2)
 "ykY" = (
 /obj/effect/landmark/xeno_hive_spawn,
+/obj/effect/landmark/ert_spawns/groundside_xeno,
 /turf/open/auto_turf/sand/layer1,
 /area/kutjevo/interior/colony_north)
 "ylf" = (

--- a/maps/map_files/LV522_Chances_Claim/LV522_Chances_Claim.dmm
+++ b/maps/map_files/LV522_Chances_Claim/LV522_Chances_Claim.dmm
@@ -8584,6 +8584,7 @@
 /area/lv522/atmos/west_reactor)
 "epb" = (
 /obj/effect/landmark/xeno_hive_spawn,
+/obj/effect/landmark/ert_spawns/groundside_xeno,
 /turf/open/floor/corsat{
 	icon_state = "plate"
 	},
@@ -31484,6 +31485,7 @@
 /area/lv522/indoors/a_block/dorm_north)
 "nTl" = (
 /obj/effect/landmark/xeno_hive_spawn,
+/obj/effect/landmark/ert_spawns/groundside_xeno,
 /turf/open/floor/corsat{
 	icon_state = "plate"
 	},

--- a/maps/map_files/LV624/LV624.dmm
+++ b/maps/map_files/LV624/LV624.dmm
@@ -309,6 +309,7 @@
 /area/lv624/ground/caves/central_caves)
 "aby" = (
 /obj/effect/landmark/xeno_hive_spawn,
+/obj/effect/landmark/ert_spawns/groundside_xeno,
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/west_caves)
 "abz" = (
@@ -327,6 +328,7 @@
 /area/lv624/ground/caves/north_west_caves)
 "abE" = (
 /obj/effect/landmark/xeno_hive_spawn,
+/obj/effect/landmark/ert_spawns/groundside_xeno,
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/east_caves)
 "abF" = (
@@ -379,6 +381,7 @@
 "abV" = (
 /obj/structure/pipes/standard/simple/hidden/cyan,
 /obj/effect/landmark/xeno_hive_spawn,
+/obj/effect/landmark/ert_spawns/groundside_xeno,
 /turf/open/floor{
 	icon_state = "white"
 	},
@@ -14802,6 +14805,7 @@
 /area/lv624/ground/barrens/south_eastern_jungle_barrens)
 "ePu" = (
 /obj/effect/landmark/xeno_hive_spawn,
+/obj/effect/landmark/ert_spawns/groundside_xeno,
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/south_west_caves)
 "ePw" = (
@@ -15753,6 +15757,7 @@
 /area/lv624/ground/colony/telecomm/sw_lz2)
 "hdA" = (
 /obj/effect/landmark/xeno_hive_spawn,
+/obj/effect/landmark/ert_spawns/groundside_xeno,
 /turf/open/floor/plating{
 	dir = 4;
 	icon_state = "asteroidwarning"

--- a/maps/map_files/LV624/sprinkles/30.nexuscenter_barricaded.dmm
+++ b/maps/map_files/LV624/sprinkles/30.nexuscenter_barricaded.dmm
@@ -168,6 +168,7 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/item/ammo_casing,
 /obj/effect/landmark/xeno_hive_spawn,
+/obj/effect/landmark/ert_spawns/groundside_xeno,
 /turf/open/floor{
 	icon_state = "white"
 	},

--- a/maps/map_files/New_Varadero/New_Varadero.dmm
+++ b/maps/map_files/New_Varadero/New_Varadero.dmm
@@ -5310,6 +5310,7 @@
 /area/varadero/interior/medical)
 "eMf" = (
 /obj/effect/landmark/xeno_hive_spawn,
+/obj/effect/landmark/ert_spawns/groundside_xeno,
 /turf/open/auto_turf/sand_white/layer1,
 /area/varadero/interior_protected/caves/digsite)
 "eMi" = (
@@ -14934,6 +14935,7 @@
 /area/varadero/interior/hall_SE)
 "ncd" = (
 /obj/effect/landmark/xeno_hive_spawn,
+/obj/effect/landmark/ert_spawns/groundside_xeno,
 /turf/open/auto_turf/sand_white/layer1,
 /area/varadero/interior_protected/maintenance/south)
 "ncg" = (
@@ -15716,6 +15718,7 @@
 /area/varadero/interior/hall_NW)
 "nOI" = (
 /obj/effect/landmark/xeno_hive_spawn,
+/obj/effect/landmark/ert_spawns/groundside_xeno,
 /turf/open/auto_turf/sand_white/layer0,
 /area/varadero/interior_protected/caves)
 "nOO" = (
@@ -16944,6 +16947,7 @@
 /area/varadero/interior/research)
 "oPb" = (
 /obj/effect/landmark/xeno_hive_spawn,
+/obj/effect/landmark/ert_spawns/groundside_xeno,
 /turf/open/floor/corsat{
 	dir = 1;
 	icon_state = "squareswood"

--- a/maps/map_files/Sorokyne_Strata/Sorokyne_Strata.dmm
+++ b/maps/map_files/Sorokyne_Strata/Sorokyne_Strata.dmm
@@ -11358,6 +11358,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/xeno_hive_spawn,
+/obj/effect/landmark/ert_spawns/groundside_xeno,
 /turf/open/floor/strata{
 	dir = 8;
 	icon_state = "white_cyan2"
@@ -23145,6 +23146,7 @@
 /area/strata/ag/interior/restricted)
 "byl" = (
 /obj/effect/landmark/xeno_hive_spawn,
+/obj/effect/landmark/ert_spawns/groundside_xeno,
 /obj/effect/landmark/queen_spawn,
 /turf/open/floor/strata{
 	icon_state = "floor2"
@@ -31604,6 +31606,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/xeno_hive_spawn,
+/obj/effect/landmark/ert_spawns/groundside_xeno,
 /turf/open/floor/plating,
 /area/strata/ag/interior/tcomms)
 "fKt" = (
@@ -40639,6 +40642,7 @@
 /area/strata/ag/exterior/research_decks)
 "uSR" = (
 /obj/effect/landmark/xeno_hive_spawn,
+/obj/effect/landmark/ert_spawns/groundside_xeno,
 /obj/effect/landmark/queen_spawn,
 /turf/open/auto_turf/strata_grass/layer1,
 /area/strata/ug/interior/jungle/deep/tearlake)


### PR DESCRIPTION
# About the pull request

This PR automatically spawns forsaken at a 1:1 marine:xeno rate when marines are groundside during hijack.

The xenos are only tier 1/2s. With a 3:1 ratio of tier 1 to tier 2.

# Explain why it's good for the game

The planet is meant to still be an infested hellhole rather than empty once the hive leaves. You *should* fear it.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
add: Added automatic forsaken spawns groundside during hijack
/:cl:
