### PR TITLE
Experimental: Bump rust_g to 2.1.0

### DIFF
--- a/.github/alternate_byond_versions.txt
+++ b/.github/alternate_byond_versions.txt
@@ -6,4 +6,4 @@
 # Example:
 # 500.1337: runtimestation
 
-515.1609: lv624
+515.1603: lv624

--- a/.github/alternate_byond_versions.txt
+++ b/.github/alternate_byond_versions.txt
@@ -6,4 +6,4 @@
 # Example:
 # 500.1337: runtimestation
 
-515.1603: lv624
+515.1609: lv624

--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -8,7 +8,7 @@ jobs:
   run_linters:
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     name: Run Linters
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     concurrency:
       group: run_linters-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
@@ -63,7 +63,7 @@ jobs:
   compile_all_maps:
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     name: Compile Maps
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Restore BYOND cache
@@ -80,7 +80,7 @@ jobs:
   find_all_maps:
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     name: Find Maps to Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     outputs:
       maps: ${{ steps.map_finder.outputs.maps }}
       alternate_tests: ${{ steps.alternate_test_finder.outputs.alternate_tests }}
@@ -137,7 +137,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[ci skip]') && needs.find_all_maps.outputs.alternate_tests != '[]'"
     name: Check Alternate Tests
     needs: [run_alternate_tests]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - run: echo Alternate tests passed.
 

--- a/.github/workflows/compile_changelogs.yml
+++ b/.github/workflows/compile_changelogs.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   compile:
     name: "Compile changelogs"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: "Check for ACTION_ENABLER secret and pass true to output if it exists to be checked by later steps"
         id: value_holder

--- a/.github/workflows/conflicts.yml
+++ b/.github/workflows/conflicts.yml
@@ -7,7 +7,7 @@ on:
     types: [ready_for_review, opened, synchronize, reopened]
 jobs:
   triage:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: eps1lon/actions-label-merge-conflict@v2.1.0
         with:

--- a/.github/workflows/generate_documentation.yml
+++ b/.github/workflows/generate_documentation.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   generate_documentation:
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     concurrency: gen-docs
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/run_approval.yml
+++ b/.github/workflows/run_approval.yml
@@ -1,11 +1,11 @@
 name: Automatic Approve Workflows
 on:
-  schedule: 
+  schedule:
     - cron: "*/10 * * * *"
 jobs:
   automatic-approve:
     name: Automatic Approve Workflows
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Automatic Approve
         uses: mheap/automatic-approve-action@v1

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           sudo dpkg --add-architecture i386
           sudo apt update || true
-          sudo apt install -o APT::Immediate-Configure=false libssl1.1:i386
+          sudo apt install -o APT::Immediate-Configure=false libgcc-s1:i386 g++-multilib zlib1g-dev:i386 libssl-dev:i386
           bash tools/ci/install_rust_g.sh
       - name: Configure version
         run: |

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           sudo dpkg --add-architecture i386
           sudo apt update || true
-          sudo apt install -o APT::Immediate-Configure=false libgcc-s1:i386 g++-multilib zlib1g-dev:i386 libssl-dev:i386
+          sudo apt install -o APT::Immediate-Configure=false zlib1g-dev:i386 libssl-dev:i386
           bash tools/ci/install_rust_g.sh
       - name: Configure version
         run: |

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -15,7 +15,7 @@ on:
         type: string
 jobs:
   run_unit_tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Restore BYOND cache

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   stale:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/stale@v4

--- a/.github/workflows/update_changelog.yml
+++ b/.github/workflows/update_changelog.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   update-changelog:
     concurrency: changelog
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - name: "Check for ACTION_ENABLER secret and pass true to output if it exists to be checked by later steps"
       id: value_holder

--- a/.github/workflows/update_tgs_dmapi.yml
+++ b/.github/workflows/update_tgs_dmapi.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   update-dmapi:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     name: Update the TGS DMAPI
     steps:
     - name: Clone

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -8,7 +8,7 @@ export BYOND_MAJOR=514
 export BYOND_MINOR=1588
 
 #rust_g git tag
-export RUST_G_VERSION=1.2.0
+export RUST_G_VERSION=2.1.0
 
 #node version
 export NODE_VERSION=14


### PR DESCRIPTION
# About the pull request

This PR updates rust_g to https://github.com/tgstation/rust-g/releases/tag/2.1.0

Feel free to request the other ubuntu changes reverted (I just bumped all - at a minimum run_unit_tests.yml needs a newer ubuntu version because of missing libraries libssl and libcrypto).

# Explain why it's good for the game

~~Potentially may fix the byond crash on live during `rustg_log_write(GLOB.world_game_log, "ADMIN: [text]", "true")` but I would expect the alternate 515.1609 unit test to break in #3925 but it passes...~~
(That issue may actually just be 1609 breaking call_ext support. See https://www.byond.com/forum/post/2880096)

All the changes from https://github.com/tgstation/rust-g/compare/1.2.0...2.1.0

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

# Changelog
:cl: Drathek
code: Bump rust_g to 2.1.0 and bump all github testing ubuntu versions to latest.
/:cl:
