### PR TITLE
Disables Shivas Snowball

### DIFF
--- a/map_config/maps.txt
+++ b/map_config/maps.txt
@@ -44,6 +44,8 @@ map ice_colony_v2
 endmap
 
 map shivas_snowball
+	voteweight 0
+	disabled
 endmap
 
 map kutjevo


### PR DESCRIPTION
# About the pull request

This PR disables Shivas Snowball.

# Explain why it's good for the game

Shivas Snowball was created for a different future of the game that never came to pass. It's an interesting map and I've had fun with it over the years. Sadly, with the way objectives are moving forward a map with opposite LZs does not work.

Shivas Snowball is free to come back when:
LZs are on the same side of the map or a singular LZ
Greater hive options outside of "lanes" that end up east-west or north-south fighting
Tightens up middle of the map "flow" which will be subjective
Removal of out of place items like base SS13 uniforms


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
del: Disables Shivas Snowball
/:cl:
