### PR TITLE
IOs get their own squads

### DIFF
--- a/code/__DEFINES/job.dm
+++ b/code/__DEFINES/job.dm
@@ -9,6 +9,7 @@
 #define SQUAD_MARINE_4 "Delta"
 #define SQUAD_MARINE_5 "Echo"
 #define SQUAD_MARINE_CRYO "Foxtrot"
+#define SQUAD_MARINE_INTEL "Intel"
 #define SQUAD_SOF "SOF"
 
 // Job name defines

--- a/code/game/jobs/job/command/auxiliary/intel.dm
+++ b/code/game/jobs/job/command/auxiliary/intel.dm
@@ -6,7 +6,7 @@
 	allow_additional = 1
 	scaled = 1
 	supervisors = "the auxiliary support officer"
-	flags_startup_parameters = ROLE_ADD_TO_DEFAULT
+	flags_startup_parameters = ROLE_ADD_TO_DEFAULT|ROLE_ADD_TO_SQUAD
 	gear_preset = "USCM Intelligence Officer (IO) (Cryo)"
 	entry_message_body = "<a href='"+URL_WIKI_IO_GUIDE+"'>Your job is to assist the marines in collecting intelligence related</a> to the current operation to better inform command of their opposition. You are in charge of gathering any data disks, folders, and notes you may find on the operational grounds and decrypt them to grant the USCM additional resources."
 

--- a/code/game/jobs/job/marine/squads.dm
+++ b/code/game/jobs/job/marine/squads.dm
@@ -180,8 +180,6 @@
 
 /datum/squad/marine/intel
 	name = SQUAD_MARINE_INTEL
-	equipment_color = "#67d692"
-	chat_color = "#67d692"
 	minimap_color = MINIMAP_SQUAD_ECHO
 	radio_freq = null
 

--- a/code/game/jobs/job/marine/squads.dm
+++ b/code/game/jobs/job/marine/squads.dm
@@ -175,6 +175,15 @@
 	roundstart = FALSE
 	locked = TRUE
 
+/datum/squad/marine/intel
+	name = SQUAD_MARINE_INTEL
+	equipment_color = "#67d692"
+	chat_color = "#67d692"
+	minimap_color = MINIMAP_SQUAD_ECHO
+	radio_freq = null
+
+	roundstart = FALSE
+
 /datum/squad/marine/sof
 	name = SQUAD_SOF
 	equipment_color = "#400000"
@@ -504,7 +513,7 @@
 	C.name = "[C.registered_name]'s ID Card ([C.assignment])"
 
 	var/obj/item/device/radio/headset/almayer/marine/headset = locate() in list(M.wear_l_ear, M.wear_r_ear)
-	if(headset)
+	if(headset && radio_freq)
 		headset.set_frequency(radio_freq)
 	M.update_inv_head()
 	M.update_inv_wear_suit()

--- a/code/game/jobs/job/marine/squads.dm
+++ b/code/game/jobs/job/marine/squads.dm
@@ -108,6 +108,9 @@
 
 	var/minimap_color = MINIMAP_SQUAD_UNKNOWN
 
+	///Should we add the name of our squad in front of their name? Ex: Alpha Hospital Corpsman
+	var/prepend_squad_name_to_assignment = TRUE
+
 
 /datum/squad/marine
 	name = "Root"
@@ -183,6 +186,7 @@
 	radio_freq = null
 
 	roundstart = FALSE
+	prepend_squad_name_to_assignment = FALSE
 
 /datum/squad/marine/sof
 	name = SQUAD_SOF
@@ -504,7 +508,10 @@
 	marines_list += M
 	M.assigned_squad = src //Add them to the squad
 	C.access += (src.access + extra_access) //Add their squad access to their ID
-	C.assignment = "[name] [assignment]"
+	if(prepend_squad_name_to_assignment)
+		C.assignment = "[name] [assignment]"
+	else
+		C.assignment = assignment
 
 	SEND_SIGNAL(M, COMSIG_SET_SQUAD)
 

--- a/code/game/jobs/role_authority.dm
+++ b/code/game/jobs/role_authority.dm
@@ -652,6 +652,15 @@ I hope it's easier to tell what the heck this proc is even doing, unlike previou
 		if (S.roundstart && S.usable && S.faction == H.faction && S.name != "Root")
 			mixed_squads += S
 
+	//Deal with IOs first
+	if(H.job == JOB_INTEL)
+		var/datum/squad/intel_squad = get_squad_by_name(SQUAD_MARINE_INTEL)
+		if(!intel_squad || !istype(intel_squad)) //Something went horribly wrong!
+			to_chat(H, "Something went wrong with randomize_squad()! Tell a coder!")
+			return
+		intel_squad.put_marine_in_squad(H) //Found one, finish up
+		return
+
 	//Deal with non-standards first.
 	//Non-standards are distributed regardless of squad population.
 	//If the number of available positions for the job are more than max_whatever, it will break.

--- a/tgui/packages/tgui/interfaces/OverwatchConsole.js
+++ b/tgui/packages/tgui/interfaces/OverwatchConsole.js
@@ -28,6 +28,7 @@ const HomePanel = (props, context) => {
     'delta': 'blue',
     'echo': 'green',
     'foxtrot': 'brown',
+    'intel': 'green',
   };
 
   return (


### PR DESCRIPTION
# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

IOs get their own squad, and they get assigned roundstart

# Explain why it's good for the game
It promotes teamwork for IOs, the lack of which is the #1 cause of IO death

In addition there's already an overwatch console in the CIC office.

You could already do this via Echo, but that's not apparant to new players

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: IOs start in their own squad now
/:cl:
