### PR TITLE
"Fixes" missing window frame icon states

### DIFF
--- a/code/game/smoothwall.dm
+++ b/code/game/smoothwall.dm
@@ -170,6 +170,11 @@
 		setDir(NORTH)
 
 /obj/structure/window/framed/handle_icon_junction(jun_1, jun_2)
+	if(!icon_exists(icon, "[basestate][jun_2 ? jun_2 : jun_1]")) //Missing states for 5, 6, 7, 9, 19, 11, 13, 14, 15 for the vast majority of /obj/structure/window/framed
+		icon_state = "[basestate]0"
+		junction = 0
+		return
+
 	icon_state = "[basestate][jun_2 ? jun_2 : jun_1]" //Use junction 2 if possible, junction 1 otherwise.
 	if(jun_2)
 		junction = jun_2
@@ -177,6 +182,11 @@
 		junction = jun_1
 
 /obj/structure/window_frame/handle_icon_junction(jun_1, jun_2)
+	if(!icon_exists(icon, "[basestate][jun_2 ? jun_2 : jun_1]_frame")) //Missing states for 5, 6, 7, 9, 19, 11, 13, 14, 15 for the vast majority of /obj/structure/window_frame
+		icon_state = "[basestate]0_frame"
+		junction = 0
+		return
+
 	icon_state = "[basestate][jun_2 ? jun_2 : jun_1]_frame" //Use junction 2 if possible, junction 1 otherwise.
 	if(jun_2)
 		junction = jun_2

--- a/code/game/smoothwall.dm
+++ b/code/game/smoothwall.dm
@@ -170,7 +170,7 @@
 		setDir(NORTH)
 
 /obj/structure/window/framed/handle_icon_junction(jun_1, jun_2)
-	if(!icon_exists(icon, "[basestate][jun_2 ? jun_2 : jun_1]")) //Missing states for 5, 6, 7, 9, 19, 11, 13, 14, 15 for the vast majority of /obj/structure/window/framed
+	if(!icon_exists(icon, "[basestate][jun_2 ? jun_2 : jun_1]")) //Missing states for 5, 6, 7, 9, 10, 11, 13, 14, 15 for the vast majority of /obj/structure/window/framed
 		icon_state = "[basestate]0"
 		junction = 0
 		return
@@ -182,7 +182,7 @@
 		junction = jun_1
 
 /obj/structure/window_frame/handle_icon_junction(jun_1, jun_2)
-	if(!icon_exists(icon, "[basestate][jun_2 ? jun_2 : jun_1]_frame")) //Missing states for 5, 6, 7, 9, 19, 11, 13, 14, 15 for the vast majority of /obj/structure/window_frame
+	if(!icon_exists(icon, "[basestate][jun_2 ? jun_2 : jun_1]_frame")) //Missing states for 5, 6, 7, 9, 10, 11, 13, 14, 15 for the vast majority of /obj/structure/window_frame
 		icon_state = "[basestate]0_frame"
 		junction = 0
 		return


### PR DESCRIPTION
# About the pull request

This PR "fixes" missing window frame icon states by just checking if they exist and if not then defaulting to base.

The vast majority of these are missing states 5, 6, 7, 9, 10, 11, 13, 14, 15 but some have them and others do not.

It's essentially a bandaid but until we get someone who wants to sprite 100ish icons 🤷 

closes https://github.com/cmss13-devs/cmss13/issues/2531

# Explain why it's good for the game

Dealing with invisible window frames is super frustrating for everyone.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
fix: "Fixed" missing window frame icon states
/:cl:
