### PR TITLE
Made Research nightmare insert blast doors no longer be invulnerable

### DIFF
--- a/maps/map_files/LV624/science/40.fullylocked.dmm
+++ b/maps/map_files/LV624/science/40.fullylocked.dmm
@@ -7,7 +7,7 @@
 /area/lv624/lazarus/research)
 "ac" = (
 /obj/structure/window/framed/colony/reinforced,
-/obj/structure/machinery/door/poddoor/almayer/locked{
+/obj/structure/machinery/door/poddoor/almayer{
 	id = "science_blast";
 	layer = 3.3;
 	name = "\improper Science Wing Blast Door"
@@ -15,7 +15,7 @@
 /turf/open/floor/plating,
 /area/lv624/lazarus/research)
 "ad" = (
-/obj/structure/machinery/door/poddoor/almayer/locked{
+/obj/structure/machinery/door/poddoor/almayer{
 	id = "science_blast";
 	layer = 3.3;
 	name = "\improper Science Wing Blast Door"
@@ -41,7 +41,7 @@
 /area/lv624/ground/jungle/north_west_jungle)
 "ai" = (
 /obj/structure/window_frame/colony/reinforced,
-/obj/structure/machinery/door/poddoor/almayer/locked{
+/obj/structure/machinery/door/poddoor/almayer{
 	id = "science_blast";
 	layer = 3.3;
 	name = "\improper Science Wing Blast Door"
@@ -73,7 +73,7 @@
 /area/lv624/ground/colony/south_medbay_road)
 "ao" = (
 /obj/structure/window/framed/colony/reinforced,
-/obj/structure/machinery/door/poddoor/almayer/locked{
+/obj/structure/machinery/door/poddoor/almayer{
 	dir = 4;
 	id = "science_blast";
 	layer = 3.3;
@@ -218,7 +218,7 @@
 	},
 /area/lv624/lazarus/research)
 "aI" = (
-/obj/structure/machinery/door/poddoor/almayer/locked{
+/obj/structure/machinery/door/poddoor/almayer{
 	dir = 4;
 	id = "science_blast";
 	layer = 3.3;
@@ -336,7 +336,7 @@
 	},
 /area/lv624/lazarus/research)
 "aU" = (
-/obj/structure/machinery/door/poddoor/almayer/locked{
+/obj/structure/machinery/door/poddoor/almayer{
 	dir = 4;
 	id = "science_blast";
 	layer = 3.3;

--- a/maps/map_files/LV624/science/40.fullylocked.dmm
+++ b/maps/map_files/LV624/science/40.fullylocked.dmm
@@ -7,7 +7,7 @@
 /area/lv624/lazarus/research)
 "ac" = (
 /obj/structure/window/framed/colony/reinforced,
-/obj/structure/machinery/door/poddoor/almayer{
+/obj/structure/machinery/door/poddoor/almayer/planet_side_blastdoor{
 	id = "science_blast";
 	layer = 3.3;
 	name = "\improper Science Wing Blast Door"
@@ -15,7 +15,7 @@
 /turf/open/floor/plating,
 /area/lv624/lazarus/research)
 "ad" = (
-/obj/structure/machinery/door/poddoor/almayer{
+/obj/structure/machinery/door/poddoor/almayer/planet_side_blastdoor{
 	id = "science_blast";
 	layer = 3.3;
 	name = "\improper Science Wing Blast Door"
@@ -41,7 +41,7 @@
 /area/lv624/ground/jungle/north_west_jungle)
 "ai" = (
 /obj/structure/window_frame/colony/reinforced,
-/obj/structure/machinery/door/poddoor/almayer{
+/obj/structure/machinery/door/poddoor/almayer/planet_side_blastdoor{
 	id = "science_blast";
 	layer = 3.3;
 	name = "\improper Science Wing Blast Door"
@@ -73,7 +73,7 @@
 /area/lv624/ground/colony/south_medbay_road)
 "ao" = (
 /obj/structure/window/framed/colony/reinforced,
-/obj/structure/machinery/door/poddoor/almayer{
+/obj/structure/machinery/door/poddoor/almayer/planet_side_blastdoor{
 	dir = 4;
 	id = "science_blast";
 	layer = 3.3;
@@ -218,7 +218,7 @@
 	},
 /area/lv624/lazarus/research)
 "aI" = (
-/obj/structure/machinery/door/poddoor/almayer{
+/obj/structure/machinery/door/poddoor/almayer/planet_side_blastdoor{
 	dir = 4;
 	id = "science_blast";
 	layer = 3.3;
@@ -336,7 +336,7 @@
 	},
 /area/lv624/lazarus/research)
 "aU" = (
-/obj/structure/machinery/door/poddoor/almayer{
+/obj/structure/machinery/door/poddoor/almayer/planet_side_blastdoor{
 	dir = 4;
 	id = "science_blast";
 	layer = 3.3;


### PR DESCRIPTION

# About the pull request

The "fully locked" nightmare insert had blast doors that were: Unacidable, unpryable and just generally indestructible.
Replaced it with a variant that is non of those, but merely van-proof.

# Explain why it's good for the game

It lead to very strange gameplay where you could destroy the walls, but not the podlocks. Would be particularly problematic during an LZ2 siege.
I doubt that the intention with this insert was to make Research completely inaccessible, so I rather made the podlocks destructible rather than the walls invulnerable too.

https://github.com/cmss13-devs/cmss13/assets/15560820/3d987d21-0fdf-4133-8df4-b65f30036ddf


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
maptweak: Made LV-624's "Fully-locked" Research nightmare insert no longer have indestructible blast doors.
/:cl:
