### PR TITLE
moves full auto guns to be full auto by default

### DIFF
--- a/code/modules/projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/gun_helpers.dm
@@ -693,14 +693,14 @@ DEFINES in setup.dm, referenced here.
 	var/old_firemode = gun_firemode
 	gun_firemode_list.len = 0
 
+	if(start_automatic)
+		gun_firemode_list |= GUN_FIREMODE_AUTOMATIC
+
 	if(start_semiauto)
 		gun_firemode_list |= GUN_FIREMODE_SEMIAUTO
 
 	if(burst_amount > BURST_AMOUNT_TIER_1)
 		gun_firemode_list |= GUN_FIREMODE_BURSTFIRE
-
-	if(start_automatic)
-		gun_firemode_list |= GUN_FIREMODE_AUTOMATIC
 
 	if(!length(gun_firemode_list))
 		CRASH("[src] called setup_firemodes() with an empty gun_firemode_list")


### PR DESCRIPTION
i think having the qol of full auto behind the unintuitive weapon change verb. the Real fraggers that know that burst/semi-auto (take your pick) is better will just change to it and feel more elitist

:cl:
add: guns that have full auto now start on full auto by default
/:cl: