### PR TITLE
Fixes some descriptions

### DIFF
--- a/code/game/objects/items/devices/coins.dm
+++ b/code/game/objects/items/devices/coins.dm
@@ -30,7 +30,7 @@
 	black_market_value = 25
 
 /obj/item/coin/copper
-	name = "gold coin"
+	name = "copper coin"
 	desc = "A familiar, but cheap form of currency."
 	icon_state = "coin_copper"
 	black_market_value = 30
@@ -43,7 +43,7 @@
 
 /obj/item/coin/iron
 	name = "iron coin"
-	desc = "You fear this might get rusty."
+	desc = "A coin made of sturdy iron. You fear this might become rusty."
 	icon_state = "coin_iron"
 	black_market_value = 15
 
@@ -55,13 +55,13 @@
 
 /obj/item/coin/uranium
 	name = "uranium coin"
-	desc = "Don't touch it!"
+	desc = "A radioactive coin. Don't touch it!"
 	icon_state = "coin_uranium"
 	black_market_value = 35
 
 /obj/item/coin/platinum
 	name = "platinum coin"
-	desc = "This is quite valuable."
+	desc = "A coin made of shiny platinum. It is quite valuable."
 	icon_state = "coin_platinum"
 	black_market_value = 35
 
@@ -73,7 +73,7 @@
 
 /obj/item/coin/chitin
 	name = "chitin coin"
-	desc = "Durable chitin pressed into a coin. Why would anyone make this?"
+	desc = "Durable alien chitin pressed into a coin. There are much better uses for chitin..."
 	icon_state = "coin_chitin"
 	black_market_value = 35
 

--- a/code/modules/mob/living/carbon/xenomorph/mutators/strains/praetorian/dancer.dm
+++ b/code/modules/mob/living/carbon/xenomorph/mutators/strains/praetorian/dancer.dm
@@ -1,7 +1,7 @@
 /datum/xeno_mutator/praetorian_dancer
 	// My name is Cuban Pete, I'm the King of the Rumba Beat
 	name = "STRAIN: Praetorian - Dancer"
-	description = "You lose all of your acid-based abilities and a small amount of your armor in exchange for increased movement speed, evasion, and unparalleled agility that gives you an ability to move even more quickly, dodge bullets, and phase through tallhosts. By slashing tallhosts, you temporarily increase your evasion and you also you apply a tag that changes how your two new tail abilities function. By tagging hosts, you will make Impale hit twice and instead of once and make Tail Trip knock hosts down instead of stunning them."
+	description = "You lose all of your acid-based abilities and a small amount of your armor in exchange for increased movement speed, evasion, and unparalleled agility that gives you an ability to move even more quickly, dodge bullets, and phase through tallhosts. By slashing tallhosts, you temporarily increase your movement speed and you also you apply a tag that changes how your two new tail abilities function. By tagging hosts, you will make Impale hit twice instead of once and make Tail Trip knock hosts down instead of stunning them."
 	flavor_description = "Demonstrate to the talls what 'there is beauty in death' truly symbolizes, then dance upon their graves!"
 	cost = MUTATOR_COST_EXPENSIVE
 	individual_only = TRUE

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -500,7 +500,7 @@
 
 /obj/item/paper/flag
 	name = "paper flag"
-	desc = "Somebody attached a blank piece of paper to a stick. You feel like waving it around like an idiot."
+	desc = "Somebody crudely glued a piece of paper to a stick. You feel like waving it around like an idiot."
 	icon_state = "paper_flag"
 	item_state = "paper_flag"
 


### PR DESCRIPTION
# About the pull request
This PR fixes a spelling error and corrects outdated information about slashing since it no longer increases evasion.

# Changelog

:cl:
fix: Corrected outdated information about one of Dancer's abilities in its strain description.
fix: Fixed the erroneously-named copper coin from gold coin.
fix: Paper flags with writing on them will not say they are blank in the examine text.
/:cl:
