### PR TITLE
Removes nesting the dead

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
@@ -712,6 +712,10 @@
 		to_chat(src, SPAN_XENONOTICE("This is not a host."))
 		return
 
+	if(current_mob.stat == DEAD)
+		to_chat(src, SPAN_XENONOTICE("This host is dead."))
+		return
+
 	var/mob/living/carbon/human/host_to_nest = current_mob
 
 	var/found_grab = FALSE


### PR DESCRIPTION

# About the pull request

This PR makes it impossible to nest the dead.

# Explain why it's good for the game

Dead people being placed on resin walls to create magical bullet shields is not the intention of nests.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
del: Removed nesting the dead
/:cl:
