### PR TITLE
LV Comms Update

### DIFF
--- a/maps/map_files/LV624/LV624.dmm
+++ b/maps/map_files/LV624/LV624.dmm
@@ -2670,10 +2670,6 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/north_east_jungle)
-"anr" = (
-/obj/effect/decal/cleanable/blood/gibs/xeno/limb,
-/turf/open/gm/dirt,
-/area/lv624/ground/jungle/north_west_jungle)
 "anv" = (
 /obj/structure/flora/bush/ausbushes/var3/sunnybush,
 /turf/open/gm/grass/grass1,
@@ -5311,8 +5307,9 @@
 	},
 /area/lv624/lazarus/sleep_female)
 "azB" = (
-/turf/open/gm/dirtgrassborder/grassdirt_corner2/north_east,
-/area/lv624/ground/jungle/east_jungle)
+/obj/structure/flora/bush/ausbushes/var3/sparsegrass,
+/turf/open/gm/dirt,
+/area/lv624/ground/jungle/north_west_jungle)
 "azD" = (
 /obj/structure/fence,
 /turf/open/gm/dirtgrassborder/grassdirt_corner/north_east,
@@ -5439,6 +5436,10 @@
 	},
 /turf/open/floor/vault,
 /area/lv624/lazarus/quartstorage)
+"azX" = (
+/obj/effect/landmark/hunter_primary,
+/turf/open/gm/dirt,
+/area/lv624/ground/jungle/north_west_jungle)
 "azY" = (
 /obj/item/weapon/harpoon/yautja{
 	anchored = 1;
@@ -11281,6 +11282,10 @@
 	icon_state = "whiteyellowfull"
 	},
 /area/lv624/ground/jungle/south_west_jungle/ceiling)
+"aWq" = (
+/obj/effect/decal/cleanable/blood/xeno,
+/turf/open/gm/dirtgrassborder/east,
+/area/lv624/ground/jungle/north_west_jungle)
 "aWs" = (
 /obj/structure/flora/jungle/vines/heavy{
 	pixel_x = -28
@@ -12260,6 +12265,10 @@
 /obj/structure/flora/bush/ausbushes/var3/fullgrass,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/east_central_jungle)
+"bav" = (
+/obj/effect/decal/cleanable/blood/gibs/xeno/up,
+/turf/open/gm/dirt,
+/area/lv624/ground/jungle/north_west_jungle)
 "baN" = (
 /obj/structure/flora/jungle/vines/light_3,
 /turf/open/gm/grass/grass2,
@@ -12365,10 +12374,6 @@
 "bfe" = (
 /turf/open/gm/dirtgrassborder/grassdirt_corner2/south_east,
 /area/lv624/ground/jungle/north_east_jungle)
-"bfD" = (
-/obj/effect/decal/cleanable/blood/gibs/xeno,
-/turf/open/gm/dirt,
-/area/lv624/ground/jungle/north_west_jungle)
 "bfY" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_wall,
@@ -12465,10 +12470,6 @@
 	},
 /turf/open/floor/vault,
 /area/lv624/lazarus/quartstorage)
-"bqn" = (
-/obj/effect/landmark/monkey_spawn,
-/turf/open/gm/dirt,
-/area/lv624/ground/jungle/east_jungle)
 "brh" = (
 /obj/structure/flora/jungle/plantbot1,
 /obj/structure/flora/jungle/vines/light_1,
@@ -12515,9 +12516,8 @@
 /turf/open/gm/grass/grass1,
 /area/lv624/lazarus/landing_zones/lz1)
 "btS" = (
-/obj/structure/flora/bush/ausbushes/var3/ywflowers,
-/turf/open/gm/dirt,
-/area/lv624/ground/jungle/north_west_jungle)
+/turf/open/gm/dirtgrassborder/north,
+/area/lv624/ground/jungle/east_jungle)
 "btX" = (
 /turf/open/gm/river,
 /area/lv624/ground/caves/sand_temple)
@@ -12814,10 +12814,6 @@
 	},
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/south_west_jungle)
-"cbS" = (
-/obj/effect/decal/cleanable/blood/gibs/xeno/up,
-/turf/open/gm/dirt,
-/area/lv624/ground/jungle/north_west_jungle)
 "ccn" = (
 /obj/structure/flora/grass/tallgrass/jungle/corner{
 	dir = 4
@@ -12892,6 +12888,13 @@
 /obj/structure/flora/jungle/vines/heavy,
 /turf/open/gm/dirtgrassborder/grassdirt_corner2/north_east,
 /area/lv624/ground/caves/sand_temple)
+"ciz" = (
+/obj/item/device/assembly/signaller{
+	pixel_x = -6;
+	pixel_y = -9
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/jungle/east_jungle)
 "ciA" = (
 /obj/structure/surface/table/reinforced/prison{
 	color = "#6b675e"
@@ -12958,10 +12961,6 @@
 	icon_state = "warning"
 	},
 /area/lv624/lazarus/landing_zones/lz1)
-"crC" = (
-/obj/effect/landmark/hunter_primary,
-/turf/open/gm/dirtgrassborder/south,
-/area/lv624/ground/jungle/east_jungle)
 "crF" = (
 /obj/structure/flora/bush/ausbushes/var3/fernybush,
 /obj/structure/flora/jungle/vines/heavy,
@@ -12994,9 +12993,6 @@
 	icon_state = "desert_dug"
 	},
 /area/lv624/ground/barrens/west_barrens)
-"cxZ" = (
-/turf/closed/wall/r_wall/unmeltable,
-/area/lv624/lazarus/landing_zones/lz2)
 "cys" = (
 /obj/structure/foamed_metal,
 /turf/open/gm/dirtgrassborder/south,
@@ -13051,6 +13047,22 @@
 "cCr" = (
 /turf/open/gm/dirtgrassborder/south,
 /area/lv624/ground/jungle/east_jungle)
+"cDQ" = (
+/obj/item/ammo_magazine/sentry{
+	current_rounds = 0;
+	pixel_y = -13
+	},
+/obj/item/ammo_casing/bullet{
+	icon_state = "cartridge_10_1"
+	},
+/obj/item/ammo_casing/bullet{
+	icon_state = "casing_9_1"
+	},
+/obj/item/ammo_casing/bullet{
+	icon_state = "cartridge_6_1"
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/jungle/north_west_jungle)
 "cEh" = (
 /obj/structure/flora/bush/ausbushes/pointybush,
 /turf/open/gm/grass/grass1,
@@ -13228,6 +13240,15 @@
 	},
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/south_west_jungle)
+"deU" = (
+/obj/item/circuitboard/airlock{
+	pixel_x = 12
+	},
+/turf/open/floor{
+	dir = 1;
+	icon_state = "asteroidwarning"
+	},
+/area/lv624/ground/colony/telecomm/cargo)
 "dff" = (
 /obj/structure/bed/sofa/vert/grey,
 /turf/open/floor{
@@ -13314,6 +13335,12 @@
 	icon_state = "whiteyellowfull"
 	},
 /area/lv624/ground/barrens/south_eastern_barrens)
+"dqz" = (
+/turf/open/floor{
+	dir = 1;
+	icon_state = "asteroidwarning"
+	},
+/area/lv624/ground/colony/telecomm/cargo)
 "dqK" = (
 /obj/structure/flora/bush/ausbushes/var3/ywflowers,
 /turf/open/gm/grass/grass1,
@@ -13332,6 +13359,10 @@
 	icon_state = "dark"
 	},
 /area/lv624/ground/barrens/north_east_barrens/ceiling)
+"dsi" = (
+/obj/effect/landmark/monkey_spawn,
+/turf/open/gm/dirt,
+/area/lv624/ground/jungle/east_jungle)
 "dsz" = (
 /obj/structure/closet/crate/hydroponics/prespawned,
 /obj/effect/landmark/objective_landmark/close,
@@ -13676,10 +13707,6 @@
 "efX" = (
 /turf/open/gm/coast/east,
 /area/lv624/ground/river/east_river)
-"egN" = (
-/obj/structure/flora/bush/ausbushes/var3/sparsegrass,
-/turf/open/gm/dirt,
-/area/lv624/ground/jungle/north_west_jungle)
 "ehy" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/generic{
 	name = "Hydroponics"
@@ -13770,13 +13797,6 @@
 	icon_state = "whiteblue"
 	},
 /area/lv624/lazarus/corporate_dome)
-"eqm" = (
-/obj/item/ammo_magazine/sentry{
-	current_rounds = 0;
-	pixel_y = -13
-	},
-/turf/open/gm/dirt,
-/area/lv624/ground/jungle/north_west_jungle)
 "eqs" = (
 /obj/structure/flora/grass/tallgrass/jungle/corner{
 	dir = 9
@@ -13786,27 +13806,12 @@
 "eqF" = (
 /turf/open/gm/coast/north,
 /area/lv624/ground/river/central_river)
-"eqM" = (
-/obj/structure/barricade/metal/wired{
-	dir = 1;
-	health = 10;
-	is_wired = 1
-	},
-/turf/open/gm/dirt,
-/area/lv624/ground/jungle/north_west_jungle)
 "eqP" = (
 /obj/structure/machinery/bioprinter,
 /turf/open/floor{
 	icon_state = "whitebluefull"
 	},
 /area/lv624/lazarus/medbay)
-"ert" = (
-/obj/item/stack/sheet/metal{
-	pixel_x = -7;
-	pixel_y = 1
-	},
-/turf/open/gm/dirt,
-/area/lv624/ground/jungle/north_west_jungle)
 "erx" = (
 /turf/open/gm/coast/beachcorner/south_east,
 /area/lv624/ground/jungle/west_jungle)
@@ -13988,17 +13993,13 @@
 	icon_state = "desert_dug"
 	},
 /area/lv624/ground/barrens/south_eastern_jungle_barrens)
+"eOk" = (
+/turf/open/gm/dirtgrassborder/grassdirt_corner/north_east,
+/area/lv624/ground/jungle/east_jungle)
 "eOq" = (
 /obj/structure/machinery/colony_floodlight,
 /turf/open/gm/dirt,
 /area/lv624/ground/barrens/east_barrens)
-"eOx" = (
-/obj/item/storage/toolkit/empty{
-	pixel_x = 5;
-	pixel_y = -3
-	},
-/turf/open/gm/dirt,
-/area/lv624/ground/jungle/east_jungle)
 "ePp" = (
 /turf/open/gm/dirt{
 	icon_state = "desert3"
@@ -14020,12 +14021,6 @@
 /obj/structure/largecrate/random,
 /turf/open/floor,
 /area/lv624/lazarus/landing_zones/lz1)
-"eRy" = (
-/turf/open/floor{
-	dir = 1;
-	icon_state = "asteroidwarning"
-	},
-/area/lv624/ground/colony/telecomm/cargo)
 "eSg" = (
 /obj/structure/flora/jungle/vines/heavy,
 /turf/closed/wall/strata_ice/jungle,
@@ -14367,6 +14362,13 @@
 	icon_state = "white"
 	},
 /area/lv624/lazarus/corporate_dome)
+"fHw" = (
+/obj/item/device/sentry_computer{
+	pixel_y = 5
+	},
+/obj/structure/surface/table,
+/turf/open/gm/dirt,
+/area/lv624/ground/jungle/north_west_jungle)
 "fHz" = (
 /obj/structure/flora/jungle/vines/light_3,
 /turf/closed/wall/strata_ice/jungle,
@@ -14409,14 +14411,6 @@
 "fPi" = (
 /turf/open/gm/coast/north,
 /area/lv624/ground/caves/sand_temple)
-"fPp" = (
-/obj/item/device/radio/off{
-	frequency = 1469;
-	pixel_x = -9;
-	pixel_y = -13
-	},
-/turf/open/gm/dirt,
-/area/lv624/ground/jungle/east_jungle)
 "fPH" = (
 /turf/open/gm/dirtgrassborder/south,
 /area/lv624/ground/jungle/west_central_jungle)
@@ -14488,15 +14482,6 @@
 /obj/structure/flora/bush/ausbushes/lavendergrass,
 /turf/open/gm/grass/grass2,
 /area/lv624/ground/jungle/south_central_jungle)
-"gct" = (
-/obj/item/circuitboard/airlock{
-	pixel_x = 12
-	},
-/turf/open/floor{
-	dir = 1;
-	icon_state = "asteroidwarning"
-	},
-/area/lv624/ground/colony/telecomm/cargo)
 "gcI" = (
 /obj/effect/landmark/crap_item,
 /turf/open/shuttle{
@@ -15061,10 +15046,6 @@
 /obj/structure/fence,
 /turf/open/gm/dirtgrassborder/west,
 /area/lv624/ground/colony/west_nexus_road)
-"hEJ" = (
-/obj/structure/flora/jungle/vines/light_3,
-/turf/open/gm/dirtgrassborder/south,
-/area/lv624/ground/jungle/east_jungle)
 "hFO" = (
 /obj/structure/fence,
 /turf/open/gm/dirtgrassborder/grassdirt_corner/south_west,
@@ -15223,21 +15204,10 @@
 	},
 /area/lv624/lazarus/medbay)
 "hZn" = (
-/obj/item/ammo_casing/bullet{
-	icon_state = "cartridge_3_1"
+/obj/item/stack/sheet/metal{
+	pixel_x = 6;
+	pixel_y = 30
 	},
-/obj/item/ammo_casing/bullet{
-	icon_state = "cartridge_6_1"
-	},
-/obj/item/ammo_casing/bullet{
-	icon_state = "casing_9_1"
-	},
-/obj/item/ammo_casing/bullet,
-/obj/item/ammo_casing/bullet{
-	icon_state = "cartridge_10_1"
-	},
-/obj/effect/decal/cleanable/blood/oil,
-/obj/effect/decal/cleanable/blood/gibs/robot/down,
 /turf/open/gm/dirt,
 /area/lv624/ground/jungle/north_west_jungle)
 "hZW" = (
@@ -15322,6 +15292,17 @@
 	},
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/central_jungle)
+"ihS" = (
+/obj/structure/surface/table,
+/obj/item/reagent_container/food/drinks/cans/lemon_lime{
+	pixel_x = -5;
+	pixel_y = 2
+	},
+/obj/structure/prop/server_equipment/laptop/on{
+	pixel_y = 8
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/jungle/east_jungle)
 "iiK" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
 /obj/effect/landmark/queen_spawn,
@@ -15349,10 +15330,20 @@
 /obj/effect/landmark/objective_landmark/close,
 /turf/open/floor/greengrid,
 /area/lv624/lazarus/secure_storage)
+"ioC" = (
+/turf/open/gm/dirtgrassborder/grassdirt_corner2/north_west,
+/area/lv624/ground/jungle/east_jungle)
 "isF" = (
 /obj/effect/landmark/hunter_primary,
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/south_west_caves)
+"isJ" = (
+/obj/structure/surface/table,
+/obj/item/storage/beer_pack{
+	pixel_y = 9
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/jungle/east_jungle)
 "isR" = (
 /obj/effect/landmark/objective_landmark/medium,
 /obj/structure/largecrate/random,
@@ -15438,12 +15429,8 @@
 /turf/open/gm/grass/grass2,
 /area/lv624/ground/jungle/west_central_jungle)
 "iBy" = (
-/obj/structure/flora/bush/ausbushes/lavendergrass,
-/turf/open/floor{
-	dir = 1;
-	icon_state = "asteroidfloor"
-	},
-/area/lv624/ground/colony/telecomm/cargo)
+/turf/open/gm/dirtgrassborder/east,
+/area/lv624/ground/jungle/east_jungle)
 "iBD" = (
 /turf/open/floor{
 	dir = 10;
@@ -15647,10 +15634,6 @@
 	icon_state = "vault"
 	},
 /area/lv624/lazarus/quartstorage)
-"jjN" = (
-/obj/effect/decal/cleanable/blood/oil,
-/turf/open/gm/dirt,
-/area/lv624/ground/jungle/north_west_jungle)
 "jlh" = (
 /obj/structure/machinery/colony_floodlight,
 /turf/open/gm/dirt,
@@ -15777,10 +15760,10 @@
 	icon_state = "floor6"
 	},
 /area/lv624/ground/caves/sand_temple)
-"jCJ" = (
-/obj/structure/flora/jungle/vines/heavy,
+"jDY" = (
+/obj/effect/decal/cleanable/blood/gibs/xeno/limb,
 /turf/open/gm/dirt,
-/area/lv624/ground/jungle/east_jungle)
+/area/lv624/ground/jungle/north_west_jungle)
 "jEc" = (
 /obj/structure/fence,
 /turf/open/gm/dirtgrassborder/grassdirt_corner/north_east,
@@ -15938,6 +15921,10 @@
 	icon_state = "white"
 	},
 /area/lv624/lazarus/corporate_dome)
+"jRJ" = (
+/obj/effect/decal/cleanable/blood/xeno,
+/turf/open/gm/dirt,
+/area/lv624/ground/jungle/north_west_jungle)
 "jRM" = (
 /obj/structure/flora/bush/ausbushes/var3/fullgrass,
 /obj/effect/landmark/lv624/fog_blocker,
@@ -16037,6 +16024,10 @@
 "kjC" = (
 /turf/open/gm/coast/beachcorner/south_east,
 /area/lv624/ground/barrens/east_barrens)
+"kjD" = (
+/obj/structure/flora/jungle/vines/light_3,
+/turf/open/gm/dirtgrassborder/grassdirt_corner/south_west,
+/area/lv624/ground/jungle/east_jungle)
 "kmP" = (
 /obj/item/stool,
 /turf/open/gm/dirt,
@@ -16136,9 +16127,6 @@
 /obj/structure/flora/jungle/vines/heavy,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/north_east_jungle)
-"kzc" = (
-/turf/open/gm/dirtgrassborder/grassdirt_corner2/south_west,
-/area/lv624/ground/jungle/south_central_jungle)
 "kzd" = (
 /obj/structure/surface/table,
 /obj/effect/landmark/crap_item,
@@ -16198,7 +16186,11 @@
 /turf/open/gm/coast/beachcorner/north_east,
 /area/lv624/ground/barrens/west_barrens)
 "kGk" = (
-/turf/open/gm/dirtgrassborder/grassdirt_corner2/south_east,
+/obj/item/storage/toolkit/empty{
+	pixel_x = 5;
+	pixel_y = -3
+	},
+/turf/open/gm/dirt,
 /area/lv624/ground/jungle/east_jungle)
 "kHB" = (
 /turf/open/gm/dirt{
@@ -16311,6 +16303,10 @@
 	icon_state = "asteroidwarning"
 	},
 /area/lv624/ground/colony/telecomm/sw_lz2)
+"kXE" = (
+/obj/structure/flora/bush/ausbushes/ausbush,
+/turf/open/gm/dirtgrassborder/north,
+/area/lv624/ground/jungle/south_central_jungle)
 "kYx" = (
 /obj/structure/flora/grass/tallgrass/jungle/corner{
 	dir = 9
@@ -16366,17 +16362,6 @@
 "ldZ" = (
 /turf/closed/wall/strata_ice/jungle,
 /area/lv624/ground/jungle/north_jungle)
-"leh" = (
-/obj/structure/surface/table,
-/obj/item/reagent_container/food/drinks/cans/lemon_lime{
-	pixel_x = -5;
-	pixel_y = 2
-	},
-/obj/structure/prop/server_equipment/laptop/on{
-	pixel_y = 8
-	},
-/turf/open/gm/dirt,
-/area/lv624/ground/jungle/east_jungle)
 "lfy" = (
 /obj/structure/fence,
 /turf/open/gm/dirtgrassborder/west,
@@ -16388,12 +16373,6 @@
 "lju" = (
 /turf/open/gm/coast/beachcorner2/south_east,
 /area/lv624/ground/river/central_river)
-"ljy" = (
-/turf/open/floor{
-	dir = 4;
-	icon_state = "asteroidwarning"
-	},
-/area/lv624/ground/colony/telecomm/cargo)
 "lke" = (
 /obj/effect/landmark/crap_item,
 /turf/open/floor,
@@ -16469,9 +16448,6 @@
 /obj/structure/flora/bush/ausbushes/lavendergrass,
 /turf/open/gm/dirtgrassborder/west,
 /area/lv624/ground/colony/north_tcomms_road)
-"lxp" = (
-/turf/open/gm/dirtgrassborder/grassdirt_corner/north_east,
-/area/lv624/ground/jungle/east_jungle)
 "lxr" = (
 /obj/structure/flora/jungle/vines/light_2,
 /turf/open/gm/dirtgrassborder/south,
@@ -16523,6 +16499,11 @@
 "lBw" = (
 /turf/closed/wall/strata_ice/jungle,
 /area/lv624/ground/jungle/south_east_jungle)
+"lCG" = (
+/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/decal/cleanable/blood/gibs/robot/down,
+/turf/open/gm/dirt,
+/area/lv624/ground/jungle/north_west_jungle)
 "lDh" = (
 /obj/item/clothing/suit/armor/yautja_flavor,
 /turf/open/floor/strata{
@@ -16752,6 +16733,10 @@
 	},
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/south_east_jungle)
+"mbN" = (
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/gm/dirt,
+/area/lv624/ground/jungle/east_jungle)
 "mdQ" = (
 /turf/closed/wall/rock/brown,
 /area/lv624/ground/caves/west_caves)
@@ -16844,6 +16829,9 @@
 /obj/structure/flora/jungle/plantbot1,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/colony/west_tcomms_road)
+"mnr" = (
+/turf/open/gm/dirtgrassborder/grassdirt_corner2/south_east,
+/area/lv624/ground/jungle/east_jungle)
 "mnK" = (
 /obj/structure/flora/bush/ausbushes/lavendergrass,
 /turf/open/gm/grass/grass1,
@@ -16887,10 +16875,6 @@
 	},
 /turf/open/floor/sandstone/runed,
 /area/lv624/ground/caves/sand_temple)
-"mrX" = (
-/obj/structure/flora/jungle/vines/heavy,
-/turf/open/gm/dirtgrassborder/south,
-/area/lv624/ground/jungle/east_jungle)
 "msd" = (
 /turf/open/gm/dirtgrassborder/west,
 /area/lv624/ground/caves/sand_temple)
@@ -17195,10 +17179,20 @@
 	icon_state = "asteroidwarning"
 	},
 /area/lv624/lazarus/landing_zones/lz2)
+"njl" = (
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/gm/dirt,
+/area/lv624/ground/jungle/north_west_jungle)
 "njC" = (
 /obj/effect/landmark/crap_item,
 /turf/open/gm/dirt,
 /area/lv624/ground/colony/west_tcomms_road)
+"njO" = (
+/turf/open/floor{
+	dir = 5;
+	icon_state = "asteroidwarning"
+	},
+/area/lv624/ground/colony/telecomm/cargo)
 "nkg" = (
 /obj/structure/prop/brazier/torch,
 /turf/closed/wall/mineral/sandstone/runed,
@@ -17745,15 +17739,6 @@
 "oek" = (
 /turf/open/gm/coast/north,
 /area/lv624/ground/jungle/west_jungle)
-"oen" = (
-/obj/structure/flora/jungle/vines/light_3,
-/obj/structure/barricade/metal/wired{
-	dir = 1;
-	health = 10;
-	is_wired = 1
-	},
-/turf/open/gm/dirtgrassborder/east,
-/area/lv624/ground/jungle/north_west_jungle)
 "oeN" = (
 /turf/closed/wall,
 /area/lv624/ground/barrens/north_east_barrens/ceiling)
@@ -17804,16 +17789,13 @@
 /obj/effect/landmark/objective_landmark/close,
 /turf/open/floor/plating,
 /area/lv624/ground/barrens/central_barrens)
-"okA" = (
-/turf/open/gm/dirtgrassborder/grassdirt_corner/north_west,
-/area/lv624/ground/jungle/east_jungle)
+"omu" = (
+/obj/structure/flora/bush/ausbushes/var3/sparsegrass,
+/turf/open/gm/dirt,
+/area/lv624/ground/jungle/west_jungle)
 "omK" = (
 /turf/open/gm/coast/beachcorner/south_east,
 /area/lv624/ground/barrens/west_barrens)
-"onf" = (
-/obj/structure/flora/bush/ausbushes/ausbush,
-/turf/open/gm/dirt,
-/area/lv624/ground/jungle/west_jungle)
 "onU" = (
 /turf/closed/wall/strata_ice/jungle,
 /area/lv624/ground/caves/west_caves)
@@ -17844,6 +17826,12 @@
 /obj/structure/flora/jungle/vines/heavy,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/south_central_jungle)
+"orB" = (
+/turf/open/floor{
+	dir = 4;
+	icon_state = "asteroidwarning"
+	},
+/area/lv624/ground/colony/telecomm/cargo)
 "oua" = (
 /obj/effect/landmark/crap_item,
 /turf/open/gm/dirt,
@@ -17933,6 +17921,18 @@
 	},
 /turf/open/gm/coast/north,
 /area/lv624/ground/caves/sand_temple)
+"oEc" = (
+/obj/item/ammo_casing/bullet{
+	icon_state = "cartridge_6_1"
+	},
+/obj/item/ammo_casing/bullet{
+	icon_state = "cartridge_3_1"
+	},
+/obj/item/ammo_casing/bullet{
+	icon_state = "cartridge_10_1"
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/jungle/north_west_jungle)
 "oED" = (
 /obj/structure/fence,
 /turf/open/gm/dirtgrassborder/grassdirt_corner2/south_east,
@@ -18003,10 +18003,6 @@
 /obj/structure/fence,
 /turf/open/gm/dirtgrassborder/grassdirt_corner2/south_east,
 /area/lv624/ground/colony/west_nexus_road)
-"oLO" = (
-/obj/structure/flora/bush/ausbushes/var3/sparsegrass,
-/turf/open/gm/dirt,
-/area/lv624/ground/jungle/west_jungle)
 "oMZ" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_membrane,
 /turf/open/gm/dirt,
@@ -18043,10 +18039,6 @@
 /obj/structure/machinery/landinglight/ds2/delayone,
 /turf/open/floor/plating,
 /area/lv624/lazarus/landing_zones/lz2)
-"oOK" = (
-/obj/effect/landmark/hunter_primary,
-/turf/open/gm/dirt,
-/area/lv624/ground/jungle/north_west_jungle)
 "oOV" = (
 /obj/structure/flora/jungle/vines/light_1,
 /obj/structure/flora/jungle/vines/light_3,
@@ -18131,9 +18123,6 @@
 	icon_state = "warnplate"
 	},
 /area/lv624/ground/barrens/east_barrens/ceiling)
-"oVO" = (
-/turf/open/gm/dirtgrassborder/grassdirt_corner2/north_west,
-/area/lv624/ground/jungle/east_jungle)
 "oWN" = (
 /obj/structure/flora/jungle/vines/heavy,
 /turf/open/gm/grass/grass2,
@@ -18142,9 +18131,8 @@
 /turf/open/gm/dirtgrassborder/east,
 /area/lv624/ground/jungle/south_west_jungle)
 "oXI" = (
-/obj/effect/decal/cleanable/blood/xeno,
-/turf/open/gm/dirt,
-/area/lv624/ground/jungle/north_west_jungle)
+/turf/closed/wall/r_wall/unmeltable,
+/area/lv624/lazarus/landing_zones/lz2)
 "oXS" = (
 /turf/open/gm/coast/west,
 /area/lv624/ground/river/central_river)
@@ -18490,6 +18478,12 @@
 /obj/effect/landmark/hunter_secondary,
 /turf/open/gm/grass/grass1,
 /area/lv624/lazarus/quartstorage/outdoors)
+"pKm" = (
+/turf/open/floor{
+	icon_state = "asteroidwarning";
+	dir = 8
+	},
+/area/lv624/ground/colony/telecomm/sw_lz2)
 "pKp" = (
 /obj/effect/landmark/crap_item,
 /turf/open/floor{
@@ -18505,6 +18499,10 @@
 /obj/structure/fence,
 /turf/open/gm/dirtgrassborder/grassdirt_corner/south_west,
 /area/lv624/ground/colony/west_nexus_road)
+"pMM" = (
+/obj/structure/flora/bush/ausbushes/ppflowers,
+/turf/open/gm/dirtgrassborder/east,
+/area/lv624/ground/jungle/east_jungle)
 "pMV" = (
 /obj/effect/landmark/hunter_primary,
 /turf/open/gm/dirt,
@@ -18692,17 +18690,14 @@
 /obj/structure/flora/bush/ausbushes/var3/fernybush,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/south_east_jungle)
+"qns" = (
+/obj/structure/machinery/colony_floodlight,
+/turf/open/gm/dirt,
+/area/lv624/ground/jungle/east_jungle)
 "qnQ" = (
 /obj/structure/flora/bush/ausbushes/var3/ywflowers,
 /turf/open/gm/grass/grass2,
 /area/lv624/ground/jungle/north_east_jungle)
-"qof" = (
-/obj/item/stack/cable_coil/random{
-	pixel_y = 9;
-	pixel_x = 7
-	},
-/turf/open/gm/dirt,
-/area/lv624/ground/jungle/east_jungle)
 "qpX" = (
 /obj/structure/stairs/perspective{
 	color = "#b29082";
@@ -18777,10 +18772,6 @@
 	icon_state = "whiteyellow"
 	},
 /area/lv624/lazarus/corporate_dome)
-"qxw" = (
-/obj/effect/landmark/hunter_primary,
-/turf/open/gm/dirt,
-/area/lv624/ground/jungle/east_jungle)
 "qxZ" = (
 /obj/structure/surface/table/woodentable/poor,
 /obj/item/stack/sheet/metal{
@@ -18893,6 +18884,10 @@
 "qIO" = (
 /turf/open/gm/dirt,
 /area/lv624/ground/colony/west_tcomms_road)
+"qJe" = (
+/obj/structure/flora/bush/ausbushes/var3/ywflowers,
+/turf/open/gm/dirt,
+/area/lv624/ground/jungle/north_west_jungle)
 "qJg" = (
 /obj/structure/surface/table,
 /obj/effect/landmark/objective_landmark/science,
@@ -19031,6 +19026,10 @@
 	},
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/north_east_jungle)
+"rcy" = (
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/gm/dirtgrassborder/west,
+/area/lv624/ground/jungle/east_jungle)
 "rcR" = (
 /obj/effect/landmark/hunter_primary,
 /turf/open/gm/dirt,
@@ -19227,10 +19226,6 @@
 "rCV" = (
 /turf/open/gm/grass/grass2,
 /area/lv624/ground/jungle/south_central_jungle)
-"rDv" = (
-/obj/structure/flora/jungle/vines/heavy,
-/turf/open/gm/dirtgrassborder/west,
-/area/lv624/ground/jungle/east_jungle)
 "rGd" = (
 /obj/structure/girder/displaced,
 /obj/structure/shuttle/engine/propulsion,
@@ -19250,7 +19245,8 @@
 /turf/open/floor/vault,
 /area/lv624/lazarus/quartstorage)
 "rGW" = (
-/turf/open/gm/dirtgrassborder/north,
+/obj/structure/flora/jungle/vines/light_3,
+/turf/open/gm/dirtgrassborder/south,
 /area/lv624/ground/jungle/east_jungle)
 "rGZ" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
@@ -19346,6 +19342,9 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
+"rSy" = (
+/turf/open/gm/dirtgrassborder/grassdirt_corner2/north_east,
+/area/lv624/ground/jungle/east_jungle)
 "rTG" = (
 /obj/structure/machinery/colony_floodlight,
 /obj/structure/flora/jungle/vines/light_3,
@@ -19499,6 +19498,13 @@
 "sqj" = (
 /turf/open/gm/river,
 /area/lv624/ground/river/central_river)
+"sqs" = (
+/obj/item/stack/sheet/metal{
+	pixel_x = -7;
+	pixel_y = 1
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/jungle/north_west_jungle)
 "sqw" = (
 /obj/structure/machinery/colony_floodlight,
 /obj/structure/flora/jungle/vines/heavy,
@@ -19572,13 +19578,6 @@
 	icon_state = "whiteblue"
 	},
 /area/lv624/lazarus/corporate_dome)
-"sBo" = (
-/obj/item/stack/sheet/metal{
-	pixel_x = 16;
-	pixel_y = -10
-	},
-/turf/open/gm/dirt,
-/area/lv624/ground/jungle/north_west_jungle)
 "sBC" = (
 /obj/structure/fence,
 /turf/open/gm/dirtgrassborder/grassdirt_corner/south_east,
@@ -19637,13 +19636,6 @@
 	},
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/south_east_jungle)
-"sHP" = (
-/obj/structure/surface/table,
-/obj/item/storage/beer_pack{
-	pixel_y = 9
-	},
-/turf/open/gm/dirt,
-/area/lv624/ground/jungle/east_jungle)
 "sHT" = (
 /obj/structure/flora/bush/ausbushes/reedbush,
 /turf/open/gm/grass/grass1,
@@ -19701,6 +19693,13 @@
 /obj/structure/flora/jungle/planttop1,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/central_jungle)
+"sOC" = (
+/obj/item/stack/sheet/metal{
+	pixel_x = 16;
+	pixel_y = -10
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/jungle/north_west_jungle)
 "sOZ" = (
 /obj/structure/flora/jungle/vines/heavy,
 /turf/open/gm/dirtgrassborder/south,
@@ -19717,6 +19716,9 @@
 /obj/structure/flora/bush/ausbushes/palebush,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/south_west_jungle)
+"sRW" = (
+/turf/open/gm/dirtgrassborder/grassdirt_corner/north_west,
+/area/lv624/ground/jungle/east_jungle)
 "sSE" = (
 /obj/structure/flora/bush/ausbushes/ppflowers,
 /turf/open/gm/grass/grass1,
@@ -19847,17 +19849,6 @@
 	icon_state = "warning"
 	},
 /area/lv624/lazarus/landing_zones/lz1)
-"tgl" = (
-/obj/item/device/sentry_computer{
-	pixel_y = 5
-	},
-/obj/structure/surface/table,
-/turf/open/gm/dirt,
-/area/lv624/ground/jungle/north_west_jungle)
-"tgw" = (
-/obj/structure/flora/bush/ausbushes/ppflowers,
-/turf/open/gm/dirtgrassborder/east,
-/area/lv624/ground/jungle/east_jungle)
 "tgL" = (
 /mob/living/simple_animal/bat,
 /turf/open/gm/dirt,
@@ -19909,9 +19900,17 @@
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/north_west_caves)
 "tka" = (
-/obj/structure/machinery/colony_floodlight,
+/obj/item/ammo_casing/bullet{
+	icon_state = "casing_9_1"
+	},
+/obj/item/ammo_casing/bullet{
+	icon_state = "cartridge_6_1"
+	},
+/obj/item/ammo_casing/bullet{
+	icon_state = "cartridge_9_1"
+	},
 /turf/open/gm/dirt,
-/area/lv624/ground/jungle/east_jungle)
+/area/lv624/ground/jungle/north_west_jungle)
 "tlD" = (
 /obj/structure/flora/bush/ausbushes/var3/fernybush,
 /turf/open/gm/river,
@@ -20159,11 +20158,6 @@
 /obj/structure/flora/jungle/vines/heavy,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/south_west_jungle)
-"tMq" = (
-/obj/structure/flora/jungle/vines/heavy,
-/obj/effect/landmark/lv624/xeno_tunnel,
-/turf/open/gm/grass/grass1,
-/area/lv624/ground/jungle/north_west_jungle)
 "tMB" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
 /turf/open/gm/dirt,
@@ -20180,13 +20174,6 @@
 	icon_state = "whiteyellowfull"
 	},
 /area/lv624/ground/barrens/south_eastern_barrens)
-"tNb" = (
-/obj/item/stack/sheet/metal{
-	pixel_x = 6;
-	pixel_y = 30
-	},
-/turf/open/gm/dirt,
-/area/lv624/ground/jungle/north_west_jungle)
 "tOS" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
 /turf/open/gm/dirt,
@@ -20196,6 +20183,10 @@
 /obj/structure/flora/jungle/vines/heavy,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/south_west_jungle)
+"tRE" = (
+/obj/effect/decal/cleanable/blood/gibs/xeno,
+/turf/open/gm/dirt,
+/area/lv624/ground/jungle/north_west_jungle)
 "tSd" = (
 /turf/open/gm/dirtgrassborder/grassdirt_corner/south_west,
 /area/lv624/lazarus/quartstorage/outdoors)
@@ -20213,10 +20204,6 @@
 /obj/structure/flora/jungle/vines/heavy,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/east_central_jungle)
-"tUH" = (
-/obj/structure/flora/jungle/vines/light_3,
-/turf/open/gm/dirtgrassborder/grassdirt_corner/south_west,
-/area/lv624/ground/jungle/east_jungle)
 "tWw" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor{
@@ -20345,10 +20332,27 @@
 /obj/structure/fence,
 /turf/open/gm/dirtgrassborder/north,
 /area/lv624/ground/colony/north_tcomms_road)
+"uiW" = (
+/obj/structure/barricade/metal/wired{
+	dir = 1;
+	health = 10;
+	is_wired = 1
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/jungle/north_west_jungle)
 "ujd" = (
 /obj/structure/flora/bush/ausbushes/ausbush,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/central_jungle)
+"ukh" = (
+/obj/item/ammo_casing/bullet{
+	icon_state = "cartridge_6_1"
+	},
+/obj/item/ammo_casing/bullet{
+	icon_state = "casing_9_1"
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/jungle/north_west_jungle)
 "ukk" = (
 /obj/structure/flora/grass/tallgrass/jungle/corner{
 	dir = 1
@@ -20398,12 +20402,9 @@
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/south_east_caves)
 "unT" = (
-/obj/item/stack/sheet/metal{
-	pixel_x = 16;
-	pixel_y = -10
-	},
-/turf/open/gm/dirt,
-/area/lv624/ground/jungle/west_jungle)
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/gm/dirtgrassborder/south,
+/area/lv624/ground/jungle/east_jungle)
 "upM" = (
 /obj/effect/landmark/crap_item,
 /turf/open/gm/grass/grass1,
@@ -20414,6 +20415,13 @@
 /obj/effect/landmark/corpsespawner/colonist/random/burst,
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/east_caves)
+"upV" = (
+/obj/item/stack/cable_coil/random{
+	pixel_y = 9;
+	pixel_x = 7
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/jungle/east_jungle)
 "urR" = (
 /turf/open/floor/corsat{
 	dir = 1;
@@ -20426,15 +20434,18 @@
 	},
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/north_central_caves)
-"usp" = (
-/obj/structure/flora/bush/ausbushes/var3/sparsegrass,
-/obj/structure/flora/jungle/vines/heavy,
-/turf/open/gm/dirtgrassborder/north,
-/area/lv624/ground/jungle/east_jungle)
 "usE" = (
 /obj/structure/flora/bush/ausbushes/reedbush,
 /turf/open/gm/dirt,
 /area/lv624/ground/barrens/central_barrens)
+"uuf" = (
+/obj/effect/landmark/hunter_primary,
+/turf/open/gm/dirt,
+/area/lv624/ground/jungle/east_jungle)
+"uuV" = (
+/obj/effect/landmark/hunter_primary,
+/turf/open/gm/dirtgrassborder/south,
+/area/lv624/ground/jungle/east_jungle)
 "uve" = (
 /turf/closed/wall/strata_ice/jungle,
 /area/lv624/ground/barrens/south_eastern_jungle_barrens)
@@ -20469,10 +20480,6 @@
 "uAp" = (
 /turf/closed/wall/strata_ice/jungle,
 /area/lv624/ground/barrens/south_eastern_barrens)
-"uBu" = (
-/obj/effect/decal/cleanable/blood/xeno,
-/turf/open/gm/dirtgrassborder/east,
-/area/lv624/ground/jungle/north_west_jungle)
 "uDd" = (
 /obj/structure/showcase{
 	desc = "An ancient, dusty tomb with strange alien writing. It's best not to touch it.";
@@ -20697,6 +20704,14 @@
 /obj/structure/flora/bush/ausbushes/reedbush,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/north_east_jungle)
+"vbh" = (
+/obj/item/device/radio/off{
+	frequency = 1469;
+	pixel_x = -9;
+	pixel_y = -13
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/jungle/east_jungle)
 "vcY" = (
 /obj/structure/machinery/colony_floodlight,
 /turf/open/gm/grass/grass1,
@@ -20759,12 +20774,6 @@
 /obj/structure/girder,
 /turf/open/gm/dirt,
 /area/lv624/lazarus/crashed_ship_containers)
-"viw" = (
-/turf/open/floor{
-	icon_state = "asteroidwarning";
-	dir = 8
-	},
-/area/lv624/ground/colony/telecomm/sw_lz2)
 "vjH" = (
 /obj/structure/flora/jungle/vines/light_3,
 /turf/open/gm/grass/grass1,
@@ -20915,12 +20924,6 @@
 /obj/structure/flora/jungle/vines/light_1,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/north_west_jungle)
-"vED" = (
-/turf/open/floor{
-	dir = 5;
-	icon_state = "asteroidwarning"
-	},
-/area/lv624/ground/colony/telecomm/cargo)
 "vGg" = (
 /obj/structure/flora/grass/tallgrass/jungle/corner{
 	dir = 6
@@ -20985,8 +20988,9 @@
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/south_east_jungle)
 "vOD" = (
-/turf/open/gm/dirtgrassborder/east,
-/area/lv624/ground/jungle/east_jungle)
+/obj/structure/flora/bush/ausbushes/reedbush,
+/turf/open/gm/dirt,
+/area/lv624/ground/jungle/north_west_jungle)
 "vOF" = (
 /turf/open/gm/dirtgrassborder/west,
 /area/lv624/ground/jungle/south_central_jungle)
@@ -21170,6 +21174,15 @@
 	},
 /turf/open/floor/sandstone/runed,
 /area/lv624/ground/caves/sand_temple)
+"woF" = (
+/obj/structure/flora/jungle/vines/light_3,
+/obj/structure/barricade/metal/wired{
+	dir = 1;
+	health = 10;
+	is_wired = 1
+	},
+/turf/open/gm/dirtgrassborder/east,
+/area/lv624/ground/jungle/north_west_jungle)
 "woK" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/wood{
@@ -21454,6 +21467,11 @@
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/wood,
 /area/lv624/ground/caves/north_central_caves)
+"wUv" = (
+/obj/structure/flora/bush/ausbushes/var3/sparsegrass,
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/gm/dirtgrassborder/north,
+/area/lv624/ground/jungle/east_jungle)
 "wUz" = (
 /obj/structure/flora/jungle/vines/heavy,
 /turf/open/gm/dirt,
@@ -21498,9 +21516,12 @@
 /turf/open/gm/dirt,
 /area/lv624/ground/barrens/north_east_barrens)
 "wXg" = (
-/obj/structure/flora/bush/ausbushes/reedbush,
+/obj/item/stack/sheet/metal{
+	pixel_x = 16;
+	pixel_y = -10
+	},
 /turf/open/gm/dirt,
-/area/lv624/ground/jungle/north_west_jungle)
+/area/lv624/ground/jungle/west_jungle)
 "wXp" = (
 /turf/open/gm/dirtgrassborder/grassdirt_corner2/north_west,
 /area/lv624/ground/jungle/west_central_jungle)
@@ -21624,13 +21645,6 @@
 	icon_state = "warning"
 	},
 /area/lv624/lazarus/landing_zones/lz2)
-"xrM" = (
-/obj/item/device/assembly/signaller{
-	pixel_x = -6;
-	pixel_y = -9
-	},
-/turf/open/gm/dirt,
-/area/lv624/ground/jungle/east_jungle)
 "xsN" = (
 /obj/structure/flora/jungle/vines/light_1,
 /obj/structure/flora/bush/ausbushes/ppflowers,
@@ -21811,6 +21825,10 @@
 /obj/effect/landmark/objective_landmark/close,
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/south_central_caves)
+"xTM" = (
+/obj/structure/flora/bush/ausbushes/ausbush,
+/turf/open/gm/dirt,
+/area/lv624/ground/jungle/west_jungle)
 "xTT" = (
 /turf/open/gm/dirt,
 /area/lv624/ground/jungle/south_west_jungle)
@@ -21827,6 +21845,9 @@
 	},
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/north_east_jungle)
+"xVN" = (
+/turf/open/gm/dirtgrassborder/grassdirt_corner2/south_west,
+/area/lv624/ground/jungle/south_central_jungle)
 "xXB" = (
 /obj/structure/flora/bush/ausbushes/var3/sunnybush,
 /turf/open/gm/grass/grass1,
@@ -21919,9 +21940,10 @@
 	},
 /area/lv624/lazarus/corporate_dome)
 "yiE" = (
-/obj/structure/flora/bush/ausbushes/ausbush,
-/turf/open/gm/dirtgrassborder/north,
-/area/lv624/ground/jungle/south_central_jungle)
+/obj/structure/flora/jungle/vines/heavy,
+/obj/effect/landmark/lv624/xeno_tunnel,
+/turf/open/gm/grass/grass1,
+/area/lv624/ground/jungle/north_west_jungle)
 "yiT" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/storage/firstaid/adv{
@@ -27603,7 +27625,7 @@ auf
 aZp
 aFm
 aAl
-oLO
+omu
 aqS
 aAp
 aAp
@@ -27830,7 +27852,7 @@ aug
 wFx
 avo
 aFQ
-onf
+xTM
 aAl
 aDv
 aAp
@@ -28059,7 +28081,7 @@ axp
 auf
 aFm
 aAl
-unT
+wXg
 aDv
 aAp
 nmO
@@ -28516,7 +28538,7 @@ aFm
 aFm
 aAl
 qKC
-viw
+pKm
 aAp
 nmO
 aZP
@@ -28735,11 +28757,11 @@ aud
 aud
 aud
 avy
-oXI
+jRJ
 oTJ
 oTJ
-eqM
-ert
+uiW
+sqs
 oTJ
 qKC
 kWX
@@ -28963,10 +28985,10 @@ aud
 arU
 aud
 auP
-wXg
+vOD
 oTJ
-egN
-sBo
+azB
+sOC
 oTJ
 oTJ
 mBL
@@ -29192,14 +29214,14 @@ aud
 aud
 auP
 oTJ
-bfD
-oXI
+tRE
+jRJ
 oTJ
-oTJ
-jjN
+ukh
+njl
 vVf
 fqM
-cxZ
+oXI
 aAp
 fuy
 aXX
@@ -29421,11 +29443,11 @@ amG
 auP
 oTJ
 oTJ
-cbS
-eqM
-oTJ
-hZn
-eqm
+bav
+uiW
+tka
+lCG
+cDQ
 oTJ
 nuW
 aAp
@@ -29648,12 +29670,12 @@ arV
 aud
 auP
 oTJ
-oOK
-btS
+azX
+qJe
 oTJ
 oTJ
-oTJ
-tgl
+oEc
+fHw
 oTJ
 aAp
 aAp
@@ -29875,8 +29897,8 @@ aud
 aud
 aud
 auP
-wXg
-oXI
+vOD
+jRJ
 oTJ
 oTJ
 oTJ
@@ -30106,7 +30128,7 @@ auP
 oTJ
 oTJ
 oTJ
-tNb
+hZn
 oTJ
 oTJ
 oTJ
@@ -30332,7 +30354,7 @@ aud
 aud
 auP
 asH
-anr
+jDY
 oTJ
 oTJ
 tlE
@@ -30561,8 +30583,8 @@ amG
 auP
 oTJ
 tlE
-uBu
-oen
+aWq
+woF
 gyP
 vEp
 txx
@@ -30790,7 +30812,7 @@ auP
 oTJ
 teS
 pDI
-tMq
+yiE
 pYJ
 dmS
 cRT
@@ -39511,7 +39533,7 @@ kxI
 awQ
 qtj
 qtj
-kzc
+xVN
 tsa
 tsa
 aac
@@ -40193,7 +40215,7 @@ aPt
 tzK
 kxI
 kxI
-yiE
+kXE
 qtj
 tsa
 tsa
@@ -58153,10 +58175,10 @@ atI
 avS
 atI
 asN
-leh
+ihS
 oUa
 oUa
-gct
+deU
 fFZ
 xDw
 apu
@@ -58375,16 +58397,16 @@ vNP
 dLY
 dLY
 pcu
-oVO
+ioC
 oUa
 oUa
 oUa
 oUa
 oUa
-sHP
+isJ
 oUa
-eOx
-eRy
+kGk
+dqz
 ukZ
 mvc
 apu
@@ -58602,18 +58624,18 @@ dLY
 dLY
 fSX
 dLY
-rGW
+btS
 oUa
 oUa
 oUa
 oUa
 oUa
 oUa
-fPp
-bqn
+vbh
+dsi
 oUa
-eRy
-iBy
+dqz
+ukZ
 ukZ
 apu
 apu
@@ -58830,7 +58852,7 @@ dLY
 dLY
 fED
 dLY
-rGW
+btS
 oUa
 oUa
 oUa
@@ -58838,10 +58860,10 @@ oUa
 oUa
 oUa
 oUa
-qof
+upV
 oUa
-vED
-ljy
+njO
+orB
 apu
 apu
 oUa
@@ -59058,7 +59080,7 @@ fSX
 dLY
 dLY
 fSX
-rGW
+btS
 oUa
 jik
 oUa
@@ -59068,7 +59090,7 @@ oUa
 oUa
 oUa
 oUa
-xrM
+ciz
 oUa
 oUa
 oUa
@@ -59286,8 +59308,8 @@ dLY
 gAI
 dLY
 dLY
-lxp
-azB
+eOk
+rSy
 oUa
 oUa
 oUa
@@ -59295,11 +59317,11 @@ oUa
 oUa
 oUa
 oUa
-tka
+qns
 oUa
 oUa
 oUa
-qxw
+uuf
 oUa
 cCr
 vKt
@@ -59515,8 +59537,8 @@ fSX
 dLY
 dLY
 dLY
-rGW
-tka
+btS
+qns
 oUa
 oUa
 oUa
@@ -59743,7 +59765,7 @@ fSX
 dLY
 gMe
 gcn
-rGW
+btS
 oUa
 oUa
 oUa
@@ -59971,7 +59993,7 @@ hKk
 psc
 xQI
 dLY
-rGW
+btS
 oUa
 oUa
 oUa
@@ -60198,8 +60220,8 @@ cCr
 lLO
 eil
 sXi
-okA
-oVO
+sRW
+ioC
 oUa
 oUa
 oUa
@@ -60426,7 +60448,7 @@ cCr
 dLY
 xDR
 sXi
-rGW
+btS
 oUa
 oUa
 oUa
@@ -60654,22 +60676,22 @@ cCr
 dLY
 xDR
 sXi
-lxp
-tgw
-vOD
-azB
+eOk
+pMM
+iBy
+rSy
 oUa
-kGk
-vOD
-azB
+mnr
+iBy
+rSy
 oUa
 oUa
 oUa
 jik
 jik
 jik
-vOD
-vOD
+iBy
+iBy
 iab
 hmK
 xVk
@@ -60885,14 +60907,14 @@ dNN
 dLY
 fSX
 hRS
-rGW
+btS
 oUa
-crC
+uuV
 dLY
-lxp
-vOD
+eOk
+iBy
 jik
-vOD
+iBy
 iab
 jik
 dLY
@@ -60906,8 +60928,8 @@ dLY
 djI
 jik
 crF
-rDv
-tUH
+rcy
+kjD
 dZY
 fbD
 xVk
@@ -61113,8 +61135,8 @@ fSX
 dLY
 dLY
 dLY
-lxp
-vOD
+eOk
+iBy
 jik
 dLY
 fED
@@ -61134,8 +61156,8 @@ dLY
 jik
 oUa
 oUa
-jCJ
-hEJ
+mbN
+rGW
 jik
 jik
 vWs
@@ -61359,11 +61381,11 @@ jik
 jik
 dLY
 dLY
-usp
+wUv
 oUa
 oUa
-jCJ
-mrX
+mbN
+unT
 djI
 uVU
 jik

--- a/maps/map_files/LV624/LV624.dmm
+++ b/maps/map_files/LV624/LV624.dmm
@@ -2670,6 +2670,10 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/north_east_jungle)
+"anr" = (
+/obj/effect/decal/cleanable/blood/gibs/xeno/limb,
+/turf/open/gm/dirt,
+/area/lv624/ground/jungle/north_west_jungle)
 "anv" = (
 /obj/structure/flora/bush/ausbushes/var3/sunnybush,
 /turf/open/gm/grass/grass1,
@@ -3938,9 +3942,7 @@
 	req_access_txt = "100";
 	req_one_access = null
 	},
-/turf/open/floor{
-	icon_state = "cult"
-	},
+/turf/open/floor/wood,
 /area/lv624/ground/jungle/west_jungle/ceiling)
 "auP" = (
 /obj/effect/landmark/lv624/fog_blocker,
@@ -5066,7 +5068,7 @@
 /area/lv624/lazarus/research)
 "ayN" = (
 /obj/structure/flora/bush/ausbushes/reedbush,
-/turf/open/gm/grass/grass1,
+/turf/open/gm/dirtgrassborder/grassdirt_corner2/south_west,
 /area/lv624/ground/jungle/west_jungle)
 "ayO" = (
 /obj/item/weapon/baseballbat/metal,
@@ -5106,7 +5108,7 @@
 /area/lv624/ground/jungle/west_jungle)
 "ayU" = (
 /obj/structure/machinery/colony_floodlight,
-/turf/open/gm/dirtgrassborder/grassdirt_corner/north_east,
+/turf/open/gm/dirtgrassborder/north,
 /area/lv624/ground/jungle/south_central_jungle)
 "ayV" = (
 /obj/structure/flora/bush/ausbushes/var3/sparsegrass,
@@ -5309,9 +5311,8 @@
 	},
 /area/lv624/lazarus/sleep_female)
 "azB" = (
-/obj/effect/landmark/static_comms/net_one,
-/turf/open/gm/dirt,
-/area/lv624/ground/colony/telecomm/tcommdome/south)
+/turf/open/gm/dirtgrassborder/grassdirt_corner2/north_east,
+/area/lv624/ground/jungle/east_jungle)
 "azD" = (
 /obj/structure/fence,
 /turf/open/gm/dirtgrassborder/grassdirt_corner/north_east,
@@ -7217,7 +7218,7 @@
 /area/lv624/lazarus/toilet)
 "aFQ" = (
 /obj/structure/window_frame/wood,
-/turf/open/floor/plating,
+/turf/open/floor/wood,
 /area/lv624/ground/jungle/west_jungle/ceiling)
 "aFR" = (
 /turf/open/floor{
@@ -8778,7 +8779,7 @@
 /area/lv624/lazarus/landing_zones/lz1)
 "aMr" = (
 /obj/effect/landmark/lv624/xeno_tunnel,
-/turf/open/gm/grass/grass1,
+/turf/open/gm/dirtgrassborder/grassdirt_corner/north_west,
 /area/lv624/ground/jungle/east_jungle)
 "aMt" = (
 /obj/structure/flora/bush/ausbushes/var3/ywflowers,
@@ -12364,6 +12365,10 @@
 "bfe" = (
 /turf/open/gm/dirtgrassborder/grassdirt_corner2/south_east,
 /area/lv624/ground/jungle/north_east_jungle)
+"bfD" = (
+/obj/effect/decal/cleanable/blood/gibs/xeno,
+/turf/open/gm/dirt,
+/area/lv624/ground/jungle/north_west_jungle)
 "bfY" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_wall,
@@ -12460,6 +12465,10 @@
 	},
 /turf/open/floor/vault,
 /area/lv624/lazarus/quartstorage)
+"bqn" = (
+/obj/effect/landmark/monkey_spawn,
+/turf/open/gm/dirt,
+/area/lv624/ground/jungle/east_jungle)
 "brh" = (
 /obj/structure/flora/jungle/plantbot1,
 /obj/structure/flora/jungle/vines/light_1,
@@ -12507,8 +12516,8 @@
 /area/lv624/lazarus/landing_zones/lz1)
 "btS" = (
 /obj/structure/flora/bush/ausbushes/var3/ywflowers,
-/turf/open/gm/grass/grass1,
-/area/lv624/ground/jungle/east_jungle)
+/turf/open/gm/dirt,
+/area/lv624/ground/jungle/north_west_jungle)
 "btX" = (
 /turf/open/gm/river,
 /area/lv624/ground/caves/sand_temple)
@@ -12805,6 +12814,10 @@
 	},
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/south_west_jungle)
+"cbS" = (
+/obj/effect/decal/cleanable/blood/gibs/xeno/up,
+/turf/open/gm/dirt,
+/area/lv624/ground/jungle/north_west_jungle)
 "ccn" = (
 /obj/structure/flora/grass/tallgrass/jungle/corner{
 	dir = 4
@@ -12945,9 +12958,14 @@
 	icon_state = "warning"
 	},
 /area/lv624/lazarus/landing_zones/lz1)
+"crC" = (
+/obj/effect/landmark/hunter_primary,
+/turf/open/gm/dirtgrassborder/south,
+/area/lv624/ground/jungle/east_jungle)
 "crF" = (
 /obj/structure/flora/bush/ausbushes/var3/fernybush,
-/turf/open/gm/grass/grass1,
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/gm/dirtgrassborder/west,
 /area/lv624/ground/jungle/east_jungle)
 "csu" = (
 /obj/structure/flora/bush/ausbushes/reedbush,
@@ -12976,6 +12994,9 @@
 	icon_state = "desert_dug"
 	},
 /area/lv624/ground/barrens/west_barrens)
+"cxZ" = (
+/turf/closed/wall/r_wall/unmeltable,
+/area/lv624/lazarus/landing_zones/lz2)
 "cys" = (
 /obj/structure/foamed_metal,
 /turf/open/gm/dirtgrassborder/south,
@@ -13655,6 +13676,10 @@
 "efX" = (
 /turf/open/gm/coast/east,
 /area/lv624/ground/river/east_river)
+"egN" = (
+/obj/structure/flora/bush/ausbushes/var3/sparsegrass,
+/turf/open/gm/dirt,
+/area/lv624/ground/jungle/north_west_jungle)
 "ehy" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/generic{
 	name = "Hydroponics"
@@ -13745,6 +13770,13 @@
 	icon_state = "whiteblue"
 	},
 /area/lv624/lazarus/corporate_dome)
+"eqm" = (
+/obj/item/ammo_magazine/sentry{
+	current_rounds = 0;
+	pixel_y = -13
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/jungle/north_west_jungle)
 "eqs" = (
 /obj/structure/flora/grass/tallgrass/jungle/corner{
 	dir = 9
@@ -13754,12 +13786,27 @@
 "eqF" = (
 /turf/open/gm/coast/north,
 /area/lv624/ground/river/central_river)
+"eqM" = (
+/obj/structure/barricade/metal/wired{
+	dir = 1;
+	health = 10;
+	is_wired = 1
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/jungle/north_west_jungle)
 "eqP" = (
 /obj/structure/machinery/bioprinter,
 /turf/open/floor{
 	icon_state = "whitebluefull"
 	},
 /area/lv624/lazarus/medbay)
+"ert" = (
+/obj/item/stack/sheet/metal{
+	pixel_x = -7;
+	pixel_y = 1
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/jungle/north_west_jungle)
 "erx" = (
 /turf/open/gm/coast/beachcorner/south_east,
 /area/lv624/ground/jungle/west_jungle)
@@ -13945,6 +13992,13 @@
 /obj/structure/machinery/colony_floodlight,
 /turf/open/gm/dirt,
 /area/lv624/ground/barrens/east_barrens)
+"eOx" = (
+/obj/item/storage/toolkit/empty{
+	pixel_x = 5;
+	pixel_y = -3
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/jungle/east_jungle)
 "ePp" = (
 /turf/open/gm/dirt{
 	icon_state = "desert3"
@@ -13966,6 +14020,12 @@
 /obj/structure/largecrate/random,
 /turf/open/floor,
 /area/lv624/lazarus/landing_zones/lz1)
+"eRy" = (
+/turf/open/floor{
+	dir = 1;
+	icon_state = "asteroidwarning"
+	},
+/area/lv624/ground/colony/telecomm/cargo)
 "eSg" = (
 /obj/structure/flora/jungle/vines/heavy,
 /turf/closed/wall/strata_ice/jungle,
@@ -14292,8 +14352,9 @@
 /obj/structure/machinery/power/apc{
 	start_charge = 0
 	},
-/turf/open/floor/plating{
-	icon_state = "platebotc"
+/turf/open/floor{
+	dir = 1;
+	icon_state = "asteroidfloor"
 	},
 /area/lv624/ground/colony/telecomm/cargo)
 "fGO" = (
@@ -14348,6 +14409,14 @@
 "fPi" = (
 /turf/open/gm/coast/north,
 /area/lv624/ground/caves/sand_temple)
+"fPp" = (
+/obj/item/device/radio/off{
+	frequency = 1469;
+	pixel_x = -9;
+	pixel_y = -13
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/jungle/east_jungle)
 "fPH" = (
 /turf/open/gm/dirtgrassborder/south,
 /area/lv624/ground/jungle/west_central_jungle)
@@ -14419,6 +14488,15 @@
 /obj/structure/flora/bush/ausbushes/lavendergrass,
 /turf/open/gm/grass/grass2,
 /area/lv624/ground/jungle/south_central_jungle)
+"gct" = (
+/obj/item/circuitboard/airlock{
+	pixel_x = 12
+	},
+/turf/open/floor{
+	dir = 1;
+	icon_state = "asteroidwarning"
+	},
+/area/lv624/ground/colony/telecomm/cargo)
 "gcI" = (
 /obj/effect/landmark/crap_item,
 /turf/open/shuttle{
@@ -14983,6 +15061,10 @@
 /obj/structure/fence,
 /turf/open/gm/dirtgrassborder/west,
 /area/lv624/ground/colony/west_nexus_road)
+"hEJ" = (
+/obj/structure/flora/jungle/vines/light_3,
+/turf/open/gm/dirtgrassborder/south,
+/area/lv624/ground/jungle/east_jungle)
 "hFO" = (
 /obj/structure/fence,
 /turf/open/gm/dirtgrassborder/grassdirt_corner/south_west,
@@ -15141,11 +15223,23 @@
 	},
 /area/lv624/lazarus/medbay)
 "hZn" = (
-/obj/structure/flora/grass/tallgrass/jungle/corner{
-	dir = 8
+/obj/item/ammo_casing/bullet{
+	icon_state = "cartridge_3_1"
 	},
-/turf/open/gm/grass/grass1,
-/area/lv624/ground/jungle/east_jungle)
+/obj/item/ammo_casing/bullet{
+	icon_state = "cartridge_6_1"
+	},
+/obj/item/ammo_casing/bullet{
+	icon_state = "casing_9_1"
+	},
+/obj/item/ammo_casing/bullet,
+/obj/item/ammo_casing/bullet{
+	icon_state = "cartridge_10_1"
+	},
+/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/decal/cleanable/blood/gibs/robot/down,
+/turf/open/gm/dirt,
+/area/lv624/ground/jungle/north_west_jungle)
 "hZW" = (
 /obj/effect/landmark/objective_landmark/close,
 /turf/open/floor{
@@ -15345,8 +15439,9 @@
 /area/lv624/ground/jungle/west_central_jungle)
 "iBy" = (
 /obj/structure/flora/bush/ausbushes/lavendergrass,
-/turf/open/floor/plating{
-	icon_state = "platebotc"
+/turf/open/floor{
+	dir = 1;
+	icon_state = "asteroidfloor"
 	},
 /area/lv624/ground/colony/telecomm/cargo)
 "iBD" = (
@@ -15552,6 +15647,10 @@
 	icon_state = "vault"
 	},
 /area/lv624/lazarus/quartstorage)
+"jjN" = (
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/gm/dirt,
+/area/lv624/ground/jungle/north_west_jungle)
 "jlh" = (
 /obj/structure/machinery/colony_floodlight,
 /turf/open/gm/dirt,
@@ -15678,6 +15777,10 @@
 	icon_state = "floor6"
 	},
 /area/lv624/ground/caves/sand_temple)
+"jCJ" = (
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/gm/dirt,
+/area/lv624/ground/jungle/east_jungle)
 "jEc" = (
 /obj/structure/fence,
 /turf/open/gm/dirtgrassborder/grassdirt_corner/north_east,
@@ -16033,6 +16136,9 @@
 /obj/structure/flora/jungle/vines/heavy,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/north_east_jungle)
+"kzc" = (
+/turf/open/gm/dirtgrassborder/grassdirt_corner2/south_west,
+/area/lv624/ground/jungle/south_central_jungle)
 "kzd" = (
 /obj/structure/surface/table,
 /obj/effect/landmark/crap_item,
@@ -16092,8 +16198,8 @@
 /turf/open/gm/coast/beachcorner/north_east,
 /area/lv624/ground/barrens/west_barrens)
 "kGk" = (
-/turf/closed/wall/r_wall,
-/area/lv624/ground/colony/telecomm/tcommdome/south)
+/turf/open/gm/dirtgrassborder/grassdirt_corner2/south_east,
+/area/lv624/ground/jungle/east_jungle)
 "kHB" = (
 /turf/open/gm/dirt{
 	icon_state = "desert3"
@@ -16260,6 +16366,17 @@
 "ldZ" = (
 /turf/closed/wall/strata_ice/jungle,
 /area/lv624/ground/jungle/north_jungle)
+"leh" = (
+/obj/structure/surface/table,
+/obj/item/reagent_container/food/drinks/cans/lemon_lime{
+	pixel_x = -5;
+	pixel_y = 2
+	},
+/obj/structure/prop/server_equipment/laptop/on{
+	pixel_y = 8
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/jungle/east_jungle)
 "lfy" = (
 /obj/structure/fence,
 /turf/open/gm/dirtgrassborder/west,
@@ -16271,6 +16388,12 @@
 "lju" = (
 /turf/open/gm/coast/beachcorner2/south_east,
 /area/lv624/ground/river/central_river)
+"ljy" = (
+/turf/open/floor{
+	dir = 4;
+	icon_state = "asteroidwarning"
+	},
+/area/lv624/ground/colony/telecomm/cargo)
 "lke" = (
 /obj/effect/landmark/crap_item,
 /turf/open/floor,
@@ -16346,6 +16469,9 @@
 /obj/structure/flora/bush/ausbushes/lavendergrass,
 /turf/open/gm/dirtgrassborder/west,
 /area/lv624/ground/colony/north_tcomms_road)
+"lxp" = (
+/turf/open/gm/dirtgrassborder/grassdirt_corner/north_east,
+/area/lv624/ground/jungle/east_jungle)
 "lxr" = (
 /obj/structure/flora/jungle/vines/light_2,
 /turf/open/gm/dirtgrassborder/south,
@@ -16761,6 +16887,10 @@
 	},
 /turf/open/floor/sandstone/runed,
 /area/lv624/ground/caves/sand_temple)
+"mrX" = (
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/gm/dirtgrassborder/south,
+/area/lv624/ground/jungle/east_jungle)
 "msd" = (
 /turf/open/gm/dirtgrassborder/west,
 /area/lv624/ground/caves/sand_temple)
@@ -16792,8 +16922,9 @@
 /area/lv624/ground/jungle/north_east_jungle)
 "mvc" = (
 /obj/effect/landmark/static_comms/net_two,
-/turf/open/floor/plating{
-	icon_state = "platebotc"
+/turf/open/floor{
+	dir = 1;
+	icon_state = "asteroidfloor"
 	},
 /area/lv624/ground/colony/telecomm/cargo)
 "mvr" = (
@@ -17614,6 +17745,15 @@
 "oek" = (
 /turf/open/gm/coast/north,
 /area/lv624/ground/jungle/west_jungle)
+"oen" = (
+/obj/structure/flora/jungle/vines/light_3,
+/obj/structure/barricade/metal/wired{
+	dir = 1;
+	health = 10;
+	is_wired = 1
+	},
+/turf/open/gm/dirtgrassborder/east,
+/area/lv624/ground/jungle/north_west_jungle)
 "oeN" = (
 /turf/closed/wall,
 /area/lv624/ground/barrens/north_east_barrens/ceiling)
@@ -17664,9 +17804,16 @@
 /obj/effect/landmark/objective_landmark/close,
 /turf/open/floor/plating,
 /area/lv624/ground/barrens/central_barrens)
+"okA" = (
+/turf/open/gm/dirtgrassborder/grassdirt_corner/north_west,
+/area/lv624/ground/jungle/east_jungle)
 "omK" = (
 /turf/open/gm/coast/beachcorner/south_east,
 /area/lv624/ground/barrens/west_barrens)
+"onf" = (
+/obj/structure/flora/bush/ausbushes/ausbush,
+/turf/open/gm/dirt,
+/area/lv624/ground/jungle/west_jungle)
 "onU" = (
 /turf/closed/wall/strata_ice/jungle,
 /area/lv624/ground/caves/west_caves)
@@ -17856,6 +18003,10 @@
 /obj/structure/fence,
 /turf/open/gm/dirtgrassborder/grassdirt_corner2/south_east,
 /area/lv624/ground/colony/west_nexus_road)
+"oLO" = (
+/obj/structure/flora/bush/ausbushes/var3/sparsegrass,
+/turf/open/gm/dirt,
+/area/lv624/ground/jungle/west_jungle)
 "oMZ" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_membrane,
 /turf/open/gm/dirt,
@@ -17892,6 +18043,10 @@
 /obj/structure/machinery/landinglight/ds2/delayone,
 /turf/open/floor/plating,
 /area/lv624/lazarus/landing_zones/lz2)
+"oOK" = (
+/obj/effect/landmark/hunter_primary,
+/turf/open/gm/dirt,
+/area/lv624/ground/jungle/north_west_jungle)
 "oOV" = (
 /obj/structure/flora/jungle/vines/light_1,
 /obj/structure/flora/jungle/vines/light_3,
@@ -17976,6 +18131,9 @@
 	icon_state = "warnplate"
 	},
 /area/lv624/ground/barrens/east_barrens/ceiling)
+"oVO" = (
+/turf/open/gm/dirtgrassborder/grassdirt_corner2/north_west,
+/area/lv624/ground/jungle/east_jungle)
 "oWN" = (
 /obj/structure/flora/jungle/vines/heavy,
 /turf/open/gm/grass/grass2,
@@ -17984,7 +18142,8 @@
 /turf/open/gm/dirtgrassborder/east,
 /area/lv624/ground/jungle/south_west_jungle)
 "oXI" = (
-/turf/open/gm/grass/grass2,
+/obj/effect/decal/cleanable/blood/xeno,
+/turf/open/gm/dirt,
 /area/lv624/ground/jungle/north_west_jungle)
 "oXS" = (
 /turf/open/gm/coast/west,
@@ -18049,7 +18208,7 @@
 /area/lv624/ground/barrens/east_barrens)
 "pcu" = (
 /obj/structure/flora/bush/ausbushes/genericbush,
-/turf/open/gm/grass/grass1,
+/turf/open/gm/dirtgrassborder/grassdirt_corner/north_west,
 /area/lv624/ground/jungle/east_jungle)
 "pcz" = (
 /obj/effect/landmark/objective_landmark/medium,
@@ -18537,6 +18696,13 @@
 /obj/structure/flora/bush/ausbushes/var3/ywflowers,
 /turf/open/gm/grass/grass2,
 /area/lv624/ground/jungle/north_east_jungle)
+"qof" = (
+/obj/item/stack/cable_coil/random{
+	pixel_y = 9;
+	pixel_x = 7
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/jungle/east_jungle)
 "qpX" = (
 /obj/structure/stairs/perspective{
 	color = "#b29082";
@@ -18611,6 +18777,10 @@
 	icon_state = "whiteyellow"
 	},
 /area/lv624/lazarus/corporate_dome)
+"qxw" = (
+/obj/effect/landmark/hunter_primary,
+/turf/open/gm/dirt,
+/area/lv624/ground/jungle/east_jungle)
 "qxZ" = (
 /obj/structure/surface/table/woodentable/poor,
 /obj/item/stack/sheet/metal{
@@ -18744,7 +18914,6 @@
 /turf/open/gm/dirtgrassborder/east,
 /area/lv624/ground/colony/north_nexus_road)
 "qKC" = (
-/obj/structure/flora/jungle/vines/heavy,
 /turf/open/floor{
 	dir = 9;
 	icon_state = "asteroidwarning"
@@ -19058,6 +19227,10 @@
 "rCV" = (
 /turf/open/gm/grass/grass2,
 /area/lv624/ground/jungle/south_central_jungle)
+"rDv" = (
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/gm/dirtgrassborder/west,
+/area/lv624/ground/jungle/east_jungle)
 "rGd" = (
 /obj/structure/girder/displaced,
 /obj/structure/shuttle/engine/propulsion,
@@ -19077,9 +19250,8 @@
 /turf/open/floor/vault,
 /area/lv624/lazarus/quartstorage)
 "rGW" = (
-/obj/structure/flora/bush/ausbushes/genericbush,
-/turf/open/gm/grass/grass2,
-/area/lv624/ground/jungle/north_west_jungle)
+/turf/open/gm/dirtgrassborder/north,
+/area/lv624/ground/jungle/east_jungle)
 "rGZ" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
 /turf/open/gm/dirt,
@@ -19400,6 +19572,13 @@
 	icon_state = "whiteblue"
 	},
 /area/lv624/lazarus/corporate_dome)
+"sBo" = (
+/obj/item/stack/sheet/metal{
+	pixel_x = 16;
+	pixel_y = -10
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/jungle/north_west_jungle)
 "sBC" = (
 /obj/structure/fence,
 /turf/open/gm/dirtgrassborder/grassdirt_corner/south_east,
@@ -19458,6 +19637,13 @@
 	},
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/south_east_jungle)
+"sHP" = (
+/obj/structure/surface/table,
+/obj/item/storage/beer_pack{
+	pixel_y = 9
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/jungle/east_jungle)
 "sHT" = (
 /obj/structure/flora/bush/ausbushes/reedbush,
 /turf/open/gm/grass/grass1,
@@ -19661,6 +19847,17 @@
 	icon_state = "warning"
 	},
 /area/lv624/lazarus/landing_zones/lz1)
+"tgl" = (
+/obj/item/device/sentry_computer{
+	pixel_y = 5
+	},
+/obj/structure/surface/table,
+/turf/open/gm/dirt,
+/area/lv624/ground/jungle/north_west_jungle)
+"tgw" = (
+/obj/structure/flora/bush/ausbushes/ppflowers,
+/turf/open/gm/dirtgrassborder/east,
+/area/lv624/ground/jungle/east_jungle)
 "tgL" = (
 /mob/living/simple_animal/bat,
 /turf/open/gm/dirt,
@@ -19712,9 +19909,9 @@
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/north_west_caves)
 "tka" = (
-/obj/effect/landmark/lv624/xeno_tunnel,
-/turf/open/gm/grass/grass1,
-/area/lv624/ground/jungle/north_west_jungle)
+/obj/structure/machinery/colony_floodlight,
+/turf/open/gm/dirt,
+/area/lv624/ground/jungle/east_jungle)
 "tlD" = (
 /obj/structure/flora/bush/ausbushes/var3/fernybush,
 /turf/open/gm/river,
@@ -19962,6 +20159,11 @@
 /obj/structure/flora/jungle/vines/heavy,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/south_west_jungle)
+"tMq" = (
+/obj/structure/flora/jungle/vines/heavy,
+/obj/effect/landmark/lv624/xeno_tunnel,
+/turf/open/gm/grass/grass1,
+/area/lv624/ground/jungle/north_west_jungle)
 "tMB" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
 /turf/open/gm/dirt,
@@ -19978,6 +20180,13 @@
 	icon_state = "whiteyellowfull"
 	},
 /area/lv624/ground/barrens/south_eastern_barrens)
+"tNb" = (
+/obj/item/stack/sheet/metal{
+	pixel_x = 6;
+	pixel_y = 30
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/jungle/north_west_jungle)
 "tOS" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
 /turf/open/gm/dirt,
@@ -20004,6 +20213,10 @@
 /obj/structure/flora/jungle/vines/heavy,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/east_central_jungle)
+"tUH" = (
+/obj/structure/flora/jungle/vines/light_3,
+/turf/open/gm/dirtgrassborder/grassdirt_corner/south_west,
+/area/lv624/ground/jungle/east_jungle)
 "tWw" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor{
@@ -20148,8 +20361,9 @@
 	},
 /area/lv624/ground/barrens/south_eastern_barrens)
 "ukZ" = (
-/turf/open/floor/plating{
-	icon_state = "platebotc"
+/turf/open/floor{
+	dir = 1;
+	icon_state = "asteroidfloor"
 	},
 /area/lv624/ground/colony/telecomm/cargo)
 "ulj" = (
@@ -20184,8 +20398,12 @@
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/south_east_caves)
 "unT" = (
+/obj/item/stack/sheet/metal{
+	pixel_x = 16;
+	pixel_y = -10
+	},
 /turf/open/gm/dirt,
-/area/lv624/ground/colony/telecomm/tcommdome/south)
+/area/lv624/ground/jungle/west_jungle)
 "upM" = (
 /obj/effect/landmark/crap_item,
 /turf/open/gm/grass/grass1,
@@ -20208,6 +20426,11 @@
 	},
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/north_central_caves)
+"usp" = (
+/obj/structure/flora/bush/ausbushes/var3/sparsegrass,
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/gm/dirtgrassborder/north,
+/area/lv624/ground/jungle/east_jungle)
 "usE" = (
 /obj/structure/flora/bush/ausbushes/reedbush,
 /turf/open/gm/dirt,
@@ -20246,6 +20469,10 @@
 "uAp" = (
 /turf/closed/wall/strata_ice/jungle,
 /area/lv624/ground/barrens/south_eastern_barrens)
+"uBu" = (
+/obj/effect/decal/cleanable/blood/xeno,
+/turf/open/gm/dirtgrassborder/east,
+/area/lv624/ground/jungle/north_west_jungle)
 "uDd" = (
 /obj/structure/showcase{
 	desc = "An ancient, dusty tomb with strange alien writing. It's best not to touch it.";
@@ -20532,6 +20759,12 @@
 /obj/structure/girder,
 /turf/open/gm/dirt,
 /area/lv624/lazarus/crashed_ship_containers)
+"viw" = (
+/turf/open/floor{
+	icon_state = "asteroidwarning";
+	dir = 8
+	},
+/area/lv624/ground/colony/telecomm/sw_lz2)
 "vjH" = (
 /obj/structure/flora/jungle/vines/light_3,
 /turf/open/gm/grass/grass1,
@@ -20682,6 +20915,12 @@
 /obj/structure/flora/jungle/vines/light_1,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/north_west_jungle)
+"vED" = (
+/turf/open/floor{
+	dir = 5;
+	icon_state = "asteroidwarning"
+	},
+/area/lv624/ground/colony/telecomm/cargo)
 "vGg" = (
 /obj/structure/flora/grass/tallgrass/jungle/corner{
 	dir = 6
@@ -20746,11 +20985,8 @@
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/south_east_jungle)
 "vOD" = (
-/turf/open/floor{
-	dir = 9;
-	icon_state = "asteroidwarning"
-	},
-/area/lv624/ground/colony/telecomm/tcommdome/south)
+/turf/open/gm/dirtgrassborder/east,
+/area/lv624/ground/jungle/east_jungle)
 "vOF" = (
 /turf/open/gm/dirtgrassborder/west,
 /area/lv624/ground/jungle/south_central_jungle)
@@ -21262,14 +21498,9 @@
 /turf/open/gm/dirt,
 /area/lv624/ground/barrens/north_east_barrens)
 "wXg" = (
-/obj/structure/machinery/power/apc{
-	start_charge = 0
-	},
-/turf/open/floor{
-	dir = 1;
-	icon_state = "asteroidwarning"
-	},
-/area/lv624/ground/colony/telecomm/tcommdome/south)
+/obj/structure/flora/bush/ausbushes/reedbush,
+/turf/open/gm/dirt,
+/area/lv624/ground/jungle/north_west_jungle)
 "wXp" = (
 /turf/open/gm/dirtgrassborder/grassdirt_corner2/north_west,
 /area/lv624/ground/jungle/west_central_jungle)
@@ -21393,6 +21624,13 @@
 	icon_state = "warning"
 	},
 /area/lv624/lazarus/landing_zones/lz2)
+"xrM" = (
+/obj/item/device/assembly/signaller{
+	pixel_x = -6;
+	pixel_y = -9
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/jungle/east_jungle)
 "xsN" = (
 /obj/structure/flora/jungle/vines/light_1,
 /obj/structure/flora/bush/ausbushes/ppflowers,
@@ -21681,9 +21919,9 @@
 	},
 /area/lv624/lazarus/corporate_dome)
 "yiE" = (
-/obj/structure/flora/bush/ausbushes/pointybush,
-/turf/open/gm/grass/grass1,
-/area/lv624/ground/jungle/east_jungle)
+/obj/structure/flora/bush/ausbushes/ausbush,
+/turf/open/gm/dirtgrassborder/north,
+/area/lv624/ground/jungle/south_central_jungle)
 "yiT" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/storage/firstaid/adv{
@@ -26908,8 +27146,8 @@ aFm
 auO
 aFm
 aFm
-uSw
-asa
+aAl
+aqR
 asa
 aja
 asa
@@ -27136,9 +27374,9 @@ aue
 auf
 aXC
 aFm
-aro
+aAl
 ayN
-asc
+asx
 ayT
 aAp
 aAp
@@ -27364,9 +27602,9 @@ auf
 auf
 aZp
 aFm
-aro
-aro
-ayT
+aAl
+oLO
+aqS
 aAp
 aAp
 aAp
@@ -27592,9 +27830,9 @@ aug
 wFx
 avo
 aFQ
-axX
-baN
-aAp
+onf
+aAl
+aDv
 aAp
 aAp
 nmO
@@ -27814,15 +28052,15 @@ aud
 bGb
 auP
 aqi
-aqS
+ase
 aFm
 aZn
 axp
 auf
 aFm
-asw
-aro
-aAp
+aAl
+unT
+aDv
 aAp
 nmO
 aXX
@@ -28041,16 +28279,16 @@ aud
 aud
 aud
 auP
-aqR
-arn
+aAl
+aAl
 aFm
 aIH
 auR
 auf
 aFm
-atC
-ayT
-aAp
+aAl
+aAl
+aDv
 aAp
 aXX
 aRG
@@ -28269,16 +28507,16 @@ sFc
 aud
 aud
 auP
-aqS
-aro
+aAl
+aAl
 aFm
 aFm
 aFQ
 aFm
 aFm
-atC
-aAp
-aAp
+aAl
+qKC
+viw
 aAp
 nmO
 aZP
@@ -28497,12 +28735,12 @@ aud
 aud
 aud
 avy
-teS
-rGW
-psh
-nuW
-psh
-vEp
+oXI
+oTJ
+oTJ
+eqM
+ert
+oTJ
 qKC
 kWX
 hdh
@@ -28725,12 +28963,12 @@ aud
 arU
 aud
 auP
-teS
-psh
-dop
-kVP
-psh
-psh
+wXg
+oTJ
+egN
+sBo
+oTJ
+oTJ
 mBL
 hdh
 hdh
@@ -28953,15 +29191,15 @@ aud
 aud
 aud
 auP
-teS
-pYq
-hIq
-nuW
-psh
-psh
+oTJ
+bfD
+oXI
+oTJ
+oTJ
+jjN
 vVf
 fqM
-aAp
+cxZ
 aAp
 fuy
 aXX
@@ -29181,15 +29419,15 @@ aud
 aud
 amG
 auP
-teS
-qSZ
-fio
+oTJ
+oTJ
+cbS
+eqM
+oTJ
+hZn
+eqm
+oTJ
 nuW
-tka
-nuW
-psh
-cRT
-cqz
 aAp
 cIL
 nmO
@@ -29409,14 +29647,14 @@ aud
 arV
 aud
 auP
-teS
-kRg
-nVG
-psh
-nuW
-txx
-cRT
-cRT
+oTJ
+oOK
+btS
+oTJ
+oTJ
+oTJ
+tgl
+oTJ
 aAp
 aAp
 aAp
@@ -29637,15 +29875,15 @@ aud
 aud
 aud
 auP
-eHQ
-pOC
-nuW
+wXg
 oXI
-nuW
-cqz
-cTi
-cRT
-cRT
+oTJ
+oTJ
+oTJ
+asH
+oTJ
+oTJ
+oTJ
 aAp
 aAp
 aXX
@@ -29866,14 +30104,14 @@ amG
 aud
 auP
 oTJ
-teS
-psh
-psh
-dmS
-cRT
-cRT
-dmS
-txx
+oTJ
+oTJ
+tNb
+oTJ
+oTJ
+oTJ
+oTJ
+nuW
 aAp
 nmO
 aXX
@@ -30094,13 +30332,13 @@ aud
 aud
 auP
 asH
-teS
-psh
-pGD
-vXW
-cTi
-cTi
-psh
+anr
+oTJ
+oTJ
+tlE
+fZO
+fZO
+fZO
 aAp
 aAp
 cIL
@@ -30322,10 +30560,10 @@ aud
 amG
 auP
 oTJ
-teS
-psh
-pYJ
-cRT
+tlE
+uBu
+oen
+gyP
 vEp
 txx
 xHa
@@ -30552,7 +30790,7 @@ auP
 oTJ
 teS
 pDI
-cRT
+tMq
 pYJ
 dmS
 cRT
@@ -39273,7 +39511,7 @@ kxI
 awQ
 qtj
 qtj
-hLu
+kzc
 tsa
 tsa
 aac
@@ -39500,9 +39738,9 @@ kxI
 kxI
 dEc
 pcA
-azB
-vOD
-kGk
+qtj
+qtj
+tsa
 tsa
 aac
 aaa
@@ -39728,9 +39966,9 @@ sBJ
 kxI
 kxI
 ayU
-unT
-wXg
-kGk
+qtj
+qtj
+tsa
 tsa
 aac
 aaa
@@ -39955,10 +40193,10 @@ aPt
 tzK
 kxI
 kxI
-ooM
-unT
-kGk
-kGk
+yiE
+qtj
+tsa
+tsa
 tsa
 aac
 aaa
@@ -57915,10 +58153,10 @@ atI
 avS
 atI
 asN
-dLY
-dLY
-dLY
-dLY
+leh
+oUa
+oUa
+gct
 fFZ
 xDw
 apu
@@ -58137,16 +58375,16 @@ vNP
 dLY
 dLY
 pcu
-dLY
-dLY
-dLY
-dLY
-lxX
-dLY
-dLY
-hRS
-dLY
-dLY
+oVO
+oUa
+oUa
+oUa
+oUa
+oUa
+sHP
+oUa
+eOx
+eRy
 ukZ
 mvc
 apu
@@ -58364,17 +58602,17 @@ dLY
 dLY
 fSX
 dLY
-dLY
-fSX
-btS
-dLY
-dLY
-dLY
-dLY
-dLY
-vNP
-eCx
-dLY
+rGW
+oUa
+oUa
+oUa
+oUa
+oUa
+oUa
+fPp
+bqn
+oUa
+eRy
 iBy
 ukZ
 apu
@@ -58592,21 +58830,21 @@ dLY
 dLY
 fED
 dLY
-dLY
-dLY
-dLY
-fSX
-dLY
-dLY
-dLY
-dLY
-dLY
-dLY
-dLY
-dLY
+rGW
+oUa
+oUa
+oUa
+oUa
+oUa
+oUa
+oUa
+qof
+oUa
+vED
+ljy
 apu
 apu
-dLY
+oUa
 apu
 apu
 apu
@@ -58820,21 +59058,21 @@ fSX
 dLY
 dLY
 fSX
-dLY
-dLY
+rGW
+oUa
 jik
-dLY
-dLY
-dLY
-dLY
-dLY
-dLY
-crF
-dLY
-dLY
-dLY
-hmK
-xVk
+oUa
+oUa
+oUa
+oUa
+oUa
+oUa
+oUa
+xrM
+oUa
+oUa
+oUa
+oUa
 apu
 apu
 apu
@@ -59048,22 +59286,22 @@ dLY
 gAI
 dLY
 dLY
-dLY
-lxX
-dLY
-dLY
-dLY
-hRS
-dLY
-dLY
-dLY
-qcX
-dLY
-dLY
-yiE
-kNm
-dLY
-eSg
+lxp
+azB
+oUa
+oUa
+oUa
+oUa
+oUa
+oUa
+oUa
+tka
+oUa
+oUa
+oUa
+qxw
+oUa
+cCr
 vKt
 apu
 apu
@@ -59277,21 +59515,21 @@ fSX
 dLY
 dLY
 dLY
-dLY
-qcX
-dLY
-dLY
-dLY
+rGW
+tka
+oUa
+oUa
+oUa
 jik
-dLY
-dLY
-dLY
-dLY
+oUa
+oUa
+oUa
+oUa
 jik
-dLY
-dLY
-vKt
-vKt
+oUa
+oUa
+oUa
+cCr
 djI
 dZY
 djI
@@ -59505,21 +59743,21 @@ fSX
 dLY
 gMe
 gcn
-fSX
-dLY
-hmK
-xVk
-dLY
-dLY
-dLY
-uYC
-psc
-xQI
-dLY
-dLY
-crF
-dLY
-vKt
+rGW
+oUa
+oUa
+oUa
+oUa
+oUa
+oUa
+oUa
+oUa
+oUa
+oUa
+oUa
+oUa
+oUa
+cCr
 rON
 djI
 vKt
@@ -59733,21 +59971,21 @@ hKk
 psc
 xQI
 dLY
-dLY
-dLY
-dLY
-dLY
-dLY
-uYC
-psc
-eil
-eil
-sXi
-dLY
-sHT
-dLY
-hRS
-dLY
+rGW
+oUa
+oUa
+oUa
+oUa
+oUa
+oUa
+oUa
+oUa
+oUa
+oUa
+oUa
+oUa
+oUa
+cCr
 jik
 jik
 rON
@@ -59960,22 +60198,22 @@ cCr
 lLO
 eil
 sXi
-dLY
-dLY
-fSX
-fSX
-dLY
-dLY
-lLO
-hZn
-eil
-eil
-dNN
-dLY
-dLY
-dLY
-dLY
-dLY
+okA
+oVO
+oUa
+oUa
+oUa
+oUa
+oUa
+oUa
+oUa
+oUa
+oUa
+oUa
+oUa
+oUa
+oUa
+cCr
 jik
 jik
 jik
@@ -60188,23 +60426,23 @@ cCr
 dLY
 xDR
 sXi
-dLY
-dLY
-dLY
-dLY
-dLY
-lxX
+rGW
+oUa
+oUa
+oUa
+oUa
+oUa
 jik
-dLY
-lLO
-dNN
-dLY
-hRS
-dLY
-dLY
-dLY
-fED
-dLY
+oUa
+oUa
+oUa
+oUa
+oUa
+oUa
+oUa
+oUa
+vPV
+fqh
 vKt
 jik
 jik
@@ -60416,23 +60654,23 @@ cCr
 dLY
 xDR
 sXi
-dLY
-eCx
-dLY
-hRS
-dLY
-dLY
-dLY
-dLY
-lxX
-dLY
-dLY
+lxp
+tgw
+vOD
+azB
+oUa
+kGk
+vOD
+azB
+oUa
+oUa
+oUa
 jik
 jik
-bMu
-bMu
-bMu
-fqh
+jik
+vOD
+vOD
+iab
 hmK
 xVk
 dLY
@@ -60646,21 +60884,21 @@ lbX
 dNN
 dLY
 fSX
+hRS
+rGW
+oUa
+crC
 dLY
-dLY
-dLY
-kNm
-dLY
-dLY
-dLY
+lxp
+vOD
+jik
+vOD
+iab
 jik
 dLY
 dLY
-jik
-oUa
-oUa
-oUa
-cCr
+dLY
+dLY
 dLY
 dLY
 dLY
@@ -60668,8 +60906,8 @@ dLY
 djI
 jik
 crF
-dLY
-dZY
+rDv
+tUH
 dZY
 fbD
 xVk
@@ -60875,8 +61113,8 @@ fSX
 dLY
 dLY
 dLY
-dLY
-dLY
+lxp
+vOD
 jik
 dLY
 fED
@@ -60886,18 +61124,18 @@ jik
 kNm
 jik
 jik
-oUa
-oUa
-cCr
+dLY
+dLY
+dLY
 jik
 dLY
 kNm
 dLY
 jik
-dLY
-dLY
-djI
-dZY
+oUa
+oUa
+jCJ
+hEJ
 jik
 jik
 vWs
@@ -61121,11 +61359,11 @@ jik
 jik
 dLY
 dLY
-hRS
-dLY
-dLY
-djI
-djI
+usp
+oUa
+oUa
+jCJ
+mrX
 djI
 uVU
 jik


### PR DESCRIPTION

# About the pull request

This PR updates the telecomms around the map. There is a guaranteed telecomms spawn in the Tcomms area of the map. Additionally, the west and east bank rivers have had their areas altered to make them easier to siege for xenos. 

# Explain why it's good for the game

Xenos can finally weed the tcomms units and properly siege them, and the extremely enclosed tcomms units have been opened up to make them less claustrophobic. Done at the request of @morrowwolf. 

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/cmss13-devs/cmss13/assets/133173804/9743d88c-2be3-48a0-b989-eef6dc6d96bd)

![image](https://github.com/cmss13-devs/cmss13/assets/133173804/f846f90f-e142-4037-b832-f1552d9f8cf1)

![image](https://github.com/cmss13-devs/cmss13/assets/133173804/e9581e81-b4a8-4ede-a6c0-7b5952e9de8c)


</details>


# Changelog

:cl:
balance: Comms areas around the east/west rivers expanded for easier sieges and weedable now.
maptweak: LV Comms now always spawn in Tcomms and one either on the east or west river
/:cl:
