### PR TITLE
Fixes UPP Soldier preset

### DIFF
--- a/code/modules/gear_presets/survivors.dm
+++ b/code/modules/gear_presets/survivors.dm
@@ -1566,7 +1566,7 @@
 	..()
 
 /datum/equipment_preset/survivor/upp
-	name = "UPP Soldier"
+	name = "Survivor - UPP"
 	paygrade = "UE1"
 	origin_override = ORIGIN_UPP
 	rank = JOB_SURVIVOR


### PR DESCRIPTION


# About the pull request

UPP soldier preset was getting overridden by the base UPP survivor preset via having the same preset name. 😢 

Fixes.


# Explain why it's good for the game

People will stop pinging me thinking my UPP gun PR is the thing causing the issue.


# Changelog
:cl:
fix: UPP soldier preset works again
/:cl:
