### PR TITLE
Shipside role weight nerf

### DIFF
--- a/code/game/jobs/role_authority.dm
+++ b/code/game/jobs/role_authority.dm
@@ -23,7 +23,7 @@ var/global/datum/authority/branch/role/RoleAuthority
 #define MED_PRIORITY 2
 #define LOW_PRIORITY 3
 
-#define SHIPSIDE_ROLE_WEIGHT 0.5
+#define SHIPSIDE_ROLE_WEIGHT 0.25
 
 var/global/players_preassigned = 0
 


### PR DESCRIPTION

# About the pull request

This PR changes shipside role weight to 0.25.

Shipside roles will now count as 0.25 a regular marine when it comes to xeno count.

# Explain why it's good for the game

The differences at different pop levels of ratio of shipside:groundside is causing huge disparities in xeno count per marine. This should help nullify some of that. Possibly lowering further if the issue persists.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
balance: Shipside roles now weight even less for xeno counts.
/:cl:
