### PR TITLE
Dropship Sentry Camera

### DIFF
--- a/code/modules/cm_marines/dropship_equipment.dm
+++ b/code/modules/cm_marines/dropship_equipment.dm
@@ -256,7 +256,7 @@
 	deployed_turret.start_processing()
 	deployed_turret.set_range()
 
-	deployed_turret.linked_cam = new(deployed_turret.loc, "[name]")
+	deployed_turret.linked_cam = new(deployed_turret.loc, "[attach_point.name] [name]")
 	deployed_turret.linked_cam.network = (linked_shuttle.id == DROPSHIP_ALAMO ? list(CAMERA_NET_ALAMO) : list(CAMERA_NET_NORMANDY))
 
 

--- a/code/modules/cm_marines/dropship_equipment.dm
+++ b/code/modules/cm_marines/dropship_equipment.dm
@@ -256,6 +256,10 @@
 	deployed_turret.start_processing()
 	deployed_turret.set_range()
 
+	deployed_turret.linked_cam = new(deployed_turret.loc, "[name]")
+	deployed_turret.linked_cam.network = (linked_shuttle.id == DROPSHIP_ALAMO ? list(CAMERA_NET_ALAMO) : list(CAMERA_NET_NORMANDY))
+
+
 /obj/structure/dropship_equipment/sentry_holder/proc/undeploy_sentry()
 	if(!deployed_turret)
 		return
@@ -268,7 +272,11 @@
 	deployed_turret.unset_range()
 	icon_state = "sentry_system_installed"
 
+	QDEL_NULL(deployed_turret.linked_cam)
 
+/obj/structure/dropship_equipment/sentry_holder/launchable/Destroy()
+	QDEL_NULL(deployed_turret.linked_cam)
+	. = ..()
 
 
 /// Holder for the dropship mannable machinegun system

--- a/code/modules/cm_marines/dropship_equipment.dm
+++ b/code/modules/cm_marines/dropship_equipment.dm
@@ -257,7 +257,10 @@
 	deployed_turret.set_range()
 
 	deployed_turret.linked_cam = new(deployed_turret.loc, "[attach_point.name] [name]")
-	deployed_turret.linked_cam.network = (linked_shuttle.id == DROPSHIP_ALAMO ? list(CAMERA_NET_ALAMO) : list(CAMERA_NET_NORMANDY))
+	if (linked_shuttle.id == DROPSHIP_ALAMO)
+		deployed_turret.linked_cam.network = list(CAMERA_NET_ALAMO)
+	else if (linked_shuttle.id == DROPSHIP_NORMANDY)
+		deployed_turret.linked_cam.network = list(CAMERA_NET_NORMANDY)
 
 
 /obj/structure/dropship_equipment/sentry_holder/proc/undeploy_sentry()

--- a/code/modules/cm_marines/dropship_equipment.dm
+++ b/code/modules/cm_marines/dropship_equipment.dm
@@ -277,7 +277,8 @@
 	QDEL_NULL(deployed_turret.linked_cam)
 
 /obj/structure/dropship_equipment/sentry_holder/Destroy()
-	QDEL_NULL(deployed_turret.linked_cam)
+	if(deployed_turret)
+		QDEL_NULL(deployed_turret.linked_cam)
 	. = ..()
 
 

--- a/code/modules/cm_marines/dropship_equipment.dm
+++ b/code/modules/cm_marines/dropship_equipment.dm
@@ -256,7 +256,7 @@
 	deployed_turret.start_processing()
 	deployed_turret.set_range()
 
-	deployed_turret.linked_cam = new(deployed_turret.loc, "[attach_point.name] [name]")
+	deployed_turret.linked_cam = new(deployed_turret.loc, "[ship_base.name] [name]")
 	if (linked_shuttle.id == DROPSHIP_ALAMO)
 		deployed_turret.linked_cam.network = list(CAMERA_NET_ALAMO)
 	else if (linked_shuttle.id == DROPSHIP_NORMANDY)

--- a/code/modules/cm_marines/dropship_equipment.dm
+++ b/code/modules/cm_marines/dropship_equipment.dm
@@ -256,7 +256,7 @@
 	deployed_turret.start_processing()
 	deployed_turret.set_range()
 
-	deployed_turret.linked_cam = new(deployed_turret.loc, "[ship_base.name] [name]")
+	deployed_turret.linked_cam = new(deployed_turret.loc, "[capitalize_first_letters(ship_base.name)] [capitalize_first_letters(name)]")
 	if (linked_shuttle.id == DROPSHIP_ALAMO)
 		deployed_turret.linked_cam.network = list(CAMERA_NET_ALAMO)
 	else if (linked_shuttle.id == DROPSHIP_NORMANDY)

--- a/code/modules/cm_marines/dropship_equipment.dm
+++ b/code/modules/cm_marines/dropship_equipment.dm
@@ -277,7 +277,7 @@
 
 	QDEL_NULL(deployed_turret.linked_cam)
 
-/obj/structure/dropship_equipment/sentry_holder/launchable/Destroy()
+/obj/structure/dropship_equipment/sentry_holder/Destroy()
 	QDEL_NULL(deployed_turret.linked_cam)
 	. = ..()
 

--- a/code/modules/cm_marines/dropship_equipment.dm
+++ b/code/modules/cm_marines/dropship_equipment.dm
@@ -274,7 +274,6 @@
 	deployed_turret.stop_processing()
 	deployed_turret.unset_range()
 	icon_state = "sentry_system_installed"
-
 	QDEL_NULL(deployed_turret.linked_cam)
 
 /obj/structure/dropship_equipment/sentry_holder/Destroy()

--- a/code/modules/defenses/sentry.dm
+++ b/code/modules/defenses/sentry.dm
@@ -539,11 +539,13 @@
 	choice_categories = list()
 	selected_categories = list()
 	var/obj/structure/dropship_equipment/sentry_holder/deployment_system
+	var/obj/structure/machinery/camera/cas/linked_cam
 
 /obj/structure/machinery/defenses/sentry/premade/dropship/Destroy()
 	if(deployment_system)
 		deployment_system.deployed_turret = null
 		deployment_system = null
+	QDEL_NULL(linked_cam)
 	. = ..()
 
 #define SENTRY_SNIPER_RANGE 10


### PR DESCRIPTION

# About the pull request

Adds cameras to dropship deployable sentries. Only work when deployed.

# Explain why it's good for the game

A bit more awareness for the most boring role in the game won't hurt. Also, it was a feature a few years ago, I still don't understand why it was removed, maybe just got dropped during refactoring or something.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: ihatethisengine
add: Added cameras to dropship deployable sentries.
/:cl:
