### PR TITLE
Fix runtime with hijack burrowed PR

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -931,9 +931,10 @@
 		potential_host.update_med_icon()
 	for(var/mob/living/carbon/human/current_human as anything in GLOB.alive_human_list)
 		if((isspecieshuman(current_human) || isspeciessynth(current_human)) && current_human.job)
+			var/datum/job/job = RoleAuthority.roles_for_mode[current_human.job]
 			var/turf/turf = get_turf(current_human)
 			if(is_mainship_level(turf?.z))
-				shipside_humans_weighted_count += RoleAuthority.calculate_role_weight(current_human.job)
+				shipside_humans_weighted_count += RoleAuthority.calculate_role_weight(job)
 	hijack_burrowed_surge = TRUE
 	hijack_burrowed_left = max(n_ceil(shipside_humans_weighted_count * 0.5) - xenos_count, 5)
 	hivecore_cooldown = FALSE

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -930,10 +930,10 @@
 			embryo.hivenumber = XENO_HIVE_FORSAKEN
 		potential_host.update_med_icon()
 	for(var/mob/living/carbon/human/current_human as anything in GLOB.alive_human_list)
-		if((isspecieshuman(current_human) || isspeciessynth(current_human)) && current_human.job)
+		if((isspecieshuman(current_human) || isspeciessynth(current_human)))
 			var/datum/job/job = RoleAuthority.roles_for_mode[current_human.job]
 			var/turf/turf = get_turf(current_human)
-			if(is_mainship_level(turf?.z))
+			if(job && is_mainship_level(turf?.z))
 				shipside_humans_weighted_count += RoleAuthority.calculate_role_weight(job)
 	hijack_burrowed_surge = TRUE
 	hijack_burrowed_left = max(n_ceil(shipside_humans_weighted_count * 0.5) - xenos_count, 5)

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -930,11 +930,14 @@
 			embryo.hivenumber = XENO_HIVE_FORSAKEN
 		potential_host.update_med_icon()
 	for(var/mob/living/carbon/human/current_human as anything in GLOB.alive_human_list)
-		if(isspecieshuman(current_human) || isspeciessynth(current_human))
-			var/datum/job/job = RoleAuthority.roles_for_mode[current_human.job]
-			var/turf/turf = get_turf(current_human)
-			if(job && is_mainship_level(turf?.z))
-				shipside_humans_weighted_count += RoleAuthority.calculate_role_weight(job)
+		if(!(isspecieshuman(current_human) || isspeciessynth(current_human)))
+			continue
+		var/datum/job/job = RoleAuthority.roles_for_mode[current_human.job]
+		if(!job)
+			continue
+		var/turf/turf = get_turf(current_human)
+		if(is_mainship_level(turf?.z))
+			shipside_humans_weighted_count += RoleAuthority.calculate_role_weight(job)
 	hijack_burrowed_surge = TRUE
 	hijack_burrowed_left = max(n_ceil(shipside_humans_weighted_count * 0.5) - xenos_count, 5)
 	hivecore_cooldown = FALSE

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -930,7 +930,7 @@
 			embryo.hivenumber = XENO_HIVE_FORSAKEN
 		potential_host.update_med_icon()
 	for(var/mob/living/carbon/human/current_human as anything in GLOB.alive_human_list)
-		if((isspecieshuman(current_human) || isspeciessynth(current_human)))
+		if(isspecieshuman(current_human) || isspeciessynth(current_human))
 			var/datum/job/job = RoleAuthority.roles_for_mode[current_human.job]
 			var/turf/turf = get_turf(current_human)
 			if(job && is_mainship_level(turf?.z))


### PR DESCRIPTION

# About the pull request

This PR is a followup to #3592 fixing runtimes when hijack occurs because it was assumed the mob's job was a datum/job when it actually is a string.

# Explain why it's good for the game

Code shouldn't runtime.

Fixes: 
![image](https://github.com/cmss13-devs/cmss13/assets/76988376/b9f47464-07d3-4972-af6d-21dd7dffd3e9)

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: Drathek
fix: Fixed runtimes with hijack not calculating roles correctly for hijack larva surge
/:cl:
