### PR TITLE
fix having inapropriate ammo in CL lockbox.

### DIFF
--- a/code/game/objects/items/devices/portable_vendor.dm
+++ b/code/game/objects/items/devices/portable_vendor.dm
@@ -270,4 +270,7 @@
 
 		list("MISC", 0, null, null, null),
 		list("Hollow Cane", 15, /obj/item/weapon/pole/fancy_cane/this_is_a_knife, "white", "A hollow cane that can store any commonplace sharp weaponry. Said weapon not included."),
+
+		list("AMMO", 0, null, null, null),
+		list("ES-4 stun magazine", 10, /obj/item/ammo_magazine/pistol/es4, "white", "Holds 19 rounds of specialized Conductive 9mm."),
 	)

--- a/code/game/objects/items/storage/lockbox.dm
+++ b/code/game/objects/items/storage/lockbox.dm
@@ -54,6 +54,9 @@
 	req_access = list(ACCESS_WY_CORPORATE)
 
 /obj/item/storage/lockbox/loyalty/fill_preset_inventory()
+	new /obj/item/ammo_magazine/pistol/es4(src)
+	new /obj/item/ammo_magazine/pistol/es4(src)
+	new /obj/item/ammo_magazine/pistol/es4(src)
 
 /obj/item/storage/lockbox/cluster
 	name = "lockbox of cluster flashbangs"

--- a/code/game/objects/items/storage/lockbox.dm
+++ b/code/game/objects/items/storage/lockbox.dm
@@ -53,12 +53,6 @@
 	name = "\improper Wey-Yu equipment lockbox"
 	req_access = list(ACCESS_WY_CORPORATE)
 
-/obj/item/storage/lockbox/loyalty/fill_preset_inventory()
-	new /obj/item/ammo_magazine/pistol/mod88(src)
-	new /obj/item/ammo_magazine/pistol/mod88(src)
-	new /obj/item/ammo_magazine/pistol/mod88/rubber(src)
-	new /obj/item/ammo_magazine/pistol/mod88/rubber(src)
-
 
 /obj/item/storage/lockbox/cluster
 	name = "lockbox of cluster flashbangs"

--- a/code/game/objects/items/storage/lockbox.dm
+++ b/code/game/objects/items/storage/lockbox.dm
@@ -53,6 +53,7 @@
 	name = "\improper Wey-Yu equipment lockbox"
 	req_access = list(ACCESS_WY_CORPORATE)
 
+/obj/item/storage/lockbox/loyalty/fill_preset_inventory()
 
 /obj/item/storage/lockbox/cluster
 	name = "lockbox of cluster flashbangs"


### PR DESCRIPTION
# About the pull request
fixes: https://github.com/cmss13-devs/cmss13/issues/3976
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
removing the improper ammo in the lock box because it's obsolete considering the new gun CL as.
adding a way to buy more ammo so that CL as a way to refill is weapon.
didn't wanted to give it for free in the lockbox.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/cmss13-devs/cmss13/assets/117036822/f9aeb4e9-e11f-4a3f-9ccd-da244ee74713)

![image](https://github.com/cmss13-devs/cmss13/assets/117036822/815b6f6a-0532-4beb-9a68-7c524ead3eb1)


Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: adding the possibility to buy "ES-4 stun magazine" for 10 point in the portable vendor.
fix: remove a bunch of ammo that where improper for ES-4 gun that are in the lockbox.
/:cl:
