### PR TITLE
Eggs No Longer Have Melee Resistance

### DIFF
--- a/code/modules/cm_aliens/structures/egg.dm
+++ b/code/modules/cm_aliens/structures/egg.dm
@@ -212,9 +212,9 @@
 		visible_message(SPAN_DANGER("\The [src] has been [pick(W.attack_verb)] with \the [W][(user ? " by [user]." : ".")]"))
 	else
 		visible_message(SPAN_DANGER("\The [src] has been attacked with \the [W][(user ? " by [user]." : ".")]"))
+	var/damage = W.force
 	if(iswelder(W))
 		var/obj/item/tool/weldingtool/WT = W
-
 		if(WT.remove_fuel(0, user))
 			damage = 15
 			playsound(src.loc, 'sound/items/Welder.ogg', 25, 1)

--- a/code/modules/cm_aliens/structures/egg.dm
+++ b/code/modules/cm_aliens/structures/egg.dm
@@ -212,9 +212,6 @@
 		visible_message(SPAN_DANGER("\The [src] has been [pick(W.attack_verb)] with \the [W][(user ? " by [user]." : ".")]"))
 	else
 		visible_message(SPAN_DANGER("\The [src] has been attacked with \the [W][(user ? " by [user]." : ".")]"))
-	var/damage = W.force
-	if(W.w_class < SIZE_LARGE || !W.sharp || W.force < 20) //only big strong sharp weapon are adequate
-		damage /= 4
 	if(iswelder(W))
 		var/obj/item/tool/weldingtool/WT = W
 


### PR DESCRIPTION
# About the pull request

Eggs no longer have magical resistance to certain kinds of melee damage. 

# Explain why it's good for the game

The old system means certain melee weapons are utterly ineffective against eggs, wheras others are lethally effective (a breaching hammer or knife taking forever to kill one egg, but a machete or axe taking 2 swings).

I'd also argue a giant blunt force attack would be more effective against an egg than a edged blade. 


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: Eggs no longer are resistant to certain kinds of melee attacks. Making them far easier to kill in melee. 
/:cl:
