### PR TITLE
Adds Synthetic Biohazard Suits To Vendor

### DIFF
--- a/code/game/machinery/vending/vendor_types/crew/synthetic.dm
+++ b/code/game/machinery/vending/vendor_types/crew/synthetic.dm
@@ -230,6 +230,7 @@ GLOBAL_LIST_INIT(cm_vending_clothing_synth_snowflake, list(
 	list("MP Cap", 12, /obj/item/clothing/head/beret/marine/mp/mpcap, null, VENDOR_ITEM_REGULAR),
 	list("RO Cap", 12, /obj/item/clothing/head/cmcap/req, null, VENDOR_ITEM_REGULAR),
 	list("Officer Cap", 12, /obj/item/clothing/head/cmcap/ro, null, VENDOR_ITEM_REGULAR),
+	list("Bio Hood", 12, /obj/item/clothing/head/bio_hood/synth, null, VENDOR_ITEM_REGULAR),
 	list("Marine Helmet", 12, /obj/item/clothing/head/helmet/marine, null, VENDOR_ITEM_REGULAR),
 	list("Grey Marine Helmet", 12, /obj/item/clothing/head/helmet/marine/grey, null, VENDOR_ITEM_REGULAR),
 	list("Technician Helmet", 12, /obj/item/clothing/head/helmet/marine/tech, null, VENDOR_ITEM_REGULAR),
@@ -257,6 +258,7 @@ GLOBAL_LIST_INIT(cm_vending_clothing_synth_snowflake, list(
 	list("Labcoat", 12, /obj/item/clothing/suit/storage/labcoat, null, VENDOR_ITEM_REGULAR),
 	list("Labcoat, Researcher", 12, /obj/item/clothing/suit/storage/labcoat/researcher, null, VENDOR_ITEM_REGULAR),
 	list("Quartermaster Jacket", 12, /obj/item/clothing/suit/storage/RO, null, VENDOR_ITEM_REGULAR),
+	list("Bio Suit", 12, /obj/item/clothing/suit/storage/synthbio, null, VENDOR_ITEM_REGULAR),
 	list("USCM Poncho", 12, /obj/item/clothing/accessory/poncho, null, VENDOR_ITEM_REGULAR),
 
 	list("BACKPACK", 0, null, null, null),

--- a/code/modules/clothing/suits/bio.dm
+++ b/code/modules/clothing/suits/bio.dm
@@ -17,6 +17,11 @@
 	flags_armor_protection = BODY_FLAG_HEAD|BODY_FLAG_FACE|BODY_FLAG_EYES
 	siemens_coefficient = 0.9
 
+/obj/item/clothing/head/bio_hood/synth
+	desc = "A hood that protects the head and face from biological contaminants, synthetic complient. Offers no real protection."
+	armor_bio = CLOTHING_ARMOR_NONE
+	armor_rad = CLOTHING_ARMOR_NONE
+	armor_internaldamage = CLOTHING_ARMOR_NONE
 /obj/item/clothing/suit/bio_suit
 	name = "bio suit"
 	desc = "A suit that protects against biological contamination."
@@ -38,6 +43,26 @@
 	flags_inv_hide = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT|HIDETAIL
 	siemens_coefficient = 0.9
 
+/obj/item/clothing/suit/storage/synthbio
+	name = "bio suit"
+	desc = "Synthetic complient bio-hazard suit. Intended to allow a synthetic to offer the illusion of infection control to humans. Has had most of the interal protective lining removed, allowing it to hold equipment and be lighter to move in."
+	icon_state = "bio"
+	item_state = "bio_suit"
+	allowed = list(
+		/obj/item/weapon/baton,
+		/obj/item/handcuffs,
+		/obj/item/device/binoculars,
+		/obj/item/attachable/bayonet,
+
+		/obj/item/device/flashlight,
+		/obj/item/device/healthanalyzer,
+		/obj/item/device/radio,
+		/obj/item/tool/crowbar,
+		/obj/item/tool/crew_monitor,
+		/obj/item/tool/pen,
+		/obj/item/storage/large_holster/machete,
+		/obj/item/device/motiondetector,
+	)
 
 //Standard biosuit, orange stripe
 /obj/item/clothing/head/bio_hood/general

--- a/code/modules/clothing/suits/bio.dm
+++ b/code/modules/clothing/suits/bio.dm
@@ -18,7 +18,7 @@
 	siemens_coefficient = 0.9
 
 /obj/item/clothing/head/bio_hood/synth
-	desc = "A hood that protects the head and face from biological contaminants, synthetic complient. Offers no real protection."
+	desc = "A hood that protects the head and face from biological contaminants, synthetic compliant. Offers no real protection."
 	armor_bio = CLOTHING_ARMOR_NONE
 	armor_rad = CLOTHING_ARMOR_NONE
 	armor_internaldamage = CLOTHING_ARMOR_NONE
@@ -46,7 +46,7 @@
 
 /obj/item/clothing/suit/storage/synthbio
 	name = "bio suit"
-	desc = "Synthetic complient bio-hazard suit. Intended to allow a synthetic to offer the illusion of infection control to humans. Has had most of the interal protective lining removed, allowing it to hold equipment and be lighter to move in."
+	desc = "Synthetic compliant bio-hazard suit. Intended to allow a synthetic to offer the illusion of infection control to humans. Has had most of the internal protective lining removed, allowing it to hold equipment and be lighter to move in."
 	icon_state = "bio"
 	item_state = "bio_suit"
 	allowed = list(

--- a/code/modules/clothing/suits/bio.dm
+++ b/code/modules/clothing/suits/bio.dm
@@ -22,6 +22,7 @@
 	armor_bio = CLOTHING_ARMOR_NONE
 	armor_rad = CLOTHING_ARMOR_NONE
 	armor_internaldamage = CLOTHING_ARMOR_NONE
+
 /obj/item/clothing/suit/bio_suit
 	name = "bio suit"
 	desc = "A suit that protects against biological contamination."


### PR DESCRIPTION

# About the pull request

USCM Synthetics can now vend synthetic compliant biohazard uniforms from their snowflake vendor. 

The helmet and suit offer no actual protection from radiological or biological attacks. But they do provide the illusion towards their human counterparts.

The suit offers no actual slowdown, functioning identically to other synthetic cosmetic options with two inventory slots and the ability to holster support items. 

# Explain why it's good for the game

More customization options. Also helps Synths out during the rare biohazard event where they can dress up to play the part. 


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Synthetics may now vend biohazard suits for personal use. Synth compliant. 
/:cl:
