### PR TITLE
Throws check tick all over the photo code

### DIFF
--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -184,6 +184,7 @@
 		for(var/atom/A in the_turf)
 			if(A.invisibility) continue
 			atoms.Add(A)
+			CHECK_TICK
 
 	// Sort the atoms into their layers
 	var/list/sorted = sort_atoms_by_layer(atoms)
@@ -209,6 +210,7 @@
 					xoff+=A:step_x
 					yoff+=A:step_y
 				res.Blend(IM, blendMode2iconMode(A.blend_mode),  A.pixel_x + xoff, A.pixel_y + yoff)
+				CHECK_TICK
 
 	// Lastly, render any contained effects on top.
 	for(var/turf/the_turf as anything in turfs)
@@ -218,6 +220,7 @@
 		var/image/IM = getFlatIcon(the_turf.loc)
 		if(IM)
 			res.Blend(IM, blendMode2iconMode(the_turf.blend_mode),xoff,yoff)
+			CHECK_TICK
 	return res
 
 
@@ -262,6 +265,7 @@
 	var/list/turf/turfs = RANGE_TURFS(radius, target) & view(world_view_size + radius, user.client)
 	for(var/turf/T as anything in turfs)
 		mobs += get_mobs(T)
+		CHECK_TICK
 	var/datum/picture/P = createpicture(target, user, turfs, mobs, flag)
 	printpicture(user, P)
 

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -246,13 +246,15 @@
 /obj/item/device/camera/afterattack(atom/target as mob|obj|turf|area, mob/user as mob, flag)
 	if(!on || !pictures_left || ismob(target.loc) || isstorage(target.loc)) return
 	if(user.contains(target) || istype(target, /atom/movable/screen)) return
-	captureimage(target, user, flag)
 
 	playsound(loc, pick('sound/items/polaroid1.ogg', 'sound/items/polaroid2.ogg'), 15, 1)
 
 	pictures_left--
 	desc = "A polaroid camera. It has [pictures_left] photos left."
 	to_chat(user, SPAN_NOTICE("[pictures_left] photos left."))
+
+	captureimage(target, user, flag)
+
 	icon_state = icon_off
 	on = 0
 	spawn(64)


### PR DESCRIPTION

# About the pull request

So I have a general understanding of how this works in scheduling and all but I'm sure this could be done better.

This *should* help with the absolutely gnarly 3-4 second hard stops on the server when cameras are taking pictures of lots of stuff at 7 width.

# Explain why it's good for the game

Hard server freezes are bad (hypothetically)


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
fix: Throws check tick all over the photo code to stop hard freezes
/:cl:
