### PR TITLE
Adds a Commissary to the Hangar

### DIFF
--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -30090,6 +30090,13 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/starboard_umbilical)
+"dir" = (
+/obj/structure/pipes/standard/manifold/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hallways/hangar)
 "diz" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/dropshiprear/lifeboat/blastdoor{
 	id_tag = "Boat1-D4";
@@ -34011,7 +34018,6 @@
 /area/almayer/engineering/upper_engineering/port)
 "eNx" = (
 /obj/structure/machinery/vending/cigarette,
-/obj/effect/decal/cleanable/ash,
 /turf/open/floor/wood,
 /area/almayer/hull/lower_hull/l_f_s)
 "eNI" = (
@@ -38799,6 +38805,15 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/upper_hull/u_f_p)
+"gSC" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hallways/hangar)
 "gSV" = (
 /obj/structure/machinery/camera/autoname/almayer{
 	dir = 4;
@@ -40654,14 +40669,14 @@
 	},
 /area/almayer/hallways/aft_hallway)
 "hJz" = (
-/obj/structure/machinery/light/small{
-	dir = 1
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/hull/lower_hull/l_f_s)
+/area/almayer/hallways/hangar)
 "hJJ" = (
 /obj/structure/pipes/standard/manifold/hidden/supply{
 	dir = 4
@@ -44777,6 +44792,13 @@
 	icon_state = "cargo"
 	},
 /area/almayer/hallways/hangar)
+"jzh" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/open/floor/almayer,
+/area/almayer/hallways/hangar)
 "jzD" = (
 /obj/structure/machinery/door/poddoor/almayer/locked{
 	icon_state = "almayer_pdoor";
@@ -48090,12 +48112,13 @@
 	},
 /area/almayer/medical/medical_science)
 "kXJ" = (
-/obj/structure/disposalpipe/junction{
-	dir = 8;
-	icon_state = "pipe-j2"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/hull/lower_hull/l_f_s)
+/turf/open/floor/almayer{
+	icon_state = "dark_sterile"
+	},
+/area/almayer/medical/lower_medical_lobby)
 "kXK" = (
 /obj/structure/machinery/light,
 /turf/open/floor/almayer{
@@ -48952,9 +48975,6 @@
 "lqI" = (
 /obj/structure/bed/chair{
 	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_f_s)
@@ -50633,7 +50653,6 @@
 /obj/structure/machinery/light{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/almayer/hull/lower_hull/l_f_s)
 "mce" = (
@@ -51572,9 +51591,6 @@
 	pixel_x = 8;
 	pixel_y = -32
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -51978,7 +51994,6 @@
 	pixel_y = 32
 	},
 /obj/structure/machinery/vending/coffee,
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/almayer/hull/lower_hull/l_f_s)
 "mIW" = (
@@ -52876,10 +52891,10 @@
 /turf/closed/wall/almayer/reinforced,
 /area/almayer/shipboard/brig/perma)
 "naD" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
 /obj/structure/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
 /turf/open/floor/wood,
 /area/almayer/hull/lower_hull/l_f_s)
 "naQ" = (
@@ -53390,6 +53405,14 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/aft_hallway)
+"nmA" = (
+/obj/structure/pipes/standard/manifold/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hallways/hangar)
 "nmD" = (
 /obj/structure/machinery/light{
 	dir = 1
@@ -55174,14 +55197,12 @@
 	},
 /area/almayer/squads/alpha_bravo_shared)
 "obG" = (
-/obj/effect/landmark/yautja_teleport,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/structure/pipes/standard/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/hull/lower_hull/l_f_s)
+/area/almayer/hallways/hangar)
 "obQ" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -58770,12 +58791,6 @@
 	pixel_y = 7
 	},
 /obj/item/storage/box/lights/mixed,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_f_s)
 "pGT" = (
@@ -61078,7 +61093,11 @@
 	},
 /area/almayer/medical/operating_room_two)
 "qHb" = (
-/obj/structure/disposalpipe/segment,
+/obj/structure/pipes/standard/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/open/floor/wood,
 /area/almayer/hull/lower_hull/l_f_s)
 "qHg" = (
@@ -61743,6 +61762,16 @@
 "qVM" = (
 /turf/closed/wall/almayer,
 /area/almayer/hull/upper_hull/u_m_p)
+"qVN" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "SE-out";
+	pixel_x = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/almayer,
+/area/almayer/hallways/hangar)
 "qVS" = (
 /obj/structure/machinery/door/poddoor/almayer/open{
 	dir = 2;
@@ -62231,6 +62260,9 @@
 "rgy" = (
 /obj/structure/pipes/standard/manifold/hidden/supply{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/hangar)
@@ -62977,9 +63009,6 @@
 	pixel_x = 8;
 	pixel_y = -32
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -63563,6 +63592,9 @@
 	pixel_y = -23;
 	req_one_access_txt = "2;3;12;19"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
 	},
@@ -63586,6 +63618,7 @@
 	name = "\improper Commissary"
 	},
 /obj/structure/pipes/standard/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/almayer/hull/lower_hull/l_f_s)
 "rIO" = (
@@ -68978,12 +69011,12 @@
 	},
 /area/almayer/living/briefing)
 "udr" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /obj/structure/pipes/standard/manifold/hidden/supply{
 	dir = 8
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 4;
+	icon_state = "pipe-j2"
 	},
 /turf/open/floor/almayer{
 	icon_state = "dark_sterile"
@@ -72039,6 +72072,16 @@
 	icon_state = "plate"
 	},
 /area/almayer/hull/upper_hull/u_a_s)
+"voD" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hallways/hangar)
 "voQ" = (
 /obj/structure/machinery/door/airlock/almayer/maint{
 	dir = 1
@@ -78265,9 +78308,15 @@
 /turf/open/floor/almayer,
 /area/almayer/hallways/starboard_hallway)
 "xOC" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 1
+	},
 /obj/structure/disposalpipe/segment,
-/turf/closed/wall/almayer,
-/area/almayer/hull/lower_hull/l_f_s)
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hallways/hangar)
 "xOL" = (
 /obj/structure/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
@@ -97233,10 +97282,10 @@ rMs
 fJg
 vKf
 vKf
-vKf
+qHb
 rII
-baN
-hBF
+obG
+nmA
 aZQ
 baI
 baI
@@ -97429,17 +97478,17 @@ aaa
 aaa
 aaa
 nXP
-pwK
-xOC
+hJp
+uNL
 mIB
 mbQ
-qHb
-qHb
+xfZ
+xfZ
 mbQ
 naD
 kYa
 xyw
-bHB
+hJz
 aZR
 baI
 baI
@@ -97632,7 +97681,7 @@ aaa
 aaa
 aaa
 nXP
-kKG
+mGL
 uNL
 uNL
 uNL
@@ -97642,7 +97691,7 @@ uNL
 uNL
 vpE
 xyw
-bHB
+hJz
 aZO
 baI
 baI
@@ -97845,7 +97894,7 @@ hqs
 jFh
 uNL
 wlb
-bHB
+hJz
 aZP
 baI
 baI
@@ -98038,7 +98087,7 @@ aaa
 aaa
 aaa
 nXP
-kKG
+mGL
 qee
 hJp
 mGL
@@ -98048,7 +98097,7 @@ hJp
 mGL
 mBb
 wqh
-bHB
+hJz
 aZQ
 baI
 baI
@@ -98241,7 +98290,7 @@ aac
 aaf
 aaf
 nXP
-dnX
+hJp
 uNL
 afd
 hJp
@@ -98251,7 +98300,7 @@ jFh
 cQF
 uNL
 pyC
-bHB
+hJz
 aZR
 baI
 baI
@@ -98444,7 +98493,7 @@ aad
 aag
 nXP
 nXP
-hJz
+tRV
 uNL
 uNL
 agi
@@ -98454,7 +98503,7 @@ uNL
 uNL
 uNL
 cCE
-bHB
+hJz
 aZO
 baI
 baI
@@ -98647,7 +98696,7 @@ aad
 aag
 nXP
 mGL
-dnX
+hJp
 uNL
 aas
 alI
@@ -98657,7 +98706,7 @@ ajp
 vdJ
 bJo
 amo
-bHB
+hJz
 aZP
 baI
 baI
@@ -98850,7 +98899,7 @@ aad
 aag
 nXP
 mGL
-dnX
+hJp
 uNL
 aga
 alQ
@@ -98860,7 +98909,7 @@ cdF
 sgw
 bJo
 gRP
-bHB
+hJz
 aZQ
 baI
 baI
@@ -99266,7 +99315,7 @@ ccJ
 ajL
 bJo
 bwl
-bHB
+hJz
 xyw
 puI
 aol
@@ -99469,7 +99518,7 @@ ajz
 aBC
 cfM
 wqh
-bHB
+hJz
 vpW
 eXq
 rri
@@ -99662,7 +99711,7 @@ aad
 aag
 nXP
 hJp
-dnX
+hJp
 uNL
 aaK
 cfN
@@ -99672,7 +99721,7 @@ ajz
 aBC
 cfM
 wqh
-bHB
+hJz
 xyw
 aho
 vWc
@@ -99865,7 +99914,7 @@ aad
 aag
 nXP
 fpd
-kKG
+mGL
 uNL
 ceQ
 ceU
@@ -99875,7 +99924,7 @@ ajz
 aBC
 cfM
 wqh
-bHB
+hJz
 ezQ
 eXq
 fAa
@@ -100068,7 +100117,7 @@ aag
 aag
 nXP
 dUF
-kKG
+mGL
 uNL
 ceR
 ceU
@@ -100078,7 +100127,7 @@ ajx
 tqg
 bJo
 mVE
-bHB
+hJz
 xyw
 anU
 aeJ
@@ -100271,7 +100320,7 @@ aag
 aag
 nXP
 fQF
-kKG
+mGL
 uNL
 abd
 adk
@@ -100281,7 +100330,7 @@ eLz
 uFL
 ssa
 sqa
-hBF
+dir
 hCt
 eXq
 qYN
@@ -100474,7 +100523,7 @@ aag
 aag
 nXP
 wVD
-kKG
+mGL
 uNL
 uZQ
 uZQ
@@ -100484,7 +100533,7 @@ aoF
 aBC
 cfM
 wqh
-bHB
+hJz
 xyw
 aho
 dkj
@@ -100677,7 +100726,7 @@ aag
 aag
 nXP
 mNf
-dnX
+hJp
 uNL
 cdE
 xSI
@@ -100687,7 +100736,7 @@ aoF
 aBC
 cfM
 wqh
-bHB
+hJz
 vpW
 eXq
 rri
@@ -100880,7 +100929,7 @@ aag
 aag
 nXP
 bvO
-dnX
+hJp
 ahd
 adg
 amp
@@ -100890,7 +100939,7 @@ gds
 aky
 bJo
 vPM
-bHB
+hJz
 xyw
 anW
 aol
@@ -101083,7 +101132,7 @@ aag
 aag
 nXP
 dNB
-dnX
+hJp
 uNL
 hSL
 agn
@@ -101286,7 +101335,7 @@ aag
 aag
 nXP
 mGL
-obG
+iBE
 uNL
 eXq
 adR
@@ -101296,7 +101345,7 @@ aho
 aho
 eXq
 hmy
-bHB
+hJz
 aZV
 baI
 baI
@@ -101489,7 +101538,7 @@ aag
 aag
 nXP
 mGL
-kKG
+mGL
 uNL
 abG
 aeh
@@ -101499,7 +101548,7 @@ aAL
 aBt
 ajM
 aXh
-bHB
+hJz
 aZW
 baI
 baI
@@ -101692,7 +101741,7 @@ aag
 aag
 nXP
 rbv
-dnX
+hJp
 uNL
 abH
 aer
@@ -101702,7 +101751,7 @@ aoL
 akz
 ajM
 caM
-bHB
+hJz
 aZX
 baI
 baI
@@ -101895,7 +101944,7 @@ aag
 aag
 nXP
 mGL
-kXJ
+pwK
 pJW
 acq
 aeJ
@@ -101905,7 +101954,7 @@ khD
 rYJ
 ajM
 xyw
-bHB
+hJz
 aZY
 baI
 baI
@@ -102108,7 +102157,7 @@ azJ
 bLP
 eXq
 eVm
-bHB
+hJz
 aZV
 baI
 baI
@@ -102311,7 +102360,7 @@ xWp
 aBw
 ajM
 xyw
-bHB
+hJz
 aZW
 baI
 baI
@@ -102514,7 +102563,7 @@ ajA
 akz
 ajM
 xyw
-bHB
+hJz
 aZX
 baI
 baI
@@ -102717,7 +102766,7 @@ aAK
 aBz
 ajM
 aXj
-bHB
+hJz
 aZY
 baI
 baI
@@ -102920,7 +102969,7 @@ eXq
 eXq
 eXq
 mrD
-bHB
+hJz
 aZV
 baI
 baI
@@ -103123,7 +103172,7 @@ aRu
 aRu
 bcm
 aXj
-bHB
+hJz
 aZW
 baI
 baI
@@ -103326,7 +103375,7 @@ aRu
 aRu
 bcm
 xyw
-bHB
+hJz
 aZX
 baI
 baI
@@ -103529,7 +103578,7 @@ aRu
 aRu
 bcm
 hmy
-bHB
+hJz
 aZL
 baX
 bcw
@@ -103732,18 +103781,18 @@ aRu
 aRu
 bcm
 xyw
-bHB
-wqh
-xyw
-bcc
-aYt
-aYt
-aYt
-aYt
-aYt
-aYt
-aYt
-aYt
+voD
+xOC
+brW
+gSC
+bwn
+bwn
+bwn
+bwn
+bwn
+bwn
+bwn
+jzh
 aYt
 aYt
 aYt
@@ -103946,7 +103995,7 @@ byv
 bdI
 rBb
 ehi
-mha
+qVN
 kTY
 ehi
 mha
@@ -104352,7 +104401,7 @@ dvg
 bgG
 bnI
 qjN
-qjN
+kXJ
 rdS
 qjN
 qjN
@@ -104555,7 +104604,7 @@ bzS
 nvM
 vyu
 qjN
-qjN
+kXJ
 qjN
 qjN
 qjN

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -5003,15 +5003,8 @@
 	},
 /area/almayer/command/telecomms)
 "aqc" = (
-/obj/structure/machinery/door_control{
-	id = "panicroomback";
-	name = "\improper Safe Room";
-	pixel_x = -25;
-	req_one_access_txt = "3"
-	},
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
+/obj/structure/sign/nosmoking_2,
+/turf/closed/wall/almayer,
 /area/almayer/hull/lower_hull/l_f_s)
 "aqd" = (
 /obj/structure/disposalpipe/trunk{
@@ -11636,14 +11629,13 @@
 /turf/closed/wall/almayer,
 /area/almayer/living/chapel)
 "aNj" = (
-/obj/structure/bed/chair/office/dark,
 /obj/structure/machinery/light{
 	dir = 1
 	},
-/obj/structure/sign/safety/terminal{
-	pixel_x = 8;
-	pixel_y = 32
+/obj/structure/machinery/computer/card{
+	dir = 8
 	},
+/obj/structure/surface/table/reinforced/almayer_B,
 /turf/open/floor/almayer{
 	dir = 5;
 	icon_state = "plating"
@@ -11689,6 +11681,7 @@
 	pixel_y = 24;
 	req_access_txt = "4"
 	},
+/obj/structure/bed/chair/office/dark,
 /turf/open/floor/almayer{
 	dir = 5;
 	icon_state = "plating"
@@ -17240,6 +17233,7 @@
 "bpW" = (
 /obj/structure/surface/table/almayer,
 /obj/effect/spawner/random/technology_scanner,
+/obj/effect/decal/cleanable/ash,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -34016,10 +34010,9 @@
 /turf/open/floor/almayer,
 /area/almayer/engineering/upper_engineering/port)
 "eNx" = (
-/obj/structure/machinery/vending/snack,
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
+/obj/structure/machinery/vending/cigarette,
+/obj/effect/decal/cleanable/ash,
+/turf/open/floor/wood,
 /area/almayer/hull/lower_hull/l_f_s)
 "eNI" = (
 /obj/structure/machinery/door/poddoor/shutters/almayer{
@@ -35990,15 +35983,8 @@
 	},
 /area/almayer/hull/upper_hull/u_f_p)
 "fGY" = (
-/obj/structure/machinery/door_control{
-	id = "panicroomback";
-	name = "\improper Safe Room";
-	pixel_x = 25;
-	req_one_access_txt = "3"
-	},
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
+/obj/structure/bed/chair,
+/turf/open/floor/wood,
 /area/almayer/hull/lower_hull/l_f_s)
 "fHc" = (
 /obj/structure/surface/table/almayer,
@@ -36112,6 +36098,12 @@
 	icon_state = "emeraldfull"
 	},
 /area/almayer/living/briefing)
+"fJg" = (
+/obj/structure/pipes/vents/pump{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/almayer/hull/lower_hull/l_f_s)
 "fJm" = (
 /obj/structure/flora/pottedplant{
 	icon_state = "pottedplant_22";
@@ -39051,16 +39043,6 @@
 	icon_state = "redfull"
 	},
 /area/almayer/living/offices/flight)
-"gYB" = (
-/obj/item/device/radio/intercom{
-	freerange = 1;
-	name = "Saferoom Channel";
-	pixel_x = 27
-	},
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/hull/lower_hull/l_f_s)
 "gYS" = (
 /obj/structure/prop/invuln/overhead_pipe{
 	dir = 4;
@@ -39340,15 +39322,13 @@
 	},
 /area/almayer/squads/req)
 "hdR" = (
-/obj/structure/window/framed/almayer,
-/obj/structure/machinery/door/poddoor/shutters/almayer{
-	dir = 4;
-	id = "OfficeSafeRoom";
-	name = "\improper Office Safe Room"
+/obj/structure/machinery/light{
+	dir = 8
 	},
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
+/obj/structure/surface/table/almayer,
+/obj/item/ashtray/glass,
+/obj/item/trash/cigbutt,
+/turf/open/floor/wood,
 /area/almayer/hull/lower_hull/l_f_s)
 "hec" = (
 /turf/open/floor/almayer{
@@ -40674,11 +40654,13 @@
 	},
 /area/almayer/hallways/aft_hallway)
 "hJz" = (
-/obj/structure/sign/safety/restrictedarea,
-/obj/structure/sign/safety/security{
-	pixel_x = 15
+/obj/structure/machinery/light/small{
+	dir = 1
 	},
-/turf/closed/wall/almayer,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_f_s)
 "hJJ" = (
 /obj/structure/pipes/standard/manifold/hidden/supply{
@@ -43114,12 +43096,8 @@
 /obj/structure/machinery/light{
 	dir = 8
 	},
-/obj/structure/bed/chair{
-	dir = 16
-	},
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
+/obj/structure/machinery/vending/walkman,
+/turf/open/floor/wood,
 /area/almayer/hull/lower_hull/l_f_s)
 "iOh" = (
 /obj/structure/machinery/light/small,
@@ -45360,11 +45338,9 @@
 	},
 /area/almayer/hull/lower_hull/l_f_p)
 "jNt" = (
-/obj/structure/surface/rack,
-/obj/item/stack/folding_barricade/three,
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
+/obj/structure/flora/pottedplant,
+/obj/structure/window/reinforced,
+/turf/open/floor/wood,
 /area/almayer/hull/lower_hull/l_f_s)
 "jOi" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
@@ -46087,25 +46063,8 @@
 	},
 /area/almayer/engineering/laundry)
 "kdt" = (
-/obj/structure/machinery/door_control{
-	id = "OuterShutter";
-	name = "Outer Shutter";
-	pixel_x = 5;
-	pixel_y = -2;
-	req_one_access_txt = "1;3"
-	},
-/obj/structure/surface/table/reinforced/almayer_B,
-/obj/structure/machinery/door_control{
-	id = "OfficeSafeRoom";
-	name = "Office Safe Room";
-	pixel_x = 5;
-	pixel_y = 5;
-	req_one_access_txt = "1;3"
-	},
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/hull/lower_hull/l_f_s)
+/turf/closed/wall/almayer,
+/area/almayer/hull)
 "kdB" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/pipes/standard/simple/hidden/supply,
@@ -48131,13 +48090,11 @@
 	},
 /area/almayer/medical/medical_science)
 "kXJ" = (
-/obj/structure/surface/table/reinforced/almayer_B,
-/obj/structure/machinery/computer/secure_data{
-	dir = 1
+/obj/structure/disposalpipe/junction{
+	dir = 8;
+	icon_state = "pipe-j2"
 	},
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
+/turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_f_s)
 "kXK" = (
 /obj/structure/machinery/light,
@@ -48156,13 +48113,9 @@
 	},
 /area/almayer/engineering/laundry)
 "kYa" = (
-/obj/structure/machinery/door/poddoor/shutters/almayer{
-	dir = 2;
-	id = "OuterShutter";
-	name = "\improper Saferoom Shutters"
-	},
+/obj/structure/window/framed/almayer,
 /turf/open/floor/almayer{
-	icon_state = "test_floor4"
+	icon_state = "plate"
 	},
 /area/almayer/hull/lower_hull/l_f_s)
 "kYP" = (
@@ -48999,6 +48952,9 @@
 "lqI" = (
 /obj/structure/bed/chair{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_f_s)
@@ -50306,23 +50262,8 @@
 	},
 /area/almayer/command/securestorage)
 "lQj" = (
-/obj/structure/machinery/door_control{
-	id = "InnerShutter";
-	name = "Inner Shutter";
-	pixel_x = 5;
-	pixel_y = 10
-	},
-/obj/item/toy/deck{
-	pixel_x = -9
-	},
-/obj/item/ashtray/plastic,
-/obj/structure/surface/table/reinforced/almayer_B,
-/obj/structure/sign/safety/intercom{
-	pixel_y = -32
-	},
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
+/obj/structure/machinery/vending/snack,
+/turf/open/floor/wood,
 /area/almayer/hull/lower_hull/l_f_s)
 "lQq" = (
 /obj/structure/bed,
@@ -50688,6 +50629,13 @@
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/engineering/lower_engineering)
+"mbQ" = (
+/obj/structure/machinery/light{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/wood,
+/area/almayer/hull/lower_hull/l_f_s)
 "mce" = (
 /turf/open/floor/almayer{
 	icon_state = "greencorner"
@@ -51624,6 +51572,9 @@
 	pixel_x = 8;
 	pixel_y = -32
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -51776,6 +51727,12 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/living/chapel)
+"mBW" = (
+/obj/effect/decal/cleanable/ash,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_f_s)
 "mCo" = (
 /obj/structure/window/framed/almayer,
 /obj/structure/machinery/door/firedoor/border_only/almayer{
@@ -52016,14 +51973,13 @@
 	},
 /area/almayer/lifeboat_pumps/south2)
 "mIB" = (
-/obj/structure/machinery/cm_vending/sorted/medical/marinemed,
 /obj/structure/sign/safety/medical{
 	pixel_x = 8;
 	pixel_y = 32
 	},
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
+/obj/structure/machinery/vending/coffee,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/wood,
 /area/almayer/hull/lower_hull/l_f_s)
 "mIW" = (
 /obj/structure/machinery/light,
@@ -52919,6 +52875,13 @@
 "naB" = (
 /turf/closed/wall/almayer/reinforced,
 /area/almayer/shipboard/brig/perma)
+"naD" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/structure/machinery/disposal,
+/turf/open/floor/wood,
+/area/almayer/hull/lower_hull/l_f_s)
 "naQ" = (
 /obj/structure/machinery/light/small{
 	dir = 4
@@ -55211,9 +55174,9 @@
 	},
 /area/almayer/squads/alpha_bravo_shared)
 "obG" = (
-/obj/structure/surface/table/reinforced/almayer_B,
-/obj/structure/machinery/computer/card{
-	dir = 8
+/obj/effect/landmark/yautja_teleport,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
@@ -56245,7 +56208,7 @@
 /obj/structure/sign/safety/security{
 	pixel_x = 15
 	},
-/turf/closed/wall/almayer,
+/turf/closed/wall/almayer/reinforced,
 /area/almayer/hallways/starboard_umbilical)
 "owg" = (
 /turf/open/floor/almayer{
@@ -58807,6 +58770,12 @@
 	pixel_y = 7
 	},
 /obj/item/storage/box/lights/mixed,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_f_s)
 "pGT" = (
@@ -59576,15 +59545,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/living/pilotbunks)
-"pXQ" = (
-/obj/structure/sign/safety/intercom{
-	pixel_x = 32;
-	pixel_y = 7
-	},
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/hull/lower_hull/l_f_s)
 "pXV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -61118,17 +61078,8 @@
 	},
 /area/almayer/medical/operating_room_two)
 "qHb" = (
-/obj/structure/bed/chair{
-	dir = 8
-	},
-/obj/item/device/radio/intercom{
-	freerange = 1;
-	name = "Saferoom Channel";
-	pixel_y = -28
-	},
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/wood,
 /area/almayer/hull/lower_hull/l_f_s)
 "qHg" = (
 /turf/open/floor/almayer{
@@ -62846,6 +62797,7 @@
 	pixel_x = 32;
 	pixel_y = -8
 	},
+/obj/effect/decal/cleanable/ash,
 /turf/open/floor/almayer{
 	icon_state = "cargo"
 	},
@@ -63024,6 +62976,9 @@
 /obj/structure/sign/safety/storage{
 	pixel_x = 8;
 	pixel_y = -32
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
@@ -63626,15 +63581,12 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/squads/req)
 "rII" = (
-/obj/structure/machinery/door/airlock/multi_tile/almayer/generic,
-/obj/structure/machinery/door/poddoor/shutters/almayer{
+/obj/structure/machinery/door/airlock/almayer/generic/glass{
 	dir = 2;
-	id = "OuterShutter";
-	name = "\improper Saferoom Shutters"
+	name = "\improper Commissary"
 	},
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
+/obj/structure/pipes/standard/simple/hidden/supply,
+/turf/open/floor/wood,
 /area/almayer/hull/lower_hull/l_f_s)
 "rIO" = (
 /obj/structure/machinery/vending/snack,
@@ -63791,6 +63743,12 @@
 	dir = 8
 	},
 /area/almayer/medical/containment/cell/cl)
+"rMs" = (
+/obj/effect/decal/cleanable/ash{
+	pixel_y = 15
+	},
+/turf/open/floor/wood,
+/area/almayer/hull/lower_hull/l_f_s)
 "rNF" = (
 /obj/structure/machinery/light{
 	unacidable = 1;
@@ -64119,19 +64077,8 @@
 	},
 /area/almayer/shipboard/brig/cells)
 "rUU" = (
-/obj/structure/machinery/door/airlock/almayer/maint{
-	req_access = null;
-	req_one_access = null
-	},
-/obj/structure/machinery/door/poddoor/shutters/almayer{
-	dir = 4;
-	id = "panicroomback";
-	name = "\improper Safe Room Shutters"
-	},
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/hull/lower_hull/l_f_s)
+/turf/closed/wall/almayer/reinforced,
+/area/almayer/hallways/starboard_umbilical)
 "rVo" = (
 /obj/structure/machinery/light/small{
 	dir = 1
@@ -71348,7 +71295,7 @@
 	pixel_x = 15;
 	pixel_y = 32
 	},
-/turf/closed/wall/almayer,
+/turf/closed/wall/almayer/reinforced,
 /area/almayer/hallways/starboard_umbilical)
 "vbf" = (
 /obj/structure/machinery/landinglight/ds2/delaytwo{
@@ -72107,6 +72054,10 @@
 	icon_state = "red"
 	},
 /area/almayer/lifeboat_pumps/south1)
+"vpE" = (
+/obj/structure/machinery/atm,
+/turf/closed/wall/almayer,
+/area/almayer/hull/lower_hull/l_f_s)
 "vpI" = (
 /obj/effect/landmark/start/police,
 /turf/open/floor/plating/plating_catwalk,
@@ -72935,6 +72886,17 @@
 	icon_state = "containment_corner_variant_2"
 	},
 /area/almayer/medical/containment/cell)
+"vHU" = (
+/obj/structure/surface/table/reinforced/almayer_B,
+/obj/structure/machinery/door_control{
+	id = "OfficeSafeRoom";
+	name = "Office Safe Room";
+	req_one_access_txt = "1;3"
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_f_s)
 "vHW" = (
 /obj/structure/surface/rack,
 /obj/item/tool/extinguisher,
@@ -73080,14 +73042,8 @@
 	},
 /area/almayer/living/briefing)
 "vKf" = (
-/obj/structure/machinery/door/airlock/multi_tile/almayer/generic,
-/obj/structure/machinery/door/poddoor/shutters/almayer/open{
-	id = "InnerShutter";
-	name = "\improper Saferoom Shutters"
-	},
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
+/obj/structure/pipes/standard/simple/hidden/supply,
+/turf/open/floor/wood,
 /area/almayer/hull/lower_hull/l_f_s)
 "vKF" = (
 /obj/structure/stairs{
@@ -73107,12 +73063,13 @@
 	},
 /area/almayer/hallways/aft_hallway)
 "vLh" = (
-/obj/item/roller,
-/obj/structure/surface/rack,
-/obj/item/roller,
-/turf/open/floor/almayer{
-	icon_state = "plate"
+/obj/structure/machinery/vending/cola,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 3.3;
+	pixel_y = 4
 	},
+/turf/open/floor/wood,
 /area/almayer/hull/lower_hull/l_f_s)
 "vLj" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/medidoor{
@@ -76026,13 +75983,10 @@
 	},
 /area/almayer/hull/upper_hull/u_a_p)
 "wUO" = (
-/obj/structure/machinery/door/poddoor/shutters/almayer/open{
-	id = "InnerShutter";
-	name = "\improper Saferoom Shutters"
+/obj/structure/bed/chair{
+	dir = 1
 	},
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
+/turf/open/floor/wood,
 /area/almayer/hull/lower_hull/l_f_s)
 "wUP" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
@@ -76625,6 +76579,9 @@
 	icon_state = "sterile_green_corner"
 	},
 /area/almayer/medical/operating_room_one)
+"xfZ" = (
+/turf/open/floor/wood,
+/area/almayer/hull/lower_hull/l_f_s)
 "xgh" = (
 /obj/structure/pipes/vents/scrubber{
 	dir = 4
@@ -78307,6 +78264,10 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/hallways/starboard_hallway)
+"xOC" = (
+/obj/structure/disposalpipe/segment,
+/turf/closed/wall/almayer,
+/area/almayer/hull/lower_hull/l_f_s)
 "xOL" = (
 /obj/structure/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
@@ -96048,12 +96009,12 @@ aaa
 aaa
 aPy
 aPY
-aQv
-aQv
-aQv
-aQv
-aQv
-aQv
+rUU
+rUU
+rUU
+rUU
+rUU
+rUU
 vak
 ovP
 xyw
@@ -96251,7 +96212,7 @@ aaa
 aaa
 nXP
 ndx
-uNL
+sIT
 nDd
 soS
 sgy
@@ -96454,13 +96415,13 @@ aaa
 aaa
 nXP
 hJp
-uNL
+sIT
 gka
 bwQ
 oNf
-uNL
+sIT
 aNw
-kXJ
+xmv
 kVX
 xyw
 bHB
@@ -96663,7 +96624,7 @@ sIT
 sIT
 sIT
 aNj
-xmv
+vHU
 kVX
 xyw
 bHB
@@ -96860,15 +96821,15 @@ aaa
 aaa
 nXP
 tRV
-sIT
+kdt
 jNt
 iNZ
 lQj
 sIT
-obG
-kdt
-kVX
-xyw
+sIT
+sIT
+sIT
+hmy
 bHB
 aZO
 baI
@@ -97063,15 +97024,15 @@ aaa
 aaa
 nXP
 hJp
-sIT
+kdt
 vLh
-mGL
-qHb
-sIT
+xfZ
+xfZ
+fGY
 hdR
-hdR
-hJz
-hmy
+wUO
+kYa
+xyw
 bHB
 aZP
 baI
@@ -97266,16 +97227,16 @@ aaa
 aaa
 nXP
 mfe
-sIT
+aqc
 eNx
-mGL
-mGL
+rMs
+fJg
 vKf
-mGL
-mGL
+vKf
+vKf
 rII
-xyw
-bHB
+baN
+hBF
 aZQ
 baI
 baI
@@ -97468,14 +97429,14 @@ aaa
 aaa
 aaa
 nXP
-hJp
-sIT
+pwK
+xOC
 mIB
-mGL
-fGY
-wUO
-gYB
-pXQ
+mbQ
+qHb
+qHb
+mbQ
+naD
 kYa
 xyw
 bHB
@@ -97671,15 +97632,15 @@ aaa
 aaa
 aaa
 nXP
-mGL
-sIT
-sIT
-rUU
-sIT
-sIT
+kKG
 uNL
 uNL
 uNL
+uNL
+uNL
+uNL
+uNL
+vpE
 xyw
 bHB
 aZO
@@ -97876,7 +97837,7 @@ aaa
 nXP
 rxk
 uNL
-aqc
+mGL
 hJp
 qbd
 cQF
@@ -98077,12 +98038,12 @@ aaa
 aaa
 aaa
 nXP
-mGL
+kKG
 qee
 hJp
 mGL
 qaZ
-mGL
+mBW
 hJp
 mGL
 mBb
@@ -98280,7 +98241,7 @@ aac
 aaf
 aaf
 nXP
-hJp
+dnX
 uNL
 afd
 hJp
@@ -98483,7 +98444,7 @@ aad
 aag
 nXP
 nXP
-tRV
+hJz
 uNL
 uNL
 agi
@@ -98686,7 +98647,7 @@ aad
 aag
 nXP
 mGL
-hJp
+dnX
 uNL
 aas
 alI
@@ -98889,7 +98850,7 @@ aad
 aag
 nXP
 mGL
-hJp
+dnX
 uNL
 aga
 alQ
@@ -99701,7 +99662,7 @@ aad
 aag
 nXP
 hJp
-hJp
+dnX
 uNL
 aaK
 cfN
@@ -99904,7 +99865,7 @@ aad
 aag
 nXP
 fpd
-mGL
+kKG
 uNL
 ceQ
 ceU
@@ -100107,7 +100068,7 @@ aag
 aag
 nXP
 dUF
-mGL
+kKG
 uNL
 ceR
 ceU
@@ -100310,7 +100271,7 @@ aag
 aag
 nXP
 fQF
-mGL
+kKG
 uNL
 abd
 adk
@@ -100513,7 +100474,7 @@ aag
 aag
 nXP
 wVD
-mGL
+kKG
 uNL
 uZQ
 uZQ
@@ -100716,7 +100677,7 @@ aag
 aag
 nXP
 mNf
-hJp
+dnX
 uNL
 cdE
 xSI
@@ -100919,7 +100880,7 @@ aag
 aag
 nXP
 bvO
-hJp
+dnX
 ahd
 adg
 amp
@@ -101122,7 +101083,7 @@ aag
 aag
 nXP
 dNB
-hJp
+dnX
 uNL
 hSL
 agn
@@ -101325,7 +101286,7 @@ aag
 aag
 nXP
 mGL
-iBE
+obG
 uNL
 eXq
 adR
@@ -101528,7 +101489,7 @@ aag
 aag
 nXP
 mGL
-mGL
+kKG
 uNL
 abG
 aeh
@@ -101731,7 +101692,7 @@ aag
 aag
 nXP
 rbv
-hJp
+dnX
 uNL
 abH
 aer
@@ -101934,7 +101895,7 @@ aag
 aag
 nXP
 mGL
-pwK
+kXJ
 pJW
 acq
 aeJ


### PR DESCRIPTION
# About the pull request

Adds a small self-serve commissary to the hangar.

# Explain why it's good for the game

The old panic room which this is replacing was never used so I decided to replace it with a more useful room, this commissary has the five main vendors (RecVend, Hot Drinks, Snacks, Smokes and Souto) all in one place and the intent is to have an area right in the hangar where returning/departing marines can grab things such as a walkman, cigarettes or whatever else they wish.

I believe this to be much more useful than the old panic room which I have never seen actually be used in-game at all.

# Testing Photographs and Procedure

I ran it locally, the disposal and vent systems both work as intended and the vendors all work as intended,

![image](https://github.com/cmss13-devs/cmss13/assets/31109792/9a039406-d4da-414f-a3e6-7cf026f46ba1)

# Changelog

:cl:
mapadd: added a commissary accessible in the hangar
/:cl:
