### PR TITLE
You can no longer bypass skill checks on pill bottles

### DIFF
--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -448,6 +448,22 @@
 	..()
 	update_icon()
 
+/obj/item/storage/pill_bottle/attack_hand(mob/user, mods)
+	if(loc != user)
+		return ..()
+
+	if(!mods || !mods["alt"])
+		return ..()
+
+	if(!ishuman(user))
+		return ..()
+
+	if(skilllock && !skillcheck(user, SKILL_MEDICAL, SKILL_MEDICAL_MEDIC))
+		error_idlock(user)
+		return FALSE
+
+	return ..()
+
 /obj/item/storage/pill_bottle/proc/error_idlock(mob/user)
 	to_chat(user, SPAN_WARNING("It must have some kind of ID lock..."))
 


### PR DESCRIPTION

# About the pull request

When it got passed to attack_hand() from unarmed_attack() in click() it would not check the skillcheck as it calls attack_hand() on the pill rather than through the pill bottle which was allowing a bypass for the skillcheck for pill bottles. This *feels* like the wrong way to do it as like OOP so I'm happy to do it in a different way.

# Explain why it's good for the game

Bug bad


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
fix: You can no longer bypass skill checks on pill bottles
/:cl:
