### PR TITLE
Floodlight rework

### DIFF
--- a/code/game/machinery/floodlight.dm
+++ b/code/game/machinery/floodlight.dm
@@ -1,5 +1,3 @@
-//these are probably broken
-
 /obj/structure/machinery/floodlight
 	name = "Emergency Floodlight"
 	icon = 'icons/obj/structures/machinery/floodlight.dmi'

--- a/code/game/machinery/floodlight.dm
+++ b/code/game/machinery/floodlight.dm
@@ -6,25 +6,21 @@
 	icon_state = "flood00"
 	density = TRUE
 	anchored = TRUE
-	var/obj/item/cell/cell = null
-	var/use = 0
-	var/unlocked = 0
-	var/open = 0
 	light_power = 2
-	unslashable = TRUE
-	unacidable = TRUE
+	wrenchable = TRUE
+	use_power = USE_POWER_IDLE
+	idle_power_usage = 10
+	active_power_usage = 100
 
 	var/on_light_range = 6
 
+	///Whether or not the floodlight can be toggled on or off
+	var/toggleable = TRUE
+
 /obj/structure/machinery/floodlight/Initialize(mapload, ...)
 	. = ..()
-	cell = new /obj/item/cell(src)
 	if(light_on)
 		set_light(on_light_range)
-
-/obj/structure/machinery/floodlight/Destroy()
-	QDEL_NULL(cell)
-	return ..()
 
 /obj/structure/machinery/floodlight/turn_light(mob/user, toggle_on)
 	. = ..()
@@ -36,85 +32,33 @@
 	else
 		set_light(0)
 
-
-/obj/structure/machinery/floodlight/proc/updateicon()
-	icon_state = "flood[open ? "o" : ""][open && cell ? "b" : ""]0[light_on]"
+	update_icon()
 
 /obj/structure/machinery/floodlight/attack_hand(mob/user as mob)
-	if(open && cell)
-		if(ishuman(user))
-			if(!user.get_active_hand())
-				user.put_in_hands(cell)
-				cell.forceMove(user.loc)
-		else
-			cell.forceMove(loc)
+	. = ..()
+	if(.)
+		return
 
-		cell.add_fingerprint(user)
-		cell.update_icon()
-
-		src.cell = null
-		to_chat(user, "You remove the power cell.")
-		updateicon()
+	if(!toggleable)
 		return
 
 	if(light_on)
 		to_chat(user, SPAN_NOTICE("You turn off the light."))
 		turn_light(user, toggle_on = FALSE)
-		unslashable = TRUE
-		unacidable = TRUE
+		update_use_power(USE_POWER_IDLE)
 	else
-		if(!cell)
-			return
-		if(cell.charge <= 0)
-			return
 		to_chat(user, SPAN_NOTICE("You turn on the light."))
 		turn_light(user, toggle_on = TRUE)
-		unacidable = FALSE
+		update_use_power(USE_POWER_ACTIVE)
 
-	updateicon()
+/obj/structure/machinery/floodlight/update_icon()
+	. = ..()
+	icon_state = "flood0[light_on]"
 
-
-/obj/structure/machinery/floodlight/attackby(obj/item/W as obj, mob/user as mob)
-	if(!ishuman(user))
-		return
-
-	if (HAS_TRAIT(W, TRAIT_TOOL_WRENCH))
-		if (!anchored)
-			anchored = TRUE
-			to_chat(user, "You anchor the [src] in place.")
-		else
-			anchored = FALSE
-			to_chat(user, "You remove the bolts from the [src].")
-
-	if (HAS_TRAIT(W, TRAIT_TOOL_SCREWDRIVER))
-		if (!open)
-			if(unlocked)
-				unlocked = 0
-				to_chat(user, "You screw the battery panel in place.")
-			else
-				unlocked = 1
-				to_chat(user, "You unscrew the battery panel.")
-
-	if (HAS_TRAIT(W, TRAIT_TOOL_CROWBAR))
-		if(unlocked)
-			if(open)
-				open = 0
-				overlays = null
-				to_chat(user, "You crowbar the battery panel in place.")
-			else
-				if(unlocked)
-					open = 1
-					to_chat(user, "You remove the battery panel.")
-
-	if (istype(W, /obj/item/cell))
-		if(open)
-			if(cell)
-				to_chat(user, "There is a power cell already installed.")
-			else
-				if(user.drop_inv_item_to_loc(W, src))
-					cell = W
-					to_chat(user, "You insert the power cell.")
-	updateicon()
+/obj/structure/machinery/floodlight/power_change(area/master_area = null)
+	..()
+	if(stat & NOPOWER)
+		turn_light(toggle_on = FALSE)
 
 //Magical floodlight that cannot be destroyed or interacted with.
 /obj/structure/machinery/floodlight/landing
@@ -124,12 +68,11 @@
 	light_on = TRUE
 	in_use = 1
 	use_power = USE_POWER_NONE
-
-/obj/structure/machinery/floodlight/landing/attack_hand()
-	return
-
-/obj/structure/machinery/floodlight/landing/attackby()
-	return
+	needs_power = FALSE
+	unslashable = TRUE
+	unacidable = TRUE
+	wrenchable = FALSE
+	toggleable = FALSE
 
 /obj/structure/machinery/floodlight/landing/floor
 	icon_state = "floor_flood01"

--- a/maps/map_files/LV624/LV624.dmm
+++ b/maps/map_files/LV624/LV624.dmm
@@ -1119,8 +1119,10 @@
 	},
 /area/lv624/ground/barrens/containers)
 "afu" = (
-/obj/structure/machinery/floodlight,
 /obj/item/ammo_casing,
+/obj/structure/machinery/floodlight/landing{
+	name = "Bolted Emergency Floodlight"
+	},
 /turf/open/floor/plating{
 	dir = 9;
 	icon_state = "warnplate"
@@ -1154,7 +1156,9 @@
 	},
 /area/lv624/ground/barrens/central_barrens)
 "afy" = (
-/obj/structure/machinery/floodlight,
+/obj/structure/machinery/floodlight/landing{
+	name = "Bolted Emergency Floodlight"
+	},
 /turf/open/floor/plating{
 	dir = 5;
 	icon_state = "warnplate"
@@ -1203,11 +1207,6 @@
 /obj/item/ammo_casing,
 /obj/item/ammo_casing,
 /obj/item/ammo_casing,
-/turf/open/floor/plating,
-/area/lv624/ground/barrens/central_barrens)
-"afM" = (
-/obj/structure/machinery/floodlight,
-/obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating,
 /area/lv624/ground/barrens/central_barrens)
 "afN" = (
@@ -1389,10 +1388,6 @@
 "agA" = (
 /turf/open/floor/sandstone/runed,
 /area/lv624/ground/caves/south_east_caves)
-"agC" = (
-/obj/structure/machinery/floodlight,
-/turf/open/floor/plating,
-/area/lv624/ground/barrens/central_barrens)
 "agD" = (
 /obj/structure/surface/table/reinforced{
 	dir = 8;
@@ -1407,8 +1402,10 @@
 /turf/open/floor/plating,
 /area/lv624/ground/barrens/central_barrens)
 "agF" = (
-/obj/structure/machinery/floodlight,
 /obj/item/ammo_casing,
+/obj/structure/machinery/floodlight/landing{
+	name = "Bolted Emergency Floodlight"
+	},
 /turf/open/floor/plating,
 /area/lv624/ground/barrens/central_barrens)
 "agG" = (
@@ -1585,7 +1582,9 @@
 	},
 /area/lv624/ground/barrens/west_barrens/ceiling)
 "ahM" = (
-/obj/structure/machinery/floodlight,
+/obj/structure/machinery/floodlight/landing{
+	name = "Bolted Emergency Floodlight"
+	},
 /turf/open/floor/plating{
 	dir = 10;
 	icon_state = "warnplate"
@@ -1625,7 +1624,9 @@
 	},
 /area/lv624/ground/barrens/central_barrens)
 "ahT" = (
-/obj/structure/machinery/floodlight,
+/obj/structure/machinery/floodlight/landing{
+	name = "Bolted Emergency Floodlight"
+	},
 /turf/open/floor/plating{
 	dir = 6;
 	icon_state = "warnplate"
@@ -41057,7 +41058,7 @@ ajW
 afI
 ajW
 ajW
-agC
+ajW
 afN
 ajW
 ajW
@@ -42192,7 +42193,7 @@ jaa
 wVk
 wVk
 afx
-afM
+agf
 ajW
 agi
 ajW
@@ -42202,7 +42203,7 @@ agT
 ahh
 ahl
 afN
-agC
+ajW
 ahS
 afk
 wVk
@@ -43337,7 +43338,7 @@ ajW
 agl
 ajW
 ajW
-agC
+ajW
 ajW
 afN
 eah

--- a/maps/map_files/LV624/LV624.dmm
+++ b/maps/map_files/LV624/LV624.dmm
@@ -1121,7 +1121,7 @@
 "afu" = (
 /obj/item/ammo_casing,
 /obj/structure/machinery/floodlight/landing{
-	name = "Bolted Emergency Floodlight"
+	name = "bolted floodlight"
 	},
 /turf/open/floor/plating{
 	dir = 9;
@@ -1157,7 +1157,7 @@
 /area/lv624/ground/barrens/central_barrens)
 "afy" = (
 /obj/structure/machinery/floodlight/landing{
-	name = "Bolted Emergency Floodlight"
+	name = "bolted floodlight"
 	},
 /turf/open/floor/plating{
 	dir = 5;
@@ -1404,7 +1404,7 @@
 "agF" = (
 /obj/item/ammo_casing,
 /obj/structure/machinery/floodlight/landing{
-	name = "Bolted Emergency Floodlight"
+	name = "bolted floodlight"
 	},
 /turf/open/floor/plating,
 /area/lv624/ground/barrens/central_barrens)
@@ -1583,7 +1583,7 @@
 /area/lv624/ground/barrens/west_barrens/ceiling)
 "ahM" = (
 /obj/structure/machinery/floodlight/landing{
-	name = "Bolted Emergency Floodlight"
+	name = "bolted floodlight"
 	},
 /turf/open/floor/plating{
 	dir = 10;
@@ -1625,7 +1625,7 @@
 /area/lv624/ground/barrens/central_barrens)
 "ahT" = (
 /obj/structure/machinery/floodlight/landing{
-	name = "Bolted Emergency Floodlight"
+	name = "bolted floodlight"
 	},
 /turf/open/floor/plating{
 	dir = 6;

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -5852,7 +5852,9 @@
 	},
 /area/almayer/medical/morgue)
 "asV" = (
-/obj/structure/machinery/floodlight/landing,
+/obj/structure/machinery/floodlight/landing{
+	name = "bolted floodlight"
+	},
 /turf/open/floor/almayer{
 	icon_state = "mono"
 	},
@@ -6629,7 +6631,9 @@
 	},
 /area/almayer/engineering/engineering_workshop/hangar)
 "auJ" = (
-/obj/structure/machinery/floodlight/landing,
+/obj/structure/machinery/floodlight/landing{
+	name = "bolted floodlight"
+	},
 /turf/open/floor/almayer{
 	icon_state = "mono"
 	},
@@ -49266,7 +49270,9 @@
 	},
 /area/almayer/living/port_emb)
 "lqZ" = (
-/obj/structure/machinery/floodlight/landing,
+/obj/structure/machinery/floodlight/landing{
+	name = "bolted floodlight"
+	},
 /turf/open/floor/almayer{
 	icon_state = "mono"
 	},
@@ -52574,7 +52580,9 @@
 	},
 /area/almayer/hallways/stern_hallway)
 "mMu" = (
-/obj/structure/machinery/floodlight/landing,
+/obj/structure/machinery/floodlight/landing{
+	name = "bolted floodlight"
+	},
 /turf/open/floor/almayer{
 	icon_state = "mono"
 	},


### PR DESCRIPTION
# About the pull request

Alright so this expanded in scope rapidly once I saw what the hell was going on in this file.

Normal floodlights are now:
Slashable
Acidable
Require power and turn off appropriately
Wrenchable

Landing lights (and some special floodlights on maps):
Unslashable
Unacidable
Unwrenchable
Do not require power or ever turn off

# Explain why it's good for the game

Old and goofy code BAD

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
fix: Fixed floodlight stacking to make mostly invincible walls
refactor: Refactored 90% of the floodlight code
/:cl:
