### PR TITLE
Sentries now work correctly on dropships

### DIFF
--- a/code/modules/defenses/planted_flag.dm
+++ b/code/modules/defenses/planted_flag.dm
@@ -83,6 +83,7 @@
 		apply_buff_to_player(H)
 
 /obj/structure/machinery/defenses/planted_flag/proc/turf_changed()
+	SIGNAL_HANDLER
 	if(range_bounds)
 		QDEL_NULL(range_bounds)
 

--- a/code/modules/defenses/planted_flag.dm
+++ b/code/modules/defenses/planted_flag.dm
@@ -27,6 +27,8 @@
 /obj/structure/machinery/defenses/planted_flag/Initialize()
 	. = ..()
 
+	RegisterSignal(src, COMSIG_ATOM_TURF_CHANGE, PROC_REF(turf_changed))
+
 	if(turned_on)
 		apply_area_effect()
 		start_processing()
@@ -79,6 +81,10 @@
 			continue
 
 		apply_buff_to_player(H)
+
+/obj/structure/machinery/defenses/planted_flag/proc/turf_changed()
+	if(range_bounds)
+		QDEL_NULL(range_bounds)
 
 /obj/structure/machinery/defenses/planted_flag/proc/apply_buff_to_player(mob/living/carbon/human/H)
 	H.activate_order_buff(COMMAND_ORDER_HOLD, buff_intensity, 1.5 SECONDS)

--- a/code/modules/defenses/sentry.dm
+++ b/code/modules/defenses/sentry.dm
@@ -63,6 +63,7 @@
 		start_processing()
 		set_range()
 	update_icon()
+	RegisterSignal(src, COMSIG_ATOM_TURF_CHANGE, PROC_REF(unset_range))
 
 /obj/structure/machinery/defenses/sentry/Destroy() //Clear these for safety's sake.
 	targets = null
@@ -107,7 +108,8 @@
 			range_bounds = RECT(x, y - 4, 7, 7)
 
 /obj/structure/machinery/defenses/sentry/proc/unset_range()
-	qdel(range_bounds)
+	if(range_bounds)
+		QDEL_NULL(range_bounds)
 
 /obj/structure/machinery/defenses/sentry/update_icon()
 	..()

--- a/code/modules/defenses/sentry.dm
+++ b/code/modules/defenses/sentry.dm
@@ -108,6 +108,7 @@
 			range_bounds = RECT(x, y - 4, 7, 7)
 
 /obj/structure/machinery/defenses/sentry/proc/unset_range()
+	SIGNAL_HANDLER
 	if(range_bounds)
 		QDEL_NULL(range_bounds)
 


### PR DESCRIPTION
# About the pull request

The sentries work by creating bounds and using those to check if anyone is in range. Since X and Y coordinates change when the dropships move, this would break until you redeployed the sentry.

Partially fixes #3554 and fixes #436 (Can't reproduce M56D not working)

# Explain why it's good for the game

Bugs bad.


# Testing Photographs and Procedure



# Changelog

:cl:
fix: Sentries now work correctly on dropships.
/:cl:
