### PR TITLE
Give CLF medics a scalpel

### DIFF
--- a/code/modules/gear_presets/clf.dm
+++ b/code/modules/gear_presets/clf.dm
@@ -307,6 +307,7 @@
 	new_human.equip_to_slot_or_del(new /obj/item/tool/surgery/surgical_line, WEAR_IN_BACK)
 	new_human.equip_to_slot_or_del(new /obj/item/tool/surgery/synthgraft, WEAR_IN_BACK)
 	new_human.equip_to_slot_or_del(new /obj/item/tool/crowbar(new_human), WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/tool/surgery/scalpel(new_human), WEAR_IN_BACK)
 	if(new_human.disabilities & NEARSIGHTED)
 		new_human.equip_to_slot_or_del(new /obj/item/clothing/glasses/hud/health/prescription(new_human), WEAR_EYES)
 	else


### PR DESCRIPTION

# About the pull request
Give CLF medics a scalpel for shrapnel removal.

# Explain why it's good for the game
The CLF has many (intentional) failings, but one of the most unavoidable is shrapnel, to which they have no fix for. This changes that, while keeping them scarce. (I also find it to be a special kind of scuffed to have to beg the medic for their scalpel)


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

<img width="354" alt="image" src="https://github.com/cmss13-devs/cmss13/assets/41448081/9c359a09-5ce1-4957-877d-ef562dfc2c4c">

</details>


# Changelog
:cl:
balance: CLF medics now get a scalpel for shrapnel removal.
/:cl:
