### PR TITLE
Remove Larva Queue Messages

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -281,30 +281,6 @@
 
 	return candidates
 
-/**
- * Messages observers that are currently candidates an update on the queue.
- *
- * Arguments:
- * * candidates - The list of observers from get_alien_candidates()
- * * dequeued - How many candidates to skip messaging because they were dequeued
- * * cache_only - Whether to not actually send a to_chat message and instead only update larva_queue_cached_message
- */
-/proc/message_alien_candidates(list/candidates, dequeued, cache_only = FALSE)
-	var/new_players = 0
-	for(var/i in (1 + dequeued) to candidates.len)
-		var/mob/dead/observer/cur_obs = candidates[i]
-
-		// Generate the messages
-		var/cached_message = SPAN_XENONOTICE("You are currently [i-dequeued]\th in the larva queue. There are [new_players] ahead of you that have yet to play this round.")
-		cur_obs.larva_queue_cached_message = cached_message
-		if(!cache_only)
-			var/chat_message = dequeued ? replacetext(cached_message, "currently", "now") : cached_message
-			to_chat(candidates[i], chat_message)
-
-		// Count how many are prioritized
-		if(cur_obs.client.player_details.larva_queue_time < 2) // 0 and 1 because facehuggers/t-domers are slightly deprioritized
-			new_players++
-
 /proc/convert_k2c(temp)
 	return ((temp - T0C))
 

--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -368,23 +368,6 @@ Additional game mode variables.
 			to_chat(xeno_candidate, SPAN_WARNING("There aren't any available xenomorphs or burrowed larvae. You can try getting spawned as a chestburster larva by toggling your Xenomorph candidacy in Preferences -> Toggle SpecialRole Candidacy."))
 			return FALSE
 		to_chat(xeno_candidate, SPAN_WARNING("There aren't any available xenomorphs or burrowed larvae."))
-
-		// Give the player a cached message of their queue status if they are an observer
-		var/mob/dead/observer/candidate_observer = xeno_candidate
-		if(istype(candidate_observer))
-			if(candidate_observer.larva_queue_cached_message)
-				to_chat(xeno_candidate, candidate_observer.larva_queue_cached_message)
-				return FALSE
-
-			// No cache, lets check now then
-			message_alien_candidates(get_alien_candidates(), dequeued = 0, cache_only = TRUE)
-			if(candidate_observer.larva_queue_cached_message)
-				to_chat(xeno_candidate, candidate_observer.larva_queue_cached_message)
-				return FALSE
-
-			// We aren't in queue yet, lets teach them about the queue then
-			candidate_observer.larva_queue_cached_message = SPAN_XENONOTICE("You are currently still awaiting assignment in the larva queue. Priority is given to players who have yet to play in the round, but otherwise the ordering is based on your time of death. When you have been dead long enough and are not inactive, you will periodically receive messages where you are in the queue relative to other currently valid xeno candidates. Note: Playing as a facehugger or in the thunderdome will not alter your time of death. This means you won't lose your relative place in queue if you step away, disconnect, play as a facehugger, or play in the thunderdome.")
-			to_chat(xeno_candidate, candidate_observer.larva_queue_cached_message)
 		return FALSE
 
 	var/mob/living/carbon/xenomorph/new_xeno

--- a/code/modules/cm_aliens/structures/special/pylon_core.dm
+++ b/code/modules/cm_aliens/structures/special/pylon_core.dm
@@ -108,7 +108,6 @@
 	var/last_healed = 0
 	var/last_attempt = 0 // logs time of last attempt to prevent spam. if you want to destroy it, you must commit.
 	var/last_larva_time = 0
-	var/last_larva_queue_time = 0
 	var/last_surge_time = 0
 	var/spawn_cooldown = 30 SECONDS
 	var/surge_cooldown = 90 SECONDS
@@ -145,19 +144,11 @@
 					linked_hive.hive_ui.update_burrowed_larva()
 				qdel(worm)
 
-		var/spawning_larva = can_spawn_larva() && (last_larva_time + spawn_cooldown) < world.time
-		if(spawning_larva)
+		if(can_spawn_larva() && (last_larva_time + spawn_cooldown) < world.time)
 			last_larva_time = world.time
-		if(spawning_larva || (last_larva_queue_time + spawn_cooldown * 4) < world.time)
-			last_larva_queue_time = world.time
 			var/list/players_with_xeno_pref = get_alien_candidates()
 			if(players_with_xeno_pref && players_with_xeno_pref.len)
-				if(spawning_larva && spawn_burrowed_larva(players_with_xeno_pref[1]))
-					// We were in spawning_larva mode and successfully spawned someone
-					message_alien_candidates(players_with_xeno_pref, dequeued = 1)
-				else
-					// Just time to update everyone their queue status (or the spawn failed)
-					message_alien_candidates(players_with_xeno_pref, dequeued = 0)
+				spawn_burrowed_larva(players_with_xeno_pref[1])
 
 		if(linked_hive.hijack_burrowed_surge && (last_surge_time + surge_cooldown) < world.time)
 			last_surge_time = world.time

--- a/code/modules/mob/living/carbon/xenomorph/Embryo.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Embryo.dm
@@ -163,8 +163,6 @@
 				for(var/mob/dead/observer/cur_obs as anything in candidates)
 					if(cur_obs.ckey == hugger_ckey)
 						picked = cur_obs
-						candidates -= cur_obs
-						message_alien_candidates(candidates, dequeued = 0)
 						for(var/obj/item/alien_embryo/embryo as anything in GLOB.player_embryo_list)
 							if(embryo.hugger_ckey == cur_obs.ckey && embryo != src)
 								// Skipping src just in case an admin wants to quickly check before this thing fully deletes
@@ -174,7 +172,6 @@
 
 			if(!picked)
 				picked = candidates[1]
-				message_alien_candidates(candidates, dequeued = 1)
 
 	// Spawn the larva
 	var/mob/living/carbon/xenomorph/larva/new_xeno

--- a/code/modules/mob/living/carbon/xenomorph/death.dm
+++ b/code/modules/mob/living/carbon/xenomorph/death.dm
@@ -57,8 +57,6 @@
 
 						GLOB.hive_datum[hivenumber].stored_larva--
 						GLOB.hive_datum[hivenumber].hive_ui.update_burrowed_larva()
-					if(count)
-						message_alien_candidates(players_with_xeno_pref, dequeued = count)
 
 			if(hive && hive.living_xeno_queen == src)
 				xeno_message(SPAN_XENOANNOUNCE("A sudden tremor ripples through the hive... the Queen has been slain! Vengeance!"),3, hivenumber)


### PR DESCRIPTION
# About the pull request

This PR removes the messages informing the player about their position in queue relative to others. Since the number changes as people disconnect/reconnect/go afk/return from afk/change their preferences/etc., the number fluctuates so its just not worth informing the player about it.

# Explain why it's good for the game

It has only caused confusion and frustration despite my best efforts to explain why this is the effect and why it is desireable. See my thoughts here: https://forum.cm-ss13.com/t/rework-larva-queue/3050/35?u=drulikar My hope originally with the messages was to inform the player approximately how long it might be, but players are too focused on when their relative position is further back than it was a moment ago.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

# Changelog
:cl: Drathek
del: Removed larva queue messages
/:cl:
