### PR TITLE
Fixes ranged Vampire Lurker headbiting

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/lurker/lurker_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/lurker/lurker_powers.dm
@@ -336,6 +336,11 @@
 	if(!do_after(xeno, 0.8 SECONDS, INTERRUPT_NO_NEEDHAND, BUSY_ICON_HOSTILE, numticks = 2)) // would be 0.75 but that doesn't really work with numticks
 		return
 
+	// To make sure that the headbite does nothing if the target is moved away.
+	if(!xeno.Adjacent(target_carbon))
+		to_chat(xeno, SPAN_XENOHIGHDANGER("You missed! Your target was moved away before you could finish headbiting them!"))
+		return
+
 	if(target_carbon.stat == DEAD)
 		to_chat(xeno, SPAN_XENODANGER("They died before you could finish headbiting them! Be more careful next time!"))
 		return


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

Fixes a bug where lurker headbite would still trigger after a target was moved away during windup by adding a proximity check after the headbite timer.

# Explain why it's good for the game
fixes #3643

# Changelog
:cl: Clairion

fix: Vampire Lurker headbite will no longer trigger if the target is moved away during windup.

/:cl:
