### PR TITLE
Cryorine changes

### DIFF
--- a/code/datums/emergency_calls/cryo_marines.dm
+++ b/code/datums/emergency_calls/cryo_marines.dm
@@ -1,13 +1,12 @@
 
 
-//whiskey outpost extra marines
 /datum/emergency_call/cryo_squad
 	name = "Marine Cryo Reinforcements (Squad)"
 	mob_max = 10
 	mob_min = 1
 	probability = 0
 	objectives = "Assist the USCM forces"
-	max_engineers = 4
+	max_engineers = 2
 	max_medics = 2
 	name_of_spawn = /obj/effect/landmark/ert_spawns/distress_cryo
 	shuttle_id = ""
@@ -95,3 +94,10 @@
 
 /obj/effect/landmark/ert_spawns/distress_cryo
 	name = "Distress_Cryo"
+
+/datum/emergency_call/cryo_squad/tech
+	name = "Marine Cryo Reinforcements (Tech)"
+	mob_max = 5
+	max_engineers = 1
+	max_medics = 1
+	max_heavies = 0

--- a/code/modules/cm_tech/techs/marine/tier3/cryorine.dm
+++ b/code/modules/cm_tech/techs/marine/tier3/cryorine.dm
@@ -7,8 +7,8 @@
 	announce_name = "ALMAYER SPECIAL ASSETS AUTHORIZED"
 	announce_message = "Additional troops are being taken out of cryo."
 
-	required_points = 10
-	increase_per_purchase = 5
+	required_points = 6
+	increase_per_purchase = 6
 
 	flags = TREE_FLAG_MARINE
 	tier = /datum/tier/three
@@ -23,4 +23,4 @@
 
 /datum/tech/repeatable/cryomarine/on_unlock()
 	. = ..()
-	SSticker.mode.get_specific_call("Marine Cryo Reinforcements (Squad)", FALSE, FALSE, announce_dispatch_message = FALSE)
+	SSticker.mode.get_specific_call("Marine Cryo Reinforcements (Tech)", FALSE, FALSE, announce_dispatch_message = FALSE)


### PR DESCRIPTION

# About the pull request

Cryorines now cost 6 points. It increases by 6 each purchase.

Cryorines now give 5 marines. 1 SL (for the first one only), 1 medic, 1 engi, rest rifleman.

# Explain why it's good for the game

A bunch of extra specs running around is just too strong.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
balance: Cryorines now cost 6 points. It increases by 6 each purchase.
balance: Cryorines now give 5 marines. 1 SL (for the first one only), 1 medic, 1 engi, rest rifleman.
/:cl:
