### PR TITLE
[NI] - Kutjevo Communications | Re-Addition of Kutjevo Blackbox

### DIFF
--- a/maps/map_files/Kutjevo/Kutjevo.dmm
+++ b/maps/map_files/Kutjevo/Kutjevo.dmm
@@ -17219,7 +17219,7 @@
 /area/kutjevo/interior/complex/botany)
 "xPU" = (
 /obj/effect/landmark/nightmare{
-	insert_tag = communications
+	insert_tag = "communications"
 	},
 /turf/open/auto_turf/sand/layer1,
 /area/kutjevo/exterior/construction)
@@ -40198,7 +40198,7 @@ bKH
 xWK
 xWK
 bKH
-xWK
+xPU
 xWK
 bKH
 xWK

--- a/maps/map_files/Kutjevo/Kutjevo.dmm
+++ b/maps/map_files/Kutjevo/Kutjevo.dmm
@@ -17217,6 +17217,12 @@
 /obj/structure/barricade/wooden,
 /turf/open/floor/kutjevo/colors/red/tile,
 /area/kutjevo/interior/complex/botany)
+"xPU" = (
+/obj/effect/landmark/nightmare{
+	insert_tag = communications
+	},
+/turf/open/auto_turf/sand/layer1,
+/area/kutjevo/exterior/construction)
 "xQz" = (
 /turf/open/floor/kutjevo/colors/cyan/inner_corner{
 	dir = 1
@@ -39694,7 +39700,7 @@ xWK
 bKH
 xWK
 xWK
-xWK
+xPU
 xWK
 jhx
 bKH

--- a/maps/map_files/Kutjevo/Kutjevo.dmm
+++ b/maps/map_files/Kutjevo/Kutjevo.dmm
@@ -2534,6 +2534,14 @@
 	icon = 'icons/turf/floors/desert_water_toxic.dmi'
 	},
 /area/kutjevo/interior/oob)
+"dtV" = (
+/obj/structure/machinery/blackbox_recorder,
+/obj/item/prop/almayer/flight_recorder/colony{
+	pixel_x = 10;
+	pixel_y = 10
+	},
+/turf/open/floor/kutjevo/grey/plate,
+/area/kutjevo/interior/complex/botany/east_tech)
 "duu" = (
 /obj/structure/machinery/door/poddoor/shutters/almayer{
 	name = "\improper South Power Shutters"
@@ -40564,7 +40572,7 @@ hws
 qwg
 vcY
 jhS
-htT
+dtV
 dkE
 tfx
 dkE

--- a/maps/map_files/Kutjevo/Kutjevo.dmm
+++ b/maps/map_files/Kutjevo/Kutjevo.dmm
@@ -40198,7 +40198,7 @@ bKH
 xWK
 xWK
 bKH
-xPU
+xWK
 xWK
 bKH
 xWK

--- a/maps/map_files/Kutjevo/sprinkles/35.communications.dmm
+++ b/maps/map_files/Kutjevo/sprinkles/35.communications.dmm
@@ -292,8 +292,8 @@
 "Q" = (
 /obj/structure/bed/chair{
 	dir = 4;
-	step_y = 5;
-	step_x = 4
+	pixel_x = 4;
+	pixel_y = 5
 	},
 /turf/open/floor/kutjevo/grey/plate,
 /area/template_noop)

--- a/maps/map_files/Kutjevo/sprinkles/35.communications.dmm
+++ b/maps/map_files/Kutjevo/sprinkles/35.communications.dmm
@@ -1,49 +1,88 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"a" = (
+"aA" = (
+/obj/structure/girder/displaced,
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/auto_turf/sand/layer0,
+/area/template_noop)
+"cm" = (
+/turf/open/floor/kutjevo/tan/grey_edge{
+	dir = 8
+	},
+/area/template_noop)
+"cL" = (
+/obj/item/clothing/suit/storage/hazardvest/yellow,
+/turf/open/floor/kutjevo/tan,
+/area/template_noop)
+"cW" = (
+/turf/open/floor/kutjevo/grey/plate,
+/area/template_noop)
+"di" = (
 /turf/open/floor/kutjevo/tan/grey_edge{
 	dir = 1
 	},
 /area/template_noop)
-"b" = (
-/obj/structure/machinery/constructable_frame,
+"dl" = (
+/obj/structure/girder/displaced,
+/obj/item/stack/sheet/metal,
+/turf/open/auto_turf/sand/layer0,
+/area/template_noop)
+"gD" = (
+/obj/item/stack/rods,
+/obj/item/tool/warning_cone,
 /turf/open/floor/kutjevo/grey/plate,
 /area/template_noop)
-"c" = (
-/obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
-	dir = 1;
-	req_one_access = null
+"ix" = (
+/obj/item/tool/warning_cone,
+/obj/item/paper/crumpled{
+	pixel_x = 5;
+	pixel_y = -8
+	},
+/obj/item/paper/crumpled{
+	pixel_x = -4;
+	pixel_y = 14
+	},
+/turf/open/floor/kutjevo/grey/plate,
+/area/template_noop)
+"lD" = (
+/obj/structure/machinery/door_display{
+	desc = "A work schedule monitor. It appears to be broken."
 	},
 /turf/closed/wall/kutjevo/colony,
 /area/template_noop)
-"d" = (
-/obj/structure/machinery/power/port_gen/pacman,
-/turf/open/floor/kutjevo/grey/plate,
-/area/template_noop)
-"e" = (
-/obj/structure/girder/displaced,
-/turf/open/auto_turf/sand/layer0,
-/area/template_noop)
-"f" = (
-/obj/structure/window/framed/kutjevo,
-/obj/structure/barricade/handrail/kutjevo{
-	layer = 3.1
+"lZ" = (
+/obj/structure/bed/chair{
+	dir = 4;
+	pixel_x = 4;
+	pixel_y = 5
 	},
 /turf/open/floor/kutjevo/grey/plate,
 /area/template_noop)
-"g" = (
-/turf/open/floor/kutjevo/tan,
-/area/template_noop)
-"h" = (
+"mv" = (
 /obj/structure/girder,
 /turf/open/floor/plating/kutjevo,
 /area/template_noop)
-"i" = (
-/obj/item/clothing/head/hardhat/orange,
-/turf/open/floor/kutjevo/tan/grey_edge{
-	dir = 1
-	},
+"nn" = (
+/obj/structure/machinery/constructable_frame,
+/turf/open/floor/kutjevo/grey/plate,
 /area/template_noop)
-"j" = (
+"oB" = (
+/obj/structure/surface/table/almayer,
+/obj/structure/machinery/prop/almayer/computer/PC{
+	dir = 8;
+	layer = 2.8
+	},
+/turf/open/floor/kutjevo/grey/plate,
+/area/template_noop)
+"oK" = (
+/obj/structure/machinery/photocopier,
+/turf/open/floor/kutjevo/grey/plate,
+/area/template_noop)
+"oU" = (
+/obj/structure/machinery/blackbox_recorder,
+/obj/structure/machinery/light,
+/turf/open/floor/kutjevo/grey/plate,
+/area/template_noop)
+"pP" = (
 /obj/structure/largecrate/random{
 	pixel_y = 19;
 	layer = 3.02
@@ -60,22 +99,25 @@
 	},
 /turf/open/floor/kutjevo/grey/plate,
 /area/template_noop)
-"k" = (
+"qp" = (
 /obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
-	dir = 1;
 	req_one_access = null
 	},
 /turf/open/floor/kutjevo/tan/grey_edge{
-	dir = 4
+	dir = 1
 	},
 /area/template_noop)
-"l" = (
-/obj/structure/machinery/door_display{
-	desc = "A work schedule monitor. It appears to be broken."
-	},
-/turf/closed/wall/kutjevo/colony,
+"qI" = (
+/obj/structure/window/framed/kutjevo,
+/turf/open/space/basic,
 /area/template_noop)
-"m" = (
+"qM" = (
+/obj/structure/machinery/light,
+/obj/effect/decal/cleanable/blood/oil,
+/obj/item/tool/warning_cone,
+/turf/open/floor/kutjevo/grey/plate,
+/area/template_noop)
+"rm" = (
 /obj/structure/surface/rack,
 /obj/item/storage/backpack/marine/satchel{
 	desc = "It's the heavy-duty black polymer kind. Time to take out the trash!";
@@ -87,23 +129,27 @@
 	},
 /turf/open/floor/kutjevo/grey/plate,
 /area/template_noop)
-"n" = (
-/obj/item/stack/sheet/metal,
+"ry" = (
 /obj/item/stack/rods,
-/obj/effect/decal/cleanable/blood/oil,
-/turf/open/auto_turf/sand/layer0,
-/area/template_noop)
-"o" = (
 /obj/structure/fence,
-/turf/open/auto_turf/sand/layer0,
+/turf/open/auto_turf/sand/layer1,
 /area/template_noop)
-"p" = (
+"rG" = (
+/obj/item/stack/rods,
+/turf/open/floor/kutjevo/grey/plate,
+/area/template_noop)
+"rP" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/kutjevo/grey/plate,
+/area/template_noop)
+"sQ" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/kutjevo/tan/grey_edge{
 	dir = 1
 	},
 /area/template_noop)
-"q" = (
+"uS" = (
 /obj/structure/surface/table/almayer,
 /obj/item/device/flashlight/lamp/on{
 	pixel_x = 9;
@@ -120,30 +166,22 @@
 	pixel_x = 9;
 	pixel_y = 3
 	},
+/obj/item/paper{
+	pixel_x = -5;
+	info = "It has been three weeks since I was relocated to the 'finished' comms office. Me and Paul have been trying to work with this infernal racket going on, but by all that's holy I can't think- let alone recalibrate the new computers. Speaking of, these new computers are all fine and dandy but the sensor uplink tower still hasn't been setup properly after the accident with the apprentice, you know, the one that pilled up those debris filled trash bags by Paul's 'desk' and then left. Anyway, like you said the builders didn't lay down the protective matting for the new flooring so there's dirt everywhere. For your sake Jeff, I hope your holiday doesn't end too soon, you still don't even have a desk yet."
+	},
 /turf/open/floor/kutjevo/grey/plate,
 /area/template_noop)
-"r" = (
-/obj/structure/fence{
-	desc = "A large metal mesh strewn between two poles. A 'Keep Out! Under Construction' sign dangles from one of the fence posts."
-	},
-/turf/open/auto_turf/sand/layer1,
+"wh" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/auto_turf/sand/layer0,
 /area/template_noop)
-"s" = (
-/obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
-	req_one_access = null
-	},
-/turf/open/floor/kutjevo/tan/grey_edge{
-	dir = 1
-	},
-/area/template_noop)
-"t" = (
-/turf/closed/wall/kutjevo/colony,
-/area/template_noop)
-"u" = (
-/obj/effect/decal/cleanable/blood/drip,
+"wC" = (
+/obj/structure/surface/rack,
+/obj/item/notepad/blue,
 /turf/open/floor/kutjevo/grey/plate,
 /area/template_noop)
-"v" = (
+"wO" = (
 /obj/structure/filingcabinet{
 	density = 0;
 	layer = 3.0;
@@ -160,12 +198,154 @@
 	icon = 'icons/obj/janitor.dmi';
 	icon_state = "trashbag3";
 	name = "trash bag";
+	pixel_x = 5;
+	pixel_y = 6
+	},
+/obj/item/storage/backpack/marine/satchel{
+	desc = "It's the heavy-duty black polymer kind. Time to take out the trash!";
+	icon = 'icons/obj/janitor.dmi';
+	icon_state = "trashbag3";
+	name = "trash bag";
+	pixel_x = -9;
+	pixel_y = 6
+	},
+/obj/item/storage/backpack/marine/satchel{
+	desc = "It's the heavy-duty black polymer kind. Time to take out the trash!";
+	icon = 'icons/obj/janitor.dmi';
+	icon_state = "trashbag3";
+	name = "trash bag";
 	pixel_x = -4;
 	pixel_y = 6
 	},
+/obj/item/storage/backpack/marine/satchel{
+	desc = "It's the heavy-duty black polymer kind. Time to take out the trash!";
+	icon = 'icons/obj/janitor.dmi';
+	icon_state = "trashbag3";
+	name = "trash bag"
+	},
 /turf/open/floor/kutjevo/grey/plate,
 /area/template_noop)
-"w" = (
+"yQ" = (
+/obj/structure/machinery/light{
+	dir = 1
+	},
+/obj/structure/machinery/power/apc/weak{
+	dir = 1
+	},
+/obj/structure/surface/rack,
+/turf/open/floor/kutjevo/grey/plate,
+/area/template_noop)
+"zb" = (
+/turf/open/floor/kutjevo/tan/grey_edge,
+/area/template_noop)
+"zh" = (
+/obj/structure/surface/table/almayer,
+/obj/effect/spawner/random/tool,
+/turf/open/floor/kutjevo/grey/plate,
+/area/template_noop)
+"Af" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/kutjevo/tan/grey_edge{
+	dir = 4
+	},
+/area/template_noop)
+"Ca" = (
+/obj/structure/window/framed/kutjevo,
+/obj/structure/barricade/handrail/kutjevo{
+	layer = 3.1
+	},
+/turf/open/floor/kutjevo/grey/plate,
+/area/template_noop)
+"Ci" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/kutjevo/tan/grey_edge{
+	dir = 1
+	},
+/area/template_noop)
+"DY" = (
+/obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
+	dir = 1;
+	req_one_access = null
+	},
+/turf/open/floor/kutjevo/tan/grey_edge{
+	dir = 4
+	},
+/area/template_noop)
+"EK" = (
+/obj/structure/window/framed/kutjevo,
+/turf/open/floor/plating/kutjevo,
+/area/template_noop)
+"GH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/paper/crumpled{
+	pixel_x = -4;
+	pixel_y = 14
+	},
+/turf/open/floor/kutjevo/grey/plate,
+/area/template_noop)
+"IR" = (
+/obj/item/paper/crumpled,
+/turf/open/floor/kutjevo/grey/plate,
+/area/template_noop)
+"Jg" = (
+/obj/effect/spawner/random/toolbox,
+/turf/open/floor/kutjevo/tan/grey_edge{
+	dir = 4
+	},
+/area/template_noop)
+"Jz" = (
+/obj/item/stack/sheet/metal,
+/obj/item/stack/rods,
+/turf/open/floor/kutjevo/tan/grey_edge{
+	dir = 4
+	},
+/area/template_noop)
+"Ks" = (
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/kutjevo/grey/plate,
+/area/template_noop)
+"KC" = (
+/obj/structure/bed/chair/comfy{
+	dir = 1;
+	pixel_y = 11
+	},
+/obj/item/paper/crumpled{
+	pixel_x = -12;
+	pixel_y = 14
+	},
+/obj/item/paper/crumpled{
+	pixel_x = -5;
+	pixel_y = -2
+	},
+/obj/item/paper/crumpled{
+	pixel_x = 5;
+	pixel_y = -8
+	},
+/turf/open/floor/kutjevo/grey/plate,
+/area/template_noop)
+"KD" = (
+/obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
+	dir = 1;
+	req_one_access = null
+	},
+/turf/closed/wall/kutjevo/colony,
+/area/template_noop)
+"LG" = (
+/obj/structure/fence,
+/turf/open/auto_turf/sand/layer0,
+/area/template_noop)
+"LO" = (
+/obj/effect/decal/cleanable/blood/drip,
+/obj/item/prop/alien/hugger,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/kutjevo/grey/plate,
+/area/template_noop)
+"LR" = (
+/obj/structure/prop/almayer/computers/sensor_computer2,
+/turf/open/floor/kutjevo/grey/plate,
+/area/template_noop)
+"MV" = (
 /obj/structure/largecrate/random{
 	pixel_y = 1
 	},
@@ -185,261 +365,204 @@
 	},
 /turf/open/floor/kutjevo/grey/plate,
 /area/template_noop)
-"x" = (
-/obj/structure/machinery/photocopier,
+"Nr" = (
+/obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/kutjevo/grey/plate,
 /area/template_noop)
-"y" = (
-/obj/structure/girder/displaced,
+"Or" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/kutjevo/grey/plate,
+/area/template_noop)
+"Pp" = (
+/obj/structure/prop/almayer/computers/sensor_computer1,
+/turf/open/floor/kutjevo/grey/plate,
+/area/template_noop)
+"Re" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/tool/warning_cone,
+/turf/open/floor/kutjevo/grey/plate,
+/area/template_noop)
+"Rj" = (
+/obj/item/stack/rods,
 /obj/effect/decal/cleanable/blood/oil,
+/obj/item/tool/warning_cone,
 /turf/open/auto_turf/sand/layer0,
 /area/template_noop)
-"z" = (
+"RK" = (
+/turf/closed/wall/kutjevo/colony,
+/area/template_noop)
+"SZ" = (
+/turf/closed/wall/kutjevo/colony/reinforced,
+/area/template_noop)
+"Ul" = (
+/obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
+	req_one_access = null
+	},
+/turf/open/floor/kutjevo/tan/grey_edge,
+/area/template_noop)
+"Um" = (
+/turf/open/floor/kutjevo/tan/grey_edge{
+	dir = 4
+	},
+/area/template_noop)
+"Vc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/tool/warning_cone,
+/turf/open/auto_turf/sand/layer0,
+/area/template_noop)
+"Xi" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/kutjevo/tan/grey_edge,
+/area/template_noop)
+"Xq" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/kutjevo/tan/grey_edge{
+	dir = 8
+	},
+/area/template_noop)
+"XS" = (
+/obj/structure/fence{
+	desc = "A large metal mesh strewn between two poles. A 'Keep Out! Under Construction' sign dangles from one of the fence posts."
+	},
+/turf/open/auto_turf/sand/layer1,
+/area/template_noop)
+"Yo" = (
+/obj/item/clothing/head/hardhat/orange,
+/turf/open/floor/kutjevo/tan/grey_edge{
+	dir = 1
+	},
+/area/template_noop)
+"YG" = (
+/obj/structure/machinery/power/port_gen/pacman,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/kutjevo/grey/plate,
 /area/template_noop)
-"A" = (
+"YO" = (
+/obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
+	dir = 1;
+	req_one_access = null
+	},
+/turf/open/floor/kutjevo/tan/grey_edge{
+	dir = 8
+	},
+/area/template_noop)
+"Zf" = (
 /obj/structure/window/framed/kutjevo,
 /obj/structure/barricade/handrail/kutjevo{
 	layer = 3
 	},
 /turf/open/floor/kutjevo/grey/plate,
 /area/template_noop)
-"B" = (
-/obj/item/stack/sheet/metal,
-/obj/item/stack/rods,
-/obj/effect/spawner/random/toolbox,
-/turf/open/auto_turf/sand/layer0,
-/area/template_noop)
-"C" = (
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/kutjevo/grey/plate,
-/area/template_noop)
-"D" = (
-/obj/structure/surface/table/almayer,
-/obj/effect/spawner/random/tool,
-/turf/open/floor/kutjevo/grey/plate,
-/area/template_noop)
-"E" = (
-/turf/open/floor/kutjevo/tan/grey_edge{
-	dir = 4
-	},
-/area/template_noop)
-"F" = (
-/obj/structure/bed/chair/comfy{
-	dir = 1;
-	pixel_y = 11
-	},
-/turf/open/floor/kutjevo/grey/plate,
-/area/template_noop)
-"G" = (
-/obj/structure/prop/almayer/computers/sensor_computer1,
-/turf/open/floor/kutjevo/grey/plate,
-/area/template_noop)
-"H" = (
-/obj/item/stack/rods,
-/obj/structure/fence,
-/turf/open/auto_turf/sand/layer1,
-/area/template_noop)
-"I" = (
-/obj/structure/machinery/light{
-	dir = 1
-	},
-/obj/structure/machinery/power/apc/weak{
-	dir = 1
-	},
-/obj/structure/surface/rack,
-/turf/open/floor/kutjevo/grey/plate,
-/area/template_noop)
-"J" = (
-/obj/structure/surface/rack,
-/turf/open/floor/kutjevo/grey/plate,
-/area/template_noop)
-"K" = (
-/obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
-	req_one_access = null
-	},
-/turf/open/floor/kutjevo/tan/grey_edge,
-/area/template_noop)
-"L" = (
-/obj/structure/machinery/blackbox_recorder,
-/obj/structure/machinery/light,
-/turf/open/floor/kutjevo/grey/plate,
-/area/template_noop)
-"M" = (
-/obj/item/stack/rods,
-/turf/open/floor/kutjevo/grey/plate,
-/area/template_noop)
-"N" = (
-/obj/structure/surface/table/almayer,
-/obj/structure/machinery/prop/almayer/computer/PC{
-	dir = 8
-	},
-/turf/open/floor/kutjevo/grey/plate,
-/area/template_noop)
-"O" = (
-/obj/structure/prop/almayer/computers/sensor_computer2,
-/turf/open/floor/kutjevo/grey/plate,
-/area/template_noop)
-"P" = (
-/obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
-	dir = 1;
-	req_one_access = null
-	},
-/turf/open/floor/kutjevo/tan/grey_edge{
-	dir = 8
-	},
-/area/template_noop)
-"Q" = (
-/obj/structure/bed/chair{
-	dir = 4;
-	pixel_x = 4;
-	pixel_y = 5
-	},
-/turf/open/floor/kutjevo/grey/plate,
-/area/template_noop)
-"R" = (
-/obj/effect/decal/cleanable/blood/drip,
-/obj/item/prop/alien/hugger,
-/turf/open/floor/kutjevo/grey/plate,
-/area/template_noop)
-"S" = (
-/obj/structure/window/framed/kutjevo,
-/turf/open/space/basic,
-/area/template_noop)
-"U" = (
-/turf/open/auto_turf/sand/layer0,
-/area/template_noop)
-"V" = (
-/turf/closed/wall/kutjevo/colony/reinforced,
-/area/template_noop)
-"W" = (
-/turf/open/floor/kutjevo/tan/grey_edge{
-	dir = 8
-	},
-/area/template_noop)
-"X" = (
-/obj/structure/machinery/light,
-/obj/effect/decal/cleanable/blood/oil,
-/obj/effect/spawner/random/tool,
-/turf/open/floor/kutjevo/grey/plate,
-/area/template_noop)
-"Y" = (
-/turf/open/floor/kutjevo/tan/grey_edge,
-/area/template_noop)
-"Z" = (
-/obj/structure/window/framed/kutjevo,
-/turf/open/floor/plating/kutjevo,
-/area/template_noop)
 
 (1,1,1) = {"
-V
-t
-t
-t
-s
-K
-t
-t
-t
-t
-t
-t
+SZ
+RK
+RK
+RK
+qp
+Ul
+RK
+RK
+RK
+RK
+RK
+RK
 "}
 (2,1,1) = {"
-t
-j
-z
-z
-a
-Y
-f
-G
-x
-b
-L
-t
+RK
+pP
+cW
+cW
+Ci
+zb
+Ca
+Pp
+oK
+nn
+oU
+RK
 "}
 (3,1,1) = {"
-c
-u
-u
-z
-a
-Y
-A
-q
-F
-z
-z
-t
+KD
+Nr
+Ks
+cW
+di
+Xi
+Zf
+uS
+KC
+IR
+Or
+RK
 "}
 (4,1,1) = {"
-V
-w
-z
-C
-i
-Y
-l
-O
-z
-z
-z
-Z
+SZ
+MV
+Or
+rP
+Yo
+zb
+lD
+LR
+ix
+GH
+Re
+EK
 "}
 (5,1,1) = {"
-S
-J
-z
-R
-p
-g
-W
-W
-W
-W
-W
-P
+qI
+wC
+rG
+LO
+sQ
+cL
+cm
+Xq
+Xq
+cm
+cm
+YO
 "}
 (6,1,1) = {"
-S
-m
-Q
-b
-z
-E
-E
-E
-E
-E
-U
-k
+qI
+rm
+lZ
+nn
+Or
+Af
+Um
+Jg
+Um
+Jz
+wh
+DY
 "}
 (7,1,1) = {"
-V
-I
-N
-v
-M
-D
-n
-e
-d
-B
-X
-t
+SZ
+yQ
+oB
+wO
+gD
+zh
+Rj
+dl
+YG
+Vc
+qM
+RK
 "}
 (8,1,1) = {"
-V
-h
-t
-t
-y
-t
-o
-o
-h
-H
-r
-h
+SZ
+mv
+RK
+RK
+aA
+RK
+LG
+LG
+mv
+ry
+XS
+mv
 "}

--- a/maps/map_files/Kutjevo/sprinkles/35.communications.dmm
+++ b/maps/map_files/Kutjevo/sprinkles/35.communications.dmm
@@ -124,7 +124,7 @@
 /area/template_noop)
 "r" = (
 /obj/structure/fence{
-	desc = "A large metal mesh strewn between two poles. A "Keep Out! Under Csssssonstruction." sign dangles from one of the fence posts."
+	desc = "A large metal mesh strewn between two poles. A 'Keep Out! Under Construction' sign dangles from one of the fence posts."
 	},
 /turf/open/auto_turf/sand/layer1,
 /area/template_noop)

--- a/maps/map_files/Kutjevo/sprinkles/35.communications.dmm
+++ b/maps/map_files/Kutjevo/sprinkles/35.communications.dmm
@@ -167,8 +167,9 @@
 	pixel_y = 3
 	},
 /obj/item/paper{
+	info = "It has been three weeks since I was relocated to the 'finished' comms office. Me and Paul have been trying to work with this infernal racket going on, but by all that's holy I can't think- let alone recalibrate the new computers. Speaking of, these new computers are all fine and dandy but the sensor uplink tower still hasn't been setup properly after the accident with the apprentice, you know, the one that pilled up those debris filled trash bags by Paul's 'desk' and then left. Anyway, like you said the builders didn't lay down the protective matting for the new flooring so there's dirt everywhere. For your sake Jeff, I hope your holiday doesn't end too soon, you still don't even have a desk yet.";
 	pixel_x = -5;
-	info = "It has been three weeks since I was relocated to the 'finished' comms office. Me and Paul have been trying to work with this infernal racket going on, but by all that's holy I can't think- let alone recalibrate the new computers. Speaking of, these new computers are all fine and dandy but the sensor uplink tower still hasn't been setup properly after the accident with the apprentice, you know, the one that pilled up those debris filled trash bags by Paul's 'desk' and then left. Anyway, like you said the builders didn't lay down the protective matting for the new flooring so there's dirt everywhere. For your sake Jeff, I hope your holiday doesn't end too soon, you still don't even have a desk yet."
+	icon_state = "paper_words"
 	},
 /turf/open/floor/kutjevo/grey/plate,
 /area/template_noop)

--- a/maps/map_files/Kutjevo/sprinkles/35.communications.dmm
+++ b/maps/map_files/Kutjevo/sprinkles/35.communications.dmm
@@ -45,7 +45,8 @@
 /area/template_noop)
 "lD" = (
 /obj/structure/machinery/door_display{
-	desc = "A work schedule monitor. It appears to be broken."
+	desc = "A work schedule monitor. It appears to be broken.";
+	name = "Schedule Monitor"
 	},
 /turf/closed/wall/kutjevo/colony,
 /area/template_noop)
@@ -78,8 +79,8 @@
 /turf/open/floor/kutjevo/grey/plate,
 /area/template_noop)
 "oU" = (
-/obj/structure/machinery/blackbox_recorder,
 /obj/structure/machinery/light,
+/obj/structure/machinery/message_server,
 /turf/open/floor/kutjevo/grey/plate,
 /area/template_noop)
 "pP" = (
@@ -119,10 +120,6 @@
 /area/template_noop)
 "rm" = (
 /obj/structure/surface/rack,
-/obj/item/storage/bag/trash{
-	icon_state = "trashbag3";
-	pixel_x = -4
-	},
 /turf/open/floor/kutjevo/grey/plate,
 /area/template_noop)
 "ry" = (
@@ -165,7 +162,8 @@
 /obj/item/paper{
 	info = "It has been three weeks since I was relocated to the 'finished' comms office. Me and Paul have been trying to work with this infernal racket going on, but by all that's holy I can't think- let alone recalibrate the new computers. Speaking of, these new computers are all fine and dandy but the sensor uplink tower still hasn't been setup properly after the accident with the apprentice, you know, the one that piled up those debris filled trash bags by Paul's 'desk' and then left. Anyway, like you said the builders didn't lay down the protective matting for the new flooring so there's dirt everywhere. For your sake Jeff, I hope your holiday doesn't end too soon, you still don't even have a desk yet.";
 	pixel_x = -5;
-	icon_state = "paper_words"
+	icon_state = "paper_words";
+	name = "I should have gone on holiday"
 	},
 /turf/open/floor/kutjevo/grey/plate,
 /area/template_noop)
@@ -190,23 +188,21 @@
 	pixel_x = -8;
 	pixel_y = 18
 	},
-/obj/item/storage/bag/trash{
-	icon_state = "trashbag3";
+/obj/structure/prop/rock{
+	pixel_x = -8;
+	pixel_y = -5
+	},
+/obj/structure/prop/rock{
+	layer = 3.1;
+	pixel_y = 3
+	},
+/obj/structure/prop/rock{
 	pixel_x = 5;
-	pixel_y = 6
+	pixel_y = -5
 	},
-/obj/item/storage/bag/trash{
-	icon_state = "trashbag3";
-	pixel_x = -9;
-	pixel_y = 6
-	},
-/obj/item/storage/bag/trash{
-	icon_state = "trashbag3";
-	pixel_x = -4;
-	pixel_y = 6
-	},
-/obj/item/storage/bag/trash{
-	icon_state = "trashbag3"
+/obj/structure/flora/pottedplant/random/unanchored{
+	pixel_y = 16;
+	layer = 3.3
 	},
 /turf/open/floor/kutjevo/grey/plate,
 /area/template_noop)
@@ -360,10 +356,6 @@
 /area/template_noop)
 "Pp" = (
 /obj/structure/prop/almayer/computers/sensor_computer1,
-/obj/item/prop/almayer/flight_recorder/colony{
-	pixel_x = -10;
-	pixel_y = 16
-	},
 /turf/open/floor/kutjevo/grey/plate,
 /area/template_noop)
 "Re" = (

--- a/maps/map_files/Kutjevo/sprinkles/35.communications.dmm
+++ b/maps/map_files/Kutjevo/sprinkles/35.communications.dmm
@@ -119,13 +119,9 @@
 /area/template_noop)
 "rm" = (
 /obj/structure/surface/rack,
-/obj/item/storage/backpack/marine/satchel{
-	desc = "It's the heavy-duty black polymer kind. Time to take out the trash!";
-	icon = 'icons/obj/janitor.dmi';
+/obj/item/storage/bag/trash{
 	icon_state = "trashbag3";
-	name = "trash bag";
-	pixel_x = -4;
-	pixel_y = 6
+	pixel_x = -4
 	},
 /turf/open/floor/kutjevo/grey/plate,
 /area/template_noop)
@@ -194,35 +190,23 @@
 	pixel_x = -8;
 	pixel_y = 18
 	},
-/obj/item/storage/backpack/marine/satchel{
-	desc = "It's the heavy-duty black polymer kind. Time to take out the trash!";
-	icon = 'icons/obj/janitor.dmi';
+/obj/item/storage/bag/trash{
 	icon_state = "trashbag3";
-	name = "trash bag";
 	pixel_x = 5;
 	pixel_y = 6
 	},
-/obj/item/storage/backpack/marine/satchel{
-	desc = "It's the heavy-duty black polymer kind. Time to take out the trash!";
-	icon = 'icons/obj/janitor.dmi';
+/obj/item/storage/bag/trash{
 	icon_state = "trashbag3";
-	name = "trash bag";
 	pixel_x = -9;
 	pixel_y = 6
 	},
-/obj/item/storage/backpack/marine/satchel{
-	desc = "It's the heavy-duty black polymer kind. Time to take out the trash!";
-	icon = 'icons/obj/janitor.dmi';
+/obj/item/storage/bag/trash{
 	icon_state = "trashbag3";
-	name = "trash bag";
 	pixel_x = -4;
 	pixel_y = 6
 	},
-/obj/item/storage/backpack/marine/satchel{
-	desc = "It's the heavy-duty black polymer kind. Time to take out the trash!";
-	icon = 'icons/obj/janitor.dmi';
-	icon_state = "trashbag3";
-	name = "trash bag"
+/obj/item/storage/bag/trash{
+	icon_state = "trashbag3"
 	},
 /turf/open/floor/kutjevo/grey/plate,
 /area/template_noop)

--- a/maps/map_files/Kutjevo/sprinkles/35.communications.dmm
+++ b/maps/map_files/Kutjevo/sprinkles/35.communications.dmm
@@ -376,6 +376,10 @@
 /area/template_noop)
 "Pp" = (
 /obj/structure/prop/almayer/computers/sensor_computer1,
+/obj/item/prop/almayer/flight_recorder/colony{
+	pixel_x = -10;
+	pixel_y = 16
+	},
 /turf/open/floor/kutjevo/grey/plate,
 /area/template_noop)
 "Re" = (

--- a/maps/map_files/Kutjevo/sprinkles/35.communications.dmm
+++ b/maps/map_files/Kutjevo/sprinkles/35.communications.dmm
@@ -1,0 +1,449 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/open/floor/kutjevo/tan/grey_edge{
+	dir = 1
+	},
+/area/template_noop)
+"b" = (
+/obj/structure/machinery/constructable_frame,
+/turf/open/floor/kutjevo/grey/plate,
+/area/template_noop)
+"c" = (
+/obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
+	dir = 1;
+	req_one_access = null
+	},
+/turf/closed/wall/kutjevo/colony,
+/area/template_noop)
+"d" = (
+/obj/structure/machinery/power/port_gen/pacman,
+/turf/open/floor/kutjevo/grey/plate,
+/area/template_noop)
+"e" = (
+/obj/structure/girder/displaced,
+/turf/open/auto_turf/sand/layer0,
+/area/template_noop)
+"f" = (
+/obj/structure/window/framed/kutjevo,
+/obj/structure/barricade/handrail/kutjevo{
+	layer = 3.1
+	},
+/turf/open/floor/kutjevo/grey/plate,
+/area/template_noop)
+"g" = (
+/turf/open/floor/kutjevo/tan,
+/area/template_noop)
+"h" = (
+/obj/structure/girder,
+/turf/open/floor/plating/kutjevo,
+/area/template_noop)
+"i" = (
+/obj/item/clothing/head/hardhat/orange,
+/turf/open/floor/kutjevo/tan/grey_edge{
+	dir = 1
+	},
+/area/template_noop)
+"j" = (
+/obj/structure/largecrate/random{
+	pixel_y = 19;
+	layer = 3.02
+	},
+/obj/structure/largecrate/random{
+	pixel_x = -3;
+	pixel_y = 1
+	},
+/obj/structure/barricade/handrail/kutjevo{
+	layer = 3.1
+	},
+/obj/structure/barricade/handrail/kutjevo{
+	dir = 4
+	},
+/turf/open/floor/kutjevo/grey/plate,
+/area/template_noop)
+"k" = (
+/obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
+	dir = 1;
+	req_one_access = null
+	},
+/turf/open/floor/kutjevo/tan/grey_edge{
+	dir = 4
+	},
+/area/template_noop)
+"l" = (
+/obj/structure/machinery/door_display{
+	desc = "A work schedule monitor. It appears to be broken."
+	},
+/turf/closed/wall/kutjevo/colony,
+/area/template_noop)
+"m" = (
+/obj/structure/surface/rack,
+/obj/item/storage/backpack/marine/satchel{
+	desc = "It's the heavy-duty black polymer kind. Time to take out the trash!";
+	icon = 'icons/obj/janitor.dmi';
+	icon_state = "trashbag3";
+	name = "trash bag";
+	pixel_x = -4;
+	pixel_y = 6
+	},
+/turf/open/floor/kutjevo/grey/plate,
+/area/template_noop)
+"n" = (
+/obj/item/stack/sheet/metal,
+/obj/item/stack/rods,
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/auto_turf/sand/layer0,
+/area/template_noop)
+"o" = (
+/obj/structure/fence,
+/turf/open/auto_turf/sand/layer0,
+/area/template_noop)
+"p" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/kutjevo/tan/grey_edge{
+	dir = 1
+	},
+/area/template_noop)
+"q" = (
+/obj/structure/surface/table/almayer,
+/obj/item/device/flashlight/lamp/on{
+	pixel_x = 9;
+	pixel_y = 15;
+	layer = 3.04
+	},
+/obj/item/clipboard{
+	pixel_x = -6
+	},
+/obj/item/tool/pen/blue/clicky{
+	pixel_x = 9
+	},
+/obj/item/paper_bin{
+	pixel_x = 9;
+	pixel_y = 3
+	},
+/turf/open/floor/kutjevo/grey/plate,
+/area/template_noop)
+"r" = (
+/obj/structure/fence{
+	desc = "A large metal mesh strewn between two poles. A "Keep Out! Under Csssssonstruction." sign dangles from one of the fence posts."
+	},
+/turf/open/auto_turf/sand/layer1,
+/area/template_noop)
+"s" = (
+/obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
+	req_one_access = null
+	},
+/turf/open/floor/kutjevo/tan/grey_edge{
+	dir = 1
+	},
+/area/template_noop)
+"t" = (
+/turf/closed/wall/kutjevo/colony,
+/area/template_noop)
+"u" = (
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/kutjevo/grey/plate,
+/area/template_noop)
+"v" = (
+/obj/structure/filingcabinet{
+	density = 0;
+	layer = 3.0;
+	pixel_x = 8;
+	pixel_y = 18
+	},
+/obj/structure/filingcabinet/chestdrawer{
+	density = 0;
+	pixel_x = -8;
+	pixel_y = 18
+	},
+/obj/item/storage/backpack/marine/satchel{
+	desc = "It's the heavy-duty black polymer kind. Time to take out the trash!";
+	icon = 'icons/obj/janitor.dmi';
+	icon_state = "trashbag3";
+	name = "trash bag";
+	pixel_x = -4;
+	pixel_y = 6
+	},
+/turf/open/floor/kutjevo/grey/plate,
+/area/template_noop)
+"w" = (
+/obj/structure/largecrate/random{
+	pixel_y = 1
+	},
+/obj/structure/largecrate/random{
+	pixel_y = 19;
+	layer = 3.02;
+	pixel_x = -3
+	},
+/obj/structure/barricade/handrail/kutjevo{
+	layer = 3.1
+	},
+/obj/structure/barricade/handrail/kutjevo{
+	dir = 4
+	},
+/obj/structure/barricade/handrail/kutjevo{
+	dir = 8
+	},
+/turf/open/floor/kutjevo/grey/plate,
+/area/template_noop)
+"x" = (
+/obj/structure/machinery/photocopier,
+/turf/open/floor/kutjevo/grey/plate,
+/area/template_noop)
+"y" = (
+/obj/structure/girder/displaced,
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/auto_turf/sand/layer0,
+/area/template_noop)
+"z" = (
+/turf/open/floor/kutjevo/grey/plate,
+/area/template_noop)
+"A" = (
+/obj/structure/window/framed/kutjevo,
+/obj/structure/barricade/handrail/kutjevo{
+	layer = 3
+	},
+/turf/open/floor/kutjevo/grey/plate,
+/area/template_noop)
+"B" = (
+/obj/item/stack/sheet/metal,
+/obj/item/stack/rods,
+/obj/effect/spawner/random/toolbox,
+/turf/open/auto_turf/sand/layer0,
+/area/template_noop)
+"C" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/kutjevo/grey/plate,
+/area/template_noop)
+"D" = (
+/obj/structure/surface/table/almayer,
+/obj/effect/spawner/random/tool,
+/turf/open/floor/kutjevo/grey/plate,
+/area/template_noop)
+"E" = (
+/turf/open/floor/kutjevo/tan/grey_edge{
+	dir = 4
+	},
+/area/template_noop)
+"F" = (
+/obj/structure/bed/chair/comfy{
+	dir = 1;
+	pixel_y = 11
+	},
+/turf/open/floor/kutjevo/grey/plate,
+/area/template_noop)
+"G" = (
+/obj/structure/prop/almayer/computers/sensor_computer1,
+/turf/open/floor/kutjevo/grey/plate,
+/area/template_noop)
+"H" = (
+/obj/item/stack/rods,
+/obj/structure/fence,
+/turf/open/auto_turf/sand/layer1,
+/area/template_noop)
+"I" = (
+/obj/structure/machinery/light{
+	dir = 1
+	},
+/obj/structure/machinery/power/apc/weak{
+	dir = 1
+	},
+/obj/structure/surface/rack,
+/turf/open/floor/kutjevo/grey/plate,
+/area/template_noop)
+"J" = (
+/obj/structure/surface/rack,
+/turf/open/floor/kutjevo/grey/plate,
+/area/template_noop)
+"K" = (
+/obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
+	req_one_access = null
+	},
+/turf/open/floor/kutjevo/tan/grey_edge,
+/area/template_noop)
+"L" = (
+/obj/structure/machinery/blackbox_recorder,
+/obj/structure/machinery/light,
+/turf/open/floor/kutjevo/grey/plate,
+/area/template_noop)
+"M" = (
+/obj/item/stack/rods,
+/turf/open/floor/kutjevo/grey/plate,
+/area/template_noop)
+"N" = (
+/obj/structure/surface/table/almayer,
+/obj/structure/machinery/prop/almayer/computer/PC{
+	dir = 8
+	},
+/turf/open/floor/kutjevo/grey/plate,
+/area/template_noop)
+"O" = (
+/obj/structure/prop/almayer/computers/sensor_computer2,
+/turf/open/floor/kutjevo/grey/plate,
+/area/template_noop)
+"P" = (
+/obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
+	dir = 1;
+	req_one_access = null
+	},
+/turf/open/floor/kutjevo/tan/grey_edge{
+	dir = 8
+	},
+/area/template_noop)
+"Q" = (
+/obj/structure/bed/chair{
+	dir = 4;
+	step_y = 5;
+	step_x = 4
+	},
+/turf/open/floor/kutjevo/grey/plate,
+/area/template_noop)
+"R" = (
+/obj/effect/decal/cleanable/blood/drip,
+/obj/item/prop/alien/hugger,
+/turf/open/floor/kutjevo/grey/plate,
+/area/template_noop)
+"S" = (
+/obj/structure/window/framed/kutjevo,
+/turf/open/space/basic,
+/area/template_noop)
+"T" = (
+/obj/structure/lattice,
+/turf/closed/wall/kutjevo/colony/reinforced,
+/area/template_noop)
+"U" = (
+/turf/open/auto_turf/sand/layer0,
+/area/template_noop)
+"V" = (
+/turf/closed/wall/kutjevo/colony/reinforced,
+/area/template_noop)
+"W" = (
+/turf/open/floor/kutjevo/tan/grey_edge{
+	dir = 8
+	},
+/area/template_noop)
+"X" = (
+/obj/structure/machinery/light,
+/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/spawner/random/tool,
+/turf/open/floor/kutjevo/grey/plate,
+/area/template_noop)
+"Y" = (
+/turf/open/floor/kutjevo/tan/grey_edge,
+/area/template_noop)
+"Z" = (
+/obj/structure/window/framed/kutjevo,
+/turf/open/floor/plating/kutjevo,
+/area/template_noop)
+
+(1,1,1) = {"
+V
+t
+t
+t
+s
+K
+t
+t
+t
+t
+t
+t
+"}
+(2,1,1) = {"
+t
+j
+z
+z
+a
+Y
+f
+G
+x
+b
+L
+t
+"}
+(3,1,1) = {"
+c
+u
+u
+z
+a
+Y
+A
+q
+F
+z
+z
+t
+"}
+(4,1,1) = {"
+V
+w
+z
+C
+i
+Y
+l
+O
+z
+z
+z
+Z
+"}
+(5,1,1) = {"
+S
+J
+z
+R
+p
+g
+W
+W
+W
+W
+W
+P
+"}
+(6,1,1) = {"
+S
+m
+Q
+b
+z
+E
+E
+E
+E
+E
+U
+k
+"}
+(7,1,1) = {"
+V
+I
+N
+v
+M
+D
+n
+e
+d
+B
+X
+t
+"}
+(8,1,1) = {"
+T
+h
+t
+t
+y
+t
+o
+o
+h
+H
+r
+h
+"}

--- a/maps/map_files/Kutjevo/sprinkles/35.communications.dmm
+++ b/maps/map_files/Kutjevo/sprinkles/35.communications.dmm
@@ -167,7 +167,7 @@
 	pixel_y = 3
 	},
 /obj/item/paper{
-	info = "It has been three weeks since I was relocated to the 'finished' comms office. Me and Paul have been trying to work with this infernal racket going on, but by all that's holy I can't think- let alone recalibrate the new computers. Speaking of, these new computers are all fine and dandy but the sensor uplink tower still hasn't been setup properly after the accident with the apprentice, you know, the one that pilled up those debris filled trash bags by Paul's 'desk' and then left. Anyway, like you said the builders didn't lay down the protective matting for the new flooring so there's dirt everywhere. For your sake Jeff, I hope your holiday doesn't end too soon, you still don't even have a desk yet.";
+	info = "It has been three weeks since I was relocated to the 'finished' comms office. Me and Paul have been trying to work with this infernal racket going on, but by all that's holy I can't think- let alone recalibrate the new computers. Speaking of, these new computers are all fine and dandy but the sensor uplink tower still hasn't been setup properly after the accident with the apprentice, you know, the one that piled up those debris filled trash bags by Paul's 'desk' and then left. Anyway, like you said the builders didn't lay down the protective matting for the new flooring so there's dirt everywhere. For your sake Jeff, I hope your holiday doesn't end too soon, you still don't even have a desk yet.";
 	pixel_x = -5;
 	icon_state = "paper_words"
 	},

--- a/maps/map_files/Kutjevo/sprinkles/35.communications.dmm
+++ b/maps/map_files/Kutjevo/sprinkles/35.communications.dmm
@@ -306,10 +306,6 @@
 /obj/structure/window/framed/kutjevo,
 /turf/open/space/basic,
 /area/template_noop)
-"T" = (
-/obj/structure/lattice,
-/turf/closed/wall/kutjevo/colony/reinforced,
-/area/template_noop)
 "U" = (
 /turf/open/auto_turf/sand/layer0,
 /area/template_noop)
@@ -434,7 +430,7 @@ X
 t
 "}
 (8,1,1) = {"
-T
+V
 h
 t
 t


### PR DESCRIPTION
# About the pull request
- Nightmare insert for Kutjevo; attaches onto the sensor tower by W8 H12.

- Re-adds the Kutjevo blackbox after it was removed previously.

# Explain why it's good for the game

A nightmare insert for Kutjevo and re-adding blackbox hrp


# Testing Photographs and Procedure

Location: https://i.gyazo.com/aa80cd26fcfa5ec5585e9ab43a8956aa.png (Green square is where it is inserted from)
The actual insert: https://i.gyazo.com/1f089ffa66f5893e89fd0ec7c5ab5778.png

Kutjevo Blackbox Re-Addition: https://i.gyazo.com/5a68d21efa55b6d71d404574d579ff64.png



# Changelog
:cl: TopHatPenguin
add: Adds a mostly built communications office nightmare insert to Kutjevo which attaches onto the sensor tower.
add: Re-adds the Kutjevo blackbox.
/:cl:
