### PR TITLE
Auto observer fixes, preferences, and QoL

### DIFF
--- a/code/__DEFINES/dcs/signals/atom/mob/signals_mob.dm
+++ b/code/__DEFINES/dcs/signals/atom/mob/signals_mob.dm
@@ -111,6 +111,12 @@
 
 #define COMSIG_GHOST_MOVED "ghost_moved"
 
+/// When a mob is turned into a /mob/dead/observer at /mob/proc/ghostize()
+#define COMSIG_MOB_GHOSTIZE "mob_ghostize"
+
+/// When a mob gets a new mind via transfer at /datum/mind/proc/transfer_to()
+#define COMSIG_MOB_NEW_MIND "mob_new_mind"
+
 #define COMSIG_MOB_MOUSEDOWN "mob_mousedown"					//from /client/MouseDown(): (atom/object, turf/location, control, params)
 #define COMSIG_MOB_MOUSEUP "mob_mouseup"						//from /client/MouseUp(): (atom/object, turf/location, control, params)
 #define COMSIG_MOB_MOUSEDRAG "mob_mousedrag"				//from /client/MouseDrag(): (atom/src_object, atom/over_object, turf/src_location, turf/over_location, src_control, over_control, params)

--- a/code/__DEFINES/dcs/signals/signals_client.dm
+++ b/code/__DEFINES/dcs/signals/signals_client.dm
@@ -27,3 +27,6 @@
 
 /// Called when something is removed from a client's screen : /client/proc/remove_from_screen(screen_remove)
 #define COMSIG_CLIENT_SCREEN_REMOVE "client_screen_remove"
+
+/// When a mind is transfered to another mob at /datum/mind/proc/transfer_to()
+#define COMSIG_CLIENT_MIND_TRANSFER "mind_transfer"

--- a/code/__DEFINES/dcs/signals/signals_client.dm
+++ b/code/__DEFINES/dcs/signals/signals_client.dm
@@ -21,3 +21,9 @@
 
 /// Called after a client logs into a mob: (mob)
 #define COMSIG_CLIENT_MOB_LOGIN "client_mob_changed"
+
+/// Called when something is added to a client's screen : /client/proc/add_to_screen(screen_add)
+#define COMSIG_CLIENT_SCREEN_ADD "client_screen_add"
+
+/// Called when something is removed from a client's screen : /client/proc/remove_from_screen(screen_remove)
+#define COMSIG_CLIENT_SCREEN_REMOVE "client_screen_remove"

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -357,7 +357,7 @@
 /client/proc/create_clickcatcher()
 	if(!void)
 		void = new()
-	screen += void
+	add_to_screen(void)
 
 /client/proc/apply_clickcatcher()
 	create_clickcatcher()

--- a/code/_onclick/hud/alien.dm
+++ b/code/_onclick/hud/alien.dm
@@ -64,10 +64,10 @@
 	var/mob/living/carbon/xenomorph/H = mymob
 	if(hud_version != HUD_STYLE_NOHUD)
 		if(H.r_hand)
-			H.client.screen += H.r_hand
+			H.client.add_to_screen(H.r_hand)
 			H.r_hand.screen_loc = ui_alien_datum.hud_slot_offset(H.r_hand, ui_alien_datum.ui_rhand)
 		if(H.l_hand)
-			H.client.screen += H.l_hand
+			H.client.add_to_screen(H.l_hand)
 			H.l_hand.screen_loc = ui_alien_datum.hud_slot_offset(H.l_hand, ui_alien_datum.ui_lhand)
 	else
 		if(H.r_hand)

--- a/code/_onclick/hud/fullscreen.dm
+++ b/code/_onclick/hud/fullscreen.dm
@@ -17,7 +17,7 @@
 	screen.severity = severity
 	if (client && screen.should_show_to(src))
 		screen.update_for_view(client.view)
-		client.screen += screen
+		client.add_to_screen(screen)
 
 	return screen
 
@@ -33,12 +33,12 @@
 		addtimer(CALLBACK(src, PROC_REF(clear_fullscreen_after_animate), screen), animated, TIMER_CLIENT_TIME)
 	else
 		if(client)
-			client.screen -= screen
+			client.remove_from_screen(screen)
 		qdel(screen)
 
 /mob/proc/clear_fullscreen_after_animate(atom/movable/screen/fullscreen/screen)
 	if(client)
-		client.screen -= screen
+		client.remove_from_screen(screen)
 	qdel(screen)
 
 /mob/proc/clear_fullscreens()
@@ -48,7 +48,7 @@
 /mob/proc/hide_fullscreens()
 	if(client)
 		for(var/category in fullscreens)
-			client.screen -= fullscreens[category]
+			client.remove_from_screen(fullscreens[category])
 
 /mob/proc/reload_fullscreens()
 	if(client)
@@ -57,9 +57,9 @@
 			screen = fullscreens[category]
 			if(screen.should_show_to(src))
 				screen.update_for_view(client.view)
-				client.screen |= screen
+				client.add_to_screen(screen)
 			else
-				client.screen -= screen
+				client.remove_from_screen(screen)
 
 
 /atom/movable/screen/fullscreen

--- a/code/_onclick/hud/ghost.dm
+++ b/code/_onclick/hud/ghost.dm
@@ -72,7 +72,7 @@
 /datum/hud/ghost/show_hud(version = 0, mob/viewmob)
 	// don't show this HUD if observing; show the HUD of the observee
 	var/mob/dead/observer/O = mymob
-	if (istype(O) && O.observetarget)
+	if (istype(O) && O.observe_target_mob)
 		plane_masters_update()
 		return FALSE
 

--- a/code/_onclick/hud/ghost.dm
+++ b/code/_onclick/hud/ghost.dm
@@ -82,6 +82,6 @@
 	var/mob/screenmob = viewmob || mymob
 
 	if(!hud_shown)
-		screenmob.client.screen -= static_inventory
+		screenmob.client.remove_from_screen(static_inventory)
 	else
-		screenmob.client.screen += static_inventory
+		screenmob.client.add_to_screen(static_inventory)

--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -189,43 +189,43 @@
 		if(HUD_STYLE_STANDARD) //Default HUD
 			hud_shown = 1 //Governs behavior of other procs
 			if(static_inventory.len)
-				screenmob.client.screen += static_inventory
+				screenmob.client.add_to_screen(static_inventory)
 			if(toggleable_inventory.len && inventory_shown)
-				screenmob.client.screen += toggleable_inventory
+				screenmob.client.add_to_screen(toggleable_inventory)
 			if(hotkeybuttons.len && !hotkey_ui_hidden)
-				screenmob.client.screen += hotkeybuttons
+				screenmob.client.add_to_screen(hotkeybuttons)
 			if(infodisplay.len)
-				screenmob.client.screen += infodisplay
+				screenmob.client.add_to_screen(infodisplay)
 
 		if(HUD_STYLE_REDUCED) //Reduced HUD
 			hud_shown = 0 //Governs behavior of other procs
 			if(static_inventory.len)
-				screenmob.client.screen -= static_inventory
+				screenmob.client.remove_from_screen(static_inventory)
 			if(toggleable_inventory.len)
-				screenmob.client.screen -= toggleable_inventory
+				screenmob.client.remove_from_screen(toggleable_inventory)
 			if(hotkeybuttons.len)
-				screenmob.client.screen -= hotkeybuttons
+				screenmob.client.remove_from_screen(hotkeybuttons)
 			if(infodisplay.len)
-				screenmob.client.screen += infodisplay
+				screenmob.client.add_to_screen(infodisplay)
 
 			//These ones are a part of 'static_inventory', 'toggleable_inventory' or 'hotkeybuttons' but we want them to stay
 			if(l_hand_hud_object)
-				screenmob.client.screen += l_hand_hud_object //we want the hands to be visible
+				screenmob.client.add_to_screen(l_hand_hud_object) //we want the hands to be visible
 			if(r_hand_hud_object)
-				screenmob.client.screen += r_hand_hud_object //we want the hands to be visible
+				screenmob.client.add_to_screen(r_hand_hud_object) //we want the hands to be visible
 			if(action_intent)
-				screenmob.client.screen += action_intent //we want the intent switcher visible
+				screenmob.client.add_to_screen(action_intent) //we want the intent switcher visible
 
 		if(HUD_STYLE_NOHUD) //No HUD
 			hud_shown = 0 //Governs behavior of other procs
 			if(static_inventory.len)
-				screenmob.client.screen -= static_inventory
+				screenmob.client.remove_from_screen(static_inventory)
 			if(toggleable_inventory.len)
-				screenmob.client.screen -= toggleable_inventory
+				screenmob.client.remove_from_screen(toggleable_inventory)
 			if(hotkeybuttons.len)
-				screenmob.client.screen -= hotkeybuttons
+				screenmob.client.remove_from_screen(hotkeybuttons)
 			if(infodisplay.len)
-				screenmob.client.screen -= infodisplay
+				screenmob.client.remove_from_screen(infodisplay)
 
 	hud_version = display_hud_version
 	persistent_inventory_update(screenmob)
@@ -247,7 +247,7 @@
 	for(var/thing in plane_masters)
 		var/atom/movable/screen/plane_master/PM = plane_masters[thing]
 		PM.backdrop(mymob)
-		mymob.client.screen += PM
+		mymob.client.add_to_screen(PM)
 
 /datum/hud/human/show_hud(version = 0, mob/viewmob)
 	. = ..()
@@ -412,7 +412,7 @@
 	if(!hud_shown)
 		for(var/category in alerts)
 			var/atom/movable/screen/alert/alert = alerts[category]
-			screenmob.client.screen -= alert
+			screenmob.client.remove_from_screen(alert)
 		return TRUE
 	var/c = 0
 	for(var/category in alerts)
@@ -432,8 +432,16 @@
 			else
 				. = ""
 		alert.screen_loc = .
-		screenmob.client.screen |= alert
+		screenmob.client.add_to_screen(alert)
 	if(!viewmob)
 		for(var/obs in mymob.observers)
 			reorganize_alerts(obs)
 	return TRUE
+
+/client/proc/add_to_screen(screen_add)
+	screen += screen_add
+	SEND_SIGNAL(src, COMSIG_CLIENT_SCREEN_ADD, screen_add)
+
+/client/proc/remove_from_screen(screen_remove)
+	screen -= screen_remove
+	SEND_SIGNAL(src, COMSIG_CLIENT_SCREEN_REMOVE, screen_remove)

--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -438,10 +438,12 @@
 			reorganize_alerts(obs)
 	return TRUE
 
+/// Wrapper for adding anything to a client's screen
 /client/proc/add_to_screen(screen_add)
 	screen += screen_add
 	SEND_SIGNAL(src, COMSIG_CLIENT_SCREEN_ADD, screen_add)
 
+/// Wrapper for removing anything from a client's screen
 /client/proc/remove_from_screen(screen_remove)
 	screen -= screen_remove
 	SEND_SIGNAL(src, COMSIG_CLIENT_SCREEN_REMOVE, screen_remove)

--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -105,10 +105,10 @@
 	set desc = "This disables or enables the user interface buttons which can be used with hotkeys."
 
 	if(hud_used.hotkey_ui_hidden)
-		client.screen += hud_used.hotkeybuttons
+		client.add_to_screen(hud_used.hotkeybuttons)
 		hud_used.hotkey_ui_hidden = 0
 	else
-		client.screen -= hud_used.hotkeybuttons
+		client.remove_from_screen(hud_used.hotkeybuttons)
 		hud_used.hotkey_ui_hidden = TRUE
 
 /datum/hud/human/hidden_inventory_update(mob/viewer)
@@ -120,53 +120,57 @@
 		inventory_shown = FALSE
 		return //species without inv slots don't show items.
 
-	if(screenmob.hud_used.inventory_shown && screenmob.hud_used.hud_shown)
+	if(H.hud_used.inventory_shown && H.hud_used.hud_shown)
 		if(H.shoes)
 			H.shoes.screen_loc = ui_datum.ui_shoes
-			screenmob.client.screen += H.shoes
+			screenmob.client.add_to_screen(H.shoes)
 		if(H.gloves)
 			H.gloves.screen_loc = ui_datum.ui_gloves
-			screenmob.client.screen += H.gloves
+			screenmob.client.add_to_screen(H.gloves)
 		if(H.wear_l_ear)
 			H.wear_l_ear.screen_loc = ui_datum.ui_wear_l_ear
-			screenmob.client.screen += H.wear_l_ear
+			screenmob.client.add_to_screen(H.wear_l_ear)
 		if(H.wear_r_ear)
 			H.wear_r_ear.screen_loc = ui_datum.ui_wear_r_ear
-			screenmob.client.screen += H.wear_r_ear
+			screenmob.client.add_to_screen(H.wear_r_ear)
 		if(H.glasses)
 			H.glasses.screen_loc = ui_datum.ui_glasses
-			screenmob.client.screen += H.glasses
+			screenmob.client.add_to_screen(H.glasses)
 		if(H.w_uniform)
 			H.w_uniform.screen_loc = ui_datum.ui_iclothing
-			screenmob.client.screen += H.w_uniform
+			screenmob.client.add_to_screen(H.w_uniform)
 		if(H.wear_suit)
 			H.wear_suit.screen_loc = ui_datum.ui_oclothing
-			screenmob.client.screen += H.wear_suit
+			screenmob.client.add_to_screen(H.wear_suit)
 		if(H.wear_mask)
 			H.wear_mask.screen_loc = ui_datum.ui_mask
-			screenmob.client.screen += H.wear_mask
+			screenmob.client.add_to_screen(H.wear_mask)
 		if(H.head)
 			H.head.screen_loc = ui_datum.ui_head
-			screenmob.client.screen += H.head
+			screenmob.client.add_to_screen(H.head)
 	else
 		if(H.shoes)
-			screenmob.client.screen -= H.shoes
+			screenmob.client.remove_from_screen(H.shoes)
 		if(H.gloves)
-			screenmob.client.screen -= H.gloves
+			screenmob.client.remove_from_screen(H.gloves)
 		if(H.wear_r_ear)
-			screenmob.client.screen -= H.wear_r_ear
+			screenmob.client.remove_from_screen(H.wear_r_ear)
 		if(H.wear_l_ear)
-			screenmob.client.screen -= H.wear_l_ear
+			screenmob.client.remove_from_screen(H.wear_l_ear)
 		if(H.glasses)
-			screenmob.client.screen -= H.glasses
+			screenmob.client.remove_from_screen(H.glasses)
 		if(H.w_uniform)
-			screenmob.client.screen -= H.w_uniform
+			screenmob.client.remove_from_screen(H.w_uniform)
 		if(H.wear_suit)
-			screenmob.client.screen -= H.wear_suit
+			screenmob.client.remove_from_screen(H.wear_suit)
 		if(H.wear_mask)
-			screenmob.client.screen -= H.wear_mask
+			screenmob.client.remove_from_screen(H.wear_mask)
 		if(H.head)
-			screenmob.client.screen -= H.head
+			screenmob.client.remove_from_screen(H.head)
+
+	if(screenmob == mymob)
+		for(var/M in mymob.observers)
+			hidden_inventory_update(M)
 
 /datum/hud/human/persistent_inventory_update(mob/viewer)
 	if(!mymob)
@@ -177,52 +181,56 @@
 	var/mob/living/carbon/human/H = mymob
 	var/mob/screenmob = viewer || H
 
-	if(screenmob.hud_used)
-		if(screenmob.hud_used.hud_shown)
+	if(H.hud_used)
+		if(H.hud_used.hud_shown)
 			if(H.s_store)
 				H.s_store.screen_loc = ui_datum.hud_slot_offset(H.s_store, ui_datum.ui_sstore1)
-				screenmob.client.screen += H.s_store
+				screenmob.client.add_to_screen(H.s_store)
 			if(H.wear_id)
 				H.wear_id.screen_loc = ui_datum.hud_slot_offset(H.wear_id, ui_datum.ui_id)
-				screenmob.client.screen += H.wear_id
+				screenmob.client.add_to_screen(H.wear_id)
 			if(H.belt)
 				H.belt.screen_loc = ui_datum.hud_slot_offset(H.belt, ui_datum.ui_belt)
-				screenmob.client.screen += H.belt
+				screenmob.client.add_to_screen(H.belt)
 			if(H.back)
 				H.back.screen_loc = ui_datum.hud_slot_offset(H.back, ui_datum.ui_back)
-				screenmob.client.screen += H.back
+				screenmob.client.add_to_screen(H.back)
 			if(H.l_store)
 				H.l_store.screen_loc = ui_datum.hud_slot_offset(H.l_store, ui_datum.ui_storage1)
-				screenmob.client.screen += H.l_store
+				screenmob.client.add_to_screen(H.l_store)
 			if(H.r_store)
 				H.r_store.screen_loc = ui_datum.hud_slot_offset(H.r_store, ui_datum.ui_storage2)
-				screenmob.client.screen += H.r_store
+				screenmob.client.add_to_screen(H.r_store)
 		else
 			if(H.s_store)
-				screenmob.client.screen -= H.s_store
+				screenmob.client.remove_from_screen(H.s_store)
 			if(H.wear_id)
-				screenmob.client.screen -= H.wear_id
+				screenmob.client.remove_from_screen(H.wear_id)
 			if(H.belt)
-				screenmob.client.screen -= H.belt
+				screenmob.client.remove_from_screen(H.belt)
 			if(H.back)
-				screenmob.client.screen -= H.back
+				screenmob.client.remove_from_screen(H.back)
 			if(H.l_store)
-				screenmob.client.screen -= H.l_store
+				screenmob.client.remove_from_screen(H.l_store)
 			if(H.r_store)
-				screenmob.client.screen -= H.r_store
+				screenmob.client.remove_from_screen(H.r_store)
 
 	if(hud_version != HUD_STYLE_NOHUD)
 		if(H.r_hand)
 			H.r_hand.screen_loc = ui_datum.hud_slot_offset(H.r_hand, ui_datum.ui_rhand)
-			H.client.screen += H.r_hand
+			screenmob.client.add_to_screen(H.r_hand)
 		if(H.l_hand)
 			H.l_hand.screen_loc = ui_datum.hud_slot_offset(H.l_hand, ui_datum.ui_lhand)
-			H.client.screen += H.l_hand
+			screenmob.client.add_to_screen(H.l_hand)
 	else
 		if(H.r_hand)
 			H.r_hand.screen_loc = null
 		if(H.l_hand)
 			H.l_hand.screen_loc = null
+
+	if(screenmob == mymob)
+		for(var/M in mymob.observers)
+			persistent_inventory_update(M)
 
 /datum/hud/human/proc/draw_inventory_slots(gear, datum/custom_hud/ui_datum, ui_alpha, ui_color)
 	for(var/gear_slot in gear)

--- a/code/_onclick/hud/map_popups.dm
+++ b/code/_onclick/hud/map_popups.dm
@@ -108,7 +108,7 @@
 	if(!screen_map.Find(screen_obj))
 		screen_map += screen_obj
 	if(!screen.Find(screen_obj))
-		screen += screen_obj
+		add_to_screen(screen_obj)
 
 /**
  * Clears the map of registered screen objects.

--- a/code/_onclick/hud/rendering/render_plate.dm
+++ b/code/_onclick/hud/rendering/render_plate.dm
@@ -74,6 +74,6 @@
 		relay.blend_mode = blend_mode
 	relay.mouse_opacity = mouse_opacity
 	relay.name = render_target
-	mymob.client.screen += relay
+	mymob.client.add_to_screen(relay)
 	if(blend_mode != BLEND_MULTIPLY)
 		blend_mode = BLEND_DEFAULT

--- a/code/_onclick/hud/robot.dm
+++ b/code/_onclick/hud/robot.dm
@@ -134,13 +134,13 @@
 	if(hud_shown)
 		if(R.module_state_1)
 			R.module_state_1.screen_loc = ui_robot_datum.ui_inv1
-			R.client.screen += R.module_state_1
+			R.client.add_to_screen(R.module_state_1)
 		if(R.module_state_2)
 			R.module_state_2.screen_loc = ui_robot_datum.ui_inv2
-			R.client.screen += R.module_state_2
+			R.client.add_to_screen(R.module_state_2)
 		if(R.module_state_3)
 			R.module_state_3.screen_loc = ui_robot_datum.ui_inv3
-			R.client.screen += R.module_state_3
+			R.client.add_to_screen(R.module_state_3)
 	else
 		if(R.module_state_1)
 			R.module_state_1.screen_loc = null

--- a/code/_onclick/hud/screen_object_holder.dm
+++ b/code/_onclick/hud/screen_object_holder.dm
@@ -24,14 +24,14 @@
 	ASSERT(istype(screen_object))
 
 	screen_objects += screen_object
-	client?.screen += screen_object
+	client?.add_to_screen(screen_object)
 
 /// Gives the screen object to the client, but does not qdel it when it's cleared
 /datum/screen_object_holder/proc/give_protected_screen_object(atom/screen_object)
 	ASSERT(istype(screen_object))
 
 	protected_screen_objects += screen_object
-	client?.screen += screen_object
+	client?.add_to_screen(screen_object)
 
 /datum/screen_object_holder/proc/remove_screen_object(atom/screen_object)
 	ASSERT(istype(screen_object))
@@ -39,11 +39,11 @@
 
 	screen_objects -= screen_object
 	protected_screen_objects -= screen_object
-	client?.screen -= screen_object
+	client?.remove_from_screen(screen_object)
 
 /datum/screen_object_holder/proc/clear()
-	client?.screen -= screen_objects
-	client?.screen -= protected_screen_objects
+	client?.remove_from_screen(screen_objects)
+	client?.remove_from_screen(protected_screen_objects)
 
 	QDEL_LIST(screen_objects)
 	protected_screen_objects.Cut()

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -37,6 +37,8 @@
 
 
 /atom/movable/screen/close/clicked(mob/user)
+	if(isobserver(user))
+		return TRUE
 	if(master)
 		if(isstorage(master))
 			var/obj/item/storage/master_storage = master
@@ -612,10 +614,10 @@
 	if(user && user.hud_used)
 		if(user.hud_used.inventory_shown)
 			user.hud_used.inventory_shown = 0
-			user.client.screen -= user.hud_used.toggleable_inventory
+			user.client.remove_from_screen(user.hud_used.toggleable_inventory)
 		else
 			user.hud_used.inventory_shown = 1
-			user.client.screen += user.hud_used.toggleable_inventory
+			user.client.add_to_screen(user.hud_used.toggleable_inventory)
 
 		user.hud_used.hidden_inventory_update()
 	return 1

--- a/code/_onclick/observer.dm
+++ b/code/_onclick/observer.dm
@@ -31,7 +31,7 @@
 				var/mob/living/carbon/xenomorph/xeno = target
 				if(xeno.stat == DEAD || is_admin_level(xeno.z) || xeno.aghosted)
 					to_chat(src, SPAN_WARNING("You cannot join as [xeno]."))
-					ManualFollow(xeno)
+					do_observe(xeno)
 					return FALSE
 
 				if(!SSticker.mode.xeno_bypass_timer)
@@ -41,7 +41,7 @@
 							to_wait = XENO_LEAVE_TIMER_LARVA - xeno.away_timer
 						if(to_wait > 60 SECONDS) // don't spam for clearly non-AFK xenos
 							to_chat(src, SPAN_WARNING("That player hasn't been away long enough. Please wait [to_wait] second\s longer."))
-						ManualFollow(target)
+						do_observe(target)
 						return FALSE
 
 					var/deathtime = world.time - timeofdeath
@@ -50,14 +50,14 @@
 						message = SPAN_WARNING("[message]")
 						to_chat(src, message)
 						to_chat(src, SPAN_WARNING("You must wait atleast 2.5 minutes before rejoining the game!"))
-						ManualFollow(target)
+						do_observe(target)
 						return FALSE
 
 				if(xeno.hive)
 					for(var/mob_name in xeno.hive.banished_ckeys)
 						if(xeno.hive.banished_ckeys[mob_name] == ckey)
 							to_chat(src, SPAN_WARNING("You are banished from the [xeno.hive], you may not rejoin unless the Queen re-admits you or dies."))
-							ManualFollow(target)
+							do_observe(target)
 							return FALSE
 
 				if(alert(src, "Are you sure you want to transfer yourself into [xeno]?", "Confirm Transfer", "Yes", "No") != "Yes")
@@ -67,7 +67,7 @@
 					return FALSE
 				SSticker.mode.transfer_xeno(src, xeno)
 				return TRUE
-			ManualFollow(target)
+			do_observe(target)
 			return TRUE
 
 		if(!istype(target, /atom/movable/screen))

--- a/code/controllers/subsystem/minimap.dm
+++ b/code/controllers/subsystem/minimap.dm
@@ -390,9 +390,9 @@ SUBSYSTEM_DEF(minimaps)
 	if(!map)
 		return
 	if(minimap_displayed)
-		owner.client.screen -= map
+		owner.client.remove_from_screen(map)
 	else
-		owner.client.screen += map
+		owner.client.add_to_screen(map)
 	minimap_displayed = !minimap_displayed
 
 /datum/action/minimap/give_to(mob/target)
@@ -415,7 +415,7 @@ SUBSYSTEM_DEF(minimaps)
 /datum/action/minimap/remove_from(mob/target)
 	. = ..()
 	if(minimap_displayed)
-		owner?.client?.screen -= map
+		owner?.client?.remove_from_screen(map)
 		minimap_displayed = FALSE
 
 /**
@@ -424,7 +424,7 @@ SUBSYSTEM_DEF(minimaps)
 /datum/action/minimap/proc/on_owner_z_change(atom/movable/source, oldz, newz)
 	SIGNAL_HANDLER
 	if(minimap_displayed)
-		owner.client.screen -= map
+		owner.client.remove_from_screen(map)
 		minimap_displayed = FALSE
 	map = null
 	if(!SSminimaps.minimaps_by_z["[newz]"] || !SSminimaps.minimaps_by_z["[newz]"].hud_image)

--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -103,7 +103,7 @@
 /mob/proc/handle_add_action(datum/action/action)
 	LAZYADD(actions, action)
 	if(client)
-		client.screen += action.button
+		client.add_to_screen(action.button)
 	update_action_buttons()
 
 /proc/remove_action(mob/L, action_path)
@@ -122,7 +122,7 @@
 /mob/proc/handle_remove_action(datum/action/action)
 	actions?.Remove(action)
 	if(client)
-		client.screen -= action.button
+		client.remove_from_screen(action.button)
 	update_action_buttons()
 
 /mob/living/carbon/human/handle_remove_action(datum/action/action)
@@ -219,12 +219,12 @@
 		for(var/datum/action/A in actions)
 			A.button.screen_loc = null
 			if(reload_screen)
-				client.screen += A.button
+				client.add_to_screen(A.button)
 	else
 		for(var/datum/action/A in actions)
 			var/atom/movable/screen/action_button/B = A.button
 			if(reload_screen)
-				client.screen += B
+				client.add_to_screen(B)
 			if(A.hidden)
 				B.screen_loc = null
 				continue
@@ -234,11 +234,11 @@
 		if(!button_number)
 			hud_used.hide_actions_toggle.screen_loc = null
 			if(reload_screen)
-				client.screen += hud_used.hide_actions_toggle
+				client.add_to_screen(hud_used.hide_actions_toggle)
 			return
 
 	hud_used.hide_actions_toggle.screen_loc = hud_used.hide_actions_toggle.get_button_screen_loc(button_number+1)
 
 	if(reload_screen)
-		client.screen += hud_used.hide_actions_toggle
+		client.add_to_screen(hud_used.hide_actions_toggle)
 

--- a/code/datums/keybinding/mob.dm
+++ b/code/datums/keybinding/mob.dm
@@ -2,6 +2,16 @@
 	category = CATEGORY_HUMAN
 	weight = WEIGHT_MOB
 
+/datum/keybinding/mob/down(client/user)
+	. = ..()
+	if(isobserver(user.mob))
+		return TRUE
+
+/datum/keybinding/mob/up(client/user)
+	. = ..()
+	if(isobserver(user.mob))
+		return TRUE
+
 /datum/keybinding/mob/stop_pulling
 	hotkey_keys = list("H", "Delete")
 	classic_keys = list("Delete")
@@ -85,7 +95,7 @@
 	. = ..()
 	if(.)
 		return
-	user.mob.a_select_zone("head")
+	user.mob.a_select_zone("head", user)
 	return TRUE
 
 /datum/keybinding/mob/target_r_arm
@@ -100,7 +110,7 @@
 	. = ..()
 	if(.)
 		return
-	user.mob.a_select_zone("rarm")
+	user.mob.a_select_zone("rarm", user)
 	return TRUE
 
 /datum/keybinding/mob/target_body_chest
@@ -115,7 +125,7 @@
 	. = ..()
 	if(.)
 		return
-	user.mob.a_select_zone("chest")
+	user.mob.a_select_zone("chest", user)
 	return TRUE
 
 /datum/keybinding/mob/target_left_arm
@@ -130,7 +140,7 @@
 	. = ..()
 	if(.)
 		return
-	user.mob.a_select_zone("larm")
+	user.mob.a_select_zone("larm", user)
 	return TRUE
 
 /datum/keybinding/mob/target_right_leg
@@ -145,7 +155,7 @@
 	. = ..()
 	if(.)
 		return
-	user.mob.a_select_zone("rleg")
+	user.mob.a_select_zone("rleg", user)
 	return TRUE
 
 /datum/keybinding/mob/target_body_groin
@@ -160,7 +170,7 @@
 	. = ..()
 	if(.)
 		return
-	user.mob.a_select_zone("groin")
+	user.mob.a_select_zone("groin", user)
 	return TRUE
 
 /datum/keybinding/mob/target_left_leg
@@ -175,7 +185,7 @@
 	. = ..()
 	if(.)
 		return
-	user.mob.a_select_zone("lleg")
+	user.mob.a_select_zone("lleg", user)
 	return TRUE
 
 /datum/keybinding/mob/target_next
@@ -190,7 +200,7 @@
 	. = ..()
 	if(.)
 		return
-	user.mob.a_select_zone("next")
+	user.mob.a_select_zone("next", user)
 	return TRUE
 
 /datum/keybinding/mob/target_prev
@@ -205,7 +215,7 @@
 	. = ..()
 	if(.)
 		return
-	user.mob.a_select_zone("prev")
+	user.mob.a_select_zone("prev", user)
 	return TRUE
 
 /datum/keybinding/mob/prevent_movement

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -39,6 +39,8 @@
 		msg_admin_niche("[key]/[ckey] has tried to transfer to deleted [new_character].")
 		return
 
+	SEND_SIGNAL(current.client, COMSIG_CLIENT_MIND_TRANSFER, new_character)
+
 	if(current)
 		current.mind = null //remove ourself from our old body's mind variable
 		nanomanager.user_transferred(current, new_character) // transfer active NanoUI instances to new user
@@ -70,6 +72,8 @@
 						ui.close()
 						continue
 			player_entity = setup_player_entity(ckey)
+
+	SEND_SIGNAL(new_character, COMSIG_MOB_NEW_MIND, current.client)
 
 	new_character.refresh_huds(current) //inherit the HUDs from the old body
 	new_character.aghosted = FALSE //reset aghost and away timer

--- a/code/game/gamemodes/cm_self_destruct.dm
+++ b/code/game/gamemodes/cm_self_destruct.dm
@@ -278,7 +278,7 @@ var/global/datum/authority/branch/evacuation/EvacuationAuthority //This is initi
 		if(play_anim)
 			for(var/mob/current_mob as anything in alive_mobs + dead_mobs)
 				if(current_mob && current_mob.loc && current_mob.client)
-					current_mob.client.screen |= C //They may have disconnected in the mean time.
+					current_mob.client.add_to_screen(C)  //They may have disconnected in the mean time.
 
 			sleep(15) //Extra 1.5 seconds to look at the ship.
 			flick(override ? "intro_override" : "intro_nuke", C)
@@ -292,7 +292,7 @@ var/global/datum/authority/branch/evacuation/EvacuationAuthority //This is initi
 					current_mob.death(create_cause_data("nuclear explosion"))
 				else
 					if(play_anim)
-						current_mob.client.screen -= C //those who managed to escape the z level at last second shouldn't have their view obstructed.
+						current_mob.client.remove_from_screen(C) //those who managed to escape the z level at last second shouldn't have their view obstructed.
 		if(play_anim)
 			flick(ship_status ? "ship_spared" : "ship_destroyed", C)
 			C.icon_state = ship_status ? "summary_spared" : "summary_destroyed"

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -186,7 +186,7 @@
 	if(istype(S))
 		for(var/mob/M in S.can_see_content())
 			if(M.client)
-				M.client.screen -= src
+				M.client.remove_from_screen(src)
 	if(ismob(loc))
 		dropped(loc)
 

--- a/code/game/objects/items/devices/motion_detector.dm
+++ b/code/game/objects/items/devices/motion_detector.dm
@@ -281,12 +281,12 @@
 			DB.setDir(initial(DB.dir))
 
 		DB.screen_loc = "[Clamp(c_view + 1 - view_x_offset + (target.x - user.x), 1, 2*c_view+1)],[Clamp(c_view + 1 - view_y_offset + (target.y - user.y), 1, 2*c_view+1)]"
-		user.client.screen += DB
+		user.client.add_to_screen(DB)
 		addtimer(CALLBACK(src, PROC_REF(clear_pings), user, DB), 1 SECONDS)
 
 /obj/item/device/motiondetector/proc/clear_pings(mob/user, obj/effect/detector_blip/DB)
 	if(user.client)
-		user.client.screen -= DB
+		user.client.remove_from_screen(DB)
 
 /obj/item/device/motiondetector/m717
 	name = "M717 pocket motion detector"

--- a/code/game/objects/items/misc.dm
+++ b/code/game/objects/items/misc.dm
@@ -204,7 +204,7 @@
 				return //too deeply nested to access or not being carried by the user.
 
 			var/obj/item/storage/U = I.loc
-			user.client.screen -= I
+			user.client.remove_from_screen(I)
 			U.contents.Remove(I)
 		else if(user.l_hand == I) //in a hand
 			user.drop_l_hand()

--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -92,25 +92,24 @@
 				return
 	if(user.s_active)
 		user.s_active.hide_from(user)
-	user.client.screen -= boxes
-	user.client.screen -= storage_start
-	user.client.screen -= storage_continue
-	user.client.screen -= storage_end
-	user.client.screen -= closer
-	user.client.screen -= contents
-	user.client.screen += closer
-	user.client.screen += contents
+	user.client.remove_from_screen(boxes)
+	user.client.remove_from_screen(storage_start)
+	user.client.remove_from_screen(storage_continue)
+	user.client.remove_from_screen(storage_end)
+	user.client.remove_from_screen(closer)
+	user.client.remove_from_screen(contents)
+	user.client.add_to_screen(closer)
+	user.client.add_to_screen(contents)
 
 	if(storage_slots)
-		user.client.screen += boxes
+		user.client.add_to_screen(boxes)
 	else
-		user.client.screen += storage_start
-		user.client.screen += storage_continue
-		user.client.screen += storage_end
+		user.client.add_to_screen(storage_start)
+		user.client.add_to_screen(storage_continue)
+		user.client.add_to_screen(storage_end)
 
 	user.s_active = src
 	add_to_watchers(user)
-	return
 
 /obj/item/storage/proc/add_to_watchers(mob/user)
 	if(!(user in content_watchers))
@@ -125,12 +124,12 @@
 ///Used to hide the storage's inventory screen.
 /obj/item/storage/proc/hide_from(mob/user as mob)
 	if(user.client)
-		user.client.screen -= src.boxes
-		user.client.screen -= storage_start
-		user.client.screen -= storage_continue
-		user.client.screen -= storage_end
-		user.client.screen -= src.closer
-		user.client.screen -= src.contents
+		user.client.remove_from_screen(src.boxes)
+		user.client.remove_from_screen(storage_start)
+		user.client.remove_from_screen(storage_continue)
+		user.client.remove_from_screen(storage_end)
+		user.client.remove_from_screen(src.closer)
+		user.client.remove_from_screen(src.contents)
 	if(user.s_active == src)
 		user.s_active = null
 	del_from_watchers(user)
@@ -474,7 +473,7 @@ W is always an item. stop_warning prevents messaging. user may be null.**/
 	W.on_enter_storage(src)
 	if(user)
 		if (user.client && user.s_active != src)
-			user.client.screen -= W
+			user.client.remove_from_screen(W)
 		add_fingerprint(user)
 		if(!prevent_warning)
 			var/visidist = W.w_class >= 3 ? 3 : 1
@@ -500,7 +499,7 @@ W is always an item. stop_warning prevents messaging. user may be null.**/
 /obj/item/storage/proc/_item_removal(obj/item/W as obj, atom/new_location)
 	for(var/mob/M in can_see_content())
 		if(M.client)
-			M.client.screen -= W
+			M.client.remove_from_screen(W)
 
 	if(new_location)
 		if(ismob(new_location))

--- a/code/modules/admin/player_panel/actions/general.dm
+++ b/code/modules/admin/player_panel/actions/general.dm
@@ -187,7 +187,7 @@
 /datum/player_action/follow/act(client/user, mob/target, list/params)
 	if(istype(user.mob, /mob/dead/observer))
 		var/mob/dead/observer/O = user.mob
-		O.ManualFollow(target)
+		O.do_observe(target)
 		return TRUE
 	else
 		to_chat(user, SPAN_WARNING("You must be a ghost to do this."))

--- a/code/modules/admin/topic/topic.dm
+++ b/code/modules/admin/topic/topic.dm
@@ -1129,7 +1129,7 @@
 		sleep(2)
 		if(isobserver(usr))
 			var/mob/dead/observer/G = usr
-			G.ManualFollow(M)
+			G.do_observe(M)
 
 	else if(href_list["check_antagonist"])
 		check_antagonists()

--- a/code/modules/admin/view_variables/color_matrix_editor.dm
+++ b/code/modules/admin/view_variables/color_matrix_editor.dm
@@ -19,7 +19,7 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/color_matrix_proxy_view)
 
 /atom/movable/screen/color_matrix_proxy_view/Destroy()
 	for (var/plane_master in plane_masters)
-		client?.screen -= plane_master
+		client?.remove_from_screen(plane_master)
 		qdel(plane_master)
 
 	client?.clear_map(assigned_map)
@@ -40,7 +40,7 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/color_matrix_proxy_view)
 	for (var/plane_master_type in subtypesof(/atom/movable/screen/plane_master) - /atom/movable/screen/plane_master/blackness)
 		var/atom/movable/screen/plane_master/plane_master = new plane_master_type()
 		plane_master.screen_loc = "[assigned_map]:CENTER"
-		client?.screen |= plane_master
+		client?.add_to_screen(plane_master)
 
 		plane_masters += plane_master
 

--- a/code/modules/buildmode/buildmode.dm
+++ b/code/modules/buildmode/buildmode.dm
@@ -31,13 +31,13 @@
 	holder.player_details.post_login_callbacks += li_cb
 	holder.show_popup_menus = FALSE
 	create_buttons()
-	holder.screen += buttons
+	holder.add_to_screen(buttons)
 	holder.click_intercept = src
 	mode.enter_mode(src)
 
 /datum/buildmode/proc/quit()
 	mode.exit_mode(src)
-	holder.screen -= buttons
+	holder.remove_from_screen(buttons)
 	holder.click_intercept = null
 	holder.show_popup_menus = TRUE
 	qdel(src)
@@ -53,7 +53,7 @@
 
 /datum/buildmode/proc/post_login()
 	// since these will get wiped upon login
-	holder?.screen += buttons
+	holder?.add_to_screen(buttons)
 	// re-open the according switch mode
 	switch(switch_state)
 		if(BM_SWITCHSTATE_MODE)
@@ -103,11 +103,11 @@
 
 /datum/buildmode/proc/open_modeswitch()
 	switch_state = BM_SWITCHSTATE_MODE
-	holder.screen += modeswitch_buttons
+	holder.add_to_screen(modeswitch_buttons)
 
 /datum/buildmode/proc/close_modeswitch()
 	switch_state = BM_SWITCHSTATE_NONE
-	holder.screen -= modeswitch_buttons
+	holder.remove_from_screen(modeswitch_buttons)
 
 /datum/buildmode/proc/toggle_dirswitch()
 	if(switch_state == BM_SWITCHSTATE_DIR)
@@ -118,11 +118,11 @@
 
 /datum/buildmode/proc/open_dirswitch()
 	switch_state = BM_SWITCHSTATE_DIR
-	holder.screen += dirswitch_buttons
+	holder.add_to_screen(dirswitch_buttons)
 
 /datum/buildmode/proc/close_dirswitch()
 	switch_state = BM_SWITCHSTATE_NONE
-	holder.screen -= dirswitch_buttons
+	holder.remove_from_screen(dirswitch_buttons)
 
 /datum/buildmode/proc/change_mode(newmode)
 	mode.exit_mode(src)

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -753,7 +753,7 @@ GLOBAL_LIST_INIT(whitelisted_client_procs, list(
 		return FALSE
 
 	var/mob/dead/observer/observer = mob
-	observer.ManualFollow(target)
+	observer.do_observe(target)
 
 /client/proc/check_timelock(list/roles, hours)
 	var/timelock_name = "[islist(roles) ? jointext(roles, "") : roles][hours]"

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -783,7 +783,7 @@ GLOBAL_LIST_INIT(whitelisted_client_procs, list(
 			if (!screen_object.clear_with_screen)
 				continue
 
-		screen -= object
+		remove_from_screen(object)
 
 ///opens the particle editor UI for the in_atom object for this client
 /client/proc/open_particle_editor(atom/movable/in_atom)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -238,6 +238,9 @@ var/const/MAX_SAVE_SLOTS = 10
 	/// if this client has tooltips enabled
 	var/tooltips = TRUE
 
+	/// If this client has auto observe enabled, used by /datum/orbit_menu
+	var/auto_observe = TRUE
+
 /datum/preferences/New(client/C)
 	key_bindings = deepCopyList(GLOB.hotkey_keybinding_list_by_key) // give them default keybinds and update their movement keys
 	macros = new(C, src)

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -139,6 +139,7 @@
 	S["fps"] >> fps
 	S["ghost_vision_pref"] >> ghost_vision_pref
 	S["ghost_orbit"] >> ghost_orbit
+	S["auto_observe"] >> auto_observe
 
 	S["human_name_ban"] >> human_name_ban
 
@@ -219,6 +220,7 @@
 	window_skin = sanitize_integer(window_skin, 0, SHORT_REAL_LIMIT, initial(window_skin))
 	ghost_vision_pref = sanitize_inlist(ghost_vision_pref, list(GHOST_VISION_LEVEL_NO_NVG, GHOST_VISION_LEVEL_MID_NVG, GHOST_VISION_LEVEL_FULL_NVG), GHOST_VISION_LEVEL_MID_NVG)
 	ghost_orbit = sanitize_inlist(ghost_orbit, GLOB.ghost_orbits, initial(ghost_orbit))
+	auto_observe = sanitize_integer(auto_observe, 0, 1, 1)
 	playtime_perks   = sanitize_integer(playtime_perks, 0, 1, 1)
 	xeno_vision_level_pref = sanitize_inlist(xeno_vision_level_pref, list(XENO_VISION_LEVEL_NO_NVG, XENO_VISION_LEVEL_MID_NVG, XENO_VISION_LEVEL_FULL_NVG), XENO_VISION_LEVEL_MID_NVG)
 	hear_vox = sanitize_integer(hear_vox, FALSE, TRUE, TRUE)
@@ -322,6 +324,7 @@
 	S["fps"] << fps
 	S["ghost_vision_pref"] << ghost_vision_pref
 	S["ghost_orbit"] << ghost_orbit
+	S["auto_observe"] << auto_observe
 
 	S["human_name_ban"] << human_name_ban
 

--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -85,10 +85,10 @@ Gunshots/explosions/opening doors/less rare audio (done)
 								halitem.icon_state = "flashbang1"
 								halitem.name = "Flashbang"
 						if(client)
-							client.screen += halitem
+							client.add_to_screen(halitem)
 						spawn(rand(100,250))
 							if(client)
-								client.screen -= halitem
+								client.remove_from_screen(halitem)
 							halitem = null
 			if(26 to 40)
 				//Flashes of danger

--- a/code/modules/maptext_alerts/screen_alerts.dm
+++ b/code/modules/maptext_alerts/screen_alerts.dm
@@ -243,6 +243,6 @@
 			if(gotten_turf)
 				ghost_user.forceMove(gotten_turf)
 		if(NOTIFY_ORBIT)
-			ghost_user.ManualFollow(target)
+			ghost_user.do_observe(target)
 		if(NOTIFY_JOIN_XENO)
 			ghost_user.join_as_alien()

--- a/code/modules/maptext_alerts/screen_alerts.dm
+++ b/code/modules/maptext_alerts/screen_alerts.dm
@@ -66,7 +66,7 @@
 
 ///proc for actually playing this screen_text on a mob.
 /atom/movable/screen/text/screen_text/proc/play_to_client()
-	player?.screen += src
+	player?.add_to_screen(src)
 	if(fade_in_time)
 		animate(src, alpha = 255)
 	var/list/lines_to_skip = list()
@@ -106,7 +106,7 @@
 		qdel(src)
 		return
 
-	player.screen -= src
+	player.remove_from_screen(src)
 	LAZYREMOVE(player.screen_texts, src)
 	qdel(src)
 
@@ -196,7 +196,7 @@
 	alerts -= category
 	if(client && hud_used)
 		hud_used.reorganize_alerts()
-		client.screen -= alert
+		client.remove_from_screen(alert)
 	qdel(alert)
 
 /atom/movable/screen/alert

--- a/code/modules/maptext_alerts/text_blurbs.dm
+++ b/code/modules/maptext_alerts/text_blurbs.dm
@@ -136,7 +136,7 @@ but should see their own spawn message even if the player already dropped as USC
 			if(!ignore_key && (M.key in GLOB.blurb_witnesses[blurb_key]))
 				continue
 			LAZYDISTINCTADD(GLOB.blurb_witnesses[blurb_key], M.key)
-		M.client?.screen += T
+		M.client?.add_to_screen(T)
 
 	for(var/i in 1 to length(message) + 1)
 		if(i in linebreaks)
@@ -154,5 +154,5 @@ but should see their own spawn message even if the player already dropped as USC
 	animate(T, alpha = 0, time = 0.5 SECONDS)
 	sleep(5)
 	for(var/mob/M as anything in targets)
-		M.client?.screen -= T
+		M.client?.remove_from_screen(T)
 	qdel(T)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -49,8 +49,10 @@
 	var/updatedir = TRUE //Do we have to update our dir as the ghost moves around?
 	var/atom/movable/following = null
 	var/datum/orbit_menu/orbit_menu
-	/// The target mob that the ghost is observing. Used as a reference in logout()
-	var/mob/observetarget = null
+	/// The target mob that the ghost is observing.
+	var/mob/observe_target_mob = null
+	/// The target client that the ghost is observing.
+	var/client/observe_target_client = null
 	var/datum/health_scan/last_health_display
 	var/ghost_orbit = GHOST_ORBIT_CIRCLE
 	var/own_orbit_size = 0
@@ -152,28 +154,42 @@
 			lighting_alpha = LIGHTING_PLANE_ALPHA_INVISIBLE
 	update_sight()
 
-/mob/dead/observer/proc/clean_observetarget()
+/// Removes all signals and data related to the observe target and resets observer's HUD/eye
+/mob/dead/observer/proc/clean_observe_target()
 	SIGNAL_HANDLER
-	UnregisterSignal(observetarget, COMSIG_PARENT_QDELETING)
-	if(observetarget.client)
-		UnregisterSignal(observetarget.client, COMSIG_CLIENT_SCREEN_ADD)
-		UnregisterSignal(observetarget.client, COMSIG_CLIENT_SCREEN_REMOVE)
-	if(observetarget?.observers)
-		observetarget.observers -= src
-		UNSETEMPTY(observetarget.observers)
-	observetarget = null
+
+	UnregisterSignal(observe_target_mob, COMSIG_PARENT_QDELETING)
+	UnregisterSignal(observe_target_mob, COMSIG_MOB_GHOSTIZE)
+	UnregisterSignal(observe_target_mob, COMSIG_MOB_NEW_MIND)
+	UnregisterSignal(observe_target_mob, COMSIG_MOB_LOGIN)
+
+	if(observe_target_client)
+		UnregisterSignal(observe_target_client, COMSIG_CLIENT_SCREEN_ADD)
+		UnregisterSignal(observe_target_client, COMSIG_CLIENT_SCREEN_REMOVE)
+
+	if(observe_target_mob?.observers)
+		observe_target_mob.observers -= src
+		UNSETEMPTY(observe_target_mob.observers)
+
+	observe_target_mob = null
+	observe_target_client = null
+
 	client.eye = src
 	hud_used.show_hud(hud_used.hud_version, src)
 	UnregisterSignal(src, COMSIG_MOVABLE_MOVED)
 
+/// When the observer moves we disconnect from the observe target if we aren't on the same turf
 /mob/dead/observer/proc/observer_move_react()
 	SIGNAL_HANDLER
-	if(src.loc == get_turf(observetarget))
-		return
-	clean_observetarget()
 
-/mob/dead/observer/proc/observertarget_screen_add(observetarget_client, add_to_screen)
+	if(loc == get_turf(observe_target_mob))
+		return
+	clean_observe_target()
+
+/// When the observer target gets a screen, our observer gets a screen minus some game screens we don't want the observer to touch
+/mob/dead/observer/proc/observe_target_screen_add(observe_target_mob_client, add_to_screen)
 	SIGNAL_HANDLER
+
 	if(!client)
 		return
 
@@ -194,12 +210,42 @@
 
 	client.add_to_screen(add_to_screen)
 
-/mob/dead/observer/proc/observertarget_screen_remove(observetarget_client, remove_from_screen)
+/// When the observer target loses a screen, our observer loses it as well
+/mob/dead/observer/proc/observe_target_screen_remove(observe_target_mob_client, remove_from_screen)
 	SIGNAL_HANDLER
+
 	if(!client)
 		return
 
 	client.remove_from_screen(remove_from_screen)
+
+/// When the observe target ghosts our observer disconnect from their screen updates
+/mob/dead/observer/proc/observe_target_ghosting(mob/observer_target_mob)
+	SIGNAL_HANDLER
+
+	if(observe_target_client) //Should never not have one if ghostizing but maaaybe?
+		UnregisterSignal(observe_target_client, COMSIG_CLIENT_SCREEN_ADD)
+		UnregisterSignal(observe_target_client, COMSIG_CLIENT_SCREEN_REMOVE)
+
+/// When the observe target gets a new mind our observer connects to the new client's screens
+/mob/dead/observer/proc/observe_target_new_mind(mob/living/new_character, client/new_client)
+	SIGNAL_HANDLER
+
+	if(observe_target_client != new_client)
+		observe_target_client = new_client
+
+	RegisterSignal(observe_target_client, COMSIG_CLIENT_SCREEN_ADD, PROC_REF(observe_target_screen_add))
+	RegisterSignal(observe_target_client, COMSIG_CLIENT_SCREEN_REMOVE, PROC_REF(observe_target_screen_remove))
+
+/// When the observe target logs in our observer connect to the new client
+/mob/dead/observer/proc/observe_target_login(mob/living/new_character)
+	SIGNAL_HANDLER
+
+	if(observe_target_client != new_character.client)
+		observe_target_client = new_character.client
+
+	RegisterSignal(observe_target_client, COMSIG_CLIENT_SCREEN_ADD, PROC_REF(observe_target_screen_add))
+	RegisterSignal(observe_target_client, COMSIG_CLIENT_SCREEN_REMOVE, PROC_REF(observe_target_screen_remove))
 
 ///makes the ghost see the target hud and sets the eye at the target.
 /mob/dead/observer/proc/do_observe(mob/target)
@@ -241,16 +287,23 @@
 
 		break
 
-	observetarget = target
-	RegisterSignal(observetarget, COMSIG_PARENT_QDELETING, PROC_REF(clean_observetarget))
+	observe_target_mob = target
+	RegisterSignal(observe_target_mob, COMSIG_PARENT_QDELETING, PROC_REF(clean_observe_target))
+	RegisterSignal(observe_target_mob, COMSIG_MOB_GHOSTIZE, PROC_REF(observe_target_ghosting))
+	RegisterSignal(observe_target_mob, COMSIG_MOB_NEW_MIND, PROC_REF(observe_target_new_mind))
+	RegisterSignal(observe_target_mob, COMSIG_MOB_LOGIN, PROC_REF(observe_target_login))
+
 	RegisterSignal(src, COMSIG_MOVABLE_MOVED, PROC_REF(observer_move_react))
+
 	if(target.client)
-		RegisterSignal(target.client, COMSIG_CLIENT_SCREEN_ADD, PROC_REF(observertarget_screen_add))
-		RegisterSignal(target.client, COMSIG_CLIENT_SCREEN_REMOVE, PROC_REF(observertarget_screen_remove))
+		observe_target_client = target.client
+		RegisterSignal(observe_target_client, COMSIG_CLIENT_SCREEN_ADD, PROC_REF(observe_target_screen_add))
+		RegisterSignal(observe_target_client, COMSIG_CLIENT_SCREEN_REMOVE, PROC_REF(observe_target_screen_remove))
+		return
 
 /mob/dead/observer/reset_perspective(atom/A)
-	if(observetarget)
-		clean_observetarget()
+	if(observe_target_mob)
+		clean_observe_target()
 	. = ..()
 
 	if(!.)
@@ -269,12 +322,16 @@
 
 	client.move_delay = MINIMAL_MOVEMENT_INTERVAL
 
+	if(observe_target_mob)
+		clean_observe_target()
+
 /mob/dead/observer/Destroy()
 	QDEL_NULL(orbit_menu)
 	QDEL_NULL(last_health_display)
 	GLOB.observer_list -= src
 	following = null
-	observetarget = null
+	observe_target_mob = null
+	observe_target_client = null
 	return ..()
 
 /mob/dead/observer/MouseDrop(atom/A)
@@ -388,6 +445,9 @@ Works together with spawning an observer, noted above.
 		return
 	if(aghosted)
 		src.aghosted = TRUE
+
+	SEND_SIGNAL(src, COMSIG_MOB_GHOSTIZE)
+
 	var/mob/dead/observer/ghost = new(loc, src) //Transfer safety to observer spawning proc.
 	ghost.can_reenter_corpse = can_reenter_corpse
 	ghost.timeofdeath = timeofdeath //BS12 EDIT

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -186,6 +186,9 @@
 	if(istype(add_to_screen, /atom/movable/screen/click_catcher))
 		return
 
+	if(istype(add_to_screen, /atom/movable/screen/escape_menu))
+		return
+
 	client.add_to_screen(add_to_screen)
 
 /mob/dead/observer/proc/observertarget_screen_remove(observetarget_client, remove_from_screen)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -180,6 +180,12 @@
 	if(istype(add_to_screen, /atom/movable/screen/action_button))
 		return
 
+	if(istype(add_to_screen, /atom/movable/screen/fullscreen))
+		return
+
+	if(istype(add_to_screen, /atom/movable/screen/click_catcher))
+		return
+
 	client.add_to_screen(add_to_screen)
 
 /mob/dead/observer/proc/observertarget_screen_remove(observetarget_client, remove_from_screen)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -176,12 +176,17 @@
 	SIGNAL_HANDLER
 	if(!client)
 		return
+
+	if(istype(add_to_screen, /atom/movable/screen/action_button))
+		return
+
 	client.add_to_screen(add_to_screen)
 
 /mob/dead/observer/proc/observertarget_screen_remove(observetarget_client, remove_from_screen)
 	SIGNAL_HANDLER
 	if(!client)
 		return
+
 	client.remove_from_screen(remove_from_screen)
 
 ///makes the ghost see the target hud and sets the eye at the target.

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -189,6 +189,9 @@
 	if(istype(add_to_screen, /atom/movable/screen/escape_menu))
 		return
 
+	if(istype(add_to_screen, /obj/effect/detector_blip))
+		return
+
 	client.add_to_screen(add_to_screen)
 
 /mob/dead/observer/proc/observertarget_screen_remove(observetarget_client, remove_from_screen)
@@ -293,8 +296,14 @@
 			A.reenter_corpse()
 	if(href_list["track"])
 		var/mob/target = locate(href_list["track"]) in GLOB.mob_list
-		if(target)
-			ManualFollow(target)
+		if(!target)
+			return
+		ManualFollow(target)
+		reset_perspective(null)
+
+		if(client.prefs.auto_observe)
+			do_observe(target)
+
 	if(href_list[XENO_OVERWATCH_TARGET_HREF])
 		var/mob/target = locate(href_list[XENO_OVERWATCH_TARGET_HREF]) in GLOB.living_xeno_list
 		if(target)
@@ -635,7 +644,10 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	set desc = "Follow on-screen mob"
 
 	ManualFollow(target)
-	return
+	reset_perspective(null)
+
+	if(client.prefs.auto_observe)
+		do_observe(target)
 
 /mob/dead/observer/verb/follow()
 	set category = "Ghost.Follow"

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -155,6 +155,9 @@
 /mob/dead/observer/proc/clean_observetarget()
 	SIGNAL_HANDLER
 	UnregisterSignal(observetarget, COMSIG_PARENT_QDELETING)
+	if(observetarget.client)
+		UnregisterSignal(observetarget.client, COMSIG_CLIENT_SCREEN_ADD)
+		UnregisterSignal(observetarget.client, COMSIG_CLIENT_SCREEN_REMOVE)
 	if(observetarget?.observers)
 		observetarget.observers -= src
 		UNSETEMPTY(observetarget.observers)
@@ -169,12 +172,23 @@
 		return
 	clean_observetarget()
 
+/mob/dead/observer/proc/observertarget_screen_add(observetarget_client, add_to_screen)
+	SIGNAL_HANDLER
+	if(!client)
+		return
+	client.add_to_screen(add_to_screen)
+
+/mob/dead/observer/proc/observertarget_screen_remove(observetarget_client, remove_from_screen)
+	SIGNAL_HANDLER
+	if(!client)
+		return
+	client.remove_from_screen(remove_from_screen)
+
 ///makes the ghost see the target hud and sets the eye at the target.
 /mob/dead/observer/proc/do_observe(mob/target)
 	if(!client || !target || !istype(target))
 		return
 
-	//I do not give a singular flying fuck about not being able to see xeno huds, literally only human huds are useful to see
 	if(!ishuman(target))
 		ManualFollow(target)
 		return
@@ -191,6 +205,9 @@
 	observetarget = target
 	RegisterSignal(observetarget, COMSIG_PARENT_QDELETING, PROC_REF(clean_observetarget))
 	RegisterSignal(src, COMSIG_MOVABLE_MOVED, PROC_REF(observer_move_react))
+	if(target.client)
+		RegisterSignal(target.client, COMSIG_CLIENT_SCREEN_ADD, PROC_REF(observertarget_screen_add))
+		RegisterSignal(target.client, COMSIG_CLIENT_SCREEN_REMOVE, PROC_REF(observertarget_screen_remove))
 
 /mob/dead/observer/reset_perspective(atom/A)
 	if(observetarget)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -252,8 +252,10 @@
 	if(!client || !target || !istype(target))
 		return
 
-	if(!ishuman(target))
-		ManualFollow(target)
+	ManualFollow(target)
+	reset_perspective()
+
+	if(!ishuman(target) || !client.prefs?.auto_observe)
 		return
 
 	client.eye = target
@@ -355,11 +357,7 @@
 		var/mob/target = locate(href_list["track"]) in GLOB.mob_list
 		if(!target)
 			return
-		ManualFollow(target)
-		reset_perspective(null)
-
-		if(client.prefs.auto_observe)
-			do_observe(target)
+		do_observe(target)
 
 	if(href_list[XENO_OVERWATCH_TARGET_HREF])
 		var/mob/target = locate(href_list[XENO_OVERWATCH_TARGET_HREF]) in GLOB.living_xeno_list
@@ -703,11 +701,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	set name = "Follow Local Mob"
 	set desc = "Follow on-screen mob"
 
-	ManualFollow(target)
-	reset_perspective(null)
-
-	if(client.prefs.auto_observe)
-		do_observe(target)
+	do_observe(target)
 
 /mob/dead/observer/verb/follow()
 	set category = "Ghost.Follow"

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -213,6 +213,28 @@
 	LAZYINITLIST(target.observers)
 	target.observers |= src
 	target.hud_used.show_hud(target.hud_used.hud_version, src)
+
+	var/mob/living/carbon/human/human_target = target
+
+	var/list/target_contents = human_target.get_contents()
+
+	//Handles any currently open storage containers the target is looking in when we observe
+	for(var/obj/item/storage/checked_storage in target_contents)
+		if(!(target in checked_storage.content_watchers))
+			continue
+
+		client.add_to_screen(checked_storage.closer)
+		client.add_to_screen(checked_storage.contents)
+
+		if(checked_storage.storage_slots)
+			client.add_to_screen(checked_storage.boxes)
+		else
+			client.add_to_screen(checked_storage.storage_start)
+			client.add_to_screen(checked_storage.storage_continue)
+			client.add_to_screen(checked_storage.storage_end)
+
+		break
+
 	observetarget = target
 	RegisterSignal(observetarget, COMSIG_PARENT_QDELETING, PROC_REF(clean_observetarget))
 	RegisterSignal(src, COMSIG_MOVABLE_MOVED, PROC_REF(observer_move_react))

--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -23,7 +23,7 @@
 	switch(action)
 		if("orbit")
 			var/ref = params["ref"]
-			var/auto_observe = params["auto_observe"]
+			var/auto_observe = ui.user?.client?.prefs.auto_observe
 			var/atom/movable/poi = locate(ref) in GLOB.mob_list
 			if (poi == null)
 				poi = locate(ref) in GLOB.all_multi_vehicles
@@ -38,11 +38,15 @@
 		if("refresh")
 			update_static_data(owner)
 			. = TRUE
-
-
+		if("toggle_auto_observe")
+			ui.user?.client?.prefs.auto_observe = !ui.user?.client?.prefs.auto_observe
+			ui.user?.client?.prefs.save_preferences()
+			. = TRUE
 
 /datum/orbit_menu/ui_data(mob/user)
 	var/list/data = list()
+
+	data["auto_observe"] = user?.client?.prefs.auto_observe
 	return data
 
 /datum/orbit_menu/ui_static_data(mob/user)

--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -23,30 +23,27 @@
 	switch(action)
 		if("orbit")
 			var/ref = params["ref"]
-			var/auto_observe = ui.user?.client?.prefs.auto_observe
+			var/auto_observe = ui.user.client?.prefs?.auto_observe
 			var/atom/movable/poi = locate(ref) in GLOB.mob_list
 			if (poi == null)
 				poi = locate(ref) in GLOB.all_multi_vehicles
 				if (poi == null)
 					. = TRUE
 					return
-			owner.ManualFollow(poi)
-			owner.reset_perspective(null)
-			if(auto_observe)
-				owner.do_observe(poi)
+			owner.do_observe(poi)
 			. = TRUE
 		if("refresh")
 			update_static_data(owner)
 			. = TRUE
 		if("toggle_auto_observe")
-			ui.user?.client?.prefs.auto_observe = !ui.user?.client?.prefs.auto_observe
-			ui.user?.client?.prefs.save_preferences()
+			ui.user.client?.prefs?.auto_observe = !ui.user?.client?.prefs.auto_observe
+			ui.user.client?.prefs?.save_preferences()
 			. = TRUE
 
 /datum/orbit_menu/ui_data(mob/user)
 	var/list/data = list()
 
-	data["auto_observe"] = user?.client?.prefs.auto_observe
+	data["auto_observe"] = user.client?.prefs?.auto_observe
 	return data
 
 /datum/orbit_menu/ui_static_data(mob/user)

--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -23,7 +23,6 @@
 	switch(action)
 		if("orbit")
 			var/ref = params["ref"]
-			var/auto_observe = ui.user.client?.prefs?.auto_observe
 			var/atom/movable/poi = locate(ref) in GLOB.mob_list
 			if (poi == null)
 				poi = locate(ref) in GLOB.all_multi_vehicles

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -211,7 +211,8 @@
 		update_inv_l_hand()
 
 	if (client)
-		client.screen -= I
+		client.remove_from_screen(I)
+
 	I.layer = initial(I.layer)
 	I.plane = initial(I.plane)
 	if(newloc)

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -358,7 +358,7 @@ Applied by gun suicide and high impact bullet executions, removed by rejuvenate,
 	remove_overlay(UNIFORM_LAYER)
 	if(w_uniform)
 		if(client && hud_used && hud_used.hud_shown && hud_used.inventory_shown && hud_used.ui_datum)
-			client.screen += w_uniform
+			client.add_to_screen(w_uniform)
 			w_uniform.screen_loc = hud_used.ui_datum.hud_slot_offset(w_uniform, hud_used.ui_datum.ui_iclothing)
 
 		if(!(wear_suit && wear_suit.flags_inv_hide & HIDEJUMPSUIT))
@@ -375,7 +375,7 @@ Applied by gun suicide and high impact bullet executions, removed by rejuvenate,
 	if(!wear_id)
 		return
 	if(client && hud_used && hud_used.hud_shown && hud_used.ui_datum)
-		client.screen += wear_id
+		client.add_to_screen(wear_id)
 		wear_id.screen_loc = hud_used.ui_datum.hud_slot_offset(wear_id, hud_used.ui_datum.ui_id)
 
 	if(!wear_id.pinned_on_uniform || (w_uniform && w_uniform.displays_id && !(w_uniform.flags_jumpsuit & UNIFORM_JACKET_REMOVED)))
@@ -389,7 +389,7 @@ Applied by gun suicide and high impact bullet executions, removed by rejuvenate,
 	var/image/I
 	if(gloves)
 		if(client && hud_used && hud_used.hud_shown && hud_used.inventory_shown && hud_used.ui_datum)
-			client.screen += gloves
+			client.add_to_screen(gloves)
 			gloves.screen_loc = hud_used.ui_datum.hud_slot_offset(gloves, hud_used.ui_datum.ui_gloves)
 
 		if(!(wear_suit && wear_suit.flags_inv_hide & HIDEGLOVES))
@@ -408,7 +408,7 @@ Applied by gun suicide and high impact bullet executions, removed by rejuvenate,
 	remove_overlay(GLASSES_LAYER)
 	if(glasses)
 		if(client && hud_used &&  hud_used.hud_shown && hud_used.inventory_shown && hud_used.ui_datum)
-			client.screen += glasses
+			client.add_to_screen(glasses)
 			glasses.screen_loc = hud_used.ui_datum.hud_slot_offset(glasses, hud_used.ui_datum.ui_glasses)
 
 		var/image/I = glasses.get_mob_overlay(src, WEAR_EYES)
@@ -423,9 +423,9 @@ Applied by gun suicide and high impact bullet executions, removed by rejuvenate,
 	if(wear_l_ear || wear_r_ear)
 		if(client && hud_used && hud_used.hud_shown && hud_used.inventory_shown && hud_used.ui_datum)
 			if(wear_l_ear)
-				client.screen += wear_l_ear
+				client.add_to_screen(wear_l_ear)
 			if(wear_r_ear)
-				client.screen += wear_r_ear
+				client.add_to_screen(wear_r_ear)
 			wear_l_ear?.screen_loc = hud_used.ui_datum.hud_slot_offset(wear_l_ear, hud_used.ui_datum.ui_wear_l_ear)
 			wear_r_ear?.screen_loc = hud_used.ui_datum.hud_slot_offset(wear_r_ear, hud_used.ui_datum.ui_wear_r_ear)
 
@@ -444,7 +444,7 @@ Applied by gun suicide and high impact bullet executions, removed by rejuvenate,
 	var/image/I
 	if(shoes)
 		if(client && hud_used && hud_used.hud_shown && hud_used.inventory_shown && hud_used.ui_datum)
-			client.screen += shoes
+			client.add_to_screen(shoes)
 			shoes.screen_loc = hud_used.ui_datum.hud_slot_offset(shoes, hud_used.ui_datum.ui_shoes)
 
 		if(!((wear_suit && wear_suit.flags_inv_hide & HIDESHOES) || (w_uniform && w_uniform.flags_inv_hide & HIDESHOES)))
@@ -463,7 +463,7 @@ Applied by gun suicide and high impact bullet executions, removed by rejuvenate,
 	remove_overlay(SUIT_STORE_LAYER)
 	if(s_store)
 		if(client && hud_used && hud_used.hud_shown && hud_used.ui_datum)
-			client.screen += s_store
+			client.add_to_screen(s_store)
 			s_store.screen_loc = hud_used.ui_datum.hud_slot_offset(s_store, hud_used.ui_datum.ui_sstore1)
 
 		var/image/I = s_store.get_mob_overlay(src, WEAR_J_STORE)
@@ -483,7 +483,7 @@ Applied by gun suicide and high impact bullet executions, removed by rejuvenate,
 	if(head)
 
 		if(client && hud_used && hud_used.hud_shown && hud_used.inventory_shown && hud_used.ui_datum)
-			client.screen += head
+			client.add_to_screen(head)
 			head.screen_loc = hud_used.ui_datum.hud_slot_offset(head, hud_used.ui_datum.ui_head)
 
 		var/image/I = head.get_mob_overlay(src, WEAR_HEAD)
@@ -528,7 +528,7 @@ Applied by gun suicide and high impact bullet executions, removed by rejuvenate,
 	if(!belt)
 		return
 	if(client && hud_used && hud_used.hud_shown && hud_used.ui_datum)
-		client.screen += belt
+		client.add_to_screen(belt)
 		belt.screen_loc = hud_used.ui_datum.hud_slot_offset(belt, hud_used.ui_datum.ui_belt)
 
 	var/image/I = belt.get_mob_overlay(src, WEAR_WAIST)
@@ -545,7 +545,7 @@ Applied by gun suicide and high impact bullet executions, removed by rejuvenate,
 
 	if(wear_suit)
 		if(client && hud_used && hud_used.hud_shown && hud_used.inventory_shown && hud_used.ui_datum)
-			client.screen += wear_suit
+			client.add_to_screen(wear_suit)
 			wear_suit.screen_loc = hud_used.ui_datum.hud_slot_offset(wear_suit, hud_used.ui_datum.ui_oclothing)
 
 		var/image/I = wear_suit.get_mob_overlay(src, WEAR_JACKET)
@@ -597,10 +597,10 @@ Applied by gun suicide and high impact bullet executions, removed by rejuvenate,
 		return
 
 	if(l_store)
-		client.screen += l_store
+		client.add_to_screen(l_store)
 		l_store.screen_loc = hud_used.ui_datum.hud_slot_offset(l_store, hud_used.ui_datum.ui_storage1)
 	if(r_store)
-		client.screen += r_store
+		client.add_to_screen(r_store)
 		r_store.screen_loc = hud_used.ui_datum.hud_slot_offset(r_store, hud_used.ui_datum.ui_storage2)
 
 
@@ -609,7 +609,7 @@ Applied by gun suicide and high impact bullet executions, removed by rejuvenate,
 	if(!wear_mask)
 		return
 	if(client && hud_used && hud_used.hud_shown && hud_used.inventory_shown && hud_used.ui_datum)
-		client.screen += wear_mask
+		client.add_to_screen(wear_mask)
 		wear_mask.screen_loc = hud_used.ui_datum.hud_slot_offset(wear_mask, hud_used.ui_datum.ui_mask)
 
 	if(!(head && head.flags_inv_hide & HIDEMASK))
@@ -623,7 +623,7 @@ Applied by gun suicide and high impact bullet executions, removed by rejuvenate,
 	if(!back)
 		return
 	if(client && hud_used && hud_used.hud_shown && hud_used.ui_datum)
-		client.screen += back
+		client.add_to_screen(back)
 		back.screen_loc = hud_used.ui_datum.hud_slot_offset(back, hud_used.ui_datum.ui_back)
 
 	var/image/I = back.get_mob_overlay(src, WEAR_BACK)
@@ -661,7 +661,7 @@ Applied by gun suicide and high impact bullet executions, removed by rejuvenate,
 	if(!r_hand)
 		return
 	if(client && hud_used && hud_used.hud_version != HUD_STYLE_NOHUD && hud_used.ui_datum)
-		client.screen += r_hand
+		client.add_to_screen(r_hand)
 		r_hand.screen_loc = hud_used.ui_datum.hud_slot_offset(r_hand, hud_used.ui_datum.ui_rhand)
 
 	var/image/I = r_hand.get_mob_overlay(src, WEAR_R_HAND)
@@ -676,7 +676,7 @@ Applied by gun suicide and high impact bullet executions, removed by rejuvenate,
 	if(!l_hand)
 		return
 	if(client && hud_used && hud_used.hud_version != HUD_STYLE_NOHUD && hud_used.ui_datum)
-		client.screen += l_hand
+		client.add_to_screen(l_hand)
 		l_hand.screen_loc = hud_used.ui_datum.hud_slot_offset(l_hand, hud_used.ui_datum.ui_lhand)
 
 	var/image/I = l_hand.get_mob_overlay(src, WEAR_L_HAND)

--- a/code/modules/mob/living/carbon/xenomorph/update_icons.dm
+++ b/code/modules/mob/living/carbon/xenomorph/update_icons.dm
@@ -97,11 +97,11 @@
 	var/datum/custom_hud/alien/ui_datum = GLOB.custom_huds_list[HUD_ALIEN]
 	if(l_store)
 		if(client && hud_used && hud_used.hud_shown)
-			client.screen += l_store
+			client.add_to_screen(l_store)
 			l_store.screen_loc = ui_datum.hud_slot_offset(l_store, ui_datum.ui_storage1)
 	if(r_store)
 		if(client && hud_used && hud_used.hud_shown)
-			client.screen += r_store
+			client.add_to_screen(r_store)
 			r_store.screen_loc = ui_datum.hud_slot_offset(r_store, ui_datum.ui_storage2)
 
 /mob/living/carbon/xenomorph/update_inv_r_hand()
@@ -109,7 +109,7 @@
 	if(r_hand)
 		if(client && hud_used && hud_used.hud_version != HUD_STYLE_NOHUD)
 			var/datum/custom_hud/alien/ui_datum = GLOB.custom_huds_list[HUD_ALIEN]
-			client.screen += r_hand
+			client.add_to_screen(r_hand)
 			r_hand.screen_loc = ui_datum.hud_slot_offset(r_hand, ui_datum.ui_rhand)
 		var/t_state = r_hand.item_state
 		if(!t_state)
@@ -122,7 +122,7 @@
 	if(l_hand)
 		if(client && hud_used && hud_used.hud_version != HUD_STYLE_NOHUD)
 			var/datum/custom_hud/alien/ui_datum = GLOB.custom_huds_list[HUD_ALIEN]
-			client.screen += l_hand
+			client.add_to_screen(l_hand)
 			l_hand.screen_loc = ui_datum.hud_slot_offset(l_hand, ui_datum.ui_lhand)
 		var/t_state = l_hand.item_state
 		if(!t_state)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -95,43 +95,26 @@
 
 
 //Recursive function to find everything a mob is holding.
-/mob/living/get_contents(obj/item/storage/Storage = null)
-	var/list/L = list()
+/mob/living/get_contents(obj/passed_object, recursion = 0)
+	var/list/total_contents = list()
 
-	if(Storage) //If it called itself
-		L += Storage.return_inv()
+	if(passed_object)
+		if(recursion > 8)
+			debug_log("Recursion went long for get_contents() for [src] ending at the object [passed_object]. Likely object_one is holding object_two which is holding object_one ad naseum.")
+			return total_contents
 
-		//Leave this commented out, it will cause storage items to exponentially add duplicate to the list
-		//for(var/obj/item/storage/S in Storage.return_inv()) //Check for storage items
-		// L += get_contents(S)
+		total_contents += passed_object.contents
 
-		for(var/obj/item/gift/G in Storage.return_inv()) //Check for gift-wrapped items
-			L += G.gift
-			if(isstorage(G.gift))
-				L += get_contents(G.gift)
+		for(var/obj/checked_object in total_contents)
+			total_contents += get_contents(checked_object, recursion + 1)
 
-		for(var/obj/item/smallDelivery/D in Storage.return_inv()) //Check for package wrapped items
-			L += D.wrapped
-			if(isstorage(D.wrapped)) //this should never happen
-				L += get_contents(D.wrapped)
-		return L
+		return total_contents
 
-	else
+	total_contents += contents
+	for(var/obj/checked_object in total_contents)
+		total_contents += get_contents(checked_object, recursion + 1)
 
-		L += src.contents
-		for(var/obj/item/storage/S in src.contents) //Check for storage items
-			L += get_contents(S)
-
-		for(var/obj/item/gift/G in src.contents) //Check for gift-wrapped items
-			L += G.gift
-			if(isstorage(G.gift))
-				L += get_contents(G.gift)
-
-		for(var/obj/item/smallDelivery/D in src.contents) //Check for package wrapped items
-			L += D.wrapped
-			if(isstorage(D.wrapped)) //this should never happen
-				L += get_contents(D.wrapped)
-		return L
+	return total_contents
 
 /mob/living/proc/check_contents_for(A)
 	var/list/L = src.get_contents()

--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -13,7 +13,7 @@
 		if(istype(module_state_1,/obj/item/robot/sight))
 			sight_mode &= ~module_state_1:sight_mode
 		if (client)
-			client.screen -= module_state_1
+			client.remove_from_screen(module_state_1)
 		contents -= module_state_1
 		module_active = null
 		module_state_1 = null
@@ -22,7 +22,7 @@
 		if(istype(module_state_2,/obj/item/robot/sight))
 			sight_mode &= ~module_state_2:sight_mode
 		if (client)
-			client.screen -= module_state_2
+			client.remove_from_screen(module_state_2)
 		contents -= module_state_2
 		module_active = null
 		module_state_2 = null
@@ -31,7 +31,7 @@
 		if(istype(module_state_3,/obj/item/robot/sight))
 			sight_mode &= ~module_state_3:sight_mode
 		if (client)
-			client.screen -= module_state_3
+			client.remove_from_screen(module_state_3)
 		contents -= module_state_3
 		module_active = null
 		module_state_3 = null
@@ -45,7 +45,7 @@
 		if(istype(module_state_1,/obj/item/robot/sight))
 			sight_mode &= ~module_state_1:sight_mode
 		if (client)
-			client.screen -= module_state_1
+			client.remove_from_screen(module_state_1)
 		contents -= module_state_1
 		module_state_1 = null
 		inv1.icon_state = "inv1"
@@ -53,7 +53,7 @@
 		if(istype(module_state_2,/obj/item/robot/sight))
 			sight_mode &= ~module_state_2:sight_mode
 		if (client)
-			client.screen -= module_state_2
+			client.remove_from_screen(module_state_2)
 		contents -= module_state_2
 		module_state_2 = null
 		inv2.icon_state = "inv2"
@@ -61,7 +61,7 @@
 		if(istype(module_state_3,/obj/item/robot/sight))
 			sight_mode &= ~module_state_3:sight_mode
 		if (client)
-			client.screen -= module_state_3
+			client.remove_from_screen(module_state_3)
 		contents -= module_state_3
 		module_state_3 = null
 		inv3.icon_state = "inv3"

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -239,10 +239,10 @@
 
 /mob/living/silicon/robot/proc/update_items()
 	if (client)
-		client.screen -= contents
+		client.remove_from_screen(contents)
 		for(var/obj/I in contents)
 			if(I && !(istype(I,/obj/item/cell) || istype(I,/obj/item/device/radio)  || istype(I,/obj/structure/machinery/camera) || istype(I,/obj/item/device/mmi)))
-				client.screen += I
+				client.add_to_screen(I)
 	var/datum/custom_hud/robot/ui_datum = GLOB.custom_huds_list[HUD_ROBOT]
 	if(module_state_1)
 		module_state_1.screen_loc = ui_datum.ui_inv1

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -322,13 +322,10 @@ var/global/list/limb_types_by_name = list(
 /mob/proc/get_eye_protection()
 	return EYE_PROTECTION_NONE
 
-/mob/verb/a_select_zone(input as text)
-	set name = "a-select-zone"
-	set hidden = TRUE
-
+/mob/proc/a_select_zone(input, client/user)
 	var/atom/movable/screen/zone_sel/zone
 
-	for(var/A in usr.client.screen)
+	for(var/A in user.screen)
 		if(istype(A, /atom/movable/screen/zone_sel))
 			zone = A
 

--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -200,19 +200,19 @@
 
 	if(isnull(preview_front))
 		preview_front = new()
-		owner.screen |= preview_front
+		owner.add_to_screen(preview_front)
 		preview_front.vis_contents += preview_dummy
 		preview_front.screen_loc = "preview:0,0"
 	preview_front.icon_state = bg_state
 
 	if(isnull(rotate_left))
 		rotate_left = new(null, preview_dummy)
-		owner.screen |= rotate_left
+		owner.add_to_screen(rotate_left)
 		rotate_left.screen_loc = "preview:-1:16,0"
 
 	if(isnull(rotate_right))
 		rotate_right = new(null, preview_dummy)
-		owner.screen |= rotate_right
+		owner.add_to_screen(rotate_right)
 		rotate_right.screen_loc = "preview:1:-16,0"
 
 /datum/preferences/proc/job_pref_to_gear_preset()

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -1535,7 +1535,7 @@ Defined in conflicts.dm of the #defines folder.
 	recalculate_scope_pos()
 	gun_user.overlay_fullscreen("vulture", /atom/movable/screen/fullscreen/vulture)
 	scope_element = new(src)
-	gun_user.client.screen += scope_element
+	gun_user.client.add_to_screen(scope_element)
 	gun_user.see_in_dark += darkness_view
 	gun_user.lighting_alpha = 127
 	gun_user.sync_lighting_plane_alpha()
@@ -1564,7 +1564,7 @@ Defined in conflicts.dm of the #defines folder.
 	stop_holding_breath()
 	scope_user_initial_dir = null
 	scoper.clear_fullscreen("vulture")
-	scoper.client.screen -= scope_element
+	scoper.client.remove_from_screen(scope_element)
 	scoper.see_in_dark -= darkness_view
 	scoper.lighting_alpha = 127
 	scoper.sync_lighting_plane_alpha()

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -241,7 +241,7 @@
 			var/obj/item/smallDelivery/P = new /obj/item/smallDelivery(get_turf(O.loc)) //Aaannd wrap it up!
 			if(!istype(O.loc, /turf))
 				if(user.client)
-					user.client.screen -= O
+					user.client.remove_from_screen(O)
 			P.wrapped = O
 			O.forceMove(P)
 			P.w_class = O.w_class

--- a/tgui/packages/tgui/interfaces/Orbit/index.tsx
+++ b/tgui/packages/tgui/interfaces/Orbit/index.tsx
@@ -29,18 +29,14 @@ export const Orbit = (props, context) => {
 /** Controls filtering out the list of observables via search */
 const ObservableSearch = (props, context) => {
   const { act, data } = useBackend<OrbitData>(context);
-  const {
-    auto_observe,
-    humans = [],
-    marines = [],
-    survivors = [],
-    xenos = [],
-  } = data;
+  const { humans = [], marines = [], survivors = [], xenos = [] } = data;
+
+  let auto_observe = data.auto_observe;
 
   const [autoObserve, setAutoObserve] = useLocalState<boolean>(
     context,
     'autoObserve',
-    false
+    auto_observe ? true : false
   );
   const [searchQuery, setSearchQuery] = useLocalState<string>(
     context,
@@ -89,7 +85,7 @@ const ObservableSearch = (props, context) => {
           <Button
             color={autoObserve ? 'good' : 'transparent'}
             icon={autoObserve ? 'toggle-on' : 'toggle-off'}
-            onClick={() => setAutoObserve(!autoObserve)}
+            onClick={() => act('toggle_auto_observe')}
             tooltip={multiline`Toggle Auto-Observe. When active, you'll
             see the UI / full inventory of whoever you're orbiting. Neat!`}
             tooltipPosition="bottom-start"
@@ -228,7 +224,7 @@ const ObservableItem = (
         'border-width': '1px',
         'color': color ? 'white' : 'grey',
       }}
-      onClick={() => act('orbit', { auto_observe: autoObserve, ref: ref })}
+      onClick={() => act('orbit', { ref: ref })}
       tooltip={!!health && <ObservableTooltip item={item} />}
       tooltipPosition="bottom-start">
       {!!health && (


### PR DESCRIPTION
# About the pull request

This PR creates wrappers for screen additions and removals to allow for a creation of a signal observers can then register to so the observed screen changes are all changed on any observer's screen as well.

Let me be very clear: this needs a lot of testing and I did this kind of ad hoc just to see if it would work. Brief testing seems to show it working but I expect there are oversights and problems. More than likely I am recreating the wheel in some way and doing it the dumb way.

# Explain why it's good for the game

Making the HUD observer more accurate is cool.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
add: Added a save-able preference for auto-observe
fix: Fixed numerous problems with HUD observer mode
code: Created a wrapper for client screen changes
code: Made check contents less horrendous
/:cl:
