### PR TITLE
LV-624 Move Position of Hidden Floor Safe

### DIFF
--- a/maps/map_files/LV624/LV624.dmm
+++ b/maps/map_files/LV624/LV624.dmm
@@ -10305,7 +10305,6 @@
 "aSQ" = (
 /obj/structure/safe/floor{
 	name = "safe";
-	pixel_x = 30;
 	spawnkey = 0
 	},
 /turf/open/floor{


### PR DESCRIPTION

# About the pull request

Moves the positioning of the hidden floor safe in the Commandant's office from being placed in a wall to being in the centre of the tile it is on.

# Explain why it's good for the game

Floor safe should be on the floor, not hidden under a wall. 


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
maptweak: Hidden floor safe in LV-624 is now positioned correctly. 
/:cl:
