### PR TITLE
Recalibrate limbs tweak

### DIFF
--- a/code/modules/surgery/robolimb_repair.dm
+++ b/code/modules/surgery/robolimb_repair.dm
@@ -12,6 +12,7 @@
 	pain_reduction_required = NONE
 	requires_bodypart = TRUE
 	requires_bodypart_type = LIMB_ROBOT
+	lying_required = FALSE
 
 /datum/surgery/prosthetic_recalibration/can_start(mob/user, mob/living/carbon/patient, obj/limb/L, obj/item/tool)
 	if(L.status & LIMB_UNCALIBRATED_PROSTHETIC)


### PR DESCRIPTION

# About the pull request

This PR makes it so recalibrating limbs no longer requires the patient to be laying down.

# Explain why it's good for the game

Someone reported this was bugged but I cannot get it to break and *someone* ahealed it before I could take a look 😁 . The only thing I can think of is people aren't having the person lay down properly before fixing it but after initial attachment it should be fine to just do it while the person is standing and makes it easier for medics who don't know any better.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
qol: Recalibrating limbs can now be done with the patient standing
/:cl:
