### PR TITLE
Stops xenos from bypassing dead moving via roller beds

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -208,8 +208,8 @@
 			return
 	..()
 
-/obj/structure/bed/roller/Collided(atom/movable/AM)
-	if(!isxeno(AM))
+/obj/structure/bed/roller/Collided(atom/movable/moving_atom)
+	if(!isxeno(moving_atom))
 		return ..()
 
 	if(buckled_mob && buckled_mob.stat != DEAD)

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -208,6 +208,20 @@
 			return
 	..()
 
+/obj/structure/bed/roller/Collided(atom/movable/AM)
+	if(!isxeno(AM))
+		return ..()
+
+	if(buckled_mob && buckled_mob.stat != DEAD)
+		return ..()
+
+	if(buckled_bodybag)
+		var/mob/mob_in_bodybag = locate(/mob) in buckled_bodybag
+		if(mob_in_bodybag && mob_in_bodybag.stat != DEAD)
+			return ..()
+
+	return
+
 /obj/item/roller
 	name = "roller bed"
 	desc = "A collapsed roller bed that can be carried around."


### PR DESCRIPTION

# About the pull request

This PR makes it so a roller bed with a dead person on it now is unmovable. Can still be moved if unconscious or alive so as to mimic current restrictions.

# Explain why it's good for the game

This has been a longstanding ruling issue that we can now just let be mechanically prevented. Less rule bloat good.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
fix: Stops xenos from bypassing dead moving via roller beds
/:cl:
