### PR TITLE
Bugfix: Small wording fix

### DIFF
--- a/code/game/objects/items/tools/flame_tools.dm
+++ b/code/game/objects/items/tools/flame_tools.dm
@@ -366,7 +366,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 			if(user == M)
 				user.visible_message(SPAN_NOTICE(type_butt ? "[user] calmly drops and treads on the lit [src], putting it out instantly." : "[user] puts out \the [src]."))
 			else
-				to_chat(M, SPAN_NOTICE("Your [src] goes out."))
+				to_chat(M, SPAN_NOTICE("Your [src.name] goes out."))
 	STOP_PROCESSING(SSobj, src)
 	if(type_butt)
 		var/turf/T = get_turf(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Removes 'the'.

![image](https://github.com/cmss13-devs/cmss13/assets/59719612/0931deb7-9158-4e01-a003-9ff3ef3a5e35)

Fixes https://github.com/cmss13-devs/cmss13/issues/4472

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/cmss13-devs/cmss13/assets/59719612/73e38110-8141-4855-8600-023b2a238aa6)

</details>


# Changelog

:cl: Casper
fix: fixed cigarette punctuation error
/:cl: