### PR TITLE
Replaces LV522 ceramic plates with MRE crate

### DIFF
--- a/maps/map_files/LV522_Chances_Claim/LV522_Chances_Claim.dmm
+++ b/maps/map_files/LV522_Chances_Claim/LV522_Chances_Claim.dmm
@@ -55007,12 +55007,7 @@
 /turf/open/floor/plating,
 /area/lv522/indoors/lone_buildings/engineering)
 "xKc" = (
-/obj/structure/closet/coffin/woodencrate,
-/obj/item/clothing/accessory/health/ceramic_plate,
-/obj/item/clothing/accessory/health/ceramic_plate,
-/obj/item/clothing/accessory/health/ceramic_plate,
-/obj/item/clothing/accessory/health/ceramic_plate,
-/obj/item/clothing/accessory/health/ceramic_plate,
+/obj/structure/largecrate/supply/supplies/mre,
 /obj/structure/barricade/handrail{
 	dir = 4
 	},


### PR DESCRIPTION

# About the pull request

This PR replaces the LV522 ceramic plates with an MRE crate 

# Explain why it's good for the game

Morrow doesn't want them there so they're not going there if FORECON really is the best they wont FF each other anyway 


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: SpartanBobby
maptweak: Replaces LV522 ceramic plates with MRE crate
/:cl:
