### PR TITLE
Weed Addition To Trijent, Fix Larva Issue

### DIFF
--- a/maps/map_files/DesertDam/Desert_Dam.dmm
+++ b/maps/map_files/DesertDam/Desert_Dam.dmm
@@ -62422,6 +62422,13 @@
 "lNu" = (
 /turf/open/desert/dirt,
 /area/desert_dam/exterior/valley/bar_valley_dam)
+"lNN" = (
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
+/turf/open/jungle{
+	bushes_spawn = 0;
+	icon_state = "grass_impenetrable"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_containment)
 "lOM" = (
 /obj/effect/decal/sand_overlay/sand2/corner2,
 /turf/open/asphalt/cement,
@@ -104947,7 +104954,7 @@ agL
 amn
 afI
 akW
-akW
+lNN
 agL
 afG
 aqG


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Adds a weed node to a secure cell adjacent to a xeno larva spawn location on Trijent. If a player is unlucky there is a chance they'll spawn inside the containment cell. The weed will allow this player to grow from Larva to a T1 and break out on their own.

Fixes #3557 

# Explain why it's good for the game

Don't want people being trapped in a cell.


# Testing Photographs and Procedure


# Changelog

:cl:
fix: Larva who spawn in containment in Trijent will now have weeds to grow on.
/:cl:

