### PR TITLE
BUG FIX: 3rd Party Music Filename References

### DIFF
--- a/code/game/gamemodes/colonialmarines/colonialmarines.dm
+++ b/code/game/gamemodes/colonialmarines/colonialmarines.dm
@@ -372,11 +372,11 @@
 				var/headcount = count_per_faction()
 				var/living = headcount["total_headcount"]
 				if ((headcount["WY_headcount"] / living) > MAJORITY)
-					musical_track = pick('sound/theme/LastManStanding_WY.ogg')
+					musical_track = pick('sound/theme/lastmanstanding_wy.ogg')
 				else if ((headcount["UPP_headcount"] / living) > MAJORITY)
-					musical_track = pick('sound/theme/LastManStanding_UPP.ogg')
+					musical_track = pick('sound/theme/lastmanstanding_upp.ogg')
 				else if ((headcount["CLF_headcount"] / living) > MAJORITY)
-					musical_track = pick('sound/theme/LastManStanding_CLF.ogg')
+					musical_track = pick('sound/theme/lastmanstanding_clf.ogg')
 				else if ((headcount["marine_headcount"] / living) > MAJORITY)
 					musical_track = pick('sound/theme/neutral_melancholy2.ogg') //This is the theme song for Colonial Marines the game, fitting
 			else


### PR DESCRIPTION

# About the pull request
3rd Party victory music isn't playing when WY/UPP/CLF win a round, I believe this is why:

Was told to update the .ogg files to all lower case in the original PR.  Unfortunately when I referenced them in code they still had capitalization, and that was not caught.  This should fix 3rd Party music not playing. (I think).

# Explain why it's good for the game
Bug fixes good


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: fixed a file reference that broke end of round music for some factions
/:cl:
