### PR TITLE
Bonus evolution slowly deteriorates over time when all castes are unlocked

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -48,8 +48,15 @@
 			if(!got_evolution_message)
 				evolve_message()
 				got_evolution_message = TRUE
+
 			if(ROUND_TIME < XENO_ROUNDSTART_PROGRESS_TIME_2)
 				evolution_stored += progress_amount
+				return
+
+			if(evolution_stored > evolution_threshold + progress_amount)
+				evolution_stored -= progress_amount
+				return
+
 		else
 			evolution_stored += progress_amount
 


### PR DESCRIPTION
# About the pull request

Bonus evolution slowly deteriorates over time when all castes are unlocked.

# Explain why it's good for the game

Having pocket T3s in every T1 is not how I'd like to see things go.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
balance: Bonus evolution slowly deteriorates over time when all castes are unlocked
/:cl:
