### PR TITLE
Cloaked mobs don't give off visible messages (+cloak logic refactor)

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -179,6 +179,8 @@
 #define TRAIT_HARDCORE "t_hardcore"
 /// If the mob is able to use the vulture rifle or spotting scope
 #define TRAIT_VULTURE_USER "t_vulture_user"
+/// If the mob is cloaked in any form
+#define TRAIT_CLOAKED "t_cloaked"
 
 // -- ability traits --
 /// Xenos with this trait cannot have plasma transfered to them
@@ -278,6 +280,7 @@ GLOBAL_LIST_INIT(traits_by_type, list(
 		"TRAIT_LISPING" = TRAIT_LISPING,
 		"TRAIT_CANNOT_EAT" = TRAIT_CANNOT_EAT,
 		"TRAIT_VULTURE_USER" = TRAIT_VULTURE_USER,
+		"TRAIT_CLOAKED" = TRAIT_CLOAKED,
 	),
 	/mob/living/carbon/xenomorph = list(
 		"TRAIT_ABILITY_NO_PLASMA_TRANSFER" = TRAIT_ABILITY_NO_PLASMA_TRANSFER,

--- a/code/game/machinery/ARES/ARES_step_triggers.dm
+++ b/code/game/machinery/ARES/ARES_step_triggers.dm
@@ -25,7 +25,7 @@
 		return FALSE
 	if(!(ishuman(passer) || isxeno(passer)))
 		return FALSE
-	if(passer.alpha <= 100)//Can't be seen/detected to trigger alert.
+	if(HAS_TRAIT(passer, TRAIT_CLOAKED))
 		return FALSE
 	if(pass_jobs)
 		if(passer.job in pass_jobs)
@@ -117,7 +117,7 @@
 		return FALSE
 	if(!passer)
 		return FALSE
-	if(passer.alpha <= 100)//Can't be seen/detected to trigger alert.
+	if(HAS_TRAIT(passer, TRAIT_CLOAKED))//Can't be seen/detected to trigger alert.
 		return FALSE
 	var/area/pass_area = get_area(get_step(passer, passer.dir))
 	if(istype(pass_area, /area/almayer/command/airoom))//Don't want it to freak out over someone /entering/ the area. Only leaving.

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -741,6 +741,7 @@ GLOBAL_LIST_EMPTY_TYPED(radio_packs, /obj/item/storage/backpack/marine/satchel/r
 	RegisterSignal(H, COMSIG_HUMAN_EXTINGUISH, PROC_REF(wrapper_fizzle_camouflage))
 
 	camo_active = TRUE
+	ADD_TRAIT(H, TRAIT_CLOAKED, "scout_cloak")
 	H.visible_message(SPAN_DANGER("[H] vanishes into thin air!"), SPAN_NOTICE("You activate your cloak's camouflage."), max_distance = 4)
 	playsound(H.loc, 'sound/effects/cloak_scout_on.ogg', 15, TRUE)
 	H.unset_interaction()
@@ -779,6 +780,7 @@ GLOBAL_LIST_EMPTY_TYPED(radio_packs, /obj/item/storage/backpack/marine/satchel/r
 		cloak_cooldown = world.time + 10 SECONDS
 
 	camo_active = FALSE
+	REMOVE_TRAIT(H, TRAIT_CLOAKED, "scout_cloak")
 	H.visible_message(SPAN_DANGER("[H] shimmers into existence!"), SPAN_WARNING("Your cloak's camouflage has deactivated!"), max_distance = 4)
 	playsound(H.loc, 'sound/effects/cloak_scout_off.ogg', 15, TRUE)
 

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -741,7 +741,7 @@ GLOBAL_LIST_EMPTY_TYPED(radio_packs, /obj/item/storage/backpack/marine/satchel/r
 	RegisterSignal(H, COMSIG_HUMAN_EXTINGUISH, PROC_REF(wrapper_fizzle_camouflage))
 
 	camo_active = TRUE
-	ADD_TRAIT(H, TRAIT_CLOAKED, "scout_cloak")
+	ADD_TRAIT(H, TRAIT_CLOAKED, TRAIT_SOURCE_EQUIPMENT(WEAR_BACK))
 	H.visible_message(SPAN_DANGER("[H] vanishes into thin air!"), SPAN_NOTICE("You activate your cloak's camouflage."), max_distance = 4)
 	playsound(H.loc, 'sound/effects/cloak_scout_on.ogg', 15, TRUE)
 	H.unset_interaction()
@@ -780,7 +780,7 @@ GLOBAL_LIST_EMPTY_TYPED(radio_packs, /obj/item/storage/backpack/marine/satchel/r
 		cloak_cooldown = world.time + 10 SECONDS
 
 	camo_active = FALSE
-	REMOVE_TRAIT(H, TRAIT_CLOAKED, "scout_cloak")
+	REMOVE_TRAIT(H, TRAIT_CLOAKED, TRAIT_SOURCE_EQUIPMENT(WEAR_BACK))
 	H.visible_message(SPAN_DANGER("[H] shimmers into existence!"), SPAN_WARNING("Your cloak's camouflage has deactivated!"), max_distance = 4)
 	playsound(H.loc, 'sound/effects/cloak_scout_off.ogg', 15, TRUE)
 

--- a/code/modules/cm_preds/yaut_bracers.dm
+++ b/code/modules/cm_preds/yaut_bracers.dm
@@ -571,7 +571,7 @@
 			return FALSE
 
 		cloaked = TRUE
-		ADD_TRAIT(M, TRAIT_CLOAKED, "pred_cloak")
+		ADD_TRAIT(M, TRAIT_CLOAKED, TRAIT_SOURCE_EQUIPMENT(WEAR_HANDS))
 
 		RegisterSignal(M, COMSIG_HUMAN_EXTINGUISH, PROC_REF(wrapper_fizzle_camouflage))
 		RegisterSignal(M, COMSIG_HUMAN_PRE_BULLET_ACT, PROC_REF(bullet_hit))
@@ -618,7 +618,7 @@
 		cloak_malfunction = world.time + decloak_timer
 
 	cloaked = FALSE
-	REMOVE_TRAIT(user, TRAIT_CLOAKED, "pred_cloak")
+	REMOVE_TRAIT(user, TRAIT_CLOAKED, TRAIT_SOURCE_EQUIPMENT(WEAR_HANDS))
 	log_game("[key_name_admin(user)] has disabled their cloaking device.")
 	user.visible_message(SPAN_WARNING("[user] shimmers into existence!"), SPAN_WARNING("Your cloaking device deactivates."))
 	playsound(user.loc, 'sound/effects/pred_cloakoff.ogg', 15, 1)

--- a/code/modules/cm_preds/yaut_bracers.dm
+++ b/code/modules/cm_preds/yaut_bracers.dm
@@ -571,6 +571,7 @@
 			return FALSE
 
 		cloaked = TRUE
+		ADD_TRAIT(M, TRAIT_CLOAKED, "pred_cloak")
 
 		RegisterSignal(M, COMSIG_HUMAN_EXTINGUISH, PROC_REF(wrapper_fizzle_camouflage))
 		RegisterSignal(M, COMSIG_HUMAN_PRE_BULLET_ACT, PROC_REF(bullet_hit))
@@ -617,7 +618,8 @@
 		cloak_malfunction = world.time + decloak_timer
 
 	cloaked = FALSE
-	log_game("[key_name_admin(usr)] has disabled their cloaking device.")
+	REMOVE_TRAIT(user, TRAIT_CLOAKED, "pred_cloak")
+	log_game("[key_name_admin(user)] has disabled their cloaking device.")
 	user.visible_message(SPAN_WARNING("[user] shimmers into existence!"), SPAN_WARNING("Your cloaking device deactivates."))
 	playsound(user.loc, 'sound/effects/pred_cloakoff.ogg', 15, 1)
 	user.alpha = initial(user.alpha)

--- a/code/modules/mob/living/carbon/xenomorph/castes/Lurker.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Lurker.dm
@@ -120,7 +120,7 @@
 	if (LPA && istype(LPA))
 		LPA.knockdown = TRUE // pounce knocks down
 		LPA.freeze_self = TRUE
-	ADD_TRAIT(bound_xeno, TRAIT_CLOAKED, "lurker_cloak")
+	ADD_TRAIT(bound_xeno, TRAIT_CLOAKED, TRAIT_SOURCE_ABILITY("cloak"))
 	bound_xeno.stealth = TRUE
 	can_go_invisible = FALSE
 	invis_start_time = world.time
@@ -131,7 +131,7 @@
 		LPA.knockdown = FALSE // pounce no longer knocks down
 		LPA.freeze_self = FALSE
 	bound_xeno.stealth = FALSE
-	REMOVE_TRAIT(bound_xeno, TRAIT_CLOAKED, "lurker_cloak")
+	REMOVE_TRAIT(bound_xeno, TRAIT_CLOAKED, TRAIT_SOURCE_ABILITY("cloak"))
 
 	// SLIGHTLY hacky because we need to maintain lots of other state on the lurker
 	// whenever invisibility is on/off CD and when it's active.

--- a/code/modules/mob/living/carbon/xenomorph/castes/Lurker.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Lurker.dm
@@ -120,6 +120,7 @@
 	if (LPA && istype(LPA))
 		LPA.knockdown = TRUE // pounce knocks down
 		LPA.freeze_self = TRUE
+	ADD_TRAIT(bound_xeno, TRAIT_CLOAKED, "lurker_cloak")
 	bound_xeno.stealth = TRUE
 	can_go_invisible = FALSE
 	invis_start_time = world.time
@@ -130,6 +131,7 @@
 		LPA.knockdown = FALSE // pounce no longer knocks down
 		LPA.freeze_self = FALSE
 	bound_xeno.stealth = FALSE
+	REMOVE_TRAIT(bound_xeno, TRAIT_CLOAKED, "lurker_cloak")
 
 	// SLIGHTLY hacky because we need to maintain lots of other state on the lurker
 	// whenever invisibility is on/off CD and when it's active.
@@ -166,8 +168,8 @@
 		return
 
 	var/mob/living/carbon/human/bumped_into = movable_atom
-	if(bumped_into.alpha < 100) //ignore invisible scouts and preds
+	if(HAS_TRAIT(bumped_into, TRAIT_CLOAKED)) //ignore invisible scouts and preds
 		return
-	
+
 	to_chat(bound_xeno, SPAN_XENOHIGHDANGER("You bumped into someone and lost your invisibility!"))
 	lurker_invisibility_action.invisibility_off()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -148,10 +148,15 @@
 	if(max_distance) view_dist = max_distance
 	for(var/mob/M as anything in viewers(view_dist, src))
 		var/msg = message
-		if(self_message && M==src)
+		if(self_message && M == src)
 			msg = self_message
 			if(flags & CHAT_TYPE_TARGETS_ME)
 				flags = CHAT_TYPE_BEING_HIT
+
+		else if((M != src) && HAS_TRAIT(src, TRAIT_CLOAKED))
+			debug_msg("cloaked hid message")
+			continue
+
 		M.show_message( msg, SHOW_MESSAGE_VISIBLE, blind_message, SHOW_MESSAGE_AUDIBLE, flags)
 		CHECK_TICK
 
@@ -186,6 +191,8 @@
 	var/view_dist = 7
 	if(max_distance) view_dist = max_distance
 	for(var/mob/M as anything in viewers(view_dist, src))
+		if(HAS_TRAIT(src, TRAIT_CLOAKED))
+			continue
 		M.show_message(message, SHOW_MESSAGE_VISIBLE, blind_message, SHOW_MESSAGE_AUDIBLE, message_flags)
 
 // Show a message to all mobs in earshot of this atom

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -187,12 +187,14 @@
 // message is output to anyone who can see, e.g. "The [src] does something!"
 // blind_message (optional) is what blind people will hear e.g. "You hear something!"
 /atom/proc/visible_message(message, blind_message, max_distance, message_flags = CHAT_TYPE_OTHER)
+	if(HAS_TRAIT(src, TRAIT_CLOAKED))
+		return FALSE
 	var/view_dist = 7
-	if(max_distance) view_dist = max_distance
+	if(max_distance)
+		view_dist = max_distance
 	for(var/mob/M as anything in viewers(view_dist, src))
-		if(HAS_TRAIT(src, TRAIT_CLOAKED))
-			continue
 		M.show_message(message, SHOW_MESSAGE_VISIBLE, blind_message, SHOW_MESSAGE_AUDIBLE, message_flags)
+	return TRUE
 
 // Show a message to all mobs in earshot of this atom
 // Use for objects performing only audible actions

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -154,7 +154,6 @@
 				flags = CHAT_TYPE_BEING_HIT
 
 		else if((M != src) && HAS_TRAIT(src, TRAIT_CLOAKED))
-			debug_msg("cloaked hid message")
 			continue
 
 		M.show_message( msg, SHOW_MESSAGE_VISIBLE, blind_message, SHOW_MESSAGE_AUDIBLE, flags)


### PR DESCRIPTION

# About the pull request
Pretty much the title. Visible messages (visible_message proc) don't give off messages to others if the origin is cloaked.

I'm a bit leery of doing this on `visible_message` so this is gonna need testing first.

Makes checking for cloaking better, adding a trait on cloak instead of checking for user alpha

# Explain why it's good for the game
Being able to see things like "Unknown peers through the laser designator" while they're invisible is a pretty large tell despite you not having seen them.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Works

</details>


# Changelog
:cl:
balance: Cloaked mobs no longer give off visible messages
/:cl:
