### PR TITLE
Added preference to disallow de-activation of your current ability

### DIFF
--- a/code/__DEFINES/client_prefs.dm
+++ b/code/__DEFINES/client_prefs.dm
@@ -22,6 +22,7 @@
 #define TOGGLE_VEND_ITEM_TO_HAND (1<<15) // This toggles whether items from vendors will be automatically put into your hand.
 #define TOGGLE_START_JOIN_CURRENT_SLOT (1<<16) // Whether joining at roundstart ignores assigned character slot for the job and uses currently selected slot.
 #define TOGGLE_LATE_JOIN_CURRENT_SLOT (1<<17) //Whether joining during the round ignores assigned character slot for the job and uses currently selected slot.
+#define TOGGLE_ABILITY_DEACTIVATION_OFF (1<<18) // This toggles whether selecting the same ability again can toggle it off
 
 #define JOB_SLOT_RANDOMISED_SLOT -1
 #define JOB_SLOT_CURRENT_SLOT 0

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -46,6 +46,7 @@ GLOBAL_LIST_INIT(whitelisted_client_procs, list(
 	/client/proc/toggle_eject_to_hand,
 	/client/proc/toggle_automatic_punctuation,
 	/client/proc/toggle_middle_mouse_click,
+	/client/proc/toggle_ability_deactivation,
 	/client/proc/toggle_clickdrag_override,
 	/client/proc/toggle_dualwield,
 	/client/proc/toggle_middle_mouse_swap_hands,

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -595,6 +595,8 @@ var/const/MAX_SAVE_SLOTS = 10
 					</b> <a href='?_src_=prefs;preference=toggle_prefs;flag=[TOGGLE_HELP_INTENT_SAFETY]'><b>[toggle_prefs & TOGGLE_HELP_INTENT_SAFETY ? "On" : "Off"]</b></a><br>"
 			dat += "<b>Toggle Middle Mouse Ability Activation: \
 					</b> <a href='?_src_=prefs;preference=toggle_prefs;flag=[TOGGLE_MIDDLE_MOUSE_CLICK]'><b>[toggle_prefs & TOGGLE_MIDDLE_MOUSE_CLICK ? "On" : "Off"]</b></a><br>"
+			dat += "<b>Toggle Ability Deactivation: \
+					</b> <a href='?_src_=prefs;preference=toggle_prefs;flag=[TOGGLE_ABILITY_DEACTIVATION_OFF]'><b>[toggle_prefs & TOGGLE_ABILITY_DEACTIVATION_OFF ? "Off" : "On"]</b></a><br>"
 			dat += "<b>Toggle Directional Assist: \
 					</b> <a href='?_src_=prefs;preference=toggle_prefs;flag=[TOGGLE_DIRECTIONAL_ATTACK]'><b>[toggle_prefs & TOGGLE_DIRECTIONAL_ATTACK ? "On" : "Off"]</b></a><br>"
 			dat += "<b>Toggle Magazine Auto-Ejection: \
@@ -1229,7 +1231,7 @@ var/const/MAX_SAVE_SLOTS = 10
 					predator_gender = predator_gender == MALE ? FEMALE : MALE
 				if("pred_age")
 					var/new_predator_age = tgui_input_number(user, "Choose your Predator's age(175 to 3000):", "Character Preference", 1234, 3000, 175)
-					if(new_predator_age) 
+					if(new_predator_age)
 						predator_age = max(min( round(text2num(new_predator_age)), 3000),175)
 				if("pred_trans_type")
 					var/new_translator_type = tgui_input_list(user, "Choose your translator type.", "Translator Type", PRED_TRANSLATORS)

--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -205,7 +205,7 @@
 	set name = "Toggle SpecialRole Candidacy"
 	set category = "Preferences"
 	set desc = "Toggles which special roles you would like to be a candidate for, during events."
-	
+
 	var/list/be_special_flags = list(
 		"Xenomorph after unrevivable death" = BE_ALIEN_AFTER_DEATH,
 		"Agent" = BE_AGENT,
@@ -356,7 +356,7 @@
 		to_chat(src, SPAN_NOTICE("Your selected ability will now be activated with shift clicking."))
 	prefs.save_preferences()
 
-/client/proc/toggle_ability_deactivation() // Toggle whether abilities should use middle or shift clicking
+/client/proc/toggle_ability_deactivation() // Toggle whether the current ability can be deactivated when re-selected
 	prefs.toggle_prefs ^= TOGGLE_ABILITY_DEACTIVATION_OFF
 	if (prefs.toggle_prefs & TOGGLE_ABILITY_DEACTIVATION_OFF)
 		to_chat(src, SPAN_NOTICE("Your current ability can no longer be toggled off when re-selected."))

--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -274,6 +274,7 @@
 		"<a href='?src=\ref[src];action=proccall;procpath=/client/proc/toggle_eject_to_hand'>Toggle 'Unload Weapon' Ejecting Magazines to Your Hands</a><br>",
 		"<a href='?src=\ref[src];action=proccall;procpath=/client/proc/toggle_automatic_punctuation'>Toggle Automatic Punctuation</a><br>",
 		"<a href='?src=\ref[src];action=proccall;procpath=/client/proc/toggle_middle_mouse_click'>Toggle Middle Mouse Ability Activation</a><br>",
+		"<a href='?src=\ref[src];action=proccall;procpath=/client/proc/toggle_ability_deactivation'>Toggle Ability Deactivation</a><br>",
 		"<a href='?src=\ref[src];action=proccall;procpath=/client/proc/toggle_clickdrag_override'>Toggle Combat Click-Drag Override</a><br>",
 		"<a href='?src=\ref[src];action=proccall;procpath=/client/proc/toggle_dualwield'>Toggle Alternate-Fire Dual Wielding</a><br>",
 		"<a href='?src=\ref[src];action=proccall;procpath=/client/proc/toggle_middle_mouse_swap_hands'>Toggle Middle Mouse Swapping Hands</a><br>",
@@ -287,7 +288,7 @@
 	for (var/pref_button in pref_buttons)
 		dat += "[pref_button]\n"
 
-	var/height = 50+22*length(pref_buttons)
+	var/height = 50+24*length(pref_buttons)
 
 	show_browser(src, dat, "Toggle Preferences", "togglepreferences", "size=475x[height]")
 
@@ -353,6 +354,14 @@
 		to_chat(src, SPAN_NOTICE("Your selected ability will now be activated with middle clicking."))
 	else
 		to_chat(src, SPAN_NOTICE("Your selected ability will now be activated with shift clicking."))
+	prefs.save_preferences()
+
+/client/proc/toggle_ability_deactivation() // Toggle whether abilities should use middle or shift clicking
+	prefs.toggle_prefs ^= TOGGLE_ABILITY_DEACTIVATION_OFF
+	if (prefs.toggle_prefs & TOGGLE_ABILITY_DEACTIVATION_OFF)
+		to_chat(src, SPAN_NOTICE("Your current ability can no longer be toggled off when re-selected."))
+	else
+		to_chat(src, SPAN_NOTICE("Your current ability can be toggled off when re-selected."))
 	prefs.save_preferences()
 
 /client/proc/toggle_clickdrag_override() //Toggle whether mousedown clicks immediately when on disarm or harm intent to prevent click-dragging from 'eating' attacks.

--- a/code/modules/mob/living/carbon/xenomorph/abilities/xeno_action.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/xeno_action.dm
@@ -158,6 +158,8 @@
 	if(xeno.selected_ability == src)
 		if(xeno.deselect_timer > world.time)
 			return // We clicked the same ability in a very short time
+		if(xeno.client && xeno.client.prefs && xeno.client.prefs.toggle_prefs & TOGGLE_ABILITY_DEACTIVATION_OFF)
+			return
 		to_chat(xeno, "You will no longer use [ability_name] with \
 			[xeno.client && xeno.client.prefs && xeno.client.prefs.toggle_prefs & TOGGLE_MIDDLE_MOUSE_CLICK ? "middle-click" : "shift-click"].")
 		button.icon_state = "template"

--- a/code/modules/mob/living/carbon/xenomorph/xeno_verbs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_verbs.dm
@@ -111,6 +111,21 @@
 	else
 		to_chat(src, SPAN_NOTICE("The selected xeno ability will now be activated with shift clicking."))
 
+/mob/living/carbon/xenomorph/verb/ability_deactivation_toggle()
+	set name = "Toggle Ability Deactivation"
+	set desc = "Toggles whether you can deactivate your currently active ability when re-selecting it."
+	set category = "Alien"
+
+	if (!client || !client.prefs)
+		return
+
+	client.prefs.toggle_prefs ^= TOGGLE_ABILITY_DEACTIVATION_OFF
+	client.prefs.save_preferences()
+	if (client.prefs.toggle_prefs & TOGGLE_ABILITY_DEACTIVATION_OFF)
+		to_chat(src, SPAN_NOTICE("Your current ability can no longer be toggled off when re-selected."))
+	else
+		to_chat(src, SPAN_NOTICE("Your current ability can be toggled off when re-selected."))
+
 /mob/living/carbon/xenomorph/verb/directional_attack_toggle()
 	set name = "Toggle Directional Attacks"
 	set desc = "Toggles the use of directional assist attacks."


### PR DESCRIPTION

# About the pull request

This PR adds a xeno preference where you can disallow the deactivation of your currently selected ability when re-selecting it again. The default state of this toggle will still allow ability deactivation since that is the old behavior.

Locally testing no preferences seem to save so I couldn't confirm that was working correctly; but I did not introduce a new field to be saved, just added to the existing one. Maybe they require a DB?

# Explain why it's good for the game

This can help xeno players not accidentally deactivate an ability if they have no need to deactivate an ability. Generally it should be the case there is no need to, but maybe someone has multi-binded MMB or wants to still examine with shift click (if they use shift click preference).

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/cmss13-devs/cmss13/assets/76988376/4324860f-80cd-46ec-9310-dbea6ecbe804)
![image](https://github.com/cmss13-devs/cmss13/assets/76988376/fe8744cb-8a2a-495b-8d96-282417fcacbc)
![image](https://github.com/cmss13-devs/cmss13/assets/76988376/bfde2f29-2e02-4878-97a8-017fedaeb40b)

</details>


# Changelog
:cl: Drathek
qol: Added a preference to disable xeno ability deactivation when re-selecting the same ability
/:cl:
