### PR TITLE
Vulture tweaks

### DIFF
--- a/code/game/objects/items/devices/vulture_spotter.dm
+++ b/code/game/objects/items/devices/vulture_spotter.dm
@@ -18,6 +18,8 @@
 	. = ..()
 	to_chat(user, SPAN_WARNING("[src] needs to be mounted on a tripod to use!"))
 
+/obj/item/device/vulture_spotter_scope/skillless
+
 /obj/item/device/vulture_spotter_tripod
 	name = "\improper M707 spotter tripod"
 	desc = "A tripod, meant for stabilizing a spotting scope for the M707 anti-materiel rifle."

--- a/code/game/objects/structures/vulture_spotter.dm
+++ b/code/game/objects/structures/vulture_spotter.dm
@@ -158,11 +158,11 @@
 		user.pixel_y = 0
 
 /// Handler for when the scope is being attached to the tripod
-/obj/structure/vulture_spotter_tripod/proc/on_scope_attach(mob/user, obj/item/scope)
+/obj/structure/vulture_spotter_tripod/proc/on_scope_attach(mob/user, obj/item/device/vulture_spotter_scope/scope)
 	if(scope_attached)
 		return
 
-	if(istype(scope, /obj/item/vulture_spotter_scope/skillless))
+	if(istype(scope, /obj/item/device/vulture_spotter_scope/skillless))
 		skillless = TRUE
 
 	user.visible_message(SPAN_NOTICE("[user] attaches [scope] to [src]."), SPAN_NOTICE("You attach [scope] to [src]."))

--- a/code/game/objects/structures/vulture_spotter.dm
+++ b/code/game/objects/structures/vulture_spotter.dm
@@ -21,6 +21,8 @@
 	var/darkness_view = 12
 	/// The maximum distance this can be from the sniper scope
 	var/max_sniper_distance = 7
+	/// If this requires the vulture_user trait to use
+	var/skillless = FALSE
 
 /obj/structure/vulture_spotter_tripod/Initialize(mapload)
 	. = ..()
@@ -36,7 +38,10 @@
 /obj/structure/vulture_spotter_tripod/deconstruct(disassembled)
 	. = ..()
 	if(scope_attached && bound_rifle)
-		new /obj/item/device/vulture_spotter_scope(get_turf(src), bound_rifle)
+		if(skillless)
+			new /obj/item/device/vulture_spotter_scope/skillless(get_turf(src), bound_rifle)
+		else
+			new /obj/item/device/vulture_spotter_scope(get_turf(src), bound_rifle)
 	new /obj/item/device/vulture_spotter_tripod(get_turf(src))
 
 /obj/structure/vulture_spotter_tripod/get_examine_text(mob/user)
@@ -63,7 +68,7 @@
 		return
 	var/mob/living/carbon/human/user = usr //this is us
 
-	if(!HAS_TRAIT(user, TRAIT_VULTURE_USER))
+	if(!HAS_TRAIT(user, TRAIT_VULTURE_USER) && !skillless)
 		to_chat(user, SPAN_WARNING("You don't know how to use this!"))
 		return
 
@@ -153,9 +158,12 @@
 		user.pixel_y = 0
 
 /// Handler for when the scope is being attached to the tripod
-/obj/structure/vulture_spotter_tripod/proc/on_scope_attach(mob/user, obj/structure/vulture_spotter_tripod/scope)
+/obj/structure/vulture_spotter_tripod/proc/on_scope_attach(mob/user, obj/item/scope)
 	if(scope_attached)
 		return
+
+	if(istype(scope, /obj/item/vulture_spotter_scope/skillless))
+		skillless = TRUE
 
 	user.visible_message(SPAN_NOTICE("[user] attaches [scope] to [src]."), SPAN_NOTICE("You attach [scope] to [src]."))
 	icon_state = "vulture_scope"

--- a/code/modules/cm_marines/equipment/guncases.dm
+++ b/code/modules/cm_marines/equipment/guncases.dm
@@ -300,7 +300,7 @@
 	name = "\improper M707 anti-materiel rifle case"
 	desc = "A gun case containing the M707 \"Vulture\" anti-materiel rifle and its requisite spotting tools."
 	icon_state = "guncase_blue"
-	storage_slots = 7
+	storage_slots = 5
 	can_hold = list(
 		/obj/item/weapon/gun/boltaction/vulture,
 		/obj/item/ammo_magazine/rifle/boltaction/vulture,
@@ -324,6 +324,15 @@
 	new /obj/item/tool/screwdriver(src) // Spotter scope needs a screwdriver to disassemble
 	new /obj/item/pamphlet/trait/vulture(src) //both pamphlets give use of the scope and the rifle
 	new /obj/item/pamphlet/trait/vulture(src)
+
+/obj/item/storage/box/guncase/vulture/skillless
+
+/obj/item/storage/box/guncase/vulture/skillless/fill_preset_inventory()
+	var/obj/item/weapon/gun/boltaction/vulture/skillless/rifle = new(src)
+	new /obj/item/ammo_magazine/rifle/boltaction/vulture(src)
+	new /obj/item/device/vulture_spotter_tripod(src)
+	new /obj/item/device/vulture_spotter_scope/skillless(src, WEAKREF(rifle))
+	new /obj/item/tool/screwdriver(src) // Spotter scope needs a screwdriver to disassemble
 
 //Handgun case for Military police vendor three mag , a railflashligh and the handgun.
 

--- a/code/modules/cm_marines/equipment/guncases.dm
+++ b/code/modules/cm_marines/equipment/guncases.dm
@@ -326,6 +326,7 @@
 	new /obj/item/pamphlet/trait/vulture(src)
 
 /obj/item/storage/box/guncase/vulture/skillless
+	storage_slots = 5
 
 /obj/item/storage/box/guncase/vulture/skillless/fill_preset_inventory()
 	var/obj/item/weapon/gun/boltaction/vulture/skillless/rifle = new(src)

--- a/code/modules/cm_marines/equipment/guncases.dm
+++ b/code/modules/cm_marines/equipment/guncases.dm
@@ -300,7 +300,7 @@
 	name = "\improper M707 anti-materiel rifle case"
 	desc = "A gun case containing the M707 \"Vulture\" anti-materiel rifle and its requisite spotting tools."
 	icon_state = "guncase_blue"
-	storage_slots = 5
+	storage_slots = 7
 	can_hold = list(
 		/obj/item/weapon/gun/boltaction/vulture,
 		/obj/item/ammo_magazine/rifle/boltaction/vulture,

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -1238,6 +1238,8 @@ Defined in conflicts.dm of the #defines folder.
 	var/darkness_view = 12
 	/// If there is currently a spotter using the linked spotting scope
 	var/spotter_spotting = FALSE
+	/// How much time it takes to adjust the position of the scope. Adjusting the offset will take half of this time
+	var/adjust_delay = 1 SECONDS
 
 /obj/item/attachable/vulture_scope/Initialize(mapload, ...)
 	. = ..()
@@ -1289,7 +1291,7 @@ Defined in conflicts.dm of the #defines folder.
 				if(!COOLDOWN_FINISHED(src, scope_interact_cd))
 					return
 				to_chat(scoper, SPAN_NOTICE("You begin adjusting [src]..."))
-				COOLDOWN_START(src, scope_interact_cd, 0.5 SECONDS)
+				COOLDOWN_START(src, scope_interact_cd, adjust_delay / 2)
 				if(!do_after(scoper, 0.4 SECONDS))
 					return
 
@@ -1307,7 +1309,7 @@ Defined in conflicts.dm of the #defines folder.
 					return
 
 				to_chat(scoper, SPAN_NOTICE("You begin moving [src]..."))
-				COOLDOWN_START(src, scope_interact_cd, 1 SECONDS)
+				COOLDOWN_START(src, scope_interact_cd, adjust_delay)
 				if(!do_after(scoper, 0.8 SECONDS))
 					return
 

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -1217,9 +1217,9 @@ Defined in conflicts.dm of the #defines folder.
 	/// If the gun should experience scope drift
 	var/scope_drift = TRUE
 	/// % chance for the scope to drift on process with a spotter using their scope
-	var/spotted_drift_chance = 33
+	var/spotted_drift_chance = 25
 	/// % chance for the scope to drift on process without a spotter using their scope
-	var/unspotted_drift_chance = 100
+	var/unspotted_drift_chance = 90
 	/// If the scope should use do_afters for adjusting and moving the sight
 	var/slow_use = TRUE
 	/// Cooldown for interacting with the scope's adjustment or position
@@ -3244,6 +3244,8 @@ Defined in conflicts.dm of the #defines folder.
 	attachment_action_type = /datum/action/item_action/toggle
 	var/initial_mob_dir = NORTH // the dir the mob faces the moment it deploys the bipod
 	var/bipod_deployed = FALSE
+	/// If this should anchor the user while in use
+	var/heavy_bipod = FALSE
 
 /obj/item/attachable/bipod/New()
 	..()
@@ -3309,6 +3311,9 @@ Defined in conflicts.dm of the #defines folder.
 	if(G.flags_gun_features & GUN_SUPPORT_PLATFORM)
 		G.remove_firemode(GUN_FIREMODE_AUTOMATIC)
 
+	if(heavy_bipod)
+		user.anchored = FALSE
+
 	if(!QDELETED(G))
 		playsound(user,'sound/items/m56dauto_rotate.ogg', 55, 1)
 		update_icon()
@@ -3347,6 +3352,9 @@ Defined in conflicts.dm of the #defines folder.
 
 				if(G.flags_gun_features & GUN_SUPPORT_PLATFORM)
 					G.add_firemode(GUN_FIREMODE_AUTOMATIC)
+
+				if(heavy_bipod)
+					user.anchored = TRUE
 
 			else
 				to_chat(user, SPAN_NOTICE("You retract [src]."))
@@ -3396,6 +3404,7 @@ Defined in conflicts.dm of the #defines folder.
 	desc = "A set of rugged telescopic poles to keep a weapon stabilized during firing."
 	icon_state = "bipod_m60"
 	attach_icon = "vulture_bipod"
+	heavy_bipod = TRUE
 
 /obj/item/attachable/burstfire_assembly
 	name = "burst fire assembly"

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -1290,7 +1290,7 @@ Defined in conflicts.dm of the #defines folder.
 					return
 				to_chat(scoper, SPAN_NOTICE("You begin adjusting [src]..."))
 				COOLDOWN_START(src, scope_interact_cd, 0.5 SECONDS)
-				if(!do_after(scoper, 0.5 SECONDS))
+				if(!do_after(scoper, 0.4 SECONDS))
 					return
 
 			adjust_offset(direction)
@@ -1308,7 +1308,7 @@ Defined in conflicts.dm of the #defines folder.
 
 				to_chat(scoper, SPAN_NOTICE("You begin moving [src]..."))
 				COOLDOWN_START(src, scope_interact_cd, 1 SECONDS)
-				if(!do_after(scoper, 1 SECONDS))
+				if(!do_after(scoper, 0.8 SECONDS))
 					return
 
 			adjust_position(direction)

--- a/code/modules/projectiles/guns/boltaction.dm
+++ b/code/modules/projectiles/guns/boltaction.dm
@@ -275,3 +275,7 @@
 			to_chat(user, SPAN_DANGER("The splint on your [limb.display_name] comes apart under the recoil!"))
 			user.pain.apply_pain(PAIN_BONE_BREAK_SPLINTED)
 			user.update_med_icon()
+
+
+/obj/item/weapon/gun/boltaction/vulture/skillless
+	bypass_trait = TRUE


### PR DESCRIPTION

# About the pull request
- Adds a skillless variant of the vulture
- Lowered spotted/unspotted drift from 33/100 to 25/90
- Lowered scope adjust/move time from 0.5/1.0s to 0.4/0.8s
- Vulture bipod anchors you in place

# Explain why it's good for the game
- Lets admins do memery without wrangling a trait
- Drift is a little *too* overbearing right now, this should make it a bit better.
- Adjusting is hard on a battlefield (as it's meant to be), but it needs to be a little more flexible.
- This is something many bipod users have struggled with, and especially with the vulture sight, considering how much adjustment is done.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>
tested

</details>


# Changelog
:cl:
admin: Added skillless subtype of the m707
balance: Lowered vulture spotted/unspotted drift from 33/100 to 25/90
balance: Lowered vulture scope adjust/move time from 0.5/1.0s to 0.4/0.8s
balance: Vulture bipod anchors user in place
/:cl:
