### PR TITLE
Tool Pouch Allowed Items Change

### DIFF
--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -1172,23 +1172,37 @@
 
 /obj/item/storage/pouch/tools
 	name = "tools pouch"
-	desc = "It's designed to hold maintenance tools - screwdriver, wrench, cable coil, etc. It also has a hook for an entrenching tool."
+	desc = "It's designed to hold maintenance tools - screwdriver, wrench, cable coil, etc. It also has a hook for an entrenching tool or light replacer."
 	storage_slots = 4
 	max_w_class = SIZE_MEDIUM
 	icon_state = "tools"
 	can_hold = list(
-		/obj/item/tool/wirecutters,
-		/obj/item/tool/shovel/etool,
-		/obj/item/tool/screwdriver,
 		/obj/item/tool/crowbar,
+		/obj/item/tool/screwdriver,
 		/obj/item/tool/weldingtool,
-		/obj/item/device/multitool,
+		/obj/item/tool/wirecutters,
 		/obj/item/tool/wrench,
-		/obj/item/stack/cable_coil,
 		/obj/item/tool/extinguisher/mini,
 		/obj/item/tool/shovel/etool,
+		/obj/item/stack/cable_coil,
+		/obj/item/weapon/gun/smg/nailgun/compact,
+		/obj/item/cell,
+		/obj/item/circuitboard,
+		/obj/item/stock_parts,
+		/obj/item/device/demo_scanner,
+		/obj/item/device/reagent_scanner,
+		/obj/item/device/assembly,
+		/obj/item/device/multitool,
+		/obj/item/device/flashlight,
+		/obj/item/device/t_scanner,
+		/obj/item/device/analyzer,
+		/obj/item/explosive/plastic,
+		/obj/item/device/lightreplacer,
 	)
-	bypass_w_limit = list(/obj/item/tool/shovel/etool)
+	bypass_w_limit = list(
+		/obj/item/tool/shovel/etool,
+		/obj/item/device/lightreplacer,
+	)
 
 /obj/item/storage/pouch/tools/tactical
 	name = "tactical tools pouch"


### PR DESCRIPTION

# About the pull request

The tool pouch can now hold the same items that the toolbelt is allowed to hold. It is still restricted to four item slots.

# Explain why it's good for the game

Consistency in item management. It felt odd the tool pouch was excluded from holding items the toolbelt can hold. 


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: Tool Pouch can now hold the same types of items that a toolbelt can hold. It is still restricted to 4 inventory slots. 
/:cl:
