### PR TITLE
Fix for synths' default language.

### DIFF
--- a/code/modules/gear_presets/synths.dm
+++ b/code/modules/gear_presets/synths.dm
@@ -1,7 +1,6 @@
 /datum/equipment_preset/synth
 	name = "Synth"
 	uses_special_name = TRUE
-	languages = ALL_SYNTH_LANGUAGES_UPP
 	skills = /datum/skills/synthetic
 	paygrade = "SYN"
 
@@ -458,6 +457,7 @@
 /datum/equipment_preset/synth/survivor/upp
 	name = "Survivor - Synthetic - UPP Synth"
 	flags = EQUIPMENT_PRESET_EXTRA
+	languages = ALL_SYNTH_LANGUAGES_UPP
 	assignment = JOB_UPP_COMBAT_SYNTH
 	rank = JOB_SURVIVOR
 	faction = FACTION_UPP

--- a/code/modules/gear_presets/synths.dm
+++ b/code/modules/gear_presets/synths.dm
@@ -1,6 +1,7 @@
 /datum/equipment_preset/synth
 	name = "Synth"
 	uses_special_name = TRUE
+	languages = ALL_SYNTH_LANGUAGES
 	skills = /datum/skills/synthetic
 	paygrade = "SYN"
 


### PR DESCRIPTION

# About the pull request

Followup to #3845.

# Explain why it's good for the game

Selfevident.

# Changelog
:cl:
fix: Non-UPP synthetics no longer default to speaking Russian.
/:cl:
