### PR TITLE
Hazard Joe Naming

### DIFF
--- a/code/modules/gear_presets/synths.dm
+++ b/code/modules/gear_presets/synths.dm
@@ -546,6 +546,9 @@
 /datum/equipment_preset/synth/working_joe/load_name(mob/living/carbon/human/new_human, randomise)
 	new_human.change_real_name(new_human, "Working Joe #[rand(100)][rand(100)]")
 
+/datum/equipment_preset/synth/working_joe/engi/load_name(mob/living/carbon/human/new_human, randomise)
+	new_human.change_real_name(new_human, "Hazard Joe #[rand(100)][rand(100)]")
+
 //*****************************************************************************************************/
 
 /datum/equipment_preset/synth/survivor/cultist_synth


### PR DESCRIPTION

# About the pull request

Hazard Joes are now labeled as 'Hazard Joes' in name
# Explain why it's good for the game

Hazard Joes have different responsibilities than a Working Joe, and as such it is important to be able to tell what type a Joe is at a glance (outside of a face to face conversation)

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/cmss13-devs/cmss13/assets/91219575/fb7531ff-153f-44aa-89bb-2d962289798c)
Name change

</details>


# Changelog
:cl:
qol: Hazard Joes are now named Hazard Joe in their name.
/:cl:
