### PR TITLE
Remove dead code for langchat rotations

### DIFF
--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -302,11 +302,9 @@
 		src.add_fingerprint(user)
 		afterbuckle(target)
 		if(buckle_lying) // Make sure buckling to beds/nests etc only turns, and doesn't give a random offset
-			var/matrix/M = matrix()
-			var/matrix/L = matrix() //Counterrotation for langchat text.
-			M.Turn(90)
-			L.Turn(270)
-			target.apply_transform(M)
+			var/matrix/new_matrix = matrix()
+			new_matrix.Turn(90)
+			target.apply_transform(new_matrix)
 		return TRUE
 
 /obj/proc/send_buckling_message(mob/M, mob/user)

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -94,23 +94,19 @@ There are several things that need to be remembered:
 	if(lying == lying_prev && !force)
 		return
 	lying_prev = lying
-	var/matrix/M = matrix()
-	var/matrix/L = matrix() //Counter-rotation for langchat text.
+	var/matrix/new_matrix = matrix()
 	if(lying)
 		if(pulledby && pulledby.grab_level >= GRAB_CARRY)
-			M.Turn(90)
-			L.Turn(270)
+			new_matrix.Turn(90)
 		else
 			if(prob(50))
-				M.Turn(90)
-				L.Turn(270)
+				new_matrix.Turn(90)
 			else
-				M.Turn(270)
-				L.Turn(90)
-			M.Translate(rand(-10,10),rand(-10,10))
-		apply_transform(M)
+				new_matrix.Turn(270)
+			new_matrix.Translate(rand(-10,10), rand(-10,10))
+		apply_transform(new_matrix)
 	else
-		apply_transform(M)
+		apply_transform(new_matrix)
 
 /mob/living/carbon/human/UpdateDamageIcon()
 	for(var/obj/limb/O in limbs)


### PR DESCRIPTION

# About the pull request

This PR removes some unused code as of #671 

# Explain why it's good for the game

Less work for the server when updating a mob's transform.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

# Changelog
:cl: Drathek
code: Removed unnecessary calculations when updating a mob's transform.
/:cl:
