### PR TITLE
De-Squads the Spotter

### DIFF
--- a/code/game/objects/items/pamphlets.dm
+++ b/code/game/objects/items/pamphlets.dm
@@ -96,8 +96,8 @@
 	user.hud_set_squad()
 
 	var/obj/item/card/id/ID = user.wear_id
-	ID.set_assignment((user.assigned_squad ? (user.assigned_squad.name + " ") : "") + "Squad Spotter")
-	GLOB.data_core.manifest_modify(user.real_name, WEAKREF(user), "Squad Spotter")
+	ID.set_assignment((user.assigned_squad ? (user.assigned_squad.name + " ") : "") + "Spotter")
+	GLOB.data_core.manifest_modify(user.real_name, WEAKREF(user), "Spotter")
 
 /obj/item/pamphlet/skill/machinegunner
 	name = "heavy machinegunner instructional pamphlet"


### PR DESCRIPTION

# About the pull request

Title.

# Explain why it's good for the game

Barring the *Squad* Leader, no other job has the Squad prefix. This fixes that.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

Labelled spelling fix as there isn't exactly a "consistency" one.


# Changelog
:cl:
spellcheck: Goodbye Squad Spotter, hello regular non-squaded Spotter.
/:cl:
