### PR TITLE
Anchors the yautja carpnade

### DIFF
--- a/code/datums/supply_packs/black_market.dm
+++ b/code/datums/supply_packs/black_market.dm
@@ -184,10 +184,9 @@ Non-USCM items, from CLF, UPP, colonies, etc. Mostly combat-related.
 				new /obj/item/ammo_magazine/rifle/mar40/extended(src)
 				new /obj/item/ammo_magazine/rifle/mar40(src)
 			else
-				new /obj/item/weapon/gun/rifle/m41aMK1/tactical(src)
-				new /obj/item/ammo_magazine/rifle/m41aMK1/ap(src)
-				new /obj/item/ammo_magazine/rifle/m41aMK1(src)
-				new /obj/item/ammo_magazine/rifle/m41aMK1(src)
+				new /obj/item/weapon/gun/rifle/mar40/lmg(src)
+				new /obj/item/ammo_magazine/rifle/mar40/lmg(src)
+				new /obj/item/ammo_magazine/rifle/mar40/lmg(src)
 
 /* Misc. Individual Guns */
 

--- a/code/datums/supply_packs/black_market.dm
+++ b/code/datums/supply_packs/black_market.dm
@@ -184,9 +184,10 @@ Non-USCM items, from CLF, UPP, colonies, etc. Mostly combat-related.
 				new /obj/item/ammo_magazine/rifle/mar40/extended(src)
 				new /obj/item/ammo_magazine/rifle/mar40(src)
 			else
-				new /obj/item/weapon/gun/rifle/mar40/lmg(src)
-				new /obj/item/ammo_magazine/rifle/mar40/lmg(src)
-				new /obj/item/ammo_magazine/rifle/mar40/lmg(src)
+				new /obj/item/weapon/gun/rifle/m41aMK1/tactical(src)
+				new /obj/item/ammo_magazine/rifle/m41aMK1/ap(src)
+				new /obj/item/ammo_magazine/rifle/m41aMK1(src)
+				new /obj/item/ammo_magazine/rifle/m41aMK1(src)
 
 /* Misc. Individual Guns */
 

--- a/maps/predship/huntership.dmm
+++ b/maps/predship/huntership.dmm
@@ -674,9 +674,9 @@
 	color = "#6b675e"
 	},
 /obj/item/weapon/claymore/mercsword/machete/arnold{
+	anchored = 1;
 	desc = "Won by an Elder during their youthful hunting days. None are allowed to touch it.";
-	name = "\improper Dutch's Machete";
-	anchored = 1
+	name = "\improper Dutch's Machete"
 	},
 /turf/open/floor/corsat{
 	dir = 1;
@@ -1789,9 +1789,9 @@
 /area/yautja)
 "gr" = (
 /obj/structure/closet/crate/secure{
-	req_one_access_txt = "252";
 	color = "#6b675e";
-	name = "Secure Yautja crate"
+	name = "Secure Yautja crate";
+	req_one_access_txt = "252"
 	},
 /obj/item/explosive/grenade/spawnergrenade/hellhound,
 /obj/item/explosive/grenade/spawnergrenade/hellhound,
@@ -1806,9 +1806,9 @@
 /obj/structure/machinery/door_control{
 	id = "Yautja Armory";
 	name = "Armory Shutters";
+	needs_power = 0;
 	pixel_x = 24;
-	req_one_access_txt = "252";
-	needs_power = 0
+	req_one_access_txt = "252"
 	},
 /turf/open/floor/corsat{
 	dir = 1;
@@ -2424,9 +2424,9 @@
 /area/yautja)
 "Bg" = (
 /obj/structure/closet/crate/secure{
-	req_one_access_txt = "252";
 	color = "#6b675e";
-	name = "Secure Yautja crate"
+	name = "Secure Yautja crate";
+	req_one_access_txt = "252"
 	},
 /obj/item/weapon/yautja/combistick,
 /obj/item/weapon/yautja/combistick{
@@ -2623,7 +2623,10 @@
 /obj/structure/surface/table/reinforced/prison{
 	color = "#6b675e"
 	},
-/obj/item/explosive/grenade/spawnergrenade/spesscarp,
+/obj/item/explosive/grenade/spawnergrenade/spesscarp{
+	anchored = 1;
+	desc = "A strange device taken from a far-off land. It looks incredibly fragile, best not to touch it."
+	},
 /turf/open/floor/corsat{
 	dir = 1;
 	icon_state = "squareswood"
@@ -2686,14 +2689,14 @@
 	layer = 2.79
 	},
 /obj/item/stack/medical/advanced/ointment/predator{
-	pixel_x = 6;
 	desc = "A poultice made of cold, blue petals that is rubbed on burns. Not to be removed from the ship.";
-	name = "arena soothing herbs"
+	name = "arena soothing herbs";
+	pixel_x = 6
 	},
 /obj/item/stack/medical/advanced/bruise_pack/predator{
-	pixel_x = -6;
 	desc = "A poultice made of soft leaves that is rubbed on bruises. Not to be removed from the ship.";
-	name = "arena mending herbs"
+	name = "arena mending herbs";
+	pixel_x = -6
 	},
 /turf/open/shuttle/predship,
 /area/yautja)
@@ -2721,9 +2724,9 @@
 "HD" = (
 /obj/structure/surface/rack{
 	color = "#6b675e";
+	density = 0;
 	layer = 2.79;
-	pixel_y = 24;
-	density = 0
+	pixel_y = 24
 	},
 /obj/item/weapon/gun/energy/yautja/plasmarifle{
 	pixel_y = -8


### PR DESCRIPTION

# About the pull request
Anchors the carpnade found in the yautja ship.

# Explain why it's good for the game

- Requested by forest
- Prevents people abducted onto the pred ship from being dumb with the grenade
- Prevents preds from unwittingly handing out the carpnade despite it being expressly prohibited by a senator (see [here](https://discord.com/channels/150315577943130112/207230793423126539/966035290399592468))

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

It's a one tile change

</details>


# Changelog
:cl:
del: You can no longer move the carp nade in the yautja ship
/:cl:
