### PR TITLE
Foxtrot cryomarines spawn as freed mobs if not taken

### DIFF
--- a/code/__DEFINES/techtree.dm
+++ b/code/__DEFINES/techtree.dm
@@ -10,7 +10,7 @@
 #define TREE_MARINE "Marine Tech Tree"
 #define TREE_XENO "Xenomorph Tech Tree"
 
-#define INITIAL_STARTING_POINTS 0
+#define INITIAL_STARTING_POINTS 999999
 
 // Tech Flags
 /// The tech can be purchased multiple times

--- a/code/__DEFINES/techtree.dm
+++ b/code/__DEFINES/techtree.dm
@@ -10,7 +10,7 @@
 #define TREE_MARINE "Marine Tech Tree"
 #define TREE_XENO "Xenomorph Tech Tree"
 
-#define INITIAL_STARTING_POINTS 999999
+#define INITIAL_STARTING_POINTS 0
 
 // Tech Flags
 /// The tech can be purchased multiple times

--- a/code/datums/emergency_calls/cryo_marines.dm
+++ b/code/datums/emergency_calls/cryo_marines.dm
@@ -23,7 +23,7 @@
 	if(mob_max > length(members))
 		announce_dchat("Some cryomarines were not taken, use the Join As Freed Mob verb to take one of them.")
 
-/datum/emergency_call/cryo_squad/create_member(datum/mind/M, turf/override_spawn_loc)
+/datum/emergency_call/cryo_squad/create_member(datum/mind/mind, turf/override_spawn_loc)
 	set waitfor = 0
 	if(SSmapping.configs[GROUND_MAP].map_name == MAP_WHISKEY_OUTPOST)
 		name_of_spawn = /obj/effect/landmark/ert_spawns/distress_wo
@@ -31,61 +31,61 @@
 
 	if(!istype(spawn_loc)) return //Didn't find a useable spawn point.
 
-	var/mob/living/carbon/human/H = new(spawn_loc)
+	var/mob/living/carbon/human/human = new(spawn_loc)
 
-	if(M)
-		M.transfer_to(H, TRUE)
+	if(mind)
+		mind.transfer_to(human, TRUE)
 	else
-		H.create_hud()
+		human.create_hud()
 
-	if(!M)
-		for(var/obj/structure/machinery/cryopod/pod in view(7,H))
+	if(!mind)
+		for(var/obj/structure/machinery/cryopod/pod in view(7,human))
 			if(pod && !pod.occupant)
-				pod.go_in_cryopod(H, silent = TRUE)
+				pod.go_in_cryopod(human, silent = TRUE)
 				break
 
 	sleep(5)
 	var/datum/squad/marine/cryo/cryo_squad = RoleAuthority.squads_by_type[/datum/squad/marine/cryo]
-	if(leaders < cryo_squad.max_leaders && (!M || (HAS_FLAG(H.client.prefs.toggles_ert, PLAY_LEADER) && check_timelock(H.client, JOB_SQUAD_LEADER, time_required_for_job))))
-		leader = H
+	if(leaders < cryo_squad.max_leaders && (!mind || (HAS_FLAG(human.client.prefs.toggles_ert, PLAY_LEADER) && check_timelock(human.client, JOB_SQUAD_LEADER, time_required_for_job))))
+		leader = human
 		leaders++
-		H.client?.prefs.copy_all_to(H, JOB_SQUAD_LEADER, TRUE, TRUE)
-		arm_equipment(H, /datum/equipment_preset/uscm/leader/cryo, M == null, TRUE)
-		to_chat(H, SPAN_ROLE_HEADER("You are a Squad Leader in the USCM"))
-		to_chat(H, SPAN_ROLE_BODY("You are here to assist in the defence of the [SSmapping.configs[GROUND_MAP].map_name]. Listen to the chain of command."))
-		to_chat(H, SPAN_BOLDWARNING("If you wish to cryo or ghost upon spawning in, you must ahelp and inform staff so you can be replaced."))
-	else if (heavies < max_heavies && (!M || (HAS_FLAG(H.client.prefs.toggles_ert, PLAY_HEAVY) && check_timelock(H.client, JOB_SQUAD_SPECIALIST, time_required_for_job))))
+		human.client?.prefs.copy_all_to(human, JOB_SQUAD_LEADER, TRUE, TRUE)
+		arm_equipment(human, /datum/equipment_preset/uscm/leader/cryo, mind == null, TRUE)
+		to_chat(human, SPAN_ROLE_HEADER("You are a Squad Leader in the USCM"))
+		to_chat(human, SPAN_ROLE_BODY("You are here to assist in the defence of the [SSmapping.configs[GROUND_MAP].map_name]. Listen to the chain of command."))
+		to_chat(human, SPAN_BOLDWARNING("If you wish to cryo or ghost upon spawning in, you must ahelp and inform staff so you can be replaced."))
+	else if (heavies < max_heavies && (!mind || (HAS_FLAG(human.client.prefs.toggles_ert, PLAY_HEAVY) && check_timelock(human.client, JOB_SQUAD_SPECIALIST, time_required_for_job))))
 		heavies++
-		H.client?.prefs.copy_all_to(H, JOB_SQUAD_SPECIALIST, TRUE, TRUE)
-		arm_equipment(H, /datum/equipment_preset/uscm/spec/cryo,  M == null, TRUE)
-		to_chat(H, SPAN_ROLE_HEADER("You are a Weapons Specialist in the USCM"))
-		to_chat(H, SPAN_ROLE_BODY("Your squad is here to assist in the defence of the [SSmapping.configs[GROUND_MAP].map_name]. Listen to the chain of command."))
-		to_chat(H, SPAN_BOLDWARNING("If you wish to cryo or ghost upon spawning in, you must ahelp and inform staff so you can be replaced."))
-	else if (medics < max_medics && (!M || (HAS_FLAG(H.client.prefs.toggles_ert, PLAY_MEDIC) && check_timelock(H.client, JOB_SQUAD_MEDIC, time_required_for_job))))
+		human.client?.prefs.copy_all_to(human, JOB_SQUAD_SPECIALIST, TRUE, TRUE)
+		arm_equipment(human, /datum/equipment_preset/uscm/spec/cryo,  mind == null, TRUE)
+		to_chat(human, SPAN_ROLE_HEADER("You are a Weapons Specialist in the USCM"))
+		to_chat(human, SPAN_ROLE_BODY("Your squad is here to assist in the defence of the [SSmapping.configs[GROUND_MAP].map_name]. Listen to the chain of command."))
+		to_chat(human, SPAN_BOLDWARNING("If you wish to cryo or ghost upon spawning in, you must ahelp and inform staff so you can be replaced."))
+	else if (medics < max_medics && (!mind || (HAS_FLAG(human.client.prefs.toggles_ert, PLAY_MEDIC) && check_timelock(human.client, JOB_SQUAD_MEDIC, time_required_for_job))))
 		medics++
-		H.client?.prefs.copy_all_to(H, JOB_SQUAD_MEDIC, TRUE, TRUE)
-		arm_equipment(H, /datum/equipment_preset/uscm/medic/cryo,  M == null, TRUE)
-		to_chat(H, SPAN_ROLE_HEADER("You are a Hospital Corpsman in the USCM"))
-		to_chat(H, SPAN_ROLE_BODY("You are here to assist in the defence of the [SSmapping.configs[GROUND_MAP].map_name]. Listen to the chain of command."))
-		to_chat(H, SPAN_BOLDWARNING("If you wish to cryo or ghost upon spawning in, you must ahelp and inform staff so you can be replaced."))
-	else if (engineers < max_engineers && (!M || (HAS_FLAG(H.client.prefs.toggles_ert, PLAY_ENGINEER) && check_timelock(H.client, JOB_SQUAD_ENGI, time_required_for_job))))
+		human.client?.prefs.copy_all_to(human, JOB_SQUAD_MEDIC, TRUE, TRUE)
+		arm_equipment(human, /datum/equipment_preset/uscm/medic/cryo,  mind == null, TRUE)
+		to_chat(human, SPAN_ROLE_HEADER("You are a Hospital Corpsman in the USCM"))
+		to_chat(human, SPAN_ROLE_BODY("You are here to assist in the defence of the [SSmapping.configs[GROUND_MAP].map_name]. Listen to the chain of command."))
+		to_chat(human, SPAN_BOLDWARNING("If you wish to cryo or ghost upon spawning in, you must ahelp and inform staff so you can be replaced."))
+	else if (engineers < max_engineers && (!mind || (HAS_FLAG(human.client.prefs.toggles_ert, PLAY_ENGINEER) && check_timelock(human.client, JOB_SQUAD_ENGI, time_required_for_job))))
 		engineers++
-		H.client?.prefs.copy_all_to(H, JOB_SQUAD_ENGI, TRUE, TRUE)
-		arm_equipment(H, /datum/equipment_preset/uscm/engineer/cryo,  M == null, TRUE)
-		to_chat(H, SPAN_ROLE_HEADER("You are an Engineer in the USCM"))
-		to_chat(H, SPAN_ROLE_BODY("You are here to assist in the defence of the [SSmapping.configs[GROUND_MAP].map_name]. Listen to the chain of command."))
-		to_chat(H, SPAN_BOLDWARNING("If you wish to cryo or ghost upon spawning in, you must ahelp and inform staff so you can be replaced."))
+		human.client?.prefs.copy_all_to(human, JOB_SQUAD_ENGI, TRUE, TRUE)
+		arm_equipment(human, /datum/equipment_preset/uscm/engineer/cryo,  mind == null, TRUE)
+		to_chat(human, SPAN_ROLE_HEADER("You are an Engineer in the USCM"))
+		to_chat(human, SPAN_ROLE_BODY("You are here to assist in the defence of the [SSmapping.configs[GROUND_MAP].map_name]. Listen to the chain of command."))
+		to_chat(human, SPAN_BOLDWARNING("If you wish to cryo or ghost upon spawning in, you must ahelp and inform staff so you can be replaced."))
 	else
-		H.client?.prefs.copy_all_to(H, JOB_SQUAD_MARINE, TRUE, TRUE)
-		arm_equipment(H, /datum/equipment_preset/uscm/pfc/cryo,  M == null, TRUE)
-		to_chat(H, SPAN_ROLE_HEADER("You are a Rifleman in the USCM"))
-		to_chat(H, SPAN_ROLE_BODY("You are here to assist in the defence of the [SSmapping.configs[GROUND_MAP].map_name]. Listen to the chain of command."))
-		to_chat(H, SPAN_BOLDWARNING("If you wish to cryo or ghost upon spawning in, you must ahelp and inform staff so you can be replaced."))
+		human.client?.prefs.copy_all_to(human, JOB_SQUAD_MARINE, TRUE, TRUE)
+		arm_equipment(human, /datum/equipment_preset/uscm/pfc/cryo,  mind == null, TRUE)
+		to_chat(human, SPAN_ROLE_HEADER("You are a Rifleman in the USCM"))
+		to_chat(human, SPAN_ROLE_BODY("You are here to assist in the defence of the [SSmapping.configs[GROUND_MAP].map_name]. Listen to the chain of command."))
+		to_chat(human, SPAN_BOLDWARNING("If you wish to cryo or ghost upon spawning in, you must ahelp and inform staff so you can be replaced."))
 
 	sleep(10)
-	if(!M)
-		H.free_for_ghosts()
-	to_chat(H, SPAN_BOLD("Objectives: [objectives]"))
+	if(!mind)
+		human.free_for_ghosts()
+	to_chat(human, SPAN_BOLD("Objectives: [objectives]"))
 
 /datum/emergency_call/cryo_squad/platoon
 	name = "Marine Cryo Reinforcements (Platoon)"

--- a/code/datums/emergency_calls/cryo_marines.dm
+++ b/code/datums/emergency_calls/cryo_marines.dm
@@ -12,6 +12,7 @@
 	name_of_spawn = /obj/effect/landmark/ert_spawns/distress_cryo
 	shuttle_id = ""
 	var/leaders = 0
+	spawn_max_amount = TRUE
 
 /datum/emergency_call/cryo_squad/spawn_candidates(announce, override_spawn_loc, announce_dispatch_message)
 	var/datum/squad/marine/cryo/cryo_squad = RoleAuthority.squads_by_type[/datum/squad/marine/cryo]
@@ -29,11 +30,11 @@
 	if(!istype(spawn_loc)) return //Didn't find a useable spawn point.
 
 	var/mob/living/carbon/human/H = new(spawn_loc)
-	M.transfer_to(H, TRUE)
+	M?.transfer_to(H, TRUE)
 
 	sleep(5)
 	var/datum/squad/marine/cryo/cryo_squad = RoleAuthority.squads_by_type[/datum/squad/marine/cryo]
-	if(leaders < cryo_squad.max_leaders && HAS_FLAG(H.client.prefs.toggles_ert, PLAY_LEADER) && check_timelock(H.client, JOB_SQUAD_LEADER, time_required_for_job))
+	if(leaders < cryo_squad.max_leaders && (!M || (HAS_FLAG(H.client.prefs.toggles_ert, PLAY_LEADER) && check_timelock(H.client, JOB_SQUAD_LEADER, time_required_for_job))))
 		leader = H
 		leaders++
 		H.client.prefs.copy_all_to(H, JOB_SQUAD_LEADER, TRUE, TRUE)
@@ -41,21 +42,21 @@
 		to_chat(H, SPAN_ROLE_HEADER("You are a Squad Leader in the USCM"))
 		to_chat(H, SPAN_ROLE_BODY("You are here to assist in the defence of the [SSmapping.configs[GROUND_MAP].map_name]. Listen to the chain of command."))
 		to_chat(H, SPAN_BOLDWARNING("If you wish to cryo or ghost upon spawning in, you must ahelp and inform staff so you can be replaced."))
-	else if (heavies < max_heavies && HAS_FLAG(H.client.prefs.toggles_ert, PLAY_HEAVY) && check_timelock(H.client, JOB_SQUAD_SPECIALIST, time_required_for_job))
+	else if (heavies < max_heavies && (!M || (HAS_FLAG(H.client.prefs.toggles_ert, PLAY_HEAVY) && check_timelock(H.client, JOB_SQUAD_SPECIALIST, time_required_for_job))))
 		heavies++
 		H.client.prefs.copy_all_to(H, JOB_SQUAD_SPECIALIST, TRUE, TRUE)
 		arm_equipment(H, /datum/equipment_preset/uscm/spec/cryo, FALSE, TRUE)
 		to_chat(H, SPAN_ROLE_HEADER("You are a Weapons Specialist in the USCM"))
 		to_chat(H, SPAN_ROLE_BODY("Your squad is here to assist in the defence of the [SSmapping.configs[GROUND_MAP].map_name]. Listen to the chain of command."))
 		to_chat(H, SPAN_BOLDWARNING("If you wish to cryo or ghost upon spawning in, you must ahelp and inform staff so you can be replaced."))
-	else if (medics < max_medics && HAS_FLAG(H.client.prefs.toggles_ert, PLAY_MEDIC) && check_timelock(H.client, JOB_SQUAD_MEDIC, time_required_for_job))
+	else if (medics < max_medics && (!M || (HAS_FLAG(H.client.prefs.toggles_ert, PLAY_MEDIC) && check_timelock(H.client, JOB_SQUAD_MEDIC, time_required_for_job))))
 		medics++
 		H.client.prefs.copy_all_to(H, JOB_SQUAD_MEDIC, TRUE, TRUE)
 		arm_equipment(H, /datum/equipment_preset/uscm/medic/cryo, FALSE, TRUE)
 		to_chat(H, SPAN_ROLE_HEADER("You are a Hospital Corpsman in the USCM"))
 		to_chat(H, SPAN_ROLE_BODY("You are here to assist in the defence of the [SSmapping.configs[GROUND_MAP].map_name]. Listen to the chain of command."))
 		to_chat(H, SPAN_BOLDWARNING("If you wish to cryo or ghost upon spawning in, you must ahelp and inform staff so you can be replaced."))
-	else if (engineers < max_engineers && HAS_FLAG(H.client.prefs.toggles_ert, PLAY_ENGINEER) && check_timelock(H.client, JOB_SQUAD_ENGI, time_required_for_job))
+	else if (engineers < max_engineers && (!M || (HAS_FLAG(H.client.prefs.toggles_ert, PLAY_ENGINEER) && check_timelock(H.client, JOB_SQUAD_ENGI, time_required_for_job))))
 		engineers++
 		H.client.prefs.copy_all_to(H, JOB_SQUAD_ENGI, TRUE, TRUE)
 		arm_equipment(H, /datum/equipment_preset/uscm/engineer/cryo, FALSE, TRUE)
@@ -70,6 +71,8 @@
 		to_chat(H, SPAN_BOLDWARNING("If you wish to cryo or ghost upon spawning in, you must ahelp and inform staff so you can be replaced."))
 
 	sleep(10)
+	if(!M)
+		H.free_for_ghosts()
 	to_chat(H, SPAN_BOLD("Objectives: [objectives]"))
 
 /datum/emergency_call/cryo_squad/platoon

--- a/code/datums/emergency_calls/cryo_marines.dm
+++ b/code/datums/emergency_calls/cryo_marines.dm
@@ -19,7 +19,9 @@
 	leaders = cryo_squad.num_leaders
 	. = ..()
 	// if(length(members))
-	shipwide_ai_announcement("Successfully deployed [length(members)] Foxtrot marines.")
+	shipwide_ai_announcement("Successfully deployed [mob_max] Foxtrot marines, of which [length(members)] ready for duty.")
+	if(mob_max > length(members))
+		announce_dchat("Some cryomarines were not taken, use the Join As Freed Mob verb to take one of them.", src)
 
 /datum/emergency_call/cryo_squad/create_member(datum/mind/M, turf/override_spawn_loc)
 	set waitfor = 0
@@ -30,49 +32,52 @@
 	if(!istype(spawn_loc)) return //Didn't find a useable spawn point.
 
 	var/mob/living/carbon/human/H = new(spawn_loc)
+
 	if(M)
 		M.transfer_to(H, TRUE)
+	else
+		H.create_hud()
+
+	if(!M)
+		for(var/obj/structure/machinery/cryopod/pod in view(7,H))
+			if(pod && !pod.occupant)
+				pod.go_in_cryopod(H, silent = TRUE)
+				break
 
 	sleep(5)
 	var/datum/squad/marine/cryo/cryo_squad = RoleAuthority.squads_by_type[/datum/squad/marine/cryo]
 	if(leaders < cryo_squad.max_leaders && (!M || (HAS_FLAG(H.client.prefs.toggles_ert, PLAY_LEADER) && check_timelock(H.client, JOB_SQUAD_LEADER, time_required_for_job))))
 		leader = H
 		leaders++
-		ai_announcement("test1")
-		//H.client.prefs.copy_all_to(H, JOB_SQUAD_LEADER, TRUE, TRUE)
-		ai_announcement("test2")
-		arm_equipment(H, /datum/equipment_preset/uscm/leader/cryo, FALSE, TRUE)
+		H.client?.prefs.copy_all_to(H, JOB_SQUAD_LEADER, TRUE, TRUE)
+		arm_equipment(H, /datum/equipment_preset/uscm/leader/cryo, M == null, TRUE)
 		to_chat(H, SPAN_ROLE_HEADER("You are a Squad Leader in the USCM"))
 		to_chat(H, SPAN_ROLE_BODY("You are here to assist in the defence of the [SSmapping.configs[GROUND_MAP].map_name]. Listen to the chain of command."))
 		to_chat(H, SPAN_BOLDWARNING("If you wish to cryo or ghost upon spawning in, you must ahelp and inform staff so you can be replaced."))
 	else if (heavies < max_heavies && (!M || (HAS_FLAG(H.client.prefs.toggles_ert, PLAY_HEAVY) && check_timelock(H.client, JOB_SQUAD_SPECIALIST, time_required_for_job))))
 		heavies++
-		//H.client.prefs.copy_all_to(H, JOB_SQUAD_SPECIALIST, TRUE, TRUE)
-		arm_equipment(H, /datum/equipment_preset/uscm/spec/cryo, FALSE, TRUE)
-		ai_announcement("test11")
+		H.client?.prefs.copy_all_to(H, JOB_SQUAD_SPECIALIST, TRUE, TRUE)
+		arm_equipment(H, /datum/equipment_preset/uscm/spec/cryo,  M == null, TRUE)
 		to_chat(H, SPAN_ROLE_HEADER("You are a Weapons Specialist in the USCM"))
 		to_chat(H, SPAN_ROLE_BODY("Your squad is here to assist in the defence of the [SSmapping.configs[GROUND_MAP].map_name]. Listen to the chain of command."))
 		to_chat(H, SPAN_BOLDWARNING("If you wish to cryo or ghost upon spawning in, you must ahelp and inform staff so you can be replaced."))
 	else if (medics < max_medics && (!M || (HAS_FLAG(H.client.prefs.toggles_ert, PLAY_MEDIC) && check_timelock(H.client, JOB_SQUAD_MEDIC, time_required_for_job))))
 		medics++
-		//H.client.prefs.copy_all_to(H, JOB_SQUAD_MEDIC, TRUE, TRUE)
-		arm_equipment(H, /datum/equipment_preset/uscm/medic/cryo, FALSE, TRUE)
-		ai_announcement("test11")
+		H.client?.prefs.copy_all_to(H, JOB_SQUAD_MEDIC, TRUE, TRUE)
+		arm_equipment(H, /datum/equipment_preset/uscm/medic/cryo,  M == null, TRUE)
 		to_chat(H, SPAN_ROLE_HEADER("You are a Hospital Corpsman in the USCM"))
 		to_chat(H, SPAN_ROLE_BODY("You are here to assist in the defence of the [SSmapping.configs[GROUND_MAP].map_name]. Listen to the chain of command."))
 		to_chat(H, SPAN_BOLDWARNING("If you wish to cryo or ghost upon spawning in, you must ahelp and inform staff so you can be replaced."))
 	else if (engineers < max_engineers && (!M || (HAS_FLAG(H.client.prefs.toggles_ert, PLAY_ENGINEER) && check_timelock(H.client, JOB_SQUAD_ENGI, time_required_for_job))))
 		engineers++
-		//H.client.prefs.copy_all_to(H, JOB_SQUAD_ENGI, TRUE, TRUE)
-		arm_equipment(H, /datum/equipment_preset/uscm/engineer/cryo, FALSE, TRUE)
-		ai_announcement("test11")
+		H.client?.prefs.copy_all_to(H, JOB_SQUAD_ENGI, TRUE, TRUE)
+		arm_equipment(H, /datum/equipment_preset/uscm/engineer/cryo,  M == null, TRUE)
 		to_chat(H, SPAN_ROLE_HEADER("You are an Engineer in the USCM"))
 		to_chat(H, SPAN_ROLE_BODY("You are here to assist in the defence of the [SSmapping.configs[GROUND_MAP].map_name]. Listen to the chain of command."))
 		to_chat(H, SPAN_BOLDWARNING("If you wish to cryo or ghost upon spawning in, you must ahelp and inform staff so you can be replaced."))
 	else
-		//H.client.prefs.copy_all_to(H, JOB_SQUAD_MARINE, TRUE, TRUE)
-		arm_equipment(H, /datum/equipment_preset/uscm/pfc/cryo, FALSE, TRUE)
-		ai_announcement("test11")
+		H.client?.prefs.copy_all_to(H, JOB_SQUAD_MARINE, TRUE, TRUE)
+		arm_equipment(H, /datum/equipment_preset/uscm/pfc/cryo,  M == null, TRUE)
 		to_chat(H, SPAN_ROLE_HEADER("You are a Rifleman in the USCM"))
 		to_chat(H, SPAN_ROLE_BODY("You are here to assist in the defence of the [SSmapping.configs[GROUND_MAP].map_name]. Listen to the chain of command."))
 		to_chat(H, SPAN_BOLDWARNING("If you wish to cryo or ghost upon spawning in, you must ahelp and inform staff so you can be replaced."))

--- a/code/datums/emergency_calls/cryo_marines.dm
+++ b/code/datums/emergency_calls/cryo_marines.dm
@@ -21,7 +21,7 @@
 	// if(length(members))
 	shipwide_ai_announcement("Successfully deployed [mob_max] Foxtrot marines, of which [length(members)] ready for duty.")
 	if(mob_max > length(members))
-		announce_dchat("Some cryomarines were not taken, use the Join As Freed Mob verb to take one of them.", src)
+		announce_dchat("Some cryomarines were not taken, use the Join As Freed Mob verb to take one of them.")
 
 /datum/emergency_call/cryo_squad/create_member(datum/mind/M, turf/override_spawn_loc)
 	set waitfor = 0

--- a/code/datums/emergency_calls/cryo_marines.dm
+++ b/code/datums/emergency_calls/cryo_marines.dm
@@ -19,7 +19,7 @@
 	leaders = cryo_squad.num_leaders
 	. = ..()
 	// if(length(members))
-	shipwide_ai_announcement("Successfully deployed [mob_max] Foxtrot marines, of which [length(members)] ready for duty.")
+	shipwide_ai_announcement("Successfully deployed [mob_max] Foxtrot marines, of which [length(members)] are ready for duty.")
 	if(mob_max > length(members))
 		announce_dchat("Some cryomarines were not taken, use the Join As Freed Mob verb to take one of them.")
 

--- a/code/datums/emergency_calls/cryo_marines.dm
+++ b/code/datums/emergency_calls/cryo_marines.dm
@@ -18,7 +18,6 @@
 	var/datum/squad/marine/cryo/cryo_squad = RoleAuthority.squads_by_type[/datum/squad/marine/cryo]
 	leaders = cryo_squad.num_leaders
 	. = ..()
-	// if(length(members))
 	shipwide_ai_announcement("Successfully deployed [mob_max] Foxtrot marines, of which [length(members)] are ready for duty.")
 	if(mob_max > length(members))
 		announce_dchat("Some cryomarines were not taken, use the Join As Freed Mob verb to take one of them.")

--- a/code/datums/emergency_calls/cryo_marines.dm
+++ b/code/datums/emergency_calls/cryo_marines.dm
@@ -18,8 +18,8 @@
 	var/datum/squad/marine/cryo/cryo_squad = RoleAuthority.squads_by_type[/datum/squad/marine/cryo]
 	leaders = cryo_squad.num_leaders
 	. = ..()
-	if(length(members))
-		shipwide_ai_announcement("Successfully deployed [length(members)] Foxtrot marines.")
+	// if(length(members))
+	shipwide_ai_announcement("Successfully deployed [length(members)] Foxtrot marines.")
 
 /datum/emergency_call/cryo_squad/create_member(datum/mind/M, turf/override_spawn_loc)
 	set waitfor = 0
@@ -30,42 +30,49 @@
 	if(!istype(spawn_loc)) return //Didn't find a useable spawn point.
 
 	var/mob/living/carbon/human/H = new(spawn_loc)
-	M?.transfer_to(H, TRUE)
+	if(M)
+		M.transfer_to(H, TRUE)
 
 	sleep(5)
 	var/datum/squad/marine/cryo/cryo_squad = RoleAuthority.squads_by_type[/datum/squad/marine/cryo]
 	if(leaders < cryo_squad.max_leaders && (!M || (HAS_FLAG(H.client.prefs.toggles_ert, PLAY_LEADER) && check_timelock(H.client, JOB_SQUAD_LEADER, time_required_for_job))))
 		leader = H
 		leaders++
-		H.client.prefs.copy_all_to(H, JOB_SQUAD_LEADER, TRUE, TRUE)
+		ai_announcement("test1")
+		//H.client.prefs.copy_all_to(H, JOB_SQUAD_LEADER, TRUE, TRUE)
+		ai_announcement("test2")
 		arm_equipment(H, /datum/equipment_preset/uscm/leader/cryo, FALSE, TRUE)
 		to_chat(H, SPAN_ROLE_HEADER("You are a Squad Leader in the USCM"))
 		to_chat(H, SPAN_ROLE_BODY("You are here to assist in the defence of the [SSmapping.configs[GROUND_MAP].map_name]. Listen to the chain of command."))
 		to_chat(H, SPAN_BOLDWARNING("If you wish to cryo or ghost upon spawning in, you must ahelp and inform staff so you can be replaced."))
 	else if (heavies < max_heavies && (!M || (HAS_FLAG(H.client.prefs.toggles_ert, PLAY_HEAVY) && check_timelock(H.client, JOB_SQUAD_SPECIALIST, time_required_for_job))))
 		heavies++
-		H.client.prefs.copy_all_to(H, JOB_SQUAD_SPECIALIST, TRUE, TRUE)
+		//H.client.prefs.copy_all_to(H, JOB_SQUAD_SPECIALIST, TRUE, TRUE)
 		arm_equipment(H, /datum/equipment_preset/uscm/spec/cryo, FALSE, TRUE)
+		ai_announcement("test11")
 		to_chat(H, SPAN_ROLE_HEADER("You are a Weapons Specialist in the USCM"))
 		to_chat(H, SPAN_ROLE_BODY("Your squad is here to assist in the defence of the [SSmapping.configs[GROUND_MAP].map_name]. Listen to the chain of command."))
 		to_chat(H, SPAN_BOLDWARNING("If you wish to cryo or ghost upon spawning in, you must ahelp and inform staff so you can be replaced."))
 	else if (medics < max_medics && (!M || (HAS_FLAG(H.client.prefs.toggles_ert, PLAY_MEDIC) && check_timelock(H.client, JOB_SQUAD_MEDIC, time_required_for_job))))
 		medics++
-		H.client.prefs.copy_all_to(H, JOB_SQUAD_MEDIC, TRUE, TRUE)
+		//H.client.prefs.copy_all_to(H, JOB_SQUAD_MEDIC, TRUE, TRUE)
 		arm_equipment(H, /datum/equipment_preset/uscm/medic/cryo, FALSE, TRUE)
+		ai_announcement("test11")
 		to_chat(H, SPAN_ROLE_HEADER("You are a Hospital Corpsman in the USCM"))
 		to_chat(H, SPAN_ROLE_BODY("You are here to assist in the defence of the [SSmapping.configs[GROUND_MAP].map_name]. Listen to the chain of command."))
 		to_chat(H, SPAN_BOLDWARNING("If you wish to cryo or ghost upon spawning in, you must ahelp and inform staff so you can be replaced."))
 	else if (engineers < max_engineers && (!M || (HAS_FLAG(H.client.prefs.toggles_ert, PLAY_ENGINEER) && check_timelock(H.client, JOB_SQUAD_ENGI, time_required_for_job))))
 		engineers++
-		H.client.prefs.copy_all_to(H, JOB_SQUAD_ENGI, TRUE, TRUE)
+		//H.client.prefs.copy_all_to(H, JOB_SQUAD_ENGI, TRUE, TRUE)
 		arm_equipment(H, /datum/equipment_preset/uscm/engineer/cryo, FALSE, TRUE)
+		ai_announcement("test11")
 		to_chat(H, SPAN_ROLE_HEADER("You are an Engineer in the USCM"))
 		to_chat(H, SPAN_ROLE_BODY("You are here to assist in the defence of the [SSmapping.configs[GROUND_MAP].map_name]. Listen to the chain of command."))
 		to_chat(H, SPAN_BOLDWARNING("If you wish to cryo or ghost upon spawning in, you must ahelp and inform staff so you can be replaced."))
 	else
-		H.client.prefs.copy_all_to(H, JOB_SQUAD_MARINE, TRUE, TRUE)
+		//H.client.prefs.copy_all_to(H, JOB_SQUAD_MARINE, TRUE, TRUE)
 		arm_equipment(H, /datum/equipment_preset/uscm/pfc/cryo, FALSE, TRUE)
+		ai_announcement("test11")
 		to_chat(H, SPAN_ROLE_HEADER("You are a Rifleman in the USCM"))
 		to_chat(H, SPAN_ROLE_BODY("You are here to assist in the defence of the [SSmapping.configs[GROUND_MAP].map_name]. Listen to the chain of command."))
 		to_chat(H, SPAN_BOLDWARNING("If you wish to cryo or ghost upon spawning in, you must ahelp and inform staff so you can be replaced."))

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -193,7 +193,7 @@ GLOBAL_LIST_INIT(frozen_items, list(SQUAD_MARINE_1 = list(), SQUAD_MARINE_2 = li
 
 //Lifted from Unity stasis.dm and refactored. ~Zuhayr
 /obj/structure/machinery/cryopod/process()
-	if(occupant)
+	if(occupant && !(WEAKREF(occupant) in GLOB.freed_mob_list)) //ignore freed mobs
 		//if occupant ghosted, time till despawn is severely shorter
 		if(!occupant.key && time_till_despawn == 10 MINUTES)
 			time_till_despawn -= 8 MINUTES


### PR DESCRIPTION

# About the pull request

Foxtrot cryomarines spawn as freed mobs if not taken.

# Explain why it's good for the game

It sucks when only 3 cryomarines spawn in because there is not enough candidates. Now people can take cryomarines later.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: ihatethisengine
add: foxtrot cryomarines spawn as freed mobs if not taken.
/:cl:
