### PR TITLE
fixes xeno wound icon delay

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
@@ -1125,3 +1125,8 @@
 	SPAN_WARNING("You squeeze and scuttle underneath [current_structure]."), max_distance = 5)
 	forceMove(current_structure.loc)
 	return TRUE
+
+/mob/living/carbon/xenomorph/knocked_down_callback()
+	. = ..()
+	if(!resting) // !resting because we dont wanna prematurely update wounds if they're just trying to rest
+		update_wounds()

--- a/code/modules/mob/mob_status_procs.dm
+++ b/code/modules/mob/mob_status_procs.dm
@@ -94,9 +94,6 @@
 	handle_regular_status_updates(FALSE)
 	update_canmove()
 	knocked_down_timer = null
-	if(isxeno(src) && !resting) // !resting because we dont wanna prematurely update wounds if they're just trying to rest
-		var/mob/living/carbon/xenomorph/xeno = src
-		xeno.update_wounds()
 
 /mob/proc/knocked_down_callback_check()
 	if(knocked_down && knocked_down < recovery_constant)


### PR DESCRIPTION

# About the pull request

when xenos were getting back up from a stun/rest their bloody wounds would briefly disappear until the next time their wound icon got updated
now the wound icon is updated right as soon as they get up

# Explain why it's good for the game

a heavily wounded xeno getting up from a stun and appearing full health for a bit shouldn't be a thing

# Testing Photographs and Procedure

https://github.com/cmss13-devs/cmss13/assets/54692343/233604be-bc88-427e-9397-4059bba5c01a

# Changelog
:cl:Khadd
fix: xenos now update their wound icon when getting up
/:cl:
