### PR TITLE
no more anchorpoint pvt

### DIFF
--- a/code/datums/emergency_calls/cmb.dm
+++ b/code/datums/emergency_calls/cmb.dm
@@ -113,7 +113,7 @@
 /datum/emergency_call/cmb/anchorpoint/New()
 	..()
 	arrival_message = "[MAIN_SHIP_NAME], this is Anchorpoint Station. Be advised, a QRF Team of our Colonial Marines is currently attempting to board you. Open your ports, transmitting docking codes now. Standby."
-	objectives = "QRF Team. You are here to reinforce the cmb team we deployed earlier. Make contact and work with the CMB Marshal and their deputies. Facilitate their protection and evacuation if necessary. Secondary Objective: Investigate the reason for distress aboard the [MAIN_SHIP_NAME], and assist the crew if possible."
+	objectives = "QRF Team. You are here to reinforce the CMB team we deployed earlier. Make contact and work with the CMB Marshal and their deputies. Facilitate their protection and evacuation if necessary. Secondary Objective: Investigate the reason for distress aboard the [MAIN_SHIP_NAME], and assist the crew if possible."
 
 /datum/emergency_call/cmb/anchorpoint/create_member(datum/mind/M, turf/override_spawn_loc)
 	var/turf/spawn_loc = override_spawn_loc ? override_spawn_loc : get_spawn_point()

--- a/code/game/jobs/job/special/cmb.dm
+++ b/code/game/jobs/job/special/cmb.dm
@@ -6,11 +6,6 @@
 /datum/job/special/cmb/marshal
 	title = JOB_CMB_TL
 
-AddTimelock(/datum/job/special/cmb/marshal, list(
-	JOB_SQUAD_LEADER = 5 HOURS,
-))
-
-
 // CMB Investigative Synthetic
 /datum/job/special/cmb/synthetic
 	title = JOB_CMB_SYN
@@ -18,10 +13,6 @@ AddTimelock(/datum/job/special/cmb/marshal, list(
 // Interstellar Commerce Commission Corporate Liaison
 /datum/job/special/cmb/icc_liaison
 	title = JOB_CMB_ICC
-
-AddTimelock(/datum/job/special/cmb/icc_liaison, list(
-	JOB_CORPORATE_LIAISON = 1 HOURS,
-))
 
 // Interstellar Human Rights Observer
 /datum/job/special/cmb/observer

--- a/code/game/jobs/job/special/cmb.dm
+++ b/code/game/jobs/job/special/cmb.dm
@@ -6,6 +6,11 @@
 /datum/job/special/cmb/marshal
 	title = JOB_CMB_TL
 
+AddTimelock(/datum/job/special/cmb/marshal, list(
+	JOB_SQUAD_LEADER = 5 HOURS,
+))
+
+
 // CMB Investigative Synthetic
 /datum/job/special/cmb/synthetic
 	title = JOB_CMB_SYN
@@ -13,6 +18,10 @@
 // Interstellar Commerce Commission Corporate Liaison
 /datum/job/special/cmb/icc_liaison
 	title = JOB_CMB_ICC
+
+AddTimelock(/datum/job/special/cmb/icc_liaison, list(
+	JOB_CORPORATE_LIAISON = 1 HOURS,
+))
 
 // Interstellar Human Rights Observer
 /datum/job/special/cmb/observer

--- a/code/modules/gear_presets/cmb.dm
+++ b/code/modules/gear_presets/cmb.dm
@@ -416,12 +416,6 @@
 	. = ..()
 	new_human.nutrition = rand(NUTRITION_MAX, NUTRITION_NORMAL)
 
-/datum/equipment_preset/uscm/cmb/load_rank(mob/living/carbon/human/new_human)
-	if(new_human.client)
-		if(get_job_playtime(new_human.client, rank) < JOB_PLAYTIME_TIER_1)
-			return "ME1"
-	return paygrade
-
 /datum/equipment_preset/uscm/cmb/load_gear(mob/living/carbon/human/new_human)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/under/marine, WEAR_BODY)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/accessory/storage/holster, WEAR_ACCESSORY)


### PR DESCRIPTION
# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

hi this mainly fixes intended timelocks for 2 vital CMB roles, and removes Pvts from Anchorpoint QRF

Had a rank/timelock error due to the way the root was set, this alleviates it so no more Pvt leading the entire squad LMAO(In hindsight I feel like a Pvt is out of place to be on a QRF being sent from anchorpoint, and instead newer troops would stay on the station, may readd later tho)
Also the intended 5hr SL timelock was placed on CMB Mar to prevent weird incidents which have happened. 1hr for ICC for CL duties. 

also I'm not sure why but it seems black market CMB may be having problems with their hud? i will add it if I find a problem
# Explain why it's good for the game
bug bad 

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
del: removed Pvts from Anchorpoint QRF (rip)
spellcheck: fixed a typo in CMB call-in
/:cl:
