### PR TITLE
Prompt Confirmation before Random Fact

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -576,6 +576,10 @@ var/list/roundstart_mod_verbs = list(
 	set desc = "Tells everyone about a random statistic in the round."
 	set category = "OOC"
 
+	var/prompt = tgui_alert(usr, "Are you sure you want to do this?", "Announce Random Fact", list("No", "Yes"))
+	if(prompt != "Yes")
+		return
+
 	message_admins("[key_name(usr)] announced a random fact.")
 	SSticker.mode?.declare_fun_facts()
 


### PR DESCRIPTION

# About the pull request

Add confirmation prompt before triggering random fact

# Explain why it's good for the game

Misclicking something that does a announcement SIMILAR TO END OF ROUND without any confirmation leads to said admin getting bullied. 
![image](https://github.com/cmss13-devs/cmss13/assets/91219575/3383b2b5-de8c-468b-837d-4520c87e8cad)


# Testing Photographs and Procedure

![image](https://github.com/cmss13-devs/cmss13/assets/91219575/5ad5c776-fb28-4287-9fcd-83a28534d69d)

# Changelog
:cl:
admin: You now need to give confirmation before announcing random facts (OOC tab verb)
/:cl:
