### PR TITLE
Fix Deterred Crashsite Offset

### DIFF
--- a/code/modules/shuttle/dropship_hijack.dm
+++ b/code/modules/shuttle/dropship_hijack.dm
@@ -1,3 +1,5 @@
+#define HIJACK_CRASH_SITE_OFFSET_X -5
+#define HIJACK_CRASH_SITE_OFFSET_Y -11
 
 /datum/dropship_hijack
 	var/obj/docking_port/mobile/shuttle
@@ -90,8 +92,8 @@
 
 	var/obj/docking_port/stationary/marine_dropship/crash_site/target_site = new()
 	crash_site = target_site
-	crash_site.x = target.x - 5
-	crash_site.y = target.y - 11
+	crash_site.x = target.x + HIJACK_CRASH_SITE_OFFSET_X
+	crash_site.y = target.y + HIJACK_CRASH_SITE_OFFSET_Y
 	crash_site.z = target.z
 
 	target_site.name = "[shuttle] crash site"
@@ -116,8 +118,10 @@
 		remaining_crash_sites -= target_ship_section
 		var/new_target_ship_section = pick(remaining_crash_sites)
 		var/turf/target = get_crashsite_turf(new_target_ship_section)
-		crash_site.Move(target)
 		marine_announcement("A hostile aircraft on course for the [target_ship_section] has been successfully deterred.", "IX-50 MGAD System")
+		crash_site.x = target.x + HIJACK_CRASH_SITE_OFFSET_X
+		crash_site.y = target.y + HIJACK_CRASH_SITE_OFFSET_Y
+		crash_site.z = target.z
 		target_ship_section = new_target_ship_section
 		// TODO mobs not alerted
 		for(var/area/internal_area in shuttle.shuttle_areas)
@@ -218,3 +222,6 @@
 		else
 			CRASH("Crash site [ship_section] unknown.")
 	return pick(turfs)
+
+#undef HIJACK_CRASH_SITE_OFFSET_X
+#undef HIJACK_CRASH_SITE_OFFSET_Y

--- a/code/modules/shuttle/dropship_hijack.dm
+++ b/code/modules/shuttle/dropship_hijack.dm
@@ -92,9 +92,10 @@
 
 	var/obj/docking_port/stationary/marine_dropship/crash_site/target_site = new()
 	crash_site = target_site
-	crash_site.x = target.x + HIJACK_CRASH_SITE_OFFSET_X
-	crash_site.y = target.y + HIJACK_CRASH_SITE_OFFSET_Y
-	crash_site.z = target.z
+	var/turf/offset_target = locate(target.x + HIJACK_CRASH_SITE_OFFSET_X, target.y + HIJACK_CRASH_SITE_OFFSET_Y, target.z)
+	if(!offset_target)
+		offset_target = target // Welp the offsetting failed so...
+	target_site.forceMove(offset_target)
 
 	target_site.name = "[shuttle] crash site"
 	target_site.id = "crash_site_[shuttle.id]"
@@ -118,10 +119,11 @@
 		remaining_crash_sites -= target_ship_section
 		var/new_target_ship_section = pick(remaining_crash_sites)
 		var/turf/target = get_crashsite_turf(new_target_ship_section)
+		var/turf/offset_target = locate(target.x + HIJACK_CRASH_SITE_OFFSET_X, target.y + HIJACK_CRASH_SITE_OFFSET_Y, target.z)
+		if(!offset_target)
+			offset_target = target // Welp the offsetting failed so...
+		crash_site.forceMove(offset_target)
 		marine_announcement("A hostile aircraft on course for the [target_ship_section] has been successfully deterred.", "IX-50 MGAD System")
-		crash_site.x = target.x + HIJACK_CRASH_SITE_OFFSET_X
-		crash_site.y = target.y + HIJACK_CRASH_SITE_OFFSET_Y
-		crash_site.z = target.z
 		target_ship_section = new_target_ship_section
 		// TODO mobs not alerted
 		for(var/area/internal_area in shuttle.shuttle_areas)


### PR DESCRIPTION

# About the pull request

This PR fixes an oversight where a deterred crashsite does not get positioned the same as a non-deterred one.

# Explain why it's good for the game

Fixes #3593 or atleast should much better mitigate it making it so a deterred crashsite positions the same as a non-deterred.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

# Changelog
:cl: Drathek
fix: Fixed the crashsite offset for a hijack shuttle that gets deterred by the MGAD System
/:cl:
