### PR TITLE
More Xeno Alliances Tweaks

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
@@ -18,7 +18,7 @@
 	if(SSticker.mode && SSticker.mode.xenomorphs.len) //Send to only xenos in our gamemode list. This is faster than scanning all mobs
 		for(var/datum/mind/L in SSticker.mode.xenomorphs)
 			var/mob/living/carbon/M = L.current
-			if(M && istype(M) && !M.stat && M.client && (!hivenumber || M.ally_of_hivenumber(hivenumber))) //Only living and connected xenos
+			if(M && istype(M) && !M.stat && M.client && (!hivenumber || M.hivenumber == hivenumber)) //Only living and connected xenos
 				to_chat(M, SPAN_XENODANGER("<span class=\"[fontsize_style]\"> [message]</span>"))
 
 //Sends a maptext alert to our currently selected squad. Does not make sound.

--- a/code/modules/mob/living/carbon/xenomorph/death.dm
+++ b/code/modules/mob/living/carbon/xenomorph/death.dm
@@ -69,6 +69,7 @@
 					if(!QDELETED(Q) && Q != src && Q.hivenumber == hivenumber)
 						hive.set_living_xeno_queen(Q)
 						break
+				hive.on_queen_death()
 				hive.handle_xeno_leader_pheromones()
 				if(SSticker.mode)
 					INVOKE_ASYNC(SSticker.mode, TYPE_PROC_REF(/datum/game_mode, check_queen_status), hivenumber)

--- a/code/modules/mob/living/carbon/xenomorph/hive_faction.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_faction.dm
@@ -56,6 +56,5 @@ GLOBAL_LIST_INIT(hive_alliable_factions, generate_alliable_factions())
 				return
 
 			var/should_ally = text2num(params["should_ally"])
-			assoc_hive.allies[params["target_faction"]] = should_ally
-			assoc_hive.on_stance_change(params["target_faction"])
+			assoc_hive.change_stance(params["target_faction"], should_ally)
 			. = TRUE

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -1364,7 +1364,7 @@
 
 
 	if(broken_alliances)
-		xeno_message(SPAN_XENOANNOUNCE("With the death of the Queen all alliances has been broken."), 3, hivenumber)
+		xeno_message(SPAN_XENOANNOUNCE("With the death of the Queen, all alliances have been broken."), 3, hivenumber)
 
 /datum/hive_status/proc/change_stance(faction, should_ally)
 	if(faction == name)

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -1367,6 +1367,8 @@
 		xeno_message(SPAN_XENOANNOUNCE("With the death of the Queen all alliances has been broken."), 3, hivenumber)
 
 /datum/hive_status/proc/change_stance(faction, should_ally)
+	if(faction == name)
+		return
 	if(allies[faction] == should_ally)
 		return
 	allies[faction] = should_ally


### PR DESCRIPTION
# About the pull request
1) xeno_message no longer sends the message to allied hives.

2) All hive's alliances break on Queen's death (instead of essentially just ceasing to function).

3) If another hive breaks alliance with you, you break alliance with them automatically.

4) Some code improvements.

# Explain why it's good for the game
1) Less confusing. I meant to add a "notify_allies" var to the proc, but I haven't found a single message that should be sent to allies.

2) Less confusing. Essentially all alliances already don't function if queen is dead, so this way it's just more clear for everyone.

3) You don't have to keep hive alliance status open all the time in case allied queen decides to betray you. Simply a QoL.

4) Just good

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: ihatethisengine
add: All hive's alliances break on Queen's death.
qol: If a hive breaks an alliance with another, the second hive also breaks the alliance.
fix: xeno_message no longer sends the message to allied hives
/:cl:
