### PR TITLE
Xenos can eat food to regain health (lore accurate)

### DIFF
--- a/code/game/objects/items/reagent_containers/food/snacks.dm
+++ b/code/game/objects/items/reagent_containers/food/snacks.dm
@@ -19,14 +19,14 @@
 	center_of_mass = "x=15;y=15"
 
 	//Placeholder for effect that trigger on eating that aren't tied to reagents.
-/obj/item/reagent_container/food/snacks/proc/On_Consume(mob/M)
-	SEND_SIGNAL(src, COMSIG_SNACK_EATEN, M)
+/obj/item/reagent_container/food/snacks/proc/On_Consume(mob/target_mob)
+	SEND_SIGNAL(src, COMSIG_SNACK_EATEN, target_mob)
 	if(!usr) return
 
 	if(!reagents.total_volume)
-		if(M == usr)
+		if(target_mob == usr)
 			to_chat(usr, SPAN_NOTICE("You finish eating \the [src]."))
-		M.visible_message(SPAN_NOTICE("[M] finishes eating \the [src]."))
+		target_mob.visible_message(SPAN_NOTICE("[target_mob] finishes eating \the [src]."))
 		update_icon()
 
 		if(trash)
@@ -35,7 +35,7 @@
 				trash_item = new trash(usr)
 			else if(istype(trash,/obj/item))
 				trash_item = trash
-			if(isxeno(M))
+			if(isxeno(target_mob))
 				trash_item.forceMove(get_turf(src))
 			else
 				usr.put_in_hands(trash_item)
@@ -237,10 +237,10 @@
 			//N.emote("nibbles away at the [src]")
 			N.health = min(N.health + 1, N.maxHealth)
 
-/obj/item/reagent_container/food/snacks/attack_alien(mob/living/carbon/xenomorph/M)
+/obj/item/reagent_container/food/snacks/attack_alien(mob/living/carbon/xenomorph/xeno)
 	if(reagents && !reagents.total_volume) //Shouldn't be needed but it checks to see if it has anything left in it.
-		to_chat(M, SPAN_DANGER("None of [src] left, oh no!"))
-		M.drop_inv_item_on_ground(src) //so icons update :[
+		to_chat(xeno, SPAN_DANGER("None of [src] left, oh no!"))
+		xeno.drop_inv_item_on_ground(src) //so icons update :[
 		qdel(src)
 		return XENO_NO_DELAY_ACTION
 
@@ -248,15 +248,15 @@
 		return XENO_NO_DELAY_ACTION
 
 	if(reagents) //Handle ingestion of the reagent.
-		playsound(M.loc,'sound/items/eatfood.ogg', 15, 1)
+		playsound(xeno.loc,'sound/items/eatfood.ogg', 15, 1)
 		if(reagents.total_volume)
-			reagents.set_source_mob(M)
+			reagents.set_source_mob(xeno)
 			if(reagents.total_volume > bitesize)
-				reagents.trans_to_ingest(M, bitesize)
+				reagents.trans_to_ingest(xeno, bitesize)
 			else
-				reagents.trans_to_ingest(M, reagents.total_volume)
+				reagents.trans_to_ingest(xeno, reagents.total_volume)
 			bitecount++
-			On_Consume(M)
+			On_Consume(xeno)
 		return XENO_NONCOMBAT_ACTION
 
 	return XENO_NO_DELAY_ACTION

--- a/code/game/objects/items/reagent_containers/food/snacks.dm
+++ b/code/game/objects/items/reagent_containers/food/snacks.dm
@@ -63,8 +63,8 @@
 		if(fullness > 540 && world.time < C.overeat_cooldown)
 			to_chat(user, SPAN_WARNING("[user == M ? "You" : "They"] don't feel like eating more right now."))
 			return
-		if(issynth(C))
-			fullness = 200 //Synths never get full
+		if(issynth(C) || isxeno(C))
+			fullness = 200 //Synths and xenos never get full
 
 		if(HAS_TRAIT(M, TRAIT_CANNOT_EAT)) //Do not feed the Working Joes
 			to_chat(user, SPAN_DANGER("[user == M ? "You are" : "[M] is"] unable to eat!"))
@@ -232,6 +232,30 @@
 				N.visible_message("[N] nibbles away at [src].", "")
 			//N.emote("nibbles away at the [src]")
 			N.health = min(N.health + 1, N.maxHealth)
+
+/obj/item/reagent_container/food/snacks/attack_alien(mob/living/carbon/xenomorph/M)
+	if(reagents && !reagents.total_volume) //Shouldn't be needed but it checks to see if it has anything left in it.
+		to_chat(M, SPAN_DANGER("None of [src] left, oh no!"))
+		M.drop_inv_item_on_ground(src) //so icons update :[
+		qdel(src)
+		return XENO_NO_DELAY_ACTION
+
+	if(package)
+		return XENO_NO_DELAY_ACTION
+
+	if(reagents) //Handle ingestion of the reagent.
+		playsound(M.loc,'sound/items/eatfood.ogg', 15, 1)
+		if(reagents.total_volume)
+			reagents.set_source_mob(M)
+			if(reagents.total_volume > bitesize)
+				reagents.trans_to_ingest(M, bitesize)
+			else
+				reagents.trans_to_ingest(M, reagents.total_volume)
+			bitecount++
+			On_Consume(M)
+		return XENO_NONCOMBAT_ACTION
+
+	return XENO_NO_DELAY_ACTION
 
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/code/game/objects/items/reagent_containers/food/snacks.dm
+++ b/code/game/objects/items/reagent_containers/food/snacks.dm
@@ -30,11 +30,15 @@
 		usr.drop_inv_item_on_ground(src) //so icons update :[
 
 		if(trash)
+			var/obj/item/trash_item
 			if(ispath(trash,/obj/item))
-				var/obj/item/TrashItem = new trash(usr)
-				usr.put_in_hands(TrashItem)
+				trash_item = new trash(usr)
 			else if(istype(trash,/obj/item))
-				usr.put_in_hands(trash)
+				trash_item = trash
+			if(isxeno(M))
+				trash_item.forceMove(get_turf(src))
+			else
+				usr.put_in_hands(trash_item)
 		qdel(src)
 	return
 

--- a/code/game/objects/items/reagent_containers/food/snacks.dm
+++ b/code/game/objects/items/reagent_containers/food/snacks.dm
@@ -27,7 +27,7 @@
 		if(M == usr)
 			to_chat(usr, SPAN_NOTICE("You finish eating \the [src]."))
 		M.visible_message(SPAN_NOTICE("[M] finishes eating \the [src]."))
-		usr.drop_inv_item_on_ground(src) //so icons update :[
+		update_icon()
 
 		if(trash)
 			var/obj/item/trash_item

--- a/code/modules/reagents/chemistry_properties/prop_neutral.dm
+++ b/code/modules/reagents/chemistry_properties/prop_neutral.dm
@@ -61,11 +61,11 @@
 		M.nutrition += holder.nutriment_factor * level
 
 
-/datum/chem_property/neutral/nutritious/reaction_mob(mob/M, method=TOUCH, volume, potency)
-	if(method == INGEST && isxeno(M))
-		var/mob/living/carbon/xenomorph/xeno = M
+/datum/chem_property/neutral/nutritious/reaction_mob(mob/target_mob, method=TOUCH, volume, potency)
+	if(method == INGEST && isxeno(target_mob))
+		var/mob/living/carbon/xenomorph/xeno = target_mob
 		if(xeno.health < xeno.maxHealth)
-			xeno.gain_health(holder.nutriment_factor * level * 4)
+			xeno.gain_health(holder.nutriment_factor * level * 3)
 			xeno.flick_heal_overlay(1 SECONDS, "#666d09")
 		xeno.reagents.remove_reagent("nutriment", volume, TRUE) //xenos don't process chems so we don't want it to max at 100u
 		holder.on_delete()

--- a/code/modules/reagents/chemistry_properties/prop_neutral.dm
+++ b/code/modules/reagents/chemistry_properties/prop_neutral.dm
@@ -61,8 +61,12 @@
 		M.nutrition += holder.nutriment_factor * level
 
 /datum/chem_property/neutral/nutritious/reaction_mob(mob/target_mob, method=TOUCH, volume, potency)
+	if(target_mob.stat == DEAD)
+		return
+
 	if(method == INGEST && isxeno(target_mob))
 		var/mob/living/carbon/xenomorph/xeno = target_mob
+		if(xeno.stat == DEAD)
 		if(xeno.health < xeno.maxHealth || xeno.plasma_stored < xeno.plasma_max)
 			xeno.gain_health(holder.nutriment_factor * level * 4)
 			xeno.gain_plasma(holder.nutriment_factor * level * 4)

--- a/code/modules/reagents/chemistry_properties/prop_neutral.dm
+++ b/code/modules/reagents/chemistry_properties/prop_neutral.dm
@@ -65,7 +65,7 @@
 		var/mob/living/carbon/xenomorph/xeno = target_mob
 		if(xeno.health < xeno.maxHealth || xeno.plasma_stored < xeno.plasma_max)
 			xeno.gain_health(holder.nutriment_factor * level * 4)
-			xeno.plasma_stored = min(xeno.plasma_stored + holder.nutriment_factor * level * 4, xeno.plasma_max)
+			xeno.gain_plasma(holder.nutriment_factor * level * 4)
 			xeno.flick_heal_overlay(1 SECONDS, "#666d09")
 		xeno.reagents.remove_reagent("nutriment", volume, TRUE) //xenos don't process chems so we don't want it to max at 100u
 		holder.on_delete()

--- a/code/modules/reagents/chemistry_properties/prop_neutral.dm
+++ b/code/modules/reagents/chemistry_properties/prop_neutral.dm
@@ -60,7 +60,6 @@
 	else
 		M.nutrition += holder.nutriment_factor * level
 
-
 /datum/chem_property/neutral/nutritious/reaction_mob(mob/target_mob, method=TOUCH, volume, potency)
 	if(method == INGEST && isxeno(target_mob))
 		var/mob/living/carbon/xenomorph/xeno = target_mob
@@ -70,8 +69,6 @@
 			xeno.flick_heal_overlay(1 SECONDS, "#666d09")
 		xeno.reagents.remove_reagent("nutriment", volume, TRUE) //xenos don't process chems so we don't want it to max at 100u
 		holder.on_delete()
-
-
 
 /datum/chem_property/neutral/nutritious/reset_reagent()
 	holder.nutriment_factor = initial(holder.nutriment_factor)

--- a/code/modules/reagents/chemistry_properties/prop_neutral.dm
+++ b/code/modules/reagents/chemistry_properties/prop_neutral.dm
@@ -66,7 +66,6 @@
 
 	if(method == INGEST && isxeno(target_mob))
 		var/mob/living/carbon/xenomorph/xeno = target_mob
-		if(xeno.stat == DEAD)
 		if(xeno.health < xeno.maxHealth || xeno.plasma_stored < xeno.plasma_max)
 			xeno.gain_health(holder.nutriment_factor * level * 4)
 			xeno.gain_plasma(holder.nutriment_factor * level * 4)

--- a/code/modules/reagents/chemistry_properties/prop_neutral.dm
+++ b/code/modules/reagents/chemistry_properties/prop_neutral.dm
@@ -60,6 +60,18 @@
 	else
 		M.nutrition += holder.nutriment_factor * level
 
+
+/datum/chem_property/neutral/nutritious/reaction_mob(mob/M, method=TOUCH, volume, potency)
+	if(method == INGEST && isxeno(M))
+		var/mob/living/carbon/xenomorph/xeno = M
+		if(xeno.health < xeno.maxHealth)
+			xeno.gain_health(holder.nutriment_factor * level * 5)
+			xeno.flick_heal_overlay(1 SECONDS, "#666d09")
+		xeno.reagents.remove_reagent("nutriment", volume, TRUE) //xenos don't process chems so we don't want it to max at 100u
+		holder.on_delete()
+
+
+
 /datum/chem_property/neutral/nutritious/reset_reagent()
 	holder.nutriment_factor = initial(holder.nutriment_factor)
 	..()

--- a/code/modules/reagents/chemistry_properties/prop_neutral.dm
+++ b/code/modules/reagents/chemistry_properties/prop_neutral.dm
@@ -64,8 +64,9 @@
 /datum/chem_property/neutral/nutritious/reaction_mob(mob/target_mob, method=TOUCH, volume, potency)
 	if(method == INGEST && isxeno(target_mob))
 		var/mob/living/carbon/xenomorph/xeno = target_mob
-		if(xeno.health < xeno.maxHealth)
-			xeno.gain_health(holder.nutriment_factor * level * 3)
+		if(xeno.health < xeno.maxHealth || xeno.plasma_stored < xeno.plasma_max)
+			xeno.gain_health(holder.nutriment_factor * level * 4)
+			xeno.plasma_stored = min(xeno.plasma_stored + holder.nutriment_factor * level * 4, xeno.plasma_max)
 			xeno.flick_heal_overlay(1 SECONDS, "#666d09")
 		xeno.reagents.remove_reagent("nutriment", volume, TRUE) //xenos don't process chems so we don't want it to max at 100u
 		holder.on_delete()

--- a/code/modules/reagents/chemistry_properties/prop_neutral.dm
+++ b/code/modules/reagents/chemistry_properties/prop_neutral.dm
@@ -65,7 +65,7 @@
 	if(method == INGEST && isxeno(M))
 		var/mob/living/carbon/xenomorph/xeno = M
 		if(xeno.health < xeno.maxHealth)
-			xeno.gain_health(holder.nutriment_factor * level * 5)
+			xeno.gain_health(holder.nutriment_factor * level * 2.5)
 			xeno.flick_heal_overlay(1 SECONDS, "#666d09")
 		xeno.reagents.remove_reagent("nutriment", volume, TRUE) //xenos don't process chems so we don't want it to max at 100u
 		holder.on_delete()

--- a/code/modules/reagents/chemistry_properties/prop_neutral.dm
+++ b/code/modules/reagents/chemistry_properties/prop_neutral.dm
@@ -65,7 +65,7 @@
 	if(method == INGEST && isxeno(M))
 		var/mob/living/carbon/xenomorph/xeno = M
 		if(xeno.health < xeno.maxHealth)
-			xeno.gain_health(holder.nutriment_factor * level * 2.5)
+			xeno.gain_health(holder.nutriment_factor * level * 4)
 			xeno.flick_heal_overlay(1 SECONDS, "#666d09")
 		xeno.reagents.remove_reagent("nutriment", volume, TRUE) //xenos don't process chems so we don't want it to max at 100u
 		holder.on_delete()


### PR DESCRIPTION
# About the pull request

Xenos can eat not packaged food. Nutriments from food now heal xenos and restore their plasma. 

# Explain why it's good for the game

It's lore accurate (I've been told so, my source is @Diegoflores31).

Gives a way for marines to heal friendly xenos. Gives shipside runner a way to heal off weeds. Massive mess chief buff.

# Testing Photographs and Procedure
<details>

https://github.com/cmss13-devs/cmss13/assets/115417687/3ec00ec5-1bf6-4f38-893c-4f8e421bb7bc


</details>


# Changelog
:cl: ihatethisengine
add: Xenos can eat food to regain health and plasma.
/:cl:
