### PR TITLE
Xenos no longer can pull dead xenos

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -287,6 +287,9 @@
 	SPAN_DANGER("You nudge your head against [src]."), null, 5, CHAT_TYPE_XENO_FLUFF)
 
 /mob/living/proc/is_xeno_grabbable()
+	if(stat == DEAD)
+		return FALSE
+
 	return TRUE
 
 /mob/living/carbon/human/is_xeno_grabbable()

--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -287,7 +287,7 @@
 	SPAN_DANGER("You nudge your head against [src]."), null, 5, CHAT_TYPE_XENO_FLUFF)
 
 /mob/living/proc/is_xeno_grabbable()
-	if(stat == DEAD && !istype(src, /mob/living/carbon/xenomorph/larva))
+	if(stat == DEAD)
 		return FALSE
 
 	return TRUE

--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -287,7 +287,7 @@
 	SPAN_DANGER("You nudge your head against [src]."), null, 5, CHAT_TYPE_XENO_FLUFF)
 
 /mob/living/proc/is_xeno_grabbable()
-	if(stat == DEAD)
+	if(stat == DEAD && !istype(src, /mob/living/carbon/xenomorph/larva))
 		return FALSE
 
 	return TRUE

--- a/code/modules/mob/living/carbon/xenomorph/castes/Larva.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Larva.dm
@@ -170,3 +170,5 @@
 /mob/living/carbon/xenomorph/larva/emote(act, m_type, message, intentional, force_silence)
 	playsound(loc, "alien_roar_larva", 15)
 
+/mob/living/carbon/xenomorph/larva/is_xeno_grabbable()
+	return TRUE


### PR DESCRIPTION
# About the pull request

This PR makes it so xenos can no longer pull dead xenos (or other non-human typepathed dead mobs).

The exception is dead larva.

When https://github.com/cmss13-devs/cmss13/pull/3644 is merged I'll likely add xeno corpses so as to minimize clutter/wall blocking.

# Explain why it's good for the game

Recovering corpses for marines is an important part of multiple gameplay loops now. We shouldn't really be seeing stacks of xeno corpses in hives.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
balance: Xenos no longer can pull dead xenos
/:cl:
