### PR TITLE
Fix drop ships having inconsistent ceiling setting to prevent OBs

### DIFF
--- a/code/game/area/Sulaco.dm
+++ b/code/game/area/Sulaco.dm
@@ -13,6 +13,7 @@
 	is_resin_allowed = FALSE
 	flags_area = AREA_NOTUNNEL
 	is_landing_zone = TRUE
+	ceiling = CEILING_REINFORCED_METAL
 
 /area/shuttle/drop1/Enter(atom/movable/O, atom/oldloc)
 	if(istype(O, /obj/structure/barricade))
@@ -23,36 +24,30 @@
 	name = "\improper Dropship Alamo"
 	icon_state = "shuttlered"
 	base_muffle = MUFFLE_HIGH
-	ceiling = CEILING_REINFORCED_METAL
 
 /area/shuttle/drop1/LV624
 	name = "\improper Dropship Alamo"
 	ambience_exterior = AMBIENCE_LV624
 	icon_state = "shuttle"
-	ceiling = CEILING_REINFORCED_METAL
 
 /area/shuttle/drop1/prison
 	name = "\improper Dropship Alamo"
 	ambience_exterior = AMBIENCE_PRISON
 	icon_state = "shuttle"
-	ceiling = CEILING_REINFORCED_METAL
 
 /area/shuttle/drop1/BigRed
 	name = "\improper Dropship Alamo"
 	ambience_exterior = AMBIENCE_BIGRED
 	icon_state = "shuttle"
-	ceiling = CEILING_REINFORCED_METAL
 
 /area/shuttle/drop1/ice_colony
 	name = "\improper Dropship Alamo"
 	icon_state = "shuttle"
-	ceiling = CEILING_REINFORCED_METAL
 
 /area/shuttle/drop1/DesertDam
 	name = "\improper Dropship Alamo"
 	ambience_exterior = AMBIENCE_TRIJENT
 	icon_state = "shuttle"
-	ceiling = CEILING_REINFORCED_METAL
 
 /area/shuttle/drop1/transit
 	ambience_exterior = 'sound/ambience/dropship_ambience_loop.ogg'
@@ -75,41 +70,36 @@
 	is_resin_allowed = FALSE
 	flags_area = AREA_NOTUNNEL
 	is_landing_zone = TRUE
+	ceiling = CEILING_REINFORCED_METAL
 
 /area/shuttle/drop2/sulaco
 	name = "\improper Dropship Normandy"
 	icon_state = "shuttle"
 	base_muffle = MUFFLE_HIGH
-	ceiling = CEILING_REINFORCED_METAL
 
 /area/shuttle/drop2/LV624
 	name = "\improper Dropship Normandy"
 	ambience_exterior = AMBIENCE_LV624
 	icon_state = "shuttle2"
-	ceiling = CEILING_REINFORCED_METAL
 
 /area/shuttle/drop2/prison
 	name = "\improper Dropship Normandy"
 	ambience_exterior = AMBIENCE_PRISON
 	icon_state = "shuttle2"
-	ceiling = CEILING_REINFORCED_METAL
 
 /area/shuttle/drop2/BigRed
 	name = "\improper Dropship Normandy"
 	ambience_exterior = AMBIENCE_BIGRED
 	icon_state = "shuttle2"
-	ceiling = CEILING_REINFORCED_METAL
 
 /area/shuttle/drop2/ice_colony
 	name = "\improper Dropship Normandy"
 	icon_state = "shuttle2"
-	ceiling = CEILING_REINFORCED_METAL
 
 /area/shuttle/drop2/DesertDam
 	name = "\improper Dropship Normandy"
 	ambience_exterior = AMBIENCE_TRIJENT
 	icon_state = "shuttle2"
-	ceiling = CEILING_REINFORCED_METAL
 
 /area/shuttle/drop2/transit
 	ambience_exterior = 'sound/ambience/dropship_ambience_loop.ogg'


### PR DESCRIPTION

# About the pull request

This PR is a followup to #3237 and in response to Round 18077 on New Varadero which had a cluster OB wipe a large portion of the hive on the dropship.

# Explain why it's good for the game

OB protections should not be inconsistent. If a dropship is supposed to provide protection, then it should do so on all maps.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

# Changelog
:cl: Drathek
fix: Fix new map dropship areas not getting changes to dropship ceilings that prevents OBs
/:cl:
