### PR TITLE
Gives the M4A3 service pistol the correct lore accurate magazine size

### DIFF
--- a/code/modules/projectiles/magazines/pistols.dm
+++ b/code/modules/projectiles/magazines/pistols.dm
@@ -8,7 +8,7 @@
 	caliber = "9mm"
 	icon = 'icons/obj/items/weapons/guns/ammo_by_faction/uscm.dmi'
 	icon_state = "m4a3"
-	max_rounds = 9
+	max_rounds = 12
 	w_class = SIZE_SMALL
 	default_ammo = /datum/ammo/bullet/pistol
 	gun_type = /obj/item/weapon/gun/pistol/m4a3


### PR DESCRIPTION

# About the pull request

This PR changes the M4A3 magazine size from 9 to 12

# Explain why it's good for the game

https://i.imgur.com/fefeBtF.png

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: SpartanBobby
balance: changes M4A3 magazine size from 9 to 12
/:cl:
