### PR TITLE
Removes ability to high toss over ultra reinforced windows

### DIFF
--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -445,7 +445,7 @@
 	unacidable = TRUE
 
 /obj/structure/window/reinforced/ultra/initialize_pass_flags(datum/pass_flags_container/PF)
-	..()
+	. = ..()
 	if (PF)
 		PF.flags_can_pass_all = NONE
 		PF.flags_can_pass_front = NONE

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -444,6 +444,15 @@
 	unslashable = TRUE
 	unacidable = TRUE
 
+/obj/structure/window/reinforced/ultra/initialize_pass_flags(datum/pass_flags_container/PF)
+	..()
+	if (PF)
+		PF.flags_can_pass_all = NONE
+		PF.flags_can_pass_front = NONE
+		PF.flags_can_pass_behind = PASS_OVER^(PASS_OVER_ACID_SPRAY)
+	flags_can_pass_front_temp = NONE
+	flags_can_pass_behind_temp = NONE
+
 /obj/structure/window/reinforced/ultra/Initialize()
 	. = ..()
 	GLOB.hijack_bustable_windows += src


### PR DESCRIPTION

# About the pull request

This PR removes ability to high toss over ultra reinforced windows.

Stop bullying brand new XOs man :(

I think I did this correctly but my grasp on pass flags is amateur at best.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
del: Removed ability to high toss over ultra reinforced windows
/:cl:
