### PR TITLE
Almayer: Dirty Up The Ship (Revival)

### DIFF
--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -2365,6 +2365,22 @@
 	icon_state = "mono"
 	},
 /area/almayer/lifeboat_pumps/north2)
+"ahA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	dir = 1;
+	icon_state = "lattice-simple";
+	pixel_x = -15;
+	pixel_y = 6
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_f_s)
 "ahB" = (
 /obj/structure/platform{
 	dir = 8
@@ -4200,6 +4216,11 @@
 /obj/item/tool/pen,
 /turf/open/floor/almayer,
 /area/almayer/lifeboat_pumps/north1)
+"anN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_f_s)
 "anO" = (
 /turf/open/floor/almayer{
 	dir = 8;
@@ -4270,6 +4291,13 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/weapon_room)
+"aob" = (
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/decal/cleanable/blood/tracks,
+/turf/open/shuttle/escapepod{
+	icon_state = "floor1"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "aoc" = (
 /obj/structure/stairs{
 	dir = 1
@@ -7871,6 +7899,13 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/powered)
+"ayp" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_p)
 "ayq" = (
 /obj/structure/surface/table/reinforced/almayer_B,
 /obj/structure/machinery/prop/almayer/CICmap,
@@ -8539,6 +8574,20 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/command/cic)
+"aAp" = (
+/obj/structure/surface/rack,
+/obj/structure/prop/invuln{
+	icon = 'icons/obj/items/weapons/guns/ammo_by_faction/event.dmi';
+	icon_state = "quad_rocket";
+	name = "IX-50 Anti-Air Rocket Ammo";
+	desc = "Self-guided anti-air rockets intended for use with the IX-50";
+	density = 0
+	},
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/weapon_room)
 "aAq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -9230,6 +9279,18 @@
 	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/upper_medical)
+"aCs" = (
+/obj/item/tool/warning_cone{
+	pixel_x = 13;
+	pixel_y = 15
+	},
+/obj/item/tool/warning_cone{
+	pixel_x = -12;
+	pixel_y = 16
+	},
+/obj/effect/decal/strata_decals/grime/grime4,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_s)
 "aCt" = (
 /obj/structure/bed/sofa/south/white/right,
 /turf/open/floor/almayer{
@@ -10572,6 +10633,14 @@
 	icon_state = "red"
 	},
 /area/almayer/lifeboat_pumps/north1)
+"aIu" = (
+/obj/structure/sign/safety/hvac_old{
+	pixel_x = 8;
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_f_s)
 "aIv" = (
 /obj/structure/platform_decoration{
 	dir = 8
@@ -11242,7 +11311,16 @@
 /obj/structure/machinery/light/small{
 	dir = 1
 	},
-/turf/open/floor/plating/plating_catwalk,
+/obj/structure/prop/invuln/overhead/flammable_pipe/fly{
+	dir = 8;
+	pixel_x = 6;
+	pixel_y = 7;
+	layer = 4
+	},
+/turf/open/floor/plating{
+	dir = 8;
+	icon_state = "platingdmg3"
+	},
 /area/almayer/hull/lower_hull/l_m_s)
 "aLd" = (
 /turf/closed/wall/almayer,
@@ -11259,6 +11337,12 @@
 "aLl" = (
 /obj/structure/machinery/light/small{
 	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/lattice_prop{
+	dir = 1;
+	icon_state = "lattice-simple";
+	pixel_x = -14
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_f_s)
@@ -11472,6 +11556,11 @@
 	pixel_x = 8;
 	pixel_y = -32
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/ice_colony/ground_wire{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/liquid_fuel,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_m_s)
 "aMt" = (
@@ -11754,6 +11843,17 @@
 	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/containment)
+"aOc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/largecrate/random/barrel/green{
+	pixel_x = 2;
+	pixel_y = 11;
+	layer = 3.1
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_f_p)
 "aOd" = (
 /turf/open/floor/almayer{
 	dir = 5;
@@ -11924,10 +12024,34 @@
 	pixel_x = 15;
 	pixel_y = 32
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/cigbutt{
+	pixel_x = -12;
+	pixel_y = 17
+	},
+/obj/item/trash/cigbutt{
+	icon_state = "ucigbutt";
+	pixel_x = 2;
+	pixel_y = 8
+	},
+/obj/item/trash/cigbutt{
+	pixel_x = -7;
+	pixel_y = 13
+	},
+/obj/effect/decal/strata_decals/grime/grime1,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
 /area/almayer/shipboard/starboard_point_defense)
+"aOO" = (
+/obj/structure/machinery/door/poddoor/almayer/open{
+	id = "Hangar Lockdown";
+	name = "\improper Hangar Lockdown Blast Door"
+	},
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/hallways/hangar)
 "aOP" = (
 /obj/structure/machinery/camera/autoname/almayer{
 	name = "ship-grade camera"
@@ -12351,6 +12475,16 @@
 	icon_state = "mono"
 	},
 /area/almayer/medical/hydroponics)
+"aRb" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "W"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/grille,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_f_s)
 "aRd" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/structure/machinery/door/window/westright,
@@ -12435,8 +12569,11 @@
 	},
 /area/almayer/command/cic)
 "aRu" = (
-/obj/structure/foamed_metal,
-/turf/open/floor/plating,
+/obj/structure/surface/table/almayer,
+/obj/structure/prop/mech/hydralic_clamp,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
 /area/almayer/hallways/hangar)
 "aRv" = (
 /obj/structure/machinery/light{
@@ -13333,6 +13470,10 @@
 	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering/starboard)
+"aVD" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/port_point_defense)
 "aVF" = (
 /obj/structure/closet/secure_closet/engineering_electrical,
 /obj/structure/machinery/light/small,
@@ -13701,6 +13842,23 @@
 	icon_state = "plate"
 	},
 /area/almayer/hallways/hangar)
+"aXq" = (
+/obj/structure/closet/crate/trashcart{
+	opened = 1
+	},
+/obj/item/prop/helmetgarb/helmet_nvg/cosmetic{
+	pixel_x = 9;
+	pixel_y = -9
+	},
+/obj/item/prop/helmetgarb/helmet_nvg/cosmetic{
+	pixel_y = 4;
+	pixel_x = -6
+	},
+/obj/effect/decal/cleanable/cobweb2,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "aXx" = (
 /obj/structure/machinery/cryopod{
 	pixel_y = 6
@@ -13760,6 +13918,7 @@
 /obj/structure/machinery/power/apc/almayer{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -14481,6 +14640,15 @@
 /area/almayer/living/cryo_cells)
 "bbv" = (
 /obj/structure/largecrate/random/barrel/blue,
+/obj/structure/prop/invuln/overhead_pipe{
+	pixel_x = 6
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	dir = 1;
+	icon_state = "lattice-simple";
+	pixel_x = 10
+	},
+/obj/effect/decal/cleanable/cobweb2,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -14582,6 +14750,7 @@
 	},
 /area/almayer/hull/upper_hull/u_f_p)
 "bbS" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/starboard_point_defense)
 "bbU" = (
@@ -14719,6 +14888,12 @@
 	icon_state = "plate"
 	},
 /area/almayer/hallways/hangar)
+"bcy" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/tool/wet_sign,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_p)
 "bcz" = (
 /turf/open/floor/almayer{
 	dir = 1;
@@ -14892,6 +15067,7 @@
 	icon_state = "E";
 	pixel_x = 1
 	},
+/obj/structure/largecrate/random/barrel/green,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -15190,6 +15366,10 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
+/obj/structure/prop/invuln/overhead_pipe{
+	pixel_x = 12
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -15205,6 +15385,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_m_s)
 "beO" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	dir = 5;
 	icon_state = "orange"
@@ -15477,6 +15658,7 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_f_p)
 "bgj" = (
@@ -15634,6 +15816,10 @@
 	},
 /area/almayer/medical/operating_room_one)
 "bgF" = (
+/obj/structure/prop/invuln/overhead_pipe{
+	pixel_x = 12
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	dir = 8;
 	icon_state = "orange"
@@ -15644,6 +15830,7 @@
 /turf/open/floor/plating,
 /area/almayer/medical/chemistry)
 "bgH" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	dir = 4;
 	icon_state = "orange"
@@ -15705,6 +15892,25 @@
 	icon_state = "red"
 	},
 /area/almayer/squads/alpha)
+"bhe" = (
+/obj/structure/sign/safety/hvac_old{
+	pixel_x = 8;
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/obj/effect/decal/cleanable/blood/oil/streak,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "bhf" = (
 /obj/structure/machinery/light{
 	dir = 4
@@ -16399,6 +16605,22 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/engineering/upper_engineering/starboard)
+"blX" = (
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice10";
+	pixel_x = 15;
+	pixel_y = 11
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 9;
+	pixel_y = 7
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_p)
 "blZ" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/structure/machinery/computer/med_data/laptop,
@@ -16880,6 +17102,18 @@
 	pixel_y = 12
 	},
 /obj/structure/largecrate/random/secure,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/overhead/flammable_pipe/fly{
+	dir = 8;
+	pixel_x = -2;
+	pixel_y = 12;
+	layer = 4
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice3";
+	pixel_x = 15;
+	pixel_y = -6
+	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -17587,7 +17821,8 @@
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
 	},
-/turf/open/floor/plating/plating_catwalk,
+/obj/structure/platform,
+/turf/open/floor/plating,
 /area/almayer/hull/lower_hull/l_a_p)
 "brY" = (
 /obj/structure/pipes/vents/pump,
@@ -18301,6 +18536,11 @@
 /area/almayer/engineering/engineering_workshop)
 "bvO" = (
 /obj/structure/largecrate/random/barrel/white,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -18463,14 +18703,39 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer,
 /area/almayer/hallways/hangar)
+"bwp" = (
+/obj/structure/prop/invuln/lattice_prop{
+	dir = 1;
+	icon_state = "lattice-simple";
+	pixel_x = -16;
+	pixel_y = -16
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_p)
 "bwF" = (
 /obj/structure/machinery/light/small{
 	dir = 1
 	},
-/obj/structure/largecrate/random/case/double,
-/turf/open/floor/almayer{
-	icon_state = "plate"
+/obj/effect/decal/warning_stripes{
+	icon_state = "E"
 	},
+/obj/item/device/flashlight{
+	pixel_x = -8;
+	pixel_y = -9
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7;
+	pixel_x = -9
+	},
+/turf/open/floor/plating,
 /area/almayer/hull/lower_hull/l_f_s)
 "bwH" = (
 /obj/structure/surface/table/reinforced/prison,
@@ -18482,6 +18747,21 @@
 	icon_state = "sterile_green_corner"
 	},
 /area/almayer/medical/lower_medical_medbay)
+"bwN" = (
+/obj/structure/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/obj/structure/prop/invuln/overhead_pipe{
+	pixel_x = 6;
+	pixel_y = 12
+	},
+/obj/effect/decal/strata_decals/grime/grime3,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_p)
 "bwQ" = (
 /obj/structure/machinery/light{
 	dir = 4
@@ -19026,8 +19306,14 @@
 /area/almayer/hull/upper_hull/u_m_s)
 "bzF" = (
 /obj/effect/landmark/yautja_teleport,
-/turf/open/floor/almayer{
-	icon_state = "plate"
+/obj/effect/decal/cleanable/dirt,
+/obj/item/tool/warning_cone{
+	layer = 3.6;
+	pixel_x = -16;
+	pixel_y = -9
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
 	},
 /area/almayer/hull/lower_hull/l_m_s)
 "bzG" = (
@@ -19220,6 +19506,19 @@
 	icon_state = "red"
 	},
 /area/almayer/lifeboat_pumps/south1)
+"bAI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/obj/item/trash/burger,
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 5;
+	pixel_y = 7
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_p)
 "bAJ" = (
 /obj/structure/sign/safety/terminal{
 	pixel_x = -17
@@ -19437,6 +19736,14 @@
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/cigbutt{
+	pixel_x = -7;
+	pixel_y = 13
+	},
+/obj/effect/decal/strata_decals/grime/grime1{
+	dir = 8
+	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/engineering/lower_engineering)
 "bBq" = (
@@ -19446,12 +19753,37 @@
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 1
 	},
+/obj/item/trash/cigbutt{
+	pixel_x = 4
+	},
+/obj/item/trash/cigbutt{
+	pixel_x = 1;
+	pixel_y = 8
+	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
 /area/almayer/engineering/lower_engineering)
 "bBu" = (
 /obj/structure/surface/rack,
+/obj/structure/prop/invuln{
+	icon = 'icons/obj/items/weapons/guns/ammo_by_faction/event.dmi';
+	icon_state = "quad_rocket";
+	name = "IX-50 Anti-Air Rocket Ammo";
+	desc = "Self-guided anti-air rockets intended for use with the IX-50";
+	pixel_x = -4;
+	pixel_y = -7;
+	density = 0
+	},
+/obj/structure/prop/invuln{
+	icon = 'icons/obj/items/weapons/guns/ammo_by_faction/event.dmi';
+	icon_state = "quad_rocket";
+	name = "IX-50 Anti-Air Rocket Ammo";
+	desc = "Self-guided anti-air rockets intended for use with the IX-50";
+	pixel_x = 3;
+	pixel_y = 2;
+	density = 0
+	},
 /turf/open/floor/almayer{
 	dir = 1;
 	icon_state = "red"
@@ -19783,6 +20115,7 @@
 /area/almayer/squads/alpha)
 "bCQ" = (
 /obj/structure/machinery/light/small,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -19885,6 +20218,14 @@
 /obj/structure/largecrate/random/case/double,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/hangar)
+"bDJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/grille,
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_s)
 "bDL" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/almayer{
 	dir = 1;
@@ -20724,14 +21065,6 @@
 "bGQ" = (
 /obj/structure/machinery/status_display{
 	pixel_y = 30
-	},
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/hallways/hangar)
-"bGR" = (
-/obj/structure/machinery/cm_vending/sorted/medical/wall_med{
-	pixel_y = 25
 	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
@@ -22204,6 +22537,27 @@
 	icon_state = "plating"
 	},
 /area/almayer/hull/lower_hull/l_a_s)
+"bMZ" = (
+/obj/structure/closet/crate/trashcart{
+	opened = 1
+	},
+/obj/item/ammo_magazine/rifle/l42a/heap{
+	current_rounds = 0
+	},
+/obj/item/ammo_magazine/rifle/l42a/heap{
+	current_rounds = 0;
+	pixel_y = 9;
+	pixel_x = 9
+	},
+/obj/item/ammo_magazine/rifle/l42a/heap{
+	current_rounds = 0;
+	pixel_y = 4;
+	pixel_x = -9
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "bNa" = (
 /obj/structure/surface/table/almayer,
 /obj/item/folder/black,
@@ -22355,6 +22709,7 @@
 /obj/item/frame/table,
 /obj/item/frame/table,
 /obj/item/frame/table,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "cargo"
 	},
@@ -22612,6 +22967,13 @@
 	icon_state = "orange"
 	},
 /area/almayer/hallways/hangar)
+"bOD" = (
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_f_s)
 "bOG" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -23283,6 +23645,23 @@
 /obj/structure/machinery/light,
 /turf/open/floor/almayer,
 /area/almayer/hallways/vehiclehangar)
+"bRy" = (
+/obj/structure/prop/invuln/overhead_pipe{
+	pixel_x = 6;
+	pixel_y = 12
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	dir = 1;
+	icon_state = "lattice-simple";
+	pixel_x = 10
+	},
+/obj/effect/decal/strata_decals/grime/grime2{
+	dir = 1
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_s)
 "bRz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -23780,6 +24159,7 @@
 /area/almayer/shipboard/port_point_defense)
 "bTQ" = (
 /obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -23860,7 +24240,18 @@
 	},
 /area/almayer/living/briefing)
 "bUc" = (
-/obj/structure/foamed_metal,
+/obj/structure/cable{
+	icon_state = "1-4";
+	pixel_x = -12
+	},
+/obj/structure/sign/poster/blacklight{
+	pixel_x = -2;
+	pixel_y = -25
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice3";
+	pixel_x = -11
+	},
 /turf/open/floor/plating,
 /area/almayer/hull/lower_hull/l_m_s)
 "bUd" = (
@@ -23903,6 +24294,14 @@
 	icon_state = "blue"
 	},
 /area/almayer/squads/charlie_delta_shared)
+"bUj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/obj/item/trash/uscm_mre,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_s)
 "bUo" = (
 /obj/structure/closet/secure_closet/guncabinet/red,
 /obj/item/weapon/gun/shotgun/combat,
@@ -24054,13 +24453,15 @@
 /area/almayer/squads/delta)
 "bUO" = (
 /obj/structure/machinery/portable_atmospherics/canister/air,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
 /area/almayer/shipboard/port_point_defense)
 "bUP" = (
 /obj/structure/machinery/door/airlock/almayer/maint{
-	dir = 1
+	dir = 1;
+	name = "\improper Ammo Storage"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/pipes/standard/simple/hidden/supply,
@@ -24156,6 +24557,16 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
+/obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -24192,6 +24603,7 @@
 	req_one_access_txt = "2;3;12;19";
 	throw_range = 15
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -24274,6 +24686,7 @@
 /obj/structure/ob_ammo/ob_fuel,
 /obj/structure/ob_ammo/ob_fuel,
 /obj/structure/ob_ammo/ob_fuel,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -24304,6 +24717,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/overhead/flammable_pipe/fly{
+	dir = 8;
+	pixel_x = -2;
+	pixel_y = 12;
+	layer = 4
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_a_p)
@@ -25360,6 +25780,7 @@
 	dir = 4
 	},
 /obj/structure/machinery/door/firedoor/border_only/almayer,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
 	},
@@ -25373,6 +25794,20 @@
 	icon_state = "red"
 	},
 /area/almayer/hallways/aft_hallway)
+"caI" = (
+/obj/structure/prop/invuln/overhead_pipe{
+	pixel_x = 12
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = -9
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = -5
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_s)
 "caM" = (
 /obj/structure/largecrate/random/barrel/blue,
 /turf/open/floor/almayer{
@@ -25426,6 +25861,10 @@
 	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/operating_room_three)
+"cba" = (
+/obj/effect/decal/strata_decals/grime/grime3,
+/turf/open/floor/plating,
+/area/almayer/hull/lower_hull/l_m_p)
 "cbg" = (
 /obj/structure/machinery/door/airlock/almayer/command{
 	dir = 2;
@@ -25550,6 +25989,7 @@
 	icon_state = "N";
 	pixel_y = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -26184,8 +26624,16 @@
 /obj/effect/spawner/random/toolbox,
 /obj/effect/spawner/random/toolbox,
 /obj/effect/spawner/random/tool,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_a_p)
+"cef" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/girder/displaced,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_s)
 "ceg" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -26460,6 +26908,22 @@
 	icon_state = "plate"
 	},
 /area/almayer/squads/charlie)
+"cgw" = (
+/obj/item/tool/warning_cone{
+	pixel_x = -8;
+	pixel_y = 8
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	pixel_x = 6;
+	pixel_y = 12
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	dir = 1;
+	icon_state = "lattice-simple";
+	pixel_x = 10
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_s)
 "cgy" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -27138,6 +27602,16 @@
 	icon_state = "silver"
 	},
 /area/almayer/engineering/port_atmos)
+"ckO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/ice_colony/ground_wire{
+	dir = 4
+	},
+/obj/effect/decal/strata_decals/grime/grime1,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "ckP" = (
 /obj/structure/surface/table/almayer,
 /turf/open/floor/almayer{
@@ -27448,6 +27922,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spider/stickyweb{
+	icon_state = "stickyweb2"
+	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -27460,6 +27938,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spider/stickyweb,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -27995,6 +28475,7 @@
 /obj/structure/surface/table/almayer,
 /obj/effect/spawner/random/tool,
 /obj/item/storage/firstaid/regular,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -28033,6 +28514,7 @@
 /obj/structure/machinery/alarm/almayer{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/port_point_defense)
 "cpp" = (
@@ -28130,6 +28612,19 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/shipboard/starboard_missiles)
+"cqT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln{
+	desc = "non functional set of snowplowers for tanks";
+	icon = 'icons/obj/vehicles/hardpoints/tank.dmi';
+	icon_state = "snowplow";
+	name = "Bleihagel RE-RE700 Frontal Cannon";
+	density = 0;
+	pixel_x = -2;
+	layer = 3
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hallways/hangar)
 "cqY" = (
 /obj/structure/surface/table/reinforced/almayer_B,
 /obj/item/storage/fancy/cigar/tarbacktube,
@@ -28166,6 +28661,18 @@
 	icon_state = "greencorner"
 	},
 /area/almayer/squads/req)
+"crE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/tool/wet_sign,
+/obj/structure/prop/invuln/lattice_prop{
+	dir = 1;
+	icon_state = "lattice-simple";
+	pixel_x = -14
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_f_s)
 "crP" = (
 /obj/item/tool/kitchen/utensil/pfork,
 /turf/open/floor/almayer{
@@ -28178,6 +28685,12 @@
 	icon_state = "plate"
 	},
 /area/almayer/hallways/starboard_hallway)
+"csc" = (
+/obj/item/tool/crowbar,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_p)
 "csl" = (
 /obj/structure/pipes/vents/scrubber,
 /turf/open/floor/almayer{
@@ -28209,6 +28722,19 @@
 	icon_state = "red"
 	},
 /area/almayer/lifeboat_pumps/south1)
+"csO" = (
+/obj/item/tool/crowbar,
+/obj/item/tool/warning_cone{
+	pixel_x = -20;
+	pixel_y = 18
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_p)
+"csX" = (
+/obj/item/tool/wrench,
+/obj/effect/decal/cleanable/liquid_fuel,
+/turf/open/floor/plating,
+/area/almayer/hull/lower_hull/l_m_s)
 "csZ" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -28292,6 +28818,28 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/shipboard/brig/cryo)
+"cul" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/tool/warning_cone{
+	pixel_x = 4;
+	pixel_y = 14
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	pixel_x = 6;
+	pixel_y = 12
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice5";
+	pixel_x = 10
+	},
+/obj/effect/decal/strata_decals/grime/grime2{
+	dir = 8
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_s)
 "cus" = (
 /obj/docking_port/stationary/lifeboat_dock/starboard,
 /turf/open/floor/almayer_hull{
@@ -28313,6 +28861,13 @@
 "cuC" = (
 /turf/closed/wall/almayer/outer,
 /area/almayer/engineering/upper_engineering/starboard)
+"cuN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/tool/wet_sign,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_p)
 "cuY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -28423,6 +28978,37 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/shipboard/brig/main_office)
+"cxL" = (
+/obj/effect/decal/cleanable/liquid_fuel,
+/obj/item/tool/warning_cone{
+	pixel_x = 4;
+	pixel_y = 14
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_s)
+"cxY" = (
+/obj/structure/platform{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/pipes/standard/manifold/hidden/supply{
+	dir = 1
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hallways/hangar)
+"cya" = (
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_p)
 "cyo" = (
 /obj/structure/machinery/vending/cigarette,
 /turf/open/floor/almayer{
@@ -28430,6 +29016,14 @@
 	icon_state = "green"
 	},
 /area/almayer/squads/req)
+"cyB" = (
+/obj/structure/sign/safety/hvac_old{
+	pixel_x = 8;
+	pixel_y = -32
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_f_p)
 "cyE" = (
 /obj/structure/platform_decoration{
 	dir = 8
@@ -28510,10 +29104,17 @@
 	},
 /area/almayer/medical/lower_medical_lobby)
 "cAH" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
 /area/almayer/hull/lower_hull/l_a_p)
+"cAJ" = (
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "cBb" = (
 /obj/structure/machinery/light{
 	dir = 1
@@ -28662,12 +29263,13 @@
 	},
 /area/almayer/hallways/hangar)
 "cDe" = (
-/obj/structure/largecrate/random/barrel/white,
 /obj/structure/sign/safety/storage{
 	pixel_x = -17
 	},
-/turf/open/floor/almayer{
-	icon_state = "plate"
+/obj/structure/platform,
+/obj/effect/decal/cleanable/blood/oil/streak,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
 	},
 /area/almayer/hull/lower_hull/l_m_s)
 "cDj" = (
@@ -28806,6 +29408,7 @@
 /obj/structure/largecrate/supply/ammo/pistol/half{
 	pixel_y = 12
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_f_p)
 "cFh" = (
@@ -28925,10 +29528,6 @@
 	},
 /obj/structure/bed/chair{
 	dir = 1
-	},
-/obj/structure/sign/safety/distribution_pipes{
-	pixel_x = 8;
-	pixel_y = -32
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_f_s)
@@ -29057,6 +29656,17 @@
 	pixel_x = 8;
 	pixel_y = 32
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/overhead/flammable_pipe/fly{
+	dir = 5;
+	pixel_x = 2;
+	pixel_y = 12;
+	layer = 4
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -29134,6 +29744,37 @@
 	icon_state = "cargo"
 	},
 /area/almayer/living/bridgebunks)
+"cLZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_s)
+"cMk" = (
+/obj/structure/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/surface/rack,
+/obj/structure/prop/invuln{
+	icon = 'icons/obj/items/weapons/guns/ammo_by_faction/event.dmi';
+	icon_state = "quad_rocket";
+	name = "IX-50 Anti-Air Rocket Ammo";
+	desc = "Self-guided anti-air rockets intended for use with the IX-50";
+	pixel_x = 3;
+	pixel_y = 2;
+	density = 0
+	},
+/obj/structure/prop/invuln{
+	icon = 'icons/obj/items/weapons/guns/ammo_by_faction/event.dmi';
+	icon_state = "quad_rocket";
+	name = "IX-50 Anti-Air Rocket Ammo";
+	desc = "Self-guided anti-air rockets intended for use with the IX-50";
+	pixel_x = -4;
+	pixel_y = -7;
+	density = 0
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_f_s)
 "cMl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -29205,6 +29846,22 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/medical/containment/cell/cl)
+"cNM" = (
+/obj/structure/sign/safety/hvac_old{
+	pixel_x = 8;
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_s)
 "cNX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -29261,6 +29918,17 @@
 	icon_state = "silver"
 	},
 /area/almayer/command/cichallway)
+"cPF" = (
+/obj/item/trash/used_stasis_bag,
+/obj/item/trash/used_stasis_bag{
+	pixel_x = -11;
+	pixel_y = 12
+	},
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_s)
 "cQc" = (
 /turf/open/floor/almayer{
 	dir = 1;
@@ -29303,6 +29971,7 @@
 	icon_state = "N";
 	pixel_y = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -29349,6 +30018,20 @@
 	},
 /turf/open/floor/wood/ship,
 /area/almayer/living/basketball)
+"cRV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_p)
 "cSk" = (
 /obj/structure/machinery/door/window/southleft,
 /turf/open/floor/almayer{
@@ -29650,6 +30333,15 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/upper_hull/u_f_s)
+"cYa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/lattice_prop{
+	dir = 1;
+	icon_state = "lattice-simple";
+	pixel_x = -14
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_f_s)
 "cYu" = (
 /obj/structure/pipes/vents/pump{
 	dir = 1
@@ -29700,6 +30392,14 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/engineering/engine_core)
+"cZM" = (
+/obj/structure/machinery/light/small,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spider/stickyweb,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_p)
 "cZV" = (
 /obj/structure/surface/table/reinforced/almayer_B,
 /obj/item/storage/fancy/cigarettes/wypacket,
@@ -29759,6 +30459,18 @@
 "daz" = (
 /turf/closed/wall/almayer/white/hull,
 /area/almayer/command/airoom)
+"daP" = (
+/obj/structure/prop/invuln/overhead/flammable_pipe/fly{
+	dir = 8;
+	pixel_x = -2;
+	pixel_y = 13;
+	layer = 4
+	},
+/obj/effect/decal/cleanable/blood/oil/streak,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_p)
 "dbe" = (
 /obj/structure/largecrate/random/case/double,
 /obj/structure/machinery/camera/autoname/almayer{
@@ -29791,6 +30503,11 @@
 	icon_state = "plating_striped"
 	},
 /area/almayer/engineering/upper_engineering/port)
+"dbs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/oil/streak,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hallways/hangar)
 "dbv" = (
 /obj/structure/surface/table/reinforced/almayer_B,
 /obj/structure/machinery/prop/almayer/computer{
@@ -29828,6 +30545,10 @@
 	icon_state = "plate"
 	},
 /area/almayer/engineering/upper_engineering/starboard)
+"dbP" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_s)
 "dcd" = (
 /obj/structure/bed/chair/comfy{
 	dir = 8
@@ -29852,6 +30573,10 @@
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/lifeboat_pumps/south2)
+"dcC" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/almayer/hull/lower_hull/l_m_p)
 "dcP" = (
 /obj/structure/machinery/body_scanconsole{
 	dir = 8
@@ -29872,6 +30597,10 @@
 /obj/structure/prop/invuln/overhead_pipe{
 	dir = 4;
 	pixel_y = 13
+	},
+/obj/structure/grille{
+	icon_state = "brokengrille";
+	density = 0
 	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
@@ -29898,8 +30627,32 @@
 	pixel_x = 8;
 	pixel_y = 32
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 5;
+	pixel_y = 7
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_m_p)
+"ddI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/overhead/flammable_pipe/fly{
+	dir = 8;
+	pixel_x = -2;
+	pixel_y = 13;
+	layer = 4
+	},
+/obj/structure/prop/ice_colony/ground_wire{
+	dir = 8
+	},
+/obj/item/tool/weldingtool,
+/obj/effect/decal/cleanable/liquid_fuel,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_s)
 "ddK" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "SE-out";
@@ -29997,6 +30750,13 @@
 	icon_state = "green"
 	},
 /area/almayer/living/grunt_rnr)
+"dfF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/broken_arcade,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_p)
 "dfO" = (
 /obj/structure/machinery/medical_pod/bodyscanner{
 	dir = 8
@@ -30041,10 +30801,32 @@
 	},
 /obj/item/tool/shovel/etool,
 /obj/item/tool/wirecutters,
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
 /area/almayer/hull/lower_hull/l_m_s)
+"dhk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_x = -8
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_f_s)
 "dhQ" = (
 /obj/structure/sign/safety/terminal{
 	pixel_x = -17
@@ -30170,6 +30952,11 @@
 	icon_state = "cargo"
 	},
 /area/almayer/engineering/engineering_workshop/hangar)
+"djC" = (
+/turf/closed/shuttle/escapepod{
+	icon_state = "wall1"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "djL" = (
 /obj/structure/machinery/light{
 	dir = 4
@@ -30203,10 +30990,24 @@
 	pixel_x = 32;
 	pixel_y = 7
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
 /area/almayer/shipboard/starboard_point_defense)
+"djX" = (
+/obj/item/stack/tile/plasteel{
+	pixel_x = 4;
+	pixel_y = -6
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/ice_colony/ground_wire{
+	dir = 4
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "dka" = (
 /obj/structure/machinery/optable,
 /turf/open/floor/almayer{
@@ -30354,6 +31155,25 @@
 	icon_state = "plate"
 	},
 /area/almayer/hull/upper_hull/u_a_p)
+"dnl" = (
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
+/obj/structure/platform{
+	dir = 8;
+	layer = 2.7
+	},
+/obj/structure/platform{
+	dir = 4;
+	layer = 2.7
+	},
+/obj/structure/prop/invuln/overhead/flammable_pipe/fly{
+	icon_state = "flammable_pipe_2";
+	layer = 4
+	},
+/turf/open/floor/plating,
+/area/almayer/hull/lower_hull/l_f_s)
 "dnm" = (
 /obj/structure/machinery/cm_vending/sorted/cargo_guns/intelligence_officer,
 /obj/structure/machinery/light{
@@ -30406,6 +31226,17 @@
 	icon_state = "silver"
 	},
 /area/almayer/command/securestorage)
+"dnW" = (
+/obj/structure/sign/safety/hvac_old{
+	pixel_x = 8;
+	pixel_y = -32
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_p)
 "dnX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -30416,6 +31247,13 @@
 /obj/structure/closet/crate/trashcart,
 /turf/open/floor/almayer,
 /area/almayer/engineering/upper_engineering/port)
+"doe" = (
+/obj/structure/platform{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/oil/streak,
+/turf/open/floor/plating,
+/area/almayer/hull/lower_hull/l_m_s)
 "dof" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/engidoor{
 	name = "\improper Upper Engineering"
@@ -30487,6 +31325,19 @@
 /obj/structure/bed/chair{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_f_s)
+"dpH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/hotdog{
+	pixel_x = -1;
+	pixel_y = -7
+	},
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/strata_decals/grime/grime3,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -30668,6 +31519,25 @@
 	icon_state = "plate"
 	},
 /area/almayer/shipboard/brig/cryo)
+"dsE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = -9
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = -5
+	},
+/obj/effect/decal/cleanable/blood/oil/streak,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_s)
+"dta" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_s)
 "dtH" = (
 /obj/structure/bed/chair/comfy{
 	dir = 8
@@ -30811,6 +31681,12 @@
 	icon_state = "cargo"
 	},
 /area/almayer/living/cryo_cells)
+"dvu" = (
+/obj/item/vehicle_clamp,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_s)
 "dvF" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/computer/cameras/wooden_tv/ot{
@@ -31050,6 +31926,22 @@
 	icon_state = "cargo"
 	},
 /area/almayer/command/cic)
+"dBz" = (
+/obj/structure/largecrate/random/barrel/blue{
+	pixel_x = 5;
+	pixel_y = 3
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/lattice_prop{
+	dir = 1;
+	icon_state = "lattice-simple";
+	pixel_x = -16;
+	pixel_y = -16
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "dBG" = (
 /obj/structure/machinery/vending/snack,
 /turf/open/floor/almayer{
@@ -31101,6 +31993,20 @@
 	icon_state = "plate"
 	},
 /area/almayer/hull/upper_hull/u_m_s)
+"dCo" = (
+/obj/structure/prop/invuln/overhead_pipe{
+	pixel_x = 12
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	pixel_x = 12;
+	pixel_y = 12
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/strata_decals/grime/grime3,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_p)
 "dCr" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -31306,6 +32212,15 @@
 	icon_state = "plate"
 	},
 /area/almayer/hull/lower_hull/l_f_p)
+"dGi" = (
+/obj/structure/machinery/light/small,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/obj/item/trash/barcardine,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "dGl" = (
 /obj/effect/step_trigger/teleporter_vector{
 	name = "Almayer_AresUp";
@@ -31344,6 +32259,12 @@
 	dir = 4
 	},
 /obj/structure/largecrate/random/case/double,
+/obj/structure/prop/invuln/overhead/flammable_pipe/fly{
+	dir = 5;
+	pixel_x = -1;
+	pixel_y = 12;
+	layer = 4
+	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_a_p)
 "dGC" = (
@@ -31406,6 +32327,7 @@
 /area/almayer/lifeboat_pumps/south2)
 "dHk" = (
 /obj/structure/largecrate/random/barrel/green,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -31511,6 +32433,12 @@
 	icon_state = "cargo"
 	},
 /area/almayer/hull/lower_hull/l_m_s)
+"dJX" = (
+/obj/item/trash/used_stasis_bag,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_p)
 "dKm" = (
 /obj/structure/machinery/power/apc/almayer{
 	dir = 4
@@ -31566,6 +32494,16 @@
 	icon_state = "plating_striped"
 	},
 /area/almayer/shipboard/sea_office)
+"dLv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/tool/warning_cone{
+	pixel_y = 13
+	},
+/turf/open/floor/almayer{
+	dir = 4;
+	icon_state = "silvercorner"
+	},
+/area/almayer/hallways/hangar)
 "dLz" = (
 /obj/structure/surface/table/almayer,
 /obj/item/storage/backpack/satchel,
@@ -31624,6 +32562,10 @@
 /area/almayer/engineering/engine_core)
 "dNB" = (
 /obj/structure/largecrate/random/barrel/yellow,
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -31679,6 +32621,7 @@
 /obj/structure/sign/safety/nonpress_ag{
 	pixel_x = 32
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_f_s)
 "dPY" = (
@@ -31707,6 +32650,11 @@
 	icon_state = "silver"
 	},
 /area/almayer/command/airoom)
+"dQs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/oil/streak,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_s)
 "dQv" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -31786,6 +32734,18 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/hull/upper_hull/u_f_s)
+"dRX" = (
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = -11;
+	pixel_x = 1
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = -9
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_p)
 "dSc" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer{
 	dir = 1
@@ -31834,6 +32794,31 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/medical/morgue)
+"dSN" = (
+/obj/structure/sign/safety/hvac_old{
+	pixel_x = 8;
+	pixel_y = -32
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_p)
+"dSR" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7;
+	pixel_x = 13
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_p)
 "dSX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -31893,6 +32878,10 @@
 	dir = 1
 	},
 /obj/structure/closet/firecloset,
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_f_s)
 "dUI" = (
@@ -32099,6 +33088,21 @@
 	icon_state = "orange"
 	},
 /area/almayer/hallways/stern_hallway)
+"dZi" = (
+/obj/structure/platform{
+	dir = 1
+	},
+/obj/item/clothing/head/helmet/marine/tech/tanker{
+	pixel_x = 3;
+	pixel_y = -5
+	},
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hallways/hangar)
 "dZr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -32157,6 +33161,7 @@
 /obj/structure/surface/table/almayer,
 /obj/item/tool/weldpack,
 /obj/item/tool/crowbar,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -32185,6 +33190,7 @@
 	dir = 1
 	},
 /obj/structure/largecrate/random/barrel/yellow,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -32202,10 +33208,27 @@
 /area/almayer/command/airoom)
 "ebO" = (
 /obj/structure/machinery/light/small,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
 /area/almayer/hull/lower_hull/l_a_p)
+"ebX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/tool/crowbar/red{
+	pixel_x = -9;
+	pixel_y = 13
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = -9
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = -5
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_s)
 "ebY" = (
 /obj/structure/surface/rack,
 /obj/effect/spawner/random/toolbox,
@@ -32253,11 +33276,17 @@
 	icon_state = "orange"
 	},
 /area/almayer/engineering/engineering_workshop)
-"ecM" = (
-/obj/structure/bed/chair{
-	dir = 4
+"ecy" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/strata_decals/grime/grime4,
+/turf/open/floor/almayer{
+	icon_state = "plate"
 	},
-/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_s)
+"ecM" = (
+/turf/closed/shuttle/escapepod{
+	icon_state = "wall2"
+	},
 /area/almayer/hull/lower_hull/l_m_s)
 "ecQ" = (
 /obj/structure/machinery/door_display/research_cell{
@@ -32323,6 +33352,13 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/almayer,
 /area/almayer/hallways/vehiclehangar)
+"edY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/strata_decals/grime/grime4,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_f_s)
 "eed" = (
 /turf/open/floor/almayer{
 	icon_state = "mono"
@@ -32358,6 +33394,7 @@
 	pixel_x = 15;
 	pixel_y = -32
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -32393,6 +33430,14 @@
 	icon_state = "red"
 	},
 /area/almayer/shipboard/brig/processing)
+"eeO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_s)
 "efa" = (
 /obj/item/frame/camera{
 	desc = "The Staff Officer insisted he needed to monitor everyone at all times.";
@@ -32455,6 +33500,14 @@
 "efU" = (
 /obj/structure/machinery/power/apc/almayer{
 	dir = 1
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
 	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
@@ -32581,10 +33634,40 @@
 	pixel_x = 8;
 	pixel_y = 32
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
 /area/almayer/living/tankerbunks)
+"eic" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/platform{
+	dir = 1
+	},
+/obj/structure/prop/invuln{
+	desc = "a pile of cables";
+	icon = 'icons/obj/structures/props/almayer_props.dmi';
+	icon_state = "cannon_cables";
+	name = "cables";
+	density = 0;
+	layer = 2;
+	pixel_x = -4;
+	pixel_y = -9
+	},
+/turf/open/floor/plating,
+/area/almayer/hull/lower_hull/l_a_p)
+"eij" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/warning_stripes{
+	icon_state = "S";
+	layer = 3.3
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	pixel_x = -15;
+	pixel_y = 12
+	},
+/turf/open/floor/plating,
+/area/almayer/hull/lower_hull/l_f_s)
 "eim" = (
 /obj/structure/pipes/vents/pump{
 	dir = 1
@@ -32726,8 +33809,11 @@
 	},
 /area/almayer/shipboard/brig/perma)
 "eko" = (
-/obj/structure/largecrate/random/secure,
-/turf/open/floor/plating/plating_catwalk,
+/obj/structure/grille{
+	icon_state = "brokengrille";
+	density = 0
+	},
+/turf/open/floor/plating,
 /area/almayer/hull/lower_hull/l_m_s)
 "eky" = (
 /turf/open/floor/almayer,
@@ -32790,6 +33876,12 @@
 	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/operating_room_one)
+"elP" = (
+/obj/effect/decal/strata_decals/grime/grime4,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_s)
 "elR" = (
 /turf/closed/wall/almayer/research/containment/wall/corner{
 	dir = 1
@@ -32832,6 +33924,7 @@
 /obj/structure/prop/invuln/overhead_pipe{
 	pixel_x = 12
 	},
+/obj/item/trash/uscm_mre,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_a_p)
 "emK" = (
@@ -32857,11 +33950,13 @@
 	},
 /area/almayer/command/securestorage)
 "enf" = (
-/obj/structure/bed/chair{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
 	},
-/turf/open/floor/almayer{
-	icon_state = "plate"
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
 	},
 /area/almayer/hull/lower_hull/l_m_s)
 "eni" = (
@@ -32872,6 +33967,18 @@
 	icon_state = "red"
 	},
 /area/almayer/shipboard/brig/evidence_storage)
+"enw" = (
+/obj/structure/platform{
+	dir = 8
+	},
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 6
+	},
+/obj/effect/decal/strata_decals/grime/grime3,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hallways/hangar)
 "enx" = (
 /obj/structure/pipes/vents/pump,
 /turf/open/floor/almayer{
@@ -32891,6 +33998,18 @@
 	icon_state = "red"
 	},
 /area/almayer/shipboard/brig/main_office)
+"enV" = (
+/obj/structure/platform{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/almayer/hull/lower_hull/l_m_p)
+"eon" = (
+/obj/item/device/flashlight/lamp/tripod/grey,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "eoG" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 5
@@ -32921,6 +34040,12 @@
 	icon_state = "red"
 	},
 /area/almayer/hallways/aft_hallway)
+"epr" = (
+/obj/effect/decal/cleanable/blood/oil/streak,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_p)
 "epu" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer,
 /obj/structure/machinery/door/poddoor/almayer/open{
@@ -32937,6 +34062,14 @@
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
 	pixel_x = 1
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice9";
+	pixel_y = 11
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 9;
+	pixel_y = 7
 	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
@@ -32968,12 +34101,52 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/squads/req)
+"eqf" = (
+/obj/structure/prop/invuln/lattice_prop{
+	dir = 1;
+	icon_state = "lattice-simple";
+	pixel_x = 14;
+	pixel_y = -16
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "eqk" = (
 /mob/living/simple_animal/mouse/brown,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
 /area/almayer/hull/lower_hull/l_f_s)
+"eqv" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7;
+	pixel_x = 13
+	},
+/obj/item/stack/tile/plasteel{
+	pixel_y = -12;
+	pixel_x = 5
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_p)
+"eqy" = (
+/obj/effect/decal/strata_decals/grime/grime3,
+/obj/item/trash/buritto,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_s)
 "eqB" = (
 /obj/item/bedsheet/brown{
 	layer = 3.2
@@ -33111,6 +34284,25 @@
 	icon_state = "plate"
 	},
 /area/almayer/hallways/starboard_hallway)
+"esA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/firecloset,
+/obj/structure/prop/invuln/overhead_pipe{
+	pixel_x = 6;
+	pixel_y = 12
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	dir = 1;
+	icon_state = "lattice-simple";
+	pixel_x = 10
+	},
+/obj/effect/decal/strata_decals/grime/grime2{
+	dir = 8
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_s)
 "esF" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 1
@@ -33171,14 +34363,31 @@
 	icon_state = "plating"
 	},
 /area/almayer/engineering/upper_engineering)
+"etx" = (
+/obj/structure/sign/safety/hvac_old{
+	pixel_x = 8;
+	pixel_y = -32
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = -9
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = -11;
+	pixel_x = 1
+	},
+/obj/effect/decal/cleanable/liquid_fuel,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_p)
 "etB" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/sign/safety/storage{
 	pixel_x = 32
 	},
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
+/turf/open/floor/plating,
 /area/almayer/hull/lower_hull/l_m_p)
 "etE" = (
 /obj/structure/prop/almayer/name_stencil,
@@ -33190,6 +34399,10 @@
 /obj/structure/machinery/light/small{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/cigbutt/cigarbutt,
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/strata_decals/grime/grime1,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -33367,6 +34580,30 @@
 	icon_state = "tcomms"
 	},
 /area/almayer/engineering/upper_engineering/starboard)
+"exD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/prop{
+	desc = "An older design of the Pulse Rifle commonly used by Colonial Marines. This one has seen better days. The trigger is missing, the barrel is bent, and it no longer appropriately feeds magazines.";
+	icon = 'icons/obj/items/weapons/guns/guns_by_faction/uscm.dmi';
+	icon_state = "m41amk1_e";
+	item_state = "m41amk1";
+	name = "\improper Broken M41A pulse rifle";
+	pixel_y = 7
+	},
+/obj/item/prop{
+	desc = "An older design of the Pulse Rifle commonly used by Colonial Marines. This one has seen better days. The trigger is missing, the barrel is bent, and it no longer appropriately feeds magazines.";
+	icon = 'icons/obj/items/weapons/guns/guns_by_faction/uscm.dmi';
+	icon_state = "m41amk1_e";
+	item_state = "m41amk1";
+	name = "\improper Broken M41A pulse rifle";
+	pixel_y = -5;
+	pixel_x = 4
+	},
+/obj/structure/surface/rack,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "eyd" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "NW-out";
@@ -33635,6 +34872,21 @@
 	icon_state = "plate"
 	},
 /area/almayer/hallways/hangar)
+"eEe" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/strata_decals/grime/grime1{
+	dir = 4
+	},
+/obj/item/prop/magazine,
+/obj/structure/prop/invuln/lattice_prop{
+	dir = 1;
+	icon_state = "lattice-simple";
+	pixel_x = -14
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_f_s)
 "eEk" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/pipes/standard/simple/hidden/supply,
@@ -33656,6 +34908,19 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/cic_hallway)
+"eEJ" = (
+/obj/structure/prop/ice_colony/ground_wire{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/oil/streak,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_s)
+"eER" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "eFj" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/pipes/standard/manifold/hidden/supply{
@@ -33837,6 +35102,7 @@
 /obj/structure/prop/invuln/pipe_water{
 	pixel_x = 17
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_m_p)
 "eHx" = (
@@ -33846,6 +35112,20 @@
 	icon_state = "bluefull"
 	},
 /area/almayer/command/cichallway)
+"eHJ" = (
+/obj/effect/decal/cleanable/blood/oil/streak,
+/obj/structure/machinery/light{
+	dir = 4;
+	invisibility = 101
+	},
+/obj/effect/decal/strata_decals/grime/grime1{
+	dir = 8
+	},
+/obj/structure/pipes/vents/pump{
+	dir = 1
+	},
+/turf/open/floor/almayer,
+/area/almayer/hallways/hangar)
 "eHY" = (
 /obj/structure/surface/rack,
 /obj/item/device/taperecorder,
@@ -33853,11 +35133,18 @@
 	icon_state = "silver"
 	},
 /area/almayer/command/computerlab)
+"eIm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_p)
 "eIA" = (
 /obj/structure/sign/safety/water{
 	pixel_x = 8;
 	pixel_y = -32
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_m_s)
 "eJd" = (
@@ -33869,7 +35156,11 @@
 	},
 /area/almayer/hull/upper_hull/u_a_s)
 "eJg" = (
-/obj/structure/largecrate/random/barrel/red,
+/obj/structure/surface/table/almayer,
+/obj/item/ammo_box/magazine/heap/empty{
+	pixel_x = 4
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "cargo"
 	},
@@ -33966,6 +35257,20 @@
 /obj/structure/bed/chair{
 	dir = 1
 	},
+/obj/structure/sign/safety/distribution_pipes{
+	pixel_x = 8;
+	pixel_y = -32
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	dir = 1;
+	icon_state = "lattice-simple";
+	pixel_x = -14
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice1";
+	pixel_x = -14;
+	pixel_y = -13
+	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_f_s)
 "eKT" = (
@@ -33992,6 +35297,13 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/engineering/laundry)
+"eMo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/emcloset,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_s)
 "eMP" = (
 /obj/structure/machinery/door/poddoor/almayer/open{
 	dir = 4;
@@ -34008,6 +35320,22 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/command/cichallway)
+"eNe" = (
+/obj/structure/prop/invuln/overhead/flammable_pipe/fly{
+	dir = 4;
+	icon_state = "flammable_pipe_3";
+	pixel_x = 17;
+	pixel_y = -16;
+	layer = 5.9
+	},
+/obj/structure/prop/invuln/overhead/flammable_pipe/fly{
+	icon_state = "flammable_pipe_3";
+	pixel_x = -3;
+	pixel_y = 12;
+	dir = 1
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_p)
 "eNi" = (
 /turf/closed/wall/almayer,
 /area/almayer/engineering/ce_room)
@@ -34069,6 +35397,14 @@
 	icon_state = "plate"
 	},
 /area/almayer/hull/lower_hull/l_f_p)
+"eOQ" = (
+/obj/structure/largecrate/random/barrel/green,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/liquid_fuel,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "eOR" = (
 /obj/structure/machinery/light{
 	dir = 4
@@ -34308,6 +35644,13 @@
 	icon_state = "plate"
 	},
 /area/almayer/squads/alpha)
+"eUE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/largecrate/random/secure,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_f_s)
 "eUR" = (
 /obj/structure/bed/chair/comfy/orange,
 /obj/structure/pipes/standard/simple/hidden/supply{
@@ -34366,6 +35709,12 @@
 /obj/item/storage/beer_pack,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_m_s)
+"eVG" = (
+/obj/structure/blocker/invisible_wall{
+	name = "\improper M34A2 Longstreet light tank"
+	},
+/turf/open/floor/plating,
+/area/almayer/hallways/hangar)
 "eVQ" = (
 /obj/structure/machinery/light{
 	dir = 4
@@ -34381,6 +35730,15 @@
 	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/medical_science)
+"eVY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/liquid_fuel,
+/obj/effect/decal/cleanable/liquid_fuel,
+/obj/item/tool/weldingtool,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "eWp" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /obj/structure/bed/chair/comfy/charlie{
@@ -34403,6 +35761,14 @@
 	dir = 1
 	},
 /obj/structure/largecrate/random/barrel/white,
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_m_s)
 "eXb" = (
@@ -34525,6 +35891,13 @@
 /obj/structure/filingcabinet/security,
 /turf/open/floor/wood/ship,
 /area/almayer/command/corporateliason)
+"eZe" = (
+/obj/structure/largecrate/random/barrel/yellow,
+/obj/effect/decal/cleanable/blood/oil/streak,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_s)
 "eZi" = (
 /obj/effect/projector{
 	name = "Almayer_Up4";
@@ -34547,6 +35920,7 @@
 	pixel_x = 8;
 	pixel_y = -32
 	},
+/obj/effect/decal/cleanable/liquid_fuel,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -34571,6 +35945,18 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/starboard_hallway)
+"faB" = (
+/obj/structure/prop/invuln/overhead_pipe{
+	pixel_x = 6;
+	pixel_y = 12
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	dir = 1;
+	icon_state = "lattice-simple";
+	pixel_x = 10
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_p)
 "faO" = (
 /obj/item/stack/cable_coil,
 /turf/open/floor/plating/plating_catwalk,
@@ -34617,6 +36003,17 @@
 	icon_state = "kitchen"
 	},
 /area/almayer/living/grunt_rnr)
+"fbq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/largecrate/random/case/small,
+/obj/structure/prop/invuln/lattice_prop{
+	dir = 1;
+	icon_state = "lattice-simple";
+	pixel_x = 14;
+	pixel_y = -16
+	},
+/turf/open/floor/plating,
+/area/almayer/hull/lower_hull/l_m_s)
 "fbv" = (
 /obj/structure/machinery/light{
 	dir = 8
@@ -34774,6 +36171,42 @@
 	icon_state = "plate"
 	},
 /area/almayer/living/pilotbunks)
+"fdO" = (
+/obj/structure/surface/rack,
+/obj/item/tool/crowbar,
+/obj/item/tool/weldingtool,
+/obj/item/tool/wrench,
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/obj/structure/prop/invuln/overhead/flammable_pipe/fly{
+	dir = 5;
+	pixel_x = 2;
+	pixel_y = -4
+	},
+/obj/structure/prop/invuln/overhead/flammable_pipe/fly{
+	icon_state = "flammable_pipe_2";
+	pixel_x = 2;
+	pixel_y = 9;
+	layer = 5.9
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
+"fdW" = (
+/obj/structure/disposalpipe/segment,
+/obj/item/tool/warning_cone{
+	pixel_x = 13;
+	pixel_y = 15
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_p)
 "fdX" = (
 /obj/structure/surface/table/almayer,
 /obj/item/tool/hand_labeler,
@@ -34858,6 +36291,7 @@
 /obj/item/device/flashlight,
 /obj/item/device/flashlight,
 /obj/item/device/flashlight,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -35000,6 +36434,7 @@
 	pixel_y = 5
 	},
 /obj/item/toy/deck/uno,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -35009,6 +36444,15 @@
 	dir = 8
 	},
 /area/almayer/medical/containment/cell/cl)
+"fln" = (
+/obj/structure/largecrate/random/barrel/yellow{
+	anchored = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer{
+	icon_state = "silver"
+	},
+/area/almayer/hallways/hangar)
 "flE" = (
 /obj/structure/platform{
 	dir = 8
@@ -35035,6 +36479,16 @@
 	icon_state = "silver"
 	},
 /area/almayer/living/briefing)
+"fmb" = (
+/obj/structure/prop/invuln/overhead_pipe{
+	pixel_x = 12
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/grille,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_s)
 "fmf" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/almayer/glass{
 	dir = 2;
@@ -35074,6 +36528,7 @@
 /area/almayer/living/pilotbunks)
 "fmS" = (
 /obj/structure/closet/secure_closet/engineering_electrical,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -35181,6 +36636,11 @@
 	pixel_x = 8;
 	pixel_y = 32
 	},
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
+/obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_f_s)
 "fps" = (
@@ -35328,6 +36788,23 @@
 	icon_state = "tcomms"
 	},
 /area/almayer/command/airoom)
+"frY" = (
+/obj/structure/prop/invuln/overhead_pipe{
+	pixel_x = 6;
+	pixel_y = 12
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	dir = 1;
+	icon_state = "lattice-simple";
+	pixel_x = 10
+	},
+/obj/effect/decal/strata_decals/grime/grime2{
+	dir = 8
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_s)
 "fsd" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
@@ -35418,6 +36895,14 @@
 	icon_state = "plate"
 	},
 /area/almayer/hull/lower_hull/l_m_p)
+"ftY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_f_s)
 "fut" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N";
@@ -35484,6 +36969,13 @@
 	icon_state = "silver"
 	},
 /area/almayer/living/briefing)
+"fvp" = (
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_s)
 "fvu" = (
 /obj/item/tool/crowbar,
 /turf/open/floor/almayer{
@@ -35518,8 +37010,24 @@
 	pixel_x = 8;
 	pixel_y = 32
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/port_point_defense)
+"fvZ" = (
+/obj/structure/largecrate/random/barrel/green{
+	pixel_x = 3
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/lattice_prop{
+	dir = 1;
+	icon_state = "lattice-simple";
+	pixel_x = -16;
+	pixel_y = -16
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "fwD" = (
 /obj/structure/surface/table/almayer,
 /obj/item/trash/plate{
@@ -35561,6 +37069,7 @@
 	pixel_x = 8;
 	pixel_y = -32
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -35673,6 +37182,24 @@
 	icon_state = "red"
 	},
 /area/almayer/living/offices/flight)
+"fAe" = (
+/obj/structure/largecrate/random/case/small,
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 9;
+	pixel_y = -9
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	pixel_y = 11
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice9";
+	pixel_x = 1;
+	pixel_y = -11
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_p)
 "fAo" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -35689,6 +37216,7 @@
 "fAS" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/pipes/standard/simple/hidden/supply,
+/obj/effect/decal/strata_decals/grime/grime4,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -35702,6 +37230,21 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/hull/upper_hull/u_a_s)
+"fBr" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7;
+	pixel_x = 13
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_p)
 "fBx" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/almayer{
@@ -35747,12 +37290,33 @@
 	icon_state = "mono"
 	},
 /area/almayer/medical/medical_science)
+"fCl" = (
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_p)
 "fCp" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 5
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/command/lifeboat)
+"fCF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/candy{
+	pixel_y = 1;
+	pixel_x = 13
+	},
+/obj/effect/decal/cleanable/molten_item{
+	pixel_x = -8;
+	pixel_y = 10
+	},
+/obj/effect/decal/strata_decals/grime/grime4,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_f_s)
 "fCL" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -35914,6 +37478,9 @@
 	indestructible = 1;
 	unacidable = 1
 	},
+/obj/structure/platform{
+	dir = 8
+	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
 	},
@@ -36068,6 +37635,32 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/shipboard/brig/processing)
+"fHZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/cigbutt{
+	pixel_x = -10;
+	pixel_y = 13
+	},
+/obj/item/trash/cigbutt{
+	pixel_x = -12;
+	pixel_y = 17
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/starboard_point_defense)
+"fId" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/overhead/flammable_pipe/fly{
+	dir = 8;
+	pixel_x = -2;
+	pixel_y = 13;
+	layer = 4
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_p)
 "fIf" = (
 /obj/structure/sign/safety/bulkhead_door{
 	pixel_x = 8;
@@ -36083,6 +37676,7 @@
 /area/almayer/engineering/engine_core)
 "fIH" = (
 /obj/structure/largecrate/random/barrel/blue,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -36197,10 +37791,6 @@
 	icon_state = "tcomms"
 	},
 /area/almayer/command/airoom)
-"fKg" = (
-/obj/structure/closet/firecloset,
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/hull/lower_hull/l_a_s)
 "fKl" = (
 /obj/structure/surface/rack,
 /obj/item/tool/shovel/etool{
@@ -36208,6 +37798,12 @@
 	},
 /obj/item/tool/shovel/etool,
 /obj/item/tool/wirecutters,
+/obj/structure/prop/invuln/lattice_prop{
+	dir = 1;
+	icon_state = "lattice-simple";
+	pixel_x = -16;
+	pixel_y = -16
+	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -36348,7 +37944,26 @@
 /turf/open/floor/carpet,
 /area/almayer/living/commandbunks)
 "fNg" = (
-/obj/structure/largecrate/random/barrel/yellow,
+/obj/structure/surface/rack,
+/obj/structure/prop/invuln{
+	icon = 'icons/obj/items/weapons/guns/ammo_by_faction/event.dmi';
+	icon_state = "quad_rocket";
+	name = "IX-50 Anti-Air Rocket Ammo";
+	desc = "Self-guided anti-air rockets intended for use with the IX-50";
+	pixel_x = 2;
+	pixel_y = -7;
+	density = 0
+	},
+/obj/structure/prop/invuln{
+	icon = 'icons/obj/items/weapons/guns/ammo_by_faction/event.dmi';
+	icon_state = "quad_rocket";
+	name = "IX-50 Anti-Air Rocket Ammo";
+	desc = "Self-guided anti-air rockets intended for use with the IX-50";
+	pixel_x = 1;
+	pixel_y = 7;
+	density = 0
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_f_s)
 "fNi" = (
@@ -36486,7 +38101,13 @@
 /area/almayer/medical/upper_medical)
 "fQF" = (
 /obj/structure/surface/rack,
+/obj/item/storage/bag/plasticbag,
 /obj/item/storage/firstaid/regular,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_f_s)
 "fQK" = (
@@ -36538,6 +38159,12 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/lifeboat_pumps/north1)
+"fSv" = (
+/obj/structure/machinery/door/morgue{
+	name = "hull"
+	},
+/turf/open/floor/plating,
+/area/almayer/hull/lower_hull/l_m_s)
 "fSF" = (
 /obj/structure/sink{
 	dir = 1;
@@ -36564,6 +38191,13 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/living/grunt_rnr)
+"fSI" = (
+/obj/item/tool/warning_cone{
+	pixel_x = -12;
+	pixel_y = 16
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_s)
 "fTi" = (
 /obj/structure/largecrate/supply/floodlights,
 /turf/open/floor/almayer{
@@ -36576,6 +38210,7 @@
 /turf/open/floor/almayer,
 /area/almayer/hallways/hangar)
 "fTu" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/almayer/reinforced,
 /area/almayer/hull/lower_hull/l_f_p)
 "fTx" = (
@@ -36589,6 +38224,23 @@
 	pixel_x = 12;
 	pixel_y = 12
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/overhead/flammable_pipe/fly{
+	dir = 8;
+	pixel_x = -2;
+	pixel_y = 12;
+	layer = 4
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice3";
+	pixel_x = 15;
+	pixel_y = -6
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -36636,9 +38288,27 @@
 	},
 /turf/open/floor/wood/ship,
 /area/almayer/command/corporateliason)
+"fUo" = (
+/obj/structure/largecrate/random/barrel/yellow,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_s)
 "fUA" = (
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/living/briefing)
+"fVa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/overhead/flammable_pipe/fly{
+	dir = 4;
+	icon_state = "flammable_pipe_3";
+	pixel_x = 2;
+	pixel_y = -3;
+	layer = 5.9
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "fVz" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
@@ -36659,6 +38329,25 @@
 	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/chemistry)
+"fVT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = -9
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = -11;
+	pixel_x = 1
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_p)
+"fWg" = (
+/obj/effect/spider/stickyweb,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_f_p)
 "fWT" = (
 /obj/structure/machinery/door/airlock/almayer/engineering{
 	dir = 2;
@@ -36676,6 +38365,7 @@
 /obj/structure/machinery/light/small{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -36698,6 +38388,12 @@
 /obj/structure/machinery/alarm/almayer{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/cigbutt{
+	pixel_x = -10;
+	pixel_y = 13
+	},
+/obj/item/storage/box/matches,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -36720,6 +38416,20 @@
 	icon_state = "plate"
 	},
 /area/almayer/command/combat_correspondent)
+"fXM" = (
+/obj/structure/machinery/light/small,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = -9
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = -11;
+	pixel_x = 1
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_p)
 "fXN" = (
 /obj/effect/landmark/start/marine/delta,
 /obj/effect/landmark/late_join/delta,
@@ -36738,6 +38448,16 @@
 /obj/structure/sign/safety/distribution_pipes{
 	pixel_x = 8;
 	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7;
+	pixel_x = 13
 	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
@@ -36809,10 +38529,33 @@
 /area/almayer/squads/bravo)
 "gai" = (
 /obj/structure/closet/firecloset,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
 /area/almayer/hull/lower_hull/l_a_p)
+"gaC" = (
+/obj/structure/machinery/light{
+	dir = 8;
+	invisibility = 101
+	},
+/obj/structure/prop/invuln{
+	desc = "Integral to the movement of the APC, these one's are non-functional";
+	icon = 'icons/obj/vehicles/hardpoints/apc.dmi';
+	icon_state = "tires";
+	name = "APC Wheels";
+	density = 0;
+	pixel_x = 5;
+	pixel_y = 13;
+	layer = 3
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/pipes/vents/scrubber{
+	dir = 1
+	},
+/turf/open/floor/almayer,
+/area/almayer/hallways/hangar)
 "gaJ" = (
 /turf/closed/wall/almayer,
 /area/almayer/shipboard/brig/cryo)
@@ -36921,6 +38664,8 @@
 	pixel_x = 12;
 	pixel_y = 12
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/inflatable,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_a_s)
 "gcN" = (
@@ -36944,6 +38689,10 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/sign/safety/distribution_pipes{
 	pixel_x = 32
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spider/stickyweb{
+	icon_state = "stickyweb2"
 	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
@@ -36982,6 +38731,14 @@
 	icon_state = "red"
 	},
 /area/almayer/hallways/hangar)
+"gdr" = (
+/obj/effect/spider/stickyweb{
+	icon_state = "stickyweb2"
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_p)
 "gds" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -37119,6 +38876,12 @@
 /obj/structure/sign/safety/cryo{
 	pixel_y = -26
 	},
+/obj/item/pipe{
+	dir = 4;
+	layer = 3.5;
+	pixel_x = 7;
+	pixel_y = 11
+	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_m_s)
 "gfW" = (
@@ -37139,6 +38902,18 @@
 	icon_state = "mono"
 	},
 /area/almayer/medical/medical_science)
+"ggs" = (
+/obj/structure/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "ggt" = (
 /turf/open/floor/almayer{
 	dir = 5;
@@ -37337,6 +39112,13 @@
 	icon_state = "plate"
 	},
 /area/almayer/hull/lower_hull/l_a_s)
+"gjS" = (
+/obj/structure/prop/invuln/overhead_pipe{
+	pixel_x = 12
+	},
+/obj/structure/inflatable/door,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_s)
 "gka" = (
 /obj/structure/closet/secure_closet/guncabinet/red,
 /obj/item/weapon/gun/shotgun/combat,
@@ -37351,6 +39133,10 @@
 /obj/structure/largecrate/random/secure,
 /turf/open/floor/plating,
 /area/almayer/hull/lower_hull/l_f_p)
+"gkG" = (
+/obj/effect/decal/strata_decals/grime/grime4,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_s)
 "gkK" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /obj/structure/surface/table/reinforced/almayer_B,
@@ -37361,6 +39147,14 @@
 	icon_state = "plate"
 	},
 /area/almayer/command/cic)
+"gkO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = -5
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_s)
 "gll" = (
 /obj/structure/machinery/power/apc/almayer{
 	dir = 1
@@ -37413,12 +39207,38 @@
 /obj/structure/bed/chair/office/dark,
 /turf/open/floor/carpet,
 /area/almayer/living/commandbunks)
+"glW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/ash,
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 5;
+	pixel_y = 7
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_x = -8
+	},
+/obj/effect/decal/strata_decals/grime/grime4,
+/obj/effect/decal/strata_decals/grime/grime2{
+	dir = 4
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_f_s)
 "gmj" = (
 /obj/structure/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
 /area/almayer/shipboard/starboard_point_defense)
+"gmn" = (
+/obj/structure/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_s)
 "gms" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer{
@@ -37426,6 +39246,11 @@
 	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering/port)
+"gmA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb2,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_f_s)
 "gnu" = (
 /obj/structure/surface/table/almayer,
 /obj/item/facepaint/green,
@@ -37446,6 +39271,20 @@
 	pixel_x = 32;
 	pixel_y = -8
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/hotdog{
+	pixel_x = -11;
+	pixel_y = -5
+	},
+/obj/item/trash/USCMtray{
+	pixel_x = 14;
+	pixel_y = 3
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	pixel_x = 6;
+	pixel_y = 12
+	},
+/obj/effect/decal/strata_decals/grime/grime4,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -37471,6 +39310,19 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/shipboard/weapon_room)
+"gos" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/cigbutt{
+	pixel_x = -7;
+	pixel_y = 13
+	},
+/obj/item/trash/cigbutt/cigarbutt{
+	pixel_x = 9;
+	pixel_y = 15
+	},
+/obj/effect/decal/strata_decals/grime/grime3,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/starboard_point_defense)
 "goD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -37512,9 +39364,8 @@
 /obj/structure/sign/safety/distribution_pipes{
 	pixel_x = 32
 	},
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
+/obj/effect/decal/strata_decals/grime/grime4,
+/turf/open/floor/plating,
 /area/almayer/hull/lower_hull/l_m_p)
 "gpI" = (
 /obj/structure/disposalpipe/segment,
@@ -37524,12 +39375,30 @@
 	icon_state = "green"
 	},
 /area/almayer/living/grunt_rnr)
+"gpS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/strata_decals/grime/grime1{
+	dir = 4
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_f_s)
 "gpY" = (
 /turf/closed/wall/almayer/reinforced,
 /area/almayer/lifeboat_pumps/north1)
 "gqK" = (
 /obj/structure/machinery/light/small{
 	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_m_p)
@@ -37659,6 +39528,12 @@
 	icon_state = "greencorner"
 	},
 /area/almayer/hallways/port_hallway)
+"guv" = (
+/obj/effect/decal/strata_decals/grime/grime3,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_s)
 "guC" = (
 /obj/item/paper_bin/wy,
 /obj/structure/surface/table/woodentable/fancy,
@@ -37686,6 +39561,7 @@
 /area/almayer/living/port_emb)
 "guS" = (
 /obj/structure/reagent_dispensers/fueltank/custom,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -37718,6 +39594,22 @@
 	icon_state = "silver"
 	},
 /area/almayer/command/cic)
+"gvv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/oil/streak,
+/obj/effect/decal/cleanable/generic,
+/obj/item/trash/liquidfood{
+	pixel_x = -11;
+	pixel_y = 5
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	pixel_x = 6;
+	pixel_y = 12
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_s)
 "gvC" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/prop/invuln/overhead_pipe{
@@ -37736,6 +39628,27 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/upper_hull/u_f_p)
+"gvI" = (
+/obj/structure/largecrate/random/case/small,
+/obj/structure/machinery{
+	density = 1;
+	dir = 4;
+	icon = 'icons/obj/vehicles/tank.dmi';
+	indestructible = 1;
+	name = "\improper M34A2 Longstreet light tank gun barrel";
+	pixel_y = -19;
+	unacidable = 1;
+	unslashable = 1;
+	pixel_x = -37;
+	icon_state = "ltb_cannon_1";
+	layer = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "silver"
+	},
+/area/almayer/hallways/hangar)
 "gvU" = (
 /obj/structure/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -37800,6 +39713,10 @@
 	icon_state = "lattice12";
 	pixel_y = 16
 	},
+/obj/item/trash/used_stasis_bag{
+	pixel_y = -4;
+	pixel_x = -5
+	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -37860,6 +39777,7 @@
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -37881,6 +39799,24 @@
 	pixel_x = 8;
 	pixel_y = 32
 	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
+"gxs" = (
+/obj/structure/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/obj/effect/decal/cleanable/blood/oil/streak,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -37972,6 +39908,13 @@
 	icon_state = "orange"
 	},
 /area/almayer/engineering/ce_room)
+"gzi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/strata_decals/grime/grime4,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_p)
 "gzn" = (
 /obj/structure/machinery/landinglight/ds2/delaytwo{
 	dir = 8
@@ -38042,6 +39985,14 @@
 	icon_state = "green"
 	},
 /area/almayer/living/grunt_rnr)
+"gzX" = (
+/obj/structure/cable{
+	icon_state = "1-8";
+	pixel_x = -12
+	},
+/obj/structure/bed,
+/turf/open/floor/plating,
+/area/almayer/hull/lower_hull/l_m_s)
 "gAd" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -38134,6 +40085,14 @@
 /obj/structure/machinery/light/small{
 	dir = 8
 	},
+/obj/structure/prop/invuln{
+	desc = "a pile of cables";
+	icon = 'icons/obj/structures/machinery/artillery.dmi';
+	icon_state = "29";
+	name = "cables";
+	density = 0;
+	layer = 3
+	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_m_s)
 "gCf" = (
@@ -38176,6 +40135,13 @@
 	icon_state = "plate"
 	},
 /area/almayer/living/bridgebunks)
+"gCT" = (
+/obj/structure/machinery/door/firedoor/border_only/almayer,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/hull/lower_hull/l_f_s)
 "gDq" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 10
@@ -38229,6 +40195,7 @@
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer,
 /area/almayer/shipboard/starboard_point_defense)
 "gFd" = (
@@ -38241,15 +40208,19 @@
 	},
 /area/almayer/lifeboat_pumps/south1)
 "gFs" = (
-/obj/effect/spawner/random/toolbox,
-/turf/open/floor/almayer{
-	icon_state = "plate"
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
 	},
 /area/almayer/hull/lower_hull/l_m_s)
 "gFG" = (
 /obj/structure/surface/rack,
 /obj/effect/spawner/random/tool,
 /obj/effect/spawner/random/tool,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -38262,6 +40233,17 @@
 	icon_state = "plate"
 	},
 /area/almayer/squads/delta)
+"gGp" = (
+/obj/structure/machinery/door/airlock/almayer/engineering{
+	req_one_access = null;
+	req_access = null;
+	name = "\improper EVA Airlock"
+	},
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "gGr" = (
 /obj/structure/machinery/vending/cigarette,
 /turf/open/floor/almayer{
@@ -38389,6 +40371,13 @@
 /obj/structure/largecrate/random/barrel/red,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/upper_hull/u_a_s)
+"gIT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/strata_decals/grime/grime2,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "gJd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -38397,6 +40386,7 @@
 	pixel_x = 8;
 	pixel_y = 32
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_f_p)
 "gJq" = (
@@ -38565,6 +40555,7 @@
 /area/almayer/shipboard/brig/perma)
 "gMx" = (
 /obj/structure/closet/firecloset,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_f_p)
 "gMA" = (
@@ -38648,8 +40639,18 @@
 /obj/effect/spawner/random/toolbox,
 /obj/effect/spawner/random/toolbox,
 /obj/effect/spawner/random/tool,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_m_p)
+"gNC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice6";
+	pixel_x = 1;
+	pixel_y = -11
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_p)
 "gOs" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N";
@@ -38686,6 +40687,21 @@
 	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering/starboard)
+"gPm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/obj/effect/decal/cleanable/blood/oil/streak,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "gPr" = (
 /obj/effect/step_trigger/teleporter_vector{
 	name = "Almayer_AresUp";
@@ -38864,6 +40880,7 @@
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -38919,6 +40936,13 @@
 /obj/structure/pipes/standard/manifold/hidden/supply,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/lifeboat_pumps/north2)
+"gUY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_p)
 "gVq" = (
 /obj/structure/machinery/light,
 /obj/effect/decal/warning_stripes{
@@ -38942,6 +40966,11 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/lifeboat_pumps/south1)
+"gWm" = (
+/obj/effect/decal/cleanable/blood/oil,
+/obj/structure/blocker/invisible_wall,
+/turf/open/floor/plating,
+/area/almayer/hallways/hangar)
 "gWE" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/start/marine/spec/alpha,
@@ -38961,10 +40990,23 @@
 	pixel_x = 8;
 	pixel_y = -32
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
 /area/almayer/hull/lower_hull/l_f_p)
+"gXb" = (
+/obj/structure/closet/firecloset,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice3";
+	pixel_x = -5;
+	pixel_y = 15
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_p)
 "gXh" = (
 /obj/structure/machinery/light/small{
 	dir = 8
@@ -39015,6 +41057,15 @@
 	icon_state = "plating"
 	},
 /area/almayer/hull/lower_hull/l_a_p)
+"gXS" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_f_p)
 "gXY" = (
 /obj/structure/machinery/light{
 	dir = 8
@@ -39060,6 +41111,27 @@
 	icon_state = "plate"
 	},
 /area/almayer/hull/lower_hull/l_f_s)
+"gYN" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7;
+	pixel_x = 13
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7;
+	pixel_x = 13
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_p)
 "gYS" = (
 /obj/structure/prop/invuln/overhead_pipe{
 	dir = 4;
@@ -39155,6 +41227,16 @@
 	icon_state = "silver"
 	},
 /area/almayer/command/cichallway)
+"haJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/device/radio/marine{
+	pixel_x = 5;
+	pixel_y = 3
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hallways/hangar)
 "haM" = (
 /obj/structure/machinery/constructable_frame,
 /obj/effect/decal/cleanable/blood/oil,
@@ -39181,6 +41263,16 @@
 	icon_state = "green"
 	},
 /area/almayer/hallways/port_hallway)
+"haY" = (
+/obj/structure/surface/table/almayer,
+/obj/item/clothing/suit/space/compression/uscm,
+/obj/item/clothing/head/helmet/space/compression/uscm{
+	pixel_x = 9
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_s)
 "hbu" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -39355,6 +41447,22 @@
 	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/medical_science)
+"hed" = (
+/obj/structure/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7;
+	pixel_x = 13
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_s)
 "hee" = (
 /turf/open/floor/almayer{
 	dir = 4;
@@ -39440,6 +41548,10 @@
 	icon_state = "red"
 	},
 /area/almayer/command/lifeboat)
+"hfA" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_p)
 "hfO" = (
 /obj/structure/surface/table/almayer,
 /obj/item/reagent_container/spray/cleaner,
@@ -39558,6 +41670,10 @@
 	icon_state = "cargo_arrow"
 	},
 /area/almayer/living/offices)
+"hhu" = (
+/obj/effect/decal/cleanable/blood/oil/streak,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_s)
 "hhw" = (
 /turf/closed/wall/almayer,
 /area/almayer/hull/lower_hull/l_m_s)
@@ -39565,6 +41681,10 @@
 /obj/structure/bed/sofa/vert/grey/bot,
 /turf/open/floor/almayer,
 /area/almayer/lifeboat_pumps/north1)
+"hhS" = (
+/obj/item/tool/wet_sign,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_p)
 "hif" = (
 /obj/structure/machinery/floodlight/landing,
 /turf/open/floor/almayer{
@@ -39615,6 +41735,19 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/living/briefing)
+"hjo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/surface/rack,
+/obj/structure/prop/invuln{
+	icon = 'icons/obj/items/weapons/guns/ammo_by_faction/event.dmi';
+	icon_state = "quad_rocket";
+	name = "IX-50 Anti-Air Rocket Ammo";
+	desc = "Self-guided anti-air rockets intended for use with the IX-50";
+	density = 0
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_f_s)
 "hjs" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -39633,6 +41766,26 @@
 	icon_state = "red"
 	},
 /area/almayer/shipboard/port_missiles)
+"hjH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/USCMtray{
+	pixel_x = 6;
+	pixel_y = -10
+	},
+/obj/item/trash/hotdog{
+	pixel_x = -1;
+	pixel_y = -7
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	pixel_x = 6;
+	pixel_y = 12
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_p)
+"hjK" = (
+/obj/effect/decal/cleanable/liquid_fuel,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_p)
 "hki" = (
 /obj/structure/machinery/cm_vending/sorted/tech/electronics_storage,
 /turf/open/floor/almayer{
@@ -39659,6 +41812,7 @@
 	pixel_x = 8;
 	pixel_y = 32
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/port_point_defense)
 "hkG" = (
@@ -39766,6 +41920,14 @@
 	icon_state = "plate"
 	},
 /area/almayer/squads/delta)
+"hmE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/candy{
+	pixel_y = 1;
+	pixel_x = 13
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_p)
 "hmF" = (
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -39799,6 +41961,18 @@
 	icon_state = "sterile_green"
 	},
 /area/almayer/medical/hydroponics)
+"hnM" = (
+/obj/structure/prop/invuln{
+	desc = "harmless exhaust discharge from a broken pipeline";
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "exhaust";
+	density = 0;
+	pixel_x = -9;
+	pixel_y = -17
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_p)
 "hnV" = (
 /obj/structure/machinery/light,
 /turf/open/floor/almayer,
@@ -39890,6 +42064,23 @@
 	icon_state = "cargo"
 	},
 /area/almayer/hull/lower_hull/l_f_s)
+"hqL" = (
+/obj/structure/sign/safety/hvac_old{
+	pixel_x = 8;
+	pixel_y = 32
+	},
+/obj/item/device/flashlight/lamp/tripod/grey,
+/obj/structure/prop/ice_colony/ground_wire{
+	dir = 8
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_f_s)
 "hqW" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/medidoor{
 	name = "\improper Medical Bay";
@@ -39946,6 +42137,17 @@
 	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical_medbay)
+"hrV" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	layer = 3.33;
+	pixel_y = 2
+	},
+/obj/structure/pipes/standard/simple/hidden/supply,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hallways/hangar)
 "hrX" = (
 /obj/structure/closet/secure_closet/engineering_welding,
 /obj/structure/machinery/light{
@@ -39955,6 +42157,19 @@
 	icon_state = "cargo"
 	},
 /area/almayer/engineering/engine_core)
+"hrY" = (
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 13
+	},
+/obj/structure/prop/invuln/pipe_water,
+/obj/structure/prop/invuln/lattice_prop{
+	dir = 1;
+	icon_state = "lattice-simple";
+	pixel_x = -14
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_f_s)
 "hsg" = (
 /obj/structure/pipes/vents/pump{
 	dir = 4
@@ -39973,6 +42188,20 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/squads/delta)
+"hsC" = (
+/obj/structure/prop/invuln/overhead_pipe{
+	pixel_x = 12
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/coffin/woodencrate,
+/obj/structure/largecrate/random/mini/wooden{
+	pixel_x = 4;
+	pixel_y = 6
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_p)
 "hsW" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N";
@@ -39989,6 +42218,36 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/engineering/upper_engineering/starboard)
+"hto" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/strata_decals/grime/grime3,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_p)
+"htF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln{
+	desc = "harmless exhaust discharge from a broken pipeline";
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "exhaust";
+	density = 0;
+	pixel_y = -1
+	},
+/obj/item/pipe{
+	pixel_y = -2;
+	pixel_x = -7
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	dir = 1;
+	icon_state = "lattice-simple";
+	pixel_x = 10
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_s)
 "htI" = (
 /obj/structure/platform_decoration{
 	dir = 1
@@ -40005,6 +42264,18 @@
 	icon_state = "greenfull"
 	},
 /area/almayer/living/offices)
+"htN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/lattice_prop{
+	dir = 1;
+	icon_state = "lattice-simple";
+	pixel_x = -16;
+	pixel_y = -16
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "huK" = (
 /turf/open/floor/almayer{
 	icon_state = "redcorner"
@@ -40027,6 +42298,19 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/hull/upper_hull/u_f_s)
+"hvk" = (
+/obj/structure/machinery/light/small,
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = -9
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = -11;
+	pixel_x = 1
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_p)
 "hvp" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
@@ -40120,6 +42404,13 @@
 	icon_state = "cargo"
 	},
 /area/almayer/engineering/engine_core)
+"hxx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/strata_decals/grime/grime2,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_s)
 "hxG" = (
 /obj/structure/pipes/vents/pump{
 	dir = 4
@@ -40326,6 +42617,18 @@
 	icon_state = "kitchen"
 	},
 /area/almayer/living/grunt_rnr)
+"hAB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/largecrate/random/barrel/green{
+	pixel_x = 2;
+	pixel_y = -8
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_s)
 "hAG" = (
 /obj/structure/closet/crate/internals,
 /obj/item/handcuffs/cable/blue,
@@ -40368,6 +42671,18 @@
 	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/lower_medical_medbay)
+"hBv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/used_stasis_bag{
+	pixel_x = 4
+	},
+/obj/item/trash/used_stasis_bag{
+	pixel_x = -8;
+	pixel_y = -7
+	},
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_s)
 "hBz" = (
 /obj/item/mortar_kit,
 /turf/open/floor/almayer{
@@ -40390,13 +42705,32 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/hangar)
 "hBU" = (
-/obj/structure/largecrate/random/secure,
 /obj/effect/decal/warning_stripes{
 	icon_state = "E"
 	},
-/turf/open/floor/almayer{
-	icon_state = "plate"
+/obj/structure/platform{
+	dir = 4;
+	layer = 2.7
 	},
+/obj/structure/prop/invuln{
+	desc = "a pile of cables";
+	icon = 'icons/obj/structures/machinery/artillery.dmi';
+	icon_state = "27";
+	name = "cables";
+	density = 0;
+	layer = 3
+	},
+/obj/structure/prop/invuln{
+	desc = "a pile of cables";
+	icon = 'icons/obj/structures/machinery/artillery.dmi';
+	icon_state = "27";
+	name = "cables";
+	density = 0;
+	layer = 3;
+	pixel_x = 14;
+	pixel_y = 5
+	},
+/turf/open/floor/plating,
 /area/almayer/hull/lower_hull/l_a_p)
 "hCo" = (
 /obj/structure/surface/table/almayer,
@@ -40474,6 +42808,10 @@
 	icon_state = "plate"
 	},
 /area/almayer/squads/bravo)
+"hEp" = (
+/obj/effect/decal/strata_decals/grime/grime3,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_s)
 "hEt" = (
 /obj/structure/surface/table/almayer,
 /obj/item/reagent_container/glass/bucket/mopbucket{
@@ -40535,6 +42873,17 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/upper_hull/u_f_s)
+"hGG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/hotdog{
+	pixel_x = -1;
+	pixel_y = -7
+	},
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_p)
 "hGN" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
@@ -40563,9 +42912,11 @@
 /area/almayer/living/briefing)
 "hGZ" = (
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/almayer{
-	icon_state = "plate"
+/obj/structure/bed/chair{
+	dir = 1
 	},
+/obj/effect/decal/cleanable/liquid_fuel,
+/turf/open/floor/plating,
 /area/almayer/hull/lower_hull/l_m_p)
 "hHl" = (
 /obj/structure/surface/table/reinforced/almayer_B,
@@ -40615,6 +42966,10 @@
 	icon_state = "plate"
 	},
 /area/almayer/hull/upper_hull/u_a_p)
+"hIh" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_f_s)
 "hII" = (
 /obj/structure/machinery/cm_vending/gear/tl{
 	density = 0;
@@ -40644,8 +42999,31 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/command/corporateliason)
+"hIR" = (
+/obj/item/reagent_container/glass/bucket/janibucket{
+	pixel_x = -1;
+	pixel_y = 13
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	dir = 1;
+	icon_state = "lattice-simple";
+	pixel_x = -14
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_f_s)
 "hJb" = (
 /obj/item/tool/pen,
+/obj/structure/prop/invuln/overhead_pipe{
+	pixel_x = 6;
+	pixel_y = 12
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	dir = 1;
+	icon_state = "lattice-simple";
+	pixel_x = 10
+	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -40748,6 +43126,19 @@
 /obj/structure/pipes/vents/scrubber,
 /turf/open/floor/almayer,
 /area/almayer/living/chapel)
+"hMl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/tool/warning_cone{
+	pixel_y = 7
+	},
+/obj/structure/barricade/handrail{
+	dir = 1;
+	pixel_y = 2
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_f_s)
 "hMs" = (
 /obj/structure/bed/stool,
 /turf/open/floor/almayer{
@@ -40827,6 +43218,23 @@
 	pixel_x = 32;
 	pixel_y = -8
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/hotdog{
+	pixel_x = -13;
+	pixel_y = 1
+	},
+/obj/item/trash/uscm_mre{
+	pixel_x = 9;
+	pixel_y = -10
+	},
+/obj/item/trash/uscm_mre{
+	pixel_x = -3;
+	pixel_y = 17
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	pixel_x = 6;
+	pixel_y = 12
+	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -40882,6 +43290,13 @@
 	icon_state = "orange"
 	},
 /area/almayer/hallways/stern_hallway)
+"hPL" = (
+/obj/effect/landmark/yautja_teleport,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_f_s)
 "hPN" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /obj/effect/decal/warning_stripes{
@@ -40912,6 +43327,11 @@
 	icon_state = "cargo_arrow"
 	},
 /area/almayer/squads/charlie_delta_shared)
+"hQj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/girder/displaced,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_s)
 "hQU" = (
 /obj/structure/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -40974,6 +43394,14 @@
 	icon_state = "lattice-simple";
 	pixel_x = -16;
 	pixel_y = -15
+	},
+/obj/item/prop{
+	desc = "An older design of the Pulse Rifle commonly used by Colonial Marines. This one has seen better days. The trigger is missing, the barrel is bent, and it no longer appropriately feeds magazines.";
+	icon = 'icons/obj/items/weapons/guns/guns_by_faction/uscm.dmi';
+	icon_state = "m41amk1_e";
+	item_state = "m41amk1";
+	name = "\improper Broken M41A pulse rifle";
+	pixel_y = 7
 	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
@@ -41072,6 +43500,12 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/hallways/repair_bay)
+"hSY" = (
+/obj/structure/girder/displaced,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "hTc" = (
 /obj/structure/machinery/firealarm{
 	pixel_y = 28
@@ -41131,6 +43565,33 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/aft_hallway)
+"hTE" = (
+/obj/structure/surface/table/almayer,
+/obj/item/prop{
+	desc = "An M83 SADAR Anti-Tank RPG, compacted for easier storage. This one has been expended";
+	icon = 'icons/obj/items/weapons/guns/guns_by_faction/uscm.dmi';
+	icon_state = "m83a2";
+	item_state = "m83a2_folded";
+	name = "\improper Used M83 SADAR";
+	pixel_y = -6;
+	pixel_x = -7
+	},
+/obj/item/prop{
+	desc = "An M83 SADAR Anti-Tank RPG, compacted for easier storage. This one has been expended";
+	icon = 'icons/obj/items/weapons/guns/guns_by_faction/uscm.dmi';
+	icon_state = "m83a2_folded";
+	item_state = "m83a2_folded";
+	name = "\improper Used M83 SADAR (folded)";
+	pixel_y = 9;
+	pixel_x = 1
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	pixel_x = 12
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "hTF" = (
 /obj/structure/machinery/suit_storage_unit/compression_suit/uscm{
 	isopen = 1;
@@ -41143,6 +43604,13 @@
 	icon_state = "plate"
 	},
 /area/almayer/engineering/upper_engineering/port)
+"hTG" = (
+/obj/structure/machinery/cm_vending/sorted/tech/tool_storage,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hallways/hangar)
 "hTP" = (
 /obj/structure/machinery/door_control{
 	id = "crate_room2";
@@ -41280,6 +43748,11 @@
 	icon_state = "blue"
 	},
 /area/almayer/command/cichallway)
+"hWP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/strata_decals/grime/grime3,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_s)
 "hWU" = (
 /obj/structure/largecrate/random/barrel/blue,
 /turf/open/floor/almayer{
@@ -41312,6 +43785,34 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/squads/alpha_bravo_shared)
+"hXf" = (
+/obj/effect/landmark/yautja_teleport,
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 15;
+	pixel_x = 1
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_p)
+"hXt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/obj/item/trash/uscm_mre{
+	pixel_x = -14;
+	pixel_y = 17
+	},
+/obj/item/trash/uscm_mre{
+	pixel_x = 9;
+	pixel_y = -10
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	pixel_x = 6;
+	pixel_y = 12
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_s)
 "hXY" = (
 /turf/open/floor/almayer{
 	dir = 4;
@@ -41330,6 +43831,7 @@
 /obj/item/tool/kitchen/knife{
 	pixel_x = 6
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -41406,6 +43908,13 @@
 	icon_state = "plate"
 	},
 /area/almayer/command/cichallway)
+"iai" = (
+/obj/structure/grille{
+	icon_state = "brokengrille";
+	density = 0
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_p)
 "iaj" = (
 /obj/structure/bed/chair/comfy/orange{
 	dir = 1
@@ -41495,6 +44004,19 @@
 	icon_state = "red"
 	},
 /area/almayer/shipboard/brig/perma)
+"idw" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_x = -12;
+	pixel_y = 13
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_f_s)
 "idx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -41507,12 +44029,32 @@
 	icon_state = "kitchen"
 	},
 /area/almayer/living/grunt_rnr)
+"idL" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/shipboard/port_point_defense)
 "idX" = (
 /obj/structure/pipes/vents/pump,
 /turf/open/floor/prison{
 	icon_state = "kitchen"
 	},
 /area/almayer/living/grunt_rnr)
+"ieh" = (
+/obj/effect/decal/cleanable/liquid_fuel,
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "ieo" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -41623,6 +44165,13 @@
 	icon_state = "red"
 	},
 /area/almayer/lifeboat_pumps/north1)
+"ifj" = (
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 9;
+	pixel_y = 7
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_f_s)
 "ifR" = (
 /obj/structure/sign/safety/hvac_old{
 	pixel_x = 8;
@@ -41674,12 +44223,9 @@
 	},
 /area/almayer/shipboard/brig/main_office)
 "ihn" = (
-/obj/structure/surface/table/almayer,
-/obj/item/reagent_container/food/drinks/cans/souto/blue{
-	pixel_x = 2;
-	pixel_y = 3
+/turf/closed/shuttle/escapepod{
+	icon_state = "wall3"
 	},
-/turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_m_s)
 "ihw" = (
 /obj/structure/machinery/cm_vending/sorted/medical,
@@ -41803,11 +44349,31 @@
 /area/almayer/command/corporateliason)
 "ijp" = (
 /obj/structure/surface/rack,
-/obj/item/storage/toolbox/mechanical,
-/obj/effect/spawner/random/tool,
+/obj/structure/prop/invuln/lattice_prop{
+	dir = 1;
+	icon_state = "lattice-simple";
+	pixel_x = -16;
+	pixel_y = -1
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice2";
+	pixel_x = -16;
+	pixel_y = 27
+	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
+/area/almayer/hull/lower_hull/l_f_s)
+"ijN" = (
+/obj/structure/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
+/turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_f_s)
 "ijQ" = (
 /obj/structure/surface/table/almayer,
@@ -41893,6 +44459,7 @@
 /area/almayer/lifeboat_pumps/south1)
 "ilZ" = (
 /obj/effect/spawner/random/toolbox,
+/obj/effect/decal/cleanable/blood/oil/streak,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -41910,6 +44477,16 @@
 	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/morgue)
+"imv" = (
+/obj/item/hardpoint/support/flare_launcher{
+	pixel_x = -11;
+	pixel_y = 5
+	},
+/obj/structure/blocker/invisible_wall{
+	name = "\improper M34A2 Longstreet light tank"
+	},
+/turf/open/floor/plating,
+/area/almayer/hallways/hangar)
 "imy" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer,
@@ -41972,6 +44549,16 @@
 	icon_state = "plate"
 	},
 /area/almayer/hull/lower_hull/l_f_p)
+"ioq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/ash,
+/obj/effect/decal/cleanable/generic,
+/obj/item/trash/tray{
+	pixel_x = -11;
+	pixel_y = 12
+	},
+/turf/open/floor/plating,
+/area/almayer/hull/lower_hull/l_m_p)
 "iow" = (
 /obj/structure/machinery/cm_vending/sorted/attachments/squad{
 	req_access = null;
@@ -42010,6 +44597,10 @@
 "ipD" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 10
+	},
+/obj/item/tool/warning_cone{
+	pixel_y = 7;
+	pixel_x = -2
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_m_s)
@@ -42101,6 +44692,16 @@
 	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering/port)
+"iqR" = (
+/obj/structure/machinery/camera/autoname/almayer{
+	dir = 8;
+	name = "ship-grade camera"
+	},
+/obj/effect/decal/strata_decals/grime/grime1{
+	dir = 8
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hallways/hangar)
 "irn" = (
 /obj/structure/largecrate/random/case/double,
 /turf/open/floor/plating/plating_catwalk,
@@ -42137,6 +44738,15 @@
 	icon_state = "red"
 	},
 /area/almayer/shipboard/brig/general_equipment)
+"irL" = (
+/obj/structure/sign/safety/storage{
+	pixel_x = -17
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_f_p)
 "irS" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/structure/cable/heavyduty{
@@ -42253,6 +44863,29 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/lifeboat_pumps/south2)
+"itW" = (
+/obj/structure/prop/invuln/overhead_pipe{
+	pixel_x = 6;
+	pixel_y = 12
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice10";
+	pixel_x = 10;
+	pixel_y = 15
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	dir = 1;
+	icon_state = "lattice-simple";
+	pixel_x = 10;
+	pixel_y = -16
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 15;
+	pixel_x = 1
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_p)
 "itX" = (
 /obj/structure/machinery/vending/coffee,
 /turf/open/floor/almayer{
@@ -42272,6 +44905,14 @@
 /obj/effect/spawner/random/tool,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/lifeboat_pumps/south1)
+"iuo" = (
+/obj/structure/closet/emcloset,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_p)
 "iur" = (
 /obj/structure/machinery/cm_vending/sorted/medical/wall_med{
 	pixel_y = 25
@@ -42327,6 +44968,25 @@
 	icon_state = "silver"
 	},
 /area/almayer/shipboard/brig/cic_hallway)
+"iuF" = (
+/obj/structure/machinery/door/airlock/almayer/maint{
+	dir = 1;
+	req_access = null;
+	req_one_access = null;
+	req_one_access_txt = "3;22;19"
+	},
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/hull/lower_hull/l_f_s)
+"iuM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/overhead/flammable_pipe/fly{
+	pixel_x = -2;
+	pixel_y = 13
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_s)
 "iuT" = (
 /obj/structure/closet/emcloset,
 /obj/structure/machinery/camera/autoname/almayer{
@@ -42414,6 +45074,19 @@
 	dir = 8
 	},
 /area/almayer/medical/containment/cell)
+"iwV" = (
+/obj/structure/prop/invuln/overhead_pipe{
+	pixel_x = 12
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	pixel_x = 12;
+	pixel_y = 12
+	},
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_s)
 "iwW" = (
 /obj/structure/bed/chair/comfy/beige,
 /turf/open/floor/carpet,
@@ -42493,6 +45166,13 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/shipboard/brig/main_office)
+"iyF" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_f_p)
 "iyH" = (
 /obj/structure/surface/table/reinforced/almayer_B{
 	climbable = 0;
@@ -42532,6 +45212,11 @@
 	icon_state = "plate"
 	},
 /area/almayer/living/offices)
+"izo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/strata_decals/grime/grime3,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_s)
 "izx" = (
 /obj/structure/reagent_dispensers/water_cooler/stacks{
 	density = 0;
@@ -42554,10 +45239,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/squads/alpha)
-"izU" = (
-/obj/structure/largecrate/random/case/small,
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/hull/lower_hull/l_m_s)
 "izY" = (
 /obj/structure/machinery/autodoc_console,
 /turf/open/floor/almayer{
@@ -42609,6 +45290,10 @@
 /area/almayer/hull/upper_hull/u_m_p)
 "iBE" = (
 /obj/effect/landmark/yautja_teleport,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/ice_colony/ground_wire{
+	dir = 4
+	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -42620,6 +45305,8 @@
 /obj/structure/reagent_dispensers/fueltank{
 	anchored = 1
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spider/stickyweb,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -42644,6 +45331,12 @@
 	icon_state = "red"
 	},
 /area/almayer/hallways/aft_hallway)
+"iCq" = (
+/obj/structure/grille,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "iCu" = (
 /obj/structure/machinery/door/poddoor/almayer/open{
 	dir = 4;
@@ -42724,6 +45417,16 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/hull/upper_hull/u_a_p)
+"iEF" = (
+/obj/structure/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/strata_decals/grime/grime1,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_s)
 "iFc" = (
 /obj/structure/pipes/vents/pump{
 	dir = 1
@@ -42748,6 +45451,12 @@
 	icon_state = "bluefull"
 	},
 /area/almayer/living/pilotbunks)
+"iFy" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/pipes/standard/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_s)
 "iFC" = (
 /obj/structure/surface/table/almayer,
 /obj/effect/landmark/map_item,
@@ -42816,7 +45525,12 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/obj/structure/largecrate/random/barrel/yellow,
+/obj/structure/prop/invuln/overhead/flammable_pipe/fly{
+	dir = 8;
+	pixel_x = -2;
+	pixel_y = 12;
+	layer = 4
+	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_m_p)
 "iGQ" = (
@@ -42876,6 +45590,17 @@
 	icon_state = "kitchen"
 	},
 /area/almayer/living/grunt_rnr)
+"iIF" = (
+/obj/structure/prop/invuln/overhead_pipe{
+	pixel_x = 12
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	pixel_x = 12;
+	pixel_y = 12
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_f_s)
 "iIP" = (
 /obj/structure/toilet{
 	pixel_y = 16
@@ -42903,6 +45628,7 @@
 /area/almayer/squads/bravo)
 "iIY" = (
 /obj/structure/closet/emcloset,
+/obj/effect/decal/cleanable/cobweb2,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -43001,6 +45727,18 @@
 	icon_state = "mono"
 	},
 /area/almayer/engineering/port_atmos)
+"iKV" = (
+/obj/effect/decal/cleanable/mucus,
+/obj/item/trash/hotdog{
+	pixel_x = -1;
+	pixel_y = -7
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	pixel_x = 6;
+	pixel_y = 12
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_p)
 "iKX" = (
 /obj/structure/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -43109,6 +45847,42 @@
 	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical_medbay)
+"iMJ" = (
+/obj/structure/machinery/light/small,
+/obj/structure/prop/invuln{
+	desc = "harmless exhaust discharge from a broken pipeline";
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "exhaust";
+	density = 0;
+	pixel_y = 1;
+	pixel_x = -9
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_p)
+"iNa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 15;
+	pixel_x = 1
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_p)
+"iNi" = (
+/obj/structure/platform{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/blood/oil,
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hallways/hangar)
 "iNZ" = (
 /obj/structure/machinery/light{
 	dir = 8
@@ -43133,6 +45907,12 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/shipboard/brig/cells)
+"iOP" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer{
+	icon_state = "silvercorner"
+	},
+/area/almayer/hallways/hangar)
 "iPv" = (
 /obj/structure/bed/chair/comfy,
 /obj/structure/window/reinforced/ultra,
@@ -43281,6 +46061,25 @@
 /obj/item/trash/chips,
 /turf/open/floor/plating,
 /area/almayer/hull/lower_hull/l_f_p)
+"iSo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/strata_decals/grime/grime3,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_p)
+"iSu" = (
+/obj/item/tool/warning_cone{
+	pixel_y = 11;
+	pixel_x = 13
+	},
+/obj/structure/largecrate/random/case{
+	pixel_x = 4;
+	pixel_y = -11
+	},
+/obj/structure/pipes/standard/simple/hidden/supply,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hallways/hangar)
 "iSZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -43321,6 +46120,7 @@
 	pixel_x = 8;
 	pixel_y = 32
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -43355,6 +46155,28 @@
 	},
 /turf/open/floor/plating,
 /area/almayer/hull/lower_hull/l_f_p)
+"iTR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/oil/streak,
+/obj/structure/prop/invuln/overhead_pipe{
+	pixel_x = 6;
+	pixel_y = 12
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_p)
+"iUc" = (
+/obj/structure/sign/safety/water{
+	pixel_x = 8;
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/tool/wet_sign,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_p)
 "iUo" = (
 /obj/structure/sign/safety/terminal{
 	pixel_x = 7;
@@ -43409,6 +46231,19 @@
 	icon_state = "silvercorner"
 	},
 /area/almayer/command/cichallway)
+"iVz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 6;
+	pixel_y = -9
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice6";
+	pixel_x = 1;
+	pixel_y = -11
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_p)
 "iVE" = (
 /obj/structure/sign/safety/bathunisex{
 	pixel_x = 32
@@ -43464,6 +46299,13 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/hallways/stern_hallway)
+"iWk" = (
+/obj/item/device/flashlight/lamp/tripod/grey,
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/shuttle/escapepod{
+	icon_state = "floor10"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "iWx" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "SW-out"
@@ -43474,6 +46316,24 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/hallways/hangar)
+"iWI" = (
+/obj/structure/prop/invuln/overhead_pipe{
+	pixel_x = 12
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 6;
+	pixel_y = -9
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = -11;
+	pixel_x = 1
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_p)
 "iWL" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer{
@@ -43740,8 +46600,27 @@
 	pixel_x = 8;
 	pixel_y = 32
 	},
+/obj/structure/prop/invuln/overhead/flammable_pipe/fly{
+	dir = 8;
+	pixel_x = -2;
+	pixel_y = 13;
+	layer = 4
+	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_m_p)
+"jbo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7;
+	pixel_x = 13
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_s)
 "jbq" = (
 /obj/structure/window/framed/almayer/hull,
 /turf/open/floor/plating,
@@ -43849,8 +46728,19 @@
 	pixel_x = 7;
 	pixel_y = 32
 	},
+/obj/effect/decal/cleanable/liquid_fuel,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_a_p)
+"jdE" = (
+/obj/structure/largecrate/random/barrel/red{
+	pixel_x = -11;
+	pixel_y = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_f_p)
 "jdG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -43868,6 +46758,15 @@
 /obj/structure/sign/safety/water{
 	pixel_x = 15;
 	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_a_p)
@@ -44130,6 +47029,7 @@
 	dir = 8;
 	pixel_y = 3
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -44140,6 +47040,21 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/squads/alpha_bravo_shared)
+"jhU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/overhead_pipe{
+	pixel_x = 6;
+	pixel_y = 12
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	dir = 1;
+	icon_state = "lattice-simple";
+	pixel_x = 10
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_s)
 "jhW" = (
 /obj/structure/machinery/cryopod/right,
 /turf/open/floor/almayer{
@@ -44312,6 +47227,14 @@
 	icon_state = "plate"
 	},
 /area/almayer/shipboard/brig/perma)
+"jlj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/powerloader_wreckage,
+/turf/open/floor/almayer{
+	dir = 10;
+	icon_state = "cargo"
+	},
+/area/almayer/hallways/hangar)
 "jlA" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
@@ -44368,8 +47291,31 @@
 	icon_state = "plate"
 	},
 /area/almayer/command/lifeboat)
+"jma" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_x = -12;
+	pixel_y = 13
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_f_s)
 "jmg" = (
 /obj/structure/largecrate/supply/ammo/shotgun,
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7;
+	pixel_x = 13
+	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_a_s)
 "jmK" = (
@@ -44447,12 +47393,30 @@
 	icon_state = "silvercorner"
 	},
 /area/almayer/shipboard/brig/cic_hallway)
+"jnI" = (
+/obj/structure/platform{
+	dir = 4;
+	layer = 2.7
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/folder/black_random,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hallways/hangar)
 "jnT" = (
 /obj/structure/bed/chair,
 /turf/open/floor/almayer{
 	allow_construction = 0
 	},
 /area/almayer/shipboard/brig/lobby)
+"jnW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "jnX" = (
 /obj/structure/window/framed/almayer,
 /obj/structure/machinery/door/poddoor/almayer/open{
@@ -44516,21 +47480,44 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/upper_hull/u_f_s)
 "jpN" = (
-/obj/structure/surface/rack,
-/obj/item/storage/box/cups{
-	pixel_x = 4;
-	pixel_y = 9
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 6;
+	pixel_y = 7;
+	pixel_x = -15
 	},
-/obj/item/storage/box/cups,
-/turf/open/floor/almayer{
-	icon_state = "plate"
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7;
+	pixel_x = 16
 	},
+/turf/open/floor/plating,
 /area/almayer/hull/lower_hull/l_f_s)
 "jpQ" = (
 /turf/open/floor/almayer{
 	allow_construction = 0
 	},
 /area/almayer/shipboard/brig/lobby)
+"jpW" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/grille,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_p)
+"jql" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plating,
+/area/almayer/hull/lower_hull/l_m_p)
+"jqv" = (
+/obj/effect/decal/cleanable/blood/oil/streak,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_s)
 "jqP" = (
 /obj/structure/machinery/door/poddoor/shutters/almayer{
 	id = "ARES Interior";
@@ -44568,6 +47555,29 @@
 	icon_state = "plate"
 	},
 /area/almayer/living/pilotbunks)
+"jrn" = (
+/obj/structure/sign/safety/hvac_old{
+	pixel_x = 8;
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/obj/effect/decal/cleanable/cobweb,
+/obj/item/stack/tile/plasteel{
+	pixel_y = -12;
+	pixel_x = 5
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "jrM" = (
 /obj/structure/machinery/camera/autoname/almayer/containment{
 	dir = 4
@@ -44623,6 +47633,7 @@
 	layer = 2.5;
 	pixel_y = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_f_s)
 "juD" = (
@@ -44738,6 +47749,21 @@
 "jvY" = (
 /turf/closed/wall/almayer/reinforced,
 /area/almayer/command/telecomms)
+"jwJ" = (
+/obj/effect/decal/cleanable/liquid_fuel,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "jwK" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer{
@@ -44860,6 +47886,13 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/engineering/upper_engineering/port)
+"jAT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/girder,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_s)
 "jBy" = (
 /obj/structure/machinery/light{
 	dir = 4
@@ -44954,6 +47987,18 @@
 	},
 /turf/open/floor/plating,
 /area/almayer/hull/lower_hull/l_f_p)
+"jEz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_p)
 "jFe" = (
 /obj/structure/prop/holidays/string_lights{
 	pixel_y = 27
@@ -44993,6 +48038,31 @@
 	icon_state = "cargo"
 	},
 /area/almayer/hull/lower_hull/l_f_s)
+"jFy" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln{
+	desc = "a pile of cables";
+	icon = 'icons/obj/structures/props/almayer_props.dmi';
+	icon_state = "cannon_cables";
+	name = "cables";
+	density = 0;
+	layer = 3;
+	pixel_x = -17
+	},
+/obj/structure/prop/invuln{
+	desc = "a pile of cables";
+	icon = 'icons/obj/structures/machinery/artillery.dmi';
+	icon_state = "27";
+	name = "cables";
+	density = 0;
+	layer = 3;
+	pixel_x = -4
+	},
+/obj/item/device/flashlight/lamp/tripod/grey{
+	pixel_x = 5
+	},
+/turf/open/floor/plating,
+/area/almayer/hull/lower_hull/l_a_p)
 "jFE" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/pipes/standard/simple/hidden/supply,
@@ -45204,6 +48274,16 @@
 	icon_state = "green"
 	},
 /area/almayer/hallways/aft_hallway)
+"jKL" = (
+/obj/structure/largecrate,
+/obj/structure/prop/server_equipment/laptop{
+	pixel_x = 1;
+	pixel_y = 10
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_p)
 "jLj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -45354,6 +48434,7 @@
 	req_access = null
 	},
 /obj/item/clothing/mask/rebreather/scarf/tacticalmask/red,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -45365,6 +48446,18 @@
 	icon_state = "plate"
 	},
 /area/almayer/hull/lower_hull/l_f_s)
+"jNL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/strata_decals/grime/grime1{
+	dir = 1
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	pixel_x = 12
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "jOi" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -45435,6 +48528,16 @@
 	icon_state = "plate"
 	},
 /area/almayer/squads/bravo)
+"jOA" = (
+/obj/structure/sign/safety/water{
+	pixel_x = 8;
+	pixel_y = -32
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/liquid_fuel,
+/obj/structure/girder/displaced,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_s)
 "jOG" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /obj/structure/machinery/firealarm{
@@ -45446,10 +48549,24 @@
 	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/upper_medical)
+"jOU" = (
+/obj/item/device/radio/intercom{
+	freerange = 1;
+	name = "General Listening Channel";
+	pixel_y = 28
+	},
+/obj/item/tool/warning_cone{
+	pixel_x = -20;
+	pixel_y = 18
+	},
+/turf/open/floor/almayer,
+/area/almayer/hallways/starboard_hallway)
 "jPf" = (
 /obj/structure/prop/invuln/overhead_pipe{
 	pixel_x = 12
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/inflatable,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_a_s)
 "jPq" = (
@@ -45466,6 +48583,9 @@
 "jQA" = (
 /obj/structure/pipes/vents/scrubber{
 	dir = 4
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	pixel_x = 12
 	},
 /turf/open/floor/almayer{
 	dir = 8;
@@ -45545,6 +48665,25 @@
 	icon_state = "red"
 	},
 /area/almayer/shipboard/brig/processing)
+"jSx" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "E";
+	pixel_x = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/strata_decals/grime/grime3,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
+"jSL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/oil/streak,
+/obj/item/trash/cheesie,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_p)
 "jSU" = (
 /obj/structure/bed/chair{
 	can_buckle = 0;
@@ -45604,6 +48743,7 @@
 /obj/structure/sign/safety/nonpress_ag{
 	pixel_x = 32
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_f_p)
 "jTI" = (
@@ -45737,6 +48877,13 @@
 	icon_state = "test_floor5"
 	},
 /area/almayer/command/computerlab)
+"jVH" = (
+/obj/item/tool/wrench{
+	pixel_x = -6;
+	pixel_y = -9
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_s)
 "jWh" = (
 /turf/closed/wall/almayer,
 /area/almayer/engineering/upper_engineering/port)
@@ -45877,6 +49024,31 @@
 	icon_state = "emerald"
 	},
 /area/almayer/squads/charlie)
+"jZz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/platform,
+/obj/structure/platform{
+	dir = 1
+	},
+/obj/structure/platform{
+	dir = 4
+	},
+/obj/structure/platform_decoration{
+	dir = 6;
+	layer = 3.51
+	},
+/obj/structure/platform_decoration{
+	dir = 9;
+	layer = 3.51
+	},
+/obj/structure/prop/invuln/overhead/flammable_pipe/fly{
+	dir = 4;
+	icon_state = "flammable_pipe_3";
+	pixel_x = 2;
+	pixel_y = 8
+	},
+/turf/open/floor/plating,
+/area/almayer/hull/lower_hull/l_m_s)
 "jZL" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/computer/cameras/almayer_network{
@@ -45896,7 +49068,7 @@
 /turf/open/floor/almayer,
 /area/almayer/shipboard/brig/main_office)
 "jZO" = (
-/obj/structure/largecrate/random/barrel/blue,
+/obj/structure/prop/cash_register/broken,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -46051,6 +49223,15 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/living/briefing)
+"kch" = (
+/obj/structure/prop/invuln/lattice_prop{
+	dir = 1;
+	icon_state = "lattice-simple";
+	pixel_x = 14;
+	pixel_y = -16
+	},
+/turf/closed/wall/almayer/outer,
+/area/almayer/hull/lower_hull/l_m_s)
 "kcl" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer{
 	dir = 2
@@ -46076,6 +49257,22 @@
 "kcN" = (
 /turf/closed/wall/almayer/outer,
 /area/almayer/living/commandbunks)
+"kdc" = (
+/obj/effect/decal/cleanable/blood/oil/streak,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/strata_decals/grime/grime4,
+/obj/item/ammo_magazine/smg/m39/heap{
+	pixel_y = -1;
+	pixel_x = 6;
+	current_rounds = 0
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	pixel_x = 12
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "kdi" = (
 /obj/item/device/flashlight/pen{
 	pixel_x = 4;
@@ -46152,6 +49349,13 @@
 	icon_state = "plate"
 	},
 /area/almayer/hull/upper_hull/u_a_p)
+"kfD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/largecrate/random/barrel/yellow,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_p)
 "kfE" = (
 /obj/structure/bed/sofa/south/grey/right,
 /obj/structure/machinery/cm_vending/sorted/medical/wall_med{
@@ -46271,6 +49475,7 @@
 /obj/structure/machinery/light/small{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -46377,6 +49582,13 @@
 	icon_state = "greenfull"
 	},
 /area/almayer/living/offices)
+"kkv" = (
+/obj/item/tool/crowbar,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "kkx" = (
 /obj/structure/pipes/standard/manifold/hidden/supply,
 /turf/open/floor/almayer{
@@ -46470,6 +49682,14 @@
 	icon_state = "plate"
 	},
 /area/almayer/living/pilotbunks)
+"knl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/cigbutt{
+	pixel_x = 1;
+	pixel_y = 8
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/starboard_point_defense)
 "knH" = (
 /obj/structure/machinery/vending/coffee,
 /obj/structure/sign/safety/coffee{
@@ -46505,6 +49725,8 @@
 	pixel_x = 8;
 	pixel_y = 32
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_m_p)
 "koB" = (
@@ -46571,6 +49793,7 @@
 	pixel_x = 12;
 	pixel_y = 12
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -46675,6 +49898,15 @@
 	icon_state = "bluecorner"
 	},
 /area/almayer/living/basketball)
+"kqX" = (
+/obj/effect/decal/strata_decals/grime/grime1{
+	dir = 8
+	},
+/obj/structure/largecrate/random/barrel/green{
+	pixel_x = 3
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_p)
 "kro" = (
 /turf/open/floor/almayer{
 	icon_state = "green"
@@ -46796,7 +50028,24 @@
 	},
 /area/almayer/shipboard/brig/armory)
 "ktB" = (
-/obj/structure/largecrate/random/barrel/white,
+/obj/structure/surface/table/almayer,
+/obj/item/ammo_magazine/rifle/heap{
+	current_rounds = 0;
+	pixel_y = 5;
+	pixel_x = 6
+	},
+/obj/item/ammo_magazine/rifle/heap{
+	current_rounds = 0;
+	pixel_y = 10;
+	pixel_x = -4
+	},
+/obj/item/ammo_magazine/rifle/heap{
+	current_rounds = 0;
+	pixel_x = -3;
+	pixel_y = -4
+	},
+/obj/item/ammo_casing/bullet,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "cargo"
 	},
@@ -46811,7 +50060,11 @@
 	},
 /area/almayer/engineering/engine_core)
 "ktP" = (
-/obj/structure/curtain/red,
+/obj/structure/machinery/door/airlock/almayer/generic/glass,
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = -5
+	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -46835,6 +50088,15 @@
 	icon_state = "emeraldcorner"
 	},
 /area/almayer/living/briefing)
+"kuD" = (
+/obj/item/device/taperecorder/empty{
+	pixel_x = -1;
+	pixel_y = -9
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_p)
 "kvh" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/computer/station_alert{
@@ -46853,6 +50115,10 @@
 	},
 /area/almayer/engineering/engine_core)
 "kvN" = (
+/obj/structure/prop/invuln/overhead_pipe{
+	pixel_x = 12
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	dir = 10;
 	icon_state = "orange"
@@ -46875,7 +50141,7 @@
 /turf/open/floor/almayer,
 /area/almayer/lifeboat_pumps/south1)
 "kwq" = (
-/obj/structure/largecrate/random/case/double,
+/obj/effect/spider/stickyweb,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_f_p)
 "kws" = (
@@ -47071,6 +50337,16 @@
 	icon_state = "silver"
 	},
 /area/almayer/command/airoom)
+"kAg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/grille{
+	icon_state = "brokengrille";
+	density = 0
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "kAh" = (
 /obj/structure/sign/safety/restrictedarea{
 	pixel_x = -17
@@ -47090,6 +50366,7 @@
 /obj/structure/prop/invuln/overhead_pipe{
 	pixel_x = 12
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -47114,6 +50391,13 @@
 	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/medical_science)
+"kBq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_p)
 "kBy" = (
 /obj/structure/machinery/ares/processor,
 /turf/open/floor/almayer/no_build{
@@ -47172,6 +50456,12 @@
 	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/containment)
+"kCL" = (
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_p)
 "kCS" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer,
@@ -47232,6 +50522,19 @@
 	icon_state = "red"
 	},
 /area/almayer/lifeboat_pumps/south1)
+"kDu" = (
+/obj/effect/decal/cleanable/blood/oil/streak,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_s)
 "kDA" = (
 /obj/structure/pipes/vents/scrubber,
 /turf/open/floor/almayer{
@@ -47264,6 +50567,20 @@
 	icon_state = "sterile_green_corner"
 	},
 /area/almayer/medical/morgue)
+"kEN" = (
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/obj/effect/decal/cleanable/blood/oil/streak,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "kFe" = (
 /obj/structure/machinery/constructable_frame,
 /turf/open/floor/almayer{
@@ -47333,6 +50650,7 @@
 /obj/structure/sign/safety/distribution_pipes{
 	pixel_x = -17
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -47400,7 +50718,9 @@
 	pixel_x = 32;
 	pixel_y = 7
 	},
-/turf/open/floor/plating/plating_catwalk,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/platform,
+/turf/open/floor/plating,
 /area/almayer/hull/lower_hull/l_m_p)
 "kHK" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
@@ -47535,6 +50855,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_x = -8
+	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -47594,6 +50919,12 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/upper_hull/u_a_p)
+"kMD" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/buritto,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_p)
 "kMH" = (
 /obj/structure/machinery/door/window/brigdoor/southright{
 	id = "Cell 1";
@@ -47687,11 +51018,10 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/weapon_room)
 "kOf" = (
-/obj/structure/bed/chair{
-	dir = 8;
-	pixel_y = 3
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
 	},
-/turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_m_s)
 "kOi" = (
 /obj/structure/sink{
@@ -47708,6 +51038,18 @@
 	},
 /turf/open/floor/plating,
 /area/almayer/hull/lower_hull/l_f_p)
+"kOr" = (
+/obj/structure/largecrate/supply/supplies/flares,
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_p)
 "kOv" = (
 /turf/open/floor/almayer{
 	icon_state = "cargo_arrow"
@@ -47858,6 +51200,16 @@
 	pixel_x = -16;
 	pixel_y = 17
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7;
+	pixel_x = 13
+	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_m_p)
 "kRP" = (
@@ -47916,6 +51268,11 @@
 	icon_state = "red"
 	},
 /area/almayer/hallways/aft_hallway)
+"kSR" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_p)
 "kTc" = (
 /obj/structure/closet/secure_closet/guncabinet/red,
 /obj/item/ammo_magazine/shotgun,
@@ -47940,6 +51297,15 @@
 /area/almayer/shipboard/brig/armory)
 "kTq" = (
 /obj/structure/largecrate/supply/supplies/mre,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -47994,16 +51360,29 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/living/pilotbunks)
+"kUm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/largecrate/random/secure,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_s)
 "kUt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
 	},
 /obj/structure/surface/rack,
-/obj/item/frame/table,
-/obj/item/frame/table,
-/obj/item/frame/table,
-/turf/open/floor/plating/plating_catwalk,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/overhead/flammable_pipe/fly{
+	dir = 8;
+	pixel_x = 3;
+	pixel_y = -7
+	},
+/obj/structure/prop/invuln/fire,
+/obj/item/trash/crushed_cup,
+/obj/effect/decal/cleanable/ash,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
 /area/almayer/hull/lower_hull/l_m_p)
 "kUw" = (
 /obj/structure/surface/rack,
@@ -48031,6 +51410,21 @@
 	icon_state = "mono"
 	},
 /area/almayer/lifeboat_pumps/south2)
+"kVJ" = (
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = -9
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = -11;
+	pixel_x = 1
+	},
+/obj/effect/decal/cleanable/liquid_fuel,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_p)
 "kVX" = (
 /obj/structure/window/framed/almayer,
 /obj/structure/machinery/door/poddoor/shutters/almayer{
@@ -48164,6 +51558,16 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/hull/lower_hull/l_f_s)
+"kYd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/ice_colony/ground_wire{
+	dir = 8
+	},
+/obj/effect/decal/strata_decals/grime/grime4,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "kYP" = (
 /obj/structure/sign/safety/maint{
 	pixel_x = 32
@@ -48198,6 +51602,20 @@
 	icon_state = "plate"
 	},
 /area/almayer/living/offices)
+"kZt" = (
+/obj/structure/prop/invuln/overhead_pipe{
+	pixel_x = 6;
+	pixel_y = 12
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	dir = 1;
+	icon_state = "lattice-simple";
+	pixel_x = 10
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_p)
 "kZA" = (
 /turf/open/floor/almayer{
 	dir = 4;
@@ -48228,6 +51646,21 @@
 	icon_state = "mono"
 	},
 /area/almayer/medical/hydroponics)
+"lab" = (
+/obj/structure/platform{
+	dir = 8
+	},
+/obj/structure/prop/invuln{
+	desc = "a pile of cables";
+	icon = 'icons/obj/structures/machinery/artillery.dmi';
+	icon_state = "27";
+	name = "cables";
+	density = 0;
+	layer = 3;
+	pixel_x = 6
+	},
+/turf/open/floor/plating,
+/area/almayer/hull/lower_hull/l_a_p)
 "lah" = (
 /turf/open/floor/almayer{
 	dir = 6;
@@ -48254,6 +51687,19 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/upper_hull/u_m_p)
+"laF" = (
+/obj/structure/platform{
+	dir = 4;
+	layer = 2.7
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 10
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hallways/hangar)
 "laO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -48267,7 +51713,11 @@
 /obj/structure/machinery/light/small{
 	dir = 8
 	},
-/turf/open/floor/plating/plating_catwalk,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/strata_decals/grime/grime2{
+	dir = 4
+	},
+/turf/open/floor/plating,
 /area/almayer/hull/lower_hull/l_m_p)
 "laQ" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer{
@@ -48467,6 +51917,7 @@
 /obj/effect/spawner/random/tool,
 /obj/effect/spawner/random/powercell,
 /obj/effect/spawner/random/powercell,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -48617,6 +52068,13 @@
 	icon_state = "mono"
 	},
 /area/almayer/medical/medical_science)
+"lih" = (
+/obj/structure/largecrate/random/case/double,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "lin" = (
 /obj/effect/projector{
 	name = "Almayer_AresDown";
@@ -48729,6 +52187,30 @@
 	icon_state = "red"
 	},
 /area/almayer/living/offices/flight)
+"lki" = (
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = -9
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = -5
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_s)
+"lkz" = (
+/obj/structure/bed/stool,
+/obj/structure/prop/holidays/string_lights{
+	pixel_y = 27
+	},
+/turf/open/floor/plating,
+/area/almayer/hull/lower_hull/l_m_s)
+"lkH" = (
+/obj/effect/decal/strata_decals/grime/grime2{
+	dir = 1
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_s)
 "lkM" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
@@ -48966,6 +52448,15 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/powered/agent)
+"lpz" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_p)
 "lpD" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
@@ -48981,9 +52472,39 @@
 /obj/structure/largecrate/random/barrel/red,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_f_s)
+"lpU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/obj/item/trash/barcardine,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hallways/hangar)
 "lpX" = (
 /obj/structure/prop/invuln/overhead_pipe{
 	pixel_x = 12
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice1";
+	pixel_x = 15;
+	pixel_y = -6
+	},
+/obj/effect/decal/cleanable/cobweb{
+	dir = 8;
+	pixel_x = -11;
+	pixel_y = 1
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
+"lqz" = (
+/obj/structure/closet/emcloset,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
 	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
@@ -48997,6 +52518,9 @@
 /area/almayer/medical/lower_medical_lobby)
 "lqI" = (
 /obj/structure/bed/chair{
+	dir = 8
+	},
+/obj/effect/decal/strata_decals/grime/grime2{
 	dir = 8
 	},
 /turf/open/floor/plating/plating_catwalk,
@@ -49079,6 +52603,23 @@
 	icon_state = "plate"
 	},
 /area/almayer/living/port_emb)
+"lrC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/handrail{
+	dir = 8
+	},
+/obj/item/tool/warning_cone{
+	pixel_x = 3;
+	pixel_y = 11
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_f_s)
 "lrT" = (
 /obj/structure/bed/chair,
 /turf/open/floor/almayer,
@@ -49134,6 +52675,27 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/command/cichallway)
+"lsy" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/sign/safety/distribution_pipes{
+	pixel_x = 8;
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/overhead/flammable_pipe/fly{
+	dir = 8;
+	pixel_x = -2;
+	pixel_y = 13;
+	layer = 4
+	},
+/obj/structure/bed/chair{
+	dir = 8;
+	pixel_y = 3
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_p)
 "lsD" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 4
@@ -49202,8 +52764,8 @@
 /obj/structure/machinery/light/small{
 	dir = 8
 	},
-/obj/item/clothing/head/helmet/marine/tech/tanker,
 /obj/structure/largecrate/random/secure,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -49223,6 +52785,7 @@
 	pixel_x = 8;
 	pixel_y = 32
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -49312,6 +52875,20 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/command/cic)
+"lvu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_p)
 "lvA" = (
 /obj/structure/machinery/power/apc/almayer/hardened{
 	dir = 1
@@ -49409,6 +52986,12 @@
 	icon_state = "emeraldfull"
 	},
 /area/almayer/squads/charlie)
+"lwR" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_p)
 "lxo" = (
 /obj/structure/sign/safety/hazard{
 	pixel_x = -17;
@@ -49430,6 +53013,13 @@
 	icon_state = "plate"
 	},
 /area/almayer/living/auxiliary_officer_office)
+"lyb" = (
+/obj/item/ammo_magazine/rocket/custom{
+	pixel_y = -7
+	},
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_s)
 "lyi" = (
 /obj/structure/surface/table/almayer,
 /obj/item/trash/pistachios,
@@ -49470,6 +53060,18 @@
 	icon_state = "plate"
 	},
 /area/almayer/living/auxiliary_officer_office)
+"lyY" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/prop/invuln/overhead/flammable_pipe/fly{
+	dir = 8;
+	pixel_x = -2;
+	pixel_y = 12;
+	layer = 4
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_p)
 "lzj" = (
 /obj/structure/sign/safety/storage{
 	pixel_x = 8;
@@ -49564,6 +53166,7 @@
 	dir = 1
 	},
 /obj/structure/largecrate/random/barrel/red,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -49637,6 +53240,34 @@
 	icon_state = "plate"
 	},
 /area/almayer/engineering/engineering_workshop/hangar)
+"lCh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/strata_decals/grime/grime1,
+/obj/effect/decal/strata_decals/grime/grime1,
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_f_s)
+"lCo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/surface/table/almayer,
+/obj/item/tool/weldpack{
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/obj/item/tool/screwdriver,
+/obj/item/stack/cable_coil{
+	pixel_x = 5;
+	pixel_y = 11
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hallways/hangar)
 "lCt" = (
 /turf/open/floor/almayer{
 	dir = 10;
@@ -49657,6 +53288,21 @@
 	icon_state = "red"
 	},
 /area/almayer/hallways/aft_hallway)
+"lCG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/obj/effect/decal/cleanable/blood/oil,
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_p)
 "lCM" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -49666,6 +53312,10 @@
 	icon_state = "red"
 	},
 /area/almayer/shipboard/brig/main_office)
+"lCN" = (
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_s)
 "lCS" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "SW-out";
@@ -49875,6 +53525,15 @@
 	pixel_x = 16;
 	pixel_y = -15
 	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7;
+	pixel_x = 13
+	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_m_p)
 "lFK" = (
@@ -49888,11 +53547,21 @@
 /obj/structure/sign/safety/maint{
 	pixel_x = -17
 	},
+/obj/item/tool/warning_cone{
+	pixel_y = 7;
+	pixel_x = -2
+	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/starboard_hallway)
 "lGr" = (
 /obj/structure/prop/invuln/overhead_pipe{
 	pixel_x = 12
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice1";
+	pixel_x = 15;
+	pixel_y = -6
 	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
@@ -49913,6 +53582,20 @@
 	icon_state = "plate"
 	},
 /area/almayer/hull/upper_hull/u_f_p)
+"lGE" = (
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = -9
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = -5
+	},
+/obj/effect/decal/cleanable/blood/oil/streak,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_s)
 "lGG" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -49933,9 +53616,15 @@
 /turf/open/floor/almayer,
 /area/almayer/hull/upper_hull/u_f_s)
 "lGO" = (
-/obj/structure/largecrate/random/case/double,
 /obj/structure/machinery/light/small{
 	dir = 4
+	},
+/obj/structure/surface/rack,
+/obj/item/ammo_magazine/rifle{
+	ammo_band_color = "#9C9A19";
+	current_rounds = 5;
+	desc = "Seems someone stuffed this with soft point ammo";
+	name = "\improper M41A HEAP magazine (10x24mm)"
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_m_s)
@@ -49972,6 +53661,38 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/hull/upper_hull/u_f_s)
+"lIj" = (
+/obj/structure/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/cigbutt,
+/obj/item/trash/cigbutt,
+/obj/item/trash/cigbutt{
+	pixel_x = -7;
+	pixel_y = 13
+	},
+/obj/item/trash/cigbutt{
+	pixel_x = -12;
+	pixel_y = 17
+	},
+/obj/item/trash/cigbutt{
+	pixel_x = 4
+	},
+/obj/item/trash/cigbutt{
+	pixel_x = -9;
+	pixel_y = -6
+	},
+/obj/item/trash/cigbutt{
+	pixel_x = 1;
+	pixel_y = 8
+	},
+/obj/effect/decal/cleanable/cobweb2,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/shipboard/starboard_point_defense)
 "lIp" = (
 /obj/structure/bed/chair/comfy/beige{
 	dir = 1
@@ -50112,6 +53833,12 @@
 /obj/structure/surface/table/almayer,
 /turf/open/floor/almayer,
 /area/almayer/squads/charlie)
+"lLH" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_s)
 "lLS" = (
 /obj/structure/sign/safety/galley{
 	pixel_x = 32
@@ -50122,8 +53849,10 @@
 	},
 /area/almayer/command/cichallway)
 "lLV" = (
-/obj/structure/largecrate/random/barrel/green,
-/turf/open/floor/plating/plating_catwalk,
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
 /area/almayer/hull/lower_hull/l_m_s)
 "lMc" = (
 /turf/open/floor/almayer{
@@ -50217,6 +53946,16 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7;
+	pixel_x = 13
+	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -50234,6 +53973,16 @@
 	icon_state = "redcorner"
 	},
 /area/almayer/shipboard/brig/execution)
+"lNS" = (
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/obj/structure/girder/displaced,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "lOl" = (
 /obj/structure/machinery/light{
 	dir = 8
@@ -50272,6 +54021,13 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/medical/medical_science)
+"lOO" = (
+/obj/structure/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_f_s)
 "lPB" = (
 /obj/structure/surface/table/almayer,
 /obj/item/device/lightreplacer,
@@ -50442,6 +54198,13 @@
 	icon_state = "green"
 	},
 /area/almayer/hallways/port_hallway)
+"lSW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/accessory/stethoscope,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_s)
 "lTt" = (
 /obj/structure/pipes/standard/manifold/hidden/supply{
 	dir = 1
@@ -50465,6 +54228,18 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/upper_hull/u_f_p)
+"lUx" = (
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/blood/oil/streak,
+/turf/open/floor/plating,
+/area/almayer/hull/lower_hull/l_m_s)
+"lUJ" = (
+/obj/structure/largecrate/random/secure,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "lVl" = (
 /obj/structure/machinery/cm_vending/sorted/tech/electronics_storage,
 /turf/open/floor/almayer,
@@ -50483,6 +54258,13 @@
 	icon_state = "redfull"
 	},
 /area/almayer/living/briefing)
+"lVY" = (
+/obj/effect/decal/cleanable/liquid_fuel,
+/obj/structure/prop/mech/hydralic_clamp,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "lWh" = (
 /obj/structure/machinery/pipedispenser/orderable,
 /turf/open/floor/almayer{
@@ -50496,6 +54278,26 @@
 	icon_state = "red"
 	},
 /area/almayer/lifeboat_pumps/south1)
+"lWU" = (
+/obj/structure/sign/safety/hvac_old{
+	pixel_x = 8;
+	pixel_y = 32
+	},
+/obj/item/stack/tile/plasteel{
+	pixel_x = 3;
+	pixel_y = 10
+	},
+/obj/item/tool/warning_cone{
+	pixel_x = -20;
+	pixel_y = 18
+	},
+/obj/structure/prop/ice_colony/ground_wire{
+	dir = 8
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "lXg" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/recharger,
@@ -50515,6 +54317,10 @@
 	icon_state = "plate"
 	},
 /area/almayer/hull/lower_hull)
+"lXG" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_s)
 "lXO" = (
 /obj/structure/surface/table/almayer,
 /obj/item/paper_bin/uscm,
@@ -50547,6 +54353,7 @@
 /obj/item/tool/wet_sign,
 /obj/structure/disposalpipe/segment,
 /obj/structure/pipes/standard/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -50609,6 +54416,7 @@
 	pixel_x = 8;
 	pixel_y = 32
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -50648,7 +54456,8 @@
 "maw" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/machinery/door/airlock/almayer/maint{
-	dir = 1
+	dir = 1;
+	name = "\improper Ammo Storage"
 	},
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer{
@@ -50682,11 +54491,34 @@
 	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/upper_medical)
+"maX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/largecrate/random/barrel/yellow,
+/obj/structure/prop/invuln/overhead/flammable_pipe/fly{
+	dir = 8;
+	pixel_x = -2;
+	pixel_y = 12;
+	layer = 4
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_p)
 "mbn" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/engineering/lower_engineering)
+"mbW" = (
+/obj/structure/machinery/door/poddoor/almayer/open{
+	id = "Hangar Lockdown";
+	name = "\improper Hangar Lockdown Blast Door"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/hallways/hangar)
 "mce" = (
 /turf/open/floor/almayer{
 	icon_state = "greencorner"
@@ -50722,6 +54554,13 @@
 	icon_state = "plate"
 	},
 /area/almayer/squads/alpha)
+"mdA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_p)
 "mdJ" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 10
@@ -50812,8 +54651,26 @@
 	pixel_x = 8;
 	pixel_y = -32
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb2,
+/obj/item/trash/hotdog{
+	pixel_x = -4;
+	pixel_y = 11
+	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_f_s)
+"mfF" = (
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 10;
+	pixel_y = -9;
+	icon_state = "exposed01-scrubbers"
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = -5
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_s)
 "mfI" = (
 /obj/structure/ladder{
 	height = 1;
@@ -50947,6 +54804,14 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/squads/charlie_delta_shared)
+"mje" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_p)
 "mji" = (
 /obj/structure/pipes/standard/manifold/fourway/hidden/supply,
 /turf/open/floor/plating/plating_catwalk,
@@ -51105,12 +54970,26 @@
 	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical_lobby)
+"mmA" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/shuttle/escapepod{
+	icon_state = "floor0"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "mmC" = (
 /obj/structure/closet/secure_closet/engineering_welding{
 	req_one_access_txt = "7;23;27"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_f_s)
+"mmM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_p)
 "mmN" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer{
 	dir = 1
@@ -51195,10 +55074,6 @@
 	icon_state = "sterile_green"
 	},
 /area/almayer/medical/containment)
-"moh" = (
-/obj/structure/closet/firecloset,
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/hull/lower_hull/l_m_s)
 "mor" = (
 /obj/structure/machinery/light{
 	dir = 8
@@ -51258,6 +55133,22 @@
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall/almayer,
 /area/almayer/squads/req)
+"mpX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7;
+	pixel_x = 13
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_p)
 "mqc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -51483,6 +55374,20 @@
 	icon_state = "plate"
 	},
 /area/almayer/squads/alpha)
+"muJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/prop/magazine/dirty/torn,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_f_s)
+"mvd" = (
+/obj/effect/decal/cleanable/ash,
+/obj/effect/decal/cleanable/blood/oil/streak,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_p)
 "mvl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -51568,6 +55473,7 @@
 	pixel_x = 15;
 	pixel_y = 32
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_f_p)
 "myn" = (
@@ -51623,6 +55529,7 @@
 	pixel_x = 8;
 	pixel_y = -32
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -51668,6 +55575,13 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/hallways/starboard_hallway)
+"mzU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/tool/warning_cone{
+	pixel_x = -12
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_s)
 "mzV" = (
 /turf/open/floor/almayer{
 	dir = 1;
@@ -51775,6 +55689,10 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/living/chapel)
+"mBO" = (
+/obj/effect/decal/cleanable/blood/oil/streak,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_s)
 "mCo" = (
 /obj/structure/window/framed/almayer,
 /obj/structure/machinery/door/firedoor/border_only/almayer{
@@ -51789,6 +55707,14 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/lifeboat_pumps/south2)
+"mDg" = (
+/obj/structure/prop/almayer/computers/sensor_computer2{
+	icon_state = "mapping_comp_off"
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_p)
 "mDj" = (
 /obj/structure/machinery/photocopier,
 /obj/item/paper{
@@ -51912,6 +55838,14 @@
 	icon_state = "plate"
 	},
 /area/almayer/shipboard/brig/main_office)
+"mGp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/largecrate/random/barrel/yellow{
+	pixel_y = -7;
+	pixel_x = -8
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_s)
 "mGu" = (
 /turf/open/floor/almayer{
 	dir = 4;
@@ -51974,6 +55908,31 @@
 	icon_state = "silver"
 	},
 /area/almayer/command/airoom)
+"mHI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/molten_item{
+	pixel_x = -8;
+	pixel_y = 10
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_f_s)
+"mHN" = (
+/obj/structure/platform{
+	dir = 8;
+	layer = 2.7
+	},
+/obj/structure/platform{
+	dir = 4;
+	layer = 2.7
+	},
+/obj/structure/prop/invuln/overhead/flammable_pipe/fly{
+	icon_state = "flammable_pipe_2";
+	layer = 4
+	},
+/turf/open/floor/plating,
+/area/almayer/hull/lower_hull/l_m_p)
 "mHO" = (
 /obj/structure/machinery/light,
 /turf/open/floor/almayer,
@@ -51983,6 +55942,7 @@
 	pixel_x = 8;
 	pixel_y = -32
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_a_p)
 "mIy" = (
@@ -52041,6 +56001,18 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/squads/req)
+"mJc" = (
+/obj/structure/sign/safety/hvac_old{
+	pixel_x = 8;
+	pixel_y = -32
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/obj/item/trash/boonie,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_p)
 "mJe" = (
 /obj/structure/sign/safety/conference_room{
 	pixel_x = -17;
@@ -52195,6 +56167,24 @@
 /obj/structure/pipes/standard/manifold/fourway/hidden/supply,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/port_hallway)
+"mLt" = (
+/obj/structure/largecrate/random/barrel/red{
+	pixel_x = 9
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	dir = 1;
+	icon_state = "lattice-simple";
+	pixel_x = -16;
+	pixel_y = -16
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "mLu" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N";
@@ -52281,6 +56271,11 @@
 /area/almayer/shipboard/brig/cic_hallway)
 "mNf" = (
 /obj/structure/largecrate/random/case/double,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_f_s)
 "mNm" = (
@@ -52351,6 +56346,13 @@
 "mOi" = (
 /turf/closed/wall/almayer/outer,
 /area/almayer/command/airoom)
+"mOq" = (
+/obj/structure/platform{
+	dir = 4
+	},
+/obj/item/trash/crushed_cup,
+/turf/open/floor/plating,
+/area/almayer/hull/lower_hull/l_m_s)
 "mOr" = (
 /obj/structure/surface/table/almayer,
 /obj/item/clipboard,
@@ -52360,6 +56362,12 @@
 	icon_state = "plate"
 	},
 /area/almayer/engineering/engineering_workshop)
+"mOy" = (
+/obj/structure/machinery/door/airlock/almayer/generic/glass{
+	dir = 1
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_s)
 "mOL" = (
 /obj/structure/sign/safety/maint{
 	pixel_x = 8;
@@ -52492,6 +56500,21 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/command/airoom)
+"mRA" = (
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 16
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/used_stasis_bag{
+	pixel_x = -12;
+	pixel_y = -12
+	},
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_s)
 "mRW" = (
 /turf/open/floor/almayer/research/containment/corner1,
 /area/almayer/medical/containment/cell/cl)
@@ -52579,6 +56602,15 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/port_hallway)
+"mTl" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/pipes/standard/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/strata_decals/grime/grime2,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "mTm" = (
 /turf/open/floor/almayer{
 	dir = 4;
@@ -52607,6 +56639,19 @@
 /obj/structure/pipes/standard/manifold/hidden/supply,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/starboard_hallway)
+"mUe" = (
+/obj/structure/sign/safety/hvac_old{
+	pixel_x = 8;
+	pixel_y = -32
+	},
+/obj/effect/decal/strata_decals/grime/grime2{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_p)
 "mUn" = (
 /obj/structure/machinery/conveyor_switch{
 	id = "lower_garbage"
@@ -52694,6 +56739,16 @@
 	icon_state = "plate"
 	},
 /area/almayer/hallways/hangar)
+"mVN" = (
+/obj/structure/prop/invuln{
+	icon = 'icons/obj/structures/machinery/cryogenics.dmi';
+	icon_state = "body_scanner_open";
+	name = "broken hypersleep chamber";
+	desc = "The console on this reads the pod was opened from the inside."
+	},
+/obj/effect/decal/cleanable/blood/xeno,
+/turf/open/shuttle/escapepod,
+/area/almayer/hull/lower_hull/l_m_s)
 "mWe" = (
 /obj/structure/machinery/camera/autoname/almayer{
 	dir = 8;
@@ -52734,6 +56789,11 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/squads/alpha_bravo_shared)
+"mWA" = (
+/turf/closed/shuttle/escapepod{
+	icon_state = "wall4"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "mWD" = (
 /obj/structure/machinery/cryopod/right{
 	layer = 3.1;
@@ -52776,12 +56836,53 @@
 "mXj" = (
 /turf/closed/wall/almayer,
 /area/almayer/living/commandbunks)
+"mXm" = (
+/obj/effect/spawner/random/toolbox,
+/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/decal/strata_decals/grime/grime1{
+	dir = 8
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_p)
+"mXu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7;
+	pixel_x = 13
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_p)
 "mXU" = (
 /turf/open/floor/almayer{
 	dir = 9;
 	icon_state = "red"
 	},
 /area/almayer/hallways/aft_hallway)
+"mYp" = (
+/obj/structure/prop/invuln/overhead_pipe{
+	pixel_x = 12
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = -9
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = -11;
+	pixel_x = 1
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_p)
 "mYs" = (
 /obj/structure/machinery/light{
 	dir = 4
@@ -52858,6 +56959,7 @@
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -52918,6 +57020,19 @@
 "naB" = (
 /turf/closed/wall/almayer/reinforced,
 /area/almayer/shipboard/brig/perma)
+"naP" = (
+/obj/structure/largecrate/random/barrel/white{
+	pixel_x = -41;
+	pixel_y = -4
+	},
+/obj/structure/largecrate/random/barrel/white{
+	pixel_x = -2;
+	pixel_y = 6
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_f_p)
 "naQ" = (
 /obj/structure/machinery/light/small{
 	dir = 4
@@ -52959,6 +57074,23 @@
 	icon_state = "plate"
 	},
 /area/almayer/living/grunt_rnr)
+"nbU" = (
+/obj/structure/sign/safety/hvac_old{
+	pixel_x = 8;
+	pixel_y = -32
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = -9
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = -11;
+	pixel_x = 1
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_p)
 "ncp" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 9
@@ -52987,6 +57119,18 @@
 /obj/structure/sign/safety/west{
 	pixel_y = 32
 	},
+/obj/effect/decal/cleanable/generic,
+/obj/item/trash/uscm_mre{
+	pixel_x = -3;
+	pixel_y = 17
+	},
+/obj/item/trash/uscm_mre{
+	pixel_x = 9;
+	pixel_y = -10
+	},
+/obj/effect/decal/strata_decals/grime/grime1{
+	dir = 4
+	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -53009,6 +57153,8 @@
 	pixel_x = 16;
 	pixel_y = -8
 	},
+/obj/item/tool/weldingtool,
+/obj/effect/decal/cleanable/liquid_fuel,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -53194,6 +57340,30 @@
 	icon_state = "plate"
 	},
 /area/almayer/hull/upper_hull/u_a_p)
+"nhp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/overhead_pipe{
+	pixel_x = 6;
+	pixel_y = 12
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	dir = 1;
+	icon_state = "lattice-simple";
+	pixel_x = 10
+	},
+/obj/structure/prop/invuln{
+	desc = "harmless exhaust discharge from a broken pipeline";
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "exhaust";
+	density = 0;
+	pixel_y = -15;
+	pixel_x = 1
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_s)
 "nhx" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/toy/deck{
@@ -53237,6 +57407,13 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/shipboard/brig/cells)
+"nif" = (
+/obj/structure/platform{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/blood/oil/streak,
+/turf/open/floor/plating,
+/area/almayer/hull/lower_hull/l_m_s)
 "nig" = (
 /turf/open/floor/almayer{
 	icon_state = "red"
@@ -53348,6 +57525,17 @@
 	pixel_x = 8;
 	pixel_y = 32
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/overhead/flammable_pipe/fly{
+	dir = 8;
+	pixel_x = -2;
+	pixel_y = 12;
+	layer = 4
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_a_p)
 "nka" = (
@@ -53390,6 +57578,13 @@
 	icon_state = "red"
 	},
 /area/almayer/shipboard/brig/cells)
+"nlK" = (
+/obj/structure/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_s)
 "nlW" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /obj/structure/largecrate/random/barrel/green,
@@ -53405,6 +57600,17 @@
 /obj/structure/sign/safety/life_support{
 	pixel_x = 8;
 	pixel_y = 32
+	},
+/obj/item/trash/cigbutt{
+	pixel_x = -12;
+	pixel_y = 17
+	},
+/obj/item/trash/cigbutt{
+	pixel_x = -9;
+	pixel_y = -6
+	},
+/obj/effect/decal/strata_decals/grime/grime1{
+	dir = 4
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/engineering/lower_engineering)
@@ -53482,6 +57688,15 @@
 /obj/structure/prop/invuln/overhead_pipe{
 	pixel_x = 12;
 	pixel_y = 12
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
 	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
@@ -53563,6 +57778,13 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/medical/hydroponics)
+"noH" = (
+/obj/structure/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_f_s)
 "noV" = (
 /obj/structure/sign/safety/storage{
 	pixel_x = 8;
@@ -53654,6 +57876,7 @@
 /obj/structure/surface/rack,
 /obj/item/tool/kitchen/rollingpin,
 /obj/item/tool/hatchet,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -53780,8 +58003,18 @@
 	icon_state = "N";
 	pixel_y = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_f_s)
+"ntB" = (
+/obj/structure/grille{
+	icon_state = "brokengrille";
+	density = 0
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_s)
 "ntI" = (
 /obj/structure/machinery/light{
 	dir = 4
@@ -53806,6 +58039,15 @@
 /obj/structure/prop/invuln/overhead_pipe{
 	pixel_x = 12;
 	pixel_y = 12
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_x = -8
 	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
@@ -53981,6 +58223,33 @@
 	icon_state = "blue"
 	},
 /area/almayer/hallways/aft_hallway)
+"nxL" = (
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
+/obj/effect/decal/cleanable/liquid_fuel,
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_p)
+"nxO" = (
+/obj/effect/landmark/yautja_teleport,
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_s)
 "nyj" = (
 /obj/effect/decal/medical_decals{
 	icon_state = "docdecal2"
@@ -54052,6 +58321,11 @@
 	icon_state = "red"
 	},
 /area/almayer/command/lifeboat)
+"nzL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/oil/streak,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_p)
 "nzO" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/effect/decal/warning_stripes{
@@ -54063,6 +58337,36 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/squads/req)
+"nAo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/strata_decals/grime/grime3,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_f_s)
+"nAC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = -9
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = -11;
+	pixel_x = 1
+	},
+/obj/effect/decal/cleanable/liquid_fuel,
+/obj/effect/decal/cleanable/liquid_fuel,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_p)
+"nAK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/obj/item/trash/candy,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_s)
 "nBa" = (
 /obj/structure/machinery/cm_vending/sorted/cargo_guns/squad{
 	req_access = null;
@@ -54091,6 +58395,14 @@
 "nBl" = (
 /obj/structure/machinery/power/apc/almayer{
 	dir = 1
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_m_p)
@@ -54131,6 +58443,21 @@
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer,
 /area/almayer/living/pilotbunks)
+"nBQ" = (
+/obj/structure/platform{
+	dir = 4;
+	layer = 2.7
+	},
+/obj/structure/machinery/gear,
+/obj/effect/decal/strata_decals/grime/grime2,
+/obj/structure/sign/safety/storage{
+	pixel_x = 8;
+	pixel_y = 32
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hallways/hangar)
 "nBW" = (
 /obj/structure/sign/safety/maint{
 	pixel_x = -17
@@ -54210,6 +58537,22 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/medical/medical_science)
+"nDF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/platform{
+	dir = 8
+	},
+/obj/structure/prop/invuln{
+	desc = "a pile of cables";
+	icon = 'icons/obj/structures/machinery/artillery.dmi';
+	icon_state = "29";
+	name = "cables";
+	density = 0;
+	layer = 3;
+	pixel_x = 30
+	},
+/turf/open/floor/plating,
+/area/almayer/hull/lower_hull/l_a_p)
 "nDL" = (
 /obj/structure/barricade/handrail{
 	dir = 4
@@ -54242,8 +58585,20 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/port_umbilical)
+"nEv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	layer = 3.33;
+	pixel_y = 2
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hallways/hangar)
 "nEz" = (
 /obj/effect/landmark/yautja_teleport,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_f_p)
 "nEA" = (
@@ -54313,6 +58668,8 @@
 /obj/structure/machinery/light/small{
 	dir = 4
 	},
+/obj/structure/largecrate/random/barrel/red,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -54329,6 +58686,19 @@
 	icon_state = "green"
 	},
 /area/almayer/hallways/starboard_hallway)
+"nFC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/machinery/blackbox_recorder,
+/obj/item/prop/almayer/flight_recorder{
+	pixel_x = -7;
+	pixel_y = 4
+	},
+/obj/item/prop/almayer/box{
+	pixel_x = 8;
+	pixel_y = 14
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_p)
 "nFI" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/disposalpipe/segment{
@@ -54392,6 +58762,7 @@
 /obj/structure/machinery/light/small{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -54504,6 +58875,14 @@
 /obj/item/newspaper,
 /turf/open/floor/almayer,
 /area/almayer/command/lifeboat)
+"nJv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/grille{
+	icon_state = "brokengrille";
+	density = 0
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_s)
 "nJy" = (
 /obj/structure/sign/safety/bathunisex{
 	pixel_x = -18
@@ -54633,6 +59012,18 @@
 /obj/structure/sign/safety/cryo{
 	pixel_x = 35
 	},
+/obj/item/stack/tile/plasteel{
+	pixel_x = 15;
+	pixel_y = -12
+	},
+/obj/structure/largecrate/random/barrel/white{
+	pixel_x = 4;
+	pixel_y = -6
+	},
+/obj/item/tool/warning_cone{
+	pixel_x = -21;
+	pixel_y = 13
+	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -54748,6 +59139,17 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/overhead/flammable_pipe/fly{
+	dir = 8;
+	pixel_x = -2;
+	pixel_y = 12;
+	layer = 4
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_a_p)
 "nPa" = (
@@ -54838,6 +59240,23 @@
 	icon_state = "mono"
 	},
 /area/almayer/lifeboat_pumps/north2)
+"nQf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/tile/plasteel{
+	pixel_x = 3;
+	pixel_y = 10
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_s)
+"nQs" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood,
+/mob/living/simple_animal/mouse/gray,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_p)
 "nQv" = (
 /obj/structure/machinery/power/apc/almayer{
 	dir = 4
@@ -55017,6 +59436,7 @@
 /obj/structure/bed/chair{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -55139,6 +59559,36 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/shipboard/brig/cells)
+"nYU" = (
+/obj/item/stack/tile/plasteel{
+	name = "ceiling tile";
+	pixel_x = -2;
+	pixel_y = 1
+	},
+/obj/item/tool/warning_cone{
+	pixel_y = 11;
+	pixel_x = 13
+	},
+/obj/item/tool/warning_cone{
+	pixel_x = -21;
+	pixel_y = 13
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_p)
+"nZe" = (
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7;
+	pixel_x = 13
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_s)
 "nZy" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/disposalpipe/segment{
@@ -55280,6 +59730,13 @@
 	icon_state = "ai_floors"
 	},
 /area/almayer/command/airoom)
+"ocH" = (
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = -16
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_s)
 "oda" = (
 /obj/structure/surface/table/reinforced/almayer_B,
 /obj/item/device/radio{
@@ -55377,6 +59834,8 @@
 /area/almayer/squads/alpha_bravo_shared)
 "oeo" = (
 /obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spider/stickyweb,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_f_p)
 "oer" = (
@@ -55437,6 +59896,15 @@
 	icon_state = "plate"
 	},
 /area/almayer/hull/upper_hull/u_f_p)
+"ogb" = (
+/obj/structure/prop/invuln{
+	icon = 'icons/obj/structures/machinery/cryogenics.dmi';
+	icon_state = "body_scanner_closed";
+	name = "broken hypersleep chamber";
+	desc = "You think you can see the outline of a young female inside? The pod reads no lifesigns."
+	},
+/turf/open/shuttle/escapepod,
+/area/almayer/hull/lower_hull/l_m_s)
 "ohj" = (
 /obj/structure/machinery/cryopod,
 /turf/open/floor/almayer{
@@ -55493,6 +59961,22 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/lifeboat_pumps/north2)
+"ohM" = (
+/obj/structure/prop/invuln/lattice_prop{
+	dir = 1;
+	icon_state = "lattice-simple";
+	pixel_x = -16;
+	pixel_y = -16
+	},
+/obj/effect/decal/cleanable/blood/oil,
+/obj/structure/largecrate/random/barrel/yellow{
+	pixel_y = -7;
+	pixel_x = -8
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_p)
 "oih" = (
 /obj/structure/bed{
 	icon_state = "abed"
@@ -55731,6 +60215,17 @@
 /obj/structure/window/framed/almayer/white,
 /turf/open/floor/plating,
 /area/almayer/medical/lockerroom)
+"omr" = (
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_p)
 "omt" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/pipes/standard/simple/hidden/supply,
@@ -55773,6 +60268,18 @@
 	icon_state = "orange"
 	},
 /area/almayer/hallways/hangar)
+"onA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/cigbutt{
+	pixel_x = 4
+	},
+/obj/item/trash/cigbutt/cigarbutt{
+	pixel_x = 10;
+	pixel_y = 15
+	},
+/obj/item/tool/match,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/starboard_point_defense)
 "onN" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/disposalpipe/segment{
@@ -55836,6 +60343,18 @@
 	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical_medbay)
+"ooN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_s)
 "ooR" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer{
 	dir = 1
@@ -55855,6 +60374,22 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/shipboard/brig/perma)
+"opa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/lattice_prop{
+	dir = 1;
+	icon_state = "lattice-simple";
+	pixel_x = -16;
+	pixel_y = -16
+	},
+/obj/effect/decal/strata_decals/grime/grime2{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_p)
 "opj" = (
 /obj/structure/surface/table/almayer,
 /obj/effect/spawner/random/powercell,
@@ -55864,6 +60399,15 @@
 	icon_state = "green"
 	},
 /area/almayer/squads/req)
+"opk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/strata_decals/grime/grime2{
+	dir = 8
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "opC" = (
 /obj/structure/machinery/door/airlock/almayer/command/reinforced{
 	name = "\improper Combat Information Center"
@@ -56011,6 +60555,7 @@
 "orv" = (
 /obj/structure/machinery/light/small,
 /obj/structure/largecrate/random/secure,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_f_p)
 "orH" = (
@@ -56083,6 +60628,16 @@
 /area/almayer/squads/bravo)
 "osE" = (
 /obj/structure/closet/emcloset,
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 15;
+	pixel_x = 1
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice6";
+	pixel_x = -5;
+	pixel_y = 15
+	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -56102,6 +60657,11 @@
 	},
 /turf/open/floor/wood/ship,
 /area/almayer/shipboard/brig/chief_mp_office)
+"osM" = (
+/obj/structure/machinery/light/small,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_p)
 "osT" = (
 /obj/structure/surface/table/reinforced/almayer_B,
 /obj/structure/prop/ice_colony/hula_girl{
@@ -56158,6 +60718,24 @@
 	icon_state = "ai_floors"
 	},
 /area/almayer/command/airoom)
+"ouA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/platform_decoration{
+	dir = 4
+	},
+/obj/structure/machinery/gear,
+/obj/item/tool/warning_cone{
+	layer = 3.6;
+	pixel_x = -16;
+	pixel_y = -9
+	},
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 9
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hallways/hangar)
 "ouB" = (
 /obj/structure/bed/sofa/vert/grey/bot,
 /turf/open/floor/almayer,
@@ -56223,6 +60801,8 @@
 	icon_state = "E";
 	pixel_x = 1
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/vomit,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -56337,7 +60917,15 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/engineering/port_atmos)
 "oyG" = (
-/obj/structure/largecrate/random/secure,
+/obj/structure/prop/tower{
+	desc = "An old portable comms tower used to transmit communications between subspace bodies. Looks like this one has seen better days."
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	dir = 1;
+	icon_state = "lattice-simple";
+	pixel_x = -16;
+	pixel_y = -16
+	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -56384,6 +60972,26 @@
 	icon_state = "mono"
 	},
 /area/almayer/engineering/upper_engineering/starboard)
+"ozC" = (
+/obj/structure/platform{
+	dir = 1
+	},
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hallways/hangar)
+"ozF" = (
+/obj/structure/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "ozN" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/dropshiprear/lifeboat/blastdoor{
 	id_tag = "Boat2-D2";
@@ -56519,6 +61127,20 @@
 /obj/structure/sign/safety/distribution_pipes{
 	pixel_x = 32
 	},
+/obj/structure/surface/table/almayer,
+/obj/item/ammo_magazine/rifle/m4ra/heap{
+	current_rounds = 0
+	},
+/obj/item/ammo_magazine/rifle/m4ra/heap{
+	current_rounds = 0;
+	pixel_x = -5;
+	pixel_y = 10
+	},
+/obj/item/ammo_magazine/rifle/m4ra/heap{
+	current_rounds = 0;
+	pixel_y = 12;
+	pixel_x = 9
+	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -56529,6 +61151,13 @@
 	icon_state = "red"
 	},
 /area/almayer/living/gym)
+"oDD" = (
+/obj/effect/decal/cleanable/generic,
+/obj/item/trash/used_stasis_bag,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "oDE" = (
 /obj/structure/surface/rack,
 /obj/item/reagent_container/spray/cleaner{
@@ -56623,6 +61252,11 @@
 	icon_state = "bluefull"
 	},
 /area/almayer/command/cichallway)
+"oEU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/tool/wet_sign,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_f_s)
 "oEX" = (
 /obj/structure/pipes/vents/scrubber{
 	dir = 4
@@ -56721,6 +61355,17 @@
 	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering/port)
+"oHo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/overhead/flammable_pipe/fly{
+	dir = 1;
+	pixel_y = 13;
+	pixel_x = -2
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "oHx" = (
 /obj/structure/machinery/door/airlock/almayer/maint{
 	dir = 1
@@ -56729,6 +61374,11 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/engineering/laundry)
+"oHU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/plating,
+/area/almayer/hull/lower_hull/l_m_s)
 "oIc" = (
 /obj/structure/machinery/power/apc/almayer{
 	dir = 4
@@ -56746,13 +61396,13 @@
 	},
 /area/almayer/engineering/upper_engineering/starboard)
 "oIn" = (
-/obj/structure/bed/chair{
-	dir = 8;
-	pixel_y = 3
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/oil/streak,
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
 	},
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
+/turf/open/floor/plating,
 /area/almayer/hull/lower_hull/l_m_s)
 "oIr" = (
 /obj/effect/decal/warning_stripes{
@@ -57091,7 +61741,8 @@
 	},
 /area/almayer/command/cic)
 "oPI" = (
-/obj/structure/largecrate/random/case/small,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/tool,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -57139,6 +61790,13 @@
 	icon_state = "silver"
 	},
 /area/almayer/living/auxiliary_officer_office)
+"oQQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/tool/wet_sign,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_f_s)
 "oRj" = (
 /obj/structure/stairs{
 	icon_state = "ramptop"
@@ -57282,6 +61940,42 @@
 	icon_state = "test_floor5"
 	},
 /area/almayer/squads/req)
+"oTp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/platform{
+	dir = 1
+	},
+/obj/structure/platform{
+	dir = 8
+	},
+/obj/structure/platform_decoration{
+	dir = 5;
+	layer = 3.51
+	},
+/obj/structure/prop/invuln{
+	desc = "a pile of cables";
+	icon = 'icons/obj/structures/machinery/artillery.dmi';
+	icon_state = "29";
+	name = "cables";
+	density = 0;
+	layer = 3;
+	pixel_x = 6;
+	pixel_y = -29
+	},
+/turf/open/floor/plating,
+/area/almayer/hull/lower_hull/l_a_p)
+"oTy" = (
+/obj/structure/foamed_metal,
+/obj/structure/prop/invuln/lattice_prop{
+	dir = 1;
+	icon_state = "lattice-simple";
+	pixel_x = 14;
+	pixel_y = -16
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "oTz" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/almayer{
@@ -57371,10 +62065,64 @@
 /obj/effect/landmark/late_join/charlie,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/squads/charlie)
+"oXk" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/sign/safety/water{
+	pixel_x = 8;
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/overhead/flammable_pipe/fly{
+	dir = 8;
+	pixel_x = -2;
+	pixel_y = 12;
+	layer = 4
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_p)
 "oXp" = (
 /obj/effect/decal/cleanable/ash,
 /turf/open/floor/wood/ship,
 /area/almayer/shipboard/brig/cells)
+"oXq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/almayer/computers/sensor_computer1,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_p)
+"oXv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
+/obj/structure/platform{
+	dir = 8;
+	layer = 2.7
+	},
+/obj/structure/platform{
+	dir = 4;
+	layer = 2.7
+	},
+/obj/structure/prop/invuln/overhead/flammable_pipe/fly{
+	icon_state = "flammable_pipe_2";
+	layer = 4
+	},
+/turf/open/floor/plating,
+/area/almayer/hull/lower_hull/l_m_p)
+"oXD" = (
+/obj/effect/decal/strata_decals/grime/grime4,
+/turf/open/space,
+/area/space)
 "oXJ" = (
 /obj/structure/machinery/suit_storage_unit/compression_suit/uscm,
 /turf/open/floor/almayer{
@@ -57406,6 +62154,7 @@
 	pixel_x = 8;
 	pixel_y = 32
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -57504,6 +62253,14 @@
 	icon_state = "red"
 	},
 /area/almayer/shipboard/brig/main_office)
+"pbm" = (
+/obj/item/tool/warning_cone{
+	pixel_x = -12
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "pbp" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer{
@@ -57623,6 +62380,7 @@
 /area/almayer/hull/lower_hull/l_f_s)
 "pdk" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer,
+/obj/effect/spider/stickyweb,
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
 	},
@@ -57728,6 +62486,27 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/command/airoom)
+"pgd" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/sign/safety/water{
+	pixel_x = 8;
+	pixel_y = -32
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice1";
+	pixel_x = -14;
+	pixel_y = -13
+	},
+/obj/structure/prop/invuln/lattice_prop,
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice2";
+	pixel_x = -14;
+	pixel_y = 6
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_f_s)
 "pgo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -57766,6 +62545,25 @@
 	icon_state = "mono"
 	},
 /area/almayer/medical/medical_science)
+"pgQ" = (
+/obj/structure/prop/invuln{
+	desc = "a pile of cables";
+	icon = 'icons/obj/structures/machinery/artillery.dmi';
+	icon_state = "27";
+	name = "cables";
+	density = 0;
+	layer = 3
+	},
+/obj/structure/prop/invuln{
+	desc = "a pile of cables";
+	icon = 'icons/obj/structures/machinery/artillery.dmi';
+	icon_state = "29";
+	name = "cables";
+	density = 0;
+	layer = 3
+	},
+/turf/open/floor/plating,
+/area/almayer/hull/lower_hull/l_a_p)
 "pha" = (
 /obj/structure/machinery/photocopier,
 /turf/open/floor/almayer{
@@ -57791,6 +62589,7 @@
 /obj/structure/surface/rack,
 /obj/item/tool/weldingtool,
 /obj/item/tool/wrench,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_f_p)
 "piX" = (
@@ -57862,6 +62661,15 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/engineering/engineering_workshop/hangar)
+"pjV" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/pipes/standard/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/strata_decals/grime/grime1{
+	dir = 1
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_s)
 "pky" = (
 /obj/structure/largecrate/random/secure,
 /turf/open/floor/almayer{
@@ -57969,6 +62777,13 @@
 	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical_medbay)
+"pog" = (
+/obj/item/tool/warning_cone{
+	pixel_x = 13;
+	pixel_y = 15
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_s)
 "pop" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 1
@@ -57986,6 +62801,7 @@
 /obj/structure/machinery/light/small{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_f_s)
 "poZ" = (
@@ -58016,6 +62832,17 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/living/auxiliary_officer_office)
+"ppK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/tool/wet_sign,
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_f_s)
 "pqc" = (
 /obj/structure/machinery/firealarm{
 	dir = 4;
@@ -58161,6 +62988,25 @@
 	icon_state = "sterile_green_corner"
 	},
 /area/almayer/medical/lower_medical_medbay)
+"ptb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7;
+	pixel_x = 13
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "pth" = (
 /obj/structure/surface/table/almayer,
 /obj/item/folder/blue,
@@ -58234,6 +63080,21 @@
 	icon_state = "plate"
 	},
 /area/almayer/hull/lower_hull/l_f_p)
+"pve" = (
+/obj/structure/sign/safety/water{
+	pixel_x = 8;
+	pixel_y = -32
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = -9
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = -5
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_s)
 "pvh" = (
 /obj/structure/pipes/standard/manifold/hidden/supply,
 /obj/item/tool/warning_cone{
@@ -58319,6 +63180,7 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_f_s)
 "pxj" = (
@@ -58370,6 +63232,19 @@
 	icon_state = "emerald"
 	},
 /area/almayer/living/port_emb)
+"pyg" = (
+/obj/structure/foamed_metal,
+/obj/structure/foamed_metal,
+/obj/structure/prop/invuln/lattice_prop{
+	dir = 1;
+	icon_state = "lattice-simple";
+	pixel_x = 14;
+	pixel_y = -16
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "pyi" = (
 /obj/structure/prop/almayer/missile_tube{
 	icon_state = "missiletubesouth"
@@ -58464,6 +63339,7 @@
 	pixel_x = 12;
 	pixel_y = 12
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_m_p)
 "pzy" = (
@@ -58506,10 +63382,15 @@
 	},
 /area/almayer/living/briefing)
 "pzZ" = (
-/obj/structure/largecrate/random/barrel/blue,
+/obj/item/storage/toolbox/mechanical,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
+/area/almayer/hull/lower_hull/l_f_s)
+"pAH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/mucus,
+/turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_f_s)
 "pAR" = (
 /obj/structure/pipes/vents/scrubber{
@@ -58520,6 +63401,16 @@
 	icon_state = "orange"
 	},
 /area/almayer/hallways/starboard_umbilical)
+"pBk" = (
+/obj/structure/largecrate/random/barrel/red,
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_p)
 "pBn" = (
 /obj/structure/sign/safety/escapepod{
 	pixel_x = 8;
@@ -58556,6 +63447,12 @@
 	icon_state = "mono"
 	},
 /area/almayer/hallways/stern_hallway)
+"pCU" = (
+/obj/structure/machinery/space_heater,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_s)
 "pDh" = (
 /obj/structure/machinery/power/monitor{
 	name = "Core Power Monitoring"
@@ -58815,6 +63712,16 @@
 "pHp" = (
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/perma)
+"pHr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb,
+/obj/item/trash/USCMtray{
+	pixel_x = 6;
+	pixel_y = -10
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_f_s)
 "pHA" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -58846,8 +63753,19 @@
 	pixel_x = 8;
 	pixel_y = 32
 	},
+/obj/effect/decal/cleanable/cobweb2,
 /turf/open/floor/plating/almayer,
 /area/almayer/hull/lower_hull/l_a_s)
+"pIE" = (
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = -9
+	},
+/obj/effect/decal/strata_decals/grime/grime4,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_p)
 "pIH" = (
 /obj/structure/machinery/door_control{
 	id = "perma_exit";
@@ -59049,6 +63967,13 @@
 	dir = 4
 	},
 /obj/structure/largecrate/random/case/double,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/overhead/flammable_pipe/fly{
+	dir = 8;
+	pixel_x = -2;
+	pixel_y = 12;
+	layer = 4
+	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_m_p)
 "pNM" = (
@@ -59185,6 +64110,28 @@
 /obj/structure/window/framed/almayer,
 /turf/open/floor/plating,
 /area/almayer/living/bridgebunks)
+"pQD" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/sign/safety/distribution_pipes{
+	pixel_x = 8;
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7;
+	pixel_x = 13
+	},
+/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_p)
 "pQF" = (
 /obj/structure/machinery/cm_vending/sorted/cargo_guns/squad{
 	req_access = null;
@@ -59269,12 +64216,33 @@
 	icon_state = "silvercorner"
 	},
 /area/almayer/shipboard/brig/cic_hallway)
+"pRU" = (
+/obj/structure/foamed_metal,
+/obj/structure/prop/invuln/lattice_prop{
+	dir = 1;
+	icon_state = "lattice-simple";
+	pixel_x = 14;
+	pixel_y = -16
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "pRX" = (
 /obj/structure/machinery/portable_atmospherics/hydroponics,
 /turf/open/floor/almayer{
 	icon_state = "test_floor5"
 	},
 /area/almayer/medical/hydroponics)
+"pSp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/liquid_fuel,
+/obj/item/tool/wet_sign,
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "silvercorner"
+	},
+/area/almayer/hallways/hangar)
 "pSL" = (
 /obj/structure/machinery/alarm/almayer{
 	dir = 1
@@ -59284,6 +64252,17 @@
 	icon_state = "blue"
 	},
 /area/almayer/hallways/aft_hallway)
+"pSN" = (
+/obj/effect/decal/cleanable/blood/oil/streak,
+/obj/structure/surface/table/almayer,
+/obj/item/storage/belt/tank{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hallways/hangar)
 "pSU" = (
 /obj/structure/machinery/light,
 /obj/structure/machinery/photocopier,
@@ -59393,6 +64372,21 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_a_p)
+"pVq" = (
+/obj/item/ammo_casing/bullet,
+/obj/item/ammo_casing/bullet,
+/obj/item/ammo_casing/bullet,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln{
+	desc = "a pile of cables";
+	icon = 'icons/obj/structures/props/almayer_props.dmi';
+	icon_state = "cannon_cables";
+	name = "cables";
+	density = 0;
+	layer = 3
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_s)
 "pVu" = (
 /obj/item/paper/prison_station/interrogation_log{
 	pixel_x = 10;
@@ -59507,6 +64501,25 @@
 	icon_state = "green"
 	},
 /area/almayer/shipboard/brig/cells)
+"pWu" = (
+/obj/item/tool/warning_cone{
+	pixel_y = 11;
+	pixel_x = 13
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/ice_colony/ground_wire{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_s)
+"pWz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/largecrate/random/barrel/white{
+	pixel_x = -10
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_f_p)
 "pWA" = (
 /obj/structure/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
@@ -59562,6 +64575,17 @@
 	dir = 4;
 	pixel_x = -12;
 	pixel_y = 13
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/grille{
+	icon_state = "brokengrille";
+	density = 0
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	dir = 1;
+	icon_state = "lattice-simple";
+	pixel_x = -16;
+	pixel_y = -16
 	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
@@ -59817,6 +64841,21 @@
 	icon_state = "plate"
 	},
 /area/almayer/living/auxiliary_officer_office)
+"qcD" = (
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 10;
+	pixel_x = 12;
+	pixel_y = 7
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "qdk" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/pipes/standard/simple/hidden/supply{
@@ -59892,6 +64931,26 @@
 	icon_state = "plate"
 	},
 /area/almayer/command/lifeboat)
+"qeJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln{
+	desc = "a pile of cables";
+	icon = 'icons/obj/structures/machinery/artillery.dmi';
+	icon_state = "27";
+	name = "cables";
+	density = 0;
+	layer = 3
+	},
+/obj/structure/prop/invuln{
+	desc = "a pile of cables";
+	icon = 'icons/obj/structures/machinery/artillery.dmi';
+	icon_state = "29";
+	name = "cables";
+	density = 0;
+	layer = 3
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_s)
 "qeK" = (
 /obj/structure/pipes/vents/scrubber,
 /obj/structure/surface/table/reinforced/black,
@@ -60183,6 +65242,20 @@
 	},
 /turf/open/floor/plating,
 /area/almayer/shipboard/sea_office)
+"qlY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/tool/warning_cone{
+	pixel_y = 11;
+	pixel_x = 13
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = -5
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_s)
 "qmk" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/pipes/standard/simple/hidden/supply{
@@ -60348,6 +65421,8 @@
 	pixel_x = 12;
 	pixel_y = 12
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/inflatable/door,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -60557,6 +65632,20 @@
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer,
 /area/almayer/engineering/ce_room)
+"qtf" = (
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 5;
+	pixel_y = 7
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/obj/effect/decal/cleanable/ash,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "qtv" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer{
@@ -60573,6 +65662,13 @@
 /obj/structure/largecrate/random/case/double,
 /turf/open/floor/almayer,
 /area/almayer/hull/upper_hull/u_f_s)
+"quo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cryofeed,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_p)
 "quq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -60719,6 +65815,19 @@
 /area/almayer/medical/containment/cell)
 "qxA" = (
 /obj/structure/closet/firecloset,
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
+/obj/structure/prop/invuln/overhead/flammable_pipe/fly{
+	icon_state = "flammable_pipe_3";
+	pixel_x = 2;
+	pixel_y = -4
+	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -60848,6 +65957,16 @@
 	icon_state = "emeraldfull"
 	},
 /area/almayer/squads/charlie_delta_shared)
+"qyY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/tool/warning_cone{
+	pixel_x = -7;
+	pixel_y = 2
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_p)
 "qyZ" = (
 /obj/structure/surface/table/reinforced/almayer_B,
 /obj/structure/machinery/computer/view_objectives,
@@ -61029,6 +66148,15 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/medical/hydroponics)
+"qEs" = (
+/obj/item/trash/cigbutt{
+	pixel_x = -7;
+	pixel_y = 13
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "qEy" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/pipes/standard/simple/hidden/supply{
@@ -61455,9 +66583,20 @@
 	icon_state = "plate"
 	},
 /area/almayer/hull/upper_hull/u_a_p)
+"qMr" = (
+/obj/item/device/flashlight/lamp/tripod/grey,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_f_s)
 "qMu" = (
 /turf/closed/wall/almayer/outer,
 /area/almayer/hull/upper_hull/u_a_p)
+"qML" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/port_point_defense)
 "qMP" = (
 /obj/structure/bed/chair/comfy{
 	dir = 8
@@ -61510,6 +66649,11 @@
 	pixel_x = 8;
 	pixel_y = -32
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_x = -8
+	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_f_s)
 "qNR" = (
@@ -61546,6 +66690,13 @@
 /obj/structure/disposalpipe/junction,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/living/gym)
+"qOS" = (
+/obj/structure/largecrate/random/barrel/white{
+	pixel_x = -4;
+	pixel_y = -5
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_s)
 "qOU" = (
 /obj/structure/machinery/door/airlock/almayer/maint,
 /turf/open/floor/almayer{
@@ -61641,6 +66792,10 @@
 	icon_state = "tcomms"
 	},
 /area/almayer/command/airoom)
+"qRf" = (
+/obj/effect/decal/cleanable/blood/oil/streak,
+/turf/open/floor/plating,
+/area/almayer/hull/lower_hull/l_m_s)
 "qRj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -61672,6 +66827,20 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/shipboard/brig/execution)
+"qSf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7;
+	pixel_x = 13
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_s)
 "qSl" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -61688,6 +66857,7 @@
 /obj/structure/pipes/vents/pump{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer,
 /area/almayer/shipboard/port_point_defense)
 "qSE" = (
@@ -61708,6 +66878,19 @@
 	},
 /turf/open/floor/plating,
 /area/almayer/living/port_emb)
+"qTE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/uscm_mre{
+	pixel_x = 2;
+	pixel_y = -5
+	},
+/obj/item/trash/hotdog{
+	pixel_x = -4;
+	pixel_y = 11
+	},
+/obj/effect/decal/cleanable/mucus,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_f_s)
 "qTY" = (
 /obj/structure/machinery/gibber,
 /turf/open/floor/plating/plating_catwalk,
@@ -61735,7 +66918,7 @@
 	},
 /area/almayer/hallways/hangar)
 "qUj" = (
-/obj/structure/largecrate/random/case/small,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -61776,6 +66959,20 @@
 	icon_state = "plate"
 	},
 /area/almayer/hallways/hangar)
+"qUV" = (
+/obj/structure/sign/safety/hvac_old{
+	pixel_x = 8;
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "qVC" = (
 /obj/structure/surface/table/reinforced/almayer_B,
 /turf/open/floor/almayer{
@@ -61844,6 +67041,20 @@
 	icon_state = "plate"
 	},
 /area/almayer/hull/upper_hull/u_a_s)
+"qXe" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "qXo" = (
 /obj/structure/machinery/seed_extractor,
 /obj/structure/machinery/light{
@@ -61869,6 +67080,7 @@
 /obj/effect/decal/warning_stripes{
 	icon_state = "SW-out"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -61889,6 +67101,13 @@
 	icon_state = "plate"
 	},
 /area/almayer/hallways/hangar)
+"qYb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_s)
 "qYr" = (
 /obj/effect/step_trigger/teleporter_vector{
 	name = "Almayer_Down3";
@@ -62055,6 +67274,7 @@
 /obj/structure/machinery/light/small{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -62097,6 +67317,13 @@
 	icon_state = "cargo_arrow"
 	},
 /area/almayer/squads/charlie)
+"rbQ" = (
+/obj/effect/decal/cleanable/blood/oil,
+/obj/structure/prop/invuln/overhead_pipe{
+	pixel_x = 12
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_s)
 "rbX" = (
 /obj/structure/sign/safety/manualopenclose{
 	pixel_x = 15;
@@ -62131,10 +67358,21 @@
 	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical_lobby)
+"rcC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/strata_decals/grime/grime2{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/blood/oil/streak,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_p)
 "rcH" = (
 /obj/structure/machinery/light/small{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -62148,6 +67386,50 @@
 	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
+"rcT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/pipe{
+	layer = 3.5;
+	pixel_y = 6
+	},
+/obj/structure/prop/invuln{
+	desc = "harmless exhaust discharge from a broken pipeline";
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "exhaust";
+	density = 0;
+	pixel_x = 8;
+	pixel_y = 18
+	},
+/obj/structure/prop/invuln{
+	desc = "harmless exhaust discharge from a broken pipeline";
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "exhaust";
+	density = 0;
+	pixel_x = 9;
+	pixel_y = -1
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_p)
+"rcV" = (
+/obj/structure/prop/invuln/lattice_prop{
+	dir = 1;
+	icon_state = "lattice-simple";
+	pixel_x = 14;
+	pixel_y = -16
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/obj/structure/girder/displaced,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "rde" = (
 /obj/structure/sign/prop1,
 /turf/closed/wall/almayer,
@@ -62226,6 +67508,13 @@
 	icon_state = "plate"
 	},
 /area/almayer/living/gym)
+"rez" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_p)
 "reL" = (
 /obj/structure/surface/table/almayer,
 /obj/item/reagent_container/food/snacks/sliceable/bread{
@@ -62271,6 +67560,7 @@
 	pixel_x = 15;
 	pixel_y = -32
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -62285,7 +67575,21 @@
 /obj/structure/machinery/light/small{
 	dir = 4
 	},
-/turf/open/floor/plating/plating_catwalk,
+/obj/structure/prop/invuln{
+	desc = "a pile of cables";
+	icon = 'icons/obj/structures/props/almayer_props.dmi';
+	icon_state = "cannon_cables";
+	name = "cables";
+	density = 0;
+	layer = 2;
+	pixel_x = -18;
+	pixel_y = -10
+	},
+/obj/item/stack/tile/plasteel{
+	pixel_x = 3;
+	pixel_y = 10
+	},
+/turf/open/floor/plating,
 /area/almayer/hull/lower_hull/l_a_p)
 "rgJ" = (
 /obj/structure/machinery/light,
@@ -62395,6 +67699,15 @@
 	icon_state = "plating"
 	},
 /area/almayer/engineering/engine_core)
+"rjm" = (
+/obj/structure/grille{
+	icon_state = "brokengrille";
+	density = 0
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_p)
 "rjn" = (
 /obj/structure/machinery/light,
 /obj/structure/reagent_dispensers/water_cooler/stacks,
@@ -62665,6 +67978,22 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/command/airoom)
+"roS" = (
+/obj/structure/prop/invuln{
+	desc = "harmless exhaust discharge from a broken pipeline";
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "exhaust";
+	density = 0
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_p)
 "roU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -62702,6 +68031,14 @@
 	icon_state = "plate"
 	},
 /area/almayer/command/cichallway)
+"rpS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/grille{
+	icon_state = "brokengrille";
+	density = 0
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_p)
 "rpW" = (
 /obj/structure/prop/invuln/overhead_pipe{
 	pixel_x = 12
@@ -62710,6 +68047,7 @@
 	pixel_x = 12;
 	pixel_y = 12
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -62832,7 +68170,29 @@
 	pixel_x = 16;
 	pixel_y = 16
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice10";
+	pixel_x = 15;
+	pixel_y = 11
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
 /turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_s)
+"rst" = (
+/obj/structure/cable{
+	icon_state = "2-10";
+	pixel_x = -12
+	},
+/obj/structure/bed/stool,
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
+/turf/open/floor/plating,
 /area/almayer/hull/lower_hull/l_m_s)
 "rsx" = (
 /obj/structure/largecrate/random/barrel/red,
@@ -62865,6 +68225,15 @@
 /obj/structure/pipes/standard/manifold/hidden/supply,
 /turf/open/floor/almayer,
 /area/almayer/command/computerlab)
+"rsT" = (
+/obj/effect/decal/cleanable/molten_item,
+/obj/effect/decal/strata_decals/grime/grime1{
+	dir = 1
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "rsW" = (
 /turf/open/floor/prison{
 	icon_state = "kitchen"
@@ -63023,6 +68392,8 @@
 	pixel_x = 8;
 	pixel_y = -32
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/oil/streak,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -63040,6 +68411,18 @@
 /obj/structure/pipes/standard/manifold/hidden/supply,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/navigation)
+"rxL" = (
+/obj/effect/decal/cleanable/liquid_fuel,
+/obj/structure/largecrate/random/barrel/white{
+	pixel_x = -8;
+	pixel_y = 3;
+	anchored = 1
+	},
+/turf/open/floor/almayer{
+	dir = 8;
+	icon_state = "silvercorner"
+	},
+/area/almayer/hallways/hangar)
 "rxO" = (
 /obj/structure/machinery/cm_vending/clothing/intelligence_officer,
 /turf/open/floor/almayer{
@@ -63168,6 +68551,11 @@
 	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering/starboard)
+"rAV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/weapon/baseballbat,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_s)
 "rBa" = (
 /obj/structure/machinery/cm_vending/clothing/synth,
 /obj/structure/prop/invuln/overhead_pipe{
@@ -63187,6 +68575,26 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/hallways/hangar)
+"rBf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice3";
+	pixel_x = -5;
+	pixel_y = 15
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice9";
+	pixel_x = -5;
+	pixel_y = -11
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = -9
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_p)
 "rBj" = (
 /obj/structure/machinery/processor,
 /turf/open/floor/plating/plating_catwalk,
@@ -63225,6 +68633,19 @@
 	icon_state = "red"
 	},
 /area/almayer/shipboard/brig/main_office)
+"rCc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/largecrate/random/secure,
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_p)
 "rCi" = (
 /obj/structure/machinery/camera/autoname/almayer/containment/ares{
 	dir = 8
@@ -63334,6 +68755,14 @@
 /obj/structure/sign/safety/water{
 	pixel_x = -17
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/lattice_prop{
+	dir = 1;
+	icon_state = "lattice-simple";
+	pixel_x = -16;
+	pixel_y = -16
+	},
+/obj/structure/girder/displaced,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_a_p)
 "rDr" = (
@@ -63364,12 +68793,30 @@
 	icon_state = "plate"
 	},
 /area/almayer/living/offices)
+"rDL" = (
+/obj/structure/machinery/light/small{
+	dir = 4
+	},
+/obj/item/clothing/accessory/armband/medgreen{
+	pixel_x = -7
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_s)
 "rDV" = (
 /obj/structure/bed/chair/comfy{
 	dir = 8
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/medical/medical_science)
+"rEe" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/spider/stickyweb{
+	icon_state = "stickyweb2"
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_p)
 "rEf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -63430,6 +68877,21 @@
 	icon_state = "plate"
 	},
 /area/almayer/squads/delta)
+"rEB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
+/obj/structure/girder/displaced,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_p)
 "rEL" = (
 /obj/structure/machinery/cm_vending/gear/intelligence_officer,
 /turf/open/floor/almayer{
@@ -63644,6 +69106,13 @@
 	icon_state = "plate"
 	},
 /area/almayer/living/briefing)
+"rIS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_f_s)
 "rIW" = (
 /obj/structure/machinery/cm_vending/gear/synth,
 /obj/effect/decal/cleanable/cobweb2,
@@ -63656,7 +69125,15 @@
 	pixel_x = 8;
 	pixel_y = 32
 	},
-/turf/open/floor/plating/plating_catwalk,
+/obj/structure/prop/invuln/overhead/flammable_pipe/fly{
+	dir = 8;
+	pixel_x = 3;
+	pixel_y = -7
+	},
+/obj/structure/prop/invuln/fire,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
 /area/almayer/hull/lower_hull/l_m_s)
 "rJh" = (
 /obj/item/storage/backpack/marine/satchel{
@@ -63680,6 +69157,25 @@
 	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering/port)
+"rJj" = (
+/obj/structure/surface/table/almayer,
+/obj/item/ammo_magazine/rifle/heap{
+	current_rounds = 0
+	},
+/obj/item/ammo_magazine/rifle/heap{
+	current_rounds = 0;
+	pixel_x = -3;
+	pixel_y = 5
+	},
+/obj/item/ammo_casing/bullet,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/overhead_pipe{
+	pixel_x = 12
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "rJu" = (
 /turf/open/floor/almayer{
 	dir = 1;
@@ -63711,6 +69207,27 @@
 	dir = 5
 	},
 /area/almayer/command/cic)
+"rKf" = (
+/obj/item/stack/tile/plasteel{
+	name = "ceiling tile";
+	pixel_x = -2;
+	pixel_y = 1
+	},
+/obj/structure/prop/invuln/overhead/flammable_pipe/fly{
+	dir = 8;
+	pixel_x = 6;
+	pixel_y = 7;
+	layer = 4
+	},
+/turf/open/floor/plating,
+/area/almayer/hull/lower_hull/l_m_s)
+"rKl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/grille,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_p)
 "rKn" = (
 /obj/structure/machinery/door_control{
 	id = "agentshuttle";
@@ -63869,6 +69386,11 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/shipboard/brig/cells)
+"rPr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_s)
 "rPt" = (
 /turf/open/floor/wood/ship,
 /area/almayer/engineering/ce_room)
@@ -63914,6 +69436,18 @@
 	icon_state = "cargo_arrow"
 	},
 /area/almayer/squads/delta)
+"rQI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_p)
+"rQL" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer,
+/area/almayer/shipboard/port_point_defense)
 "rQU" = (
 /obj/structure/largecrate/random/barrel/red,
 /turf/open/floor/almayer{
@@ -63950,6 +69484,19 @@
 	icon_state = "red"
 	},
 /area/almayer/shipboard/brig/cells)
+"rRm" = (
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = -9
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = -5
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_s)
 "rRq" = (
 /turf/closed/wall/almayer,
 /area/almayer/lifeboat_pumps/south2)
@@ -63991,6 +69538,16 @@
 	icon_state = "plate"
 	},
 /area/almayer/living/briefing)
+"rSb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/cigbutt/bcigbutt,
+/obj/effect/decal/strata_decals/grime/grime1{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/generic,
+/obj/item/trash/buritto,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/starboard_point_defense)
 "rSj" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -63999,6 +69556,12 @@
 	icon_state = "orangefull"
 	},
 /area/almayer/squads/alpha_bravo_shared)
+"rSy" = (
+/obj/effect/decal/strata_decals/grime/grime4,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "rSG" = (
 /obj/structure/toilet{
 	pixel_y = 16
@@ -64027,10 +69590,18 @@
 /area/almayer/shipboard/brig/lobby)
 "rSK" = (
 /obj/structure/machinery/light/small,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
 /area/almayer/hull/lower_hull/l_f_p)
+"rSU" = (
+/obj/structure/grille{
+	icon_state = "brokengrille";
+	density = 0
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_s)
 "rSW" = (
 /obj/structure/machinery/light{
 	dir = 8
@@ -64052,6 +69623,25 @@
 	icon_state = "redcorner"
 	},
 /area/almayer/shipboard/brig/chief_mp_office)
+"rTx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/tool/warning_cone{
+	pixel_x = -8;
+	pixel_y = 8
+	},
+/obj/structure/barricade/handrail{
+	dir = 1;
+	pixel_y = 2
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 9;
+	pixel_x = -15;
+	pixel_y = 20
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_f_s)
 "rTJ" = (
 /obj/effect/decal/cleanable/blood/oil/streak,
 /turf/open/floor/almayer{
@@ -64134,6 +69724,7 @@
 /obj/structure/machinery/light/small{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -64196,6 +69787,15 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/living/gym)
+"rXw" = (
+/obj/structure/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/decal/strata_decals/grime/grime4,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_s)
 "rXC" = (
 /obj/structure/disposalpipe/junction,
 /obj/structure/pipes/standard/manifold/hidden/supply{
@@ -64257,6 +69857,13 @@
 	icon_state = "plate"
 	},
 /area/almayer/living/offices/flight)
+"rYP" = (
+/obj/effect/decal/cleanable/blood/oil,
+/obj/structure/blocker/invisible_wall{
+	name = "\improper M34A2 Longstreet light tank"
+	},
+/turf/open/floor/plating,
+/area/almayer/hallways/hangar)
 "rZB" = (
 /obj/structure/pipes/standard/simple/visible{
 	dir = 9
@@ -64280,6 +69887,7 @@
 /obj/structure/surface/table/almayer,
 /obj/item/tool/weldpack,
 /obj/item/tool/crowbar,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -64335,6 +69943,7 @@
 "scg" = (
 /obj/structure/surface/rack,
 /obj/effect/spawner/random/toolbox,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -64680,6 +70289,15 @@
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer,
 /area/almayer/shipboard/brig/main_office)
+"sjf" = (
+/obj/structure/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_p)
 "sjj" = (
 /obj/structure/machinery/keycard_auth{
 	pixel_x = -7;
@@ -64736,6 +70354,17 @@
 	icon_state = "cargo_arrow"
 	},
 /area/almayer/squads/charlie_delta_shared)
+"skS" = (
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_p)
 "sld" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -64778,6 +70407,12 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/engineering/engineering_workshop)
+"smx" = (
+/obj/item/device/sentry_computer,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "snb" = (
 /obj/structure/ladder{
 	height = 1;
@@ -64947,7 +70582,11 @@
 	},
 /area/almayer/command/cic)
 "soZ" = (
-/obj/structure/largecrate/random/case/double,
+/obj/structure/surface/table/almayer,
+/obj/item/ammo_box/magazine/heap/empty{
+	pixel_x = -7;
+	pixel_y = 5
+	},
 /turf/open/floor/almayer{
 	icon_state = "cargo"
 	},
@@ -65046,6 +70685,19 @@
 	icon_state = "red"
 	},
 /area/almayer/shipboard/brig/main_office)
+"srW" = (
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice2";
+	pixel_x = -11;
+	pixel_y = 7
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice3";
+	pixel_x = -11;
+	pixel_y = -24
+	},
+/turf/open/floor/plating,
+/area/almayer/hull/lower_hull/l_m_s)
 "ssa" = (
 /obj/structure/machinery/door/poddoor/almayer/open{
 	id = "Hangar Lockdown";
@@ -65134,6 +70786,16 @@
 	allow_construction = 0
 	},
 /area/almayer/stair_clone/upper)
+"stF" = (
+/obj/structure/platform{
+	dir = 8
+	},
+/obj/structure/machinery/gear,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hallways/hangar)
 "stY" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer,
 /obj/structure/pipes/standard/simple/hidden/supply{
@@ -65158,6 +70820,16 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/command/computerlab)
+"suN" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	layer = 3.33;
+	pixel_y = 2
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hallways/hangar)
 "suT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -65220,6 +70892,10 @@
 	icon_state = "greencorner"
 	},
 /area/almayer/living/grunt_rnr)
+"swD" = (
+/obj/structure/largecrate/random/barrel/green,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_f_p)
 "swE" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/alarm/almayer{
@@ -65274,6 +70950,13 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_m_s)
+"sxn" = (
+/obj/structure/surface/table/almayer,
+/obj/item/circuitboard/airalarm,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_s)
 "sxu" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
@@ -65372,10 +71055,33 @@
 /area/almayer/squads/delta)
 "sAm" = (
 /obj/structure/largecrate/random/case/double,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb,
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice2";
+	pixel_x = -14;
+	pixel_y = 6
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	dir = 1;
+	icon_state = "lattice-simple";
+	pixel_x = -14;
+	pixel_y = -14
+	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
 /area/almayer/hull/lower_hull/l_f_s)
+"sAy" = (
+/obj/item/trash/hotdog{
+	pixel_x = -4;
+	pixel_y = 11
+	},
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_p)
 "sAA" = (
 /obj/structure/machinery/light{
 	dir = 1
@@ -65435,6 +71141,31 @@
 	icon_state = "green"
 	},
 /area/almayer/living/grunt_rnr)
+"sBW" = (
+/obj/structure/sign/safety/hvac_old{
+	pixel_x = 8;
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
+"sCl" = (
+/obj/structure/platform{
+	dir = 1
+	},
+/obj/structure/largecrate/random/case/small{
+	pixel_x = -7;
+	pixel_y = -8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "sCA" = (
 /obj/structure/bed/chair/comfy/delta{
 	dir = 4
@@ -65477,12 +71208,44 @@
 	icon_state = "silver"
 	},
 /area/almayer/shipboard/brig/cic_hallway)
+"sDc" = (
+/obj/structure/prop/ice_colony/ground_wire{
+	dir = 8
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_f_s)
+"sDk" = (
+/obj/effect/decal/cleanable/liquid_fuel,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_p)
+"sDo" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_f_p)
 "sDu" = (
 /obj/item/clothing/under/marine/dress,
 /turf/open/floor/almayer{
 	icon_state = "dark_sterile"
 	},
 /area/almayer/engineering/laundry)
+"sDx" = (
+/obj/structure/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/blood/oil/streak,
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "sDy" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 10
@@ -65802,13 +71565,41 @@
 	},
 /area/almayer/hallways/hangar)
 "sIV" = (
-/obj/structure/largecrate/random/barrel/yellow,
 /obj/effect/decal/warning_stripes{
 	icon_state = "SE-out"
 	},
-/turf/open/floor/almayer{
-	icon_state = "plate"
+/obj/structure/platform_decoration,
+/obj/structure/prop/invuln{
+	desc = "a pile of cables";
+	icon = 'icons/obj/structures/machinery/artillery.dmi';
+	icon_state = "29";
+	name = "cables";
+	density = 0;
+	layer = 3;
+	pixel_x = -12;
+	pixel_y = -22
 	},
+/obj/structure/prop/invuln{
+	desc = "a pile of cables";
+	icon = 'icons/obj/structures/machinery/artillery.dmi';
+	icon_state = "27";
+	name = "cables";
+	density = 0;
+	layer = 3;
+	pixel_x = 18;
+	pixel_y = -14
+	},
+/obj/structure/prop/invuln{
+	desc = "a pile of cables";
+	icon = 'icons/obj/structures/machinery/artillery.dmi';
+	icon_state = "29";
+	name = "cables";
+	density = 0;
+	layer = 3;
+	pixel_x = -2;
+	pixel_y = -8
+	},
+/turf/open/floor/plating,
 /area/almayer/hull/lower_hull/l_a_p)
 "sIY" = (
 /obj/structure/machinery/brig_cell/perma_1{
@@ -65848,6 +71639,12 @@
 	icon_state = "orange"
 	},
 /area/almayer/living/port_emb)
+"sJZ" = (
+/obj/effect/decal/strata_decals/grime/grime2{
+	dir = 1
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_s)
 "sKa" = (
 /turf/open/floor/almayer{
 	dir = 4;
@@ -65999,6 +71796,12 @@
 	icon_state = "redfull"
 	},
 /area/almayer/medical/upper_medical)
+"sPb" = (
+/obj/effect/decal/strata_decals/grime/grime3,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_p)
 "sPc" = (
 /obj/structure/machinery/light{
 	dir = 1
@@ -66132,6 +71935,23 @@
 	icon_state = "blue"
 	},
 /area/almayer/squads/delta)
+"sSF" = (
+/obj/structure/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/obj/effect/decal/strata_decals/grime/grime2,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "sSR" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "SW-out";
@@ -66175,6 +71995,21 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/living/briefing)
+"sTJ" = (
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = -9
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = -11;
+	pixel_x = 1
+	},
+/obj/effect/decal/cleanable/blood/oil/streak,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_p)
 "sTV" = (
 /obj/structure/machinery/power/apc/almayer/hardened{
 	cell_type = /obj/item/cell/hyper;
@@ -66228,6 +72063,16 @@
 	icon_state = "orangecorner"
 	},
 /area/almayer/hallways/stern_hallway)
+"sUJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/platform,
+/obj/item/trash/hotdog{
+	pixel_x = -1;
+	pixel_y = -7
+	},
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plating,
+/area/almayer/hull/lower_hull/l_m_p)
 "sUO" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -66267,12 +72112,45 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_m_p)
+"sVo" = (
+/obj/structure/largecrate/random/barrel/white,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "sVy" = (
 /obj/structure/machinery/power/apc/almayer{
 	dir = 1
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/cryo)
+"sWB" = (
+/obj/item/trash/boonie,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = -16
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	dir = 1;
+	icon_state = "lattice-simple";
+	pixel_x = -16;
+	pixel_y = -16
+	},
+/obj/effect/decal/strata_decals/grime/grime3,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "sWW" = (
 /obj/structure/machinery/flasher{
 	alpha = 1;
@@ -66373,6 +72251,24 @@
 	icon_state = "orange"
 	},
 /area/almayer/engineering/lower_engineering)
+"sYe" = (
+/obj/structure/cable{
+	icon_state = "2-6";
+	pixel_x = -12
+	},
+/obj/structure/sign/poster/music{
+	pixel_x = -27
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice3";
+	pixel_x = -11
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
+/turf/open/floor/plating,
+/area/almayer/hull/lower_hull/l_m_s)
 "sYh" = (
 /turf/open/floor/almayer{
 	dir = 1;
@@ -66441,6 +72337,14 @@
 	icon_state = "plate"
 	},
 /area/almayer/command/lifeboat)
+"sYK" = (
+/obj/item/trash/used_stasis_bag,
+/obj/structure/prop/invuln/overhead_pipe{
+	pixel_x = 6;
+	pixel_y = 12
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_s)
 "sYP" = (
 /obj/structure/reagent_dispensers/fueltank/custom,
 /turf/open/floor/almayer{
@@ -66588,8 +72492,14 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_m_p)
+"tcd" = (
+/obj/structure/girder/displaced,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "tce" = (
-/obj/structure/closet/emcloset,
+/obj/item/tank/oxygen/red,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -66613,6 +72523,13 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/shipboard/brig/perma)
+"tcX" = (
+/obj/structure/closet/emcloset,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_p)
 "tdc" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
@@ -66727,6 +72644,16 @@
 	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering/starboard)
+"tfj" = (
+/obj/structure/machinery/door/poddoor/almayer/open{
+	id = "Hangar Lockdown";
+	name = "\improper Hangar Lockdown Blast Door"
+	},
+/obj/structure/pipes/standard/simple/hidden/supply,
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/hallways/hangar)
 "tfl" = (
 /obj/structure/machinery/light{
 	dir = 1
@@ -66846,6 +72773,14 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
+/area/almayer/hull/lower_hull/l_f_s)
+"thU" = (
+/obj/effect/decal/cleanable/greenglow,
+/obj/effect/decal/cleanable/molten_item{
+	pixel_x = -8;
+	pixel_y = 10
+	},
+/turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_f_s)
 "thV" = (
 /turf/open/floor/almayer{
@@ -67235,6 +73170,18 @@
 	icon_state = "plate"
 	},
 /area/almayer/hull/upper_hull/u_a_p)
+"tqd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 15;
+	pixel_x = 1
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_p)
 "tqe" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -67243,6 +73190,19 @@
 	icon_state = "sterile_green_side"
 	},
 /area/almayer/shipboard/brig/surgery)
+"tqf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/obj/item/trash/hotdog{
+	pixel_x = -4;
+	pixel_y = 11
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	pixel_x = 6;
+	pixel_y = 12
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_s)
 "tqg" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "SE-out"
@@ -67284,7 +73244,37 @@
 	pixel_x = 12;
 	pixel_y = 12
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_p)
+"tqo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/chair/office/dark{
+	dir = 8
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hallways/hangar)
+"tqx" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7;
+	pixel_x = 13
+	},
+/obj/structure/prop/invuln/pipe_water,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
 /area/almayer/hull/lower_hull/l_m_p)
 "tqB" = (
 /obj/structure/machinery/light{
@@ -67308,6 +73298,73 @@
 /obj/structure/window/framed/almayer/hull,
 /turf/open/floor/plating,
 /area/almayer/lifeboat_pumps/south1)
+"trq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/cigbutt{
+	pixel_x = 1;
+	pixel_y = 8
+	},
+/obj/item/trash/cigbutt{
+	pixel_x = 1;
+	pixel_y = 8
+	},
+/obj/item/trash/cigbutt{
+	pixel_x = 4
+	},
+/obj/item/trash/cigbutt{
+	pixel_x = -7;
+	pixel_y = 13
+	},
+/obj/item/trash/cigbutt{
+	pixel_x = 13;
+	pixel_y = 3
+	},
+/obj/item/trash/cigbutt{
+	pixel_x = -1;
+	pixel_y = 17
+	},
+/obj/item/trash/cigbutt{
+	pixel_x = -4;
+	pixel_y = 2
+	},
+/obj/item/trash/cigbutt{
+	pixel_x = -9;
+	pixel_y = -6
+	},
+/obj/item/trash/cigbutt{
+	pixel_x = -7;
+	pixel_y = 13
+	},
+/obj/item/trash/cigbutt{
+	pixel_x = 13;
+	pixel_y = 8
+	},
+/obj/item/trash/cigbutt{
+	pixel_x = -1;
+	pixel_y = 17
+	},
+/obj/effect/decal/strata_decals/grime/grime1{
+	dir = 8
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_s)
+"trw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = -9
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = -11;
+	pixel_x = 1
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_p)
 "trB" = (
 /turf/open/floor/almayer{
 	dir = 10;
@@ -67322,6 +73379,7 @@
 	pixel_x = 8;
 	pixel_y = 32
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_m_p)
 "trF" = (
@@ -67418,6 +73476,22 @@
 	icon_state = "sterile_green_corner"
 	},
 /area/almayer/medical/upper_medical)
+"tsG" = (
+/obj/structure/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/oil,
+/obj/structure/prop/invuln/lattice_prop{
+	dir = 1;
+	icon_state = "lattice-simple";
+	pixel_x = -16;
+	pixel_y = -16
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "tsH" = (
 /obj/structure/pipes/standard/manifold/hidden/supply{
 	dir = 1
@@ -67444,6 +73518,20 @@
 "tsX" = (
 /turf/closed/wall/almayer/reinforced,
 /area/almayer/shipboard/brig/lobby)
+"tsZ" = (
+/obj/item/stack/tile/plasteel{
+	pixel_x = 3;
+	pixel_y = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/tool/warning_cone{
+	pixel_y = 11;
+	pixel_x = 13
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "ttd" = (
 /obj/structure/sign/safety/bathunisex{
 	pixel_x = 32
@@ -67459,6 +73547,15 @@
 	},
 /turf/open/floor/plating,
 /area/almayer/powered/agent)
+"ttF" = (
+/obj/structure/prop/invuln/lattice_prop{
+	dir = 1;
+	icon_state = "lattice-simple";
+	pixel_x = -16;
+	pixel_y = -16
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_p)
 "ttM" = (
 /obj/item/device/radio/intercom{
 	freerange = 1;
@@ -67538,6 +73635,30 @@
 "tuA" = (
 /turf/closed/wall/almayer/outer,
 /area/almayer/shipboard/port_missiles)
+"tuK" = (
+/obj/structure/platform{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/oil/streak,
+/obj/item/clothing/glasses/welding{
+	pixel_x = 5;
+	pixel_y = -7
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hallways/hangar)
+"tuM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/largecrate/random/barrel/red{
+	pixel_x = 5;
+	pixel_y = -9
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_f_p)
 "tuN" = (
 /turf/open/floor/almayer{
 	icon_state = "orange"
@@ -67550,6 +73671,16 @@
 	icon_state = "redcorner"
 	},
 /area/almayer/shipboard/weapon_room)
+"tvl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/grille{
+	icon_state = "brokengrille";
+	density = 0
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "tvw" = (
 /obj/structure/pipes/standard/manifold/hidden/supply{
 	dir = 4
@@ -67623,6 +73754,16 @@
 	icon_state = "outerhull_dir"
 	},
 /area/space)
+"twL" = (
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice3";
+	pixel_x = -5;
+	pixel_y = 15
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_p)
 "twT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -67667,6 +73808,18 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/port_hallway)
+"txK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/lattice_prop{
+	dir = 1;
+	icon_state = "lattice-simple";
+	pixel_x = 14;
+	pixel_y = -16
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "txO" = (
 /obj/structure/machinery/landinglight/ds1{
 	dir = 4
@@ -67785,6 +73938,7 @@
 	pixel_x = 8;
 	pixel_y = 32
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -67827,6 +73981,7 @@
 "tAR" = (
 /obj/effect/spawner/random/toolbox,
 /obj/structure/largecrate/random/barrel/red,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -67876,6 +74031,38 @@
 	icon_state = "plate"
 	},
 /area/almayer/hull/upper_hull/u_f_s)
+"tCJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/platform,
+/obj/structure/platform{
+	dir = 1
+	},
+/obj/structure/platform{
+	dir = 4
+	},
+/obj/structure/platform_decoration{
+	dir = 6;
+	layer = 3.51
+	},
+/obj/structure/platform{
+	dir = 8
+	},
+/obj/structure/platform_decoration{
+	dir = 10
+	},
+/obj/item/ammo_box/magazine/heap/empty{
+	pixel_y = -4
+	},
+/obj/structure/platform_decoration{
+	dir = 5;
+	layer = 3.51
+	},
+/obj/structure/platform_decoration{
+	dir = 9;
+	layer = 3.51
+	},
+/turf/open/floor/plating,
+/area/almayer/hull/lower_hull/l_a_s)
 "tCN" = (
 /turf/open/floor/almayer{
 	dir = 8;
@@ -68001,6 +74188,19 @@
 	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering/port)
+"tGe" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "W"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/grille{
+	icon_state = "brokengrille";
+	density = 0
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_f_s)
 "tGf" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 9
@@ -68027,6 +74227,13 @@
 /obj/effect/spawner/random/tool,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/lifeboat_pumps/south2)
+"tGj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/largecrate/random/case/small,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_f_s)
 "tGq" = (
 /obj/effect/projector{
 	name = "Almayer_Up4";
@@ -68196,6 +74403,27 @@
 	icon_state = "plate"
 	},
 /area/almayer/hull/upper_hull/u_a_s)
+"tIV" = (
+/obj/structure/prop/invuln/overhead_pipe{
+	pixel_x = 12
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	pixel_x = 12;
+	pixel_y = 12
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/liquid_fuel,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_s)
+"tIW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/largecrate/random/barrel/blue,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_f_s)
 "tJa" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer{
 	dir = 1
@@ -68272,6 +74500,11 @@
 	icon_state = "green"
 	},
 /area/almayer/living/grunt_rnr)
+"tJW" = (
+/obj/structure/machinery/light/small,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_f_p)
 "tKf" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer,
 /obj/structure/machinery/light{
@@ -68345,6 +74578,14 @@
 /obj/structure/bed/chair/comfy/beige,
 /turf/open/floor/carpet,
 /area/almayer/living/commandbunks)
+"tMQ" = (
+/obj/effect/decal/strata_decals/grime/grime2{
+	dir = 1
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_f_s)
 "tMW" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "NW-out";
@@ -68415,6 +74656,11 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/aft_hallway)
+"tOp" = (
+/obj/effect/decal/cleanable/ash,
+/obj/effect/decal/cleanable/liquid_fuel,
+/turf/open/floor/plating,
+/area/almayer/hull/lower_hull/l_m_s)
 "tOr" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N";
@@ -68458,6 +74704,13 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/squads/req)
+"tPD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "tPI" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -68541,6 +74794,12 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/aft_hallway)
+"tSd" = (
+/obj/effect/decal/strata_decals/grime/grime4,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_p)
 "tSp" = (
 /obj/item/device/radio/intercom{
 	freerange = 1;
@@ -68556,6 +74815,8 @@
 	pixel_x = 12;
 	pixel_y = 12
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/strata_decals/grime/grime3,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -68572,6 +74833,17 @@
 	icon_state = "orangecorner"
 	},
 /area/almayer/living/briefing)
+"tSE" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "W"
+	},
+/obj/structure/machinery/status_display{
+	pixel_y = 30
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hallways/hangar)
 "tTp" = (
 /obj/structure/surface/table/almayer,
 /obj/item/reagent_container/food/condiment/hotsauce/sriracha{
@@ -68650,6 +74922,7 @@
 /obj/structure/sign/safety/restrictedarea{
 	pixel_x = -17
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -68674,6 +74947,10 @@
 	icon_state = "cargo_arrow"
 	},
 /area/almayer/squads/alpha)
+"tVx" = (
+/obj/item/device/flashlight/lamp/tripod/grey,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_s)
 "tVB" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/almayer{
@@ -68822,6 +75099,18 @@
 	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/lower_medical_lobby)
+"tYu" = (
+/obj/structure/largecrate/random/barrel/blue,
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_s)
 "tYw" = (
 /obj/effect/decal/medical_decals{
 	icon_state = "triagedecalbottomleft";
@@ -68843,6 +75132,11 @@
 	icon_state = "plate"
 	},
 /area/almayer/hull/upper_hull/u_f_s)
+"tYP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/foamed_metal,
+/turf/open/floor/plating,
+/area/almayer/hull/lower_hull/l_m_s)
 "tYX" = (
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -68964,6 +75258,26 @@
 	dir = 4
 	},
 /area/almayer/medical/containment/cell)
+"uat" = (
+/obj/effect/decal/strata_decals/grime/grime3,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
+"uax" = (
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_p)
 "uaI" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/processor{
@@ -69004,6 +75318,19 @@
 /obj/item/frame/table,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_a_p)
+"ubf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/handrail{
+	dir = 8
+	},
+/obj/item/tool/warning_cone{
+	pixel_x = -7;
+	pixel_y = 2
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_f_s)
 "ubA" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
@@ -69013,6 +75340,17 @@
 	icon_state = "ai_floors"
 	},
 /area/almayer/command/airoom)
+"ubB" = (
+/obj/structure/blocker/invisible_wall,
+/turf/open/floor/plating,
+/area/almayer/hallways/hangar)
+"ucd" = (
+/obj/structure/prop/invuln/overhead_pipe{
+	pixel_x = 12
+	},
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_s)
 "ucp" = (
 /obj/structure/window/framed/almayer,
 /turf/open/floor/plating,
@@ -69023,6 +75361,18 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/lifeboat_pumps/south2)
+"ucA" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/platform{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/almayer/hull/lower_hull/l_m_p)
+"ucE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/grille,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_p)
 "udi" = (
 /turf/open/floor/almayer{
 	icon_state = "red"
@@ -69102,6 +75452,7 @@
 	pixel_x = 8;
 	pixel_y = 32
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -69261,6 +75612,8 @@
 /obj/structure/prop/invuln/overhead_pipe{
 	pixel_x = 12
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/inflatable,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -69459,10 +75812,23 @@
 /obj/structure/machinery/door/airlock/almayer/security/glass{
 	name = "Brig"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
 	},
 /area/almayer/hull/lower_hull/l_f_p)
+"umX" = (
+/obj/item/tool/crowbar{
+	pixel_y = -9
+	},
+/obj/structure/prop/invuln/overhead/flammable_pipe/fly{
+	dir = 8;
+	pixel_x = 6;
+	pixel_y = 7;
+	layer = 4
+	},
+/turf/open/floor/plating,
+/area/almayer/hull/lower_hull/l_m_s)
 "unh" = (
 /obj/structure/surface/table/almayer,
 /obj/item/storage/firstaid/o2,
@@ -69471,10 +75837,20 @@
 	dir = 1;
 	pixel_y = -28
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
 /area/almayer/shipboard/port_point_defense)
+"unn" = (
+/obj/structure/prop/invuln{
+	icon = 'icons/obj/structures/machinery/cryogenics.dmi';
+	icon_state = "body_scanner_closed";
+	name = "broken hypersleep chamber";
+	desc = "You just can make out the shape of a man inside this. The pod reads no lifesigns."
+	},
+/turf/open/shuttle/escapepod,
+/area/almayer/hull/lower_hull/l_m_s)
 "uns" = (
 /obj/structure/machinery/portable_atmospherics/hydroponics,
 /obj/item/seeds/carrotseed,
@@ -69486,6 +75862,29 @@
 	icon_state = "green"
 	},
 /area/almayer/shipboard/brig/cells)
+"unu" = (
+/obj/structure/surface/table/almayer,
+/obj/effect/spawner/random/toolbox,
+/obj/item/ashtray/bronze{
+	pixel_x = 9;
+	pixel_y = 8
+	},
+/obj/item/trash/cigbutt/ucigbutt{
+	pixel_x = -13;
+	pixel_y = 8
+	},
+/obj/item/trash/cigbutt/ucigbutt{
+	pixel_x = 3;
+	pixel_y = 12
+	},
+/obj/item/trash/cigbutt/ucigbutt{
+	pixel_x = -4;
+	pixel_y = 16
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hallways/hangar)
 "unJ" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 6
@@ -69513,6 +75912,10 @@
 	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical_medbay)
+"unX" = (
+/obj/effect/decal/cleanable/liquid_fuel,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_s)
 "uoi" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
@@ -69653,6 +76056,7 @@
 /area/almayer/squads/bravo)
 "uqH" = (
 /obj/structure/machinery/light/small,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_m_p)
 "uqI" = (
@@ -69661,6 +76065,13 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/command/lifeboat)
+"urn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/strata_decals/grime/grime2,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_p)
 "urM" = (
 /obj/structure/machinery/light{
 	dir = 8
@@ -69730,6 +76141,13 @@
 	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/medical_science)
+"usR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/largecrate/random/secure,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_p)
 "usX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -70060,6 +76478,18 @@
 "uys" = (
 /turf/closed/wall/almayer/reinforced,
 /area/almayer/squads/req)
+"uyt" = (
+/obj/structure/sign/safety/hvac_old{
+	pixel_x = 8;
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/liquid_fuel,
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_s)
 "uyC" = (
 /obj/structure/window/framed/almayer/hull,
 /turf/open/floor/plating,
@@ -70073,11 +76503,32 @@
 	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/chemistry)
+"uyX" = (
+/obj/structure/prop/invuln{
+	desc = "a pile of cables";
+	icon = 'icons/obj/structures/props/almayer_props.dmi';
+	icon_state = "cannon_cables";
+	name = "cables";
+	density = 0;
+	layer = 3
+	},
+/obj/item/stack/tile/plasteel{
+	pixel_x = 24;
+	pixel_y = 13;
+	layer = 3.1
+	},
+/turf/open/floor/plating,
+/area/almayer/hull/lower_hull/l_a_p)
 "uzg" = (
 /obj/structure/sign/safety/water{
 	pixel_x = 8;
 	pixel_y = -32
 	},
+/obj/structure/surface/table/almayer,
+/obj/item/clothing/head/helmet/space/compression/uscm{
+	pixel_x = -3
+	},
+/obj/item/clothing/suit/space/compression/uscm,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -70093,6 +76544,28 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/hull/upper_hull/u_f_s)
+"uzu" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/grille{
+	icon_state = "brokengrille";
+	density = 0
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_p)
+"uzv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/grille{
+	icon_state = "brokengrille";
+	density = 0
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_p)
 "uzx" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -70200,15 +76673,6 @@
 	icon_state = "red"
 	},
 /area/almayer/shipboard/port_missiles)
-"uAs" = (
-/obj/structure/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/largecrate/random/barrel/white,
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/hull/lower_hull/l_m_s)
 "uAC" = (
 /obj/item/bedsheet/purple{
 	layer = 3.2
@@ -70272,6 +76736,20 @@
 	icon_state = "orange"
 	},
 /area/almayer/hallways/stern_hallway)
+"uBD" = (
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = -9
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = -11;
+	pixel_x = 1
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_p)
 "uBM" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/plating/plating_catwalk,
@@ -70397,6 +76875,12 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/hull/upper_hull/u_f_p)
+"uEG" = (
+/obj/effect/decal/strata_decals/grime/grime3,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_f_s)
 "uFd" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N";
@@ -70496,12 +76980,11 @@
 	},
 /area/almayer/hallways/aft_hallway)
 "uGw" = (
-/obj/structure/surface/table/almayer,
-/obj/item/reagent_container/food/drinks/cans/souto/diet/lime{
-	pixel_x = 7;
-	pixel_y = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/item/device/flashlight/lamp/tripod/grey,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
 	},
-/turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_m_s)
 "uGz" = (
 /obj/structure/machinery/camera/autoname/almayer{
@@ -70517,6 +77000,13 @@
 	icon_state = "plate"
 	},
 /area/almayer/engineering/upper_engineering/starboard)
+"uHP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/strata_decals/grime/grime2{
+	dir = 1
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_s)
 "uId" = (
 /obj/structure/bed/chair/comfy/teal{
 	dir = 8
@@ -70562,6 +77052,18 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/squads/alpha_bravo_shared)
+"uJj" = (
+/obj/item/trash/used_stasis_bag{
+	pixel_x = -7;
+	pixel_y = 10
+	},
+/obj/item/trash/used_stasis_bag{
+	pixel_x = 11;
+	pixel_y = -3
+	},
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_s)
 "uJk" = (
 /obj/structure/prop/almayer/name_stencil{
 	icon_state = "almayer4"
@@ -70571,22 +77073,18 @@
 	},
 /area/space)
 "uJl" = (
-/obj/structure/surface/table/almayer,
-/obj/item/pizzabox/meat,
-/obj/item/reagent_container/food/drinks/cans/souto/diet/peach{
-	pixel_x = -4;
-	pixel_y = -3
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
 	},
-/obj/item/reagent_container/food/drinks/cans/souto/diet/cherry{
-	pixel_x = 8;
-	pixel_y = 6
-	},
-/turf/open/floor/almayer{
-	icon_state = "plate"
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
 	},
 /area/almayer/hull/lower_hull/l_m_s)
 "uJo" = (
 /obj/structure/largecrate/random/barrel/blue,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -70600,6 +77098,13 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/shipboard/brig/main_office)
+"uJF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/oil/streak,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_s)
 "uJU" = (
 /obj/structure/machinery/cryopod/right{
 	pixel_y = 6
@@ -70676,6 +77181,7 @@
 /area/almayer/engineering/upper_engineering/starboard)
 "uLn" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer,
 /area/almayer/shipboard/starboard_point_defense)
 "uLu" = (
@@ -70764,6 +77270,14 @@
 	icon_state = "blue"
 	},
 /area/almayer/squads/delta)
+"uMZ" = (
+/obj/item/device/flashlight/lamp/tripod/grey,
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice3";
+	pixel_x = -11
+	},
+/turf/open/floor/plating,
+/area/almayer/hull/lower_hull/l_m_s)
 "uNe" = (
 /obj/structure/pipes/standard/manifold/hidden/supply{
 	dir = 8
@@ -70815,6 +77329,21 @@
 	icon_state = "blue"
 	},
 /area/almayer/living/basketball)
+"uNQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/platform{
+	dir = 1
+	},
+/obj/structure/prop/invuln{
+	desc = "a pile of cables";
+	icon = 'icons/obj/structures/props/almayer_props.dmi';
+	icon_state = "cannon_cables";
+	name = "cables";
+	density = 0;
+	layer = 2
+	},
+/turf/open/floor/plating,
+/area/almayer/hull/lower_hull/l_a_p)
 "uNV" = (
 /obj/structure/flora/pottedplant{
 	icon_state = "pottedplant_22"
@@ -70825,6 +77354,12 @@
 /obj/structure/prop/invuln/overhead_pipe{
 	pixel_x = 12
 	},
+/obj/structure/prop/invuln/overhead_pipe{
+	pixel_x = 12
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/liquid_fuel,
+/obj/item/trash/boonie,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -70855,6 +77390,11 @@
 	icon_state = "blue"
 	},
 /area/almayer/living/basketball)
+"uPE" = (
+/obj/effect/decal/cleanable/generic,
+/obj/item/trash/used_stasis_bag,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_f_s)
 "uPI" = (
 /obj/structure/pipes/vents/pump{
 	dir = 1
@@ -70962,6 +77502,18 @@
 	},
 /turf/open/floor/plating,
 /area/almayer/living/port_emb)
+"uRO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_s)
 "uRQ" = (
 /obj/item/storage/firstaid/fire,
 /obj/structure/surface/rack,
@@ -70969,6 +77521,10 @@
 	icon_state = "plate"
 	},
 /area/almayer/hull/upper_hull/u_a_s)
+"uSk" = (
+/obj/effect/decal/strata_decals/grime/grime4,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_s)
 "uSq" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "NW-out";
@@ -70998,6 +77554,14 @@
 	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/lockerroom)
+"uTr" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/strata_decals/grime/grime1{
+	dir = 4
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_p)
 "uTv" = (
 /obj/structure/surface/table/almayer,
 /obj/item/trash/USCMtray{
@@ -71085,6 +77649,7 @@
 /obj/structure/machinery/alarm/almayer{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -71125,6 +77690,16 @@
 	icon_state = "kitchen"
 	},
 /area/almayer/engineering/upper_engineering/port)
+"uUZ" = (
+/obj/structure/largecrate/random/case/double,
+/obj/structure/prop/invuln/lattice_prop{
+	dir = 1;
+	icon_state = "lattice-simple";
+	pixel_x = 14;
+	pixel_y = -16
+	},
+/turf/open/floor/plating,
+/area/almayer/hull/lower_hull/l_m_s)
 "uVd" = (
 /obj/structure/machinery/cm_vending/sorted/medical/wall_med{
 	pixel_y = -25
@@ -71288,6 +77863,12 @@
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer,
 /area/almayer/command/lifeboat)
+"uYu" = (
+/obj/item/trash/crushed_cup,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_p)
 "uYO" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 6
@@ -71313,6 +77894,13 @@
 	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering/starboard)
+"uZN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_s)
 "uZQ" = (
 /obj/structure/window/framed/almayer,
 /turf/open/floor/plating,
@@ -71359,6 +77947,20 @@
 	icon_state = "plate"
 	},
 /area/almayer/hallways/hangar)
+"vbt" = (
+/obj/structure/prop/invuln/overhead_pipe{
+	pixel_x = 12
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	pixel_x = 12;
+	pixel_y = 12
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/oil/streak,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_f_s)
 "vbB" = (
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/lifeboat_pumps/south1)
@@ -71553,6 +78155,26 @@
 	icon_state = "emerald"
 	},
 /area/almayer/squads/charlie)
+"vfj" = (
+/obj/structure/surface/table/almayer,
+/obj/item/reagent_container/food/snacks/meatpie,
+/obj/item/reagent_container/food/condiment/saltshaker{
+	pixel_x = -14;
+	pixel_y = 10
+	},
+/obj/item/reagent_container/food/condiment/peppermill{
+	pixel_x = -13
+	},
+/obj/item/reagent_container/food/drinks/cup{
+	pixel_x = -7;
+	pixel_y = 9
+	},
+/obj/item/reagent_container/food/drinks/cup{
+	pixel_x = 13;
+	pixel_y = -7
+	},
+/turf/open/floor/plating,
+/area/almayer/hull/lower_hull/l_m_s)
 "vfo" = (
 /obj/structure/machinery/door/airlock/almayer/secure/reinforced{
 	dir = 2;
@@ -71601,6 +78223,11 @@
 /obj/item/frame/table,
 /obj/item/frame/table,
 /obj/item/frame/table,
+/obj/item/frame/table,
+/obj/item/frame/table,
+/obj/item/frame/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/oil/streak,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -71723,6 +78350,14 @@
 	icon_state = "ai_floors"
 	},
 /area/almayer/command/airoom)
+"vhg" = (
+/obj/effect/decal/cleanable/generic,
+/obj/item/trash/hotdog{
+	pixel_x = -1;
+	pixel_y = -7
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_f_s)
 "vhq" = (
 /turf/open/floor/almayer{
 	icon_state = "plate"
@@ -71733,6 +78368,7 @@
 	pixel_x = 8;
 	pixel_y = 32
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_f_p)
 "vhw" = (
@@ -71744,6 +78380,7 @@
 /area/almayer/living/offices/flight)
 "vhI" = (
 /obj/structure/closet/firecloset,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_m_p)
 "vhR" = (
@@ -71884,6 +78521,10 @@
 	icon_state = "plating"
 	},
 /area/almayer/shipboard/port_missiles)
+"vjm" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_f_p)
 "vjx" = (
 /obj/structure/largecrate/random/barrel/yellow,
 /turf/open/floor/almayer{
@@ -72035,6 +78676,7 @@
 	pixel_x = 8;
 	pixel_y = -32
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_f_s)
 "vmN" = (
@@ -72399,9 +79041,37 @@
 	icon_state = "blue"
 	},
 /area/almayer/squads/delta)
+"vuO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 6;
+	pixel_y = -9
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = -5
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_s)
 "vuR" = (
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_a_p)
+"vuU" = (
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "vuZ" = (
 /obj/structure/pipes/vents/scrubber{
 	dir = 4
@@ -72514,6 +79184,12 @@
 /obj/structure/machinery/light,
 /turf/open/floor/almayer,
 /area/almayer/hallways/hangar)
+"vxh" = (
+/obj/structure/grille,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "vxC" = (
 /turf/open/floor/almayer{
 	icon_state = "red"
@@ -72561,6 +79237,12 @@
 	},
 /turf/open/floor/plating,
 /area/almayer/shipboard/brig/processing)
+"vym" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_p)
 "vyp" = (
 /obj/structure/machinery/cryopod{
 	pixel_y = 6
@@ -72616,6 +79298,13 @@
 	icon_state = "greenfull"
 	},
 /area/almayer/shipboard/brig/cells)
+"vzB" = (
+/obj/item/stack/sheet/metal,
+/obj/effect/decal/strata_decals/grime/grime3,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_s)
 "vzK" = (
 /turf/open/floor/almayer,
 /area/almayer/engineering/ce_room)
@@ -72822,6 +79511,16 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/medical/upper_medical)
+"vEA" = (
+/obj/structure/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/strata_decals/grime/grime4,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "vEH" = (
 /obj/structure/machinery/vending/coffee,
 /turf/open/floor/almayer,
@@ -72874,6 +79573,21 @@
 "vGk" = (
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/upper_hull/u_m_p)
+"vGo" = (
+/obj/structure/platform{
+	dir = 8
+	},
+/obj/structure/prop/invuln/overhead/flammable_pipe/fly{
+	dir = 8;
+	pixel_x = 6;
+	pixel_y = 7;
+	layer = 4
+	},
+/turf/open/floor/plating{
+	dir = 8;
+	icon_state = "platingdmg3"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "vGr" = (
 /obj/structure/closet/firecloset,
 /obj/item/clothing/mask/gas,
@@ -72882,6 +79596,13 @@
 	icon_state = "plate"
 	},
 /area/almayer/hull/upper_hull/u_a_p)
+"vGs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/molten_item,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_p)
 "vGy" = (
 /obj/structure/largecrate/supply/supplies/tables_racks,
 /turf/open/floor/plating,
@@ -72899,6 +79620,20 @@
 	icon_state = "orangefull"
 	},
 /area/almayer/living/briefing)
+"vGI" = (
+/obj/structure/machinery/light/small{
+	dir = 1
+	},
+/obj/item/trash/liquidfood{
+	pixel_x = -11;
+	pixel_y = 5
+	},
+/obj/item/trash/USCMtray{
+	pixel_x = 15;
+	pixel_y = 19
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_f_s)
 "vHa" = (
 /obj/structure/surface/table/reinforced/almayer_B,
 /obj/structure/machinery/computer/ares_console{
@@ -72977,6 +79712,7 @@
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -73031,6 +79767,7 @@
 	pixel_x = 8;
 	pixel_y = -32
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -73071,6 +79808,10 @@
 	icon_state = "sterile_green_corner"
 	},
 /area/almayer/medical/containment)
+"vKd" = (
+/obj/effect/decal/strata_decals/grime/grime4,
+/turf/closed/wall/almayer/outer,
+/area/almayer/hull/lower_hull/l_a_p)
 "vKe" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer{
@@ -73104,6 +79845,13 @@
 	allow_construction = 0
 	},
 /area/almayer/hallways/aft_hallway)
+"vKW" = (
+/obj/structure/largecrate/random/case/small,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_f_p)
 "vLh" = (
 /obj/item/roller,
 /obj/structure/surface/rack,
@@ -73127,6 +79875,11 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/medical/upper_medical)
+"vLy" = (
+/obj/structure/surface/table/almayer,
+/obj/item/fuelCell,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_s)
 "vLA" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W";
@@ -73141,11 +79894,44 @@
 	icon_state = "cargo_arrow"
 	},
 /area/almayer/squads/charlie)
+"vLH" = (
+/obj/structure/sign/safety/storage{
+	pixel_x = 8;
+	pixel_y = -32
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_s)
+"vLW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
+/obj/item/trash/candy{
+	pixel_y = 1;
+	pixel_x = 13
+	},
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_p)
 "vMn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/largecrate/random/barrel/blue,
+/obj/structure/prop/invuln/overhead/flammable_pipe/fly{
+	dir = 8;
+	pixel_x = -2;
+	pixel_y = 12;
+	layer = 4
+	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -73231,6 +80017,45 @@
 "vOy" = (
 /turf/closed/wall/almayer/white/reinforced,
 /area/almayer/medical/medical_science)
+"vOB" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7;
+	pixel_x = 13
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_p)
+"vOJ" = (
+/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/ammo_magazine/rifle/lmg/heap{
+	current_rounds = 0
+	},
+/obj/structure/closet/crate/supply,
+/obj/item/ammo_magazine/rifle/lmg/heap{
+	current_rounds = 0;
+	pixel_x = -10;
+	pixel_y = -4
+	},
+/obj/item/ammo_magazine/rifle/lmg/heap{
+	current_rounds = 0;
+	pixel_x = 4;
+	pixel_y = -7
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "vOP" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer{
 	dir = 2
@@ -73269,6 +80094,7 @@
 	pixel_x = 12;
 	pixel_y = 12
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -73386,6 +80212,15 @@
 	dir = 10
 	},
 /area/almayer/command/cic)
+"vRr" = (
+/obj/item/trash/cigbutt{
+	pixel_x = 1;
+	pixel_y = 8
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "vRu" = (
 /obj/structure/surface/rack{
 	layer = 2.5
@@ -73416,6 +80251,24 @@
 	icon_state = "sterile_green_corner"
 	},
 /area/almayer/medical/upper_medical)
+"vSf" = (
+/obj/structure/ob_ammo/ob_fuel{
+	desc = "leaked a bit of fuel, but its still functional, right?";
+	name = "slightly punctured solid fuel"
+	},
+/obj/effect/decal/cleanable/liquid_fuel,
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "vSg" = (
 /obj/structure/machinery/light/small,
 /obj/structure/pipes/standard/simple/hidden/supply{
@@ -73521,6 +80374,18 @@
 	icon_state = "plate"
 	},
 /area/almayer/engineering/upper_engineering)
+"vTH" = (
+/obj/structure/prop/invuln/overhead/flammable_pipe/fly{
+	dir = 8;
+	pixel_x = -2;
+	pixel_y = 13;
+	layer = 4
+	},
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "vTK" = (
 /turf/closed/wall/almayer/outer,
 /area/almayer/hull/lower_hull/l_a_p)
@@ -73617,6 +80482,12 @@
 	icon_state = "plate"
 	},
 /area/almayer/engineering/upper_engineering/port)
+"vVH" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "vVW" = (
 /obj/effect/decal/medical_decals{
 	icon_state = "triagedecaltopright"
@@ -73772,6 +80643,7 @@
 	pixel_x = 8;
 	pixel_y = -32
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_m_p)
 "vXY" = (
@@ -73998,12 +80870,18 @@
 "wcn" = (
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/upper_hull/u_f_s)
+"wcC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/tool/warning_cone,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_p)
 "wcN" = (
 /obj/structure/machinery/status_display{
 	pixel_y = 30
 	},
 /obj/structure/surface/table/almayer,
 /obj/effect/spawner/random/tool,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -74088,6 +80966,23 @@
 	icon_state = "plate"
 	},
 /area/almayer/engineering/upper_engineering/starboard)
+"web" = (
+/obj/effect/decal/strata_decals/grime/grime4,
+/obj/item/tool/warning_cone{
+	pixel_x = -12
+	},
+/obj/structure/platform_decoration{
+	dir = 8
+	},
+/obj/structure/machinery/gear,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 5
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hallways/hangar)
 "wei" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
@@ -74135,6 +81030,17 @@
 	},
 /turf/open/floor/plating,
 /area/almayer/living/pilotbunks)
+"weJ" = (
+/obj/structure/prop/invuln/overhead_pipe{
+	pixel_x = 12
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/overhead_pipe{
+	pixel_x = 12;
+	pixel_y = 7
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_s)
 "weR" = (
 /obj/structure/machinery/cryopod,
 /turf/open/floor/almayer{
@@ -74155,6 +81061,17 @@
 	},
 /turf/open/floor/wood/ship,
 /area/almayer/command/corporateliason)
+"wfD" = (
+/obj/item/stack/tile/plasteel{
+	pixel_x = 4;
+	pixel_y = -6
+	},
+/obj/item/tool/warning_cone{
+	pixel_y = 7;
+	pixel_x = -2
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_p)
 "wfE" = (
 /turf/closed/wall/almayer,
 /area/almayer/living/gym)
@@ -74217,6 +81134,7 @@
 /obj/structure/machinery/light/small{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -74227,6 +81145,7 @@
 /obj/structure/machinery/alarm/almayer{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -74348,6 +81267,29 @@
 	icon_state = "mono"
 	},
 /area/almayer/medical/hydroponics)
+"wiX" = (
+/obj/effect/landmark/yautja_teleport,
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/obj/effect/decal/cleanable/vomit,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_s)
+"wja" = (
+/obj/effect/decal/prints,
+/obj/item/tool/wrench{
+	pixel_y = 2;
+	pixel_x = -11
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "wjq" = (
 /obj/structure/bed/chair/comfy/beige{
 	dir = 8
@@ -74381,6 +81323,10 @@
 	icon_state = "plate"
 	},
 /area/almayer/shipboard/port_point_defense)
+"wjD" = (
+/obj/item/trash/ceramic_plate,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_s)
 "wka" = (
 /obj/structure/surface/table/almayer,
 /obj/item/reagent_container/food/condiment/hotsauce/sriracha{
@@ -74415,6 +81361,12 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/medical/medical_science)
+"wkC" = (
+/obj/structure/machinery/light/small,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/oil/streak,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_p)
 "wkH" = (
 /obj/structure/surface/table/reinforced/almayer_B,
 /obj/item/device/whistle{
@@ -74554,6 +81506,16 @@
 	icon_state = "red"
 	},
 /area/almayer/shipboard/starboard_missiles)
+"wmj" = (
+/obj/structure/surface/rack,
+/obj/item/frame/table,
+/obj/item/frame/table,
+/obj/item/frame/table,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_p)
 "wmE" = (
 /obj/structure/machinery/door/window/brigdoor/southright{
 	id = "Cell 4";
@@ -74596,6 +81558,73 @@
 /obj/structure/window/framed/almayer/white/hull,
 /turf/open/floor/plating,
 /area/almayer/command/airoom)
+"wnD" = (
+/obj/effect/decal/cleanable/blood/oil,
+/obj/structure/machinery{
+	density = 1;
+	dir = 4;
+	icon = 'icons/obj/vehicles/tank.dmi';
+	icon_state = "tank_base";
+	indestructible = 1;
+	name = "\improper M34A2 Longstreet light tank";
+	pixel_y = -18;
+	unacidable = 1;
+	unslashable = 1;
+	pixel_x = 17
+	},
+/obj/structure/machinery{
+	density = 1;
+	dir = 4;
+	icon = 'icons/obj/vehicles/tank.dmi';
+	indestructible = 1;
+	name = "\improper M34A2 Longstreet light tank";
+	pixel_y = -18;
+	unacidable = 1;
+	unslashable = 1;
+	pixel_x = 10;
+	icon_state = "tank_turret_1"
+	},
+/obj/structure/machinery{
+	density = 1;
+	dir = 4;
+	icon = 'icons/obj/vehicles/tank.dmi';
+	indestructible = 1;
+	name = "\improper M34A2 Longstreet light tank";
+	pixel_y = -18;
+	unacidable = 1;
+	unslashable = 1;
+	pixel_x = 18;
+	icon_state = "damaged_frame"
+	},
+/obj/structure/machinery{
+	density = 1;
+	dir = 4;
+	icon = 'icons/obj/vehicles/tank.dmi';
+	indestructible = 1;
+	name = "\improper M34A2 Longstreet light tank";
+	pixel_y = -18;
+	unacidable = 1;
+	unslashable = 1;
+	pixel_x = -5;
+	icon_state = "damaged_turret"
+	},
+/obj/structure/machinery{
+	density = 1;
+	dir = 4;
+	icon = 'icons/obj/vehicles/tank.dmi';
+	indestructible = 1;
+	name = "\improper M34A2 Longstreet light tank";
+	pixel_y = -18;
+	unacidable = 1;
+	unslashable = 1;
+	pixel_x = 17;
+	icon_state = "treads_1"
+	},
+/obj/structure/blocker/invisible_wall{
+	name = "\improper M34A2 Longstreet light tank"
+	},
+/turf/open/floor/plating,
+/area/almayer/hallways/hangar)
 "wnL" = (
 /obj/item/stack/tile/carpet{
 	amount = 12
@@ -74616,6 +81645,22 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/squads/alpha_bravo_shared)
+"wob" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/platform{
+	dir = 8;
+	layer = 2.7
+	},
+/obj/structure/platform{
+	dir = 4;
+	layer = 2.7
+	},
+/obj/structure/prop/invuln/overhead/flammable_pipe/fly{
+	icon_state = "flammable_pipe_2";
+	layer = 4
+	},
+/turf/open/floor/plating,
+/area/almayer/hull/lower_hull/l_f_s)
 "woh" = (
 /turf/closed/wall/almayer/research/containment/wall/corner{
 	dir = 4
@@ -74631,6 +81676,13 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/starboard_hallway)
+"wop" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/strata_decals/grime/grime3,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_s)
 "wos" = (
 /obj/structure/machinery/cm_vending/sorted/marine_food{
 	density = 0;
@@ -74699,6 +81751,17 @@
 	icon_state = "green"
 	},
 /area/almayer/living/grunt_rnr)
+"wpR" = (
+/obj/structure/prop/invuln/overhead/flammable_pipe/fly{
+	dir = 8;
+	pixel_x = -2;
+	pixel_y = 13;
+	layer = 4
+	},
+/obj/effect/decal/cleanable/ash,
+/obj/effect/decal/cleanable/liquid_fuel,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_s)
 "wqc" = (
 /obj/structure/sign/poster{
 	pixel_y = 32
@@ -74757,9 +81820,9 @@
 	icon_state = "green"
 	},
 /area/almayer/hallways/aft_hallway)
-"wqE" = (
-/obj/structure/largecrate/random/case/small,
-/turf/open/floor/plating/plating_catwalk,
+"wqV" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/almayer/outer,
 /area/almayer/hull/lower_hull/l_f_p)
 "wqW" = (
 /obj/structure/closet/secure_closet/CMO,
@@ -74802,6 +81865,35 @@
 	icon_state = "sterile_green"
 	},
 /area/almayer/medical/containment)
+"wsu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/overhead_pipe{
+	pixel_x = 6;
+	pixel_y = 12
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	dir = 1;
+	icon_state = "lattice-simple";
+	pixel_x = 10
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7;
+	pixel_x = 28
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7;
+	pixel_x = 13
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_s)
 "wsD" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -74840,6 +81932,29 @@
 	icon_state = "cargo_arrow"
 	},
 /area/almayer/squads/delta)
+"wtI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln{
+	desc = "a pile of cables";
+	icon = 'icons/obj/structures/machinery/artillery.dmi';
+	icon_state = "29";
+	name = "cables";
+	density = 0;
+	layer = 3;
+	pixel_x = -3
+	},
+/obj/structure/prop/invuln{
+	desc = "a pile of cables";
+	icon = 'icons/obj/structures/machinery/artillery.dmi';
+	icon_state = "27";
+	name = "cables";
+	density = 0;
+	layer = 2;
+	pixel_x = -12;
+	pixel_y = -8
+	},
+/turf/open/floor/plating,
+/area/almayer/hull/lower_hull/l_a_p)
 "wtM" = (
 /obj/structure/machinery/light{
 	unacidable = 1;
@@ -74865,6 +81980,18 @@
 "wul" = (
 /obj/structure/machinery/light/small{
 	dir = 4
+	},
+/obj/effect/decal/cleanable/molten_item{
+	pixel_x = -8;
+	pixel_y = 10
+	},
+/obj/item/trash/candy{
+	pixel_y = 1;
+	pixel_x = 13
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	pixel_x = 6;
+	pixel_y = 12
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_a_s)
@@ -74928,6 +82055,22 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/living/briefing)
+"wvA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/obj/effect/decal/cleanable/cobweb2,
+/obj/effect/decal/strata_decals/grime/grime4,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "wvI" = (
 /obj/item/paper_bin/uscm{
 	pixel_y = 7
@@ -75096,6 +82239,24 @@
 	pixel_x = 12;
 	pixel_y = 12
 	},
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice10";
+	pixel_x = 15;
+	pixel_y = 11
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice2";
+	pixel_x = 15;
+	pixel_y = -8
+	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_m_s)
 "wyQ" = (
@@ -75114,6 +82275,8 @@
 /obj/structure/bed/chair{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/generic,
+/obj/item/trash/cheesie,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -75219,6 +82382,7 @@
 	icon_state = "NE-out";
 	pixel_y = 1
 	},
+/obj/item/stack/sheet/metal,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -75390,6 +82554,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/overhead/flammable_pipe/fly{
+	dir = 5;
+	pixel_x = -1;
+	pixel_y = 12;
+	layer = 4
+	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -75436,6 +82607,24 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/lifeboat_pumps/south1)
+"wHC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_p)
+"wHY" = (
+/obj/effect/decal/strata_decals/grime/grime3,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_p)
 "wIr" = (
 /obj/structure/machinery/cm_vending/clothing/senior_officer{
 	req_access = list();
@@ -75671,6 +82860,22 @@
 	icon_state = "cargo"
 	},
 /area/almayer/squads/alpha)
+"wMM" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	pixel_x = 12
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_x = -8
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_f_s)
 "wMO" = (
 /obj/structure/machinery/door/poddoor/almayer/biohazard/white{
 	dir = 4
@@ -75898,6 +83103,12 @@
 	icon_state = "dark_sterile"
 	},
 /area/almayer/engineering/laundry)
+"wSq" = (
+/obj/structure/prop/ice_colony/ground_wire{
+	dir = 4
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_f_s)
 "wSR" = (
 /obj/structure/pipes/standard/manifold/hidden/supply{
 	dir = 1
@@ -75988,6 +83199,11 @@
 /obj/item/storage/fancy/candle_box,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/medical/morgue)
+"wUe" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/spider/stickyweb,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_f_p)
 "wUz" = (
 /obj/structure/sign/safety/life_support{
 	pixel_x = 8;
@@ -76132,6 +83348,11 @@
 /obj/structure/surface/rack,
 /obj/item/tool/wirecutters,
 /obj/item/tool/shovel/snow,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -76248,6 +83469,13 @@
 /obj/effect/landmark/late_join/delta,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/squads/delta)
+"wXq" = (
+/obj/structure/machinery/light/small,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/shipboard/port_point_defense)
 "wXv" = (
 /obj/structure/prop/invuln/joey,
 /turf/open/floor/almayer{
@@ -76358,6 +83586,16 @@
 /obj/structure/machinery/light/small{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/overhead_pipe{
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	dir = 1;
+	icon_state = "lattice-simple";
+	pixel_x = 10
+	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -76374,12 +83612,10 @@
 	pixel_x = 8;
 	pixel_y = -32
 	},
-/obj/item/clipboard,
-/obj/item/paper,
-/obj/item/tool/pen,
-/turf/open/floor/almayer{
-	icon_state = "plate"
+/obj/structure/platform{
+	dir = 8
 	},
+/turf/open/floor/plating,
 /area/almayer/hull/lower_hull/l_a_p)
 "wZX" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
@@ -76486,6 +83722,23 @@
 	icon_state = "plate"
 	},
 /area/almayer/living/briefing)
+"xbi" = (
+/obj/structure/machinery/light{
+	dir = 1
+	},
+/obj/structure/sign/safety/bulkhead_door{
+	pixel_x = 8;
+	pixel_y = 32
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "NE-out";
+	pixel_y = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hallways/hangar)
 "xbk" = (
 /turf/open/floor/almayer{
 	icon_state = "plate"
@@ -76500,6 +83753,15 @@
 /obj/item/tool/mop,
 /turf/open/floor/plating,
 /area/almayer/command/airoom)
+"xbX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/oil/streak,
+/obj/item/trash/hotdog{
+	pixel_x = -1;
+	pixel_y = -7
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_f_s)
 "xcp" = (
 /obj/structure/stairs/perspective{
 	icon_state = "p_stair_ew_full_cap";
@@ -76520,6 +83782,21 @@
 	icon_state = "plate"
 	},
 /area/almayer/hull/upper_hull/u_a_p)
+"xcT" = (
+/obj/item/trash/used_stasis_bag,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_s)
+"xcZ" = (
+/obj/structure/prop/invuln/lattice_prop{
+	dir = 1;
+	icon_state = "lattice-simple";
+	pixel_x = 14;
+	pixel_y = -16
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_s)
 "xdx" = (
 /obj/structure/surface/rack,
 /obj/item/storage/firstaid/regular/empty,
@@ -76534,6 +83811,21 @@
 	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical_medbay)
+"xdC" = (
+/obj/structure/disposalpipe/segment,
+/obj/item/reagent_container/glass/bucket/janibucket{
+	pixel_x = -1;
+	pixel_y = 13
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_p)
+"xei" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/tool/wrench,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_p)
 "xeG" = (
 /obj/structure/machinery/door/airlock/almayer/maint,
 /turf/open/floor/almayer{
@@ -76623,6 +83915,13 @@
 	icon_state = "sterile_green_corner"
 	},
 /area/almayer/medical/operating_room_one)
+"xfW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_p)
 "xgh" = (
 /obj/structure/pipes/vents/scrubber{
 	dir = 4
@@ -76646,6 +83945,7 @@
 	pixel_x = 8;
 	pixel_y = -32
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/almayer,
 /area/almayer/hull/lower_hull/l_f_p)
 "xgr" = (
@@ -76674,6 +83974,16 @@
 	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lockerroom)
+"xgK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/grille{
+	icon_state = "brokengrille";
+	density = 0
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_s)
 "xgL" = (
 /obj/item/clothing/head/welding{
 	pixel_y = 6
@@ -76701,6 +84011,10 @@
 	pixel_x = 12;
 	pixel_y = 12
 	},
+/obj/item/prop/helmetgarb/helmet_nvg/cosmetic{
+	pixel_x = 4;
+	pixel_y = 3
+	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -76725,6 +84039,16 @@
 	icon_state = "plate"
 	},
 /area/almayer/living/port_emb)
+"xhk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_f_s)
 "xhn" = (
 /obj/structure/largecrate/random/case/double,
 /turf/open/floor/almayer{
@@ -76738,6 +84062,16 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/shipboard/brig/cells)
+"xhz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/strata_decals/grime/grime2{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_f_s)
 "xhE" = (
 /obj/structure/bed/chair/bolted{
 	dir = 8
@@ -76775,6 +84109,17 @@
 	},
 /turf/open/floor/carpet,
 /area/almayer/command/cichallway)
+"xir" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/item/tool/wrench{
+	pixel_y = 2;
+	pixel_x = -11
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_p)
 "xiC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -76889,8 +84234,16 @@
 /obj/structure/machinery/light/small{
 	dir = 4
 	},
-/turf/open/floor/almayer{
-	icon_state = "plate"
+/obj/structure/platform,
+/obj/item/storage/toolbox{
+	pixel_y = 1;
+	pixel_x = -11
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
 	},
 /area/almayer/hull/lower_hull/l_m_s)
 "xlX" = (
@@ -76934,6 +84287,11 @@
 	icon_state = "plate"
 	},
 /area/almayer/hull/lower_hull/l_f_s)
+"xmw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/tool/screwdriver,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_p)
 "xmJ" = (
 /obj/structure/closet,
 /obj/structure/sign/safety/bathunisex{
@@ -76944,6 +84302,25 @@
 	icon_state = "plate"
 	},
 /area/almayer/living/port_emb)
+"xmN" = (
+/obj/structure/prop/invuln/overhead_pipe{
+	pixel_x = 12
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	pixel_x = 12;
+	pixel_y = 12
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_p)
 "xmT" = (
 /obj/structure/machinery/cryopod{
 	pixel_y = 6
@@ -76991,7 +84368,25 @@
 	},
 /area/almayer/engineering/upper_engineering)
 "xnY" = (
-/obj/structure/largecrate/random/barrel/yellow,
+/obj/structure/surface/table/almayer,
+/obj/item/prop{
+	desc = "Test version of the L42A issued in limited numbers to the Colonial Marines. This one has seen better days. The aiming reticule is bent, the stock is loose and its magazine can't be removed.";
+	icon = 'icons/obj/items/weapons/guns/guns_by_faction/uscm.dmi';
+	icon_state = "l42mk1";
+	item_state = "l42mk1";
+	name = "\improper Broken L42A battle rifle";
+	pixel_y = 6;
+	pixel_x = 6
+	},
+/obj/item/prop{
+	desc = "Test version of the L42A issued in limited numbers to the Colonial Marines. This one has seen better days. The aiming reticule is bent, the stock is loose and its magazine can't be removed.";
+	icon = 'icons/obj/items/weapons/guns/guns_by_faction/uscm.dmi';
+	icon_state = "l42mk1";
+	item_state = "l42mk1";
+	name = "\improper Broken L42A battle rifle";
+	pixel_x = -1;
+	pixel_y = -7
+	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_m_s)
 "xoe" = (
@@ -77016,6 +84411,21 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/upper_hull/u_a_s)
+"xom" = (
+/obj/structure/surface/table/almayer,
+/obj/structure/prop/invuln{
+	desc = "The marketing department over at Bleihagel would have you believe that the RE-RE700 is an original design. However, experts who pried the cover off the cannon have discovered an object with a striking similarity to the popular M56 Cupola. It is still unknown why the cannon has two barrels. This one is non-functional.";
+	icon = 'icons/obj/vehicles/hardpoints/apc.dmi';
+	icon_state = "front_cannon";
+	name = "Bleihagel RE-RE700 Frontal Cannon";
+	density = 0;
+	pixel_y = 5;
+	pixel_x = -4
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hallways/hangar)
 "xoJ" = (
 /obj/structure/machinery/door/airlock/almayer/maint{
 	dir = 1
@@ -77067,6 +84477,7 @@
 /obj/structure/bed/chair{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -77119,6 +84530,11 @@
 	icon_state = "plate"
 	},
 /area/almayer/hallways/hangar)
+"xpZ" = (
+/turf/closed/shuttle/escapepod{
+	icon_state = "wall6"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "xqg" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer{
@@ -77144,6 +84560,10 @@
 	icon_state = "mono"
 	},
 /area/almayer/medical/medical_science)
+"xqs" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_p)
 "xqv" = (
 /obj/structure/bed/sofa/south/white/right,
 /turf/open/floor/almayer{
@@ -77175,6 +84595,13 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/engineering/engineering_workshop/hangar)
+"xqX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/girder/displaced,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "xro" = (
 /obj/structure/toilet{
 	pixel_y = 13
@@ -77189,6 +84616,16 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/stern_hallway)
+"xrJ" = (
+/obj/structure/foamed_metal,
+/obj/structure/prop/invuln/lattice_prop{
+	dir = 1;
+	icon_state = "lattice-simple";
+	pixel_x = 14;
+	pixel_y = -16
+	},
+/turf/open/floor/plating,
+/area/almayer/hull/lower_hull/l_m_s)
 "xrN" = (
 /obj/structure/largecrate/supply/supplies/mre,
 /turf/open/floor/almayer{
@@ -77257,6 +84694,13 @@
 	icon_state = "orange"
 	},
 /area/almayer/hull/upper_hull/u_a_s)
+"xtH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/vomit,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_f_p)
 "xtM" = (
 /obj/structure/machinery/light,
 /turf/open/floor/almayer{
@@ -77325,6 +84769,23 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer,
 /area/almayer/living/port_emb)
+"xuT" = (
+/obj/structure/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "xuU" = (
 /obj/structure/machinery/light{
 	dir = 8
@@ -77348,6 +84809,16 @@
 	icon_state = "mono"
 	},
 /area/almayer/hallways/aft_hallway)
+"xvi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 9;
+	pixel_y = 7
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_f_s)
 "xvr" = (
 /turf/closed/wall/almayer,
 /area/almayer/shipboard/brig/chief_mp_office)
@@ -77455,8 +84926,14 @@
 "xxe" = (
 /obj/structure/surface/rack,
 /obj/item/tool/crowbar,
-/obj/item/tool/weldingtool,
-/obj/item/tool/wrench,
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -77554,6 +85031,19 @@
 	icon_state = "plate"
 	},
 /area/almayer/hull/upper_hull/u_a_p)
+"xxO" = (
+/obj/structure/closet/firecloset,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = 7
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_p)
 "xxT" = (
 /obj/structure/surface/table/almayer,
 /obj/item/frame/table,
@@ -77644,9 +85134,32 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/shipboard/brig/cells)
+"xzO" = (
+/obj/item/pipe{
+	dir = 4;
+	layer = 3.5;
+	pixel_x = 7;
+	pixel_y = 11
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_p)
 "xAe" = (
 /turf/closed/wall/almayer/research/containment/wall/corner,
 /area/almayer/medical/containment/cell)
+"xAi" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "S";
+	layer = 3.3
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "E"
+	},
+/obj/item/clothing/head/beret/cm/tan{
+	pixel_x = -7;
+	pixel_y = 11
+	},
+/turf/open/floor/plating,
+/area/almayer/hull/lower_hull/l_f_s)
 "xAj" = (
 /obj/structure/bed/chair/bolted{
 	dir = 8
@@ -77695,6 +85208,11 @@
 	icon_state = "red"
 	},
 /area/almayer/lifeboat_pumps/south1)
+"xAK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/static_tank/fuel,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_s)
 "xAY" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
@@ -77769,6 +85287,7 @@
 /area/almayer/hull/lower_hull/l_m_s)
 "xCR" = (
 /obj/structure/machinery/light/small,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_f_s)
 "xCX" = (
@@ -77779,6 +85298,13 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/hull/upper_hull/u_m_p)
+"xDg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_s)
 "xDn" = (
 /turf/open/floor/almayer{
 	dir = 1;
@@ -77828,6 +85354,12 @@
 	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/operating_room_two)
+"xED" = (
+/obj/effect/decal/cleanable/liquid_fuel,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_p)
 "xEF" = (
 /turf/closed/wall/almayer/outer,
 /area/almayer/hull/upper_hull/u_f_p)
@@ -77881,6 +85413,19 @@
 	},
 /turf/open/floor/plating/almayer,
 /area/almayer/hull/lower_hull/l_f_s)
+"xFG" = (
+/obj/structure/platform{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/oil/streak,
+/obj/structure/prop/invuln/overhead/flammable_pipe/fly{
+	dir = 8;
+	pixel_x = -7;
+	pixel_y = 7;
+	layer = 4
+	},
+/turf/open/floor/plating,
+/area/almayer/hull/lower_hull/l_m_s)
 "xFP" = (
 /turf/open/floor/almayer{
 	dir = 5;
@@ -77951,6 +85496,12 @@
 	icon_state = "red"
 	},
 /area/almayer/living/briefing)
+"xGQ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_f_s)
 "xHe" = (
 /obj/structure/pipes/vents/pump{
 	dir = 4
@@ -77964,6 +85515,20 @@
 	icon_state = "orange"
 	},
 /area/almayer/squads/alpha_bravo_shared)
+"xHs" = (
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 11
+	},
+/obj/structure/prop/invuln{
+	desc = "harmless exhaust discharge from a broken pipeline";
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "exhaust";
+	density = 0
+	},
+/turf/open/floor/plating,
+/area/almayer/hull/lower_hull/l_m_s)
 "xHG" = (
 /obj/structure/machinery/door/airlock/almayer/secure/reinforced{
 	dir = 2;
@@ -78029,6 +85594,17 @@
 	icon_state = "cargo"
 	},
 /area/almayer/medical/lower_medical_medbay)
+"xIo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/grille{
+	icon_state = "brokengrille";
+	density = 0
+	},
+/obj/effect/decal/strata_decals/grime/grime3,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_s)
 "xIw" = (
 /obj/structure/machinery/brig_cell/cell_2{
 	pixel_x = 32
@@ -78059,6 +85635,7 @@
 /area/almayer/command/lifeboat)
 "xJi" = (
 /obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -78069,6 +85646,11 @@
 	icon_state = "plate"
 	},
 /area/almayer/engineering/upper_engineering/starboard)
+"xJp" = (
+/obj/effect/decal/cleanable/liquid_fuel,
+/obj/effect/decal/cleanable/blood/oil/streak,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_p)
 "xJC" = (
 /obj/structure/machinery/door/airlock/almayer/generic/corporate{
 	name = "Corporate Liaison's Closet"
@@ -78133,6 +85715,7 @@
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer,
 /area/almayer/shipboard/port_point_defense)
 "xMh" = (
@@ -78152,6 +85735,7 @@
 /obj/item/explosive/grenade/smokebomb,
 /obj/item/explosive/grenade/smokebomb,
 /obj/item/explosive/grenade/smokebomb,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -78183,6 +85767,13 @@
 	allow_construction = 0
 	},
 /area/almayer/hallways/aft_hallway)
+"xMo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/tool/warning_cone{
+	pixel_y = 16
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_s)
 "xMs" = (
 /turf/closed/wall/almayer/white,
 /area/almayer/medical/operating_room_two)
@@ -78195,6 +85786,14 @@
 	icon_state = "plating_striped"
 	},
 /area/almayer/squads/req)
+"xMw" = (
+/obj/structure/machinery/door/airlock/almayer/generic/glass{
+	dir = 1
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "xMA" = (
 /obj/structure/machinery/computer/med_data,
 /obj/structure/sign/safety/terminal{
@@ -78305,6 +85904,18 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/hallways/starboard_hallway)
+"xOz" = (
+/obj/structure/prop/invuln/overhead_pipe{
+	pixel_x = 12
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice1";
+	pixel_x = 15;
+	pixel_y = -6
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_p)
 "xOL" = (
 /obj/structure/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
@@ -78338,7 +85949,7 @@
 	},
 /area/almayer/hallways/starboard_hallway)
 "xPE" = (
-/obj/structure/largecrate/random/barrel/white,
+/obj/item/device/encryptionkey/sentry_laptop,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_m_s)
 "xPZ" = (
@@ -78456,6 +86067,12 @@
 	dir = 4
 	},
 /obj/structure/largecrate/random/barrel/green,
+/obj/structure/prop/invuln/overhead/flammable_pipe/fly{
+	dir = 8;
+	pixel_x = -2;
+	pixel_y = 12;
+	layer = 4
+	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -78480,6 +86097,13 @@
 	icon_state = "orangefull"
 	},
 /area/almayer/living/briefing)
+"xRO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/liquid_fuel,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "xRU" = (
 /obj/structure/sign/safety/maint{
 	pixel_x = -17
@@ -78736,6 +86360,11 @@
 	},
 /turf/closed/wall/almayer,
 /area/almayer/living/tankerbunks)
+"xVY" = (
+/turf/closed/shuttle/escapepod{
+	icon_state = "wall7"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "xWd" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer{
@@ -78808,6 +86437,22 @@
 	icon_state = "mono"
 	},
 /area/almayer/medical/medical_science)
+"xXU" = (
+/obj/structure/largecrate/random/barrel/white,
+/obj/structure/sign/safety/storage{
+	pixel_x = 8;
+	pixel_y = 32
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hallways/hangar)
+"xYb" = (
+/obj/structure/platform{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/almayer/hull/lower_hull/l_a_p)
 "xYf" = (
 /obj/structure/machinery/cm_vending/clothing/sea,
 /turf/open/floor/almayer{
@@ -78836,12 +86481,18 @@
 	pixel_x = 8;
 	pixel_y = -32
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/cigbutt{
+	pixel_x = -12;
+	pixel_y = 17
+	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/starboard_point_defense)
 "xYN" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -78886,6 +86537,13 @@
 	icon_state = "plate"
 	},
 /area/almayer/hull/lower_hull/l_a_p)
+"xZN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/strata_decals/grime/grime1,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_f_s)
 "xZU" = (
 /obj/structure/machinery/cryopod{
 	pixel_y = 6
@@ -78973,6 +86631,8 @@
 	pixel_x = 8;
 	pixel_y = 32
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/strata_decals/grime/grime3,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -79047,7 +86707,7 @@
 /turf/open/floor/almayer,
 /area/almayer/shipboard/brig/processing)
 "ycV" = (
-/obj/structure/curtain/red,
+/obj/structure/machinery/door/airlock/almayer/generic/glass,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_m_s)
 "ycZ" = (
@@ -79069,11 +86729,35 @@
 	icon_state = "plate"
 	},
 /area/almayer/engineering/upper_engineering/port)
+"ydj" = (
+/obj/structure/platform,
+/obj/structure/platform{
+	dir = 1
+	},
+/obj/structure/platform{
+	dir = 8
+	},
+/obj/structure/platform_decoration{
+	dir = 5;
+	layer = 3.51
+	},
+/obj/structure/platform_decoration{
+	dir = 10
+	},
+/obj/structure/prop/invuln/overhead/flammable_pipe/fly{
+	dir = 4;
+	icon_state = "flammable_pipe_3";
+	pixel_x = 17;
+	pixel_y = 8
+	},
+/turf/open/floor/plating,
+/area/almayer/hull/lower_hull/l_a_p)
 "ydx" = (
 /obj/structure/sign/safety/hvac_old{
 	pixel_x = 8;
 	pixel_y = -32
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -79138,6 +86822,12 @@
 	icon_state = "plate"
 	},
 /area/almayer/command/lifeboat)
+"yej" = (
+/obj/effect/decal/cleanable/blood/oil/streak,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_a_p)
 "yeo" = (
 /obj/structure/machinery/cm_vending/clothing/dress{
 	req_access = list(1)
@@ -79255,9 +86945,16 @@
 /obj/structure/machinery/light/small{
 	dir = 1
 	},
-/obj/structure/surface/rack,
-/obj/effect/spawner/random/tool,
-/obj/effect/spawner/random/tool,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/largecrate/random/barrel/yellow{
+	pixel_x = -9;
+	pixel_y = -14
+	},
+/obj/structure/largecrate/random/barrel/blue{
+	pixel_x = -6;
+	pixel_y = -1;
+	layer = 2.9
+	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_f_p)
 "yhI" = (
@@ -79269,6 +86966,18 @@
 "yhQ" = (
 /turf/closed/wall/almayer/outer,
 /area/almayer/hull/lower_hull/l_m_p)
+"yim" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/invuln/overhead_pipe{
+	dir = 4;
+	pixel_y = -9
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = -5
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_a_s)
 "yiq" = (
 /obj/structure/sign/safety/north{
 	pixel_x = -17;
@@ -79419,6 +87128,17 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/medical/containment)
+"yld" = (
+/obj/structure/largecrate/random/case/small,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/tool/warning_cone{
+	pixel_x = -12;
+	pixel_y = 16
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/lower_hull/l_m_s)
 "yle" = (
 /obj/effect/landmark/start/marine/engineer/delta,
 /obj/effect/landmark/late_join/delta,
@@ -89762,7 +97482,7 @@ aad
 aag
 nXP
 thT
-mGL
+xGQ
 gol
 akb
 bCY
@@ -89786,8 +97506,8 @@ bPn
 bPG
 ald
 gol
-nqU
-pch
+vjm
+cyB
 vRz
 aag
 ajZ
@@ -89964,7 +97684,7 @@ bdH
 aad
 aag
 nXP
-mGL
+xGQ
 fEV
 bBA
 bAN
@@ -89990,7 +97710,7 @@ bPG
 acs
 bBA
 lZB
-nqU
+vjm
 vRz
 aag
 ajZ
@@ -90167,8 +97887,8 @@ bdH
 aad
 aag
 nXP
-tRV
-hJp
+cMk
+hIh
 bBA
 bAO
 bCZ
@@ -90192,7 +97912,7 @@ bDW
 bPJ
 iuz
 bBA
-vhq
+qUj
 orv
 vRz
 aag
@@ -90370,8 +98090,8 @@ bdH
 aad
 aag
 nXP
-hJp
-mGL
+hjo
+xGQ
 bBA
 bAP
 aqu
@@ -90395,7 +98115,7 @@ aqu
 aqu
 bQz
 bBA
-nqU
+vjm
 cEY
 vRz
 aag
@@ -90574,7 +98294,7 @@ aad
 aag
 nXP
 fNg
-hJp
+hIh
 bBA
 bBu
 amg
@@ -90598,8 +98318,8 @@ amg
 amg
 rAD
 bBA
-nqU
-vhq
+vjm
+qUj
 vRz
 aag
 ajZ
@@ -90777,9 +98497,9 @@ aad
 aag
 nXP
 gjv
-mGL
+xGQ
 bBA
-bBu
+aAp
 amg
 amg
 bFj
@@ -90980,7 +98700,7 @@ aad
 aag
 nXP
 oZd
-mGL
+xGQ
 bBA
 bBv
 aqu
@@ -91005,7 +98725,7 @@ aqu
 bQG
 bBA
 vht
-vhq
+qUj
 vRz
 aag
 ajZ
@@ -91183,7 +98903,7 @@ aad
 aag
 nXP
 lAP
-mGL
+xGQ
 bBA
 bBx
 amg
@@ -91207,7 +98927,7 @@ bPq
 amg
 rAD
 bBA
-nqU
+vjm
 rSK
 vRz
 aag
@@ -91385,7 +99105,7 @@ aac
 aag
 aag
 nXP
-tpg
+iIF
 vmK
 bBA
 bBy
@@ -91411,7 +99131,7 @@ amg
 bQE
 bBA
 bVL
-nqU
+vjm
 vRz
 aag
 aag
@@ -91589,7 +99309,7 @@ aag
 nXP
 nXP
 mGL
-mGL
+xGQ
 bBA
 bBz
 aqu
@@ -91614,7 +99334,7 @@ aqu
 bQI
 bBA
 ueh
-nqU
+vjm
 vRz
 vRz
 aag
@@ -91791,7 +99511,7 @@ aad
 aag
 nXP
 tRV
-hJp
+hIh
 mmC
 bBA
 lsV
@@ -91817,7 +99537,7 @@ amg
 pyL
 bBA
 jNq
-nqU
+vjm
 rSK
 vRz
 aag
@@ -91994,7 +99714,7 @@ aag
 nXP
 nXP
 hJp
-mGL
+tGj
 fmS
 bBA
 bBA
@@ -92020,8 +99740,8 @@ aib
 jAi
 jAi
 nrz
-vhq
-nqU
+qUj
+vjm
 vRz
 vRz
 aag
@@ -92195,13 +99915,13 @@ nXP
 nXP
 nXP
 nXP
-hJp
-hJp
+hIh
+oEU
 uNL
 uNL
 uNL
 tVf
-mGL
+xGQ
 oxp
 kcp
 bWJ
@@ -92224,9 +99944,9 @@ dRw
 bzy
 bzy
 bzy
-vhq
-nqU
-vRz
+qUj
+vjm
+wqV
 vRz
 vRz
 vRz
@@ -92396,15 +100116,15 @@ aad
 aag
 nXP
 jpN
-hJp
-mGL
-hJp
+eij
+rTx
+wSq
 iBE
 uNL
-hJp
+hIh
 mGL
 poR
-mGL
+xGQ
 pNp
 kcp
 bTS
@@ -92427,9 +100147,9 @@ pqQ
 bzA
 rEu
 bzy
-vhq
+qUj
 nEz
-vhq
+qUj
 ioj
 mjR
 vRz
@@ -92599,12 +100319,12 @@ aad
 aag
 nXP
 bwF
-hJp
-mGL
-hJp
+xAi
+hMl
+qMr
 oPI
 uNL
-hJp
+hIh
 kcp
 kcp
 iqp
@@ -92631,9 +100351,9 @@ uOc
 bPj
 bzy
 piO
-vhq
-nqU
-nqU
+qUj
+vjm
+vjm
 rSK
 vRz
 aag
@@ -92801,11 +100521,11 @@ aaa
 aad
 aag
 nXP
-mGL
-mGL
+lrC
+ubf
+hIh
+xGQ
 hJp
-mGL
-dqd
 uNL
 hJp
 kcp
@@ -92837,7 +100557,7 @@ bSv
 bSv
 bSv
 bSv
-nqU
+vjm
 vRz
 aag
 ajZ
@@ -93004,13 +100724,13 @@ aaa
 aad
 aag
 nXP
+bOD
 hJp
-hJp
-mGL
+xGQ
 pzZ
 ijp
 uNL
-mGL
+xGQ
 kcp
 bTR
 iEg
@@ -93040,7 +100760,7 @@ bTH
 foN
 cDZ
 bSv
-pch
+cyB
 vRz
 aag
 ajZ
@@ -93207,13 +100927,13 @@ aaa
 aad
 aag
 nXP
-thT
-hJp
+hqL
+sDc
 uNL
 uNL
 uNL
 uNL
-mGL
+xGQ
 kcp
 lxW
 hPh
@@ -93243,7 +100963,7 @@ tjw
 bTH
 bTV
 bSv
-nqU
+vjm
 vRz
 aag
 ajZ
@@ -93410,8 +101130,8 @@ aaa
 aad
 aag
 nXP
-mGL
-hJp
+ppK
+hIh
 uNL
 qDv
 aLk
@@ -93613,8 +101333,8 @@ aaa
 aad
 aag
 nXP
-tRV
-mGL
+ijN
+eUE
 uNL
 kmM
 eqk
@@ -93649,7 +101369,7 @@ aIX
 aIX
 bSv
 ehZ
-eXo
+tJW
 vRz
 aag
 ajZ
@@ -93816,8 +101536,8 @@ aaa
 aad
 aag
 nXP
-hJp
-mGL
+ftY
+tIW
 hKe
 hJp
 hJp
@@ -93851,8 +101571,8 @@ bSv
 cop
 cop
 bSv
-vhq
-nqU
+qUj
+vjm
 vRz
 aag
 ajZ
@@ -94019,13 +101739,13 @@ aaa
 aad
 aag
 nXP
-hJp
-mGL
+ifj
+mHI
 uNL
 aSY
 hJp
 uNL
-hJp
+hIh
 dqd
 kcp
 bTU
@@ -94054,8 +101774,8 @@ bSv
 kBY
 bTn
 bSv
-vhq
-vhq
+qUj
+qUj
 vRz
 aag
 ajZ
@@ -94228,7 +101948,7 @@ uNL
 uNL
 lgY
 uNL
-mGL
+xGQ
 hJp
 kcp
 onY
@@ -94421,17 +102141,17 @@ aaa
 aaa
 aaa
 nXP
-hJp
+anN
 dPU
-hJp
+vhg
 mGL
-mGL
+rIS
 khS
-hJp
+thU
 crc
-hJp
+gmA
 qee
-mGL
+xGQ
 hzM
 kcp
 xNz
@@ -94457,15 +102177,15 @@ bBB
 bzA
 cBl
 bRU
-vhq
-eJh
-nqU
+qUj
+irL
+vjm
 rcH
-vhq
-vhq
-nqU
+qUj
+qUj
+vjm
 jTu
-nqU
+vjm
 vRz
 aaa
 aaa
@@ -96451,7 +104171,7 @@ aaa
 aaa
 aaa
 nXP
-hJp
+xbX
 uNL
 gka
 bwQ
@@ -96654,7 +104374,7 @@ aaa
 aaa
 aaa
 nXP
-hJp
+qTE
 sIT
 sIT
 sIT
@@ -96857,7 +104577,7 @@ aaa
 aaa
 aaa
 nXP
-tRV
+vGI
 sIT
 jNt
 iNZ
@@ -97060,7 +104780,7 @@ aaa
 aaa
 aaa
 nXP
-hJp
+uPE
 sIT
 vLh
 mGL
@@ -97466,7 +105186,7 @@ aaa
 aaa
 aaa
 nXP
-hJp
+pHr
 sIT
 mIB
 mGL
@@ -97669,7 +105389,7 @@ aaa
 aaa
 aaa
 nXP
-mGL
+dpH
 sIT
 sIT
 rUU
@@ -98075,7 +105795,7 @@ aaa
 aaa
 aaa
 nXP
-mGL
+fCF
 qee
 hJp
 mGL
@@ -98278,7 +105998,7 @@ aac
 aaf
 aaf
 nXP
-hJp
+pAH
 uNL
 afd
 hJp
@@ -98481,7 +106201,7 @@ aad
 aag
 nXP
 nXP
-tRV
+lOO
 uNL
 uNL
 agi
@@ -98683,8 +106403,8 @@ aaa
 aad
 aag
 nXP
-mGL
-hJp
+glW
+hIh
 uNL
 aas
 alI
@@ -98886,8 +106606,8 @@ aaa
 aad
 aag
 nXP
-mGL
-hJp
+dhk
+hIh
 uNL
 aga
 alQ
@@ -99292,7 +107012,7 @@ aaa
 aad
 aag
 nXP
-mGL
+ahA
 pGP
 uNL
 aay
@@ -99338,7 +107058,7 @@ kCT
 hTu
 mzo
 oFG
-vhq
+qUj
 vRz
 aag
 ajZ
@@ -99495,7 +107215,7 @@ aaa
 aad
 aag
 nXP
-mGL
+xhk
 lqI
 uNL
 aaD
@@ -99540,8 +107260,8 @@ kCT
 kCT
 eNL
 mzo
-oFG
-nqU
+gXS
+vjm
 vRz
 aag
 ajZ
@@ -99698,8 +107418,8 @@ aaa
 aad
 aag
 nXP
-hJp
-hJp
+dnl
+wob
 uNL
 aaK
 cfN
@@ -99743,7 +107463,7 @@ kCT
 kCT
 gks
 mzo
-oFG
+gXS
 nqU
 vRz
 aag
@@ -99902,7 +107622,7 @@ aad
 aag
 nXP
 fpd
-mGL
+gpS
 uNL
 ceQ
 ceU
@@ -99946,7 +107666,7 @@ kCT
 kOk
 fIf
 mzo
-oFG
+gXS
 pch
 vRz
 aag
@@ -100105,7 +107825,7 @@ aag
 aag
 nXP
 dUF
-mGL
+tMQ
 uNL
 ceR
 ceU
@@ -100308,7 +108028,7 @@ aag
 aag
 nXP
 fQF
-mGL
+xGQ
 uNL
 abd
 adk
@@ -100351,8 +108071,8 @@ sEt
 bcm
 wbx
 vhq
-vhq
-oFG
+qUj
+gXS
 vhq
 vRz
 aag
@@ -100511,7 +108231,7 @@ aag
 aag
 nXP
 wVD
-mGL
+nAo
 uNL
 uZQ
 uZQ
@@ -100554,8 +108274,8 @@ eyR
 bcm
 wgo
 nqU
-vhq
-dQH
+qUj
+iyF
 xpf
 vRz
 aag
@@ -100714,7 +108434,7 @@ aag
 aag
 nXP
 mNf
-hJp
+hIh
 uNL
 cdE
 xSI
@@ -100757,8 +108477,8 @@ tuN
 fPn
 nqU
 nqU
-vhq
-dQH
+qUj
+iyF
 hYc
 vRz
 aag
@@ -100917,7 +108637,7 @@ aag
 aag
 nXP
 bvO
-hJp
+hIh
 ahd
 adg
 amp
@@ -100958,7 +108678,7 @@ omP
 aYt
 bOC
 bcm
-vhq
+qUj
 nqU
 vhq
 dQH
@@ -101165,7 +108885,7 @@ mzo
 puR
 aKI
 dQH
-nqU
+vjm
 vRz
 aag
 aag
@@ -101322,8 +109042,8 @@ aag
 aag
 aag
 nXP
-mGL
-iBE
+lCh
+hPL
 uNL
 eXq
 adR
@@ -101525,8 +109245,8 @@ aag
 aag
 aag
 nXP
-mGL
-mGL
+xvi
+xhz
 uNL
 abG
 aeh
@@ -101570,7 +109290,7 @@ aYt
 lrX
 bcm
 kGt
-oFG
+gXS
 pch
 vRz
 aag
@@ -101729,7 +109449,7 @@ aag
 aag
 nXP
 rbv
-hJp
+hIh
 uNL
 abH
 aer
@@ -101773,7 +109493,7 @@ btO
 uII
 fPn
 cQN
-oFG
+gXS
 eXo
 vRz
 aag
@@ -101931,7 +109651,7 @@ aag
 aag
 aag
 nXP
-mGL
+xZN
 pwK
 pJW
 acq
@@ -101976,8 +109696,8 @@ puI
 iWx
 bcm
 uSq
-dQH
-vhq
+iyF
+qUj
 vRz
 aag
 aag
@@ -102134,7 +109854,7 @@ aag
 aag
 aag
 nXP
-mGL
+nAo
 fJX
 uNL
 acu
@@ -102381,8 +110101,8 @@ fER
 bcm
 mzo
 xSb
-vhq
-dQH
+qUj
+iyF
 mjR
 vRz
 aag
@@ -102583,7 +110303,7 @@ aYt
 jyR
 bcm
 ioj
-nqU
+swD
 vhq
 dQH
 fIH
@@ -102786,10 +110506,10 @@ aYt
 iKb
 bcm
 ygy
-nqU
-vhq
-oFG
-qUj
+pWz
+aOc
+gXS
+vKW
 vRz
 aag
 aag
@@ -102946,7 +110666,7 @@ aag
 aag
 aag
 nXP
-fpd
+aIu
 nVS
 uNL
 eXq
@@ -102988,10 +110708,10 @@ uiT
 aYt
 xNj
 bcm
-mjR
-nqU
-vhq
-dQH
+tuM
+vjm
+qUj
+iyF
 gWR
 vRz
 aag
@@ -103151,15 +110871,15 @@ aag
 nXP
 hJp
 dnX
-uNL
-aRu
-aRu
-aRu
-aRu
-aRu
+iuF
+dbs
+dbs
+gaC
+hTG
+jlj
 aRu
 bcm
-aXj
+xXU
 bHB
 aZW
 baI
@@ -103192,9 +110912,9 @@ llO
 vml
 bcm
 mzo
-jhA
-jhA
-dQH
+naP
+jdE
+iyF
 wlL
 vRz
 aag
@@ -103352,17 +111072,17 @@ aag
 aag
 aag
 nXP
-mGL
+edY
 dnX
 uNL
-aRu
-aRu
-aRu
-aRu
-aRu
-aRu
+nBQ
+jnI
+laF
+web
+haJ
+lpU
 bcm
-xyw
+xbi
 bHB
 aZX
 baI
@@ -103398,7 +111118,7 @@ mzo
 mzo
 mzo
 gJd
-vhq
+qUj
 vRz
 aag
 aag
@@ -103555,17 +111275,17 @@ aag
 aag
 aag
 nXP
-mGL
+muJ
 fJX
 uNL
-aRu
-aRu
-aRu
-aRu
-aRu
-aRu
-bcm
-hmy
+eVG
+imv
+wnD
+iNi
+iOP
+dLv
+aOO
+suN
 bHB
 aZL
 baX
@@ -103599,9 +111319,9 @@ eJh
 eFp
 qUH
 mzo
+vKW
+iyF
 qUj
-dQH
-vhq
 vRz
 aag
 aag
@@ -103758,18 +111478,18 @@ aag
 aag
 aag
 nXP
-tRV
-dnX
+noH
+pgd
 uNL
-aRu
-aRu
-aRu
-aRu
-aRu
-aRu
-bcm
-xyw
-bHB
+eVG
+gWm
+eVG
+cxY
+iSu
+bvf
+tfj
+hrV
+hBF
 wqh
 xyw
 bcc
@@ -103802,9 +111522,9 @@ nqU
 nqU
 vhq
 gsL
-nqU
-oFG
-eXo
+vjm
+gXS
+tJW
 vRz
 aag
 aag
@@ -103961,17 +111681,17 @@ aag
 aag
 aag
 nXP
-nun
-vJM
+vbt
+wMM
 uNL
-aRu
-aRu
-aRu
-aRu
-aRu
-aRu
-bcm
-bGQ
+eVG
+ubB
+rYP
+dZi
+fln
+gvI
+mbW
+nEv
 bHB
 tdc
 rOc
@@ -104164,17 +111884,17 @@ aag
 aag
 aag
 nXP
-hJp
+hIh
 qNG
 uNL
-aRu
-aRu
-aRu
-aRu
-aRu
-aRu
-bcm
-bGR
+eVG
+ubB
+eVG
+iNi
+btO
+btO
+aOO
+nEv
 bHB
 xyw
 bkA
@@ -104209,8 +111929,8 @@ dFV
 iVO
 mzo
 nqU
-oFG
-pch
+gXS
+cyB
 vRz
 aag
 aag
@@ -104367,17 +112087,17 @@ nXP
 nXP
 nXP
 nXP
-mGL
+nAo
 kKG
 uNL
-aRu
-aRu
-aRu
-aRu
-aRu
-aRu
-bcm
-xyw
+eVG
+eVG
+rYP
+ozC
+rxL
+pSp
+aOO
+suN
 bHB
 xyw
 bkA
@@ -104412,8 +112132,8 @@ cmp
 cmp
 cmp
 vwN
-oFG
-nqU
+gXS
+vjm
 vRz
 vRz
 vRz
@@ -104565,22 +112285,22 @@ aaY
 aad
 nXP
 sAm
-mGL
+eEe
 aLl
-hJp
-hJp
-mGL
-mGL
+cYa
+hrY
+hIR
+crE
 eKO
 uNL
-aRu
-aRu
-aRu
-aRu
-aRu
-aRu
+stF
+tuK
+enw
+ouA
+tqo
+unu
 bcm
-aYu
+tSE
 wTg
 bGq
 bkA
@@ -104615,13 +112335,13 @@ apV
 djM
 cmp
 mjR
-oFG
-nqU
+gXS
+vjm
 vhq
-vhq
+fWg
 rcH
-vhq
-wqE
+xtH
+nqU
 kwq
 vRz
 ajZ
@@ -104768,20 +112488,20 @@ aaY
 aad
 nXP
 hJp
-hJp
-mGL
-mGL
-pwK
+hIh
+uEG
+oQQ
+idw
 cmk
 xJi
 cIi
 uNL
-aRu
-aRu
-aRu
-aRu
-aRu
-aRu
+cqT
+iqR
+eHJ
+xom
+pSN
+lCo
 bcm
 aZZ
 aYC
@@ -104819,10 +112539,10 @@ bWS
 cmp
 mjR
 bVR
-oeo
-oeo
+sDo
+wUe
 gdd
-oeo
+sDo
 oeo
 bgc
 qUj
@@ -104970,12 +112690,12 @@ bdH
 aaa
 aad
 nXP
-xYN
-xYN
+aRb
+tGe
 uNL
 bdi
-kKG
-hJp
+jma
+hIh
 pda
 lpS
 wfE
@@ -105174,7 +112894,7 @@ aaa
 aad
 nXP
 aMr
-aMr
+gCT
 wfE
 wfE
 rXv
@@ -105376,7 +113096,7 @@ bdH
 aaa
 aad
 aKW
-bdn
+jSx
 bdn
 wfE
 mcL
@@ -105580,7 +113300,7 @@ aaa
 aad
 aKW
 uJo
-aLf
+kUm
 wfE
 dgl
 jOo
@@ -105636,8 +113356,8 @@ auw
 auM
 avb
 asE
-scI
-oed
+rEe
+gdr
 yhQ
 ajZ
 aaa
@@ -105783,7 +113503,7 @@ aaa
 aad
 aKW
 ebD
-aLf
+xMo
 wfE
 krp
 jOo
@@ -105840,7 +113560,7 @@ aus
 ava
 asE
 suT
-ftl
+cZM
 yhQ
 ajZ
 aaa
@@ -105985,8 +113705,8 @@ bdH
 aaa
 aad
 aKW
-bPW
-aLf
+ckO
+eEJ
 wfE
 eiP
 qOp
@@ -106188,8 +113908,8 @@ bdH
 aaa
 aad
 aKW
-bPT
-aLf
+eOQ
+dbP
 wfE
 fHz
 opD
@@ -106246,7 +113966,7 @@ auP
 wZy
 asE
 iTz
-vfJ
+wmj
 yhQ
 ajZ
 aaa
@@ -106391,8 +114111,8 @@ bdH
 aaa
 aad
 aKW
-aLf
-aSm
+iuM
+xRO
 wfE
 iYx
 opD
@@ -106448,7 +114168,7 @@ gwW
 xqS
 yiE
 avk
-wlp
+lpz
 vXX
 yhQ
 ajZ
@@ -106594,8 +114314,8 @@ bdH
 aaa
 aad
 aKW
-aLf
-aSm
+vTH
+csX
 wfE
 gww
 opD
@@ -106798,7 +114518,7 @@ aaa
 aad
 aKW
 rJb
-aSm
+tOp
 wfE
 rYi
 opD
@@ -106854,7 +114574,7 @@ gwW
 ati
 lBY
 asE
-wlp
+lpz
 oDf
 yhQ
 ajZ
@@ -107000,8 +114720,8 @@ bdH
 aaa
 aad
 aKW
-aLf
-aSm
+wpR
+qRf
 wfE
 cVK
 opD
@@ -107057,7 +114777,7 @@ gwW
 kiF
 ave
 asE
-scI
+rez
 oDf
 yhQ
 ajZ
@@ -107203,7 +114923,7 @@ bdH
 aaa
 aad
 aKW
-aLf
+ddI
 aMs
 wfE
 wfE
@@ -107261,7 +114981,7 @@ bWM
 avi
 asE
 suT
-oed
+lwR
 yhQ
 ajZ
 aaa
@@ -107406,12 +115126,12 @@ aKR
 aKR
 aKR
 aKR
-aSm
-aLf
+oHo
+aCs
 vXY
-aLf
-aLf
-jiX
+wjD
+dbP
+vEA
 cmq
 aKW
 aeL
@@ -107464,7 +115184,7 @@ bWM
 avi
 asE
 scI
-oed
+lwR
 bVU
 bVU
 bVU
@@ -108016,7 +115736,7 @@ aKS
 bbz
 aLL
 etF
-bbS
+rSb
 aLL
 coT
 fgh
@@ -108072,8 +115792,8 @@ nGi
 bVd
 bUO
 bSf
-weC
-tZc
+qML
+wXq
 bSf
 cmm
 bWe
@@ -108219,7 +115939,7 @@ aKS
 bbz
 aLL
 fXz
-bbS
+fHZ
 aLL
 uUt
 aLW
@@ -108271,12 +115991,12 @@ azD
 azD
 yhQ
 wgR
-bTO
+rQL
 bTO
 sYP
 bSf
 cpk
-bVd
+idL
 bSf
 cmm
 bWe
@@ -108421,8 +116141,8 @@ aKS
 aKS
 bbz
 bdy
-bbS
-bbS
+knl
+gos
 bdy
 bbS
 xka
@@ -108474,12 +116194,12 @@ azD
 azD
 yhQ
 hkB
-bTO
+rQL
 qSm
 cls
 xoJ
 weC
-cls
+aVD
 bWc
 cmm
 bWe
@@ -108681,7 +116401,7 @@ bTO
 xMf
 unh
 bSf
-weC
+qML
 rfI
 bSf
 qzc
@@ -108827,8 +116547,8 @@ aKS
 aKS
 bbz
 aLL
-etF
-bbS
+lIj
+onA
 aLL
 djQ
 nFs
@@ -109233,11 +116953,11 @@ aKS
 aKV
 aKS
 aLL
-iIY
-bCQ
+lqz
+dGi
 hhw
-bPU
-bPS
+tsZ
+nif
 cDe
 ipD
 rmN
@@ -109291,7 +117011,7 @@ cla
 cly
 voQ
 bVi
-tVB
+iuo
 bSf
 bWe
 bWp
@@ -109436,16 +117156,16 @@ aKR
 aKR
 aKR
 aKR
-aSm
-aLf
+qtf
+hWP
 tps
-aLf
-aLf
+jVH
+sCl
 xlD
 nMz
-aSm
+eER
 hhw
-aNn
+jOU
 aNO
 asO
 apC
@@ -109494,7 +117214,7 @@ clb
 clz
 fiq
 gqK
-oed
+lwR
 bVU
 bVU
 bVU
@@ -109639,7 +117359,7 @@ aaa
 bdH
 aad
 aKW
-aSm
+kEN
 aLf
 hhw
 aQF
@@ -109696,8 +117416,8 @@ bTq
 fiq
 fiq
 fiq
-oDf
-oed
+jEz
+hGG
 yhQ
 ajZ
 bdH
@@ -109842,8 +117562,8 @@ aaa
 bdH
 aad
 aKW
-uDB
-aLf
+bhe
+dbP
 hhw
 weR
 aPE
@@ -109899,8 +117619,8 @@ uaa
 uaa
 cmX
 fiq
-oDf
-oDf
+skS
+hfA
 yhQ
 ajZ
 bdH
@@ -110045,7 +117765,7 @@ aaa
 bdH
 aad
 aKW
-aSm
+gPm
 aVt
 hhw
 aNr
@@ -110102,8 +117822,8 @@ uaa
 uaa
 uaa
 fiq
-oed
-bxX
+uax
+dSN
 yhQ
 ajZ
 bdH
@@ -110248,7 +117968,7 @@ aaa
 bdH
 aad
 aKW
-bhC
+gxs
 bPT
 hhw
 jKh
@@ -110305,7 +118025,7 @@ uaa
 uaa
 uaa
 fiq
-oed
+vLW
 uqH
 yhQ
 ajZ
@@ -110451,7 +118171,7 @@ aaa
 bdH
 aad
 aKW
-aSm
+vuU
 xCm
 hhw
 mTi
@@ -110508,8 +118228,8 @@ uaa
 uaa
 uaa
 fiq
-oed
-oed
+oXv
+mHN
 yhQ
 ajZ
 bdH
@@ -110654,8 +118374,8 @@ aaa
 bdH
 aad
 aKW
-aSm
-xnY
+wvA
+fUo
 hhw
 aQF
 aQF
@@ -110711,8 +118431,8 @@ bJt
 bJt
 bJt
 bJt
-oed
-oDf
+lvu
+rpS
 yhQ
 ajZ
 bdH
@@ -110857,8 +118577,8 @@ bdH
 bdH
 aad
 aKW
-uDB
-aLf
+jrn
+rPr
 hhw
 weR
 aPE
@@ -110914,8 +118634,8 @@ iIl
 bDs
 ujV
 bJt
-oed
-bxX
+rEB
+dSN
 yhQ
 ajZ
 bdH
@@ -111060,7 +118780,7 @@ bdH
 bdH
 aad
 aKW
-aSm
+xHs
 gfS
 hhw
 lHc
@@ -111117,7 +118837,7 @@ idx
 hAz
 fhQ
 bJt
-vhI
+xxO
 oDf
 yhQ
 ajZ
@@ -111263,8 +118983,8 @@ bdH
 bdH
 aad
 aKW
-aLf
-aSm
+uRO
+wja
 tps
 aNs
 aNs
@@ -111467,7 +119187,7 @@ bdH
 aad
 aKW
 eWY
-aSm
+eER
 hhw
 vMr
 vMr
@@ -111727,7 +119447,7 @@ bDs
 vwI
 bJt
 koz
-oed
+lwR
 yhQ
 ajZ
 avo
@@ -111872,7 +119592,7 @@ bdH
 bdH
 aad
 aKW
-aVt
+tYu
 eZz
 hhw
 aQF
@@ -111929,8 +119649,8 @@ gSk
 bDs
 oMd
 bJt
-oDf
-oed
+ucE
+lwR
 avo
 avo
 avo
@@ -112075,8 +119795,8 @@ bdH
 bdH
 aad
 aKW
-cmq
-aSm
+wiX
+eVY
 hhw
 weR
 aPE
@@ -112133,7 +119853,7 @@ bDs
 pdt
 bJt
 sIx
-oed
+lwR
 lpy
 avC
 avC
@@ -112279,7 +119999,7 @@ bdH
 aad
 aKW
 xxe
-aLf
+dbP
 hhw
 aQI
 aQI
@@ -112335,7 +120055,7 @@ cnu
 bDs
 knK
 bJt
-oed
+lwR
 eep
 avo
 avo
@@ -112482,7 +120202,7 @@ bdH
 aad
 aKW
 dgN
-aLf
+dbP
 hhw
 aQI
 aQI
@@ -112538,8 +120258,8 @@ gSk
 ljG
 tSp
 bJt
-oed
-oDf
+mmM
+hfA
 yhQ
 ajZ
 avo
@@ -112684,8 +120404,8 @@ bdH
 bdH
 aad
 aKW
-bhC
-aLf
+sSF
+lCN
 hhw
 mTi
 lJK
@@ -112741,7 +120461,7 @@ gSk
 oDE
 bJt
 bJt
-oed
+lwR
 uqH
 yhQ
 ajZ
@@ -112888,7 +120608,7 @@ bdH
 aad
 aKW
 efU
-aLf
+sJZ
 hhw
 aQF
 aQF
@@ -112944,8 +120664,8 @@ gSk
 luS
 bJt
 iGg
-oed
-bxX
+sAy
+dSN
 yhQ
 ajZ
 aaa
@@ -113090,8 +120810,8 @@ aaa
 bdH
 aad
 aKW
-aSm
-aSm
+ptb
+cAJ
 hhw
 baY
 bfb
@@ -113099,11 +120819,11 @@ bNz
 dIR
 yky
 hhw
+lyb
 xnY
-xnY
-aSm
-aLf
-aLf
+bMZ
+pVq
+qeJ
 soZ
 hhw
 bwd
@@ -113147,7 +120867,7 @@ gSk
 vSp
 xtC
 qgH
-oDf
+hmE
 oDf
 yhQ
 ajZ
@@ -113293,8 +121013,8 @@ aaa
 bdH
 aad
 aKW
-aSm
-aLf
+qcD
+weJ
 hhw
 beG
 bgF
@@ -113302,12 +121022,12 @@ jQA
 bgF
 kvN
 hhw
-aSm
-aLf
-aSm
-aSm
-aLf
-aSm
+hTE
+iiP
+kdc
+rJj
+rbQ
+jNL
 hhw
 aLG
 aYO
@@ -113350,7 +121070,7 @@ rui
 vSp
 bJt
 wuH
-oed
+fCl
 vgQ
 yhQ
 ajZ
@@ -113496,8 +121216,8 @@ aaa
 bdH
 aad
 aKW
-uDB
-aLf
+qUV
+dbP
 ahU
 beI
 bTQ
@@ -113505,12 +121225,12 @@ qoX
 jfm
 lYu
 maw
+mTl
+iFy
+jfm
 fAS
 jfm
-jfm
-fAS
-jfm
-jfm
+pjV
 bUP
 aem
 mUa
@@ -113699,8 +121419,8 @@ aaa
 bdH
 aad
 aKW
-aSm
-aMs
+lNS
+vLH
 hhw
 beO
 bgH
@@ -113708,12 +121428,12 @@ bgH
 bgH
 bPV
 hhw
-aLF
-bPV
+aXq
+cAJ
 lGO
 oDu
-bPU
-bPS
+exD
+vOJ
 hhw
 irI
 awb
@@ -113902,8 +121622,8 @@ aaa
 bdH
 aad
 aKW
-bhC
-aSm
+ggs
+tvl
 hhw
 bfa
 bHM
@@ -113959,7 +121679,7 @@ rsM
 iMm
 hTT
 bJt
-oDf
+hfA
 jRn
 yhQ
 ajZ
@@ -114105,8 +121825,8 @@ aaa
 bdH
 aad
 aKW
-aLf
-aSm
+fvp
+vxh
 hhw
 hhw
 hhw
@@ -114162,8 +121882,8 @@ rsM
 iMm
 gzV
 bJt
-oDf
-oed
+hfA
+jKL
 yhQ
 ajZ
 bdH
@@ -114308,8 +122028,8 @@ aaa
 bdH
 aad
 aKW
-aLf
-aSm
+eeO
+tPD
 hhw
 fJA
 btk
@@ -114366,7 +122086,7 @@ oos
 sBL
 bJt
 pzi
-uNW
+hsC
 yhQ
 ajZ
 bdH
@@ -114569,7 +122289,7 @@ wGb
 gUf
 bJt
 ddG
-oed
+lwR
 yhQ
 ajZ
 bdH
@@ -114771,8 +122491,8 @@ rsM
 oos
 gUf
 bJt
-oDf
-oed
+cya
+lwR
 yhQ
 aag
 aaf
@@ -114917,7 +122637,7 @@ aKW
 aKW
 aKW
 aKW
-aSm
+cAJ
 vUi
 hhw
 xCN
@@ -115111,17 +122831,17 @@ aaa
 aKW
 aKW
 bPV
-aSm
-aSm
-jiX
-bPU
-bPT
-uJo
-aSm
-jiX
-aSm
-aSm
-aSm
+htN
+sWB
+tsG
+mLt
+fvZ
+dBz
+htN
+ozF
+eER
+oDD
+rsT
 hhw
 nEA
 lQu
@@ -115177,18 +122897,18 @@ rsM
 oos
 gUf
 bJt
-oDf
-oed
-oed
-sow
-oed
-oDf
-oDf
-oDf
+wHC
+lwR
+uYu
+sjf
+lwR
+enV
+cba
+jql
 laP
-oDf
-oed
-oed
+sUJ
+epr
+mXu
 yhQ
 yhQ
 aaa
@@ -115312,19 +123032,19 @@ aaa
 aaa
 aaa
 aKW
-aLF
+tcd
 aLf
+dbP
+ocH
+eER
+hAB
+mGp
+qOS
 aLf
+hWP
+eER
 aLf
-aSm
-aLf
-aLf
-aLf
-aLf
-aLf
-aSm
-aLf
-bPW
+lUJ
 hhw
 hhw
 yfy
@@ -115380,19 +123100,19 @@ cNX
 cdI
 sBL
 bJt
-oed
-oDf
+roS
+xzO
 alm
-hGZ
-tbK
-hGZ
+ayp
+kSR
+ucA
 etB
-hGZ
+dcC
 gpE
 kHA
 tbK
 lNy
-oed
+xfW
 yhQ
 aaa
 aaa
@@ -115515,17 +123235,17 @@ aaa
 aaa
 aaa
 aKW
-aSm
-aLf
+eER
+dbP
 hhw
 hhw
 hhw
 hhw
 hhw
 hhw
-bPV
-aLF
-aSm
+opk
+kkv
+opk
 bzG
 hhw
 hhw
@@ -115583,7 +123303,7 @@ roU
 oos
 uVh
 bJt
-aYU
+kOr
 bVt
 wlp
 aYU
@@ -115594,8 +123314,8 @@ fFz
 fiq
 fiq
 jZO
-wlp
-ndQ
+vOB
+dnW
 yhQ
 aaa
 aaa
@@ -115718,12 +123438,12 @@ aaa
 aaa
 aaa
 aKW
-uDB
-aSm
-hhw
-bUc
-bUc
-bUc
+lWU
+kYd
+fSv
+srW
+uMZ
+sYe
 bUc
 aLB
 aLB
@@ -115921,13 +123641,13 @@ aaa
 aaa
 aaa
 aKW
-aLf
-aLf
+vGo
+doe
 hhw
-bUc
-bUc
-bUc
-bUc
+lkz
+vfj
+rst
+gzX
 aLB
 aWN
 pyB
@@ -115996,12 +123716,12 @@ kMU
 fBx
 fiq
 hRg
-oDf
+hfA
 xMh
 fiq
 rNW
 kRu
-oDf
+hfA
 yhQ
 aaa
 aaa
@@ -116124,8 +123844,8 @@ aaa
 aaa
 aaa
 aKW
-aLf
-aSm
+rKf
+vRr
 hhw
 hhw
 hhw
@@ -116203,8 +123923,8 @@ fiq
 fiq
 fiq
 fiq
-wlp
-oDf
+vOB
+rpS
 yhQ
 aaa
 aaa
@@ -116328,7 +124048,7 @@ aaa
 aaa
 aKW
 aLa
-aSm
+lUx
 hhw
 nHF
 nHF
@@ -116407,7 +124127,7 @@ uaa
 oFM
 fiq
 fYc
-uqH
+wkC
 yhQ
 aaa
 aaa
@@ -116530,8 +124250,8 @@ aaa
 aaa
 aaa
 aKW
-aLf
-aSm
+umX
+qEs
 hhw
 nHF
 nHF
@@ -116609,7 +124329,7 @@ uaa
 uaa
 uaa
 fiq
-wlp
+vOB
 vfJ
 yhQ
 aaa
@@ -116733,8 +124453,8 @@ aaa
 aaa
 aaa
 aKW
-aLf
-aSm
+xFG
+mOq
 hhw
 nHF
 nHF
@@ -116812,7 +124532,7 @@ uaa
 uaa
 uaa
 fiq
-scI
+gYN
 gFG
 yhQ
 aaa
@@ -116936,8 +124656,8 @@ aaf
 aaf
 aaf
 aKW
-aSm
-aLf
+djX
+pWu
 hhw
 nHF
 nHF
@@ -117015,7 +124735,7 @@ uaa
 uaa
 uaa
 fiq
-scI
+mpX
 scg
 yhQ
 aaf
@@ -117140,7 +124860,7 @@ aag
 aag
 aKW
 vPr
-iiP
+ucd
 hhw
 nHF
 nHF
@@ -117218,8 +124938,8 @@ uaa
 uaa
 uaa
 fiq
-wlp
-oDf
+eqv
+hfA
 yhQ
 aag
 aag
@@ -117342,7 +125062,7 @@ aag
 aag
 aag
 aKW
-aSm
+rSy
 eIA
 hhw
 hhw
@@ -117421,7 +125141,7 @@ fiq
 fiq
 fiq
 fiq
-wlp
+dSR
 bxX
 yhQ
 aag
@@ -117545,8 +125265,8 @@ aag
 aag
 aag
 aKW
-uDB
-aLf
+sBW
+lXG
 hhw
 nHF
 nHF
@@ -117624,7 +125344,7 @@ uaa
 uaa
 oFM
 fiq
-wlp
+vOB
 oDf
 yhQ
 aag
@@ -117748,7 +125468,7 @@ aag
 aag
 aag
 aKW
-aSm
+gIT
 aLf
 hhw
 nHF
@@ -117827,8 +125547,8 @@ uaa
 uaa
 uaa
 fiq
-scI
-oed
+mpX
+lwR
 yhQ
 aag
 aag
@@ -117952,7 +125672,7 @@ aKW
 aKW
 aKW
 aSm
-aSm
+uat
 hhw
 nHF
 nHF
@@ -118030,8 +125750,8 @@ uaa
 uaa
 uaa
 fiq
-suT
-oed
+pQD
+mdA
 yhQ
 yhQ
 yhQ
@@ -118150,12 +125870,12 @@ aaa
 aab
 aKW
 qxA
-aSm
-aSm
-aSm
+fVa
+jZz
+eER
 jiX
-aSm
-bPV
+cAJ
+smx
 hhw
 nHF
 nHF
@@ -118233,13 +125953,13 @@ uaa
 uaa
 uaa
 fiq
-scI
-oed
+fBr
+cuN
 sow
 oDf
 leh
 vhI
-tVB
+tcX
 yhQ
 aaa
 aab
@@ -118352,13 +126072,13 @@ aaa
 aaa
 aab
 aKW
-xxe
+fdO
 aLf
+uSk
 aLf
-aLf
-aLf
+dbP
 xPE
-bPT
+aSm
 hhw
 nHF
 nHF
@@ -118436,13 +126156,13 @@ uaa
 uaa
 uaa
 fiq
-wUS
-tbK
+tqx
+xdC
 sVi
-tbK
-tbK
-bfc
-oed
+bcy
+kSR
+mje
+epr
 yhQ
 aaa
 aab
@@ -118555,8 +126275,8 @@ aaa
 aaa
 aab
 aKW
-aSm
-aLf
+qXe
+dbP
 aKW
 aKW
 aKW
@@ -118758,8 +126478,8 @@ aaa
 aaa
 aab
 aKW
-bhC
-aSm
+xuT
+eER
 aKW
 bbB
 bbB
@@ -118847,7 +126567,7 @@ aAv
 eZi
 eZi
 yhQ
-wlp
+jpW
 ftl
 yhQ
 aaa
@@ -118961,7 +126681,7 @@ aaa
 aaa
 aab
 aKW
-aLf
+ooN
 aLF
 aKW
 bbB
@@ -119050,7 +126770,7 @@ aAv
 eZi
 eZi
 yhQ
-scI
+rez
 oDf
 yhQ
 aaa
@@ -119164,7 +126884,7 @@ aaa
 aaa
 aab
 aKW
-cmq
+nxO
 bPS
 aKW
 bbB
@@ -119367,7 +127087,7 @@ aaa
 aaa
 aab
 aKW
-rJb
+cNM
 yaG
 aKW
 bbC
@@ -119457,7 +127177,7 @@ tGq
 jjT
 yhQ
 trD
-oDf
+rpS
 yhQ
 aaa
 aab
@@ -119570,7 +127290,7 @@ aaa
 aaa
 aab
 aKW
-aLf
+kDu
 aaz
 aKW
 bdY
@@ -119660,7 +127380,7 @@ pfp
 pfp
 yhQ
 scI
-oed
+lwR
 yhQ
 aaa
 aab
@@ -119773,8 +127493,8 @@ aaa
 aaa
 aab
 aKW
-aSm
-aLf
+jwJ
+dbP
 aKW
 bdY
 bdY
@@ -119862,8 +127582,8 @@ pfp
 pfp
 pfp
 yhQ
-wlp
-oed
+uzu
+lwR
 yhQ
 aaa
 aab
@@ -119976,8 +127696,8 @@ aaa
 aaa
 aab
 aKW
-bhC
-aSm
+sDx
+lVY
 aKW
 bdY
 bdY
@@ -120065,7 +127785,7 @@ pfp
 pfp
 pfp
 yhQ
-scI
+rez
 uqH
 yhQ
 aaa
@@ -120179,8 +127899,8 @@ aaa
 aaa
 aab
 aKW
-aSm
-aLf
+vSf
+dbP
 aKW
 aKW
 aKW
@@ -120268,7 +127988,7 @@ yhQ
 yhQ
 yhQ
 yhQ
-wlp
+lpz
 oDf
 yhQ
 aaa
@@ -120382,21 +128102,21 @@ aaa
 aaa
 aab
 aKW
+ieh
+unX
+cxL
+mOy
+dbP
+eER
 aSm
 aLf
-aLf
-ycV
-aLf
-aSm
-bbx
-izU
 gFs
-yaG
-bPV
-aaz
-bPT
-eko
-bPV
+djC
+mVN
+unn
+ogb
+xVY
+hSY
 aLT
 bco
 aMB
@@ -120469,9 +128189,9 @@ ixP
 fiq
 kUt
 hGZ
-tbK
-tbK
-sQU
+kMD
+uTr
+xir
 ebY
 yhQ
 aaa
@@ -120585,20 +128305,20 @@ aaa
 aaa
 aab
 aKW
-aLF
-bbx
-bPS
-ktP
+sVo
+lih
+yld
+xMw
+eER
+dbP
 aSm
-aLf
-aSm
-ecM
+oHU
 enf
 ecM
-aSm
-aLf
-bbx
-eko
+mmA
+aob
+iWk
+xVY
 lLV
 aLT
 bco
@@ -120670,10 +128390,10 @@ ant
 glM
 mUn
 fiq
-suT
-oed
-oed
-oed
+lsy
+ioq
+jSL
+hto
 uim
 qNy
 yhQ
@@ -120793,15 +128513,15 @@ aKW
 aKW
 aKW
 uDB
-aLf
-aSm
+hhu
+kAg
 uGw
 uJl
 ihn
-aSm
-aLf
-aSm
-aSm
+mWA
+gGp
+mWA
+xpZ
 eko
 aLT
 bcZ
@@ -120995,17 +128715,17 @@ aaa
 aaa
 aaa
 aKW
-uAs
-aLf
-aSm
-kOf
+bhC
+iCq
+xqX
+tYP
 oIn
 kOf
-aSm
-aLf
+pbm
+jnW
 bzF
-aSm
-aLf
+vVH
+eon
 aLT
 bco
 bdr
@@ -121068,16 +128788,16 @@ clg
 clY
 bSJ
 iGK
+fdW
 tbK
-tbK
-tbK
+nQs
 sQU
 wUS
-hGZ
+ayp
 tbK
 tbK
-sQU
-oDf
+fId
+sDk
 yhQ
 aaa
 aaa
@@ -121197,18 +128917,18 @@ aaa
 aaa
 aaa
 aaa
-aKW
-bPU
-bPS
-bbx
-moh
-iIY
-bPW
-xlD
-aLf
-aSm
-aSm
-aLf
+kch
+eqf
+uUZ
+pRU
+xrJ
+rcV
+xrJ
+oTy
+pyg
+fbq
+txK
+xcZ
 aLT
 bco
 aMC
@@ -121271,15 +128991,15 @@ bVo
 clY
 bSJ
 pNG
+lwR
+lwR
 oed
-oed
-oed
-oed
-oDf
+kBq
+hfA
 mOU
 oDf
-oed
-oed
+hto
+daP
 uFt
 yhQ
 aaa
@@ -121473,8 +129193,8 @@ bSJ
 bSJ
 bSJ
 bSJ
-scI
-oed
+maX
+wHY
 yhQ
 yhQ
 yhQ
@@ -121613,8 +129333,8 @@ aaa
 aaa
 aaa
 wVb
-eFH
-hlz
+fSI
+qlY
 aLT
 bcE
 aMB
@@ -121677,7 +129397,7 @@ bVn
 clZ
 bSJ
 dGz
-cAH
+tSd
 vTK
 aaa
 aaa
@@ -121817,7 +129537,7 @@ aaa
 aaa
 wVb
 iDm
-hlz
+vuO
 aLT
 bcE
 bdr
@@ -122019,8 +129739,8 @@ aaa
 aaa
 aaa
 wVb
-eFH
-hlz
+dta
+rRm
 aLT
 abS
 bdr
@@ -122083,7 +129803,7 @@ clg
 acp
 bSJ
 vMn
-vuR
+xqs
 vTK
 aaa
 aaa
@@ -122222,8 +129942,8 @@ aaa
 aaa
 aaa
 wVb
-hlz
-eFH
+lLH
+yim
 aLT
 bcE
 aMC
@@ -122286,7 +130006,7 @@ bVo
 clZ
 bSJ
 bob
-emG
+xOz
 vTK
 aaa
 aaa
@@ -122425,8 +130145,8 @@ aaa
 aaa
 aaa
 wVb
-qnP
-jPf
+iwV
+caI
 aLT
 aLT
 aLT
@@ -122489,7 +130209,7 @@ bSJ
 bSJ
 bSJ
 cJP
-vuR
+xqs
 vTK
 aaa
 aaa
@@ -122628,8 +130348,8 @@ aaa
 aaa
 aaa
 wVb
-hlz
-moE
+nQf
+pve
 aLT
 bdJ
 bds
@@ -122692,7 +130412,7 @@ clM
 clS
 bSJ
 nOG
-vuR
+xqs
 vTK
 aaa
 aaa
@@ -122831,8 +130551,8 @@ aaa
 aaa
 aaa
 wVb
-hlz
-eFH
+tCJ
+lki
 aLT
 beT
 bdr
@@ -122895,7 +130615,7 @@ clg
 bVq
 bSJ
 njT
-ydx
+mUe
 vTK
 aaa
 aaa
@@ -123035,7 +130755,7 @@ aaa
 aaa
 wVb
 tAi
-eFH
+ebX
 aLT
 aLT
 aLT
@@ -123237,8 +130957,8 @@ aaa
 aaa
 aaa
 wVb
-hlz
-eFH
+nAK
+yim
 aLT
 beT
 bdr
@@ -123440,8 +131160,8 @@ aaa
 aaa
 aaa
 wVb
-eFH
-hlz
+dta
+dsE
 aLT
 beU
 bdv
@@ -123503,8 +131223,8 @@ bSJ
 clN
 clT
 bSJ
-cJP
-vuR
+oXk
+xqs
 vTK
 aaa
 aaa
@@ -123644,7 +131364,7 @@ aaa
 aaa
 wVb
 iDm
-hlz
+lGE
 aLT
 aLT
 aLT
@@ -123707,7 +131427,7 @@ bSJ
 bSJ
 bSJ
 wGi
-woG
+osM
 vTK
 aaa
 aaa
@@ -123847,7 +131567,7 @@ wVb
 wVb
 wVb
 eFH
-eFH
+mfF
 aLT
 vZb
 tnY
@@ -123909,8 +131629,8 @@ hcI
 hcI
 vPK
 bSJ
-nOG
-vuR
+lyY
+xqs
 vTK
 vTK
 vTK
@@ -124049,8 +131769,8 @@ fTR
 qaD
 jeU
 dHk
-hlz
-eFH
+xDg
+gkO
 aWT
 aMH
 beV
@@ -124113,10 +131833,10 @@ wGE
 erG
 ewO
 bWb
-cAH
+iSo
 luk
 rQj
-ngs
+pBk
 gai
 vTK
 aaa
@@ -124248,12 +131968,12 @@ aaa
 aaa
 aaa
 wVb
-vjx
-eFH
-eFH
-eFH
-eFH
-eFH
+eZe
+dta
+gkG
+dta
+dta
+gkO
 aLT
 aZf
 duV
@@ -124315,11 +132035,11 @@ jGR
 jGR
 oqu
 bSJ
+eNe
+ydj
 vuR
-vuR
-vuR
-vuR
-vuR
+eIm
+rQI
 cAH
 vTK
 aaa
@@ -124452,7 +132172,7 @@ aaa
 aaa
 wVb
 ilZ
-eFH
+nJv
 aLT
 aLT
 aLT
@@ -124522,7 +132242,7 @@ bSJ
 bSJ
 bSJ
 bSJ
-vuR
+bAI
 ydx
 vTK
 aaa
@@ -124654,8 +132374,8 @@ aaa
 aaa
 aaa
 wVb
-hlz
-eFH
+eqy
+rSU
 aLT
 bBg
 vPv
@@ -124725,8 +132445,8 @@ qNd
 hzu
 hcI
 bSJ
-cAH
-cAH
+cRV
+uzv
 vTK
 aaa
 aaa
@@ -124857,8 +132577,8 @@ aaa
 aaa
 aaa
 wVb
-hlz
-hlz
+bDJ
+xIo
 aLT
 nuN
 nuN
@@ -124928,7 +132648,7 @@ rYp
 oEo
 oEo
 bSJ
-cAH
+nxL
 cea
 vTK
 aaa
@@ -125060,8 +132780,8 @@ aaa
 aaa
 aaa
 wVb
-rVo
-hlz
+iEF
+xgK
 aLT
 vug
 vug
@@ -125131,7 +132851,7 @@ yle
 wWX
 wWX
 bSJ
-cAH
+cRV
 bpJ
 vTK
 aaa
@@ -125263,8 +132983,8 @@ aaa
 aaa
 aaa
 wVb
-qnP
-uia
+tIV
+fmb
 aLT
 iPS
 vAE
@@ -125334,7 +133054,7 @@ vSW
 scy
 kPJ
 bSJ
-cAH
+lCG
 ubd
 vTK
 aaa
@@ -125466,8 +133186,8 @@ aaa
 aaa
 aaa
 wVb
-tAi
-moE
+uyt
+jOA
 aLT
 aLT
 aLT
@@ -125537,7 +133257,7 @@ bSJ
 bSJ
 bSJ
 bSJ
-pUY
+xmN
 emG
 vTK
 aaa
@@ -125670,7 +133390,7 @@ aaa
 aaa
 wVb
 wzg
-eFH
+uHP
 aLT
 bBg
 vPv
@@ -125741,7 +133461,7 @@ hzu
 hcI
 bSJ
 jea
-cAH
+tSd
 vTK
 aaa
 aaa
@@ -125873,7 +133593,7 @@ aaa
 aaa
 wVb
 jMi
-eFH
+lkH
 aLT
 cjc
 cjc
@@ -125943,7 +133663,7 @@ yfm
 fXN
 fXN
 bSJ
-vuR
+rCc
 cAH
 vTK
 aaa
@@ -126076,7 +133796,7 @@ aaa
 aaa
 wVb
 pQG
-eFH
+lkH
 aLT
 cjc
 cjc
@@ -126146,8 +133866,8 @@ yfm
 fXN
 fXN
 bSJ
-cAH
-ydx
+cRV
+mJc
 vTK
 aaa
 aaa
@@ -126279,7 +133999,7 @@ aaa
 aaa
 wVb
 fhA
-eFH
+dta
 aLT
 iPS
 vAE
@@ -126349,7 +134069,7 @@ gEo
 scy
 kPJ
 bSJ
-vuR
+omr
 ebO
 vTK
 aaa
@@ -126552,7 +134272,7 @@ bSJ
 bSJ
 bSJ
 bSJ
-vuR
+blX
 tAR
 vTK
 aaa
@@ -126685,12 +134405,12 @@ aaa
 aaa
 wVb
 fTR
-hlz
-hlz
-hlz
-hlz
+ecy
+bUj
+xDg
+guv
 fTR
-hlz
+dvu
 aLT
 cjc
 cjc
@@ -126752,10 +134472,10 @@ fXN
 bSJ
 rHs
 ngs
-vuR
-cAH
-cAH
-cAH
+xqs
+gUY
+tSd
+bwp
 fKl
 vTK
 aaa
@@ -126892,8 +134612,8 @@ wVb
 wVb
 wVb
 hlz
-eFH
-hlz
+dta
+xDg
 aLT
 iPS
 vAE
@@ -126955,10 +134675,10 @@ scy
 bSJ
 tSr
 pUY
-lGr
+rcT
 vTK
-vTK
-vTK
+vKd
+vKd
 vTK
 vTK
 aaa
@@ -127094,9 +134814,9 @@ aaa
 aaa
 aaa
 wVb
-rVo
-eFH
-hlz
+rXw
+dta
+lLH
 aLT
 meY
 meY
@@ -127157,11 +134877,11 @@ oer
 oer
 oer
 ybr
-vuR
-ebO
+hnM
+iMJ
 vTK
 aaa
-aaa
+oXD
 aaa
 aaa
 aaa
@@ -127298,16 +135018,16 @@ aaa
 aaa
 wVb
 cbZ
+dta
 eFH
 eFH
-eFH
-eFH
-eFH
-eFH
-eFH
-hlz
-eFH
-hlz
+rAV
+dta
+cLZ
+dta
+lLH
+qSf
+cef
 aQL
 qZX
 qZX
@@ -127351,15 +135071,15 @@ lbf
 lbf
 lbf
 bJC
-vuR
+ttF
 oyG
-vuR
-cAH
+ttF
+opa
 rDi
 pXn
-cAH
+ohM
 vuR
-vuR
+xqs
 vuR
 vuR
 vTK
@@ -127502,15 +135222,15 @@ aaa
 wVb
 bbv
 hJb
-hlz
-hlz
-hlz
-hlz
+jhU
+frY
+nhp
+htF
 wZH
-hlz
-hlz
-hlz
-hlz
+jhU
+jhU
+wsu
+bRy
 aQL
 qDq
 qDq
@@ -127554,16 +135274,16 @@ oXb
 oXb
 oXb
 bJC
-vuR
-cAH
-vuR
-cAH
+xmw
+xei
+xqs
+mXm
 vuR
 dcS
-cAH
-vuR
-cAH
-cAH
+dJX
+kqX
+csc
+vGs
 xZK
 vTK
 aaa
@@ -127712,7 +135432,7 @@ wVb
 wVb
 wVb
 wVb
-eFH
+jbo
 rdK
 aQL
 qDq
@@ -127757,9 +135477,9 @@ oXb
 oXb
 oXb
 bJC
-cAH
-vuR
-vuR
+urn
+xqs
+xqs
 vTK
 vTK
 hTk
@@ -127915,7 +135635,7 @@ aaa
 aaa
 aaa
 wVb
-iDm
+hed
 fTR
 aQL
 ksp
@@ -127960,7 +135680,7 @@ kIP
 qer
 kIP
 bJC
-cAH
+usR
 pFP
 ebO
 vTK
@@ -128118,8 +135838,8 @@ aaa
 aaa
 aaa
 wVb
-eFH
-hlz
+nZe
+jqv
 aQL
 aQL
 aQL
@@ -128163,9 +135883,9 @@ bJC
 bJC
 bJC
 bJC
-vuR
-vuR
-vuR
+wcC
+csO
+wfD
 vTK
 aaa
 aaa
@@ -128321,11 +136041,11 @@ aaa
 aaa
 aaa
 wVb
-eFH
-hlz
-hlz
+nZe
+lLH
+ntB
 gjN
-hlz
+vzB
 rdK
 rdK
 rdK
@@ -128363,11 +136083,11 @@ bJC
 bJC
 bJC
 bJC
-cAH
-cAH
-cAH
-vuR
-cAH
+oXq
+kfD
+oTp
+nDF
+lab
 wZT
 vTK
 aaa
@@ -128525,14 +136245,14 @@ aaa
 aaa
 wVb
 jmg
-hlz
-eFH
-eFH
-hlz
-hlz
+elP
+dta
+hQj
+lSW
+lLH
 gwF
-eFH
-eFH
+hBv
+uJj
 rdK
 rdK
 aZn
@@ -128562,16 +136282,16 @@ haq
 lAA
 haq
 haq
+quo
+quo
+quo
+mDg
 cAH
-cAH
-cAH
-cAH
-cAH
-cAH
-cAH
-cAH
-cAH
-ngs
+qyY
+uNQ
+jFy
+uyX
+pgQ
 vTK
 aaa
 aaa
@@ -128729,17 +136449,17 @@ aaa
 wVb
 epA
 wDm
-hlz
-hlz
-hlz
-hlz
-gwF
-hlz
-hlz
+lLH
+jAT
+lLH
+lLH
+mRA
+xcT
+cPF
 rdK
 aYc
-hlz
-hlz
+wop
+uJF
 rdK
 rdK
 aVl
@@ -128761,18 +136481,18 @@ bZA
 aVl
 haq
 haq
-cAH
+dfF
 vuR
-cAH
-cAH
+rKl
+rjm
 vuR
-vuR
-vuR
+xqs
+xqs
 cAH
 cAH
-cAH
-cAH
-vuR
+nYU
+eic
+wtI
 sIV
 hBU
 vTK
@@ -128932,18 +136652,18 @@ aaa
 wVb
 pIk
 bNT
-wul
-eFH
+nlK
+rSU
 eFH
 eFH
 ybS
-wul
-hlz
-hlz
-hlz
-hlz
+rDL
+qYb
+xgK
+lLH
+elP
 eFH
-eFH
+dta
 rdK
 bEU
 bjl
@@ -128965,16 +136685,16 @@ ccW
 haq
 pFM
 hzV
+iai
 vuR
-vuR
-vuR
+xqs
 cAH
 fXd
-cAH
+sPb
 vuR
 cAH
 vuR
-vuR
+xYb
 rgA
 brX
 mfI
@@ -129146,7 +136866,7 @@ aVl
 bxE
 aVl
 rdK
-iDm
+gmn
 rdK
 bEU
 bjl
@@ -129166,7 +136886,7 @@ bBc
 bCI
 ccW
 haq
-vuR
+xqs
 haq
 aVl
 bxE
@@ -129552,7 +137272,7 @@ aVl
 bxG
 byK
 aVl
-hlz
+trq
 rdK
 wun
 bht
@@ -129572,7 +137292,7 @@ bYI
 pIf
 bJk
 haq
-cAH
+gzi
 aVl
 byQ
 ccR
@@ -130770,7 +138490,7 @@ aWZ
 byh
 byQ
 aVl
-hlz
+hxx
 rdK
 bFf
 aVp
@@ -130790,7 +138510,7 @@ mbn
 mUZ
 caA
 haq
-cAH
+vym
 aVl
 ccC
 ccW
@@ -130973,7 +138693,7 @@ ggQ
 aAb
 byR
 aVl
-eFH
+dta
 rdK
 bFg
 bHv
@@ -130993,7 +138713,7 @@ bjg
 gJq
 caB
 haq
-vuR
+xqs
 aVl
 ccD
 ccX
@@ -131176,7 +138896,7 @@ aep
 byk
 byQ
 aVl
-eFH
+cLZ
 rdK
 bhB
 bhB
@@ -131379,8 +139099,8 @@ bwj
 byl
 bzj
 aVl
-eFH
-eFH
+izo
+vLy
 bhB
 bfA
 bLe
@@ -131398,8 +139118,8 @@ bXQ
 bLe
 psp
 bhB
-cAH
-vuR
+mvd
+gNC
 aVl
 bzj
 cHO
@@ -131582,8 +139302,8 @@ aUx
 aUx
 aUx
 aUx
-hlz
-hlz
+uZN
+sxn
 bhB
 bHy
 bLe
@@ -131602,7 +139322,7 @@ bLe
 bHy
 bhB
 kpX
-lGr
+iWI
 aUx
 aUx
 aUx
@@ -131785,8 +139505,8 @@ aag
 aag
 aag
 wVb
-iDm
-eFH
+gmn
+xAK
 bhB
 ozi
 bJF
@@ -131805,7 +139525,7 @@ bYO
 bZD
 bhB
 vim
-woG
+hvk
 vTK
 aag
 aag
@@ -131988,8 +139708,8 @@ aad
 aag
 aag
 wVb
-hlz
-hlz
+lLH
+ecy
 bhB
 bJQ
 bLe
@@ -132007,8 +139727,8 @@ bXS
 bLe
 bJR
 bhB
-cAH
-cAH
+kCL
+trw
 vTK
 aag
 aag
@@ -132191,8 +139911,8 @@ aad
 aag
 aag
 wVb
-eFH
-eFH
+dta
+dQs
 bhB
 bHz
 bJI
@@ -132211,7 +139931,7 @@ bYS
 bJR
 bhB
 cAH
-cAH
+uBD
 vTK
 aag
 aag
@@ -132394,7 +140114,7 @@ aad
 aag
 aag
 wVb
-hlz
+lLH
 eFH
 bhB
 bhB
@@ -132414,7 +140134,7 @@ bJR
 bhB
 bhB
 vuR
-mHR
+nbU
 vTK
 aag
 aag
@@ -132597,9 +140317,9 @@ aad
 aag
 aag
 wVb
-hlz
-hlz
-hlz
+jqv
+lLH
+haY
 bhB
 bYV
 bKV
@@ -132617,7 +140337,7 @@ bYV
 bhB
 jcK
 cAH
-cAH
+sTJ
 vTK
 aag
 aag
@@ -132800,9 +140520,9 @@ aad
 aag
 aag
 wVb
-eFH
-eFH
-eFH
+hEp
+mzU
+pog
 bhB
 bJK
 bLc
@@ -132819,8 +140539,8 @@ bXV
 bJK
 bhB
 rbp
-vuR
-rbp
+iVz
+fAe
 vTK
 aag
 aag
@@ -133005,7 +140725,7 @@ aag
 wVb
 wVb
 rVo
-hlz
+lLH
 bhB
 bJK
 bKV
@@ -133021,8 +140741,8 @@ bhB
 bXQ
 bJK
 bhB
-kpX
-emG
+dCo
+mYp
 vTK
 vTK
 aag
@@ -133224,8 +140944,8 @@ bhB
 bzX
 bhB
 bhB
-ybr
-vuR
+iUc
+fVT
 vTK
 aag
 aag
@@ -133427,8 +141147,8 @@ ebJ
 xiC
 fYG
 bhB
-vuR
-woG
+xJp
+fXM
 vTK
 aag
 aag
@@ -133631,7 +141351,7 @@ bLd
 bYU
 bhB
 jdy
-cAH
+kVJ
 vTK
 aag
 aag
@@ -133817,7 +141537,7 @@ aag
 aag
 wVb
 hlz
-hlz
+pCU
 bhB
 bJP
 mzO
@@ -133833,8 +141553,8 @@ bMN
 tdx
 bYW
 bhB
-vuR
-ydx
+hjK
+etx
 vTK
 aag
 aag
@@ -134036,8 +141756,8 @@ bMM
 bYU
 gNd
 bhB
-cAH
-cAH
+xED
+kVJ
 vTK
 aag
 aag
@@ -134223,7 +141943,7 @@ aag
 aag
 wVb
 hlz
-hlz
+tce
 bhB
 sgM
 fIx
@@ -134239,8 +141959,8 @@ bMM
 bYU
 upe
 bhB
-vuR
-vuR
+hhS
+nAC
 vTK
 aag
 aag
@@ -134442,8 +142162,8 @@ dCS
 tLy
 svd
 bhB
-cAH
-cAH
+yej
+trw
 vTK
 aag
 aag
@@ -134629,7 +142349,7 @@ aag
 aag
 wVb
 hlz
-eFH
+tVx
 bhB
 bhB
 bhB
@@ -134645,8 +142365,8 @@ bhB
 bhB
 bhB
 bhB
-vuR
-vuR
+nzL
+dRX
 vTK
 aag
 aag
@@ -134833,7 +142553,7 @@ aag
 wVb
 hlz
 eFH
-fKg
+eFH
 tce
 bhB
 heg
@@ -134847,9 +142567,9 @@ ktO
 heg
 bhB
 osE
-gai
-cAH
-cAH
+gXb
+twL
+rBf
 vTK
 aag
 aag
@@ -135034,7 +142754,7 @@ aag
 aag
 aag
 wVb
-hlz
+pCU
 hlz
 hlz
 hlz
@@ -135049,10 +142769,10 @@ aut
 riA
 heg
 bhB
-pFP
+hXf
 cAH
 cAH
-cAH
+pIE
 vTK
 aag
 aag
@@ -135239,7 +142959,7 @@ aag
 wVb
 wVb
 gcK
-jPf
+gjS
 jPf
 bhB
 dVZ
@@ -135252,8 +142972,8 @@ bTp
 jyi
 cDj
 bhB
-vuR
-vuR
+iNa
+nFC
 woG
 vTK
 vTK
@@ -135441,8 +143161,8 @@ aag
 aag
 aag
 wVb
-hlz
-eFH
+eMo
+mBO
 uzg
 bhB
 bhB
@@ -135455,9 +143175,9 @@ bhB
 bhB
 bhB
 bhB
-cAH
-cAH
-cAH
+tqd
+kuD
+rcC
 vTK
 aag
 aag
@@ -135644,23 +143364,23 @@ aag
 aag
 aag
 wVb
-hlz
-eFH
-hlz
-eFH
+esA
+cgw
+cul
+hXt
 wul
-hlz
+gvv
 gnz
-eFH
-eFH
-vuR
+sYK
+tqf
+iKV
 hOe
-cAH
-fXd
-vuR
-vuR
-vuR
-cAH
+iTR
+bwN
+hjH
+itW
+faB
+kZt
 vTK
 aag
 aag

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -12043,15 +12043,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/shipboard/starboard_point_defense)
-"aOO" = (
-/obj/structure/machinery/door/poddoor/almayer/open{
-	id = "Hangar Lockdown";
-	name = "\improper Hangar Lockdown Blast Door"
-	},
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/hallways/hangar)
 "aOP" = (
 /obj/structure/machinery/camera/autoname/almayer{
 	name = "ship-grade camera"
@@ -12569,11 +12560,8 @@
 	},
 /area/almayer/command/cic)
 "aRu" = (
-/obj/structure/surface/table/almayer,
-/obj/structure/prop/mech/hydralic_clamp,
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
+/obj/structure/foamed_metal,
+/turf/open/floor/plating,
 /area/almayer/hallways/hangar)
 "aRv" = (
 /obj/structure/machinery/light{
@@ -20169,6 +20157,12 @@
 	icon_state = "kitchen"
 	},
 /area/almayer/living/grunt_rnr)
+"bDu" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hallways/hangar)
 "bDv" = (
 /obj/structure/machinery/cm_vending/clothing/medical_crew,
 /turf/open/floor/almayer{
@@ -28612,19 +28606,6 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/shipboard/starboard_missiles)
-"cqT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/prop/invuln{
-	desc = "non functional set of snowplowers for tanks";
-	icon = 'icons/obj/vehicles/hardpoints/tank.dmi';
-	icon_state = "snowplow";
-	name = "Bleihagel RE-RE700 Frontal Cannon";
-	density = 0;
-	pixel_x = -2;
-	layer = 3
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/hallways/hangar)
 "cqY" = (
 /obj/structure/surface/table/reinforced/almayer_B,
 /obj/item/storage/fancy/cigar/tarbacktube,
@@ -28986,18 +28967,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_m_s)
-"cxY" = (
-/obj/structure/platform{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/pipes/standard/manifold/hidden/supply{
-	dir = 1
-	},
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/hallways/hangar)
 "cya" = (
 /obj/structure/prop/invuln/overhead_pipe{
 	dir = 4;
@@ -30503,11 +30472,6 @@
 	icon_state = "plating_striped"
 	},
 /area/almayer/engineering/upper_engineering/port)
-"dbs" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/oil/streak,
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/hallways/hangar)
 "dbv" = (
 /obj/structure/surface/table/reinforced/almayer_B,
 /obj/structure/machinery/prop/almayer/computer{
@@ -32494,16 +32458,6 @@
 	icon_state = "plating_striped"
 	},
 /area/almayer/shipboard/sea_office)
-"dLv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/tool/warning_cone{
-	pixel_y = 13
-	},
-/turf/open/floor/almayer{
-	dir = 4;
-	icon_state = "silvercorner"
-	},
-/area/almayer/hallways/hangar)
 "dLz" = (
 /obj/structure/surface/table/almayer,
 /obj/item/storage/backpack/satchel,
@@ -33088,21 +33042,6 @@
 	icon_state = "orange"
 	},
 /area/almayer/hallways/stern_hallway)
-"dZi" = (
-/obj/structure/platform{
-	dir = 1
-	},
-/obj/item/clothing/head/helmet/marine/tech/tanker{
-	pixel_x = 3;
-	pixel_y = -5
-	},
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/hallways/hangar)
 "dZr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -33967,18 +33906,6 @@
 	icon_state = "red"
 	},
 /area/almayer/shipboard/brig/evidence_storage)
-"enw" = (
-/obj/structure/platform{
-	dir = 8
-	},
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 6
-	},
-/obj/effect/decal/strata_decals/grime/grime3,
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/hallways/hangar)
 "enx" = (
 /obj/structure/pipes/vents/pump,
 /turf/open/floor/almayer{
@@ -35112,20 +35039,6 @@
 	icon_state = "bluefull"
 	},
 /area/almayer/command/cichallway)
-"eHJ" = (
-/obj/effect/decal/cleanable/blood/oil/streak,
-/obj/structure/machinery/light{
-	dir = 4;
-	invisibility = 101
-	},
-/obj/effect/decal/strata_decals/grime/grime1{
-	dir = 8
-	},
-/obj/structure/pipes/vents/pump{
-	dir = 1
-	},
-/turf/open/floor/almayer,
-/area/almayer/hallways/hangar)
 "eHY" = (
 /obj/structure/surface/rack,
 /obj/item/device/taperecorder,
@@ -35709,12 +35622,6 @@
 /obj/item/storage/beer_pack,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_m_s)
-"eVG" = (
-/obj/structure/blocker/invisible_wall{
-	name = "\improper M34A2 Longstreet light tank"
-	},
-/turf/open/floor/plating,
-/area/almayer/hallways/hangar)
 "eVQ" = (
 /obj/structure/machinery/light{
 	dir = 4
@@ -36444,15 +36351,6 @@
 	dir = 8
 	},
 /area/almayer/medical/containment/cell/cl)
-"fln" = (
-/obj/structure/largecrate/random/barrel/yellow{
-	anchored = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/almayer{
-	icon_state = "silver"
-	},
-/area/almayer/hallways/hangar)
 "flE" = (
 /obj/structure/platform{
 	dir = 8
@@ -38535,27 +38433,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/hull/lower_hull/l_a_p)
-"gaC" = (
-/obj/structure/machinery/light{
-	dir = 8;
-	invisibility = 101
-	},
-/obj/structure/prop/invuln{
-	desc = "Integral to the movement of the APC, these one's are non-functional";
-	icon = 'icons/obj/vehicles/hardpoints/apc.dmi';
-	icon_state = "tires";
-	name = "APC Wheels";
-	density = 0;
-	pixel_x = 5;
-	pixel_y = 13;
-	layer = 3
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/pipes/vents/scrubber{
-	dir = 1
-	},
-/turf/open/floor/almayer,
-/area/almayer/hallways/hangar)
 "gaJ" = (
 /turf/closed/wall/almayer,
 /area/almayer/shipboard/brig/cryo)
@@ -39628,27 +39505,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/upper_hull/u_f_p)
-"gvI" = (
-/obj/structure/largecrate/random/case/small,
-/obj/structure/machinery{
-	density = 1;
-	dir = 4;
-	icon = 'icons/obj/vehicles/tank.dmi';
-	indestructible = 1;
-	name = "\improper M34A2 Longstreet light tank gun barrel";
-	pixel_y = -19;
-	unacidable = 1;
-	unslashable = 1;
-	pixel_x = -37;
-	icon_state = "ltb_cannon_1";
-	layer = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "silver"
-	},
-/area/almayer/hallways/hangar)
 "gvU" = (
 /obj/structure/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -40966,11 +40822,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/lifeboat_pumps/south1)
-"gWm" = (
-/obj/effect/decal/cleanable/blood/oil,
-/obj/structure/blocker/invisible_wall,
-/turf/open/floor/plating,
-/area/almayer/hallways/hangar)
 "gWE" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/start/marine/spec/alpha,
@@ -41227,16 +41078,6 @@
 	icon_state = "silver"
 	},
 /area/almayer/command/cichallway)
-"haJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/device/radio/marine{
-	pixel_x = 5;
-	pixel_y = 3
-	},
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/hallways/hangar)
 "haM" = (
 /obj/structure/machinery/constructable_frame,
 /obj/effect/decal/cleanable/blood/oil,
@@ -42137,17 +41978,6 @@
 	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical_medbay)
-"hrV" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "N";
-	layer = 3.33;
-	pixel_y = 2
-	},
-/obj/structure/pipes/standard/simple/hidden/supply,
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/hallways/hangar)
 "hrX" = (
 /obj/structure/closet/secure_closet/engineering_welding,
 /obj/structure/machinery/light{
@@ -43604,13 +43434,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/engineering/upper_engineering/port)
-"hTG" = (
-/obj/structure/machinery/cm_vending/sorted/tech/tool_storage,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/hallways/hangar)
 "hTP" = (
 /obj/structure/machinery/door_control{
 	id = "crate_room2";
@@ -44477,16 +44300,6 @@
 	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/morgue)
-"imv" = (
-/obj/item/hardpoint/support/flare_launcher{
-	pixel_x = -11;
-	pixel_y = 5
-	},
-/obj/structure/blocker/invisible_wall{
-	name = "\improper M34A2 Longstreet light tank"
-	},
-/turf/open/floor/plating,
-/area/almayer/hallways/hangar)
 "imy" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer,
@@ -44692,16 +44505,6 @@
 	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering/port)
-"iqR" = (
-/obj/structure/machinery/camera/autoname/almayer{
-	dir = 8;
-	name = "ship-grade camera"
-	},
-/obj/effect/decal/strata_decals/grime/grime1{
-	dir = 8
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/hallways/hangar)
 "irn" = (
 /obj/structure/largecrate/random/case/double,
 /turf/open/floor/plating/plating_catwalk,
@@ -44968,17 +44771,6 @@
 	icon_state = "silver"
 	},
 /area/almayer/shipboard/brig/cic_hallway)
-"iuF" = (
-/obj/structure/machinery/door/airlock/almayer/maint{
-	dir = 1;
-	req_access = null;
-	req_one_access = null;
-	req_one_access_txt = "3;22;19"
-	},
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/hull/lower_hull/l_f_s)
 "iuM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/prop/invuln/overhead/flammable_pipe/fly{
@@ -45871,18 +45663,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_a_p)
-"iNi" = (
-/obj/structure/platform{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/blood/oil,
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/hallways/hangar)
 "iNZ" = (
 /obj/structure/machinery/light{
 	dir = 8
@@ -45907,12 +45687,6 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/shipboard/brig/cells)
-"iOP" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/almayer{
-	icon_state = "silvercorner"
-	},
-/area/almayer/hallways/hangar)
 "iPv" = (
 /obj/structure/bed/chair/comfy,
 /obj/structure/window/reinforced/ultra,
@@ -46068,18 +45842,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/hull/lower_hull/l_a_p)
-"iSu" = (
-/obj/item/tool/warning_cone{
-	pixel_y = 11;
-	pixel_x = 13
-	},
-/obj/structure/largecrate/random/case{
-	pixel_x = 4;
-	pixel_y = -11
-	},
-/obj/structure/pipes/standard/simple/hidden/supply,
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/hallways/hangar)
 "iSZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -47227,14 +46989,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/shipboard/brig/perma)
-"jlj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/powerloader_wreckage,
-/turf/open/floor/almayer{
-	dir = 10;
-	icon_state = "cargo"
-	},
-/area/almayer/hallways/hangar)
 "jlA" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
@@ -47393,17 +47147,6 @@
 	icon_state = "silvercorner"
 	},
 /area/almayer/shipboard/brig/cic_hallway)
-"jnI" = (
-/obj/structure/platform{
-	dir = 4;
-	layer = 2.7
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/item/folder/black_random,
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/hallways/hangar)
 "jnT" = (
 /obj/structure/bed/chair,
 /turf/open/floor/almayer{
@@ -51687,19 +51430,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/upper_hull/u_m_p)
-"laF" = (
-/obj/structure/platform{
-	dir = 4;
-	layer = 2.7
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 10
-	},
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/hallways/hangar)
 "laO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -52472,14 +52202,6 @@
 /obj/structure/largecrate/random/barrel/red,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_f_s)
-"lpU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/generic,
-/obj/item/trash/barcardine,
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/hallways/hangar)
 "lpX" = (
 /obj/structure/prop/invuln/overhead_pipe{
 	pixel_x = 12
@@ -53252,22 +52974,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/hull/lower_hull/l_f_s)
-"lCo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/surface/table/almayer,
-/obj/item/tool/weldpack{
-	pixel_x = -6;
-	pixel_y = 4
-	},
-/obj/item/tool/screwdriver,
-/obj/item/stack/cable_coil{
-	pixel_x = 5;
-	pixel_y = 11
-	},
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/hallways/hangar)
 "lCt" = (
 /turf/open/floor/almayer{
 	dir = 10;
@@ -54509,16 +54215,6 @@
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/engineering/lower_engineering)
-"mbW" = (
-/obj/structure/machinery/door/poddoor/almayer/open{
-	id = "Hangar Lockdown";
-	name = "\improper Hangar Lockdown Blast Door"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/hallways/hangar)
 "mce" = (
 /turf/open/floor/almayer{
 	icon_state = "greencorner"
@@ -58443,21 +58139,6 @@
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer,
 /area/almayer/living/pilotbunks)
-"nBQ" = (
-/obj/structure/platform{
-	dir = 4;
-	layer = 2.7
-	},
-/obj/structure/machinery/gear,
-/obj/effect/decal/strata_decals/grime/grime2,
-/obj/structure/sign/safety/storage{
-	pixel_x = 8;
-	pixel_y = 32
-	},
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/hallways/hangar)
 "nBW" = (
 /obj/structure/sign/safety/maint{
 	pixel_x = -17
@@ -58587,10 +58268,8 @@
 /area/almayer/hallways/port_umbilical)
 "nEv" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/warning_stripes{
-	icon_state = "N";
-	layer = 3.33;
-	pixel_y = 2
+/obj/structure/machinery/light{
+	dir = 1
 	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
@@ -60718,24 +60397,6 @@
 	icon_state = "ai_floors"
 	},
 /area/almayer/command/airoom)
-"ouA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/platform_decoration{
-	dir = 4
-	},
-/obj/structure/machinery/gear,
-/obj/item/tool/warning_cone{
-	layer = 3.6;
-	pixel_x = -16;
-	pixel_y = -9
-	},
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 9
-	},
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/hallways/hangar)
 "ouB" = (
 /obj/structure/bed/sofa/vert/grey/bot,
 /turf/open/floor/almayer,
@@ -60972,17 +60633,6 @@
 	icon_state = "mono"
 	},
 /area/almayer/engineering/upper_engineering/starboard)
-"ozC" = (
-/obj/structure/platform{
-	dir = 1
-	},
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/hallways/hangar)
 "ozF" = (
 /obj/structure/machinery/light/small{
 	dir = 8
@@ -64234,15 +63884,6 @@
 	icon_state = "test_floor5"
 	},
 /area/almayer/medical/hydroponics)
-"pSp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/liquid_fuel,
-/obj/item/tool/wet_sign,
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "silvercorner"
-	},
-/area/almayer/hallways/hangar)
 "pSL" = (
 /obj/structure/machinery/alarm/almayer{
 	dir = 1
@@ -64252,17 +63893,6 @@
 	icon_state = "blue"
 	},
 /area/almayer/hallways/aft_hallway)
-"pSN" = (
-/obj/effect/decal/cleanable/blood/oil/streak,
-/obj/structure/surface/table/almayer,
-/obj/item/storage/belt/tank{
-	pixel_x = -4;
-	pixel_y = 8
-	},
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/hallways/hangar)
 "pSU" = (
 /obj/structure/machinery/light,
 /obj/structure/machinery/photocopier,
@@ -68411,18 +68041,6 @@
 /obj/structure/pipes/standard/manifold/hidden/supply,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/navigation)
-"rxL" = (
-/obj/effect/decal/cleanable/liquid_fuel,
-/obj/structure/largecrate/random/barrel/white{
-	pixel_x = -8;
-	pixel_y = 3;
-	anchored = 1
-	},
-/turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "silvercorner"
-	},
-/area/almayer/hallways/hangar)
 "rxO" = (
 /obj/structure/machinery/cm_vending/clothing/intelligence_officer,
 /turf/open/floor/almayer{
@@ -69857,13 +69475,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/living/offices/flight)
-"rYP" = (
-/obj/effect/decal/cleanable/blood/oil,
-/obj/structure/blocker/invisible_wall{
-	name = "\improper M34A2 Longstreet light tank"
-	},
-/turf/open/floor/plating,
-/area/almayer/hallways/hangar)
 "rZB" = (
 /obj/structure/pipes/standard/simple/visible{
 	dir = 9
@@ -70786,16 +70397,6 @@
 	allow_construction = 0
 	},
 /area/almayer/stair_clone/upper)
-"stF" = (
-/obj/structure/platform{
-	dir = 8
-	},
-/obj/structure/machinery/gear,
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/hallways/hangar)
 "stY" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer,
 /obj/structure/pipes/standard/simple/hidden/supply{
@@ -70820,16 +70421,6 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/command/computerlab)
-"suN" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "N";
-	layer = 3.33;
-	pixel_y = 2
-	},
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/hallways/hangar)
 "suT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -72644,16 +72235,6 @@
 	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering/starboard)
-"tfj" = (
-/obj/structure/machinery/door/poddoor/almayer/open{
-	id = "Hangar Lockdown";
-	name = "\improper Hangar Lockdown Blast Door"
-	},
-/obj/structure/pipes/standard/simple/hidden/supply,
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/hallways/hangar)
 "tfl" = (
 /obj/structure/machinery/light{
 	dir = 1
@@ -73247,15 +72828,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_m_p)
-"tqo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/chair/office/dark{
-	dir = 8
-	},
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/hallways/hangar)
 "tqx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -73635,20 +73207,6 @@
 "tuA" = (
 /turf/closed/wall/almayer/outer,
 /area/almayer/shipboard/port_missiles)
-"tuK" = (
-/obj/structure/platform{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/oil/streak,
-/obj/item/clothing/glasses/welding{
-	pixel_x = 5;
-	pixel_y = -7
-	},
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/hallways/hangar)
 "tuM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/largecrate/random/barrel/red{
@@ -75340,10 +74898,6 @@
 	icon_state = "ai_floors"
 	},
 /area/almayer/command/airoom)
-"ubB" = (
-/obj/structure/blocker/invisible_wall,
-/turf/open/floor/plating,
-/area/almayer/hallways/hangar)
 "ucd" = (
 /obj/structure/prop/invuln/overhead_pipe{
 	pixel_x = 12
@@ -75862,29 +75416,6 @@
 	icon_state = "green"
 	},
 /area/almayer/shipboard/brig/cells)
-"unu" = (
-/obj/structure/surface/table/almayer,
-/obj/effect/spawner/random/toolbox,
-/obj/item/ashtray/bronze{
-	pixel_x = 9;
-	pixel_y = 8
-	},
-/obj/item/trash/cigbutt/ucigbutt{
-	pixel_x = -13;
-	pixel_y = 8
-	},
-/obj/item/trash/cigbutt/ucigbutt{
-	pixel_x = 3;
-	pixel_y = 12
-	},
-/obj/item/trash/cigbutt/ucigbutt{
-	pixel_x = -4;
-	pixel_y = 16
-	},
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/hallways/hangar)
 "unJ" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 6
@@ -80966,23 +80497,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/engineering/upper_engineering/starboard)
-"web" = (
-/obj/effect/decal/strata_decals/grime/grime4,
-/obj/item/tool/warning_cone{
-	pixel_x = -12
-	},
-/obj/structure/platform_decoration{
-	dir = 8
-	},
-/obj/structure/machinery/gear,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 5
-	},
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/hallways/hangar)
 "wei" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
@@ -81558,73 +81072,6 @@
 /obj/structure/window/framed/almayer/white/hull,
 /turf/open/floor/plating,
 /area/almayer/command/airoom)
-"wnD" = (
-/obj/effect/decal/cleanable/blood/oil,
-/obj/structure/machinery{
-	density = 1;
-	dir = 4;
-	icon = 'icons/obj/vehicles/tank.dmi';
-	icon_state = "tank_base";
-	indestructible = 1;
-	name = "\improper M34A2 Longstreet light tank";
-	pixel_y = -18;
-	unacidable = 1;
-	unslashable = 1;
-	pixel_x = 17
-	},
-/obj/structure/machinery{
-	density = 1;
-	dir = 4;
-	icon = 'icons/obj/vehicles/tank.dmi';
-	indestructible = 1;
-	name = "\improper M34A2 Longstreet light tank";
-	pixel_y = -18;
-	unacidable = 1;
-	unslashable = 1;
-	pixel_x = 10;
-	icon_state = "tank_turret_1"
-	},
-/obj/structure/machinery{
-	density = 1;
-	dir = 4;
-	icon = 'icons/obj/vehicles/tank.dmi';
-	indestructible = 1;
-	name = "\improper M34A2 Longstreet light tank";
-	pixel_y = -18;
-	unacidable = 1;
-	unslashable = 1;
-	pixel_x = 18;
-	icon_state = "damaged_frame"
-	},
-/obj/structure/machinery{
-	density = 1;
-	dir = 4;
-	icon = 'icons/obj/vehicles/tank.dmi';
-	indestructible = 1;
-	name = "\improper M34A2 Longstreet light tank";
-	pixel_y = -18;
-	unacidable = 1;
-	unslashable = 1;
-	pixel_x = -5;
-	icon_state = "damaged_turret"
-	},
-/obj/structure/machinery{
-	density = 1;
-	dir = 4;
-	icon = 'icons/obj/vehicles/tank.dmi';
-	indestructible = 1;
-	name = "\improper M34A2 Longstreet light tank";
-	pixel_y = -18;
-	unacidable = 1;
-	unslashable = 1;
-	pixel_x = 17;
-	icon_state = "treads_1"
-	},
-/obj/structure/blocker/invisible_wall{
-	name = "\improper M34A2 Longstreet light tank"
-	},
-/turf/open/floor/plating,
-/area/almayer/hallways/hangar)
 "wnL" = (
 /obj/item/stack/tile/carpet{
 	amount = 12
@@ -83723,16 +83170,9 @@
 	},
 /area/almayer/living/briefing)
 "xbi" = (
-/obj/structure/machinery/light{
-	dir = 1
-	},
 /obj/structure/sign/safety/bulkhead_door{
 	pixel_x = 8;
 	pixel_y = 32
-	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "NE-out";
-	pixel_y = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
@@ -84411,21 +83851,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/upper_hull/u_a_s)
-"xom" = (
-/obj/structure/surface/table/almayer,
-/obj/structure/prop/invuln{
-	desc = "The marketing department over at Bleihagel would have you believe that the RE-RE700 is an original design. However, experts who pried the cover off the cannon have discovered an object with a striking similarity to the popular M56 Cupola. It is still unknown why the cannon has two barrels. This one is non-functional.";
-	icon = 'icons/obj/vehicles/hardpoints/apc.dmi';
-	icon_state = "front_cannon";
-	name = "Bleihagel RE-RE700 Frontal Cannon";
-	density = 0;
-	pixel_y = 5;
-	pixel_x = -4
-	},
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/hallways/hangar)
 "xoJ" = (
 /obj/structure/machinery/door/airlock/almayer/maint{
 	dir = 1
@@ -110871,12 +110296,12 @@ aag
 nXP
 hJp
 dnX
-iuF
-dbs
-dbs
-gaC
-hTG
-jlj
+uNL
+aRu
+aRu
+aRu
+aRu
+aRu
 aRu
 bcm
 xXU
@@ -111075,12 +110500,12 @@ nXP
 edY
 dnX
 uNL
-nBQ
-jnI
-laF
-web
-haJ
-lpU
+aRu
+aRu
+aRu
+aRu
+aRu
+aRu
 bcm
 xbi
 bHB
@@ -111278,14 +110703,14 @@ nXP
 muJ
 fJX
 uNL
-eVG
-imv
-wnD
-iNi
-iOP
-dLv
-aOO
-suN
+aRu
+aRu
+aRu
+aRu
+aRu
+aRu
+bcm
+xyw
 bHB
 aZL
 baX
@@ -111481,15 +110906,15 @@ nXP
 noH
 pgd
 uNL
-eVG
-gWm
-eVG
-cxY
-iSu
-bvf
-tfj
-hrV
-hBF
+aRu
+aRu
+aRu
+aRu
+aRu
+aRu
+bcm
+xyw
+bHB
 wqh
 xyw
 bcc
@@ -111684,13 +111109,13 @@ nXP
 vbt
 wMM
 uNL
-eVG
-ubB
-rYP
-dZi
-fln
-gvI
-mbW
+aRu
+aRu
+aRu
+aRu
+aRu
+aRu
+bcm
 nEv
 bHB
 tdc
@@ -111887,14 +111312,14 @@ nXP
 hIh
 qNG
 uNL
-eVG
-ubB
-eVG
-iNi
-btO
-btO
-aOO
-nEv
+aRu
+aRu
+aRu
+aRu
+aRu
+aRu
+bcm
+bDu
 bHB
 xyw
 bkA
@@ -112090,14 +111515,14 @@ nXP
 nAo
 kKG
 uNL
-eVG
-eVG
-rYP
-ozC
-rxL
-pSp
-aOO
-suN
+aRu
+aRu
+aRu
+aRu
+aRu
+aRu
+bcm
+xyw
 bHB
 xyw
 bkA
@@ -112293,12 +111718,12 @@ hIR
 crE
 eKO
 uNL
-stF
-tuK
-enw
-ouA
-tqo
-unu
+aRu
+aRu
+aRu
+aRu
+aRu
+aRu
 bcm
 tSE
 wTg
@@ -112496,12 +111921,12 @@ cmk
 xJi
 cIi
 uNL
-cqT
-iqR
-eHJ
-xom
-pSN
-lCo
+aRu
+aRu
+aRu
+aRu
+aRu
+aRu
 bcm
 aZZ
 aYC


### PR DESCRIPTION
# About the pull request

Had to open a new PR to fix some issues, but essentially this is the same PR as #4089 

Only difference is I ditched the concept of the broken sentry guns. I also attended to the prior requested changes requested in the last PR

------

Transforms the lower decks maintenance areas into a far more dirty, disorganized, area to be in. Emphasizing how many areas of the ship are in dire need of drydock repairs.

Sees the addition of a old 'tank repair bay' in one of the empty hanger rooms. Featuring a broken tank.
Also sees the addition of a 'ammo storage room' north of briefing. Featuring all of the ships remaining HEAP magazines and SADARs.

I hope to get to the upper deck in a separate PR.

(There should not be any actual real hidden HEAP ammo or anything akin to that.)

Major Things Worth Mentioning

The 'ammo store room' contains a lot of empty HEAP magazines and several SADARS and L42A's, the SADARS and guns are props and are non-functional. There is a single "HEAP" magazine with 5 bullets in it, but the bullets are standard rounds, with the magazine explicitly stating this.
The items in the Tank bay are all props, no tank gear is useable except for the Tanker helmet.

# Explain why it's good for the game

Aesthetics.

The Almayer is intended to be a ship in very desperate need of repairs. Transforming the unused areas of the ship into a more derelict apperance may help impart this to the player.

No major balance change has been effected to these maint areas. Aside from being more cluttered and dank.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
maptweak: Lower deck maint of the Almayer is significantly more run down.
maptweak: Tank repair bay has been placed in the north-east of hanger. Behold the Tank in all its glory.
maptweak: Ammo storage room can be found north of briefing. All the remaining HEAP magazines can be found there.
/:cl:
