### PR TITLE
Clean up predator emote panel

### DIFF
--- a/code/modules/mob/living/carbon/human/species/yautja/fake_sounds.dm
+++ b/code/modules/mob/living/carbon/human/species/yautja/fake_sounds.dm
@@ -2,21 +2,25 @@
 	category = YAUTJA_EMOTE_CATEGORY_FAKESOUND
 
 /datum/emote/living/carbon/human/yautja/fake_sound/aliengrowl
+	override_say = "Xenomorph growl"
 	key = "aliengrowl"
 
 /datum/emote/living/carbon/human/yautja/fake_sound/aliengrowl/get_sound(mob/living/user)
 	return pick('sound/voice/alien_growl1.ogg', 'sound/voice/alien_growl2.ogg')
 
 /datum/emote/living/carbon/human/yautja/fake_sound/alienhelp
+	override_say = "Xenomorph needs help"
 	key = "alienhelp"
 
 /datum/emote/living/carbon/human/yautja/fake_sound/alienhelp/get_sound(mob/living/user)
 	return pick('sound/voice/alien_help1.ogg', 'sound/voice/alien_help2.ogg')
 
 /datum/emote/living/carbon/human/yautja/fake_sound/malescream
+	override_say = "Human scream (male)"
 	key = "malescream"
 	sound = "male_scream"
 
 /datum/emote/living/carbon/human/yautja/fake_sound/femalescream
+	override_say = "Human scream (female)"
 	key = "femalescream"
 	sound = "female_scream"

--- a/code/modules/mob/living/carbon/human/species/yautja/fake_voice.dm
+++ b/code/modules/mob/living/carbon/human/species/yautja/fake_voice.dm
@@ -2,49 +2,58 @@
 	category = YAUTJA_EMOTE_CATEGORY_VOICE
 
 /datum/emote/living/carbon/human/yautja/voice/anytime
+	override_say = "Anytime."
 	key = "anytime"
 	sound = 'sound/voice/pred_anytime.ogg'
 
 
 /datum/emote/living/carbon/human/yautja/voice/helpme
+	override_say = "Help me!"
 	key = "helpme"
 	sound = 'sound/voice/pred_helpme.ogg'
 	volume = 25
 
 
 /datum/emote/living/carbon/human/yautja/voice/iseeyou
+	override_say = "I see you."
 	key = "iseeyou"
 	sound = 'sound/hallucinations/i_see_you2.ogg'
 
 
 /datum/emote/living/carbon/human/yautja/voice/itsatrap
+	override_say = "It's a trap."
 	key = "itsatrap"
 	sound = 'sound/voice/pred_itsatrap.ogg'
 	volume = 25
 
 
 /datum/emote/living/carbon/human/yautja/voice/overhere
+	override_say = "Over here."
 	key = "overhere"
 	sound = 'sound/voice/pred_overhere.ogg'
 	volume = 25
 
 
 /datum/emote/living/carbon/human/yautja/voice/turnaround
+	override_say = "Turn around."
 	key = "turnaround"
 	sound = 'sound/voice/pred_turnaround.ogg'
 	volume = 25
 
 
 /datum/emote/living/carbon/human/yautja/voice/comeonout
+	override_say = "Come on out, motherfucker."
 	key = "comeonout"
 	sound = 'sound/voice/pred_come_on_out.ogg'
 
 
 /datum/emote/living/carbon/human/yautja/voice/overthere
+	override_say = "Over there."
 	key = "overthere"
 	sound = 'sound/voice/pred_over_there.ogg'
 
 
 /datum/emote/living/carbon/human/yautja/voice/uglyfreak
+	override_say = "Come on, you ugly freak."
 	key = "uglyfreak"
 	sound = 'sound/voice/pred_ugly_freak.ogg'


### PR DESCRIPTION

# About the pull request
Adds much more user-friendly labels to the predator emote panel's emotes.

# Explain why it's good for the game
It's better UX to see "Human scream (male)" over "malescream", for instance.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

<img width="226" alt="image" src="https://github.com/cmss13-devs/cmss13/assets/41448081/899f3dd0-e42f-49d0-b090-5c3afad6e288">

</details>


# Changelog
:cl:
qol: Predator emote panel emotes now look a bit cleaner in the menu
/:cl:
