### PR TITLE
disable girders for cult walls

### DIFF
--- a/code/game/turfs/walls/wall_types.dm
+++ b/code/game/turfs/walls/wall_types.dm
@@ -412,6 +412,8 @@
 	walltype = WALL_CULT
 	color = "#3c3434"
 
+/turf/closed/wall/cult/make_girder(destroyed_girder)
+	return
 
 /turf/closed/wall/vault
 	icon_state = "rockvault"


### PR DESCRIPTION
Stops cult walls present on LV from deconstructing to metal under (ever so common) explosions. 

It just looks kinda dumb.

![image](https://github.com/cmss13-devs/cmss13/assets/604624/cdf12710-c58a-4bb2-a136-709d15406065)

Optionally these could have baseturfs to prevent plating but it depends on where you place them..
