### PR TITLE
Xenos can slash trolleys now

### DIFF
--- a/code/modules/vehicles/train.dm
+++ b/code/modules/vehicles/train.dm
@@ -190,3 +190,25 @@
 
 /obj/vehicle/train/proc/update_car(train_length, active_engines)
 	return
+
+/obj/vehicle/train/attack_alien(mob/living/carbon/xenomorph/attacking_xeno)
+	. = ..()
+
+	if(attacking_xeno.a_intent == INTENT_HELP)
+		return XENO_NO_DELAY_ACTION
+
+	if(attacking_xeno.mob_size < MOB_SIZE_XENO)
+		to_chat(attacking_xeno, SPAN_XENOWARNING("You're too small to do any significant damage to this vehicle!"))
+		return XENO_NO_DELAY_ACTION
+
+	attacking_xeno.animation_attack_on(src)
+
+	attacking_xeno.visible_message(SPAN_DANGER("\The [attacking_xeno] slashes \the [src]!"), SPAN_DANGER("You slash \the [src]!"))
+	playsound(attacking_xeno.loc, pick('sound/effects/metalhit.ogg', 'sound/weapons/alien_claw_metal1.ogg', 'sound/weapons/alien_claw_metal2.ogg', 'sound/weapons/alien_claw_metal3.ogg'), 25, 1)
+
+	var/damage = (attacking_xeno.melee_vehicle_damage + rand(-5,5)) * XENO_UNIVERSAL_VEHICLE_DAMAGEMULT
+
+	health -= damage
+
+	if(health <= 0)
+		explode()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

This PR makes trolleys slashable

# Explain why it's good for the game

Using them to block movement is not their purpose.


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
balance: Xenos can slash trolleys now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
