### PR TITLE
Fixes predator crew monitor console

### DIFF
--- a/code/modules/cm_marines/marines_consoles.dm
+++ b/code/modules/cm_marines/marines_consoles.dm
@@ -679,11 +679,13 @@
 	idle_power_usage = 250
 	active_power_usage = 500
 	var/faction = FACTION_MARINE
+	/// What type of /datum/crewmonitor this will create
+	var/crewmonitor_type = /datum/crewmonitor
 
 /obj/structure/machinery/computer/crew/Initialize()
 	. = ..()
 	if(!GLOB.crewmonitor[faction])
-		GLOB.crewmonitor[faction] = new /datum/crewmonitor(faction)
+		GLOB.crewmonitor[faction] = new crewmonitor_type(faction)
 
 /obj/structure/machinery/computer/crew/attack_remote(mob/living/user)
 	attack_hand(user)
@@ -713,6 +715,12 @@
 /obj/structure/machinery/computer/crew/alt
 	icon_state = "cmonitor"
 	density = FALSE
+
+/obj/structure/machinery/computer/crew/alt/yautja
+	name = "\improper Yautja health monitor"
+	desc = "Used to monitor active health sensors of all Yautja in the system. You can see that the console highlights the human's ship areas with BLUE and the hunting locations with RED."
+	faction = FACTION_YAUTJA
+	crewmonitor_type = /datum/crewmonitor/yautja
 
 /obj/structure/machinery/computer/crew/upp
 	faction = FACTION_UPP
@@ -790,7 +798,7 @@ GLOBAL_LIST_EMPTY_TYPED(crewmonitor, /datum/crewmonitor)
 /datum/crewmonitor/ui_data(mob/user)
 	. = list(
 		"sensors" = update_data(),
-		"link_allowed" = isAI(user)
+		"link_allowed" = isAI(user),
 	)
 
 /datum/crewmonitor/proc/update_data()
@@ -1101,6 +1109,51 @@ GLOBAL_LIST_EMPTY_TYPED(crewmonitor, /datum/crewmonitor)
 			)
 		else
 			jobs = list()
+
+/datum/crewmonitor/yautja
+	faction = FACTION_YAUTJA
+
+/datum/crewmonitor/yautja/update_data()
+	var/list/results = list()
+	for(var/mob/living/carbon/human/human_mob as anything in GLOB.human_mob_list)
+
+		if(!isyautja(human_mob))
+			continue
+
+		if(faction != human_mob.faction)
+			continue
+
+		// Check if z-level is correct
+		var/turf/pos = get_turf(human_mob)
+		if(!pos)
+			continue
+
+		// The entry for this human
+		var/list/entry = list(
+			"ref" = REF(human_mob),
+			"name" = human_mob.real_name,
+			"ijob" = UNKNOWN_JOB_ID,
+			"assignment" = "Hunter",
+			"oxydam" = round(human_mob.getOxyLoss(), 1),
+			"toxdam" = round(human_mob.getToxLoss(), 1),
+			"burndam" = round(human_mob.getFireLoss(), 1),
+			"brutedam" = round(human_mob.getBruteLoss(), 1),
+			"can_track" = TRUE,
+		)
+
+		if(is_mainship_level(pos.z))
+			entry["side"] = "Almayer"
+
+		var/area/mob_area = get_area(human_mob)
+		entry["area"] = sanitize_area(mob_area.name)
+
+		results[++results.len] = entry
+
+	// Cache result
+	data = results
+	last_update = world.time
+
+	return results
 
 #undef SENSOR_LIVING
 #undef SENSOR_VITALS

--- a/maps/predship/huntership.dmm
+++ b/maps/predship/huntership.dmm
@@ -486,8 +486,7 @@
 /obj/structure/pipes/standard/simple/hidden{
 	dir = 4
 	},
-/obj/structure/machinery/computer/crew/alt{
-	faction = "Yautja";
+/obj/structure/machinery/computer/crew/alt/yautja{
 	pixel_y = 24
 	},
 /turf/open/floor/corsat{
@@ -674,9 +673,9 @@
 	color = "#6b675e"
 	},
 /obj/item/weapon/claymore/mercsword/machete/arnold{
+	anchored = 1;
 	desc = "Won by an Elder during their youthful hunting days. None are allowed to touch it.";
-	name = "\improper Dutch's Machete";
-	anchored = 1
+	name = "\improper Dutch's Machete"
 	},
 /turf/open/floor/corsat{
 	dir = 1;
@@ -1789,9 +1788,9 @@
 /area/yautja)
 "gr" = (
 /obj/structure/closet/crate/secure{
-	req_one_access_txt = "252";
 	color = "#6b675e";
-	name = "Secure Yautja crate"
+	name = "Secure Yautja crate";
+	req_one_access_txt = "252"
 	},
 /obj/item/explosive/grenade/spawnergrenade/hellhound,
 /obj/item/explosive/grenade/spawnergrenade/hellhound,
@@ -1806,9 +1805,9 @@
 /obj/structure/machinery/door_control{
 	id = "Yautja Armory";
 	name = "Armory Shutters";
+	needs_power = 0;
 	pixel_x = 24;
-	req_one_access_txt = "252";
-	needs_power = 0
+	req_one_access_txt = "252"
 	},
 /turf/open/floor/corsat{
 	dir = 1;
@@ -2424,9 +2423,9 @@
 /area/yautja)
 "Bg" = (
 /obj/structure/closet/crate/secure{
-	req_one_access_txt = "252";
 	color = "#6b675e";
-	name = "Secure Yautja crate"
+	name = "Secure Yautja crate";
+	req_one_access_txt = "252"
 	},
 /obj/item/weapon/yautja/combistick,
 /obj/item/weapon/yautja/combistick{
@@ -2686,14 +2685,14 @@
 	layer = 2.79
 	},
 /obj/item/stack/medical/advanced/ointment/predator{
-	pixel_x = 6;
 	desc = "A poultice made of cold, blue petals that is rubbed on burns. Not to be removed from the ship.";
-	name = "arena soothing herbs"
+	name = "arena soothing herbs";
+	pixel_x = 6
 	},
 /obj/item/stack/medical/advanced/bruise_pack/predator{
-	pixel_x = -6;
 	desc = "A poultice made of soft leaves that is rubbed on bruises. Not to be removed from the ship.";
-	name = "arena mending herbs"
+	name = "arena mending herbs";
+	pixel_x = -6
 	},
 /turf/open/shuttle/predship,
 /area/yautja)
@@ -2721,9 +2720,9 @@
 "HD" = (
 /obj/structure/surface/rack{
 	color = "#6b675e";
+	density = 0;
 	layer = 2.79;
-	pixel_y = 24;
-	density = 0
+	pixel_y = 24
 	},
 /obj/item/weapon/gun/energy/yautja/plasmarifle{
 	pixel_y = -8


### PR DESCRIPTION

# About the pull request
Fixes the predator crew monitor to work at all.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/cmss13-devs/cmss13/assets/41448081/f0928b55-378a-403e-b732-0e3bc2217692)

</details>


# Changelog
:cl:
fix: Predator ship health monitor console now works
/:cl:
