### PR TITLE
Science Annex Yard Readdition

### DIFF
--- a/maps/map_files/FOP_v3_Sciannex/Fiorina_SciAnnex.dmm
+++ b/maps/map_files/FOP_v3_Sciannex/Fiorina_SciAnnex.dmm
@@ -174,6 +174,15 @@
 	},
 /turf/open/floor/plating/prison,
 /area/fiorina/station/lowsec)
+"acx" = (
+/obj/structure/flora/bush/ausbushes/grassybush{
+	icon_state = "ppflowers_2"
+	},
+/turf/open/organic/grass{
+	desc = "It'll get in your shoes no matter what you do.";
+	name = "astroturf"
+	},
+/area/fiorina/station/central_ring)
 "adk" = (
 /obj/item/device/flashlight/lamp/tripod,
 /turf/open/floor/prison{
@@ -193,7 +202,8 @@
 /obj/structure/closet/secure_closet/medical3,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "whitegreenfull"
+	icon_state = "whitegreenfull";
+	tag = "icon-whitegreenfull (SOUTHWEST)"
 	},
 /area/fiorina/station/medbay)
 "adY" = (
@@ -205,6 +215,12 @@
 	icon_state = "yellow"
 	},
 /area/fiorina/station/disco)
+"aee" = (
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "yellow"
+	},
+/area/fiorina/station/central_ring)
 "aem" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/storage/box/donkpockets{
@@ -346,14 +362,10 @@
 	},
 /area/fiorina/tumor/servers)
 "ajp" = (
-/obj/structure/barricade/wooden{
-	dir = 4;
-	pixel_y = 4
-	},
-/obj/structure/barricade/wooden,
+/obj/structure/window/framed/prison,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "sterile_white"
+	icon_state = "whitegreenfull"
 	},
 /area/fiorina/station/medbay)
 "ajr" = (
@@ -546,6 +558,9 @@
 /area/fiorina/station/park)
 "anG" = (
 /obj/structure/largecrate/supply,
+/obj/structure/platform_decoration{
+	dir = 8
+	},
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/fiorina/station/medbay)
 "anJ" = (
@@ -562,11 +577,12 @@
 /turf/open/floor/carpet,
 /area/fiorina/station/security/wardens)
 "aoa" = (
-/obj/structure/largecrate/random/mini/med,
-/turf/open/floor/prison{
-	dir = 9;
-	icon_state = "whitegreen"
+/obj/structure/machinery/door/airlock/almayer/maint/autoname{
+	name = "\improper Null Hatch REPLACE ME";
+	req_access = null;
+	req_one_access = null
 	},
+/turf/open/floor/plating/prison,
 /area/fiorina/station/medbay)
 "aoH" = (
 /obj/structure/surface/rack,
@@ -671,6 +687,14 @@
 	icon_state = "floor_plate"
 	},
 /area/fiorina/tumor/servers)
+"arY" = (
+/obj/structure/stairs/perspective{
+	dir = 4;
+	icon_state = "p_stair_full"
+	},
+/obj/structure/platform,
+/turf/open/floor/plating/prison,
+/area/fiorina/station/central_ring)
 "ask" = (
 /obj/structure/machinery/light/double/blue{
 	dir = 8;
@@ -919,6 +943,21 @@
 /obj/structure/girder,
 /turf/open/floor/plating/prison,
 /area/fiorina/station/medbay)
+"azy" = (
+/obj/structure/platform/kutjevo/smooth{
+	dir = 1
+	},
+/obj/structure/platform/kutjevo/smooth{
+	dir = 4
+	},
+/obj/structure/platform/kutjevo/smooth,
+/obj/structure/barricade/handrail{
+	dir = 1;
+	icon_state = "hr_kutjevo";
+	name = "solar lattice"
+	},
+/turf/open/space/basic,
+/area/fiorina/oob)
 "azI" = (
 /obj/item/prop/helmetgarb/spacejam_tickets{
 	desc = "A ticket to Souto Man's raffle!";
@@ -1069,19 +1108,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/fiorina/tumor/ship)
-"aCO" = (
-/obj/structure/bed/chair{
-	dir = 1;
-	pixel_y = 3
-	},
-/obj/item/reagent_container/food/drinks/cans/beer{
-	pixel_x = 12;
-	pixel_y = 8
-	},
-/turf/open/floor/prison{
-	icon_state = "floor_plate"
-	},
-/area/fiorina/station/lowsec)
 "aCT" = (
 /obj/structure/bed/sofa/south/grey/left,
 /turf/open/floor/prison{
@@ -1216,11 +1242,12 @@
 	},
 /area/fiorina/station/telecomm/lz1_cargo)
 "aFO" = (
-/obj/structure/largecrate/supply/floodlights,
 /turf/open/floor/prison{
-	icon_state = "floor_plate"
+	dir = 10;
+	icon_state = "sterile_white";
+	tag = "icon-sterile_white (SOUTHWEST)"
 	},
-/area/fiorina/station/disco)
+/area/fiorina/station/medbay)
 "aFV" = (
 /obj/item/stack/sheet/wood,
 /obj/structure/machinery/light/double/blue,
@@ -1241,12 +1268,11 @@
 	},
 /area/fiorina/station/chapel)
 "aGS" = (
-/obj/structure/lattice,
-/obj/structure/platform_decoration/kutjevo{
-	dir = 1
+/obj/structure/platform_decoration,
+/turf/open/floor/prison{
+	icon_state = "whitegreen"
 	},
-/turf/open/space,
-/area/fiorina/oob)
+/area/fiorina/station/medbay)
 "aGV" = (
 /obj/structure/largecrate/random/barrel/red,
 /turf/open/floor/prison,
@@ -1361,6 +1387,11 @@
 	icon_state = "bluefull"
 	},
 /area/fiorina/station/power_ring)
+"aIX" = (
+/turf/open/floor/prison{
+	icon_state = "yellowfull"
+	},
+/area/fiorina/station/central_ring)
 "aIZ" = (
 /obj/structure/prop/resin_prop{
 	icon_state = "rack"
@@ -1392,6 +1423,13 @@
 	icon_state = "kitchen"
 	},
 /area/fiorina/station/civres_blue)
+"aJU" = (
+/obj/effect/decal/cleanable/blood/gibs/xeno,
+/turf/open/organic/grass{
+	desc = "It'll get in your shoes no matter what you do.";
+	name = "astroturf"
+	},
+/area/fiorina/station/central_ring)
 "aJX" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -1449,6 +1487,13 @@
 /obj/structure/blocker/invisible_wall,
 /turf/open/floor/almayer_hull,
 /area/fiorina/station/medbay)
+"aLC" = (
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "damaged1";
+	tag = "icon-bright_clean (SOUTHWEST)"
+	},
+/area/fiorina/station/central_ring)
 "aLR" = (
 /obj/item/stack/medical/bruise_pack,
 /turf/open/floor/prison,
@@ -1499,13 +1544,11 @@
 	},
 /area/fiorina/station/park)
 "aNw" = (
-/obj/structure/lattice,
-/obj/structure/platform/kutjevo/smooth,
-/obj/structure/platform/kutjevo/smooth{
-	dir = 8
+/obj/structure/platform,
+/turf/open/floor/prison{
+	icon_state = "whitegreen"
 	},
-/turf/open/space,
-/area/fiorina/oob)
+/area/fiorina/station/medbay)
 "aNP" = (
 /obj/structure/inflatable,
 /obj/structure/barricade/handrail/type_b,
@@ -1593,6 +1636,21 @@
 "aPH" = (
 /turf/closed/wall/r_wall/prison_unmeltable,
 /area/fiorina/station/security/wardens)
+"aQB" = (
+/obj/structure/platform/kutjevo/smooth{
+	dir = 1
+	},
+/obj/structure/platform_decoration/kutjevo{
+	dir = 1
+	},
+/obj/structure/barricade/handrail{
+	dir = 1;
+	icon_state = "hr_kutjevo";
+	name = "solar lattice"
+	},
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/fiorina/oob)
 "aQE" = (
 /obj/item/stack/sheet/metal{
 	amount = 5
@@ -1724,13 +1782,6 @@
 	},
 /turf/open/floor/plating/prison,
 /area/fiorina/station/research_cells)
-"aTN" = (
-/obj/structure/platform_decoration/kutjevo{
-	dir = 4
-	},
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/fiorina/oob)
 "aUa" = (
 /obj/structure/machinery/portable_atmospherics/powered/scrubber,
 /turf/open/floor/prison{
@@ -1892,6 +1943,14 @@
 	dir = 5
 	},
 /area/fiorina/tumor/aux_engi)
+"aXK" = (
+/obj/item/clothing/under/shorts/green,
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "cell_stripe";
+	tag = "icon-cell_stripe (EAST)"
+	},
+/area/fiorina/station/central_ring)
 "aXM" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/stack/cable_coil/orange,
@@ -2235,11 +2294,11 @@
 	},
 /area/fiorina/station/park)
 "biJ" = (
-/obj/structure/surface/table/reinforced/prison,
-/obj/item/tool/kitchen/utensil/fork,
-/turf/open/floor/prison{
-	icon_state = "darkpurplefull2"
+/obj/structure/stairs/perspective{
+	dir = 1;
+	icon_state = "p_stair_full"
 	},
+/turf/open/floor/plating/plating_catwalk/prison,
 /area/fiorina/station/research_cells)
 "bjk" = (
 /obj/structure/sink{
@@ -2427,10 +2486,18 @@
 	},
 /area/fiorina/station/security)
 "bqy" = (
+/obj/structure/platform,
+/obj/structure/platform{
+	dir = 8
+	},
+/obj/structure/platform_decoration{
+	dir = 10
+	},
 /obj/structure/closet/firecloset/full,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "whitegreenfull"
+	icon_state = "whitegreenfull";
+	tag = "icon-whitegreenfull (SOUTHWEST)"
 	},
 /area/fiorina/station/medbay)
 "bra" = (
@@ -2456,6 +2523,18 @@
 	icon_state = "darkyellowfull2"
 	},
 /area/fiorina/tumor/servers)
+"brI" = (
+/obj/structure/platform/kutjevo/smooth{
+	dir = 1
+	},
+/obj/structure/platform_decoration/kutjevo,
+/obj/structure/barricade/handrail{
+	dir = 1;
+	icon_state = "hr_kutjevo";
+	name = "solar lattice"
+	},
+/turf/open/space/basic,
+/area/fiorina/oob)
 "brS" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/clipboard,
@@ -2567,10 +2646,12 @@
 /turf/open/floor/plating/prison,
 /area/fiorina/station/civres_blue)
 "bxa" = (
-/obj/structure/platform_decoration/kutjevo,
-/obj/structure/lattice,
-/turf/open/space,
-/area/fiorina/oob)
+/obj/structure/platform,
+/obj/structure/machinery/light/double/blue,
+/turf/open/floor/prison{
+	icon_state = "whitegreen"
+	},
+/area/fiorina/station/medbay)
 "bxl" = (
 /obj/structure/machinery/light/double/blue{
 	dir = 1;
@@ -2607,13 +2688,6 @@
 	icon_state = "stan27"
 	},
 /area/fiorina/tumor/ship)
-"byl" = (
-/obj/structure/platform/kutjevo/smooth{
-	dir = 4
-	},
-/obj/structure/lattice,
-/turf/open/space,
-/area/fiorina/oob)
 "bym" = (
 /turf/closed/shuttle/ert{
 	icon_state = "stan20"
@@ -2686,18 +2760,6 @@
 	icon_state = "stan25"
 	},
 /area/fiorina/tumor/aux_engi)
-"bAB" = (
-/obj/structure/barricade/handrail{
-	dir = 1;
-	icon_state = "hr_kutjevo";
-	name = "solar lattice"
-	},
-/obj/structure/platform/kutjevo/smooth{
-	dir = 1
-	},
-/obj/structure/lattice,
-/turf/open/space,
-/area/fiorina/oob)
 "bAS" = (
 /obj/structure/machinery/light/double/blue,
 /turf/open/floor/prison{
@@ -2732,6 +2794,14 @@
 /obj/structure/largecrate/random/case/double,
 /turf/open/floor/prison,
 /area/fiorina/tumor/aux_engi)
+"bCk" = (
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "darkpurple2";
+	tag = "icon-darkpurple2"
+	},
+/area/fiorina/station/central_ring)
 "bCu" = (
 /obj/item/shard{
 	icon_state = "large"
@@ -3067,10 +3137,6 @@
 /obj/item/tool/pen,
 /turf/open/floor/carpet,
 /area/fiorina/station/security/wardens)
-"bMl" = (
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/fiorina/station/lowsec)
 "bMr" = (
 /turf/open/floor/prison{
 	dir = 10;
@@ -3203,13 +3269,6 @@
 	},
 /turf/open/floor/plating/prison,
 /area/fiorina/tumor/servers)
-"bQp" = (
-/obj/structure/platform/kutjevo/smooth{
-	dir = 1
-	},
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/fiorina/oob)
 "bQx" = (
 /obj/item/reagent_container/food/drinks/cans/waterbottle,
 /turf/open/floor/prison{
@@ -3372,6 +3431,10 @@
 /obj/structure/machinery/faxmachine,
 /turf/open/floor/wood,
 /area/fiorina/station/security/wardens)
+"bWr" = (
+/obj/structure/inflatable/popped,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/fiorina/station/central_ring)
 "bWE" = (
 /obj/effect/spawner/random/gun/rifle/midchance,
 /turf/open/floor/prison{
@@ -3448,6 +3511,21 @@
 	icon_state = "yellow"
 	},
 /area/fiorina/station/lowsec)
+"bZC" = (
+/obj/structure/barricade/wooden{
+	dir = 4
+	},
+/obj/item/tool/crowbar/red,
+/obj/structure/stairs/perspective{
+	icon_state = "p_stair_ew_full_cap"
+	},
+/obj/structure/platform/stair_cut/alt,
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "cell_stripe";
+	tag = "icon-cell_stripe (EAST)"
+	},
+/area/fiorina/station/medbay)
 "bZF" = (
 /obj/effect/landmark/objective_landmark/far,
 /turf/open/floor/prison{
@@ -3493,11 +3571,13 @@
 	},
 /area/fiorina/station/power_ring)
 "cbH" = (
-/obj/structure/largecrate/supply/generator,
+/obj/structure/inflatable/door,
 /turf/open/floor/prison{
-	icon_state = "floor_plate"
+	dir = 10;
+	icon_state = "sterile_white";
+	tag = "icon-sterile_white (SOUTHWEST)"
 	},
-/area/fiorina/station/disco)
+/area/fiorina/station/medbay)
 "cbK" = (
 /obj/structure/closet/secure_closet/guncabinet{
 	req_access = null
@@ -3601,19 +3681,13 @@
 	},
 /area/fiorina/station/research_cells)
 "chA" = (
-/obj/structure/barricade/handrail{
-	dir = 1;
-	icon_state = "hr_kutjevo";
-	name = "solar lattice"
-	},
-/obj/structure/lattice,
 /obj/structure/platform/kutjevo/smooth{
 	dir = 4
 	},
 /obj/structure/platform/kutjevo/smooth{
 	dir = 1
 	},
-/turf/open/space,
+/turf/open/space/basic,
 /area/fiorina/oob)
 "chJ" = (
 /obj/structure/bed{
@@ -3707,19 +3781,18 @@
 	},
 /area/fiorina/station/botany)
 "cjA" = (
-/obj/structure/barricade/handrail{
-	dir = 1;
-	icon_state = "hr_kutjevo";
-	name = "solar lattice"
-	},
-/obj/structure/lattice,
 /obj/structure/platform/kutjevo/smooth{
 	dir = 8
 	},
 /obj/structure/platform/kutjevo/smooth{
 	dir = 1
 	},
-/turf/open/space,
+/obj/structure/barricade/handrail{
+	dir = 1;
+	icon_state = "hr_kutjevo";
+	name = "solar lattice"
+	},
+/turf/open/space/basic,
 /area/fiorina/oob)
 "cjF" = (
 /turf/open/floor/prison{
@@ -3733,6 +3806,12 @@
 	icon_state = "whitegreen"
 	},
 /area/fiorina/tumor/ice_lab)
+"ckj" = (
+/turf/open/floor/prison{
+	dir = 6;
+	icon_state = "yellow"
+	},
+/area/fiorina/station/central_ring)
 "ckm" = (
 /obj/structure/window/framed/prison/reinforced/hull,
 /turf/open/floor/plating/prison,
@@ -3827,6 +3906,18 @@
 	icon_state = "floor_plate"
 	},
 /area/fiorina/tumor/servers)
+"cmz" = (
+/obj/structure/platform_decoration/kutjevo,
+/obj/structure/platform/kutjevo/smooth{
+	dir = 1
+	},
+/obj/structure/barricade/handrail{
+	dir = 1;
+	icon_state = "hr_kutjevo";
+	name = "solar lattice"
+	},
+/turf/open/space,
+/area/fiorina/oob)
 "cmI" = (
 /obj/structure/platform{
 	dir = 8
@@ -3854,6 +3945,10 @@
 	icon_state = "panelscorched"
 	},
 /area/fiorina/station/chapel)
+"cnl" = (
+/obj/structure/largecrate/supply/supplies/metal,
+/turf/open/floor/plating/prison,
+/area/fiorina/station/central_ring)
 "cnn" = (
 /obj/item/device/flashlight,
 /turf/open/floor/prison{
@@ -3866,9 +3961,11 @@
 /turf/open/floor/prison,
 /area/fiorina/station/disco)
 "cnF" = (
-/obj/effect/landmark/objective_landmark/science,
-/turf/open/floor/prison,
-/area/fiorina/station/medbay)
+/turf/open/floor/prison{
+	icon_state = "darkpurplefull2";
+	tag = "icon-darkpurplefull2"
+	},
+/area/fiorina/station/research_cells)
 "cnU" = (
 /obj/structure/machinery/computer/atmos_alert,
 /obj/structure/surface/table/reinforced/prison,
@@ -3927,6 +4024,8 @@
 /obj/structure/platform/kutjevo/smooth{
 	dir = 8
 	},
+/obj/structure/platform/kutjevo/smooth,
+/obj/structure/lattice,
 /turf/open/space/basic,
 /area/fiorina/oob)
 "cqc" = (
@@ -3952,7 +4051,8 @@
 /obj/item/clothing/gloves/latex,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "whitegreenfull"
+	icon_state = "whitegreenfull";
+	tag = "icon-whitegreenfull (SOUTHWEST)"
 	},
 /area/fiorina/station/medbay)
 "cqU" = (
@@ -4231,12 +4331,19 @@
 	},
 /area/fiorina/station/research_cells)
 "cAv" = (
-/obj/structure/barricade/handrail/type_b{
-	dir = 8;
-	layer = 3.5
+/obj/structure/stairs/perspective{
+	dir = 1;
+	icon_state = "p_stair_sn_full_cap"
 	},
-/turf/open/floor/prison,
-/area/fiorina/station/disco)
+/obj/structure/platform{
+	dir = 8
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "whitegreenfull";
+	tag = "icon-whitegreenfull (SOUTHWEST)"
+	},
+/area/fiorina/station/central_ring)
 "cAA" = (
 /obj/effect/landmark/static_comms/net_two,
 /turf/open/floor/prison{
@@ -4431,6 +4538,14 @@
 	icon_state = "whitepurple"
 	},
 /area/fiorina/station/research_cells)
+"cFN" = (
+/obj/structure/machinery/light/double/blue,
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "cell_stripe";
+	tag = "icon-cell_stripe (EAST)"
+	},
+/area/fiorina/station/central_ring)
 "cFQ" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/reagent_container/food/drinks/bottle/vodka{
@@ -4616,6 +4731,15 @@
 	},
 /turf/open/floor/prison,
 /area/fiorina/station/power_ring)
+"cNC" = (
+/obj/structure/prop/almayer/computers/mission_planning_system{
+	density = 0;
+	desc = "Its a telephone, and a computer. Woah.";
+	name = "\improper funny telephone booth";
+	pixel_y = 21
+	},
+/turf/open/floor/prison,
+/area/fiorina/station/central_ring)
 "cOb" = (
 /obj/item/ammo_casing{
 	icon_state = "casing_6"
@@ -4835,6 +4959,13 @@
 	icon_state = "floor_plate"
 	},
 /area/fiorina/station/telecomm/lz1_cargo)
+"cWN" = (
+/obj/item/weapon/gun/rifle/mar40,
+/turf/open/floor/prison{
+	icon_state = "floor_plate";
+	tag = "icon-floor_plate"
+	},
+/area/fiorina/station/lowsec)
 "cWR" = (
 /obj/effect/landmark/objective_landmark/medium,
 /obj/structure/closet/secure_closet/engineering_personal,
@@ -4884,20 +5015,33 @@
 /turf/open/floor/plating/prison,
 /area/fiorina/station/flight_deck)
 "cYa" = (
-/obj/structure/lattice,
-/obj/structure/platform/kutjevo/smooth{
-	dir = 8
+/obj/structure/stairs/perspective{
+	dir = 1;
+	icon_state = "p_stair_full"
 	},
-/obj/structure/platform/kutjevo/smooth,
-/turf/open/space,
-/area/fiorina/oob)
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "whitegreen"
+	},
+/area/fiorina/station/central_ring)
 "cYg" = (
-/obj/item/ammo_magazine/m56d,
+/obj/structure/stairs/perspective{
+	dir = 1;
+	icon_state = "p_stair_full"
+	},
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "sterile_white"
+	icon_state = "sterile_white";
+	tag = "icon-sterile_white (SOUTHWEST)"
 	},
-/area/fiorina/station/medbay)
+/area/fiorina/station/central_ring)
+"cYv" = (
+/obj/structure/stairs/perspective{
+	dir = 4;
+	icon_state = "p_stair_full"
+	},
+/turf/open/floor/plating/prison,
+/area/fiorina/station/central_ring)
 "cYP" = (
 /obj/structure/closet/crate/trashcart,
 /obj/item/storage/pill_bottle/dexalin/skillless,
@@ -4922,6 +5066,15 @@
 	icon_state = "whitepurple"
 	},
 /area/fiorina/station/research_cells)
+"cZc" = (
+/obj/structure/platform/kutjevo/smooth{
+	dir = 1
+	},
+/obj/structure/platform/kutjevo/smooth{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/fiorina/oob)
 "cZq" = (
 /obj/item/shard{
 	icon_state = "medium"
@@ -4938,6 +5091,12 @@
 	},
 /turf/open/floor/wood,
 /area/fiorina/station/security)
+"das" = (
+/obj/structure/platform/shiva{
+	dir = 1
+	},
+/turf/open/floor/plating/prison,
+/area/fiorina/station/central_ring)
 "daA" = (
 /obj/item/clothing/accessory/armband/cargo{
 	desc = "Sworn to the shrapnel and the shards therein. So sayeth her command when the first detonation occured.";
@@ -5087,6 +5246,10 @@
 	icon_state = "whitegreen"
 	},
 /area/fiorina/station/medbay)
+"deH" = (
+/obj/structure/machinery/light/double/blue,
+/turf/open/floor/prison,
+/area/fiorina/station/central_ring)
 "deL" = (
 /obj/structure/window/framed/prison/reinforced/hull,
 /obj/structure/window/framed/prison/reinforced/hull,
@@ -5185,13 +5348,11 @@
 	},
 /area/fiorina/station/chapel)
 "dhe" = (
-/obj/structure/barricade/metal/wired{
-	dir = 4
-	},
 /turf/open/floor/prison{
-	icon_state = "cell_stripe"
+	icon_state = "cell_stripe";
+	tag = "icon-cell_stripe"
 	},
-/area/fiorina/station/disco)
+/area/fiorina/station/central_ring)
 "dhi" = (
 /obj/structure/platform_decoration/kutjevo,
 /turf/open/space/basic,
@@ -5313,6 +5474,20 @@
 	name = "astroturf"
 	},
 /area/fiorina/station/research_cells)
+"djU" = (
+/obj/structure/platform/kutjevo/smooth{
+	dir = 1
+	},
+/obj/structure/platform/kutjevo/smooth{
+	dir = 8
+	},
+/obj/structure/barricade/handrail{
+	dir = 1;
+	icon_state = "hr_kutjevo";
+	name = "solar lattice"
+	},
+/turf/open/space/basic,
+/area/fiorina/oob)
 "dka" = (
 /obj/structure/flora/pottedplant{
 	icon_state = "pottedplant_22"
@@ -5326,20 +5501,16 @@
 /turf/open/floor/plating/prison,
 /area/fiorina/maintenance)
 "dkg" = (
-/obj/structure/barricade/handrail{
-	dir = 1;
-	icon_state = "hr_kutjevo";
-	name = "solar lattice"
+/obj/structure/toilet{
+	dir = 8;
+	pixel_y = 8;
+	tag = "icon-toilet00 (WEST)"
 	},
-/obj/structure/platform/kutjevo/smooth{
-	dir = 4
+/turf/open/floor/prison{
+	dir = 5;
+	icon_state = "whitepurple"
 	},
-/obj/structure/platform/kutjevo/smooth{
-	dir = 1
-	},
-/obj/structure/lattice,
-/turf/open/space,
-/area/fiorina/oob)
+/area/fiorina/station/research_cells)
 "dkj" = (
 /turf/open/floor/prison{
 	dir = 8;
@@ -5438,6 +5609,16 @@
 /obj/effect/spawner/random/toy,
 /turf/open/floor/wood,
 /area/fiorina/station/chapel)
+"dnA" = (
+/obj/structure/stairs/perspective{
+	dir = 4;
+	icon_state = "p_stair_sn_full_cap"
+	},
+/obj/structure/platform{
+	dir = 4
+	},
+/turf/open/floor/plating/prison,
+/area/fiorina/station/central_ring)
 "dnB" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/prison{
@@ -5451,6 +5632,15 @@
 	},
 /turf/open/floor/prison,
 /area/fiorina/station/security)
+"dnI" = (
+/obj/structure/flora/bush/ausbushes/grassybush{
+	icon_state = "ywflowers_4"
+	},
+/turf/open/organic/grass{
+	desc = "It'll get in your shoes no matter what you do.";
+	name = "astroturf"
+	},
+/area/fiorina/station/central_ring)
 "dnK" = (
 /obj/structure/bed/chair/comfy{
 	dir = 4
@@ -5694,13 +5884,14 @@
 	},
 /area/fiorina/station/power_ring)
 "dvY" = (
-/obj/structure/lattice,
-/obj/structure/platform/kutjevo/smooth{
-	dir = 4
+/obj/structure/machinery/door/airlock/almayer/maint/autoname{
+	dir = 1;
+	name = "\improper Null Hatch REPLACE ME";
+	req_access = null;
+	req_one_access = null
 	},
-/obj/structure/platform/kutjevo/smooth,
-/turf/open/space,
-/area/fiorina/oob)
+/turf/open/floor/plating/prison,
+/area/fiorina/station/medbay)
 "dwg" = (
 /obj/structure/stairs/perspective{
 	dir = 8;
@@ -6123,11 +6314,8 @@
 /turf/open/floor/prison,
 /area/fiorina/station/flight_deck)
 "dGw" = (
-/obj/structure/barricade/handrail/type_b{
-	dir = 4
-	},
 /turf/open/floor/prison,
-/area/fiorina/station/disco)
+/area/fiorina/station/central_ring)
 "dGx" = (
 /obj/structure/flora/grass/tallgrass/jungle/corner{
 	dir = 10
@@ -6150,6 +6338,15 @@
 	icon_state = "yellow"
 	},
 /area/fiorina/station/lowsec)
+"dHI" = (
+/obj/item/ammo_casing{
+	icon_state = "casing_1"
+	},
+/turf/open/floor/prison{
+	icon_state = "floor_plate";
+	tag = "icon-floor_plate"
+	},
+/area/fiorina/station/central_ring)
 "dIa" = (
 /obj/item/stack/sheet/metal{
 	amount = 5
@@ -6185,10 +6382,10 @@
 	dir = 4;
 	icon_state = "triagedecaldir"
 	},
-/obj/effect/landmark/objective_landmark/close,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "whitegreenfull"
+	icon_state = "whitegreenfull";
+	tag = "icon-whitegreenfull (SOUTHWEST)"
 	},
 /area/fiorina/station/medbay)
 "dIK" = (
@@ -6255,7 +6452,7 @@
 	},
 /area/fiorina/station/research_cells)
 "dMa" = (
-/obj/structure/largecrate/random,
+/obj/structure/stairs/perspective,
 /turf/open/floor/plating/prison,
 /area/fiorina/maintenance)
 "dMc" = (
@@ -6304,21 +6501,6 @@
 	icon_state = "floor_marked"
 	},
 /area/fiorina/station/park)
-"dMU" = (
-/obj/structure/barricade/handrail{
-	dir = 1;
-	icon_state = "hr_kutjevo";
-	name = "solar lattice"
-	},
-/obj/structure/platform/kutjevo/smooth{
-	dir = 8
-	},
-/obj/structure/lattice,
-/obj/structure/platform/kutjevo/smooth{
-	dir = 1
-	},
-/turf/open/space,
-/area/fiorina/oob)
 "dNh" = (
 /turf/open/auto_turf/sand/layer1,
 /area/fiorina/lz/near_lzI)
@@ -6415,6 +6597,14 @@
 	name = "metal wall"
 	},
 /area/fiorina/oob)
+"dRW" = (
+/obj/structure/machinery/light/double/blue{
+	dir = 4;
+	pixel_x = 10;
+	pixel_y = -3
+	},
+/turf/open/floor/plating/prison,
+/area/fiorina/station/central_ring)
 "dSw" = (
 /obj/structure/bed{
 	icon_state = "abed"
@@ -6561,8 +6751,13 @@
 "dYr" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/explosive/grenade/incendiary/molotov,
+/obj/structure/machinery/light/double/blue{
+	dir = 1;
+	pixel_y = 21
+	},
 /turf/open/floor/prison{
-	icon_state = "floor_plate"
+	icon_state = "floor_plate";
+	tag = "icon-floor_plate"
 	},
 /area/fiorina/station/lowsec)
 "dYv" = (
@@ -6680,6 +6875,12 @@
 /obj/item/stack/sheet/metal/medium_stack,
 /turf/open/floor/plating/prison,
 /area/fiorina/station/medbay)
+"ecC" = (
+/obj/structure/barricade/metal/wired{
+	dir = 8
+	},
+/turf/open/floor/plating/prison,
+/area/fiorina/station/central_ring)
 "ecF" = (
 /obj/structure/machinery/cm_vending/sorted/medical/wall_med/limited{
 	pixel_y = 32
@@ -6713,6 +6914,10 @@
 	icon_state = "greenfull"
 	},
 /area/fiorina/tumor/servers)
+"edd" = (
+/obj/structure/window/framed/prison/reinforced,
+/turf/open/floor/plating/prison,
+/area/fiorina/station/central_ring)
 "edv" = (
 /obj/item/storage/fancy/cigar,
 /turf/open/floor/prison,
@@ -6935,10 +7140,18 @@
 /turf/open/floor/prison,
 /area/fiorina/station/chapel)
 "eli" = (
+/obj/structure/platform,
+/obj/structure/platform{
+	dir = 4
+	},
+/obj/structure/platform_decoration{
+	dir = 6
+	},
 /obj/structure/closet/emcloset,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "whitegreenfull"
+	icon_state = "whitegreenfull";
+	tag = "icon-whitegreenfull (SOUTHWEST)"
 	},
 /area/fiorina/station/medbay)
 "elq" = (
@@ -7475,10 +7688,8 @@
 /turf/open/floor/prison,
 /area/fiorina/station/power_ring)
 "eDn" = (
-/obj/structure/platform/kutjevo/smooth,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/fiorina/oob)
+/turf/closed/wall/r_wall/prison_unmeltable,
+/area/fiorina/station/central_ring)
 "eDs" = (
 /obj/structure/machinery/door/airlock/prison_hatch/autoname,
 /turf/open/floor/prison{
@@ -7561,10 +7772,9 @@
 	},
 /area/fiorina/station/lowsec)
 "eHa" = (
-/obj/structure/lattice,
-/obj/structure/platform/kutjevo/smooth,
-/turf/open/space,
-/area/fiorina/oob)
+/obj/structure/extinguisher_cabinet,
+/turf/closed/wall/r_wall/prison_unmeltable,
+/area/fiorina/station/central_ring)
 "eHC" = (
 /turf/closed/shuttle/ert{
 	icon_state = "wy25"
@@ -7633,6 +7843,13 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/fiorina/oob)
+"eKg" = (
+/turf/open/floor/prison{
+	dir = 6;
+	icon_state = "darkpurple2";
+	tag = "icon-darkpurple2"
+	},
+/area/fiorina/station/central_ring)
 "eKu" = (
 /obj/structure/stairs/perspective{
 	dir = 8;
@@ -7662,6 +7879,10 @@
 	},
 /turf/open/floor/plating/prison,
 /area/fiorina/station/botany)
+"eMJ" = (
+/obj/structure/inflatable/popped/door,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/fiorina/station/central_ring)
 "eML" = (
 /obj/structure/monorail{
 	name = "launch track"
@@ -7673,6 +7894,15 @@
 	icon_state = "floor_plate"
 	},
 /area/fiorina/station/telecomm/lz1_tram)
+"eMO" = (
+/obj/structure/flora/bush/ausbushes/grassybush{
+	icon_state = "ywflowers_2"
+	},
+/turf/open/organic/grass{
+	desc = "It'll get in your shoes no matter what you do.";
+	name = "astroturf"
+	},
+/area/fiorina/station/central_ring)
 "eMU" = (
 /turf/closed/shuttle/ert{
 	icon_state = "rightengine_1";
@@ -7745,6 +7975,14 @@
 	icon_state = "greenfull"
 	},
 /area/fiorina/tumor/servers)
+"eON" = (
+/obj/structure/stairs/perspective{
+	dir = 8;
+	icon_state = "p_stair_ew_full_cap"
+	},
+/obj/structure/platform/stair_cut,
+/turf/open/floor/plating/prison,
+/area/fiorina/station/central_ring)
 "eOS" = (
 /obj/item/tool/warning_cone,
 /obj/structure/machinery/light/double/blue,
@@ -7758,6 +7996,16 @@
 	icon_state = "floor_plate"
 	},
 /area/fiorina/station/flight_deck)
+"ePm" = (
+/obj/structure/barricade/handrail{
+	dir = 1;
+	pixel_y = 2
+	},
+/turf/open/floor/prison{
+	icon_state = "floor_plate";
+	tag = "icon-floor_plate"
+	},
+/area/fiorina/station/central_ring)
 "ePq" = (
 /obj/item/trash/cigbutt/ucigbutt,
 /obj/item/trash/cigbutt/ucigbutt{
@@ -8102,33 +8350,17 @@
 	},
 /turf/open/floor/plating/prison,
 /area/fiorina/station/transit_hub)
-"eZq" = (
-/obj/structure/platform/kutjevo/smooth{
-	dir = 1
-	},
-/obj/structure/barricade/handrail{
-	dir = 1;
-	icon_state = "hr_kutjevo";
-	name = "solar lattice"
-	},
-/obj/structure/lattice,
-/turf/open/space,
-/area/fiorina/oob)
 "eZA" = (
-/obj/structure/platform/kutjevo/smooth{
-	dir = 1
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 12;
+	tag = "icon-sink (EAST)"
 	},
-/obj/structure/platform/kutjevo/smooth{
-	dir = 8
+/turf/open/floor/prison{
+	dir = 6;
+	icon_state = "whitepurple"
 	},
-/obj/structure/barricade/handrail{
-	dir = 1;
-	icon_state = "hr_kutjevo";
-	name = "solar lattice"
-	},
-/obj/structure/lattice,
-/turf/open/space,
-/area/fiorina/oob)
+/area/fiorina/station/research_cells)
 "eZD" = (
 /obj/structure/closet/secure_closet/guncabinet{
 	req_access = null
@@ -8238,20 +8470,16 @@
 	},
 /area/fiorina/station/chapel)
 "fcZ" = (
-/obj/structure/platform/kutjevo/smooth{
-	dir = 1
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	tag = "icon-sink (WEST)"
 	},
-/obj/structure/barricade/handrail{
-	dir = 1;
-	icon_state = "hr_kutjevo";
-	name = "solar lattice"
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "whitepurple"
 	},
-/obj/structure/platform/kutjevo/smooth{
-	dir = 4
-	},
-/obj/structure/lattice,
-/turf/open/space,
-/area/fiorina/oob)
+/area/fiorina/station/research_cells)
 "fde" = (
 /obj/structure/stairs/perspective{
 	icon_state = "p_stair_full"
@@ -8341,10 +8569,10 @@
 	pixel_x = 10;
 	pixel_y = -3
 	},
-/obj/effect/landmark/objective_landmark/science,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "whitegreenfull"
+	icon_state = "whitegreenfull";
+	tag = "icon-whitegreenfull (SOUTHWEST)"
 	},
 /area/fiorina/station/medbay)
 "fgB" = (
@@ -8374,19 +8602,13 @@
 	},
 /area/fiorina/maintenance)
 "fhz" = (
-/obj/structure/barricade/handrail{
-	dir = 1;
-	icon_state = "hr_kutjevo";
-	name = "solar lattice"
+/obj/structure/barricade/wooden,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "cell_stripe";
+	tag = "icon-cell_stripe (WEST)"
 	},
-/obj/structure/platform/kutjevo/smooth{
-	dir = 8
-	},
-/obj/structure/platform/kutjevo/smooth{
-	dir = 1
-	},
-/turf/open/space/basic,
-/area/fiorina/oob)
+/area/fiorina/station/central_ring)
 "fhC" = (
 /obj/item/stack/rods,
 /turf/open/floor/prison{
@@ -8475,6 +8697,17 @@
 "fjd" = (
 /turf/closed/wall/prison,
 /area/fiorina/lz/near_lzI)
+"fje" = (
+/obj/structure/bed/chair{
+	dir = 8;
+	pixel_y = 6
+	},
+/obj/item/reagent_container/food/drinks/cans/beer{
+	pixel_x = -13;
+	pixel_y = 13
+	},
+/turf/open/floor/prison,
+/area/fiorina/station/central_ring)
 "fjr" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating/plating_catwalk/prison,
@@ -8738,13 +8971,9 @@
 /turf/open/floor/plating/prison,
 /area/fiorina/tumor/fiberbush)
 "fsn" = (
-/obj/structure/platform/kutjevo/smooth,
-/obj/structure/platform/kutjevo/smooth{
-	dir = 4
-	},
-/obj/structure/lattice,
-/turf/open/space,
-/area/fiorina/oob)
+/obj/item/device/flashlight,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/fiorina/station/central_ring)
 "ftq" = (
 /obj/item/stack/cable_coil/orange,
 /turf/open/floor/prison{
@@ -8815,6 +9044,17 @@
 /obj/item/stack/sheet/metal,
 /turf/open/floor/plating/prison,
 /area/fiorina/station/telecomm/lz2_maint)
+"fvY" = (
+/obj/structure/machinery/light/double/blue{
+	dir = 8;
+	pixel_x = -10;
+	pixel_y = -3
+	},
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "whitepurple"
+	},
+/area/fiorina/station/research_cells)
 "fwn" = (
 /obj/structure/lattice,
 /obj/item/stack/sheet/metal,
@@ -9049,7 +9289,7 @@
 /obj/structure/inflatable/popped/door,
 /obj/item/ammo_magazine/m56d,
 /turf/open/floor/plating/prison,
-/area/fiorina/station/disco)
+/area/fiorina/station/central_ring)
 "fBp" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/prison{
@@ -9088,12 +9328,9 @@
 	},
 /area/fiorina/tumor/civres)
 "fDI" = (
-/obj/structure/prop/almayer/computers/mission_planning_system{
-	density = 0;
-	desc = "Its a telephone, and a computer. Woah.";
-	name = "\improper funny telephone booth";
-	pixel_x = 2;
-	pixel_y = 21
+/obj/structure/barricade/handrail/type_b{
+	dir = 8;
+	layer = 3.5
 	},
 /turf/open/floor/prison{
 	icon_state = "floor_plate"
@@ -9390,7 +9627,8 @@
 "fLR" = (
 /obj/item/device/flashlight/lamp/tripod,
 /turf/open/floor/prison{
-	icon_state = "floor_plate"
+	icon_state = "floor_plate";
+	tag = "icon-floor_plate"
 	},
 /area/fiorina/station/lowsec)
 "fLS" = (
@@ -9663,7 +9901,8 @@
 "fUZ" = (
 /obj/structure/largecrate/supply,
 /turf/open/floor/prison{
-	icon_state = "floor_plate"
+	icon_state = "floor_plate";
+	tag = "icon-floor_plate"
 	},
 /area/fiorina/station/medbay)
 "fVA" = (
@@ -9781,6 +10020,15 @@
 /obj/structure/bed/chair/office/dark,
 /turf/open/floor/prison,
 /area/fiorina/tumor/ice_lab)
+"fYV" = (
+/obj/structure/machinery/door/airlock/almayer/marine{
+	dir = 1;
+	icon = 'icons/obj/structures/doors/prepdoor_charlie.dmi'
+	},
+/turf/open/floor/prison{
+	icon_state = "floor_plate"
+	},
+/area/fiorina/station/research_cells)
 "fYW" = (
 /obj/structure/machinery/light/double/blue,
 /turf/open/floor/carpet,
@@ -9886,9 +10134,17 @@
 	icon_state = "greenfull"
 	},
 /area/fiorina/tumor/civres)
-"gcy" = (
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/fiorina/station/lowsec)
+"gde" = (
+/obj/structure/machinery/light/double/blue{
+	dir = 1;
+	pixel_y = 21
+	},
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "cell_stripe";
+	tag = "icon-cell_stripe (NORTH)"
+	},
+/area/fiorina/station/central_ring)
 "gdn" = (
 /obj/structure/machinery/door/airlock/prison_hatch/autoname,
 /turf/open/floor/prison{
@@ -9956,20 +10212,9 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/fiorina/maintenance)
 "gfp" = (
-/obj/structure/platform/kutjevo/smooth{
-	dir = 1
-	},
-/obj/structure/platform/kutjevo/smooth{
-	dir = 4
-	},
-/obj/structure/barricade/handrail{
-	dir = 1;
-	icon_state = "hr_kutjevo";
-	name = "solar lattice"
-	},
-/obj/structure/lattice,
-/turf/open/space,
-/area/fiorina/oob)
+/obj/structure/machinery/m56d_hmg/mg_turret/dropship,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/fiorina/station/central_ring)
 "gfw" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/storage/donut_box{
@@ -10020,12 +10265,9 @@
 	},
 /area/fiorina/station/lowsec)
 "ggu" = (
-/obj/item/ammo_casing{
-	icon_state = "casing_6_1"
-	},
-/obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison{
-	icon_state = "floor_plate"
+	icon_state = "floor_plate";
+	tag = "icon-floor_plate"
 	},
 /area/fiorina/station/lowsec)
 "ggB" = (
@@ -10044,12 +10286,16 @@
 	},
 /area/fiorina/tumor/ice_lab)
 "ggQ" = (
-/obj/structure/platform_decoration/kutjevo{
-	dir = 1
+/obj/structure/flora/pottedplant{
+	icon_state = "pottedplant_22";
+	tag = "icon-pottedplant_10"
 	},
-/obj/structure/lattice,
-/turf/open/space,
-/area/fiorina/oob)
+/obj/structure/machinery/light/double/blue{
+	dir = 1;
+	pixel_y = 21
+	},
+/turf/open/floor/prison,
+/area/fiorina/station/central_ring)
 "ghg" = (
 /obj/structure/barricade/handrail{
 	dir = 1;
@@ -10091,13 +10337,10 @@
 	},
 /area/fiorina/tumor/servers)
 "gik" = (
-/obj/structure/surface/table/reinforced/prison,
-/obj/structure/machinery/recharger{
-	pixel_y = 4
-	},
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "whitegreenfull"
+	icon_state = "whitegreenfull";
+	tag = "icon-whitegreenfull (SOUTHWEST)"
 	},
 /area/fiorina/station/medbay)
 "giX" = (
@@ -10152,6 +10395,16 @@
 	},
 /turf/open/floor/prison,
 /area/fiorina/station/medbay)
+"gky" = (
+/obj/structure/machinery/light/double/blue{
+	dir = 8;
+	pixel_x = -10;
+	pixel_y = -3
+	},
+/turf/open/floor/prison{
+	icon_state = "floor_plate"
+	},
+/area/fiorina/station/disco)
 "gkZ" = (
 /obj/effect/decal/medical_decals{
 	icon_state = "triagedecalleft"
@@ -10456,14 +10709,14 @@
 /turf/open/floor/plating/prison,
 /area/fiorina/tumor/ice_lab)
 "guB" = (
-/obj/structure/barricade/handrail/type_b{
-	dir = 8;
-	layer = 3.5
-	},
+/obj/item/ammo_magazine/m56d,
+/obj/item/ammo_magazine/m56d,
 /turf/open/floor/prison{
-	icon_state = "floor_plate"
+	dir = 4;
+	icon_state = "cell_stripe";
+	tag = "icon-cell_stripe (EAST)"
 	},
-/area/fiorina/station/disco)
+/area/fiorina/station/central_ring)
 "guG" = (
 /turf/open/floor/prison{
 	dir = 9;
@@ -10588,9 +10841,8 @@
 	},
 /area/fiorina/station/park)
 "gyW" = (
-/obj/item/weapon/harpoon,
-/turf/open/floor/plating/prison,
-/area/fiorina/maintenance)
+/turf/open/space,
+/area/fiorina/station/medbay)
 "gzb" = (
 /obj/structure/cable/heavyduty{
 	icon_state = "1-2"
@@ -10648,6 +10900,16 @@
 /obj/structure/largecrate/random/case,
 /turf/open/floor/prison,
 /area/fiorina/tumor/aux_engi)
+"gAk" = (
+/obj/structure/platform/kutjevo/smooth,
+/obj/structure/platform/kutjevo/smooth{
+	dir = 4
+	},
+/obj/structure/platform/kutjevo/smooth{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/fiorina/oob)
 "gAA" = (
 /obj/item/stack/sheet/metal/medium_stack,
 /turf/open/floor/plating/prison,
@@ -10710,6 +10972,16 @@
 	icon_state = "cell_stripe"
 	},
 /area/fiorina/station/flight_deck)
+"gDt" = (
+/obj/structure/machinery/light/double/blue{
+	dir = 4;
+	pixel_x = 10;
+	pixel_y = -3
+	},
+/turf/open/floor/prison{
+	icon_state = "darkpurplefull2"
+	},
+/area/fiorina/station/research_cells)
 "gDx" = (
 /obj/structure/surface/table/woodentable,
 /obj/item/newspaper{
@@ -10779,9 +11051,10 @@
 /turf/open/space,
 /area/fiorina/oob)
 "gEW" = (
-/obj/structure/surface/table/reinforced/prison,
 /turf/open/floor/prison{
-	icon_state = "floor_plate"
+	dir = 1;
+	icon_state = "cell_stripe";
+	tag = "icon-cell_stripe (NORTH)"
 	},
 /area/fiorina/station/lowsec)
 "gFc" = (
@@ -11244,10 +11517,12 @@
 	},
 /area/fiorina/station/park)
 "gTw" = (
-/obj/structure/lattice,
-/obj/structure/platform_decoration/kutjevo,
-/turf/open/space/basic,
-/area/fiorina/oob)
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "cell_stripe";
+	tag = "icon-cell_stripe (WEST)"
+	},
+/area/fiorina/station/central_ring)
 "gUf" = (
 /turf/open/floor/prison{
 	dir = 10;
@@ -11278,11 +11553,9 @@
 	},
 /area/fiorina/station/telecomm/lz1_cargo)
 "gUH" = (
-/obj/effect/decal/cleanable/blood/gibs/core,
-/turf/open/floor/prison{
-	icon_state = "whitepurple"
-	},
-/area/fiorina/station/research_cells)
+/obj/structure/machinery/cm_vending/sorted/medical/wall_med,
+/turf/closed/wall/prison,
+/area/fiorina/station/medbay)
 "gUO" = (
 /obj/item/tool/warning_cone,
 /turf/open/floor/prison,
@@ -11308,6 +11581,20 @@
 	icon_state = "redfull"
 	},
 /area/fiorina/station/security)
+"gVR" = (
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "cell_stripe";
+	tag = "icon-cell_stripe (NORTH)"
+	},
+/area/fiorina/maintenance)
+"gVX" = (
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "darkpurple2";
+	tag = "icon-darkpurple2"
+	},
+/area/fiorina/station/central_ring)
 "gWf" = (
 /obj/structure/barricade/handrail/type_b{
 	dir = 1
@@ -11342,6 +11629,13 @@
 	icon_state = "green"
 	},
 /area/fiorina/tumor/civres)
+"gXi" = (
+/obj/structure/barricade/metal/wired{
+	dir = 8
+	},
+/obj/item/stack/sheet/metal,
+/turf/open/floor/plating/prison,
+/area/fiorina/station/central_ring)
 "gXt" = (
 /turf/open/floor/prison{
 	icon_state = "platingdmg1"
@@ -11352,6 +11646,14 @@
 /obj/effect/landmark/objective_landmark/far,
 /turf/open/floor/plating/prison,
 /area/fiorina/station/telecomm/lz2_maint)
+"gXD" = (
+/obj/structure/machinery/light/double/blue{
+	dir = 8;
+	pixel_x = -10;
+	pixel_y = 13
+	},
+/turf/open/floor/prison,
+/area/fiorina/station/central_ring)
 "gXH" = (
 /obj/structure/prop/structure_lattice{
 	dir = 4;
@@ -11424,6 +11726,14 @@
 	icon_state = "panelscorched"
 	},
 /area/fiorina/station/transit_hub)
+"haa" = (
+/obj/structure/machinery/light/double/blue{
+	dir = 8;
+	pixel_x = -10;
+	pixel_y = 13
+	},
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/fiorina/station/central_ring)
 "hab" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/trash/plate{
@@ -11539,7 +11849,8 @@
 /obj/item/paper/carbon,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "sterile_white"
+	icon_state = "sterile_white";
+	tag = "icon-sterile_white (SOUTHWEST)"
 	},
 /area/fiorina/station/medbay)
 "hcv" = (
@@ -11652,7 +11963,7 @@
 "hgJ" = (
 /obj/structure/largecrate/random/case/small,
 /turf/open/floor/plating/prison,
-/area/fiorina/station/disco)
+/area/fiorina/station/central_ring)
 "hgS" = (
 /turf/closed/shuttle/ert{
 	icon_state = "stan5"
@@ -11792,12 +12103,9 @@
 /turf/open/floor/almayer_hull,
 /area/fiorina/oob)
 "hkW" = (
-/obj/item/trash/popcorn,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "sterile_white"
-	},
-/area/fiorina/station/medbay)
+/obj/structure/barricade/wooden,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/fiorina/station/central_ring)
 "hll" = (
 /obj/item/tool/warning_cone,
 /turf/open/floor/prison{
@@ -11895,7 +12203,8 @@
 	layer = 2.7
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2"
+	icon_state = "darkpurplefull2";
+	tag = "icon-darkpurplefull2"
 	},
 /area/fiorina/station/research_cells)
 "hoy" = (
@@ -11959,8 +12268,8 @@
 "hpJ" = (
 /obj/structure/bed/roller,
 /obj/structure/machinery/filtration/console{
-	pixel_y = 22;
-	can_block_movement = 0
+	can_block_movement = 0;
+	pixel_y = 22
 	},
 /obj/item/trash/used_stasis_bag,
 /turf/open/floor/plating/prison,
@@ -12015,6 +12324,15 @@
 	icon_state = "whitegreenfull"
 	},
 /area/fiorina/station/medbay)
+"hrg" = (
+/obj/structure/barricade/handrail{
+	dir = 4
+	},
+/turf/open/floor/prison{
+	icon_state = "floor_plate";
+	tag = "icon-floor_plate"
+	},
+/area/fiorina/station/central_ring)
 "hro" = (
 /obj/structure/girder,
 /turf/open/floor/plating/prison,
@@ -12069,6 +12387,10 @@
 	},
 /turf/open/floor/prison/chapel_carpet,
 /area/fiorina/maintenance)
+"htc" = (
+/obj/item/tool/wrench,
+/turf/open/floor/plating/prison,
+/area/fiorina/station/central_ring)
 "htt" = (
 /turf/closed/shuttle/ert,
 /area/fiorina/station/power_ring)
@@ -12468,6 +12790,11 @@
 	icon_state = "greenblue"
 	},
 /area/fiorina/station/botany)
+"hGP" = (
+/obj/structure/platform_decoration/kutjevo,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/fiorina/oob)
 "hGZ" = (
 /obj/item/stack/cable_coil,
 /turf/open/floor/prison{
@@ -12652,6 +12979,20 @@
 	icon_state = "red"
 	},
 /area/fiorina/lz/near_lzII)
+"hNi" = (
+/obj/structure/flora/pottedplant{
+	icon_state = "pottedplant_22";
+	tag = "icon-pottedplant_10"
+	},
+/obj/effect/decal/medical_decals{
+	icon_state = "triagedecalbottomright"
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "whitegreenfull";
+	tag = "icon-whitegreenfull (SOUTHWEST)"
+	},
+/area/fiorina/station/medbay)
 "hNY" = (
 /obj/item/stack/rods,
 /turf/open/floor/plating/prison,
@@ -12787,6 +13128,16 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/prison,
 /area/fiorina/station/security)
+"hTc" = (
+/obj/structure/stairs/perspective{
+	dir = 8;
+	icon_state = "p_stair_sn_full_cap"
+	},
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "whitegreen"
+	},
+/area/fiorina/station/central_ring)
 "hTf" = (
 /obj/structure/prop/structure_lattice{
 	dir = 4;
@@ -12907,10 +13258,14 @@
 /turf/closed/wall/prison,
 /area/fiorina/station/medbay)
 "hVS" = (
-/obj/structure/platform_decoration/kutjevo,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/fiorina/oob)
+/obj/structure/flora/bush/ausbushes/grassybush{
+	icon_state = "lavendergrass_4"
+	},
+/turf/open/organic/grass{
+	desc = "It'll get in your shoes no matter what you do.";
+	name = "astroturf"
+	},
+/area/fiorina/station/central_ring)
 "hWB" = (
 /obj/item/device/flashlight/lamp/tripod,
 /turf/open/floor/prison{
@@ -13034,10 +13389,13 @@
 	},
 /area/fiorina/station/medbay)
 "ick" = (
-/obj/item/tool/candle,
-/obj/effect/landmark/objective_landmark/medium,
-/turf/open/floor/prison/chapel_carpet,
-/area/fiorina/maintenance)
+/obj/structure/barricade/wooden,
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "cell_stripe";
+	tag = "icon-cell_stripe (EAST)"
+	},
+/area/fiorina/station/central_ring)
 "icK" = (
 /obj/effect/decal/cleanable/blood/splatter{
 	icon_state = "gibmid3"
@@ -13380,6 +13738,15 @@
 /obj/item/device/cassette_tape/hiphop,
 /turf/open/floor/plating/prison,
 /area/fiorina/tumor/ice_lab)
+"ioG" = (
+/obj/structure/flora/bush/ausbushes/grassybush{
+	icon_state = "brflowers_1"
+	},
+/turf/open/organic/grass{
+	desc = "It'll get in your shoes no matter what you do.";
+	name = "astroturf"
+	},
+/area/fiorina/station/central_ring)
 "ioM" = (
 /turf/closed/wall/r_wall/prison,
 /area/fiorina/station/medbay)
@@ -13447,6 +13814,9 @@
 	icon_state = "sterile_white"
 	},
 /area/fiorina/station/research_cells)
+"irx" = (
+/turf/open/floor/plating/prison,
+/area/fiorina/station/central_ring)
 "iry" = (
 /obj/structure/janitorialcart,
 /turf/open/floor/prison{
@@ -13483,6 +13853,12 @@
 	icon_state = "kitchen"
 	},
 /area/fiorina/station/research_cells)
+"isl" = (
+/obj/structure/stairs/perspective{
+	icon_state = "p_stair_full"
+	},
+/turf/open/floor/plating/prison,
+/area/fiorina/station/central_ring)
 "isB" = (
 /obj/structure/bed/chair/comfy{
 	dir = 1
@@ -13506,6 +13882,14 @@
 	icon_state = "yellow"
 	},
 /area/fiorina/station/lowsec)
+"isL" = (
+/obj/structure/machinery/light/double/blue{
+	dir = 4;
+	pixel_x = 10;
+	pixel_y = 13
+	},
+/turf/open/floor/prison,
+/area/fiorina/station/central_ring)
 "isP" = (
 /obj/item/trash/snack_bowl,
 /turf/open/floor/prison{
@@ -13566,6 +13950,13 @@
 	name = "astroturf"
 	},
 /area/fiorina/tumor/fiberbush)
+"iuw" = (
+/obj/item/reagent_container/food/drinks/cans/souto/cherry,
+/turf/open/floor/prison{
+	icon_state = "floor_plate";
+	tag = "icon-floor_plate"
+	},
+/area/fiorina/station/central_ring)
 "iuV" = (
 /obj/structure/curtain,
 /turf/open/floor/prison{
@@ -13607,7 +13998,6 @@
 "ivB" = (
 /obj/structure/surface/rack,
 /obj/item/storage/pouch/tools/full,
-/obj/effect/landmark/objective_landmark/close,
 /turf/open/floor/plating/prison,
 /area/fiorina/maintenance)
 "ivL" = (
@@ -13639,7 +14029,8 @@
 	},
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "whitegreenfull"
+	icon_state = "whitegreenfull";
+	tag = "icon-whitegreenfull (SOUTHWEST)"
 	},
 /area/fiorina/station/medbay)
 "iwf" = (
@@ -13647,11 +14038,11 @@
 /turf/open/floor/prison/chapel_carpet,
 /area/fiorina/station/chapel)
 "iwK" = (
-/obj/structure/surface/table/reinforced/prison,
-/obj/item/reagent_container/food/snacks/mre_pack/meal1,
-/turf/open/floor/prison{
-	icon_state = "darkpurplefull2"
+/obj/structure/stairs/perspective{
+	dir = 5;
+	icon_state = "p_stair_full"
 	},
+/turf/open/floor/plating/plating_catwalk/prison,
 /area/fiorina/station/research_cells)
 "iwT" = (
 /obj/structure/ice/thin/indestructible{
@@ -13769,6 +14160,14 @@
 	icon_state = "stan25"
 	},
 /area/fiorina/oob)
+"iCi" = (
+/obj/item/device/flashlight/lamp/tripod,
+/obj/structure/machinery/light/double/blue{
+	dir = 1;
+	pixel_y = 21
+	},
+/turf/open/floor/prison,
+/area/fiorina/station/central_ring)
 "iCo" = (
 /obj/structure/machinery/door/poddoor/almayer{
 	density = 0;
@@ -13964,9 +14363,6 @@
 	dir = 1
 	},
 /obj/structure/inflatable/popped,
-/obj/structure/barricade/wooden{
-	dir = 8
-	},
 /turf/open/floor/prison{
 	icon_state = "whitegreen"
 	},
@@ -14040,6 +14436,21 @@
 /obj/effect/landmark/corpsespawner/prison_security,
 /turf/open/floor/prison,
 /area/fiorina/station/park)
+"iKT" = (
+/obj/structure/platform/kutjevo/smooth{
+	dir = 1
+	},
+/obj/structure/platform/kutjevo/smooth{
+	dir = 8
+	},
+/obj/structure/platform/kutjevo/smooth,
+/obj/structure/barricade/handrail{
+	dir = 1;
+	icon_state = "hr_kutjevo";
+	name = "solar lattice"
+	},
+/turf/open/space/basic,
+/area/fiorina/oob)
 "iLy" = (
 /obj/item/stack/rods/plasteel,
 /turf/open/floor/prison{
@@ -14309,6 +14720,13 @@
 	icon_state = "darkyellow2"
 	},
 /area/fiorina/station/telecomm/lz1_cargo)
+"iTe" = (
+/obj/structure/stairs/perspective{
+	dir = 4;
+	icon_state = "p_stair_sn_full_cap"
+	},
+/turf/open/floor/plating/prison,
+/area/fiorina/station/central_ring)
 "iTm" = (
 /turf/open/auto_turf/sand/layer1,
 /area/fiorina/station/civres_blue)
@@ -14608,6 +15026,12 @@
 	icon_state = "sterile_white"
 	},
 /area/fiorina/station/civres_blue)
+"jdX" = (
+/obj/item/clothing/under/shorts/red,
+/turf/open/floor/prison{
+	icon_state = "yellowfull"
+	},
+/area/fiorina/station/central_ring)
 "jeh" = (
 /obj/structure/stairs/perspective{
 	icon_state = "p_stair_ew_full_cap"
@@ -14657,21 +15081,13 @@
 	name = "pool"
 	},
 /area/fiorina/station/park)
-"jfm" = (
-/obj/structure/lattice,
-/obj/structure/platform/kutjevo/smooth{
-	dir = 1
+"jfk" = (
+/obj/item/ammo_magazine/rifle/mar40/extended,
+/turf/open/floor/prison{
+	icon_state = "floor_plate";
+	tag = "icon-floor_plate"
 	},
-/obj/structure/platform/kutjevo/smooth{
-	dir = 4
-	},
-/obj/structure/barricade/handrail{
-	dir = 1;
-	icon_state = "hr_kutjevo";
-	name = "solar lattice"
-	},
-/turf/open/space/basic,
-/area/fiorina/oob)
+/area/fiorina/station/lowsec)
 "jfp" = (
 /obj/structure/barricade/handrail,
 /obj/structure/barricade/handrail{
@@ -14712,6 +15128,13 @@
 "jgu" = (
 /turf/closed/wall/prison,
 /area/fiorina/station/park)
+"jgN" = (
+/obj/item/weapon/gun/shotgun/pump/dual_tube/cmb,
+/turf/open/organic/grass{
+	desc = "It'll get in your shoes no matter what you do.";
+	name = "astroturf"
+	},
+/area/fiorina/station/central_ring)
 "jgW" = (
 /obj/structure/barricade/metal/wired{
 	dir = 1
@@ -15133,18 +15556,12 @@
 	},
 /area/fiorina/station/power_ring)
 "jqR" = (
-/obj/structure/flora/pottedplant{
-	icon_state = "pottedplant_22"
+/obj/structure/barricade/wooden{
+	dir = 4;
+	pixel_y = 4
 	},
-/obj/structure/machinery/light/double/blue{
-	dir = 8;
-	pixel_x = -10;
-	pixel_y = 13
-	},
-/turf/open/floor/prison{
-	icon_state = "floor_plate"
-	},
-/area/fiorina/station/disco)
+/turf/open/floor/prison,
+/area/fiorina/station/central_ring)
 "jqX" = (
 /obj/structure/platform{
 	dir = 8
@@ -15383,6 +15800,10 @@
 /obj/item/stack/tile/plasteel,
 /turf/open/floor/prison,
 /area/fiorina/station/disco)
+"jAt" = (
+/obj/structure/platform/shiva,
+/turf/open/floor/plating/prison,
+/area/fiorina/station/central_ring)
 "jAx" = (
 /turf/open/floor/prison{
 	dir = 1;
@@ -15554,6 +15975,14 @@
 	icon_state = "greenfull"
 	},
 /area/fiorina/tumor/servers)
+"jEC" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 3;
+	tag = "icon-rwindow (NORTH)"
+	},
+/turf/open/floor/prison,
+/area/fiorina/station/central_ring)
 "jEG" = (
 /obj/structure/prop/resin_prop,
 /turf/open/floor/prison{
@@ -15660,6 +16089,12 @@
 	},
 /turf/open/floor/plating/prison,
 /area/fiorina/maintenance)
+"jJe" = (
+/obj/structure/barricade/handrail/type_b{
+	dir = 4
+	},
+/turf/open/floor/prison,
+/area/fiorina/station/disco)
 "jJh" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/structure/machinery/computer/objective,
@@ -15843,6 +16278,16 @@
 /obj/structure/machinery/power/smes/buildable,
 /turf/open/floor/prison,
 /area/fiorina/station/power_ring)
+"jMA" = (
+/obj/structure/machinery/light/double/blue{
+	dir = 8;
+	pixel_x = -10;
+	pixel_y = 13
+	},
+/turf/open/floor/prison{
+	icon_state = "floor_plate"
+	},
+/area/fiorina/station/disco)
 "jMH" = (
 /obj/structure/barricade/metal/wired{
 	dir = 4
@@ -15851,6 +16296,12 @@
 	icon_state = "plate"
 	},
 /area/fiorina/tumor/ship)
+"jNa" = (
+/turf/open/floor/prison{
+	icon_state = "darkpurple2";
+	tag = "icon-darkpurple2"
+	},
+/area/fiorina/station/central_ring)
 "jNl" = (
 /obj/structure/ice/thin/indestructible{
 	icon_state = "Straight"
@@ -16127,6 +16578,11 @@
 /obj/effect/landmark/yautja_teleport,
 /turf/open/floor/prison,
 /area/fiorina/station/park)
+"jXx" = (
+/turf/open/floor/prison{
+	icon_state = "yellow"
+	},
+/area/fiorina/station/central_ring)
 "jXz" = (
 /turf/closed/wall/prison,
 /area/fiorina/tumor/servers)
@@ -16209,11 +16665,12 @@
 	},
 /area/fiorina/lz/near_lzII)
 "jZb" = (
-/obj/item/ammo_magazine/shotgun/buckshot,
 /turf/open/floor/prison{
-	icon_state = "floor_plate"
+	dir = 4;
+	icon_state = "cell_stripe";
+	tag = "icon-cell_stripe (EAST)"
 	},
-/area/fiorina/station/lowsec)
+/area/fiorina/station/central_ring)
 "jZc" = (
 /obj/structure/disposalpipe/segment{
 	icon_state = "delivery_outlet";
@@ -16223,6 +16680,13 @@
 	},
 /turf/open/floor/plating/prison,
 /area/fiorina/tumor/ice_lab)
+"jZx" = (
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/prison{
+	icon_state = "floor_plate";
+	tag = "icon-floor_plate"
+	},
+/area/fiorina/station/central_ring)
 "jZR" = (
 /obj/item/frame/rack,
 /obj/structure/barricade/handrail/type_b{
@@ -16400,6 +16864,7 @@
 	},
 /area/fiorina/station/security)
 "kdo" = (
+/obj/structure/platform_decoration,
 /obj/structure/inflatable,
 /turf/open/floor/prison{
 	icon_state = "whitegreen"
@@ -16431,6 +16896,13 @@
 /obj/structure/largecrate/random/case/small,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/fiorina/lz/near_lzI)
+"keo" = (
+/obj/structure/platform_decoration/kutjevo{
+	dir = 1
+	},
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/fiorina/oob)
 "keF" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/device/flash,
@@ -16534,6 +17006,11 @@
 /obj/structure/machinery/light/double/blue,
 /turf/open/floor/wood,
 /area/fiorina/station/civres_blue)
+"kiq" = (
+/turf/open/floor/prison{
+	icon_state = "damaged2"
+	},
+/area/fiorina/station/central_ring)
 "kis" = (
 /obj/structure/machinery/light/double/blue{
 	dir = 1;
@@ -16943,6 +17420,15 @@
 	icon_state = "redfull"
 	},
 /area/fiorina/station/medbay)
+"kuT" = (
+/obj/structure/flora/bush/ausbushes/grassybush{
+	icon_state = "ywflowers_3"
+	},
+/turf/open/organic/grass{
+	desc = "It'll get in your shoes no matter what you do.";
+	name = "astroturf"
+	},
+/area/fiorina/station/central_ring)
 "kvd" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/reagent_container/food/drinks/golden_cup,
@@ -16965,6 +17451,20 @@
 	name = "astroturf"
 	},
 /area/fiorina/station/park)
+"kvm" = (
+/obj/structure/platform/kutjevo/smooth{
+	dir = 1
+	},
+/obj/structure/platform/kutjevo/smooth{
+	dir = 4
+	},
+/obj/structure/barricade/handrail{
+	dir = 1;
+	icon_state = "hr_kutjevo";
+	name = "solar lattice"
+	},
+/turf/open/space/basic,
+/area/fiorina/oob)
 "kvn" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/weapon/gun/energy/taser,
@@ -17773,6 +18273,16 @@
 	icon_state = "blue"
 	},
 /area/fiorina/station/civres_blue)
+"kUR" = (
+/obj/structure/stairs/perspective{
+	dir = 1;
+	icon_state = "p_stair_full"
+	},
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "whitegreen"
+	},
+/area/fiorina/station/central_ring)
 "kVg" = (
 /obj/item/stack/cable_coil/blue,
 /turf/open/floor/plating/prison,
@@ -18055,6 +18565,10 @@
 	icon_state = "whitegreen"
 	},
 /area/fiorina/station/medbay)
+"ldZ" = (
+/obj/structure/machinery/door/airlock/prison_hatch/autoname,
+/turf/open/floor/plating/prison,
+/area/fiorina/station/central_ring)
 "leq" = (
 /obj/effect/landmark/corpsespawner/prison_security,
 /turf/open/floor/prison{
@@ -18153,6 +18667,19 @@
 	},
 /turf/open/floor/plating/prison,
 /area/fiorina/maintenance)
+"liE" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/prison{
+	icon_state = "floor_plate";
+	tag = "icon-floor_plate"
+	},
+/area/fiorina/station/lowsec)
+"liT" = (
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "yellow"
+	},
+/area/fiorina/station/central_ring)
 "liX" = (
 /obj/structure/reagent_dispensers/water_cooler/stacks,
 /turf/open/floor/prison{
@@ -18639,6 +19166,7 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/fiorina/station/medbay)
 "lwB" = (
+/obj/structure/platform,
 /obj/structure/bed/chair{
 	dir = 1;
 	layer = 2.7
@@ -18727,11 +19255,14 @@
 	},
 /area/fiorina/station/medbay)
 "lzb" = (
-/obj/structure/largecrate/random,
-/turf/open/floor/prison{
-	icon_state = "floor_plate"
+/obj/structure/platform_decoration{
+	dir = 1
 	},
-/area/fiorina/station/disco)
+/turf/open/floor/prison{
+	icon_state = "floor_plate";
+	tag = "icon-floor_plate"
+	},
+/area/fiorina/station/central_ring)
 "lzm" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/structure/window/reinforced/tinted,
@@ -18815,6 +19346,10 @@
 	},
 /turf/open/floor/prison,
 /area/fiorina/station/flight_deck)
+"lBY" = (
+/obj/item/stack/sheet/metal,
+/turf/open/floor/plating/prison,
+/area/fiorina/station/central_ring)
 "lCm" = (
 /obj/item/ammo_casing{
 	icon_state = "cartridge_1"
@@ -18885,12 +19420,8 @@
 	},
 /area/fiorina/station/civres_blue)
 "lDC" = (
-/obj/structure/platform/kutjevo/smooth,
-/obj/structure/platform/kutjevo/smooth{
-	dir = 4
-	},
-/turf/open/space/basic,
-/area/fiorina/oob)
+/turf/closed/wall/prison,
+/area/fiorina/station/central_ring)
 "lEa" = (
 /obj/structure/stairs/perspective{
 	icon_state = "p_stair_ew_full_cap"
@@ -18986,18 +19517,16 @@
 /turf/open/floor/prison,
 /area/fiorina/station/transit_hub)
 "lGA" = (
-/obj/structure/machinery/bioprinter{
-	stored_metal = 1000
-	},
-/obj/structure/machinery/door/window/eastright,
-/obj/structure/machinery/door/window/eastright{
-	dir = 8
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/storage/fancy/cigarettes/arcturian_ace{
+	pixel_x = -4;
+	pixel_y = 9
 	},
 /turf/open/floor/prison{
-	dir = 10;
-	icon_state = "whitegreenfull"
+	icon_state = "darkpurplefull2";
+	tag = "icon-darkpurplefull2"
 	},
-/area/fiorina/station/medbay)
+/area/fiorina/station/research_cells)
 "lHc" = (
 /obj/structure/bed{
 	icon_state = "abed"
@@ -19073,6 +19602,7 @@
 	},
 /area/fiorina/station/park)
 "lJv" = (
+/obj/structure/platform,
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/storage/firstaid/regular,
 /obj/structure/machinery/light/double/blue{
@@ -19211,6 +19741,15 @@
 	icon_state = "darkbrownfull2"
 	},
 /area/fiorina/tumor/aux_engi)
+"lOB" = (
+/obj/structure/platform/kutjevo/smooth{
+	dir = 1
+	},
+/obj/structure/platform/kutjevo/smooth{
+	dir = 8
+	},
+/turf/open/space/basic,
+/area/fiorina/oob)
 "lOE" = (
 /turf/open/floor/prison{
 	dir = 9;
@@ -19382,6 +19921,21 @@
 	icon_state = "damaged2"
 	},
 /area/fiorina/station/lowsec)
+"lWh" = (
+/obj/item/clothing/under/shorts/black,
+/turf/open/floor/prison{
+	icon_state = "floor_plate";
+	tag = "icon-floor_plate"
+	},
+/area/fiorina/station/central_ring)
+"lWr" = (
+/obj/structure/stairs/perspective{
+	dir = 4;
+	icon_state = "p_stair_full"
+	},
+/obj/structure/platform/shiva,
+/turf/open/floor/plating/prison,
+/area/fiorina/station/central_ring)
 "lWD" = (
 /obj/structure/machinery/light/double/blue{
 	dir = 4;
@@ -19826,12 +20380,11 @@
 	},
 /area/fiorina/station/telecomm/lz1_cargo)
 "mhv" = (
-/obj/structure/platform_decoration/kutjevo{
-	dir = 8
+/obj/structure/machinery/power/apc{
+	dir = 1
 	},
-/obj/structure/lattice,
-/turf/open/space,
-/area/fiorina/oob)
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/fiorina/station/central_ring)
 "mhM" = (
 /obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	dir = 1;
@@ -20155,6 +20708,12 @@
 	icon_state = "yellow"
 	},
 /area/fiorina/station/lowsec)
+"msS" = (
+/obj/structure/machinery/door/airlock/prison_hatch/autoname{
+	dir = 1
+	},
+/turf/open/floor/plating/prison,
+/area/fiorina/station/central_ring)
 "mtj" = (
 /obj/structure/machinery/light/double/blue{
 	dir = 4;
@@ -20185,6 +20744,10 @@
 	icon_state = "floor_plate"
 	},
 /area/fiorina/tumor/fiberbush)
+"muf" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/prison,
+/area/fiorina/station/central_ring)
 "muB" = (
 /obj/effect/landmark/corpsespawner/ua_riot/burst,
 /turf/open/floor/prison{
@@ -20256,6 +20819,13 @@
 	icon_state = "floor_plate"
 	},
 /area/fiorina/station/lowsec)
+"mxG" = (
+/obj/structure/platform/kutjevo/smooth,
+/obj/structure/platform/kutjevo/smooth{
+	dir = 8
+	},
+/turf/open/space/basic,
+/area/fiorina/oob)
 "mxO" = (
 /obj/structure/flora/pottedplant{
 	icon_state = "pottedplant_22"
@@ -20369,7 +20939,6 @@
 /area/fiorina/station/security)
 "mAz" = (
 /obj/structure/closet/emcloset,
-/obj/effect/landmark/objective_landmark/close,
 /turf/open/floor/prison{
 	dir = 5;
 	icon_state = "whitegreen"
@@ -20460,16 +21029,12 @@
 	},
 /area/fiorina/station/lowsec)
 "mDi" = (
-/obj/structure/flora/pottedplant{
-	icon_state = "pottedplant_22"
+/obj/structure/platform_decoration,
+/turf/open/floor/prison{
+	icon_state = "floor_plate";
+	tag = "icon-floor_plate"
 	},
-/obj/structure/machinery/light/double/blue{
-	dir = 8;
-	pixel_x = -10;
-	pixel_y = -3
-	},
-/turf/open/floor/prison,
-/area/fiorina/station/disco)
+/area/fiorina/station/central_ring)
 "mDs" = (
 /obj/item/stack/sandbags_empty/half,
 /turf/open/floor/prison{
@@ -20498,11 +21063,11 @@
 	},
 /area/fiorina/station/park)
 "mEv" = (
-/obj/structure/surface/table/reinforced/prison,
-/obj/item/reagent_container/food/snacks/mre_pack/meal5,
-/turf/open/floor/prison{
-	icon_state = "darkpurplefull2"
+/obj/structure/stairs/perspective{
+	dir = 1;
+	icon_state = "p_stair_sn_full_cap"
 	},
+/turf/open/floor/plating/plating_catwalk/prison,
 /area/fiorina/station/research_cells)
 "mEL" = (
 /obj/item/prop/helmetgarb/spacejam_tickets{
@@ -20532,6 +21097,10 @@
 	icon_state = "floor_plate"
 	},
 /area/fiorina/station/civres_blue)
+"mFv" = (
+/obj/structure/largecrate/random/mini/ammo,
+/turf/open/floor/prison,
+/area/fiorina/station/central_ring)
 "mFz" = (
 /obj/effect/decal/cleanable/blood/splatter{
 	icon_state = "gibmid1"
@@ -20542,19 +21111,8 @@
 	},
 /area/fiorina/station/medbay)
 "mGe" = (
-/obj/structure/bed/chair{
-	dir = 1;
-	pixel_y = 3
-	},
-/obj/effect/decal/cleanable/blood,
-/obj/item/reagent_container/food/drinks/cans/beer{
-	pixel_x = -11;
-	pixel_y = -6
-	},
-/turf/open/floor/prison{
-	icon_state = "floor_plate"
-	},
-/area/fiorina/station/lowsec)
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/fiorina/station/central_ring)
 "mGx" = (
 /obj/item/reagent_container/food/drinks/sillycup,
 /turf/open/floor/prison,
@@ -20595,6 +21153,15 @@
 	icon_state = "whitegreenfull"
 	},
 /area/fiorina/station/medbay)
+"mIq" = (
+/obj/structure/barricade/handrail{
+	dir = 8
+	},
+/turf/open/floor/prison{
+	icon_state = "floor_plate";
+	tag = "icon-floor_plate"
+	},
+/area/fiorina/station/central_ring)
 "mIu" = (
 /obj/effect/spawner/random/sentry/midchance,
 /turf/open/floor/plating/prison,
@@ -22022,6 +22589,13 @@
 	icon_state = "floor_plate"
 	},
 /area/fiorina/station/security)
+"nzp" = (
+/obj/item/clothing/gloves/boxing/blue,
+/turf/open/floor/prison{
+	dir = 9;
+	icon_state = "yellow"
+	},
+/area/fiorina/station/central_ring)
 "nzI" = (
 /obj/structure/largecrate/random,
 /turf/open/floor/wood,
@@ -23217,6 +23791,13 @@
 	icon_state = "sterile_white"
 	},
 /area/fiorina/tumor/ice_lab)
+"olQ" = (
+/obj/structure/platform/kutjevo/smooth,
+/obj/structure/platform/kutjevo/smooth{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/fiorina/oob)
 "olT" = (
 /obj/structure/machinery/computer3/server/rack,
 /obj/structure/window{
@@ -23300,9 +23881,19 @@
 	},
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "whitegreenfull"
+	icon_state = "whitegreenfull";
+	tag = "icon-whitegreenfull (SOUTHWEST)"
 	},
 /area/fiorina/station/medbay)
+"ooA" = (
+/obj/item/ammo_casing{
+	icon_state = "casing_6_1"
+	},
+/turf/open/floor/prison{
+	icon_state = "floor_plate";
+	tag = "icon-floor_plate"
+	},
+/area/fiorina/station/lowsec)
 "ooF" = (
 /obj/structure/machinery/power/apc,
 /turf/open/floor/wood,
@@ -23865,12 +24456,14 @@
 /turf/open/floor/plating/prison,
 /area/fiorina/station/lowsec)
 "oFW" = (
+/obj/structure/platform,
 /obj/structure/bed/chair{
 	dir = 1;
 	layer = 2.7
 	},
+/obj/structure/machinery/light/double/blue,
 /turf/open/floor/prison{
-	icon_state = "whitegreencorner"
+	icon_state = "whitegreen"
 	},
 /area/fiorina/station/medbay)
 "oGm" = (
@@ -24022,6 +24615,15 @@
 /obj/effect/landmark/objective_landmark/close,
 /turf/open/floor/plating/prison,
 /area/fiorina/tumor/civres)
+"oKQ" = (
+/obj/structure/machinery/floodlight{
+	name = "Yard Floodlight"
+	},
+/turf/open/floor/prison{
+	icon_state = "floor_plate";
+	tag = "icon-floor_plate"
+	},
+/area/fiorina/station/central_ring)
 "oKV" = (
 /obj/structure/machinery/door/airlock/multi_tile/elevator/freight,
 /turf/open/floor/corsat{
@@ -24083,6 +24685,19 @@
 	icon_state = "doubleside"
 	},
 /area/fiorina/maintenance)
+"oOs" = (
+/turf/open/floor/prison{
+	dir = 5;
+	icon_state = "darkpurple2";
+	tag = "icon-darkpurple2"
+	},
+/area/fiorina/station/central_ring)
+"oOv" = (
+/obj/structure/barricade/wooden{
+	dir = 8
+	},
+/turf/open/floor/plating/prison,
+/area/fiorina/station/central_ring)
 "oOK" = (
 /obj/item/device/multitool,
 /turf/open/floor/prison{
@@ -24104,6 +24719,14 @@
 	icon_state = "floor_plate"
 	},
 /area/fiorina/station/park)
+"oPJ" = (
+/obj/effect/decal/cleanable/blood/gibs,
+/obj/item/ammo_magazine/rifle/mar40,
+/turf/open/floor/prison{
+	icon_state = "floor_plate";
+	tag = "icon-floor_plate"
+	},
+/area/fiorina/station/lowsec)
 "oPN" = (
 /obj/structure/inflatable/popped/door,
 /turf/open/floor/plating/prison,
@@ -24205,6 +24828,13 @@
 	name = "astroturf"
 	},
 /area/fiorina/station/civres_blue)
+"oTG" = (
+/obj/structure/platform_decoration/kutjevo{
+	dir = 8
+	},
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/fiorina/oob)
 "oTH" = (
 /obj/structure/bed/chair,
 /turf/open/floor/prison{
@@ -24227,6 +24857,12 @@
 	},
 /turf/open/space,
 /area/fiorina/oob)
+"oVk" = (
+/obj/structure/sign/prop3{
+	desc = "Enlist in the Penal Battalions today! The USCM 3rd Fleet features a subset of UA sanctioned penal battalions, drawing from inmate popualtions across the colonies. Mostly New Argentina though."
+	},
+/turf/closed/wall/r_wall/prison_unmeltable,
+/area/fiorina/station/central_ring)
 "oVn" = (
 /obj/structure/surface/rack,
 /obj/effect/landmark/objective_landmark/close,
@@ -24648,6 +25284,15 @@
 /obj/item/stack/cable_coil/cut,
 /turf/open/floor/prison,
 /area/fiorina/tumor/servers)
+"pkw" = (
+/obj/structure/stairs/perspective{
+	icon_state = "p_stair_sn_full_cap"
+	},
+/obj/structure/platform{
+	dir = 8
+	},
+/turf/open/floor/plating/prison,
+/area/fiorina/station/central_ring)
 "pkG" = (
 /obj/item/stool,
 /turf/open/floor/prison{
@@ -25671,7 +26316,6 @@
 	},
 /area/fiorina/station/medbay)
 "pSJ" = (
-/obj/effect/landmark/corpsespawner/pmc,
 /turf/open/floor/wood,
 /area/fiorina/maintenance)
 "pSU" = (
@@ -25878,6 +26522,15 @@
 "qbl" = (
 /turf/open/auto_turf/sand/layer1,
 /area/fiorina/lz/near_lzII)
+"qbr" = (
+/obj/structure/flora/bush/ausbushes/grassybush{
+	icon_state = "lavendergrass_2"
+	},
+/turf/open/organic/grass{
+	desc = "It'll get in your shoes no matter what you do.";
+	name = "astroturf"
+	},
+/area/fiorina/station/central_ring)
 "qbu" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 4
@@ -26039,6 +26692,13 @@
 	icon_state = "whitepurple"
 	},
 /area/fiorina/oob)
+"qfE" = (
+/obj/item/ammo_magazine/shotgun/buckshot,
+/turf/open/organic/grass{
+	desc = "It'll get in your shoes no matter what you do.";
+	name = "astroturf"
+	},
+/area/fiorina/station/central_ring)
 "qfI" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 8
@@ -26062,12 +26722,12 @@
 /turf/open/space/basic,
 /area/fiorina/oob)
 "qgh" = (
-/obj/structure/surface/table/reinforced/prison,
-/obj/item/book/manual/surgery,
+/obj/item/stool,
 /turf/open/floor/prison{
-	icon_state = "redfull"
+	icon_state = "darkpurplefull2";
+	tag = "icon-darkpurplefull2"
 	},
-/area/fiorina/station/medbay)
+/area/fiorina/station/research_cells)
 "qgi" = (
 /obj/structure/disposalpipe/segment{
 	color = "#c4c4c4";
@@ -26388,7 +27048,8 @@
 "qpw" = (
 /obj/structure/window/reinforced{
 	dir = 1;
-	layer = 3
+	layer = 3;
+	tag = "icon-rwindow (NORTH)"
 	},
 /turf/open/floor/prison,
 /area/fiorina/station/medbay)
@@ -26605,6 +27266,16 @@
 	icon_state = "darkbrowncorners2"
 	},
 /area/fiorina/maintenance)
+"qwZ" = (
+/obj/structure/stairs/perspective{
+	dir = 1;
+	icon_state = "p_stair_sn_full_cap"
+	},
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "whitegreen"
+	},
+/area/fiorina/station/central_ring)
 "qxB" = (
 /obj/structure/stairs/perspective{
 	dir = 1;
@@ -26656,11 +27327,18 @@
 	},
 /area/fiorina/station/park)
 "qyX" = (
-/obj/structure/barricade/wooden,
-/turf/open/floor/prison{
-	icon_state = "floor_plate"
+/obj/structure/stairs/perspective{
+	dir = 1;
+	icon_state = "p_stair_sn_full_cap"
 	},
-/area/fiorina/station/disco)
+/obj/structure/platform{
+	dir = 8
+	},
+/turf/open/floor/prison{
+	icon_state = "floor_plate";
+	tag = "icon-floor_plate"
+	},
+/area/fiorina/station/central_ring)
 "qzl" = (
 /obj/structure/machinery/shower{
 	pixel_y = 13
@@ -27324,7 +28002,8 @@
 	},
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "whitegreenfull"
+	icon_state = "whitegreenfull";
+	tag = "icon-whitegreenfull (SOUTHWEST)"
 	},
 /area/fiorina/station/medbay)
 "qSv" = (
@@ -27626,9 +28305,19 @@
 	pixel_y = 2
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2"
+	icon_state = "darkpurplefull2";
+	tag = "icon-darkpurplefull2"
 	},
 /area/fiorina/station/research_cells)
+"rac" = (
+/obj/structure/platform/kutjevo/smooth{
+	dir = 8
+	},
+/obj/structure/platform/kutjevo/smooth{
+	dir = 1
+	},
+/turf/open/space/basic,
+/area/fiorina/oob)
 "rar" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -27687,6 +28376,13 @@
 	icon_state = "redfull"
 	},
 /area/fiorina/station/security)
+"rcG" = (
+/obj/structure/barricade/handrail,
+/turf/open/floor/prison{
+	icon_state = "floor_plate";
+	tag = "icon-floor_plate"
+	},
+/area/fiorina/station/central_ring)
 "rdS" = (
 /obj/structure/machinery/light/double/blue{
 	dir = 8;
@@ -27710,6 +28406,15 @@
 	icon_state = "blue"
 	},
 /area/fiorina/station/power_ring)
+"reD" = (
+/obj/structure/platform_decoration{
+	dir = 8
+	},
+/turf/open/floor/prison{
+	icon_state = "floor_plate";
+	tag = "icon-floor_plate"
+	},
+/area/fiorina/station/lowsec)
 "reO" = (
 /obj/structure/platform_decoration{
 	dir = 4
@@ -27767,7 +28472,8 @@
 	pixel_y = 9
 	},
 /turf/open/floor/prison{
-	icon_state = "darkpurplefull2"
+	icon_state = "darkpurplefull2";
+	tag = "icon-darkpurplefull2"
 	},
 /area/fiorina/station/research_cells)
 "rfR" = (
@@ -27854,7 +28560,8 @@
 	},
 /turf/open/floor/prison{
 	dir = 1;
-	icon_state = "cell_stripe"
+	icon_state = "cell_stripe";
+	tag = "icon-cell_stripe (NORTH)"
 	},
 /area/fiorina/station/medbay)
 "rjM" = (
@@ -27893,9 +28600,12 @@
 	},
 /area/fiorina/station/botany)
 "rkB" = (
+/obj/structure/platform_decoration{
+	dir = 4
+	},
 /obj/item/device/flashlight,
 /turf/open/floor/plating/prison,
-/area/fiorina/station/disco)
+/area/fiorina/station/central_ring)
 "rkH" = (
 /obj/structure/grille,
 /obj/structure/lattice,
@@ -28173,6 +28883,16 @@
 	icon_state = "floor_plate"
 	},
 /area/fiorina/station/security/wardens)
+"rud" = (
+/obj/effect/decal/medical_decals{
+	icon_state = "triagedecaldir"
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "whitegreenfull";
+	tag = "icon-whitegreenfull (SOUTHWEST)"
+	},
+/area/fiorina/station/medbay)
 "rue" = (
 /obj/structure/monorail{
 	dir = 10;
@@ -28198,7 +28918,8 @@
 	},
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "whitegreenfull"
+	icon_state = "whitegreenfull";
+	tag = "icon-whitegreenfull (SOUTHWEST)"
 	},
 /area/fiorina/station/medbay)
 "ruD" = (
@@ -28294,6 +29015,15 @@
 	},
 /turf/open/floor/almayer_hull,
 /area/fiorina/oob)
+"rxu" = (
+/obj/structure/flora/bush/ausbushes/grassybush{
+	icon_state = "lavendergrass_3"
+	},
+/turf/open/organic/grass{
+	desc = "It'll get in your shoes no matter what you do.";
+	name = "astroturf"
+	},
+/area/fiorina/station/central_ring)
 "rxz" = (
 /obj/structure/curtain/open/black,
 /turf/open/floor/prison,
@@ -28301,7 +29031,7 @@
 "rym" = (
 /obj/structure/inflatable/popped/door,
 /turf/open/floor/plating/prison,
-/area/fiorina/station/disco)
+/area/fiorina/station/central_ring)
 "ryt" = (
 /obj/structure/window/framed/prison/reinforced,
 /turf/open/floor/prison,
@@ -28343,11 +29073,6 @@
 	icon_state = "whitegreenfull"
 	},
 /area/fiorina/station/medbay)
-"rAe" = (
-/obj/structure/platform/kutjevo/smooth,
-/obj/structure/lattice,
-/turf/open/space,
-/area/fiorina/oob)
 "rAk" = (
 /obj/structure/stairs/perspective{
 	dir = 8;
@@ -28382,6 +29107,9 @@
 /turf/open/floor/wood,
 /area/fiorina/station/park)
 "rAQ" = (
+/obj/structure/platform_decoration{
+	dir = 1
+	},
 /obj/structure/machinery/light/double/blue{
 	dir = 8;
 	pixel_x = -10;
@@ -28494,7 +29222,8 @@
 "rEg" = (
 /obj/structure/sink{
 	dir = 4;
-	pixel_x = 12
+	pixel_x = 12;
+	tag = "icon-sink (EAST)"
 	},
 /obj/item/storage/fancy/cigarettes/blackpack,
 /turf/open/floor/prison{
@@ -28519,13 +29248,20 @@
 /turf/open/floor/prison{
 	icon_state = "damaged3"
 	},
-/area/fiorina/station/disco)
+/area/fiorina/station/central_ring)
 "rFu" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/prison/chapel_carpet{
 	icon_state = "doubleside"
 	},
 /area/fiorina/station/chapel)
+"rFH" = (
+/obj/structure/largecrate/random,
+/turf/open/floor/prison{
+	icon_state = "floor_plate";
+	tag = "icon-floor_plate"
+	},
+/area/fiorina/station/central_ring)
 "rFT" = (
 /obj/item/ammo_casing{
 	icon_state = "casing_7_1"
@@ -28686,6 +29422,14 @@
 	icon_state = "darkyellow2"
 	},
 /area/fiorina/lz/near_lzI)
+"rKO" = (
+/obj/structure/machinery/light/double/blue{
+	dir = 8;
+	pixel_x = -10;
+	pixel_y = -3
+	},
+/turf/open/floor/prison,
+/area/fiorina/station/central_ring)
 "rKS" = (
 /obj/item/tool/wrench,
 /turf/open/floor/prison{
@@ -28751,7 +29495,8 @@
 /obj/structure/machinery/bot/medbot,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "whitegreenfull"
+	icon_state = "whitegreenfull";
+	tag = "icon-whitegreenfull (SOUTHWEST)"
 	},
 /area/fiorina/station/medbay)
 "rMP" = (
@@ -28762,11 +29507,6 @@
 /area/fiorina/lz/near_lzI)
 "rMS" = (
 /obj/structure/largecrate/random/secure,
-/obj/structure/machinery/light/double/blue{
-	dir = 4;
-	pixel_x = 10;
-	pixel_y = 1
-	},
 /turf/open/floor/prison{
 	dir = 6;
 	icon_state = "whitegreen"
@@ -29052,15 +29792,12 @@
 	},
 /area/fiorina/station/disco)
 "rVy" = (
-/obj/structure/bed{
-	icon_state = "abed"
+/obj/structure/stairs/perspective{
+	dir = 1;
+	icon_state = "p_stair_full"
 	},
-/obj/effect/spawner/random/pills/midchance,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "whitepurple"
-	},
-/area/fiorina/station/research_cells)
+/turf/open/floor/prison,
+/area/fiorina/station/central_ring)
 "rVM" = (
 /obj/structure/closet/crate/miningcar,
 /obj/structure/barricade/wooden{
@@ -29095,6 +29832,10 @@
 	icon_state = "blue_plate"
 	},
 /area/fiorina/station/botany)
+"rWB" = (
+/obj/structure/closet/boxinggloves,
+/turf/open/floor/prison,
+/area/fiorina/station/central_ring)
 "rWX" = (
 /turf/open/floor/prison{
 	icon_state = "damaged3"
@@ -29325,6 +30066,21 @@
 /obj/structure/platform/stair_cut,
 /turf/open/floor/plating/prison,
 /area/fiorina/station/park)
+"seu" = (
+/obj/effect/decal/medical_decals{
+	icon_state = "triagedecaldir"
+	},
+/obj/structure/machinery/light/double/blue{
+	dir = 4;
+	pixel_x = 10;
+	pixel_y = 13
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "whitegreenfull";
+	tag = "icon-whitegreenfull (SOUTHWEST)"
+	},
+/area/fiorina/station/medbay)
 "seW" = (
 /turf/closed/shuttle/ert{
 	icon_state = "stan_r_w"
@@ -29506,7 +30262,6 @@
 /obj/item/stack/sheet/mineral/plastic,
 /obj/item/stack/sheet/mineral/plastic,
 /obj/item/stack/sheet/mineral/plastic,
-/obj/effect/landmark/objective_landmark/close,
 /turf/open/floor/plating/prison,
 /area/fiorina/maintenance)
 "sma" = (
@@ -29544,6 +30299,10 @@
 	},
 /turf/open/floor/plating/prison,
 /area/fiorina/lz/near_lzI)
+"smz" = (
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/prison,
+/area/fiorina/station/central_ring)
 "smX" = (
 /obj/item/stock_parts/matter_bin/super,
 /turf/open/floor/prison{
@@ -29776,6 +30535,10 @@
 /obj/structure/machinery/computer/telecomms/monitor,
 /turf/open/floor/plating/prison,
 /area/fiorina/station/medbay)
+"svo" = (
+/obj/structure/grille,
+/turf/open/floor/plating/prison,
+/area/fiorina/station/central_ring)
 "svF" = (
 /obj/structure/blocker/invisible_wall,
 /turf/open/floor/prison{
@@ -29986,6 +30749,12 @@
 	},
 /turf/open/floor/plating/prison,
 /area/fiorina/oob)
+"sDV" = (
+/turf/open/floor/prison{
+	dir = 5;
+	icon_state = "yellow"
+	},
+/area/fiorina/station/central_ring)
 "sEi" = (
 /turf/open/floor/prison{
 	dir = 8;
@@ -30183,6 +30952,13 @@
 	icon_state = "yellow"
 	},
 /area/fiorina/station/disco)
+"sLl" = (
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "darkpurple2";
+	tag = "icon-darkpurple2"
+	},
+/area/fiorina/station/central_ring)
 "sLo" = (
 /obj/structure/machinery/landinglight/ds1/delaythree{
 	dir = 1
@@ -30209,9 +30985,12 @@
 	},
 /area/fiorina/station/civres_blue)
 "sMj" = (
+/obj/structure/barricade/metal/wired{
+	dir = 8
+	},
 /obj/structure/largecrate/random/secure,
 /turf/open/floor/plating/prison,
-/area/fiorina/station/disco)
+/area/fiorina/station/central_ring)
 "sMo" = (
 /obj/item/clothing/under/marine/ua_riot,
 /obj/item/weapon/gun/rifle/m16,
@@ -30530,11 +31309,18 @@
 	},
 /area/fiorina/station/medbay)
 "sWF" = (
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "damaged2"
+/obj/structure/stairs/perspective{
+	dir = 8;
+	icon_state = "p_stair_sn_full_cap"
 	},
-/area/fiorina/station/disco)
+/obj/structure/platform{
+	dir = 4
+	},
+/turf/open/floor/prison{
+	icon_state = "floor_plate";
+	tag = "icon-floor_plate"
+	},
+/area/fiorina/station/central_ring)
 "sXi" = (
 /turf/open/floor/corsat{
 	icon_state = "plate"
@@ -30546,17 +31332,16 @@
 	icon_state = "floor_plate"
 	},
 /area/fiorina/station/chapel)
+"sYe" = (
+/turf/open/floor/prison{
+	dir = 9;
+	icon_state = "yellow"
+	},
+/area/fiorina/station/central_ring)
 "sYn" = (
 /obj/structure/machinery/light/double/blue,
 /turf/open/floor/wood,
 /area/fiorina/station/security/wardens)
-"sYv" = (
-/obj/structure/platform_decoration/kutjevo{
-	dir = 4
-	},
-/obj/structure/lattice,
-/turf/open/space,
-/area/fiorina/oob)
 "sYM" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison{
@@ -30635,14 +31420,16 @@
 /obj/structure/filingcabinet,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "whitegreenfull"
+	icon_state = "whitegreenfull";
+	tag = "icon-whitegreenfull (SOUTHWEST)"
 	},
 /area/fiorina/station/medbay)
 "tcl" = (
 /obj/structure/largecrate/random/mini/med,
 /turf/open/floor/prison{
-	dir = 5;
-	icon_state = "whitegreen"
+	dir = 10;
+	icon_state = "whitegreenfull";
+	tag = "icon-whitegreenfull (SOUTHWEST)"
 	},
 /area/fiorina/station/medbay)
 "tcJ" = (
@@ -30807,6 +31594,15 @@
 	icon_state = "floor_plate"
 	},
 /area/fiorina/station/park)
+"tjM" = (
+/obj/structure/platform_decoration{
+	dir = 4
+	},
+/turf/open/floor/prison{
+	icon_state = "floor_plate";
+	tag = "icon-floor_plate"
+	},
+/area/fiorina/station/lowsec)
 "tjQ" = (
 /obj/effect/spawner/random/tool,
 /turf/open/floor/prison{
@@ -30995,7 +31791,7 @@
 	},
 /obj/structure/largecrate/random/case/double,
 /turf/open/floor/plating/prison,
-/area/fiorina/station/disco)
+/area/fiorina/station/central_ring)
 "tov" = (
 /obj/effect/spawner/random/gun/smg/midchance,
 /turf/open/floor/prison{
@@ -31060,6 +31856,12 @@
 /obj/effect/landmark/monkey_spawn,
 /turf/open/floor/plating/prison,
 /area/fiorina/station/civres_blue)
+"tqa" = (
+/obj/structure/platform_decoration/kutjevo{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/fiorina/oob)
 "tqM" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/prison{
@@ -31125,6 +31927,14 @@
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating/prison,
 /area/fiorina/station/chapel)
+"tsf" = (
+/obj/structure/machinery/light/double/blue{
+	dir = 4;
+	pixel_x = 10;
+	pixel_y = -3
+	},
+/turf/open/floor/prison,
+/area/fiorina/station/central_ring)
 "tsi" = (
 /obj/structure/barricade/metal/wired,
 /turf/open/floor/prison{
@@ -31238,12 +32048,11 @@
 	},
 /area/fiorina/station/power_ring)
 "tvI" = (
-/obj/structure/platform/kutjevo/smooth{
-	dir = 8
+/turf/open/organic/grass{
+	desc = "It'll get in your shoes no matter what you do.";
+	name = "astroturf"
 	},
-/obj/structure/lattice,
-/turf/open/space,
-/area/fiorina/oob)
+/area/fiorina/station/central_ring)
 "tvM" = (
 /obj/structure/platform{
 	dir = 1
@@ -31353,12 +32162,19 @@
 /turf/open/floor/plating/prison,
 /area/fiorina/station/research_cells)
 "tzF" = (
-/obj/item/storage/pill_bottle/tramadol/skillless,
+/obj/structure/stairs/perspective{
+	dir = 8;
+	icon_state = "p_stair_sn_full_cap"
+	},
+/obj/structure/platform{
+	dir = 4
+	},
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "sterile_white"
+	icon_state = "whitegreenfull";
+	tag = "icon-whitegreenfull (SOUTHWEST)"
 	},
-/area/fiorina/station/medbay)
+/area/fiorina/station/central_ring)
 "tAb" = (
 /obj/structure/surface/rack,
 /obj/item/storage/backpack/general_belt{
@@ -31682,6 +32498,13 @@
 	icon_state = "green"
 	},
 /area/fiorina/station/chapel)
+"tJn" = (
+/obj/item/tool/wirecutters,
+/obj/structure/platform/shiva{
+	dir = 1
+	},
+/turf/open/floor/plating/prison,
+/area/fiorina/station/central_ring)
 "tJM" = (
 /obj/item/prop/helmetgarb/riot_shield,
 /turf/open/floor/prison{
@@ -31695,6 +32518,12 @@
 /obj/structure/surface/table/reinforced/prison,
 /turf/open/floor/plating/prison,
 /area/fiorina/station/power_ring)
+"tJT" = (
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "yellow"
+	},
+/area/fiorina/station/central_ring)
 "tJU" = (
 /obj/structure/machinery/vending/coffee,
 /obj/structure/machinery/light/double/blue{
@@ -32394,6 +33223,12 @@
 /obj/item/prop/almayer/flight_recorder,
 /turf/open/floor/prison,
 /area/fiorina/lz/near_lzI)
+"ued" = (
+/obj/structure/sign/prop3{
+	desc = "Enlist in the Penal Battalions today! The USCM 3rd Fleet features a subset of UA sanctioned penal battalions, drawing from inmate popualtions across the colonies. Mostly New Argentina though."
+	},
+/turf/closed/wall/prison,
+/area/fiorina/station/central_ring)
 "uef" = (
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_core,
 /turf/open/floor/prison{
@@ -32890,6 +33725,10 @@
 	icon_state = "whitegreenfull"
 	},
 /area/fiorina/station/medbay)
+"uvM" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plating/prison,
+/area/fiorina/station/central_ring)
 "uwg" = (
 /obj/effect/spawner/random/tool,
 /turf/open/floor/prison{
@@ -32915,6 +33754,11 @@
 /obj/item/stack/sheet/mineral/plastic,
 /turf/open/floor/prison,
 /area/fiorina/tumor/servers)
+"uwY" = (
+/obj/structure/lattice,
+/obj/structure/platform/kutjevo/smooth,
+/turf/open/space,
+/area/fiorina/oob)
 "uxa" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/prison{
@@ -32973,6 +33817,10 @@
 /obj/item/stack/sheet/metal,
 /turf/open/floor/prison,
 /area/fiorina/station/lowsec)
+"uym" = (
+/obj/structure/machinery/door/airlock/prison_hatch/autoname,
+/turf/open/floor/plating/prison,
+/area/fiorina/station/disco)
 "uyq" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/prison{
@@ -33012,7 +33860,7 @@
 	},
 /obj/structure/largecrate/random/secure,
 /turf/open/floor/plating/prison,
-/area/fiorina/station/disco)
+/area/fiorina/station/central_ring)
 "uzX" = (
 /obj/structure/barricade/wooden{
 	dir = 8
@@ -33023,6 +33871,13 @@
 	icon_state = "sterile_white"
 	},
 /area/fiorina/station/research_cells)
+"uAd" = (
+/obj/item/clothing/gloves/boxing/green,
+/turf/open/floor/prison{
+	dir = 6;
+	icon_state = "yellow"
+	},
+/area/fiorina/station/central_ring)
 "uAi" = (
 /obj/structure/sink{
 	dir = 4;
@@ -33110,11 +33965,11 @@
 	},
 /area/fiorina/station/medbay)
 "uCD" = (
-/obj/effect/landmark/nightmare{
-	insert_tag = "medicalhold"
+/turf/open/floor/prison{
+	icon_state = "cell_stripe";
+	tag = "icon-cell_stripe"
 	},
-/turf/closed/wall/prison,
-/area/fiorina/station/medbay)
+/area/fiorina/station/research_cells)
 "uCW" = (
 /obj/item/reagent_container/glass/bucket/janibucket,
 /turf/open/floor/prison{
@@ -33262,6 +34117,16 @@
 	icon_state = "floor_plate"
 	},
 /area/fiorina/tumor/civres)
+"uIA" = (
+/obj/structure/stairs/perspective{
+	icon_state = "p_stair_sn_full_cap"
+	},
+/obj/structure/machinery/light/double/blue{
+	dir = 8;
+	pixel_x = -10
+	},
+/turf/open/floor/plating/prison,
+/area/fiorina/station/central_ring)
 "uIG" = (
 /obj/structure/prop/structure_lattice{
 	dir = 4
@@ -33467,6 +34332,12 @@
 	icon_state = "floor_plate"
 	},
 /area/fiorina/station/disco)
+"uRu" = (
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "yellow"
+	},
+/area/fiorina/station/central_ring)
 "uRK" = (
 /obj/structure/platform{
 	dir = 8
@@ -33486,6 +34357,13 @@
 	icon_state = "blue_plate"
 	},
 /area/fiorina/station/botany)
+"uRY" = (
+/obj/item/ammo_magazine/rifle/mar40,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "yellow"
+	},
+/area/fiorina/station/lowsec)
 "uSb" = (
 /obj/structure/barricade/wooden{
 	dir = 4;
@@ -33493,9 +34371,10 @@
 	},
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "damaged1"
+	icon_state = "damaged1";
+	tag = "icon-bright_clean (SOUTHWEST)"
 	},
-/area/fiorina/station/disco)
+/area/fiorina/station/central_ring)
 "uSo" = (
 /obj/item/poster,
 /turf/open/floor/prison{
@@ -33611,6 +34490,14 @@
 	icon_state = "darkbrown2"
 	},
 /area/fiorina/tumor/aux_engi)
+"uWs" = (
+/obj/structure/platform/kutjevo/smooth{
+	dir = 4
+	},
+/obj/structure/platform/kutjevo/smooth,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/fiorina/oob)
 "uWQ" = (
 /obj/structure/platform{
 	dir = 8
@@ -33713,15 +34600,13 @@
 /turf/open/floor/plating/prison,
 /area/fiorina/station/park)
 "uYD" = (
-/obj/structure/bed{
-	icon_state = "abed"
-	},
-/obj/effect/landmark/objective_landmark/close,
+/obj/structure/surface/table/reinforced/prison,
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "whitepurple"
+	icon_state = "whitegreenfull";
+	tag = "icon-whitegreenfull (SOUTHWEST)"
 	},
-/area/fiorina/station/research_cells)
+/area/fiorina/station/medbay)
 "uYR" = (
 /obj/structure/machinery/light/double/blue{
 	dir = 1;
@@ -33801,14 +34686,15 @@
 	},
 /area/fiorina/station/lowsec)
 "vbe" = (
-/obj/structure/machinery/m56d_hmg/mg_turret/dropship{
-	dir = 1
+/obj/structure/stairs/perspective{
+	dir = 1;
+	icon_state = "p_stair_full"
 	},
 /turf/open/floor/prison{
 	dir = 8;
 	icon_state = "whitegreen"
 	},
-/area/fiorina/station/medbay)
+/area/fiorina/station/central_ring)
 "vbl" = (
 /obj/structure/closet/bombcloset,
 /obj/effect/landmark/objective_landmark/medium,
@@ -34019,6 +34905,10 @@
 	},
 /turf/open/floor/prison,
 /area/fiorina/station/telecomm/lz1_tram)
+"vgP" = (
+/obj/structure/largecrate/random,
+/turf/open/floor/prison,
+/area/fiorina/station/central_ring)
 "vgS" = (
 /obj/item/stack/sheet/metal,
 /turf/open/floor/prison{
@@ -34285,12 +35175,16 @@
 	},
 /area/fiorina/tumor/ice_lab)
 "vqi" = (
+/obj/structure/platform{
+	dir = 1
+	},
 /obj/structure/machinery/light/double/blue{
 	dir = 1;
 	pixel_y = 21
 	},
 /turf/open/floor/prison{
-	icon_state = "cell_stripe"
+	icon_state = "cell_stripe";
+	tag = "icon-cell_stripe"
 	},
 /area/fiorina/station/lowsec)
 "vqM" = (
@@ -34465,20 +35359,12 @@
 	},
 /area/fiorina/station/civres_blue)
 "vuc" = (
-/obj/structure/platform/kutjevo/smooth{
-	dir = 1
+/obj/structure/flora/pottedplant{
+	icon_state = "pottedplant_22";
+	tag = "icon-pottedplant_10"
 	},
-/obj/structure/platform/kutjevo/smooth{
-	dir = 8
-	},
-/obj/structure/barricade/handrail{
-	dir = 1;
-	icon_state = "hr_kutjevo";
-	name = "solar lattice"
-	},
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/fiorina/oob)
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/fiorina/station/central_ring)
 "vuE" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/structure/machinery/landinglight/ds2/delayone,
@@ -34734,6 +35620,17 @@
 	},
 /turf/open/floor/prison,
 /area/fiorina/station/power_ring)
+"vCT" = (
+/obj/structure/machinery/light/double/blue{
+	dir = 8;
+	pixel_x = -10;
+	pixel_y = -3
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "whitepurple"
+	},
+/area/fiorina/station/research_cells)
 "vDc" = (
 /obj/structure/bed/sofa/south/grey/left,
 /obj/item/reagent_container/food/snacks/sandwich{
@@ -34862,8 +35759,9 @@
 /obj/structure/barricade/metal/wired{
 	dir = 4
 	},
+/obj/structure/largecrate/random,
 /turf/open/floor/plating/prison,
-/area/fiorina/station/disco)
+/area/fiorina/station/central_ring)
 "vGO" = (
 /obj/structure/platform{
 	dir = 4
@@ -35025,6 +35923,13 @@
 	icon_state = "floor_plate"
 	},
 /area/fiorina/station/power_ring)
+"vMX" = (
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "cell_stripe";
+	tag = "icon-cell_stripe (NORTH)"
+	},
+/area/fiorina/station/central_ring)
 "vNq" = (
 /turf/closed/wall/r_wall/prison,
 /area/fiorina/station/telecomm/lz1_cargo)
@@ -35120,12 +36025,11 @@
 /turf/open/floor/prison,
 /area/fiorina/lz/near_lzII)
 "vPM" = (
-/obj/structure/platform_decoration/kutjevo{
-	dir = 8
+/turf/open/floor/prison{
+	icon_state = "floor_plate";
+	tag = "icon-floor_plate"
 	},
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/fiorina/oob)
+/area/fiorina/station/central_ring)
 "vPR" = (
 /turf/closed/shuttle/ert{
 	icon_state = "stan1"
@@ -35260,6 +36164,10 @@
 	icon_state = "greenfull"
 	},
 /area/fiorina/station/transit_hub)
+"vVR" = (
+/obj/structure/extinguisher_cabinet,
+/turf/closed/wall/prison,
+/area/fiorina/station/central_ring)
 "vWe" = (
 /obj/structure/extinguisher_cabinet,
 /turf/closed/wall/prison,
@@ -35271,6 +36179,15 @@
 	icon_state = "cell_stripe"
 	},
 /area/fiorina/station/power_ring)
+"vWE" = (
+/obj/structure/platform_decoration{
+	dir = 8
+	},
+/turf/open/floor/prison{
+	icon_state = "floor_plate";
+	tag = "icon-floor_plate"
+	},
+/area/fiorina/station/central_ring)
 "vWI" = (
 /obj/structure/flora/pottedplant{
 	icon_state = "pottedplant_22"
@@ -35324,6 +36241,15 @@
 	icon_state = "yellow"
 	},
 /area/fiorina/station/disco)
+"vYE" = (
+/obj/structure/flora/bush/ausbushes/grassybush{
+	icon_state = "lavendergrass_1"
+	},
+/turf/open/organic/grass{
+	desc = "It'll get in your shoes no matter what you do.";
+	name = "astroturf"
+	},
+/area/fiorina/station/central_ring)
 "vYL" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison{
@@ -35371,6 +36297,13 @@
 	icon_state = "blue"
 	},
 /area/fiorina/station/power_ring)
+"vZz" = (
+/obj/item/device/flashlight/lamp/tripod,
+/turf/open/floor/prison{
+	icon_state = "floor_plate";
+	tag = "icon-floor_plate"
+	},
+/area/fiorina/station/central_ring)
 "vZD" = (
 /obj/item/storage/box/donkpockets,
 /turf/open/floor/plating/prison,
@@ -35447,9 +36380,16 @@
 "wby" = (
 /obj/structure/platform/kutjevo/smooth,
 /obj/structure/platform/kutjevo/smooth{
+	dir = 1
+	},
+/obj/structure/barricade/handrail{
+	dir = 1;
+	icon_state = "hr_kutjevo";
+	name = "solar lattice"
+	},
+/obj/structure/platform/kutjevo/smooth{
 	dir = 8
 	},
-/obj/structure/lattice,
 /turf/open/space,
 /area/fiorina/oob)
 "wbB" = (
@@ -35711,6 +36651,13 @@
 "wkD" = (
 /obj/structure/largecrate/random/case/double,
 /turf/open/floor/plating/prison,
+/area/fiorina/station/central_ring)
+"wkZ" = (
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "cell_stripe";
+	tag = "icon-cell_stripe (WEST)"
+	},
 /area/fiorina/station/disco)
 "wlp" = (
 /obj/item/reagent_container/food/snacks/donkpocket,
@@ -35781,17 +36728,12 @@
 	},
 /area/fiorina/station/lowsec)
 "wnB" = (
-/obj/structure/platform/kutjevo/smooth{
-	dir = 1
+/turf/open/floor/prison{
+	dir = 9;
+	icon_state = "darkpurple2";
+	tag = "icon-darkpurple2"
 	},
-/obj/structure/barricade/handrail{
-	dir = 1;
-	icon_state = "hr_kutjevo";
-	name = "solar lattice"
-	},
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/fiorina/oob)
+/area/fiorina/station/central_ring)
 "wnW" = (
 /obj/structure/toilet{
 	pixel_y = 4
@@ -35953,13 +36895,19 @@
 	},
 /area/fiorina/station/botany)
 "wuT" = (
-/obj/structure/lattice,
-/obj/structure/platform/kutjevo/smooth,
-/obj/structure/platform/kutjevo/smooth{
-	dir = 4
+/obj/structure/platform_decoration{
+	dir = 1
 	},
-/turf/open/space/basic,
-/area/fiorina/oob)
+/obj/structure/machinery/light/double/blue{
+	dir = 8;
+	pixel_x = -10;
+	pixel_y = 13
+	},
+/turf/open/floor/prison{
+	icon_state = "floor_plate";
+	tag = "icon-floor_plate"
+	},
+/area/fiorina/station/central_ring)
 "wvf" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/structure/flora/pottedplant{
@@ -35970,6 +36918,21 @@
 	},
 /turf/open/floor/prison,
 /area/fiorina/station/security)
+"wvu" = (
+/obj/structure/platform/kutjevo/smooth{
+	dir = 4
+	},
+/obj/structure/platform/kutjevo/smooth{
+	dir = 1
+	},
+/obj/structure/barricade/handrail{
+	dir = 1;
+	icon_state = "hr_kutjevo";
+	name = "solar lattice"
+	},
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/fiorina/oob)
 "wvH" = (
 /obj/effect/landmark/objective_landmark/medium,
 /turf/open/floor/prison/chapel_carpet{
@@ -36297,6 +37260,18 @@
 /obj/structure/window/framed/prison/reinforced/hull,
 /turf/open/floor/plating/prison,
 /area/fiorina/station/civres_blue)
+"wGa" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 3;
+	tag = "icon-rwindow (NORTH)"
+	},
+/obj/structure/largecrate/random/mini/med{
+	pixel_x = -6;
+	pixel_y = -3
+	},
+/turf/open/floor/prison,
+/area/fiorina/station/central_ring)
 "wGe" = (
 /obj/structure/barricade/metal/wired{
 	dir = 8
@@ -36435,6 +37410,14 @@
 	icon_state = "whitegreen"
 	},
 /area/fiorina/station/medbay)
+"wJX" = (
+/obj/structure/platform/kutjevo/smooth,
+/obj/structure/platform/kutjevo/smooth{
+	dir = 8
+	},
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/fiorina/oob)
 "wKb" = (
 /obj/effect/spawner/random/gun/rifle/midchance,
 /turf/open/floor/wood,
@@ -36793,6 +37776,13 @@
 	icon_state = "green"
 	},
 /area/fiorina/tumor/aux_engi)
+"wUN" = (
+/obj/item/reagent_container/food/drinks/cans/sodawater,
+/turf/open/floor/prison{
+	icon_state = "floor_plate";
+	tag = "icon-floor_plate"
+	},
+/area/fiorina/station/central_ring)
 "wVu" = (
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_door,
 /turf/open/floor/prison{
@@ -36833,6 +37823,14 @@
 "wWs" = (
 /turf/open/floor/greengrid,
 /area/fiorina/station/security)
+"wWF" = (
+/obj/item/frame/rack,
+/turf/open/floor/plating/prison,
+/area/fiorina/station/disco)
+"wWT" = (
+/obj/effect/decal/cleanable/blood/gibs/xeno,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/fiorina/station/central_ring)
 "wWW" = (
 /obj/structure/platform/kutjevo/smooth{
 	dir = 8
@@ -37189,9 +38187,10 @@
 	},
 /turf/open/floor/prison{
 	dir = 1;
-	icon_state = "cell_stripe"
+	icon_state = "cell_stripe";
+	tag = "icon-cell_stripe (NORTH)"
 	},
-/area/fiorina/station/disco)
+/area/fiorina/station/central_ring)
 "xkG" = (
 /obj/structure/machinery/light/double/blue{
 	dir = 4;
@@ -37301,7 +38300,8 @@
 	},
 /turf/open/floor/prison{
 	dir = 10;
-	icon_state = "whitegreenfull"
+	icon_state = "whitegreenfull";
+	tag = "icon-whitegreenfull (SOUTHWEST)"
 	},
 /area/fiorina/station/medbay)
 "xnA" = (
@@ -37423,6 +38423,15 @@
 	icon_state = "darkbrownfull2"
 	},
 /area/fiorina/tumor/aux_engi)
+"xqh" = (
+/obj/item/ammo_casing{
+	icon_state = "cartridge_2"
+	},
+/turf/open/floor/prison{
+	icon_state = "floor_plate";
+	tag = "icon-floor_plate"
+	},
+/area/fiorina/station/central_ring)
 "xqj" = (
 /obj/structure/bed{
 	icon_state = "abed"
@@ -37699,6 +38708,21 @@
 	},
 /turf/open/floor/prison,
 /area/fiorina/station/telecomm/lz1_cargo)
+"xyy" = (
+/obj/structure/platform/kutjevo/smooth{
+	dir = 1
+	},
+/obj/structure/barricade/handrail{
+	dir = 1;
+	icon_state = "hr_kutjevo";
+	name = "solar lattice"
+	},
+/obj/structure/platform/kutjevo/smooth{
+	dir = 4
+	},
+/obj/structure/platform/kutjevo/smooth,
+/turf/open/space,
+/area/fiorina/oob)
 "xyK" = (
 /obj/structure/stairs/perspective{
 	dir = 1;
@@ -38264,14 +39288,19 @@
 	icon_state = "whitegreenfull"
 	},
 /area/fiorina/tumor/ice_lab)
-"xQC" = (
-/obj/structure/platform/kutjevo/smooth,
-/obj/structure/platform/kutjevo/smooth{
-	dir = 8
+"xQs" = (
+/obj/item/reagent_container/food/drinks/coffee{
+	name = "\improper paper cup"
 	},
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/fiorina/oob)
+/turf/open/floor/prison{
+	dir = 5;
+	icon_state = "yellow"
+	},
+/area/fiorina/station/central_ring)
+"xQC" = (
+/obj/structure/window/framed/prison/reinforced/hull,
+/turf/open/floor/plating/prison,
+/area/fiorina/station/central_ring)
 "xQE" = (
 /obj/structure/closet/bodybag,
 /obj/effect/decal/cleanable/blood/gibs/up,
@@ -38471,6 +39500,13 @@
 	icon_state = "floor_plate"
 	},
 /area/fiorina/station/civres_blue)
+"xXw" = (
+/obj/item/device/flashlight/lamp/tripod,
+/turf/open/organic/grass{
+	desc = "It'll get in your shoes no matter what you do.";
+	name = "astroturf"
+	},
+/area/fiorina/station/central_ring)
 "xYg" = (
 /obj/docking_port/stationary/marine_dropship/lz2,
 /turf/open/floor/plating/prison,
@@ -38594,6 +39630,15 @@
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_nest,
 /turf/open/floor/plating/prison,
 /area/fiorina/tumor/fiberbush)
+"ybs" = (
+/obj/structure/platform_decoration{
+	dir = 4
+	},
+/turf/open/floor/prison{
+	icon_state = "floor_plate";
+	tag = "icon-floor_plate"
+	},
+/area/fiorina/station/central_ring)
 "ybR" = (
 /obj/item/stack/sheet/metal{
 	amount = 5
@@ -66530,8 +67575,8 @@ djA
 hVI
 ivR
 ovJ
-aif
-kqz
+dvY
+aFO
 cwO
 hVI
 fgb
@@ -66541,17 +67586,17 @@ lbu
 mEO
 gbS
 aFZ
-dhi
-lDC
+brI
+gAk
 qOk
-mKS
-mhv
-cAW
-hVS
-lDC
+cZc
+lml
+hGP
+olQ
 qOk
-mKS
-mhv
+kvm
+oTG
+bQM
 tPN
 ecL
 cME
@@ -66737,12 +67782,12 @@ cwO
 nQq
 hVI
 hVI
-lGA
 hVI
 hVI
 hVI
 hVI
-nQq
+hVI
+gUH
 mJy
 tkk
 vWe
@@ -66753,17 +67798,17 @@ lyJ
 ndh
 kwT
 tQB
-daD
+azy
 afk
 afk
 afk
 chA
-qFE
-dvY
+uWs
 afk
 afk
 afk
-dkg
+wvu
+fQV
 tPN
 ecL
 cME
@@ -66950,9 +67995,9 @@ hVI
 rCL
 fPZ
 fPZ
-fPZ
+gik
 hVI
-kSP
+adH
 qSg
 hVI
 mJy
@@ -66970,19 +68015,19 @@ afk
 hkh
 afk
 tCZ
-pcu
 urJ
 afk
 hkh
 afk
 tCZ
+pcu
 tPN
 slM
 cME
 cME
 tIU
 gZc
-ick
+tIU
 cME
 liA
 cME
@@ -67161,33 +68206,33 @@ cwO
 hVI
 djA
 vDj
-qgh
 fPZ
+gik
 hVI
 ivR
 ovJ
-aif
-kqz
+dvY
+aFO
 cwO
-fPZ
-fPZ
+gik
+gik
 sJu
 rjE
 dQp
-cnF
+idE
 fUX
 tQB
-mdJ
+iKT
 afk
 afk
 afk
 cjA
 cpW
-cYa
 afk
 afk
 afk
-dMU
+rac
+jlH
 twb
 twb
 twb
@@ -67199,7 +68244,7 @@ bgy
 eLu
 cME
 cME
-gyW
+cME
 liA
 cFy
 mcc
@@ -67373,15 +68418,15 @@ uGq
 hVI
 tEH
 tEH
-hVI
-jjs
+ajp
+aoa
 hVI
 tEH
 tEH
 hVI
 ldT
 lAf
-fPZ
+gik
 xns
 vWe
 hVI
@@ -67389,19 +68434,19 @@ hVI
 anG
 wyl
 aFZ
-ggQ
-eJQ
-eJQ
-tvI
-sYv
+aQB
+wJX
+llQ
+djU
+tqa
+keo
+mxG
+llQ
+lOB
+tqa
 bQM
-ggQ
-eJQ
-eJQ
-tvI
-sYv
+bQM
 kPz
-eHa
 twb
 aLT
 cME
@@ -67586,34 +68631,34 @@ cnW
 mhb
 mhb
 mhb
-kqz
+aFO
 mhb
 mhb
 mhb
 mhb
 avX
 cwO
-fPZ
+gik
 cqH
+hVI
+hVI
+hVI
+bZC
+hVI
 aFZ
-aFZ
-aFZ
-aFZ
-aFZ
-aFZ
-cAW
-cAW
-bQM
-bQM
-bQM
-bQM
-cAW
-cAW
-cAW
-cAW
-cAW
+xQC
+xQC
+eDn
+eDn
+eDn
+eDn
+eDn
+eDn
+xQC
+xQC
+eDn
 kPz
-bTo
+kPz
 twb
 twb
 twb
@@ -67801,34 +68846,34 @@ jEb
 hcf
 jEb
 jEb
-kqz
+aFO
 pxI
 jEb
 tur
-fPZ
-goA
-aFZ
-dhi
+gik
+uYD
+hVI
 lDC
-qOk
-mKS
-mhv
-bQM
-bQM
-bQM
-bQM
-bQM
-bQM
-cAW
-cAW
-cAW
-cAW
-cAW
-hVS
 lDC
-qOk
-mKS
+ldZ
+lDC
 mhv
+mGe
+dGw
+vPM
+haa
+mGe
+mGe
+vPM
+rKO
+mGe
+mGe
+eDn
+eDn
+cAW
+bQM
+bQM
+bQM
 twb
 ivB
 uzw
@@ -68010,37 +69055,37 @@ hVI
 hVI
 hVI
 hVI
-jjs
+aoa
 hVI
 hVI
-jjs
+aoa
 hVI
 vWe
 ruB
 ruB
 dID
-aSS
-daD
-afk
-afk
-afk
-bAB
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
+vWe
+mFv
+gXD
+gTw
+dGw
+vPM
+vPM
+vPM
+vPM
+vPM
+vPM
+vPM
+vPM
+vPM
+vPM
+vPM
+dGw
 eDn
-afk
-afk
-afk
-dkg
+oVk
+eDn
+bQM
+bQM
 twb
 nSU
 cME
@@ -68221,38 +69266,38 @@ jBK
 hVI
 sol
 fPZ
-fPZ
-fPZ
-fPZ
+gik
+gik
+gik
 hVI
 mFh
 isJ
 pQD
 rME
-fPZ
-fPZ
-tQB
-urJ
-afk
-hkh
-afk
-bQp
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
+gik
+gik
+wGa
+dGw
+tvI
+tvI
+tvI
+tvI
+tvI
+tvI
+tvI
+vPM
+vPM
+vPM
+tvI
+tvI
+tvI
+tvI
+vPM
+vPM
+dGw
+eHa
 eDn
-afk
-hkh
-afk
-tCZ
+bQM
 twb
 uts
 cME
@@ -68434,40 +69479,40 @@ hVI
 mMb
 dLx
 gik
-fPZ
-fPZ
-aif
+gik
+gik
+dvY
 ryN
 gBo
 qpw
-fPZ
-fPZ
-fPZ
-tQB
-mdJ
-afk
-afk
-afk
-bAB
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-rAe
-afk
-afk
-afk
-dMU
+gik
+gik
+gik
+jEC
+dGw
+tvI
+tvI
+tvI
+tvI
+tvI
+tvI
+tvI
+vPM
+vPM
+vPM
+tvI
+tvI
+tvI
+tvI
+tvI
+tvI
+vPM
+deH
+eDn
+eDn
 twb
-dTf
-cME
+eLu
+eLu
 eLu
 srI
 dTf
@@ -68645,42 +69690,42 @@ lUp
 hVI
 mei
 oZz
-vWe
-hVI
-hVI
-uCD
 hVI
 hVI
 hVI
-fPZ
-fPZ
-hBX
-tQB
+hVI
+hVI
+hVI
+hVI
+gik
+gik
+hNi
+lDC
 ggQ
-eJQ
-eJQ
 tvI
-sYv
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-ggQ
-eJQ
-eJQ
 tvI
-sYv
-twb
-wQT
+tvI
+tvI
+eMO
+tvI
+tvI
+vPM
+vPM
+vPM
+tvI
+tvI
+tvI
+tvI
+tvI
+tvI
+tvI
+vPM
+dGw
+dhe
+liA
+gVR
 dMa
-eLu
+gfo
 cME
 wQT
 eLu
@@ -68857,45 +69902,45 @@ uXc
 cQn
 mhb
 mhb
-cQn
+mhb
 rAQ
 bqy
 hVI
 kSp
 pEe
-aoa
-aja
 mFh
 aja
-aFZ
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-twb
-twb
+gik
+rud
+qwZ
+bWr
+tvI
+tvI
+tvI
+tvI
+tvI
+tvI
+tvI
+vPM
+mGe
+vPM
+jgN
+tvI
+acx
+tvI
+tvI
+eMO
+tvI
+vPM
+dGw
+lDC
 twb
 twb
 tPN
+tPN
+tPN
 twb
-twb
+eLu
 kqC
 pHu
 mcc
@@ -69070,39 +70115,39 @@ tST
 kqz
 kqz
 kqz
-cwO
+aGS
 eli
 hVI
 myO
 cwO
 mJy
 cwO
-mJy
-cwO
-tQB
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
+gik
+rud
+kUR
+eMJ
+tvI
+vYE
+tvI
+tvI
+tvI
+tvI
+qbr
+vPM
+mGe
+vPM
+tvI
+tvI
+tvI
+tvI
+tvI
+tvI
+tvI
+tvI
+vPM
+mGe
+xQC
+bQM
 bQM
 bQM
 bQM
@@ -69281,8 +70326,8 @@ icj
 kqz
 kqz
 sZr
-ffm
-cwO
+kqz
+aNw
 hVI
 hVI
 mAz
@@ -69290,31 +70335,31 @@ tur
 quk
 rMS
 tcl
-tur
-tQB
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
+seu
+hTc
+bWr
+tvI
+tvI
+tvI
+tvI
+tvI
+tvI
+tvI
+vPM
+dGw
+vPM
+tvI
+tvI
+tvI
+tvI
+tvI
+tvI
+tvI
+tvI
+vPM
+mGe
+xQC
+bQM
 bQM
 bQM
 bQM
@@ -69494,44 +70539,44 @@ vro
 kqz
 sWu
 kqz
-tkk
-hVI
-hVI
-aFZ
-tQB
-tQB
-aFZ
-tQB
-tQB
-aFZ
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-wzE
-hZR
-hZR
-wzE
-wzE
+bxa
+lDC
+lDC
+lDC
+lDC
+lDC
+lDC
+lDC
+lDC
+lDC
+ggQ
+tvI
+kuT
+tvI
+tvI
+tvI
+oKQ
+tvI
+vPM
+mGe
+vPM
+tvI
+oKQ
+tvI
+tvI
+tvI
+ioG
+tvI
+tvI
+vPM
+deH
+eDn
+eDn
+xQC
+xQC
+xQC
+eDn
+eDn
 vqi
 pHu
 mcc
@@ -69705,46 +70750,46 @@ pnc
 bII
 kqz
 kqz
-hkW
+kqz
 iJj
-fPZ
-aFZ
-aFZ
-bce
+cAv
+vPM
+fhz
+gTw
 gTw
 wuT
-qOk
-jfm
+qyX
 vPM
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-wzE
-mcc
-mcc
-mcc
-sHH
-mcc
+vPM
+dGw
+tvI
+tvI
+tvI
+tvI
+tvI
+tvI
+kuT
+vPM
+mGe
+xqh
+tvI
+tvI
+ioG
+tvI
+aJU
+tvI
+tvI
+tvI
+vPM
+vPM
+pkw
+ybs
+gTw
+gTw
+gTw
+vPM
+pkw
+tjM
 cMg
 mcc
 vei
@@ -69920,42 +70965,42 @@ kqz
 kqz
 lcu
 vbe
-aja
-tQB
-cAW
-ajx
-afk
-afk
-afk
-wnB
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-hZR
+dGw
+fsn
 mGe
-gcy
-gcy
-sHH
+mGe
+dGw
+rVy
+mGe
+wnB
+wnB
+gVX
+vPM
+vPM
+vPM
+vPM
+vPM
+vPM
+vPM
+dGw
+vPM
+vPM
+vPM
+vPM
+vPM
+vPM
+vPM
+sYe
+tJT
+tJT
+mGe
+isl
+dGw
+mGe
+mGe
+mGe
+dGw
+isl
 sHH
 pHu
 mcc
@@ -70129,45 +71174,45 @@ hVI
 fcO
 sZr
 kqz
-ajp
-pIX
+kqz
+cbH
 cYg
-cwO
-tQB
-cAW
-ajx
-afk
-hkh
-afk
-wnB
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-hZR
-mcc
-sHH
-sHH
-sHH
+dGw
+dGw
+dGw
+jqR
+dGw
+rVy
+mGe
+bCk
+sLl
+jNa
+vPM
+mGe
+mGe
+smz
+mGe
+mGe
+dGw
+muf
+dGw
+mGe
+wWT
+dGw
+mGe
+mGe
+vPM
+liT
+jXx
+jXx
+mGe
+isl
+dGw
+dGw
+dGw
+dGw
+dGw
+isl
 sHH
 pHu
 mcc
@@ -70343,43 +71388,43 @@ kqz
 kqz
 kqz
 aSw
-kqz
-cwO
-tQB
-cAW
-ajx
-afk
-afk
-afk
-wnB
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-hZR
-aCO
-bMl
-gcy
-sHH
+cYa
+dGw
+gfp
+hkW
+mGe
+dGw
+rVy
+mGe
+oOs
+oOs
+eKg
+vPM
+jZx
+vPM
+vPM
+vPM
+vPM
+jZx
+dGw
+vPM
+dHI
+vPM
+vPM
+vPM
+vPM
+vPM
+xQs
+ckj
+ckj
+mGe
+isl
+dGw
+mGe
+mGe
+mGe
+dGw
+isl
 sHH
 pHu
 mcc
@@ -70553,46 +71598,46 @@ ueA
 bII
 kqz
 kqz
-xzb
+kqz
 kdo
 tzF
-cwO
-tQB
-cAW
-ajx
-afk
-afk
-afk
-wnB
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-wzE
-mcc
+vPM
+guB
+ick
 jZb
-mcc
-sHH
-mcc
+mDi
+sWF
+vPM
+vPM
+tvI
+tvI
+tvI
+tvI
+tvI
+tvI
+tvI
+tvI
+vPM
+mGe
+vPM
+tvI
+tvI
+tvI
+tvI
+tvI
+tvI
+tvI
+tvI
+vPM
+vPM
+dnA
+vWE
+jZb
+jZb
+jZb
+vPM
+dnA
+reD
 pHu
 mcc
 vei
@@ -70767,43 +71812,43 @@ xzb
 kqz
 kqz
 oFW
-jEb
-tur
-tQB
-cAW
-ajx
-afk
-hkh
-afk
-wnB
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-wzE
-hZR
-hZR
-wzE
-wzE
+eDn
+eHa
+xQC
+xQC
+xQC
+eDn
+eDn
+iCi
+vPM
+tvI
+rxu
+tvI
+tvI
+tvI
+tvI
+oKQ
+tvI
+vPM
+mGe
+vPM
+tvI
+oKQ
+tvI
+vYE
+tvI
+xXw
+hVS
+tvI
+vPM
+deH
+eDn
+eDn
+xQC
+xQC
+xQC
+eDn
+eDn
 vqi
 pHu
 mcc
@@ -70979,42 +72024,42 @@ kqz
 kqz
 kqz
 lwB
-aSS
 aFZ
 aFZ
-cAW
-ajx
-afk
-afk
-afk
-wnB
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-dhi
-fsn
+gyW
+bQM
+bQM
+bQM
+xQC
+mGe
+vPM
+tvI
+tvI
+tvI
+tvI
+tvI
+tvI
+tvI
+rxu
+vPM
+dGw
+vPM
+tvI
+tvI
+rxu
+tvI
+kuT
+tvI
+hVS
+tvI
+vPM
+mGe
+xQC
+cmz
+fyC
 qOk
-gfp
-mhv
+mKS
+erT
 wzE
 wzE
 pHu
@@ -71189,40 +72234,40 @@ jEb
 aaf
 eTd
 jEb
-jEb
+kqz
 lJv
 aFZ
 aFZ
-aFZ
-kPz
-aGS
-aNw
-llQ
+gyW
+bQM
+bQM
+bQM
+xQC
 vuc
-aTN
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-ajx
+vPM
+tvI
+tvI
+tvI
+qfE
+dnI
+tvI
+tvI
+tvI
+vPM
+mGe
+vPM
+tvI
+rxu
+tvI
+tvI
+tvI
+tvI
+tvI
+tvI
+vPM
+mGe
+xQC
+xyy
 afk
 afk
 afk
@@ -71401,40 +72446,40 @@ tOp
 jmG
 sta
 sta
-sta
 jmG
 jmG
 jmG
 jmG
 jmG
-uwk
-uwk
 jmG
 jmG
 jmG
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-ajx
+jmG
+cKa
+cKa
+cNC
+tvI
+tvI
+tvI
+tvI
+tvI
+tvI
+vYE
+vPM
+mGe
+vPM
+vPM
+vPM
+vPM
+hrg
+hrg
+hrg
+vPM
+vPM
+rWB
+eDn
+eDn
+urJ
 afk
 hkh
 afk
@@ -71617,36 +72662,36 @@ kNz
 hor
 cKa
 ocJ
-rsE
+fcZ
 cKa
-imL
-ggB
-ggB
+lGA
+qgh
+uCD
 mEv
-uwk
-cAW
-cAW
-cAW
-cAW
+jYs
+vMX
+tvI
+tvI
+tvI
 hVS
-vBP
-vBP
-vBP
-vBP
-vBP
-vBP
-vBP
-vBP
-vBP
-vBP
+tvI
+tvI
+tvI
 vPM
-cAW
-cAW
-cAW
-cAW
-cAW
-bQM
-ajx
+vZz
+vPM
+ioG
+tvI
+rcG
+nzp
+jdX
+tJT
+ePm
+vPM
+rWB
+eDn
+jKI
+mdJ
 afk
 afk
 afk
@@ -71832,40 +72877,40 @@ ikq
 mYp
 cKa
 qZW
-ggB
-ggB
+qgh
+uCD
 biJ
-uwk
-cAW
-cAW
-cAW
-cAW
-rAe
-afk
-afk
-afk
-hkh
-afk
-afk
-hkh
-afk
-afk
-afk
-eZq
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-fdV
+jYs
+vMX
+iuw
+tvI
+tvI
+tvI
+tvI
+tvI
+tvI
+sYe
+aee
+tJT
+tvI
+tvI
+rcG
+aIX
+vPM
+aIX
+ePm
+dGw
+vVR
+eDn
+eDn
+eDn
 wby
 llQ
-eZA
-sYv
-kPz
+jKI
+bUB
+bQM
 wzE
-pHu
+ulJ
 mcc
 vei
 kqC
@@ -72044,34 +73089,34 @@ kzh
 tOp
 cKa
 rfJ
-ggB
-ggB
+qgh
+uCD
 iwK
-uwk
-cAW
-cAW
-cAW
-cAW
-rAe
-afk
-afk
-afk
-pcu
-afk
-afk
-pcu
-afk
-afk
-afk
-eZq
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-ajx
+cKa
+gde
+dGw
+vPM
+vPM
+tvI
+tvI
+tvI
+tvI
+sDV
+uRu
+ckj
+tvI
+kuT
+rcG
+sDV
+aIX
+uAd
+ePm
+deH
+ued
+uvM
+cnl
+eDn
+xQC
 wzE
 wzE
 wzE
@@ -72250,45 +73295,45 @@ cKa
 bdI
 fnj
 iZV
-vJD
+cnF
 hFn
 dkj
 oMR
 dkj
 dkj
 kNz
-vJD
-vJD
+cnF
+cnF
 jmG
-cAW
-cAW
-bQM
-bQM
-rAe
-afk
-afk
-afk
-hkh
-afk
-afk
-hkh
-afk
-afk
-afk
-eZq
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-ajx
-hZR
+eHa
+eDn
+dGw
+dGw
+vPM
+vPM
+vPM
+aLC
+sDV
+uRu
+ckj
+vPM
+vZz
+vPM
+mIq
+mIq
+mIq
+vPM
+dhe
+msS
+vMX
+mGe
+uIA
+mGe
+oFI
 gEW
-mcc
+ggu
 fLR
-usz
+kqC
 pHu
 mcc
 vei
@@ -72461,45 +73506,45 @@ kNz
 aau
 xMR
 roY
-gUH
-vJD
+iZV
+cnF
 jvE
 vII
 vII
 vII
 vII
 dyM
-vJD
-vJD
+cnF
+cnF
 jmG
-cAW
-cAW
-cAW
-cAW
-ggQ
-jlH
-jlH
-tWI
-llQ
-jKI
-tWI
-llQ
-jKI
-jlH
-jlH
-sYv
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-cAW
-bTo
-hZR
+bQM
+eDn
+xQC
+eDn
+mGe
+mGe
+isL
+wUN
+mGe
+mGe
+mGe
+kiq
+tsf
+lWh
+vPM
+kiq
+vPM
+vPM
+dhe
+msS
+vMX
+mGe
+iTe
+mGe
+oFI
 gEW
 ggu
-mcc
+ggu
 usz
 pHu
 mcc
@@ -72684,34 +73729,34 @@ cKa
 aaK
 kNz
 jmG
-bQM
-bQM
-cAW
-cAW
-bce
-cAW
-ecM
-ecM
-mlC
-mlC
-mlC
-ecM
-ecM
-cAW
-cAW
-bce
-cAW
-bce
-hVS
-vBP
-byl
-byl
-mhv
-rAe
+kPz
+uwY
+pcu
+eDn
+xQC
+xQC
+eDn
+eON
+cYv
+cYv
+cYv
+arY
+lDC
+irx
+aXK
+jZb
+dRW
+jZb
+cFN
+eDn
+eDn
+xQC
+xQC
+xQC
 wzE
 dYr
-mcc
-mcc
+ggu
+ggu
 usz
 qRD
 mcc
@@ -72888,38 +73933,38 @@ roY
 iZV
 cKa
 aaK
-rVy
+soQ
 cKa
 cFE
-uYD
+soQ
 cKa
 xMR
 iZV
 uwk
-bxa
-byl
-vBP
-byl
-mhv
+swg
+fyC
+qOk
+sHO
+erT
 kPz
-ecM
+eDn
 rkB
 rFr
-miU
+lBY
 uSb
 lzb
-ecM
-bQM
-bQM
-kPz
+lDC
+lDC
+ldZ
+ldZ
+lDC
+ldZ
+ldZ
+eDn
 cAW
-kPz
-ajx
-afk
-afk
-afk
-ghg
-fsn
+bce
+bce
+bce
 wzE
 kqC
 usz
@@ -73097,12 +74142,12 @@ tOp
 cKa
 fiu
 gbi
-tHu
+iZV
 cKa
-ldm
-usA
+dkg
+eZA
 cKa
-ldm
+dkg
 rEg
 cKa
 xMR
@@ -73114,27 +74159,27 @@ afk
 afk
 ghg
 gef
-mlC
+xQC
 wkD
 sMj
-miU
-xKX
+gXi
+ecC
 hgJ
-mlC
-bQM
+edd
+vgP
+irx
+htc
+svo
+irx
+irx
+xQC
 cAW
-kPz
-bQM
-kPz
-bTo
-afk
-hkh
-afk
-tCZ
-pcu
+bce
+cAW
+cAW
 wzE
 msv
-dHp
+uRY
 dHp
 dHp
 bop
@@ -73326,29 +74371,29 @@ hkh
 afk
 tCZ
 pcu
-mlC
+xQC
 rym
 fBi
-xKX
+irx
 rym
 rym
-mlC
-kPz
-kPz
-kPz
-kPz
-kPz
-rAe
-afk
-afk
-afk
-fhz
-tvI
+edd
+vgP
+eON
+lWr
+svo
+eON
+lWr
+xQC
+bce
+bce
+cAW
+cAW
 wzE
 pHu
-dui
-mcc
-dWM
+ooA
+cWN
+liE
 mcc
 mcc
 mcc
@@ -73524,10 +74569,10 @@ roY
 iZV
 cKa
 ocJ
-rsE
+fcZ
 cKa
 ocJ
-rsE
+fcZ
 cKa
 xMR
 iZV
@@ -73538,29 +74583,29 @@ afk
 afk
 xMW
 ssJ
-mlC
+xQC
 xkC
 tom
 vGv
 uzO
 dhe
-mlC
-bQM
-kPz
-cAW
+edd
+fje
+das
+jAt
+svo
+tJn
+jAt
+xQC
 cAW
 bce
-aKA
-xQC
-llQ
-eZA
-sYv
-kPz
+bce
+bce
 wzE
 lll
-mcc
-vza
-mcc
+ggu
+oPJ
+jfk
 mcc
 vza
 mcc
@@ -73750,29 +74795,29 @@ llQ
 eOF
 bUB
 kPz
+eDn
+vPM
+lBY
+oOv
+dGw
+rFH
+lDC
+izZ
+uym
+uym
+izZ
+uym
+uym
 ecM
-cjF
-miU
-xKX
-gqe
-lzb
-ecM
-ecM
-mlC
-mlC
-mlC
-mlC
-ecM
-ecM
-pcu
-fcZ
-erT
-bQM
+cAW
+bce
+cAW
+cAW
 wzE
 scw
 uFh
-mcc
-mcc
+ggu
+ggu
 mcc
 evf
 dWM
@@ -73953,8 +74998,8 @@ cKa
 kzh
 tOp
 cKa
-vJD
-vJD
+cnF
+cnF
 jmG
 jmG
 mlC
@@ -73962,29 +75007,29 @@ mlC
 mlC
 mlC
 ecM
-ecM
+eDn
+eON
+cYv
+cYv
+cYv
+arY
+lDC
 xKX
-xKX
-rWX
-xKX
-xKX
-ecM
-cjF
-cjF
-cjF
-cjF
-cjF
-cjF
+wkZ
+wkZ
+wWF
+wkZ
+wkZ
 ecM
 mlC
 wzE
-iWq
-bQM
+wzE
+wzE
 wzE
 glW
 vei
-mcc
-mcc
+ggu
+ggu
 jsE
 mcc
 mcc
@@ -74161,40 +75206,40 @@ dkj
 dkj
 dkj
 dkj
+fvY
 dkj
 dkj
 dkj
 dkj
 dkj
-dkj
-kNz
-cKa
+vCT
+fYV
 fDI
-gqe
+fDI
 cjF
-qyX
 cjF
-jqR
 cjF
-qnu
-xKX
-sWF
+jMA
 cjF
-mDi
-gqe
-gqe
-gqe
-gqe
-gqe
-gqe
-aFO
-cbH
-wzE
-hZR
-hZR
-wzE
-vei
-iUy
+cjF
+cjF
+cjF
+cjF
+gky
+cjF
+cjF
+cjF
+cjF
+cjF
+cjF
+gky
+cjF
+kqC
+usz
+usz
+usz
+usz
+usz
 mcc
 mcc
 mcc
@@ -74381,8 +75426,8 @@ roY
 gLG
 iZV
 fSq
-guB
-cAv
+cjF
+gqe
 rAW
 cjF
 vEF
@@ -74593,8 +75638,8 @@ vII
 vII
 dyM
 fSq
-cjF
-gqe
+ebP
+jJe
 gqe
 gqe
 sad
@@ -74795,18 +75840,18 @@ wef
 roY
 roY
 roY
-iZV
+fin
 jpN
 uwk
 uwk
 uwk
 lIG
 vJD
+gDt
 vJD
-vJD
-fSq
-ebP
-dGw
+cKa
+cjF
+gqe
 gqe
 gqe
 vTl
@@ -76491,7 +77536,7 @@ xMR
 roY
 wef
 roY
-iZV
+fin
 jmG
 uwk
 uwk


### PR DESCRIPTION
# About the pull request

This PR aims to readd yard to Science Annex. In February last year, we removed yard due to having a negative effect on Science Annex's gameplay flow. However, the complete removal of it has shown over time that it also has its own major issues. This readdition should address the flow issues that the map suffers. 

Will probably require test merging to gauge its effect, another possible solution is only allowing it to serve as a connector to the North and South.

# Explain why it's good for the game

Science Annex currently suffers badly from there being no center of the map, meaning that you have to travel all the way around the map to reach the other side. This should aid in the flow of the map, without allowing yard to turn into the meta afk and hold spot while ignoring the rest of the map. You can use yard as a hold, but you will need to use the rest of the map to push. 


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/cmss13-devs/cmss13/assets/133173804/1009ca47-3119-4076-a221-df84122784d5)


</details>


# Changelog

:cl:
mapadd: Readds yard to Science Annex
maptweak: Redid the yard loot to be more in line with current surv loot standards.
/:cl:
