### PR TITLE
Nerfs sticky resin

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/resin_constructions.dm
+++ b/code/modules/mob/living/carbon/xenomorph/resin_constructions.dm
@@ -239,6 +239,7 @@ GLOBAL_VAR_INIT(resin_lz_allowed, FALSE)
 	construction_name = "sticky resin"
 	cost = XENO_RESIN_STICKY_COST
 	build_time = 1 SECONDS
+	max_per_xeno = 25
 
 	build_path = /obj/effect/alien/resin/sticky
 
@@ -249,7 +250,6 @@ GLOBAL_VAR_INIT(resin_lz_allowed, FALSE)
 	construction_name = "fast resin"
 	cost = XENO_RESIN_FAST_COST
 	build_time = 1 SECONDS
-	max_per_xeno = 25
 
 	build_path = /obj/effect/alien/resin/sticky/fast
 

--- a/code/modules/mob/living/carbon/xenomorph/resin_constructions.dm
+++ b/code/modules/mob/living/carbon/xenomorph/resin_constructions.dm
@@ -249,6 +249,7 @@ GLOBAL_VAR_INIT(resin_lz_allowed, FALSE)
 	construction_name = "fast resin"
 	cost = XENO_RESIN_FAST_COST
 	build_time = 1 SECONDS
+	max_per_xeno = 25
 
 	build_path = /obj/effect/alien/resin/sticky/fast
 


### PR DESCRIPTION

# About the pull request
Adds a build cap to sticky resin
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Sticky resin right now is pretty awful ingame, not because it's bad but because it promotes the act of hivelords spending 20 minutes placing sticky resin on every single tile in caves, it should be used more strategically and develop where the combat is, rather than coating every square inch in 5 layers of it. 

Overall it will provide a more pleasant time for marines, increase the usage of hive clusters for the slowdown of hiveweeds and it will encourage builders to play more strategically

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl:
balance: Added a build cap to sticky resin of 25
/:cl:

