### PR TITLE
Fixes grab delay after performing an action

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -210,7 +210,7 @@
 		return TRUE
 
 	if (mods["ctrl"])
-		if (Adjacent(user) && user.next_move < world.time)
+		if (Adjacent(user))
 			user.start_pulling(src)
 		return TRUE
 	return FALSE

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -126,10 +126,11 @@
 	if (!isturf(loc))
 		return
 
-	if (world.time <= next_move && A.loc != src) // Attack click cooldown check
+	if (world.time <= next_move && A.loc != src && src.a_intent != INTENT_GRAB) // Attack click cooldown check
 		return
 
-	next_move = world.time
+	if (src.a_intent != INTENT_GRAB)
+		next_move = world.time
 	// If standing next to the atom clicked.
 	if(A.Adjacent(src))
 		click_adjacent(A, W, mods)
@@ -158,7 +159,8 @@
 			W.afterattack(A, src, 1, mods)
 	else
 		if(!isitem(A) && !issurface(A))
-			next_move += 4
+			if (a_intent != INTENT_GRAB)
+				next_move += 4
 		UnarmedAttack(A, 1, mods)
 
 /mob/proc/check_click_intercept(params,A)

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -126,11 +126,14 @@
 	if (!isturf(loc))
 		return
 
-	if (world.time <= next_move && A.loc != src && src.a_intent != INTENT_GRAB) // Attack click cooldown check
+	if(A.Adjacent(src) && src.a_intent == INTENT_GRAB && !W)
+		click_adjacent(A, W, mods)
 		return
 
-	if (src.a_intent != INTENT_GRAB)
-		next_move = world.time
+	if (world.time <= next_move && A.loc != src) // Attack click cooldown check
+		return
+
+	next_move = world.time
 	// If standing next to the atom clicked.
 	if(A.Adjacent(src))
 		click_adjacent(A, W, mods)
@@ -158,9 +161,8 @@
 
 			W.afterattack(A, src, 1, mods)
 	else
-		if(!isitem(A) && !issurface(A))
-			if (a_intent != INTENT_GRAB)
-				next_move += 4
+		if(!isitem(A) && !issurface(A) && src.a_intent != INTENT_GRAB)
+			next_move += 4
 		UnarmedAttack(A, 1, mods)
 
 /mob/proc/check_click_intercept(params,A)

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -126,7 +126,9 @@
 	if (!isturf(loc))
 		return
 
-	if(A.Adjacent(src) && src.a_intent == INTENT_GRAB && !W)
+	var/adjacent = A.Adjacent(src)
+
+	if(adjacent && src.a_intent == INTENT_GRAB && !W)
 		click_adjacent(A, W, mods)
 		return
 
@@ -135,7 +137,7 @@
 
 	next_move = world.time
 	// If standing next to the atom clicked.
-	if(A.Adjacent(src))
+	if(adjacent)
 		click_adjacent(A, W, mods)
 		return
 

--- a/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
@@ -759,8 +759,6 @@
 		return FALSE
 	var/atom/A = AM.handle_barriers(src)
 	if(A != AM)
-		A.attack_alien(src)
-		xeno_attack_delay(src)
 		return FALSE
 	return ..()
 

--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -39,6 +39,7 @@
 
 			if(Adjacent(M)) //Logic!
 				M.start_pulling(src)
+				return XENO_NO_DELAY_ACTION
 
 		if(INTENT_HARM)
 			if(M.can_not_harm(src))


### PR DESCRIPTION
# About the pull request
First there was an issue where you could grab a marine behind a cade to bypass grab delay and hit it faster than intended.
Which was then fixed by #4204 which in turn fucked your ability to grab things without delay and then attempted to be fixed by #4246 which only partially fixed it.

This PR fixes it with a simpler solution that doesn't affect any other click delays, or actions. By removing a mechanic which automatically attacks the "barricade" (can also be a mob, just the general name for something in the way of you grabbing someone else) when attempting to grab it fails.

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Fixes an annoying bug that's been up for a while
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: xenos no longer have grab delay via any grab method
/:cl:
