### PR TITLE
whispering should use the correct new icon

### DIFF
--- a/code/modules/mob/living/carbon/human/whisper.dm
+++ b/code/modules/mob/living/carbon/human/whisper.dm
@@ -95,7 +95,7 @@
 
 	//now mobs
 	var/speech_bubble_test = say_test(message)
-	var/image/speech_bubble = image('icons/mob/hud/talk.dmi',src,"h[speech_bubble_test]")
+	var/image/speech_bubble = image('icons/mob/effects/talk.dmi',src,"[bubble_icon][speech_bubble_test]")
 	speech_bubble.appearance_flags = NO_CLIENT_COLOR|KEEP_APART|RESET_COLOR
 
 	var/not_dead_speaker = (stat != DEAD)


### PR DESCRIPTION
not this old one

:cl:
fix: whispering no longer uses the old speech bubble
/:cl: