### PR TITLE
Prevents spamming open and close tarps

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -149,7 +149,7 @@
 
 /obj/structure/closet/proc/toggle(mob/living/user)
 	user.next_move = world.time + 5
-	if(!(src.opened ? src.close() : src.open()))
+	if(!(src.opened ? src.close(user) : src.open()))
 		to_chat(user, SPAN_NOTICE("It won't budge!"))
 	return
 

--- a/code/modules/cm_marines/equipment/gear.dm
+++ b/code/modules/cm_marines/equipment/gear.dm
@@ -144,7 +144,7 @@
 
 /obj/structure/closet/bodybag/tarp/close()
 	if(delay_time > world.time)
-		to_chat(usr, SPAN_WARNING("It is too soon to close the [src]!"))
+		to_chat(usr, SPAN_WARNING("It is too soon to close [src]!"))
 		return FALSE
 	. = ..()
 	handle_cloaking()

--- a/code/modules/cm_marines/equipment/gear.dm
+++ b/code/modules/cm_marines/equipment/gear.dm
@@ -58,7 +58,8 @@
 	var/is_animating = FALSE
 	var/first_open = TRUE
 	exit_stun = 0
-	COOLDOWN_DECLARE(toggle_delay)//used to implement a delay before tarp can be entered again after opened (anti-exploit)
+	/// used to implement a delay before tarp can be entered again after opened (anti-exploit)
+	COOLDOWN_DECLARE(toggle_delay)
 
 /obj/structure/closet/bodybag/tarp/snow
 	icon_state = "snowtarp_closed"

--- a/code/modules/cm_marines/equipment/gear.dm
+++ b/code/modules/cm_marines/equipment/gear.dm
@@ -139,7 +139,7 @@
 			return
 
 /obj/structure/closet/bodybag/tarp/open()
-	COOLDOWN_START(src,toggle_delay,3 SECONDS) //3 seconds must pass before tarp can be closed
+	COOLDOWN_START(src, toggle_delay, 3 SECONDS) //3 seconds must pass before tarp can be closed
 	. = ..()
 	handle_cloaking()
 

--- a/code/modules/cm_marines/equipment/gear.dm
+++ b/code/modules/cm_marines/equipment/gear.dm
@@ -53,6 +53,7 @@
 	anchored = FALSE
 	var/uncloak_time = 3 //in SECONDS, this is how long it takes for the tarp to become fully visible again once it's opened from an invisible state
 	var/cloak_time = 15 //ditto for cloaking
+	var/delay_time = 0 //in SECONDS, used to implement a delay before tarp can be entered again after opened (anti-exploit)
 	var/closed_alpha = 60 //how much ALPHA the tarp has once it's fully cloaked.
 	var/can_store_dead = FALSE
 	var/is_animating = FALSE
@@ -137,10 +138,14 @@
 			return
 
 /obj/structure/closet/bodybag/tarp/open()
+	delay_time = world.time + 3 SECONDS //3 seconds must past before tarp can be closed again
 	. = ..()
 	handle_cloaking()
 
 /obj/structure/closet/bodybag/tarp/close()
+	if(delay_time > world.time)
+		to_chat(usr, SPAN_WARNING("It is too soon to close the [src]!"))
+		return FALSE
 	. = ..()
 	handle_cloaking()
 


### PR DESCRIPTION
# About the pull request

Fixes #3734
Deals with exploit that allows the user to spam open and close a tarp, making it hard for the Xeno to hit the marine, this makes it so when tarp is opened, 3 seconds must pass before it can be closed again. If 3 seconds isn't enough, delay can be lengthened.

# Explain why it's good for the game

I was tasked by the Xeno Agents to buff Xeno win rate by any means necessary, including fixing exploits.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

https://github.com/cmss13-devs/cmss13/assets/91219575/999e0f72-a802-41d3-b1d8-5a4569d84e5a

Before

![image](https://github.com/cmss13-devs/cmss13/assets/91219575/7eb71b25-4077-4042-bab6-760f0c429190)
After

</details>


# Changelog
:cl:
fix: fixes exploit relating to cloaking tarps by adding a delay before tarp can be closed again.
/:cl:
