### PR TITLE
Hivelord Mini-Buff

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/Hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Hivelord.dm
@@ -18,7 +18,7 @@
 	caste_desc = "A builder of really big hives."
 	deevolves_to = list(XENO_CASTE_DRONE)
 	can_hold_facehuggers = 1
-	can_hold_eggs = CAN_HOLD_TWO_HANDS
+	can_hold_eggs = CAN_HOLD_ONE_HAND
 	acid_level = 2
 	weed_level = WEED_LEVEL_STANDARD
 	build_time_mult = BUILD_TIME_MULT_HIVELORD


### PR DESCRIPTION
# About the pull request

Hivelord can now carry an egg in each hand instead of one single egg.

# Explain why it's good for the game

It's just a little QOL thing for Hivelords that make it easier to place more eggs in the hive when it is being built.

# Testing Photographs and Procedure

![6e66f53cc62026742662d3535aa95f9f](https://github.com/cmss13-devs/cmss13/assets/31109792/cc7ce13a-4900-41e5-9346-6d25f007ddf5)

# Changelog
:cl:
qol: Hivelord can now hold two eggs, one per hand.
/:cl: