### PR TITLE
Lurker no longer decloaks if they pounce onto a dead guy.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/lurker/lurker_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/lurker/lurker_abilities.dm
@@ -21,8 +21,9 @@
 	if (X.mutation_type == LURKER_NORMAL)
 		var/found = FALSE
 		for (var/mob/living/carbon/human/H in get_turf(X))
-			found = TRUE
-			break
+			if(H.stat != DEAD)
+				found = TRUE
+				break
 
 		if (found)
 			var/datum/action/xeno_action/onclick/lurker_invisibility/LIA = get_xeno_action_by_type(X, /datum/action/xeno_action/onclick/lurker_invisibility)

--- a/code/modules/mob/living/carbon/xenomorph/abilities/lurker/lurker_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/lurker/lurker_abilities.dm
@@ -14,22 +14,22 @@
 	can_be_shield_blocked = TRUE
 
 /datum/action/xeno_action/activable/pounce/lurker/additional_effects_always()
-	var/mob/living/carbon/xenomorph/X = owner
-	if (!istype(X))
-		return
+    var/mob/living/carbon/xenomorph/xeno = owner
+    if (!istype(xeno))
+        return
 
-	if (X.mutation_type == LURKER_NORMAL)
-		var/found = FALSE
-		for (var/mob/living/carbon/human/H in get_turf(X))
-			if(H.stat == DEAD)
-				continue
-			found = TRUE
-			break
+    if (xeno.mutation_type == LURKER_NORMAL)
+        var/found = FALSE
+        for (var/mob/living/carbon/human/human in get_turf(xeno))
+            if(human.stat == DEAD)
+                continue
+            found = TRUE
+            break
 
-		if (found)
-			var/datum/action/xeno_action/onclick/lurker_invisibility/LIA = get_xeno_action_by_type(X, /datum/action/xeno_action/onclick/lurker_invisibility)
-			if (istype(LIA))
-				LIA.invisibility_off()
+        if (found)
+            var/datum/action/xeno_action/onclick/lurker_invisibility/lurker_invis = get_xeno_action_by_type(xeno, /datum/action/xeno_action/onclick/lurker_invisibility)
+            if (istype(lurker_invis))
+                lurker_invis.invisibility_off()
 
 /datum/action/xeno_action/activable/pounce/lurker/additional_effects(mob/living/L)
 	var/mob/living/carbon/xenomorph/X = owner

--- a/code/modules/mob/living/carbon/xenomorph/abilities/lurker/lurker_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/lurker/lurker_abilities.dm
@@ -25,10 +25,10 @@
 			found = TRUE
 			break
 
-	if (found)
-		var/datum/action/xeno_action/onclick/lurker_invisibility/lurker_invis = get_xeno_action_by_type(xeno, /datum/action/xeno_action/onclick/lurker_invisibility)
-		if (istype(lurker_invis))
-			lurker_invis.invisibility_off()
+		if (found)
+			var/datum/action/xeno_action/onclick/lurker_invisibility/lurker_invis = get_xeno_action_by_type(xeno, /datum/action/xeno_action/onclick/lurker_invisibility)
+			if (istype(lurker_invis))
+				lurker_invis.invisibility_off()
 
 /datum/action/xeno_action/activable/pounce/lurker/additional_effects(mob/living/L)
 	var/mob/living/carbon/xenomorph/X = owner

--- a/code/modules/mob/living/carbon/xenomorph/abilities/lurker/lurker_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/lurker/lurker_abilities.dm
@@ -14,22 +14,21 @@
 	can_be_shield_blocked = TRUE
 
 /datum/action/xeno_action/activable/pounce/lurker/additional_effects_always()
-    var/mob/living/carbon/xenomorph/xeno = owner
-    if (!istype(xeno))
-        return
+	var/mob/living/carbon/xenomorph/xeno = owner
+	if (!istype(xeno))
+		return
+	if (xeno.mutation_type == LURKER_NORMAL)
+		var/found = FALSE
+		for (var/mob/living/carbon/human/human in get_turf(xeno))
+			if(human.stat == DEAD)
+				continue
+			found = TRUE
+			break
 
-    if (xeno.mutation_type == LURKER_NORMAL)
-        var/found = FALSE
-        for (var/mob/living/carbon/human/human in get_turf(xeno))
-            if(human.stat == DEAD)
-                continue
-            found = TRUE
-            break
-
-        if (found)
-            var/datum/action/xeno_action/onclick/lurker_invisibility/lurker_invis = get_xeno_action_by_type(xeno, /datum/action/xeno_action/onclick/lurker_invisibility)
-            if (istype(lurker_invis))
-                lurker_invis.invisibility_off()
+	if (found)
+		var/datum/action/xeno_action/onclick/lurker_invisibility/lurker_invis = get_xeno_action_by_type(xeno, /datum/action/xeno_action/onclick/lurker_invisibility)
+		if (istype(lurker_invis))
+			lurker_invis.invisibility_off()
 
 /datum/action/xeno_action/activable/pounce/lurker/additional_effects(mob/living/L)
 	var/mob/living/carbon/xenomorph/X = owner

--- a/code/modules/mob/living/carbon/xenomorph/abilities/lurker/lurker_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/lurker/lurker_abilities.dm
@@ -21,9 +21,10 @@
 	if (X.mutation_type == LURKER_NORMAL)
 		var/found = FALSE
 		for (var/mob/living/carbon/human/H in get_turf(X))
-			if(H.stat != DEAD)
-				found = TRUE
-				break
+			if(H.stat == DEAD)
+				continue
+			found = TRUE
+			break
 
 		if (found)
 			var/datum/action/xeno_action/onclick/lurker_invisibility/LIA = get_xeno_action_by_type(X, /datum/action/xeno_action/onclick/lurker_invisibility)


### PR DESCRIPTION
# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

Doesn't make sense to lose your cloak for pouncing at a dead guy.

They'll still decloak if it's a living guy hiding under a dead guy.

(This only happens if your pounce ends on a tile where there's a dead guy)

# Explain why it's good for the game
Inconsistent at best. Bad

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Lurkers no longer lose their pounce if they happen to end their pounce on a tile with a dead human
/:cl:
