### PR TITLE
Removes some PMC gear

### DIFF
--- a/code/modules/gear_presets/_select_equipment.dm
+++ b/code/modules/gear_presets/_select_equipment.dm
@@ -430,7 +430,6 @@
 		/obj/item/tool/hatchet = null,
 		/obj/item/tool/hatchet = null,
 		/obj/item/storage/box/MRE = null,
-		/obj/item/clothing/mask/gas/pmc = null,
 		/obj/item/clothing/glasses/night/m42_night_goggles/upp = null,
 		/obj/item/storage/box/handcuffs = null,
 		/obj/item/storage/pill_bottle/happy = null,

--- a/maps/map_files/BigRed/standalone/crashlanding-offices.dmm
+++ b/maps/map_files/BigRed/standalone/crashlanding-offices.dmm
@@ -1453,15 +1453,6 @@
 	icon_state = "rasputin3"
 	},
 /area/bigredv2/outside/office_complex)
-"od" = (
-/obj/structure/bed/chair/dropship/passenger{
-	dir = 4
-	},
-/obj/item/clothing/gloves/marine/veteran/pmc,
-/turf/open/shuttle/dropship{
-	icon_state = "rasputin15"
-	},
-/area/bigredv2/outside/office_complex)
 "oF" = (
 /obj/structure/bed/chair/dropship/passenger{
 	dir = 4
@@ -1622,15 +1613,6 @@
 	dir = 8
 	},
 /obj/effect/landmark/survivor_spawner/bigred_crashed_cl,
-/turf/open/shuttle/dropship{
-	icon_state = "rasputin15"
-	},
-/area/bigredv2/outside/office_complex)
-"Ra" = (
-/obj/structure/bed/chair/dropship/passenger{
-	dir = 8
-	},
-/obj/item/clothing/gloves/marine/veteran/pmc,
 /turf/open/shuttle/dropship{
 	icon_state = "rasputin15"
 	},
@@ -1939,7 +1921,7 @@ dP
 aV
 id
 yS
-od
+yS
 cE
 cM
 cM
@@ -2092,7 +2074,7 @@ aN
 bv
 dL
 bm
-od
+yS
 yS
 yS
 cu
@@ -2155,7 +2137,7 @@ bv
 aV
 fv
 dA
-Ra
+bp
 cF
 cN
 cN

--- a/maps/map_files/Ice_Colony_v3/Shivas_Snowball.dmm
+++ b/maps/map_files/Ice_Colony_v3/Shivas_Snowball.dmm
@@ -18272,13 +18272,6 @@
 /obj/item/tool/wrench,
 /turf/open/auto_turf/snow/layer1,
 /area/shiva/interior/colony/central)
-"nhh" = (
-/obj/item/clothing/gloves/marine/veteran/insulated,
-/turf/open/floor/shiva{
-	dir = 1;
-	icon_state = "yellow"
-	},
-/area/shiva/interior/colony/deck)
 "nhl" = (
 /turf/open/floor/shiva{
 	dir = 5;
@@ -58881,7 +58874,7 @@ jVI
 kQF
 kzE
 acT
-nhh
+qOD
 kTZ
 iLS
 mms

--- a/maps/map_files/LV522_Chances_Claim/LV522_Chances_Claim.dmm
+++ b/maps/map_files/LV522_Chances_Claim/LV522_Chances_Claim.dmm
@@ -18862,12 +18862,6 @@
 	name = "Display synthetic"
 	},
 /obj/structure/window/reinforced,
-/obj/item/clothing/under/marine/veteran/pmc,
-/obj/item/clothing/mask/gas/pmc,
-/obj/item/clothing/head/helmet/marine/veteran/pmc/leader{
-	layer = 3.1;
-	pixel_y = 10
-	},
 /obj/structure/sign/safety/synth_storage{
 	pixel_x = 23;
 	pixel_y = 29

--- a/maps/map_files/LV624/LV624.dmm
+++ b/maps/map_files/LV624/LV624.dmm
@@ -15394,9 +15394,6 @@
 /area/lv624/ground/barrens/south_eastern_jungle_barrens)
 "iKp" = (
 /obj/structure/surface/rack,
-/obj/item/clothing/mask/gas/pmc/leader,
-/obj/item/clothing/under/marine/veteran/pmc,
-/obj/item/clothing/gloves/marine/veteran/pmc,
 /turf/open/shuttle{
 	icon_state = "floor4"
 	},

--- a/maps/map_files/LV624/cargospecial/cargospecial3_gear.dmm
+++ b/maps/map_files/LV624/cargospecial/cargospecial3_gear.dmm
@@ -1,11 +1,6 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /obj/structure/surface/rack,
-/obj/item/clothing/gloves/marine/veteran/pmc{
-	pixel_x = 2;
-	pixel_y = -3
-	},
-/obj/item/clothing/gloves/marine/veteran/pmc,
 /turf/open/floor{
 	dir = 8;
 	icon_state = "vault"

--- a/maps/map_files/LV624/crashedship/10.digsite.dmm
+++ b/maps/map_files/LV624/crashedship/10.digsite.dmm
@@ -219,15 +219,6 @@
 /obj/effect/alien/weeds/node,
 /turf/open/gm/dirt,
 /area/lv624/ground/barrens/north_east_barrens)
-"FG" = (
-/obj/structure/bed/chair{
-	dir = 8
-	},
-/obj/item/clothing/gloves/marine/veteran/pmc,
-/turf/open/shuttle{
-	icon_state = "floor4"
-	},
-/area/lv624/lazarus/crashed_ship_containers)
 "Gs" = (
 /obj/structure/girder,
 /turf/closed/shuttle{
@@ -503,7 +494,7 @@ xg
 zH
 cv
 uw
-FG
+cv
 Xk
 Gs
 Xk

--- a/maps/map_files/New_Varadero/New_Varadero.dmm
+++ b/maps/map_files/New_Varadero/New_Varadero.dmm
@@ -2261,13 +2261,6 @@
 	default_name = "shallow ocean"
 	},
 /area/varadero/exterior/pontoon_beach)
-"bvS" = (
-/obj/structure/bedsheetbin,
-/obj/item/clothing/gloves/marine/veteran/pmc,
-/turf/open/floor/shiva{
-	icon_state = "floor3"
-	},
-/area/varadero/interior/laundry)
 "bwz" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/shiva{
@@ -5661,7 +5654,6 @@
 /area/varadero/interior/hall_N)
 "dKm" = (
 /obj/structure/closet/secure_closet/personal/patient,
-/obj/item/clothing/gloves/marine/veteran/pmc,
 /turf/open/floor/shiva{
 	icon_state = "multi_tiles"
 	},
@@ -16173,7 +16165,6 @@
 /obj/item/bedsheet/hos{
 	layer = 3.1
 	},
-/obj/item/clothing/gloves/marine/veteran/insulated,
 /turf/open/floor/wood,
 /area/varadero/interior/bunks)
 "kyh" = (
@@ -50586,7 +50577,7 @@ tvv
 pRP
 sBX
 gmE
-bvS
+nfv
 nfv
 aFh
 uNq

--- a/maps/map_files/Sorokyne_Strata/Sorokyne_Strata.dmm
+++ b/maps/map_files/Sorokyne_Strata/Sorokyne_Strata.dmm
@@ -4669,13 +4669,6 @@
 	},
 /turf/open/auto_turf/snow/brown_base/layer0,
 /area/strata/ag/interior/restricted/devroom)
-"anO" = (
-/obj/structure/bedsheetbin,
-/obj/item/clothing/gloves/marine/veteran/pmc,
-/turf/open/floor/strata{
-	icon_state = "blue1"
-	},
-/area/strata/ag/interior/outpost/canteen/personal_storage)
 "anP" = (
 /obj/structure/bedsheetbin,
 /obj/item/device/binoculars/range,
@@ -74324,7 +74317,7 @@ akE
 alo
 bPZ
 alo
-anO
+bmX
 alU
 apG
 aqK


### PR DESCRIPTION

# About the pull request

These should not be in areas that can be rushed by the same three people every round.

# Explain why it's good for the game

Identifying PMC gear (specifically gloves, mask) is a huge pain as a xeno and the difference it makes in survivability is huge. Really some of these items just need toned down in general but these in specific gotta go.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
balance: Removed some PMC gear on maps
/:cl:
