### PR TITLE
Remove old armor crit tip

### DIFF
--- a/strings/metatips.txt
+++ b/strings/metatips.txt
@@ -11,4 +11,3 @@ You shouldn't ignore what your allies are up to. Sometimes they can be organizin
 The Wiki (https://cm-ss13.com/wiki) is a very useful repository of information about the game, such as weapons, equipment, xenomorph castes and their strains. It may not be fully up to date the majority of the time, but the basics are usually accurate.
 As an observer, you may see how much remaining hijack time is left in the status panel.
 Embrace the suck.
-Any applied damage has a small chance of being a critical hit, reducing armor's reduction of it to its minimal efficiency. For some reason.


### PR DESCRIPTION
Removes an outdated and misleading tip. Armor Crits were removed like over 6 months ago.
