### PR TITLE
Working Joe Respawns

### DIFF
--- a/code/__DEFINES/ARES.dm
+++ b/code/__DEFINES/ARES.dm
@@ -70,3 +70,6 @@
 /// Cooldowns
 #define COOLDOWN_ARES_SENSOR 60 SECONDS
 #define COOLDOWN_ARES_ACCESS_CONTROL 20 SECONDS
+
+/// Time until someone can respawn as Working Joe
+#define JOE_JOIN_DEAD_TIME = 10 MINUTES

--- a/code/__DEFINES/ARES.dm
+++ b/code/__DEFINES/ARES.dm
@@ -72,4 +72,4 @@
 #define COOLDOWN_ARES_ACCESS_CONTROL 20 SECONDS
 
 /// Time until someone can respawn as Working Joe
-#define JOE_JOIN_DEAD_TIME = 10 MINUTES
+#define JOE_JOIN_DEAD_TIME (10 MINUTES)

--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -966,9 +966,6 @@ Additional game mode variables.
 			return
 
 	var/deathtime = world.time - joe_candidate.timeofdeath
-	if(isnewplayer(joe_candidate))
-		message_admins("This triggered.")
-		deathtime = JOE_JOIN_DEAD_TIME //so new players don't have to wait to latejoin as Working Joe in the round's first 10 mins.
 	if(deathtime < JOE_JOIN_DEAD_TIME && check_client_rights(joe_candidate.client, R_ADMIN, FALSE) && !MODE_HAS_TOGGLEABLE_FLAG(MODE_BYPASS_JOE))
 		to_chat(joe_candidate, SPAN_WARNING("You have been dead for [DisplayTimeText(deathtime)]. You need to wait [DisplayTimeText(JOE_JOIN_DEAD_TIME - deathtime)] before rejoining as a Working Joe!"))
 		return FALSE

--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -966,7 +966,7 @@ Additional game mode variables.
 			return
 
 	var/deathtime = world.time - joe_candidate.timeofdeath
-	if(deathtime < JOE_JOIN_DEAD_TIME && !check_client_rights(joe_candidate.client, R_ADMIN, FALSE) && !MODE_HAS_TOGGLEABLE_FLAG(MODE_BYPASS_JOE))
+	if(deathtime < JOE_JOIN_DEAD_TIME && !MODE_HAS_TOGGLEABLE_FLAG(MODE_BYPASS_JOE))
 		to_chat(joe_candidate, SPAN_WARNING("You have been dead for [DisplayTimeText(deathtime)]. You need to wait [DisplayTimeText(JOE_JOIN_DEAD_TIME - deathtime)] before rejoining as a Working Joe!"))
 		return FALSE
 

--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -966,9 +966,10 @@ Additional game mode variables.
 			return
 
 	var/deathtime = world.time - joe_candidate.timeofdeath
-	if(istype(joe_candidate, /mob/new_player))
+	if(isnewplayer(joe_candidate))
+		message_admins("This triggered.")
 		deathtime = JOE_JOIN_DEAD_TIME //so new players don't have to wait to latejoin as Working Joe in the round's first 10 mins.
-	if(deathtime < JOE_JOIN_DEAD_TIME && !check_client_rights(joe_candidate.client, R_ADMIN, FALSE) && !MODE_HAS_TOGGLEABLE_FLAG(MODE_BYPASS_JOE))
+	if(deathtime < JOE_JOIN_DEAD_TIME && check_client_rights(joe_candidate.client, R_ADMIN, FALSE) && !MODE_HAS_TOGGLEABLE_FLAG(MODE_BYPASS_JOE))
 		to_chat(joe_candidate, SPAN_WARNING("You have been dead for [DisplayTimeText(deathtime)]. You need to wait [DisplayTimeText(JOE_JOIN_DEAD_TIME - deathtime)] before rejoining as a Working Joe!"))
 		return FALSE
 

--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -967,9 +967,9 @@ Additional game mode variables.
 
 	var/deathtime = world.time - joe_candidate.timeofdeath
 	if(istype(joe_candidate, /mob/new_player))
-		deathtime = JOE_DEAD_TIME //so new players don't have to wait to latejoin as Working Joe in the round's first 10 mins.
-	if(deathtime < JOE_DEAD_TIME && !check_client_rights(joe_candidate.client, R_ADMIN, FALSE) && !MODE_HAS_TOGGLEABLE_FLAG(MODE_BYPASS_JOE))
-		to_chat(joe_candidate, SPAN_WARNING("You have been dead for [DisplayTimeText(deathtime)]. You need to wait [DisplayTimeText(JOE_DEAD_TIME - deathtime)] before rejoining as a Working Joe!"))
+		deathtime = JOE_JOIN_DEAD_TIME //so new players don't have to wait to latejoin as Working Joe in the round's first 10 mins.
+	if(deathtime < JOE_JOIN_DEAD_TIME && !check_client_rights(joe_candidate.client, R_ADMIN, FALSE) && !MODE_HAS_TOGGLEABLE_FLAG(MODE_BYPASS_JOE))
+		to_chat(joe_candidate, SPAN_WARNING("You have been dead for [DisplayTimeText(deathtime)]. You need to wait [DisplayTimeText(JOE_JOIN_DEAD_TIME - deathtime)] before rejoining as a Working Joe!"))
 		return FALSE
 
 	if(!enter_allowed && !MODE_HAS_TOGGLEABLE_FLAG(MODE_BYPASS_JOE))

--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -957,11 +957,6 @@ Additional game mode variables.
 			to_chat(joe_candidate, SPAN_WARNING("You are not whitelisted! You may apply on the forums to be whitelisted as a synth."))
 		return
 
-	if((joe_candidate.ckey in joes) && !MODE_HAS_TOGGLEABLE_FLAG(MODE_BYPASS_JOE))
-		if(show_warning)
-			to_chat(joe_candidate, SPAN_WARNING("You already were a Working Joe this round!"))
-		return
-
 	// council doesn't count towards this conditional.
 	if(joe_job.get_whitelist_status(RoleAuthority.roles_whitelist, joe_candidate.client) == WHITELIST_NORMAL)
 		var/joe_max = joe_job.total_positions
@@ -969,6 +964,13 @@ Additional game mode variables.
 			if(show_warning)
 				to_chat(joe_candidate, SPAN_WARNING("Only [joe_max] Working Joes may spawn per round."))
 			return
+
+	var/deathtime = world.time - joe_candidate.timeofdeath
+	if(istype(joe_candidate, /mob/new_player))
+		deathtime = JOE_DEAD_TIME //so new players don't have to wait to latejoin as Working Joe in the round's first 10 mins.
+	if(deathtime < JOE_DEAD_TIME && !check_client_rights(joe_candidate.client, R_ADMIN, FALSE) && !MODE_HAS_TOGGLEABLE_FLAG(MODE_BYPASS_JOE))
+		to_chat(joe_candidate, SPAN_WARNING("You have been dead for [DisplayTimeText(deathtime)]. You need to wait [DisplayTimeText(JOE_DEAD_TIME - deathtime)] before rejoining as a Working Joe!"))
+		return FALSE
 
 	if(!enter_allowed && !MODE_HAS_TOGGLEABLE_FLAG(MODE_BYPASS_JOE))
 		if(show_warning)

--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -966,7 +966,7 @@ Additional game mode variables.
 			return
 
 	var/deathtime = world.time - joe_candidate.timeofdeath
-	if(deathtime < JOE_JOIN_DEAD_TIME && check_client_rights(joe_candidate.client, R_ADMIN, FALSE) && !MODE_HAS_TOGGLEABLE_FLAG(MODE_BYPASS_JOE))
+	if(deathtime < JOE_JOIN_DEAD_TIME && !check_client_rights(joe_candidate.client, R_ADMIN, FALSE) && !MODE_HAS_TOGGLEABLE_FLAG(MODE_BYPASS_JOE))
 		to_chat(joe_candidate, SPAN_WARNING("You have been dead for [DisplayTimeText(deathtime)]. You need to wait [DisplayTimeText(JOE_JOIN_DEAD_TIME - deathtime)] before rejoining as a Working Joe!"))
 		return FALSE
 

--- a/code/game/jobs/job/civilians/support/working_joe.dm
+++ b/code/game/jobs/job/civilians/support/working_joe.dm
@@ -1,6 +1,10 @@
 #define STANDARD_VARIANT "Working Joe"
 #define HAZMAT_VARIANT "Hazmat Joe"
 
+/// Time until someone can respawn as Working Joe
+
+#define JOE_DEAD_TIME = 10 MINUTES
+
 /datum/job/civilian/working_joe
 	title = JOB_WORKING_JOE
 	total_positions = 6

--- a/code/game/jobs/job/civilians/support/working_joe.dm
+++ b/code/game/jobs/job/civilians/support/working_joe.dm
@@ -1,10 +1,6 @@
 #define STANDARD_VARIANT "Working Joe"
 #define HAZMAT_VARIANT "Hazmat Joe"
 
-/// Time until someone can respawn as Working Joe
-
-#define JOE_DEAD_TIME = 10 MINUTES
-
 /datum/job/civilian/working_joe
 	title = JOB_WORKING_JOE
 	total_positions = 6


### PR DESCRIPTION

# About the pull request

Working Joes can respawn after 10 minutes

# Explain why it's good for the game

The restriction on Working Joes being unable to play as Working Joe again (for example if they cryo) is unnecessary. This change allows Joes to spawn after 10 minutes since death (still locked from respawns as before during hijack)

# Changelog
:cl:
add: Working Joes can now respawn after 10 minutes
/:cl:
