### PR TITLE
Replaces heavy revolver knockback with screenshake

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -570,6 +570,7 @@
 	name = "heavy revolver bullet"
 
 	damage = 35
+	accurate_range = 4
 	penetration = ARMOR_PENETRATION_TIER_4
 	accuracy = HIT_ACCURACY_TIER_3
 

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -573,8 +573,10 @@
 	penetration = ARMOR_PENETRATION_TIER_4
 	accuracy = HIT_ACCURACY_TIER_3
 
-/datum/ammo/bullet/revolver/heavy/on_hit_mob(mob/M, obj/item/projectile/P)
-	knockback(M, P, 4)
+/datum/ammo/bullet/revolver/heavy/on_hit_mob(mob/M, obj/item/projectile/fired_projectile)
+	if(fired_projectile.distance_travelled > accurate_range)
+		return
+	shake_camera(M, 6, 4)
 
 /datum/ammo/bullet/revolver/incendiary
 	name = "incendiary revolver bullet"


### PR DESCRIPTION
# About the pull request

Replaces heavy revolver knockback with heavy screenshake that extends to t3 and t4, maintains 4 tiles as max range for this effect. See video section for demonstration.

# Explain why it's good for the game

I trust I don't have to explain why the ability to permastun t1s and t2s in a secondary gun you can easily conceal is problematic. It's questionably balanced as a specialist's (scout) primary gun, let alone on a revolver.

Replaced it with a heavy screenshake effect, effects of which demonstrated in the video section - completely throws off clicks making xenos unable to effectively fight back or use abilities (ravs charging sideways, queen 1v1 hype) without leaving them entirely helpless to escape. Unique, balanced effect that keeps the gun's niche = good.

Might've been better to use a new var to set the range, but it doesn't seem to affect much as far as targets within screen range are concerned + makes sense given it's heavier ammo and fits with marksman ammo extending the range aswell.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

https://streamable.com/2le3t9

</details>


# Changelog
:cl:
balance: Replaced heavy revolver knockback with screenshake
balance: Heavy revolver accurate range set to 4 tiles
/:cl:
