### PR TITLE
Lesser Drone now Has 3 Guarantied Slots

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -1050,7 +1050,7 @@
 	hugger.timeofdeath = user.timeofdeath // Keep old death time
 
 /datum/hive_status/proc/update_lesser_drone_limit()
-	lesser_drone_limit = max(Ceiling(length(totalXenos) / 3), lesser_drone_minimum)
+	lesser_drone_limit = lesser_drone_minimum + Ceiling(length(totalXenos) / 3)
 
 /datum/hive_status/proc/can_spawn_as_lesser_drone(mob/dead/observer/user)
 	if(!GLOB.hive_datum || ! GLOB.hive_datum[hivenumber])

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -1050,9 +1050,7 @@
 	hugger.timeofdeath = user.timeofdeath // Keep old death time
 
 /datum/hive_status/proc/update_lesser_drone_limit()
-	lesser_drone_limit = Ceiling(totalXenos.len / 3)
-	if(lesser_drone_limit < lesser_drone_minimum)
-		lesser_drone_limit = lesser_drone_minumum
+	lesser_drone_limit = max(Ceiling(length(totalXenos) / 3), lesser_drone_minimum)
 
 /datum/hive_status/proc/can_spawn_as_lesser_drone(mob/dead/observer/user)
 	if(!GLOB.hive_datum || ! GLOB.hive_datum[hivenumber])

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -353,6 +353,8 @@
 
 	/// How many lesser drones the hive can support
 	var/lesser_drone_limit = 0
+	/// Slots available for lesser drones will never go below this number
+	var/lesser_drone_minimum = 3
 
 	var/datum/tacmap/xeno/tacmap
 	var/minimap_type = MINIMAP_FLAG_XENO
@@ -1049,6 +1051,8 @@
 
 /datum/hive_status/proc/update_lesser_drone_limit()
 	lesser_drone_limit = Ceiling(totalXenos.len / 3)
+	if(lesser_drone_limit < lesser_drone_minimum)
+		lesser_drone_limit = lesser_drone_minumum
 
 /datum/hive_status/proc/can_spawn_as_lesser_drone(mob/dead/observer/user)
 	if(!GLOB.hive_datum || ! GLOB.hive_datum[hivenumber])


### PR DESCRIPTION
# About the pull request

Lesser Drones now will always have at least 3 slots, no matter the state of the hive

# Explain why it's good for the game

Lesser Drones as supposed to be a swarm, and at this stage of the game many Xenos are likely ghosting. This gives them a bigger chance to participate in rounds (at least the ones where Xenos are on the backfoot). This should make it so lesser drones have a baseline of 3 slots, plus additional limit based on hive size.

# Changelog
:cl:
add: Lesser Drone Slots now have a minimum, currently set to 3.
/:cl:
