### PR TITLE
Flashlight gun attachments turn off when they should

### DIFF
--- a/code/modules/projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/gun_helpers.dm
@@ -167,8 +167,9 @@ As sniper rifles have both and weapon mods can change them as well. ..() deals w
 		var/obj/item/attachable/attachment = attachments[slot]
 		if (!attachment || !attachment.light_mod)
 			continue
-		bearer.SetLuminosity(0, FALSE, src)
-		SetLuminosity(attachment.light_mod)
+
+		attachment.activate_attachment(src, bearer)
+
 		return TRUE
 	return FALSE
 


### PR DESCRIPTION

# About the pull request

This PR makes flashlight gun attachments turn off when they should.

Previously, the light source was just taken away without actually turning off the light.

# Explain why it's good for the game

Bug/inconsistency bad

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
fix: Flashlight gun attachments turn off when they should
/:cl:
