### PR TITLE
Fix for dummy rotation in character setup.

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -71,7 +71,9 @@
 		return
 
 	// Click handled elsewhere. (These clicks are not affected by the next_move cooldown)
-	if (click(A, mods) || A.clicked(src, mods, location, params))
+	if(click(A, mods))
+		return
+	if(A.clicked(src, mods, location, params))
 		return
 
 	// Default click functions from here on.

--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -34,4 +34,4 @@
 	Have no reason to click on anything at all.
 */
 /mob/new_player/click()
-	return 1
+	return


### PR DESCRIPTION
# About the pull request

Followup to #3516. That PR changed the general click behaviour from `if (click(A, mods) | A.clicked(src, mods, location, params))` to use `||` instead. And in Byond, that means quick resolution: if left side is true, then right side is not evaluated - thus not executed - at all. ~~I am not sure what exactly was that meant to address (or whether it was intentional at all, for that matter),~~ but as it happens, `/mob/new_player/click()` is set to always simply return true while all the code for those arrows is in their `clicked()`. Solution is obvious then.

P.S. On second thought, reading the PR does explain the PR. But quick resolution is not exactly intuitive, and even though it is probably highly unlikely to ever change, there is probably no need to rely on it so implicitly. While I have the file open anyway, might as well make returning after the left half alone explicit.

# Explain why it's good for the game

Is fix.

# Changelog
:cl:
fix: Preview dummy in character setup once again can be rotated.
/:cl:
