### PR TITLE
Medkit Pouch Change 

### DIFF
--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -813,10 +813,22 @@
 
 
 /obj/item/storage/pouch/medkit/full/fill_preset_inventory()
-	new /obj/item/storage/firstaid/regular(src)
+	new /obj/item/device/healthanalyzer(src)
+	new /obj/item/reagent_container/hypospray/autoinjector/skillless(src)
+	new /obj/item/reagent_container/hypospray/autoinjector/skillless/tramadol(src)
+	new /obj/item/reagent_container/hypospray/autoinjector/inaprovaline(src)
+	new /obj/item/stack/medical/bruise_pack(src)
+	new /obj/item/stack/medical/ointment(src)
+	new /obj/item/stack/medical/splint(src)
 
 /obj/item/storage/pouch/medkit/full_advanced/fill_preset_inventory()
-	new /obj/item/storage/firstaid/adv(src)
+	new /obj/item/reagent_container/hypospray/autoinjector/tricord(src)
+	new /obj/item/stack/medical/advanced/bruise_pack(src)
+	new /obj/item/stack/medical/advanced/bruise_pack(src)
+	new /obj/item/stack/medical/advanced/bruise_pack(src)
+	new /obj/item/stack/medical/advanced/ointment(src)
+	new /obj/item/stack/medical/advanced/ointment(src)
+	new /obj/item/stack/medical/splint(src)
 
 
 /obj/item/storage/pouch/pressurized_reagent_canister

--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -792,11 +792,17 @@
 
 /obj/item/storage/pouch/medkit
 	name = "medkit pouch"
-	max_w_class = SIZE_MEDIUM
-	storage_flags = STORAGE_FLAGS_POUCH|STORAGE_USING_DRAWING_METHOD
+	max_w_class = SIZE_SMALL
+	storage_flags = STORAGE_FLAGS_POUCH
 	icon_state = "medkit"
-	desc = "It's specifically made to hold a medkit."
-	can_hold = list(/obj/item/storage/firstaid)
+	storage_slots = 7
+	desc = "It's specifically made to hold medical items."
+	cant_hold = list(
+		/obj/item/ammo_magazine,
+		/obj/item/explosive/grenade,
+		/obj/item/tool,
+		/obj/item/storage,
+	)
 
 /obj/item/storage/pouch/medkit/handle_mmb_open(mob/user)
 	var/obj/item/storage/firstaid/FA = locate() in contents


### PR DESCRIPTION

# About the pull request

The medkit pouch no longer holds a single medkit. It instead can now hold seven items, akin to what a standard medkit can carry. 

It is now functionally just a medkit that goes into your pouch slot instead of being a pouch that holds a medkit that goes into your pouch.

# Explain why it's good for the game

Functionally a quality of life improvement. Instead of storing a medkit you need to open you now just have a direct medkit inventory you can access from your pouch with one click. 


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: The medkit pouch no longer can hold a medkit. It now has seven slots that can carry the same kind of items that a medkit can carry. 
/:cl:
