### PR TITLE
add extra info to reagent tanks description

### DIFF
--- a/code/game/objects/structures/reagent_dispensers.dm
+++ b/code/game/objects/structures/reagent_dispensers.dm
@@ -38,6 +38,11 @@
 		. += SPAN_NOTICE(" Nothing.")
 	if(reagents)
 		. += SPAN_NOTICE("Total volume: [reagents.total_volume] / [reagents.maximum_volume].")
+	if(dispensing)
+		. += SPAN_NOTICE("\nTransfer mode: Dispensing")
+	else
+		. += SPAN_NOTICE("\nTransfer mode: Filling")
+	. += SPAN_NOTICE("Transfer rate: [amount_per_transfer_from_this] units")
 
 /obj/structure/reagent_dispensers/Destroy()
 	playsound(src.loc, 'sound/effects/slosh.ogg', 50, 1, 3)


### PR DESCRIPTION

# About the pull request

when you examine a reagent tank you can now see which direction fluids are going and how much will be transferred
no more accidentally contaminating a tank just because someone changed the direction

# Explain why it's good for the game

less contaminated tanks


# Testing Photographs and Procedure
![image](https://github.com/cmss13-devs/cmss13/assets/54692343/bc4f2d2a-0545-40ae-9d41-0ba2248f5b70)


# Changelog
:cl:Khadd
qol: transfer direction & rate are now listed in the description of reagent tanks
/:cl:
