### PR TITLE
AFK Facehuggers Convert to Normal Huggers

### DIFF
--- a/code/__DEFINES/xeno.dm
+++ b/code/__DEFINES/xeno.dm
@@ -168,6 +168,8 @@
 #define XENO_LEAVE_TIMER_LARVA 80 //80 seconds
 /// The time against away_timer when an AFK xeno (not larva) can be replaced
 #define XENO_LEAVE_TIMER 300 //300 seconds
+/// The time against away_timer when an AFK facehugger converts to a npc
+#define XENO_FACEHUGGER_LEAVE_TIMER 420 //420 seconds
 /// The time against away_timer when an AFK xeno gets listed in the available list so ghosts can get ready
 #define XENO_AVAILABLE_TIMER 60 //60 seconds
 

--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -333,23 +333,28 @@ Additional game mode variables.
 /datum/game_mode/proc/check_xeno_late_join(mob/xeno_candidate)
 	if(jobban_isbanned(xeno_candidate, JOB_XENOMORPH)) // User is jobbanned
 		to_chat(xeno_candidate, SPAN_WARNING("You are banned from playing aliens and cannot spawn as a xenomorph."))
-		return
-	return 1
+		return FALSE
+	return TRUE
 
-/datum/game_mode/proc/attempt_to_join_as_xeno(mob/xeno_candidate, instant_join = 0)
+/datum/game_mode/proc/attempt_to_join_as_xeno(mob/xeno_candidate, instant_join = FALSE)
 	var/list/available_xenos = list()
 	var/list/available_xenos_non_ssd = list()
 
-	for(var/mob/living/carbon/xenomorph/X in GLOB.living_xeno_list)
-		var/area/A = get_area(X)
-		if(is_admin_level(X.z) && (!A || !(A.flags_area & AREA_ALLOW_XENO_JOIN)) || X.aghosted)
-			continue //xenos on admin z level and aghosted ones don't count
-		if(istype(X) && ((!islarva(X) && (XENO_LEAVE_TIMER - X.away_timer < XENO_AVAILABLE_TIMER)) || (islarva(X) && (XENO_LEAVE_TIMER_LARVA - X.away_timer < XENO_AVAILABLE_TIMER))))
-			if(!X.client)
-				available_xenos += X
-			else
-				available_xenos_non_ssd += X
-
+	for(var/mob/living/carbon/xenomorph/cur_xeno in GLOB.living_xeno_list)
+		if(cur_xeno.aghosted)
+			continue //aghosted xenos don't count
+		var/area/area = get_area(cur_xeno)
+		if(is_admin_level(cur_xeno.z) && (!area || !(area.flags_area & AREA_ALLOW_XENO_JOIN)))
+			continue //xenos on admin z level don't count
+		if(!istype(cur_xeno))
+			continue
+		var/required_time = islarva(cur_xeno) ? XENO_LEAVE_TIMER_LARVA - cur_xeno.away_timer : XENO_LEAVE_TIMER - cur_xeno.away_timer
+		if(required_time > XENO_AVAILABLE_TIMER)
+			continue
+		if(!cur_xeno.client)
+			available_xenos += cur_xeno
+		else
+			available_xenos_non_ssd += cur_xeno
 
 	var/datum/hive_status/hive
 	for(var/hivenumber in GLOB.hive_datum)

--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -340,7 +340,7 @@ Additional game mode variables.
 	var/list/available_xenos = list()
 	var/list/available_xenos_non_ssd = list()
 
-	for(var/mob/living/carbon/xenomorph/cur_xeno in GLOB.living_xeno_list)
+	for(var/mob/living/carbon/xenomorph/cur_xeno as anything in GLOB.living_xeno_list)
 		if(cur_xeno.aghosted)
 			continue //aghosted xenos don't count
 		var/area/area = get_area(cur_xeno)

--- a/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
@@ -67,6 +67,11 @@
 		PF.flags_can_pass_all = PASS_ALL^PASS_OVER_THROW_ITEM
 
 /mob/living/carbon/xenomorph/facehugger/Life(delta_time)
+	if(!client && !aghosted && away_timer > XENO_FACEHUGGER_LEAVE_TIMER)
+		// Become a npc once again
+		new /obj/item/clothing/mask/facehugger(loc, hivenumber)
+		qdel(src)
+		return
 	if(stat != DEAD && !lying && !(locate(/obj/effect/alien/weeds) in get_turf(src)))
 		adjustBruteLoss(1)
 	return ..()


### PR DESCRIPTION

# About the pull request

This PR makes it so sentient huggers that have been AFK for 7 minutes, aren't aghosted, and have no client will convert to normal huggers (and subsequently die like normal unless they hug someone or get grabbed). I was considering removing facehuggers from the join as xeno list, but this way there's still a couple minutes they can be taken over before they convert.

# Explain why it's good for the game

This can help cleanup the afk xeno list and possibly make a funny situation if a marine happens to be nearby when one converts.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

(Timer here was set to just 10 seconds for testing)
![facehugger](https://github.com/cmss13-devs/cmss13/assets/76988376/7b6f1ac9-3408-4c83-9e14-7ff73207a50d)

</details>


# Changelog
:cl: Drathek
add: Facehuggers now convert to their NPC version after 7 minutes of inactivity and no client.
code: Cleanup join as xeno button code somewhat.
/:cl:
