### PR TITLE
Smurfing Queens

### DIFF
--- a/code/game/gamemodes/cm_process.dm
+++ b/code/game/gamemodes/cm_process.dm
@@ -58,18 +58,18 @@ of predators), but can be added to include variant game modes (like humans vs. h
 	if(LAZYLEN(xenomorphs) || LAZYLEN(dead_queens))
 		var/dat = "<br>"
 		dat += SPAN_ROUNDBODY("<br>The xenomorph Queen(s) were:")
-		var/mob/M
+		var/mob/living/carbon/xenomorph/xeno_mob
 		for (var/msg in dead_queens)
 			dat += msg
-		for(var/datum/mind/X in xenomorphs)
-			if(!istype(X))
+		for(var/datum/mind/xeno_mind in xenomorphs)
+			if(!istype(xeno_mind))
 				continue
 
-			M = X.current
-			if(!M || !M.loc)
-				M = X.original
-			if(M && M.loc && isqueen(M) && M.stat != DEAD) // Dead queens handled separately
-				dat += "<br>[X.key] was [M] [SPAN_BOLDNOTICE("(SURVIVED)")]"
+			xeno_mob = xeno_mind.current
+			if(!xeno_mob || !xeno_mob.loc)
+				xeno_mob = xeno_mind.original
+			if(xeno_mob && xeno_mob.loc && isqueen(xeno_mob) && xeno_mob.stat != DEAD) // Dead queens handled separately
+				dat += "<br>[xeno_mob.full_designation] was [xeno_mob] [SPAN_BOLDNOTICE("(SURVIVED)")]"
 
 		to_world("[dat]")
 

--- a/code/modules/mob/living/carbon/xenomorph/death.dm
+++ b/code/modules/mob/living/carbon/xenomorph/death.dm
@@ -72,7 +72,7 @@
 				hive.handle_xeno_leader_pheromones()
 				if(SSticker.mode)
 					INVOKE_ASYNC(SSticker.mode, TYPE_PROC_REF(/datum/game_mode, check_queen_status), hivenumber)
-					LAZYADD(SSticker.mode.dead_queens, "<br>[!isnull(src.key) ? src.key : "?"] was [src] [SPAN_BOLDNOTICE("(DIED)")]")
+					LAZYADD(SSticker.mode.dead_queens, "<br>[!isnull(full_designation) ? full_designation : "?"] was [src] [SPAN_BOLDNOTICE("(DIED)")]")
 
 		else if(ispredalien(src))
 			playsound(loc,'sound/voice/predalien_death.ogg', 25, TRUE)


### PR DESCRIPTION

# About the pull request

This PR changes the tags at end of round from a queen's CKEY to their in round designations (prefix-number-postfix) so as to allow for people who would like to play queen without their ckey attached. Those who want to be known can still be known via their tag.

# Explain why it's good for the game

I want to play Queen without getting pinged 20 times post round in #LRC


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
add: At end of round it now shows a Queen's prefix/postfix rather than their ckey
/:cl:
