### PR TITLE
Decreases blood bag IV insertion time

### DIFF
--- a/code/game/objects/items/reagent_containers/blood_pack.dm
+++ b/code/game/objects/items/reagent_containers/blood_pack.dm
@@ -65,7 +65,7 @@
 	if(user.action_busy)
 		return
 
-	if(!do_after(user, 3 SECONDS * user.get_skill_duration_multiplier(SKILL_SURGERY), INTERRUPT_ALL, BUSY_ICON_FRIENDLY, attacked_mob, INTERRUPT_MOVED, BUSY_ICON_MEDICAL))
+	if(!do_after(user, (1 SECONDS) * user.get_skill_duration_multiplier(SKILL_SURGERY), INTERRUPT_ALL, BUSY_ICON_FRIENDLY, attacked_mob, INTERRUPT_MOVED, BUSY_ICON_MEDICAL))
 		to_chat(user, SPAN_WARNING("You were interrupted before you could finish!"))
 		return
 


### PR DESCRIPTION

# About the pull request

This PR makes it take 1 second instead of 3 seconds (times the surgery skill multiplier) for blood bag insertion time.

# Explain why it's good for the game

This is taking too long which is severely disincentivizing usage of a mechanic we want to encourage.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
balance: Decreased blood bag IV insertion time from 3 to 1 second
/:cl:
