### PR TITLE
attachment obliteration

### DIFF
--- a/code/__DEFINES/conflict.dm
+++ b/code/__DEFINES/conflict.dm
@@ -90,6 +90,8 @@
 #define ATTACH_IGNORE_EMPTY (1<<5)
 /// This attachment should activate if you attack() with it attached.
 #define ATTACH_MELEE (1<<6)
+/// Override for attachies so you can fire them with a single hand . ONLY FOR PROJECTILES!!
+#define ATTACH_WIELD_OVERRIDE (1<<7)
 
 //Ammo magazine defines, for flags_magazine
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -1080,7 +1080,7 @@ and you're good to go.
 		if(!(active_attachable.flags_attach_features & ATTACH_PROJECTILE)) //If it's unique projectile, this is where we fire it.
 			if((active_attachable.current_rounds <= 0) && !(active_attachable.flags_attach_features & ATTACH_IGNORE_EMPTY))
 				click_empty(user) //If it's empty, let them know.
-				to_chat(user, SPAN_WARNING("[active_attachable] is empty!"))
+				to_chat(user, SPAN_WARNING("[active_attachable] is empty !"))
 				to_chat(user, SPAN_NOTICE("You disable [active_attachable]."))
 				active_attachable.activate_attachment(src, null, TRUE)
 			else
@@ -1503,7 +1503,11 @@ not all weapons use normal magazines etc. load_into_chamber() itself is designed
 		if(flags_gun_features & GUN_TRIGGER_SAFETY)
 			to_chat(user, SPAN_WARNING("The safety is on!"))
 			return
-
+		if(active_attachable)
+			if(active_attachable && active_attachable.flags_attach_features & ATTACH_PROJECTILE)
+				if(!(active_attachable.flags_attach_features & ATTACH_WIELD_OVERRIDE) && !(flags_item & WIELDED))
+					to_chat(user, SPAN_WARNING("You must wield \the [src] to fire \the [active_attachable]!"))
+					return
 		if((flags_gun_features & GUN_WIELDED_FIRING_ONLY) && !(flags_item & WIELDED)) //If we're not holding the weapon with both hands when we should.
 			to_chat(user, SPAN_WARNING("You need a more secure grip to fire this weapon!"))
 			return

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -1334,11 +1334,10 @@ and you're good to go.
 
 	//The following relating to bursts was borrowed from Fire code.
 	var/check_for_attachment_fire = FALSE
-	if(active_attachable)
-		if(active_attachable.flags_attach_features & ATTACH_PROJECTILE)
-			check_for_attachment_fire = TRUE
-		else
-			active_attachable.activate_attachment(src, null, TRUE)//No way.
+	if(active_attachable?.flags_attach_features & ATTACH_PROJECTILE)
+		check_for_attachment_fire = TRUE
+	else
+		active_attachable.activate_attachment(src, null, TRUE)//No way.
 
 
 	var/bullets_to_fire = 1
@@ -1506,7 +1505,7 @@ not all weapons use normal magazines etc. load_into_chamber() itself is designed
 		if(active_attachable)
 			if(active_attachable.flags_attach_features & ATTACH_PROJECTILE)
 				if(!(active_attachable.flags_attach_features & ATTACH_WIELD_OVERRIDE) && !(flags_item & WIELDED))
-					to_chat(user, SPAN_WARNING("You must wield [src] to fire \the [active_attachable]!"))
+					to_chat(user, SPAN_WARNING("You must wield [src] to fire [active_attachable]!"))
 					return
 		if((flags_gun_features & GUN_WIELDED_FIRING_ONLY) && !(flags_item & WIELDED) && !active_attachable) //If we're not holding the weapon with both hands when we should.
 			to_chat(user, SPAN_WARNING("You need a more secure grip to fire this weapon!"))

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -1080,7 +1080,7 @@ and you're good to go.
 		if(!(active_attachable.flags_attach_features & ATTACH_PROJECTILE)) //If it's unique projectile, this is where we fire it.
 			if((active_attachable.current_rounds <= 0) && !(active_attachable.flags_attach_features & ATTACH_IGNORE_EMPTY))
 				click_empty(user) //If it's empty, let them know.
-				to_chat(user, SPAN_WARNING("[active_attachable] is empty !"))
+				to_chat(user, SPAN_WARNING("[active_attachable] is empty!"))
 				to_chat(user, SPAN_NOTICE("You disable [active_attachable]."))
 				active_attachable.activate_attachment(src, null, TRUE)
 			else
@@ -1504,11 +1504,11 @@ not all weapons use normal magazines etc. load_into_chamber() itself is designed
 			to_chat(user, SPAN_WARNING("The safety is on!"))
 			return
 		if(active_attachable)
-			if(active_attachable && active_attachable.flags_attach_features & ATTACH_PROJECTILE)
+			if(active_attachable.flags_attach_features & ATTACH_PROJECTILE)
 				if(!(active_attachable.flags_attach_features & ATTACH_WIELD_OVERRIDE) && !(flags_item & WIELDED))
-					to_chat(user, SPAN_WARNING("You must wield \the [src] to fire \the [active_attachable]!"))
+					to_chat(user, SPAN_WARNING("You must wield [src] to fire \the [active_attachable]!"))
 					return
-		if((flags_gun_features & GUN_WIELDED_FIRING_ONLY) && !(flags_item & WIELDED)) //If we're not holding the weapon with both hands when we should.
+		if((flags_gun_features & GUN_WIELDED_FIRING_ONLY) && !(flags_item & WIELDED) && !active_attachable) //If we're not holding the weapon with both hands when we should.
 			to_chat(user, SPAN_WARNING("You need a more secure grip to fire this weapon!"))
 			return
 

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -2261,7 +2261,7 @@ Defined in conflicts.dm of the #defines folder.
 	var/obj/item/weapon/gun/attached_gun = loc
 
 	if(!(attached_gun.flags_item & WIELDED))
-		to_chat(user, SPAN_WARNING("You must wield [attached_gun] to fire \the [src]!"))
+		to_chat(user, SPAN_WARNING("You must wield [attached_gun] to fire [src]!"))
 		return
 
 	if(current_rounds > round_usage_per_tile && ..())
@@ -2408,7 +2408,7 @@ Defined in conflicts.dm of the #defines folder.
 	if(!internal_extinguisher)
 		return
 	if(!(gun.flags_item & WIELDED))
-		to_chat(user, SPAN_WARNING("You must wield [gun] to fire \the [src]!"))
+		to_chat(user, SPAN_WARNING("You must wield [gun] to fire [src]!"))
 		return
 	if(..())
 		return internal_extinguisher.afterattack(target, user)
@@ -2470,7 +2470,7 @@ Defined in conflicts.dm of the #defines folder.
 		return
 
 	if((gun.flags_gun_features & GUN_WIELDED_FIRING_ONLY) && !(gun.flags_item & WIELDED))
-		to_chat(user, SPAN_WARNING("You must wield [gun] to fire \the [src]!"))
+		to_chat(user, SPAN_WARNING("You must wield [gun] to fire [src]!"))
 		return
 
 	if(gun.flags_gun_features & GUN_TRIGGER_SAFETY)

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -2407,6 +2407,9 @@ Defined in conflicts.dm of the #defines folder.
 /obj/item/attachable/attached_gun/extinguisher/fire_attachment(atom/target, obj/item/weapon/gun/gun, mob/living/user)
 	if(!internal_extinguisher)
 		return
+	if(!(gun.flags_item & WIELDED))
+		to_chat(user, SPAN_WARNING("You must wield \the [gun] to fire \the [src]!"))
+		return
 	if(..())
 		return internal_extinguisher.afterattack(target, user)
 
@@ -2467,7 +2470,7 @@ Defined in conflicts.dm of the #defines folder.
 		return
 
 	if((gun.flags_gun_features & GUN_WIELDED_FIRING_ONLY) && !(gun.flags_item & WIELDED))
-		to_chat(user, SPAN_WARNING("You need a more secure grip to fire this weapon!"))
+		to_chat(user, SPAN_WARNING("You must wield \the [gun] to fire \the [src]!"))
 		return
 
 	if(gun.flags_gun_features & GUN_TRIGGER_SAFETY)

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -2261,7 +2261,7 @@ Defined in conflicts.dm of the #defines folder.
 	var/obj/item/weapon/gun/attached_gun = loc
 
 	if(!(attached_gun.flags_item & WIELDED))
-		to_chat(user, SPAN_WARNING("You must wield \the [attached_gun] to fire \the [src]!"))
+		to_chat(user, SPAN_WARNING("You must wield [attached_gun] to fire \the [src]!"))
 		return
 
 	if(current_rounds > round_usage_per_tile && ..())
@@ -2408,7 +2408,7 @@ Defined in conflicts.dm of the #defines folder.
 	if(!internal_extinguisher)
 		return
 	if(!(gun.flags_item & WIELDED))
-		to_chat(user, SPAN_WARNING("You must wield \the [gun] to fire \the [src]!"))
+		to_chat(user, SPAN_WARNING("You must wield [gun] to fire \the [src]!"))
 		return
 	if(..())
 		return internal_extinguisher.afterattack(target, user)

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -2470,7 +2470,7 @@ Defined in conflicts.dm of the #defines folder.
 		return
 
 	if((gun.flags_gun_features & GUN_WIELDED_FIRING_ONLY) && !(gun.flags_item & WIELDED))
-		to_chat(user, SPAN_WARNING("You must wield \the [gun] to fire \the [src]!"))
+		to_chat(user, SPAN_WARNING("You must wield [gun] to fire \the [src]!"))
 		return
 
 	if(gun.flags_gun_features & GUN_TRIGGER_SAFETY)


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->
fixes #4194 
Fixes weird behaviour with underbarrel fire extinguisher being able to be used one handed on some weapons but not on others 

All attachable weapons will now require you to hold them with both hands in order to be used. (( added an exception flag for future attachies that may need it))

standarized error message you receive when you are not wielding an attachment.

# Explain why it's good for the game
realism and standarized behaviour for all attachments 

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: Masterkey and underbarrel extinguisher now must be wielded in order to be used.
fix: Underbarrel extinguisher no longer bypass wielding restrictions on flamers.
/:cl:
