### PR TITLE
Fixes communications intel objective being instantly completed

### DIFF
--- a/code/game/machinery/telecomms/presets.dm
+++ b/code/game/machinery/telecomms/presets.dm
@@ -211,6 +211,7 @@ GLOBAL_LIST_EMPTY(all_static_telecomms_towers)
 	bound_width = 64
 	freq_listening = list(COLONY_FREQ)
 	var/toggle_cooldown = 0
+	on = FALSE
 
 /obj/structure/machinery/telecomms/relay/preset/tower/mapcomms/attack_hand(mob/user)
 	if(user.action_busy)

--- a/code/game/machinery/telecomms/presets.dm
+++ b/code/game/machinery/telecomms/presets.dm
@@ -60,7 +60,7 @@
 		return TRUE
 	return FALSE
 
-/obj/structure/machinery/telecomms/relay/preset/tower/tcomms_startup()
+/obj/structure/machinery/telecomms/relay/preset/tower/update_state()
 	. = ..()
 	if(on)
 		playsound(src, 'sound/machines/tcomms_on.ogg', vol = 80, vary = FALSE, sound_range = 16, falloff = 0.5)
@@ -211,7 +211,6 @@ GLOBAL_LIST_EMPTY(all_static_telecomms_towers)
 	bound_width = 64
 	freq_listening = list(COLONY_FREQ)
 	var/toggle_cooldown = 0
-	on = FALSE
 
 /obj/structure/machinery/telecomms/relay/preset/tower/mapcomms/attack_hand(mob/user)
 	if(user.action_busy)


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

tcomms_startup sets on = TRUE and is called on Initialize(), silly.

This means it just checks when you toggle the state of the tower (usually to on)

Doesn't check if you inputted the frequencies I guess but eh

# Explain why it's good for the game
Don't give marines free intel they didn't earn

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Communications intel objective now actually works
/:cl:
