### PR TITLE
Fixes distress signal manual calls and a WO distress signal announcement

### DIFF
--- a/code/datums/emergency_calls/whiskey_outpost.dm
+++ b/code/datums/emergency_calls/whiskey_outpost.dm
@@ -60,7 +60,7 @@
 
 /datum/game_mode/whiskey_outpost/activate_distress()
 	var/datum/emergency_call/em_call = /datum/emergency_call/wo
-	em_call.activate(FALSE)
+	em_call.activate(TRUE, FALSE)
 	return
 
 /datum/emergency_call/wo/platoon

--- a/code/modules/admin/tabs/event_tab.dm
+++ b/code/modules/admin/tabs/event_tab.dm
@@ -218,14 +218,14 @@
 	if(!istype(chosen_ert))
 		return
 
-	var/is_announcing = tgui_alert(usr, "Would you like to announce the distress beacon to the server population? This will reveal the distress beacon to all players.", "Announce distress beacon?", list("Yes", "No"), 20 SECONDS)
-	if(!is_announcing)
+	var/quiet_launch = tgui_alert(usr, "Would you like to announce the distress beacon to the server population? This will reveal the distress beacon to all players.", "Announce distress beacon?", list("Yes", "No"), 20 SECONDS)
+	if(!quiet_launch)
 		qdel(chosen_ert)
 		return
-	if(is_announcing == "No")
-		is_announcing = FALSE
-	if (is_announcing == "Yes")
-		is_announcing = TRUE
+	if(quiet_launch == "No")
+		quiet_launch = TRUE
+	if (quiet_launch == "Yes")
+		quiet_launch = FALSE
 
 	var/turf/override_spawn_loc
 	var/prompt = tgui_alert(usr, "Spawn at their assigned spawn, or at your location?", "Spawnpoint Selection", list("Spawn", "Current Location"), 0)
@@ -235,7 +235,7 @@
 	if(prompt == "Current Location")
 		override_spawn_loc = get_turf(usr)
 
-	chosen_ert.activate(is_announcing, override_spawn_loc)
+	chosen_ert.activate(quiet_launch = quiet_launch, announce = !quiet_launch, override_spawn_loc = override_spawn_loc)
 
 	message_admins("[key_name_admin(usr)] admin-called a [choice == "Randomize" ? "randomized ":""]distress beacon: [chosen_ert.name]")
 


### PR DESCRIPTION

# About the pull request

Fixes distress signal manual call options

Fixes WO distress signal announcement

If you change a proc's arguments and don't check everything that calls it I am reporting you to the police

# Explain why it's good for the game

Bug bad

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
fix: Fixed manual distress signal manual call options
fix: Fixed a WO distress signal over announcing
/:cl:
