### PR TITLE
Working Joes no longer get a cryo emergency kit

### DIFF
--- a/code/game/jobs/job/civilians/support/working_joe.dm
+++ b/code/game/jobs/job/civilians/support/working_joe.dm
@@ -12,6 +12,7 @@
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT|ROLE_WHITELISTED|ROLE_CUSTOM_SPAWN
 	flags_whitelist = WHITELIST_JOE
 	gear_preset = /datum/equipment_preset/synth/working_joe
+	gets_emergency_kit = FALSE
 
 	job_options = list(STANDARD_VARIANT = "JOE", HAZMAT_VARIANT = "HAZ")
 	var/standard = TRUE

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -37,6 +37,8 @@
 	/// When set you will be able to choose between the different job options when selecting your role.
 	/// Associated list. Main list elements - actual options, associated values - shorthands for job preferences menu (keep those short).
 	var/job_options
+	/// If TRUE, this job will spawn w/ a cryo emergency kit during evac/red alert
+	var/gets_emergency_kit = TRUE
 
 /datum/job/New()
 	. = ..()

--- a/code/modules/cm_marines/equipment/kit_boxes.dm
+++ b/code/modules/cm_marines/equipment/kit_boxes.dm
@@ -483,7 +483,7 @@
 	name = "\improper Cryo Self Defense Kit"
 	desc = "A basic self-defense kit reserved for emergencies. As you might expect, not much care was put into keeping the stock fresh, who would be insane enough to attack a USCM ship directly?"
 	icon_state = "cryo_defense_kit"
-	storage_slots = 2
+	storage_slots = 3
 
 /obj/item/storage/box/kit/cryo_self_defense/update_icon()
 	if(LAZYLEN(contents))

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -228,6 +228,7 @@
 			new_player_panel()
 
 /mob/new_player/proc/AttemptLateSpawn(rank)
+	var/datum/job/player_rank = RoleAuthority.roles_for_mode[rank]
 	if (src != usr)
 		return
 	if(SSticker.current_state != GAME_STATE_PLAYING)
@@ -236,7 +237,7 @@
 	if(!enter_allowed)
 		to_chat(usr, SPAN_WARNING("There is an administrative lock on entering the game! (The dropship likely crashed into the Almayer. This should take at most 20 minutes.)"))
 		return
-	if(!RoleAuthority.assign_role(src, RoleAuthority.roles_for_mode[rank], 1))
+	if(!RoleAuthority.assign_role(src, player_rank, 1))
 		to_chat(src, alert("[rank] is not available. Please try another."))
 		return
 
@@ -244,16 +245,16 @@
 	close_spawn_windows()
 
 	var/mob/living/carbon/human/character = create_character(TRUE) //creates the human and transfers vars and mind
-	RoleAuthority.equip_role(character, RoleAuthority.roles_for_mode[rank], late_join = TRUE)
+	RoleAuthority.equip_role(character, player_rank, late_join = TRUE)
 	EquipCustomItems(character)
 
-	if(security_level > SEC_LEVEL_BLUE || EvacuationAuthority.evac_status)
+	if((security_level > SEC_LEVEL_BLUE || EvacuationAuthority.evac_status) && player_rank.gets_emergency_kit)
 		to_chat(character, SPAN_HIGHDANGER("As you stagger out of hypersleep, the sleep bay blares: '[EvacuationAuthority.evac_status ? "VESSEL UNDERGOING EVACUATION PROCEDURES, SELF DEFENSE KIT PROVIDED" : "VESSEL IN HEIGHTENED ALERT STATUS, SELF DEFENSE KIT PROVIDED"]'."))
 		character.put_in_hands(new /obj/item/storage/box/kit/cryo_self_defense(character.loc))
 
 	GLOB.data_core.manifest_inject(character)
 	SSticker.minds += character.mind//Cyborgs and AIs handle this in the transform proc. //TODO!!!!! ~Carn
-	SSticker.mode.latejoin_tally += RoleAuthority.calculate_role_weight(RoleAuthority.roles_for_mode[rank])
+	SSticker.mode.latejoin_tally += RoleAuthority.calculate_role_weight(player_rank)
 
 	for(var/datum/squad/sq in RoleAuthority.squads)
 		if(sq)


### PR DESCRIPTION

# About the pull request
Title.
Also gives the emergency kit the right amount of slots (2->3)

# Explain why it's good for the game
Joes are incapable of using guns and, in general, fighting back at all (some exceptions apply, but even then fists are better).

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>
works

</details>


# Changelog
:cl:
fix: Working Joes no longer get cryo self defense kits
fix: Cryo self defense kits now have the correct amount of slots
/:cl:
