### PR TITLE
Fix signallers bricking headsets on shared frequency

### DIFF
--- a/code/controllers/subsystem/communications.dm
+++ b/code/controllers/subsystem/communications.dm
@@ -216,6 +216,7 @@ var/const/RADIO_DEFAULT = "radio_default"
 var/const/RADIO_TO_AIRALARM = "radio_airalarm" //air alarms
 var/const/RADIO_FROM_AIRALARM = "radio_airalarm_rcvr" //devices interested in receiving signals from air alarms
 var/const/RADIO_CHAT = "radio_telecoms"
+var/const/RADIO_SIGNALS = "radio_signals"
 var/const/RADIO_ATMOSIA = "radio_atmos"
 var/const/RADIO_NAVBEACONS = "radio_navbeacon"
 var/const/RADIO_AIRLOCK = "radio_airlock"

--- a/code/modules/assembly/signaller.dm
+++ b/code/modules/assembly/signaller.dm
@@ -139,7 +139,7 @@
 /obj/item/device/assembly/signaller/proc/set_frequency(new_frequency)
 	SSradio.remove_object(src, frequency)
 	frequency = new_frequency
-	radio_connection = SSradio.add_object(src, frequency, RADIO_CHAT)
+	radio_connection = SSradio.add_object(src, frequency, RADIO_SIGNALS)
 
 /obj/item/device/assembly/signaller/Destroy()
 	SSradio.remove_object(src, frequency)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

Moves the signallers signals to their own radio filter, so they don't subscribe to headset radio and brick it (see runtime below)

I'm not hugely well versed in the telecomms system, it is possible this kills signallers communication across Z-levels, but I don't see any serious usage for this anyway

# Explain why it's good for the game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->

fixes #3529

![image](https://github.com/cmss13-devs/cmss13/assets/604624/5b5e9a50-e1cd-465e-9bd8-ab152a01ddc2)


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
\*beep* \*beep*


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: Fixed signallers hijacking radio headsets filters, bricking the frequency for radio usage. They now have their own radio filter.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
