### PR TITLE
Fixes gun light attachment issues

### DIFF
--- a/code/modules/projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/gun_helpers.dm
@@ -143,7 +143,7 @@ As sniper rifles have both and weapon mods can change them as well. ..() deals w
 /obj/item/weapon/gun/dropped(mob/user)
 	. = ..()
 
-	turn_off_light(user)
+	disconnect_light_from_mob(user)
 
 	var/delay_left = (last_fired + fire_delay + additional_fire_group_delay) - world.time
 	if(fire_delay_group && delay_left > 0)
@@ -160,6 +160,20 @@ As sniper rifles have both and weapon mods can change them as well. ..() deals w
 		for(var/group in fire_delay_group)
 			LAZYSET(user.fire_delay_next_fire, group, world.time + delay_left)
 
+/// This function disconnects the luminosity from the mob and back to the gun
+/obj/item/weapon/gun/proc/disconnect_light_from_mob(mob/bearer)
+	if (!(flags_gun_features & GUN_FLASHLIGHT_ON))
+		return FALSE
+	for (var/slot in attachments)
+		var/obj/item/attachable/attachment = attachments[slot]
+		if (!attachment || !attachment.light_mod)
+			continue
+		bearer.SetLuminosity(0, FALSE, src)
+		SetLuminosity(attachment.light_mod)
+		return TRUE
+	return FALSE
+
+/// This function actually turns the lights on the gun off
 /obj/item/weapon/gun/proc/turn_off_light(mob/bearer)
 	if (!(flags_gun_features & GUN_FLASHLIGHT_ON))
 		return FALSE
@@ -167,9 +181,7 @@ As sniper rifles have both and weapon mods can change them as well. ..() deals w
 		var/obj/item/attachable/attachment = attachments[slot]
 		if (!attachment || !attachment.light_mod)
 			continue
-
 		attachment.activate_attachment(src, bearer)
-
 		return TRUE
 	return FALSE
 


### PR DESCRIPTION

# About the pull request

Remember, when you move an object around you drop it. Fun.

This PR should fix two things:
Lights not being disconnected from a mob and back to the gun when dropping a gun with a light.
Light attachments turning off when moving a weapon around.

Uuuuh my bad. Somehow missed this in testing.

# Explain why it's good for the game

Bugs bad.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
fix: Fixed two gun light attachment issues
/:cl:
