### PR TITLE
Project ARES - APOLLO Console Distribution

### DIFF
--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -2839,6 +2839,10 @@
 	pixel_y = 7
 	},
 /obj/effect/decal/cleanable/blood/oil,
+/obj/structure/machinery/computer/working_joe{
+	dir = 4;
+	pixel_x = -17
+	},
 /turf/open/floor/almayer{
 	dir = 8;
 	icon_state = "silver"
@@ -5322,7 +5326,13 @@
 "are" = (
 /obj/structure/machinery/computer/demo_sim{
 	dir = 4;
-	pixel_x = -16
+	pixel_x = -17;
+	pixel_y = 8
+	},
+/obj/structure/machinery/computer/working_joe{
+	dir = 4;
+	pixel_x = -17;
+	pixel_y = -8
 	},
 /turf/open/floor/almayer,
 /area/almayer/engineering/engineering_workshop/hangar)
@@ -9677,6 +9687,9 @@
 /area/almayer/shipboard/brig/main_office)
 "aEm" = (
 /obj/structure/surface/table/almayer,
+/obj/structure/machinery/computer/working_joe{
+	dir = 4
+	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -10322,6 +10335,10 @@
 	},
 /area/almayer/living/numbertwobunks)
 "aHo" = (
+/obj/structure/machinery/computer/working_joe{
+	dir = 4;
+	pixel_x = -17
+	},
 /turf/open/floor/almayer{
 	dir = 8;
 	icon_state = "orange"
@@ -18183,7 +18200,7 @@
 /area/almayer/squads/bravo)
 "buQ" = (
 /obj/structure/surface/table/almayer,
-/obj/structure/machinery/computer/station_alert{
+/obj/structure/machinery/computer/working_joe{
 	dir = 8
 	},
 /turf/open/floor/almayer{
@@ -21103,11 +21120,11 @@
 	},
 /area/almayer/squads/req)
 "bIw" = (
-/obj/structure/machinery/prop/almayer/computer,
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/light{
 	dir = 1
 	},
+/obj/structure/machinery/computer/working_joe,
 /turf/open/floor/almayer{
 	dir = 1;
 	icon_state = "red"
@@ -39046,11 +39063,11 @@
 /area/almayer/medical/upper_medical)
 "hbZ" = (
 /obj/structure/surface/table/almayer,
-/obj/structure/machinery/computer/station_alert{
-	dir = 4
-	},
 /obj/structure/sign/safety/terminal{
 	pixel_x = -17
+	},
+/obj/structure/machinery/computer/working_joe{
+	dir = 4
 	},
 /turf/open/floor/almayer{
 	dir = 8;
@@ -49790,6 +49807,9 @@
 "lXg" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/recharger,
+/obj/structure/machinery/computer/working_joe{
+	pixel_y = 16
+	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -56167,6 +56187,10 @@
 	},
 /obj/effect/decal/cleanable/cobweb2/dynamic,
 /obj/item/packageWrap,
+/obj/structure/machinery/computer/working_joe{
+	dir = 8;
+	pixel_x = 17
+	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor5"
 	},
@@ -76719,6 +76743,11 @@
 	},
 /obj/structure/surface/rack,
 /obj/effect/spawner/random/toolbox,
+/obj/structure/machinery/computer/working_joe{
+	dir = 4;
+	pixel_y = 14;
+	pixel_x = -17
+	},
 /turf/open/floor/almayer{
 	dir = 10;
 	icon_state = "orange"


### PR DESCRIPTION

# About the pull request
Places more apollo maintenance consoles around the Almayer. Combined with #3783 will make the consoles actually useful.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Allows them to be accessed in more places rather than exclusively on the top deck.
This allows more people to readily report maintenance issues.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
maptweak: Added Apollo Maintenance Controllers to the following locations.
maptweak: Astronavigation, CIC Substation, Brig Substation, Req Aux Storage, Hangar & OT & Engineering workshops, Reactor Core Room and Lifeboat Control Ring.
/:cl:
