### PR TITLE
Fix Hiding When Busy

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
@@ -506,7 +506,9 @@
 	var/mob/living/carbon/xenomorph/xeno = owner
 	if(!xeno.check_state(TRUE))
 		return
-	if (!action_cooldown_check())
+	if(!action_cooldown_check())
+		return
+	if(xeno.action_busy)
 		return
 	if(xeno.layer != XENO_HIDING_LAYER)
 		xeno.layer = XENO_HIDING_LAYER


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

This PR makes it so the xenohide ability requires the xeno to not be busy (such as channeling a pounce). #3902 almost addressed this, but not in the scenario of not being hidden -> pounce start -> insta hide.

# Explain why it's good for the game

Fixes working around unhide mechanics like this (can be much faster than my example but I just had hide bound to a separate key): https://cdn.discordapp.com/attachments/745447048261795890/1133194895918649354/hug.mp4

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

See above.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl: Drathek
fix: Fixed xeno hide ability not checking for busy status.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
