### PR TITLE
Fixes holding two guns firing both

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1064,3 +1064,7 @@ cases. Override_icon_state should be a list.*/
 	animate(attack_image, alpha = 175, transform = copy_transform.Scale(0.75), pixel_x = 0, pixel_y = 0, pixel_z = 0, time = 3)
 	animate(time = 1)
 	animate(alpha = 0, time = 3, easing = CIRCULAR_EASING|EASE_OUT)
+
+///Called by /mob/living/carbon/swap_hand() when hands are swapped
+/obj/item/proc/hands_swapped(mob/living/carbon/swapper_of_hands)
+	return

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -238,6 +238,10 @@
 		else
 			hud_used.l_hand_hud_object.icon_state = "hand_inactive"
 			hud_used.r_hand_hud_object.icon_state = "hand_active"
+	if(l_hand)
+		l_hand.hands_swapped(src)
+	if(r_hand)
+		r_hand.hands_swapped(src)
 	return
 
 /mob/living/carbon/proc/activate_hand(selhand) //0 or "r" or "right" for right hand; 1 or "l" or "left" for left hand.

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -1821,6 +1821,15 @@ not all weapons use normal magazines etc. load_into_chamber() itself is designed
 	RegisterSignal(gun_user, COMSIG_MOB_MOUSEDRAG, PROC_REF(change_target))
 	RegisterSignal(gun_user, COMSIG_MOB_MOUSEUP, PROC_REF(stop_fire))
 
+/obj/item/weapon/gun/hands_swapped(mob/living/carbon/swapper_of_hands)
+	if(src == swapper_of_hands.get_active_hand())
+		set_gun_user(swapper_of_hands)
+		return
+
+	if(gun_user)
+		UnregisterSignal(gun_user, list(COMSIG_MOB_MOUSEUP, COMSIG_MOB_MOUSEDOWN, COMSIG_MOB_MOUSEDRAG))
+		gun_user = null
+
 ///Update the target if you draged your mouse
 /obj/item/weapon/gun/proc/change_target(datum/source, atom/src_object, atom/over_object, turf/src_location, turf/over_location, src_control, over_control, params)
 	SIGNAL_HANDLER

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -1817,18 +1817,17 @@ not all weapons use normal magazines etc. load_into_chamber() itself is designed
 		UnregisterSignal(gun_user, list(COMSIG_MOB_MOUSEUP, COMSIG_MOB_MOUSEDOWN, COMSIG_MOB_MOUSEDRAG))
 
 	gun_user = to_set
-	RegisterSignal(gun_user, COMSIG_MOB_MOUSEDOWN, PROC_REF(start_fire))
-	RegisterSignal(gun_user, COMSIG_MOB_MOUSEDRAG, PROC_REF(change_target))
-	RegisterSignal(gun_user, COMSIG_MOB_MOUSEUP, PROC_REF(stop_fire))
+	if(gun_user)
+		RegisterSignal(gun_user, COMSIG_MOB_MOUSEDOWN, PROC_REF(start_fire))
+		RegisterSignal(gun_user, COMSIG_MOB_MOUSEDRAG, PROC_REF(change_target))
+		RegisterSignal(gun_user, COMSIG_MOB_MOUSEUP, PROC_REF(stop_fire))
 
 /obj/item/weapon/gun/hands_swapped(mob/living/carbon/swapper_of_hands)
 	if(src == swapper_of_hands.get_active_hand())
 		set_gun_user(swapper_of_hands)
 		return
 
-	if(gun_user)
-		UnregisterSignal(gun_user, list(COMSIG_MOB_MOUSEUP, COMSIG_MOB_MOUSEDOWN, COMSIG_MOB_MOUSEDRAG))
-		gun_user = null
+	set_gun_user(null)
 
 ///Update the target if you draged your mouse
 /obj/item/weapon/gun/proc/change_target(datum/source, atom/src_object, atom/over_object, turf/src_location, turf/over_location, src_control, over_control, params)


### PR DESCRIPTION

# About the pull request

Fixes an issue where non-akimbo or automatic hand switching was turned on would fire both guns if one is held in each hand.

# Explain why it's good for the game

Bug bad.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
fix: Fixed holding two guns firing both
/:cl:
