### PR TITLE
Brain damage tweaks

### DIFF
--- a/code/modules/organs/organ_internal.dm
+++ b/code/modules/organs/organ_internal.dm
@@ -250,10 +250,14 @@
 /datum/internal_organ/brain/process(delta_time)
 	..()
 
+	if(owner.chem_effect_flags & CHEM_EFFECT_ORGAN_STASIS)
+		return
+
 	if(organ_status >= ORGAN_BRUISED && prob(5 * delta_time))
 		var/dir_choice = pick(list(NORTH, SOUTH, EAST, WEST))
 		owner.drop_held_items()
-		owner.Move(get_step(get_turf(owner), dir_choice))
+		if(!owner.buckled && owner.stat == CONSCIOUS)
+			owner.Move(get_step(get_turf(owner), dir_choice))
 		to_chat(owner, SPAN_DANGER("Your mind wanders and goes blank for a moment..."))
 
 	if(organ_status >= ORGAN_BROKEN && prob(5 * delta_time))


### PR DESCRIPTION

# About the pull request

This PR:

Makes peri work for brain damage

Stops you from moving while buckled or not conscious

# Explain why it's good for the game

No more unconscious people crawling away from medics

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
fix: Peri now works for brain damage
fix: Brain damage movement will no longer occur while buckled and unconscious
/:cl:
