### PR TITLE
Add security camera console to ARES Chamber

### DIFF
--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -53990,7 +53990,7 @@
 	},
 /area/almayer/hull/upper_hull/u_a_p)
 "nJH" = (
-/obj/structure/machinery/computer/cameras/almayer_network{
+/obj/structure/machinery/computer/cameras/almayer{
 	dir = 8;
 	pixel_x = 17
 	},

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -53990,7 +53990,7 @@
 	},
 /area/almayer/hull/upper_hull/u_a_p)
 "nJH" = (
-/obj/structure/machinery/computer/cameras/almayer/ares{
+/obj/structure/machinery/computer/cameras/almayer_network{
 	dir = 8;
 	pixel_x = 17
 	},


### PR DESCRIPTION

# About the pull request

Add general camera console to ARES Chamber

# Explain why it's good for the game

ARES core and chamber especially is supposed to be the nexus of information, as such, I believe it would be better to start adding some new consoles to chamber, as right now it just mirrors itself on each side.

# Changelog
:cl:
mapadd: ARES Chamber now has a security camera console
/:cl:
