### PR TITLE
Add cached larva queue message to observer status panel

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -309,11 +309,11 @@
 		var/mob/dead/observer/cur_obs = candidates[i]
 
 		// Generate the messages
-		var/cached_message = SPAN_XENONOTICE("You are currently [i-dequeued]\th in the larva queue.")
+		var/cached_message = "You are currently [i-dequeued]\th in the larva queue."
 		cur_obs.larva_queue_cached_message = cached_message
 		if(!cache_only)
 			var/chat_message = dequeued ? replacetext(cached_message, "currently", "now") : cached_message
-			to_chat(candidates[i], chat_message)
+			to_chat(candidates[i], SPAN_XENONOTICE(chat_message))
 
 /proc/convert_k2c(temp)
 	return ((temp - T0C))

--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -378,7 +378,7 @@ Additional game mode variables.
 		var/mob/dead/observer/candidate_observer = xeno_candidate
 		if(istype(candidate_observer))
 			if(candidate_observer.larva_queue_cached_message)
-				to_chat(xeno_candidate, candidate_observer.larva_queue_cached_message)
+				to_chat(xeno_candidate, SPAN_XENONOTICE(candidate_observer.larva_queue_cached_message))
 				return FALSE
 
 			// No cache, lets check now then
@@ -389,14 +389,14 @@ Additional game mode variables.
 					cur_hive = GLOB.hive_datum[hive_num]
 					for(var/mob_name in cur_hive.banished_ckeys)
 						if(cur_hive.banished_ckeys[mob_name] == xeno_candidate.ckey)
-							candidate_observer.larva_queue_cached_message += "\n" + SPAN_WARNING("NOTE: You are banished from the [cur_hive] and you may not rejoin unless the Queen re-admits you or dies. Your queue number won't update until there is a hive you aren't banished from.")
+							candidate_observer.larva_queue_cached_message += "\nNOTE: You are banished from the [cur_hive] and you may not rejoin unless the Queen re-admits you or dies. Your queue number won't update until there is a hive you aren't banished from."
 							break
-				to_chat(xeno_candidate, candidate_observer.larva_queue_cached_message)
+				to_chat(xeno_candidate, SPAN_XENONOTICE(candidate_observer.larva_queue_cached_message))
 				return FALSE
 
 			// We aren't in queue yet, lets teach them about the queue then
-			candidate_observer.larva_queue_cached_message = SPAN_XENONOTICE("You are currently awaiting assignment in the larva queue. The ordering is based on your time of death or the time you joined. When you have been dead long enough and are not inactive, you will periodically receive messages where you are in the queue relative to other currently valid xeno candidates. Your current position will shift as others change their preferences or go inactive, but your relative position compared to all observers is the same. Note: Playing as a facehugger or in the thunderdome will not alter your time of death. This means you won't lose your relative place in queue if you step away, disconnect, play as a facehugger, or play in the thunderdome.")
-			to_chat(xeno_candidate, candidate_observer.larva_queue_cached_message)
+			candidate_observer.larva_queue_cached_message = "You are currently awaiting assignment in the larva queue. The ordering is based on your time of death or the time you joined. When you have been dead long enough and are not inactive, you will periodically receive messages where you are in the queue relative to other currently valid xeno candidates. Your current position will shift as others change their preferences or go inactive, but your relative position compared to all observers is the same. Note: Playing as a facehugger or in the thunderdome will not alter your time of death. This means you won't lose your relative place in queue if you step away, disconnect, play as a facehugger, or play in the thunderdome."
+			to_chat(xeno_candidate, SPAN_XENONOTICE(candidate_observer.larva_queue_cached_message))
 		return FALSE
 
 	var/mob/living/carbon/xenomorph/new_xeno

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -1090,6 +1090,10 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		if(eta_status)
 			. += "Evacuation: [eta_status]"
 
+	if(client.prefs?.be_special & BE_ALIEN_AFTER_DEATH)
+		if(larva_queue_cached_message)
+			. += larva_queue_cached_message
+
 
 /proc/message_ghosts(message)
 	for(var/mob/dead/observer/O as anything in GLOB.observer_list)


### PR DESCRIPTION

# About the pull request

This PR simply places the cached larva queue message into an observer's status panel if they have xeno preference set. The spans are removed from the cache because the status panel doesn't parse spans.

# Explain why it's good for the game

More or less fixes #4183 by putting the message also into the status panel.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/cmss13-devs/cmss13/assets/76988376/30a510e6-0f70-4752-ae3a-a035e732ed76)

</details>


# Changelog
:cl: Drathek
add: Add the last larva queue message to observer's status panel
/:cl:
