### PR TITLE
Increases power of special xeno structures

### DIFF
--- a/code/game/turfs/walls/wall_types.dm
+++ b/code/game/turfs/walls/wall_types.dm
@@ -1102,9 +1102,9 @@
 
 	// 75% chance of reflecting projectiles
 	var/chance_to_reflect = 75
-	var/reflect_range = 10
+	var/reflect_range = 7
 
-	var/brute_multiplier = 0.3
+	var/brute_multiplier = 0.1
 	var/explosive_multiplier = 0.3
 	var/reflection_multiplier = 0.5
 
@@ -1112,18 +1112,19 @@
 	if(src in P.permutated)
 		return
 
-	if(!prob(chance_to_reflect))
+	if(P.runtime_iff_group) // Iff bullets wont deflect as easy as normal bullets
+		reflect_range = 3
+		chance_to_reflect = 25
+
+	if(!prob(chance_to_reflect) || P.ammo.flags_ammo_behavior & AMMO_NO_DEFLECT)
 		if(P.ammo.damage_type == BRUTE)
 			P.damage *= brute_multiplier
 		return ..()
-	if(P.runtime_iff_group || P.ammo.flags_ammo_behavior & AMMO_NO_DEFLECT)
-		// Bullet gets absorbed if it has IFF or can't be reflected.
-		return
 
 	var/obj/item/projectile/new_proj = new(src, construction_data ? construction_data : create_cause_data(initial(name)))
 	new_proj.generate_bullet(P.ammo)
 	new_proj.damage = P.damage * reflection_multiplier // don't make it too punishing
-	new_proj.accuracy = HIT_ACCURACY_TIER_7 // 35% chance to hit something
+	new_proj.accuracy = HIT_ACCURACY_TIER_8 // 40% chance to hit something
 
 	// Move back to who fired you.
 	RegisterSignal(new_proj, COMSIG_BULLET_PRE_HANDLE_TURF, PROC_REF(bullet_ignore_turf))

--- a/code/modules/cm_aliens/XenoStructures.dm
+++ b/code/modules/cm_aliens/XenoStructures.dm
@@ -187,13 +187,11 @@
 	layer = RESIN_STRUCTURE_LAYER
 	should_track_build = TRUE
 	var/hivenumber = XENO_HIVE_NORMAL
-	var/damage = 8
+	var/damage = 10
 	var/penetration = 50
 
 	var/target_limbs = list(
-		"l_leg",
 		"l_foot",
-		"r_leg",
 		"r_foot"
 	)
 


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->
IFF bullets will now be reflected on Reflective walls ( with decreased probability of 25% instead of 75% )
increased the damage reduction on reflective walls to 90%.
increased damage to resin spikes from 8 to 10.
Resin spikes will no longer target legs

# Explain why it's good for the game
Current Reflective walls are basically useless . they can just tank about 7-10 bullets more than a normal drone wall and they have a 5 max cap , only buildable by the queen and hivelords. and they get 2 tabbed at melee because of their low health.

This PR provides them with more strenght to acomplish their specialized role of being a bullet sponge. marine will have to find more creative ways to deal with this structure rather than shoot it down.

Resin spikes will now apply 10 damage instead of 8 and only target the feet , first it doesnt make sense that the damage goes directly to the leg when you are stepping on a spike and secondly this will increase the room for fractures if marines decide to ignore the resin spikes while chasing.

This will give room to more advanced Xeno defence by giving options for hivelords and queen to implement more this structures that are normally completely useless.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: Reflective wall projectile resistance increased to 90%
balance: Reflective wall will now reflect IFF bullets with a decreased amount.
balance: Resin spikes damage increased to 10
balance: Resin spike will now only target the feet
/:cl:
