### PR TITLE
Bugfix: Reagent Canister Nullspace

### DIFF
--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -1052,7 +1052,10 @@
 		to_chat(usr, SPAN_WARNING("There is no container inside this pouch!"))
 		return
 
-	usr.put_in_any_hand_if_possible(inner, disable_warning = TRUE)
+	var/had_empty_hand = usr.put_in_any_hand_if_possible(inner, disable_warning = TRUE)
+	if(!had_empty_hand)
+		usr.drop_inv_item_on_ground(inner)
+
 	inner = null
 	update_icon()
 


### PR DESCRIPTION
# About the pull request

Removing the container from a reagent canister with your hands full would cause the container to be nullspaced. Now it is instead dropped on the floor.

Fixes https://github.com/cmss13-devs/cmss13/issues/4445

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

https://github.com/cmss13-devs/cmss13/assets/59719612/c2187a7d-95e9-4fc2-9a42-3ee7b0192b02

</details>

# Changelog

:cl: Casper
fix: fixed reagent canister being deleted if ejected with your hands full
/:cl: