### PR TITLE
Fixes wordiness about re-entering your body when you're unnested

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -398,7 +398,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		var/is_nested = (buckled && istype(buckled, /obj/structure/bed/nest)) ? TRUE : FALSE
 		var/obj/structure/bed/nest/nest = FALSE
 		if(is_nested)
-			text_prompt += "\nSince you're nested, you will be given a chance to reenter your body upon being freed."
+			text_prompt += "\nSince you're nested, you will get a chance to reenter your body if freed."
 			nest = buckled
 		var/response = tgui_alert(src, text_prompt, "Are you sure you want to ghost?", options)
 		if(response == "Aghost")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

This PR is a followup to #3597 that was requested but refused in #3747 to improve the situation where there is too much text in a tgui_alert.

# Explain why it's good for the game

Instead of:
![image](https://github.com/cmss13-devs/cmss13/assets/76988376/aee760ce-ed79-4cac-be06-b2d265bd69c6)
It is now:
![image](https://github.com/cmss13-devs/cmss13/assets/76988376/26859630-c185-4c2a-94e2-d275e85a620e)

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

1. Get nested
2. Remain in body for the first prompt
3. Ghost

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl: Drathek
spellcheck: Tweaked message when ghosting while nested
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
