### PR TITLE
Everyone can see Comms on Minimap now

### DIFF
--- a/code/game/machinery/telecomms/presets.dm
+++ b/code/game/machinery/telecomms/presets.dm
@@ -50,7 +50,7 @@
 	. = ..()
 
 	if(z)
-		SSminimaps.add_marker(src, z, MINIMAP_FLAG_USCM, "supply")
+		SSminimaps.add_marker(src, z, MINIMAP_FLAG_ALL, "supply")
 
 // doesn't need power, instead uses health
 /obj/structure/machinery/telecomms/relay/preset/tower/inoperable(additional_flags)


### PR DESCRIPTION

# About the pull request

Comms no longer only on USMC minimap, now shown for all. (esp Xenos)

# Explain why it's good for the game

With PR #3985, Xenos now need to know where comms are. As such, it makes sense for minimap to allow for more people to see the comms. I set it so ALL can see it, but if we want it so only USMC and Xenos can see it, that can be done.

# Changelog
:cl:
ui: Xenos (and others) now see comms relays on minimap
/:cl:
