### PR TITLE
Sneaks an extra tile into Almayer squad preps by using fancy density and offsetting magic

### DIFF
--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -12009,12 +12009,6 @@
 	layer = 4.1;
 	pixel_y = -29
 	},
-/obj/structure/barricade/handrail{
-	dir = 8
-	},
-/obj/structure/barricade/handrail{
-	dir = 4
-	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -12029,12 +12023,6 @@
 /obj/structure/machinery/cm_vending/clothing/marine/bravo{
 	density = 0;
 	pixel_y = 16
-	},
-/obj/structure/barricade/handrail{
-	dir = 4
-	},
-/obj/structure/barricade/handrail{
-	dir = 8
 	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
@@ -12902,12 +12890,7 @@
 	},
 /area/almayer/squads/bravo)
 "aTx" = (
-/obj/structure/machinery/light{
-	dir = 4
-	},
-/obj/structure/machinery/power/apc/almayer{
-	dir = 4
-	},
+/obj/structure/machinery/power/apc/almayer,
 /obj/structure/surface/table/almayer,
 /obj/item/tool/hand_labeler,
 /turf/open/floor/almayer{
@@ -15327,13 +15310,13 @@
 	},
 /area/almayer/squads/alpha)
 "bfw" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/item/device/radio/intercom{
 	freerange = 1;
 	name = "General Listening Channel";
 	pixel_y = 28
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/open/floor/almayer{
 	dir = 1;
@@ -15673,33 +15656,11 @@
 	icon_state = "red"
 	},
 /area/almayer/squads/alpha)
-"bgV" = (
-/obj/structure/machinery/cm_vending/clothing/marine/charlie{
-	density = 0;
-	layer = 4.1;
-	pixel_y = -29
-	},
-/obj/structure/barricade/handrail{
-	dir = 8
-	},
-/obj/structure/barricade/handrail{
-	dir = 4
-	},
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/squads/charlie)
 "bgW" = (
 /obj/structure/machinery/cm_vending/clothing/marine/charlie{
 	density = 0;
 	layer = 4.1;
 	pixel_y = -29
-	},
-/obj/structure/barricade/handrail{
-	dir = 4
-	},
-/obj/structure/barricade/handrail{
-	dir = 8
 	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
@@ -15992,12 +15953,6 @@
 "bjs" = (
 /obj/structure/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
-/obj/structure/barricade/handrail{
-	dir = 8
-	},
-/obj/structure/barricade/handrail{
-	dir = 4
-	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -26863,21 +26818,6 @@
 	icon_state = "emerald"
 	},
 /area/almayer/squads/charlie)
-"cje" = (
-/obj/structure/machinery/cm_vending/clothing/marine/delta{
-	density = 0;
-	pixel_y = 16
-	},
-/obj/structure/barricade/handrail{
-	dir = 8
-	},
-/obj/structure/barricade/handrail{
-	dir = 4
-	},
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/squads/delta)
 "cjf" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -26959,12 +26899,6 @@
 /obj/structure/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
-	},
-/obj/structure/barricade/handrail{
-	dir = 4
-	},
-/obj/structure/barricade/handrail{
-	dir = 8
 	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
@@ -27107,12 +27041,6 @@
 "ckr" = (
 /obj/structure/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
-/obj/structure/barricade/handrail{
-	dir = 8
-	},
-/obj/structure/barricade/handrail{
-	dir = 4
-	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -27173,12 +27101,6 @@
 /obj/structure/machinery/cm_vending/clothing/marine/delta{
 	density = 0;
 	pixel_y = 16
-	},
-/obj/structure/barricade/handrail{
-	dir = 4
-	},
-/obj/structure/barricade/handrail{
-	dir = 8
 	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
@@ -27966,9 +27888,7 @@
 	},
 /area/almayer/squads/charlie)
 "coj" = (
-/obj/structure/machinery/power/apc/almayer{
-	dir = 4
-	},
+/obj/structure/machinery/power/apc/almayer,
 /obj/structure/surface/table/almayer,
 /obj/item/tool/hand_labeler,
 /turf/open/floor/almayer{
@@ -41440,12 +41360,6 @@
 /obj/structure/sign/safety/cryo{
 	pixel_x = 32
 	},
-/obj/structure/barricade/handrail{
-	dir = 4
-	},
-/obj/structure/barricade/handrail{
-	dir = 8
-	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -45227,12 +45141,6 @@
 /obj/structure/sign/safety/cryo{
 	pixel_x = 32
 	},
-/obj/structure/barricade/handrail{
-	dir = 8
-	},
-/obj/structure/barricade/handrail{
-	dir = 4
-	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -45813,9 +45721,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/machinery/firealarm{
-	pixel_y = -29
-	},
+/obj/structure/machinery/light,
 /turf/open/floor/almayer{
 	icon_state = "orange"
 	},
@@ -47545,12 +47451,6 @@
 /obj/structure/sign/safety/cryo{
 	pixel_x = 32
 	},
-/obj/structure/barricade/handrail{
-	dir = 4
-	},
-/obj/structure/barricade/handrail{
-	dir = 8
-	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -48261,12 +48161,6 @@
 	},
 /obj/structure/sign/safety/cryo{
 	pixel_x = 32
-	},
-/obj/structure/barricade/handrail{
-	dir = 4
-	},
-/obj/structure/barricade/handrail{
-	dir = 8
 	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
@@ -71323,6 +71217,9 @@
 	},
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
+	},
+/obj/structure/machinery/firealarm{
+	pixel_y = -29
 	},
 /turf/open/floor/almayer{
 	icon_state = "orange"
@@ -118130,7 +118027,7 @@ aLT
 aLT
 aLT
 aLT
-bfw
+bfx
 rGj
 aQT
 aLT
@@ -118379,9 +118276,9 @@ cgr
 bJC
 raK
 mzg
-bgV
+bgW
 bJC
-cje
+ckR
 ckX
 iyS
 bSJ
@@ -118536,7 +118433,7 @@ bco
 bdr
 bdA
 aLT
-bfx
+bfw
 rGj
 aQT
 aLT
@@ -119597,7 +119494,7 @@ cgt
 bJC
 chS
 bQA
-bgV
+bgW
 bJC
 ckR
 ckX
@@ -120206,7 +120103,7 @@ cgt
 bJC
 chV
 cjf
-bgV
+bgW
 bJC
 ckR
 bTC

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -837,8 +837,8 @@
 /area/almayer/living/basketball)
 "acJ" = (
 /mob/living/silicon/decoy/ship_ai{
-	pixel_y = -16;
-	layer = 2.98
+	layer = 2.98;
+	pixel_y = -16
 	},
 /obj/structure/blocker/invisible_wall,
 /obj/effect/decal/warning_stripes{
@@ -2464,22 +2464,22 @@
 /obj/structure/machinery/door_control{
 	id = "ARES StairsLock";
 	name = "ARES Exterior Lockdown Override";
-	req_one_access_txt = "90;91;92";
+	pixel_x = 8;
 	pixel_y = -24;
-	pixel_x = 8
+	req_one_access_txt = "90;91;92"
 	},
 /obj/structure/machinery/door_control{
 	id = "ARES Emergency";
 	name = "ARES Emergency Lockdown Override";
-	req_one_access_txt = "91;92";
-	pixel_y = -24
+	pixel_y = -24;
+	req_one_access_txt = "91;92"
 	},
 /obj/structure/machinery/door_control{
 	id = "Brig Lockdown Shutters";
 	name = "Brig Lockdown Override";
-	req_access_txt = "1;3";
 	pixel_x = -8;
-	pixel_y = -24
+	pixel_y = -24;
+	req_access_txt = "1;3"
 	},
 /turf/open/floor/wood/ship,
 /area/almayer/living/commandbunks)
@@ -5816,9 +5816,9 @@
 /obj/structure/machinery/door_control{
 	id = "ARES StairsUpper";
 	name = "ARES Core Access";
-	req_one_access_txt = "1;200;90;91;92";
+	pixel_x = -24;
 	pixel_y = 24;
-	pixel_x = -24
+	req_one_access_txt = "1;200;90;91;92"
 	},
 /turf/open/floor/almayer/no_build{
 	icon_state = "ai_floors"
@@ -5840,9 +5840,9 @@
 "asG" = (
 /obj/structure/surface/table/reinforced/almayer_B{
 	climbable = 0;
+	indestructible = 1;
 	unacidable = 1;
-	unslashable = 1;
-	indestructible = 1
+	unslashable = 1
 	},
 /turf/open/floor/almayer/no_build{
 	icon_state = "ai_floors"
@@ -7084,34 +7084,34 @@
 /obj/structure/machinery/door_control{
 	id = "ARES StairsUpper";
 	name = "ARES Core Access";
-	req_one_access_txt = "91;92";
+	pixel_x = -10;
 	pixel_y = -24;
-	pixel_x = -10
+	req_one_access_txt = "91;92"
 	},
 /obj/structure/machinery/door_control{
 	id = "ARES StairsLock";
 	name = "ARES Exterior Lockdown";
-	req_one_access_txt = "91;92";
-	pixel_y = -24
+	pixel_y = -24;
+	req_one_access_txt = "91;92"
 	},
 /obj/structure/surface/table/reinforced/almayer_B{
 	climbable = 0;
+	indestructible = 1;
 	unacidable = 1;
-	unslashable = 1;
-	indestructible = 1
+	unslashable = 1
 	},
 /obj/structure/transmitter/rotary{
-	phone_color = "blue";
-	phone_id = "AI Reception";
+	name = "AI Reception Telephone";
 	phone_category = "ARES";
-	name = "AI Reception Telephone"
+	phone_color = "blue";
+	phone_id = "AI Reception"
 	},
 /obj/structure/machinery/door_control{
 	id = "ARES Emergency";
 	name = "ARES Emergency Lockdown";
-	req_one_access_txt = "91;92";
+	pixel_x = 10;
 	pixel_y = -24;
-	pixel_x = 10
+	req_one_access_txt = "91;92"
 	},
 /turf/open/floor/almayer/no_build{
 	icon_state = "ai_floors"
@@ -7125,9 +7125,9 @@
 	},
 /obj/structure/surface/table/reinforced/almayer_B{
 	climbable = 0;
+	indestructible = 1;
 	unacidable = 1;
-	unslashable = 1;
-	indestructible = 1
+	unslashable = 1
 	},
 /obj/item/paper_bin/uscm{
 	pixel_y = 6
@@ -10992,31 +10992,31 @@
 	},
 /obj/structure/machinery/door_control{
 	id = "ARES Interior";
+	indestructible = 1;
 	name = "ARES Chamber Lockdown";
-	req_one_access_txt = "1;200;90;91;92";
 	pixel_x = 24;
 	pixel_y = -8;
-	indestructible = 1
+	req_one_access_txt = "1;200;90;91;92"
 	},
 /obj/structure/machinery/door_control{
 	id = "ARES Railing";
+	indestructible = 1;
 	name = "ARES Chamber Railings";
-	req_one_access_txt = "91;92";
-	pixel_x = 24;
 	needs_power = 0;
-	indestructible = 1
+	pixel_x = 24;
+	req_one_access_txt = "91;92"
 	},
 /obj/structure/machinery/door/poddoor/railing{
-	dir = 2;
-	id = "ARES Railing";
-	unslashable = 0;
-	unacidable = 0;
-	pixel_y = -1;
-	pixel_x = -1;
-	open_layer = 2.1;
 	closed_layer = 4.1;
 	density = 0;
-	layer = 2.1
+	dir = 2;
+	id = "ARES Railing";
+	layer = 2.1;
+	open_layer = 2.1;
+	pixel_x = -1;
+	pixel_y = -1;
+	unacidable = 0;
+	unslashable = 0
 	},
 /turf/open/floor/almayer/no_build{
 	icon_state = "ai_floors"
@@ -11990,7 +11990,9 @@
 /obj/structure/pipes/vents/pump{
 	dir = 4
 	},
-/turf/open/floor/almayer,
+/turf/open/floor/almayer{
+	icon_state = "red"
+	},
 /area/almayer/squads/alpha)
 "aPk" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
@@ -12002,10 +12004,20 @@
 	},
 /area/almayer/command/lifeboat)
 "aPl" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
+/obj/structure/machinery/cm_vending/clothing/marine/alpha{
+	density = 0;
+	layer = 4.1;
+	pixel_y = -29
+	},
+/obj/structure/barricade/handrail{
+	dir = 8
+	},
+/obj/structure/barricade/handrail{
 	dir = 4
 	},
-/turf/open/floor/almayer,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
 /area/almayer/squads/alpha)
 "aPm" = (
 /obj/structure/closet/firecloset,
@@ -12014,13 +12026,20 @@
 	},
 /area/almayer/hallways/aft_hallway)
 "aPn" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
+/obj/structure/machinery/cm_vending/clothing/marine/bravo{
+	density = 0;
+	pixel_y = 16
+	},
+/obj/structure/barricade/handrail{
 	dir = 4
 	},
-/turf/open/floor/almayer{
-	icon_state = "redcorner"
+/obj/structure/barricade/handrail{
+	dir = 8
 	},
-/area/almayer/squads/alpha)
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/squads/bravo)
 "aPo" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -12109,19 +12128,6 @@
 "aPK" = (
 /obj/structure/sign/nosmoking_1,
 /turf/closed/wall/almayer,
-/area/almayer/squads/alpha)
-"aPM" = (
-/obj/structure/machinery/cm_vending/clothing/marine/alpha,
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/squads/alpha)
-"aPN" = (
-/obj/structure/machinery/light,
-/obj/structure/machinery/cm_vending/clothing/marine/alpha,
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
 /area/almayer/squads/alpha)
 "aPX" = (
 /obj/structure/largecrate/random/case/double,
@@ -12292,69 +12298,16 @@
 /obj/structure/sign/nosmoking_1,
 /turf/closed/wall/almayer,
 /area/almayer/squads/bravo)
-"aQP" = (
-/obj/structure/machinery/cm_vending/clothing/marine/bravo,
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/squads/bravo)
-"aQQ" = (
-/obj/structure/machinery/firealarm{
-	pixel_y = 28
-	},
-/obj/structure/machinery/cm_vending/clothing/marine/bravo,
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/squads/bravo)
-"aQR" = (
-/obj/item/device/radio/intercom{
-	freerange = 1;
-	name = "General Listening Channel";
-	pixel_y = 28
-	},
-/obj/structure/machinery/cm_vending/clothing/marine/bravo,
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/squads/bravo)
-"aQS" = (
-/obj/structure/machinery/light{
-	dir = 1
-	},
-/obj/structure/machinery/cm_vending/clothing/marine/bravo,
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/squads/bravo)
 "aQT" = (
-/obj/structure/machinery/cm_vending/clothing/marine/alpha,
-/obj/structure/machinery/camera/autoname/almayer{
-	dir = 1;
-	name = "ship-grade camera"
+/obj/structure/machinery/cm_vending/clothing/marine/alpha{
+	density = 0;
+	layer = 4.1;
+	pixel_y = -29
 	},
 /turf/open/floor/almayer{
-	icon_state = "plate"
+	icon_state = "cargo_arrow"
 	},
 /area/almayer/squads/alpha)
-"aQU" = (
-/obj/structure/machinery/alarm/almayer{
-	dir = 1
-	},
-/obj/structure/machinery/cm_vending/clothing/marine/bravo,
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/squads/bravo)
-"aQV" = (
-/obj/structure/machinery/status_display{
-	pixel_y = 30
-	},
-/obj/structure/machinery/cm_vending/clothing/marine/bravo,
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/squads/bravo)
 "aQW" = (
 /obj/structure/machinery/vending/cola{
 	pixel_x = -6;
@@ -12596,7 +12549,10 @@
 /area/almayer/squads/bravo)
 "aRU" = (
 /obj/structure/pipes/vents/pump/on,
-/turf/open/floor/almayer,
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "orange"
+	},
 /area/almayer/squads/bravo)
 "aRV" = (
 /obj/structure/platform{
@@ -12610,7 +12566,10 @@
 /obj/structure/pipes/vents/scrubber{
 	dir = 4
 	},
-/turf/open/floor/almayer,
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "orange"
+	},
 /area/almayer/squads/bravo)
 "aRZ" = (
 /turf/open/floor/almayer{
@@ -12927,12 +12886,13 @@
 	},
 /area/almayer/living/offices)
 "aTv" = (
-/obj/structure/machinery/camera/autoname/almayer{
-	name = "ship-grade camera"
+/obj/structure/machinery/cm_vending/clothing/marine/bravo{
+	density = 0;
+	pixel_y = 16
 	},
-/obj/structure/machinery/cm_vending/clothing/marine/bravo,
 /turf/open/floor/almayer{
-	icon_state = "plate"
+	dir = 1;
+	icon_state = "cargo_arrow"
 	},
 /area/almayer/squads/bravo)
 "aTw" = (
@@ -14290,9 +14250,9 @@
 /obj/structure/machinery/door_control{
 	id = "ARES Mainframe Right";
 	name = "ARES Mainframe Lockdown";
-	req_one_access_txt = "200;91;92";
 	pixel_x = -24;
-	pixel_y = -24
+	pixel_y = -24;
+	req_one_access_txt = "200;91;92"
 	},
 /turf/open/floor/almayer/no_build{
 	icon_state = "ai_floors"
@@ -15431,11 +15391,11 @@
 	},
 /area/almayer/squads/alpha)
 "bfD" = (
-/obj/structure/machinery/status_display{
-	pixel_y = 30
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/machinery/light{
+	dir = 1
 	},
 /turf/open/floor/almayer{
 	dir = 1;
@@ -15714,18 +15674,37 @@
 	},
 /area/almayer/squads/alpha)
 "bgV" = (
-/turf/open/floor/almayer{
-	icon_state = "cargo_arrow"
+/obj/structure/machinery/cm_vending/clothing/marine/charlie{
+	density = 0;
+	layer = 4.1;
+	pixel_y = -29
 	},
-/area/almayer/squads/alpha)
-"bgW" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
+/obj/structure/barricade/handrail{
+	dir = 8
+	},
+/obj/structure/barricade/handrail{
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	icon_state = "cargo_arrow"
+	icon_state = "plate"
 	},
-/area/almayer/squads/alpha)
+/area/almayer/squads/charlie)
+"bgW" = (
+/obj/structure/machinery/cm_vending/clothing/marine/charlie{
+	density = 0;
+	layer = 4.1;
+	pixel_y = -29
+	},
+/obj/structure/barricade/handrail{
+	dir = 4
+	},
+/obj/structure/barricade/handrail{
+	dir = 8
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/squads/charlie)
 "bgY" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -16013,6 +15992,12 @@
 "bjs" = (
 /obj/structure/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
+/obj/structure/barricade/handrail{
+	dir = 8
+	},
+/obj/structure/barricade/handrail{
+	dir = 4
+	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -16418,7 +16403,7 @@
 "blB" = (
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "cargo_arrow"
+	icon_state = "orange"
 	},
 /area/almayer/squads/bravo)
 "blZ" = (
@@ -17215,6 +17200,9 @@
 "bpL" = (
 /obj/structure/sign/poster{
 	pixel_y = 32
+	},
+/obj/structure/machinery/light{
+	dir = 8
 	},
 /turf/open/floor/almayer{
 	dir = 8;
@@ -20411,19 +20399,6 @@
 	icon_state = "orange"
 	},
 /area/almayer/engineering/lower_engineering)
-"bFh" = (
-/obj/structure/machinery/cm_vending/clothing/marine/charlie,
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/squads/charlie)
-"bFi" = (
-/obj/structure/machinery/light,
-/obj/structure/machinery/cm_vending/clothing/marine/charlie,
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/squads/charlie)
 "bFj" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -21071,12 +21046,12 @@
 	plane = -7
 	},
 /obj/structure/machinery/door/poddoor/almayer/blended/white/open{
-	open_layer = 1.9;
-	id = "ARES Emergency";
-	needs_power = 0;
-	name = "ARES Emergency Lockdown";
-	layer = 3.2;
 	closed_layer = 3.2;
+	id = "ARES Emergency";
+	layer = 3.2;
+	name = "ARES Emergency Lockdown";
+	needs_power = 0;
+	open_layer = 1.9;
 	plane = -7
 	},
 /turf/open/floor/almayer/no_build{
@@ -21868,17 +21843,17 @@
 /obj/structure/machinery/door_control{
 	id = "ARES StairsLower";
 	name = "ARES Core Lockdown";
-	req_one_access_txt = "19;200;90;91;92";
 	pixel_x = 24;
-	pixel_y = -8
+	pixel_y = -8;
+	req_one_access_txt = "19;200;90;91;92"
 	},
 /obj/structure/machinery/camera/autoname/almayer/containment/ares{
 	dir = 8;
 	pixel_y = 2
 	},
 /turf/open/floor/almayer/no_build{
-	icon_state = "silver";
-	dir = 4
+	dir = 4;
+	icon_state = "silver"
 	},
 /area/almayer/command/airoom)
 "bLw" = (
@@ -23072,20 +23047,8 @@
 /obj/structure/pipes/vents/pump{
 	dir = 4
 	},
-/turf/open/floor/almayer,
-/area/almayer/squads/charlie)
-"bQB" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/turf/open/floor/almayer,
-/area/almayer/squads/charlie)
-"bQC" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
 /turf/open/floor/almayer{
-	icon_state = "emeraldcorner"
+	icon_state = "emerald"
 	},
 /area/almayer/squads/charlie)
 "bQD" = (
@@ -23265,22 +23228,22 @@
 	plane = -7
 	},
 /obj/effect/step_trigger/ares_alert/public{
+	alert_id = "AresStairs";
 	alert_message = "Caution: Movement detected in ARES Core.";
-	cooldown_duration = 1200;
-	alert_id = "AresStairs"
+	cooldown_duration = 1200
 	},
 /obj/effect/step_trigger/ares_alert/public{
+	alert_id = "AresStairs";
 	alert_message = "Caution: Movement detected in ARES Core.";
-	cooldown_duration = 1200;
-	alert_id = "AresStairs"
+	cooldown_duration = 1200
 	},
 /obj/structure/machinery/door/poddoor/almayer/blended/white/open{
-	open_layer = 1.9;
-	id = "ARES Emergency";
-	needs_power = 0;
-	name = "ARES Emergency Lockdown";
-	layer = 3.2;
 	closed_layer = 3.2;
+	id = "ARES Emergency";
+	layer = 3.2;
+	name = "ARES Emergency Lockdown";
+	needs_power = 0;
+	open_layer = 1.9;
 	plane = -7
 	},
 /turf/open/floor/almayer/no_build{
@@ -23736,7 +23699,10 @@
 /obj/structure/pipes/vents/scrubber{
 	dir = 4
 	},
-/turf/open/floor/almayer,
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "blue"
+	},
 /area/almayer/squads/delta)
 "bTE" = (
 /turf/open/floor/almayer{
@@ -26151,13 +26117,13 @@
 /turf/open/floor/almayer,
 /area/almayer/living/grunt_rnr)
 "cdP" = (
-/obj/structure/machinery/cm_vending/clothing/marine/charlie,
-/obj/structure/machinery/camera/autoname/almayer{
-	dir = 1;
-	name = "ship-grade camera"
+/obj/structure/machinery/cm_vending/clothing/marine/charlie{
+	density = 0;
+	layer = 4.1;
+	pixel_y = -29
 	},
 /turf/open/floor/almayer{
-	icon_state = "plate"
+	icon_state = "cargo_arrow"
 	},
 /area/almayer/squads/charlie)
 "cdT" = (
@@ -26664,6 +26630,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/machinery/camera/autoname/almayer,
 /turf/open/floor/almayer{
 	dir = 1;
 	icon_state = "emerald"
@@ -26897,16 +26864,26 @@
 	},
 /area/almayer/squads/charlie)
 "cje" = (
-/turf/open/floor/almayer{
-	icon_state = "cargo_arrow"
+/obj/structure/machinery/cm_vending/clothing/marine/delta{
+	density = 0;
+	pixel_y = 16
 	},
-/area/almayer/squads/charlie)
+/obj/structure/barricade/handrail{
+	dir = 8
+	},
+/obj/structure/barricade/handrail{
+	dir = 4
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/squads/delta)
 "cjf" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	icon_state = "cargo_arrow"
+	icon_state = "emerald"
 	},
 /area/almayer/squads/charlie)
 "cjg" = (
@@ -26983,6 +26960,12 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
+/obj/structure/barricade/handrail{
+	dir = 4
+	},
+/obj/structure/barricade/handrail{
+	dir = 8
+	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -27017,15 +27000,6 @@
 	icon_state = "emerald"
 	},
 /area/almayer/squads/charlie)
-"cjF" = (
-/obj/structure/machinery/camera/autoname/almayer{
-	name = "ship-grade camera"
-	},
-/obj/structure/machinery/cm_vending/clothing/marine/delta,
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/squads/delta)
 "cjK" = (
 /obj/structure/machinery/door/airlock/almayer/maint,
 /obj/structure/disposalpipe/segment{
@@ -27133,50 +27107,12 @@
 "ckr" = (
 /obj/structure/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
-/turf/open/floor/almayer{
-	icon_state = "plate"
+/obj/structure/barricade/handrail{
+	dir = 8
 	},
-/area/almayer/squads/delta)
-"cks" = (
-/obj/structure/machinery/cm_vending/clothing/marine/delta,
-/turf/open/floor/almayer{
-	icon_state = "plate"
+/obj/structure/barricade/handrail{
+	dir = 4
 	},
-/area/almayer/squads/delta)
-"cku" = (
-/obj/item/device/radio/intercom{
-	freerange = 1;
-	name = "General Listening Channel";
-	pixel_y = 28
-	},
-/obj/structure/machinery/cm_vending/clothing/marine/delta,
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/squads/delta)
-"ckv" = (
-/obj/structure/machinery/light{
-	dir = 1
-	},
-/obj/structure/machinery/cm_vending/clothing/marine/delta,
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/squads/delta)
-"ckx" = (
-/obj/structure/machinery/alarm/almayer{
-	dir = 1
-	},
-/obj/structure/machinery/cm_vending/clothing/marine/delta,
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/squads/delta)
-"cky" = (
-/obj/structure/machinery/status_display{
-	pixel_y = 30
-	},
-/obj/structure/machinery/cm_vending/clothing/marine/delta,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -27234,9 +27170,18 @@
 	},
 /area/almayer/squads/delta)
 "ckR" = (
+/obj/structure/machinery/cm_vending/clothing/marine/delta{
+	density = 0;
+	pixel_y = 16
+	},
+/obj/structure/barricade/handrail{
+	dir = 4
+	},
+/obj/structure/barricade/handrail{
+	dir = 8
+	},
 /turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "cargo_arrow"
+	icon_state = "plate"
 	},
 /area/almayer/squads/delta)
 "ckS" = (
@@ -27323,6 +27268,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/device/radio/intercom{
+	freerange = 1;
+	name = "General Listening Channel";
+	pixel_y = -29
+	},
 /turf/open/floor/almayer{
 	dir = 8;
 	icon_state = "bluecorner"
@@ -27354,6 +27304,10 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/machinery/alarm/almayer{
+	dir = 1;
+	pixel_y = -29
 	},
 /turf/open/floor/almayer{
 	icon_state = "blue"
@@ -27404,9 +27358,9 @@
 "clw" = (
 /obj/structure/machinery/light{
 	dir = 8;
+	invisibility = 101;
 	unacidable = 1;
-	unslashable = 1;
-	invisibility = 101
+	unslashable = 1
 	},
 /turf/open/floor/almayer/no_build{
 	icon_state = "ai_floors"
@@ -28152,8 +28106,8 @@
 	pixel_y = 6
 	},
 /obj/item/folder/white{
-	pixel_y = 6;
-	pixel_x = 5
+	pixel_x = 5;
+	pixel_y = 6
 	},
 /turf/open/floor/almayer/no_build{
 	icon_state = "ai_floors"
@@ -28644,8 +28598,8 @@
 	icon_state = "ramptop"
 	},
 /turf/open/floor/almayer/no_build{
-	icon_state = "silver";
-	dir = 4
+	dir = 4;
+	icon_state = "silver"
 	},
 /area/almayer/command/airoom)
 "cBs" = (
@@ -30460,12 +30414,13 @@
 	},
 /area/almayer/hull/lower_hull/l_f_s)
 "dpO" = (
-/obj/structure/machinery/cm_vending/clothing/marine/delta,
-/obj/structure/sign/banners/maximumeffort{
-	pixel_y = 30
+/obj/structure/machinery/cm_vending/clothing/marine/delta{
+	density = 0;
+	pixel_y = 16
 	},
 /turf/open/floor/almayer{
-	icon_state = "plate"
+	dir = 1;
+	icon_state = "cargo_arrow"
 	},
 /area/almayer/squads/delta)
 "dpV" = (
@@ -31267,8 +31222,8 @@
 	dir = 1
 	},
 /turf/open/floor/almayer/no_build{
-	icon_state = "silver";
-	dir = 8
+	dir = 8;
+	icon_state = "silver"
 	},
 /area/almayer/command/airoom)
 "dGr" = (
@@ -31619,8 +31574,8 @@
 	dir = 1
 	},
 /turf/open/floor/almayer/no_build{
-	icon_state = "silver";
-	dir = 4
+	dir = 4;
+	icon_state = "silver"
 	},
 /area/almayer/command/airoom)
 "dQv" = (
@@ -33167,9 +33122,9 @@
 /obj/structure/machinery/door_control{
 	id = "ARES Mainframe Left";
 	name = "ARES Mainframe Lockdown";
-	req_one_access_txt = "200;91;92";
 	pixel_x = 24;
-	pixel_y = 24
+	pixel_y = 24;
+	req_one_access_txt = "200;91;92"
 	},
 /turf/open/floor/almayer/no_build{
 	icon_state = "tcomms"
@@ -33866,9 +33821,9 @@
 	},
 /obj/structure/machinery/light{
 	dir = 4;
+	invisibility = 101;
 	unacidable = 1;
-	unslashable = 1;
-	invisibility = 101
+	unslashable = 1
 	},
 /turf/open/floor/almayer/no_build{
 	icon_state = "ai_floors"
@@ -34697,8 +34652,8 @@
 	dir = 1
 	},
 /turf/open/floor/almayer/no_build{
-	icon_state = "silver";
-	dir = 8
+	dir = 8;
+	icon_state = "silver"
 	},
 /area/almayer/command/airoom)
 "fdj" = (
@@ -35097,6 +35052,18 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/command/lifeboat)
+"foL" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/almayer{
+	dir = 4;
+	icon_state = "emeraldcorner"
+	},
+/area/almayer/squads/charlie)
 "fpd" = (
 /obj/structure/sign/safety/hvac_old{
 	pixel_x = 8;
@@ -36195,13 +36162,13 @@
 /obj/structure/machinery/door_control{
 	id = "ARES Operations Right";
 	name = "ARES Operations Shutter";
-	req_one_access_txt = "1;200;91;92";
 	pixel_x = 24;
-	pixel_y = -8
+	pixel_y = -8;
+	req_one_access_txt = "1;200;91;92"
 	},
 /turf/open/floor/almayer/no_build{
-	icon_state = "silver";
-	dir = 4
+	dir = 4;
+	icon_state = "silver"
 	},
 /area/almayer/command/airoom)
 "fMt" = (
@@ -36212,12 +36179,12 @@
 	},
 /obj/effect/step_trigger/ares_alert/core,
 /obj/structure/machinery/door/poddoor/almayer/blended/white/open{
-	open_layer = 1.9;
-	id = "ARES Emergency";
-	needs_power = 0;
-	name = "ARES Emergency Lockdown";
-	layer = 3.2;
 	closed_layer = 3.2;
+	id = "ARES Emergency";
+	layer = 3.2;
+	name = "ARES Emergency Lockdown";
+	needs_power = 0;
+	open_layer = 1.9;
 	plane = -7
 	},
 /obj/structure/sign/safety/laser{
@@ -36225,8 +36192,8 @@
 	pixel_y = -8
 	},
 /obj/structure/sign/safety/rewire{
-	pixel_y = 6;
-	pixel_x = 32
+	pixel_x = 32;
+	pixel_y = 6
 	},
 /turf/open/floor/almayer/no_build{
 	icon_state = "test_floor4"
@@ -36749,12 +36716,12 @@
 	pixel_y = 8
 	},
 /obj/structure/transmitter/rotary{
-	pixel_x = 8;
-	pixel_y = -8;
+	name = "AI Core Telephone";
+	phone_category = "ARES";
 	phone_color = "blue";
 	phone_id = "AI Core";
-	phone_category = "ARES";
-	name = "AI Core Telephone"
+	pixel_x = 8;
+	pixel_y = -8
 	},
 /turf/open/floor/almayer/no_build{
 	icon_state = "ai_floors"
@@ -36762,8 +36729,8 @@
 /area/almayer/command/airoom)
 "gbg" = (
 /obj/structure/sign/safety/terminal{
-	pixel_y = 24;
-	pixel_x = 14
+	pixel_x = 14;
+	pixel_y = 24
 	},
 /obj/structure/sign/safety/laser{
 	pixel_y = 24
@@ -36778,9 +36745,9 @@
 /obj/structure/machinery/door_control{
 	id = "ARES Operations Right";
 	name = "ARES Operations Shutter";
-	req_one_access_txt = "1;200;91;92";
 	pixel_x = -24;
-	pixel_y = -8
+	pixel_y = -8;
+	req_one_access_txt = "1;200;91;92"
 	},
 /turf/open/floor/almayer/no_build{
 	icon_state = "ai_floors"
@@ -37167,13 +37134,13 @@
 /area/almayer/hull/lower_hull/l_f_s)
 "gjw" = (
 /obj/structure/machinery/faxmachine/uscm/command{
+	density = 0;
 	department = "AI Core";
-	pixel_y = 32;
-	density = 0
+	pixel_y = 32
 	},
 /obj/structure/surface/rack{
-	pixel_y = 16;
-	density = 0
+	density = 0;
+	pixel_y = 16
 	},
 /obj/structure/machinery/computer/working_joe{
 	dir = 8;
@@ -37830,9 +37797,9 @@
 /area/almayer/hallways/starboard_hallway)
 "gyN" = (
 /obj/structure/machinery/prop{
+	desc = "It's a server box...";
 	icon_state = "comm_server";
-	name = "server box";
-	desc = "It's a server box..."
+	name = "server box"
 	},
 /turf/open/floor/almayer/no_build{
 	icon_state = "test_floor4"
@@ -38475,23 +38442,23 @@
 	},
 /obj/structure/machinery/door_control{
 	id = "ARES Interior";
+	indestructible = 1;
 	name = "ARES Chamber Lockdown";
-	req_one_access_txt = "1;200;90;91;92";
 	pixel_x = -24;
 	pixel_y = -8;
-	indestructible = 1
+	req_one_access_txt = "1;200;90;91;92"
 	},
 /obj/structure/machinery/door/poddoor/railing{
+	closed_layer = 4.1;
+	density = 0;
 	dir = 2;
 	id = "ARES Railing";
-	unslashable = 0;
-	unacidable = 0;
-	pixel_y = -1;
-	pixel_x = -1;
+	layer = 2.1;
 	open_layer = 2.1;
-	density = 0;
-	closed_layer = 4.1;
-	layer = 2.1
+	pixel_x = -1;
+	pixel_y = -1;
+	unacidable = 0;
+	unslashable = 0
 	},
 /turf/open/floor/almayer/no_build{
 	icon_state = "ai_floors"
@@ -38538,24 +38505,24 @@
 	},
 /obj/structure/machinery/door_control{
 	id = "ARES Interior";
+	indestructible = 1;
 	name = "ARES Chamber Lockdown";
-	req_one_access_txt = "1;200;90;91;92";
 	pixel_x = 24;
 	pixel_y = 8;
-	indestructible = 1
+	req_one_access_txt = "1;200;90;91;92"
 	},
 /obj/structure/machinery/door/poddoor/railing{
-	id = "ARES Railing";
-	unslashable = 0;
-	unacidable = 0;
-	open_layer = 2.1;
+	closed_layer = 4;
 	density = 0;
+	id = "ARES Railing";
 	layer = 2.1;
-	closed_layer = 4
+	open_layer = 2.1;
+	unacidable = 0;
+	unslashable = 0
 	},
 /turf/open/floor/almayer/no_build{
-	icon_state = "silver";
-	dir = 4
+	dir = 4;
+	icon_state = "silver"
 	},
 /area/almayer/command/airoom)
 "gPc" = (
@@ -38858,9 +38825,9 @@
 "gXs" = (
 /obj/effect/step_trigger/ares_alert/terminals,
 /obj/structure/machinery/door/poddoor/shutters/almayer{
+	dir = 4;
 	id = "ARES Operations Right";
-	name = "\improper ARES Operations Shutters";
-	dir = 4
+	name = "\improper ARES Operations Shutters"
 	},
 /obj/structure/pipes/standard/simple/hidden/supply/no_boom{
 	dir = 4
@@ -40132,6 +40099,18 @@
 	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical_medbay)
+"hAZ" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/machinery/light,
+/turf/open/floor/almayer{
+	icon_state = "blue"
+	},
+/area/almayer/squads/delta)
 "hBc" = (
 /obj/structure/pipes/vents/scrubber{
 	dir = 4
@@ -40790,12 +40769,12 @@
 	pixel_y = 24
 	},
 /obj/structure/machinery/computer/crew/alt{
-	pixel_x = -17;
-	dir = 4
+	dir = 4;
+	pixel_x = -17
 	},
 /obj/structure/sign/safety/terminal{
-	pixel_y = 24;
-	pixel_x = 14
+	pixel_x = 14;
+	pixel_y = 24
 	},
 /obj/structure/sign/safety/fibre_optics{
 	pixel_x = 14;
@@ -40868,10 +40847,10 @@
 /area/almayer/hull/lower_hull/l_a_p)
 "hTl" = (
 /obj/structure/prop/server_equipment/yutani_server{
-	pixel_y = 16;
-	name = "server tower";
+	density = 0;
 	desc = "A powerful server tower housing various AI functions.";
-	density = 0
+	name = "server tower";
+	pixel_y = 16
 	},
 /obj/structure/pipes/standard/simple/hidden/supply/no_boom,
 /turf/open/floor/almayer/no_build{
@@ -41454,9 +41433,18 @@
 	},
 /area/almayer/medical/lower_medical_medbay)
 "ihM" = (
-/obj/structure/machinery/cm_vending/clothing/marine/delta,
+/obj/structure/machinery/cm_vending/clothing/marine/delta{
+	density = 0;
+	pixel_y = 16
+	},
 /obj/structure/sign/safety/cryo{
 	pixel_x = 32
+	},
+/obj/structure/barricade/handrail{
+	dir = 4
+	},
+/obj/structure/barricade/handrail{
+	dir = 8
 	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
@@ -41958,24 +41946,24 @@
 	},
 /obj/structure/machinery/door_control{
 	id = "ARES Interior";
+	indestructible = 1;
 	name = "ARES Chamber Lockdown";
-	req_one_access_txt = "1;200;90;91;92";
 	pixel_x = -24;
 	pixel_y = 8;
-	indestructible = 1
+	req_one_access_txt = "1;200;90;91;92"
 	},
 /obj/structure/machinery/door/poddoor/railing{
-	id = "ARES Railing";
-	unslashable = 0;
-	unacidable = 0;
-	open_layer = 2.1;
+	closed_layer = 4;
 	density = 0;
+	id = "ARES Railing";
 	layer = 2.1;
-	closed_layer = 4
+	open_layer = 2.1;
+	unacidable = 0;
+	unslashable = 0
 	},
 /turf/open/floor/almayer/no_build{
-	icon_state = "silver";
-	dir = 8
+	dir = 8;
+	icon_state = "silver"
 	},
 /area/almayer/command/airoom)
 "itR" = (
@@ -42210,10 +42198,10 @@
 "iyH" = (
 /obj/structure/surface/table/reinforced/almayer_B{
 	climbable = 0;
-	unacidable = 1;
-	unslashable = 1;
+	desc = "A square metal surface resting on its fat metal bottom. You can't flip something that doesn't have legs. This one has a metal rail running above it, preventing something large passing over. Like you.";
 	indestructible = 1;
-	desc = "A square metal surface resting on its fat metal bottom. You can't flip something that doesn't have legs. This one has a metal rail running above it, preventing something large passing over. Like you."
+	unacidable = 1;
+	unslashable = 1
 	},
 /turf/open/floor/almayer/no_build{
 	icon_state = "ai_floors"
@@ -43288,8 +43276,8 @@
 	dir = 1
 	},
 /turf/open/floor/almayer/no_build{
-	icon_state = "silver";
-	dir = 4
+	dir = 4;
+	icon_state = "silver"
 	},
 /area/almayer/command/airoom)
 "iZG" = (
@@ -44152,12 +44140,12 @@
 	},
 /obj/effect/step_trigger/ares_alert/core,
 /obj/structure/machinery/door/poddoor/almayer/blended/white/open{
-	open_layer = 1.9;
-	id = "ARES Emergency";
-	needs_power = 0;
-	name = "ARES Emergency Lockdown";
-	layer = 3.2;
 	closed_layer = 3.2;
+	id = "ARES Emergency";
+	layer = 3.2;
+	name = "ARES Emergency Lockdown";
+	needs_power = 0;
+	open_layer = 1.9;
 	plane = -7
 	},
 /turf/open/floor/almayer/no_build{
@@ -44521,8 +44509,8 @@
 /obj/structure/machinery/door_control{
 	id = "ARES StairsUpper";
 	name = "ARES Core Access";
-	req_one_access_txt = "19;200;90;91;92";
-	pixel_x = 24
+	pixel_x = 24;
+	req_one_access_txt = "19;200;90;91;92"
 	},
 /turf/open/floor/almayer/no_build{
 	icon_state = "ai_floors"
@@ -45231,9 +45219,19 @@
 /turf/open/floor/almayer,
 /area/almayer/shipboard/brig/cells)
 "jVr" = (
-/obj/structure/machinery/cm_vending/clothing/marine/alpha,
+/obj/structure/machinery/cm_vending/clothing/marine/alpha{
+	density = 0;
+	layer = 4.1;
+	pixel_y = -29
+	},
 /obj/structure/sign/safety/cryo{
 	pixel_x = 32
+	},
+/obj/structure/barricade/handrail{
+	dir = 8
+	},
+/obj/structure/barricade/handrail{
+	dir = 4
 	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
@@ -45814,6 +45812,9 @@
 "kiU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/machinery/firealarm{
+	pixel_y = -29
 	},
 /turf/open/floor/almayer{
 	icon_state = "orange"
@@ -46574,13 +46575,13 @@
 /obj/structure/machinery/door_control{
 	id = "ARES StairsLower";
 	name = "ARES Core Lockdown";
-	req_one_access_txt = "19;200;90;91;92";
 	pixel_x = -24;
-	pixel_y = -8
+	pixel_y = -8;
+	req_one_access_txt = "19;200;90;91;92"
 	},
 /turf/open/floor/almayer/no_build{
-	icon_state = "silver";
-	dir = 8
+	dir = 8;
+	icon_state = "silver"
 	},
 /area/almayer/command/airoom)
 "kAh" = (
@@ -46983,8 +46984,8 @@
 	icon_state = "ramptop"
 	},
 /turf/open/floor/almayer/no_build{
-	icon_state = "silver";
-	dir = 8
+	dir = 8;
+	icon_state = "silver"
 	},
 /area/almayer/command/airoom)
 "kKG" = (
@@ -47339,9 +47340,9 @@
 /obj/structure/machinery/door_control{
 	id = "ARES Mainframe Right";
 	name = "ARES Mainframe Lockdown";
-	req_one_access_txt = "200;91;92";
 	pixel_x = -24;
-	pixel_y = 24
+	pixel_y = 24;
+	req_one_access_txt = "200;91;92"
 	},
 /turf/open/floor/almayer/no_build{
 	icon_state = "tcomms"
@@ -47537,9 +47538,18 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_f_p)
 "kXa" = (
-/obj/structure/machinery/cm_vending/clothing/marine/bravo,
+/obj/structure/machinery/cm_vending/clothing/marine/bravo{
+	density = 0;
+	pixel_y = 16
+	},
 /obj/structure/sign/safety/cryo{
 	pixel_x = 32
+	},
+/obj/structure/barricade/handrail{
+	dir = 4
+	},
+/obj/structure/barricade/handrail{
+	dir = 8
 	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
@@ -47557,8 +47567,8 @@
 /area/almayer/command/computerlab)
 "kXj" = (
 /turf/open/floor/almayer/no_build{
-	icon_state = "silver";
-	dir = 4
+	dir = 4;
+	icon_state = "silver"
 	},
 /area/almayer/command/airoom)
 "kXu" = (
@@ -48229,24 +48239,34 @@
 	pixel_y = 24
 	},
 /obj/structure/sign/safety/terminal{
-	pixel_y = 24;
-	pixel_x = 14
+	pixel_x = 14;
+	pixel_y = 24
 	},
 /obj/structure/machinery/door_control{
 	id = "ARES Operations Left";
 	name = "ARES Operations Shutter";
-	req_one_access_txt = "1;200;91;92";
 	pixel_x = 24;
-	pixel_y = -8
+	pixel_y = -8;
+	req_one_access_txt = "1;200;91;92"
 	},
 /turf/open/floor/almayer/no_build{
 	icon_state = "ai_floors"
 	},
 /area/almayer/command/airoom)
 "lok" = (
-/obj/structure/machinery/cm_vending/clothing/marine/charlie,
+/obj/structure/machinery/cm_vending/clothing/marine/charlie{
+	density = 0;
+	layer = 4.1;
+	pixel_y = -29
+	},
 /obj/structure/sign/safety/cryo{
 	pixel_x = 32
+	},
+/obj/structure/barricade/handrail{
+	dir = 4
+	},
+/obj/structure/barricade/handrail{
+	dir = 8
 	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
@@ -48266,6 +48286,23 @@
 "loP" = (
 /turf/closed/wall/almayer,
 /area/almayer/engineering/laundry)
+"loS" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/item/device/radio/intercom{
+	freerange = 1;
+	name = "General Listening Channel";
+	pixel_y = -29
+	},
+/obj/structure/machinery/light,
+/turf/open/floor/almayer{
+	icon_state = "bluecorner"
+	},
+/area/almayer/squads/delta)
 "loV" = (
 /obj/structure/desertdam/decals/road_edge{
 	icon_state = "road_edge_decal3";
@@ -50606,6 +50643,20 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/lifeboat_pumps/north1)
+"mtr" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/machinery/status_display{
+	pixel_y = -29
+	},
+/turf/open/floor/almayer{
+	icon_state = "orange"
+	},
+/area/almayer/squads/bravo)
 "mtD" = (
 /obj/structure/machinery/status_display{
 	pixel_x = 16;
@@ -50678,6 +50729,10 @@
 	dir = 4
 	},
 /obj/structure/pipes/standard/manifold/hidden/supply,
+/obj/structure/machinery/camera/autoname/almayer{
+	dir = 1;
+	name = "ship-grade camera"
+	},
 /turf/open/floor/almayer{
 	icon_state = "bluecorner"
 	},
@@ -50807,9 +50862,6 @@
 	},
 /area/almayer/hull/lower_hull/l_f_s)
 "mzg" = (
-/obj/structure/sign/poster{
-	pixel_y = -32
-	},
 /turf/open/floor/almayer{
 	icon_state = "emerald"
 	},
@@ -51042,12 +51094,12 @@
 	plane = -7
 	},
 /obj/structure/machinery/door/poddoor/almayer/blended/white/open{
-	open_layer = 1.9;
-	id = "ARES Emergency";
-	needs_power = 0;
-	name = "ARES Emergency Lockdown";
-	layer = 3.2;
 	closed_layer = 3.2;
+	id = "ARES Emergency";
+	layer = 3.2;
+	name = "ARES Emergency Lockdown";
+	needs_power = 0;
+	open_layer = 1.9;
 	plane = -7
 	},
 /turf/open/floor/almayer/no_build{
@@ -51131,8 +51183,8 @@
 /area/almayer/medical/medical_science)
 "mHE" = (
 /turf/open/floor/almayer/no_build{
-	icon_state = "silver";
-	dir = 8
+	dir = 8;
+	icon_state = "silver"
 	},
 /area/almayer/command/airoom)
 "mHO" = (
@@ -51631,17 +51683,17 @@
 	},
 /obj/effect/step_trigger/ares_alert/core,
 /obj/structure/machinery/door/poddoor/almayer/blended/white/open{
-	open_layer = 1.9;
-	id = "ARES Emergency";
-	needs_power = 0;
-	name = "ARES Emergency Lockdown";
-	layer = 3.2;
 	closed_layer = 3.2;
+	id = "ARES Emergency";
+	layer = 3.2;
+	name = "ARES Emergency Lockdown";
+	needs_power = 0;
+	open_layer = 1.9;
 	plane = -7
 	},
 /obj/structure/sign/safety/terminal{
-	pixel_y = -8;
-	pixel_x = -18
+	pixel_x = -18;
+	pixel_y = -8
 	},
 /obj/structure/sign/safety/fibre_optics{
 	pixel_x = -18;
@@ -51791,9 +51843,9 @@
 "mUC" = (
 /obj/structure/machinery/light{
 	dir = 4;
+	invisibility = 101;
 	unacidable = 1;
-	unslashable = 1;
-	invisibility = 101
+	unslashable = 1
 	},
 /turf/open/floor/almayer/no_build{
 	icon_state = "ai_floors"
@@ -51886,6 +51938,9 @@
 	icon_state = "pottedplant_22";
 	name = "synthetic potted plant";
 	pixel_y = 8
+	},
+/obj/structure/sign/banners/maximumeffort{
+	pixel_y = 30
 	},
 /turf/open/floor/almayer{
 	dir = 9;
@@ -52424,7 +52479,7 @@
 "njd" = (
 /obj/structure/pipes/standard/manifold/hidden/supply,
 /turf/open/floor/almayer{
-	icon_state = "cargo_arrow"
+	icon_state = "red"
 	},
 /area/almayer/squads/alpha)
 "njD" = (
@@ -53222,6 +53277,22 @@
 /obj/effect/landmark/late_join/charlie,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/squads/charlie)
+"nCp" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/item/device/radio/intercom{
+	freerange = 1;
+	name = "General Listening Channel";
+	pixel_y = -29
+	},
+/turf/open/floor/almayer{
+	icon_state = "orange"
+	},
+/area/almayer/squads/bravo)
 "nDd" = (
 /obj/structure/closet/secure_closet/guncabinet/red,
 /obj/item/ammo_magazine/smg/m39,
@@ -54286,8 +54357,8 @@
 	layer = 3.3
 	},
 /obj/structure/sign/safety/terminal{
-	pixel_y = 24;
-	pixel_x = 14
+	pixel_x = 14;
+	pixel_y = 24
 	},
 /obj/structure/sign/safety/fibre_optics{
 	pixel_x = 14;
@@ -55013,8 +55084,8 @@
 	},
 /obj/structure/platform_decoration,
 /turf/open/floor/almayer/no_build{
-	icon_state = "silver";
-	dir = 4
+	dir = 4;
+	icon_state = "silver"
 	},
 /area/almayer/command/airoom)
 "osz" = (
@@ -55709,8 +55780,8 @@
 /obj/structure/machinery/door_control{
 	id = "ARES StairsUpper";
 	name = "ARES Core Access";
-	req_one_access_txt = "19;200;90;91;92";
-	pixel_x = -24
+	pixel_x = -24;
+	req_one_access_txt = "19;200;90;91;92"
 	},
 /turf/open/floor/almayer/no_build{
 	icon_state = "ai_floors"
@@ -55767,9 +55838,9 @@
 /obj/structure/machinery/door_control{
 	id = "ARES StairsLower";
 	name = "ARES Core Lockdown";
-	req_one_access_txt = "19;200;90;91;92";
 	pixel_x = -24;
-	pixel_y = 8
+	pixel_y = 8;
+	req_one_access_txt = "19;200;90;91;92"
 	},
 /obj/structure/machinery/camera/autoname/almayer/containment/ares{
 	dir = 4;
@@ -55777,8 +55848,8 @@
 	},
 /obj/effect/step_trigger/clone_cleaner,
 /turf/open/floor/almayer/no_build{
-	icon_state = "silver";
-	dir = 8
+	dir = 8;
+	icon_state = "silver"
 	},
 /area/almayer/command/airoom)
 "oLv" = (
@@ -56807,10 +56878,10 @@
 /area/almayer/living/briefing)
 "pmV" = (
 /obj/structure/prop/server_equipment/yutani_server/broken{
-	pixel_y = 16;
-	name = "server tower";
+	density = 0;
 	desc = "A powerful server tower housing various AI functions.";
-	density = 0
+	name = "server tower";
+	pixel_y = 16
 	},
 /obj/structure/pipes/standard/simple/hidden/supply/no_boom,
 /turf/open/floor/almayer/no_build{
@@ -58434,8 +58505,8 @@
 	dir = 8
 	},
 /turf/open/floor/almayer/no_build{
-	icon_state = "silver";
-	dir = 4
+	dir = 4;
+	icon_state = "silver"
 	},
 /area/almayer/command/airoom)
 "pYo" = (
@@ -59432,13 +59503,13 @@
 /obj/structure/machinery/door_control{
 	id = "ARES Operations Left";
 	name = "ARES Operations Shutter";
-	req_one_access_txt = "1;200;91;92";
 	pixel_x = -24;
-	pixel_y = -8
+	pixel_y = -8;
+	req_one_access_txt = "1;200;91;92"
 	},
 /turf/open/floor/almayer/no_build{
-	icon_state = "silver";
-	dir = 8
+	dir = 8;
+	icon_state = "silver"
 	},
 /area/almayer/command/airoom)
 "qxA" = (
@@ -60700,9 +60771,9 @@
 /obj/structure/machinery/door_control{
 	id = "ARES Mainframe Left";
 	name = "ARES Mainframe Lockdown";
-	req_one_access_txt = "200;91;92";
 	pixel_x = 24;
-	pixel_y = -24
+	pixel_y = -24;
+	req_one_access_txt = "200;91;92"
 	},
 /turf/open/floor/almayer/no_build{
 	icon_state = "ai_floors"
@@ -61227,8 +61298,8 @@
 	pixel_y = 1
 	},
 /obj/structure/machinery/computer/crew/alt{
-	pixel_x = 17;
-	dir = 8
+	dir = 8;
+	pixel_x = 17
 	},
 /turf/open/floor/almayer/no_build{
 	icon_state = "ai_floors"
@@ -61276,9 +61347,9 @@
 "roH" = (
 /obj/effect/step_trigger/ares_alert/terminals,
 /obj/structure/machinery/door/poddoor/shutters/almayer{
+	dir = 4;
 	id = "ARES Operations Left";
-	name = "\improper ARES Operations Shutters";
-	dir = 4
+	name = "\improper ARES Operations Shutters"
 	},
 /obj/structure/pipes/standard/simple/hidden/supply/no_boom{
 	dir = 4
@@ -61393,11 +61464,17 @@
 /turf/open/floor/plating,
 /area/almayer/living/offices/flight)
 "rrq" = (
-/turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "blue"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/area/almayer/squads/delta)
+/obj/structure/machinery/status_display{
+	pixel_y = 30
+	},
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/almayer/squads/alpha)
 "rrB" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/comdoor/reinforced{
 	name = "\improper Cryogenics Bay"
@@ -61594,7 +61671,7 @@
 "rvT" = (
 /obj/structure/pipes/standard/manifold/hidden/supply,
 /turf/open/floor/almayer{
-	icon_state = "cargo_arrow"
+	icon_state = "emerald"
 	},
 /area/almayer/squads/charlie)
 "rwv" = (
@@ -62989,9 +63066,9 @@
 	},
 /obj/structure/machinery/light{
 	dir = 8;
+	invisibility = 101;
 	unacidable = 1;
-	unslashable = 1;
-	invisibility = 101
+	unslashable = 1
 	},
 /turf/open/floor/almayer/no_build{
 	icon_state = "ai_floors"
@@ -62999,8 +63076,8 @@
 /area/almayer/command/airoom)
 "sdl" = (
 /obj/structure/surface/rack{
-	pixel_y = 16;
-	density = 0
+	density = 0;
+	pixel_y = 16
 	},
 /obj/item/tool/wet_sign,
 /obj/item/tool/wet_sign,
@@ -64440,8 +64517,14 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/lifeboat_pumps/south1)
 "sNb" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/machinery/light,
 /turf/open/floor/almayer{
-	dir = 8;
 	icon_state = "orange"
 	},
 /area/almayer/squads/bravo)
@@ -65555,8 +65638,8 @@
 "tmK" = (
 /obj/structure/machinery/door/airlock/almayer/maint{
 	dir = 1;
-	req_one_access_txt = "91;92";
-	req_one_access = null
+	req_one_access = null;
+	req_one_access_txt = "91;92"
 	},
 /turf/open/floor/almayer/no_build{
 	icon_state = "test_floor4"
@@ -69661,6 +69744,9 @@
 	name = "synthetic potted plant";
 	pixel_y = 8
 	},
+/obj/structure/machinery/alarm/almayer{
+	dir = 1
+	},
 /turf/open/floor/almayer{
 	dir = 9;
 	icon_state = "orange"
@@ -70002,10 +70088,10 @@
 /area/almayer/hull/lower_hull/l_m_p)
 "vhe" = (
 /obj/structure/prop/server_equipment/yutani_server{
-	pixel_y = 16;
-	name = "server tower";
+	density = 0;
 	desc = "A powerful server tower housing various AI functions.";
-	density = 0
+	name = "server tower";
+	pixel_y = 16
 	},
 /turf/open/floor/almayer/no_build{
 	icon_state = "ai_floors"
@@ -70902,8 +70988,8 @@
 	dir = 4
 	},
 /turf/open/floor/almayer/no_build{
-	icon_state = "silver";
-	dir = 8
+	dir = 8;
+	icon_state = "silver"
 	},
 /area/almayer/command/airoom)
 "vBm" = (
@@ -72549,17 +72635,17 @@
 	plane = -7
 	},
 /obj/effect/step_trigger/ares_alert/public{
+	alert_id = "AresStairs";
 	alert_message = "Caution: Movement detected in ARES Core.";
-	cooldown_duration = 1200;
-	alert_id = "AresStairs"
+	cooldown_duration = 1200
 	},
 /obj/structure/machinery/door/poddoor/almayer/blended/white/open{
-	open_layer = 1.9;
-	id = "ARES Emergency";
-	needs_power = 0;
-	name = "ARES Emergency Lockdown";
-	layer = 3.2;
 	closed_layer = 3.2;
+	id = "ARES Emergency";
+	layer = 3.2;
+	name = "ARES Emergency Lockdown";
+	needs_power = 0;
+	open_layer = 1.9;
 	plane = -7
 	},
 /turf/open/floor/almayer/no_build{
@@ -73204,9 +73290,9 @@
 /obj/structure/surface/table/reinforced/almayer_B,
 /obj/structure/machinery/door_control{
 	id = "ARES Emergency";
+	indestructible = 1;
 	name = "ARES Emergency Lockdown";
-	req_one_access_txt = "91;92";
-	indestructible = 1
+	req_one_access_txt = "91;92"
 	},
 /turf/open/floor/almayer/no_build{
 	icon_state = "plating"
@@ -74530,8 +74616,8 @@
 /area/almayer/living/gym)
 "xbN" = (
 /obj/structure/surface/rack{
-	pixel_y = 16;
-	density = 0
+	density = 0;
+	pixel_y = 16
 	},
 /obj/structure/janitorialcart,
 /obj/item/tool/mop,
@@ -75016,6 +75102,21 @@
 /obj/structure/largecrate/random/barrel/yellow,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_m_s)
+"xoe" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/machinery/status_display{
+	pixel_y = -29
+	},
+/turf/open/floor/almayer{
+	dir = 8;
+	icon_state = "bluecorner"
+	},
+/area/almayer/squads/delta)
 "xoh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -75340,14 +75441,14 @@
 /obj/structure/machinery/door_control{
 	id = "ARES StairsLower";
 	name = "ARES Core Lockdown";
-	req_one_access_txt = "19;200;90;91;92";
 	pixel_x = 24;
-	pixel_y = 8
+	pixel_y = 8;
+	req_one_access_txt = "19;200;90;91;92"
 	},
 /obj/effect/step_trigger/clone_cleaner,
 /turf/open/floor/almayer/no_build{
-	icon_state = "silver";
-	dir = 4
+	dir = 4;
+	icon_state = "silver"
 	},
 /area/almayer/command/airoom)
 "xvX" = (
@@ -76583,9 +76684,9 @@
 /obj/structure/machinery/door_control{
 	id = "ARES StairsUpper";
 	name = "ARES Core Access";
-	req_one_access_txt = "1;200;90;91;92";
+	pixel_x = 24;
 	pixel_y = 24;
-	pixel_x = 24
+	req_one_access_txt = "1;200;90;91;92"
 	},
 /turf/open/floor/almayer/no_build{
 	icon_state = "ai_floors"
@@ -117827,10 +117928,10 @@ aMC
 aLT
 avv
 bfu
-bgV
-aPM
+rGj
+aQT
 aLT
-aQP
+aTv
 blB
 bnp
 aTx
@@ -117871,11 +117972,11 @@ bMy
 bJC
 cog
 chN
-cje
-bFh
+mzg
+cdP
 bJC
 dpO
-ckR
+ckX
 cli
 coj
 bSJ
@@ -118030,10 +118131,10 @@ aLT
 aLT
 aLT
 bfw
-bgV
-aPM
+rGj
+aQT
 aLT
-aQQ
+aTv
 blB
 kiU
 aQL
@@ -118074,11 +118175,11 @@ bJC
 bJC
 bJC
 chO
-cje
-bFh
+mzg
+cdP
 bJC
-cks
-ckR
+dpO
+ckX
 clj
 bSJ
 bSJ
@@ -118233,10 +118334,10 @@ aMB
 bdA
 aLT
 ial
-aMz
-aPM
+rGj
+aPl
 aLT
-aQP
+aPn
 aRU
 bnr
 aQL
@@ -118277,11 +118378,11 @@ bMx
 cgr
 bJC
 raK
-cje
-bFh
+mzg
+bgV
 bJC
-cks
-ckR
+cje
+ckX
 iyS
 bSJ
 clJ
@@ -118436,10 +118537,10 @@ bdr
 bdA
 aLT
 bfx
-bgV
-aPM
+rGj
+aQT
 aLT
-aQP
+aTv
 blB
 vJV
 aQL
@@ -118480,11 +118581,11 @@ cfo
 cgr
 bJC
 chQ
-cje
-bFh
+mzg
+cdP
 bJC
-cks
-ckR
+dpO
+ckX
 clk
 bSJ
 clJ
@@ -118639,10 +118740,10 @@ bdr
 bdC
 beR
 bfy
-bgV
-aPM
+rGj
+aQT
 aLT
-aQR
+aTv
 blB
 bnt
 bpG
@@ -118683,11 +118784,11 @@ cfo
 cgs
 chk
 chR
-cje
-bFh
+mzg
+cdP
 bJC
-cku
-ckR
+dpO
+ckX
 cll
 clE
 clK
@@ -118841,13 +118942,13 @@ bco
 bdr
 bdA
 aLT
-bfx
+bfD
 aPj
-aPN
+aPl
 aLT
-aQS
-aRT
-bnu
+aPn
+blB
+sNb
 aQL
 brr
 aRT
@@ -118885,13 +118986,13 @@ cdV
 cfo
 cgr
 bJC
-chN
-bJD
-bFi
+foL
+mzg
+bgW
 bJC
-ckv
-bTA
-clm
+ckR
+ckX
+loS
 bSJ
 clJ
 clg
@@ -119045,12 +119146,12 @@ aMC
 bdA
 aLT
 bfx
-bgW
-aPM
+bgY
+aQT
 aLT
-aQP
+aTv
 blB
-bnu
+nCp
 aQL
 brr
 aUY
@@ -119089,11 +119190,11 @@ bMy
 cgr
 bJC
 chP
-cje
-bFh
+mzg
+cdP
 bJC
-cks
-ckR
+dpO
+ckX
 cln
 bSJ
 clJ
@@ -119248,10 +119349,10 @@ aLT
 aLT
 aLT
 hQW
-bgW
-aPM
+bgY
+aQT
 aLT
-aQP
+aTv
 blB
 qhU
 aQL
@@ -119292,11 +119393,11 @@ bJC
 bJC
 bJC
 uUo
-cje
+mzg
 cdP
 bJC
-cjF
-ckR
+dpO
+ckX
 sUO
 bSJ
 bSJ
@@ -119451,11 +119552,11 @@ aMB
 bdD
 aLT
 bfz
+bgY
 aPl
-aQT
 aLT
-aTv
-aRT
+aPn
+blB
 bnu
 aQL
 brt
@@ -119496,10 +119597,10 @@ cgt
 bJC
 chS
 bQA
-bFh
+bgV
 bJC
-cks
-bTA
+ckR
+ckX
 meu
 bSJ
 clL
@@ -119653,13 +119754,13 @@ bcE
 bdr
 bdD
 aLT
-bfx
-bgW
-aPM
+rrq
+bgY
+aQT
 aLT
-aQP
+aTv
 blB
-bnu
+mtr
 aQL
 brt
 bpC
@@ -119699,11 +119800,11 @@ cgt
 bJC
 chQ
 cjf
-bFh
+cdP
 bJC
-cks
-ckR
-clo
+dpO
+ckX
+xoe
 bSJ
 clL
 clg
@@ -119857,10 +119958,10 @@ bdr
 bdC
 beS
 bfy
-bgW
-aPM
+bgY
+aQT
 aLT
-aQP
+aTv
 blB
 bnt
 bpH
@@ -119902,10 +120003,10 @@ cgs
 chl
 chR
 cjf
-bFh
+cdP
 bJC
-cks
-ckR
+dpO
+ckX
 cll
 clF
 clK
@@ -120060,10 +120161,10 @@ aMC
 bdD
 aLT
 bfC
+bgY
 aPl
-aPM
 aLT
-aQU
+aPn
 aRX
 cSQ
 aQL
@@ -120104,10 +120205,10 @@ bMy
 cgt
 bJC
 chV
-bQB
-bFh
+cjf
+bgV
 bJC
-ckx
+ckR
 bTC
 mvl
 bSJ
@@ -120262,13 +120363,13 @@ aLT
 aLT
 aLT
 aLT
-bfD
-bgW
-aPM
+bfx
+bgY
+aQT
 aLT
-aQV
+aTv
 blB
-bnu
+sNb
 aQL
 aQL
 aQL
@@ -120308,11 +120409,11 @@ bJC
 bJC
 chW
 rvT
-bFh
+cdP
 bJC
-cky
-ckR
-cln
+dpO
+ckX
+hAZ
 bSJ
 bSJ
 bSJ
@@ -120467,12 +120568,12 @@ aLT
 bpL
 bfE
 njd
-aPN
+aQT
 aLT
-aQS
+aTv
 blB
 uvu
-sNb
+aUZ
 aQL
 bsS
 mqK
@@ -120508,15 +120609,15 @@ bJC
 cfp
 cgu
 bJC
-fcB
+bMx
 chQ
 cjf
-bFh
+cdP
 bJC
-cks
-ckR
+dpO
+ckX
 clo
-rrq
+bVn
 bSJ
 clM
 clS
@@ -120669,11 +120770,11 @@ bdr
 bkg
 aMz
 bfy
+bgY
 aPl
-aPM
 aLT
-aQP
-aRT
+aPn
+blB
 bnt
 aRT
 ihY
@@ -120713,11 +120814,11 @@ cfo
 chm
 bJD
 chR
-bQB
-bFi
+cjf
+bgW
 bJC
-ckv
-bTA
+ckR
+ckX
 cll
 bTA
 clG
@@ -120872,10 +120973,10 @@ aLT
 aLT
 brv
 nuA
-bgW
-aPM
+bgY
+aQT
 aLT
-aQP
+aTv
 blB
 oiQ
 lml
@@ -120917,10 +121018,10 @@ bJC
 cdf
 jxx
 cjf
-bFh
+cdP
 bJC
-cks
-ckR
+dpO
+ckX
 rXj
 gfo
 bSJ
@@ -121075,10 +121176,10 @@ bdr
 bpK
 aMz
 bfy
-bgW
-aPM
+bgY
+aQT
 aLT
-aQP
+aTv
 blB
 bnt
 aRT
@@ -121120,10 +121221,10 @@ chn
 bJD
 chR
 cjf
-bFh
+cdP
 bJC
-cks
-ckR
+dpO
+ckX
 cll
 bTA
 clH
@@ -121278,11 +121379,11 @@ bdv
 aLT
 bry
 bfu
-aPn
+bgY
 jVr
 aLT
 kXa
-aRZ
+blB
 chL
 lAl
 aQL
@@ -121322,11 +121423,11 @@ cgv
 bJC
 wqc
 chN
-bQC
+cjf
 lok
 bJC
 ihM
-bTE
+ckX
 clm
 hXY
 bSJ


### PR DESCRIPTION
# About the pull request

Title basically explains it

Some "issues"

downwards-facing prep rooms have a bit of a weird perspective thing going on but they already had those anyway so????

some items spawn on the floor below your sprite instead of on the vendor (because of where the vendor actually is) I dont think this is much of an issue to be honest it might be slightly confusing for all of 3 seconds

video to follow 
https://streamable.com/mf2bs2

# Explain why it's good for the game

It allows players who are prepping in the main hall of squad prep to indent themselves so that they're not pushed by people who're just running down the hall


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: SpartanBobby
maptweaks: edits Almayer squad preps to allow for more space
/:cl:
