### PR TITLE
Underbarrel extinguisher no longer requires wield

### DIFF
--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -3058,9 +3058,6 @@ Defined in conflicts.dm of the #defines folder.
 /obj/item/attachable/attached_gun/extinguisher/fire_attachment(atom/target, obj/item/weapon/gun/gun, mob/living/user)
 	if(!internal_extinguisher)
 		return
-	if(!(gun.flags_item & WIELDED))
-		to_chat(user, SPAN_WARNING("You must wield [gun] to fire [src]!"))
-		return
 	if(..())
 		return internal_extinguisher.afterattack(target, user)
 


### PR DESCRIPTION

# About the pull request

Underbarrel extinguisher no longer requires wield

# Explain why it's good for the game

Frankly, this just feels so much better and it's not an offensive weapon.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
balance: Underbarrel extinguisher no longer requires wield
/:cl:
