### PR TITLE
Standardize hugger attack windup and attack windup duration

### DIFF
--- a/code/__DEFINES/xeno.dm
+++ b/code/__DEFINES/xeno.dm
@@ -8,6 +8,9 @@
 #define TUNNEL_ENTER_BIG_XENO_DELAY 120
 #define TUNNEL_ENTER_LARVA_DELAY 10
 
+/// The duration it takes a player controlled facehugger to leap or hug adjacently
+#define FACEHUGGER_WINDUP_DURATION 1 SECONDS
+
 // Defines for action types and click delays used by xenomorph/unarmedattack() and attack_alien().
 
 /// Full attack delay.

--- a/code/modules/mob/living/carbon/xenomorph/abilities/facehugger/facehugger_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/facehugger/facehugger_abilities.dm
@@ -1,3 +1,6 @@
+/// The duration it takes a player controlled facehugger to leap or hug adjacently
+#define FACEHUGGER_WINDUP_DURATION 1 SECONDS
+
 /datum/action/xeno_action/activable/pounce/facehugger
 	name = "Leap"
 	action_icon_state = "pounce"
@@ -12,7 +15,7 @@
 	knockdown = TRUE
 	knockdown_duration = 0.5
 	windup = TRUE
-	windup_duration = 10
+	windup_duration = FACEHUGGER_WINDUP_DURATION
 	freeze_self = TRUE
 	freeze_time = 5
 	freeze_play_sound = FALSE

--- a/code/modules/mob/living/carbon/xenomorph/abilities/facehugger/facehugger_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/facehugger/facehugger_abilities.dm
@@ -1,6 +1,3 @@
-/// The duration it takes a player controlled facehugger to leap or hug adjacently
-#define FACEHUGGER_WINDUP_DURATION 1 SECONDS
-
 /datum/action/xeno_action/activable/pounce/facehugger
 	name = "Leap"
 	action_icon_state = "pounce"

--- a/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
@@ -133,7 +133,7 @@
 			to_chat(src, SPAN_WARNING("You can't infect \the [human]..."))
 			return
 		visible_message(SPAN_WARNING("\The [src] starts climbing onto \the [human]'s face..."), SPAN_XENONOTICE("You start climbing onto \the [human]'s face..."))
-		if(!do_after(src, 6 SECONDS, INTERRUPT_ALL, BUSY_ICON_HOSTILE, human, INTERRUPT_MOVED, BUSY_ICON_HOSTILE))
+		if(!do_after(src, FACEHUGGER_WINDUP_DURATION, INTERRUPT_ALL, BUSY_ICON_HOSTILE, human, INTERRUPT_MOVED, BUSY_ICON_HOSTILE))
 			return
 		if(!human.lying)
 			to_chat(src, SPAN_WARNING("You can't reach \the [human], they need to be lying down."))


### PR DESCRIPTION

# About the pull request

This PR sets the attack windup duration for a player facehugger to 1 second, like it is for a pounce.

# Explain why it's good for the game

Since you can just pounce at point blank, there is zero reason for a point blank attack (that also requires them tackled) to take 6x longer. Any hugger that would do this would obviously be new to the caste for doing it in an inferior way.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>


https://github.com/cmss13-devs/cmss13/assets/76988376/c81c1635-42a9-4b6a-8411-e99b562fdb98

</details>


# Changelog
:cl: Drathek
balance: Facehugger attack windup duration is now 1s like the pounce windup.
/:cl:
