### PR TITLE
Data detector no longer goes off on empty vial boxes

### DIFF
--- a/code/game/objects/items/devices/data_detector.dm
+++ b/code/game/objects/items/devices/data_detector.dm
@@ -17,6 +17,7 @@
 		/obj/structure/machinery/computer/objective,
 		/obj/item/limb/head/synth,
 	)
+	var/detect_empty_vial_boxes = FALSE
 
 /obj/item/device/motiondetector/intel/get_help_text()
 	. = "Green indicators on your HUD will show the location of intelligence objects detected by the scanner. Has two modes: slow long-range [SPAN_HELPFUL("(14 tiles)")] and fast short-range [SPAN_HELPFUL("(7 tiles)")]."
@@ -42,10 +43,16 @@
 		var/detected
 		for(var/DT in objects_to_detect)
 			if(istype(I, DT))
+				if(!detect_empty_vial_boxes && istype(I, /obj/item/storage/fancy/vials/random))
+					if(!I.contents)
+						continue
 				detected = TRUE
 			if(I.contents)
 				for(var/obj/item/CI in I.contents)
 					if(istype(CI, DT))
+						if(!detect_empty_vial_boxes && istype(I, /obj/item/storage/fancy/vials/random))
+							if(!I.contents)
+								continue
 						detected = TRUE
 						break
 			if(human_user && detected)
@@ -69,6 +76,9 @@
 			for(var/obj/I in M.contents_twice())
 				for(var/DT in objects_to_detect)
 					if(istype(I, DT))
+						if(!detect_empty_vial_boxes && istype(I, /obj/item/storage/fancy/vials/random))
+							if(!I.contents)
+								continue
 						detected = TRUE
 						break
 				if(detected)


### PR DESCRIPTION

# About the pull request

This is just a quality of life fix really, fixes #3420

# Explain why it's good for the game

There's no reason to detect on objects with no intel.


</details>


# Changelog


:cl:
fix: Data detector no longer triggers on empty vial boxes
/:cl:

