### PR TITLE
Fixes PMC Survivor Synth AGAIN

### DIFF
--- a/code/game/objects/effects/landmarks/survivor_spawner.dm
+++ b/code/game/objects/effects/landmarks/survivor_spawner.dm
@@ -80,7 +80,7 @@
 
 /obj/effect/landmark/survivor_spawner/bigred_crashed_pmc_medic
 	equipment = /datum/equipment_preset/survivor/pmc/medic
-	synth_equipment = /datum/equipment_preset/pmc/synth
+	synth_equipment = /datum/equipment_preset/synth/survivor/pmc
 	intro_text = list("<h2>You are a survivor of a crash landing!</h2>",\
 	"You are NOT aware of the xenomorph threat.",\
 	"Your primary objective is to heal up and survive. If you want to assault the hive - adminhelp.")
@@ -93,7 +93,7 @@
 
 /obj/effect/landmark/survivor_spawner/bigred_crashed_pmc_engineer
 	equipment = /datum/equipment_preset/survivor/pmc/engineer
-	synth_equipment = /datum/equipment_preset/pmc/synth
+	synth_equipment = /datum/equipment_preset/synth/survivor/pmc
 	intro_text = list("<h2>You are a survivor of a crash landing!</h2>",\
 	"You are NOT aware of the xenomorph threat.",\
 	"Your primary objective is to heal up and survive. If you want to assault the hive - adminhelp.")


### PR DESCRIPTION

# About the pull request
Again removes marine comms from PMC survivor synth. Please stop sneaking marine comms into survivors.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
-_-
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Fixes PMC survivor synth spawning with marine comms, again.
/:cl:
