### PR TITLE
Admin Global Blurb

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -152,7 +152,8 @@ var/list/admin_verbs_major_event = list(
 	/client/proc/map_template_upload,
 	/client/proc/enable_podlauncher,
 	/client/proc/change_taskbar_icon,
-	/client/proc/change_weather
+	/client/proc/change_weather,
+	/client/proc/admin_blurb
 )
 
 var/list/admin_verbs_spawn = list(
@@ -206,6 +207,7 @@ var/list/admin_verbs_debug = list(
 	/datum/admins/proc/view_runtime_log, /*shows the server runtime log for this round*/
 	/datum/admins/proc/view_href_log, /*shows the server HREF log for this round*/
 	/datum/admins/proc/view_tgui_log, /*shows the server TGUI log for this round*/
+	/client/proc/admin_blurb,
 )
 
 var/list/admin_verbs_debug_advanced = list(

--- a/code/modules/admin/tabs/event_tab.dm
+++ b/code/modules/admin/tabs/event_tab.dm
@@ -975,3 +975,20 @@
 				GLOB.bioscan_data.ares_bioscan(FALSE, variance)
 			if("Yautja")
 				GLOB.bioscan_data.yautja_bioscan()
+
+/client/proc/admin_blurb()
+	set name = "Global Blurb Message"
+	set category = "Admin.Events"
+
+	if(!check_rights(R_ADMIN|R_DEBUG))
+		return FALSE
+	var/duration = 5 SECONDS
+	var/message = "ADMIN TEST"
+	var/text_input = tgui_input_text(usr, "Announcement message", "Message Contents", message, timeout = 5 MINUTES)
+	message = text_input
+	duration = tgui_input_number(usr, "Set the duration of the alert in deci-seconds.", "Duration", 5 SECONDS, 5 MINUTES, 5 SECONDS, 20 SECONDS)
+	var/confirm = tgui_alert(usr, "Are you sure you wish to send '[message]' to all players for [(duration / 10)] seconds?", "Confirm", list("Yes", "No"), 20 SECONDS)
+	if(confirm != "Yes")
+		return FALSE
+	show_blurb(GLOB.player_list, duration, message, TRUE, "center", "center", "#bd2020", "ADMIN")
+	message_admins("[key_name(usr)] sent an admin blurb alert to all players. Alert reads: '[message]' and lasts [(duration / 10)] seconds.")


### PR DESCRIPTION

# About the pull request
Gives admins and maintainers a button to send a global blurb message. This sends to all players with a connected client.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Sometimes we really need to get info to everyone and they don't always pay attention to the chat window where we're putting announcements. Also useful for system messages like planned server outages.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Adds an admin button for global blurb alerts. (Visual on game screen)
/:cl:
