### PR TITLE
Research Trait fixes

### DIFF
--- a/code/modules/reagents/chemistry_properties/chem_property.dm
+++ b/code/modules/reagents/chemistry_properties/chem_property.dm
@@ -12,6 +12,7 @@
 	var/updates_stats = FALSE //should the property change other variables in the reagent when added or removed?
 	/// Should reagent with this property explode/start fire when mixed more than overdose threshold at once?
 	var/volatile = FALSE
+	var/potency = 1
 
 /datum/chem_property/Destroy()
 	holder = null
@@ -21,10 +22,10 @@
 /datum/chem_property/proc/reagent_added(atom/A, datum/reagent/R, amount)
 	return
 
-/datum/chem_property/proc/pre_process(mob/living/M) //used for properties that need special checks before processing starts, such as cryometabolization
+/datum/chem_property/proc/pre_process(mob/living/M, potency) //used for properties that need special checks before processing starts, such as cryometabolization
 	return
 
-/datum/chem_property/proc/on_delete(mob/living/M) //used for properties that do something on delete
+/datum/chem_property/proc/on_delete(mob/living/M, potency) //used for properties that do something on delete
 	qdel(src)
 	return
 
@@ -49,13 +50,13 @@
 /datum/chem_property/proc/process_dead(mob/living/M, potency = 1, delta_time)
 	return FALSE // By default, chemicals don't process in dead personnel.
 
-/datum/chem_property/proc/trigger(A) //used for properties that needs something to trigger outside of where process is usually called
+/datum/chem_property/proc/trigger(A, potency) //used for properties that needs something to trigger outside of where process is usually called
 	return
 
-/datum/chem_property/proc/reset_reagent()
+/datum/chem_property/proc/reset_reagent(potency)
 	return
 
-/datum/chem_property/proc/update_reagent() //used for changing other variables in the reagent, set update to FALSE to remove the update
+/datum/chem_property/proc/update_reagent(potency) //used for changing other variables in the reagent, set update to FALSE to remove the update
 	return
 
 /datum/chem_property/proc/reaction_mob(mob/M, method=TOUCH, volume, potency)
@@ -67,7 +68,7 @@
 /datum/chem_property/proc/reaction_turf(turf/T, volume, potency)
 	return
 
-/datum/chem_property/proc/post_update_reagent()
+/datum/chem_property/proc/post_update_reagent(potency)
 	return
 
 /datum/chem_property/proc/categories_to_string()

--- a/code/modules/reagents/chemistry_properties/prop_negative.dm
+++ b/code/modules/reagents/chemistry_properties/prop_negative.dm
@@ -446,7 +446,7 @@
 	..()
 
 /datum/chem_property/negative/hypermetabolic/update_reagent()
-	holder.custom_metabolism = holder.custom_metabolism * (1 + POTENCY_MULTIPLIER_VLOW * level)
+	holder.custom_metabolism = holder.custom_metabolism * (1 + POTENCY_MULTIPLIER_LOW * potency)
 	..()
 
 /datum/chem_property/negative/addictive

--- a/code/modules/reagents/chemistry_properties/prop_neutral.dm
+++ b/code/modules/reagents/chemistry_properties/prop_neutral.dm
@@ -14,7 +14,7 @@
 /datum/chem_property/neutral/cryometabolizing/pre_process(mob/living/M)
 	if(M.bodytemperature > 170)
 		return list(REAGENT_CANCEL = TRUE)
-	return list(REAGENT_BOOST = POTENCY_MULTIPLIER_LOW * level)
+	return list(REAGENT_BOOST = potency)
 
 /datum/chem_property/neutral/thanatometabolizing
 	name = PROPERTY_THANATOMETABOL
@@ -40,7 +40,7 @@
 	category = PROPERTY_TYPE_IRRITANT
 
 /datum/chem_property/neutral/excreting/pre_process(mob/living/M)
-	return list(REAGENT_PURGE = level)
+	return list(REAGENT_PURGE = potency * POTENCY_MULTIPLIER_MEDIUM)
 
 /datum/chem_property/neutral/nutritious
 	name = PROPERTY_NUTRITIOUS
@@ -54,18 +54,18 @@
 	if(M.stat == DEAD)
 		return
 
-	if(M.nutrition + (holder.nutriment_factor * level) >= NUTRITION_MAX)
+	if(M.nutrition + (holder.nutriment_factor * potency * POTENCY_MULTIPLIER_MEDIUM) >= NUTRITION_MAX)
 		M.nutrition = NUTRITION_MAX
 		return
 	else
-		M.nutrition += holder.nutriment_factor * level
+		M.nutrition += holder.nutriment_factor * potency * POTENCY_MULTIPLIER_MEDIUM
 
 /datum/chem_property/neutral/nutritious/reset_reagent()
 	holder.nutriment_factor = initial(holder.nutriment_factor)
 	..()
 
 /datum/chem_property/neutral/nutritious/update_reagent()
-	holder.nutriment_factor += level
+	holder.nutriment_factor += potency * POTENCY_MULTIPLIER_MEDIUM
 	..()
 
 /datum/chem_property/neutral/ketogenic
@@ -467,7 +467,7 @@
 	..()
 
 /datum/chem_property/neutral/hypometabolic/update_reagent()
-	holder.custom_metabolism = max(holder.custom_metabolism / (1 + 0.35 * level), 0.005)
+	holder.custom_metabolism = max(holder.custom_metabolism / (1 + 0.35 * potency * POTENCY_MULTIPLIER_MEDIUM), 0.005)
 	..()
 
 /datum/chem_property/neutral/sedative
@@ -533,7 +533,7 @@
 
 /datum/chem_property/neutral/viscous/update_reagent()
 	holder.chemfiresupp = TRUE
-	holder.radiusmod -= 0.025 * level
+	holder.radiusmod -= 0.025 * potency * POTENCY_MULTIPLIER_MEDIUM
 	..()
 
 //PROPERTY_DISABLED (in generation)

--- a/code/modules/reagents/chemistry_properties/prop_positive.dm
+++ b/code/modules/reagents/chemistry_properties/prop_positive.dm
@@ -536,9 +536,9 @@
 /datum/chem_property/positive/electrogenetic/trigger(A)
 	if(isliving(A))
 		var/mob/living/M = A
-		M.apply_damage(-POTENCY_MULTIPLIER_VHIGH * level, BRUTE)
-		M.apply_damage(-POTENCY_MULTIPLIER_VHIGH * level, BURN)
-		M.apply_damage(-POTENCY_MULTIPLIER_VHIGH * level, TOX)
+		M.apply_damage(-POTENCY_MULTIPLIER_EXTREME * potency, BRUTE)
+		M.apply_damage(-POTENCY_MULTIPLIER_EXTREME * potency, BURN)
+		M.apply_damage(-POTENCY_MULTIPLIER_EXTREME * potency, TOX)
 		M.updatehealth()
 
 /datum/chem_property/positive/defibrillating
@@ -694,13 +694,13 @@
 /datum/chem_property/positive/fire/update_reagent()
 	holder.chemfiresupp = TRUE
 
-	holder.radiusmod += radiusmod_per_level * level
-	holder.durationmod += durationmod_per_level * level
-	holder.intensitymod += intensitymod_per_level * level
+	holder.radiusmod += radiusmod_per_level * potency * POTENCY_MULTIPLIER_MEDIUM
+	holder.durationmod += durationmod_per_level * potency * POTENCY_MULTIPLIER_MEDIUM
+	holder.intensitymod += intensitymod_per_level * potency * POTENCY_MULTIPLIER_MEDIUM
 
-	holder.rangefire += range_per_level * level
-	holder.durationfire += duration_per_level * level
-	holder.intensityfire += intensity_per_level * level
+	holder.rangefire += range_per_level * potency * POTENCY_MULTIPLIER_MEDIUM
+	holder.durationfire += duration_per_level * potency * POTENCY_MULTIPLIER_MEDIUM
+	holder.intensityfire += intensity_per_level * potency * POTENCY_MULTIPLIER_MEDIUM
 
 	..()
 
@@ -786,8 +786,8 @@
 
 /datum/chem_property/positive/explosive/update_reagent()
 	holder.explosive = TRUE
-	holder.power += level
-	holder.falloff_modifier += -3 / level
+	holder.power += potency * POTENCY_MULTIPLIER_MEDIUM
+	holder.falloff_modifier += -3 / potency * POTENCY_MULTIPLIER_MEDIUM
 	..()
 
 //properties for CAS matrixes

--- a/code/modules/reagents/chemistry_properties/prop_special.dm
+++ b/code/modules/reagents/chemistry_properties/prop_special.dm
@@ -305,8 +305,8 @@
 
 	holder.rangefire = max(holder.rangefire, 0) // Initial starts at -1 for some (aka infinite range), need to reset that to 0 so that calc doesn't fuck up
 
-	holder.rangefire += 1 * potency * POTENCY_MULTIPLIER_MEDIUM
-	holder.radiusmod += 0.1 * potency * POTENCY_MULTIPLIER_MEDIUM
+	holder.rangefire += 1 * level
+	holder.radiusmod += 0.1 * level
 	..()
 
 /datum/chem_property/special/intensity
@@ -327,8 +327,8 @@
 /datum/chem_property/special/intensity/update_reagent()
 	holder.chemfiresupp = TRUE
 
-	holder.intensityfire += 1 * potency * POTENCY_MULTIPLIER_MEDIUM
-	holder.intensitymod += 0.1 * potency * POTENCY_MULTIPLIER_MEDIUM
+	holder.intensityfire += 1 * level
+	holder.intensitymod += 0.1 * level
 	..()
 
 /datum/chem_property/special/duration
@@ -349,8 +349,8 @@
 /datum/chem_property/special/duration/update_reagent()
 	holder.chemfiresupp = TRUE
 
-	holder.durationfire += 1 * potency * POTENCY_MULTIPLIER_MEDIUM
-	holder.durationmod += 0.1 * potency * POTENCY_MULTIPLIER_MEDIUM
+	holder.durationfire += 1 * level
+	holder.durationmod += 0.1 * level
 	..()
 
 /datum/chem_property/special/firepenetrating

--- a/code/modules/reagents/chemistry_properties/prop_special.dm
+++ b/code/modules/reagents/chemistry_properties/prop_special.dm
@@ -120,7 +120,7 @@
 		if(!istype(content, /obj/item/alien_embryo))
 			continue
 		// level is a number rather than a hivenumber, which are strings
-		var/hivenumber = GLOB.hive_datum[level]
+		var/hivenumber = GLOB.hive_datum[potency * POTENCY_MULTIPLIER_MEDIUM]
 		var/datum/hive_status/hive = GLOB.hive_datum[hivenumber]
 		var/obj/item/alien_embryo/A = content
 		A.hivenumber = hivenumber
@@ -148,8 +148,8 @@
 
 	playsound(E, 'sound/effects/attackblob.ogg', 25, TRUE)
 
-	E.hivenumber = GLOB.hive_datum[level]
-	set_hive_data(E, GLOB.hive_datum[level])
+	E.hivenumber = GLOB.hive_datum[potency * POTENCY_MULTIPLIER_MEDIUM]
+	set_hive_data(E, GLOB.hive_datum[potency * POTENCY_MULTIPLIER_MEDIUM])
 	E.flags_embryo |= FLAG_EMBRYO_PREDATOR
 
 /datum/chem_property/special/crossmetabolizing

--- a/code/modules/reagents/chemistry_properties/prop_special.dm
+++ b/code/modules/reagents/chemistry_properties/prop_special.dm
@@ -113,14 +113,14 @@
 	max_level = 6
 
 /datum/chem_property/special/ciphering/process(mob/living/M, potency = 1, delta_time)
-	if(!GLOB.hive_datum[level]) // This should probably always be valid
+	if(!GLOB.hive_datum[round(potency * POTENCY_MULTIPLIER_MEDIUM)]) // This should probably always be valid
 		return
 
 	for(var/content in M.contents)
 		if(!istype(content, /obj/item/alien_embryo))
 			continue
 		// level is a number rather than a hivenumber, which are strings
-		var/hivenumber = GLOB.hive_datum[potency * POTENCY_MULTIPLIER_MEDIUM]
+		var/hivenumber = GLOB.hive_datum[round(potency * POTENCY_MULTIPLIER_MEDIUM)]
 		var/datum/hive_status/hive = GLOB.hive_datum[hivenumber]
 		var/obj/item/alien_embryo/A = content
 		A.hivenumber = hivenumber
@@ -141,7 +141,7 @@
 	if(amount < 10)
 		return
 
-	if((E.flags_embryo & FLAG_EMBRYO_PREDATOR) && E.hivenumber == GLOB.hive_datum[level])
+	if((E.flags_embryo & FLAG_EMBRYO_PREDATOR) && E.hivenumber == GLOB.hive_datum[round(potency * POTENCY_MULTIPLIER_MEDIUM)])
 		return
 
 	E.visible_message(SPAN_DANGER("\the [E] rapidly mutates"))
@@ -167,7 +167,7 @@
 	var/mob/living/carbon/human/H = M
 	if(H.species.reagent_tag == IS_YAUTJA)
 		return list(REAGENT_FORCE = TRUE)
-	else if(level < 2)//needs level two to work on humans too
+	else if(potency * POTENCY_MULTIPLIER_MEDIUM < 2)//needs level two to work on humans too
 		return list(REAGENT_CANCEL = TRUE)
 
 /datum/chem_property/special/embryonic
@@ -184,9 +184,9 @@
 	var/mob/living/carbon/human/H = M
 	if((locate(/obj/item/alien_embryo) in H.contents) || (H.species.flags & IS_SYNTHETIC) || !H.huggable) //No effect if already infected
 		return
-	for(var/i=1,i<=max((level % 100)/10,1),i++)//10's determine number of embryos
+	for(var/i=1,i<=max((potency * POTENCY_MULTIPLIER_MEDIUM % 100)/10,1),i++)//10's determine number of embryos
 		var/obj/item/alien_embryo/embryo = new /obj/item/alien_embryo(H)
-		embryo.hivenumber = min(level % 10,5) //1's determine hivenumber
+		embryo.hivenumber = min(round(potency * POTENCY_MULTIPLIER_MEDIUM) % 10,5) //1's determine hivenumber
 		embryo.faction = FACTION_LIST_XENOMORPH[embryo.hivenumber]
 
 /datum/chem_property/special/transforming
@@ -305,8 +305,8 @@
 
 	holder.rangefire = max(holder.rangefire, 0) // Initial starts at -1 for some (aka infinite range), need to reset that to 0 so that calc doesn't fuck up
 
-	holder.rangefire += 1 * level
-	holder.radiusmod += 0.1 * level
+	holder.rangefire += 1 * potency * POTENCY_MULTIPLIER_MEDIUM
+	holder.radiusmod += 0.1 * potency * POTENCY_MULTIPLIER_MEDIUM
 	..()
 
 /datum/chem_property/special/intensity
@@ -327,8 +327,8 @@
 /datum/chem_property/special/intensity/update_reagent()
 	holder.chemfiresupp = TRUE
 
-	holder.intensityfire += 1 * level
-	holder.intensitymod += 0.1 * level
+	holder.intensityfire += 1 * potency * POTENCY_MULTIPLIER_MEDIUM
+	holder.intensitymod += 0.1 * potency * POTENCY_MULTIPLIER_MEDIUM
 	..()
 
 /datum/chem_property/special/duration
@@ -349,8 +349,8 @@
 /datum/chem_property/special/duration/update_reagent()
 	holder.chemfiresupp = TRUE
 
-	holder.durationfire += 1 * level
-	holder.durationmod += 0.1 * level
+	holder.durationfire += 1 * potency * POTENCY_MULTIPLIER_MEDIUM
+	holder.durationmod += 0.1 * potency * POTENCY_MULTIPLIER_MEDIUM
 	..()
 
 /datum/chem_property/special/firepenetrating


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->
ALL traits will now use Potency instead of level to calculate their effects . I have noticed there was some traits that were not using this and as a result they were not working at all when used with modifiers like Boosting. This PR corrects that behaviour to work as it should .

PD : STATS UNTOUCHED THIS PR JUST FIXES THE BEHAVIOUR ALL NUMBERS ARE THE SAME AS BEFORE .
PD 2 : potency = level / 2 which means i have to add a (potency * POTENCY_MULTIPLIER_MEDIUM) to keep the numbers the same

# Explain why it's good for the game
bug bad . research = funny

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Fixes Booting , Cryometabolizing , and other metabolites  not working on some traits
/:cl:
