### PR TITLE
Another Banishment Check For Observers Joining as a Xeno

### DIFF
--- a/code/_onclick/observer.dm
+++ b/code/_onclick/observer.dm
@@ -53,6 +53,13 @@
 						ManualFollow(target)
 						return FALSE
 
+				if(xeno.hive)
+					for(var/mob_name in xeno.hive.banished_ckeys)
+						if(xeno.hive.banished_ckeys[mob_name] == ckey)
+							to_chat(src, SPAN_WARNING("You are banished from the [xeno.hive], you may not rejoin unless the Queen re-admits you or dies."))
+							ManualFollow(target)
+							return FALSE
+
 				if(alert(src, "Are you sure you want to transfer yourself into [xeno]?", "Confirm Transfer", "Yes", "No") != "Yes")
 					return FALSE
 				if(((!islarva(xeno) && xeno.away_timer < XENO_LEAVE_TIMER) || (islarva(xeno) && xeno.away_timer < XENO_LEAVE_TIMER_LARVA)) || xeno.stat == DEAD) // Do it again, just in case


### PR DESCRIPTION

# About the pull request

This PR is a followup to #4031 where I found that ctrl clicking an afk xeno is also a method to join as a xeno. Now this method also checks for banishment.

# Explain why it's good for the game

Rejoining as a different mob should not circumvent banishment.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/cmss13-devs/cmss13/assets/76988376/2bed0b6a-b3e6-498b-a7f7-c18bfd48eb6e)

</details>


# Changelog
:cl: Drathek
fix: Fixed ctrl+click joining as an afk xeno not checking banishment
/:cl:
