### PR TITLE
End game timing changes

### DIFF
--- a/code/__DEFINES/xeno.dm
+++ b/code/__DEFINES/xeno.dm
@@ -169,7 +169,7 @@
 #define XENO_BURIED_LARVA_TIME_LIMIT (30 MINUTES)
 
 /// The time when xenos can start taking over comm towers
-#define XENO_COMM_ACQUISITION_TIME (90 MINUTES)
+#define XENO_COMM_ACQUISITION_TIME (55 MINUTES)
 
 /// The time it takes for a pylon to give one larva while activated
 #define XENO_PYLON_ACTIVATION_COOLDOWN (5 MINUTES)

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -199,6 +199,8 @@ SUBSYSTEM_DEF(ticker)
 	if(CONFIG_GET(flag/autooocmute))
 		ooc_allowed = FALSE
 
+	round_start_time = world.time
+
 	CHECK_TICK
 	for(var/I in round_start_events)
 		var/datum/callback/cb = I
@@ -222,9 +224,7 @@ SUBSYSTEM_DEF(ticker)
 			equip_characters()
 
 	GLOB.data_core.manifest()
-
 	log_world("Game start took [(world.timeofday - init_start) / 10]s")
-	round_start_time = world.time
 	//SSdbcore.SetRoundStart()
 
 	current_state = GAME_STATE_PLAYING

--- a/code/modules/cm_tech/techs/marine/tier4/nuke.dm
+++ b/code/modules/cm_tech/techs/marine/tier4/nuke.dm
@@ -2,7 +2,7 @@
 
 /datum/tech/nuke
 	name = "Nuclear Device"
-	//desc = "Purchase a nuclear device. Only able to purchase after X minutes into the operation. It's the only way to be sure." //See New()
+	desc = "Purchase a nuclear device. It's the only way to be sure."
 	icon_state = "nuke"
 
 	required_points = 5
@@ -15,7 +15,7 @@
 	flags = TREE_FLAG_MARINE
 
 /datum/tech/nuke/New()
-	desc = "Purchase a nuclear device. Only able to purchase [NUKE_UNLOCK_TIME / (1 MINUTES)] minutes into the operation. It's the only way to be sure."
+	SSticker.OnRoundstart(CALLBACK(src, PROC_REF(handle_description)))
 
 /datum/tech/nuke/on_unlock()
 	. = ..()
@@ -41,4 +41,5 @@
 
 	return TRUE
 
-#undef NUKE_UNLOCK_TIME
+/datum/tech/nuke/proc/handle_description()
+	desc = "Purchase a nuclear device. Only purchasable [Ceiling((NUKE_UNLOCK_TIME + SSticker.round_start_time) / (1 MINUTES))] minutes into the operation. It's the only way to be sure."

--- a/code/modules/cm_tech/techs/marine/tier4/nuke.dm
+++ b/code/modules/cm_tech/techs/marine/tier4/nuke.dm
@@ -1,11 +1,11 @@
-#define NUKE_UNLOCK_TIME (120 MINUTES)
+#define NUKE_UNLOCK_TIME (115 MINUTES)
 
 /datum/tech/nuke
 	name = "Nuclear Device"
 	//desc = "Purchase a nuclear device. Only able to purchase after X minutes into the operation. It's the only way to be sure." //See New()
 	icon_state = "nuke"
 
-	required_points = 20
+	required_points = 5
 
 	tier = /datum/tier/four
 


### PR DESCRIPTION

# About the pull request

This PR:

Lowers the xeno endgame start to 55 minutes into the round.

Lowers the nuke endgame start to 115 minutes into the round.

Lowers the nuke cost to 5 points.

# Explain why it's good for the game

Xenos need a bit of a boost come midgame.

Nuke should be easier to acquire once it is time to consider it and it should become available on the hour rather than 5 minutes offset due to roundstart time.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
balance: Lowered the xeno endgame start to 55 minutes into the round
balance: Lowered the nuke endgame start to 115 minutes into the round
balance: Lowered the nuke cost to 5 points
/:cl:
