### PR TITLE
Almayer Maintenence Light Adjustments

### DIFF
--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -993,6 +993,9 @@
 /obj/structure/closet,
 /obj/item/clothing/suit/armor/riot/marine/vintage_riot,
 /obj/item/clothing/head/helmet/riot/vintage_riot,
+/obj/structure/machinery/light/small{
+	dir = 1
+	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -6506,6 +6509,9 @@
 /obj/structure/sign/safety/terminal{
 	pixel_x = 8;
 	pixel_y = -32
+	},
+/obj/structure/machinery/light/small{
+	dir = 4
 	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
@@ -28322,6 +28328,9 @@
 "cBd" = (
 /obj/structure/surface/rack,
 /obj/item/reagent_container/food/snacks/wrapped/chunk,
+/obj/structure/machinery/light/small{
+	dir = 4
+	},
 /turf/open/floor/almayer{
 	icon_state = "cargo"
 	},
@@ -33609,6 +33618,9 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/blood,
+/obj/structure/machinery/light/small{
+	dir = 4
+	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -38088,6 +38100,12 @@
 	icon_state = "plate"
 	},
 /area/almayer/hull/lower_hull/l_f_p)
+"gXh" = (
+/obj/structure/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/upper_hull/u_m_s)
 "gXl" = (
 /obj/structure/closet/secure_closet/personal/cabinet{
 	req_access_txt = "5"
@@ -68840,6 +68858,14 @@
 	icon_state = "dark_sterile"
 	},
 /area/almayer/engineering/laundry)
+"vqO" = (
+/obj/structure/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/upper_hull/u_a_p)
 "vqW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -71968,6 +71994,9 @@
 /obj/item/coin/silver{
 	desc = "A small coin, bearing the falling falcons insignia.";
 	name = "falling falcons challenge coin"
+	},
+/obj/structure/machinery/light/small{
+	dir = 8
 	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
@@ -109116,7 +109145,7 @@ awE
 vGk
 xCX
 vGk
-csz
+hoX
 qVM
 csz
 qVM
@@ -109928,7 +109957,7 @@ awE
 csz
 iid
 csz
-csz
+hoX
 qVM
 noV
 csz
@@ -115354,7 +115383,7 @@ aag
 lYA
 aao
 aap
-aap
+gXh
 aao
 aap
 aap
@@ -122920,7 +122949,7 @@ vuv
 vuv
 cxo
 cxo
-cxo
+vqO
 sXK
 tbD
 qMu


### PR DESCRIPTION
# About the pull request
Half a dozen rooms in Maint did not have any light fixtures at all (including rooms that were meant to be work spaces and storage.    Added 1 small light to each of these rooms.  Additionally, added one small light near important gameplay objects (1x near the ladder in upper port aft, and 1x near a door in upper starboard mid).  The dark atmosphere of the corridors should remain 99.99% untouched. 
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Places like work spaces and food storage should have lights of some kind.  Rooms, broadly speaking should have a light as well.  This adds the bare minimum to closed off rooms as well as adds lights to two significant gameplay objects on the map (a ladder and a door)
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
maptweak: Added a small light to unlit rooms.
/:cl:
