### PR TITLE
Increases default window sizes for paper and desc_lore windows

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -439,7 +439,7 @@ Parameters are passed from New.
 		return TRUE
 
 	if(href_list["desc_lore"])
-		show_browser(usr, "<BODY><TT>[replacetext(desc_lore, "\n", "<BR>")]</TT></BODY>", name, name, "size=500x200")
+		show_browser(usr, "<BODY><TT>[replacetext(desc_lore, "\n", "<BR>")]</TT></BODY>", name, name, "size=500x500")
 		onclose(usr, "[name]")
 
 ///This proc is called on atoms when they are loaded into a shuttle

--- a/code/modules/admin/verbs/custom_paper.dm
+++ b/code/modules/admin/verbs/custom_paper.dm
@@ -19,7 +19,7 @@
 		if(new_sheet)
 			qdel(sheet)
 		return
-	show_browser(usr, "<body class='paper'>[new_text]</body>", "Custom paper preview", "custom_paper_preview", "size=500x400")
+	show_browser(usr, "<body class='paper'>[new_text]</body>", "Custom paper preview", "custom_paper_preview", "size=650x900")
 	if(alert(usr, "Make this new content?", "Customising [new_name]", "OK", "Cancel") == "Cancel")
 		close_browser(usr, "custom_paper_preview")
 		if(new_sheet)

--- a/code/modules/admin/verbs/custom_paper.dm
+++ b/code/modules/admin/verbs/custom_paper.dm
@@ -19,7 +19,7 @@
 		if(new_sheet)
 			qdel(sheet)
 		return
-	show_browser(usr, "<body class='paper'>[new_text]</body>", "Custom paper preview", "custom_paper_preview", "size=650x900")
+	show_browser(usr, "<body class='paper'>[new_text]</body>", "Custom paper preview", "custom_paper_preview", "size=650x700")
 	if(alert(usr, "Make this new content?", "Customising [new_name]", "OK", "Cancel") == "Cancel")
 		close_browser(usr, "custom_paper_preview")
 		if(new_sheet)

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -81,7 +81,7 @@
 			if(photo_list)
 				for(var/photo in photo_list)
 					user << browse_rsc(photo_list[photo], photo)
-			show_browser(user, "<BODY class='paper'>[stars(info)][stamps]</BODY>", name, name)
+			show_browser(user, "<BODY class='paper'>[stars(info)][stamps]</BODY>", name, name, "size=650x700")
 			onclose(user, name)
 		else
 			read_paper(user)
@@ -94,7 +94,7 @@
 	if(photo_list)
 		for(var/photo in photo_list)
 			user << browse_rsc(photo_list[photo], photo)
-	show_browser(user, "<BODY class='paper'>[info][stamps]</BODY>", name, name)
+	show_browser(user, "<BODY class='paper'>[info][stamps]</BODY>", name, name, "size=650x700")
 	onclose(user, name)
 
 /obj/item/paper/verb/rename()


### PR DESCRIPTION

# About the pull request

This PR adjusts the window size for both paper (including faxes) and desc_lore preview windows. Paper previews were made both wider and longer so most custom templates currently used by staff load in immediately. lore_desc is made about twice as longer by default, again to enhance its initial readability and account for the fact that both windows are meant to be text heavy. This was also going to fix desc_lore not interpreting HTML tags properly, but that apparently fixed itself. We can probably safely bet that in the year 2023 people play CM on resolutions greater than 800x600.

# Explain why it's good for the game

Both windows were comically too small by default, seemingly both running on the assumption that people still run SS13 in 640x480. This PR makes it so you can read paper and/or lore without having to start each time by resizing your window. Having our default window sizes actually more or less match expected content in the window is a positive all around.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:silencer_pl
qol: Default paper and desc_lore viewing windows are now larger to match the expected content in them better.
/:cl:
