### PR TITLE
Fixes being unable to re-enter your body when you're unnested

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/xeno_nest.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/xeno_nest.dm
@@ -289,11 +289,12 @@
 	if(buckled_human.stat == DEAD )
 		buckled_mob_density = FALSE
 
-	. = ..()
-
 	var/mob/dead/observer/G = ghost_of_buckled_mob
 	var/datum/mind/M = G?.mind
 	ghost_of_buckled_mob = null
+
+	. = ..() //Very important that this comes after, since it deletes the nest and clears ghost_of_buckled_mob
+
 	if(!istype(buckled_human) || !istype(G) || !istype(M) || buckled_human.undefibbable || buckled_human.mind || M.original != buckled_human || buckled_human.chestburst)
 		return // Zealous checking as most is handled by ghost code
 	to_chat(G, FONT_SIZE_HUGE(SPAN_DANGER("You have been freed from your nest and may go back to your body! (Look for 'Re-enter Corpse' in Ghost verbs, or <a href='?src=\ref[G];reentercorpse=1'>click here</a>!)")))


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

Turns out the parent call of unbuckle() calls afterbuckle() which deletes the nest and clears ghost_of_buckled_mob, which means it can't set your ghost to can_reenter_corpse = TRUE

# Explain why it's good for the game
Bugs bad


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: You can now re-enter your body when unnested, marine mains, rejoice!
/:cl:
