### PR TITLE
Adds discretionary arrests as capital crime

### DIFF
--- a/code/modules/law/laws/capital_crime.dm
+++ b/code/modules/law/laws/capital_crime.dm
@@ -34,3 +34,7 @@
 /datum/law/capital_law/prisoner_of_war
 	name = "Prisoner of War"
 	desc = "Being a member of a currently hostile faction to the USCM."
+
+/datum/law/capital_law/discretionary_arrest
+	name = "CO's Discretionary Arrest"
+	desc = "Executive-privilege arrest ordered by the Commanding Officer. Can be revoked by them at any time."


### PR DESCRIPTION
As part of the latest CO announcement, adds discretionary arrests into the JAS database as a capital crime. Will make this into a full PR once the trial is complete and successful.