### PR TITLE
Hive core and dead larvas.

### DIFF
--- a/code/modules/cm_aliens/structures/special/pylon_core.dm
+++ b/code/modules/cm_aliens/structures/special/pylon_core.dm
@@ -137,7 +137,7 @@
 	// Handle spawning larva if core is connected to a hive
 	if(linked_hive)
 		for(var/mob/living/carbon/xenomorph/larva/L in range(2, src))
-			if(!L.ckey && L.burrowable && !QDELETED(L))
+			if((!L.ckey || L.stat == DEAD) && L.burrowable && (L.hivenumber == linked_hive.hivenumber) && !QDELETED(L))
 				visible_message(SPAN_XENODANGER("[L] quickly burrows into \the [src]."))
 				linked_hive.stored_larva++
 				linked_hive.hive_ui.update_burrowed_larva()


### PR DESCRIPTION

# About the pull request

Hive core, by design, absorbs AFK larvas to let somebody else actually play instead. And as long as it has been a thing, the definition of "AFK" was actually "without a client", so a dead larva that ghosted was absorbed all the same and replaced with a new alive larva - while dead larvas that did not ghost were seen as being actively played and left alone.
Frankly, if a larva dies without the core and entire hive being destroyed, it was most likely running out somewhere whither it has no business going. We refund these anyway. Might as well formally declare it an intended mechanic that dead larvas can be recycled at core.
Also, funny as it might be, it should only work on the hive's _own_ larvas.

# Explain why it's good for the game

Closes #3667.

# Changelog
:cl:
fix: Hive core now always correctly absorbs hive's dead larvas.
/:cl:
