### PR TITLE
Remove ckey from queen jellies

### DIFF
--- a/code/datums/medal_awards.dm
+++ b/code/datums/medal_awards.dm
@@ -20,9 +20,10 @@ GLOBAL_LIST_EMPTY(jelly_awards)
 	var/recipient_rank
 	var/recipient_ckey
 	var/mob/recipient_mob
-	var/list/giver_name // Actually key for xenos
-	var/list/giver_rank // Actually name for xenos
+	var/list/giver_name // Designation for xenos
+	var/list/giver_rank // "Name" for xenos
 	var/list/giver_mob
+	var/list/giver_ckey
 
 /datum/recipient_awards/New()
 	medal_names = list()
@@ -32,6 +33,7 @@ GLOBAL_LIST_EMPTY(jelly_awards)
 	giver_name = list()
 	giver_rank = list()
 	giver_mob = list()
+	giver_ckey = list()
 
 
 /proc/give_medal_award(medal_location, as_admin = FALSE)
@@ -116,12 +118,13 @@ GLOBAL_LIST_EMPTY(jelly_awards)
 	recipient_award.medal_names += medal_type
 	recipient_award.medal_citations += citation
 	recipient_award.posthumous += posthumous
+	recipient_award.giver_ckey += usr.ckey
 
 	if(!as_admin)
 		recipient_award.giver_rank += recipient_ranks[usr.real_name] // Currently not used in marine award message
 		recipient_award.giver_name += usr.real_name // Currently not used in marine award message
 	else
-		recipient_award.giver_rank += "([usr.ckey])" // Just because it'll be displayed in the panel
+		recipient_award.giver_rank += null
 		recipient_award.giver_name += null
 
 	// Create an actual medal item
@@ -258,15 +261,21 @@ GLOBAL_LIST_EMPTY(jelly_awards)
 	recipient_award.medal_names += medal_type
 	recipient_award.medal_citations += citation
 	recipient_award.posthumous += posthumous
+	recipient_award.giver_ckey += usr.ckey
+
 	if(!admin_attribution)
 		recipient_award.giver_rank += usr.name
-		recipient_award.giver_name += usr.key
+		var/mob/living/carbon/xenomorph/giving_xeno = usr
+		if(istype(giving_xeno))
+			recipient_award.giver_name += giving_xeno.full_designation
+		else
+			recipient_award.giver_name += null
 	else if(admin_attribution == "none")
 		recipient_award.giver_rank += null
 		recipient_award.giver_name += null
 	else
 		recipient_award.giver_rank += admin_attribution
-		recipient_award.giver_name += null // If not null, rescinding it will take stats away from a mob with this key
+		recipient_award.giver_name += null
 
 	recipient_award.medal_items += null // TODO: Xeno award item?
 
@@ -337,6 +346,7 @@ GLOBAL_LIST_EMPTY(jelly_awards)
 		recipient_award.giver_name.Cut(index, index + 1)
 		recipient_award.giver_rank.Cut(index, index + 1)
 		recipient_award.giver_mob.Cut(index, index + 1)
+		recipient_award.giver_ckey.Cut(index, index + 1)
 		recipient_award.medal_items.Cut(index, index + 1)
 
 	// Remove giver's stat

--- a/code/modules/admin/medal_panel/medals_panel_tgui.dm
+++ b/code/modules/admin/medal_panel/medals_panel_tgui.dm
@@ -19,22 +19,22 @@ GLOBAL_DATUM_INIT(medals_panel, /datum/medals_panel_tgui, new)
 	var/list/xeno_awards = list()
 	var/list/uscm_award_ckeys = list()
 	var/list/xeno_award_ckeys = list()
-	
+
 	// Break the medals up by recipient and then pack each medal into a string
 	for(var/recipient_name as anything in GLOB.medal_awards)
 		var/datum/recipient_awards/recipient_award = GLOB.medal_awards[recipient_name]
 		uscm_awards[recipient_name] = list()
 		uscm_award_ckeys[recipient_name] = recipient_award.recipient_ckey ? " ([recipient_award.recipient_ckey])" : ""
 		for(var/i in 1 to recipient_award.medal_names.len) // We're assuming everything is same length
-			uscm_awards[recipient_name] += "[recipient_award.medal_names[i]]: \'[recipient_award.medal_citations[i]]\' by [recipient_award.giver_rank[i]] [recipient_award.giver_name[i]]."
-		
+			uscm_awards[recipient_name] += "[recipient_award.medal_names[i]]: \'[recipient_award.medal_citations[i]]\' by [recipient_award.giver_rank[i] ? "[recipient_award.giver_rank[i]] " : ""][recipient_award.giver_name[i] ? "[recipient_award.giver_name[i]] " : ""]([recipient_award.giver_ckey[i]])."
+
 	for(var/recipient_name as anything in GLOB.jelly_awards)
 		var/datum/recipient_awards/recipient_award = GLOB.jelly_awards[recipient_name]
 		xeno_awards[recipient_name] = list()
 		xeno_award_ckeys[recipient_name] = recipient_award.recipient_ckey ? " ([recipient_award.recipient_ckey])" : ""
 		for(var/i in 1 to recipient_award.medal_names.len) // We're assuming everything is same length
-			xeno_awards[recipient_name] += "[recipient_award.medal_names[i]]: \'[recipient_award.medal_citations[i]]\'[recipient_award.giver_rank[i] ? " by [recipient_award.giver_rank[i]]" : ""][recipient_award.giver_name[i] ? " ([recipient_award.giver_name[i]])" : ""]."
-	
+			xeno_awards[recipient_name] += "[recipient_award.medal_names[i]]: \'[recipient_award.medal_citations[i]]\' by [recipient_award.giver_rank[i] ? "[recipient_award.giver_rank[i]] " : ""][recipient_award.giver_name[i] ? "[recipient_award.giver_name[i]] " : ""]([recipient_award.giver_ckey[i]])."
+
 	data["uscm_awards"] = uscm_awards
 	data["xeno_awards"] = xeno_awards
 	data["uscm_award_ckeys"] = uscm_award_ckeys
@@ -61,8 +61,8 @@ GLOBAL_DATUM_INIT(medals_panel, /datum/medals_panel_tgui, new)
 		if("delete_medal")
 			remove_award(params["recipient"], TRUE, params["index"] + 1) // Why is byond not 0 indexed?
 			return TRUE
-		
+
 		if("delete_jelly")
-			remove_award(params["recipient"], FALSE, params["index"] + 1) // Why is byond not 0 indexed? 
+			remove_award(params["recipient"], FALSE, params["index"] + 1) // Why is byond not 0 indexed?
 			return TRUE
-	
+


### PR DESCRIPTION

# About the pull request

This PR is a followup to #4166 removing queen ckeys from attribution; now it is the designation like that PR uses:
![image](https://github.com/cmss13-devs/cmss13/assets/76988376/8f9e44a7-c768-4048-9e00-005794720b3c)

# Explain why it's good for the game

Consistency - if queens aren't going to be known by ckey at end game, then jellies should behave the same.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/cmss13-devs/cmss13/assets/76988376/0817ea74-bb07-40ed-b65c-73b26b17d7f5)
![image](https://github.com/cmss13-devs/cmss13/assets/76988376/dd83152e-35d2-484a-b042-3e4169e05f25)

</details>

# Changelog
:cl: Drathek
add: Queen jellies now use designation rather than ckey for attribution
/:cl:
