### PR TITLE
HEFA Knights spawn with their armor + small buff

### DIFF
--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -1324,6 +1324,10 @@ GLOBAL_LIST_INIT(allowed_helmet_items, list(
 	var/active = FALSE
 	var/det_time = 40
 
+/obj/item/clothing/head/helmet/marine/specialist/hefa/Initialize(mapload, list/new_protection)
+	. = ..()
+	pockets.bypass_w_limit = list(/obj/item/explosive/grenade/high_explosive/frag)
+
 /obj/item/clothing/head/helmet/marine/specialist/hefa/proc/apply_explosion_overlay()
 	var/obj/effect/overlay/O = new /obj/effect/overlay(loc)
 	O.name = "grenade"

--- a/code/modules/clothing/suits/marine_armor.dm
+++ b/code/modules/clothing/suits/marine_armor.dm
@@ -1598,6 +1598,7 @@
 	specialty = "HEFA Knight"
 	icon_state = "hefadier"
 	flags_atom = NO_NAME_OVERRIDE|NO_SNOW_TYPE
+	flags_item = NO_CRYO_STORE
 	flags_marine_armor = ARMOR_LAMP_OVERLAY
 	armor_bullet = CLOTHING_ARMOR_VERYHIGH
 	armor_melee = CLOTHING_ARMOR_VERYHIGH

--- a/code/modules/gear_presets/fun.dm
+++ b/code/modules/gear_presets/fun.dm
@@ -185,7 +185,7 @@
 	new_human.equip_to_slot_or_del(M, WEAR_BODY)
 	var/shoes_success = new_human.equip_to_slot_or_del(new /obj/item/clothing/shoes/marine/knife(new_human), WEAR_FEET)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/gloves/combat(new_human), WEAR_HANDS)
-	new_human.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/marine/specialist/hefa(new_human), WEAR_HEAD)
+	var/helmet_success = new_human.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/marine/specialist/hefa(new_human), WEAR_HEAD)
 	new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/firstaid/ert(new_human), WEAR_L_STORE)
 	var/jacket_success = new_human.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/marine/M3G/hefa(new_human), WEAR_JACKET)
 	var/satchel_success = new_human.equip_to_slot_or_del(new /obj/item/storage/backpack/marine/satchel(new_human), WEAR_BACK)
@@ -231,6 +231,12 @@
 	// Webbing
 	for(var/i in 1 to W.hold.storage_slots)
 		new_human.equip_to_slot_or_del(new /obj/item/explosive/grenade/high_explosive/frag(new_human.back), WEAR_IN_ACCESSORY)
+
+	// Helmet
+	if(helmet_success)
+		var/obj/item/clothing/head/helmet/marine/hefa_helmet = new_human.head
+		for(var/i in 1 to hefa_helmet.pockets.storage_slots)
+			new_human.equip_to_slot_or_del(new /obj/item/explosive/grenade/high_explosive/frag(new_human.head), WEAR_IN_HELMET)
 
 /datum/equipment_preset/fun/santa
 	name = "Fun - Santa"


### PR DESCRIPTION

# About the pull request
HEFA Knights now spawn with their armor, as intended.

Allows HEFA knights to put nades in their helmets, and spawns 2 more in there.

# Explain why it's good for the game
Bugs bad

There's free real estate unused in the helmet slot, so might as well use it.

# Changelog
:cl:
fix: HEFA Knights now spawn with their armor again
balance: HEFA Knights now spawn with 2 HEFA in their helmets
/:cl:
