### PR TITLE
Changes rifleman sandbags from 20 points to 15

### DIFF
--- a/code/game/machinery/vending/vendor_types/squad_prep/squad_rifleman.dm
+++ b/code/game/machinery/vending/vendor_types/squad_prep/squad_rifleman.dm
@@ -76,7 +76,7 @@ GLOBAL_LIST_INIT(cm_vending_clothing_marine, list(
 
 		list("UTILITIES", 0, null, null, null),
 		list("E-Tool", 5, /obj/item/tool/shovel/etool/folded, null, VENDOR_ITEM_REGULAR),
-		list("Sandbags", 20, /obj/item/stack/sandbags_empty/half, null, VENDOR_ITEM_REGULAR),
+		list("Sandbags", 15, /obj/item/stack/sandbags_empty/half, null, VENDOR_ITEM_REGULAR),
 		list("Webbing", 10, /obj/item/clothing/accessory/storage/webbing, null, VENDOR_ITEM_REGULAR),
 		list("Brown Webbing Vest", 15, /obj/item/clothing/accessory/storage/black_vest/brown_vest, null, VENDOR_ITEM_REGULAR),
 		list("Black Webbing Vest", 15, /obj/item/clothing/accessory/storage/black_vest, null, VENDOR_ITEM_REGULAR),


### PR DESCRIPTION
In all my rifleman loadouts I seem to always have 15 points left over vs 20 so this change would allow people like me to actually take some sandbags with them if they buy other things. The price just seems too high at the moment so I'd like to see this value lowered.

For example If you just buy the pulse rifle kit and nothing else you have exactly 15 points left over.


![image](https://github.com/cmss13-devs/cmss13/assets/24533979/12e10199-4837-43e7-8b3b-043bdc410fe2)
![image](https://github.com/cmss13-devs/cmss13/assets/24533979/cdce7662-2025-4124-809c-1daed0d1684f)


:cl: Hopek
add: Rifleman sandbags now cost 15 points instead of 20 so that more riflemen can fit them in their loadout
/:cl: