### PR TITLE
Xeno interactions with reinforced walls and window frames

### DIFF
--- a/code/game/turfs/walls/r_wall.dm
+++ b/code/game/turfs/walls/r_wall.dm
@@ -10,7 +10,7 @@
 
 	walltype = WALL_REINFORCED
 
-	claws_minimum = CLAW_TYPE_VERY_SHARP
+	claws_minimum = CLAW_TYPE_SHARP
 
 /turf/closed/wall/r_wall/attackby(obj/item/W, mob/user)
 	if(hull)
@@ -179,7 +179,7 @@
 	if(hull)
 		return 0
 	else
-		return 2
+		return 1
 
 
 //Just different looking wall

--- a/code/modules/mob/living/carbon/xenomorph/abilities/ability_helper_procs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/ability_helper_procs.dm
@@ -31,12 +31,6 @@
 	if(isobj(O))
 		I = O
 
-		if(istype(I, /obj/structure/window_frame))
-			var/obj/structure/window_frame/WF = I
-			if(WF.reinforced && acid_type != /obj/effect/xenomorph/acid/strong)
-				to_chat(src, SPAN_WARNING("This [O.name] is too tough to be melted by your weak acid."))
-				return
-
 		wait_time = I.get_applying_acid_time()
 		if(wait_time == -1)
 			to_chat(src, SPAN_WARNING("You cannot dissolve \the [I]."))


### PR DESCRIPTION
# About the pull request

Allows acid below boiler level to melt reinforced window frames and reinforced walls.
Allows t2s to make holes in reinforced walls.

# Explain why it's good for the game
Reinf frames are already slashable, forgot to make them meltable when I PR'd slash fixes way back. Makes no sense to require boiler acid for these.

Since marines were buffed to be capable of making reinforced walls planetside and no one updated xenos to be able to break them, the meta thing to do has been to simply wall off flanks to FOB or tcomms with these as it prevents any t2s from accessing the area - it's way too easy and cheap to remove player interaction in this way. The intended way to protect flanks is to have people and/or sentry guns there, not wall them off else that'd be done by the mapper to begin with.
It also admittedly makes little sense to restrict slashing in this way, this PR makes it more consistent with bolted and welded doors aswell as window frames and other structures - the only difference between walls and RWalls being that they take longer to break due to more health.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: Xenos no longer require boiler acid to melt reinforced walls.
balance: Xenos no longer require t3 claws to make holes in reinforced walls.
qol: Xenos no longer require boiler acid to melt reinforced window frames.
/:cl:
