### PR TITLE
Fix larva doubling when banished and returned to core

### DIFF
--- a/code/modules/cm_aliens/structures/special/pylon_core.dm
+++ b/code/modules/cm_aliens/structures/special/pylon_core.dm
@@ -136,12 +136,14 @@
 
 	// Handle spawning larva if core is connected to a hive
 	if(linked_hive)
-		for(var/mob/living/carbon/xenomorph/larva/L in range(2, src))
-			if((!L.ckey || L.stat == DEAD) && L.burrowable && (L.hivenumber == linked_hive.hivenumber) && !QDELETED(L))
-				visible_message(SPAN_XENODANGER("[L] quickly burrows into \the [src]."))
-				linked_hive.stored_larva++
-				linked_hive.hive_ui.update_burrowed_larva()
-				qdel(L)
+		for(var/mob/living/carbon/xenomorph/larva/worm in range(2, src))
+			if((!worm.ckey || worm.stat == DEAD) && worm.burrowable && (worm.hivenumber == linked_hive.hivenumber) && !QDELETED(worm))
+				visible_message(SPAN_XENODANGER("[worm] quickly burrows into \the [src]."))
+				if(!worm.banished)
+					// Goob job bringing her back home, but no doubling please
+					linked_hive.stored_larva++
+					linked_hive.hive_ui.update_burrowed_larva()
+				qdel(worm)
 
 		var/spawning_larva = can_spawn_larva() && (last_larva_time + spawn_cooldown) < world.time
 		if(spawning_larva)


### PR DESCRIPTION
# About the pull request

This PR fixes an oversight brought up by TheGamer01 where banishing larva can double stored larva because banishment rewards it on death, and if there is still a body that body can also be returned to core. Now returning banished larva just has the same to_chat and effect as regular larva, but there is no additional larva granted.

Also note that readmitting a dead xeno doesn't change the banished status on the mob (if you want to test be sure to set the ckey of the mob to something other than you).

# Explain why it's good for the game

No exploiting banishment please.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![larba](https://github.com/cmss13-devs/cmss13/assets/76988376/1e8c40bf-66bd-4a65-9e8c-a7793aa886e6)

</details>


# Changelog
:cl: Drathek
fix: Fix a possibility of banished larva refunding double the larva
/:cl:
