### PR TITLE
Fix Map Landing Lights

### DIFF
--- a/html/changelogs/AutoChangeLog-pr-3522.yml
+++ b/html/changelogs/AutoChangeLog-pr-3522.yml
@@ -1,0 +1,4 @@
+author: "realforest2001"
+delete-after: True
+changes:
+  - rscadd: "Adds a staff to IC chat tab setting for faxes and prayers."

--- a/maps/map_files/DesertDam/Desert_Dam.dmm
+++ b/maps/map_files/DesertDam/Desert_Dam.dmm
@@ -934,7 +934,7 @@
 /area/desert_dam/interior/dam_interior/hanger)
 "adb" = (
 /obj/structure/machinery/floodlight/landing,
-/obj/structure/machinery/landinglight/ds2/delayone{
+/obj/structure/machinery/landinglight/ds1/delaytwo{
 	dir = 8
 	},
 /turf/open/floor{
@@ -42429,7 +42429,7 @@
 /area/desert_dam/interior/dam_interior/CE_office)
 "cDV" = (
 /obj/structure/machinery/floodlight/landing,
-/obj/structure/machinery/landinglight/ds2/delayone{
+/obj/structure/machinery/landinglight/ds2/delaythree{
 	dir = 4
 	},
 /turf/open/floor{
@@ -42768,9 +42768,7 @@
 	},
 /area/desert_dam/exterior/landing_pad_two)
 "cFa" = (
-/obj/docking_port/stationary/marine_dropship/lz2{
-	dwidth = 1
-	},
+/obj/docking_port/stationary/marine_dropship/lz2,
 /turf/open/floor/plating,
 /area/desert_dam/exterior/landing_pad_two)
 "cFb" = (
@@ -54066,9 +54064,7 @@
 	},
 /area/desert_dam/exterior/valley/valley_civilian)
 "dGU" = (
-/obj/docking_port/stationary/marine_dropship/lz1{
-	dwidth = 1
-	},
+/obj/docking_port/stationary/marine_dropship/lz1,
 /turf/open/floor/plating,
 /area/desert_dam/exterior/landing_pad_one)
 "dGV" = (
@@ -57679,8 +57675,7 @@
 "dUe" = (
 /obj/structure/surface/table/reinforced,
 /obj/structure/machinery/door/poddoor/shutters{
-	dir = 2;
-	icon_state = "shutter1"
+	dir = 2
 	},
 /turf/open/floor/prison{
 	icon_state = "sterile_white"
@@ -57690,8 +57685,7 @@
 /obj/structure/surface/table/reinforced,
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/structure/machinery/door/poddoor/shutters{
-	dir = 2;
-	icon_state = "shutter1"
+	dir = 2
 	},
 /turf/open/floor/prison{
 	icon_state = "sterile_white"
@@ -70045,12 +70039,12 @@ csD
 cMC
 cEZ
 cGG
-cGG
+cFc
 cFI
 cFS
 cGG
 cFc
-cGG
+cFI
 cFS
 cGG
 cFc

--- a/maps/map_files/DesertDam/Desert_Dam.dmm
+++ b/maps/map_files/DesertDam/Desert_Dam.dmm
@@ -63564,10 +63564,6 @@
 	icon_state = "cement_sunbleached4"
 	},
 /area/desert_dam/interior/caves/central_caves)
-"pgJ" = (
-/obj/structure/machinery/floodlight/landing/floor,
-/turf/open/floor/plating/prison,
-/area/desert_dam/exterior/valley/valley_cargo)
 "pif" = (
 /obj/docking_port/stationary/trijent_elevator/engineering,
 /turf/open/gm/empty,
@@ -74476,7 +74472,7 @@ cfd
 doE
 cSR
 doE
-pgJ
+doE
 doE
 cxU
 dTs

--- a/maps/map_files/DesertDam/Desert_Dam.dmm
+++ b/maps/map_files/DesertDam/Desert_Dam.dmm
@@ -108,11 +108,13 @@
 /turf/open/floor/plating,
 /area/desert_dam/building/substation/northwest)
 "aav" = (
-/obj/structure/machinery/landinglight/ds1,
-/turf/open/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached12"
+/obj/structure/machinery/landinglight/ds2/delayone{
+	dir = 4
 	},
-/area/desert_dam/exterior/landing_pad_one)
+/turf/open/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached9"
+	},
+/area/desert_dam/exterior/landing_pad_two)
 "aaw" = (
 /turf/open/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached1"
@@ -135,11 +137,11 @@
 	},
 /area/desert_dam/interior/caves/east_caves)
 "aaA" = (
-/obj/structure/machinery/landinglight/ds1/delaythree,
-/turf/open/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached12"
+/obj/structure/desertdam/decals/road_edge{
+	icon_state = "road_edge_decal11"
 	},
-/area/desert_dam/exterior/landing_pad_one)
+/turf/open/asphalt,
+/area/desert_dam/exterior/valley/valley_northwest)
 "aaB" = (
 /obj/structure/desertdam/decals/road_edge{
 	icon_state = "road_edge_decal9"
@@ -567,9 +569,9 @@
 	},
 /area/desert_dam/exterior/valley/valley_labs)
 "abQ" = (
-/obj/structure/machinery/landinglight/ds1/delaytwo,
+/obj/structure/machinery/landinglight/ds1/delayone,
 /turf/open/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached12"
+	icon_state = "cement_sunbleached4"
 	},
 /area/desert_dam/exterior/landing_pad_one)
 "abR" = (
@@ -581,11 +583,11 @@
 	},
 /area/desert_dam/exterior/valley/valley_labs)
 "abS" = (
-/obj/structure/machinery/landinglight/ds1/delayone,
+/obj/structure/machinery/landinglight/ds2,
 /turf/open/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached12"
 	},
-/area/desert_dam/exterior/landing_pad_one)
+/area/desert_dam/exterior/landing_pad_two)
 "abT" = (
 /obj/structure/machinery/conveyor{
 	id = "anomalybelt"
@@ -956,13 +958,11 @@
 	},
 /area/desert_dam/exterior/valley/valley_labs)
 "adf" = (
-/obj/structure/machinery/landinglight/ds1{
-	dir = 4
-	},
+/obj/structure/machinery/landinglight/ds2/delayone,
 /turf/open/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached9"
+	icon_state = "cement_sunbleached12"
 	},
-/area/desert_dam/exterior/landing_pad_one)
+/area/desert_dam/exterior/landing_pad_two)
 "adg" = (
 /obj/effect/decal/sand_overlay/sand1/corner1,
 /turf/open/asphalt/cement_sunbleached{
@@ -3678,13 +3678,13 @@
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_excavation)
 "alh" = (
-/obj/structure/machinery/landinglight/ds1{
-	dir = 8
+/obj/effect/decal/sand_overlay/sand1{
+	dir = 1
 	},
 /turf/open/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached2"
+	icon_state = "cement_sunbleached12"
 	},
-/area/desert_dam/exterior/landing_pad_one)
+/area/desert_dam/exterior/landing_pad_two)
 "ali" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N"
@@ -12323,9 +12323,7 @@
 /obj/effect/decal/sand_overlay/sand1{
 	dir = 9
 	},
-/turf/open/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached20"
-	},
+/turf/open/asphalt/cement_sunbleached,
 /area/desert_dam/exterior/landing_pad_two)
 "aKZ" = (
 /turf/open/floor{
@@ -12334,14 +12332,11 @@
 	},
 /area/desert_dam/building/lab_northwest/west_lab_xenoflora)
 "aLa" = (
-/obj/structure/machinery/landinglight/ds2,
-/obj/effect/decal/sand_overlay/sand1{
-	dir = 1
-	},
+/obj/structure/machinery/landinglight/ds1/delaythree,
 /turf/open/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached2"
+	icon_state = "cement_sunbleached4"
 	},
-/area/desert_dam/exterior/landing_pad_two)
+/area/desert_dam/exterior/landing_pad_one)
 "aLb" = (
 /obj/structure/machinery/power/apc{
 	dir = 1;
@@ -12541,11 +12536,10 @@
 /area/desert_dam/exterior/valley/valley_crashsite)
 "aLy" = (
 /obj/effect/decal/sand_overlay/sand1{
-	dir = 1
+	dir = 4
 	},
-/obj/structure/machinery/landinglight/ds2/delaytwo,
 /turf/open/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached9"
+	icon_state = "cement_sunbleached1"
 	},
 /area/desert_dam/exterior/landing_pad_two)
 "aLz" = (
@@ -12637,7 +12631,7 @@
 	dir = 1
 	},
 /turf/open/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached20"
+	icon_state = "cement_sunbleached1"
 	},
 /area/desert_dam/exterior/landing_pad_two)
 "aLL" = (
@@ -22092,12 +22086,11 @@
 	},
 /area/desert_dam/exterior/valley/valley_telecoms)
 "bqk" = (
-/obj/structure/machinery/floodlight/landing,
-/obj/structure/machinery/landinglight/ds1/delaytwo{
+/obj/structure/machinery/landinglight/ds1/delaythree{
 	dir = 4
 	},
-/turf/open/floor{
-	icon_state = "asteroidplating"
+/turf/open/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached15"
 	},
 /area/desert_dam/exterior/landing_pad_one)
 "bql" = (
@@ -22627,11 +22620,11 @@
 	},
 /area/desert_dam/interior/dam_interior/engine_west_wing)
 "brW" = (
-/obj/structure/machinery/landinglight/ds1{
+/obj/structure/machinery/landinglight/ds1/delayone{
 	dir = 4
 	},
 /turf/open/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached15"
+	icon_state = "cement_sunbleached9"
 	},
 /area/desert_dam/exterior/landing_pad_one)
 "brX" = (
@@ -24176,7 +24169,7 @@
 	},
 /area/desert_dam/interior/dam_interior/auxilary_tool_storage)
 "bxj" = (
-/obj/structure/machinery/landinglight/ds1{
+/obj/structure/machinery/landinglight/ds1/delayone{
 	dir = 8
 	},
 /turf/open/asphalt/cement_sunbleached{
@@ -25174,7 +25167,7 @@
 /turf/open/floor/wood,
 /area/desert_dam/building/administration/overseer_office)
 "bAF" = (
-/obj/structure/machinery/landinglight/ds1/delayone{
+/obj/structure/machinery/landinglight/ds1/delaytwo{
 	dir = 1
 	},
 /turf/open/asphalt/cement_sunbleached{
@@ -26045,7 +26038,7 @@
 /turf/open/floor/prison,
 /area/desert_dam/building/security/staffroom)
 "bDO" = (
-/obj/structure/machinery/landinglight/ds1/delaytwo{
+/obj/structure/machinery/landinglight/ds1/delaythree{
 	dir = 1
 	},
 /turf/open/asphalt/cement_sunbleached{
@@ -26507,7 +26500,7 @@
 	},
 /area/desert_dam/building/security/holding)
 "bFg" = (
-/obj/structure/machinery/landinglight/ds1/delaythree{
+/obj/structure/machinery/landinglight/ds1{
 	dir = 1
 	},
 /turf/open/asphalt/cement_sunbleached{
@@ -42104,30 +42097,22 @@
 	},
 /area/desert_dam/building/mining/workshop_foyer)
 "cCY" = (
-/obj/structure/machinery/landinglight/ds2,
-/obj/effect/decal/sand_overlay/sand1{
-	dir = 1
-	},
-/turf/open/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached12"
-	},
-/area/desert_dam/exterior/landing_pad_two)
+/turf/open/desert/dirt,
+/area/desert_dam/exterior/rock)
 "cCZ" = (
-/obj/structure/machinery/landinglight/ds2/delaythree,
-/obj/effect/decal/sand_overlay/sand1{
-	dir = 1
+/obj/structure/machinery/landinglight/ds2/delaytwo{
+	dir = 4
 	},
 /turf/open/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached12"
+	icon_state = "cement_sunbleached9"
 	},
 /area/desert_dam/exterior/landing_pad_two)
 "cDb" = (
-/obj/structure/machinery/landinglight/ds2/delaytwo,
 /obj/effect/decal/sand_overlay/sand1{
 	dir = 1
 	},
 /turf/open/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached12"
+	icon_state = "cement_sunbleached4"
 	},
 /area/desert_dam/exterior/landing_pad_two)
 "cDc" = (
@@ -42354,27 +42339,20 @@
 	},
 /area/desert_dam/building/medical/east_wing_hallway)
 "cDK" = (
-/obj/structure/machinery/landinglight/ds2/delayone,
-/obj/effect/decal/sand_overlay/sand1{
-	dir = 1
-	},
+/obj/structure/machinery/landinglight/ds2,
 /turf/open/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached12"
+	icon_state = "cement_sunbleached14"
 	},
 /area/desert_dam/exterior/landing_pad_two)
 "cDL" = (
-/obj/effect/decal/sand_overlay/sand1{
-	dir = 1
+/obj/structure/machinery/landinglight/ds2/delayone{
+	dir = 4
 	},
-/obj/structure/machinery/landinglight/ds2,
 /turf/open/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached12"
+	icon_state = "cement_sunbleached15"
 	},
 /area/desert_dam/exterior/landing_pad_two)
 "cDM" = (
-/obj/effect/decal/sand_overlay/sand1{
-	dir = 1
-	},
 /obj/structure/machinery/landinglight/ds2/delaythree,
 /turf/open/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached12"
@@ -42428,12 +42406,9 @@
 	},
 /area/desert_dam/interior/dam_interior/CE_office)
 "cDV" = (
-/obj/structure/machinery/floodlight/landing,
-/obj/structure/machinery/landinglight/ds2/delaythree{
-	dir = 4
-	},
-/turf/open/floor{
-	icon_state = "asteroidplating"
+/obj/structure/machinery/landinglight/ds2/delaytwo,
+/turf/open/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached15"
 	},
 /area/desert_dam/exterior/landing_pad_two)
 "cDX" = (
@@ -42463,14 +42438,11 @@
 	},
 /area/desert_dam/building/bar/bar)
 "cEc" = (
-/obj/structure/machinery/floodlight/landing,
-/obj/structure/machinery/landinglight/ds2/delayone{
-	dir = 8
+/obj/structure/machinery/landinglight/ds1,
+/turf/open/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached4"
 	},
-/turf/open/floor{
-	icon_state = "asteroidplating"
-	},
-/area/desert_dam/exterior/landing_pad_two)
+/area/desert_dam/exterior/landing_pad_one)
 "cEd" = (
 /obj/structure/prop/dam/wide_boulder/boulder1,
 /turf/open/desert/dirt{
@@ -42760,11 +42732,12 @@
 /turf/open/asphalt,
 /area/desert_dam/exterior/valley/valley_civilian)
 "cEZ" = (
-/obj/structure/machinery/landinglight/ds2{
+/obj/structure/machinery/floodlight/landing,
+/obj/structure/machinery/landinglight/ds2/delayone{
 	dir = 4
 	},
-/turf/open/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached9"
+/turf/open/floor{
+	icon_state = "asteroidplating"
 	},
 /area/desert_dam/exterior/landing_pad_two)
 "cFa" = (
@@ -43483,11 +43456,9 @@
 	},
 /area/desert_dam/exterior/valley/valley_cargo)
 "cGS" = (
-/obj/structure/machinery/landinglight/ds2/delaytwo{
-	dir = 4
-	},
+/obj/structure/machinery/landinglight/ds2/delaytwo,
 /turf/open/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached15"
+	icon_state = "cement_sunbleached12"
 	},
 /area/desert_dam/exterior/landing_pad_two)
 "cGT" = (
@@ -44915,7 +44886,7 @@
 /turf/open/asphalt,
 /area/desert_dam/building/warehouse/warehouse)
 "cLL" = (
-/obj/structure/machinery/landinglight/ds2{
+/obj/structure/machinery/landinglight/ds2/delayone{
 	dir = 8
 	},
 /turf/open/asphalt/cement_sunbleached{
@@ -45125,7 +45096,7 @@
 	},
 /area/desert_dam/exterior/landing_pad_two)
 "cMD" = (
-/obj/structure/machinery/landinglight/ds2/delayone{
+/obj/structure/machinery/landinglight/ds2/delaytwo{
 	dir = 1
 	},
 /turf/open/asphalt/cement_sunbleached{
@@ -45157,7 +45128,7 @@
 /turf/open/asphalt,
 /area/desert_dam/exterior/valley/valley_cargo)
 "cML" = (
-/obj/structure/machinery/landinglight/ds2/delaytwo{
+/obj/structure/machinery/landinglight/ds2/delaythree{
 	dir = 1
 	},
 /turf/open/asphalt/cement_sunbleached{
@@ -45288,7 +45259,7 @@
 /turf/open/floor/plating,
 /area/desert_dam/building/medical/virology_isolation)
 "cNb" = (
-/obj/structure/machinery/landinglight/ds2/delaythree{
+/obj/structure/machinery/landinglight/ds2{
 	dir = 1
 	},
 /turf/open/asphalt/cement_sunbleached{
@@ -45333,23 +45304,23 @@
 	},
 /area/desert_dam/interior/dam_interior/central_tunnel)
 "cNh" = (
-/obj/structure/machinery/landinglight/ds2{
-	dir = 1
-	},
 /obj/structure/desertdam/decals/road_edge,
 /obj/structure/desertdam/decals/road_stop{
 	dir = 1;
 	icon_state = "stop_decal5"
 	},
-/turf/open/asphalt,
-/area/desert_dam/exterior/landing_pad_two)
-"cNi" = (
 /obj/structure/machinery/landinglight/ds2/delayone{
 	dir = 1
 	},
+/turf/open/asphalt,
+/area/desert_dam/exterior/landing_pad_two)
+"cNi" = (
 /obj/structure/desertdam/decals/road_stop{
 	dir = 1;
 	icon_state = "stop_decal5"
+	},
+/obj/structure/machinery/landinglight/ds2/delaytwo{
+	dir = 1
 	},
 /turf/open/asphalt,
 /area/desert_dam/exterior/landing_pad_two)
@@ -45418,12 +45389,12 @@
 /turf/open/asphalt,
 /area/desert_dam/exterior/valley/valley_cargo)
 "cNx" = (
-/obj/structure/machinery/landinglight/ds2/delaytwo{
-	dir = 1
-	},
 /obj/structure/desertdam/decals/road_stop{
 	dir = 1;
 	icon_state = "stop_decal5"
+	},
+/obj/structure/machinery/landinglight/ds2/delaythree{
+	dir = 1
 	},
 /turf/open/asphalt,
 /area/desert_dam/exterior/landing_pad_two)
@@ -46117,12 +46088,12 @@
 	},
 /area/desert_dam/building/substation/southwest)
 "cPI" = (
-/obj/structure/machinery/landinglight/ds2/delaythree{
-	dir = 1
-	},
 /obj/structure/desertdam/decals/road_stop{
 	dir = 1;
 	icon_state = "stop_decal5"
+	},
+/obj/structure/machinery/landinglight/ds2{
+	dir = 1
 	},
 /turf/open/asphalt,
 /area/desert_dam/exterior/landing_pad_two)
@@ -46221,15 +46192,15 @@
 	},
 /area/desert_dam/exterior/valley/valley_cargo)
 "cPW" = (
-/obj/structure/machinery/landinglight/ds2{
-	dir = 1
-	},
 /obj/structure/desertdam/decals/road_edge{
 	icon_state = "road_edge_decal2"
 	},
 /obj/structure/desertdam/decals/road_stop{
 	dir = 1;
 	icon_state = "stop_decal5"
+	},
+/obj/structure/machinery/landinglight/ds2/delayone{
+	dir = 1
 	},
 /turf/open/asphalt,
 /area/desert_dam/exterior/landing_pad_two)
@@ -63593,6 +63564,10 @@
 	icon_state = "cement_sunbleached4"
 	},
 /area/desert_dam/interior/caves/central_caves)
+"pgJ" = (
+/obj/structure/machinery/floodlight/landing/floor,
+/turf/open/floor/plating/prison,
+/area/desert_dam/exterior/valley/valley_cargo)
 "pif" = (
 /obj/docking_port/stationary/trijent_elevator/engineering,
 /turf/open/gm/empty,
@@ -63907,6 +63882,12 @@
 	icon_state = "cement_sunbleached4"
 	},
 /area/desert_dam/exterior/valley/valley_crashsite)
+"qoJ" = (
+/obj/structure/machinery/landinglight/ds1/delaytwo,
+/turf/open/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached4"
+	},
+/area/desert_dam/exterior/landing_pad_one)
 "qqR" = (
 /obj/structure/desertdam/decals/road_edge{
 	icon_state = "road_edge_decal4"
@@ -65344,6 +65325,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/asphalt,
 /area/desert_dam/exterior/valley/valley_hydro)
+"vpn" = (
+/obj/structure/machinery/landinglight/ds2/delayone{
+	dir = 8
+	},
+/obj/structure/machinery/floodlight/landing,
+/turf/open/floor{
+	icon_state = "asteroidplating"
+	},
+/area/desert_dam/exterior/landing_pad_two)
 "vpz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -65802,6 +65792,14 @@
 /obj/structure/flora/grass/tallgrass/desert,
 /turf/open/desert/dirt,
 /area/desert_dam/exterior/valley/valley_civilian)
+"wRg" = (
+/obj/structure/machinery/landinglight/ds2/delayone{
+	dir = 8
+	},
+/turf/open/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached2"
+	},
+/area/desert_dam/exterior/landing_pad_two)
 "wRi" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/asphalt,
@@ -66158,11 +66156,12 @@
 /turf/open/asphalt,
 /area/desert_dam/exterior/river/riverside_central_north)
 "xNB" = (
-/obj/structure/machinery/landinglight/ds1/delaythree{
+/obj/structure/machinery/floodlight/landing,
+/obj/structure/machinery/landinglight/ds1{
 	dir = 4
 	},
-/turf/open/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached9"
+/turf/open/floor{
+	icon_state = "asteroidplating"
 	},
 /area/desert_dam/exterior/landing_pad_one)
 "xOb" = (
@@ -69803,20 +69802,20 @@ dTs
 dTs
 cwz
 aKY
-cGu
-cGu
-cGu
-cGu
-cGu
-cGu
-cGu
-cGu
-cGu
-cGu
-cGu
-cGu
 cMq
 cGu
+cGu
+cGu
+cGu
+cGu
+cGu
+cGu
+cGu
+cGu
+cGu
+cGu
+cGu
+aLy
 cGu
 cGu
 cGu
@@ -70036,21 +70035,12 @@ cAa
 dTs
 dTs
 csD
+alh
 cMC
-cEZ
-cGG
-cFc
+aav
 cFI
 cFS
 cGG
-cFc
-cFI
-cFS
-cGG
-cFc
-cGS
-cDV
-cEZ
 cFc
 cFI
 cFS
@@ -70059,6 +70049,15 @@ cFc
 cFI
 cFS
 cLe
+cEZ
+cCZ
+cFS
+cGG
+cFc
+cFI
+cFS
+cGG
+cDL
 cMC
 cgh
 cUl
@@ -70270,8 +70269,8 @@ doE
 crr
 dTs
 dTs
-aLa
-cDY
+cDb
+cDK
 cDY
 cDY
 cDY
@@ -70504,7 +70503,8 @@ doE
 doE
 dTs
 dTs
-cCZ
+cDb
+cDM
 cDY
 cDY
 cDY
@@ -70526,7 +70526,6 @@ cDY
 cDY
 cDY
 cFa
-cDY
 cML
 cBS
 cUl
@@ -70739,7 +70738,7 @@ cSR
 dTs
 dTs
 cDb
-cDY
+cGS
 cDY
 cDY
 cDY
@@ -70972,8 +70971,8 @@ cji
 ckp
 crr
 dTs
-cDK
-cDY
+cDb
+adf
 cDY
 cDY
 cDY
@@ -71205,9 +71204,9 @@ cRM
 cRM
 dFn
 doE
-dTs
 cCY
-cDY
+cDb
+abS
 cDY
 cDY
 cDY
@@ -71440,8 +71439,8 @@ crx
 dFo
 doE
 doE
-cCZ
-cDY
+cDb
+cDM
 cDY
 cDY
 cDY
@@ -71675,7 +71674,7 @@ dFo
 doE
 doE
 cDb
-cDY
+cGS
 cDY
 cDY
 cDY
@@ -71908,8 +71907,8 @@ crx
 dFo
 cOj
 doE
-cDK
-cDY
+cDb
+adf
 cDY
 cDY
 cDY
@@ -72142,8 +72141,8 @@ crx
 dFo
 doE
 doE
-cDL
-cDY
+cDb
+abS
 cDY
 cDY
 cDY
@@ -72376,8 +72375,8 @@ crx
 dFo
 doE
 doE
+cDb
 cDM
-cDY
 cDY
 cDY
 cDY
@@ -72610,8 +72609,8 @@ crx
 dFo
 doE
 cDc
-aLy
-cDY
+cDb
+cDV
 cDY
 cDY
 cDY
@@ -72664,20 +72663,20 @@ aSY
 aQg
 aUi
 aUC
-aQX
-aVg
-aVg
-aVg
-aVg
-aVg
-aVg
-aVg
-aVg
-aVg
-aVg
 aVg
 aQX
 aVg
+aVg
+aVg
+aVg
+aVg
+aVg
+aVg
+aVg
+aVg
+aVg
+aVg
+aQX
 aVg
 aVg
 aVg
@@ -72844,8 +72843,9 @@ crx
 dFo
 doE
 doE
+alh
 cMC
-cFb
+wRg
 cGQ
 cFe
 cFP
@@ -72857,7 +72857,7 @@ cGa
 cGQ
 cFe
 cHn
-cEc
+vpn
 cFb
 cFe
 cFP
@@ -72865,7 +72865,6 @@ cGa
 cGQ
 cFe
 cFP
-cGa
 cLL
 cMC
 cgh
@@ -72897,11 +72896,22 @@ aSx
 aQV
 aQV
 aUi
-aSa
+aUD
+aVh
 aQY
-adf
+brW
+bhv
+boV
 bpQ
 aNv
+bhv
+boV
+bpQ
+aNv
+bhv
+bqk
+xNB
+brW
 bhv
 boV
 bpQ
@@ -72910,17 +72920,6 @@ bhv
 boV
 bpQ
 vRc
-bqk
-xNB
-bpQ
-aNv
-bhv
-boV
-bpQ
-aNv
-bhv
-boV
-brW
 aQY
 aUD
 aVh
@@ -73091,7 +73090,7 @@ cDX
 cDX
 cDX
 cDX
-cES
+cDX
 cDX
 cDX
 cDX
@@ -73132,8 +73131,8 @@ aQV
 aQV
 aUi
 aUD
+aVj
 acI
-aWh
 aWh
 aWh
 aWh
@@ -73364,9 +73363,10 @@ auy
 aPJ
 aql
 ara
-asa
-aUD
-aaA
+asc
+auy
+arZ
+aLa
 aWh
 aWh
 aWh
@@ -73388,7 +73388,6 @@ aWh
 aWh
 aWh
 dGU
-aWh
 bDO
 aVi
 aVh
@@ -73598,10 +73597,10 @@ aDb
 aqg
 aqg
 aqg
+agV
+aqg
 asa
-aUD
-abQ
-aWh
+qoJ
 aWh
 aWh
 aWh
@@ -73832,9 +73831,10 @@ aDc
 aqg
 aqg
 aqg
+agV
+aqg
 asa
-aUD
-abS
+abQ
 aWh
 aWh
 aWh
@@ -73856,8 +73856,7 @@ aWh
 aWh
 aWh
 aWh
-aWh
-bFB
+bGY
 aQV
 beT
 aQg
@@ -74066,9 +74065,10 @@ aSc
 aIJ
 aql
 ara
+agV
+aqg
 asa
-aUD
-aav
+cEc
 aWh
 aWh
 aWh
@@ -74090,8 +74090,7 @@ aWh
 aWh
 aWh
 aWh
-aWh
-bGY
+bJQ
 aQV
 beT
 aQg
@@ -74300,9 +74299,10 @@ aSd
 apz
 aqg
 aqg
+aqg
+aqg
 asa
-aUD
-aaA
+aLa
 aWh
 aWh
 aWh
@@ -74324,8 +74324,7 @@ aWh
 aWh
 aWh
 aWh
-aWh
-bJQ
+bKC
 aQV
 beT
 aQg
@@ -74477,7 +74476,7 @@ cfd
 doE
 cSR
 doE
-doE
+pgJ
 doE
 cxU
 dTs
@@ -74534,9 +74533,10 @@ aIa
 apz
 aqg
 aqg
+agV
+aqg
 asa
-aUD
-abQ
+qoJ
 aWh
 aWh
 aWh
@@ -74558,8 +74558,7 @@ aWh
 aWh
 aWh
 aWh
-aWh
-bKC
+bFB
 aQV
 beT
 aQg
@@ -74768,9 +74767,10 @@ aIa
 apz
 aql
 ara
+agV
+aqg
 asa
-aUD
-abS
+abQ
 aWh
 aWh
 aWh
@@ -74792,8 +74792,7 @@ aWh
 aWh
 aWh
 aWh
-aWh
-bFB
+bGY
 aQV
 beT
 aQg
@@ -75002,10 +75001,10 @@ aIa
 apz
 aqg
 aqg
+agV
+aqg
 asa
-aUD
-aav
-aWh
+cEc
 aWh
 aWh
 aWh
@@ -75236,10 +75235,10 @@ aIa
 apz
 aqg
 aqg
-asa
-aUD
+asd
+auz
 aaA
-aWh
+aLa
 aWh
 aWh
 aWh
@@ -75472,8 +75471,8 @@ aql
 ara
 asa
 aUD
+aVg
 acJ
-aWh
 aWh
 aWh
 aWh
@@ -75705,9 +75704,10 @@ apz
 aqg
 aqg
 asa
-aSa
+aUD
+aVh
 aQY
-alh
+oCD
 bpT
 aWi
 blD
@@ -75727,7 +75727,6 @@ bpu
 bpT
 aWi
 blD
-bpu
 bxj
 aQY
 aUD
@@ -75940,20 +75939,20 @@ aqg
 aqg
 asa
 aUE
-aQX
-aVj
-aVj
-aVj
-aVj
-aVj
-aVj
-aVj
-aVj
-aVj
-aVj
 aVj
 aQX
 aVj
+aVj
+aVj
+aVj
+aVj
+aVj
+aVj
+aVj
+aVj
+aVj
+aVj
+aQX
 aVj
 aVj
 aVj

--- a/maps/map_files/FOP_v3_Sciannex/Fiorina_SciAnnex.dmm
+++ b/maps/map_files/FOP_v3_Sciannex/Fiorina_SciAnnex.dmm
@@ -26003,12 +26003,7 @@
 /obj/structure/machinery/landinglight/ds2/delaythree{
 	dir = 8
 	},
-/obj/structure/machinery/landinglight/ds2{
-	dir = 8
-	},
-/turf/open/floor/prison{
-	icon_state = "floor_plate"
-	},
+/turf/open/floor/plating/prison,
 /area/fiorina/lz/near_lzII)
 "qeU" = (
 /obj/structure/window/reinforced{
@@ -72778,7 +72773,7 @@ wSm
 wSm
 wSm
 wSm
-wSm
+qeR
 wSm
 wSm
 wSm
@@ -72990,7 +72985,7 @@ wSm
 wSm
 wSm
 wSm
-wSm
+qeR
 wSm
 wSm
 wSm
@@ -74460,11 +74455,11 @@ hxy
 hxy
 tZs
 hLK
-qeR
+yfC
 fHV
 tZs
 lLv
-qeR
+yfC
 fHV
 tZs
 hLK

--- a/maps/map_files/FOP_v3_Sciannex/Fiorina_SciAnnex.dmm
+++ b/maps/map_files/FOP_v3_Sciannex/Fiorina_SciAnnex.dmm
@@ -21576,15 +21576,6 @@
 	icon_state = "floor_plate"
 	},
 /area/fiorina/station/civres_blue)
-"njs" = (
-/obj/structure/machinery/landinglight/ds2/delaythree{
-	dir = 4
-	},
-/obj/structure/machinery/landinglight/ds2{
-	dir = 4
-	},
-/turf/open/floor/prison,
-/area/fiorina/lz/near_lzII)
 "njx" = (
 /turf/open/floor/prison,
 /area/fiorina/tumor/servers)
@@ -71941,7 +71932,7 @@ fpM
 hTm
 eZN
 sIT
-njs
+uVo
 hTm
 eZN
 hxy

--- a/maps/map_files/FOP_v3_Sciannex/Fiorina_SciAnnex.dmm
+++ b/maps/map_files/FOP_v3_Sciannex/Fiorina_SciAnnex.dmm
@@ -71930,11 +71930,11 @@ hTm
 eZN
 sIT
 fpM
-eZN
+hTm
 eZN
 sIT
 fpM
-eZN
+hTm
 eZN
 sIT
 fpM

--- a/maps/map_files/FOP_v3_Sciannex/Fiorina_SciAnnex.dmm
+++ b/maps/map_files/FOP_v3_Sciannex/Fiorina_SciAnnex.dmm
@@ -25999,12 +25999,6 @@
 /obj/effect/spawner/random/pills/highchance,
 /turf/open/floor/plating/prison,
 /area/fiorina/station/security/wardens)
-"qeR" = (
-/obj/structure/machinery/landinglight/ds2/delaythree{
-	dir = 8
-	},
-/turf/open/floor/plating/prison,
-/area/fiorina/lz/near_lzII)
 "qeU" = (
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -72773,7 +72767,7 @@ wSm
 wSm
 wSm
 wSm
-qeR
+wSm
 wSm
 wSm
 wSm
@@ -72985,7 +72979,7 @@ wSm
 wSm
 wSm
 wSm
-qeR
+wSm
 wSm
 wSm
 wSm

--- a/maps/map_files/FOP_v3_Sciannex/Fiorina_SciAnnex.dmm
+++ b/maps/map_files/FOP_v3_Sciannex/Fiorina_SciAnnex.dmm
@@ -306,7 +306,6 @@
 "aif" = (
 /obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	dir = 1;
-	req_access = null;
 	req_one_access = null
 	},
 /turf/open/floor/plating/prison,
@@ -894,7 +893,6 @@
 "ayX" = (
 /obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	dir = 1;
-	req_access = null;
 	req_one_access = null
 	},
 /turf/open/floor/plating/prison,
@@ -1481,7 +1479,6 @@
 "aMM" = (
 /obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	dir = 1;
-	req_access = null;
 	req_one_access = null
 	},
 /turf/open/floor/plating/prison,
@@ -2255,9 +2252,7 @@
 	},
 /area/fiorina/station/lowsec)
 "bju" = (
-/obj/docking_port/stationary/marine_dropship/lz1{
-	dwidth = 1
-	},
+/obj/docking_port/stationary/marine_dropship/lz1,
 /turf/open/floor/plating/prison,
 /area/fiorina/lz/near_lzI)
 "bjx" = (
@@ -4358,7 +4353,6 @@
 /area/fiorina/station/civres_blue)
 "cDl" = (
 /obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
-	req_access = null;
 	req_one_access = null
 	},
 /turf/open/floor/plating/prison,
@@ -4494,7 +4488,6 @@
 /area/fiorina/station/security)
 "cHD" = (
 /obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
-	req_access = null;
 	req_one_access = null
 	},
 /turf/open/floor/prison,
@@ -5741,7 +5734,6 @@
 /area/fiorina/tumor/fiberbush)
 "dwT" = (
 /obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
-	req_access = null;
 	req_one_access = null
 	},
 /turf/open/floor/plating/prison,
@@ -7428,6 +7420,12 @@
 	icon_state = "green"
 	},
 /area/fiorina/station/transit_hub)
+"eAM" = (
+/obj/structure/machinery/landinglight/ds2/delaytwo{
+	dir = 1
+	},
+/turf/open/floor/plating/prison,
+/area/fiorina/lz/near_lzII)
 "eAQ" = (
 /obj/effect/landmark/corpsespawner/ua_riot,
 /turf/open/floor/prison{
@@ -7852,6 +7850,12 @@
 /obj/item/prop/helmetgarb/riot_shield,
 /turf/open/floor/prison,
 /area/fiorina/station/security)
+"eSF" = (
+/obj/structure/machinery/landinglight/ds2/delaythree{
+	dir = 1
+	},
+/turf/open/floor/plating/prison,
+/area/fiorina/lz/near_lzII)
 "eSZ" = (
 /obj/structure/bed/roller,
 /turf/open/floor/prison{
@@ -8140,7 +8144,7 @@
 	},
 /area/fiorina/station/botany)
 "eZN" = (
-/obj/structure/machinery/landinglight/ds1/delayone{
+/obj/structure/machinery/landinglight/ds2/delayone{
 	dir = 4
 	},
 /turf/open/floor/prison{
@@ -9234,6 +9238,14 @@
 	icon_state = "floor_plate"
 	},
 /area/fiorina/station/security)
+"fHV" = (
+/obj/structure/machinery/landinglight/ds2/delaytwo{
+	dir = 8
+	},
+/turf/open/floor/prison{
+	icon_state = "floor_plate"
+	},
+/area/fiorina/lz/near_lzII)
 "fIj" = (
 /obj/item/clothing/suit/storage/hazardvest,
 /turf/open/floor/prison,
@@ -9771,7 +9783,7 @@
 /turf/open/floor/carpet,
 /area/fiorina/station/security/wardens)
 "fZd" = (
-/obj/structure/machinery/landinglight/ds1/delaytwo{
+/obj/structure/machinery/landinglight/ds2/delayone{
 	dir = 1
 	},
 /turf/open/floor/plating/prison,
@@ -9928,7 +9940,6 @@
 "gfh" = (
 /obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	dir = 1;
-	req_access = null;
 	req_one_access = null
 	},
 /turf/open/floor/plating/prison,
@@ -12582,7 +12593,7 @@
 /turf/closed/wall/prison,
 /area/fiorina/lz/near_lzII)
 "hLK" = (
-/obj/structure/machinery/landinglight/ds1/delayone{
+/obj/structure/machinery/landinglight/ds2{
 	dir = 8
 	},
 /turf/open/floor/prison{
@@ -12784,6 +12795,14 @@
 	icon_state = "squares"
 	},
 /area/fiorina/station/telecomm/lz1_cargo)
+"hTm" = (
+/obj/structure/machinery/landinglight/ds2{
+	dir = 4
+	},
+/turf/open/floor/prison{
+	icon_state = "floor_plate"
+	},
+/area/fiorina/lz/near_lzII)
 "hTr" = (
 /obj/structure/closet,
 /obj/item/clothing/mask/gas/clown_hat,
@@ -12877,7 +12896,6 @@
 "hVG" = (
 /obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	dir = 1;
-	req_access = null;
 	req_one_access = null
 	},
 /turf/open/floor/plating/prison,
@@ -14773,7 +14791,6 @@
 /area/fiorina/station/transit_hub)
 "jjs" = (
 /obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
-	req_access = null;
 	req_one_access = null
 	},
 /turf/open/floor/plating/prison,
@@ -15296,7 +15313,6 @@
 "jwc" = (
 /obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	dir = 1;
-	req_access = null;
 	req_one_access = null
 	},
 /turf/open/floor/plating/prison,
@@ -15428,6 +15444,13 @@
 	icon_state = "damaged2"
 	},
 /area/fiorina/station/security)
+"jCp" = (
+/obj/structure/machinery/landinglight/ds1/delaytwo,
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "darkyellowfull2"
+	},
+/area/fiorina/lz/near_lzI)
 "jCt" = (
 /obj/structure/machinery/light/small{
 	dir = 4;
@@ -16446,9 +16469,7 @@
 	},
 /area/fiorina/station/power_ring)
 "kfE" = (
-/obj/docking_port/stationary/marine_dropship/lz2{
-	dwidth = 1
-	},
+/obj/docking_port/stationary/marine_dropship/lz2,
 /turf/open/floor/plating/prison,
 /area/fiorina/lz/near_lzII)
 "kfF" = (
@@ -18951,7 +18972,7 @@
 /area/fiorina/station/telecomm/lz1_cargo)
 "lGh" = (
 /obj/effect/decal/cleanable/blood/oil,
-/obj/structure/machinery/landinglight/ds1/delayone{
+/obj/structure/machinery/landinglight/ds1/delaythree{
 	dir = 1
 	},
 /turf/open/floor/prison{
@@ -19093,7 +19114,7 @@
 /turf/open/floor/plating/prison,
 /area/fiorina/tumor/civres)
 "lLv" = (
-/obj/structure/machinery/landinglight/ds1/delayone{
+/obj/structure/machinery/landinglight/ds2{
 	dir = 8
 	},
 /turf/open/floor/prison,
@@ -19444,6 +19465,15 @@
 	icon_state = "floor_plate"
 	},
 /area/fiorina/station/security)
+"lYA" = (
+/obj/structure/machinery/landinglight/ds1{
+	dir = 8
+	},
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "darkyellowfull2"
+	},
+/area/fiorina/lz/near_lzI)
 "lZf" = (
 /turf/closed/shuttle/elevator{
 	dir = 10
@@ -19543,8 +19573,7 @@
 /area/fiorina/station/medbay)
 "mbp" = (
 /obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
-	dir = 1;
-	locked = 0
+	dir = 1
 	},
 /turf/open/floor/plating/prison,
 /area/fiorina/oob)
@@ -19806,7 +19835,6 @@
 "mhM" = (
 /obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	dir = 1;
-	req_access = null;
 	req_one_access = null
 	},
 /turf/open/floor/plating/prison,
@@ -21548,6 +21576,15 @@
 	icon_state = "floor_plate"
 	},
 /area/fiorina/station/civres_blue)
+"njs" = (
+/obj/structure/machinery/landinglight/ds2/delaythree{
+	dir = 4
+	},
+/obj/structure/machinery/landinglight/ds2{
+	dir = 4
+	},
+/turf/open/floor/prison,
+/area/fiorina/lz/near_lzII)
 "njx" = (
 /turf/open/floor/prison,
 /area/fiorina/tumor/servers)
@@ -22078,6 +22115,15 @@
 	icon_state = "bluefull"
 	},
 /area/fiorina/station/power_ring)
+"nBR" = (
+/obj/structure/machinery/landinglight/ds1/delaytwo{
+	dir = 1
+	},
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "darkyellowfull2"
+	},
+/area/fiorina/lz/near_lzI)
 "nBV" = (
 /turf/open/floor/prison{
 	icon_state = "darkpurple2"
@@ -22179,6 +22225,15 @@
 	icon_state = "floor_plate"
 	},
 /area/fiorina/station/medbay)
+"nGk" = (
+/obj/structure/machinery/landinglight/ds1/delaytwo{
+	dir = 4
+	},
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "darkyellowfull2"
+	},
+/area/fiorina/lz/near_lzI)
 "nGq" = (
 /obj/structure/machinery/portable_atmospherics/powered/scrubber,
 /turf/open/floor/prison,
@@ -23499,6 +23554,13 @@
 	icon_state = "whitegreen"
 	},
 /area/fiorina/station/medbay)
+"owG" = (
+/obj/structure/machinery/landinglight/ds1,
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "darkyellowfull2"
+	},
+/area/fiorina/lz/near_lzI)
 "oxg" = (
 /obj/structure/machinery/light/double/blue{
 	dir = 4;
@@ -24709,7 +24771,6 @@
 /area/fiorina/lz/near_lzII)
 "ppI" = (
 /obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
-	req_access = null;
 	req_one_access = null
 	},
 /turf/open/floor/plating/prison,
@@ -25067,6 +25128,15 @@
 	icon_state = "floor_plate"
 	},
 /area/fiorina/station/flight_deck)
+"pAN" = (
+/obj/structure/machinery/landinglight/ds1{
+	dir = 1
+	},
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "darkyellowfull2"
+	},
+/area/fiorina/lz/near_lzI)
 "pAO" = (
 /obj/structure/stairs/perspective{
 	dir = 4;
@@ -25939,7 +26009,10 @@
 /turf/open/floor/plating/prison,
 /area/fiorina/station/security/wardens)
 "qeR" = (
-/obj/structure/machinery/landinglight/ds1{
+/obj/structure/machinery/landinglight/ds2/delaythree{
+	dir = 8
+	},
+/obj/structure/machinery/landinglight/ds2{
 	dir = 8
 	},
 /turf/open/floor/prison{
@@ -28798,6 +28871,16 @@
 	icon_state = "darkpurplefull2"
 	},
 /area/fiorina/tumor/ice_lab)
+"rPu" = (
+/obj/effect/decal/cleanable/blood/oil,
+/obj/structure/machinery/landinglight/ds1/delaytwo{
+	dir = 1
+	},
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "darkyellowfull2"
+	},
+/area/fiorina/lz/near_lzI)
 "rPI" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/reagent_container/food/drinks/cans/souto/cherry{
@@ -28919,7 +29002,6 @@
 "rSr" = (
 /obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	dir = 1;
-	req_access = null;
 	req_one_access = null
 	},
 /turf/open/floor/plating/prison,
@@ -29860,7 +29942,6 @@
 "sBA" = (
 /obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	dir = 1;
-	req_access = null;
 	req_one_access = null
 	},
 /turf/open/floor/plating/prison,
@@ -29920,7 +30001,6 @@
 "sDL" = (
 /obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	dir = 1;
-	req_access = null;
 	req_one_access = null
 	},
 /turf/open/floor/plating/prison,
@@ -30046,7 +30126,7 @@
 	},
 /area/fiorina/tumor/civres)
 "sIT" = (
-/obj/structure/machinery/landinglight/ds1/delaytwo{
+/obj/structure/machinery/landinglight/ds2/delaytwo{
 	dir = 4
 	},
 /turf/open/floor/prison{
@@ -30122,6 +30202,15 @@
 	icon_state = "yellow"
 	},
 /area/fiorina/station/disco)
+"sLo" = (
+/obj/structure/machinery/landinglight/ds1/delaythree{
+	dir = 1
+	},
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "darkyellowfull2"
+	},
+/area/fiorina/lz/near_lzI)
 "sLx" = (
 /obj/structure/disposalpipe/segment{
 	color = "#c4c4c4";
@@ -30951,7 +31040,6 @@
 /area/fiorina/station/security)
 "tpa" = (
 /obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
-	req_access = null;
 	req_one_access = null
 	},
 /turf/open/floor/plating/prison,
@@ -31078,13 +31166,13 @@
 /turf/open/floor/prison,
 /area/fiorina/station/park)
 "tts" = (
-/obj/structure/machinery/landinglight/ds1/delaytwo,
+/obj/structure/machinery/landinglight/ds2,
 /turf/open/floor/prison{
 	icon_state = "floor_plate"
 	},
 /area/fiorina/lz/near_lzII)
 "ttK" = (
-/obj/structure/machinery/landinglight/ds1/delayone,
+/obj/structure/machinery/landinglight/ds2/delaythree,
 /turf/open/floor/prison{
 	icon_state = "floor_plate"
 	},
@@ -31477,6 +31565,10 @@
 	},
 /turf/open/floor/plating/prison,
 /area/fiorina/station/transit_hub)
+"tFu" = (
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/prison,
+/area/fiorina/lz/near_lzII)
 "tFA" = (
 /obj/structure/platform{
 	dir = 4
@@ -32192,7 +32284,7 @@
 /turf/open/floor/prison,
 /area/fiorina/station/security)
 "tZs" = (
-/obj/structure/machinery/landinglight/ds1/delaytwo{
+/obj/structure/machinery/landinglight/ds2/delayone{
 	dir = 8
 	},
 /turf/open/floor/prison{
@@ -32210,6 +32302,15 @@
 	icon_state = "platingdmg1"
 	},
 /area/fiorina/tumor/civres)
+"tZV" = (
+/obj/structure/machinery/landinglight/ds1/delayone{
+	dir = 8
+	},
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "darkyellowfull2"
+	},
+/area/fiorina/lz/near_lzI)
 "tZW" = (
 /obj/item/tool/wet_sign,
 /turf/open/floor/almayer{
@@ -32408,6 +32509,15 @@
 /obj/structure/window_frame/prison/reinforced,
 /turf/open/floor/plating/prison,
 /area/fiorina/station/research_cells)
+"uhH" = (
+/obj/structure/machinery/landinglight/ds1/delaythree{
+	dir = 4
+	},
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "darkyellowfull2"
+	},
+/area/fiorina/lz/near_lzI)
 "uin" = (
 /obj/item/ammo_box/magazine/misc/flares/empty{
 	pixel_x = -1;
@@ -32596,6 +32706,15 @@
 /obj/structure/largecrate/random/barrel/white,
 /turf/open/floor/prison,
 /area/fiorina/station/power_ring)
+"uol" = (
+/obj/structure/machinery/landinglight/ds1{
+	dir = 4
+	},
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "darkyellowfull2"
+	},
+/area/fiorina/lz/near_lzI)
 "upt" = (
 /obj/structure/platform,
 /turf/open/floor/prison,
@@ -33031,7 +33150,7 @@
 	},
 /area/fiorina/station/security)
 "uEN" = (
-/obj/structure/machinery/landinglight/ds1,
+/obj/structure/machinery/landinglight/ds2/delaytwo,
 /turf/open/floor/prison{
 	icon_state = "floor_plate"
 	},
@@ -33473,7 +33592,7 @@
 	},
 /area/fiorina/tumor/ship)
 "uVo" = (
-/obj/structure/machinery/landinglight/ds1/delaytwo{
+/obj/structure/machinery/landinglight/ds2/delaythree{
 	dir = 4
 	},
 /turf/open/floor/prison,
@@ -34379,8 +34498,8 @@
 /turf/open/space/basic,
 /area/fiorina/oob)
 "vuE" = (
-/obj/structure/machinery/landinglight/ds2/delaythree,
 /obj/effect/decal/cleanable/blood/oil,
+/obj/structure/machinery/landinglight/ds2/delayone,
 /turf/open/floor/prison,
 /area/fiorina/lz/near_lzII)
 "vuW" = (
@@ -34732,7 +34851,6 @@
 "vFs" = (
 /obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	dir = 1;
-	req_access = null;
 	req_one_access = null
 	},
 /turf/open/floor/plating/prison,
@@ -35016,7 +35134,7 @@
 	},
 /area/fiorina/station/botany)
 "vPA" = (
-/obj/structure/machinery/landinglight/ds2/delaythree,
+/obj/structure/machinery/landinglight/ds2/delayone,
 /turf/open/floor/prison,
 /area/fiorina/lz/near_lzII)
 "vPM" = (
@@ -35492,7 +35610,7 @@
 	},
 /area/fiorina/station/chapel)
 "wfp" = (
-/obj/structure/machinery/landinglight/ds2/delaythree{
+/obj/structure/machinery/landinglight/ds1/delaythree{
 	dir = 8
 	},
 /turf/open/floor/prison{
@@ -36306,6 +36424,13 @@
 	name = "astroturf"
 	},
 /area/fiorina/station/research_cells)
+"wJf" = (
+/obj/structure/machinery/landinglight/ds1/delaythree,
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "darkyellowfull2"
+	},
+/area/fiorina/lz/near_lzI)
 "wJt" = (
 /obj/structure/bed/chair/comfy,
 /turf/open/floor/prison{
@@ -36405,7 +36530,6 @@
 /area/fiorina/tumor/servers)
 "wMi" = (
 /obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
-	req_access = null;
 	req_one_access = null
 	},
 /turf/open/floor/plating/prison,
@@ -36613,7 +36737,6 @@
 "wRP" = (
 /obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	dir = 1;
-	req_access = null;
 	req_one_access = null
 	},
 /turf/open/floor/plating/prison,
@@ -37030,7 +37153,6 @@
 /area/fiorina/station/security)
 "xja" = (
 /obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
-	req_access = null;
 	req_one_access = null
 	},
 /turf/open/floor/plating/prison,
@@ -37045,6 +37167,15 @@
 	icon_state = "cell_stripe"
 	},
 /area/fiorina/station/power_ring)
+"xjw" = (
+/obj/structure/machinery/landinglight/ds1/delaytwo{
+	dir = 8
+	},
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "darkyellowfull2"
+	},
+/area/fiorina/lz/near_lzI)
 "xjK" = (
 /turf/open/floor/prison{
 	dir = 10;
@@ -37360,6 +37491,12 @@
 /obj/structure/platform/stair_cut/alt,
 /turf/open/floor/plating/prison,
 /area/fiorina/station/disco)
+"xrH" = (
+/obj/structure/machinery/landinglight/ds2{
+	dir = 1
+	},
+/turf/open/floor/plating/prison,
+/area/fiorina/lz/near_lzII)
 "xrJ" = (
 /obj/effect/spawner/random/tool,
 /turf/open/floor/prison{
@@ -71784,28 +71921,28 @@ hxy
 pax
 aWR
 hxy
+tFu
 hxy
-hxy
-fpM
-fpM
-uVo
 eZN
-sIT
-fpM
-sIT
-eZN
-sIT
-fpM
-fpM
-eZN
-sIT
-sIT
-sIT
-sIT
-sIT
 sIT
 uVo
+hTm
+eZN
 sIT
+fpM
+eZN
+eZN
+sIT
+fpM
+eZN
+eZN
+sIT
+fpM
+hTm
+eZN
+sIT
+njs
+hTm
 eZN
 hxy
 aWR
@@ -72019,7 +72156,7 @@ wSm
 wSm
 wSm
 wQN
-fZd
+eAM
 wSm
 wSm
 wSm
@@ -72231,7 +72368,7 @@ wSm
 xnU
 wSm
 kfE
-fZd
+eSF
 qnB
 fHB
 fHB
@@ -72443,7 +72580,7 @@ wSm
 wSm
 wSm
 wSm
-fZd
+xrH
 gAS
 wSm
 wSm
@@ -72867,7 +73004,7 @@ wSm
 wSm
 wSm
 kHG
-fZd
+eAM
 gAS
 wSm
 wSm
@@ -73079,7 +73216,7 @@ wSm
 wSm
 wSm
 wSm
-fZd
+eSF
 gAS
 wSm
 wSm
@@ -73291,7 +73428,7 @@ wSm
 wSm
 wSm
 wSm
-fZd
+xrH
 gAS
 wSm
 wSm
@@ -73715,7 +73852,7 @@ wSm
 wSm
 wSm
 wSm
-fZd
+eAM
 kAr
 wSm
 wSm
@@ -73927,7 +74064,7 @@ wSm
 xnU
 wSm
 wSm
-fZd
+eSF
 mmP
 fHB
 fHB
@@ -74139,7 +74276,7 @@ wSm
 wSm
 wSm
 wQN
-fZd
+xrH
 wSm
 wSm
 wSm
@@ -74330,26 +74467,26 @@ mxQ
 vMK
 hxy
 hxy
-hLK
+tZs
 hLK
 qeR
-yfC
+fHV
 tZs
 lLv
 qeR
-yfC
+fHV
 tZs
 hLK
-hLK
 yfC
+fHV
 tZs
 hLK
-qeR
 yfC
+fHV
 tZs
 hLK
-qeR
 yfC
+fHV
 tZs
 aWR
 aWR
@@ -87604,25 +87741,25 @@ iJf
 hKI
 hsA
 wFk
+nGk
+uhH
+uol
 wFk
+nGk
+uhH
+uol
 wFk
+nGk
+uhH
+uol
 wFk
+nGk
+uhH
+uol
 wFk
-wFk
-wFk
-wFk
-wFk
-wFk
-wFk
-wFk
-wFk
-wFk
-wFk
-wFk
-wFk
-wFk
-wFk
-wFk
+nGk
+uhH
+uol
 wFk
 hsA
 hlK
@@ -87814,7 +87951,7 @@ gws
 vzB
 iJf
 hKI
-hHh
+owG
 iOa
 xeO
 xeO
@@ -87836,7 +87973,7 @@ xeO
 xeO
 xeO
 iOa
-aVK
+nBR
 hlK
 hKI
 hKI
@@ -88026,7 +88163,7 @@ iSi
 ssD
 tPi
 viV
-hHh
+wJf
 xeO
 xeO
 cCx
@@ -88048,7 +88185,7 @@ xeO
 cCx
 xeO
 bju
-aVK
+sLo
 hlK
 hKI
 iWW
@@ -88238,7 +88375,7 @@ gws
 vzB
 iJf
 bYS
-hHh
+jCp
 xeO
 xeO
 xeO
@@ -88260,7 +88397,7 @@ xeO
 xeO
 xeO
 xeO
-aVK
+pAN
 hlK
 hjW
 iWW
@@ -88662,7 +88799,7 @@ gws
 vzB
 iJf
 bYS
-hHh
+owG
 xeO
 xeO
 xeO
@@ -88684,7 +88821,7 @@ xeO
 xeO
 xeO
 mUA
-aVK
+nBR
 hlK
 hjW
 iWW
@@ -88874,7 +89011,7 @@ gws
 vzB
 iJf
 bYS
-hHh
+wJf
 xeO
 xeO
 xeO
@@ -88896,7 +89033,7 @@ xeO
 xeO
 xeO
 xeO
-aVK
+sLo
 hlK
 hKI
 iWW
@@ -89086,7 +89223,7 @@ gws
 vzB
 iJf
 bYS
-hHh
+jCp
 xeO
 xeO
 xeO
@@ -89108,7 +89245,7 @@ xeO
 xeO
 xeO
 xeO
-aVK
+pAN
 hlK
 hjW
 iWW
@@ -89510,7 +89647,7 @@ gws
 vzB
 iJf
 bYS
-hHh
+owG
 xeO
 xeO
 xeO
@@ -89532,7 +89669,7 @@ xeO
 xeO
 xeO
 xeO
-lGh
+rPu
 hlK
 hjW
 iWW
@@ -89722,7 +89859,7 @@ iSi
 ssD
 tPi
 oSK
-hHh
+wJf
 doA
 xeO
 cCx
@@ -89934,7 +90071,7 @@ gws
 vzB
 iJf
 hKI
-hHh
+jCp
 iOa
 xeO
 xeO
@@ -89956,7 +90093,7 @@ xeO
 xeO
 xeO
 iOa
-aVK
+pAN
 hlK
 hKI
 hKI
@@ -90147,27 +90284,27 @@ vzB
 iJf
 hKI
 hsA
+tZV
+lYA
 wfp
+xjw
+tZV
+lYA
 wfp
+xjw
+tZV
+lYA
 wfp
+xjw
+tZV
+lYA
 wfp
+xjw
+tZV
+lYA
 wfp
-wfp
-wfp
-wfp
-wfp
-wfp
-wfp
-wfp
-wfp
-wfp
-wfp
-wfp
-wfp
-wfp
-wfp
-wfp
-wfp
+xjw
+tZV
 hsA
 hlK
 sEi

--- a/maps/map_files/Ice_Colony_v3/Shivas_Snowball.dmm
+++ b/maps/map_files/Ice_Colony_v3/Shivas_Snowball.dmm
@@ -30784,7 +30784,7 @@ lBC
 mQl
 bjP
 jBN
-mQl
+lBC
 mQl
 aWv
 mhP

--- a/maps/map_files/Ice_Colony_v3/Shivas_Snowball.dmm
+++ b/maps/map_files/Ice_Colony_v3/Shivas_Snowball.dmm
@@ -1579,6 +1579,15 @@
 	dir = 1
 	},
 /area/shiva/interior/colony/medseceng)
+"agF" = (
+/obj/structure/machinery/landinglight/ds2,
+/obj/structure/machinery/landinglight/ds2/delaythree{
+	dir = 4
+	},
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/exterior/lz2_fortress)
 "agJ" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/effect/spawner/random/technology_scanner,
@@ -4881,7 +4890,6 @@
 "aDS" = (
 /obj/structure/machinery/door/airlock/almayer/secure/colony{
 	id = "st_17";
-	locked = 0;
 	name = "Power Storage Unit"
 	},
 /turf/open/floor/plating,
@@ -4965,7 +4973,6 @@
 /obj/structure/machinery/door/airlock/almayer/secure/colony{
 	dir = 2;
 	id = "st_18";
-	locked = 0;
 	name = "Disposals Storage Unit"
 	},
 /turf/open/floor/plating,
@@ -5201,6 +5208,14 @@
 	},
 /turf/open/auto_turf/snow/layer2,
 /area/shiva/exterior/cp_lz2)
+"aHQ" = (
+/obj/structure/machinery/landinglight/ds2/delayone{
+	dir = 4
+	},
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/exterior/lz2_fortress)
 "aIh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/barbed_wire,
@@ -6606,6 +6621,15 @@
 	icon_state = "floor3"
 	},
 /area/shiva/interior/colony/research_hab)
+"aWv" = (
+/obj/structure/machinery/landinglight/ds2,
+/obj/structure/machinery/landinglight/ds2/delayone{
+	dir = 8
+	},
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/exterior/lz2_fortress)
 "aWB" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "NW-out"
@@ -7261,6 +7285,14 @@
 "bjv" = (
 /turf/open/auto_turf/ice/layer1,
 /area/shiva/exterior/cp_colony_grounds)
+"bjP" = (
+/obj/structure/machinery/landinglight/ds2/delayone{
+	dir = 8
+	},
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/exterior/lz2_fortress)
 "bks" = (
 /obj/structure/morgue{
 	dir = 8
@@ -7339,9 +7371,7 @@
 /turf/open/auto_turf/snow/layer2,
 /area/shiva/exterior/junkyard)
 "boD" = (
-/obj/docking_port/stationary/marine_dropship/lz1{
-	dwidth = 1
-	},
+/obj/docking_port/stationary/marine_dropship/lz1,
 /turf/open/floor/plating,
 /area/shiva/exterior/lz1_valley)
 "boS" = (
@@ -7981,7 +8011,6 @@
 "bXo" = (
 /obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	dir = 1;
-	req_access = null;
 	req_one_access = null
 	},
 /turf/open/floor/plating,
@@ -8456,6 +8485,12 @@
 	icon_state = "multi_tiles"
 	},
 /area/shiva/exterior/lz2_fortress)
+"cBF" = (
+/obj/structure/machinery/landinglight/ds2/delayone,
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/exterior/lz2_fortress)
 "cBG" = (
 /obj/structure/machinery/vending/coffee,
 /obj/structure/machinery/light/double{
@@ -8541,7 +8576,6 @@
 /obj/structure/machinery/door/airlock/multi_tile/almayer/medidoor/colony{
 	dir = 1;
 	name = "\improper Aurora Medical Clinic Treatment";
-	req_access = null;
 	req_one_access = null
 	},
 /turf/open/floor/plating,
@@ -8896,6 +8930,17 @@
 /obj/item/device/multitool,
 /turf/open/floor/shiva,
 /area/shiva/interior/colony/research_hab)
+"cYR" = (
+/obj/structure/machinery/landinglight/ds2/delayone{
+	dir = 8
+	},
+/obj/structure/machinery/landinglight/ds2/delaytwo{
+	dir = 1
+	},
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/exterior/lz2_fortress)
 "cYT" = (
 /obj/structure/prop/invuln/ice_prefab{
 	dir = 10
@@ -9954,7 +9999,6 @@
 "esf" = (
 /obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	dir = 1;
-	req_access = null;
 	req_one_access = null
 	},
 /turf/open/floor/plating,
@@ -10373,6 +10417,14 @@
 "eUT" = (
 /turf/closed/wall/shiva/prefabricated/white,
 /area/shiva/exterior/cp_lz2)
+"eVa" = (
+/obj/structure/machinery/landinglight/ds2{
+	dir = 8
+	},
+/turf/open/floor/shiva{
+	icon_state = "floor3"
+	},
+/area/shiva/exterior/lz2_fortress)
 "eVG" = (
 /obj/structure/largecrate/random,
 /turf/open/floor/shiva,
@@ -10596,9 +10648,7 @@
 	},
 /area/shiva/interior/colony/research_hab)
 "fiy" = (
-/obj/docking_port/stationary/marine_dropship/lz2{
-	dwidth = 1
-	},
+/obj/docking_port/stationary/marine_dropship/lz2,
 /turf/open/floor/plating,
 /area/shiva/exterior/lz2_fortress)
 "fiK" = (
@@ -10836,6 +10886,15 @@
 	},
 /turf/open/floor/plating,
 /area/shiva/interior/colony/botany)
+"fxw" = (
+/obj/structure/machinery/landinglight/ds2/spoke,
+/obj/structure/machinery/landinglight/ds2/delaytwo{
+	dir = 4
+	},
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/exterior/lz2_fortress)
 "fxy" = (
 /obj/item/lightstick/variant/planted,
 /turf/open/auto_turf/snow/layer1,
@@ -11130,6 +11189,17 @@
 	},
 /turf/open/auto_turf/snow/layer2,
 /area/shiva/exterior/junkyard)
+"fLz" = (
+/obj/structure/machinery/landinglight/ds2{
+	dir = 4
+	},
+/obj/structure/machinery/landinglight/ds2/delaythree{
+	dir = 4
+	},
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/exterior/lz2_fortress)
 "fLX" = (
 /obj/structure/prop/invuln/minecart_tracks{
 	dir = 8
@@ -11199,7 +11269,6 @@
 /obj/structure/machinery/door/airlock/almayer/engineering/colony{
 	dir = 8;
 	name = "\improper Colony Power Substation";
-	req_access = null;
 	req_one_access = null
 	},
 /turf/open/floor/plating,
@@ -11529,6 +11598,12 @@
 	},
 /turf/open/auto_turf/snow/layer0,
 /area/shiva/exterior/cp_colony_grounds)
+"gkK" = (
+/obj/structure/machinery/landinglight/ds2/delaythree,
+/turf/open/floor/shiva{
+	icon_state = "floor3"
+	},
+/area/shiva/exterior/lz2_fortress)
 "gkL" = (
 /obj/structure/machinery/medical_pod/sleeper,
 /turf/open/floor/shiva{
@@ -12481,6 +12556,15 @@
 	},
 /turf/open/gm/river/no_overlay,
 /area/shiva/interior/colony/central)
+"hpN" = (
+/obj/structure/machinery/landinglight/ds2/delayone{
+	dir = 4
+	},
+/obj/structure/machinery/landinglight/ds2/delaytwo,
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/exterior/lz2_fortress)
 "hqd" = (
 /obj/structure/prop/invuln/ice_prefab{
 	dir = 6;
@@ -13027,6 +13111,14 @@
 /obj/structure/cargo_container/horizontal/blue/top,
 /turf/open/auto_turf/snow/layer3,
 /area/shiva/exterior/junkyard)
+"hSq" = (
+/obj/structure/machinery/landinglight/ds2/delaythree{
+	dir = 4
+	},
+/turf/open/floor/shiva{
+	icon_state = "floor3"
+	},
+/area/shiva/exterior/lz2_fortress)
 "hSW" = (
 /obj/item/lightstick/red/spoke/planted{
 	layer = 2.99;
@@ -13181,6 +13273,17 @@
 	icon_state = "floor3"
 	},
 /area/shiva/interior/colony/botany)
+"hZu" = (
+/obj/structure/machinery/landinglight/ds2{
+	dir = 1
+	},
+/obj/structure/machinery/landinglight/ds2/delaythree{
+	dir = 8
+	},
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/exterior/lz2_fortress)
 "hZI" = (
 /obj/structure/largecrate/random/mini/small_case/b{
 	pixel_x = -9
@@ -14037,6 +14140,14 @@
 /obj/structure/girder,
 /turf/open/floor/plating,
 /area/shiva/interior/caves/research_caves)
+"iUk" = (
+/obj/structure/machinery/landinglight/ds2{
+	dir = 1
+	},
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/exterior/lz2_fortress)
 "iVj" = (
 /turf/open/floor/shiva{
 	dir = 4;
@@ -14615,6 +14726,14 @@
 	dir = 1
 	},
 /area/shiva/interior/colony/s_admin)
+"jBN" = (
+/obj/structure/machinery/landinglight/ds2{
+	dir = 8
+	},
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/exterior/lz2_fortress)
 "jCe" = (
 /obj/structure/machinery/light/double,
 /turf/open/floor/shiva{
@@ -14761,6 +14880,14 @@
 /obj/structure/fence,
 /turf/open/auto_turf/snow/layer0,
 /area/shiva/exterior/junkyard)
+"jLc" = (
+/obj/structure/machinery/landinglight/ds2/delaytwo{
+	dir = 1
+	},
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/exterior/lz2_fortress)
 "jLn" = (
 /obj/structure/closet/secure_closet/engineering_welding,
 /obj/effect/landmark/objective_landmark/far,
@@ -15069,6 +15196,15 @@
 	icon_state = "yellowfull"
 	},
 /area/shiva/interior/colony/medseceng)
+"kcB" = (
+/obj/structure/machinery/landinglight/ds2/spoke,
+/obj/structure/machinery/landinglight/ds2/delayone{
+	dir = 4
+	},
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/exterior/lz2_fortress)
 "kdd" = (
 /obj/effect/landmark/nightmare{
 	insert_tag = "lz2-east-gate"
@@ -15203,6 +15339,12 @@
 /obj/effect/landmark/objective_landmark/far,
 /turf/open/floor/wood,
 /area/shiva/interior/colony/botany)
+"kiv" = (
+/obj/structure/machinery/landinglight/ds2,
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/exterior/lz2_fortress)
 "kiB" = (
 /obj/structure/machinery/alarm{
 	pixel_y = 24
@@ -15714,6 +15856,14 @@
 	icon_state = "red"
 	},
 /area/shiva/interior/colony/medseceng)
+"kIH" = (
+/obj/structure/machinery/landinglight/ds2{
+	dir = 4
+	},
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/exterior/lz2_fortress)
 "kJi" = (
 /obj/structure/closet/crate/hydroponics,
 /obj/item/reagent_container/glass/watertank,
@@ -15749,6 +15899,14 @@
 /obj/item/lightstick/red/variant,
 /turf/open/auto_turf/snow/layer1,
 /area/shiva/exterior/lz1_valley)
+"kLa" = (
+/obj/structure/machinery/landinglight/ds2/delayone{
+	dir = 8
+	},
+/turf/open/floor/shiva{
+	icon_state = "floor3"
+	},
+/area/shiva/exterior/lz2_fortress)
 "kLi" = (
 /obj/structure/surface/rack,
 /obj/item/clothing/suit/storage/snow_suit/doctor{
@@ -16193,6 +16351,17 @@
 /obj/structure/fence,
 /turf/open/auto_turf/snow/layer4,
 /area/shiva/exterior/junkyard)
+"lgx" = (
+/obj/structure/machinery/landinglight/ds2{
+	dir = 1
+	},
+/obj/structure/machinery/landinglight/ds2/delayone{
+	dir = 4
+	},
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/exterior/lz2_fortress)
 "lgN" = (
 /turf/closed/wall/shiva/prefabricated/reinforced/hull,
 /area/shiva/exterior/junkyard/fortbiceps)
@@ -16437,6 +16606,20 @@
 /obj/structure/machinery/space_heater,
 /turf/open/auto_turf/snow/layer1,
 /area/shiva/exterior/junkyard/fortbiceps)
+"luR" = (
+/obj/structure/machinery/landinglight/ds2/delaytwo{
+	dir = 4
+	},
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/exterior/lz2_fortress)
+"lvj" = (
+/obj/structure/machinery/landinglight/ds2,
+/turf/open/floor/shiva{
+	icon_state = "floor3"
+	},
+/area/shiva/exterior/lz2_fortress)
 "lvq" = (
 /obj/structure/surface/table,
 /obj/effect/landmark/objective_landmark/far,
@@ -16524,6 +16707,14 @@
 /obj/item/lightstick/red/variant/planted,
 /turf/open/auto_turf/ice/layer1,
 /area/shiva/interior/caves/cp_camp)
+"lBC" = (
+/obj/structure/machinery/landinglight/ds2/delaythree{
+	dir = 8
+	},
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/exterior/lz2_fortress)
 "lCb" = (
 /obj/item/tool/pickaxe,
 /turf/open/auto_turf/ice/layer0,
@@ -17522,6 +17713,14 @@
 	},
 /turf/open/floor/wood,
 /area/shiva/interior/colony/botany)
+"mEp" = (
+/obj/structure/machinery/landinglight/ds2/delaythree{
+	dir = 1
+	},
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/exterior/lz2_fortress)
 "mEw" = (
 /obj/structure/cargo_container/wy/left,
 /turf/open/auto_turf/snow/layer3,
@@ -17768,6 +17967,14 @@
 /obj/effect/landmark/hunter_primary,
 /turf/open/auto_turf/ice/layer1,
 /area/shiva/exterior/valley)
+"mQl" = (
+/obj/structure/machinery/landinglight/ds2/delaytwo{
+	dir = 8
+	},
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/exterior/lz2_fortress)
 "mQs" = (
 /obj/structure/machinery/light/double{
 	dir = 1;
@@ -18167,6 +18374,15 @@
 	},
 /turf/open/gm/river/no_overlay,
 /area/shiva/interior/caves/cp_camp)
+"nlG" = (
+/obj/structure/machinery/landinglight/ds2/spoke,
+/obj/structure/machinery/landinglight/ds2/delaytwo{
+	dir = 8
+	},
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/exterior/lz2_fortress)
 "nmi" = (
 /obj/item/weapon/twohanded/spear,
 /turf/open/floor/shiva{
@@ -20147,6 +20363,15 @@
 	icon_state = "multi_tiles"
 	},
 /area/shiva/interior/bar)
+"pBl" = (
+/obj/structure/machinery/landinglight/ds2/spoke,
+/obj/structure/machinery/landinglight/ds2/delaythree{
+	dir = 8
+	},
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/exterior/lz2_fortress)
 "pBy" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /obj/effect/landmark/objective_landmark/far,
@@ -20295,6 +20520,12 @@
 	icon_state = "wred"
 	},
 /area/shiva/interior/colony/medseceng)
+"pGg" = (
+/obj/structure/machinery/landinglight/ds2/delaytwo,
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/exterior/lz2_fortress)
 "pGj" = (
 /obj/item/weapon/ice_axe/red,
 /turf/open/auto_turf/snow/layer0,
@@ -22409,6 +22640,12 @@
 	dir = 5
 	},
 /area/shiva/interior/aerodrome)
+"rXp" = (
+/obj/structure/machinery/landinglight/ds2/delayone,
+/turf/open/floor/shiva{
+	icon_state = "floor3"
+	},
+/area/shiva/exterior/lz2_fortress)
 "rXt" = (
 /obj/structure/cable/heavyduty{
 	icon_state = "0-8"
@@ -23324,6 +23561,14 @@
 /obj/item/clothing/shoes/snow,
 /turf/open/floor/interior/plastic/alt,
 /area/shiva/interior/warehouse)
+"sZx" = (
+/obj/structure/machinery/landinglight/ds2/delayone{
+	dir = 1
+	},
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/exterior/lz2_fortress)
 "tad" = (
 /obj/structure/platform/strata{
 	dir = 1
@@ -24670,6 +24915,17 @@
 	icon_state = "bluefull"
 	},
 /area/shiva/interior/colony/n_admin)
+"ujV" = (
+/obj/structure/machinery/landinglight/ds2/delaytwo{
+	dir = 1
+	},
+/obj/structure/machinery/landinglight/ds2/delaythree{
+	dir = 4
+	},
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/exterior/lz2_fortress)
 "ukp" = (
 /turf/open/auto_turf/ice/layer1,
 /area/shiva/exterior/cp_s_research)
@@ -26402,6 +26658,14 @@
 /obj/structure/blocker/forcefield/multitile_vehicles,
 /turf/open/floor/plating,
 /area/shiva/interior/colony/medseceng)
+"wfO" = (
+/obj/structure/machinery/landinglight/ds2{
+	dir = 4
+	},
+/turf/open/floor/shiva{
+	icon_state = "floor3"
+	},
+/area/shiva/exterior/lz2_fortress)
 "wfP" = (
 /obj/item/lightstick/red/spoke/planted{
 	pixel_x = -16;
@@ -26566,6 +26830,15 @@
 	icon_state = "multi_tiles"
 	},
 /area/shiva/interior/colony/botany)
+"wpl" = (
+/obj/structure/machinery/landinglight/ds2/delaytwo,
+/obj/structure/machinery/landinglight/ds2/delaythree{
+	dir = 8
+	},
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/exterior/lz2_fortress)
 "wpG" = (
 /obj/structure/machinery/door/airlock/almayer/security/glass/colony{
 	name = "\improper Colony Security Checkpoint"
@@ -27561,6 +27834,14 @@
 	icon_state = "purplefull"
 	},
 /area/shiva/interior/colony/research_hab)
+"xEd" = (
+/obj/structure/machinery/landinglight/ds2/delaythree{
+	dir = 4
+	},
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/exterior/lz2_fortress)
 "xEu" = (
 /obj/structure/morgue,
 /turf/open/floor/shiva{
@@ -28024,6 +28305,12 @@
 	dir = 1
 	},
 /area/shiva/interior/colony/medseceng)
+"ylP" = (
+/obj/structure/machinery/landinglight/ds2/delaythree,
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/exterior/lz2_fortress)
 "ylU" = (
 /obj/structure/prop/ice_colony/ground_wire{
 	dir = 4
@@ -30479,27 +30766,27 @@ mFm
 mFm
 mhP
 mhP
-sxD
-mFm
-mFm
-mFm
-mFm
-mFm
-mFm
-sxD
-iuK
-iuK
-sxD
-mFm
-mFm
-mFm
-mFm
-mFm
-mFm
-mFm
-mFm
-mFm
-sxD
+cYR
+jBN
+lBC
+mQl
+bjP
+jBN
+lBC
+nlG
+kLa
+eVa
+pBl
+mQl
+bjP
+jBN
+lBC
+mQl
+bjP
+jBN
+mQl
+mQl
+aWv
 mhP
 mhP
 mFm
@@ -30640,9 +30927,9 @@ caS
 mFm
 mFm
 mhP
+hZu
+mFm
 sxD
-mFm
-mFm
 mFm
 mFm
 mFm
@@ -30660,9 +30947,9 @@ mFm
 mFm
 mFm
 mFm
-mFm
-mFm
 sxD
+mFm
+wpl
 mhP
 mFm
 iuK
@@ -30802,8 +31089,8 @@ caS
 mFm
 mFm
 mhP
-mFm
-mFm
+sZx
+sxD
 mFm
 mFm
 mFm
@@ -30823,8 +31110,8 @@ gkY
 gkY
 mFm
 mFm
-mFm
-mFm
+sxD
+cBF
 mhP
 mFm
 iuK
@@ -30964,7 +31251,7 @@ mFm
 mFm
 mFm
 mhP
-mFm
+jLc
 mFm
 mFm
 aar
@@ -30986,7 +31273,7 @@ gkY
 mFm
 aar
 fiy
-mFm
+kiv
 mhP
 mFm
 iuK
@@ -31126,11 +31413,11 @@ mFm
 mFm
 mFm
 mhP
+mEp
 mFm
 mFm
 mFm
 mFm
-mFm
 gkY
 gkY
 gkY
@@ -31148,7 +31435,7 @@ gkY
 gkY
 mFm
 gkY
-mFm
+ylP
 mhP
 mFm
 axq
@@ -31288,7 +31575,7 @@ caS
 mFm
 mFm
 mhP
-mFm
+iUk
 gkY
 gkY
 gkY
@@ -31310,7 +31597,7 @@ gkY
 gkY
 gkY
 gkY
-mFm
+pGg
 mhP
 mFm
 iuK
@@ -31450,7 +31737,7 @@ caS
 mFm
 mFm
 mhP
-mFm
+sZx
 gkY
 gkY
 gkY
@@ -31472,7 +31759,7 @@ gkY
 gkY
 iuK
 iuK
-iuK
+rXp
 mhP
 mFm
 rSL
@@ -31612,7 +31899,7 @@ caS
 mFm
 mFm
 mhP
-mFm
+jLc
 gkY
 gkY
 gkY
@@ -31634,7 +31921,7 @@ gkY
 gkY
 iuK
 iuK
-iuK
+lvj
 mhP
 mFm
 iuK
@@ -31774,7 +32061,7 @@ caS
 mFm
 mFm
 mhP
-mFm
+mEp
 gkY
 gkY
 gkY
@@ -31796,7 +32083,7 @@ gkY
 gkY
 iuK
 iuK
-iuK
+gkK
 mhP
 mFm
 iuK
@@ -31936,7 +32223,7 @@ caS
 mFm
 mFm
 mhP
-mFm
+iUk
 gkY
 gkY
 gkY
@@ -31958,7 +32245,7 @@ gkY
 gkY
 gkY
 gkY
-mFm
+pGg
 mhP
 otV
 iuK
@@ -32098,11 +32385,11 @@ mFm
 mFm
 mFm
 mhP
+sZx
 mFm
 mFm
 mFm
 mFm
-mFm
 gkY
 gkY
 gkY
@@ -32120,7 +32407,7 @@ gkY
 gkY
 mFm
 gkY
-mFm
+cBF
 mhP
 apY
 iuK
@@ -32260,7 +32547,7 @@ mFm
 mFm
 mFm
 mhP
-mFm
+jLc
 mFm
 mFm
 aar
@@ -32282,7 +32569,7 @@ gkY
 mFm
 aar
 gkY
-mFm
+kiv
 mhP
 mFm
 iuK
@@ -32422,8 +32709,8 @@ caS
 mFm
 mFm
 mhP
-mFm
-mFm
+mEp
+sxD
 mFm
 mFm
 mFm
@@ -32443,8 +32730,8 @@ gkY
 gkY
 mFm
 mFm
-mFm
-mFm
+sxD
+ylP
 mhP
 mFm
 qyC
@@ -32584,9 +32871,9 @@ caS
 mFm
 mFm
 mhP
+lgx
+mFm
 sxD
-mFm
-mFm
 mFm
 mFm
 mFm
@@ -32604,9 +32891,9 @@ mFm
 mFm
 mFm
 mFm
-mFm
-mFm
 sxD
+mFm
+hpN
 mhP
 mFm
 wgX
@@ -32747,27 +33034,27 @@ mFm
 mFm
 mhP
 mhP
-sxD
-mFm
-mFm
-mFm
-mFm
-mFm
-mFm
-sxD
-iuK
-iuK
-sxD
-mFm
-mFm
-mFm
-mFm
-mFm
-mFm
-mFm
-mFm
-mFm
-sxD
+ujV
+kIH
+aHQ
+luR
+xEd
+kIH
+aHQ
+fxw
+hSq
+wfO
+kcB
+luR
+xEd
+fLz
+aHQ
+luR
+xEd
+kIH
+aHQ
+luR
+agF
 mhP
 mhP
 mFm

--- a/maps/map_files/Kutjevo/Kutjevo.dmm
+++ b/maps/map_files/Kutjevo/Kutjevo.dmm
@@ -292,9 +292,7 @@
 /turf/open/floor/kutjevo/colors/cyan,
 /area/kutjevo/interior/complex/med/cells)
 "asT" = (
-/obj/structure/machinery/landinglight/ds2/delaythree{
-	dir = 8
-	},
+/obj/structure/machinery/landinglight/ds1/delaythree,
 /turf/open/floor/kutjevo/multi_tiles,
 /area/kutjevo/exterior/lz_dunes)
 "atn" = (
@@ -567,6 +565,12 @@
 	},
 /turf/open/auto_turf/sand/layer0,
 /area/kutjevo/exterior/scrubland)
+"aKl" = (
+/obj/structure/machinery/landinglight/ds1{
+	dir = 1
+	},
+/turf/open/floor/kutjevo/multi_tiles,
+/area/kutjevo/exterior/lz_dunes)
 "aKH" = (
 /obj/structure/machinery/light,
 /turf/open/floor/kutjevo/multi_tiles,
@@ -1466,7 +1470,7 @@
 /turf/open/floor/plating/kutjevo,
 /area/kutjevo/interior/colony_north)
 "ccs" = (
-/obj/structure/machinery/landinglight/ds1/delaytwo{
+/obj/structure/machinery/landinglight/ds2/delaytwo{
 	dir = 4
 	},
 /turf/open/floor/kutjevo/multi_tiles,
@@ -2378,7 +2382,7 @@
 /turf/open/floor/almayer/research/containment/floor1,
 /area/kutjevo/exterior/Northwest_Colony)
 "dhL" = (
-/obj/structure/machinery/landinglight/ds1/delayone{
+/obj/structure/machinery/landinglight/ds2{
 	dir = 4
 	},
 /turf/open/floor/kutjevo/multi_tiles,
@@ -2459,6 +2463,12 @@
 	dir = 9
 	},
 /area/kutjevo/exterior/runoff_river)
+"dpt" = (
+/obj/structure/machinery/landinglight/ds2/delayone{
+	dir = 1
+	},
+/turf/open/floor/kutjevo/multi_tiles,
+/area/kutjevo/exterior/Northwest_Colony)
 "dpH" = (
 /obj/structure/largecrate/random/case/double,
 /turf/open/floor/kutjevo/tan,
@@ -2711,8 +2721,8 @@
 /turf/open/gm/river/desert/shallow,
 /area/kutjevo/exterior/Northwest_Colony)
 "dEI" = (
-/obj/structure/machinery/landinglight/ds2/delaythree,
 /obj/effect/decal/cleanable/blood/oil,
+/obj/structure/machinery/landinglight/ds1/delayone,
 /turf/open/floor/kutjevo/multi_tiles,
 /area/kutjevo/exterior/lz_dunes)
 "dFc" = (
@@ -3996,7 +4006,7 @@
 	},
 /area/kutjevo/interior/complex/med/auto_doc)
 "ffP" = (
-/obj/structure/machinery/landinglight/ds2/delaythree{
+/obj/structure/machinery/landinglight/ds1/delaythree{
 	dir = 4
 	},
 /turf/open/floor/kutjevo/multi_tiles,
@@ -7160,7 +7170,7 @@
 	},
 /area/kutjevo/interior/complex/botany/east)
 "jUK" = (
-/obj/structure/machinery/landinglight/ds1/delayone{
+/obj/structure/machinery/landinglight/ds2{
 	dir = 8
 	},
 /turf/open/floor/kutjevo/multi_tiles,
@@ -8498,6 +8508,12 @@
 /obj/structure/platform_decoration/kutjevo,
 /turf/open/floor/almayer/research/containment/floor1,
 /area/kutjevo/interior/complex/med/locks)
+"lNl" = (
+/obj/structure/machinery/landinglight/ds2/delaytwo{
+	dir = 1
+	},
+/turf/open/floor/kutjevo/multi_tiles,
+/area/kutjevo/exterior/Northwest_Colony)
 "lNt" = (
 /obj/structure/platform/kutjevo/smooth{
 	dir = 8
@@ -9252,6 +9268,10 @@
 	},
 /turf/open/floor/almayer/research/containment/floor1,
 /area/kutjevo/interior/complex/med/auto_doc)
+"mIT" = (
+/obj/structure/machinery/landinglight/ds2/delayone,
+/turf/open/floor/kutjevo/multi_tiles,
+/area/kutjevo/exterior/Northwest_Colony)
 "mJq" = (
 /obj/structure/machinery/computer/cameras/telescreen/entertainment{
 	icon_state = "ai_bsod";
@@ -11611,7 +11631,7 @@
 	},
 /area/kutjevo/interior/power/comms)
 "pPz" = (
-/obj/structure/machinery/landinglight/ds1/delaytwo{
+/obj/structure/machinery/landinglight/ds2/delayone{
 	dir = 8
 	},
 /turf/open/floor/kutjevo/multi_tiles,
@@ -12313,7 +12333,7 @@
 /turf/open/floor/kutjevo/colors/green,
 /area/kutjevo/interior/complex/botany)
 "qTI" = (
-/obj/structure/machinery/landinglight/ds1/delayone{
+/obj/structure/machinery/landinglight/ds2/delaythree{
 	dir = 1
 	},
 /turf/open/floor/kutjevo/multi_tiles,
@@ -12898,9 +12918,11 @@
 /turf/open/floor/kutjevo/colors/orange,
 /area/kutjevo/interior/power/comms)
 "rMV" = (
-/obj/structure/machinery/landinglight/ds1/delayone,
+/obj/structure/machinery/landinglight/ds1/delaythree{
+	dir = 8
+	},
 /turf/open/floor/kutjevo/multi_tiles,
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_dunes)
 "rMZ" = (
 /obj/structure/platform/kutjevo{
 	dir = 1
@@ -13110,7 +13132,7 @@
 	},
 /area/kutjevo/interior/colony_central)
 "saK" = (
-/obj/structure/machinery/landinglight/ds1,
+/obj/structure/machinery/landinglight/ds2/delaytwo,
 /turf/open/floor/kutjevo/multi_tiles,
 /area/kutjevo/exterior/Northwest_Colony)
 "sbb" = (
@@ -13246,7 +13268,9 @@
 	},
 /area/kutjevo/interior/colony_South/power2)
 "slB" = (
-/obj/structure/machinery/landinglight/ds2/delaythree,
+/obj/structure/machinery/landinglight/ds1/delaythree{
+	dir = 1
+	},
 /turf/open/floor/kutjevo/multi_tiles,
 /area/kutjevo/exterior/lz_dunes)
 "slF" = (
@@ -13632,8 +13656,8 @@
 /turf/open/floor/kutjevo/colors/cyan,
 /area/kutjevo/interior/complex/med/cells)
 "sLf" = (
-/obj/structure/machinery/landinglight/ds2/delaythree,
 /obj/effect/decal/cleanable/blood/oil,
+/obj/structure/machinery/landinglight/ds2/delayone,
 /turf/open/floor/kutjevo/multi_tiles,
 /area/kutjevo/exterior/Northwest_Colony)
 "sLx" = (
@@ -14324,7 +14348,7 @@
 /turf/open/floor/kutjevo/plate,
 /area/kutjevo/exterior/Northwest_Colony)
 "tHI" = (
-/obj/structure/machinery/landinglight/ds1{
+/obj/structure/machinery/landinglight/ds2/delaytwo{
 	dir = 8
 	},
 /turf/open/floor/kutjevo/multi_tiles,
@@ -14854,6 +14878,12 @@
 	icon_state = "8,8"
 	},
 /area/kutjevo/interior/colony_north)
+"usd" = (
+/obj/structure/machinery/landinglight/ds1/delaytwo{
+	dir = 1
+	},
+/turf/open/floor/kutjevo/multi_tiles,
+/area/kutjevo/exterior/lz_dunes)
 "ush" = (
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_nest,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_nest,
@@ -16349,7 +16379,7 @@
 	},
 /area/kutjevo/exterior/complex_border/med_park)
 "wrk" = (
-/obj/structure/machinery/landinglight/ds1{
+/obj/structure/machinery/landinglight/ds2/delayone{
 	dir = 4
 	},
 /turf/open/floor/kutjevo/multi_tiles,
@@ -16430,7 +16460,7 @@
 /turf/open/floor/plating/kutjevo,
 /area/kutjevo/exterior/runoff_bridge)
 "wvX" = (
-/obj/structure/machinery/landinglight/ds1/delaytwo,
+/obj/structure/machinery/landinglight/ds2,
 /turf/open/floor/kutjevo/multi_tiles,
 /area/kutjevo/exterior/Northwest_Colony)
 "wwc" = (
@@ -16755,6 +16785,12 @@
 "wXd" = (
 /turf/closed/wall/kutjevo/rock,
 /area/kutjevo/interior/colony_South)
+"wXf" = (
+/obj/structure/machinery/landinglight/ds2{
+	dir = 1
+	},
+/turf/open/floor/kutjevo/multi_tiles,
+/area/kutjevo/exterior/Northwest_Colony)
 "wXy" = (
 /obj/effect/landmark/static_comms/net_two,
 /turf/open/auto_turf/sand/layer2,
@@ -19569,6 +19605,13 @@ wGH
 cWV
 swZ
 ffP
+tld
+ptH
+sKo
+ffP
+tld
+ptH
+sKo
 ffP
 tld
 ptH
@@ -19578,18 +19621,11 @@ tld
 ptH
 sKo
 ffP
-ffP
+tld
 ptH
 sKo
 ffP
 tld
-sKo
-sKo
-ffP
-tld
-ptH
-ptH
-ptH
 swZ
 cWV
 wGH
@@ -19734,7 +19770,7 @@ wGH
 wGH
 wGH
 cWV
-uhO
+exI
 nbV
 nbV
 umo
@@ -19901,7 +19937,7 @@ prJ
 wGH
 wGH
 cWV
-rPq
+asT
 nbV
 nbV
 nbV
@@ -19924,7 +19960,7 @@ nbV
 nbV
 jZJ
 nbV
-qVc
+usd
 cWV
 aRu
 vei
@@ -20068,7 +20104,7 @@ vei
 wGH
 wGH
 cWV
-exI
+uhO
 nbV
 nbV
 nbV
@@ -20091,7 +20127,7 @@ lAI
 nbV
 lAI
 nbV
-qVc
+slB
 cWV
 aRu
 wGH
@@ -20258,7 +20294,7 @@ lAI
 lAI
 lAI
 nbV
-qVc
+aKl
 cWV
 aRu
 qnU
@@ -20402,7 +20438,7 @@ wGH
 wGH
 maE
 cWV
-uhO
+exI
 nbV
 lAI
 lAI
@@ -20569,7 +20605,7 @@ vei
 wGH
 wGH
 cWV
-rPq
+asT
 nbV
 lAI
 lAI
@@ -20592,7 +20628,7 @@ lAI
 nbV
 nbV
 nbV
-qVc
+usd
 cWV
 aRu
 qnU
@@ -20641,26 +20677,26 @@ oJE
 xBm
 tGE
 hnq
-hnq
-wrk
 dhL
-ccs
-hnq
-wrk
-dhL
-ccs
-hnq
-hnq
-dhL
-ccs
-hnq
 wrk
 ccs
+hnq
+dhL
+wrk
 ccs
 hnq
+dhL
 wrk
+ccs
+hnq
 dhL
+wrk
+ccs
+hnq
 dhL
+wrk
+ccs
+hnq
 dhL
 tGE
 xBm
@@ -20736,7 +20772,7 @@ wGH
 wGH
 wGH
 cWV
-exI
+uhO
 nbV
 lAI
 lAI
@@ -20759,7 +20795,7 @@ lAI
 nbV
 nbV
 nbV
-qVc
+slB
 cWV
 aRu
 wGH
@@ -20829,7 +20865,7 @@ hzN
 wqk
 hzN
 hzN
-qTI
+dpt
 xBm
 huR
 huR
@@ -20903,7 +20939,7 @@ prJ
 wGH
 maE
 cWV
-slB
+rPq
 nbV
 lAI
 lAI
@@ -20926,7 +20962,7 @@ lAI
 lAI
 lAI
 nbV
-qVc
+aKl
 cWV
 aRu
 gZj
@@ -20973,7 +21009,7 @@ sVF
 hrz
 sVF
 xBm
-rMV
+sUt
 hzN
 hzN
 hzN
@@ -20996,7 +21032,7 @@ hzN
 hzN
 kvd
 hzN
-qTI
+lNl
 xBm
 huR
 huR
@@ -21070,7 +21106,7 @@ prJ
 wGH
 maE
 cWV
-uhO
+exI
 nbV
 nbV
 nbV
@@ -21237,7 +21273,7 @@ dxF
 vei
 maE
 cWV
-rPq
+asT
 nbV
 nbV
 nbV
@@ -21260,7 +21296,7 @@ nbV
 nbV
 lAI
 cBF
-qVc
+usd
 cWV
 aRu
 wGH
@@ -21330,7 +21366,7 @@ ppX
 ppX
 ppX
 hzN
-qTI
+wXf
 xBm
 huR
 huR
@@ -21404,7 +21440,7 @@ dxF
 dxF
 wGH
 cWV
-exI
+uhO
 bbc
 nbV
 umo
@@ -21427,7 +21463,7 @@ nbV
 umo
 nbV
 nbV
-qVc
+slB
 cWV
 wGH
 wGH
@@ -21497,7 +21533,7 @@ ppX
 hzN
 eBI
 hzN
-qTI
+dpt
 xBm
 huR
 huR
@@ -21573,27 +21609,27 @@ wGH
 cWV
 swZ
 yaE
-yaE
 qzr
-asT
-dIo
-yaE
-qzr
-asT
-dIo
-yaE
-yaE
-asT
+rMV
 dIo
 yaE
 qzr
-asT
+rMV
 dIo
 yaE
 qzr
-asT
+rMV
 dIo
+yaE
+qzr
+rMV
 dIo
+yaE
+qzr
+rMV
+dIo
+yaE
+qzr
 swZ
 cWV
 wGH
@@ -21641,7 +21677,7 @@ sVF
 hrz
 oJE
 xBm
-rMV
+sUt
 hzN
 ppX
 ppX
@@ -21664,7 +21700,7 @@ ppX
 hzN
 hzN
 hzN
-qTI
+lNl
 xBm
 huR
 huR
@@ -21975,7 +22011,7 @@ hrz
 hrz
 oJE
 xBm
-sUt
+mIT
 hzN
 ppX
 ppX
@@ -21998,7 +22034,7 @@ ppX
 ppX
 ppX
 hzN
-qTI
+wXf
 xBm
 huR
 huR
@@ -22165,7 +22201,7 @@ ppX
 hzN
 ppX
 eBI
-qTI
+dpt
 xBm
 huR
 huR
@@ -22309,7 +22345,7 @@ hrz
 hrz
 iin
 xBm
-rMV
+sUt
 hzN
 hzN
 hzN
@@ -22332,7 +22368,7 @@ hzN
 hzN
 ppX
 eBI
-qTI
+lNl
 xBm
 huR
 huR
@@ -22644,28 +22680,28 @@ sVF
 oJE
 xBm
 tGE
+pPz
 jUK
-jUK
+xDR
 tHI
-xDR
 pPz
 jUK
+xDR
 tHI
-xDR
 pPz
 jUK
-jUK
 xDR
-pPz
-jUK
 tHI
-xDR
 pPz
 jUK
-tHI
 xDR
+tHI
 pPz
+jUK
+xDR
+tHI
 pPz
+jUK
 tGE
 xBm
 huR

--- a/maps/map_files/LV522_Chances_Claim/LV522_Chances_Claim.dmm
+++ b/maps/map_files/LV522_Chances_Claim/LV522_Chances_Claim.dmm
@@ -54,8 +54,7 @@
 	pixel_x = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/atmos/cargo_intake)
 "abX" = (
@@ -149,8 +148,7 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/mining)
 "afn" = (
@@ -233,8 +231,7 @@
 "agM" = (
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/bridge)
 "ahH" = (
@@ -270,8 +267,7 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "aij" = (
@@ -356,8 +352,7 @@
 /area/lv522/oob)
 "alJ" = (
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/oob)
 "amc" = (
@@ -400,8 +395,7 @@
 	layer = 3.1;
 	name = "synthethic potted plant";
 	pixel_x = -7;
-	pixel_y = 9;
-	tag = null
+	pixel_y = 9
 	},
 /turf/open/floor/plating,
 /area/lv522/indoors/c_block/cargo)
@@ -454,8 +448,7 @@
 "anH" = (
 /obj/structure/largecrate/random,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_west_street)
 "anM" = (
@@ -481,8 +474,7 @@
 /obj/structure/machinery/light,
 /obj/structure/machinery/disposal,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "apc" = (
@@ -503,8 +495,7 @@
 "api" = (
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "cell_stripe";
-	tag = null
+	icon_state = "cell_stripe"
 	},
 /area/lv522/outdoors/n_rockies)
 "apt" = (
@@ -547,8 +538,7 @@
 	pixel_y = 6
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/oob)
 "arq" = (
@@ -613,7 +603,6 @@
 /area/lv522/indoors/a_block/security)
 "att" = (
 /obj/structure/prop/invuln/lifeboat_hatch_placeholder/terminal{
-	icon_state = "closed";
 	layer = 2.1
 	},
 /obj/structure/barricade/handrail{
@@ -633,8 +622,7 @@
 /obj/item/tool/pickaxe/silver,
 /obj/item/tool/pickaxe/silver,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/lone_buildings/storage_blocks)
 "atV" = (
@@ -643,8 +631,7 @@
 	icon_state = "S"
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/n_rockies)
 "aut" = (
@@ -670,8 +657,7 @@
 /obj/item/stack/sheet/metal,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "awj" = (
@@ -696,8 +682,7 @@
 	pixel_y = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/south_west_street)
 "axC" = (
@@ -707,8 +692,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/hallway)
 "axD" = (
@@ -765,16 +749,14 @@
 /area/lv522/indoors/c_block/mining)
 "aAN" = (
 /obj/structure/cargo_container/wy/mid{
-	health = 5000;
-	unacidable = 0
+	health = 5000
 	},
 /turf/open/auto_turf/shale/layer0,
 /area/lv522/outdoors/colony_streets/north_east_street)
 "aAW" = (
 /obj/effect/spawner/gibspawner/xeno,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "aBm" = (
@@ -815,8 +797,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/mining)
 "aDf" = (
@@ -904,8 +885,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/c_block/cargo)
 "aFf" = (
@@ -924,8 +904,7 @@
 	icon_state = "S"
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/n_rockies)
 "aFN" = (
@@ -958,8 +937,7 @@
 	pixel_y = 7
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/c_block/mining)
 "aGE" = (
@@ -1010,8 +988,7 @@
 /obj/structure/machinery/cm_vending/sorted/tech/comtech_tools,
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/lone_buildings/outdoor_bot)
 "aIf" = (
@@ -1035,13 +1012,11 @@
 /area/lv522/indoors/c_block/mining)
 "aII" = (
 /obj/structure/bed/chair/comfy{
-	dir = 1;
-	tag = null
+	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "aIY" = (
@@ -1069,8 +1044,7 @@
 /obj/structure/surface/table/almayer,
 /obj/effect/landmark/objective_landmark/far,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/windbreaker/observation)
 "aJT" = (
@@ -1097,8 +1071,7 @@
 	stat = 2
 	},
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/landing_zone_2)
 "aKK" = (
@@ -1113,8 +1086,7 @@
 /area/lv522/atmos/north_command_centre)
 "aKO" = (
 /obj/structure/bed/chair/comfy{
-	dir = 1;
-	tag = null
+	dir = 1
 	},
 /turf/open/floor/prison{
 	dir = 1;
@@ -1151,8 +1123,7 @@
 	layer = 3.1
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "aNr" = (
@@ -1260,8 +1231,7 @@
 /obj/structure/machinery/telecomms/bus/preset_one,
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/lone_buildings/outdoor_bot)
 "aQH" = (
@@ -1292,8 +1262,7 @@
 /area/lv522/indoors/a_block/medical)
 "aRi" = (
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/mining)
 "aRH" = (
@@ -1389,8 +1358,7 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "aUb" = (
@@ -1421,8 +1389,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/casino)
 "aVa" = (
@@ -1528,8 +1495,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkpurple2";
-	tag = null
+	icon_state = "darkpurple2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "aWJ" = (
@@ -1583,8 +1549,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/cargo)
 "aZj" = (
@@ -1663,8 +1628,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/c_block/cargo)
 "bbL" = (
@@ -1725,8 +1689,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/indoors/c_block/t_comm)
 "bdj" = (
@@ -1736,8 +1699,7 @@
 	icon_state = "S"
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_west_street)
 "bdv" = (
@@ -1787,8 +1749,7 @@
 "bel" = (
 /obj/structure/machinery/computer/crew/colony,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/windbreaker/observation)
 "ben" = (
@@ -1866,8 +1827,7 @@
 /obj/item/newspaper,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/garage)
 "bgS" = (
@@ -1926,8 +1886,7 @@
 	},
 /obj/structure/machinery/disposal,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/garage)
 "bhL" = (
@@ -1959,8 +1918,7 @@
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor/prison{
 	dir = 8;
-	icon_state = "darkpurple2";
-	tag = null
+	icon_state = "darkpurple2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "bjF" = (
@@ -1995,8 +1953,7 @@
 /obj/effect/decal/cleanable/blood/oil,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/garage)
 "bkf" = (
@@ -2064,13 +2021,11 @@
 /obj/structure/machinery/light/double,
 /obj/structure/window/reinforced{
 	dir = 1;
-	layer = 3;
-	tag = null
+	layer = 3
 	},
 /obj/structure/machinery/computer3/server/rack,
 /turf/open/floor{
-	icon_state = "bcircuit";
-	tag = null
+	icon_state = "bcircuit"
 	},
 /area/lv522/indoors/c_block/mining)
 "bmg" = (
@@ -2090,15 +2045,13 @@
 	icon_state = "W"
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/landing_zone_2/ceiling)
 "bnf" = (
 /obj/structure/pipes/vents/pump,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/garage)
 "bnz" = (
@@ -2114,8 +2067,7 @@
 /mob/living/simple_animal/mouse,
 /turf/open/floor/prison{
 	dir = 1;
-	icon_state = "darkpurple2";
-	tag = null
+	icon_state = "darkpurple2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "bnP" = (
@@ -2202,8 +2154,7 @@
 /obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/windbreaker/observation)
 "buD" = (
@@ -2242,8 +2193,7 @@
 	pixel_x = 9
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "bwd" = (
@@ -2268,8 +2218,7 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "bwH" = (
@@ -2285,8 +2234,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/c_block/t_comm)
 "bwU" = (
@@ -2302,8 +2250,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
 	dir = 1;
-	icon_state = "darkpurple2";
-	tag = null
+	icon_state = "darkpurple2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "bxr" = (
@@ -2339,8 +2286,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 1;
-	icon_state = "darkpurple2";
-	tag = null
+	icon_state = "darkpurple2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "byJ" = (
@@ -2350,8 +2296,7 @@
 /obj/item/circuitboard/machine/ghettosmes,
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/lone_buildings/outdoor_bot)
 "byR" = (
@@ -2361,8 +2306,7 @@
 /obj/item/ore/silver,
 /obj/item/ore/silver,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/lone_buildings/storage_blocks)
 "bzC" = (
@@ -2385,8 +2329,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/lone_buildings/engineering)
 "bAc" = (
@@ -2418,8 +2361,7 @@
 	dir = 10
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/oob)
 "bBe" = (
@@ -2495,8 +2437,7 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/b_block/bar)
 "bDn" = (
@@ -2530,8 +2471,7 @@
 /obj/structure/barricade/wooden,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/cargo)
 "bDR" = (
@@ -2579,8 +2519,7 @@
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/mouse,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "bGN" = (
@@ -2594,8 +2533,7 @@
 /obj/effect/landmark/objective_landmark/close,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/cargo)
 "bGT" = (
@@ -2638,8 +2576,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/c_block/t_comm)
 "bIe" = (
@@ -2654,8 +2591,7 @@
 	},
 /obj/item/tool/pen/red/clicky,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/c_block/mining)
 "bIr" = (
@@ -2730,8 +2666,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/c_block/t_comm)
 "bJZ" = (
@@ -2789,8 +2724,7 @@
 /obj/structure/machinery/light,
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/c_block/t_comm)
 "bLV" = (
@@ -2803,8 +2737,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/casino)
 "bMa" = (
@@ -2858,8 +2791,7 @@
 "bNA" = (
 /obj/structure/machinery/light,
 /turf/open/floor/prison{
-	icon_state = "darkpurple2";
-	tag = null
+	icon_state = "darkpurple2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "bNE" = (
@@ -2899,8 +2831,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/pipes/vents/pump,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/b_block/bar)
 "bPH" = (
@@ -2940,8 +2871,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "whitegreenfull";
-	tag = null
+	icon_state = "whitegreenfull"
 	},
 /area/lv522/indoors/a_block/fitness)
 "bQl" = (
@@ -2986,8 +2916,7 @@
 /area/lv522/atmos/north_command_centre)
 "bRP" = (
 /obj/structure/bed/chair/comfy{
-	dir = 1;
-	tag = null
+	dir = 1
 	},
 /turf/open/floor/prison,
 /area/lv522/indoors/a_block/security)
@@ -3079,8 +3008,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/mining)
 "bUJ" = (
@@ -3132,8 +3060,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/garage)
 "bVF" = (
@@ -3175,8 +3102,7 @@
 	pixel_y = 11
 	},
 /obj/structure/sink/puddle{
-	layer = 2.1;
-	name = "puddle"
+	layer = 2.1
 	},
 /turf/open/organic/grass,
 /area/lv522/indoors/a_block/garden)
@@ -3185,8 +3111,7 @@
 	dir = 9
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/hallway)
 "bXl" = (
@@ -3209,8 +3134,7 @@
 	pixel_y = 9
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "bXq" = (
@@ -3262,8 +3186,7 @@
 /obj/structure/cargo_container/wy/right,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/landing_zone_2)
 "bYy" = (
@@ -3310,8 +3233,7 @@
 	icon_state = "W"
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_west_street)
 "bZK" = (
@@ -3640,8 +3562,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/lone_buildings/engineering)
 "cjv" = (
@@ -3708,8 +3629,7 @@
 /area/lv522/outdoors/colony_streets/north_west_street)
 "cmc" = (
 /obj/structure/bed/chair/comfy{
-	dir = 1;
-	tag = null
+	dir = 1
 	},
 /turf/open/floor/strata{
 	icon_state = "multi_tiles"
@@ -3739,8 +3659,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/casino)
 "cnN" = (
@@ -3756,8 +3675,7 @@
 	pixel_x = -2
 	},
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/mining)
 "con" = (
@@ -3769,8 +3687,7 @@
 /obj/structure/ore_box,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/mining)
 "cpk" = (
@@ -3865,8 +3782,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "cqr" = (
@@ -3888,8 +3804,7 @@
 /area/lv522/outdoors/colony_streets/central_streets)
 "cqH" = (
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/c_block/cargo)
 "cqL" = (
@@ -3988,8 +3903,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/dorms)
 "ctE" = (
@@ -4000,8 +3914,7 @@
 /obj/structure/cargo_container/horizontal/blue/top,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/outdoors/colony_streets/north_east_street)
 "cuF" = (
@@ -4014,8 +3927,7 @@
 /obj/structure/machinery/cm_vending/sorted/tech/electronics_storage,
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/lone_buildings/outdoor_bot)
 "cve" = (
@@ -4040,8 +3952,7 @@
 /obj/structure/machinery/portable_atmospherics/canister/empty/oxygen,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/mining)
 "cwq" = (
@@ -4059,8 +3970,7 @@
 	icon_state = "W"
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/landing_zone_2/ceiling)
 "cwO" = (
@@ -4089,8 +3999,7 @@
 	pixel_x = -3
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "cxE" = (
@@ -4121,8 +4030,7 @@
 /obj/structure/cargo_container/wy/left,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/atmos/cargo_intake)
 "cys" = (
@@ -4159,8 +4067,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/garage)
 "cyV" = (
@@ -4186,8 +4093,7 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/mining)
 "czC" = (
@@ -4261,8 +4167,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/casino)
 "cAy" = (
@@ -4275,8 +4180,7 @@
 /obj/structure/cargo_container/kelland/right,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/indoors/lone_buildings/storage_blocks)
 "cBi" = (
@@ -4302,8 +4206,7 @@
 /obj/item/clothing/head/helmet/riot,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/kitchen)
 "cCC" = (
@@ -4424,8 +4327,7 @@
 /obj/structure/cargo_container/wy/mid,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/atmos/cargo_intake)
 "cFP" = (
@@ -4452,8 +4354,7 @@
 /obj/structure/prop/server_equipment/laptop/on,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/windbreaker/observation)
 "cGw" = (
@@ -4528,8 +4429,7 @@
 	},
 /turf/open/floor/plating{
 	dir = 8;
-	icon_state = "platingdmg3";
-	tag = null
+	icon_state = "platingdmg3"
 	},
 /area/lv522/indoors/a_block/dorms)
 "cHL" = (
@@ -4637,8 +4537,7 @@
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/pipes/vents/pump,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/b_block/bar)
 "cIV" = (
@@ -4716,8 +4615,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/casino)
 "cKi" = (
@@ -4809,8 +4707,7 @@
 /area/lv522/indoors/b_block/bar)
 "cLx" = (
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms/glass)
 "cLB" = (
@@ -4841,8 +4738,7 @@
 /obj/effect/landmark/objective_landmark/science,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/atmos/cargo_intake)
 "cMt" = (
@@ -4901,8 +4797,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/indoors/lone_buildings/storage_blocks)
 "cOZ" = (
@@ -4947,8 +4842,7 @@
 /area/lv522/oob)
 "cPO" = (
 /obj/structure/bed/chair/comfy{
-	dir = 1;
-	tag = null
+	dir = 1
 	},
 /turf/open/floor/corsat{
 	dir = 1;
@@ -4957,8 +4851,7 @@
 /area/lv522/oob)
 "cPU" = (
 /obj/structure/bed/chair/comfy{
-	dir = 1;
-	tag = null
+	dir = 1
 	},
 /turf/open/floor/corsat{
 	dir = 4;
@@ -4973,8 +4866,7 @@
 	pixel_y = 9
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "cQc" = (
@@ -5020,8 +4912,7 @@
 /obj/structure/surface/rack,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/atmos/cargo_intake)
 "cQW" = (
@@ -5035,8 +4926,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/cargo)
 "cRB" = (
@@ -5072,7 +4962,6 @@
 /area/lv522/atmos/north_command_centre)
 "cRT" = (
 /obj/structure/prop/vehicles/crawler{
-	density = 1;
 	dir = 8;
 	layer = 3.1
 	},
@@ -5100,8 +4989,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/casino)
 "cTf" = (
@@ -5181,8 +5069,7 @@
 	pixel_y = 11
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/c_block/t_comm)
 "cVc" = (
@@ -5249,8 +5136,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/b_block/bar)
 "cWr" = (
@@ -5314,8 +5200,7 @@
 /area/lv522/atmos/filt)
 "cXf" = (
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/casino)
 "cXm" = (
@@ -5363,8 +5248,7 @@
 /obj/structure/cargo_container/wy/right,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/atmos/cargo_intake)
 "cYG" = (
@@ -5395,8 +5279,7 @@
 /obj/structure/pipes/vents/pump,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/cargo)
 "cZu" = (
@@ -5420,8 +5303,7 @@
 /obj/structure/cargo_container/horizontal/blue/top,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/atmos/cargo_intake)
 "cZN" = (
@@ -5490,16 +5372,14 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/casino)
 "daG" = (
 /obj/structure/largecrate/random,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/outdoors/colony_streets/north_west_street)
 "daL" = (
@@ -5520,8 +5400,7 @@
 	icon_state = "S"
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/central_streets)
 "dbi" = (
@@ -5663,8 +5542,7 @@
 /obj/effect/landmark/objective_landmark/close,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/atmos/cargo_intake)
 "ddq" = (
@@ -5672,8 +5550,7 @@
 /obj/item/device/analyzer,
 /obj/effect/landmark/objective_landmark/close,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/mining)
 "ddr" = (
@@ -5683,15 +5560,13 @@
 	pixel_y = 9
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "ddy" = (
 /turf/open/floor/prison{
 	dir = 1;
-	icon_state = "cell_stripe";
-	tag = null
+	icon_state = "cell_stripe"
 	},
 /area/lv522/atmos/cargo_intake)
 "ddC" = (
@@ -5848,8 +5723,7 @@
 	},
 /obj/structure/machinery/disposal,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "dgq" = (
@@ -5869,8 +5743,7 @@
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor/prison{
 	dir = 1;
-	icon_state = "cell_stripe";
-	tag = null
+	icon_state = "cell_stripe"
 	},
 /area/lv522/atmos/cargo_intake)
 "dgO" = (
@@ -5943,8 +5816,7 @@
 	dir = 4
 	},
 /turf/open/shuttle/dropship{
-	icon_state = "rasputin15";
-	tag = null
+	icon_state = "rasputin15"
 	},
 /area/lv522/landing_zone_forecon/UD6_Tornado)
 "dip" = (
@@ -5961,8 +5833,7 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/mining)
 "diT" = (
@@ -6101,8 +5972,7 @@
 	},
 /obj/structure/largecrate/random,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_west_street)
 "dlM" = (
@@ -6132,8 +6002,7 @@
 /obj/structure/surface/table/almayer,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms/glass)
 "dmx" = (
@@ -6202,8 +6071,7 @@
 	pixel_y = 26
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "dnA" = (
@@ -6327,8 +6195,7 @@
 	dir = 8
 	},
 /turf/open/shuttle/dropship{
-	icon_state = "rasputin15";
-	tag = null
+	icon_state = "rasputin15"
 	},
 /area/lv522/landing_zone_forecon/UD6_Tornado)
 "dqr" = (
@@ -6361,8 +6228,7 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms/glass)
 "drS" = (
@@ -6389,8 +6255,7 @@
 	icon_state = "W"
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/landing_zone_2/ceiling)
 "dsl" = (
@@ -6409,8 +6274,7 @@
 /obj/item/stack/sheet/mineral/platinum,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/atmos/cargo_intake)
 "dsu" = (
@@ -6437,8 +6301,7 @@
 /area/lv522/indoors/a_block/admin)
 "dsQ" = (
 /obj/structure/bed/chair/comfy{
-	dir = 1;
-	tag = null
+	dir = 1
 	},
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/lv522/indoors/a_block/hallway)
@@ -6453,8 +6316,7 @@
 	pixel_y = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_west_street)
 "dtb" = (
@@ -6494,8 +6356,7 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/casino)
 "dua" = (
@@ -6572,8 +6433,7 @@
 /obj/structure/surface/table/reinforced/prison,
 /obj/effect/landmark/objective_landmark/close,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/garage)
 "dxl" = (
@@ -6590,12 +6450,10 @@
 	pixel_y = 16
 	},
 /obj/structure/bed/chair/comfy{
-	dir = 1;
-	tag = null
+	dir = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/mining)
 "dya" = (
@@ -6641,8 +6499,7 @@
 /obj/item/paper,
 /obj/item/tool/pen/blue/clicky,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/casino)
 "dzv" = (
@@ -6686,8 +6543,7 @@
 	pixel_y = 10
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "dBb" = (
@@ -6709,8 +6565,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/casino)
 "dBd" = (
@@ -6727,8 +6582,7 @@
 /obj/structure/pipes/vents/pump,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/garage)
 "dBo" = (
@@ -6766,8 +6620,7 @@
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "whitegreenfull";
-	tag = null
+	icon_state = "whitegreenfull"
 	},
 /area/lv522/indoors/a_block/fitness/glass)
 "dCY" = (
@@ -6797,8 +6650,7 @@
 	pixel_x = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/landing_zone_2/ceiling)
 "dDC" = (
@@ -6878,8 +6730,7 @@
 /obj/item/prop/colony/used_flare,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/atmos/cargo_intake)
 "dEP" = (
@@ -6973,8 +6824,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "cell_stripe";
-	tag = null
+	icon_state = "cell_stripe"
 	},
 /area/lv522/indoors/lone_buildings/storage_blocks)
 "dGV" = (
@@ -7014,8 +6864,7 @@
 /area/lv522/outdoors/colony_streets/north_street)
 "dHy" = (
 /obj/structure/bed/chair/comfy{
-	dir = 1;
-	tag = null
+	dir = 1
 	},
 /obj/item/clothing/suit/storage/snow_suit/survivor/parka/red,
 /turf/open/floor/carpet,
@@ -7070,8 +6919,7 @@
 	pixel_x = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/south_west_street)
 "dIG" = (
@@ -7085,8 +6933,7 @@
 	pixel_y = 3
 	},
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/garage)
 "dIK" = (
@@ -7113,18 +6960,15 @@
 /area/lv522/atmos/east_reactor)
 "dJn" = (
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/nw_rockies)
 "dJp" = (
 /obj/structure/bed/chair/comfy{
-	dir = 1;
-	tag = null
+	dir = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "dJs" = (
@@ -7168,8 +7012,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "whitegreenfull";
-	tag = null
+	icon_state = "whitegreenfull"
 	},
 /area/lv522/indoors/a_block/fitness/glass)
 "dKF" = (
@@ -7275,8 +7118,7 @@
 "dMy" = (
 /obj/structure/cargo_container/kelland/left,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_west_street)
 "dMN" = (
@@ -7330,8 +7172,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/security/glass)
 "dOa" = (
@@ -7348,8 +7189,7 @@
 	dir = 9
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/b_block/hydro)
 "dOI" = (
@@ -7361,8 +7201,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/shuttle/drop2/lv522)
 "dOK" = (
@@ -7413,8 +7252,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/lone_buildings/outdoor_bot)
 "dPP" = (
@@ -7440,8 +7278,7 @@
 /area/lv522/atmos/east_reactor/west)
 "dQh" = (
 /obj/structure/machinery/light{
-	dir = 1;
-	tag = null
+	dir = 1
 	},
 /obj/structure/machinery/disposal,
 /turf/open/floor/strata{
@@ -7488,8 +7325,7 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/b_block/bar)
 "dQQ" = (
@@ -7687,13 +7523,11 @@
 "dWG" = (
 /obj/structure/window/reinforced{
 	dir = 1;
-	layer = 3;
-	tag = null
+	layer = 3
 	},
 /obj/structure/machinery/computer3/server/rack,
 /turf/open/floor{
-	icon_state = "bcircuit";
-	tag = null
+	icon_state = "bcircuit"
 	},
 /area/lv522/indoors/c_block/mining)
 "dWT" = (
@@ -7789,8 +7623,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/mining)
 "dZs" = (
@@ -7830,8 +7663,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/atmos/cargo_intake)
 "dZP" = (
@@ -7859,22 +7691,19 @@
 	icon_state = "pottedplant_21";
 	layer = 3.1;
 	name = "synthethic potted plant";
-	pixel_y = 14;
-	tag = null
+	pixel_y = 14
 	},
 /obj/item/prop/alien/hugger,
 /obj/effect/landmark/objective_landmark/medium,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "eai" = (
 /obj/structure/largecrate/random/case/double,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/atmos/outdoor)
 "eam" = (
@@ -7895,8 +7724,7 @@
 "eaG" = (
 /obj/structure/ore_box,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/lone_buildings/storage_blocks)
 "ebn" = (
@@ -7929,8 +7757,7 @@
 	pixel_x = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/atmos/cargo_intake)
 "ebP" = (
@@ -7947,8 +7774,7 @@
 /obj/structure/closet/secure_closet/engineering_welding,
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/lone_buildings/engineering)
 "ecm" = (
@@ -7968,8 +7794,7 @@
 	icon_state = "S"
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_east_street)
 "ecP" = (
@@ -8191,8 +8016,7 @@
 /obj/structure/surface/table/almayer,
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/lone_buildings/outdoor_bot)
 "egD" = (
@@ -8212,8 +8036,7 @@
 	pixel_y = 29
 	},
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/mining)
 "egP" = (
@@ -8315,8 +8138,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 1;
-	icon_state = "darkpurple2";
-	tag = null
+	icon_state = "darkpurple2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "ejN" = (
@@ -8350,8 +8172,7 @@
 /area/lv522/oob)
 "ekO" = (
 /obj/structure/bed/chair/wood/normal{
-	dir = 8;
-	tag = null
+	dir = 8
 	},
 /turf/open/floor/prison,
 /area/lv522/indoors/c_block/casino)
@@ -8366,8 +8187,7 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/garage)
 "elq" = (
@@ -8399,8 +8219,7 @@
 /obj/structure/surface/table/almayer,
 /obj/item/clothing/suit/storage/CMB,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/windbreaker/observation)
 "emb" = (
@@ -8431,8 +8250,7 @@
 /obj/structure/cargo_container/grant/rightmid,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/indoors/lone_buildings/storage_blocks)
 "emz" = (
@@ -8485,8 +8303,7 @@
 "enD" = (
 /obj/structure/curtain/red,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "enG" = (
@@ -8495,13 +8312,6 @@
 	icon_state = "browncorner"
 	},
 /area/lv522/atmos/north_command_centre)
-"enJ" = (
-/obj/effect/decal/warning_stripes,
-/obj/structure/machinery/landinglight/ds1{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/lv522/landing_zone_1)
 "enP" = (
 /obj/structure/pipes/standard/manifold/hidden/green{
 	dir = 4
@@ -8648,8 +8458,7 @@
 	pixel_y = 3
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/hallway/damage)
 "equ" = (
@@ -8663,8 +8472,7 @@
 "eqE" = (
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/outdoors/nw_rockies)
 "eqM" = (
@@ -8694,8 +8502,7 @@
 /obj/structure/cargo_container/watatsumi/rightmid,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/indoors/lone_buildings/storage_blocks)
 "erZ" = (
@@ -8735,8 +8542,7 @@
 "esF" = (
 /obj/structure/surface/rack,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/mining)
 "etn" = (
@@ -8830,8 +8636,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/c_block/t_comm)
 "evx" = (
@@ -9042,16 +8847,14 @@
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "ezH" = (
 /obj/structure/cargo_container/watatsumi/rightmid,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/outdoors/colony_streets/north_west_street)
 "ezU" = (
@@ -9225,8 +9028,7 @@
 /obj/structure/machinery/light,
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/lone_buildings/outdoor_bot)
 "eDL" = (
@@ -9236,8 +9038,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/garage)
 "eEv" = (
@@ -9329,8 +9130,7 @@
 "eHu" = (
 /obj/structure/closet/secure_closet/miner,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/mining)
 "eHy" = (
@@ -9347,8 +9147,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/garage)
 "eHF" = (
@@ -9358,8 +9157,7 @@
 "eHI" = (
 /obj/structure/machinery/light,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/bridge)
 "eHR" = (
@@ -9383,16 +9181,14 @@
 /obj/effect/landmark/objective_landmark/close,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/atmos/cargo_intake)
 "eIk" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/dorms/glass)
 "eIn" = (
@@ -9402,8 +9198,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/atmos/cargo_intake)
 "eIF" = (
@@ -9476,8 +9271,7 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/mining)
 "eKe" = (
@@ -9589,8 +9383,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/bridge)
 "eMY" = (
@@ -9625,8 +9418,7 @@
 	stat = 2
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_east_street)
 "eOe" = (
@@ -9647,8 +9439,7 @@
 	},
 /obj/structure/machinery/vending/coffee,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms/glass)
 "eOl" = (
@@ -9657,8 +9448,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/admin)
 "eOn" = (
@@ -9687,8 +9477,7 @@
 	},
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "ePc" = (
@@ -9701,8 +9490,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/admin)
 "ePl" = (
@@ -9761,8 +9549,7 @@
 	pixel_y = 4
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "eQY" = (
@@ -9772,8 +9559,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/hallway)
 "eRg" = (
@@ -9826,8 +9612,7 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/mining)
 "eSQ" = (
@@ -9836,8 +9621,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/landing_zone_2/ceiling)
 "eSY" = (
@@ -9893,8 +9677,7 @@
 	pixel_x = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/atmos/cargo_intake)
 "eUh" = (
@@ -9935,8 +9718,7 @@
 	icon_state = "pottedplant_21";
 	layer = 3.1;
 	name = "synthethic potted plant";
-	pixel_y = 28;
-	tag = null
+	pixel_y = 28
 	},
 /turf/open/floor/plating{
 	icon_state = "platebot"
@@ -10089,20 +9871,17 @@
 	icon_state = "S"
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/n_rockies)
 "eZK" = (
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/admin)
 "eZM" = (
 /obj/structure/bed/chair/wood/normal{
-	dir = 4;
-	tag = null
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
@@ -10140,8 +9919,7 @@
 	pixel_y = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/south_east_street)
 "faK" = (
@@ -10218,8 +9996,7 @@
 "fcd" = (
 /obj/vehicle/train/cargo/trolley,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/lone_buildings/storage_blocks)
 "fcv" = (
@@ -10228,8 +10005,7 @@
 	pixel_y = 7
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "fcV" = (
@@ -10286,8 +10062,7 @@
 "fdT" = (
 /obj/structure/closet/crate,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/landing_zone_2)
 "fdZ" = (
@@ -10304,8 +10079,7 @@
 /obj/item/prop/alien/hugger,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/landing_zone_2/ceiling)
 "feF" = (
@@ -10319,8 +10093,7 @@
 /area/lv522/atmos/east_reactor/west)
 "ffb" = (
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/bridge)
 "ffj" = (
@@ -10405,8 +10178,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/mining)
 "fhQ" = (
@@ -10423,8 +10195,7 @@
 /obj/item/tool/pickaxe,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/atmos/cargo_intake)
 "fib" = (
@@ -10629,8 +10400,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "fmL" = (
@@ -10703,8 +10473,7 @@
 	icon_state = "W"
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_west_street)
 "foX" = (
@@ -10713,13 +10482,11 @@
 	pixel_y = 16
 	},
 /obj/structure/bed/chair/comfy{
-	dir = 1;
-	tag = null
+	dir = 1
 	},
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/c_block/t_comm)
 "fpl" = (
@@ -10744,8 +10511,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/dorms)
 "fpB" = (
@@ -10786,8 +10552,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/dorms/glass)
 "frc" = (
@@ -10900,8 +10665,7 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "ftK" = (
@@ -11077,8 +10841,7 @@
 "fxl" = (
 /obj/vehicle/train/cargo/engine,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/cargo)
 "fxq" = (
@@ -11122,8 +10885,7 @@
 /obj/structure/barricade/wooden,
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/hallway)
 "fzf" = (
@@ -11295,8 +11057,7 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/kitchen/glass)
 "fCE" = (
@@ -11326,8 +11087,7 @@
 "fCU" = (
 /obj/effect/decal/cleanable/blood{
 	desc = "Watch your step.";
-	icon_state = "gib6";
-	tag = null
+	icon_state = "gib6"
 	},
 /turf/open/asphalt/cement{
 	icon_state = "cement12"
@@ -11335,8 +11095,7 @@
 /area/lv522/outdoors/colony_streets/south_west_street)
 "fCW" = (
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/lone_buildings/storage_blocks)
 "fDg" = (
@@ -11458,8 +11217,7 @@
 	pixel_y = 13
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "fEY" = (
@@ -11591,15 +11349,13 @@
 "fIr" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_street)
 "fIx" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/mining)
 "fII" = (
@@ -11702,8 +11458,7 @@
 	pixel_x = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/atmos/cargo_intake)
 "fLF" = (
@@ -11808,8 +11563,7 @@
 	pixel_y = 10
 	},
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/garage)
 "fMT" = (
@@ -11832,8 +11586,7 @@
 /obj/structure/surface/table/reinforced/prison,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/garage)
 "fOc" = (
@@ -11847,8 +11600,7 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/casino)
 "fOl" = (
@@ -11872,8 +11624,7 @@
 "fOX" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/landing_zone_2/ceiling)
 "fPa" = (
@@ -11895,8 +11646,7 @@
 /obj/structure/bed/chair,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkpurple2";
-	tag = null
+	icon_state = "darkpurple2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "fPH" = (
@@ -11924,15 +11674,13 @@
 	pixel_y = 9
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "fRc" = (
 /obj/structure/machinery/mill,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/cargo)
 "fRd" = (
@@ -11962,7 +11710,6 @@
 /area/lv522/indoors/a_block/admin)
 "fRP" = (
 /obj/structure/prop/vehicles/crawler{
-	density = 1;
 	layer = 3.3
 	},
 /obj/structure/barricade/wooden{
@@ -12005,8 +11752,7 @@
 "fSv" = (
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/lone_buildings/engineering)
 "fSR" = (
@@ -12016,8 +11762,7 @@
 	icon_state = "pottedplant_21";
 	layer = 3.1;
 	name = "synthethic potted plant";
-	pixel_y = 12;
-	tag = null
+	pixel_y = 12
 	},
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor/corsat{
@@ -12052,8 +11797,7 @@
 	icon_state = "p_stair_full"
 	},
 /turf/open/shuttle/dropship{
-	icon_state = "rasputin3";
-	tag = null
+	icon_state = "rasputin3"
 	},
 /area/lv522/landing_zone_forecon/UD6_Tornado)
 "fTs" = (
@@ -12128,8 +11872,7 @@
 /obj/structure/closet,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "fVU" = (
@@ -12165,8 +11908,7 @@
 /obj/structure/machinery/vending/snack,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/b_block/bar)
 "fXn" = (
@@ -12214,8 +11956,7 @@
 "fXS" = (
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/atmos/cargo_intake)
 "fXU" = (
@@ -12255,8 +11996,7 @@
 /obj/item/clothing/glasses/meson,
 /obj/effect/landmark/objective_landmark/close,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/c_block/mining)
 "fYD" = (
@@ -12283,8 +12023,7 @@
 "fZd" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/t_comm)
 "fZy" = (
@@ -12305,8 +12044,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/indoors/c_block/mining)
 "gat" = (
@@ -12324,8 +12062,7 @@
 /obj/item/prop/alien/hugger,
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/c_block/t_comm)
 "gaS" = (
@@ -12350,8 +12087,7 @@
 /obj/structure/machinery/recharge_station,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/mining)
 "gbk" = (
@@ -12454,8 +12190,7 @@
 /obj/structure/foamed_metal,
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/dorms/glass)
 "gcO" = (
@@ -12569,8 +12304,7 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "geH" = (
@@ -12627,15 +12361,13 @@
 "ggj" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/admin)
 "ggp" = (
 /obj/structure/machinery/floodlight,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/garage)
 "ggH" = (
@@ -12694,8 +12426,7 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms/glass)
 "ghy" = (
@@ -12768,8 +12499,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/t_comm)
 "gjV" = (
@@ -12814,8 +12544,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb2,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/b_block/bar)
 "gkY" = (
@@ -12896,15 +12625,13 @@
 /obj/effect/landmark/objective_landmark/close,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/mining)
 "gny" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/bridges)
 "gnA" = (
@@ -12930,8 +12657,7 @@
 "gou" = (
 /turf/open/floor/prison{
 	dir = 9;
-	icon_state = "darkpurple2";
-	tag = null
+	icon_state = "darkpurple2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "goK" = (
@@ -12970,8 +12696,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/c_block/mining)
 "goT" = (
@@ -12985,8 +12710,7 @@
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/cargo)
 "gpp" = (
@@ -12995,8 +12719,7 @@
 	pixel_y = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_west_street)
 "gpu" = (
@@ -13139,8 +12862,7 @@
 /obj/structure/pipes/vents/pump,
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/c_block/t_comm)
 "gts" = (
@@ -13159,8 +12881,7 @@
 	pixel_y = 20
 	},
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/casino)
 "gug" = (
@@ -13203,8 +12924,7 @@
 /obj/structure/pipes/vents/pump,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "guR" = (
@@ -13293,7 +13013,6 @@
 /area/lv522/indoors/c_block/cargo)
 "gwR" = (
 /obj/structure/machinery/door/airlock/almayer/security/glass{
-	locked = 0;
 	name = "\improper Marshal Office Holding Cell"
 	},
 /obj/structure/pipes/standard/simple/hidden/green{
@@ -13340,8 +13059,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/hallway)
 "gxE" = (
@@ -13506,8 +13224,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "gCE" = (
@@ -13555,15 +13272,13 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/kitchen/glass)
 "gDA" = (
 /obj/structure/platform,
 /turf/open/floor/prison{
-	icon_state = "darkpurple2";
-	tag = null
+	icon_state = "darkpurple2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "gDL" = (
@@ -13594,7 +13309,6 @@
 "gEA" = (
 /obj/structure/machinery/door/airlock/almayer/security/glass{
 	dir = 8;
-	locked = 0;
 	name = "\improper Marshall Head Office"
 	},
 /obj/structure/pipes/standard/simple/hidden/green{
@@ -13628,8 +13342,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "gES" = (
@@ -13706,8 +13419,7 @@
 	pixel_y = 18
 	},
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/garage)
 "gGk" = (
@@ -13790,8 +13502,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/dorms)
 "gIa" = (
@@ -13859,8 +13570,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spider/spiderling/nogrow,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/lone_buildings/storage_blocks)
 "gJM" = (
@@ -13870,8 +13580,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/cargo)
 "gKg" = (
@@ -14012,8 +13721,7 @@
 /obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "gNe" = (
@@ -14149,8 +13857,7 @@
 /obj/structure/closet/secure_closet/engineering_electrical,
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/lone_buildings/outdoor_bot)
 "gPQ" = (
@@ -14202,8 +13909,7 @@
 "gRp" = (
 /obj/structure/machinery/floodlight/landing,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/landing_zone_2)
 "gRs" = (
@@ -14234,8 +13940,7 @@
 	pixel_y = 7
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "gRV" = (
@@ -14261,8 +13966,7 @@
 	layer = 3.1
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms/glass)
 "gTw" = (
@@ -14291,8 +13995,7 @@
 /obj/structure/ore_box,
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/mining)
 "gUi" = (
@@ -14333,8 +14036,7 @@
 /obj/structure/machinery/recharge_station,
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/lone_buildings/engineering)
 "gUQ" = (
@@ -14406,8 +14108,7 @@
 "gWh" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkpurple2";
-	tag = null
+	icon_state = "darkpurple2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "gWq" = (
@@ -14423,8 +14124,7 @@
 	pixel_x = 4
 	},
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/mining)
 "gWI" = (
@@ -14533,8 +14233,7 @@
 /obj/structure/pipes/vents/pump,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkpurple2";
-	tag = null
+	icon_state = "darkpurple2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "gYM" = (
@@ -14546,14 +14245,12 @@
 /area/lv522/atmos/cargo_intake)
 "gYO" = (
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/south_west_street)
 "gYT" = (
 /obj/structure/bed/chair/comfy{
-	dir = 1;
-	tag = null
+	dir = 1
 	},
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/lv522/atmos/command_centre)
@@ -14581,8 +14278,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/lone_buildings/engineering)
 "gZh" = (
@@ -14606,8 +14302,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/indoors/lone_buildings/storage_blocks)
 "gZL" = (
@@ -14640,8 +14335,7 @@
 /area/lv522/indoors/a_block/admin)
 "hai" = (
 /obj/structure/bed/chair/comfy{
-	dir = 1;
-	tag = null
+	dir = 1
 	},
 /turf/open/floor/corsat{
 	icon_state = "plate"
@@ -14729,8 +14423,7 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "hbu" = (
@@ -14743,15 +14436,13 @@
 	},
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/landing_zone_2)
 "hbF" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
 /obj/structure/bed/chair/comfy{
-	dir = 1;
-	tag = null
+	dir = 1
 	},
 /turf/open/floor/corsat{
 	dir = 9;
@@ -14793,8 +14484,7 @@
 	pixel_x = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/landing_zone_2/ceiling)
 "hcx" = (
@@ -14849,8 +14539,7 @@
 "hdq" = (
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/garage)
 "hds" = (
@@ -14905,8 +14594,7 @@
 "heC" = (
 /obj/structure/machinery/disposal,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/cargo)
 "heF" = (
@@ -15082,8 +14770,7 @@
 	icon_state = "W"
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/south_east_street)
 "hiB" = (
@@ -15170,8 +14857,7 @@
 	pixel_y = 7
 	},
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/garage)
 "hku" = (
@@ -15194,8 +14880,7 @@
 	pixel_y = 3
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "hkw" = (
@@ -15296,8 +14981,7 @@
 /obj/structure/surface/table/almayer,
 /obj/item/device/binoculars,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/windbreaker/observation)
 "hlH" = (
@@ -15379,8 +15063,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/b_block/bar)
 "hnD" = (
@@ -15447,8 +15130,7 @@
 	pixel_x = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/atmos/cargo_intake)
 "hoZ" = (
@@ -15466,8 +15148,7 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "hpq" = (
@@ -15484,8 +15165,7 @@
 "hpH" = (
 /obj/structure/largecrate/random/secure,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/hallway)
 "hpO" = (
@@ -15524,13 +15204,6 @@
 	icon_state = "browncorner"
 	},
 /area/lv522/atmos/command_centre)
-"hqY" = (
-/obj/effect/decal/warning_stripes,
-/obj/structure/machinery/landinglight/ds1{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/lv522/landing_zone_1)
 "hqZ" = (
 /obj/structure/bed/chair/wheelchair,
 /turf/open/auto_turf/shale/layer1,
@@ -15551,8 +15224,7 @@
 	pixel_y = 3
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "hry" = (
@@ -15567,8 +15239,7 @@
 "hrU" = (
 /obj/structure/pipes/vents/pump,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/mining)
 "hsh" = (
@@ -15581,8 +15252,7 @@
 /obj/structure/machinery/floodlight,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/indoors/lone_buildings/storage_blocks)
 "hsA" = (
@@ -15599,8 +15269,7 @@
 	},
 /turf/open/floor/plating{
 	dir = 8;
-	icon_state = "platingdmg3";
-	tag = null
+	icon_state = "platingdmg3"
 	},
 /area/lv522/indoors/a_block/admin)
 "htu" = (
@@ -15663,8 +15332,7 @@
 "huF" = (
 /obj/structure/machinery/space_heater/radiator/red,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "huN" = (
@@ -15807,8 +15475,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/b_block/bar)
 "hyE" = (
@@ -15834,15 +15501,13 @@
 	icon_state = "S"
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_west_street)
 "hzc" = (
 /obj/structure/largecrate/random,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/mining)
 "hzk" = (
@@ -15864,8 +15529,7 @@
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/cargo)
 "hzA" = (
@@ -15886,8 +15550,7 @@
 	pixel_y = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/atmos/cargo_intake)
 "hzO" = (
@@ -15981,8 +15644,7 @@
 	pixel_y = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_west_street)
 "hAK" = (
@@ -15995,8 +15657,7 @@
 /obj/item/weapon/gun/boltaction,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/c_block/cargo)
 "hBf" = (
@@ -16014,8 +15675,7 @@
 /obj/structure/dispenser/oxygen,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/mining)
 "hBB" = (
@@ -16142,8 +15802,7 @@
 /area/lv522/indoors/c_block/mining)
 "hFm" = (
 /turf/open/shuttle/dropship{
-	icon_state = "rasputin4";
-	tag = null
+	icon_state = "rasputin4"
 	},
 /area/lv522/landing_zone_forecon/UD6_Tornado)
 "hFu" = (
@@ -16155,8 +15814,7 @@
 "hFG" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/casino)
 "hFL" = (
@@ -16212,8 +15870,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/windbreaker/observation)
 "hHN" = (
@@ -16231,8 +15888,7 @@
 /area/lv522/atmos/command_centre)
 "hIf" = (
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/landing_zone_2)
 "hIp" = (
@@ -16253,8 +15909,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb2,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/cargo)
 "hID" = (
@@ -16288,8 +15943,7 @@
 	},
 /obj/structure/machinery/disposal,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms/glass)
 "hJq" = (
@@ -16328,8 +15982,7 @@
 /obj/item/explosive/plastic,
 /obj/item/explosive/plastic,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/lone_buildings/storage_blocks)
 "hJZ" = (
@@ -16349,15 +16002,13 @@
 /obj/item/trash/ceramic_plate,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/windbreaker/observation)
 "hKy" = (
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/indoors/lone_buildings/outdoor_bot)
 "hKz" = (
@@ -16396,8 +16047,7 @@
 	layer = 3.1;
 	name = "synthethic potted plant";
 	pixel_x = -2;
-	pixel_y = 10;
-	tag = null
+	pixel_y = 10
 	},
 /turf/open/floor/prison{
 	dir = 9;
@@ -16410,8 +16060,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/outdoors/colony_streets/north_east_street)
 "hLl" = (
@@ -16421,8 +16070,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 8;
-	icon_state = "cell_stripe";
-	tag = null
+	icon_state = "cell_stripe"
 	},
 /area/lv522/indoors/lone_buildings/storage_blocks)
 "hLm" = (
@@ -16476,8 +16124,7 @@
 /obj/item/clothing/glasses/kutjevo,
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/lone_buildings/outdoor_bot)
 "hMz" = (
@@ -16568,8 +16215,7 @@
 /obj/effect/spawner/gibspawner/xeno,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/atmos/cargo_intake)
 "hOl" = (
@@ -16700,8 +16346,7 @@
 	icon_state = "S"
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/nw_rockies)
 "hQE" = (
@@ -16754,8 +16399,7 @@
 /obj/structure/pipes/vents/pump,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/casino)
 "hRG" = (
@@ -16797,13 +16441,11 @@
 "hTd" = (
 /obj/structure/window/reinforced{
 	dir = 1;
-	layer = 3;
-	tag = null
+	layer = 3
 	},
 /obj/structure/machinery/computer3/server/rack,
 /turf/open/floor{
-	icon_state = "bcircuit";
-	tag = null
+	icon_state = "bcircuit"
 	},
 /area/lv522/atmos/command_centre)
 "hTe" = (
@@ -16850,8 +16492,7 @@
 	pixel_x = -4
 	},
 /turf/open/floor{
-	icon_state = "bcircuit";
-	tag = null
+	icon_state = "bcircuit"
 	},
 /area/lv522/atmos/east_reactor)
 "hTW" = (
@@ -16879,8 +16520,7 @@
 /obj/structure/foamed_metal,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms/glass)
 "hUq" = (
@@ -16889,8 +16529,7 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/garage)
 "hUM" = (
@@ -16916,8 +16555,7 @@
 	},
 /obj/structure/prop/almayer/computers/sensor_computer1,
 /turf/open/floor{
-	icon_state = "bcircuit";
-	tag = null
+	icon_state = "bcircuit"
 	},
 /area/lv522/atmos/east_reactor)
 "hUZ" = (
@@ -16942,8 +16580,7 @@
 "hVk" = (
 /obj/item/stack/sheet/metal,
 /turf/open/floor{
-	icon_state = "bcircuit";
-	tag = null
+	icon_state = "bcircuit"
 	},
 /area/lv522/atmos/east_reactor)
 "hVu" = (
@@ -16996,8 +16633,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/c_block/casino)
 "hWV" = (
@@ -17089,14 +16725,12 @@
 	name = "weak acid"
 	},
 /turf/open/floor{
-	icon_state = "bcircuit";
-	tag = null
+	icon_state = "bcircuit"
 	},
 /area/lv522/atmos/east_reactor)
 "hYf" = (
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/lone_buildings/storage_blocks)
 "hYk" = (
@@ -17105,8 +16739,7 @@
 	},
 /obj/item/stack/sheet/metal,
 /turf/open/floor{
-	icon_state = "bcircuit";
-	tag = null
+	icon_state = "bcircuit"
 	},
 /area/lv522/atmos/east_reactor)
 "hYn" = (
@@ -17161,8 +16794,7 @@
 	pixel_x = -4
 	},
 /turf/open/floor{
-	icon_state = "bcircuit";
-	tag = null
+	icon_state = "bcircuit"
 	},
 /area/lv522/atmos/east_reactor)
 "hZK" = (
@@ -17173,14 +16805,12 @@
 	pixel_x = -16
 	},
 /turf/open/floor{
-	icon_state = "bcircuit";
-	tag = null
+	icon_state = "bcircuit"
 	},
 /area/lv522/atmos/east_reactor)
 "hZL" = (
 /obj/structure/bed/chair/wood/normal{
-	dir = 4;
-	tag = null
+	dir = 4
 	},
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
@@ -17214,8 +16844,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "whitegreenfull";
-	tag = null
+	icon_state = "whitegreenfull"
 	},
 /area/lv522/oob)
 "iam" = (
@@ -17317,8 +16946,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/bridge)
 "idq" = (
@@ -17366,8 +16994,7 @@
 	icon_state = "W"
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/south_west_street)
 "iel" = (
@@ -17379,8 +17006,7 @@
 /area/lv522/oob)
 "ier" = (
 /obj/structure/bed/chair/comfy{
-	dir = 1;
-	tag = null
+	dir = 1
 	},
 /turf/open/floor/corsat{
 	dir = 9;
@@ -17451,8 +17077,7 @@
 /area/lv522/outdoors/colony_streets/north_east_street)
 "igp" = (
 /obj/structure/bed/chair/comfy{
-	dir = 1;
-	tag = null
+	dir = 1
 	},
 /turf/open/floor/corsat{
 	dir = 1;
@@ -17520,8 +17145,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
 	dir = 1;
-	icon_state = "darkpurple2";
-	tag = null
+	icon_state = "darkpurple2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "ihy" = (
@@ -17538,8 +17162,7 @@
 	pixel_y = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_west_street)
 "iiz" = (
@@ -17629,8 +17252,7 @@
 /area/lv522/indoors/a_block/corpo/glass)
 "ijJ" = (
 /obj/structure/machinery/light{
-	dir = 4;
-	tag = null
+	dir = 4
 	},
 /obj/structure/machinery/disposal,
 /turf/open/floor/strata{
@@ -17737,8 +17359,7 @@
 /obj/effect/spawner/gibspawner/xeno,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/atmos/cargo_intake)
 "imh" = (
@@ -17765,8 +17386,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/bridges/dorms_fitness)
 "imT" = (
@@ -17825,8 +17445,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/c_block/t_comm)
 "ipf" = (
@@ -17935,8 +17554,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb2,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/casino)
 "irx" = (
@@ -17971,16 +17589,14 @@
 	pixel_x = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_west_street)
 "iso" = (
 /obj/structure/cargo_container/lockmart/left,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/atmos/cargo_intake)
 "iss" = (
@@ -18021,8 +17637,7 @@
 "isG" = (
 /obj/structure/largecrate/random/barrel,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/lone_buildings/storage_blocks)
 "iti" = (
@@ -18098,8 +17713,7 @@
 	pixel_y = 7
 	},
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/cargo)
 "iuv" = (
@@ -18153,8 +17767,7 @@
 	icon_state = "p_stair_full"
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "ivk" = (
@@ -18188,8 +17801,7 @@
 	pixel_y = 8
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "iwb" = (
@@ -18298,8 +17910,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/admin)
 "iyC" = (
@@ -18350,8 +17961,7 @@
 	icon_state = "p_stair_full"
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/c_block/garage)
 "izz" = (
@@ -18388,8 +17998,7 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/mining)
 "iAZ" = (
@@ -18423,8 +18032,7 @@
 /obj/item/clothing/under/overalls,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/mining)
 "iBr" = (
@@ -18453,8 +18061,7 @@
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/structure/bed/chair,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/c_block/t_comm)
 "iBY" = (
@@ -18488,8 +18095,7 @@
 /obj/effect/landmark/survivor_spawner,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/admin)
 "iCR" = (
@@ -18510,8 +18116,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "iDg" = (
@@ -18552,8 +18157,7 @@
 /obj/structure/cargo_container/lockmart/mid,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/atmos/cargo_intake)
 "iFB" = (
@@ -18567,16 +18171,14 @@
 /obj/item/explosive/mine/active,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/outdoors/colony_streets/north_east_street)
 "iFO" = (
 /obj/structure/surface/rack,
 /obj/item/clothing/under/colonist,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms/glass)
 "iFV" = (
@@ -18617,8 +18219,7 @@
 "iGr" = (
 /obj/structure/largecrate/random,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/landing_zone_2)
 "iGD" = (
@@ -18651,8 +18252,7 @@
 	pixel_y = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/atmos/cargo_intake)
 "iGM" = (
@@ -18695,8 +18295,7 @@
 	name = "inventory computer"
 	},
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/casino)
 "iHw" = (
@@ -18959,8 +18558,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/machinery/space_heater/radiator/red,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/windbreaker/observation)
 "iMS" = (
@@ -18977,8 +18575,7 @@
 /obj/structure/machinery/space_heater,
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/lone_buildings/outdoor_bot)
 "iNb" = (
@@ -19006,8 +18603,7 @@
 "iNX" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/security/glass)
 "iOi" = (
@@ -19063,8 +18659,7 @@
 /obj/structure/cargo_container/lockmart/right,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/atmos/cargo_intake)
 "iPu" = (
@@ -19178,8 +18773,7 @@
 /area/lv522/atmos/east_reactor)
 "iSc" = (
 /obj/structure/bed/chair/comfy{
-	dir = 1;
-	tag = null
+	dir = 1
 	},
 /turf/open/floor/corsat{
 	dir = 5;
@@ -19192,8 +18786,7 @@
 /area/lv522/outdoors/colony_streets/north_west_street)
 "iSu" = (
 /turf/open/shuttle/dropship{
-	icon_state = "rasputin8";
-	tag = null
+	icon_state = "rasputin8"
 	},
 /area/lv522/landing_zone_forecon/UD6_Tornado)
 "iSF" = (
@@ -19214,9 +18807,7 @@
 	},
 /area/lv522/indoors/c_block/mining)
 "iTn" = (
-/obj/structure/bed/chair/comfy{
-	tag = null
-	},
+/obj/structure/bed/chair/comfy,
 /turf/open/floor/corsat{
 	dir = 10;
 	icon_state = "brown"
@@ -19251,16 +18842,14 @@
 /obj/structure/surface/rack,
 /obj/item/clothing/suit/storage/hazardvest,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/lone_buildings/storage_blocks)
 "iUj" = (
 /obj/item/prop/colony/used_flare,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/atmos/cargo_intake)
 "iUk" = (
@@ -19275,8 +18864,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
 	dir = 6;
-	icon_state = "darkpurple2";
-	tag = null
+	icon_state = "darkpurple2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "iUT" = (
@@ -19308,9 +18896,7 @@
 	},
 /area/lv522/indoors/a_block/hallway)
 "iVk" = (
-/obj/structure/bed/chair/comfy{
-	tag = null
-	},
+/obj/structure/bed/chair/comfy,
 /turf/open/floor/corsat{
 	dir = 6;
 	icon_state = "brown"
@@ -19332,8 +18918,7 @@
 	pixel_x = 6
 	},
 /turf/open/floor{
-	icon_state = "bcircuit";
-	tag = null
+	icon_state = "bcircuit"
 	},
 /area/lv522/indoors/a_block/admin)
 "iVU" = (
@@ -19363,8 +18948,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "whitegreenfull";
-	tag = null
+	icon_state = "whitegreenfull"
 	},
 /area/lv522/oob)
 "iWh" = (
@@ -19384,8 +18968,7 @@
 /obj/structure/foamed_metal,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms/glass)
 "iWu" = (
@@ -19394,8 +18977,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "whitegreenfull";
-	tag = null
+	icon_state = "whitegreenfull"
 	},
 /area/lv522/oob)
 "iWy" = (
@@ -19629,15 +19211,13 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "jbm" = (
 /obj/structure/largecrate/random,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/cargo)
 "jbn" = (
@@ -19688,8 +19268,7 @@
 /area/lv522/outdoors/nw_rockies)
 "jbO" = (
 /obj/structure/pipes/standard/simple/visible{
-	dir = 6;
-	tag = null
+	dir = 6
 	},
 /turf/open/floor/strata{
 	icon_state = "white_cyan3"
@@ -19729,8 +19308,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 1;
-	icon_state = "darkpurple2";
-	tag = null
+	icon_state = "darkpurple2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "jdf" = (
@@ -19738,8 +19316,7 @@
 /obj/effect/landmark/static_comms/net_two,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/indoors/c_block/t_comm)
 "jdl" = (
@@ -19758,8 +19335,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/surface/table/reinforced/prison,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/c_block/t_comm)
 "jdq" = (
@@ -19805,8 +19381,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/lone_buildings/engineering)
 "jey" = (
@@ -19829,8 +19404,7 @@
 /obj/structure/pipes/vents/pump,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/casino)
 "jeI" = (
@@ -19844,8 +19418,7 @@
 "jeJ" = (
 /obj/structure/machinery/disposal,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/garage)
 "jft" = (
@@ -19882,8 +19455,7 @@
 	icon_state = "W"
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_west_street)
 "jgV" = (
@@ -19906,8 +19478,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms/glass)
 "jhl" = (
@@ -19917,7 +19488,6 @@
 /area/lv522/indoors/a_block/dorms)
 "jhp" = (
 /obj/structure/prop/invuln/lifeboat_hatch_placeholder/terminal{
-	icon_state = "closed";
 	layer = 2.1
 	},
 /obj/structure/barricade/handrail{
@@ -19976,8 +19546,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "whitegreenfull";
-	tag = null
+	icon_state = "whitegreenfull"
 	},
 /area/lv522/oob)
 "jis" = (
@@ -19986,8 +19555,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "whitegreenfull";
-	tag = null
+	icon_state = "whitegreenfull"
 	},
 /area/lv522/oob)
 "jix" = (
@@ -20001,8 +19569,7 @@
 	icon_state = "W"
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/south_east_street)
 "jiF" = (
@@ -20063,8 +19630,7 @@
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/atmos/cargo_intake)
 "jjo" = (
@@ -20173,8 +19739,7 @@
 /obj/structure/closet/secure_closet/engineering_electrical,
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/lone_buildings/engineering)
 "jlc" = (
@@ -20232,8 +19797,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/cargo)
 "jmd" = (
@@ -20292,8 +19856,7 @@
 	pixel_x = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/atmos/cargo_intake)
 "jnb" = (
@@ -20333,8 +19896,7 @@
 /obj/structure/machinery/floodlight,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/indoors/lone_buildings/storage_blocks)
 "jnB" = (
@@ -20399,8 +19961,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/garage)
 "jpa" = (
@@ -20483,8 +20044,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/cargo)
 "jru" = (
@@ -20528,8 +20088,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/c_block/t_comm)
 "jrL" = (
@@ -20541,8 +20100,7 @@
 	icon_state = "S"
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_west_street)
 "jrT" = (
@@ -20620,8 +20178,7 @@
 "jub" = (
 /obj/structure/machinery/floodlight,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/lone_buildings/storage_blocks)
 "jud" = (
@@ -20629,8 +20186,7 @@
 	dir = 1
 	},
 /turf/open/floor{
-	icon_state = "bcircuit";
-	tag = null
+	icon_state = "bcircuit"
 	},
 /area/lv522/indoors/a_block/admin)
 "jur" = (
@@ -20720,8 +20276,7 @@
 "jvG" = (
 /obj/structure/machinery/vending/cola,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms/glass)
 "jwM" = (
@@ -20811,8 +20366,7 @@
 /obj/structure/pipes/vents/pump,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/hallway)
 "jyF" = (
@@ -20821,8 +20375,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "jyM" = (
@@ -20939,8 +20492,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/lone_buildings/outdoor_bot)
 "jBw" = (
@@ -21005,8 +20557,7 @@
 /area/lv522/landing_zone_1/tunnel)
 "jCq" = (
 /obj/structure/bed/chair/comfy{
-	dir = 1;
-	tag = null
+	dir = 1
 	},
 /turf/open/floor/corsat{
 	icon_state = "squares"
@@ -21162,8 +20713,7 @@
 /area/lv522/atmos/east_reactor/south)
 "jFu" = (
 /obj/structure/morgue{
-	dir = 8;
-	tag = null
+	dir = 8
 	},
 /turf/open/floor/strata{
 	dir = 4;
@@ -21174,8 +20724,7 @@
 /obj/structure/machinery/space_heater,
 /turf/open/floor/prison{
 	dir = 1;
-	icon_state = "darkpurple2";
-	tag = null
+	icon_state = "darkpurple2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "jFG" = (
@@ -21250,8 +20799,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "jHy" = (
@@ -21295,15 +20843,13 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/cargo)
 "jII" = (
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/outdoors/n_rockies)
 "jIQ" = (
@@ -21343,8 +20889,7 @@
 	pixel_y = 27
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/b_block/bar)
 "jJi" = (
@@ -21390,8 +20935,7 @@
 	icon_state = "S"
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/east_central_street)
 "jKm" = (
@@ -21436,8 +20980,7 @@
 "jLk" = (
 /obj/structure/cargo_container/wy/left,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/landing_zone_2)
 "jLD" = (
@@ -21446,8 +20989,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/casino)
 "jLF" = (
@@ -21523,8 +21065,7 @@
 "jNk" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/generic{
 	dir = 1;
-	name = "\improper Westlock";
-	welded = null
+	name = "\improper Westlock"
 	},
 /turf/open/floor/corsat{
 	icon_state = "marked"
@@ -21545,8 +21086,7 @@
 	layer = 3.1;
 	name = "synthethic potted plant";
 	pixel_x = -2;
-	pixel_y = 16;
-	tag = null
+	pixel_y = 16
 	},
 /turf/open/floor/prison{
 	dir = 1;
@@ -21584,8 +21124,7 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "jOw" = (
@@ -21650,8 +21189,7 @@
 	},
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/cargo)
 "jPk" = (
@@ -21687,8 +21225,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/indoors/lone_buildings/engineering)
 "jQa" = (
@@ -21749,16 +21286,14 @@
 /obj/structure/machinery/disposal,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "jSG" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/indoors/lone_buildings/engineering)
 "jSR" = (
@@ -21807,8 +21342,7 @@
 "jTr" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms/glass)
 "jTx" = (
@@ -21841,8 +21375,7 @@
 "jTJ" = (
 /obj/structure/cargo_container/watatsumi/leftmid,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_west_street)
 "jTS" = (
@@ -21850,8 +21383,7 @@
 /obj/item/circuitboard/apc,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms/glass)
 "jUe" = (
@@ -21863,8 +21395,7 @@
 "jUk" = (
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/indoors/lone_buildings/storage_blocks)
 "jUn" = (
@@ -21879,24 +21410,21 @@
 	pixel_x = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/n_rockies)
 "jUy" = (
 /obj/structure/machinery/power/port_gen/pacman/super,
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/lone_buildings/outdoor_bot)
 "jUI" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/cargo)
 "jUO" = (
@@ -21947,8 +21475,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/bridge)
 "jVC" = (
@@ -22016,8 +21543,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 8;
-	icon_state = "darkpurple2";
-	tag = null
+	icon_state = "darkpurple2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "jXc" = (
@@ -22052,8 +21578,7 @@
 	pixel_y = 6
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "jYr" = (
@@ -22115,8 +21640,7 @@
 /obj/structure/cargo_container/watatsumi/leftmid,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/indoors/lone_buildings/storage_blocks)
 "jZo" = (
@@ -22128,8 +21652,7 @@
 "jZA" = (
 /obj/item/prop/colony/used_flare,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/hallway)
 "jZD" = (
@@ -22325,8 +21848,7 @@
 /area/lv522/landing_zone_2)
 "kcS" = (
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "kdi" = (
@@ -22338,8 +21860,7 @@
 	icon_state = "p_stair_full"
 	},
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/mining)
 "kdm" = (
@@ -22365,8 +21886,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/cargo)
 "kdx" = (
@@ -22428,8 +21948,7 @@
 /obj/structure/closet/toolcloset,
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/lone_buildings/engineering)
 "kfq" = (
@@ -22445,8 +21964,7 @@
 	icon_state = "p_stair_full"
 	},
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/casino)
 "kfu" = (
@@ -22537,8 +22055,7 @@
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_street)
 "khd" = (
@@ -22548,8 +22065,7 @@
 /obj/structure/prop/server_equipment,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/indoors/lone_buildings/outdoor_bot)
 "kho" = (
@@ -22607,8 +22123,7 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/c_block/cargo)
 "kih" = (
@@ -22643,8 +22158,7 @@
 	icon_state = "medium"
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/admin)
 "kiG" = (
@@ -22672,8 +22186,7 @@
 	},
 /obj/item/prop/alien/hugger,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "kiY" = (
@@ -22687,8 +22200,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/landing_zone_2)
 "kjj" = (
@@ -22755,20 +22267,17 @@
 	icon_state = "pottedplant_21";
 	layer = 3.1;
 	name = "synthethic potted plant";
-	pixel_y = 14;
-	tag = null
+	pixel_y = 14
 	},
 /obj/structure/machinery/light,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "kkP" = (
 /obj/structure/surface/rack,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/cargo)
 "kkS" = (
@@ -22790,8 +22299,7 @@
 "klj" = (
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "cell_stripe";
-	tag = null
+	icon_state = "cell_stripe"
 	},
 /area/lv522/atmos/outdoor)
 "kll" = (
@@ -22806,8 +22314,7 @@
 	},
 /obj/item/prop/alien/hugger,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "klx" = (
@@ -22895,8 +22402,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/garden)
 "kmH" = (
@@ -22932,8 +22438,7 @@
 	},
 /obj/item/prop/alien/hugger,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "kne" = (
@@ -22966,8 +22471,7 @@
 	},
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/casino)
 "knS" = (
@@ -23013,8 +22517,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/landing_zone_2/ceiling)
 "koG" = (
@@ -23022,8 +22525,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/bridges/corpo)
 "koM" = (
@@ -23055,8 +22557,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 1;
-	icon_state = "darkpurple2";
-	tag = null
+	icon_state = "darkpurple2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "kpB" = (
@@ -23179,8 +22680,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/windbreaker/observation)
 "ksf" = (
@@ -23224,8 +22724,7 @@
 	},
 /obj/structure/platform_decoration{
 	dir = 10;
-	layer = 3.51;
-	tag = null
+	layer = 3.51
 	},
 /turf/open/floor/plating,
 /area/lv522/oob)
@@ -23269,8 +22768,7 @@
 /obj/structure/surface/table/almayer,
 /obj/item/device/camera,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms/glass)
 "kup" = (
@@ -23321,8 +22819,7 @@
 /obj/structure/pipes/vents/pump,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/windbreaker/observation)
 "kwc" = (
@@ -23351,8 +22848,7 @@
 	},
 /obj/structure/platform_decoration{
 	dir = 6;
-	layer = 3.51;
-	tag = null
+	layer = 3.51
 	},
 /turf/open/floor/plating,
 /area/lv522/oob)
@@ -23401,16 +22897,14 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/mining)
 "kxW" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkpurple2";
-	tag = null
+	icon_state = "darkpurple2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "kyb" = (
@@ -23526,8 +23020,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/casino)
 "kAj" = (
@@ -23642,8 +23135,7 @@
 /obj/effect/landmark/objective_landmark/close,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/casino)
 "kCf" = (
@@ -23655,8 +23147,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/outdoors/colony_streets/north_west_street)
 "kCC" = (
@@ -23668,8 +23159,7 @@
 	pixel_x = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_west_street)
 "kCD" = (
@@ -23712,15 +23202,13 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "kDH" = (
 /obj/structure/machinery/disposal,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "kDQ" = (
@@ -23763,8 +23251,7 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/admin)
 "kEl" = (
@@ -23968,8 +23455,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/outdoors/colony_streets/north_west_street)
 "kIj" = (
@@ -23985,8 +23471,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/outdoors/colony_streets/north_west_street)
 "kIM" = (
@@ -24038,8 +23523,7 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "kJh" = (
@@ -24065,8 +23549,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "whitegreenfull";
-	tag = null
+	icon_state = "whitegreenfull"
 	},
 /area/lv522/oob)
 "kKc" = (
@@ -24114,8 +23597,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "kLk" = (
@@ -24216,8 +23698,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/security)
 "kNL" = (
@@ -24225,8 +23706,7 @@
 /obj/item/clothing/gloves/yellow,
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/lone_buildings/outdoor_bot)
 "kNM" = (
@@ -24244,8 +23724,7 @@
 /obj/structure/closet/crate/explosives,
 /obj/item/storage/box/explosive_mines,
 /turf/open/shuttle/dropship{
-	icon_state = "rasputin15";
-	tag = null
+	icon_state = "rasputin15"
 	},
 /area/lv522/landing_zone_forecon/UD6_Tornado)
 "kOa" = (
@@ -24261,16 +23740,14 @@
 	pixel_y = -9
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/c_block/t_comm)
 "kOz" = (
 /obj/structure/machinery/vending/cigarette/colony,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/windbreaker/observation)
 "kOE" = (
@@ -24313,8 +23790,7 @@
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/outdoors/colony_streets/north_west_street)
 "kPG" = (
@@ -24351,8 +23827,7 @@
 	pixel_x = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_west_street)
 "kPV" = (
@@ -24361,15 +23836,13 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "kQc" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/windbreaker/observation)
 "kQw" = (
@@ -24507,8 +23980,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/garage)
 "kRZ" = (
@@ -24526,8 +23998,7 @@
 	icon_state = "p_stair_full"
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/admin)
 "kSm" = (
@@ -24575,8 +24046,7 @@
 	icon_state = "S"
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_west_street)
 "kSZ" = (
@@ -24605,8 +24075,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/security/glass)
 "kTn" = (
@@ -24619,8 +24088,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/c_block/cargo)
 "kTF" = (
@@ -24641,15 +24109,13 @@
 	},
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/outdoors/colony_streets/north_east_street)
 "kUf" = (
 /obj/structure/machinery/vending/snack,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms/glass)
 "kUo" = (
@@ -24712,8 +24178,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/dorms)
 "kVG" = (
@@ -24758,8 +24223,7 @@
 /obj/structure/pipes/standard/manifold/hidden/green,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "kWp" = (
@@ -24790,20 +24254,17 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "kXa" = (
 /obj/structure/window/reinforced{
 	dir = 1;
-	layer = 3;
-	tag = null
+	layer = 3
 	},
 /obj/structure/machinery/computer3/server/rack,
 /turf/open/floor{
-	icon_state = "bcircuit";
-	tag = null
+	icon_state = "bcircuit"
 	},
 /area/lv522/atmos/east_reactor/south)
 "kXc" = (
@@ -24887,8 +24348,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/windbreaker/observation)
 "kYM" = (
@@ -24998,8 +24458,7 @@
 	icon_state = "medium"
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "lbo" = (
@@ -25047,8 +24506,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "cell_stripe";
-	tag = null
+	icon_state = "cell_stripe"
 	},
 /area/lv522/atmos/outdoor)
 "lcK" = (
@@ -25083,8 +24541,7 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "ldg" = (
@@ -25092,8 +24549,7 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/admin)
 "ldu" = (
@@ -25136,8 +24592,7 @@
 "leg" = (
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "whitegreenfull";
-	tag = null
+	icon_state = "whitegreenfull"
 	},
 /area/lv522/indoors/a_block/fitness/glass)
 "leh" = (
@@ -25151,15 +24606,13 @@
 "lek" = (
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkpurple2";
-	tag = null
+	icon_state = "darkpurple2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "lel" = (
 /obj/structure/machinery/floodlight,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/mining)
 "lep" = (
@@ -25186,8 +24639,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "leO" = (
@@ -25258,8 +24710,7 @@
 /obj/effect/decal/cleanable/blood/xeno,
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/admin)
 "lhC" = (
@@ -25280,8 +24731,7 @@
 /obj/structure/cargo_container/hd/left/alt,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/landing_zone_2)
 "lhI" = (
@@ -25290,8 +24740,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/mining)
 "lhK" = (
@@ -25310,16 +24759,14 @@
 /area/lv522/indoors/a_block/medical)
 "lhT" = (
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/security)
 "liD" = (
 /obj/item/prop/alien/hugger,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/atmos/cargo_intake)
 "liN" = (
@@ -25400,8 +24847,7 @@
 /obj/effect/decal/cleanable/blood/drip,
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/kitchen)
 "llJ" = (
@@ -25454,8 +24900,7 @@
 	layer = 3.1
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/hallway)
 "lmu" = (
@@ -25479,8 +24924,7 @@
 /obj/item/folder/black_random,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "lmF" = (
@@ -25499,8 +24943,7 @@
 	stat = 2
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/lone_buildings/outdoor_bot)
 "lmJ" = (
@@ -25547,8 +24990,7 @@
 /obj/structure/surface/table/almayer,
 /obj/item/ore/gold,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "lnL" = (
@@ -25618,8 +25060,7 @@
 /obj/structure/cargo_container/watatsumi/right,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/indoors/lone_buildings/storage_blocks)
 "lpH" = (
@@ -25672,8 +25113,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/security)
 "lrG" = (
@@ -25726,8 +25166,7 @@
 	pixel_y = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_east_street)
 "ltf" = (
@@ -25751,8 +25190,7 @@
 /area/lv522/indoors/a_block/dorms)
 "ltI" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/generic{
-	name = "\improper Westlock";
-	welded = null
+	name = "\improper Westlock"
 	},
 /turf/open/floor/corsat{
 	icon_state = "marked"
@@ -25814,8 +25252,7 @@
 	icon_state = "W"
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/nw_rockies)
 "lvX" = (
@@ -25855,8 +25292,7 @@
 	pixel_y = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "lwW" = (
@@ -25891,8 +25327,7 @@
 /obj/structure/surface/table/almayer,
 /obj/effect/spider/spiderling/nogrow,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/b_block/bar)
 "lxI" = (
@@ -25957,8 +25392,7 @@
 	icon_state = "S"
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_west_street)
 "lzk" = (
@@ -25987,8 +25421,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb2/dynamic,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/garage)
 "lzB" = (
@@ -26023,8 +25456,7 @@
 	icon_state = "W"
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/south_east_street)
 "lAj" = (
@@ -26033,8 +25465,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/dorms)
 "lAk" = (
@@ -26054,8 +25485,7 @@
 /area/lv522/indoors/a_block/fitness/glass)
 "lAn" = (
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_east_street)
 "lAD" = (
@@ -26078,8 +25508,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "lBl" = (
@@ -26169,8 +25598,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/outdoors/colony_streets/north_west_street)
 "lDc" = (
@@ -26243,14 +25671,12 @@
 	pixel_y = 3
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "lEF" = (
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/bridges/dorms_fitness)
 "lER" = (
@@ -26290,8 +25716,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/lone_buildings/outdoor_bot)
 "lGx" = (
@@ -26386,8 +25811,7 @@
 "lHH" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/landing_zone_2/ceiling)
 "lHL" = (
@@ -26417,8 +25841,7 @@
 "lId" = (
 /obj/structure/largecrate/random/barrel,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/landing_zone_2)
 "lIB" = (
@@ -26485,8 +25908,7 @@
 	icon_state = "S"
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_west_street)
 "lKl" = (
@@ -26505,8 +25927,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/lone_buildings/engineering)
 "lKC" = (
@@ -26523,8 +25944,7 @@
 /obj/effect/landmark/survivor_spawner/lv522_forecon_marksman,
 /turf/open/floor/plating{
 	dir = 8;
-	icon_state = "platingdmg3";
-	tag = null
+	icon_state = "platingdmg3"
 	},
 /area/lv522/indoors/a_block/admin)
 "lKH" = (
@@ -26548,8 +25968,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/c_block/t_comm)
 "lMH" = (
@@ -26593,7 +26012,6 @@
 "lNb" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/generic{
 	dir = 8;
-	locked = 0;
 	name = "\improper Wildcatters Office";
 	panel_open = 1
 	},
@@ -26707,8 +26125,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/mining)
 "lPY" = (
@@ -26748,8 +26165,7 @@
 	pixel_y = 3
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "lRF" = (
@@ -26844,14 +26260,12 @@
 /obj/effect/landmark/static_comms/net_one,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/indoors/lone_buildings/outdoor_bot)
 "lUi" = (
 /obj/structure/bed/chair/comfy{
-	dir = 1;
-	tag = null
+	dir = 1
 	},
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
@@ -26947,8 +26361,7 @@
 "lVV" = (
 /obj/structure/surface/table/reinforced/prison,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/casino)
 "lVY" = (
@@ -26957,8 +26370,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/dorms)
 "lVZ" = (
@@ -27048,8 +26460,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms/glass)
 "lYR" = (
@@ -27280,8 +26691,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/casino)
 "mdD" = (
@@ -27318,8 +26728,7 @@
 /area/lv522/atmos/filt)
 "meq" = (
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/dorms/glass)
 "mev" = (
@@ -27440,8 +26849,7 @@
 "miW" = (
 /obj/structure/cargo_container/kelland/left,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/lone_buildings/storage_blocks)
 "miZ" = (
@@ -27453,7 +26861,6 @@
 /area/lv522/outdoors/colony_streets/south_east_street)
 "mji" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/generic{
-	locked = 0;
 	name = "\improper Corporation Dome";
 	req_access_txt = "100"
 	},
@@ -27495,8 +26902,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/landing_zone_2/ceiling)
 "mjT" = (
@@ -27587,8 +26993,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "mlE" = (
@@ -27616,8 +27021,7 @@
 	pixel_y = 6
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "mlQ" = (
@@ -27664,8 +27068,7 @@
 /obj/structure/pipes/vents/pump,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "mmw" = (
@@ -27723,16 +27126,14 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/garden)
 "mnN" = (
 /obj/item/prop/alien/hugger,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "mnX" = (
@@ -28055,8 +27456,7 @@
 	pixel_x = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/south_west_street)
 "mwp" = (
@@ -28091,8 +27491,7 @@
 /obj/item/tool/pickaxe,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/mining)
 "mxp" = (
@@ -28108,8 +27507,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "cell_stripe";
-	tag = null
+	icon_state = "cell_stripe"
 	},
 /area/lv522/indoors/c_block/cargo)
 "mxz" = (
@@ -28151,8 +27549,7 @@
 "myC" = (
 /obj/structure/machinery/vending/snack,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/mining)
 "myE" = (
@@ -28242,8 +27639,7 @@
 /area/lv522/outdoors/nw_rockies)
 "mBc" = (
 /obj/structure/bed/chair/comfy{
-	dir = 1;
-	tag = null
+	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
@@ -28274,8 +27670,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "whitegreenfull";
-	tag = null
+	icon_state = "whitegreenfull"
 	},
 /area/lv522/indoors/a_block/fitness/glass)
 "mCq" = (
@@ -28336,8 +27731,7 @@
 /obj/structure/bed/chair,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms/glass)
 "mEx" = (
@@ -28362,8 +27756,7 @@
 /obj/structure/cargo_container/grant/left,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/indoors/lone_buildings/storage_blocks)
 "mFm" = (
@@ -28413,8 +27806,7 @@
 /obj/structure/largecrate/random/barrel/white,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/outdoors/nw_rockies)
 "mGN" = (
@@ -28434,8 +27826,7 @@
 "mHa" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/dorms/glass)
 "mHo" = (
@@ -28483,8 +27874,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/b_block/bar)
 "mIU" = (
@@ -28579,8 +27969,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/admin)
 "mKN" = (
@@ -28597,8 +27986,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_street)
 "mLp" = (
@@ -28670,8 +28058,7 @@
 "mMQ" = (
 /obj/effect/decal/cleanable/blood/xeno,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/hallway)
 "mMU" = (
@@ -28704,8 +28091,7 @@
 	pixel_y = 7
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "mNy" = (
@@ -28830,8 +28216,7 @@
 	},
 /obj/structure/foamed_metal,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms/glass)
 "mPc" = (
@@ -28853,8 +28238,7 @@
 "mPy" = (
 /obj/structure/largecrate/random/barrel/green,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/cargo)
 "mPz" = (
@@ -28872,13 +28256,11 @@
 "mPL" = (
 /obj/structure/surface/rack,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "mPQ" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/generic{
-	locked = 0;
 	welded = 1
 	},
 /obj/structure/pipes/standard/simple/hidden/green,
@@ -28927,8 +28309,7 @@
 	pixel_y = 6
 	},
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/landing_zone_2/ceiling)
 "mQo" = (
@@ -28946,8 +28327,7 @@
 /obj/item/prop/colony/used_flare,
 /turf/open/floor/prison{
 	dir = 5;
-	icon_state = "darkpurple2";
-	tag = null
+	icon_state = "darkpurple2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "mQw" = (
@@ -29039,8 +28419,7 @@
 	icon_state = "W"
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_east_street)
 "mTd" = (
@@ -29052,8 +28431,7 @@
 /obj/structure/largecrate/random/secure,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/atmos/outdoor)
 "mTx" = (
@@ -29139,8 +28517,7 @@
 "mUG" = (
 /obj/structure/platform_decoration,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/garden)
 "mUS" = (
@@ -29159,8 +28536,7 @@
 "mVi" = (
 /obj/structure/platform,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/garden)
 "mVj" = (
@@ -29206,8 +28582,7 @@
 "mVH" = (
 /obj/structure/surface/table/almayer,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms/glass)
 "mWc" = (
@@ -29221,8 +28596,7 @@
 	pixel_y = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/landing_zone_2/ceiling)
 "mWw" = (
@@ -29243,8 +28617,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/c_block/cargo)
 "mXn" = (
@@ -29311,8 +28684,7 @@
 "mZE" = (
 /obj/structure/foamed_metal,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms/glass)
 "mZJ" = (
@@ -29370,8 +28742,7 @@
 	pixel_y = 9
 	},
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/landing_zone_2/ceiling)
 "naw" = (
@@ -29379,8 +28750,7 @@
 	current_rounds = 0
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_east_street)
 "nax" = (
@@ -29443,8 +28813,7 @@
 	icon_state = "W"
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/south_west_street)
 "nbj" = (
@@ -29459,8 +28828,7 @@
 	},
 /turf/open/floor/plating{
 	dir = 8;
-	icon_state = "platingdmg3";
-	tag = null
+	icon_state = "platingdmg3"
 	},
 /area/lv522/indoors/a_block/admin)
 "nbn" = (
@@ -29528,8 +28896,7 @@
 	pixel_y = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_east_street)
 "ncA" = (
@@ -29547,8 +28914,7 @@
 	icon_state = "S"
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/nw_rockies)
 "ndb" = (
@@ -29604,8 +28970,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/outdoors/colony_streets/north_east_street)
 "neO" = (
@@ -29651,8 +29016,7 @@
 	pixel_x = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_east_street)
 "nfm" = (
@@ -29710,8 +29074,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/garden)
 "ngL" = (
@@ -29792,8 +29155,7 @@
 "niE" = (
 /obj/structure/pipes/standard/manifold/fourway/hidden/green,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/hallway)
 "niL" = (
@@ -29833,8 +29195,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/hallway)
 "njW" = (
@@ -29893,8 +29254,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/indoors/lone_buildings/storage_blocks)
 "nlz" = (
@@ -29941,8 +29301,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "nlV" = (
@@ -30167,8 +29526,7 @@
 	layer = 3.1
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "npT" = (
@@ -30201,8 +29559,7 @@
 "nqw" = (
 /obj/structure/girder,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/lone_buildings/storage_blocks)
 "nqy" = (
@@ -30252,8 +29609,7 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "nrh" = (
@@ -30270,8 +29626,7 @@
 	icon_state = "W"
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_street)
 "nru" = (
@@ -30288,8 +29643,7 @@
 /obj/structure/surface/rack,
 /obj/item/stack/sheet/metal/medium_stack,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/lone_buildings/storage_blocks)
 "nrJ" = (
@@ -30344,8 +29698,7 @@
 "nti" = (
 /obj/structure/bed/chair,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms/glass)
 "ntq" = (
@@ -30495,8 +29848,7 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "nwR" = (
@@ -30516,8 +29868,7 @@
 /obj/structure/platform_decoration,
 /obj/structure/machinery/light,
 /turf/open/floor/prison{
-	icon_state = "darkpurple2";
-	tag = null
+	icon_state = "darkpurple2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "nxj" = (
@@ -30556,8 +29907,7 @@
 	icon_state = "S"
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/south_west_street)
 "nyJ" = (
@@ -30573,8 +29923,7 @@
 /obj/structure/surface/table/almayer,
 /obj/item/device/radio,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "nzt" = (
@@ -30600,8 +29949,7 @@
 "nzU" = (
 /obj/structure/barricade/deployable,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_east_street)
 "nzZ" = (
@@ -30845,21 +30193,18 @@
 	pixel_y = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_street)
 "nHi" = (
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/landing_zone_1)
 "nHA" = (
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/cargo)
 "nHT" = (
@@ -30939,8 +30284,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "cell_stripe";
-	tag = null
+	icon_state = "cell_stripe"
 	},
 /area/lv522/indoors/lone_buildings/storage_blocks)
 "nKk" = (
@@ -31032,8 +30376,7 @@
 	pixel_x = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_street)
 "nLW" = (
@@ -31055,8 +30398,7 @@
 /obj/effect/landmark/objective_landmark/close,
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/lone_buildings/engineering)
 "nMt" = (
@@ -31082,8 +30424,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "nMC" = (
@@ -31094,8 +30435,7 @@
 	icon_state = "W"
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_street)
 "nMP" = (
@@ -31125,8 +30465,7 @@
 	pixel_x = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_street)
 "nNh" = (
@@ -31153,8 +30492,7 @@
 	icon_state = "W"
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_street)
 "nNA" = (
@@ -31163,8 +30501,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/c_block/cargo)
 "nNH" = (
@@ -31215,8 +30552,7 @@
 	icon_state = "S"
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_street)
 "nOl" = (
@@ -31229,8 +30565,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/dorms)
 "nOB" = (
@@ -31241,8 +30576,7 @@
 /obj/structure/surface/table/almayer,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/b_block/bar)
 "nOS" = (
@@ -31257,8 +30591,7 @@
 	pixel_x = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_street)
 "nOT" = (
@@ -31300,8 +30633,7 @@
 	icon_state = "pottedplant_21";
 	layer = 3.1;
 	name = "synthethic potted plant";
-	pixel_y = 14;
-	tag = null
+	pixel_y = 14
 	},
 /turf/open/floor/prison{
 	icon_state = "darkredfull2"
@@ -31385,8 +30717,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/machinery/light,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "nRJ" = (
@@ -31568,8 +30899,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/c_block/t_comm)
 "nVh" = (
@@ -31606,16 +30936,14 @@
 	pixel_x = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/south_east_street)
 "nVW" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/structure/fence,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/atmos/outdoor)
 "nVX" = (
@@ -31623,8 +30951,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_east_street)
 "nWl" = (
@@ -31640,8 +30967,7 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "nWp" = (
@@ -31660,8 +30986,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/lone_buildings/outdoor_bot)
 "nWq" = (
@@ -31716,8 +31041,7 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "nXi" = (
@@ -31730,8 +31054,7 @@
 	},
 /obj/effect/landmark/objective_landmark/close,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/south_west_street)
 "nXl" = (
@@ -31782,8 +31105,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/casino)
 "nXO" = (
@@ -31811,8 +31133,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "cell_stripe";
-	tag = null
+	icon_state = "cell_stripe"
 	},
 /area/lv522/indoors/c_block/cargo)
 "nYv" = (
@@ -31842,8 +31163,7 @@
 	pixel_x = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/south_east_street)
 "nYU" = (
@@ -31891,14 +31211,12 @@
 /obj/item/ore/uranium,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/mining)
 "nZF" = (
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/atmos/cargo_intake)
 "oaa" = (
@@ -31919,8 +31237,7 @@
 	icon_state = "S"
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/central_streets)
 "oaq" = (
@@ -31986,8 +31303,7 @@
 /obj/structure/machinery/telecomms/bus/preset_one,
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/c_block/t_comm)
 "oce" = (
@@ -32022,8 +31338,7 @@
 "odi" = (
 /obj/structure/largecrate/random/barrel/white,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_street)
 "odt" = (
@@ -32072,8 +31387,7 @@
 "odZ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/bridges/dorms_fitness)
 "oem" = (
@@ -32130,8 +31444,7 @@
 	},
 /obj/effect/spawner/gibspawner/xeno,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "oeN" = (
@@ -32170,8 +31483,7 @@
 "ofy" = (
 /obj/structure/bed/chair/wood/normal{
 	dir = 4;
-	pixel_x = -9;
-	tag = null
+	pixel_x = -9
 	},
 /turf/open/auto_turf/shale/layer0,
 /area/lv522/outdoors/colony_streets/central_streets)
@@ -32185,8 +31497,7 @@
 /obj/structure/cargo_container/kelland/left,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/indoors/lone_buildings/storage_blocks)
 "ofX" = (
@@ -32208,23 +31519,20 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/cargo)
 "oga" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/casino)
 "ogf" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/security)
 "ogA" = (
@@ -32326,8 +31634,7 @@
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "whitegreenfull";
-	tag = null
+	icon_state = "whitegreenfull"
 	},
 /area/lv522/indoors/a_block/fitness)
 "ohX" = (
@@ -32392,8 +31699,7 @@
 /obj/structure/prop/turbine_extras/border,
 /obj/structure/prop/turbine,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/landing_zone_2/ceiling)
 "oiP" = (
@@ -32409,8 +31715,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/lone_buildings/storage_blocks)
 "oiW" = (
@@ -32470,8 +31775,7 @@
 	icon_state = "medium"
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "ojy" = (
@@ -32485,8 +31789,7 @@
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/hallway)
 "okA" = (
@@ -32516,8 +31819,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "olz" = (
@@ -32606,15 +31908,13 @@
 "oot" = (
 /turf/open/floor/prison{
 	dir = 1;
-	icon_state = "darkpurple2";
-	tag = null
+	icon_state = "darkpurple2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "oow" = (
 /obj/structure/largecrate/random/barrel/yellow,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_street)
 "ooG" = (
@@ -32682,8 +31982,7 @@
 	icon_state = "W"
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_east_street)
 "oqp" = (
@@ -32742,8 +32041,7 @@
 	pixel_x = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_west_street)
 "ora" = (
@@ -32753,8 +32051,7 @@
 	layer = 3.1;
 	name = "synthethic potted plant";
 	pixel_x = -17;
-	pixel_y = 9;
-	tag = null
+	pixel_y = 9
 	},
 /turf/open/floor/plating,
 /area/lv522/indoors/c_block/cargo)
@@ -32822,8 +32119,7 @@
 	icon_state = "S"
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_west_street)
 "osN" = (
@@ -32835,16 +32131,14 @@
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/dorms)
 "osV" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/casino)
 "ote" = (
@@ -32946,8 +32240,7 @@
 "ouI" = (
 /obj/structure/cargo_container/kelland/right,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/lone_buildings/storage_blocks)
 "ouO" = (
@@ -33040,8 +32333,7 @@
 	pixel_x = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_east_street)
 "oyf" = (
@@ -33117,8 +32409,7 @@
 "ozw" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/mining)
 "ozF" = (
@@ -33190,8 +32481,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "oBf" = (
@@ -33245,8 +32535,7 @@
 /obj/structure/machinery/light,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/mining)
 "oCt" = (
@@ -33282,8 +32571,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/lone_buildings/outdoor_bot)
 "oEw" = (
@@ -33336,8 +32624,7 @@
 "oFU" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/c_block/cargo)
 "oGl" = (
@@ -33347,15 +32634,13 @@
 /obj/effect/decal/cleanable/liquid_fuel,
 /turf/open/floor/plating{
 	dir = 8;
-	icon_state = "platingdmg3";
-	tag = null
+	icon_state = "platingdmg3"
 	},
 /area/lv522/indoors/a_block/kitchen/damage)
 "oGp" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/security)
 "oGE" = (
@@ -33377,8 +32662,7 @@
 	pixel_y = -7
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "oGY" = (
@@ -33387,8 +32671,7 @@
 	pixel_y = 26
 	},
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/cargo)
 "oGZ" = (
@@ -33403,8 +32686,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms/glass)
 "oHl" = (
@@ -33423,8 +32705,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/hallway)
 "oHB" = (
@@ -33447,8 +32728,7 @@
 "oIr" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/dorms/glass)
 "oIu" = (
@@ -33470,8 +32750,7 @@
 "oIP" = (
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/cargo)
 "oJj" = (
@@ -33507,8 +32786,7 @@
 	pixel_y = 8
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "oJQ" = (
@@ -33555,8 +32833,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/cargo)
 "oKG" = (
@@ -33589,8 +32866,7 @@
 /obj/structure/machinery/autolathe,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/cargo)
 "oKQ" = (
@@ -33705,8 +32981,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/c_block/t_comm)
 "oNe" = (
@@ -33727,15 +33002,13 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/firstaid/adv/empty,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/hallway)
 "oNM" = (
 /obj/structure/machinery/light,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/casino)
 "oNQ" = (
@@ -33765,8 +33038,7 @@
 /obj/structure/machinery/space_heater/radiator/red,
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/lone_buildings/engineering)
 "oPs" = (
@@ -33808,8 +33080,7 @@
 /obj/structure/machinery/light,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/bridge)
 "oQs" = (
@@ -33850,15 +33121,13 @@
 	},
 /obj/structure/machinery/disposal,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/landing_zone_2/ceiling)
 "oRr" = (
 /obj/structure/pipes/vents/pump,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms/glass)
 "oRt" = (
@@ -33869,8 +33138,7 @@
 /obj/structure/machinery/light,
 /obj/structure/machinery/space_heater/radiator/red,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "oRG" = (
@@ -33920,8 +33188,7 @@
 /area/lv522/outdoors/colony_streets/south_street)
 "oSH" = (
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/bridges)
 "oSX" = (
@@ -33949,8 +33216,7 @@
 /area/lv522/outdoors/colony_streets/north_west_street)
 "oTg" = (
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/dorms)
 "oTl" = (
@@ -33958,8 +33224,7 @@
 /obj/effect/decal/cleanable/cobweb2/dynamic,
 /obj/item/stack/sheet/metal/medium_stack,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "oTp" = (
@@ -33984,14 +33249,12 @@
 /obj/structure/largecrate/random,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/cargo)
 "oTI" = (
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/b_block/hydro)
 "oTJ" = (
@@ -34000,16 +33263,14 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/dorms)
 "oTL" = (
 /obj/structure/largecrate/random,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/landing_zone_2)
 "oTX" = (
@@ -34047,8 +33308,7 @@
 /obj/vehicle/train/cargo/trolley,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/lone_buildings/storage_blocks)
 "oVk" = (
@@ -34095,8 +33355,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/garage)
 "oVS" = (
@@ -34109,8 +33368,7 @@
 /obj/effect/landmark/static_comms/net_one,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/indoors/lone_buildings/engineering)
 "oWq" = (
@@ -34124,8 +33382,7 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "oWK" = (
@@ -34270,15 +33527,13 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/c_block/cargo)
 "paK" = (
 /obj/structure/machinery/vending/coffee,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/admin)
 "paT" = (
@@ -34307,16 +33562,14 @@
 /obj/item/stack/sheet/wood,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/landing_zone_2)
 "pck" = (
 /obj/structure/largecrate/random/barrel/white,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/lone_buildings/storage_blocks)
 "pcr" = (
@@ -34340,8 +33593,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/indoors/lone_buildings/outdoor_bot)
 "pcO" = (
@@ -34383,8 +33635,7 @@
 	stat = 2
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "pdv" = (
@@ -34398,8 +33649,7 @@
 	icon_state = "W"
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_east_street)
 "pdB" = (
@@ -34408,8 +33658,7 @@
 	},
 /obj/structure/pipes/vents/pump,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "pdF" = (
@@ -34419,8 +33668,7 @@
 	},
 /obj/structure/machinery/light/small,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/admin)
 "pdO" = (
@@ -34495,8 +33743,7 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "pfj" = (
@@ -34570,8 +33817,7 @@
 /obj/item/prop/alien/hugger,
 /obj/structure/machinery/light,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "pfX" = (
@@ -34580,8 +33826,7 @@
 /area/lv522/indoors/a_block/admin)
 "pgl" = (
 /obj/structure/bed/chair/comfy{
-	dir = 1;
-	tag = null
+	dir = 1
 	},
 /turf/open/floor/strata{
 	dir = 4;
@@ -34613,8 +33858,7 @@
 	icon_state = "S"
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_east_street)
 "pgs" = (
@@ -34624,8 +33868,7 @@
 	},
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/prison{
-	icon_state = "darkpurple2";
-	tag = null
+	icon_state = "darkpurple2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "pgt" = (
@@ -34646,16 +33889,14 @@
 	pixel_x = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_east_street)
 "pgL" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/atmos/outdoor)
 "pha" = (
@@ -34679,8 +33920,7 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "phn" = (
@@ -34763,8 +34003,7 @@
 /obj/effect/spawner/gibspawner/xeno,
 /turf/open/floor/prison{
 	dir = 1;
-	icon_state = "darkpurple2";
-	tag = null
+	icon_state = "darkpurple2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "pjT" = (
@@ -34793,15 +34032,13 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/mining)
 "pka" = (
 /obj/structure/platform_decoration,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/cargo)
 "pkB" = (
@@ -34838,8 +34075,7 @@
 	pixel_y = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/east_central_street)
 "pme" = (
@@ -34848,8 +34084,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/landing_zone_2/ceiling)
 "pmg" = (
@@ -34863,13 +34098,11 @@
 /area/lv522/indoors/a_block/hallway)
 "png" = (
 /obj/structure/cargo_container/wy/mid{
-	health = 5000;
-	unacidable = 0
+	health = 5000
 	},
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/landing_zone_1)
 "pni" = (
@@ -34880,8 +34113,7 @@
 /obj/structure/largecrate/random/secure,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/landing_zone_1)
 "pnu" = (
@@ -34942,8 +34174,7 @@
 	icon_state = "pottedplant_21";
 	layer = 3.1;
 	name = "synthethic potted plant";
-	pixel_y = 14;
-	tag = null
+	pixel_y = 14
 	},
 /obj/effect/decal/cleanable/cobweb2,
 /obj/effect/spider/spiderling/nogrow,
@@ -34970,8 +34201,7 @@
 	flipped = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "ppD" = (
@@ -35008,8 +34238,7 @@
 /obj/item/spacecash/c1000,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/casino)
 "pqA" = (
@@ -35024,8 +34253,7 @@
 /obj/item/newspaper,
 /obj/item/tool/pen/blue/clicky,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/casino)
 "pqI" = (
@@ -35159,8 +34387,7 @@
 /area/lv522/outdoors/colony_streets/south_east_street)
 "psT" = (
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/hallway)
 "ptc" = (
@@ -35176,8 +34403,7 @@
 /obj/structure/machinery/light,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/cargo)
 "ptU" = (
@@ -35204,8 +34430,7 @@
 	pixel_x = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/landing_zone_2/ceiling)
 "puu" = (
@@ -35281,8 +34506,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 1;
-	icon_state = "darkpurple2";
-	tag = null
+	icon_state = "darkpurple2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "pwk" = (
@@ -35295,8 +34519,7 @@
 /obj/item/stack/sheet/metal/medium_stack,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/indoors/lone_buildings/storage_blocks)
 "pwu" = (
@@ -35330,8 +34553,7 @@
 /obj/structure/prop/dam/crane/damaged,
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "cell_stripe";
-	tag = null
+	icon_state = "cell_stripe"
 	},
 /area/lv522/indoors/lone_buildings/storage_blocks)
 "pwW" = (
@@ -35379,8 +34601,7 @@
 "pxS" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/dorms)
 "pxY" = (
@@ -35461,8 +34682,7 @@
 	pixel_y = 15
 	},
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/garage)
 "pzo" = (
@@ -35473,8 +34693,7 @@
 /obj/structure/barricade/wooden,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/hallway)
 "pzH" = (
@@ -35510,8 +34729,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "whitegreenfull";
-	tag = null
+	icon_state = "whitegreenfull"
 	},
 /area/lv522/indoors/a_block/fitness)
 "pAW" = (
@@ -35534,8 +34752,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/secure_closet/miner,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/mining)
 "pBF" = (
@@ -35544,8 +34761,7 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "pBK" = (
@@ -35566,15 +34782,13 @@
 	icon_state = "p_stair_full"
 	},
 /turf/open/shuttle/dropship{
-	icon_state = "rasputin3";
-	tag = null
+	icon_state = "rasputin3"
 	},
 /area/lv522/landing_zone_forecon/UD6_Typhoon)
 "pBT" = (
 /turf/open/floor/prison{
 	dir = 6;
-	icon_state = "darkpurple2";
-	tag = null
+	icon_state = "darkpurple2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "pCb" = (
@@ -35684,8 +34898,7 @@
 "pDh" = (
 /obj/structure/pipes/standard/manifold/hidden/green,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/dorms)
 "pDA" = (
@@ -35712,8 +34925,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "whitegreenfull";
-	tag = null
+	icon_state = "whitegreenfull"
 	},
 /area/lv522/indoors/a_block/fitness)
 "pDU" = (
@@ -35738,8 +34950,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "pEk" = (
@@ -35748,8 +34959,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/garage)
 "pEm" = (
@@ -35770,8 +34980,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "whitegreenfull";
-	tag = null
+	icon_state = "whitegreenfull"
 	},
 /area/lv522/indoors/a_block/fitness)
 "pEs" = (
@@ -35783,8 +34992,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "whitegreenfull";
-	tag = null
+	icon_state = "whitegreenfull"
 	},
 /area/lv522/indoors/a_block/fitness)
 "pEu" = (
@@ -35801,8 +35009,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "whitegreenfull";
-	tag = null
+	icon_state = "whitegreenfull"
 	},
 /area/lv522/indoors/a_block/fitness)
 "pEA" = (
@@ -35833,8 +35040,7 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/garden)
 "pFH" = (
@@ -35887,8 +35093,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/admin)
 "pGY" = (
@@ -35914,8 +35119,7 @@
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/bridges/dorms_fitness)
 "pIu" = (
@@ -35937,8 +35141,7 @@
 	pixel_y = 21
 	},
 /obj/structure/bed/chair/dropship/pilot{
-	dir = 1;
-	tag = null
+	dir = 1
 	},
 /obj/structure/machinery/light/double{
 	dir = 1;
@@ -35951,8 +35154,7 @@
 	pixel_y = 4
 	},
 /turf/open/shuttle/dropship{
-	icon_state = "rasputin15";
-	tag = null
+	icon_state = "rasputin15"
 	},
 /area/lv522/landing_zone_forecon/UD6_Typhoon)
 "pJd" = (
@@ -36003,8 +35205,7 @@
 	},
 /obj/structure/pipes/vents/pump,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "pJW" = (
@@ -36038,8 +35239,7 @@
 	pixel_y = 16
 	},
 /obj/structure/bed/chair/comfy{
-	dir = 1;
-	tag = null
+	dir = 1
 	},
 /turf/open/floor/prison{
 	dir = 1;
@@ -36092,7 +35292,6 @@
 "pLN" = (
 /obj/structure/machinery/door/airlock/almayer/medical{
 	dir = 2;
-	locked = 0;
 	name = "Medical Airlock"
 	},
 /obj/structure/pipes/standard/simple/hidden/green,
@@ -36153,7 +35352,6 @@
 "pMt" = (
 /obj/structure/machinery/door/airlock/almayer/medical{
 	dir = 2;
-	locked = 0;
 	name = "Medical Airlock"
 	},
 /turf/open/floor/corsat{
@@ -36261,8 +35459,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "pON" = (
@@ -36286,8 +35483,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "whitegreenfull";
-	tag = null
+	icon_state = "whitegreenfull"
 	},
 /area/lv522/indoors/a_block/fitness)
 "pPt" = (
@@ -36298,8 +35494,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "whitegreenfull";
-	tag = null
+	icon_state = "whitegreenfull"
 	},
 /area/lv522/indoors/a_block/fitness)
 "pPC" = (
@@ -36315,8 +35510,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "whitegreenfull";
-	tag = null
+	icon_state = "whitegreenfull"
 	},
 /area/lv522/indoors/a_block/fitness)
 "pPV" = (
@@ -36333,8 +35527,7 @@
 "pQx" = (
 /obj/structure/closet/firecloset/full,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/cargo)
 "pQA" = (
@@ -36368,8 +35561,7 @@
 /obj/structure/surface/table/almayer,
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/lone_buildings/outdoor_bot)
 "pQQ" = (
@@ -36397,8 +35589,7 @@
 /obj/item/clothing/gloves/black,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "whitegreenfull";
-	tag = null
+	icon_state = "whitegreenfull"
 	},
 /area/lv522/indoors/a_block/fitness)
 "pRi" = (
@@ -36434,8 +35625,7 @@
 /obj/effect/spawner/gibspawner/xeno,
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/security)
 "pRT" = (
@@ -36472,7 +35662,6 @@
 /area/lv522/indoors/a_block/dorms)
 "pTa" = (
 /obj/structure/prop/vehicles/crawler{
-	density = 1;
 	layer = 3.1
 	},
 /turf/open/asphalt/cement{
@@ -36482,8 +35671,7 @@
 "pTj" = (
 /obj/structure/machinery/vending/cigarette/colony,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms/glass)
 "pTl" = (
@@ -36496,15 +35684,13 @@
 /obj/item/trash/plate,
 /obj/structure/machinery/light,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "pTH" = (
 /obj/structure/machinery/door/airlock/hatch/cockpit/two,
 /turf/open/shuttle/dropship{
-	icon_state = "rasputin15";
-	tag = null
+	icon_state = "rasputin15"
 	},
 /area/lv522/landing_zone_forecon/UD6_Typhoon)
 "pTO" = (
@@ -36535,8 +35721,7 @@
 	},
 /obj/item/prop/alien/hugger,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "pTW" = (
@@ -36558,8 +35743,7 @@
 /obj/structure/machinery/light,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "pUo" = (
@@ -36583,8 +35767,7 @@
 "pVb" = (
 /obj/item/prop/colony/used_flare,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_east_street)
 "pVn" = (
@@ -36628,8 +35811,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/mining)
 "pVA" = (
@@ -36669,8 +35851,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/landing_zone_2/ceiling)
 "pWR" = (
@@ -36690,8 +35871,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/lone_buildings/engineering)
 "pWX" = (
@@ -36708,8 +35888,7 @@
 /obj/structure/machinery/cell_charger,
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/lone_buildings/engineering)
 "pXq" = (
@@ -36757,8 +35936,7 @@
 /obj/vehicle/train/cargo/engine,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/indoors/lone_buildings/storage_blocks)
 "pYj" = (
@@ -36804,8 +35982,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/indoors/lone_buildings/storage_blocks)
 "pZb" = (
@@ -36860,8 +36037,7 @@
 /obj/structure/surface/table/almayer,
 /obj/item/device/flashlight/lamp/green,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "qaT" = (
@@ -36900,8 +36076,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/mining)
 "qbD" = (
@@ -36993,8 +36168,7 @@
 /obj/structure/machinery/photocopier,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/landing_zone_1)
 "qda" = (
@@ -37053,8 +36227,7 @@
 	dir = 6
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "qfu" = (
@@ -37108,8 +36281,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "whitegreenfull";
-	tag = null
+	icon_state = "whitegreenfull"
 	},
 /area/lv522/indoors/a_block/fitness)
 "qhm" = (
@@ -37138,8 +36310,7 @@
 "qig" = (
 /obj/structure/bed/chair/wood/normal{
 	dir = 4;
-	pixel_x = -8;
-	tag = null
+	pixel_x = -8
 	},
 /turf/open/auto_turf/shale/layer0,
 /area/lv522/outdoors/colony_streets/central_streets)
@@ -37164,8 +36335,7 @@
 /obj/structure/machinery/recharger,
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/c_block/t_comm)
 "qiC" = (
@@ -37193,8 +36363,7 @@
 "qiJ" = (
 /obj/structure/machinery/vending/coffee,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "qiN" = (
@@ -37215,8 +36384,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/landing_zone_1)
 "qjr" = (
@@ -37271,8 +36439,7 @@
 	stat = 2
 	},
 /turf/open/shuttle/dropship{
-	icon_state = "rasputin3";
-	tag = null
+	icon_state = "rasputin3"
 	},
 /area/lv522/landing_zone_forecon/UD6_Tornado)
 "qkw" = (
@@ -37337,8 +36504,7 @@
 	pixel_y = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "qmr" = (
@@ -37357,8 +36523,7 @@
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/lone_buildings/engineering)
 "qmD" = (
@@ -37371,8 +36536,7 @@
 	pixel_x = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/atmos/cargo_intake)
 "qmM" = (
@@ -37398,7 +36562,6 @@
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/computer/overwatch/almayer/broken{
 	dir = 8;
-	layer = 2.98;
 	pixel_x = -12;
 	pixel_y = 1
 	},
@@ -37448,8 +36611,7 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms/glass)
 "qnM" = (
@@ -37468,8 +36630,7 @@
 	icon_state = "W"
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_street)
 "qnU" = (
@@ -37486,8 +36647,7 @@
 	},
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/shuttle/dropship{
-	icon_state = "rasputin6";
-	tag = null
+	icon_state = "rasputin6"
 	},
 /area/lv522/landing_zone_forecon/UD6_Typhoon)
 "qnY" = (
@@ -37495,8 +36655,7 @@
 /obj/item/prop/alien/hugger,
 /obj/structure/machinery/light,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "qot" = (
@@ -37511,14 +36670,12 @@
 "qpc" = (
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "cell_stripe";
-	tag = null
+	icon_state = "cell_stripe"
 	},
 /area/lv522/indoors/lone_buildings/storage_blocks)
 "qpg" = (
 /turf/open/shuttle/dropship{
-	icon_state = "floor8";
-	tag = null
+	icon_state = "floor8"
 	},
 /area/lv522/landing_zone_forecon/UD6_Typhoon)
 "qpq" = (
@@ -37557,8 +36714,7 @@
 /obj/structure/filingcabinet,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/landing_zone_1)
 "qqk" = (
@@ -37606,8 +36762,7 @@
 	icon_state = "p_stair_full"
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/c_block/garage)
 "qqS" = (
@@ -37615,8 +36770,7 @@
 	dir = 4
 	},
 /turf/open/shuttle/dropship{
-	icon_state = "rasputin7";
-	tag = null
+	icon_state = "rasputin7"
 	},
 /area/lv522/outdoors/w_rockies)
 "qqW" = (
@@ -37641,8 +36795,7 @@
 	pixel_y = 7
 	},
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/mining)
 "qrj" = (
@@ -37654,8 +36807,7 @@
 /area/lv522/outdoors/w_rockies)
 "qsd" = (
 /obj/structure/pipes/standard/simple/visible{
-	dir = 10;
-	tag = null
+	dir = 10
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/strata{
@@ -37709,8 +36861,7 @@
 	},
 /obj/structure/machinery/light/small,
 /turf/open/floor/prison{
-	icon_state = "darkpurple2";
-	tag = null
+	icon_state = "darkpurple2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "qsU" = (
@@ -37718,8 +36869,7 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/garden)
 "qtc" = (
@@ -37738,8 +36888,7 @@
 	icon_state = "W"
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/east_central_street)
 "qtl" = (
@@ -37815,15 +36964,13 @@
 /obj/structure/largecrate,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/landing_zone_1)
 "qvA" = (
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/landing_zone_2)
 "qvJ" = (
@@ -37835,8 +36982,7 @@
 /obj/structure/cargo_container/grant/right,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/indoors/lone_buildings/storage_blocks)
 "qvM" = (
@@ -37876,8 +37022,7 @@
 	pixel_y = 7
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "qxf" = (
@@ -37941,8 +37086,7 @@
 /obj/structure/machinery/microwave,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/landing_zone_1)
 "qxF" = (
@@ -37980,8 +37124,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "qyG" = (
@@ -38019,12 +37162,10 @@
 /area/lv522/indoors/a_block/fitness/glass)
 "qzp" = (
 /obj/structure/machinery/door/airlock/dropship_hatch/two{
-	dir = 8;
-	locked = 0
+	dir = 8
 	},
 /turf/open/shuttle/dropship{
-	icon_state = "rasputin3";
-	tag = null
+	icon_state = "rasputin3"
 	},
 /area/lv522/landing_zone_forecon/UD6_Typhoon)
 "qzw" = (
@@ -38101,8 +37242,7 @@
 "qAy" = (
 /obj/item/toy/beach_ball,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/bridges/dorms_fitness)
 "qAF" = (
@@ -38111,8 +37251,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms/glass)
 "qAX" = (
@@ -38179,8 +37318,7 @@
 /area/lv522/oob)
 "qBR" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/generic{
-	name = "\improper Northlock";
-	welded = null
+	name = "\improper Northlock"
 	},
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor/corsat{
@@ -38190,8 +37328,7 @@
 "qBW" = (
 /obj/structure/pipes/standard/manifold/hidden/green,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/admin)
 "qCd" = (
@@ -38233,8 +37370,7 @@
 	pixel_y = -8
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/b_block/bar)
 "qCL" = (
@@ -38337,8 +37473,7 @@
 	icon_state = "p_stair_full"
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "qET" = (
@@ -38395,8 +37530,7 @@
 	},
 /obj/structure/barricade/wooden,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "qGC" = (
@@ -38428,8 +37562,7 @@
 "qHa" = (
 /obj/structure/bed/chair/comfy,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "qHg" = (
@@ -38498,8 +37631,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/bridge)
 "qIJ" = (
@@ -38508,15 +37640,13 @@
 	},
 /obj/structure/pipes/vents/pump,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/cargo)
 "qJl" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/shuttle/dropship{
-	icon_state = "rasputin15";
-	tag = null
+	icon_state = "rasputin15"
 	},
 /area/lv522/landing_zone_forecon/UD6_Typhoon)
 "qJp" = (
@@ -38547,8 +37677,7 @@
 	name = "\improper UA jacket"
 	},
 /turf/open/shuttle/dropship{
-	icon_state = "rasputin3";
-	tag = null
+	icon_state = "rasputin3"
 	},
 /area/lv522/landing_zone_forecon/UD6_Typhoon)
 "qJy" = (
@@ -38564,8 +37693,7 @@
 "qJH" = (
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/c_block/t_comm)
 "qJK" = (
@@ -38630,8 +37758,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/lone_buildings/engineering)
 "qLd" = (
@@ -38660,8 +37787,7 @@
 "qLy" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor/prison{
-	icon_state = "darkpurple2";
-	tag = null
+	icon_state = "darkpurple2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "qLz" = (
@@ -38762,8 +37888,7 @@
 /obj/structure/closet/secure_closet/engineering_electrical,
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/c_block/t_comm)
 "qNG" = (
@@ -38875,8 +38000,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "whitegreenfull";
-	tag = null
+	icon_state = "whitegreenfull"
 	},
 /area/lv522/indoors/a_block/fitness)
 "qOS" = (
@@ -38936,8 +38060,7 @@
 /area/lv522/landing_zone_1/tunnel)
 "qPS" = (
 /obj/structure/machinery/door/airlock/almayer/generic{
-	dir = 1;
-	locked = 0
+	dir = 1
 	},
 /turf/open/floor/corsat{
 	icon_state = "marked"
@@ -39056,8 +38179,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 8;
-	icon_state = "darkpurple2";
-	tag = null
+	icon_state = "darkpurple2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "qRB" = (
@@ -39098,8 +38220,7 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/admin)
 "qSj" = (
@@ -39118,8 +38239,7 @@
 "qSu" = (
 /obj/structure/machinery/disposal,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/casino)
 "qSw" = (
@@ -39145,8 +38265,7 @@
 	},
 /obj/effect/landmark/objective_landmark/close,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/cargo)
 "qSP" = (
@@ -39175,8 +38294,7 @@
 	},
 /obj/structure/machinery/disposal,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/mining)
 "qTh" = (
@@ -39266,8 +38384,7 @@
 	pixel_y = -15
 	},
 /turf/open/shuttle/dropship{
-	icon_state = "rasputin15";
-	tag = null
+	icon_state = "rasputin15"
 	},
 /area/lv522/landing_zone_forecon/UD6_Typhoon)
 "qUf" = (
@@ -39291,8 +38408,7 @@
 	dir = 4
 	},
 /turf/open/shuttle/dropship{
-	icon_state = "rasputin15";
-	tag = null
+	icon_state = "rasputin15"
 	},
 /area/lv522/landing_zone_forecon/UD6_Typhoon)
 "qUh" = (
@@ -39323,8 +38439,7 @@
 	pixel_y = 4
 	},
 /turf/open/shuttle/dropship{
-	icon_state = "rasputin15";
-	tag = null
+	icon_state = "rasputin15"
 	},
 /area/lv522/landing_zone_forecon/UD6_Typhoon)
 "qUL" = (
@@ -39354,8 +38469,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "qVl" = (
@@ -39382,8 +38496,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/lone_buildings/engineering)
 "qWt" = (
@@ -39436,8 +38549,7 @@
 	},
 /obj/structure/closet,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "qXY" = (
@@ -39459,8 +38571,7 @@
 	},
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/dorms)
 "qYo" = (
@@ -39516,8 +38627,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/bridge)
 "qZh" = (
@@ -39526,8 +38636,7 @@
 /obj/effect/landmark/objective_landmark/medium,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "qZu" = (
@@ -39569,8 +38678,7 @@
 	},
 /obj/item/prop/alien/hugger,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "qZY" = (
@@ -39701,13 +38809,11 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/mining)
 "rbV" = (
 /obj/structure/prop/vehicles/crawler{
-	density = 1;
 	dir = 8;
 	layer = 3.1
 	},
@@ -39782,8 +38888,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/machinery/space_heater/radiator/red,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/b_block/bar)
 "rdq" = (
@@ -39856,8 +38961,7 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/landing_zone_2/ceiling)
 "rex" = (
@@ -39886,8 +38990,7 @@
 /area/lv522/indoors/a_block/dorm_north)
 "rfe" = (
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/bridges/corpo)
 "rfg" = (
@@ -39898,8 +39001,7 @@
 	icon_state = "W"
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/east_central_street)
 "rfi" = (
@@ -39953,8 +39055,7 @@
 	},
 /obj/effect/landmark/objective_landmark/close,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/cargo)
 "rfW" = (
@@ -39983,8 +39084,7 @@
 "rgk" = (
 /obj/structure/machinery/power/port_gen/pacman/mrs,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/cargo)
 "rgA" = (
@@ -40009,8 +39109,7 @@
 	},
 /obj/item/toy/farwadoll,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/windbreaker/observation)
 "rhh" = (
@@ -40020,19 +39119,18 @@
 /obj/structure/bed/chair/wheelchair,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/windbreaker/observation)
 "rhk" = (
-/obj/structure/machinery/door/airlock/dropship_hatch/two{
-	dir = 8
+/obj/structure/machinery/landinglight/ds1/delaytwo{
+	dir = 4
 	},
-/turf/open/shuttle/dropship{
-	icon_state = "rasputin3";
-	tag = null
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "greenfull"
 	},
-/area/lv522/landing_zone_forecon/UD6_Typhoon)
+/area/lv522/landing_zone_1)
 "rhz" = (
 /obj/structure/pipes/standard/tank/oxygen{
 	dir = 1
@@ -40044,8 +39142,7 @@
 /area/lv522/indoors/a_block/medical/glass)
 "rhB" = (
 /turf/open/shuttle/dropship{
-	icon_state = "rasputin15";
-	tag = null
+	icon_state = "rasputin15"
 	},
 /area/lv522/landing_zone_forecon/UD6_Typhoon)
 "rhF" = (
@@ -40069,8 +39166,7 @@
 	current_rounds = 0
 	},
 /turf/open/shuttle/dropship{
-	icon_state = "rasputin3";
-	tag = null
+	icon_state = "rasputin3"
 	},
 /area/lv522/landing_zone_forecon/UD6_Typhoon)
 "rii" = (
@@ -40094,8 +39190,7 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/casino)
 "riZ" = (
@@ -40148,8 +39243,7 @@
 /area/lv522/outdoors/colony_streets/east_central_street)
 "rjP" = (
 /turf/open/shuttle/dropship{
-	icon_state = "rasputin3";
-	tag = null
+	icon_state = "rasputin3"
 	},
 /area/lv522/landing_zone_forecon/UD6_Typhoon)
 "rkd" = (
@@ -40165,8 +39259,7 @@
 	dir = 4
 	},
 /turf/open/shuttle/dropship{
-	icon_state = "rasputin15";
-	tag = null
+	icon_state = "rasputin15"
 	},
 /area/lv522/landing_zone_forecon/UD6_Typhoon)
 "rkV" = (
@@ -40255,8 +39348,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/hallway)
 "rng" = (
@@ -40275,8 +39367,7 @@
 	icon_state = "S"
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/n_rockies)
 "rnq" = (
@@ -40367,8 +39458,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "whitegreenfull";
-	tag = null
+	icon_state = "whitegreenfull"
 	},
 /area/lv522/indoors/a_block/fitness)
 "rpe" = (
@@ -40412,8 +39502,7 @@
 /area/lv522/indoors/a_block/fitness)
 "rqn" = (
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/landing_zone_2)
 "rqs" = (
@@ -40424,8 +39513,7 @@
 "rqA" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/c_block/cargo)
 "rqP" = (
@@ -40452,8 +39540,7 @@
 /obj/structure/machinery/disposal,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms/glass)
 "rrI" = (
@@ -40462,8 +39549,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/landing_zone_1)
 "rrN" = (
@@ -40538,8 +39624,7 @@
 	pixel_y = 24
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "rtr" = (
@@ -40576,8 +39661,7 @@
 "rtX" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/windbreaker/observation)
 "ruc" = (
@@ -40605,8 +39689,7 @@
 "rus" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/shuttle/dropship{
-	icon_state = "rasputin3";
-	tag = null
+	icon_state = "rasputin3"
 	},
 /area/lv522/landing_zone_forecon/UD6_Typhoon)
 "ruv" = (
@@ -40639,8 +39722,7 @@
 /obj/effect/landmark/objective_landmark/close,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/garage)
 "ruY" = (
@@ -40722,8 +39804,7 @@
 	icon_state = "W"
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/south_west_street)
 "rwx" = (
@@ -40791,16 +39872,14 @@
 /obj/structure/surface/table/almayer,
 /obj/item/reagent_container/food/snacks/tofukabob,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "rxo" = (
 /obj/structure/surface/table/almayer,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/outdoors/colony_streets/north_east_street)
 "rxu" = (
@@ -40847,8 +39926,7 @@
 "ryb" = (
 /obj/structure/largecrate/random/barrel/red,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_street)
 "ryj" = (
@@ -40880,8 +39958,7 @@
 /obj/item/ore/silver,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/mining)
 "ryv" = (
@@ -40918,8 +39995,7 @@
 "ryW" = (
 /obj/structure/largecrate/random/secure,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_street)
 "rza" = (
@@ -40940,8 +40016,7 @@
 /obj/structure/surface/table/almayer,
 /obj/item/storage/beer_pack,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "rzR" = (
@@ -40965,8 +40040,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
 	dir = 1;
-	icon_state = "darkpurple2";
-	tag = null
+	icon_state = "darkpurple2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "rAt" = (
@@ -40995,8 +40069,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/bridges)
 "rAX" = (
@@ -41036,8 +40109,7 @@
 /obj/structure/closet/secure_closet/atmos_personal,
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/lone_buildings/engineering)
 "rCi" = (
@@ -41050,8 +40122,7 @@
 	dir = 4
 	},
 /turf/open/shuttle/dropship{
-	icon_state = "rasputin15";
-	tag = null
+	icon_state = "rasputin15"
 	},
 /area/lv522/landing_zone_forecon/UD6_Typhoon)
 "rCE" = (
@@ -41084,8 +40155,7 @@
 "rDb" = (
 /obj/item/device/m56d_post,
 /turf/open/shuttle/dropship{
-	icon_state = "rasputin3";
-	tag = null
+	icon_state = "rasputin3"
 	},
 /area/lv522/landing_zone_forecon/UD6_Typhoon)
 "rDu" = (
@@ -41100,8 +40170,7 @@
 	dir = 8
 	},
 /turf/open/shuttle/dropship{
-	icon_state = "rasputin15";
-	tag = null
+	icon_state = "rasputin15"
 	},
 /area/lv522/landing_zone_forecon/UD6_Typhoon)
 "rDz" = (
@@ -41109,8 +40178,7 @@
 	dir = 8
 	},
 /turf/open/shuttle/dropship{
-	icon_state = "rasputin15";
-	tag = null
+	icon_state = "rasputin15"
 	},
 /area/lv522/landing_zone_forecon/UD6_Typhoon)
 "rDM" = (
@@ -41118,8 +40186,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/hallway)
 "rEc" = (
@@ -41141,8 +40208,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/c_block/t_comm)
 "rEo" = (
@@ -41173,8 +40239,7 @@
 	pixel_x = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/east_central_street)
 "rFp" = (
@@ -41204,8 +40269,7 @@
 "rGm" = (
 /obj/item/tool/weldingtool,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/dorms)
 "rGD" = (
@@ -41223,8 +40287,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "rHl" = (
@@ -41242,8 +40305,7 @@
 	pixel_y = 6
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "rHX" = (
@@ -41270,8 +40332,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/outdoors/colony_streets/south_west_street)
 "rIn" = (
@@ -41281,8 +40342,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/lone_buildings/engineering)
 "rIr" = (
@@ -41302,16 +40362,14 @@
 /obj/structure/machinery/disposal,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/casino)
 "rIB" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/prison{
 	dir = 1;
-	icon_state = "darkpurple2";
-	tag = null
+	icon_state = "darkpurple2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "rIH" = (
@@ -41321,8 +40379,7 @@
 	pixel_y = 24
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "rIM" = (
@@ -41342,8 +40399,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/machinery/disposal,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "rJf" = (
@@ -41360,8 +40416,7 @@
 /obj/structure/surface/rack,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/outdoors/colony_streets/north_east_street)
 "rJv" = (
@@ -41408,8 +40463,7 @@
 	pixel_x = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/east_central_street)
 "rKg" = (
@@ -41433,8 +40487,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "whitegreenfull";
-	tag = null
+	icon_state = "whitegreenfull"
 	},
 /area/lv522/indoors/a_block/fitness)
 "rKW" = (
@@ -41550,8 +40603,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "whitegreenfull";
-	tag = null
+	icon_state = "whitegreenfull"
 	},
 /area/lv522/indoors/a_block/fitness)
 "rMr" = (
@@ -41592,8 +40644,7 @@
 "rNs" = (
 /obj/item/stack/sheet/wood,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/landing_zone_2)
 "rNv" = (
@@ -41629,8 +40680,7 @@
 /area/lv522/indoors/c_block/cargo)
 "rOb" = (
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/landing_zone_2/ceiling)
 "rOf" = (
@@ -41663,8 +40713,7 @@
 	},
 /obj/structure/platform_decoration{
 	dir = 6;
-	layer = 3.51;
-	tag = null
+	layer = 3.51
 	},
 /obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt/cement,
@@ -41717,8 +40766,7 @@
 "rQd" = (
 /obj/structure/closet/secure_closet/quartermaster,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/cargo)
 "rQg" = (
@@ -41769,8 +40817,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/machinery/light,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "rRr" = (
@@ -41797,8 +40844,7 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/landing_zone_2/ceiling)
 "rRJ" = (
@@ -41816,8 +40862,7 @@
 	pixel_y = 2
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/c_block/t_comm)
 "rRP" = (
@@ -41837,8 +40882,7 @@
 /obj/structure/closet,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/landing_zone_2)
 "rSd" = (
@@ -41892,8 +40936,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/pipes/vents/pump,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/b_block/bar)
 "rSW" = (
@@ -41942,8 +40985,7 @@
 	pixel_x = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/east_central_street)
 "rUr" = (
@@ -41984,8 +41026,7 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "rWu" = (
@@ -41998,8 +41039,7 @@
 	icon_state = "W"
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/south_west_street)
 "rWP" = (
@@ -42015,8 +41055,7 @@
 	},
 /obj/structure/ore_box,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/mining)
 "rXb" = (
@@ -42026,8 +41065,7 @@
 "rXE" = (
 /obj/item/stack/sheet/wood,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/cargo)
 "rXH" = (
@@ -42056,8 +41094,7 @@
 	pixel_y = 4
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_street)
 "rYq" = (
@@ -42128,8 +41165,7 @@
 /obj/structure/pipes/vents/pump,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/mining)
 "rZF" = (
@@ -42147,8 +41183,7 @@
 /area/lv522/outdoors/colony_streets/south_street)
 "rZL" = (
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/landing_zone_2/ceiling)
 "sag" = (
@@ -42172,8 +41207,7 @@
 /obj/structure/closet/crate,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/lone_buildings/storage_blocks)
 "saz" = (
@@ -42219,8 +41253,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/garage)
 "saY" = (
@@ -42252,8 +41285,7 @@
 	pixel_x = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/n_rockies)
 "sbx" = (
@@ -42264,8 +41296,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/mining)
 "sbG" = (
@@ -42315,8 +41346,7 @@
 	pixel_y = -5
 	},
 /turf/open/shuttle/dropship{
-	icon_state = "rasputin15";
-	tag = null
+	icon_state = "rasputin15"
 	},
 /area/lv522/landing_zone_forecon/UD6_Typhoon)
 "scw" = (
@@ -42324,8 +41354,7 @@
 	current_rounds = 0
 	},
 /turf/open/shuttle/dropship{
-	icon_state = "rasputin15";
-	tag = null
+	icon_state = "rasputin15"
 	},
 /area/lv522/landing_zone_forecon/UD6_Typhoon)
 "scy" = (
@@ -42337,8 +41366,7 @@
 	pixel_y = -5
 	},
 /turf/open/shuttle/dropship{
-	icon_state = "rasputin15";
-	tag = null
+	icon_state = "rasputin15"
 	},
 /area/lv522/landing_zone_forecon/UD6_Typhoon)
 "scM" = (
@@ -42365,8 +41393,7 @@
 /obj/structure/surface/table/almayer,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "sdN" = (
@@ -42396,8 +41423,7 @@
 "seA" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/hallway)
 "seG" = (
@@ -42406,8 +41432,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 8;
-	icon_state = "darkpurple2";
-	tag = null
+	icon_state = "darkpurple2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "seJ" = (
@@ -42478,8 +41503,7 @@
 	pixel_y = 2
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "sgT" = (
@@ -42497,8 +41521,7 @@
 "sha" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/hallway)
 "shc" = (
@@ -42507,8 +41530,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/casino)
 "shm" = (
@@ -42567,8 +41589,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "whitegreenfull";
-	tag = null
+	icon_state = "whitegreenfull"
 	},
 /area/lv522/indoors/a_block/fitness)
 "siX" = (
@@ -42601,8 +41622,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "whitegreenfull";
-	tag = null
+	icon_state = "whitegreenfull"
 	},
 /area/lv522/indoors/a_block/fitness)
 "sjp" = (
@@ -42613,8 +41633,7 @@
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "whitegreenfull";
-	tag = null
+	icon_state = "whitegreenfull"
 	},
 /area/lv522/indoors/a_block/fitness)
 "sjy" = (
@@ -42646,8 +41665,7 @@
 	layer = 3.1
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/c_block/mining)
 "sjS" = (
@@ -42655,8 +41673,7 @@
 /obj/item/device/sentry_computer,
 /obj/item/defenses/handheld/sentry,
 /turf/open/shuttle/dropship{
-	icon_state = "rasputin15";
-	tag = null
+	icon_state = "rasputin15"
 	},
 /area/lv522/landing_zone_forecon/UD6_Tornado)
 "sjY" = (
@@ -42743,8 +41760,7 @@
 	pixel_y = 21
 	},
 /obj/structure/bed/chair/dropship/pilot{
-	dir = 1;
-	tag = null
+	dir = 1
 	},
 /obj/structure/machinery/light/double{
 	dir = 1;
@@ -42757,8 +41773,7 @@
 	pixel_y = 4
 	},
 /turf/open/shuttle/dropship{
-	icon_state = "rasputin15";
-	tag = null
+	icon_state = "rasputin15"
 	},
 /area/lv522/landing_zone_forecon/UD6_Tornado)
 "slO" = (
@@ -42846,8 +41861,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "cell_stripe";
-	tag = null
+	icon_state = "cell_stripe"
 	},
 /area/lv522/indoors/lone_buildings/storage_blocks)
 "snR" = (
@@ -42856,8 +41870,7 @@
 /obj/item/tank/oxygen,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/mining)
 "snX" = (
@@ -42910,8 +41923,7 @@
 	icon_state = "W"
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_street)
 "spz" = (
@@ -42940,8 +41952,7 @@
 "spM" = (
 /obj/structure/machinery/light,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/cargo)
 "spW" = (
@@ -42952,14 +41963,12 @@
 	icon_state = "S"
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/south_east_street)
 "sqd" = (
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/b_block/bridge)
 "sql" = (
@@ -42990,8 +41999,7 @@
 	pixel_x = 7
 	},
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/cargo)
 "srJ" = (
@@ -43029,8 +42037,7 @@
 	icon_state = "S"
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_east_street)
 "ssl" = (
@@ -43064,8 +42071,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/lone_buildings/outdoor_bot)
 "suh" = (
@@ -43181,8 +42187,7 @@
 	pixel_x = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/landing_zone_2/ceiling)
 "swF" = (
@@ -43201,8 +42206,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/c_block/t_comm)
 "swY" = (
@@ -43244,8 +42248,7 @@
 /obj/structure/surface/table/almayer,
 /obj/effect/landmark/objective_landmark/medium,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms/glass)
 "syy" = (
@@ -43254,8 +42257,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/garage)
 "syB" = (
@@ -43324,8 +42326,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/mining)
 "sAp" = (
@@ -43357,20 +42358,17 @@
 	icon_state = "pottedplant_21";
 	layer = 3.1;
 	name = "synthethic potted plant";
-	pixel_y = 14;
-	tag = null
+	pixel_y = 14
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms/glass)
 "sAT" = (
 /obj/structure/surface/table/almayer,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/landing_zone_1)
 "sAU" = (
@@ -43384,8 +42382,7 @@
 	pixel_x = -16
 	},
 /turf/open/floor{
-	icon_state = "bcircuit";
-	tag = null
+	icon_state = "bcircuit"
 	},
 /area/lv522/atmos/east_reactor)
 "sBt" = (
@@ -43433,8 +42430,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/mining)
 "sCk" = (
@@ -43493,8 +42489,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/landing_zone_2)
 "sDS" = (
@@ -43523,8 +42518,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/lone_buildings/engineering)
 "sEc" = (
@@ -43543,8 +42537,7 @@
 	},
 /obj/item/tool/weldingtool,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/kitchen/glass)
 "sED" = (
@@ -43553,8 +42546,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/lone_buildings/storage_blocks)
 "sFf" = (
@@ -43580,8 +42572,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/b_block/hydro)
 "sFG" = (
@@ -43610,8 +42601,7 @@
 /obj/item/tool/pickaxe/silver,
 /obj/item/tool/pickaxe/silver,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/lone_buildings/storage_blocks)
 "sGt" = (
@@ -43627,8 +42617,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/c_block/t_comm)
 "sGQ" = (
@@ -43642,15 +42631,13 @@
 /obj/structure/barricade/deployable,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/shuttle/dropship{
-	icon_state = "rasputin4";
-	tag = null
+	icon_state = "rasputin4"
 	},
 /area/lv522/landing_zone_forecon/UD6_Typhoon)
 "sGY" = (
 /obj/structure/barricade/deployable,
 /turf/open/shuttle/dropship{
-	icon_state = "floor8";
-	tag = null
+	icon_state = "floor8"
 	},
 /area/lv522/landing_zone_forecon/UD6_Typhoon)
 "sHb" = (
@@ -43675,8 +42662,7 @@
 "sHg" = (
 /obj/structure/barricade/deployable,
 /turf/open/shuttle/dropship{
-	icon_state = "rasputin8";
-	tag = null
+	icon_state = "rasputin8"
 	},
 /area/lv522/landing_zone_forecon/UD6_Typhoon)
 "sHk" = (
@@ -43692,8 +42678,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/casino)
 "sHY" = (
@@ -43707,8 +42692,7 @@
 	},
 /obj/structure/platform_decoration{
 	dir = 10;
-	layer = 3.51;
-	tag = null
+	layer = 3.51
 	},
 /turf/open/floor/plating,
 /area/lv522/indoors/c_block/garage)
@@ -43716,8 +42700,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "sIr" = (
@@ -43773,8 +42756,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/lone_buildings/engineering)
 "sJI" = (
@@ -43877,8 +42859,7 @@
 /obj/effect/spider/spiderling/nogrow,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "whitegreenfull";
-	tag = null
+	icon_state = "whitegreenfull"
 	},
 /area/lv522/indoors/a_block/fitness)
 "sKS" = (
@@ -43887,8 +42868,7 @@
 	pixel_y = 11
 	},
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/garage)
 "sKU" = (
@@ -43936,8 +42916,7 @@
 "sLQ" = (
 /obj/structure/pipes/vents/pump,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "sLR" = (
@@ -43968,8 +42947,7 @@
 	pixel_x = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/nw_rockies)
 "sMa" = (
@@ -43985,8 +42963,7 @@
 	},
 /obj/structure/machinery/light/small,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/casino)
 "sML" = (
@@ -44048,8 +43025,7 @@
 	pixel_y = 27
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/b_block/bar)
 "sNU" = (
@@ -44087,8 +43063,7 @@
 /obj/structure/closet/crate,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/indoors/lone_buildings/storage_blocks)
 "sOA" = (
@@ -44121,8 +43096,7 @@
 /area/lv522/landing_zone_1)
 "sON" = (
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_west_street)
 "sOR" = (
@@ -44148,16 +43122,14 @@
 /obj/structure/machinery/vending/cola,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/b_block/bar)
 "sPb" = (
 /obj/structure/barricade/wooden,
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/admin)
 "sPh" = (
@@ -44239,8 +43211,7 @@
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/lone_buildings/engineering)
 "sQI" = (
@@ -44269,8 +43240,7 @@
 /obj/structure/surface/table/almayer,
 /obj/item/folder/black_random,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "sQT" = (
@@ -44286,8 +43256,7 @@
 /obj/item/weapon/twohanded/folded_metal_chair,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/landing_zone_1)
 "sRd" = (
@@ -44331,8 +43300,7 @@
 /obj/structure/cargo_container/wy/right,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/landing_zone_1)
 "sSk" = (
@@ -44363,8 +43331,7 @@
 	icon_state = "p_stair_full"
 	},
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/casino)
 "sSQ" = (
@@ -44395,8 +43362,7 @@
 /obj/item/ore/silver,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/mining)
 "sTr" = (
@@ -44465,8 +43431,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
 	dir = 8;
-	icon_state = "cell_stripe";
-	tag = null
+	icon_state = "cell_stripe"
 	},
 /area/lv522/indoors/c_block/cargo)
 "sUN" = (
@@ -44510,8 +43475,7 @@
 	pixel_y = 16
 	},
 /obj/structure/bed/chair/comfy{
-	dir = 1;
-	tag = null
+	dir = 1
 	},
 /turf/open/floor/prison{
 	dir = 1;
@@ -44533,8 +43497,7 @@
 /obj/item/newspaper,
 /obj/structure/machinery/light,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "sXo" = (
@@ -44543,8 +43506,7 @@
 	icon_state = "W"
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_west_street)
 "sXM" = (
@@ -44553,8 +43515,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/lone_buildings/engineering)
 "sXQ" = (
@@ -44568,8 +43529,7 @@
 	pixel_x = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_west_street)
 "sXZ" = (
@@ -44581,8 +43541,7 @@
 "sYh" = (
 /obj/structure/machinery/door/airlock/hatch/cockpit/two,
 /turf/open/shuttle/dropship{
-	icon_state = "rasputin15";
-	tag = null
+	icon_state = "rasputin15"
 	},
 /area/lv522/landing_zone_forecon/UD6_Tornado)
 "sYk" = (
@@ -44602,8 +43561,7 @@
 /obj/structure/machinery/light,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/casino)
 "sZq" = (
@@ -44702,8 +43660,7 @@
 	icon_state = "S"
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_west_street)
 "tcj" = (
@@ -44730,8 +43687,7 @@
 /obj/item/prop/colony/used_flare,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/outdoors/colony_streets/north_east_street)
 "tcz" = (
@@ -44817,8 +43773,7 @@
 	dir = 8
 	},
 /turf/open/shuttle/dropship{
-	icon_state = "rasputin15";
-	tag = null
+	icon_state = "rasputin15"
 	},
 /area/lv522/landing_zone_forecon/UD6_Typhoon)
 "tdT" = (
@@ -44838,8 +43793,7 @@
 /area/lv522/indoors/a_block/admin)
 "teh" = (
 /turf/open/floor/prison{
-	icon_state = "darkpurple2";
-	tag = null
+	icon_state = "darkpurple2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "tek" = (
@@ -44850,8 +43804,7 @@
 	},
 /obj/item/tool/pen/blue/clicky,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "tew" = (
@@ -44888,8 +43841,7 @@
 	dir = 4
 	},
 /turf/open/shuttle/dropship{
-	icon_state = "rasputin15";
-	tag = null
+	icon_state = "rasputin15"
 	},
 /area/lv522/landing_zone_forecon/UD6_Typhoon)
 "tfb" = (
@@ -44914,8 +43866,7 @@
 /obj/effect/landmark/railgun_camera_pos,
 /obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/landing_zone_1/ceiling)
 "tfP" = (
@@ -44941,8 +43892,7 @@
 "tfZ" = (
 /obj/effect/spider/spiderling/nogrow,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/lone_buildings/storage_blocks)
 "tgj" = (
@@ -44954,8 +43904,7 @@
 /obj/structure/surface/rack,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/landing_zone_1)
 "tgM" = (
@@ -44979,8 +43928,7 @@
 /obj/structure/foamed_metal,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms/glass)
 "the" = (
@@ -45034,8 +43982,7 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/garage)
 "tiQ" = (
@@ -45068,8 +44015,7 @@
 "tjh" = (
 /obj/structure/closet/firecloset/full,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/garage)
 "tjx" = (
@@ -45115,8 +44061,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/c_block/t_comm)
 "tkA" = (
@@ -45152,8 +44097,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "tlr" = (
@@ -45194,8 +44138,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/landing_zone_2/ceiling)
 "tlX" = (
@@ -45289,8 +44232,7 @@
 	},
 /obj/item/prop/alien/hugger,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "tni" = (
@@ -45317,8 +44259,7 @@
 "tnL" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/b_block/bar)
 "tnM" = (
@@ -45401,8 +44342,7 @@
 /obj/item/clipboard,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms/glass)
 "tpz" = (
@@ -45432,8 +44372,7 @@
 /obj/structure/barricade/deployable,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/outdoors/colony_streets/north_east_street)
 "tqG" = (
@@ -45454,8 +44393,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "whitegreenfull";
-	tag = null
+	icon_state = "whitegreenfull"
 	},
 /area/lv522/indoors/a_block/fitness/glass)
 "tra" = (
@@ -45491,8 +44429,7 @@
 	pixel_y = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_east_street)
 "trW" = (
@@ -45516,8 +44453,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "tsx" = (
@@ -45548,8 +44484,7 @@
 /obj/item/prop/alien/hugger,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "tsM" = (
@@ -45588,8 +44523,7 @@
 	dir = 4
 	},
 /turf/open/shuttle/dropship{
-	icon_state = "rasputin15";
-	tag = null
+	icon_state = "rasputin15"
 	},
 /area/lv522/landing_zone_forecon/UD6_Tornado)
 "tti" = (
@@ -45634,8 +44568,7 @@
 /obj/structure/cargo_container/hd/right/alt,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/landing_zone_2)
 "tuJ" = (
@@ -45655,8 +44588,7 @@
 "tuK" = (
 /obj/structure/ore_box,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/mining)
 "tvi" = (
@@ -45671,8 +44603,7 @@
 /obj/structure/prop/turbine_extras/border,
 /obj/structure/prop/turbine,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/south_west_street)
 "tvn" = (
@@ -45699,16 +44630,14 @@
 /obj/structure/bed/chair,
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/c_block/t_comm)
 "tvz" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/foamed_metal,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms/glass)
 "tvO" = (
@@ -45740,8 +44669,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "whitegreenfull";
-	tag = null
+	icon_state = "whitegreenfull"
 	},
 /area/lv522/indoors/a_block/fitness)
 "twq" = (
@@ -45819,8 +44747,7 @@
 /obj/structure/closet/crate,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/indoors/lone_buildings/storage_blocks)
 "typ" = (
@@ -45856,8 +44783,7 @@
 	pixel_y = -5
 	},
 /turf/open/shuttle/dropship{
-	icon_state = "rasputin15";
-	tag = null
+	icon_state = "rasputin15"
 	},
 /area/lv522/landing_zone_forecon/UD6_Tornado)
 "tzz" = (
@@ -45877,8 +44803,7 @@
 	current_mag = null
 	},
 /turf/open/shuttle/dropship{
-	icon_state = "rasputin15";
-	tag = null
+	icon_state = "rasputin15"
 	},
 /area/lv522/landing_zone_forecon/UD6_Typhoon)
 "tzF" = (
@@ -45886,8 +44811,7 @@
 	dir = 8
 	},
 /turf/open/shuttle/dropship{
-	icon_state = "rasputin15";
-	tag = null
+	icon_state = "rasputin15"
 	},
 /area/lv522/landing_zone_forecon/UD6_Typhoon)
 "tzY" = (
@@ -45900,8 +44824,7 @@
 	pixel_y = 25
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "tAh" = (
@@ -45932,8 +44855,7 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/garden)
 "tBb" = (
@@ -45942,7 +44864,6 @@
 /area/lv522/outdoors/colony_streets/south_east_street)
 "tBw" = (
 /obj/structure/prop/invuln/lifeboat_hatch_placeholder{
-	icon_state = "closed";
 	layer = 2.1
 	},
 /obj/structure/barricade/handrail{
@@ -45962,8 +44883,7 @@
 /area/lv522/outdoors/colony_streets/central_streets)
 "tBM" = (
 /turf/open/shuttle/dropship{
-	icon_state = "rasputin6";
-	tag = null
+	icon_state = "rasputin6"
 	},
 /area/lv522/landing_zone_forecon/UD6_Tornado)
 "tBQ" = (
@@ -45982,15 +44902,13 @@
 /obj/item/prop/alien/hugger,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "whitegreenfull";
-	tag = null
+	icon_state = "whitegreenfull"
 	},
 /area/lv522/indoors/a_block/fitness)
 "tBT" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/generic{
 	dir = 1;
-	name = "\improper Eastlock";
-	welded = null
+	name = "\improper Eastlock"
 	},
 /turf/open/floor/corsat{
 	icon_state = "marked"
@@ -46025,8 +44943,7 @@
 /area/lv522/outdoors/colony_streets/south_east_street)
 "tCR" = (
 /turf/open/shuttle/dropship{
-	icon_state = "floor8";
-	tag = null
+	icon_state = "floor8"
 	},
 /area/lv522/landing_zone_forecon/UD6_Tornado)
 "tCX" = (
@@ -46043,8 +44960,7 @@
 /area/lv522/outdoors/colony_streets/central_streets)
 "tDm" = (
 /turf/open/shuttle/dropship{
-	icon_state = "rasputin7";
-	tag = null
+	icon_state = "rasputin7"
 	},
 /area/lv522/landing_zone_forecon/UD6_Tornado)
 "tDq" = (
@@ -46152,8 +45068,7 @@
 "tEW" = (
 /obj/structure/machinery/vending/cigarette/colony,
 /obj/structure/machinery/light{
-	dir = 4;
-	tag = null
+	dir = 4
 	},
 /turf/open/floor/strata{
 	dir = 4;
@@ -46202,8 +45117,7 @@
 /obj/item/storage/bag/ore,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/mining)
 "tFx" = (
@@ -46254,7 +45168,6 @@
 /area/lv522/outdoors/colony_streets/north_street)
 "tGm" = (
 /obj/structure/machinery/door/airlock/almayer/generic{
-	locked = 0;
 	name = "\improper Corporate Liason"
 	},
 /turf/open/floor/corsat{
@@ -46269,8 +45182,7 @@
 /obj/item/stack/sheet/wood,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/outdoors/colony_streets/north_west_street)
 "tGI" = (
@@ -46307,8 +45219,7 @@
 	layer = 3.1
 	},
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/cargo)
 "tGY" = (
@@ -46337,8 +45248,7 @@
 /obj/structure/cargo_container/kelland/left,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/landing_zone_1)
 "tID" = (
@@ -46350,8 +45260,7 @@
 	dir = 8
 	},
 /turf/open/shuttle/dropship{
-	icon_state = "rasputin15";
-	tag = null
+	icon_state = "rasputin15"
 	},
 /area/lv522/landing_zone_forecon/UD6_Tornado)
 "tIM" = (
@@ -46426,8 +45335,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/mining)
 "tKo" = (
@@ -46465,8 +45373,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/landing_zone_1/ceiling)
 "tLl" = (
@@ -46516,8 +45423,7 @@
 /obj/structure/cargo_container/horizontal/blue/bottom,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/outdoors/colony_streets/north_east_street)
 "tLL" = (
@@ -46573,8 +45479,7 @@
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/lone_buildings/outdoor_bot)
 "tMS" = (
@@ -46637,8 +45542,7 @@
 	pixel_x = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/south_east_street)
 "tOo" = (
@@ -46747,8 +45651,7 @@
 "tQp" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/lone_buildings/outdoor_bot)
 "tQC" = (
@@ -46823,8 +45726,7 @@
 "tSn" = (
 /obj/structure/girder,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/admin)
 "tSo" = (
@@ -46838,8 +45740,7 @@
 	pixel_y = -5
 	},
 /turf/open/shuttle/dropship{
-	icon_state = "rasputin15";
-	tag = null
+	icon_state = "rasputin15"
 	},
 /area/lv522/landing_zone_forecon/UD6_Typhoon)
 "tSL" = (
@@ -46856,8 +45757,7 @@
 	pixel_y = -5
 	},
 /turf/open/shuttle/dropship{
-	icon_state = "rasputin15";
-	tag = null
+	icon_state = "rasputin15"
 	},
 /area/lv522/landing_zone_forecon/UD6_Typhoon)
 "tTr" = (
@@ -46890,8 +45790,7 @@
 	icon_state = "medium"
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "tTZ" = (
@@ -46947,8 +45846,7 @@
 /obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/landing_zone_1/ceiling)
 "tVv" = (
@@ -47001,8 +45899,7 @@
 /obj/item/storage/backpack,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "whitegreenfull";
-	tag = null
+	icon_state = "whitegreenfull"
 	},
 /area/lv522/indoors/a_block/fitness)
 "tXa" = (
@@ -47050,8 +45947,7 @@
 "tXg" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "tXG" = (
@@ -47062,8 +45958,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/landing_zone_1/ceiling)
 "tXS" = (
@@ -47131,8 +46026,7 @@
 "tZc" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/b_block/bridge)
 "tZh" = (
@@ -47185,8 +46079,7 @@
 /obj/item/prop/alien/hugger,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/landing_zone_2/ceiling)
 "tZR" = (
@@ -47286,8 +46179,7 @@
 "ucx" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/fitness)
 "ucD" = (
@@ -47349,8 +46241,7 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/lone_buildings/storage_blocks)
 "udR" = (
@@ -47469,8 +46360,7 @@
 "ufs" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/admin)
 "ufu" = (
@@ -47537,8 +46427,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/outdoors/colony_streets/north_east_street)
 "ugo" = (
@@ -47546,8 +46435,7 @@
 	icon_state = "p_stair_full"
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/admin)
 "ugu" = (
@@ -47560,8 +46448,7 @@
 	pixel_x = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/atmos/cargo_intake)
 "ugG" = (
@@ -47569,8 +46456,7 @@
 /obj/effect/spawner/random/tool,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/landing_zone_2)
 "ugN" = (
@@ -47594,16 +46480,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/c_block/t_comm)
 "uhf" = (
 /obj/item/prop/alien/hugger,
 /turf/open/floor/prison{
 	dir = 1;
-	icon_state = "darkpurple2";
-	tag = null
+	icon_state = "darkpurple2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "uhv" = (
@@ -47660,8 +46544,7 @@
 	pixel_y = 26
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "uic" = (
@@ -47674,8 +46557,7 @@
 	pixel_y = 26
 	},
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/bridge)
 "uie" = (
@@ -47778,8 +46660,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/garage)
 "ujy" = (
@@ -47798,8 +46679,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/outdoors/colony_streets/north_east_street)
 "ukp" = (
@@ -47825,8 +46705,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "ukK" = (
@@ -47845,8 +46724,7 @@
 "ulL" = (
 /turf/open/floor/prison{
 	dir = 8;
-	icon_state = "darkpurple2";
-	tag = null
+	icon_state = "darkpurple2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "ulZ" = (
@@ -47889,8 +46767,7 @@
 /area/lv522/indoors/c_block/cargo)
 "unE" = (
 /obj/structure/machinery/door/airlock/almayer/generic{
-	dir = 2;
-	locked = 0
+	dir = 2
 	},
 /turf/open/floor/corsat{
 	icon_state = "marked"
@@ -47913,8 +46790,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "unS" = (
@@ -47927,8 +46803,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/hallway)
 "uog" = (
@@ -47998,8 +46873,7 @@
 	pixel_x = 16
 	},
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/mining)
 "upl" = (
@@ -48104,8 +46978,7 @@
 	dir = 4
 	},
 /obj/structure/bed/chair/comfy{
-	dir = 1;
-	tag = null
+	dir = 1
 	},
 /turf/open/floor/prison,
 /area/lv522/indoors/c_block/mining)
@@ -48129,8 +47002,7 @@
 /area/lv522/indoors/a_block/security)
 "urY" = (
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_street)
 "usn" = (
@@ -48139,8 +47011,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/lone_buildings/engineering)
 "usy" = (
@@ -48154,8 +47025,7 @@
 /area/lv522/indoors/a_block/fitness)
 "usz" = (
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/fitness)
 "usJ" = (
@@ -48182,8 +47052,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/c_block/t_comm)
 "utd" = (
@@ -48327,8 +47196,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/lone_buildings/outdoor_bot)
 "uvC" = (
@@ -48425,15 +47293,13 @@
 /area/lv522/outdoors/colony_streets/south_east_street)
 "uya" = (
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/garage)
 "uye" = (
 /obj/structure/largecrate/random,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_street)
 "uyt" = (
@@ -48448,8 +47314,7 @@
 /obj/structure/machinery/disposal,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/hallway)
 "uyM" = (
@@ -48467,8 +47332,7 @@
 	pixel_y = 9
 	},
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/garage)
 "uyN" = (
@@ -48586,8 +47450,7 @@
 /area/lv522/indoors/c_block/mining)
 "uCr" = (
 /obj/structure/bed/chair/comfy{
-	dir = 1;
-	tag = null
+	dir = 1
 	},
 /turf/open/floor/corsat{
 	icon_state = "marked"
@@ -48614,8 +47477,7 @@
 	dir = 4
 	},
 /turf/open/shuttle/dropship{
-	icon_state = "rasputin15";
-	tag = null
+	icon_state = "rasputin15"
 	},
 /area/lv522/landing_zone_forecon/UD6_Tornado)
 "uDP" = (
@@ -48624,8 +47486,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "uDT" = (
@@ -48683,8 +47544,7 @@
 "uEC" = (
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "whitegreenfull";
-	tag = null
+	icon_state = "whitegreenfull"
 	},
 /area/lv522/indoors/a_block/fitness)
 "uEE" = (
@@ -48696,23 +47556,23 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_east_street)
 "uEH" = (
-/obj/structure/bed/chair/comfy{
-	dir = 1;
-	tag = null
+/obj/structure/machinery/landinglight/ds1/delaytwo{
+	dir = 8
 	},
-/turf/open/floor/prison,
-/area/lv522/indoors/a_block/dorms)
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "greenfull"
+	},
+/area/lv522/landing_zone_1)
 "uEP" = (
 /obj/structure/machinery/disposal,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/hallway)
 "uEV" = (
@@ -48775,8 +47635,7 @@
 "uFF" = (
 /obj/vehicle/train/cargo/trolley,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/cargo)
 "uFG" = (
@@ -48812,8 +47671,7 @@
 "uGl" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/cargo)
 "uGO" = (
@@ -48826,8 +47684,7 @@
 	pixel_y = 9
 	},
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/landing_zone_2/ceiling)
 "uGT" = (
@@ -48849,8 +47706,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkpurple2";
-	tag = null
+	icon_state = "darkpurple2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "uHn" = (
@@ -48871,8 +47727,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms/glass)
 "uHE" = (
@@ -48894,8 +47749,7 @@
 	},
 /obj/structure/machinery/light/small,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/hallway)
 "uIe" = (
@@ -48912,8 +47766,7 @@
 /obj/structure/pipes/vents/pump,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "whitegreenfull";
-	tag = null
+	icon_state = "whitegreenfull"
 	},
 /area/lv522/indoors/a_block/fitness)
 "uIr" = (
@@ -48931,8 +47784,7 @@
 /obj/structure/surface/rack,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/garage)
 "uIF" = (
@@ -48956,8 +47808,7 @@
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "whitegreenfull";
-	tag = null
+	icon_state = "whitegreenfull"
 	},
 /area/lv522/indoors/a_block/fitness)
 "uIW" = (
@@ -48990,23 +47841,20 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/hallway)
 "uJr" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor/prison{
 	dir = 8;
-	icon_state = "darkpurple2";
-	tag = null
+	icon_state = "darkpurple2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "uJY" = (
 /obj/structure/pipes/vents/pump,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/admin)
 "uKa" = (
@@ -49049,8 +47897,7 @@
 /area/lv522/indoors/c_block/cargo)
 "uKQ" = (
 /turf/open/shuttle/dropship{
-	icon_state = "rasputin3";
-	tag = null
+	icon_state = "rasputin3"
 	},
 /area/lv522/landing_zone_forecon/UD6_Tornado)
 "uKR" = (
@@ -49225,8 +48072,7 @@
 	pixel_y = 6
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms/glass)
 "uOd" = (
@@ -49305,8 +48151,7 @@
 /obj/effect/decal/cleanable/blood/oil,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/cargo)
 "uPo" = (
@@ -49314,8 +48159,7 @@
 /obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/landing_zone_1/ceiling)
 "uPy" = (
@@ -49337,8 +48181,7 @@
 /obj/structure/surface/table/almayer,
 /obj/item/paper/janitor,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/c_block/mining)
 "uQf" = (
@@ -49435,8 +48278,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "whitegreenfull";
-	tag = null
+	icon_state = "whitegreenfull"
 	},
 /area/lv522/indoors/a_block/fitness)
 "uRB" = (
@@ -49450,8 +48292,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "uRL" = (
@@ -49468,8 +48309,7 @@
 	icon_state = "S"
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_street)
 "uRR" = (
@@ -49503,8 +48343,7 @@
 /obj/structure/surface/table/reinforced/prison,
 /obj/effect/landmark/objective_landmark/close,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/casino)
 "uSB" = (
@@ -49596,8 +48435,7 @@
 /obj/structure/surface/table/almayer,
 /obj/item/prop/alien/hugger,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "uTY" = (
@@ -49618,8 +48456,7 @@
 /area/lv522/indoors/a_block/security/glass)
 "uUk" = (
 /obj/structure/bed/chair/wood/normal{
-	dir = 4;
-	tag = null
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet,
@@ -49633,8 +48470,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/mining)
 "uUB" = (
@@ -49661,8 +48497,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/indoors/c_block/mining)
 "uVy" = (
@@ -49687,8 +48522,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/landing_zone_1)
 "uVU" = (
@@ -49712,15 +48546,13 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms/glass)
 "uWh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/chair/comfy{
-	dir = 1;
-	tag = null
+	dir = 1
 	},
 /turf/open/floor/strata{
 	dir = 4;
@@ -49774,14 +48606,12 @@
 	icon_state = "W"
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/landing_zone_2/ceiling)
 "uXj" = (
 /turf/open/shuttle/dropship{
-	icon_state = "rasputin15";
-	tag = null
+	icon_state = "rasputin15"
 	},
 /area/lv522/landing_zone_forecon/UD6_Tornado)
 "uXp" = (
@@ -49812,8 +48642,7 @@
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/casino)
 "uYq" = (
@@ -49839,8 +48668,7 @@
 	},
 /obj/effect/landmark/objective_landmark/close,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/cargo)
 "uZO" = (
@@ -49884,8 +48712,7 @@
 	},
 /obj/effect/landmark/objective_landmark/close,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/cargo)
 "vaZ" = (
@@ -49902,8 +48729,7 @@
 	dir = 4
 	},
 /turf/open/shuttle/dropship{
-	icon_state = "rasputin15";
-	tag = null
+	icon_state = "rasputin15"
 	},
 /area/lv522/landing_zone_forecon/UD6_Tornado)
 "vbm" = (
@@ -49950,8 +48776,7 @@
 	},
 /obj/item/prop/alien/hugger,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "vbV" = (
@@ -49960,8 +48785,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/mining)
 "vbX" = (
@@ -49982,16 +48806,14 @@
 /obj/structure/barricade/wooden,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/casino)
 "vcJ" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/mining)
 "vcR" = (
@@ -50040,8 +48862,7 @@
 /obj/effect/landmark/objective_landmark/close,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/landing_zone_2/ceiling)
 "vdH" = (
@@ -50050,8 +48871,7 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/casino)
 "vdP" = (
@@ -50069,8 +48889,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/reagent_container/food/snacks/cheesyfries,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "vdZ" = (
@@ -50090,8 +48909,7 @@
 	},
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/cargo)
 "veD" = (
@@ -50176,8 +48994,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/garage)
 "vga" = (
@@ -50332,8 +49149,7 @@
 "vjn" = (
 /obj/structure/surface/rack,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/garage)
 "vjr" = (
@@ -50351,8 +49167,7 @@
 	dir = 8
 	},
 /turf/open/shuttle/dropship{
-	icon_state = "rasputin15";
-	tag = null
+	icon_state = "rasputin15"
 	},
 /area/lv522/landing_zone_forecon/UD6_Tornado)
 "vjv" = (
@@ -50377,8 +49192,7 @@
 	pixel_y = 27
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/b_block/bar)
 "vjB" = (
@@ -50394,8 +49208,7 @@
 "vjF" = (
 /obj/structure/cargo_container/horizontal/blue/bottom,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/landing_zone_2)
 "vjG" = (
@@ -50443,8 +49256,7 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "whitegreenfull";
-	tag = null
+	icon_state = "whitegreenfull"
 	},
 /area/lv522/indoors/a_block/fitness)
 "vlp" = (
@@ -50455,8 +49267,7 @@
 /obj/structure/bed/chair,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "whitegreenfull";
-	tag = null
+	icon_state = "whitegreenfull"
 	},
 /area/lv522/indoors/a_block/fitness)
 "vlv" = (
@@ -50467,8 +49278,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/garage)
 "vlN" = (
@@ -50492,8 +49302,7 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/c_block/cargo)
 "vmo" = (
@@ -50506,9 +49315,7 @@
 	},
 /area/lv522/indoors/a_block/fitness)
 "vmp" = (
-/obj/structure/machinery/door/airlock/multi_tile/almayer/generic{
-	locked = 0
-	},
+/obj/structure/machinery/door/airlock/multi_tile/almayer/generic,
 /turf/open/floor/corsat{
 	icon_state = "marked"
 	},
@@ -50527,8 +49334,7 @@
 /obj/item/stack/sheet/cardboard/full_stack,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/cargo)
 "vmQ" = (
@@ -50542,8 +49348,7 @@
 /obj/structure/pipes/vents/pump,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "vne" = (
@@ -50604,14 +49409,12 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/casino)
 "vou" = (
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/lone_buildings/outdoor_bot)
 "vov" = (
@@ -50708,8 +49511,7 @@
 /obj/vehicle/train/cargo/trolley,
 /obj/structure/machinery/light,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/cargo)
 "vqm" = (
@@ -50742,8 +49544,7 @@
 "vqW" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/casino)
 "vra" = (
@@ -50805,8 +49606,7 @@
 	layer = 2.9
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/south_west_street)
 "vsk" = (
@@ -50825,8 +49625,7 @@
 /obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/landing_zone_1/ceiling)
 "vss" = (
@@ -50865,8 +49664,7 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/bridges/corpo)
 "vtp" = (
@@ -50909,8 +49707,7 @@
 /area/lv522/indoors/b_block/hydro/glass)
 "vuc" = (
 /obj/structure/bed/chair/comfy{
-	dir = 8;
-	tag = null
+	dir = 8
 	},
 /obj/structure/machinery/light{
 	dir = 1
@@ -50932,8 +49729,7 @@
 /obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/landing_zone_1/ceiling)
 "vuY" = (
@@ -50945,8 +49741,7 @@
 	stat = 2
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_east_street)
 "vvi" = (
@@ -51092,8 +49887,7 @@
 /obj/structure/closet/wardrobe/engineering_yellow,
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/lone_buildings/engineering)
 "vzg" = (
@@ -51133,8 +49927,7 @@
 "vzu" = (
 /obj/item/prop/alien/hugger,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/b_block/bar)
 "vzw" = (
@@ -51175,8 +49968,7 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/hallway)
 "vzZ" = (
@@ -51199,8 +49991,7 @@
 /obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/landing_zone_1/ceiling)
 "vBa" = (
@@ -51214,8 +50005,7 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/b_block/bar)
 "vBd" = (
@@ -51246,8 +50036,7 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "vBB" = (
@@ -51278,8 +50067,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 8;
-	icon_state = "cell_stripe";
-	tag = null
+	icon_state = "cell_stripe"
 	},
 /area/lv522/indoors/lone_buildings/storage_blocks)
 "vBN" = (
@@ -51348,8 +50136,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "vDr" = (
@@ -51415,8 +50202,7 @@
 "vEK" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/b_block/hydro)
 "vER" = (
@@ -51460,8 +50246,7 @@
 /obj/structure/surface/table/almayer,
 /obj/item/device/flashlight/lamp,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "vFS" = (
@@ -51562,8 +50347,7 @@
 	},
 /obj/item/prop/alien/hugger,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "vHN" = (
@@ -51596,8 +50380,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 5;
-	icon_state = "darkpurple2";
-	tag = null
+	icon_state = "darkpurple2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "vIg" = (
@@ -51619,8 +50402,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/indoors/lone_buildings/storage_blocks)
 "vIy" = (
@@ -51649,8 +50431,7 @@
 /obj/structure/surface/table/almayer,
 /obj/item/newspaper,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "vJo" = (
@@ -51658,8 +50439,7 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_east_street)
 "vJr" = (
@@ -51691,8 +50471,7 @@
 "vJT" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "vKe" = (
@@ -51724,8 +50503,7 @@
 /obj/structure/surface/table/almayer,
 /obj/item/clothing/under/redpyjamas,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms/glass)
 "vKF" = (
@@ -51760,8 +50538,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/b_block/bar)
 "vLu" = (
@@ -51794,8 +50571,7 @@
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/hardpoint/locomotion/van_wheels,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/garage)
 "vLQ" = (
@@ -51805,16 +50581,14 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/casino)
 "vLR" = (
 /obj/item/stack/sheet/wood,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/casino)
 "vLW" = (
@@ -51827,8 +50601,7 @@
 "vMg" = (
 /obj/structure/safe,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/casino)
 "vMu" = (
@@ -51847,8 +50620,7 @@
 	pixel_y = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/central_streets)
 "vMJ" = (
@@ -51875,8 +50647,7 @@
 	},
 /obj/item/ammo_box/magazine/misc/flares,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/lone_buildings/storage_blocks)
 "vNi" = (
@@ -51999,8 +50770,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "vPb" = (
@@ -52116,16 +50886,14 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "vRQ" = (
 /obj/structure/surface/table/almayer,
 /obj/item/stack/sheet/metal/medium_stack,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/c_block/cargo)
 "vSc" = (
@@ -52149,8 +50917,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/c_block/mining)
 "vSJ" = (
@@ -52289,8 +51056,7 @@
 /obj/structure/powerloader_wreckage/ft,
 /obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/landing_zone_1/ceiling)
 "vVd" = (
@@ -52328,8 +51094,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/garage)
 "vVs" = (
@@ -52351,8 +51116,7 @@
 	icon_state = "p_stair_full"
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/landing_zone_2/ceiling)
 "vWe" = (
@@ -52396,8 +51160,7 @@
 	pixel_x = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_west_street)
 "vXc" = (
@@ -52409,8 +51172,7 @@
 	},
 /obj/item/prop/alien/hugger,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "vXY" = (
@@ -52433,8 +51195,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/casino)
 "vYK" = (
@@ -52459,8 +51220,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms/glass)
 "vYY" = (
@@ -52543,8 +51303,7 @@
 "wan" = (
 /obj/structure/surface/table/almayer,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "wao" = (
@@ -52628,8 +51387,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/garage)
 "wbL" = (
@@ -52676,8 +51434,7 @@
 /area/lv522/indoors/a_block/corpo/glass)
 "wcq" = (
 /obj/structure/machinery/light{
-	dir = 4;
-	tag = null
+	dir = 4
 	},
 /turf/open/floor/strata{
 	dir = 4;
@@ -52686,8 +51443,7 @@
 /area/lv522/indoors/a_block/corpo/glass)
 "wcO" = (
 /obj/structure/machinery/light{
-	dir = 4;
-	tag = null
+	dir = 4
 	},
 /obj/structure/bed/chair{
 	dir = 1
@@ -52716,8 +51472,7 @@
 "wcX" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "wdd" = (
@@ -52730,14 +51485,12 @@
 	icon_state = "W"
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_west_street)
 "wdi" = (
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/security/glass)
 "wdj" = (
@@ -52755,8 +51508,7 @@
 /obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/landing_zone_1/ceiling)
 "wdY" = (
@@ -52783,8 +51535,7 @@
 /obj/structure/closet/secure_closet/freezer/fridge/full,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/b_block/bar)
 "wes" = (
@@ -52836,8 +51587,7 @@
 	},
 /obj/structure/girder/reinforced,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "wfe" = (
@@ -52917,8 +51667,7 @@
 	pixel_y = 16
 	},
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/cargo)
 "wgn" = (
@@ -52956,16 +51705,14 @@
 	pixel_y = 4
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "whs" = (
 /obj/structure/surface/rack,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/garage)
 "whz" = (
@@ -53006,8 +51753,7 @@
 "whG" = (
 /obj/structure/largecrate/random/barrel/yellow,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/landing_zone_2)
 "whR" = (
@@ -53022,8 +51768,7 @@
 /obj/structure/machinery/vending/coffee,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/garage)
 "whZ" = (
@@ -53032,8 +51777,7 @@
 	id = "cargo_container"
 	},
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/cargo)
 "wiz" = (
@@ -53072,8 +51816,7 @@
 /area/lv522/landing_zone_1)
 "wjf" = (
 /obj/structure/bed/chair/wood/normal{
-	dir = 8;
-	tag = null
+	dir = 8
 	},
 /turf/open/floor/carpet,
 /area/lv522/indoors/c_block/casino)
@@ -53135,15 +51878,13 @@
 	},
 /obj/effect/spider/spiderling/nogrow,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/cargo)
 "wky" = (
 /obj/structure/largecrate/random/barrel/white,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/lone_buildings/storage_blocks)
 "wkC" = (
@@ -53154,8 +51895,7 @@
 	},
 /turf/open/floor/plating{
 	dir = 8;
-	icon_state = "platingdmg3";
-	tag = null
+	icon_state = "platingdmg3"
 	},
 /area/lv522/indoors/a_block/kitchen/damage)
 "wkO" = (
@@ -53186,24 +51926,9 @@
 /obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/landing_zone_1/ceiling)
-"wmg" = (
-/obj/structure/machinery/door/airlock/multi_tile/almayer/generic{
-	dir = 1;
-	locked = 0
-	},
-/obj/structure/machinery/door/poddoor/shutters/almayer/open{
-	dir = 4;
-	id = "Sec-Kitchen-Lockdown";
-	name = "\improper Storm Shutters"
-	},
-/turf/open/floor/corsat{
-	icon_state = "marked"
-	},
-/area/lv522/indoors/a_block/kitchen)
 "wmk" = (
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/lv522/indoors/a_block/fitness)
@@ -53213,8 +51938,7 @@
 /area/lv522/outdoors/w_rockies)
 "wmI" = (
 /obj/structure/bed/chair/comfy{
-	dir = 1;
-	tag = null
+	dir = 1
 	},
 /turf/open/floor{
 	icon_state = "wood"
@@ -53268,15 +51992,13 @@
 "wog" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/bridge)
 "woi" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/cargo)
 "woq" = (
@@ -53315,8 +52037,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/indoors/lone_buildings/outdoor_bot)
 "wpd" = (
@@ -53373,8 +52094,7 @@
 /obj/effect/landmark/objective_landmark/medium,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "wqt" = (
@@ -53418,8 +52138,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/c_block/cargo)
 "wrC" = (
@@ -53435,8 +52154,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "wsz" = (
@@ -53446,8 +52164,7 @@
 /obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/garage)
 "wsC" = (
@@ -53494,8 +52211,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/lone_buildings/outdoor_bot)
 "wtH" = (
@@ -53550,8 +52266,7 @@
 /obj/structure/closet/crate,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/landing_zone_1)
 "wuQ" = (
@@ -53561,8 +52276,7 @@
 /area/lv522/indoors/b_block/bar)
 "wuX" = (
 /obj/structure/bed/chair/wood/normal{
-	dir = 4;
-	tag = null
+	dir = 4
 	},
 /turf/open/floor/carpet,
 /area/lv522/indoors/c_block/casino)
@@ -53710,8 +52424,7 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "wxg" = (
@@ -53723,8 +52436,7 @@
 	pixel_x = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/south_west_street)
 "wxB" = (
@@ -53745,8 +52457,7 @@
 /obj/item/ammo_magazine/rifle/boltaction,
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/c_block/t_comm)
 "wyv" = (
@@ -53784,8 +52495,7 @@
 	pixel_y = 7
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "wyI" = (
@@ -53834,8 +52544,7 @@
 "wzJ" = (
 /obj/structure/machinery/light,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "wzS" = (
@@ -53848,8 +52557,7 @@
 	icon_state = "W"
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/east_central_street)
 "wAf" = (
@@ -53865,8 +52573,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/outdoors/colony_streets/north_east_street)
 "wBp" = (
@@ -53885,8 +52592,7 @@
 	dir = 8
 	},
 /turf/open/shuttle/dropship{
-	icon_state = "rasputin15";
-	tag = null
+	icon_state = "rasputin15"
 	},
 /area/lv522/landing_zone_forecon/UD6_Tornado)
 "wBx" = (
@@ -53963,12 +52669,10 @@
 	icon_state = "pottedplant_21";
 	layer = 3.1;
 	name = "synthethic potted plant";
-	pixel_y = 14;
-	tag = null
+	pixel_y = 14
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "wCW" = (
@@ -54034,13 +52738,11 @@
 /area/lv522/indoors/a_block/hallway)
 "wEo" = (
 /obj/structure/cargo_container/wy/mid{
-	health = 5000;
-	unacidable = 0
+	health = 5000
 	},
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/landing_zone_2)
 "wEz" = (
@@ -54076,8 +52778,7 @@
 /obj/structure/surface/table/almayer,
 /obj/effect/landmark/objective_landmark/medium,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "wEW" = (
@@ -54128,8 +52829,7 @@
 	},
 /obj/effect/landmark/objective_landmark/close,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/cargo)
 "wGG" = (
@@ -54151,8 +52851,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "wGY" = (
@@ -54162,8 +52861,7 @@
 "wHi" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/lone_buildings/storage_blocks)
 "wHj" = (
@@ -54171,8 +52869,7 @@
 /obj/structure/machinery/light,
 /obj/item/clothing/mask/gas,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/lone_buildings/storage_blocks)
 "wHo" = (
@@ -54196,8 +52893,7 @@
 /obj/structure/machinery/light,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/mining)
 "wHF" = (
@@ -54209,8 +52905,7 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/cargo)
 "wHU" = (
@@ -54228,8 +52923,7 @@
 /area/lv522/indoors/b_block/bridge)
 "wIu" = (
 /obj/structure/bed/chair/comfy{
-	dir = 1;
-	tag = null
+	dir = 1
 	},
 /turf/open/floor/prison,
 /area/lv522/indoors/c_block/mining)
@@ -54255,8 +52949,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "wJq" = (
@@ -54278,8 +52971,7 @@
 /obj/effect/landmark/objective_landmark/close,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/casino)
 "wKR" = (
@@ -54295,8 +52987,7 @@
 /obj/structure/surface/rack,
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/lone_buildings/outdoor_bot)
 "wLd" = (
@@ -54318,8 +53009,7 @@
 /obj/item/reagent_container/food/drinks/coffee,
 /obj/effect/landmark/objective_landmark/medium,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "wLU" = (
@@ -54345,8 +53035,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/casino)
 "wMF" = (
@@ -54357,8 +53046,7 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "wNl" = (
@@ -54382,8 +53070,7 @@
 "wNp" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/casino)
 "wNF" = (
@@ -54414,16 +53101,14 @@
 /obj/structure/surface/table/almayer,
 /obj/effect/landmark/objective_landmark/close,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/b_block/bar)
 "wOU" = (
 /obj/item/prop/alien/hugger,
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/c_block/t_comm)
 "wPt" = (
@@ -54431,8 +53116,7 @@
 /obj/structure/machinery/power/port_gen/pacman,
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/lone_buildings/outdoor_bot)
 "wPA" = (
@@ -54459,8 +53143,7 @@
 "wQy" = (
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/indoors/c_block/mining)
 "wRa" = (
@@ -54476,8 +53159,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "darkpurple2";
-	tag = null
+	icon_state = "darkpurple2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "wRk" = (
@@ -54625,8 +53307,7 @@
 "wTx" = (
 /obj/structure/cargo_container/kelland/left,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/mining)
 "wTy" = (
@@ -54668,8 +53349,7 @@
 /obj/item/ore/diamond,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/mining)
 "wUx" = (
@@ -54677,8 +53357,7 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/admin)
 "wUL" = (
@@ -54754,8 +53433,7 @@
 "wXQ" = (
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/outdoors/colony_streets/north_east_street)
 "wYa" = (
@@ -54849,8 +53527,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/b_block/bar)
 "wZI" = (
@@ -54860,8 +53537,7 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/cargo)
 "xaj" = (
@@ -54872,8 +53548,7 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/admin)
 "xay" = (
@@ -54884,15 +53559,13 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "xaD" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/dorms)
 "xaM" = (
@@ -54921,8 +53594,7 @@
 	pixel_y = 4
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/c_block/mining)
 "xbj" = (
@@ -54958,8 +53630,7 @@
 /obj/structure/pipes/vents/pump,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/hallway)
 "xce" = (
@@ -54967,8 +53638,7 @@
 /area/lv522/atmos/command_centre)
 "xci" = (
 /obj/structure/bed/chair/comfy{
-	dir = 1;
-	tag = null
+	dir = 1
 	},
 /turf/open/floor/carpet,
 /area/lv522/indoors/b_block/bar)
@@ -54980,8 +53650,7 @@
 /obj/effect/landmark/static_comms/net_two,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/indoors/c_block/mining)
 "xcE" = (
@@ -55018,8 +53687,7 @@
 /area/lv522/indoors/c_block/mining)
 "xcY" = (
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/landing_zone_1)
 "xdb" = (
@@ -55137,8 +53805,7 @@
 /obj/structure/largecrate/random/barrel/yellow,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/landing_zone_1)
 "xfX" = (
@@ -55211,8 +53878,7 @@
 "xhq" = (
 /obj/structure/closet,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "xhu" = (
@@ -55227,8 +53893,7 @@
 "xhB" = (
 /obj/structure/closet/firecloset/full,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "xhD" = (
@@ -55252,8 +53917,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/indoors/lone_buildings/storage_blocks)
 "xic" = (
@@ -55264,8 +53928,7 @@
 "xig" = (
 /obj/structure/closet/crate,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/lone_buildings/storage_blocks)
 "xiu" = (
@@ -55285,8 +53948,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "xiY" = (
@@ -55304,8 +53966,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/bridge)
 "xju" = (
@@ -55321,16 +53982,14 @@
 /obj/structure/machinery/cm_vending/sorted/tech/comp_storage,
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/lone_buildings/outdoor_bot)
 "xjC" = (
 /obj/structure/pipes/vents/pump,
 /obj/structure/closet,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "xjF" = (
@@ -55356,8 +54015,7 @@
 	},
 /obj/item/prop/alien/hugger,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/windbreaker/observation)
 "xjY" = (
@@ -55369,8 +54027,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/bridge)
 "xka" = (
@@ -55393,8 +54050,7 @@
 	pixel_y = -5
 	},
 /turf/open/shuttle/dropship{
-	icon_state = "rasputin15";
-	tag = null
+	icon_state = "rasputin15"
 	},
 /area/lv522/landing_zone_forecon/UD6_Tornado)
 "xkr" = (
@@ -55415,8 +54071,7 @@
 "xkB" = (
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/atmos/outdoor)
 "xkO" = (
@@ -55426,8 +54081,7 @@
 /obj/structure/closet/crate,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/mining)
 "xlq" = (
@@ -55435,8 +54089,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkpurple2";
-	tag = null
+	icon_state = "darkpurple2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "xly" = (
@@ -55477,8 +54130,7 @@
 /obj/structure/surface/table/almayer,
 /obj/item/device/flashlight/lamp,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/mining)
 "xlY" = (
@@ -55487,8 +54139,7 @@
 	},
 /obj/structure/machinery/vending/coffee,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/mining)
 "xmj" = (
@@ -55496,8 +54147,7 @@
 	icon_state = "S"
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/nw_rockies)
 "xmk" = (
@@ -55532,8 +54182,7 @@
 	},
 /obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/landing_zone_1/ceiling)
 "xnk" = (
@@ -55582,8 +54231,7 @@
 /obj/structure/surface/table/almayer,
 /obj/effect/landmark/objective_landmark/science,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/hallway)
 "xnI" = (
@@ -55612,8 +54260,7 @@
 	},
 /obj/item/storage/toolbox/electrical,
 /obj/structure/machinery/light{
-	dir = 4;
-	tag = null
+	dir = 4
 	},
 /turf/open/floor/strata{
 	dir = 4;
@@ -55624,22 +54271,19 @@
 /obj/structure/largecrate/random/barrel/red,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/lone_buildings/storage_blocks)
 "xpg" = (
 /obj/structure/prop/server_equipment/yutani_server,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/nw_rockies)
 "xpu" = (
 /obj/structure/platform,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/dorms)
 "xpH" = (
@@ -55658,8 +54302,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/outdoors/colony_streets/north_east_street)
 "xqd" = (
@@ -55686,16 +54329,14 @@
 "xqV" = (
 /obj/structure/cargo_container/kelland/right,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/mining)
 "xqY" = (
 /obj/structure/cargo_container/kelland/right,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/landing_zone_1)
 "xrr" = (
@@ -55770,8 +54411,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/c_block/t_comm)
 "xtk" = (
@@ -55831,8 +54471,7 @@
 /obj/structure/cargo_container/watatsumi/right,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/outdoors/colony_streets/north_west_street)
 "xvl" = (
@@ -55851,8 +54490,7 @@
 /area/lv522/indoors/c_block/bridge)
 "xvG" = (
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/b_block/bar)
 "xvQ" = (
@@ -55863,8 +54501,7 @@
 /area/lv522/indoors/lone_buildings/engineering)
 "xvW" = (
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/bridges)
 "xwv" = (
@@ -55946,8 +54583,7 @@
 	pixel_x = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_west_street)
 "xxU" = (
@@ -55969,16 +54605,14 @@
 "xyi" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "xym" = (
 /obj/structure/closet/secure_closet/engineering_electrical,
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/lone_buildings/outdoor_bot)
 "xyL" = (
@@ -56061,8 +54695,7 @@
 	icon_state = "W"
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_west_street)
 "xAO" = (
@@ -56089,8 +54722,7 @@
 	pixel_y = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/south_west_street)
 "xAZ" = (
@@ -56166,8 +54798,7 @@
 "xCY" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/garage)
 "xDl" = (
@@ -56207,8 +54838,7 @@
 	pixel_x = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/south_west_street)
 "xDJ" = (
@@ -56220,8 +54850,7 @@
 /obj/structure/cargo_container/kelland/left,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/outdoors/colony_streets/north_west_street)
 "xDM" = (
@@ -56262,14 +54891,12 @@
 /obj/structure/cargo_container/kelland/right,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/outdoors/colony_streets/north_west_street)
 "xEB" = (
 /obj/structure/bed/chair/comfy{
-	dir = 1;
-	tag = null
+	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
@@ -56303,8 +54930,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/admin)
 "xFG" = (
@@ -56338,8 +54964,7 @@
 /obj/item/reagent_container/glass/bucket/janibucket,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/mining)
 "xHj" = (
@@ -56367,8 +54992,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spider/spiderling/nogrow,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/dorms)
 "xIv" = (
@@ -56399,8 +55023,7 @@
 	icon_state = "S"
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/landing_zone_2/ceiling)
 "xJF" = (
@@ -56460,8 +55083,7 @@
 	dir = 8
 	},
 /turf/open/shuttle/dropship{
-	icon_state = "rasputin15";
-	tag = null
+	icon_state = "rasputin15"
 	},
 /area/lv522/landing_zone_forecon/UD6_Typhoon)
 "xKk" = (
@@ -56476,8 +55098,7 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
 "xKO" = (
@@ -56544,8 +55165,7 @@
 	pixel_y = 16
 	},
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/cargo)
 "xMu" = (
@@ -56557,8 +55177,7 @@
 "xMz" = (
 /obj/structure/machinery/disposal,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/b_block/bar)
 "xMO" = (
@@ -56602,8 +55221,7 @@
 	dir = 8
 	},
 /turf/open/shuttle/dropship{
-	icon_state = "rasputin15";
-	tag = null
+	icon_state = "rasputin15"
 	},
 /area/lv522/landing_zone_forecon/UD6_Tornado)
 "xNw" = (
@@ -56680,8 +55298,7 @@
 "xPj" = (
 /obj/structure/largecrate/random,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/garage)
 "xPo" = (
@@ -56725,8 +55342,7 @@
 	pixel_x = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_west_street)
 "xPW" = (
@@ -56749,8 +55365,7 @@
 "xPY" = (
 /obj/structure/fence,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/atmos/outdoor)
 "xQc" = (
@@ -56785,14 +55400,12 @@
 /obj/effect/landmark/objective_landmark/science,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/hallway)
 "xRg" = (
 /obj/structure/bed/chair/comfy{
-	dir = 1;
-	tag = null
+	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
@@ -56864,8 +55477,7 @@
 "xRE" = (
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/outdoors/colony_streets/north_west_street)
 "xRG" = (
@@ -56874,8 +55486,7 @@
 	pixel_y = 7
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms/glass)
 "xRI" = (
@@ -56894,8 +55505,7 @@
 /area/lv522/outdoors/colony_streets/north_street)
 "xRM" = (
 /obj/structure/machinery/door/airlock/dropship_hatch/two{
-	dir = 8;
-	locked = 0
+	dir = 8
 	},
 /obj/structure/machinery/door/poddoor/shutters/almayer{
 	dir = 4;
@@ -56903,8 +55513,7 @@
 	indestructible = 1
 	},
 /turf/open/shuttle/dropship{
-	icon_state = "rasputin3";
-	tag = null
+	icon_state = "rasputin3"
 	},
 /area/lv522/landing_zone_forecon/UD6_Tornado)
 "xRQ" = (
@@ -56968,16 +55577,14 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/mining)
 "xTs" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "whitegreenfull";
-	tag = null
+	icon_state = "whitegreenfull"
 	},
 /area/lv522/indoors/a_block/fitness)
 "xTJ" = (
@@ -57013,8 +55620,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/b_block/bar)
 "xUx" = (
@@ -57095,8 +55701,7 @@
 /area/lv522/atmos/cargo_intake)
 "xWf" = (
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/bridges/dorms_fitness)
 "xWx" = (
@@ -57121,8 +55726,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/hallway)
 "xWF" = (
@@ -57176,8 +55780,7 @@
 /obj/structure/foamed_metal,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms/glass)
 "xXN" = (
@@ -57287,8 +55890,7 @@
 /obj/item/tool/pen/blue/clicky,
 /obj/effect/landmark/objective_landmark/science,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/hallway)
 "yaf" = (
@@ -57309,20 +55911,17 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/mining)
 "yar" = (
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/landing_zone_2/ceiling)
 "yat" = (
 /obj/structure/machinery/door/airlock/almayer/security/glass{
-	locked = 0;
 	name = "\improper Marshall Office Armory"
 	},
 /obj/structure/pipes/standard/simple/hidden/green{
@@ -57385,8 +55984,7 @@
 /obj/effect/spawner/random/toolbox,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/garage)
 "yca" = (
@@ -57406,8 +56004,7 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms/glass)
 "ycv" = (
@@ -57488,8 +56085,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/b_block/bar)
 "ydV" = (
@@ -57513,8 +56109,7 @@
 	},
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "floor_marked";
-	tag = null
+	icon_state = "floor_marked"
 	},
 /area/lv522/outdoors/colony_streets/north_west_street)
 "yeM" = (
@@ -57530,8 +56125,7 @@
 	pixel_x = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_west_street)
 "yeS" = (
@@ -57593,8 +56187,7 @@
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/security)
 "ygJ" = (
@@ -57650,8 +56243,7 @@
 "yhU" = (
 /obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/landing_zone_1/ceiling)
 "yif" = (
@@ -57775,8 +56367,7 @@
 "yjL" = (
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "whitegreenfull";
-	tag = null
+	icon_state = "whitegreenfull"
 	},
 /area/lv522/oob)
 "yjP" = (
@@ -57789,8 +56380,7 @@
 /obj/item/tool/screwdriver,
 /obj/effect/landmark/objective_landmark/close,
 /turf/open/floor/prison{
-	icon_state = "darkbrownfull2";
-	tag = null
+	icon_state = "darkbrownfull2"
 	},
 /area/lv522/landing_zone_2/ceiling)
 "yjT" = (
@@ -57814,15 +56404,13 @@
 /obj/item/tank/emergency_oxygen/engi,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2";
-	tag = null
+	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms/glass)
 "ykc" = (
 /turf/open/floor/plating{
 	dir = 8;
-	icon_state = "platingdmg3";
-	tag = null
+	icon_state = "platingdmg3"
 	},
 /area/lv522/indoors/a_block/bridges/op_centre)
 "yke" = (
@@ -57846,8 +56434,7 @@
 "ykL" = (
 /turf/open/floor/prison{
 	dir = 4;
-	icon_state = "darkyellowfull2";
-	tag = null
+	icon_state = "darkyellowfull2"
 	},
 /area/lv522/indoors/lone_buildings/outdoor_bot)
 "ykR" = (
@@ -57858,8 +56445,7 @@
 	pixel_x = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate";
-	tag = null
+	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_west_street)
 "ykT" = (
@@ -60618,7 +59204,7 @@ tns
 fOc
 uTd
 oyf
-hqY
+tns
 fOc
 uTd
 oyf
@@ -60628,7 +59214,7 @@ uTd
 oyf
 tns
 fOc
-ryU
+rhk
 ryU
 sOM
 vYK
@@ -61876,8 +60462,8 @@ pUc
 qst
 qLz
 qVl
-rhk
-rhk
+qzp
+qzp
 rFp
 sdE
 sIx
@@ -63335,14 +61921,6 @@ pkH
 pwH
 sCk
 vJj
-nFj
-aGS
-dhP
-vJj
-jIk
-aGS
-dhP
-enJ
 jIk
 aGS
 dhP
@@ -63352,7 +61930,15 @@ aGS
 dhP
 vJj
 jIk
-ryU
+aGS
+dhP
+vJj
+jIk
+aGS
+dhP
+vJj
+jIk
+uEH
 ryU
 gPv
 gVn
@@ -73054,7 +71640,7 @@ nwj
 nLm
 qxb
 wqn
-uEH
+cve
 vJT
 sLQ
 nLm
@@ -83709,7 +82295,7 @@ sjy
 kqb
 kqb
 mUS
-wmg
+egP
 kqb
 kqb
 pGl

--- a/maps/map_files/LV522_Chances_Claim/LV522_Chances_Claim.dmm
+++ b/maps/map_files/LV522_Chances_Claim/LV522_Chances_Claim.dmm
@@ -33500,10 +33500,6 @@
 	icon_state = "darkredfull2"
 	},
 /area/lv522/indoors/a_block/bridges/op_centre)
-"oZq" = (
-/obj/structure/machinery/landinglight/ds1/delayone,
-/turf/open/floor/plating,
-/area/lv522/landing_zone_1)
 "oZC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/pipes/standard/simple/hidden/green,
@@ -61241,7 +61237,7 @@ lBl
 ttT
 pkH
 eyy
-oZq
+nFj
 nFj
 nFj
 sYH

--- a/maps/map_files/LV522_Chances_Claim/LV522_Chances_Claim.dmm
+++ b/maps/map_files/LV522_Chances_Claim/LV522_Chances_Claim.dmm
@@ -5351,8 +5351,8 @@
 	},
 /area/lv522/oob)
 "das" = (
-/obj/structure/machinery/landinglight/ds1/delaythree,
 /obj/effect/landmark/lv624/fog_blocker/short,
+/obj/structure/machinery/landinglight/ds1/delayone,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1)
 "daz" = (
@@ -8790,8 +8790,8 @@
 	},
 /area/lv522/outdoors/colony_streets/central_streets)
 "eyy" = (
-/obj/structure/machinery/landinglight/ds1/delaytwo,
 /obj/effect/landmark/lv624/fog_blocker/short,
+/obj/structure/machinery/landinglight/ds1,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1)
 "eyM" = (
@@ -11023,8 +11023,8 @@
 	},
 /area/lv522/outdoors/colony_streets/east_central_street)
 "fBL" = (
-/obj/structure/machinery/landinglight/ds1,
 /obj/effect/landmark/lv624/fog_blocker/short,
+/obj/structure/machinery/landinglight/ds1/delaytwo,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -11735,8 +11735,8 @@
 	},
 /area/lv522/atmos/east_reactor/east)
 "fSo" = (
-/obj/structure/machinery/landinglight/ds1/delaytwo,
 /obj/effect/landmark/lv624/fog_blocker/short,
+/obj/structure/machinery/landinglight/ds1,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -14322,8 +14322,8 @@
 	},
 /area/lv522/indoors/b_block/bridge)
 "haf" = (
-/obj/structure/machinery/landinglight/ds1,
 /obj/effect/landmark/lv624/fog_blocker/short,
+/obj/structure/machinery/landinglight/ds1/delaytwo,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1)
 "hag" = (
@@ -28788,8 +28788,8 @@
 	},
 /area/lv522/indoors/a_block/hallway)
 "naS" = (
-/obj/structure/machinery/landinglight/ds1/delayone,
 /obj/effect/landmark/lv624/fog_blocker/short,
+/obj/structure/machinery/landinglight/ds1/delaythree,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1)
 "naZ" = (
@@ -29093,10 +29093,10 @@
 /turf/open/floor/plating,
 /area/lv522/atmos/filt)
 "nhi" = (
-/obj/structure/machinery/landinglight/ds1/delaythree{
+/obj/effect/landmark/lv624/fog_blocker/short,
+/obj/structure/machinery/landinglight/ds1/delaytwo{
 	dir = 4
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1)
 "nhs" = (
@@ -33500,6 +33500,10 @@
 	icon_state = "darkredfull2"
 	},
 /area/lv522/indoors/a_block/bridges/op_centre)
+"oZq" = (
+/obj/structure/machinery/landinglight/ds1/delayone,
+/turf/open/floor/plating,
+/area/lv522/landing_zone_1)
 "oZC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/pipes/standard/simple/hidden/green,
@@ -34473,10 +34477,10 @@
 /turf/open/auto_turf/shale/layer1,
 /area/lv522/outdoors/colony_streets/central_streets)
 "pvd" = (
-/obj/structure/machinery/landinglight/ds1/delaythree{
+/obj/effect/landmark/lv624/fog_blocker/short,
+/obj/structure/machinery/landinglight/ds1/delayone{
 	dir = 4
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -34540,10 +34544,10 @@
 	},
 /area/lv522/indoors/a_block/fitness)
 "pwH" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
 /obj/structure/machinery/landinglight/ds1/delayone{
 	dir = 8
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -39123,7 +39127,7 @@
 	},
 /area/lv522/outdoors/colony_streets/windbreaker/observation)
 "rhk" = (
-/obj/structure/machinery/landinglight/ds1/delaytwo{
+/obj/structure/machinery/landinglight/ds1/delayone{
 	dir = 4
 	},
 /turf/open/floor/prison{
@@ -42434,10 +42438,10 @@
 	},
 /area/lv522/indoors/c_block/mining)
 "sCk" = (
-/obj/structure/machinery/landinglight/ds1/delayone{
+/obj/effect/landmark/lv624/fog_blocker/short,
+/obj/structure/machinery/landinglight/ds1{
 	dir = 8
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1)
 "sCp" = (
@@ -47560,7 +47564,7 @@
 	},
 /area/lv522/outdoors/colony_streets/north_east_street)
 "uEH" = (
-/obj/structure/machinery/landinglight/ds1/delaytwo{
+/obj/structure/machinery/landinglight/ds1/delayone{
 	dir = 8
 	},
 /turf/open/floor/prison{
@@ -47951,7 +47955,7 @@
 /area/lv522/indoors/a_block/bridges/corpo_fitness)
 "uLz" = (
 /obj/effect/landmark/hunter_secondary,
-/obj/structure/machinery/landinglight/ds1/delayone{
+/obj/structure/machinery/landinglight/ds1{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -50206,7 +50210,7 @@
 	},
 /area/lv522/indoors/b_block/hydro)
 "vER" = (
-/obj/structure/machinery/landinglight/ds1/delaythree{
+/obj/structure/machinery/landinglight/ds1/delaytwo{
 	dir = 1
 	},
 /turf/open/floor/prison{
@@ -54906,7 +54910,7 @@
 /turf/closed/wall/mineral/bone_resin,
 /area/lv522/oob)
 "xEH" = (
-/obj/structure/machinery/landinglight/ds1/delayone{
+/obj/structure/machinery/landinglight/ds1{
 	dir = 1
 	},
 /turf/open/floor/prison{
@@ -59196,9 +59200,6 @@ pLm
 pkH
 pvd
 nhi
-tns
-fOc
-uTd
 oyf
 tns
 fOc
@@ -59209,11 +59210,14 @@ fOc
 uTd
 oyf
 tns
+fOc
+uTd
+oyf
 uLz
+fOc
 uTd
 oyf
 tns
-fOc
 rhk
 ryU
 sOM
@@ -59669,7 +59673,7 @@ sYH
 nFj
 nFj
 bhy
-vTO
+gnf
 ryU
 wes
 pxb
@@ -59896,7 +59900,7 @@ sYH
 sYH
 nFj
 sYH
-orU
+vTO
 ryU
 wiY
 pxb
@@ -60123,7 +60127,7 @@ sYH
 sYH
 sYH
 sYH
-dMY
+orU
 ryU
 wiY
 pxb
@@ -60350,7 +60354,7 @@ sYH
 sYH
 nFj
 nFj
-gnf
+dMY
 ryU
 wiY
 pxb
@@ -60577,7 +60581,7 @@ sYH
 sYH
 nFj
 nFj
-vTO
+gnf
 ryU
 wiY
 pxb
@@ -60804,7 +60808,7 @@ sYH
 sYH
 nFj
 nFj
-orU
+vTO
 ryU
 wiY
 pxb
@@ -61031,7 +61035,7 @@ sYH
 sYH
 sYH
 sYH
-dMY
+orU
 ryU
 wiY
 pxb
@@ -61237,9 +61241,9 @@ lBl
 ttT
 pkH
 eyy
+oZq
 nFj
 nFj
-nFj
 sYH
 sYH
 sYH
@@ -61258,7 +61262,7 @@ sYH
 sYH
 nFj
 sYH
-gnf
+dMY
 ryU
 wiY
 pxb
@@ -61485,7 +61489,7 @@ sYH
 nFj
 nFj
 sYH
-vTO
+gnf
 ryU
 wjE
 pxb
@@ -61920,7 +61924,6 @@ oKG
 pkH
 pwH
 sCk
-vJj
 jIk
 aGS
 dhP
@@ -61938,6 +61941,7 @@ aGS
 dhP
 vJj
 jIk
+aGS
 uEH
 ryU
 gPv

--- a/maps/map_files/LV624/LV624.dmm
+++ b/maps/map_files/LV624/LV624.dmm
@@ -2332,12 +2332,6 @@
 	icon_state = "warnplate"
 	},
 /area/lv624/ground/river/east_river)
-"akG" = (
-/obj/structure/machinery/floodlight/landing,
-/turf/open/floor/mech_bay_recharge_floor{
-	name = "Shuttle Landing Lights"
-	},
-/area/lv624/lazarus/landing_zones/lz1)
 "akJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6895,10 +6889,6 @@
 	icon_state = "warning"
 	},
 /area/lv624/lazarus/landing_zones/lz1)
-"aDH" = (
-/obj/effect/decal/warning_stripes,
-/turf/open/floor/plating,
-/area/lv624/lazarus/landing_zones/lz1)
 "aDI" = (
 /obj/structure/machinery/landinglight/ds1/delaytwo,
 /turf/open/floor/plating,
@@ -8665,20 +8655,6 @@
 "aJS" = (
 /obj/effect/landmark/hunter_primary,
 /turf/open/floor,
-/area/lv624/lazarus/landing_zones/lz1)
-"aJT" = (
-/obj/effect/decal/warning_stripes,
-/obj/structure/machinery/landinglight/ds1{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/lv624/lazarus/landing_zones/lz1)
-"aJU" = (
-/obj/effect/decal/warning_stripes,
-/obj/structure/machinery/landinglight/ds1{
-	dir = 8
-	},
-/turf/open/floor/plating,
 /area/lv624/lazarus/landing_zones/lz1)
 "aJZ" = (
 /obj/structure/closet,
@@ -21949,9 +21925,10 @@
 /turf/open/gm/grass,
 /area/lv624/lazarus/landing_zones/lz1)
 "uVx" = (
-/turf/open/floor{
-	dir = 6;
-	icon_state = "warning"
+/obj/structure/machinery/floodlight/landing,
+/obj/effect/decal/warning_stripes,
+/turf/open/floor/mech_bay_recharge_floor{
+	name = "Shuttle Landing Lights"
 	},
 /area/lv624/lazarus/landing_zones/lz1)
 "uVU" = (
@@ -56625,7 +56602,7 @@ acb
 avS
 acb
 asN
-akG
+uVx
 aDG
 aDG
 aDG
@@ -56637,7 +56614,7 @@ aHu
 aGz
 aGz
 aGz
-akG
+uVx
 aGz
 aGz
 aGz
@@ -56649,7 +56626,7 @@ aDG
 aDG
 aDG
 aDG
-aMq
+uVx
 aky
 aky
 aky
@@ -56854,18 +56831,18 @@ btb
 uZq
 aDG
 aHu
-aDH
-aEj
-aEj
-aFK
-aGe
+ank
 aGB
 aEj
 aFK
 aGe
 aGB
 aEj
-aJT
+aFK
+aGe
+aGB
+aEj
+aFK
 aGe
 aGB
 aEj
@@ -56875,8 +56852,8 @@ aGB
 aEj
 aFK
 aGe
-akG
-aDH
+aGB
+ank
 aMq
 aky
 aky
@@ -57082,7 +57059,7 @@ lke
 aGz
 aGz
 aGz
-aDI
+aDJ
 ank
 ank
 ano
@@ -57310,7 +57287,7 @@ aDM
 aDM
 aDM
 hSa
-aDJ
+aDK
 ank
 ank
 ank
@@ -57538,7 +57515,7 @@ btF
 btF
 btF
 aDi
-aDK
+aDL
 ank
 ank
 ank
@@ -57766,7 +57743,7 @@ aky
 dbY
 btF
 aDi
-aDL
+aDI
 ank
 ank
 ank
@@ -57994,7 +57971,7 @@ aky
 aky
 btF
 aDi
-aDI
+aDJ
 ank
 ank
 ank
@@ -58222,7 +58199,7 @@ nSR
 aky
 btF
 aDi
-aDJ
+aDK
 ank
 ank
 ank
@@ -58450,7 +58427,7 @@ qBX
 nSR
 btF
 aDi
-aDK
+aDL
 ank
 ank
 ank
@@ -58678,7 +58655,7 @@ qBX
 tKI
 btF
 aDi
-aDL
+aDI
 ank
 ank
 ank
@@ -58906,7 +58883,7 @@ qBX
 tKI
 btF
 aDi
-aDI
+aDJ
 ank
 ank
 ank
@@ -59134,7 +59111,7 @@ shq
 rKQ
 btF
 aDi
-aDJ
+aDK
 ank
 ank
 ank
@@ -59362,7 +59339,7 @@ aky
 jtg
 btF
 aDi
-aDK
+aDL
 ank
 ank
 ano
@@ -59590,10 +59567,6 @@ aky
 aky
 btF
 aDi
-aDH
-aEl
-aEl
-aFM
 ank
 aGE
 aEl
@@ -59601,7 +59574,11 @@ aFM
 aGf
 aGE
 aEl
-aJU
+aFM
+aGf
+aGE
+aEl
+aFM
 aGf
 aGE
 aEl
@@ -59611,8 +59588,8 @@ aGE
 aEl
 aFM
 aGf
-akG
-aDH
+aGE
+ank
 aMq
 btF
 aky
@@ -59817,7 +59794,7 @@ phU
 eHr
 aky
 btF
-akG
+uVx
 aDM
 aDM
 aDM
@@ -59829,7 +59806,7 @@ aDM
 aDM
 aDM
 aDM
-akG
+uVx
 aDM
 aDM
 aDM

--- a/maps/map_files/Sorokyne_Strata/Sorokyne_Strata.dmm
+++ b/maps/map_files/Sorokyne_Strata/Sorokyne_Strata.dmm
@@ -43552,7 +43552,7 @@ arR
 atp
 auj
 rhk
-atp
+arR
 atp
 auj
 rhk
@@ -45880,8 +45880,8 @@ cqE
 cnv
 crb
 apc
-cwQ
-cwQ
+cZH
+auk
 arT
 atq
 auk

--- a/maps/map_files/Sorokyne_Strata/Sorokyne_Strata.dmm
+++ b/maps/map_files/Sorokyne_Strata/Sorokyne_Strata.dmm
@@ -5065,8 +5065,8 @@
 	},
 /area/strata/ag/interior/landingzone_1)
 "api" = (
-/obj/structure/machinery/landinglight/ds2/delaythree,
 /obj/effect/decal/cleanable/blood/oil,
+/obj/structure/machinery/landinglight/ds1/delaythree,
 /turf/open/asphalt/cement{
 	icon_state = "cement12"
 	},
@@ -5078,7 +5078,7 @@
 	},
 /area/strata/ag/interior/landingzone_1)
 "apk" = (
-/obj/structure/machinery/landinglight/ds2/delaythree,
+/obj/structure/machinery/landinglight/ds1/delaythree,
 /turf/open/asphalt/cement{
 	icon_state = "cement12"
 	},
@@ -5141,7 +5141,7 @@
 	},
 /area/strata/ag/interior/research_decks/security)
 "apv" = (
-/obj/structure/machinery/landinglight/ds1{
+/obj/structure/machinery/landinglight/ds2/delayone{
 	dir = 4
 	},
 /turf/open/asphalt/cement{
@@ -6543,10 +6543,10 @@
 	},
 /area/strata/ag/interior/landingzone_1)
 "atq" = (
-/obj/structure/machinery/landinglight/ds2/delaythree{
+/obj/effect/decal/cleanable/blood/oil,
+/obj/structure/machinery/landinglight/ds1/delaythree{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/blood/oil,
 /turf/open/asphalt/cement{
 	icon_state = "cement3"
 	},
@@ -8174,12 +8174,12 @@
 /area/strata/ag/interior/landingzone_1)
 "ayh" = (
 /obj/structure/machinery/landinglight/ds2/delaythree{
-	dir = 8
+	dir = 1
 	},
 /turf/open/asphalt/cement{
-	icon_state = "cement3"
+	icon_state = "cement4"
 	},
-/area/strata/ag/interior/landingzone_1)
+/area/strata/ag/exterior/landingzone_2)
 "ayj" = (
 /obj/structure/flora/pottedplant{
 	icon_state = "pottedplant_22"
@@ -14708,10 +14708,10 @@
 /turf/open/floor/strata,
 /area/strata/ag/interior/dorms/south)
 "aSX" = (
-/obj/structure/machinery/landinglight/ds1/delayone{
+/obj/effect/decal/cleanable/blood/oil,
+/obj/structure/machinery/landinglight/ds2{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/blood/oil,
 /turf/open/asphalt/cement{
 	icon_state = "cement4"
 	},
@@ -30889,7 +30889,7 @@
 	},
 /area/strata/ag/exterior/tcomms/tcomms_deck)
 "eBo" = (
-/obj/structure/machinery/landinglight/ds1,
+/obj/structure/machinery/landinglight/ds2/delaytwo,
 /turf/open/asphalt/cement{
 	icon_state = "cement12"
 	},
@@ -32712,7 +32712,7 @@
 /turf/open/auto_turf/strata_grass/layer1,
 /area/strata/ug/interior/jungle/platform/east/scrub)
 "hue" = (
-/obj/structure/machinery/landinglight/ds1/delaytwo{
+/obj/structure/machinery/landinglight/ds2{
 	dir = 8
 	},
 /turf/open/asphalt/cement{
@@ -34083,9 +34083,11 @@
 	},
 /area/strata/ug/interior/jungle/deep/structures/engi)
 "jPQ" = (
-/obj/structure/machinery/landinglight/ds1/delayone,
+/obj/structure/machinery/landinglight/ds2{
+	dir = 4
+	},
 /turf/open/asphalt/cement{
-	icon_state = "cement12"
+	icon_state = "cement1"
 	},
 /area/strata/ag/exterior/landingzone_2)
 "jPV" = (
@@ -35122,7 +35124,7 @@
 /turf/open/gm/river,
 /area/strata/ag/interior/tcomms)
 "lEo" = (
-/obj/structure/machinery/landinglight/ds1/delaytwo,
+/obj/structure/machinery/landinglight/ds2,
 /turf/open/asphalt/cement{
 	icon_state = "cement12"
 	},
@@ -36470,7 +36472,7 @@
 	},
 /area/strata/ag/interior/outpost/med)
 "nTf" = (
-/obj/structure/machinery/landinglight/ds1/delayone{
+/obj/structure/machinery/landinglight/ds2/delaytwo{
 	dir = 4
 	},
 /turf/open/asphalt/cement{
@@ -36578,6 +36580,12 @@
 	icon_state = "multi_tiles"
 	},
 /area/strata/ag/interior/tcomms)
+"odB" = (
+/obj/structure/machinery/landinglight/ds2/delayone,
+/turf/open/asphalt/cement{
+	icon_state = "cement12"
+	},
+/area/strata/ag/exterior/landingzone_2)
 "odJ" = (
 /turf/closed/wall/strata_ice/dirty,
 /area/strata/ag/interior/outpost/engi/drome)
@@ -37776,11 +37784,11 @@
 /turf/open/auto_turf/strata_grass/layer1,
 /area/strata/ug/interior/jungle/deep/south_dorms)
 "qbk" = (
-/obj/structure/machinery/landinglight/ds1{
-	dir = 8
+/obj/structure/machinery/landinglight/ds2/delaytwo{
+	dir = 1
 	},
 /turf/open/asphalt/cement{
-	icon_state = "cement3"
+	icon_state = "cement4"
 	},
 /area/strata/ag/exterior/landingzone_2)
 "qbA" = (
@@ -37792,6 +37800,14 @@
 "qbR" = (
 /turf/closed/wall/strata_outpost/reinforced/hull,
 /area/strata/ug/interior/outpost/jung/dorms/sec2)
+"qbU" = (
+/obj/structure/machinery/landinglight/ds2/delaytwo{
+	dir = 8
+	},
+/turf/open/asphalt/cement{
+	icon_state = "cement3"
+	},
+/area/strata/ag/exterior/landingzone_2)
 "qcB" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
 /turf/open/auto_turf/strata_grass/layer1,
@@ -39052,10 +39068,10 @@
 	},
 /area/strata/ag/interior/outpost/engi/drome)
 "skJ" = (
-/obj/structure/machinery/landinglight/ds2/delaythree{
+/obj/effect/decal/cleanable/blood/oil,
+/obj/structure/machinery/landinglight/ds2{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/blood/oil,
 /turf/open/asphalt/cement{
 	icon_state = "cement1"
 	},
@@ -39273,11 +39289,11 @@
 /turf/open/gm/dirt,
 /area/strata/ug/exterior/jungle/deep/carplake_center)
 "sFB" = (
-/obj/structure/machinery/landinglight/ds1/delaytwo{
-	dir = 4
+/obj/structure/machinery/landinglight/ds2{
+	dir = 1
 	},
 /turf/open/asphalt/cement{
-	icon_state = "cement1"
+	icon_state = "cement4"
 	},
 /area/strata/ag/exterior/landingzone_2)
 "sGJ" = (
@@ -41026,7 +41042,7 @@
 	},
 /area/strata/ag/interior/outpost/med)
 "vsp" = (
-/obj/structure/machinery/landinglight/ds1/delayone{
+/obj/structure/machinery/landinglight/ds2/delayone{
 	dir = 8
 	},
 /turf/open/asphalt/cement{
@@ -42310,8 +42326,8 @@
 /turf/open/auto_turf/strata_grass/layer0,
 /area/strata/ug/interior/jungle/deep/west_engi)
 "xGE" = (
-/obj/structure/machinery/landinglight/ds1/delayone,
 /obj/effect/decal/cleanable/blood/oil,
+/obj/structure/machinery/landinglight/ds2/delaythree,
 /turf/open/asphalt/cement{
 	icon_state = "cement12"
 	},
@@ -42629,7 +42645,7 @@
 /turf/open/floor/strata,
 /area/strata/ag/exterior/research_decks)
 "yee" = (
-/obj/structure/machinery/landinglight/ds1/delayone{
+/obj/structure/machinery/landinglight/ds2/delayone{
 	dir = 1
 	},
 /turf/open/asphalt/cement{
@@ -45871,15 +45887,15 @@ atq
 auk
 cwQ
 arT
-ayh
+cZH
 auk
 cwQ
 arT
-ayh
+cZH
 auk
 cwQ
 arT
-ayh
+cZH
 auk
 cwQ
 arT
@@ -50635,27 +50651,27 @@ bvD
 eFa
 bJI
 iwp
-iwp
+jPQ
 apv
 nTf
-sFB
+iwp
 skJ
 apv
 nTf
-sFB
 iwp
-iwp
-nTf
-sFB
-iwp
-apv
-sFB
-sFB
-iwp
+jPQ
 apv
 nTf
+iwp
+jPQ
+apv
 nTf
+iwp
+jPQ
+apv
 nTf
+iwp
+jPQ
 bJI
 wvF
 bvE
@@ -51023,7 +51039,7 @@ rNI
 xTU
 bvD
 eFa
-jPQ
+sBg
 jWs
 jWs
 jWs
@@ -51046,7 +51062,7 @@ jWs
 jWs
 iUK
 jWs
-yee
+qbk
 wvF
 bvE
 bwt
@@ -51241,7 +51257,7 @@ jWs
 jWs
 jWs
 jWs
-yee
+ayh
 wvF
 bvE
 bwt
@@ -51413,7 +51429,7 @@ rNI
 xTU
 bvD
 eFa
-sBg
+odB
 vqx
 jWs
 jWs
@@ -51826,7 +51842,7 @@ jWs
 jWs
 jWs
 jWs
-yee
+qbk
 wvF
 bvD
 bvD
@@ -52021,7 +52037,7 @@ jWs
 jWs
 jWs
 jWs
-yee
+ayh
 wvF
 bvE
 bvE
@@ -52193,7 +52209,7 @@ bvD
 bvD
 bvE
 eFa
-sBg
+odB
 jWs
 jWs
 jWs
@@ -52216,7 +52232,7 @@ jWs
 jWs
 jWs
 jWs
-yee
+sFB
 oFG
 bvE
 byr
@@ -52583,7 +52599,7 @@ bvD
 bvE
 bvD
 eFa
-jPQ
+sBg
 jWs
 jWs
 jWs
@@ -52606,7 +52622,7 @@ jWs
 jWs
 jWs
 jWs
-yee
+qbk
 wvF
 bvD
 bvE
@@ -52801,7 +52817,7 @@ jWs
 ewk
 jWs
 jWs
-yee
+ayh
 wvF
 bvD
 bvE
@@ -52975,26 +52991,26 @@ xTU
 eFa
 bJI
 vsp
-vsp
-qbk
-hzb
 hue
-vsp
-qbk
 hzb
+qbU
+vsp
 hue
-vsp
-vsp
 hzb
-hue
+qbU
 vsp
-qbk
-hzb
 hue
+hzb
+qbU
 vsp
-qbk
-hzb
 hue
+hzb
+qbU
+vsp
+hue
+hzb
+qbU
+vsp
 hue
 bJI
 wvF

--- a/maps/map_files/Sorokyne_Strata/Sorokyne_Strata.dmm
+++ b/maps/map_files/Sorokyne_Strata/Sorokyne_Strata.dmm
@@ -13604,7 +13604,6 @@
 "aPz" = (
 /obj/structure/machinery/door/airlock/almayer/maint/colony{
 	dir = 2;
-	req_access = null;
 	req_one_access = null
 	},
 /turf/open/floor/strata{
@@ -14271,10 +14270,10 @@
 /turf/open/auto_turf/snow/brown_base/layer3,
 /area/strata/ag/exterior/paths/adminext)
 "aRz" = (
+/obj/effect/decal/cleanable/blood/oil,
 /obj/structure/machinery/landinglight/ds1/delayone{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/blood/oil,
 /turf/open/asphalt/cement{
 	icon_state = "cement4"
 	},
@@ -27835,9 +27834,7 @@
 /turf/closed/wall/wood,
 /area/strata/ug/interior/jungle/deep/north_carp)
 "ciy" = (
-/obj/docking_port/stationary/marine_dropship/lz1{
-	dwidth = 1
-	},
+/obj/docking_port/stationary/marine_dropship/lz1,
 /turf/open/floor/plating,
 /area/strata/ag/interior/landingzone_1)
 "ciA" = (
@@ -29158,11 +29155,11 @@
 	},
 /area/strata/ag/interior/administration)
 "crW" = (
-/obj/structure/machinery/landinglight/ds2/delaythree{
-	dir = 4
+/obj/structure/machinery/landinglight/ds1/delaytwo{
+	dir = 1
 	},
 /turf/open/asphalt/cement{
-	icon_state = "cement1"
+	icon_state = "cement4"
 	},
 /area/strata/ag/interior/landingzone_1)
 "crY" = (
@@ -30083,6 +30080,14 @@
 	icon_state = "multi_tiles"
 	},
 /area/strata/ag/interior/dorms/hive)
+"cZH" = (
+/obj/structure/machinery/landinglight/ds1/delaythree{
+	dir = 8
+	},
+/turf/open/asphalt/cement{
+	icon_state = "cement3"
+	},
+/area/strata/ag/interior/landingzone_1)
 "daq" = (
 /turf/open/auto_turf/strata_grass/layer1,
 /area/strata/ug/interior/jungle/deep/east_carp)
@@ -30224,6 +30229,14 @@
 	icon_state = "floor3"
 	},
 /area/strata/ug/interior/outpost/jung/dorms/sec1)
+"dnS" = (
+/obj/structure/machinery/landinglight/ds1{
+	dir = 1
+	},
+/turf/open/asphalt/cement{
+	icon_state = "cement4"
+	},
+/area/strata/ag/interior/landingzone_1)
 "doO" = (
 /obj/structure/machinery/weather_siren{
 	dir = 1;
@@ -31411,6 +31424,14 @@
 	icon_state = "red1"
 	},
 /area/strata/ag/interior/dorms/flight_control)
+"fuA" = (
+/obj/structure/machinery/landinglight/ds1/delaythree{
+	dir = 1
+	},
+/turf/open/asphalt/cement{
+	icon_state = "cement4"
+	},
+/area/strata/ag/interior/landingzone_1)
 "fuX" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /turf/open/auto_turf/strata_grass/layer0,
@@ -33519,9 +33540,7 @@
 /turf/open/auto_turf/strata_grass/layer1,
 /area/strata/ug/interior/jungle/deep/south_dorms)
 "iUK" = (
-/obj/docking_port/stationary/marine_dropship/lz2{
-	dwidth = 1
-	},
+/obj/docking_port/stationary/marine_dropship/lz2,
 /turf/open/floor/plating,
 /area/strata/ag/exterior/landingzone_2)
 "iUN" = (
@@ -38473,6 +38492,14 @@
 	icon_state = "white_cyan1"
 	},
 /area/strata/ag/interior/dorms/maintenance)
+"rhk" = (
+/obj/structure/machinery/landinglight/ds1/delaythree{
+	dir = 4
+	},
+/turf/open/asphalt/cement{
+	icon_state = "cement1"
+	},
+/area/strata/ag/interior/landingzone_1)
 "rhJ" = (
 /obj/structure/barricade/handrail/strata{
 	dir = 8
@@ -43497,27 +43524,27 @@ cqE
 cnv
 crb
 apc
-crW
-crW
 arR
 atp
 auj
-crW
+rhk
 arR
 atp
 auj
-crW
-crW
-atp
-auj
-crW
-arR
-auj
-auj
-crW
+rhk
 arR
 atp
+auj
+rhk
 atp
+atp
+auj
+rhk
+arR
+atp
+auj
+rhk
+arR
 atp
 apc
 cmA
@@ -43714,7 +43741,7 @@ crE
 arS
 crE
 crE
-aRx
+crW
 cmA
 cnv
 cqE
@@ -43909,7 +43936,7 @@ crE
 crE
 ciy
 crE
-aRx
+fuA
 cmA
 cnv
 cqE
@@ -44104,7 +44131,7 @@ crE
 crE
 crE
 crE
-aRx
+dnS
 cmA
 cnv
 cqE
@@ -44494,7 +44521,7 @@ crE
 crE
 crE
 crE
-aRx
+crW
 cmA
 cnv
 cqE
@@ -44689,7 +44716,7 @@ crE
 crE
 crE
 crE
-aRx
+fuA
 aSH
 coX
 aVX
@@ -44884,7 +44911,7 @@ crE
 crE
 crE
 crE
-aRx
+dnS
 cmA
 cnv
 acY
@@ -45274,7 +45301,7 @@ crE
 crE
 crE
 crE
-aRx
+crW
 cmA
 cnv
 cot
@@ -45469,7 +45496,7 @@ crE
 crE
 crE
 crE
-aRx
+fuA
 cmA
 cnv
 aoj
@@ -45664,7 +45691,7 @@ crE
 arS
 crE
 crE
-aRx
+dnS
 cmA
 cnv
 aoj
@@ -45847,10 +45874,6 @@ arT
 ayh
 auk
 cwQ
-cwQ
-ayh
-auk
-cwQ
 arT
 ayh
 auk
@@ -45858,7 +45881,11 @@ cwQ
 arT
 ayh
 auk
+cwQ
+arT
+cZH
 auk
+cwQ
 apc
 cmA
 cnv


### PR DESCRIPTION
# About the pull request
This PR fixes issues with landing lights on the following maps.
- LV-624
- Solaris Ridge
- Fiorina Science Annex
- Trijent Dam
- Sorokyne Strata
- Kutjevo Refinery

This PR also adds landing lights for LZ2 on Shivas Snowball. LZ1 does not gain any due to its 'non standard landing' nature. For Lv-624, the lower two floodlights have been pushed one tile away from the landing zone for consistency.

Fixes Issue #3427 

# Explain why it's good for the game

Fixes glaring issues with landing lights on many maps being out of order, not working or flashing in a odd way. Addition of landing lights to LZ2 of Shivas Snowball brings it up to standard with every other LZ. 


# Testing Photographs and Procedure
![New LZ 1](https://github.com/cmss13-devs/cmss13/assets/6595389/ff4a4f88-6e15-4fe5-99bf-3393757f1f45)
New LZ1 appearance. 

# Changelog
:cl:
maptweak: Fixed landing strip lights on most maps
/:cl:
