### PR TITLE
UPP Survivors Use Player Names + Radio Change

### DIFF
--- a/code/modules/gear_presets/survivors.dm
+++ b/code/modules/gear_presets/survivors.dm
@@ -1592,7 +1592,6 @@
 	role_comm_title = "173/RECON"
 	idtype = /obj/item/card/id/dogtag
 	flags = EQUIPMENT_PRESET_EXTRA
-	uses_special_name = TRUE
 	access = list(
 		ACCESS_CIVILIAN_PUBLIC,
 	)

--- a/code/modules/gear_presets/survivors.dm
+++ b/code/modules/gear_presets/survivors.dm
@@ -1589,17 +1589,13 @@
 	languages = list(LANGUAGE_RUSSIAN, LANGUAGE_GERMAN, LANGUAGE_CHINESE)
 	faction = FACTION_UPP
 	faction_group = list(FACTION_UPP, FACTION_SURVIVOR)
-	role_comm_title = "UPP 173RD RECON"
+	role_comm_title = "173/RECON"
 	idtype = /obj/item/card/id/dogtag
 	flags = EQUIPMENT_PRESET_EXTRA
 	uses_special_name = TRUE
 	access = list(
 		ACCESS_CIVILIAN_PUBLIC,
 	)
-
-/datum/equipment_preset/survivor/upp/load_name(mob/living/carbon/human/new_human, randomise)
-	var/random_name = capitalize(pick(new_human.gender == MALE ? first_names_male_upp : first_names_female_upp)) + " " + capitalize(pick(last_names_upp))
-	new_human.change_real_name(new_human, random_name)
 
 /datum/equipment_preset/survivor/upp/load_gear(mob/living/carbon/human/new_human)
 	var/obj/item/clothing/under/marine/veteran/UPP/uniform = new()
@@ -1726,7 +1722,7 @@
 	assignment = JOB_UPP_LEADER
 	rank = JOB_UPP_LEADER
 	languages = list(LANGUAGE_RUSSIAN, LANGUAGE_ENGLISH,  LANGUAGE_GERMAN,  LANGUAGE_CHINESE)
-	role_comm_title = "UPP 173Rd RECON SL"
+	role_comm_title = "173/RECON SL"
 	skills = /datum/skills/military/survivor/upp_sl
 
 /datum/equipment_preset/survivor/upp/squad_leader/load_gear(mob/living/carbon/human/new_human)

--- a/code/modules/gear_presets/synths.dm
+++ b/code/modules/gear_presets/synths.dm
@@ -466,7 +466,7 @@
 	skills = /datum/skills/colonial_synthetic
 	paygrade = "SYN"
 	idtype = /obj/item/card/id/dogtag
-	role_comm_title = "UPP 173Rd RECON Syn"
+	role_comm_title = "173/RECON Syn"
 
 /datum/equipment_preset/synth/survivor/upp/load_gear(mob/living/carbon/human/new_human)
 	var/obj/item/clothing/under/marine/veteran/UPP/medic/uniform = new()


### PR DESCRIPTION
# About the pull request

UPP survivors now default to using the players preferred name instead of a random UPP name. 

The UPP radio name is now changed to "173/RECON" from "UPP 173rd Recon". 

# Explain why it's good for the game

The radio change is to make the radio text log less cumbersome to observe. 

The name change was a requested change from the maintainers, as players should be using their preferred name instead of being forced to use a random one.

(On that note, if anyone has the coding skills, please put up a PR to let players select their own name for non-USCM spawns, guaranteed to be approved)


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: UPP survivor radio role identifiers now have a shorter title.
add: UPP survivors now default to using a players preferred name instead of a random UPP name. 
/:cl:
