### PR TITLE
Changes pod crash land probability to 33% from 50%.

### DIFF
--- a/code/modules/shuttle/shuttles/escape_shuttle.dm
+++ b/code/modules/shuttle/shuttles/escape_shuttle.dm
@@ -1,4 +1,4 @@
-#define CRASH_LAND_PROBABILITY 50
+#define CRASH_LAND_PROBABILITY 33
 
 /obj/docking_port/mobile/escape_shuttle
 	name = "Escape Pod"


### PR DESCRIPTION

# About the pull request

Changes pod crash land probability to 33% from 50%.

# Explain why it's good for the game

Morrow please hear me out: with crash land probability at 50%, it makes crash-landings normal rather than something cool and special. This lowers it slightly to 33%. I know your changes are part of a larger set of changes but just for now it would be nice if the value was tweaked. I am open to another number somewhere below 50%.

That's my OOC reasoning. IC reasoning: "The USCM engineers finally have refined their pod-building process, making it slightly more likely that pods function as intended rather than crashing a whopping 50% of the time."

# Changelog
:cl:
balance: pods crash land 33% of the time rather than 50%
/:cl:
