### PR TITLE
Yautja can no longer mark xenoes as honorable

### DIFF
--- a/code/modules/cm_preds/yaut_hudprocs.dm
+++ b/code/modules/cm_preds/yaut_hudprocs.dm
@@ -150,7 +150,7 @@
 
 	var/list/target_list = list()
 	for(var/mob/living/carbon/target in view(7, usr.client))
-		if((ishuman_strict(target) || isxeno(target)) && target.stat != DEAD)
+		if(ishuman_strict(target) && (target.stat != DEAD))
 			target_list += target
 
 	var/mob/living/carbon/T = tgui_input_list(usr, "Target", "Choose a target.", target_list)
@@ -187,7 +187,7 @@
 
 	var/list/target_list = list()
 	for(var/mob/living/carbon/target in view(7, usr.client))
-		if((ishuman_strict(target) || isxeno(target)) && target.stat != DEAD)
+		if(ishuman_strict(target) && (target.stat != DEAD))
 			if(target.hunter_data.honored)
 				target_list += target
 


### PR DESCRIPTION

# About the pull request
Yautja could mark xenoes as honored. It's not an explicit HC violation, but it's not intended to be done. As per a pred councilor (see below), xenoes cannot be honorable.

![image](https://github.com/cmss13-devs/cmss13/assets/41448081/042ca732-a51f-4e6c-b6c4-c89737beeec3)


# Explain why it's good for the game
Less coded-in ways to violate the Honor Code.


# Changelog
:cl:
fix: Yautja can no longer mark xenoes as honorable
/:cl:
