### PR TITLE
Reintroduces auto red alert when xenos are aboard a dropship

### DIFF
--- a/code/modules/shuttle/shuttles/dropship.dm
+++ b/code/modules/shuttle/shuttles/dropship.dm
@@ -82,14 +82,15 @@
 	control_doors("force-lock-launch", "all", force=TRUE, asynchronous = FALSE)
 
 	for(var/area/checked_area in shuttle_areas)
-		for(var/turf/checked_turf in checked_area)
-			for(var/mob/living/carbon/xenomorph/checked_xeno in checked_turf)
-				if(checked_xeno.stat == CONSCIOUS)
-					var/name = "Unidentified Lifesigns"
-					var/input = "Unidentified lifesigns detected onboard. Recommendation: lockdown of exterior access ports, including ducting and ventilation."
-					shipwide_ai_announcement(input, name, 'sound/AI/unidentified_lifesigns.ogg')
-					set_security_level(SEC_LEVEL_RED)
-					return
+		for(var/mob/living/carbon/xenomorph/checked_xeno in checked_area)
+			if(checked_xeno.stat == DEAD)
+				continue
+
+			var/name = "Unidentified Lifesigns"
+			var/input = "Unidentified lifesigns detected onboard. Recommendation: lockdown of exterior access ports, including ducting and ventilation."
+			shipwide_ai_announcement(input, name, 'sound/AI/unidentified_lifesigns.ogg')
+			set_security_level(SEC_LEVEL_RED)
+			return
 
 /obj/docking_port/mobile/marine_dropship/alamo
 	name = "Alamo"

--- a/code/modules/shuttle/shuttles/dropship.dm
+++ b/code/modules/shuttle/shuttles/dropship.dm
@@ -81,7 +81,7 @@
 	. = ..()
 	control_doors("force-lock-launch", "all", force=TRUE, asynchronous = FALSE)
 
-	if(is_hijack)
+	if(is_hijacked)
 		return
 
 	for(var/area/checked_area in shuttle_areas)

--- a/code/modules/shuttle/shuttles/dropship.dm
+++ b/code/modules/shuttle/shuttles/dropship.dm
@@ -84,7 +84,7 @@
 	for(var/area/checked_area in shuttle_areas)
 		for(var/turf/checked_turf in checked_area)
 			for(var/mob/living/carbon/xenomorph/checked_xeno in checked_turf)
-				if(checked_xeno.stat == LIVING)
+				if(checked_xeno.stat == CONSCIOUS)
 					var/name = "Unidentified Lifesigns"
 					var/input = "Unidentified lifesigns detected onboard. Recommendation: lockdown of exterior access ports, including ducting and ventilation."
 					shipwide_ai_announcement(input, name, 'sound/AI/unidentified_lifesigns.ogg')

--- a/code/modules/shuttle/shuttles/dropship.dm
+++ b/code/modules/shuttle/shuttles/dropship.dm
@@ -81,6 +81,9 @@
 	. = ..()
 	control_doors("force-lock-launch", "all", force=TRUE, asynchronous = FALSE)
 
+	if(is_hijack)
+		return
+
 	for(var/area/checked_area in shuttle_areas)
 		for(var/mob/living/carbon/xenomorph/checked_xeno in checked_area)
 			if(checked_xeno.stat == DEAD)

--- a/code/modules/shuttle/shuttles/dropship.dm
+++ b/code/modules/shuttle/shuttles/dropship.dm
@@ -82,12 +82,14 @@
 	control_doors("force-lock-launch", "all", force=TRUE, asynchronous = FALSE)
 
 	for(var/area/checked_area in shuttle_areas)
-		if(locate(/mob/living/carbon/xenomorph) in checked_area)
-			var/name = "Unidentified Lifesigns"
-			var/input = "Unidentified lifesigns detected onboard. Recommendation: lockdown of exterior access ports, including ducting and ventilation."
-			shipwide_ai_announcement(input, name, 'sound/AI/unidentified_lifesigns.ogg')
-			set_security_level(SEC_LEVEL_RED)
-			return
+		for(var/turf/checked_turf in checked_area)
+			for(var/mob/living/carbon/xenomorph/checked_xeno in checked_turf)
+				if(checked_xeno.stat == LIVING)
+					var/name = "Unidentified Lifesigns"
+					var/input = "Unidentified lifesigns detected onboard. Recommendation: lockdown of exterior access ports, including ducting and ventilation."
+					shipwide_ai_announcement(input, name, 'sound/AI/unidentified_lifesigns.ogg')
+					set_security_level(SEC_LEVEL_RED)
+					return
 
 /obj/docking_port/mobile/marine_dropship/alamo
 	name = "Alamo"

--- a/code/modules/shuttle/shuttles/dropship.dm
+++ b/code/modules/shuttle/shuttles/dropship.dm
@@ -81,9 +81,6 @@
 	. = ..()
 	control_doors("force-lock-launch", "all", force=TRUE, asynchronous = FALSE)
 
-	if(is_hijacked)
-		return
-
 	for(var/area/checked_area in shuttle_areas)
 		for(var/mob/living/carbon/xenomorph/checked_xeno in checked_area)
 			if(checked_xeno.stat == DEAD)

--- a/code/modules/shuttle/shuttles/dropship.dm
+++ b/code/modules/shuttle/shuttles/dropship.dm
@@ -81,6 +81,14 @@
 	. = ..()
 	control_doors("force-lock-launch", "all", force=TRUE, asynchronous = FALSE)
 
+	for(var/area/checked_area in shuttle_areas)
+		if(locate(/mob/living/carbon/xenomorph) in checked_area)
+			var/name = "Unidentified Lifesigns"
+			var/input = "Unidentified lifesigns detected onboard. Recommendation: lockdown of exterior access ports, including ducting and ventilation."
+			shipwide_ai_announcement(input, name, 'sound/AI/unidentified_lifesigns.ogg')
+			set_security_level(SEC_LEVEL_RED)
+			return
+
 /obj/docking_port/mobile/marine_dropship/alamo
 	name = "Alamo"
 	id = DROPSHIP_ALAMO

--- a/code/modules/shuttle/shuttles/dropship.dm
+++ b/code/modules/shuttle/shuttles/dropship.dm
@@ -81,6 +81,9 @@
 	. = ..()
 	control_doors("force-lock-launch", "all", force=TRUE, asynchronous = FALSE)
 
+	if(is_hijacked)
+		return
+
 	for(var/area/checked_area in shuttle_areas)
 		for(var/mob/living/carbon/xenomorph/checked_xeno in checked_area)
 			if(checked_xeno.stat == DEAD)


### PR DESCRIPTION

# About the pull request

This PR reintroduces auto red alert when xenos are aboard a dropship.

# Explain why it's good for the game

Oversight from shuttle port.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
add: Reintroduced auto red alert when xenos are aboard a dropship
/:cl:
