### PR TITLE
Removes neuro gas screen spin effect

### DIFF
--- a/code/datums/effects/neurotoxin.dm
+++ b/code/datums/effects/neurotoxin.dm
@@ -40,7 +40,6 @@
 // General effects
 	affected_mob.last_damage_data = cause_data
 	affected_mob.apply_stamina_damage(stam_dam)
-	affected_mob.make_dizzy(12)
 
 // Effect levels (shit that doesn't stack)
 	switch(duration)
@@ -102,7 +101,6 @@
 		step(affected_mob, pick(CARDINAL_ALL_DIRS))
 		affected_mob.apply_effect(5, DAZE) // Unable to talk and weldervision
 		affected_mob.make_jittery(25)
-		affected_mob.make_dizzy(55)
 		affected_mob.emote("pain")
 		stumble = FALSE
 		addtimer(VARSET_CALLBACK(src,stumble,TRUE),3 SECONDS)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request
Removes the nauseating screen spin effect of neuro gas.



# Explain why it's good for the game
Has no real effect on gameplay and seems to exist only to torment the player.
The screen spin isn't severe enough to throw off aim nor does it make things harder to spot. As far as I can tell the only effect it has is giving the player nausea.
After several minutes (!!!) of my screen spinning around from getting hit by a neuro glob I was seriously considering ahelping for an aheal, but opted to stand in a corner and go do something else irl until the effect passes, because any more and I'd hurl. I do not believe motion sickness meds and a bucket should be a requirement for CM.

Can replace with some other, actually mechanically impairing effect if required, but I can't be arsed to test the absolutely insane durations the gas seems to apply. Also would happily expand this to remove the hallucination audio aside from the lurker one if allowed to, because between vomiting and having to take off my headphones before I go deaf from max volume CAS blaring into my ears, it's pretty hard to tell which is worse.

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
del: Removes the screen spinning (dizzy) effect of neuro gas
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
