### PR TITLE
Lurkers don't lose invisibility when bumping into invisible mobs

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/Lurker.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Lurker.dm
@@ -164,5 +164,6 @@
 	var/datum/action/xeno_action/onclick/lurker_invisibility/lurker_invisibility_action = get_xeno_action_by_type(bound_xeno, /datum/action/xeno_action/onclick/lurker_invisibility)
 	if(!lurker_invisibility_action)
 		return
-
-	animate(bound_xeno, alpha = 75, time = 0.1 SECONDS, easing = QUAD_EASING)
+	to_chat(bound_xeno, SPAN_XENOWARNING("[bound_xeno.alpha]"))
+	animate(bound_xeno, alpha = 80, time = 0.1 SECONDS, easing = QUAD_EASING)
+	to_chat(bound_xeno, SPAN_XENOWARNING("[bound_xeno.alpha]"))

--- a/code/modules/mob/living/carbon/xenomorph/castes/Lurker.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Lurker.dm
@@ -164,6 +164,13 @@
 	var/datum/action/xeno_action/onclick/lurker_invisibility/lurker_invisibility_action = get_xeno_action_by_type(bound_xeno, /datum/action/xeno_action/onclick/lurker_invisibility)
 	if(!lurker_invisibility_action)
 		return
-	to_chat(bound_xeno, SPAN_XENOWARNING("[bound_xeno.alpha]"))
+	if(bound_xeno.alpha >= 80)
+		return
+
+	var/mob/living/carbon/human/bumped_into = movable_atom
+	if(bumped_into.alpha < 100)
+		to_chat(bound_xeno, SPAN_XENOHIGHDANGER("Scout moment!"))
+		return
+	
+	to_chat(bound_xeno, SPAN_XENOHIGHDANGER("You bumped into someone and partly lost your invisibility!"))
 	animate(bound_xeno, alpha = 80, time = 0.1 SECONDS, easing = QUAD_EASING)
-	to_chat(bound_xeno, SPAN_XENOWARNING("[bound_xeno.alpha]"))

--- a/code/modules/mob/living/carbon/xenomorph/castes/Lurker.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Lurker.dm
@@ -165,4 +165,4 @@
 	if(!lurker_invisibility_action)
 		return
 
-	lurker_invisibility_action.invisibility_off()
+	animate(bound_xeno, alpha = 75, time = 0.1 SECONDS, easing = QUAD_EASING)

--- a/code/modules/mob/living/carbon/xenomorph/castes/Lurker.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Lurker.dm
@@ -168,8 +168,7 @@
 		return
 
 	var/mob/living/carbon/human/bumped_into = movable_atom
-	if(bumped_into.alpha < 100)
-		to_chat(bound_xeno, SPAN_XENOHIGHDANGER("Scout moment!"))
+	if(bumped_into.alpha < 100) //ignore invisible scouts and preds
 		return
 	
 	to_chat(bound_xeno, SPAN_XENOHIGHDANGER("You bumped into someone and partly lost your invisibility!"))

--- a/code/modules/mob/living/carbon/xenomorph/castes/Lurker.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Lurker.dm
@@ -164,7 +164,7 @@
 	var/datum/action/xeno_action/onclick/lurker_invisibility/lurker_invisibility_action = get_xeno_action_by_type(bound_xeno, /datum/action/xeno_action/onclick/lurker_invisibility)
 	if(!lurker_invisibility_action)
 		return
-	if(bound_xeno.alpha >= 80)
+	if(bound_xeno.alpha >= 85)
 		return
 
 	var/mob/living/carbon/human/bumped_into = movable_atom
@@ -173,4 +173,4 @@
 		return
 	
 	to_chat(bound_xeno, SPAN_XENOHIGHDANGER("You bumped into someone and partly lost your invisibility!"))
-	animate(bound_xeno, alpha = 80, time = 0.1 SECONDS, easing = QUAD_EASING)
+	animate(bound_xeno, alpha = 85, time = 0.1 SECONDS, easing = QUAD_EASING)

--- a/code/modules/mob/living/carbon/xenomorph/castes/Lurker.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Lurker.dm
@@ -164,12 +164,10 @@
 	var/datum/action/xeno_action/onclick/lurker_invisibility/lurker_invisibility_action = get_xeno_action_by_type(bound_xeno, /datum/action/xeno_action/onclick/lurker_invisibility)
 	if(!lurker_invisibility_action)
 		return
-	if(bound_xeno.alpha >= 85)
-		return
 
 	var/mob/living/carbon/human/bumped_into = movable_atom
 	if(bumped_into.alpha < 100) //ignore invisible scouts and preds
 		return
 	
-	to_chat(bound_xeno, SPAN_XENOHIGHDANGER("You bumped into someone and partly lost your invisibility!"))
-	animate(bound_xeno, alpha = 85, time = 0.1 SECONDS, easing = QUAD_EASING)
+	to_chat(bound_xeno, SPAN_XENOHIGHDANGER("You bumped into someone and lost your invisibility!"))
+	lurker_invisibility_action.invisibility_off()


### PR DESCRIPTION
# About the pull request

Lurker don't lose invis when bump into partly visible mobs like cloaked scout/preds.

# Explain why it's good for the game

More fair.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Outdated
https://github.com/cmss13-devs/cmss13/assets/115417687/58990b87-1cd2-45e0-a1ac-830b07fcdc00


</details>


# Changelog
:cl: ihatethisengine
balance: Lurkers don't lose invisibility when they bump into partly visible mobs.
/:cl:
