### PR TITLE
Forsaken ERT is now weighted by type

### DIFF
--- a/code/datums/emergency_calls/forsaken_xenos.dm
+++ b/code/datums/emergency_calls/forsaken_xenos.dm
@@ -20,15 +20,9 @@
 
 	var/mob/current_mob = new_member.current
 
-	var/picked
-	var/mob/living/carbon/xenomorph/new_xeno
-	if(!leader)
-		picked = pick(/mob/living/carbon/xenomorph/warrior, /mob/living/carbon/xenomorph/lurker, /mob/living/carbon/xenomorph/spitter)
-		leader = new_xeno
-	else
-		picked = pick(/mob/living/carbon/xenomorph/drone, /mob/living/carbon/xenomorph/runner)
+	var/picked = pick(2;/mob/living/carbon/xenomorph/warrior, 2;/mob/living/carbon/xenomorph/lurker, 2;/mob/living/carbon/xenomorph/spitter, 5;/mob/living/carbon/xenomorph/drone, 5;/mob/living/carbon/xenomorph/runner)
 
-	new_xeno = new picked(spawn_loc)
+	var/mob/living/carbon/xenomorph/new_xeno = new picked(spawn_loc)
 
 	new_member.transfer_to(new_xeno, TRUE)
 

--- a/code/datums/emergency_calls/forsaken_xenos.dm
+++ b/code/datums/emergency_calls/forsaken_xenos.dm
@@ -20,7 +20,7 @@
 
 	var/mob/current_mob = new_member.current
 
-	var/picked = pick(2;/mob/living/carbon/xenomorph/warrior, 2;/mob/living/carbon/xenomorph/lurker, 2;/mob/living/carbon/xenomorph/spitter, 5;/mob/living/carbon/xenomorph/drone, 5;/mob/living/carbon/xenomorph/runner)
+	var/picked = pick_weight(list(/mob/living/carbon/xenomorph/warrior = 2, /mob/living/carbon/xenomorph/lurker = 2, /mob/living/carbon/xenomorph/spitter = 2, /mob/living/carbon/xenomorph/drone = 5, /mob/living/carbon/xenomorph/runner = 5))
 
 	var/mob/living/carbon/xenomorph/new_xeno = new picked(spawn_loc)
 


### PR DESCRIPTION

# About the pull request

The caste types in forsaken ERT at end of round are now weighted rather than handled via leader setting.

2;/mob/living/carbon/xenomorph/warrior, 
2;/mob/living/carbon/xenomorph/lurker, 
2;/mob/living/carbon/xenomorph/spitter, 
5;/mob/living/carbon/xenomorph/drone, 
5;/mob/living/carbon/xenomorph/runner

# Explain why it's good for the game

The other way was causing there to be very few drones/runners when I wanted the opposite.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
add: Forsaken ERT is now weighted by type
/:cl:
