### PR TITLE
Removes automatic hardcore from Whiskey

### DIFF
--- a/code/game/gamemodes/colonialmarines/whiskey_outpost.dm
+++ b/code/game/gamemodes/colonialmarines/whiskey_outpost.dm
@@ -73,7 +73,7 @@
 
 	var/list/whiskey_outpost_waves = list()
 
-	hardcore = TRUE
+	hardcore = FALSE
 
 	votable = TRUE
 	vote_cycle = 25 // approx. once every 5 days, if it wins the vote
@@ -87,7 +87,6 @@
 	return 1
 
 /datum/game_mode/whiskey_outpost/pre_setup()
-	SSticker.mode.toggleable_flags ^= MODE_HARDCORE_PERMA
 	for(var/obj/effect/landmark/whiskey_outpost/xenospawn/X)
 		xeno_spawns += X.loc
 	for(var/obj/effect/landmark/whiskey_outpost/supplydrops/S)


### PR DESCRIPTION

# About the pull request

Removes automatic global hardcore from Whiskey Outpost, can still be enabled on a per-round basis via an admin verb(or so the last PR leads me to believe.)

# Explain why it's good for the game

Please read all of it and don't close without reading it 🙏 🙏 🙏 

Hardcore mode makes Whiskey Outpost rather unfun, and essentially makes the medical roles useless, as being able to be tended to by a medic after say critting is nearly impossible before you fully die.
In addition, full on medical staff rarely get patients, as most often whenever someone say gets a fracture or recieves organ damage, that usually comes with death, while with non-permadeath this means that they can be recovered and revived, with permadeath doctors very rarely have anything to do, often choosing to act as un-armored medics near the fronts. And even past this, permadeath means that medics usually have very few time-consuming patients so they often are either just running from slightly damaged patient to slightly damaged patient just brute/burnkitting minor wounds or simply sitting around as most badly hurt people usually always die as well.

As well, Whiskey Outpost's map design makes FF very common(constant offscreen cadelines that run adjacent to eachother in the main bunker perimeter, cades all being perfectly horizontal in the main lines leading to single xenos running back and forth slashing them and burst-tracking hitting people, etc) 
and since FF is so lethal it causes many deaths that instantly perma you, regardless of personal or other mistakes or lack thereof, leading to what would be insta-death via FF causing organ/fracture damage needing to temporarily weaken the front by going for surgery or fighting while more fragile into insta-death via FF instantly knocking you out of the round.

As well, permadeath removes a big facet of WO gameplay in that in the small interims between waves after a line was lost, you often would try and quickly rush out and save some pour souls who died and were stranded in the old line, causing a nice rapid rush to save before xenos arrive, and xenos trying to rush to get back to stop recoveries and potentially get some nice un-cadeline hell kills.

Regarding the hardcore WO PR's Why Its good

> It brings a fresh Air to Whiskey outpost and solves a lot of issues for boths sides . Marines obtain a thrilling round with a lot of dopamine , Xenos can feel they are doing something rather than bashing their heads agains barricades.

I feel like it does not solve enough issues(a bit vague but I can see one or two) to compensate for what it causes.

Regarding 

> Marines obtain a thrilling round with a lot of dopamine

Whiskey ends up removing some of the more exciting parts of rushing to repair cades or save people and replacing it with always having to be cautious lest a simple mistake(or FF, FF is constant in WO) spell the end of your round instantly.

> Xenos can feel they are doing something rather than bashing their heads agains barricades.

The gameplay that perma-death encourages means that marines always sit behind caves due to the fear of their rounds ending instantly, potentially exacerbating the issue of WO for xenos being bashing head against cade-walls 

All in all, I do not believe that permadeath is good for the enjoyment of Whiskey Outpost.

In anecdote, WO was one of my favorite modes(genuinely, I know its unpopular but I loved it), but its just a bit unfun(due to hell insta-death from hell of doom) and boring(due to the above stated not being able to do anything risky because the risk is so much higher than it used to be)

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: Whiskey Outpost no longer starts on global hardcore mode by default
/:cl:
