### PR TITLE
Removes 2second queen building cooldown when building away from hive while boosted

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/queen/queen_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/queen/queen_powers.dm
@@ -472,22 +472,6 @@
 	user_xeno.hive.banished_ckeys.Remove(banished_name)
 	return ..()
 
-/datum/action/xeno_action/activable/secrete_resin/remote/queen/use_ability(atom/A)
-	. = ..()
-	if(!.)
-		return
-
-	if(!boosted)
-		return
-	var/mob/living/carbon/xenomorph/X = owner
-	var/datum/hive_status/HS = X.hive
-	if(!HS || !HS.hive_location)
-		return
-	// 5 screen radius
-	if(get_dist(A, HS.hive_location) > 35)
-		// Apply the normal cooldown if not building near the hive
-		apply_cooldown_override(initial(xeno_cooldown))
-
 /datum/action/xeno_action/onclick/eye
 	name = "Enter Eye Form"
 	action_icon_state = "queen_eye"


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

Currently, when the Queen has boosted building at the start of the game, she gets a 2 second cooldown AFTER construction is complete if she’s building far away from the hive.

This removes that cooldown

# Explain why it's good for the game
This cooldown was introduced when queen boosted building was added 2 years ago. It has never worked, and started working recently due to a refactor. It obviously hasn’t been needed else someone wouldve fixed it.

Currently, unboosted building has a 2 second cooldown from when you START building, this cooldown is only triggered AFTER the wall is built. 

This makes it very hard for Queen to build chokes, especially on lower pops. 

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: Queen boosted building no longer has 2 second cooldown when far from hive
/:cl:
