### PR TITLE
Fix carrier mutation sprite update

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/mutators/strains/carrier/eggsac.dm
+++ b/code/modules/mob/living/carbon/xenomorph/mutators/strains/carrier/eggsac.dm
@@ -24,7 +24,6 @@
 	var/mob/living/carbon/xenomorph/carrier/carrier = mutator_set.xeno
 	if(!istype(carrier))
 		return FALSE
-	carrier.mutation_type = CARRIER_EGGSAC
 	carrier.plasma_types = list(PLASMA_EGG)
 	carrier.phero_modifier += XENO_PHERO_MOD_LARGE // praetorian level pheremones
 	carrier.plasmapool_modifier = 1.2
@@ -37,6 +36,7 @@
 	carrier.huggers_cur = 0
 	carrier.huggers_max = 0
 	carrier.update_hugger_overlays()
+	carrier.mutation_type = CARRIER_EGGSAC
 	carrier.update_eggsac_overlays()
 	carrier.eggs_max = 12
 	carrier.egg_planting_range = 2


### PR DESCRIPTION

# About the pull request

Fixes #3994 

# Explain why it's good for the game

Fixes issue

# Testing Photographs and Procedure
Tested in local instance. Set huggers to 16 qty and then purchase the strain.
`update_hugger_overlays()` was running with the eggsac mutation type. So it would just return and not actually update the icon. It now updates correctly before applying the eggsac icon.
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: fixed eggsac carrier strain not updating hugger sprites.
/:cl:
