### PR TITLE
Xeno Candidate Queue

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -11,8 +11,6 @@
 #define OVEREAT_TIME 200
 
 //=================================================
-#define ALIEN_SELECT_AFK_BUFFER 1 // How many minutes that a person can be AFK before not being allowed to be an alien.
-
 #define HEAT_DAMAGE_LEVEL_1 2 //Amount of damage applied when your body temperature just passes the 360.15k safety point
 #define HEAT_DAMAGE_LEVEL_2 4 //Amount of damage applied when your body temperature passes the 400K point
 #define HEAT_DAMAGE_LEVEL_3 8 //Amount of damage applied when your body temperature passes the 1000K point

--- a/code/__DEFINES/xeno.dm
+++ b/code/__DEFINES/xeno.dm
@@ -154,6 +154,22 @@
 #define WEED_BASE_GROW_SPEED (5 SECONDS)
 #define WEED_BASE_DECAY_SPEED (10 SECONDS)
 
+/// The time you must be dead to join as a xeno larva
+#define XENO_JOIN_DEAD_LARVA_TIME (2.5 MINUTES)
+/// The time you must be dead to join as xeno (not larva)
+#define XENO_JOIN_DEAD_TIME (5 MINUTES)
+/// The time of inactivity you cannot exceed to join as a xeno
+#define XENO_JOIN_AFK_TIME_LIMIT (5 MINUTES)
+/// The amount of time after round start before buried larva spawns are disallowed
+#define XENO_BURIED_LARVA_TIME_LIMIT (30 MINUTES)
+
+/// The time against away_timer when an AFK xeno larva can be replaced
+#define XENO_LEAVE_TIMER_LARVA 80 //80 seconds
+/// The time against away_timer when an AFK xeno (not larva) can be replaced
+#define XENO_LEAVE_TIMER 300 //300 seconds
+/// The time against away_timer when an AFK xeno gets listed in the available list so ghosts can get ready
+#define XENO_AVAILABLE_TIMER 60 //60 seconds
+
 /// Between 2% to 10% of explosion severity
 #define WEED_EXPLOSION_DAMAGEMULT rand(2, 10)*0.01
 

--- a/code/__HELPERS/_time.dm
+++ b/code/__HELPERS/_time.dm
@@ -15,10 +15,6 @@
 
 #define DECISECONDS_TO_HOURS /36000
 
-#define XENO_LEAVE_TIMER_LARVA 80 //80 seconds
-#define XENO_LEAVE_TIMER 300 //300 seconds
-#define XENO_AVAILABLE_TIMER 60 //60 seconds, when to add a xeno to the avaliable list so ghosts can get ready
-
 var/midnight_rollovers = 0
 var/rollovercheck_last_timeofday = 0
 

--- a/code/__HELPERS/cmp.dm
+++ b/code/__HELPERS/cmp.dm
@@ -57,3 +57,7 @@ var/atom/cmp_dist_origin=null
 
 /proc/cmp_typepaths_asc(A, B)
 	return sorttext("[B]","[A]")
+
+/// Compares mobs based on their timeofdeath value in ascending order
+/proc/cmp_mob_deathtime_asc(mob/A, mob/B)
+	return A.timeofdeath - B.timeofdeath

--- a/code/__HELPERS/cmp.dm
+++ b/code/__HELPERS/cmp.dm
@@ -61,3 +61,8 @@ var/atom/cmp_dist_origin=null
 /// Compares mobs based on their timeofdeath value in ascending order
 /proc/cmp_mob_deathtime_asc(mob/A, mob/B)
 	return A.timeofdeath - B.timeofdeath
+
+/// Compares observers based on their larva_queue_time value in ascending order
+/// Assumes the client on the observer is not null
+/proc/cmp_obs_larvaqueuetime_asc(mob/dead/observer/A, mob/dead/observer/B)
+	return A.client.larva_queue_time - B.client.larva_queue_time

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -277,7 +277,7 @@
 		candidates += cur_obs
 
 	// Optionally sort by timeofdeath
-	if(sorted && candidates.len)
+	if(sorted && length(candidates))
 		candidates = sort_list(candidates, GLOBAL_PROC_REF(cmp_mob_deathtime_asc))
 
 	return candidates

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -291,18 +291,11 @@
  */
 /proc/message_alien_candidates(list/candidates, dequeued)
 	var/new_players = 0
-	if(dequeued)
-		for(var/i in (1 + dequeued) to candidates.len)
-			to_chat(candidates[i], SPAN_XENONOTICE("You are now [i-dequeued]\th in the larva queue. There are [new_players] ahead of you that have yet to play this round."))
-			var/mob/dead/observer/cur_obs = candidates[i]
-			if (!cur_obs.timeofdeath)
-				new_players++
-	else
-		for(var/i in 1 to candidates.len)
-			to_chat(candidates[i], SPAN_XENONOTICE("You are currently [i]\th in the larva queue. There are [new_players] ahead of you that have yet to play this round."))
-			var/mob/dead/observer/cur_obs = candidates[i]
-			if (!cur_obs.timeofdeath)
-				new_players++
+	for(var/i in (1 + dequeued) to candidates.len)
+		to_chat(candidates[i], SPAN_XENONOTICE("You are [dequeued ? "now" : "currently"] [i-dequeued]\th in the larva queue. There are [new_players] ahead of you that have yet to play this round."))
+		var/mob/dead/observer/cur_obs = candidates[i]
+		if(!cur_obs.timeofdeath)
+			new_players++
 
 /proc/convert_k2c(temp)
 	return ((temp - T0C))

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -282,6 +282,28 @@
 
 	return candidates
 
+/**
+ * Messages observers that are currently candidates an update on the queue.
+ *
+ * Arguments:
+ * * candidates - The list of observers from get_alien_candidates() with atleast one
+ * * dequeued - How many candidates to skip messaging because they were dequeued
+ */
+/proc/message_alien_candidates(list/candidates, dequeued)
+	var/new_players = 0
+	if(dequeued)
+		for(var/i in (1 + dequeued) to candidates.len)
+			to_chat(candidates[i], SPAN_XENONOTICE("You are now [i-dequeued]\th in the larva queue. There are [new_players] ahead of you that have yet to play this round."))
+			var/mob/dead/observer/cur_obs = candidates[i]
+			if (!cur_obs.timeofdeath)
+				new_players++
+	else
+		for(var/i in 1 to candidates.len)
+			to_chat(candidates[i], SPAN_XENONOTICE("You are currently [i]\th in the larva queue. There are [new_players] ahead of you that have yet to play this round."))
+			var/mob/dead/observer/cur_obs = candidates[i]
+			if (!cur_obs.timeofdeath)
+				new_players++
+
 /proc/convert_k2c(temp)
 	return ((temp - T0C))
 

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -285,7 +285,7 @@
  * Messages observers that are currently candidates an update on the queue.
  *
  * Arguments:
- * * candidates - The list of observers from get_alien_candidates() with atleast one
+ * * candidates - The list of observers from get_alien_candidates()
  * * dequeued - How many candidates to skip messaging because they were dequeued
  * * cache_only - Whether to not actually send a to_chat message and instead only update larva_queue_cached_message
  */

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -262,11 +262,11 @@
 
 		// copied from join as xeno
 		var/deathtime = world.time - cur_obs.timeofdeath
-		if(deathtime < (5 MINUTES) && ( !cur_obs.client.admin_holder || !(cur_obs.client.admin_holder.rights & R_ADMIN)) )
+		if(deathtime < XENO_JOIN_DEAD_TIME && ( !cur_obs.client.admin_holder || !(cur_obs.client.admin_holder.rights & R_ADMIN)) )
 			continue
 
 		// AFK players cannot be drafted
-		if(cur_obs.client.inactivity / (1 MINUTES) > ALIEN_SELECT_AFK_BUFFER + 5)
+		if(cur_obs.client.inactivity > XENO_JOIN_AFK_TIME_LIMIT)
 			continue
 
 		// Mods with larva protection cannot be drafted

--- a/code/_onclick/observer.dm
+++ b/code/_onclick/observer.dm
@@ -45,11 +45,11 @@
 						return FALSE
 
 					var/deathtime = world.time - timeofdeath
-					if(deathtime < 2.5 MINUTES)
+					if(deathtime < XENO_JOIN_DEAD_LARVA_TIME)
 						var/message = "You have been dead for [DisplayTimeText(deathtime)]."
 						message = SPAN_WARNING("[message]")
 						to_chat(src, message)
-						to_chat(src, SPAN_WARNING("You must wait 2.5 minutes before rejoining the game!"))
+						to_chat(src, SPAN_WARNING("You must wait atleast 2.5 minutes before rejoining the game!"))
 						ManualFollow(target)
 						return FALSE
 

--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -354,7 +354,7 @@ Additional game mode variables.
 	var/datum/hive_status/hive
 	for(var/hivenumber in GLOB.hive_datum)
 		hive = GLOB.hive_datum[hivenumber]
-		if(!hive.hardcore && hive.stored_larva && (hive.hive_location || (world.time < 30 MINUTES + SSticker.round_start_time)))
+		if(!hive.hardcore && hive.stored_larva && (hive.hive_location || (world.time < XENO_BURIED_LARVA_TIME_LIMIT + SSticker.round_start_time)))
 			if(SSticker.mode && (SSticker.mode.flags_round_type & MODE_RANDOM_HIVE))
 				available_xenos |= "any buried larva"
 				LAZYADD(available_xenos["any buried larva"], hive)
@@ -397,11 +397,11 @@ Additional game mode variables.
 				if(!xeno_bypass_timer)
 					var/deathtime = world.time - xeno_candidate.timeofdeath
 					if(isnewplayer(xeno_candidate))
-						deathtime = 2.5 MINUTES //so new players don't have to wait to latejoin as xeno in the round's first 5 mins.
-					if(deathtime < 2.5 MINUTES && !check_client_rights(xeno_candidate.client, R_ADMIN, FALSE))
+						deathtime = XENO_JOIN_DEAD_LARVA_TIME //so new players don't have to wait to latejoin as xeno in the round's first 5 mins.
+					if(deathtime < XENO_JOIN_DEAD_LARVA_TIME && !check_client_rights(xeno_candidate.client, R_ADMIN, FALSE))
 						var/message = SPAN_WARNING("You have been dead for [DisplayTimeText(deathtime)].")
 						to_chat(xeno_candidate, message)
-						to_chat(xeno_candidate, SPAN_WARNING("You must wait 2.5 minutes before rejoining the game as a buried larva!"))
+						to_chat(xeno_candidate, SPAN_WARNING("You must wait 2 minutes and 30 seconds before rejoining the game as a buried larva!"))
 						return FALSE
 
 				for(var/mob_name in picked_hive.banished_ckeys)
@@ -413,7 +413,7 @@ Additional game mode variables.
 					noob.close_spawn_windows()
 				if(picked_hive.hive_location)
 					picked_hive.hive_location.spawn_burrowed_larva(xeno_candidate)
-				else if((world.time < 30 MINUTES + SSticker.round_start_time))
+				else if((world.time < XENO_BURIED_LARVA_TIME_LIMIT + SSticker.round_start_time))
 					picked_hive.do_buried_larva_spawn(xeno_candidate)
 				else
 					to_chat(xeno_candidate, SPAN_WARNING("Seems like something went wrong. Try again?"))
@@ -437,8 +437,8 @@ Additional game mode variables.
 		if(!xeno_bypass_timer)
 			var/deathtime = world.time - xeno_candidate.timeofdeath
 			if(istype(xeno_candidate, /mob/new_player))
-				deathtime = 5 MINUTES //so new players don't have to wait to latejoin as xeno in the round's first 5 mins.
-			if(deathtime < 5 MINUTES && !check_client_rights(xeno_candidate.client, R_ADMIN, FALSE))
+				deathtime = XENO_JOIN_DEAD_TIME //so new players don't have to wait to latejoin as xeno in the round's first 5 mins.
+			if(deathtime < XENO_JOIN_DEAD_TIME && !check_client_rights(xeno_candidate.client, R_ADMIN, FALSE))
 				var/message = "You have been dead for [DisplayTimeText(deathtime)]."
 				message = SPAN_WARNING("[message]")
 				to_chat(xeno_candidate, message)

--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -364,7 +364,27 @@ Additional game mode variables.
 				available_xenos[larva_option] = list(hive)
 
 	if(!available_xenos.len || (instant_join && !available_xenos_non_ssd.len))
-		to_chat(xeno_candidate, SPAN_WARNING("There aren't any available xenomorphs or burrowed larvae. You can try getting spawned as a chestburster larva by toggling your Xenomorph candidacy in Preferences -> Toggle SpecialRole Candidacy."))
+		if(!xeno_candidate.client || !xeno_candidate.client.prefs || !(xeno_candidate.client.prefs.be_special & BE_ALIEN_AFTER_DEATH))
+			to_chat(xeno_candidate, SPAN_WARNING("There aren't any available xenomorphs or burrowed larvae. You can try getting spawned as a chestburster larva by toggling your Xenomorph candidacy in Preferences -> Toggle SpecialRole Candidacy."))
+			return FALSE
+		to_chat(xeno_candidate, SPAN_WARNING("There aren't any available xenomorphs or burrowed larvae."))
+
+		// Give the player a cached message of their queue status if they are an observer
+		var/mob/dead/observer/candidate_observer = xeno_candidate
+		if(istype(candidate_observer))
+			if(candidate_observer.larva_queue_cached_message)
+				to_chat(xeno_candidate, candidate_observer.larva_queue_cached_message)
+				return FALSE
+
+			// No cache, lets check now then
+			message_alien_candidates(get_alien_candidates(), dequeued = 0, cache_only = TRUE)
+			if(candidate_observer.larva_queue_cached_message)
+				to_chat(xeno_candidate, candidate_observer.larva_queue_cached_message)
+				return FALSE
+
+			// We aren't in queue yet, lets teach them about the queue then
+			candidate_observer.larva_queue_cached_message = SPAN_XENONOTICE("You are currently still awaiting assignment in the larva queue. Priority is given to players who have yet to play in the round, but otherwise the ordering is based on your time of death. When you have been dead long enough and are not inactive, you will periodically receive messages where you are in the queue relative to other currently valid xeno candidates. Note: Playing as a facehugger or in the thunderdome will not alter your time of death. This means you won't lose your relative place in queue if you step away, disconnect, play as a facehugger, or play in the thunderdome.")
+			to_chat(xeno_candidate, candidate_observer.larva_queue_cached_message)
 		return FALSE
 
 	var/mob/living/carbon/xenomorph/new_xeno

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -26,6 +26,8 @@
 	var/adminobs = null
 	var/area = null
 	var/time_died_as_mouse = null //when the client last died as a mouse
+	/// The descriminator for larva queue ordering: Generally set to timeofdeath except for facehuggers/admin z-level play
+	var/larva_queue_time
 
 	var/donator = 0
 	var/adminhelped = 0

--- a/code/modules/cm_aliens/structures/special/pylon_core.dm
+++ b/code/modules/cm_aliens/structures/special/pylon_core.dm
@@ -147,6 +147,8 @@
 			var/list/players_with_xeno_pref = get_alien_candidates()
 			if(players_with_xeno_pref && players_with_xeno_pref.len && can_spawn_larva())
 				spawn_burrowed_larva(players_with_xeno_pref[1])
+				for(var/i in 2 to players_with_xeno_pref.len)
+					to_chat(players_with_xeno_pref[i], SPAN_XENONOTICE("You are now [i-1]\th in the larva queue."))
 
 		if(linked_hive.hijack_burrowed_surge && (last_surge_time + surge_cooldown) < world.time)
 			last_surge_time = world.time

--- a/code/modules/cm_aliens/structures/special/pylon_core.dm
+++ b/code/modules/cm_aliens/structures/special/pylon_core.dm
@@ -108,6 +108,7 @@
 	var/last_healed = 0
 	var/last_attempt = 0 // logs time of last attempt to prevent spam. if you want to destroy it, you must commit.
 	var/last_larva_time = 0
+	var/last_larva_queue_time = 0
 	var/last_surge_time = 0
 	var/spawn_cooldown = 30 SECONDS
 	var/surge_cooldown = 90 SECONDS
@@ -142,13 +143,17 @@
 				linked_hive.hive_ui.update_burrowed_larva()
 				qdel(L)
 
-		if((last_larva_time + spawn_cooldown) < world.time && can_spawn_larva()) // every minute
+		var/spawning_larva = can_spawn_larva() && (last_larva_time + spawn_cooldown) < world.time
+		if(spawning_larva)
 			last_larva_time = world.time
+		if(spawning_larva || (last_larva_queue_time + spawn_cooldown * 4) < world.time)
+			last_larva_queue_time = world.time
 			var/list/players_with_xeno_pref = get_alien_candidates()
-			if(players_with_xeno_pref && players_with_xeno_pref.len && can_spawn_larva())
-				spawn_burrowed_larva(players_with_xeno_pref[1])
-				for(var/i in 2 to players_with_xeno_pref.len)
-					to_chat(players_with_xeno_pref[i], SPAN_XENONOTICE("You are now [i-1]\th in the larva queue."))
+			if(players_with_xeno_pref && players_with_xeno_pref.len)
+				if(spawning_larva && spawn_burrowed_larva(players_with_xeno_pref[1]))
+					message_alien_candidates(players_with_xeno_pref, 1)
+				else
+					message_alien_candidates(players_with_xeno_pref, 0)
 
 		if(linked_hive.hijack_burrowed_surge && (last_surge_time + surge_cooldown) < world.time)
 			last_surge_time = world.time

--- a/code/modules/cm_aliens/structures/special/pylon_core.dm
+++ b/code/modules/cm_aliens/structures/special/pylon_core.dm
@@ -151,9 +151,9 @@
 			var/list/players_with_xeno_pref = get_alien_candidates()
 			if(players_with_xeno_pref && players_with_xeno_pref.len)
 				if(spawning_larva && spawn_burrowed_larva(players_with_xeno_pref[1]))
-					message_alien_candidates(players_with_xeno_pref, 1)
+					message_alien_candidates(players_with_xeno_pref, dequeued = 1)
 				else
-					message_alien_candidates(players_with_xeno_pref, 0)
+					message_alien_candidates(players_with_xeno_pref, dequeued = 0)
 
 		if(linked_hive.hijack_burrowed_surge && (last_surge_time + surge_cooldown) < world.time)
 			last_surge_time = world.time

--- a/code/modules/cm_aliens/structures/special/pylon_core.dm
+++ b/code/modules/cm_aliens/structures/special/pylon_core.dm
@@ -151,8 +151,10 @@
 			var/list/players_with_xeno_pref = get_alien_candidates()
 			if(players_with_xeno_pref && players_with_xeno_pref.len)
 				if(spawning_larva && spawn_burrowed_larva(players_with_xeno_pref[1]))
+					// We were in spawning_larva mode and successfully spawned someone
 					message_alien_candidates(players_with_xeno_pref, dequeued = 1)
 				else
+					// Just time to update everyone their queue status (or the spawn failed)
 					message_alien_candidates(players_with_xeno_pref, dequeued = 0)
 
 		if(linked_hive.hijack_burrowed_surge && (last_surge_time + surge_cooldown) < world.time)

--- a/code/modules/cm_aliens/structures/special/pylon_core.dm
+++ b/code/modules/cm_aliens/structures/special/pylon_core.dm
@@ -146,7 +146,7 @@
 			last_larva_time = world.time
 			var/list/players_with_xeno_pref = get_alien_candidates()
 			if(players_with_xeno_pref && players_with_xeno_pref.len && can_spawn_larva())
-				spawn_burrowed_larva(pick(players_with_xeno_pref))
+				spawn_burrowed_larva(players_with_xeno_pref[1])
 
 		if(linked_hive.hijack_burrowed_surge && (last_surge_time + surge_cooldown) < world.time)
 			last_surge_time = world.time

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -329,8 +329,8 @@ Works together with spawning an observer, noted above.
 	ghost.langchat_make_image()
 
 	SStgui.on_transfer(src, ghost)
-	if(is_admin_level(z))
-		ghost.timeofdeath = 0 // Bypass respawn limit if you die on the admin zlevel
+	if(is_admin_level((get_turf(src))?.z)) // Gibbed humans ghostize the brain in their head which itself is z 0
+		ghost.timeofdeath = 1 // Bypass respawn limit if you die on the admin zlevel
 
 	ghost.key = key
 	ghost.mind = mind

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -33,8 +33,8 @@
 	plane = GHOST_PLANE
 	layer = ABOVE_FLY_LAYER
 	stat = DEAD
-	var/adminlarva = 0
-	var/ghostvision = 1
+	var/adminlarva = FALSE
+	var/ghostvision = TRUE
 	var/can_reenter_corpse
 	var/started_as_observer //This variable is set to 1 when you enter the game as an observer.
 							//If you died in the game and are a ghost - this will remain as null.
@@ -45,7 +45,7 @@
 							"Squad HUD" = FALSE,
 							"Xeno Status HUD" = FALSE
 							)
-	universal_speak = 1
+	universal_speak = TRUE
 	var/updatedir = TRUE //Do we have to update our dir as the ghost moves around?
 	var/atom/movable/following = null
 	var/datum/orbit_menu/orbit_menu
@@ -55,6 +55,8 @@
 	var/own_orbit_size = 0
 	var/observer_actions = list(/datum/action/observer_action/join_xeno)
 	var/datum/action/minimap/observer/minimap
+	var/larva_queue_cached_message
+
 	alpha = 127
 
 /mob/dead/observer/verb/toggle_ghostsee()
@@ -363,6 +365,12 @@ Works together with spawning an observer, noted above.
 		if(ghost.client.player_data)
 			ghost.client.player_data.load_timestat_data()
 
+		// Larva queue: We use the larger of their existing queue time or the new timeofdeath except for facehuggers
+		// We don't change facehugger timeofdeath because they are still on cooldown if they died as a hugger
+		// Facehuggers are atleast 1 because they did get some action compared to those at 0 timeofdeath
+		var/new_tod = isfacehugger(src) ? 1 : ghost.timeofdeath
+		ghost.client.larva_queue_time = max(ghost.client.larva_queue_time, new_tod)
+
 	ghost.set_huds_from_prefs()
 
 	return ghost
@@ -405,6 +413,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		var/mob/dead/observer/ghost = ghostize((is_nested && nest && !QDELETED(nest))) //FALSE parameter is so we can never re-enter our body, "Charlie, you can never come baaaack~" :3
 		if(ghost && !is_admin_level(z))
 			ghost.timeofdeath = world.time
+			ghost.client?.larva_queue_time = world.time
 		if(is_nested && nest && !QDELETED(nest))
 			ghost.can_reenter_corpse = FALSE
 

--- a/code/modules/mob/living/carbon/xenomorph/Embryo.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Embryo.dm
@@ -158,6 +158,8 @@
 
 		if(candidates && candidates.len)
 			picked = candidates[1]
+			for(var/i in 2 to candidates.len)
+				to_chat(candidates[i], SPAN_XENONOTICE("You are now [i-1]\th in the larva queue."))
 
 	// Spawn the larva
 	var/mob/living/carbon/xenomorph/larva/new_xeno

--- a/code/modules/mob/living/carbon/xenomorph/Embryo.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Embryo.dm
@@ -157,7 +157,7 @@
 		var/list/candidates = get_alien_candidates()
 
 		if(candidates && candidates.len)
-			picked = pick(candidates)
+			picked = candidates[1]
 
 	// Spawn the larva
 	var/mob/living/carbon/xenomorph/larva/new_xeno

--- a/code/modules/mob/living/carbon/xenomorph/Embryo.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Embryo.dm
@@ -158,8 +158,7 @@
 
 		if(candidates && candidates.len)
 			picked = candidates[1]
-			for(var/i in 2 to candidates.len)
-				to_chat(candidates[i], SPAN_XENONOTICE("You are now [i-1]\th in the larva queue."))
+			message_alien_candidates(candidates, 1)
 
 	// Spawn the larva
 	var/mob/living/carbon/xenomorph/larva/new_xeno

--- a/code/modules/mob/living/carbon/xenomorph/Embryo.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Embryo.dm
@@ -158,7 +158,7 @@
 
 		if(candidates && candidates.len)
 			picked = candidates[1]
-			message_alien_candidates(candidates, 1)
+			message_alien_candidates(candidates, dequeued = 1)
 
 	// Spawn the larva
 	var/mob/living/carbon/xenomorph/larva/new_xeno

--- a/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
@@ -155,6 +155,7 @@
 		for(var/mob/dead/observer/observer as anything in GLOB.observer_list)
 			to_chat(observer, SPAN_DEADSAY("<b>[human]</b> has been facehugged by <b>[src]</b>" + " [OBSERVER_JMP(observer, human)]"))
 		to_chat(src, SPAN_DEADSAY("<b>[human]</b> has been facehugged by <b>[src]</b>"))
+	timeofdeath = 1 // Ever so slightly deprioritized for larva queue
 	qdel(src)
 	if(hug_area)
 		xeno_message(SPAN_XENOMINORWARNING("You sense that [src] has facehugged a host at \the [hug_area]!"), 1, src.hivenumber)

--- a/code/modules/mob/living/carbon/xenomorph/death.dm
+++ b/code/modules/mob/living/carbon/xenomorph/death.dm
@@ -42,7 +42,7 @@
 				if(players_with_xeno_pref && istype(GLOB.hive_datum[hivenumber].hive_location, /obj/effect/alien/resin/special/pylon/core))
 					var/turf/larva_spawn = get_turf(GLOB.hive_datum[hivenumber].hive_location)
 					var/count = 1
-					while(GLOB.hive_datum[hivenumber].stored_larva > 0 && count <= players_with_xeno_pref.len) // stil some left
+					while(GLOB.hive_datum[hivenumber].stored_larva > 0 && count <= length(players_with_xeno_pref)) // still some left
 						var/mob/xeno_candidate = players_with_xeno_pref[count++]
 						var/mob/living/carbon/xenomorph/larva/new_xeno = new /mob/living/carbon/xenomorph/larva(larva_spawn)
 						new_xeno.set_hive_and_update(hivenumber)

--- a/code/modules/mob/living/carbon/xenomorph/death.dm
+++ b/code/modules/mob/living/carbon/xenomorph/death.dm
@@ -58,7 +58,7 @@
 						GLOB.hive_datum[hivenumber].stored_larva--
 						GLOB.hive_datum[hivenumber].hive_ui.update_burrowed_larva()
 					if(count)
-						message_alien_candidates(players_with_xeno_pref, count)
+						message_alien_candidates(players_with_xeno_pref, dequeued = count)
 
 			if(hive && hive.living_xeno_queen == src)
 				xeno_message(SPAN_XENOANNOUNCE("A sudden tremor ripples through the hive... the Queen has been slain! Vengeance!"),3, hivenumber)

--- a/code/modules/mob/living/carbon/xenomorph/death.dm
+++ b/code/modules/mob/living/carbon/xenomorph/death.dm
@@ -41,9 +41,9 @@
 				var/list/players_with_xeno_pref = get_alien_candidates()
 				if(players_with_xeno_pref && istype(GLOB.hive_datum[hivenumber].hive_location, /obj/effect/alien/resin/special/pylon/core))
 					var/turf/larva_spawn = get_turf(GLOB.hive_datum[hivenumber].hive_location)
-					var/count = 1
-					while(GLOB.hive_datum[hivenumber].stored_larva > 0 && count <= length(players_with_xeno_pref)) // still some left
-						var/mob/xeno_candidate = players_with_xeno_pref[count++]
+					var/count = 0
+					while(GLOB.hive_datum[hivenumber].stored_larva > 0 && count < length(players_with_xeno_pref)) // still some left
+						var/mob/xeno_candidate = players_with_xeno_pref[++count]
 						var/mob/living/carbon/xenomorph/larva/new_xeno = new /mob/living/carbon/xenomorph/larva(larva_spawn)
 						new_xeno.set_hive_and_update(hivenumber)
 
@@ -57,6 +57,8 @@
 
 						GLOB.hive_datum[hivenumber].stored_larva--
 						GLOB.hive_datum[hivenumber].hive_ui.update_burrowed_larva()
+					if(count)
+						message_alien_candidates(players_with_xeno_pref, count)
 
 			if(hive && hive.living_xeno_queen == src)
 				xeno_message(SPAN_XENOANNOUNCE("A sudden tremor ripples through the hive... the Queen has been slain! Vengeance!"),3, hivenumber)

--- a/code/modules/mob/living/carbon/xenomorph/death.dm
+++ b/code/modules/mob/living/carbon/xenomorph/death.dm
@@ -37,12 +37,13 @@
 
 			if(GLOB.hive_datum[hivenumber].stored_larva)
 				GLOB.hive_datum[hivenumber].stored_larva = round(GLOB.hive_datum[hivenumber].stored_larva * 0.5) //Lose half on dead queen
-				var/turf/larva_spawn
+
 				var/list/players_with_xeno_pref = get_alien_candidates()
-				while(GLOB.hive_datum[hivenumber].stored_larva > 0 && istype(GLOB.hive_datum[hivenumber].hive_location, /obj/effect/alien/resin/special/pylon/core)) // stil some left
-					larva_spawn = get_turf(GLOB.hive_datum[hivenumber].hive_location)
-					if(players_with_xeno_pref && players_with_xeno_pref.len)
-						var/mob/xeno_candidate = pick(players_with_xeno_pref)
+				if(players_with_xeno_pref && istype(GLOB.hive_datum[hivenumber].hive_location, /obj/effect/alien/resin/special/pylon/core))
+					var/turf/larva_spawn = get_turf(GLOB.hive_datum[hivenumber].hive_location)
+					var/count = 1
+					while(GLOB.hive_datum[hivenumber].stored_larva > 0 && count <= players_with_xeno_pref.len) // stil some left
+						var/mob/xeno_candidate = players_with_xeno_pref[count++]
 						var/mob/living/carbon/xenomorph/larva/new_xeno = new /mob/living/carbon/xenomorph/larva(larva_spawn)
 						new_xeno.set_hive_and_update(hivenumber)
 
@@ -50,11 +51,12 @@
 						if(!SSticker.mode.transfer_xeno(xeno_candidate, new_xeno))
 							qdel(new_xeno)
 							return
+
 						new_xeno.visible_message(SPAN_XENODANGER("A larva suddenly burrows out of the ground!"),
 						SPAN_XENODANGER("You burrow out of the ground after feeling an immense tremor through the hive, which quickly fades into complete silence..."))
 
-					GLOB.hive_datum[hivenumber].stored_larva--
-					GLOB.hive_datum[hivenumber].hive_ui.update_burrowed_larva()
+						GLOB.hive_datum[hivenumber].stored_larva--
+						GLOB.hive_datum[hivenumber].hive_ui.update_burrowed_larva()
 
 			if(hive && hive.living_xeno_queen == src)
 				xeno_message(SPAN_XENOANNOUNCE("A sudden tremor ripples through the hive... the Queen has been slain! Vengeance!"),3, hivenumber)

--- a/code/modules/shuttle/helpers.dm
+++ b/code/modules/shuttle/helpers.dm
@@ -8,7 +8,8 @@
 
 /datum/door_controller/aggregate/Destroy(force, ...)
 	. = ..()
-	QDEL_NULL_LIST(door_controllers)
+	QDEL_LIST_ASSOC_VAL(door_controllers)
+	door_controllers = null
 
 /datum/door_controller/aggregate/proc/set_label(label)
 	for(var/datum/door_controller/single/cont in door_controllers)

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -628,15 +628,15 @@
 
 /obj/docking_port/mobile/proc/intoTheSunset()
 	// Loop over mobs
-	for(var/t in return_turfs())
-		var/turf/T = t
-		for(var/mob/living/L in T.GetAllContents())
+	for(var/turf/turf as anything in return_turfs())
+		for(var/mob/living/mob in turf.GetAllContents())
 			// Ghostize them and put them in nullspace stasis (for stat & possession checks)
-			//L.notransform = TRUE
-			var/mob/dead/observer/O = L.ghostize(FALSE)
-			if(O)
-				O.timeofdeath = world.time
-			L.moveToNullspace()
+			//mob.notransform = TRUE
+			var/mob/dead/observer/obs = mob.ghostize(FALSE)
+			if(obs)
+				obs.timeofdeath = world.time
+				obs.client?.larva_queue_time = world.time
+			mob.moveToNullspace()
 
 	// Now that mobs are stowed, delete the shuttle
 	jumpToNullSpace()


### PR DESCRIPTION
# About the pull request

This PR changes it so get_alien_candidates is normally a sorted list based generally on timeofdeath in ascending order and larva spawns now pull candidates out of that list in order. That means that an observer that has yet to play, or was the first to die, and still meets all other criteria to become a larva (not AFK, has preferences set to become larva, has been dead long enough, etc.) will be chosen before others.

Playing as a facehugger (dying or hugging successfully) or dying in an admin z-levels (such as thunderdome) also do not affect the value used for how you are sorted in the queue. So you should be able to freely play in either of those situations without losing your relative spot in the queue. Of course its not going to nab you out of whatever mob you are playing, but when you are a ghost again the same values will be used to sort you in the queue.

Since people may enter and leave the queue each time the queue is checked, your place in the queue may go up or down. It is just a snapshot of that moment where you are. If you missed your queue message, or haven't gotten one yet, the join xeno action will now display the last message for you.

# Explain why it's good for the game

Picking candidates randomly is okay, but it would be more fair to give privilege to those that have been waiting longer - especially those who have yet to play.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Example of queen death code (since that was the most altered):
![larva](https://github.com/cmss13-devs/cmss13/assets/76988376/48211b1e-7556-4a41-879f-1dfbfabe8704)

</details>

# Changelog
:cl: Drathek
add: The selection to become a xeno larva is now based on timeofdeath rather than random and also sends a message to all candidates when the queue moves. Playing as a facehugger or on admin z-levels (thunderdome) will not affect your relative place in queue. The join xeno action will also display the last queue message for you when you allow xeno candidacy.
fix: Fixed gibbed humans not properly setting their timeofdeath when on an admin z-level.
fix: Fixed a bad del on shuttle doors when a shuttle deletes (such as intoTheSunset).
/:cl:
