### PR TITLE
Increases amount of survivor spawns on shivas to required level

### DIFF
--- a/maps/map_files/Ice_Colony_v3/Shivas_Snowball.dmm
+++ b/maps/map_files/Ice_Colony_v3/Shivas_Snowball.dmm
@@ -11081,6 +11081,12 @@
 /obj/structure/fence,
 /turf/open/auto_turf/snow/layer0,
 /area/shiva/exterior/lz1_valley)
+"fKx" = (
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor/shiva{
+	icon_state = "greenfull"
+	},
+/area/shiva/interior/colony/n_admin)
 "fKy" = (
 /obj/item/tool/pen/blue{
 	pixel_x = 5
@@ -13838,6 +13844,13 @@
 	},
 /turf/open/floor/shiva,
 /area/shiva/interior/bar)
+"iHN" = (
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor/shiva{
+	dir = 4;
+	icon_state = "green"
+	},
+/area/shiva/interior/colony/botany)
 "iHV" = (
 /obj/structure/largecrate/random{
 	anchored = 1;
@@ -26288,6 +26301,13 @@
 	dir = 1
 	},
 /area/shiva/interior/colony/medseceng)
+"vXk" = (
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor/shiva{
+	dir = 6;
+	icon_state = "multi_tiles"
+	},
+/area/shiva/interior/colony/botany)
 "vXl" = (
 /obj/structure/flora/bush/snow{
 	icon_state = "snowgrassbb_1"
@@ -43474,7 +43494,7 @@ rBH
 lmL
 ejt
 lmL
-bJF
+vXk
 gjY
 vHM
 gjY
@@ -44258,7 +44278,7 @@ kJi
 cCI
 axf
 cCI
-axf
+fKx
 cCI
 axf
 gZG
@@ -46716,7 +46736,7 @@ mqe
 rFA
 rBH
 joh
-aUM
+iHN
 krM
 nOd
 nOd


### PR DESCRIPTION

# About the pull request

This PR increases amount of survivor spawns on shivas to required level

# Explain why it's good for the game

There were not enough spawners for potential surv counts.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
fix: Increases amount of survivor spawns on shivas to required level
/:cl:
