### PR TITLE
Fix yank object verb for others

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -843,7 +843,7 @@ note dizziness decrements automatically in the mob's Life() proc.
 			return FALSE
 		to_chat(src, SPAN_WARNING("You attempt to get a good grip on [selection] in your body."))
 	else
-		if(get_active_hand())
+		if(usr.get_active_hand())
 			to_chat(usr, SPAN_WARNING("You need an empty hand for this!"))
 			return FALSE
 		to_chat(usr, SPAN_WARNING("You attempt to get a good grip on [selection] in [src]'s body."))


### PR DESCRIPTION

# About the pull request

This PR fixes an oversight where the yank object verb when used to yank an object out of someone other than yourself would test if the person with the object had a free hand, rather than the person trying to do the action.

# Explain why it's good for the game

Rather than getting (such as when a object gets stuck in a zombie who has claws in each hand):
![image](https://github.com/cmss13-devs/cmss13/assets/76988376/47a8891d-18ea-4cf0-a0fc-73a0c295318a)
You can yank it out:
![stab](https://github.com/cmss13-devs/cmss13/assets/76988376/8fe6cce6-cbcc-4239-bd4e-b642d0f6b7c4)

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

See Explanation.

</details>

# Changelog
:cl: Drathek
fix: Fixed the yank object verb not testing who is actually performing the action has a free hand
/:cl:
