### PR TITLE
String Changes for Tips

### DIFF
--- a/strings/marinetips.txt
+++ b/strings/marinetips.txt
@@ -75,7 +75,7 @@ Intel Officers can be put in a squad by going to CIC and requesting it.
 Any marine can perform CPR. On dead marines, this will increase the time they have until they become unrevivable.
 If you've been pounced on and your squad is unloading into the target, you can hit the 'rest' button to stay down so you don't get filled with lead after getting up.
 You can check the landing zone as a marine in the status panel.
-Functioning night vision goggles can be recharged with batteries. Broken night vision goggles can be repaired by an Engineer with a screwdriver. Not the loadout ones though, those are cannot be fixed.
+Functioning night vision goggles can be recharged with batteries. Broken night vision goggles can be repaired by an Engineer with a screwdriver. Not the loadout ones though, those cannot be fixed.
 You can put a pistol belt on your suit slot. (Just grab a rifle instead.)
 Alt-clicking the Squad Leader tracker lets you track your fireteam leader instead.
 Armor has a randomized reduction in effectiveness, and does not protect the digits. Take the wiki damage values as a best-case scenario.

--- a/strings/marinetips.txt
+++ b/strings/marinetips.txt
@@ -28,7 +28,7 @@ Examine your gun and click [See combat statistics] to view information such as d
 Xenomorphs who resist while on fire are stunned for some time and emit light. Use that time to catch up and finish them off!
 When you have shrapnel embedded, take out your boot knife and use it in your hand to rip them out of your body.
 If your weapon has a bayonet, you can manually pry open unpowered doors by clicking on them with the gun. Click on the door again to close it. UPP bayonets can pry them open quicker.
-Items on the floor can be shot. Shoot a misthrown HEDP away to save your buddies!
+Items on the floor can be shot. Shoot a poorly thrown HEDP away to save your buddies!
 You can hold a bayonet or throwing knife on your mask slot. Always be prepared.
 Xenomorphs can't apply huggers to marines if they're on fire.
 Dragging a Nanomed onto yourself instantly gives a Health Analyzer report. Always know what's wrong with you.
@@ -46,18 +46,18 @@ By right clicking your medical belt and selecting "toggle belt mode", you can ta
 You can put screwdrivers, cigarettes, and some other things in your second ear slot!
 Pilots : there is one of each engine upgrade in the hangar at the start of the round, saving you the point cost of having to print out a pair of each.
 You can use a hand labeler (as found in squad prep rooms) to name your equipment and make it less likely to be stolen.
-You can use a health analyser in hand (Z key) to check the last scan readout from it.
+You can use a health analyzer in hand (Z key) to check the last scan readout from it.
 Holocards are a useful triage tool for doctors and medics. Ensure you assign them (examine the marine with shift-click and select an appropriate holocard) to marines who have taken damage that cannot be healed without surgery. (Hint : major organ damage or larval infection = red card!)
 Escape pods are designed for only three occupants - more than that, or if a larger xenomorph is in the pod, and it will malfunction and blow up on launch.
 A misloaded OB can deviate severely from the intended target area - ensure you load them correctly!
-The XO and CO are trained in powerloader use and engineering, and can load the OB.
+The XO and CO are trained in Power Loader use and engineering, and can load the OB.
 You can change what your SL tracker beacon is tracking by right clicking on your headset and clicking "Switch Tracker Target".
 Boilers emit light - not every glow from around the corner is friendly!
 You can carry a variety of items inside your helmet - from gauze and cigarettes to flares and screwdrivers.
 CIC staff can track every USCM-aligned person via the suit sensors console and overwatch console - useful for finding escaped prisoners or dead marines.
 When the M7 RPG is fired, it creates a substantial shockwave behind it that can stun and harm marines standing too close. Watch your backblast!
 Remember that you need to put a defibrillator's paddles away in order to store it.
-W-Y PMCs do not have marine IFF. Don't fire smartguns through them!
+W-Y PMCs do not have marine IFF. Don't fire Smartguns through them!
 To talk on multiple radio channels at once, put a COMMA [,] before your message and add up to four prefixes. E.g, ,abcd talks on all squad channels at once.
 Put .w or :w before your message to whisper. Another way to whisper is to use the verb "whisper" in the IC tab or command bar.
 For Vehicle Crewmen : it is often safer to repair the parts of your APC or tank inside the vehicle than outside it.
@@ -75,13 +75,13 @@ Intel Officers can be put in a squad by going to CIC and requesting it.
 Any marine can perform CPR. On dead marines, this will increase the time they have until they become unrevivable.
 If you've been pounced on and your squad is unloading into the target, you can hit the 'rest' button to stay down so you don't get filled with lead after getting up.
 You can check the landing zone as a marine in the status panel.
-Functioning night vision goggles can be recharged with batteries. Broken night vision goggles can be repaired by an Engineer with a screwdriver. Not the loadout ones though, those are unfixable and unchargeable.
-You can put a pistol belt on your suit slot. (Just grab a rifle instead..)
+Functioning night vision goggles can be recharged with batteries. Broken night vision goggles can be repaired by an Engineer with a screwdriver. Not the loadout ones though, those are cannot be fixed.
+You can put a pistol belt on your suit slot. (Just grab a rifle instead.)
 Alt-clicking the Squad Leader tracker lets you track your fireteam leader instead.
-Armor has a randomized reduction in effectiveness, and does not protect the digits. Take the wiki damage values as a best case scenario.
+Armor has a randomized reduction in effectiveness, and does not protect the digits. Take the wiki damage values as a best-case scenario.
 You can click on your Security Access Tuner (multitool) in your hand to locate the area's APC if there is one.
 Clicking on your sprite with help intent will let you check your body, seeing where your fractures and other wounds are.
 Armor has insulative properties - taking it off will help you cool off and take less damage faster if you've been set on fire.
-Both foldable cades & plasteel cades if loosened and folded down can be transported in crates! In this way, you can use the crate as a portable breach-repair kit, or dragged (or carried via Powerloader) to an unsecure area for quick defensive set up.
+Both foldable cades & plasteel cades if loosened and folded down can be transported in crates! In this way, you can use the crate as a portable breach-repair kit, or dragged (or carried via Power Loader) to an unsecure area for quick defensive set up.
 The fuel tank pouch doesn't just carry fuel for an incinerator- they can also carry full-size extinguishers. Toolbelts & tool pouches also may hold miniature extinguishers.
-The M2C heavy machinegunner belt rig can also carry C4, breaching charges, and most tools.
+The M2C heavy machine gunner belt rig can also carry C4, breaching charges, and most tools.

--- a/strings/metatips.txt
+++ b/strings/metatips.txt
@@ -1,13 +1,13 @@
-Remember hotkeys and marcos can be customized to your liking. Hotkeys can be accessed in your preferences, and macros can be edited in the Byond macro editor, available in the top left drop down menu (click the Byond logo in the corner of the game window).
-If you're unsure about a gameplay mechanic, use the 'mentorhelp' verb in the Admins tab to ask veteran players on the subject.
+Remember hotkeys and macros can be customized to your liking. Hotkeys can be accessed in your preferences, and macros can be edited in the Byond macro editor, available in the top left drop down menu (click the Byond logo in the corner of the game window).
+If you're unsure about a gameplay mechanic, use the 'mentorhelp' verb in the Admin tab to ask veteran players on the subject.
 Try not to get too mad about dying. We’re all here to have fun.
 After dying, ask yourself what you did wrong and make a mental note to not make the same mistake again.
 Communication, be it from a marine to a marine, a drone to the queen, or command to everyone, is vital and information on flanks can change how the entire round plays out.
 As an alien or marine, be careful of the flank, regardless of if the push is going well or stalling out.
 Half of getting good is knowing to be aggressive. The other half is knowing when not to be aggressive.
-Alt-click a storage item to draw the last item in it (last non-weapon if it's a weapon belt). Middle-click a storage item to inmediately open it, and middle-click structures to attempt to vault them.
+Alt-click a storage item to draw the last item in it (last non-weapon if it's a weapon belt). Middle-click a storage item to immediately open it, and middle-click structures to attempt to vault them.
 Use "North, South, West, East" when referring to locations in-game rather than "up, down, left, right".
 You shouldn't ignore what your allies are up to. Sometimes they can be organizing a flank in hivemind/radio, sometimes they can be walking up behind you with a slug-loaded shotgun. Either way, it pays to be alert to what they're doing, as much to as what the enemies are.
-The Wiki (https://cm-ss13.com/wiki) is a very useful repository of information about the game, such as weapons, equipment, xenomorph castes and their strains. It may not be fully up to date the majority of the time, but the basics are usually accurate.
+The Wiki (https://cm-ss13.com/wiki) is a very useful repository of information about the game, such as weapons, equipment, xenomorph castes and their strains. It may not be fully up to date much of the time, but the basics are usually accurate.
 As an observer, you may see how much remaining hijack time is left in the status panel.
 Embrace the suck.

--- a/strings/xenotips.txt
+++ b/strings/xenotips.txt
@@ -1,6 +1,6 @@
 Acid pillars can be sneakily placed next to a door in order to surprise marines.
-Alien structures like clusters, walls, or pillars are absolutely vital to your victory, be it as cover or to delay and funnel marines.
-Always thank your drones and hivelords for supporting the hive!
+Alien structures like clusters, walls, or pillars are vital to your victory, be it as cover or to delay and funnel marines.
+Always thank your drones and Hivelords for supporting the hive!
 Don't underestimate survivors. They have no armor but that makes them very fast, they're inherently hardier than marines and have various tricks up their sleeves.
 While the Queen is de-ovied, the hive does not gain evolution points.
 Try out new castes or strains that you might have passed up initially. You might find them to be surprisingly fun.
@@ -16,21 +16,21 @@ If a fellow alien is stunned, be sure to drag them to safety.
 On help intent, click a xenomorph who is on fire to pat them out. This works on marines too!
 Frenzy increases your speed and damage, Recovery increases your health regeneration, and Warding increases the time you have until you bleed out in critical health.
 Remember that, as a Xenomorph, you can fully disable your night-vision. This helps put into perspective how hidden your position is to marines onscreen.
-You can devour bursted corpses in order to transport them to the Spawn Pool or Egg Morpher easier.
+You can devour burst corpses in order to transport them to the Spawn Pool or Egg Morpher easier.
 The bigger you are, the more time it'll take to enter a tunnel.
-Drag yourself onto a hole in a wall as a medium-sized or smaller xeno to pass through it.
+Drag yourself onto a hole in a wall as a medium-sized or smaller Xeno to pass through it.
 Claymores have directional explosions. Set them off early by slashing them from behind.
 If you have difficulty clicking marines, try using Directional Slashing, though there's no directional slashing for abilities.
 You can diagonally pounce through the corners of fire as a Lurker or Runner without getting ignited.
-When playing as xeno, consider aiming at the limbs instead of the chest. Marine armour doesn't protect the arms and legs as well as it does the body.
-As xeno, you can break Night-Vision goggles that some marines wear on their helmets. Just aim for the head and slash until the goggles shatter.
+When playing as Xeno, consider aiming at the limbs instead of the chest. Marine armor doesn't protect the arms and legs as well as it does the body.
+As Xeno, you can break Night-Vision goggles that some marines wear on their helmets. Just aim for the head and slash until the goggles shatter.
 Pounces are ineffective on marines who are laying down.
-You may rest inmediately during a pounce to pounce straight through mobs. It's not very practical or useful though.
-Pouncing someone who is buckled to a chair will still stun them, but you won't jump into their tile and they will not be knocked to the grund.
-Starshell dust from said grenades is just as meltable as normal flares.
-You can join the hive as a living facehugger by clicking on the hive's eggmorpher. This works on other hives too..
-Playable facehuggers can leap onto targets with a one-second windup, but this will only infect them if they are adjacent to it.  Otherwise, it will simply knock them down for a small duration.
-As a facehugger, you cannot talk in hivemind, but you can still open Hive Status and overwatch your sisters. This can be useful if you're locating other facehuggers, flanker castes, or trying to learn from experienced facehugger players.
+You may rest immediately during a pounce to pounce straight through mobs. It's not very practical or useful though.
+Pouncing someone who is buckled to a chair will still stun them, but you won't jump into their tile and they will not be knocked to the ground.
+Star shell dust from said grenades is just as meltable as normal flares.
+You can join the hive as a living Facehugger by clicking on the hive's Eggmorpher. This works on other hives too..
+Playable Facehuggers can leap onto targets with a one-second windup, but this will only infect them if they are adjacent to it.  Otherwise, it will simply knock them down for a small duration.
+As a Facehugger, you cannot talk in hivemind, but you can still open Hive Status and overwatch your sisters. This can be useful if you're locating other Facehuggers, flanker castes, or trying to learn from experienced Facehugger players.
 Shift-clicking the Queen indicator will tell you what area you are in, on the map.
-Resisting on a water tile will inmediately put out fires. Make sure you're alone though - It's usually better to let a friendly Xenomorph pat you out than it is to expose yourself to open water.
+Resisting on a water tile will immediately put out fires. Make sure you're alone though - It's usually better to let a friendly Xenomorph pat you out than it is to expose yourself to open water.
 You can filter out the Xenomorphs displayed in hive status by health, allowing you to look only for wounded sisters.


### PR DESCRIPTION
# About the pull request
Updates Memetips, Xenotips, and Marinetips to have better grammar and removes typos.

# Explain why it's good for the game
Everyone gets very tired when seeing typos in the round start tips.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>
</details>


# Changelog
Altered the Meme/Xeno/Marine tips that display at round start.

:cl:
spellcheck: multiple typos and grammar changes in the round start tooltips.
/:cl:
