### PR TITLE
Renames Underbarrel Grenade Launcher to its canonical name: U1 Grenade Launcher

### DIFF
--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -1967,7 +1967,7 @@ Defined in conflicts.dm of the #defines folder.
 
 //The requirement for an attachable being alt fire is AMMO CAPACITY > 0.
 /obj/item/attachable/attached_gun/grenade
-	name = "underslung grenade launcher"
+	name = "U1 grenade launcher"
 	desc = "A weapon-mounted, reloadable grenade launcher."
 	icon_state = "grenade"
 	attach_icon = "grenade_a"


### PR DESCRIPTION

# About the pull request

Adds soul to generically named item, this is the canonical designation: https://avp.fandom.com/wiki/U1_Grenade_Launcher

# Explain why it's good for the game

We love technical designations here.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
spellcheck: Added "U1" designation to the UGL attachment.
/:cl:
