### PR TITLE
Makes it possible to complete the power intel objective on Kutjevo.

### DIFF
--- a/maps/map_files/Kutjevo/Kutjevo.dmm
+++ b/maps/map_files/Kutjevo/Kutjevo.dmm
@@ -13631,7 +13631,9 @@
 /turf/open/auto_turf/sand/layer0,
 /area/kutjevo/interior/colony_north)
 "sNp" = (
-/obj/structure/machinery/power/smes/buildable/charged,
+/obj/structure/machinery/power/smes/buildable/charged{
+	cur_coils = 2
+	},
 /turf/open/floor/kutjevo/multi_tiles,
 /area/kutjevo/interior/power)
 "sNZ" = (


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

This just doubles the SMESs max power (and storage I guess)

# Explain why it's good for the game
This is a pretty big amount of intel points you can't get

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: The Kutjevo SMES is now able to output enough power to complete the power intel objective.
/:cl:
