### PR TITLE
Trijent Weed Tile Addition

### DIFF
--- a/maps/map_files/DesertDam/Desert_Dam.dmm
+++ b/maps/map_files/DesertDam/Desert_Dam.dmm
@@ -60906,6 +60906,12 @@
 	icon_state = "tile"
 	},
 /area/desert_dam/exterior/valley/south_valley_dam)
+"goY" = (
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
+/turf/open/mars_cave{
+	icon_state = "mars_dirt_5"
+	},
+/area/desert_dam/interior/lab_northeast/east_lab_containment)
 "gpi" = (
 /obj/structure/prop/dam/large_boulder/boulder1,
 /turf/open/desert/dirt,
@@ -64042,6 +64048,10 @@
 	icon_state = "wood"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_west_hallway)
+"rEa" = (
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
+/turf/open/floor/plating,
+/area/desert_dam/interior/lab_northeast/east_lab_biology)
 "rEH" = (
 /obj/structure/surface/table,
 /obj/effect/landmark/objective_landmark/close,
@@ -100042,7 +100052,7 @@ amq
 afI
 ana
 amZ
-ana
+goY
 agL
 afG
 arH
@@ -104949,7 +104959,7 @@ acu
 afG
 afI
 akW
-akW
+lNN
 agL
 amn
 afI
@@ -109407,7 +109417,7 @@ alI
 alI
 aoI
 aoN
-apg
+rEa
 apk
 apg
 apy
@@ -110579,7 +110589,7 @@ aoI
 aoN
 apg
 apk
-apg
+rEa
 apy
 afP
 amx


### PR DESCRIPTION

# About the pull request

Adds some extra weed tiles near xeno spawns on Desert Dam to prevent more circumstances of a larva spawning in a trapped area which requires a xeno to come and rescue the larva.  

# Explain why it's good for the game

We don't like trapped larva, at round start. 


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
maptweak: More weed spawns so larva don't spawn in area with no weed to evolve on. 
/:cl:
