### PR TITLE
Portable Generators can now be turned off/unanchored by xeno slashes

### DIFF
--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -102,6 +102,30 @@ display round(lastgen) and phorontank amount
 	else
 		. += SPAN_NOTICE("The generator is off.")
 
+/obj/structure/machinery/power/port_gen/attack_alien(mob/living/carbon/xenomorph/attacking_xeno)
+	if(!active && !anchored)
+		return ..()
+
+	if(attacking_xeno.mob_size < MOB_SIZE_XENO)
+		to_chat(attacking_xeno, SPAN_XENOWARNING("You're too small to do any significant damage to affect this!"))
+		return XENO_NO_DELAY_ACTION
+
+	attacking_xeno.animation_attack_on(src)
+	attacking_xeno.visible_message(SPAN_DANGER("[attacking_xeno] slashes [src]!"), SPAN_DANGER("You slash [src]!"))
+	playsound(attacking_xeno, pick('sound/effects/metalhit.ogg', 'sound/weapons/alien_claw_metal1.ogg', 'sound/weapons/alien_claw_metal2.ogg', 'sound/weapons/alien_claw_metal3.ogg'), 25, 1)
+
+	if(active)
+		active = FALSE
+		stop_processing()
+		icon_state = initial(icon_state)
+		visible_message(SPAN_NOTICE("[src] sputters to a stop!"))
+		return XENO_NONCOMBAT_ACTION
+
+	if(anchored)
+		anchored = FALSE
+		visible_message(SPAN_NOTICE("[src]'s bolts are dislodged!"))
+		return XENO_NONCOMBAT_ACTION
+
 //A power generator that runs on solid plasma sheets.
 /obj/structure/machinery/power/port_gen/pacman
 	name = "P.A.C.M.A.N.-type Portable Generator"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

This PR makes Portable Generators able to be turned off/unanchored by xeno slashes.

# Explain why it's good for the game

These are not meant to be used as path blockers/cades.

Protect your generators.

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
balance: Portable Generators can now be turned off/unanchored by xeno slashes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
