### PR TITLE
Player controlled facehuggers no longer have a shortened stun duration

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
@@ -149,7 +149,7 @@
 
 /mob/living/carbon/xenomorph/facehugger/proc/handle_hug(mob/living/carbon/human/human)
 	var/obj/item/clothing/mask/facehugger/hugger = new /obj/item/clothing/mask/facehugger(loc, hivenumber)
-	var/did_hug = hugger.attach(human, TRUE, 0.5, src)
+	var/did_hug = hugger.attach(human, TRUE, 1, src)
 	if(client)
 		client.player_data?.adjust_stat(PLAYER_STAT_FACEHUGS, STAT_CATEGORY_XENO, 1)
 	qdel(src)


### PR DESCRIPTION

# About the pull request

Sets the knockout timer for player controlled facehuggers to be the same as standard hugs.

# Explain why it's good for the game

Facehuggers no longer grief the hive by fulfilling their purpose.
If you've played facehugger you've surely seen experienced xenos try to run from you or flame you if you attempted to hug. The reason for that was this shortened stun which usually led to chaos in the hive because the capture woke up. Not really sure why it was set to half to begin with.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: Player controlled facehuggers apply the same knockout duration as regular ones.
/:cl:
