### PR TITLE
Crippling Strike is now forced harm intent

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -12,8 +12,13 @@
 	if(M.fortify || M.burrow)
 		return XENO_NO_DELAY_ACTION
 
+	var/intent = M.a_intent
+
+	if(M.behavior_delegate)
+		intent = M.behavior_delegate.override_intent(src)
+
 	//Reviewing the four primary intents
-	switch(M.a_intent)
+	switch(intent)
 
 		if(INTENT_HELP)
 			if(on_fire)

--- a/code/modules/mob/living/carbon/xenomorph/castes/Lurker.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Lurker.dm
@@ -88,6 +88,15 @@
 
 	return original_damage
 
+/datum/behavior_delegate/lurker_base/override_intent(mob/living/carbon/target_carbon)
+	. = ..()
+
+	if(!isxeno_human(target_carbon))
+		return
+
+	if(next_slash_buffed)
+		return INTENT_HARM
+
 /datum/behavior_delegate/lurker_base/melee_attack_additional_effects_target(mob/living/carbon/target_carbon)
 	if (!isxeno_human(target_carbon))
 		return

--- a/code/modules/mob/living/carbon/xenomorph/mutators/behavior_delegate.dm
+++ b/code/modules/mob/living/carbon/xenomorph/mutators/behavior_delegate.dm
@@ -100,3 +100,7 @@
 /// Handling the xeno icon state or overlays, return TRUE if icon state should not be changed
 /datum/behavior_delegate/proc/on_update_icons()
 	return
+
+/// Used to override an intent for some abilities that must force harm on next attack_alien()
+/datum/behavior_delegate/proc/override_intent(mob/living/carbon/target_carbon)
+	return bound_xeno.a_intent


### PR DESCRIPTION

# About the pull request

This PR makes lurker's crippling strike ability forced on harm intent for the next attack.

Let's see if reviewers shoot me for how I did this.

# Explain why it's good for the game

Using crippling strike as a attack delay cancel to double disarm is not the wanted behavior.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
balance: Crippling Strike is now forced harm intent
/:cl:
