### PR TITLE
Operation time logging

### DIFF
--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -105,6 +105,7 @@ var/global/cas_tracking_id_increment = 0 //this var used to assign unique tracki
 		np.new_player_panel_proc()
 	round_time_lobby = world.time
 	log_game("Round started at [time2text(world.realtime)]")
+	log_game("Operation time at round start is [worldtime2text()]")
 	if(SSticker.mode)
 		log_game("Game mode set to [SSticker.mode]")
 	log_game("Server IP: [world.internet_address]:[world.port]")


### PR DESCRIPTION

# About the pull request

This PR adds operation time offset to logs.

# Explain why it's good for the game

I don't see it logged anywhere else and it may be relevant in the coming map drawing PR.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
admin: Operation time logging
/:cl:
