### PR TITLE
Synthetic Gas fixes

### DIFF
--- a/code/game/objects/effects/effect_system/smoke.dm
+++ b/code/game/objects/effects/effect_system/smoke.dm
@@ -132,6 +132,8 @@
 
 /obj/effect/particle_effect/smoke/bad/affect(mob/living/carbon/M)
 	..()
+	if (isxeno(M) || isyautja(M) || issynth(M))
+		return
 	if (M.internal != null && M.wear_mask && (M.wear_mask.flags_inventory & ALLOWINTERNALS))
 		return
 	else
@@ -365,7 +367,7 @@
 
 /obj/effect/particle_effect/smoke/xeno_weak/affect(mob/living/carbon/moob) // This applies every tick someone is in the smoke
 	..()
-	if(isxeno(moob))
+	if(isxeno(moob) || issynth(moob))
 		return
 	if(isyautja(moob))
 		neuro_dose = neuro_dose*2 // Yautja get half effects


### PR DESCRIPTION
# About the pull request

Synthetics are no longer effected by boiler's neurotoxin gas

Synth, xenos and predators no longer drop items and cough in normal smoke

# Explain why it's good for the game

Robot beep boops, ignores neurotoxins,

Smoke dropping LRP for non-humans

# Changelog

:cl: ghostsheet
fix: Synthetics are no longer affect by neurotoxin gas.
fix: Synthetics, Predators and Xenos are no longer affect by regular smoke.
/:cl:
