### PR TITLE
New Varadero CO Survivor

### DIFF
--- a/code/modules/gear_presets/survivors.dm
+++ b/code/modules/gear_presets/survivors.dm
@@ -1371,12 +1371,12 @@
 	human.equip_to_slot_or_del(new shoespath, WEAR_FEET)
 
 /datum/equipment_preset/survivor/new_varadero/commander
-	name = "Survivor - UAASF Commander"
-	assignment = "UAASF Commander"
+	name = "Survivor - USASF Commander"
+	assignment = "USASF Commander"
 	skills = /datum/skills/commander
 	paygrade = "NO5"
 	idtype = /obj/item/card/id/gold
-	role_comm_title = "UAASF CDR"
+	role_comm_title = "USASF CDR"
 	flags = EQUIPMENT_PRESET_START_OF_ROUND
 	access = list(
 		ACCESS_CIVILIAN_PUBLIC,

--- a/code/modules/gear_presets/survivors.dm
+++ b/code/modules/gear_presets/survivors.dm
@@ -1386,7 +1386,7 @@
 		ACCESS_CIVILIAN_BRIG,
 		ACCESS_CIVILIAN_MEDBAY,
 		ACCESS_CIVILIAN_COMMAND,
-		)
+	)
 
 /datum/equipment_preset/survivor/new_varadero/commander/load_gear(mob/living/carbon/human/new_human)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/under/marine/officer/bridge(new_human), WEAR_BODY)

--- a/code/modules/gear_presets/survivors.dm
+++ b/code/modules/gear_presets/survivors.dm
@@ -1369,3 +1369,43 @@
 		return
 	var/shoespath = /obj/item/clothing/shoes/combat
 	human.equip_to_slot_or_del(new shoespath, WEAR_FEET)
+
+/datum/equipment_preset/survivor/new_varadero/commander
+	name = "Survivor - UAASF Commander"
+	assignment = "UAASF Commander"
+	skills = /datum/skills/commander
+	paygrade = "NO5"
+	idtype = /obj/item/card/id/gold
+	role_comm_title = "UAASF CDR"
+	flags = EQUIPMENT_PRESET_START_OF_ROUND
+	access = list(
+		ACCESS_CIVILIAN_PUBLIC,
+		ACCESS_CIVILIAN_RESEARCH,
+		ACCESS_CIVILIAN_ENGINEERING,
+		ACCESS_CIVILIAN_LOGISTICS,
+		ACCESS_CIVILIAN_BRIG,
+		ACCESS_CIVILIAN_MEDBAY,
+		ACCESS_CIVILIAN_COMMAND,
+		)
+
+/datum/equipment_preset/survivor/new_varadero/commander/load_gear(mob/living/carbon/human/new_human)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/under/marine/officer/bridge(new_human), WEAR_BODY)
+
+	var/obj/item/clothing/suit/storage/jacket/marine/service/suit = new()
+	suit.icon_state = "[suit.initial_icon_state]_o"
+	suit.buttoned = FALSE
+
+	var/obj/item/clothing/accessory/ranks/navy/o5/pin = new()
+	suit.attach_accessory(new_human, pin)
+
+	new_human.equip_to_slot_or_del(suit, WEAR_JACKET)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/shoes/marine/knife(new_human), WEAR_FEET)
+	new_human.equip_to_slot_or_del(new /obj/item/device/radio/headset/distress(new_human), WEAR_L_EAR)
+	new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/survival/full(new_human), WEAR_L_STORE)
+	new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/general/large(new_human), WEAR_R_STORE)
+	new_human.equip_to_slot_or_del(new /obj/item/notepad(new_human), WEAR_IN_R_STORE)
+	new_human.equip_to_slot_or_del(new /obj/item/tool/pen/fountain(new_human), WEAR_IN_R_STORE)
+	new_human.equip_to_slot_or_del(new /obj/item/storage/backpack/satchel(new_human), WEAR_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/stack/sheet/metal/med_small_stack(new_human), WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/storage/belt/gun/m4a3/m1911(new_human), WEAR_WAIST)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/head/cmcap(new_human), WEAR_HEAD)

--- a/maps/new_varadero.json
+++ b/maps/new_varadero.json
@@ -13,6 +13,9 @@
         "/datum/equipment_preset/survivor/security/lv",
         "/datum/equipment_preset/survivor/colonial_marshal/lv"
     ],
+	"CO_survivor_types": [
+        "/datum/equipment_preset/survivor/new_varadero/commander"
+    ],
 
     "defcon_triggers": [
         3300,
@@ -21,7 +24,7 @@
         580,
         0.0
     ],
-    "survivor_message": "You are an UA employee on the island outpost of New Varadero, it is vital that you do all that you can to contain the outbreak, or at least survive.",
+    "survivor_message": "You are a UA employee or visiting military official on the island outpost of New Varadero, it is vital that you do all that you can to contain the outbreak, or at least survive.",
     "map_item_type": "/obj/item/map/new_varadero",
     "announce_text": "A manual distress signal has been received from United American outpost New Varadero. A response team from the ###SHIPNAME### will be dispatched shortly to investigate.\nDesgination: Radio survey station\n\nPop: 98\nTemp: 95F : 35C ext\nRanking officer: Maj. Afric Zimmerman\nTelecommunications array: Repair required\n\nNo further information available at this time.",
     "monkey_types": [

--- a/maps/new_varadero.json
+++ b/maps/new_varadero.json
@@ -24,7 +24,7 @@
         580,
         0.0
     ],
-    "survivor_message": "You are a UA employee or visiting military official on the island outpost of New Varadero, it is vital that you do all that you can to contain the outbreak, or at least survive.",
+    "survivor_message": "You are an UA employee on the island outpost of New Varadero, it is vital that you do all that you can to contain the outbreak, or at least survive.",
     "map_item_type": "/obj/item/map/new_varadero",
     "announce_text": "A manual distress signal has been received from United American outpost New Varadero. A response team from the ###SHIPNAME### will be dispatched shortly to investigate.\nDesgination: Radio survey station\n\nPop: 98\nTemp: 95F : 35C ext\nRanking officer: Maj. Afric Zimmerman\nTelecommunications array: Repair required\n\nNo further information available at this time.",
     "monkey_types": [


### PR DESCRIPTION
# About the pull request

Adds a USASF Commander as a CO survivor to New Varadero. The idea is the commander was visiting the outpost when the xeno infestation started. Lore and flavor is up for grabs if someone has a better way to make the role naval.

# Explain why it's good for the game

It's neat.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
add: Added a visiting USASF Commander (CO survivor) to New Varadero
/:cl:
