### PR TITLE
Fixes underbarrel extinguishers

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -1218,6 +1218,16 @@ and you're good to go.
 
 #define EXECUTION_CHECK (attacked_mob.stat == UNCONSCIOUS || attacked_mob.is_mob_restrained()) && ((user.a_intent == INTENT_GRAB)||(user.a_intent == INTENT_DISARM))
 
+/obj/item/weapon/gun/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
+	if(!proximity_flag)
+		return FALSE
+
+	if(active_attachable && (active_attachable.flags_attach_features & ATTACH_MELEE))
+		active_attachable.last_fired = world.time
+		active_attachable.fire_attachment(target, src, user)
+		return TRUE
+
+
 /obj/item/weapon/gun/attack(mob/living/attacked_mob, mob/living/user)
 	if(active_attachable && (active_attachable.flags_attach_features & ATTACH_MELEE)) //this is expected to do something in melee.
 		active_attachable.last_fired = world.time


### PR DESCRIPTION

# About the pull request
Closes https://github.com/cmss13-devs/cmss13/issues/4036
You can now refill underbarrel extinguishers at watertanks and such when they are selected.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/cmss13-devs/cmss13/assets/41448081/b9d57670-0532-46d8-8c24-baae3e099618)

</details>


# Changelog
:cl:
fix: Underbarrel extinguishers can now be refilled.
/:cl:
