### PR TITLE
Big Red Liaison Survivor

### DIFF
--- a/code/modules/gear_presets/survivors.dm
+++ b/code/modules/gear_presets/survivors.dm
@@ -352,8 +352,11 @@
 
 /datum/equipment_preset/survivor/corporate/solaris/load_gear(mob/living/carbon/human/new_human)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/under/liaison_suit/outing/red(new_human), WEAR_BODY)
+	if(new_human.disabilities & NEARSIGHTED)
+		new_human.equip_to_slot_or_del(new /obj/item/clothing/glasses/sunglasses/prescription(new_human), WEAR_EYES)
+	else
+		new_human.equip_to_slot_or_del(new /obj/item/clothing/glasses/sunglasses(new_human), WEAR_EYES)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/shoes/marine/knife(new_human), WEAR_FEET)
-	new_human.equip_to_slot_or_del(new /obj/item/clothing/glasses/sunglasses(new_human), WEAR_EYES)
 
 	..()
 

--- a/code/modules/gear_presets/survivors.dm
+++ b/code/modules/gear_presets/survivors.dm
@@ -346,6 +346,17 @@
 
 	..()
 
+/datum/equipment_preset/survivor/corporate/solaris
+	name = "Survivor - Solaris Ridge Corporate Liaison"
+	assignment = "Solaris Ridge Corporate Liaison"
+
+/datum/equipment_preset/survivor/corporate/solaris/load_gear(mob/living/carbon/human/new_human)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/under/liaison_suit/outing/red(new_human), WEAR_BODY)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/shoes/marine/knife(new_human), WEAR_FEET)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/glasses/sunglasses(new_human), WEAR_EYES)
+
+	..()
+
 // ----- Security Survivor
 
 /datum/equipment_preset/survivor/security

--- a/maps/bigredv2.json
+++ b/maps/bigredv2.json
@@ -12,6 +12,7 @@
         "/datum/equipment_preset/survivor/trucker/solaris",
         "/datum/equipment_preset/survivor/security/solaris",
         "/datum/equipment_preset/survivor/colonial_marshal/solaris",
+        "/datum/equipment_preset/survivor/corporate/solaris",
         "/datum/equipment_preset/survivor/clf",
         "/datum/equipment_preset/survivor/civilian"
     ],


### PR DESCRIPTION

# About the pull request
 Adds a Corporate Liaison survivor to Solaris Ridge. Tested it, was able to spawn in and select it via the role category selection thing.
# Explain why it's good for the game
more options for roleplay are good, the map didn't have a survivor for the corporate category, plus it makes sense to have one because of the map's lore + the new liaison drip gets more use
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: IowaPotatoFarmer
add: Solaris Ridge now has a Corporate Liaison survivor.
/:cl:
