### PR TITLE
Fix for runner-lesserdrone collision.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/Runner.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Runner.dm
@@ -71,7 +71,7 @@
 /mob/living/carbon/xenomorph/runner/initialize_pass_flags(datum/pass_flags_container/PF)
 	..()
 	if (PF)
-		PF.flags_pass = PASS_FLAGS_CRAWLER
+		PF.flags_pass |= PASS_FLAGS_CRAWLER
 
 /datum/behavior_delegate/runner_base
 	name = "Base Runner Behavior Delegate"


### PR DESCRIPTION

# About the pull request

I tried digging for the reasoning behind the current state of things, and I gave up. Git blamer for the pass flags on base xenomorph and on runner goes through several overhauls into a separate two-three years old commits (CM Dev strikes again), and I honestly cannot be bothered to check which predates which or go dig deep into private repository on Gitlab in search of corresponding PRs and their descriptions. I do not know what can go wrong here, anyway. (Last time I said something like that, things managed to go wrong anyway...)

# Explain why it's good for the game

Closes #4012.

# Changelog
:cl:
fix: Lesser drones now can pass through runners same as through any other castes.
/:cl:
