### PR TITLE
Lower dropship equipment costs

### DIFF
--- a/code/modules/cm_marines/dropship_equipment.dm
+++ b/code/modules/cm_marines/dropship_equipment.dm
@@ -289,7 +289,7 @@
 	density = FALSE
 	equip_categories = list(DROPSHIP_WEAPON, DROPSHIP_CREW_WEAPON)
 	icon_state = "mg_system"
-	point_cost = 300
+	point_cost = 50
 	var/deployment_cooldown
 	var/obj/structure/machinery/m56d_hmg/mg_turret/dropship/deployed_mg
 	combat_equipment = FALSE
@@ -449,7 +449,7 @@
 	icon_state = "spotlights"
 	desc = "A set of high-powered spotlights to illuminate large areas. Fits on electronics attach points of dropships. Moving this will require a powerloader."
 	is_interactable = TRUE
-	point_cost = 300
+	point_cost = 25
 	var/spotlights_cooldown
 	var/brightness = 11
 
@@ -513,7 +513,7 @@
 	name = "\improper LZ detector"
 	desc = "An electronic device linked to the dropship's camera system that lets you observe your landing zone mid-flight."
 	icon_state = "lz_detector"
-	point_cost = 400
+	point_cost = 25
 	var/obj/structure/machinery/computer/cameras/dropship/linked_cam_console
 
 /obj/structure/dropship_equipment/electronics/landing_zone_detector/update_equipment()
@@ -1137,7 +1137,7 @@
 	name = "rappel deployment system"
 	equip_categories = list(DROPSHIP_CREW_WEAPON)
 	icon_state = "rappel_module_packaged"
-	point_cost = 500
+	point_cost = 50
 	combat_equipment = FALSE
 
 	var/harness = /obj/item/rappel_harness

--- a/code/modules/cm_marines/dropship_equipment.dm
+++ b/code/modules/cm_marines/dropship_equipment.dm
@@ -449,7 +449,7 @@
 	icon_state = "spotlights"
 	desc = "A set of high-powered spotlights to illuminate large areas. Fits on electronics attach points of dropships. Moving this will require a powerloader."
 	is_interactable = TRUE
-	point_cost = 25
+	point_cost = 50
 	var/spotlights_cooldown
 	var/brightness = 11
 
@@ -513,7 +513,7 @@
 	name = "\improper LZ detector"
 	desc = "An electronic device linked to the dropship's camera system that lets you observe your landing zone mid-flight."
 	icon_state = "lz_detector"
-	point_cost = 25
+	point_cost = 50
 	var/obj/structure/machinery/computer/cameras/dropship/linked_cam_console
 
 /obj/structure/dropship_equipment/electronics/landing_zone_detector/update_equipment()


### PR DESCRIPTION
# About the pull request

Lowers manufacturing costs for useless/unused equipment.

# Explain why it's good for the game

CAS weaponry always was and will be a priority, therefore the transport and other QOL additions either need to be really strong/useful to warrant purchasing them, or have costs so negligible that it doesn't feel like griefing if you do.

LZ detectors and spotlights are exceedingly useless and a massive noobtrap/missclick bait, if they're not being removed they should at least be almost costless.
Rappel's a cool system, but sadly extremely underused and as far as I know never had much of an impact on a round - I see no point in gatekeeping fun situations for both sides behind that price cost. Encourages teamwork and communication, everyone wins here.
M56 similar to the above - sovlful, encourages fun and holdouts, but rather useless in practice and will likely get the user killed. A fun way to go though.

If some hidden worth of these ends up being discovered and they actually make a dent on the balance, the prices can be raised up accordingly.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: Dropship machine gun cost lowered from 300 to 50.
balance: Dropship rappel module cost lowered from 500 to 50.
balance: Dropship spotlight cost lowered from 300 to 50.
balance: Dropship LZ detector cost lowered from 400 to 50.
/:cl:
