### PR TITLE
Fix minimap removeimage proc not checking z level correctly

### DIFF
--- a/code/controllers/subsystem/minimap.dm
+++ b/code/controllers/subsystem/minimap.dm
@@ -262,8 +262,12 @@ SUBSYSTEM_DEF(minimaps)
  * removes an image from raw tracked lists, invoked by callback
  */
 /datum/controller/subsystem/minimaps/proc/removeimage(image/blip, atom/target)
+	var/turf/turf_gotten = get_turf(target)
+	if(!turf_gotten)
+		return
+	var/z_level = turf_gotten.z
 	for(var/flag in GLOB.all_minimap_flags)
-		minimaps_by_z["[target.z]"].images_raw["[flag]"] -= blip
+		minimaps_by_z["[z_level]"].images_raw["[flag]"] -= blip
 	blip.UnregisterSignal(target, COMSIG_MOVABLE_MOVED)
 	removal_cbs -= target
 

--- a/code/controllers/subsystem/minimap.dm
+++ b/code/controllers/subsystem/minimap.dm
@@ -395,18 +395,24 @@ SUBSYSTEM_DEF(minimaps)
 		owner.client.screen += map
 	minimap_displayed = !minimap_displayed
 
-/datum/action/minimap/give_to(mob/M)
+/datum/action/minimap/give_to(mob/target)
 	. = ..()
 
 	if(default_overwatch_level)
 		map = SSminimaps.fetch_minimap_object(default_overwatch_level, minimap_flags)
 	else
-		RegisterSignal(M, COMSIG_MOVABLE_Z_CHANGED, PROC_REF(on_owner_z_change))
-	if(!SSminimaps.minimaps_by_z["[M.z]"] || !SSminimaps.minimaps_by_z["[M.z]"].hud_image)
-		return
-	map = SSminimaps.fetch_minimap_object(M.z, minimap_flags)
+		RegisterSignal(target, COMSIG_MOVABLE_Z_CHANGED, PROC_REF(on_owner_z_change))
 
-/datum/action/minimap/remove_from(mob/M)
+	var/turf/turf_gotten = get_turf(target)
+	if(!turf_gotten)
+		return
+	var/z_level = turf_gotten.z
+
+	if(!SSminimaps.minimaps_by_z["[z_level]"] || !SSminimaps.minimaps_by_z["[z_level]"].hud_image)
+		return
+	map = SSminimaps.fetch_minimap_object(z_level, minimap_flags)
+
+/datum/action/minimap/remove_from(mob/target)
 	. = ..()
 	if(minimap_displayed)
 		owner?.client?.screen -= map


### PR DESCRIPTION

# About the pull request

This PR fixes an issue where the removeimage proc in the minimap subsystem didn't get the turf of the target to correctly test what Z level they were added to such as being deleted in a cryopod. (Entering say a cryopod is not considered a onTransitZ trigger despite the z value changing)

# Explain why it's good for the game
This PR should fix runtimes such as:
```
[2023-06-28 07:08:53.119] runtime error: /list {len = 5}l"istress Signal"Êß@'
 - proc name: removeimage (/datum/controller/subsystem/minimaps/proc/removeimage)
 -   source file: minimap.dm,266
 -   usr: null
 -   src: Minimaps (/datum/controller/subsystem/minimaps)
 -   call stack:
 - Minimaps (/datum/controller/subsystem/minimaps): removeimage(, Leroy Luna (/mob/living/carbon/human))
 - /datum/callback (/datum/callback): Invoke()
 - Minimaps (/datum/controller/subsystem/minimaps): remove marker(Leroy Luna (/mob/living/carbon/human), null, null)
 - the marine senior command head... (/obj/item/device/radio/headset/almayer/mcom/cdrcom): dropped(Leroy Luna (/mob/living/carbon/human))
 - Leroy Luna (/mob/living/carbon/human): u equip(the marine senior command head... (/obj/item/device/radio/headset/almayer/mcom/cdrcom), the hypersleep chamber (/obj/structure/machinery/cryopod/right), null, null)
 - Leroy Luna (/mob/living/carbon/human): u equip(the marine senior command head... (/obj/item/device/radio/headset/almayer/mcom/cdrcom), the hypersleep chamber (/obj/structure/machinery/cryopod/right), null, null)
 - Leroy Luna (/mob/living/carbon/human): u equip(the marine senior command head... (/obj/item/device/radio/headset/almayer/mcom/cdrcom), the hypersleep chamber (/obj/structure/machinery/cryopod/right), null, null)
 - Leroy Luna (/mob/living/carbon/human): drop inv item to loc(the marine senior command head... (/obj/item/device/radio/headset/almayer/mcom/cdrcom), the hypersleep chamber (/obj/structure/machinery/cryopod/right), null, null)
 - the hypersleep chamber (/obj/structure/machinery/cryopod/right): despawn occupant()
 - the hypersleep chamber (/obj/structure/machinery/cryopod/right): process()
 - Machinery (/datum/controller/subsystem/machinery): fire(0)
 - Machinery (/datum/controller/subsystem/machinery): ignite(0)
 - Master (/datum/controller/master): RunQueue()
 - Master (/datum/controller/master): Loop(2)
 - Master (/datum/controller/master): StartProcessing(0)
```

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![cryo](https://github.com/cmss13-devs/cmss13/assets/76988376/9ade906e-cde1-4330-9cd7-cc82ffb938e4)

</details>

# Changelog
:cl: Drathek
fix: Fix runtimes with minimap subsystem not handling targets inside of objects during removal
/:cl:
