### PR TITLE
Donor gear is now manually claimed.

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -398,7 +398,6 @@ SUBSYSTEM_DEF(ticker)
 		var/mob/M = J.spawn_in_player(player)
 		if(istype(M))
 			J.equip_job(M)
-			EquipCustomItems(M)
 
 			if(M.client)
 				var/client/C = M.client
@@ -428,7 +427,6 @@ SUBSYSTEM_DEF(ticker)
 				captainless = FALSE
 			if(player.job)
 				RoleAuthority.equip_role(player, RoleAuthority.roles_by_name[player.job], late_join = FALSE)
-				EquipCustomItems(player)
 			if(player.client)
 				var/client/C = player.client
 				if(C.player_data && C.player_data.playtime_loaded && length(C.player_data.playtimes) == 0)

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -404,6 +404,8 @@ var/list/roundstart_mod_verbs = list(
 	if(!ishuman(mob))
 		to_chat(usr, SPAN_WARNING("You need to be a living human to do this."))
 		return FALSE
+	log_game("[key_name(mob)] claimed their donor gear at [get_area_name(mob)].")//No gaming it in the field for free stuff.
+	mob.attack_log += text("\[[time_stamp()]\] <font color='orange'>[key_name(mob)] claimed their donor gear at [get_area_name(mob)].</font>")
 	EquipCustomItems(mob)
 	return TRUE
 

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -398,6 +398,8 @@ var/list/roundstart_mod_verbs = list(
 	set name = "Claim Donor Gear"
 	if(!donator)
 		to_chat(usr, SPAN_WARNING("You are not a donator. How did you get this?"))
+		log_debug("[key_name(mob)] attempted to claim donor gear without being on the donor list.")
+		remove_verb(src, /client/proc/claim_donor)//Little bit of self-policing.
 		return FALSE
 	if(!ishuman(mob))
 		to_chat(usr, SPAN_WARNING("You need to be a living human to do this."))

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -393,6 +393,17 @@ var/list/roundstart_mod_verbs = list(
 		prefs.save_preferences()
 	return
 
+/client/proc/claim_donor()
+	set category = "OOC.Donor"
+	set name = "Claim Donor Gear"
+	if(!donator)
+		to_chat(usr, SPAN_WARNING("You are not a donator. How did you get this?"))
+		return FALSE
+	if(!ishuman(mob))
+		to_chat(usr, SPAN_WARNING("You need to be a living human to do this."))
+		return FALSE
+	EquipCustomItems(mob)
+	return TRUE
 
 #define MAX_WARNS 3
 #define AUTOBANTIME 10

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -437,7 +437,7 @@ GLOBAL_LIST_INIT(whitelisted_client_procs, list(
 			src.donator = 1
 			add_verb(src, /client/proc/set_ooc_color_self)
 			add_verb(src, /client/proc/claim_donor)
-			to_chat(src, SPAN_WARNING("If you have special donor gear, you may claim it from the OOC tab."))
+			to_chat(src, SPAN_YAUTJABOLDBIG("If you have special donor gear, you may claim it from the OOC tab."))
 
 	//if(prefs.window_skin & TOGGLE_WINDOW_SKIN)
 	// set_night_skin()

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -436,6 +436,8 @@ GLOBAL_LIST_INIT(whitelisted_client_procs, list(
 		if(src.ckey == line)
 			src.donator = 1
 			add_verb(src, /client/proc/set_ooc_color_self)
+			add_verb(src, /client/proc/claim_donor)
+			to_chat(src, SPAN_WARNING("If you have special donor gear, you may claim it from the OOC tab."))
 
 	//if(prefs.window_skin & TOGGLE_WINDOW_SKIN)
 	// set_night_skin()

--- a/code/modules/customitems/item_spawning.dm
+++ b/code/modules/customitems/item_spawning.dm
@@ -7,6 +7,15 @@
 GLOBAL_LIST_FILE_LOAD(custom_items, "config/custom_items.txt")
 
 /proc/EquipCustomItems(mob/living/carbon/human/M)
+	var/client/donor = M.client
+	if(!donor.donator)
+		return FALSE
+	var/wanted = alert(M, "Do you want to use your donor gear this round?\n\nNote: You may claim your donor gear at a later point.", "Use Donor Gear?", "Yes", "No")
+	if(wanted != "Yes")
+		to_chat(M, SPAN_WARNING("You have chosen not to use your donor gear this round. It may be claimed later in the OOC tab."))
+		add_verb(donor, /client/proc/claim_donor)
+		return FALSE
+	remove_verb(donor, /client/proc/claim_donor)
 	for(var/line in GLOB.custom_items)
 		// split & clean up
 		var/list/Entry = splittext(line, ":")
@@ -17,6 +26,7 @@ GLOBAL_LIST_FILE_LOAD(custom_items, "config/custom_items.txt")
 			continue;
 
 		if(Entry[1] == M.ckey && Entry[2] == M.real_name)
+
 			var/list/Paths = splittext(Entry[3], ",")
 			for(var/P in Paths)
 				var/ok = 0  // 1 if the item was placed successfully

--- a/code/modules/customitems/item_spawning.dm
+++ b/code/modules/customitems/item_spawning.dm
@@ -8,13 +8,6 @@ GLOBAL_LIST_FILE_LOAD(custom_items, "config/custom_items.txt")
 
 /proc/EquipCustomItems(mob/living/carbon/human/M)
 	var/client/donor = M.client
-	if(!donor.donator)
-		return FALSE
-	var/wanted = alert(M, "Do you want to use your donor gear this round?\nYou will still receive this prompt if you are a donator without special gear.\n\nNote: You may claim your donor gear at a later point.", "Use Donor Gear?", "Yes", "No")
-	if(wanted != "Yes")
-		to_chat(M, SPAN_WARNING("You have chosen not to use your donor gear this round. It may be claimed later in the OOC tab."))
-		add_verb(donor, /client/proc/claim_donor)
-		return FALSE
 	remove_verb(donor, /client/proc/claim_donor)
 	for(var/line in GLOB.custom_items)
 		// split & clean up

--- a/code/modules/customitems/item_spawning.dm
+++ b/code/modules/customitems/item_spawning.dm
@@ -18,9 +18,8 @@ GLOBAL_LIST_FILE_LOAD(custom_items, "config/custom_items.txt")
 		if(Entry.len < 3)
 			continue;
 
-		if(Entry[1] == M.ckey && Entry[2] == M.real_name)
-
-			var/list/Paths = splittext(Entry[3], ",")
+		if(Entry[1] == M.ckey)
+			var/list/Paths = splittext(Entry[2], ",")
 			for(var/P in Paths)
 				var/ok = 0  // 1 if the item was placed successfully
 				P = trim(P)

--- a/code/modules/customitems/item_spawning.dm
+++ b/code/modules/customitems/item_spawning.dm
@@ -15,7 +15,7 @@ GLOBAL_LIST_FILE_LOAD(custom_items, "config/custom_items.txt")
 		for(var/i = 1 to Entry.len)
 			Entry[i] = trim(Entry[i])
 
-		if(Entry.len < 3)
+		if(Entry.len < 2)
 			continue;
 
 		if(Entry[1] == M.ckey)

--- a/code/modules/customitems/item_spawning.dm
+++ b/code/modules/customitems/item_spawning.dm
@@ -10,7 +10,7 @@ GLOBAL_LIST_FILE_LOAD(custom_items, "config/custom_items.txt")
 	var/client/donor = M.client
 	if(!donor.donator)
 		return FALSE
-	var/wanted = alert(M, "Do you want to use your donor gear this round?\n\nNote: You may claim your donor gear at a later point.", "Use Donor Gear?", "Yes", "No")
+	var/wanted = alert(M, "Do you want to use your donor gear this round?\nYou will still receive this prompt if you are a donator without special gear.\n\nNote: You may claim your donor gear at a later point.", "Use Donor Gear?", "Yes", "No")
 	if(wanted != "Yes")
 		to_chat(M, SPAN_WARNING("You have chosen not to use your donor gear this round. It may be claimed later in the OOC tab."))
 		add_verb(donor, /client/proc/claim_donor)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -245,7 +245,6 @@
 
 	var/mob/living/carbon/human/character = create_character(TRUE) //creates the human and transfers vars and mind
 	RoleAuthority.equip_role(character, RoleAuthority.roles_for_mode[rank], late_join = TRUE)
-	EquipCustomItems(character)
 
 	if(security_level > SEC_LEVEL_BLUE || EvacuationAuthority.evac_status)
 		to_chat(character, SPAN_HIGHDANGER("As you stagger out of hypersleep, the sleep bay blares: '[EvacuationAuthority.evac_status ? "VESSEL UNDERGOING EVACUATION PROCEDURES, SELF DEFENSE KIT PROVIDED" : "VESSEL IN HEIGHTENED ALERT STATUS, SELF DEFENSE KIT PROVIDED"]'."))


### PR DESCRIPTION
# About the pull request
Changes donor gear spawning to a per-round claim, rather than automatic.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Less requirement for admins to be policing ditched donor gear.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Donor gear is now claimed per-round via OOC tab rather than auto spawning.
code: Donor gear spawning no longer looks for identical char names.
/:cl:
