### PR TITLE
Ghost scan health nerf round 2

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -558,7 +558,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 	var/mob/living/carbon/human/original_human = mind.original
 
-	if(!original_human.check_tod() || !original_human.is_revivable() || !can_reenter_corpse)
+	if((original_human.stat == DEAD && !original_human.check_tod() || !original_human.is_revivable()) || !can_reenter_corpse)
 		view_health_scan(target)
 		return
 


### PR DESCRIPTION

# About the pull request

Sneaky fellas were waiting to be revived and then scanning health before re-entering the body which bypassed the previous checks. Naughty naughty.


# Explain why it's good for the game

Not intentional.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
fix: fixed a bypass to allow ghost scan health when it should not be allowed
/:cl:
