### PR TITLE
Fixes perma helmet HUDs

### DIFF
--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -494,19 +494,20 @@ GLOBAL_LIST_INIT(allowed_helmet_items, list(
 		return
 
 	if(HAS_TRAIT(attacking_item, TRAIT_TOOL_SCREWDRIVER) && length(inserted_visors))
-		for(var/obj/item/device/visor as anything in inserted_visors)
+		for(var/obj/item/device/helmet_visor/visor as anything in inserted_visors)
 			visor.forceMove(get_turf(src))
 
 		inserted_visors = list()
 		to_chat(user, SPAN_NOTICE("You remove the inserted visors."))
-		turn_off_visor(user, active_visor, TRUE)
+		var/obj/item/device/helmet_visor/temp_visor_holder = active_visor
+		active_visor = null
+		turn_off_visor(user, temp_visor_holder, TRUE)
 
 		var/datum/action/item_action/cycle_helmet_huds/cycle_action = locate() in actions
 		cycle_action.set_default_overlay()
 		if(!length(built_in_visors))
 			cycle_action.remove_from(user)
 
-		active_visor = null
 		recalculate_visors(user)
 		return
 


### PR DESCRIPTION

# About the pull request

Fixes https://github.com/cmss13-devs/cmss13/issues/4317

In the refactor to have all functionality in helmet_visors base it now requires the active_visor to *not* be the current visor to turn off so we gotta null active_visor before we turn it off.

# Explain why it's good for the game

Bug bad


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
fix: Fixed perma helmet HUDs
/:cl:
