### PR TITLE
Reverts all recent nerfs to Warrior

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/warrior/warrior_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/warrior/warrior_abilities.dm
@@ -24,9 +24,9 @@
 
 	// Configurables
 	var/fling_distance = 4
-	var/stun_power = 0
-	var/weaken_power = 0.5
-	var/slowdown = 2
+	var/stun_power = 1
+	var/weaken_power = 1
+	var/slowdown = FALSE
 
 
 // Warrior Lunge
@@ -40,7 +40,7 @@
 	xeno_cooldown = 100
 
 	// Configurables
-	var/grab_range = 4
+	var/grab_range = 6
 	var/click_miss_cooldown = 15
 	var/twitch_message_cooldown = 0 //apparently this is necessary for a tiny code that makes the lunge message on cooldown not be spammable, doesn't need to be big so 5 will do.
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/Warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Warrior.dm
@@ -139,9 +139,6 @@
 /datum/behavior_delegate/warrior_base/melee_attack_additional_effects_target(mob/living/carbon/A)
 	..()
 
-	if(SEND_SIGNAL(bound_xeno, COMSIG_XENO_PRE_HEAL) & COMPONENT_CANCEL_XENO_HEAL)
-		return
-
 	var/final_lifesteal = lifesteal_percent
 	var/list/mobs_in_range = oviewers(lifesteal_range, bound_xeno)
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/Warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Warrior.dm
@@ -113,12 +113,28 @@
 /datum/behavior_delegate/warrior_base
 	name = "Base Warrior Behavior Delegate"
 
+	var/slash_charge_cdr = 0.20 SECONDS // Amount to reduce charge cooldown by per slash
 	var/lifesteal_percent = 7
 	var/max_lifesteal = 9
 	var/lifesteal_range =  3 // Marines within 3 tiles of range will give the warrior extra health
 	var/lifesteal_lock_duration = 20 // This will remove the glow effect on warrior after 2 seconds
 	var/color = "#6c6f24"
 	var/emote_cooldown = 0
+
+/datum/behavior_delegate/warrior_base/melee_attack_additional_effects_self()
+	..()
+
+	var/datum/action/xeno_action/activable/lunge/cAction1 = get_xeno_action_by_type(bound_xeno, /datum/action/xeno_action/activable/lunge)
+	if (!cAction1.action_cooldown_check())
+		cAction1.reduce_cooldown(slash_charge_cdr)
+
+	var/datum/action/xeno_action/activable/fling/cAction2 = get_xeno_action_by_type(bound_xeno, /datum/action/xeno_action/activable/fling)
+	if (!cAction2.action_cooldown_check())
+		cAction2.reduce_cooldown(slash_charge_cdr)
+
+	var/datum/action/xeno_action/activable/warrior_punch/cAction3 = get_xeno_action_by_type(bound_xeno, /datum/action/xeno_action/activable/warrior_punch)
+	if (!cAction3.action_cooldown_check())
+		cAction3.reduce_cooldown(slash_charge_cdr)
 
 /datum/behavior_delegate/warrior_base/melee_attack_additional_effects_target(mob/living/carbon/A)
 	..()


### PR DESCRIPTION
# About the pull request

This PR reverts all recent nerfs (2 prs) which includes the removal of slash CDR, lunge and fling weakening, and lifesteal no longer working while on fire.

# Explain why it's good for the game

Hello, I have created this PR in regards to a long time void of general direction for the game balancing of Warrior. As a result of neglect for the caste it has received a downhill trend of nerfs, and mechanic changes that prevent it from shining in combat. I believe these nerfs targeted an aspect of warrior that wasn't necessarily utilized enough to necessitate multiple nerfs. This area was, like I said it's combat related power. What it didn't target was Warriors capturing capability which is what I'm certain frustrates players the most. I am certain that the first step towards balancing warrior is a revert of t's combat related nerfs and to take a more general balancing viewpoint in regards to "how and why can it capture so easily", as opposed to a "how and why can it kill/punish mistakes so easily". This (in a perfect world) would include an actual revamp of lunge, along with tackling for warrior specifically being changed and/or nerfed. It would not mean a place-holder style nerf for its actual abilities, which does not help in anyway aside from reducing the combat presence, fear, and total power of warrior for anyone but highly capable players. 

# Changelog

:cl:
balance: Warriors fling now stuns for 1 second
balance: Warriors lunge range is increased to 6 tiles
balance: Warriors slash cooldown-reduction has been brought back
balance: Warriors lifesteal now works while on fire
/:cl:


