### PR TITLE
Get_Access() overhaul

### DIFF
--- a/code/__DEFINES/access.dm
+++ b/code/__DEFINES/access.dm
@@ -35,7 +35,7 @@ most of them are tied into map-placed objects. This should be reworked in the fu
 #define ACCESS_MARINE_RESEARCH 28
 #define ACCESS_MARINE_SEA    29
 #define ACCESS_MARINE_KITCHEN    30
-#define ACCESS_MARINE_CAPTAIN 31
+#define ACCESS_MARINE_CO 31
 #define ACCESS_MARINE_TL_PREP 32
 
 #define ACCESS_MARINE_MAINT 34

--- a/code/game/gamemodes/cm_self_destruct.dm
+++ b/code/game/gamemodes/cm_self_destruct.dm
@@ -369,7 +369,7 @@ var/global/datum/authority/branch/evacuation/EvacuationAuthority //This is initi
 	name = "self-destruct control panel"
 	icon_state = "console_1"
 	base_icon_state = "console"
-	req_one_access = list(ACCESS_MARINE_CAPTAIN, ACCESS_MARINE_SENIOR)
+	req_one_access = list(ACCESS_MARINE_CO, ACCESS_MARINE_SENIOR)
 
 /obj/structure/machinery/self_destruct/console/Destroy()
 	. = ..()

--- a/code/game/jobs/access.dm
+++ b/code/game/jobs/access.dm
@@ -82,11 +82,10 @@
 		return
 	return 1
 
-/proc/get_centcom_access(job)
-	return get_all_centcom_access()
-
-/proc/get_all_accesses()
-	return get_all_marine_access() + get_all_civilian_accesses()
+/proc/get_global_access()//Grants access to EVERYWHERE
+	return get_all_marine_accesses() + get_all_main_accesses()
+/proc/get_all_main_accesses()//Grants standard access for all factions, does not include high restrictions like COs office.
+	return get_antagonist_access() + get_all_civilian_accesses() + get_all_weyland_access()
 
 /proc/get_all_civilian_accesses()
 	return list(
@@ -99,7 +98,10 @@
 		ACCESS_CIVILIAN_COMMAND,
 	)
 
-/proc/get_all_marine_access()
+/proc/get_all_marine_accesses()//Includes restricted accesses
+	return list(ACCESS_MARINE_CAPTAIN) + get_main_marine_accesses()
+
+/proc/get_main_marine_accesses()//All Almayer accesses other than the highly restricted ones, such as CO's office.
 	return list(
 		ACCESS_MARINE_CAPTAIN,
 		ACCESS_MARINE_SENIOR,
@@ -138,25 +140,27 @@
 		ACCESS_PRESS,
 	)
 
-/proc/get_all_centcom_access()
+/proc/get_weyland_access(job)//Fairly sure this isn't really needed anymore
+	return get_all_weyland_access()
+/proc/get_all_weyland_access()//Renamed from centcom for fairly obvious reasons.
 	return list(ACCESS_WY_PMC_GREEN, ACCESS_WY_PMC_ORANGE, ACCESS_WY_PMC_RED, ACCESS_WY_PMC_BLACK, ACCESS_WY_PMC_WHITE, ACCESS_WY_CORPORATE)
 
-/proc/get_all_syndicate_access()
-	return list(ACCESS_ILLEGAL_PIRATE)
+/proc/get_antagonist_access()//CLF & UPP, UPP Commandos have global.
+	return get_main_marine_accesses() + list(ACCESS_ILLEGAL_PIRATE)
 
-/proc/get_antagonist_access()
-	return get_all_accesses() + get_all_syndicate_access()
+/proc/get_weyland_pmc_access()//Used by PMCs and elite mercs.
+	return get_all_main_accesses()
 
-/proc/get_antagonist_pmc_access()
-	return get_antagonist_access()
+/proc/get_friendly_ert_access()//This is only used by USCM ERTs at present
+	return get_main_marine_accesses() + get_all_civilian_accesses()
 
-/proc/get_freelancer_access()
+/proc/get_civil_ert_access()//Pizza and Souto
 	return list(ACCESS_MARINE_COMMAND, ACCESS_MARINE_CARGO, ACCESS_CIVILIAN_PUBLIC, ACCESS_CIVILIAN_RESEARCH, ACCESS_CIVILIAN_ENGINEERING, ACCESS_CIVILIAN_LOGISTICS)
 
 /proc/get_region_accesses(code)
 	switch(code)
 		if(0)
-			return get_all_accesses()
+			return get_all_main_accesses()
 		if(1)
 			return list(ACCESS_MARINE_CMP, ACCESS_MARINE_BRIG, ACCESS_MARINE_ARMORY) // Security
 		if(2)
@@ -248,7 +252,7 @@
 		if(ACCESS_MARINE_KITCHEN) return "Kitchen"
 		if(ACCESS_MARINE_SYNTH) return "Synthetic Storage"
 
-/proc/get_centcom_access_desc(A)
+/proc/get_weyland_access_desc(A)
 	switch(A)
 		if(ACCESS_WY_PMC_GREEN) return "Wey-Yu PMC Green"
 		if(ACCESS_WY_PMC_ORANGE) return "Wey-Yu PMC Orange"

--- a/code/game/jobs/access.dm
+++ b/code/game/jobs/access.dm
@@ -82,12 +82,14 @@
 		return
 	return 1
 
-/proc/get_global_access()//Grants access to EVERYWHERE
-	return get_all_marine_accesses() + get_all_main_accesses()
-/proc/get_all_main_accesses()//Grants standard access for all factions, does not include high restrictions like COs office.
-	return get_antagonist_access() + get_all_civilian_accesses() + get_all_weyland_access()
+///Grants access to EVERYWHERE
+/proc/get_global_access()
+	return get_all_marine_access() + get_all_main_access()
+///Grants standard access for all factions, does not include high restrictions like COs office.
+/proc/get_all_main_access()
+	return get_antagonist_access() + get_all_civilian_access() + get_all_weyland_access()
 
-/proc/get_all_civilian_accesses()
+/proc/get_all_civilian_access()
 	return list(
 		ACCESS_CIVILIAN_PUBLIC,
 		ACCESS_CIVILIAN_RESEARCH,
@@ -98,12 +100,13 @@
 		ACCESS_CIVILIAN_COMMAND,
 	)
 
-/proc/get_all_marine_accesses()//Includes restricted accesses
-	return list(ACCESS_MARINE_CAPTAIN) + get_main_marine_accesses()
+///Includes restricted accesses
+/proc/get_all_marine_access()
+	return list(ACCESS_MARINE_CO) + get_main_marine_access()
 
-/proc/get_main_marine_accesses()//All Almayer accesses other than the highly restricted ones, such as CO's office.
+///All Almayer accesses other than the highly restricted ones, such as CO's office.
+/proc/get_main_marine_access()
 	return list(
-		ACCESS_MARINE_CAPTAIN,
 		ACCESS_MARINE_SENIOR,
 		ACCESS_MARINE_DATABASE,
 		ACCESS_MARINE_COMMAND,
@@ -140,27 +143,30 @@
 		ACCESS_PRESS,
 	)
 
-/proc/get_weyland_access(job)//Fairly sure this isn't really needed anymore
-	return get_all_weyland_access()
-/proc/get_all_weyland_access()//Renamed from centcom for fairly obvious reasons.
+///Renamed from centcom for fairly obvious reasons.
+/proc/get_all_weyland_access()
 	return list(ACCESS_WY_PMC_GREEN, ACCESS_WY_PMC_ORANGE, ACCESS_WY_PMC_RED, ACCESS_WY_PMC_BLACK, ACCESS_WY_PMC_WHITE, ACCESS_WY_CORPORATE)
 
-/proc/get_antagonist_access()//CLF & UPP, UPP Commandos have global.
-	return get_main_marine_accesses() + list(ACCESS_ILLEGAL_PIRATE)
+///CLF & UPP, UPP Commandos have global.
+/proc/get_antagonist_access()
+	return get_main_marine_access() + list(ACCESS_ILLEGAL_PIRATE)
 
-/proc/get_weyland_pmc_access()//Used by PMCs and elite mercs.
-	return get_all_main_accesses()
+///Used by PMCs and elite mercs.
+/proc/get_weyland_pmc_access()
+	return get_all_main_access()
 
-/proc/get_friendly_ert_access()//This is only used by USCM ERTs at present
-	return get_main_marine_accesses() + get_all_civilian_accesses()
+///This is only used by USCM ERTs at present
+/proc/get_friendly_ert_access()
+	return get_main_marine_access() + get_all_civilian_access()
 
-/proc/get_civil_ert_access()//Pizza and Souto
+///Pizza and Souto
+/proc/get_civil_ert_access()
 	return list(ACCESS_MARINE_COMMAND, ACCESS_MARINE_CARGO, ACCESS_CIVILIAN_PUBLIC, ACCESS_CIVILIAN_RESEARCH, ACCESS_CIVILIAN_ENGINEERING, ACCESS_CIVILIAN_LOGISTICS)
 
 /proc/get_region_accesses(code)
 	switch(code)
 		if(0)
-			return get_all_main_accesses()
+			return get_all_main_access()
 		if(1)
 			return list(ACCESS_MARINE_CMP, ACCESS_MARINE_BRIG, ACCESS_MARINE_ARMORY) // Security
 		if(2)
@@ -170,7 +176,7 @@
 		if(4)
 			return list(ACCESS_MARINE_CE, ACCESS_MARINE_ENGINEERING, ACCESS_MARINE_OT, ACCESS_MARINE_MAINT) // Engineering
 		if(5)
-			return list(ACCESS_MARINE_CAPTAIN, ACCESS_MARINE_SENIOR, ACCESS_MARINE_DATABASE, ACCESS_MARINE_COMMAND, ACCESS_MARINE_RO, ACCESS_MARINE_CARGO, ACCESS_MARINE_SEA, ACCESS_MARINE_SYNTH) // Command
+			return list(ACCESS_MARINE_CO, ACCESS_MARINE_SENIOR, ACCESS_MARINE_DATABASE, ACCESS_MARINE_COMMAND, ACCESS_MARINE_RO, ACCESS_MARINE_CARGO, ACCESS_MARINE_SEA, ACCESS_MARINE_SYNTH) // Command
 		if(6)
 			return list(ACCESS_MARINE_PREP, ACCESS_MARINE_MEDPREP, ACCESS_MARINE_ENGPREP, ACCESS_MARINE_SMARTPREP, ACCESS_MARINE_LEADER, ACCESS_MARINE_SPECPREP, ACCESS_MARINE_TL_PREP, ACCESS_MARINE_KITCHEN)//spess mahreens
 		if(7)
@@ -222,7 +228,7 @@
 		if(ACCESS_MARINE_ENGINEERING) return "[MAIN_SHIP_NAME] Engineering"
 		if(ACCESS_MARINE_OT) return "[MAIN_SHIP_NAME] Ordnance Workshop"
 		if(ACCESS_MARINE_SENIOR) return "[MAIN_SHIP_NAME] Senior Command"
-		if(ACCESS_MARINE_CAPTAIN) return "Commander's Quarters"
+		if(ACCESS_MARINE_CO) return "Commander's Quarters"
 		if(ACCESS_MARINE_DATABASE) return "[MAIN_SHIP_NAME]'s Database"
 		if(ACCESS_MARINE_COMMAND) return "[MAIN_SHIP_NAME] Command"
 		if(ACCESS_MARINE_CREWMAN) return "Vehicle Crewman"

--- a/code/game/jobs/access.dm
+++ b/code/game/jobs/access.dm
@@ -143,7 +143,6 @@
 		ACCESS_PRESS,
 	)
 
-///Renamed from centcom for fairly obvious reasons.
 /proc/get_all_weyland_access()
 	return list(ACCESS_WY_PMC_GREEN, ACCESS_WY_PMC_ORANGE, ACCESS_WY_PMC_RED, ACCESS_WY_PMC_BLACK, ACCESS_WY_PMC_WHITE, ACCESS_WY_CORPORATE)
 

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -331,7 +331,7 @@
 	assignment = "Captain"
 
 /obj/item/card/id/captains_spare/New()
-	access = get_all_marine_accesses()
+	access = get_all_marine_access()
 	..()
 
 /obj/item/card/id/centcom

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -210,7 +210,7 @@
 	assignment = "Corporate Mercenary"
 
 /obj/item/card/id/pmc/New()
-	access = get_all_centcom_access()
+	access = get_all_weyland_access()
 	..()
 
 /obj/item/card/id/pmc/ds
@@ -236,7 +236,7 @@
 	assignment = "General"
 
 /obj/item/card/id/general/New()
-	access = get_all_centcom_access()
+	access = get_all_weyland_access()
 
 /obj/item/card/id/provost
 	name = "provost holo-badge"
@@ -246,7 +246,7 @@
 	assignment = "Provost"
 
 /obj/item/card/id/provost/New()
-	access = get_all_centcom_access()
+	access = get_all_weyland_access()
 
 /obj/item/card/id/syndicate
 	name = "agent card"
@@ -331,7 +331,7 @@
 	assignment = "Captain"
 
 /obj/item/card/id/captains_spare/New()
-	access = get_all_marine_access()
+	access = get_all_marine_accesses()
 	..()
 
 /obj/item/card/id/centcom
@@ -342,7 +342,7 @@
 	assignment = "General"
 
 /obj/item/card/id/centcom/New()
-	access = get_all_centcom_access()
+	access = get_all_weyland_access()
 	..()
 
 

--- a/code/game/objects/items/circuitboards/airlock.dm
+++ b/code/game/objects/items/circuitboards/airlock.dm
@@ -44,7 +44,7 @@
 
 		t1 += "<br>"
 
-		var/list/accesses = get_all_main_accesses()
+		var/list/accesses = get_all_main_access()
 		for (var/acc in accesses)
 			var/aname = get_access_desc(acc)
 

--- a/code/game/objects/items/circuitboards/airlock.dm
+++ b/code/game/objects/items/circuitboards/airlock.dm
@@ -44,7 +44,7 @@
 
 		t1 += "<br>"
 
-		var/list/accesses = get_all_accesses()
+		var/list/accesses = get_all_main_accesses()
 		for (var/acc in accesses)
 			var/aname = get_access_desc(acc)
 

--- a/code/game/objects/structures/crates_lockers/closets/secure/cm_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/cm_closets.dm
@@ -5,7 +5,7 @@ GLOBAL_LIST_EMPTY(co_secure_boxes)
 //MARINE COMMAND CLOSET
 /obj/structure/closet/secure_closet/commander
 	name = "commanding officer's locker"
-	req_access = list(ACCESS_MARINE_CAPTAIN)
+	req_access = list(ACCESS_MARINE_CO)
 	icon_state = "secure_locked_commander"
 	icon_closed = "secure_unlocked_commander"
 	icon_locked = "secure_locked_commander"
@@ -22,7 +22,7 @@ GLOBAL_LIST_EMPTY(co_secure_boxes)
 
 /obj/structure/closet/secure_closet/securecom
 	name = "commanding officer's secure box"
-	req_access = list(ACCESS_MARINE_CAPTAIN)
+	req_access = list(ACCESS_MARINE_CO)
 	desc = "A safe for the Commanding Officer to store any equipment they need to have ready at a moment's notice. There's a note inside saying that whatever was inside it before was moved out."
 	icon = 'icons/obj/structures/marine_closet.dmi'
 	icon_state = "commander_safe"

--- a/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
@@ -41,7 +41,7 @@
 				open()
 			else
 				src.req_access = list()
-				src.req_access += pick(get_all_accesses())
+				src.req_access += pick(get_all_main_accesses())
 	..()
 
 /obj/structure/closet/secure_closet/proc/togglelock(mob/living/user)

--- a/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
@@ -41,7 +41,7 @@
 				open()
 			else
 				src.req_access = list()
-				src.req_access += pick(get_all_main_accesses())
+				src.req_access += pick(get_all_main_access())
 	..()
 
 /obj/structure/closet/secure_closet/proc/togglelock(mob/living/user)

--- a/code/game/objects/structures/crates_lockers/secure_crates.dm
+++ b/code/game/objects/structures/crates_lockers/secure_crates.dm
@@ -104,7 +104,7 @@
 			open()
 		else
 			src.req_access = list()
-			src.req_access += pick(get_all_main_accesses())
+			src.req_access += pick(get_all_main_access())
 	..()
 
 

--- a/code/game/objects/structures/crates_lockers/secure_crates.dm
+++ b/code/game/objects/structures/crates_lockers/secure_crates.dm
@@ -104,7 +104,7 @@
 			open()
 		else
 			src.req_access = list()
-			src.req_access += pick(get_all_accesses())
+			src.req_access += pick(get_all_main_accesses())
 	..()
 
 

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -149,11 +149,11 @@
 		if (H.wear_id)
 			var/obj/item/card/id/id = H.wear_id
 			id.icon_state = "gold"
-			id:access = get_all_accesses()+get_all_centcom_access()+get_all_syndicate_access()
+			id:access = get_global_access()
 		else
 			var/obj/item/card/id/id = new/obj/item/card/id(M);
 			id.icon_state = "gold"
-			id:access = get_all_accesses()+get_all_centcom_access()+get_all_syndicate_access()
+			id:access = get_all_main_accesses()+list(ACCESS_ILLEGAL_PIRATE)
 			id.registered_name = H.real_name
 			id.registered_ref = WEAKREF(H)
 			id.assignment = "Captain"

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -153,7 +153,7 @@
 		else
 			var/obj/item/card/id/id = new/obj/item/card/id(M);
 			id.icon_state = "gold"
-			id:access = get_all_main_accesses()+list(ACCESS_ILLEGAL_PIRATE)
+			id:access = get_all_main_access()
 			id.registered_name = H.real_name
 			id.registered_ref = WEAKREF(H)
 			id.assignment = "Captain"

--- a/code/modules/cm_marines/marines_consoles.dm
+++ b/code/modules/cm_marines/marines_consoles.dm
@@ -109,7 +109,7 @@
 								<u>Access:</u><br>
 								"}
 
-					var/known_access_rights = get_all_accesses()
+					var/known_access_rights = get_all_main_accesses()
 					for(var/A in target_id_card.access)
 						if(A in known_access_rights)
 							contents += "  [get_access_desc(A)]"
@@ -197,7 +197,7 @@
 			else
 				var/list/new_access = list()
 				if(is_centcom)
-					new_access = get_centcom_access(target)
+					new_access = get_weyland_access(target)
 				else
 					var/datum/job/job = RoleAuthority.roles_for_mode[target]
 
@@ -205,7 +205,7 @@
 						visible_message("[SPAN_BOLD("[src]")] states, \"DATA ERROR: Can not find next entry in database: [target]\"")
 						return
 					new_access = job.get_access()
-				target_id_card.access -= get_all_centcom_access() + get_all_accesses()
+				target_id_card.access -= get_all_weyland_access() + get_all_main_accesses()
 				target_id_card.access |= new_access
 				target_id_card.assignment = target
 				target_id_card.rank = target
@@ -227,7 +227,7 @@
 					log_idmod(target_id_card, "<font color='green'> [key_name_admin(usr)] granted [access_type] IFF. </font>")
 				return TRUE
 			access_type = text2num(params["access_target"])
-			if(access_type in (is_centcom ? get_all_centcom_access() : get_all_accesses()))
+			if(access_type in (is_centcom ? get_all_weyland_access() : get_all_main_accesses()))
 				if(access_type in target_id_card.access)
 					target_id_card.access -= access_type
 					log_idmod(target_id_card, "<font color='red'> [key_name_admin(usr)] revoked access '[access_type]'. </font>")
@@ -239,7 +239,7 @@
 			if(!authenticated || !target_id_card)
 				return
 
-			target_id_card.access |= (is_centcom ? get_all_centcom_access() : get_all_accesses())
+			target_id_card.access |= (is_centcom ? get_all_weyland_access() : get_all_main_accesses())
 			target_id_card.faction_group |= factions
 			log_idmod(target_id_card, "<font color='green'> [key_name_admin(usr)] granted the ID all access and USCM IFF. </font>")
 			return TRUE

--- a/code/modules/cm_marines/marines_consoles.dm
+++ b/code/modules/cm_marines/marines_consoles.dm
@@ -109,7 +109,7 @@
 								<u>Access:</u><br>
 								"}
 
-					var/known_access_rights = get_all_main_accesses()
+					var/known_access_rights = get_all_main_access()
 					for(var/A in target_id_card.access)
 						if(A in known_access_rights)
 							contents += "  [get_access_desc(A)]"
@@ -197,7 +197,7 @@
 			else
 				var/list/new_access = list()
 				if(is_centcom)
-					new_access = get_weyland_access(target)
+					new_access = get_all_weyland_access()
 				else
 					var/datum/job/job = RoleAuthority.roles_for_mode[target]
 
@@ -205,7 +205,7 @@
 						visible_message("[SPAN_BOLD("[src]")] states, \"DATA ERROR: Can not find next entry in database: [target]\"")
 						return
 					new_access = job.get_access()
-				target_id_card.access -= get_all_weyland_access() + get_all_main_accesses()
+				target_id_card.access -= get_all_weyland_access() + get_all_main_access()
 				target_id_card.access |= new_access
 				target_id_card.assignment = target
 				target_id_card.rank = target
@@ -227,7 +227,7 @@
 					log_idmod(target_id_card, "<font color='green'> [key_name_admin(usr)] granted [access_type] IFF. </font>")
 				return TRUE
 			access_type = text2num(params["access_target"])
-			if(access_type in (is_centcom ? get_all_weyland_access() : get_all_main_accesses()))
+			if(access_type in (is_centcom ? get_all_weyland_access() : get_main_marine_access()))
 				if(access_type in target_id_card.access)
 					target_id_card.access -= access_type
 					log_idmod(target_id_card, "<font color='red'> [key_name_admin(usr)] revoked access '[access_type]'. </font>")
@@ -239,7 +239,7 @@
 			if(!authenticated || !target_id_card)
 				return
 
-			target_id_card.access |= (is_centcom ? get_all_weyland_access() : get_all_main_accesses())
+			target_id_card.access |= (is_centcom ? get_all_weyland_access() : get_main_marine_access())
 			target_id_card.faction_group |= factions
 			log_idmod(target_id_card, "<font color='green'> [key_name_admin(usr)] granted the ID all access and USCM IFF. </font>")
 			return TRUE

--- a/code/modules/gear_presets/cmb.dm
+++ b/code/modules/gear_presets/cmb.dm
@@ -7,7 +7,7 @@
 
 /datum/equipment_preset/cmb/New()
 	. = ..()
-	access = get_all_accesses() + get_all_civilian_accesses()
+	access = get_main_marine_accesses() + get_all_civilian_accesses()
 
 /datum/equipment_preset/cmb/load_name(mob/living/carbon/human/new_human, randomise)
 	new_human.gender = pick(80;MALE,20;FEMALE)
@@ -53,7 +53,7 @@
 
 /datum/equipment_preset/cmb/New()
 	. = ..()
-	access = get_all_accesses() + get_all_civilian_accesses()
+	access = get_friendly_ert_access()
 
 
 /datum/equipment_preset/cmb/load_name(mob/living/carbon/human/new_human)
@@ -448,7 +448,7 @@
 
 /datum/equipment_preset/uscm/cmb/New()
 	. = ..()
-	access = get_all_accesses() + list(ACCESS_MARINE_PREP)
+	access = get_friendly_ert_access()
 
 	assignment = "Anchorpoint Station Marine Rifleman"
 	rank = JOB_SQUAD_MARINE
@@ -504,7 +504,6 @@
 	flags = EQUIPMENT_PRESET_EXTRA|EQUIPMENT_PRESET_MARINE
 /datum/equipment_preset/uscm/cmb/leader/New()
 	. = ..()
-	access = get_all_accesses() + list(ACCESS_MARINE_PREP, ACCESS_MARINE_LEADER, ACCESS_MARINE_DROPSHIP)
 
 	assignment = "Anchorpoint Station Marine Team Leader"
 	rank = JOB_SQUAD_LEADER
@@ -550,7 +549,7 @@
 	flags = EQUIPMENT_PRESET_EXTRA|EQUIPMENT_PRESET_MARINE
 /datum/equipment_preset/uscm/cmb/rto/New()
 	. = ..()
-	access = get_all_accesses() + list(ACCESS_MARINE_PREP, ACCESS_MARINE_TL_PREP)
+	access = get_friendly_ert_access()
 
 	assignment = "Anchorpoint Station Marine Technical Specialist"
 	rank = JOB_SQUAD_TEAM_LEADER
@@ -598,7 +597,6 @@
 	flags = EQUIPMENT_PRESET_EXTRA|EQUIPMENT_PRESET_MARINE
 /datum/equipment_preset/uscm/cmb/medic/New()
 	. = ..()
-	access = get_all_accesses() + list(ACCESS_MARINE_PREP, ACCESS_MARINE_MEDPREP, ACCESS_MARINE_MEDBAY)
 
 	assignment = "Anchorpoint Station Hospital Corpsman"
 	rank = JOB_SQUAD_MEDIC
@@ -660,7 +658,6 @@
 	flags = EQUIPMENT_PRESET_EXTRA|EQUIPMENT_PRESET_MARINE
 /datum/equipment_preset/uscm/cmb/smartgunner/New()
 	. = ..()
-	access = get_all_accesses() + list(ACCESS_MARINE_PREP, ACCESS_MARINE_SMARTPREP)
 
 	assignment = "Anchorpoint Station Marine Smartgunner"
 	rank = JOB_SQUAD_SMARTGUN

--- a/code/modules/gear_presets/cmb.dm
+++ b/code/modules/gear_presets/cmb.dm
@@ -1,49 +1,5 @@
 /datum/equipment_preset/cmb
 	name = "Colonial Marshal"
-
-	assignment = "CMB Deputy"
-	rank = JOB_CMB
-	faction = FACTION_USCM
-
-/datum/equipment_preset/cmb/New()
-	. = ..()
-	access = get_main_marine_accesses() + get_all_civilian_accesses()
-
-/datum/equipment_preset/cmb/load_name(mob/living/carbon/human/new_human, randomise)
-	new_human.gender = pick(80;MALE,20;FEMALE)
-	var/datum/preferences/A = new()
-	A.randomize_appearance(new_human)
-	var/random_name
-	var/static/list/colors = list("BLACK" = list(15, 15, 25), "BROWN" = list(102, 51, 0), "AUBURN" = list(139, 62, 19))
-	var/static/list/hair_colors = colors.Copy() + list("BLONDE" = list(197, 164, 30), "CARROT" = list(174, 69, 42))
-	var/hair_color = pick(hair_colors)
-	new_human.r_hair = hair_colors[hair_color][1]
-	new_human.g_hair = hair_colors[hair_color][2]
-	new_human.b_hair = hair_colors[hair_color][3]
-	new_human.r_facial = hair_colors[hair_color][1]
-	new_human.g_facial = hair_colors[hair_color][2]
-	new_human.b_facial = hair_colors[hair_color][3]
-	var/eye_color = pick(colors)
-	new_human.r_eyes = colors[eye_color][1]
-	new_human.g_eyes = colors[eye_color][2]
-	new_human.b_eyes = colors[eye_color][3]
-	if(new_human.gender == MALE)
-		random_name = "[pick(first_names_male)] [pick(last_names)]"
-		new_human.h_style = pick("Crewcut", "Shaved Head", "Buzzcut", "Undercut", "Side Undercut", "Pvt. Joker", "Marine Fade", "Low Fade", "Medium Fade", "High Fade", "No Fade", "Coffee House Cut", "Flat Top",)
-		new_human.f_style = pick("5 O'clock Shadow", "Shaved", "Full Beard", "3 O'clock Moustache", "5 O'clock Shadow", "5 O'clock Moustache", "7 O'clock Shadow", "7 O'clock Moustache",)
-	else
-		random_name = "[pick(first_names_female)] [pick(last_names)]"
-		new_human.h_style = pick("Ponytail 1", "Ponytail 2", "Ponytail 3", "Ponytail 4", "Pvt. Redding", "Pvt. Clarison", "Cpl. Dietrich", "Pvt. Vasquez", "Marine Bun", "Marine Bun 2", "Marine Flat Top",)
-	new_human.change_real_name(new_human, random_name)
-	new_human.age = rand(20,45)
-	new_human.r_hair = rand(15,35)
-	new_human.g_hair = rand(15,35)
-	new_human.b_hair = rand(25,45)
-
-//*****************************************************************************************************/
-
-/datum/equipment_preset/cmb
-	name = "Colonial Marshal"
 	faction = FACTION_USCM
 	rank = JOB_CMB
 	idtype = /obj/item/card/id/deputy
@@ -54,7 +10,6 @@
 /datum/equipment_preset/cmb/New()
 	. = ..()
 	access = get_friendly_ert_access()
-
 
 /datum/equipment_preset/cmb/load_name(mob/living/carbon/human/new_human)
 	new_human.gender = pick(80;MALE,20;FEMALE)
@@ -549,7 +504,6 @@
 	flags = EQUIPMENT_PRESET_EXTRA|EQUIPMENT_PRESET_MARINE
 /datum/equipment_preset/uscm/cmb/rto/New()
 	. = ..()
-	access = get_friendly_ert_access()
 
 	assignment = "Anchorpoint Station Marine Technical Specialist"
 	rank = JOB_SQUAD_TEAM_LEADER

--- a/code/modules/gear_presets/contractor.dm
+++ b/code/modules/gear_presets/contractor.dm
@@ -8,7 +8,7 @@
 
 /datum/equipment_preset/contractor/New()
 	. = ..()
-	access = get_all_accesses() + get_all_centcom_access()
+	access = get_all_main_accesses()
 
 /datum/equipment_preset/contractor/load_name(mob/living/carbon/human/new_human, randomise)
 	new_human.gender = pick(80;MALE,20;FEMALE)
@@ -57,7 +57,7 @@
 
 /datum/equipment_preset/contractor/New()
 	. = ..()
-	access = get_all_accesses() + get_all_centcom_access()
+	access = get_all_main_accesses()
 
 
 /datum/equipment_preset/dust_raider/load_name(mob/living/carbon/human/new_human)
@@ -598,7 +598,7 @@
 
 /datum/equipment_preset/contractor/covert/heavy/New()
 	. = ..()
-	access = get_antagonist_pmc_access()
+	access = get_weyland_pmc_access()
 
 /datum/equipment_preset/contractor/covert/heavy/load_gear(mob/living/carbon/human/new_human)
 	new_human.equip_to_slot_or_del(new headset_type, WEAR_L_EAR)
@@ -651,7 +651,7 @@
 
 /datum/equipment_preset/contractor/covert/engi/New()
 	. = ..()
-	access = get_antagonist_pmc_access()
+	access = get_weyland_pmc_access()
 
 /datum/equipment_preset/contractor/covert/engi/load_gear(mob/living/carbon/human/new_human)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/under/colonist/wy_davisone, WEAR_BODY)
@@ -703,7 +703,7 @@
 
 /datum/equipment_preset/contractor/covert/medic/New()
 	. = ..()
-	access = get_antagonist_pmc_access()
+	access = get_weyland_pmc_access()
 
 /datum/equipment_preset/contractor/covert/medic/load_gear(mob/living/carbon/human/new_human)
 	//clothing

--- a/code/modules/gear_presets/contractor.dm
+++ b/code/modules/gear_presets/contractor.dm
@@ -8,7 +8,7 @@
 
 /datum/equipment_preset/contractor/New()
 	. = ..()
-	access = get_all_main_accesses()
+	access = get_all_main_access()
 
 /datum/equipment_preset/contractor/load_name(mob/living/carbon/human/new_human, randomise)
 	new_human.gender = pick(80;MALE,20;FEMALE)
@@ -57,7 +57,7 @@
 
 /datum/equipment_preset/contractor/New()
 	. = ..()
-	access = get_all_main_accesses()
+	access = get_all_main_access()
 
 
 /datum/equipment_preset/dust_raider/load_name(mob/living/carbon/human/new_human)

--- a/code/modules/gear_presets/corpses.dm
+++ b/code/modules/gear_presets/corpses.dm
@@ -217,7 +217,7 @@
 /datum/equipment_preset/corpse/clown/New()
 	. = ..()
 	//As a joke, clown has all access so they can clown everywhere...
-	access = get_all_main_accesses()
+	access = get_all_main_access()
 
 /datum/equipment_preset/corpse/clown/load_name(mob/living/carbon/human/new_human, randomise)
 	. = ..() //To load gender, randomise appearance, etc.

--- a/code/modules/gear_presets/corpses.dm
+++ b/code/modules/gear_presets/corpses.dm
@@ -217,7 +217,7 @@
 /datum/equipment_preset/corpse/clown/New()
 	. = ..()
 	//As a joke, clown has all access so they can clown everywhere...
-	access = get_all_accesses()
+	access = get_all_main_accesses()
 
 /datum/equipment_preset/corpse/clown/load_name(mob/living/carbon/human/new_human, randomise)
 	. = ..() //To load gender, randomise appearance, etc.

--- a/code/modules/gear_presets/fun.dm
+++ b/code/modules/gear_presets/fun.dm
@@ -246,7 +246,7 @@
 
 /datum/equipment_preset/fun/santa/New()
 	. = ..()
-	access = get_all_accesses() + get_all_centcom_access()
+	access = get_global_access()
 
 /datum/equipment_preset/fun/santa/load_name(mob/living/carbon/human/new_human, randomise)
 	new_human.gender = MALE
@@ -342,7 +342,7 @@
 
 /datum/equipment_preset/fun/van_bandolier/New()
 	. = ..()
-	access = get_all_accesses()
+	access = get_global_access()
 
 /datum/equipment_preset/fun/van_bandolier/load_name(mob/living/carbon/human/new_human, randomise)
 	new_human.gender = MALE

--- a/code/modules/gear_presets/other.dm
+++ b/code/modules/gear_presets/other.dm
@@ -38,7 +38,7 @@
 
 /datum/equipment_preset/other/freelancer/New()
 	. = ..()
-	access = get_all_main_accesses()
+	access = get_all_main_access()
 
 /datum/equipment_preset/other/freelancer/load_name(mob/living/carbon/human/new_human, randomise)
 	new_human.gender = pick(60;MALE,40;FEMALE)
@@ -247,7 +247,7 @@
 
 /datum/equipment_preset/other/elite_merc/New()
 	. = ..()
-	access = get_all_main_accesses()
+	access = get_all_main_access()
 
 /datum/equipment_preset/other/elite_merc/load_name(mob/living/carbon/human/new_human, randomise)
 	new_human.gender = pick(70;MALE,30;FEMALE)
@@ -512,7 +512,7 @@
 
 /datum/equipment_preset/other/business_person/New()
 	. = ..()
-	access = get_all_main_accesses()
+	access = get_all_main_access()
 
 /datum/equipment_preset/other/business_person/load_gear(mob/living/carbon/human/new_human)
 	//TODO: add backpacks and satchels
@@ -789,7 +789,7 @@
 
 /datum/equipment_preset/other/xeno_cultist/New()
 	. = ..()
-	access = get_all_civilian_accesses()
+	access = get_all_civilian_access()
 
 /datum/equipment_preset/other/xeno_cultist/load_gear(mob/living/carbon/human/new_human)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/under/rank/chaplain/cultist(new_human), WEAR_BODY)

--- a/code/modules/gear_presets/other.dm
+++ b/code/modules/gear_presets/other.dm
@@ -38,7 +38,7 @@
 
 /datum/equipment_preset/other/freelancer/New()
 	. = ..()
-	access = get_all_accesses()
+	access = get_all_main_accesses()
 
 /datum/equipment_preset/other/freelancer/load_name(mob/living/carbon/human/new_human, randomise)
 	new_human.gender = pick(60;MALE,40;FEMALE)
@@ -247,7 +247,7 @@
 
 /datum/equipment_preset/other/elite_merc/New()
 	. = ..()
-	access = get_all_accesses()
+	access = get_all_main_accesses()
 
 /datum/equipment_preset/other/elite_merc/load_name(mob/living/carbon/human/new_human, randomise)
 	new_human.gender = pick(70;MALE,30;FEMALE)
@@ -280,7 +280,7 @@
 
 /datum/equipment_preset/other/elite_merc/standard/New()
 	. = ..()
-	access = get_antagonist_pmc_access()
+	access = get_weyland_pmc_access()
 
 /datum/equipment_preset/other/elite_merc/standard/load_gear(mob/living/carbon/human/new_human)
 	//TODO: add unique backpacks and satchels
@@ -321,7 +321,7 @@
 
 /datum/equipment_preset/other/elite_merc/heavy/New()
 	. = ..()
-	access = get_antagonist_pmc_access()
+	access = get_weyland_pmc_access()
 
 /datum/equipment_preset/other/elite_merc/heavy/load_gear(mob/living/carbon/human/new_human)
 	//TODO: add backpacks and satchels
@@ -365,7 +365,7 @@
 
 /datum/equipment_preset/other/elite_merc/engineer/New()
 	. = ..()
-	access = get_antagonist_pmc_access()
+	access = get_weyland_pmc_access()
 
 /datum/equipment_preset/other/elite_merc/engineer/load_gear(mob/living/carbon/human/new_human)
 	//TODO: add backpacks and satchels
@@ -422,7 +422,7 @@
 
 /datum/equipment_preset/other/elite_merc/medic/New()
 	. = ..()
-	access = get_antagonist_pmc_access()
+	access = get_weyland_pmc_access()
 
 /datum/equipment_preset/other/elite_merc/medic/load_gear(mob/living/carbon/human/new_human)
 	//webbing
@@ -472,7 +472,7 @@
 
 /datum/equipment_preset/other/elite_merc/leader/New()
 	. = ..()
-	access = get_antagonist_pmc_access()
+	access = get_weyland_pmc_access()
 
 /datum/equipment_preset/other/elite_merc/leader/load_gear(mob/living/carbon/human/new_human)
 	//clothes
@@ -512,7 +512,7 @@
 
 /datum/equipment_preset/other/business_person/New()
 	. = ..()
-	access = get_all_accesses() + get_all_centcom_access()
+	access = get_all_main_accesses()
 
 /datum/equipment_preset/other/business_person/load_gear(mob/living/carbon/human/new_human)
 	//TODO: add backpacks and satchels
@@ -562,7 +562,7 @@
 
 /datum/equipment_preset/other/pizza/New()
 	. = ..()
-	access = get_freelancer_access()
+	access = get_civil_ert_access()
 
 /datum/equipment_preset/other/pizza/load_name(mob/living/carbon/human/new_human, randomise)
 	new_human.gender = pick(MALE,FEMALE)
@@ -607,7 +607,7 @@
 
 /datum/equipment_preset/other/souto/New()
 	. = ..()
-	access = get_freelancer_access()
+	access = get_civil_ert_access()
 
 /datum/equipment_preset/other/souto/load_name(mob/living/carbon/human/new_human, randomise)
 	new_human.gender = MALE

--- a/code/modules/gear_presets/pmc.dm
+++ b/code/modules/gear_presets/pmc.dm
@@ -12,7 +12,7 @@
 
 /datum/equipment_preset/pmc/New()
 	. = ..()
-	access = get_all_accesses() + get_all_centcom_access() + get_antagonist_access()
+	access = get_weyland_pmc_access()
 
 
 /datum/equipment_preset/pmc/load_name(mob/living/carbon/human/new_human, randomise)

--- a/code/modules/gear_presets/synths.dm
+++ b/code/modules/gear_presets/synths.dm
@@ -9,7 +9,7 @@
 
 /datum/equipment_preset/synth/New()
 	. = ..()
-	access = get_all_accesses()
+	access = get_global_access()
 
 /datum/equipment_preset/synth/load_race(mob/living/carbon/human/new_human)
 	if(new_human.client?.prefs?.synthetic_type)
@@ -465,7 +465,7 @@
 
 /datum/equipment_preset/synth/working_joe/New()
 	. = ..()
-	access = get_all_accesses()
+	access = get_global_access()
 
 /datum/equipment_preset/synth/working_joe/load_race(mob/living/carbon/human/new_human)
 	new_human.set_species(SYNTH_WORKING_JOE)
@@ -589,7 +589,7 @@
 
 /datum/equipment_preset/synth/infiltrator/New()
 	. = ..()
-	access = get_all_accesses()
+	access = get_global_access()
 
 /datum/equipment_preset/synth/infiltrator/load_name(mob/living/carbon/human/new_human, randomise)
 	new_human.gender = pick(MALE,FEMALE)

--- a/code/modules/gear_presets/synths.dm
+++ b/code/modules/gear_presets/synths.dm
@@ -141,7 +141,7 @@
 
 /datum/equipment_preset/synth/survivor/New()
 	. = ..()
-	access = get_all_civilian_accesses() + get_region_accesses(2) + get_region_accesses(4) + ACCESS_MARINE_RESEARCH + ACCESS_WY_CORPORATE //Access to civillians stuff + medbay stuff + engineering stuff + research
+	access = get_all_civilian_access() + get_region_accesses(2) + get_region_accesses(4) + ACCESS_MARINE_RESEARCH + ACCESS_WY_CORPORATE //Access to civillians stuff + medbay stuff + engineering stuff + research
 
 /datum/equipment_preset/synth/survivor/load_gear(mob/living/carbon/human/new_human)
 	for(var/equipment in equipment_to_spawn)

--- a/code/modules/gear_presets/upp.dm
+++ b/code/modules/gear_presets/upp.dm
@@ -2103,7 +2103,7 @@
 	idtype = /obj/item/card/id/data
 	languages = list(LANGUAGE_RUSSIAN, LANGUAGE_ENGLISH, LANGUAGE_TSL, LANGUAGE_SPANISH, LANGUAGE_CHINESE)
 
-/datum/equipment_preset/upp/New()
+/datum/equipment_preset/upp/commando/New()
 	. = ..()
 	access = get_global_access()
 

--- a/code/modules/gear_presets/upp.dm
+++ b/code/modules/gear_presets/upp.dm
@@ -2103,6 +2103,10 @@
 	idtype = /obj/item/card/id/data
 	languages = list(LANGUAGE_RUSSIAN, LANGUAGE_ENGLISH, LANGUAGE_TSL, LANGUAGE_SPANISH, LANGUAGE_CHINESE)
 
+/datum/equipment_preset/upp/New()
+	. = ..()
+	access = get_global_access()
+
 /datum/equipment_preset/upp/commando/load_gear(mob/living/carbon/human/new_human)
 	//TODO: add backpacks and satchels
 	new_human.equip_to_slot_or_del(new /obj/item/device/radio/headset/distress/UPP/kdo, WEAR_L_EAR)

--- a/code/modules/gear_presets/uscm.dm
+++ b/code/modules/gear_presets/uscm.dm
@@ -790,7 +790,7 @@
 
 /datum/equipment_preset/uscm/marsoc/New()
 	. = ..()
-	access = get_all_accesses() + get_all_centcom_access()
+	access = get_global_access()
 
 /datum/equipment_preset/uscm/marsoc/load_gear(mob/living/carbon/human/new_human)
 	//back

--- a/code/modules/gear_presets/uscm_dress.dm
+++ b/code/modules/gear_presets/uscm_dress.dm
@@ -111,7 +111,7 @@
 
 /datum/equipment_preset/uscm_event/dress/officer/capt/New()
 	. = ..()
-	access = get_main_marine_accesses()
+	access = get_main_marine_access()
 
 /datum/equipment_preset/uscm_event/dress/officer/co
 	name = "Dress Blues - (O-4) Major"
@@ -121,7 +121,7 @@
 
 /datum/equipment_preset/uscm_event/dress/officer/co/New()
 	. = ..()
-	access = get_all_marine_accesses()
+	access = get_all_marine_access()
 
 /datum/equipment_preset/uscm_event/dress/officer/co/ltcol
 	name = "Dress Blues - (O-5) Lieutenant Colonel"
@@ -145,7 +145,7 @@
 
 /datum/equipment_preset/uscm_event/dress/officer/general/New()
 	. = ..()
-	access = get_all_marine_accesses()
+	access = get_all_marine_access()
 
 /datum/equipment_preset/uscm_event/dress/officer/general/load_gear(mob/living/carbon/human/new_human)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/under/marine/dress/blues/general(new_human), WEAR_BODY)

--- a/code/modules/gear_presets/uscm_dress.dm
+++ b/code/modules/gear_presets/uscm_dress.dm
@@ -111,7 +111,7 @@
 
 /datum/equipment_preset/uscm_event/dress/officer/capt/New()
 	. = ..()
-	access = get_all_marine_access() - ACCESS_MARINE_CAPTAIN
+	access = get_main_marine_accesses()
 
 /datum/equipment_preset/uscm_event/dress/officer/co
 	name = "Dress Blues - (O-4) Major"
@@ -121,7 +121,7 @@
 
 /datum/equipment_preset/uscm_event/dress/officer/co/New()
 	. = ..()
-	access = get_all_marine_access()
+	access = get_all_marine_accesses()
 
 /datum/equipment_preset/uscm_event/dress/officer/co/ltcol
 	name = "Dress Blues - (O-5) Lieutenant Colonel"
@@ -145,7 +145,7 @@
 
 /datum/equipment_preset/uscm_event/dress/officer/general/New()
 	. = ..()
-	access = get_all_marine_access()
+	access = get_all_marine_accesses()
 
 /datum/equipment_preset/uscm_event/dress/officer/general/load_gear(mob/living/carbon/human/new_human)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/under/marine/dress/blues/general(new_human), WEAR_BODY)

--- a/code/modules/gear_presets/uscm_event.dm
+++ b/code/modules/gear_presets/uscm_event.dm
@@ -39,7 +39,7 @@
 
 /datum/equipment_preset/uscm_event/colonel/New()
 	. = ..()
-	access = get_all_accesses() + get_all_centcom_access()
+	access = get_global_access()
 
 /datum/equipment_preset/uscm_event/colonel/load_gear(mob/living/carbon/human/new_human)
 	new_human.equip_to_slot_or_del(new /obj/item/device/radio/headset/almayer/highcom(new_human), WEAR_L_EAR)
@@ -74,7 +74,7 @@
 
 /datum/equipment_preset/uscm_event/general/New()
 	. = ..()
-	access = get_all_accesses() + get_all_centcom_access()
+	access = get_global_access()
 
 /datum/equipment_preset/uscm_event/general/load_gear(mob/living/carbon/human/new_human)
 	//TODO: add backpacks and satchels
@@ -206,7 +206,7 @@
 
 /datum/equipment_preset/uscm_event/provost/New()
 	. = ..()
-	access = get_all_marine_access()
+	access = get_global_access()
 
 /datum/equipment_preset/uscm_event/provost/enforcer
 	name = "Provost Enforcer (ME5)"
@@ -485,7 +485,7 @@
 
 /datum/equipment_preset/uscm_event/uaac/tis/New()
 	. = ..()
-	access = get_all_marine_access()
+	access = get_global_access()
 
 /datum/equipment_preset/uscm_event/uaac/tis/io
 	name = "UAAC-TIS Intelligence Officer (NO2)"

--- a/code/modules/gear_presets/uscm_police.dm
+++ b/code/modules/gear_presets/uscm_police.dm
@@ -204,7 +204,7 @@
 
 /datum/equipment_preset/uscm_ship/uscm_police/riot_mp/New()
 	. = ..()
-	access = get_main_marine_accesses()
+	access = get_main_marine_access()
 
 /datum/equipment_preset/uscm_ship/uscm_police/riot_mp/load_gear(mob/living/carbon/human/new_human)
 	//TODO: add backpacks and satchels

--- a/code/modules/gear_presets/uscm_police.dm
+++ b/code/modules/gear_presets/uscm_police.dm
@@ -204,7 +204,7 @@
 
 /datum/equipment_preset/uscm_ship/uscm_police/riot_mp/New()
 	. = ..()
-	access = get_all_accesses() + get_all_centcom_access()
+	access = get_main_marine_accesses()
 
 /datum/equipment_preset/uscm_ship/uscm_police/riot_mp/load_gear(mob/living/carbon/human/new_human)
 	//TODO: add backpacks and satchels

--- a/code/modules/gear_presets/uscm_ship.dm
+++ b/code/modules/gear_presets/uscm_ship.dm
@@ -420,7 +420,7 @@
 
 /datum/equipment_preset/uscm_ship/commander/New()
 	. = ..()
-	access = get_all_marine_accesses()
+	access = get_all_marine_access()
 
 /datum/equipment_preset/uscm_ship/commander/load_race(mob/living/carbon/human/new_human, client/mob_client)
 	..()
@@ -510,7 +510,7 @@
 
 /datum/equipment_preset/uscm_ship/xo/New()
 	. = ..()
-	access = get_main_marine_accesses()
+	access = get_main_marine_access()
 
 /datum/equipment_preset/uscm_ship/xo/load_gear(mob/living/carbon/human/new_human)
 	var/back_item = /obj/item/storage/backpack/satchel
@@ -581,7 +581,7 @@
 
 /datum/equipment_preset/uscm_ship/sea/New()
 	. = ..()
-	access = get_main_marine_accesses()
+	access = get_main_marine_access()
 
 /datum/equipment_preset/uscm_ship/sea/load_gear(mob/living/carbon/human/new_human)
 	var/back_item = /obj/item/storage/backpack/satchel
@@ -733,7 +733,7 @@
 
 /datum/equipment_preset/uscm_ship/officer/New()
 	. = ..()
-	access = get_all_marine_accesses()
+	access = get_all_marine_access()
 
 /datum/equipment_preset/uscm_ship/officer/load_gear(mob/living/carbon/human/new_human)
 	//TODO: add backpacks and satchels

--- a/code/modules/gear_presets/uscm_ship.dm
+++ b/code/modules/gear_presets/uscm_ship.dm
@@ -420,7 +420,7 @@
 
 /datum/equipment_preset/uscm_ship/commander/New()
 	. = ..()
-	access = get_all_marine_access()
+	access = get_all_marine_accesses()
 
 /datum/equipment_preset/uscm_ship/commander/load_race(mob/living/carbon/human/new_human, client/mob_client)
 	..()
@@ -510,7 +510,7 @@
 
 /datum/equipment_preset/uscm_ship/xo/New()
 	. = ..()
-	access = get_all_marine_access() - ACCESS_MARINE_CAPTAIN
+	access = get_main_marine_accesses()
 
 /datum/equipment_preset/uscm_ship/xo/load_gear(mob/living/carbon/human/new_human)
 	var/back_item = /obj/item/storage/backpack/satchel
@@ -581,7 +581,7 @@
 
 /datum/equipment_preset/uscm_ship/sea/New()
 	. = ..()
-	access = get_all_marine_access() - ACCESS_MARINE_CAPTAIN
+	access = get_main_marine_accesses()
 
 /datum/equipment_preset/uscm_ship/sea/load_gear(mob/living/carbon/human/new_human)
 	var/back_item = /obj/item/storage/backpack/satchel
@@ -733,7 +733,7 @@
 
 /datum/equipment_preset/uscm_ship/officer/New()
 	. = ..()
-	access = get_all_accesses() + get_all_centcom_access()
+	access = get_all_marine_accesses()
 
 /datum/equipment_preset/uscm_ship/officer/load_gear(mob/living/carbon/human/new_human)
 	//TODO: add backpacks and satchels

--- a/code/modules/gear_presets/whiteout.dm
+++ b/code/modules/gear_presets/whiteout.dm
@@ -13,7 +13,7 @@
 
 /datum/equipment_preset/pmc/w_y_whiteout/New()
 	. = ..()
-	access = get_antagonist_pmc_access()
+	access = get_global_access()
 
 /datum/equipment_preset/pmc/w_y_whiteout/load_race(mob/living/carbon/human/new_human)
 	new_human.set_species(SYNTH_COMBAT)

--- a/code/modules/gear_presets/wo.dm
+++ b/code/modules/gear_presets/wo.dm
@@ -41,7 +41,7 @@
 
 /datum/equipment_preset/wo/commander/New()
 	. = ..()
-	access = get_all_marine_access()
+	access = get_all_marine_accesses()
 
 /datum/equipment_preset/wo/commander/load_gear(mob/living/carbon/human/new_human)
 	var/sidearm = "Mateba"
@@ -109,7 +109,7 @@
 
 /datum/equipment_preset/wo/xo/New()
 	. = ..()
-	access = get_all_marine_access()
+	access = get_main_marine_accesses()
 
 /datum/equipment_preset/wo/xo/load_gear(mob/living/carbon/human/new_human)
 	var/back_item = /obj/item/storage/backpack/satchel

--- a/code/modules/gear_presets/wo.dm
+++ b/code/modules/gear_presets/wo.dm
@@ -41,7 +41,7 @@
 
 /datum/equipment_preset/wo/commander/New()
 	. = ..()
-	access = get_all_marine_accesses()
+	access = get_all_marine_access()
 
 /datum/equipment_preset/wo/commander/load_gear(mob/living/carbon/human/new_human)
 	var/sidearm = "Mateba"
@@ -109,7 +109,7 @@
 
 /datum/equipment_preset/wo/xo/New()
 	. = ..()
-	access = get_main_marine_accesses()
+	access = get_main_marine_access()
 
 /datum/equipment_preset/wo/xo/load_gear(mob/living/carbon/human/new_human)
 	var/back_item = /obj/item/storage/backpack/satchel

--- a/code/modules/gear_presets/wy.dm
+++ b/code/modules/gear_presets/wy.dm
@@ -21,7 +21,7 @@
 
 /datum/equipment_preset/wy/New()
 	. = ..()
-	access += get_all_civilian_accesses() + get_all_centcom_access()
+	access += get_all_civilian_accesses() + get_all_weyland_access()
 
 /datum/equipment_preset/wy/load_id(mob/living/carbon/human/new_human)
 	. = ..()
@@ -86,7 +86,7 @@
 
 /datum/equipment_preset/wy/manager/New()
 	. = ..()
-	access = get_all_accesses() + get_all_centcom_access()
+	access = get_global_access()
 
 /datum/equipment_preset/wy/manager/load_gear(mob/living/carbon/human/new_human)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/under/suit_jacket/manager(new_human), WEAR_BODY)

--- a/code/modules/gear_presets/wy.dm
+++ b/code/modules/gear_presets/wy.dm
@@ -21,7 +21,7 @@
 
 /datum/equipment_preset/wy/New()
 	. = ..()
-	access += get_all_civilian_accesses() + get_all_weyland_access()
+	access += get_all_civilian_access() + get_all_weyland_access()
 
 /datum/equipment_preset/wy/load_id(mob/living/carbon/human/new_human)
 	. = ..()

--- a/code/modules/gear_presets/wy_goons.dm
+++ b/code/modules/gear_presets/wy_goons.dm
@@ -9,7 +9,7 @@
 
 /datum/equipment_preset/goon/New()
 	. = ..()
-	access = get_all_accesses() + get_all_centcom_access()
+	access = get_all_main_accesses()
 
 /datum/equipment_preset/goon/load_name(mob/living/carbon/human/new_human, randomise)
 	new_human.gender = pick(MALE, FEMALE)

--- a/code/modules/gear_presets/wy_goons.dm
+++ b/code/modules/gear_presets/wy_goons.dm
@@ -9,7 +9,7 @@
 
 /datum/equipment_preset/goon/New()
 	. = ..()
-	access = get_all_main_accesses()
+	access = get_all_main_access()
 
 /datum/equipment_preset/goon/load_name(mob/living/carbon/human/new_human, randomise)
 	new_human.gender = pick(MALE, FEMALE)


### PR DESCRIPTION

# About the pull request
Goes over all the Get_Access() procs, renaming them and making sure relevant ERTs/Presets are using the correct procs for their accesses.
Made a new proc for Restricted marine access like COs office, rather than it being manually removed from people like the XO and SEA.
Removed any places where accesses were overlapping entirely, such as get_all_weyland_access() and get_all_main_accesses() (formerly centcom and all_access respectively)
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
code: Updated all the Get_Access() procs, and removed some procs where they completely overlapped with others in presets.
/:cl:
