### PR TITLE
Fix fluff type check for map overrides

### DIFF
--- a/code/__DEFINES/equipment.dm
+++ b/code/__DEFINES/equipment.dm
@@ -27,7 +27,7 @@
 #define ITEM_UNCATCHABLE (1<<9)
 /// Used for nonstandard marine clothing to ignore 'specialty' var.
 #define NO_NAME_OVERRIDE (1<<10)
-/// Used for armors or uniforms that don't have a snow icon state.
+/// Used for armors or uniforms that don't have a snow/desert/etc icon state set via select_gamemode_skin (not all item types currently perform this test though).
 #define NO_SNOW_TYPE (1<<11)
 
 #define INVULNERABLE (1<<12)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -229,7 +229,7 @@ item, and will change the skin to whatever you specify here. You can also
 manually override the icon with a unique skin if wanted, for the outlier
 cases. Override_icon_state should be a list.*/
 /obj/item/proc/select_gamemode_skin(expected_type, list/override_icon_state, list/override_protection)
-	if(type == expected_type && !istype(src, /obj/item/clothing/suit/storage/marine/fluff) && !istype(src, /obj/item/clothing/head/helmet/marine/fluff) && !istype(src, /obj/item/clothing/under/marine/fluff))
+	if(type == expected_type && !findtext("[type]", "fluff"))
 		var/new_icon_state
 		var/new_protection
 		var/new_item_state

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -229,28 +229,28 @@ item, and will change the skin to whatever you specify here. You can also
 manually override the icon with a unique skin if wanted, for the outlier
 cases. Override_icon_state should be a list.*/
 /obj/item/proc/select_gamemode_skin(expected_type, list/override_icon_state, list/override_protection)
-	if(type == expected_type && !findtext("[type]", "fluff"))
-		var/new_icon_state
-		var/new_protection
-		var/new_item_state
-		if(override_icon_state && override_icon_state.len)
-			new_icon_state = override_icon_state[SSmapping.configs[GROUND_MAP].map_name]
-		if(override_protection && override_protection.len)
-			new_protection = override_protection[SSmapping.configs[GROUND_MAP].map_name]
-		switch(SSmapping.configs[GROUND_MAP].camouflage_type)
-			if("snow")
-				icon_state = new_icon_state ? new_icon_state : "s_" + icon_state
-				item_state = new_item_state ? new_item_state : "s_" + item_state
-			if("desert")
-				icon_state = new_icon_state ? new_icon_state : "d_" + icon_state
-				item_state = new_item_state ? new_item_state : "d_" + item_state
-			if("classic")
-				icon_state = new_icon_state ? new_icon_state : "c_" + icon_state
-				item_state = new_item_state ? new_item_state : "c_" + item_state
-		if(new_protection)
-			min_cold_protection_temperature = new_protection
-	else return
+	if(type != expected_type)
+		return
 
+	var/new_icon_state
+	var/new_protection
+	var/new_item_state
+	if(override_icon_state && override_icon_state.len)
+		new_icon_state = override_icon_state[SSmapping.configs[GROUND_MAP].map_name]
+	if(override_protection && override_protection.len)
+		new_protection = override_protection[SSmapping.configs[GROUND_MAP].map_name]
+	switch(SSmapping.configs[GROUND_MAP].camouflage_type)
+		if("snow")
+			icon_state = new_icon_state ? new_icon_state : "s_" + icon_state
+			item_state = new_item_state ? new_item_state : "s_" + item_state
+		if("desert")
+			icon_state = new_icon_state ? new_icon_state : "d_" + icon_state
+			item_state = new_item_state ? new_item_state : "d_" + item_state
+		if("classic")
+			icon_state = new_icon_state ? new_icon_state : "c_" + icon_state
+			item_state = new_item_state ? new_item_state : "c_" + item_state
+	if(new_protection)
+		min_cold_protection_temperature = new_protection
 
 /obj/item/get_examine_text(mob/user)
 	. = list()

--- a/code/modules/cm_marines/Donator_Items.dm
+++ b/code/modules/cm_marines/Donator_Items.dm
@@ -15,7 +15,7 @@
 	icon_override = 'icons/mob/humans/onmob/head_0.dmi'
 	flags_inventory = BLOCKSHARPOBJ
 	flags_inv_hide = HIDEEARS
-	flags_atom = NO_NAME_OVERRIDE
+	flags_atom = FPRINT|CONDUCT|NO_NAME_OVERRIDE|NO_SNOW_TYPE
 	min_cold_protection_temperature = ICE_PLANET_MIN_COLD_PROT
 	flags_marine_helmet = NO_FLAGS
 
@@ -67,7 +67,7 @@
 	desc = "ITEM DESCRIPTION.  DONOR ITEM" //Add UNIQUE if Unique
 	icon_state = null
 	item_state = null
-	flags_atom = NO_NAME_OVERRIDE
+	flags_atom = FPRINT|CONDUCT|NO_NAME_OVERRIDE|NO_SNOW_TYPE
 	//DON'T GRAB STUFF BETWEEN THIS LINE
 	icon = 'icons/obj/items/clothing/suits.dmi'
 	icon_override = 'icons/mob/humans/onmob/suit_0.dmi'  //Don't fuck with this in the future please.
@@ -80,7 +80,7 @@
 	desc = "ITEM DESCRIPTION.  DONOR ITEM" //Add UNIQUE if Unique
 	icon_state = null
 	item_state = null
-	flags_atom = NO_NAME_OVERRIDE
+	flags_atom = FPRINT|CONDUCT|NO_NAME_OVERRIDE|NO_SNOW_TYPE
 	//DON'T GRAB STUFF BETWEEN THIS LINE
 	icon = 'icons/obj/items/clothing/suits.dmi'
 	icon_override = 'icons/mob/humans/onmob/suit_0.dmi'  //Don't fuck with this in the future please.
@@ -971,7 +971,7 @@
 /obj/item/clothing/under/marine/fluff
 	name = "ITEM NAME"
 	desc = "ITEM DESCRIPTION.  DONOR ITEM" //Add UNIQUE if Unique
-	flags_atom = NO_NAME_OVERRIDE
+	flags_atom = FPRINT|NO_NAME_OVERRIDE|NO_SNOW_TYPE
 	icon_state = null
 	item_state = null
 	min_cold_protection_temperature = ICE_PLANET_MIN_COLD_PROT


### PR DESCRIPTION
# About the pull request

This PR fixes an issue caused by a path remapping in #4245 where a typecheck for an old fluff value no longer triggered to prevent map specific camos on the fluff gear.

Note: NO_SNOW_TYPE is more than just snow, but also not all item types even perform a test on that flag to prevent calling select_gamemode_skin.

# Explain why it's good for the game

Fixes #4398 (Or any /obj/item/clothing/suit/storage/marine/light/fluff)

# Changelog
:cl: Drathek
fix: Fix some donor items breaking on maps with camos.
fix: Fix donor items not having a fingerprint atom flag and donor armors not having conductive atom flag.
/:cl:
