### PR TITLE
Fix banishing huggers and lesser drones

### DIFF
--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -576,6 +576,11 @@ Additional game mode variables.
 		to_chat(xeno_candidate, SPAN_WARNING("The selected hive does not have a hive core to spawn from!"))
 		return
 
+	for(var/mob_name in hive.banished_ckeys)
+		if(hive.banished_ckeys[mob_name] == xeno_candidate.ckey)
+			to_chat(xeno_candidate, SPAN_WARNING("You are banished from the [hive], you may not rejoin unless the Queen re-admits you or dies."))
+			return
+
 	hive.hive_location.spawn_lesser_drone(xeno_candidate)
 
 	return TRUE

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -1022,7 +1022,7 @@
 	for(var/mob_name in banished_ckeys)
 		if(banished_ckeys[mob_name] == user.ckey)
 			to_chat(user, SPAN_WARNING("You are banished from the [name], you may not rejoin unless the Queen re-admits you or dies."))
-			return
+			return FALSE
 
 	update_hugger_limit()
 

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -1019,6 +1019,10 @@
 		//This is to prevent people from joining as Forsaken Huggers on the pred ship
 		to_chat(user, SPAN_WARNING("The hive has fallen, you can't join it!"))
 		return FALSE
+	for(var/mob_name in banished_ckeys)
+		if(banished_ckeys[mob_name] == user.ckey)
+			to_chat(user, SPAN_WARNING("You are banished from the [name], you may not rejoin unless the Queen re-admits you or dies."))
+			return
 
 	update_hugger_limit()
 


### PR DESCRIPTION

# About the pull request

This PR makes it so huggers and lesser drones cannot join a hive they are currently banished from.

# Explain why it's good for the game

Rejoining as a different mob should not circumvent banishment.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/cmss13-devs/cmss13/assets/76988376/c207f552-a8ba-4607-8ca3-173583bb2c69)

</details>


# Changelog
:cl: Drathek
fix: Fix joining as facehugger or lesser drone not checking banishment.
/:cl:
