### PR TITLE
Donut Spelling Error Fix

### DIFF
--- a/code/datums/supply_packs/food.dm
+++ b/code/datums/supply_packs/food.dm
@@ -141,7 +141,7 @@
 	//all the finish snacks.
 
 /datum/supply_packs/donuts
-	name = "boxe of donut (x5)"
+	name = "box of donuts (x5)"
 	contains = list(
 		/obj/item/storage/donut_box,
 		/obj/item/storage/donut_box,
@@ -151,7 +151,7 @@
 	)
 	cost = 10
 	containertype = /obj/structure/closet/crate/supply
-	containername = "\improper boxe of donut (x5)"
+	containername = "\improper box of donuts (x5)"
 	group = "Food"
 
 /datum/supply_packs/mre

--- a/code/datums/supply_packs/food.dm
+++ b/code/datums/supply_packs/food.dm
@@ -151,7 +151,7 @@
 	)
 	cost = 10
 	containertype = /obj/structure/closet/crate/supply
-	containername = "\improper box of donuts (x5)"
+	containername = "box of donuts (x5)"
 	group = "Food"
 
 /datum/supply_packs/mre


### PR DESCRIPTION

# About the pull request

Fixes a spelling error with the box of donuts crate in req.

# Explain why it's good for the game

Spelling


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
spellcheck: Box of donuts order from req is now spelt correctly
/:cl:
