### PR TITLE
Upgrades the External Webbing

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/cm_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/cm_closets.dm
@@ -62,8 +62,6 @@ GLOBAL_LIST_EMPTY(co_secure_boxes)
 	new /obj/item/storage/belt/marine(src)
 	new /obj/item/clothing/under/marine/officer/command(src)
 	new /obj/item/clothing/under/marine/officer/command(src)
-	new /obj/item/clothing/suit/storage/webbing(src)
-	new /obj/item/clothing/suit/storage/webbing(src)
 	new /obj/item/clothing/gloves/combat(src)
 	new /obj/item/clothing/gloves/combat(src)
 

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -287,10 +287,10 @@
 		/obj/item/device/radio,
 		/obj/item/tool/crowbar,
 		/obj/item/tool/crew_monitor,
-		/obj/item/tool/pen,
 		/obj/item/storage/large_holster/machete,
 		/obj/item/device/motiondetector,
 	)
+
 
 /obj/item/clothing/suit/storage/utility_vest
 	name = "utility vest"


### PR DESCRIPTION
Makes the External Webbing work like an Hazard vest for storage, Removes the item from the Staff Officers Locker because morrow wanted (?)
# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Added something
del: Removed old things
qol: made something easier to use
balance: rebalanced something
fix: fixed a few things
spellcheck: fixed a few typos
ui: changed something relating to user interfaces
code: changed some code
refactor: refactored some code
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
mapadd: added a new map or section to a map
maptweak: tweaked a map
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:
