### PR TITLE
Fix Larva and Ovi Queen Ghost Icons

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/Larva.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Larva.dm
@@ -138,6 +138,9 @@
 	else
 		icon_state = "[state_override || state]Larva"
 
+/mob/living/carbon/xenomorph/larva/alter_ghost(mob/dead/observer/ghost)
+	ghost.icon_state = "[caste.caste_type]"
+
 /mob/living/carbon/xenomorph/larva/handle_name()
 	return
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
@@ -940,3 +940,7 @@
 
 	// Switch icon back and then let normal icon behavior happen
 	Queen.icon = Queen.queen_standing_icon
+
+/mob/living/carbon/xenomorph/queen/alter_ghost(mob/dead/observer/ghost)
+	ghost.icon = queen_standing_icon
+	return ..()


### PR DESCRIPTION

# About the pull request

This PR fixes the ghost sprite for larva and ovi queens.

# Explain why it's good for the game

Fixes #3308 and ovi queen ghost sprites.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/cmss13-devs/cmss13/assets/76988376/3283ae49-7013-47cb-8831-aa5717e2677f)

</details>


# Changelog
:cl: Drathek
fix: Fixed ghost icons for larva and ovi queen
/:cl:
