### PR TITLE
Fix Xenos targeting their UI with abilities

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -71,7 +71,7 @@
 		return
 
 	// Click handled elsewhere. (These clicks are not affected by the next_move cooldown)
-	if (click(A, mods) | A.clicked(src, mods, location, params))
+	if (click(A, mods) || A.clicked(src, mods, location, params))
 		return
 
 	// Default click functions from here on.


### PR DESCRIPTION

# About the pull request

This PR forces xeno abilities that are targeting /atom/movable/screen to instead target the turf at that screenspace coordinate. Also refactors the /mob/living/carbon/xenomorph/click proc.

NOTE: This requires the /mob/proc/do_click proc to short-circuit when calling the click proc (previously was a bitwise OR which would still execute the atom.clicked proc regardless of what the click proc returned) so there could be unintended consequences. I can't currently find any, but should be test merged to see if anyone notices something change unfavorably.

# Explain why it's good for the game

Fixes issues for xenos, particularly the boiler, where they use abilities that require a target but can target their UI. Now rather than the ability doing nothing and going on cooldown, it will target the turf under that UI element. It does not however allow a sprite click on a mob.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![boiler](https://github.com/cmss13-devs/cmss13/assets/76988376/d81ca674-66ed-47d2-b796-96e8190fa831)

</details>


# Changelog
:cl: Drathek
fix: Fixed xenos being able to use abilities on their UI; They will target the turf under it.
/:cl:
