### PR TITLE
Adds more sidewalks to bigred, places warning stripe tiles under all doors on bigred, give LZ1 glass ceiling so weather doesn't get in there

### DIFF
--- a/code/game/area/BigRed.dm
+++ b/code/game/area/BigRed.dm
@@ -325,6 +325,9 @@
 	is_resin_allowed = FALSE
 	soundscape_playlist = SCAPE_PL_DESERT_STORM
 
+/area/bigredv2/outside/nw/ceiling
+	ceiling = CEILING_GLASS
+
 /area/bigredv2/outside/c
 	name = "\improper Central Colony Grounds"
 	icon_state = "purple"
@@ -485,7 +488,7 @@
 /area/bigredv2/outside/space_port
 	name = "\improper Space Port"
 	icon_state = "green"
-	ceiling = CEILING_NONE
+	ceiling = CEILING_GLASS
 	is_resin_allowed = FALSE
 	is_landing_zone = TRUE
 

--- a/maps/map_files/BigRed/BigRed.dmm
+++ b/maps/map_files/BigRed/BigRed.dmm
@@ -308,7 +308,7 @@
 	name = "\improper Spaceport"
 	},
 /turf/open/floor{
-	icon_state = "dark"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/space_port)
 "aaX" = (
@@ -935,7 +935,7 @@
 	},
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor{
-	icon_state = "dark"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/telecomm)
 "acS" = (
@@ -1054,7 +1054,9 @@
 /area/bigredv2/outside/marshal_office)
 "adi" = (
 /obj/item/shard,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/marshal_office)
 "adj" = (
 /obj/item/shard,
@@ -1358,7 +1360,7 @@
 	name = "\improper Telecommunications"
 	},
 /turf/open/floor{
-	icon_state = "dark"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/telecomm)
 "aed" = (
@@ -1441,8 +1443,7 @@
 	name = "\improper Marshal Office Prison"
 	},
 /turf/open/floor{
-	dir = 5;
-	icon_state = "whitegreenfull"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/marshal_office)
 "aen" = (
@@ -1452,8 +1453,7 @@
 	name = "\improper Marshal Office Prison"
 	},
 /turf/open/floor{
-	dir = 5;
-	icon_state = "whitegreenfull"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/marshal_office)
 "aeo" = (
@@ -1462,7 +1462,7 @@
 	name = "\improper Marshal Office Prison Toilet"
 	},
 /turf/open/floor{
-	icon_state = "freezerfloor"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/marshal_office)
 "aep" = (
@@ -1718,17 +1718,6 @@
 /obj/structure/window/framed/solaris/reinforced,
 /turf/open/floor/plating,
 /area/bigredv2/caves/lambda/xenobiology)
-"afe" = (
-/obj/structure/blocker/forcefield/multitile_vehicles,
-/obj/structure/machinery/door/poddoor/almayer/closed{
-	id = "eta";
-	name = "Eta Lockdown"
-	},
-/turf/open/floor{
-	dir = 4;
-	icon_state = "asteroidwarning"
-	},
-/area/bigredv2/outside/lz2_south_cas)
 "aff" = (
 /obj/effect/decal/cleanable/mucus,
 /obj/structure/surface/table,
@@ -1990,8 +1979,7 @@
 	name = "\improper Marshal Office Prison"
 	},
 /turf/open/floor{
-	dir = 5;
-	icon_state = "whitegreenfull"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/marshal_office)
 "afQ" = (
@@ -2002,8 +1990,7 @@
 	name = "\improper Marshal Office Prison"
 	},
 /turf/open/floor{
-	dir = 5;
-	icon_state = "whitegreenfull"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/marshal_office)
 "afR" = (
@@ -2088,7 +2075,9 @@
 	dir = 1;
 	name = "\improper Lambda Lab Storage"
 	},
-/turf/open/floor/plating,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/caves/lambda/xenobiology)
 "agf" = (
 /obj/structure/surface/table/reinforced,
@@ -2110,7 +2099,7 @@
 	name = "\improper Lambda Lab Chemistry Lab"
 	},
 /turf/open/floor{
-	icon_state = "dark"
+	icon_state = "delivery"
 	},
 /area/bigredv2/caves/lambda/xenobiology)
 "agh" = (
@@ -2170,32 +2159,23 @@
 	},
 /area/bigredv2/outside/space_port)
 "agq" = (
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 4
-	},
 /turf/open/floor{
 	dir = 9;
 	icon_state = "asteroidwarning"
 	},
-/area/bigredv2/outside/space_port)
+/area/bigredv2/outside/n)
 "agr" = (
 /obj/structure/pipes/standard/manifold/hidden/green{
 	dir = 1
 	},
-/turf/open/floor{
-	dir = 1;
-	icon_state = "asteroidwarning"
-	},
+/turf/open/floor/plating,
 /area/bigredv2/outside/space_port)
 "ags" = (
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 4
-	},
 /turf/open/floor{
 	dir = 5;
 	icon_state = "asteroidwarning"
 	},
-/area/bigredv2/outside/space_port)
+/area/bigredv2/outside/n)
 "agt" = (
 /obj/structure/surface/table/woodentable/fancy,
 /turf/open/floor{
@@ -2317,7 +2297,7 @@
 	name = "\improper Marshal Head Office"
 	},
 /turf/open/floor{
-	icon_state = "wood"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/marshal_office)
 "agK" = (
@@ -2341,7 +2321,7 @@
 	name = "\improper Lambda Lab Surgery"
 	},
 /turf/open/floor{
-	icon_state = "dark"
+	icon_state = "delivery"
 	},
 /area/bigredv2/caves/lambda/xenobiology)
 "agN" = (
@@ -2473,7 +2453,7 @@
 	dir = 8;
 	icon_state = "asteroidwarning"
 	},
-/area/bigredv2/outside/space_port)
+/area/bigredv2/outside/n)
 "ahf" = (
 /obj/structure/surface/table,
 /turf/open/floor,
@@ -2611,7 +2591,7 @@
 	name = "\improper Lambda Lab Surgery"
 	},
 /turf/open/floor{
-	icon_state = "darkpurple2"
+	icon_state = "delivery"
 	},
 /area/bigredv2/caves/lambda/xenobiology)
 "ahC" = (
@@ -2674,9 +2654,9 @@
 /area/bigredv2/caves/lambda/xenobiology)
 "ahK" = (
 /turf/open/floor{
-	icon_state = "darkish"
+	icon_state = "delivery"
 	},
-/area/bigredv2/caves/lambda/xenobiology)
+/area/bigredv2/outside/space_port)
 "ahL" = (
 /turf/open/floor{
 	dir = 4;
@@ -2689,7 +2669,7 @@
 	name = "\improper Lambda Lab Cell"
 	},
 /turf/open/floor{
-	icon_state = "dark"
+	icon_state = "delivery"
 	},
 /area/bigredv2/caves/lambda/xenobiology)
 "ahN" = (
@@ -2718,11 +2698,11 @@
 	},
 /area/bigredv2/outside/nw)
 "ahS" = (
-/obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor{
-	icon_state = "asteroidwarning"
+	dir = 1;
+	icon_state = "asteroidfloor"
 	},
-/area/bigredv2/outside/nw)
+/area/bigredv2/outside/n)
 "ahT" = (
 /turf/open/floor{
 	dir = 6;
@@ -2743,7 +2723,9 @@
 "ahW" = (
 /obj/item/stack/rods,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/mars,
+/turf/open/floor{
+	icon_state = "asteroidwarning"
+	},
 /area/bigredv2/outside/nw)
 "ahX" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2753,13 +2735,17 @@
 /obj/item/stack/sheet/metal,
 /obj/item/stack/rods,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/mars,
+/turf/open/floor{
+	icon_state = "asteroidwarning"
+	},
 /area/bigredv2/outside/nw)
 "ahZ" = (
 /obj/item/stack/rods,
 /obj/item/stack/rods,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/mars,
+/turf/open/floor{
+	icon_state = "asteroidwarning"
+	},
 /area/bigredv2/outside/nw)
 "aia" = (
 /obj/structure/machinery/door_control{
@@ -2817,7 +2803,7 @@
 	name = "\improper Marshal Office Armory"
 	},
 /turf/open/floor{
-	icon_state = "dark"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/marshal_office)
 "aii" = (
@@ -2825,7 +2811,9 @@
 	dir = 1;
 	name = "\improper Marshal Office Equipment"
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/marshal_office)
 "aij" = (
 /obj/effect/landmark/hunter_secondary,
@@ -2866,7 +2854,9 @@
 	dir = 1;
 	name = "\improper Lambda Lab Maintenance"
 	},
-/turf/open/floor/plating,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/caves/lambda/xenobiology)
 "aio" = (
 /turf/open/floor{
@@ -3066,7 +3056,9 @@
 /obj/structure/machinery/door/airlock/multi_tile/almayer/generic{
 	name = "\improper Marshal Office"
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/marshal_office)
 "aiR" = (
 /obj/structure/machinery/light{
@@ -3081,7 +3073,7 @@
 /obj/effect/landmark/corpsespawner/scientist,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
 /turf/open/floor{
-	icon_state = "darkish"
+	icon_state = "dark"
 	},
 /area/bigredv2/caves/lambda/xenobiology)
 "aiT" = (
@@ -3096,7 +3088,7 @@
 	name = "\improper Lambda Lab Prison Restroom"
 	},
 /turf/open/floor{
-	icon_state = "dark"
+	icon_state = "delivery"
 	},
 /area/bigredv2/caves/lambda/xenobiology)
 "aiV" = (
@@ -3251,7 +3243,7 @@
 	name = "\improper Lambda Lab Prisoner Room"
 	},
 /turf/open/floor{
-	icon_state = "dark"
+	icon_state = "delivery"
 	},
 /area/bigredv2/caves/lambda/xenobiology)
 "ajs" = (
@@ -3399,7 +3391,7 @@
 	name = "\improper Marshal Office Armory"
 	},
 /turf/open/floor{
-	icon_state = "dark"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/marshal_office)
 "ajL" = (
@@ -3457,8 +3449,8 @@
 /turf/open/floor,
 /area/bigredv2/outside/marshal_office)
 "ajT" = (
+/obj/structure/barricade/wooden,
 /turf/open/floor{
-	dir = 5;
 	icon_state = "asteroidwarning"
 	},
 /area/bigredv2/outside/n)
@@ -3637,7 +3629,9 @@
 	name = "\improper Marshal Office"
 	},
 /obj/structure/pipes/standard/simple/hidden/green,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/marshal_office)
 "akw" = (
 /obj/effect/decal/cleanable/dirt,
@@ -3785,7 +3779,9 @@
 	dir = 1;
 	name = "\improper Marshal Office"
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/marshal_office)
 "akS" = (
 /obj/structure/bed/chair,
@@ -3927,7 +3923,7 @@
 	name = "\improper Marshal Office Evidence Room"
 	},
 /turf/open/floor{
-	icon_state = "dark"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/marshal_office)
 "alq" = (
@@ -4192,8 +4188,7 @@
 	dir = 4
 	},
 /turf/open/floor{
-	dir = 8;
-	icon_state = "red"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/marshal_office)
 "ame" = (
@@ -4290,7 +4285,9 @@
 /obj/structure/machinery/door/airlock/almayer/security/glass/colony{
 	name = "\improper Marshal Office Courtroom"
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/marshal_office)
 "amu" = (
 /obj/structure/bed/chair{
@@ -4524,8 +4521,7 @@
 	name = "\improper Marshal Office"
 	},
 /turf/open/floor{
-	dir = 8;
-	icon_state = "red"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/marshal_office)
 "anb" = (
@@ -4627,11 +4623,13 @@
 /obj/structure/machinery/door/airlock/almayer/maint/colony{
 	name = "\improper Lambda Lab Maintenance Storage"
 	},
-/turf/open/floor/plating,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/caves/lambda/xenobiology)
 "anp" = (
 /turf/closed/wall/solaris/reinforced,
-/area/bigredv2/outside/nw)
+/area/bigredv2/outside/nw/ceiling)
 "anq" = (
 /obj/structure/machinery/light{
 	dir = 8
@@ -4690,7 +4688,7 @@
 	name = "\improper Marshal Office Holding Cell"
 	},
 /turf/open/floor{
-	icon_state = "dark"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/marshal_office)
 "any" = (
@@ -4699,8 +4697,7 @@
 	name = "\improper Marshal Office Checkpoint"
 	},
 /turf/open/floor{
-	dir = 9;
-	icon_state = "redfull"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/marshal_office)
 "anz" = (
@@ -4709,7 +4706,9 @@
 /obj/structure/machinery/door/airlock/multi_tile/almayer/generic{
 	name = "\improper Marshal Office"
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/marshal_office)
 "anB" = (
 /obj/structure/machinery/light{
@@ -5252,7 +5251,9 @@
 /obj/structure/machinery/door/airlock/almayer/maint/colony{
 	name = "\improper Dormitories EVA Maintenance"
 	},
-/turf/open/floor/plating,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/general_offices)
 "apk" = (
 /obj/structure/pipes/standard/simple/hidden/green{
@@ -5278,7 +5279,7 @@
 	name = "\improper Dormitories EVA"
 	},
 /turf/open/floor{
-	icon_state = "dark"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/general_offices)
 "apn" = (
@@ -5404,15 +5405,13 @@
 	name = "\improper Medical Clinic"
 	},
 /turf/open/floor{
-	dir = 1;
-	icon_state = "warnwhite"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/medical)
 "apF" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor{
-	dir = 1;
-	icon_state = "warnwhite"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/medical)
 "apG" = (
@@ -5423,7 +5422,9 @@
 /obj/structure/machinery/door/airlock/multi_tile/almayer/generic{
 	name = "\improper Marshal Office"
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/marshal_office)
 "apI" = (
 /turf/closed/wall/solaris/reinforced/hull,
@@ -5455,7 +5456,7 @@
 	name = "\improper Dormitories Lavatory"
 	},
 /turf/open/floor{
-	icon_state = "freezerfloor"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/general_offices)
 "apN" = (
@@ -5795,7 +5796,8 @@
 	dir = 5
 	},
 /turf/open/floor{
-	icon_state = "asteroidwarning"
+	dir = 1;
+	icon_state = "asteroidfloor"
 	},
 /area/bigredv2/outside/n)
 "aqH" = (
@@ -5807,28 +5809,23 @@
 	},
 /area/bigredv2/outside/n)
 "aqI" = (
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 4
-	},
 /turf/open/floor{
 	dir = 6;
 	icon_state = "asteroidwarning"
 	},
 /area/bigredv2/outside/n)
 "aqJ" = (
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 4
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/mars_cave{
 	icon_state = "mars_dirt_4"
 	},
-/area/bigredv2/outside/n)
+/area/bigredv2/outside/nw)
 "aqK" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 10
 	},
-/turf/open/mars_cave{
-	icon_state = "mars_dirt_4"
+/turf/open/floor{
+	icon_state = "asteroidwarning"
 	},
 /area/bigredv2/outside/n)
 "aqL" = (
@@ -5837,8 +5834,8 @@
 	},
 /area/bigredv2/outside/n)
 "aqM" = (
-/turf/open/mars{
-	icon_state = "mars_dirt_12"
+/turf/open/floor{
+	icon_state = "asteroidwarning"
 	},
 /area/bigredv2/outside/n)
 "aqN" = (
@@ -5848,7 +5845,9 @@
 	health = 25000
 	},
 /obj/structure/barricade/wooden,
-/turf/open/mars,
+/turf/open/floor{
+	icon_state = "asteroidwarning"
+	},
 /area/bigredv2/outside/n)
 "aqO" = (
 /obj/structure/barricade/wooden,
@@ -6300,14 +6299,9 @@
 	icon_state = "mars_dirt_9"
 	},
 /area/bigredv2/outside/n)
-"asb" = (
-/turf/open/mars{
-	icon_state = "mars_dirt_11"
-	},
-/area/bigredv2/outside/n)
 "asc" = (
 /turf/open/floor{
-	dir = 9;
+	dir = 1;
 	icon_state = "asteroidwarning"
 	},
 /area/bigredv2/outside/n)
@@ -6327,9 +6321,9 @@
 	},
 /area/bigredv2/outside/n)
 "asf" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/wooden,
 /turf/open/floor{
-	dir = 5;
+	dir = 4;
 	icon_state = "asteroidwarning"
 	},
 /area/bigredv2/outside/n)
@@ -6344,7 +6338,10 @@
 	dir = 8;
 	health = 25000
 	},
-/turf/open/mars,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "asteroidwarning"
+	},
 /area/bigredv2/outside/n)
 "ash" = (
 /obj/structure/barricade/wooden{
@@ -6352,7 +6349,10 @@
 	dir = 1;
 	health = 25000
 	},
-/turf/open/mars,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "asteroidwarning"
+	},
 /area/bigredv2/outside/n)
 "asi" = (
 /obj/structure/pipes/standard/simple/hidden/green,
@@ -6360,7 +6360,9 @@
 	dir = 1;
 	name = "\improper Dormitories Tool Storage Maintenance"
 	},
-/turf/open/floor/plating,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/general_offices)
 "asj" = (
 /obj/structure/window/framed/solaris,
@@ -6377,7 +6379,7 @@
 	name = "\improper Dormitories EVA"
 	},
 /turf/open/floor{
-	icon_state = "dark"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/general_offices)
 "asl" = (
@@ -6755,12 +6757,12 @@
 	},
 /area/bigredv2/caves_lambda)
 "atl" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/wooden,
 /turf/open/floor{
-	dir = 9;
+	dir = 8;
 	icon_state = "asteroidwarning"
 	},
-/area/bigredv2/outside/nw)
+/area/bigredv2/outside/n)
 "atm" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor{
@@ -6925,8 +6927,7 @@
 	name = "\improper Lambda Lab Secure Storage"
 	},
 /turf/open/floor{
-	dir = 1;
-	icon_state = "elevatorshaft"
+	icon_state = "delivery"
 	},
 /area/bigredv2/caves/lambda/breakroom)
 "atJ" = (
@@ -6943,7 +6944,9 @@
 	dir = 1;
 	name = "\improper Lambda Lab Administration Office"
 	},
-/turf/open/floor/wood,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/caves/lambda/breakroom)
 "atL" = (
 /obj/structure/bed/chair{
@@ -7030,7 +7033,7 @@
 	name = "\improper Medical Clinic CMO's Office"
 	},
 /turf/open/floor{
-	icon_state = "white"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/medical)
 "atW" = (
@@ -7040,7 +7043,7 @@
 	name = "\improper Medical Clinic Morgue"
 	},
 /turf/open/floor{
-	icon_state = "dark"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/medical)
 "atX" = (
@@ -7063,7 +7066,7 @@
 	name = "\improper Dormitories Bedroom"
 	},
 /turf/open/floor{
-	icon_state = "wood"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/dorms)
 "aua" = (
@@ -7150,7 +7153,9 @@
 /obj/structure/machinery/door/airlock/almayer/research/glass/colony{
 	name = "\improper Lambda Lab Administration Office"
 	},
-/turf/open/floor/wood,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/caves/lambda/breakroom)
 "aun" = (
 /obj/structure/closet/firecloset/full,
@@ -7290,12 +7295,12 @@
 	},
 /area/bigredv2/caves/lambda/breakroom)
 "auE" = (
-/obj/structure/pipes/standard/simple/hidden/green,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor{
-	dir = 1;
+	dir = 8;
 	icon_state = "asteroidwarning"
 	},
-/area/bigredv2/outside/nw)
+/area/bigredv2/outside/n)
 "auF" = (
 /turf/open/floor{
 	dir = 5;
@@ -7408,20 +7413,22 @@
 	name = "\improper Dormitories Bedroom"
 	},
 /turf/open/floor{
-	icon_state = "wood"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/dorms)
 "auV" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/generic{
 	name = "\improper Dormitories Tool Storage"
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/general_offices)
 "auW" = (
 /turf/closed/wall/solaris/reinforced/hull,
 /area/bigredv2/outside/c)
 "auX" = (
-/obj/structure/window/framed/solaris/reinforced/hull,
+/obj/structure/window/framed/solaris/reinforced,
 /turf/open/floor/plating,
 /area/bigredv2/outside/c)
 "auY" = (
@@ -7476,7 +7483,7 @@
 	name = "\improper Lambda Lab Administration Wing"
 	},
 /turf/open/floor{
-	icon_state = "dark"
+	icon_state = "delivery"
 	},
 /area/bigredv2/caves/lambda/breakroom)
 "avf" = (
@@ -7584,26 +7591,19 @@
 /obj/structure/window_frame/solaris,
 /turf/open/floor/plating,
 /area/bigredv2/outside/office_complex)
-"avs" = (
-/turf/open/floor/plating{
-	dir = 1;
-	icon_state = "warnplate"
-	},
-/area/bigredv2/outside/nw)
 "avt" = (
 /obj/structure/pipes/standard/simple/hidden/green,
-/turf/open/floor/plating{
-	dir = 1;
-	icon_state = "warnplate"
+/turf/open/floor{
+	icon_state = "delivery"
 	},
-/area/bigredv2/outside/nw)
+/area/bigredv2/outside/nw/ceiling)
 "avu" = (
 /obj/structure/machinery/door/airlock/almayer/medical/glass/colony{
 	dir = 1;
 	name = "\improper Medical Clinic Chemistry"
 	},
 /turf/open/floor{
-	icon_state = "white"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/medical)
 "avv" = (
@@ -7732,7 +7732,9 @@
 /obj/structure/machinery/door/airlock/multi_tile/almayer/medidoor/colony{
 	name = "\improper Lambda Lab Relaxation Room"
 	},
-/turf/open/floor/wood,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/caves/lambda/breakroom)
 "avP" = (
 /obj/structure/machinery/light{
@@ -7769,17 +7771,17 @@
 /area/bigredv2/outside/office_complex)
 "avT" = (
 /turf/open/floor/plating,
-/area/bigredv2/outside/nw)
+/area/bigredv2/outside/nw/ceiling)
 "avU" = (
 /obj/structure/machinery/light{
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/bigredv2/outside/nw)
+/area/bigredv2/outside/nw/ceiling)
 "avV" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor/plating,
-/area/bigredv2/outside/nw)
+/area/bigredv2/outside/nw/ceiling)
 "avW" = (
 /obj/structure/surface/table,
 /obj/item/trash/burger,
@@ -7891,7 +7893,7 @@
 	name = "\improper Medical Clinic Scanner Room"
 	},
 /turf/open/floor{
-	icon_state = "white"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/medical)
 "awk" = (
@@ -8211,7 +8213,9 @@
 	dir = 1;
 	name = "\improper Dormitories"
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/dorms)
 "axi" = (
 /obj/structure/machinery/light,
@@ -8311,11 +8315,10 @@
 	},
 /area/bigredv2/outside/nw)
 "axv" = (
-/turf/open/floor/plating{
-	dir = 8;
-	icon_state = "warnplate"
+/turf/open/floor{
+	icon_state = "delivery"
 	},
-/area/bigredv2/outside/nw)
+/area/bigredv2/outside/nw/ceiling)
 "axw" = (
 /obj/structure/surface/table,
 /obj/item/storage/firstaid/adv,
@@ -8336,7 +8339,7 @@
 	name = "\improper Medical Clinic Treatment"
 	},
 /turf/open/floor{
-	icon_state = "white"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/medical)
 "axz" = (
@@ -8382,7 +8385,10 @@
 "axF" = (
 /obj/structure/barricade/wooden,
 /obj/structure/barricade/wooden,
-/turf/open/mars,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "asteroidwarning"
+	},
 /area/bigredv2/outside/n)
 "axG" = (
 /obj/structure/machinery/camera/autoname{
@@ -8461,7 +8467,7 @@
 	name = "\improper Dormitories Bedroom"
 	},
 /turf/open/floor{
-	icon_state = "wood"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/general_offices)
 "axS" = (
@@ -8469,7 +8475,9 @@
 /obj/structure/machinery/door/airlock/multi_tile/almayer/generic{
 	name = "\improper Dormitories"
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/general_offices)
 "axT" = (
 /obj/effect/landmark/xeno_spawn,
@@ -8490,14 +8498,11 @@
 	},
 /area/bigredv2/caves_lambda)
 "axW" = (
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 4
-	},
 /turf/open/floor{
-	dir = 8;
+	dir = 6;
 	icon_state = "asteroidwarning"
 	},
-/area/bigredv2/outside/nw)
+/area/bigredv2/outside/c)
 "axX" = (
 /turf/closed/wall/solaris/reinforced,
 /area/bigredv2/outside/engineering)
@@ -8505,28 +8510,27 @@
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
 	},
-/turf/open/floor/plating{
-	dir = 8;
-	icon_state = "warnplate"
+/turf/open/floor{
+	icon_state = "delivery"
 	},
-/area/bigredv2/outside/nw)
+/area/bigredv2/outside/nw/ceiling)
 "axZ" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/bigredv2/outside/nw)
+/area/bigredv2/outside/nw/ceiling)
 "aya" = (
 /obj/effect/landmark/hunter_primary,
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/bigredv2/outside/nw)
+/area/bigredv2/outside/nw/ceiling)
 "ayb" = (
 /obj/structure/pipes/standard/manifold/hidden/green,
 /turf/open/floor/plating,
-/area/bigredv2/outside/nw)
+/area/bigredv2/outside/nw/ceiling)
 "ayc" = (
 /obj/structure/window/framed/solaris/reinforced/hull,
 /turf/open/floor/plating,
@@ -8540,7 +8544,7 @@
 	name = "\improper Medical Clinic"
 	},
 /turf/open/floor{
-	icon_state = "white"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/medical)
 "aye" = (
@@ -8794,8 +8798,7 @@
 /area/bigredv2/outside/medical)
 "ayN" = (
 /turf/open/floor{
-	dir = 4;
-	icon_state = "warnwhite"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/medical)
 "ayO" = (
@@ -8986,11 +8989,11 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/bigredv2/outside/nw)
+/area/bigredv2/outside/nw/ceiling)
 "azo" = (
 /obj/structure/cargo_container/horizontal/blue/top,
 /turf/open/floor/plating,
-/area/bigredv2/outside/nw)
+/area/bigredv2/outside/nw/ceiling)
 "azp" = (
 /obj/structure/bed/roller,
 /obj/effect/decal/cleanable/blood,
@@ -9083,8 +9086,7 @@
 	name = "\improper Medical Clinic Treatment"
 	},
 /turf/open/floor{
-	dir = 4;
-	icon_state = "warnwhite"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/medical)
 "azA" = (
@@ -9141,9 +9143,8 @@
 /obj/structure/machinery/door/airlock/almayer/maint/colony{
 	name = "\improper Medical Clinic Power Station"
 	},
-/turf/open/floor/plating{
-	dir = 8;
-	icon_state = "warnplate"
+/turf/open/floor{
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/medical)
 "azK" = (
@@ -9270,7 +9271,9 @@
 /obj/structure/machinery/door/airlock/almayer/maint/colony{
 	name = "\improper Bar Maintenance"
 	},
-/turf/open/floor/plating,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/dorms)
 "aAd" = (
 /obj/structure/pipes/standard/simple/hidden/green{
@@ -9350,14 +9353,14 @@
 "aAq" = (
 /obj/structure/cargo_container/horizontal/blue/middle,
 /turf/open/floor/plating,
-/area/bigredv2/outside/nw)
+/area/bigredv2/outside/nw/ceiling)
 "aAr" = (
 /obj/structure/machinery/door/airlock/almayer/medical/glass/colony{
-	name = "\improper Medical Clinic Operating Theatre";
-	dir = 2
+	dir = 2;
+	name = "\improper Medical Clinic Operating Theatre"
 	},
 /turf/open/floor{
-	icon_state = "darkish"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/medical)
 "aAs" = (
@@ -9443,7 +9446,7 @@
 	name = "\improper Dormitories Restroom"
 	},
 /turf/open/floor{
-	icon_state = "freezerfloor"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/dorms)
 "aAE" = (
@@ -9452,7 +9455,7 @@
 	name = "\improper Recreation"
 	},
 /turf/open/floor{
-	icon_state = "wood"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/dorms)
 "aAF" = (
@@ -9602,11 +9605,11 @@
 "aAZ" = (
 /obj/structure/cargo_container/horizontal/blue/bottom,
 /turf/open/floor/plating,
-/area/bigredv2/outside/nw)
+/area/bigredv2/outside/nw/ceiling)
 "aBa" = (
 /obj/structure/machinery/light,
 /turf/open/floor/plating,
-/area/bigredv2/outside/nw)
+/area/bigredv2/outside/nw/ceiling)
 "aBb" = (
 /obj/structure/bed/chair,
 /turf/open/floor{
@@ -9634,7 +9637,7 @@
 	name = "\improper Medical Clinic"
 	},
 /turf/open/floor{
-	icon_state = "white"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/medical)
 "aBf" = (
@@ -9776,7 +9779,9 @@
 	dir = 1;
 	name = "\improper Greenhouse"
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/hydroponics)
 "aBy" = (
 /obj/structure/window/framed/solaris/reinforced,
@@ -9905,8 +9910,9 @@
 /turf/open/mars,
 /area/bigredv2/outside/c)
 "aBS" = (
+/obj/effect/landmark/hunter_secondary,
 /turf/open/floor{
-	dir = 9;
+	dir = 4;
 	icon_state = "asteroidwarning"
 	},
 /area/bigredv2/outside/c)
@@ -9914,7 +9920,9 @@
 /obj/structure/machinery/door/airlock/almayer/generic{
 	name = "\improper Dormitories Storage"
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/dorms)
 "aBU" = (
 /obj/structure/pipes/standard/simple/hidden/green,
@@ -10052,7 +10060,9 @@
 /area/bigredv2/caves/lambda/research)
 "aCr" = (
 /obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/engine,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/caves/lambda/research)
 "aCs" = (
 /obj/effect/decal/warning_stripes{
@@ -10111,14 +10121,10 @@
 	},
 /area/bigredv2/caves/lambda/research)
 "aCy" = (
-/obj/structure/machinery/door/airlock/almayer/research/glass/colony{
-	dir = 1;
-	name = "\improper Lambda Lab Anomaly Chamber"
-	},
 /turf/open/floor{
-	icon_state = "podhatchfloor"
+	icon_state = "delivery"
 	},
-/area/bigredv2/caves/lambda/research)
+/area/bigredv2/caves/lambda/xenobiology)
 "aCz" = (
 /obj/structure/machinery/power/port_gen/pacman,
 /obj/effect/decal/warning_stripes{
@@ -10158,7 +10164,7 @@
 	name = "\improper Medical Clinic Storage"
 	},
 /turf/open/floor{
-	icon_state = "white"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/medical)
 "aCD" = (
@@ -10193,7 +10199,7 @@
 	name = "\improper Medical Clinic Storage"
 	},
 /turf/open/floor{
-	icon_state = "white"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/medical)
 "aCH" = (
@@ -10245,7 +10251,7 @@
 	name = "\improper Dormitories Restroom"
 	},
 /turf/open/floor{
-	icon_state = "freezerfloor"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/dorms)
 "aCR" = (
@@ -10275,7 +10281,9 @@
 	dir = 1;
 	name = "\improper Bar Maintenance"
 	},
-/turf/open/floor/plating,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/bar)
 "aCV" = (
 /obj/effect/landmark/hunter_primary,
@@ -10348,7 +10356,7 @@
 	name = "\improper Library Backroom"
 	},
 /turf/open/floor{
-	icon_state = "wood"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/library)
 "aDg" = (
@@ -10493,9 +10501,9 @@
 	},
 /turf/open/floor{
 	dir = 1;
-	icon_state = "asteroidwarning"
+	icon_state = "asteroidfloor"
 	},
-/area/bigredv2/outside/nw)
+/area/bigredv2/outside/e)
 "aDz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/pipes/standard/simple/hidden/green{
@@ -10503,7 +10511,7 @@
 	},
 /turf/open/floor{
 	dir = 1;
-	icon_state = "asteroidwarning"
+	icon_state = "asteroidfloor"
 	},
 /area/bigredv2/outside/nw)
 "aDA" = (
@@ -10511,7 +10519,7 @@
 	dir = 10
 	},
 /turf/open/floor{
-	dir = 5;
+	dir = 4;
 	icon_state = "asteroidwarning"
 	},
 /area/bigredv2/outside/nw)
@@ -10696,7 +10704,7 @@
 	name = "\improper Bar Backroom"
 	},
 /turf/open/floor{
-	icon_state = "wood"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/bar)
 "aEa" = (
@@ -10964,7 +10972,7 @@
 	name = "\improper Dormitories Toilet"
 	},
 /turf/open/floor{
-	icon_state = "freezerfloor"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/dorms)
 "aEO" = (
@@ -11233,7 +11241,7 @@
 	name = "\improper Medical Clinic Operating Theatre"
 	},
 /turf/open/floor{
-	icon_state = "white"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/medical)
 "aFB" = (
@@ -11332,7 +11340,9 @@
 /obj/structure/machinery/door/airlock/almayer/generic{
 	name = "\improper Dormitories Storage"
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/dorms)
 "aFP" = (
 /obj/structure/pipes/standard/simple/hidden/green{
@@ -11428,7 +11438,9 @@
 	dir = 1;
 	name = "\improper Greenhouse Storage"
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/hydroponics)
 "aGb" = (
 /obj/effect/decal/cleanable/dirt,
@@ -11445,7 +11457,7 @@
 	name = "\improper Greenhouse Storage"
 	},
 /turf/open/floor{
-	icon_state = "wood"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/library)
 "aGd" = (
@@ -11685,7 +11697,9 @@
 /obj/structure/machinery/door/airlock/multi_tile/almayer/generic{
 	name = "\improper Dormitories"
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/dorms)
 "aGG" = (
 /obj/structure/surface/table/woodentable,
@@ -11762,7 +11776,8 @@
 	dir = 1
 	},
 /turf/open/floor{
-	icon_state = "darkish"
+	dir = 4;
+	icon_state = "darkpurplecorners2"
 	},
 /area/bigredv2/caves/lambda/research)
 "aGV" = (
@@ -12045,7 +12060,9 @@
 /obj/structure/machinery/door/airlock/multi_tile/almayer/generic{
 	name = "\improper Kitchen Storage"
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/hydroponics)
 "aHM" = (
 /obj/structure/pipes/standard/simple/hidden/green,
@@ -12076,7 +12093,8 @@
 /area/bigredv2/caves/lambda/research)
 "aHQ" = (
 /turf/open/floor{
-	icon_state = "darkish"
+	dir = 4;
+	icon_state = "darkpurplecorners2"
 	},
 /area/bigredv2/caves/lambda/research)
 "aHR" = (
@@ -12208,8 +12226,7 @@
 	name = "Virology Lockdown"
 	},
 /turf/open/floor{
-	dir = 1;
-	icon_state = "asteroidfloor"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/virology)
 "aIi" = (
@@ -12430,7 +12447,7 @@
 	dir = 1
 	},
 /turf/open/floor{
-	icon_state = "darkish"
+	icon_state = "dark"
 	},
 /area/bigredv2/caves/lambda/research)
 "aIP" = (
@@ -12629,7 +12646,7 @@
 	name = "\improper Medical Clinic"
 	},
 /turf/open/floor{
-	icon_state = "white"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/medical)
 "aJm" = (
@@ -12677,7 +12694,7 @@
 	name = "\improper Bar Backroom"
 	},
 /turf/open/floor{
-	icon_state = "wood"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/bar)
 "aJs" = (
@@ -12689,17 +12706,6 @@
 "aJt" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 6
-	},
-/turf/open/floor{
-	icon_state = "freezerfloor"
-	},
-/area/bigredv2/outside/hydroponics)
-"aJu" = (
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 4
-	},
-/obj/structure/machinery/door/airlock/almayer/generic{
-	name = "\improper Kitchen Storage"
 	},
 /turf/open/floor{
 	icon_state = "freezerfloor"
@@ -12733,7 +12739,7 @@
 "aJy" = (
 /obj/structure/surface/table/woodentable,
 /turf/open/floor{
-	icon_state = "darkish"
+	icon_state = "dark"
 	},
 /area/bigredv2/outside/chapel)
 "aJz" = (
@@ -12744,7 +12750,7 @@
 	name = "\improper Kitchen Storage"
 	},
 /turf/open/floor{
-	icon_state = "yellowfull"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/hydroponics)
 "aJA" = (
@@ -13044,8 +13050,8 @@
 	pixel_x = 32
 	},
 /turf/open/floor{
-	dir = 8;
-	icon_state = "asteroidwarning"
+	dir = 1;
+	icon_state = "asteroidfloor"
 	},
 /area/bigredv2/outside/c)
 "aKn" = (
@@ -13072,8 +13078,8 @@
 	pixel_x = -32
 	},
 /turf/open/floor{
-	dir = 4;
-	icon_state = "asteroidwarning"
+	dir = 1;
+	icon_state = "asteroidfloor"
 	},
 /area/bigredv2/outside/c)
 "aKr" = (
@@ -13353,7 +13359,7 @@
 	name = "\improper Medical Command Complex"
 	},
 /turf/open/floor{
-	icon_state = "white"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/admin_building)
 "aLf" = (
@@ -13792,8 +13798,7 @@
 	name = "\improper Lambda Lab"
 	},
 /turf/open/floor{
-	dir = 8;
-	icon_state = "darkpurple2"
+	icon_state = "delivery"
 	},
 /area/bigredv2/caves/lambda/research)
 "aMr" = (
@@ -13869,17 +13874,6 @@
 	icon_state = "whitegreen"
 	},
 /area/bigredv2/caves/lambda/virology)
-"aMA" = (
-/obj/structure/pipes/standard/simple/hidden/green,
-/obj/structure/machinery/door/airlock/almayer/research/colony{
-	dir = 1;
-	name = "\improper Virology Lab Decontamination"
-	},
-/turf/open/floor{
-	dir = 1;
-	icon_state = "warnwhite"
-	},
-/area/bigredv2/outside/virology)
 "aMB" = (
 /obj/structure/surface/table,
 /obj/effect/decal/cleanable/dirt,
@@ -13896,7 +13890,9 @@
 	dir = 1;
 	name = "\improper General Store"
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/general_store)
 "aMF" = (
 /obj/structure/pipes/standard/simple/hidden/green,
@@ -13904,7 +13900,7 @@
 	name = "\improper Operations"
 	},
 /turf/open/floor{
-	icon_state = "white"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/admin_building)
 "aMG" = (
@@ -14146,12 +14142,6 @@
 "aNo" = (
 /turf/open/floor,
 /area/bigredv2/outside/general_store)
-"aNp" = (
-/obj/structure/machinery/door/airlock/almayer/medical/glass/colony{
-	name = "\improper General Store"
-	},
-/turf/open/floor,
-/area/bigredv2/outside/general_store)
 "aNq" = (
 /obj/structure/barricade/wooden{
 	desc = "This barricade is heavily reinforced. Nothing short of blasting it open seems like it'll do the trick, that or melting the breams supporting it...";
@@ -14295,7 +14285,7 @@
 	dir = 4
 	},
 /turf/open/floor{
-	icon_state = "dark"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/admin_building)
 "aNI" = (
@@ -14717,7 +14707,7 @@
 	name = "\improper Operations Bedroom"
 	},
 /turf/open/floor{
-	icon_state = "wood"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/admin_building)
 "aOO" = (
@@ -14764,7 +14754,9 @@
 	dir = 1;
 	name = "\improper Crew Habitation Complex"
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/hydroponics)
 "aOV" = (
 /obj/structure/bed/chair{
@@ -14980,7 +14972,7 @@
 	name = "\improper Virology Lab Decontamination"
 	},
 /turf/open/floor{
-	icon_state = "warnwhite"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/virology)
 "aPu" = (
@@ -15721,7 +15713,7 @@
 	name = "\improper Bar"
 	},
 /turf/open/floor{
-	icon_state = "wood"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/bar)
 "aRp" = (
@@ -15730,7 +15722,7 @@
 	name = "\improper Kitchen"
 	},
 /turf/open/floor{
-	icon_state = "yellowfull"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/hydroponics)
 "aRq" = (
@@ -15762,7 +15754,7 @@
 	name = "\improper Library"
 	},
 /turf/open/floor{
-	icon_state = "wood"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/library)
 "aRv" = (
@@ -16005,21 +15997,25 @@
 	dir = 1;
 	name = "\improper Operations EVA"
 	},
-/turf/open/floor/plating,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/admin_building)
 "aSc" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/generic{
 	name = "\improper Bar"
 	},
 /turf/open/floor{
-	icon_state = "wood"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/bar)
 "aSe" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/generic{
 	name = "\improper Kitchen"
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/hydroponics)
 "aSf" = (
 /obj/structure/pipes/standard/simple/hidden/green,
@@ -16169,7 +16165,7 @@
 	name = "\improper Virology Lab Cell"
 	},
 /turf/open/floor{
-	icon_state = "freezerfloor"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/virology)
 "aSB" = (
@@ -16315,7 +16311,7 @@
 	name = "\improper General Store Security"
 	},
 /turf/open/floor{
-	icon_state = "yellowfull"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/general_store)
 "aSQ" = (
@@ -16324,7 +16320,7 @@
 	name = "\improper Operations"
 	},
 /turf/open/floor{
-	icon_state = "dark"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/admin_building)
 "aSR" = (
@@ -16418,8 +16414,8 @@
 "aTe" = (
 /obj/effect/decal/cleanable/blood/gibs/xeno/limb,
 /turf/open/floor{
-	dir = 10;
-	icon_state = "asteroidwarning"
+	dir = 1;
+	icon_state = "asteroidfloor"
 	},
 /area/bigredv2/outside/c)
 "aTf" = (
@@ -16427,7 +16423,8 @@
 	dir = 5
 	},
 /turf/open/floor{
-	icon_state = "asteroidwarning"
+	dir = 1;
+	icon_state = "asteroidfloor"
 	},
 /area/bigredv2/outside/c)
 "aTg" = (
@@ -16438,8 +16435,8 @@
 	dir = 4
 	},
 /turf/open/floor{
-	dir = 6;
-	icon_state = "asteroidwarning"
+	dir = 1;
+	icon_state = "asteroidfloor"
 	},
 /area/bigredv2/outside/c)
 "aTh" = (
@@ -16455,7 +16452,8 @@
 	dir = 1
 	},
 /turf/open/floor{
-	icon_state = "asteroidwarning"
+	dir = 1;
+	icon_state = "asteroidfloor"
 	},
 /area/bigredv2/outside/c)
 "aTj" = (
@@ -16464,7 +16462,8 @@
 	dir = 4
 	},
 /turf/open/floor{
-	icon_state = "asteroidwarning"
+	dir = 1;
+	icon_state = "asteroidfloor"
 	},
 /area/bigredv2/outside/c)
 "aTk" = (
@@ -16481,7 +16480,8 @@
 	dir = 4
 	},
 /turf/open/floor{
-	icon_state = "asteroidwarning"
+	dir = 1;
+	icon_state = "asteroidfloor"
 	},
 /area/bigredv2/outside/e)
 "aTo" = (
@@ -16514,12 +16514,10 @@
 	},
 /area/bigredv2/outside/e)
 "aTs" = (
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor{
-	dir = 1;
-	icon_state = "asteroidwarning"
+	icon_state = "delivery"
 	},
-/area/bigredv2/outside/e)
+/area/bigred/ground/garage_workshop)
 "aTt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/pipes/standard/simple/hidden/green,
@@ -16809,8 +16807,9 @@
 /area/bigredv2/outside/c)
 "aUi" = (
 /obj/effect/decal/cleanable/blood/xeno,
-/turf/open/mars_cave{
-	icon_state = "mars_dirt_4"
+/turf/open/floor{
+	dir = 1;
+	icon_state = "asteroidfloor"
 	},
 /area/bigredv2/outside/c)
 "aUk" = (
@@ -16892,8 +16891,7 @@
 	name = "Lambda Lockdown"
 	},
 /turf/open/floor{
-	dir = 1;
-	icon_state = "asteroidfloor"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/lambda_cave_cas)
 "aUv" = (
@@ -16916,8 +16914,7 @@
 	name = "Lambda Lockdown"
 	},
 /turf/open/floor{
-	dir = 1;
-	icon_state = "asteroidfloor"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/lambda_cave_cas)
 "aUx" = (
@@ -17037,9 +17034,10 @@
 	},
 /area/bigredv2/outside/virology)
 "aUQ" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor{
-	dir = 9;
-	icon_state = "asteroidwarning"
+	dir = 1;
+	icon_state = "asteroidfloor"
 	},
 /area/bigredv2/outside/w)
 "aUS" = (
@@ -17220,8 +17218,9 @@
 /area/bigredv2/outside/admin_building)
 "aVn" = (
 /obj/effect/landmark/hunter_primary,
-/turf/open/mars{
-	icon_state = "mars_dirt_10"
+/turf/open/floor{
+	dir = 9;
+	icon_state = "asteroidwarning"
 	},
 /area/bigredv2/outside/c)
 "aVo" = (
@@ -17364,7 +17363,7 @@
 	name = "\improper General Store"
 	},
 /turf/open/floor{
-	icon_state = "bar"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/general_store)
 "aVK" = (
@@ -17644,7 +17643,9 @@
 	dir = 1;
 	name = "\improper Operations Armory"
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/admin_building)
 "aWD" = (
 /obj/structure/machinery/computer3/server,
@@ -17683,7 +17684,7 @@
 /area/bigredv2/outside/admin_building)
 "aWI" = (
 /turf/open/floor{
-	dir = 6;
+	dir = 9;
 	icon_state = "asteroidwarning"
 	},
 /area/bigredv2/outside/c)
@@ -17733,7 +17734,7 @@
 	name = "\improper Virology Lab Chemistry"
 	},
 /turf/open/floor{
-	icon_state = "white"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/virology)
 "aWQ" = (
@@ -17792,11 +17793,12 @@
 	},
 /area/bigredv2/outside/w)
 "aWW" = (
+/obj/effect/landmark/crap_item,
 /turf/open/floor{
-	dir = 10;
+	dir = 1;
 	icon_state = "asteroidwarning"
 	},
-/area/bigredv2/outside/w)
+/area/bigredv2/outside/c)
 "aWX" = (
 /obj/structure/surface/table,
 /obj/item/toy/prize/ripley,
@@ -17900,7 +17902,9 @@
 /obj/structure/machinery/door/airlock/multi_tile/almayer/generic{
 	name = "\improper Office Complex"
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/office_complex)
 "aXr" = (
 /turf/open/floor,
@@ -17928,7 +17932,7 @@
 	name = "\improper Virology Lab Cell"
 	},
 /turf/open/floor{
-	icon_state = "freezerfloor"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/virology)
 "aXy" = (
@@ -18088,8 +18092,9 @@
 	},
 /area/bigredv2/outside/e)
 "aXY" = (
-/turf/open/mars{
-	icon_state = "mars_dirt_3"
+/turf/open/floor{
+	dir = 10;
+	icon_state = "asteroidwarning"
 	},
 /area/bigredv2/outside/w)
 "aXZ" = (
@@ -18098,7 +18103,9 @@
 	dir = 1;
 	name = "\improper General Store Maintenance"
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/general_store)
 "aYc" = (
 /obj/structure/machinery/light,
@@ -18148,7 +18155,7 @@
 	name = "\improper Operations Office"
 	},
 /turf/open/floor{
-	icon_state = "dark"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/admin_building)
 "aYo" = (
@@ -18156,7 +18163,7 @@
 	name = "\improper Operations Toilet"
 	},
 /turf/open/floor{
-	icon_state = "freezerfloor"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/admin_building)
 "aYp" = (
@@ -18405,12 +18412,12 @@
 	name = "\improper Chapel"
 	},
 /turf/open/floor{
-	icon_state = "darkish"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/chapel)
 "aZi" = (
 /turf/open/floor{
-	icon_state = "darkish"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/chapel)
 "aZj" = (
@@ -18430,7 +18437,7 @@
 	name = "\improper Virology Lab Decontamination"
 	},
 /turf/open/floor{
-	icon_state = "white"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/virology)
 "aZl" = (
@@ -18568,7 +18575,7 @@
 	dir = 6
 	},
 /turf/open/floor{
-	icon_state = "darkish"
+	icon_state = "dark"
 	},
 /area/bigredv2/outside/chapel)
 "aZK" = (
@@ -18576,7 +18583,7 @@
 	dir = 9
 	},
 /turf/open/floor{
-	icon_state = "darkish"
+	icon_state = "dark"
 	},
 /area/bigredv2/outside/chapel)
 "aZL" = (
@@ -18585,7 +18592,9 @@
 	dir = 1;
 	name = "\improper General Store Maintenance"
 	},
-/turf/open/floor/plating,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/cargo)
 "aZM" = (
 /obj/effect/landmark/crap_item,
@@ -18681,8 +18690,8 @@
 "baa" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor{
-	dir = 8;
-	icon_state = "asteroidwarning"
+	dir = 1;
+	icon_state = "asteroidfloor"
 	},
 /area/bigredv2/outside/c)
 "bac" = (
@@ -18874,7 +18883,9 @@
 /obj/structure/machinery/door/airlock/multi_tile/almayer/comdoor/colony{
 	name = "\improper Operations"
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/admin_building)
 "baJ" = (
 /obj/structure/pipes/standard/simple/hidden/green,
@@ -18999,7 +19010,9 @@
 	dir = 1;
 	name = "\improper Cargo Bay"
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/cargo)
 "bbh" = (
 /obj/effect/landmark/survivor_spawner,
@@ -19203,13 +19216,13 @@
 	dir = 4
 	},
 /turf/open/floor{
-	icon_state = "darkish"
+	icon_state = "dark"
 	},
 /area/bigredv2/outside/chapel)
 "bbG" = (
 /obj/structure/pipes/standard/manifold/hidden/green,
 /turf/open/floor{
-	icon_state = "darkish"
+	icon_state = "dark"
 	},
 /area/bigredv2/outside/chapel)
 "bbH" = (
@@ -19218,7 +19231,7 @@
 	},
 /obj/effect/landmark/crap_item,
 /turf/open/floor{
-	icon_state = "darkish"
+	icon_state = "dark"
 	},
 /area/bigredv2/outside/chapel)
 "bbI" = (
@@ -19226,7 +19239,7 @@
 	dir = 8
 	},
 /turf/open/floor{
-	icon_state = "darkish"
+	icon_state = "dark"
 	},
 /area/bigredv2/outside/chapel)
 "bbJ" = (
@@ -19234,22 +19247,6 @@
 	icon_state = "mars_dirt_14"
 	},
 /area/bigredv2/outside/w)
-"bbK" = (
-/turf/open/floor{
-	dir = 9;
-	icon_state = "asteroidwarning"
-	},
-/area/bigredv2/outside/cargo)
-"bbL" = (
-/obj/structure/machinery/light{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor{
-	dir = 1;
-	icon_state = "asteroidwarning"
-	},
-/area/bigredv2/outside/cargo)
 "bbM" = (
 /obj/structure/machinery/camera/autoname{
 	dir = 4
@@ -19395,7 +19392,9 @@
 	dir = 1;
 	name = "\improper Private Office"
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/office_complex)
 "bcl" = (
 /obj/structure/bed/chair/wood/normal{
@@ -19428,14 +19427,15 @@
 /area/bigredv2/outside/w)
 "bcq" = (
 /obj/effect/landmark/crap_item,
-/turf/open/mars{
-	icon_state = "mars_dirt_10"
+/turf/open/floor{
+	dir = 1;
+	icon_state = "asteroidwarning"
 	},
 /area/bigredv2/outside/w)
 "bcr" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor{
-	dir = 8;
+	dir = 1;
 	icon_state = "asteroidwarning"
 	},
 /area/bigredv2/outside/cargo)
@@ -19452,7 +19452,10 @@
 	dir = 8;
 	health = 25000
 	},
-/turf/open/floor/plating,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "loadingarea"
+	},
 /area/bigredv2/outside/cargo)
 "bcu" = (
 /obj/structure/barricade/wooden{
@@ -19522,7 +19525,9 @@
 	dir = 1;
 	name = "\improper Cargo Bay Offices"
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/cargo)
 "bcE" = (
 /obj/structure/surface/table,
@@ -19587,7 +19592,7 @@
 	name = "\improper Operations Office"
 	},
 /turf/open/floor{
-	icon_state = "wood"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/admin_building)
 "bcL" = (
@@ -19728,7 +19733,9 @@
 	dir = 1;
 	name = "\improper Cargo Bay Offices"
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/cargo)
 "bdk" = (
 /obj/effect/landmark/crap_item,
@@ -19755,7 +19762,9 @@
 /obj/structure/machinery/door/airlock/almayer/command/colony{
 	name = "\improper Operations Meeting Room"
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/admin_building)
 "bdo" = (
 /obj/structure/pipes/standard/simple/hidden/green{
@@ -19843,7 +19852,9 @@
 /obj/structure/machinery/door/airlock/almayer/generic{
 	name = "\improper Private Office"
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/office_complex)
 "bdD" = (
 /obj/structure/machinery/light{
@@ -19868,13 +19879,13 @@
 "bdF" = (
 /obj/structure/machinery/light,
 /turf/open/floor{
-	icon_state = "darkish"
+	icon_state = "dark"
 	},
 /area/bigredv2/outside/chapel)
 "bdG" = (
 /obj/structure/machinery/power/apc,
 /turf/open/floor{
-	icon_state = "darkish"
+	icon_state = "dark"
 	},
 /area/bigredv2/outside/chapel)
 "bdI" = (
@@ -19883,7 +19894,7 @@
 	pixel_y = -30
 	},
 /turf/open/floor{
-	icon_state = "darkish"
+	icon_state = "dark"
 	},
 /area/bigredv2/outside/chapel)
 "bdK" = (
@@ -20001,11 +20012,15 @@
 /obj/structure/machinery/door/airlock/multi_tile/almayer/comdoor/colony{
 	name = "\improper Operations"
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/admin_building)
 "bek" = (
 /obj/structure/machinery/deployable/barrier,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/admin_building)
 "bel" = (
 /obj/structure/machinery/autolathe,
@@ -20024,7 +20039,9 @@
 /obj/structure/machinery/door/airlock/multi_tile/almayer/generic{
 	name = "\improper Robotics"
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/office_complex)
 "bep" = (
 /turf/open/floor{
@@ -20055,20 +20072,17 @@
 "beu" = (
 /obj/effect/landmark/hunter_primary,
 /turf/open/floor{
-	dir = 1;
-	icon_state = "asteroidfloor"
+	icon_state = "asteroidwarning"
 	},
 /area/bigredv2/outside/w)
 "bev" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor{
-	dir = 1;
-	icon_state = "asteroidfloor"
+	icon_state = "asteroidwarning"
 	},
 /area/bigredv2/outside/w)
 "bew" = (
 /turf/open/floor{
-	dir = 8;
 	icon_state = "asteroidwarning"
 	},
 /area/bigredv2/outside/cargo)
@@ -20117,7 +20131,8 @@
 	dir = 9
 	},
 /turf/open/floor{
-	icon_state = "asteroidwarning"
+	dir = 1;
+	icon_state = "asteroidfloor"
 	},
 /area/bigredv2/outside/c)
 "beF" = (
@@ -20185,8 +20200,8 @@
 /area/bigredv2/outside/office_complex)
 "beP" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor{
-	icon_state = "asteroidwarning"
+/turf/open/mars_cave{
+	icon_state = "mars_dirt_4"
 	},
 /area/bigredv2/outside/w)
 "beQ" = (
@@ -20195,9 +20210,8 @@
 	},
 /area/bigredv2/outside/w)
 "beR" = (
-/turf/open/floor{
-	dir = 10;
-	icon_state = "asteroidwarning"
+/turf/open/mars_cave{
+	icon_state = "mars_dirt_4"
 	},
 /area/bigredv2/outside/cargo)
 "beS" = (
@@ -20206,6 +20220,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor{
+	dir = 8;
 	icon_state = "asteroidwarning"
 	},
 /area/bigredv2/outside/cargo)
@@ -20225,10 +20240,13 @@
 /obj/structure/machinery/door/airlock/multi_tile/almayer/generic{
 	name = "\improper Cargo Offices"
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/cargo)
 "beW" = (
 /obj/structure/machinery/computer/cameras,
+/obj/structure/surface/table,
 /turf/open/floor,
 /area/bigredv2/outside/cargo)
 "beX" = (
@@ -20313,7 +20331,9 @@
 /obj/structure/machinery/door/airlock/almayer/generic{
 	name = "\improper Office Complex Storage"
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/office_complex)
 "bfj" = (
 /obj/structure/pipes/standard/manifold/hidden/green{
@@ -20551,8 +20571,7 @@
 	name = "\improper Office Complex Janitor Room"
 	},
 /turf/open/floor{
-	dir = 4;
-	icon_state = "whiteyellowfull"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/office_complex)
 "bfR" = (
@@ -20619,7 +20638,9 @@
 /obj/structure/machinery/door/airlock/almayer/security/glass/colony{
 	name = "\improper Cargo Bay Security"
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/cargo)
 "bgb" = (
 /obj/structure/surface/table,
@@ -21184,25 +21205,19 @@
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 6
 	},
-/turf/open/floor{
-	dir = 1;
-	icon_state = "asteroidwarning"
-	},
+/turf/open/mars,
 /area/bigredv2/outside/c)
 "bhP" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
 	},
-/turf/open/floor{
-	dir = 1;
-	icon_state = "asteroidwarning"
-	},
+/turf/open/mars,
 /area/bigredv2/outside/c)
 "bhQ" = (
 /obj/structure/pipes/standard/manifold/hidden/green,
 /turf/open/floor{
-	dir = 1;
-	icon_state = "asteroidfloor"
+	dir = 8;
+	icon_state = "asteroidwarning"
 	},
 /area/bigredv2/outside/c)
 "bhR" = (
@@ -21218,9 +21233,8 @@
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 10
 	},
-/turf/open/floor{
-	dir = 5;
-	icon_state = "asteroidwarning"
+/turf/open/mars{
+	icon_state = "mars_dirt_12"
 	},
 /area/bigredv2/outside/c)
 "bhT" = (
@@ -21228,13 +21242,15 @@
 	icon_state = "gib6"
 	},
 /turf/open/floor{
-	icon_state = "asteroidwarning"
+	dir = 1;
+	icon_state = "asteroidfloor"
 	},
 /area/bigredv2/outside/c)
 "bhU" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor{
-	icon_state = "asteroidwarning"
+	dir = 1;
+	icon_state = "asteroidfloor"
 	},
 /area/bigredv2/outside/c)
 "bhX" = (
@@ -21333,7 +21349,9 @@
 	dir = 4;
 	health = 25000
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/cargo)
 "bix" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
@@ -21373,13 +21391,17 @@
 /obj/structure/machinery/door/airlock/multi_tile/almayer/generic{
 	name = "\improper Office Complex"
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/office_complex)
 "biE" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/generic{
 	name = "\improper Office Complex Janitor Room"
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/office_complex)
 "biH" = (
 /obj/structure/machinery/landinglight/ds2{
@@ -21431,8 +21453,7 @@
 	dir = 5
 	},
 /turf/open/floor{
-	dir = 1;
-	icon_state = "asteroidfloor"
+	icon_state = "asteroidwarning"
 	},
 /area/bigredv2/outside/c)
 "biT" = (
@@ -21467,7 +21488,7 @@
 "biY" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor{
-	dir = 4;
+	dir = 1;
 	icon_state = "asteroidwarning"
 	},
 /area/bigredv2/outside/c)
@@ -21716,7 +21737,9 @@
 	dir = 1;
 	name = "\improper Cargo Bay Quartermaster"
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/cargo)
 "bjX" = (
 /turf/open/floor/plating{
@@ -21729,11 +21752,12 @@
 	},
 /area/bigredv2/outside/s)
 "bjZ" = (
+/obj/structure/barricade/wooden,
 /turf/open/floor{
-	dir = 6;
-	icon_state = "asteroidwarning"
+	dir = 1;
+	icon_state = "asteroidfloor"
 	},
-/area/bigredv2/outside/s)
+/area/bigredv2/outside/c)
 "bka" = (
 /turf/open/mars{
 	icon_state = "mars_dirt_3"
@@ -21761,16 +21785,18 @@
 "bke" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor{
-	dir = 4;
-	icon_state = "asteroidwarning"
+/turf/open/mars{
+	icon_state = "mars_dirt_12"
 	},
 /area/bigredv2/outside/c)
 "bkf" = (
 /obj/structure/sign/safety/distribution_pipes{
 	pixel_y = -32
 	},
-/turf/open/mars,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "asteroidfloor"
+	},
 /area/bigredv2/outside/c)
 "bkg" = (
 /obj/structure/machinery/light,
@@ -21808,7 +21834,9 @@
 	dir = 1;
 	name = "\improper Cargo Bay Storage"
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/cargo)
 "bkp" = (
 /turf/open/mars{
@@ -21837,14 +21865,18 @@
 	dir = 1;
 	name = "\improper Atmospherics Condenser"
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bkw" = (
 /obj/structure/machinery/door/airlock/almayer/engineering/colony{
 	dir = 1;
 	name = "\improper Atmospherics Condenser"
 	},
-/turf/open/floor/plating,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bkx" = (
 /obj/effect/spawner/gibspawner/human,
@@ -21853,7 +21885,9 @@
 	dir = 1;
 	name = "\improper Atmospherics Condenser"
 	},
-/turf/open/floor/plating,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bky" = (
 /turf/open/mars_cave{
@@ -21864,7 +21898,9 @@
 /obj/structure/machinery/door/airlock/almayer/engineering/colony{
 	name = "\improper Cargo Bay Quartermaster"
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/cargo)
 "bkA" = (
 /obj/structure/bed/chair/office/dark,
@@ -22162,18 +22198,10 @@
 	},
 /turf/open/floor/plating,
 /area/bigredv2/outside/filtration_plant)
-"blK" = (
-/obj/structure/machinery/door/airlock/multi_tile/almayer/generic{
-	name = "\improper Engineering Complex"
-	},
-/turf/open/floor{
-	icon_state = "dark"
-	},
-/area/bigredv2/outside/engineering)
 "blL" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor{
-	icon_state = "dark"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/engineering)
 "blT" = (
@@ -22512,7 +22540,9 @@
 /obj/structure/machinery/door/airlock/almayer/engineering/colony{
 	name = "\improper Atmospherics Condenser Storage"
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bnl" = (
 /obj/effect/decal/cleanable/dirt,
@@ -22541,6 +22571,7 @@
 /area/bigredv2/outside/filtration_plant)
 "bnp" = (
 /obj/structure/machinery/computer/area_atmos/area,
+/obj/structure/surface/table,
 /turf/open/floor,
 /area/bigredv2/outside/filtration_plant)
 "bnq" = (
@@ -22557,7 +22588,9 @@
 	dir = 1;
 	name = "\improper Engineering SMES"
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/engineering)
 "bnt" = (
 /obj/effect/decal/cleanable/dirt,
@@ -22617,7 +22650,9 @@
 	dir = 1;
 	name = "\improper Atmospherics Condenser"
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bnB" = (
 /obj/structure/pipes/standard/simple/hidden/green{
@@ -22703,7 +22738,9 @@
 /obj/structure/machinery/door/airlock/almayer/secure/colony{
 	name = "\improper Engineering Secure Storage"
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/engineering)
 "bnV" = (
 /obj/structure/sign/safety/electronics{
@@ -22891,14 +22928,18 @@
 	dir = 1;
 	name = "\improper Chief Engineer's Office"
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/engineering)
 "boV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/machinery/door/airlock/multi_tile/almayer/generic{
 	name = "\improper Engineering Complex"
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/engineering)
 "boW" = (
 /obj/structure/closet/secure_closet/atmos_personal,
@@ -22963,7 +23004,9 @@
 	dir = 1;
 	name = "\improper Engineering Tool Storage"
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/engineering)
 "bpl" = (
 /obj/structure/machinery/light{
@@ -23032,7 +23075,9 @@
 	dir = 1;
 	name = "\improper Engineering Lockers"
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/engineering)
 "bpA" = (
 /obj/structure/pipes/standard/simple/hidden/green,
@@ -23040,7 +23085,9 @@
 	dir = 1;
 	name = "\improper Engineering Lockers"
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/engineering)
 "bpC" = (
 /obj/structure/reagent_dispensers/fueltank,
@@ -23227,7 +23274,9 @@
 	dir = 1;
 	name = "\improper Engineering Break Room"
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/engineering)
 "bqg" = (
 /turf/open/floor/plating{
@@ -23312,7 +23361,9 @@
 /obj/structure/machinery/door/airlock/almayer/engineering/colony{
 	name = "\improper Engineering Workshop"
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/engineering)
 "bqM" = (
 /obj/effect/decal/cleanable/dirt,
@@ -23334,7 +23385,9 @@
 	name = "\improper Engine Reactor Control"
 	},
 /obj/structure/pipes/standard/simple/hidden/green,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/engineering)
 "bqT" = (
 /obj/effect/decal/cleanable/dirt,
@@ -23386,7 +23439,9 @@
 /obj/structure/machinery/door/airlock/almayer/engineering/colony{
 	name = "\improper Engineering Workshop"
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/engineering)
 "brg" = (
 /obj/structure/machinery/light{
@@ -23486,9 +23541,7 @@
 /turf/open/floor,
 /area/bigredv2/outside/filtration_plant)
 "brD" = (
-/turf/open/floor{
-	icon_state = "dark"
-	},
+/turf/open/floor/plating,
 /area/bigredv2/outside/filtration_cave_cas)
 "brE" = (
 /turf/open/floor/greengrid,
@@ -23681,9 +23734,7 @@
 /area/bigredv2/outside/filtration_plant)
 "bsH" = (
 /obj/effect/landmark/hunter_primary,
-/turf/open/floor{
-	icon_state = "dark"
-	},
+/turf/open/floor,
 /area/bigredv2/outside/filtration_cave_cas)
 "bsI" = (
 /turf/open/mars{
@@ -23738,13 +23789,17 @@
 /obj/structure/machinery/door/airlock/multi_tile/almayer/generic{
 	name = "\improper Engineering Complex"
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/engineering)
 "bsY" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/generic{
 	name = "\improper Atmospherics Condenser"
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bsZ" = (
 /obj/structure/janitorialcart,
@@ -23859,7 +23914,9 @@
 	dir = 1;
 	name = "\improper Engineering Complex"
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/engineering)
 "btJ" = (
 /obj/structure/pipes/standard/simple/hidden/green{
@@ -23889,7 +23946,9 @@
 /obj/structure/machinery/door/airlock/multi_tile/almayer/generic{
 	name = "\improper Engineering Complex"
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/engineering)
 "bub" = (
 /turf/open/mars_cave{
@@ -23942,7 +24001,10 @@
 /area/bigredv2/caves_sw)
 "buB" = (
 /obj/effect/landmark/lv624/xeno_tunnel,
-/turf/open/mars,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "asteroidfloor"
+	},
 /area/bigredv2/outside/n)
 "buJ" = (
 /obj/structure/pipes/standard/simple/hidden/green,
@@ -23985,13 +24047,6 @@
 	icon_state = "mars_cave_16"
 	},
 /area/bigredv2/outside/s)
-"bvm" = (
-/obj/structure/machinery/door/airlock/almayer/engineering/colony{
-	dir = 1;
-	name = "\improper Power Substation"
-	},
-/turf/open/floor,
-/area/bigredv2/outside/lz2_south_cas)
 "bvv" = (
 /obj/structure/machinery/light{
 	dir = 1
@@ -24011,8 +24066,7 @@
 	name = "Eta Lockdown"
 	},
 /turf/open/floor{
-	dir = 1;
-	icon_state = "asteroidfloor"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/eta)
 "bvD" = (
@@ -24040,7 +24094,9 @@
 	dir = 1;
 	name = "\improper Power Substation"
 	},
-/turf/open/floor/plating,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/lz2_south_cas)
 "bvO" = (
 /turf/open/mars{
@@ -24165,12 +24221,12 @@
 	name = "\improper Eta Lab Storage Bay"
 	},
 /turf/open/floor{
-	icon_state = "loadingarea"
+	icon_state = "delivery"
 	},
 /area/bigredv2/caves/eta/storage)
 "bwH" = (
 /turf/open/floor{
-	icon_state = "loadingarea"
+	icon_state = "delivery"
 	},
 /area/bigredv2/caves/eta/storage)
 "bwI" = (
@@ -24179,7 +24235,7 @@
 	name = "\improper Eta Lab Decontamination"
 	},
 /turf/open/floor{
-	icon_state = "freezerfloor"
+	icon_state = "delivery"
 	},
 /area/bigredv2/caves/eta/research)
 "bwK" = (
@@ -24191,7 +24247,8 @@
 	dir = 5
 	},
 /turf/open/floor{
-	icon_state = "delivery"
+	dir = 1;
+	icon_state = "loadingarea"
 	},
 /area/bigredv2/caves/eta/storage)
 "bwM" = (
@@ -24199,7 +24256,8 @@
 	dir = 4
 	},
 /turf/open/floor{
-	icon_state = "delivery"
+	dir = 1;
+	icon_state = "loadingarea"
 	},
 /area/bigredv2/caves/eta/storage)
 "bwN" = (
@@ -24398,7 +24456,9 @@
 /obj/structure/machinery/door/airlock/almayer/research/glass/colony{
 	name = "\improper Eta Lab Robotics"
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/caves/eta/storage)
 "bxs" = (
 /obj/effect/decal/cleanable/dirt,
@@ -24813,7 +24873,7 @@
 	name = "\improper Eta Lab Technical Storage"
 	},
 /turf/open/floor{
-	icon_state = "dark"
+	icon_state = "delivery"
 	},
 /area/bigredv2/caves/eta/research)
 "byF" = (
@@ -24823,7 +24883,7 @@
 	name = "\improper Eta Lab Dormitories"
 	},
 /turf/open/floor{
-	icon_state = "wood"
+	icon_state = "delivery"
 	},
 /area/bigredv2/caves/eta/research)
 "byG" = (
@@ -25138,7 +25198,7 @@
 	name = "\improper Eta Lab Armory"
 	},
 /turf/open/floor{
-	icon_state = "dark"
+	icon_state = "delivery"
 	},
 /area/bigredv2/caves/eta/research)
 "bzt" = (
@@ -25326,7 +25386,7 @@
 	name = "\improper Eta Lab Server"
 	},
 /turf/open/floor{
-	icon_state = "darkish"
+	icon_state = "delivery"
 	},
 /area/bigredv2/caves/eta/storage)
 "bzR" = (
@@ -25336,7 +25396,7 @@
 	name = "\improper Eta Lab Security Office"
 	},
 /turf/open/floor{
-	icon_state = "dark"
+	icon_state = "delivery"
 	},
 /area/bigredv2/caves/eta/storage)
 "bzT" = (
@@ -25577,7 +25637,7 @@
 	name = "\improper Eta Lab Director's Office"
 	},
 /turf/open/floor{
-	icon_state = "dark"
+	icon_state = "delivery"
 	},
 /area/bigredv2/caves/eta/research)
 "bAE" = (
@@ -25864,7 +25924,7 @@
 	name = "\improper Eta Lab Maintenance Storage"
 	},
 /turf/open/floor{
-	icon_state = "dark"
+	icon_state = "delivery"
 	},
 /area/bigredv2/caves/eta/storage)
 "bBA" = (
@@ -25895,7 +25955,7 @@
 	name = "\improper Eta Lab Cell"
 	},
 /turf/open/floor{
-	icon_state = "dark"
+	icon_state = "delivery"
 	},
 /area/bigredv2/caves/eta/research)
 "bBI" = (
@@ -25955,7 +26015,7 @@
 	name = "\improper Eta Lab Cell"
 	},
 /turf/open/floor{
-	icon_state = "dark"
+	icon_state = "delivery"
 	},
 /area/bigredv2/caves/eta/xenobiology)
 "bBT" = (
@@ -26205,7 +26265,7 @@
 	name = "\improper Eta Lab Xenobiology Lab"
 	},
 /turf/open/floor{
-	icon_state = "dark"
+	icon_state = "delivery"
 	},
 /area/bigredv2/caves/eta/xenobiology)
 "bCA" = (
@@ -26305,7 +26365,7 @@
 	name = "\improper Eta Lab"
 	},
 /turf/open/floor{
-	icon_state = "dark"
+	icon_state = "delivery"
 	},
 /area/bigredv2/caves/eta/living)
 "bCS" = (
@@ -26659,7 +26719,7 @@
 	name = "\improper Eta Lab Research Office"
 	},
 /turf/open/floor{
-	icon_state = "wood"
+	icon_state = "delivery"
 	},
 /area/bigredv2/caves/eta/living)
 "bDP" = (
@@ -26667,7 +26727,9 @@
 	dir = 1;
 	name = "\improper Eta Lab Canteen"
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/caves/eta/living)
 "bDQ" = (
 /turf/open/floor{
@@ -26797,7 +26859,7 @@
 	name = "\improper Eta Lab Restroom"
 	},
 /turf/open/floor{
-	icon_state = "dark"
+	icon_state = "delivery"
 	},
 /area/bigredv2/caves/eta/living)
 "bEk" = (
@@ -26961,7 +27023,9 @@
 /obj/structure/machinery/door/airlock/almayer/research/glass/colony{
 	name = "\improper Eta Lab Relaxation"
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/caves/eta/living)
 "bEI" = (
 /obj/structure/bed/chair/comfy/orange{
@@ -27046,6 +27110,11 @@
 /obj/structure/machinery/light,
 /turf/open/floor,
 /area/bigredv2/caves/eta/living)
+"bET" = (
+/turf/open/floor{
+	icon_state = "delivery"
+	},
+/area/bigredv2/outside/office_complex)
 "bFh" = (
 /obj/structure/surface/table,
 /turf/open/floor{
@@ -27109,6 +27178,12 @@
 	icon_state = "asteroidwarning"
 	},
 /area/bigredv2/outside/filtration_plant)
+"bMz" = (
+/turf/open/floor{
+	dir = 5;
+	icon_state = "asteroidwarning"
+	},
+/area/bigredv2/outside/ne)
 "bNl" = (
 /turf/open/mars_cave{
 	icon_state = "mars_cave_2"
@@ -27231,7 +27306,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/bigredv2/outside/nw)
+/area/bigredv2/outside/nw/ceiling)
 "bZL" = (
 /obj/effect/landmark/monkey_spawn,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
@@ -27281,6 +27356,11 @@
 	icon_state = "mars_dirt_4"
 	},
 /area/bigredv2/caves/mining)
+"cgt" = (
+/turf/open/floor{
+	icon_state = "delivery"
+	},
+/area/bigredv2/outside/dorms)
 "chq" = (
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_door,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
@@ -27340,17 +27420,6 @@
 	icon_state = "mars_cave_2"
 	},
 /area/space)
-"cnm" = (
-/obj/structure/machinery/door/poddoor/almayer/closed{
-	dir = 4;
-	id = "eta";
-	name = "Eta Lockdown"
-	},
-/turf/open/floor{
-	dir = 1;
-	icon_state = "asteroidwarning"
-	},
-/area/bigredv2/outside/lz2_south_cas)
 "cns" = (
 /obj/effect/landmark/nightmare{
 	insert_tag = "se-checkpoint"
@@ -27588,6 +27657,12 @@
 	icon_state = "dark"
 	},
 /area/bigredv2/outside/marshal_office)
+"cNH" = (
+/obj/structure/pipes/standard/simple/hidden/green,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
+/area/bigredv2/outside/bar)
 "cOl" = (
 /turf/open/mars_cave{
 	icon_state = "mars_cave_18"
@@ -27597,6 +27672,14 @@
 /obj/structure/sign/poster/clf,
 /turf/closed/wall/solaris/reinforced,
 /area/bigredv2/caves/mining)
+"cOJ" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/turf/open/floor{
+	icon_state = "delivery"
+	},
+/area/bigredv2/caves/eta/research)
 "cPZ" = (
 /obj/structure/window/framed/solaris/reinforced,
 /obj/effect/decal/cleanable/dirt,
@@ -27659,6 +27742,14 @@
 "cVY" = (
 /turf/open/mars,
 /area/bigredv2/outside/space_port_lz2)
+"cYI" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/turf/open/floor{
+	icon_state = "delivery"
+	},
+/area/bigredv2/outside/hydroponics)
 "cYJ" = (
 /turf/open/mars_cave{
 	icon_state = "mars_cave_2"
@@ -27817,6 +27908,12 @@
 	icon_state = "mars_dirt_4"
 	},
 /area/bigredv2/caves/mining)
+"dvC" = (
+/obj/structure/pipes/standard/simple/hidden/green,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
+/area/bigredv2/outside/filtration_plant)
 "dwL" = (
 /obj/structure/bed/chair{
 	buckling_y = 5;
@@ -27848,7 +27945,6 @@
 "dzY" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor{
-	dir = 6;
 	icon_state = "asteroidwarning"
 	},
 /area/bigredv2/outside/c)
@@ -27954,6 +28050,9 @@
 	icon_state = "mars_cave_2"
 	},
 /area/bigredv2/caves/mining)
+"dIb" = (
+/turf/open/floor,
+/area/bigredv2/caves)
 "dIz" = (
 /turf/open/mars_cave{
 	icon_state = "mars_cave_8"
@@ -28084,7 +28183,9 @@
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/engineering)
 "dSg" = (
 /obj/effect/landmark/crap_item,
@@ -28115,6 +28216,12 @@
 	icon_state = "mars_cave_5"
 	},
 /area/bigredv2/outside/lz2_south_cas)
+"dWg" = (
+/obj/structure/pipes/standard/simple/hidden/green,
+/turf/open/mars{
+	icon_state = "mars_dirt_12"
+	},
+/area/bigredv2/outside/c)
 "dWl" = (
 /obj/structure/closet/toolcloset,
 /turf/open/floor,
@@ -28299,6 +28406,9 @@
 	icon_state = "mars_cave_9"
 	},
 /area/bigredv2/caves/mining)
+"erf" = (
+/turf/closed/wall/solaris,
+/area/bigredv2/outside/c)
 "ers" = (
 /obj/effect/landmark/nightmare{
 	insert_tag = "etatunnel"
@@ -28695,8 +28805,8 @@
 /obj/structure/machinery/door/airlock/almayer/research/glass/colony{
 	name = "\improper Lambda Lab Server Room"
 	},
-/turf/open/floor/bluegrid{
-	icon_state = "bcircuitoff"
+/turf/open/floor{
+	icon_state = "delivery"
 	},
 /area/bigredv2/caves/lambda/research)
 "fgE" = (
@@ -28730,7 +28840,7 @@
 /area/bigredv2/outside/w)
 "fjP" = (
 /turf/open/floor{
-	icon_state = "dark"
+	icon_state = "delivery"
 	},
 /area/bigredv2/caves)
 "fmd" = (
@@ -28818,6 +28928,17 @@
 	icon_state = "mars_cave_7"
 	},
 /area/bigredv2/caves_virology)
+"fwD" = (
+/obj/structure/barricade/wooden{
+	desc = "This barricade is heavily reinforced. Nothing short of blasting it open seems like it'll do the trick, that or melting the breams supporting it...";
+	dir = 4;
+	health = 25000
+	},
+/turf/open/floor{
+	dir = 8;
+	icon_state = "loadingarea"
+	},
+/area/bigredv2/outside/cargo)
 "fwO" = (
 /obj/structure/prop/almayer/cannon_cables{
 	name = "\improper Cables"
@@ -28833,9 +28954,7 @@
 /area/bigredv2/oob)
 "fwV" = (
 /obj/structure/surface/table,
-/turf/open/floor{
-	icon_state = "dark"
-	},
+/turf/open/floor,
 /area/bigredv2/caves)
 "fxh" = (
 /obj/structure/pipes/standard/simple/hidden/green{
@@ -28885,6 +29004,9 @@
 /obj/structure/pipes/standard/tank/phoron,
 /turf/open/floor/plating,
 /area/bigredv2/caves/mining)
+"fCb" = (
+/turf/open/floor,
+/area/bigredv2/outside/filtration_cave_cas)
 "fDr" = (
 /turf/open/floor{
 	dir = 1;
@@ -29059,6 +29181,12 @@
 	icon_state = "mars_dirt_4"
 	},
 /area/bigredv2/caves/mining)
+"fSJ" = (
+/obj/structure/pipes/standard/simple/hidden/green,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
+/area/bigredv2/outside/space_port)
 "fST" = (
 /obj/structure/machinery/light,
 /turf/open/floor{
@@ -29116,6 +29244,11 @@
 	icon_state = "mars_dirt_10"
 	},
 /area/bigredv2/outside/eta)
+"gad" = (
+/turf/open/floor{
+	icon_state = "delivery"
+	},
+/area/bigredv2/outside/filtration_plant)
 "gan" = (
 /obj/structure/platform_decoration/shiva{
 	dir = 1
@@ -29188,6 +29321,16 @@
 	icon_state = "mars_dirt_4"
 	},
 /area/bigredv2/caves/mining)
+"gkD" = (
+/obj/structure/barricade/wooden{
+	desc = "This barricade is heavily reinforced. Nothing short of blasting it open seems like it'll do the trick, that or melting the breams supporting it...";
+	dir = 4;
+	health = 25000
+	},
+/turf/open/floor{
+	icon_state = "delivery"
+	},
+/area/bigredv2/outside/cargo)
 "glB" = (
 /obj/structure/blocker/forcefield/multitile_vehicles,
 /turf/closed/wall/solaris/reinforced,
@@ -29217,6 +29360,12 @@
 	icon_state = "platingdmg3"
 	},
 /area/bigredv2/caves/mining)
+"gpt" = (
+/obj/effect/landmark/crap_item,
+/turf/open/floor{
+	icon_state = "asteroidwarning"
+	},
+/area/bigredv2/outside/c)
 "gpB" = (
 /turf/open/mars_cave{
 	icon_state = "mars_dirt_6"
@@ -29244,8 +29393,7 @@
 	name = "Virology Lockdown"
 	},
 /turf/open/floor{
-	dir = 1;
-	icon_state = "asteroidfloor"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/virology)
 "gsW" = (
@@ -29493,8 +29641,7 @@
 	name = "Lambda Lockdown"
 	},
 /turf/open/floor{
-	dir = 1;
-	icon_state = "asteroidfloor"
+	icon_state = "delivery"
 	},
 /area/bigredv2/caves_lambda)
 "heU" = (
@@ -29517,16 +29664,6 @@
 	icon_state = "mars_dirt_7"
 	},
 /area/bigredv2/outside/lz1_north_cas)
-"hhW" = (
-/obj/structure/machinery/door/poddoor/almayer/closed{
-	dir = 4;
-	id = "eta";
-	name = "Eta Lockdown"
-	},
-/turf/open/floor{
-	icon_state = "asteroidwarning"
-	},
-/area/bigredv2/outside/lz2_south_cas)
 "hiP" = (
 /obj/structure/sign/safety/one{
 	pixel_x = 16
@@ -29852,8 +29989,7 @@
 	name = "Virology Lockdown"
 	},
 /turf/open/floor{
-	dir = 1;
-	icon_state = "asteroidfloor"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/virology)
 "hUh" = (
@@ -30134,6 +30270,11 @@
 	icon_state = "asteroidfloor"
 	},
 /area/bigredv2/outside/lambda_cave_cas)
+"iyd" = (
+/obj/structure/machinery/computer/general_air_control,
+/obj/structure/surface/table,
+/turf/open/floor,
+/area/bigredv2/outside/filtration_plant)
 "iyY" = (
 /turf/open/mars_cave{
 	icon_state = "mars_cave_13"
@@ -30369,9 +30510,7 @@
 /area/bigredv2/outside/lambda_cave_cas)
 "iZA" = (
 /obj/structure/surface/rack,
-/turf/open/floor{
-	icon_state = "dark"
-	},
+/turf/open/floor,
 /area/bigredv2/caves)
 "jbU" = (
 /obj/effect/decal/cleanable/blood{
@@ -30401,7 +30540,10 @@
 /obj/effect/landmark/nightmare{
 	insert_tag = "crashlanding-offices"
 	},
-/turf/open/mars,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "asteroidfloor"
+	},
 /area/bigredv2/outside/c)
 "jdQ" = (
 /obj/structure/prop/dam/truck/mining{
@@ -30414,6 +30556,12 @@
 	icon_state = "mars_dirt_3"
 	},
 /area/bigredv2/outside/s)
+"jfr" = (
+/turf/open/floor{
+	dir = 5;
+	icon_state = "asteroidwarning"
+	},
+/area/bigredv2/outside/se)
 "jgw" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
@@ -30756,8 +30904,7 @@
 	name = "Eta Lockdown"
 	},
 /turf/open/floor{
-	dir = 1;
-	icon_state = "asteroidfloor"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/lz2_south_cas)
 "jOS" = (
@@ -30921,6 +31068,14 @@
 	icon_state = "mars_dirt_7"
 	},
 /area/bigredv2/caves/mining)
+"jZp" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/turf/open/floor{
+	icon_state = "delivery"
+	},
+/area/bigredv2/outside/dorms)
 "jZy" = (
 /obj/structure/prop/invuln/minecart_tracks{
 	dir = 1
@@ -31119,6 +31274,11 @@
 	icon_state = "platingdmg3"
 	},
 /area/bigredv2/caves/mining)
+"kmm" = (
+/turf/open/floor{
+	icon_state = "delivery"
+	},
+/area/bigredv2/outside/admin_building)
 "knN" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
@@ -31401,9 +31561,7 @@
 /area/bigredv2/outside/filtration_cave_cas)
 "kTs" = (
 /obj/effect/decal/cleanable/blood,
-/turf/open/floor{
-	icon_state = "dark"
-	},
+/turf/open/floor,
 /area/bigredv2/outside/filtration_cave_cas)
 "kVS" = (
 /obj/effect/landmark/crap_item,
@@ -31599,17 +31757,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/mars,
 /area/bigredv2/outside/se)
-"lvX" = (
-/obj/structure/blocker/forcefield/multitile_vehicles,
-/obj/structure/machinery/door/poddoor/almayer/closed{
-	id = "eta";
-	name = "Eta Lockdown"
-	},
-/turf/open/floor{
-	dir = 8;
-	icon_state = "asteroidwarning"
-	},
-/area/bigredv2/outside/lz2_south_cas)
 "lwT" = (
 /obj/structure/machinery/light{
 	dir = 8
@@ -31701,17 +31848,6 @@
 	icon_state = "redfull"
 	},
 /area/bigredv2/caves/eta/research)
-"lEb" = (
-/obj/structure/machinery/door/poddoor/almayer/closed{
-	dir = 4;
-	id = "lambda";
-	name = "Lambda Lockdown"
-	},
-/turf/open/floor{
-	dir = 1;
-	icon_state = "asteroidwarning"
-	},
-/area/bigredv2/outside/lambda_cave_cas)
 "lEw" = (
 /obj/item/tool/pickaxe{
 	pixel_y = -3
@@ -31721,6 +31857,11 @@
 	icon_state = "platingdmg3"
 	},
 /area/bigredv2/caves/mining)
+"lGt" = (
+/turf/open/floor{
+	icon_state = "delivery"
+	},
+/area/bigredv2/caves/eta/living)
 "lIe" = (
 /obj/item/weapon/twohanded/folded_metal_chair,
 /obj/effect/decal/cleanable/dirt,
@@ -31907,6 +32048,11 @@
 	icon_state = "mars_cave_23"
 	},
 /area/bigredv2/caves/mining)
+"maD" = (
+/turf/open/floor{
+	icon_state = "delivery"
+	},
+/area/bigredv2/outside/engineering)
 "maF" = (
 /obj/item/frame/rack,
 /obj/effect/landmark/good_item,
@@ -32112,6 +32258,11 @@
 	icon_state = "mars_cave_15"
 	},
 /area/bigredv2/caves/mining)
+"myY" = (
+/turf/open/floor{
+	icon_state = "delivery"
+	},
+/area/bigredv2/outside/filtration_cave_cas)
 "mzV" = (
 /turf/open/mars,
 /area/bigredv2/outside/filtration_plant)
@@ -32157,7 +32308,9 @@
 /area/bigredv2/outside/lz1_north_cas)
 "mGS" = (
 /obj/effect/landmark/static_comms/net_one,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/admin_building)
 "mHp" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
@@ -32238,9 +32391,7 @@
 "mRD" = (
 /obj/structure/surface/table,
 /obj/structure/machinery/computer/atmos_alert,
-/turf/open/floor{
-	icon_state = "dark"
-	},
+/turf/open/floor,
 /area/bigredv2/caves)
 "mSn" = (
 /obj/effect/decal/cleanable/blood/oil/streak,
@@ -32260,7 +32411,7 @@
 	name = "\improper Operations"
 	},
 /turf/open/floor{
-	icon_state = "dark"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/admin_building)
 "mWt" = (
@@ -32398,6 +32549,13 @@
 	icon_state = "mars_dirt_7"
 	},
 /area/bigredv2/caves_research)
+"nnK" = (
+/obj/structure/pipes/standard/simple/hidden/green,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "asteroidfloor"
+	},
+/area/bigredv2/outside/e)
 "npz" = (
 /obj/structure/surface/table,
 /obj/item/spacecash/c100,
@@ -32555,8 +32713,7 @@
 	name = "Filtration Lockdown"
 	},
 /turf/open/floor{
-	dir = 1;
-	icon_state = "asteroidfloor"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/filtration_cave_cas)
 "nKL" = (
@@ -32611,6 +32768,11 @@
 	icon_state = "mars_dirt_4"
 	},
 /area/bigredv2/caves/mining)
+"nRT" = (
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/bigredv2/outside/chapel)
 "nSP" = (
 /turf/open/mars_cave{
 	icon_state = "mars_dirt_7"
@@ -32733,6 +32895,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/bigredv2/caves/eta/research)
+"ocA" = (
+/turf/open/floor{
+	icon_state = "delivery"
+	},
+/area/bigredv2/outside/library)
 "ocG" = (
 /obj/structure/bookcase/manuals/research_and_development,
 /obj/item/storage/fancy/vials/random,
@@ -32964,13 +33131,10 @@
 	},
 /area/bigredv2/caves/mining)
 "ovq" = (
-/obj/structure/window/framed/solaris/reinforced,
-/obj/structure/machinery/door/poddoor/shutters/almayer{
-	id = "Engineering";
-	name = "\improper Engineering Shutters"
+/turf/open/floor{
+	icon_state = "delivery"
 	},
-/turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/general_offices)
 "ovB" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
 /turf/open/mars_cave{
@@ -33614,9 +33778,7 @@
 "pQv" = (
 /obj/structure/surface/table,
 /obj/effect/landmark/objective_landmark/close,
-/turf/open/floor{
-	icon_state = "dark"
-	},
+/turf/open/floor,
 /area/bigredv2/caves)
 "pQE" = (
 /obj/effect/decal/cleanable/dirt,
@@ -33761,7 +33923,7 @@
 "qaR" = (
 /obj/vehicle/powerloader/ft,
 /turf/open/floor/plating,
-/area/bigredv2/outside/nw)
+/area/bigredv2/outside/nw/ceiling)
 "qez" = (
 /obj/structure/blocker/forcefield/multitile_vehicles,
 /turf/open/mars_cave{
@@ -33984,8 +34146,7 @@
 	name = "Eta Lockdown"
 	},
 /turf/open/floor{
-	dir = 1;
-	icon_state = "asteroidfloor"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/lz2_south_cas)
 "qzY" = (
@@ -34015,8 +34176,7 @@
 	name = "\improper Workshop Garage"
 	},
 /turf/open/floor{
-	dir = 1;
-	icon_state = "asteroidfloor"
+	icon_state = "delivery"
 	},
 /area/bigred/ground/garage_workshop)
 "qFg" = (
@@ -34316,9 +34476,7 @@
 /area/bigredv2/caves/mining)
 "rjw" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor{
-	icon_state = "dark"
-	},
+/turf/open/floor,
 /area/bigredv2/outside/filtration_cave_cas)
 "rjF" = (
 /obj/structure/sign/safety/bathunisex{
@@ -34535,7 +34693,10 @@
 /area/bigredv2/outside/filtration_plant)
 "rHD" = (
 /obj/effect/landmark/lv624/xeno_tunnel,
-/turf/open/mars,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "asteroidfloor"
+	},
 /area/bigredv2/outside/c)
 "rIl" = (
 /turf/closed/wall/solaris/reinforced/hull,
@@ -35025,7 +35186,9 @@
 	dir = 1;
 	name = "\improper Engineering Workshop"
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigred/ground/garage_workshop)
 "svp" = (
 /obj/structure/surface/table,
@@ -35076,8 +35239,7 @@
 	name = "Lambda Lockdown"
 	},
 /turf/open/floor{
-	dir = 1;
-	icon_state = "asteroidfloor"
+	icon_state = "delivery"
 	},
 /area/bigredv2/caves_lambda)
 "szw" = (
@@ -35228,6 +35390,14 @@
 	icon_state = "mars_cave_10"
 	},
 /area/bigredv2/caves_east)
+"sPv" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/turf/open/floor{
+	icon_state = "delivery"
+	},
+/area/bigredv2/outside/bar)
 "sQw" = (
 /turf/open/mars_cave{
 	icon_state = "mars_cave_23"
@@ -35536,6 +35706,20 @@
 	icon_state = "mars_cave_14"
 	},
 /area/bigredv2/outside/lz2_south_cas)
+"tuu" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/obj/structure/barricade/wooden{
+	desc = "This barricade is heavily reinforced. Nothing short of blasting it open seems like it'll do the trick, that or melting the breams supporting it...";
+	dir = 4;
+	health = 25000
+	},
+/turf/open/floor{
+	dir = 8;
+	icon_state = "loadingarea"
+	},
+/area/bigredv2/outside/cargo)
 "tuN" = (
 /obj/structure/machinery/light/small,
 /turf/open/mars_cave,
@@ -35562,8 +35746,8 @@
 "tAW" = (
 /obj/effect/landmark/lv624/xeno_tunnel,
 /turf/open/floor{
-	dir = 1;
-	icon_state = "asteroidfloor"
+	dir = 4;
+	icon_state = "asteroidwarning"
 	},
 /area/bigredv2/outside/ne)
 "tBb" = (
@@ -35718,6 +35902,11 @@
 	icon_state = "platingdmg3"
 	},
 /area/bigredv2/caves/mining)
+"tKR" = (
+/turf/open/floor{
+	icon_state = "delivery"
+	},
+/area/bigredv2/outside/hydroponics)
 "tLt" = (
 /turf/open/mars_cave{
 	icon_state = "mars_cave_14"
@@ -35927,8 +36116,7 @@
 	name = "Filtration Lockdown"
 	},
 /turf/open/floor{
-	dir = 1;
-	icon_state = "asteroidfloor"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/filtration_cave_cas)
 "ujU" = (
@@ -35981,6 +36169,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor,
 /area/bigred/ground/garage_workshop)
+"upV" = (
+/obj/structure/pipes/standard/simple/hidden/green,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
+/area/bigredv2/outside/admin_building)
 "usg" = (
 /obj/item/tool/warning_cone,
 /turf/open/floor{
@@ -36277,8 +36471,8 @@
 /area/bigredv2/caves_sw)
 "vbi" = (
 /turf/open/floor{
-	dir = 4;
-	icon_state = "darkpurplecorners2"
+	dir = 5;
+	icon_state = "darkpurple2"
 	},
 /area/bigredv2/caves/lambda/research)
 "vcm" = (
@@ -36357,6 +36551,15 @@
 	icon_state = "mars_cave_13"
 	},
 /area/bigredv2/caves/mining)
+"vis" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/turf/open/floor{
+	dir = 4;
+	icon_state = "asteroidwarning"
+	},
+/area/bigredv2/outside/c)
 "viN" = (
 /obj/structure/machinery/door_control{
 	id = "workshop_br_g";
@@ -36370,7 +36573,7 @@
 	dir = 1;
 	icon_state = "asteroidwarning"
 	},
-/area/bigred/ground/garage_workshop)
+/area/bigredv2/outside/nw)
 "vjc" = (
 /obj/item/tool/warning_cone{
 	pixel_x = -13;
@@ -36406,6 +36609,13 @@
 	icon_state = "mars_dirt_4"
 	},
 /area/bigredv2/caves/mining)
+"vmm" = (
+/obj/structure/barricade/wooden,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "asteroidwarning"
+	},
+/area/bigredv2/outside/c)
 "vmI" = (
 /obj/item/device/flashlight/lantern,
 /turf/open/mars_cave{
@@ -36453,8 +36663,7 @@
 	name = "Eta Lockdown"
 	},
 /turf/open/floor{
-	dir = 1;
-	icon_state = "asteroidfloor"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/eta)
 "vqY" = (
@@ -36479,7 +36688,7 @@
 	name = "\improper Eta Lab Cell"
 	},
 /turf/open/floor{
-	icon_state = "dark"
+	icon_state = "delivery"
 	},
 /area/bigredv2/caves/eta/xenobiology)
 "vuz" = (
@@ -36731,7 +36940,7 @@
 /turf/open/floor{
 	icon_state = "asteroidwarning"
 	},
-/area/bigred/ground/garage_workshop)
+/area/bigredv2/outside/nw)
 "vYw" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
 /turf/open/mars_cave{
@@ -37122,6 +37331,14 @@
 	icon_state = "platingdmg3"
 	},
 /area/bigredv2/caves/mining)
+"wLU" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/turf/open/floor{
+	icon_state = "delivery"
+	},
+/area/bigredv2/outside/cargo)
 "wMg" = (
 /obj/item/tool/warning_cone{
 	pixel_x = 5;
@@ -37137,17 +37354,6 @@
 	icon_state = "mars_cave_9"
 	},
 /area/bigredv2/caves_north)
-"wMP" = (
-/obj/structure/machinery/door/poddoor/almayer/closed{
-	dir = 4;
-	id = "lambda";
-	name = "Lambda Lockdown"
-	},
-/turf/open/floor{
-	dir = 1;
-	icon_state = "asteroidfloor"
-	},
-/area/bigredv2/outside/lambda_cave_cas)
 "wMQ" = (
 /obj/structure/largecrate/random/secure,
 /turf/open/floor,
@@ -37159,7 +37365,7 @@
 	name = "Lambda Lockdown"
 	},
 /turf/open/floor{
-	icon_state = "asteroidwarning"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/lambda_cave_cas)
 "wNA" = (
@@ -37614,9 +37820,22 @@
 	icon_state = "platingdmg3"
 	},
 /area/bigredv2/oob)
+"xDW" = (
+/obj/structure/pipes/standard/simple/hidden/green,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
+/area/bigredv2/outside/engineering)
 "xFZ" = (
 /turf/open/mars_cave,
 /area/bigredv2/caves_lambda)
+"xGT" = (
+/turf/open/floor{
+	dir = 9;
+	icon_state = "asteroidwarning"
+	},
+/area/bigredv2/outside/w)
 "xIo" = (
 /obj/structure/window/framed/solaris/reinforced/hull,
 /turf/open/floor/plating{
@@ -37707,6 +37926,14 @@
 	icon_state = "platingdmg3"
 	},
 /area/bigredv2/caves/mining)
+"xNL" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 1
+	},
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/bigredv2/caves/lambda/research)
 "xPg" = (
 /obj/structure/barricade/handrail/wire,
 /turf/open/mars_cave{
@@ -37962,6 +38189,14 @@
 	icon_state = "mars_cave_2"
 	},
 /area/bigredv2/caves/mining)
+"yhV" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/turf/open/floor{
+	icon_state = "delivery"
+	},
+/area/bigredv2/outside/filtration_plant)
 "yjU" = (
 /obj/item/weapon/broken_bottle,
 /turf/open/floor/plating{
@@ -42427,7 +42662,7 @@ aJg
 aJg
 aJg
 aLU
-aMA
+aPt
 aNb
 aOr
 aPt
@@ -43257,7 +43492,7 @@ aae
 aao
 qsE
 qsE
-vLd
+aTs
 suV
 qsE
 qsE
@@ -43482,7 +43717,7 @@ clB
 uIB
 shV
 qsE
-vLd
+aTs
 suV
 qsE
 qsE
@@ -45222,9 +45457,9 @@ pdN
 aeI
 aeI
 aeI
-aiz
-ahP
-atl
+aoO
+aiw
+aqp
 aqp
 aqp
 aiw
@@ -45424,26 +45659,26 @@ aam
 aam
 ago
 aae
-aeI
+ahR
 aeI
 aeI
 aeI
 aeI
 auF
-aiy
-akd
-aiy
-aiy
+ajx
+aoN
+ajx
+ajx
 ahT
 aeI
 aeI
 aeI
 aeI
-aiA
-aoO
+ajy
+ajx
 aoN
-aoN
-aoN
+akd
+akd
 akd
 aiy
 aoN
@@ -45451,10 +45686,10 @@ ajx
 amc
 aix
 aix
-alm
-alm
-alm
-alm
+aix
+aix
+aix
+aix
 aDx
 aDw
 ahP
@@ -45641,7 +45876,7 @@ aah
 aah
 aeG
 aae
-aeI
+ahR
 aeI
 aeI
 aeI
@@ -45656,23 +45891,23 @@ aeI
 aeI
 aeI
 aiz
-aoO
+ajy
+ajx
+ahR
+ahP
+aqJ
+ahP
+ahP
+ajy
+ajx
+ajY
 ajx
 ajx
 ajx
-atm
-ahP
-ahP
-aoO
-aiw
-axW
-aiw
-ahQ
-ahP
-ahP
-ahP
-ahP
-aDy
+ajx
+ajx
+ajx
+ajY
 akK
 ahP
 auF
@@ -45704,14 +45939,14 @@ aSB
 aSB
 aSB
 aSB
-aVF
-aVI
-aVI
-aWk
-aWk
-aWk
-aWk
-aWk
+beP
+beP
+beP
+aSB
+aSB
+aSB
+aSB
+aSB
 bgX
 bhz
 bie
@@ -45858,7 +46093,7 @@ aah
 aah
 aeG
 aae
-ahO
+ahR
 aeI
 aeI
 aeI
@@ -45875,20 +46110,20 @@ aeI
 aiA
 ajy
 aoN
-aoN
-atm
-ahP
-ahP
-ahP
-ajy
+akK
+aqJ
+aoO
+aiw
+aiw
+ajx
 ajx
 ajY
 ajx
-ahR
-ahP
-ahP
-ahP
-ahP
+ajx
+ajx
+ajx
+ajx
+ajx
 aDz
 aEv
 ahP
@@ -45921,15 +46156,15 @@ aWk
 aVI
 aWk
 aWk
-aVH
-bdZ
-bdZ
-bev
-bev
-bdZ
-bdZ
-bdZ
-bgX
+aVI
+aWk
+aWk
+aVI
+aVI
+aWk
+aWk
+aWk
+eWd
 bhA
 bie
 bie
@@ -46075,7 +46310,7 @@ aah
 aah
 aeG
 aae
-ahP
+ahR
 ahO
 aeI
 aeI
@@ -46094,7 +46329,7 @@ ajz
 ajx
 akK
 ahP
-ahV
+ajy
 anp
 anp
 anp
@@ -46105,8 +46340,8 @@ anp
 anp
 anp
 anp
-ahP
-aDy
+ajx
+ajY
 akK
 ahP
 ahP
@@ -46136,17 +46371,17 @@ aXA
 aWV
 bba
 aXA
+bdZ
+aUQ
+bdZ
+bdZ
+bdZ
 aXA
 aWV
-aVG
-bdZ
-bdZ
-bdZ
-aWV
 aXA
 aXA
 aXA
-bgX
+eWd
 bhv
 bie
 bie
@@ -46292,7 +46527,7 @@ aah
 aah
 aeG
 aae
-ahQ
+ahR
 ahP
 ahO
 aeI
@@ -46311,7 +46546,7 @@ ajy
 ajx
 akK
 aln
-aeI
+ajy
 anp
 avT
 bZp
@@ -46322,8 +46557,8 @@ azn
 avT
 avT
 anp
-ahP
-aDy
+ajx
+ajY
 ahR
 ahP
 ahP
@@ -46353,9 +46588,9 @@ aYE
 aYE
 aYE
 aSB
-aSB
-aSB
 aVG
+bdZ
+bdZ
 bdZ
 beu
 beP
@@ -46528,7 +46763,7 @@ ajy
 ajx
 ahR
 aln
-aeI
+ajy
 bFw
 bjj
 bjj
@@ -46539,8 +46774,8 @@ azo
 aAq
 aAZ
 anp
-ahP
-aDy
+ajx
+ajY
 ajx
 aiw
 aiw
@@ -46558,21 +46793,21 @@ aEu
 aEu
 aEu
 aEu
-aUQ
-aVI
 aWk
-aWW
-aSB
+aUQ
+bdZ
+aWk
+aWk
+aWk
+aWk
+aWk
+aWk
 aXY
 aYF
-aYF
-aYF
-aYF
-aYF
 bbJ
-aSB
-aSB
-aVH
+aVG
+bdZ
+aUQ
 bdZ
 bev
 beP
@@ -46724,9 +46959,9 @@ aah
 aah
 aah
 aah
-agq
-ahe
-ahQ
+aeG
+ahK
+ajx
 aiw
 aiw
 aiw
@@ -46745,7 +46980,7 @@ ajx
 ajx
 akK
 aln
-aeI
+ajy
 bFw
 kRo
 joi
@@ -46756,7 +46991,7 @@ avT
 avT
 avT
 anp
-ahP
+ajx
 aDA
 alm
 alm
@@ -46784,12 +47019,12 @@ aoH
 asK
 asK
 asK
+beQ
 aYF
 aYF
-aYF
-bcp
-aSB
-aVH
+aVG
+bdZ
+aUQ
 bdZ
 bev
 beP
@@ -46942,8 +47177,8 @@ aah
 aah
 aah
 agr
-aeg
-ahS
+fSJ
+aix
 aix
 aix
 aix
@@ -46962,7 +47197,7 @@ ajx
 aoN
 ahR
 aln
-aeI
+ajy
 bFw
 kRo
 kRo
@@ -46973,7 +47208,7 @@ avT
 avT
 avT
 anp
-ahV
+ahR
 ahV
 ahV
 ahV
@@ -47001,20 +47236,20 @@ aoH
 aXH
 aXH
 asK
+beQ
 aYF
 aYF
-aYF
-bcp
-aSB
-aVH
+aVG
+bdZ
+aUQ
 bdZ
 bev
-beQ
 aSB
 aSB
 aSB
-aSB
-bgX
+xGT
+aWk
+eWd
 eWd
 kHK
 kHK
@@ -47158,9 +47393,9 @@ aah
 acx
 aah
 aah
-ags
-aam
-ahT
+aeG
+ahK
+ajx
 aiy
 aiy
 ajx
@@ -47179,7 +47414,7 @@ aiy
 akd
 atm
 aln
-aeI
+ajy
 bFw
 rhx
 bjv
@@ -47190,7 +47425,7 @@ azo
 aAq
 aAZ
 anp
-aeI
+ahR
 aeI
 aeI
 ahi
@@ -47218,22 +47453,22 @@ aoH
 aXH
 aXH
 asK
-aYF
+beQ
 aYF
 aYF
 bcq
-aSB
-aVG
+bdZ
+bdZ
 bdZ
 bev
-beQ
 aSB
 aSB
 aSB
+aVG
 asK
 asK
 asK
-aZu
+bdg
 bbg
 asK
 atw
@@ -47352,7 +47587,7 @@ pXu
 rgp
 aae
 aaw
-aaO
+ahK
 aaW
 aaw
 aaw
@@ -47396,7 +47631,7 @@ ahP
 ahP
 ahP
 ahP
-aog
+ajy
 anp
 avT
 avT
@@ -47407,7 +47642,7 @@ avT
 avT
 avT
 anp
-aeI
+ahR
 aeI
 aeI
 aeI
@@ -47435,18 +47670,18 @@ aoH
 aXH
 aXH
 asK
-aYF
+beQ
 bbb
 aYF
-bcp
-aSB
 aVG
 bdZ
+bdZ
+bdZ
 bev
-beQ
+aSB
 aSB
 bfU
-aSB
+aVG
 asK
 svp
 svp
@@ -47594,7 +47829,7 @@ aah
 aah
 aeG
 aae
-ahT
+ahR
 ahP
 ahP
 ajy
@@ -47613,7 +47848,7 @@ ahP
 ahP
 ahP
 ahP
-aoO
+ajy
 anp
 avU
 avT
@@ -47624,7 +47859,7 @@ avT
 avT
 aBa
 anp
-aeI
+ahR
 aeI
 aeI
 aeI
@@ -47652,18 +47887,18 @@ aoH
 aXH
 aXH
 asK
-aYF
+beQ
 aYF
 bbc
-aSB
-aSB
 aVG
+bdZ
 bdZ
 bdZ
 beQ
 aSB
 aSB
 aSB
+aVG
 asK
 bhb
 bhb
@@ -47811,7 +48046,7 @@ afg
 afg
 adl
 aae
-ahV
+ahR
 ahV
 ahP
 ajy
@@ -47830,8 +48065,8 @@ aiw
 aiw
 aiw
 aiw
-ajy
-avs
+ajx
+axv
 avT
 avT
 avT
@@ -47841,7 +48076,7 @@ avT
 avT
 avT
 anp
-aeI
+ahR
 aeI
 aeI
 aeI
@@ -47869,18 +48104,18 @@ aXZ
 aYG
 aXH
 asK
-aYF
+beQ
 bbc
 aSB
-aSB
-aSB
 aVG
+bdZ
 bdZ
 bdZ
 beQ
 aSB
 aSB
 aSB
+aVG
 asK
 bhc
 bbe
@@ -47911,7 +48146,7 @@ brG
 brG
 brG
 brG
-lvX
+qzO
 cHn
 cHn
 cHn
@@ -48047,8 +48282,8 @@ ajx
 ajx
 ajx
 ajx
-ajy
-avs
+ajx
+axv
 avT
 avT
 avT
@@ -48058,7 +48293,7 @@ avT
 avT
 avT
 anp
-aeI
+ahR
 aeI
 aeI
 aeI
@@ -48086,18 +48321,18 @@ aoH
 aYH
 aXH
 asK
-bax
+beQ
 aSB
-bbK
+beR
 bcr
-bcr
-bcr
-bcr
+bcs
+bcs
+bcs
 bew
 beR
 aSB
 aSB
-aSB
+aVG
 asK
 bhd
 bhD
@@ -48245,7 +48480,7 @@ aah
 afM
 agw
 agv
-ahX
+akK
 ahX
 aiA
 ajy
@@ -48264,7 +48499,7 @@ alm
 alm
 alm
 alm
-auE
+aix
 avt
 avV
 avV
@@ -48275,7 +48510,7 @@ avT
 avT
 avT
 anp
-aeI
+ahR
 aeI
 aeI
 aeI
@@ -48303,18 +48538,18 @@ aoH
 aYI
 aXH
 asK
-aSB
-aSB
-bbL
+bdZ
+aWk
+beS
 bcs
 bdf
 bdf
 beb
 bdf
 beS
-aSB
-aSB
-aSB
+aWk
+aWk
+bdZ
 asK
 oEJ
 oEJ
@@ -48345,7 +48580,7 @@ heU
 heU
 heU
 heU
-afe
+qzO
 bGL
 bGL
 bGL
@@ -48481,7 +48716,7 @@ ahV
 ahP
 ahP
 ahP
-auF
+ajy
 anp
 avT
 avT
@@ -48492,7 +48727,7 @@ avT
 avT
 avT
 anp
-aeI
+ahR
 aeI
 aeI
 aeI
@@ -48535,7 +48770,7 @@ atw
 asK
 asK
 asK
-baz
+wLU
 bbg
 asK
 asK
@@ -48567,7 +48802,7 @@ rJJ
 bGL
 bGL
 bGL
-bvm
+bvK
 rdR
 rdR
 bvK
@@ -48679,7 +48914,7 @@ aah
 aah
 afM
 agw
-aeI
+ahR
 ahX
 aiA
 ajy
@@ -48698,7 +48933,7 @@ aeI
 aiB
 ahV
 ahV
-ahV
+ajy
 anp
 avU
 avT
@@ -48709,7 +48944,7 @@ avT
 avT
 aBa
 anp
-aeI
+ahR
 aeI
 aeI
 aeI
@@ -48915,7 +49150,7 @@ aeI
 aeI
 aeI
 aeI
-aeI
+ajy
 anp
 avT
 avT
@@ -48926,7 +49161,7 @@ avT
 avT
 avT
 anp
-aeI
+ahR
 aeI
 aeI
 aeI
@@ -48997,10 +49232,10 @@ bme
 bme
 aao
 glB
-cnm
 jOc
 jOc
-hhW
+jOc
+jOc
 keg
 xIP
 xIP
@@ -49113,7 +49348,7 @@ aah
 aah
 afM
 ahh
-ahX
+akK
 aeI
 aiA
 ajy
@@ -49132,7 +49367,7 @@ aeI
 aeI
 aeI
 aeI
-aeI
+ajy
 anp
 qaR
 avT
@@ -49143,7 +49378,7 @@ azo
 aAq
 aAZ
 anp
-aeI
+ahR
 aeI
 aeI
 aeI
@@ -49330,7 +49565,7 @@ aae
 aae
 aae
 aae
-ahX
+atm
 aeI
 aiA
 ajz
@@ -49349,7 +49584,7 @@ aeI
 aeI
 aeI
 aeI
-aeI
+ajy
 anp
 avT
 avT
@@ -49360,7 +49595,7 @@ avT
 avT
 avT
 anp
-aeI
+ahR
 aeI
 aeI
 aeI
@@ -49566,18 +49801,18 @@ aeI
 aeI
 aeI
 aeI
-aeI
+ajy
 anp
 anp
 alX
-aqw
+ayN
 ayd
 alX
 anp
 anp
 anp
 anp
-aeI
+ahR
 aeI
 aeI
 ahi
@@ -49783,18 +50018,18 @@ aeI
 aeI
 aeI
 aeI
-aeI
-aeI
-aeI
+ajy
+ajx
+ajx
 alu
 aqw
 azv
 alu
-aeI
-aeI
-aeI
-aeI
-aeI
+ajx
+ajx
+ajx
+ajx
+ahR
 aeI
 aeI
 aeI
@@ -50000,18 +50235,18 @@ aiw
 aiw
 aiw
 aiw
-aiw
-aiw
-aiw
+ajx
+ajx
+ajx
 alu
 aqw
 aye
 alu
-aiw
-aiw
-aiw
-aiw
-aiw
+ajx
+ajx
+ajx
+ajx
+ajx
 aiw
 aiw
 aiw
@@ -50076,7 +50311,7 @@ bmi
 bmi
 brI
 bmi
-ovq
+azb
 bpx
 bpx
 bpx
@@ -50221,7 +50456,7 @@ alu
 alu
 alu
 alu
-aqw
+ayN
 ayd
 alu
 alu
@@ -50293,7 +50528,7 @@ bmi
 bmi
 bmg
 bmi
-ovq
+azb
 kdh
 aao
 aao
@@ -50473,7 +50708,7 @@ aXH
 asK
 asK
 atA
-aZu
+bdg
 bbg
 auk
 asK
@@ -50496,7 +50731,7 @@ bfz
 aZO
 aZu
 bli
-blK
+bsX
 bmg
 bmO
 bmy
@@ -51108,8 +51343,8 @@ aBR
 aBR
 aMc
 aoH
-aNp
-aNp
+aVJ
+aVJ
 aoH
 aQO
 aOC
@@ -51124,7 +51359,7 @@ aXH
 asK
 asK
 atA
-aZu
+bdg
 bbg
 auk
 asK
@@ -51712,13 +51947,13 @@ adi
 adz
 adz
 acp
-agu
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
+aao
+aiw
+aiw
+aiw
+aiw
+aiw
+ahQ
 aeI
 aeI
 aeI
@@ -51759,8 +51994,8 @@ aBR
 aBR
 aMc
 aoH
-aNp
-aNp
+aVJ
+aVJ
 aoH
 aQR
 aNo
@@ -51935,7 +52170,7 @@ acp
 agy
 agy
 acp
-aeI
+ahR
 aeI
 aeI
 aeI
@@ -52000,11 +52235,11 @@ asK
 aZu
 beh
 aZO
-aZu
+bdg
 aZO
 bbO
 aZu
-aZu
+bdg
 aZu
 aZO
 biq
@@ -52152,7 +52387,7 @@ afO
 adk
 adS
 acp
-aeI
+ahR
 aeI
 aeI
 aeI
@@ -52174,7 +52409,7 @@ auK
 aqw
 azv
 arR
-aqw
+ayN
 arR
 arR
 azu
@@ -52369,8 +52604,8 @@ aeJ
 adS
 adk
 acp
-aeI
-aeI
+ajx
+ahQ
 aeI
 aeI
 aiz
@@ -52587,13 +52822,13 @@ agz
 ahj
 acp
 acp
+ajx
 aiw
 aiw
 aiw
 aiw
-aiw
-aiw
-aiw
+ajx
+ajx
 aiw
 aiw
 ajx
@@ -53090,8 +53325,8 @@ bfH
 bgb
 bei
 asK
-aZu
-bbi
+bdg
+gkD
 biw
 asK
 eLq
@@ -53296,7 +53531,7 @@ atw
 atw
 atw
 asK
-aZu
+bdg
 bcD
 asK
 atw
@@ -53307,9 +53542,9 @@ asK
 asK
 asK
 asK
-bbi
-bbi
-biw
+fwD
+fwD
+tuu
 asK
 asK
 asK
@@ -53528,12 +53763,12 @@ bgF
 bgF
 bhR
 biR
-aHF
+aMg
+bjx
+bjx
+bjx
+bjx
 bjw
-bjY
-bka
-bjA
-bjA
 axX
 dWl
 bmi
@@ -53745,12 +53980,12 @@ aVo
 aIn
 biy
 biS
-aMg
-bjx
-bjZ
+aIn
+bjy
+bjy
 bjy
 bjB
-bjA
+blq
 axX
 bmp
 bmi
@@ -53967,7 +54202,7 @@ bjy
 bjy
 bjy
 bkp
-bjA
+blq
 axX
 bmq
 bmi
@@ -54141,11 +54376,11 @@ aFG
 aFG
 aHz
 alu
-aHD
-aBR
-aBR
-aBR
-aBS
+aHF
+aFM
+aFM
+aFM
+aFM
 aFM
 aOE
 aFM
@@ -54184,7 +54419,7 @@ bjz
 bjz
 bkp
 bjA
-bjA
+blq
 axX
 trr
 bmg
@@ -54358,11 +54593,11 @@ aqw
 aqw
 awO
 alu
-aHD
-aBR
-aLd
-aKl
-aMc
+aHF
+aHF
+aHF
+aHF
+aHF
 apC
 apC
 apC
@@ -54401,7 +54636,7 @@ bjA
 bjA
 bjA
 bjA
-bkC
+blq
 axX
 bms
 bmg
@@ -54575,10 +54810,10 @@ aEE
 aGB
 aHA
 alu
-aHD
-aKl
-aIn
-aIn
+aHF
+aHF
+aHF
+aHF
 apC
 apC
 aOF
@@ -54618,7 +54853,7 @@ bjB
 bjA
 bjA
 bkC
-bkd
+blq
 axX
 axX
 axX
@@ -54794,8 +55029,8 @@ alu
 alu
 alu
 aKm
-aFM
-aFM
+aHF
+aHF
 uRE
 aGD
 aMf
@@ -55443,11 +55678,11 @@ arR
 arl
 arR
 aDN
-aqw
+ayN
 aKp
 aQW
 aMf
-aMf
+kmm
 aNA
 aMf
 aMf
@@ -55833,7 +56068,7 @@ aao
 aao
 aao
 aao
-acP
+alF
 buB
 acp
 afl
@@ -55879,8 +56114,8 @@ aqw
 aIk
 alu
 aKq
-aMg
-aMg
+aHF
+aHF
 apC
 aNC
 aMf
@@ -56051,7 +56286,7 @@ aao
 aao
 aao
 acP
-acP
+asc
 acp
 afm
 afS
@@ -56095,9 +56330,9 @@ aqw
 arl
 aqw
 alu
-aIn
-aIn
-aKt
+aHF
+aHF
+aHF
 apD
 aND
 aMf
@@ -56268,7 +56503,7 @@ aao
 aao
 aao
 acP
-acP
+asc
 acp
 xyu
 afS
@@ -56312,9 +56547,9 @@ arl
 aqw
 aIl
 alu
-aIn
-aIp
-aBR
+aHF
+aHF
+aHF
 apD
 aNE
 aOH
@@ -56355,13 +56590,13 @@ bkc
 bkc
 bkc
 blt
-bmz
+xDW
 bmz
 bna
 bmz
 boc
 bmz
-bmz
+xDW
 bop
 bpO
 bop
@@ -56485,7 +56720,7 @@ aao
 aao
 acP
 acP
-acP
+asc
 acp
 afn
 afT
@@ -56529,9 +56764,9 @@ alu
 alu
 alu
 alu
-aIp
-aBR
-aBR
+aHF
+aHF
+aHF
 apC
 aOM
 aOM
@@ -56702,7 +56937,7 @@ aao
 acP
 acP
 acP
-acP
+asc
 acp
 afo
 afT
@@ -56737,18 +56972,18 @@ ayV
 ayV
 bBg
 alu
-aBR
-aBR
-aBR
-aBR
-aCM
-aBR
-aBR
-aBR
-aBR
-aBR
-aBR
-aBR
+aHF
+aMg
+aMg
+aMg
+aBS
+aMg
+aMg
+aMg
+aMg
+aMg
+aMg
+aHF
 apC
 aOM
 aOM
@@ -56798,7 +57033,7 @@ bjx
 bjx
 bjx
 bjx
-bjx
+bjw
 axX
 bru
 bmg
@@ -56809,7 +57044,7 @@ axX
 axX
 axX
 axX
-bjA
+bjY
 bjA
 bjA
 bjA
@@ -56919,7 +57154,7 @@ acP
 acP
 acP
 acP
-acP
+asc
 acp
 afp
 afT
@@ -56954,7 +57189,7 @@ ayW
 ayV
 bBg
 alu
-aBR
+aHD
 aBR
 aBR
 aBR
@@ -56965,7 +57200,7 @@ aBR
 aBR
 aBR
 aFL
-aBS
+aMc
 apC
 aNG
 aOI
@@ -57015,7 +57250,7 @@ bjA
 bjA
 bjA
 bjA
-bjA
+blq
 axX
 brv
 bmi
@@ -57026,7 +57261,7 @@ bop
 bop
 boq
 axX
-bjA
+bjY
 bjA
 bjA
 bjA
@@ -57136,7 +57371,7 @@ acP
 acP
 acP
 acP
-acP
+asc
 acp
 afo
 afT
@@ -57171,7 +57406,7 @@ alu
 alu
 alu
 alu
-aBR
+aHD
 aBR
 aBR
 aBR
@@ -57232,7 +57467,7 @@ bjA
 bjA
 bjA
 bjA
-bjA
+blq
 axX
 brw
 bmi
@@ -57243,7 +57478,7 @@ bpC
 bmi
 bor
 axX
-bjA
+bjY
 bjA
 bjA
 bkC
@@ -57350,10 +57585,10 @@ aao
 aao
 aao
 acP
-acP
-acP
-acP
-acP
+agq
+ahe
+ahe
+ahS
 acp
 afq
 afS
@@ -57373,22 +57608,22 @@ aoj
 aoj
 apH
 aqG
-aqL
-aqL
-asa
-acP
-acP
-acP
-acP
-acP
-acP
+alF
+alF
+alF
+alF
+alF
+alF
+alF
+alF
+alF
 axF
-aqO
-acP
-azK
-acP
-acP
-aBR
+asf
+alF
+akw
+alF
+alF
+axW
 aBR
 aBR
 aBR
@@ -57449,7 +57684,7 @@ bjA
 bjA
 bjA
 bjA
-bjA
+blq
 axX
 axX
 axX
@@ -57457,10 +57692,10 @@ axX
 axX
 axX
 axX
-bmi
+maD
 btH
 axX
-bjA
+bjY
 bjA
 bkC
 bjy
@@ -57567,7 +57802,7 @@ aao
 aao
 aao
 acP
-acP
+asc
 acp
 acp
 acp
@@ -57585,10 +57820,10 @@ acp
 alv
 amq
 ahj
-adS
+aeJ
 adS
 aoW
-adS
+aeJ
 aqH
 aqL
 arZ
@@ -57666,18 +57901,18 @@ bjA
 bjA
 bjA
 bjA
-bjA
-blv
-bjy
-bjy
-bjy
+blu
+bjx
+bjx
+bjx
+bjw
 ayr
 bmq
 bmq
 bmi
 bor
 ayr
-bkr
+bjY
 bkr
 bjy
 bjy
@@ -57784,7 +58019,7 @@ aao
 aao
 aao
 acP
-acP
+asc
 acp
 adQ
 aep
@@ -57806,7 +58041,7 @@ acp
 acp
 acp
 acp
-aqI
+aqH
 aqL
 asa
 acP
@@ -57865,8 +58100,8 @@ aBR
 aBR
 aBR
 aBR
-aBS
-aHF
+aBR
+aMc
 aHD
 aIn
 bjD
@@ -57887,14 +58122,14 @@ bjA
 bjA
 bjH
 bjy
-bkd
+blq
 ayr
 bmq
 bqo
 bmi
 btJ
 ayr
-bkb
+bjw
 bun
 btD
 btD
@@ -58001,7 +58236,7 @@ aao
 aao
 acP
 acP
-acP
+asc
 acp
 adR
 aeq
@@ -58023,23 +58258,23 @@ aer
 afS
 cLZ
 acp
-aqJ
+aqH
 arp
-acP
-acP
-acP
-acP
-acP
-acP
-acP
-acP
-acP
-aqO
-acP
-acP
-azK
-acP
-aBS
+agq
+ahe
+ahe
+ahe
+ahe
+ahe
+ahe
+ahe
+ahe
+atl
+ahe
+ahe
+auE
+ahe
+aFM
 aCN
 aCN
 aCN
@@ -58083,7 +58318,7 @@ aBR
 aBR
 aBR
 bhO
-aVp
+biY
 dzY
 bpT
 bjG
@@ -58218,7 +58453,7 @@ aao
 aao
 acP
 acP
-acP
+asc
 acp
 adS
 adS
@@ -58240,9 +58475,9 @@ anx
 afS
 akM
 acp
-aqJ
+aqH
 arp
-acP
+asc
 amn
 amV
 amV
@@ -58300,8 +58535,8 @@ aBR
 aBR
 aBR
 bhP
-aHD
-bdk
+aMc
+gpt
 aKt
 bjy
 bjy
@@ -58322,12 +58557,12 @@ bjy
 bjy
 bjy
 blq
-bmi
+maD
 bmi
 bmi
 bsu
 bor
-bmi
+maD
 bjw
 bjw
 bjx
@@ -58435,7 +58670,7 @@ aao
 aao
 acP
 acP
-acP
+asc
 acp
 adT
 adT
@@ -58457,9 +58692,9 @@ aer
 afS
 aoT
 acp
-aqJ
+aqH
 aqL
-asb
+asc
 amn
 vti
 atY
@@ -58517,8 +58752,8 @@ aBR
 aBR
 aBR
 bhP
+aMc
 aHD
-aWJ
 aBR
 bjH
 bkd
@@ -58652,7 +58887,7 @@ aao
 aao
 aao
 acP
-acP
+asc
 acp
 acr
 aer
@@ -58674,9 +58909,9 @@ acp
 acp
 acp
 acp
-aqJ
+aqH
 aqL
-aqL
+asc
 amn
 aty
 atY
@@ -58734,18 +58969,18 @@ bfI
 bfI
 bfI
 bhQ
-aHD
-aWJ
-aBR
-aVo
-aMc
+aHF
+aHF
+aFM
+aFM
+aHF
 awp
 awp
 axr
 axr
 axr
 awp
-bkE
+gad
 bnA
 awp
 awp
@@ -58869,7 +59104,7 @@ aao
 aao
 aao
 acP
-acP
+asc
 acp
 acl
 aes
@@ -58891,9 +59126,9 @@ anB
 alx
 alx
 acr
-aqJ
+aqH
 aqL
-aqL
+asc
 amn
 atY
 atY
@@ -58950,12 +59185,12 @@ aNw
 aNw
 aMg
 aMg
-bhR
+vis
 aHF
-aFM
-aFM
-aFM
 aHF
+aMg
+aMg
+aMg
 awp
 bkD
 blx
@@ -59086,7 +59321,7 @@ aao
 aao
 aao
 acP
-acP
+asc
 acq
 acv
 adW
@@ -59108,7 +59343,7 @@ adk
 alx
 alx
 alZ
-aqJ
+aqH
 aqL
 asc
 amn
@@ -59153,7 +59388,7 @@ aOM
 aOM
 aOM
 aZZ
-baJ
+upV
 baJ
 bcb
 bcR
@@ -59166,12 +59401,12 @@ aIn
 aIn
 aKt
 aKt
-aIn
+aKt
 bhS
 biY
-biY
-biY
-biY
+dzY
+dWg
+dWg
 bke
 bku
 bmF
@@ -59303,7 +59538,7 @@ aao
 aao
 aao
 acP
-acP
+asc
 adG
 adW
 aet
@@ -59382,14 +59617,14 @@ aIn
 aKt
 aIp
 aBR
-aBR
-aYK
-aKt
-aKt
-aKt
-aKt
-aKt
-aKt
+aWI
+aFM
+aFM
+aHF
+aHF
+aFM
+aFM
+aFM
 awp
 bkE
 bly
@@ -59407,7 +59642,7 @@ bnF
 bry
 bnF
 bof
-bmF
+dvC
 bmF
 bmF
 btB
@@ -59520,7 +59755,7 @@ aao
 aao
 aao
 acP
-acP
+asc
 acq
 adX
 aeu
@@ -59542,7 +59777,7 @@ anC
 alz
 alz
 amb
-aqL
+aqM
 aqL
 ase
 asJ
@@ -59599,14 +59834,14 @@ aWJ
 aBR
 aBR
 aBR
-aBR
-auW
+aMc
+erf
 auX
 auX
 auX
 auX
-auW
-aBR
+erf
+aHF
 awp
 bkG
 blX
@@ -59737,7 +59972,7 @@ aao
 aao
 aao
 acP
-acP
+asc
 acp
 adY
 jGn
@@ -59761,7 +59996,7 @@ alA
 acr
 aqM
 aqL
-asf
+ase
 amn
 amn
 amn
@@ -59814,9 +60049,9 @@ apC
 aTh
 aIn
 aKl
-aKl
 aIm
 aBR
+aMc
 auX
 gpR
 gpR
@@ -59954,7 +60189,7 @@ aao
 aao
 aao
 acP
-acP
+asc
 acp
 acp
 acp
@@ -59976,9 +60211,9 @@ adk
 adk
 adS
 alZ
-acP
+aqM
 arr
-aqL
+asc
 amI
 aty
 atY
@@ -59997,7 +60232,7 @@ asJ
 aua
 aua
 asJ
-asJ
+cgt
 aHD
 aIn
 aIn
@@ -60031,16 +60266,16 @@ bej
 beE
 aFM
 aFM
-aFM
 aHC
 aBR
+aMc
 auX
 gpR
 gpR
 gpR
 gpR
 auX
-aBR
+aHF
 awM
 awM
 awM
@@ -60052,7 +60287,7 @@ awM
 awM
 awp
 awp
-bpo
+yhV
 bnA
 awp
 awp
@@ -60171,13 +60406,13 @@ aao
 aao
 aao
 acP
-acP
-acP
-acP
-acP
-acP
-acP
-acP
+ags
+alF
+alF
+alF
+alF
+alF
+ahS
 acr
 ahu
 adS
@@ -60193,9 +60428,9 @@ anE
 aok
 adk
 acr
+aqM
 acP
-acP
-arr
+asc
 amI
 atB
 atY
@@ -60245,19 +60480,19 @@ aYO
 aTa
 aYO
 bek
-beF
-aMg
+bjZ
 aMg
 aHF
 aHD
 aBR
+aMc
 auX
 gpR
 gpR
 gpR
 gpR
 auX
-aBR
+aHF
 awM
 bkI
 bkI
@@ -60394,7 +60629,7 @@ acP
 acP
 acP
 acP
-acP
+asc
 acr
 ahu
 adS
@@ -60410,9 +60645,9 @@ anF
 aol
 adS
 acr
+aqM
 acP
-acP
-acP
+asc
 amn
 atz
 atY
@@ -60453,7 +60688,7 @@ apJ
 apC
 apC
 apC
-aOM
+kmm
 mWg
 apC
 apC
@@ -60464,17 +60699,17 @@ apC
 apC
 beF
 bfb
-aIn
 aMc
 aHD
 aIm
+aMc
 auX
 gpR
 gpR
 gpR
 gpR
 auX
-aBR
+aHF
 awM
 bkJ
 bkJ
@@ -60611,7 +60846,7 @@ acP
 acP
 acP
 acP
-acP
+asc
 acr
 acr
 acr
@@ -60627,9 +60862,9 @@ acr
 acr
 acr
 acr
+aqM
 acP
-acP
-acP
+asc
 amn
 aty
 atY
@@ -60670,8 +60905,8 @@ aMg
 aMg
 aMg
 aMg
-aMg
-aMg
+aHF
+aHF
 aMg
 aMg
 aMg
@@ -60681,17 +60916,17 @@ aMg
 aMg
 beG
 aIn
-bfb
-aMc
-aHD
-aIn
-auW
+vmm
+aHF
+aFM
+aHF
+erf
 auX
 auX
 auX
 auX
-auW
-aBR
+erf
+aHF
 awM
 awM
 awM
@@ -60828,10 +61063,10 @@ acP
 acP
 acP
 acP
-acP
-acP
-acP
-acP
+ags
+alF
+alF
+ahS
 acr
 adS
 ajL
@@ -60844,9 +61079,9 @@ aom
 aoX
 apb
 acr
+aqM
 acP
-acP
-acP
+asc
 amn
 tmH
 atY
@@ -60887,8 +61122,8 @@ aVo
 aIn
 aWJ
 aBR
-aBR
-aBR
+aMc
+aHD
 aBR
 aBR
 aVo
@@ -60898,17 +61133,17 @@ aWJ
 aBR
 aBR
 bfc
-bfb
-aMc
-aHD
-aIn
-aBR
-aBR
-aBR
-aBR
-aBR
-aBR
-aBR
+vmm
+aHF
+aMg
+aHF
+aHF
+aHF
+aHF
+aHF
+aHF
+aHF
+aHF
 awp
 bkK
 blB
@@ -61048,7 +61283,7 @@ acP
 acP
 acP
 acP
-acP
+asc
 acr
 adS
 ajR
@@ -61061,7 +61296,7 @@ alB
 alB
 adW
 acr
-acP
+aqM
 acP
 asg
 amI
@@ -61104,28 +61339,28 @@ aIn
 aIn
 aIn
 aKl
-aKl
-aKl
-aKl
-aKl
-aIn
-aIn
-aIn
-aIn
+aMc
+aHD
 aKl
 aKl
 aIn
+aIn
+aIn
+aIn
+aKl
+aKl
 aIn
 aMc
 aHD
 aIn
-auW
+aMc
+erf
 auX
 auX
 auX
 auX
-auW
-aBR
+erf
+aHF
 awp
 bkK
 blX
@@ -61265,7 +61500,7 @@ acP
 acP
 acP
 acP
-acP
+asc
 acr
 adS
 ajS
@@ -61278,7 +61513,7 @@ alC
 aon
 aoY
 acr
-acP
+aqM
 acP
 ash
 amI
@@ -61315,15 +61550,14 @@ aBR
 aBR
 aBR
 aVn
-aBS
 aFM
 aFM
 aFM
 aFM
 aFM
 aFM
+aHF
 baa
-aFM
 aFM
 aFM
 aFM
@@ -61336,13 +61570,14 @@ aFM
 aHF
 aHD
 aWJ
+aMc
 auX
 gpR
 gpR
 gpR
 gpR
 auX
-aBR
+aHF
 awp
 bkL
 bkE
@@ -61410,7 +61645,7 @@ xpl
 bCs
 xpl
 xpl
-ioS
+lGt
 ioS
 ioS
 ioS
@@ -61482,7 +61717,7 @@ acP
 acP
 acP
 acP
-acP
+asc
 aiQ
 adS
 adk
@@ -61531,7 +61766,6 @@ aBR
 aBR
 aBR
 aBR
-aVo
 aMc
 aHF
 aMg
@@ -61551,15 +61785,16 @@ aMg
 aMg
 aMg
 aMg
-aWI
+axW
 aIp
+aMc
 auX
 gpR
 gpR
 gpR
 gpR
 auX
-aBR
+aHF
 awp
 bkM
 bkE
@@ -61699,8 +61934,8 @@ acP
 acP
 acP
 acP
-acP
-adS
+asc
+aeJ
 adS
 adk
 akc
@@ -61712,9 +61947,9 @@ anH
 agt
 apa
 acr
-aqO
+ajT
 acP
-acP
+asc
 amI
 aty
 atY
@@ -61748,9 +61983,9 @@ aBR
 aBR
 aBR
 aBR
-aVo
 aMc
 aHD
+aIn
 aIn
 aIn
 aIn
@@ -61769,14 +62004,14 @@ aKt
 aKt
 aIp
 aBR
-aBR
+aMc
 auX
 gpR
 gpR
 gpR
 gpR
 auX
-aBR
+aHF
 awp
 qeK
 ccP
@@ -61787,8 +62022,8 @@ bnH
 bkE
 box
 bkE
-bnH
-bnH
+iyd
+iyd
 eKU
 bkE
 bkE
@@ -61837,7 +62072,7 @@ bAR
 aBv
 aBA
 aCh
-qZo
+cOJ
 aCh
 aBA
 aBA
@@ -61916,7 +62151,7 @@ acP
 acP
 acP
 acP
-acP
+asc
 acr
 ajj
 adk
@@ -61929,9 +62164,9 @@ akS
 agO
 aCk
 acr
+aqM
 acP
-acP
-acP
+asc
 amI
 atB
 atY
@@ -61965,9 +62200,9 @@ aFM
 aFM
 aHC
 aBR
-aVo
 aMc
 aHD
+aIn
 aXo
 aKt
 aKt
@@ -61986,14 +62221,14 @@ aBR
 aBR
 aBR
 aBR
-aFL
+aWW
 auX
 gpR
 gpR
 gpR
 gpR
 auX
-aBR
+aHF
 awp
 awp
 awp
@@ -62133,22 +62368,22 @@ aao
 acP
 acP
 acP
+asc
+acr
+acr
+acr
+acr
+akj
+akj
+akj
+akj
+akj
+akj
+akj
+acr
+aqM
 acP
-acr
-acr
-acr
-acr
-akj
-akj
-akj
-akj
-akj
-akj
-akj
-acr
-acP
-acP
-acP
+asc
 amn
 atB
 atY
@@ -62182,9 +62417,9 @@ anJ
 anJ
 aHD
 aBR
-aVo
 aMc
 aHD
+aIn
 aWJ
 aBR
 aBR
@@ -62203,14 +62438,14 @@ aBR
 aBR
 aBR
 aBR
-aBR
-auW
+aMc
+erf
 auX
 auX
 auX
 auX
-auW
-aBR
+erf
+aHF
 awp
 bkO
 blC
@@ -62350,10 +62585,10 @@ aao
 aao
 acP
 acP
-acP
-acP
-acP
-ajT
+ags
+alF
+alF
+alF
 akw
 akw
 alF
@@ -62362,10 +62597,10 @@ akw
 akw
 akw
 akw
-acP
-acP
+alF
+aqI
 amD
-acP
+asc
 amn
 aty
 atY
@@ -62399,12 +62634,11 @@ aEO
 anJ
 aTc
 aBR
-aVo
 aMc
 aHD
+aIn
 aWJ
-aBR
-aBS
+aWI
 aFM
 aFM
 aFM
@@ -62421,13 +62655,14 @@ aFM
 aFM
 aFM
 aFM
-aFM
-aHC
-aBR
-aBR
+aHF
+aHF
+aHF
+aHF
+aHF
 jdj
-aBR
-aBR
+aHF
+aHF
 awp
 bkE
 hsF
@@ -62582,7 +62817,7 @@ acP
 acP
 acP
 acP
-acP
+asc
 amn
 lyx
 atY
@@ -62616,11 +62851,11 @@ aEO
 aqz
 aHD
 aKl
-aIn
 aMc
 aHD
+aIn
 aWJ
-aBR
+aMc
 asv
 asv
 asv
@@ -62639,9 +62874,9 @@ atJ
 atJ
 asv
 asv
-aHD
-aBR
-aBR
+aHF
+aHF
+aHF
 asv
 awf
 awf
@@ -62799,7 +63034,7 @@ acP
 acP
 acP
 acP
-acP
+asc
 amI
 vti
 atY
@@ -62833,11 +63068,11 @@ aEO
 anJ
 aTd
 aIn
-aIn
 aMc
 aHD
+aIn
 aWJ
-aBR
+aMc
 asv
 aYX
 aZE
@@ -62856,9 +63091,9 @@ bgc
 bfe
 bgI
 asv
-aHD
-aBR
-aBR
+aHF
+aHF
+aHF
 asv
 bjJ
 bgx
@@ -63009,14 +63244,14 @@ acP
 acP
 acP
 acP
-acP
-acP
-acP
-acP
-acP
-acP
-acP
-acP
+agq
+ahe
+ahe
+ahe
+ahe
+ahe
+ahe
+ahS
 amI
 aty
 atY
@@ -63050,11 +63285,11 @@ aRj
 aqz
 aHD
 aUh
-aIn
 aMc
 aHD
+aIn
 aWJ
-aFL
+aWW
 asH
 aYY
 aZE
@@ -63073,9 +63308,9 @@ bgd
 bgd
 aLf
 asH
-aHD
-aBR
-aBR
+aHF
+aHF
+aHF
 asv
 beI
 bgx
@@ -63226,7 +63461,7 @@ acP
 akV
 acP
 acP
-acP
+asc
 ako
 ako
 ako
@@ -63267,11 +63502,11 @@ aEO
 anJ
 aHD
 aIn
-aIn
 aMc
 aHD
+aIn
 aWJ
-aBR
+aMc
 asH
 aYZ
 aZE
@@ -63291,8 +63526,8 @@ bgs
 bfM
 avr
 bhT
-aBR
-aBR
+aHF
+aHF
 asv
 beI
 bgx
@@ -63443,7 +63678,7 @@ acP
 acP
 acP
 acP
-acP
+asc
 aku
 aoo
 apc
@@ -63456,7 +63691,7 @@ atC
 ars
 amn
 amn
-aws
+jZp
 axh
 amn
 amn
@@ -63484,11 +63719,11 @@ aRk
 anJ
 aTe
 aFM
-aFM
 aHF
 aHD
+aIn
 aWJ
-aBR
+aMc
 asH
 aZa
 aZE
@@ -63507,9 +63742,9 @@ bgc
 bgc
 bgK
 asH
-aHD
-aBR
-aBR
+aHF
+aHF
+aHF
 asv
 bjK
 aZF
@@ -63660,7 +63895,7 @@ acP
 acP
 acP
 acP
-acP
+asc
 aku
 aop
 apc
@@ -63699,13 +63934,13 @@ aLr
 aPY
 aEO
 aSc
-aHD
 aHF
 aHF
 aHF
 aHD
+aIn
 aWJ
-aBR
+aMc
 asv
 aYY
 aZE
@@ -63725,7 +63960,7 @@ bgt
 bgL
 asv
 bhU
-aBR
+aHF
 rHD
 asv
 bjL
@@ -63877,7 +64112,7 @@ acP
 acP
 acP
 acP
-acP
+asc
 aku
 aop
 apc
@@ -63915,14 +64150,14 @@ aNU
 aEO
 aEO
 aRl
-aER
+cNH
 aTf
 aHF
 aHF
-aHF
 aHD
+aIn
 aWJ
-aBR
+aMc
 asv
 aZb
 aZE
@@ -64094,7 +64329,7 @@ acP
 acP
 acP
 acP
-acP
+asc
 aku
 aoq
 apd
@@ -64134,12 +64369,12 @@ aDW
 aRm
 anJ
 aTg
-aMg
 aHF
 aHF
-aWI
+aHD
+aIn
 aWJ
-aBR
+aMc
 asv
 asv
 asv
@@ -64311,7 +64546,7 @@ aao
 acP
 acP
 acP
-acP
+asc
 ako
 ako
 ako
@@ -64350,15 +64585,15 @@ aEO
 aNS
 aEO
 anJ
-aTh
+bhR
 aUi
-aMc
+aHF
 aHD
 aIn
 aIp
-aBR
-aBR
-aBR
+aMc
+aHF
+aHF
 asv
 baf
 bac
@@ -64528,7 +64763,7 @@ aao
 acP
 acP
 acP
-acP
+asc
 ako
 aor
 ape
@@ -64567,15 +64802,15 @@ aKx
 aNS
 aRn
 aqz
-aTh
-aIn
-aMc
-aHD
-aWJ
-aBR
-aBR
-aBR
-aBR
+bhR
+aHF
+aHF
+aHF
+aFM
+aFM
+aHF
+aHF
+aHF
 asv
 bag
 bac
@@ -64745,7 +64980,7 @@ aao
 aao
 acP
 acP
-acP
+asc
 ako
 aos
 ape
@@ -64784,11 +65019,11 @@ aKx
 aNS
 aEO
 anJ
-aTh
-aIn
-aMc
-aHD
-aIn
+bhR
+aHF
+aHF
+aHF
+aHF
 asv
 asv
 asv
@@ -64801,7 +65036,7 @@ aZE
 aXr
 aXr
 aXU
-aXr
+bET
 beI
 bft
 asv
@@ -64811,10 +65046,10 @@ bgN
 bgg
 bhX
 asv
-bja
-bfw
-bfw
-bfw
+bqa
+bep
+bep
+bqa
 awp
 bkU
 bkU
@@ -64962,7 +65197,7 @@ aao
 aao
 aao
 acP
-acP
+asc
 ako
 aos
 ape
@@ -65001,11 +65236,11 @@ aKx
 aNS
 aRk
 anJ
-aTh
-aIn
-aMc
-aHD
-aIn
+bhR
+aHF
+aHF
+aHF
+aHF
 asv
 aXS
 aYs
@@ -65029,9 +65264,9 @@ bgf
 bgg
 asH
 bjb
-bes
-bes
-bes
+bfw
+bfw
+bpX
 awp
 bkT
 blG
@@ -65179,7 +65414,7 @@ aao
 aao
 aao
 acP
-acP
+asc
 ako
 aos
 apf
@@ -65219,10 +65454,10 @@ aNS
 aEO
 aqz
 aTi
-bfI
 aVp
 aVp
-bfI
+aVp
+aVp
 aXq
 bcX
 bcX
@@ -65248,7 +65483,7 @@ asv
 bjb
 bes
 bes
-bes
+bpX
 awp
 awp
 awp
@@ -65432,15 +65667,15 @@ anJ
 anJ
 anJ
 anJ
-aNS
+sPv
 aRo
 anJ
 aTj
 aMg
 aMg
 aMg
-aMg
-aXr
+aHF
+bET
 aXr
 aXr
 aXU
@@ -65465,16 +65700,16 @@ asH
 bjb
 bjl
 bes
-bes
-bki
-bes
-bes
-bes
-bes
-bes
-bes
-bes
-bpX
+jfr
+bep
+bep
+bep
+bep
+bep
+bep
+bep
+bep
+bqa
 bWk
 bMf
 xJC
@@ -65624,7 +65859,7 @@ ako
 asQ
 atE
 atE
-apc
+ovq
 apc
 aop
 apc
@@ -65656,7 +65891,7 @@ aTk
 aQu
 aQu
 aQu
-aQu
+aTr
 asH
 aXU
 aYt
@@ -65873,7 +66108,7 @@ aTk
 aQu
 aVq
 aVq
-aQu
+aTr
 asv
 aXV
 aYu
@@ -66090,7 +66325,7 @@ aTk
 aUk
 aKP
 aKP
-aWK
+aTr
 asv
 asv
 asv
@@ -66300,16 +66535,16 @@ anT
 anT
 anT
 anT
-aQc
+cYI
 aRp
 anT
 aTk
 aUk
 aKP
 aVY
-aKP
-aSh
-aTr
+aXW
+aSg
+aTq
 aTq
 aTq
 asv
@@ -66329,7 +66564,7 @@ bfP
 bfP
 bhl
 bbB
-aXr
+bET
 bqa
 bja
 beq
@@ -66521,11 +66756,11 @@ aQd
 aIE
 anT
 aTk
-aUl
-aOk
-aOk
-aOk
-aQu
+aUk
+aKP
+aKP
+aKP
+aSh
 aTr
 aTq
 aTq
@@ -66738,11 +66973,11 @@ aQe
 aQm
 aqU
 aTk
-aTu
-aTu
-aTu
-aTu
-aTu
+aUl
+aOk
+aOk
+aOk
+aQu
 aTr
 aTq
 aTq
@@ -66930,7 +67165,7 @@ ako
 avJ
 apc
 axl
-apc
+ovq
 ayz
 ayz
 aAh
@@ -66955,12 +67190,12 @@ aQf
 aQh
 aqU
 aTl
-aSg
-aSg
-aSg
-aSg
-aSg
-aTr
+aTu
+aTu
+aTu
+aTu
+aTu
+aTq
 aTq
 aTq
 asv
@@ -67171,13 +67406,13 @@ aOY
 aQg
 aCo
 aqU
-aTk
-aQu
-aVq
-aVq
-aVq
-aQu
-aTr
+aDy
+aSg
+aSg
+aSg
+aSg
+aSg
+aTq
 aTq
 aTq
 asv
@@ -67389,11 +67624,11 @@ aMQ
 aMN
 aqU
 aTk
-aUk
-aKP
-aKP
-aKP
-aSh
+aQu
+aVq
+aVq
+aVq
+aQu
 aTr
 aTq
 aTq
@@ -67414,7 +67649,7 @@ bgA
 bgU
 bhn
 bgB
-aXr
+bET
 gSg
 bja
 bjm
@@ -67625,7 +67860,7 @@ aXr
 asv
 beI
 bbB
-bfR
+bET
 bfR
 bgB
 bgB
@@ -67645,11 +67880,11 @@ ujD
 ujD
 vVZ
 rjw
-brD
+fCb
 aao
-brD
-brD
-brD
+fCb
+fCb
+fCb
 aao
 pcF
 kBn
@@ -67861,17 +68096,17 @@ uij
 uij
 uVe
 brD
-brD
-brD
+fCb
+fCb
 rjw
-brD
-brD
+fCb
+fCb
 rjw
-brD
+fCb
 pcF
 kBn
 iZA
-fjP
+dIb
 pQv
 fwV
 fwV
@@ -68038,7 +68273,7 @@ aOd
 aPb
 aQj
 aRr
-aCZ
+tKR
 aTk
 aQu
 aUk
@@ -68080,17 +68315,17 @@ iXp
 aao
 aao
 rjw
-brD
+fCb
 aao
 aao
 aao
 aao
 pcF
 fjP
-fjP
-fjP
-fjP
-fjP
+dIb
+dIb
+dIb
+dIb
 fwV
 kBn
 aao
@@ -68241,7 +68476,7 @@ anT
 anY
 anY
 anY
-aQa
+cYI
 aGa
 anY
 anT
@@ -68296,19 +68531,19 @@ ujD
 ujD
 vVZ
 brE
-brD
-brD
+fCb
+fCb
 rjw
-brD
+fCb
 aao
 aao
 pcF
 kBn
-fjP
-fjP
-fjP
-fjP
-fjP
+dIb
+dIb
+dIb
+dIb
+dIb
 kBn
 aao
 aao
@@ -68463,7 +68698,7 @@ aCo
 aGL
 anT
 anT
-aJu
+aJz
 anT
 anT
 aIE
@@ -68515,16 +68750,16 @@ vVZ
 vVZ
 vVZ
 vVZ
-brD
+fCb
 vVZ
 vVZ
 vVZ
 pcF
 kBn
-fjP
-fjP
-fjP
-fjP
+dIb
+dIb
+dIb
+dIb
 iZA
 kBn
 aao
@@ -68729,19 +68964,19 @@ mDs
 mDs
 ooD
 vVZ
-brD
-brD
-brD
-brD
-brD
-brD
+fCb
+fCb
+fCb
+fCb
+fCb
+fCb
 aao
 pcF
 kBn
-fjP
-fjP
-fjP
-fjP
+dIb
+dIb
+dIb
+dIb
 kBn
 kBn
 kSL
@@ -68945,20 +69180,20 @@ cAs
 mDs
 mDs
 ooD
-brD
+myY
 kTs
-brD
+fCb
 bsH
-brD
-brD
+fCb
+fCb
 aao
 aao
 pcF
 kBn
 fwV
-fjP
-fjP
-fjP
+dIb
+dIb
+dIb
 ssE
 kSL
 fOx
@@ -69112,7 +69347,7 @@ aDa
 aFa
 aEU
 aCZ
-aCZ
+tKR
 aIC
 aJx
 aKH
@@ -69162,10 +69397,10 @@ cAs
 mDs
 mDs
 ooD
-brD
-brD
-brD
-brD
+myY
+fCb
+fCb
+fCb
 aao
 aao
 aao
@@ -69173,9 +69408,9 @@ aao
 pcF
 kBn
 mRD
-fjP
-fjP
-fjP
+dIb
+dIb
+dIb
 ssE
 kSL
 fOx
@@ -69380,7 +69615,7 @@ mDs
 mDs
 ooD
 vVZ
-brD
+fCb
 kTs
 kTs
 aao
@@ -69390,8 +69625,8 @@ aao
 pcF
 kBn
 fwV
-fjP
-fjP
+dIb
+dIb
 kBn
 kBn
 fOx
@@ -69598,11 +69833,11 @@ bpZ
 qkC
 vVZ
 kTs
-brD
-brD
-brD
-brD
-brD
+fCb
+fCb
+fCb
+fCb
+fCb
 brE
 pcF
 kBn
@@ -70225,8 +70460,8 @@ aZe
 aTu
 aZe
 aZe
-aVv
-bes
+aTu
+kwQ
 bes
 bes
 bes
@@ -70407,7 +70642,7 @@ arD
 arD
 arD
 arD
-arD
+aMk
 anW
 aDc
 aEi
@@ -70425,8 +70660,8 @@ aDc
 aEi
 aQr
 anW
-aQu
-aTr
+aTq
+aTq
 aTk
 aUk
 aKP
@@ -70443,7 +70678,7 @@ atP
 atP
 atb
 iIp
-bes
+bja
 bes
 bes
 bes
@@ -70624,7 +70859,7 @@ arD
 arD
 arD
 arD
-arD
+aMk
 anW
 aDc
 aEi
@@ -70642,8 +70877,8 @@ aDc
 aEi
 aEi
 aqx
-aQu
-aTr
+aTq
+aTq
 aUp
 aUk
 aKP
@@ -70660,7 +70895,7 @@ bal
 bal
 bdE
 atb
-bes
+bja
 bes
 bes
 bes
@@ -70841,7 +71076,7 @@ arD
 arD
 arD
 arD
-arD
+aMk
 anW
 aDc
 aEi
@@ -70859,8 +71094,8 @@ aLF
 aPk
 aEi
 aqx
-aQu
-aTr
+aTq
+aTq
 aUp
 aQu
 aVr
@@ -70869,15 +71104,15 @@ aKP
 aKP
 aTr
 atd
-aZi
+nRT
 bam
 bal
 bbD
 bal
 bdd
-aZi
+nRT
 atb
-bes
+bja
 bes
 bes
 bes
@@ -71058,7 +71293,7 @@ arD
 arD
 arD
 arD
-arD
+aMk
 anW
 aDc
 aEi
@@ -71076,8 +71311,8 @@ aOi
 aPl
 aQs
 anW
-aQu
-aTs
+aTq
+aTp
 aUp
 aQu
 aUk
@@ -71086,15 +71321,15 @@ aKP
 aKP
 aTr
 atd
-aZi
+nRT
 ban
 baR
 bbE
 baR
 baR
-aZi
+nRT
 atb
-bes
+bja
 bes
 bes
 bes
@@ -71275,7 +71510,7 @@ arD
 arD
 arD
 arD
-arD
+aMk
 anW
 aDd
 aEi
@@ -71293,7 +71528,7 @@ aOj
 aPm
 aQt
 aRu
-aSf
+nnK
 aTt
 aUq
 aQu
@@ -71303,7 +71538,7 @@ aKP
 aMR
 aTr
 atb
-aZi
+nRT
 bao
 baS
 bbF
@@ -71311,7 +71546,7 @@ bao
 baS
 bdF
 atb
-bes
+bja
 bes
 bes
 aEX
@@ -71492,7 +71727,7 @@ arD
 arD
 arD
 arD
-arD
+aMk
 anW
 aDe
 aQt
@@ -71509,8 +71744,8 @@ aEi
 aOj
 aPn
 aEi
-aEi
-aSg
+ocA
+aTq
 aTp
 aUr
 aQu
@@ -71520,15 +71755,15 @@ aOk
 aQu
 aTr
 atd
-aZi
+nRT
 bap
 baT
 bbF
 bap
 baT
-aZi
+nRT
 atb
-bes
+bja
 bes
 bes
 aEX
@@ -71709,7 +71944,7 @@ arD
 arD
 arD
 arD
-arD
+aMk
 anW
 aDf
 anW
@@ -71727,8 +71962,8 @@ aOj
 aPo
 aQs
 anW
-aQu
-aTr
+aTq
+aTq
 aUs
 aSf
 aSf
@@ -71737,15 +71972,15 @@ aSf
 aSf
 aYv
 atd
-aZi
+nRT
 baq
 baU
 bbF
 bar
 baU
-aZi
+nRT
 atb
-bes
+bja
 bes
 bes
 bes
@@ -71926,7 +72161,7 @@ aao
 arD
 arD
 arD
-arD
+aMk
 anW
 aDg
 aEk
@@ -71944,8 +72179,8 @@ aGO
 aPp
 aEi
 aqx
-aQu
-aTr
+aTq
+aTq
 foT
 aSg
 aSg
@@ -71954,15 +72189,15 @@ aSg
 aSg
 qhl
 atb
-aZi
+nRT
 bap
 baT
 bbF
 bcl
 baT
-aZi
+nRT
 atb
-bes
+bja
 bes
 bes
 bes
@@ -72143,7 +72378,7 @@ aao
 arD
 arD
 arD
-arD
+aMk
 anW
 aDh
 aEl
@@ -72161,8 +72396,8 @@ aEi
 aEi
 aEi
 aqx
-aQu
-aTr
+aTq
+aTq
 aUp
 aQu
 aVq
@@ -72171,15 +72406,15 @@ aQu
 aQu
 aYx
 atd
-aZi
+nRT
 bar
 baU
 bbF
 bar
 baU
-aZi
+nRT
 atb
-bes
+bja
 bes
 bes
 bes
@@ -72360,7 +72595,7 @@ aao
 aao
 aao
 arD
-arD
+aMk
 anW
 anW
 anW
@@ -72378,8 +72613,8 @@ aoc
 aoc
 anW
 anW
-aQu
-aTs
+aTq
+aTp
 aUp
 aUk
 aKP
@@ -72388,7 +72623,7 @@ aWK
 aQu
 aYx
 atd
-aZi
+nRT
 bap
 baT
 bbF
@@ -72396,7 +72631,7 @@ bap
 baT
 bdG
 atb
-bes
+bja
 bes
 bes
 bes
@@ -72577,26 +72812,26 @@ aao
 aao
 aao
 arD
-arD
-arD
-arD
-arD
-arD
-arD
-arD
-arD
-arD
-arD
-aKP
-aKP
-aKP
-aKP
-aKP
-aKP
-aKP
-aKP
-aSh
-aTs
+bMz
+aqa
+aqa
+aqa
+aqa
+aqa
+aqa
+aqa
+aqa
+aqa
+aSg
+aSg
+aSg
+aSg
+aSg
+aSg
+aSg
+aSg
+aSg
+aTp
 aUp
 aUk
 aKP
@@ -72611,9 +72846,9 @@ baV
 bbG
 bar
 baU
-aZi
+nRT
 atb
-bes
+bja
 bes
 bes
 bes
@@ -72828,9 +73063,9 @@ baT
 bbF
 bap
 baT
-aZi
+nRT
 atb
-bes
+bja
 bes
 bes
 bes
@@ -73045,9 +73280,9 @@ baU
 bbH
 bar
 baU
-aZi
+nRT
 atb
-bes
+bja
 bes
 bes
 aEX
@@ -73246,8 +73481,8 @@ aOk
 aOk
 aQu
 kYd
-lEb
-wMP
+wNw
+wNw
 aUu
 wNw
 kYd
@@ -73264,7 +73499,7 @@ bap
 baT
 bdF
 atb
-bes
+bja
 bes
 aEX
 aEX
@@ -73479,9 +73714,9 @@ baS
 bbF
 bao
 baS
-aZi
+nRT
 atb
-bes
+bja
 bes
 aEX
 aEX
@@ -73680,8 +73915,8 @@ aao
 aao
 aao
 apI
-lEb
-wMP
+wNw
+wNw
 aUw
 wNw
 apI
@@ -73690,15 +73925,15 @@ aXt
 aXX
 aTr
 aZi
-aZi
+nRT
 bat
 baW
 bbI
 bat
 baW
-aZi
+nRT
 atb
-bes
+bja
 bes
 aEX
 bes
@@ -73907,15 +74142,15 @@ aXt
 aXt
 aTr
 atb
-aZi
+nRT
 aJy
 aJy
-aZi
+nRT
 aJy
 aJy
 bdI
 atb
-bes
+bja
 bes
 bes
 bes
@@ -74132,7 +74367,7 @@ atb
 atb
 atb
 atb
-bes
+bja
 bes
 bes
 bes
@@ -75585,7 +75820,7 @@ adZ
 adZ
 adZ
 adZ
-agQ
+aCy
 ahB
 adZ
 aev
@@ -75824,7 +76059,7 @@ aev
 adZ
 aup
 agd
-aqc
+auy
 auY
 aqc
 aqc
@@ -76266,7 +76501,7 @@ amk
 amk
 anI
 anL
-aAO
+hmm
 aCr
 anL
 anI
@@ -76929,7 +77164,7 @@ aIK
 aJE
 aKQ
 aKQ
-aKQ
+hmm
 aMT
 aOn
 aOn
@@ -77341,7 +77576,7 @@ aao
 azm
 amk
 amk
-agd
+auy
 ave
 amk
 amk
@@ -77756,7 +77991,7 @@ adZ
 adZ
 adZ
 agX
-ahK
+agc
 aio
 adZ
 adZ
@@ -77974,7 +78209,7 @@ aao
 adZ
 adZ
 ahL
-ahK
+agc
 aiR
 adZ
 adZ
@@ -78443,7 +78678,7 @@ poF
 aFk
 aGg
 aGU
-aGU
+xNL
 aIO
 tkN
 anI
@@ -78626,7 +78861,7 @@ adZ
 adZ
 adZ
 adZ
-agc
+aCy
 ajr
 adZ
 afd
@@ -78661,7 +78896,7 @@ anI
 anI
 vbi
 aHQ
-aHQ
+hWa
 wko
 anI
 aao
@@ -79956,7 +80191,7 @@ eFh
 anL
 aAT
 aAY
-aCy
+aPq
 aDq
 hWa
 aFm
@@ -81475,7 +81710,7 @@ eFh
 anL
 aAY
 aAU
-aCy
+aPq
 aDq
 hWa
 aFo

--- a/maps/map_files/BigRed/sprinkles/70.se-checkpoint.dmm
+++ b/maps/map_files/BigRed/sprinkles/70.se-checkpoint.dmm
@@ -5,18 +5,14 @@
 	pixel_y = 28;
 	start_charge = 0
 	},
-/turf/open/floor{
-	icon_state = "dark"
-	},
+/turf/open/floor,
 /area/bigred/ground/security)
 "aN" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/computer/secure_data{
 	dir = 8
 	},
-/turf/open/floor{
-	icon_state = "dark"
-	},
+/turf/open/floor,
 /area/bigred/ground/security)
 "bp" = (
 /obj/structure/machinery/door/airlock/almayer/security/glass/colony{
@@ -24,16 +20,12 @@
 	locked = 0;
 	name = "\improper Checkpoint Office"
 	},
-/turf/open/floor{
-	icon_state = "dark"
-	},
+/turf/open/floor,
 /area/bigred/ground/security)
 "bx" = (
 /obj/structure/surface/table/almayer,
 /obj/item/device/motiondetector,
-/turf/open/floor{
-	icon_state = "dark"
-	},
+/turf/open/floor,
 /area/bigred/ground/security)
 "cO" = (
 /obj/effect/decal/cleanable/dirt,
@@ -53,9 +45,7 @@
 "el" = (
 /obj/structure/surface/table/almayer,
 /obj/item/handcuffs,
-/turf/open/floor{
-	icon_state = "dark"
-	},
+/turf/open/floor,
 /area/bigred/ground/security)
 "ge" = (
 /obj/structure/closet/secure_closet/marshal,
@@ -68,7 +58,7 @@
 	},
 /obj/structure/blocker/forcefield/multitile_vehicles,
 /turf/open/floor{
-	icon_state = "dark"
+	icon_state = "delivery"
 	},
 /area/bigred/ground/security)
 "ie" = (
@@ -81,8 +71,8 @@
 /obj/structure/surface/table/almayer,
 /obj/structure/transmitter/colony_net/rotary{
 	phone_category = "Solaris Ridge";
-	phone_id = "Filtration Checkpoint";
-	phone_color = "red"
+	phone_color = "red";
+	phone_id = "Filtration Checkpoint"
 	},
 /turf/open/floor/greengrid,
 /area/bigred/ground/security)
@@ -133,9 +123,7 @@
 "pV" = (
 /obj/structure/surface/table/almayer,
 /obj/effect/spawner/random/tool,
-/turf/open/floor{
-	icon_state = "dark"
-	},
+/turf/open/floor,
 /area/bigred/ground/security)
 "qg" = (
 /obj/effect/decal/cleanable/dirt,
@@ -146,17 +134,13 @@
 "qy" = (
 /obj/item/device/radio,
 /obj/structure/surface/table/almayer,
-/turf/open/floor{
-	icon_state = "dark"
-	},
+/turf/open/floor,
 /area/bigred/ground/security)
 "rD" = (
 /obj/structure/machinery/camera/autoname{
 	dir = 8
 	},
-/turf/open/floor{
-	icon_state = "dark"
-	},
+/turf/open/floor,
 /area/bigred/ground/security)
 "rF" = (
 /obj/structure/machinery/deployable/barrier,
@@ -169,15 +153,12 @@
 	name = "Filtration Lockdown"
 	},
 /turf/open/floor{
-	dir = 1;
-	icon_state = "asteroidfloor"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/filtration_cave_cas)
 "uk" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor{
-	icon_state = "dark"
-	},
+/turf/open/floor,
 /area/bigred/ground/security)
 "uF" = (
 /obj/structure/surface/table/almayer,
@@ -190,21 +171,17 @@
 	name = "\improper Checkpoint Office"
 	},
 /turf/open/floor{
-	icon_state = "dark"
+	icon_state = "delivery"
 	},
 /area/bigred/ground/security)
 "vH" = (
 /obj/effect/decal/cleanable/blood,
-/turf/open/floor{
-	icon_state = "dark"
-	},
+/turf/open/floor,
 /area/bigred/ground/security)
 "vO" = (
 /obj/structure/surface/rack,
 /obj/item/stack/sheet/metal/small_stack,
-/turf/open/floor{
-	icon_state = "dark"
-	},
+/turf/open/floor,
 /area/bigred/ground/security)
 "wi" = (
 /obj/effect/decal/cleanable/dirt,
@@ -220,9 +197,7 @@
 /obj/structure/bed/chair/office/light{
 	dir = 4
 	},
-/turf/open/floor{
-	icon_state = "dark"
-	},
+/turf/open/floor,
 /area/bigred/ground/security)
 "xr" = (
 /obj/structure/surface/rack,
@@ -231,9 +206,7 @@
 /obj/structure/machinery/light{
 	dir = 4
 	},
-/turf/open/floor{
-	icon_state = "dark"
-	},
+/turf/open/floor,
 /area/bigred/ground/security)
 "zE" = (
 /obj/effect/decal/cleanable/dirt,
@@ -250,9 +223,7 @@
 	},
 /area/bigredv2/outside/filtration_cave_cas)
 "AY" = (
-/turf/open/floor{
-	icon_state = "dark"
-	},
+/turf/open/floor,
 /area/bigred/ground/security)
 "AZ" = (
 /turf/open/floor{
@@ -309,18 +280,14 @@
 "KO" = (
 /obj/item/trash/sosjerky,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor{
-	icon_state = "dark"
-	},
+/turf/open/floor,
 /area/bigred/ground/security)
 "LX" = (
 /obj/structure/machinery/light{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor{
-	icon_state = "dark"
-	},
+/turf/open/floor,
 /area/bigred/ground/security)
 "Mq" = (
 /obj/structure/surface/table/almayer,
@@ -335,9 +302,7 @@
 	dir = 8
 	},
 /obj/structure/machinery/vending/security,
-/turf/open/floor{
-	icon_state = "dark"
-	},
+/turf/open/floor,
 /area/bigred/ground/security)
 "OD" = (
 /turf/open/floor{
@@ -355,9 +320,7 @@
 "Pf" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/spawner/gibspawner/human,
-/turf/open/floor{
-	icon_state = "dark"
-	},
+/turf/open/floor,
 /area/bigred/ground/security)
 "PS" = (
 /turf/open/mars,
@@ -370,8 +333,7 @@
 	name = "Filtration Lockdown"
 	},
 /turf/open/floor{
-	dir = 1;
-	icon_state = "asteroidfloor"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/filtration_cave_cas)
 "Qo" = (
@@ -384,9 +346,7 @@
 	},
 /obj/structure/surface/rack,
 /obj/effect/spawner/random/toolbox,
-/turf/open/floor{
-	icon_state = "dark"
-	},
+/turf/open/floor,
 /area/bigred/ground/security)
 "SF" = (
 /obj/structure/window/framed/solaris/reinforced,
@@ -413,9 +373,7 @@
 /area/bigred/ground/security)
 "VI" = (
 /obj/structure/largecrate,
-/turf/open/floor{
-	icon_state = "dark"
-	},
+/turf/open/floor,
 /area/bigred/ground/security)
 "Wa" = (
 /turf/open/floor{
@@ -432,9 +390,7 @@
 "Yo" = (
 /obj/structure/surface/rack,
 /obj/item/storage/firstaid,
-/turf/open/floor{
-	icon_state = "dark"
-	},
+/turf/open/floor,
 /area/bigred/ground/security)
 "YZ" = (
 /obj/structure/surface/table/almayer,
@@ -456,9 +412,7 @@
 /obj/structure/machinery/light{
 	dir = 4
 	},
-/turf/open/floor{
-	icon_state = "dark"
-	},
+/turf/open/floor,
 /area/bigred/ground/security)
 
 (1,1,1) = {"
@@ -522,7 +476,7 @@ uk
 AY
 uk
 uk
-xa
+AY
 hz
 "}
 (5,1,1) = {"

--- a/maps/map_files/BigRed/standalone/crashlanding-offices.dmm
+++ b/maps/map_files/BigRed/standalone/crashlanding-offices.dmm
@@ -1,15 +1,10 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"aa" = (
-/turf/open/floor{
-	icon_state = "asteroidwarning"
-	},
-/area/bigredv2/outside/c)
 "ab" = (
 /turf/open/floor{
-	icon_state = "asteroidwarning";
-	dir = 6
+	dir = 5;
+	icon_state = "asteroidwarning"
 	},
-/area/bigredv2/outside/c)
+/area/bigredv2/outside/e)
 "ac" = (
 /turf/open/mars_cave{
 	icon_state = "mars_dirt_4"
@@ -23,14 +18,8 @@
 "ae" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor{
-	icon_state = "asteroidwarning";
-	dir = 8
-	},
-/area/bigredv2/outside/c)
-"af" = (
-/turf/open/floor{
-	icon_state = "asteroidwarning";
-	dir = 4
+	dir = 1;
+	icon_state = "asteroidfloor"
 	},
 /area/bigredv2/outside/c)
 "ag" = (
@@ -39,10 +28,11 @@
 	},
 /area/bigredv2/outside/e)
 "ah" = (
-/turf/open/mars{
-	icon_state = "mars_dirt_14"
+/turf/open/floor{
+	dir = 1;
+	icon_state = "asteroidwarning"
 	},
-/area/bigredv2/outside/e)
+/area/bigredv2/outside/c)
 "ai" = (
 /turf/open/mars,
 /area/bigredv2/outside/e)
@@ -53,14 +43,14 @@
 /area/bigredv2/outside/e)
 "ak" = (
 /turf/open/floor{
-	icon_state = "asteroidwarning";
-	dir = 8
+	dir = 8;
+	icon_state = "asteroidwarning"
 	},
 /area/bigredv2/outside/e)
 "al" = (
 /turf/open/floor{
-	icon_state = "asteroidwarning";
-	dir = 4
+	dir = 4;
+	icon_state = "asteroidwarning"
 	},
 /area/bigredv2/outside/e)
 "am" = (
@@ -74,7 +64,10 @@
 	},
 /area/bigredv2/outside/c)
 "ao" = (
-/turf/open/mars,
+/turf/open/floor{
+	dir = 9;
+	icon_state = "asteroidwarning"
+	},
 /area/bigredv2/outside/c)
 "ap" = (
 /turf/closed/wall/solaris,
@@ -108,7 +101,10 @@
 /area/bigredv2/outside/e)
 "au" = (
 /obj/effect/landmark/crap_item,
-/turf/open/mars,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "asteroidwarning"
+	},
 /area/bigredv2/outside/c)
 "av" = (
 /obj/structure/machinery/vending/snack,
@@ -152,14 +148,15 @@
 /area/bigredv2/outside/office_complex)
 "aA" = (
 /turf/open/floor{
-	icon_state = "asteroidwarning";
-	dir = 1
+	dir = 1;
+	icon_state = "asteroidwarning"
 	},
 /area/bigredv2/outside/e)
 "aB" = (
+/obj/effect/landmark/lv624/xeno_tunnel,
 /turf/open/floor{
-	icon_state = "asteroidwarning";
-	dir = 9
+	dir = 1;
+	icon_state = "asteroidfloor"
 	},
 /area/bigredv2/outside/c)
 "aC" = (
@@ -184,14 +181,14 @@
 /area/bigredv2/outside/office_complex)
 "aG" = (
 /turf/open/floor{
-	icon_state = "asteroidfloor";
-	dir = 1
+	dir = 1;
+	icon_state = "asteroidfloor"
 	},
 /area/bigredv2/outside/e)
 "aH" = (
 /turf/open/floor{
-	icon_state = "asteroidwarning";
-	dir = 8
+	dir = 8;
+	icon_state = "asteroidwarning"
 	},
 /area/bigredv2/outside/c)
 "aI" = (
@@ -439,8 +436,8 @@
 "bx" = (
 /obj/item/shard,
 /turf/open/floor{
-	icon_state = "asteroidfloor";
-	dir = 1
+	dir = 1;
+	icon_state = "asteroidfloor"
 	},
 /area/bigredv2/outside/e)
 "by" = (
@@ -556,8 +553,8 @@
 "bR" = (
 /obj/item/shard,
 /turf/open/floor{
-	icon_state = "asteroidwarning";
-	dir = 8
+	dir = 8;
+	icon_state = "asteroidwarning"
 	},
 /area/bigredv2/outside/c)
 "bS" = (
@@ -604,8 +601,8 @@
 /area/bigredv2/outside/office_complex)
 "bY" = (
 /turf/open/floor{
-	icon_state = "redcorner";
-	dir = 4
+	dir = 4;
+	icon_state = "redcorner"
 	},
 /area/bigredv2/outside/office_complex)
 "bZ" = (
@@ -768,8 +765,8 @@
 /area/bigredv2/outside/office_complex)
 "cw" = (
 /obj/item/weapon/gun/rifle/nsg23/no_lock/stripped{
-	name = "smashed NSG 23 assault rifle";
-	desc = "A rare sight, this rifle is seen most commonly in the hands of Weyland-Yutani PMCs. Compared to the M41A MK2, it has noticeably improved handling and vastly improved performance at long and medium range, but compares similarly up close. This one seems to have been heavily damaged from impact, you can still see some debris that resembles a scope and underbarrel attachment point on it."
+	desc = "A rare sight, this rifle is seen most commonly in the hands of Weyland-Yutani PMCs. Compared to the M41A MK2, it has noticeably improved handling and vastly improved performance at long and medium range, but compares similarly up close. This one seems to have been heavily damaged from impact, you can still see some debris that resembles a scope and underbarrel attachment point on it.";
+	name = "smashed NSG 23 assault rifle"
 	},
 /turf/open/shuttle/dropship{
 	icon_state = "rasputin12"
@@ -936,8 +933,8 @@
 "cV" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor{
-	icon_state = "redcorner";
-	dir = 4
+	dir = 4;
+	icon_state = "redcorner"
 	},
 /area/bigredv2/outside/office_complex)
 "cW" = (
@@ -950,8 +947,8 @@
 /area/bigredv2/outside/office_complex)
 "cX" = (
 /turf/open/floor{
-	icon_state = "asteroidwarning";
-	dir = 10
+	dir = 1;
+	icon_state = "asteroidfloor"
 	},
 /area/bigredv2/outside/c)
 "cY" = (
@@ -959,13 +956,15 @@
 	icon_state = "gib6"
 	},
 /turf/open/floor{
-	icon_state = "asteroidwarning"
+	dir = 1;
+	icon_state = "asteroidfloor"
 	},
 /area/bigredv2/outside/c)
 "cZ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor{
-	icon_state = "asteroidwarning"
+	dir = 1;
+	icon_state = "asteroidfloor"
 	},
 /area/bigredv2/outside/c)
 "da" = (
@@ -1083,7 +1082,9 @@
 "dt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/mars,
+/turf/open/mars{
+	icon_state = "mars_dirt_12"
+	},
 /area/bigredv2/outside/se)
 "du" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1099,15 +1100,15 @@
 /area/bigredv2/outside/se)
 "dw" = (
 /turf/open/floor{
-	icon_state = "asteroidwarning";
-	dir = 10
+	dir = 10;
+	icon_state = "asteroidwarning"
 	},
 /area/bigredv2/outside/se)
 "dx" = (
 /obj/item/tool/warning_cone,
 /turf/open/floor{
-	icon_state = "asteroidwarning";
-	dir = 6
+	dir = 6;
+	icon_state = "asteroidwarning"
 	},
 /area/bigredv2/outside/se)
 "dz" = (
@@ -1146,8 +1147,8 @@
 /area/bigredv2/outside/office_complex)
 "dE" = (
 /obj/effect/decal/cleanable/blood{
-	icon_state = "gib6";
-	dir = 1
+	dir = 1;
+	icon_state = "gib6"
 	},
 /turf/open/shuttle/dropship{
 	icon_state = "rasputin3"
@@ -1286,15 +1287,15 @@
 "dW" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor{
-	icon_state = "asteroidwarning";
-	dir = 1
+	dir = 4;
+	icon_state = "asteroidwarning"
 	},
-/area/bigredv2/outside/e)
+/area/bigredv2/outside/se)
 "dX" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor{
-	icon_state = "asteroidfloor";
-	dir = 1
+	dir = 1;
+	icon_state = "asteroidfloor"
 	},
 /area/bigredv2/outside/e)
 "dY" = (
@@ -1359,8 +1360,8 @@
 "eg" = (
 /obj/item/stack/rods,
 /turf/open/floor{
-	icon_state = "asteroidwarning";
-	dir = 8
+	dir = 8;
+	icon_state = "asteroidwarning"
 	},
 /area/bigredv2/outside/c)
 "eh" = (
@@ -1435,8 +1436,8 @@
 /area/bigredv2/outside/office_complex)
 "jx" = (
 /obj/effect/decal/cleanable/blood{
-	icon_state = "gib6";
-	dir = 1
+	dir = 1;
+	icon_state = "gib6"
 	},
 /obj/item/limb/leg/l_leg,
 /turf/open/shuttle/dropship{
@@ -1507,9 +1508,8 @@
 "uC" = (
 /obj/effect/spawner/gibspawner/human,
 /obj/item/weapon/gun/rifle/m41a/corporate/no_lock{
-	name = "battered M41A pulse rifle Mk2";
 	desc = "A Weyland-Yutani creation, this M41A MK2 comes equipped in corporate white. Uses 10x24mm caseless ammunition. The IFF electronics appear to be non-functional.";
-	pixel_x = 4
+	name = "battered M41A pulse rifle Mk2"
 	},
 /turf/open/shuttle/dropship{
 	icon_state = "rasputin3"
@@ -1570,9 +1570,8 @@
 /area/bigredv2/outside/office_complex)
 "GG" = (
 /obj/item/weapon/gun/rifle/m41a/corporate/no_lock{
-	name = "battered M41A pulse rifle Mk2";
 	desc = "A Weyland-Yutani creation, this M41A MK2 comes equipped in corporate white. Uses 10x24mm caseless ammunition. The IFF electronics appear to be non-functional.";
-	pixel_x = 4
+	name = "battered M41A pulse rifle Mk2"
 	},
 /turf/open/shuttle/dropship{
 	icon_state = "rasputin3"
@@ -1581,8 +1580,8 @@
 "Ha" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor{
-	icon_state = "asteroidfloor";
-	dir = 1
+	dir = 1;
+	icon_state = "asteroidfloor"
 	},
 /area/bigredv2/outside/se)
 "Lk" = (
@@ -1605,8 +1604,8 @@
 /area/bigredv2/outside/office_complex)
 "PR" = (
 /turf/open/floor{
-	icon_state = "asteroidfloor";
-	dir = 1
+	dir = 1;
+	icon_state = "asteroidfloor"
 	},
 /area/bigredv2/outside/se)
 "Qc" = (
@@ -1633,18 +1632,12 @@
 	icon_state = "floor8"
 	},
 /area/bigredv2/outside/office_complex)
-"ZG" = (
-/obj/effect/landmark/objective_landmark/close,
-/turf/open/mars_cave{
-	icon_state = "mars_dirt_4"
-	},
-/area/bigredv2/outside/e)
 
 (1,1,1) = {"
-aa
+ac
 ad
 ao
-aB
+aH
 aH
 aH
 aH
@@ -1660,17 +1653,17 @@ bR
 aH
 eg
 aH
-aH
-aH
 cX
-ao
-ao
-ao
+cX
+cX
+cX
+cX
+cX
 "}
 (2,1,1) = {"
-aa
+ac
 ad
-ao
+ah
 ap
 ap
 ap
@@ -1689,15 +1682,15 @@ ax
 aY
 ap
 ap
-aa
-ao
-ao
+cX
+cX
+cX
 ap
 "}
 (3,1,1) = {"
-aa
+ac
 ad
-ao
+ah
 ap
 aI
 aR
@@ -1716,13 +1709,13 @@ cq
 ca
 cH
 ap
-aa
-ao
-ao
+cX
+cX
+cX
 ap
 "}
 (4,1,1) = {"
-aa
+ac
 ad
 au
 as
@@ -1743,15 +1736,15 @@ ck
 ej
 cI
 as
-aa
-ao
-ao
+cX
+cX
+cX
 ap
 "}
 (5,1,1) = {"
-aa
+ac
 ad
-ao
+ah
 as
 aK
 bB
@@ -1771,14 +1764,14 @@ ek
 cm
 cR
 cY
-ao
-ao
+cX
+cX
 ap
 "}
 (6,1,1) = {"
-aa
+ac
 ad
-ao
+ah
 as
 aL
 aR
@@ -1797,15 +1790,15 @@ eh
 aS
 ed
 as
-aa
-ao
-ao
+cX
+cX
+cX
 ap
 "}
 (7,1,1) = {"
-aa
+ac
 ad
-ao
+ah
 ap
 aJ
 aR
@@ -1825,14 +1818,14 @@ cr
 cr
 ap
 cZ
-ao
-ao
+cX
+aB
 ap
 "}
 (8,1,1) = {"
-aa
+ac
 ad
-ao
+ah
 ap
 aM
 aS
@@ -1857,9 +1850,9 @@ ap
 ap
 "}
 (9,1,1) = {"
-ab
+ac
 ad
-ao
+ah
 ap
 ap
 ap
@@ -1886,9 +1879,9 @@ dr
 (10,1,1) = {"
 ac
 an
-ao
-ao
-ao
+ah
+cX
+cX
 ap
 aC
 bj
@@ -1911,11 +1904,11 @@ bu
 ar
 "}
 (11,1,1) = {"
-ad
-ao
-ao
-ao
-ao
+aH
+aH
+cX
+cX
+cX
 by
 aN
 id
@@ -1938,7 +1931,7 @@ bI
 bI
 "}
 (12,1,1) = {"
-ac
+cX
 ap
 ap
 ap
@@ -1962,10 +1955,10 @@ id
 yS
 cE
 dm
-ds
+dW
 "}
 (13,1,1) = {"
-ac
+cX
 ap
 av
 ar
@@ -2019,7 +2012,7 @@ do
 ds
 "}
 (15,1,1) = {"
-af
+cX
 ar
 bt
 aD
@@ -2046,7 +2039,7 @@ dp
 du
 "}
 (16,1,1) = {"
-ag
+aA
 ba
 bb
 aE
@@ -2073,7 +2066,7 @@ dm
 dv
 "}
 (17,1,1) = {"
-ZG
+aA
 ap
 az
 bu
@@ -2100,7 +2093,7 @@ dn
 dw
 "}
 (18,1,1) = {"
-ah
+aA
 ap
 ap
 ap
@@ -2127,11 +2120,11 @@ do
 dq
 "}
 (19,1,1) = {"
-ai
-at
-dW
-dX
-dX
+ab
+al
+aG
+aG
+aG
 dY
 aN
 fv

--- a/maps/map_files/BigRed/standalone/lambda-graveyard.dmm
+++ b/maps/map_files/BigRed/standalone/lambda-graveyard.dmm
@@ -2,28 +2,16 @@
 "a" = (
 /turf/open/mars,
 /area/bigredv2/outside/se)
-"b" = (
-/obj/structure/prop/dam/wide_boulder/boulder1,
-/turf/open/mars,
-/area/bigredv2/outside/se)
-"c" = (
-/turf/open/mars{
-	icon_state = "mars_dirt_13"
-	},
-/area/bigredv2/outside/se)
-"d" = (
-/turf/open/mars{
-	icon_state = "mars_dirt_10"
-	},
-/area/bigredv2/outside/se)
 "e" = (
-/turf/open/mars{
-	icon_state = "mars_dirt_14"
+/turf/open/floor{
+	icon_state = "asteroidwarning"
 	},
 /area/bigredv2/outside/se)
 "f" = (
 /obj/item/stool,
-/turf/open/mars,
+/turf/open/floor{
+	icon_state = "asteroidwarning"
+	},
 /area/bigredv2/outside/se)
 "g" = (
 /turf/open/mars{
@@ -103,7 +91,7 @@
 /area/bigredv2/caves)
 
 (1,1,1) = {"
-a
+e
 a
 a
 a
@@ -115,7 +103,7 @@ a
 D
 "}
 (2,1,1) = {"
-a
+e
 a
 a
 a
@@ -127,7 +115,7 @@ a
 s
 "}
 (3,1,1) = {"
-a
+e
 a
 a
 a
@@ -139,7 +127,7 @@ a
 a
 "}
 (4,1,1) = {"
-a
+e
 a
 a
 a
@@ -151,7 +139,7 @@ a
 a
 "}
 (5,1,1) = {"
-b
+e
 a
 a
 o
@@ -163,7 +151,7 @@ a
 a
 "}
 (6,1,1) = {"
-a
+e
 a
 a
 o
@@ -175,7 +163,7 @@ o
 a
 "}
 (7,1,1) = {"
-a
+e
 a
 a
 a
@@ -187,7 +175,7 @@ o
 o
 "}
 (8,1,1) = {"
-c
+e
 g
 l
 a
@@ -199,7 +187,7 @@ a
 t
 "}
 (9,1,1) = {"
-d
+e
 h
 m
 a
@@ -223,7 +211,7 @@ a
 t
 "}
 (11,1,1) = {"
-a
+e
 a
 a
 a
@@ -235,7 +223,7 @@ a
 t
 "}
 (12,1,1) = {"
-a
+e
 a
 a
 a
@@ -247,7 +235,7 @@ a
 t
 "}
 (13,1,1) = {"
-a
+e
 a
 a
 o
@@ -259,7 +247,7 @@ r
 t
 "}
 (14,1,1) = {"
-a
+e
 a
 o
 o
@@ -271,7 +259,7 @@ a
 t
 "}
 (15,1,1) = {"
-a
+e
 j
 o
 o
@@ -295,7 +283,7 @@ s
 s
 "}
 (17,1,1) = {"
-a
+e
 a
 p
 a
@@ -307,7 +295,7 @@ s
 s
 "}
 (18,1,1) = {"
-a
+e
 a
 a
 a

--- a/maps/map_files/BigRed/standalone/medbay-passage.dmm
+++ b/maps/map_files/BigRed/standalone/medbay-passage.dmm
@@ -2,12 +2,6 @@
 "a" = (
 /turf/template_noop,
 /area/template_noop)
-"b" = (
-/turf/open/floor{
-	dir = 8;
-	icon_state = "asteroidwarning"
-	},
-/area/bigredv2/outside/c)
 "c" = (
 /obj/structure/sign/safety/medical{
 	pixel_x = 0;
@@ -41,12 +35,6 @@
 /turf/open/floor{
 	dir = 1;
 	icon_state = "asteroidfloor"
-	},
-/area/bigredv2/outside/c)
-"g" = (
-/turf/open/floor{
-	dir = 4;
-	icon_state = "asteroidwarning"
 	},
 /area/bigredv2/outside/c)
 "h" = (
@@ -99,9 +87,9 @@
 (1,1,1) = {"
 a
 a
-b
-b
-b
+l
+l
+l
 R
 "}
 (2,1,1) = {"
@@ -139,8 +127,8 @@ R
 (6,1,1) = {"
 a
 a
-g
-g
-g
+l
+l
+l
 R
 "}

--- a/maps/map_files/BigRed/standalone/medbay-v3.dmm
+++ b/maps/map_files/BigRed/standalone/medbay-v3.dmm
@@ -20,15 +20,15 @@
 	name = "\improper Medical Clinic"
 	},
 /turf/open/floor{
-	icon_state = "warnwhite";
-	dir = 1
+	dir = 1;
+	icon_state = "warnwhite"
 	},
 /area/bigredv2/outside/medical)
 "ae" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor{
-	icon_state = "warnwhite";
-	dir = 1
+	dir = 1;
+	icon_state = "warnwhite"
 	},
 /area/bigredv2/outside/medical)
 "af" = (
@@ -37,8 +37,8 @@
 "ag" = (
 /obj/structure/closet/secure_closet/chemical,
 /turf/open/floor{
-	icon_state = "whitepurplecorner";
-	dir = 1
+	dir = 1;
+	icon_state = "whitepurplecorner"
 	},
 /area/bigredv2/outside/medical)
 "ah" = (
@@ -60,8 +60,8 @@
 /area/bigredv2/outside/medical)
 "ak" = (
 /turf/open/floor{
-	icon_state = "damaged2";
-	dir = 8
+	dir = 8;
+	icon_state = "damaged2"
 	},
 /area/bigredv2/outside/medical)
 "al" = (
@@ -78,16 +78,16 @@
 "an" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor{
-	icon_state = "damaged2";
-	dir = 8
+	dir = 8;
+	icon_state = "damaged2"
 	},
 /area/bigredv2/outside/medical)
 "ao" = (
 /obj/structure/machinery/chem_master,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor{
-	icon_state = "damaged4";
-	dir = 8
+	dir = 8;
+	icon_state = "damaged4"
 	},
 /area/bigredv2/outside/medical)
 "ap" = (
@@ -137,14 +137,14 @@
 "aw" = (
 /obj/structure/machinery/chem_dispenser,
 /turf/open/floor{
-	icon_state = "damaged4";
-	dir = 8
+	dir = 8;
+	icon_state = "damaged4"
 	},
 /area/bigredv2/outside/medical)
 "ax" = (
 /turf/open/floor{
-	icon_state = "damaged4";
-	dir = 8
+	dir = 8;
+	icon_state = "damaged4"
 	},
 /area/bigredv2/outside/medical)
 "ay" = (
@@ -158,15 +158,15 @@
 "az" = (
 /obj/structure/bed,
 /turf/open/floor{
-	icon_state = "damaged2";
-	dir = 8
+	dir = 8;
+	icon_state = "damaged2"
 	},
 /area/bigredv2/outside/medical)
 "aA" = (
 /obj/structure/surface/table,
 /turf/open/floor{
-	icon_state = "damaged4";
-	dir = 8
+	dir = 8;
+	icon_state = "damaged4"
 	},
 /area/bigredv2/outside/medical)
 "aB" = (
@@ -196,8 +196,8 @@
 /obj/item/storage/box/beakers,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor{
-	icon_state = "whitepurplecorner";
-	dir = 1
+	dir = 1;
+	icon_state = "whitepurplecorner"
 	},
 /area/bigredv2/outside/medical)
 "aF" = (
@@ -242,8 +242,8 @@
 	amount = 1
 	},
 /turf/open/floor{
-	icon_state = "damaged2";
-	dir = 8
+	dir = 8;
+	icon_state = "damaged2"
 	},
 /area/bigredv2/outside/medical)
 "aL" = (
@@ -254,8 +254,8 @@
 /area/bigredv2/outside/medical)
 "aM" = (
 /turf/open/floor{
-	icon_state = "damaged5";
-	dir = 8
+	dir = 8;
+	icon_state = "damaged5"
 	},
 /area/bigredv2/outside/medical)
 "aN" = (
@@ -284,8 +284,8 @@
 "aQ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor{
-	icon_state = "damaged3";
-	dir = 8
+	dir = 8;
+	icon_state = "damaged3"
 	},
 /area/bigredv2/outside/medical)
 "aR" = (
@@ -309,30 +309,30 @@
 /area/bigredv2/outside/medical)
 "aU" = (
 /turf/open/floor{
-	icon_state = "damaged3";
-	dir = 8
+	dir = 8;
+	icon_state = "damaged3"
 	},
 /area/bigredv2/outside/medical)
 "aV" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor{
-	icon_state = "damaged2";
-	dir = 8
+	dir = 8;
+	icon_state = "damaged2"
 	},
 /area/bigredv2/outside/medical)
 "aX" = (
 /obj/structure/window_frame/solaris,
 /obj/item/stack/sheet/metal,
 /turf/open/floor{
-	icon_state = "damaged4";
-	dir = 8
+	dir = 8;
+	icon_state = "damaged4"
 	},
 /area/bigredv2/outside/medical)
 "aY" = (
 /obj/item/shard,
 /turf/open/floor{
-	icon_state = "damaged5";
-	dir = 8
+	dir = 8;
+	icon_state = "damaged5"
 	},
 /area/bigredv2/outside/medical)
 "aZ" = (
@@ -376,15 +376,15 @@
 "bf" = (
 /obj/structure/pipes/standard/manifold/hidden/green,
 /turf/open/floor{
-	icon_state = "damaged5";
-	dir = 8
+	dir = 8;
+	icon_state = "damaged5"
 	},
 /area/bigredv2/outside/medical)
 "bg" = (
 /obj/item/stack/sheet/metal,
 /turf/open/floor{
-	icon_state = "damaged5";
-	dir = 8
+	dir = 8;
+	icon_state = "damaged5"
 	},
 /area/bigredv2/outside/medical)
 "bh" = (
@@ -396,8 +396,8 @@
 "bi" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor{
-	icon_state = "damaged5";
-	dir = 8
+	dir = 8;
+	icon_state = "damaged5"
 	},
 /area/bigredv2/outside/medical)
 "bj" = (
@@ -411,8 +411,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/frame/table,
 /turf/open/floor{
-	icon_state = "damaged2";
-	dir = 8
+	dir = 8;
+	icon_state = "damaged2"
 	},
 /area/bigredv2/outside/medical)
 "bl" = (
@@ -490,22 +490,22 @@
 	},
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor{
-	icon_state = "damaged3";
-	dir = 8
+	dir = 8;
+	icon_state = "damaged3"
 	},
 /area/bigredv2/outside/medical)
 "bw" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor{
-	icon_state = "damaged2";
-	dir = 8
+	dir = 8;
+	icon_state = "damaged2"
 	},
 /area/bigredv2/outside/medical)
 "bx" = (
 /obj/item/stack/rods,
 /turf/open/floor{
-	icon_state = "damaged3";
-	dir = 8
+	dir = 8;
+	icon_state = "damaged3"
 	},
 /area/bigredv2/outside/medical)
 "by" = (
@@ -517,8 +517,8 @@
 /area/bigredv2/outside/medical)
 "bz" = (
 /turf/open/floor{
-	icon_state = "whitegreen";
-	dir = 5
+	dir = 5;
+	icon_state = "whitegreen"
 	},
 /area/bigredv2/outside/medical)
 "bA" = (
@@ -584,8 +584,8 @@
 /obj/item/shard,
 /obj/item/frame/table,
 /turf/open/floor{
-	icon_state = "damaged5";
-	dir = 8
+	dir = 8;
+	icon_state = "damaged5"
 	},
 /area/bigredv2/outside/medical)
 "bJ" = (
@@ -605,8 +605,8 @@
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor{
-	icon_state = "whitegreen";
-	dir = 1
+	dir = 1;
+	icon_state = "whitegreen"
 	},
 /area/bigredv2/outside/medical)
 "bM" = (
@@ -618,8 +618,8 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor{
-	icon_state = "whitegreen";
-	dir = 1
+	dir = 1;
+	icon_state = "whitegreen"
 	},
 /area/bigredv2/outside/medical)
 "bN" = (
@@ -647,8 +647,8 @@
 "bQ" = (
 /obj/structure/machinery/light,
 /turf/open/floor{
-	icon_state = "damaged5";
-	dir = 8
+	dir = 8;
+	icon_state = "damaged5"
 	},
 /area/bigredv2/outside/medical)
 "bR" = (
@@ -769,8 +769,8 @@
 "cj" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor{
-	icon_state = "whitegreen";
-	dir = 4
+	dir = 4;
+	icon_state = "whitegreen"
 	},
 /area/bigredv2/outside/medical)
 "ck" = (
@@ -820,15 +820,15 @@
 "cq" = (
 /obj/item/ammo_casing/bullet,
 /turf/open/floor{
-	icon_state = "damaged5";
-	dir = 8
+	dir = 8;
+	icon_state = "damaged5"
 	},
 /area/bigredv2/outside/medical)
 "cr" = (
 /obj/item/ammo_casing/bullet,
 /turf/open/floor{
-	icon_state = "damaged3";
-	dir = 8
+	dir = 8;
+	icon_state = "damaged3"
 	},
 /area/bigredv2/outside/medical)
 "cs" = (
@@ -846,15 +846,15 @@
 "cu" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor{
-	icon_state = "damaged4";
-	dir = 8
+	dir = 8;
+	icon_state = "damaged4"
 	},
 /area/bigredv2/outside/medical)
 "cv" = (
 /obj/item/ammo_casing/bullet,
 /turf/open/floor{
-	icon_state = "damaged4";
-	dir = 8
+	dir = 8;
+	icon_state = "damaged4"
 	},
 /area/bigredv2/outside/medical)
 "cw" = (
@@ -868,15 +868,15 @@
 "cx" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor{
-	icon_state = "damaged5";
-	dir = 8
+	dir = 8;
+	icon_state = "damaged5"
 	},
 /area/bigredv2/outside/medical)
 "cy" = (
 /obj/item/stack/sheet/metal,
 /turf/open/floor{
-	icon_state = "whitegreen";
-	dir = 4
+	dir = 4;
+	icon_state = "whitegreen"
 	},
 /area/bigredv2/outside/medical)
 "cz" = (
@@ -885,8 +885,8 @@
 	},
 /obj/item/shard,
 /turf/open/floor{
-	icon_state = "whitegreen";
-	dir = 1
+	dir = 1;
+	icon_state = "whitegreen"
 	},
 /area/bigredv2/outside/medical)
 "cA" = (
@@ -910,8 +910,8 @@
 	icon_state = "coil2"
 	},
 /turf/open/floor{
-	icon_state = "damaged3";
-	dir = 8
+	dir = 8;
+	icon_state = "damaged3"
 	},
 /area/bigredv2/outside/medical)
 "cC" = (
@@ -920,8 +920,8 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor{
-	icon_state = "damaged2";
-	dir = 8
+	dir = 8;
+	icon_state = "damaged2"
 	},
 /area/bigredv2/outside/medical)
 "cD" = (
@@ -934,8 +934,8 @@
 	icon_state = "coil2"
 	},
 /turf/open/floor{
-	icon_state = "damaged4";
-	dir = 8
+	dir = 8;
+	icon_state = "damaged4"
 	},
 /area/bigredv2/outside/medical)
 "cE" = (
@@ -954,8 +954,8 @@
 "cF" = (
 /obj/structure/machinery/cm_vending/sorted/medical/no_access,
 /turf/open/floor{
-	icon_state = "whitegreen";
-	dir = 1
+	dir = 1;
+	icon_state = "whitegreen"
 	},
 /area/bigredv2/outside/medical)
 "cH" = (
@@ -965,8 +965,8 @@
 	icon_state = "coil2"
 	},
 /turf/open/floor{
-	icon_state = "damaged5";
-	dir = 8
+	dir = 8;
+	icon_state = "damaged5"
 	},
 /area/bigredv2/outside/medical)
 "cI" = (
@@ -979,8 +979,8 @@
 	icon_state = "coil2"
 	},
 /turf/open/floor{
-	icon_state = "damaged3";
-	dir = 8
+	dir = 8;
+	icon_state = "damaged3"
 	},
 /area/bigredv2/outside/medical)
 "cJ" = (
@@ -992,8 +992,8 @@
 	icon_state = "coil2"
 	},
 /turf/open/floor{
-	icon_state = "damaged5";
-	dir = 8
+	dir = 8;
+	icon_state = "damaged5"
 	},
 /area/bigredv2/outside/medical)
 "cK" = (
@@ -1008,8 +1008,8 @@
 	},
 /obj/item/ammo_casing/bullet,
 /turf/open/floor{
-	icon_state = "damaged3";
-	dir = 8
+	dir = 8;
+	icon_state = "damaged3"
 	},
 /area/bigredv2/outside/medical)
 "cL" = (
@@ -1052,8 +1052,8 @@
 "cR" = (
 /obj/item/stack/sheet/metal,
 /turf/open/floor{
-	icon_state = "damaged4";
-	dir = 8
+	dir = 8;
+	icon_state = "damaged4"
 	},
 /area/bigredv2/outside/medical)
 "cS" = (
@@ -1067,8 +1067,8 @@
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor{
-	icon_state = "damaged2";
-	dir = 8
+	dir = 8;
+	icon_state = "damaged2"
 	},
 /area/bigredv2/outside/medical)
 "cU" = (
@@ -1091,16 +1091,16 @@
 "cW" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor{
-	icon_state = "damaged4";
-	dir = 8
+	dir = 8;
+	icon_state = "damaged4"
 	},
 /area/bigredv2/outside/medical)
 "cX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor{
-	icon_state = "damaged2";
-	dir = 8
+	dir = 8;
+	icon_state = "damaged2"
 	},
 /area/bigredv2/outside/medical)
 "cY" = (
@@ -1115,8 +1115,8 @@
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/effect/landmark/corpsespawner/wygoon,
 /turf/open/floor{
-	icon_state = "damaged5";
-	dir = 8
+	dir = 8;
+	icon_state = "damaged5"
 	},
 /area/bigredv2/outside/medical)
 "db" = (
@@ -1193,8 +1193,8 @@
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor{
-	icon_state = "damaged3";
-	dir = 8
+	dir = 8;
+	icon_state = "damaged3"
 	},
 /area/bigredv2/outside/medical)
 "dn" = (
@@ -1225,8 +1225,8 @@
 	},
 /obj/item/stack/sheet/metal,
 /turf/open/floor{
-	icon_state = "damaged3";
-	dir = 8
+	dir = 8;
+	icon_state = "damaged3"
 	},
 /area/bigredv2/outside/medical)
 "dq" = (
@@ -1241,8 +1241,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/ammo_casing/bullet,
 /turf/open/floor{
-	icon_state = "damaged3";
-	dir = 8
+	dir = 8;
+	icon_state = "damaged3"
 	},
 /area/bigredv2/outside/medical)
 "ds" = (
@@ -1264,8 +1264,8 @@
 	pixel_x = 30
 	},
 /turf/open/floor{
-	icon_state = "damaged4";
-	dir = 8
+	dir = 8;
+	icon_state = "damaged4"
 	},
 /area/bigredv2/outside/medical)
 "du" = (
@@ -1312,8 +1312,8 @@
 	},
 /obj/item/stack/sheet/metal,
 /turf/open/floor{
-	icon_state = "damaged4";
-	dir = 8
+	dir = 8;
+	icon_state = "damaged4"
 	},
 /area/bigredv2/outside/medical)
 "dA" = (
@@ -1337,16 +1337,16 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/objective_landmark/science,
 /turf/open/floor{
-	icon_state = "whitebluefull";
-	dir = 5
+	dir = 5;
+	icon_state = "whitebluefull"
 	},
 /area/bigredv2/outside/medical)
 "dD" = (
 /obj/structure/surface/table,
 /obj/item/device/autopsy_scanner,
 /turf/open/floor{
-	icon_state = "whitebluefull";
-	dir = 5
+	dir = 5;
+	icon_state = "whitebluefull"
 	},
 /area/bigredv2/outside/medical)
 "dE" = (
@@ -1391,8 +1391,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/ammo_casing/bullet,
 /turf/open/floor{
-	icon_state = "damaged3";
-	dir = 8
+	dir = 8;
+	icon_state = "damaged3"
 	},
 /area/bigredv2/outside/medical)
 "dL" = (
@@ -1436,8 +1436,8 @@
 /obj/structure/surface/table,
 /obj/item/reagent_container/food/snacks/sliceable/pizza/margherita,
 /turf/open/floor{
-	icon_state = "whitebluefull";
-	dir = 5
+	dir = 5;
+	icon_state = "whitebluefull"
 	},
 /area/bigredv2/outside/medical)
 "dT" = (
@@ -1466,8 +1466,8 @@
 /obj/structure/machinery/body_scanconsole,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor{
-	icon_state = "whitegreen";
-	dir = 6
+	dir = 6;
+	icon_state = "whitegreen"
 	},
 /area/bigredv2/outside/medical)
 "dX" = (
@@ -1485,8 +1485,8 @@
 "dZ" = (
 /obj/structure/bed/chair,
 /turf/open/floor{
-	icon_state = "damaged2";
-	dir = 8
+	dir = 8;
+	icon_state = "damaged2"
 	},
 /area/bigredv2/outside/medical)
 "ea" = (
@@ -1528,15 +1528,15 @@
 /area/bigredv2/outside/medical)
 "ef" = (
 /obj/structure/sink{
-	icon_state = "sink";
 	dir = 8;
+	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
 /obj/item/tool/surgery/scalpel/manager,
 /turf/open/floor{
-	icon_state = "whitebluefull";
-	dir = 5
+	dir = 5;
+	icon_state = "whitebluefull"
 	},
 /area/bigredv2/outside/medical)
 "eg" = (
@@ -1634,20 +1634,20 @@
 /obj/structure/bed/chair,
 /obj/item/shard,
 /turf/open/floor{
-	icon_state = "damaged4";
-	dir = 8
+	dir = 8;
+	icon_state = "damaged4"
 	},
 /area/bigredv2/outside/medical)
 "es" = (
 /turf/open/floor{
-	icon_state = "whitebluefull";
-	dir = 5
+	dir = 5;
+	icon_state = "whitebluefull"
 	},
 /area/bigredv2/outside/medical)
 "et" = (
 /obj/item/reagent_container/spray/cleaner{
-	name = "Surgery Cleaner";
-	desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back."
+	desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back.";
+	name = "Surgery Cleaner"
 	},
 /turf/open/floor{
 	icon_state = "white"
@@ -1675,8 +1675,8 @@
 "ew" = (
 /obj/structure/surface/table,
 /turf/open/floor{
-	icon_state = "whitebluefull";
-	dir = 5
+	dir = 5;
+	icon_state = "whitebluefull"
 	},
 /area/bigredv2/outside/medical)
 "ex" = (
@@ -1684,23 +1684,23 @@
 /obj/item/storage/box/masks,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor{
-	icon_state = "damaged4";
-	dir = 8
+	dir = 8;
+	icon_state = "damaged4"
 	},
 /area/bigredv2/outside/medical)
 "ey" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/frame/table,
 /turf/open/floor{
-	icon_state = "whitepurplecorner";
-	dir = 1
+	dir = 1;
+	icon_state = "whitepurplecorner"
 	},
 /area/bigredv2/outside/medical)
 "ez" = (
 /obj/item/device/healthanalyzer,
 /turf/open/floor{
-	icon_state = "whitegreen";
-	dir = 4
+	dir = 4;
+	icon_state = "whitegreen"
 	},
 /area/bigredv2/outside/medical)
 "eA" = (
@@ -1742,15 +1742,15 @@
 "eE" = (
 /obj/structure/closet/secure_closet/medical2,
 /turf/open/floor{
-	icon_state = "whitebluefull";
-	dir = 5
+	dir = 5;
+	icon_state = "whitebluefull"
 	},
 /area/bigredv2/outside/medical)
 "eF" = (
 /obj/structure/closet/secure_closet/medical1,
 /turf/open/floor{
-	icon_state = "damaged4";
-	dir = 8
+	dir = 8;
+	icon_state = "damaged4"
 	},
 /area/bigredv2/outside/medical)
 "eG" = (
@@ -1758,8 +1758,8 @@
 	stored_metal = 1000
 	},
 /turf/open/floor{
-	icon_state = "whitebluefull";
-	dir = 5
+	dir = 5;
+	icon_state = "whitebluefull"
 	},
 /area/bigredv2/outside/medical)
 "eH" = (
@@ -1774,8 +1774,8 @@
 "eI" = (
 /obj/structure/curtain/medical,
 /turf/open/floor{
-	icon_state = "damaged5";
-	dir = 8
+	dir = 8;
+	icon_state = "damaged5"
 	},
 /area/bigredv2/outside/medical)
 "eJ" = (
@@ -1798,8 +1798,8 @@
 	},
 /obj/item/shard,
 /turf/open/floor{
-	icon_state = "damaged2";
-	dir = 8
+	dir = 8;
+	icon_state = "damaged2"
 	},
 /area/bigredv2/outside/medical)
 "eM" = (
@@ -1820,16 +1820,16 @@
 "eO" = (
 /obj/effect/decal/cleanable/blood/gibs/body,
 /turf/open/floor{
-	icon_state = "damaged2";
-	dir = 8
+	dir = 8;
+	icon_state = "damaged2"
 	},
 /area/bigredv2/outside/medical)
 "eP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/ammo_casing/bullet,
 /turf/open/floor{
-	icon_state = "damaged5";
-	dir = 8
+	dir = 8;
+	icon_state = "damaged5"
 	},
 /area/bigredv2/outside/medical)
 "eQ" = (
@@ -1838,8 +1838,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/frame/table,
 /turf/open/floor{
-	icon_state = "whitegreen";
-	dir = 9
+	dir = 9;
+	icon_state = "whitegreen"
 	},
 /area/bigredv2/outside/medical)
 "eR" = (
@@ -1889,16 +1889,16 @@
 	dir = 6
 	},
 /turf/open/floor{
-	icon_state = "damaged5";
-	dir = 8
+	dir = 8;
+	icon_state = "damaged5"
 	},
 /area/bigredv2/outside/medical)
 "eY" = (
 /obj/structure/bed,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor{
-	icon_state = "whitegreen";
-	dir = 4
+	dir = 4;
+	icon_state = "whitegreen"
 	},
 /area/bigredv2/outside/medical)
 "eZ" = (
@@ -1906,8 +1906,8 @@
 	dir = 5
 	},
 /turf/open/floor{
-	icon_state = "damaged5";
-	dir = 8
+	dir = 8;
+	icon_state = "damaged5"
 	},
 /area/bigredv2/outside/medical)
 "fa" = (
@@ -1918,8 +1918,8 @@
 	name = "\improper Medical Clinic Operating Theatre"
 	},
 /turf/open/floor{
-	icon_state = "damaged2";
-	dir = 8
+	dir = 8;
+	icon_state = "damaged2"
 	},
 /area/bigredv2/outside/medical)
 "fb" = (
@@ -1978,8 +1978,8 @@
 "fj" = (
 /obj/effect/decal/cleanable/vomit,
 /turf/open/floor{
-	icon_state = "damaged4";
-	dir = 8
+	dir = 8;
+	icon_state = "damaged4"
 	},
 /area/bigredv2/outside/medical)
 "fk" = (
@@ -2019,8 +2019,8 @@
 /obj/structure/machinery/light,
 /obj/item/tool/surgery/cautery,
 /turf/open/floor{
-	icon_state = "whitebluefull";
-	dir = 5
+	dir = 5;
+	icon_state = "whitebluefull"
 	},
 /area/bigredv2/outside/medical)
 "fp" = (
@@ -2050,6 +2050,12 @@
 	icon_state = "platingdmg1"
 	},
 /area/bigredv2/outside/medical)
+"hn" = (
+/turf/open/floor{
+	dir = 1;
+	icon_state = "asteroidfloor"
+	},
+/area/bigredv2/outside/medical)
 "om" = (
 /obj/effect/landmark/objective_landmark/close,
 /turf/open/floor{
@@ -2066,27 +2072,27 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/objective_landmark/medium,
 /turf/open/floor{
-	icon_state = "damaged3";
-	dir = 8
+	dir = 8;
+	icon_state = "damaged3"
 	},
 /area/bigredv2/outside/medical)
 "MK" = (
 /obj/effect/landmark/objective_landmark/science,
 /turf/open/floor{
-	icon_state = "damaged5";
-	dir = 8
+	dir = 8;
+	icon_state = "damaged5"
 	},
 /area/bigredv2/outside/medical)
 "Xh" = (
 /obj/structure/transmitter/colony_net{
-	pixel_y = 24;
 	phone_category = "Solaris Ridge";
 	phone_color = "green";
-	phone_id = "Clinic Labs"
+	phone_id = "Clinic Labs";
+	pixel_y = 24
 	},
 /turf/open/floor{
-	icon_state = "damaged2";
-	dir = 8
+	dir = 8;
+	icon_state = "damaged2"
 	},
 /area/bigredv2/outside/medical)
 
@@ -2620,7 +2626,7 @@ ai
 ai
 dP
 ab
-eU
+hn
 "}
 (20,1,1) = {"
 af
@@ -2648,7 +2654,7 @@ fg
 fg
 dP
 aa
-eU
+hn
 "}
 (21,1,1) = {"
 af
@@ -2676,7 +2682,7 @@ eY
 fn
 fq
 aa
-eU
+hn
 "}
 (22,1,1) = {"
 af


### PR DESCRIPTION

# About the pull request

This PR

Adds more sidewalks (the outlines around the buildings) to bigred making the map feel more consistant 

Adds glass ceilings to LZ and that warehouse west of medical

Puts warning stripes under all the doors

Cleans up out of place tiles that I assume were mapper error?

does all of the above to a bunch of nightmares 

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

I think the outlines looked cool and wanted them to be around more because I think it makes sense

I think warning stripes under doors is also cool and I did it to the Almayer and LV522 so I'm doing it here too

I think that LZ1 and that warehouse probably would have ceilings ICly

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: SpartanBobby
maptweak: LZ1 Bigred and west medical warehouse now has a glass ceiling
maptweak: More sidewalks and pathways on big red
maptweak: various minor turf edits to big red
maptweak: places warning stripes tile under all doors on big red

/:cl:
