### PR TITLE
Fixes resin areas around LZs

### DIFF
--- a/code/game/area/BigRed.dm
+++ b/code/game/area/BigRed.dm
@@ -654,6 +654,7 @@
 	minimap_color = MINIMAP_AREA_LZ
 	icon_state = "tcomsatcham"
 	requires_power = FALSE
+	is_resin_allowed = FALSE
 
 /area/bigredv2/landing/console
 	name = "\improper LZ1 'Telecomms'"

--- a/code/game/area/IceColony.dm
+++ b/code/game/area/IceColony.dm
@@ -65,6 +65,7 @@
 	name = "\improper Emergency Landing Pad"
 	icon_state = "landing_pad"
 	minimap_color = MINIMAP_AREA_LZ
+	is_resin_allowed = FALSE
 
 
 //Everything around the physical landing pad
@@ -79,6 +80,7 @@
 	name = "\improper Aerodrome Container Yard"
 	icon_state = "container_yard"
 	minimap_color = MINIMAP_AREA_LZ
+	is_resin_allowed = FALSE
 
 //
 // Valleys

--- a/code/game/area/LV522_Chances_Claim.dm
+++ b/code/game/area/LV522_Chances_Claim.dm
@@ -180,6 +180,7 @@
 	name = "North LZ1 - Spaceport"
 	icon_state = "red"
 	minimap_color = MINIMAP_AREA_LZ
+	is_resin_allowed = FALSE
 
 /area/lv522/indoors/lone_buildings/outdoor_bot
 	name = "East LZ1 - Outdoor T-Comms"

--- a/code/game/area/prison_v3_fiorina.dm
+++ b/code/game/area/prison_v3_fiorina.dm
@@ -71,14 +71,13 @@
 	name = "Fiorina - LZ"
 	is_landing_zone = TRUE
 	minimap_color = MINIMAP_AREA_LZ
+	is_resin_allowed = FALSE
 
 /area/fiorina/lz/near_lzI
 	name = "Fiorina - LZ1 Aux Port"
-	is_resin_allowed = FALSE
 
 /area/fiorina/lz/near_lzII
 	name = "Fiorina - LZ2 Prison Port"
-	is_resin_allowed = FALSE
 
 /area/fiorina/lz/console_I
 	name = "Fiorina - LZ1 Control Console"

--- a/code/game/area/strata.dm
+++ b/code/game/area/strata.dm
@@ -20,12 +20,14 @@ EXTERIOR is FUCKING FREEZING, and refers to areas out in the open and or exposed
 	icon_state = "shuttle"
 	lighting_use_dynamic = 0 //No bad
 	minimap_color = MINIMAP_AREA_LZ
+	is_resin_allowed = FALSE
 
 /area/shuttle/drop2/strata
 	name = "Dropship Normandy Landing Zone"
 	icon_state = "shuttle2"
 	lighting_use_dynamic = 0
 	minimap_color = MINIMAP_AREA_LZ
+	is_resin_allowed = FALSE
 
 /area/strata/ag
 	name = "Above Ground Area"
@@ -92,6 +94,7 @@ EXTERIOR is FUCKING FREEZING, and refers to areas out in the open and or exposed
 	unlimited_power = 1 //So the DS computer always works for the Queen
 	is_landing_zone = TRUE
 	minimap_color = MINIMAP_AREA_LZ
+	is_resin_allowed = FALSE
 
 /area/strata/ag/exterior/landingzone_2
 	name = "Landing Zone 2 Pad - Ice Fields"
@@ -100,6 +103,7 @@ EXTERIOR is FUCKING FREEZING, and refers to areas out in the open and or exposed
 	unlimited_power = 1 //So the DS computer always works for the Queen
 	is_landing_zone = TRUE
 	minimap_color = MINIMAP_AREA_LZ
+	is_resin_allowed = FALSE
 
 /area/strata/ag/interior/nearlz1
 	name = "Landing Zone 1 - Mining Aerodrome"
@@ -113,6 +117,7 @@ EXTERIOR is FUCKING FREEZING, and refers to areas out in the open and or exposed
 	icon_state = "nearlz2"
 	weather_enabled = TRUE //This LZ is outside, but consider disabling if it destroys the meta.
 	minimap_color = MINIMAP_AREA_LZ
+	is_resin_allowed = FALSE
 
 /area/strata/ag/exterior/landingzone_valley
 	name = "Landing Zone Valley"


### PR DESCRIPTION

# About the pull request
Some areas (such as sorokyne LZ) are weedable when they're not supposed to be. This fixes those instances.
Primary focus was the sorokyne LZ and dropship console single-tile areas.
Some areas should be reviewed on if needed where added to Sorokyne.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Consistency!
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Areas around LZs (particularly on Sorokyne) are now unweedable as intended.
/:cl:
