### PR TITLE
Fix erronous flamer_tank is empty messages and add sfx to empty canister verb

### DIFF
--- a/code/modules/projectiles/magazines/flamer.dm
+++ b/code/modules/projectiles/magazines/flamer.dm
@@ -58,6 +58,7 @@
 
 	reagents.clear_reagents()
 
+	playsound(loc, 'sound/effects/refill.ogg', 25, 1, 3)
 	to_chat(usr, SPAN_NOTICE("You empty out [src]"))
 	update_icon()
 

--- a/code/modules/projectiles/magazines/flamer.dm
+++ b/code/modules/projectiles/magazines/flamer.dm
@@ -96,7 +96,8 @@
 
 	var/fuel_amt_to_remove = Clamp(to_add.volume, 0, max_rounds - reagents.get_reagent_amount(to_add.id))
 	if(!fuel_amt_to_remove)
-		to_chat(user, SPAN_WARNING("[O] is empty!"))
+		if(!max_rounds)
+			to_chat(user, SPAN_WARNING("[O] is empty!"))
 		return
 
 	O.reagents.remove_reagent(to_add.id, fuel_amt_to_remove)

--- a/code/modules/projectiles/magazines/flamer.dm
+++ b/code/modules/projectiles/magazines/flamer.dm
@@ -78,7 +78,7 @@
 		return ..()
 
 	if(!target.reagents || target.reagents.reagent_list.len < 1)
-		to_chat(user, SPAN_WARNING("\The [target] is empty!"))
+		to_chat(user, SPAN_WARNING("[target] is empty!"))
 		return
 
 	if(!reagents)
@@ -97,7 +97,7 @@
 	var/fuel_amt_to_remove = Clamp(to_add.volume, 0, max_rounds - reagents.get_reagent_amount(to_add.id))
 	if(!fuel_amt_to_remove)
 		if(!max_rounds)
-			to_chat(user, SPAN_WARNING("\The [target] is empty!"))
+			to_chat(user, SPAN_WARNING("[target] is empty!"))
 		return
 
 	target.reagents.remove_reagent(to_add.id, fuel_amt_to_remove)
@@ -106,7 +106,7 @@
 	caliber = to_add.name
 	flamer_chem = to_add.id
 
-	to_chat(user, SPAN_NOTICE("You refill \the [src] with [caliber]."))
+	to_chat(user, SPAN_NOTICE("You refill [src] with [caliber]."))
 	update_icon()
 
 /obj/item/ammo_magazine/flamer_tank/update_icon()

--- a/code/modules/projectiles/magazines/flamer.dm
+++ b/code/modules/projectiles/magazines/flamer.dm
@@ -72,22 +72,21 @@
 			G.update_icon()
 
 /obj/item/ammo_magazine/flamer_tank/afterattack(obj/target, mob/user , flag) //refuel at fueltanks when we run out of ammo.
-	if(!istype(target, /obj/structure/reagent_dispensers/fueltank) && !istype(target, /obj/item/tool/weldpack) && !istype(target, /obj/item/storage/backpack/marine/engineerpack))
-		return ..()
 	if(get_dist(user,target) > 1)
 		return ..()
+	if(!istype(target, /obj/structure/reagent_dispensers/fueltank) && !istype(target, /obj/item/tool/weldpack) && !istype(target, /obj/item/storage/backpack/marine/engineerpack))
+		return ..()
 
-	var/obj/O = target
-	if(!O.reagents || O.reagents.reagent_list.len < 1)
-		to_chat(user, SPAN_WARNING("[O] is empty!"))
+	if(!target.reagents || target.reagents.reagent_list.len < 1)
+		to_chat(user, SPAN_WARNING("\The [target] is empty!"))
 		return
 
 	if(!reagents)
 		create_reagents(max_rounds)
 
-	var/datum/reagent/to_add = O.reagents.reagent_list[1]
+	var/datum/reagent/to_add = target.reagents.reagent_list[1]
 
-	if(!istype(to_add) || (length(reagents.reagent_list) && flamer_chem != to_add.id) || length(O.reagents.reagent_list) > 1)
+	if(!istype(to_add) || (length(reagents.reagent_list) && flamer_chem != to_add.id) || length(target.reagents.reagent_list) > 1)
 		to_chat(user, SPAN_WARNING("You can't mix fuel mixtures!"))
 		return
 
@@ -98,16 +97,16 @@
 	var/fuel_amt_to_remove = Clamp(to_add.volume, 0, max_rounds - reagents.get_reagent_amount(to_add.id))
 	if(!fuel_amt_to_remove)
 		if(!max_rounds)
-			to_chat(user, SPAN_WARNING("[O] is empty!"))
+			to_chat(user, SPAN_WARNING("\The [target] is empty!"))
 		return
 
-	O.reagents.remove_reagent(to_add.id, fuel_amt_to_remove)
+	target.reagents.remove_reagent(to_add.id, fuel_amt_to_remove)
 	reagents.add_reagent(to_add.id, fuel_amt_to_remove)
 	playsound(loc, 'sound/effects/refill.ogg', 25, 1, 3)
 	caliber = to_add.name
 	flamer_chem = to_add.id
 
-	to_chat(user, SPAN_NOTICE("You refill [src] with [caliber]."))
+	to_chat(user, SPAN_NOTICE("You refill \the [src] with [caliber]."))
 	update_icon()
 
 /obj/item/ammo_magazine/flamer_tank/update_icon()


### PR DESCRIPTION
# About the pull request

This PR is a followup to #3357 to fix an incorrect message discovered when reviewing that PR as well as to make the existing empty_reagents verb behave the same as the empty_reagents verb added in that PR.

# Explain why it's good for the game
The messages sent to the user should be accurate, and verbs should have consistent behavior.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

[Refill](https://github.com/cmss13-devs/cmss13/assets/76988376/50b1cbca-ac0f-4856-9e27-8d1004c722f0)

</details>


# Changelog
:cl: Drathek
fix: Fixed erroneous is empty messages when inserting tanks into a flamer pack.
soundadd: Added the refill sfx when using the empty canister verb on flamer tanks.
/:cl:
