### PR TITLE
tgui research desktop fix

### DIFF
--- a/tgui/packages/tgui/interfaces/ResearchTerminal.tsx
+++ b/tgui/packages/tgui/interfaces/ResearchTerminal.tsx
@@ -142,7 +142,6 @@ const CompoundRecord = (props: CompoundRecordProps, context) => {
     'print_type': compound.category,
     'print_title': compound.id,
   };
-  const isThreeWords = compound.type.document.split(' ')[0] === 'Simulation';
   return (
     <TableRow key={compound.id}>
       <TableCell>
@@ -154,14 +153,13 @@ const CompoundRecord = (props: CompoundRecordProps, context) => {
       </TableCell>
 
       <TableCell className="chemical-td">
-        {!isThreeWords && (
-          <span className="compound_label">
-            {compound.type.document.split(' ')[2]}
-          </span>
-        )}
-        {isThreeWords && (
+        {compound.type.document.split(' ')[0] === 'Simulation' ? (
           <span className="compound_label">
             {compound.type.document.split(' ')[3]}
+          </span>
+        ) : (
+          <span className="compound_label">
+            {compound.type.document.split(' ')[2]}
           </span>
         )}
       </TableCell>

--- a/tgui/packages/tgui/interfaces/ResearchTerminal.tsx
+++ b/tgui/packages/tgui/interfaces/ResearchTerminal.tsx
@@ -142,6 +142,7 @@ const CompoundRecord = (props: CompoundRecordProps, context) => {
     'print_type': compound.category,
     'print_title': compound.id,
   };
+  const isThreeWords = compound.type.document.split(' ')[0] === 'Simulation';
   return (
     <TableRow key={compound.id}>
       <TableCell>
@@ -153,9 +154,16 @@ const CompoundRecord = (props: CompoundRecordProps, context) => {
       </TableCell>
 
       <TableCell className="chemical-td">
-        <span className="compound_label">
-          {compound.type.document.split(' ')[2]}
-        </span>
+        {!isThreeWords && (
+          <span className="compound_label">
+            {compound.type.document.split(' ')[2]}
+          </span>
+        )}
+        {isThreeWords && (
+          <span className="compound_label">
+            {compound.type.document.split(' ')[3]}
+          </span>
+        )}
       </TableCell>
 
       <TableCell>


### PR DESCRIPTION

# About the pull request
3 out of 4

Have you ever noticed that when you simulate something new, lets say you called it "gamer juice" and instead, in computer lab it always has "for" instead of the actual name that you created?  this is because "Analysis of X" Has two words before the name of the chemical while "Simulation results for X" has 3

TGUI splits it the same way despite having different number of words, thus,  "Simulation results **for** X"  - this is where For  comes from.

I had two ways to do it, either remove third word, or try to fix it in tgui, this however, still doesnt include the spaces you can put in the name.

(tgui is weiiirdd, if I did something funny which I dont get, sorry)
# Explain why it's good for the game
Always annoying to look for correct chemical you did in like ~8 "for"


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: kiVts
fix: Research computer no longer shows "for" for every simulation result.
/:cl:
