### PR TITLE
Removes fourth awkward LZ2 Soro communication relay

### DIFF
--- a/maps/map_files/Sorokyne_Strata/Sorokyne_Strata.dmm
+++ b/maps/map_files/Sorokyne_Strata/Sorokyne_Strata.dmm
@@ -40452,10 +40452,6 @@
 "uux" = (
 /turf/closed/wall/strata_outpost,
 /area/strata/ug/interior/jungle/deep/structures/res)
-"uvm" = (
-/obj/effect/landmark/static_comms/net_two,
-/turf/open/auto_turf/snow/brown_base/layer0,
-/area/strata/ag/exterior/marsh/crash)
 "uvw" = (
 /turf/open/auto_turf/strata_grass/layer0,
 /area/strata/ug/interior/jungle/deep/west_engi)
@@ -45557,7 +45553,7 @@ cXU
 bhO
 bgS
 bhO
-uvm
+bhO
 bhO
 bhO
 bhO


### PR DESCRIPTION

# About the pull request

This PR removes the LZ2 Soro communication relay that is right next to an LZ1 communication relay.

# Explain why it's good for the game

Given some of the coming objective changes it is too strong to have them right next to each other.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
del: Removes fourth awkward LZ2 Soro communication relay
/:cl:
