### PR TITLE
Etool size buff

### DIFF
--- a/code/game/objects/items/tools/shovel_tools.dm
+++ b/code/game/objects/items/tools/shovel_tools.dm
@@ -233,7 +233,7 @@
 /obj/item/tool/shovel/etool/attack_self(mob/user as mob)
 	folded = !folded
 	if(folded)
-		w_class = SIZE_MEDIUM
+		w_class = SIZE_SMALL
 		force = 2
 	else
 		w_class = SIZE_LARGE
@@ -242,7 +242,7 @@
 
 /obj/item/tool/shovel/etool/folded
 	folded = TRUE
-	w_class = SIZE_MEDIUM
+	w_class = SIZE_SMALL
 	force = 2
 	icon_state = "etool_c"
 	item_state = "etool_c"


### PR DESCRIPTION

# About the pull request

Folded etool is now a small item

# Explain why it's good for the game

I like etools and want to see them used more

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
balance: Folded etools are now small items
/:cl:
