### PR TITLE
Renames Pred Ship

### DIFF
--- a/code/modules/cm_preds/yaut_items.dm
+++ b/code/modules/cm_preds/yaut_items.dm
@@ -396,7 +396,7 @@
 		return
 
 	var/mob/living/carbon/human/H = user
-	var/ship_to_tele = list("Public" = -1, "Human Ship" = "Human")
+	var/ship_to_tele = list("Yautja Ship" = -1, "Human Ship" = "Human")
 
 	if(!HAS_TRAIT(H, TRAIT_YAUTJA_TECH) || is_admin_level(H.z))
 		to_chat(user, SPAN_WARNING("You fiddle with it, but nothing happens!"))


### PR DESCRIPTION

# About the pull request

Renames the teleport name for the predator ship from "Public" to "Yautja Ship".

# Explain why it's good for the game

Ancient hold over from when there were multiple places preds spawned. Makes more in universe sense for the area to be called the Predator ship instead of public. Thematically in-tone alongside 'Human Ship"


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
ui: Predator Ship is now called 'Yautja Ship" for teleporting Predators
/:cl:
