### PR TITLE
Berserker ravager low rage eviscerate tweaks

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/ravager/ravager_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/ravager/ravager_abilities.dm
@@ -103,9 +103,9 @@
 	var/activation_delay = 20
 
 	var/base_damage = 25
-	var/damage_at_rage_levels = list(5, 10, 25, 45, 70)
+	var/damage_at_rage_levels = list(10, 25, 35, 50, 70)
 	var/range_at_rage_levels = list(1, 1, 1, 2, 2)
-	var/windup_reduction_at_rage_levels = list(0, 2, 4, 6, 10)
+	var/windup_reduction_at_rage_levels = list(6, 6, 6, 6, 10)
 
 
 ////// HEDGEHOG ABILITIES


### PR DESCRIPTION
# About the pull request

Tweaks the damage numbers so the growth curve makes more sense and sets the minimum eviscerate delay at what was previously rage level 4 (5 is max) duration to prevent ravs from dying via locking themselves in place for no benefit through accidental key presses.

# Explain why it's good for the game

Stunlocking yourself for no benefit as a t3 because you pressed the wrong button shouldnt be a thing, its extremely punishing for both new and skilled players alike for no real reason - no one ever intentionally uses the ability below the max rage level because it is pointless. Hopefully leads to less dumb deaths on one of the most skill reliant strains.

As for the damage part - raised it on lower levels as it was astronomically low and had massive spikes in growth rather than a linear curve. Mostly because it bothered me - I do not see any real use for it even with these changes, but maybe once in a blue moon someone will find a reason to go for it (it's still 1 range so balance impact is essentially null.)

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: Berserker eviscerate windup below rage lvl 4 set to level 4 values (0, 2 and 4 to 6)
balance: Berserker eviscerate damage raised on lower levels (5, 10, 25, 45 **to** 10, 25, 35, 50)
/:cl:
