### PR TITLE
Experimental xeno tackle changes

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
@@ -621,22 +621,22 @@
 	if(pipe)
 		handle_ventcrawl(pipe)
 
-/mob/living/carbon/xenomorph/proc/attempt_tackle(mob/M, tackle_mult = 1, tackle_min_offset = 0, tackle_max_offset = 0, tackle_bonus = 0)
-	var/datum/tackle_counter/TC = LAZYACCESS(tackle_counter, M)
+/mob/living/carbon/xenomorph/proc/attempt_tackle(mob/living/carbon/human/tackled_mob, tackle_min_offset = 0, tackle_max_offset = 0)
+	var/datum/tackle_counter/TC = LAZYACCESS(tackle_counter, tackled_mob)
 	if(!TC)
-		TC = new(tackle_min + tackle_min_offset, tackle_max + tackle_max_offset, tackle_chance*tackle_mult)
-		LAZYSET(tackle_counter, M, TC)
-		RegisterSignal(M, COMSIG_MOB_KNOCKED_DOWN, PROC_REF(tackle_handle_lying_changed))
+		TC = new(tackled_mob, tackle_min + tackle_min_offset, tackle_max + tackle_max_offset)
+		LAZYSET(tackle_counter, tackled_mob, TC)
+		RegisterSignal(tackled_mob, COMSIG_MOB_KNOCKED_DOWN, PROC_REF(tackle_handle_lying_changed))
 
 	if (TC.tackle_reset_id)
 		deltimer(TC.tackle_reset_id)
 		TC.tackle_reset_id = null
 
-	. = TC.attempt_tackle(tackle_bonus)
-	if (!. || (M.status_flags & XENO_HOST))
-		TC.tackle_reset_id = addtimer(CALLBACK(src, PROC_REF(reset_tackle), M), 4 SECONDS, TIMER_UNIQUE | TIMER_STOPPABLE)
+	. = TC.attempt_tackle()
+	if (!. || (tackled_mob.status_flags & XENO_HOST))
+		TC.tackle_reset_id = addtimer(CALLBACK(src, PROC_REF(reset_tackle), tackled_mob), 4 SECONDS, TIMER_UNIQUE | TIMER_STOPPABLE)
 	else
-		reset_tackle(M)
+		reset_tackle(tackled_mob)
 
 /mob/living/carbon/xenomorph/proc/tackle_handle_lying_changed(mob/M)
 	SIGNAL_HANDLER

--- a/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
@@ -102,7 +102,7 @@
 	var/can_hivemind_speak = TRUE
 
 	// Tackles
-	var/tackle_min = 2
+	var/tackle_min = 3
 	var/tackle_max = 7
 	var/tacklestrength_min = 2
 	var/tacklestrength_max = 3

--- a/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
@@ -103,8 +103,7 @@
 
 	// Tackles
 	var/tackle_min = 2
-	var/tackle_max = 6
-	var/tackle_chance = 35
+	var/tackle_max = 7
 	var/tacklestrength_min = 2
 	var/tacklestrength_max = 3
 
@@ -199,7 +198,6 @@
 	var/explosivearmor_modifier = 0
 	var/plasmapool_modifier = 1
 	var/plasmagain_modifier = 0
-	var/tackle_chance_modifier = 0
 	var/regeneration_multiplier = 1
 	var/speed_modifier = 0
 	var/phero_modifier = 0
@@ -876,7 +874,6 @@
 /mob/living/carbon/xenomorph/proc/recalculate_tackle()
 	tackle_min = caste.tackle_min
 	tackle_max = caste.tackle_max
-	tackle_chance = caste.tackle_chance + tackle_chance_modifier
 	tacklestrength_min = caste.tacklestrength_min + mutators.tackle_strength_bonus + hive.mutators.tackle_strength_bonus
 	tacklestrength_max = caste.tacklestrength_max + mutators.tackle_strength_bonus + hive.mutators.tackle_strength_bonus
 

--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -194,15 +194,13 @@
 				return XENO_ATTACK_ACTION
 			M.flick_attack_overlay(src, "disarm")
 
-			var/tackle_mult = 1
 			var/tackle_min_offset = 0
 			var/tackle_max_offset = 0
 			if (isyautja(src))
-				tackle_mult = 0.2
-				tackle_min_offset += 2
-				tackle_max_offset += 2
+				tackle_min_offset += 3
+				tackle_max_offset += 3
 
-			if(M.attempt_tackle(src, tackle_mult, tackle_min_offset, tackle_max_offset))
+			if(M.attempt_tackle(src, tackle_min_offset, tackle_max_offset))
 				playsound(loc, 'sound/weapons/alien_knockdown.ogg', 25, 1)
 				apply_effect(rand(M.tacklestrength_min, M.tacklestrength_max), WEAKEN)
 				M.visible_message(SPAN_DANGER("[M] tackles down [src]!"), \

--- a/code/modules/mob/living/carbon/xenomorph/castes/Boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Boiler.dm
@@ -26,9 +26,8 @@
 	// 3x fire damage
 	fire_vulnerability_mult = FIRE_MULTIPLIER_DEADLY
 
-	tackle_min = 2
+	tackle_min = 3
 	tackle_max = 6
-	tackle_chance = 25
 	tacklestrength_min = 3
 	tacklestrength_max = 4
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/Burrower.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Burrower.dm
@@ -24,8 +24,7 @@
 	behavior_delegate_type = /datum/behavior_delegate/burrower_base
 
 	tackle_min = 3
-	tackle_max = 5
-	tackle_chance = 40
+	tackle_max = 6
 	tacklestrength_min = 4
 	tacklestrength_max = 5
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/Carrier.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Carrier.dm
@@ -26,9 +26,8 @@
 	huggers_max = 16
 	eggs_max = 8
 
-	tackle_min = 2
-	tackle_max = 4
-	tackle_chance = 50
+	tackle_min = 3
+	tackle_max = 5
 	tacklestrength_min = 4
 	tacklestrength_max = 5
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/Crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Crusher.dm
@@ -18,9 +18,8 @@
 
 	minimum_evolve_time = 15 MINUTES
 
-	tackle_min = 2
+	tackle_min = 3
 	tackle_max = 6
-	tackle_chance = 25
 
 	evolution_allowed = FALSE
 	deevolves_to = list(XENO_CASTE_WARRIOR)

--- a/code/modules/mob/living/carbon/xenomorph/castes/Defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Defender.dm
@@ -20,7 +20,7 @@
 
 	behavior_delegate_type = /datum/behavior_delegate/defender_base
 
-	tackle_min = 2
+	tackle_min = 3
 	tackle_max = 4
 
 	minimum_evolve_time = 4 MINUTES

--- a/code/modules/mob/living/carbon/xenomorph/castes/Drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Drone.dm
@@ -24,7 +24,7 @@
 	weed_level = WEED_LEVEL_STANDARD
 	max_build_dist = 1
 
-	tackle_min = 2
+	tackle_min = 3
 	tackle_max = 4
 	tacklestrength_min = 3
 	tacklestrength_max = 4

--- a/code/modules/mob/living/carbon/xenomorph/castes/Hellhound.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Hellhound.dm
@@ -18,7 +18,6 @@
 
 	tackle_min = 4
 	tackle_max = 5
-	tackle_chance = 40
 	tacklestrength_min = 4
 	tacklestrength_max = 4
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/Hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Hivelord.dm
@@ -25,9 +25,8 @@
 	behavior_delegate_type = /datum/behavior_delegate/hivelord_base
 	max_build_dist = 1
 
-	tackle_min = 2
+	tackle_min = 3
 	tackle_max = 4
-	tackle_chance = 45
 	tacklestrength_min = 4
 	tacklestrength_max = 5
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/Lurker.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Lurker.dm
@@ -53,7 +53,7 @@
 	mutation_type = LURKER_NORMAL
 	claw_type = CLAW_TYPE_SHARP
 
-	tackle_min = 2
+	tackle_min = 4
 	tackle_max = 6
 
 	icon_xeno = 'icons/mob/xenos/lurker.dmi'

--- a/code/modules/mob/living/carbon/xenomorph/castes/Praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Praetorian.dm
@@ -22,9 +22,8 @@
 	aura_strength = 3
 	spit_delay = 20
 
-	tackle_min = 2
+	tackle_min = 3
 	tackle_max = 5
-	tackle_chance = 45
 
 	behavior_delegate_type = /datum/behavior_delegate/praetorian_base
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/Predalien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Predalien.dm
@@ -147,7 +147,7 @@ Your health meter will not regenerate normally, so kill and die for the hive!</s
 			for(var/i in 1 to 3)
 				var/obj/item/reagent_container/food/snacks/meat/new_meat = new flesh_type(human_victim.loc)
 				new_meat.name = "[human_victim.name] [flesh]"
-				
+
 
 		else if (isxeno(victim))
 			var/mob/living/carbon/xenomorph/xeno_victim = victim

--- a/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
@@ -35,9 +35,8 @@
 
 	spit_delay = 25
 
-	tackle_min = 2
+	tackle_min = 3
 	tackle_max = 6
-	tackle_chance = 55
 
 	aura_strength = 4
 	tacklestrength_min = 5

--- a/code/modules/mob/living/carbon/xenomorph/castes/Ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Ravager.dm
@@ -14,9 +14,8 @@
 	speed = XENO_SPEED_TIER_3
 	heal_standing = 0.66
 
-	tackle_min = 2
-	tackle_max = 5
-	tackle_chance = 35
+	tackle_min = 3
+	tackle_max = 6
 	tacklestrength_min = 4
 	tacklestrength_max = 5
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/Runner.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Runner.dm
@@ -18,10 +18,7 @@
 	deevolves_to = list("Larva")
 
 	tackle_min = 4
-	tackle_max = 5
-	tackle_chance = 40
-	tacklestrength_min = 4
-	tacklestrength_max = 4
+	tackle_max = 6
 
 	heal_resting = 1.75
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/Sentinel.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Sentinel.dm
@@ -19,8 +19,7 @@
 	acid_level = 1
 
 	tackle_min = 4
-	tackle_max = 4
-	tackle_chance = 50
+	tackle_max = 5
 	tacklestrength_min = 4
 	tacklestrength_max = 4
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/Spitter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Spitter.dm
@@ -21,9 +21,8 @@
 
 	spit_delay = 2.5 SECONDS
 
-	tackle_min = 2
+	tackle_min = 3
 	tackle_max = 6
-	tackle_chance = 45
 	tacklestrength_min = 4
 	tacklestrength_max = 5
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/Warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Warrior.dm
@@ -20,8 +20,8 @@
 	caste_desc = "A powerful front line combatant."
 	can_vent_crawl = 0
 
-	tackle_min = 2
-	tackle_max = 4
+	tackle_min = 3
+	tackle_max = 6
 
 	agility_speed_increase = -0.9
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/lesser_drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/lesser_drone.dm
@@ -26,7 +26,7 @@
 	max_build_dist = 1
 
 	tackle_min = 4
-	tackle_max = 5
+	tackle_max = 6
 
 	aura_strength = 1
 

--- a/code/modules/mob/living/carbon/xenomorph/mutators/strains/drone/healer.dm
+++ b/code/modules/mob/living/carbon/xenomorph/mutators/strains/drone/healer.dm
@@ -33,7 +33,6 @@
 	drone.max_placeable = 3
 	drone.available_fruits = list(/obj/effect/alien/resin/fruit)
 	drone.selected_fruit = /obj/effect/alien/resin/fruit
-	drone.tackle_chance_modifier -= 5
 	mutator_update_actions(drone)
 	apply_behavior_holder(drone)
 	mutator_set.recalculate_actions(description, flavor_description)

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -34,9 +34,8 @@
 	var/caste_desc = null
 
 	// Tackles
-	var/tackle_min = 2
-	var/tackle_max = 6
-	var/tackle_chance = 35
+	var/tackle_min = 3
+	var/tackle_max = 7
 	var/tacklestrength_min = 2
 	var/tacklestrength_max = 3
 

--- a/code/modules/mob/living/carbon/xenomorph/xeno_tackle_counter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_tackle_counter.dm
@@ -1,23 +1,36 @@
 /datum/tackle_counter
+	var/mob/living/carbon/human/tackled_mob
 	var/tackle_count = 0
 	var/min_tackles
 	var/max_tackles
-	var/tackle_chance
 	var/tackle_reset_id
 
-/datum/tackle_counter/New(min, max, chance)
+/datum/tackle_counter/New(mob/living/carbon/human/tackle_mob, min, max)
+	tackled_mob = tackle_mob
 	min_tackles = min
 	max_tackles = max
-	tackle_chance = chance
 
-/datum/tackle_counter/proc/attempt_tackle(tackle_bonus = 0)
+#define TACKLE_HEALTH_CONSIDERATION_CAP 20
+#define TACKLE_DAMAGE_CONSIDERATION_MAX 80
+
+/datum/tackle_counter/proc/attempt_tackle()
 	tackle_count++
 
 	if (tackle_count >= max_tackles)
 		return TRUE
-	else if (tackle_count < min_tackles)
+
+	if (tackle_count < min_tackles)
 		return FALSE
-	else if (prob(tackle_chance + tackle_bonus))
+
+	var/tackle_mob_damage = 100 - max(tackled_mob.health, TACKLE_HEALTH_CONSIDERATION_CAP)
+	var/tackle_tier_cut_offs = TACKLE_DAMAGE_CONSIDERATION_MAX / (max_tackles - min_tackles)
+	var/tackle_tier_diff = tackle_mob_damage / tackle_tier_cut_offs
+	var/tackles_required = max_tackles - tackle_tier_diff
+
+	if(tackle_count >= tackles_required)
 		return TRUE
 
 	return FALSE
+
+#undef TACKLE_HEALTH_CONSIDERATION_CAP
+#undef TACKLE_DAMAGE_CONSIDERATION_MAX


### PR DESCRIPTION
# About the pull request

This PR removes all randomness from xeno tackles.

If you hit the maximum tackle for the caste you will tackle.

Depending on how much damage the person being tackled has it will lower the required tackles.

This goes all the way to minimum tackle count at 80 damage.

Alongside this, tackle chances have been moved around to try and account for randomness no longer being a factor.

Three castes in particular have been moved higher on purpose above the others: warriors, lurkers, and runners.

# Explain why it's good for the game

Twofold:

Randomness with tackle chance creates insanely unfun situations where you get two tap disarmed by a drone and want to die.

Stun combat is slowly but surely being cut away and we want to encourage people to fight.

Do note, we still want xenos to cap so the maximum damage to reach the minimum amount of tackles is 80 damage. These numbers will be flexible as we see what happens in the tests.

As usual, we do feedback through a form on the forums and the maintainers read through and try to curb issues: https://forum.cm-ss13.com/w/pr-feedback/steps/step_1

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
balance: Xeno tackles are no longer random and range in required disarms based on damage to the disarmed. Max damage to get minimum number of tackles is 80.
balance: Alongside xeno tackles being no longer random, pretty much every caste has had tweaks to their disarm related variables. Specific nerfs to: warrior, lurker, and runner.
/:cl:
