### PR TITLE
fixes xenos being blocked by humans fireman-carrying

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -315,92 +315,92 @@
 	if(.)
 		reset_view(destination)
 
-/mob/living/Collide(atom/movable/AM)
+/mob/living/Collide(atom/movable/moving_atom)
 	if(buckled || now_pushing)
 		return
 
 	if(throwing)
-		launch_impact(AM)
+		launch_impact(moving_atom)
 		return
 
-	if(SEND_SIGNAL(src, COMSIG_LIVING_PRE_COLLIDE, AM) & COMPONENT_LIVING_COLLIDE_HANDLED)
+	if(SEND_SIGNAL(src, COMSIG_LIVING_PRE_COLLIDE, moving_atom) & COMPONENT_LIVING_COLLIDE_HANDLED)
 		return
 
-	if(!isliving(AM))
+	if(!isliving(moving_atom))
 		..()
 		return
 
 	now_pushing = TRUE
-	var/mob/living/L = AM
+	var/mob/living/living_mob = moving_atom
 
-	if(L.status_flags & IMMOBILE_ACTION && src.faction == L.faction && src.mob_size <= L.mob_size)
+	if(living_mob.status_flags & IMMOBILE_ACTION && src.faction == living_mob.faction && src.mob_size <= living_mob.mob_size)
 		now_pushing = FALSE
 		return
 
 	//Leaping mobs just land on the tile, no pushing, no anything.
 	if(status_flags & LEAPING)
-		forceMove(L.loc)
+		forceMove(living_mob.loc)
 		status_flags &= ~LEAPING
 		now_pushing = FALSE
 		return
 
-	if(L.pulledby && L.pulledby != src && L.is_mob_restrained())
+	if(living_mob.pulledby && living_mob.pulledby != src && living_mob.is_mob_restrained() && ishumansynth_strict(src))
 		if(!(world.time % 5))
-			to_chat(src, SPAN_WARNING("[L] is restrained, you cannot push past."))
+			to_chat(src, SPAN_WARNING("[living_mob] is restrained, you cannot push past."))
 		now_pushing = FALSE
 		return
 
-	if(isxeno(L) && !islarva(L))
-		var/mob/living/carbon/xenomorph/X = L
-		if(X.mob_size >= MOB_SIZE_BIG || (ishuman(src) && !isyautja(src))) // Small xenos can be pushed by other xenos or preds
+	if(isxeno(living_mob) && !islarva(living_mob))
+		var/mob/living/carbon/xenomorph/xeno = living_mob
+		if(xeno.mob_size >= MOB_SIZE_BIG || (ishuman(src) && !isyautja(src))) // Small xenos can be pushed by other xenos or preds
 			now_pushing = FALSE
 			return
 
-	if(L.pulling)
-		if(ismob(L.pulling))
-			var/mob/P = L.pulling
-			if(P.is_mob_restrained())
+	if(living_mob.pulling)
+		if(ismob(living_mob.pulling) && ishumansynth_strict(src))
+			var/mob/pulled_mob = living_mob.pulling
+			if(pulled_mob.is_mob_restrained())
 				if(!(world.time % 5))
-					to_chat(src, SPAN_WARNING("[L] is restraining [P], you cannot push past."))
+					to_chat(src, SPAN_WARNING("[living_mob] is restraining [pulled_mob], you cannot push past."))
 				now_pushing = FALSE
 				return
 
-	if(ishuman(L))
-		if(!(L.status_flags & CANPUSH))
+	if(ishuman(living_mob))
+		if(!(living_mob.status_flags & CANPUSH))
 			now_pushing = FALSE
 			return
 
-	if(!L.buckled && !L.anchored)
+	if(!living_mob.buckled && !living_mob.anchored)
 		var/mob_swap
 		//the puller can always swap with its victim if on grab intent
-		if(L.pulledby == src && a_intent == INTENT_GRAB)
+		if(living_mob.pulledby == src && a_intent == INTENT_GRAB)
 			mob_swap = 1
 		//restrained people act if they were on 'help' intent to prevent a person being pulled from being separated from their puller
-		else if((L.is_mob_restrained() || L.a_intent == INTENT_HELP) && (is_mob_restrained() || a_intent == INTENT_HELP))
+		else if((living_mob.is_mob_restrained() || living_mob.a_intent == INTENT_HELP) && (is_mob_restrained() || a_intent == INTENT_HELP))
 			mob_swap = 1
 		if(mob_swap)
 			//switch our position with L
-			if(loc && !loc.Adjacent(L.loc))
+			if(loc && !loc.Adjacent(living_mob.loc))
 				now_pushing = FALSE
 				return
 			var/oldloc = loc
-			var/oldLloc = L.loc
+			var/oldLloc = living_mob.loc
 
-			L.add_temp_pass_flags(PASS_MOB_THRU)
+			living_mob.add_temp_pass_flags(PASS_MOB_THRU)
 			add_temp_pass_flags(PASS_MOB_THRU)
 
-			L.Move(oldloc)
+			living_mob.Move(oldloc)
 			Move(oldLloc)
 
 			remove_temp_pass_flags(PASS_MOB_THRU)
-			L.remove_temp_pass_flags(PASS_MOB_THRU)
+			living_mob.remove_temp_pass_flags(PASS_MOB_THRU)
 
 			now_pushing = FALSE
 			return
 
 	now_pushing = FALSE
 
-	if(!(L.status_flags & CANPUSH))
+	if(!(living_mob.status_flags & CANPUSH))
 		return
 
 	..()


### PR DESCRIPTION

# About the pull request

xenos and such can now move past and push around a human using fireman-carry & pulled cuffed humans
also bye bye 1-letter vars
fixes #3951 

# Explain why it's good for the game

fix good


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:Khadd
fix: xenos can now push humans that are using fireman-carry & humans that are being pulled and are cuffed
code: replaced 1-letter vars
/:cl:
