### PR TITLE
Fix the first prompt to ghost when nested

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/xeno_nest.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/xeno_nest.dm
@@ -261,7 +261,7 @@
 	human.disable_lights()
 	human.disable_special_items()
 
-	if(human.mind)
+	if(human.client)
 		human.do_ghost()
 
 	return TRUE

--- a/code/game/objects/structures/stool_bed_chair_nest/xeno_nest.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/xeno_nest.dm
@@ -192,12 +192,12 @@
 	recently_nested = TRUE
 	addtimer(VARSET_CALLBACK(src, recently_nested, FALSE), 5 SECONDS)
 
-/obj/structure/bed/nest/buckle_mob(mob/M as mob, mob/user as mob)
+/obj/structure/bed/nest/buckle_mob(mob/mob, mob/user)
 	. = FALSE
-	if(!isliving(M) || islarva(user) || (get_dist(src, user) > 1) || user.is_mob_restrained() || user.stat || user.lying || M.buckled || !iscarbon(user))
+	if(!isliving(mob) || islarva(user) || (get_dist(src, user) > 1) || user.is_mob_restrained() || user.stat || user.lying || mob.buckled || !iscarbon(user))
 		return
 
-	if(isxeno(M))
+	if(isxeno(mob))
 		to_chat(user, SPAN_WARNING("You can't buckle your sisters."))
 		return
 
@@ -205,69 +205,64 @@
 		to_chat(user, SPAN_WARNING("There's already someone in [src]."))
 		return
 
-	if(M.mob_size > MOB_SIZE_HUMAN)
-		to_chat(user, SPAN_WARNING("\The [M] is too big to fit in [src]."))
+	if(mob.mob_size > MOB_SIZE_HUMAN)
+		to_chat(user, SPAN_WARNING("\The [mob] is too big to fit in [src]."))
 		return
 
-	if(!isxeno(user) || issynth(M))
+	if(!isxeno(user) || issynth(mob))
 		to_chat(user, SPAN_WARNING("Gross! You're not touching that stuff."))
 		return
 
-	if(isyautja(M) && !force_nest)
-		to_chat(user, SPAN_WARNING("\The [M] seems to be wearing some kind of resin-resistant armor!"))
+	if(isyautja(mob) && !force_nest)
+		to_chat(user, SPAN_WARNING("\The [mob] seems to be wearing some kind of resin-resistant armor!"))
 		return
 
-	if(M == user)
+	if(mob == user)
 		return
 
-	if(ishuman(M))
-		var/mob/living/carbon/human/H = M
-		if(!H.lying) //Don't ask me why is has to be
-			to_chat(user, SPAN_WARNING("[M] is resisting, ground them."))
+	var/mob/living/carbon/human/human = null
+	if(ishuman(mob))
+		human = mob
+		if(!human.lying) //Don't ask me why is has to be
+			to_chat(user, SPAN_WARNING("[mob] is resisting, ground them."))
 			return
 
 	var/securing_time = 15
 	// Don't increase the nesting time for monkeys and other species
-	if(ishuman_strict(M))
+	if(ishuman_strict(mob))
 		securing_time = 75
 
-	user.visible_message(SPAN_WARNING("[user] pins [M] into [src], preparing the securing resin."),
-	SPAN_WARNING("[user] pins [M] into [src], preparing the securing resin."))
-	var/M_loc = M.loc
+	user.visible_message(SPAN_WARNING("[user] pins [mob] into [src], preparing the securing resin."),
+	SPAN_WARNING("[user] pins [mob] into [src], preparing the securing resin."))
+	var/M_loc = mob.loc
 	if(!do_after(user, securing_time, INTERRUPT_NO_NEEDHAND, BUSY_ICON_HOSTILE))
 		return
-	if(M.loc != M_loc)
+	if(mob.loc != M_loc)
 		return
 
 	if(buckled_mob) //Just in case
 		to_chat(user, SPAN_WARNING("There's already someone in [src]."))
 		return
 
-	if(ishuman(M)) //Improperly stunned Marines won't be nested
-		var/mob/living/carbon/human/H = M
-		if(!H.lying) //Don't ask me why is has to be
-			to_chat(user, SPAN_WARNING("[M] is resisting, ground them."))
+	if(human) //Improperly stunned Marines won't be nested
+		if(!human.lying) //Don't ask me why is has to be
+			to_chat(user, SPAN_WARNING("[mob] is resisting, ground them."))
 			return
 
-	do_buckle(M, user)
-	ADD_TRAIT(M, TRAIT_NESTED, TRAIT_SOURCE_BUCKLE)
+	do_buckle(mob, user)
+	ADD_TRAIT(mob, TRAIT_NESTED, TRAIT_SOURCE_BUCKLE)
 
-	if(!ishuman(M))
+	if(!human)
 		return TRUE
 
 	//Disabling motion detectors and other stuff they might be carrying
-	var/mob/living/carbon/human/H = M
-	H.start_nesting_cooldown()
-	H.disable_special_flags()
-	H.disable_lights()
-	H.disable_special_items()
+	human.start_nesting_cooldown()
+	human.disable_special_flags()
+	human.disable_lights()
+	human.disable_special_items()
 
-	if(H.mind)
-		var/choice = alert(M, "You have no possibility of escaping unless freed by your fellow marines, do you wish to Ghost? If you are freed while ghosted, you will be given the choice to return to your body.", ,"Ghost", "Remain")
-		if(choice == "Ghost")
-			// Ask to ghostize() so they can reenter, to leave mind and such intact
-			ghost_of_buckled_mob = M.ghostize(can_reenter_corpse = TRUE)
-			ghost_of_buckled_mob?.can_reenter_corpse = FALSE // Just don't for now
+	if(human.mind)
+		human.do_ghost()
 
 	return TRUE
 

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -391,7 +391,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		ghostize(TRUE)
 	else
 		var/list/options = list("Ghost", "Stay in body")
-		if(check_rights(R_MOD))
+		if(check_other_rights(client, R_MOD, FALSE))
 			options = list("Aghost") + options
 		var/text_prompt = "Are you -sure- you want to ghost?\n(You are alive. If you ghost, you won't be able to return to your body. You can't change your mind so choose wisely!)"
 		var/is_nested = (buckled && istype(buckled, /obj/structure/bed/nest)) ? TRUE : FALSE
@@ -407,8 +407,8 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		AdjustSleeping(2) // Sleep so you will be properly recognized as ghosted
 		var/turf/location = get_turf(src)
 		if(location) //to avoid runtime when a mob ends up in nullspace
-			msg_admin_niche("[key_name_admin(usr)] has ghosted. [ADMIN_JMP(location)]")
-		log_game("[key_name_admin(usr)] has ghosted.")
+			msg_admin_niche("[key_name_admin(client)] has ghosted. [ADMIN_JMP(location)]")
+		log_game("[key_name_admin(client)] has ghosted.")
 		var/mob/dead/observer/ghost = ghostize((is_nested && nest && !QDELETED(nest))) //FALSE parameter is so we can never re-enter our body, "Charlie, you can never come baaaack~" :3
 		if(ghost && !is_admin_level(z))
 			ghost.timeofdeath = world.time


### PR DESCRIPTION

# About the pull request

This PR fixes an oversight where the initial prompt to ghost when nested performed ghosting a different way than the ghost verb. Not only does it now use a TGUI prompt, but the larva queue time will be assigned to the time they ghosted so they aren't immediately a candidate (the get_xeno_candidates proc is checking reviveability, but they have no TOD yet so it skipped that check for nested).

An alternative implementation to this would be to have that proc account for nested, but I was more inclined to do this this way to update the prompt to tgui.

# Explain why it's good for the game

More TGUI usage for user prompts, and nested marines should not get prioritized in the larva queue.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

https://youtu.be/FZTtlhTQPbE

</details>

# Changelog
:cl: Drathek
fix: Fixed the prompt when nested to ghost: Now uses a TGUI prompt and sets larva queue time.
/:cl:
