### PR TITLE
Pods tweaks and features, changes to pods crash chance

### DIFF
--- a/code/modules/shuttle/computers/escape_pod_computer.dm
+++ b/code/modules/shuttle/computers/escape_pod_computer.dm
@@ -226,16 +226,16 @@
 /obj/structure/machinery/door/airlock/evacuation/attack_hand()
 	return FALSE
 
-/obj/structure/machinery/door/airlock/evacuation/attack_alien()
+/obj/structure/machinery/door/airlock/evacuation/attack_alien(mob/living/carbon/xenomorph/xeno)
 	if(locked && EvacuationAuthority.evac_status != EVACUATION_STATUS_STANDING_BY)
-		if(M.claw_type >= CLAW_TYPE_SHARP)
-			M.animation_attack_on(src)
+		if(xeno.claw_type >= CLAW_TYPE_SHARP)
+			xeno.animation_attack_on(src)
 			playsound(src, 'sound/effects/metalhit.ogg', 25, 1)
 			take_damage(HEALTH_DOOR / XENO_HITS_TO_DESTROY_BOLTED_DOOR)
 			return XENO_ATTACK_ACTION
 		else
-			to_chat(M, SPAN_WARNING("[src] is bolted down tight."))
-			return XENO_NO_DELAY_ACTION		
+			to_chat(xeno, SPAN_WARNING("[src] is bolted down tight."))
+			return XENO_NO_DELAY_ACTION
 	return FALSE //Probably a better idea that these cannot be forced open.
 
 /obj/structure/machinery/door/airlock/evacuation/attack_remote()

--- a/code/modules/shuttle/computers/escape_pod_computer.dm
+++ b/code/modules/shuttle/computers/escape_pod_computer.dm
@@ -227,7 +227,7 @@
 	return FALSE
 
 /obj/structure/machinery/door/airlock/evacuation/attack_alien(mob/living/carbon/xenomorph/xeno)
-	if(locked && !unslashable) //doors become slashable after evac is called
+	if(density && !unslashable) //doors become slashable after evac is called
 		if(xeno.claw_type >= CLAW_TYPE_SHARP)
 			xeno.animation_attack_on(src)
 			playsound(src, 'sound/effects/metalhit.ogg', 25, 1)
@@ -242,6 +242,6 @@
 	return FALSE
 
 /obj/structure/machinery/door/airlock/evacuation/get_applying_acid_time() //you can melt evacuation doors only when they are manually locked
-	if(!locked)
+	if(!density)
 		return -1
-	..()
+	return ..()

--- a/code/modules/shuttle/computers/escape_pod_computer.dm
+++ b/code/modules/shuttle/computers/escape_pod_computer.dm
@@ -204,10 +204,17 @@
 	heat_proof = 1
 	unslashable = TRUE
 	unacidable = TRUE
+	var/obj/docking_port/mobile/escape_shuttle/linked_shuttle
 
 /obj/structure/machinery/door/airlock/evacuation/Initialize()
 	. = ..()
 	INVOKE_ASYNC(src, PROC_REF(lock))
+
+/obj/structure/machinery/door/airlock/evacuation/Destroy()
+	if(linked_shuttle)
+		linked_shuttle.mode = SHUTTLE_CRASHED
+		linked_shuttle.door_handler.doors -= list(src)
+	. = ..()
 
 	//Can't interact with them, mostly to prevent grief and meta.
 /obj/structure/machinery/door/airlock/evacuation/Collided()
@@ -220,6 +227,15 @@
 	return FALSE
 
 /obj/structure/machinery/door/airlock/evacuation/attack_alien()
+	if(locked && EvacuationAuthority.evac_status != EVACUATION_STATUS_STANDING_BY)
+		if(M.claw_type >= CLAW_TYPE_SHARP)
+			M.animation_attack_on(src)
+			playsound(src, 'sound/effects/metalhit.ogg', 25, 1)
+			take_damage(HEALTH_DOOR / XENO_HITS_TO_DESTROY_BOLTED_DOOR)
+			return XENO_ATTACK_ACTION
+		else
+			to_chat(M, SPAN_WARNING("[src] is bolted down tight."))
+			return XENO_NO_DELAY_ACTION		
 	return FALSE //Probably a better idea that these cannot be forced open.
 
 /obj/structure/machinery/door/airlock/evacuation/attack_remote()

--- a/code/modules/shuttle/computers/escape_pod_computer.dm
+++ b/code/modules/shuttle/computers/escape_pod_computer.dm
@@ -227,7 +227,7 @@
 	return FALSE
 
 /obj/structure/machinery/door/airlock/evacuation/attack_alien(mob/living/carbon/xenomorph/xeno)
-	if(locked && EvacuationAuthority.evac_status != EVACUATION_STATUS_STANDING_BY)
+	if(locked && !unslashable) //doors become slashable after evac is called
 		if(xeno.claw_type >= CLAW_TYPE_SHARP)
 			xeno.animation_attack_on(src)
 			playsound(src, 'sound/effects/metalhit.ogg', 25, 1)
@@ -240,3 +240,8 @@
 
 /obj/structure/machinery/door/airlock/evacuation/attack_remote()
 	return FALSE
+
+/obj/structure/machinery/door/airlock/evacuation/get_applying_acid_time() //you can melt evacuation doors only when they are manually locked
+	if(!locked)
+		return -1
+	..()

--- a/code/modules/shuttle/shuttles/escape_shuttle.dm
+++ b/code/modules/shuttle/shuttles/escape_shuttle.dm
@@ -20,12 +20,15 @@
 /obj/docking_port/mobile/escape_shuttle/Initialize(mapload)
 	. = ..(mapload)
 	for(var/place in shuttle_areas)
-		for(var/obj/structure/machinery/door/air in place)
+		for(var/obj/structure/machinery/door/airlock/evacuation/air in place)
 			door_handler.doors += list(air)
 			air.breakable = FALSE
 			air.indestructible = TRUE
 			air.unacidable = TRUE
 			air.linked_shuttle = src
+	if(id == ESCAPE_SHUTTLE_EAST_CL)
+		early_crash_land_chance = 25
+		crash_land_chance = 5
 
 /obj/docking_port/mobile/escape_shuttle/proc/cancel_evac()
 	door_handler.control_doors("force-unlock")
@@ -45,11 +48,11 @@
 	for(var/area/interior_area in shuttle_areas)
 		for(var/obj/structure/machinery/cryopod/evacuation/cryotube in interior_area)
 			cryotube.dock_state = STATE_READY
-	for(var/obj/structure/machinery/door/air in door_handler.doors) 
+	for(var/obj/structure/machinery/door/air in door_handler.doors)
 		air.breakable = TRUE
 		air.indestructible = FALSE
 		air.unslashable = FALSE
-	
+
 
 /obj/docking_port/mobile/escape_shuttle/proc/evac_launch()
 	if(mode == SHUTTLE_CRASHED)

--- a/code/modules/shuttle/shuttles/escape_shuttle.dm
+++ b/code/modules/shuttle/shuttles/escape_shuttle.dm
@@ -52,6 +52,7 @@
 		air.breakable = TRUE
 		air.indestructible = FALSE
 		air.unslashable = FALSE
+		air.unacidable = FALSE
 
 
 /obj/docking_port/mobile/escape_shuttle/proc/evac_launch()
@@ -93,6 +94,15 @@
 	on_ignition()
 	setTimer(ignitionTime)
 	launched = TRUE
+
+	if(!crash_land) // so doors won't break in space
+		for(var/obj/structure/machinery/door/air in door_handler.doors)
+			for(var/obj/effect/xenomorph/acid/acid in air.loc)
+				qdel(acid)
+			air.breakable = FALSE
+			air.indestructible = TRUE
+			air.unacidable = TRUE
+
 
 /obj/docking_port/mobile/escape_shuttle/proc/create_crash_point()
 	for(var/i = 1 to 10)

--- a/code/modules/shuttle/shuttles/escape_shuttle.dm
+++ b/code/modules/shuttle/shuttles/escape_shuttle.dm
@@ -9,7 +9,8 @@
 	ignitionTime = 8 SECONDS
 	ignition_sound = 'sound/effects/escape_pod_warmup.ogg'
 	/// The % chance of the escape pod crashing into the groundmap
-	var/crash_land_chance = 33
+	var/early_crash_land_chance = 75
+	var/crash_land_chance = 25
 
 	var/datum/door_controller/single/door_handler = new()
 	var/launched = FALSE
@@ -24,6 +25,7 @@
 			air.breakable = FALSE
 			air.indestructible = TRUE
 			air.unacidable = TRUE
+			air.linked_shuttle = src
 
 /obj/docking_port/mobile/escape_shuttle/proc/cancel_evac()
 	door_handler.control_doors("force-unlock")
@@ -43,6 +45,11 @@
 	for(var/area/interior_area in shuttle_areas)
 		for(var/obj/structure/machinery/cryopod/evacuation/cryotube in interior_area)
 			cryotube.dock_state = STATE_READY
+	for(var/obj/structure/machinery/door/air in door_handler.doors) 
+		air.breakable = TRUE
+		air.indestructible = FALSE
+		air.unslashable = FALSE
+	
 
 /obj/docking_port/mobile/escape_shuttle/proc/evac_launch()
 	if(mode == SHUTTLE_CRASHED)
@@ -76,7 +83,7 @@
 		return
 
 	destination = null
-	if(prob(crash_land_chance))
+	if(prob((EvacuationAuthority.evac_status >= EVACUATION_STATUS_IN_PROGRESS ? crash_land_chance : early_crash_land_chance)))
 		create_crash_point()
 
 	set_mode(SHUTTLE_IGNITING)

--- a/code/modules/shuttle/shuttles/escape_shuttle.dm
+++ b/code/modules/shuttle/shuttles/escape_shuttle.dm
@@ -98,7 +98,8 @@
 	if(!crash_land) // so doors won't break in space
 		for(var/obj/structure/machinery/door/air in door_handler.doors)
 			for(var/obj/effect/xenomorph/acid/acid in air.loc)
-				qdel(acid)
+				if(acid.acid_t == air)
+					qdel(acid)
 			air.breakable = FALSE
 			air.indestructible = TRUE
 			air.unacidable = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Xenos can break and acid manually locked pods' doors, but still cannot slash/acid them before evac is called to prevent metagaming. Pod cannot launch without doors. No more delaying in pods.

Early launch has a 75% chance of crash, launch after the evacuation timer (whether manual or automatic) has only 25%.

CL's pod has a 25% chance of crash on early launch and only 5% otherwise.


# Explain why it's good for the game

Encourages players to actually play during hijack sequence. You need to live for long enough to have a better chance to evac on pods, but if situation is dire you can still risk it. If you crash, your story continues. Also, no more delayers in pods.


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>



</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl: ihatethisengine
balance: early pod launch now has a 75% chance of crashing, launch after the timer has a 25% chance.
add: CL's pod has a 25% chance of crashing on early launch and only 5% otherwise.
add: xenos can slash and melt manually locked pod's doors.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
