### PR TITLE
Adds a new tab to the spec vendor, EXTRA EQUIPMENT

### DIFF
--- a/code/game/machinery/vending/vendor_types/squad_prep/squad_specialist.dm
+++ b/code/game/machinery/vending/vendor_types/squad_prep/squad_specialist.dm
@@ -36,6 +36,17 @@ GLOBAL_LIST_INIT(cm_vending_gear_spec, list(
 		list("Large Incinerator Tank (B) (Green Flame)", 40, /obj/item/ammo_magazine/flamer_tank/large/B, null, VENDOR_ITEM_REGULAR),
 		list("Large Incinerator Tank (X) (Blue Flame)", 40, /obj/item/ammo_magazine/flamer_tank/large/X, null, VENDOR_ITEM_REGULAR),
 
+		list("EXTRA EQUIPMENT", 0, null, null, null),
+		list("M2 Night Vision Goggles", 40, /obj/item/prop/helmetgarb/helmet_nvg, null, VENDOR_ITEM_REGULAR),
+		list("Advanced Firstaid Kit", 40, /obj/item/storage/firstaid/adv, null, VENDOR_ITEM_REGULAR),
+		list("M4RA Sniper Kit", 40, /obj/item/storage/box/kit/mini_sniper, MARINE_CAN_BUY_KIT, VENDOR_ITEM_REGULAR),
+		list("M41A Standard Kit", 40, /obj/item/storage/box/kit/m41a_kit	, MARINE_CAN_BUY_KIT, VENDOR_ITEM_REGULAR),
+		list("M2C Heavy Machine Gun", 40, /obj/item/storage/box/guncase/m2c, MARINE_CAN_BUY_KIT, VENDOR_ITEM_REGULAR),
+		list("M56D Heavy Machine Gun", 40, /obj/item/storage/box/guncase/m56d, MARINE_CAN_BUY_KIT, VENDOR_ITEM_REGULAR),
+		list("MOU-53 Shotgun", 40, /obj/item/storage/box/guncase/mou53, MARINE_CAN_BUY_KIT, VENDOR_ITEM_REGULAR),
+		list("XM88 Heavy Rifle", 40, /obj/item/storage/box/guncase/xm88, MARINE_CAN_BUY_KIT, VENDOR_ITEM_REGULAR),
+		list("Basic Engineering Supplies", 40, /obj/item/storage/box/kit/engineering_supply_kit, MARINE_CAN_BUY_KIT, VENDOR_ITEM_REGULAR),
+
 	))
 
 /obj/structure/machinery/cm_vending/gear/spec


### PR DESCRIPTION

# About the pull request

This adds a few new items that the Squad Specialist can purchase from his vendor. None of them are very strong, but they cut down prep time by a fair amount and add a small bit of variety to the specialists.

# Explain why it's good for the game

Getting prepped as spec has always been a hassle, at least to me. This small change should be able to cut down prep time, as well as giving Specialists options if they wish to spend their Spec points on something besides extra ammunition.

# Testing Photographs and Procedure

![image](https://github.com/cmss13-devs/cmss13/assets/91508746/5af7029a-9e60-449e-9f1d-f240226668ef)


# Changelog
:cl:
add: New dispensable's in the specialist vendor
/:cl:
