### PR TITLE
Larva Queue Late Joiner Nerf

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -290,20 +290,15 @@
  * * cache_only - Whether to not actually send a to_chat message and instead only update larva_queue_cached_message
  */
 /proc/message_alien_candidates(list/candidates, dequeued, cache_only = FALSE)
-	var/new_players = 0
 	for(var/i in (1 + dequeued) to candidates.len)
 		var/mob/dead/observer/cur_obs = candidates[i]
 
 		// Generate the messages
-		var/cached_message = SPAN_XENONOTICE("You are currently [i-dequeued]\th in the larva queue. There are [new_players] ahead of you that have yet to play this round.")
+		var/cached_message = SPAN_XENONOTICE("You are currently [i-dequeued]\th in the larva queue.")
 		cur_obs.larva_queue_cached_message = cached_message
 		if(!cache_only)
 			var/chat_message = dequeued ? replacetext(cached_message, "currently", "now") : cached_message
 			to_chat(candidates[i], chat_message)
-
-		// Count how many are prioritized
-		if(cur_obs.client.player_details.larva_queue_time < 2) // 0 and 1 because facehuggers/t-domers are slightly deprioritized
-			new_players++
 
 /proc/convert_k2c(temp)
 	return ((temp - T0C))

--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -383,7 +383,7 @@ Additional game mode variables.
 				return FALSE
 
 			// We aren't in queue yet, lets teach them about the queue then
-			candidate_observer.larva_queue_cached_message = SPAN_XENONOTICE("You are currently still awaiting assignment in the larva queue. Priority is given to players who have yet to play in the round, but otherwise the ordering is based on your time of death. When you have been dead long enough and are not inactive, you will periodically receive messages where you are in the queue relative to other currently valid xeno candidates. Note: Playing as a facehugger or in the thunderdome will not alter your time of death. This means you won't lose your relative place in queue if you step away, disconnect, play as a facehugger, or play in the thunderdome.")
+			candidate_observer.larva_queue_cached_message = SPAN_XENONOTICE("You are currently awaiting assignment in the larva queue. The ordering is based on your time of death or the time you joined. When you have been dead long enough and are not inactive, you will periodically receive messages where you are in the queue relative to other currently valid xeno candidates. Your current position will shift as others change their preferences or go inactive, but your relative position compared to all observers is the same. Note: Playing as a facehugger or in the thunderdome will not alter your time of death. This means you won't lose your relative place in queue if you step away, disconnect, play as a facehugger, or play in the thunderdome.")
 			to_chat(xeno_candidate, candidate_observer.larva_queue_cached_message)
 		return FALSE
 

--- a/code/modules/client/player_details.dm
+++ b/code/modules/client/player_details.dm
@@ -10,6 +10,9 @@ GLOBAL_LIST_EMPTY(player_details) // ckey -> /datum/player_details
 	/// The descriminator for larva queue ordering: Generally set to timeofdeath except for facehuggers/admin z-level play
 	var/larva_queue_time
 
+/datum/player_details/New()
+	larva_queue_time = world.time
+	return ..()
 
 /proc/log_played_names(ckey, ...)
 	if(!ckey)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -367,7 +367,6 @@ Works together with spawning an observer, noted above.
 
 		// Larva queue: We use the larger of their existing queue time or the new timeofdeath except for facehuggers
 		// We don't change facehugger timeofdeath because they are still on cooldown if they died as a hugger
-		// Facehuggers are atleast 1 because they did get some action compared to those at 0 timeofdeath
 		var/new_tod = isfacehugger(src) ? 1 : ghost.timeofdeath
 		ghost.client.player_details.larva_queue_time = max(ghost.client.player_details.larva_queue_time, new_tod)
 

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -412,7 +412,10 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		var/mob/dead/observer/ghost = ghostize((is_nested && nest && !QDELETED(nest))) //FALSE parameter is so we can never re-enter our body, "Charlie, you can never come baaaack~" :3
 		if(ghost && !is_admin_level(z))
 			ghost.timeofdeath = world.time
-			ghost.client?.player_details.larva_queue_time = world.time
+
+			// Larva queue: We use the larger of their existing queue time or the new timeofdeath except for facehuggers
+			var/new_tod = isfacehugger(src) ? 1 : world.time
+			ghost.client?.player_details.larva_queue_time = max(ghost.client.player_details.larva_queue_time, new_tod)
 		if(is_nested && nest && !QDELETED(nest))
 			ghost.can_reenter_corpse = FALSE
 			nest.ghost_of_buckled_mob = ghost

--- a/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
@@ -156,7 +156,6 @@
 		for(var/mob/dead/observer/observer as anything in GLOB.observer_list)
 			to_chat(observer, SPAN_DEADSAY("<b>[human]</b> has been facehugged by <b>[src]</b>" + " [OBSERVER_JMP(observer, human)]"))
 		to_chat(src, SPAN_DEADSAY("<b>[human]</b> has been facehugged by <b>[src]</b>"))
-	timeofdeath = 1 // Ever so slightly deprioritized for larva queue
 	qdel(src)
 	if(hug_area)
 		xeno_message(SPAN_XENOMINORWARNING("You sense that [src] has facehugged a host at \the [hug_area]!"), 1, src.hivenumber)


### PR DESCRIPTION
# About the pull request

This PR makes it so players who haven't played yet have their join time recorded, and that is used for their initial sorting value rather than 0. This means late joiners will be at the back of the line as if they had just died.

This PR also fixes an oversight where ghosting as a facehugger would count as death. Even though they really shouldn't be ghosting when alive, they still shouldn't be penalized as far as the queue is concerned.

# Explain why it's good for the game

Its not; its a bad experience for everyone that hasn't even gotten one life in the round. However it seems I'm in the minority thinking that a xeno shouldn't squander their first life and that death shouldn't bear more consequences.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

The new informational message if you press join as xeno while currently ineligible to be a xeno candidate:
![image](https://github.com/cmss13-devs/cmss13/assets/76988376/9fb295c2-e654-4843-9e3e-bf37f2c8755e)

</details>


# Changelog
:cl: Drathek
del: Remove first life priority for larva queue
fix: Fix ghosting as a facehugger counting as death for the larva queue
/:cl:
