### PR TITLE
Eggsac no longer able to plant eggs outside hive weeds

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/egg_item.dm
+++ b/code/modules/mob/living/carbon/xenomorph/egg_item.dm
@@ -98,7 +98,7 @@
 		to_chat(user, SPAN_XENOWARNING("[src] must be planted on [lowertext(hive.prefix)]weeds."))
 		return
 
-	if(!hive_weeds && user.mutation_type != CARRIER_EGGSAC)
+	if(!hive_weeds)
 		to_chat(user, SPAN_XENOWARNING("[src] can only be planted on [lowertext(hive.prefix)]hive weeds."))
 		return
 
@@ -117,7 +117,7 @@
 		return
 
 	for(var/obj/effect/alien/weeds/weed in T)
-		if(weed.weed_strength >= WEED_LEVEL_HIVE || user.mutation_type == CARRIER_EGGSAC)
+		if(weed.weed_strength >= WEED_LEVEL_HIVE)
 			user.use_plasma(30)
 			var/obj/effect/alien/egg/newegg = new /obj/effect/alien/egg(T, hivenumber)
 


### PR DESCRIPTION

# About the pull request

Re-adds the weed restriction for egg planting to eggsac carrier.

# Explain why it's good for the game

It was removed for a VERY good reason that's more than apparent immediately after this was merged. An egg behind every corner has a massive impact on balance with marines no longer being able to chase any xeno without an instant round end, to say nothing about any pushback ability and especially warrior lunge being an instant round ender now. Even without that simply opening the egg, waiting several seconds and opening the door will cause the hugger to leap several tiles.
It was absurdly overpowered, which is why it was removed in the first place. It is even more so now, given the shorter gestation period making this the easiest and best way to perma marines xenos ever had.

Stop bringing back old issues.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: Makes eggsac carrier unable to plant eggs outside of hive weeds again.
/:cl:
