### PR TITLE
Fixes the damage caused by the HE OB

### DIFF
--- a/code/modules/cm_marines/orbital_cannon.dm
+++ b/code/modules/cm_marines/orbital_cannon.dm
@@ -430,7 +430,6 @@ var/list/ob_type_fuel_requirements
 	icon_state = "ob_warhead_1"
 	shake_frequency = 3
 	max_shake_factor = 15
-	max_knockdown_time = 6
 
 	var/clear_power = 1200
 	var/clear_falloff = 400


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Fixes issue #3863

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

This PR fixes an unintentional nerf to the HE OB.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->


BEFORE:
Mature Queen, Praetorian, Crusher, Ravager at the edge of the screen from a HE OB
![image](https://github.com/cmss13-devs/cmss13/assets/8739855/78e6581c-1a97-4fa5-b86a-2a2f58b6fcf3)
Prae gets obliterated, Ravager goes into crit, Crusher has 435 health, Queen has 726 health.
AFTER:
same setup
Prae gets obliterated, Ravager gets obliterated, Crusher has 253 health, Queen has 539 health.


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: The HE OB now deals the correct amount of damage to xenos, before it dealt half damage caused by xenos being forced to rest before it hit.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
