### PR TITLE
Find internal bleeding via Health Scanner

### DIFF
--- a/code/modules/mob/living/living_healthscan.dm
+++ b/code/modules/mob/living/living_healthscan.dm
@@ -101,7 +101,7 @@ GLOBAL_LIST_INIT(known_implants, subtypesof(/obj/item/implant))
 		"hugged" = (locate(/obj/item/alien_embryo) in target_mob),
 	)
 
-	var/internal_bleeding = FALSE
+	var/internal_bleeding = FALSE //do they have internal bleeding anywhere
 
 	if(!isnull(data_detail_level))
 		detail_level = data_detail_level
@@ -158,11 +158,10 @@ GLOBAL_LIST_INIT(known_implants, subtypesof(/obj/item/implant))
 		var/core_fracture_detected = FALSE
 		var/unknown_implants = 0
 		for(var/obj/limb/limb in human_target_mob.limbs)
-			var/internal_bleeding_check = FALSE
+			var/internal_bleeding_check = FALSE //do they have internal bleeding in this limb
 			for(var/datum/effects/bleeding/internal/ib in limb.bleeding_effects_list)
 				internal_bleeding = TRUE
-				if(detail_level >= DETAIL_LEVEL_BODYSCAN)
-					internal_bleeding_check = TRUE
+				internal_bleeding_check = TRUE
 				break
 			if(limb.hidden)
 				unknown_implants++

--- a/tgui/packages/tgui/interfaces/HealthScan.js
+++ b/tgui/packages/tgui/interfaces/HealthScan.js
@@ -353,7 +353,7 @@ const ScannerLimbs = (props, context) => {
                       [Bleeding]
                     </Box>
                   ) : null}
-                  {limb.internal_bleeding && bodyscanner ? (
+                  {limb.internal_bleeding ? (
                     <Box inline color={'red'} bold={1}>
                       [Internal Bleeding]
                     </Box>

--- a/tgui/packages/tgui/interfaces/HealthScan.js
+++ b/tgui/packages/tgui/interfaces/HealthScan.js
@@ -27,7 +27,6 @@ export const HealthScan = (props, context) => {
     has_blood,
     body_temperature,
     pulse,
-    internal_bleeding,
     implants,
     core_fracture,
     lung_ruptured,
@@ -194,18 +193,11 @@ export const HealthScan = (props, context) => {
             </LabeledList.Item>
             <LabeledList.Item label={'Pulse'}>{pulse}</LabeledList.Item>
           </LabeledList>
-          {internal_bleeding ||
-          implants ||
+          {implants ||
           hugged ||
           core_fracture ||
           (lung_ruptured && bodyscanner) ? (
             <Divider />
-          ) : null}
-          {internal_bleeding ? (
-            <NoticeBox danger>
-              Internal Bleeding Detected!
-              {healthanalyser ? ' Advanced scanner required for location.' : ''}
-            </NoticeBox>
           ) : null}
           {implants && detail_level !== 1 ? (
             <NoticeBox danger>


### PR DESCRIPTION

# About the pull request

This PR allows finding internal bleeding via the health scanner.

# Explain why it's good for the game

While I think the check status way to do this is cool (and the analyzer is kind of lame overall(different conversation)), it's just not very intuitive and so here we are.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
add: You can now find internal bleeding via Health Scanner
/:cl:
