### PR TITLE
Bugfix: Unorderable Black Market Crate

### DIFF
--- a/code/datums/supply_packs/black_market.dm
+++ b/code/datums/supply_packs/black_market.dm
@@ -448,7 +448,7 @@ Additionally, weapons that are way too good to put in the basically-flavor black
 	containertype = /obj/structure/largecrate/black_market
 
 /datum/supply_packs/contraband/seized/small
-	name = "S&W revolver (x6 magazines included)"
+	name = "Smith and Wesson revolver (x6 magazines included)"
 	contains = list(
 		/obj/item/weapon/gun/revolver/small,
 		/obj/item/ammo_magazine/revolver/small,


### PR DESCRIPTION
# About the pull request

The '&' in the S&W revolver crate name was breaking the Topic href and made the button do nothing when clicked.

Ideally the fix would keep the S&W text, but I don't know how to do this. Sanitizing '&' just returns '& amp ;' so that doesn't achieve anything.

Fixes https://github.com/cmss13-devs/cmss13/issues/4351

# Explain why it's good for the game

The crate is now orderable.

# Changelog

:cl: Casper
fix: fixed S&W black market crate not working
/:cl: