### PR TITLE
Create humans tweaks

### DIFF
--- a/code/modules/admin/tabs/event_tab.dm
+++ b/code/modules/admin/tabs/event_tab.dm
@@ -744,7 +744,7 @@
 		create_humans_html = replacetext(create_humans_html, "null /* object types */", "\"[equipment_presets]\"")
 		create_humans_html = replacetext(create_humans_html, "/* href token */", RawHrefToken(forceGlobal = TRUE))
 
-	show_browser(user, replacetext(create_humans_html, "/* ref src */", "\ref[src]"), "Create Humans", "create_humans", "size=450x630")
+	show_browser(user, replacetext(create_humans_html, "/* ref src */", "\ref[src]"), "Create Humans", "create_humans", "size=450x720")
 
 /client/proc/create_humans()
 	set name = "Create Humans"

--- a/html/create_humans.html
+++ b/html/create_humans.html
@@ -11,7 +11,7 @@
 		<input type="hidden" name="admin_token" value="/* href token */">
 		Amount of humans: <input type="text" name="object_count" value="1" style="width:30px">
 		<br>
-		Range to spawn in: <input type="text" name="object_range" value="1" style="width:30px">
+		Range to spawn in: <input type="text" name="object_range" value="0" style="width:30px">
 		<br><br>
 		Spawn mobs as: <br>
 		<input type="radio" class="radioButton" name="spawn_as" value="none" checked="checked"> Regular<br>


### PR DESCRIPTION

# About the pull request

This PR adds extra length to the create humans menu so you don't have to scroll every time.

This PR sets the default "range to spawn" variable to 0 as we don't really want variance unless it is an active decision to do so.

# Explain why it's good for the game

Easier usage of admin tools good.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
qol: Create humans tab length increase
qol: Create humans tab now defaults to 0 range to spawn
/:cl:
