### PR TITLE
Tent Tweaks & Fixes!

### DIFF
--- a/code/modules/tents/blockers.dm
+++ b/code/modules/tents/blockers.dm
@@ -35,7 +35,7 @@
 		PF.flags_can_pass_behind = NONE
 
 /obj/structure/blocker/tent/get_projectile_hit_boolean(obj/item/projectile/P)
-	..()
+	. = ..()
 	return FALSE // Always fly through the tent
 
 //Blocks all direction, basically an invisible wall

--- a/code/modules/tents/blockers.dm
+++ b/code/modules/tents/blockers.dm
@@ -7,6 +7,7 @@
 	invisibility = INVISIBILITY_MAXIMUM
 	density = TRUE
 	opacity = FALSE // Unfortunately this doesn't behave as we'd want with ON_BORDER so we can't make tent opaque
+	throwpass = TRUE // Needs this so xenos can attack through the blocker and hit the tents or people inside
 	/// The tent this blocker relates to, will be destroyed along with it
 	var/obj/structure/tent/linked_tent
 
@@ -34,5 +35,11 @@
 		PF.flags_can_pass_behind = NONE
 
 /obj/structure/blocker/tent/get_projectile_hit_boolean(obj/item/projectile/P)
-	. = ..()
+	..()
 	return FALSE // Always fly through the tent
+
+//Blocks all direction, basically an invisible wall
+/obj/structure/blocker/tent/full_tile
+	flags_atom = NO_FLAGS
+	icon = 'icons/landmarks.dmi'
+	icon_state = "invisible_wall"

--- a/code/modules/tents/deployed_tents.dm
+++ b/code/modules/tents/deployed_tents.dm
@@ -99,7 +99,7 @@
 	visible_message(SPAN_HIGHDANGER("[user] is trying to tear down the [src]"))
 	playsound(src, 'sound/items/paper_ripped.ogg', 25, 1)
 
-	if(!do_after(user, 150, INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_HOSTILE, src) || QDELETED(src))
+	if(user.action_busy || !do_after(user, 150, INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_HOSTILE, src) || QDELETED(src))
 		return
 
 	visible_message(SPAN_HIGHDANGER("[user] tears down the [src]"))

--- a/code/modules/tents/deployed_tents.dm
+++ b/code/modules/tents/deployed_tents.dm
@@ -94,17 +94,21 @@
 
 /obj/structure/tent/attackby(obj/item/item, mob/user)
 	var/obj/item/tool/shovel/shovel = item
-	if(istype(shovel) && !shovel.folded)
-		visible_message(SPAN_HIGHDANGER("[user] is trying to tear down the [src]"))
-		playsound(src, 'sound/items/paper_ripped.ogg', 25, 1)
-		if(do_after(user, 150, INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_HOSTILE, src) && !QDELETED(src))
-			visible_message(SPAN_HIGHDANGER("[user] tears down the [src]"))
-			playsound(src, 'sound/items/paper_ripped.ogg', 25, 1)
-			qdel(src)
+	if(!istype(shovel) || shovel.folded)
+		return
+	visible_message(SPAN_HIGHDANGER("[user] is trying to tear down the [src]"))
+	playsound(src, 'sound/items/paper_ripped.ogg', 25, 1)
+
+	if(!do_after(user, 150, INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_HOSTILE, src) || QDELETED(src))
+		return
+
+	visible_message(SPAN_HIGHDANGER("[user] tears down the [src]"))
+	playsound(src, 'sound/items/paper_ripped.ogg', 25, 1)
+	qdel(src)
 
 /obj/structure/tent/get_projectile_hit_boolean(obj/item/projectile/P)
+	. = ..()
 	return FALSE // Always fly through the tent
-
 
 /// Command tent, providing basics for field command: a phone, and an overwatch console
 /obj/structure/tent/cmd

--- a/code/modules/tents/deployed_tents.dm
+++ b/code/modules/tents/deployed_tents.dm
@@ -110,6 +110,12 @@
 	. = ..()
 	return FALSE // Always fly through the tent
 
+/obj/structure/tent/Destroy()
+	for(var/turf/turf in locs)
+		for(var/mob/mobs in turf)
+			mob_exited_tent(mobs)
+	. = ..()
+
 /// Command tent, providing basics for field command: a phone, and an overwatch console
 /obj/structure/tent/cmd
 	icon_state = "cmd_interior"

--- a/code/modules/tents/folded_tents.dm
+++ b/code/modules/tents/folded_tents.dm
@@ -112,7 +112,7 @@
 	icon_state = "cmd"
 	desc = "A standard USCM Command Tent. This one comes equipped with a self-powered Overwatch Console and a Telephone. Unfold in a suitable location to maximize usefulness. Staff Officer not included. ENTRANCE TO THE SOUTH."
 	dim_x = 2
-	dim_y = 3
+	dim_y = 4
 	off_x = -1
 	template = /datum/map_template/tent/cmd
 
@@ -121,7 +121,7 @@
 	icon_state = "med"
 	desc = "A standard USCM Medical Tent. This one comes equipped with advanced field surgery facilities. Unfold in a suitable location to maximize health gains. Surgical Tray not included. ENTRANCE TO THE SOUTH."
 	dim_x = 2
-	dim_y = 3
+	dim_y = 4
 	template = /datum/map_template/tent/med
 
 /obj/item/folded_tent/reqs
@@ -129,7 +129,7 @@
 	icon_state = "req"
 	desc = "A standard USCM Requisitions Tent. Now, you can enjoy req line anywhere you go! Unfold in a suitable location to maximize resource distribution. ASRS not included. ENTRANCE TO THE SOUTH."
 	dim_x = 4
-	dim_y = 3
+	dim_y = 4
 	off_x = -2
 	template = /datum/map_template/tent/reqs
 
@@ -138,7 +138,7 @@
 	icon_state = "big"
 	desc = "A standard USCM Tent. This one is just a bigger, general purpose version. Unfold in a suitable location for maximum FOB vibes. Mess Tech not included. ENTRANCE TO THE SOUTH."
 	dim_x = 3
-	dim_y = 3
+	dim_y = 4
 	off_x = -2
 	template = /datum/map_template/tent/big
 

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -5928,6 +5928,7 @@
 /obj/item/device/radio/marine,
 /obj/item/device/radio/marine,
 /obj/item/device/radio/marine,
+/obj/item/folded_tent/cmd,
 /turf/open/floor/almayer{
 	icon_state = "redfull"
 	},
@@ -15879,6 +15880,10 @@
 /obj/item/reagent_container/spray/cleaner{
 	desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back.";
 	name = "Surgery Cleaner"
+	},
+/obj/item/folded_tent/med{
+	pixel_x = -8;
+	pixel_y = 14
 	},
 /turf/open/floor/almayer{
 	dir = 8;
@@ -29641,11 +29646,6 @@
 	pixel_x = 9
 	},
 /obj/item/reagent_container/pill/happy,
-/obj/item/stack/tile/plasteel{
-	layer = 2.5;
-	pixel_x = -8;
-	pixel_y = 4
-	},
 /obj/item/clothing/glasses/disco_fever{
 	pixel_x = -3;
 	pixel_y = -2
@@ -37919,18 +37919,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/hallways/vehiclehangar)
-"gCu" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/obj/item/folded_tent/cmd,
-/turf/open/floor/almayer{
-	icon_state = "plating_striped"
-	},
-/area/almayer/squads/req)
 "gCw" = (
 /obj/item/reagent_container/food/drinks/cans/beer{
 	pixel_x = 10
@@ -40074,18 +40062,6 @@
 /obj/structure/pipes/standard/manifold/hidden/supply,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/hangar)
-"hBP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/obj/item/folded_tent/med,
-/turf/open/floor/almayer{
-	icon_state = "plating_striped"
-	},
-/area/almayer/squads/req)
 "hBU" = (
 /obj/structure/largecrate/random/secure,
 /obj/effect/decal/warning_stripes{
@@ -42087,8 +42063,9 @@
 /area/almayer/squads/delta)
 "ixN" = (
 /obj/structure/largecrate,
-/obj/item/prop/almayer/handheld1{
-	pixel_y = 12
+/obj/item/folded_tent/reqs{
+	pixel_x = -3;
+	pixel_y = 10
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -57095,18 +57072,6 @@
 	icon_state = "green"
 	},
 /area/almayer/hallways/aft_hallway)
-"pvF" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/obj/item/folded_tent/reqs,
-/turf/open/floor/almayer{
-	icon_state = "plating_striped"
-	},
-/area/almayer/squads/req)
 "pvJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -71603,18 +71568,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/living/grunt_rnr)
-"vSr" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/obj/item/folded_tent/big,
-/turf/open/floor/almayer{
-	icon_state = "plating_striped"
-	},
-/area/almayer/squads/req)
 "vSE" = (
 /obj/structure/closet/secure_closet/personal,
 /turf/open/floor/almayer{
@@ -74734,11 +74687,16 @@
 	desc = "A supply crate containing everything you need to stop a CLF uprising.";
 	name = "\improper USCM crate 'FOB supplies'"
 	},
-/obj/item/storage/box/mousetraps{
-	pixel_y = 12
-	},
 /obj/structure/sign/arcturianstopsign{
 	pixel_y = 32
+	},
+/obj/item/folded_tent/big{
+	pixel_y = 10;
+	pixel_x = -6
+	},
+/obj/item/storage/box/mousetraps{
+	pixel_y = 12;
+	pixel_x = 3
 	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
@@ -119280,7 +119238,7 @@ bEi
 bZr
 bmD
 ngw
-gCu
+pjG
 boz
 bpR
 bpR
@@ -119483,7 +119441,7 @@ brp
 bZr
 bmD
 xId
-hBP
+pjG
 boz
 bpR
 bpR
@@ -119889,7 +119847,7 @@ buz
 bZr
 bmD
 dmE
-pvF
+pjG
 boz
 bpR
 bpR
@@ -120092,7 +120050,7 @@ bEm
 bZr
 bmD
 hAc
-vSr
+pjG
 boz
 bpR
 bpR

--- a/maps/tents/tent_big.dmm
+++ b/maps/tents/tent_big.dmm
@@ -7,6 +7,10 @@
 /obj/structure/tent_curtain,
 /turf/template_noop,
 /area/template_noop)
+"k" = (
+/obj/structure/blocker/tent/full_tile,
+/turf/template_noop,
+/area/template_noop)
 "n" = (
 /obj/structure/blocker/tent{
 	dir = 4
@@ -59,19 +63,19 @@
 /area/template_noop)
 
 (1,1,1) = {"
-O
+k
 J
 v
 a
 "}
 (2,1,1) = {"
-O
+k
 S
 O
 x
 "}
 (3,1,1) = {"
-O
+k
 n
 s
 G

--- a/maps/tents/tent_cmd.dmm
+++ b/maps/tents/tent_cmd.dmm
@@ -30,6 +30,7 @@
 /turf/template_noop,
 /area/template_noop)
 "p" = (
+/obj/structure/blocker/tent/full_tile,
 /turf/template_noop,
 /area/template_noop)
 "v" = (

--- a/maps/tents/tent_med.dmm
+++ b/maps/tents/tent_med.dmm
@@ -16,6 +16,7 @@
 /turf/template_noop,
 /area/template_noop)
 "p" = (
+/obj/structure/blocker/tent/full_tile,
 /turf/template_noop,
 /area/template_noop)
 "v" = (

--- a/maps/tents/tent_reqs.dmm
+++ b/maps/tents/tent_reqs.dmm
@@ -70,6 +70,10 @@
 	},
 /turf/template_noop,
 /area/template_noop)
+"R" = (
+/obj/structure/blocker/tent/full_tile,
+/turf/template_noop,
+/area/template_noop)
 "S" = (
 /obj/structure/blocker/tent{
 	dir = 8
@@ -83,25 +87,25 @@
 /area/template_noop)
 
 (1,1,1) = {"
-a
+R
 B
 S
 m
 "}
 (2,1,1) = {"
-a
+R
 J
 a
 c
 "}
 (3,1,1) = {"
-a
+R
 w
 U
 k
 "}
 (4,1,1) = {"
-a
+R
 n
 d
 k


### PR DESCRIPTION
# About the pull request

Marines can destroy tents with an E-tool or shovel

Scattered the 4 tents to (the four corners) their own respective department with the big tent being in Bravo Bunks

You can no longer stand behind tent, (increases all tent height by 1)

Re-wrote xeno attacks on tents so it gives more feedback and is handled similarly to cades being attacked

Fixed bug where xenos can't slash the tent (or people in the tents) from the sides

Fixed bug where tent would possibly block bullets

Fixed bug where staying inside a tent that's being deleted will give your permanent see-through roof vision

# Explain why it's good for the game

Tents were soft-griefing the marines by being poorly placed with no way to remove them.

This will allow marines to take down poorly placed tents 
While pushing the responsibility of the tents onto the department that decides to take it down.

Big tent (RP tent) is in bravo bunks as it is an all access area where anyone can grab it, from bravo marines to CL or mess sergeant

The north walls of tents are now full density blocks no one should be able to enter or hide behind it (or hide traps/sentry items behind there)

Bug bad for the rest


# Changelog

:cl: ghostsheet
add: Tents can be destroyed with an E-tool.
add: Tents are now in their respective department, Big tent is now in Bravo Bunks.
add: You can no longer stand behind a tent.
fix: Xenos can now slash tents from the side.
fix: Tents no longer randomly block bullets.
fix: Staying inside a tent when it is destroyed no longer give your permanent see-through roof vision.
/:cl:
