### PR TITLE
Fix hugger/lesser drone time of death bypass

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -268,7 +268,7 @@
 
 		// copied from join as xeno
 		var/deathtime = world.time - cur_obs.timeofdeath
-		if(deathtime < XENO_JOIN_DEAD_TIME && ( !cur_obs.client.admin_holder || !(cur_obs.client.admin_holder.rights & R_ADMIN) || !cur_obs.bypass_time_of_death_checks))
+		if(deathtime < XENO_JOIN_DEAD_TIME && ( !cur_obs.client.admin_holder || !(cur_obs.client.admin_holder.rights & R_ADMIN)) && !cur_obs.bypass_time_of_death_checks)
 			continue
 
 		// AFK players cannot be drafted


### PR DESCRIPTION

# About the pull request

Should fix the bypass_time_of_death_checks variable which is supposed to allow facehuggers and lesser drones to be eligible for larva queue even if they have recently died.
NOTE: I have no idea how to test this locally since for some reason I just cannot get larva queue to work locally at all (even when I haven't changed any code). I figured I'd put this PR up anyway and maintainers can take a look at it, but it may or may not actually work.

# Explain why it's good for the game

It was clearly intended that ghosts of lesser drones and face huggers (and anything else with bypass_time_of_death_checks set to true) will bypass the time of death check when the game checks for larva queue candidates. I think because of how the logic was written it never actually worked properly unless you were an admin.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Hugger and Lesser Drone ghosts now actually bypass time of death checks for the larva queue.
/:cl:
