### PR TITLE
Increases the availability and minimum burn time for Star Shells

### DIFF
--- a/code/game/machinery/vending/vendor_types/squad_prep/squad_prep.dm
+++ b/code/game/machinery/vending/vendor_types/squad_prep/squad_prep.dm
@@ -194,7 +194,7 @@
 		list("M56D Drum Magazine", round(scale * 2), /obj/item/ammo_magazine/m56d, VENDOR_ITEM_REGULAR),
 		list("M2C Box Magazine", round(scale * 2), /obj/item/ammo_magazine/m2c, VENDOR_ITEM_REGULAR),
 		list("HIRR Baton Slugs", round(scale * 6), /obj/item/explosive/grenade/slug/baton, VENDOR_ITEM_REGULAR),
-		list("M74 AGM-S Star Shell", round(scale * 2), /obj/item/explosive/grenade/high_explosive/airburst/starshell, VENDOR_ITEM_REGULAR),
+		list("M74 AGM-S Star Shell", round(scale * 4), /obj/item/explosive/grenade/high_explosive/airburst/starshell, VENDOR_ITEM_REGULAR),
 		list("M74 AGM-S Hornet Shell", round(scale * 4), /obj/item/explosive/grenade/high_explosive/airburst/hornet_shell, VENDOR_ITEM_REGULAR),
 		)
 

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -441,7 +441,7 @@
 	if(mapload)
 		return INITIALIZE_HINT_QDEL
 	. = ..()
-	fuel = rand(5 SECONDS, 60 SECONDS)
+	fuel = rand(30 SECONDS,	60 SECONDS)
 
 /obj/item/device/flashlight/flare/on/illumination/chemical
 	name = "chemical light"


### PR DESCRIPTION
# About the pull request

raises the minimum burn time for star shell fragments to 30 seconds from 5 and increases their quantity in squad vendors from scale * 2 to scale * 4.

# Explain why it's good for the game

these grenades are fairly innocuous but rarely, if ever, used outside the free packet you get with the m79. their short burn time coupled with the fact you are giving up space that could be used for actual grenades that have a lot more utility place them into the "not really worth it" category.

hopefully with a higher minimum burn time and a bit more abundance in the squad vendor they'll see some more use, whether in an ugl or the m79.

# Changelog
:cl:Vile Beggar
balance: Star Shells now have a higher minimum burn time and are more plentiful in squad prep.
/:cl: