### PR TITLE
Generators can no longer be blown up

### DIFF
--- a/code/game/machinery/groundmap_geothermal.dm
+++ b/code/game/machinery/groundmap_geothermal.dm
@@ -198,6 +198,9 @@
 	else
 		return ..() //Deal with everything else, like hitting with stuff
 
+/obj/structure/machinery/power/geothermal/ex_act(severity, direction)
+	return FALSE //gameplay-wise these should really never go away
+
 //Putting these here since it's power-related
 /obj/structure/machinery/colony_floodlight_switch
 	name = "Colony Floodlight Switch"


### PR DESCRIPTION

# About the pull request

This PR makes generators impervious to explosions.

# Explain why it's good for the game

Should allow us to throw out the rule clarification about pushing fuel tanks nearby. Also, power is kind of important.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
balance: Generators can no longer be blown up
/:cl:
