### PR TITLE
Minor QOL Buff To Handheld Crew Monitor

### DIFF
--- a/code/modules/cm_marines/radar.dm
+++ b/code/modules/cm_marines/radar.dm
@@ -204,17 +204,20 @@
 		if(!trackable(humanoid))
 			continue
 		var/crewmember_name = "Unknown"
+		var/crewmember_rank = "Unknown"
 		if(humanoid.wear_id)
 			var/obj/item/card/id/ID = humanoid.wear_id.GetID()
 			if(ID?.registered_name)
 				crewmember_name = ID.registered_name
+			if(ID?.assignment)
+				crewmember_rank = ID.assignment
 		switch(humanoid.stat)
 			if(CONSCIOUS)
-				crewmember_name = "[crewmember_name] (Conscious)"
+				crewmember_name = "[crewmember_name] ([crewmember_rank]) (Conscious)"
 			if(UNCONSCIOUS)
-				crewmember_name = "[crewmember_name] (Unconscious)"
+				crewmember_name = "[crewmember_name] ([crewmember_rank]) (Unconscious)"
 			if(DEAD)
-				crewmember_name = "[crewmember_name] (DEAD)"
+				crewmember_name = "[crewmember_name] ([crewmember_rank]) (DEAD)"
 		var/list/crewinfo = list(
 			ref = REF(humanoid),
 			name = crewmember_name,

--- a/tgui/packages/tgui/interfaces/Radar.tsx
+++ b/tgui/packages/tgui/interfaces/Radar.tsx
@@ -29,7 +29,7 @@ type Target = {
 
 export const Radar = (props, context) => {
   return (
-    <Window width={800} height={600} theme="ntos">
+    <Window width={965} height={600} theme="ntos">
       <Window.Content scrollable>
         <RadarContent />
       </Window.Content>
@@ -40,7 +40,7 @@ export const Radar = (props, context) => {
 export const RadarContent = (props, context) => {
   return (
     <Stack fill>
-      <Stack.Item position="relative" width={20.5}>
+      <Stack.Item position="relative" width={35}>
         <ObjectDisplay />
       </Stack.Item>
       <Stack.Item


### PR DESCRIPTION

# About the pull request

Adds the job title of a person to the crew list on the handheld crew monitor. Also expands the default screen size of the radar menu so the user can see the entire name and job title of the crew.

# Explain why it's good for the game

Makes the monitor slightly easier to use. Helps differentiate who exactly you are looking at. 


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![Screenshot 2023-09-29 14 31 45](https://github.com/cmss13-devs/cmss13/assets/6595389/6bc15031-50e9-475c-9d00-22e13979fd38)


</details>


# Changelog
:cl:
ui: Added personnel job titles to the handheld crew monitor, to make it easier to tell find out exactly what role's you are looking for. Also slightly expands the default monitor screen size to accommodate the entire personnel text on screen.
/:cl:
