### PR TITLE
Shaking removes stuns faster

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -279,9 +279,9 @@
 			playsound(loc, 'sound/weapons/thudswoosh.ogg', 25, 1, 5)
 		return
 
-	adjust_effect(-3, PARALYZE)
-	adjust_effect(-3, STUN)
-	adjust_effect(-3, WEAKEN)
+	adjust_effect(-6, PARALYZE)
+	adjust_effect(-6, STUN)
+	adjust_effect(-6, WEAKEN)
 
 	playsound(loc, 'sound/weapons/thudswoosh.ogg', 25, 1, 5)
 

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -227,9 +227,9 @@
 			playsound(src.loc, 'sound/weapons/thudswoosh.ogg', 25, 1, 5)
 		return
 
-	adjust_effect(-3, PARALYZE)
-	adjust_effect(-3, STUN)
-	adjust_effect(-3, WEAKEN)
+	adjust_effect(-6, PARALYZE)
+	adjust_effect(-6, STUN)
+	adjust_effect(-6, WEAKEN)
 
 	playsound(loc, 'sound/weapons/thudswoosh.ogg', 25, 1, 7)
 


### PR DESCRIPTION

# About the pull request

Doubles the speed at which shaking removes stuns.
Semi-related to https://github.com/cmss13-devs/cmss13/pull/4017 Hope that's not atomizing too much.

# Explain why it's good for the game

There's no reason to require this much clickspamming - a crowd of people LMB'ing someone feels excessive. Teamwork good and it should feel good to help others, currently feels like a chore particularly in cases of facehugging.
Shouldn't affect balance much unless im forgetting some effect - other than being facehugged - applying extremely long durations.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: Shaking people up shortens stun durations by 6 instead of 3.
/:cl:
