### PR TITLE
Null reference fix for full auto

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -1916,6 +1916,8 @@ not all weapons use normal magazines etc. load_into_chamber() itself is designed
 		target = src.target
 	if(!user)
 		user = gun_user
+	if(!target || !user)
+		return NONE
 	return Fire(target, user, params, reflex, dual_wield)
 
 /// Setter proc for fa_firing


### PR DESCRIPTION

# About the pull request

If you drop the gun while holding down full auto it will attempt to fire the next shot. The (!user) check on line 1917 just tries to assign gun_user to user but since there is no gun_user either it passes null. I debated on where to put this check for if user existed and am happy to move it around (and also remove the !target as it doesn't *seem* to have any issues so far).

```
runtime error: Cannot execute null.is mob incapacitated().
proc name: able to fire (/obj/item/weapon/gun/proc/able_to_fire)
  source file: code/modules/projectiles/gun.dm,1495
  usr: null
  src: the NSG 23 assault rifle (/obj/item/weapon/gun/rifle/nsg23/no_lock)
  src.loc: the floor (36,18,2) (/turf/open/floor/greengrid)
  call stack:
the NSG 23 assault rifle (/obj/item/weapon/gun/rifle/nsg23/no_lock): able to fire(null)
the NSG 23 assault rifle (/obj/item/weapon/gun/rifle/nsg23/no_lock): Fire(the grass (36,25,2) (/turf/open/gm/grass/grass1), null, null, 0, null)
the NSG 23 assault rifle (/obj/item/weapon/gun/rifle/nsg23/no_lock): fire wrapper(the grass (36,25,2) (/turf/open/gm/grass/grass1), null, null, 0, null)
/datum/callback (/datum/callback): Invoke()
/datum/component/automatedfire... (/datum/component/automatedfire/autofire): process shot()
ImmediateInvokeAsync(/datum/component/automatedfire... (/datum/component/automatedfire/autofire), "process_shot")
Automated fire (/datum/controller/subsystem/automatedfire): fire(0)
Automated fire (/datum/controller/subsystem/automatedfire): ignite(0)
Master (/datum/controller/master): RunQueue()
Master (/datum/controller/master): Loop(2)
Master (/datum/controller/master): StartProcessing(0)
```

# Changelog

:cl: Morrow
fix: Fixed a null reference when firing full auto and dropping your weapon
/:cl:
