### PR TITLE
Fix cade attack speed exploit

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
@@ -755,6 +755,9 @@
 
 
 /mob/living/carbon/xenomorph/start_pulling(atom/movable/AM, lunge, no_msg)
+	if(next_move >= world.time)
+		return FALSE
+
 	if(SEND_SIGNAL(AM, COMSIG_MOVABLE_XENO_START_PULLING, src) & COMPONENT_ALLOW_PULL)
 		return do_pull(AM, lunge, no_msg)
 


### PR DESCRIPTION

# About the pull request

This PR fixes an exploit where dragging could be used to bypass an attack cooldown.

# Explain why it's good for the game

Fixes #4184 

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

https://youtu.be/nIfXqQ6IBw0

</details>


# Changelog
:cl: Drathek
fix: Fixed a cade attack exploit
/:cl:
