### PR TITLE
Beserker Rav glows yellow when fast

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/ravager/ravager_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/ravager/ravager_powers.dm
@@ -254,7 +254,7 @@
 	X.recalculate_speed()
 
 	addtimer(CALLBACK(src, PROC_REF(apprehend_off)), buff_duration, TIMER_UNIQUE)
-	X.add_filter("apprehend_on", 1, list("type" = "outline", "color" = "#522020ff", "size" = 1)) // Dark red because the berserker is scary in this state
+	X.add_filter("apprehend_on", 1, list("type" = "outline", "color" = "#f7d302", "size" = 1)) // Dark red because the berserker is scary in this state
 
 	apply_cooldown()
 


### PR DESCRIPTION
# About the pull request

Beserker rav will glow yellow when using apprehend.

# Explain why it's good for the game

You can see when Rav uses their ability, BEFORE IT GLOWED RED.... glowing red on a rav....

This just makes it more visible


# Testing Photographs and Procedure

![Rav Glow](https://github.com/cmss13-devs/cmss13/assets/43085828/0e2db25e-8f0c-4201-91e8-a7872788872c)

# Changelog

:cl: ghostsheet
add: Beserker Rav now glows yellow when using apprehend.
/:cl:
