### PR TITLE
Updates chemistry grammar

### DIFF
--- a/code/modules/reagents/chemistry_reagents/medical.dm
+++ b/code/modules/reagents/chemistry_reagents/medical.dm
@@ -205,7 +205,7 @@
 /datum/reagent/medical/russianred
 	name = "Russian Red"
 	id = "russianred"
-	description = "An emergency radiation treatment, however it has extreme side effects."
+	description = "An emergency radiation treatment. The list of potential side effects include retinal damage and unconsciousness."
 	reagent_state = LIQUID
 	color = "#C8A5DC" // rgb: 200, 165, 220
 	custom_metabolism = AMOUNT_PER_TIME(1, 2 SECONDS)
@@ -251,7 +251,7 @@
 /datum/reagent/medical/bicaridine // yes it cures IB, it's located in some other part of wound code for whatever reason
 	name = "Bicaridine"
 	id = "bicaridine"
-	description = "Bicaridine is an analgesic medication and can be used to treat severe external blunt trauma and to stabilize patients. Overdosing will cause caustic burns, but can mend internal broken bloodvessels."
+	description = "Bicaridine is an analgesic medication and can be used to treat severe external blunt trauma and to stabilize patients. Overdosing on Bicaridine will cause caustic burns and toxins."
 	reagent_state = LIQUID
 	color = "#E8756C"
 	overdose = REAGENTS_OVERDOSE
@@ -339,7 +339,7 @@
 /datum/reagent/medical/rezadone
 	name = "Rezadone"
 	id = "rezadone"
-	description = "A powder derived from fish toxin, this substance can effectively treat genetic damage in humanoids, though excessive consumption has side effects."
+	description = "A powder derived from fish toxin, this substance can effectively treat genetic damage in humanoids. Excessive consumption may cause disastrous side effects."
 	reagent_state = SOLID
 	color = "#669900" // rgb: 102, 153, 0
 	overdose = REAGENTS_OVERDOSE
@@ -405,7 +405,7 @@
 /datum/reagent/medical/antized
 	name = "Anti-Zed"
 	id = "antiZed"
-	description = "Destroy the zombie virus in living humans and prevents regeneration for those who have already turned."
+	description = "Anti-Zed is an experimental drug that destroys the zombie virus in living humans and prevents regeneration for those who have already turned."
 	reagent_state = LIQUID
 	color = "#C8A5DC"
 	custom_metabolism = AMOUNT_PER_TIME(1, 200 SECONDS)

--- a/code/modules/reagents/chemistry_reagents/medical.dm
+++ b/code/modules/reagents/chemistry_reagents/medical.dm
@@ -405,7 +405,7 @@
 /datum/reagent/medical/antized
 	name = "Anti-Zed"
 	id = "antiZed"
-	description = "Anti-Zed is an experimental drug that destroys the zombie virus in living humans and prevents regeneration for those who have already turned."
+	description = "An experimental drug that destroys the zombie virus in living humans and prevents regeneration for those who have already turned."
 	reagent_state = LIQUID
 	color = "#C8A5DC"
 	custom_metabolism = AMOUNT_PER_TIME(1, 200 SECONDS)


### PR DESCRIPTION

# About the pull request

Adjusts the description of several chemicals to be more consistent and telling of their side-effects.

# Explain why it's good for the game

1. RR doesn't mention anything about eye damage, which is harder to detect than bruises. 
2. Bicaridine OD no longer fixes IB
3. Rezadone has brutal consequences. It is one of the best intentional poisons in the game. This is made more apparent.  
4. Anti-Zed is no longer a direct order to eradicate the undead masses. We will miss this dearly.

# Testing Photographs and Procedure
N/A
# Changelog

:cl:
fix: Bicaridine no-longer says it can fix IB.
spellcheck: RR, Bica, Rezadone and Anti-Zed are now more informative about their side effects.
/:cl: