### PR TITLE
Fix time of death persistence for larva queue

### DIFF
--- a/code/__HELPERS/cmp.dm
+++ b/code/__HELPERS/cmp.dm
@@ -65,4 +65,4 @@ var/atom/cmp_dist_origin=null
 /// Compares observers based on their larva_queue_time value in ascending order
 /// Assumes the client on the observer is not null
 /proc/cmp_obs_larvaqueuetime_asc(mob/dead/observer/A, mob/dead/observer/B)
-	return A.client.larva_queue_time - B.client.larva_queue_time
+	return A.client.player_details.larva_queue_time - B.client.player_details.larva_queue_time

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -302,7 +302,7 @@
 			to_chat(candidates[i], chat_message)
 
 		// Count how many are prioritized
-		if(cur_obs.client.larva_queue_time < 2) // 0 and 1 because facehuggers/t-domers are slightly deprioritized
+		if(cur_obs.client.player_details.larva_queue_time < 2) // 0 and 1 because facehuggers/t-domers are slightly deprioritized
 			new_players++
 
 /proc/convert_k2c(temp)

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -26,8 +26,6 @@
 	var/adminobs = null
 	var/area = null
 	var/time_died_as_mouse = null //when the client last died as a mouse
-	/// The descriminator for larva queue ordering: Generally set to timeofdeath except for facehuggers/admin z-level play
-	var/larva_queue_time
 
 	var/donator = 0
 	var/adminhelped = 0

--- a/code/modules/client/player_details.dm
+++ b/code/modules/client/player_details.dm
@@ -7,6 +7,8 @@ GLOBAL_LIST_EMPTY(player_details) // ckey -> /datum/player_details
 	var/list/post_logout_callbacks = list()
 	var/list/played_names = list() //List of names this key played under this round
 	var/byond_version = "Unknown"
+	/// The descriminator for larva queue ordering: Generally set to timeofdeath except for facehuggers/admin z-level play
+	var/larva_queue_time
 
 
 /proc/log_played_names(ckey, ...)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -369,7 +369,7 @@ Works together with spawning an observer, noted above.
 		// We don't change facehugger timeofdeath because they are still on cooldown if they died as a hugger
 		// Facehuggers are atleast 1 because they did get some action compared to those at 0 timeofdeath
 		var/new_tod = isfacehugger(src) ? 1 : ghost.timeofdeath
-		ghost.client.larva_queue_time = max(ghost.client.larva_queue_time, new_tod)
+		ghost.client.player_details.larva_queue_time = max(ghost.client.player_details.larva_queue_time, new_tod)
 
 	ghost.set_huds_from_prefs()
 
@@ -413,7 +413,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		var/mob/dead/observer/ghost = ghostize((is_nested && nest && !QDELETED(nest))) //FALSE parameter is so we can never re-enter our body, "Charlie, you can never come baaaack~" :3
 		if(ghost && !is_admin_level(z))
 			ghost.timeofdeath = world.time
-			ghost.client?.larva_queue_time = world.time
+			ghost.client?.player_details.larva_queue_time = world.time
 		if(is_nested && nest && !QDELETED(nest))
 			ghost.can_reenter_corpse = FALSE
 			nest.ghost_of_buckled_mob = ghost

--- a/code/modules/organs/limb_objects.dm
+++ b/code/modules/organs/limb_objects.dm
@@ -136,6 +136,7 @@
 	H.regenerate_icons()
 
 	if(braindeath_on_decap)
+		brainmob.timeofdeath = world.time
 		brainmob.set_stat(DEAD)
 		brainmob.death(cause)
 

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -635,7 +635,7 @@
 			var/mob/dead/observer/obs = mob.ghostize(FALSE)
 			if(obs)
 				obs.timeofdeath = world.time
-				obs.client?.larva_queue_time = world.time
+				obs.client?.player_details.larva_queue_time = world.time
 			mob.moveToNullspace()
 
 	// Now that mobs are stowed, delete the shuttle


### PR DESCRIPTION
# About the pull request

This PR moves the value used to sort players in the larva queue from the client to player_details. In testing reconnecting a client seemed to work because I didn't give enough time for the client to delete, but now it should always persistent for the round.

# Explain why it's good for the game

Larva queue is supposed to actually give players who have yet to play the priority, not players who have died, and disconnect long enough.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

# Changelog
:cl: Drathek
fix: Fixed a persistence problem for the time of death value used for the larva queue.
fix: Fixed brainmobs (human gibbing) not getting a time of death value.
/:cl:
