### PR TITLE
Hard delete fixes for predator landmarks and van if their area changes

### DIFF
--- a/code/game/objects/effects/landmarks/landmarks.dm
+++ b/code/game/objects/effects/landmarks/landmarks.dm
@@ -216,23 +216,25 @@
 
 /obj/effect/landmark/yautja_teleport
 	name = "yautja_teleport"
+	/// The index we registered as in mainship_yautja_desc or yautja_teleport_descs
+	var/desc_index
 
 /obj/effect/landmark/yautja_teleport/Initialize(mapload, ...)
 	. = ..()
-	var/turf/T = get_turf(src)
+	var/turf/turf = get_turf(src)
+	desc_index = turf.loc.name + turf.loc_to_string()
 	if(is_mainship_level(z))
 		GLOB.mainship_yautja_teleports += src
-		GLOB.mainship_yautja_desc[T.loc.name + T.loc_to_string()] = src
+		GLOB.mainship_yautja_desc[desc_index] = src
 	else
 		GLOB.yautja_teleports += src
-		GLOB.yautja_teleport_descs[T.loc.name + T.loc_to_string()] = src
+		GLOB.yautja_teleport_descs[desc_index] = src
 
 /obj/effect/landmark/yautja_teleport/Destroy()
-	var/turf/T = get_turf(src)
 	GLOB.mainship_yautja_teleports -= src
 	GLOB.yautja_teleports -= src
-	GLOB.mainship_yautja_desc -= T.loc.name + T.loc_to_string()
-	GLOB.yautja_teleport_descs -= T.loc.name + T.loc_to_string()
+	GLOB.mainship_yautja_desc -= desc_index
+	GLOB.yautja_teleport_descs -= desc_index
 	return ..()
 
 

--- a/code/modules/vehicles/interior/interior.dm
+++ b/code/modules/vehicles/interior/interior.dm
@@ -72,6 +72,7 @@
 	entrance_markers = null
 
 	QDEL_NULL(reservation)
+	SSinterior.interiors -= src
 
 	return ..()
 


### PR DESCRIPTION
# About the pull request

This PR applies the fixes previously suggested for #3671. That PR was originally replacing much of the colony in a nightmare insert and it exposed how predator landmarks do not handle their area being changed and an issue with the van being replaced. The description made for these landmarks is based on some area information and that is used to index them. This PR makes it so the description of the landmark is saved so it can still be found in the list even if the area changes.

# Explain why it's good for the game

Less hard deletes and more futureproofing.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: Drathek, Steelpoint
fix: Fixed possible hardeletes for predator landmarks and vehicles. Predator teleporation descriptions now do not change if the area is altered at runtime so they can still be found correctly.
/:cl:
