### PR TITLE
heavy mg ammo accuracy to 75%

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1876,7 +1876,7 @@
 	accurate_range = 10
 	damage =  50
 	penetration = ARMOR_PENETRATION_TIER_6
-	accuracy = HIT_ACCURACY_TIER_9 + HIT_ACCURACY_TIER_5 // 75 accuracy
+	accuracy = -HIT_ACCURACY_TIER_2 // 75 accuracy
 	shell_speed = AMMO_SPEED_TIER_2
 	max_range = 15
 	effective_range_max = 7


### PR DESCRIPTION
# About the pull request

Currently, hmg ammo's average accuracy is base accuracy + 75 within it's accurate range with some variance. That's ~160%

This does not make sense and I believe the intention was to make the TOTAL accuracy 75%.

https://gitlab.com/cmdevs/colonial-warfare/-/merge_requests/2573

"Accuracy from 40 to 75"

# Explain why it's good for the game

No more accurate bullets outside the accurate range. 

I shot at a crusher 14 tiles away as a test and the final projectile hit chance was still over 100% before this change.


# Testing Photographs and Procedure
Base accuracy on bullet generation
![image](https://github.com/cmss13-devs/cmss13/assets/107966994/c16038e8-8326-4ba3-815a-b9bb4f5bc622)




# Changelog
:cl:
balance: Reduced M2C accuracy to be more in line with realistic accuracy intent
/:cl:
