### PR TITLE
Get Flat Icon Fixes

### DIFF
--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -435,11 +435,19 @@ world
 			if(layer_image.alpha == 0)
 				continue
 
+			var/apply_color = TRUE
+			var/apply_alpha = TRUE
+
 			if(layer_image == copy) // 'layer_image' is an /image based on the object being flattened.
 				curblend = BLEND_OVERLAY
 				add = icon(layer_image.icon, layer_image.icon_state, base_icon_dir)
 			else // 'I' is an appearance object.
-				add = getFlatIcon(image(layer_image), curdir, curicon, curstate, curblend, FALSE, no_anim)
+				var/image/layer_as_image = image(layer_image)
+				if(layer_as_image.appearance_flags & RESET_COLOR)
+					apply_color = FALSE
+				if(layer_as_image.appearance_flags & RESET_ALPHA)
+					apply_alpha = FALSE
+				add = getFlatIcon(layer_as_image, curdir, curicon, curstate, curblend, FALSE, no_anim)
 			if(!add)
 				continue
 
@@ -468,17 +476,17 @@ world
 				flatY1 = addY1
 				flatY2 = addY2
 
+			if(apply_color && appearance.color)
+				if(islist(appearance.color))
+					add.MapColors(arglist(appearance.color))
+				else
+					add.Blend(appearance.color, ICON_MULTIPLY)
+
+			if(apply_alpha && appearance.alpha < 255)
+				add.Blend(rgb(255, 255, 255, appearance.alpha), ICON_MULTIPLY)
+
 			// Blend the overlay into the flattened icon
 			flat.Blend(add, blendMode2iconMode(curblend), layer_image.pixel_x + 2 - flatX1, layer_image.pixel_y + 2 - flatY1)
-
-		if(appearance.color)
-			if(islist(appearance.color))
-				flat.MapColors(arglist(appearance.color))
-			else
-				flat.Blend(appearance.color, ICON_MULTIPLY)
-
-		if(appearance.alpha < 255)
-			flat.Blend(rgb(255, 255, 255, appearance.alpha), ICON_MULTIPLY)
 
 		if(no_anim)
 			//Clean up repeated frames

--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -451,9 +451,9 @@ world
 
 			if (
 				addX1 != flatX1 \
-				&& addX2 != flatX2 \
-				&& addY1 != flatY1 \
-				&& addY2 != flatY2 \
+				|| addX2 != flatX2 \
+				|| addY1 != flatY1 \
+				|| addY2 != flatY2 \
 			)
 				// Resize the flattened icon so the new icon fits
 				flat.Crop(
@@ -464,8 +464,8 @@ world
 				)
 
 				flatX1 = addX1
-				flatX2 = addY1
-				flatY1 = addX2
+				flatX2 = addX2
+				flatY1 = addY1
 				flatY2 = addY2
 
 			// Blend the overlay into the flattened icon


### PR DESCRIPTION
# About the pull request

This PR fixes two issues with getFlatIcon: It failing to properly resize its template dimensions to whatever icon dimensions it was passed, and it ignoring appearance_flags for RESET_COLOR and RESET_ALPHA. This was done to address issues with #4475 but can be even more performance costly than it already was because now it applies color and alpha blends per overlay/underlay layer rather than once per recursive call if there is a color/alpha to apply.

# Explain why it's good for the game

Fixes the broader potential uses for getFlatIcon such as flattening the tacmap.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Example of tacmap flattened prior to dimension fixes: 
![image](https://github.com/cmss13-devs/cmss13/assets/76988376/d74dcfcf-bd13-47bb-ae04-ef6caa281bae)

Example of tacmap flatted prior to color fixes: 
![image](https://github.com/cmss13-devs/cmss13/assets/76988376/81fb7d26-7c10-485b-8f5c-bc153ffbf74c)

Example of tacmap properly flattened: 
![image](https://github.com/cmss13-devs/cmss13/assets/76988376/0923382e-6dd5-44f6-8d72-9343784e26f1)

</details>


# Changelog
:cl: Drathek
fix: Fix getFlatIcon not resizing its template nor respect appearance_flags of RESET_COLOR and RESET_ALPHA
/:cl:
