### PR TITLE
Disallows taking control of crit xenos

### DIFF
--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -446,6 +446,10 @@ Additional game mode variables.
 			to_chat(xeno_candidate, SPAN_WARNING("You cannot join if the xenomorph is dead."))
 			return FALSE
 
+		if(new_xeno.stat == UNCONSCIOUS)
+			to_chat(xeno_candidate, SPAN_WARNING("You cannot join if the xenomorph is in critical condition or unconscious."))
+			return FALSE
+
 		if(!xeno_bypass_timer)
 			var/deathtime = world.time - xeno_candidate.timeofdeath
 			if(istype(xeno_candidate, /mob/new_player))


### PR DESCRIPTION

# About the pull request

Best case: You get to sit in crit and heal, then play.

Worst case: You're off-weeds and die slowly, losing your place in the larva queue.

This removes the worst case, while still allowing the best case (Just take control after they're out of crit.)

# Explain why it's good for the game


# Testing Photographs and Procedure



# Changelog


:cl:
qol: You can no longer doom yourself by joining as a crit xeno
/:cl:
