### PR TITLE
Gives survivors a bank account.

### DIFF
--- a/code/game/jobs/job/civilians/other/survivors.dm
+++ b/code/game/jobs/job/civilians/other/survivors.dm
@@ -20,15 +20,15 @@
 	addtimer(CALLBACK(src, PROC_REF(announce_entry_message), survivor, generated_account), 2 SECONDS)
 	return
 
-/datum/job/civilian/survivor/announce_entry_message(mob/living/carbon/human/H, datum/money_account/M, whitelist_status) //The actual message that is displayed to the mob when they enter the game as a new player.
-	if(H && H.loc && H.client)
+/datum/job/civilian/survivor/announce_entry_message(mob/living/carbon/human/survivor, datum/money_account/account, whitelist_status) //The actual message that is displayed to the mob when they enter the game as a new player.
+	if(survivor && survivor.loc && survivor.client)
 		//Document syntax cannot have tabs for proper formatting.
 		var/entrydisplay = " \
 			[SPAN_ROLE_BODY("|______________________|")] \n\
-			[SPAN_ROLE_BODY("[generate_entry_message(H)]<br>[M ? "Your account number is: <b>[M.account_number]</b>. Your account pin is: <b>[M.remote_access_pin]</b>." : "You do not have a bank account."]")] \n\
+			[SPAN_ROLE_BODY("[generate_entry_message(survivor)]<br>[M ? "Your account number is: <b>[account.account_number]</b>. Your account pin is: <b>[account.remote_access_pin]</b>." : "You do not have a bank account."]")] \n\
 			[SPAN_ROLE_BODY("|______________________|")] \
 		"
-		to_chat_spaced(H, html = entrydisplay)
+		to_chat_spaced(survivor, html = entrydisplay)
 
 /datum/job/civilian/survivor/spawn_in_player(mob/new_player/NP)
 	. = ..()

--- a/code/game/jobs/job/civilians/other/survivors.dm
+++ b/code/game/jobs/job/civilians/other/survivors.dm
@@ -21,7 +21,7 @@
 	return
 
 /datum/job/civilian/survivor/announce_entry_message(mob/living/carbon/human/survivor, datum/money_account/account, whitelist_status) //The actual message that is displayed to the mob when they enter the game as a new player.
-	if(survivor && survivor.loc && survivor.client)
+	if(survivor?.loc && survivor?.client)
 		//Document syntax cannot have tabs for proper formatting.
 		var/entrydisplay = " \
 			[SPAN_ROLE_BODY("|______________________|")] \n\

--- a/code/game/jobs/job/civilians/other/survivors.dm
+++ b/code/game/jobs/job/civilians/other/survivors.dm
@@ -21,7 +21,7 @@
 	return
 
 /datum/job/civilian/survivor/announce_entry_message(mob/living/carbon/human/survivor, datum/money_account/account, whitelist_status) //The actual message that is displayed to the mob when they enter the game as a new player.
-	if(survivor?.loc && survivor?.client)
+	if(survivor?.loc && survivor.client)
 		//Document syntax cannot have tabs for proper formatting.
 		var/entrydisplay = " \
 			[SPAN_ROLE_BODY("|______________________|")] \n\

--- a/code/game/jobs/job/civilians/other/survivors.dm
+++ b/code/game/jobs/job/civilians/other/survivors.dm
@@ -25,7 +25,7 @@
 		//Document syntax cannot have tabs for proper formatting.
 		var/entrydisplay = " \
 			[SPAN_ROLE_BODY("|______________________|")] \n\
-			[SPAN_ROLE_BODY("[generate_entry_message(survivor)]<br>[M ? "Your account number is: <b>[account.account_number]</b>. Your account pin is: <b>[account.remote_access_pin]</b>." : "You do not have a bank account."]")] \n\
+			[SPAN_ROLE_BODY("[generate_entry_message(survivor)]<br>[account ? "Your account number is: <b>[account.account_number]</b>. Your account pin is: <b>[account.remote_access_pin]</b>." : "You do not have a bank account."]")] \n\
 			[SPAN_ROLE_BODY("|______________________|")] \
 		"
 		to_chat_spaced(survivor, html = entrydisplay)

--- a/code/game/jobs/job/civilians/other/survivors.dm
+++ b/code/game/jobs/job/civilians/other/survivors.dm
@@ -15,8 +15,20 @@
 	spawn_positions = Clamp((round(count * SURVIVOR_TO_TOTAL_SPAWN_RATIO)), 2, 8)
 	total_positions = spawn_positions
 
-/datum/job/civilian/survivor/equip_job(mob/living/M)
+/datum/job/civilian/survivor/equip_job(mob/living/survivor)
+	var/generated_account = generate_money_account(survivor)
+	addtimer(CALLBACK(src, PROC_REF(announce_entry_message), survivor, generated_account), 2 SECONDS)
 	return
+
+/datum/job/civilian/survivor/announce_entry_message(mob/living/carbon/human/H, datum/money_account/M, whitelist_status) //The actual message that is displayed to the mob when they enter the game as a new player.
+	if(H && H.loc && H.client)
+		//Document syntax cannot have tabs for proper formatting.
+		var/entrydisplay = " \
+			[SPAN_ROLE_BODY("|______________________|")] \n\
+			[SPAN_ROLE_BODY("[generate_entry_message(H)]<br>[M ? "Your account number is: <b>[M.account_number]</b>. Your account pin is: <b>[M.remote_access_pin]</b>." : "You do not have a bank account."]")] \n\
+			[SPAN_ROLE_BODY("|______________________|")] \
+		"
+		to_chat_spaced(H, html = entrydisplay)
 
 /datum/job/civilian/survivor/spawn_in_player(mob/new_player/NP)
 	. = ..()


### PR DESCRIPTION

# About the pull request
Since the update where vendors require a bank account to function survivors really struggle to acquire food on the colony they supposedly live. This should let them use bank accounts again.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Food is good. Money is good. Food and Money is great.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Gives survivors bank accounts.
/:cl:
