### PR TITLE
Fix Infinite Recursion in Hugger Custom Rebound

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
@@ -209,6 +209,11 @@
 	if(stat == UNCONSCIOUS)
 		return
 
+	// Force reset throw now because [/atom/movable/proc/launch_impact] only does that later on
+	// If we DON'T, step()'s move below can collide, rebound, trigger this proc again, into infinite recursion
+	throwing = FALSE
+	rebounding = FALSE
+
 	if(leaping && can_hug(L, hivenumber))
 		attach(L)
 	else if(L.density)


### PR DESCRIPTION
# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

```
hugger egg trigger
-> /obj/effect/alien/egg/proc/release_hugger
-> /obj/item/clothing/mask/facehugger/proc/leap_at_nearest_target
-> throw_atom
-> collide against crusher in the way    <<-------------------------
-> launch_impact                                                    |
-> hugger custom mob_launch_collision                               |
-> step away                                                        |
-> launch_impact didn't have time to reset throw yet                |
-> collides with something as throw again --------------------------
```


# Testing Photographs and Procedure
Untested


# Changelog
:cl:
fix: Fixed a MC crash related to NPC huggers rebounding logic.
/:cl:
