### PR TITLE
Disables marine joins after hijack

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -486,3 +486,4 @@ SUBSYSTEM_DEF(ticker)
 	if(mode)
 		mode.is_in_endgame = TRUE
 		mode.force_end_at = (world.time + 25 MINUTES)
+		enter_allowed = FALSE

--- a/code/modules/shuttle/dropship_hijack.dm
+++ b/code/modules/shuttle/dropship_hijack.dm
@@ -153,8 +153,6 @@
 
 	addtimer(CALLBACK(src, PROC_REF(do_dropship_incoming_sound)), 13 SECONDS)
 
-	addtimer(CALLBACK(src, PROC_REF(disable_latejoin)), 3 MINUTES) // latejoin cryorines have 3 minutes to get the hell out
-
 /datum/dropship_hijack/almayer/proc/do_dropship_incoming_sound()
 	for(var/area/internal_area in shuttle.shuttle_areas)
 		playsound_area(internal_area, 'sound/effects/dropship_incoming.ogg', vol = 75)
@@ -165,11 +163,8 @@
 /datum/dropship_hijack/almayer/proc/do_dropship_collision_sound()
 	playsound_z(SSmapping.levels_by_any_trait(list(ZTRAIT_MARINE_MAIN_SHIP)), 'sound/effects/dropship_crash.ogg', volume = 75)
 
-/datum/dropship_hijack/almayer/proc/disable_latejoin()
-	enter_allowed = FALSE
-
-/datum/dropship_hijack/almayer/proc/get_crashsite_turf(ship_section)
-	var/list/turfs = list()
+/datum/dropship_hijack/almayer/proc/get_crashsite_area(ship_section)
+	var/list/areas = list()
 	switch(ship_section)
 		if("Upper deck Foreship")
 			turfs += get_area_turfs(/area/almayer/shipboard/brig/armory)

--- a/code/modules/shuttles/marine_ferry.dm
+++ b/code/modules/shuttles/marine_ferry.dm
@@ -505,7 +505,7 @@
 			shake_camera(affected_mob, 10, 1)
 			affected_mob.apply_effect(3, WEAKEN)
 
-	addtimer(CALLBACK(src, PROC_REF(disable_latejoin)), 3 MINUTES) // latejoin cryorines have 3 minutes to get the hell out
+	enter_allowed = FALSE
 
 	var/list/turfs_trg = get_shuttle_turfs(T_trg, info_datums) //Final destination turfs <insert bad jokey reference here>
 
@@ -554,9 +554,6 @@
 		if(istype(SSticker.mode, /datum/game_mode/colonialmarines))
 			var/datum/game_mode/colonialmarines/colonial_marines = SSticker.mode
 			colonial_marines.add_current_round_status_to_end_results("Hijack")
-
-/datum/shuttle/ferry/marine/proc/disable_latejoin()
-	enter_allowed = FALSE
 
 
 /datum/shuttle/ferry/marine/short_jump()


### PR DESCRIPTION

# About the pull request
New players joining the round after hijack doesn't really serve a purpose beyond feeding xenos, and just results in confusion for a lot of people. This PR changes it so that the moment the shuttle actually crashes, joins are stopped.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Stops marines joining after the hijack impacts.
/:cl:
