### PR TITLE
Knife webbing fixes and consistency

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -18,3 +18,5 @@
 //the define for visible message range in combat
 #define COMBAT_MESSAGE_RANGE 3
 #define DEFAULT_MESSAGE_RANGE 7
+
+#define BAYONET_DRAW_DELAY (1 SECONDS)

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -736,7 +736,6 @@
 	cant_hold = list()
 	flap = FALSE
 	var/draw_cooldown = 0
-	var/draw_cooldown_interval = 1 SECONDS
 
 /obj/item/storage/belt/knifepouch/fill_preset_inventory()
 	for(var/i = 1 to storage_slots)
@@ -753,7 +752,7 @@
 /obj/item/storage/belt/knifepouch/attack_hand(mob/user, mods)
 	if(draw_cooldown < world.time)
 		..()
-		draw_cooldown = world.time + draw_cooldown_interval
+		draw_cooldown = world.time + BAYONET_DRAW_DELAY
 		playsound(src, 'sound/weapons/gun_shotgun_shell_insert.ogg', 15, TRUE)
 	else
 		to_chat(user, SPAN_WARNING("You need to wait before drawing another knife!"))

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -735,7 +735,8 @@
 	)
 	cant_hold = list()
 	flap = FALSE
-	var/draw_cooldown = 0
+
+	COOLDOWN_DECLARE(draw_cooldown)
 
 /obj/item/storage/belt/knifepouch/fill_preset_inventory()
 	for(var/i = 1 to storage_slots)
@@ -750,9 +751,9 @@
 	playsound(src, 'sound/weapons/gun_shotgun_shell_insert.ogg', 15, TRUE)
 
 /obj/item/storage/belt/knifepouch/attack_hand(mob/user, mods)
-	if(draw_cooldown < world.time)
+	if(COOLDOWN_FINISHED(src, draw_cooldown))
 		..()
-		draw_cooldown = world.time + BAYONET_DRAW_DELAY
+		COOLDOWN_START(src, draw_cooldown, BAYONET_DRAW_DELAY)
 		playsound(src, 'sound/weapons/gun_shotgun_shell_insert.ogg', 15, TRUE)
 	else
 		to_chat(user, SPAN_WARNING("You need to wait before drawing another knife!"))

--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -129,7 +129,6 @@
 	storage_slots = 5
 	storage_flags = STORAGE_FLAGS_POUCH|STORAGE_USING_DRAWING_METHOD|STORAGE_ALLOW_QUICKDRAW
 	var/draw_cooldown = 0
-	var/draw_cooldown_interval = 1 SECONDS
 	var/default_knife_type = /obj/item/weapon/throwing_knife
 
 /obj/item/storage/pouch/bayonet/Initialize()
@@ -151,7 +150,7 @@
 /obj/item/storage/pouch/bayonet/attack_hand(mob/user, mods)
 	if(draw_cooldown < world.time)
 		..()
-		draw_cooldown = world.time + draw_cooldown_interval
+		draw_cooldown = world.time + BAYONET_DRAW_DELAY
 		playsound(src, 'sound/weapons/gun_shotgun_shell_insert.ogg', 15, TRUE)
 	else
 		to_chat(user, SPAN_WARNING("You need to wait before drawing another knife!"))

--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -128,8 +128,9 @@
 	icon_state = "bayonet"
 	storage_slots = 5
 	storage_flags = STORAGE_FLAGS_POUCH|STORAGE_USING_DRAWING_METHOD|STORAGE_ALLOW_QUICKDRAW
-	var/draw_cooldown = 0
 	var/default_knife_type = /obj/item/weapon/throwing_knife
+
+	COOLDOWN_DECLARE(draw_cooldown)
 
 /obj/item/storage/pouch/bayonet/Initialize()
 	. = ..()
@@ -148,9 +149,9 @@
 	playsound(src, 'sound/weapons/gun_shotgun_shell_insert.ogg', 15, TRUE)
 
 /obj/item/storage/pouch/bayonet/attack_hand(mob/user, mods)
-	if(draw_cooldown < world.time)
+	if(COOLDOWN_FINISHED(src, draw_cooldown))
 		..()
-		draw_cooldown = world.time + BAYONET_DRAW_DELAY
+		COOLDOWN_START(src, draw_cooldown, BAYONET_DRAW_DELAY)
 		playsound(src, 'sound/weapons/gun_shotgun_shell_insert.ogg', 15, TRUE)
 	else
 		to_chat(user, SPAN_WARNING("You need to wait before drawing another knife!"))

--- a/code/modules/clothing/under/ties.dm
+++ b/code/modules/clothing/under/ties.dm
@@ -593,6 +593,12 @@
 	icon_state = "vest_knives"
 	hold = /obj/item/storage/internal/accessory/knifeharness
 
+/obj/item/clothing/accessory/storage/knifeharness/attack_hand(mob/user, mods)
+	if(!mods || !mods["alt"] || !length(hold.contents))
+		return ..()
+
+	hold.contents[length(contents)].attack_hand(user, mods)
+
 /obj/item/storage/internal/accessory/knifeharness
 	storage_slots = 5
 	max_storage_space = 5
@@ -603,6 +609,31 @@
 		/obj/item/attachable/bayonet,
 		/obj/item/weapon/throwing_knife,
 	)
+	storage_flags = STORAGE_ALLOW_QUICKDRAW|STORAGE_FLAGS_POUCH
+	var/draw_cooldown = 0
+
+/obj/item/storage/internal/accessory/knifeharness/fill_preset_inventory()
+	for(var/i = 1 to storage_slots)
+		new /obj/item/weapon/throwing_knife(src)
+
+/obj/item/storage/internal/accessory/knifeharness/attack_hand(mob/user, mods)
+	. = ..()
+
+	if(draw_cooldown >= world.time)
+		to_chat(user, SPAN_WARNING("You need to wait before drawing another knife!"))
+		return FALSE
+
+	if(length(contents))
+		contents[length(contents)].attack_hand(user, mods)
+		draw_cooldown = world.time + BAYONET_DRAW_DELAY
+
+/obj/item/storage/internal/accessory/knifeharness/_item_insertion(obj/item/inserted_item, prevent_warning = 0)
+	..()
+	playsound(src, 'sound/weapons/gun_shotgun_shell_insert.ogg', 15, TRUE)
+
+/obj/item/storage/internal/accessory/knifeharness/_item_removal(obj/item/removed_item, atom/new_location)
+	..()
+	playsound(src, 'sound/weapons/gun_shotgun_shell_insert.ogg', 15, TRUE)
 
 /obj/item/clothing/accessory/storage/knifeharness/duelling
 	name = "decorated harness"

--- a/code/modules/clothing/under/ties.dm
+++ b/code/modules/clothing/under/ties.dm
@@ -610,7 +610,8 @@
 		/obj/item/weapon/throwing_knife,
 	)
 	storage_flags = STORAGE_ALLOW_QUICKDRAW|STORAGE_FLAGS_POUCH
-	var/draw_cooldown = 0
+
+	COOLDOWN_DECLARE(draw_cooldown)
 
 /obj/item/storage/internal/accessory/knifeharness/fill_preset_inventory()
 	for(var/i = 1 to storage_slots)
@@ -619,13 +620,13 @@
 /obj/item/storage/internal/accessory/knifeharness/attack_hand(mob/user, mods)
 	. = ..()
 
-	if(draw_cooldown >= world.time)
+	if(!COOLDOWN_FINISHED(src, draw_cooldown))
 		to_chat(user, SPAN_WARNING("You need to wait before drawing another knife!"))
 		return FALSE
 
 	if(length(contents))
 		contents[length(contents)].attack_hand(user, mods)
-		draw_cooldown = world.time + BAYONET_DRAW_DELAY
+		COOLDOWN_START(src, draw_cooldown, BAYONET_DRAW_DELAY)
 
 /obj/item/storage/internal/accessory/knifeharness/_item_insertion(obj/item/inserted_item, prevent_warning = 0)
 	..()

--- a/code/modules/projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/gun_helpers.dm
@@ -554,6 +554,12 @@ As sniper rifles have both and weapon mods can change them as well. ..() deals w
 			var/obj/item/storage/internal/accessory/holster/holster = cycled_holster.hold
 			if(holster.current_gun)
 				return holster.current_gun
+
+		for(var/obj/item/clothing/accessory/storage/cycled_accessory in w_uniform.accessories)
+			var/obj/item/storage/internal/accessory/accessory_storage = cycled_accessory.hold
+			if(accessory_storage.storage_flags & STORAGE_ALLOW_QUICKDRAW)
+				return accessory_storage
+
 		return FALSE
 
 	if(istype(slot) && (slot.storage_flags & STORAGE_ALLOW_QUICKDRAW))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

This PR:

Adds sounds for inserting and removing knifes to the knife webbing

Adds draw delay for knives to the knife webbing

Allows using quickdraw with the knife webbing

Standardizes knife draw delay in a define

Knife webbing is now spawned full

Allows knife webbing to be alt-clicked to draw from it

Reviewer notes:
The gun helper stuff looks weird to me. I don't think we ever have to iterate through internal directly from a mob's accessories var but there may be some snowflake stuff going on. Happy to move things around but leaving just in case. (Also looks out of scope :D)

# Explain why it's good for the game

Consistency and usability good. I genuinely have no clue how I ended up in this rabbit hole.


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
add: Added sounds for inserting and removing knifes to the knife webbing
add: Added draw delay for knives to the knife webbing
add: Allowed using quickdraw with the knife webbing
add: Allowed knife webbing to be alt-clicked to draw from it
add: Knife webbing is now spawned full
code: Standardized knife draw delay in a define
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
