### PR TITLE
UFOs can be photographed again

### DIFF
--- a/code/game/turfs/closed.dm
+++ b/code/game/turfs/closed.dm
@@ -230,6 +230,7 @@
 	name = "wall"
 	icon_state = "wall1"
 	icon = 'icons/turf/shuttle.dmi'
+	layer = ABOVE_TURF_LAYER
 
 /turf/closed/shuttle/is_weedable()
 	return FULLY_WEEDABLE


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

Dropships were invisible to photography (or anything that used `getFlatIcon`, like VV) due to a difference in how it handled rendering (ordering of images with identical layer + no planes support)

This raises ever so slightly the dropship so it's unambigously above. I tried the reverse (lowering the underlays) but that didn't work out at all for some reason. I mean, it IS above anyway right...


# Explain why it's good for the game
It's not, it means less banter in MSay :(

# Changelog
:cl:
fix: To the joy of conspiracy theorists everywhere, USCM dropships can now be caught on tape again.
/:cl:
