### PR TITLE
Replace Robotics Dome Operating Table with Bioprinter (LVL-624)

### DIFF
--- a/maps/map_files/LV624/LV624.dmm
+++ b/maps/map_files/LV624/LV624.dmm
@@ -4877,7 +4877,9 @@
 /turf/open/gm/coast/beachcorner/north_west,
 /area/lv624/ground/jungle/west_jungle)
 "ayj" = (
-/obj/structure/machinery/optable,
+/obj/structure/machinery/bioprinter{
+	stored_metal = 1000
+	},
 /obj/structure/machinery/light/small{
 	dir = 4
 	},


### PR DESCRIPTION

# About the pull request

As name says, robotics dome LVL-624 will have it's operating table removed and replaced with bioprinter.

# Explain why it's good for the game

Operating Tables are one of the most powerful objects in the game. The reason is simple: larva removal. They are the only way to get it removed, and as such, securing a area WITH a operating table ends up as a worthwhile side-objective for marines.

However, with LVL-624, it's robotics dome ALSO has a operating table. This becomes problematic for the following reasons:

- It is VERY VERY VERY close to LZ2, making LZ2 by far the usual best option in a large part due to this, as robotics dome can easily be fortified by expanding the FOB. 
- Due to above nature, xenos cannot reliably try to contest this area compared to other ares in LVL (medical dome) or other maps (Big red: medbay)
- Combination of both these factors makes robotics dome, and by extension lz2, extremely powerful, as the ability to have shipside quality surgery at FOB greatly shortens the time a marine can be 'out of action'. 

Overall, I feel that replacing this operating table with a bioprinter fits the spirit of robotics, while still giving a advantage to securing that area, that being a nearby source of prosthetics. 

# Changelog

:cl:
balance: LVL-624 Robotics Dome operating table replaced with bioprinter.
/:cl:
