### PR TITLE
Fix marines not getting first dibs if they ghost

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/Embryo.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Embryo.dm
@@ -152,7 +152,13 @@
 		if(affected_mob.first_xeno || (affected_mob.client && affected_mob.client.prefs && (affected_mob.client.prefs.be_special & BE_ALIEN_AFTER_DEATH) && !jobban_isbanned(affected_mob, JOB_XENOMORPH)))
 			picked = affected_mob
 		else if(affected_mob.mind && affected_mob.mind.ghost_mob && affected_mob.client && affected_mob.client.prefs && (affected_mob.client.prefs.be_special & BE_ALIEN_AFTER_DEATH) && !jobban_isbanned(affected_mob, JOB_XENOMORPH))
-			picked = affected_mob.mind.ghost_mob
+			picked = affected_mob.mind.ghost_mob // This currently doesn't look possible
+		else if(affected_mob.persistent_ckey)
+			for(var/mob/dead/observer/cur_obs as anything in GLOB.observer_list)
+				if(cur_obs.ckey == affected_mob.persistent_ckey)
+					if(cur_obs.client && cur_obs.client.prefs && (cur_obs.client.prefs.be_special & BE_ALIEN_AFTER_DEATH) && !jobban_isbanned(cur_obs, JOB_XENOMORPH))
+						picked = cur_obs
+					break
 
 	if(!picked)
 		// Get a candidate from observers

--- a/code/modules/mob/living/carbon/xenomorph/Embryo.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Embryo.dm
@@ -149,16 +149,17 @@
 	var/mob/picked
 	// If the bursted person themselves has Xeno enabled, they get the honor of first dibs on the new larva.
 	if((!isyautja(affected_mob) || (isyautja(affected_mob) && prob(20))) && istype(affected_mob.buckled, /obj/structure/bed/nest))
-		if(affected_mob.first_xeno || (affected_mob.client && affected_mob.client.prefs && (affected_mob.client.prefs.be_special & BE_ALIEN_AFTER_DEATH) && !jobban_isbanned(affected_mob, JOB_XENOMORPH)))
+		if(affected_mob.first_xeno || (affected_mob.client?.prefs?.be_special & BE_ALIEN_AFTER_DEATH && !jobban_isbanned(affected_mob, JOB_XENOMORPH)))
 			picked = affected_mob
-		else if(affected_mob.mind && affected_mob.mind.ghost_mob && affected_mob.client && affected_mob.client.prefs && (affected_mob.client.prefs.be_special & BE_ALIEN_AFTER_DEATH) && !jobban_isbanned(affected_mob, JOB_XENOMORPH))
+		else if(affected_mob.mind?.ghost_mob && affected_mob.client?.prefs?.be_special & BE_ALIEN_AFTER_DEATH && !jobban_isbanned(affected_mob, JOB_XENOMORPH))
 			picked = affected_mob.mind.ghost_mob // This currently doesn't look possible
 		else if(affected_mob.persistent_ckey)
 			for(var/mob/dead/observer/cur_obs as anything in GLOB.observer_list)
-				if(cur_obs.ckey == affected_mob.persistent_ckey)
-					if(cur_obs.client && cur_obs.client.prefs && (cur_obs.client.prefs.be_special & BE_ALIEN_AFTER_DEATH) && !jobban_isbanned(cur_obs, JOB_XENOMORPH))
-						picked = cur_obs
-					break
+				if(cur_obs.ckey != affected_mob.persistent_ckey)
+					continue
+				if(cur_obs?.client?.prefs?.be_special & BE_ALIEN_AFTER_DEATH && !jobban_isbanned(cur_obs, JOB_XENOMORPH))
+					picked = cur_obs
+				break
 
 	if(!picked)
 		// Get a candidate from observers


### PR DESCRIPTION

# About the pull request

This PR fixes an issue where hugged marines that burst were not getting first dibs on the larva if they ghosted. Previously the mind maybe wasn't cleared out to find the ghost mob, but it currently is.

NOTE: The existing check requiring the marine to be nested is still in place to get first dibs. I'm honestly not sure if this check should still exist. On one hand I can agree it might be hard for the marine trying to get help to suddenly become the larva and switch gears - they are still going to be in the mindset of a marine that the larva should die. But its also sort of weird to only get the first dibs if nested. If xenos are unnesting hugged marines just before they pop, thats already a mechanic abuse that should be ahelped; but ideally there wouldn't be anything to be abused. Also, some may consider this kind of larva undesirable anyways so maybe they'd prefer the marine to have it... So let me know if I should just remove the nested check on line 151.

# Explain why it's good for the game

Fixes an unintended consequence of ghosting when hugged that would prevent that marine from getting their first dibs on the larva.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![dibs](https://github.com/cmss13-devs/cmss13/assets/76988376/84e44345-2b83-473f-9997-f7865bcef1dd)

</details>


# Changelog
:cl: Drathek
fix: Fix ghosting preventing first dibs on the larva in a hugged marine
/:cl:
