### PR TITLE
Huggers no longer lose health over time on weeds

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
@@ -66,7 +66,7 @@
 		PF.flags_can_pass_all = PASS_ALL^PASS_OVER_THROW_ITEM
 
 /mob/living/carbon/xenomorph/facehugger/Life(delta_time)
-	if(stat != DEAD && !lying)
+	if(stat != DEAD && !lying && !locate(/obj/effect/alien/weeds) in get_turf(src))
 		adjustBruteLoss(1)
 	return ..()
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
@@ -66,7 +66,7 @@
 		PF.flags_can_pass_all = PASS_ALL^PASS_OVER_THROW_ITEM
 
 /mob/living/carbon/xenomorph/facehugger/Life(delta_time)
-	if(stat != DEAD && !lying && !locate(/obj/effect/alien/weeds) in get_turf(src))
+	if(stat != DEAD && !lying && !(locate(/obj/effect/alien/weeds) in get_turf(src)))
 		adjustBruteLoss(1)
 	return ..()
 


### PR DESCRIPTION
From what I can tell the damage is meant to effect huggers outside of weeds so it is more of a QoL for huggers to make the role more bearable to play on the weeds.

If it is meant to effect huggers on weeds too then I'd like to challenge that idea because I find that part more of a chore vs a fun gameplay aspect.

:cl: Hopek
balance: Huggers no longer lose health over time on weeds.
/:cl:

