### PR TITLE
Adds a confirmation to disabling round end delay

### DIFF
--- a/code/modules/admin/tabs/round_tab.dm
+++ b/code/modules/admin/tabs/round_tab.dm
@@ -148,7 +148,10 @@
 
 	if(!check_rights(R_SERVER))
 		return
-	if (SSticker.current_state != GAME_STATE_PREGAME)
+	if(SSticker.current_state != GAME_STATE_PREGAME)
+		if(SSticker.delay_end)
+			if(tgui_alert(usr, "Round end delay is already enabled, are you sure you want to disable it?", "Confirmation", list("Yes", "No"), 30 SECONDS) != "Yes")
+				return
 		SSticker.delay_end = !SSticker.delay_end
 		message_admins("[SPAN_NOTICE("[key_name(usr)] [SSticker.delay_end ? "delayed the round end" : "has made the round end normally"].")]")
 		for(var/client/C in GLOB.admins)


### PR DESCRIPTION

# About the pull request

Multiple people press at once and it doesn't delay
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

Not delaying when should delay
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/cmss13-devs/cmss13/assets/56142455/cf0505aa-de19-4657-a166-5b206c0917d5)

</details>


# Changelog
:cl:
admin: Disabling round end delay has a confirmation
/:cl:
