### PR TITLE
Restore mouse_opacity for morpher ejected items

### DIFF
--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -799,9 +799,10 @@ W is always an item. stop_warning prevents messaging. user may be null.**/
 	storage_close(watcher)
 
 /obj/item/storage/proc/dump_objectives()
-	for(var/obj/item/I in src)
-		if(I.is_objective)
-			I.forceMove(loc)
+	for(var/obj/item/cur_item in src)
+		if(cur_item.is_objective)
+			cur_item.forceMove(loc)
+			cur_item.mouse_opacity = initial(cur_item.mouse_opacity)
 
 
 /obj/item/storage/Destroy()

--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -801,8 +801,7 @@ W is always an item. stop_warning prevents messaging. user may be null.**/
 /obj/item/storage/proc/dump_objectives()
 	for(var/obj/item/cur_item in src)
 		if(cur_item.is_objective)
-			cur_item.forceMove(loc)
-			cur_item.mouse_opacity = initial(cur_item.mouse_opacity)
+			remove_from_storage(cur_item, loc)
 
 
 /obj/item/storage/Destroy()

--- a/code/modules/cm_aliens/structures/special/egg_morpher.dm
+++ b/code/modules/cm_aliens/structures/special/egg_morpher.dm
@@ -148,6 +148,7 @@
 					var/obj/item/item = A
 					if(item.is_objective && item.unacidable)
 						item.forceMove(get_step(loc, pick(alldirs)))
+						item.mouse_opacity = initial(item.mouse_opacity)
 
 			QDEL_NULL(captured_mob)
 			update_icon()


### PR DESCRIPTION

# About the pull request

This PR simply restores the mouse_opacity setting for any item ejected by the egg morpher. Normally /obj/item/storage/proc/_item_removal restores this change, but the morpher is simply force moving items and doesn't restore that to initial like removing from storage would normally.

# Explain why it's good for the game

Fixes #3703 or at least should greatly mitigate it.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/cmss13-devs/cmss13/assets/76988376/ae816b0e-0a85-441b-ab6d-962e02eff97a)

</details>


# Changelog
:cl: Drathek
fix: Fix morpher ejected items and dumped objectives not restoring their mouse_opacity setting.
/:cl:
