### PR TITLE
Fluff security record entry is now added as a comment to the security records.

### DIFF
--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -307,7 +307,7 @@ GLOBAL_DATUM_INIT(data_core, /datum/datacore, new)
 	S.fields["ref"] = WEAKREF(H)
 
 	if(H.sec_record && !jobban_isbanned(H, "Records"))
-		var/new_comment = list("entry" = H.sec_record, "created_by" = list("name" = "\[REDACTED\]", "rank" = "Military Police"), "deleted_by" = null, "deleted_at" = null, "created_at" = "Pre Deployment")
+		var/new_comment = list("entry" = H.sec_record, "created_by" = list("name" = "\[REDACTED\]", "rank" = "Military Police"), "deleted_by" = null, "deleted_at" = null, "created_at" = "Pre-Deployment")
 		S.fields["comments"] = list("1" = new_comment)
 		S.fields["notes"] = H.sec_record
 	security += S

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -305,7 +305,13 @@ GLOBAL_DATUM_INIT(data_core, /datum/datacore, new)
 	S.fields["criminal"] = "None"
 	S.fields["incident"] = ""
 	S.fields["ref"] = WEAKREF(H)
+
+	if(H.sec_record && !jobban_isbanned(H, "Records"))
+		var/new_comment = list("entry" = H.sec_record, "created_by" = list("name" = "\[REDACTED\]", "rank" = "Military Police"), "deleted_by" = null, "deleted_at" = null, "created_at" = "Pre Deployment")
+		S.fields["comments"] = list("1" = new_comment)
+		S.fields["notes"] = H.sec_record
 	security += S
+
 
 	//Locked Record
 	var/datum/data/record/L = new()


### PR DESCRIPTION

# About the pull request

Very old bug. fixes #30

Adds as a comment added by user [REDACTED] (Military Police) at date "Pre-Deployment"

# Explain why it's good for the game

Consistency, the other records are there.


</details>


# Changelog


:cl:
fix: Your fluff security record from preferences is now visible to MPs.
/:cl:

