### PR TITLE
Makes Dropship Pilot Two Dropship Crew Chief hours, instead of Five Marine squad hours.

### DIFF
--- a/code/__DEFINES/job.dm
+++ b/code/__DEFINES/job.dm
@@ -78,6 +78,8 @@ var/global/list/job_command_roles = JOB_COMMAND_ROLES_LIST
 #define JOB_DROPSHIP_CREW_CHIEF "Dropship Crew Chief"
 #define JOB_CREWMAN "Vehicle Crewman"
 #define JOB_INTEL "Intelligence Officer"
+#define JOB_DROPSHIP_ROLES   /datum/timelock/dropship
+#define JOB_DROPSHIP_ROLES_LIST   list(JOB_DROPSHIP_CREW_CHIEF, JOB_PILOT)
 #define JOB_AUXILIARY_ROLES    /datum/timelock/auxiliary
 #define JOB_AUXILIARY_ROLES_LIST   list(JOB_PILOT, JOB_DROPSHIP_CREW_CHIEF, JOB_CREWMAN, JOB_INTEL)
 

--- a/code/game/jobs/job/command/auxiliary/pilot.dm
+++ b/code/game/jobs/job/command/auxiliary/pilot.dm
@@ -10,7 +10,7 @@
 	entry_message_body = "<a href='"+URL_WIKI_PO_GUIDE+"'>Your job is to fly, protect, and maintain the ship's dropship.</a> While you are an officer, your authority is limited to the dropship, where you have authority over the enlisted personnel. If you are not piloting, there is an autopilot fallback for command, but don't leave the dropship without reason."
 
 AddTimelock(/datum/job/command/pilot, list(
-	JOB_SQUAD_ROLES = 5 HOURS
+	JOB_DROPSHIP_CREW_CHIEF = 5 HOURS
 ))
 
 /obj/effect/landmark/start/pilot

--- a/code/game/jobs/job/command/auxiliary/pilot.dm
+++ b/code/game/jobs/job/command/auxiliary/pilot.dm
@@ -9,8 +9,9 @@
 	gear_preset = /datum/equipment_preset/uscm_ship/po
 	entry_message_body = "<a href='"+URL_WIKI_PO_GUIDE+"'>Your job is to fly, protect, and maintain the ship's dropship.</a> While you are an officer, your authority is limited to the dropship, where you have authority over the enlisted personnel. If you are not piloting, there is an autopilot fallback for command, but don't leave the dropship without reason."
 
+// Dropship Roles is both PO and DCC combined to not force people to backtrack
 AddTimelock(/datum/job/command/pilot, list(
-	JOB_DROPSHIP_CREW_CHIEF = 2 HOURS
+	JOB_DROPSHIP_ROLES = 2 HOURS
 ))
 
 /obj/effect/landmark/start/pilot

--- a/code/game/jobs/job/command/auxiliary/pilot.dm
+++ b/code/game/jobs/job/command/auxiliary/pilot.dm
@@ -10,7 +10,7 @@
 	entry_message_body = "<a href='"+URL_WIKI_PO_GUIDE+"'>Your job is to fly, protect, and maintain the ship's dropship.</a> While you are an officer, your authority is limited to the dropship, where you have authority over the enlisted personnel. If you are not piloting, there is an autopilot fallback for command, but don't leave the dropship without reason."
 
 AddTimelock(/datum/job/command/pilot, list(
-	JOB_DROPSHIP_CREW_CHIEF = 5 HOURS
+	JOB_DROPSHIP_CREW_CHIEF = 2 HOURS
 ))
 
 /obj/effect/landmark/start/pilot

--- a/code/game/jobs/job/command/command.dm
+++ b/code/game/jobs/job/command/command.dm
@@ -26,4 +26,11 @@
 	
 /datum/timelock/human/get_role_requirement(client/C)
 	return time_required - C.get_total_human_playtime()
+
+/datum/timelock/dropship
+	name = "Dropship Roles"
+
+/datum/timelock/dropship/New(name, time_required, list/roles)
+	. = ..()
+	src.roles = JOB_DROPSHIP_ROLES_LIST
 	


### PR DESCRIPTION
# About the pull request

### Changes the hours from five marine hours to *two* DCC hours, something that should've been done years ago.

# Explain why it's good for the game

I'm **SICK** and **TIRED** of TROGLADYTE dropship pilots who don't even ATTEMPT to read the guide, and think they're the coolest person ever after direct firing without a laser detector, wiping the front with six minis, and they don't even have the GAL 
to apologize afterwards. I want this to END.

It's honestly comical how terrible pilots have gotten, so much so that I refuse to call them in unless they have a silver medal or above. It makes absolutely no sense how pilots only need five hours as a marine to have the power to kill fifteen marines with one napalm. By making it two DCC hours, you give them a chance to learn how to fly, and also get tips from experienced pilots.

I honestly believe that the reason marine winrate is so low is because of the sheer incompetence shown by command slots and fire support-ists, and by making the hours needed higher, HOPEFULLY marines can actually use fire support without fear of the person faltering and killing everyone.

I was thinking of having Two Fireteam Leader hours as well, but because of the moving away of RTO's, I didn't think it was necessary and would've been overkill. Might be something to consider though.

was brought upon by this screenshot:
https://media.discordapp.net/attachments/604397850675380234/1155395437256249354/image_4.png

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>



</details>


# Changelog
:cl: bostonthebear
add: Changes pilot officer timelock from 5 hours as squad marine to 2 hours as DCC
/:cl: