### PR TITLE
Fixes repeatable techs not having correct overlays

### DIFF
--- a/code/modules/cm_tech/techs/abstract/repeatable.dm
+++ b/code/modules/cm_tech/techs/abstract/repeatable.dm
@@ -9,8 +9,6 @@
 	var/next_purchase = 0
 	var/increase_per_purchase = 0
 
-	unlocked = TRUE
-
 /datum/tech/repeatable/ui_static_data(mob/user)
 	. = ..()
 	if(increase_per_purchase)


### PR DESCRIPTION

# About the pull request

Repeatable techs now are not set as unlocked immediately and fit with the other techs.

# Explain why it's good for the game

Inconsistency bad


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
fix: Fixed repeatable techs not having correct overlays
/:cl:
