### PR TITLE
Fix to whatever happens after lifeboats crash

### DIFF
--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -132,8 +132,7 @@ All ShuttleMove procs go here
 	var/turf/target = get_edge_target_turf(src, move_dir)
 	var/range = throw_force * 10
 	range = CEILING(rand(range-(range*0.1), range+(range*0.1)), 10)/10
-	var/speed = range/5
-	INVOKE_ASYNC(src, TYPE_PROC_REF(/atom/movable, safe_throw_at), target, range, speed)
+	INVOKE_ASYNC(src, TYPE_PROC_REF(/atom/movable, safe_throw_at), target, range, SPEED_FAST)
 
 //=====================================================================//
 

--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -132,7 +132,7 @@ All ShuttleMove procs go here
 	var/turf/target = get_edge_target_turf(src, move_dir)
 	var/range = throw_force * 10
 	range = CEILING(rand(range-(range*0.1), range+(range*0.1)), 10)/10
-	INVOKE_ASYNC(src, TYPE_PROC_REF(/atom/movable, safe_throw_at), target, range, SPEED_FAST)
+	INVOKE_ASYNC(src, TYPE_PROC_REF(/atom/movable, safe_throw_at), target, range, SPEED_AVERAGE)
 
 //=====================================================================//
 

--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -133,7 +133,7 @@ All ShuttleMove procs go here
 	var/range = throw_force * 10
 	range = CEILING(rand(range-(range*0.1), range+(range*0.1)), 10)/10
 	var/speed = range/5
-	safe_throw_at(target, range, speed) //, force = MOVE_FORCE_EXTREMELY_STRONG)
+	INVOKE_ASYNC(src, TYPE_PROC_REF(/atom/movable, safe_throw_at), target, range, speed)
 
 //=====================================================================//
 


### PR DESCRIPTION

# About the pull request

Throws being called non-asynchronously caused a queue of throws immediately after the lifeboat crashed.

Also buffed speed of the throw, because it was painfully slow.

# Explain why it's good for the game

Bug is bad.


# Testing Photographs and Procedure
<details>
I did test it. Trust me bro.
</details>


# Changelog
:cl: ihatethisengine
fix: shuttles now throw mobs asynchronously and faster
/:cl:
