### PR TITLE
[QOL] You can acid things on surfaces

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/ability_helper_procs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/ability_helper_procs.dm
@@ -119,7 +119,7 @@
 	if(!check_plasma(plasma_cost))
 		return
 
-	if(!O.Adjacent(src) || (I && !isturf(I.loc)))//not adjacent or inside something
+	if(!O.Adjacent(src) || (I && !isturf(I.loc) && !issurface(I.loc)))//not adjacent or inside something
 		if(istype(O,/obj/item/explosive/plastic))
 			var/obj/item/explosive/plastic/E = O
 			if(E.plant_target && !E.plant_target.Adjacent(src))


### PR DESCRIPTION
# About the pull request

Allows aciding of items again on surfaces.

Currently, it says you're too far even if you're adjacent to the item and surface the item is on.

Starts the progress to acid but then says you're too far away. This fixes that.

# Explain why it's good for the game

I remember being able to acid items on tables a while back.

Would alt click and then select the items to acid.

Without this, you need to destroy the surface first before aciding the items which is fine but annoying. 

I don't think this would change things too much destroying things on the tables without needing to touch the table. Just a minor QOL / fix from what it used to be like.


# Changelog
:cl:
qol: You can acid objects on surfaces again
/:cl:

