### PR TITLE
Disable join as xeno buried spawns when there is a queue

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -294,6 +294,8 @@
 	if(sorted && length(candidates))
 		candidates = sort_list(candidates, GLOBAL_PROC_REF(cmp_obs_larvaqueuetime_asc))
 
+	GLOB.xeno_queue_candidate_count = length(candidates)
+
 	return candidates
 
 /**

--- a/code/_globalvars/misc.dm
+++ b/code/_globalvars/misc.dm
@@ -27,3 +27,6 @@ GLOBAL_VAR_INIT(time_offset, setup_offset())
 /// Sets the offset 2 lines above.
 /proc/setup_offset()
 	return rand(10 MINUTES, 24 HOURS)
+
+/// The last count of possible candidates in the xeno larva queue (updated via get_alien_candidates)
+GLOBAL_VAR(xeno_queue_candidate_count)

--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -356,17 +356,21 @@ Additional game mode variables.
 		else
 			available_xenos_non_ssd += cur_xeno
 
-	var/datum/hive_status/hive
-	for(var/hivenumber in GLOB.hive_datum)
-		hive = GLOB.hive_datum[hivenumber]
-		if(!hive.hardcore && hive.stored_larva && (hive.hive_location || (world.time < XENO_BURIED_LARVA_TIME_LIMIT + SSticker.round_start_time)))
-			if(SSticker.mode && (SSticker.mode.flags_round_type & MODE_RANDOM_HIVE))
-				available_xenos |= "any buried larva"
-				LAZYADD(available_xenos["any buried larva"], hive)
-			else
-				var/larva_option = "buried larva ([hive])"
-				available_xenos += larva_option
-				available_xenos[larva_option] = list(hive)
+	// Only offer buried larva if there is no queue:
+	// This basically means this block of code will almost never execute, because we are instead relying on the hive cores/larva pops to handle their larva
+	// Technically this should be after a get_alien_candidates() call to be accurate, but we are intentionally trying to not call that proc as much as possible
+	if(GLOB.xeno_queue_candidate_count < 1)
+		var/datum/hive_status/hive
+		for(var/hivenumber in GLOB.hive_datum)
+			hive = GLOB.hive_datum[hivenumber]
+			if(!hive.hardcore && hive.stored_larva && (hive.hive_location || (world.time < XENO_BURIED_LARVA_TIME_LIMIT + SSticker.round_start_time)))
+				if(SSticker.mode && (SSticker.mode.flags_round_type & MODE_RANDOM_HIVE))
+					available_xenos |= "any buried larva"
+					LAZYADD(available_xenos["any buried larva"], hive)
+				else
+					var/larva_option = "buried larva ([hive])"
+					available_xenos += larva_option
+					available_xenos[larva_option] = list(hive)
 
 	if(!available_xenos.len || (instant_join && !available_xenos_non_ssd.len))
 		if(!xeno_candidate.client || !xeno_candidate.client.prefs || !(xeno_candidate.client.prefs.be_special & BE_ALIEN_AFTER_DEATH))

--- a/code/modules/cm_aliens/structures/special/pylon_core.dm
+++ b/code/modules/cm_aliens/structures/special/pylon_core.dm
@@ -263,25 +263,26 @@
 					linked_hive.hive_ui.update_burrowed_larva()
 				qdel(worm)
 
+		var/count_spawned = 0
 		var/spawning_larva = can_spawn_larva() && (last_larva_time + spawn_cooldown) < world.time
 		if(spawning_larva)
 			last_larva_time = world.time
 		if(spawning_larva || (last_larva_queue_time + spawn_cooldown * 4) < world.time)
 			last_larva_queue_time = world.time
 			var/list/players_with_xeno_pref = get_alien_candidates(linked_hive)
-			if(players_with_xeno_pref && players_with_xeno_pref.len)
+			if(length(players_with_xeno_pref))
 				if(spawning_larva && spawn_burrowed_larva(players_with_xeno_pref[1]))
 					// We were in spawning_larva mode and successfully spawned someone
-					message_alien_candidates(players_with_xeno_pref, dequeued = 1)
-				else
-					// Just time to update everyone their queue status (or the spawn failed)
-					message_alien_candidates(players_with_xeno_pref, dequeued = 0)
+					count_spawned = 1
+				// Update everyone's queue status
+				message_alien_candidates(players_with_xeno_pref, dequeued = count_spawned)
 
 		if(linked_hive.hijack_burrowed_surge && (last_surge_time + surge_cooldown) < world.time)
 			last_surge_time = world.time
 			linked_hive.stored_larva++
 			linked_hive.hijack_burrowed_left--
-			notify_ghosts(header = "Claim Xeno", message = "The Hive has gained another burrowed larva! Click to take it.", source = src, action = NOTIFY_JOIN_XENO, enter_link = "join_xeno")
+			if(GLOB.xeno_queue_candidate_count < 1 + count_spawned)
+				notify_ghosts(header = "Claim Xeno", message = "The Hive has gained another burrowed larva! Click to take it.", source = src, action = NOTIFY_JOIN_XENO, enter_link = "join_xeno")
 			if(surge_cooldown > 30 SECONDS) //mostly for sanity purposes
 				surge_cooldown = surge_cooldown - surge_incremental_reduction //ramps up over time
 			if(linked_hive.hijack_burrowed_left < 1)


### PR DESCRIPTION
# About the pull request

This PR changes the logic of the Join as Xeno button to only offer joining as a buried larva if the last call of get_alien_candidates had no candidates. This means almost never will join as xeno offer buried spawns unless the queue was empty. Instead, hive cores ticking (basically they are the larva queue) and larva pops will be the avenue to join as a buried larva.

Also removes the ghost popup on hive surge if there is a queue. The messages ultimately wouldn't allow buried spawns regardless, but no point notifying ghosts if its not possible.

# Explain why it's good for the game

Fixes #4498 and as I mentioned there, this was a possibility even before the larva queue system (when it would just randomly give larva to a ghost that's eligible rather than in time of death order). It did require you to know exactly when a stored larva is added to the hive and to be attempting join as xeno between hive core's processing windows, but since this action is hotkey-able, its pretty easy to just spam to force yourself into that window.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

# Changelog
:cl: Drathek
fix: Join as xeno no longer offers buried larva spawns if there are larva queue candidates
/:cl:
