### PR TITLE
Keycard authenticator can call ERT winout admin intervention

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -101,8 +101,6 @@
 
 /datum/config_entry/flag/continous_rounds
 
-/datum/config_entry/flag/ert_admin_call_only
-
 /datum/config_entry/flag/use_loyalty_implants
 
 /datum/config_entry/number/explosive_antigrief

--- a/code/datums/emergency_calls/emergency_call.dm
+++ b/code/datums/emergency_calls/emergency_call.dm
@@ -34,8 +34,8 @@
 
 ///Process of the ERT call , checks if the request was denied, if not it will call ERT
 /datum/game_mode/proc/process_ert_call(user)
-	if(distress_cancel)
-		distress_cancel = FALSE
+	if(GLOB.distress_cancel)
+		GLOB.distress_cancel = FALSE
 		return
 	activate_distress()
 

--- a/code/datums/emergency_calls/emergency_call.dm
+++ b/code/datums/emergency_calls/emergency_call.dm
@@ -26,7 +26,14 @@
 		return FALSE
 	if(ert_dispatched) //safety check we dont want ert spam
 		return FALSE
-	message_admins("[key_name(user)] has launched a keycard Distress Beacon![ADMIN_JMP_USER(user)] [CC_REPLY(user)]")
+	message_admins("[key_name(user)] has launched a keycard Distress Beacon! (<A HREF='?_src_=admin_holder;[HrefToken(forceGlobal = TRUE)];distresscancel=\ref[user]'>DENY</A>)[ADMIN_JMP_USER(user)] [CC_REPLY(user)]")
+	addtimer(CALLBACK(src, PROC_REF(process_ert_call)), 15 SECONDS)
+	return TRUE
+
+/datum/game_mode/proc/process_ert_call(user)
+	if(distress_cancel)
+		distress_cancel = FALSE
+		return
 	activate_distress()
 
 //The distress call parent. Cannot be called itself due to "name" being a filtered target.

--- a/code/datums/emergency_calls/emergency_call.dm
+++ b/code/datums/emergency_calls/emergency_call.dm
@@ -15,13 +15,15 @@
 	var/input = "ARES. Online. Good morning, marines."
 	shipwide_ai_announcement(input, name, 'sound/AI/ares_online.ogg')
 
+///normal manual approval ERT request
 /datum/game_mode/proc/request_ert(user, ares = FALSE)
 	if(!user)
 		return FALSE
 	message_admins("[key_name(user)] has requested a Distress Beacon! [ares ? SPAN_ORANGE("(via ARES)") : ""] ([SSticker.mode.ert_dispatched ? SPAN_RED("A random ERT was dispatched previously.") : SPAN_GREEN("No previous random ERT dispatched.")]) [CC_MARK(user)] (<A HREF='?_src_=admin_holder;[HrefToken(forceGlobal = TRUE)];distress=\ref[user]'>SEND</A>) (<A HREF='?_src_=admin_holder;[HrefToken(forceGlobal = TRUE)];ccdeny=\ref[user]'>DENY</A>) [ADMIN_JMP_USER(user)] [CC_REPLY(user)]")
 	return TRUE
 
-/datum/game_mode/proc/authorized_request_ert(user) // calls the first ERT winout the need of admin approval.
+/// Automatic Approval ERT request , Admins are given 15 seconds to DENY the ERT
+/datum/game_mode/proc/authorized_request_ert(user)
 	if(!user)
 		return FALSE
 	if(ert_dispatched) //safety check we dont want ert spam
@@ -30,6 +32,7 @@
 	addtimer(CALLBACK(src, PROC_REF(process_ert_call)), 15 SECONDS)
 	return TRUE
 
+///Process of the ERT call , checks if the request was denied, if not it will call ERT
 /datum/game_mode/proc/process_ert_call(user)
 	if(distress_cancel)
 		distress_cancel = FALSE

--- a/code/datums/emergency_calls/emergency_call.dm
+++ b/code/datums/emergency_calls/emergency_call.dm
@@ -21,6 +21,14 @@
 	message_admins("[key_name(user)] has requested a Distress Beacon! [ares ? SPAN_ORANGE("(via ARES)") : ""] ([SSticker.mode.ert_dispatched ? SPAN_RED("A random ERT was dispatched previously.") : SPAN_GREEN("No previous random ERT dispatched.")]) [CC_MARK(user)] (<A HREF='?_src_=admin_holder;[HrefToken(forceGlobal = TRUE)];distress=\ref[user]'>SEND</A>) (<A HREF='?_src_=admin_holder;[HrefToken(forceGlobal = TRUE)];ccdeny=\ref[user]'>DENY</A>) [ADMIN_JMP_USER(user)] [CC_REPLY(user)]")
 	return TRUE
 
+/datum/game_mode/proc/authorized_request_ert(user) // calls the first ERT winout the need of admin approval.
+	if(!user)
+		return FALSE
+	if(ert_dispatched) //safety check we dont want ert spam
+		return FALSE
+	message_admins("[key_name(user)] has launched a keycard Distress Beacon![ADMIN_JMP_USER(user)] [CC_REPLY(user)]")
+	activate_distress()
+
 //The distress call parent. Cannot be called itself due to "name" being a filtered target.
 /datum/emergency_call
 	var/name = "name"

--- a/code/modules/security_levels/keycard_authentication.dm
+++ b/code/modules/security_levels/keycard_authentication.dm
@@ -42,7 +42,7 @@
 			else if(screen == 2)
 				event_triggered_by = usr
 				broadcast_request() //This is the device making the initial event request. It needs to broadcast to other devices
-
+			playsound(src, 'sound/machines/switch.ogg', 25, 1)
 /obj/structure/machinery/keycard_auth/power_change()
 	..()
 	if(stat & NOPOWER)
@@ -68,10 +68,10 @@
 		if(GLOB.security_level < SEC_LEVEL_RED)
 			dat += "<li><A href='?src=\ref[src];triggerevent=Red alert'>Red alert</A></li>"
 		if(!SSticker.mode.ert_dispatched)
-			dat += "<li><A href='?src=\ref[src];triggerevent=distress_beacon'>Distress Beacon</A></li>"
+			dat += "<li><A href='?src=\ref[src];triggerevent=Distress Beacon'>Distress Beacon</A></li>"
 
-		dat += "<li><A href='?src=\ref[src];triggerevent=enable_maint_sec'>Enable Maintenance Security</A></li>"
-		dat += "<li><A href='?src=\ref[src];triggerevent=disable_maint_sec'>Disable Maintenance Security</A></li>"
+		dat += "<li><A href='?src=\ref[src];triggerevent=Disable Maintenance Access'>Disable Maintenance Access</A></li>"
+		dat += "<li><A href='?src=\ref[src];triggerevent=Enable Maintenance Access'>Enable Maintenance Access</A></li>"
 		dat += "</ul>"
 	if(screen == 2)
 		dat += "Please swipe your card to authorize the following event: <b>[event]</b>"
@@ -142,11 +142,11 @@
 	switch(event)
 		if("Red alert")
 			set_security_level(SEC_LEVEL_RED)
-		if("disable_maint_sec")
+		if("Enable Maintenance Access")
 			make_maint_all_access()
-		if("enable_maint_sec")
+		if("Disable Maintenance Access")
 			revoke_maint_all_access()
-		if("distress_beacon")
+		if("Distress Beacon")
 			call_ert()
 
 /obj/structure/machinery/keycard_auth/proc/call_ert()
@@ -175,9 +175,11 @@
 			playsound_client(client,'sound/effects/sos-morse-code.ogg')
 	if(SSticker.mode.is_in_endgame)
 		SSticker.mode.authorized_request_ert(usr)
+		to_chat(usr, SPAN_WARNING("Priority distress beacon launched successfully!"))
 	else
 		SSticker.mode.request_ert(usr)
-	to_chat(usr, SPAN_NOTICE("An emergency distress beacon has been sent to nearby vessels."))
+		to_chat(usr, SPAN_NOTICE("Distress beacon request sent to ARES systems."))
+	playsound(src, 'sound/machines/terminal_success.ogg', 25, 1)
 	COOLDOWN_START(src, distress_cooldown, COOLDOWN_COMM_REQUEST)
 
 GLOBAL_VAR_INIT(maint_all_access, TRUE)

--- a/code/modules/security_levels/keycard_authentication.dm
+++ b/code/modules/security_levels/keycard_authentication.dm
@@ -175,7 +175,6 @@
 		SSticker.mode.request_ert(usr)
 	to_chat(usr, SPAN_NOTICE("An emergency distress beacon has been sent to nearby vessels."))
 	COOLDOWN_START(src, distress_Cooldown, COOLDOWN_COMM_REQUEST)
-	return
 
 GLOBAL_VAR_INIT(maint_all_access, TRUE)
 

--- a/code/modules/security_levels/keycard_authentication.dm
+++ b/code/modules/security_levels/keycard_authentication.dm
@@ -158,10 +158,10 @@
 		to_chat(usr, SPAN_WARNING("The distress beacon has recently broadcast a message. Please wait."))
 		return
 
-if(ert_dispatched)
+	if(SSticker.mode.ert_dispatched)
 		to_chat(usr, SPAN_WARNING("A distress beacon has already launched successfully!"))
 		return
-		
+
 	if(security_level == SEC_LEVEL_DELTA)
 		to_chat(usr, SPAN_WARNING("The ship is already undergoing self-destruct procedures!"))
 		return
@@ -178,7 +178,7 @@ if(ert_dispatched)
 	else
 		SSticker.mode.request_ert(usr)
 	to_chat(usr, SPAN_NOTICE("An emergency distress beacon has been sent to nearby vessels."))
-	COOLDOWN_START(src, distress_Cooldown, COOLDOWN_COMM_REQUEST)
+	COOLDOWN_START(src, distress_cooldown, COOLDOWN_COMM_REQUEST)
 
 GLOBAL_VAR_INIT(maint_all_access, TRUE)
 

--- a/code/modules/security_levels/keycard_authentication.dm
+++ b/code/modules/security_levels/keycard_authentication.dm
@@ -158,6 +158,10 @@
 		to_chat(usr, SPAN_WARNING("The distress beacon has recently broadcast a message. Please wait."))
 		return
 
+if(ert_dispatched)
+		to_chat(usr, SPAN_WARNING("A distress beacon has already launched successfully!"))
+		return
+		
 	if(security_level == SEC_LEVEL_DELTA)
 		to_chat(usr, SPAN_WARNING("The ship is already undergoing self-destruct procedures!"))
 		return

--- a/code/modules/security_levels/keycard_authentication.dm
+++ b/code/modules/security_levels/keycard_authentication.dm
@@ -65,7 +65,8 @@
 
 	if(screen == 1)
 		dat += "Select an event to trigger:<ul>"
-		dat += "<li><A href='?src=\ref[src];triggerevent=Red alert'>Red alert</A></li>"
+		if(security_level < SEC_LEVEL_RED)
+			dat += "<li><A href='?src=\ref[src];triggerevent=Red alert'>Red alert</A></li>"
 		if(!SSticker.mode.ert_dispatched)
 			dat += "<li><A href='?src=\ref[src];triggerevent=distress_beacon'>Distress Beacon</A></li>"
 
@@ -154,9 +155,6 @@
 		to_chat(usr, SPAN_WARNING("The distress beacon cannot be launched this early in the operation. Please wait another [time_left_until(DISTRESS_TIME_LOCK, world.time, 1 MINUTES)] minutes before trying again."))
 		return FALSE
 
-	if(!SSticker.mode)
-		return FALSE //Not a game mode?
-
 	if(world.time < cooldown_request + COOLDOWN_COMM_REQUEST)
 		to_chat(usr, SPAN_WARNING("The distress beacon has recently broadcast a message. Please wait."))
 		return FALSE
@@ -164,6 +162,7 @@
 	if(security_level == SEC_LEVEL_DELTA)
 		to_chat(usr, SPAN_WARNING("The ship is already undergoing self-destruct procedures!"))
 		return FALSE
+
 	if(security_level < SEC_LEVEL_RED)
 		to_chat(usr, SPAN_WARNING("The ship security level is not high enough to call a distress beacon!"))
 		return FALSE
@@ -173,7 +172,10 @@
 	for(var/client/C in GLOB.admins)
 		if((R_ADMIN|R_MOD) & C.admin_holder.rights)
 			C << 'sound/effects/sos-morse-code.ogg'
-	SSticker.mode.authorized_request_ert(usr)
+	if(SSticker.mode.is_in_endgame)
+		SSticker.mode.authorized_request_ert(usr)
+	else
+		SSticker.mode.request_ert(usr)
 	to_chat(usr, SPAN_NOTICE("An emergency distress beacon has been sent to nearby vessels."))
 	cooldown_request = world.time
 	return

--- a/code/modules/security_levels/keycard_authentication.dm
+++ b/code/modules/security_levels/keycard_authentication.dm
@@ -154,7 +154,7 @@
 		to_chat(usr, SPAN_WARNING("The distress beacon cannot be launched this early in the operation. Please wait another [time_left_until(DISTRESS_TIME_LOCK, world.time, 1 MINUTES)] minutes before trying again."))
 		return
 
-	if(!COOLDOWN_FINISHED(src, distress_Cooldown))
+	if(!COOLDOWN_FINISHED(src, distress_cooldown))
 		to_chat(usr, SPAN_WARNING("The distress beacon has recently broadcast a message. Please wait."))
 		return
 

--- a/code/modules/security_levels/keycard_authentication.dm
+++ b/code/modules/security_levels/keycard_authentication.dm
@@ -65,7 +65,7 @@
 
 	if(screen == 1)
 		dat += "Select an event to trigger:<ul>"
-		if(security_level < SEC_LEVEL_RED)
+		if(GLOB.security_level < SEC_LEVEL_RED)
 			dat += "<li><A href='?src=\ref[src];triggerevent=Red alert'>Red alert</A></li>"
 		if(!SSticker.mode.ert_dispatched)
 			dat += "<li><A href='?src=\ref[src];triggerevent=distress_beacon'>Distress Beacon</A></li>"
@@ -162,11 +162,11 @@
 		to_chat(usr, SPAN_WARNING("A distress beacon has already launched successfully!"))
 		return
 
-	if(security_level == SEC_LEVEL_DELTA)
+	if(GLOB.security_level == SEC_LEVEL_DELTA)
 		to_chat(usr, SPAN_WARNING("The ship is already undergoing self-destruct procedures!"))
 		return
 
-	if(security_level < SEC_LEVEL_RED)
+	if(GLOB.security_level < SEC_LEVEL_RED)
 		to_chat(usr, SPAN_WARNING("The ship security level is not high enough to call a distress beacon!"))
 		return
 

--- a/code/modules/security_levels/keycard_authentication.dm
+++ b/code/modules/security_levels/keycard_authentication.dm
@@ -168,7 +168,7 @@
 
 	for(var/client/client in GLOB.admins)
 		if((R_ADMIN|R_MOD) & client.admin_holder.rights)
-			client << 'sound/effects/sos-morse-code.ogg'
+			playsound_client(client,'sound/effects/sos-morse-code.ogg')
 	if(SSticker.mode.is_in_endgame)
 		SSticker.mode.authorized_request_ert(usr)
 	else

--- a/code/modules/security_levels/keycard_authentication.dm
+++ b/code/modules/security_levels/keycard_authentication.dm
@@ -21,7 +21,7 @@
 	idle_power_usage = 2
 	active_power_usage = 6
 	power_channel = POWER_CHANNEL_ENVIRON
-	COOLDOWN_DECLARE(distress_Cooldown)
+	COOLDOWN_DECLARE(distress_cooldown)
 
 /obj/structure/machinery/keycard_auth/attack_remote(mob/user as mob)
 	to_chat(user, "The station AI is not to interact with these devices.")


### PR DESCRIPTION
# About the pull request

Fixes #4333

the keycard authentication will now show an option to send a distress signal similar to the almayer control console that will allow to call the FIRST distress signal on the almayer winout the need for admin approval . ( only works on red alert)

# Explain why it's good for the game

Gives more options to lowpop command and provides a unique reward for using the authenticator in CIC instead of callling ERT remotely from lifeboats.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Adds a new way to send a Distress signal with the Keycard authenticator.
fix: Removes non functional "Call ERT" button in Keycard authenticator.
/:cl:
