### PR TITLE
General Quarters via ARES no longer cares if Red alert or not

### DIFF
--- a/code/game/machinery/ARES/ARES.dm
+++ b/code/game/machinery/ARES/ARES.dm
@@ -157,6 +157,7 @@
 
 	COOLDOWN_DECLARE(ares_distress_cooldown)
 	COOLDOWN_DECLARE(ares_nuclear_cooldown)
+	COOLDOWN_DECLARE(ares_quarters_cooldown)
 
 /obj/structure/machinery/computer/ares_console/proc/link_systems(datum/ares_link/new_link = GLOB.ares_link, override)
 	if(link && !override)

--- a/code/game/machinery/ARES/ARES_procs.dm
+++ b/code/game/machinery/ARES/ARES_procs.dm
@@ -508,7 +508,7 @@ GLOBAL_LIST_INIT(maintenance_categories, list(
 		// -- Emergency Buttons -- //
 		if("general_quarters")
 			if(!COOLDOWN_FINISHED(src, ares_quarters_cooldown))
-				to_chat(usr, SPAN_WARNING("It has not been long enough since last General Quarters call!"))
+				to_chat(usr, SPAN_WARNING("It has not been long enough since the last General Quarters call!"))
 				playsound(src, 'sound/machines/buzz-two.ogg', 15, 1)
 				return FALSE
 			if(security_level < SEC_LEVEL_RED)

--- a/code/game/machinery/ARES/ARES_procs.dm
+++ b/code/game/machinery/ARES/ARES_procs.dm
@@ -511,8 +511,8 @@ GLOBAL_LIST_INIT(maintenance_categories, list(
 				to_chat(usr, SPAN_WARNING("It has not been long enough since last General Quarters call!"))
 				playsound(src, 'sound/machines/buzz-two.ogg', 15, 1)
 				return FALSE
-			if(security_level != SEC_LEVEL_RED && security_level != SEC_LEVEL_DELTA)
-				set_security_level(2, no_sound = TRUE, announce = FALSE)
+			if(security_level < SEC_LEVEL_RED)
+				set_security_level(SEC_LEVEL_RED, no_sound = TRUE, announce = FALSE)
 			shipwide_ai_announcement("ATTENTION! GENERAL QUARTERS. ALL HANDS, MAN YOUR BATTLESTATIONS.", MAIN_AI_SYSTEM, 'sound/effects/GQfullcall.ogg')
 			log_game("[key_name(usr)] has called for general quarters via ARES.")
 			message_admins("[key_name_admin(usr)] has called for general quarters via ARES.")

--- a/code/game/machinery/ARES/ARES_procs.dm
+++ b/code/game/machinery/ARES/ARES_procs.dm
@@ -208,6 +208,7 @@ GLOBAL_LIST_INIT(maintenance_categories, list(
 
 	data["distresstime"] = ares_distress_cooldown
 	data["distresstimelock"] = DISTRESS_TIME_LOCK
+	data["quarterstime"] = ares_quarters_cooldown
 	data["mission_failed"] = SSticker.mode.is_in_endgame
 	data["nuketimelock"] = NUCLEAR_TIME_LOCK
 	data["nuke_available"] = nuke_available
@@ -506,16 +507,18 @@ GLOBAL_LIST_INIT(maintenance_categories, list(
 
 		// -- Emergency Buttons -- //
 		if("general_quarters")
-			if(security_level == SEC_LEVEL_RED || security_level == SEC_LEVEL_DELTA)
-				to_chat(usr, SPAN_WARNING("Alert level is already red or above, General Quarters cannot be called."))
+			if(!COOLDOWN_FINISHED(src, ares_quarters_cooldown))
+				to_chat(usr, SPAN_WARNING("It has not been long enough since last General Quarters call!"))
 				playsound(src, 'sound/machines/buzz-two.ogg', 15, 1)
 				return FALSE
-			set_security_level(2, no_sound = TRUE, announce = FALSE)
+			if(security_level != SEC_LEVEL_RED && security_level != SEC_LEVEL_DELTA)
+				set_security_level(2, no_sound = TRUE, announce = FALSE)
 			shipwide_ai_announcement("ATTENTION! GENERAL QUARTERS. ALL HANDS, MAN YOUR BATTLESTATIONS.", MAIN_AI_SYSTEM, 'sound/effects/GQfullcall.ogg')
 			log_game("[key_name(usr)] has called for general quarters via ARES.")
 			message_admins("[key_name_admin(usr)] has called for general quarters via ARES.")
 			var/datum/ares_link/link = GLOB.ares_link
 			link.log_ares_security("General Quarters", "[last_login] has called for general quarters via ARES.")
+			COOLDOWN_START(src, ares_quarters_cooldown, 10 MINUTES)
 			. = TRUE
 
 		if("evacuation_start")

--- a/tgui/packages/tgui/interfaces/AresInterface.js
+++ b/tgui/packages/tgui/interfaces/AresInterface.js
@@ -1385,8 +1385,7 @@ const Emergency = (props, context) => {
   let quarters_reason = 'Call for General Quarters.';
   if (quartersCooldown) {
     quarters_reason = 'It has not been long enough since last General Quarters call.';
-  }
-  const canDistress = alert_level === 2 && !distressCooldown && minimumEvacTime;
+  } const canDistress = alert_level === 2 && !distressCooldown && minimumEvacTime;
   let distress_reason = 'Launch a Distress Beacon.';
   if (alert_level === 3) {
     distress_reason = 'Self-destruct in progress. Beacon disabled.';

--- a/tgui/packages/tgui/interfaces/AresInterface.js
+++ b/tgui/packages/tgui/interfaces/AresInterface.js
@@ -1372,15 +1372,20 @@ const Emergency = (props, context) => {
     worldtime,
     distresstimelock,
     distresstime,
+    quarterstime,
     evac_status,
     mission_failed,
     nuketimelock,
     nuke_available,
   } = data;
-  const canQuarters = alert_level < 2;
-  let quarters_reason = 'Call for General Quarters.';
   const minimumEvacTime = worldtime > distresstimelock;
   const distressCooldown = worldtime < distresstime;
+  const quartersCooldown = worldtime < quarterstime;
+  const canQuarters = !quartersCooldown;
+  let quarters_reason = 'Call for General Quarters.';
+  if(quartersCooldown) {
+    quarters_reason = 'It has not been long enough since last General Quarters call.';
+  }
   const canDistress = alert_level === 2 && !distressCooldown && minimumEvacTime;
   let distress_reason = 'Launch a Distress Beacon.';
   if (alert_level === 3) {

--- a/tgui/packages/tgui/interfaces/AresInterface.js
+++ b/tgui/packages/tgui/interfaces/AresInterface.js
@@ -1385,7 +1385,7 @@ const Emergency = (props, context) => {
   let quarters_reason = 'Call for General Quarters.';
   if (quartersCooldown) {
     quarters_reason =
-      'It has not been long enough since last General Quarters call.';
+      'It has not been long enough since the last General Quarters call.';
   }
   const canDistress = alert_level === 2 && !distressCooldown && minimumEvacTime;
   let distress_reason = 'Launch a Distress Beacon.';

--- a/tgui/packages/tgui/interfaces/AresInterface.js
+++ b/tgui/packages/tgui/interfaces/AresInterface.js
@@ -1384,8 +1384,10 @@ const Emergency = (props, context) => {
   const canQuarters = !quartersCooldown;
   let quarters_reason = 'Call for General Quarters.';
   if (quartersCooldown) {
-    quarters_reason = 'It has not been long enough since last General Quarters call.';
-  } const canDistress = alert_level === 2 && !distressCooldown && minimumEvacTime;
+    quarters_reason =
+      'It has not been long enough since last General Quarters call.';
+  }
+  const canDistress = alert_level === 2 && !distressCooldown && minimumEvacTime;
   let distress_reason = 'Launch a Distress Beacon.';
   if (alert_level === 3) {
     distress_reason = 'Self-destruct in progress. Beacon disabled.';

--- a/tgui/packages/tgui/interfaces/AresInterface.js
+++ b/tgui/packages/tgui/interfaces/AresInterface.js
@@ -1383,7 +1383,7 @@ const Emergency = (props, context) => {
   const quartersCooldown = worldtime < quarterstime;
   const canQuarters = !quartersCooldown;
   let quarters_reason = 'Call for General Quarters.';
-  if(quartersCooldown) {
+  if (quartersCooldown) {
     quarters_reason = 'It has not been long enough since last General Quarters call.';
   }
   const canDistress = alert_level === 2 && !distressCooldown && minimumEvacTime;


### PR DESCRIPTION

# About the pull request

ARES general quarter call no longer cares if it is Red Alert already, but has a 10 minute cooldown between uses

# Explain why it's good for the game

Many been telling me how they like General Quarters, but usually can't use it as Red Alert has been called already, this makes it so it can still be used (albeit no mechanical effect), but a cooldown has been added to prevent spam.

# Changelog
:cl:
qol: General Quarters via ARES can now be called regardless of alert level.
/:cl:
