### PR TITLE
fixes overwrite mark prompt

### DIFF
--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -530,10 +530,10 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 			return
 		to_chat(usr, SPAN_WARNING("This ticket has already been marked by [marked_admin]."))
 		var/unmark_option = tgui_alert(usr, "This message has been marked by [marked_admin]. Do you want to override?", "Marked Ticket", list("Overwrite Mark", "Unmark", "Cancel"))
-		if(unmark_option == "Cancel")
-			return
 		if(unmark_option == "Unmark")
 			unmark_ticket()
+			return
+		if(unmark_option != "Overwrite Mark")
 			return
 
 	var/key_name = key_name_admin(usr)


### PR DESCRIPTION

# About the pull request
As title says. Allows staff to press the X button without it overwriting the mark.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Fixes the overwrite mark prompt on admin tickets not respecting closing the confirmation prompt.
/:cl:
