### PR TITLE
LV522 Maint Tunnel now useable by xenos as tunnels

### DIFF
--- a/code/game/objects/structures/props.dm
+++ b/code/game/objects/structures/props.dm
@@ -1016,13 +1016,6 @@
 	icon_state = "arcadeb"
 	name = "Spirit Phone, The Game, The Movie: II"
 
-/obj/structure/prop/maintenance_hatch
-	name = "\improper Maintenance Hatch"
-	icon = 'icons/obj/structures/structures.dmi'
-	icon_state = "hatchclosed"
-	desc = "Looks like it's rusted shut. Creepy."
-	layer = HATCH_LAYER
-
 //INVULNERABLE PROPS
 
 /obj/structure/prop/invuln

--- a/code/modules/cm_aliens/structures/tunnel.dm
+++ b/code/modules/cm_aliens/structures/tunnel.dm
@@ -254,3 +254,12 @@
 	else
 		to_chat(M, SPAN_WARNING("\The [src] ended unexpectedly, so you return back up."))
 	return XENO_NO_DELAY_ACTION
+
+/obj/structure/tunnel/maint_tunnel
+	name = "\improper Maintenance Hatch"
+	desc = "An entrance to a maintenance tunnel. You can see bits of slime and resin within. Pieces of debris keep you from getting a closer look."
+	icon = 'icons/obj/structures/structures.dmi'
+	icon_state = "hatchclosed"
+
+/obj/structure/tunnel/maint_tunnel/no_xeno_desc
+	desc = "An entrance to a maintenance tunnel. Pieces of debris keep you from getting a closer look."

--- a/maps/map_files/LV522_Chances_Claim/LV522_Chances_Claim.dmm
+++ b/maps/map_files/LV522_Chances_Claim/LV522_Chances_Claim.dmm
@@ -9673,13 +9673,12 @@
 /turf/closed/wall/mineral/bone_resin,
 /area/lv522/oob)
 "evu" = (
-/obj/structure/prop/maintenance_hatch{
+/obj/structure/tunnel/maint_tunnel{
 	pixel_y = 6
 	},
 /obj/structure/machinery/light/small{
 	dir = 1
 	},
-/obj/structure/barricade/handrail,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "evv" = (
@@ -9814,13 +9813,10 @@
 	},
 /area/lv522/atmos/east_reactor)
 "exQ" = (
-/obj/structure/prop/maintenance_hatch{
-	pixel_y = 6
-	},
 /obj/structure/machinery/light/small{
 	dir = 1
 	},
-/obj/structure/barricade/handrail,
+/obj/structure/largecrate,
 /obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
@@ -14472,7 +14468,7 @@
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "gul" = (
-/obj/structure/prop/maintenance_hatch{
+/obj/structure/tunnel/maint_tunnel{
 	pixel_y = 6
 	},
 /turf/open/floor/prison{
@@ -20477,14 +20473,10 @@
 	},
 /area/lv522/landing_zone_2)
 "iGD" = (
-/obj/structure/prop/maintenance_hatch{
+/obj/structure/tunnel/maint_tunnel{
 	pixel_y = 6
 	},
 /obj/structure/machinery/light/small,
-/obj/structure/barricade/handrail{
-	dir = 1;
-	pixel_y = 9
-	},
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "iGF" = (
@@ -24208,7 +24200,7 @@
 /turf/open/floor/corsat,
 /area/lv522/atmos/east_reactor)
 "jYp" = (
-/obj/structure/prop/maintenance_hatch{
+/obj/structure/tunnel/maint_tunnel{
 	pixel_y = 6
 	},
 /turf/open/floor/prison{
@@ -56793,7 +56785,7 @@
 /area/lv522/indoors/a_block/executive)
 "vSV" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/prop/maintenance_hatch{
+/obj/structure/tunnel/maint_tunnel{
 	pixel_y = 6
 	},
 /turf/open/floor/prison{


### PR DESCRIPTION
# About the pull request

This PR lets Xenos use the maintenance hatches scattered around on LV522 as tunnels and also removes the prop tunnel now that it has an actual use so as to not confuse players if a prop one was added to a map

https://i.imgur.com/qwBobX1.png

# Explain why it's good for the game

In my mind, I'm attempting to draw from the movie moment where Hudson is pulled down under the floor obviously that isn't exactly right but I want to show that on maps where these new tunnel subtypes are placed, Xenos have complete control of every aspect of the colony.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: SpartanBobby gdifirehawk
add: Subtype of tunnel added "Maintenance Tunnel" currently only on LV522 these tunnels act the same as regular tunnels but look different, keep an eye out marines. Description by GDIFIREHAWK
/:cl:
