### PR TITLE
Removes debuffs from the folded M39 stock

### DIFF
--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -1809,7 +1809,7 @@ Defined in conflicts.dm of the #defines folder.
 
 /obj/item/attachable/stock/smg/collapsible
 	name = "submachinegun folding stock"
-	desc = "A Kirchner brand K2 M39 folding stock, standard issue in the USCM. The stock, when extended, reduces recoil and improves accuracy, but at a reduction to handling and agility. Seemingly a bit more effective in a brawl. This stock can collapse in, removing almost all positive and negative effects, however it slightly increases spread due to weapon being off-balanced by the collapsed stock."
+	desc = "A Kirchner brand K2 M39 folding stock, standard issue in the USCM. The stock, when extended, reduces recoil and improves accuracy, but at a reduction to handling and agility. Seemingly a bit more effective in a brawl. This stock can collapse in, removing all positive and negative effects."
 	slot = "stock"
 	melee_mod = 10
 	size_mod = 1
@@ -1842,6 +1842,9 @@ Defined in conflicts.dm of the #defines folder.
 
 /obj/item/attachable/stock/smg/collapsible/apply_on_weapon(obj/item/weapon/gun/gun)
 	if(stock_activated)
+		accuracy_mod = HIT_ACCURACY_MULT_TIER_3
+		recoil_mod = -RECOIL_AMOUNT_TIER_4
+		scatter_mod = -SCATTER_AMOUNT_TIER_8
 		scatter_unwielded_mod = SCATTER_AMOUNT_TIER_10
 		size_mod = 1
 		aim_speed_mod = CONFIG_GET(number/slowdown_low)
@@ -1854,21 +1857,19 @@ Defined in conflicts.dm of the #defines folder.
 		attach_icon = "smgstockc_a"
 
 	else
+		accuracy_mod = 0
+		recoil_mod = 0
+		scatter_mod = 0
 		scatter_unwielded_mod = 0
 		size_mod = 0
 		aim_speed_mod = 0
 		wield_delay_mod = 0
 		movement_onehanded_acc_penalty_mod = 0
-		accuracy_unwielded_mod = -HIT_ACCURACY_MULT_TIER_1
-		recoil_unwielded_mod = RECOIL_AMOUNT_TIER_5
+		accuracy_unwielded_mod = 0
+		recoil_unwielded_mod = 0
 		hud_offset_mod = 3
 		icon_state = "smgstockcc"
 		attach_icon = "smgstockcc_a"
-
-	//don't *= -1 on debuffs, you'd actually be making than without stock when it's collapsed.
-	accuracy_mod *= -1
-	recoil_mod *= -1
-	scatter_mod *= -1
 
 	gun.recalculate_attachment_bonuses()
 	gun.update_overlays(src, "stock")


### PR DESCRIPTION
# About the pull request

removes the debuffs from the folded M39 stock, making it equal to a stockless M39.

# Explain why it's good for the game

currently there's no reason to fold your stock, as it inflicts a heavy wielded scatter penalty (from 9 scatter when extended to 15 when folded) with the only benefit being a removal of the wield delay and slightly better onehanded performance.

a marine shouldn't be penalized for interacting with the folding stock. hopefully this make the attachment a bit more useful in its secondary form.

<details>
  <summary>stat changes for anyone curious how it looks like in-game</summary>
  
![image](https://github.com/cmss13-devs/cmss13/assets/17518895/bfd6b1cf-48fa-4fec-b925-8b71b1857112)
(old stock, folded)
![image](https://github.com/cmss13-devs/cmss13/assets/17518895/c7b2aee8-cddd-4e55-b6f1-a005a9ee75ff)
</details>

# Changelog

:cl:
balance: The M39 foldable stock no longer inflicts debuffs when folded.
/:cl:
