### PR TITLE
Fix the M56D ignoring collision when dismounting the user

### DIFF
--- a/code/modules/cm_marines/smartgun_mount.dm
+++ b/code/modules/cm_marines/smartgun_mount.dm
@@ -906,7 +906,7 @@
 	user.visible_message(SPAN_NOTICE("[user] lets go of \the [src]."),SPAN_NOTICE("You let go of \the [src], letting the gun rest."))
 	user.unfreeze()
 	user.reset_view(null)
-	user.forceMove(get_step(src, reverse_direction(src.dir)))
+	user.Move(get_step(src, reverse_direction(src.dir)))
 	user.setDir(dir) //set the direction of the player to the direction the gun is facing
 	user_old_x = 0 //reset our x
 	user_old_y = 0 //reset our y

--- a/code/modules/cm_marines/smartgun_mount.dm
+++ b/code/modules/cm_marines/smartgun_mount.dm
@@ -906,7 +906,7 @@
 	user.visible_message(SPAN_NOTICE("[user] lets go of \the [src]."),SPAN_NOTICE("You let go of \the [src], letting the gun rest."))
 	user.unfreeze()
 	user.reset_view(null)
-	user.Move(get_step(src, reverse_direction(src.dir)))
+	step(user, reverse_direction(src.dir))
 	user.setDir(dir) //set the direction of the player to the direction the gun is facing
 	user_old_x = 0 //reset our x
 	user_old_y = 0 //reset our y

--- a/code/modules/cm_marines/smartgun_mount.dm
+++ b/code/modules/cm_marines/smartgun_mount.dm
@@ -906,7 +906,7 @@
 	user.visible_message(SPAN_NOTICE("[user] lets go of \the [src]."),SPAN_NOTICE("You let go of \the [src], letting the gun rest."))
 	user.unfreeze()
 	user.reset_view(null)
-	step(user, reverse_direction(src.dir))
+	user.Move(get_step(src, reverse_direction(src.dir)))
 	user.setDir(dir) //set the direction of the player to the direction the gun is facing
 	user_old_x = 0 //reset our x
 	user_old_y = 0 //reset our y


### PR DESCRIPTION
# About the pull request

Fixes #3926

It used a force move to dismount from the gun causing these issues. Now, if you can exit behind you will exit behind the gun.


# Explain why it's good for the game

You could exit into turfs with a density of 1 using this. And you should not be able to.


# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

Testing it. With cades and a window frame. To ensure it works.
https://imgur.com/a/eT2LBjW

</details>

# Changelog
:cl:
fix: The M56D no longer let's you violate density code when exiting it.
/:cl:
