### PR TITLE
Fixes medbay door buttons

### DIFF
--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -60064,7 +60064,7 @@
 	},
 /obj/structure/machinery/door/airlock/multi_tile/almayer/medidoor{
 	dir = 2;
-	id_tag = "tc04";
+	id_tag = "tc02";
 	name = "\improper Treatment Center"
 	},
 /turf/open/floor/almayer{
@@ -62940,7 +62940,7 @@
 	},
 /obj/structure/machinery/door/airlock/multi_tile/almayer/medidoor{
 	dir = 2;
-	id_tag = "tc04";
+	id_tag = "tc01";
 	name = "\improper Treatment Center"
 	},
 /turf/open/floor/almayer{


### PR DESCRIPTION

# About the pull request

Fixes the button IDs on the western medbay doors.

I just want it on the record this is probably the third time I've fixed these and if I have to do it again I will curse your family for 11 generations.

# Explain why it's good for the game

Bug bad


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
fix: Fixed western medbay door buttons
/:cl:
