### PR TITLE
Combistick now uses a chain

### DIFF
--- a/code/modules/cm_preds/yaut_bracers.dm
+++ b/code/modules/cm_preds/yaut_bracers.dm
@@ -955,19 +955,10 @@
 	if(.)
 		return
 
-	for(var/obj/item/weapon/yautja/combistick/C in range(7))
-		if(C in caller.contents) //Can't yank if they are wearing it
-			return FALSE
-		if(caller.put_in_active_hand(C))//Try putting it in our active hand, or, if it's full...
-			if(!drain_power(caller, 70)) //We should only drain power if we actually yank the chain back. Failed attempts can quickly drain the charge away.
-				return TRUE
-			caller.visible_message(SPAN_WARNING("<b>[caller] yanks [C]'s chain back!</b>"), SPAN_WARNING("<b>You yank [C]'s chain back!</b>"))
-		else if(caller.put_in_inactive_hand(C))///...Try putting it in our inactive hand.
-			if(!drain_power(caller, 70)) //We should only drain power if we actually yank the chain back. Failed attempts can quickly drain the charge away.
-				return TRUE
-			caller.visible_message(SPAN_WARNING("<b>[caller] yanks [C]'s chain back!</b>"), SPAN_WARNING("<b>You yank [C]'s chain back!</b>"))
-		else //If neither hand can hold it, you must not have a free hand.
-			to_chat(caller, SPAN_WARNING("You need a free hand to do this!</b>"))
+	for(var/datum/effects/tethering/tether in caller.effects_list)
+		if(istype(tether.tethered.affected_atom, /obj/item/weapon/yautja/combistick))
+			var/obj/item/weapon/yautja/combistick/stick = tether.tethered.affected_atom
+			stick.recall()
 
 /obj/item/clothing/gloves/yautja/hunter/verb/translate()
 	set name = "Translator"

--- a/code/modules/cm_preds/yaut_weapons.dm
+++ b/code/modules/cm_preds/yaut_weapons.dm
@@ -276,7 +276,15 @@
 	chain = tether_effects["tetherer_tether"]
 	RegisterSignal(chain, COMSIG_PARENT_QDELETING, PROC_REF(cleanup_chain))
 	RegisterSignal(src, COMSIG_ITEM_PICKUP, PROC_REF(on_pickup))
+	RegisterSignal(src, COMSIG_MOVABLE_MOVED, PROC_REF(on_move))
 
+/// The chain normally breaks if it's put into a container, so let's yank it back if that's the case
+/obj/item/weapon/yautja/combistick/proc/on_move(datum/source, atom/moved, dir, forced)
+	SIGNAL_HANDLER
+	if(!z && !is_type_in_list(loc, list(/obj/structure/surface, /mob))) // I rue for the day I can remove the surface snowflake check
+		recall()
+
+/// Clean up the chain, deleting/nulling/unregistering as needed
 /obj/item/weapon/yautja/combistick/proc/cleanup_chain()
 	SIGNAL_HANDLER
 	if(!QDELETED(chain))
@@ -286,6 +294,7 @@
 		chain = null
 
 	UnregisterSignal(src, COMSIG_ITEM_PICKUP)
+	UnregisterSignal(src, COMSIG_MOVABLE_MOVED)
 
 /obj/item/weapon/yautja/combistick/proc/on_pickup(datum/source, mob/user)
 	SIGNAL_HANDLER
@@ -294,6 +303,7 @@
 
 	cleanup_chain()
 
+/// recall the combistick to the pred's hands or to be at their feet
 /obj/item/weapon/yautja/combistick/proc/recall()
 	SIGNAL_HANDLER
 	if(!chain)


### PR DESCRIPTION

# About the pull request
<img width="361" alt="image" src="https://github.com/cmss13-devs/cmss13/assets/41448081/3de6928b-36e2-41fe-8604-743ec8bac24a">

Pred combistick now uses a visible chain.

Balance ramifications:

- Someone picking up the combi (still has a do_after for non-preds mind you) will sever the chain with a message to the pred
- You can no longer yank any combi-stick regardless of if it's actually yours
- Combistick will be pulled with you when you would get more than 6 tiles from it
- You will automatically yank back a combistick that tries to get put into a container

# Explain why it's good for the game

- Preventing chain weirdness while still allowing it to be recovered by marines if the pred really isn't good about holding onto the combi
- Side effect of me making the code a lot better
- Side effect of the tether effect
- Preventing chain weirdness

# Changelog
:cl:
add: Combisticks now use a proper chain instead of an invisible magic one.
/:cl:
