### PR TITLE
Blood bag storage and purchasing tweak

### DIFF
--- a/code/game/machinery/vending/vendor_types/crew/synthetic.dm
+++ b/code/game/machinery/vending/vendor_types/crew/synthetic.dm
@@ -37,6 +37,7 @@
 		list("Roller Bed", 4, /obj/item/roller, null, VENDOR_ITEM_REGULAR),
 		list("Stasis Bag", 6, /obj/item/bodybag/cryobag, null, VENDOR_ITEM_REGULAR),
 		list("MS-11 Smart Refill Tank", 6, /obj/item/reagent_container/glass/minitank, null, VENDOR_ITEM_REGULAR),
+		list("Blood Bag (O-)", 4, /obj/item/reagent_container/blood/OMinus, null, VENDOR_ITEM_REGULAR),
 
 		list("Pillbottle (Bicaridine)", 5, /obj/item/storage/pill_bottle/bicaridine, null, VENDOR_ITEM_RECOMMENDED),
 		list("Pillbottle (Dexalin)", 5, /obj/item/storage/pill_bottle/dexalin, null, VENDOR_ITEM_REGULAR),

--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -812,6 +812,14 @@
 		/obj/item/roller = list(SKILL_MEDICAL, SKILL_MEDICAL_MEDIC),
 		/obj/item/bodybag = list(SKILL_MEDICAL, SKILL_MEDICAL_MEDIC),
 		/obj/item/reagent_container/blood = list(SKILL_MEDICAL, SKILL_MEDICAL_MEDIC),
+		/obj/item/reagent_container/blood/OMinus = list(SKILL_MEDICAL, SKILL_MEDICAL_MEDIC),
+		/obj/item/reagent_container/blood/OPlus = list(SKILL_MEDICAL, SKILL_MEDICAL_MEDIC),
+		/obj/item/reagent_container/blood/AMinus = list(SKILL_MEDICAL, SKILL_MEDICAL_MEDIC),
+		/obj/item/reagent_container/blood/APlus = list(SKILL_MEDICAL, SKILL_MEDICAL_MEDIC),
+		/obj/item/reagent_container/blood/BMinus = list(SKILL_MEDICAL, SKILL_MEDICAL_MEDIC),
+		/obj/item/reagent_container/blood/BPlus = list(SKILL_MEDICAL, SKILL_MEDICAL_MEDIC),
+		/obj/item/reagent_container/blood/ABMinus = list(SKILL_MEDICAL, SKILL_MEDICAL_MEDIC),
+		/obj/item/reagent_container/blood/ABPlus = list(SKILL_MEDICAL, SKILL_MEDICAL_MEDIC),
 	)
 	can_hold_skill_only = TRUE
 

--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -812,12 +812,6 @@
 		/obj/item/roller = list(SKILL_MEDICAL, SKILL_MEDICAL_MEDIC),
 		/obj/item/bodybag = list(SKILL_MEDICAL, SKILL_MEDICAL_MEDIC),
 		/obj/item/reagent_container/blood = list(SKILL_MEDICAL, SKILL_MEDICAL_MEDIC),
-		/obj/item/reagent_container/blood/OMinus = list(SKILL_MEDICAL, SKILL_MEDICAL_MEDIC),
-		/obj/item/reagent_container/blood/OPlus = list(SKILL_MEDICAL, SKILL_MEDICAL_MEDIC),
-		/obj/item/reagent_container/blood/AMinus = list(SKILL_MEDICAL, SKILL_MEDICAL_MEDIC),
-		/obj/item/reagent_container/blood/APlus = list(SKILL_MEDICAL, SKILL_MEDICAL_MEDIC),
-		/obj/item/reagent_container/blood/BMinus = list(SKILL_MEDICAL, SKILL_MEDICAL_MEDIC),
-		/obj/item/reagent_container/blood/BPlus = list(SKILL_MEDICAL, SKILL_MEDICAL_MEDIC),
 	)
 	can_hold_skill_only = TRUE
 

--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -818,8 +818,6 @@
 		/obj/item/reagent_container/blood/APlus = list(SKILL_MEDICAL, SKILL_MEDICAL_MEDIC),
 		/obj/item/reagent_container/blood/BMinus = list(SKILL_MEDICAL, SKILL_MEDICAL_MEDIC),
 		/obj/item/reagent_container/blood/BPlus = list(SKILL_MEDICAL, SKILL_MEDICAL_MEDIC),
-		/obj/item/reagent_container/blood/ABMinus = list(SKILL_MEDICAL, SKILL_MEDICAL_MEDIC),
-		/obj/item/reagent_container/blood/ABPlus = list(SKILL_MEDICAL, SKILL_MEDICAL_MEDIC),
 	)
 	can_hold_skill_only = TRUE
 


### PR DESCRIPTION
# About the pull request

Enables storing blood bags in medkits again, this was an oversight when storage got rebalanced and it was accidentally only made so the untyped empty blood bags could go in medkits. This allows for all blood bag types to go into medkits again. Also gives synthetics the option to purchase O- blood bags in their point vendor for 4 points just like medics. 

# Explain why it's good for the game

Fixes an oversight, keeps synthetics from having to raid the entire blood bank.

# Testing Photographs and Procedure

Booted up private testing, worked smooth and as intended.

</details>


# Changelog

:cl:
balance: Allows synthetics to purchase O- blood bags in point vendor
fix: Lets blood bags of all types fit in medkits
/:cl:

