### PR TITLE
Fix Restore some object back to original to keep them compatible with older map

### DIFF
--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -83,6 +83,7 @@ PLANT_CUT_MACHETE = 3 = Needs at least a machete to be cut down
 //dead
 /obj/structure/flora/tree/dead
 	icon = 'icons/obj/structures/props/deadtrees.dmi'
+	icon_state = "tree_1"
 
 /obj/structure/flora/tree/dead/tree_1
 	icon_state = "tree_1"
@@ -149,6 +150,7 @@ ICE GRASS
 
 //brown
 /obj/structure/flora/grass/ice/brown
+	icon_state = "snowgrassbb_1"
 	icon_tag = "snowgrassbb"
 
 /obj/structure/flora/grass/ice/brown/snowgrassbb_1
@@ -162,8 +164,8 @@ ICE GRASS
 
 //green
 /obj/structure/flora/grass/ice/green
-	icon_tag = "snowgrassgb"
 	icon_state = "snowgrassgb_1"
+	icon_tag = "snowgrassgb"
 
 //both
 /obj/structure/flora/grass/ice/both
@@ -202,6 +204,7 @@ ICEY GRASS. IT LOOKS LIKE IT'S MADE OF ICE.
 
 /obj/structure/flora/grass/desert
 	icon = 'icons/obj/structures/props/dam.dmi'
+	icon_state = "lightgrass_1"
 
 // to replace with
 /obj/structure/flora/grass/desert/lightgrass_1
@@ -241,6 +244,8 @@ ICEY GRASS. IT LOOKS LIKE IT'S MADE OF ICE.
 	icon_state = "lightgrass_12"
 
 //heavy desert grass
+/obj/structure/flora/grass/desert/heavy
+	icon_state = "heavygrass_1"
 
 /obj/structure/flora/grass/desert/heavygrass_1
 	icon_state = "heavygrass_1"
@@ -618,6 +623,7 @@ ICEY GRASS. IT LOOKS LIKE IT'S MADE OF ICE.
 	name = "vines"
 	desc = "A mass of twisted vines."
 	icon = 'icons/effects/spacevines.dmi'
+	icon_state = "light_1"
 	icon_tag = "light"
 	variations = 3
 	cut_level = PLANT_CUT_MACHETE

--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -327,6 +327,7 @@
 
 /turf/open/gm/grass
 	name = "grass"
+	icon_state = "grass1"
 	baseturfs = /turf/open/gm/grass
 	scorchable = "grass1"
 


### PR DESCRIPTION
# About the pull request
Restore some object back to original to keep them compatible with older map that people are working on off the main maps.
it was a miss on my part and we have no reason to penalize people that are working on maps off the grid...

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Because i don't want to piss off mapper for no good reason or give a reason for people to give up project.
i don't want to create issues i want to solve them.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: restore some object back to original to keep them compatible with older map.
/:cl:
