### PR TITLE
Bugfix: Flashlights now correct their icon when disabled by a xeno slash.

### DIFF
--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -65,6 +65,7 @@
 	if(on)
 		on = FALSE
 		set_light_on(on)
+		update_icon()
 		for(var/X in actions)
 			var/datum/action/A = X
 			A.update_button_icon()


### PR DESCRIPTION
# About the pull request

When slashed off, a flashlight would maintain it's 'on' sprite. Now it updates correctly.

Fixes https://github.com/cmss13-devs/cmss13/issues/4361

# Changelog

:cl: Casper
fix: fixed flashlights showing incorrect sprite state
/:cl: