### PR TITLE
Made filled resin holes and weed nodes destroyable by xenos

### DIFF
--- a/code/modules/cm_aliens/structures/trap.dm
+++ b/code/modules/cm_aliens/structures/trap.dm
@@ -217,6 +217,20 @@
 			to_chat(X, SPAN_XENONOTICE("[src] is occupied by a child."))
 			return XENO_NO_DELAY_ACTION
 
+	if(X.a_intent == INTENT_HARM)
+		to_chat(X, SPAN_XENONOTICE("You start tearing away at the hole."))
+		xeno_attack_delay(X)
+		if(!do_after(X, 30, INTERRUPT_NO_NEEDHAND, BUSY_ICON_HOSTILE, src))
+			return XENO_NO_DELAY_ACTION
+		var/area/A = get_area(src)
+		if (X.hivenumber == hivenumber)
+			Destroy()
+		to_chat(X, SPAN_XENONOTICE("You destroy the trap."))
+		for(var/mob/living/carbon/xenomorph/Xeno in GLOB.living_xeno_list)
+			if(Xeno.hivenumber == hivenumber)
+				to_chat(Xeno, SPAN_XENOMINORWARNING("One of your Hive's traps at [A.name] has been torn apart by [X]!"))
+		return XENO_NO_DELAY_ACTION
+
 	if((!X.acid_level || trap_type == RESIN_TRAP_GAS) && trap_type != RESIN_TRAP_EMPTY)
 		to_chat(X, SPAN_XENONOTICE("Better not risk setting this off."))
 		return XENO_NO_DELAY_ACTION

--- a/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
@@ -27,8 +27,16 @@
 		return
 
 	var/obj/effect/alien/weeds/node/N = locate() in T
-	if(N && N.weed_strength >= X.weed_level)
-		to_chat(X, SPAN_WARNING("There's a pod here already!"))
+	if(N)
+		if(N.weed_strength > X.weed_level)
+			to_chat(X, SPAN_WARNING("There's a pod here already!"))
+		else
+			to_chat(X, SPAN_WARNING("You start removing the resin node."))
+			if(!do_after(X, 10, INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD))
+				return
+			playsound(X.loc, "alien_resin_break", 25)
+			N.Destroy()
+			to_chat(X, SPAN_WARNING("You removed the resin node."))
 		return
 
 	var/obj/effect/alien/resin/trap/resin_trap = locate() in T


### PR DESCRIPTION

# About the pull request

Made weed nodes destroyable with the plant weeds button.
Made filled resin holes destroyable by harm intent click, with a hive-wide message telling about it to avoid griefing going unnoticed. It does constitute a bit of a buff, due to it being usable for extinguishing yourself.
Both have a short windup delay to avoid accidental use.

# Explain why it's good for the game

If a resin hole gets filled it becomes unremovable by xenos until something triggers it, no reason for it to work like that, was just annoying if a badly placed hole got filled.

Pretty much the same for weeds, nice to be able to remove weeds when trying to be stealthy, not giving away your presence (For example the west LZ2 wall on BR when you are doing a Mining Hive and some XX drone weeded it).

# Testing Photographs and Procedure
Tested every possible shenanigans I could think of relating to these two things.


# Changelog
:cl:
qol: Weed nodes are now removable with the 'plant weeds' ability.
balance: Acid filled resin holes can now be destroyed by xenos via clicking on them with harm intent.
/:cl:
