### PR TITLE
Fixes machinery coming out of largecrates not updating power

### DIFF
--- a/code/game/objects/structures/crates_lockers/largecrate.dm
+++ b/code/game/objects/structures/crates_lockers/largecrate.dm
@@ -32,8 +32,8 @@
 		var/atom/movable/current_atom = contents[1]
 		current_atom.forceMove(current_turf)
 		if(istype(current_atom, /obj/structure/machinery))
-			var/obj/structure/machinery/current_machine = current_atom
-			current_machine.power_change()
+			var/area/current_area = get_area(src)
+			current_area.add_machine(current_atom)
 
 	deconstruct(TRUE)
 

--- a/code/game/objects/structures/crates_lockers/largecrate.dm
+++ b/code/game/objects/structures/crates_lockers/largecrate.dm
@@ -31,6 +31,9 @@
 	for(var/atom/movable/moving_atom in contents)
 		var/atom/movable/current_atom = contents[1]
 		current_atom.forceMove(current_turf)
+		if(istype(current_atom, /obj/structure/machinery))
+			var/obj/structure/machinery/current_machine = current_atom
+			current_machine.power_change()
 
 	deconstruct(TRUE)
 


### PR DESCRIPTION

# About the pull request

Due to how forceMove() works it does not properly call area's Entered() proc as the areas are not changing when the contents are removed.

This is a hacky way to force add the machinery.

# Explain why it's good for the game

Non-updating machinery is lame

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
fix: Fixed machinery coming out of largecrates not updating power
/:cl:
