### PR TITLE
Fixes binocs destroying while zoomed FOR REAL

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -828,6 +828,15 @@ cases. Override_icon_state should be a list.*/
 	INVOKE_ASYNC(user, TYPE_PROC_REF(/atom, visible_message), SPAN_NOTICE("[user] looks up from [zoom_device]."),
 	SPAN_NOTICE("You look up from [zoom_device]."))
 	zoom = !zoom
+
+	// Due to how qdel calls back when the item is destroyed we lack a user, if we are still zoomed in and the item is being destroyed it should be in the direct contents of the user (hypothetically).
+	// When you read this in 10 years from now when it stops working uuuh sorry about that.
+	if(!user)
+		user = loc
+		if(!istype(user))
+			log_debug("[src] called unzoom without a user and user was not loc. Current loc: [loc ? loc : "null"]")
+			return
+
 	COOLDOWN_START(user, zoom_cooldown, 20)
 	SEND_SIGNAL(user, COMSIG_LIVING_ZOOM_OUT, src)
 	SEND_SIGNAL(src, COMSIG_ITEM_UNZOOM, user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Alright Morrow coming at you again with a hacky solution to a bug.

Due to how qdel callback works we don't get a user, if we're still zoomed though we feel we can *assume* that we are still in the direct contents of the user.

I am, admittedly, very sleepy so there could be a blatantly obvious answer that I'm missing and I hope there is. I'm not sure if it would be worth climbing locs up to an area or turf or whatever.

# Explain why it's good for the game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl: Morrow
fix: Fixed binocs destroying while zoomed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
