### PR TITLE
2.5 marines per 1 larva latejoin

### DIFF
--- a/code/__DEFINES/mode.dm
+++ b/code/__DEFINES/mode.dm
@@ -73,7 +73,7 @@
 #define ROUNDSTATUS_FOG_DOWN 1
 #define ROUNDSTATUS_PODDOORS_OPEN 2
 
-#define LATEJOIN_MARINES_PER_LATEJOIN_LARVA 3
+#define LATEJOIN_MARINES_PER_LATEJOIN_LARVA 2.5
 
 //=================================================
 #define SHOW_ITEM_ANIMATIONS_NONE 0 //Do not show any item pickup animations


### PR DESCRIPTION
# About the pull request

This PR lowers the latejoin barrier from 3 to 2.5 for weighted marine joins.

This means every 2.5 squad marines that join the xenos get 1 larva.

Shipside personnel give 0.25 per to this number.

# Explain why it's good for the game

We want about 2.5 marines per 1 larva.

The previous 0.5 per shipside was causing some weird numbers at extreme populations but the effect was lessened now that it is 0.25.

This should be tested with #3664 

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
balance: 2.5 latejoin marines per 1 larva from 3 latejoin marines to 1 larva
/:cl:
