### PR TITLE
Metalfoam speed improvement

### DIFF
--- a/code/game/objects/effects/effect_system/foam.dm
+++ b/code/game/objects/effects/effect_system/foam.dm
@@ -28,7 +28,7 @@
 	metal = ismetal
 	playsound(src, 'sound/effects/bubbles2.ogg', 25, 1, 5)
 	addtimer(CALLBACK(src, PROC_REF(foam_react)), 3 + metal*3)
-	addtimer(CALLBACK(src, PROC_REF(foam_metal_final_react)), 120)
+	addtimer(CALLBACK(src, PROC_REF(foam_metal_final_react)), 40)
 
 /obj/effect/particle_effect/foam/proc/foam_react()
 	process()


### PR DESCRIPTION
# About the pull request

Makes metal foam solidify faster, applies to both regular and OT variants

Changes tested, cuts down the time it takes for metal foam to solidify to roughly a third of before.

# Explain why it's good for the game

Metal foam is completely irrelevant in the current state of the game aside from lifeboat memes, making it faster could open up a niche for it.

# Changelog

:cl: thatoneyeeter
balance: metal foam now becomes solid faster
/:cl:

