### PR TITLE
Hardy Weeds Upgrade Weeds

### DIFF
--- a/code/__DEFINES/xeno.dm
+++ b/code/__DEFINES/xeno.dm
@@ -132,6 +132,7 @@
 // Weed defines
 #define WEED_LEVEL_WEAK 0
 #define WEED_LEVEL_STANDARD  1.5
+#define WEED_LEVEL_HARDY 1.6
 #define WEED_LEVEL_HIVE   4
 
 #define WEED_RANGE_STANDARD  3

--- a/code/modules/cm_aliens/weeds.dm
+++ b/code/modules/cm_aliens/weeds.dm
@@ -492,20 +492,20 @@
 	overlay_node = TRUE
 	overlays += staticnode
 
-/obj/effect/alien/weeds/node/Initialize(mapload, obj/effect/alien/weeds/node/node, mob/living/carbon/xenomorph/X, datum/hive_status/hive)
+/obj/effect/alien/weeds/node/Initialize(mapload, obj/effect/alien/weeds/node/node, mob/living/carbon/xenomorph/xeno, datum/hive_status/hive)
 	if (istype(hive))
 		linked_hive = hive
-	else if (istype(X) && X.hive)
-		linked_hive = X.hive
+	else if (istype(xeno) && xeno.hive)
+		linked_hive = xeno.hive
 	else
 		linked_hive = GLOB.hive_datum[hivenumber]
 
-	for(var/obj/effect/alien/weeds/W in loc)
-		if(W != src)
-			if(W.weed_strength > WEED_LEVEL_HIVE)
+	for(var/obj/effect/alien/weeds/weed in loc)
+		if(weed != src)
+			if(weed.weed_strength > WEED_LEVEL_HIVE)
 				qdel(src)
 				return
-			qdel(W) //replaces the previous weed
+			qdel(weed) //replaces the previous weed
 			break
 
 	. = ..(mapload, src)
@@ -513,15 +513,15 @@
 	if(!staticnode)
 		staticnode = image('icons/mob/xenos/weeds.dmi', "weednode", ABOVE_OBJ_LAYER)
 
-	var/obj/effect/alien/resin/trap/TR = locate() in loc
-	if(TR)
-		RegisterSignal(TR, COMSIG_PARENT_PREQDELETED, PROC_REF(trap_destroyed))
+	var/obj/effect/alien/resin/trap/trap = locate() in loc
+	if(trap)
+		RegisterSignal(trap, COMSIG_PARENT_PREQDELETED, PROC_REF(trap_destroyed))
 		overlay_node = FALSE
 		overlays -= staticnode
 
-	if(X)
-		add_hiddenprint(X)
-		weed_strength = max(weed_strength, X.weed_level)
+	if(xeno)
+		add_hiddenprint(xeno)
+		weed_strength = max(weed_strength, xeno.weed_level)
 		if (weed_strength < WEED_LEVEL_STANDARD)
 			weed_strength = WEED_LEVEL_STANDARD
 

--- a/code/modules/cm_aliens/weeds.dm
+++ b/code/modules/cm_aliens/weeds.dm
@@ -521,7 +521,7 @@
 
 	if(X)
 		add_hiddenprint(X)
-		weed_strength = X.weed_level
+		weed_strength = max(weed_strength, X.weed_level)
 		if (weed_strength < WEED_LEVEL_STANDARD)
 			weed_strength = WEED_LEVEL_STANDARD
 

--- a/code/modules/mob/living/carbon/xenomorph/mutators/strains/drone/gardener.dm
+++ b/code/modules/mob/living/carbon/xenomorph/mutators/strains/drone/gardener.dm
@@ -352,8 +352,8 @@
 
 /obj/effect/alien/weeds/node/gardener
 	spread_on_semiweedable = TRUE
-	block_structures = BLOCK_SPECIAL_STRUCTURES
 	fruit_growth_multiplier = 0.8
+	weed_strength = WEED_LEVEL_HARDY
 
 /datum/action/xeno_action/verb/verb_plant_gardening_weeds()
 	set category = "Alien"


### PR DESCRIPTION
# About the pull request

This PR makes it so hardy weeds can upgrade weeds much like hive weeds do. They now allow special structures (hive core and hive cluster - morpher and recovery need hive weeds) since both it was weird they wouldn't (the turf is already checks anyways if it supports special structures such that you cannot build special on semi-weedable turfs or worse), and a gardener would just hurt the hive making areas where you couldn't build those special structures.

# Explain why it's good for the game

Gardeners should not be punished for using their special weeds. They grow fruit faster and have more health, so they are better than normal weeds. It makes no sense for them to not support special structures (the turf dictates that). Be careful though, you will replace nodes that are inferior (see testing gif)!

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![weeds](https://github.com/cmss13-devs/cmss13/assets/76988376/e659a2e1-4e27-439b-9f44-8bfdfee7b455)

</details>


# Changelog
:cl: Drathek
balance: Gardener's hardy weeds now upgrade normal weeds (just like hive weeds upgrade weeds).
balance: Gardener's hardy weeds now don't prevent special structures (core and pylons) but they are still only allowed if the turf allows them.
/:cl:
