### PR TITLE
B5 Hammer slowdown

### DIFF
--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -327,10 +327,8 @@
 
 /obj/item/weapon/twohanded/breacher/synth/pickup(mob/user)
 	if(!(HAS_TRAIT(user, TRAIT_SUPER_STRONG)))
-		to_chat(user, SPAN_HIGHDANGER("You barely manage to lift \the [src] above your knees. This thing will probably be useless to you."))
-		user.apply_effect(6, EYE_BLUR)
-		user.apply_effect(3, DAZE)
-		user.emote("pain")
+		to_chat(user, SPAN_HIGHDANGER("You barely manage to lift [src] above your knees. This thing will probably be useless to you."))
+		user.apply_effect(3, EYE_BLUR)
 		RegisterSignal(user, COMSIG_HUMAN_POST_MOVE_DELAY, PROC_REF(handle_movedelay))
 
 		return

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -323,25 +323,29 @@
 	item_state = "syn_breacher"
 	force_wielded = MELEE_FORCE_VERY_STRONG
 	really_heavy = TRUE
+	var/move_delay_addition = 1.5
 
 /obj/item/weapon/twohanded/breacher/synth/pickup(mob/user)
 	if(!(HAS_TRAIT(user, TRAIT_SUPER_STRONG)))
-		to_chat(user, SPAN_WARNING("You barely manage to lift \the [src] above your knees. This thing will probably be useless to you."))
-		user.apply_effect(1.1, SLOW)
-		START_PROCESSING(SSobj, src)
+		to_chat(user, SPAN_HIGHDANGER("You barely manage to lift \the [src] above your knees. This thing will probably be useless to you."))
+		user.apply_effect(6, EYE_BLUR)
+		user.apply_effect(3, DAZE)
+		user.emote("pain")
+		RegisterSignal(user, COMSIG_HUMAN_POST_MOVE_DELAY, PROC_REF(handle_movedelay))
+
 		return
 	..()
+
+/obj/item/weapon/twohanded/breacher/synth/proc/handle_movedelay(mob/living/M, list/movedata)
+	SIGNAL_HANDLER
+	movedata["move_delay"] += move_delay_addition
+
+/obj/item/weapon/twohanded/breacher/synth/dropped(mob/user, silent)
+	. = ..()
+	UnregisterSignal(user, COMSIG_HUMAN_POST_MOVE_DELAY)
 
 /obj/item/weapon/twohanded/breacher/synth/attack(target as mob, mob/living/user as mob)
 	if(!HAS_TRAIT(user, TRAIT_SUPER_STRONG))
 		to_chat(user, SPAN_WARNING("\The [src] is too heavy for you to use as a weapon!"))
 		return
 	..()
-
-/obj/item/weapon/twohanded/breacher/synth/process()
-	var/mob/user = src.loc
-	if(istype(user) && !(HAS_TRAIT(user, TRAIT_SUPER_STRONG)))
-		user.apply_effect(1.1, SLOW)
-		return
-
-	STOP_PROCESSING(SSobj, src)

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -327,6 +327,8 @@
 /obj/item/weapon/twohanded/breacher/synth/pickup(mob/user)
 	if(!(HAS_TRAIT(user, TRAIT_SUPER_STRONG)))
 		to_chat(user, SPAN_WARNING("You barely manage to lift \the [src] above your knees. This thing will probably be useless to you."))
+		user.apply_effect(1.1, SLOW)
+		START_PROCESSING(SSobj, src)
 		return
 	..()
 
@@ -335,3 +337,11 @@
 		to_chat(user, SPAN_WARNING("\The [src] is too heavy for you to use as a weapon!"))
 		return
 	..()
+
+/obj/item/weapon/twohanded/breacher/synth/process()
+	var/mob/user = src.loc
+	if(istype(user) && !(HAS_TRAIT(user, TRAIT_SUPER_STRONG)))
+		user.apply_effect(1.1, SLOW)
+		return
+
+	STOP_PROCESSING(SSobj, src)


### PR DESCRIPTION
# About the pull request

This makes Synth b5 breaching hammer, apply a slowdown to (marines) anyone who picks it up but doesn't have the strength to use it.

Added extra warning and effect to show that MARINE REALLY SHOULDN'T pick it up and try to use it.

# Explain why it's good for the game

Synth have been complaining that marines are running off their hammer. 
The visible slowdown should prevent marines from running off with it too often

# Changelog

:cl: ghostsheet
add: B5 Breaching Hammer will now slow down humans who picks it up.
/:cl: