### PR TITLE
Powerloader wreckage now can be attacked by xenos

### DIFF
--- a/code/modules/vehicles/powerloader.dm
+++ b/code/modules/vehicles/powerloader.dm
@@ -338,6 +338,29 @@
 	opacity = FALSE
 	pixel_x = -18
 	pixel_y = -5
+	health = 100
+
+/obj/structure/powerloader_wreckage/attack_alien(mob/living/carbon/xenomorph/attacking_xeno)
+	if(attacking_xeno.a_intent == INTENT_HELP)
+		return XENO_NO_DELAY_ACTION
+
+	if(attacking_xeno.mob_size < MOB_SIZE_XENO)
+		to_chat(attacking_xeno, SPAN_XENOWARNING("You're too small to do any significant damage to this vehicle!"))
+		return XENO_NO_DELAY_ACTION
+
+	attacking_xeno.animation_attack_on(src)
+
+	attacking_xeno.visible_message(SPAN_DANGER("[attacking_xeno] slashes [src]!"), SPAN_DANGER("You slash [src]!"))
+	playsound(attacking_xeno, pick('sound/effects/metalhit.ogg', 'sound/weapons/alien_claw_metal1.ogg', 'sound/weapons/alien_claw_metal2.ogg', 'sound/weapons/alien_claw_metal3.ogg'), 25, 1)
+
+	var/damage = (attacking_xeno.melee_vehicle_damage + rand(-5,5))
+
+	health -= damage
+
+	if(health <= 0)
+		qdel(src)
+
+	return XENO_NONCOMBAT_ACTION
 
 /obj/structure/powerloader_wreckage/jd
 	name = "\improper John Deere 4300 Power Loader wreckage"

--- a/code/modules/vehicles/powerloader.dm
+++ b/code/modules/vehicles/powerloader.dm
@@ -358,7 +358,7 @@
 	health -= damage
 
 	if(health <= 0)
-		qdel(src)
+		deconstruct(FALSE)
 
 	return XENO_NONCOMBAT_ACTION
 


### PR DESCRIPTION

# About the pull request

Powerloader wreckage now can be attacked by xenos

# Explain why it's good for the game

Dumb meta rules/oversight

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
add: Powerloader wreckage now can be attacked by xenos
/:cl:
