### PR TITLE
Removes annoying and inaccurate to_chat from join response team menu

### DIFF
--- a/code/datums/emergency_calls/emergency_call.dm
+++ b/code/datums/emergency_calls/emergency_call.dm
@@ -155,7 +155,6 @@
 	var/choice = tgui_input_list(src, "Choose a distress beacon to join", "", beacons)
 
 	if(!choice)
-		to_chat(src, "Something seems to have gone wrong!")
 		return
 
 	if(!beacons[choice] || !(beacons[choice] in SSticker.mode.picked_calls))


### PR DESCRIPTION

# About the pull request

Removes annoying and inaccurate to_chat from join response team menu

# Explain why it's good for the game

It keeps bugging me

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
fix: Removed annoying and inaccurate to_chat from join response team menu
/:cl:
