### PR TITLE
Working Joe Announcement Removal

### DIFF
--- a/code/game/jobs/job/civilians/support/working_joe.dm
+++ b/code/game/jobs/job/civilians/support/working_joe.dm
@@ -46,11 +46,6 @@
 	else
 		. = {"You are a <a href='"+URL_WIKI_WJ_GUIDE+"'>Working Joe</a> for Hazardous Environments!  You are held to a higher standard and are required to obey not only the Server Rules but Marine Law, Roleplay Expectations and Synthetic Rules.  You are a variant of the Working Joe built for tougher environments and fulfill the specific duty of dangerous repairs or maintenance. Your primary task is to maintain the reactor, SMES and AI Core. Your secondary task is to respond to hazardous environments, such as an atmospheric breach or biohazard spill, and assist with repairs when ordered to by either an AI Mainframe, or a Commisioned Officer.  You should not be seen outside of emergencies besides in Engineering and the AI Core! Stay in character at all times. Use the APOLLO link to communicate with your uplink!"}
 
-
-/datum/job/civilian/working_joe/announce_entry_message(mob/living/carbon/human/H)
-	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(ai_announcement), "[H.real_name] has been activated."), 1.5 SECONDS)
-	return ..()
-
 /obj/effect/landmark/start/working_joe
 	name = JOB_WORKING_JOE
 	icon_state = "wj_spawn"


### PR DESCRIPTION

# About the pull request

Removes the shipside announcement for working joes joining.

# Explain why it's good for the game

Frankly, Working Joes aren't nearly important enough to have a message about them joining the round. They should be quiet and (vaguely) efficient in their tasks.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
del: Removed the shipside announcement for working joes joining
/:cl:
