### PR TITLE
Fix Tableflip scanning logic + infinite loop

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -326,12 +326,16 @@
 /// Checks whether a table is a straight line along a given axis
 /obj/structure/surface/table/proc/straight_table_check(direction)
 	var/obj/structure/surface/table/table = src
-	while(table)
-		// Check whether there are connected tables perpendicular to the axis
-		for(var/angle in list(-90, 90))
-			table = locate() in get_step(loc, turn(direction, angle))
-			if(table && !table.flipped)
-				return FALSE
+
+	// Check whether there are connected tables perpendicular to the axis
+	for(var/angle in list(-90, 90))
+		table = locate() in get_step(loc, turn(direction, angle))
+		if(table && !table.flipped)
+			return FALSE
+
+	table = src
+	var/max_tables = 8 // Lazy extra safety against infinite loops. If table big, can't flip, i guess.
+	while(table && max_tables--)
 		table = locate() in get_step(table, direction)
 		if(!table || table.flipped)
 			return TRUE

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -343,6 +343,8 @@
 			var/obj/structure/surface/table/reinforced/reinforced_table = table
 			if(reinforced_table.status == RTABLE_NORMAL)
 				return FALSE
+	if(!max_tables)
+		return FALSE
 	return TRUE
 
 /obj/structure/surface/table/verb/do_flip()

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -334,8 +334,8 @@
 			return FALSE
 
 	table = src
-	var/max_tables = 8 // Lazy extra safety against infinite loops. If table big, can't flip, i guess.
-	while(table && max_tables--)
+	var/tables_count = 8 // Lazy extra safety against infinite loops. If table big, can't flip, i guess.
+	while(table && tables_count--)
 		table = locate() in get_step(table, direction)
 		if(!table || table.flipped)
 			return TRUE
@@ -343,7 +343,7 @@
 			var/obj/structure/surface/table/reinforced/reinforced_table = table
 			if(reinforced_table.status == RTABLE_NORMAL)
 				return FALSE
-	if(!max_tables)
+	if(!tables_count)
 		return FALSE
 	return TRUE
 


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

Infinite loop observed live.

This fixes three things with the table flipping:

 * The table scan at top shouldn't be in the loop, since it's always done from the starting `loc`
 * The table scan reuses `table`, meaning that the second part would essentially "follow turns" through already-flipped tables incorrectly. This is both incorrect and would cause the infinite loop.
 * The table scan is now capped at 8 tables in either direction. This should mean you can't flip a 12 long table from edge, but can from the middle. Unintended feature, but it makes sense...

# Testing Photographs and Procedure
Flipping 5 wide flat tables still works.


# Changelog
:cl:
fix: Fixed an issue with table flips that could make some tables incorrectly unflippable, and cause infinite loops. It is no longer possible to flip tables more than 8 long in either direction from flipping point. 
/:cl:
