### PR TITLE
Fix Shuttle Crash Crash For Hijack

### DIFF
--- a/code/modules/shuttle/dropship_hijack.dm
+++ b/code/modules/shuttle/dropship_hijack.dm
@@ -83,9 +83,7 @@
 
 /datum/dropship_hijack/almayer/proc/target_crash_site(ship_section)
 	target_ship_section = ship_section
-	var/area/target_area = get_crashsite_area(ship_section)
-	// spawn crash location
-	var/turf/target = pick(get_area_turfs(target_area))
+	var/turf/target = get_crashsite_turf(ship_section)
 	if(!target)
 		to_chat(usr, SPAN_WARNING("No area available"))
 		return
@@ -117,9 +115,7 @@
 		var/list/remaining_crash_sites = almayer_ship_sections.Copy()
 		remaining_crash_sites -= target_ship_section
 		var/new_target_ship_section = pick(remaining_crash_sites)
-		var/area/target_area = get_crashsite_area(new_target_ship_section)
-		// spawn crash location
-		var/turf/target = pick(get_area_turfs(target_area))
+		var/turf/target = get_crashsite_turf(new_target_ship_section)
 		crash_site.Move(target)
 		marine_announcement("A hostile aircraft on course for the [target_ship_section] has been successfully deterred.", "IX-50 MGAD System")
 		target_ship_section = new_target_ship_section
@@ -172,53 +168,53 @@
 /datum/dropship_hijack/almayer/proc/disable_latejoin()
 	enter_allowed = FALSE
 
-/datum/dropship_hijack/almayer/proc/get_crashsite_area(ship_section)
-	var/list/areas = list()
+/datum/dropship_hijack/almayer/proc/get_crashsite_turf(ship_section)
+	var/list/turfs = list()
 	switch(ship_section)
 		if("Upper deck Foreship")
-			areas += typesof(/area/almayer/shipboard/brig)
-			areas += list(/area/almayer/command/cichallway)
-			areas += list(/area/almayer/command/cic)
+			turfs += get_area_turfs(/area/almayer/shipboard/brig/armory)
+			turfs += get_area_turfs(/area/almayer/shipboard/brig/cells)
+			turfs += get_area_turfs(/area/almayer/shipboard/brig/cic_hallway)
+			turfs += get_area_turfs(/area/almayer/shipboard/brig/cryo)
+			turfs += get_area_turfs(/area/almayer/shipboard/brig/evidence_storage)
+			turfs += get_area_turfs(/area/almayer/shipboard/brig/execution)
+			turfs += get_area_turfs(/area/almayer/shipboard/brig/general_equipment)
+			turfs += get_area_turfs(/area/almayer/shipboard/brig/lobby)
+			turfs += get_area_turfs(/area/almayer/shipboard/brig/main_office)
+			turfs += get_area_turfs(/area/almayer/shipboard/brig/perma)
+			turfs += get_area_turfs(/area/almayer/shipboard/brig/processing)
+			turfs += get_area_turfs(/area/almayer/shipboard/brig/surgery)
+			turfs += get_area_turfs(/area/almayer/command/cichallway)
+			turfs += get_area_turfs(/area/almayer/command/cic)
 		if("Upper deck Midship")
-			areas += list(
-				/area/almayer/medical/morgue,
-				/area/almayer/medical/upper_medical,
-				/area/almayer/medical/containment,
-				/area/almayer/medical/containment/cell,
-				/area/almayer/medical/medical_science,
-				/area/almayer/medical/testlab,
-				/area/almayer/medical/hydroponics,
-			)
+			turfs += get_area_turfs(/area/almayer/medical/morgue)
+			turfs += get_area_turfs(/area/almayer/medical/upper_medical)
+			turfs += get_area_turfs(/area/almayer/medical/containment)
+			turfs += get_area_turfs(/area/almayer/medical/containment/cell)
+			turfs += get_area_turfs(/area/almayer/medical/medical_science)
+			turfs += get_area_turfs(/area/almayer/medical/testlab)
+			turfs += get_area_turfs(/area/almayer/medical/hydroponics)
 		if("Upper deck Aftship")
-			areas += list(
-				/area/almayer/engineering/upper_engineering,
-				/area/almayer/command/computerlab,
-				/area/almayer/engineering/laundry,
-			)
+			turfs += get_area_turfs(/area/almayer/engineering/upper_engineering)
+			turfs += get_area_turfs(/area/almayer/command/computerlab)
+			turfs += get_area_turfs(/area/almayer/engineering/laundry)
 		if("Lower deck Foreship")
-			areas += list(
-				/area/almayer/hallways/hangar,
-				/area/almayer/hallways/vehiclehangar
-			)
+			turfs += get_area_turfs(/area/almayer/hallways/hangar)
+			turfs += get_area_turfs(/area/almayer/hallways/vehiclehangar)
 		if("Lower deck Midship")
-			areas += list(
-				/area/almayer/medical/chemistry,
-				/area/almayer/medical/lower_medical_lobby,
-				/area/almayer/medical/lockerroom,
-				/area/almayer/medical/lower_medical_medbay,
-				/area/almayer/medical/operating_room_one,
-				/area/almayer/medical/operating_room_two,
-				/area/almayer/medical/operating_room_three,
-				/area/almayer/medical/operating_room_four,
-				/area/almayer/living/briefing,
-				/area/almayer/squads/req,
-
-			)
+			turfs += get_area_turfs(/area/almayer/medical/chemistry)
+			turfs += get_area_turfs(/area/almayer/medical/lower_medical_lobby)
+			turfs += get_area_turfs(/area/almayer/medical/lockerroom)
+			turfs += get_area_turfs(/area/almayer/medical/lower_medical_medbay)
+			turfs += get_area_turfs(/area/almayer/medical/operating_room_one)
+			turfs += get_area_turfs(/area/almayer/medical/operating_room_two)
+			turfs += get_area_turfs(/area/almayer/medical/operating_room_three)
+			turfs += get_area_turfs(/area/almayer/medical/operating_room_four)
+			turfs += get_area_turfs(/area/almayer/living/briefing)
+			turfs += get_area_turfs(/area/almayer/squads/req)
 		if("Lower deck Aftship")
-			areas += list(
-				/area/almayer/living/cryo_cells,
-				/area/almayer/engineering/engineering_workshop,
-			)
+			turfs += get_area_turfs(/area/almayer/living/cryo_cells)
+			turfs += get_area_turfs(/area/almayer/engineering/engineering_workshop)
 		else
 			CRASH("Crash site [ship_section] unknown.")
-	return pick(areas)
+	return pick(turfs)


### PR DESCRIPTION

This PR fixes a crash... with shuttles crashing! Namely with this runtime on round 17377 that prevent the shuttle from launching:
```
[2023-06-19 11:33:51.878] runtime error: Cannot read null.related
 - proc name: get area turfs (/proc/get_area_turfs)
 -   source file: code/__HELPERS/unsorted.dm,1251
 -   usr: Young Queen (/mob/living/carbon/xenomorph/queen)
 -   src: null
 -   usr.loc: the floor (35,50,2) (/turf/open/shuttle/dropship)
 -   call stack:
 - get area turfs(/area/almayer/shipboard/brig/d... (/area/almayer/shipboard/brig/dress))
 - /datum/dropship_hijack/almayer (/datum/dropship_hijack/almayer): target crash site("Upper deck Foreship")
 - the dropship navigation comput... (/obj/structure/machinery/computer/shuttle/dropship/flight): hijack(Young Queen (/mob/living/carbon/xenomorph/queen), 0)
 - the dropship navigation comput... (/obj/structure/machinery/computer/shuttle/dropship/flight): attack alien(Young Queen (/mob/living/carbon/xenomorph/queen))
 - Young Queen (/mob/living/carbon/xenomorph/queen): UnarmedAttack(the dropship navigation comput... (/obj/structure/machinery/computer/shuttle/dropship/flight), 1, /list (/list), 0, 0)
 - Young Queen (/mob/living/carbon/xenomorph/queen): click adjacent(the dropship navigation comput... (/obj/structure/machinery/computer/shuttle/dropship/flight), null, /list (/list))
 - Young Queen (/mob/living/carbon/xenomorph/queen): do click(the dropship navigation comput... (/obj/structure/machinery/computer/shuttle/dropship/flight), the floor (36,51,2) (/turf/open/shuttle/dropship), "icon-x=24;icon-y=6;left=1;butt...")
 - SOMEONE (/client): Click(the dropship navigation comput... (/obj/structure/machinery/computer/shuttle/dropship/flight), the floor (36,51,2) (/turf/open/shuttle/dropship), "mapwindow.map", "icon-x=24;icon-y=6;left=1;butt...")
 ```

# Explain why it's good for the game

Not only does this fix the case of a non-existent /area/almayer/shipboard/brig/dress being selected, it will now evenly weight the possibilities of landing sites. Previously this code would favor smaller areas because an area that was 1 tile would be just as likely as an area with 20k tiles.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/cmss13-devs/cmss13/assets/76988376/aa45fd06-6b8b-44b0-85b7-ff98f3038555)

</details>


# Changelog
:cl: Drathek Firartix
fix: Fixed a crash with hijack code possibly picking a non-existent brig area, and weighting smaller areas heavier.
/:cl:
