### PR TITLE
Machete in-hand activation

### DIFF
--- a/code/game/objects/items/weapons/blades.dm
+++ b/code/game/objects/items/weapons/blades.dm
@@ -32,6 +32,25 @@
 	icon_state = "machete"
 	w_class = SIZE_LARGE
 
+/obj/item/weapon/claymore/mercsword/machete/attack_self(mob/user)
+	if(user.action_busy)
+		return
+
+	var/turf/root = get_turf(user)
+	var/facing = user.dir
+	// List containing the 3 tiles in front of the user
+	var/list/in_front = list(get_step(root, facing),  get_step(root, turn(facing, 45)),  get_step(root, turn(facing, -45)))
+
+	// We check each tile in front of us, if it has flora that can be cut we will attempt to cut it
+	for(var/turf/current_turf in in_front)
+		for(var/obj/structure/flora/target in current_turf)
+			if(target.cut_level > 1)
+				if(!do_after(user, 10, INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD))
+					return
+				target.attackby(src, user)
+
+	return ..()
+
 /obj/item/weapon/claymore/mercsword/machete/arnold
 	name = "\improper M2100 \"Ngájhe\" machete"
 	desc = "An older issue USCM machete, never left testing. Designed in the Central African Republic. The notching made it hard to clean, and as such the USCM refused to adopt it - despite the superior bludgeoning power offered. Difficult to carry with the usual kit."

--- a/code/game/objects/items/weapons/blades.dm
+++ b/code/game/objects/items/weapons/blades.dm
@@ -38,16 +38,14 @@
 
 	var/turf/root = get_turf(user)
 	var/facing = user.dir
-	// List containing the 3 tiles in front of the user
-	var/list/in_front = list(get_step(root, facing),  get_step(root, turn(facing, 45)),  get_step(root, turn(facing, -45)))
+	var/turf/in_front = get_step(root, facing)
 
-	// We check each tile in front of us, if it has flora that can be cut we will attempt to cut it
-	for(var/turf/current_turf in in_front)
-		for(var/obj/structure/flora/target in current_turf)
-			if(target.cut_level > 1)
-				if(!do_after(user, 10, INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD))
-					return
-				target.attackby(src, user)
+	// We check the tile in front of us, if it has flora that can be cut we will attempt to cut it
+	for(var/obj/structure/flora/target in in_front)
+		if(target.cut_level > 1)
+			if(!do_after(user, 10, INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD))
+				return
+			target.attackby(src, user)
 
 	return ..()
 


### PR DESCRIPTION
# About the pull request

Trying to clear vines by clicking on them is extremely infuriating due to their thin hitboxes. This will give marines a much much comfier way to clear vines, while also making the machete actually be better for doing it than the easier to store hatchet.
Works by checking the tile directly ahead of the user, and if it finds any cutable objects it will try to cut them.
The delay on cutting was set in a way so as to reflect the speed at what a semi-good player would be able to cut at with clicking (accounting for usual server tick slowdown).

Also there appears to be a ton of invisible vines littered all over LV, someone should fix that.

# Explain why it's good for the game

QOL, less annoying to do an important job on maps like LV-624.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>



https://github.com/cmss13-devs/cmss13/assets/15560820/e0ccb094-4f1a-49cd-a8cb-08b4428bfa33




</details>


# Changelog
:cl:
qol: Added in-hand activation for machetes, which will cause one to start cutting vines and grass on the tile directly in-front.
/:cl:
