### PR TITLE
LV522 Fixes (Weedable tiles, Invis walls, weird windows)

### DIFF
--- a/code/game/area/LV522_Chances_Claim.dm
+++ b/code/game/area/LV522_Chances_Claim.dm
@@ -28,6 +28,10 @@
 	is_resin_allowed = FALSE
 	flags_area = AREA_NOTUNNEL
 
+/area/lv522/oob/w_y_vault
+	name = "LV522 - Weyland Secure Vault"
+	icon_state = "blue"
+
 //Landing Zone 1
 
 /area/lv522/landing_zone_1

--- a/code/game/turfs/auto_turf.dm
+++ b/code/game/turfs/auto_turf.dm
@@ -316,9 +316,6 @@
 	icon = 'icons/turf/floors/auto_shale.dmi'
 	icon_prefix = "shale"
 
-/turf/open/auto_turf/shale/is_weedable()
-	return SEMI_WEEDABLE
-
 /turf/open/auto_turf/shale/get_dirt_type()
 	return DIRT_TYPE_SHALE
 

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -561,10 +561,10 @@
 	return NOT_WEEDABLE
 
 /turf/open/auto_turf/shale/layer1/is_weedable()
-	return FALSE
+	return SEMI_WEEDABLE
 
 /turf/open/auto_turf/shale/layer2/is_weedable()
-	return FALSE
+	return SEMI_WEEDABLE
 
 /turf/closed/wall/is_weedable()
 	return FULLY_WEEDABLE //so we can spawn weeds on the walls

--- a/maps/map_files/LV522_Chances_Claim/LV522_Chances_Claim.dmm
+++ b/maps/map_files/LV522_Chances_Claim/LV522_Chances_Claim.dmm
@@ -16992,9 +16992,10 @@
 	dir = 6
 	},
 /obj/structure/prop/vehicles/crawler{
+	density = 0;
 	dir = 8;
-	layer = 2.9;
-	pixel_y = -14
+	layer = 2.0;
+	pixel_y = -13
 	},
 /turf/open/auto_turf/shale/layer0,
 /area/lv522/outdoors/nw_rockies)
@@ -94219,7 +94220,7 @@ qSH
 qSH
 qSH
 qSH
-qSH
+oQC
 qnb
 krH
 krH

--- a/maps/map_files/LV522_Chances_Claim/LV522_Chances_Claim.dmm
+++ b/maps/map_files/LV522_Chances_Claim/LV522_Chances_Claim.dmm
@@ -19092,7 +19092,7 @@
 	dir = 4;
 	icon_state = "white_cyan1"
 	},
-/area/lv522/oob)
+/area/lv522/oob/w_y_vault)
 "jab" = (
 /obj/structure/window/framed/strata/reinforced,
 /turf/open/floor/corsat{
@@ -19197,7 +19197,7 @@
 	dir = 4;
 	icon_state = "white_cyan1"
 	},
-/area/lv522/oob)
+/area/lv522/oob/w_y_vault)
 "jbs" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor/corsat{
@@ -20441,7 +20441,7 @@
 	dir = 4;
 	icon_state = "white_cyan1"
 	},
-/area/lv522/oob)
+/area/lv522/oob/w_y_vault)
 "jBs" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
@@ -20608,7 +20608,7 @@
 	dir = 4;
 	icon_state = "whiteyellowfull"
 	},
-/area/lv522/oob)
+/area/lv522/oob/w_y_vault)
 "jEk" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_nest,
@@ -22937,7 +22937,7 @@
 	dir = 4;
 	icon_state = "whiteyellowfull"
 	},
-/area/lv522/oob)
+/area/lv522/oob/w_y_vault)
 "kze" = (
 /obj/structure/pipes/vents/pump,
 /turf/open/floor/prison{
@@ -23368,7 +23368,7 @@
 	dir = 4;
 	icon_state = "whiteyellowfull"
 	},
-/area/lv522/oob)
+/area/lv522/oob/w_y_vault)
 "kHy" = (
 /obj/structure/surface/table/almayer,
 /obj/item/storage/box/flashbangs{
@@ -23467,7 +23467,7 @@
 	dir = 4;
 	icon_state = "white_cyan1"
 	},
-/area/lv522/oob)
+/area/lv522/oob/w_y_vault)
 "kIZ" = (
 /obj/structure/machinery/door/poddoor/shutters/almayer/open{
 	dir = 4;
@@ -23574,7 +23574,7 @@
 	dir = 4;
 	icon_state = "white_cyan1"
 	},
-/area/lv522/oob)
+/area/lv522/oob/w_y_vault)
 "kLs" = (
 /obj/item/clothing/mask/facehugger{
 	desc = "It has some sort of a tube at the end of its tail. What the hell is this thing?";
@@ -24283,7 +24283,7 @@
 	dir = 4;
 	icon_state = "white_cyan1"
 	},
-/area/lv522/oob)
+/area/lv522/oob/w_y_vault)
 "kYm" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 5
@@ -24439,7 +24439,7 @@
 	dir = 4;
 	icon_state = "white_cyan1"
 	},
-/area/lv522/oob)
+/area/lv522/oob/w_y_vault)
 "lbA" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 10
@@ -24825,7 +24825,7 @@
 	dir = 4;
 	icon_state = "white_cyan1"
 	},
-/area/lv522/oob)
+/area/lv522/oob/w_y_vault)
 "llM" = (
 /obj/item/tool/kitchen/knife/butcher,
 /obj/effect/decal/cleanable/dirt,
@@ -25351,7 +25351,7 @@
 	dir = 4;
 	icon_state = "white_cyan1"
 	},
-/area/lv522/oob)
+/area/lv522/oob/w_y_vault)
 "lze" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/effect/decal/warning_stripes{
@@ -25831,7 +25831,7 @@
 /turf/open/floor/corsat{
 	icon_state = "marked"
 	},
-/area/lv522/oob)
+/area/lv522/oob/w_y_vault)
 "lIR" = (
 /obj/structure/prop/invuln/ice_prefab/trim{
 	dir = 8
@@ -27432,7 +27432,7 @@
 "mwv" = (
 /obj/effect/landmark/lv624/fog_blocker/short,
 /turf/closed/wall/strata_outpost/reinforced,
-/area/lv522/oob)
+/area/lv522/oob/w_y_vault)
 "mwT" = (
 /obj/structure/prop/dam/truck,
 /obj/structure/prop/holidays/wreath{
@@ -28357,7 +28357,7 @@
 /obj/effect/landmark/lv624/fog_blocker/short,
 /obj/effect/landmark/lv624/fog_blocker/short,
 /turf/closed/wall/strata_outpost/reinforced,
-/area/lv522/oob)
+/area/lv522/oob/w_y_vault)
 "mSe" = (
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/lv522/indoors/a_block/bridges/garden_bridge)
@@ -47815,7 +47815,7 @@
 /area/lv522/indoors/a_block/bridges/op_centre)
 "uKD" = (
 /turf/closed/wall/strata_outpost/reinforced,
-/area/lv522/oob)
+/area/lv522/oob/w_y_vault)
 "uKE" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 5
@@ -49098,6 +49098,9 @@
 	icon_state = "rasputin15"
 	},
 /area/lv522/landing_zone_forecon/UD6_Tornado)
+"vju" = (
+/turf/closed/wall/strata_outpost,
+/area/lv522/oob/w_y_vault)
 "vjv" = (
 /turf/closed/shuttle/dropship2/tornado{
 	icon_state = "69"
@@ -76038,12 +76041,12 @@ saC
 xED
 uKD
 uKD
-abo
-abo
-abo
-abo
-abo
-abo
+vju
+vju
+vju
+vju
+vju
+vju
 uKD
 mwv
 tvO
@@ -76264,14 +76267,14 @@ saC
 saC
 xED
 uKD
-abo
-abo
+vju
+vju
 jbn
 jbn
 jbn
 kIY
-abo
-abo
+vju
+vju
 mwv
 tvO
 ugV
@@ -76491,14 +76494,14 @@ saC
 saC
 xED
 uKD
-abo
+vju
 iZS
 jBr
 jEa
 jEa
 kLk
 lbo
-abo
+vju
 mwv
 tvO
 ugV
@@ -76718,7 +76721,7 @@ saC
 saC
 xED
 uKD
-abo
+vju
 iZS
 jEa
 kHd
@@ -76945,8 +76948,8 @@ saC
 saC
 xED
 uKD
-abo
-abo
+vju
+vju
 kzd
 jEa
 jEa
@@ -77172,7 +77175,7 @@ saC
 saC
 xED
 uKD
-abo
+vju
 iZS
 jEa
 jEa
@@ -77399,14 +77402,14 @@ saC
 saC
 xED
 uKD
-abo
+vju
 iZS
 jBr
 jEa
 jEa
 kXY
 lzb
-abo
+vju
 mwv
 tvO
 ugV
@@ -77626,14 +77629,14 @@ saC
 saC
 xED
 uKD
-abo
-abo
+vju
+vju
 jbn
 jbn
 jbn
 kIY
-abo
-abo
+vju
+vju
 mwv
 tvO
 ugV
@@ -77854,12 +77857,12 @@ saC
 xED
 uKD
 uKD
-abo
-abo
-abo
-abo
-abo
-abo
+vju
+vju
+vju
+vju
+vju
+vju
 uKD
 mSc
 tvO

--- a/maps/map_files/LV522_Chances_Claim/LV522_Chances_Claim.dmm
+++ b/maps/map_files/LV522_Chances_Claim/LV522_Chances_Claim.dmm
@@ -5559,6 +5559,7 @@
 /obj/structure/surface/rack,
 /obj/item/device/analyzer,
 /obj/effect/landmark/objective_landmark/close,
+/obj/item/stack/sandbags_empty/small_stack,
 /turf/open/floor/prison{
 	icon_state = "darkbrownfull2"
 	},
@@ -15182,6 +15183,11 @@
 /obj/structure/bed/chair/wheelchair,
 /turf/open/auto_turf/shale/layer1,
 /area/lv522/outdoors/colony_streets/north_east_street)
+"hra" = (
+/obj/structure/largecrate/random,
+/obj/item/stack/sandbags_empty/small_stack,
+/turf/open/floor/plating,
+/area/lv522/indoors/c_block/mining)
 "hre" = (
 /obj/structure/flora/jungle/planttop1,
 /turf/open/organic/grass,
@@ -84128,7 +84134,7 @@ jas
 jas
 jas
 jas
-tms
+hra
 nQu
 aEF
 jas

--- a/maps/map_files/LV522_Chances_Claim/LV522_Chances_Claim.dmm
+++ b/maps/map_files/LV522_Chances_Claim/LV522_Chances_Claim.dmm
@@ -2055,10 +2055,20 @@
 	},
 /area/lv522/indoors/c_block/garage)
 "bnz" = (
-/obj/item/stack/sandbags_empty/half,
-/obj/structure/pipes/standard/simple/hidden/green,
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/lv522/indoors/b_block/bridge)
+/obj/structure/surface/table/almayer,
+/obj/structure/flora/pottedplant{
+	desc = "It is made of Fiberbush(tm). It contains asbestos. Studies say that greenery calms the mind due to some sort evolved mechanism in the brain. This plant is not calming.";
+	icon_state = "pottedplant_21";
+	layer = 3.1;
+	name = "synthethic potted plant";
+	pixel_y = 14
+	},
+/obj/effect/decal/cleanable/cobweb2,
+/obj/effect/spider/spiderling/nogrow,
+/turf/open/floor/prison{
+	icon_state = "darkredfull2"
+	},
+/area/lv522/indoors/a_block/security)
 "bnH" = (
 /obj/structure/machinery/light{
 	dir = 1
@@ -4651,12 +4661,12 @@
 /turf/open/floor/corsat,
 /area/lv522/atmos/east_reactor/west)
 "cKF" = (
-/obj/item/explosive/plastic/breaching_charge,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/prison{
-	icon_state = "darkredfull2"
+/obj/structure/cargo_container/kelland/left,
+/obj/item/explosive/plastic/breaching_charge{
+	layer = 5
 	},
-/area/lv522/indoors/a_block/security)
+/turf/open/auto_turf/shale/layer0,
+/area/lv522/outdoors/colony_streets/east_central_street)
 "cKG" = (
 /turf/closed/wall/strata_ice/dirty,
 /area/lv522/outdoors/nw_rockies)
@@ -7741,19 +7751,6 @@
 	icon_state = "cement4"
 	},
 /area/lv522/outdoors/colony_streets/south_east_street)
-"ebM" = (
-/obj/structure/blocker/invisible_wall,
-/obj/effect/decal/warning_stripes{
-	icon_state = "W"
-	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "E";
-	pixel_x = 1
-	},
-/turf/open/floor/prison{
-	icon_state = "floor_plate"
-	},
-/area/lv522/atmos/cargo_intake)
 "ebP" = (
 /obj/effect/decal/hefa_cult_decals/d32{
 	icon_state = "2"
@@ -7858,12 +7855,6 @@
 	icon_state = "greenfull"
 	},
 /area/lv522/indoors/b_block/bridge)
-"eeX" = (
-/obj/structure/blocker/invisible_wall,
-/turf/open/asphalt/cement{
-	icon_state = "cement1"
-	},
-/area/lv522/outdoors/n_rockies)
 "eeY" = (
 /obj/structure/pipes/standard/manifold/hidden/green,
 /turf/open/auto_turf/shale/layer0,
@@ -9656,7 +9647,6 @@
 	},
 /area/lv522/atmos/west_reactor)
 "eUf" = (
-/obj/structure/blocker/invisible_wall,
 /obj/item/ammo_magazine/m2c{
 	current_rounds = 0;
 	layer = 4.2;
@@ -9670,10 +9660,8 @@
 	icon_state = "E";
 	pixel_x = 1
 	},
-/turf/open/floor/prison{
-	icon_state = "floor_plate"
-	},
-/area/lv522/atmos/cargo_intake)
+/turf/closed/wall/strata_ice/dirty,
+/area/lv522/oob)
 "eUh" = (
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/lv522/indoors/a_block/security)
@@ -10121,14 +10109,13 @@
 /turf/open/floor/prison,
 /area/lv522/landing_zone_2)
 "fgf" = (
-/obj/structure/blocker/invisible_wall,
 /obj/item/ammo_magazine/m2c{
 	current_rounds = 0;
 	layer = 4.2;
 	pixel_x = 17
 	},
-/turf/open/auto_turf/shale/layer0,
-/area/lv522/outdoors/n_rockies)
+/turf/closed/wall/strata_ice/dirty,
+/area/lv522/oob)
 "fgk" = (
 /obj/structure/platform_decoration{
 	dir = 1
@@ -11443,7 +11430,6 @@
 	unacidable = 1;
 	unslashable = 1
 	},
-/obj/structure/blocker/invisible_wall,
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
 	},
@@ -11451,10 +11437,8 @@
 	icon_state = "E";
 	pixel_x = 1
 	},
-/turf/open/floor/prison{
-	icon_state = "floor_plate"
-	},
-/area/lv522/atmos/cargo_intake)
+/turf/closed/wall/strata_ice/dirty,
+/area/lv522/oob)
 "fLF" = (
 /obj/structure/machinery/door/poddoor/almayer/closed{
 	dir = 4;
@@ -11597,10 +11581,6 @@
 	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/casino)
-"fOl" = (
-/obj/structure/blocker/invisible_wall,
-/turf/open/auto_turf/shale/layer0,
-/area/lv522/outdoors/n_rockies)
 "fOy" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/decal/cleanable/cobweb,
@@ -13029,7 +13009,7 @@
 	},
 /area/lv522/atmos/command_centre)
 "gxe" = (
-/obj/item/stack/sandbags_empty/half,
+/obj/item/stack/sandbags_empty/small_stack,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/lv522/indoors/b_block/bridge)
 "gxl" = (
@@ -17159,15 +17139,6 @@
 	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_west_street)
-"iiz" = (
-/obj/structure/window/framed/strata/reinforced,
-/obj/structure/machinery/door/poddoor/shutters/almayer{
-	id = "Sec-Corpo-Bridge-Lockdown"
-	},
-/turf/open/floor/corsat{
-	icon_state = "marked"
-	},
-/area/lv522/indoors/a_block/security)
 "iiC" = (
 /obj/structure/surface/table/almayer,
 /obj/item/paper_bin/wy{
@@ -33535,15 +33506,6 @@
 /obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/auto_turf/shale/layer0,
 /area/lv522/landing_zone_1)
-"pbb" = (
-/obj/structure/platform{
-	dir = 1
-	},
-/obj/structure/girder/displaced,
-/turf/open/asphalt/cement{
-	icon_state = "cement12"
-	},
-/area/lv522/outdoors/colony_streets/south_street)
 "pbp" = (
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/lv522/indoors/a_block/dorms/glass)
@@ -34159,21 +34121,6 @@
 	},
 /turf/open/floor/corsat{
 	icon_state = "marked"
-	},
-/area/lv522/indoors/a_block/security)
-"poN" = (
-/obj/structure/surface/table/almayer,
-/obj/structure/flora/pottedplant{
-	desc = "It is made of Fiberbush(tm). It contains asbestos. Studies say that greenery calms the mind due to some sort evolved mechanism in the brain. This plant is not calming.";
-	icon_state = "pottedplant_21";
-	layer = 3.1;
-	name = "synthethic potted plant";
-	pixel_y = 14
-	},
-/obj/effect/decal/cleanable/cobweb2,
-/obj/effect/spider/spiderling/nogrow,
-/turf/open/floor/prison{
-	icon_state = "darkredfull2"
 	},
 /area/lv522/indoors/a_block/security)
 "poQ" = (
@@ -38053,9 +38000,7 @@
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "qPS" = (
-/obj/structure/machinery/door/airlock/almayer/generic{
-	dir = 1
-	},
+/obj/structure/machinery/door/airlock/multi_tile/almayer/generic,
 /turf/open/floor/corsat{
 	icon_state = "marked"
 	},
@@ -39956,7 +39901,6 @@
 	},
 /area/lv522/indoors/c_block/mining)
 "ryv" = (
-/obj/structure/window/framed/strata/reinforced,
 /turf/open/floor/corsat{
 	icon_state = "marked"
 	},
@@ -68134,7 +68078,7 @@ bIJ
 bIJ
 yim
 abV
-ebM
+abV
 eUf
 fLz
 abV
@@ -68361,9 +68305,9 @@ yim
 yim
 yim
 cpy
-eeX
-eeX
-eeX
+inU
+cpy
+cpy
 gGx
 inU
 inU
@@ -68590,7 +68534,7 @@ cpy
 cpy
 cpy
 fgf
-fOl
+cpy
 yim
 hzA
 ihy
@@ -68817,7 +68761,7 @@ yim
 cpy
 cpy
 cpy
-fOl
+cpy
 cpy
 hIp
 ijv
@@ -69300,7 +69244,7 @@ roT
 xTs
 sKL
 tkM
-xtb
+xyL
 uad
 xTs
 uIo
@@ -69527,7 +69471,7 @@ vsG
 xTs
 xTs
 tkM
-xtb
+xyL
 ubd
 xTs
 jLF
@@ -69981,7 +69925,7 @@ rLq
 siT
 uEC
 xqd
-xyL
+xtb
 xqd
 uEC
 pAW
@@ -70662,7 +70606,7 @@ rLy
 siT
 uEC
 xqd
-xyL
+xtb
 ubv
 xXX
 xtb
@@ -72597,7 +72541,7 @@ hyf
 wIr
 hWs
 pXq
-bnz
+pOs
 uNu
 pKl
 oLa
@@ -72824,7 +72768,7 @@ dgY
 gwg
 cHb
 oqp
-gxe
+oLa
 pKl
 pKl
 tkf
@@ -75757,7 +75701,7 @@ xgH
 tkf
 pfD
 rQg
-pbb
+vdp
 nax
 nax
 uXp
@@ -79530,7 +79474,7 @@ nTx
 nTx
 nTx
 mvR
-ryv
+sjy
 uVj
 kOS
 uDb
@@ -79758,7 +79702,7 @@ nTx
 nTx
 mvR
 qPS
-uVj
+oGp
 xxs
 eUh
 eUh
@@ -79985,7 +79929,7 @@ mcC
 nTx
 jNv
 ryv
-jft
+lhT
 xxs
 uDb
 uDb
@@ -80212,8 +80156,8 @@ nTx
 eHn
 uWh
 sjy
-poN
-uVj
+jft
+xxs
 uDb
 kBB
 nrP
@@ -80439,7 +80383,7 @@ nTx
 eHn
 pgl
 sjy
-sjy
+bnz
 xQi
 uDb
 uDb
@@ -81347,8 +81291,8 @@ xlI
 mev
 mev
 tdD
-iiz
-cKF
+sjy
+uVj
 qDr
 xxs
 nrP
@@ -82028,7 +81972,7 @@ xlI
 xlI
 yjy
 xlI
-iiz
+sjy
 uVj
 eqM
 cvi
@@ -94551,7 +94495,7 @@ tTD
 tTD
 tSm
 rnB
-oXZ
+cKF
 uKR
 rnB
 rnB

--- a/maps/map_files/LV522_Chances_Claim/LV522_Chances_Claim.dmm
+++ b/maps/map_files/LV522_Chances_Claim/LV522_Chances_Claim.dmm
@@ -6688,12 +6688,6 @@
 	},
 /turf/open/floor/prison,
 /area/lv522/indoors/a_block/kitchen)
-"dEu" = (
-/obj/structure/window/framed/strata/reinforced,
-/turf/open/floor/corsat{
-	icon_state = "marked"
-	},
-/area/lv522/indoors/a_block/dorm_north)
 "dEy" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/microwave{
@@ -18002,7 +17996,7 @@
 	},
 /area/lv522/indoors/c_block/mining)
 "iAZ" = (
-/obj/structure/pipes/standard/manifold/fourway/hidden/green,
+/obj/structure/pipes/standard/manifold/hidden/green,
 /turf/open/floor/prison,
 /area/lv522/indoors/a_block/dorm_north)
 "iBd" = (
@@ -45654,17 +45648,6 @@
 	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/lone_buildings/outdoor_bot)
-"tQC" = (
-/obj/structure/window_frame/strata,
-/obj/item/stack/rods,
-/obj/structure/machinery/door/poddoor/shutters/almayer/open{
-	id = "LV522CIC_1";
-	name = "\improper Storm Shutters"
-	},
-/turf/open/floor/corsat{
-	icon_state = "marked"
-	},
-/area/lv522/indoors/a_block/admin)
 "tQE" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/generic{
 	dir = 1;
@@ -55101,10 +55084,6 @@
 	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
-"xKO" = (
-/obj/structure/window/framed/strata/reinforced,
-/turf/open/floor/plating,
-/area/lv522/indoors/a_block/fitness)
 "xLg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/chair/comfy{
@@ -67284,7 +67263,7 @@ xqd
 pVx
 pVx
 pVx
-xyL
+xtb
 xWf
 imJ
 xWf
@@ -67292,7 +67271,7 @@ xWf
 xWf
 qAy
 xWf
-pMd
+nLm
 kcS
 gou
 ulL
@@ -67309,14 +67288,14 @@ pDh
 kcS
 wfb
 qjt
-pMd
+nLm
 klp
 oot
 pJW
 tUM
 gWh
 aTS
-pMd
+nLm
 lAj
 ulL
 ulL
@@ -67332,7 +67311,7 @@ ulL
 lAj
 wRd
 wLN
-pMd
+nLm
 qQM
 vXc
 wth
@@ -67965,7 +67944,7 @@ uEC
 uEC
 uEC
 pVx
-xyL
+xtb
 odZ
 imJ
 xWf
@@ -67973,7 +67952,7 @@ xWf
 xWf
 xWf
 odZ
-pMd
+nLm
 kcS
 vId
 oTg
@@ -67990,14 +67969,14 @@ fps
 npp
 cHC
 vJT
-pMd
+nLm
 oeL
 rAg
 dNm
 tUM
 gWh
 aAW
-pMd
+nLm
 kxW
 kxW
 lek
@@ -68013,7 +67992,7 @@ oTg
 pJW
 iUo
 vdV
-pMd
+nLm
 qQM
 vXc
 puY
@@ -72583,7 +72562,7 @@ tSL
 pJZ
 drz
 bFU
-yfH
+tSL
 tne
 kGm
 lML
@@ -73264,7 +73243,7 @@ tne
 yfR
 tne
 yfR
-yfH
+tSL
 hES
 tne
 tne
@@ -74090,10 +74069,10 @@ xtb
 xtb
 xtb
 xtb
-xKO
+xtb
 rMb
 skQ
-xKO
+xtb
 xtb
 tvO
 ugV
@@ -75452,10 +75431,10 @@ emH
 emH
 yjp
 beB
-dhQ
+beB
 uPk
 vnB
-dhQ
+beB
 wrC
 wrC
 xXR
@@ -81129,10 +81108,10 @@ umR
 onj
 wKg
 wKg
-lVD
+wKg
 vQT
 fmg
-lVD
+wKg
 wKg
 wKg
 lVD
@@ -86878,7 +86857,7 @@ lGW
 xgA
 acE
 kEQ
-xvB
+xvl
 otS
 fWG
 fWG
@@ -87053,7 +87032,7 @@ qBb
 iXZ
 nxj
 rMg
-hDZ
+tDS
 uNJ
 orS
 muV
@@ -87332,7 +87311,7 @@ ntS
 xgA
 bsG
 kEQ
-xvB
+xvl
 otS
 fWG
 cpy
@@ -87734,7 +87713,7 @@ lRF
 ojt
 muV
 vrg
-tQC
+tDS
 iNb
 wWV
 tvi
@@ -87966,14 +87945,14 @@ nxO
 ilR
 nGq
 way
-raj
+gdO
 puJ
 iuy
 uuH
 pfN
 pqU
 lSl
-jab
+tTK
 jmi
 cMt
 kiG
@@ -89296,10 +89275,10 @@ dRL
 dRL
 dRL
 dRL
-dEu
+dRL
 qhA
 qiG
-dEu
+dRL
 dRL
 xFp
 nQa
@@ -90211,7 +90190,7 @@ xCT
 rsq
 xCT
 yfP
-dEu
+dRL
 fKf
 qSH
 qSH
@@ -90434,9 +90413,9 @@ oBx
 nTg
 nTg
 iAZ
-qUq
-qUq
-qUq
+xCT
+xCT
+xCT
 yfP
 rJf
 fKf
@@ -90665,7 +90644,7 @@ reo
 xCT
 xCT
 yfP
-dEu
+dRL
 fKf
 qSH
 qSH
@@ -91566,10 +91545,10 @@ dRL
 dRL
 dRL
 dRL
-dEu
+dRL
 qhA
 qiG
-dEu
+dRL
 dRL
 pGY
 jKB


### PR DESCRIPTION

# About the pull request

This PR aims to fix bugs with LV522 that have been brought to my attention one of them being a critical bug involving a recent change to weedable tiles

APC: APCs had a problem for a while now somehow despite being invincible it can still be destroyed I'm not much of a coder so instead of trying to fix whatever's going wrong there I've replaced the invisible blockers with rock walls that'll only be seen if the APC gets deleted

Weedable Tiles: A recent PR tried to address a problem with gardener drone for LV522 but messed up regular shale tiles making them unweedable this PR should fix both the problem the OG PR tried to fix and the once weedable tiles now being weedable again

Areas: the W-Y vault was considered OOB this PR should also fix that

Other: I also moved around some sandbags and a breaching charge just to mess with people % the sandbags being all in the same place AND being near a "meta" hold spot was pretty strong

Hardy Weeds working on layer1 shale
https://i.imgur.com/CG80UJ3.png

Weeds working on dirt
https://i.imgur.com/RWRnyPE.png

Weird windows: I'm not exactly sure what's wrong here and will look into this further for now all the problem windows have been replaced with walls and I want to reach out to players to screenshot any invisible windows they encounter on LV522 or any map so I can actually figure out whats going wrong

# Explain why it's good for the game

The bugs in this PR are frustrating to players and should be fixed


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: SpartanBobby
fix: fixes invisible walls on LV522
fix: fixes unweedable tiles on LV522
fix: fixes invisible windows on LV522 (if you spot any invisible windows send a picture of them to the SS13: CM discord #mapperchannel @spartanbobby
fix: fixes LV522 OOB area in the W-Y vault
maptweak: moves sandbags and a breaching charge on LV522
/:cl:
