### PR TITLE
actually fixes m4ra custom barrel offset

### DIFF
--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -567,7 +567,7 @@
 
 
 /obj/item/weapon/gun/rifle/m4ra_custom/set_gun_attachment_offsets()
-	attachable_offset = list("muzzle_x" = 43, "muzzle_y" = 17,"rail_x" = 23, "rail_y" = 21, "under_x" = 30, "under_y" = 11, "stock_x" = 24, "stock_y" = 13, "special_x" = 39, "special_y" = 17)
+	attachable_offset = list("muzzle_x" = 43, "muzzle_y" = 17,"rail_x" = 23, "rail_y" = 21, "under_x" = 30, "under_y" = 11, "stock_x" = 24, "stock_y" = 13, "special_x" = 37, "special_y" = 16)
 
 /obj/item/weapon/gun/rifle/m4ra_custom/set_gun_config_values()
 	..()


### PR DESCRIPTION

# About the pull request

I'm very confused, one day this is the correct thing that fixes the offset and the next it breaks it. I literally tested it, but I guess the old offsets are right? Maybe?

# Explain why it's good for the game


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: actually fixes m4ra custom barrel offset
/:cl:
