### PR TITLE
Fixes no-delay on m56d burst fire mode

### DIFF
--- a/code/modules/cm_marines/smartgun_mount.dm
+++ b/code/modules/cm_marines/smartgun_mount.dm
@@ -1063,7 +1063,8 @@
 		reset_fire()
 		display_ammo()
 		return
-	SEND_SIGNAL(src, COMSIG_GUN_FIRE)
+	else if(gun_firemode != GUN_FIREMODE_SEMIAUTO)
+		SEND_SIGNAL(src, COMSIG_GUN_FIRE)
 
 /// setter for fire_delay
 /obj/structure/machinery/m56d_hmg/proc/set_fire_delay(value)

--- a/code/modules/cm_marines/smartgun_mount.dm
+++ b/code/modules/cm_marines/smartgun_mount.dm
@@ -1032,6 +1032,9 @@
 /obj/structure/machinery/m56d_hmg/proc/start_fire(datum/source, atom/object, turf/location, control, params, bypass_checks = FALSE)
 	SIGNAL_HANDLER
 
+	if (burst_firing)
+		return
+
 	var/list/modifiers = params2list(params)
 	if(modifiers["shift"] || modifiers["middle"] || modifiers["right"])
 		return


### PR DESCRIPTION
# About the pull request
Fixes a bug with m56d on burst-fire and single-fire mode which allows it to fire with no delay due to #4336 
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Game-breaking and actively abused
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Fixes no fire delay on m56d in semi-auto and burst fire
/:cl:
