### PR TITLE
Facehuggers no longer remove helmets

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
@@ -485,8 +485,7 @@
 					return FALSE
 				can_infect = FALSE
 			else
-				visible_message(SPAN_DANGER("[hugger] smashes against [src]'s [D.name] and rips it off!"))
-				drop_inv_item_on_ground(D)
+				visible_message(SPAN_DANGER("[hugger] smashes against [src]'s [D.name]!"))
 				if(istype(D, /obj/item/clothing/head/helmet/marine)) //Marine helmets now get a fancy overlay.
 					var/obj/item/clothing/head/helmet/marine/m_helmet = D
 					m_helmet.add_hugger_damage()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Facehuggers will no longer rip off a helmet when they facehug someone. 

They will rip off any mask item the user was wearing. 

# Explain why it's good for the game

The increasing relevance of helmet bound items has reached a point where losing a helmet can be a massive loss to a marine, especially considering other marines can steal helmets, the helmets can be destroyed with bombs or xenos can melt helmets, thus denying you the ability to reacquire your equipment. 

This change won't affect a xenos ability to tell an infected marine apart from non-infected. 


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
balance: Facehuggers no longer rip off helmets. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
