### PR TITLE
Adds the ability to put Folding Sheilds in the IMP ammo rack

### DIFF
--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -401,11 +401,11 @@
 
 /obj/item/storage/backpack/marine/ammo_rack
 	name = "\improper IMP ammo rack"
-	desc = "A bare IMP frame with buckles designed to hold multiple ammo cans, but can fit any cumbersome box thanks to Marine ingenuity. Helps you lug around extra rounds or supplies."
+	desc = "A bare IMP frame with buckles designed to hold multiple ammo cans and a sheild or two, but can fit any cumbersome box thanks to Marine ingenuity. Helps you lug around extra rounds or supplies."
 	has_gamemode_skin = FALSE
 	storage_slots = 3
 	icon_state = "ammo_pack_0"
-	can_hold = list(/obj/item/ammo_box)
+	can_hold = list(/obj/item/ammo_box, /obj/item/stack/folding_barricade)
 	max_w_class = SIZE_MASSIVE
 	throw_range = 0
 	xeno_types = null

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -401,7 +401,7 @@
 
 /obj/item/storage/backpack/marine/ammo_rack
 	name = "\improper IMP ammo rack"
-	desc = "A bare IMP frame with buckles designed to hold multiple ammo cans and a sheild or two, but can fit any cumbersome box thanks to Marine ingenuity. Helps you lug around extra rounds or supplies."
+	desc = "A bare IMP frame with buckles designed to hold multiple ammo cans, but can fit any cumbersome box thanks to Marine ingenuity. Helps you lug around extra rounds or supplies."
 	has_gamemode_skin = FALSE
 	storage_slots = 3
 	icon_state = "ammo_pack_0"


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. --> Adds the folding shield to the ammo rack to give it a bit more of a use, also seemed wanted 
![Discord_ksdl2muR76](https://github.com/cmss13-devs/cmss13/assets/30062054/3905c481-18c4-41e5-b6bb-e0fee693c9e0)

# Explain why it's good for the game
It Gives a bit more use of the IMP ammo rack, and is just a cool feature in general, more utility for a under used item!
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/cmss13-devs/cmss13/assets/30062054/1cb3335f-8f08-47ed-943e-ad9bbe74e946)

</details>


# Changelog
:cl:
add: Added the ability for the IMP Ammo Rack to hold folding barricades.

/:cl:
