### PR TITLE
Hand and feet now cannot get IB

### DIFF
--- a/code/modules/mob/living/carbon/human/life/handle_organs.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_organs.dm
@@ -1,4 +1,3 @@
-#define NO_IB_LIMBS list("l_foot","r_foot","l_hand","r_hand")
 // Takes care of organ & limb related updates, such as broken and missing limbs
 /mob/living/carbon/human/proc/handle_organs()
 
@@ -25,7 +24,7 @@
 					var/damage = rand(3,5)
 					I.take_damage(damage)
 					pain.apply_pain(damage * PAIN_ORGAN_DAMAGE_MULTIPLIER)
-				if(E.is_broken() && prob(2) && !(E.name in NO_IB_LIMBS))
+				if(E.is_broken() && prob(2))
 					var/damage = rand(3,5)
 					var/datum/wound/internal_bleeding/internal_bleed = new
 					E.add_bleeding(internal_bleed, TRUE, damage)
@@ -60,5 +59,3 @@
 				emote("pain")
 			custom_pain("You can't stand on broken legs!", 1)
 			apply_effect(5, WEAKEN)
-
-#undef NO_IB_LIMBS

--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -65,6 +65,8 @@
 
 	var/list/bleeding_effects_list = list()
 
+	var/can_bleed_internally = TRUE
+
 	var/destroyed = FALSE
 	var/status = LIMB_ORGANIC
 	var/processing = FALSE
@@ -510,6 +512,9 @@ This function completely restores a damaged organ to perfect condition.
 
 	if(status & (LIMB_ROBOT|LIMB_SYNTHSKIN))
 		return
+
+	if(internal && !can_bleed_internally)
+		internal = FALSE
 
 	if(length(bleeding_effects_list))
 		if(!internal)
@@ -1278,6 +1283,7 @@ treat_grafted var tells it to apply to grafted but unsalved wounds, for burn kit
 	display_name = "foot"
 	max_damage = 30
 	min_broken_damage = 20
+	can_bleed_internally = FALSE
 
 /obj/limb/arm
 	name = "arm"
@@ -1290,6 +1296,7 @@ treat_grafted var tells it to apply to grafted but unsalved wounds, for burn kit
 	display_name = "hand"
 	max_damage = 30
 	min_broken_damage = 20
+	can_bleed_internally = FALSE
 
 /obj/limb/arm/l_arm
 	name = "l_arm"


### PR DESCRIPTION

# About the pull request

This PR makes it impossible to get IB in your hands and feet.

# Explain why it's good for the game

Incentivizing the tradeoffs for armored versus unarmored regions when it comes to choosing a limb to target is important. This further tilts it towards armored areas which should help promote varied preference.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
balance: Hand and feet now cannot get IB
/:cl:
