### PR TITLE
Airburst Packet Typo Fix

### DIFF
--- a/code/controllers/subsystem/x_evolution.dm
+++ b/code/controllers/subsystem/x_evolution.dm
@@ -3,7 +3,7 @@
 #define EVOLUTION_INCREMENT_TIME (30 MINUTES) // Evolution increases by 1 every 25 minutes.
 
 SUBSYSTEM_DEF(xevolution)
-	name = "Evilution"
+	name = "Evilution" //This is not a typo, do not change it.
 	wait = 1 MINUTES
 	priority = SS_PRIORITY_INACTIVITY
 

--- a/code/modules/projectiles/ammo_boxes/grenade_packets.dm
+++ b/code/modules/projectiles/ammo_boxes/grenade_packets.dm
@@ -110,19 +110,19 @@ var/list/grenade_packets = list(
 	content_type = /obj/item/explosive/grenade/high_explosive/m15/rubber
 
 /obj/item/storage/box/packet/airburst_he
-	name = "\improper M74 airbust grenade packet"
+	name = "\improper M74 airburst grenade packet"
 	desc = "It contains three M74 airburst fragmentation grenades. This end towards the enemy."
 	icon_state = "agmf_packet"
 	content_type = /obj/item/explosive/grenade/high_explosive/airburst
 
 /obj/item/storage/box/packet/airburst_incen
-	name = "\improper M74 airbust incendiary grenade packet"
+	name = "\improper M74 airburst incendiary grenade packet"
 	desc = "It contains three M74 airburst incendiary grenades. This end towards the enemy."
 	icon_state = "agmi_packet"
 	content_type = /obj/item/explosive/grenade/incendiary/airburst
 
 /obj/item/storage/box/packet/airburst_smoke
-	name = "\improper M74 airbust smoke grenade packet"
+	name = "\improper M74 airburst smoke grenade packet"
 	desc = "It contains three M74 airburst smoke grenades. This end towards the enemy."
 	icon_state = "agms_packet"
 	content_type = /obj/item/explosive/grenade/smokebomb/airburst


### PR DESCRIPTION

# About the pull request

Fixes typo related to grenade airburst packets

# Explain why it's good for the game

It isn't. This will actively worsen the experience of the game.

# Changelog
:cl:
spellcheck: Fixed typos relating to M74 airburst packets.
/:cl:
