### PR TITLE
Combat Information Center pens from blue to black

### DIFF
--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -39827,7 +39827,7 @@
 /obj/item/paper{
 	pixel_x = 5
 	},
-/obj/item/tool/pen/blue{
+/obj/item/tool/pen{
 	pixel_x = 5
 	},
 /obj/structure/surface/table/reinforced/black,
@@ -67853,8 +67853,8 @@
 /area/almayer/squads/req)
 "tUo" = (
 /obj/item/clipboard,
-/obj/item/tool/pen/blue,
 /obj/structure/surface/table/reinforced/black,
+/obj/item/tool/pen,
 /turf/open/floor/almayer,
 /area/almayer/command/cic)
 "tUv" = (


### PR DESCRIPTION

# About the pull request

Pens in Combat Information Center are now the black-ink variant

# Explain why it's good for the game

Frankly, having paperwork thats blue instead of standard black is ugly, special colored pens should not be the norm.

# Changelog
:cl:
maptweak: Combat Information Center pens now use black ink
/:cl:
