### PR TITLE
Bugfix: Camera sprites

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -187,9 +187,9 @@
 		else
 			visible_message(SPAN_WARNING("[user] has deactivated [src]!"))
 	if(status)
-		icon_state = initial(icon_state)
+		icon_state = "camera"
 	else
-		icon_state = "[initial(icon_state)]1"
+		icon_state = "camera1"
 	// now disconnect anyone using the camera
 	//Apparently, this will disconnect anyone even if the camera was re-activated.
 	//I guess that doesn't matter since they can't use it anyway?


### PR DESCRIPTION
# About the pull request

Fixes: https://github.com/cmss13-devs/cmss13/issues/4426

Stops the camera sprites from breaking when wires were cut. Caused by the icon switch code using the 'initial' sprite value, which is an map-editor sprite.

Before / after in the dropdown.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Before:

https://github.com/cmss13-devs/cmss13/assets/59719612/9d7ee3e2-8d7e-4942-9dad-2e0bc488fa3f

After:

https://github.com/cmss13-devs/cmss13/assets/59719612/b87d9fbe-d691-4237-a3d7-074cda26087f

</details>

# Changelog

:cl: Casper
fix: fixed cameras going invisible on wire cut
/:cl: