### PR TITLE
Sentinel buffs

### DIFF
--- a/code/__DEFINES/weapon_stats.dm
+++ b/code/__DEFINES/weapon_stats.dm
@@ -66,7 +66,7 @@ var/accuracy_mult_unwielded
 ////SCATTER////
 */
 
-#define SCATTER_AMOUNT_NEURO 60
+#define SCATTER_AMOUNT_NEURO 45
 #define SCATTER_AMOUNT_TIER_1 15
 #define SCATTER_AMOUNT_TIER_2 10
 #define SCATTER_AMOUNT_TIER_3 8

--- a/code/modules/mob/living/carbon/xenomorph/abilities/sentinel/sentinel_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/sentinel/sentinel_abilities.dm
@@ -6,7 +6,7 @@
 	macro_path = /datum/action/xeno_action/verb/verb_slowing_spit
 	action_type = XENO_ACTION_CLICK
 	ability_primacy = XENO_PRIMARY_ACTION_1
-	xeno_cooldown = 1.5 SECONDS
+	xeno_cooldown = 2 SECONDS
 	plasma_cost = 20
 
 // Scatterspit
@@ -17,7 +17,7 @@
 	macro_path = /datum/action/xeno_action/verb/verb_scattered_spit
 	action_type = XENO_ACTION_CLICK
 	ability_primacy = XENO_PRIMARY_ACTION_2
-	xeno_cooldown = 8 SECONDS
+	xeno_cooldown = 5 SECONDS
 	plasma_cost = 30
 
 // Paralyzing slash
@@ -32,3 +32,19 @@
 	plasma_cost = 50
 
 	var/buff_duration = 50
+
+/datum/action/xeno_action/activable/hibernate
+	name = "hibernate"
+	action_icon_state = "warden_heal"
+	ability_name = "hibernate"
+	macro_path = /datum/action/xeno_action/verb/verb_hibernate
+	action_type = XENO_ACTION_CLICK
+	ability_primacy = XENO_PRIMARY_ACTION_4
+	xeno_cooldown = 50 SECONDS
+	plasma_cost = 150
+
+	var/regeneration_amount_total = 500
+	var/regeneration_ticks = 10
+	var/plasma_amount = 400
+	var/plasma_time = 10
+	var/time_between_plasmas = 1

--- a/code/modules/mob/living/carbon/xenomorph/abilities/sentinel/sentinel_macros.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/sentinel/sentinel_macros.dm
@@ -18,3 +18,10 @@
 	set hidden = TRUE
 	var/action_name = "Paralyzing Slash"
 	handle_xeno_macro(src,action_name)
+
+/datum/action/xeno_action/verb/verb_hibernate()
+	set category = "Alien"
+	set name = "hibernate"
+	set hidden = TRUE
+	var/action_name = "hibernate"
+	handle_xeno_macro(src,action_name)

--- a/code/modules/mob/living/carbon/xenomorph/abilities/sentinel/sentinel_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/sentinel/sentinel_powers.dm
@@ -105,3 +105,42 @@
 
 	to_chat(xeno, SPAN_XENODANGER("You have waited too long, your slash will no longer apply neurotoxin!"))
 	button.icon_state = "template"
+
+/datum/action/xeno_action/activable/hibernate/use_ability(atom/target)
+	var/mob/living/carbon/xenomorph/X = owner
+	if (!X.check_state() || X.action_busy)
+		return
+
+	var/turf/current_turf = get_turf(X)
+	if(!current_turf || !istype(current_turf))
+		return
+
+	if (!action_cooldown_check() && check_and_use_plasma_owner())
+		return
+
+	if (!action_cooldown_check())
+		return
+
+	var/obj/effect/alien/weeds/alien_weeds = locate() in current_turf
+
+	if(!alien_weeds)
+		to_chat(X, SPAN_XENOWARNING("You need to be on weeds in order to hibernate."))
+		return
+
+	if(alien_weeds.linked_hive.hivenumber != X.hivenumber)
+		to_chat(X, SPAN_XENOWARNING("These weeds don't belong to your hive! You can't hibernate here."))
+		return
+
+	new /datum/effects/plasma_over_time(X, plasma_amount, plasma_time, time_between_plasmas)
+	new /datum/effects/heal_over_time(X, regeneration_amount_total, regeneration_ticks, 1)
+	X.SetSleeping(5)
+	addtimer(CALLBACK(src, PROC_REF(sleep_off)), 10 SECONDS, TIMER_UNIQUE)
+	X.add_filter("sleep_on", 1, list("type" = "outline", "color" = "#17991b80", "size" = 1))
+
+	apply_cooldown()
+	to_chat(X, SPAN_XENONOTICE("You fall into a deep sleep, quickly healing your wounds and restoring your plasma."))
+	return ..()
+
+/datum/action/xeno_action/activable/hibernate/proc/sleep_off()
+	var/mob/living/carbon/xenomorph/X = owner
+	X.remove_filter("sleep_on")

--- a/code/modules/mob/living/carbon/xenomorph/castes/Sentinel.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Sentinel.dm
@@ -11,7 +11,7 @@
 	xeno_explosion_resistance = XENO_EXPLOSIVE_ARMOR_TIER_1
 	armor_deflection = XENO_NO_ARMOR
 	evasion = XENO_EVASION_NONE
-	speed = XENO_SPEED_TIER_HELLHOUND
+	speed = XENO_SPEED_HELLHOUND
 
 	caste_desc = "A weak ranged combat alien."
 	evolves_to = list(XENO_CASTE_SPITTER)

--- a/code/modules/mob/living/carbon/xenomorph/castes/Sentinel.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Sentinel.dm
@@ -11,15 +11,15 @@
 	xeno_explosion_resistance = XENO_EXPLOSIVE_ARMOR_TIER_1
 	armor_deflection = XENO_NO_ARMOR
 	evasion = XENO_EVASION_NONE
-	speed = XENO_SPEED_TIER_7
+	speed = XENO_SPEED_TIER_HELLHOUND
 
 	caste_desc = "A weak ranged combat alien."
 	evolves_to = list(XENO_CASTE_SPITTER)
 	deevolves_to = list("Larva")
 	acid_level = 1
 
-	tackle_min = 4
-	tackle_max = 4
+	tackle_min = 3
+	tackle_max = 3
 	tackle_chance = 50
 	tacklestrength_min = 4
 	tacklestrength_max = 4
@@ -48,6 +48,7 @@
 		/datum/action/xeno_action/activable/slowing_spit, //first macro
 		/datum/action/xeno_action/activable/scattered_spit, //second macro
 		/datum/action/xeno_action/onclick/paralyzing_slash, //third macro
+		/datum/action/xeno_action/activable/hibernate, //fourth macro
 		/datum/action/xeno_action/onclick/tacmap,
 	)
 	inherent_verbs = list(
@@ -64,7 +65,7 @@
 	// State
 	var/next_slash_buffed = FALSE
 
-#define NEURO_TOUCH_DELAY 4 SECONDS
+#define NEURO_TOUCH_DELAY 3 SECONDS
 
 /datum/behavior_delegate/sentinel_base/melee_attack_modify_damage(original_damage, mob/living/carbon/carbon_target)
 	if (!next_slash_buffed)

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -2450,7 +2450,7 @@
 			return
 
 		if(ishuman(M))
-			M.apply_effect(2.5, SUPERSLOW)
+			M.apply_effect(5, SUPERSLOW)
 			M.visible_message(SPAN_DANGER("[M]'s movements are slowed."))
 
 		var/no_clothes_neuro = FALSE
@@ -2475,9 +2475,11 @@
 			H.visible_message(SPAN_DANGER("[M] shrugs off the neurotoxin!"))
 			return
 
-		if(M.knocked_down < 0.7) // apply knockdown only if current knockdown is less than 0.7 second
-			M.apply_effect(0.7, WEAKEN)
+		if(M.knocked_down < 0.8) // apply knockdown only if current knockdown is less than 0.7 second
+			M.apply_effect(0.8, WEAKEN)
 			M.visible_message(SPAN_DANGER("[M] falls prone."))
+		if(M.slowed <1.5)
+			M.apply_effect(1.5, SLOW)
 
 /datum/ammo/xeno/toxin/on_hit_mob(mob/M,obj/item/projectile/P)
 	if(ishuman(M))


### PR DESCRIPTION

# About the pull request

Follows-up on my old sentinel rework and buffs it into a more adequate state as it's severely underperforming.

# Explain why it's good for the game

Having been the one to rework them, while I don’t regret it and think they’re in a far better place now than with the old braindead 1 ability stunlock kit, I believe they’re underperforming as t1s

The initial design goal was to turn the lil annoying bodyblocker into an offensive support caste with strong abilities for a t1 - but unable to make good use of them by itself, thus heavily reliant on teamwork.
In practice they became

- too reliant on others

they struggle in 1v1 situations far more than any other t1 caste

- often unable to make an effective/satisfactory use of their kit

Their entire kit is about supporting and working with other caste, which requires them walking out with bulkier t3s and leads to them eating a ton of bullets that they’re ill-suited to tank. Compounded with said teamwork often being unreliable (either because there were too many bullets and the sent had to fall back unable to follow the t3, or the players just didn’t mesh very well etc) and their slow healing it can be frustrating to play when on such a bad streak of achieving nothing and having to rest.
Therefore the "hibernate" ability, to mitigate the downtime and better allow it to actually support the tankier frontline xenos without having to take ages to heal inbetween.
Also considering sentinels are supposed to guard the hive I think it’s cool and fitting to have an ability centered on hibernating somewhere.

Speed increase to let and encourage them to support backliners aswell as make it easier to work near the front.

Tackle buffs - addresses the paralyzing slash interaction - currently the window to tackle successfully is extremely tight, you’d have to start tackling the moment the marine falls down. This results in average player being entirely unable to chain these two abilities properly and even in the cases where he played good and should be winning a 1v1, the marine still comes out on top because the sent didn’t play perfectly - balance for 1% bad.

Rest I believe to be self explanatory.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Added a new ability to sentinel - "Hibernate" - causes them to enter a 10 second sleep that restores their health and plasma to full. Requires weeds. 50 second cd and 150 plasma cost.
balance: Sentinel neuro spit cooldown raised 1.5 to 2s, superslow 2.5 to 5s
balance: Sentinel scatter spit scatter lowered 60 to 45, cooldown lowered 8s to 5s, stun time increased 0.7s to 0.8s and added a 1.5s slow
balance: Sentinel paralyzing slash stuns after 3 seconds instead of 4.
balance: Sentinel speed raised from -0.8 to -1
balance: Sentinel tackle now requires 3 attempts instead of 4.
/:cl:
