### PR TITLE
Clusters turning into pylons expand properly

### DIFF
--- a/code/game/machinery/telecomms/presets.dm
+++ b/code/game/machinery/telecomms/presets.dm
@@ -340,6 +340,8 @@ GLOBAL_LIST_EMPTY(all_static_telecomms_towers)
 
 	for(var/obj/effect/alien/weeds/weed in new_pylon.node.children)
 		weed.parent = new_pylon.node
+		weed.spread_on_semiweedable = TRUE
+		weed.weed_expand()
 
 	RegisterSignal(new_pylon, COMSIG_PARENT_QDELETING, PROC_REF(uncorrupt))
 


### PR DESCRIPTION

# About the pull request

Pylon weeds expand on semiweedable but if they inherit weeds from a cluster they will not update properly. This updates them and gives them a "keep growing idiot" kick so as to actually expand fully.

# Explain why it's good for the game

Pylons should expand onto semiweedable when made.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
fix: Clusters turning into pylons expand properly
/:cl:
