### PR TITLE
Fix hugger death timer exploit

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -1054,6 +1054,7 @@
 	hugger.visible_message(SPAN_XENODANGER("A facehugger suddenly emerges out of \the [A]!"), SPAN_XENODANGER("You emerge out of \the [A] and awaken from your slumber. For the Hive!"))
 	playsound(hugger, 'sound/effects/xeno_newlarva.ogg', 25, TRUE)
 	hugger.generate_name()
+	hugger.timeofdeath = user.timeofdeath // Keep old death time
 
 /datum/hive_status/proc/update_lesser_drone_limit()
 	lesser_drone_limit = Ceiling(totalXenos.len / 3)


### PR DESCRIPTION

# About the pull request

This PR simply makes it so huggers retain their ghost's time of death value since huggers have two means to delete themselves without "dieing": successful hug and return to morpher.

# Explain why it's good for the game

Fixes #3989 

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/cmss13-devs/cmss13/assets/76988376/21591de0-4dd4-4fdc-b9d2-1674b2535599)

</details>

# Changelog
:cl: Drathek
fix: Fix huggers not retaining at least their old death value.
/:cl:
