### PR TITLE
Removes alpha egg on LV522

### DIFF
--- a/maps/map_files/LV522_Chances_Claim/LV522_Chances_Claim.dmm
+++ b/maps/map_files/LV522_Chances_Claim/LV522_Chances_Claim.dmm
@@ -40710,7 +40710,6 @@
 /area/lv522/indoors/b_block/bridge)
 "pXH" = (
 /obj/effect/alien/weeds/node/alpha,
-/obj/effect/alien/egg/alpha,
 /turf/open/auto_turf/sand_white/layer0,
 /area/lv522/outdoors/w_rockies)
 "pYf" = (


### PR DESCRIPTION

# About the pull request

Removes alpha egg on LV522.

# Explain why it's good for the game

When it gets to the point of metarushing the egg to fuck with rounds it's time to go. Secrets can only be secrets when they're not being passed around to abuse. RIP a real one.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
del: Removed alpha egg on LV522
/:cl:
