### PR TITLE
No NPC Fun Facts

### DIFF
--- a/code/datums/statistics/random_facts/random_fact.dm
+++ b/code/datums/statistics/random_facts/random_fact.dm
@@ -41,6 +41,8 @@
 		list_to_check += GLOB.living_xeno_list
 
 	for(var/mob/checked_mob as anything in list_to_check)
+		if(!checked_mob?.persistent_ckey)
+			continue // We don't care about NPCs
 		if(living_stat_gotten < life_grab_stat(checked_mob))
 			mob_to_report = checked_mob
 			living_stat_gotten = life_grab_stat(checked_mob)


### PR DESCRIPTION
# About the pull request

This PR adds a check for random facts so they only apply to players, not NPCs. 

# Explain why it's good for the game

Should fix dumb things like this: 
![image](https://github.com/cmss13-devs/cmss13/assets/76988376/2dd2e803-7acd-4755-b375-5b2f3e146f72)

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

https://github.com/cmss13-devs/cmss13/assets/76988376/b671b7c5-bd41-4c30-9e81-d69b19689d2e

</details>


# Changelog
:cl: Drathek
fix: Random facts now only check players.
/:cl:
