### PR TITLE
Xeno structure cheese reduction

### DIFF
--- a/code/game/turfs/walls/wall_types.dm
+++ b/code/game/turfs/walls/wall_types.dm
@@ -1114,6 +1114,10 @@ INITIALIZE_IMMEDIATE(/turf/closed/wall/indestructible/splashscreen)
 	if(src in P.permutated)
 		return
 
+	//Ineffective if someone is sitting on the wall
+	if(locate(/mob) in contents)
+		return ..()
+
 	if(!prob(chance_to_reflect))
 		if(P.ammo.damage_type == BRUTE)
 			P.damage *= brute_multiplier

--- a/code/modules/cm_aliens/structures/special_structure.dm
+++ b/code/modules/cm_aliens/structures/special_structure.dm
@@ -72,3 +72,9 @@
 /obj/effect/alien/resin/special/attack_alien(mob/living/carbon/xenomorph/M)
 	if(M.can_destroy_special() || M.hivenumber != linked_hive.hivenumber)
 		return ..()
+
+/obj/effect/alien/resin/special/get_projectile_hit_boolean(obj/projectile/firing_projectile)
+	if(firing_projectile.original == src || firing_projectile.original == get_turf(src))
+		return TRUE
+
+	return FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

If a mob is on top of a reflective wall the wall does not function.

If you are not directly clicking on a xeno special structure (cluster/core/etc) it will not stop your bullets.

# Explain why it's good for the game

Seeing an uptick in cheesy nonsense we don't really want to encourage. This should mitigate it.

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
balance: If a mob is on top of a reflective wall the wall no longer functions
balance: Bullets will not longer get eaten by xeno special structures unless you click directly on them
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
