### PR TITLE
Stops multiple facehuggers spawning from one client

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -1036,8 +1036,17 @@
 		to_chat(user, SPAN_WARNING("\The [GLOB.hive_datum[hivenumber]] cannot support more facehuggers! Limit: <b>[current_hugger_count]/[playable_hugger_limit]</b>"))
 		return FALSE
 
+	if(user.action_busy)
+		to_chat(user, SPAN_WARNING("You are already attempting to join the game!"))
+		return
+
+	user.action_busy = TRUE
+
 	if(alert(user, "Are you sure you want to become a facehugger?", "Confirmation", "Yes", "No") != "Yes")
+		user.action_busy = FALSE
 		return FALSE
+
+	user.action_busy = FALSE
 	return TRUE
 
 /datum/hive_status/proc/spawn_as_hugger(mob/dead/observer/user, atom/A)

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -1036,17 +1036,12 @@
 		to_chat(user, SPAN_WARNING("\The [GLOB.hive_datum[hivenumber]] cannot support more facehuggers! Limit: <b>[current_hugger_count]/[playable_hugger_limit]</b>"))
 		return FALSE
 
-	if(user.action_busy)
-		to_chat(user, SPAN_WARNING("You are already attempting to join the game!"))
-		return
-
-	user.action_busy = TRUE
-
-	if(alert(user, "Are you sure you want to become a facehugger?", "Confirmation", "Yes", "No") != "Yes")
-		user.action_busy = FALSE
+	if(tgui_alert(user, "Are you sure you want to become a facehugger?", "Confirmation", list("Yes", "No")) != "Yes")
 		return FALSE
 
-	user.action_busy = FALSE
+	if(!user.client)
+		return FALSE
+
 	return TRUE
 
 /datum/hive_status/proc/spawn_as_hugger(mob/dead/observer/user, atom/A)


### PR DESCRIPTION

# About the pull request

Stops stacking prompts to spawn multiple facehuggers.

# Explain why it's good for the game

Bug bad

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
fix: Stops multiple facehuggers spawning from one client
/:cl:
