### PR TITLE
3324 - Fixes kitchen soda fountain being wrenchable

### DIFF
--- a/code/modules/reagents/chemistry_machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry_machinery/chem_dispenser.dm
@@ -235,6 +235,7 @@
 	if(HAS_TRAIT(attacking_object, TRAIT_TOOL_WRENCH))
 		if(!wrenchable)
 			to_chat(user, "[src] cannot be unwrenched.")
+			return
 
 		if(!do_after(user, 2 SECONDS, INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD))
 			return


### PR DESCRIPTION
# About the pull request

Fixes #3324

Fixes the kitchen soda fountain displaying an error about being unwrenchable, but still allowing the soda machine to be unanchored and moved.

# Explain why it's good for the game

It stops players moving the soda fountain planetside.

# Changelog
:cl:
fix: Fixes the kitchen soda fountain being wrenchable.
/:cl:
