### PR TITLE
Foxtrot total number nerf

### DIFF
--- a/code/datums/emergency_calls/cryo_marines.dm
+++ b/code/datums/emergency_calls/cryo_marines.dm
@@ -3,7 +3,7 @@
 //whiskey outpost extra marines
 /datum/emergency_call/cryo_squad
 	name = "Marine Cryo Reinforcements (Squad)"
-	mob_max = 15
+	mob_max = 10
 	mob_min = 1
 	probability = 0
 	objectives = "Assist the USCM forces"


### PR DESCRIPTION

# About the pull request

This PR reduces max marines from foxtrot from 15 to 10.

# Explain why it's good for the game

Current potential gain from foxtrot is too high.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
balance: Marines called with foxtrot nerfed from 15 to 10.
/:cl:
