### PR TITLE
Limits view range of large crate destroy message.

### DIFF
--- a/code/game/objects/structures/crates_lockers/largecrate.dm
+++ b/code/game/objects/structures/crates_lockers/largecrate.dm
@@ -64,7 +64,7 @@
 	M.animation_attack_on(src)
 	unpack()
 	M.visible_message(SPAN_DANGER("[M] smashes [src] apart!"), \
-					  SPAN_DANGER("You smash [src] apart!"), 5, CHAT_TYPE_XENO_COMBAT)
+					  SPAN_DANGER("You smash [src] apart!"), 5, message_flags = CHAT_TYPE_XENO_COMBAT)
 	return XENO_ATTACK_ACTION
 
 /obj/structure/largecrate/ex_act(power)

--- a/code/game/objects/structures/crates_lockers/largecrate.dm
+++ b/code/game/objects/structures/crates_lockers/largecrate.dm
@@ -64,7 +64,7 @@
 	M.animation_attack_on(src)
 	unpack()
 	M.visible_message(SPAN_DANGER("[M] smashes [src] apart!"), \
-					  SPAN_DANGER("You smash [src] apart!"), 5, message_flags = CHAT_TYPE_XENO_COMBAT)
+					  SPAN_DANGER("You smash [src] apart!"), null, 5, CHAT_TYPE_XENO_COMBAT)
 	return XENO_ATTACK_ACTION
 
 /obj/structure/largecrate/ex_act(power)


### PR DESCRIPTION

# About the pull request

Oversight in message flags, fixes #3387

# Explain why it's good for the game

Bugs aren't so good


</details>


# Changelog


:cl:
fix: Xenos are no longer notified each time a sister destroys a large crate.
/:cl:

