### PR TITLE
Vendor icon_state fix

### DIFF
--- a/code/game/machinery/vending/cm_vending.dm
+++ b/code/game/machinery/vending/cm_vending.dm
@@ -1182,6 +1182,7 @@ GLOBAL_LIST_INIT(cm_vending_gear_corresponding_types_list, list(
 		sleep(15)
 
 	vendor.stat &= ~IN_USE
+	vendor.icon_state = initial(vendor.icon_state)
 	vendor.update_icon()
 
 /proc/vendor_successful_vend_one(obj/structure/machinery/cm_vending/vendor, prod_type, mob/living/carbon/human/user, turf/target_turf, insignas_override)


### PR DESCRIPTION

# About the pull request

I don't know how no one noticed that but some of the vendors were stuck at "_vend" icon_state after first vending. Now it works as intended (hopefully).

# Explain why it's good for the game

Bug bad


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog


:cl: ihatethisengine
fix: vendors icon_state resets after vending as intended.
/:cl:
