### PR TITLE
Folding Barricade Fixes

### DIFF
--- a/code/game/objects/structures/barricade/deployable.dm
+++ b/code/game/objects/structures/barricade/deployable.dm
@@ -4,7 +4,7 @@
 	icon_state = "folding_0"
 	health = 350
 	maxhealth = 350
-	burn_multiplier = 1.15
+	burn_multiplier = 0.85
 	brute_multiplier = 1
 	crusher_resistant = TRUE
 	force_level_absorption = 15
@@ -88,7 +88,7 @@
 		usr.visible_message(SPAN_NOTICE("[usr] starts collapsing [src]."),
 			SPAN_NOTICE("You begin collapsing [src]."))
 		playsound(src.loc, 'sound/items/Crowbar.ogg', 25, 1)
-		if(do_after(usr, 3 SECONDS, INTERRUPT_ALL, BUSY_ICON_FRIENDLY, src))
+		if(do_after(usr, 3 SECONDS, INTERRUPT_NO_NEEDHAND, BUSY_ICON_FRIENDLY, src))
 			collapse(usr)
 		else
 			to_chat(usr, SPAN_WARNING("You stop collapsing [src]."))
@@ -107,6 +107,7 @@
 	..()
 	if(PF)
 		PF.flags_can_pass_front &= ~PASS_OVER_THROW_MOB
+		PF.flags_can_pass_behind &= ~PASS_OVER_THROW_MOB
 
 
 // Cade in hands


### PR DESCRIPTION

# About the pull request

Fixes a few things with folding barricades. 

First of all, folding cade now takes 15% less acid damage rather than 15% extra damage, so now it's following the description: `Resistant to most acids while being simple to repair`. Apparently someone thought that the modifier should be higher to give more protection, which is not correct.

Secondly, when unfolded it also blocks pounces from behind. There is no reason for the cade to block throws and pounces only from the front, so it's safe to assume it was an oversight.

And finally, collapsing folding barricade by hand is no longer interrupted by appearance of an item in hand (it used to be like this: player tries to collapse several folding barricades at once, first one goes into his hand, so the rest are interrupted, that was pretty annoying).

# Explain why it's good for the game

Bugs and oversights are bad.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: ihatethisengine
fix: folding barricade now takes 15% less acid damage instead of 15% extra acid damage, as the description hints.
fix: folding barricade now blocks pounces from behind.
qol: collapsing folding barricade by hand is no longer interrupted by taking an item.
/:cl:
