### PR TITLE
Fix runtime in proc is_in_shuttle_bounds

### DIFF
--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -180,18 +180,20 @@
 	if(P)
 		return P.id
 
-/obj/docking_port/proc/is_in_shuttle_bounds(atom/A)
-	var/turf/T = get_turf(A)
-	if(T.z != z)
+/obj/docking_port/proc/is_in_shuttle_bounds(atom/target)
+	if(!target)
+		return FALSE
+	var/turf/target_turf = get_turf(target)
+	if(!target_turf || target_turf.z != z)
 		return FALSE
 	var/list/bounds = return_coords()
 	var/x0 = bounds[1]
 	var/y0 = bounds[2]
 	var/x1 = bounds[3]
 	var/y1 = bounds[4]
-	if(!ISINRANGE(T.x, min(x0, x1), max(x0, x1)))
+	if(!ISINRANGE(target_turf.x, min(x0, x1), max(x0, x1)))
 		return FALSE
-	if(!ISINRANGE(T.y, min(y0, y1), max(y0, y1)))
+	if(!ISINRANGE(target_turf.y, min(y0, y1), max(y0, y1)))
 		return FALSE
 	return TRUE
 


### PR DESCRIPTION

# About the pull request

This PR adds checks to the proc is_in_shuttle_bounds to address the runtime:
```
[2023-06-13 04:28:51.553] runtime error: Cannot read null.z
 - proc name: is in shuttle bounds (/obj/docking_port/proc/is_in_shuttle_bounds)
 -   source file: code/modules/shuttle/shuttle.dm,185
 -   usr: null
 -   src: Alamo (/obj/docking_port/mobile/marine_dropship/alamo)
 -   src.loc: the Alamo (282,53,4) (/turf/closed/shuttle/dropship1/transparent)
 -   call stack:
 - Alamo (/obj/docking_port/mobile/marine_dropship/alamo): is in shuttle bounds(PERSON NAME (/mob/living/carbon/human))
 - Alamo (/obj/docking_port/mobile/marine_dropship/alamo): update ambience()
 - ImmediateInvokeAsync(Alamo (/obj/docking_port/mobile/marine_dropship/alamo), "update_ambience")
 - Alamo (/obj/docking_port/mobile/marine_dropship/alamo): set mode("pre-arrival")
 - Alamo (/obj/docking_port/mobile/marine_dropship/alamo): check()
 - Alamo (/obj/docking_port/mobile/marine_dropship/alamo): check()
 - Shuttle (/datum/controller/subsystem/shuttle): fire(0)
 - Shuttle (/datum/controller/subsystem/shuttle): ignite(0)
 - Master (/datum/controller/master): RunQueue()
 - Master (/datum/controller/master): Loop(2)
 - Master (/datum/controller/master): StartProcessing(0)
 ```

# Explain why it's good for the game

Should fix issues such as: https://cdn.discordapp.com/attachments/745447048261795890/1118046867863908364/Replay_2023-06-13_08-09-07.mp4

# Changelog
:cl: Drathek
fix: Fixed a runtime in shuttles when a mob is non-existent or has no turf location.
/:cl:
