### PR TITLE
Adds the Corpsman Helmet to Req

### DIFF
--- a/code/game/machinery/vending/vendor_types/requisitions.dm
+++ b/code/game/machinery/vending/vendor_types/requisitions.dm
@@ -426,6 +426,7 @@
 		list("ARMOR", -1, null, null),
 		list("M10 Pattern Marine Helmet", 20, /obj/item/clothing/head/helmet/marine, VENDOR_ITEM_REGULAR),
 		list("M10 Pattern Technician Helmet", 20, /obj/item/clothing/head/helmet/marine/tech, VENDOR_ITEM_REGULAR),
+		list("M10 Pattern Corpman Helmet", 20, /obj/item/clothing/head/helmet/marine/medic, VENDOR_ITEM_REGULAR),
 		list("M3 Pattern Carrier Marine Armor", 20, /obj/item/clothing/suit/storage/marine/carrier, VENDOR_ITEM_REGULAR),
 		list("M3 Pattern Padded Marine Armor", 20, /obj/item/clothing/suit/storage/marine/padded, VENDOR_ITEM_REGULAR),
 		list("M3 Pattern Padless Marine Armor", 20, /obj/item/clothing/suit/storage/marine/padless, VENDOR_ITEM_REGULAR),


### PR DESCRIPTION

# About the pull request

Wanna know what the rarest marine helmet is?
Basic grunt, squad level I mean.

The Medic helmet.
Can't get it from Req, or nothing.
And most folks dump them anyway because they wanna drop their flags.
# Explain why it's good for the game

If you want to replace it, it's near impossible.
If you wanna deploy as a FOB Surgeon you have to stick with a grunt helmet.

This makes that better.

It, as before has the exact same stats and usage as a regular helmet.
If we can give tech helmets to everyone (don't get me started) then we should be able to give red crosses to everyone.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
qol: Added the Corpsman Helmet to Req's surplus vendor.
/:cl:
