### PR TITLE
Fixes misleading info on weapon stats

### DIFF
--- a/tgui/packages/tgui/interfaces/WeaponStats.js
+++ b/tgui/packages/tgui/interfaces/WeaponStats.js
@@ -242,7 +242,7 @@ const Accuracy = (props, context) => {
   return (
     <Fragment>
       <ProgressBar value={accuracy / accuracy_max} ranges={RedGreenRange}>
-        Wielded accuracy: {accuracy} / {accuracy_max}
+        Wielded accurate range: {accuracy} / {accuracy_max}
       </ProgressBar>
       {!two_handed_only ? (
         <Fragment>
@@ -250,7 +250,7 @@ const Accuracy = (props, context) => {
           <ProgressBar
             value={unwielded_accuracy / accuracy_max}
             ranges={RedGreenRange}>
-            Unwielded accuracy: {unwielded_accuracy} / {accuracy_max}
+            Unwielded accurate range: {unwielded_accuracy} / {accuracy_max}
           </ProgressBar>
         </Fragment>
       ) : null}
@@ -258,7 +258,7 @@ const Accuracy = (props, context) => {
         <Fragment>
           <Box height="5px" />
           <ProgressBar value={min_accuracy / accuracy_max}>
-            Minimum accuracy: {min_accuracy}
+            Minimum accurate range: {min_accuracy}
           </ProgressBar>
         </Fragment>
       ) : null}


### PR DESCRIPTION

# About the pull request
The examine weapon stats accuracy section is highly misleading, it's not actually how accurate the weapon is, it's the distance at which it's accuracy is unaffected.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Cleans up confusion. This lead to some misinformation on ammunition types such as smartgun ammo, where AP rounds are inherently half as accurate as standard, but their accuracy bar is twice as high because the accurate distance is twice as high.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
spellcheck: Weapon Stats examine UI now shows 'accurate range' rather than 'accuracy'
/:cl:
