### PR TITLE
Acid Runner can no longer get acid stacks from Synthetics and Working Joes

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/mutators/strains/runner/acid.dm
+++ b/code/modules/mob/living/carbon/xenomorph/mutators/strains/runner/acid.dm
@@ -77,7 +77,7 @@
 	for(var/datum/effects/acid/AA in target_mob.effects_list)
 		qdel(AA)
 		break
-	if(isxeno_human(target_mob))
+	if(isxeno_human(target_mob) && !issynth(target_mob)) //no stacks from synthetic life
 		if(target_mob.lying)
 			modify_acid(acid_slash_regen_lying)
 		else


### PR DESCRIPTION

# About the pull request


This PR makes it so synthetic life no longer gives acid stacks for Acid Runner (WJs, Synths)

# Explain why it's good for the game

For Colonial Synthetics and Working Joes, the fact that the Acid Runner is encouraged to kill them to gain strength made it so RP potential with xenos were often cut short. Some members of the Synthetic Council agree with this assessment, and have recommended for synthetics to not give acid stacks, as they have no biomatter for the Acid Runner.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/cmss13-devs/cmss13/assets/91219575/8381dea4-0571-46e7-8bbb-c2b5d663d8ce)
Council seal of approval

</details>


# Changelog
:cl:
balance: Acid Runners no longer gain acid stacks from Synthetics and Working Joes
/:cl:
