### PR TITLE
Burrower burrow fixes

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/burrower/burrower_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/burrower/burrower_powers.dm
@@ -88,6 +88,13 @@
 		to_chat(src, SPAN_NOTICE("You must be burrowed to do this."))
 		return
 
+	if(tunnel)
+		tunnel = FALSE
+		to_chat(src, SPAN_NOTICE("You stop tunneling."))
+		used_tunnel = TRUE
+		addtimer(CALLBACK(src, PROC_REF(do_tunnel_cooldown)), (caste ? caste.tunnel_cooldown : 5 SECONDS))
+		return
+
 	if(used_tunnel)
 		to_chat(src, SPAN_NOTICE("You must wait some time to do this."))
 		return
@@ -119,13 +126,6 @@
 				continue
 			to_chat(src, SPAN_WARNING("There's something solid there to stop you emerging."))
 			return
-
-	if(tunnel)
-		tunnel = FALSE
-		to_chat(src, SPAN_NOTICE("You stop tunneling."))
-		used_tunnel = TRUE
-		addtimer(CALLBACK(src, PROC_REF(do_tunnel_cooldown)), (caste ? caste.tunnel_cooldown : 5 SECONDS))
-		return
 
 	if(!T || T.density)
 		to_chat(src, SPAN_NOTICE("You cannot tunnel to there!"))

--- a/code/modules/mob/living/carbon/xenomorph/abilities/burrower/burrower_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/burrower/burrower_powers.dm
@@ -136,6 +136,9 @@
 
 
 /mob/living/carbon/xenomorph/proc/process_tunnel(turf/T)
+	if(!tunnel)
+		return
+
 	if(world.time > tunnel_timer)
 		tunnel = FALSE
 		do_tunnel(T)


### PR DESCRIPTION
# About the pull request
1. Burrowers couldn't cancel their burrowing if they were clicking a tile that was non-valid to burrow to.
-Fixed by putting the 'if' for catching the request to cancel the burrow, ahead of everything else, so it wouldn't stopped by a validity check, since that would be irrelevant.

2. If the burrow was cancelled in the _literal_ last second the burrow would complete regardless, due the 1 second timer to teleport to the tile already having been started, with nothing to stop it. This can cause hillarities like you see in the video where the burrower first unburrows on the original tile, then proceeds to teleport to the target tile.
-Fixed by quitting the method that gets called by the 1 sec timer if we already cancelled.

# Explain why it's good for the game

Because stuff like this makes burrower players pull their hairs out

https://github.com/cmss13-devs/cmss13/assets/15560820/69ff6381-35fc-4123-91fa-856c51cec31e




# Testing Photographs and Procedure
Jawohl.


# Changelog
:cl: Jackie_Estegado
fix: The Burrower's burrow ability will no longer be not cancelled just because you clicked on a tile that you wouldn't have been able to burrow to.
fix: Burrowing will no longer complete even though you cancelled it.
/:cl:
