### PR TITLE
Removes no-armor sentinel slow-spit insta-knockdown

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -2428,7 +2428,7 @@
 			M.apply_effect(2.5, SUPERSLOW)
 			M.visible_message(SPAN_DANGER("[M]'s movements are slowed."))
 
-		var/no_clothes_neuro = FALSE
+		/*var/no_clothes_neuro = FALSE
 
 		if(ishuman(M))
 			var/mob/living/carbon/human/H = M
@@ -2438,7 +2438,7 @@
 		if(no_clothes_neuro)
 			if(M.knocked_down < 5)
 				M.adjust_effect(1 * power, WEAKEN) // KD them a bit more
-				M.visible_message(SPAN_DANGER("[M] falls prone."))
+				M.visible_message(SPAN_DANGER("[M] falls prone.")) */
 
 /proc/apply_scatter_neuro(mob/M)
 	if(ishuman(M))


### PR DESCRIPTION

# About the pull request

Disables the mechanic of sentinel's *slowing* spit that instantly KOs someone if they don't have an armor item on(and sometimes from what I can tell if they do and it has no slow).
Simply commented out if this ever is needed to be reverted someday.

# Explain why it's good for the game

Sentinel instantly knocking down un-armored humans is a legacy mechanic that has no reason to currently be in the game, and only provides unfair and annoying gameplay.

Primarily effected survivors, who are unable to acquire slow-spit protecting armors, what this mechanic does is allow sent to knock down anyone with their SLOWING SPIT.
![image](https://github.com/cmss13-devs/cmss13/assets/103988604/7956ad97-192e-4cfb-859f-12a6e92a420b)
working essentially as queen neuro that a t1 caste can use, which is extremely oppressive for survivor players, forcing them to stay not just as a group of more than 2(two people can get stunlocked by a sent, providing they don't run out of plasma), but also close enough together to shake, or forcing them into a hold that due to skill nerfs, they are often unable to adequately protect provided they aren't an engineer(and if theres just 1 engineer, they can be spam-stunned through cades and left unable to repair).

I've asked and tried to get this removed many times, primarily 2021 kind of, but the primary response I received was: "marines would just take no armor, rush xenos, then double chung without xenos having any sort of ranged stun to keep them back", more or less. In modern CM, with sentinel having a second neuro ability that KOs regardless of armor, their stun-slash, as well as double chung being removed, this argument is already void, but the factor of having no armor meaning damage is MUCH more lethal seals this strategy off as essentially suicidal and useless.

Sentinel is already quite a good matchup against humans, and especially survivors with their typically small groups, due to their ranged multi-stun and slash delayed long-stun, as well as the primary slowing ability of their spit, I believe sentinel would still be around about the same power-level, especially as this mechanic mostly comes into play in the first 20~ minutes of the round as xenos engage survivors before marines drop.


# Testing Photographs and Procedure

I didnt get any pictures, but I spawned as a sent, tested on an armored and unarmored marine, worked as simply a slow as intended, queen spit also works normally, so I didn't fuck that up in the process, which I doubt would be even possible as I believe the sent spit and queen spit are in completely different files.


# Changelog
:cl:
balance: Sentinel slowing spit no longer stuns humans with no armor
/:cl:
