### PR TITLE
Fluff Command RP Career Paths (DRAFT)

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1340,7 +1340,7 @@ var/const/MAX_SAVE_SLOTS = 10
 					affiliation = new_co_affiliation
 
 				if("co_career_path")
-					var/list/options = list("Infantry", "Intel", "Logistics", "Aviation")
+					var/list/options = list("Infantry", "Engineering", "Medical", "Intel", "Logistics", "Aviation")
 					var/new_career_path = tgui_input_list(user, "Choose your career path.", "Commanding Officer's Career", options)
 					if(!new_career_path)
 						return

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -100,6 +100,7 @@ var/const/MAX_SAVE_SLOTS = 10
 	var/predator_flavor_text = ""
 	//CO-specific preferences
 	var/commander_sidearm = "Mateba"
+	var/co_career_path = "infantry"
 	var/affiliation = "Unaligned"
 	//SEA specific preferences
 
@@ -479,6 +480,7 @@ var/const/MAX_SAVE_SLOTS = 10
 				dat += "<h2><b><u>Commander Settings:</u></b></h2>"
 				dat += "<b>Commander Whitelist Status:</b> <a href='?_src_=prefs;preference=commander_status;task=input'><b>[commander_status]</b></a><br>"
 				dat += "<b>Commander Sidearm:</b> <a href='?_src_=prefs;preference=co_sidearm;task=input'><b>[commander_sidearm]</b></a><br>"
+				dat += "<b>Commander Career Path:</b> <a href='?_src_=prefs;preference=co_career_path;task=input'><b>[co_career_path]</b></a><br>"
 				dat += "<b>Commander Affiliation:</b> <a href='?_src_=prefs;preference=co_affiliation;task=input'><b>[affiliation]</b></a><br>"
 				dat += "</div>"
 			else
@@ -1337,6 +1339,12 @@ var/const/MAX_SAVE_SLOTS = 10
 						return
 					affiliation = new_co_affiliation
 
+				if("co_career_path")
+					var/list/options = list("Infantry", "Intel", "Logistics", "Aviation")
+					var/new_career_path = tgui_input_list(user, "Choose your career path.", "Commanding Officer's Career Path", options)
+					if(!new_career_path)
+						return
+					command-path = new_command_path // Default should be infantry, with the other paths overriding it.
 
 				if("yautja_status")
 					var/list/options = list("Normal" = WHITELIST_NORMAL)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1341,10 +1341,10 @@ var/const/MAX_SAVE_SLOTS = 10
 
 				if("co_career_path")
 					var/list/options = list("Infantry", "Intel", "Logistics", "Aviation")
-					var/new_career_path = tgui_input_list(user, "Choose your career path.", "Commanding Officer's Career Path", options)
+					var/new_career_path = tgui_input_list(user, "Choose your career path.", "Commanding Officer's Career", options)
 					if(!new_career_path)
 						return
-					command-path = new_command_path // Default should be infantry, with the other paths overriding it.
+					co_career_path = new_career_path // Default should be infantry, with the other paths overriding it.
 
 				if("yautja_status")
 					var/list/options = list("Normal" = WHITELIST_NORMAL)

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -173,7 +173,7 @@
 
 	S["commander_status"] >> commander_status
 	S["co_sidearm"] >> commander_sidearm
-	S["co_command_path"] >> co_command_path
+	S["co_command_path"] >> co_career_path
 	S["co_affiliation"] >> affiliation
 	S["yautja_status"] >> yautja_status
 	S["synth_status"] >> synth_status
@@ -247,7 +247,7 @@
 	predator_flavor_text = predator_flavor_text ? sanitize_text(predator_flavor_text, initial(predator_flavor_text)) : initial(predator_flavor_text)
 	commander_status = sanitize_inlist(commander_status, whitelist_hierarchy, initial(commander_status))
 	commander_sidearm   = sanitize_inlist(commander_sidearm, list("Mateba","Colonel's Mateba","Golden Desert Eagle","Desert Eagle"), initial(commander_sidearm))
-	co_career_path = sanitize_inlist(co_career_path, list("Infantry", "Intel", "Logistics", Aviation), initial(co_career_path))
+	co_career_path = sanitize_inlist(co_career_path, list("Infantry", "Intel", "Logistics", "Aviation"), initial(co_career_path))
 	affiliation = sanitize_inlist(affiliation, FACTION_ALLEGIANCE_USCM_COMMANDER, initial(affiliation))
 	yautja_status = sanitize_inlist(yautja_status, whitelist_hierarchy + list("Elder"), initial(yautja_status))
 	synth_status = sanitize_inlist(synth_status, whitelist_hierarchy, initial(synth_status))
@@ -355,7 +355,7 @@
 
 	S["commander_status"] << commander_status
 	S["co_sidearm"] << commander_sidearm
-	S["co_command_path"] << co_command_path
+	S["co_command_path"] << co_career_path
 	S["co_affiliation"] << affiliation
 	S["yautja_status"] << yautja_status
 	S["synth_status"] << synth_status

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -173,6 +173,7 @@
 
 	S["commander_status"] >> commander_status
 	S["co_sidearm"] >> commander_sidearm
+	S["co_command_path"] >> co_command_path
 	S["co_affiliation"] >> affiliation
 	S["yautja_status"] >> yautja_status
 	S["synth_status"] >> synth_status
@@ -246,6 +247,7 @@
 	predator_flavor_text = predator_flavor_text ? sanitize_text(predator_flavor_text, initial(predator_flavor_text)) : initial(predator_flavor_text)
 	commander_status = sanitize_inlist(commander_status, whitelist_hierarchy, initial(commander_status))
 	commander_sidearm   = sanitize_inlist(commander_sidearm, list("Mateba","Colonel's Mateba","Golden Desert Eagle","Desert Eagle"), initial(commander_sidearm))
+	co_career_path = sanitize_inlist(co_career_path, list("Infantry", "Intel", "Logistics", Aviation), initial(co_career_path))
 	affiliation = sanitize_inlist(affiliation, FACTION_ALLEGIANCE_USCM_COMMANDER, initial(affiliation))
 	yautja_status = sanitize_inlist(yautja_status, whitelist_hierarchy + list("Elder"), initial(yautja_status))
 	synth_status = sanitize_inlist(synth_status, whitelist_hierarchy, initial(synth_status))
@@ -353,6 +355,7 @@
 
 	S["commander_status"] << commander_status
 	S["co_sidearm"] << commander_sidearm
+	S["co_command_path"] << co_command_path
 	S["co_affiliation"] << affiliation
 	S["yautja_status"] << yautja_status
 	S["synth_status"] << synth_status

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -247,7 +247,7 @@
 	predator_flavor_text = predator_flavor_text ? sanitize_text(predator_flavor_text, initial(predator_flavor_text)) : initial(predator_flavor_text)
 	commander_status = sanitize_inlist(commander_status, whitelist_hierarchy, initial(commander_status))
 	commander_sidearm   = sanitize_inlist(commander_sidearm, list("Mateba","Colonel's Mateba","Golden Desert Eagle","Desert Eagle"), initial(commander_sidearm))
-	co_career_path = sanitize_inlist(co_career_path, list("Infantry", "Intel", "Logistics", "Aviation"), initial(co_career_path))
+	co_career_path = sanitize_inlist(co_career_path, list("Infantry", "Engineering", "Medical", "Intel", "Logistics", "Aviation"), initial(co_career_path))
 	affiliation = sanitize_inlist(affiliation, FACTION_ALLEGIANCE_USCM_COMMANDER, initial(affiliation))
 	yautja_status = sanitize_inlist(yautja_status, whitelist_hierarchy + list("Elder"), initial(yautja_status))
 	synth_status = sanitize_inlist(synth_status, whitelist_hierarchy, initial(synth_status))

--- a/code/modules/gear_presets/uscm_ship.dm
+++ b/code/modules/gear_presets/uscm_ship.dm
@@ -451,18 +451,87 @@
 			if("VP78")
 				sidearmpath = /obj/item/storage/belt/gun/m4a3/vp78
 
-	new_human.equip_to_slot_or_del(new /obj/item/device/radio/headset/almayer/mcom/cdrcom(new_human), WEAR_L_EAR)
-	new_human.equip_to_slot_or_del(new /obj/item/clothing/under/marine/officer/bridge(new_human), WEAR_BODY)
-	new_human.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/jacket/marine/service(new_human), WEAR_JACKET)
-	new_human.equip_to_slot_or_del(new /obj/item/clothing/shoes/dress/commander(new_human), WEAR_FEET)
-	new_human.equip_to_slot_or_del(new /obj/item/clothing/head/beret/cm(new_human), WEAR_HEAD)
-	new_human.equip_to_slot_or_del(new sidearmpath(new_human), WEAR_WAIST)
-	new_human.equip_to_slot_or_del(new back_item(new_human), WEAR_BACK)
-	new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/general/large(new_human), WEAR_R_STORE)
-	new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/pistol/command(new_human), WEAR_L_STORE)
-	new_human.equip_to_slot_or_del(new /obj/item/device/binoculars/range/designator(new_human), WEAR_L_HAND)
-	if(kit)
-		new_human.equip_to_slot_or_del(new kit(new_human), WEAR_IN_BACK)
+	if(new_human.client && new_human.client.prefs)
+		var/co_career_path = "Infantry"
+		co_career_path = new_human.client.prefs.co_career_path
+		switch(co_career_path)
+			if("Infantry")
+				//back
+				new_human.equip_to_slot_or_del(new back_item(new_human), WEAR_BACK)
+				//head
+				new_human.equip_to_slot_or_del(new /obj/item/clothing/head/cmcap/ro(new_human), WEAR_HEAD)
+				new_human.equip_to_slot_or_del(new /obj/item/device/radio/headset/almayer/mcom/cdrcom(new_human), WEAR_L_EAR)
+				//uniform
+				new_human.equip_to_slot_or_del(new /obj/item/clothing/under/marine(new_human), WEAR_BODY)
+				//gun
+				new_human.equip_to_slot_or_del(new sidearmpath(new_human), WEAR_WAIST)
+				if(kit)
+					new_human.equip_to_slot_or_del(new kit(new_human), WEAR_IN_BACK)
+					//limbs
+					new_human.equip_to_slot_or_del(new /obj/item/clothing/gloves/marine/black(new_human), WEAR_HANDS)
+					new_human.equip_to_slot_or_del(new /obj/item/clothing/shoes/marine/knife(new_human), WEAR_FEET)
+					new_human.equip_to_slot_or_del(new /obj/item/device/binoculars/range/designator(new_human), WEAR_L_HAND)
+					//pockets
+					new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/general/large(new_human), WEAR_R_STORE)
+					new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/pistol/command(new_human), WEAR_L_STORE)
+			if("Intel")
+				//back
+				new_human.equip_to_slot_or_del(new back_item(new_human), WEAR_BACK)
+				//head
+				new_human.equip_to_slot_or_del(new /obj/item/clothing/head/beret/marine/commander/black(new_human), WEAR_HEAD)
+				new_human.equip_to_slot_or_del(new /obj/item/device/radio/headset/almayer/mcom/cdrcom(new_human), WEAR_L_EAR)
+				//uniform
+				new_human.equip_to_slot_or_del(new /obj/item/clothing/under/marine/officer/intel(new_human), WEAR_BODY)
+				//gun
+				new_human.equip_to_slot_or_del(new sidearmpath(new_human), WEAR_WAIST)
+				if(kit)
+					new_human.equip_to_slot_or_del(new kit(new_human), WEAR_IN_BACK)
+					//limbs
+					new_human.equip_to_slot_or_del(new /obj/item/clothing/gloves/marine/black(new_human), WEAR_HANDS)
+					new_human.equip_to_slot_or_del(new /obj/item/clothing/shoes/marine/knife(new_human), WEAR_FEET)
+					new_human.equip_to_slot_or_del(new /obj/item/device/binoculars/range/designator(new_human), WEAR_L_HAND)
+					//pockets
+					new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/general/large(new_human), WEAR_R_STORE)
+					new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/pistol/command(new_human), WEAR_L_STORE)
+			if("Logistics")
+				//back
+				new_human.equip_to_slot_or_del(new back_item(new_human), WEAR_BACK)
+				//head
+				new_human.equip_to_slot_or_del(new /obj/item/clothing/head/beret/cm/tan(new_human), WEAR_HEAD)
+				new_human.equip_to_slot_or_del(new /obj/item/device/radio/headset/almayer/mcom/cdrcom(new_human), WEAR_L_EAR)
+				//uniform
+				new_human.equip_to_slot_or_del(new /obj/item/clothing/under/marine/dress(new_human), WEAR_BODY)
+				//gun
+				new_human.equip_to_slot_or_del(new sidearmpath(new_human), WEAR_WAIST)
+				if(kit)
+					new_human.equip_to_slot_or_del(new kit(new_human), WEAR_IN_BACK)
+					//limbs
+					new_human.equip_to_slot_or_del(new /obj/item/clothing/gloves/marine/dress(new_human), WEAR_HANDS)
+					new_human.equip_to_slot_or_del(new /obj/item/clothing/shoes/dress(new_human), WEAR_FEET)
+					new_human.equip_to_slot_or_del(new /obj/item/device/binoculars/range/designator(new_human), WEAR_L_HAND)
+					//pockets
+					new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/general/large(new_human), WEAR_R_STORE)
+					new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/pistol/command(new_human), WEAR_L_STORE)
+			if("Aviation")
+				//back
+				new_human.equip_to_slot_or_del(new back_item(new_human), WEAR_BACK)
+				//head
+				new_human.equip_to_slot_or_del(new  /obj/item/clothing/head/helmet/marine/pilot(new_human), WEAR_HEAD)
+				new_human.equip_to_slot_or_del(new /obj/item/device/radio/headset/almayer/mcom/cdrcom(new_human), WEAR_L_EAR)
+				//uniform
+				new_human.equip_to_slot_or_del(new /obj/item/clothing/under/rank/synthetic/flight(new_human), WEAR_BODY)
+				//gun
+				new_human.equip_to_slot_or_del(new sidearmpath(new_human), WEAR_WAIST)
+				if(kit)
+					new_human.equip_to_slot_or_del(new kit(new_human), WEAR_IN_BACK)
+					//limbs
+					new_human.equip_to_slot_or_del(new /obj/item/clothing/gloves/black(new_human), WEAR_HANDS)
+					new_human.equip_to_slot_or_del(new /obj/item/clothing/shoes/marine/knife(new_human), WEAR_FEET)
+					new_human.equip_to_slot_or_del(new /obj/item/device/binoculars/range/designator(new_human), WEAR_L_HAND)
+					//pockets
+					new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/general/large(new_human), WEAR_R_STORE)
+					new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/pistol/command(new_human), WEAR_L_STORE)
+
 
 //*****************************************************************************************************/
 

--- a/code/modules/gear_presets/uscm_ship.dm
+++ b/code/modules/gear_presets/uscm_ship.dm
@@ -468,7 +468,49 @@
 				if(kit)
 					new_human.equip_to_slot_or_del(new kit(new_human), WEAR_IN_BACK)
 					//limbs
-					new_human.equip_to_slot_or_del(new /obj/item/clothing/gloves/marine/black(new_human), WEAR_HANDS)
+					new_human.equip_to_slot_or_del(new /obj/item/clothing/gloves/black(new_human), WEAR_HANDS)
+					new_human.equip_to_slot_or_del(new /obj/item/clothing/shoes/marine/knife(new_human), WEAR_FEET)
+					new_human.equip_to_slot_or_del(new /obj/item/device/binoculars/range/designator(new_human), WEAR_L_HAND)
+					//pockets
+					new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/general/large(new_human), WEAR_R_STORE)
+					new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/pistol/command(new_human), WEAR_L_STORE)
+					//Jacket
+					new_human.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/webbing(new_human), WEAR_JACKET)
+			if("Engineering")
+				//back
+				new_human.equip_to_slot_or_del(new back_item(new_human), WEAR_BACK)
+				//head
+				new_human.equip_to_slot_or_del(new /obj/item/clothing/head/beret/eng(new_human), WEAR_HEAD)
+				new_human.equip_to_slot_or_del(new /obj/item/device/radio/headset/almayer/mcom/cdrcom(new_human), WEAR_L_EAR)
+				//uniform
+				new_human.equip_to_slot_or_del(new /obj/item/clothing/under/marine/engineer(new_human), WEAR_BODY)
+				//gun
+				new_human.equip_to_slot_or_del(new sidearmpath(new_human), WEAR_WAIST)
+				if(kit)
+					new_human.equip_to_slot_or_del(new kit(new_human), WEAR_IN_BACK)
+					//limbs
+					new_human.equip_to_slot_or_del(new /obj/item/clothing/gloves/yellow(new_human), WEAR_HANDS)
+					new_human.equip_to_slot_or_del(new /obj/item/clothing/shoes/marine/knife(new_human), WEAR_FEET)
+					new_human.equip_to_slot_or_del(new /obj/item/device/binoculars/range/designator(new_human), WEAR_L_HAND)
+					//pockets
+					new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/general/large(new_human), WEAR_R_STORE)
+					new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/pistol/command(new_human), WEAR_L_STORE)
+					//Jacket
+					new_human.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/webbing(new_human), WEAR_JACKET)
+			if("Medical")
+				//back
+				new_human.equip_to_slot_or_del(new back_item(new_human), WEAR_BACK)
+				//head
+				new_human.equip_to_slot_or_del(new /obj/item/clothing/head/beret/marine/commander/dress(new_human), WEAR_HEAD)
+				new_human.equip_to_slot_or_del(new /obj/item/device/radio/headset/almayer/mcom/cdrcom(new_human), WEAR_L_EAR)
+				//uniform
+				new_human.equip_to_slot_or_del(new /obj/item/clothing/under/marine/medic(new_human), WEAR_BODY)
+				//gun
+				new_human.equip_to_slot_or_del(new sidearmpath(new_human), WEAR_WAIST)
+				if(kit)
+					new_human.equip_to_slot_or_del(new kit(new_human), WEAR_IN_BACK)
+					//limbs
+					new_human.equip_to_slot_or_del(new /obj/item/clothing/gloves/latex(new_human), WEAR_HANDS)
 					new_human.equip_to_slot_or_del(new /obj/item/clothing/shoes/marine/knife(new_human), WEAR_FEET)
 					new_human.equip_to_slot_or_del(new /obj/item/device/binoculars/range/designator(new_human), WEAR_L_HAND)
 					//pockets
@@ -493,6 +535,8 @@
 					//pockets
 					new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/general/large(new_human), WEAR_R_STORE)
 					new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/pistol/command(new_human), WEAR_L_STORE)
+					//Jacket
+					new_human.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/webbing(new_human), WEAR_JACKET)
 			if("Logistics")
 				//back
 				new_human.equip_to_slot_or_del(new back_item(new_human), WEAR_BACK)
@@ -516,10 +560,9 @@
 				//back
 				new_human.equip_to_slot_or_del(new back_item(new_human), WEAR_BACK)
 				//head
-				new_human.equip_to_slot_or_del(new  /obj/item/clothing/head/helmet/marine/pilot(new_human), WEAR_HEAD)
 				new_human.equip_to_slot_or_del(new /obj/item/device/radio/headset/almayer/mcom/cdrcom(new_human), WEAR_L_EAR)
 				//uniform
-				new_human.equip_to_slot_or_del(new /obj/item/clothing/under/rank/synthetic/flight(new_human), WEAR_BODY)
+				new_human.equip_to_slot_or_del(new /obj/item/clothing/under/marine/officer/pilot(new_human), WEAR_BODY)
 				//gun
 				new_human.equip_to_slot_or_del(new sidearmpath(new_human), WEAR_WAIST)
 				if(kit)
@@ -531,6 +574,8 @@
 					//pockets
 					new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/general/large(new_human), WEAR_R_STORE)
 					new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/pistol/command(new_human), WEAR_L_STORE)
+					//Jacket
+					new_human.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/webbing(new_human), WEAR_JACKET)
 
 
 //*****************************************************************************************************/

--- a/config/example/role_whitelist.txt
+++ b/config/example/role_whitelist.txt
@@ -39,3 +39,4 @@
 #######################################################
 
 #Your_name_here				+Everything
+Misfrag				+Everything


### PR DESCRIPTION
# About the pull request

So, there's been an increasing amount of COs with varied niches to their characters from my understanding. Some prominent examples are Soomis, who formerly played an Intel Major, NuSix who plays a logistics Major, and myself who does an Airwing major. I thought with these varied characters and units COs are RPing out leading, it'd be nice to add some ingame representation of the matter.

This PR seeks to represent that fact ingame by adding optional command path preferences for COs. Six options exist:
- Infantry
- Engineering
- Medical
- Logistics
- Intel 
- Aviation

Infantry is the default option, and what I suspect will be the most used. The others have to be manually set as preference by a CO player.


# Explain why it's good for the game

This PR is meant to add more flexibility and customization options to CO players, alongside that, it seeks to achieve a better representation of lore written for CO characters in game. It does that by adding these fluff career paths that COs can manually select that have corresponding outfits. No actual items or pouches are changed, only hat, uniform, gloves and boots.

# Testing Photographs and Procedure
<Photos>

![image](https://github.com/cmss13-devs/cmss13/assets/112246304/e87a85bf-294a-4b69-82d9-2308a9ee9cd9)

![image](https://github.com/cmss13-devs/cmss13/assets/112246304/99c7fbd0-fd2a-4fcb-b919-ea7bf14db606)

![image](https://github.com/cmss13-devs/cmss13/assets/112246304/bb0f7398-35c8-4743-ab14-9775a94baf65)

Left to right: Infantry, Engineering, Medical, Intel, Logistics, Aviation
</details>


# Changelog
:cl: Misty
add: Adds command career paths for COs. This lets you select from six different career paths that spawn you in with different ingame outfits.
/:cl:

For now, this is a draft at Naut's suggestion for those within the CL whitelist to view and discuss upon internally.