### PR TITLE
Devour now turns off lights

### DIFF
--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -141,10 +141,9 @@
 				X.visible_message(SPAN_WARNING("[X] devours [pulled]!"), \
 					SPAN_WARNING("You devour [pulled]!"), null, 5)
 
-				//IMPORTANT CODER NOTE: Due to us using the old lighting engine, we need to hacky hack hard to get this working properly
-				//So we're just going to get the lights out of here by forceMoving them to a far-away place
-				//They will be recovered when regurgitating, since this also calls forceMove
-				pulled.moveToNullspace()
+				if(istype(pulled, /mob/living/carbon/human))
+					var/mob/living/carbon/human/pulled_human = pulled
+					pulled_human.disable_lights()
 
 				//Then, we place the mob where it ought to be
 				X.stomach_contents.Add(pulled)

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -141,7 +141,7 @@
 				X.visible_message(SPAN_WARNING("[X] devours [pulled]!"), \
 					SPAN_WARNING("You devour [pulled]!"), null, 5)
 
-				if(istype(pulled, /mob/living/carbon/human))
+				if(ishuman(pulled))
 					var/mob/living/carbon/human/pulled_human = pulled
 					pulled_human.disable_lights()
 


### PR DESCRIPTION

# About the pull request

This PR makes it so devour turns off lights.

# Explain why it's good for the game

This should stop some of the pesky bugs that have been cropping up around lights and devour/regurg.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
fix: Prevented some light bugs with devouring marines
/:cl:
