### PR TITLE
fixes m4ra custom barrel offset

### DIFF
--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -580,7 +580,7 @@
 
 
 /obj/item/weapon/gun/rifle/m4ra_custom/set_gun_attachment_offsets()
-	attachable_offset = list("muzzle_x" = 43, "muzzle_y" = 17,"rail_x" = 23, "rail_y" = 21, "under_x" = 30, "under_y" = 11, "stock_x" = 24, "stock_y" = 13, "special_x" = 37, "special_y" = 16)
+	attachable_offset = list("muzzle_x" = 43, "muzzle_y" = 17,"rail_x" = 23, "rail_y" = 21, "under_x" = 30, "under_y" = 11, "stock_x" = 24, "stock_y" = 13, "special_x" = 39, "special_y" = 17)
 
 /obj/item/weapon/gun/rifle/m4ra_custom/set_gun_config_values()
 	..()


### PR DESCRIPTION
i accidentally deleted the pr form and i cant be bothered to re-open the open pr page so you're getting this in a messed up version without big text, 🖕 

ABOUT THE PULL REQUEST OR SOMETHING

fixes the offset for m4ra custom's barrel, appropriately putting it on the gun

WHY ITS GOOD FOR THE GAME PROBABLY

bugfix

Changelog

:cl:
fix: fixes the offset on m4ra custom barrel, it should appropriately be sat right on the gun sprite
/:cl:
