### PR TITLE
Fixes surgery trays to hold surgical graft

### DIFF
--- a/code/game/objects/items/storage/surgical_tray.dm
+++ b/code/game/objects/items/storage/surgical_tray.dm
@@ -4,7 +4,7 @@
 	icon_state = "surgical_tray"
 	flags_atom = FPRINT|CONDUCT
 	w_class = SIZE_LARGE //Should not fit in backpacks
-	storage_slots = 13
+	storage_slots = 14
 	max_storage_space = 24
 	use_sound = "toolbox"
 	matter = list("plastic" = 3000)
@@ -31,6 +31,7 @@
 	new /obj/item/tool/surgery/FixOVein(src)
 	new /obj/item/stack/nanopaste(src)
 	new /obj/item/tool/surgery/surgical_line(src)
+	new /obj/item/tool/surgery/synthgraft(src)
 
 /obj/item/storage/surgical_tray/update_icon()
 	if(!contents.len)

--- a/code/modules/clothing/under/ties.dm
+++ b/code/modules/clothing/under/ties.dm
@@ -529,7 +529,7 @@
 	new /obj/item/device/multitool(src)
 
 /obj/item/storage/internal/accessory/surg_vest
-	storage_slots = 13
+	storage_slots = 14
 	can_hold = list(
 		/obj/item/tool/surgery,
 		/obj/item/stack/medical/advanced/bruise_pack,
@@ -569,6 +569,7 @@
 	new /obj/item/tool/surgery/FixOVein(src)
 	new /obj/item/stack/nanopaste(src)
 	new /obj/item/tool/surgery/surgical_line(src)
+	new /obj/item/tool/surgery/synthgraft(src)
 
 /obj/item/clothing/accessory/storage/surg_vest
 	name = "surgical webbing vest"


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Forgot to put it in trays when it was added, now it can fit and will be in trays.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Surgical graft now fits in surgical trays and vests.
/:cl:
