### PR TITLE
USS Almayer, CL & CC Hypersleep bay, fixes symmetry issue in CIC hallway (that I broke), adds some warning stripes around for detailing, re-gigs the PO bunk area to get rid of horrible 1x3 hallway

### DIFF
--- a/code/modules/cm_tech/resources/resource.dm
+++ b/code/modules/cm_tech/resources/resource.dm
@@ -177,3 +177,9 @@
 	SPAN_XENONOTICE("You connect [src] to the hive."), max_distance = 3)
 
 	return XENO_NO_DELAY_ACTION
+
+/obj/structure/prop/resource_node
+	name = "\improper fuel pump"
+	desc = "Generates vast amounts of fuel. Required to be active to fuel the USS Almayers lifeboats"
+	icon = 'icons/obj/structures/resources_64x64.dmi'
+	icon_state = "node_off"

--- a/code/modules/cm_tech/resources/resource.dm
+++ b/code/modules/cm_tech/resources/resource.dm
@@ -177,10 +177,3 @@
 	SPAN_XENONOTICE("You connect [src] to the hive."), max_distance = 3)
 
 	return XENO_NO_DELAY_ACTION
-
-/obj/structure/prop/resource_node
-	name = "\improper fuel pump"
-	desc = "Generates vast amounts of fuel. Required to be active to fuel the USS Almayers lifeboats"
-	density = TRUE
-	icon = 'icons/obj/structures/resources_64x64.dmi'
-	icon_state = "node_off"

--- a/code/modules/cm_tech/resources/resource.dm
+++ b/code/modules/cm_tech/resources/resource.dm
@@ -181,5 +181,6 @@
 /obj/structure/prop/resource_node
 	name = "\improper fuel pump"
 	desc = "Generates vast amounts of fuel. Required to be active to fuel the USS Almayers lifeboats"
+	density = TRUE
 	icon = 'icons/obj/structures/resources_64x64.dmi'
 	icon_state = "node_off"

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -4262,10 +4262,12 @@
 /area/almayer/shipboard/navigation)
 "aok" = (
 /obj/structure/machinery/power/apc/almayer/hardened{
-	dir = 1
+	dir = 4
 	},
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/lifeboat_pumps/north1)
+/turf/open/floor/almayer{
+	icon_state = "mono"
+	},
+/area/almayer/lifeboat_pumps/north2)
 "aol" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -14488,9 +14490,8 @@
 /turf/open/floor/almayer,
 /area/almayer/shipboard/starboard_missiles)
 "bbX" = (
-/obj/structure/prop/resource_node,
 /obj/effect/decal/cleanable/blood/oil,
-/obj/structure/blocker/invisible_wall,
+/obj/structure/machinery/constructable_frame,
 /turf/open/floor/almayer{
 	icon_state = "mono"
 	},
@@ -18123,8 +18124,7 @@
 /turf/open/floor/wood/ship,
 /area/almayer/command/corporateliason)
 "bvd" = (
-/obj/structure/prop/resource_node,
-/obj/structure/blocker/invisible_wall,
+/obj/structure/machinery/constructable_frame,
 /turf/open/floor/almayer{
 	icon_state = "mono"
 	},
@@ -24546,9 +24546,6 @@
 /area/almayer/command/corporateliason)
 "bXz" = (
 /obj/effect/decal/cleanable/blood/oil,
-/obj/structure/machinery/power/apc/almayer/hardened{
-	dir = 1
-	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/lifeboat_pumps/north2)
 "bXH" = (
@@ -33689,7 +33686,9 @@
 /turf/open/floor/almayer,
 /area/almayer/lifeboat_pumps/north1)
 "eGb" = (
-/obj/structure/blocker/invisible_wall,
+/obj/structure/machinery/constructable_frame{
+	icon_state = "box_2"
+	},
 /turf/open/floor/almayer{
 	icon_state = "mono"
 	},
@@ -36669,6 +36668,14 @@
 "fUA" = (
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/living/briefing)
+"fVc" = (
+/obj/structure/machinery/power/apc/almayer/hardened{
+	dir = 4
+	},
+/turf/open/floor/almayer{
+	icon_state = "mono"
+	},
+/area/almayer/lifeboat_pumps/south1)
 "fVz" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
@@ -39197,9 +39204,8 @@
 	},
 /area/almayer/command/cichallway)
 "haM" = (
-/obj/structure/prop/resource_node,
 /obj/effect/decal/cleanable/blood/oil,
-/obj/structure/blocker/invisible_wall,
+/obj/structure/machinery/constructable_frame,
 /turf/open/floor/almayer{
 	icon_state = "mono"
 	},
@@ -47685,7 +47691,9 @@
 /turf/open/floor/almayer,
 /area/almayer/shipboard/brig/main_office)
 "kJL" = (
-/obj/structure/blocker/invisible_wall,
+/obj/structure/machinery/constructable_frame{
+	icon_state = "box_2"
+	},
 /turf/open/floor/almayer{
 	icon_state = "mono"
 	},
@@ -48240,7 +48248,7 @@
 /area/almayer/engineering/upper_engineering/port)
 "kUQ" = (
 /obj/effect/decal/cleanable/blood/oil/streak,
-/obj/structure/blocker/invisible_wall,
+/obj/structure/machinery/constructable_frame,
 /turf/open/floor/almayer{
 	icon_state = "mono"
 	},
@@ -49655,7 +49663,7 @@
 	},
 /area/almayer/living/auxiliary_officer_office)
 "lxT" = (
-/obj/structure/blocker/invisible_wall,
+/obj/structure/machinery/constructable_frame,
 /turf/open/floor/almayer{
 	icon_state = "mono"
 	},
@@ -51940,10 +51948,6 @@
 /area/almayer/living/offices)
 "mzF" = (
 /obj/effect/decal/cleanable/blood/oil,
-/obj/structure/machinery/power/apc/almayer/hardened{
-	cell_type = /obj/item/cell/hyper;
-	dir = 1
-	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/lifeboat_pumps/south2)
 "mzO" = (
@@ -63395,6 +63399,12 @@
 	icon_state = "plate"
 	},
 /area/almayer/hull/lower_hull/l_f_s)
+"rxy" = (
+/obj/structure/machinery/power/apc/almayer/hardened{
+	dir = 4
+	},
+/turf/open/floor/almayer,
+/area/almayer/lifeboat_pumps/south2)
 "rxG" = (
 /obj/structure/sign/safety/medical{
 	pixel_x = 8;
@@ -63579,8 +63589,9 @@
 	},
 /area/almayer/command/cichallway)
 "rBH" = (
-/obj/structure/prop/resource_node,
-/obj/structure/blocker/invisible_wall,
+/obj/structure/machinery/constructable_frame{
+	icon_state = "box_2"
+	},
 /turf/open/floor/almayer{
 	icon_state = "mono"
 	},
@@ -64803,6 +64814,15 @@
 	icon_state = "ai_floors"
 	},
 /area/almayer/command/airoom)
+"sdk" = (
+/obj/structure/machinery/power/apc/almayer/hardened{
+	dir = 4
+	},
+/turf/open/floor/almayer{
+	dir = 5;
+	icon_state = "red"
+	},
+/area/almayer/lifeboat_pumps/north1)
 "sdl" = (
 /obj/structure/surface/rack{
 	density = 0;
@@ -103837,8 +103857,8 @@ add
 auJ
 aHU
 aTm
-abs
-aok
+awW
+aTm
 jgF
 auJ
 add
@@ -103883,7 +103903,7 @@ aJU
 lqZ
 ouQ
 iun
-tQV
+baw
 vPm
 qys
 lqZ
@@ -104446,7 +104466,7 @@ add
 auJ
 aHU
 aTm
-abs
+awW
 aTm
 jgF
 auJ
@@ -104492,7 +104512,7 @@ aJU
 lqZ
 ouQ
 vbB
-tQV
+baw
 tBq
 qys
 lqZ
@@ -105665,7 +105685,7 @@ oGC
 ryG
 aVL
 bBl
-aeZ
+sdk
 pzy
 oGC
 awW
@@ -105712,7 +105732,7 @@ aJU
 bnZ
 cIe
 jez
-aJU
+fVc
 baw
 baw
 baw
@@ -121091,7 +121111,7 @@ aeC
 asV
 ayn
 atr
-abh
+aeA
 aex
 ciw
 asV
@@ -121139,7 +121159,7 @@ vcE
 mMu
 iMx
 tGi
-uOi
+lJY
 bXe
 eyG
 mMu
@@ -121700,7 +121720,7 @@ aeC
 asV
 ayn
 atr
-abh
+aeA
 bXz
 ciw
 asV
@@ -121748,7 +121768,7 @@ vcE
 mMu
 iMx
 bXe
-uOi
+lJY
 mzF
 eyG
 mMu
@@ -122559,7 +122579,7 @@ uxC
 lJY
 lJY
 fFe
-lJY
+rxy
 lJY
 lJY
 vcE
@@ -123117,7 +123137,7 @@ aad
 aag
 aag
 abh
-aeC
+aok
 atu
 azU
 aeC

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -1116,8 +1116,8 @@
 	pixel_y = -9
 	},
 /obj/item/stock_parts/scanning_module/adv{
-	pixel_y = 15;
-	pixel_x = 4
+	pixel_x = 4;
+	pixel_y = 15
 	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
@@ -1190,9 +1190,9 @@
 /area/almayer/lifeboat_pumps/north1)
 "adR" = (
 /obj/structure/machinery/door/airlock/almayer/generic{
+	access_modified = 1;
 	name = "\improper Pilot's Office";
-	req_one_access_txt = "3;22;19";
-	access_modified = 1
+	req_one_access_txt = "3;22;19"
 	},
 /obj/structure/machinery/door/firedoor/border_only/almayer{
 	dir = 8
@@ -1336,11 +1336,12 @@
 /turf/open/floor/wood/ship,
 /area/almayer/living/commandbunks)
 "aex" = (
-/turf/open/floor/almayer{
-	dir = 6;
-	icon_state = "red"
+/obj/item/reagent_container/food/drinks/cans/beer{
+	pixel_x = 6;
+	pixel_y = 12
 	},
-/area/almayer/shipboard/starboard_missiles)
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/lifeboat_pumps/north2)
 "aey" = (
 /obj/structure/machinery/alarm/almayer{
 	dir = 1
@@ -1378,9 +1379,9 @@
 /area/almayer/lifeboat_pumps/north2)
 "aeD" = (
 /obj/structure/machinery/door/airlock/almayer/maint/reinforced{
+	access_modified = 1;
 	req_one_access = null;
-	req_one_access_txt = "2;7";
-	access_modified = 1
+	req_one_access_txt = "2;7"
 	},
 /obj/structure/machinery/door/poddoor/almayer/open{
 	dir = 4;
@@ -1863,11 +1864,11 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/machinery/door/airlock/almayer/security/glass/reinforced{
+	access_modified = 1;
 	dir = 1;
 	name = "\improper Particle Cannon Systems Room";
 	req_access = null;
-	req_one_access_txt = "3;19";
-	access_modified = 1
+	req_one_access_txt = "3;19"
 	},
 /obj/structure/machinery/door/firedoor/border_only/almayer{
 	dir = 2
@@ -1935,10 +1936,10 @@
 /area/almayer/living/starboard_garden)
 "agi" = (
 /obj/structure/machinery/door/airlock/almayer/maint{
+	access_modified = 1;
 	req_access = null;
 	req_one_access = null;
-	req_one_access_txt = "3;22;19";
-	access_modified = 1
+	req_one_access_txt = "3;22;19"
 	},
 /obj/structure/machinery/door/poddoor/almayer/open{
 	dir = 4;
@@ -1956,12 +1957,6 @@
 /obj/effect/step_trigger/clone_cleaner,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/hallways/aft_hallway)
-"agm" = (
-/obj/structure/closet/firecloset,
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
 /area/almayer/hallways/aft_hallway)
 "agn" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
@@ -2138,6 +2133,7 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/upper_hull/u_f_s)
 "agV" = (
@@ -2161,10 +2157,10 @@
 "aha" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer,
 /obj/structure/machinery/door/airlock/almayer/command/reinforced{
+	access_modified = 1;
 	name = "\improper Commanding Officer's Quarters";
 	req_access = null;
-	req_access_txt = "31";
-	access_modified = 1
+	req_access_txt = "31"
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -2186,11 +2182,11 @@
 /area/almayer/living/cafeteria_officer)
 "ahd" = (
 /obj/structure/machinery/door/airlock/almayer/maint{
+	access_modified = 1;
 	dir = 1;
 	req_access = null;
 	req_one_access = null;
-	req_one_access_txt = "3;22;19";
-	access_modified = 1
+	req_one_access_txt = "3;22;19"
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -2375,12 +2371,6 @@
 /obj/structure/window/framed/almayer/hull,
 /turf/open/floor/plating,
 /area/almayer/hull/upper_hull/u_f_s)
-"ahF" = (
-/obj/structure/closet/emcloset,
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/hallways/aft_hallway)
 "ahG" = (
 /obj/structure/machinery/door/airlock/almayer/engineering{
 	dir = 2;
@@ -2520,9 +2510,9 @@
 "aib" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer,
 /obj/structure/machinery/door/airlock/almayer/maint/reinforced{
+	access_modified = 1;
 	req_one_access = null;
-	req_one_access_txt = "7;19";
-	access_modified = 1
+	req_one_access_txt = "7;19"
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -2683,6 +2673,13 @@
 "aiw" = (
 /turf/open/floor/almayer,
 /area/almayer/engineering/starboard_atmos)
+"aiy" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 3
+	},
+/turf/open/floor/almayer,
+/area/almayer/hallways/starboard_hallway)
 "aiz" = (
 /obj/structure/closet,
 /obj/item/clothing/under/marine,
@@ -3139,6 +3136,7 @@
 /area/almayer/hull/upper_hull/u_a_s)
 "ake" = (
 /obj/structure/largecrate/random/barrel/white,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -3151,25 +3149,21 @@
 	},
 /area/almayer/shipboard/weapon_room)
 "akk" = (
-/obj/structure/window/reinforced/tinted/frosted,
-/obj/structure/mirror{
-	pixel_x = -28
+/obj/structure/machinery/door/window/westright{
+	dir = 4
 	},
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
+/obj/structure/machinery/shower{
+	dir = 4
 	},
-/turf/open/floor/almayer{
-	icon_state = "sterile"
-	},
+/obj/structure/window/reinforced,
+/turf/open/floor/plating/plating_catwalk,
 /area/almayer/living/commandbunks)
 "akl" = (
 /obj/structure/machinery/light{
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	icon_state = "sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/living/commandbunks)
 "akm" = (
@@ -3450,14 +3444,16 @@
 	},
 /area/almayer/living/starboard_garden)
 "alb" = (
-/obj/structure/machinery/door/window/westright{
-	dir = 4
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
 	},
-/obj/structure/machinery/shower{
-	dir = 4
+/obj/structure/mirror{
+	pixel_x = -28
 	},
 /turf/open/floor/almayer{
-	icon_state = "plate"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/living/commandbunks)
 "alc" = (
@@ -3465,7 +3461,7 @@
 	dir = 8
 	},
 /turf/open/floor/almayer{
-	icon_state = "sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/living/commandbunks)
 "ald" = (
@@ -3717,10 +3713,27 @@
 	},
 /area/almayer/command/cic)
 "amb" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	health = 80
+	},
+/obj/structure/window/reinforced{
+	dir = 4;
+	health = 80
+	},
+/obj/structure/machinery/shower{
+	dir = 1
+	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/living/pilotbunks)
 "amd" = (
-/turf/open/floor/almayer,
+/obj/structure/machinery/vending/cola{
+	density = 0;
+	pixel_y = 16
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
 /area/almayer/living/pilotbunks)
 "amg" = (
 /turf/open/floor/plating/plating_catwalk,
@@ -3951,7 +3964,11 @@
 	pixel_x = -17;
 	pixel_y = 7
 	},
-/obj/structure/machinery/cm_vending/clothing/pilot_officer,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/structure/machinery/disposal,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -3972,7 +3989,17 @@
 	},
 /area/almayer/hallways/aft_hallway)
 "and" = (
-/obj/effect/landmark/yautja_teleport,
+/obj/structure/window/reinforced{
+	dir = 4;
+	health = 80
+	},
+/obj/structure/window/reinforced{
+	dir = 8;
+	health = 80
+	},
+/obj/structure/machinery/shower{
+	dir = 1
+	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/living/pilotbunks)
 "anf" = (
@@ -4321,13 +4348,11 @@
 /turf/open/floor/almayer,
 /area/almayer/shipboard/navigation)
 "aok" = (
-/obj/structure/surface/table/almayer,
-/obj/structure/machinery/computer/emails,
-/turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "red"
+/obj/structure/machinery/power/apc/almayer/hardened{
+	dir = 1
 	},
-/area/almayer/shipboard/starboard_missiles)
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/lifeboat_pumps/north1)
 "aol" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -4743,11 +4768,9 @@
 /turf/open/floor/almayer,
 /area/almayer/hallways/port_hallway)
 "apq" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
-	icon_state = "cargo"
+	icon_state = "plate"
 	},
 /area/almayer/living/pilotbunks)
 "apr" = (
@@ -4774,7 +4797,9 @@
 /obj/structure/machinery/power/apc/almayer{
 	dir = 1
 	},
-/turf/open/floor/almayer,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
 /area/almayer/living/pilotbunks)
 "apu" = (
 /turf/open/floor/almayer{
@@ -4902,8 +4927,8 @@
 	dir = 1
 	},
 /obj/structure/pipes/vents/pump/no_boom{
-	welded = 1;
-	name = "Secure Reinforced Air Vent"
+	name = "Secure Reinforced Air Vent";
+	welded = 1
 	},
 /turf/open/floor/almayer{
 	icon_state = "sterile_green"
@@ -5139,9 +5164,11 @@
 /turf/open/floor/almayer,
 /area/almayer/shipboard/weapon_room)
 "aqw" = (
-/obj/structure/machinery/cm_vending/clothing/pilot_officer,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/almayer{
-	icon_state = "plate"
+	icon_state = "mono"
 	},
 /area/almayer/living/pilotbunks)
 "aqx" = (
@@ -5158,16 +5185,16 @@
 	},
 /area/almayer/hallways/starboard_hallway)
 "aqy" = (
-/obj/structure/machinery/camera/autoname/almayer{
-	dir = 8;
-	name = "ship-grade camera";
-	pixel_x = 27;
-	pixel_y = -27
-	},
 /obj/structure/pipes/standard/manifold/hidden/supply{
 	dir = 4
 	},
-/turf/open/floor/almayer,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/almayer{
+	icon_state = "mono"
+	},
 /area/almayer/living/pilotbunks)
 "aqz" = (
 /obj/structure/machinery/door/airlock/almayer/generic{
@@ -5647,18 +5674,20 @@
 /area/almayer/command/cic)
 "ase" = (
 /turf/open/floor/almayer{
-	icon_state = "sterile"
+	icon_state = "cargo"
 	},
 /area/almayer/living/pilotbunks)
 "asf" = (
-/obj/structure/machinery/shower{
-	dir = 8
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
 	},
-/obj/structure/window/reinforced/tinted/frosted,
-/obj/structure/machinery/door/window/westright,
-/obj/item/tool/soap,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
+	},
 /turf/open/floor/almayer{
-	icon_state = "plate"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/living/pilotbunks)
 "asi" = (
@@ -5841,10 +5870,10 @@
 /area/almayer/engineering/engineering_workshop/hangar)
 "asF" = (
 /obj/structure/machinery/door/airlock/almayer/secure/reinforced{
+	access_modified = 1;
 	name = "\improper AI Reception";
 	req_access = null;
-	req_one_access_txt = "91;92";
-	access_modified = 1
+	req_one_access_txt = "91;92"
 	},
 /turf/open/floor/almayer/no_build{
 	icon_state = "ai_floors"
@@ -6219,11 +6248,11 @@
 /area/almayer/hull/upper_hull/u_a_s)
 "atA" = (
 /obj/structure/machinery/door/airlock/almayer/maint/reinforced{
+	access_modified = 1;
 	dir = 1;
 	name = "\improper Spare Bomb Suit";
 	req_one_access = null;
-	req_one_access_txt = "35";
-	access_modified = 1
+	req_one_access_txt = "35"
 	},
 /turf/open/floor/almayer,
 /area/almayer/engineering/engineering_workshop/hangar)
@@ -6344,24 +6373,19 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/command/cic)
-"atS" = (
-/obj/structure/machinery/light,
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/turf/open/floor/almayer{
-	icon_state = "sterile"
-	},
-/area/almayer/living/pilotbunks)
 "atT" = (
 /obj/structure/toilet{
-	dir = 8
+	dir = 1
 	},
-/turf/open/floor/almayer{
-	icon_state = "sterile"
+/obj/structure/window/reinforced{
+	dir = 4;
+	health = 80
 	},
+/obj/structure/window/reinforced{
+	dir = 8;
+	health = 80
+	},
+/turf/open/floor/plating/plating_catwalk,
 /area/almayer/living/pilotbunks)
 "atU" = (
 /obj/structure/machinery/status_display{
@@ -6724,10 +6748,10 @@
 	dir = 2
 	},
 /obj/structure/machinery/door/airlock/almayer/secure/reinforced{
+	access_modified = 1;
 	dir = 2;
 	name = "Telecommunications";
-	req_access_txt = "6";
-	access_modified = 1
+	req_access_txt = "6"
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -6866,12 +6890,11 @@
 	},
 /area/almayer/engineering/engineering_workshop/hangar)
 "auZ" = (
-/obj/structure/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
 /obj/structure/machinery/light,
-/turf/open/floor/almayer,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
 /area/almayer/living/pilotbunks)
 "ava" = (
 /obj/effect/decal/warning_stripes{
@@ -6945,10 +6968,10 @@
 /area/almayer/hallways/aft_hallway)
 "avk" = (
 /obj/structure/machinery/door/airlock/almayer/maint/reinforced{
+	access_modified = 1;
 	dir = 1;
 	req_one_access = null;
-	req_one_access_txt = "35";
-	access_modified = 1
+	req_one_access_txt = "35"
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -7336,7 +7359,9 @@
 /obj/structure/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/almayer,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
 /area/almayer/living/pilotbunks)
 "awt" = (
 /turf/open/floor/almayer{
@@ -7402,11 +7427,11 @@
 /area/almayer/command/cic)
 "awB" = (
 /obj/structure/machinery/door/airlock/almayer/maint{
+	access_modified = 1;
 	dir = 1;
 	name = "\improper Engineering Storage";
 	req_one_access = null;
-	req_one_access_txt = "2;7";
-	access_modified = 1
+	req_one_access_txt = "2;7"
 	},
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer{
@@ -7523,10 +7548,13 @@
 /area/almayer/living/pilotbunks)
 "awZ" = (
 /obj/structure/surface/table/reinforced/almayer_B,
-/obj/structure/machinery/computer/emails{
-	dir = 1
+/obj/item/paper_bin/uscm{
+	pixel_x = 8;
+	pixel_y = 12
 	},
-/turf/open/floor/almayer,
+/turf/open/floor/almayer{
+	icon_state = "bluefull"
+	},
 /area/almayer/living/pilotbunks)
 "axa" = (
 /turf/open/shuttle/dropship{
@@ -8055,12 +8083,11 @@
 	},
 /area/almayer/command/cic)
 "ayP" = (
-/obj/structure/surface/table/reinforced/almayer_B,
-/obj/item/storage/bible,
+/obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer{
-	icon_state = "plate"
+	icon_state = "test_floor4"
 	},
-/area/almayer/living/bridgebunks)
+/area/almayer/hull/upper_hull/u_f_s)
 "ayQ" = (
 /obj/structure/platform_decoration{
 	dir = 4
@@ -8669,11 +8696,11 @@
 /area/almayer/command/cic)
 "aAG" = (
 /obj/structure/machinery/door/airlock/almayer/medical{
+	access_modified = 1;
 	dir = 2;
 	name = "Morgue";
 	req_access_txt = "25";
-	req_one_access = null;
-	access_modified = 1
+	req_one_access = null
 	},
 /obj/structure/machinery/door/firedoor/border_only/almayer{
 	dir = 2
@@ -8814,9 +8841,9 @@
 /area/almayer/medical/containment/cell)
 "aBf" = (
 /obj/structure/machinery/door/airlock/almayer/secure/reinforced{
+	access_modified = 1;
 	name = "Telecommunications";
-	req_access_txt = "6";
-	access_modified = 1
+	req_access_txt = "6"
 	},
 /obj/structure/machinery/door/firedoor/border_only/almayer{
 	dir = 8
@@ -9053,9 +9080,9 @@
 /area/almayer/hull/upper_hull/u_f_p)
 "aBP" = (
 /obj/structure/machinery/door/airlock/almayer/maint/reinforced{
+	access_modified = 1;
 	dir = 1;
-	req_one_access = list(36);
-	access_modified = 1
+	req_one_access = list(36)
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -10070,9 +10097,9 @@
 	name = "\improper Brig Lockdown Shutter"
 	},
 /obj/structure/machinery/door/airlock/almayer/maint{
+	access_modified = 1;
 	dir = 2;
-	req_one_access = list(2,34,30);
-	access_modified = 1
+	req_one_access = list(2,34,30)
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -10108,6 +10135,16 @@
 	icon_state = "plate"
 	},
 /area/almayer/command/cichallway)
+"aGc" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "E";
+	pixel_x = 2
+	},
+/turf/open/floor/almayer{
+	dir = 5;
+	icon_state = "green"
+	},
+/area/almayer/hallways/port_hallway)
 "aGd" = (
 /turf/open/floor/almayer{
 	dir = 8;
@@ -10312,7 +10349,13 @@
 /obj/structure/mirror{
 	pixel_y = 21
 	},
-/turf/open/floor/almayer,
+/obj/effect/decal/warning_stripes{
+	icon_state = "E";
+	pixel_x = 1
+	},
+/turf/open/floor/almayer{
+	icon_state = "dark_sterile"
+	},
 /area/almayer/living/numbertwobunks)
 "aHl" = (
 /obj/structure/machinery/portable_atmospherics/canister/air,
@@ -10324,9 +10367,7 @@
 	},
 /obj/structure/machinery/door/window/westleft,
 /obj/structure/window/reinforced/tinted/frosted,
-/turf/open/floor/almayer{
-	icon_state = "mono"
-	},
+/turf/open/floor/plating/plating_catwalk,
 /area/almayer/living/numbertwobunks)
 "aHo" = (
 /obj/structure/machinery/computer/working_joe{
@@ -10380,12 +10421,12 @@
 	pixel_y = 1
 	},
 /obj/structure/machinery/door/airlock/almayer/maint/reinforced{
+	access_modified = 1;
 	dir = 1;
 	name = "\improper Engineering Storage";
 	no_panel = 1;
 	req_one_access = null;
-	req_one_access_txt = "2;7";
-	access_modified = 1
+	req_one_access_txt = "2;7"
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -10400,12 +10441,12 @@
 	pixel_y = 1
 	},
 /obj/structure/machinery/door/airlock/almayer/maint/reinforced{
+	access_modified = 1;
 	dir = 1;
 	name = "\improper Engineering Storage";
 	no_panel = 1;
 	req_one_access = null;
-	req_one_access_txt = "2;7";
-	access_modified = 1
+	req_one_access_txt = "2;7"
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -10491,13 +10532,12 @@
 	},
 /area/almayer/living/numbertwobunks)
 "aHY" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 4
+/obj/structure/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
 	},
-/obj/structure/machinery/disposal,
 /turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "red"
+	icon_state = "cargo"
 	},
 /area/almayer/shipboard/starboard_missiles)
 "aHZ" = (
@@ -10655,10 +10695,10 @@
 "aIQ" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer,
 /obj/structure/machinery/door/airlock/almayer/command/reinforced{
+	access_modified = 1;
 	name = "\improper XO's Quarters";
 	req_access = null;
-	req_access_txt = "1";
-	access_modified = 1
+	req_access_txt = "1"
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -10683,10 +10723,10 @@
 	dir = 2
 	},
 /obj/structure/machinery/door/airlock/almayer/secure/reinforced{
+	access_modified = 1;
 	dir = 2;
 	name = "Telecommunications";
-	req_access_txt = "6";
-	access_modified = 1
+	req_access_txt = "6"
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -11135,19 +11175,28 @@
 	},
 /area/almayer/command/cic)
 "aKG" = (
-/obj/structure/surface/table/almayer,
-/obj/item/tool/extinguisher,
-/obj/item/tool/crowbar,
-/turf/open/floor/almayer,
-/area/almayer/living/pilotbunks)
-"aKH" = (
-/obj/structure/janitorialcart,
-/obj/item/tool/mop,
-/obj/structure/machinery/light/small{
-	dir = 1
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
 	},
 /turf/open/floor/almayer{
-	icon_state = "cargo"
+	icon_state = "dark_sterile"
+	},
+/area/almayer/living/pilotbunks)
+"aKH" = (
+/obj/structure/machinery/light{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
+	},
+/turf/open/floor/almayer{
+	icon_state = "dark_sterile"
 	},
 /area/almayer/living/pilotbunks)
 "aKI" = (
@@ -11267,14 +11316,24 @@
 	pixel_x = 8;
 	pixel_y = -26
 	},
-/obj/structure/surface/rack,
-/turf/open/floor/almayer,
+/obj/effect/decal/warning_stripes{
+	icon_state = "NE-out";
+	pixel_x = 1;
+	pixel_y = 1
+	},
+/turf/open/floor/almayer{
+	icon_state = "dark_sterile"
+	},
 /area/almayer/living/numbertwobunks)
 "aLt" = (
-/obj/structure/toilet{
-	dir = 8
+/obj/structure/surface/rack,
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 1
 	},
-/turf/open/floor/almayer,
+/turf/open/floor/almayer{
+	icon_state = "dark_sterile"
+	},
 /area/almayer/living/numbertwobunks)
 "aLB" = (
 /turf/closed/wall/almayer,
@@ -12046,7 +12105,7 @@
 "aPm" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/almayer{
-	icon_state = "mono"
+	icon_state = "cargo"
 	},
 /area/almayer/hallways/aft_hallway)
 "aPn" = (
@@ -12228,6 +12287,8 @@
 "aQs" = (
 /obj/structure/surface/table/almayer,
 /obj/item/tool/extinguisher,
+/obj/item/tool/extinguisher,
+/obj/item/tool/crowbar,
 /turf/open/floor/almayer{
 	dir = 10;
 	icon_state = "orange"
@@ -12500,11 +12561,11 @@
 /area/almayer/living/captain_mess)
 "aRF" = (
 /obj/structure/machinery/door/airlock/almayer/medical{
+	access_modified = 1;
 	dir = 2;
 	name = "Morgue Processing";
 	req_access_txt = "25";
-	req_one_access = null;
-	access_modified = 1
+	req_one_access = null
 	},
 /obj/structure/machinery/door/firedoor/border_only/almayer{
 	dir = 2
@@ -12648,15 +12709,14 @@
 /area/almayer/medical/hydroponics)
 "aSo" = (
 /obj/effect/decal/warning_stripes{
-	icon_state = "SE-out";
-	pixel_x = 1
-	},
-/obj/effect/decal/warning_stripes{
 	icon_state = "SW-out";
 	pixel_x = -1
 	},
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/medical/hydroponics)
@@ -13851,10 +13911,6 @@
 	},
 /area/almayer/hallways/hangar)
 "aYz" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "N";
-	pixel_y = 1
-	},
 /obj/structure/closet/firecloset,
 /turf/open/floor/almayer{
 	icon_state = "cargo"
@@ -14258,6 +14314,9 @@
 	pixel_x = 8;
 	pixel_y = -32
 	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "SW-out"
+	},
 /turf/open/floor/almayer,
 /area/almayer/hallways/starboard_hallway)
 "bat" = (
@@ -14597,17 +14656,13 @@
 	},
 /area/almayer/hallways/starboard_hallway)
 "bbV" = (
-/obj/structure/largecrate/random/secure,
-/obj/item/reagent_container/food/drinks/cans/beer{
-	pixel_x = 6;
-	pixel_y = 12
+/obj/structure/machinery/light{
+	dir = 8
 	},
-/turf/open/floor/almayer{
-	icon_state = "mono"
-	},
-/area/almayer/lifeboat_pumps/north2)
+/turf/open/floor/almayer,
+/area/almayer/shipboard/starboard_missiles)
 "bbX" = (
-/obj/structure/machinery/constructable_frame,
+/obj/structure/resource_node,
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/almayer{
 	icon_state = "mono"
@@ -14620,11 +14675,11 @@
 	},
 /area/almayer/squads/alpha)
 "bbZ" = (
-/obj/structure/machinery/constructable_frame,
-/turf/open/floor/almayer{
-	icon_state = "mono"
+/obj/structure/bed/chair{
+	dir = 1
 	},
-/area/almayer/lifeboat_pumps/north2)
+/turf/open/floor/almayer,
+/area/almayer/shipboard/starboard_missiles)
 "bca" = (
 /obj/structure/machinery/cm_vending/gear/smartgun,
 /obj/structure/sign/safety/hazard{
@@ -15446,6 +15501,13 @@
 	icon_state = "plate"
 	},
 /area/almayer/hallways/hangar)
+"bfP" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer,
+/area/almayer/hull/upper_hull/u_f_p)
 "bfV" = (
 /obj/structure/machinery/landinglight/ds2{
 	dir = 8
@@ -15863,11 +15925,11 @@
 /area/almayer/hallways/aft_hallway)
 "biu" = (
 /obj/structure/machinery/door/airlock/almayer/medical/glass{
+	access_modified = 1;
 	dir = 2;
 	name = "\improper Chemistry Laboratory";
 	req_access_txt = "20";
-	req_one_access = null;
-	access_modified = 1
+	req_one_access = null
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/pipes/standard/simple/hidden/supply,
@@ -16148,11 +16210,11 @@
 	dir = 2
 	},
 /obj/structure/machinery/door/airlock/almayer/medical/glass{
+	access_modified = 1;
 	dir = 2;
 	name = "\improper Nurse Office";
 	req_access_txt = "20";
-	req_one_access = null;
-	access_modified = 1
+	req_one_access = null
 	},
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer{
@@ -16353,11 +16415,11 @@
 /area/almayer/living/offices)
 "blq" = (
 /obj/structure/machinery/door/airlock/almayer/security/glass{
+	access_modified = 1;
 	dir = 2;
 	name = "Firing Range";
 	req_access = null;
-	req_one_access_txt = "2;4;7;9;21";
-	access_modified = 1
+	req_one_access_txt = "2;4;7;9;21"
 	},
 /obj/structure/machinery/door/firedoor/border_only/almayer{
 	dir = 1
@@ -17086,11 +17148,11 @@
 	dir = 2
 	},
 /obj/structure/machinery/door/airlock/almayer/security/glass/reinforced{
+	access_modified = 1;
 	dir = 1;
 	name = "\improper Particle Cannon Systems Room";
 	req_access = null;
-	req_one_access_txt = "3;19";
-	access_modified = 1
+	req_one_access_txt = "3;19"
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -17323,9 +17385,9 @@
 	},
 /area/almayer/hallways/hangar)
 "bqG" = (
-/obj/structure/largecrate/supply/supplies/flares,
 /turf/open/floor/almayer{
-	icon_state = "plate"
+	dir = 6;
+	icon_state = "silver"
 	},
 /area/almayer/hull/upper_hull/u_m_p)
 "bqH" = (
@@ -18221,7 +18283,7 @@
 /turf/open/floor/wood/ship,
 /area/almayer/command/corporateliason)
 "bvd" = (
-/obj/structure/machinery/constructable_frame,
+/obj/structure/resource_node,
 /turf/open/floor/almayer{
 	icon_state = "mono"
 	},
@@ -18240,10 +18302,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/hangar)
 "bvl" = (
-/obj/structure/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer,
 /area/almayer/command/corporateliason)
 "bvr" = (
@@ -18328,6 +18387,10 @@
 	},
 /area/almayer/hallways/starboard_umbilical)
 "bvU" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "SE-out";
+	pixel_x = 1
+	},
 /obj/structure/machinery/door/airlock/almayer/generic{
 	dir = 2;
 	name = "\improper Liasion's Bathroom"
@@ -18800,18 +18863,13 @@
 /obj/structure/bed/chair/office/dark{
 	dir = 8
 	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "S"
-	},
 /turf/open/floor/almayer,
 /area/almayer/command/corporateliason)
 "byq" = (
 /obj/structure/machinery/light{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "S"
-	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer,
 /area/almayer/command/corporateliason)
 "byr" = (
@@ -18992,19 +19050,18 @@
 /obj/structure/machinery/door/window/westright,
 /obj/structure/window/reinforced/tinted/frosted,
 /obj/item/tool/soap/deluxe,
-/turf/open/floor/almayer{
-	icon_state = "dark_sterile"
-	},
+/turf/open/floor/plating/plating_catwalk,
 /area/almayer/command/corporateliason)
 "bzy" = (
 /turf/closed/wall/almayer,
 /area/almayer/hallways/vehiclehangar)
 "bzz" = (
-/obj/item/stack/sheet/metal,
-/turf/open/floor/almayer{
-	icon_state = "mono"
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
-/area/almayer/lifeboat_pumps/north1)
+/obj/structure/machinery/disposal,
+/turf/open/floor/almayer,
+/area/almayer/shipboard/starboard_missiles)
 "bzA" = (
 /turf/open/floor/almayer{
 	icon_state = "plate"
@@ -19309,7 +19366,7 @@
 "bAX" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/almayer{
-	icon_state = "plate"
+	icon_state = "cargo"
 	},
 /area/almayer/hallways/starboard_hallway)
 "bAY" = (
@@ -19577,11 +19634,11 @@
 	dir = 2
 	},
 /obj/structure/machinery/door/airlock/almayer/security{
+	access_modified = 1;
 	dir = 2;
 	name = "\improper Security Checkpoint";
 	req_access = null;
-	req_one_access_txt = "3;19";
-	access_modified = 1
+	req_one_access_txt = "3;19"
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -19887,10 +19944,10 @@
 /area/almayer/hallways/hangar)
 "bDL" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/almayer{
+	access_modified = 1;
 	dir = 1;
 	name = "\improper Auxiliary Combat Support Secondary Preparations";
-	req_one_access = "19;27;22";
-	access_modified = 1
+	req_one_access = "19;27;22"
 	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
@@ -20802,11 +20859,11 @@
 	},
 /obj/structure/pipes/standard/simple/hidden/supply,
 /obj/structure/machinery/door/airlock/almayer/security/glass/reinforced{
+	access_modified = 1;
 	dir = 1;
 	name = "\improper Particle Cannon Systems Room";
 	req_access = null;
-	req_one_access_txt = "3;19";
-	access_modified = 1
+	req_one_access_txt = "3;19"
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -21076,9 +21133,9 @@
 "bIu" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer,
 /obj/structure/machinery/door/airlock/almayer/generic{
+	access_modified = 1;
 	name = "Storage";
-	req_one_access = "2;21";
-	access_modified = 1
+	req_one_access = "2;21"
 	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
@@ -21274,10 +21331,10 @@
 /area/almayer/engineering/lower_engineering)
 "bJl" = (
 /obj/structure/machinery/door/airlock/almayer/generic{
+	access_modified = 1;
 	dir = 1;
 	name = "\improper Auxiliary Support Officers Quarters";
-	req_one_access_txt = "37";
-	access_modified = 1
+	req_one_access_txt = "37"
 	},
 /obj/structure/pipes/standard/simple/hidden/supply,
 /obj/structure/machinery/door/firedoor/border_only/almayer{
@@ -21462,11 +21519,11 @@
 	},
 /obj/structure/pipes/standard/simple/hidden/supply,
 /obj/structure/machinery/door/airlock/almayer/security/glass/reinforced{
+	access_modified = 1;
 	dir = 1;
 	name = "\improper Particle Cannon Systems Room";
 	req_access = null;
-	req_one_access_txt = "7;19";
-	access_modified = 1
+	req_one_access_txt = "7;19"
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -24639,6 +24696,9 @@
 /area/almayer/command/corporateliason)
 "bXz" = (
 /obj/effect/decal/cleanable/blood/oil,
+/obj/structure/machinery/power/apc/almayer/hardened{
+	dir = 1
+	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/lifeboat_pumps/north2)
 "bXH" = (
@@ -24981,12 +25041,6 @@
 	},
 /area/almayer/command/cic)
 "bZa" = (
-/obj/structure/machinery/door/airlock/almayer/generic{
-	dir = 1;
-	name = "\improper Flight Crew Quarters";
-	req_one_access_txt = "19;22";
-	access_modified = 1
-	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/machinery/door/firedoor/border_only/almayer{
 	dir = 2
@@ -25009,16 +25063,12 @@
 	},
 /area/almayer/lifeboat_pumps/north1)
 "bZg" = (
-/obj/structure/machinery/door/airlock/almayer/maint{
-	dir = 1
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 9
 	},
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 2
-	},
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/living/pilotbunks)
+/obj/structure/machinery/light,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/upper_hull/u_f_s)
 "bZi" = (
 /obj/structure/largecrate/random/case/double,
 /turf/open/floor/almayer{
@@ -25258,11 +25308,11 @@
 "cau" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/machinery/door/airlock/almayer/security/glass{
+	access_modified = 1;
 	dir = 2;
 	name = "Firing Range";
 	req_access = null;
-	req_one_access_txt = "2;4;7;9;21";
-	access_modified = 1
+	req_one_access_txt = "2;4;7;9;21"
 	},
 /obj/structure/machinery/door/firedoor/border_only/almayer{
 	dir = 1
@@ -25637,6 +25687,10 @@
 /obj/structure/sign/safety/storage{
 	pixel_y = 32
 	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "NW-out";
+	pixel_y = 3
+	},
 /turf/open/floor/almayer,
 /area/almayer/hallways/port_hallway)
 "cbW" = (
@@ -25675,17 +25729,6 @@
 	icon_state = "red"
 	},
 /area/almayer/living/cryo_cells)
-"ccc" = (
-/obj/structure/sign/safety/bathunisex{
-	pixel_x = 8;
-	pixel_y = 25
-	},
-/obj/structure/sign/safety/bathunisex{
-	pixel_x = 8;
-	pixel_y = -25
-	},
-/turf/open/floor/almayer,
-/area/almayer/living/pilotbunks)
 "ccd" = (
 /obj/structure/machinery/cm_vending/sorted/cargo_guns/squad_prep,
 /turf/open/floor/almayer{
@@ -26308,12 +26351,22 @@
 	},
 /area/almayer/hallways/repair_bay)
 "ceZ" = (
-/obj/structure/bed/sofa/south,
+/obj/structure/bed/sofa/south/grey/left,
 /turf/open/floor/almayer{
 	dir = 9;
 	icon_state = "silver"
 	},
 /area/almayer/shipboard/brig/cic_hallway)
+"cfk" = (
+/obj/structure/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/port_missiles)
 "cfo" = (
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/squads/charlie)
@@ -27681,10 +27734,10 @@
 	},
 /obj/structure/machinery/door/firedoor/border_only/almayer,
 /obj/structure/machinery/door/airlock/almayer/security/reinforced{
+	access_modified = 1;
 	name = "\improper Astronavigational Deck";
 	req_access = null;
-	req_one_access_txt = "3;19";
-	access_modified = 1
+	req_one_access_txt = "3;19"
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -27693,10 +27746,10 @@
 "cmJ" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer,
 /obj/structure/machinery/door/airlock/almayer/security/reinforced{
+	access_modified = 1;
 	name = "\improper Astronavigational Deck";
 	req_access = null;
-	req_one_access_txt = "3;19";
-	access_modified = 1
+	req_one_access_txt = "3;19"
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -28479,6 +28532,7 @@
 	pixel_x = 8;
 	pixel_y = -32
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer,
 /area/almayer/hull/upper_hull/u_f_p)
 "czM" = (
@@ -28995,7 +29049,10 @@
 /obj/structure/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/almayer,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
 /area/almayer/living/pilotbunks)
 "cJB" = (
 /obj/structure/machinery/vending/coffee,
@@ -29438,11 +29495,6 @@
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 1
 	},
-/obj/structure/machinery/door/airlock/almayer/medical/glass{
-	dir = 2;
-	name = "\improper Port Viewing Room";
-	req_one_access = null
-	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
 	},
@@ -29748,14 +29800,19 @@
 	},
 /area/almayer/shipboard/brig/surgery)
 "dav" = (
-/obj/structure/machinery/constructable_frame{
-	icon_state = "box_2"
+/obj/structure/machinery/door/poddoor/almayer/open{
+	id = "Brig Lockdown Shutters";
+	name = "\improper Brig Lockdown Shutter"
 	},
-/obj/effect/decal/cleanable/blood/oil/streak,
+/obj/structure/machinery/door/airlock/almayer/maint{
+	access_modified = 1;
+	dir = 2;
+	req_one_access = list(2,34,30)
+	},
 /turf/open/floor/almayer{
-	icon_state = "mono"
+	icon_state = "plate"
 	},
-/area/almayer/lifeboat_pumps/south1)
+/area/almayer/hull/upper_hull/u_f_s)
 "daz" = (
 /turf/closed/wall/almayer/white/hull,
 /area/almayer/command/airoom)
@@ -30058,10 +30115,6 @@
 	pixel_y = 3
 	},
 /obj/item/device/camera,
-/obj/effect/decal/warning_stripes{
-	icon_state = "SE-out";
-	pixel_x = 1
-	},
 /turf/open/floor/almayer,
 /area/almayer/command/corporateliason)
 "dhR" = (
@@ -30077,8 +30130,7 @@
 "dhU" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/almayer{
-	dir = 5;
-	icon_state = "green"
+	icon_state = "cargo"
 	},
 /area/almayer/hallways/port_hallway)
 "dhZ" = (
@@ -31194,6 +31246,7 @@
 /obj/structure/machinery/light/small{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -31306,6 +31359,12 @@
 	icon_state = "plate"
 	},
 /area/almayer/hull/lower_hull/l_f_p)
+"dGc" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/upper_hull/u_f_p)
 "dGl" = (
 /obj/effect/step_trigger/teleporter_vector{
 	name = "Almayer_AresUp";
@@ -31327,7 +31386,10 @@
 /obj/structure/pipes/vents/scrubber{
 	dir = 8
 	},
-/turf/open/floor/almayer,
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "blue"
+	},
 /area/almayer/living/pilotbunks)
 "dGw" = (
 /obj/effect/step_trigger/clone_cleaner,
@@ -31373,11 +31435,11 @@
 /area/almayer/shipboard/brig/processing)
 "dGW" = (
 /obj/structure/machinery/door/airlock/almayer/security{
+	access_modified = 1;
 	dir = 2;
 	name = "\improper Security Checkpoint";
 	req_access = null;
-	req_one_access_txt = "3;19";
-	access_modified = 1
+	req_one_access_txt = "3;19"
 	},
 /obj/structure/machinery/door/firedoor/border_only/almayer{
 	dir = 2
@@ -31857,6 +31919,10 @@
 	pixel_y = 6;
 	serial_number = 12
 	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "E";
+	pixel_x = 1
+	},
 /turf/open/floor/almayer{
 	icon_state = "dark_sterile"
 	},
@@ -31896,16 +31962,25 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_f_s)
 "dUI" = (
-/turf/open/floor/almayer{
-	dir = 9;
-	icon_state = "red"
+/obj/structure/machinery/door/airlock/multi_tile/almayer/generic{
+	name = "\improper Port Viewing Room"
 	},
-/area/almayer/shipboard/port_missiles)
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/hull/upper_hull/u_f_s)
 "dUS" = (
 /turf/open/floor/almayer{
 	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/operating_room_two)
+"dUZ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer{
+	dir = 10;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/port_missiles)
 "dVd" = (
 /obj/structure/machinery/seed_extractor{
 	density = 0;
@@ -32056,7 +32131,10 @@
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
 	},
-/turf/open/floor/almayer,
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "blue"
+	},
 /area/almayer/living/pilotbunks)
 "dYh" = (
 /obj/structure/machinery/power/apc/almayer{
@@ -32547,6 +32625,14 @@
 /obj/effect/landmark/late_join/alpha,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/squads/alpha)
+"ehH" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "NE-out";
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hallways/starboard_hallway)
 "ehR" = (
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -32684,7 +32770,7 @@
 "ejp" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/almayer{
-	icon_state = "mono"
+	icon_state = "cargo"
 	},
 /area/almayer/hallways/aft_hallway)
 "ejt" = (
@@ -32732,6 +32818,17 @@
 "eky" = (
 /turf/open/floor/almayer,
 /area/almayer/command/lifeboat)
+"ekO" = (
+/obj/structure/machinery/cryopod{
+	pixel_y = 6
+	},
+/obj/structure/sign/safety/cryo{
+	pixel_x = -17
+	},
+/turf/open/floor/almayer{
+	icon_state = "cargo"
+	},
+/area/almayer/hull/upper_hull/u_m_p)
 "ekY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -32761,6 +32858,7 @@
 /obj/structure/machinery/light{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer,
 /area/almayer/shipboard/brig/cic_hallway)
 "elq" = (
@@ -33258,17 +33356,12 @@
 /area/almayer/living/basketball)
 "evg" = (
 /obj/structure/surface/table/reinforced/almayer_B,
-/obj/item/clipboard{
-	pixel_x = -6
+/obj/structure/machinery/computer/emails{
+	dir = 1
 	},
-/obj/item/tool/pen/blue{
-	pixel_x = -6
+/turf/open/floor/almayer{
+	icon_state = "bluefull"
 	},
-/obj/item/paper_bin/uscm{
-	pixel_x = 8;
-	pixel_y = 12
-	},
-/turf/open/floor/almayer,
 /area/almayer/living/pilotbunks)
 "evk" = (
 /obj/structure/surface/rack,
@@ -33949,12 +34042,17 @@
 /obj/structure/mirror{
 	pixel_x = 28
 	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 2
+	},
 /turf/open/floor/almayer{
 	icon_state = "dark_sterile"
 	},
 /area/almayer/command/corporateliason)
 "eKM" = (
 /obj/structure/surface/rack,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -35037,10 +35135,10 @@
 /area/almayer/living/briefing)
 "fmf" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/almayer/glass{
+	access_modified = 1;
 	dir = 2;
 	name = "\improper Requisitions Break Room";
-	req_one_access = "19;21";
-	access_modified = 1
+	req_one_access = "19;21"
 	},
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -35070,7 +35168,9 @@
 /obj/structure/bed/chair/comfy{
 	dir = 8
 	},
-/turf/open/floor/almayer,
+/turf/open/floor/almayer{
+	icon_state = "bluecorner"
+	},
 /area/almayer/living/pilotbunks)
 "fmS" = (
 /obj/structure/closet/secure_closet/engineering_electrical,
@@ -35101,8 +35201,7 @@
 	dir = 8
 	},
 /turf/open/floor/almayer{
-	dir = 5;
-	icon_state = "plating"
+	icon_state = "redfull"
 	},
 /area/almayer/medical/upper_medical)
 "fnC" = (
@@ -35176,6 +35275,16 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/medical/medical_science)
+"foR" = (
+/obj/structure/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/janitorialcart,
+/obj/item/tool/mop,
+/turf/open/floor/almayer{
+	icon_state = "cargo"
+	},
+/area/almayer/hull/upper_hull/u_f_p)
 "fpd" = (
 /obj/structure/sign/safety/hvac_old{
 	pixel_x = 8;
@@ -35251,6 +35360,17 @@
 /obj/structure/largecrate/random/barrel/red,
 /turf/open/floor/almayer,
 /area/almayer/hull/upper_hull/u_f_s)
+"fqx" = (
+/obj/structure/machinery/light,
+/obj/effect/decal/warning_stripes{
+	icon_state = "W";
+	pixel_x = -1
+	},
+/turf/open/floor/almayer{
+	dir = 10;
+	icon_state = "silver"
+	},
+/area/almayer/hull/upper_hull/u_m_p)
 "fqO" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 1
@@ -35342,10 +35462,10 @@
 	dir = 2
 	},
 /obj/structure/machinery/door/airlock/multi_tile/almayer/secdoor/glass/reinforced{
+	access_modified = 1;
 	name = "\improper Cryogenics Bay";
 	req_access = null;
-	req_one_access_txt = "1;3";
-	access_modified = 1
+	req_one_access_txt = "1;3"
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -35429,12 +35549,9 @@
 	},
 /area/almayer/hallways/vehiclehangar)
 "fuz" = (
-/obj/structure/toilet{
-	dir = 8
-	},
-/obj/structure/window/reinforced/tinted/frosted,
+/obj/structure/machinery/cm_vending/clothing/pilot_officer,
 /turf/open/floor/almayer{
-	icon_state = "sterile"
+	icon_state = "plate"
 	},
 /area/almayer/living/pilotbunks)
 "fuB" = (
@@ -35485,11 +35602,17 @@
 	},
 /area/almayer/living/briefing)
 "fvu" = (
-/obj/item/tool/crowbar,
-/turf/open/floor/almayer{
-	icon_state = "mono"
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer,
+/area/almayer/hull/upper_hull/u_f_s)
+"fvv" = (
+/obj/structure/machinery/door/airlock/multi_tile/almayer/generic{
+	name = "\improper Port Viewing Room"
 	},
-/area/almayer/lifeboat_pumps/south1)
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/hull/upper_hull/u_f_p)
 "fvB" = (
 /obj/structure/closet/secure_closet/staff_officer/armory/m4a1,
 /turf/open/floor/almayer{
@@ -35856,9 +35979,9 @@
 /area/almayer/command/cichallway)
 "fEo" = (
 /obj/structure/machinery/door/airlock/almayer/generic{
+	access_modified = 1;
 	name = "Kitchen";
-	req_one_access_txt = "30;19";
-	access_modified = 1
+	req_one_access_txt = "30;19"
 	},
 /obj/structure/machinery/door/firedoor/border_only/almayer,
 /turf/open/floor/almayer{
@@ -36094,9 +36217,9 @@
 /area/almayer/squads/bravo)
 "fIX" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/almayer{
+	access_modified = 1;
 	name = "\improper Requisitions Auxiliary Storage Room";
-	req_one_access = "19;21";
-	access_modified = 1
+	req_one_access = "19;21"
 	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
@@ -36896,9 +37019,7 @@
 /obj/structure/toilet{
 	dir = 8
 	},
-/turf/open/floor/almayer{
-	icon_state = "dark_sterile"
-	},
+/turf/open/floor/plating/plating_catwalk,
 /area/almayer/command/corporateliason)
 "gbX" = (
 /obj/structure/disposalpipe/segment{
@@ -36925,10 +37046,10 @@
 /area/almayer/hull/lower_hull/l_a_s)
 "gcN" = (
 /obj/structure/machinery/door/airlock/almayer/command{
+	access_modified = 1;
 	name = "\improper Senior Enlisted Advisor's Office";
 	req_access = null;
-	req_access_txt = "19;29";
-	access_modified = 1
+	req_access_txt = "19;29"
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -37175,6 +37296,10 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/hallways/port_hallway)
+"ghW" = (
+/obj/effect/landmark/start/liaison,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/upper_hull/u_m_p)
 "ghX" = (
 /obj/structure/window/reinforced/tinted{
 	pixel_y = -8
@@ -37462,10 +37587,10 @@
 /area/almayer/lifeboat_pumps/north1)
 "gol" = (
 /obj/structure/machinery/door/airlock/almayer/maint/reinforced{
+	access_modified = 1;
 	dir = 1;
 	req_one_access = null;
-	req_one_access_txt = "7;19";
-	access_modified = 1
+	req_one_access_txt = "7;19"
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -38569,9 +38694,9 @@
 /area/almayer/hull/lower_hull/l_f_p)
 "gMA" = (
 /obj/structure/machinery/door/airlock/almayer/maint{
+	access_modified = 1;
 	dir = 8;
-	req_one_access = list(2,34,30);
-	access_modified = 1
+	req_one_access = list(2,34,30)
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -39156,7 +39281,7 @@
 	},
 /area/almayer/command/cichallway)
 "haM" = (
-/obj/structure/machinery/constructable_frame,
+/obj/structure/resource_node,
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/almayer{
 	icon_state = "mono"
@@ -39661,6 +39786,12 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/port_point_defense)
+"hkE" = (
+/obj/structure/closet/firecloset,
+/turf/open/floor/almayer{
+	icon_state = "cargo"
+	},
+/area/almayer/hallways/port_hallway)
 "hkG" = (
 /obj/structure/sign/safety/ammunition{
 	pixel_y = -32
@@ -39799,6 +39930,20 @@
 	icon_state = "sterile_green"
 	},
 /area/almayer/medical/hydroponics)
+"hnI" = (
+/obj/structure/machinery/door/firedoor/border_only/almayer{
+	dir = 2
+	},
+/obj/structure/machinery/door/airlock/multi_tile/almayer/generic2{
+	access_modified = 1;
+	name = "\improper Flight Crew Quarters";
+	req_access_txt = null;
+	req_one_access_txt = "19;22"
+	},
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/living/pilotbunks)
 "hnV" = (
 /obj/structure/machinery/light,
 /turf/open/floor/almayer,
@@ -40163,6 +40308,16 @@
 	icon_state = "plate"
 	},
 /area/almayer/squads/charlie_delta_shared)
+"hyt" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "E";
+	pixel_x = 2
+	},
+/turf/open/floor/almayer{
+	dir = 6;
+	icon_state = "green"
+	},
+/area/almayer/hallways/starboard_hallway)
 "hyw" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "NW-out";
@@ -40437,6 +40592,10 @@
 	icon_state = "plate"
 	},
 /area/almayer/medical/lower_medical_medbay)
+"hDv" = (
+/obj/effect/landmark/start/reporter,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/upper_hull/u_m_p)
 "hDw" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/computer/emails{
@@ -40511,10 +40670,10 @@
 /area/almayer/medical/medical_science)
 "hFF" = (
 /obj/structure/machinery/door/airlock/almayer/medical{
+	access_modified = 1;
 	name = "Autopsy";
 	req_access_txt = "25";
-	req_one_access = null;
-	access_modified = 1
+	req_one_access = null
 	},
 /obj/structure/machinery/door/firedoor/border_only/almayer,
 /turf/open/floor/almayer{
@@ -40636,9 +40795,9 @@
 	name = "\improper Privacy Shutters"
 	},
 /obj/structure/machinery/door/airlock/almayer/maint{
+	access_modified = 1;
 	req_access_txt = "200";
-	req_one_access = null;
-	access_modified = 1
+	req_one_access = null
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -41054,11 +41213,11 @@
 /area/almayer/living/grunt_rnr)
 "hSI" = (
 /obj/structure/machinery/door/airlock/almayer/medical{
+	access_modified = 1;
 	dir = 2;
 	name = "Morgue";
 	req_access_txt = "25";
-	req_one_access = null;
-	access_modified = 1
+	req_one_access = null
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer{
@@ -41716,21 +41875,33 @@
 /area/almayer/squads/bravo)
 "iid" = (
 /obj/structure/machinery/door/airlock/almayer/maint{
+	access_modified = 1;
 	dir = 2;
 	req_one_access = null;
-	req_one_access_txt = "19;34;30";
-	access_modified = 1
+	req_one_access_txt = "19;34;30"
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
 	},
 /area/almayer/hull/upper_hull/u_m_p)
 "iit" = (
-/obj/effect/landmark/ert_spawns/distress_cryo,
-/obj/effect/landmark/late_join,
-/obj/effect/landmark/start/reporter,
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/living/cryo_cells)
+/obj/effect/decal/warning_stripes{
+	icon_state = "W";
+	pixel_x = -1
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "SE-out";
+	pixel_x = 1
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "NE-out";
+	pixel_x = 1;
+	pixel_y = 1
+	},
+/turf/open/floor/almayer{
+	icon_state = "mono"
+	},
+/area/almayer/medical/hydroponics)
 "iiz" = (
 /obj/structure/surface/rack,
 /obj/item/reagent_container/food/drinks/bottle/sake{
@@ -42074,9 +42245,9 @@
 /area/almayer/squads/req)
 "iqp" = (
 /obj/structure/machinery/door/airlock/almayer/maint{
+	access_modified = 1;
 	req_one_access = null;
-	req_one_access_txt = "37";
-	access_modified = 1
+	req_one_access_txt = "37"
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -43228,9 +43399,9 @@
 /area/almayer/hull/lower_hull/l_f_p)
 "iQL" = (
 /obj/structure/machinery/door/airlock/almayer/maint{
+	access_modified = 1;
 	dir = 2;
-	req_one_access = list(2,34,30);
-	access_modified = 1
+	req_one_access = list(2,34,30)
 	},
 /obj/structure/prop/invuln/lattice_prop{
 	dir = 1;
@@ -44146,11 +44317,21 @@
 	icon_state = "cargo"
 	},
 /area/almayer/living/bridgebunks)
+"jhY" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "W";
+	pixel_x = -1
+	},
+/turf/open/floor/almayer{
+	dir = 8;
+	icon_state = "silver"
+	},
+/area/almayer/hull/upper_hull/u_m_p)
 "jip" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/generic{
+	access_modified = 1;
 	name = "\improper Main Kitchen";
-	req_one_access_txt = "30;19";
-	access_modified = 1
+	req_one_access_txt = "30;19"
 	},
 /turf/open/floor/prison{
 	icon_state = "kitchen"
@@ -44564,6 +44745,7 @@
 	icon_state = "NW-out";
 	pixel_y = 1
 	},
+/obj/structure/bed/chair/comfy,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -44706,14 +44888,11 @@
 	},
 /area/almayer/hull/upper_hull/u_a_p)
 "jvJ" = (
-/obj/structure/machinery/light{
-	dir = 4
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
-	dir = 4;
-	icon_state = "red"
+	icon_state = "plate"
 	},
-/area/almayer/shipboard/starboard_missiles)
+/area/almayer/hull/upper_hull/u_f_s)
 "jvX" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
@@ -45253,11 +45432,14 @@
 	},
 /area/almayer/hull/lower_hull/l_a_s)
 "jMm" = (
-/obj/effect/spawner/random/tool,
-/turf/open/floor/almayer{
-	icon_state = "mono"
+/obj/structure/closet/secure_closet/personal/cabinet{
+	req_access = null
 	},
-/area/almayer/lifeboat_pumps/south2)
+/obj/item/clothing/mask/rebreather/scarf,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/living/pilotbunks)
 "jMr" = (
 /obj/structure/surface/table/almayer,
 /obj/item/storage/donut_box{
@@ -45910,8 +46092,7 @@
 "jZY" = (
 /obj/structure/closet/l3closet/virology,
 /turf/open/floor/almayer{
-	dir = 5;
-	icon_state = "plating"
+	icon_state = "redfull"
 	},
 /area/almayer/medical/upper_medical)
 "kaj" = (
@@ -46383,6 +46564,14 @@
 	icon_state = "mono"
 	},
 /area/almayer/lifeboat_pumps/south2)
+"kkE" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "NE-out";
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/turf/open/floor/almayer,
+/area/almayer/hallways/port_hallway)
 "kkO" = (
 /obj/structure/stairs/perspective{
 	dir = 8;
@@ -46822,6 +47011,12 @@
 	icon_state = "greencorner"
 	},
 /area/almayer/living/grunt_rnr)
+"kuk" = (
+/obj/structure/pipes/vents/pump{
+	dir = 1
+	},
+/turf/open/floor/almayer,
+/area/almayer/lifeboat_pumps/south1)
 "kuu" = (
 /obj/structure/pipes/standard/manifold/hidden/supply,
 /obj/structure/disposalpipe/segment{
@@ -47120,6 +47315,13 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/command/airoom)
+"kBK" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "SE-out";
+	pixel_x = 2
+	},
+/turf/open/floor/almayer,
+/area/almayer/hallways/starboard_hallway)
 "kBP" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
@@ -47181,6 +47383,7 @@
 /area/almayer/hull/lower_hull/l_f_p)
 "kDb" = (
 /obj/structure/surface/rack,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/upper_hull/u_f_s)
 "kDi" = (
@@ -47265,11 +47468,15 @@
 	},
 /area/almayer/medical/morgue)
 "kFe" = (
-/obj/structure/machinery/constructable_frame,
-/turf/open/floor/almayer{
-	icon_state = "mono"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
 	},
-/area/almayer/lifeboat_pumps/south2)
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/living/pilotbunks)
 "kFk" = (
 /obj/structure/closet/secure_closet/commander,
 /turf/open/floor/wood/ship,
@@ -47347,6 +47554,12 @@
 	icon_state = "emerald"
 	},
 /area/almayer/squads/charlie)
+"kGI" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
+	},
+/turf/open/floor/almayer,
+/area/almayer/hallways/aft_hallway)
 "kGL" = (
 /obj/effect/step_trigger/clone_cleaner,
 /turf/open/floor/almayer{
@@ -47709,6 +47922,10 @@
 /turf/open/floor/plating,
 /area/almayer/hull/lower_hull/l_f_p)
 "kOv" = (
+/obj/structure/machinery/light{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "cargo_arrow"
 	},
@@ -47718,7 +47935,13 @@
 	icon_state = "N";
 	pixel_y = 1
 	},
-/obj/structure/bed/chair/comfy,
+/obj/structure/surface/table/reinforced/almayer_B,
+/obj/item/clipboard{
+	pixel_x = -6
+	},
+/obj/item/tool/pen/blue{
+	pixel_x = -6
+	},
 /turf/open/floor/almayer{
 	icon_state = "bluefull"
 	},
@@ -47984,12 +48207,14 @@
 /turf/open/floor/almayer,
 /area/almayer/hallways/hangar)
 "kUh" = (
-/obj/structure/machinery/door/airlock/almayer/generic{
-	name = "\improper Flight Crew Quarters";
-	req_one_access_txt = "19;22";
-	access_modified = 1
-	},
 /obj/structure/machinery/door/firedoor/border_only/almayer,
+/obj/structure/machinery/door/airlock/multi_tile/almayer/generic2{
+	access_modified = 1;
+	dir = 1;
+	name = "\improper Flight Crew Quarters";
+	req_access_txt = null;
+	req_one_access_txt = "19;22"
+	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
 	},
@@ -48074,11 +48299,11 @@
 	},
 /area/almayer/command/cichallway)
 "kWT" = (
-/obj/structure/machinery/power/apc/almayer/hardened,
 /turf/open/floor/almayer{
-	icon_state = "mono"
+	dir = 9;
+	icon_state = "blue"
 	},
-/area/almayer/lifeboat_pumps/south1)
+/area/almayer/living/pilotbunks)
 "kWY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -49182,6 +49407,13 @@
 	icon_state = "emerald"
 	},
 /area/almayer/squads/charlie)
+"ltK" = (
+/obj/structure/window/framed/almayer,
+/obj/structure/curtain/open/shower{
+	name = "hypersleep curtain"
+	},
+/turf/open/floor/plating,
+/area/almayer/hull/upper_hull/u_m_p)
 "ltU" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/almayer{
@@ -49313,13 +49545,11 @@
 	},
 /area/almayer/command/cic)
 "lvA" = (
-/obj/structure/machinery/power/apc/almayer/hardened{
-	dir = 1
-	},
 /turf/open/floor/almayer{
-	icon_state = "mono"
+	dir = 1;
+	icon_state = "blue"
 	},
-/area/almayer/lifeboat_pumps/north1)
+/area/almayer/living/pilotbunks)
 "lvZ" = (
 /obj/structure/window/framed/almayer,
 /obj/structure/machinery/door/poddoor/almayer/locked{
@@ -49331,10 +49561,10 @@
 /area/almayer/shipboard/brig/perma)
 "lwi" = (
 /obj/structure/machinery/door/airlock/almayer/maint{
+	access_modified = 1;
 	dir = 1;
 	req_one_access = null;
-	req_one_access_txt = "2;7";
-	access_modified = 1
+	req_one_access_txt = "2;7"
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -49711,18 +49941,23 @@
 	},
 /area/almayer/squads/req)
 "lDN" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
+/obj/effect/decal/warning_stripes{
+	icon_state = "E";
+	pixel_x = 1
 	},
-/obj/structure/sign/safety/coffee{
-	pixel_y = 32
+/obj/effect/decal/warning_stripes{
+	icon_state = "SW-out";
+	pixel_x = -1
 	},
-/obj/structure/sign/safety/east{
-	pixel_x = 15;
-	pixel_y = 32
+/obj/effect/decal/warning_stripes{
+	icon_state = "NW-out";
+	pixel_x = -1;
+	pixel_y = 1
 	},
-/turf/open/floor/almayer,
-/area/almayer/hull/upper_hull/u_f_p)
+/turf/open/floor/almayer{
+	icon_state = "mono"
+	},
+/area/almayer/medical/hydroponics)
 "lDV" = (
 /obj/effect/landmark/start/marine/medic/bravo,
 /obj/effect/landmark/late_join/bravo,
@@ -50238,6 +50473,10 @@
 /obj/structure/machinery/light{
 	dir = 8
 	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "E";
+	pixel_x = 1
+	},
 /turf/open/floor/almayer{
 	icon_state = "dark_sterile"
 	},
@@ -50634,16 +50873,15 @@
 	},
 /area/almayer/shipboard/brig/general_equipment)
 "maq" = (
-/obj/structure/machinery/cryopod/right{
-	pixel_y = 6
-	},
 /obj/structure/sign/safety/cryo{
 	pixel_x = 7;
 	pixel_y = -26
 	},
-/turf/open/floor/almayer{
-	icon_state = "cargo"
+/obj/structure/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
 	},
+/turf/open/floor/almayer,
 /area/almayer/command/corporateliason)
 "maw" = (
 /obj/structure/disposalpipe/segment,
@@ -50854,6 +51092,10 @@
 	icon_state = "silver"
 	},
 /area/almayer/shipboard/brig/cic_hallway)
+"mgy" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer,
+/area/almayer/shipboard/brig/cic_hallway)
 "mgF" = (
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -51033,6 +51275,11 @@
 	name = "Quarters Shutters";
 	pixel_x = -25;
 	req_access_txt = "200"
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "NE-out";
+	pixel_x = 1;
+	pixel_y = 2
 	},
 /turf/open/floor/almayer{
 	icon_state = "dark_sterile"
@@ -51323,6 +51570,13 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/upper_hull/u_f_s)
+"mru" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "SE-out";
+	pixel_x = 1
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hallways/port_hallway)
 "mrD" = (
 /obj/structure/machinery/light{
 	dir = 1
@@ -51434,6 +51688,19 @@
 	icon_state = "red"
 	},
 /area/almayer/command/lifeboat)
+"mtE" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/sign/safety/east{
+	pixel_x = 15;
+	pixel_y = 32
+	},
+/obj/structure/sign/safety/coffee{
+	pixel_y = 32
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/upper_hull/u_f_p)
 "mtM" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer{
@@ -51652,6 +51919,14 @@
 /obj/structure/machinery/light,
 /turf/open/floor/almayer,
 /area/almayer/living/offices)
+"mzF" = (
+/obj/effect/decal/cleanable/blood/oil,
+/obj/structure/machinery/power/apc/almayer/hardened{
+	cell_type = /obj/item/cell/hyper;
+	dir = 1
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/lifeboat_pumps/south2)
 "mzO" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 10
@@ -51729,6 +52004,18 @@
 	icon_state = "bluefull"
 	},
 /area/almayer/squads/charlie_delta_shared)
+"mBe" = (
+/obj/structure/machinery/light{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
+	},
+/turf/open/floor/almayer{
+	icon_state = "dark_sterile"
+	},
+/area/almayer/living/pilotbunks)
 "mBk" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 9
@@ -51744,10 +52031,10 @@
 	dir = 4
 	},
 /obj/structure/machinery/door/airlock/almayer/security/reinforced{
+	access_modified = 1;
 	name = "\improper Astronavigational Deck";
 	req_access = null;
-	req_one_access_txt = "3;19";
-	access_modified = 1
+	req_one_access_txt = "3;19"
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -51763,6 +52050,7 @@
 	dir = 4;
 	name = "ship-grade camera"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer,
 /area/almayer/hull/upper_hull/u_f_p)
 "mBJ" = (
@@ -51957,12 +52245,11 @@
 /area/almayer/living/gym)
 "mHD" = (
 /obj/effect/decal/warning_stripes{
-	icon_state = "W";
-	pixel_x = -1
+	icon_state = "S"
 	},
 /obj/effect/decal/warning_stripes{
-	icon_state = "E";
-	pixel_x = 1
+	icon_state = "N";
+	pixel_y = 1
 	},
 /turf/open/floor/almayer{
 	icon_state = "mono"
@@ -51975,8 +52262,11 @@
 	},
 /area/almayer/command/airoom)
 "mHO" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/machinery/light,
-/turf/open/floor/almayer,
+/turf/open/floor/almayer{
+	icon_state = "mono"
+	},
 /area/almayer/living/pilotbunks)
 "mHR" = (
 /obj/structure/sign/safety/hvac_old{
@@ -52066,11 +52356,10 @@
 /turf/open/floor/almayer/uscm/directional,
 /area/almayer/command/cic)
 "mJL" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+/turf/open/floor/almayer{
+	dir = 5;
+	icon_state = "blue"
 	},
-/turf/closed/wall/almayer,
 /area/almayer/living/pilotbunks)
 "mJP" = (
 /obj/structure/machinery/cm_vending/gear/tl{
@@ -52534,9 +52823,9 @@
 	name = "\improper Privacy Shutters"
 	},
 /obj/structure/machinery/door/airlock/almayer/maint/reinforced{
+	access_modified = 1;
 	req_one_access = null;
-	req_one_access_txt = "19;30";
-	access_modified = 1
+	req_one_access_txt = "19;30"
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -52585,6 +52874,12 @@
 	icon_state = "red"
 	},
 /area/almayer/shipboard/navigation)
+"mTn" = (
+/obj/structure/closet/firecloset,
+/turf/open/floor/almayer{
+	icon_state = "cargo"
+	},
+/area/almayer/hallways/starboard_hallway)
 "mTp" = (
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -53034,9 +53329,9 @@
 /area/almayer/shipboard/port_missiles)
 "nec" = (
 /obj/structure/machinery/door/airlock/almayer/maint{
+	access_modified = 1;
 	req_access_txt = "200";
-	req_one_access = null;
-	access_modified = 1
+	req_one_access = null
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -53244,11 +53539,11 @@
 /area/almayer/lifeboat_pumps/south1)
 "nim" = (
 /obj/structure/machinery/door/airlock/almayer/engineering{
+	access_modified = 1;
 	dir = 2;
 	name = "\improper Chief Engineer's Office";
 	req_one_access = null;
-	req_one_access_txt = "1;6";
-	access_modified = 1
+	req_one_access_txt = "1;6"
 	},
 /obj/structure/pipes/standard/simple/hidden/supply,
 /obj/structure/machinery/door/poddoor/shutters/almayer/open{
@@ -53314,6 +53609,12 @@
 	icon_state = "red"
 	},
 /area/almayer/squads/alpha)
+"njy" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
+	},
+/turf/open/floor/almayer,
+/area/almayer/hallways/port_hallway)
 "njD" = (
 /obj/structure/surface/table/almayer,
 /obj/item/clothing/suit/storage/hazardvest,
@@ -53373,6 +53674,8 @@
 /obj/structure/machinery/cm_vending/sorted/medical/wall_med{
 	pixel_y = 25
 	},
+/obj/structure/surface/table/almayer,
+/obj/structure/machinery/computer/emails,
 /turf/open/floor/almayer{
 	dir = 1;
 	icon_state = "red"
@@ -53898,6 +54201,12 @@
 /obj/item/tool/lighter/zippo/gold,
 /turf/open/floor/carpet,
 /area/almayer/living/commandbunks)
+"nwx" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer{
+	icon_state = "red"
+	},
+/area/almayer/shipboard/port_missiles)
 "nwz" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/pipes/standard/simple/hidden/supply,
@@ -54124,12 +54433,10 @@
 	},
 /area/almayer/living/briefing)
 "nBE" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
 /obj/structure/pipes/standard/simple/hidden/supply,
-/turf/open/floor/almayer,
+/turf/open/floor/almayer{
+	icon_state = "mono"
+	},
 /area/almayer/living/pilotbunks)
 "nBW" = (
 /obj/structure/sign/safety/maint{
@@ -54667,9 +54974,11 @@
 	},
 /area/almayer/shipboard/brig/cic_hallway)
 "nNA" = (
-/obj/structure/largecrate/random,
+/obj/structure/machinery/cryopod{
+	pixel_y = 6
+	},
 /turf/open/floor/almayer{
-	icon_state = "plate"
+	icon_state = "cargo"
 	},
 /area/almayer/hull/upper_hull/u_m_p)
 "nNH" = (
@@ -55042,6 +55351,14 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/engineering/upper_engineering/starboard)
+"nWc" = (
+/obj/structure/machinery/door/airlock/almayer/generic/glass{
+	name = "\improper Passenger Cryogenics Bay"
+	},
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/hull/upper_hull/u_m_p)
 "nWN" = (
 /obj/structure/surface/table/almayer,
 /turf/open/floor/wood/ship,
@@ -55062,6 +55379,15 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/shipboard/brig/cells)
+"nXF" = (
+/obj/structure/bed/sofa/south/white/right{
+	pixel_y = 16
+	},
+/turf/open/floor/almayer{
+	dir = 5;
+	icon_state = "silver"
+	},
+/area/almayer/hull/upper_hull/u_m_p)
 "nXP" = (
 /turf/closed/wall/almayer/outer,
 /area/almayer/hull/lower_hull/l_f_s)
@@ -55112,6 +55438,13 @@
 	icon_state = "plate"
 	},
 /area/almayer/hull/upper_hull/u_a_s)
+"nYv" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "SW-out";
+	pixel_x = -1
+	},
+/turf/open/floor/almayer,
+/area/almayer/hallways/aft_hallway)
 "nYD" = (
 /obj/structure/closet/secure_closet/medical2,
 /turf/open/floor/almayer{
@@ -55917,7 +56250,9 @@
 	name = "General Listening Channel";
 	pixel_y = 28
 	},
-/turf/open/floor/almayer,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
 /area/almayer/living/pilotbunks)
 "oqA" = (
 /obj/structure/machinery/door/poddoor/shutters/almayer/uniform_vendors,
@@ -56273,10 +56608,10 @@
 	dir = 4
 	},
 /obj/structure/machinery/door/airlock/almayer/maint{
+	access_modified = 1;
 	req_access = null;
 	req_one_access = null;
-	req_one_access_txt = "19;29";
-	access_modified = 1
+	req_one_access_txt = "19;29"
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -56324,6 +56659,13 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/upper_hull/u_a_p)
+"oyy" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "SW-out";
+	pixel_x = -1
+	},
+/turf/open/floor/almayer,
+/area/almayer/hallways/port_hallway)
 "oyE" = (
 /obj/effect/landmark/start/intel,
 /obj/structure/sign/poster{
@@ -57098,6 +57440,7 @@
 /area/almayer/hull/lower_hull/l_f_s)
 "oQo" = (
 /obj/item/stool,
+/obj/effect/landmark/yautja_teleport,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -57357,10 +57700,10 @@
 /area/almayer/shipboard/brig/cryo)
 "oWX" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/generic{
+	access_modified = 1;
 	dir = 1;
 	name = "\improper Kitchen Hydroponics";
-	req_one_access_txt = "30;19";
-	access_modified = 1
+	req_one_access_txt = "30;19"
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -57371,6 +57714,14 @@
 /obj/effect/landmark/late_join/charlie,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/squads/charlie)
+"oXd" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "SW-out"
+	},
+/turf/open/floor/almayer{
+	icon_state = "blue"
+	},
+/area/almayer/hallways/aft_hallway)
 "oXp" = (
 /obj/effect/decal/cleanable/ash,
 /turf/open/floor/wood/ship,
@@ -57899,11 +58250,11 @@
 	dir = 4
 	},
 /obj/structure/machinery/door/airlock/multi_tile/almayer/secdoor/glass/reinforced{
+	access_modified = 1;
 	dir = 2;
 	name = "Brig";
 	req_access = null;
-	req_one_access_txt = "1;3";
-	access_modified = 1
+	req_one_access_txt = "1;3"
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -58017,11 +58368,9 @@
 /turf/open/floor/almayer,
 /area/almayer/living/auxiliary_officer_office)
 "pqc" = (
-/obj/structure/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
+/turf/open/floor/almayer{
+	icon_state = "mono"
 	},
-/turf/open/floor/almayer,
 /area/almayer/living/pilotbunks)
 "pqi" = (
 /obj/item/stack/cable_coil,
@@ -58939,11 +59288,11 @@
 "pJW" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/machinery/door/airlock/almayer/maint{
+	access_modified = 1;
 	dir = 1;
 	req_access = null;
 	req_one_access = null;
-	req_one_access_txt = "3;22;19";
-	access_modified = 1
+	req_one_access_txt = "3;22;19"
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -58983,15 +59332,11 @@
 	},
 /area/almayer/medical/containment/cell)
 "pLW" = (
-/obj/structure/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
-	dir = 5;
-	icon_state = "red"
+	icon_state = "cargo"
 	},
-/area/almayer/shipboard/port_missiles)
+/area/almayer/living/pilotbunks)
 "pLZ" = (
 /obj/effect/landmark/crap_item,
 /turf/open/floor/almayer,
@@ -59104,8 +59449,13 @@
 /area/almayer/hull/lower_hull/l_m_s)
 "pOD" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/almayer,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/open/floor/almayer{
+	icon_state = "mono"
+	},
 /area/almayer/living/pilotbunks)
 "pON" = (
 /turf/open/floor/almayer/uscm/directional{
@@ -59160,6 +59510,7 @@
 	},
 /area/almayer/command/securestorage)
 "pPN" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	dir = 4;
 	icon_state = "red"
@@ -59222,9 +59573,8 @@
 	},
 /area/almayer/medical/medical_science)
 "pQV" = (
-/obj/structure/machinery/vending/cola,
 /turf/open/floor/almayer{
-	icon_state = "plate"
+	icon_state = "blue"
 	},
 /area/almayer/living/pilotbunks)
 "pQY" = (
@@ -59532,7 +59882,9 @@
 /area/almayer/shipboard/brig/main_office)
 "pWN" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
-/turf/open/floor/almayer,
+/turf/open/floor/almayer{
+	icon_state = "blue"
+	},
 /area/almayer/living/pilotbunks)
 "pXj" = (
 /obj/structure/closet/radiation,
@@ -59773,13 +60125,11 @@
 	},
 /area/almayer/living/briefing)
 "qbO" = (
-/obj/structure/machinery/power/apc/almayer/hardened{
-	dir = 1
-	},
 /turf/open/floor/almayer{
-	icon_state = "mono"
+	dir = 6;
+	icon_state = "blue"
 	},
-/area/almayer/lifeboat_pumps/north2)
+/area/almayer/living/pilotbunks)
 "qbZ" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/engidoor/glass{
 	dir = 1;
@@ -59918,10 +60268,8 @@
 /obj/structure/machinery/computer/emails{
 	dir = 1
 	},
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "redcorner"
-	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer,
 /area/almayer/shipboard/port_missiles)
 "qfh" = (
 /obj/structure/bed/chair{
@@ -60002,8 +60350,8 @@
 "qgK" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /obj/structure/machinery/door/airlock/almayer/generic/press{
-	name = "\improper Combat Correspondent Room";
-	dir = 1
+	dir = 1;
+	name = "\improper Combat Correspondent Room"
 	},
 /turf/open/floor/almayer,
 /area/almayer/command/combat_correspondent)
@@ -60165,6 +60513,7 @@
 /obj/structure/sign/safety/maint{
 	pixel_x = -17
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer,
 /area/almayer/hull/upper_hull/u_f_s)
 "qld" = (
@@ -60301,6 +60650,12 @@
 	icon_state = "plate"
 	},
 /area/almayer/shipboard/brig/perma)
+"qnd" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "SW-out"
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hallways/hangar)
 "qnh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -60805,10 +61160,6 @@
 /obj/structure/surface/table/almayer,
 /obj/item/storage/photo_album,
 /obj/item/device/camera_film,
-/obj/effect/decal/warning_stripes{
-	icon_state = "E";
-	pixel_x = 1
-	},
 /turf/open/floor/almayer,
 /area/almayer/command/corporateliason)
 "qyD" = (
@@ -61364,11 +61715,13 @@
 	},
 /area/almayer/medical/containment)
 "qLj" = (
-/obj/structure/pipes/vents/pump{
-	dir = 1
+/obj/effect/decal/warning_stripes{
+	icon_state = "SE-out"
 	},
-/turf/open/floor/almayer,
-/area/almayer/lifeboat_pumps/south1)
+/turf/open/floor/almayer{
+	icon_state = "blue"
+	},
+/area/almayer/hallways/aft_hallway)
 "qLo" = (
 /obj/structure/machinery/light,
 /turf/open/floor/plating/plating_catwalk,
@@ -62959,10 +63312,6 @@
 	},
 /area/almayer/hallways/hangar)
 "ruz" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "N";
-	pixel_y = 1
-	},
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/almayer{
 	icon_state = "cargo"
@@ -63090,10 +63439,10 @@
 	icon_state = "NW-out"
 	},
 /obj/structure/machinery/door/airlock/multi_tile/almayer/secdoor/glass/reinforced{
+	access_modified = 1;
 	name = "\improper Brig";
 	req_access = null;
-	req_one_access_txt = "1;3";
-	access_modified = 1
+	req_one_access_txt = "1;3"
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -63103,6 +63452,7 @@
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer,
 /area/almayer/shipboard/brig/cic_hallway)
 "rzN" = (
@@ -63204,7 +63554,7 @@
 "rBx" = (
 /obj/structure/surface/table/reinforced/almayer_B,
 /obj/item/tool/stamp/ro{
-	name = "spare quartermaster's rubber stamp";
+	name = "spare requisitions officer's rubber stamp";
 	pixel_x = -7;
 	pixel_y = 11
 	},
@@ -63213,7 +63563,7 @@
 	},
 /area/almayer/command/cichallway)
 "rBH" = (
-/obj/structure/machinery/constructable_frame,
+/obj/structure/resource_node,
 /turf/open/floor/almayer{
 	icon_state = "mono"
 	},
@@ -63837,6 +64187,7 @@
 /obj/structure/surface/table/reinforced/almayer_B,
 /obj/item/clipboard,
 /obj/item/device/binoculars,
+/obj/item/storage/bible,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -64630,11 +64981,8 @@
 	},
 /area/almayer/lifeboat_pumps/south2)
 "sht" = (
-/obj/structure/machinery/power/apc/almayer/hardened,
-/turf/open/floor/almayer{
-	icon_state = "mono"
-	},
-/area/almayer/lifeboat_pumps/south2)
+/turf/open/floor/almayer,
+/area/almayer/living/pilotbunks)
 "shw" = (
 /obj/structure/largecrate/random/barrel/green,
 /turf/open/floor/plating/plating_catwalk,
@@ -64882,6 +65230,12 @@
 	allow_construction = 0
 	},
 /area/almayer/hallways/port_hallway)
+"sou" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
+	},
+/turf/open/floor/almayer,
+/area/almayer/hallways/starboard_hallway)
 "sow" = (
 /obj/structure/machinery/light/small{
 	dir = 8
@@ -65313,6 +65667,13 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/upper_hull/u_f_p)
+"syP" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "E";
+	pixel_x = 1
+	},
+/turf/open/floor/almayer,
+/area/almayer/hallways/port_hallway)
 "szm" = (
 /obj/structure/machinery/power/fusion_engine{
 	name = "\improper S-52 fusion reactor 10"
@@ -65356,11 +65717,20 @@
 	},
 /area/almayer/squads/charlie)
 "szO" = (
-/obj/structure/machinery/cm_vending/sorted/cargo_guns/pilot_officer,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
 /area/almayer/living/pilotbunks)
+"szU" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/living/numbertwobunks)
 "sAc" = (
 /obj/structure/bed/chair{
 	dir = 8;
@@ -65408,12 +65778,12 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/machinery/door/airlock/almayer/command/reinforced{
+	access_modified = 1;
 	dir = 1;
 	id_tag = "CO-Office";
 	name = "\improper Commanding Officer's Office";
 	req_access = null;
-	req_access_txt = "31";
-	access_modified = 1
+	req_access_txt = "31"
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -65469,7 +65839,10 @@
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 10
 	},
-/turf/open/floor/almayer,
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "blue"
+	},
 /area/almayer/living/pilotbunks)
 "sCQ" = (
 /obj/structure/machinery/light,
@@ -65502,6 +65875,13 @@
 	icon_state = "silvercorner"
 	},
 /area/almayer/hallways/aft_hallway)
+"sDD" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/port_missiles)
 "sDM" = (
 /turf/open/floor/almayer{
 	dir = 9;
@@ -65727,17 +66107,11 @@
 /turf/open/floor/almayer,
 /area/almayer/hallways/aft_hallway)
 "sHM" = (
-/obj/structure/machinery/light{
-	dir = 8
-	},
-/obj/structure/bed/chair{
-	dir = 1
-	},
+/obj/structure/machinery/door/firedoor/border_only/almayer,
 /turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "red"
+	icon_state = "test_floor4"
 	},
-/area/almayer/shipboard/starboard_missiles)
+/area/almayer/living/pilotbunks)
 "sHY" = (
 /obj/structure/sign/poster{
 	pixel_y = -32
@@ -66936,9 +67310,9 @@
 "tiR" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer,
 /obj/structure/machinery/door/airlock/almayer/maint/reinforced{
+	access_modified = 1;
 	req_one_access = null;
-	req_one_access_txt = "7;19";
-	access_modified = 1
+	req_one_access_txt = "7;19"
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -67007,13 +67381,12 @@
 	},
 /area/almayer/shipboard/brig/processing)
 "tld" = (
-/obj/structure/machinery/shower{
-	dir = 8
+/obj/structure/machinery/prop/almayer/computer{
+	dir = 8;
+	pixel_x = 16
 	},
-/obj/structure/machinery/door/window/westright,
-/obj/item/tool/soap,
 /turf/open/floor/almayer{
-	icon_state = "plate"
+	icon_state = "cargo"
 	},
 /area/almayer/living/pilotbunks)
 "tly" = (
@@ -67705,6 +68078,9 @@
 /area/almayer/medical/containment/cell)
 "tyK" = (
 /obj/effect/spawner/random/toolbox,
+/obj/structure/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/almayer{
 	dir = 1;
 	icon_state = "cargo_arrow"
@@ -67733,6 +68109,10 @@
 	icon_state = "plate"
 	},
 /area/almayer/hull/upper_hull/u_a_p)
+"tzj" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/upper_hull/u_f_p)
 "tzx" = (
 /obj/structure/machinery/cm_vending/sorted/medical/blood,
 /obj/structure/machinery/light{
@@ -67752,20 +68132,13 @@
 	},
 /area/almayer/engineering/engineering_workshop)
 "tzL" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "W";
-	pixel_x = -1
-	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "E";
-	pixel_x = 1
-	},
 /obj/structure/sign/safety/waterhazard{
 	pixel_x = 8;
 	pixel_y = -32
 	},
+/obj/structure/machinery/portable_atmospherics/hydroponics,
 /turf/open/floor/almayer{
-	icon_state = "mono"
+	icon_state = "test_floor5"
 	},
 /area/almayer/medical/hydroponics)
 "tzP" = (
@@ -67792,8 +68165,8 @@
 "tAq" = (
 /obj/structure/surface/table/reinforced/black,
 /obj/item/clothing/mask/breath{
-	pixel_y = -5;
-	pixel_x = -3
+	pixel_x = -3;
+	pixel_y = -5
 	},
 /obj/item/clothing/head/helmet/space/compression/uscm,
 /obj/item/cell/crap{
@@ -67842,6 +68215,10 @@
 "tAV" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/pipes/standard/simple/hidden/supply,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/lifeboat_pumps/south1)
+"tBq" = (
+/obj/item/tool/crowbar,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/lifeboat_pumps/south1)
 "tBz" = (
@@ -68201,10 +68578,10 @@
 	dir = 1
 	},
 /obj/structure/machinery/door/airlock/almayer/generic{
+	access_modified = 1;
 	dir = 1;
 	name = "Storage";
-	req_one_access = "2;21";
-	access_modified = 1
+	req_one_access = "2;21"
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -68444,10 +68821,10 @@
 /area/almayer/living/grunt_rnr)
 "tPj" = (
 /obj/structure/machinery/door/airlock/almayer/marine/requisitions{
+	access_modified = 1;
 	name = "\improper Requisition's Office";
-	req_one_access_txt = "1;26";
 	req_one_access = null;
-	access_modified = 1
+	req_one_access_txt = "1;26"
 	},
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -68704,10 +69081,10 @@
 	name = "\improper CMO Office Shutters"
 	},
 /obj/structure/machinery/door/airlock/almayer/medical/glass{
+	access_modified = 1;
 	name = "\improper CMO's Office";
 	req_one_access = null;
-	req_one_access_txt = "1;5";
-	access_modified = 1
+	req_one_access_txt = "1;5"
 	},
 /obj/structure/machinery/door/firedoor/border_only/almayer,
 /turf/open/floor/almayer{
@@ -68752,9 +69129,9 @@
 "tXG" = (
 /obj/structure/surface/table/reinforced/almayer_B,
 /obj/structure/machinery/door/window/eastright{
+	access_modified = 1;
 	dir = 8;
-	req_access_txt = "19";
-	access_modified = 1
+	req_access_txt = "19"
 	},
 /obj/effect/landmark/map_item,
 /obj/structure/machinery/door/window/eastleft{
@@ -69374,10 +69751,10 @@
 /area/almayer/squads/charlie_delta_shared)
 "ukW" = (
 /obj/structure/machinery/door/airlock/almayer/security{
+	access_modified = 1;
 	name = "\improper Security Checkpoint";
 	req_access = null;
-	req_one_access_txt = "3;19";
-	access_modified = 1
+	req_one_access_txt = "3;19"
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -69446,15 +69823,14 @@
 	},
 /area/almayer/medical/upper_medical)
 "umS" = (
-/obj/structure/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
+/obj/structure/bed/chair/comfy{
+	dir = 8
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "red"
+	icon_state = "blue"
 	},
-/area/almayer/shipboard/starboard_missiles)
+/area/almayer/living/pilotbunks)
 "umT" = (
 /obj/structure/machinery/door/airlock/almayer/security/glass{
 	name = "Brig"
@@ -69966,6 +70342,14 @@
 /obj/structure/surface/table/woodentable/fancy,
 /turf/open/floor/wood/ship,
 /area/almayer/living/commandbunks)
+"uws" = (
+/obj/structure/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/almayer{
+	icon_state = "cargo_arrow"
+	},
+/area/almayer/shipboard/port_missiles)
 "uwv" = (
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/weapon_room/notunnel)
@@ -70188,8 +70572,15 @@
 	icon_state = "redcorner"
 	},
 /area/almayer/shipboard/brig/main_office)
+"uAb" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "SE-out"
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hallways/hangar)
 "uAj" = (
 /obj/structure/bed/chair,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	dir = 1;
 	icon_state = "red"
@@ -70489,6 +70880,12 @@
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
 	},
+/area/almayer/hallways/aft_hallway)
+"uGt" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "SE-out"
+	},
+/turf/open/floor/almayer,
 /area/almayer/hallways/aft_hallway)
 "uGw" = (
 /obj/structure/surface/table/almayer,
@@ -70838,11 +71235,10 @@
 /turf/closed/wall/almayer/outer,
 /area/almayer/lifeboat_pumps/south2)
 "uOJ" = (
-/obj/structure/machinery/prop/almayer/computer{
-	dir = 8;
-	pixel_x = 16
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer{
+	icon_state = "mono"
 	},
-/turf/open/floor/almayer,
 /area/almayer/living/pilotbunks)
 "uPr" = (
 /turf/open/floor/almayer{
@@ -70872,6 +71268,13 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/shipboard/brig/perma)
+"uQn" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "NW-out";
+	pixel_y = 3
+	},
+/turf/open/floor/almayer,
+/area/almayer/hallways/starboard_hallway)
 "uQU" = (
 /obj/structure/stairs{
 	dir = 1
@@ -71002,9 +71405,12 @@
 /turf/open/floor/almayer,
 /area/almayer/squads/bravo)
 "uTN" = (
-/obj/effect/landmark/start/liaison,
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/command/corporateliason)
+/obj/structure/pipes/standard/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer{
+	icon_state = "mono"
+	},
+/area/almayer/living/pilotbunks)
 "uTU" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer{
 	dir = 2
@@ -71177,13 +71583,9 @@
 /obj/structure/machinery/light{
 	dir = 1
 	},
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
+/obj/structure/machinery/cm_vending/sorted/cargo_guns/pilot_officer,
 /turf/open/floor/almayer{
-	icon_state = "sterile"
+	icon_state = "plate"
 	},
 /area/almayer/living/pilotbunks)
 "uWc" = (
@@ -71437,6 +71839,10 @@
 	icon_state = "red"
 	},
 /area/almayer/shipboard/brig/general_equipment)
+"vcK" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer,
+/area/almayer/hull/upper_hull/u_f_p)
 "vdJ" = (
 /obj/structure/surface/table/almayer,
 /obj/item/pipe{
@@ -71901,6 +72307,10 @@
 	icon_state = "green"
 	},
 /area/almayer/living/grunt_rnr)
+"vjK" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer,
+/area/almayer/shipboard/port_missiles)
 "vka" = (
 /turf/open/floor/almayer,
 /area/almayer/shipboard/brig/cic_hallway)
@@ -72286,12 +72696,12 @@
 /area/almayer/shipboard/brig/armory)
 "vsJ" = (
 /obj/structure/machinery/door/airlock/almayer/maint{
+	access_modified = 1;
 	dir = 1;
 	name = "\improper Power Control Room";
 	req_access = null;
 	req_one_access = null;
-	req_one_access_txt = "3;6";
-	access_modified = 1
+	req_one_access_txt = "3;6"
 	},
 /turf/open/floor/almayer{
 	icon_state = "orangefull"
@@ -72596,6 +73006,13 @@
 "vzp" = (
 /turf/open/floor/almayer/research/containment/entrance,
 /area/almayer/medical/containment/cell/cl)
+"vzq" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 3
+	},
+/turf/open/floor/almayer,
+/area/almayer/hallways/port_hallway)
 "vzu" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 10
@@ -72823,11 +73240,11 @@
 /area/almayer/living/briefing)
 "vEI" = (
 /obj/structure/machinery/door/airlock/almayer/medical/glass{
+	access_modified = 1;
 	dir = 2;
 	name = "\improper Field Surgery Equipment";
 	req_access_txt = "20";
-	req_one_access = null;
-	access_modified = 1
+	req_one_access = null
 	},
 /obj/structure/machinery/door/firedoor/border_only/almayer{
 	dir = 1
@@ -72894,6 +73311,15 @@
 	icon_state = "orangefull"
 	},
 /area/almayer/living/briefing)
+"vGI" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "E";
+	pixel_x = 1
+	},
+/turf/open/floor/almayer{
+	icon_state = "dark_sterile"
+	},
+/area/almayer/living/numbertwobunks)
 "vHa" = (
 /obj/structure/surface/table/reinforced/almayer_B,
 /obj/structure/machinery/computer/ares_console{
@@ -72916,6 +73342,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer,
 /area/almayer/living/port_emb)
+"vHs" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "E";
+	pixel_x = 2
+	},
+/turf/open/floor/almayer,
+/area/almayer/hallways/starboard_hallway)
 "vHO" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N";
@@ -73254,6 +73687,10 @@
 /area/almayer/medical/upper_medical)
 "vPm" = (
 /obj/item/stack/cable_coil,
+/obj/structure/machinery/power/apc/almayer/hardened{
+	cell_type = /obj/item/cell/hyper;
+	dir = 1
+	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/lifeboat_pumps/south1)
 "vPr" = (
@@ -73920,14 +74357,15 @@
 	},
 /area/almayer/hallways/aft_hallway)
 "wbu" = (
-/obj/structure/machinery/light{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/machinery/camera/autoname/almayer{
+	dir = 1;
+	name = "ship-grade camera"
 	},
 /turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "red"
+	icon_state = "mono"
 	},
-/area/almayer/shipboard/port_missiles)
+/area/almayer/living/pilotbunks)
 "wbx" = (
 /obj/structure/sign/safety/hazard{
 	desc = "A sign that warns of a hazardous environment nearby";
@@ -73969,7 +74407,15 @@
 /obj/structure/machinery/status_display{
 	pixel_y = 30
 	},
-/turf/open/floor/almayer,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/surface/table/reinforced/almayer_B,
+/obj/structure/flora/pottedplant{
+	icon_state = "pottedplant_21";
+	pixel_y = 15
+	},
+/turf/open/floor/almayer{
+	icon_state = "bluefull"
+	},
 /area/almayer/living/pilotbunks)
 "wbP" = (
 /obj/structure/machinery/bioprinter{
@@ -74094,11 +74540,14 @@
 	},
 /area/almayer/medical/hydroponics)
 "wex" = (
-/obj/structure/machinery/light{
-	dir = 4
+/obj/structure/sign/safety/bathunisex{
+	pixel_x = 8;
+	pixel_y = -25
 	},
-/turf/open/floor/almayer,
-/area/almayer/hull/upper_hull/u_f_s)
+/turf/open/floor/almayer{
+	icon_state = "mono"
+	},
+/area/almayer/living/pilotbunks)
 "weB" = (
 /obj/item/tool/screwdriver{
 	layer = 2.9;
@@ -74388,9 +74837,9 @@
 "wkc" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/structure/machinery/door/window/eastright{
+	access_modified = 1;
 	dir = 8;
-	req_access_txt = "8";
-	access_modified = 1
+	req_access_txt = "8"
 	},
 /obj/structure/machinery/door/window/eastleft{
 	req_access_txt = "8"
@@ -74670,8 +75119,8 @@
 	dir = 1
 	},
 /obj/structure/pipes/vents/pump/no_boom{
-	name = "Security Vent";
-	desc = "Has a valve and pump attached to it, connected to multiple gas tanks."
+	desc = "Has a valve and pump attached to it, connected to multiple gas tanks.";
+	name = "Security Vent"
 	},
 /turf/open/floor/almayer/no_build{
 	icon_state = "plating"
@@ -74773,10 +75222,6 @@
 /turf/open/floor/almayer,
 /area/almayer/living/gym)
 "wrT" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "N";
-	pixel_y = 1
-	},
 /obj/structure/surface/table/almayer,
 /obj/item/device/radio/marine,
 /obj/item/device/radio/marine,
@@ -74913,11 +75358,11 @@
 /area/almayer/lifeboat_pumps/south1)
 "wvl" = (
 /obj/structure/machinery/door/airlock/almayer/security{
+	access_modified = 1;
 	dir = 2;
 	name = "\improper Security Checkpoint";
 	req_access = null;
-	req_one_access_txt = "3;19";
-	access_modified = 1
+	req_one_access_txt = "3;19"
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -75407,10 +75852,7 @@
 /obj/structure/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/almayer{
-	dir = 4;
-	icon_state = "red"
-	},
+/turf/closed/wall/almayer/reinforced,
 /area/almayer/shipboard/port_missiles)
 "wGX" = (
 /obj/structure/pipes/standard/manifold/hidden/supply{
@@ -75479,10 +75921,10 @@
 /area/almayer/medical/lower_medical_medbay)
 "wJo" = (
 /obj/structure/machinery/door/airlock/almayer/research/reinforced{
+	access_modified = 1;
 	dir = 1;
 	name = "\improper CMO's Bedroom";
-	req_one_access_txt = "1;5";
-	access_modified = 1
+	req_one_access_txt = "1;5"
 	},
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer{
@@ -75591,8 +76033,8 @@
 /area/almayer/lifeboat_pumps/south2)
 "wLy" = (
 /obj/structure/pipes/vents/pump/no_boom{
-	welded = 1;
-	name = "Secure Reinforced Air Vent"
+	name = "Secure Reinforced Air Vent";
+	welded = 1
 	},
 /turf/open/floor/almayer/research/containment/floor2{
 	dir = 1
@@ -75713,9 +76155,13 @@
 /area/almayer/living/briefing)
 "wNU" = (
 /obj/structure/machinery/door/airlock/almayer/maint{
+	access_modified = 1;
 	dir = 2;
-	req_one_access = list(2,34,30);
-	access_modified = 1
+	req_one_access = list(2,34,30)
+	},
+/obj/structure/machinery/door/poddoor/almayer/open{
+	id = "Brig Lockdown Shutters";
+	name = "\improper Brig Lockdown Shutter"
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -76037,7 +76483,10 @@
 /obj/structure/bed/chair/comfy{
 	dir = 4
 	},
-/turf/open/floor/almayer,
+/turf/open/floor/almayer{
+	dir = 8;
+	icon_state = "blue"
+	},
 /area/almayer/living/pilotbunks)
 "wUS" = (
 /obj/structure/disposalpipe/segment{
@@ -76192,13 +76641,10 @@
 /turf/closed/wall/almayer/research/containment/wall/north,
 /area/almayer/medical/containment/cell)
 "wWC" = (
-/obj/structure/flora/pottedplant{
-	icon_state = "pottedplant_21"
+/turf/open/floor/almayer{
+	dir = 10;
+	icon_state = "blue"
 	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "S"
-	},
-/turf/open/floor/almayer,
 /area/almayer/living/pilotbunks)
 "wWL" = (
 /obj/item/tool/screwdriver,
@@ -76269,6 +76715,19 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/hangar)
+"wYj" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "W";
+	pixel_x = -1
+	},
+/obj/structure/bed/sofa/south/white/left{
+	pixel_y = 16
+	},
+/turf/open/floor/almayer{
+	dir = 9;
+	icon_state = "silver"
+	},
+/area/almayer/hull/upper_hull/u_m_p)
 "wYA" = (
 /obj/structure/bed/chair/comfy/teal{
 	dir = 8
@@ -76358,12 +76817,13 @@
 	},
 /area/almayer/hull/lower_hull/l_a_s)
 "wZM" = (
-/obj/structure/bed/sofa/south,
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "silver"
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
 	},
-/area/almayer/shipboard/brig/cic_hallway)
+/turf/open/floor/almayer{
+	icon_state = "blue"
+	},
+/area/almayer/hallways/aft_hallway)
 "wZT" = (
 /obj/structure/sign/safety/hvac_old{
 	pixel_x = 8;
@@ -77078,10 +77538,10 @@
 	dir = 1
 	},
 /obj/structure/machinery/door/airlock/multi_tile/almayer/secdoor/glass/reinforced{
+	access_modified = 1;
 	name = "\improper Brig";
 	req_access = null;
-	req_one_access_txt = "1;3";
-	access_modified = 1
+	req_one_access_txt = "1;3"
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -77230,10 +77690,10 @@
 /area/almayer/hallways/vehiclehangar)
 "xtC" = (
 /obj/structure/machinery/door/airlock/almayer/maint{
+	access_modified = 1;
 	dir = 1;
 	req_one_access = null;
-	req_one_access_txt = "30;19";
-	access_modified = 1
+	req_one_access_txt = "30;19"
 	},
 /obj/structure/machinery/door/firedoor/border_only/almayer{
 	dir = 2
@@ -77787,6 +78247,7 @@
 	pixel_y = 3
 	},
 /obj/item/folder/yellow,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -78355,7 +78816,10 @@
 /obj/structure/pipes/vents/pump{
 	dir = 8
 	},
-/turf/open/floor/almayer,
+/turf/open/floor/almayer{
+	dir = 8;
+	icon_state = "bluecorner"
+	},
 /area/almayer/living/pilotbunks)
 "xQm" = (
 /turf/open/floor/almayer/research/containment/floor2{
@@ -78739,9 +79203,9 @@
 /area/almayer/squads/alpha_bravo_shared)
 "xWo" = (
 /obj/structure/machinery/door/airlock/almayer/maint{
-	req_one_access_txt = "19;21";
 	access_modified = 1;
-	req_one_access = null
+	req_one_access = null;
+	req_one_access_txt = "19;21"
 	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
@@ -78758,9 +79222,9 @@
 /area/almayer/shipboard/brig/cic_hallway)
 "xWF" = (
 /obj/structure/machinery/door/airlock/almayer/maint{
+	access_modified = 1;
 	dir = 2;
-	req_one_access = list(2,34,30);
-	access_modified = 1
+	req_one_access = list(2,34,30)
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -79352,11 +79816,14 @@
 	},
 /area/almayer/engineering/upper_engineering/notunnel)
 "yjM" = (
-/obj/effect/decal/cleanable/blood/oil,
-/turf/open/floor/almayer{
-	icon_state = "mono"
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
 	},
-/area/almayer/lifeboat_pumps/south2)
+/turf/open/floor/almayer{
+	dir = 4;
+	icon_state = "blue"
+	},
+/area/almayer/living/pilotbunks)
 "ykj" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer{
 	dir = 2
@@ -93923,7 +94390,7 @@ dvT
 ieo
 vxC
 ldD
-wZM
+vGA
 hUW
 dHd
 vka
@@ -94318,9 +94785,9 @@ adG
 adG
 adG
 adG
-akC
-akC
-akC
+rPC
+rPC
+dav
 rPC
 rPC
 kDb
@@ -94354,9 +94821,9 @@ czB
 mtl
 mnm
 kIV
-kCi
-kCi
-kCi
+wNU
+kIV
+kIV
 tuA
 tuA
 tuA
@@ -94520,13 +94987,13 @@ aeK
 aeK
 bur
 hdd
-aok
-sHM
-aHY
+akC
+akC
+akC
 akC
 cVJ
 rPC
-rPC
+jvJ
 vxM
 sVy
 mKh
@@ -94556,11 +95023,11 @@ kHK
 wfL
 mtl
 mnm
-kIV
+dGc
 kCi
-dUI
-wbu
-rVN
+kCi
+kCi
+kCi
 hjA
 nIE
 jKn
@@ -94724,8 +95191,8 @@ aeK
 bur
 wdI
 sFf
-adu
-aHZ
+bbV
+bzz
 akC
 cRc
 rPC
@@ -94759,9 +95226,9 @@ sBH
 vfv
 mtl
 mnm
-kIV
+dGc
 kCi
-nRR
+sDD
 kOv
 cRv
 sQF
@@ -95130,7 +95597,7 @@ amz
 amz
 aly
 nkx
-adu
+bbZ
 btv
 akC
 dDC
@@ -95163,7 +95630,7 @@ lNF
 rkK
 cIK
 mtl
-mnm
+tzj
 kIV
 bbR
 kCi
@@ -95366,7 +95833,7 @@ pJE
 wPk
 hRy
 mtl
-mnm
+tzj
 kIV
 bVT
 kCi
@@ -95742,7 +96209,7 @@ nIt
 adu
 hxG
 akC
-avl
+fvu
 qkn
 wcn
 vxM
@@ -95981,7 +96448,7 @@ tJo
 bpd
 bqT
 vZv
-btD
+vjK
 awC
 uMj
 uMj
@@ -96176,16 +96643,16 @@ rWs
 mIy
 eEw
 lPC
-vka
+mgy
 wWT
 xuB
-gpe
+vcK
 czJ
 kCi
 nRR
 btM
-btD
-hjA
+vjK
+dUZ
 nIE
 jKn
 pyi
@@ -96347,7 +96814,7 @@ afa
 aeK
 bur
 wdI
-sFf
+aHY
 tyK
 iKI
 akC
@@ -96385,10 +96852,10 @@ lIV
 gsH
 qFl
 kCi
-nRR
-kOv
+cfk
+uws
 cRv
-sQF
+nwx
 nIE
 jKn
 vjg
@@ -96550,14 +97017,14 @@ aeK
 aeK
 bur
 xFP
-umS
-jvJ
-aex
+akC
+akC
+akC
 akC
 fcF
 avl
 lFb
-avl
+fvu
 age
 age
 vSN
@@ -96585,12 +97052,12 @@ qFl
 qFl
 gpe
 xuB
-gpe
+vcK
 mBA
 kCi
-pLW
+kCi
 wGI
-pPN
+kCi
 vmW
 nIE
 jKn
@@ -96754,13 +97221,13 @@ adG
 adG
 adG
 adG
-akC
-akC
-akC
+puK
+avl
+dUI
 avl
 avl
 lFb
-avl
+fvu
 xDp
 age
 xDn
@@ -96789,10 +97256,10 @@ rnM
 gpe
 sDy
 ukU
-cNe
-qFl
-qFl
-kCi
+bfP
+fvv
+vcK
+vcK
 tuA
 tuA
 tuA
@@ -96957,9 +97424,9 @@ aag
 aag
 aag
 pCi
-puK
+avl
 nMc
-iJf
+ayP
 iJf
 iJf
 sFZ
@@ -97161,10 +97628,10 @@ aag
 aag
 pCi
 dRV
-tGf
-wex
-avl
-puK
+bZg
+kcH
+kcH
+kcH
 kcH
 kcH
 kcH
@@ -98214,8 +98681,8 @@ aES
 aES
 aES
 aES
-aES
-lDN
+gpe
+uEv
 gpe
 xEF
 xEF
@@ -98416,9 +98883,9 @@ ceK
 sxD
 bhJ
 bHG
-ayP
 aES
-xuB
+aES
+mtE
 gpe
 cEg
 hgm
@@ -102245,7 +102712,7 @@ unT
 kng
 fDV
 aiX
-wWC
+aiX
 tAL
 awX
 tAL
@@ -102649,7 +103116,7 @@ aoI
 weD
 fdE
 amh
-fdE
+amh
 aiX
 cJu
 pXx
@@ -102850,15 +103317,15 @@ afr
 akc
 buc
 weD
-amh
+jMm
 pcG
 iFn
 qnD
-amd
-amd
+amh
+kWT
 wUR
 wUR
-amd
+wWC
 auZ
 aiX
 aiX
@@ -103058,10 +103525,10 @@ aiX
 aiX
 aiX
 oqw
-amd
+lvA
 osT
 cZV
-amd
+pQV
 apq
 ana
 aiX
@@ -103240,14 +103707,14 @@ bdH
 aaC
 abs
 adq
-lvA
+add
 ajI
 add
 auJ
 aHU
 aTm
-aea
-aTm
+adq
+aok
 jgF
 auJ
 add
@@ -103260,17 +103727,17 @@ fdE
 mLz
 iFn
 alw
-amd
+amh
 dGr
 rtY
 fJy
 xQg
-apq
+wWC
 szO
 aiX
 atU
 amO
-avj
+qLj
 awF
 awF
 aEW
@@ -103292,13 +103759,13 @@ aJU
 lqZ
 ouQ
 iun
-aJU
+pgD
 vPm
 qys
 lqZ
 aJU
 tiW
-kWT
+aJU
 pgD
 tQV
 aaC
@@ -103383,7 +103850,7 @@ baI
 baI
 bGO
 bHB
-btO
+uAb
 bcm
 mzo
 sYC
@@ -103466,18 +103933,18 @@ aiX
 amd
 dXY
 fmB
-fmB
-dXY
-apq
+umS
+yjM
+qbO
 aqw
-aiX
-atV
+hnI
+ayT
 amO
-avj
-agm
+wZM
+aPm
 awF
 aHk
-rvA
+vGI
 aLp
 awF
 jss
@@ -103586,7 +104053,7 @@ bEN
 baX
 bcp
 bHB
-aYt
+xAY
 aYz
 mzo
 vhq
@@ -103652,7 +104119,7 @@ awW
 avc
 aIv
 aTm
-bvd
+add
 cbM
 jzZ
 sLo
@@ -103669,18 +104136,18 @@ aiX
 apt
 sCI
 pWN
-pWN
+uTN
 aqy
 nBE
 pOD
 bZa
 ahM
 aEf
-avj
-ahF
+wZM
+ejp
 awF
 aHn
-rvA
+szU
 aLt
 awF
 aRC
@@ -103698,7 +104165,7 @@ baw
 hJk
 yac
 vbB
-dav
+wDl
 vbB
 fDS
 iLd
@@ -103789,7 +104256,7 @@ wqh
 xyw
 bcc
 bHB
-aYt
+xAY
 aYz
 mzo
 xIj
@@ -103855,7 +104322,7 @@ add
 auJ
 aHU
 aTm
-bzz
+adq
 aTm
 jgF
 auJ
@@ -103870,16 +104337,16 @@ aiX
 aiX
 aiX
 awq
-amd
-amd
+lvA
+pQV
 mHO
 aiX
 aiX
-mJL
 aiX
-ayT
+aiX
+atV
 amO
-avj
+oXd
 qFl
 qFl
 qFl
@@ -103901,8 +104368,8 @@ aJU
 lqZ
 ouQ
 vbB
-fvu
-vbB
+pgD
+tBq
 qys
 lqZ
 aJU
@@ -103992,7 +104459,7 @@ bEO
 rOc
 fVz
 bHB
-btO
+uII
 ruz
 mzo
 gwm
@@ -104072,14 +104539,14 @@ fdE
 feS
 iFn
 alw
-amd
-amd
-amd
-amd
+kFe
+mJL
+qbO
+wbu
 aiX
 aKG
 amb
-bZg
+aiX
 bYe
 amO
 avj
@@ -104195,7 +104662,7 @@ gfW
 gfW
 xyw
 bHB
-btO
+uII
 wrT
 mzo
 pVu
@@ -104275,11 +104742,11 @@ nwL
 amh
 nPx
 aiX
-pQV
+aiX
 uOJ
 pqc
-amd
-aiX
+pqc
+aqz
 aKH
 and
 aiX
@@ -104302,8 +104769,8 @@ awS
 tvQ
 yhI
 tTu
-gVF
-qLj
+sgU
+baw
 aJU
 aJU
 aJU
@@ -104398,7 +104865,7 @@ bEP
 gfW
 bGQ
 bHB
-btO
+qnd
 cmp
 cmp
 cmp
@@ -104478,10 +104945,10 @@ akv
 eGH
 qnl
 aiX
-aiX
-aiX
-aiX
-amd
+fuz
+pLW
+sht
+wex
 aiX
 aiX
 aiX
@@ -104683,11 +105150,11 @@ aau
 aau
 uVX
 ase
+sht
+uOJ
 aqz
-amd
-aqz
-ase
-atS
+mBe
+atT
 aiX
 ayU
 amO
@@ -104886,8 +105353,8 @@ dBs
 aau
 fuz
 tld
-aiX
-ccc
+uOJ
+mHO
 aiX
 asf
 atT
@@ -104896,7 +105363,7 @@ mQH
 amT
 ioX
 pUJ
-inC
+foR
 anX
 aht
 gvC
@@ -104911,8 +105378,8 @@ pUJ
 mSi
 wHp
 gZw
-sgU
-baw
+gVF
+kuk
 baw
 aJU
 nig
@@ -105089,7 +105556,7 @@ vwV
 aiX
 aiX
 aiX
-aiX
+sHM
 kUh
 aiX
 aiX
@@ -111587,7 +112054,7 @@ vOy
 aID
 gLc
 mKx
-mKx
+iit
 kZV
 vOy
 vOy
@@ -111790,7 +112257,7 @@ vOy
 aMd
 pGK
 pRX
-pRX
+mHD
 pRX
 vOy
 jFf
@@ -111992,7 +112459,7 @@ avj
 vOy
 aMg
 aSo
-mHD
+pRX
 mHD
 tzL
 vOy
@@ -112196,7 +112663,7 @@ vOy
 aQZ
 bkT
 pRX
-pRX
+mHD
 pRX
 vOy
 foP
@@ -112399,7 +112866,7 @@ vOy
 dVd
 lea
 hKl
-mKx
+lDN
 kZV
 vOy
 vOy
@@ -112628,7 +113095,7 @@ bqo
 aRD
 aGt
 byp
-uTN
+aGt
 awE
 vGk
 qVM
@@ -114853,7 +115320,7 @@ akU
 jHG
 qVM
 qVM
-xeG
+qVM
 qVM
 qVM
 qVM
@@ -115056,8 +115523,8 @@ akU
 avj
 qVM
 nNA
-vGk
-csz
+ekO
+nNA
 qVM
 iBt
 iBt
@@ -115257,10 +115724,10 @@ vOy
 ayT
 aii
 avj
-qVM
-har
+ltK
 vGk
-hoX
+hDv
+ghW
 qVM
 iBt
 iBt
@@ -115460,10 +115927,10 @@ vOy
 ayT
 aii
 avj
-qVM
-csz
-vGk
-csz
+ltK
+wYj
+jhY
+fqx
 qVM
 iBt
 iBt
@@ -115663,8 +116130,8 @@ vOy
 aEK
 aSv
 ioX
-qVM
-pzQ
+ltK
+nXF
 vGk
 bqG
 qVM
@@ -115868,7 +116335,7 @@ akV
 atL
 qVM
 qVM
-xeG
+nWc
 qVM
 qVM
 qVM
@@ -117083,7 +117550,7 @@ apK
 cbr
 abg
 amO
-abg
+uGt
 qVM
 qVM
 vGk
@@ -117286,7 +117753,7 @@ aHq
 aHq
 abg
 ajt
-abg
+kGI
 aPm
 qVM
 vGk
@@ -117489,7 +117956,7 @@ bti
 aHq
 sDC
 ajt
-abg
+kGI
 ejp
 qVM
 vGk
@@ -117692,7 +118159,7 @@ rUy
 cnS
 iWN
 ajt
-abg
+nYv
 qVM
 qVM
 vGk
@@ -119190,8 +119657,8 @@ aQL
 mJP
 bSn
 aQL
-aLG
-aNO
+vHs
+ehH
 aYZ
 sLE
 bAV
@@ -119217,8 +119684,8 @@ bCB
 cbv
 iEb
 bHY
-bHa
-buH
+mru
+syP
 bJC
 jSp
 lAQ
@@ -119393,8 +119860,8 @@ aTw
 aUj
 kLk
 aQL
-aWN
-aLG
+mTn
+aiy
 aYZ
 sLE
 bbk
@@ -119420,8 +119887,8 @@ bdk
 bGh
 iEb
 bHY
-buH
-fBx
+njy
+hkE
 bJC
 ojF
 bNG
@@ -119597,7 +120064,7 @@ aQL
 aQL
 aQL
 aQL
-aLG
+uQn
 aYZ
 sLE
 bbl
@@ -119623,7 +120090,7 @@ bdl
 bGi
 iEb
 bHY
-buH
+oyy
 bJC
 bJC
 bJC
@@ -120500,8 +120967,8 @@ aeC
 asV
 ayn
 atr
-bbV
-atr
+acx
+aex
 ciw
 asV
 aeC
@@ -120547,8 +121014,8 @@ kkx
 vcE
 mMu
 iMx
-bXe
-jMm
+tGi
+rRq
 bXe
 eyG
 mMu
@@ -120906,7 +121373,7 @@ aeA
 atp
 ayR
 atr
-bbZ
+aeC
 atr
 cji
 nqV
@@ -120954,7 +121421,7 @@ lJY
 hlX
 umh
 bXe
-kFe
+vcE
 tGi
 pfH
 wlF
@@ -121109,7 +121576,7 @@ aeC
 asV
 ayn
 atr
-aeC
+acx
 bXz
 ciw
 asV
@@ -121157,8 +121624,8 @@ vcE
 mMu
 iMx
 bXe
-yjM
-bXe
+rRq
+mzF
 eyG
 mMu
 vcE
@@ -122323,7 +122790,7 @@ aad
 aag
 aag
 abh
-qbO
+aeC
 atr
 aeC
 atr
@@ -122379,7 +122846,7 @@ vcE
 bXe
 vcE
 bXe
-sht
+vcE
 uOi
 aag
 aag
@@ -123659,8 +124126,8 @@ aQL
 aQL
 aLG
 aYO
-aLG
-jJs
+kBK
+hyt
 bdl
 tFS
 bdj
@@ -123680,8 +124147,8 @@ jaR
 mJa
 wWP
 rsK
-pJJ
-buH
+aGc
+kkE
 iEb
 bIT
 bJC
@@ -123862,7 +124329,7 @@ bES
 kcl
 aLG
 aYO
-aLG
+sou
 bAX
 bdl
 wIr
@@ -123884,7 +124351,7 @@ bdl
 bdl
 bdl
 dhU
-buH
+vzq
 iEb
 bIT
 hNw
@@ -125491,7 +125958,7 @@ kFY
 jmK
 bDL
 bbs
-iit
+ccQ
 bCN
 rbF
 vub

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -14664,6 +14664,7 @@
 "bbX" = (
 /obj/structure/prop/resource_node,
 /obj/effect/decal/cleanable/blood/oil,
+/obj/structure/blocker/invisible_wall,
 /turf/open/floor/almayer{
 	icon_state = "mono"
 	},
@@ -18284,6 +18285,7 @@
 /area/almayer/command/corporateliason)
 "bvd" = (
 /obj/structure/prop/resource_node,
+/obj/structure/blocker/invisible_wall,
 /turf/open/floor/almayer{
 	icon_state = "mono"
 	},
@@ -33816,6 +33818,12 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/lifeboat_pumps/north1)
+"eGb" = (
+/obj/structure/blocker/invisible_wall,
+/turf/open/floor/almayer{
+	icon_state = "mono"
+	},
+/area/almayer/lifeboat_pumps/north2)
 "eGg" = (
 /obj/structure/machinery/door/poddoor/railing{
 	dir = 8;
@@ -39283,6 +39291,7 @@
 "haM" = (
 /obj/structure/prop/resource_node,
 /obj/effect/decal/cleanable/blood/oil,
+/obj/structure/blocker/invisible_wall,
 /turf/open/floor/almayer{
 	icon_state = "mono"
 	},
@@ -47700,6 +47709,12 @@
 /obj/structure/bed/chair/comfy/orange,
 /turf/open/floor/almayer,
 /area/almayer/shipboard/brig/main_office)
+"kJL" = (
+/obj/structure/blocker/invisible_wall,
+/turf/open/floor/almayer{
+	icon_state = "mono"
+	},
+/area/almayer/lifeboat_pumps/north1)
 "kJV" = (
 /obj/structure/machinery/light,
 /turf/open/floor/almayer{
@@ -48248,6 +48263,13 @@
 	icon_state = "cargo"
 	},
 /area/almayer/engineering/upper_engineering/port)
+"kUQ" = (
+/obj/effect/decal/cleanable/blood/oil/streak,
+/obj/structure/blocker/invisible_wall,
+/turf/open/floor/almayer{
+	icon_state = "mono"
+	},
+/area/almayer/lifeboat_pumps/south1)
 "kUV" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -49652,6 +49674,12 @@
 	icon_state = "plate"
 	},
 /area/almayer/living/auxiliary_officer_office)
+"lxT" = (
+/obj/structure/blocker/invisible_wall,
+/turf/open/floor/almayer{
+	icon_state = "mono"
+	},
+/area/almayer/lifeboat_pumps/south2)
 "lxW" = (
 /obj/structure/sign/prop2{
 	pixel_y = 29
@@ -63564,6 +63592,7 @@
 /area/almayer/command/cichallway)
 "rBH" = (
 /obj/structure/prop/resource_node,
+/obj/structure/blocker/invisible_wall,
 /turf/open/floor/almayer{
 	icon_state = "mono"
 	},
@@ -103713,7 +103742,7 @@ add
 auJ
 aHU
 aTm
-adq
+abs
 aok
 jgF
 auJ
@@ -103759,7 +103788,7 @@ aJU
 lqZ
 ouQ
 iun
-pgD
+tQV
 vPm
 qys
 lqZ
@@ -104119,7 +104148,7 @@ awW
 avc
 aIv
 aTm
-add
+kJL
 cbM
 jzZ
 sLo
@@ -104165,7 +104194,7 @@ baw
 hJk
 yac
 vbB
-wDl
+kUQ
 vbB
 fDS
 iLd
@@ -104322,7 +104351,7 @@ add
 auJ
 aHU
 aTm
-adq
+abs
 aTm
 jgF
 auJ
@@ -104368,7 +104397,7 @@ aJU
 lqZ
 ouQ
 vbB
-pgD
+tQV
 tBq
 qys
 lqZ
@@ -120967,7 +120996,7 @@ aeC
 asV
 ayn
 atr
-acx
+abh
 aex
 ciw
 asV
@@ -121015,7 +121044,7 @@ vcE
 mMu
 iMx
 tGi
-rRq
+uOi
 bXe
 eyG
 mMu
@@ -121373,7 +121402,7 @@ aeA
 atp
 ayR
 atr
-aeC
+eGb
 atr
 cji
 nqV
@@ -121421,7 +121450,7 @@ lJY
 hlX
 umh
 bXe
-vcE
+lxT
 tGi
 pfH
 wlF
@@ -121576,7 +121605,7 @@ aeC
 asV
 ayn
 atr
-acx
+abh
 bXz
 ciw
 asV
@@ -121624,7 +121653,7 @@ vcE
 mMu
 iMx
 bXe
-rRq
+uOi
 mzF
 eyG
 mMu

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -14662,7 +14662,7 @@
 /turf/open/floor/almayer,
 /area/almayer/shipboard/starboard_missiles)
 "bbX" = (
-/obj/structure/resource_node,
+/obj/structure/prop/resource_node,
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/almayer{
 	icon_state = "mono"
@@ -18283,7 +18283,7 @@
 /turf/open/floor/wood/ship,
 /area/almayer/command/corporateliason)
 "bvd" = (
-/obj/structure/resource_node,
+/obj/structure/prop/resource_node,
 /turf/open/floor/almayer{
 	icon_state = "mono"
 	},
@@ -39281,7 +39281,7 @@
 	},
 /area/almayer/command/cichallway)
 "haM" = (
-/obj/structure/resource_node,
+/obj/structure/prop/resource_node,
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/almayer{
 	icon_state = "mono"
@@ -63563,7 +63563,7 @@
 	},
 /area/almayer/command/cichallway)
 "rBH" = (
-/obj/structure/resource_node,
+/obj/structure/prop/resource_node,
 /turf/open/floor/almayer{
 	icon_state = "mono"
 	},

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -19724,6 +19724,14 @@
 /area/almayer/shipboard/weapon_room)
 "bDe" = (
 /obj/structure/surface/table/almayer,
+/obj/item/circuitboard{
+	pixel_x = 12;
+	pixel_y = 7
+	},
+/obj/item/tool/crowbar{
+	pixel_x = 6;
+	pixel_y = 1
+	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -31625,6 +31633,16 @@
 	icon_state = "dark_sterile"
 	},
 /area/almayer/shipboard/brig/surgery)
+"dQE" = (
+/obj/structure/machinery/light{
+	dir = 1
+	},
+/obj/structure/janitorialcart,
+/obj/item/tool/mop,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/upper_hull/u_m_p)
 "dQH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -35153,15 +35171,11 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/medical/medical_science)
 "foR" = (
-/obj/structure/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/janitorialcart,
-/obj/item/tool/mop,
+/obj/structure/largecrate/random/case,
 /turf/open/floor/almayer{
-	icon_state = "cargo"
+	icon_state = "plate"
 	},
-/area/almayer/hull/upper_hull/u_f_p)
+/area/almayer/hull/upper_hull/u_m_p)
 "fpd" = (
 /obj/structure/sign/safety/hvac_old{
 	pixel_x = 8;
@@ -73647,6 +73661,15 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/medical/upper_medical)
+"vLv" = (
+/obj/structure/largecrate/random/case/double,
+/obj/structure/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/upper_hull/u_m_p)
 "vLA" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W";
@@ -105464,7 +105487,7 @@ mQH
 amT
 ioX
 pUJ
-foR
+inC
 anX
 aht
 gvC
@@ -107310,10 +107333,10 @@ atj
 atj
 atj
 czu
-csz
-csz
+foR
+usi
 vGk
-csz
+foR
 qVM
 rQW
 yhI
@@ -107513,10 +107536,10 @@ atj
 atj
 atj
 czu
-csz
+usi
 vGk
 vGk
-csz
+vLv
 qVM
 wTy
 wTy
@@ -107716,7 +107739,7 @@ atl
 atl
 atl
 czu
-csz
+dQE
 vGk
 csz
 qVM
@@ -107871,7 +107894,7 @@ aez
 boL
 akY
 boL
-aao
+aiH
 aiv
 aap
 uoS
@@ -107919,8 +107942,8 @@ atI
 atI
 atI
 czu
-csz
-csz
+usi
+foR
 csz
 xCX
 aJU

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -1973,15 +1973,6 @@
 "agu" = (
 /turf/open/floor/almayer,
 /area/almayer/living/officer_study)
-"agv" = (
-/obj/structure/machinery/power/apc/almayer{
-	dir = 1
-	},
-/turf/open/floor/almayer{
-	dir = 5;
-	icon_state = "red"
-	},
-/area/almayer/living/starboard_garden)
 "agw" = (
 /obj/structure/machinery/light{
 	dir = 8
@@ -108339,7 +108330,7 @@ aag
 aag
 acf
 aet
-agv
+agS
 aiP
 aYq
 aar

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -1052,7 +1052,8 @@
 	name = "ship-grade camera"
 	},
 /turf/open/floor/almayer{
-	icon_state = "plate"
+	dir = 4;
+	icon_state = "green"
 	},
 /area/almayer/living/starboard_garden)
 "adp" = (
@@ -1161,8 +1162,11 @@
 	},
 /area/almayer/hallways/aft_hallway)
 "adI" = (
-/obj/docking_port/stationary/escape_pod/south,
-/turf/open/floor/plating,
+/obj/structure/reagent_dispensers/fueltank,
+/obj/structure/machinery/light/small,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
 /area/almayer/hull/upper_hull/u_m_p)
 "adO" = (
 /turf/closed/wall/almayer,
@@ -1858,9 +1862,6 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/engineering/upper_engineering/starboard)
-"afY" = (
-/turf/open/floor/grass,
-/area/almayer/living/starboard_garden)
 "afZ" = (
 /obj/structure/bed/chair/comfy/blue{
 	dir = 8
@@ -1905,10 +1906,6 @@
 	icon_state = "bluecorner"
 	},
 /area/almayer/living/offices/flight)
-"agh" = (
-/obj/structure/flora/bush/ausbushes/var3/fullgrass,
-/turf/open/floor/grass,
-/area/almayer/living/starboard_garden)
 "agi" = (
 /obj/structure/machinery/door/airlock/almayer/maint{
 	access_modified = 1;
@@ -1977,7 +1974,10 @@
 /obj/structure/machinery/power/apc/almayer{
 	dir = 1
 	},
-/turf/open/floor/grass,
+/turf/open/floor/almayer{
+	dir = 5;
+	icon_state = "red"
+	},
 /area/almayer/living/starboard_garden)
 "agw" = (
 /obj/structure/machinery/light{
@@ -2000,13 +2000,10 @@
 /turf/open/floor/plating,
 /area/almayer/living/basketball)
 "agB" = (
-/obj/structure/flora/bush/ausbushes/var3/fullgrass,
-/obj/item/device/radio/intercom{
-	freerange = 1;
-	name = "General Listening Channel";
-	pixel_y = 28
+/turf/open/floor/almayer{
+	dir = 9;
+	icon_state = "red"
 	},
-/turf/open/floor/grass,
 /area/almayer/living/starboard_garden)
 "agG" = (
 /obj/structure/stairs/perspective{
@@ -2080,10 +2077,6 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/living/officer_study)
-"agP" = (
-/obj/structure/flora/bush/ausbushes/ppflowers,
-/turf/open/floor/grass,
-/area/almayer/living/starboard_garden)
 "agQ" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer,
 /turf/open/floor/almayer{
@@ -2091,12 +2084,10 @@
 	},
 /area/almayer/living/cafeteria_officer)
 "agS" = (
-/obj/item/device/radio/intercom{
-	freerange = 1;
-	name = "General Listening Channel";
-	pixel_y = 28
+/turf/open/floor/almayer{
+	dir = 5;
+	icon_state = "red"
 	},
-/turf/open/floor/grass,
 /area/almayer/living/starboard_garden)
 "agT" = (
 /turf/open/floor/prison{
@@ -2219,8 +2210,10 @@
 	},
 /area/almayer/hull/upper_hull/u_m_s)
 "ahl" = (
-/obj/structure/flora/bush/ausbushes/var3/ywflowers,
-/turf/open/floor/grass,
+/turf/open/floor/almayer{
+	dir = 9;
+	icon_state = "green"
+	},
 /area/almayer/living/starboard_garden)
 "ahn" = (
 /obj/structure/machinery/light/small{
@@ -2238,10 +2231,6 @@
 /obj/structure/window/framed/almayer,
 /turf/open/floor/plating,
 /area/almayer/living/offices/flight)
-"ahp" = (
-/obj/structure/flora/bush/ausbushes/var3/brflowers,
-/turf/open/floor/grass,
-/area/almayer/living/starboard_garden)
 "ahq" = (
 /obj/structure/machinery/alarm/almayer{
 	dir = 1
@@ -2260,42 +2249,12 @@
 	icon_state = "green"
 	},
 /area/almayer/hallways/aft_hallway)
-"ahs" = (
-/obj/structure/surface/table/almayer,
-/obj/item/paper_bin/uscm{
-	pixel_y = 6
-	},
-/obj/item/tool/pen,
-/obj/structure/sign/safety/terminal{
-	pixel_x = -17
-	},
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/hull/upper_hull/u_m_s)
 "aht" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
 /area/almayer/hull/upper_hull/u_f_p)
-"ahu" = (
-/obj/item/device/flashlight/lamp/green{
-	pixel_y = 10
-	},
-/obj/structure/surface/table/almayer,
-/obj/item/trash/uscm_mre{
-	pixel_x = 7;
-	pixel_y = 4
-	},
-/obj/item/reagent_container/food/snacks/mre_pack/meal1{
-	pixel_x = -13;
-	pixel_y = 8
-	},
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/hull/upper_hull/u_m_s)
 "ahv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -2311,19 +2270,17 @@
 /turf/open/floor/wood/ship,
 /area/almayer/living/commandbunks)
 "ahx" = (
-/obj/structure/closet,
-/obj/item/clothing/under/marine/engineer,
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
+/obj/structure/window/framed/almayer/hull,
+/turf/open/floor/plating,
 /area/almayer/hull/upper_hull/u_m_s)
 "ahy" = (
-/obj/structure/closet,
-/obj/item/clothing/under/marine,
-/turf/open/floor/almayer{
-	icon_state = "plate"
+/obj/item/device/radio/intercom{
+	freerange = 1;
+	name = "General Listening Channel";
+	pixel_y = 28
 	},
-/area/almayer/hull/upper_hull/u_m_s)
+/turf/closed/wall/almayer,
+/area/almayer/living/starboard_garden)
 "ahz" = (
 /obj/structure/machinery/light{
 	dir = 1
@@ -2385,11 +2342,9 @@
 	},
 /area/almayer/hallways/aft_hallway)
 "ahN" = (
-/obj/effect/decal/cleanable/blood/oil,
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/hull/upper_hull/u_m_s)
+/obj/structure/flora/bush/ausbushes/var3/ywflowers,
+/turf/open/floor/grass,
+/area/almayer/living/starboard_garden)
 "ahR" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer,
@@ -2421,18 +2376,6 @@
 	icon_state = "bluecorner"
 	},
 /area/almayer/living/offices/flight)
-"ahW" = (
-/obj/structure/surface/rack,
-/obj/item/tool/extinguisher/mini{
-	pixel_x = -4
-	},
-/obj/item/tool/extinguisher/mini{
-	pixel_x = 6
-	},
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/hull/upper_hull/u_m_s)
 "ahX" = (
 /obj/structure/machinery/light/small{
 	dir = 4
@@ -2696,12 +2639,10 @@
 /turf/open/floor/wood/ship,
 /area/almayer/living/commandbunks)
 "aiH" = (
-/obj/item/tool/crew_monitor,
-/obj/structure/surface/rack,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/hull/upper_hull/u_m_s)
+/area/almayer/living/starboard_garden)
 "aiJ" = (
 /obj/effect/step_trigger/teleporter_vector{
 	name = "Almayer_Down3";
@@ -2713,14 +2654,11 @@
 	},
 /area/almayer/stair_clone/upper)
 "aiP" = (
-/obj/structure/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/largecrate/random,
 /turf/open/floor/almayer{
-	icon_state = "plate"
+	dir = 4;
+	icon_state = "red"
 	},
-/area/almayer/hull/upper_hull/u_m_s)
+/area/almayer/living/starboard_garden)
 "aiQ" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/faxmachine,
@@ -2746,6 +2684,9 @@
 /obj/structure/closet,
 /obj/item/device/flashlight/pen,
 /obj/item/attachable/reddot,
+/obj/structure/machinery/light/small{
+	dir = 1
+	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -2761,6 +2702,7 @@
 "aiU" = (
 /obj/structure/surface/table/almayer,
 /obj/item/card/id/visa,
+/obj/item/tool/crew_monitor,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -3416,10 +3358,10 @@
 	},
 /area/almayer/hallways/starboard_hallway)
 "akY" = (
-/obj/effect/step_trigger/message/memorial,
-/turf/open/floor/almayer{
-	icon_state = "plate"
+/obj/structure/cable/heavyduty{
+	icon_state = "4-8"
 	},
+/turf/open/floor/plating/plating_catwalk,
 /area/almayer/living/starboard_garden)
 "alb" = (
 /obj/structure/sink{
@@ -3451,29 +3393,29 @@
 /obj/structure/machinery/light{
 	dir = 4
 	},
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/turf/open/floor/almayer,
+/area/almayer/living/starboard_garden)
+"alf" = (
+/obj/structure/machinery/light{
+	dir = 8
+	},
+/obj/structure/bed/chair{
+	dir = 4
+	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
 /area/almayer/living/starboard_garden)
-"alf" = (
-/obj/structure/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/surface/table/almayer,
-/obj/structure/machinery/computer/atmos_alert{
-	dir = 4;
-	pixel_y = 5
-	},
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/hull/upper_hull/u_m_s)
 "alg" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 8
+/obj/structure/flora/bush/ausbushes/ppflowers,
+/obj/structure/bed/chair{
+	dir = 4
 	},
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/hull/upper_hull/u_m_s)
+/turf/open/floor/grass,
+/area/almayer/living/starboard_garden)
 "ali" = (
 /turf/open/floor/almayer{
 	dir = 8;
@@ -3533,15 +3475,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/aft_hallway)
-"alr" = (
-/obj/structure/machinery/light/small{
-	dir = 4
-	},
-/obj/structure/largecrate/random/barrel/green,
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/hull/upper_hull/u_m_s)
 "als" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer{
@@ -4836,12 +4769,6 @@
 	icon_state = "orange"
 	},
 /area/almayer/hallways/hangar)
-"apF" = (
-/obj/structure/bed/chair{
-	dir = 4
-	},
-/turf/open/floor/grass,
-/area/almayer/living/starboard_garden)
 "apI" = (
 /obj/structure/machinery/door/airlock/almayer/command{
 	dir = 2;
@@ -5072,10 +4999,6 @@
 	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
-"aqi" = (
-/obj/structure/prop/almayer/ship_memorial,
-/turf/open/floor/plating/almayer,
-/area/almayer/living/starboard_garden)
 "aqj" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/pipes/standard/simple/hidden/supply,
@@ -5086,7 +5009,11 @@
 /turf/open/floor/plating,
 /area/almayer/engineering/upper_engineering)
 "aqk" = (
-/turf/open/floor/plating/almayer,
+/obj/structure/sign/safety/escapepod{
+	pixel_x = 8;
+	pixel_y = -32
+	},
+/turf/open/floor/almayer,
 /area/almayer/living/starboard_garden)
 "aqm" = (
 /obj/item/bedsheet/brown,
@@ -5321,12 +5248,6 @@
 "arb" = (
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/medical/morgue)
-"arc" = (
-/obj/structure/bed/chair{
-	dir = 8
-	},
-/turf/open/floor/grass,
-/area/almayer/living/starboard_garden)
 "ard" = (
 /obj/structure/filingcabinet,
 /obj/item/folder/yellow,
@@ -5437,13 +5358,13 @@
 	},
 /area/almayer/hallways/starboard_hallway)
 "arp" = (
-/obj/item/roller,
-/obj/item/roller,
-/obj/structure/surface/rack,
+/obj/structure/bed/chair{
+	dir = 4
+	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/hull/upper_hull/u_m_s)
+/area/almayer/living/starboard_garden)
 "arq" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -5472,13 +5393,6 @@
 	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
-"aru" = (
-/obj/structure/surface/table/almayer,
-/obj/item/weapon/gun/rifle/m41a/stripped,
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/hull/upper_hull/u_m_s)
 "arw" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /obj/structure/disposalpipe/junction{
@@ -5489,21 +5403,6 @@
 	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
-"ary" = (
-/obj/structure/surface/table/almayer,
-/obj/item/tool/wrench,
-/obj/item/reagent_container/food/drinks/cans/souto/cherry{
-	pixel_x = 4;
-	pixel_y = 14
-	},
-/obj/item/attachable/lasersight{
-	pixel_x = -14;
-	pixel_y = 12
-	},
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/hull/upper_hull/u_m_s)
 "arz" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/almayer{
@@ -5560,14 +5459,6 @@
 	icon_state = "redfull"
 	},
 /area/almayer/engineering/upper_engineering)
-"arI" = (
-/obj/structure/closet,
-/obj/item/clothing/under/marine/mp,
-/obj/item/device/flash,
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/hull/upper_hull/u_m_s)
 "arJ" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
@@ -5958,11 +5849,8 @@
 	},
 /area/almayer/command/cic)
 "asS" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/turf/open/floor/almayer,
-/area/almayer/hallways/aft_hallway)
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/living/starboard_garden)
 "asT" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer,
@@ -7016,13 +6904,11 @@
 /turf/open/floor/plating,
 /area/almayer/shipboard/weapon_room)
 "avx" = (
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 2
+/obj/structure/machinery/light{
+	dir = 1
 	},
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/lifeboat_pumps/north1)
+/turf/open/floor/grass,
+/area/almayer/living/starboard_garden)
 "avz" = (
 /obj/structure/machinery/light,
 /obj/structure/machinery/vending/security,
@@ -7076,16 +6962,15 @@
 	},
 /area/almayer/medical/containment)
 "avJ" = (
-/obj/item/clothing/head/helmet/marine{
-	pixel_x = 16;
-	pixel_y = 6
+/obj/structure/machinery/door/airlock/almayer/secure/reinforced{
+	dir = 2;
+	name = "\improper Evacuation Airlock SU-5";
+	req_access = null
 	},
-/obj/item/reagent_container/food/snacks/grown/poppy,
-/obj/effect/step_trigger/message/memorial,
 /turf/open/floor/almayer{
-	icon_state = "plate"
+	icon_state = "test_floor4"
 	},
-/area/almayer/living/starboard_garden)
+/area/almayer/powered)
 "avK" = (
 /turf/open/floor/almayer/no_build{
 	icon_state = "ai_floors"
@@ -7201,14 +7086,11 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/living/pilotbunks)
 "avV" = (
-/obj/item/reagent_container/food/snacks/grown/poppy{
-	pixel_x = 4;
-	pixel_y = 4
+/obj/structure/machinery/power/apc/almayer{
+	dir = 1
 	},
-/obj/effect/step_trigger/message/memorial,
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
+/obj/structure/bed/chair,
+/turf/open/floor/grass,
 /area/almayer/living/starboard_garden)
 "avW" = (
 /obj/structure/surface/table/reinforced/prison,
@@ -7243,12 +7125,12 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/command/cic)
 "avZ" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 9
+/obj/structure/flora/bush/ausbushes/var3/fullgrass,
+/obj/structure/machinery/light{
+	dir = 1
 	},
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/lifeboat_pumps/south1)
+/turf/open/floor/grass,
+/area/almayer/living/starboard_garden)
 "awa" = (
 /turf/open/shuttle/dropship{
 	icon_state = "rasputin15"
@@ -7267,32 +7149,16 @@
 /turf/closed/wall/almayer/reinforced,
 /area/almayer/living/pilotbunks)
 "awe" = (
-/obj/structure/surface/table/almayer,
-/obj/item/prop/helmetgarb/gunoil{
-	pixel_x = -6;
-	pixel_y = 9
-	},
-/obj/item/tool/screwdriver{
-	pixel_x = 5;
-	pixel_y = 4
-	},
-/obj/structure/machinery/light/small{
+/turf/open/floor/plating/almayer,
+/area/almayer/living/starboard_garden)
+"awi" = (
+/obj/structure/bed/chair{
 	dir = 8
 	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/hull/upper_hull/u_m_s)
-"awh" = (
-/obj/item/stool,
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/hull/upper_hull/u_m_s)
-"awi" = (
-/obj/structure/closet/fireaxecabinet{
-	pixel_y = 32
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/hull/upper_hull/u_m_s)
+/area/almayer/living/starboard_garden)
 "awj" = (
 /obj/structure/machinery/photocopier,
 /obj/structure/sign/safety/terminal{
@@ -10623,16 +10489,13 @@
 	},
 /area/almayer/lifeboat_pumps/north1)
 "aIx" = (
-/obj/item/tool/weldpack,
-/obj/structure/surface/rack,
-/turf/open/floor/almayer{
-	icon_state = "mono"
-	},
-/area/almayer/lifeboat_pumps/north1)
+/obj/structure/flora/bush/ausbushes/ppflowers,
+/turf/open/floor/grass,
+/area/almayer/living/starboard_garden)
 "aIB" = (
-/obj/effect/decal/cleanable/blood/oil,
-/turf/open/floor/almayer,
-/area/almayer/lifeboat_pumps/north1)
+/obj/structure/flora/bush/ausbushes/var3/fullgrass,
+/turf/open/floor/grass,
+/area/almayer/living/starboard_garden)
 "aIC" = (
 /obj/structure/surface/table/almayer,
 /obj/effect/decal/warning_stripes{
@@ -10953,18 +10816,20 @@
 	},
 /area/almayer/command/cic)
 "aJJ" = (
-/obj/item/tool/screwdriver,
-/turf/open/floor/almayer,
-/area/almayer/lifeboat_pumps/north1)
+/obj/structure/flora/bush/ausbushes/var3/brflowers,
+/obj/structure/bed/chair,
+/turf/open/floor/grass,
+/area/almayer/living/starboard_garden)
 "aJL" = (
-/obj/structure/surface/rack,
-/obj/item/frame/rack{
-	pixel_y = 19
+/obj/structure/surface/table/almayer,
+/obj/item/reagent_container/food/snacks/mre_pack/meal5,
+/obj/item/device/flashlight/lamp{
+	pixel_x = 3;
+	pixel_y = 12
 	},
-/turf/open/floor/almayer{
-	icon_state = "mono"
-	},
-/area/almayer/lifeboat_pumps/north1)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/upper_hull/u_m_s)
 "aJM" = (
 /obj/docking_port/stationary/escape_pod/east,
 /turf/open/floor/plating,
@@ -10974,22 +10839,9 @@
 	icon_state = "mono"
 	},
 /area/almayer/lifeboat_pumps/south1)
-"aJW" = (
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/living/starboard_garden)
 "aKa" = (
 /turf/open/floor/almayer,
 /area/almayer/command/cichallway)
-"aKc" = (
-/obj/item/stack/cable_coil,
-/obj/structure/surface/rack,
-/obj/item/attachable/flashlight/grip,
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/hull/upper_hull/u_m_s)
 "aKf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -11001,12 +10853,9 @@
 	},
 /area/almayer/command/cichallway)
 "aKg" = (
-/obj/structure/surface/rack,
-/obj/item/device/multitool,
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/hull/upper_hull/u_m_s)
+/obj/structure/flora/bush/ausbushes/var3/brflowers,
+/turf/open/floor/grass,
+/area/almayer/living/starboard_garden)
 "aKi" = (
 /obj/structure/pipes/standard/manifold/hidden/supply{
 	dir = 1
@@ -13573,16 +13422,13 @@
 /turf/open/floor/plating,
 /area/almayer/engineering/lower_engineering)
 "aWs" = (
-/obj/structure/surface/rack,
-/obj/effect/spawner/random/tool,
-/obj/structure/machinery/light{
-	unacidable = 1;
-	unslashable = 1
+/obj/structure/machinery/power/apc/almayer{
+	dir = 4
 	},
 /turf/open/floor/almayer{
-	icon_state = "mono"
+	icon_state = "plate"
 	},
-/area/almayer/lifeboat_pumps/north1)
+/area/almayer/hull/upper_hull/u_m_s)
 "aWt" = (
 /obj/structure/machinery/vending/coffee,
 /obj/structure/sign/safety/coffee{
@@ -13594,12 +13440,13 @@
 	},
 /area/almayer/living/bridgebunks)
 "aWu" = (
-/obj/structure/machinery/camera/autoname/almayer{
-	dir = 1;
-	name = "ship-grade camera"
+/obj/structure/sign/safety/escapepod{
+	pixel_x = 8;
+	pixel_y = -32
 	},
 /turf/open/floor/almayer{
-	icon_state = "mono"
+	dir = 6;
+	icon_state = "red"
 	},
 /area/almayer/lifeboat_pumps/north1)
 "aWw" = (
@@ -13865,35 +13712,23 @@
 /turf/open/floor/plating,
 /area/almayer/command/corporateliason)
 "aYq" = (
-/obj/item/tool/warning_cone{
-	pixel_x = -12;
-	pixel_y = 16
-	},
 /turf/open/floor/almayer{
-	icon_state = "mono"
+	dir = 6;
+	icon_state = "red"
 	},
-/area/almayer/lifeboat_pumps/north1)
+/area/almayer/living/starboard_garden)
 "aYr" = (
-/obj/structure/surface/rack,
-/obj/item/frame/rack{
-	layer = 3.1;
-	pixel_y = 19
-	},
-/obj/item/reagent_container/food/snacks/cracker,
-/obj/structure/machinery/light{
-	unacidable = 1;
-	unslashable = 1
-	},
-/turf/open/floor/almayer{
-	icon_state = "mono"
-	},
-/area/almayer/lifeboat_pumps/north1)
-"aYs" = (
-/obj/structure/machinery/light{
+/obj/structure/bed/chair/office/dark{
 	dir = 8
 	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
+	},
+/area/almayer/hull/upper_hull/u_m_s)
+"aYs" = (
+/turf/open/floor/almayer{
+	dir = 10;
+	icon_state = "red"
 	},
 /area/almayer/living/starboard_garden)
 "aYt" = (
@@ -13957,12 +13792,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/starboard_hallway)
-"aYM" = (
-/obj/structure/largecrate/supply/supplies/tables_racks,
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/hull/upper_hull/u_m_s)
 "aYO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -15989,17 +15818,19 @@
 	},
 /area/almayer/lifeboat_pumps/north2)
 "biT" = (
-/obj/structure/pipes/standard/manifold/hidden/supply{
-	dir = 8
+/obj/structure/machinery/light,
+/turf/open/floor/almayer{
+	dir = 10;
+	icon_state = "red"
 	},
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/hallways/aft_hallway)
+/area/almayer/living/starboard_garden)
 "biV" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
+/obj/structure/window/framed/almayer,
+/obj/structure/machinery/door/firedoor/border_only/almayer{
+	dir = 2
 	},
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/hallways/aft_hallway)
+/turf/open/floor/plating,
+/area/almayer/living/starboard_garden)
 "bja" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/computer/secure_data{
@@ -16091,8 +15922,7 @@
 "bjJ" = (
 /obj/structure/pipes/standard/manifold/hidden/supply,
 /obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+	dir = 4
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/aft_hallway)
@@ -17072,12 +16902,7 @@
 /turf/open/floor/almayer,
 /area/almayer/engineering/engineering_workshop)
 "boL" = (
-/obj/structure/bed/chair{
-	dir = 4
-	},
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
+/turf/open/floor/almayer,
 /area/almayer/living/starboard_garden)
 "boN" = (
 /obj/structure/surface/table/almayer,
@@ -19574,14 +19399,11 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/vehiclehangar)
 "bBC" = (
-/obj/structure/disposalpipe/segment{
+/obj/structure/bed/chair{
 	dir = 4
 	},
-/turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "green"
-	},
-/area/almayer/hallways/aft_hallway)
+/turf/open/floor/grass,
+/area/almayer/living/starboard_garden)
 "bBD" = (
 /obj/structure/machinery/firealarm{
 	pixel_y = 28
@@ -19941,9 +19763,7 @@
 /obj/structure/bed/chair{
 	dir = 8
 	},
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
+/turf/open/floor/almayer,
 /area/almayer/living/starboard_garden)
 "bDF" = (
 /obj/structure/machinery/door/poddoor/almayer{
@@ -22019,7 +21839,7 @@
 /area/almayer/shipboard/weapon_room)
 "bLO" = (
 /obj/structure/bed/chair{
-	dir = 1
+	dir = 8
 	},
 /turf/open/floor/grass,
 /area/almayer/living/starboard_garden)
@@ -24072,8 +23892,15 @@
 	},
 /area/almayer/hallways/port_hallway)
 "bUA" = (
-/obj/docking_port/stationary/escape_pod/north,
-/turf/open/floor/plating,
+/obj/structure/surface/table/almayer,
+/obj/item/tool/screwdriver,
+/obj/item/prop/helmetgarb/gunoil{
+	pixel_x = -7;
+	pixel_y = 12
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
 /area/almayer/hull/upper_hull/u_m_s)
 "bUE" = (
 /turf/open/floor/almayer{
@@ -24397,15 +24224,16 @@
 	},
 /area/almayer/shipboard/port_point_defense)
 "bWd" = (
-/obj/structure/machinery/door/airlock/almayer/secure/reinforced{
-	dir = 2;
-	name = "\improper Evacuation Airlock SU-6";
-	req_access = null
+/obj/structure/machinery/light{
+	dir = 4
+	},
+/obj/structure/bed/chair{
+	dir = 8
 	},
 /turf/open/floor/almayer{
-	icon_state = "test_floor4"
+	icon_state = "plate"
 	},
-/area/almayer/powered)
+/area/almayer/living/starboard_garden)
 "bWe" = (
 /turf/open/floor/almayer{
 	dir = 5;
@@ -24413,13 +24241,14 @@
 	},
 /area/almayer/shipboard/port_point_defense)
 "bWf" = (
-/obj/structure/surface/rack,
-/obj/effect/spawner/random/tool,
-/obj/effect/spawner/random/tool,
+/obj/structure/machinery/light,
+/obj/structure/bed/chair{
+	dir = 1
+	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/hull/upper_hull/u_m_s)
+/area/almayer/living/starboard_garden)
 "bWh" = (
 /obj/structure/machinery/door/airlock/almayer/secure/reinforced{
 	dir = 2;
@@ -24430,12 +24259,6 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/powered)
-"bWj" = (
-/obj/structure/largecrate/supply,
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/hull/upper_hull/u_m_s)
 "bWn" = (
 /obj/structure/machinery/light/small{
 	dir = 8
@@ -24462,12 +24285,13 @@
 	},
 /area/almayer/shipboard/port_point_defense)
 "bWq" = (
-/obj/structure/surface/rack,
-/obj/effect/spawner/random/toolbox,
+/obj/structure/bed/chair{
+	dir = 1
+	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/hull/upper_hull/u_m_s)
+/area/almayer/living/starboard_garden)
 "bWr" = (
 /obj/structure/machinery/door/airlock/almayer/maint,
 /turf/open/floor/almayer{
@@ -24523,13 +24347,9 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/living/auxiliary_officer_office)
 "bWK" = (
-/obj/structure/bed/chair{
-	dir = 1
-	},
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/living/starboard_garden)
+/obj/docking_port/stationary/escape_pod/north,
+/turf/open/floor/plating,
+/area/almayer/hull/upper_hull/u_m_s)
 "bWL" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/pipes/standard/simple/hidden/supply,
@@ -26297,9 +26117,11 @@
 	},
 /area/almayer/hallways/port_umbilical)
 "ceu" = (
-/obj/item/trash/barcardine,
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/hull/upper_hull/u_m_s)
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "green"
+	},
+/area/almayer/living/starboard_garden)
 "cev" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N";
@@ -26324,13 +26146,8 @@
 	},
 /area/almayer/hallways/port_umbilical)
 "ceC" = (
-/obj/structure/machinery/light,
-/obj/structure/bed/chair{
-	dir = 1
-	},
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
+/obj/structure/prop/almayer/ship_memorial,
+/turf/open/floor/plating/almayer,
 /area/almayer/living/starboard_garden)
 "ceD" = (
 /obj/structure/machinery/door/airlock/almayer/secure/reinforced{
@@ -26839,17 +26656,15 @@
 	},
 /area/almayer/squads/req)
 "cit" = (
-/obj/structure/machinery/camera/autoname/almayer{
-	dir = 1;
-	name = "ship-grade camera"
+/obj/structure/surface/table/almayer,
+/obj/item/paper_bin{
+	pixel_x = -6;
+	pixel_y = 7
 	},
-/obj/structure/bed/chair{
-	dir = 1
-	},
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/living/starboard_garden)
+/obj/item/tool/pen,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/upper_hull/u_m_s)
 "ciu" = (
 /obj/structure/platform{
 	dir = 8
@@ -29612,6 +29427,12 @@
 	icon_state = "orange"
 	},
 /area/almayer/engineering/lower_engineering)
+"cWv" = (
+/turf/open/floor/almayer{
+	dir = 8;
+	icon_state = "green"
+	},
+/area/almayer/living/starboard_garden)
 "cWy" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /obj/item/reagent_container/food/snacks/packaged_burger,
@@ -30640,6 +30461,7 @@
 /area/almayer/hull/lower_hull/l_f_p)
 "dqN" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer{
 	icon_state = "green"
 	},
@@ -30822,14 +30644,10 @@
 	},
 /area/almayer/living/briefing)
 "dux" = (
-/obj/structure/surface/table/almayer,
-/obj/item/pizzabox{
-	pixel_y = 10
-	},
 /turf/open/floor/almayer{
-	icon_state = "plate"
+	icon_state = "mono"
 	},
-/area/almayer/hull/upper_hull/u_m_p)
+/area/almayer/living/starboard_garden)
 "duF" = (
 /obj/structure/closet/secure_closet/personal,
 /turf/open/floor/almayer{
@@ -31436,7 +31254,7 @@
 "dGC" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /obj/structure/disposalpipe/segment{
-	dir = 2;
+	dir = 8;
 	icon_state = "pipe-c"
 	},
 /turf/open/floor/almayer{
@@ -32861,17 +32679,13 @@
 	},
 /area/almayer/hull/upper_hull/u_m_p)
 "ekY" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/sign/safety/maint{
-	pixel_x = 8;
-	pixel_y = -32
+/obj/structure/machinery/door/airlock/almayer/generic/glass{
+	name = "\improper Memorial Room"
 	},
 /turf/open/floor/almayer{
-	icon_state = "plate"
+	icon_state = "test_floor4"
 	},
-/area/almayer/hull/upper_hull/u_m_p)
+/area/almayer/living/starboard_garden)
 "elf" = (
 /obj/structure/sign/safety/hvac_old{
 	pixel_x = 8;
@@ -34213,6 +34027,16 @@
 	icon_state = "plate"
 	},
 /area/almayer/hull/lower_hull/l_f_p)
+"eOM" = (
+/obj/structure/machinery/door/airlock/almayer/secure/reinforced{
+	dir = 2;
+	name = "\improper Evacuation Airlock PU-6";
+	req_access = null
+	},
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/powered)
 "eOR" = (
 /obj/structure/machinery/light{
 	dir = 4
@@ -34318,15 +34142,16 @@
 /turf/open/floor/almayer,
 /area/almayer/shipboard/brig/main_office)
 "eRR" = (
-/obj/structure/surface/rack,
-/obj/effect/spawner/random/tool,
-/obj/structure/machinery/light{
-	dir = 1
+/obj/item/clothing/head/helmet/marine{
+	pixel_x = 16;
+	pixel_y = 6
 	},
+/obj/item/reagent_container/food/snacks/grown/poppy,
+/obj/effect/step_trigger/message/memorial,
 /turf/open/floor/almayer{
-	icon_state = "mono"
+	icon_state = "plate"
 	},
-/area/almayer/lifeboat_pumps/south1)
+/area/almayer/living/starboard_garden)
 "eSo" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer{
@@ -34709,7 +34534,6 @@
 /area/almayer/hull/upper_hull/u_a_p)
 "fad" = (
 /obj/effect/step_trigger/clone_cleaner,
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer{
 	icon_state = "green"
 	},
@@ -35714,15 +35538,15 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/port_point_defense)
 "fwD" = (
-/obj/structure/surface/table/almayer,
-/obj/item/trash/plate{
+/obj/item/reagent_container/food/snacks/grown/poppy{
 	pixel_x = 4;
-	pixel_y = 9
+	pixel_y = 4
 	},
+/obj/effect/step_trigger/message/memorial,
 /turf/open/floor/almayer{
-	icon_state = "mono"
+	icon_state = "plate"
 	},
-/area/almayer/lifeboat_pumps/south1)
+/area/almayer/living/starboard_garden)
 "fwF" = (
 /obj/structure/largecrate/random/case/double,
 /obj/structure/machinery/camera/autoname/almayer{
@@ -41510,6 +41334,16 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/living/briefing)
+"hWB" = (
+/obj/structure/sign/safety/escapepod{
+	pixel_x = 8;
+	pixel_y = 32
+	},
+/turf/open/floor/almayer{
+	dir = 5;
+	icon_state = "red"
+	},
+/area/almayer/lifeboat_pumps/south1)
 "hWJ" = (
 /obj/structure/largecrate/random/case/small,
 /turf/open/floor/almayer{
@@ -42184,11 +42018,14 @@
 /area/almayer/living/offices/flight)
 "ina" = (
 /obj/structure/surface/table/almayer,
-/obj/effect/spawner/random/tool,
-/turf/open/floor/almayer{
-	icon_state = "mono"
+/obj/structure/machinery/computer/emails{
+	dir = 4
 	},
-/area/almayer/lifeboat_pumps/south1)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/upper_hull/u_m_s)
 "ins" = (
 /obj/structure/pipes/standard/manifold/hidden/supply{
 	dir = 1
@@ -42290,11 +42127,11 @@
 	},
 /area/almayer/squads/alpha_bravo_shared)
 "ipK" = (
-/obj/structure/largecrate/random/case/small,
+/obj/effect/step_trigger/message/memorial,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/hull/upper_hull/u_m_s)
+/area/almayer/living/starboard_garden)
 "ipQ" = (
 /obj/structure/surface/rack,
 /obj/item/storage/fancy/vials/empty,
@@ -43853,12 +43690,14 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/upper_hull/u_a_p)
 "iYr" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+/obj/structure/machinery/light{
+	dir = 4
 	},
-/turf/open/floor/almayer,
-/area/almayer/lifeboat_pumps/south1)
+/turf/open/floor/almayer{
+	dir = 4;
+	icon_state = "green"
+	},
+/area/almayer/living/starboard_garden)
 "iYt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -51619,14 +51458,11 @@
 /turf/open/floor/almayer,
 /area/almayer/lifeboat_pumps/south1)
 "mov" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/bed/chair{
+	dir = 1
 	},
-/obj/structure/machinery/light/small,
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/hull/upper_hull/u_m_p)
+/turf/open/floor/grass,
+/area/almayer/living/starboard_garden)
 "moB" = (
 /turf/closed/wall/almayer,
 /area/almayer/shipboard/brig/cells)
@@ -52793,11 +52629,17 @@
 	},
 /area/almayer/hull/lower_hull/l_m_s)
 "mOb" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/machinery/camera/autoname/almayer{
+	dir = 8;
+	name = "ship-grade camera"
 	},
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/hull/upper_hull/u_m_p)
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/living/starboard_garden)
 "mOg" = (
 /obj/structure/sign/safety/maint{
 	pixel_x = 32
@@ -54265,11 +54107,9 @@
 /obj/structure/bed/chair{
 	dir = 8
 	},
-/obj/structure/sign/safety/maint{
-	pixel_x = 32
-	},
 /turf/open/floor/almayer{
-	icon_state = "plate"
+	dir = 5;
+	icon_state = "green"
 	},
 /area/almayer/living/starboard_garden)
 "nun" = (
@@ -54306,15 +54146,11 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/squads/alpha)
 "nuY" = (
-/obj/structure/machinery/door/airlock/almayer/secure/reinforced{
-	dir = 2;
-	name = "\improper Evacuation Airlock PU-6";
-	req_access = null
-	},
+/obj/structure/closet,
 /turf/open/floor/almayer{
-	icon_state = "test_floor4"
+	icon_state = "plate"
 	},
-/area/almayer/powered)
+/area/almayer/hull/upper_hull/u_m_s)
 "nvM" = (
 /obj/structure/window/framed/almayer/white,
 /obj/structure/machinery/door/firedoor/border_only/almayer{
@@ -55407,6 +55243,12 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/command/computerlab)
+"nTH" = (
+/obj/structure/machinery/status_display{
+	pixel_y = 30
+	},
+/turf/open/floor/almayer,
+/area/almayer/lifeboat_pumps/south1)
 "nTZ" = (
 /turf/open/floor/almayer{
 	dir = 5;
@@ -57183,14 +57025,17 @@
 	},
 /area/almayer/living/synthcloset)
 "oGy" = (
-/obj/structure/disposalpipe/segment{
+/obj/structure/machinery/camera/autoname/almayer{
 	dir = 1;
-	icon_state = "pipe-c"
+	name = "ship-grade camera"
+	},
+/obj/structure/bed/chair{
+	dir = 1
 	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/hull/upper_hull/u_m_p)
+/area/almayer/living/starboard_garden)
 "oGC" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer,
@@ -57857,9 +57702,11 @@
 	},
 /area/almayer/shipboard/brig/cic_hallway)
 "oWz" = (
-/obj/item/stool,
-/turf/open/floor/almayer,
-/area/almayer/lifeboat_pumps/south1)
+/obj/structure/machinery/light,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/living/starboard_garden)
 "oWI" = (
 /obj/structure/machinery/cryopod/right{
 	pixel_y = 6
@@ -58433,15 +58280,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/hull/upper_hull/u_a_p)
-"pmn" = (
-/obj/structure/sign/safety/storage{
-	pixel_x = 8;
-	pixel_y = 32
-	},
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/hull/upper_hull/u_m_s)
 "pmq" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
@@ -59082,14 +58920,14 @@
 	},
 /area/almayer/engineering/upper_engineering/starboard)
 "pDm" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
+/obj/structure/surface/rack,
+/obj/item/roller,
+/obj/item/roller,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/hull/upper_hull/u_m_p)
+/area/almayer/hull/upper_hull/u_m_s)
 "pDo" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
@@ -60470,14 +60308,13 @@
 	},
 /area/almayer/shipboard/brig/main_office)
 "qga" = (
-/obj/structure/machinery/space_heater,
-/obj/structure/sign/safety/maint{
-	pixel_x = 32
+/obj/structure/machinery/door/airlock/almayer/maint/reinforced{
+	dir = 1
 	},
 /turf/open/floor/almayer{
-	icon_state = "mono"
+	icon_state = "test_floor4"
 	},
-/area/almayer/lifeboat_pumps/south1)
+/area/almayer/living/starboard_garden)
 "qgG" = (
 /obj/structure/pipes/standard/manifold/hidden/supply{
 	dir = 8
@@ -61224,6 +61061,16 @@
 	},
 /turf/closed/wall/almayer/research/containment/wall/purple,
 /area/almayer/medical/containment/cell)
+"qxz" = (
+/obj/structure/machinery/door/airlock/almayer/secure/reinforced{
+	dir = 2;
+	name = "\improper Evacuation Airlock PU-5";
+	req_access = null
+	},
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/powered)
 "qxA" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/almayer{
@@ -61591,13 +61438,14 @@
 	},
 /area/almayer/squads/delta)
 "qFQ" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/prop/invuln/overhead_pipe{
-	dir = 4;
-	pixel_y = 13
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
 	},
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/hull/upper_hull/u_m_p)
+/turf/open/floor/almayer{
+	dir = 5;
+	icon_state = "red"
+	},
+/area/almayer/hallways/aft_hallway)
 "qFW" = (
 /obj/structure/sign/safety/storage{
 	pixel_x = 8;
@@ -61652,14 +61500,15 @@
 	},
 /area/almayer/hallways/starboard_hallway)
 "qHq" = (
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 2
+/obj/structure/machinery/door/airlock/almayer/secure/reinforced{
+	dir = 2;
+	name = "\improper Evacuation Airlock SU-6";
+	req_access = null
 	},
-/obj/item/tool/warning_cone,
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
 	},
-/area/almayer/lifeboat_pumps/north1)
+/area/almayer/powered)
 "qHF" = (
 /obj/structure/surface/table/almayer,
 /obj/item/storage/box/bodybags{
@@ -64229,13 +64078,14 @@
 	},
 /area/almayer/powered/agent)
 "rKs" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/machinery/door/airlock/almayer/maint{
+	req_one_access = null;
+	req_one_access_txt = "2;30;34"
 	},
 /turf/open/floor/almayer{
-	icon_state = "mono"
+	icon_state = "test_floor4"
 	},
-/area/almayer/lifeboat_pumps/south1)
+/area/almayer/hull/upper_hull/u_m_s)
 "rKy" = (
 /obj/structure/machinery/firealarm{
 	dir = 1;
@@ -64808,6 +64658,16 @@
 	icon_state = "red"
 	},
 /area/almayer/shipboard/brig/general_equipment)
+"sah" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 1
+	},
+/turf/open/floor/almayer{
+	dir = 6;
+	icon_state = "red"
+	},
+/area/almayer/hallways/aft_hallway)
 "saB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -66269,15 +66129,10 @@
 /turf/open/floor/engine,
 /area/almayer/engineering/airmix)
 "sHp" = (
-/obj/effect/step_trigger/clone_cleaner,
-/obj/structure/disposalpipe/segment,
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 2
-	},
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/hallways/aft_hallway)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/largecrate/random/case/small,
+/turf/open/floor/almayer,
+/area/almayer/lifeboat_pumps/north1)
 "sHM" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer,
 /turf/open/floor/almayer{
@@ -66721,6 +66576,12 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/living/briefing)
+"sTB" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/upper_hull/u_m_s)
 "sTV" = (
 /obj/structure/machinery/power/apc/almayer/hardened{
 	cell_type = /obj/item/cell/hyper;
@@ -67256,10 +67117,14 @@
 /turf/open/floor/almayer,
 /area/almayer/living/cryo_cells)
 "teB" = (
-/obj/structure/largecrate/random/case/small,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/almayer,
-/area/almayer/lifeboat_pumps/north1)
+/obj/structure/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/upper_hull/u_m_s)
 "teY" = (
 /obj/structure/machinery/light{
 	dir = 1
@@ -68403,10 +68268,9 @@
 	},
 /area/almayer/medical/lower_medical_medbay)
 "tAV" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/pipes/standard/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/lifeboat_pumps/south1)
+/area/almayer/hull/upper_hull/u_m_s)
 "tBq" = (
 /obj/item/tool/crowbar,
 /turf/open/floor/plating/plating_catwalk,
@@ -68465,9 +68329,13 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/upper_hull/u_f_s)
 "tDA" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/hull/upper_hull/u_m_p)
+/obj/item/tool/weldpack{
+	pixel_y = 15
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/upper_hull/u_m_s)
 "tDZ" = (
 /obj/structure/machinery/cryopod{
 	pixel_y = 6
@@ -68549,6 +68417,7 @@
 /obj/structure/machinery/door/firedoor/border_only/almayer{
 	dir = 2
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
 	},
@@ -69039,10 +68908,10 @@
 /turf/open/floor/almayer,
 /area/almayer/living/briefing)
 "tQE" = (
-/obj/structure/machinery/power/apc/almayer{
-	dir = 1
+/obj/item/clothing/head/welding,
+/turf/open/floor/almayer{
+	icon_state = "plate"
 	},
-/turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/upper_hull/u_m_s)
 "tQL" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
@@ -69557,11 +69426,11 @@
 /turf/open/floor/almayer,
 /area/almayer/command/computerlab)
 "uaZ" = (
-/obj/structure/sign/safety/storage{
-	pixel_x = 8;
-	pixel_y = -32
+/obj/structure/surface/table/almayer,
+/obj/item/weapon/gun/rifle/m41a,
+/turf/open/floor/almayer{
+	icon_state = "plate"
 	},
-/turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/upper_hull/u_m_s)
 "ubd" = (
 /obj/structure/surface/rack,
@@ -69961,12 +69830,8 @@
 	},
 /area/almayer/shipboard/brig/evidence_storage)
 "uli" = (
-/obj/structure/surface/rack,
-/obj/effect/spawner/random/facepaint,
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/hull/upper_hull/u_m_s)
+/turf/open/floor/grass,
+/area/almayer/living/starboard_garden)
 "uly" = (
 /obj/structure/bed/stool,
 /turf/open/floor/almayer{
@@ -70103,13 +69968,12 @@
 	},
 /area/almayer/command/computerlab)
 "uoS" = (
-/obj/structure/sign/safety/maint{
-	pixel_x = -17
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/machinery/light/small{
+	dir = 4
 	},
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/living/starboard_garden)
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/upper_hull/u_m_s)
 "uoY" = (
 /obj/structure/surface/table/almayer,
 /obj/item/paper_bin/uscm{
@@ -70268,6 +70132,13 @@
 	icon_state = "mono"
 	},
 /area/almayer/lifeboat_pumps/south1)
+"uso" = (
+/obj/structure/largecrate/random/case/double,
+/obj/structure/machinery/light/small,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/upper_hull/u_m_p)
 "usr" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/computer/secure_data{
@@ -70514,12 +70385,13 @@
 	},
 /area/almayer/medical/containment/cell)
 "uvS" = (
-/obj/structure/sign/safety/hvac_old{
-	pixel_x = 8;
-	pixel_y = 32
+/obj/structure/surface/rack,
+/obj/item/stack/cable_coil,
+/obj/item/attachable/flashlight/grip,
+/turf/open/floor/almayer{
+	icon_state = "plate"
 	},
-/turf/open/floor/almayer,
-/area/almayer/lifeboat_pumps/south1)
+/area/almayer/hull/upper_hull/u_m_s)
 "uvY" = (
 /turf/open/floor/almayer{
 	dir = 8;
@@ -71105,13 +70977,12 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_m_s)
 "uGz" = (
-/obj/structure/machinery/camera/autoname/almayer{
-	name = "ship-grade camera"
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/largecrate/random/secure,
 /turf/open/floor/almayer{
-	icon_state = "mono"
+	icon_state = "plate"
 	},
-/area/almayer/lifeboat_pumps/south1)
+/area/almayer/hull/upper_hull/u_m_s)
 "uGQ" = (
 /obj/structure/machinery/suit_storage_unit/compression_suit/uscm,
 /turf/open/floor/almayer{
@@ -72012,12 +71883,9 @@
 	},
 /area/almayer/medical/lower_medical_medbay)
 "vce" = (
-/obj/structure/surface/rack,
-/obj/effect/spawner/random/tool,
-/turf/open/floor/almayer{
-	icon_state = "mono"
-	},
-/area/almayer/lifeboat_pumps/south1)
+/obj/docking_port/stationary/escape_pod/south,
+/turf/open/floor/plating,
+/area/almayer/hull/upper_hull/u_m_p)
 "vcq" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer{
 	dir = 2
@@ -73471,9 +73339,16 @@
 	},
 /area/almayer/medical/lower_medical_medbay)
 "vFb" = (
-/obj/item/tool/crowbar,
-/turf/open/floor/almayer,
-/area/almayer/lifeboat_pumps/south1)
+/obj/structure/surface/table/almayer,
+/obj/item/attachable/lasersight,
+/obj/item/reagent_container/food/drinks/cans/souto/vanilla{
+	pixel_x = 10;
+	pixel_y = 11
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/upper_hull/u_m_s)
 "vFh" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/storage/toolbox/mechanical{
@@ -75482,12 +75357,11 @@
 	},
 /area/almayer/squads/bravo)
 "wta" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/structure/closet/crate,
+/turf/open/floor/almayer{
+	icon_state = "plate"
 	},
-/turf/open/floor/almayer,
-/area/almayer/hallways/aft_hallway)
+/area/almayer/hull/upper_hull/u_m_s)
 "wtd" = (
 /obj/structure/machinery/vending/coffee,
 /obj/item/toy/bikehorn/rubberducky{
@@ -76190,13 +76064,12 @@
 /turf/closed/wall/almayer/research/containment/wall/east,
 /area/almayer/medical/containment/cell/cl)
 "wKn" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/structure/surface/rack,
+/obj/item/facepaint/sniper,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/hull/upper_hull/u_m_p)
+/area/almayer/hull/upper_hull/u_m_s)
 "wKF" = (
 /obj/structure/machinery/power/apc/almayer{
 	dir = 1;
@@ -77240,15 +77113,11 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull)
 "xfh" = (
-/obj/structure/machinery/door/airlock/almayer/secure/reinforced{
-	dir = 2;
-	name = "\improper Evacuation Airlock PU-5";
-	req_access = null
-	},
+/obj/structure/largecrate/supply/floodlights,
 /turf/open/floor/almayer{
-	icon_state = "test_floor4"
+	icon_state = "plate"
 	},
-/area/almayer/powered)
+/area/almayer/hull/upper_hull/u_m_p)
 "xfi" = (
 /obj/structure/machinery/power/smes/buildable,
 /obj/structure/machinery/light{
@@ -78008,6 +77877,13 @@
 	icon_state = "plating"
 	},
 /area/almayer/engineering/engine_core)
+"xuY" = (
+/obj/structure/sign/safety/escapepod{
+	pixel_x = 8;
+	pixel_y = 32
+	},
+/turf/open/floor/almayer,
+/area/almayer/lifeboat_pumps/south1)
 "xuZ" = (
 /turf/open/floor/almayer{
 	dir = 8;
@@ -78639,15 +78515,11 @@
 	},
 /area/almayer/squads/alpha_bravo_shared)
 "xHG" = (
-/obj/structure/machinery/door/airlock/almayer/secure/reinforced{
-	dir = 2;
-	name = "\improper Evacuation Airlock SU-5";
-	req_access = null
-	},
+/obj/structure/surface/rack,
 /turf/open/floor/almayer{
-	icon_state = "test_floor4"
+	icon_state = "plate"
 	},
-/area/almayer/powered)
+/area/almayer/hull/upper_hull/u_m_p)
 "xHM" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/computer/sentencing,
@@ -79445,14 +79317,10 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/cic_hallway)
 "xWF" = (
-/obj/structure/machinery/door/airlock/almayer/maint{
-	access_modified = 1;
-	dir = 2;
-	req_one_access = list(2,34,30)
+/obj/structure/machinery/light/small{
+	dir = 8
 	},
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
+/turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/upper_hull/u_m_p)
 "xWO" = (
 /obj/structure/machinery/cm_vending/sorted/medical/wall_med{
@@ -80024,13 +79892,8 @@
 	},
 /area/almayer/medical/morgue)
 "yji" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/machinery/door/airlock/almayer/maint,
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/upper_hull/u_m_p)
 "yjq" = (
 /obj/structure/machinery/door/poddoor/almayer/locked{
@@ -101161,7 +101024,7 @@ ils
 ajZ
 aaa
 aaa
-bdH
+aaa
 bdH
 bdH
 bdH
@@ -101364,7 +101227,7 @@ xEF
 ajZ
 aaa
 aaa
-bdH
+aaa
 bdH
 bdH
 bdH
@@ -101567,7 +101430,7 @@ aag
 ajZ
 aaa
 aaa
-bdH
+aaa
 bdH
 bdH
 bdH
@@ -101770,7 +101633,7 @@ aag
 ajZ
 aaa
 aaa
-bdH
+aaa
 bdH
 bdH
 bdH
@@ -105560,9 +105423,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
 aaa
 aaa
 aaa
@@ -105763,9 +105626,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
 aaa
 aaa
 aaa
@@ -105966,9 +105829,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
 aaa
 aaa
 aaa
@@ -105982,9 +105845,9 @@ aar
 aar
 aar
 aar
-tiM
 aar
-teB
+aar
+oGC
 awW
 acW
 awW
@@ -106169,9 +106032,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
 aaa
 aaa
 aaa
@@ -106182,12 +106045,12 @@ apr
 apr
 aoV
 aar
-aIx
-aWs
+aIZ
+aIZ
+aIZ
+bWK
 aar
-aap
-aar
-uac
+aea
 oGC
 xjD
 ajf
@@ -106218,20 +106081,20 @@ suV
 bYc
 bYc
 bYc
-biT
+qgG
 dqN
 tFW
 dGC
-tAV
-tAV
-tAV
-avZ
-iYr
+aZz
+aZz
+aZz
+nsc
+baw
 cxk
 qVM
-csz
-qVM
-eRR
+iBt
+iBt
+iBt
 vce
 qVM
 wTy
@@ -106372,9 +106235,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
 aaa
 aaa
 aaa
@@ -106385,13 +106248,13 @@ aub
 akc
 euO
 aar
-awW
-awW
+aIZ
+aIZ
+aIZ
+aIZ
 aar
-wFm
-aar
-uBi
-wYA
+oGC
+sHp
 oGC
 awW
 awW
@@ -106421,7 +106284,7 @@ avn
 mTb
 avn
 nFr
-asS
+aii
 ajC
 dCD
 aXe
@@ -106429,13 +106292,13 @@ baw
 baw
 baw
 mnA
-rKs
 aJU
-xWF
-csz
-xWF
 aJU
-baw
+qVM
+iBt
+iBt
+iBt
+iBt
 qVM
 crh
 csI
@@ -106575,9 +106438,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
 aaa
 aaa
 aaa
@@ -106588,12 +106451,12 @@ avd
 akt
 awW
 qHq
-aIB
-awW
+aIZ
+aIZ
+aIZ
+aIZ
 aar
-ceu
-aar
-aar
+rKs
 aar
 aar
 aar
@@ -106624,7 +106487,7 @@ aoe
 aoe
 aoe
 aEI
-asS
+aii
 aik
 qVM
 qVM
@@ -106632,14 +106495,14 @@ qVM
 qVM
 qVM
 qVM
-yji
+xeG
 qVM
 qVM
-dux
-qVM
-baw
-vFb
-pEY
+iBt
+iBt
+iBt
+iBt
+eOM
 baw
 sMM
 xVF
@@ -106778,9 +106641,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
 aaa
 aaa
 aaa
@@ -106789,12 +106652,12 @@ abs
 adq
 aGP
 aka
-aoI
-avx
-add
 aWu
 aar
-aao
+aIZ
+aIZ
+aIZ
+aIZ
 aar
 uLW
 tZe
@@ -106827,7 +106690,7 @@ isN
 cnZ
 aoe
 dtM
-asS
+aii
 ajC
 qVM
 gKS
@@ -106835,15 +106698,15 @@ gKS
 csz
 xCX
 csz
-mOb
+vGk
+vGk
 qVM
+iBt
+iBt
+iBt
+iBt
 qVM
-qVM
-qVM
-uGz
-aJU
-pEY
-gnv
+hWB
 yhI
 qSX
 pgD
@@ -106981,9 +106844,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
 aaa
 aaa
 aaa
@@ -106993,12 +106856,12 @@ adq
 aGQ
 akc
 apg
-avx
-add
-aYq
 aar
-aao
-aao
+aIZ
+aIZ
+aIZ
+aIZ
+aar
 aao
 aap
 ijU
@@ -107030,7 +106893,7 @@ aEi
 coa
 aoe
 ahr
-biV
+akU
 ajC
 xCX
 csz
@@ -107038,14 +106901,14 @@ vGk
 vGk
 qVM
 bDe
-pDm
-tDA
-qFQ
-oGy
+csz
+csz
 qVM
-aJU
-aJU
-pEY
+iBt
+iBt
+iBt
+iBt
+qVM
 wvj
 csI
 iPH
@@ -107196,11 +107059,11 @@ aee
 avd
 akt
 awW
-avx
-aJJ
-awW
 aar
-aap
+aar
+aar
+aar
+aar
 lYA
 lYA
 lYA
@@ -107233,7 +107096,7 @@ aEi
 fFh
 aoe
 dtM
-biV
+akU
 ajC
 czu
 czu
@@ -107244,11 +107107,11 @@ czu
 czu
 czu
 czu
-mov
 qVM
-baw
-baw
-pEY
+qVM
+qVM
+qVM
+qVM
 ehj
 irS
 ilJ
@@ -107400,10 +107263,10 @@ aWm
 aka
 kyY
 aar
-awW
-awW
-aar
-wFm
+cit
+ina
+nuY
+nuY
 lYA
 aax
 aax
@@ -107436,7 +107299,7 @@ hFF
 aoe
 aoe
 dtM
-asS
+aii
 ajC
 czu
 aiJ
@@ -107447,10 +107310,10 @@ atj
 atj
 atj
 czu
-wKn
-qVM
-uvS
-oWz
+csz
+csz
+vGk
+csz
 qVM
 rQW
 yhI
@@ -107605,8 +107468,8 @@ apr
 aar
 aJL
 aYr
-aar
-aap
+aao
+aao
 lYA
 aax
 aax
@@ -107639,7 +107502,7 @@ aQz
 aRJ
 ajl
 dtM
-biV
+akU
 ajC
 czu
 aiJ
@@ -107650,10 +107513,10 @@ atj
 atj
 atj
 czu
-wKn
-qVM
-nUv
-qga
+csz
+vGk
+vGk
+csz
 qVM
 wTy
 wTy
@@ -107807,9 +107670,9 @@ akW
 apu
 aar
 aar
-aar
-aar
-tiM
+aao
+aap
+pDm
 lYA
 acV
 acV
@@ -107842,7 +107705,7 @@ aQz
 aRK
 ajl
 aDk
-biV
+akU
 ajC
 czu
 aiJ
@@ -107853,9 +107716,9 @@ atl
 atl
 atl
 czu
-wKn
-qVM
-gMA
+csz
+vGk
+csz
 qVM
 qVM
 crh
@@ -108005,14 +107868,14 @@ aaf
 aaf
 acv
 aez
-aJW
-aJW
 boL
+akY
 boL
-boL
-aYs
+aao
+aiv
+aap
 uoS
-aJW
+pDm
 lYA
 adb
 adb
@@ -108045,7 +107908,7 @@ fOL
 aRS
 ajl
 ahq
-asS
+aii
 ajC
 czu
 alW
@@ -108056,11 +107919,11 @@ atI
 atI
 atI
 czu
-mOb
-qVM
-vGk
-qVM
-ina
+csz
+csz
+csz
+xCX
+aJU
 baw
 sMM
 baw
@@ -108208,14 +108071,14 @@ aag
 aag
 acv
 aez
-agh
-afY
-apF
-apF
-apF
-agP
-agh
-aJW
+boL
+akY
+boL
+aar
+aar
+aar
+aar
+aar
 lYA
 adb
 adb
@@ -108248,7 +108111,7 @@ akw
 alD
 vEx
 bYe
-biV
+akU
 ajC
 czu
 alW
@@ -108259,12 +108122,12 @@ atI
 atI
 atI
 czu
-mOb
 qVM
-vGk
 qVM
-teg
-baw
+qVM
+qVM
+qVM
+nTH
 sMM
 baw
 teg
@@ -108412,12 +108275,12 @@ aag
 acf
 aet
 agv
-afY
-ahp
-afY
-afY
-afY
-bLO
+aiP
+aYq
+aar
+aIZ
+aIZ
+aIZ
 bWK
 lYA
 adb
@@ -108451,7 +108314,7 @@ onQ
 alD
 ajl
 hon
-biV
+akU
 ajC
 czu
 alW
@@ -108462,10 +108325,10 @@ atI
 atI
 atI
 czu
-ekY
-qVM
-csz
-qVM
+iBt
+iBt
+iBt
+vce
 qVM
 gnv
 yhI
@@ -108615,13 +108478,13 @@ aag
 acf
 aet
 agB
-akY
-akY
-akY
-agP
-afY
-bLO
-ceC
+akW
+aYs
+aar
+aIZ
+aIZ
+aIZ
+aIZ
 lYA
 vKF
 adb
@@ -108654,7 +108517,7 @@ aCp
 alD
 ajl
 wqA
-asS
+aii
 ajC
 czu
 alW
@@ -108665,10 +108528,10 @@ atI
 atI
 xMk
 czu
-wKn
-xCX
-hoX
-qVM
+iBt
+iBt
+iBt
+iBt
 qVM
 vpn
 csI
@@ -108817,14 +108680,14 @@ aag
 aag
 acv
 aez
-agP
+boL
 akY
-aqi
+boL
 avJ
-afY
-ahl
-bLO
-bWK
+aIZ
+aIZ
+aIZ
+aIZ
 lYA
 adb
 adb
@@ -108857,7 +108720,7 @@ akx
 alD
 gWG
 dtM
-asS
+aii
 ajC
 czu
 alW
@@ -108868,11 +108731,11 @@ atI
 atI
 atI
 czu
-wKn
-qVM
-csz
-qVM
-wiz
+iBt
+iBt
+iBt
+iBt
+qxz
 baw
 sMM
 baw
@@ -109020,14 +108883,14 @@ aag
 aag
 acv
 aez
-afY
+boL
 akY
 aqk
-avV
-afY
-afY
-bLO
-cit
+aar
+aIZ
+aIZ
+aIZ
+aIZ
 lYA
 adb
 adb
@@ -109060,7 +108923,7 @@ akx
 alD
 gWG
 dtM
-asS
+aii
 ajC
 czu
 alW
@@ -109071,12 +108934,12 @@ atI
 atI
 atI
 czu
-mOb
+iBt
+iBt
+iBt
+iBt
 qVM
-vGk
-qVM
-fwD
-baw
+xuY
 sMM
 baw
 oby
@@ -109224,13 +109087,13 @@ aag
 acf
 aet
 agS
-akY
-akY
-akY
-afY
-agP
-bLO
-ceC
+aiP
+aYq
+aar
+aIZ
+aIZ
+aIZ
+aIZ
 lYA
 adb
 adb
@@ -109263,7 +109126,7 @@ hVz
 alD
 ajl
 ahr
-asS
+aii
 ajC
 czu
 alW
@@ -109274,10 +109137,10 @@ atI
 atI
 atI
 czu
-mOb
-qVM
-vGk
-qVM
+iBt
+iBt
+iBt
+iBt
 qVM
 gnv
 yhI
@@ -109426,14 +109289,14 @@ aag
 aag
 acf
 aet
-ahl
-afY
-afY
-afY
-afY
-afY
-bLO
-bWK
+afB
+akW
+biT
+aar
+aar
+aar
+aar
+aar
 lYA
 adc
 adc
@@ -109466,7 +109329,7 @@ nMV
 vIf
 ajl
 aEI
-biV
+akU
 gMa
 czu
 czu
@@ -109477,9 +109340,9 @@ adc
 adc
 adc
 czu
-yji
 qVM
-gMA
+qVM
+xeG
 qVM
 qVM
 crh
@@ -109629,14 +109492,14 @@ aag
 aag
 acv
 aez
-agh
-ahp
-afY
+boL
+boL
+boL
 ahl
-agh
-ahp
-afY
-aJW
+cWv
+cWv
+cWv
+cWv
 kaj
 uId
 adH
@@ -109669,7 +109532,7 @@ aos
 alE
 bVE
 bYe
-biV
+akU
 aGd
 aWl
 hJu
@@ -109680,7 +109543,7 @@ aww
 aww
 wst
 axs
-bBC
+bbL
 bbL
 bYe
 yfv
@@ -109832,14 +109695,14 @@ aag
 aag
 acv
 aez
-ahp
-agh
-arc
-arc
-arc
-afY
-agh
-aJW
+boL
+asS
+boL
+ceu
+boL
+boL
+boL
+boL
 kGL
 uTY
 azY
@@ -109873,17 +109736,17 @@ aSb
 aEe
 ait
 bjJ
-aZE
-aZE
-aZE
-aZE
-xwG
-agl
-agl
-agl
+abx
+abx
+abx
+abx
+atC
+azY
+azY
+azY
 fad
-sHp
-wta
+kGL
+abg
 abg
 abg
 abg
@@ -110035,13 +109898,13 @@ aah
 aah
 acf
 acf
-aJW
+boL
 ale
 bDD
 nub
-bDD
-ale
-aJW
+dux
+iYr
+dux
 ado
 atC
 kHT
@@ -110238,14 +110101,14 @@ aaa
 aaa
 aaa
 lYA
-aar
-aar
-aar
-aar
-tiM
-aar
-tiM
-aar
+aet
+aet
+biV
+biV
+ekY
+aet
+ekY
+aet
 abE
 abE
 abE
@@ -110440,15 +110303,15 @@ aaa
 aaa
 aaa
 aaa
-lYA
-ahs
+ahx
+aiH
 alf
 arp
-aar
-aap
-aao
-aap
-aar
+arp
+aiH
+aiH
+aiH
+aet
 kPB
 aci
 aci
@@ -110643,15 +110506,15 @@ aaa
 aaa
 aaa
 aaa
-lYA
-ahu
+ahx
+aiH
 alg
-arp
-aar
-aap
-aao
-aap
-aar
+bBC
+bBC
+aIx
+aIB
+aiH
+aet
 kPZ
 acI
 acj
@@ -110847,14 +110710,14 @@ aaa
 aaa
 aaa
 lYA
-ahx
-aap
+aet
+avx
 ahN
-aar
-awJ
-aao
+uli
+uli
+uli
 bWf
-aar
+aet
 lwC
 aTT
 acl
@@ -111050,14 +110913,14 @@ aaa
 aaa
 aaa
 lYA
-ahy
-aap
-aao
-aar
-pmn
-aao
-bWj
-aar
+aet
+avV
+uli
+uli
+uli
+mov
+bWq
+aet
 lhX
 aXc
 acl
@@ -111239,28 +111102,28 @@ aab
 aaa
 aaa
 aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-lYA
-fZF
-alr
-aao
-sMs
-aao
-aao
+ahx
+aez
+uli
+aIx
+uli
+uli
+mov
 bWq
-aar
+aet
 lhX
 eYM
 uuR
@@ -111442,28 +111305,28 @@ aab
 aaa
 aaa
 aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-lYA
-aar
-aar
-aar
-aar
-aap
-aao
-aap
-aar
+ahx
+aez
+uli
+uli
+uli
+uli
+uli
+aiH
+aet
 lhX
 acl
 acl
@@ -111645,28 +111508,28 @@ aab
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aaa
 aaa
 aaa
 lYA
-aao
-aao
-acD
-aao
-aap
-aao
-aap
-aar
+ahy
+avZ
+ipK
+ipK
+ipK
+uli
+bWf
+aet
 lhX
 acl
 acl
@@ -111848,28 +111711,28 @@ aab
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aaa
 aaa
 aaa
 lYA
-aao
-aar
-aar
-aar
-aar
-aar
-aao
-aar
+aet
+aIx
+ipK
+ceC
+eRR
+uli
+bWq
+aet
 loV
 acK
 acm
@@ -112051,28 +111914,28 @@ aab
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aaa
 aaa
 aaa
 lYA
-aap
-aar
-aru
+aet
+uli
+ipK
 awe
-fZF
-aar
-aap
-aar
+fwD
+uli
+oGy
+aet
 lhX
 acl
 acl
@@ -112254,28 +112117,28 @@ aab
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aaa
 aaa
 aaa
 lYA
-wFm
-aar
-ary
-awh
+aet
+avx
 ipK
-aar
-wFm
-aar
+ipK
+ipK
+uli
+bWq
+aet
 lhX
 acl
 acl
@@ -112457,28 +112320,28 @@ aab
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 bdH
 aaa
 aaa
-lYA
-aap
-sMs
-ahN
-aap
-aKc
-aar
-aap
-aar
+ahx
+aez
+uli
+uli
+uli
+uli
+uli
+oWz
+aet
 lhX
 gsZ
 uxO
@@ -112660,28 +112523,28 @@ aab
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 bdH
 bdH
 aaa
-lYA
-uaZ
-aar
-arI
-ahg
+ahx
+aez
+aIB
+aKg
 uli
-aar
-aap
-aar
+uli
+mov
+bWq
+aet
 lhX
 kNO
 acl
@@ -112863,28 +112726,28 @@ aab
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 bdH
 aaa
 aaa
 lYA
-ahN
-aar
-aar
-aar
-aar
-aar
-aao
-aar
+aet
+aJJ
+aIB
+uli
+uli
+mov
+bWq
+aet
 lwC
 tIK
 acl
@@ -113066,28 +112929,28 @@ aab
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 bdH
 aaa
 aaa
 lYA
-cIU
-aao
-sMs
-aao
+aet
+avx
+ahN
+aIB
 aKg
-aYM
-aao
-aar
+uli
+bWf
+aet
 abK
 acL
 acn
@@ -113269,28 +113132,28 @@ aab
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 bdH
 aaa
 aaa
-lYA
-ahW
-aao
-aar
-aao
-aap
-aap
-aap
-sMs
+ahx
+aiH
+uli
+bLO
+bLO
+bLO
+bLO
+aiH
+qga
 eAU
 eAU
 eAU
@@ -113472,8 +113335,8 @@ aab
 aaa
 aaa
 aaa
-aaa
-aaa
+bdH
+bdH
 aaa
 aaa
 aaa
@@ -113485,15 +113348,15 @@ aaa
 bdH
 aaa
 aaa
-lYA
+ahx
 aiH
-aao
-aar
+aiH
+bWd
 awi
-aao
-aao
-aao
-aar
+bWd
+mOb
+aiH
+aet
 aBD
 acU
 uPr
@@ -113689,10 +113552,10 @@ bdH
 aaa
 aaa
 lYA
-aiP
-aao
 aar
-awJ
+tiM
+aar
+aar
 aNi
 aNi
 bWr
@@ -113894,8 +113757,8 @@ aaa
 lYA
 aiS
 aao
-aar
 aao
+acD
 aNi
 cYT
 aNm
@@ -114097,7 +113960,7 @@ aaa
 lYA
 aiT
 aap
-aar
+aao
 aap
 aNi
 aZe
@@ -114300,7 +114163,7 @@ aaa
 lYA
 aiU
 aap
-aar
+aap
 aap
 aNi
 aZr
@@ -114503,8 +114366,8 @@ aaa
 lYA
 aiZ
 aap
-aar
-tQE
+aao
+aap
 aNi
 aZs
 aNm
@@ -114706,7 +114569,7 @@ aaa
 lYA
 adf
 aao
-aar
+aao
 aao
 aNi
 jWr
@@ -114908,9 +114771,9 @@ aaa
 aaa
 lYA
 fZF
-aao
+aWs
 aar
-aao
+tiM
 aNi
 aNi
 aNi
@@ -115111,7 +114974,7 @@ aaa
 aaa
 lYA
 aar
-tiM
+aar
 aar
 awJ
 bzE
@@ -115517,7 +115380,7 @@ aam
 aam
 aam
 lYA
-aao
+qsd
 aap
 aar
 aar
@@ -117354,7 +117217,7 @@ abg
 caF
 aar
 aar
-aar
+tiM
 aar
 aar
 ael
@@ -117389,7 +117252,7 @@ xeG
 qVM
 qVM
 qVM
-qVM
+xeG
 qVM
 qVM
 qVM
@@ -117556,9 +117419,9 @@ bWs
 abg
 caF
 aar
-aIZ
-aIZ
-aIZ
+nuY
+sTB
+uaZ
 bUA
 ael
 afE
@@ -117591,9 +117454,9 @@ usi
 csz
 usi
 qVM
-iBt
-iBt
-iBt
+xfh
+vGk
+vGk
 adI
 qVM
 acG
@@ -117759,10 +117622,10 @@ acO
 aJs
 cbN
 aar
-aIZ
-aIZ
-aIZ
-aIZ
+sTB
+aap
+aao
+vFb
 ael
 afH
 agV
@@ -117794,10 +117657,10 @@ qVM
 vGk
 har
 qVM
-iBt
-iBt
-iBt
-iBt
+xHG
+csz
+vGk
+xHG
 qVM
 aJd
 aJs
@@ -117961,11 +117824,11 @@ aba
 pNQ
 abx
 hTy
-bWd
-aIZ
-aIZ
-aIZ
-aIZ
+aar
+teB
+aao
+aao
+wta
 ael
 afI
 agY
@@ -117995,13 +117858,13 @@ kGI
 aPm
 qVM
 vGk
-hoX
+csz
+xCX
+vGk
+vGk
+vGk
+csz
 qVM
-iBt
-iBt
-iBt
-iBt
-nuY
 jSY
 abx
 hLO
@@ -118163,12 +118026,12 @@ aIZ
 aar
 acP
 bUE
-cbO
+qFQ
 aar
-aIZ
-aIZ
-aIZ
-aIZ
+aao
+aap
+aao
+sTB
 ael
 afJ
 agY
@@ -118198,14 +118061,14 @@ kGI
 ejp
 qVM
 vGk
+hoX
+qVM
+xHG
+csz
+vGk
 csz
 qVM
-iBt
-iBt
-iBt
-iBt
-qVM
-acP
+sah
 bUE
 cbO
 qVM
@@ -118368,10 +118231,10 @@ acG
 abx
 caF
 aar
-aIZ
-aIZ
-aIZ
-aIZ
+aap
+aap
+aao
+sTB
 ael
 afK
 ahc
@@ -118403,10 +118266,10 @@ qVM
 vGk
 pzQ
 qVM
-iBt
-iBt
-iBt
-iBt
+usi
+vzl
+vGk
+csz
 qVM
 acG
 abx
@@ -118571,10 +118434,10 @@ oPD
 abx
 lCz
 aar
-aar
-aar
-aar
-aar
+tAV
+sTB
+uvS
+wKn
 ael
 afL
 ahe
@@ -118608,7 +118471,7 @@ dWm
 qVM
 qVM
 qVM
-qVM
+xeG
 qVM
 qVM
 oPD
@@ -118774,10 +118637,10 @@ acG
 abx
 caF
 aar
-aIZ
-aIZ
-aIZ
-bUA
+tiM
+aar
+aar
+aar
 adO
 adO
 adO
@@ -118809,10 +118672,10 @@ qVM
 qVM
 qVM
 qVM
-iBt
-iBt
-iBt
-adI
+xfh
+xWF
+vGk
+yji
 qVM
 acG
 abx
@@ -118977,10 +118840,10 @@ acO
 aJs
 arJ
 aar
-aIZ
-aIZ
-aIZ
-aIZ
+aao
+aao
+uGz
+uGz
 adO
 afM
 fpR
@@ -119012,10 +118875,10 @@ aXx
 jKI
 aXx
 qVM
-iBt
-iBt
-iBt
-iBt
+usi
+csz
+vGk
+csz
 qVM
 acO
 aJs
@@ -119179,11 +119042,11 @@ bWh
 jSY
 abx
 hTy
-xHG
-aIZ
-aIZ
-aIZ
-aIZ
+aar
+wFm
+tQE
+aao
+sTB
 adO
 afN
 ahh
@@ -119215,11 +119078,11 @@ oyE
 mMP
 mMP
 qVM
-iBt
-iBt
-iBt
-iBt
-xfh
+vGk
+csz
+vGk
+csz
+qVM
 jSY
 abx
 hLO
@@ -119381,12 +119244,12 @@ aIZ
 aar
 acP
 bUE
-cbO
+qFQ
 aar
-aIZ
-aIZ
-aIZ
-aIZ
+aap
+aap
+aao
+fZF
 adO
 afO
 ahh
@@ -119418,12 +119281,12 @@ sIA
 gSj
 aXA
 qVM
-iBt
-iBt
-iBt
-iBt
+vGk
+csz
+vGk
+xHG
 qVM
-acP
+sah
 bUE
 cbO
 qVM
@@ -119586,10 +119449,10 @@ aJa
 abg
 ccf
 aar
-aIZ
-aIZ
-aIZ
-aIZ
+tDA
+aao
+aap
+fZF
 adO
 jkj
 ahh
@@ -119621,10 +119484,10 @@ ckK
 iKM
 aHM
 qVM
-iBt
-iBt
-iBt
-iBt
+vGk
+csz
+yji
+uso
 qVM
 aJa
 abg
@@ -119791,7 +119654,7 @@ kOG
 aar
 aar
 aar
-aar
+tiM
 aar
 aar
 lFt
@@ -119824,7 +119687,7 @@ dbv
 lII
 aWc
 qVM
-qVM
+xeG
 qVM
 qVM
 qVM
@@ -119995,7 +119858,7 @@ aiv
 ahg
 aap
 aap
-aap
+aao
 rfg
 aiw
 ahh

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -1361,6 +1361,9 @@
 /obj/structure/machinery/light{
 	dir = 1
 	},
+/obj/structure/sign/safety/rewire{
+	pixel_y = 32
+	},
 /turf/open/floor/almayer{
 	icon_state = "mono"
 	},
@@ -1522,8 +1525,8 @@
 	},
 /area/almayer/hallways/aft_hallway)
 "aeW" = (
-/obj/structure/machinery/cm_vending/sorted/tech/electronics_storage,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/machinery/cm_vending/sorted/tech/electronics_storage,
 /turf/open/floor/almayer,
 /area/almayer/lifeboat_pumps/north1)
 "aeX" = (
@@ -4260,14 +4263,6 @@
 "aoi" = (
 /turf/open/floor/almayer,
 /area/almayer/shipboard/navigation)
-"aok" = (
-/obj/structure/machinery/power/apc/almayer/hardened{
-	dir = 4
-	},
-/turf/open/floor/almayer{
-	icon_state = "mono"
-	},
-/area/almayer/lifeboat_pumps/north2)
 "aol" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -32482,6 +32477,9 @@
 /area/almayer/hallways/hangar)
 "ehj" = (
 /obj/item/stack/catwalk,
+/obj/structure/machinery/status_display{
+	pixel_y = 30
+	},
 /turf/open/floor/almayer,
 /area/almayer/lifeboat_pumps/south1)
 "ehx" = (
@@ -33967,6 +33965,19 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/engineering/laundry)
+"eMn" = (
+/obj/structure/machinery/light,
+/obj/structure/sign/safety/waterhazard{
+	pixel_y = -32
+	},
+/obj/structure/sign/safety/rewire{
+	pixel_y = -32;
+	pixel_x = 14
+	},
+/turf/open/floor/almayer{
+	icon_state = "mono"
+	},
+/area/almayer/lifeboat_pumps/south1)
 "eMP" = (
 /obj/structure/machinery/door/poddoor/almayer/open{
 	dir = 4;
@@ -36668,14 +36679,6 @@
 "fUA" = (
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/living/briefing)
-"fVc" = (
-/obj/structure/machinery/power/apc/almayer/hardened{
-	dir = 4
-	},
-/turf/open/floor/almayer{
-	icon_state = "mono"
-	},
-/area/almayer/lifeboat_pumps/south1)
 "fVz" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
@@ -45937,6 +45940,15 @@
 	icon_state = "plate"
 	},
 /area/almayer/living/offices)
+"jWH" = (
+/obj/structure/machinery/power/apc/almayer/hardened{
+	cell_type = /obj/item/cell/hyper;
+	dir = 1
+	},
+/turf/open/floor/almayer{
+	icon_state = "mono"
+	},
+/area/almayer/lifeboat_pumps/north1)
 "jWU" = (
 /obj/effect/step_trigger/clone_cleaner,
 /obj/structure/blocker/forcefield/multitile_vehicles,
@@ -55164,15 +55176,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/squads/req)
-"nPX" = (
-/obj/structure/sign/safety/rewire{
-	pixel_x = 8;
-	pixel_y = 32
-	},
-/turf/open/floor/almayer{
-	icon_state = "mono"
-	},
-/area/almayer/lifeboat_pumps/north2)
 "nQv" = (
 /obj/structure/machinery/power/apc/almayer{
 	dir = 4
@@ -55262,8 +55265,9 @@
 /turf/open/floor/almayer,
 /area/almayer/command/computerlab)
 "nTH" = (
-/obj/structure/machinery/status_display{
-	pixel_y = 30
+/obj/structure/sign/safety/storage{
+	pixel_x = 8;
+	pixel_y = 32
 	},
 /turf/open/floor/almayer,
 /area/almayer/lifeboat_pumps/south1)
@@ -58828,15 +58832,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_m_p)
-"pzy" = (
-/obj/structure/sign/safety/maint{
-	pixel_x = 32
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/almayer{
-	icon_state = "mono"
-	},
-/area/almayer/lifeboat_pumps/north1)
 "pzG" = (
 /obj/docking_port/stationary/emergency_response/port1,
 /turf/open/floor/almayer{
@@ -59510,6 +59505,12 @@
 	icon_state = "plate"
 	},
 /area/almayer/hull/upper_hull/u_a_s)
+"pPF" = (
+/obj/structure/machinery/power/apc/almayer/hardened,
+/turf/open/floor/almayer{
+	icon_state = "mono"
+	},
+/area/almayer/lifeboat_pumps/south2)
 "pPM" = (
 /obj/structure/surface/rack,
 /turf/open/floor/almayer{
@@ -59688,6 +59689,12 @@
 	icon_state = "mono"
 	},
 /area/almayer/command/computerlab)
+"pUe" = (
+/obj/structure/machinery/power/apc/almayer/hardened,
+/turf/open/floor/almayer{
+	icon_state = "mono"
+	},
+/area/almayer/lifeboat_pumps/south1)
 "pUf" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -60166,6 +60173,21 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/hallways/starboard_hallway)
+"qcq" = (
+/obj/structure/machinery/light{
+	dir = 1
+	},
+/obj/structure/sign/safety/waterhazard{
+	pixel_y = 32
+	},
+/obj/structure/sign/safety/rewire{
+	pixel_y = 32;
+	pixel_x = 14
+	},
+/turf/open/floor/almayer{
+	icon_state = "mono"
+	},
+/area/almayer/lifeboat_pumps/north1)
 "qcy" = (
 /obj/structure/sign/safety/bathunisex{
 	pixel_x = 8;
@@ -62209,6 +62231,12 @@
 	icon_state = "plate"
 	},
 /area/almayer/squads/delta)
+"qWI" = (
+/obj/structure/machinery/status_display{
+	pixel_y = -30
+	},
+/turf/open/floor/almayer,
+/area/almayer/lifeboat_pumps/north1)
 "qWR" = (
 /turf/closed/wall/almayer/research/containment/wall/corner{
 	dir = 4
@@ -62759,6 +62787,9 @@
 /area/almayer/hull/upper_hull/u_m_p)
 "riP" = (
 /obj/structure/machinery/light,
+/obj/structure/sign/safety/rewire{
+	pixel_y = -32
+	},
 /turf/open/floor/almayer{
 	icon_state = "mono"
 	},
@@ -63399,12 +63430,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/hull/lower_hull/l_f_s)
-"rxy" = (
-/obj/structure/machinery/power/apc/almayer/hardened{
-	dir = 4
-	},
-/turf/open/floor/almayer,
-/area/almayer/lifeboat_pumps/south2)
 "rxG" = (
 /obj/structure/sign/safety/medical{
 	pixel_x = 8;
@@ -64814,15 +64839,6 @@
 	icon_state = "ai_floors"
 	},
 /area/almayer/command/airoom)
-"sdk" = (
-/obj/structure/machinery/power/apc/almayer/hardened{
-	dir = 4
-	},
-/turf/open/floor/almayer{
-	dir = 5;
-	icon_state = "red"
-	},
-/area/almayer/lifeboat_pumps/north1)
 "sdl" = (
 /obj/structure/surface/rack{
 	density = 0;
@@ -66165,6 +66181,9 @@
 "sHp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/largecrate/random/case/small,
+/obj/structure/sign/safety/maint{
+	pixel_x = 32
+	},
 /turf/open/floor/almayer,
 /area/almayer/lifeboat_pumps/north1)
 "sHM" = (
@@ -66820,15 +66839,6 @@
 	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical_medbay)
-"sYn" = (
-/obj/structure/sign/safety/rewire{
-	pixel_x = 8;
-	pixel_y = -32
-	},
-/turf/open/floor/almayer{
-	icon_state = "mono"
-	},
-/area/almayer/lifeboat_pumps/south2)
 "sYw" = (
 /obj/structure/platform{
 	dir = 8
@@ -69910,6 +69920,15 @@
 	icon_state = "mono"
 	},
 /area/almayer/medical/upper_medical)
+"umR" = (
+/obj/structure/machinery/power/apc/almayer/hardened{
+	cell_type = /obj/item/cell/hyper;
+	dir = 1
+	},
+/turf/open/floor/almayer{
+	icon_state = "mono"
+	},
+/area/almayer/lifeboat_pumps/north2)
 "umS" = (
 /obj/structure/bed/chair/comfy{
 	dir = 8
@@ -73822,10 +73841,6 @@
 /area/almayer/medical/upper_medical)
 "vPm" = (
 /obj/item/stack/cable_coil,
-/obj/structure/machinery/power/apc/almayer/hardened{
-	cell_type = /obj/item/cell/hyper;
-	dir = 1
-	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/lifeboat_pumps/south1)
 "vPr" = (
@@ -75356,6 +75371,13 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/living/gym)
+"wrQ" = (
+/obj/structure/sign/safety/storage{
+	pixel_x = 8;
+	pixel_y = -32
+	},
+/turf/open/floor/almayer,
+/area/almayer/living/starboard_garden)
 "wrT" = (
 /obj/structure/surface/table/almayer,
 /obj/item/device/radio/marine,
@@ -76115,8 +76137,8 @@
 /area/almayer/hull/upper_hull/u_m_s)
 "wKF" = (
 /obj/structure/machinery/power/apc/almayer{
-	dir = 1;
-	pixel_y = 25
+	cell_type = /obj/item/cell/hyper;
+	dir = 1
 	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
@@ -103648,7 +103670,7 @@ bdH
 aaC
 abs
 adq
-aeY
+qcq
 ajI
 add
 add
@@ -103706,7 +103728,7 @@ gjq
 aJU
 aJU
 tiW
-usm
+eMn
 pgD
 tQV
 aaC
@@ -103851,7 +103873,7 @@ bdH
 aaC
 abs
 adq
-add
+jWH
 ajI
 add
 auJ
@@ -103909,7 +103931,7 @@ qys
 lqZ
 aJU
 tiW
-aJU
+pUe
 pgD
 tQV
 aaC
@@ -105685,8 +105707,8 @@ oGC
 ryG
 aVL
 bBl
-sdk
-pzy
+aeZ
+ryG
 oGC
 awW
 acW
@@ -105732,7 +105754,7 @@ aJU
 bnZ
 cIe
 jez
-fVc
+aJU
 baw
 baw
 baw
@@ -107101,7 +107123,7 @@ abs
 aee
 avd
 akt
-awW
+qWI
 aar
 aar
 aar
@@ -108116,7 +108138,7 @@ acv
 aez
 boL
 akY
-boL
+wrQ
 aar
 aar
 aar
@@ -109385,7 +109407,7 @@ adc
 czu
 qVM
 qVM
-xeG
+qVM
 qVM
 qVM
 crh
@@ -109589,7 +109611,7 @@ axs
 bbL
 bbL
 bYe
-yfv
+bbL
 bit
 baw
 baw
@@ -121714,7 +121736,7 @@ aaa
 bdH
 abh
 acx
-aeC
+umR
 ajs
 aeC
 asV
@@ -121774,7 +121796,7 @@ eyG
 mMu
 vcE
 kUV
-vcE
+pPF
 rRq
 uOi
 bdH
@@ -122579,7 +122601,7 @@ uxC
 lJY
 lJY
 fFe
-rxy
+lJY
 lJY
 lJY
 vcE
@@ -122731,7 +122753,7 @@ abh
 abh
 abh
 abh
-nPX
+aeC
 atr
 aeC
 atr
@@ -122787,7 +122809,7 @@ vcE
 bXe
 vcE
 bXe
-sYn
+vcE
 uOi
 uOi
 uOi
@@ -123137,7 +123159,7 @@ aad
 aag
 aag
 abh
-aok
+aeC
 atu
 azU
 aeC

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -1073,15 +1073,6 @@
 	icon_state = "mono"
 	},
 /area/almayer/lifeboat_pumps/north1)
-"ads" = (
-/obj/structure/flora/pottedplant{
-	icon_state = "pottedplant_22";
-	pixel_y = 8
-	},
-/turf/open/floor/almayer{
-	icon_state = "mono"
-	},
-/area/almayer/lifeboat_pumps/north1)
 "adt" = (
 /obj/item/reagent_container/glass/bucket/janibucket{
 	pixel_x = -1;
@@ -1223,12 +1214,11 @@
 	},
 /area/almayer/lifeboat_pumps/north1)
 "aea" = (
-/obj/structure/bed/chair{
-	dir = 4
+/obj/structure/machinery/light{
+	dir = 1
 	},
-/turf/open/floor/almayer{
-	icon_state = "mono"
-	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer,
 /area/almayer/lifeboat_pumps/north1)
 "aeb" = (
 /obj/structure/machinery/door/poddoor/shutters/almayer/open{
@@ -1241,10 +1231,9 @@
 	},
 /area/almayer/hallways/starboard_hallway)
 "aec" = (
-/obj/structure/surface/table/almayer,
-/obj/effect/spawner/random/tool,
+/obj/structure/closet/firecloset,
 /turf/open/floor/almayer{
-	icon_state = "mono"
+	icon_state = "cargo"
 	},
 /area/almayer/lifeboat_pumps/north1)
 "aed" = (
@@ -1259,10 +1248,9 @@
 	},
 /area/almayer/living/basketball)
 "aee" = (
-/obj/structure/surface/table/almayer,
-/obj/effect/spawner/random/toolbox,
+/obj/structure/closet/emcloset,
 /turf/open/floor/almayer{
-	icon_state = "mono"
+	icon_state = "cargo"
 	},
 /area/almayer/lifeboat_pumps/north1)
 "aef" = (
@@ -1277,11 +1265,12 @@
 	},
 /area/almayer/living/offices/flight)
 "aei" = (
-/obj/structure/bed/chair{
-	dir = 8
+/obj/structure/machinery/light{
+	dir = 1
 	},
 /turf/open/floor/almayer{
-	icon_state = "mono"
+	dir = 5;
+	icon_state = "red"
 	},
 /area/almayer/lifeboat_pumps/north1)
 "aej" = (
@@ -1530,6 +1519,7 @@
 /area/almayer/hallways/aft_hallway)
 "aeW" = (
 /obj/structure/machinery/cm_vending/sorted/tech/electronics_storage,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer,
 /area/almayer/lifeboat_pumps/north1)
 "aeX" = (
@@ -1655,15 +1645,6 @@
 	},
 /turf/open/floor/wood/ship,
 /area/almayer/living/commandbunks)
-"afp" = (
-/obj/structure/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/almayer{
-	dir = 9;
-	icon_state = "red"
-	},
-/area/almayer/lifeboat_pumps/north1)
 "afq" = (
 /obj/effect/step_trigger/clone_cleaner,
 /obj/effect/decal/warning_stripes{
@@ -1734,16 +1715,10 @@
 "afz" = (
 /turf/open/floor/almayer/empty,
 /area/almayer/hallways/vehiclehangar)
-"afA" = (
+"afB" = (
 /obj/structure/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/almayer{
-	dir = 5;
-	icon_state = "red"
-	},
-/area/almayer/lifeboat_pumps/north1)
-"afB" = (
 /turf/open/floor/almayer{
 	dir = 9;
 	icon_state = "red"
@@ -2967,7 +2942,10 @@
 /area/almayer/hallways/aft_hallway)
 "ajD" = (
 /obj/structure/surface/table/almayer,
-/obj/effect/spawner/random/tool,
+/obj/structure/flora/pottedplant{
+	icon_state = "pottedplant_22";
+	pixel_y = 8
+	},
 /turf/open/floor/almayer,
 /area/almayer/lifeboat_pumps/north1)
 "ajE" = (
@@ -4225,6 +4203,8 @@
 /obj/structure/surface/table/almayer,
 /obj/item/clipboard,
 /obj/item/tool/pen,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/tool,
 /turf/open/floor/almayer,
 /area/almayer/lifeboat_pumps/north1)
 "anO" = (
@@ -4640,13 +4620,10 @@
 	},
 /area/almayer/hallways/stern_hallway)
 "aoV" = (
-/obj/structure/machinery/light{
-	unacidable = 1;
-	unslashable = 1
-	},
+/obj/structure/machinery/door/firedoor/border_only/almayer,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
-	dir = 10;
-	icon_state = "red"
+	icon_state = "test_floor4"
 	},
 /area/almayer/lifeboat_pumps/north1)
 "aoW" = (
@@ -4774,13 +4751,9 @@
 	},
 /area/almayer/living/pilotbunks)
 "apr" = (
-/obj/structure/machinery/light{
-	unacidable = 1;
-	unslashable = 1
-	},
+/obj/structure/machinery/door/firedoor/border_only/almayer,
 /turf/open/floor/almayer{
-	dir = 6;
-	icon_state = "red"
+	icon_state = "test_floor4"
 	},
 /area/almayer/lifeboat_pumps/north1)
 "aps" = (
@@ -4802,6 +4775,10 @@
 	},
 /area/almayer/living/pilotbunks)
 "apu" = (
+/obj/structure/machinery/light{
+	unacidable = 1;
+	unslashable = 1
+	},
 /turf/open/floor/almayer{
 	dir = 10;
 	icon_state = "red"
@@ -6407,6 +6384,11 @@
 	icon_state = "blue"
 	},
 /area/almayer/hallways/aft_hallway)
+"atW" = (
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/lifeboat_pumps/north1)
 "atY" = (
 /obj/structure/closet/emcloset,
 /obj/item/clothing/mask/gas,
@@ -6435,11 +6417,18 @@
 /turf/open/floor/almayer,
 /area/almayer/engineering/engineering_workshop/hangar)
 "aub" = (
-/obj/structure/machinery/vending/cigarette,
-/turf/open/floor/almayer{
-	icon_state = "mono"
+/obj/structure/machinery/light{
+	dir = 1
 	},
-/area/almayer/lifeboat_pumps/south1)
+/obj/effect/decal/warning_stripes{
+	icon_state = "NE-out";
+	pixel_y = 1
+	},
+/turf/open/floor/almayer{
+	dir = 9;
+	icon_state = "red"
+	},
+/area/almayer/lifeboat_pumps/north1)
 "auc" = (
 /obj/effect/step_trigger/clone_cleaner,
 /obj/structure/machinery/door/poddoor/almayer/open{
@@ -6933,10 +6922,11 @@
 /turf/open/floor/almayer,
 /area/almayer/lifeboat_pumps/north1)
 "avd" = (
-/obj/item/tool/warning_cone,
-/turf/open/floor/almayer{
-	icon_state = "mono"
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 1
 	},
+/turf/open/floor/almayer,
 /area/almayer/lifeboat_pumps/north1)
 "ave" = (
 /obj/item/reagent_container/glass/bucket/janibucket,
@@ -7026,17 +7016,11 @@
 /turf/open/floor/plating,
 /area/almayer/shipboard/weapon_room)
 "avx" = (
-/obj/structure/flora/pottedplant{
-	icon_state = "pottedplant_22";
-	pixel_y = 8
-	},
-/obj/structure/flora/pottedplant{
-	icon_state = "pottedplant_22";
-	pixel_x = -16;
-	pixel_y = 8
+/obj/structure/machinery/door/firedoor/border_only/almayer{
+	dir = 2
 	},
 /turf/open/floor/almayer{
-	icon_state = "mono"
+	icon_state = "test_floor4"
 	},
 /area/almayer/lifeboat_pumps/north1)
 "avz" = (
@@ -7642,9 +7626,11 @@
 	icon_state = "NW-out";
 	layer = 2.5
 	},
+/obj/structure/machinery/door/firedoor/border_only/almayer{
+	dir = 2
+	},
 /turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "green"
+	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/aft_hallway)
 "axu" = (
@@ -10252,26 +10238,25 @@
 	},
 /area/almayer/hallways/aft_hallway)
 "aGP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+/obj/effect/decal/warning_stripes{
+	icon_state = "NW-out";
+	pixel_y = 1
 	},
 /turf/open/floor/almayer{
-	icon_state = "plate"
+	dir = 5;
+	icon_state = "red"
 	},
-/area/almayer/hull/upper_hull/u_f_p)
+/area/almayer/lifeboat_pumps/north1)
 "aGQ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/machinery/door/airlock/almayer/maint{
-	req_one_access = null;
-	req_one_access_txt = "2;30;34"
+/obj/effect/decal/warning_stripes{
+	icon_state = "NE-out";
+	pixel_y = 1
 	},
 /turf/open/floor/almayer{
-	icon_state = "test_floor4"
+	dir = 9;
+	icon_state = "red"
 	},
-/area/almayer/hull/upper_hull/u_f_p)
+/area/almayer/lifeboat_pumps/north1)
 "aGR" = (
 /obj/effect/step_trigger/clone_cleaner,
 /obj/effect/decal/warning_stripes{
@@ -13544,17 +13529,29 @@
 	},
 /area/almayer/hallways/aft_hallway)
 "aWm" = (
-/obj/structure/machinery/door/firedoor/border_only/almayer,
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
+/obj/structure/machinery/light{
+	dir = 1
 	},
-/area/almayer/lifeboat_pumps/south1)
+/obj/effect/decal/warning_stripes{
+	icon_state = "NW-out";
+	pixel_y = 1
+	},
+/turf/open/floor/almayer{
+	dir = 5;
+	icon_state = "red"
+	},
+/area/almayer/lifeboat_pumps/north1)
 "aWn" = (
-/obj/structure/bed/chair/comfy/teal,
-/turf/open/floor/almayer{
-	icon_state = "mono"
+/obj/structure/machinery/light{
+	unacidable = 1;
+	unslashable = 1
 	},
-/area/almayer/lifeboat_pumps/south1)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer{
+	dir = 6;
+	icon_state = "red"
+	},
+/area/almayer/lifeboat_pumps/north1)
 "aWo" = (
 /obj/structure/pipes/unary/outlet_injector,
 /turf/open/floor/engine,
@@ -16834,6 +16831,12 @@
 	icon_state = "orange"
 	},
 /area/almayer/squads/bravo)
+"bny" = (
+/obj/structure/machinery/light,
+/turf/open/floor/almayer{
+	icon_state = "mono"
+	},
+/area/almayer/lifeboat_pumps/north1)
 "bnA" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -16931,6 +16934,17 @@
 	icon_state = "plate"
 	},
 /area/almayer/squads/bravo)
+"bnZ" = (
+/obj/structure/surface/table/almayer,
+/obj/structure/flora/pottedplant{
+	icon_state = "pottedplant_22";
+	pixel_y = 8
+	},
+/turf/open/floor/almayer{
+	dir = 6;
+	icon_state = "red"
+	},
+/area/almayer/lifeboat_pumps/south1)
 "bob" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -19886,6 +19900,12 @@
 	icon_state = "plate"
 	},
 /area/almayer/shipboard/weapon_room)
+"bDe" = (
+/obj/structure/surface/table/almayer,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/upper_hull/u_m_p)
 "bDn" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/closed/wall/almayer,
@@ -28972,6 +28992,7 @@
 /obj/structure/machinery/light{
 	dir = 4
 	},
+/obj/structure/surface/table/almayer,
 /turf/open/floor/almayer,
 /area/almayer/lifeboat_pumps/south1)
 "cIi" = (
@@ -31188,9 +31209,11 @@
 /obj/structure/sign/nosmoking_2{
 	pixel_x = 32
 	},
+/obj/structure/machinery/door/firedoor/border_only/almayer{
+	dir = 2
+	},
 /turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "red"
+	icon_state = "test_floor4"
 	},
 /area/almayer/lifeboat_pumps/south1)
 "dCK" = (
@@ -31412,8 +31435,14 @@
 /area/almayer/hull/lower_hull/l_a_p)
 "dGC" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating/plating_catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "red"
+	},
 /area/almayer/lifeboat_pumps/south1)
 "dGD" = (
 /obj/structure/closet/secure_closet{
@@ -31631,10 +31660,9 @@
 	},
 /area/almayer/shipboard/sea_office)
 "dLz" = (
-/obj/structure/surface/table/almayer,
-/obj/item/storage/backpack/satchel,
+/obj/structure/closet/firecloset,
 /turf/open/floor/almayer{
-	icon_state = "mono"
+	icon_state = "cargo"
 	},
 /area/almayer/lifeboat_pumps/south1)
 "dLE" = (
@@ -31868,6 +31896,7 @@
 /obj/structure/machinery/camera/autoname/almayer{
 	name = "ship-grade camera"
 	},
+/obj/structure/surface/table/almayer,
 /turf/open/floor/almayer{
 	dir = 9;
 	icon_state = "red"
@@ -33324,17 +33353,15 @@
 	},
 /area/almayer/command/airoom)
 "euO" = (
-/obj/structure/window/framed/almayer,
-/obj/structure/machinery/door/poddoor/shutters/almayer/open{
-	dir = 2;
-	id = "Warden Office Shutters";
-	name = "\improper Privacy Shutters"
+/obj/structure/machinery/light{
+	unacidable = 1;
+	unslashable = 1
 	},
 /turf/open/floor/almayer{
-	dir = 5;
+	dir = 10;
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/main_office)
+/area/almayer/lifeboat_pumps/north1)
 "euV" = (
 /turf/open/floor/almayer/uscm/directional{
 	dir = 8;
@@ -33811,6 +33838,17 @@
 	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering/port)
+"eFM" = (
+/obj/structure/surface/table/almayer,
+/obj/structure/flora/pottedplant{
+	icon_state = "pottedplant_22";
+	pixel_y = 8
+	},
+/turf/open/floor/almayer{
+	dir = 5;
+	icon_state = "red"
+	},
+/area/almayer/lifeboat_pumps/south1)
 "eFT" = (
 /obj/structure/bed/sofa/vert/grey,
 /obj/structure/bed/sofa/vert/grey{
@@ -34669,6 +34707,13 @@
 	icon_state = "red"
 	},
 /area/almayer/hull/upper_hull/u_a_p)
+"fad" = (
+/obj/effect/step_trigger/clone_cleaner,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/almayer{
+	icon_state = "green"
+	},
+/area/almayer/hallways/aft_hallway)
 "fau" = (
 /obj/structure/pipes/standard/manifold/hidden/supply,
 /obj/structure/disposalpipe/junction{
@@ -35504,7 +35549,15 @@
 	pixel_x = -8;
 	pixel_y = 5
 	},
-/turf/open/floor/plating/plating_catwalk,
+/obj/effect/decal/warning_stripes{
+	icon_state = "W";
+	pixel_x = -1;
+	pixel_y = 1
+	},
+/turf/open/floor/almayer{
+	dir = 5;
+	icon_state = "plating"
+	},
 /area/almayer/shipboard/brig/armory)
 "fsH" = (
 /obj/structure/disposalpipe/segment{
@@ -35516,6 +35569,15 @@
 	},
 /area/almayer/hallways/port_hallway)
 "fsT" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "E";
+	pixel_x = 1;
+	pixel_y = -1
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 2
+	},
 /turf/open/floor/almayer{
 	dir = 5;
 	icon_state = "plating"
@@ -35916,10 +35978,7 @@
 /obj/structure/machinery/cm_vending/sorted/medical/wall_med{
 	pixel_y = -25
 	},
-/turf/open/floor/almayer{
-	dir = 5;
-	icon_state = "plating"
-	},
+/turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/armory)
 "fDG" = (
 /obj/structure/machinery/vending/coffee,
@@ -36667,7 +36726,9 @@
 /obj/structure/sign/safety/storage{
 	pixel_x = -17
 	},
-/turf/open/floor/almayer,
+/turf/open/floor/almayer{
+	icon_state = "red"
+	},
 /area/almayer/lifeboat_pumps/north1)
 "fSF" = (
 /obj/structure/sink{
@@ -37039,6 +37100,15 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/shipboard/brig/processing)
+"gcc" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/hull/upper_hull/u_f_p)
 "gcK" = (
 /obj/structure/machinery/light/small{
 	dir = 1
@@ -39501,6 +39571,12 @@
 	icon_state = "plate"
 	},
 /area/almayer/engineering/engine_core)
+"heH" = (
+/obj/structure/pipes/standard/simple/hidden/supply,
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/lifeboat_pumps/north1)
 "heQ" = (
 /obj/structure/bed/chair,
 /obj/structure/extinguisher_cabinet{
@@ -41480,6 +41556,15 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/squads/alpha_bravo_shared)
+"hXV" = (
+/obj/structure/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/almayer{
+	dir = 5;
+	icon_state = "red"
+	},
+/area/almayer/lifeboat_pumps/south1)
 "hXY" = (
 /turf/open/floor/almayer{
 	dir = 4;
@@ -42069,6 +42154,9 @@
 /area/almayer/hallways/hangar)
 "ilJ" = (
 /obj/structure/bed/chair,
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
+	},
 /turf/open/floor/almayer,
 /area/almayer/lifeboat_pumps/south1)
 "ilZ" = (
@@ -43330,6 +43418,16 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/command/lifeboat)
+"iPH" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "SE-out";
+	pixel_x = 1
+	},
+/turf/open/floor/almayer{
+	dir = 10;
+	icon_state = "red"
+	},
+/area/almayer/lifeboat_pumps/south1)
 "iPS" = (
 /obj/structure/machinery/cryopod/right,
 /turf/open/floor/almayer{
@@ -44080,6 +44178,11 @@
 	dir = 8;
 	name = "ship-grade camera"
 	},
+/obj/structure/surface/table/almayer,
+/obj/structure/flora/pottedplant{
+	icon_state = "pottedplant_22";
+	pixel_y = 8
+	},
 /turf/open/floor/almayer{
 	dir = 5;
 	icon_state = "red"
@@ -44631,6 +44734,19 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/aft_hallway)
+"jnA" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "E";
+	pixel_x = 1
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
+	},
+/turf/open/floor/almayer{
+	dir = 5;
+	icon_state = "plating"
+	},
+/area/almayer/shipboard/brig/armory)
 "jnD" = (
 /turf/open/floor/almayer{
 	dir = 1;
@@ -44787,6 +44903,15 @@
 	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/medical_science)
+"jsP" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/almayer/lifeboat_pumps/south1)
 "jtj" = (
 /obj/structure/machinery/status_display{
 	pixel_y = 30
@@ -46109,9 +46234,11 @@
 /obj/effect/decal/warning_stripes{
 	icon_state = "SW-out"
 	},
+/obj/structure/machinery/door/firedoor/border_only/almayer{
+	dir = 2
+	},
 /turf/open/floor/almayer{
-	dir = 9;
-	icon_state = "green"
+	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/aft_hallway)
 "kan" = (
@@ -46976,7 +47103,8 @@
 /area/almayer/shipboard/brig/evidence_storage)
 "ktn" = (
 /obj/effect/decal/warning_stripes{
-	icon_state = "N"
+	icon_state = "N";
+	pixel_y = 2
 	},
 /obj/structure/closet/secure_closet/guncabinet/red,
 /obj/item/weapon/gun/rifle/m4ra,
@@ -47192,12 +47320,13 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/lifeboat_pumps/south1)
 "kyY" = (
-/obj/structure/largecrate/random/case/small,
-/obj/structure/machinery/cm_vending/sorted/medical/wall_med{
-	pixel_y = -25
+/obj/structure/machinery/light{
+	unacidable = 1;
+	unslashable = 1
 	},
 /turf/open/floor/almayer{
-	icon_state = "mono"
+	dir = 6;
+	icon_state = "red"
 	},
 /area/almayer/lifeboat_pumps/north1)
 "kyZ" = (
@@ -47435,15 +47564,6 @@
 	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/containment)
-"kDt" = (
-/obj/structure/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/almayer{
-	dir = 5;
-	icon_state = "red"
-	},
-/area/almayer/lifeboat_pumps/south1)
 "kDA" = (
 /obj/structure/pipes/vents/scrubber,
 /turf/open/floor/almayer{
@@ -47571,9 +47691,11 @@
 /area/almayer/hallways/aft_hallway)
 "kGL" = (
 /obj/effect/step_trigger/clone_cleaner,
+/obj/structure/machinery/door/firedoor/border_only/almayer{
+	dir = 2
+	},
 /turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "green"
+	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/aft_hallway)
 "kGQ" = (
@@ -49326,6 +49448,11 @@
 	icon_state = "plate"
 	},
 /area/almayer/living/port_emb)
+"lrF" = (
+/obj/structure/machinery/light,
+/obj/structure/surface/table/almayer,
+/turf/open/floor/almayer,
+/area/almayer/lifeboat_pumps/south1)
 "lrT" = (
 /obj/structure/bed/chair,
 /turf/open/floor/almayer,
@@ -49728,6 +49855,13 @@
 	icon_state = "plate"
 	},
 /area/almayer/living/auxiliary_officer_office)
+"lza" = (
+/obj/structure/bed/sofa/vert/grey,
+/obj/structure/bed/sofa/vert/grey/top{
+	pixel_y = 11
+	},
+/turf/open/floor/almayer,
+/area/almayer/lifeboat_pumps/south1)
 "lzj" = (
 /obj/structure/sign/safety/storage{
 	pixel_x = 8;
@@ -50457,7 +50591,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "redcorner"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/brig/main_office)
 "lNw" = (
@@ -51759,6 +51893,13 @@
 	icon_state = "plate"
 	},
 /area/almayer/living/gym)
+"muq" = (
+/obj/structure/bed/sofa/vert/grey/bot,
+/obj/structure/bed/sofa/vert/grey{
+	pixel_y = 11
+	},
+/turf/open/floor/almayer,
+/area/almayer/lifeboat_pumps/north1)
 "mux" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
@@ -53133,15 +53274,6 @@
 	icon_state = "blue"
 	},
 /area/almayer/hallways/port_hallway)
-"mYx" = (
-/obj/structure/flora/pottedplant{
-	icon_state = "pottedplant_22";
-	pixel_y = 8
-	},
-/turf/open/floor/almayer{
-	icon_state = "mono"
-	},
-/area/almayer/lifeboat_pumps/south1)
 "mYY" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "SW-out"
@@ -53644,10 +53776,9 @@
 /turf/open/floor/almayer,
 /area/almayer/hallways/port_hallway)
 "njD" = (
-/obj/structure/surface/table/almayer,
-/obj/item/clothing/suit/storage/hazardvest,
+/obj/structure/closet/emcloset,
 /turf/open/floor/almayer{
-	icon_state = "mono"
+	icon_state = "cargo"
 	},
 /area/almayer/lifeboat_pumps/south1)
 "njJ" = (
@@ -53933,6 +54064,17 @@
 	icon_state = "plate"
 	},
 /area/almayer/hull/upper_hull/u_a_p)
+"nqG" = (
+/obj/structure/machinery/light,
+/obj/effect/decal/warning_stripes{
+	icon_state = "SE-out";
+	pixel_x = 1
+	},
+/turf/open/floor/almayer{
+	dir = 10;
+	icon_state = "red"
+	},
+/area/almayer/lifeboat_pumps/south1)
 "nqU" = (
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_f_p)
@@ -54304,7 +54446,9 @@
 	id = "Warden Office Shutters";
 	name = "\improper Privacy Shutters"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
 /area/almayer/shipboard/brig/main_office)
 "nxK" = (
 /obj/structure/sign/safety/high_voltage{
@@ -55296,6 +55440,14 @@
 	icon_state = "green"
 	},
 /area/almayer/living/grunt_rnr)
+"nUn" = (
+/obj/structure/surface/table/almayer,
+/obj/structure/flora/pottedplant{
+	icon_state = "pottedplant_22";
+	pixel_y = 8
+	},
+/turf/open/floor/almayer,
+/area/almayer/lifeboat_pumps/south1)
 "nUv" = (
 /obj/structure/machinery/light{
 	dir = 1
@@ -55532,6 +55684,10 @@
 	},
 /turf/open/floor/plating,
 /area/almayer/hull/lower_hull/l_f_p)
+"oaK" = (
+/obj/structure/surface/table/almayer,
+/turf/open/floor/almayer,
+/area/almayer/lifeboat_pumps/south1)
 "oaW" = (
 /obj/structure/machinery/cryopod/right,
 /turf/open/floor/almayer{
@@ -55814,11 +55970,8 @@
 	},
 /area/almayer/shipboard/weapon_room)
 "ohB" = (
-/obj/structure/flora/pottedplant{
-	icon_state = "pottedplant_22";
-	pixel_y = 8
-	},
 /obj/structure/machinery/light,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "mono"
 	},
@@ -57039,17 +57192,9 @@
 	},
 /area/almayer/hull/upper_hull/u_m_p)
 "oGC" = (
-/obj/structure/flora/pottedplant{
-	icon_state = "pottedplant_22";
-	pixel_y = 8
-	},
-/obj/structure/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/almayer{
-	icon_state = "mono"
-	},
-/area/almayer/lifeboat_pumps/south1)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer,
+/area/almayer/lifeboat_pumps/north1)
 "oGP" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -58107,15 +58252,6 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/command/airoom)
-"pgo" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "red"
-	},
-/area/almayer/lifeboat_pumps/south1)
 "pgD" = (
 /turf/closed/wall/almayer,
 /area/almayer/lifeboat_pumps/south1)
@@ -58684,13 +58820,6 @@
 	icon_state = "redcorner"
 	},
 /area/almayer/shipboard/brig/processing)
-"pwG" = (
-/obj/structure/machinery/light,
-/turf/open/floor/almayer{
-	dir = 6;
-	icon_state = "red"
-	},
-/area/almayer/lifeboat_pumps/south1)
 "pwK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -58847,6 +58976,7 @@
 /obj/structure/sign/safety/maint{
 	pixel_x = 32
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "mono"
 	},
@@ -59055,17 +59185,11 @@
 	},
 /area/almayer/medical/containment/cell)
 "pEY" = (
-/obj/structure/flora/pottedplant{
-	icon_state = "pottedplant_22";
-	pixel_y = 8
-	},
-/obj/structure/flora/pottedplant{
-	icon_state = "pottedplant_22";
-	pixel_x = -16;
-	pixel_y = 8
+/obj/structure/machinery/door/firedoor/border_only/almayer{
+	dir = 2
 	},
 /turf/open/floor/almayer{
-	icon_state = "mono"
+	icon_state = "test_floor4"
 	},
 /area/almayer/lifeboat_pumps/south1)
 "pFa" = (
@@ -61528,20 +61652,14 @@
 	},
 /area/almayer/hallways/starboard_hallway)
 "qHq" = (
-/obj/structure/surface/table/reinforced/almayer_B,
-/obj/item/ashtray/bronze,
-/obj/item/clothing/mask/cigarette/weed{
-	desc = "What in the god damn?";
-	name = "marijuana cigarette"
+/obj/structure/machinery/door/firedoor/border_only/almayer{
+	dir = 2
 	},
-/obj/item/trash/cigbutt{
-	pixel_x = -10;
-	pixel_y = 13
-	},
+/obj/item/tool/warning_cone,
 /turf/open/floor/almayer{
-	icon_state = "mono"
+	icon_state = "test_floor4"
 	},
-/area/almayer/lifeboat_pumps/south1)
+/area/almayer/lifeboat_pumps/north1)
 "qHF" = (
 /obj/structure/surface/table/almayer,
 /obj/item/storage/box/bodybags{
@@ -62089,6 +62207,16 @@
 	},
 /turf/open/floor/plating,
 /area/almayer/living/port_emb)
+"qSX" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "SW-out";
+	pixel_x = -1
+	},
+/turf/open/floor/almayer{
+	dir = 6;
+	icon_state = "red"
+	},
+/area/almayer/lifeboat_pumps/south1)
 "qTY" = (
 /obj/structure/machinery/gibber,
 /turf/open/floor/plating/plating_catwalk,
@@ -63435,14 +63563,11 @@
 	},
 /area/almayer/medical/lower_medical_medbay)
 "ryG" = (
-/obj/structure/largecrate/random/case,
-/obj/structure/machinery/light{
-	dir = 1
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "mono"
 	},
-/area/almayer/lifeboat_pumps/south1)
+/area/almayer/lifeboat_pumps/north1)
 "ryR" = (
 /obj/structure/machinery/cm_vending/sorted/uniform_supply/squad_prep{
 	req_access = list(1)
@@ -64317,7 +64442,13 @@
 /area/almayer/squads/charlie)
 "rQW" = (
 /obj/item/tool/screwdriver,
-/turf/open/floor/almayer,
+/obj/structure/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/almayer{
+	dir = 5;
+	icon_state = "red"
+	},
 /area/almayer/lifeboat_pumps/south1)
 "rQY" = (
 /obj/structure/bed,
@@ -64333,6 +64464,13 @@
 "rRq" = (
 /turf/closed/wall/almayer,
 /area/almayer/lifeboat_pumps/south2)
+"rRz" = (
+/obj/structure/machinery/light,
+/turf/open/floor/almayer{
+	dir = 6;
+	icon_state = "red"
+	},
+/area/almayer/lifeboat_pumps/south1)
 "rRQ" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/pipes/standard/simple/hidden/supply,
@@ -65900,8 +66038,8 @@
 	pixel_y = 26
 	},
 /turf/open/floor/almayer{
-	dir = 4;
-	icon_state = "silvercorner"
+	dir = 1;
+	icon_state = "silver"
 	},
 /area/almayer/hallways/aft_hallway)
 "sDD" = (
@@ -66133,7 +66271,12 @@
 "sHp" = (
 /obj/effect/step_trigger/clone_cleaner,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/almayer,
+/obj/structure/machinery/door/firedoor/border_only/almayer{
+	dir = 2
+	},
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
 /area/almayer/hallways/aft_hallway)
 "sHM" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer,
@@ -66808,7 +66951,8 @@
 "sYB" = (
 /obj/structure/closet/secure_closet/guncabinet/red,
 /obj/effect/decal/warning_stripes{
-	icon_state = "N"
+	icon_state = "N";
+	pixel_y = 2
 	},
 /obj/item/ammo_magazine/smg/m39,
 /obj/item/ammo_magazine/smg/m39,
@@ -67113,6 +67257,7 @@
 /area/almayer/living/cryo_cells)
 "teB" = (
 /obj/structure/largecrate/random/case/small,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer,
 /area/almayer/lifeboat_pumps/north1)
 "teY" = (
@@ -67175,6 +67320,11 @@
 	pixel_y = 5
 	},
 /obj/structure/surface/table/almayer,
+/obj/effect/decal/warning_stripes{
+	icon_state = "W";
+	pixel_x = -1;
+	pixel_y = 1
+	},
 /turf/open/floor/almayer{
 	dir = 5;
 	icon_state = "plating"
@@ -67484,6 +67634,17 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/living/briefing)
+"tmI" = (
+/obj/structure/machinery/light,
+/obj/effect/decal/warning_stripes{
+	icon_state = "SW-out";
+	pixel_x = -1
+	},
+/turf/open/floor/almayer{
+	dir = 6;
+	icon_state = "red"
+	},
+/area/almayer/lifeboat_pumps/south1)
 "tmK" = (
 /obj/structure/machinery/door/airlock/almayer/maint{
 	dir = 1;
@@ -67791,7 +67952,7 @@
 	pixel_x = 32
 	},
 /turf/open/floor/almayer{
-	icon_state = "red"
+	icon_state = "test_floor4"
 	},
 /area/almayer/lifeboat_pumps/north1)
 "tsy" = (
@@ -68385,13 +68546,11 @@
 /area/almayer/squads/req)
 "tFW" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+/obj/structure/machinery/door/firedoor/border_only/almayer{
+	dir = 2
 	},
 /turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "red"
+	icon_state = "test_floor4"
 	},
 /area/almayer/lifeboat_pumps/south1)
 "tGd" = (
@@ -69338,10 +69497,11 @@
 /turf/open/floor/plating,
 /area/almayer/hull/lower_hull/l_m_p)
 "uac" = (
-/obj/structure/largecrate/random/case,
 /obj/structure/machinery/light{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/surface/table/almayer,
 /turf/open/floor/almayer,
 /area/almayer/lifeboat_pumps/north1)
 "uah" = (
@@ -70306,6 +70466,21 @@
 	icon_state = "orangecorner"
 	},
 /area/almayer/squads/bravo)
+"uvy" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 2
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "W";
+	pixel_x = -1;
+	pixel_y = 1
+	},
+/turf/open/floor/almayer{
+	dir = 5;
+	icon_state = "plating"
+	},
+/area/almayer/shipboard/brig/armory)
 "uvG" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
@@ -70663,7 +70838,12 @@
 	},
 /area/almayer/squads/bravo)
 "uBi" = (
-/obj/structure/largecrate/random/case/double,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/surface/table/almayer,
+/obj/structure/flora/pottedplant{
+	icon_state = "pottedplant_22";
+	pixel_y = 8
+	},
 /turf/open/floor/almayer,
 /area/almayer/lifeboat_pumps/north1)
 "uBn" = (
@@ -70939,13 +71119,15 @@
 	},
 /area/almayer/engineering/upper_engineering/starboard)
 "uId" = (
-/obj/structure/bed/chair/comfy/teal{
-	dir = 8
+/obj/effect/decal/warning_stripes{
+	icon_state = "W"
 	},
+/obj/effect/step_trigger/clone_cleaner,
 /turf/open/floor/almayer{
-	icon_state = "mono"
+	dir = 9;
+	icon_state = "green"
 	},
-/area/almayer/lifeboat_pumps/south1)
+/area/almayer/hallways/aft_hallway)
 "uIp" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /obj/structure/machinery/light{
@@ -71455,11 +71637,12 @@
 	},
 /area/almayer/command/cic)
 "uTY" = (
-/obj/item/trash/cigbutt/ucigbutt,
+/obj/effect/step_trigger/clone_cleaner,
 /turf/open/floor/almayer{
-	icon_state = "mono"
+	dir = 1;
+	icon_state = "green"
 	},
-/area/almayer/lifeboat_pumps/south1)
+/area/almayer/hallways/aft_hallway)
 "uTZ" = (
 /obj/structure/machinery/light/small,
 /turf/open/floor/almayer{
@@ -72473,6 +72656,11 @@
 /area/almayer/hull/lower_hull/l_f_s)
 "vmN" = (
 /obj/structure/machinery/light,
+/obj/structure/surface/table/almayer,
+/obj/structure/flora/pottedplant{
+	icon_state = "pottedplant_22";
+	pixel_y = 8
+	},
 /turf/open/floor/almayer{
 	icon_state = "mono"
 	},
@@ -72733,7 +72921,7 @@
 	req_one_access_txt = "3;6"
 	},
 /turf/open/floor/almayer{
-	icon_state = "orangefull"
+	icon_state = "test_floor4"
 	},
 /area/almayer/shipboard/brig/processing)
 "vsV" = (
@@ -75271,6 +75459,16 @@
 	icon_state = "sterile_green"
 	},
 /area/almayer/medical/containment)
+"wst" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "W"
+	},
+/obj/effect/step_trigger/clone_cleaner,
+/turf/open/floor/almayer{
+	dir = 10;
+	icon_state = "green"
+	},
+/area/almayer/hallways/aft_hallway)
 "wsD" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -76424,10 +76622,9 @@
 	},
 /area/almayer/squads/charlie_delta_shared)
 "wTy" = (
-/obj/item/reagent_container/glass/rag,
+/obj/structure/machinery/door/firedoor/border_only/almayer,
 /turf/open/floor/almayer{
-	dir = 4;
-	icon_state = "red"
+	icon_state = "test_floor4"
 	},
 /area/almayer/lifeboat_pumps/south1)
 "wTJ" = (
@@ -76552,7 +76749,8 @@
 /obj/item/vehicle_clamp,
 /obj/item/vehicle_clamp,
 /obj/effect/decal/warning_stripes{
-	icon_state = "N"
+	icon_state = "N";
+	pixel_y = 2
 	},
 /obj/item/ammo_magazine/smg/m39,
 /obj/item/ammo_magazine/smg/m39,
@@ -76758,17 +76956,10 @@
 	},
 /area/almayer/hull/upper_hull/u_m_p)
 "wYA" = (
-/obj/structure/bed/chair/comfy/teal{
-	dir = 8
-	},
-/obj/item/trash/cigbutt{
-	pixel_x = -12;
-	pixel_y = 17
-	},
-/turf/open/floor/almayer{
-	icon_state = "mono"
-	},
-/area/almayer/lifeboat_pumps/south1)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/surface/table/almayer,
+/turf/open/floor/almayer,
+/area/almayer/lifeboat_pumps/north1)
 "wYK" = (
 /obj/structure/barricade/handrail/medical,
 /turf/open/floor/almayer{
@@ -77516,10 +77707,8 @@
 /area/almayer/engineering/upper_engineering/port)
 "xoS" = (
 /obj/effect/decal/warning_stripes{
-	icon_state = "N"
-	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "E"
+	icon_state = "N";
+	pixel_y = 2
 	},
 /obj/structure/closet/secure_closet/guncabinet/red,
 /obj/item/weapon/gun/rifle/m4ra,
@@ -79187,6 +79376,12 @@
 "xVk" = (
 /turf/open/space,
 /area/space/almayer/lifeboat_dock)
+"xVF" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
+	},
+/turf/open/floor/almayer,
+/area/almayer/lifeboat_pumps/south1)
 "xVI" = (
 /obj/structure/largecrate/random/case,
 /turf/open/floor/almayer{
@@ -79260,12 +79455,14 @@
 	},
 /area/almayer/hull/upper_hull/u_m_p)
 "xWO" = (
-/obj/item/stack/catwalk,
-/obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+/obj/structure/machinery/cm_vending/sorted/medical/wall_med{
+	pixel_y = -25
 	},
-/turf/open/floor/plating,
-/area/almayer/lifeboat_pumps/south1)
+/obj/structure/largecrate/random/case/small,
+/turf/open/floor/almayer{
+	icon_state = "mono"
+	},
+/area/almayer/lifeboat_pumps/north1)
 "xWT" = (
 /obj/structure/machinery/shower{
 	pixel_y = 16
@@ -79963,6 +80160,18 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_m_s)
+"ymi" = (
+/obj/structure/machinery/door/airlock/almayer/maint{
+	req_one_access = null;
+	req_one_access_txt = "2;30;34"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/hull/upper_hull/u_f_p)
 
 (1,1,1) = {"
 aaa
@@ -90979,7 +91188,7 @@ lMc
 gjL
 cMl
 oeB
-euO
+rkL
 ldu
 eRL
 jZL
@@ -92182,7 +92391,7 @@ lrq
 mAr
 uqo
 fsT
-fsT
+jnA
 fDn
 lrq
 tqV
@@ -92587,7 +92796,7 @@ aou
 lrq
 mAr
 uqo
-fsT
+uvy
 tfO
 fsz
 lrq
@@ -101919,8 +102128,8 @@ pCi
 ifR
 jMt
 gpY
-awW
-awW
+uBi
+wYA
 awW
 awW
 awW
@@ -101956,8 +102165,8 @@ baw
 oxu
 baw
 baw
-baw
-baw
+oaK
+nUn
 pgD
 xuB
 gpe
@@ -102122,7 +102331,7 @@ pCi
 avl
 lIh
 gpY
-aeX
+uac
 vFw
 ajf
 ajf
@@ -102160,7 +102369,7 @@ aZz
 aZz
 aZz
 wUP
-cxk
+lrF
 pgD
 uEv
 gpe
@@ -102329,8 +102538,8 @@ mto
 acW
 awW
 awW
-awW
-awW
+oGC
+oGC
 aSJ
 goj
 iff
@@ -102521,7 +102730,7 @@ adq
 aeW
 ajD
 anM
-awW
+oGC
 add
 aSA
 bvb
@@ -102530,8 +102739,8 @@ ajI
 pYu
 awW
 acW
-ads
 add
+ryG
 ohB
 aiX
 awd
@@ -102562,9 +102771,9 @@ ecr
 ecr
 ygs
 aET
-oGC
+nUv
 aJU
-mYx
+aJU
 sgU
 baw
 dqb
@@ -102721,7 +102930,7 @@ bdH
 bdH
 abs
 adq
-aeX
+aea
 ajE
 awW
 awW
@@ -103983,7 +104192,7 @@ aVk
 ldC
 vkb
 aET
-gnv
+eFM
 yhI
 tTu
 sgU
@@ -104389,7 +104598,7 @@ prE
 aUw
 aUw
 awS
-aJU
+nJs
 aJU
 aJU
 tiW
@@ -104615,15 +104824,15 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aaa
 aab
 aaa
@@ -104818,15 +105027,15 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aaa
 aab
 aaa
@@ -105021,15 +105230,15 @@ bdH
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aaa
 aab
 aaa
@@ -105170,9 +105379,9 @@ awW
 awW
 abB
 add
-add
-kyY
-aau
+xWO
+aiX
+aiX
 aau
 aau
 aau
@@ -105201,8 +105410,8 @@ pUJ
 pUJ
 pUJ
 pUJ
-ryG
-aJU
+pgD
+nUv
 aJU
 pIV
 baw
@@ -105224,15 +105433,15 @@ bdH
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aaa
 aab
 aaa
@@ -105373,10 +105582,10 @@ awW
 awW
 acW
 qdQ
-eFT
-hhA
+muq
+aiX
+aiX
 aau
-dBs
 dBs
 dBs
 aau
@@ -105402,10 +105611,10 @@ bsO
 aal
 xKW
 aht
-aGP
-pUJ
-mSi
-wHp
+aht
+gcc
+pgD
+lza
 gZw
 gVF
 kuk
@@ -105424,18 +105633,18 @@ tQV
 aaa
 bdH
 bdH
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aaa
 aab
 aaa
@@ -105566,20 +105775,20 @@ adq
 awW
 awW
 awW
-awW
-add
+oGC
+ryG
 aVL
 bBl
 aeZ
 pzy
-awW
+oGC
 awW
 acW
-ads
 add
-ohB
+bny
 aiX
-vwV
+aiX
+aiX
 vwV
 vwV
 aiX
@@ -105605,16 +105814,16 @@ pUJ
 pUJ
 pUJ
 pUJ
-aGQ
 pUJ
-oGC
+ymi
+pgD
+nUv
 aJU
-mYx
 sgU
 baw
 baw
 aJU
-tTu
+bnZ
 cIe
 jez
 aJU
@@ -105627,18 +105836,18 @@ tQV
 aaa
 aaa
 bdH
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aaa
 aab
 aaa
@@ -105766,9 +105975,9 @@ aaa
 aaa
 abs
 adq
-aeZ
+aei
 aka
-aoI
+aWn
 aar
 aar
 aar
@@ -105782,7 +105991,7 @@ awW
 awW
 awW
 fSm
-aSJ
+atW
 apl
 bbL
 bbL
@@ -105808,8 +106017,8 @@ bbL
 kij
 bbL
 xRU
-pgo
-baw
+pEY
+jsP
 baw
 fGg
 baw
@@ -105822,26 +106031,26 @@ qVM
 qVM
 qVM
 qVM
-gnv
+hXV
 yhI
-tTu
+rRz
 pgD
 tQV
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aaa
 aab
 aaa
@@ -105969,8 +106178,8 @@ aaa
 aaa
 abs
 adq
-afp
-akc
+apr
+apr
 aoV
 aar
 aIx
@@ -105979,13 +106188,13 @@ aar
 aap
 aar
 uac
-awW
+oGC
 xjD
 ajf
 ajf
 ajf
-ajf
 oAO
+heH
 aod
 qgG
 amC
@@ -106025,26 +106234,26 @@ qVM
 eRR
 vce
 qVM
-crh
-csI
-qhb
+wTy
+wTy
+wTy
 pgD
 tQV
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aaa
 aab
 aaa
@@ -106170,24 +106379,24 @@ aaa
 aaa
 aaa
 aaa
-abw
-aea
-awW
-akt
-awW
-avd
+abs
+adq
+aub
+akc
+euO
+aar
 awW
 awW
 aar
 wFm
 aar
 uBi
+wYA
+oGC
 awW
 awW
 awW
-awW
-awW
-awW
+aSJ
 tsv
 dtM
 aii
@@ -106215,7 +106424,7 @@ nFr
 asS
 ajC
 dCD
-baw
+aXe
 baw
 baw
 baw
@@ -106227,27 +106436,27 @@ csz
 xWF
 aJU
 baw
-aJU
-baw
-sMM
-baw
-wiz
-trb
+qVM
+crh
+csI
+nqG
+pgD
+tQV
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aaa
 aab
 aaa
@@ -106373,12 +106582,12 @@ aaa
 aaa
 aaa
 aaa
-abw
+abs
 aec
-awW
+avd
 akt
 awW
-add
+qHq
 aIB
 awW
 aar
@@ -106418,10 +106627,10 @@ aEI
 asS
 aik
 qVM
-aWm
-aWm
-aWm
-aWm
+qVM
+qVM
+qVM
+qVM
 qVM
 yji
 qVM
@@ -106430,27 +106639,27 @@ dux
 qVM
 baw
 vFb
-aJU
+pEY
 baw
 sMM
-baw
+xVF
 dLz
-trb
+tQV
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aaa
 aab
 aaa
@@ -106578,10 +106787,10 @@ aaa
 aaa
 abs
 adq
-aeZ
+aGP
 aka
 aoI
-ads
+avx
 add
 aWu
 aar
@@ -106621,11 +106830,11 @@ dtM
 asS
 ajC
 qVM
-aWn
-baw
-baw
-uTY
-qVM
+gKS
+gKS
+csz
+xCX
+csz
 mOb
 qVM
 qVM
@@ -106633,23 +106842,23 @@ qVM
 qVM
 uGz
 aJU
-mYx
+pEY
 gnv
 yhI
-tTu
+qSX
 pgD
 tQV
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aaa
 aaa
 aaa
@@ -106781,7 +106990,7 @@ aaa
 aaa
 abs
 adq
-afr
+aGQ
 akc
 apg
 avx
@@ -106823,12 +107032,12 @@ aoe
 ahr
 biV
 ajC
+xCX
+csz
+vGk
+vGk
 qVM
-aub
-uId
-qHq
-wYA
-qVM
+bDe
 pDm
 tDA
 qFQ
@@ -106839,20 +107048,20 @@ aJU
 pEY
 wvj
 csI
-goL
+iPH
 pgD
 tQV
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aaa
 aaa
 aaa
@@ -106982,12 +107191,12 @@ aaa
 aaa
 aaa
 aaa
-abw
+abs
 aee
-awW
+avd
 akt
 awW
-add
+avx
 aJJ
 awW
 aar
@@ -107039,23 +107248,23 @@ mov
 qVM
 baw
 baw
-aJU
+pEY
 ehj
 irS
 ilJ
 njD
-trb
+tQV
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aaa
 aaa
 aaa
@@ -107185,12 +107394,12 @@ aaa
 aaa
 aaa
 aaa
-abw
-aei
-awW
-akt
-awW
-add
+abs
+adq
+aWm
+aka
+kyY
+aar
 awW
 awW
 aar
@@ -107242,23 +107451,23 @@ wKn
 qVM
 uvS
 oWz
-aJU
+qVM
 rQW
-xWO
-baw
-aJU
-trb
+yhI
+tmI
+pgD
+tQV
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aaa
 aaa
 aaa
@@ -107390,8 +107599,8 @@ aaa
 aaa
 abs
 adq
-afA
-aka
+apr
+apr
 apr
 aar
 aJL
@@ -107446,9 +107655,9 @@ qVM
 nUv
 qga
 qVM
-kDt
 wTy
-pwG
+wTy
+wTy
 pgD
 tQV
 aaa
@@ -107649,9 +107858,9 @@ qVM
 gMA
 qVM
 qVM
-vpn
+crh
 csI
-goL
+qhb
 pgD
 tQV
 bdH
@@ -109429,7 +109638,7 @@ ahp
 afY
 aJW
 kaj
-aww
+uId
 adH
 adH
 fMA
@@ -109469,7 +109678,7 @@ atC
 aAa
 aww
 aww
-aww
+wst
 axs
 bBC
 bbL
@@ -109632,7 +109841,7 @@ afY
 agh
 aJW
 kGL
-azY
+uTY
 azY
 azY
 azY
@@ -109672,7 +109881,7 @@ xwG
 agl
 agl
 agl
-agl
+fad
 sHp
 wta
 abg
@@ -109834,8 +110043,8 @@ bDD
 ale
 aJW
 ado
+atC
 kHT
-avn
 avn
 avn
 mTb
@@ -109875,8 +110084,8 @@ atC
 mTb
 avn
 avn
-avn
-avn
+aim
+atC
 avn
 bYe
 cre
@@ -117155,8 +117364,8 @@ aih
 ael
 tnl
 amO
-abg
 anc
+atC
 apJ
 apJ
 aMl
@@ -117170,8 +117379,8 @@ apJ
 aMl
 apJ
 apJ
+atC
 cnv
-abg
 amO
 lqJ
 qVM
@@ -117359,7 +117568,7 @@ ael
 cZm
 akU
 abg
-abg
+atC
 abg
 abx
 abx
@@ -117373,7 +117582,7 @@ abx
 abx
 abx
 avD
-abg
+atC
 abg
 amO
 nQx
@@ -117561,8 +117770,8 @@ ain
 ael
 eGl
 aii
-abg
 anf
+atC
 apK
 anf
 apK
@@ -117576,8 +117785,8 @@ aDp
 apK
 cbr
 apK
+atC
 cbr
-abg
 amO
 uGt
 qVM
@@ -117764,7 +117973,7 @@ oxi
 xfm
 als
 ani
-aow
+anc
 mOi
 mOi
 mOi
@@ -117780,7 +117989,7 @@ aHq
 aHq
 aHq
 aHq
-abg
+iWN
 ajt
 kGI
 aPm
@@ -117967,7 +118176,7 @@ aiq
 ajJ
 aEX
 ajt
-ali
+aow
 mOi
 rCw
 rCw
@@ -118170,7 +118379,7 @@ air
 ael
 isW
 ajt
-abg
+ali
 mOi
 wCT
 sIf


### PR DESCRIPTION
# About the pull request

Title

# Explain why it's good for the game

Lets shotgun this out

Hypersleep: CL having his own pod was an oversight everyone should be spawning in a hypersleep bay we shouldn't have any solo pod, the CC didn't have a bay so he goes in the new bay that I made out of an old maint tunnel

PO area, 1x3 hallways are really bad so I gutted it redid the room and put the vendors north-facing indented into a wall because it looks better had to remove a janitor area in the process but all the items in there got moved to the nearby maint area

symmetry those hallways were meant to be symmetrical I messed up when adding the command hypersleep bay, it's my bad so I'm fixing it 

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:SpartanBobby
maptweak: CL now spawns in a hypersleep bay "Passenger Bay" it's right next to his office, the CC spawns with him too since his landmark was in the latejoin bay on the lowerdeck
maptweak: re-arranged PO bunks should allow for better traffic in and out
maptweak: fixed symmetry issue in north-south CIC hallway
maptweak: minor warning stripe decal additions around Almayer
/:cl:
