### PR TITLE
LV624 adds glass ceilings to SW sand temple, West Shack, Inflat, Filt, mine storage (north containers)

### DIFF
--- a/code/game/area/LV624.dm
+++ b/code/game/area/LV624.dm
@@ -30,10 +30,16 @@
 	icon_state = "southwest"
 	//ambience = list('sound/ambience/jungle_amb1.ogg')
 
+/area/lv624/ground/jungle/south_west_jungle/ceiling
+	ceiling = CEILING_GLASS
+
 /area/lv624/ground/jungle/west_jungle
 	name ="\improper Western Jungle"
 	icon_state = "west"
 	//ambience = list('sound/ambience/jungle_amb1.ogg')
+
+/area/lv624/ground/jungle/west_jungle/ceiling
+	ceiling = CEILING_GLASS
 
 /area/lv624/ground/jungle/east_jungle
 	name ="\improper Eastern Jungle"
@@ -82,10 +88,16 @@
 	icon_state = "west"
 	//ambience = list('sound/ambience/ambimine.ogg','sound/ambience/ambigen10.ogg','sound/ambience/ambigen4.ogg','sound/ambience/ambisin4.ogg')
 
+/area/lv624/ground/barrens/west_barrens/ceiling
+	ceiling = CEILING_GLASS
+
 /area/lv624/ground/barrens/east_barrens
 	name = "\improper Eastern Barrens"
 	icon_state = "east"
 	//ambience = list('sound/ambience/ambimine.ogg','sound/ambience/ambigen10.ogg','sound/ambience/ambigen4.ogg','sound/ambience/ambisin4.ogg')
+
+/area/lv624/ground/barrens/east_barrens/ceiling
+	ceiling = CEILING_GLASS
 
 /area/lv624/ground/barrens/containers
 	name = "\improper Containers"
@@ -96,6 +108,9 @@
 	name = "\improper North Eastern Barrens"
 	icon_state = "northeast"
 	//ambience = list('sound/ambience/ambimine.ogg','sound/ambience/ambigen10.ogg','sound/ambience/ambigen4.ogg','sound/ambience/ambisin4.ogg')
+
+/area/lv624/ground/barrens/north_east_barrens/ceiling
+	ceiling = CEILING_GLASS
 
 /area/lv624/ground/barrens/south_west_barrens
 	name = "\improper South Western Barrens"

--- a/maps/map_files/LV624/LV624.dmm
+++ b/maps/map_files/LV624/LV624.dmm
@@ -296,7 +296,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/lv624/ground/barrens/north_east_barrens)
+/area/lv624/ground/barrens/north_east_barrens/ceiling)
 "abv" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
 /turf/open/gm/dirt,
@@ -477,7 +477,7 @@
 	pixel_y = -22
 	},
 /turf/open/gm/dirt,
-/area/lv624/ground/jungle/south_west_jungle)
+/area/lv624/ground/jungle/south_west_jungle/ceiling)
 "acs" = (
 /obj/structure/machinery/door/airlock/almayer/medical/glass/colony{
 	dir = 1;
@@ -770,7 +770,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/lv624/ground/barrens/north_east_barrens)
+/area/lv624/ground/barrens/north_east_barrens/ceiling)
 "adD" = (
 /obj/structure/surface/rack,
 /obj/item/stack/sheet/mineral/diamond{
@@ -781,7 +781,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/lv624/ground/barrens/north_east_barrens)
+/area/lv624/ground/barrens/north_east_barrens/ceiling)
 "adE" = (
 /obj/structure/surface/rack,
 /obj/item/stack/sheet/metal{
@@ -797,7 +797,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/lv624/ground/barrens/north_east_barrens)
+/area/lv624/ground/barrens/north_east_barrens/ceiling)
 "adF" = (
 /obj/structure/surface/rack,
 /obj/item/tool/shovel,
@@ -805,7 +805,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/lv624/ground/barrens/north_east_barrens)
+/area/lv624/ground/barrens/north_east_barrens/ceiling)
 "adH" = (
 /obj/effect/decal/remains/xeno,
 /obj/structure/stairs/perspective{
@@ -825,7 +825,7 @@
 /turf/open/floor{
 	icon_state = "dark"
 	},
-/area/lv624/ground/barrens/north_east_barrens)
+/area/lv624/ground/barrens/north_east_barrens/ceiling)
 "adJ" = (
 /obj/effect/landmark/monkey_spawn,
 /turf/open/gm/dirt,
@@ -834,7 +834,7 @@
 /turf/open/floor{
 	icon_state = "dark"
 	},
-/area/lv624/ground/barrens/north_east_barrens)
+/area/lv624/ground/barrens/north_east_barrens/ceiling)
 "adN" = (
 /obj/structure/surface/rack,
 /obj/item/stack/sheet/mineral/iron{
@@ -848,7 +848,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/lv624/ground/barrens/north_east_barrens)
+/area/lv624/ground/barrens/north_east_barrens/ceiling)
 "adP" = (
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_membrane,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_membrane,
@@ -869,7 +869,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/lv624/ground/barrens/north_east_barrens)
+/area/lv624/ground/barrens/north_east_barrens/ceiling)
 "adS" = (
 /obj/structure/xenoautopsy/tank/hugger,
 /turf/open/shuttle{
@@ -885,7 +885,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/lv624/ground/barrens/north_east_barrens)
+/area/lv624/ground/barrens/north_east_barrens/ceiling)
 "adU" = (
 /obj/effect/landmark/crap_item,
 /turf/open/floor/airless{
@@ -956,7 +956,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/lv624/ground/barrens/north_east_barrens)
+/area/lv624/ground/barrens/north_east_barrens/ceiling)
 "aej" = (
 /obj/structure/flora/jungle/vines/heavy,
 /obj/structure/prop/brazier/torch,
@@ -1444,7 +1444,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/lv624/ground/barrens/north_east_barrens)
+/area/lv624/ground/barrens/north_east_barrens/ceiling)
 "agv" = (
 /turf/open/floor/plating{
 	dir = 4;
@@ -1614,19 +1614,19 @@
 "ahx" = (
 /obj/structure/inflatable,
 /turf/open/gm/dirt,
-/area/lv624/ground/barrens/west_barrens)
+/area/lv624/ground/barrens/west_barrens/ceiling)
 "ahy" = (
 /obj/structure/inflatable,
 /turf/open/floor{
 	icon_state = "redyellowfull"
 	},
-/area/lv624/ground/barrens/west_barrens)
+/area/lv624/ground/barrens/west_barrens/ceiling)
 "ahz" = (
 /obj/structure/inflatable/door,
 /turf/open/floor{
 	icon_state = "redyellowfull"
 	},
-/area/lv624/ground/barrens/west_barrens)
+/area/lv624/ground/barrens/west_barrens/ceiling)
 "ahB" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
 /turf/open/floor/sandstone/runed,
@@ -1643,18 +1643,18 @@
 /turf/open/floor{
 	icon_state = "redyellowfull"
 	},
-/area/lv624/ground/barrens/west_barrens)
+/area/lv624/ground/barrens/west_barrens/ceiling)
 "ahK" = (
 /obj/item/device/analyzer,
 /turf/open/floor{
 	icon_state = "redyellowfull"
 	},
-/area/lv624/ground/barrens/west_barrens)
+/area/lv624/ground/barrens/west_barrens/ceiling)
 "ahL" = (
 /turf/open/floor{
 	icon_state = "redyellowfull"
 	},
-/area/lv624/ground/barrens/west_barrens)
+/area/lv624/ground/barrens/west_barrens/ceiling)
 "ahM" = (
 /obj/structure/machinery/floodlight,
 /turf/open/floor/plating{
@@ -1711,19 +1711,19 @@
 /turf/open/floor{
 	icon_state = "redyellowfull"
 	},
-/area/lv624/ground/barrens/west_barrens)
+/area/lv624/ground/barrens/west_barrens/ceiling)
 "aie" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
 /turf/open/floor{
 	icon_state = "redyellowfull"
 	},
-/area/lv624/ground/barrens/west_barrens)
+/area/lv624/ground/barrens/west_barrens/ceiling)
 "aif" = (
 /obj/effect/landmark/crap_item,
 /turf/open/floor{
 	icon_state = "redyellowfull"
 	},
-/area/lv624/ground/barrens/west_barrens)
+/area/lv624/ground/barrens/west_barrens/ceiling)
 "aih" = (
 /obj/structure/largecrate/random,
 /obj/item/tool/crowbar/red,
@@ -1731,7 +1731,7 @@
 	dir = 9;
 	icon_state = "warnplate"
 	},
-/area/lv624/ground/barrens/east_barrens)
+/area/lv624/ground/barrens/east_barrens/ceiling)
 "aij" = (
 /obj/structure/filingcabinet,
 /obj/effect/landmark/objective_landmark/close,
@@ -1739,7 +1739,7 @@
 	dir = 1;
 	icon_state = "warnplate"
 	},
-/area/lv624/ground/barrens/east_barrens)
+/area/lv624/ground/barrens/east_barrens/ceiling)
 "aik" = (
 /obj/structure/surface/table,
 /obj/item/ashtray/plastic,
@@ -1749,7 +1749,7 @@
 	dir = 1;
 	icon_state = "warnplate"
 	},
-/area/lv624/ground/barrens/east_barrens)
+/area/lv624/ground/barrens/east_barrens/ceiling)
 "aim" = (
 /obj/structure/surface/table,
 /obj/item/device/flashlight/lamp,
@@ -1757,14 +1757,14 @@
 	dir = 1;
 	icon_state = "warnplate"
 	},
-/area/lv624/ground/barrens/east_barrens)
+/area/lv624/ground/barrens/east_barrens/ceiling)
 "ain" = (
 /obj/structure/machinery/computer3,
 /turf/open/floor/plating{
 	dir = 1;
 	icon_state = "warnplate"
 	},
-/area/lv624/ground/barrens/east_barrens)
+/area/lv624/ground/barrens/east_barrens/ceiling)
 "aio" = (
 /obj/structure/machinery/constructable_frame{
 	icon_state = "box_1"
@@ -1773,7 +1773,7 @@
 	dir = 1;
 	icon_state = "warnplate"
 	},
-/area/lv624/ground/barrens/east_barrens)
+/area/lv624/ground/barrens/east_barrens/ceiling)
 "aip" = (
 /obj/structure/surface/table,
 /obj/item/stack/rods{
@@ -1784,7 +1784,7 @@
 	dir = 1;
 	icon_state = "warnplate"
 	},
-/area/lv624/ground/barrens/east_barrens)
+/area/lv624/ground/barrens/east_barrens/ceiling)
 "aiq" = (
 /obj/structure/surface/table,
 /obj/item/stack/cable_coil/random,
@@ -1793,13 +1793,13 @@
 	dir = 5;
 	icon_state = "warnplate"
 	},
-/area/lv624/ground/barrens/east_barrens)
+/area/lv624/ground/barrens/east_barrens/ceiling)
 "aiu" = (
 /obj/effect/landmark/corpsespawner/miner,
 /turf/open/floor{
 	icon_state = "redyellowfull"
 	},
-/area/lv624/ground/barrens/west_barrens)
+/area/lv624/ground/barrens/west_barrens/ceiling)
 "aiv" = (
 /obj/structure/flora/bush/ausbushes/ppflowers,
 /turf/open/gm/coast{
@@ -1813,21 +1813,21 @@
 	dir = 9;
 	icon_state = "warnplate"
 	},
-/area/lv624/ground/barrens/east_barrens)
+/area/lv624/ground/barrens/east_barrens/ceiling)
 "aix" = (
 /obj/item/frame/apc,
 /turf/open/floor/plating{
 	dir = 1;
 	icon_state = "warnplate"
 	},
-/area/lv624/ground/barrens/east_barrens)
+/area/lv624/ground/barrens/east_barrens/ceiling)
 "aiy" = (
 /obj/structure/machinery/portable_atmospherics/powered/scrubber,
 /turf/open/floor/plating{
 	dir = 1;
 	icon_state = "warnplate"
 	},
-/area/lv624/ground/barrens/east_barrens)
+/area/lv624/ground/barrens/east_barrens/ceiling)
 "aiz" = (
 /obj/structure/disposalpipe/junction{
 	dir = 4
@@ -1835,7 +1835,7 @@
 /turf/open/floor/plating{
 	icon_state = "warnplate"
 	},
-/area/lv624/ground/barrens/east_barrens)
+/area/lv624/ground/barrens/east_barrens/ceiling)
 "aiA" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
@@ -1844,14 +1844,14 @@
 	dir = 1;
 	icon_state = "warnplate"
 	},
-/area/lv624/ground/barrens/east_barrens)
+/area/lv624/ground/barrens/east_barrens/ceiling)
 "aiB" = (
 /obj/effect/spawner/random/tech_supply,
 /turf/open/floor/plating{
 	dir = 1;
 	icon_state = "warnplate"
 	},
-/area/lv624/ground/barrens/east_barrens)
+/area/lv624/ground/barrens/east_barrens/ceiling)
 "aiD" = (
 /obj/structure/sink{
 	pixel_y = 30
@@ -1860,24 +1860,24 @@
 	dir = 1;
 	icon_state = "warnplate"
 	},
-/area/lv624/ground/barrens/east_barrens)
+/area/lv624/ground/barrens/east_barrens/ceiling)
 "aiF" = (
 /obj/item/weapon/butterfly/switchblade,
 /turf/open/floor/plating,
-/area/lv624/ground/barrens/east_barrens)
+/area/lv624/ground/barrens/east_barrens/ceiling)
 "aiG" = (
 /obj/structure/bed/stool,
 /obj/item/storage/backpack,
 /turf/open/floor/plating,
-/area/lv624/ground/barrens/east_barrens)
+/area/lv624/ground/barrens/east_barrens/ceiling)
 "aiH" = (
 /obj/effect/spawner/random/tech_supply,
 /turf/open/floor/plating,
-/area/lv624/ground/barrens/east_barrens)
+/area/lv624/ground/barrens/east_barrens/ceiling)
 "aiI" = (
 /obj/structure/bed/stool,
 /turf/open/floor/plating,
-/area/lv624/ground/barrens/east_barrens)
+/area/lv624/ground/barrens/east_barrens/ceiling)
 "aiJ" = (
 /obj/structure/surface/table,
 /obj/item/stack/medical/ointment,
@@ -1886,13 +1886,13 @@
 	dir = 4;
 	icon_state = "warnplate"
 	},
-/area/lv624/ground/barrens/east_barrens)
+/area/lv624/ground/barrens/east_barrens/ceiling)
 "aiK" = (
 /obj/structure/window/framed/colony,
 /turf/open/floor{
 	icon_state = "platebot"
 	},
-/area/lv624/ground/barrens/east_barrens)
+/area/lv624/ground/barrens/east_barrens/ceiling)
 "aiL" = (
 /obj/structure/machinery/door/airlock/almayer/secure/colony{
 	name = "Water Filtration Plant";
@@ -1902,13 +1902,13 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/lv624/ground/barrens/east_barrens)
+/area/lv624/ground/barrens/east_barrens/ceiling)
 "aiM" = (
 /turf/open/floor/plating{
 	dir = 10;
 	icon_state = "warnplate"
 	},
-/area/lv624/ground/barrens/east_barrens)
+/area/lv624/ground/barrens/east_barrens/ceiling)
 "aiO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -1917,7 +1917,7 @@
 /turf/open/floor/plating{
 	icon_state = "warnplate"
 	},
-/area/lv624/ground/barrens/east_barrens)
+/area/lv624/ground/barrens/east_barrens/ceiling)
 "aiP" = (
 /obj/structure/disposalpipe/junction{
 	dir = 8;
@@ -1926,7 +1926,7 @@
 /turf/open/floor/plating{
 	icon_state = "warnplate"
 	},
-/area/lv624/ground/barrens/east_barrens)
+/area/lv624/ground/barrens/east_barrens/ceiling)
 "aiQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -1934,7 +1934,7 @@
 /turf/open/floor/plating{
 	icon_state = "warnplate"
 	},
-/area/lv624/ground/barrens/east_barrens)
+/area/lv624/ground/barrens/east_barrens/ceiling)
 "aiR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -1943,7 +1943,7 @@
 /turf/open/floor/plating{
 	icon_state = "warnplate"
 	},
-/area/lv624/ground/barrens/east_barrens)
+/area/lv624/ground/barrens/east_barrens/ceiling)
 "aiS" = (
 /obj/item/tool/kitchen/knife/butcher,
 /turf/open/gm/dirt,
@@ -1956,19 +1956,19 @@
 /turf/open/floor/plating{
 	icon_state = "warnplate"
 	},
-/area/lv624/ground/barrens/east_barrens)
+/area/lv624/ground/barrens/east_barrens/ceiling)
 "aiU" = (
 /obj/structure/machinery/portable_atmospherics/powered/scrubber,
 /turf/open/floor/plating{
 	icon_state = "warnplate"
 	},
-/area/lv624/ground/barrens/east_barrens)
+/area/lv624/ground/barrens/east_barrens/ceiling)
 "aiV" = (
 /turf/open/floor/plating{
 	dir = 6;
 	icon_state = "warnplate"
 	},
-/area/lv624/ground/barrens/east_barrens)
+/area/lv624/ground/barrens/east_barrens/ceiling)
 "aja" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/gm/dirtgrassborder{
@@ -1988,7 +1988,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/lv624/ground/barrens/north_east_barrens)
+/area/lv624/ground/barrens/north_east_barrens/ceiling)
 "ajg" = (
 /obj/structure/flora/bush/ausbushes,
 /turf/open/gm/coast{
@@ -1998,7 +1998,7 @@
 "ajh" = (
 /obj/structure/flora/jungle/planttop1,
 /turf/closed/wall,
-/area/lv624/ground/barrens/east_barrens)
+/area/lv624/ground/barrens/east_barrens/ceiling)
 "aji" = (
 /obj/structure/surface/table/reinforced/prison{
 	color = "#6b675e"
@@ -4012,17 +4012,17 @@
 /turf/open/floor/wood{
 	icon_state = "wood-broken3"
 	},
-/area/lv624/ground/jungle/west_jungle)
+/area/lv624/ground/jungle/west_jungle/ceiling)
 "auf" = (
 /turf/open/floor/wood,
-/area/lv624/ground/jungle/west_jungle)
+/area/lv624/ground/jungle/west_jungle/ceiling)
 "aug" = (
 /obj/structure/barricade/wooden{
 	dir = 1;
 	pixel_y = 7
 	},
 /turf/open/floor/wood,
-/area/lv624/ground/jungle/west_jungle)
+/area/lv624/ground/jungle/west_jungle/ceiling)
 "auj" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/storage/surgical_tray,
@@ -4216,7 +4216,7 @@
 /turf/open/floor{
 	icon_state = "cult"
 	},
-/area/lv624/ground/jungle/west_jungle)
+/area/lv624/ground/jungle/west_jungle/ceiling)
 "auP" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/gm/coast{
@@ -4230,7 +4230,7 @@
 /turf/open/floor/wood{
 	icon_state = "wood-broken"
 	},
-/area/lv624/ground/jungle/west_jungle)
+/area/lv624/ground/jungle/west_jungle/ceiling)
 "auV" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor{
@@ -4340,7 +4340,7 @@
 "avo" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/wood,
-/area/lv624/ground/jungle/west_jungle)
+/area/lv624/ground/jungle/west_jungle/ceiling)
 "avp" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
 /obj/structure/stairs/perspective{
@@ -4968,7 +4968,7 @@
 "axp" = (
 /obj/effect/landmark/survivor_spawner,
 /turf/open/floor/wood,
-/area/lv624/ground/jungle/west_jungle)
+/area/lv624/ground/jungle/west_jungle/ceiling)
 "axt" = (
 /turf/open/floor{
 	dir = 9;
@@ -5076,9 +5076,9 @@
 	dir = 8
 	},
 /obj/structure/transmitter/colony_net{
-	pixel_y = 24;
 	phone_category = "Lazarus Landing";
-	phone_id = "Research Dome"
+	phone_id = "Research Dome";
+	pixel_y = 24
 	},
 /turf/open/floor{
 	dir = 5;
@@ -5117,7 +5117,7 @@
 	icon_state = "light_3"
 	},
 /turf/open/gm/dirt,
-/area/lv624/ground/jungle/south_west_jungle)
+/area/lv624/ground/jungle/south_west_jungle/ceiling)
 "axS" = (
 /obj/structure/machinery/cm_vending/sorted/medical/wall_med/limited{
 	pixel_x = 29
@@ -7389,7 +7389,7 @@
 /area/lv624/lazarus/toilet)
 "aFm" = (
 /turf/closed/wall/wood,
-/area/lv624/ground/jungle/west_jungle)
+/area/lv624/ground/jungle/west_jungle/ceiling)
 "aFn" = (
 /turf/open/floor{
 	icon_state = "chapel"
@@ -7576,7 +7576,7 @@
 "aFQ" = (
 /obj/structure/window_frame/wood,
 /turf/open/floor/plating,
-/area/lv624/ground/jungle/west_jungle)
+/area/lv624/ground/jungle/west_jungle/ceiling)
 "aFR" = (
 /turf/open/floor{
 	dir = 4;
@@ -8315,7 +8315,7 @@
 /obj/item/weapon/gun/shotgun/double/with_stock,
 /obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
 /turf/open/floor/wood,
-/area/lv624/ground/jungle/west_jungle)
+/area/lv624/ground/jungle/west_jungle/ceiling)
 "aII" = (
 /obj/structure/surface/rack,
 /obj/item/clothing/glasses/regular,
@@ -9165,8 +9165,8 @@
 "aMd" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/device/flashlight/lamp{
-	pixel_y = 14;
-	pixel_x = 6
+	pixel_x = 6;
+	pixel_y = 14
 	},
 /obj/structure/transmitter/colony_net/rotary{
 	phone_category = "Lazarus Landing";
@@ -11737,7 +11737,7 @@
 /area/lv624/lazarus/kitchen)
 "aVS" = (
 /turf/closed/wall/mineral/sandstone/runed,
-/area/lv624/ground/jungle/south_west_jungle)
+/area/lv624/ground/jungle/south_west_jungle/ceiling)
 "aVT" = (
 /obj/structure/flora/jungle/vines{
 	icon_state = "light_2";
@@ -11869,7 +11869,7 @@
 	},
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/gm/dirt,
-/area/lv624/ground/jungle/south_west_jungle)
+/area/lv624/ground/jungle/south_west_jungle/ceiling)
 "aWl" = (
 /obj/structure/flora/jungle/vines{
 	icon_state = "light_3"
@@ -11878,7 +11878,7 @@
 	dir = 4;
 	icon_state = "whiteyellowfull"
 	},
-/area/lv624/ground/jungle/south_west_jungle)
+/area/lv624/ground/jungle/south_west_jungle/ceiling)
 "aWm" = (
 /obj/structure/flora/jungle/vines/heavy{
 	pixel_y = 26
@@ -11887,7 +11887,7 @@
 	dir = 4;
 	icon_state = "whiteyellowfull"
 	},
-/area/lv624/ground/jungle/south_west_jungle)
+/area/lv624/ground/jungle/south_west_jungle/ceiling)
 "aWn" = (
 /obj/structure/flora/jungle/vines{
 	icon_state = "light_2";
@@ -11897,7 +11897,7 @@
 	dir = 4;
 	icon_state = "whiteyellowfull"
 	},
-/area/lv624/ground/jungle/south_west_jungle)
+/area/lv624/ground/jungle/south_west_jungle/ceiling)
 "aWo" = (
 /obj/structure/flora/jungle/vines/heavy{
 	pixel_y = 26
@@ -11910,7 +11910,7 @@
 	dir = 4;
 	icon_state = "whiteyellowfull"
 	},
-/area/lv624/ground/jungle/south_west_jungle)
+/area/lv624/ground/jungle/south_west_jungle/ceiling)
 "aWp" = (
 /obj/structure/flora/jungle/vines/heavy{
 	pixel_y = 26
@@ -11922,7 +11922,7 @@
 	dir = 4;
 	icon_state = "whiteyellowfull"
 	},
-/area/lv624/ground/jungle/south_west_jungle)
+/area/lv624/ground/jungle/south_west_jungle/ceiling)
 "aWs" = (
 /obj/structure/flora/jungle/vines/heavy{
 	pixel_x = -28
@@ -12068,11 +12068,11 @@
 	dir = 4;
 	icon_state = "whiteyellowfull"
 	},
-/area/lv624/ground/jungle/south_west_jungle)
+/area/lv624/ground/jungle/south_west_jungle/ceiling)
 "aWP" = (
 /obj/effect/landmark/monkey_spawn,
 /turf/open/gm/dirt,
-/area/lv624/ground/jungle/south_west_jungle)
+/area/lv624/ground/jungle/south_west_jungle/ceiling)
 "aWQ" = (
 /obj/structure/flora/jungle/vines/heavy{
 	pixel_x = -28
@@ -12243,10 +12243,10 @@
 /obj/structure/surface/rack,
 /obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
 /obj/structure/transmitter/colony_net{
-	pixel_y = 24;
 	phone_category = "Lazarus Landing";
 	phone_color = "yellow";
-	phone_id = "Engineering"
+	phone_id = "Engineering";
+	pixel_y = 24
 	},
 /turf/open/floor{
 	icon_state = "dark"
@@ -12279,14 +12279,14 @@
 "aXy" = (
 /obj/structure/flora/jungle/vines/heavy,
 /turf/closed/wall/mineral/sandstone/runed,
-/area/lv624/ground/jungle/south_west_jungle)
+/area/lv624/ground/jungle/south_west_jungle/ceiling)
 "aXA" = (
 /obj/structure/flora/bush/ausbushes/var3/ywflowers,
 /turf/open/floor{
 	dir = 4;
 	icon_state = "whiteyellowfull"
 	},
-/area/lv624/ground/jungle/south_west_jungle)
+/area/lv624/ground/jungle/south_west_jungle/ceiling)
 "aXB" = (
 /obj/structure/flora/jungle/vines/heavy{
 	pixel_x = -28
@@ -12308,7 +12308,7 @@
 	},
 /obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
 /turf/open/floor/wood,
-/area/lv624/ground/jungle/west_jungle)
+/area/lv624/ground/jungle/west_jungle/ceiling)
 "aXD" = (
 /obj/structure/surface/rack,
 /obj/item/tank/phoron,
@@ -12378,20 +12378,20 @@
 "aXQ" = (
 /obj/structure/flora/bush/ausbushes/reedbush,
 /turf/open/gm/dirt,
-/area/lv624/ground/jungle/south_west_jungle)
+/area/lv624/ground/jungle/south_west_jungle/ceiling)
 "aXR" = (
 /obj/structure/flora/jungle/vines/heavy,
 /turf/open/floor{
 	dir = 4;
 	icon_state = "whiteyellowfull"
 	},
-/area/lv624/ground/jungle/south_west_jungle)
+/area/lv624/ground/jungle/south_west_jungle/ceiling)
 "aXS" = (
 /obj/structure/flora/jungle/vines/heavy{
 	pixel_y = 26
 	},
 /turf/closed/wall/mineral/sandstone/runed,
-/area/lv624/ground/jungle/south_west_jungle)
+/area/lv624/ground/jungle/south_west_jungle/ceiling)
 "aXU" = (
 /obj/effect/landmark/good_item,
 /turf/open/floor/greengrid,
@@ -12757,7 +12757,7 @@
 	},
 /obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
 /turf/open/floor/wood,
-/area/lv624/ground/jungle/west_jungle)
+/area/lv624/ground/jungle/west_jungle/ceiling)
 "aZo" = (
 /obj/structure/surface/table/woodentable/fancy,
 /obj/item/device/megaphone,
@@ -12773,7 +12773,7 @@
 /turf/open/floor/wood{
 	icon_state = "wood-broken6"
 	},
-/area/lv624/ground/jungle/west_jungle)
+/area/lv624/ground/jungle/west_jungle/ceiling)
 "aZs" = (
 /obj/structure/closet/secure_closet/bar,
 /turf/open/floor{
@@ -13295,6 +13295,11 @@
 "byY" = (
 /turf/open/gm/dirt,
 /area/lv624/ground/colony/north_tcomms_road)
+"bzs" = (
+/turf/open/gm/dirtgrassborder{
+	dir = 4
+	},
+/area/lv624/ground/jungle/south_west_jungle/ceiling)
 "bzD" = (
 /obj/structure/largecrate/random,
 /obj/item/storage/fancy/crayons{
@@ -13534,7 +13539,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/lv624/ground/barrens/east_barrens)
+/area/lv624/ground/barrens/east_barrens/ceiling)
 "cac" = (
 /obj/structure/flora/grass/tallgrass/jungle/corner{
 	dir = 3
@@ -14115,7 +14120,7 @@
 /turf/open/floor{
 	icon_state = "dark"
 	},
-/area/lv624/ground/barrens/north_east_barrens)
+/area/lv624/ground/barrens/north_east_barrens/ceiling)
 "dsz" = (
 /obj/structure/closet/crate/hydroponics/prespawned,
 /obj/effect/landmark/objective_landmark/close,
@@ -14530,7 +14535,7 @@
 /turf/open/floor/plating{
 	icon_state = "warnplate"
 	},
-/area/lv624/ground/barrens/east_barrens)
+/area/lv624/ground/barrens/east_barrens/ceiling)
 "ekB" = (
 /obj/structure/stairs/perspective{
 	color = "#b29082";
@@ -15484,7 +15489,7 @@
 "gve" = (
 /obj/structure/flora/jungle/vines/heavy,
 /turf/closed/wall/mineral/sandstone/runed/decor,
-/area/lv624/ground/jungle/south_west_jungle)
+/area/lv624/ground/jungle/south_west_jungle/ceiling)
 "gwP" = (
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/west_caves)
@@ -16020,7 +16025,7 @@
 	dir = 4;
 	icon_state = "whiteyellowfull"
 	},
-/area/lv624/ground/jungle/south_west_jungle)
+/area/lv624/ground/jungle/south_west_jungle/ceiling)
 "hMr" = (
 /obj/structure/surface/rack{
 	color = "#6b675e";
@@ -16115,9 +16120,9 @@
 /area/lv624/ground/river/central_river)
 "hXt" = (
 /obj/structure/transmitter/colony_net{
-	pixel_y = 32;
 	phone_category = "Lazarus Landing";
-	phone_id = "Lakeside Bar"
+	phone_id = "Lakeside Bar";
+	pixel_y = 32
 	},
 /turf/open/floor/wood,
 /area/lv624/ground/caves/north_central_caves)
@@ -16140,7 +16145,7 @@
 /turf/open/floor{
 	icon_state = "redyellowfull"
 	},
-/area/lv624/ground/barrens/west_barrens)
+/area/lv624/ground/barrens/west_barrens/ceiling)
 "iab" = (
 /turf/open/gm/dirtgrassborder{
 	dir = 4;
@@ -16522,7 +16527,7 @@
 /area/lv624/ground/barrens/east_barrens)
 "iXj" = (
 /turf/closed/wall,
-/area/lv624/ground/barrens/east_barrens)
+/area/lv624/ground/barrens/east_barrens/ceiling)
 "iXz" = (
 /turf/open/gm/coast{
 	dir = 8;
@@ -16763,7 +16768,7 @@
 "jGs" = (
 /obj/structure/flora/bush/ausbushes/var3/brflowers,
 /turf/open/gm/dirt,
-/area/lv624/ground/jungle/south_west_jungle)
+/area/lv624/ground/jungle/south_west_jungle/ceiling)
 "jGW" = (
 /turf/closed/wall/strata_ice/jungle,
 /area/lv624/ground/jungle/central_jungle)
@@ -16994,7 +16999,7 @@
 /area/lv624/ground/river/west_river)
 "keS" = (
 /turf/open/floor/plating,
-/area/lv624/ground/barrens/east_barrens)
+/area/lv624/ground/barrens/east_barrens/ceiling)
 "kff" = (
 /obj/structure/blocker/forcefield/multitile_vehicles,
 /turf/open/gm/dirt,
@@ -17522,7 +17527,7 @@
 /area/lv624/ground/jungle/west_jungle)
 "lyz" = (
 /turf/closed/wall/mineral/sandstone/runed/decor,
-/area/lv624/ground/jungle/south_west_jungle)
+/area/lv624/ground/jungle/south_west_jungle/ceiling)
 "lyL" = (
 /obj/structure/flora/bush/ausbushes/var3/fernybush,
 /obj/structure/flora/jungle/vines{
@@ -18361,9 +18366,9 @@
 /area/lv624/ground/barrens/west_barrens)
 "nrP" = (
 /obj/structure/transmitter/colony_net{
-	pixel_y = 24;
 	phone_category = "Lazarus Landing";
-	phone_id = "Cargo"
+	phone_id = "Cargo";
+	pixel_y = 24
 	},
 /turf/open/floor/vault,
 /area/lv624/lazarus/quartstorage)
@@ -18668,7 +18673,7 @@
 /turf/open/floor/plating{
 	icon_state = "warnplate"
 	},
-/area/lv624/ground/barrens/east_barrens)
+/area/lv624/ground/barrens/east_barrens/ceiling)
 "nOX" = (
 /obj/structure/machinery/colony_floodlight,
 /turf/open/gm/grass,
@@ -18877,7 +18882,7 @@
 /area/lv624/ground/jungle/west_jungle)
 "oeN" = (
 /turf/closed/wall,
-/area/lv624/ground/barrens/north_east_barrens)
+/area/lv624/ground/barrens/north_east_barrens/ceiling)
 "oeS" = (
 /obj/effect/decal/remains/human,
 /turf/open/gm/dirt,
@@ -19268,7 +19273,7 @@
 	dir = 1;
 	icon_state = "warnplate"
 	},
-/area/lv624/ground/barrens/east_barrens)
+/area/lv624/ground/barrens/east_barrens/ceiling)
 "oWN" = (
 /obj/structure/flora/jungle/vines/heavy,
 /turf/open/gm/grass{
@@ -19735,10 +19740,10 @@
 	pixel_y = -5
 	},
 /obj/structure/transmitter/colony_net{
-	pixel_y = 24;
 	phone_category = "Lazarus Landing";
 	phone_color = "blue";
-	phone_id = "Corporate Office"
+	phone_id = "Corporate Office";
+	pixel_y = 24
 	},
 /turf/open/floor{
 	dir = 5;
@@ -20024,6 +20029,9 @@
 	},
 /turf/open/gm/dirt,
 /area/lv624/ground/barrens/south_eastern_barrens)
+"qBW" = (
+/turf/open/gm/dirt,
+/area/lv624/ground/jungle/south_west_jungle/ceiling)
 "qBX" = (
 /obj/structure/flora/grass/tallgrass/jungle,
 /turf/open/gm/grass,
@@ -20250,7 +20258,7 @@
 /turf/open/floor{
 	icon_state = "redyellowfull"
 	},
-/area/lv624/ground/barrens/west_barrens)
+/area/lv624/ground/barrens/west_barrens/ceiling)
 "rdS" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/storage/toolbox/mechanical{
@@ -20595,10 +20603,10 @@
 /area/lv624/ground/colony/north_tcomms_road)
 "rVH" = (
 /obj/structure/transmitter/colony_net{
-	pixel_y = 24;
 	phone_category = "Lazarus Landing";
 	phone_color = "yellow";
-	phone_id = "Communications"
+	phone_id = "Communications";
+	pixel_y = 24
 	},
 /turf/open/floor{
 	dir = 9;
@@ -21673,10 +21681,10 @@
 /area/lv624/ground/caves/sand_temple)
 "ulp" = (
 /obj/structure/transmitter/colony_net{
-	pixel_y = 24;
 	phone_category = "Lazarus Landing";
 	phone_color = "red";
-	phone_id = "Secure Storage"
+	phone_id = "Secure Storage";
+	pixel_y = 24
 	},
 /turf/open/floor/greengrid,
 /area/lv624/lazarus/secure_storage)
@@ -22639,7 +22647,7 @@
 "wFx" = (
 /obj/effect/landmark/objective_landmark/medium,
 /turf/open/floor/wood,
-/area/lv624/ground/jungle/west_jungle)
+/area/lv624/ground/jungle/west_jungle/ceiling)
 "wFR" = (
 /obj/effect/landmark/crap_item,
 /obj/effect/decal/cleanable/blood/drip,
@@ -22831,7 +22839,7 @@
 /turf/open/floor/plating{
 	icon_state = "warnplate"
 	},
-/area/lv624/ground/barrens/east_barrens)
+/area/lv624/ground/barrens/east_barrens/ceiling)
 "wWm" = (
 /turf/open/gm/dirtgrassborder{
 	dir = 4
@@ -24497,7 +24505,7 @@ tMh
 aKb
 aVS
 aVS
-uUl
+bzs
 aVS
 aXy
 aKf
@@ -24725,7 +24733,7 @@ kwG
 aKb
 aVS
 aWk
-xTT
+qBW
 axR
 aXy
 gve
@@ -24953,7 +24961,7 @@ aKb
 aKb
 lyz
 aWl
-xTT
+qBW
 aWO
 hMd
 aWl
@@ -25183,7 +25191,7 @@ aVS
 aWm
 aWO
 aWO
-xTT
+qBW
 aXQ
 aVS
 aLm
@@ -25411,7 +25419,7 @@ acr
 aWn
 aWO
 jGs
-xTT
+qBW
 aWO
 aVS
 aYm
@@ -25640,7 +25648,7 @@ aWo
 aWP
 aWO
 aWO
-xTT
+qBW
 axR
 xdO
 hUs
@@ -25868,7 +25876,7 @@ aWl
 aWO
 aWO
 aWO
-xTT
+qBW
 aVS
 aYo
 aVK
@@ -26094,7 +26102,7 @@ aKb
 aVS
 aWp
 aWO
-xTT
+qBW
 aXA
 aWl
 lyz
@@ -26321,7 +26329,7 @@ aXh
 aVw
 aVS
 axR
-xTT
+qBW
 aWO
 aWO
 aXR

--- a/maps/map_files/LV624/storage-crashed-ship/10.armorystorage.dmm
+++ b/maps/map_files/LV624/storage-crashed-ship/10.armorystorage.dmm
@@ -16,13 +16,13 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/lv624/ground/barrens/north_east_barrens)
+/area/lv624/ground/barrens/north_east_barrens/ceiling)
 "d" = (
 /obj/item/tool/shovel,
 /turf/open/floor{
 	icon_state = "dark"
 	},
-/area/lv624/ground/barrens/north_east_barrens)
+/area/lv624/ground/barrens/north_east_barrens/ceiling)
 "e" = (
 /obj/structure/machinery/door/airlock/almayer/secure/colony{
 	dir = 1;
@@ -34,7 +34,7 @@
 /turf/open/floor{
 	icon_state = "dark"
 	},
-/area/lv624/ground/barrens/north_east_barrens)
+/area/lv624/ground/barrens/north_east_barrens/ceiling)
 "i" = (
 /obj/structure/surface/rack,
 /obj/item/ammo_magazine/smg/mp27,
@@ -58,10 +58,10 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/lv624/ground/barrens/north_east_barrens)
+/area/lv624/ground/barrens/north_east_barrens/ceiling)
 "j" = (
 /turf/closed/wall,
-/area/lv624/ground/barrens/north_east_barrens)
+/area/lv624/ground/barrens/north_east_barrens/ceiling)
 "n" = (
 /obj/structure/surface/rack,
 /obj/item/stack/sheet/mineral/gold{
@@ -78,7 +78,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/lv624/ground/barrens/north_east_barrens)
+/area/lv624/ground/barrens/north_east_barrens/ceiling)
 "p" = (
 /turf/open/gm/dirt,
 /area/lv624/ground/barrens/north_east_barrens)
@@ -98,19 +98,19 @@
 /turf/open/floor{
 	icon_state = "dark"
 	},
-/area/lv624/ground/barrens/north_east_barrens)
+/area/lv624/ground/barrens/north_east_barrens/ceiling)
 "t" = (
 /obj/item/tool/pickaxe,
 /turf/open/floor{
 	icon_state = "dark"
 	},
-/area/lv624/ground/barrens/north_east_barrens)
+/area/lv624/ground/barrens/north_east_barrens/ceiling)
 "v" = (
 /obj/effect/landmark/crap_item,
 /turf/open/floor{
 	icon_state = "dark"
 	},
-/area/lv624/ground/barrens/north_east_barrens)
+/area/lv624/ground/barrens/north_east_barrens/ceiling)
 "x" = (
 /obj/structure/surface/rack,
 /obj/item/weapon/gun/smg/fp9000,
@@ -118,7 +118,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/lv624/ground/barrens/north_east_barrens)
+/area/lv624/ground/barrens/north_east_barrens/ceiling)
 "y" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/explosive/grenade/high_explosive/stick,
@@ -132,7 +132,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/lv624/ground/barrens/north_east_barrens)
+/area/lv624/ground/barrens/north_east_barrens/ceiling)
 "z" = (
 /obj/structure/surface/rack,
 /obj/item/weapon/gun/rifle/mar40{
@@ -146,7 +146,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/lv624/ground/barrens/north_east_barrens)
+/area/lv624/ground/barrens/north_east_barrens/ceiling)
 "B" = (
 /obj/structure/closet/crate,
 /obj/item/ammo_magazine/rifle/mar40,
@@ -159,7 +159,7 @@
 /turf/open/floor{
 	icon_state = "dark"
 	},
-/area/lv624/ground/barrens/north_east_barrens)
+/area/lv624/ground/barrens/north_east_barrens/ceiling)
 "F" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/weapon/gun/smg/nailgun,
@@ -169,7 +169,7 @@
 /turf/open/floor{
 	icon_state = "dark"
 	},
-/area/lv624/ground/barrens/north_east_barrens)
+/area/lv624/ground/barrens/north_east_barrens/ceiling)
 "G" = (
 /obj/structure/surface/rack,
 /obj/item/weapon/gun/smg/mp27{
@@ -182,7 +182,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/lv624/ground/barrens/north_east_barrens)
+/area/lv624/ground/barrens/north_east_barrens/ceiling)
 "I" = (
 /obj/structure/machinery/light{
 	dir = 4
@@ -204,7 +204,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/lv624/ground/barrens/north_east_barrens)
+/area/lv624/ground/barrens/north_east_barrens/ceiling)
 "K" = (
 /obj/effect/landmark/crap_item,
 /turf/open/gm/dirt,
@@ -213,7 +213,7 @@
 /turf/open/floor{
 	icon_state = "dark"
 	},
-/area/lv624/ground/barrens/north_east_barrens)
+/area/lv624/ground/barrens/north_east_barrens/ceiling)
 "O" = (
 /obj/structure/machinery/light{
 	dir = 8
@@ -221,7 +221,7 @@
 /turf/open/floor{
 	icon_state = "dark"
 	},
-/area/lv624/ground/barrens/north_east_barrens)
+/area/lv624/ground/barrens/north_east_barrens/ceiling)
 "P" = (
 /obj/structure/surface/rack,
 /obj/item/weapon/gun/smg/mac15,
@@ -232,7 +232,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/lv624/ground/barrens/north_east_barrens)
+/area/lv624/ground/barrens/north_east_barrens/ceiling)
 "Q" = (
 /obj/structure/surface/rack,
 /obj/item/stack/sheet/mineral/diamond{
@@ -242,7 +242,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/lv624/ground/barrens/north_east_barrens)
+/area/lv624/ground/barrens/north_east_barrens/ceiling)
 "T" = (
 /obj/structure/machinery/door/airlock/almayer/secure/colony{
 	icon_state = "door_locked";
@@ -253,7 +253,7 @@
 /turf/open/floor{
 	icon_state = "dark"
 	},
-/area/lv624/ground/barrens/north_east_barrens)
+/area/lv624/ground/barrens/north_east_barrens/ceiling)
 "U" = (
 /obj/structure/surface/rack,
 /obj/item/weapon/gun/rifle/lmg,
@@ -262,7 +262,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/lv624/ground/barrens/north_east_barrens)
+/area/lv624/ground/barrens/north_east_barrens/ceiling)
 "V" = (
 /obj/structure/surface/rack,
 /obj/item/stack/sheet/mineral/diamond{
@@ -275,7 +275,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/lv624/ground/barrens/north_east_barrens)
+/area/lv624/ground/barrens/north_east_barrens/ceiling)
 "X" = (
 /obj/effect/alien/weeds/node,
 /turf/open/gm/dirt,
@@ -294,7 +294,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/lv624/ground/barrens/north_east_barrens)
+/area/lv624/ground/barrens/north_east_barrens/ceiling)
 
 (1,1,1) = {"
 X

--- a/maps/map_files/LV624/storage-crashed-ship/10.valuables.dmm
+++ b/maps/map_files/LV624/storage-crashed-ship/10.valuables.dmm
@@ -11,7 +11,7 @@
 /turf/open/floor{
 	icon_state = "dark"
 	},
-/area/lv624/ground/barrens/north_east_barrens)
+/area/lv624/ground/barrens/north_east_barrens/ceiling)
 "e" = (
 /obj/structure/machinery/light{
 	dir = 4
@@ -20,10 +20,10 @@
 /turf/open/floor{
 	icon_state = "dark"
 	},
-/area/lv624/ground/barrens/north_east_barrens)
+/area/lv624/ground/barrens/north_east_barrens/ceiling)
 "f" = (
 /turf/closed/wall,
-/area/lv624/ground/barrens/north_east_barrens)
+/area/lv624/ground/barrens/north_east_barrens/ceiling)
 "i" = (
 /obj/structure/surface/rack,
 /obj/item/stack/sheet/mineral/diamond{
@@ -32,7 +32,7 @@
 /turf/open/floor{
 	icon_state = "dark"
 	},
-/area/lv624/ground/barrens/north_east_barrens)
+/area/lv624/ground/barrens/north_east_barrens/ceiling)
 "l" = (
 /obj/effect/landmark/crap_item,
 /obj/effect/alien/weeds/node,
@@ -55,7 +55,7 @@
 /turf/open/floor{
 	icon_state = "dark"
 	},
-/area/lv624/ground/barrens/north_east_barrens)
+/area/lv624/ground/barrens/north_east_barrens/ceiling)
 "p" = (
 /obj/structure/surface/rack,
 /obj/item/stack/sheet/mineral/silver{
@@ -66,13 +66,13 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/lv624/ground/barrens/north_east_barrens)
+/area/lv624/ground/barrens/north_east_barrens/ceiling)
 "q" = (
 /obj/effect/landmark/crap_item,
 /turf/open/floor{
 	icon_state = "dark"
 	},
-/area/lv624/ground/barrens/north_east_barrens)
+/area/lv624/ground/barrens/north_east_barrens/ceiling)
 "r" = (
 /obj/effect/landmark/crap_item,
 /turf/open/gm/dirt,
@@ -84,14 +84,14 @@
 /turf/open/floor{
 	icon_state = "dark"
 	},
-/area/lv624/ground/barrens/north_east_barrens)
+/area/lv624/ground/barrens/north_east_barrens/ceiling)
 "t" = (
 /obj/structure/surface/rack,
 /obj/item/tool/shovel,
 /turf/open/floor{
 	icon_state = "dark"
 	},
-/area/lv624/ground/barrens/north_east_barrens)
+/area/lv624/ground/barrens/north_east_barrens/ceiling)
 "y" = (
 /obj/structure/surface/rack,
 /obj/item/stack/sheet/metal{
@@ -107,7 +107,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/lv624/ground/barrens/north_east_barrens)
+/area/lv624/ground/barrens/north_east_barrens/ceiling)
 "C" = (
 /obj/structure/surface/rack,
 /obj/item/stack/sheet/mineral/platinum{
@@ -116,14 +116,14 @@
 /turf/open/floor{
 	icon_state = "dark"
 	},
-/area/lv624/ground/barrens/north_east_barrens)
+/area/lv624/ground/barrens/north_east_barrens/ceiling)
 "D" = (
 /obj/structure/largecrate/supply,
 /turf/open/floor{
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/lv624/ground/barrens/north_east_barrens)
+/area/lv624/ground/barrens/north_east_barrens/ceiling)
 "G" = (
 /obj/structure/surface/rack,
 /obj/item/weapon/gun/rifle/lmg,
@@ -131,7 +131,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/lv624/ground/barrens/north_east_barrens)
+/area/lv624/ground/barrens/north_east_barrens/ceiling)
 "H" = (
 /obj/structure/machinery/light{
 	dir = 8
@@ -140,7 +140,7 @@
 /turf/open/floor{
 	icon_state = "dark"
 	},
-/area/lv624/ground/barrens/north_east_barrens)
+/area/lv624/ground/barrens/north_east_barrens/ceiling)
 "I" = (
 /obj/structure/surface/rack,
 /obj/item/weapon/gun/rifle/mar40{
@@ -153,7 +153,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/lv624/ground/barrens/north_east_barrens)
+/area/lv624/ground/barrens/north_east_barrens/ceiling)
 "M" = (
 /obj/structure/surface/rack,
 /obj/item/stack/sheet/mineral/iron{
@@ -163,7 +163,7 @@
 /turf/open/floor{
 	icon_state = "dark"
 	},
-/area/lv624/ground/barrens/north_east_barrens)
+/area/lv624/ground/barrens/north_east_barrens/ceiling)
 "N" = (
 /obj/effect/alien/weeds/node,
 /turf/open/gm/dirt,
@@ -184,7 +184,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/lv624/ground/barrens/north_east_barrens)
+/area/lv624/ground/barrens/north_east_barrens/ceiling)
 "U" = (
 /obj/structure/closet/crate,
 /obj/item/ammo_magazine/rifle/mar40,
@@ -197,7 +197,7 @@
 /turf/open/floor{
 	icon_state = "dark"
 	},
-/area/lv624/ground/barrens/north_east_barrens)
+/area/lv624/ground/barrens/north_east_barrens/ceiling)
 "V" = (
 /obj/structure/machinery/light{
 	dir = 4
@@ -211,7 +211,7 @@
 /turf/open/floor{
 	icon_state = "dark"
 	},
-/area/lv624/ground/barrens/north_east_barrens)
+/area/lv624/ground/barrens/north_east_barrens/ceiling)
 "X" = (
 /obj/structure/machinery/door/airlock/almayer/secure/colony{
 	icon_state = "door_locked";
@@ -222,12 +222,12 @@
 /turf/open/floor{
 	icon_state = "dark"
 	},
-/area/lv624/ground/barrens/north_east_barrens)
+/area/lv624/ground/barrens/north_east_barrens/ceiling)
 "Z" = (
 /turf/open/floor{
 	icon_state = "dark"
 	},
-/area/lv624/ground/barrens/north_east_barrens)
+/area/lv624/ground/barrens/north_east_barrens/ceiling)
 
 (1,1,1) = {"
 O


### PR DESCRIPTION
# About the pull request

This PR adds glass ceilings to the 

Building north of containers

Wooden Shack west of LZ2

SW sandtemple

West barrens inflatables

filtration

# Explain why it's good for the game

These are buildings they should have ceilings currently the weather seeps into these areas & making them class fixes that without impacting current gameplay


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: SpartanBobby
maptweak: adds glass ceilings to multiple fringe buildings on the outskirts of LV624
/:cl:
