### PR TITLE
Explosive barricade upgrade buff

### DIFF
--- a/code/__DEFINES/defenses.dm
+++ b/code/__DEFINES/defenses.dm
@@ -8,7 +8,7 @@
 // Defines for barricade upgrades
 #define BARRICADE_UPGRADE_BURN "Biohazard Upgrade (+Burn)"
 #define BARRICADE_UPGRADE_BRUTE "Reinforced Upgrade (+Brute)"
-#define BARRICADE_UPGRADE_EXPLOSIVE_AND_PROJECTILE "Composite Upgrade (++Explosive, ++Projectile)"
+#define BARRICADE_UPGRADE_ANTIFF "Composite Upgrade (++Explosive, ++Projectile, ++Fire)"
 
 // Defines for defense stats
 #define DEFENSE_FUNCTIONAL 0

--- a/code/__DEFINES/defenses.dm
+++ b/code/__DEFINES/defenses.dm
@@ -8,7 +8,7 @@
 // Defines for barricade upgrades
 #define BARRICADE_UPGRADE_BURN "Biohazard Upgrade (+Burn)"
 #define BARRICADE_UPGRADE_BRUTE "Reinforced Upgrade (+Brute)"
-#define BARRICADE_UPGRADE_EXPLOSIVE "Explosive Upgrade (+Explosive)"
+#define BARRICADE_UPGRADE_EXPLOSIVE_AND_PROJECTILES "Composite Upgrade (++Explosive, ++Projectile)"
 
 // Defines for defense stats
 #define DEFENSE_FUNCTIONAL 0

--- a/code/__DEFINES/defenses.dm
+++ b/code/__DEFINES/defenses.dm
@@ -8,7 +8,7 @@
 // Defines for barricade upgrades
 #define BARRICADE_UPGRADE_BURN "Biohazard Upgrade (+Burn)"
 #define BARRICADE_UPGRADE_BRUTE "Reinforced Upgrade (+Brute)"
-#define BARRICADE_UPGRADE_EXPLOSIVE_AND_PROJECTILES "Composite Upgrade (++Explosive, ++Projectile)"
+#define BARRICADE_UPGRADE_EXPLOSIVE_AND_PROJECTILE "Composite Upgrade (++Explosive, ++Projectile)"
 
 // Defines for defense stats
 #define DEFENSE_FUNCTIONAL 0

--- a/code/game/objects/structures/barricade/barricade.dm
+++ b/code/game/objects/structures/barricade/barricade.dm
@@ -96,7 +96,7 @@
 				overlays += image('icons/obj/structures/barricades.dmi', icon_state = "+burn_upgrade_[damage_state]")
 			if(BARRICADE_UPGRADE_BRUTE)
 				overlays += image('icons/obj/structures/barricades.dmi', icon_state = "+brute_upgrade_[damage_state]")
-			if(BARRICADE_UPGRADE_EXPLOSIVE_AND_PROJECTILES)
+			if(BARRICADE_UPGRADE_EXPLOSIVE_AND_PROJECTILE)
 				overlays += image('icons/obj/structures/barricades.dmi', icon_state = "+explosive_upgrade_[damage_state]")
 
 	if(is_wired)

--- a/code/game/objects/structures/barricade/barricade.dm
+++ b/code/game/objects/structures/barricade/barricade.dm
@@ -31,6 +31,7 @@
 	var/burn_multiplier = 1
 	var/explosive_multiplier = 1
 	var/brute_projectile_multiplier = 1
+	var/burn_flame_multiplier = 1
 	var/repair_materials = list()
 	var/metallic = TRUE
 
@@ -96,7 +97,7 @@
 				overlays += image('icons/obj/structures/barricades.dmi', icon_state = "+burn_upgrade_[damage_state]")
 			if(BARRICADE_UPGRADE_BRUTE)
 				overlays += image('icons/obj/structures/barricades.dmi', icon_state = "+brute_upgrade_[damage_state]")
-			if(BARRICADE_UPGRADE_EXPLOSIVE_AND_PROJECTILE)
+			if(BARRICADE_UPGRADE_ANTIFF)
 				overlays += image('icons/obj/structures/barricades.dmi', icon_state = "+explosive_upgrade_[damage_state]")
 
 	if(is_wired)
@@ -322,7 +323,7 @@
 	new /datum/effects/acid(src, null, null)
 
 /obj/structure/barricade/flamer_fire_act(dam = BURN_LEVEL_TIER_1)
-	take_damage(dam * burn_multiplier)
+	take_damage(dam * burn_flame_multiplier)
 
 /obj/structure/barricade/proc/hit_barricade(obj/item/I)
 	take_damage(I.force * 0.5 * brute_multiplier)

--- a/code/game/objects/structures/barricade/barricade.dm
+++ b/code/game/objects/structures/barricade/barricade.dm
@@ -197,13 +197,13 @@
 			return
 
 	if(istype(item, /obj/item/stack/barbed_wire))
-		var/obj/item/stack/barbed_wire/B = item
+		var/obj/item/stack/barbed_wire/barbed_wire = item
 		if(can_wire)
 			user.visible_message(SPAN_NOTICE("[user] starts setting up [item.name] on [src]."),
 			SPAN_NOTICE("You start setting up [item.name] on [src]."))
 			if(do_after(user, 20, INTERRUPT_NO_NEEDHAND|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD, src) && can_wire)
 				// Make sure there's still enough wire in the stack
-				if(!barricade.use(1))
+				if(!barbed_wire.use(1))
 					return
 
 				playsound(src.loc, 'sound/effects/barbed_wire_movement.ogg', 25, 1)
@@ -259,7 +259,7 @@
 	if(istype(bullet.ammo, /datum/ammo/xeno/boiler_gas))
 		take_damage(round(50 * burn_multiplier))
 
-	else if(bullet.ammo.flags_ammo_behavior & atom_movableMO_ANTISTRUCT)
+	else if(bullet.ammo.flags_ammo_behavior & AMMO_ANTISTRUCT)
 		take_damage(bullet.damage * ANTISTRUCT_DMG_MULT_BARRICADES)
 
 	take_damage(bullet.damage)

--- a/code/game/objects/structures/barricade/barricade.dm
+++ b/code/game/objects/structures/barricade/barricade.dm
@@ -44,12 +44,12 @@
 	addtimer(CALLBACK(src, PROC_REF(update_icon)), 0)
 	starting_maxhealth = maxhealth
 
-/obj/structure/barricade/initialize_pass_flags(datum/pass_flags_container/PF)
+/obj/structure/barricade/initialize_pass_flags(datum/pass_flags_container/pass_flags)
 	..()
-	if (PF)
-		PF.flags_can_pass_all = NONE
-		PF.flags_can_pass_front = NONE
-		PF.flags_can_pass_behind = PASS_OVER^(PASS_OVER_ACID_SPRAY|PASS_OVER_THROW_MOB)
+	if (pass_flags)
+		pass_flags.flags_can_pass_all = NONE
+		pass_flags.flags_can_pass_front = NONE
+		pass_flags.flags_can_pass_behind = PASS_OVER^(PASS_OVER_ACID_SPRAY|PASS_OVER_THROW_MOB)
 	flags_can_pass_front_temp = PASS_OVER_THROW_MOB
 	flags_can_pass_behind_temp = PASS_OVER_THROW_MOB
 
@@ -108,34 +108,34 @@
 
 	..()
 
-/obj/structure/barricade/hitby(atom/movable/AM)
-	if(AM.throwing && is_wired)
-		if(iscarbon(AM))
-			var/mob/living/carbon/C = AM
-			if(C.mob_size <= MOB_SIZE_XENO)
-				C.visible_message(SPAN_DANGER("The barbed wire slices into [C]!"),
+/obj/structure/barricade/hitby(atom/movable/atom_movable)
+	if(atom_movable.throwing && is_wired)
+		if(iscarbon(atom_movable))
+			var/mob/living/carbon/living_carbon = atom_movable
+			if(living_carbon.mob_size <= MOB_SIZE_XENO)
+				living_carbon.visible_message(SPAN_DANGER("The barbed wire slices into [living_carbon]!"),
 				SPAN_DANGER("The barbed wire slices into you!"))
-				C.apply_damage(10)
-				C.apply_effect(2, WEAKEN) //Leaping into barbed wire is VERY bad
-				playsound(C, "bonk", 75, FALSE)
+				living_carbon.apply_damage(10)
+				living_carbon.apply_effect(2, WEAKEN) //Leaping into barbed wire is VERY bad
+				playsound(living_carbon, "bonk", 75, FALSE)
 	..()
 
-/obj/structure/barricade/Collided(atom/movable/AM)
+/obj/structure/barricade/Collided(atom/movable/atom_movable)
 	..()
 
-	if(istype(AM, /mob/living/carbon/xenomorph/crusher))
-		var/mob/living/carbon/xenomorph/crusher/C = AM
+	if(istype(atom_movable, /mob/living/carbon/xenomorph/crusher))
+		var/mob/living/carbon/xenomorph/crusher/living_carbon = atom_movable
 
-		if (!C.throwing)
+		if (!living_carbon.throwing)
 			return
 
 		if(crusher_resistant)
-			visible_message(SPAN_DANGER("[C] smashes into [src]!"))
+			visible_message(SPAN_DANGER("[living_carbon] smashes into [src]!"))
 			take_damage(150)
 			playsound(src, barricade_hitsound, 25, TRUE)
 
-		else if(!C.stat)
-			visible_message(SPAN_DANGER("[C] smashes through [src]!"))
+		else if(!living_carbon.stat)
+			visible_message(SPAN_DANGER("[living_carbon] smashes through [src]!"))
 			deconstruct(FALSE)
 			playsound(src, barricade_hitsound, 25, TRUE)
 
@@ -165,8 +165,8 @@
 	if(closed)
 		return NO_BLOCKED_MOVEMENT
 
-	var/obj/structure/S = locate(/obj/structure) in get_turf(mover)
-	if(S && S.climbable && !(S.flags_atom & ON_BORDER) && climbable && isliving(mover)) //Climbable objects allow you to universally climb over others
+	var/obj/structure/structure = locate(/obj/structure) in get_turf(mover)
+	if(structure && structure.climbable && !(structure.flags_atom & ON_BORDER) && climbable && isliving(mover)) //Climbable objects allow you to universally climb over others
 		return NO_BLOCKED_MOVEMENT
 
 	return ..()
@@ -182,33 +182,33 @@
 /obj/structure/barricade/attack_animal(mob/user as mob)
 	return attack_alien(user)
 
-/obj/structure/barricade/attackby(obj/item/W, mob/user)
-	if(istype(W, /obj/item/weapon/zombie_claws))
+/obj/structure/barricade/attackby(obj/item/item, mob/user)
+	if(istype(item, /obj/item/weapon/zombie_claws))
 		user.visible_message(SPAN_DANGER("The zombie smashed at the [src.barricade_type] barricade!"),
 		SPAN_DANGER("You smack the [src.barricade_type] barricade!"))
 		if(barricade_hitsound)
 			playsound(src, barricade_hitsound, 35, 1)
-		hit_barricade(W)
+		hit_barricade(item)
 		return
 
-	for(var/obj/effect/xenomorph/acid/A in src.loc)
-		if(A.acid_t == src)
+	for(var/obj/effect/xenomorph/acid/acid in src.loc)
+		if(acid.acid_t == src)
 			to_chat(user, "You can't get near that, it's melting!")
 			return
 
-	if(istype(W, /obj/item/stack/barbed_wire))
-		var/obj/item/stack/barbed_wire/B = W
+	if(istype(item, /obj/item/stack/barbed_wire))
+		var/obj/item/stack/barbed_wire/B = item
 		if(can_wire)
-			user.visible_message(SPAN_NOTICE("[user] starts setting up [W.name] on [src]."),
-			SPAN_NOTICE("You start setting up [W.name] on [src]."))
+			user.visible_message(SPAN_NOTICE("[user] starts setting up [item.name] on [src]."),
+			SPAN_NOTICE("You start setting up [item.name] on [src]."))
 			if(do_after(user, 20, INTERRUPT_NO_NEEDHAND|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD, src) && can_wire)
 				// Make sure there's still enough wire in the stack
-				if(!B.use(1))
+				if(!barricade.use(1))
 					return
 
 				playsound(src.loc, 'sound/effects/barbed_wire_movement.ogg', 25, 1)
-				user.visible_message(SPAN_NOTICE("[user] sets up [W.name] on [src]."),
-				SPAN_NOTICE("You set up [W.name] on [src]."))
+				user.visible_message(SPAN_NOTICE("[user] sets up [item.name] on [src]."),
+				SPAN_NOTICE("You set up [item.name] on [src]."))
 
 				maxhealth += 50
 				update_health(-50)
@@ -220,7 +220,7 @@
 				update_icon()
 		return
 
-	if(HAS_TRAIT(W, TRAIT_TOOL_WIRECUTTERS))
+	if(HAS_TRAIT(item, TRAIT_TOOL_WIRECUTTERS))
 		if(is_wired)
 			user.visible_message(SPAN_NOTICE("[user] begin removing the barbed wire on [src]."),
 			SPAN_NOTICE("You begin removing the barbed wire on [src]."))
@@ -242,27 +242,27 @@
 				new/obj/item/stack/barbed_wire( src.loc )
 		return
 
-	if(W.force > force_level_absorption)
+	if(item.force > force_level_absorption)
 		..()
 		if(barricade_hitsound)
 			playsound(src, barricade_hitsound, 35, 1)
-		hit_barricade(W)
+		hit_barricade(item)
 
-/obj/structure/barricade/bullet_act(obj/item/projectile/P)
-	bullet_ping(P)
+/obj/structure/barricade/bullet_act(obj/item/projectile/bullet)
+	bullet_ping(bullet)
 
-	if(P.ammo.damage_type == BURN)
-		P.damage = P.damage * burn_multiplier
+	if(bullet.ammo.damage_type == BURN)
+		bullet.damage = bullet.damage * burn_multiplier
 	else
-		P.damage = P.damage * brute_projectile_multiplier
+		bullet.damage = bullet.damage * brute_projectile_multiplier
 
-	if(istype(P.ammo, /datum/ammo/xeno/boiler_gas))
+	if(istype(bullet.ammo, /datum/ammo/xeno/boiler_gas))
 		take_damage(round(50 * burn_multiplier))
 
-	else if(P.ammo.flags_ammo_behavior & AMMO_ANTISTRUCT)
-		take_damage(P.damage * ANTISTRUCT_DMG_MULT_BARRICADES)
+	else if(bullet.ammo.flags_ammo_behavior & atom_movableMO_ANTISTRUCT)
+		take_damage(bullet.damage * ANTISTRUCT_DMG_MULT_BARRICADES)
 
-	take_damage(P.damage)
+	take_damage(bullet.damage)
 
 	return TRUE
 
@@ -284,11 +284,11 @@
 
 
 /obj/structure/barricade/ex_act(severity, direction, cause_data)
-	for(var/obj/structure/barricade/B in get_step(src,dir)) //discourage double-stacking barricades by removing health from opposing barricade
-		if(B.dir == reverse_direction(dir))
+	for(var/obj/structure/barricade/barricade in get_step(src,dir)) //discourage double-stacking barricades by removing health from opposing barricade
+		if(barricade.dir == reverse_direction(dir))
 			spawn(1)
-			if(B)
-				B.ex_act(severity, direction)
+			if(barricade)
+				barricade.ex_act(severity, direction)
 	if(health <= 0)
 		var/location = get_turf(src)
 		handle_debris(severity, direction)
@@ -325,13 +325,13 @@
 /obj/structure/barricade/flamer_fire_act(dam = BURN_LEVEL_TIER_1)
 	take_damage(dam * burn_flame_multiplier)
 
-/obj/structure/barricade/proc/hit_barricade(obj/item/I)
-	take_damage(I.force * 0.5 * brute_multiplier)
+/obj/structure/barricade/proc/hit_barricade(obj/item/item)
+	take_damage(item.force * 0.5 * brute_multiplier)
 
 /obj/structure/barricade/proc/take_damage(damage)
-	for(var/obj/structure/barricade/B in get_step(src,dir)) //discourage double-stacking barricades by removing health from opposing barricade
-		if(B.dir == reverse_direction(dir))
-			B.update_health(damage)
+	for(var/obj/structure/barricade/barricade in get_step(src,dir)) //discourage double-stacking barricades by removing health from opposing barricade
+		if(barricade.dir == reverse_direction(dir))
+			barricade.update_health(damage)
 
 	update_health(damage)
 
@@ -359,12 +359,12 @@
 		if(50 to 75) damage_state = BARRICADE_DMG_SLIGHT
 		if(75 to INFINITY) damage_state = BARRICADE_DMG_NONE
 
-/obj/structure/barricade/proc/weld_cade(obj/item/tool/weldingtool/WT, mob/user)
+/obj/structure/barricade/proc/weld_cade(obj/item/tool/weldingtool/welder, mob/user)
 	if(!metallic)
 		user.visible_message(SPAN_WARNING("You can't weld \the [src]!"))
 		return FALSE
 
-	if(!(WT.remove_fuel(2, user)))
+	if(!(welder.remove_fuel(2, user)))
 		return FALSE
 
 	user.visible_message(SPAN_NOTICE("[user] begins repairing damage to [src]."),
@@ -415,20 +415,20 @@
 
 	return ..()
 
-/obj/structure/barricade/proc/try_nailgun_usage(obj/item/W, mob/user)
-	if(length(repair_materials) == 0 || health >= maxhealth || !istype(W, /obj/item/weapon/gun/smg/nailgun))
+/obj/structure/barricade/proc/try_nailgun_usage(obj/item/item, mob/user)
+	if(length(repair_materials) == 0 || health >= maxhealth || !istype(item, /obj/item/weapon/gun/smg/nailgun))
 		return FALSE
 
-	var/obj/item/weapon/gun/smg/nailgun/NG = W
+	var/obj/item/weapon/gun/smg/nailgun/nailgun = item
 
-	if(!NG.in_chamber || !NG.current_mag || NG.current_mag.current_rounds < 3)
+	if(!nailgun.in_chamber || !nailgun.current_mag || nailgun.current_mag.current_rounds < 3)
 		to_chat(user, SPAN_WARNING("You require at least 4 nails to complete this task!"))
 		return FALSE
 
 	// Check if either hand has a metal stack by checking the weapon offhand
 	// Presume the material is a sheet until proven otherwise.
 	var/obj/item/stack/sheet/material = null
-	if(user.l_hand == NG)
+	if(user.l_hand == nailgun)
 		material = user.r_hand
 	else
 		material = user.l_hand
@@ -447,8 +447,8 @@
 		to_chat(user, SPAN_WARNING("You'll need some adequate repair material in your other hand to patch up [src]!"))
 		return FALSE
 
-	var/soundchannel = playsound(src, NG.repair_sound, 25, 1)
-	if(!do_after(user, NG.nailing_speed, INTERRUPT_ALL, BUSY_ICON_FRIENDLY, src))
+	var/soundchannel = playsound(src, nailgun.repair_sound, 25, 1)
+	if(!do_after(user, nailgun.nailing_speed, INTERRUPT_ALL, BUSY_ICON_FRIENDLY, src))
 		playsound(src, null, channel = soundchannel)
 		return FALSE
 
@@ -456,7 +456,7 @@
 		to_chat(user, SPAN_WARNING("You seems to have misplaced the repair material!"))
 		return FALSE
 
-	if(!NG.in_chamber || !NG.current_mag || NG.current_mag.current_rounds < 3)
+	if(!nailgun.in_chamber || !nailgun.current_mag || nailgun.current_mag.current_rounds < 3)
 		to_chat(user, SPAN_WARNING("You require at least 4 nails to complete this task!"))
 		return FALSE
 
@@ -464,7 +464,7 @@
 	to_chat(user, SPAN_WARNING("You nail [material] to [src], restoring some of its integrity!"))
 	update_damage_state()
 	material.use(1)
-	NG.current_mag.current_rounds -= 3
-	NG.in_chamber = null
-	NG.load_into_chamber()
+	nailgun.current_mag.current_rounds -= 3
+	nailgun.in_chamber = null
+	nailgun.load_into_chamber()
 	return TRUE

--- a/code/game/objects/structures/barricade/barricade.dm
+++ b/code/game/objects/structures/barricade/barricade.dm
@@ -30,6 +30,7 @@
 	var/brute_multiplier = 1
 	var/burn_multiplier = 1
 	var/explosive_multiplier = 1
+	var/brute_projectile_multiplier = 1
 	var/repair_materials = list()
 	var/metallic = TRUE
 
@@ -95,7 +96,7 @@
 				overlays += image('icons/obj/structures/barricades.dmi', icon_state = "+burn_upgrade_[damage_state]")
 			if(BARRICADE_UPGRADE_BRUTE)
 				overlays += image('icons/obj/structures/barricades.dmi', icon_state = "+brute_upgrade_[damage_state]")
-			if(BARRICADE_UPGRADE_EXPLOSIVE)
+			if(BARRICADE_UPGRADE_EXPLOSIVE_AND_PROJECTILES)
 				overlays += image('icons/obj/structures/barricades.dmi', icon_state = "+explosive_upgrade_[damage_state]")
 
 	if(is_wired)
@@ -252,7 +253,7 @@
 	if(P.ammo.damage_type == BURN)
 		P.damage = P.damage * burn_multiplier
 	else
-		P.damage = P.damage * brute_multiplier
+		P.damage = P.damage * brute_projectile_multiplier
 
 	if(istype(P.ammo, /datum/ammo/xeno/boiler_gas))
 		take_damage(round(50 * burn_multiplier))

--- a/code/game/objects/structures/barricade/metal.dm
+++ b/code/game/objects/structures/barricade/metal.dm
@@ -42,9 +42,9 @@
 		if(BARRICADE_UPGRADE_ANTIFF)
 			. += SPAN_NOTICE("The cade is protected by a composite upgrade.")
 
-/obj/structure/barricade/metal/attackby(obj/item/W, mob/user)
-	if(iswelder(W))
-		if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH))
+/obj/structure/barricade/metal/attackby(obj/item/item, mob/user)
+	if(iswelder(item))
+		if(!HAS_TRAIT(item, TRAIT_TOOL_BLOWTORCH))
 			to_chat(user, SPAN_WARNING("You need a stronger blowtorch!"))
 			return
 		if(user.action_busy)
@@ -52,7 +52,7 @@
 		if(!skillcheck(user, SKILL_ENGINEER, SKILL_ENGINEER_TRAINED))
 			to_chat(user, SPAN_WARNING("You're not trained to repair [src]..."))
 			return
-		var/obj/item/tool/weldingtool/WT = W
+		var/obj/item/tool/weldingtool/welder = item
 		if(damage_state == BARRICADE_DMG_HEAVY)
 			to_chat(user, SPAN_WARNING("[src] has sustained too much structural damage to be repaired."))
 			return
@@ -61,10 +61,10 @@
 			to_chat(user, SPAN_WARNING("[src] doesn't need repairs."))
 			return
 
-		weld_cade(WT, user)
+		weld_cade(welder, user)
 		return
 
-	if(try_nailgun_usage(W, user))
+	if(try_nailgun_usage(item, user))
 		return
 
 	for(var/obj/effect/xenomorph/acid/A in src.loc)
@@ -74,7 +74,7 @@
 
 	switch(build_state)
 		if(BARRICADE_BSTATE_SECURED) //Fully constructed step. Use screwdriver to remove the protection panels to reveal the bolts
-			if(HAS_TRAIT(W, TRAIT_TOOL_SCREWDRIVER))
+			if(HAS_TRAIT(item, TRAIT_TOOL_SCREWDRIVER))
 				if(!skillcheck(user, SKILL_CONSTRUCTION, SKILL_CONSTRUCTION_TRAINED))
 					to_chat(user, SPAN_WARNING("You are not trained to touch [src]..."))
 					return
@@ -88,14 +88,14 @@
 				build_state = BARRICADE_BSTATE_UNSECURED
 				return
 
-			if(istype(W, /obj/item/stack/sheet/metal))
+			if(istype(item, /obj/item/stack/sheet/metal))
 				if(!skillcheck(user, SKILL_CONSTRUCTION, SKILL_CONSTRUCTION_TRAINED))
 					to_chat(user, SPAN_WARNING("You are not trained to touch [src]..."))
 					return
 				if(upgraded)
 					to_chat(user, SPAN_NOTICE("This barricade is already upgraded."))
 					return
-				var/obj/item/stack/sheet/metal/M = W
+				var/obj/item/stack/sheet/metal/metal = item
 				if(user.client?.prefs?.no_radials_preference)
 					var/choice = tgui_input_list(user, "Choose an upgrade to apply to the barricade", "Apply Upgrade", list(BARRICADE_UPGRADE_BURN, BARRICADE_UPGRADE_BRUTE, BARRICADE_UPGRADE_ANTIFF))
 					if(!choice)
@@ -106,11 +106,11 @@
 					if(upgraded)
 						to_chat(user, SPAN_NOTICE("This barricade is already upgraded."))
 						return
-					if(M.get_amount() < 2)
+					if(metal.get_amount() < 2)
 						to_chat(user, SPAN_NOTICE("You lack the required metal."))
 						return
-					if((usr.get_active_hand()) != M)
-						to_chat(user, SPAN_WARNING("You must be holding the [M] to upgrade \the [src]!"))
+					if((usr.get_active_hand()) != metal)
+						to_chat(user, SPAN_WARNING("You must be holding the [metal] to upgrade \the [src]!"))
 						return
 
 					switch(choice)
@@ -131,7 +131,7 @@
 							upgraded = BARRICADE_UPGRADE_ANTIFF
 							to_chat(user, SPAN_NOTICE("You applied a composite upgrade."))
 
-					M.use(2)
+					metal.use(2)
 					user.count_niche_stat(STATISTICS_NICHE_UPGRADE_CADES)
 					update_icon()
 					return
@@ -146,11 +146,11 @@
 					if(upgraded)
 						to_chat(user, SPAN_NOTICE("This barricade is already upgraded."))
 						return
-					if(M.get_amount() < 2)
+					if(metal.get_amount() < 2)
 						to_chat(user, SPAN_NOTICE("You lack the required metal."))
 						return
-					if((usr.get_active_hand()) != M)
-						to_chat(user, SPAN_WARNING("You must be holding the [M] to upgrade \the [src]!"))
+					if((usr.get_active_hand()) != metal)
+						to_chat(user, SPAN_WARNING("You must be holding the [metal] to upgrade \the [src]!"))
 						return
 
 					switch(choice)
@@ -171,12 +171,12 @@
 							upgraded = BARRICADE_UPGRADE_ANTIFF
 							to_chat(user, SPAN_NOTICE("You applied a composite upgrade."))
 
-					M.use(2)
+					metal.use(2)
 					user.count_niche_stat(STATISTICS_NICHE_UPGRADE_CADES)
 					update_icon()
 					return
 
-			if(HAS_TRAIT(W, TRAIT_TOOL_MULTITOOL))
+			if(HAS_TRAIT(item, TRAIT_TOOL_MULTITOOL))
 				if(!skillcheck(user, SKILL_CONSTRUCTION, SKILL_CONSTRUCTION_TRAINED))
 					to_chat(user, SPAN_WARNING("You are not trained to touch [src]..."))
 					return
@@ -197,7 +197,7 @@
 				return
 
 		if(BARRICADE_BSTATE_UNSECURED) //Protection panel removed step. Screwdriver to put the panel back, wrench to unsecure the anchor bolts
-			if(HAS_TRAIT(W, TRAIT_TOOL_SCREWDRIVER))
+			if(HAS_TRAIT(item, TRAIT_TOOL_SCREWDRIVER))
 				if(user.action_busy)
 					return
 				if(!skillcheck(user, SKILL_CONSTRUCTION, SKILL_CONSTRUCTION_TRAINED))
@@ -209,7 +209,7 @@
 				SPAN_NOTICE("You set [src]'s protection panel back."))
 				build_state = BARRICADE_BSTATE_SECURED
 				return
-			if(HAS_TRAIT(W, TRAIT_TOOL_WRENCH))
+			if(HAS_TRAIT(item, TRAIT_TOOL_WRENCH))
 				if(user.action_busy)
 					return
 				if(!skillcheck(user, SKILL_CONSTRUCTION, SKILL_CONSTRUCTION_TRAINED))
@@ -224,7 +224,7 @@
 				update_icon() //unanchored changes layer
 				return
 		if(BARRICADE_BSTATE_MOVABLE) //Anchor bolts loosened step. Apply crowbar to unseat the panel and take apart the whole thing. Apply wrench to resecure anchor bolts
-			if(HAS_TRAIT(W, TRAIT_TOOL_WRENCH))
+			if(HAS_TRAIT(item, TRAIT_TOOL_WRENCH))
 				if(user.action_busy)
 					return
 				if(!skillcheck(user, SKILL_CONSTRUCTION, SKILL_CONSTRUCTION_TRAINED))
@@ -234,8 +234,8 @@
 					if(B != src && B.dir == dir)
 						to_chat(user, SPAN_WARNING("There's already a barricade here."))
 						return
-				var/turf/open/T = loc
-				if(!(istype(T) && T.allow_construction))
+				var/turf/open/turf = loc
+				if(!(istype(turf) && turf.allow_construction))
 					to_chat(user, SPAN_WARNING("[src] must be secured on a proper surface!"))
 					return
 				playsound(src.loc, 'sound/items/Ratchet.ogg', 25, 1)
@@ -246,7 +246,7 @@
 				anchored = TRUE
 				update_icon() //unanchored changes layer
 				return
-			if(HAS_TRAIT(W, TRAIT_TOOL_CROWBAR))
+			if(HAS_TRAIT(item, TRAIT_TOOL_CROWBAR))
 				if(user.action_busy)
 					return
 				if(!skillcheck(user, SKILL_CONSTRUCTION, SKILL_CONSTRUCTION_TRAINED))

--- a/code/game/objects/structures/barricade/metal.dm
+++ b/code/game/objects/structures/barricade/metal.dm
@@ -39,8 +39,8 @@
 			. += SPAN_NOTICE("The cade is protected by a biohazardous upgrade.")
 		if(BARRICADE_UPGRADE_BRUTE)
 			. += SPAN_NOTICE("The cade is protected by a reinforced upgrade.")
-		if(BARRICADE_UPGRADE_EXPLOSIVE)
-			. += SPAN_NOTICE("The cade is protected by an explosive upgrade.")
+		if(BARRICADE_UPGRADE_EXPLOSIVE_AND_PROJECTILES)
+			. += SPAN_NOTICE("The cade is protected by a composite upgrade.")
 
 /obj/structure/barricade/metal/attackby(obj/item/W, mob/user)
 	if(iswelder(W))
@@ -97,7 +97,7 @@
 					return
 				var/obj/item/stack/sheet/metal/M = W
 				if(user.client?.prefs?.no_radials_preference)
-					var/choice = tgui_input_list(user, "Choose an upgrade to apply to the barricade", "Apply Upgrade", list(BARRICADE_UPGRADE_BURN, BARRICADE_UPGRADE_BRUTE, BARRICADE_UPGRADE_EXPLOSIVE))
+					var/choice = tgui_input_list(user, "Choose an upgrade to apply to the barricade", "Apply Upgrade", list(BARRICADE_UPGRADE_BURN, BARRICADE_UPGRADE_BRUTE, BARRICADE_UPGRADE_EXPLOSIVE_AND_PROJECTILES))
 					if(!choice)
 						return
 					if(!user.Adjacent(src))
@@ -120,19 +120,21 @@
 							to_chat(user, SPAN_NOTICE("You applied a biohazardous upgrade."))
 						if(BARRICADE_UPGRADE_BRUTE)
 							brute_multiplier = 0.75
+							brute_projectile_multiplier = 0.75
 							upgraded = BARRICADE_UPGRADE_BRUTE
 							to_chat(user, SPAN_NOTICE("You applied a reinforced upgrade."))
-						if(BARRICADE_UPGRADE_EXPLOSIVE)
-							explosive_multiplier = 0.75
-							upgraded = BARRICADE_UPGRADE_EXPLOSIVE
-							to_chat(user, SPAN_NOTICE("You applied an explosive upgrade."))
+						if(BARRICADE_UPGRADE_EXPLOSIVE_AND_PROJECTILES)
+							explosive_multiplier = 0.5
+							brute_projectile_multiplier = 0.5
+							upgraded = BARRICADE_UPGRADE_EXPLOSIVE_AND_PROJECTILES
+							to_chat(user, SPAN_NOTICE("You applied a composite upgrade."))
 
 					M.use(2)
 					user.count_niche_stat(STATISTICS_NICHE_UPGRADE_CADES)
 					update_icon()
 					return
 				else
-					var/static/list/cade_types = list(BARRICADE_UPGRADE_EXPLOSIVE = image(icon = 'icons/obj/structures/barricades.dmi', icon_state = "explosive_obj"), BARRICADE_UPGRADE_BRUTE = image(icon = 'icons/obj/structures/barricades.dmi', icon_state = "brute_obj"), BARRICADE_UPGRADE_BURN = image(icon = 'icons/obj/structures/barricades.dmi', icon_state = "burn_obj"))
+					var/static/list/cade_types = list(BARRICADE_UPGRADE_EXPLOSIVE_AND_PROJECTILES = image(icon = 'icons/obj/structures/barricades.dmi', icon_state = "explosive_obj"), BARRICADE_UPGRADE_BRUTE = image(icon = 'icons/obj/structures/barricades.dmi', icon_state = "brute_obj"), BARRICADE_UPGRADE_BURN = image(icon = 'icons/obj/structures/barricades.dmi', icon_state = "burn_obj"))
 					var/choice = show_radial_menu(user, src, cade_types, require_near = TRUE)
 					if(!choice)
 						return
@@ -156,12 +158,14 @@
 							to_chat(user, SPAN_NOTICE("You applied a biohazardous upgrade."))
 						if(BARRICADE_UPGRADE_BRUTE)
 							brute_multiplier = 0.75
+							brute_projectile_multiplier = 0.75
 							upgraded = BARRICADE_UPGRADE_BRUTE
 							to_chat(user, SPAN_NOTICE("You applied a reinforced upgrade."))
-						if(BARRICADE_UPGRADE_EXPLOSIVE)
-							explosive_multiplier = 0.75
-							upgraded = BARRICADE_UPGRADE_EXPLOSIVE
-							to_chat(user, SPAN_NOTICE("You applied an explosive upgrade."))
+						if(BARRICADE_UPGRADE_EXPLOSIVE_AND_PROJECTILES)
+							explosive_multiplier = 0.5
+							brute_projectile_multiplier = 0.5
+							upgraded = BARRICADE_UPGRADE_EXPLOSIVE_AND_PROJECTILES
+							to_chat(user, SPAN_NOTICE("You applied a composite upgrade."))
 
 					M.use(2)
 					user.count_niche_stat(STATISTICS_NICHE_UPGRADE_CADES)
@@ -180,6 +184,7 @@
 					SPAN_NOTICE("You strip off [src]'s upgrade, making it a normal cade."))
 				upgraded = null
 				explosive_multiplier = initial(explosive_multiplier)
+				brute_projectile_multiplier = initial(brute_projectile_multiplier)
 				brute_multiplier = initial(brute_multiplier)
 				burn_multiplier = initial(burn_multiplier)
 				new stack_type (loc, 1)

--- a/code/game/objects/structures/barricade/metal.dm
+++ b/code/game/objects/structures/barricade/metal.dm
@@ -39,7 +39,7 @@
 			. += SPAN_NOTICE("The cade is protected by a biohazardous upgrade.")
 		if(BARRICADE_UPGRADE_BRUTE)
 			. += SPAN_NOTICE("The cade is protected by a reinforced upgrade.")
-		if(BARRICADE_UPGRADE_EXPLOSIVE_AND_PROJECTILES)
+		if(BARRICADE_UPGRADE_EXPLOSIVE_AND_PROJECTILE)
 			. += SPAN_NOTICE("The cade is protected by a composite upgrade.")
 
 /obj/structure/barricade/metal/attackby(obj/item/W, mob/user)
@@ -97,7 +97,7 @@
 					return
 				var/obj/item/stack/sheet/metal/M = W
 				if(user.client?.prefs?.no_radials_preference)
-					var/choice = tgui_input_list(user, "Choose an upgrade to apply to the barricade", "Apply Upgrade", list(BARRICADE_UPGRADE_BURN, BARRICADE_UPGRADE_BRUTE, BARRICADE_UPGRADE_EXPLOSIVE_AND_PROJECTILES))
+					var/choice = tgui_input_list(user, "Choose an upgrade to apply to the barricade", "Apply Upgrade", list(BARRICADE_UPGRADE_BURN, BARRICADE_UPGRADE_BRUTE, BARRICADE_UPGRADE_EXPLOSIVE_AND_PROJECTILE))
 					if(!choice)
 						return
 					if(!user.Adjacent(src))
@@ -123,10 +123,10 @@
 							brute_projectile_multiplier = 0.75
 							upgraded = BARRICADE_UPGRADE_BRUTE
 							to_chat(user, SPAN_NOTICE("You applied a reinforced upgrade."))
-						if(BARRICADE_UPGRADE_EXPLOSIVE_AND_PROJECTILES)
+						if(BARRICADE_UPGRADE_EXPLOSIVE_AND_PROJECTILE)
 							explosive_multiplier = 0.5
 							brute_projectile_multiplier = 0.5
-							upgraded = BARRICADE_UPGRADE_EXPLOSIVE_AND_PROJECTILES
+							upgraded = BARRICADE_UPGRADE_EXPLOSIVE_AND_PROJECTILE
 							to_chat(user, SPAN_NOTICE("You applied a composite upgrade."))
 
 					M.use(2)
@@ -134,7 +134,7 @@
 					update_icon()
 					return
 				else
-					var/static/list/cade_types = list(BARRICADE_UPGRADE_EXPLOSIVE_AND_PROJECTILES = image(icon = 'icons/obj/structures/barricades.dmi', icon_state = "explosive_obj"), BARRICADE_UPGRADE_BRUTE = image(icon = 'icons/obj/structures/barricades.dmi', icon_state = "brute_obj"), BARRICADE_UPGRADE_BURN = image(icon = 'icons/obj/structures/barricades.dmi', icon_state = "burn_obj"))
+					var/static/list/cade_types = list(BARRICADE_UPGRADE_EXPLOSIVE_AND_PROJECTILE = image(icon = 'icons/obj/structures/barricades.dmi', icon_state = "explosive_obj"), BARRICADE_UPGRADE_BRUTE = image(icon = 'icons/obj/structures/barricades.dmi', icon_state = "brute_obj"), BARRICADE_UPGRADE_BURN = image(icon = 'icons/obj/structures/barricades.dmi', icon_state = "burn_obj"))
 					var/choice = show_radial_menu(user, src, cade_types, require_near = TRUE)
 					if(!choice)
 						return
@@ -161,10 +161,10 @@
 							brute_projectile_multiplier = 0.75
 							upgraded = BARRICADE_UPGRADE_BRUTE
 							to_chat(user, SPAN_NOTICE("You applied a reinforced upgrade."))
-						if(BARRICADE_UPGRADE_EXPLOSIVE_AND_PROJECTILES)
+						if(BARRICADE_UPGRADE_EXPLOSIVE_AND_PROJECTILE)
 							explosive_multiplier = 0.5
 							brute_projectile_multiplier = 0.5
-							upgraded = BARRICADE_UPGRADE_EXPLOSIVE_AND_PROJECTILES
+							upgraded = BARRICADE_UPGRADE_EXPLOSIVE_AND_PROJECTILE
 							to_chat(user, SPAN_NOTICE("You applied a composite upgrade."))
 
 					M.use(2)

--- a/code/game/objects/structures/barricade/metal.dm
+++ b/code/game/objects/structures/barricade/metal.dm
@@ -188,8 +188,8 @@
 					SPAN_NOTICE("You strip off [src]'s upgrade, making it a normal cade."))
 				upgraded = null
 				explosive_multiplier = initial(explosive_multiplier)
-				brute_projectile_multiplier = initial(brute_projectile_multiplier)
 				brute_multiplier = initial(brute_multiplier)
+				brute_projectile_multiplier = initial(brute_projectile_multiplier)
 				burn_multiplier = initial(burn_multiplier)
 				burn_flame_multiplier = initial(burn_flame_multiplier)
 				new stack_type (loc, 1)

--- a/code/game/objects/structures/barricade/metal.dm
+++ b/code/game/objects/structures/barricade/metal.dm
@@ -39,7 +39,7 @@
 			. += SPAN_NOTICE("The cade is protected by a biohazardous upgrade.")
 		if(BARRICADE_UPGRADE_BRUTE)
 			. += SPAN_NOTICE("The cade is protected by a reinforced upgrade.")
-		if(BARRICADE_UPGRADE_EXPLOSIVE_AND_PROJECTILE)
+		if(BARRICADE_UPGRADE_ANTIFF)
 			. += SPAN_NOTICE("The cade is protected by a composite upgrade.")
 
 /obj/structure/barricade/metal/attackby(obj/item/W, mob/user)
@@ -97,7 +97,7 @@
 					return
 				var/obj/item/stack/sheet/metal/M = W
 				if(user.client?.prefs?.no_radials_preference)
-					var/choice = tgui_input_list(user, "Choose an upgrade to apply to the barricade", "Apply Upgrade", list(BARRICADE_UPGRADE_BURN, BARRICADE_UPGRADE_BRUTE, BARRICADE_UPGRADE_EXPLOSIVE_AND_PROJECTILE))
+					var/choice = tgui_input_list(user, "Choose an upgrade to apply to the barricade", "Apply Upgrade", list(BARRICADE_UPGRADE_BURN, BARRICADE_UPGRADE_BRUTE, BARRICADE_UPGRADE_ANTIFF))
 					if(!choice)
 						return
 					if(!user.Adjacent(src))
@@ -116,6 +116,7 @@
 					switch(choice)
 						if(BARRICADE_UPGRADE_BURN)
 							burn_multiplier = 0.75
+							burn_flame_multiplier = 0.75
 							upgraded = BARRICADE_UPGRADE_BURN
 							to_chat(user, SPAN_NOTICE("You applied a biohazardous upgrade."))
 						if(BARRICADE_UPGRADE_BRUTE)
@@ -123,10 +124,11 @@
 							brute_projectile_multiplier = 0.75
 							upgraded = BARRICADE_UPGRADE_BRUTE
 							to_chat(user, SPAN_NOTICE("You applied a reinforced upgrade."))
-						if(BARRICADE_UPGRADE_EXPLOSIVE_AND_PROJECTILE)
+						if(BARRICADE_UPGRADE_ANTIFF)
 							explosive_multiplier = 0.5
 							brute_projectile_multiplier = 0.5
-							upgraded = BARRICADE_UPGRADE_EXPLOSIVE_AND_PROJECTILE
+							burn_flame_multiplier = 0.5
+							upgraded = BARRICADE_UPGRADE_ANTIFF
 							to_chat(user, SPAN_NOTICE("You applied a composite upgrade."))
 
 					M.use(2)
@@ -134,7 +136,7 @@
 					update_icon()
 					return
 				else
-					var/static/list/cade_types = list(BARRICADE_UPGRADE_EXPLOSIVE_AND_PROJECTILE = image(icon = 'icons/obj/structures/barricades.dmi', icon_state = "explosive_obj"), BARRICADE_UPGRADE_BRUTE = image(icon = 'icons/obj/structures/barricades.dmi', icon_state = "brute_obj"), BARRICADE_UPGRADE_BURN = image(icon = 'icons/obj/structures/barricades.dmi', icon_state = "burn_obj"))
+					var/static/list/cade_types = list(BARRICADE_UPGRADE_ANTIFF = image(icon = 'icons/obj/structures/barricades.dmi', icon_state = "explosive_obj"), BARRICADE_UPGRADE_BRUTE = image(icon = 'icons/obj/structures/barricades.dmi', icon_state = "brute_obj"), BARRICADE_UPGRADE_BURN = image(icon = 'icons/obj/structures/barricades.dmi', icon_state = "burn_obj"))
 					var/choice = show_radial_menu(user, src, cade_types, require_near = TRUE)
 					if(!choice)
 						return
@@ -154,6 +156,7 @@
 					switch(choice)
 						if(BARRICADE_UPGRADE_BURN)
 							burn_multiplier = 0.75
+							burn_flame_multiplier = 0.75
 							upgraded = BARRICADE_UPGRADE_BURN
 							to_chat(user, SPAN_NOTICE("You applied a biohazardous upgrade."))
 						if(BARRICADE_UPGRADE_BRUTE)
@@ -161,10 +164,11 @@
 							brute_projectile_multiplier = 0.75
 							upgraded = BARRICADE_UPGRADE_BRUTE
 							to_chat(user, SPAN_NOTICE("You applied a reinforced upgrade."))
-						if(BARRICADE_UPGRADE_EXPLOSIVE_AND_PROJECTILE)
+						if(BARRICADE_UPGRADE_ANTIFF)
 							explosive_multiplier = 0.5
 							brute_projectile_multiplier = 0.5
-							upgraded = BARRICADE_UPGRADE_EXPLOSIVE_AND_PROJECTILE
+							burn_flame_multiplier = 0.5
+							upgraded = BARRICADE_UPGRADE_ANTIFF
 							to_chat(user, SPAN_NOTICE("You applied a composite upgrade."))
 
 					M.use(2)
@@ -187,6 +191,7 @@
 				brute_projectile_multiplier = initial(brute_projectile_multiplier)
 				brute_multiplier = initial(brute_multiplier)
 				burn_multiplier = initial(burn_multiplier)
+				burn_flame_multiplier = initial(burn_flame_multiplier)
 				new stack_type (loc, 1)
 				update_icon()
 				return


### PR DESCRIPTION
# About the pull request

Explosive barricade upgrade is renamed to composite upgrade, explosion damage taken is now modified by 0.5 (was 0.75), added 0.5 anti-projectile modifier (brute barricade upgrade basically has 0.75). Latest only applies to brute projectiles, so acid damage stays the same. Also added 0.5 anti-fire modifier (acid barricade upgrade basically has 0.75 as well).

# Explain why it's good for the game

The explosive upgrade is almost never used because it is useless. This is a very weak insurance in case of a very bad situation, like an explosion inside the cades. Now it will be more like a dedicated anti-FF upgrade, so smartgunners or flamethrowers, for example, won't be grinding down cades so fast. Xenos won't be affected much because the only brute projectile they have is bone shards and those are not used much against cades.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: ihatethisengine
balance: explosive barricade upgrade provides better protection against explosions (25% to 50%)
balance: explosive barricade upgrade provides strong protection against brute-based projectiles (50%)
balance: explosive barricade upgrade provides strong protection against fire (50%)
/:cl:
