### PR TITLE
Cluster OB now respects if a hive core is created while it is firing.

### DIFF
--- a/code/modules/cm_marines/orbital_cannon.dm
+++ b/code/modules/cm_marines/orbital_cannon.dm
@@ -484,9 +484,6 @@ var/list/ob_type_fuel_requirements
 	var/list/turf_list = list()
 
 	for(var/turf/T in range(range_num, target))
-		if(protected_by_pylon(TURF_PROTECTION_OB, T))
-			continue
-
 		turf_list += T
 
 	for(var/i = 1 to total_amount)

--- a/code/modules/cm_marines/orbital_cannon.dm
+++ b/code/modules/cm_marines/orbital_cannon.dm
@@ -492,11 +492,7 @@ var/list/ob_type_fuel_requirements
 	for(var/i = 1 to total_amount)
 		for(var/k = 1 to instant_amount)
 			var/turf/U = pick(turf_list)
-			if(!turf_list.len)
-				return //No turfs left to fire upon, hive core / OB protection granted to all turfs
 			if(protected_by_pylon(TURF_PROTECTION_OB, U)) //If the turf somehow gained OB protection while the cluster was firing
-				k-- //Give them another chance to hit something else
-				turf_list -= U
 				continue
 			fire_in_a_hole(U)
 		sleep(delay_between_clusters)

--- a/code/modules/cm_marines/orbital_cannon.dm
+++ b/code/modules/cm_marines/orbital_cannon.dm
@@ -492,6 +492,12 @@ var/list/ob_type_fuel_requirements
 	for(var/i = 1 to total_amount)
 		for(var/k = 1 to instant_amount)
 			var/turf/U = pick(turf_list)
+			if(!turf_list.len)
+				return //No turfs left to fire upon, hive core / OB protection granted to all turfs
+			if(protected_by_pylon(TURF_PROTECTION_OB, U)) //If the turf somehow gained OB protection while the cluster was firing
+				k-- //Give them another chance to hit something else
+				turf_list -= U
+				continue
 			fire_in_a_hole(U)
 		sleep(delay_between_clusters)
 


### PR DESCRIPTION

# About the pull request

It checks for OB protection on the turf now. It'll remove the turf from consideration and try a different one. If no valid turfs remain the OB stops.

# Explain why it's good for the game

Seems fair enough, very niche case though.


# Testing Photographs and Procedure



# Changelog

:cl:
balance: Cluster OBs will now no longer hit turfs that have gotten OB protection after the initial OB was fired.
/:cl:

