### PR TITLE
More random slashes take two

### DIFF
--- a/code/_onclick/xeno.dm
+++ b/code/_onclick/xeno.dm
@@ -39,7 +39,7 @@
 					return FALSE
 
 	target = target.handle_barriers(src, , (PASS_MOB_THRU_XENO|PASS_TYPE_CRAWLER)) // Checks if target will be attacked by the current alien OR if the blocker will be attacked
-	switch(target.attack_alien(src))
+	switch(target.attack_alien(src, directional_assist_attack = tile_attack))
 		if(XENO_ATTACK_ACTION)
 			xeno_attack_delay(src)
 		if(XENO_NONCOMBAT_ACTION)
@@ -96,7 +96,7 @@ Return FALSE if it didn't do anything and should count as a missed slash.
 
 If using do_afters or sleeps, use invoke_async (or manually add the relevant action delayand return FALSE
 so that it doesn't double up on the delays) so that it applies the delay immediately instead of when it finishes.**/
-/atom/proc/attack_alien(mob/user as mob)
+/atom/proc/attack_alien(mob/user as mob, dam_bonus, directional_assist_attack)
 	return
 
 /mob/living/carbon/xenomorph/click(atom/target, list/mods)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -203,8 +203,8 @@
 /atom/movable/clone/attack_hand(mob/user)
 	return src.mstr.attack_hand(user)
 
-/atom/movable/clone/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus)
-	return src.mstr.attack_alien(M, dam_bonus)
+/atom/movable/clone/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
+	return src.mstr.attack_alien(M, dam_bonus = dam_bonus)
 
 /atom/movable/clone/attack_animal(mob/living/M as mob)
 	return src.mstr.attack_animal(M)

--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -79,11 +79,11 @@
 		anes_tank = null
 
 // Removing marines connected to anesthetic
-/obj/structure/machinery/optable/attack_alien(mob/living/carbon/xenomorph/alien, mob/living/user)
+/obj/structure/machinery/optable/attack_alien(mob/living/carbon/xenomorph/alien, dam_bonus, directional_assist_attack)
 	if(buckled_mob)
 		to_chat(alien, SPAN_XENONOTICE("You rip the tubes away from the host, releasing it!"))
 		playsound(alien, "alien_claw_flesh", 25, 1)
-		unbuckle(user)
+		unbuckle(buckled_mob)
 	else
 		. = ..()
 

--- a/code/game/machinery/camera/presets.dm
+++ b/code/game/machinery/camera/presets.dm
@@ -104,7 +104,7 @@
 	unacidable = TRUE
 	network = list(CAMERA_NET_RESEARCH, CAMERA_NET_CONTAINMENT)
 
-/obj/structure/machinery/camera/autoname/almayer/containment/attack_alien(mob/living/carbon/xenomorph/M)
+/obj/structure/machinery/camera/autoname/almayer/containment/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	return
 
 /obj/structure/machinery/camera/autoname/almayer/containment/hidden

--- a/code/game/machinery/door_control.dm
+++ b/code/game/machinery/door_control.dm
@@ -46,7 +46,7 @@
 	else
 		to_chat(user, "Error, no route to host.")
 
-/obj/structure/machinery/door_control/attack_alien(mob/user as mob)
+/obj/structure/machinery/door_control/attack_alien(mob/user as mob, dam_bonus, directional_assist_attack)
 	return
 
 /obj/structure/machinery/door_control/attackby(obj/item/W, mob/user as mob)

--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -862,7 +862,7 @@
 		return
 	..()
 
-/obj/structure/machinery/door/airlock/dropship_hatch/attack_alien(mob/living/carbon/xenomorph/xeno)
+/obj/structure/machinery/door/airlock/dropship_hatch/attack_alien(mob/living/carbon/xenomorph/xeno, dam_bonus, directional_assist_attack)
 
 	if(xeno.hive_pos != XENO_QUEEN)
 		return ..()

--- a/code/game/machinery/doors/multi_tile.dm
+++ b/code/game/machinery/doors/multi_tile.dm
@@ -281,7 +281,7 @@
 		return // in orbit
 	..()
 
-/obj/structure/machinery/door/airlock/multi_tile/almayer/dropshiprear/attack_alien(mob/living/carbon/xenomorph/xeno)
+/obj/structure/machinery/door/airlock/multi_tile/almayer/dropshiprear/attack_alien(mob/living/carbon/xenomorph/xeno, dam_bonus, directional_assist_attack)
 	if(xeno.hive_pos != XENO_QUEEN)
 		return ..()
 

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -47,7 +47,7 @@
 			density = FALSE
 			operating = 0
 
-/obj/structure/machinery/door/poddoor/attack_alien(mob/living/carbon/xenomorph/X)
+/obj/structure/machinery/door/poddoor/attack_alien(mob/living/carbon/xenomorph/X, dam_bonus, directional_assist_attack)
 	if((stat & NOPOWER) && density && !operating && !unacidable)
 		INVOKE_ASYNC(src, PROC_REF(pry_open), X)
 		return XENO_ATTACK_ACTION

--- a/code/game/machinery/doors/shutters.dm
+++ b/code/game/machinery/doors/shutters.dm
@@ -101,7 +101,7 @@
 /obj/structure/machinery/door/poddoor/shutters/almayer/containment
 	unacidable = TRUE
 
-/obj/structure/machinery/door/poddoor/shutters/almayer/containment/attack_alien(mob/living/carbon/xenomorph/M)
+/obj/structure/machinery/door/poddoor/shutters/almayer/containment/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	if(isqueen(M) && density && !operating)
 		INVOKE_ASYNC(src, PROC_REF(pry_open), M)
 		return XENO_ATTACK_ACTION

--- a/code/game/machinery/medical_pod/medical_pod.dm
+++ b/code/game/machinery/medical_pod/medical_pod.dm
@@ -28,7 +28,7 @@
 /obj/structure/machinery/medical_pod/attack_hand(mob/living/user)
 	eject()
 
-/obj/structure/machinery/medical_pod/attack_alien(mob/living/carbon/xenomorph/M)
+/obj/structure/machinery/medical_pod/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	eject()
 
 /obj/structure/machinery/medical_pod/update_icon()

--- a/code/game/machinery/nuclearbomb.dm
+++ b/code/game/machinery/nuclearbomb.dm
@@ -85,7 +85,7 @@ var/bomb_set = FALSE
 			timer_announcements_flags = 0
 			return
 
-/obj/structure/machinery/nuclearbomb/attack_alien(mob/living/carbon/xenomorph/M)
+/obj/structure/machinery/nuclearbomb/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	INVOKE_ASYNC(src, TYPE_PROC_REF(/atom, attack_hand), M)
 	return XENO_ATTACK_ACTION
 

--- a/code/game/machinery/vending/cm_vending.dm
+++ b/code/game/machinery/vending/cm_vending.dm
@@ -358,7 +358,7 @@ GLOBAL_LIST_EMPTY(vending_products)
 
 //------------INTERACTION PROCS---------------
 
-/obj/structure/machinery/cm_vending/attack_alien(mob/living/carbon/xenomorph/M)
+/obj/structure/machinery/cm_vending/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	if(stat & TIPPED_OVER || indestructible)
 		to_chat(M, SPAN_WARNING("There's no reason to bother with that old piece of trash."))
 		return XENO_NO_DELAY_ACTION

--- a/code/game/objects/effects/acid_hole.dm
+++ b/code/game/objects/effects/acid_hole.dm
@@ -39,7 +39,7 @@
 		use_wall_hole(user)
 
 
-/obj/effect/acid_hole/attack_alien(mob/living/carbon/xenomorph/user)
+/obj/effect/acid_hole/attack_alien(mob/living/carbon/xenomorph/user, dam_bonus, directional_assist_attack)
 	if (!holed_wall)
 		qdel(src) //no wall?! then cease existence...
 		return

--- a/code/game/objects/effects/decals/misc.dm
+++ b/code/game/objects/effects/decals/misc.dm
@@ -82,7 +82,7 @@
 /obj/effect/decal/mecha_wreckage/bullet_act(obj/item/projectile/Proj)
 	return 1
 
-/obj/effect/decal/mecha_wreckage/attack_alien(mob/living/carbon/xenomorph/M)
+/obj/effect/decal/mecha_wreckage/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	playsound(src, 'sound/effects/metal_crash.ogg', 50, 1)
 	M.animation_attack_on(src)
 	M.visible_message(SPAN_DANGER("[M] slices [src] apart!"), SPAN_DANGER("You slice [src] apart!"))

--- a/code/game/objects/effects/effect_system/foam.dm
+++ b/code/game/objects/effects/effect_system/foam.dm
@@ -210,7 +210,7 @@
 
 	return FALSE
 
-/obj/structure/foamed_metal/attack_alien(mob/living/carbon/xenomorph/X, dam_bonus)
+/obj/structure/foamed_metal/attack_alien(mob/living/carbon/xenomorph/X, dam_bonus, directional_assist_attack)
 	var/damage = (rand(X.melee_damage_lower, X.melee_damage_upper) + dam_bonus)
 
 	//Frenzy bonus

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -136,7 +136,7 @@
 	else
 		return ..()
 
-/obj/item/device/flashlight/attack_alien(mob/living/carbon/xenomorph/M)
+/obj/item/device/flashlight/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	. = ..()
 
 	if(on && can_be_broken)

--- a/code/game/objects/items/explosives/mine.dm
+++ b/code/game/objects/items/explosives/mine.dm
@@ -224,7 +224,7 @@
 			disarm()
 
 
-/obj/item/explosive/mine/attack_alien(mob/living/carbon/xenomorph/M)
+/obj/item/explosive/mine/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	if(triggered) //Mine is already set to go off
 		return XENO_NO_DELAY_ACTION
 

--- a/code/game/objects/items/toys/toys.dm
+++ b/code/game/objects/items/toys/toys.dm
@@ -560,7 +560,7 @@
 		playsound(target, pick('sound/voice/alien_queen_xmas.ogg', 'sound/voice/alien_queen_xmas_2.ogg'), 25, TRUE)
 	user.festivizer_hits_total++
 
-/obj/item/toy/festivizer/attack_alien(mob/living/carbon/xenomorph/M)
+/obj/item/toy/festivizer/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	attack_hand(M) //xenos can use them too.
 	return XENO_NONCOMBAT_ACTION
 

--- a/code/game/objects/structures/blocker.dm
+++ b/code/game/objects/structures/blocker.dm
@@ -58,7 +58,7 @@
 /obj/structure/blocker/fog/attack_hand(mob/M)
 	to_chat(M, SPAN_NOTICE("You peer through the fog, but it's impossible to tell what's on the other side..."))
 
-/obj/structure/blocker/fog/attack_alien(M)
+/obj/structure/blocker/fog/attack_alien(M, dam_bonus, directional_assist_attack)
 	attack_hand(M)
 	return XENO_NONCOMBAT_ACTION
 

--- a/code/game/objects/structures/crates_lockers/largecrate.dm
+++ b/code/game/objects/structures/crates_lockers/largecrate.dm
@@ -60,7 +60,7 @@
 	else
 		return attack_hand(user)
 
-/obj/structure/largecrate/attack_alien(mob/living/carbon/xenomorph/M)
+/obj/structure/largecrate/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	M.animation_attack_on(src)
 	unpack()
 	M.visible_message(SPAN_DANGER("[M] smashes [src] apart!"), \

--- a/code/game/objects/structures/curtains.dm
+++ b/code/game/objects/structures/curtains.dm
@@ -21,7 +21,7 @@
 	toggle()
 	..()
 
-/obj/structure/curtain/attack_alien(mob/living/carbon/xenomorph/M)
+/obj/structure/curtain/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	M.animation_attack_on(src)
 	M.visible_message(SPAN_DANGER("\The [M] slices [src] apart!"), \
 	SPAN_DANGER("You slice [src] apart!"), null, 5)

--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -180,7 +180,7 @@
 	if(signs)
 		overlays += "cart_sign[signs]"
 
-/obj/structure/janitorialcart/attack_alien(mob/living/carbon/xenomorph/xeno_attacker)
+/obj/structure/janitorialcart/attack_alien(mob/living/carbon/xenomorph/xeno_attacker, dam_bonus, directional_assist_attack)
 	xeno_attacker.animation_attack_on(src)
 	playsound(src, 'sound/effects/metalhit.ogg', 25, 1)
 	xeno_attacker.visible_message(SPAN_DANGER("[xeno_attacker] slices \the [src] apart!"),

--- a/code/game/objects/structures/props.dm
+++ b/code/game/objects/structures/props.dm
@@ -817,7 +817,7 @@
 	visible_message(SPAN_NOTICE("[user] fuels [src] with [fuel]."))
 	remaining_fuel++
 
-/obj/structure/prop/brazier/campfire/attack_alien(mob/living/carbon/xenomorph/xeno)
+/obj/structure/prop/brazier/campfire/attack_alien(mob/living/carbon/xenomorph/xeno, dam_bonus, directional_assist_attack)
 	if(!extinguishable)
 		to_chat(xeno, SPAN_WARNING("You cannot extinguish [src]."))
 		return
@@ -1262,7 +1262,7 @@
 		helmet = null
 		overlays.Cut()
 
-/obj/structure/prop/wooden_cross/attack_alien(mob/living/carbon/xenomorph/M)
+/obj/structure/prop/wooden_cross/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	M.animation_attack_on(src)
 	update_health(rand(M.melee_damage_lower, M.melee_damage_upper))
 	playsound(src, 'sound/effects/woodhit.ogg', 25, 1)

--- a/code/game/objects/structures/reagent_dispensers.dm
+++ b/code/game/objects/structures/reagent_dispensers.dm
@@ -77,7 +77,7 @@
 	healthcheck()
 	return TRUE
 
-/obj/structure/reagent_dispensers/attack_alien(mob/living/carbon/xenomorph/user)
+/obj/structure/reagent_dispensers/attack_alien(mob/living/carbon/xenomorph/user, dam_bonus, directional_assist_attack)
 	if(unslashable)
 		return XENO_NO_DELAY_ACTION
 	user.animation_attack_on(src)

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -73,7 +73,7 @@
 			flags_can_pass_all_temp |= PASS_OVER
 			projectile_coverage = PROJECTILE_COVERAGE_MEDIUM
 
-/obj/structure/bed/chair/attack_alien(mob/living/carbon/xenomorph/M)
+/obj/structure/bed/chair/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	. = ..()
 	if(stacked_size)
 		stack_collapse()
@@ -440,7 +440,7 @@
 		return
 	..()
 
-/obj/structure/bed/chair/dropship/passenger/attack_alien(mob/living/user)
+/obj/structure/bed/chair/dropship/passenger/attack_alien(mob/living/user, dam_bonus, directional_assist_attack)
 	if(chair_state != DROPSHIP_CHAIR_BROKEN)
 		playsound(loc, 'sound/effects/metalhit.ogg', 25, 1)
 		user.animation_attack_on(src)

--- a/code/game/objects/structures/stool_bed_chair_nest/xeno_nest.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/xeno_nest.dm
@@ -315,7 +315,7 @@
 		QDEL_IN(src, rand(225, 400))
 
 
-/obj/structure/bed/nest/attack_alien(mob/living/carbon/xenomorph/M)
+/obj/structure/bed/nest/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	if(islarva(M)) //Larvae can't do shit
 		return
 	if(M.a_intent == INTENT_HARM && !buckled_mob) //can't slash nest with an occupant.

--- a/code/game/objects/structures/window_frame.dm
+++ b/code/game/objects/structures/window_frame.dm
@@ -134,7 +134,7 @@
 	else
 		. = ..()
 
-/obj/structure/window_frame/attack_alien(mob/living/carbon/xenomorph/user)
+/obj/structure/window_frame/attack_alien(mob/living/carbon/xenomorph/user, dam_bonus, directional_assist_attack)
 	if(!reinforced && user.claw_type >= CLAW_TYPE_SHARP)
 		user.animation_attack_on(src)
 		playsound(src, 'sound/effects/metalhit.ogg', 25, 1)

--- a/code/game/turfs/auto_turf.dm
+++ b/code/game/turfs/auto_turf.dm
@@ -187,7 +187,7 @@
 		playsound(user, 'sound/weapons/Genhit.ogg', 25, 1)
 
 //Digging up snow
-/turf/open/auto_turf/snow/attack_alien(mob/living/carbon/xenomorph/M)
+/turf/open/auto_turf/snow/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	if(M.a_intent == INTENT_HARM) //Missed slash.
 		return
 	if(M.a_intent == INTENT_HELP || !bleed_layer)

--- a/code/game/turfs/light.dm
+++ b/code/game/turfs/light.dm
@@ -74,7 +74,7 @@
 
 	return ..()
 
-/turf/open/floor/light/attack_alien(mob/living/carbon/xenomorph/xeno_attacker) //Xeno breaking light, this makes them basically flashlight that needs a new bulb to go back on
+/turf/open/floor/light/attack_alien(mob/living/carbon/xenomorph/xeno_attacker, dam_bonus, directional_assist_attack) //Xeno breaking light, this makes them basically flashlight that needs a new bulb to go back on
 	if(!broken)
 		playsound(src, "windowshatter", 25, 1)
 		xeno_attacker.animation_attack_on(src)

--- a/code/game/turfs/walls/wall_types.dm
+++ b/code/game/turfs/walls/wall_types.dm
@@ -109,7 +109,7 @@
 		return
 	. = ..()
 
-/turf/closed/wall/almayer/research/containment/wall/attack_alien(mob/living/carbon/xenomorph/user)
+/turf/closed/wall/almayer/research/containment/wall/attack_alien(mob/living/carbon/xenomorph/user, dam_bonus, directional_assist_attack)
 	return
 
 /turf/closed/wall/almayer/research/containment/wall/corner
@@ -331,7 +331,7 @@
 	damage_cap = HEALTH_WALL_REINFORCED//Strong, but only available to Hunters, can can still be blown up or melted by boilers.
 	baseturfs = /turf/open/floor/sandstone/runed
 
-/turf/closed/wall/mineral/sandstone/runed/attack_alien(mob/living/carbon/xenomorph/user)
+/turf/closed/wall/mineral/sandstone/runed/attack_alien(mob/living/carbon/xenomorph/user, dam_bonus, directional_assist_attack)
 	visible_message("[user] scrapes uselessly against [src] with their claws.")
 	return
 
@@ -966,7 +966,7 @@
 	else
 		update_icon()
 
-/obj/structure/alien/movable_wall/attack_alien(mob/living/carbon/xenomorph/M)
+/obj/structure/alien/movable_wall/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	if(islarva(M))
 		return FALSE
 
@@ -1176,7 +1176,7 @@
 	take_damage(tforce)
 
 
-/turf/closed/wall/resin/attack_alien(mob/living/carbon/xenomorph/M)
+/turf/closed/wall/resin/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	if(SEND_SIGNAL(src, COMSIG_WALL_RESIN_XENO_ATTACK, M) & COMPONENT_CANCEL_XENO_ATTACK)
 		return XENO_NO_DELAY_ACTION
 

--- a/code/game/turfs/walls/walls.dm
+++ b/code/game/turfs/walls/walls.dm
@@ -111,7 +111,7 @@
 		user_as_xenomorph.do_nesting_host(current_mob, src)
 	..()
 
-/turf/closed/wall/attack_alien(mob/living/carbon/xenomorph/user)
+/turf/closed/wall/attack_alien(mob/living/carbon/xenomorph/user, dam_bonus, directional_assist_attack)
 	if(acided_hole && user.mob_size >= MOB_SIZE_BIG)
 		acided_hole.expand_hole(user) //This proc applies the attack delay itself.
 		return XENO_NO_DELAY_ACTION

--- a/code/modules/assembly/proximity.dm
+++ b/code/modules/assembly/proximity.dm
@@ -184,7 +184,7 @@
 	.["min_delay"] = PROXY_MINIMUM_DELAY
 	.["max_delay"] = PROXY_MAXIMUM_DELAY
 
-/obj/item/device/assembly/prox_sensor/attack_alien(mob/living/carbon/xenomorph/xeno)
+/obj/item/device/assembly/prox_sensor/attack_alien(mob/living/carbon/xenomorph/xeno, dam_bonus, directional_assist_attack)
 	. = ..()
 	if(scanning)
 		playsound(loc, "alien_claw_metal", 25, 1)

--- a/code/modules/clothing/gloves/marine_gloves.dm
+++ b/code/modules/clothing/gloves/marine_gloves.dm
@@ -13,7 +13,7 @@
 	min_cold_protection_temperature = GLOVES_MIN_COLD_PROT
 	max_heat_protection_temperature = GLOVES_MAX_HEAT_PROT
 	flags_armor_protection = BODY_FLAG_HANDS
-	armor_melee = CLOTHING_ARMOR_MEDIUM
+	armor_melee = CLOTHING_ARMOR_LOW
 	armor_bullet = CLOTHING_ARMOR_MEDIUM
 	armor_laser = CLOTHING_ARMOR_LOW
 	armor_energy = CLOTHING_ARMOR_NONE

--- a/code/modules/clothing/head/hardhat.dm
+++ b/code/modules/clothing/head/hardhat.dm
@@ -83,7 +83,7 @@
 		return TRUE
 	return FALSE
 
-/obj/item/clothing/head/hardhat/attack_alien(mob/living/carbon/xenomorph/M)
+/obj/item/clothing/head/hardhat/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	. = ..()
 
 	if(on && can_be_broken)

--- a/code/modules/clothing/shoes/marine_shoes.dm
+++ b/code/modules/clothing/shoes/marine_shoes.dm
@@ -5,14 +5,14 @@
 	desc = "Standard issue combat boots for combat scenarios or combat situations. All combat, all the time."
 	icon_state = "marine"
 	item_state = "marine"
-	armor_melee = CLOTHING_ARMOR_MEDIUM
+	armor_melee = CLOTHING_ARMOR_LOW
 	armor_bullet = CLOTHING_ARMOR_MEDIUM
 	armor_laser = CLOTHING_ARMOR_LOW
 	armor_energy = CLOTHING_ARMOR_NONE
 	armor_bomb = CLOTHING_ARMOR_MEDIUMLOW
 	armor_bio = CLOTHING_ARMOR_MEDIUM
 	armor_rad = CLOTHING_ARMOR_NONE
-	armor_internaldamage = CLOTHING_ARMOR_MEDIUMLOW
+	armor_internaldamage = CLOTHING_ARMOR_LOW
 	flags_cold_protection = BODY_FLAG_FEET
 	flags_heat_protection = BODY_FLAG_FEET
 	min_cold_protection_temperature = SHOE_MIN_COLD_PROT

--- a/code/modules/clothing/suits/marine_armor.dm
+++ b/code/modules/clothing/suits/marine_armor.dm
@@ -47,14 +47,14 @@
 	min_cold_protection_temperature = HELMET_MIN_COLD_PROT
 	max_heat_protection_temperature = HELMET_MAX_HEAT_PROT
 	blood_overlay_type = "armor"
-	armor_melee = CLOTHING_ARMOR_MEDIUM
+	armor_melee = CLOTHING_ARMOR_MEDIUMLOW
 	armor_bullet = CLOTHING_ARMOR_MEDIUM
 	armor_laser = CLOTHING_ARMOR_MEDIUMLOW
 	armor_energy = CLOTHING_ARMOR_NONE
 	armor_bomb = CLOTHING_ARMOR_MEDIUMLOW
 	armor_bio = CLOTHING_ARMOR_MEDIUM
 	armor_rad = CLOTHING_ARMOR_MEDIUMLOW
-	armor_internaldamage = CLOTHING_ARMOR_MEDIUM
+	armor_internaldamage = CLOTHING_ARMOR_MEDIUMLOW
 	movement_compensation = SLOWDOWN_ARMOR_LIGHT
 	storage_slots = 3
 	siemens_coefficient = 0.7
@@ -279,7 +279,7 @@
 	name = "\improper M2 pattern MP armor"
 	desc = "A standard Colonial Marines M2 Pattern Chestplate. Protects the chest from ballistic rounds, bladed objects and accidents. It has a small leather pouch strapped to it for limited storage."
 	icon_state = "mp_armor"
-	armor_melee = CLOTHING_ARMOR_MEDIUMHIGH
+	armor_melee = CLOTHING_ARMOR_MEDIUM
 	armor_bullet = CLOTHING_ARMOR_LOW
 	armor_laser = CLOTHING_ARMOR_LOW
 	armor_energy = CLOTHING_ARMOR_LOW
@@ -471,7 +471,7 @@
 	icon_state = "L1"
 	armor_variation = 6
 	slowdown = SLOWDOWN_ARMOR_LIGHT
-	armor_melee = CLOTHING_ARMOR_MEDIUMLOW
+	armor_melee = CLOTHING_ARMOR_LOW
 	armor_bullet = CLOTHING_ARMOR_MEDIUMLOW
 	armor_bomb = CLOTHING_ARMOR_MEDIUM
 	armor_bio = CLOTHING_ARMOR_MEDIUMLOW
@@ -509,7 +509,7 @@
 	icon_state = "VL"
 	flags_atom = NO_SNOW_TYPE|NO_NAME_OVERRIDE
 	flags_marine_armor = ARMOR_LAMP_OVERLAY //No squad colors when wearing this since it'd look funny.
-	armor_melee = CLOTHING_ARMOR_MEDIUMLOW
+	armor_melee = CLOTHING_ARMOR_LOW
 	armor_bullet = CLOTHING_ARMOR_HIGH
 	armor_energy = CLOTHING_ARMOR_LOW
 	armor_bomb = CLOTHING_ARMOR_LOW
@@ -559,7 +559,7 @@
 	specialty = "\improper M3-EOD pattern"
 	icon_state = "H1"
 	armor_variation = 6
-	armor_melee = CLOTHING_ARMOR_MEDIUMHIGH
+	armor_melee = CLOTHING_ARMOR_MEDIUM
 	armor_bullet = CLOTHING_ARMOR_HIGHPLUS
 	armor_bomb = CLOTHING_ARMOR_HIGHPLUS
 	armor_bio = CLOTHING_ARMOR_MEDIUMHIGH

--- a/code/modules/clothing/under/marine_uniform.dm
+++ b/code/modules/clothing/under/marine_uniform.dm
@@ -8,14 +8,14 @@
 	siemens_coefficient = 0.9
 	icon_state = "marine_jumpsuit"
 	worn_state = "marine_jumpsuit"
-	armor_melee = CLOTHING_ARMOR_LOW
+	armor_melee = CLOTHING_ARMOR_VERYLOW
 	armor_bullet = CLOTHING_ARMOR_LOW
 	armor_laser = CLOTHING_ARMOR_NONE
 	armor_energy = CLOTHING_ARMOR_NONE
 	armor_bomb = CLOTHING_ARMOR_NONE
 	armor_bio = CLOTHING_ARMOR_NONE
 	armor_rad = CLOTHING_ARMOR_NONE
-	armor_internaldamage = CLOTHING_ARMOR_LOW
+	armor_internaldamage = CLOTHING_ARMOR_VERYLOW
 	flags_jumpsuit = UNIFORM_SLEEVE_ROLLABLE
 	///Makes it so that we can see the right name in the vendor.
 	var/specialty = "USCM"

--- a/code/modules/cm_aliens/Ovipositor.dm
+++ b/code/modules/cm_aliens/Ovipositor.dm
@@ -62,7 +62,7 @@
 	health -= severity/4
 
 //Every other type of nonhuman mob
-/obj/ovipositor/attack_alien(mob/living/carbon/xenomorph/M)
+/obj/ovipositor/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	switch(M.a_intent)
 		if(INTENT_HELP)
 			M.visible_message(SPAN_NOTICE("\The [M] caresses [src] with its claws."), \

--- a/code/modules/cm_aliens/XenoStructures.dm
+++ b/code/modules/cm_aliens/XenoStructures.dm
@@ -79,7 +79,7 @@
 	health = max(0, health - tforce)
 	healthcheck()
 
-/obj/effect/alien/resin/attack_alien(mob/living/carbon/xenomorph/M)
+/obj/effect/alien/resin/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	if(islarva(M)) //Larvae can't do shit
 		return
 
@@ -330,7 +330,7 @@
 	if(isxeno(user) || isobserver(user))
 		. += "[mark_meaning.desc], ordered by [xeno_createdby.name]"
 
-/obj/effect/alien/resin/marker/attack_alien(mob/living/carbon/xenomorph/M)
+/obj/effect/alien/resin/marker/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	if(M.hive_pos == 1 || M.nicknumber == createdby)
 		. = ..()
 	else
@@ -813,7 +813,7 @@
 	return ..()
 
 
-/obj/effect/alien/resin/resin_pillar/attack_alien(mob/living/carbon/xenomorph/M)
+/obj/effect/alien/resin/resin_pillar/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	if(!brittle)
 		M.animation_attack_on(src)
 		M.visible_message(SPAN_XENONOTICE("\The [M] claws \the [src], but the slash bounces off!"), \
@@ -882,7 +882,7 @@
 		overlays += I
 
 
-/obj/item/explosive/grenade/alien/attack_alien(mob/living/carbon/xenomorph/M)
+/obj/item/explosive/grenade/alien/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	if(!active)
 		attack_hand(M)
 	else

--- a/code/modules/cm_aliens/structures/construction_node.dm
+++ b/code/modules/cm_aliens/structures/construction_node.dm
@@ -45,7 +45,7 @@
 		var/message = "A [template.name] construction is designated here. It requires [template.crystals_required - template.crystals_stored] more [MATERIAL_CRYSTAL]."
 		. += message
 
-/obj/effect/alien/resin/construction/attack_alien(mob/living/carbon/xenomorph/M)
+/obj/effect/alien/resin/construction/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	if(!linked_hive || (linked_hive && (M.hivenumber != linked_hive.hivenumber)) || (M.a_intent == INTENT_HARM && M.can_destroy_special()))
 		return ..()
 	if(!template)

--- a/code/modules/cm_aliens/structures/egg.dm
+++ b/code/modules/cm_aliens/structures/egg.dm
@@ -45,7 +45,7 @@
 	if(isxeno(user) && status == EGG_GROWN)
 		. += "Ctrl + Click egg to retrieve child into your empty hand if you can carry it."
 
-/obj/effect/alien/egg/attack_alien(mob/living/carbon/xenomorph/M)
+/obj/effect/alien/egg/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	if(status == EGG_BURST || status == EGG_DESTROYED)
 		M.animation_attack_on(src)
 		M.visible_message(SPAN_XENONOTICE("[M] clears the hatched egg."), \

--- a/code/modules/cm_aliens/structures/fruit.dm
+++ b/code/modules/cm_aliens/structures/fruit.dm
@@ -150,7 +150,7 @@
 	update_icon()
 	QDEL_IN(src, 3 SECONDS)
 
-/obj/effect/alien/resin/fruit/attack_alien(mob/living/carbon/xenomorph/affected_xeno)
+/obj/effect/alien/resin/fruit/attack_alien(mob/living/carbon/xenomorph/affected_xeno, dam_bonus, directional_assist_attack)
 	if(picked)
 		to_chat(affected_xeno, SPAN_XENODANGER("This fruit is already being picked!"))
 		return
@@ -433,7 +433,7 @@
 	qdel(src)
 	return TRUE
 
-/obj/item/reagent_container/food/snacks/resin_fruit/attack_alien(mob/living/carbon/xenomorph/M)
+/obj/item/reagent_container/food/snacks/resin_fruit/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	attack_hand(M)
 	return XENO_NONCOMBAT_ACTION
 

--- a/code/modules/cm_aliens/structures/special/egg_morpher.dm
+++ b/code/modules/cm_aliens/structures/special/egg_morpher.dm
@@ -182,7 +182,7 @@
 	var/obj/item/clothing/mask/facehugger/child = new(loc, linked_hive.hivenumber)
 	child.leap_at_nearest_target()
 
-/obj/effect/alien/resin/special/eggmorph/attack_alien(mob/living/carbon/xenomorph/M)
+/obj/effect/alien/resin/special/eggmorph/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	if(!istype(M))
 		return attack_hand(M)
 	if(!linked_hive || (M.hivenumber != linked_hive.hivenumber))

--- a/code/modules/cm_aliens/structures/special/hive_cluster.dm
+++ b/code/modules/cm_aliens/structures/special/hive_cluster.dm
@@ -28,7 +28,7 @@
 	QDEL_NULL(node)
 	return ..()
 
-/obj/effect/alien/resin/special/cluster/attack_alien(mob/living/carbon/xenomorph/M)
+/obj/effect/alien/resin/special/cluster/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	if(isxeno_builder(M) && M.a_intent == INTENT_HELP && M.hivenumber == linked_hive.hivenumber)
 		do_repair(M) //This handles the delay itself.
 		return XENO_NO_DELAY_ACTION

--- a/code/modules/cm_aliens/structures/special/pylon_core.dm
+++ b/code/modules/cm_aliens/structures/special/pylon_core.dm
@@ -39,7 +39,7 @@
 		QDEL_NULL(node)
 	. = ..()
 
-/obj/effect/alien/resin/special/pylon/attack_alien(mob/living/carbon/xenomorph/M)
+/obj/effect/alien/resin/special/pylon/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	if(isxeno_builder(M) && M.a_intent == INTENT_HELP && M.hivenumber == linked_hive.hivenumber)
 		do_repair(M) //This handles the delay itself.
 		return XENO_NO_DELAY_ACTION
@@ -319,7 +319,7 @@
 	linked_hive.stored_larva += larva_amount
 	linked_hive.hive_ui.update_burrowed_larva()
 
-/obj/effect/alien/resin/special/pylon/core/attack_alien(mob/living/carbon/xenomorph/M)
+/obj/effect/alien/resin/special/pylon/core/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	if(M.a_intent != INTENT_HELP && M.can_destroy_special() && M.hivenumber == linked_hive.hivenumber)
 		if(!hardcore && last_attempt + 6 SECONDS > world.time)
 			to_chat(M,SPAN_WARNING("You have attempted to destroy \the [src] too recently! Wait a bit!")) // no spammy

--- a/code/modules/cm_aliens/structures/special_structure.dm
+++ b/code/modules/cm_aliens/structures/special_structure.dm
@@ -69,6 +69,6 @@
 
 	. = ..()
 
-/obj/effect/alien/resin/special/attack_alien(mob/living/carbon/xenomorph/M)
+/obj/effect/alien/resin/special/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	if(M.can_destroy_special() || M.hivenumber != linked_hive.hivenumber)
 		return ..()

--- a/code/modules/cm_aliens/structures/trap.dm
+++ b/code/modules/cm_aliens/structures/trap.dm
@@ -207,7 +207,7 @@
 	QDEL_NULL_LIST(tripwires)
 	tripwires = list()
 
-/obj/effect/alien/resin/trap/attack_alien(mob/living/carbon/xenomorph/X)
+/obj/effect/alien/resin/trap/attack_alien(mob/living/carbon/xenomorph/X, dam_bonus, directional_assist_attack)
 	if(X.hivenumber != hivenumber)
 		return ..()
 

--- a/code/modules/cm_aliens/structures/tunnel.dm
+++ b/code/modules/cm_aliens/structures/tunnel.dm
@@ -194,7 +194,7 @@
 /obj/structure/tunnel/attack_larva(mob/living/carbon/xenomorph/M)
 	. = attack_alien(M)
 
-/obj/structure/tunnel/attack_alien(mob/living/carbon/xenomorph/M)
+/obj/structure/tunnel/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	if(!istype(M) || M.stat || M.lying)
 		return XENO_NO_DELAY_ACTION
 

--- a/code/modules/cm_aliens/structures/xeno_structures_boilertrap.dm
+++ b/code/modules/cm_aliens/structures/xeno_structures_boilertrap.dm
@@ -58,7 +58,7 @@
 	to_chat(M, SPAN_XENOHIGHDANGER("You are caught by a trap made of foul resin!"))
 	qdel(src)
 
-/obj/effect/alien/resin/boilertrap/attack_alien(mob/living/carbon/xenomorph/X)
+/obj/effect/alien/resin/boilertrap/attack_alien(mob/living/carbon/xenomorph/X, dam_bonus, directional_assist_attack)
 	to_chat(X, SPAN_XENOWARNING("Best not to meddle with that trap."))
 	return XENO_NO_DELAY_ACTION
 

--- a/code/modules/cm_aliens/weeds.dm
+++ b/code/modules/cm_aliens/weeds.dm
@@ -353,7 +353,7 @@
 		return
 	take_damage(severity * WEED_EXPLOSION_DAMAGEMULT)
 
-/obj/effect/alien/weeds/attack_alien(mob/living/carbon/xenomorph/attacking_xeno)
+/obj/effect/alien/weeds/attack_alien(mob/living/carbon/xenomorph/attacking_xeno, dam_bonus, directional_assist_attack)
 	if(!indestructible && !HIVE_ALLIED_TO_HIVE(attacking_xeno.hivenumber, hivenumber))
 		attacking_xeno.animation_attack_on(src)
 		attacking_xeno.visible_message(SPAN_DANGER("\The [attacking_xeno] slashes [src]!"), \
@@ -611,7 +611,7 @@
 /obj/effect/alien/weeds/node/pylon/attackby(obj/item/W, mob/living/user)
 	return
 
-/obj/effect/alien/weeds/node/pylon/attack_alien(mob/living/carbon/xenomorph/X)
+/obj/effect/alien/weeds/node/pylon/attack_alien(mob/living/carbon/xenomorph/X, dam_bonus, directional_assist_attack)
 	return
 
 /obj/effect/alien/weeds/node/pylon/flamer_fire_act(dam)

--- a/code/modules/cm_marines/dropship_ammo.dm
+++ b/code/modules/cm_marines/dropship_ammo.dm
@@ -39,8 +39,8 @@
 	var/mob/source_mob
 	var/combat_equipment = TRUE
 
-/obj/structure/ship_ammo/attack_alien(mob/living/carbon/xenomorph/current_xenomorph)
-	if(unslashable) 
+/obj/structure/ship_ammo/attack_alien(mob/living/carbon/xenomorph/current_xenomorph, dam_bonus, directional_assist_attack)
+	if(unslashable)
 		return XENO_NO_DELAY_ACTION
 	current_xenomorph.animation_attack_on(src)
 	playsound(src, 'sound/effects/metalhit.ogg', 25, 1)

--- a/code/modules/cm_marines/dropship_equipment.dm
+++ b/code/modules/cm_marines/dropship_equipment.dm
@@ -33,7 +33,7 @@
 		linked_console = null
 	. = ..()
 
-/obj/structure/dropship_equipment/attack_alien(mob/living/carbon/xenomorph/current_xenomorph)
+/obj/structure/dropship_equipment/attack_alien(mob/living/carbon/xenomorph/current_xenomorph, dam_bonus, directional_assist_attack)
 	if(unslashable)
 		return XENO_NO_DELAY_ACTION
 	current_xenomorph.animation_attack_on(src)

--- a/code/modules/cm_marines/equipment/mortar/mortars.dm
+++ b/code/modules/cm_marines/equipment/mortar/mortars.dm
@@ -56,7 +56,7 @@
 	else
 		return FALSE
 
-/obj/structure/mortar/attack_alien(mob/living/carbon/xenomorph/M)
+/obj/structure/mortar/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	if(islarva(M))
 		return XENO_NO_DELAY_ACTION
 

--- a/code/modules/cm_marines/smartgun_mount.dm
+++ b/code/modules/cm_marines/smartgun_mount.dm
@@ -285,7 +285,7 @@
 	else
 		. += "The M56D isn't screwed into the mount. Use a <b>screwdriver</b> to finish the job."
 
-/obj/structure/machinery/m56d_post/attack_alien(mob/living/carbon/xenomorph/M)
+/obj/structure/machinery/m56d_post/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	if(islarva(M))
 		return //Larvae can't do shit
 
@@ -652,7 +652,7 @@
 	update_health(round(P.damage / 10)) //Universal low damage to what amounts to a post with a gun.
 	return 1
 
-/obj/structure/machinery/m56d_hmg/attack_alien(mob/living/carbon/xenomorph/M) // Those Ayy lmaos.
+/obj/structure/machinery/m56d_hmg/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack) // Those Ayy lmaos.
 	if(islarva(M))
 		return //Larvae can't do shit
 

--- a/code/modules/cm_tech/implements/rev_jelly.dm
+++ b/code/modules/cm_tech/implements/rev_jelly.dm
@@ -11,7 +11,7 @@
 	max_amount = 9
 	var/time_to_take = 3 SECONDS
 
-/obj/item/stack/revival_jelly/attack_alien(mob/living/carbon/xenomorph/M)
+/obj/item/stack/revival_jelly/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	attack_hand(M) //This has a .2 second delay of its own.
 	return XENO_NO_DELAY_ACTION
 

--- a/code/modules/cm_tech/resources/resource.dm
+++ b/code/modules/cm_tech/resources/resource.dm
@@ -152,7 +152,7 @@
 	H.visible_message(SPAN_DANGER("[H] sets up [src]."),\
 	SPAN_NOTICE("You set up [src]."), max_distance = 3)
 
-/obj/structure/resource_node/attack_alien(mob/living/carbon/xenomorph/M)
+/obj/structure/resource_node/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	if(!isxeno_builder(M))
 		to_chat(M, SPAN_XENOWARNING("You can't build onto [src]."))
 		return XENO_NO_DELAY_ACTION

--- a/code/modules/defenses/sentry.dm
+++ b/code/modules/defenses/sentry.dm
@@ -595,7 +595,7 @@
 	handheld_type = /obj/item/defenses/handheld/sentry/shotgun
 	disassemble_time = 1.5 SECONDS
 
-/obj/structure/machinery/defenses/sentry/shotgun/attack_alien(mob/living/carbon/xenomorph/M)
+/obj/structure/machinery/defenses/sentry/shotgun/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	. = ..()
 	if(. == XENO_ATTACK_ACTION && turned_on)
 		M.visible_message(SPAN_DANGER("The sentry's steel tusks cut into [M]!"),

--- a/code/modules/desert_dam/motion_sensor/sensortower.dm
+++ b/code/modules/desert_dam/motion_sensor/sensortower.dm
@@ -194,7 +194,7 @@
 	else
 		return ..() //Deal with everything else, like hitting with stuff
 
-/obj/structure/machinery/sensortower/attack_alien(mob/living/carbon/xenomorph/M)
+/obj/structure/machinery/sensortower/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	if(buildstate == SENSORTOWER_BUILDSTATE_BLOWTORCH)
 		to_chat(M, SPAN_WARNING("You stare at \the [src] cluelessly."))
 		return XENO_NO_DELAY_ACTION

--- a/code/modules/droppod/container_droppod.dm
+++ b/code/modules/droppod/container_droppod.dm
@@ -97,7 +97,7 @@
 		dropoff_point = null
 
 
-/obj/structure/droppod/container/attack_alien(mob/living/carbon/xenomorph/M)
+/obj/structure/droppod/container/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	if(!(droppod_flags & DROPPOD_DROPPED) || !can_be_opened || (droppod_flags & DROPPOD_OPEN))
 		return
 

--- a/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
@@ -101,7 +101,7 @@
 	return ..()
 
 //Deal with picking up facehuggers. "attack_alien" is the universal 'xenos click something while unarmed' proc.
-/obj/item/clothing/mask/facehugger/attack_alien(mob/living/carbon/xenomorph/user)
+/obj/item/clothing/mask/facehugger/attack_alien(mob/living/carbon/xenomorph/user, dam_bonus, directional_assist_attack)
 	if(user.hivenumber != hivenumber)
 		user.animation_attack_on(src)
 		user.visible_message(SPAN_XENOWARNING("[user] crushes \the [src]"), SPAN_XENOWARNING("You crush \the [src]"))

--- a/code/modules/mob/living/carbon/xenomorph/XenoAttacks.dm
+++ b/code/modules/mob/living/carbon/xenomorph/XenoAttacks.dm
@@ -89,7 +89,7 @@
 
 //Hot hot Aliens on Aliens action.
 //Actually just used for eating people.
-/mob/living/carbon/xenomorph/attack_alien(mob/living/carbon/xenomorph/M)
+/mob/living/carbon/xenomorph/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	if (M.fortify || M.burrow)
 		return XENO_NO_DELAY_ACTION
 

--- a/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
@@ -325,7 +325,7 @@
 	pounceAction.additional_effects(M)
 
 	if(pounceAction.slash)
-		M.attack_alien(src, pounceAction.slash_bonus_damage)
+		M.attack_alien(src, dam_bonus = pounceAction.slash_bonus_damage)
 
 	throwing = FALSE //Reset throwing since something was hit.
 

--- a/code/modules/mob/living/carbon/xenomorph/abilities/ravager/ravager_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/ravager/ravager_powers.dm
@@ -129,7 +129,7 @@
 		return
 	X.visible_message(SPAN_XENODANGER("The [X] uses its shield to bash [H] as it charges at them!"), SPAN_XENODANGER("You use your shield to bash [H] as you charge at them!"))
 	H.apply_effect(BD.knockdown_amount, WEAKEN)
-	H.attack_alien(X, rand(X.melee_damage_lower, X.melee_damage_upper))
+	H.attack_alien(X, dam_bonus = rand(X.melee_damage_lower, X.melee_damage_upper))
 
 	var/facing = get_dir(X, H)
 	var/turf/T = X.loc

--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -8,7 +8,7 @@
  */
 
 
-/mob/living/carbon/human/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus)
+/mob/living/carbon/human/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	if(M.fortify || M.burrow)
 		return XENO_NO_DELAY_ACTION
 
@@ -92,11 +92,9 @@
 
 			M.flick_attack_overlay(src, "slash")
 			var/obj/limb/affecting
-			affecting = get_limb(rand_zone(M.zone_selected, 70))
-			if(!affecting) //No organ, just get a random one
-				affecting = get_limb(rand_zone(null, 0))
-			if(!affecting) //Still nothing??
-				affecting = get_limb("chest") //Gotta have a torso?!
+			affecting = get_limb(rand_zone(M.zone_selected, directional_assist_attack ? 25 : 70))
+			if(!affecting)
+				affecting = get_limb("chest") //Default to torso if we don't get a proper limb
 
 			var/armor_block = getarmor(affecting, ARMOR_MELEE)
 
@@ -219,7 +217,7 @@
 
 
 //Every other type of nonhuman mob
-/mob/living/attack_alien(mob/living/carbon/xenomorph/M)
+/mob/living/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	if(M.fortify || M.burrow)
 		return XENO_NO_DELAY_ACTION
 
@@ -307,14 +305,14 @@
 
 //This proc is here to prevent Xenomorphs from picking up objects (default attack_hand behaviour)
 //Note that this is overriden by every proc concerning a child of obj unless inherited
-/obj/item/attack_alien(mob/living/carbon/xenomorph/M)
+/obj/item/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	return
 
 /obj/attack_larva(mob/living/carbon/xenomorph/larva/M)
 	return //larva can't do anything
 
 //Breaking tables and racks
-/obj/structure/surface/table/attack_alien(mob/living/carbon/xenomorph/M)
+/obj/structure/surface/table/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	if(breakable)
 		M.animation_attack_on(src)
 		if(sheet_type == /obj/item/stack/sheet/wood)
@@ -332,7 +330,7 @@
 		return XENO_ATTACK_ACTION
 
 //Breaking barricades
-/obj/structure/barricade/attack_alien(mob/living/carbon/xenomorph/M)
+/obj/structure/barricade/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	M.animation_attack_on(src)
 	take_damage( rand(M.melee_damage_lower, M.melee_damage_upper) * brute_multiplier)
 	if(barricade_hitsound)
@@ -362,7 +360,7 @@
 		xeno.apply_damage(5)
 	return TAILSTAB_COOLDOWN_NORMAL
 
-/obj/structure/surface/rack/attack_alien(mob/living/carbon/xenomorph/M)
+/obj/structure/surface/rack/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	M.animation_attack_on(src)
 	playsound(src, 'sound/effects/metalhit.ogg', 25, 1)
 	M.visible_message(SPAN_DANGER("[M] slices [src] apart!"), \
@@ -372,7 +370,7 @@
 
 //Default "structure" proc. This should be overwritten by sub procs.
 //If we sent it to monkey we'd get some weird shit happening.
-/obj/structure/attack_alien(mob/living/carbon/xenomorph/M)
+/obj/structure/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	// fuck off dont destroy my unslashables
 	if(unslashable || health <= 0)
 		to_chat(M, SPAN_WARNING("You stare at \the [src] cluelessly."))
@@ -380,7 +378,7 @@
 
 
 //Beds, nests and chairs - unbuckling
-/obj/structure/bed/attack_alien(mob/living/carbon/xenomorph/M)
+/obj/structure/bed/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	if(M.a_intent == INTENT_HARM)
 		if(unslashable)
 			return
@@ -397,17 +395,17 @@
 
 
 //Medevac stretchers. Unbuckle ony
-/obj/structure/bed/medevac_stretcher/attack_alien(mob/living/carbon/xenomorph/M)
+/obj/structure/bed/medevac_stretcher/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	unbuckle()
 	return XENO_NONCOMBAT_ACTION
 
 //Portable surgical bed. Ditto, though it's meltable.
-/obj/structure/bed/portable_surgery/attack_alien(mob/living/carbon/xenomorph/M)
+/obj/structure/bed/portable_surgery/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	unbuckle()
 	return XENO_NONCOMBAT_ACTION
 
 //Smashing lights
-/obj/structure/machinery/light/attack_alien(mob/living/carbon/xenomorph/M)
+/obj/structure/machinery/light/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	if(is_broken()) //Ignore if broken. Note that we can't use defines here
 		return FALSE
 	M.animation_attack_on(src)
@@ -417,7 +415,7 @@
 	return XENO_ATTACK_ACTION
 
 //Smashing windows
-/obj/structure/window/attack_alien(mob/living/carbon/xenomorph/M)
+/obj/structure/window/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	if(M.a_intent == INTENT_HELP)
 		playsound(loc, 'sound/effects/glassknock.ogg', 25, 1)
 		M.visible_message(SPAN_WARNING("[M] creepily taps on [src] with its huge claw."), \
@@ -428,7 +426,7 @@
 	return XENO_ATTACK_ACTION
 
 //Slashing bots
-/obj/structure/machinery/bot/attack_alien(mob/living/carbon/xenomorph/M)
+/obj/structure/machinery/bot/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	M.animation_attack_on(src)
 	health -= rand(15, 30)
 	if(health <= 0)
@@ -444,7 +442,7 @@
 	return XENO_ATTACK_ACTION
 
 //Slashing cameras
-/obj/structure/machinery/camera/attack_alien(mob/living/carbon/xenomorph/M)
+/obj/structure/machinery/camera/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	if(status)
 		M.visible_message(SPAN_DANGER("[M] slices [src] apart!"), \
 		SPAN_DANGER("You slice [src] apart!"), null, 5, CHAT_TYPE_XENO_COMBAT)
@@ -455,7 +453,7 @@
 		return XENO_ATTACK_ACTION
 
 //Slashing windoors
-/obj/structure/machinery/door/window/attack_alien(mob/living/carbon/xenomorph/M)
+/obj/structure/machinery/door/window/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	M.animation_attack_on(src)
 	playsound(loc, 'sound/effects/Glasshit.ogg', 25, 1)
 	M.visible_message(SPAN_DANGER("[M] smashes against [src]!"), \
@@ -467,7 +465,7 @@
 	return XENO_ATTACK_ACTION
 
 //Slashing grilles
-/obj/structure/grille/attack_alien(mob/living/carbon/xenomorph/M)
+/obj/structure/grille/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	M.animation_attack_on(src)
 	playsound(loc, 'sound/effects/grillehit.ogg', 25, 1)
 	var/damage_dealt = 5
@@ -486,7 +484,7 @@
 	return XENO_ATTACK_ACTION
 
 //Slashing fences
-/obj/structure/fence/attack_alien(mob/living/carbon/xenomorph/M)
+/obj/structure/fence/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	M.animation_attack_on(src)
 	var/damage_dealt = 5
 	M.visible_message(SPAN_DANGER("[M] mangles [src]!"), \
@@ -498,7 +496,7 @@
 	return XENO_ATTACK_ACTION
 
 //Slashin mirrors
-/obj/structure/mirror/attack_alien(mob/living/carbon/xenomorph/M)
+/obj/structure/mirror/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	M.animation_attack_on(src)
 	if(shattered)
 		playsound(loc, 'sound/effects/hit_on_shattered_glass.ogg', 25, 1)
@@ -515,7 +513,7 @@
 	return XENO_ATTACK_ACTION
 
 //Prying open doors
-/obj/structure/machinery/door/airlock/attack_alien(mob/living/carbon/xenomorph/M)
+/obj/structure/machinery/door/airlock/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	var/turf/cur_loc = M.loc
 	if(isElectrified())
 		if(shock(M, 100))
@@ -593,7 +591,7 @@
 	M.scuttle(src)
 
 //Prying open FIREdoors
-/obj/structure/machinery/door/firedoor/attack_alien(mob/living/carbon/xenomorph/M)
+/obj/structure/machinery/door/firedoor/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	var/turf/cur_loc = M.loc
 	if(blocked)
 		to_chat(M, SPAN_WARNING("[src] is welded shut."))
@@ -630,7 +628,7 @@
 	return TRUE
 
 //clicking on resin doors attacks them, or opens them without harm intent
-/obj/structure/mineral_door/resin/attack_alien(mob/living/carbon/xenomorph/M)
+/obj/structure/mineral_door/resin/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	var/turf/cur_loc = M.loc
 	if(!istype(cur_loc))
 		return XENO_NO_DELAY_ACTION //Some basic logic here
@@ -656,7 +654,7 @@
 
 //Xenomorphs can't use machinery, not even the "intelligent" ones
 //Exception is Queen and shuttles, because plot power
-/obj/structure/machinery/attack_alien(mob/living/carbon/xenomorph/M)
+/obj/structure/machinery/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	if(unslashable || health <= 0)
 		to_chat(M, SPAN_WARNING("You stare at \the [src] cluelessly."))
 		return XENO_NO_DELAY_ACTION
@@ -675,7 +673,7 @@
 	return XENO_ATTACK_ACTION
 
 // Destroying reagent dispensers
-/obj/structure/reagent_dispensers/attack_alien(mob/living/carbon/xenomorph/M)
+/obj/structure/reagent_dispensers/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	if(unslashable || health <= 0)
 		to_chat(M, SPAN_WARNING("You stare at \the [src] cluelessly."))
 		return XENO_NO_DELAY_ACTION
@@ -694,7 +692,7 @@
 	return XENO_ATTACK_ACTION
 
 // Destroying filing cabinets
-/obj/structure/filingcabinet/attack_alien(mob/living/carbon/xenomorph/M)
+/obj/structure/filingcabinet/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	if(unslashable || health <= 0)
 		to_chat(M, SPAN_WARNING("You stare at \the [src] cluelessly."))
 		return XENO_NO_DELAY_ACTION
@@ -713,7 +711,7 @@
 	return XENO_ATTACK_ACTION
 
 // Destroying morgues & crematoriums
-/obj/structure/morgue/attack_alien(mob/living/carbon/xenomorph/alien)
+/obj/structure/morgue/attack_alien(mob/living/carbon/xenomorph/alien, dam_bonus, directional_assist_attack)
 	if(unslashable)
 		to_chat(alien, SPAN_WARNING("You stare at \the [src] cluelessly."))
 		return XENO_NO_DELAY_ACTION
@@ -732,7 +730,7 @@
 	return XENO_ATTACK_ACTION
 
 // Destroying hydroponics trays
-/obj/structure/machinery/portable_atmospherics/hydroponics/attack_alien(mob/living/carbon/xenomorph/alien)
+/obj/structure/machinery/portable_atmospherics/hydroponics/attack_alien(mob/living/carbon/xenomorph/alien, dam_bonus, directional_assist_attack)
 	if(unslashable)
 		to_chat(alien, SPAN_WARNING("You stare at \the [src] cluelessly."))
 		return XENO_NO_DELAY_ACTION
@@ -800,7 +798,7 @@
 		reardoor.unlock()
 
 //APCs.
-/obj/structure/machinery/power/apc/attack_alien(mob/living/carbon/xenomorph/M)
+/obj/structure/machinery/power/apc/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 
 	if(stat & BROKEN)
 		to_chat(M, SPAN_XENONOTICE("[src] is already broken!"))
@@ -830,14 +828,14 @@
 		beenhit++
 	return XENO_ATTACK_ACTION
 
-/obj/structure/ladder/attack_alien(mob/living/carbon/xenomorph/M)
+/obj/structure/ladder/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	attack_hand(M)
 	return XENO_NO_DELAY_ACTION
 
 /obj/structure/ladder/attack_larva(mob/living/carbon/xenomorph/larva/M)
 	return attack_hand(M)
 
-/obj/structure/machinery/colony_floodlight/attack_alien(mob/living/carbon/xenomorph/M)
+/obj/structure/machinery/colony_floodlight/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	if(!is_lit)
 		to_chat(M, "Why bother? It's just some weird metal thing.")
 		return XENO_NO_DELAY_ACTION
@@ -863,7 +861,7 @@
 
 
 //Digging up snow
-/turf/open/snow/attack_alien(mob/living/carbon/xenomorph/M)
+/turf/open/snow/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	if(M.a_intent == INTENT_HARM) //Missed slash.
 		return
 	if(M.a_intent == INTENT_HELP || !bleed_layer)
@@ -891,7 +889,7 @@
 
 
 //Crates, closets, other paraphernalia
-/obj/structure/closet/attack_alien(mob/living/carbon/xenomorph/M)
+/obj/structure/closet/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	if(!unacidable)
 		M.animation_attack_on(src)
 		if(!opened)
@@ -907,7 +905,7 @@
 			SPAN_DANGER("You smash [src]!"), null, 5, CHAT_TYPE_XENO_COMBAT)
 		return XENO_ATTACK_ACTION
 
-/obj/structure/girder/attack_alien(mob/living/carbon/xenomorph/M)
+/obj/structure/girder/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	if((M.caste && M.caste.tier < 2 && !isqueen(M)) || unacidable)
 		to_chat(M, SPAN_WARNING("Your claws aren't sharp enough to damage [src]."))
 		return XENO_NO_DELAY_ACTION
@@ -924,7 +922,7 @@
 		playsound(loc, 'sound/effects/metalhit.ogg', 25, TRUE)
 	return XENO_ATTACK_ACTION
 
-/obj/structure/machinery/vending/attack_alien(mob/living/carbon/xenomorph/M)
+/obj/structure/machinery/vending/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	if(is_tipped_over)
 		to_chat(M, SPAN_WARNING("There's no reason to bother with that old piece of trash."))
 		return XENO_NO_DELAY_ACTION
@@ -962,7 +960,7 @@
 	return XENO_NO_DELAY_ACTION
 
 
-/obj/structure/inflatable/attack_alien(mob/living/carbon/xenomorph/M)
+/obj/structure/inflatable/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	M.animation_attack_on(src)
 	deflate(1)
 	return XENO_ATTACK_ACTION
@@ -984,7 +982,7 @@
 	stat &= ~BROKEN //Remove broken. MAGICAL REPAIRS
 
 //Misc
-/obj/structure/prop/invuln/joey/attack_alien(mob/living/carbon/xenomorph/alien)
+/obj/structure/prop/invuln/joey/attack_alien(mob/living/carbon/xenomorph/alien, dam_bonus, directional_assist_attack)
 	alien.animation_attack_on(src)
 	alien.visible_message(SPAN_DANGER("[alien] [alien.slashes_verb] [src]!"), \
 	SPAN_DANGER("You [alien.slash_verb] [src]!"), null, 5)

--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -92,7 +92,7 @@
 
 			M.flick_attack_overlay(src, "slash")
 			var/obj/limb/affecting
-			affecting = get_limb(rand_zone(M.zone_selected, directional_assist_attack ? 25 : 70))
+			affecting = get_limb(rand_zone(M.zone_selected, directional_assist_attack ? 25 : 50))
 			if(!affecting)
 				affecting = get_limb("chest") //Default to torso if we don't get a proper limb
 

--- a/code/modules/mob/living/carbon/xenomorph/egg_item.dm
+++ b/code/modules/mob/living/carbon/xenomorph/egg_item.dm
@@ -145,7 +145,7 @@
 
 
 //Deal with picking up facehuggers. "attack_alien" is the universal 'xenos click something while unarmed' proc.
-/obj/item/xeno_egg/attack_alien(mob/living/carbon/xenomorph/user)
+/obj/item/xeno_egg/attack_alien(mob/living/carbon/xenomorph/user, dam_bonus, directional_assist_attack)
 	if(user.caste.can_hold_eggs == CAN_HOLD_ONE_HAND)
 		attack_hand(user)
 		return XENO_NO_DELAY_ACTION

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -96,23 +96,21 @@ var/global/list/limb_types_by_name = list(
 		if (prob(probability))
 			return zone
 
-	var/rand_zone = zone
-	while (rand_zone == zone)
-		rand_zone = pick (
-			organ_rel_size["head"]; "head",
-			organ_rel_size["chest"]; "chest",
-			organ_rel_size["groin"]; "groin",
-			organ_rel_size["l_arm"]; "l_arm",
-			organ_rel_size["r_arm"]; "r_arm",
-			organ_rel_size["l_leg"]; "l_leg",
-			organ_rel_size["r_leg"]; "r_leg",
-			organ_rel_size["l_hand"]; "l_hand",
-			organ_rel_size["r_hand"]; "r_hand",
-			organ_rel_size["l_foot"]; "l_foot",
-			organ_rel_size["r_foot"]; "r_foot",
-		)
+	zone = pick (
+		organ_rel_size["head"]; "head",
+		organ_rel_size["chest"]; "chest",
+		organ_rel_size["groin"]; "groin",
+		organ_rel_size["l_arm"]; "l_arm",
+		organ_rel_size["r_arm"]; "r_arm",
+		organ_rel_size["l_leg"]; "l_leg",
+		organ_rel_size["r_leg"]; "r_leg",
+		organ_rel_size["l_hand"]; "l_hand",
+		organ_rel_size["r_hand"]; "r_hand",
+		organ_rel_size["l_foot"]; "l_foot",
+		organ_rel_size["r_foot"]; "r_foot",
+	)
 
-	return rand_zone
+	return zone
 
 /proc/stars(message, clear_char_probability = 25)
 	clear_char_probability = max(clear_char_probability, 0)

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -163,7 +163,7 @@
 	unslashable = TRUE
 	unacidable = TRUE
 
-/obj/structure/machinery/light/containment/attack_alien(mob/living/carbon/xenomorph/M)
+/obj/structure/machinery/light/containment/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	return
 
 /obj/structure/machinery/light/blue

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -102,7 +102,7 @@ display round(lastgen) and phorontank amount
 	else
 		. += SPAN_NOTICE("The generator is off.")
 
-/obj/structure/machinery/power/port_gen/attack_alien(mob/living/carbon/xenomorph/attacking_xeno)
+/obj/structure/machinery/power/port_gen/attack_alien(mob/living/carbon/xenomorph/attacking_xeno, dam_bonus, directional_assist_attack)
 	if(!active && !anchored)
 		return ..()
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -1730,7 +1730,7 @@ not all weapons use normal magazines etc. load_into_chamber() itself is designed
 	I.transform = rotate
 	I.flick_overlay(user, 3)
 
-/obj/item/weapon/gun/attack_alien(mob/living/carbon/xenomorph/xeno)
+/obj/item/weapon/gun/attack_alien(mob/living/carbon/xenomorph/xeno, dam_bonus, directional_assist_attack)
 	..()
 	var/slashed_light = FALSE
 	for(var/slot in attachments)

--- a/code/modules/shuttle/computer.dm
+++ b/code/modules/shuttle/computer.dm
@@ -298,7 +298,7 @@
 			if(SHUTTLE_CALL)
 				to_chat(user, SPAN_NOTICE("\The [src] has flight information scrolling across the screen. The autopilot is working correctly."))
 
-/obj/structure/machinery/computer/shuttle/lifeboat/attack_alien(mob/living/carbon/xenomorph/xeno)
+/obj/structure/machinery/computer/shuttle/lifeboat/attack_alien(mob/living/carbon/xenomorph/xeno, dam_bonus, directional_assist_attack)
 	if(xeno.caste && xeno.caste.is_intelligent)
 		var/obj/docking_port/mobile/lifeboat/lifeboat = SSshuttle.getShuttle(shuttleId)
 		if(lifeboat.status == LIFEBOAT_LOCKED)

--- a/code/modules/shuttle/computers/dropship_computer.dm
+++ b/code/modules/shuttle/computers/dropship_computer.dm
@@ -190,7 +190,7 @@
 			return
 
 
-/obj/structure/machinery/computer/shuttle/dropship/flight/attack_alien(mob/living/carbon/xenomorph/xeno)
+/obj/structure/machinery/computer/shuttle/dropship/flight/attack_alien(mob/living/carbon/xenomorph/xeno, dam_bonus, directional_assist_attack)
 	if(!is_ground_level(z))
 		to_chat(xeno, SPAN_NOTICE("Lights flash from the terminal but you can't comprehend their meaning."))
 		playsound(loc, 'sound/machines/terminal_error.ogg', KEYBOARD_SOUND_VOLUME, 1)

--- a/code/modules/shuttle/computers/escape_pod_computer.dm
+++ b/code/modules/shuttle/computers/escape_pod_computer.dm
@@ -169,7 +169,7 @@
 		user.stop_pulling()
 		move_mob_inside(user)
 
-/obj/structure/machinery/cryopod/evacuation/attack_alien(mob/living/carbon/xenomorph/user)
+/obj/structure/machinery/cryopod/evacuation/attack_alien(mob/living/carbon/xenomorph/user, dam_bonus, directional_assist_attack)
 	if(being_forced)
 		to_chat(user, SPAN_XENOWARNING("It's being forced open already!"))
 		return XENO_NO_DELAY_ACTION
@@ -226,19 +226,19 @@
 /obj/structure/machinery/door/airlock/evacuation/attack_hand()
 	return FALSE
 
-/obj/structure/machinery/door/airlock/evacuation/attack_alien(mob/living/carbon/xenomorph/xeno)
+/obj/structure/machinery/door/airlock/evacuation/attack_alien(mob/living/carbon/xenomorph/xeno, dam_bonus, directional_assist_attack)
 	if(!density || unslashable) //doors become slashable after evac is called
 		return FALSE
-	
+
 	if(xeno.claw_type < CLAW_TYPE_SHARP)
 		to_chat(xeno, SPAN_WARNING("[src] is bolted down tight."))
 		return XENO_NO_DELAY_ACTION
-	
+
 	xeno.animation_attack_on(src)
 	playsound(src, 'sound/effects/metalhit.ogg', 25, 1)
 	take_damage(HEALTH_DOOR / XENO_HITS_TO_DESTROY_BOLTED_DOOR)
 	return XENO_ATTACK_ACTION
-			
+
 
 /obj/structure/machinery/door/airlock/evacuation/attack_remote()
 	return FALSE

--- a/code/modules/teleporters/teleporter_console.dm
+++ b/code/modules/teleporters/teleporter_console.dm
@@ -29,7 +29,7 @@
 
 	tgui_interact(user)
 
-/obj/structure/machinery/computer/teleporter_console/attack_alien(mob/living/carbon/xenomorph/X)
+/obj/structure/machinery/computer/teleporter_console/attack_alien(mob/living/carbon/xenomorph/X, dam_bonus, directional_assist_attack)
 	if(!isqueen(X))
 		return FALSE
 	attack_hand(X)

--- a/code/modules/tents/deployed_tents.dm
+++ b/code/modules/tents/deployed_tents.dm
@@ -81,7 +81,7 @@
 	SIGNAL_HANDLER
 	deleting_tent.mob_exited_tent(src)
 
-/obj/structure/tent/attack_alien(mob/living/carbon/xenomorph/M)
+/obj/structure/tent/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	if(unslashable)
 		return
 

--- a/code/modules/tents/equipment.dm
+++ b/code/modules/tents/equipment.dm
@@ -106,7 +106,7 @@
 		update_icon()
 		return TRUE
 
-/obj/structure/tent_curtain/attack_alien(mob/living/carbon/xenomorph/M)
+/obj/structure/tent_curtain/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	if(unslashable)
 		return
 	visible_message(SPAN_BOLDWARNING("[src] gets torn to shreds!"))

--- a/code/modules/vehicles/interior/interactable/doors.dm
+++ b/code/modules/vehicles/interior/interactable/doors.dm
@@ -50,7 +50,7 @@
 
 	interior.exit(M)
 
-/obj/structure/interior_exit/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus)
+/obj/structure/interior_exit/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	to_chat(M, SPAN_NOTICE("You start climbing out of \the [interior.exterior]."))
 	if(!do_after(M, 1 SECONDS, INTERRUPT_NO_NEEDHAND, BUSY_ICON_GENERIC))
 		to_chat(M, SPAN_WARNING("Something has interrupted you."))
@@ -126,7 +126,7 @@
 
 	interior.exit(M, exit_turf)
 
-/obj/structure/interior_exit/vehicle/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus)
+/obj/structure/interior_exit/vehicle/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus, directional_assist_attack)
 	to_chat(M, SPAN_NOTICE("You start climbing out of \the [interior.exterior]."))
 	if(!do_after(M, 1 SECONDS, INTERRUPT_NO_NEEDHAND, BUSY_ICON_GENERIC))
 		to_chat(M, SPAN_WARNING("Something has interrupted you."))

--- a/code/modules/vehicles/interior/interactable/seats.dm
+++ b/code/modules/vehicles/interior/interactable/seats.dm
@@ -120,7 +120,7 @@
 /obj/structure/bed/chair/comfy/vehicle/attackby(obj/item/W, mob/living/user)
 	return
 
-/obj/structure/bed/chair/comfy/vehicle/attack_alien(mob/living/carbon/xenomorph/X, dam_bonus)
+/obj/structure/bed/chair/comfy/vehicle/attack_alien(mob/living/carbon/xenomorph/X, dam_bonus, directional_assist_attack)
 
 	if(X.is_mob_incapacitated() || !Adjacent(X))
 		return
@@ -401,7 +401,7 @@
 
 //attack handling
 
-/obj/structure/bed/chair/vehicle/attack_alien(mob/living/user)
+/obj/structure/bed/chair/vehicle/attack_alien(mob/living/user, dam_bonus, directional_assist_attack)
 	if(!unslashable)
 		user.visible_message(SPAN_WARNING("[user] smashes \the [src]!"),
 		SPAN_WARNING("You smash \the [src]!"))

--- a/code/modules/vehicles/multitile/multitile_interaction.dm
+++ b/code/modules/vehicles/multitile/multitile_interaction.dm
@@ -236,7 +236,7 @@
 
 	user.forceMove(middle)
 
-/obj/vehicle/multitile/attack_alien(mob/living/carbon/xenomorph/X)
+/obj/vehicle/multitile/attack_alien(mob/living/carbon/xenomorph/X, dam_bonus, directional_assist_attack)
 	// If they're on help intent, attempt to enter the vehicle
 	if(X.a_intent == INTENT_HELP)
 		handle_player_entrance(X)

--- a/code/modules/vehicles/vehicle.dm
+++ b/code/modules/vehicles/vehicle.dm
@@ -126,7 +126,7 @@
 /obj/vehicle/attack_remote(mob/user as mob)
 	return
 
-/obj/vehicle/attack_alien(mob/living/carbon/xenomorph/attacking_xeno)
+/obj/vehicle/attack_alien(mob/living/carbon/xenomorph/attacking_xeno, dam_bonus, directional_assist_attack)
 	if(attacking_xeno.a_intent == INTENT_HELP)
 		return XENO_NO_DELAY_ACTION
 


### PR DESCRIPTION

# About the pull request

This PR:

Lowers marine melee armor across the board

Changes xeno area target probability from 70 to 25 if it is an attack using directional assist

Changes xeno area target probability from 70 to 50 if clicked on without using directional assist

# Explain why it's good for the game

Actually clicking on a target should be rewarded.

Should help slightly with the hand/feet meta.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
balance: Lowered marine melee armor across the board
balance: Changed xeno area target probability from 70 to 25 if it is an attack using directional assist
balance: Changed xeno area target probability from 70 to 50 if clicked on without using directional assist
/:cl:
