### PR TITLE
Stops queen prying open lifeboat hatches

### DIFF
--- a/code/game/machinery/doors/multi_tile.dm
+++ b/code/game/machinery/doors/multi_tile.dm
@@ -320,8 +320,8 @@
 	locked = TRUE
 	opacity = FALSE
 	glass = TRUE
-	var/throw_dir = EAST
 	queen_pryable = FALSE
+	var/throw_dir = EAST
 
 /obj/structure/machinery/door/airlock/multi_tile/almayer/dropshiprear/lifeboat/try_to_activate_door(mob/user)
 	return

--- a/code/game/machinery/doors/multi_tile.dm
+++ b/code/game/machinery/doors/multi_tile.dm
@@ -271,6 +271,7 @@
 	unacidable = TRUE
 	no_panel = 1
 	not_weldable = 1
+	var/queen_pryable = TRUE
 
 /obj/structure/machinery/door/airlock/multi_tile/almayer/dropshiprear/ex_act(severity)
 	return
@@ -283,6 +284,9 @@
 
 /obj/structure/machinery/door/airlock/multi_tile/almayer/dropshiprear/attack_alien(mob/living/carbon/xenomorph/xeno)
 	if(xeno.hive_pos != XENO_QUEEN)
+		return ..()
+
+	if(!queen_pryable)
 		return ..()
 
 	if(!locked)
@@ -317,6 +321,7 @@
 	opacity = FALSE
 	glass = TRUE
 	var/throw_dir = EAST
+	queen_pryable = FALSE
 
 /obj/structure/machinery/door/airlock/multi_tile/almayer/dropshiprear/lifeboat/try_to_activate_door(mob/user)
 	return


### PR DESCRIPTION

# About the pull request

Stops queen prying open lifeboat hatches which was causing people to float out into space and all sorts of insanity.

# Explain why it's good for the game

SPACE BAD

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
fix: Fixed queens prying open lifeboat double doors
/:cl:
