### PR TITLE
Donator masks now properly protect from cold

### DIFF
--- a/code/modules/cm_marines/Donator_Items.dm
+++ b/code/modules/cm_marines/Donator_Items.dm
@@ -55,6 +55,8 @@
 	//DON'T GRAB STUFF BETWEEN THIS LINE
 	flags_inventory = ALLOWREBREATH
 	flags_inv_hide = HIDEEARS|HIDEEYES|HIDEFACE
+	flags_cold_protection = BODY_FLAG_HEAD
+	min_cold_protection_temperature = ICE_PLANET_MIN_COLD_PROT
 	//AND THIS LINE
 
 //END MASK TEMPLATE


### PR DESCRIPTION

# About the pull request
As title. All other donor gear has cold protection, just not mask. Causes inconsistencies/problems on cold maps.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Consistency is a good thing, usually.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Donator custom masks now properly protect from cold weather.
/:cl:
