### PR TITLE
Fix launch_towards ordering for facehuggers

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
@@ -240,8 +240,8 @@
 	if(!target)
 		return FALSE
 
-	target.visible_message(SPAN_WARNING("\The scuttling [src] leaps at [target]!"), \
-	SPAN_WARNING("The scuttling [src] leaps at [target]!"))
+	target.visible_message(SPAN_WARNING("[src] leaps at [target]!"), \
+	SPAN_WARNING("[src] leaps at [target]!"))
 	leaping = TRUE
 	throw_atom(target, 3, SPEED_FAST)
 	return TRUE

--- a/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
@@ -191,9 +191,9 @@
 	return FALSE
 
 /obj/item/clothing/mask/facehugger/launch_towards(datum/launch_metadata/LM)
-	..()
 	if(stat == CONSCIOUS)
 		icon_state = "[initial(icon_state)]_thrown"
+	..()
 
 /obj/item/clothing/mask/facehugger/launch_impact(atom/hit_atom)
 	. = ..()


### PR DESCRIPTION

# About the pull request

This PR simply fixes the order of logic that is altering facehuggers so the launch_towards icon change occurs before launch_impact.

# Explain why it's good for the game

Fixes situations like https://media.discordapp.net/attachments/1069150999517868066/1126358950707728384/gank_chamber.mp4

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Example of two huggers:
![leap](https://github.com/cmss13-devs/cmss13/assets/76988376/86767e97-334f-4b52-b95d-2b5747fe7bd6)

Order of events for three huggers:
![image](https://github.com/cmss13-devs/cmss13/assets/76988376/17cefebc-80e8-4a52-b606-3090e2fa3e57)

</details>


# Changelog
:cl: Drathek
fix: Fixed facehuggers incorrectly displaying thrown state when it has landed
/:cl:
