### PR TITLE
Possible fix for double dropship landing sound

### DIFF
--- a/code/modules/shuttle/shuttles/dropship.dm
+++ b/code/modules/shuttle/shuttles/dropship.dm
@@ -123,7 +123,6 @@
 		if(istype(destination, /obj/docking_port/stationary/marine_dropship))
 			dropzone.turn_on_landing_lights()
 		playsound(dropzone.return_center_turf(), landing_sound, 60, 0)
-		playsound(return_center_turf(), landing_sound, 60, 0)
 
 	automated_check()
 


### PR DESCRIPTION
# About the pull request

From time to time I will hear two landing sounds when landing in a dropship. 

I believe this is the cause of it as the landing sound *should* be handled by on_prearrival() at line 551 of code/modules/shuttle/shuttle.dm

# Explain why it's good for the game

Bug bad

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
fix: Possible fix for double dropship landing sound
/:cl:
