### PR TITLE
Fix beams for IV drip machines when adding/removing a blood bag

### DIFF
--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -39,9 +39,9 @@
 			overlays += filling
 
 /obj/structure/machinery/iv_drip/proc/update_beam()
-	if(current_beam)
+	if(current_beam && !attached)
 		QDEL_NULL(current_beam)
-	else if(!QDELETED(src) && attached)
+	else if(!current_beam && attached && !QDELETED(src))
 		current_beam = beam(attached, "iv_tube")
 
 /obj/structure/machinery/iv_drip/power_change()
@@ -55,6 +55,7 @@
 
 /obj/structure/machinery/iv_drip/Destroy()
 	attached?.active_transfusions -= src
+	attached = null
 	update_beam()
 	. = ..()
 


### PR DESCRIPTION

# About the pull request

This PR is a followup to #3645 fixing the beam getting into an incorrect state when adding/removing a bag when the drip is already connected to someone. Also fixes a lingering reference to the attached mob ever the drip is destroyed.

# Explain why it's good for the game

Fixes this: 

https://github.com/cmss13-devs/cmss13/assets/76988376/77a69934-0eb9-4322-b0c5-74a53a34700f

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: Drathek
fix: Fix IV Drip machines not displaying the IV line correctly when adding/removing a bag when already attached
code: Fixes a lingering reference to the mob when a IV drip machine is destroyed.
/:cl:
