### PR TITLE
Fix corpses merging with weeds when hung

### DIFF
--- a/code/datums/components/weed_food.dm
+++ b/code/datums/components/weed_food.dm
@@ -193,6 +193,8 @@
 			return FALSE
 	if(!parent_turf?.weeds)
 		return FALSE
+	if(SEND_SIGNAL(parent_mob, COMSIG_ATTEMPT_MOB_PULL) & COMPONENT_CANCEL_MOB_PULL)
+		return FALSE
 
 	if(unmerged_time == world.time)
 		return merge_with_weeds() // Weeds upgraded, re-merge now re-using the apperance
@@ -244,6 +246,9 @@
 	if(parent_buckle)
 		UnregisterSignal(parent_buckle, COSMIG_OBJ_AFTER_BUCKLE)
 		parent_buckle = null
+
+	if(SEND_SIGNAL(parent_mob, COMSIG_ATTEMPT_MOB_PULL) & COMPONENT_CANCEL_MOB_PULL)
+		return FALSE
 
 	absorbing_weeds = parent_turf?.weeds
 	if(!absorbing_weeds)

--- a/code/game/objects/items/stacks/predator.dm
+++ b/code/game/objects/items/stacks/predator.dm
@@ -51,6 +51,8 @@
 			SPAN_NOTICE("You start hanging [victim] up by the rope..."))
 		if(!do_after(user, 3 SECONDS, INTERRUPT_NO_NEEDHAND, BUSY_ICON_HOSTILE, victim))
 			return
+		if(victim.anchored)
+			return // Just in case weed_food took them during this time
 		user.visible_message(SPAN_WARNING("[user] hangs [victim] from the ceiling!"), SPAN_NOTICE("You finish hanging [victim]."))
 		user.stop_pulling()
 		victim.get_hung()
@@ -106,4 +108,5 @@
 	apply_transform(A)
 	pixel_x = 0
 	pixel_y = 0
+	Moved(loc, NONE, TRUE) // Trigger any movement signals
 	return COMPONENT_CANCEL_ATTACK


### PR DESCRIPTION

# About the pull request

This PR fixes any scenario where COMPONENT_CANCEL_MOB_PULL is signaled, namely predator hanging, to prevent merging with weeds.

The chain of do_afters for hanging now checks if their victim gets anchored (in case they started to hang right as weeds were merging them), and cutting down will now call the Moved proc to send signals indicating the mob moved (to wake up weed_food).

# Explain why it's good for the game

Fixes #4048 

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: Drathek
fix: Fixed hung mobs merging with weeds
/:cl:
