### PR TITLE
Fix afk hugger conversion

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
@@ -67,9 +67,12 @@
 		PF.flags_can_pass_all = PASS_ALL^PASS_OVER_THROW_ITEM
 
 /mob/living/carbon/xenomorph/facehugger/Life(delta_time)
-	if(stat != DEAD && !lying && !(mutation_type == FACEHUGGER_WATCHER) && !(locate(/obj/effect/alien/weeds) in get_turf(src)))
-		adjustBruteLoss(1)
+	if(stat == DEAD)
 		return ..()
+
+	if(!lying && !(mutation_type == FACEHUGGER_WATCHER) && !(locate(/obj/effect/alien/weeds) in get_turf(src)))
+		adjustBruteLoss(1)
+
 	if(!client && !aghosted && away_timer > XENO_FACEHUGGER_LEAVE_TIMER)
 		// Become a npc once again
 		new /obj/item/clothing/mask/facehugger(loc, hivenumber)

--- a/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
@@ -72,6 +72,7 @@
 
 	if(!lying && !(mutation_type == FACEHUGGER_WATCHER) && !(locate(/obj/effect/alien/weeds) in get_turf(src)))
 		adjustBruteLoss(1)
+		return ..()
 
 	if(!client && !aghosted && away_timer > XENO_FACEHUGGER_LEAVE_TIMER)
 		// Become a npc once again


### PR DESCRIPTION
# About the pull request

This PR is a followup to  #3886 fixing dead huggers still converting to normal huggers when client-less. The assumption was that life wouldn't keep ticking when dead, but thats not the case.

# Explain why it's good for the game

Fixes #4486 

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

# Changelog
:cl: Drathek
fix: Fix dead huggers converting to non-player huggers
/:cl:
