### PR TITLE
Facehuggers now bypass time of death checks when joining as Larva

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -268,7 +268,7 @@
 
 		// copied from join as xeno
 		var/deathtime = world.time - cur_obs.timeofdeath
-		if(deathtime < XENO_JOIN_DEAD_TIME && ( !cur_obs.client.admin_holder || !(cur_obs.client.admin_holder.rights & R_ADMIN)) )
+		if(deathtime < XENO_JOIN_DEAD_TIME && ( !cur_obs.client.admin_holder || !(cur_obs.client.admin_holder.rights & R_ADMIN) || !cur_obs.bypass_time_of_death_checks))
 			continue
 
 		// AFK players cannot be drafted

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -56,6 +56,8 @@
 	var/observer_actions = list(/datum/action/observer_action/join_xeno)
 	var/datum/action/minimap/observer/minimap
 	var/larva_queue_cached_message
+	///Used to bypass time of death checks such as when being selected for larva.
+	var/bypass_time_of_death_checks = FALSE
 
 	alpha = 127
 
@@ -368,6 +370,8 @@ Works together with spawning an observer, noted above.
 		// Larva queue: We use the larger of their existing queue time or the new timeofdeath except for facehuggers
 		// We don't change facehugger timeofdeath because they are still on cooldown if they died as a hugger
 		var/new_tod = isfacehugger(src) ? 1 : ghost.timeofdeath
+		// if they died as facehugger, bypass typical TOD checks
+		ghost.bypass_time_of_death_checks = isfacehugger(src) ? TRUE : FALSE
 		ghost.client.player_details.larva_queue_time = max(ghost.client.player_details.larva_queue_time, new_tod)
 
 	ghost.set_huds_from_prefs()

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -372,7 +372,7 @@ Works together with spawning an observer, noted above.
 		// We don't change facehugger timeofdeath because they are still on cooldown if they died as a hugger
 		var/new_tod = isfacehugger(src) ? 1 : ghost.timeofdeath
 		// if they died as facehugger, bypass typical TOD checks
-		ghost.bypass_time_of_death_checks = isfacehugger(src) ? TRUE : FALSE
+		ghost.bypass_time_of_death_checks = isfacehugger(src)
 		ghost.client.player_details.larva_queue_time = max(ghost.client.player_details.larva_queue_time, new_tod)
 
 	ghost.set_huds_from_prefs()

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -420,6 +420,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 			// Larva queue: We use the larger of their existing queue time or the new timeofdeath except for facehuggers
 			var/new_tod = isfacehugger(src) ? 1 : world.time
+			ghost.bypass_time_of_death_checks = isfacehugger(src)
 			ghost.client?.player_details.larva_queue_time = max(ghost.client.player_details.larva_queue_time, new_tod)
 		if(is_nested && nest && !QDELETED(nest))
 			ghost.can_reenter_corpse = FALSE

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -49,7 +49,8 @@
 	var/updatedir = TRUE //Do we have to update our dir as the ghost moves around?
 	var/atom/movable/following = null
 	var/datum/orbit_menu/orbit_menu
-	var/mob/observetarget = null //The target mob that the ghost is observing. Used as a reference in logout()
+	/// The target mob that the ghost is observing. Used as a reference in logout()
+	var/mob/observetarget = null
 	var/datum/health_scan/last_health_display
 	var/ghost_orbit = GHOST_ORBIT_CIRCLE
 	var/own_orbit_size = 0


### PR DESCRIPTION
# About the pull request

Facehuggers ~~(and other ghost roles? (#3939))~~[this functionality will have to be added in said PR] now bypass the five minute time of death check, letting them join as a larva via queue or.. join as larva button.

# Explain why it's good for the game

With infection timer at 7.5 minutes, this means that after you die as facehugger, a large portion of the infection time is spent as unjoinable, which isnt a problem for a host YOU infected, but for others, you would get skipped over due to time of death. This allows for more leniency when playing as low-survivablity ghost roles. 

Code added can also be expanded, I am sure the new variable can fit in other places.

# Changelog
:cl:
add: Facehuggers now bypass time of death checks when being considered for larva.
code: new variable for observers to handle bypass of time of death checks
/:cl:
