### PR TITLE
[Experimental] Modifies INTERRUPT_NO_NEEDHAND flag

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1139,7 +1139,7 @@ var/global/image/action_purple_power_up
 			break
 		if(user_flags & INTERRUPT_NEEDHAND)
 			if(user_holding)
-				if(!user_holding.loc || busy_user.get_active_hand() != user_holding) //no longer holding the required item
+				if(!user_holding.loc || busy_user.get_active_hand() != user_holding) //no longer holding the required item in active hand
 					. = FALSE
 					break
 			else if(busy_user.get_active_hand()) //something in active hand when we need it to stay empty
@@ -1153,6 +1153,11 @@ var/global/image/action_purple_power_up
 			else if(T.get_active_hand())
 				. = FALSE
 				break
+		if(user_flags & INTERRUPT_NO_NEEDHAND)
+			if(user_holding)
+				if(!user_holding.loc || (busy_user.l_hand != user_holding && busy_user.r_hand != user_holding)) //no longer holding the required item in either hand
+					. = FALSE
+					break
 		if(user_flags & INTERRUPT_RESIST && busy_user.resisting || \
 			target_is_mob && (target_flags & INTERRUPT_RESIST && T.resisting)
 		)

--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -1220,7 +1220,7 @@ treat_grafted var tells it to apply to grafted but unsalved wounds, for burn kit
 			user.visible_message(SPAN_WARNING("[user] fumbles with [S]"), SPAN_WARNING("You fumble with [S]..."))
 			time_to_take = 15 SECONDS
 
-		if(do_after(user, time_to_take * user.get_skill_duration_multiplier(SKILL_MEDICAL), INTERRUPT_NEEDHAND, BUSY_ICON_FRIENDLY, target, INTERRUPT_MOVED, BUSY_ICON_MEDICAL))
+		if(do_after(user, time_to_take * user.get_skill_duration_multiplier(SKILL_MEDICAL), INTERRUPT_NO_NEEDHAND, BUSY_ICON_FRIENDLY, target, INTERRUPT_MOVED, BUSY_ICON_MEDICAL))
 			var/possessive = "[user == target ? "your" : "\the [target]'s"]"
 			var/possessive_their = "[user == target ? user.gender == MALE ? "his" : "her" : "\the [target]'s"]"
 			user.affected_message(target,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

This PR changes INTERRUPT_NO_NEEDHAND in the following way:
If the user needed an item they must have keep that item in one hand to the end of the do_after()

This should prevent dropping/putting away items while doing something.

This will affect the following interactions (at least):
Pilling someone
Splinting someone
Defib'ing someone
And about 100 more do_after()'s

We'll see if this feels better or worse. No matter what happens we will not be going back to dropping/putting away items and still using them.

Probably will have to rename the interrupt for clarity. Happy to take suggestions.

# Explain why it's good for the game

Splints were recently changed to be INTERRUPT_NEEDHAND and it slows medics down *considerably* and completely takes the individual out of the flow state. The enjoyment of playing medic is trying to do things as fast as possible. This allows things to be fast while also not silly (put away or dropped and still continuing). You have two hands, you can do two things at once.

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
balance: Modifies INTERRUPT_NO_NEEDHAND flag to require you hold the item at least in one hand.
balance: Changes splint back to using INTERRUPT_NO_NEEDHAND
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
