### PR TITLE
Makes nuke get those pesky closet/tunnel hiders

### DIFF
--- a/code/game/gamemodes/cm_self_destruct.dm
+++ b/code/game/gamemodes/cm_self_destruct.dm
@@ -258,12 +258,13 @@ var/global/datum/authority/branch/evacuation/EvacuationAuthority //This is initi
 
 		var/list/alive_mobs = list() //Everyone who will be destroyed on the zlevel(s).
 		var/list/dead_mobs = list() //Everyone who only needs to see the cinematic.
-		for(var/mob/current_mob in GLOB.mob_list) //This only does something cool for the people about to die, but should prove pretty interesting.
+		for(var/mob/current_mob as anything in GLOB.mob_list) //This only does something cool for the people about to die, but should prove pretty interesting.
 			if(!current_mob || !current_mob.loc)
 				continue //In case something changes when we sleep().
 			if(current_mob.stat == DEAD)
 				dead_mobs |= current_mob
-			else if((current_mob.z in z_levels) || (current_mob.loc.z in z_levels))
+				continue
+			if((current_mob.z in z_levels) || (current_mob.loc.z in z_levels))
 				alive_mobs |= current_mob
 				shake_camera(current_mob, 110, 4)
 
@@ -274,7 +275,7 @@ var/global/datum/authority/branch/evacuation/EvacuationAuthority //This is initi
 		var/atom/movable/screen/cinematic/explosion/C = new
 
 		if(play_anim)
-			for(var/mob/current_mob in alive_mobs + dead_mobs)
+			for(var/mob/current_mob as anything in alive_mobs + dead_mobs)
 				if(current_mob && current_mob.loc && current_mob.client)
 					current_mob.client.screen |= C //They may have disconnected in the mean time.
 

--- a/code/game/gamemodes/cm_self_destruct.dm
+++ b/code/game/gamemodes/cm_self_destruct.dm
@@ -264,7 +264,8 @@ var/global/datum/authority/branch/evacuation/EvacuationAuthority //This is initi
 			if(current_mob.stat == DEAD)
 				dead_mobs |= current_mob
 				continue
-			if((current_mob.z in z_levels) || (current_mob.loc.z in z_levels))
+			var/turf/current_turf = get_turf(current_mob)
+			if(current_turf.z in z_levels)
 				alive_mobs |= current_mob
 				shake_camera(current_mob, 110, 4)
 

--- a/code/game/gamemodes/cm_self_destruct.dm
+++ b/code/game/gamemodes/cm_self_destruct.dm
@@ -256,17 +256,16 @@ var/global/datum/authority/branch/evacuation/EvacuationAuthority //This is initi
 				ship_status = 0 //Destroyed.
 			break
 
-		var/L1[] = new //Everyone who will be destroyed on the zlevel(s).
-		var/L2[] = new //Everyone who only needs to see the cinematic.
-		var/mob/M
-		var/turf/T
-		for(M in GLOB.player_list) //This only does something cool for the people about to die, but should prove pretty interesting.
-			if(!M || !M.loc) continue //In case something changes when we sleep().
-			if(M.stat == DEAD)
-				L2 |= M
-			else if(M.z in z_levels)
-				L1 |= M
-				shake_camera(M, 110, 4)
+		var/list/alive_mobs = list() //Everyone who will be destroyed on the zlevel(s).
+		var/list/dead_mobs = list() //Everyone who only needs to see the cinematic.
+		for(var/mob/current_mob in GLOB.mob_list) //This only does something cool for the people about to die, but should prove pretty interesting.
+			if(!current_mob || !current_mob.loc)
+				continue //In case something changes when we sleep().
+			if(current_mob.stat == DEAD)
+				dead_mobs |= current_mob
+			else if((current_mob.z in z_levels) || (current_mob.loc.z in z_levels))
+				alive_mobs |= current_mob
+				shake_camera(current_mob, 110, 4)
 
 
 		sleep(100)
@@ -275,23 +274,23 @@ var/global/datum/authority/branch/evacuation/EvacuationAuthority //This is initi
 		var/atom/movable/screen/cinematic/explosion/C = new
 
 		if(play_anim)
-			for(M in L1 + L2)
-				if(M && M.loc && M.client)
-					M.client.screen |= C //They may have disconnected in the mean time.
+			for(var/mob/current_mob in alive_mobs + dead_mobs)
+				if(current_mob && current_mob.loc && current_mob.client)
+					current_mob.client.screen |= C //They may have disconnected in the mean time.
 
 			sleep(15) //Extra 1.5 seconds to look at the ship.
 			flick(override ? "intro_override" : "intro_nuke", C)
 		sleep(35)
-		for(M in L1)
-			if(M && M.loc) //Who knows, maybe they escaped, or don't exist anymore.
-				T = get_turf(M)
-				if(T.z in z_levels)
-					if(istype(M.loc, /obj/structure/closet/secure_closet/freezer/fridge))
+		for(var/mob/current_mob in alive_mobs)
+			if(current_mob && current_mob.loc) //Who knows, maybe they escaped, or don't exist anymore.
+				var/turf/current_mob_turf = get_turf(current_mob)
+				if(current_mob_turf.z in z_levels)
+					if(istype(current_mob.loc, /obj/structure/closet/secure_closet/freezer/fridge))
 						continue
-					M.death(create_cause_data("nuclear explosion"))
+					current_mob.death(create_cause_data("nuclear explosion"))
 				else
 					if(play_anim)
-						M.client.screen -= C //those who managed to escape the z level at last second shouldn't have their view obstructed.
+						current_mob.client.screen -= C //those who managed to escape the z level at last second shouldn't have their view obstructed.
 		if(play_anim)
 			flick(ship_status ? "ship_spared" : "ship_destroyed", C)
 			C.icon_state = ship_status ? "summary_spared" : "summary_destroyed"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

This PR makes nukes exploding kill people who are hiding in closet/tunnels OTHER THAN refrigerators.

Also please god do not make me refactor this whole thing I will die.

# Explain why it's good for the game

It's goofy to survive in a closet.

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
fix: Made nukes get those pesky closet/tunnel hiders
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
