### PR TITLE
Less Overpowered Commando ERTs (Marsoc, WY Whiteout, UPP Commandos)

### DIFF
--- a/code/datums/emergency_calls/deathsquad.dm
+++ b/code/datums/emergency_calls/deathsquad.dm
@@ -3,7 +3,7 @@
 
 //Weyland-Yutani Deathsquad - W-Y Deathsquad. Event only
 /datum/emergency_call/death
-	name = "Weyland Whiteout Operators (!WHITEOUT!)"
+	name = "Weyland Whiteout Operators (!DEATHSQUAD!)"
 	mob_max = 8
 	mob_min = 5
 	arrival_message = "'!`2*%slau#*jer t*h$em a!l%. le&*ve n(o^ w&*nes%6es.*v$e %#d ou^'"
@@ -99,7 +99,7 @@
 //################################################################################################
 // Marine commandos - USCM Deathsquad. Event only
 /datum/emergency_call/marsoc
-	name = "Marine Raider Strike Team (!WHITEOUT!)"
+	name = "Marine Raider Strike Team (!DEATHSQUAD!)"
 	mob_max = 8
 	mob_min = 5
 	probability = 0
@@ -128,7 +128,7 @@
 	return
 
 /datum/emergency_call/marsoc_covert
-	name = "Marine Raider Operatives (!WHITEOUT! Covert)"
+	name = "Marine Raider Operatives (!DEATHSQUAD! Covert)"
 	mob_max = 8
 	mob_min = 5
 	probability = 0

--- a/code/datums/emergency_calls/deathsquad.dm
+++ b/code/datums/emergency_calls/deathsquad.dm
@@ -49,11 +49,11 @@
 
 	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(to_chat), person, SPAN_BOLD("Objectives: [objectives]")), 1 SECONDS)
 
-/datum/emergency_call/death/lowthreat
+/datum/emergency_call/death/low_threat
 	name = "Weyland Whiteout Operators"
 
 // DEATH SQUAD--------------------------------------------------------------------------------
-/datum/emergency_call/death/lowthreat/create_member(datum/mind/player, turf/override_spawn_loc)
+/datum/emergency_call/death/low_threat/create_member(datum/mind/player, turf/override_spawn_loc)
 	var/turf/spawn_loc = override_spawn_loc ? override_spawn_loc : get_spawn_point()
 
 	if(!istype(spawn_loc))
@@ -66,21 +66,21 @@
 		leader = person
 		to_chat(person, SPAN_ROLE_HEADER("You are the Whiteout Team Leader!"))
 		to_chat(person, SPAN_ROLE_BODY("Whiteout protocol is in effect for the target, all assets onboard are to be liquidated with expediency unless otherwise instructed by Weyland Yutani personnel holding the position of Director or above."))
-		arm_equipment(person, /datum/equipment_preset/pmc/w_y_whiteout/lowthreat/leader, TRUE, TRUE)
+		arm_equipment(person, /datum/equipment_preset/pmc/w_y_whiteout/low_threat/leader, TRUE, TRUE)
 	else if(medics < max_medics && HAS_FLAG(person.client.prefs.toggles_ert, PLAY_MEDIC) && check_timelock(person.client, JOB_SQUAD_MEDIC, time_required_for_job))
 		medics++
 		to_chat(person, SPAN_ROLE_HEADER("You are a Whiteout Team Medic!"))
 		to_chat(person, SPAN_ROLE_BODY("Whiteout protocol is in effect for the target, all assets onboard are to be liquidated with expediency unless otherwise instructed by Weyland Yutani personnel holding the position of Director or above."))
-		arm_equipment(person, /datum/equipment_preset/pmc/w_y_whiteout/lowthreat/medic, TRUE, TRUE)
+		arm_equipment(person, /datum/equipment_preset/pmc/w_y_whiteout/low_threat/medic, TRUE, TRUE)
 	else if(heavies < max_heavies && HAS_FLAG(person.client.prefs.toggles_ert, PLAY_SMARTGUNNER) && check_timelock(person.client, list(JOB_SQUAD_SPECIALIST, JOB_SQUAD_SMARTGUN), time_required_for_job))
 		heavies++
 		to_chat(person, SPAN_ROLE_HEADER("You are a Whiteout Team Terminator!"))
 		to_chat(person, SPAN_ROLE_BODY("Whiteout protocol is in effect for the target, all assets onboard are to be liquidated with expediency unless otherwise instructed by Weyland Yutani personnel holding the position of Director or above."))
-		arm_equipment(person, /datum/equipment_preset/pmc/w_y_whiteout/lowthreat/terminator, TRUE, TRUE)
+		arm_equipment(person, /datum/equipment_preset/pmc/w_y_whiteout/low_threat/terminator, TRUE, TRUE)
 	else
 		to_chat(person, SPAN_ROLE_HEADER("You are a Whiteout Team Operative!"))
 		to_chat(person, SPAN_ROLE_BODY("Whiteout protocol is in effect for the target, all assets onboard are to be liquidated with expediency unless otherwise instructed by Weyland Yutani personnel holding the position of Director or above."))
-		arm_equipment(person, /datum/equipment_preset/pmc/w_y_whiteout/lowthreat, TRUE, TRUE)
+		arm_equipment(person, /datum/equipment_preset/pmc/w_y_whiteout/low_threat, TRUE, TRUE)
 
 	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(to_chat), person, SPAN_BOLD("Objectives: [objectives]")), 1 SECONDS)
 
@@ -144,10 +144,10 @@
 	return
 
 
-/datum/emergency_call/marsoc/lowthreat
+/datum/emergency_call/marsoc/low_threat
 	name = "Marine Raider Operatives"
 
-/datum/emergency_call/marsoc/lowthreat/create_member(datum/mind/MIND)
+/datum/emergency_call/marsoc/low_threat/create_member(datum/mind/MIND)
 
 	var/turf/spawn_loc = get_spawn_point()
 
@@ -159,10 +159,10 @@
 	if(!leader && HAS_FLAG(player.client.prefs.toggles_ert, PLAY_LEADER) && check_timelock(player.client, JOB_SQUAD_LEADER, time_required_for_job))    //First one spawned is always the leader.
 		leader = player
 		to_chat(player, SPAN_WARNING(FONT_SIZE_BIG("You are a Marine Raider Team Leader, better than all the rest.")))
-		arm_equipment(player, /datum/equipment_preset/uscm/marsoc/lowthreat/sl, TRUE, TRUE)
+		arm_equipment(player, /datum/equipment_preset/uscm/marsoc/low_threat/sl, TRUE, TRUE)
 	else
 		to_chat(player, SPAN_WARNING(FONT_SIZE_BIG("You are an elite Marine Raider, the best of the best.")))
-		arm_equipment(player, /datum/equipment_preset/uscm/marsoc/lowthreat, TRUE, TRUE)
+		arm_equipment(player, /datum/equipment_preset/uscm/marsoc/low_threat, TRUE, TRUE)
 	to_chat(player, SPAN_BOLDNOTICE("You are absolutely loyal to High Command and must follow their directives."))
 	to_chat(player, SPAN_BOLDNOTICE("Execute the mission assigned to you with extreme prejudice!"))
 	return

--- a/code/datums/emergency_calls/deathsquad.dm
+++ b/code/datums/emergency_calls/deathsquad.dm
@@ -18,83 +18,71 @@
 
 
 // DEATH SQUAD--------------------------------------------------------------------------------
-/datum/emergency_call/death/create_member(datum/mind/M, turf/override_spawn_loc)
+/datum/emergency_call/death/create_member(datum/mind/player, turf/override_spawn_loc)
 	var/turf/spawn_loc = override_spawn_loc ? override_spawn_loc : get_spawn_point()
 
 	if(!istype(spawn_loc))
 		return //Didn't find a useable spawn point.
 
-	var/mob/living/carbon/human/H = new(spawn_loc)
-	M.transfer_to(H, TRUE)
+	var/mob/living/carbon/human/person = new(spawn_loc)
+	player.transfer_to(person, TRUE)
 
-	if(!leader && HAS_FLAG(H.client.prefs.toggles_ert, PLAY_LEADER) && check_timelock(H.client, JOB_SQUAD_LEADER, time_required_for_job))
-		leader = H
-		to_chat(H, SPAN_ROLE_HEADER("You are the Whiteout Team Leader!"))
-		to_chat(H, SPAN_ROLE_BODY("Whiteout protocol is in effect for the target, all assets onboard are to be liquidated with expediency unless otherwise instructed by Weyland Yutani personnel holding the position of Director or above."))
-		arm_equipment(H, /datum/equipment_preset/pmc/w_y_whiteout/leader, TRUE, TRUE)
-	else if(medics < max_medics && HAS_FLAG(H.client.prefs.toggles_ert, PLAY_MEDIC) && check_timelock(H.client, JOB_SQUAD_MEDIC, time_required_for_job))
+	if(!leader && HAS_FLAG(person.client.prefs.toggles_ert, PLAY_LEADER) && check_timelock(person.client, JOB_SQUAD_LEADER, time_required_for_job))
+		leader = person
+		to_chat(person, SPAN_ROLE_HEADER("You are the Whiteout Team Leader!"))
+		to_chat(person, SPAN_ROLE_BODY("Whiteout protocol is in effect for the target, all assets onboard are to be liquidated with expediency unless otherwise instructed by Weyland Yutani personnel holding the position of Director or above."))
+		arm_equipment(person, /datum/equipment_preset/pmc/w_y_whiteout/leader, TRUE, TRUE)
+	else if(medics < max_medics && HAS_FLAG(person.client.prefs.toggles_ert, PLAY_MEDIC) && check_timelock(person.client, JOB_SQUAD_MEDIC, time_required_for_job))
 		medics++
-		to_chat(H, SPAN_ROLE_HEADER("You are a Whiteout Team Medic!"))
-		to_chat(H, SPAN_ROLE_BODY("Whiteout protocol is in effect for the target, all assets onboard are to be liquidated with expediency unless otherwise instructed by Weyland Yutani personnel holding the position of Director or above."))
-		arm_equipment(H, /datum/equipment_preset/pmc/w_y_whiteout/medic, TRUE, TRUE)
-	else if(heavies < max_heavies && HAS_FLAG(H.client.prefs.toggles_ert, PLAY_SMARTGUNNER) && check_timelock(H.client, list(JOB_SQUAD_SPECIALIST, JOB_SQUAD_SMARTGUN), time_required_for_job))
+		to_chat(person, SPAN_ROLE_HEADER("You are a Whiteout Team Medic!"))
+		to_chat(person, SPAN_ROLE_BODY("Whiteout protocol is in effect for the target, all assets onboard are to be liquidated with expediency unless otherwise instructed by Weyland Yutani personnel holding the position of Director or above."))
+		arm_equipment(person, /datum/equipment_preset/pmc/w_y_whiteout/medic, TRUE, TRUE)
+	else if(heavies < max_heavies && HAS_FLAG(person.client.prefs.toggles_ert, PLAY_SMARTGUNNER) && check_timelock(person.client, list(JOB_SQUAD_SPECIALIST, JOB_SQUAD_SMARTGUN), time_required_for_job))
 		heavies++
-		to_chat(H, SPAN_ROLE_HEADER("You are a Whiteout Team Terminator!"))
-		to_chat(H, SPAN_ROLE_BODY("Whiteout protocol is in effect for the target, all assets onboard are to be liquidated with expediency unless otherwise instructed by Weyland Yutani personnel holding the position of Director or above."))
-		arm_equipment(H, /datum/equipment_preset/pmc/w_y_whiteout/terminator, TRUE, TRUE)
+		to_chat(person, SPAN_ROLE_HEADER("You are a Whiteout Team Terminator!"))
+		to_chat(person, SPAN_ROLE_BODY("Whiteout protocol is in effect for the target, all assets onboard are to be liquidated with expediency unless otherwise instructed by Weyland Yutani personnel holding the position of Director or above."))
+		arm_equipment(person, /datum/equipment_preset/pmc/w_y_whiteout/terminator, TRUE, TRUE)
 	else
-		to_chat(H, SPAN_ROLE_HEADER("You are a Whiteout Team Operative!"))
-		to_chat(H, SPAN_ROLE_BODY("Whiteout protocol is in effect for the target, all assets onboard are to be liquidated with expediency unless otherwise instructed by Weyland Yutani personnel holding the position of Director or above."))
-		arm_equipment(H, /datum/equipment_preset/pmc/w_y_whiteout, TRUE, TRUE)
+		to_chat(person, SPAN_ROLE_HEADER("You are a Whiteout Team Operative!"))
+		to_chat(person, SPAN_ROLE_BODY("Whiteout protocol is in effect for the target, all assets onboard are to be liquidated with expediency unless otherwise instructed by Weyland Yutani personnel holding the position of Director or above."))
+		arm_equipment(person, /datum/equipment_preset/pmc/w_y_whiteout, TRUE, TRUE)
 
-	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(to_chat), H, SPAN_BOLD("Objectives: [objectives]")), 1 SECONDS)
+	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(to_chat), person, SPAN_BOLD("Objectives: [objectives]")), 1 SECONDS)
 
-/datum/emergency_call/death_lowthreat
-	name = "Weyland Whiteout Operators (No Overpowered Gear)"
-	mob_max = 8
-	mob_min = 5
-	arrival_message = "'!`2*%slau#*jer t*h$em a!l%. le&*ve n(o^ w&*nes%6es.*v$e %#d ou^'"
-	objectives = "Whiteout protocol is in effect for the target. Ensure there are no traces of the infestation or any witnesses."
-	probability = 0
-	shuttle_id = "Distress_PMC"
-	name_of_spawn = /obj/effect/landmark/ert_spawns/distress_pmc
-	item_spawn = /obj/effect/landmark/ert_spawns/distress_pmc/item
-	max_medics = 1
-	max_heavies = 2
-	hostility = TRUE
-
+/datum/emergency_call/death/lowthreat
+	name = "Weyland Whiteout Operators"
 
 // DEATH SQUAD--------------------------------------------------------------------------------
-/datum/emergency_call/death_lowthreat/create_member(datum/mind/M, turf/override_spawn_loc)
+/datum/emergency_call/death/lowthreat/create_member(datum/mind/player, turf/override_spawn_loc)
 	var/turf/spawn_loc = override_spawn_loc ? override_spawn_loc : get_spawn_point()
 
 	if(!istype(spawn_loc))
 		return //Didn't find a useable spawn point.
 
-	var/mob/living/carbon/human/H = new(spawn_loc)
-	M.transfer_to(H, TRUE)
+	var/mob/living/carbon/human/person = new(spawn_loc)
+	player.transfer_to(person, TRUE)
 
-	if(!leader && HAS_FLAG(H.client.prefs.toggles_ert, PLAY_LEADER) && check_timelock(H.client, JOB_SQUAD_LEADER, time_required_for_job))
-		leader = H
-		to_chat(H, SPAN_ROLE_HEADER("You are the Whiteout Team Leader!"))
-		to_chat(H, SPAN_ROLE_BODY("Whiteout protocol is in effect for the target, all assets onboard are to be liquidated with expediency unless otherwise instructed by Weyland Yutani personnel holding the position of Director or above."))
-		arm_equipment(H, /datum/equipment_preset/pmc/w_y_whiteout/lowthreat/leader, TRUE, TRUE)
-	else if(medics < max_medics && HAS_FLAG(H.client.prefs.toggles_ert, PLAY_MEDIC) && check_timelock(H.client, JOB_SQUAD_MEDIC, time_required_for_job))
+	if(!leader && HAS_FLAG(person.client.prefs.toggles_ert, PLAY_LEADER) && check_timelock(person.client, JOB_SQUAD_LEADER, time_required_for_job))
+		leader = person
+		to_chat(person, SPAN_ROLE_HEADER("You are the Whiteout Team Leader!"))
+		to_chat(person, SPAN_ROLE_BODY("Whiteout protocol is in effect for the target, all assets onboard are to be liquidated with expediency unless otherwise instructed by Weyland Yutani personnel holding the position of Director or above."))
+		arm_equipment(person, /datum/equipment_preset/pmc/w_y_whiteout/lowthreat/leader, TRUE, TRUE)
+	else if(medics < max_medics && HAS_FLAG(person.client.prefs.toggles_ert, PLAY_MEDIC) && check_timelock(person.client, JOB_SQUAD_MEDIC, time_required_for_job))
 		medics++
-		to_chat(H, SPAN_ROLE_HEADER("You are a Whiteout Team Medic!"))
-		to_chat(H, SPAN_ROLE_BODY("Whiteout protocol is in effect for the target, all assets onboard are to be liquidated with expediency unless otherwise instructed by Weyland Yutani personnel holding the position of Director or above."))
-		arm_equipment(H, /datum/equipment_preset/pmc/w_y_whiteout/lowthreat/medic, TRUE, TRUE)
-	else if(heavies < max_heavies && HAS_FLAG(H.client.prefs.toggles_ert, PLAY_SMARTGUNNER) && check_timelock(H.client, list(JOB_SQUAD_SPECIALIST, JOB_SQUAD_SMARTGUN), time_required_for_job))
+		to_chat(person, SPAN_ROLE_HEADER("You are a Whiteout Team Medic!"))
+		to_chat(person, SPAN_ROLE_BODY("Whiteout protocol is in effect for the target, all assets onboard are to be liquidated with expediency unless otherwise instructed by Weyland Yutani personnel holding the position of Director or above."))
+		arm_equipment(person, /datum/equipment_preset/pmc/w_y_whiteout/lowthreat/medic, TRUE, TRUE)
+	else if(heavies < max_heavies && HAS_FLAG(person.client.prefs.toggles_ert, PLAY_SMARTGUNNER) && check_timelock(person.client, list(JOB_SQUAD_SPECIALIST, JOB_SQUAD_SMARTGUN), time_required_for_job))
 		heavies++
-		to_chat(H, SPAN_ROLE_HEADER("You are a Whiteout Team Terminator!"))
-		to_chat(H, SPAN_ROLE_BODY("Whiteout protocol is in effect for the target, all assets onboard are to be liquidated with expediency unless otherwise instructed by Weyland Yutani personnel holding the position of Director or above."))
-		arm_equipment(H, /datum/equipment_preset/pmc/w_y_whiteout/lowthreat/terminator, TRUE, TRUE)
+		to_chat(person, SPAN_ROLE_HEADER("You are a Whiteout Team Terminator!"))
+		to_chat(person, SPAN_ROLE_BODY("Whiteout protocol is in effect for the target, all assets onboard are to be liquidated with expediency unless otherwise instructed by Weyland Yutani personnel holding the position of Director or above."))
+		arm_equipment(person, /datum/equipment_preset/pmc/w_y_whiteout/lowthreat/terminator, TRUE, TRUE)
 	else
-		to_chat(H, SPAN_ROLE_HEADER("You are a Whiteout Team Operative!"))
-		to_chat(H, SPAN_ROLE_BODY("Whiteout protocol is in effect for the target, all assets onboard are to be liquidated with expediency unless otherwise instructed by Weyland Yutani personnel holding the position of Director or above."))
-		arm_equipment(H, /datum/equipment_preset/pmc/w_y_whiteout/lowthreat, TRUE, TRUE)
+		to_chat(person, SPAN_ROLE_HEADER("You are a Whiteout Team Operative!"))
+		to_chat(person, SPAN_ROLE_BODY("Whiteout protocol is in effect for the target, all assets onboard are to be liquidated with expediency unless otherwise instructed by Weyland Yutani personnel holding the position of Director or above."))
+		arm_equipment(person, /datum/equipment_preset/pmc/w_y_whiteout/lowthreat, TRUE, TRUE)
 
-	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(to_chat), H, SPAN_BOLD("Objectives: [objectives]")), 1 SECONDS)
+	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(to_chat), person, SPAN_BOLD("Objectives: [objectives]")), 1 SECONDS)
 
 //################################################################################################
 // Marine commandos - USCM Deathsquad. Event only
@@ -155,30 +143,26 @@
 	to_chat(H, SPAN_BOLDNOTICE("Execute the mission assigned to you with extreme prejudice!"))
 	return
 
-/datum/emergency_call/marsoc_lowthreat
-	name = "Marine Raider Operatives (No Overpowered Gear)"
-	mob_max = 8
-	mob_min = 5
-	probability = 0
-	shuttle_id = "Distress_PMC"
-	name_of_spawn = /obj/effect/landmark/ert_spawns/distress_pmc
 
-/datum/emergency_call/marsoc_lowthreat/create_member(datum/mind/M)
+/datum/emergency_call/marsoc/lowthreat
+	name = "Marine Raider Operatives"
+
+/datum/emergency_call/marsoc/lowthreat/create_member(datum/mind/MIND)
 
 	var/turf/spawn_loc = get_spawn_point()
 
 	if(!istype(spawn_loc))
 		return //Didn't find a useable spawn point.
 
-	var/mob/living/carbon/human/H = new(spawn_loc)
-	M.transfer_to(H, TRUE)
-	if(!leader && HAS_FLAG(H.client.prefs.toggles_ert, PLAY_LEADER) && check_timelock(H.client, JOB_SQUAD_LEADER, time_required_for_job))    //First one spawned is always the leader.
-		leader = H
-		to_chat(H, SPAN_WARNING(FONT_SIZE_BIG("You are a Marine Raider Team Leader, better than all the rest.")))
-		arm_equipment(H, /datum/equipment_preset/uscm/marsoc/lowthreat/sl, TRUE, TRUE)
+	var/mob/living/carbon/human/player = new(spawn_loc)
+	MIND.transfer_to(player, TRUE)
+	if(!leader && HAS_FLAG(player.client.prefs.toggles_ert, PLAY_LEADER) && check_timelock(player.client, JOB_SQUAD_LEADER, time_required_for_job))    //First one spawned is always the leader.
+		leader = player
+		to_chat(player, SPAN_WARNING(FONT_SIZE_BIG("You are a Marine Raider Team Leader, better than all the rest.")))
+		arm_equipment(player, /datum/equipment_preset/uscm/marsoc/lowthreat/sl, TRUE, TRUE)
 	else
-		to_chat(H, SPAN_WARNING(FONT_SIZE_BIG("You are an elite Marine Raider, the best of the best.")))
-		arm_equipment(H, /datum/equipment_preset/uscm/marsoc/lowthreat, TRUE, TRUE)
-	to_chat(H, SPAN_BOLDNOTICE("You are absolutely loyal to High Command and must follow their directives."))
-	to_chat(H, SPAN_BOLDNOTICE("Execute the mission assigned to you with extreme prejudice!"))
+		to_chat(player, SPAN_WARNING(FONT_SIZE_BIG("You are an elite Marine Raider, the best of the best.")))
+		arm_equipment(player, /datum/equipment_preset/uscm/marsoc/lowthreat, TRUE, TRUE)
+	to_chat(player, SPAN_BOLDNOTICE("You are absolutely loyal to High Command and must follow their directives."))
+	to_chat(player, SPAN_BOLDNOTICE("Execute the mission assigned to you with extreme prejudice!"))
 	return

--- a/code/datums/emergency_calls/deathsquad.dm
+++ b/code/datums/emergency_calls/deathsquad.dm
@@ -3,7 +3,7 @@
 
 //Weyland-Yutani Deathsquad - W-Y Deathsquad. Event only
 /datum/emergency_call/death
-	name = "Weyland Whiteout Operators"
+	name = "Weyland Whiteout Operators (!WHITEOUT!)"
 	mob_max = 8
 	mob_min = 5
 	arrival_message = "'!`2*%slau#*jer t*h$em a!l%. le&*ve n(o^ w&*nes%6es.*v$e %#d ou^'"
@@ -49,10 +49,57 @@
 
 	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(to_chat), H, SPAN_BOLD("Objectives: [objectives]")), 1 SECONDS)
 
+/datum/emergency_call/death_lowthreat
+	name = "Weyland Whiteout Operators (No Overpowered Gear)"
+	mob_max = 8
+	mob_min = 5
+	arrival_message = "'!`2*%slau#*jer t*h$em a!l%. le&*ve n(o^ w&*nes%6es.*v$e %#d ou^'"
+	objectives = "Whiteout protocol is in effect for the target. Ensure there are no traces of the infestation or any witnesses."
+	probability = 0
+	shuttle_id = "Distress_PMC"
+	name_of_spawn = /obj/effect/landmark/ert_spawns/distress_pmc
+	item_spawn = /obj/effect/landmark/ert_spawns/distress_pmc/item
+	max_medics = 1
+	max_heavies = 2
+	hostility = TRUE
+
+
+// DEATH SQUAD--------------------------------------------------------------------------------
+/datum/emergency_call/death_lowthreat/create_member(datum/mind/M, turf/override_spawn_loc)
+	var/turf/spawn_loc = override_spawn_loc ? override_spawn_loc : get_spawn_point()
+
+	if(!istype(spawn_loc))
+		return //Didn't find a useable spawn point.
+
+	var/mob/living/carbon/human/H = new(spawn_loc)
+	M.transfer_to(H, TRUE)
+
+	if(!leader && HAS_FLAG(H.client.prefs.toggles_ert, PLAY_LEADER) && check_timelock(H.client, JOB_SQUAD_LEADER, time_required_for_job))
+		leader = H
+		to_chat(H, SPAN_ROLE_HEADER("You are the Whiteout Team Leader!"))
+		to_chat(H, SPAN_ROLE_BODY("Whiteout protocol is in effect for the target, all assets onboard are to be liquidated with expediency unless otherwise instructed by Weyland Yutani personnel holding the position of Director or above."))
+		arm_equipment(H, /datum/equipment_preset/pmc/w_y_whiteout/lowthreat/leader, TRUE, TRUE)
+	else if(medics < max_medics && HAS_FLAG(H.client.prefs.toggles_ert, PLAY_MEDIC) && check_timelock(H.client, JOB_SQUAD_MEDIC, time_required_for_job))
+		medics++
+		to_chat(H, SPAN_ROLE_HEADER("You are a Whiteout Team Medic!"))
+		to_chat(H, SPAN_ROLE_BODY("Whiteout protocol is in effect for the target, all assets onboard are to be liquidated with expediency unless otherwise instructed by Weyland Yutani personnel holding the position of Director or above."))
+		arm_equipment(H, /datum/equipment_preset/pmc/w_y_whiteout/lowthreat/medic, TRUE, TRUE)
+	else if(heavies < max_heavies && HAS_FLAG(H.client.prefs.toggles_ert, PLAY_SMARTGUNNER) && check_timelock(H.client, list(JOB_SQUAD_SPECIALIST, JOB_SQUAD_SMARTGUN), time_required_for_job))
+		heavies++
+		to_chat(H, SPAN_ROLE_HEADER("You are a Whiteout Team Terminator!"))
+		to_chat(H, SPAN_ROLE_BODY("Whiteout protocol is in effect for the target, all assets onboard are to be liquidated with expediency unless otherwise instructed by Weyland Yutani personnel holding the position of Director or above."))
+		arm_equipment(H, /datum/equipment_preset/pmc/w_y_whiteout/lowthreat/terminator, TRUE, TRUE)
+	else
+		to_chat(H, SPAN_ROLE_HEADER("You are a Whiteout Team Operative!"))
+		to_chat(H, SPAN_ROLE_BODY("Whiteout protocol is in effect for the target, all assets onboard are to be liquidated with expediency unless otherwise instructed by Weyland Yutani personnel holding the position of Director or above."))
+		arm_equipment(H, /datum/equipment_preset/pmc/w_y_whiteout/lowthreat, TRUE, TRUE)
+
+	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(to_chat), H, SPAN_BOLD("Objectives: [objectives]")), 1 SECONDS)
+
 //################################################################################################
 // Marine commandos - USCM Deathsquad. Event only
 /datum/emergency_call/marsoc
-	name = "Marine Raider Strike Team"
+	name = "Marine Raider Strike Team (!WHITEOUT!)"
 	mob_max = 8
 	mob_min = 5
 	probability = 0
@@ -81,7 +128,7 @@
 	return
 
 /datum/emergency_call/marsoc_covert
-	name = "Marine Raider Operatives (Covert)"
+	name = "Marine Raider Operatives (!WHITEOUT! Covert)"
 	mob_max = 8
 	mob_min = 5
 	probability = 0
@@ -104,6 +151,34 @@
 	else
 		to_chat(H, SPAN_WARNING(FONT_SIZE_BIG("You are an elite Marine Raider, the best of the best.")))
 		arm_equipment(H, /datum/equipment_preset/uscm/marsoc/covert, TRUE, TRUE)
+	to_chat(H, SPAN_BOLDNOTICE("You are absolutely loyal to High Command and must follow their directives."))
+	to_chat(H, SPAN_BOLDNOTICE("Execute the mission assigned to you with extreme prejudice!"))
+	return
+
+/datum/emergency_call/marsoc_lowthreat
+	name = "Marine Raider Operatives (No Overpowered Gear)"
+	mob_max = 8
+	mob_min = 5
+	probability = 0
+	shuttle_id = "Distress_PMC"
+	name_of_spawn = /obj/effect/landmark/ert_spawns/distress_pmc
+
+/datum/emergency_call/marsoc_lowthreat/create_member(datum/mind/M)
+
+	var/turf/spawn_loc = get_spawn_point()
+
+	if(!istype(spawn_loc))
+		return //Didn't find a useable spawn point.
+
+	var/mob/living/carbon/human/H = new(spawn_loc)
+	M.transfer_to(H, TRUE)
+	if(!leader && HAS_FLAG(H.client.prefs.toggles_ert, PLAY_LEADER) && check_timelock(H.client, JOB_SQUAD_LEADER, time_required_for_job))    //First one spawned is always the leader.
+		leader = H
+		to_chat(H, SPAN_WARNING(FONT_SIZE_BIG("You are a Marine Raider Team Leader, better than all the rest.")))
+		arm_equipment(H, /datum/equipment_preset/uscm/marsoc/lowthreat/sl, TRUE, TRUE)
+	else
+		to_chat(H, SPAN_WARNING(FONT_SIZE_BIG("You are an elite Marine Raider, the best of the best.")))
+		arm_equipment(H, /datum/equipment_preset/uscm/marsoc/lowthreat, TRUE, TRUE)
 	to_chat(H, SPAN_BOLDNOTICE("You are absolutely loyal to High Command and must follow their directives."))
 	to_chat(H, SPAN_BOLDNOTICE("Execute the mission assigned to you with extreme prejudice!"))
 	return

--- a/code/datums/emergency_calls/upp_commando.dm
+++ b/code/datums/emergency_calls/upp_commando.dm
@@ -1,7 +1,7 @@
 
 //UPP COMMANDOS
 /datum/emergency_call/upp_commando
-	name = "UPP Commandos"
+	name = "UPP Commandos (!WHITEOUT!)"
 	mob_max = 6
 	probability = 0
 	objectives = "Stealthily assault the ship. Use your silenced weapons, tranquilizers, and night vision to get the advantage on the enemy. Take out the power systems, comms and engine. Stick together and keep a low profile."
@@ -51,3 +51,53 @@
 
 	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(to_chat), H, SPAN_BOLD("Objectives: [objectives]")), 1 SECONDS)
 
+/datum/emergency_call/upp_commando
+	name = "UPP Commandos (No Overpowered Gear)"
+	mob_max = 6
+	probability = 0
+	objectives = "Stealthily assault the ship. Use your silenced weapons, tranquilizers, and night vision to get the advantage on the enemy. Take out the power systems, comms and engine. Stick together and keep a low profile."
+	shuttle_id = "Distress_UPP"
+	name_of_spawn = /obj/effect/landmark/ert_spawns/distress_upp
+	item_spawn = /obj/effect/landmark/ert_spawns/distress_upp/item
+	hostility = TRUE
+
+/datum/emergency_call/upp_commando/print_backstory(mob/living/carbon/human/M)
+	to_chat(M, SPAN_BOLD("You grew up in relativly simple family in [pick(75;"Eurasia", 25;"a famished UPP colony")] with few belongings or luxuries."))
+	to_chat(M, SPAN_BOLD("The family you grew up with were [pick(50;"getting by", 25;"impoverished", 25;"starving")] and you were one of [pick(10;"two", 20;"three", 20;"four", 30;"five", 20;"six")] children."))
+	to_chat(M, SPAN_BOLD("You come from a long line of [pick(40;"crop-harvesters", 20;"soldiers", 20;"factory workers", 5;"scientists", 15;"engineers")], and quickly enlisted to improve your living conditions."))
+	to_chat(M, SPAN_BOLD("Following your enlistment UPP military at the age of 17 you were assigned to the 17th 'Smoldering Sons' battalion (six hundred strong) under the command of Colonel Ganbaatar."))
+	to_chat(M, SPAN_BOLD("You were shipped off with the battalion to one of the UPP's most remote territories, a gas giant designated MV-35 in the Anglo-Japanese Arm, in the Neroid Sector."))
+	to_chat(M, SPAN_BOLD("For the past 14 months, you and the rest of the Smoldering Sons have been stationed at MV-35's only facility, the helium refinery, Altai Station."))
+	to_chat(M, SPAN_BOLD("As MV-35 and Altai Station are the only UPP-held zones in the Neroid Sector for many lightyears, you have spent most of your military career holed up in crammed quarters in near darkness, waiting for supply shipments and transport escort deployments."))
+	to_chat(M, SPAN_BOLD("With the recent arrival of the enemy USCM battalion the 'Falling Falcons' and their flagship, the [MAIN_SHIP_NAME], the UPP has felt threatened in the sector."))
+	to_chat(M, SPAN_BOLD("In an effort to protect the vunerable MV-35 from the emproaching UA/USCM imperialists, the leadership of your battalion has opted this the best opportunity to strike at the Falling Falcons to catch them off guard."))
+	to_chat(M, SPAN_WARNING(FONT_SIZE_BIG("Glory to Colonel Ganbaatar.")))
+	to_chat(M, SPAN_WARNING(FONT_SIZE_BIG("Glory to the Smoldering Sons.")))
+	to_chat(M, SPAN_WARNING(FONT_SIZE_BIG("Glory to the UPP.")))
+	to_chat(M, SPAN_NOTICE(" Use say :3 <text> to speak in your native tongue."))
+	to_chat(M, SPAN_NOTICE(" This allows you to speak privately with your fellow UPP allies."))
+	to_chat(M, SPAN_NOTICE(" Utilize it with your radio to prevent enemy radio interceptions."))
+
+/datum/emergency_call/upp_commando/create_member(datum/mind/M, turf/override_spawn_loc)
+	var/turf/spawn_loc = override_spawn_loc ? override_spawn_loc : get_spawn_point()
+
+	if(!istype(spawn_loc))
+		return //Didn't find a useable spawn point.
+
+	var/mob/living/carbon/human/H = new(spawn_loc)
+	M.transfer_to(H, TRUE)
+
+	if(!leader && HAS_FLAG(H.client.prefs.toggles_ert, PLAY_LEADER) && check_timelock(H.client, JOB_SQUAD_LEADER, time_required_for_job))    //First one spawned is always the leader.
+		leader = H
+		arm_equipment(H, /datum/equipment_preset/upp/commando/leader/lowthreat, TRUE, TRUE)
+		to_chat(H, SPAN_ROLE_HEADER("You are a Commando Team Leader of the Union of Progressive People, a powerful socialist state that rivals the United Americas!"))
+	else if(medics < max_medics && HAS_FLAG(H.client.prefs.toggles_ert, PLAY_MEDIC) && check_timelock(H.client, JOB_SQUAD_MEDIC, time_required_for_job))
+		medics++
+		to_chat(H, SPAN_ROLE_HEADER("You are a Commando Medic of the Union of Progressive People, a powerful socialist state that rivals the United Americas!"))
+		arm_equipment(H, /datum/equipment_preset/upp/commando/medic/lowthreat, TRUE, TRUE)
+	else
+		to_chat(H, SPAN_ROLE_HEADER("You are a Commando of the Union of Progressive People, a powerful socialist state that rivals the United Americas!"))
+		arm_equipment(H, /datum/equipment_preset/upp/commando/lowthreat, TRUE, TRUE)
+	print_backstory(H)
+
+	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(to_chat), H, SPAN_BOLD("Objectives: [objectives]")), 1 SECONDS)

--- a/code/datums/emergency_calls/upp_commando.dm
+++ b/code/datums/emergency_calls/upp_commando.dm
@@ -51,8 +51,8 @@
 
 	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(to_chat), H, SPAN_BOLD("Objectives: [objectives]")), 1 SECONDS)
 
-/datum/emergency_call/upp_commando
-	name = "UPP Commandos (No Overpowered Gear)"
+/datum/emergency_call/upp_commando/lowthreat
+	name = "UPP Commandos"
 	mob_max = 6
 	probability = 0
 	objectives = "Stealthily assault the ship. Use your silenced weapons, tranquilizers, and night vision to get the advantage on the enemy. Take out the power systems, comms and engine. Stick together and keep a low profile."
@@ -61,43 +61,43 @@
 	item_spawn = /obj/effect/landmark/ert_spawns/distress_upp/item
 	hostility = TRUE
 
-/datum/emergency_call/upp_commando/print_backstory(mob/living/carbon/human/M)
-	to_chat(M, SPAN_BOLD("You grew up in relativly simple family in [pick(75;"Eurasia", 25;"a famished UPP colony")] with few belongings or luxuries."))
-	to_chat(M, SPAN_BOLD("The family you grew up with were [pick(50;"getting by", 25;"impoverished", 25;"starving")] and you were one of [pick(10;"two", 20;"three", 20;"four", 30;"five", 20;"six")] children."))
-	to_chat(M, SPAN_BOLD("You come from a long line of [pick(40;"crop-harvesters", 20;"soldiers", 20;"factory workers", 5;"scientists", 15;"engineers")], and quickly enlisted to improve your living conditions."))
-	to_chat(M, SPAN_BOLD("Following your enlistment UPP military at the age of 17 you were assigned to the 17th 'Smoldering Sons' battalion (six hundred strong) under the command of Colonel Ganbaatar."))
-	to_chat(M, SPAN_BOLD("You were shipped off with the battalion to one of the UPP's most remote territories, a gas giant designated MV-35 in the Anglo-Japanese Arm, in the Neroid Sector."))
-	to_chat(M, SPAN_BOLD("For the past 14 months, you and the rest of the Smoldering Sons have been stationed at MV-35's only facility, the helium refinery, Altai Station."))
-	to_chat(M, SPAN_BOLD("As MV-35 and Altai Station are the only UPP-held zones in the Neroid Sector for many lightyears, you have spent most of your military career holed up in crammed quarters in near darkness, waiting for supply shipments and transport escort deployments."))
-	to_chat(M, SPAN_BOLD("With the recent arrival of the enemy USCM battalion the 'Falling Falcons' and their flagship, the [MAIN_SHIP_NAME], the UPP has felt threatened in the sector."))
-	to_chat(M, SPAN_BOLD("In an effort to protect the vunerable MV-35 from the emproaching UA/USCM imperialists, the leadership of your battalion has opted this the best opportunity to strike at the Falling Falcons to catch them off guard."))
-	to_chat(M, SPAN_WARNING(FONT_SIZE_BIG("Glory to Colonel Ganbaatar.")))
-	to_chat(M, SPAN_WARNING(FONT_SIZE_BIG("Glory to the Smoldering Sons.")))
-	to_chat(M, SPAN_WARNING(FONT_SIZE_BIG("Glory to the UPP.")))
-	to_chat(M, SPAN_NOTICE(" Use say :3 <text> to speak in your native tongue."))
-	to_chat(M, SPAN_NOTICE(" This allows you to speak privately with your fellow UPP allies."))
-	to_chat(M, SPAN_NOTICE(" Utilize it with your radio to prevent enemy radio interceptions."))
+/datum/emergency_call/upp_commando/print_backstory(mob/living/carbon/human/mind)
+	to_chat(mind, SPAN_BOLD("You grew up in relativly simple family in [pick(75;"Eurasia", 25;"a famished UPP colony")] with few belongings or luxuries."))
+	to_chat(mind, SPAN_BOLD("The family you grew up with were [pick(50;"getting by", 25;"impoverished", 25;"starving")] and you were one of [pick(10;"two", 20;"three", 20;"four", 30;"five", 20;"six")] children."))
+	to_chat(mind, SPAN_BOLD("You come from a long line of [pick(40;"crop-harvesters", 20;"soldiers", 20;"factory workers", 5;"scientists", 15;"engineers")], and quickly enlisted to improve your living conditions."))
+	to_chat(mind, SPAN_BOLD("Following your enlistment UPP military at the age of 17 you were assigned to the 17th 'Smoldering Sons' battalion (six hundred strong) under the command of Colonel Ganbaatar."))
+	to_chat(mind, SPAN_BOLD("You were shipped off with the battalion to one of the UPP's most remote territories, a gas giant designated MV-35 in the Anglo-Japanese Arm, in the Neroid Sector."))
+	to_chat(mind, SPAN_BOLD("For the past 14 months, you and the rest of the Smoldering Sons have been stationed at MV-35's only facility, the helium refinery, Altai Station."))
+	to_chat(mind, SPAN_BOLD("As MV-35 and Altai Station are the only UPP-held zones in the Neroid Sector for many lightyears, you have spent most of your military career holed up in crammed quarters in near darkness, waiting for supply shipments and transport escort deployments."))
+	to_chat(mind, SPAN_BOLD("With the recent arrival of the enemy USCM battalion the 'Falling Falcons' and their flagship, the [MAIN_SHIP_NAME], the UPP has felt threatened in the sector."))
+	to_chat(mind, SPAN_BOLD("In an effort to protect the vunerable MV-35 from the emproaching UA/USCM imperialists, the leadership of your battalion has opted this the best opportunity to strike at the Falling Falcons to catch them off guard."))
+	to_chat(mind, SPAN_WARNING(FONT_SIZE_BIG("Glory to Colonel Ganbaatar.")))
+	to_chat(mind, SPAN_WARNING(FONT_SIZE_BIG("Glory to the Smoldering Sons.")))
+	to_chat(mind, SPAN_WARNING(FONT_SIZE_BIG("Glory to the UPP.")))
+	to_chat(mind, SPAN_NOTICE(" Use say :3 <text> to speak in your native tongue."))
+	to_chat(mind, SPAN_NOTICE(" This allows you to speak privately with your fellow UPP allies."))
+	to_chat(mind, SPAN_NOTICE(" Utilize it with your radio to prevent enemy radio interceptions."))
 
-/datum/emergency_call/upp_commando/create_member(datum/mind/M, turf/override_spawn_loc)
+/datum/emergency_call/upp_commando/create_member(datum/mind/mind, turf/override_spawn_loc)
 	var/turf/spawn_loc = override_spawn_loc ? override_spawn_loc : get_spawn_point()
 
 	if(!istype(spawn_loc))
 		return //Didn't find a useable spawn point.
 
-	var/mob/living/carbon/human/H = new(spawn_loc)
-	M.transfer_to(H, TRUE)
+	var/mob/living/carbon/human/person = new(spawn_loc)
+	mind.transfer_to(person, TRUE)
 
-	if(!leader && HAS_FLAG(H.client.prefs.toggles_ert, PLAY_LEADER) && check_timelock(H.client, JOB_SQUAD_LEADER, time_required_for_job))    //First one spawned is always the leader.
-		leader = H
-		arm_equipment(H, /datum/equipment_preset/upp/commando/leader/lowthreat, TRUE, TRUE)
-		to_chat(H, SPAN_ROLE_HEADER("You are a Commando Team Leader of the Union of Progressive People, a powerful socialist state that rivals the United Americas!"))
-	else if(medics < max_medics && HAS_FLAG(H.client.prefs.toggles_ert, PLAY_MEDIC) && check_timelock(H.client, JOB_SQUAD_MEDIC, time_required_for_job))
+	if(!leader && HAS_FLAG(person.client.prefs.toggles_ert, PLAY_LEADER) && check_timelock(person.client, JOB_SQUAD_LEADER, time_required_for_job))    //First one spawned is always the leader.
+		leader = person
+		arm_equipment(person, /datum/equipment_preset/upp/commando/leader/lowthreat, TRUE, TRUE)
+		to_chat(person, SPAN_ROLE_HEADER("You are a Commando Team Leader of the Union of Progressive People, a powerful socialist state that rivals the United Americas!"))
+	else if(medics < max_medics && HAS_FLAG(person.client.prefs.toggles_ert, PLAY_MEDIC) && check_timelock(person.client, JOB_SQUAD_MEDIC, time_required_for_job))
 		medics++
-		to_chat(H, SPAN_ROLE_HEADER("You are a Commando Medic of the Union of Progressive People, a powerful socialist state that rivals the United Americas!"))
-		arm_equipment(H, /datum/equipment_preset/upp/commando/medic/lowthreat, TRUE, TRUE)
+		to_chat(person, SPAN_ROLE_HEADER("You are a Commando Medic of the Union of Progressive People, a powerful socialist state that rivals the United Americas!"))
+		arm_equipment(person, /datum/equipment_preset/upp/commando/medic/lowthreat, TRUE, TRUE)
 	else
-		to_chat(H, SPAN_ROLE_HEADER("You are a Commando of the Union of Progressive People, a powerful socialist state that rivals the United Americas!"))
-		arm_equipment(H, /datum/equipment_preset/upp/commando/lowthreat, TRUE, TRUE)
-	print_backstory(H)
+		to_chat(person, SPAN_ROLE_HEADER("You are a Commando of the Union of Progressive People, a powerful socialist state that rivals the United Americas!"))
+		arm_equipment(person, /datum/equipment_preset/upp/commando/lowthreat, TRUE, TRUE)
+	print_backstory(person)
 
-	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(to_chat), H, SPAN_BOLD("Objectives: [objectives]")), 1 SECONDS)
+	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(to_chat), person, SPAN_BOLD("Objectives: [objectives]")), 1 SECONDS)

--- a/code/datums/emergency_calls/upp_commando.dm
+++ b/code/datums/emergency_calls/upp_commando.dm
@@ -51,32 +51,8 @@
 
 	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(to_chat), H, SPAN_BOLD("Objectives: [objectives]")), 1 SECONDS)
 
-/datum/emergency_call/upp_commando/lowthreat
+/datum/emergency_call/upp_commando/low_threat
 	name = "UPP Commandos"
-	mob_max = 6
-	probability = 0
-	objectives = "Stealthily assault the ship. Use your silenced weapons, tranquilizers, and night vision to get the advantage on the enemy. Take out the power systems, comms and engine. Stick together and keep a low profile."
-	shuttle_id = "Distress_UPP"
-	name_of_spawn = /obj/effect/landmark/ert_spawns/distress_upp
-	item_spawn = /obj/effect/landmark/ert_spawns/distress_upp/item
-	hostility = TRUE
-
-/datum/emergency_call/upp_commando/print_backstory(mob/living/carbon/human/mind)
-	to_chat(mind, SPAN_BOLD("You grew up in relativly simple family in [pick(75;"Eurasia", 25;"a famished UPP colony")] with few belongings or luxuries."))
-	to_chat(mind, SPAN_BOLD("The family you grew up with were [pick(50;"getting by", 25;"impoverished", 25;"starving")] and you were one of [pick(10;"two", 20;"three", 20;"four", 30;"five", 20;"six")] children."))
-	to_chat(mind, SPAN_BOLD("You come from a long line of [pick(40;"crop-harvesters", 20;"soldiers", 20;"factory workers", 5;"scientists", 15;"engineers")], and quickly enlisted to improve your living conditions."))
-	to_chat(mind, SPAN_BOLD("Following your enlistment UPP military at the age of 17 you were assigned to the 17th 'Smoldering Sons' battalion (six hundred strong) under the command of Colonel Ganbaatar."))
-	to_chat(mind, SPAN_BOLD("You were shipped off with the battalion to one of the UPP's most remote territories, a gas giant designated MV-35 in the Anglo-Japanese Arm, in the Neroid Sector."))
-	to_chat(mind, SPAN_BOLD("For the past 14 months, you and the rest of the Smoldering Sons have been stationed at MV-35's only facility, the helium refinery, Altai Station."))
-	to_chat(mind, SPAN_BOLD("As MV-35 and Altai Station are the only UPP-held zones in the Neroid Sector for many lightyears, you have spent most of your military career holed up in crammed quarters in near darkness, waiting for supply shipments and transport escort deployments."))
-	to_chat(mind, SPAN_BOLD("With the recent arrival of the enemy USCM battalion the 'Falling Falcons' and their flagship, the [MAIN_SHIP_NAME], the UPP has felt threatened in the sector."))
-	to_chat(mind, SPAN_BOLD("In an effort to protect the vunerable MV-35 from the emproaching UA/USCM imperialists, the leadership of your battalion has opted this the best opportunity to strike at the Falling Falcons to catch them off guard."))
-	to_chat(mind, SPAN_WARNING(FONT_SIZE_BIG("Glory to Colonel Ganbaatar.")))
-	to_chat(mind, SPAN_WARNING(FONT_SIZE_BIG("Glory to the Smoldering Sons.")))
-	to_chat(mind, SPAN_WARNING(FONT_SIZE_BIG("Glory to the UPP.")))
-	to_chat(mind, SPAN_NOTICE(" Use say :3 <text> to speak in your native tongue."))
-	to_chat(mind, SPAN_NOTICE(" This allows you to speak privately with your fellow UPP allies."))
-	to_chat(mind, SPAN_NOTICE(" Utilize it with your radio to prevent enemy radio interceptions."))
 
 /datum/emergency_call/upp_commando/create_member(datum/mind/mind, turf/override_spawn_loc)
 	var/turf/spawn_loc = override_spawn_loc ? override_spawn_loc : get_spawn_point()
@@ -89,15 +65,15 @@
 
 	if(!leader && HAS_FLAG(person.client.prefs.toggles_ert, PLAY_LEADER) && check_timelock(person.client, JOB_SQUAD_LEADER, time_required_for_job))    //First one spawned is always the leader.
 		leader = person
-		arm_equipment(person, /datum/equipment_preset/upp/commando/leader/lowthreat, TRUE, TRUE)
+		arm_equipment(person, /datum/equipment_preset/upp/commando/leader/low_threat, TRUE, TRUE)
 		to_chat(person, SPAN_ROLE_HEADER("You are a Commando Team Leader of the Union of Progressive People, a powerful socialist state that rivals the United Americas!"))
 	else if(medics < max_medics && HAS_FLAG(person.client.prefs.toggles_ert, PLAY_MEDIC) && check_timelock(person.client, JOB_SQUAD_MEDIC, time_required_for_job))
 		medics++
 		to_chat(person, SPAN_ROLE_HEADER("You are a Commando Medic of the Union of Progressive People, a powerful socialist state that rivals the United Americas!"))
-		arm_equipment(person, /datum/equipment_preset/upp/commando/medic/lowthreat, TRUE, TRUE)
+		arm_equipment(person, /datum/equipment_preset/upp/commando/medic/low_threat, TRUE, TRUE)
 	else
 		to_chat(person, SPAN_ROLE_HEADER("You are a Commando of the Union of Progressive People, a powerful socialist state that rivals the United Americas!"))
-		arm_equipment(person, /datum/equipment_preset/upp/commando/lowthreat, TRUE, TRUE)
+		arm_equipment(person, /datum/equipment_preset/upp/commando/low_threat, TRUE, TRUE)
 	print_backstory(person)
 
 	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(to_chat), person, SPAN_BOLD("Objectives: [objectives]")), 1 SECONDS)

--- a/code/datums/emergency_calls/upp_commando.dm
+++ b/code/datums/emergency_calls/upp_commando.dm
@@ -1,7 +1,7 @@
 
 //UPP COMMANDOS
 /datum/emergency_call/upp_commando
-	name = "UPP Commandos (!WHITEOUT!)"
+	name = "UPP Commandos (!DEATHSQUAD!)"
 	mob_max = 6
 	probability = 0
 	objectives = "Stealthily assault the ship. Use your silenced weapons, tranquilizers, and night vision to get the advantage on the enemy. Take out the power systems, comms and engine. Stick together and keep a low profile."

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -1106,6 +1106,10 @@ GLOBAL_LIST_EMPTY_TYPED(radio_packs, /obj/item/storage/backpack/marine/satchel/r
 	max_storage_space = 21
 	camo_alpha = 10
 
+/obj/item/storage/backpack/marine/satchel/scout_cloak/upp/weak
+	desc = "A thermo-optic camouflage cloak commonly used by UPP commando units. This one is less effective than normal."
+	actions_types = null
+
 //----------TWE SECTION----------
 /obj/item/storage/backpack/rmc
 	has_gamemode_skin = FALSE

--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -683,6 +683,18 @@
 	new /obj/item/reagent_container/hypospray/autoinjector/stimulant/redemption_stimulant(src)
 	new /obj/item/reagent_container/hypospray/autoinjector/stimulant/speed_stimulant(src)
 
+/obj/item/storage/pouch/medical/socmed/not_op/fill_preset_inventory()
+	new /obj/item/device/healthanalyzer(src)
+	new /obj/item/stack/medical/splint(src)
+	new /obj/item/stack/medical/advanced/bruise_pack(src)
+	new /obj/item/stack/medical/advanced/ointment(src)
+	new /obj/item/reagent_container/hypospray/autoinjector/bicaridine(src)
+	new /obj/item/reagent_container/hypospray/autoinjector/kelotane(src)
+	new /obj/item/reagent_container/hypospray/autoinjector/oxycodone(src)
+	new /obj/item/reagent_container/hypospray/autoinjector/emergency(src)
+	new /obj/item/reagent_container/hypospray/autoinjector/emergency(src)
+	new /obj/item/tool/extinguisher/mini(src)
+
 /obj/item/storage/pouch/medical/socmed/dutch
 	name = "\improper Dutch's Medical Pouch"
 	desc = "A pouch bought from a black market trader by Dutch quite a few years ago. Rumoured to be stolen from secret USCM assets. Its contents have been slowly used up and replaced over the years."

--- a/code/modules/gear_presets/survivors.dm
+++ b/code/modules/gear_presets/survivors.dm
@@ -1589,17 +1589,13 @@
 	languages = list(LANGUAGE_RUSSIAN, LANGUAGE_GERMAN, LANGUAGE_CHINESE)
 	faction = FACTION_UPP
 	faction_group = list(FACTION_UPP, FACTION_SURVIVOR)
-	role_comm_title = "UPP 173RD RECON"
+	role_comm_title = "173/RECON"
 	idtype = /obj/item/card/id/dogtag
 	flags = EQUIPMENT_PRESET_EXTRA
 	uses_special_name = TRUE
 	access = list(
 		ACCESS_CIVILIAN_PUBLIC,
 	)
-
-/datum/equipment_preset/survivor/upp/load_name(mob/living/carbon/human/new_human, randomise)
-	var/random_name = capitalize(pick(new_human.gender == MALE ? first_names_male_upp : first_names_female_upp)) + " " + capitalize(pick(last_names_upp))
-	new_human.change_real_name(new_human, random_name)
 
 /datum/equipment_preset/survivor/upp/load_gear(mob/living/carbon/human/new_human)
 	var/obj/item/clothing/under/marine/veteran/UPP/uniform = new()
@@ -1726,7 +1722,7 @@
 	assignment = JOB_UPP_LEADER
 	rank = JOB_UPP_LEADER
 	languages = list(LANGUAGE_RUSSIAN, LANGUAGE_ENGLISH,  LANGUAGE_GERMAN,  LANGUAGE_CHINESE)
-	role_comm_title = "UPP 173Rd RECON SL"
+	role_comm_title = "173/RECON SL"
 	skills = /datum/skills/military/survivor/upp_sl
 
 /datum/equipment_preset/survivor/upp/squad_leader/load_gear(mob/living/carbon/human/new_human)

--- a/code/modules/gear_presets/survivors.dm
+++ b/code/modules/gear_presets/survivors.dm
@@ -1726,7 +1726,7 @@
 	assignment = JOB_UPP_LEADER
 	rank = JOB_UPP_LEADER
 	languages = list(LANGUAGE_RUSSIAN, LANGUAGE_ENGLISH,  LANGUAGE_GERMAN,  LANGUAGE_CHINESE)
-	role_comm_title = "UPP 173RD RECON"
+	role_comm_title = "UPP 173RD RECON SL"
 	skills = /datum/skills/military/survivor/upp_sl
 
 /datum/equipment_preset/survivor/upp/squad_leader/load_gear(mob/living/carbon/human/new_human)

--- a/code/modules/gear_presets/survivors.dm
+++ b/code/modules/gear_presets/survivors.dm
@@ -1726,7 +1726,7 @@
 	assignment = JOB_UPP_LEADER
 	rank = JOB_UPP_LEADER
 	languages = list(LANGUAGE_RUSSIAN, LANGUAGE_ENGLISH,  LANGUAGE_GERMAN,  LANGUAGE_CHINESE)
-	role_comm_title = "UPP 173RD RECON SL"
+	role_comm_title = "UPP 173Rd RECON SL"
 	skills = /datum/skills/military/survivor/upp_sl
 
 /datum/equipment_preset/survivor/upp/squad_leader/load_gear(mob/living/carbon/human/new_human)

--- a/code/modules/gear_presets/survivors.dm
+++ b/code/modules/gear_presets/survivors.dm
@@ -1589,13 +1589,17 @@
 	languages = list(LANGUAGE_RUSSIAN, LANGUAGE_GERMAN, LANGUAGE_CHINESE)
 	faction = FACTION_UPP
 	faction_group = list(FACTION_UPP, FACTION_SURVIVOR)
-	role_comm_title = "173/RECON"
+	role_comm_title = "UPP 173RD RECON"
 	idtype = /obj/item/card/id/dogtag
 	flags = EQUIPMENT_PRESET_EXTRA
 	uses_special_name = TRUE
 	access = list(
 		ACCESS_CIVILIAN_PUBLIC,
 	)
+
+/datum/equipment_preset/survivor/upp/load_name(mob/living/carbon/human/new_human, randomise)
+	var/random_name = capitalize(pick(new_human.gender == MALE ? first_names_male_upp : first_names_female_upp)) + " " + capitalize(pick(last_names_upp))
+	new_human.change_real_name(new_human, random_name)
 
 /datum/equipment_preset/survivor/upp/load_gear(mob/living/carbon/human/new_human)
 	var/obj/item/clothing/under/marine/veteran/UPP/uniform = new()
@@ -1722,7 +1726,7 @@
 	assignment = JOB_UPP_LEADER
 	rank = JOB_UPP_LEADER
 	languages = list(LANGUAGE_RUSSIAN, LANGUAGE_ENGLISH,  LANGUAGE_GERMAN,  LANGUAGE_CHINESE)
-	role_comm_title = "173/RECON SL"
+	role_comm_title = "UPP 173RD RECON"
 	skills = /datum/skills/military/survivor/upp_sl
 
 /datum/equipment_preset/survivor/upp/squad_leader/load_gear(mob/living/carbon/human/new_human)

--- a/code/modules/gear_presets/upp.dm
+++ b/code/modules/gear_presets/upp.dm
@@ -2546,6 +2546,106 @@
 		list("Drop Pouch", 10, /obj/item/clothing/accessory/storage/droppouch, null, VENDOR_ITEM_REGULAR),
 	)
 
+/datum/equipment_preset/upp/commando/lowthreat
+	name = "UPP Commando (Not Overpowered)"
+
+/datum/equipment_preset/upp/commando/lowthreat/load_gear(mob/living/carbon/human/new_human)
+	new_human.equip_to_slot_or_del(new /obj/item/device/radio/headset/distress/UPP/kdo, WEAR_L_EAR)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/under/marine/veteran/UPP, WEAR_BODY)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/marine/faction/UPP/commando, WEAR_JACKET)
+	new_human.equip_to_slot_or_del(new /obj/item/ammo_magazine/rifle/type71/ap, WEAR_IN_JACKET)
+	new_human.equip_to_slot_or_del(new /obj/item/ammo_magazine/rifle/type71/ap, WEAR_IN_JACKET)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/head/uppcap, WEAR_HEAD)
+	new_human.equip_to_slot_or_del(new /obj/item/storage/belt/gun/type47/np92/suppressed, WEAR_WAIST)
+	new_human.equip_to_slot_or_del(new /obj/item/storage/backpack/marine/satchel/scout_cloak/upp/weak, WEAR_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/shoes/marine/upp, WEAR_FEET)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/gloves/marine/veteran, WEAR_HANDS)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/pmc/upp, WEAR_FACE)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/glasses/night/m42_night_goggles/upp, WEAR_EYES)
+
+	new_human.equip_to_slot_or_del(new /obj/item/reagent_container/food/snacks/upp, WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/explosive/plastic, WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/explosive/plastic, WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/explosive/grenade/phosphorus/upp, WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/tool/crowbar, WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/magazine/large, WEAR_R_STORE)
+	new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/firstaid/full, WEAR_L_STORE)
+
+	new_human.equip_to_slot_or_del(new /obj/item/handcuffs, WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/handcuffs, WEAR_IN_BACK)
+
+	spawn_weapon(/obj/item/weapon/gun/rifle/type71/carbine/commando, /obj/item/ammo_magazine/rifle/type71, new_human, 0, 8)
+
+/datum/equipment_preset/upp/commando/medic/lowthreat
+	name = "UPP Commando Medic (Not Overpowered)"
+
+/datum/equipment_preset/upp/commando/medic/load_gear(mob/living/carbon/human/new_human)
+	//TODO: add backpacks and satchels
+	new_human.equip_to_slot_or_del(new /obj/item/device/radio/headset/distress/UPP/kdo/medic, WEAR_L_EAR)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/under/marine/veteran/UPP/medic, WEAR_BODY)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/marine/faction/UPP/commando, WEAR_JACKET)
+	new_human.equip_to_slot_or_del(new /obj/item/ammo_magazine/rifle/type71/ap, WEAR_IN_JACKET)
+	new_human.equip_to_slot_or_del(new /obj/item/ammo_magazine/rifle/type71/ap, WEAR_IN_JACKET)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/head/uppcap, WEAR_HEAD)
+	new_human.equip_to_slot_or_del(new /obj/item/storage/backpack/marine/satchel/scout_cloak/upp/weak, WEAR_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/shoes/marine/upp, WEAR_FEET)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/gloves/marine/veteran, WEAR_HANDS)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/pmc/upp, WEAR_FACE)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/glasses/night/m42_night_goggles/upp, WEAR_EYES)
+
+	new_human.equip_to_slot_or_del(new /obj/item/storage/belt/medical/lifesaver/upp/full, WEAR_WAIST)
+	new_human.equip_to_slot_or_del(new /obj/item/device/healthanalyzer, WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/tool/surgery/surgical_line, WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/tool/surgery/synthgraft, WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/device/defibrillator, WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/storage/firstaid/adv, WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/roller, WEAR_IN_BACK)
+	if(new_human.disabilities & NEARSIGHTED)
+		new_human.equip_to_slot_or_del(new /obj/item/clothing/glasses/hud/health/prescription(new_human), WEAR_IN_BACK)
+	else
+		new_human.equip_to_slot_or_del(new /obj/item/clothing/glasses/hud/health(new_human), WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/tool/crowbar, WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/magazine/large, WEAR_R_STORE)
+
+	new_human.equip_to_slot_or_del(new /obj/item/reagent_container/food/snacks/upp, WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/explosive/C4, WEAR_L_STORE)
+
+	new_human.equip_to_slot_or_del(new /obj/item/handcuffs, WEAR_IN_JACKET)
+	new_human.equip_to_slot_or_del(new /obj/item/handcuffs, WEAR_IN_JACKET)
+
+	spawn_weapon(/obj/item/weapon/gun/rifle/type71/carbine/commando, /obj/item/ammo_magazine/rifle/type71, new_human, 0, 5)
+
+/datum/equipment_preset/upp/commando/leader/lowthreat
+	name = "UPP Commando Leader (Not Overpowered)"
+
+/datum/equipment_preset/upp/commando/leader/load_gear(mob/living/carbon/human/new_human)
+	//TODO: add backpacks and satchels
+	new_human.equip_to_slot_or_del(new /obj/item/device/radio/headset/distress/UPP/kdo/command, WEAR_L_EAR)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/under/marine/veteran/UPP, WEAR_BODY)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/marine/faction/UPP/commando, WEAR_JACKET)
+	new_human.equip_to_slot_or_del(new /obj/item/ammo_magazine/rifle/type71/ap, WEAR_IN_JACKET)
+	new_human.equip_to_slot_or_del(new /obj/item/ammo_magazine/rifle/type71/ap, WEAR_IN_JACKET)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/head/uppcap/beret, WEAR_HEAD)
+	new_human.equip_to_slot_or_del(new /obj/item/storage/backpack/marine/satchel/scout_cloak/upp/weak, WEAR_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/shoes/marine/upp, WEAR_FEET)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/gloves/marine/veteran, WEAR_HANDS)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/pmc/upp, WEAR_FACE)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/glasses/night/m42_night_goggles/upp, WEAR_EYES)
+
+	new_human.equip_to_slot_or_del(new /obj/item/storage/belt/gun/type47/np92/suppressed, WEAR_WAIST)
+
+	new_human.equip_to_slot_or_del(new /obj/item/reagent_container/food/snacks/upp, WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/explosive/grenade/phosphorus/upp, WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/explosive/grenade/phosphorus/upp, WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/tool/crowbar, WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/device/binoculars/range, WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/magazine/large, WEAR_R_STORE)
+	new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/explosive/C4, WEAR_L_STORE)
+
+	new_human.equip_to_slot_or_del(new /obj/item/handcuffs, WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/handcuffs, WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/storage/box/handcuffs, WEAR_IN_BACK)
+
 //*****************************************************************************************************/
 
 /datum/equipment_preset/upp/tank

--- a/code/modules/gear_presets/upp.dm
+++ b/code/modules/gear_presets/upp.dm
@@ -2097,7 +2097,7 @@
 //*****************************************************************************************************/
 
 /datum/equipment_preset/upp/commando
-	name = "UPP Commando"
+	name = "UPP Commando (!DEATHSQUAD!)"
 	flags = EQUIPMENT_PRESET_EXTRA
 
 	skills = /datum/skills/commando
@@ -2226,7 +2226,7 @@
 //*****************************************************************************************************/
 
 /datum/equipment_preset/upp/commando/medic
-	name = "UPP Commando Medic"
+	name = "UPP Commando Medic (!DEATHSQUAD!)"
 	flags = EQUIPMENT_PRESET_EXTRA
 
 	skills = /datum/skills/commando/medic
@@ -2395,7 +2395,7 @@
 //*****************************************************************************************************/
 
 /datum/equipment_preset/upp/commando/leader
-	name = "UPP Commando Leader"
+	name = "UPP Commando Leader (!DEATHSQUAD!)"
 	flags = EQUIPMENT_PRESET_EXTRA
 
 	skills = /datum/skills/commando/leader
@@ -2547,7 +2547,7 @@
 	)
 
 /datum/equipment_preset/upp/commando/lowthreat
-	name = "UPP Commando (Not Overpowered)"
+	name = "UPP Commando"
 
 /datum/equipment_preset/upp/commando/lowthreat/load_gear(mob/living/carbon/human/new_human)
 	new_human.equip_to_slot_or_del(new /obj/item/device/radio/headset/distress/UPP/kdo, WEAR_L_EAR)
@@ -2577,7 +2577,7 @@
 	spawn_weapon(/obj/item/weapon/gun/rifle/type71/carbine/commando, /obj/item/ammo_magazine/rifle/type71, new_human, 0, 8)
 
 /datum/equipment_preset/upp/commando/medic/lowthreat
-	name = "UPP Commando Medic (Not Overpowered)"
+	name = "UPP Commando Medic"
 
 /datum/equipment_preset/upp/commando/medic/load_gear(mob/living/carbon/human/new_human)
 	//TODO: add backpacks and satchels
@@ -2616,7 +2616,7 @@
 	spawn_weapon(/obj/item/weapon/gun/rifle/type71/carbine/commando, /obj/item/ammo_magazine/rifle/type71, new_human, 0, 5)
 
 /datum/equipment_preset/upp/commando/leader/lowthreat
-	name = "UPP Commando Leader (Not Overpowered)"
+	name = "UPP Commando Leader"
 
 /datum/equipment_preset/upp/commando/leader/load_gear(mob/living/carbon/human/new_human)
 	//TODO: add backpacks and satchels

--- a/code/modules/gear_presets/upp.dm
+++ b/code/modules/gear_presets/upp.dm
@@ -2546,10 +2546,10 @@
 		list("Drop Pouch", 10, /obj/item/clothing/accessory/storage/droppouch, null, VENDOR_ITEM_REGULAR),
 	)
 
-/datum/equipment_preset/upp/commando/lowthreat
+/datum/equipment_preset/upp/commando/low_threat
 	name = "UPP Commando"
 
-/datum/equipment_preset/upp/commando/lowthreat/load_gear(mob/living/carbon/human/new_human)
+/datum/equipment_preset/upp/commando/low_threat/load_gear(mob/living/carbon/human/new_human)
 	new_human.equip_to_slot_or_del(new /obj/item/device/radio/headset/distress/UPP/kdo, WEAR_L_EAR)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/under/marine/veteran/UPP, WEAR_BODY)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/marine/faction/UPP/commando, WEAR_JACKET)
@@ -2576,7 +2576,7 @@
 
 	spawn_weapon(/obj/item/weapon/gun/rifle/type71/carbine/commando, /obj/item/ammo_magazine/rifle/type71, new_human, 0, 8)
 
-/datum/equipment_preset/upp/commando/medic/lowthreat
+/datum/equipment_preset/upp/commando/medic/low_threat
 	name = "UPP Commando Medic"
 
 /datum/equipment_preset/upp/commando/medic/load_gear(mob/living/carbon/human/new_human)
@@ -2615,7 +2615,7 @@
 
 	spawn_weapon(/obj/item/weapon/gun/rifle/type71/carbine/commando, /obj/item/ammo_magazine/rifle/type71, new_human, 0, 5)
 
-/datum/equipment_preset/upp/commando/leader/lowthreat
+/datum/equipment_preset/upp/commando/leader/low_threat
 	name = "UPP Commando Leader"
 
 /datum/equipment_preset/upp/commando/leader/load_gear(mob/living/carbon/human/new_human)

--- a/code/modules/gear_presets/uscm.dm
+++ b/code/modules/gear_presets/uscm.dm
@@ -885,3 +885,61 @@
 		if(get_job_playtime(new_human.client, rank) > JOB_PLAYTIME_TIER_3)
 			return "MO4"
 	return paygrade
+
+/datum/equipment_preset/uscm/marsoc/lowthreat
+	name = "Marine Raider (Not Overpowered)"
+
+/datum/equipment_preset/uscm/marsoc/lowthreat/load_gear(mob/living/carbon/human/new_human)
+	//back
+	new_human.equip_to_slot_or_del(new /obj/item/storage/backpack/marine/marsoc, WEAR_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/explosive/grenade/high_explosive, WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/explosive/grenade/high_explosive, WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/explosive/grenade/high_explosive, WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/explosive/grenade/phosphorus, WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/explosive/grenade/phosphorus, WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/explosive/grenade/phosphorus, WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/device/motiondetector, WEAR_IN_BACK)
+	//face
+	new_human.equip_to_slot_or_del(new /obj/item/device/radio/headset/almayer/sof, WEAR_L_EAR)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/pmc/marsoc, WEAR_FACE)
+	//head
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/marine/sof, WEAR_HEAD)
+	new_human.equip_to_slot_or_del(new /obj/item/prop/helmetgarb/helmet_nvg/marsoc, WEAR_IN_HELMET)
+	new_human.equip_to_slot_or_del(new /obj/item/ammo_magazine/handful/shotgun/buckshot, WEAR_IN_HELMET)
+	//uniform
+	var/obj/item/clothing/under/marine/veteran/marsoc/M = new()
+	var/obj/item/clothing/accessory/storage/black_vest/W = new()
+	M.attach_accessory(new_human, W)
+	new_human.equip_to_slot_or_del(M, WEAR_BODY)
+	for(var/i in 1 to W.hold.storage_slots)
+		new_human.equip_to_slot_or_del(new /obj/item/ammo_magazine/handful/shotgun/buckshot, WEAR_IN_ACCESSORY)
+	//jacket
+	var/obj/item/clothing/suit/storage/marine/sof/armor = new()
+	new_human.equip_to_slot_or_del(armor, WEAR_JACKET)
+	for(var/i in 1 to armor.storage_slots)
+		new_human.equip_to_slot_or_del(new /obj/item/ammo_magazine/rifle/xm40, WEAR_IN_JACKET)
+	new_human.equip_to_slot_or_del(new /obj/item/weapon/gun/rifle/m41a/elite/xm40/ap, WEAR_J_STORE)
+	//waist
+	new_human.equip_to_slot_or_del(new /obj/item/weapon/gun/shotgun/combat/marsoc, WEAR_WAIST)
+	//limbs
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/shoes/marine/knife(new_human), WEAR_FEET)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/gloves/marine, WEAR_HANDS)
+	//pockets
+	new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/medical/socmed/not_op, WEAR_L_STORE)
+	new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/tools/tactical/full, WEAR_R_STORE)
+
+/datum/equipment_preset/uscm/marsoc/lowthreat/sl
+	name = "Marine Raider Team Leader (Not Overpowered)"
+	assignment = JOB_MARINE_RAIDER_SL
+	rank = JOB_MARINE_RAIDER_SL
+	role_comm_title = "TL."
+	paygrade = "MO1"
+	skills = /datum/skills/commando/deathsquad/leader
+
+	minimap_icon = "leader"
+
+/datum/equipment_preset/uscm/marsoc/sl/load_rank(mob/living/carbon/human/new_human)
+	if(new_human.client)
+		if(get_job_playtime(new_human.client, rank) > JOB_PLAYTIME_TIER_2)
+			return "MO2"
+	return paygrade

--- a/code/modules/gear_presets/uscm.dm
+++ b/code/modules/gear_presets/uscm.dm
@@ -886,10 +886,10 @@
 			return "MO4"
 	return paygrade
 
-/datum/equipment_preset/uscm/marsoc/lowthreat
+/datum/equipment_preset/uscm/marsoc/low_threat
 	name = "Marine Raider"
 
-/datum/equipment_preset/uscm/marsoc/lowthreat/load_gear(mob/living/carbon/human/new_human)
+/datum/equipment_preset/uscm/marsoc/low_threat/load_gear(mob/living/carbon/human/new_human)
 	//back
 	new_human.equip_to_slot_or_del(new /obj/item/storage/backpack/marine/marsoc, WEAR_BACK)
 	new_human.equip_to_slot_or_del(new /obj/item/explosive/grenade/high_explosive, WEAR_IN_BACK)
@@ -928,7 +928,7 @@
 	new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/medical/socmed/not_op, WEAR_L_STORE)
 	new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/tools/tactical/full, WEAR_R_STORE)
 
-/datum/equipment_preset/uscm/marsoc/lowthreat/sl
+/datum/equipment_preset/uscm/marsoc/low_threat/sl
 	name = "Marine Raider Team Leader"
 	assignment = JOB_MARINE_RAIDER_SL
 	rank = JOB_MARINE_RAIDER_SL

--- a/code/modules/gear_presets/uscm.dm
+++ b/code/modules/gear_presets/uscm.dm
@@ -768,7 +768,7 @@
 //############ Marine Raiders #############
 //Operator
 /datum/equipment_preset/uscm/marsoc
-	name = "Marine Raider"
+	name = "Marine Raider (!DEATHSQUAD!)"
 	flags = EQUIPMENT_PRESET_EXTRA
 	assignment = "Marine Raider"
 	rank = JOB_MARINE_RAIDER
@@ -835,7 +835,7 @@
 
 //Covert Raiders
 /datum/equipment_preset/uscm/marsoc/covert
-	name = "Marine Raiders (Covert)"
+	name = "Marine Raiders (!DEATHSQUAD! Covert)"
 	uses_special_name = TRUE
 /datum/equipment_preset/uscm/marsoc/covert/load_name(mob/living/carbon/human/new_human, randomise)
 	new_human.gender = MALE
@@ -846,7 +846,7 @@
 
 //Team Leader
 /datum/equipment_preset/uscm/marsoc/sl
-	name = "Marine Raider Team Leader"
+	name = "Marine Raider Team Leader (!DEATHSQUAD!)"
 	assignment = JOB_MARINE_RAIDER_SL
 	rank = JOB_MARINE_RAIDER_SL
 	role_comm_title = "TL."
@@ -863,7 +863,7 @@
 
 //Codenamed Team Leader
 /datum/equipment_preset/uscm/marsoc/sl/covert
-	name = "Marine Raider Team Leader (Covert)"
+	name = "Marine Raider Team Leader (!DEATHSQUAD! Covert)"
 	uses_special_name = TRUE
 /datum/equipment_preset/uscm/marsoc/sl/covert/load_name(mob/living/carbon/human/new_human, randomise)
 	new_human.gender = MALE
@@ -873,7 +873,7 @@
 	return "O"
 //Officer
 /datum/equipment_preset/uscm/marsoc/cmd
-	name = "Marine Raider Officer"
+	name = "Marine Raider Officer (!DEATHSQUAD!)"
 	assignment = JOB_MARINE_RAIDER_CMD
 	rank = JOB_MARINE_RAIDER_CMD
 	role_comm_title = "CMD."
@@ -887,7 +887,7 @@
 	return paygrade
 
 /datum/equipment_preset/uscm/marsoc/lowthreat
-	name = "Marine Raider (Not Overpowered)"
+	name = "Marine Raider"
 
 /datum/equipment_preset/uscm/marsoc/lowthreat/load_gear(mob/living/carbon/human/new_human)
 	//back
@@ -907,11 +907,11 @@
 	new_human.equip_to_slot_or_del(new /obj/item/prop/helmetgarb/helmet_nvg/marsoc, WEAR_IN_HELMET)
 	new_human.equip_to_slot_or_del(new /obj/item/ammo_magazine/handful/shotgun/buckshot, WEAR_IN_HELMET)
 	//uniform
-	var/obj/item/clothing/under/marine/veteran/marsoc/M = new()
-	var/obj/item/clothing/accessory/storage/black_vest/W = new()
-	M.attach_accessory(new_human, W)
-	new_human.equip_to_slot_or_del(M, WEAR_BODY)
-	for(var/i in 1 to W.hold.storage_slots)
+	var/obj/item/clothing/under/marine/veteran/marsoc/uniform = new()
+	var/obj/item/clothing/accessory/storage/black_vest/accessory = new()
+	uniform.attach_accessory(new_human, accessory)
+	new_human.equip_to_slot_or_del(uniform, WEAR_BODY)
+	for(var/i in 1 to accessory.hold.storage_slots)
 		new_human.equip_to_slot_or_del(new /obj/item/ammo_magazine/handful/shotgun/buckshot, WEAR_IN_ACCESSORY)
 	//jacket
 	var/obj/item/clothing/suit/storage/marine/sof/armor = new()
@@ -929,7 +929,7 @@
 	new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/tools/tactical/full, WEAR_R_STORE)
 
 /datum/equipment_preset/uscm/marsoc/lowthreat/sl
-	name = "Marine Raider Team Leader (Not Overpowered)"
+	name = "Marine Raider Team Leader"
 	assignment = JOB_MARINE_RAIDER_SL
 	rank = JOB_MARINE_RAIDER_SL
 	role_comm_title = "TL."

--- a/code/modules/gear_presets/whiteout.dm
+++ b/code/modules/gear_presets/whiteout.dm
@@ -245,9 +245,9 @@
 	//uniform
 	var/obj/item/clothing/under/marine/veteran/pmc/commando/uniform = new()
 	var/obj/item/clothing/accessory/storage/webbing/accessory = new()
-	M.attach_accessory(new_human, accessory)
+	uniform.attach_accessory(new_human, accessory)
 	new_human.equip_to_slot_or_del(uniform, WEAR_BODY)
-	for(var/i in 1 to W.hold.storage_slots)
+	for(var/i in 1 to accessory.hold.storage_slots)
 		new_human.equip_to_slot_or_del(new /obj/item/explosive/grenade/high_explosive/pmc, WEAR_IN_ACCESSORY)
 	//jacket
 	var/obj/item/clothing/suit/storage/marine/veteran/pmc/commando/armor = new()
@@ -292,9 +292,9 @@
 	//uniform
 	var/obj/item/clothing/under/marine/veteran/pmc/commando/uniform = new()
 	var/obj/item/clothing/accessory/storage/webbing/accessory = new()
-	M.attach_accessory(new_human, accessory)
+	uniform.attach_accessory(new_human, accessory)
 	new_human.equip_to_slot_or_del(uniform, WEAR_BODY)
-	for(var/i in 1 to W.hold.storage_slots)
+	for(var/i in 1 to accessory.hold.storage_slots)
 		new_human.equip_to_slot_or_del(new /obj/item/stack/nanopaste, WEAR_IN_ACCESSORY)
 	//jacket
 	var/obj/item/clothing/suit/storage/marine/veteran/pmc/commando/armor = new()
@@ -326,9 +326,9 @@
 	//uniform
 	var/obj/item/clothing/under/marine/veteran/pmc/commando/uniform = new()
 	var/obj/item/clothing/accessory/storage/webbing/accessory = new()
-	M.attach_accessory(new_human, accessory)
+	uniform.attach_accessory(new_human, accessory)
 	new_human.equip_to_slot_or_del(uniform, WEAR_BODY)
-	for(var/i in 1 to W.hold.storage_slots)
+	for(var/i in 1 to accessory.hold.storage_slots)
 		new_human.equip_to_slot_or_del(new /obj/item/explosive/grenade/high_explosive/pmc, WEAR_IN_ACCESSORY)
 	//jacket
 	var/obj/item/clothing/suit/storage/marine/smartgunner/veteran/pmc/terminator/armor = new()
@@ -374,9 +374,9 @@
 	//uniform
 	var/obj/item/clothing/under/marine/veteran/pmc/commando/uniform = new()
 	var/obj/item/clothing/accessory/storage/webbing/accessory = new()
-	M.attach_accessory(new_human, accessory)
+	uniform.attach_accessory(new_human, accessory)
 	new_human.equip_to_slot_or_del(uniform, WEAR_BODY)
-	for(var/i in 1 to W.hold.storage_slots)
+	for(var/i in 1 to accessory.hold.storage_slots)
 		new_human.equip_to_slot_or_del(new /obj/item/explosive/grenade/high_explosive/pmc, WEAR_IN_ACCESSORY)
 	//jacket
 	var/obj/item/clothing/suit/storage/marine/veteran/pmc/commando/armor = new()

--- a/code/modules/gear_presets/whiteout.dm
+++ b/code/modules/gear_presets/whiteout.dm
@@ -219,10 +219,10 @@
 
 //*****************************************************************************************************/
 
-/datum/equipment_preset/pmc/w_y_whiteout/lowthreat
+/datum/equipment_preset/pmc/w_y_whiteout/low_threat
 	name = "Whiteout Team Operative"
 
-/datum/equipment_preset/pmc/w_y_whiteout/lowthreat/load_gear(mob/living/carbon/human/new_human)
+/datum/equipment_preset/pmc/w_y_whiteout/low_threat/load_gear(mob/living/carbon/human/new_human)
 	// back
 	new_human.equip_to_slot_or_del(new /obj/item/storage/backpack/commando, WEAR_BACK)
 	new_human.equip_to_slot_or_del(new /obj/item/explosive/plastic, WEAR_IN_BACK)
@@ -269,10 +269,10 @@
 
 //*****************************************************************************************************/
 
-/datum/equipment_preset/pmc/w_y_whiteout/lowthreat/medic
+/datum/equipment_preset/pmc/w_y_whiteout/low_threat/medic
 	name = "Whiteout Team Medic"
 
-/datum/equipment_preset/pmc/w_y_whiteout/lowthreat/medic/load_gear(mob/living/carbon/human/new_human)
+/datum/equipment_preset/pmc/w_y_whiteout/low_threat/medic/load_gear(mob/living/carbon/human/new_human)
 	// back
 	new_human.equip_to_slot_or_del(new /obj/item/storage/backpack/commando, WEAR_BACK)
 	new_human.equip_to_slot_or_del(new /obj/item/storage/firstaid/synth, WEAR_IN_BACK)
@@ -314,10 +314,10 @@
 	var/obj/item/device/internal_implant/agility/implant = new()
 	implant.on_implanted(new_human)
 
-/datum/equipment_preset/pmc/w_y_whiteout/lowthreat/terminator
+/datum/equipment_preset/pmc/w_y_whiteout/low_threat/terminator
 	name = "Whiteout Team Terminator"
 
-/datum/equipment_preset/pmc/w_y_whiteout/lowthreat/terminator/load_gear(mob/living/carbon/human/new_human)
+/datum/equipment_preset/pmc/w_y_whiteout/low_threat/terminator/load_gear(mob/living/carbon/human/new_human)
 	//face
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/pmc/leader, WEAR_FACE)
 	new_human.equip_to_slot_or_del(new /obj/item/device/radio/headset/distress/commando, WEAR_L_EAR)
@@ -351,10 +351,10 @@
 	implant.on_implanted(new_human)
 
 //*****************************************************************************************************/
-/datum/equipment_preset/pmc/w_y_whiteout/lowthreat/leader
+/datum/equipment_preset/pmc/w_y_whiteout/low_threat/leader
 	name = "Whiteout Team Leader"
 
-/datum/equipment_preset/pmc/w_y_whiteout/lowthreat/leader/load_gear(mob/living/carbon/human/new_human)
+/datum/equipment_preset/pmc/w_y_whiteout/low_threat/leader/load_gear(mob/living/carbon/human/new_human)
 	// back
 	new_human.equip_to_slot_or_del(new /obj/item/storage/backpack/commando, WEAR_BACK)
 	new_human.equip_to_slot_or_del(new /obj/item/explosive/plastic, WEAR_IN_BACK)

--- a/code/modules/gear_presets/whiteout.dm
+++ b/code/modules/gear_presets/whiteout.dm
@@ -1,5 +1,5 @@
 /datum/equipment_preset/pmc/w_y_whiteout
-	name = "Whiteout Team Operative"
+	name = "Whiteout Team Operative (!DEATHSQUAD!)"
 	flags = EQUIPMENT_PRESET_EXTRA
 	uses_special_name = TRUE //We always use a codename!
 	faction = FACTION_WY_DEATHSQUAD
@@ -130,7 +130,7 @@
 
 //*****************************************************************************************************/
 /datum/equipment_preset/pmc/w_y_whiteout/terminator
-	name = "Whiteout Team Terminator"
+	name = "Whiteout Team Terminator (!DEATHSQUAD!)"
 	flags = EQUIPMENT_PRESET_EXTRA
 	assignment = "Whiteout Team Terminator"
 	role_comm_title = "WO-TT"
@@ -170,7 +170,7 @@
 
 //*****************************************************************************************************/
 /datum/equipment_preset/pmc/w_y_whiteout/leader
-	name = "Whiteout Team Leader"
+	name = "Whiteout Team Leader (!DEATHSQUAD!)"
 	flags = EQUIPMENT_PRESET_EXTRA
 	assignment = "Whiteout Team Leader"
 	role_comm_title = "WO-TL"
@@ -220,7 +220,7 @@
 //*****************************************************************************************************/
 
 /datum/equipment_preset/pmc/w_y_whiteout/lowthreat
-	name = "Whiteout Team Operative (Not Overpowered)"
+	name = "Whiteout Team Operative"
 
 /datum/equipment_preset/pmc/w_y_whiteout/lowthreat/load_gear(mob/living/carbon/human/new_human)
 	// back
@@ -243,10 +243,10 @@
 	//head
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/marine/veteran/pmc/commando, WEAR_HEAD)
 	//uniform
-	var/obj/item/clothing/under/marine/veteran/pmc/commando/M = new()
-	var/obj/item/clothing/accessory/storage/webbing/W = new()
-	M.attach_accessory(new_human, W)
-	new_human.equip_to_slot_or_del(M, WEAR_BODY)
+	var/obj/item/clothing/under/marine/veteran/pmc/commando/uniform = new()
+	var/obj/item/clothing/accessory/storage/webbing/accessory = new()
+	M.attach_accessory(new_human, accessory)
+	new_human.equip_to_slot_or_del(uniform, WEAR_BODY)
 	for(var/i in 1 to W.hold.storage_slots)
 		new_human.equip_to_slot_or_del(new /obj/item/explosive/grenade/high_explosive/pmc, WEAR_IN_ACCESSORY)
 	//jacket
@@ -270,7 +270,7 @@
 //*****************************************************************************************************/
 
 /datum/equipment_preset/pmc/w_y_whiteout/lowthreat/medic
-	name = "Whiteout Team Medic (Not Overpowered)"
+	name = "Whiteout Team Medic"
 
 /datum/equipment_preset/pmc/w_y_whiteout/lowthreat/medic/load_gear(mob/living/carbon/human/new_human)
 	// back
@@ -290,10 +290,10 @@
 	//head
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/marine/veteran/pmc/commando, WEAR_HEAD)
 	//uniform
-	var/obj/item/clothing/under/marine/veteran/pmc/commando/M = new()
-	var/obj/item/clothing/accessory/storage/webbing/W = new()
-	M.attach_accessory(new_human, W)
-	new_human.equip_to_slot_or_del(M, WEAR_BODY)
+	var/obj/item/clothing/under/marine/veteran/pmc/commando/uniform = new()
+	var/obj/item/clothing/accessory/storage/webbing/accessory = new()
+	M.attach_accessory(new_human, accessory)
+	new_human.equip_to_slot_or_del(uniform, WEAR_BODY)
 	for(var/i in 1 to W.hold.storage_slots)
 		new_human.equip_to_slot_or_del(new /obj/item/stack/nanopaste, WEAR_IN_ACCESSORY)
 	//jacket
@@ -315,7 +315,7 @@
 	implant.on_implanted(new_human)
 
 /datum/equipment_preset/pmc/w_y_whiteout/lowthreat/terminator
-	name = "Whiteout Team Terminator (Not Overpowered)"
+	name = "Whiteout Team Terminator"
 
 /datum/equipment_preset/pmc/w_y_whiteout/lowthreat/terminator/load_gear(mob/living/carbon/human/new_human)
 	//face
@@ -324,10 +324,10 @@
 	//head
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/marine/veteran/pmc/commando, WEAR_HEAD)
 	//uniform
-	var/obj/item/clothing/under/marine/veteran/pmc/commando/M = new()
-	var/obj/item/clothing/accessory/storage/webbing/W = new()
-	M.attach_accessory(new_human, W)
-	new_human.equip_to_slot_or_del(M, WEAR_BODY)
+	var/obj/item/clothing/under/marine/veteran/pmc/commando/uniform = new()
+	var/obj/item/clothing/accessory/storage/webbing/accessory = new()
+	M.attach_accessory(new_human, accessory)
+	new_human.equip_to_slot_or_del(uniform, WEAR_BODY)
 	for(var/i in 1 to W.hold.storage_slots)
 		new_human.equip_to_slot_or_del(new /obj/item/explosive/grenade/high_explosive/pmc, WEAR_IN_ACCESSORY)
 	//jacket
@@ -352,7 +352,7 @@
 
 //*****************************************************************************************************/
 /datum/equipment_preset/pmc/w_y_whiteout/lowthreat/leader
-	name = "Whiteout Team Leader (Not Overpowered)"
+	name = "Whiteout Team Leader"
 
 /datum/equipment_preset/pmc/w_y_whiteout/lowthreat/leader/load_gear(mob/living/carbon/human/new_human)
 	// back
@@ -372,10 +372,10 @@
 	//head
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/marine/veteran/pmc/commando, WEAR_HEAD)
 	//uniform
-	var/obj/item/clothing/under/marine/veteran/pmc/commando/M = new()
-	var/obj/item/clothing/accessory/storage/webbing/W = new()
-	M.attach_accessory(new_human, W)
-	new_human.equip_to_slot_or_del(M, WEAR_BODY)
+	var/obj/item/clothing/under/marine/veteran/pmc/commando/uniform = new()
+	var/obj/item/clothing/accessory/storage/webbing/accessory = new()
+	M.attach_accessory(new_human, accessory)
+	new_human.equip_to_slot_or_del(uniform, WEAR_BODY)
 	for(var/i in 1 to W.hold.storage_slots)
 		new_human.equip_to_slot_or_del(new /obj/item/explosive/grenade/high_explosive/pmc, WEAR_IN_ACCESSORY)
 	//jacket

--- a/code/modules/gear_presets/whiteout.dm
+++ b/code/modules/gear_presets/whiteout.dm
@@ -216,3 +216,182 @@
 
 	var/obj/item/device/internal_implant/agility/implant = new()
 	implant.on_implanted(new_human)
+
+//*****************************************************************************************************/
+
+/datum/equipment_preset/pmc/w_y_whiteout/lowthreat
+	name = "Whiteout Team Operative (Not Overpowered)"
+
+/datum/equipment_preset/pmc/w_y_whiteout/lowthreat/load_gear(mob/living/carbon/human/new_human)
+	// back
+	new_human.equip_to_slot_or_del(new /obj/item/storage/backpack/commando, WEAR_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/explosive/plastic, WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/explosive/plastic, WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/explosive/plastic/breaching_charge, WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/explosive/plastic/breaching_charge, WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/stack/nanopaste, WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/tool/crowbar/tactical, WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/storage/firstaid/synth, WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/ammo_magazine/flamer_tank, WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/ammo_magazine/flamer_tank, WEAR_IN_BACK)
+
+
+	//face
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/glasses/night/m42_night_goggles/m42c, WEAR_EYES)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/pmc/leader, WEAR_FACE)
+	new_human.equip_to_slot_or_del(new /obj/item/device/radio/headset/distress/commando, WEAR_L_EAR)
+	//head
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/marine/veteran/pmc/commando, WEAR_HEAD)
+	//uniform
+	var/obj/item/clothing/under/marine/veteran/pmc/commando/M = new()
+	var/obj/item/clothing/accessory/storage/webbing/W = new()
+	M.attach_accessory(new_human, W)
+	new_human.equip_to_slot_or_del(M, WEAR_BODY)
+	for(var/i in 1 to W.hold.storage_slots)
+		new_human.equip_to_slot_or_del(new /obj/item/explosive/grenade/high_explosive/pmc, WEAR_IN_ACCESSORY)
+	//jacket
+	var/obj/item/clothing/suit/storage/marine/veteran/pmc/commando/armor = new()
+	new_human.equip_to_slot_or_del(armor, WEAR_JACKET)
+	for(var/i in 1 to armor.storage_slots)
+		new_human.equip_to_slot_or_del(new /obj/item/ammo_magazine/rifle/ap, WEAR_IN_JACKET)
+	new_human.equip_to_slot_or_del(new /obj/item/weapon/gun/rifle/m41a/elite, WEAR_J_STORE)
+	//waist
+	new_human.equip_to_slot_or_del(new /obj/item/weapon/gun/flamer/deathsquad/standard, WEAR_WAIST)
+	//limbs
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/gloves/marine/veteran/pmc/commando, WEAR_HANDS)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/shoes/veteran/pmc/commando/knife, WEAR_FEET)
+	//pockets
+	new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/magazine/large/pmc_rifle, WEAR_R_STORE)
+	new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/magazine/large/pmc_rifle, WEAR_L_STORE)
+
+	var/obj/item/device/internal_implant/agility/implant = new()
+	implant.on_implanted(new_human)
+
+//*****************************************************************************************************/
+
+/datum/equipment_preset/pmc/w_y_whiteout/lowthreat/medic
+	name = "Whiteout Team Medic (Not Overpowered)"
+
+/datum/equipment_preset/pmc/w_y_whiteout/lowthreat/medic/load_gear(mob/living/carbon/human/new_human)
+	// back
+	new_human.equip_to_slot_or_del(new /obj/item/storage/backpack/commando, WEAR_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/storage/firstaid/synth, WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/storage/firstaid/synth, WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/storage/firstaid/synth, WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/storage/firstaid/synth, WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/tool/crowbar, WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/device/healthanalyzer, WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/device/defibrillator/upgraded, WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/roller, WEAR_IN_BACK)
+	//face
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/glasses/night/medhud, WEAR_EYES)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/pmc/leader, WEAR_FACE)
+	new_human.equip_to_slot_or_del(new /obj/item/device/radio/headset/distress/commando, WEAR_L_EAR)
+	//head
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/marine/veteran/pmc/commando, WEAR_HEAD)
+	//uniform
+	var/obj/item/clothing/under/marine/veteran/pmc/commando/M = new()
+	var/obj/item/clothing/accessory/storage/webbing/W = new()
+	M.attach_accessory(new_human, W)
+	new_human.equip_to_slot_or_del(M, WEAR_BODY)
+	for(var/i in 1 to W.hold.storage_slots)
+		new_human.equip_to_slot_or_del(new /obj/item/stack/nanopaste, WEAR_IN_ACCESSORY)
+	//jacket
+	var/obj/item/clothing/suit/storage/marine/veteran/pmc/commando/armor = new()
+	new_human.equip_to_slot_or_del(armor, WEAR_JACKET)
+	for(var/i in 1 to armor.storage_slots)
+		new_human.equip_to_slot_or_del(new /obj/item/ammo_magazine/smg/m39/ap, WEAR_IN_JACKET)
+	new_human.equip_to_slot_or_del(new /obj/item/weapon/gun/smg/m39/elite, WEAR_J_STORE)
+	//waist
+	new_human.equip_to_slot_or_del(new /obj/item/weapon/gun/flamer/deathsquad/standard, WEAR_WAIST)
+	//limbs
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/gloves/marine/veteran/pmc/commando, WEAR_HANDS)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/shoes/veteran/pmc/commando/knife, WEAR_FEET)
+	//pockets
+	new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/magazine/large/pmc_m39, WEAR_L_STORE)
+	new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/magazine/large/pmc_m39, WEAR_R_STORE)
+
+	var/obj/item/device/internal_implant/agility/implant = new()
+	implant.on_implanted(new_human)
+
+/datum/equipment_preset/pmc/w_y_whiteout/lowthreat/terminator
+	name = "Whiteout Team Terminator (Not Overpowered)"
+
+/datum/equipment_preset/pmc/w_y_whiteout/lowthreat/terminator/load_gear(mob/living/carbon/human/new_human)
+	//face
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/pmc/leader, WEAR_FACE)
+	new_human.equip_to_slot_or_del(new /obj/item/device/radio/headset/distress/commando, WEAR_L_EAR)
+	//head
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/marine/veteran/pmc/commando, WEAR_HEAD)
+	//uniform
+	var/obj/item/clothing/under/marine/veteran/pmc/commando/M = new()
+	var/obj/item/clothing/accessory/storage/webbing/W = new()
+	M.attach_accessory(new_human, W)
+	new_human.equip_to_slot_or_del(M, WEAR_BODY)
+	for(var/i in 1 to W.hold.storage_slots)
+		new_human.equip_to_slot_or_del(new /obj/item/explosive/grenade/high_explosive/pmc, WEAR_IN_ACCESSORY)
+	//jacket
+	var/obj/item/clothing/suit/storage/marine/smartgunner/veteran/pmc/terminator/armor = new()
+	new_human.equip_to_slot_or_del(armor, WEAR_JACKET)
+	for(var/i in 1 to armor.storage_slots)
+		new_human.equip_to_slot_or_del(new /obj/item/stack/nanopaste, WEAR_IN_JACKET)
+	new_human.equip_to_slot_or_del(new /obj/item/weapon/gun/smartgun/dirty, WEAR_J_STORE)
+	//waist
+	new_human.equip_to_slot_or_del(new /obj/item/storage/belt/gun/smartgunner/pmc/full, WEAR_WAIST)
+	//limbs
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/gloves/marine/veteran/pmc/commando, WEAR_HANDS)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/shoes/veteran/pmc/commando/knife, WEAR_FEET)
+	//pockets
+	new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/magazine/large/pmc_sg, WEAR_R_STORE)
+	new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/magazine/large/pmc_sg, WEAR_L_STORE)
+
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/glasses/night/m56_goggles/whiteout, WEAR_EYES)
+
+	var/obj/item/device/internal_implant/agility/implant = new()
+	implant.on_implanted(new_human)
+
+//*****************************************************************************************************/
+/datum/equipment_preset/pmc/w_y_whiteout/lowthreat/leader
+	name = "Whiteout Team Leader (Not Overpowered)"
+
+/datum/equipment_preset/pmc/w_y_whiteout/lowthreat/leader/load_gear(mob/living/carbon/human/new_human)
+	// back
+	new_human.equip_to_slot_or_del(new /obj/item/storage/backpack/commando, WEAR_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/explosive/plastic, WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/explosive/plastic, WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/stack/nanopaste, WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/stack/nanopaste, WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/tool/crowbar/tactical, WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/explosive/plastic/breaching_charge, WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/explosive/plastic/breaching_charge, WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/storage/firstaid/synth, WEAR_IN_BACK)
+	//face
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/glasses/night/m42_night_goggles/m42c, WEAR_EYES)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/pmc/leader, WEAR_FACE)
+	new_human.equip_to_slot_or_del(new /obj/item/device/radio/headset/distress/commando, WEAR_L_EAR)
+	//head
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/marine/veteran/pmc/commando, WEAR_HEAD)
+	//uniform
+	var/obj/item/clothing/under/marine/veteran/pmc/commando/M = new()
+	var/obj/item/clothing/accessory/storage/webbing/W = new()
+	M.attach_accessory(new_human, W)
+	new_human.equip_to_slot_or_del(M, WEAR_BODY)
+	for(var/i in 1 to W.hold.storage_slots)
+		new_human.equip_to_slot_or_del(new /obj/item/explosive/grenade/high_explosive/pmc, WEAR_IN_ACCESSORY)
+	//jacket
+	var/obj/item/clothing/suit/storage/marine/veteran/pmc/commando/armor = new()
+	new_human.equip_to_slot_or_del(armor, WEAR_JACKET)
+	for(var/i in 1 to armor.storage_slots)
+		new_human.equip_to_slot_or_del(new /obj/item/ammo_magazine/rifle/ap, WEAR_IN_JACKET)
+	new_human.equip_to_slot_or_del(new /obj/item/weapon/gun/rifle/m41a/elite, WEAR_J_STORE)
+	//waist
+	new_human.equip_to_slot_or_del(new /obj/item/storage/belt/gun/mateba/full, WEAR_WAIST)
+	//limbs
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/gloves/marine/veteran/pmc/commando, WEAR_HANDS)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/shoes/veteran/pmc/commando/knife, WEAR_FEET)
+	//pockets
+	new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/magazine/large/pmc_rifle, WEAR_L_STORE)
+	new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/magazine/large/pmc_rifle, WEAR_R_STORE)
+
+	var/obj/item/device/internal_implant/agility/implant = new()
+	implant.on_implanted(new_human)

--- a/code/modules/projectiles/guns/flamer/flamer.dm
+++ b/code/modules/projectiles/guns/flamer/flamer.dm
@@ -250,6 +250,9 @@
 /obj/item/weapon/gun/flamer/deathsquad/nolock
 	flags_gun_features = GUN_WIELDED_FIRING_ONLY
 
+/obj/item/weapon/gun/flamer/deathsquad/standard
+	current_mag = /obj/item/ammo_magazine/flamer_tank
+
 /obj/item/weapon/gun/flamer/M240T
 	name = "\improper M240-T incinerator unit"
 	desc = "An improved version of the M240A1 incinerator unit, the M240-T model is capable of dispersing a larger variety of fuel types."

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -357,6 +357,8 @@
 	burst_scatter_mult = SCATTER_AMOUNT_TIER_10
 	scatter_unwielded = SCATTER_AMOUNT_TIER_4
 
+/obj/item/weapon/gun/rifle/m41a/elite/xm40/ap
+	current_mag = /obj/item/ammo_magazine/rifle/xm40
 //-------------------------------------------------------
 //M41A TRUE AND ORIGINAL
 


### PR DESCRIPTION
# About the pull request

This PR adds three new alternative Commando distress calls for admin/staff only usage. These are variants of the Marsoc, WY Whiteout and UPP Commando that use less overpowered gear. 

The non-OP versions have no unique identifier in the admin menus, however the overpowered versions are denoted with the affix of "(!DEATHSQUAD!)". This applies to both the distress call and the preset.

Marsoc: Have lost HEAP/Special Explosives/Unique Medical Items
WY Whiteout: Have lost HEAP/Special OP Flamer/Extra OP Smartgun, they are still combat Synthetics
UPP: Have lost their cloaking abilities, they still retain a cloak for the aesthetic but it is non-functional.

# Explain why it's good for the game

Commando ERTs are virtually never used in game outside of zombies or for clean-up after an event due to how oppressively overpowered they are. 

This addition will allow admins/staff to make usage of these unique ERTs more commonly for events without having to worry about them annihilating the entire server. While each ERT is still quite powerful, they are not as destructive. 

I am 100% open to further changes as needed. 

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Less powerful variants of the Commando ERTs (Marsoc, WY Whiteout, UPP Commandos) have been added for admin use.
admin: The powerful versions of commando ERTs are denoted with (!DEATHSQUAD!) in the distress call and equipment preset menus. 
/:cl:
