### PR TITLE
[Balance] Use skill tier duration multipliers for non-master engineers

### DIFF
--- a/code/modules/cm_marines/smartgun_mount.dm
+++ b/code/modules/cm_marines/smartgun_mount.dm
@@ -379,9 +379,6 @@
 			to_chat(user, "You're securing the M56D into place...")
 
 			var/disassemble_time = 30
-			if(skillcheck(user, SKILL_ENGINEER, SKILL_ENGINEER_TRAINED))
-				disassemble_time = 5
-
 			if(do_after(user, disassemble_time * user.get_skill_duration_multiplier(SKILL_ENGINEER), INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD))
 				playsound(src.loc, 'sound/items/Deconstruct.ogg', 25, 1)
 				user.visible_message(SPAN_NOTICE("[user] screws the M56D into the mount."),SPAN_NOTICE("You finalize the M56D heavy machine gun."))

--- a/code/modules/cm_marines/smartgun_mount.dm
+++ b/code/modules/cm_marines/smartgun_mount.dm
@@ -571,9 +571,6 @@
 			to_chat(user, "You begin disassembling [src]...")
 
 			var/disassemble_time = 30
-			if(skillcheck(user, SKILL_ENGINEER, SKILL_ENGINEER_TRAINED))
-				disassemble_time = 5
-
 			if(do_after(user, disassemble_time * user.get_skill_duration_multiplier(SKILL_ENGINEER), INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD))
 				user.visible_message(SPAN_NOTICE(" [user] disassembles [src]! "),SPAN_NOTICE(" You disassemble [src]!"))
 				playsound(src.loc, 'sound/items/Screwdriver.ogg', 25, 1)

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -410,6 +410,10 @@ var/global/list/limb_types_by_name = list(
 		if(SKILL_ENGINEER)
 			if(skillcheck(src, SKILL_ENGINEER, SKILL_ENGINEER_MASTER))
 				return DURATION_MULTIPLIER_TIER_3
+			else if(skillcheck(src, SKILL_ENGINEER, SKILL_ENGINEER_ENGI))
+				return DURATION_MULTIPLIER_TIER_2
+			else if(skillcheck(src, SKILL_ENGINEER, SKILL_ENGINEER_TRAINED))
+				return DURATION_MULTIPLIER_TIER_1
 // Construction
 		if(SKILL_CONSTRUCTION)
 			if(skillcheck(src, SKILL_CONSTRUCTION, SKILL_CONSTRUCTION_MASTER))


### PR DESCRIPTION
# About the pull request

Skill system and duration multipliers exist.

Other than master engineers, it didn't affect anybody with lower skill tiers ( like squad engies and trained engies  )

What gets changed for non-master engineers ( squad engies and trained engies):
- Floodlights can be fixed faster
- Fusion engine steps fixed faster
- Geothermal engines steps fixed faster
- Defusing a nuke faster
- Welding cameras faster
- Telecomms repaired faster
- Un/Loading dropship ammo
- Un/Loading dropship equipment
- Recycling dropship equipment
- Repairing and unfolding m2c
- Reloading Sentries
- Repairing, assembling, disassembly, reloading m56d
- Fixing sensor towers
- Disassembling SMES
- Install / uninstall APC / tank

However, I do remove a double skill reduced timing for M56d. It was disassembly 30 ( ticks?) where trained is 5 (ticks?) and master engineers can reduce that to 5 * .25 = 1.25 (ticks? ).

I left it as 30 ticks and based on duration skill multiplier tiers.
Master: 30 * .25 = 7.50 (ticks)
Squad Engies: 30 * .5 = 15 (ticks)
Trained Engies: 30 * .75 = 22.5 ( ticks )
Untrained Engies: 30 (ticks)

Needs to be tested.

# Explain why it's good for the game

There's a skill system and only master engineers seem to benefit from faster anything in terms of repairs or anything when I feel any engie with some skill should be able to affect the duration it takes to do something like repairs.

Shouldn't affect balance too much, but some timings may need to be changed if they get too wonky ( repairing cades super speed but synth already should be repairing these fairly qucikly )

Also, feels like people are using the m56d offensively and m2c defensively lol.

WIth this, m2c should be the definitive offensive weapon with deploy and undeploy times while m56d should be setup in areas where you have a bit of time to setup.

# Changelog

:cl:
balance: All trained+ engineer skill levels affect duration now.
balance: Removed double skill duration multiplier for m56d's.
/:cl:

