### PR TITLE
Fix ASRS Depths spam

### DIFF
--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -521,6 +521,7 @@ var/datum/controller/supply/supply_controller = new()
 		qdel(C)
 
 	// Sell manifests.
+	var/screams = FALSE
 	for(var/atom/movable/movable_atom in area_shuttle)
 		if(istype(movable_atom, /obj/item/paper/manifest))
 			var/obj/item/paper/manifest/M = movable_atom
@@ -531,11 +532,13 @@ var/datum/controller/supply/supply_controller = new()
 		if(black_market_enabled)
 			var/points_to_add = get_black_market_value(movable_atom)
 			if(points_to_add == KILL_MENDOZA)
+				screams = TRUE
 				kill_mendoza()
 			black_market_sold_items[movable_atom.type] += 1
 			black_market_points += points_to_add
 
 		// Don't disintegrate humans! Maul their corpse instead. >:)
+		screams = TRUE
 		if(ishuman(movable_atom))
 			var/timer = 0.5 SECONDS
 			for(var/index in 1 to 10)
@@ -545,11 +548,11 @@ var/datum/controller/supply/supply_controller = new()
 		// Delete everything else.
 		else qdel(movable_atom)
 
+	if(screams)
+		for(var/atom/computer as anything in bound_supply_computer_list)
+			computer.balloon_alert_to_viewers("you hear horrifying noises coming from the elevator!")
+
 /proc/maul_human(mob/living/carbon/human/mauled_human)
-
-	for(var/atom/computer as anything in supply_controller.bound_supply_computer_list)
-		computer.balloon_alert_to_viewers("you hear horrifying noises coming from the elevator!")
-
 	mauled_human.visible_message(SPAN_HIGHDANGER("The machinery crushes [mauled_human]"), SPAN_HIGHDANGER("The elevator machinery is CRUSHING YOU!"))
 
 	if(mauled_human.stat != DEAD)
@@ -1169,8 +1172,6 @@ var/datum/controller/supply/supply_controller = new()
 /datum/controller/supply/proc/kill_mendoza()
 	if(!mendoza_status)
 		return //cant kill him twice
-	for(var/atom/computer as anything in bound_supply_computer_list)
-		computer.balloon_alert_to_viewers("you hear horrifying noises coming from the elevator!")
 
 	mendoza_status = FALSE // he'll die soon enough, and in the meantime will be too busy to handle requests.
 


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

Going down ASRS elevator will now display ONE message above computers and not 10*atoms

# Explain why it's good for the game
Spam. Immersion breaking


# Changelog
:cl:
fix: Fixed going down ASRS elevator spamming computer messages.
/:cl:
