### PR TITLE
Working Joes no longer can have a gradient on their rare hair.

### DIFF
--- a/code/modules/gear_presets/synths.dm
+++ b/code/modules/gear_presets/synths.dm
@@ -532,6 +532,8 @@
 	new_human.h_style = "Bald"
 	new_human.f_style = "Shaved"
 	if(prob(5))
+		if(new_human.grad_style != "None") //if person had Hair Dye trait on character used to load in Working Joe, this forces off the gradient
+			new_human.grad_style = "None"
 		new_human.h_style = "Shoulder-length Hair" //Added the chance of hair as per Monkeyfist lore accuracy
 	new_human.r_eyes = 0
 	new_human.g_eyes = 0

--- a/code/modules/gear_presets/synths.dm
+++ b/code/modules/gear_presets/synths.dm
@@ -532,8 +532,7 @@
 	new_human.h_style = "Bald"
 	new_human.f_style = "Shaved"
 	if(prob(5))
-		if(new_human.grad_style != "None") //if person had Hair Dye trait on character used to load in Working Joe, this forces off the gradient
-			new_human.grad_style = "None"
+		new_human.grad_style = "None" //No gradients for Working Joes
 		new_human.h_style = "Shoulder-length Hair" //Added the chance of hair as per Monkeyfist lore accuracy
 	new_human.r_eyes = 0
 	new_human.g_eyes = 0


### PR DESCRIPTION

# About the pull request

Resolves oversight that allows for a user to have their own hair color as a Working Joe by enabling Gradient in character select, to avoid accidently overriding the default hair color. Fixes #3820

# Explain why it's good for the game

While WJs are whitelisted, this mechanical enforcement is more so to prevent accidents from when people join as Working Joe without removing gradients, as a person should not need to design a character to fit a role that should overwrite that in the first place.

# Changelog
:cl:
fix: Working Joes can no longer have a gradient on their rare hair spawn.
/:cl:
