### PR TITLE
New CAS Weapon: BLU-200 Dragons Breath, thermobaric bomb

### DIFF
--- a/code/modules/cm_marines/dropship_ammo.dm
+++ b/code/modules/cm_marines/dropship_ammo.dm
@@ -348,8 +348,8 @@
 	QDEL_IN(src, 0.5 SECONDS)
 
 /obj/structure/ship_ammo/rocket/thermobaric
-	name = "\improper BLU-200 'Dragonbreath'"
-	desc = "The BLU-200 Dragonbreath a thermobaric fuel-air bomb. The aerosolized fuel mixture creates a vacuum when ignited causing serious damage to those in its way."
+	name = "\improper BLU-200 'Dragons Breath'"
+	desc = "The BLU-200 Dragons Breath a thermobaric fuel-air bomb. The aerosolized fuel mixture creates a vacuum when ignited causing serious damage to those in its way."
 	icon_state = "fatty"
 	ammo_id = "f"
 	travelling_time = 50

--- a/code/modules/cm_marines/dropship_ammo.dm
+++ b/code/modules/cm_marines/dropship_ammo.dm
@@ -353,12 +353,12 @@
 	icon_state = "fatty"
 	ammo_id = "f"
 	travelling_time = 50
-	point_cost = 500
+	point_cost = 300
 	fire_mission_delay = 4
 
 /obj/structure/ship_ammo/rocket/thermobaric/detonate_on(turf/impact)
 	impact.ceiling_debris_check(3)
-	fire_spread(impact, create_cause_data(initial(name), source_mob), 4, 25, 50, "#c96500") //Very intense but the fire doesn't last very long
+	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(fire_spread), impact, create_cause_data(initial(name), source_mob), 4, 25, 50, "#c96500"), 0.5 SECONDS) //Very intense but the fire doesn't last very long
 	for(var/mob/living/carbon/victim in orange(5, impact))
 		victim.throw_atom(impact, 3, 15, src, TRUE) // Implosion throws affected towards center of vacuum
 	QDEL_IN(src, 0.5 SECONDS)

--- a/code/modules/cm_marines/dropship_ammo.dm
+++ b/code/modules/cm_marines/dropship_ammo.dm
@@ -347,6 +347,21 @@
 	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(fire_spread), impact, create_cause_data(initial(name), source_mob), 6, 60, 30, "#EE6515"), 0.5 SECONDS) //Color changed into napalm's color to better convey how intense the fire actually is.
 	QDEL_IN(src, 0.5 SECONDS)
 
+/obj/structure/ship_ammo/rocket/thermobaric
+	name = "\improper BLU-200 'Dragonbreath'"
+	desc = "The BLU-200 Dragonbreath a thermobaric fuel-air bomb. The aerosolized fuel mixture creates a vacuum when ignited causing serious damage to those in its way."
+	icon_state = "fatty"
+	ammo_id = "f"
+	travelling_time = 50
+	point_cost = 500
+	fire_mission_delay = 4
+
+/obj/structure/ship_ammo/rocket/thermobaric/detonate_on(turf/impact)
+	impact.ceiling_debris_check(3)
+	fire_spread(impact, create_cause_data(initial(name), source_mob), 4, 25, 50, "#c96500") //Very intense but the fire doesn't last very long
+	for(var/mob/living/carbon/victim in orange(5, impact))
+		victim.throw_atom(impact, 3, 15, src, TRUE) // Implosion throws affected towards center of vacuum
+	QDEL_IN(src, 0.5 SECONDS)
 
 
 //minirockets


### PR DESCRIPTION

# About the pull request

Adds a crowd control option to CAS missile options, to help incentivize people away from CAS Metabuilds.

- Fire equivalent of the Banshee but without the impact damage.
- Implosion from fuel-air bomb pulls nearby units towards the center.
- 500 points (Expensive)

# Explain why it's good for the game

Missiles on CAS are super expensive and rarely make their points back.  In order to give the missile rack some punch and give it capabilities the other higher damage weapons dont have, we give it a bit of CC.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Added new CAS Missile: BLU-200 Dragons Breath
/:cl:
