### PR TITLE
Fixes lifepods still working after evac canceled

### DIFF
--- a/code/modules/shuttle/computers/escape_pod_computer.dm
+++ b/code/modules/shuttle/computers/escape_pod_computer.dm
@@ -66,7 +66,7 @@
 	var/obj/docking_port/mobile/crashable/escape_shuttle/shuttle = SSshuttle.getShuttle(shuttleId)
 	switch(action)
 		if("force_launch")
-			if(!pod_state == STATE_READY && !pod_state == STATE_DELAYED)
+			if(pod_state != STATE_READY && pod_state != STATE_DELAYED)
 				return
 
 			shuttle.evac_launch()

--- a/code/modules/shuttle/computers/escape_pod_computer.dm
+++ b/code/modules/shuttle/computers/escape_pod_computer.dm
@@ -66,6 +66,9 @@
 	var/obj/docking_port/mobile/crashable/escape_shuttle/shuttle = SSshuttle.getShuttle(shuttleId)
 	switch(action)
 		if("force_launch")
+			if(!pod_state == STATE_READY && !pod_state == STATE_DELAYED)
+				return
+
 			shuttle.evac_launch()
 			pod_state = STATE_LAUNCHING
 			. = TRUE

--- a/tgui/packages/tgui/interfaces/EscapePodConsole.tsx
+++ b/tgui/packages/tgui/interfaces/EscapePodConsole.tsx
@@ -19,16 +19,15 @@ export const EscapePodConsole = (_props, context) => {
 
   switch (data.docking_status) {
     case 4:
-      statusMessage = 'SYSTEMS OK';
-      buttonColor = 'good';
-      operable = 1;
+      statusMessage = 'NO EVACUATION';
+      buttonColor = 'neutral';
       break;
     case 5:
       statusMessage = 'SYSTEMS DOWN';
       break;
     case 6:
       statusMessage = 'STANDING BY';
-      buttonColor = 'neutral';
+      buttonColor = 'good';
       operable = 1;
       break;
     case 7:


### PR DESCRIPTION

# About the pull request

This PR fixes lifepods still being operational after evac has been canceled.

# Explain why it's good for the game

Lifepods should not work if evac is canceled.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
fix: Fixed lifepods still working after evac canceled
/:cl:
