### PR TITLE
M2C ammo resized to Medium QOL

### DIFF
--- a/code/modules/cm_marines/smartgun_mount.dm
+++ b/code/modules/cm_marines/smartgun_mount.dm
@@ -1010,7 +1010,7 @@
 	name = "M2C Ammunition Box (10x28mm tungsten rounds)"
 	desc = "A box of 125, 10x28mm tungsten rounds for the M2 Heavy Machinegun System. Click the heavy machinegun while there's no ammo box loaded to reload the M2C."
 	caliber = "10x28mm"
-	w_class = SIZE_LARGE
+	w_class = SIZE_MEDIUM
 	icon = 'icons/obj/items/weapons/guns/ammo_by_faction/uscm.dmi'
 	icon_state = "m56de"
 	item_state = "m56de"


### PR DESCRIPTION
# About the pull request

M2C should be consistent with all other heavy ammo, m56d, Smartgun ammo, HPR etc.

They don't fit in any other normal ammo belt so you don't need to worry about a pistol pouch with 6 M2C magazines

# Explain why it's good for the game

Consistency Good, QOL good, gives more gameplay option

Basically it lets you pack it into backpacks and other medium storage are, BUT not into other specific belt

# Changelog

:cl:
add: M2C ammo boxes are now Medium size item
/:cl:
