### PR TITLE
Fixes combistick folding

### DIFF
--- a/code/__DEFINES/keybinding.dm
+++ b/code/__DEFINES/keybinding.dm
@@ -185,6 +185,7 @@
 //misc yautja
 
 #define COMSIG_KB_YAUTJA_TELE_LOC "keybinding_yautja_tele_loc"
+#define COMSIG_KB_YAUTJA_FOLD_COMBISTICK "keybinding_yautja_fold_combistick"
 
 #define COMSIG_KB_OBSERVER_JOIN_XENO "keybinding_observer_join_as_xeno"
 #define COMSIG_KB_OBSERVER_JOIN_ERT "keybinding_observer_join_ert"

--- a/code/datums/keybinding/yautja.dm
+++ b/code/datums/keybinding/yautja.dm
@@ -594,3 +594,21 @@
 	var/mob/living/carbon/human/H = user.mob
 	var/obj/item/device/yautja_teleporter/tele = locate(/obj/item/device/yautja_teleporter) in H.contents
 	tele.add_tele_loc()
+
+
+/datum/keybinding/yautja/fold_combi
+	hotkey_keys = list("Space")
+	classic_keys = list("Unbound")
+	name = "fold_combi"
+	full_name = "Fold Combistick"
+	keybind_signal = COMSIG_KB_YAUTJA_FOLD_COMBISTICK
+
+/datum/keybinding/yautja/fold_combi/down(client/user)
+	. = ..()
+	if(.)
+		return
+	var/mob/living/carbon/human/human = user.mob
+	var/obj/item/weapon/yautja/combistick/held_item = human.get_held_item()
+	if(istype(held_item))
+		held_item.fold_combistick()
+	return TRUE

--- a/code/datums/keybinding/yautja.dm
+++ b/code/datums/keybinding/yautja.dm
@@ -600,7 +600,7 @@
 	hotkey_keys = list("Space")
 	classic_keys = list("Unbound")
 	name = "fold_combi"
-	full_name = "Fold Combistick"
+	full_name = "Collapse Combi-stick"
 	keybind_signal = COMSIG_KB_YAUTJA_FOLD_COMBISTICK
 
 /datum/keybinding/yautja/fold_combi/down(client/user)

--- a/code/modules/cm_preds/yaut_weapons.dm
+++ b/code/modules/cm_preds/yaut_weapons.dm
@@ -337,11 +337,12 @@
 /obj/item/weapon/yautja/combistick/IsShield()
 	return on
 
-/obj/item/weapon/yautja/combistick/verb/use_unique_action()
+/obj/item/weapon/yautja/combistick/verb/fold_combistick()
 	set category = "Weapons"
-	set name = "Unique Action"
-	set desc = "Activate or deactivate the combistick."
-	set src in usr
+	set name = "Fold Combistick"
+	set desc = "Fold or unfold the combistick."
+	set src = usr.contents
+
 	unique_action(usr)
 
 /obj/item/weapon/yautja/combistick/attack_self(mob/user)

--- a/code/modules/cm_preds/yaut_weapons.dm
+++ b/code/modules/cm_preds/yaut_weapons.dm
@@ -339,8 +339,8 @@
 
 /obj/item/weapon/yautja/combistick/verb/fold_combistick()
 	set category = "Weapons"
-	set name = "Fold Combistick"
-	set desc = "Fold or unfold the combistick."
+	set name = "Collapse Combi-stick"
+	set desc = "Collapse or extend the combistick."
 	set src = usr.contents
 
 	unique_action(usr)


### PR DESCRIPTION

# About the pull request
Lets combisticks be folded without using the verb menu by splitting it into a new verb/keybind

# Explain why it's good for the game
The verb menu is terrible, and it was fully intended for this to be macro/keybind-able

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

works

</details>


# Changelog
:cl:
add: You can now fold a combi-stick using the new "collapse combi-stick" verb and/or keybind. Defaults to the space bar.
/:cl:
