### PR TITLE
Revives Armor Linking (med/heavy armor buff)

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -211,6 +211,11 @@
 	var/gloves_blood_amt = 0 //taken from blood.dm
 	var/hide_prints = FALSE
 
+/obj/item/clothing/gloves/Initialize(mapload, ...)
+	. = ..()
+	if(armor_melee || armor_bullet || armor_laser || armor_energy || armor_bomb || armor_bio || armor_rad)
+		AddComponent(/datum/component/armor_link, WEAR_JACKET, TRUE)
+
 /obj/item/clothing/gloves/update_clothing_icon()
 	if (ismob(src.loc))
 		var/mob/M = src.loc
@@ -334,6 +339,11 @@
 	var/obj/item/stored_item
 	var/list/items_allowed
 	var/shoes_blood_amt = 0
+
+	obj/item/clothing/shoes/Initialize(mapload, ...)
+	. = ..()
+	if(armor_melee || armor_bullet || armor_laser || armor_energy || armor_bomb || armor_bio || armor_rad)
+		AddComponent(/datum/component/armor_link, WEAR_JACKET, TRUE)
 
 /obj/item/clothing/shoes/update_clothing_icon()
 	if (ismob(src.loc))

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -340,7 +340,7 @@
 	var/list/items_allowed
 	var/shoes_blood_amt = 0
 
-	obj/item/clothing/shoes/Initialize(mapload, ...)
+/obj/item/clothing/shoes/Initialize(mapload, ...)
 	. = ..()
 	if(armor_melee || armor_bullet || armor_laser || armor_energy || armor_bomb || armor_bio || armor_rad)
 		AddComponent(/datum/component/armor_link, WEAR_JACKET, TRUE)


### PR DESCRIPTION
# About the pull request
a revival of #956 without the integrated drop pouch
Armor linking! wearing armor will cause your boots and gloves to share the damage resistances.

(BEFORE VS AFTER ARMOR LINKING)
for light armor you get: 
go from 15->20 bomb armor on boots and gloves

for med armor you'll get:
10 internal damage resist -> 20 internal damage resist 

for heavy armor you'll get:
20 -> 25 melee armor
10 -> 25 internal damage resist 
20 -> 35 bullet armor
15 -> 35 bomb armor
20 -> 25 bio armor

(didn't list rad/energy values because i don't think they're used??)


# Explain why it's good for the game

currently, heavy and medium armors are HEAVILY underused due to the fact that a vast majority of xenos simply aim for feet or hands, bypassing your armor and dealing the same amount of damage while being able to fracture and delimb far easier, armor linking will mitigate this, equalizing damage on every bodypart (except for helmet, which is always equivelant to med armor).

this will encourage xenos to target places that aren't just hands/feet. maybe we'll see xenos targeting head now that marines will be wearing heavy armor more often, dealing more damage for a less impactful fracture, along with possibly leading to more decaps (if they get REALLY lucky).



# Testing Photographs and Procedure
video demonstrating the difference between heavy, no armor, and light armor.
<details>
<summary>Screenshots & Videos</summary>

https://github.com/cmss13-devs/cmss13/assets/54422837/703cd552-e9ad-4758-9633-5577c83fe961

bonus video - delimbing in 3 hits through heavy armor still exists if you get lucky enough 

https://github.com/cmss13-devs/cmss13/assets/54422837/3e2a35b5-5498-429e-9cf2-e646ff3dfbc2


</details>


# Changelog
:cl: Geevies, Private Tristan
add: Armor Linking! wearing chest armor will now give its' armor stats to both your boots and gloves. 
/:cl:
