### PR TITLE
[Balance] Hive weeds now look for a supporting structure

### DIFF
--- a/code/modules/cm_aliens/weeds.dm
+++ b/code/modules/cm_aliens/weeds.dm
@@ -193,13 +193,19 @@
 // If you're still confused, scroll aaaall the way down to the bottom of the file.
 // that's /obj/effect/alien/weeds/node/Destroy().
 /obj/effect/alien/weeds/proc/avoid_orphanage()
-	for(var/obj/effect/alien/weeds/node/N in orange(node_range, get_turf(src)))
-		// WE FOUND A NEW MOMMY
-		N.add_child(src)
-		break
+	if (weed_strength >= WEED_LEVEL_HIVE)
+		for(var/obj/effect/alien/weeds/node/pylon/N in orange(node_range, get_turf(src)))
+			// A pylon, cluster or core was nearby to support the hive weed
+			N.add_child(src)
+			break
+	else
+		for(var/obj/effect/alien/weeds/node/N in orange(node_range, get_turf(src)))
+			// WE FOUND A NEW MOMMY
+			N.add_child(src)
+			break
 
 	// NO MORE FOOD ON THE TABLE. WE DIE
-	if(!parent || weed_strength > WEED_LEVEL_STANDARD)
+	if(!parent)
 		qdel(src)
 
 /obj/effect/alien/weeds/proc/weed_expand()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Similar to how weed sacs can support another sac's weeds within range, add this to stronger weeds as well.

So if you have a cluster and a core close together, when one of them is destroyed, the hive weeds that are still within the range of the other structure will not disappear.

# Explain why it's good for the game

Feels weird that all weeds receded next to other clusters / core when they can definitely support it.

Plus weak weeds can do it, why can't thick weeds?


# Changelog

:cl:
balance: Hive weeds can be supported by other structures when original parent structure is destroyed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
