### PR TITLE
Gun bugfixes

### DIFF
--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -1315,15 +1315,17 @@ Defined in conflicts.dm of the #defines folder.
 
 /obj/item/attachable/stock/hg3712/New()
 	..()
-	//it makes stuff much better when two-handed
-	accuracy_mod = HIT_ACCURACY_MULT_TIER_4
-	recoil_mod = -RECOIL_AMOUNT_TIER_4
-	scatter_mod = -SCATTER_AMOUNT_TIER_8
-	movement_onehanded_acc_penalty_mod = -MOVEMENT_ACCURACY_PENALTY_MULT_TIER_5
-	//it makes stuff much worse when one handed
-	accuracy_unwielded_mod = -HIT_ACCURACY_MULT_TIER_3
-	recoil_unwielded_mod = RECOIL_AMOUNT_TIER_4
-	scatter_unwielded_mod = SCATTER_AMOUNT_TIER_8
+
+	//HG stock is purely aesthetics, any changes should be done to the gun itself
+	accuracy_mod = 0
+	recoil_mod = 0
+	scatter_mod = 0
+	movement_onehanded_acc_penalty_mod = 0
+	accuracy_unwielded_mod = 0
+	recoil_unwielded_mod = 0
+	scatter_unwielded_mod = 0
+	aim_speed_mod = 0
+	wield_delay_mod = WIELD_DELAY_NONE
 
 /obj/item/attachable/stock/hg3712/m3717
 	name = "hg3717 stock"
@@ -2322,6 +2324,9 @@ Defined in conflicts.dm of the #defines folder.
 	max_range = 6
 	burn_level = BURN_LEVEL_TIER_5
 	burn_duration = BURN_TIME_TIER_2
+
+/obj/item/attachable/attached_gun/flamer/advanced/unique_action(mob/user)
+	return	//No need for volatile mode, it already does high damage by default
 
 /obj/item/attachable/attached_gun/flamer/advanced/integrated
 	name = "integrated flamethrower"


### PR DESCRIPTION
# About the pull request

Fixed Advanced mini flamers being able to switch to volatile mode (and nerfing itself, the min flamer is already volatile+ by default)

Removed the copy and paste stats of intergrated HG shotgun's stock, it should be aesthetics attachment only and was implemented poorly

# Explain why it's good for the game

Bug bad, advanced mini flamer shouldn't be nerfing itself by accident

HG intergrated stock stat is just purely aesthetics, any stat change should be done to the gun itself. Similar to Smart gun barrel,
I suspect the stock was used to bypass sprite 32 pixel limit, and was just a mistake by the previous contributor in #453.

# Changelog

:cl: ghostsheet
fix: Advanced mini flamer can no longer nerf itself by changing mode.
add: HG 37-12 pump shotgun's intergrated stock no longer give any stat change.
/:cl: