### PR TITLE
Fix Xeno Tacmap Persistence

### DIFF
--- a/code/controllers/subsystem/minimap.dm
+++ b/code/controllers/subsystem/minimap.dm
@@ -493,6 +493,16 @@ SUBSYSTEM_DEF(minimaps)
 	else
 		return UI_CLOSE
 
+/datum/tacmap/xeno/ui_status(mob/user)
+	if(!isxeno(user))
+		return UI_CLOSE
+
+	var/mob/living/carbon/xenomorph/xeno = user
+	if(!xeno.hive?.living_xeno_queen?.ovipositor)
+		return UI_CLOSE
+
+	return UI_INTERACTIVE
+
 /datum/tacmap_holder
 	var/map_ref
 	var/atom/movable/screen/minimap/map

--- a/code/modules/mob/living/carbon/xenomorph/abilities/general_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/general_abilities.dm
@@ -514,12 +514,11 @@
 
 	tracked_queen = new_queen
 
-	if(!tracked_queen.ovipositor)
+	if(!tracked_queen?.ovipositor)
 		hide_from(owner)
 
 	RegisterSignal(tracked_queen, COMSIG_QUEEN_MOUNT_OVIPOSITOR, PROC_REF(handle_mount_ovipositor))
 	RegisterSignal(tracked_queen, COMSIG_QUEEN_DISMOUNT_OVIPOSITOR, PROC_REF(handle_dismount_ovipositor))
-	RegisterSignal(tracked_queen, COMSIG_PARENT_QDELETING, PROC_REF(handle_queen_qdel))
 
 /// deals with the queen mounting the ovipositor, unhiding the action from the user
 /datum/action/xeno_action/onclick/tacmap/proc/handle_mount_ovipositor()
@@ -531,13 +530,6 @@
 /datum/action/xeno_action/onclick/tacmap/proc/handle_dismount_ovipositor()
 	SIGNAL_HANDLER
 
-	hide_from(owner)
-
-/// cleans up references to the queen when the queen is being qdel'd, hides the action from the user
-/datum/action/xeno_action/onclick/tacmap/proc/handle_queen_qdel()
-	SIGNAL_HANDLER
-
-	tracked_queen = null
 	hide_from(owner)
 
 /datum/action/xeno_action/onclick/tacmap/use_ability(atom/target)

--- a/code/modules/mob/living/carbon/xenomorph/abilities/general_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/general_abilities.dm
@@ -510,7 +510,7 @@
 	SIGNAL_HANDLER
 
 	if(tracked_queen)
-		UnregisterSignal(tracked_queen, list(COMSIG_QUEEN_MOUNT_OVIPOSITOR, COMSIG_QUEEN_DISMOUNT_OVIPOSITOR, COMSIG_PARENT_QDELETING))
+		UnregisterSignal(tracked_queen, list(COMSIG_QUEEN_MOUNT_OVIPOSITOR, COMSIG_QUEEN_DISMOUNT_OVIPOSITOR))
 
 	tracked_queen = new_queen
 

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -352,7 +352,7 @@
 	/// How many huggers can the hive support
 	var/playable_hugger_limit = 0
 
-	var/datum/tacmap/tacmap
+	var/datum/tacmap/xeno/tacmap
 	var/minimap_type = MINIMAP_FLAG_XENO
 
 /datum/hive_status/New()


### PR DESCRIPTION

# About the pull request

This PR makes it so the xeno tacmap will be closed when the queen dies on ovi, or leaves ovi. Also fixes the xeno tacmap handling of queen deletion runtiming.

# Explain why it's good for the game

Fixes #3888 

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: Drathek
fix: Fix xeno tacmap staying open when it should be unavailable
/:cl:
