### PR TITLE
Fix add a check when trying to regain control of locked DS to avoid waste of time.

### DIFF
--- a/code/modules/shuttle/computers/dropship_computer.dm
+++ b/code/modules/shuttle/computers/dropship_computer.dm
@@ -147,6 +147,8 @@
 		return
 
 	if(dropship_control_lost && skillcheck(user, SKILL_PILOT, SKILL_PILOT_EXPERT))
+		if(remaining_time > 60)
+			to_chat(user, SPAN_WARNING("The shuttle is not responding, try again in [remaining_time] [units]."))
 		to_chat(user, SPAN_NOTICE("You start to remove the Queens override."))
 		if(!do_after(user, 3 MINUTES, INTERRUPT_ALL, BUSY_ICON_HOSTILE))
 			to_chat(user, SPAN_WARNING("You fail to remove the Queens override"))

--- a/code/modules/shuttle/computers/dropship_computer.dm
+++ b/code/modules/shuttle/computers/dropship_computer.dm
@@ -151,6 +151,7 @@
 		var/units = "seconds"
 		if(remaining_time > 60)
 			to_chat(user, SPAN_WARNING("The shuttle is not responding, try again in [remaining_time] [units]."))
+			return
 		to_chat(user, SPAN_NOTICE("You start to remove the Queens override."))
 		if(!do_after(user, 3 MINUTES, INTERRUPT_ALL, BUSY_ICON_HOSTILE))
 			to_chat(user, SPAN_WARNING("You fail to remove the Queens override"))

--- a/code/modules/shuttle/computers/dropship_computer.dm
+++ b/code/modules/shuttle/computers/dropship_computer.dm
@@ -150,7 +150,7 @@
 		var/remaining_time = timeleft(door_control_cooldown) / 10
 		var/units = "seconds"
 		if(remaining_time > 60)
-			to_chat(user, SPAN_WARNING("The shuttle is not responding, try again in [remaining_time] [units]."))
+			to_chat(user, SPAN_WARNING("The shuttle is not responding, try again in [remaining_time] seconds."))
 			return
 		to_chat(user, SPAN_NOTICE("You start to remove the Queens override."))
 		if(!do_after(user, 3 MINUTES, INTERRUPT_ALL, BUSY_ICON_HOSTILE))

--- a/code/modules/shuttle/computers/dropship_computer.dm
+++ b/code/modules/shuttle/computers/dropship_computer.dm
@@ -148,7 +148,6 @@
 
 	if(dropship_control_lost && skillcheck(user, SKILL_PILOT, SKILL_PILOT_EXPERT))
 		var/remaining_time = timeleft(door_control_cooldown) / 10
-		var/units = "seconds"
 		if(remaining_time > 60)
 			to_chat(user, SPAN_WARNING("The shuttle is not responding, try again in [remaining_time] seconds."))
 			return

--- a/code/modules/shuttle/computers/dropship_computer.dm
+++ b/code/modules/shuttle/computers/dropship_computer.dm
@@ -147,6 +147,8 @@
 		return
 
 	if(dropship_control_lost && skillcheck(user, SKILL_PILOT, SKILL_PILOT_EXPERT))
+		var/remaining_time = timeleft(door_control_cooldown) / 10
+		var/units = "seconds"
 		if(remaining_time > 60)
 			to_chat(user, SPAN_WARNING("The shuttle is not responding, try again in [remaining_time] [units]."))
 		to_chat(user, SPAN_NOTICE("You start to remove the Queens override."))


### PR DESCRIPTION

# About the pull request
fixes: https://github.com/cmss13-devs/cmss13/issues/4188
add a check before they start the long process of unlock the DS after queen lock it to avoid people wasting time.

# Explain why it's good for the game
just a little fix or qol or both...
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

![image](https://github.com/cmss13-devs/cmss13/assets/117036822/424aadaa-536c-4fd1-9ffc-e54c92e2c05d)

</details>


# Changelog
:cl:
fix: add a check before people start the long process of unlock the DS so that people don't waste time.
/:cl:
