### PR TITLE
Fixes extraneous messages in regards to wall nests

### DIFF
--- a/code/game/turfs/walls/walls.dm
+++ b/code/game/turfs/walls/walls.dm
@@ -98,11 +98,15 @@
 					qdel(found_nest) //nests are built on walls, no walls, no nest
 
 /turf/closed/wall/MouseDrop_T(mob/current_mob, mob/user)
+	if(!ismob(current_mob))
+		return
+
 	if(acided_hole)
 		if(current_mob == user && isxeno(user))
 			acided_hole.use_wall_hole(user)
 			return
-	if(isxeno(user))
+
+	if(isxeno(user) && istype(user.get_active_hand(), /obj/item/grab))
 		var/mob/living/carbon/xenomorph/user_as_xenomorph = user
 		user_as_xenomorph.do_nesting_host(current_mob, src)
 	..()

--- a/code/modules/cm_aliens/weeds.dm
+++ b/code/modules/cm_aliens/weeds.dm
@@ -418,7 +418,11 @@
 
 /obj/effect/alien/weeds/weedwall/MouseDrop_T(mob/current_mob, mob/user)
 	. = ..()
-	if(isxeno(user))
+
+	if(!ismob(current_mob))
+		return
+
+	if(isxeno(user) && istype(user.get_active_hand(), /obj/item/grab))
 		var/mob/living/carbon/xenomorph/user_as_xenomorph = user
 		user_as_xenomorph.do_nesting_host(current_mob, src)
 


### PR DESCRIPTION

# About the pull request

Mouse drop was not checking for if you were actually grabbing something before passing to the proc like in the other areas it is called which caused extraneous messages.

Also, mouse drop does not guarantee a mob being passed which was causing extraneous and confusing messages when dropping wall resin onto a wall while dragging something.

# Explain why it's good for the game

Confusing and extraneous messages bad.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
fix: Fixed extraneous messages in regards to wall nests
/:cl:
