### PR TITLE
More portable cades tweaks and buffs

### DIFF
--- a/code/game/objects/structures/barricade/deployable.dm
+++ b/code/game/objects/structures/barricade/deployable.dm
@@ -204,16 +204,11 @@
 		if(user.action_busy)
 			return
 
-		var/need_repairs = 0
-		for(var/counter in 1 to length(stack_health))
-			if(stack_health[counter] < maxhealth)
-				need_repairs++
-
-		if(!need_repairs)
+		var/obj/item/tool/weldingtool/welder = item
+		if(min(stack_health) == maxhealth)
 			to_chat(user, SPAN_WARNING("[src.singular_name] doesn't need repairs."))
 			return
 
-		var/obj/item/tool/weldingtool/welder = item
 		if(!(welder.remove_fuel(2, user)))
 			return
 
@@ -221,7 +216,7 @@
 		SPAN_NOTICE("You begin repairing the damage to [src]."))
 		playsound(src.loc, 'sound/items/Welder2.ogg', 25, TRUE)
 
-		var/welding_time = (skillcheck(user, SKILL_CONSTRUCTION, SKILL_CONSTRUCTION_TRAINED) ? 5 SECONDS : 10 SECONDS) * need_repairs
+		var/welding_time = (skillcheck(user, SKILL_CONSTRUCTION, SKILL_CONSTRUCTION_TRAINED) ? 5 SECONDS : 10 SECONDS) * amount
 
 		if(src != user.get_inactive_hand())
 			if(!do_after(user, welding_time, INTERRUPT_NO_NEEDHAND|BEHAVIOR_IMMOBILE, BUSY_ICON_FRIENDLY, src))

--- a/code/game/objects/structures/barricade/deployable.dm
+++ b/code/game/objects/structures/barricade/deployable.dm
@@ -172,7 +172,7 @@
 	if(istype(W, /obj/item/stack/folding_barricade))
 		var/obj/item/stack/folding_barricade/F = W
 
-		if(round(health/maxhealth * 100) =< 75 || round(F.health/F.maxhealth * 100) =< 75)
+		if(round(health/maxhealth * 100) <= 75 || round(F.health/F.maxhealth * 100) <= 75)
 			to_chat(user, "You cannot stack damaged [src.singular_name]\s.")
 			return
 
@@ -262,7 +262,7 @@
 
 /obj/item/stack/folding_barricade/get_examine_text(mob/user)
 	. = ..()
-	if(round(health/maxhealth * 100) =< 75)
+	if(round(health/maxhealth * 100) <= 75)
 		. += SPAN_WARNING("It appears to be damaged.")
 	else if(health < maxhealth)
 		. += SPAN_WARNING("It appears to be scratched.")

--- a/code/game/objects/structures/barricade/deployable.dm
+++ b/code/game/objects/structures/barricade/deployable.dm
@@ -23,23 +23,23 @@
 	. = ..()
 	. += SPAN_INFO("Drag its sprite onto yourself to undeploy.")
 
-/obj/structure/barricade/deployable/attackby(obj/item/W, mob/user)
+/obj/structure/barricade/deployable/attackby(obj/item/item, mob/user)
 
-	if(iswelder(W))
-		if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH))
+	if(iswelder(item))
+		if(!HAS_TRAIT(item, TRAIT_TOOL_BLOWTORCH))
 			to_chat(user, SPAN_WARNING("You need a stronger blowtorch!"))
 			return
 		if(user.action_busy)
 			return
-		var/obj/item/tool/weldingtool/WT = W
+		var/obj/item/tool/weldingtool/welder = item
 		if(health == maxhealth)
 			to_chat(user, SPAN_WARNING("[src] doesn't need repairs."))
 			return
 
-		weld_cade(WT, user)
+		weld_cade(welder, user)
 		return
 
-	else if(HAS_TRAIT(W, TRAIT_TOOL_CROWBAR))
+	else if(HAS_TRAIT(item, TRAIT_TOOL_CROWBAR))
 		if(user.action_busy)
 			return
 		if(!skillcheck(user, SKILL_ENGINEER, SKILL_ENGINEER_TRAINED))
@@ -54,7 +54,7 @@
 			else
 				to_chat(user, SPAN_WARNING("You stop collapsing [src]."))
 
-	if(try_nailgun_usage(W, user))
+	if(try_nailgun_usage(item, user))
 		return
 
 	. = ..()
@@ -168,11 +168,11 @@
 
 	use(1)
 
-/obj/item/stack/folding_barricade/attackby(obj/item/W, mob/user)
-	if(istype(W, /obj/item/stack/folding_barricade))
-		var/obj/item/stack/folding_barricade/F = W
+/obj/item/stack/folding_barricade/attackby(obj/item/item, mob/user)
+	if(istype(item, /obj/item/stack/folding_barricade))
+		var/obj/item/stack/folding_barricade/folding = item
 
-		if(round(health/maxhealth * 100) <= 75 || round(F.health/F.maxhealth * 100) <= 75)
+		if(round(health/maxhealth * 100) <= 75 || round(folding.health/folding.maxhealth * 100) <= 75)
 			to_chat(user, "You cannot stack damaged [src.singular_name]\s.")
 			return
 
@@ -183,27 +183,27 @@
 			to_chat(user, "You cannot stack more [src.singular_name]\s.")
 			return
 
-		var/to_transfer = min(max_amount - amount, F.amount)
-		health = min(F.health, health)
-		F.use(to_transfer)
+		var/to_transfer = min(max_amount - amount, folding.amount)
+		health = min(folding.health, health)
+		folding.use(to_transfer)
 		add(to_transfer)
 		to_chat(user, SPAN_INFO("You transfer [to_transfer] between the stacks."))
 		return
 
-	else if(iswelder(W))
-		if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH))
+	else if(iswelder(item))
+		if(!HAS_TRAIT(item, TRAIT_TOOL_BLOWTORCH))
 			to_chat(user, SPAN_WARNING("You need a stronger blowtorch!"))
 			return
 
 		if(user.action_busy)
 			return
 
-		var/obj/item/tool/weldingtool/WT = W
+		var/obj/item/tool/weldingtool/welder = item
 		if(health == maxhealth)
 			to_chat(user, SPAN_WARNING("[src.singular_name] doesn't need repairs."))
 			return
 
-		if(!(WT.remove_fuel(2, user)))
+		if(!(welder.remove_fuel(2, user)))
 			return
 
 		user.visible_message(SPAN_NOTICE("[user] begins repairing damage to [src]."),

--- a/code/game/objects/structures/barricade/deployable.dm
+++ b/code/game/objects/structures/barricade/deployable.dm
@@ -213,7 +213,7 @@
 			if(!do_after(user, welding_time, INTERRUPT_NO_NEEDHAND|BEHAVIOR_IMMOBILE, BUSY_ICON_FRIENDLY, src))
 				return
 		else
-			if(!do_after(user, welding_time, (INTERRUPT_ALL & (~INTERRUPT_MOVED)), BUSY_ICON_FRIENDLY, src)) //you can move while repairing if you have cade in hand
+			if(!do_after(user, welding_time, INTERRUPT_UNCONSCIOUS|INTERRUPT_KNOCKED_DOWN|INTERRUPT_STUNNED|INTERRUPT_NEEDHAND, BUSY_ICON_FRIENDLY, src)) //you can move while repairing if you have cade in hand
 				return
 
 		if(!(WT.remove_fuel(2, user)))

--- a/code/game/objects/structures/barricade/deployable.dm
+++ b/code/game/objects/structures/barricade/deployable.dm
@@ -203,9 +203,6 @@
 			to_chat(user, SPAN_WARNING("[src.singular_name] doesn't need repairs."))
 			return
 
-		if(!(WT.remove_fuel(2, user)))
-			return
-
 		user.visible_message(SPAN_NOTICE("[user] begins repairing damage to [src]."),
 		SPAN_NOTICE("You begin repairing the damage to [src]."))
 		playsound(src.loc, 'sound/items/Welder2.ogg', 25, TRUE)
@@ -218,6 +215,9 @@
 		else
 			if(!do_after(user, welding_time, (INTERRUPT_ALL & (~INTERRUPT_MOVED)), BUSY_ICON_FRIENDLY, src)) //you can move while repairing if you have cade in hand
 				return
+
+		if(!(WT.remove_fuel(2, user)))
+			return
 
 		user.visible_message(SPAN_NOTICE("[user] repairs some damage on [src]."),
 		SPAN_NOTICE("You repair [src]."))

--- a/code/game/objects/structures/barricade/deployable.dm
+++ b/code/game/objects/structures/barricade/deployable.dm
@@ -172,8 +172,8 @@
 	if(istype(W, /obj/item/stack/folding_barricade))
 		var/obj/item/stack/folding_barricade/F = W
 
-		if(health < maxhealth * 0.80 || F.health < F.maxhealth * 0.80)
-			to_chat(user, "You cannot stack too damaged [src.singular_name]\s.")
+		if(health < maxhealth * 0.75 || F.health < F.maxhealth * 0.75)
+			to_chat(user, "You cannot stack damaged [src.singular_name]\s.")
 			return
 
 		if(!ismob(src.loc))
@@ -260,10 +260,10 @@
 
 /obj/item/stack/folding_barricade/get_examine_text(mob/user)
 	. = ..()
-	if(health < maxhealth * 0.80)
+	if(health < maxhealth * 0.75)
 		. += SPAN_WARNING("It appears to be damaged.")
 	else if(health < maxhealth)
-		. += SPAN_WARNING("It appears to be slightly damaged.")
+		. += SPAN_WARNING("It appears to be scratched.")
 
 /obj/item/stack/folding_barricade/three
 	amount = 3

--- a/code/game/objects/structures/barricade/deployable.dm
+++ b/code/game/objects/structures/barricade/deployable.dm
@@ -204,11 +204,16 @@
 		if(user.action_busy)
 			return
 
-		var/obj/item/tool/weldingtool/welder = item
-		if(min(stack_health) == maxhealth)
+		var/need_repairs = 0
+		for(var/counter in 1 to length(stack_health))
+			if(stack_health[counter] < maxhealth)
+				need_repairs++
+
+		if(!need_repairs)
 			to_chat(user, SPAN_WARNING("[src.singular_name] doesn't need repairs."))
 			return
 
+		var/obj/item/tool/weldingtool/welder = item
 		if(!(welder.remove_fuel(2, user)))
 			return
 
@@ -216,7 +221,7 @@
 		SPAN_NOTICE("You begin repairing the damage to [src]."))
 		playsound(src.loc, 'sound/items/Welder2.ogg', 25, TRUE)
 
-		var/welding_time = (skillcheck(user, SKILL_CONSTRUCTION, SKILL_CONSTRUCTION_TRAINED) ? 5 SECONDS : 10 SECONDS) * amount
+		var/welding_time = (skillcheck(user, SKILL_CONSTRUCTION, SKILL_CONSTRUCTION_TRAINED) ? 5 SECONDS : 10 SECONDS) * need_repairs
 
 		if(src != user.get_inactive_hand())
 			if(!do_after(user, welding_time, INTERRUPT_NO_NEEDHAND|BEHAVIOR_IMMOBILE, BUSY_ICON_FRIENDLY, src))

--- a/code/game/objects/structures/barricade/deployable.dm
+++ b/code/game/objects/structures/barricade/deployable.dm
@@ -203,6 +203,9 @@
 			to_chat(user, SPAN_WARNING("[src.singular_name] doesn't need repairs."))
 			return
 
+		if(!(WT.remove_fuel(2, user)))
+			return
+
 		user.visible_message(SPAN_NOTICE("[user] begins repairing damage to [src]."),
 		SPAN_NOTICE("You begin repairing the damage to [src]."))
 		playsound(src.loc, 'sound/items/Welder2.ogg', 25, TRUE)
@@ -213,11 +216,8 @@
 			if(!do_after(user, welding_time, INTERRUPT_NO_NEEDHAND|BEHAVIOR_IMMOBILE, BUSY_ICON_FRIENDLY, src))
 				return
 		else
-			if(!do_after(user, welding_time, INTERRUPT_UNCONSCIOUS|INTERRUPT_KNOCKED_DOWN|INTERRUPT_STUNNED|INTERRUPT_NEEDHAND, BUSY_ICON_FRIENDLY, src)) //you can move while repairing if you have cade in hand
+			if(!do_after(user, welding_time, (INTERRUPT_ALL & (~INTERRUPT_MOVED)), BUSY_ICON_FRIENDLY, src, INTERRUPT_DIFF_LOC)) //you can move while repairing if you have cade in hand
 				return
-
-		if(!(WT.remove_fuel(2, user)))
-			return
 
 		user.visible_message(SPAN_NOTICE("[user] repairs some damage on [src]."),
 		SPAN_NOTICE("You repair [src]."))

--- a/code/game/objects/structures/barricade/deployable.dm
+++ b/code/game/objects/structures/barricade/deployable.dm
@@ -48,7 +48,7 @@
 		else
 			user.visible_message(SPAN_NOTICE("[user] starts collapsing [src]."), \
 				SPAN_NOTICE("You begin collapsing [src]..."))
-			playsound(src.loc, 'sound/items/Crowbar.ogg', 25, 1)
+			playsound(loc, 'sound/items/Crowbar.ogg', 25, 1)
 			if(do_after(user, 1.5 SECONDS, INTERRUPT_NO_NEEDHAND, BUSY_ICON_FRIENDLY, src))
 				collapse(usr)
 			else
@@ -69,7 +69,7 @@
 	if(over_object == usr && Adjacent(usr))
 		usr.visible_message(SPAN_NOTICE("[usr] starts collapsing [src]."),
 			SPAN_NOTICE("You begin collapsing [src]."))
-		playsound(src.loc, 'sound/items/Crowbar.ogg', 25, 1)
+		playsound(loc, 'sound/items/Crowbar.ogg', 25, 1)
 		if(do_after(usr, 3 SECONDS, INTERRUPT_NO_NEEDHAND, BUSY_ICON_FRIENDLY, src))
 			collapse(usr)
 		else
@@ -115,7 +115,13 @@
 	)
 	icon = 'icons/obj/items/marine-items.dmi'
 
-	var/list/stack_health = list(350)
+	var/list/stack_health = list()
+
+/obj/item/stack/folding_barricade/Initialize(mapload, init_amount)
+	. = ..()
+	for(var/counter in 1 to amount)
+		stack_health += initial(health)
+
 
 /obj/item/stack/folding_barricade/update_icon()
 	. = ..()
@@ -137,16 +143,16 @@
 	var/obj/structure/blocker/anti_cade/AC = locate(/obj/structure/blocker/anti_cade) in OT // for M2C HMG, look at smartgun_mount.dm
 
 	if(!OT.allow_construction)
-		to_chat(usr, SPAN_WARNING("[src.singular_name] must be constructed on a proper surface!"))
+		to_chat(usr, SPAN_WARNING("[singular_name] must be constructed on a proper surface!"))
 		return
 	if(AC)
-		to_chat(usr, SPAN_WARNING("[src.singular_name] cannot be built here!"))
+		to_chat(usr, SPAN_WARNING("[singular_name] cannot be built here!"))
 		return
 
-	user.visible_message(SPAN_NOTICE("[user] begins deploying [src.singular_name]."),
-			SPAN_NOTICE("You begin deploying [src.singular_name]."))
+	user.visible_message(SPAN_NOTICE("[user] begins deploying [singular_name]."),
+			SPAN_NOTICE("You begin deploying [singular_name]."))
 
-	playsound(src.loc, 'sound/items/Ratchet.ogg', 25, 1)
+	playsound(loc, 'sound/items/Ratchet.ogg', 25, 1)
 
 	if(!do_after(user, 1 SECONDS, INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD))
 		to_chat(user, SPAN_WARNING("You were interrupted."))
@@ -157,8 +163,8 @@
 			to_chat(user, SPAN_WARNING("There is already \a [B] in this direction!"))
 			return
 
-	user.visible_message(SPAN_NOTICE("[user] has finished deploying [src.singular_name]."),
-			SPAN_NOTICE("You finish deploying [src.singular_name]."))
+	user.visible_message(SPAN_NOTICE("[user] has finished deploying [singular_name]."),
+			SPAN_NOTICE("You finish deploying [singular_name]."))
 
 	var/obj/structure/barricade/deployable/cade = new(user.loc)
 	cade.setDir(user.dir)
@@ -173,7 +179,7 @@
 /obj/item/stack/folding_barricade/attackby(obj/item/item, mob/user)
 	if(istype(item, /obj/item/stack/folding_barricade))
 		var/obj/item/stack/folding_barricade/folding = item
-		if(!ismob(src.loc)) //gather from ground
+		if(!ismob(loc)) //gather from ground
 			if(amount >= max_amount)
 				to_chat(user, "You cannot stack more [folding.singular_name]\s.")
 				return
@@ -185,7 +191,7 @@
 			to_chat(user, SPAN_INFO("You transfer [to_transfer] between the stacks."))
 			return
 		if(amount >= max_amount)
-			to_chat(user, "You cannot stack more [src.singular_name]\s.")
+			to_chat(user, "You cannot stack more [singular_name]\s.")
 			return
 
 		var/to_transfer = min(max_amount - amount, folding.amount)
@@ -210,7 +216,7 @@
 				need_repairs++
 
 		if(!need_repairs)
-			to_chat(user, SPAN_WARNING("[src.singular_name] doesn't need repairs."))
+			to_chat(user, SPAN_WARNING("[singular_name] doesn't need repairs."))
 			return
 
 		var/obj/item/tool/weldingtool/welder = item
@@ -219,7 +225,7 @@
 
 		user.visible_message(SPAN_NOTICE("[user] begins repairing damage to [src]."),
 		SPAN_NOTICE("You begin repairing the damage to [src]."))
-		playsound(src.loc, 'sound/items/Welder2.ogg', 25, TRUE)
+		playsound(loc, 'sound/items/Welder2.ogg', 25, TRUE)
 
 		var/welding_time = (skillcheck(user, SKILL_CONSTRUCTION, SKILL_CONSTRUCTION_TRAINED) ? 5 SECONDS : 10 SECONDS) * need_repairs
 
@@ -239,7 +245,7 @@
 			if(stack_health[counter] > maxhealth)
 				stack_health[counter] = maxhealth
 
-		playsound(src.loc, 'sound/items/Welder2.ogg', 25, TRUE)
+		playsound(loc, 'sound/items/Welder2.ogg', 25, TRUE)
 		return
 
 	. = ..()
@@ -252,7 +258,7 @@
 	transfer_fingerprints_to(folding)
 	folding.stack_health = list(pop(stack_health))
 	user.put_in_hands(folding)
-	src.add_fingerprint(user)
+	add_fingerprint(user)
 	folding.add_fingerprint(user)
 	use(1)
 
@@ -280,4 +286,3 @@
 
 /obj/item/stack/folding_barricade/three
 	amount = 3
-	stack_health = list(350, 350, 350)


### PR DESCRIPTION
# About the pull request

Despite making a lot of tweaks and changes to portable cades I barely touched them in the game until recently. Now I have more experience and can tweak it again.

1) You can now stack damaged cades and stack stores health of each cade. You can repair stacked cades but it will take longer time.

2) Miniengi pamphlet allows faster repairs but only when cade is folded. 

3) You can quickly collapse portable cades with crowbar if you have at least miniengi skills.

4) You no longer need to have folded portable cade in hand in order to repair it, but if you do, you can move while repairing.

# Explain why it's good for the game

1) It's extremely annoying to repair each individual cade in order to stack them just because it got hit by a stray bullet once. Now you can just ignore damage and keep going.

2) Yeah it took 10 second for PFC to repair each single cade. Really long. Now it's 5 seconds, but only when folded and if you have miniengi skills. Makes miniengi pamphlet a bit more relevant.

3) It was intended, but turned out it was a bit inconvenient. It was faster to collapse by hand because you didn't need to deal with tools. Now it requires just a crowbar and slightly faster. Also requires miniengi skill to use crowbar.

4) First was just a bit annoying, second allows more mobility which is the point of portable barricades.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: ihatethisengine
balance: you can stack scratched portable cades if their HP at least 75%. Doing so will reduce the health of all barricades in the stack to the level of the most damaged.
balance: you can repair stacked portable cades but it will take longer time depending on how many cades in stack.
balance: miniengi skill makes repairs of folded portable cades faster (10 seconds to 5 seconds, same as engineer).
balance: with engineering skill at least of miniengi you can collapse deployed portable barricade with a crowbar (wrench is no longer required, slightly faster (2 sec to 1.5 sec)).
balance: you no longer need to have folded portable cade in hand in order to repair it.
balance: if you have folded portable cade in hand, you can move while repairing it.
/:cl:
