### PR TITLE
Whiskey Outpost vote fix

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -273,10 +273,6 @@ Voting
 /datum/config_entry/string/gamemode_default
 	config_entry_value = "Extended"
 
-// Rounds needed for gamemode vote
-/datum/config_entry/number/gamemode_rounds_needed
-	config_entry_value = 5
-
 /datum/config_entry/number/rounds_until_hard_restart
 	config_entry_value = -1 // -1 is disabled by default, 0 is every round, x is after so many rounds
 

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -101,7 +101,7 @@ SUBSYSTEM_DEF(ticker)
 				mode.declare_completion(force_ending)
 				REDIS_PUBLISH("byond.round", "type" = "round-complete")
 				flash_clients()
-				if(text2num(SSperf_logging?.round?.id) % CONFIG_GET(number/gamemode_rounds_needed) == 0)
+				if(Check_WO() || text2num(SSperf_logging?.round?.id) % CONFIG_GET(number/gamemode_rounds_needed) == 0)
 					addtimer(CALLBACK(
 						SSvote,
 						/datum/controller/subsystem/vote/proc/initiate_vote,
@@ -109,7 +109,7 @@ SUBSYSTEM_DEF(ticker)
 						"SERVER",
 						CALLBACK(src, PROC_REF(handle_map_reboot)),
 						TRUE
-					), 3 SECONDS)
+					), 3 SECONDS)	
 				else
 					handle_map_reboot()
 				Master.SetRunLevel(RUNLEVEL_POSTGAME)

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -101,17 +101,14 @@ SUBSYSTEM_DEF(ticker)
 				mode.declare_completion(force_ending)
 				REDIS_PUBLISH("byond.round", "type" = "round-complete")
 				flash_clients()
-				if(Check_WO() || text2num(SSperf_logging?.round?.id) % CONFIG_GET(number/gamemode_rounds_needed) == 0)
-					addtimer(CALLBACK(
-						SSvote,
-						/datum/controller/subsystem/vote/proc/initiate_vote,
-						"gamemode",
-						"SERVER",
-						CALLBACK(src, PROC_REF(handle_map_reboot)),
-						TRUE
-					), 3 SECONDS)	
-				else
-					handle_map_reboot()
+				addtimer(CALLBACK(
+					SSvote,
+					/datum/controller/subsystem/vote/proc/initiate_vote,
+					"gamemode",
+					"SERVER",
+					CALLBACK(src, PROC_REF(handle_map_reboot)),
+					TRUE
+				), 3 SECONDS)
 				Master.SetRunLevel(RUNLEVEL_POSTGAME)
 
 /// Attempt to start game asynchronously if applicable

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -234,11 +234,8 @@ AUTOOOCMUTE
 ## The default value assumes youtube-dl is in your system PATH
 # INVOKE_YOUTUBEDL youtube-dl
 
-## Rounds needed before a gamemode vote is casted. Set to -1 to disable
-GAMEMODE_ROUNDS_NEEDED 5
-
 ## Default gamemode to auto-switch back to after a round has concluded
-GAMEMODE_DEFAULT extended
+GAMEMODE_DEFAULT Extended
 
 ## How long the mob will take to chestburst, in seconds
 #EMBRYO_BURST_TIMER 450


### PR DESCRIPTION
# About the pull request

It should now be able to select the ground for the next round properly
maybe, who knows, I couldn't force end the WO round and I was not going to wait 1.5 hours


Also changed "extended" to "Extended" because "extended" isn't real
# Explain why it's good for the game

A game mode should probably be able to work without staff intervention

# Changelog
:cl:
fix: Whiskey Outpost ground map vote works correctly
config: Removed unnecessary config
/:cl:
