### PR TITLE
Egg runtime fix

### DIFF
--- a/code/modules/cm_aliens/structures/egg.dm
+++ b/code/modules/cm_aliens/structures/egg.dm
@@ -208,7 +208,7 @@
 		return
 
 	user.animation_attack_on(src)
-	if(W.attack_verb.len)
+	if(W.attack_verb)
 		visible_message(SPAN_DANGER("\The [src] has been [pick(W.attack_verb)] with \the [W][(user ? " by [user]." : ".")]"))
 	else
 		visible_message(SPAN_DANGER("\The [src] has been attacked with \the [W][(user ? " by [user]." : ".")]"))

--- a/code/modules/cm_aliens/structures/egg.dm
+++ b/code/modules/cm_aliens/structures/egg.dm
@@ -208,7 +208,7 @@
 		return
 
 	user.animation_attack_on(src)
-	if(W.attack_verb)
+	if(length(W.attack_verb))
 		visible_message(SPAN_DANGER("\The [src] has been [pick(W.attack_verb)] with \the [W][(user ? " by [user]." : ".")]"))
 	else
 		visible_message(SPAN_DANGER("\The [src] has been attacked with \the [W][(user ? " by [user]." : ".")]"))


### PR DESCRIPTION

# About the pull request

Attacking an egg with a weapon that had no attack_verb would runtime the attack process, ending up not applying any damage.
Like a welder :|


# Testing Photographs and Procedure
Ja


# Changelog
:cl:
fix: Fixed runtime that could happen when melleing an egg.
/:cl:
