### PR TITLE
Admin Map Overrides

### DIFF
--- a/code/__DEFINES/maps.dm
+++ b/code/__DEFINES/maps.dm
@@ -104,8 +104,10 @@ require only minor tweaks.
 #define GROUND_MAP "ground_map"
 #define SHIP_MAP "ship_map"
 #define ALL_MAPTYPES list(GROUND_MAP, SHIP_MAP)
+#define OVERRIDE_MAPS_TO_FILENAME list(GROUND_MAP = "next_map_override.dmm", SHIP_MAP = "next_ship_override.dmm")
 #define MAP_TO_FILENAME list(GROUND_MAP = "data/next_map.json", SHIP_MAP = "data/next_ship.json")
 #define HUNTERSHIPS_TEMPLATE_PATH "maps/predship/huntership.dmm"
+#define OVERRIDE_DEFAULT_MAP_CONFIG list(GROUND_MAP = "maps/override_ground.json", SHIP_MAP = "maps/override_ship.json")
 
 // traity things
 #define MAP_COLD "COLD"

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -85,7 +85,7 @@ SUBSYSTEM_DEF(mapping)
 	z_list = SSmapping.z_list
 
 #define INIT_ANNOUNCE(X) to_chat(world, "<span class='notice'>[X]</span>"); log_world(X)
-/datum/controller/subsystem/mapping/proc/LoadGroup(list/errorList, name, path, files, list/traits, list/default_traits, silent = FALSE)
+/datum/controller/subsystem/mapping/proc/LoadGroup(list/errorList, name, path, files, list/traits, list/default_traits, silent = FALSE, override_map_path = "maps/")
 	. = list()
 	var/start_time = REALTIMEOFDAY
 
@@ -96,7 +96,7 @@ SUBSYSTEM_DEF(mapping)
 	var/total_z = 0
 	var/list/parsed_maps = list()
 	for (var/file in files)
-		var/full_path = "maps/[path]/[file]"
+		var/full_path = "[override_map_path]/[path]/[file]"
 		var/datum/parsed_map/pm = new(file(full_path))
 		var/bounds = pm?.bounds
 		if (!bounds)
@@ -131,11 +131,11 @@ SUBSYSTEM_DEF(mapping)
 		INIT_ANNOUNCE("Loaded [name] in [(REALTIMEOFDAY - start_time)/10]s!")
 	return parsed_maps
 
-/datum/controller/subsystem/mapping/proc/Loadship(list/errorList, name, path, files, list/traits, list/default_traits, silent = FALSE)
-	LoadGroup(errorList, name, path, files, traits, default_traits, silent)
+/datum/controller/subsystem/mapping/proc/Loadship(list/errorList, name, path, files, list/traits, list/default_traits, silent = FALSE, override_map_path = "maps/")
+	LoadGroup(errorList, name, path, files, traits, default_traits, silent, override_map_path = override_map_path)
 
-/datum/controller/subsystem/mapping/proc/Loadground(list/errorList, name, path, files, list/traits, list/default_traits, silent = FALSE)
-	LoadGroup(errorList, name, path, files, traits, default_traits, silent)
+/datum/controller/subsystem/mapping/proc/Loadground(list/errorList, name, path, files, list/traits, list/default_traits, silent = FALSE, override_map_path = "maps/")
+	LoadGroup(errorList, name, path, files, traits, default_traits, silent, override_map_path = override_map_path)
 
 /datum/controller/subsystem/mapping/proc/loadWorld()
 	//if any of these fail, something has gone horribly, HORRIBLY, wrong
@@ -149,12 +149,18 @@ SUBSYSTEM_DEF(mapping)
 
 	var/datum/map_config/ground_map = configs[GROUND_MAP]
 	INIT_ANNOUNCE("Loading [ground_map.map_name]...")
-	Loadground(FailedZs, ground_map.map_name, ground_map.map_path, ground_map.map_file, ground_map.traits, ZTRAITS_GROUND)
+	var/ground_base_path = "maps/"
+	if(ground_map.override_map)
+		ground_base_path = "data/"
+	Loadground(FailedZs, ground_map.map_name, ground_map.map_path, ground_map.map_file, ground_map.traits, ZTRAITS_GROUND, override_map_path = ground_base_path)
 
 	if(!ground_map.disable_ship_map)
 		var/datum/map_config/ship_map = configs[SHIP_MAP]
+		var/ship_base_path = "maps/"
+		if(ship_map.override_map)
+			ship_base_path = "data/"
 		INIT_ANNOUNCE("Loading [ship_map.map_name]...")
-		Loadship(FailedZs, ship_map.map_name, ship_map.map_path, ship_map.map_file, ship_map.traits, ZTRAITS_MAIN_SHIP)
+		Loadship(FailedZs, ship_map.map_name, ship_map.map_path, ship_map.map_file, ship_map.traits, ZTRAITS_MAIN_SHIP, override_map_path = ship_base_path)
 
 	if(LAZYLEN(FailedZs)) //but seriously, unless the server's filesystem is messed up this will never happen
 		var/msg = "RED ALERT! The following map files failed to load: [FailedZs[1]]"

--- a/code/datums/map_config.dm
+++ b/code/datums/map_config.dm
@@ -63,6 +63,9 @@
 
 	var/nightmare_path
 
+	/// If truthy this is config for a round overriden map: search for override maps in data/, instead of using a path in maps/
+	var/override_map
+
 /datum/map_config/New()
 	survivor_types = list(
 		/datum/equipment_preset/survivor/scientist,
@@ -147,24 +150,35 @@
 
 	config_filename = filename
 
+	override_map = json["override_map"]
+
 	CHECK_EXISTS("map_name")
 	map_name = json["map_name"]
-	CHECK_EXISTS("map_path")
-	map_path = json["map_path"]
 
 	webmap_url = json["webmap_url"]
 	short_name = json["short_name"]
 
 	map_file = json["map_file"]
+
+	var/dirpath = "maps/"
+	if(override_map)
+		dirpath = "data/"
+		map_path = "/"
+		map_file = OVERRIDE_MAPS_TO_FILENAME[maptype]
+	else
+		CHECK_EXISTS("map_path")
+		map_path = json["map_path"]
+		dirpath = "[dirpath]/[map_path]"
+
 	// "map_file": "BoxStation.dmm"
 	if (istext(map_file))
-		if (!fexists("maps/[map_path]/[map_file]"))
+		if (!fexists("[dirpath]/[map_file]"))
 			log_world("Map file ([map_file]) does not exist!")
 			return
 	// "map_file": ["Lower.dmm", "Upper.dmm"]
 	else if (islist(map_file))
 		for (var/file in map_file)
-			if (!fexists("maps/[map_path]/[file]"))
+			if (!fexists("[dirpath]/[file]"))
 				log_world("Map file ([file]) does not exist!")
 				return
 	else
@@ -372,11 +386,14 @@
 #undef CHECK_EXISTS
 
 /datum/map_config/proc/GetFullMapPaths()
+	var/dirpath = "maps/[map_path]"
+	if(override_map)
+		dirpath = "data/[map_path]"
 	if (istext(map_file))
-		return list("maps/[map_path]/[map_file]")
+		return list("[dirpath]/[map_file]")
 	. = list()
 	for (var/file in map_file)
-		. += "maps/[map_path]/[file]"
+		. += "[dirpath]/[file]"
 
 
 /datum/map_config/proc/MakeNextMap(maptype = GROUND_MAP)

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -172,6 +172,7 @@ var/list/admin_verbs_server = list(
 	/datum/admins/proc/change_ground_map,
 	/datum/admins/proc/change_ship_map,
 	/datum/admins/proc/vote_ground_map,
+	/datum/admins/proc/override_ground_map,
 	/client/proc/cmd_admin_delete, /*delete an instance/object/mob/etc*/
 	/client/proc/cmd_debug_del_all,
 	/datum/admins/proc/togglejoin,

--- a/code/modules/admin/server_verbs.dm
+++ b/code/modules/admin/server_verbs.dm
@@ -70,7 +70,7 @@
 
 	message_admins(SPAN_ADMINNOTICE("[key_name_admin(usr)] is overriding the next '[map_type]' map with a custom one."))
 	fcopy(map, "data/[OVERRIDE_MAPS_TO_FILENAME[map_type]]")
-	if(tgui_alert(usr, "Do you want to upload a custom map config or use defaults? Config controls things like survivors and monkey types, camouflages, lore messages, map items, nightmare, special environemental features...", "Map Config Flavor", list("Default", "Override")) == "Override")
+	if(tgui_alert(usr, "Do you want to upload a custom map config or use defaults? Config controls things like survivors and monkey types, camouflages, lore messages, map items, nightmare, special environmental features...", "Map Config Flavor", list("Default", "Override")) == "Override")
 		tgui_alert(usr, "Choose the custom map configuration for next round. Make sure it's VALID. It MUST have \"override_map\":true !", "Warning", list("OK!"))
 		var/map_config = input(usr, "Choose custom map configuration to upload", "Upload Map Config") as null|file
 		if(map_config)

--- a/code/modules/admin/server_verbs.dm
+++ b/code/modules/admin/server_verbs.dm
@@ -50,6 +50,42 @@
 	log_admin("[key_name(usr)] started a groundmap vote.")
 	message_admins("[key_name_admin(usr)] started a groundmap vote.")
 
+/datum/admins/proc/override_ground_map()
+	set category = "Server"
+	set name = "M: Override Next Map"
+
+	if(!check_rights(R_SERVER))
+		return
+
+	var/map_type = tgui_alert(usr, "Override Ship or Ground Map?", "Map selection", list(GROUND_MAP, SHIP_MAP, "Cancel"))
+	if(map_type == "Cancel")
+		return
+
+	var/map = input(usr, "Choose a custom map to run for next round","Upload Map") as null|file
+	if(!map)
+		return
+	if(copytext("[map]", -4) != ".dmm")//4 == length(".dmm")
+		to_chat(usr,  SPAN_WARNING("Filename must end in '.dmm': [map]"), confidential = TRUE)
+		return
+
+	message_admins(SPAN_ADMINNOTICE("[key_name_admin(usr)] is overriding the next '[map_type]' map with a custom one."))
+	fcopy(map, "data/[OVERRIDE_MAPS_TO_FILENAME[map_type]]")
+	if(tgui_alert(usr, "Do you want to upload a custom map config or use defaults? Config controls things like survivors and monkey types, camouflages, lore messages, map items, nightmare, special environemental features...", "Map Config Flavor", list("Default", "Override")) == "Override")
+		tgui_alert(usr, "Choose the custom map configuration for next round. Make sure it's VALID. It MUST have \"override_map\":true !", "Warning", list("OK!"))
+		var/map_config = input(usr, "Choose custom map configuration to upload", "Upload Map Config") as null|file
+		if(map_config)
+			var/parse_check = json_decode(file2text(map_config))
+			if(parse_check && parse_check["override_map"])
+				fcopy(map_config, MAP_TO_FILENAME[map_type])
+				tgui_alert(usr, "Done, using uploaded map_config. ALWAYS check at start of round that the map loaded correctly when using this. Passing a map vote or changing it with verb vote will revert these changes. Good luck!", "One little thing...", list("OK"))
+				message_admins(SPAN_ADMINNOTICE("[key_name_admin(usr)] overrode next '[map_type]' map with '[map]' and '[map_config]' for settings."))
+				return
+		to_chat(usr, SPAN_ADMINNOTICE("Couldn't retrieve map_config file or it was invalid, using default config."))
+
+	fcopy(OVERRIDE_DEFAULT_MAP_CONFIG[map_type], MAP_TO_FILENAME[map_type])
+	tgui_alert(usr, "Done, using default map_config ('Unknown' map). ALWAYS check at start of round that the map loaded correctly when using this. Passing a map vote or changing it with verb vote will revert these changes. Good luck!", "One little thing...", list("OK"))
+	message_admins(SPAN_ADMINNOTICE("[key_name_admin(usr)] overrode next '[map_type]' map with '[map]' and default settings."))
+
 /datum/admins/proc/change_ship_map()
 	set category = "Server"
 	set name = "M: Change Ship Map"

--- a/maps/override_ground.json
+++ b/maps/override_ground.json
@@ -1,0 +1,21 @@
+{
+    "override_map": true,
+    "map_name": "Unknown",
+    "survivor_types": [
+        "/datum/equipment_preset/survivor/civilian",
+        "/datum/equipment_preset/survivor/goon"
+    ],
+    "map_item_type": "/obj/item/map/big_red_map",
+    "announce_text": "We've lost contact with a Weyland-Yutani's research facility. The ###SHIPNAME### has been dispatched to assist.",
+    "monkey_types": [
+        "neaera"
+    ],
+    "traits": [{ "Ground": true }],
+    "gamemodes": [
+        "Distress Signal",
+        "Hunter Games",
+        "Hive Wars",
+        "Faction Clash",
+        "Infection"
+    ]
+}

--- a/maps/override_ship.json
+++ b/maps/override_ship.json
@@ -1,0 +1,5 @@
+{
+    "override_map": true,
+    "map_name": "Ship",
+    "traits": [{"Marine Main Ship": true}]
+}

--- a/tools/ci/check_grep.sh
+++ b/tools/ci/check_grep.sh
@@ -166,9 +166,10 @@ part "map json sanity"
 for json in maps/*.json
 do
 	map_path=$(jq -r '.map_path' $json)
+	override_map = $(jq -r '.override_map' $json)
 	while read map_file; do
 		filename="maps/$map_path/$map_file"
-		if [ ! -f $filename ]
+		if [ ! -f $filename ] && [ ! -z "$override_map" ]
 		then
 			echo
 			echo -e "${RED}ERROR: found invalid file reference to $filename in _maps/$json.${NC}"

--- a/tools/ci/check_grep.sh
+++ b/tools/ci/check_grep.sh
@@ -169,7 +169,7 @@ do
 	override_map=$(jq -r '.override_map' $json)
 	while read map_file; do
 		filename="maps/$map_path/$map_file"
-		if [ ! -f $filename ] && [ ! -z "$override_map" ]
+		if [ ! -f $filename ] && [ -z "$override_map" ]
 		then
 			echo
 			echo -e "${RED}ERROR: found invalid file reference to $filename in _maps/$json.${NC}"

--- a/tools/ci/check_grep.sh
+++ b/tools/ci/check_grep.sh
@@ -166,7 +166,7 @@ part "map json sanity"
 for json in maps/*.json
 do
 	map_path=$(jq -r '.map_path' $json)
-	override_map = $(jq -r '.override_map' $json)
+	override_map=$(jq -r '.override_map' $json)
 	while read map_file; do
 		filename="maps/$map_path/$map_file"
 		if [ ! -f $filename ] && [ ! -z "$override_map" ]


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

This adds a verb that allows admins to upload a DMM Map + a JSON Map Config to override the normal map selection for next round. They also have the choice of using a default config if lazy and don't mind their map being called unknown, having useless survivors, no weather, etc etc etc (seriously, use a config).

This works by saving the map DMM to `data/` folder and overwriting the `data/next_map.json`/`data/next_ship.json` (did i mention it works with ships too?) as usually done by map changing. A number of dumb small refactors were neccessary to allow loading a map residing in `data/`, outside of `maps/`.

While the option to override ship maps is also present, our game code probably doesn't support major ship changes very well. It's advised to only use it with map variations, or full ships with the same set of functionalities.


# Explain why it's good for the game
Admins can actually run their events without randomly loading their maps in the middle of ground map butchering it and causing random issues. It also lets them upload the config for it to be named / setup properly.

# Changelog
:cl:
add: Added a map override for Admins allowing them to load in maps directly as ground or ship during the next round.
/:cl:
