### PR TITLE
Fixed funny invisible vines

### DIFF
--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -633,15 +633,15 @@ ICEY GRASS. IT LOOKS LIKE IT'S MADE OF ICE.
 
 /obj/structure/flora/jungle/vines/light_1
 	icon_state = "light_1"
-	icon_tag = "light_1"
+	icon_tag = "light"
 
 /obj/structure/flora/jungle/vines/light_2
 	icon_state = "light_2"
-	icon_tag = "light_2"
+	icon_tag = "light"
 
 /obj/structure/flora/jungle/vines/light_3
 	icon_state = "light_3"
-	icon_tag = "light_3"
+	icon_tag = "light"
 
 //heavy hide you
 /obj/structure/flora/jungle/vines/heavy


### PR DESCRIPTION

# About the pull request


Did you know that most of the light vines on LV were invisible? Since 2019.09.12? Aint that great!?
Is fix now.

# Explain why it's good for the game

Bug !good

# Testing Photographs and Procedure
Check the screenshots!
<details>
<summary>Screenshots & Videos</summary>
This is how it has been looking:

![Old_SW_Jungle](https://github.com/cmss13-devs/cmss13/assets/15560820/110e6497-5369-426b-84ae-5e7e5afde026)



Is supposed to look like this:
![SW_Jungle](https://github.com/cmss13-devs/cmss13/assets/15560820/819e49f5-2bbc-4af5-b026-5884e1d26867)


</details>


# Changelog
:cl:
fix: Most 'light' vines on LV are no longer invisible.
/:cl:
