### PR TITLE
Burrowers unable to burrow while inside a non-burrow area

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/burrower/burrower_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/burrower/burrower_powers.dm
@@ -7,11 +7,16 @@
 	if(used_burrow || tunnel || is_ventcrawling || action_busy)
 		return
 
-	var/turf/T = get_turf(src)
-	if(!T)
+	var/turf/current_turf = get_turf(src)
+	if(!current_turf)
 		return
 
-	if(istype(T, /turf/open/floor/almayer/research/containment) || istype(T, /turf/closed/wall/almayer/research/containment))
+	var/area/current_area = get_area(current_turf)
+	if(current_area.flags_area & AREA_NOTUNNEL)
+		to_chat(src, SPAN_XENOWARNING("There's no way to burrow here."))
+		return
+
+	if(istype(current_turf, /turf/open/floor/almayer/research/containment) || istype(current_turf, /turf/closed/wall/almayer/research/containment))
 		to_chat(src, SPAN_XENOWARNING("You can't escape this cell!"))
 		return
 


### PR DESCRIPTION

# About the pull request

This PR makes it so burrowers can no longer burrow while inside a non-burrow area. Currently, they can burrow but not TUNNEL into a non-burrow area.

# Explain why it's good for the game

Awkward and niche interaction that is causing issues. You really shouldn't be able to hide while burrowed most of the way up on a dropship. If you win the fight and get off the dropship you get to reap the benefits go wild.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
balance: Burrowers are now unable to burrow while inside a non-burrow area
/:cl:
