### PR TITLE
Adds round end to status tab

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -362,13 +362,17 @@ SUBSYSTEM_DEF(ticker)
 	var/skip_delay = check_rights()
 	if(delay_end && !skip_delay)
 		to_chat(world, SPAN_BOLDNOTICE("An admin has delayed the round end."))
+		SSticker.mode.round_end_time = -1
 		return
 
 	to_chat(world, SPAN_BOLDNOTICE("Rebooting World in [DisplayTimeText(delay)]. [reason]"))
 
-	var/start_wait = world.time
-	sleep(delay - (world.time - start_wait))
+	SSticker.mode.round_end_time = delay + world.time
+	addtimer(CALLBACK(src, PROC_REF(standard_reboot), reason, skip_delay), delay)
 
+///Generic round-end reboot
+/datum/controller/subsystem/ticker/proc/standard_reboot(reason, skip_delay)
+	SSticker.mode.round_end_time = -1
 	if(delay_end && !skip_delay)
 		to_chat(world, SPAN_BOLDNOTICE("Reboot was cancelled by an admin."))
 		return

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -24,6 +24,7 @@ SUBSYSTEM_DEF(ticker)
 	var/start_at
 
 	var/roundend_check_paused = FALSE
+	var/roundend_restart_delay
 
 	var/round_start_time = 0
 	var/list/round_start_events
@@ -97,6 +98,7 @@ SUBSYSTEM_DEF(ticker)
 
 			if(!roundend_check_paused && mode.check_finished(force_ending) || force_ending)
 				current_state = GAME_STATE_FINISHED
+				roundend_restart_delay = CONFIG_GET(number/round_end_countdown)
 				ooc_allowed = TRUE
 				mode.declare_completion(force_ending)
 				REDIS_PUBLISH("byond.round", "type" = "round-complete")

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -24,7 +24,10 @@ var/global/cas_tracking_id_increment = 0 //this var used to assign unique tracki
 	var/required_players = 0
 	var/required_players_secret = 0 //Minimum number of players for that game mode to be chose in Secret
 	var/ert_disabled = 0
+	/// Time that hijack force ends at
 	var/force_end_at = 0
+	/// Time server restarts (without delays)
+	var/round_end_time = 0
 	var/xeno_evo_speed = 0 // if not 0 - gives xeno an evo boost/nerf
 	var/is_in_endgame = FALSE //Set it to TRUE when we trigger DELTA alert or dropship crashes
 	/// When set and this gamemode is selected, the taskbar icon will change to the png selected here

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -1091,13 +1091,12 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 			. += "Evacuation: [eta_status]"
 
 	if(SSticker.current_state == GAME_STATE_FINISHED)
+		var/round_end_timer = "Time To Restart: [(SSticker.roundend_restart_delay + (SSticker.mode.round_end_time - world.time)) / 10 ]s [SSticker.delay_end ? "(DELAYED)" : ""]"
 		if(SSticker.mode.round_end_time == 0)
-			. += "Time To Restart: Ongoing Vote [SSticker.delay_end ? "(DELAYED)" : ""]"
-			return
+			round_end_timer = "Time To Restart: Ongoing Vote [SSticker.delay_end ? "(DELAYED)" : ""]"
 		if(SSticker.mode.round_end_time < 0)
-			. += "Time To Restart: SOON [SSticker.delay_end ? "(DELAYED)" : "(RESTART NEEDED)"]"
-			return
-		. += "Time To Restart: [(SSticker.roundend_restart_delay + (SSticker.mode.round_end_time - world.time)) / 10 ]s [SSticker.delay_end ? "(DELAYED)" : ""]"
+			round_end_timer = "Time To Restart: SOON [SSticker.delay_end ? "(DELAYED)" : "(RESTART NEEDED)"]"
+		. += round_end_timer
 
 /proc/message_ghosts(message)
 	for(var/mob/dead/observer/O as anything in GLOB.observer_list)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -1095,7 +1095,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		if(SSticker.mode.round_end_time == 0)
 			round_end_timer = "Time To Restart: Ongoing Vote [SSticker.delay_end ? "(DELAYED)" : ""]"
 		if(SSticker.mode.round_end_time < 0)
-			round_end_timer = "Time To Restart: SOON [SSticker.delay_end ? "(DELAYED)" : "(RESTART NEEDED)"]"
+			round_end_timer = "Time To Restart: SOON [SSticker.delay_end ? "(DELAYED)" : "(MANUAL RESTART NEEDED)"]"
 		. += round_end_timer
 
 /proc/message_ghosts(message)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -1091,14 +1091,13 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 			. += "Evacuation: [eta_status]"
 
 	if(SSticker.current_state == GAME_STATE_FINISHED)
-		var/static/round_end_countdown = CONFIG_GET(number/round_end_countdown)
 		if(SSticker.mode.round_end_time == 0)
 			. += "Time To Restart: Ongoing Vote [SSticker.delay_end ? "(DELAYED)" : ""]"
 			return
 		if(SSticker.mode.round_end_time < 0)
 			. += "Time To Restart: SOON [SSticker.delay_end ? "(DELAYED)" : "(RESTART NEEDED)"]"
 			return
-		. += "Time To Restart: [(round_end_countdown + (SSticker.mode.round_end_time - world.time)) / 10 ]s [SSticker.delay_end ? "(DELAYED)" : ""]"
+		. += "Time To Restart: [(SSticker.roundend_restart_delay + (SSticker.mode.round_end_time - world.time)) / 10 ]s [SSticker.delay_end ? "(DELAYED)" : ""]"
 
 /proc/message_ghosts(message)
 	for(var/mob/dead/observer/O as anything in GLOB.observer_list)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -1090,6 +1090,15 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		if(eta_status)
 			. += "Evacuation: [eta_status]"
 
+	if(SSticker.current_state == GAME_STATE_FINISHED)
+		var/static/round_end_countdown = CONFIG_GET(number/round_end_countdown)
+		if(SSticker.mode.round_end_time == 0)
+			. += "Time To Restart: Ongoing Vote [SSticker.delay_end ? "(DELAYED)" : ""]"
+			return
+		if(SSticker.mode.round_end_time < 0)
+			. += "Time To Restart: SOON [SSticker.delay_end ? "(DELAYED)" : "(RESTART NEEDED)"]"
+			return
+		. += "Time To Restart: [(round_end_countdown + (SSticker.mode.round_end_time - world.time)) / 10 ]s [SSticker.delay_end ? "(DELAYED)" : ""]"
 
 /proc/message_ghosts(message)
 	for(var/mob/dead/observer/O as anything in GLOB.observer_list)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -491,14 +491,13 @@
 	. += "Game Mode: [GLOB.master_mode]"
 
 	if(SSticker.current_state == GAME_STATE_FINISHED)
-		var/static/round_end_countdown = CONFIG_GET(number/round_end_countdown)
 		if(SSticker.mode.round_end_time == 0)
 			. += "Time To Restart: Ongoing Vote [SSticker.delay_end ? "(DELAYED)" : ""]"
 			return
 		if(SSticker.mode.round_end_time < 0)
 			. += "Time To Restart: SOON [SSticker.delay_end ? "(DELAYED)" : "(RESTART NEEDED)"]"
 			return
-		. += "Time To Restart: [(round_end_countdown + (SSticker.mode.round_end_time - world.time)) / 10 ]s [SSticker.delay_end ? "(DELAYED)" : ""]"
+		. += "Time To Restart: [(SSticker.roundend_restart_delay + (SSticker.mode.round_end_time - world.time)) / 10 ]s [SSticker.delay_end ? "(DELAYED)" : ""]"
 
 	if(SSticker.HasRoundStarted())
 		return

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -491,13 +491,12 @@
 	. += "Game Mode: [GLOB.master_mode]"
 
 	if(SSticker.current_state == GAME_STATE_FINISHED)
+		var/round_end_timer = "Time To Restart: [(SSticker.roundend_restart_delay + (SSticker.mode.round_end_time - world.time)) / 10 ]s [SSticker.delay_end ? "(DELAYED)" : ""]"
 		if(SSticker.mode.round_end_time == 0)
-			. += "Time To Restart: Ongoing Vote [SSticker.delay_end ? "(DELAYED)" : ""]"
-			return
+			round_end_timer = "Time To Restart: Ongoing Vote [SSticker.delay_end ? "(DELAYED)" : ""]"
 		if(SSticker.mode.round_end_time < 0)
-			. += "Time To Restart: SOON [SSticker.delay_end ? "(DELAYED)" : "(MANUAL RESTART NEEDED)"]"
-			return
-		. += "Time To Restart: [(SSticker.roundend_restart_delay + (SSticker.mode.round_end_time - world.time)) / 10 ]s [SSticker.delay_end ? "(DELAYED)" : ""]"
+			round_end_timer = "Time To Restart: SOON [SSticker.delay_end ? "(DELAYED)" : "(MANUAL RESTART NEEDED)"]"
+		. += round_end_timer
 
 	if(SSticker.HasRoundStarted())
 		return

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -495,7 +495,7 @@
 			. += "Time To Restart: Ongoing Vote [SSticker.delay_end ? "(DELAYED)" : ""]"
 			return
 		if(SSticker.mode.round_end_time < 0)
-			. += "Time To Restart: SOON [SSticker.delay_end ? "(DELAYED)" : "(RESTART NEEDED)"]"
+			. += "Time To Restart: SOON [SSticker.delay_end ? "(DELAYED)" : "(MANUAL RESTART NEEDED)"]"
 			return
 		. += "Time To Restart: [(SSticker.roundend_restart_delay + (SSticker.mode.round_end_time - world.time)) / 10 ]s [SSticker.delay_end ? "(DELAYED)" : ""]"
 

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -490,6 +490,16 @@
 	. += ""
 	. += "Game Mode: [GLOB.master_mode]"
 
+	if(SSticker.current_state == GAME_STATE_FINISHED)
+		var/static/round_end_countdown = CONFIG_GET(number/round_end_countdown)
+		if(SSticker.mode.round_end_time == 0)
+			. += "Time To Restart: Ongoing Vote [SSticker.delay_end ? "(DELAYED)" : ""]"
+			return
+		if(SSticker.mode.round_end_time < 0)
+			. += "Time To Restart: SOON [SSticker.delay_end ? "(DELAYED)" : "(RESTART NEEDED)"]"
+			return
+		. += "Time To Restart: [(round_end_countdown + (SSticker.mode.round_end_time - world.time)) / 10 ]s [SSticker.delay_end ? "(DELAYED)" : ""]"
+
 	if(SSticker.HasRoundStarted())
 		return
 


### PR DESCRIPTION

# About the pull request

Lets ghosts and new players (lobby) see time to server restart
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

Lets you see if the automatic round-end timer ran out, and if the server is delayed
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Ghosts and players in lobby can see the time to the server restarting in the status tab
/:cl:
