### PR TITLE
Prevent Banished in Larva Queue and Set Queue Time for Cryoing

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -241,8 +241,14 @@
 		else
 			return get_step(start, EAST)
 
-/// Get a list of observers that can be alien candidates, optionally sorted by larva_queue_time
-/proc/get_alien_candidates(sorted = TRUE)
+/**
+ * Get a list of observers that can be alien candidates.
+ *
+ * Arguments:
+ * * hive - The hive we're filling a slot for to check if the player is banished
+ * * sorted - Whether to sort by larva_queue_time (default TRUE) or leave unsorted
+ */
+/proc/get_alien_candidates(datum/hive_status/hive = null, sorted = TRUE)
 	var/list/candidates = list()
 
 	for(var/mob/dead/observer/cur_obs as anything in GLOB.observer_list)
@@ -272,6 +278,15 @@
 		// Mods with larva protection cannot be drafted
 		if((cur_obs.client.admin_holder && (cur_obs.client.admin_holder.rights & R_MOD)) && !cur_obs.adminlarva)
 			continue
+
+		if(hive)
+			var/banished = FALSE
+			for(var/mob_name in hive.banished_ckeys)
+				if(hive.banished_ckeys[mob_name] == cur_obs.ckey)
+					banished = TRUE
+					break
+			if(banished)
+				continue
 
 		candidates += cur_obs
 

--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -379,6 +379,13 @@ Additional game mode variables.
 			// No cache, lets check now then
 			message_alien_candidates(get_alien_candidates(), dequeued = 0, cache_only = TRUE)
 			if(candidate_observer.larva_queue_cached_message)
+				var/datum/hive_status/cur_hive
+				for(var/hive_num in GLOB.hive_datum)
+					cur_hive = GLOB.hive_datum[hive_num]
+					for(var/mob_name in cur_hive.banished_ckeys)
+						if(cur_hive.banished_ckeys[mob_name] == xeno_candidate.ckey)
+							candidate_observer.larva_queue_cached_message += "\n" + SPAN_WARNING("NOTE: You are banished from the [cur_hive] and you may not rejoin unless the Queen re-admits you or dies.")
+							break
 				to_chat(xeno_candidate, candidate_observer.larva_queue_cached_message)
 				return FALSE
 

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -503,23 +503,25 @@ GLOBAL_LIST_INIT(frozen_items, list(SQUAD_MARINE_1 = list(), SQUAD_MARINE_2 = li
 		add_fingerprint(usr)
 
 
-/obj/structure/machinery/cryopod/proc/go_in_cryopod(mob/M, silent = FALSE)
+/obj/structure/machinery/cryopod/proc/go_in_cryopod(mob/mob, silent = FALSE)
 	if(occupant)
 		return
-	M.forceMove(src)
-	occupant = M
+	mob.forceMove(src)
+	occupant = mob
 	icon_state = "body_scanner_closed"
 	SetLuminosity(2)
 	time_entered = world.time
 	start_processing()
 
 	if(!silent)
-		if(M.client)
-			to_chat(M, SPAN_NOTICE("You feel cool air surround you. You go numb as your senses turn inward."))
-			to_chat(M, SPAN_BOLDNOTICE("If you log out or close your client now, your character will permanently removed from the round in 10 minutes. If you ghost, timer will be decreased to 2 minutes."))
+		if(mob.client)
+			to_chat(mob, SPAN_NOTICE("You feel cool air surround you. You go numb as your senses turn inward."))
+			to_chat(mob, SPAN_BOLDNOTICE("If you log out or close your client now, your character will permanently removed from the round in 10 minutes. If you ghost, timer will be decreased to 2 minutes."))
+			if(!is_admin_level(src.z)) // Set their queue time now because the client has to actually leave to despawn and at that point the client is lost
+				mob.client.player_details.larva_queue_time = max(mob.client.player_details.larva_queue_time, world.time)
 		var/area/location = get_area(src)
-		if(M.job != GET_MAPPED_ROLE(JOB_SQUAD_MARINE))
-			message_admins("[key_name_admin(M)], [M.job], has entered \a [src] at [location] after playing for [duration2text(world.time - M.life_time_start)].")
+		if(mob.job != GET_MAPPED_ROLE(JOB_SQUAD_MARINE))
+			message_admins("[key_name_admin(mob)], [mob.job], has entered \a [src] at [location] after playing for [duration2text(world.time - mob.life_time_start)].")
 		playsound(src, 'sound/machines/hydraulics_3.ogg', 30)
 	silent_exit = silent
 

--- a/code/modules/cm_aliens/structures/special/pylon_core.dm
+++ b/code/modules/cm_aliens/structures/special/pylon_core.dm
@@ -150,7 +150,7 @@
 			last_larva_time = world.time
 		if(spawning_larva || (last_larva_queue_time + spawn_cooldown * 4) < world.time)
 			last_larva_queue_time = world.time
-			var/list/players_with_xeno_pref = get_alien_candidates()
+			var/list/players_with_xeno_pref = get_alien_candidates(linked_hive)
 			if(players_with_xeno_pref && players_with_xeno_pref.len)
 				if(spawning_larva && spawn_burrowed_larva(players_with_xeno_pref[1]))
 					// We were in spawning_larva mode and successfully spawned someone

--- a/code/modules/mob/living/carbon/xenomorph/Embryo.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Embryo.dm
@@ -163,7 +163,7 @@
 
 	if(!picked)
 		// Get a candidate from observers
-		var/list/candidates = get_alien_candidates()
+		var/list/candidates = get_alien_candidates(hive)
 		if(candidates && candidates.len)
 			// If they were facehugged by a player thats still in queue, they get second dibs on the new larva.
 			if(hugger_ckey)

--- a/code/modules/mob/living/carbon/xenomorph/death.dm
+++ b/code/modules/mob/living/carbon/xenomorph/death.dm
@@ -38,7 +38,7 @@
 			if(GLOB.hive_datum[hivenumber].stored_larva)
 				GLOB.hive_datum[hivenumber].stored_larva = round(GLOB.hive_datum[hivenumber].stored_larva * 0.5) //Lose half on dead queen
 
-				var/list/players_with_xeno_pref = get_alien_candidates()
+				var/list/players_with_xeno_pref = get_alien_candidates(GLOB.hive_datum[hivenumber])
 				if(players_with_xeno_pref && istype(GLOB.hive_datum[hivenumber].hive_location, /obj/effect/alien/resin/special/pylon/core))
 					var/turf/larva_spawn = get_turf(GLOB.hive_datum[hivenumber].hive_location)
 					var/count = 0

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -635,7 +635,7 @@
 			var/mob/dead/observer/obs = mob.ghostize(FALSE)
 			if(obs)
 				obs.timeofdeath = world.time
-				obs.client?.player_details.larva_queue_time = world.time
+				obs.client?.player_details.larva_queue_time = max(obs.client.player_details.larva_queue_time, world.time)
 			mob.moveToNullspace()
 
 	// Now that mobs are stowed, delete the shuttle


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

This PR makes it so the larva queue can check if the candidate is currently in the banishment list for a hive. Join as xeno checks this, but xeno candidates (even before the queue) never has.

A note of banishment is added to the queue message if join as xeno is used to check queue placement, but otherwise they just simply won't have queue messages until some hive core they aren't banished from ticks. The reason why they personally have a number at all though is because that was a check for all possible xeno hives. If say both the normal hive and greeno hive cores were ticking, there were 10 ghosts total, and 2 were banished from the normal hive, the queue length for the greeno hive would have 10 people, and the queue length for the normal hive would have 8 people, but otherwise the queue is shared.

This PR also makes it so entering a cryopod sets your queue time; otherwise any marine that cryos (even if its say two hours in a game) would be basically the front of the queue (the time would still just be their join time).

# Explain why it's good for the game

Banished players should stay banished until the queen changes her mind or dies. Cryo'd marines also shouldn't get prioritized over people who have been waiting.

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

(Message below was also tweaked to also include "This number won't change until there is a hive you aren't banished from.")
![image](https://github.com/cmss13-devs/cmss13/assets/76988376/3664fbe4-4d56-446b-a918-350e77ec1ed9)

</details>

# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl: Drathek
fix: Banished players will no longer be candidates for hives they are banished from.
fix: Cryoing will now set your larva queue time so you don't get prioritized over others that have been waiting.
admin: Shuttle intoTheSunset will set larva queue time the same as other situations.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
