### PR TITLE
Buffs trashbags

### DIFF
--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -31,7 +31,8 @@
 
 	w_class = SIZE_LARGE
 	max_w_class = SIZE_MEDIUM
-	storage_slots = 21
+	storage_slots = null
+	max_storage_space = 21 //equivalent to an IMP backpack
 	can_hold = list() // any
 	cant_hold = list(/obj/item/disk/nuclear, /obj/item/weapon/throwing_knife)
 
@@ -39,13 +40,18 @@
 	flags_equip_slot = NONE
 
 /obj/item/storage/bag/trash/update_icon()
-	if(length(contents) == 0)
+	var/sum_storage_cost = 0
+	for(var/obj/item/item in contents)
+		sum_storage_cost += item.get_storage_cost()
+
+	if(!sum_storage_cost)
 		icon_state = "trashbag0"
-	else if(length(contents) < 12)
+	else if(sum_storage_cost < round(max_storage_space * 0.35))
 		icon_state = "trashbag1"
-	else if(length(contents) < 21)
+	else if(sum_storage_cost < round(max_storage_space * 0.7))
 		icon_state = "trashbag2"
-	else icon_state = "trashbag3"
+	else
+		icon_state = "trashbag3"
 
 // -----------------------------
 // Plastic Bag

--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -30,24 +30,22 @@
 	item_state = "trashbag"
 
 	w_class = SIZE_LARGE
-	max_w_class = SIZE_SMALL
+	max_w_class = SIZE_MEDIUM
 	storage_slots = 21
 	can_hold = list() // any
 	cant_hold = list(/obj/item/disk/nuclear, /obj/item/weapon/throwing_knife)
 
 	storage_flags = STORAGE_GATHER_SIMULTAENOUSLY|STORAGE_QUICK_GATHER|STORAGE_CLICK_GATHER
+	flags_equip_slot = NONE
 
 /obj/item/storage/bag/trash/update_icon()
-	if(contents.len == 0)
+	if(length(contents) == 0)
 		icon_state = "trashbag0"
-	else if(contents.len < 12)
+	else if(length(contents) < 12)
 		icon_state = "trashbag1"
-	else if(contents.len < 21)
+	else if(length(contents) < 21)
 		icon_state = "trashbag2"
 	else icon_state = "trashbag3"
-
-/obj/item/storage/bag/trash/open(mob/user)
-	return
 
 // -----------------------------
 // Plastic Bag
@@ -183,7 +181,7 @@
 //Turned numbered display on. Appears to work as intended, despite above comment -- Vanagandr.
 
 /obj/item/storage/bag/sheetsnatcher/orient2hud()
-	var/adjusted_contents = contents.len
+	var/adjusted_contents = length(contents)
 
 	//Numbered contents display
 	var/list/datum/numbered_display/numbered_contents


### PR DESCRIPTION
# About the pull request

- Trashbags can now be looked through like boxes
- Trashbags now fit normal-sized items
- Trashbags no longer fit as a belt
- Trashbags have the same storage limits as a backpack

# Explain why it's good for the game

- If you accidentally put something in the bag, the only way to get it out is by dumping it into disposals, which is bad UX
- This might be me coping, but holy hell is it annoying to not be able to put still-small things like grenade packets and shoes in a trashbag to throw away
- It occurred to me that marines might take the bag as a belt with these changes, to be a better G8 pouch, so I removed the ability to do that. This should not affect the primary users of trashbags (WJs) because they aren't allowed to remove their toolbelts in the first place 
- This makes trashbags worse backpacks, which morrow was alright with


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

<img width="391" alt="image" src="https://github.com/cmss13-devs/cmss13/assets/41448081/4cbd8867-4587-4c9e-a40e-52f0230e1d6f">

</details>


# Changelog
:cl:
balance: Trashbags now hold normal items and can be looked through like a box or storage container.
balance: Trashbags no longer fit in your belt slot.
/:cl:
