### PR TITLE
You can now use the Ghost verb when nested and still return to your body when freed

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -388,7 +388,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 			options = list("Aghost") + options
 		var/text_prompt = "Are you -sure- you want to ghost?\n(You are alive. If you ghost, you won't be able to return to your body. You can't change your mind so choose wisely!)"
 		var/is_nested = (buckled && istype(buckled, /obj/structure/bed/nest))
-		var/nest
+		var/obj/structure/bed/nest/nest
 		if(is_nested)
 			text_prompt += "\nSince you're nested, you will be given a chance to reenter your body upon being freed."
 			nest = buckled

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -402,10 +402,10 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		if(location) //to avoid runtime when a mob ends up in nullspace
 			msg_admin_niche("[key_name_admin(usr)] has ghosted. [ADMIN_JMP(location)]")
 		log_game("[key_name_admin(usr)] has ghosted.")
-		var/mob/dead/observer/ghost = ghostize(is_nested) //FALSE parameter is so we can never re-enter our body, "Charlie, you can never come baaaack~" :3
+		var/mob/dead/observer/ghost = ghostize((is_nested && nest && !QDELETED(nest))) //FALSE parameter is so we can never re-enter our body, "Charlie, you can never come baaaack~" :3
 		if(ghost && !is_admin_level(z))
 			ghost.timeofdeath = world.time
-		if(is_nested && nest)
+		if(is_nested && nest && !QDELETED(nest))
 			ghost.can_reenter_corpse = FALSE
 
 /mob/dead/observer/Move(atom/newloc, direct)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -386,7 +386,13 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		var/list/options = list("Ghost", "Stay in body")
 		if(check_rights(R_MOD))
 			options = list("Aghost") + options
-		var/response = tgui_alert(src, "Are you -sure- you want to ghost?\n(You are alive. If you ghost, you won't be able to return to your body. You can't change your mind so choose wisely!)", "Are you sure you want to ghost?", options)
+		var/text_prompt = "Are you -sure- you want to ghost?\n(You are alive. If you ghost, you won't be able to return to your body. You can't change your mind so choose wisely!)"
+		var/is_nested = (buckled && istype(buckled, /obj/structure/bed/nest))
+		var/nest
+		if(is_nested)
+			text_prompt += "\nSince you're nested, you will be given a chance to reenter you body upon being freed."
+			nest = buckled
+		var/response = tgui_alert(src, text_prompt, "Are you sure you want to ghost?", options)
 		if(response == "Aghost")
 			client.admin_ghost()
 			return
@@ -396,9 +402,11 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		if(location) //to avoid runtime when a mob ends up in nullspace
 			msg_admin_niche("[key_name_admin(usr)] has ghosted. [ADMIN_JMP(location)]")
 		log_game("[key_name_admin(usr)] has ghosted.")
-		var/mob/dead/observer/ghost = ghostize(FALSE) //FALSE parameter is so we can never re-enter our body, "Charlie, you can never come baaaack~" :3
+		var/mob/dead/observer/ghost = ghostize(is_nested) //FALSE parameter is so we can never re-enter our body, "Charlie, you can never come baaaack~" :3
 		if(ghost && !is_admin_level(z))
 			ghost.timeofdeath = world.time
+		if(is_nested && nest)
+			ghost.can_reenter_corpse = FALSE
 
 /mob/dead/observer/Move(atom/newloc, direct)
 	following = null

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -390,7 +390,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		var/is_nested = (buckled && istype(buckled, /obj/structure/bed/nest))
 		var/nest
 		if(is_nested)
-			text_prompt += "\nSince you're nested, you will be given a chance to reenter you body upon being freed."
+			text_prompt += "\nSince you're nested, you will be given a chance to reenter your body upon being freed."
 			nest = buckled
 		var/response = tgui_alert(src, text_prompt, "Are you sure you want to ghost?", options)
 		if(response == "Aghost")


### PR DESCRIPTION
# About the pull request

This is just confusing. Fixes #1552

# Explain why it's good for the game

Less confusion good


</details>


# Changelog

:cl:
fix: You'll now be allowed to reenter your nested body when freed, even if you used the ghost verb.
/:cl:

