### PR TITLE
Adds doors to the courtyard to perma cells.

### DIFF
--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -56156,7 +56156,6 @@
 	},
 /area/almayer/shipboard/brig/lobby)
 "pFg" = (
-/obj/structure/window/framed/almayer/hull/hijack_bustable,
 /obj/structure/machinery/door/poddoor/almayer/locked{
 	dir = 8;
 	id = "Perma 1";
@@ -56167,6 +56166,7 @@
 	id = "courtyard_cells";
 	name = "\improper Courtyard Lockdown Shutter"
 	},
+/obj/structure/machinery/door/airlock/almayer/generic,
 /turf/open/floor/plating,
 /area/almayer/shipboard/brig/perma)
 "pFA" = (
@@ -75203,7 +75203,6 @@
 	},
 /area/almayer/living/cryo_cells)
 "ydU" = (
-/obj/structure/window/framed/almayer/hull/hijack_bustable,
 /obj/structure/machinery/door/poddoor/almayer/locked{
 	dir = 8;
 	id = "Perma 2";
@@ -75214,6 +75213,7 @@
 	id = "courtyard_cells";
 	name = "\improper Courtyard Lockdown Shutter"
 	},
+/obj/structure/machinery/door/airlock/almayer/generic,
 /turf/open/floor/plating,
 /area/almayer/shipboard/brig/perma)
 "yeo" = (


### PR DESCRIPTION
# About the pull request
This PR replaces the windows between the courtyard and the permanent cells with doors which can be opened when a perma prisoner gets a trip to the courtyard authorized. If needed, I can add new windows next to the door.

# Explain why it's good for the game

According to ML, perma prisoners may be given access to the courtyard as reward for not causing trouble. However, currently the MPs need to cuff the prisoner, move them through the whole brig and put them into the courtyard through the warden's office, same when the prisoner gets moved back to the cell. With this PR, MPs can just open the cell door and let the prisoner enter the courtyard.


# Testing Photographs and Procedure

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Johannes2262
maptweak: Replaced the windows between perma cells and the courtyard with doors.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
