### PR TITLE
fixes the 'alien blade' on LV

### DIFF
--- a/maps/map_files/LV624/LV624.dmm
+++ b/maps/map_files/LV624/LV624.dmm
@@ -14106,10 +14106,9 @@
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/colony/west_nexus_road)
 "fja" = (
-/obj/item/attachable/bayonet{
+/obj/item/weapon/unathiknife{
 	desc = "A curved blade made of a strange material. It looks both old and very sharp.";
 	force = 30;
-	icon_state = "unathiknife";
 	name = "\improper alien blade";
 	throwforce = 26
 	},
@@ -17272,10 +17271,9 @@
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/sand_temple)
 "nED" = (
-/obj/item/attachable/bayonet{
+/obj/item/weapon/unathiknife{
 	desc = "A curved blade made of a strange material. It looks both old and very sharp.";
 	force = 30;
-	icon_state = "unathiknife";
 	name = "\improper alien blade";
 	throwforce = 26
 	},

--- a/maps/map_files/LV624/standalone/sandtemple-jungle.dmm
+++ b/maps/map_files/LV624/standalone/sandtemple-jungle.dmm
@@ -55,10 +55,9 @@
 /turf/closed/wall/strata_ice/jungle,
 /area/lv624/ground/jungle/south_west_jungle)
 "lR" = (
-/obj/item/attachable/bayonet{
+/obj/item/weapon/unathiknife{
 	desc = "A curved blade made of a strange material. It looks both old and very sharp.";
 	force = 30;
-	icon_state = "unathiknife";
 	name = "\improper alien blade";
 	throwforce = 26
 	},


### PR DESCRIPTION

# About the pull request
Changes the 'alien blade' on LV from an icon missing bayonet (clown mask) to the actual item it is supposed to look like.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Fixes the icon on the alien blade on LV.
/:cl:
