### PR TITLE
Reduces SG Full Auto Scatter

### DIFF
--- a/code/modules/projectiles/guns/smartgun.dm
+++ b/code/modules/projectiles/guns/smartgun.dm
@@ -88,7 +88,7 @@
 	burst_delay = FIRE_DELAY_TIER_9
 	fa_delay = FIRE_DELAY_TIER_SG
 	fa_scatter_peak = FULL_AUTO_SCATTER_PEAK_TIER_8
-	fa_max_scatter = SCATTER_AMOUNT_TIER_3
+	fa_max_scatter = SCATTER_AMOUNT_NONE
 	if(accuracy_improvement)
 		accuracy_mult += HIT_ACCURACY_MULT_TIER_3
 	else

--- a/code/modules/projectiles/guns/smartgun.dm
+++ b/code/modules/projectiles/guns/smartgun.dm
@@ -88,7 +88,7 @@
 	burst_delay = FIRE_DELAY_TIER_9
 	fa_delay = FIRE_DELAY_TIER_SG
 	fa_scatter_peak = FULL_AUTO_SCATTER_PEAK_TIER_8
-	fa_max_scatter = SCATTER_AMOUNT_NONE
+	fa_max_scatter = SCATTER_AMOUNT_TIER_9
 	if(accuracy_improvement)
 		accuracy_mult += HIT_ACCURACY_MULT_TIER_3
 	else


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

It's been bugging me for a long time, but when you fire for a good dozen seconds with the standard issue smartguns, the bullets start scattering. So, so far you'll say, good Fira, that's soulful! 

However, we have no ACTUAL recoil or similar mechanic. So letting go of the LMB for just even 20 miliseconds is enough to reset scatter to start of firing. **It's just a noobtrap with zero real gameplay elements.**

This reduces the max scatter so that bullets don't just start (after EIGHTY shots!) spraying a (roughly) 48° angle cone, but instead 12° which mostly stays on the same actual turfs. At this value the targeting impact is vastly minimized, but the projectile visuals retain significant scattering. 

I don't think this ACTUALLY qualifies as a "balance" change due to how irrelevant the "mechanic" was, but i'll slap it on.

# Explain why it's good for the game
Less of a noobtrap and pointless purely mechanical micromanagement so people can focus on playing the game.

I'd rather we get a recoil mechanic to make this meaningful but it's bit of a bigger problem...

# Changelog
:cl:
qol: Reduced USCM SG max scattering on Full Auto fire so you don't have to periodically let go of the fire button to keep it from firing way wide. 
/:cl:
