### PR TITLE
Fix solaris ridge map link and refactor current_map

### DIFF
--- a/code/__DEFINES/__game.dm
+++ b/code/__DEFINES/__game.dm
@@ -39,6 +39,7 @@ block( \
 #define MAP_RUNTIME "USS Runtime"
 #define MAP_LV522_CHANCES_CLAIM "LV-522 Chance's Claim" // Highpop Only
 #define MAP_NEW_VARADERO "New Varadero"//ice colony underground but as its own map
+#define MAP_CHINKOOK "Chinook 91 GSO" //admin level
 
 #define GAMEMODE_WHISKEY_OUTPOST "Whiskey Outpost"
 #define GAMEMODE_HIVE_WARS "Hive Wars"

--- a/code/__DEFINES/__game.dm
+++ b/code/__DEFINES/__game.dm
@@ -39,7 +39,7 @@ block( \
 #define MAP_RUNTIME "USS Runtime"
 #define MAP_LV522_CHANCES_CLAIM "LV-522 Chance's Claim" // Highpop Only
 #define MAP_NEW_VARADERO "New Varadero"//ice colony underground but as its own map
-#define MAP_CHINKOOK "Chinook 91 GSO" //admin level
+#define MAP_CHINOOK "Chinook 91 GSO" //admin level
 
 #define GAMEMODE_WHISKEY_OUTPOST "Whiskey Outpost"
 #define GAMEMODE_HIVE_WARS "Hive Wars"

--- a/code/modules/cm_marines/equipment/maps.dm
+++ b/code/modules/cm_marines/equipment/maps.dm
@@ -158,7 +158,10 @@ GLOBAL_LIST_INIT_TYPED(map_type_list, /obj/item/map, setup_all_maps())
 /obj/item/map/current_map/Initialize(mapload, ...)
 	. = ..()
 
-	var/obj/item/map/map = GLOB.map_type_list[SSmapping.configs[GROUND_MAP].map_name]
+	var/map_name = SSmapping.configs[GROUND_MAP].map_name
+	var/obj/item/map/map = GLOB.map_type_list[map_name]
+	if (!map && (map_name == MAP_RUNTIME || map_name == MAP_CHINKOOK || map_name == MAIN_SHIP_DEFAULT_NAME))
+		return // "Maps" we don't have maps for so we don't need to throw a runtime for (namely in unit_testing)
 	name = map.name
 	desc = map.desc
 	html_link = map.html_link

--- a/code/modules/cm_marines/equipment/maps.dm
+++ b/code/modules/cm_marines/equipment/maps.dm
@@ -160,7 +160,7 @@ GLOBAL_LIST_INIT_TYPED(map_type_list, /obj/item/map, setup_all_maps())
 
 	var/map_name = SSmapping.configs[GROUND_MAP].map_name
 	var/obj/item/map/map = GLOB.map_type_list[map_name]
-	if (!map && (map_name == MAP_RUNTIME || map_name == MAP_CHINKOOK || map_name == MAIN_SHIP_DEFAULT_NAME))
+	if (!map && (map_name == MAP_RUNTIME || map_name == MAP_CHINOOK || map_name == MAIN_SHIP_DEFAULT_NAME))
 		return // "Maps" we don't have maps for so we don't need to throw a runtime for (namely in unit_testing)
 	name = map.name
 	desc = map.desc

--- a/code/modules/cm_marines/equipment/maps.dm
+++ b/code/modules/cm_marines/equipment/maps.dm
@@ -133,77 +133,36 @@
 	html_link = "images/9/94/New_Varadero.png"
 	color = "red"
 
+GLOBAL_LIST_INIT_TYPED(map_type_list, /obj/item/map, setup_all_maps())
+
+/proc/setup_all_maps()
+	return list(
+		MAP_LV_624 = new /obj/item/map/lazarus_landing_map(),
+		MAP_ICE_COLONY = new /obj/item/map/ice_colony_map(),
+		MAP_ICE_COLONY_V3 = new /obj/item/map/ice_colony_map_v3(),
+		MAP_WHISKEY_OUTPOST = new /obj/item/map/whiskey_outpost_map(),
+		MAP_BIG_RED = new /obj/item/map/big_red_map(),
+		MAP_PRISON_STATION = new /obj/item/map/FOP_map(),
+		MAP_PRISON_STATION_V3 = new /obj/item/map/FOP_map_v3(),
+		MAP_DESERT_DAM = new /obj/item/map/desert_dam(),
+		MAP_SOROKYNE_STRATA = new /obj/item/map/sorokyne_map(),
+		MAP_CORSAT = new /obj/item/map/corsat(),
+		MAP_KUTJEVO = new /obj/item/map/kutjevo_map(),
+		MAP_LV522_CHANCES_CLAIM = new /obj/item/map/lv522_map(),
+		MAP_NEW_VARADERO = new /obj/item/map/new_varadero()
+	)
+
 //used by marine equipment machines to spawn the correct map.
 /obj/item/map/current_map
 
 /obj/item/map/current_map/Initialize(mapload, ...)
 	. = ..()
-	switch(SSmapping.configs[GROUND_MAP].map_name)
-		if(MAP_LV_624)
-			name = "\improper Lazarus Landing Map"
-			desc = "A satellite printout of the Lazarus Landing colony on LV-624."
-			html_link = "images/6/6f/LV624.png"
-		if(MAP_ICE_COLONY)
-			name = "\improper Ice Colony map"
-			desc = "A satellite printout of the Ice Colony."
-			html_link = "images/1/18/Map_icecolony.png"
-			color = "cyan"
-		if(MAP_ICE_COLONY_V3)
-			name = "\improper Shivas Snowball map"
-			desc = "A labelled print out of the anterior scan of the UA colony Shivas Snowball."
-			html_link = "images/1/18/Map_icecolony.png"//needs to be replaced at some point
-			color = "cyan"
-		if(MAP_BIG_RED)
-			name = "\improper Solaris Ridge Map"
-			desc = "A censored blueprint of the Solaris Ridge facility"
-			html_link = "images/9/9e/Solaris_Ridge.png"
-			color = "#e88a10"
-		if(MAP_PRISON_STATION)
-			name = "\improper Fiorina Orbital Penitentiary Map"
-			desc = "A labelled interior scan of Fiorina Orbital Penitentiary"
-			html_link = "images/4/4c/Map_Prison.png"
-			color = "#e88a10"
-		if(MAP_PRISON_STATION_V3)
-			name = "\improper Fiorina Orbital Penitentiary Map"
-			desc = "A scan produced by the Almayer's sensor array of the Fiorina Orbital Penitentiary Civilian Annex. It appears to have broken off from the rest of the station and is now in free geo-sync orbit around the planet."
-			html_link = "images/e/e0/Prison_Station_Science_Annex.png"
-			color = "#e88a10"
-		if(MAP_DESERT_DAM)
-			name = "\improper Trijent Dam map"
-			desc = "A map of Trijent Dam"
-			html_link = "images/9/92/Trijent_Dam.png"
-			color = "#cec13f"
-			//did only the basics todo change later
-		if(MAP_SOROKYNE_STRATA)
-			name = "\improper Sorokyne Strata map"
-			desc = "A map of the Weyland-Yutani colony Sorokyne Outpost, commonly known as Sorokyne Strata."
-			html_link = "images/1/1c/Sorokyne_map.png"
-			color = "cyan"
-		if (MAP_CORSAT)
-			name = "\improper CORSAT map"
-			desc = "A blueprint of CORSAT station"
-			html_link = "images/8/8e/CORSAT_Satellite.png"
-			color = "red"
-		if (MAP_KUTJEVO)
-			name = "\improper Kutjevo Refinery map"
-			desc = "An orbital scan of Kutjevo Refinery"
-			html_link = "images/0/0d/Kutjevo_a1.jpg"
-			color = "red"
-		if (MAP_LV522_CHANCES_CLAIM)
-			name = "\improper LV-522 Map"
-			desc = "An overview of LV-522 schematics."
-			html_link = "images/b/bb/C_claim.png"
-			color = "cyan"
-		if (MAP_NEW_VARADERO)
-			name = "\improper New Varadero map"
-			desc = "The blueprint and readout of the UA outpost New Varadero"
-			html_link = "images/9/94/New_Varadero.png"//replace later
-			color = "red"
 
-		else
-			return INITIALIZE_HINT_QDEL
-
-
+	var/obj/item/map/map = GLOB.map_type_list[SSmapping.configs[GROUND_MAP].map_name]
+	name = map.name
+	desc = map.desc
+	html_link = map.html_link
+	color = map.color
 
 // Landmark - Used for mapping. Will spawn the appropriate map for each gamemode (LV map items will spawn when LV is the gamemode, etc)
 /obj/effect/landmark/map_item

--- a/code/modules/cm_marines/equipment/maps.dm
+++ b/code/modules/cm_marines/equipment/maps.dm
@@ -82,7 +82,7 @@
 /obj/item/map/big_red_map
 	name = "\improper Solaris Ridge Map"
 	desc = "A censored blueprint of the Solaris Ridge facility"
-	html_link = "images/c/c5/Big_Red.png"
+	html_link = "images/9/9e/Solaris_Ridge.png"
 	color = "#e88a10"
 
 /obj/item/map/FOP_map
@@ -104,10 +104,11 @@
 	color = "#ad8d0e"
 
 /obj/item/map/sorokyne_map
-	name = "\improper Sorokyne Outpost Map"
-	desc = "A labelled schematic of the Sorokyne Outpost and the surrounding caves."
+	name = "\improper Sorokyne Strata map"
+	desc = "A map of the Weyland-Yutani colony Sorokyne Outpost, commonly known as Sorokyne Strata."
 	html_link = "images/2/21/Sorokyne_Wiki_Map.jpg" //The fact that this is just a wiki-link makes me sad and amused.
 	color = "cyan"
+
 /obj/item/map/corsat
 	name = "\improper CORSAT map"
 	desc = "A blueprint of CORSAT station"
@@ -125,6 +126,7 @@
 	desc = "An overview of LV-522 schematics."
 	html_link = "images/b/bb/C_claim.png"
 	color = "cyan"
+
 /obj/item/map/new_varadero
 	name = "\improper New Varadero map"
 	desc = "A labeled blueprint of the UA outpost New Varadero"

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -131,7 +131,7 @@ GUEST_BAN
 FORUMURL https://forum.cm-ss13.com/
 
 ## Wiki address
-WIKIURL https://cm-ss13/wiki/
+WIKIURL https://cm-ss13.com/w
 
 ## Rules address
 RULESURL https://cm-ss13.com/viewtopic.php?f=57&t=5094


### PR DESCRIPTION

# About the pull request

This PR fixes the discrepancy between maps and a current_map counterpart by removing the duplicate definitions. Additionally this will make mapped in maps work for solaris ridge, soro has its name/desc set to the latest edit, and the wiki example config is correct again.

# Explain why it's good for the game

Fixes #4191 and makes it harder for discrepancies like this to occur again.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/cmss13-devs/cmss13/assets/76988376/e1651529-ca5d-4cb0-b198-be084ca70074)

</details>

# Changelog
:cl: Drathek
fix: Fixed mapped in maps for solaris ridge not opening correctly.
refactor: Refactored current_map to use a global list instead to remove the need for duplicate definitions.
/:cl:
