### PR TITLE
Allow Mentors to Eavesdrop on Mhelps

### DIFF
--- a/code/modules/mentor/mentorhelp.dm
+++ b/code/modules/mentor/mentorhelp.dm
@@ -108,28 +108,28 @@
 			sound_to(recipient, 'sound/effects/mhelp.ogg')
 		to_chat(recipient, wrap_message(msg, sender))
 
-	for(var/client/C in GLOB.admins)
+	for(var/client/admin_client in GLOB.admins)
 		var/formatted = msg
 		var/soundfile
 
-		if(!C || C == recipient)
+		if(!admin_client || admin_client == recipient)
 			continue
 
 		// Initial broadcast
-		else if(!staff_only && !recipient && CLIENT_HAS_RIGHTS(C, R_MENTOR))
+		else if(!staff_only && !recipient && CLIENT_HAS_RIGHTS(admin_client, R_MENTOR))
 			formatted = wrap_message(formatted, sender)
 			soundfile = 'sound/effects/mhelp.ogg'
 
-		// Staff eavesdrop
-		else if(CLIENT_HAS_RIGHTS(C, R_MENTOR) && CLIENT_IS_STAFF(C))
+		// Eavesdrop
+		else if(CLIENT_HAS_RIGHTS(admin_client, R_MENTOR) && (!staff_only || CLIENT_IS_STAFF(admin_client)) && admin_client != sender)
 			if(include_keys)
 				formatted = SPAN_MENTORHELP(key_name(sender, TRUE) + " -> " + key_name(recipient, TRUE) + ": ") + msg
 
 		else continue
 
-		if(soundfile && with_sound && (C.prefs?.toggles_sound & SOUND_ADMINHELP))
-			sound_to(C, soundfile)
-		to_chat(C, formatted)
+		if(soundfile && with_sound && (admin_client.prefs?.toggles_sound & SOUND_ADMINHELP))
+			sound_to(admin_client, soundfile)
+		to_chat(admin_client, formatted)
 	return
 
 // Makes the sender input a message and sends it


### PR DESCRIPTION
# About the pull request

This PR grants mentors the ability to see other responses to mentor help messages, and fixes the double messaging if you are responder to the mhelp.

# Explain why it's good for the game

Mentors can learn from other mentors too!

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

# Changelog
:cl: Drathek
admin: Mentors can now eavesdrop on mentor messages, and the responder to a mhelp doesn't get double logging from eavesdropping.
/:cl:
