### PR TITLE
Fixes storage depth for internal storages

### DIFF
--- a/code/_onclick/adjacent.dm
+++ b/code/_onclick/adjacent.dm
@@ -94,6 +94,11 @@ Quick adjacency (to turf):
 /obj/item/Adjacent(atom/neighbor, recurse = 1)
 	if(neighbor == loc || (loc && neighbor == loc.loc))
 		return TRUE
+
+	// Internal storages have special relationships with the object they are connected to and we still want two depth adjacency for storages
+	if(istype(loc.loc, /obj/item/storage/internal) && recurse > 0)
+		return loc.loc.Adjacent(neighbor, recurse)
+
 	if(issurface(loc))
 		return loc.Adjacent(neighbor, recurse) //Surfaces don't count as storage depth.
 	else if(istype(loc, /obj/item))

--- a/code/_onclick/adjacent.dm
+++ b/code/_onclick/adjacent.dm
@@ -96,7 +96,7 @@ Quick adjacency (to turf):
 		return TRUE
 
 	// Internal storages have special relationships with the object they are connected to and we still want two depth adjacency for storages
-	if(istype(loc.loc, /obj/item/storage/internal) && recurse > 0)
+	if(istype(loc?.loc, /obj/item/storage/internal) && recurse > 0)
 		return loc.loc.Adjacent(neighbor, recurse)
 
 	if(issurface(loc))


### PR DESCRIPTION

# About the pull request

Allows two depth storage removal for internal storages

# Explain why it's good for the game

Inconsistency bad

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
fix: Fixed storage depth for internal storages
/:cl:
