### PR TITLE
prevents bad vars being touched

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -74,6 +74,23 @@
 		var/client/C = usr.client
 		C?.open_particle_editor(src)
 
+/atom/movable/vv_edit_var(var_name, var_value)
+	var/static/list/banned_edits = list(NAMEOF_STATIC(src, step_x) = TRUE, NAMEOF_STATIC(src, step_y) = TRUE, NAMEOF_STATIC(src, step_size) = TRUE, NAMEOF_STATIC(src, bounds) = TRUE)
+	var/static/list/careful_edits = list(NAMEOF_STATIC(src, bound_x) = TRUE, NAMEOF_STATIC(src, bound_y) = TRUE, NAMEOF_STATIC(src, bound_width) = TRUE, NAMEOF_STATIC(src, bound_height) = TRUE)
+	var/static/list/not_falsey_edits = list(NAMEOF_STATIC(src, bound_width) = TRUE, NAMEOF_STATIC(src, bound_height) = TRUE)
+	if(banned_edits[var_name])
+		return FALSE //PLEASE no.
+	if(careful_edits[var_name] && (var_value % world.icon_size) != 0)
+		return FALSE
+	if(not_falsey_edits[var_name] && !var_value)
+		return FALSE
+
+	if(!isnull(.))
+		datum_flags |= DF_VAR_EDITED
+		return
+
+	return ..()
+
 //when a mob interact with something that gives them a special view,
 //check_eye() is called to verify that they're still eligible.
 //if they are not check_eye() usually reset the mob's view.

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -118,6 +118,12 @@
 	VV_DROPDOWN_OPTION(VV_HK_EXPLODE, "Trigger Explosion")
 	VV_DROPDOWN_OPTION(VV_HK_EMPULSE, "Trigger EM Pulse")
 
+/turf/vv_edit_var(var_name, new_value)
+	var/static/list/banned_edits = list(NAMEOF_STATIC(src, x), NAMEOF_STATIC(src, y), NAMEOF_STATIC(src, z))
+	if(var_name in banned_edits)
+		return FALSE
+	. = ..()
+
 /turf/ex_act(severity)
 	return 0
 


### PR DESCRIPTION
apparently this wasn't ported with the rest of the vv refactor whoops!

:cl:
admin: you can no longer touch bad vars
/:cl: