### PR TITLE
Nerf UPP Surv Guns

### DIFF
--- a/maps/Nightmare/maps/DesertDam/scenario.json
+++ b/maps/Nightmare/maps/DesertDam/scenario.json
@@ -2,8 +2,8 @@
     {
     "type": "pick", "name": "uppcrash",
     "choices": [
-        { "weight": 0, "type": "def", "values": { "lvevent": "none" } },
-        { "weight": 10, "type": "def", "values": { "lvevent": "uppcrash" } }
+        { "weight": 10, "type": "def", "values": { "lvevent": "none" } },
+        { "weight": 4, "type": "def", "values": { "lvevent": "uppcrash" } }
     ]
     }
 ]

--- a/maps/Nightmare/maps/DesertDam/scenario.json
+++ b/maps/Nightmare/maps/DesertDam/scenario.json
@@ -2,8 +2,8 @@
     {
     "type": "pick", "name": "uppcrash",
     "choices": [
-        { "weight": 10, "type": "def", "values": { "lvevent": "none" } },
-        { "weight": 4, "type": "def", "values": { "lvevent": "uppcrash" } }
+        { "weight": 2, "type": "def", "values": { "lvevent": "none" } },
+        { "weight": 10, "type": "def", "values": { "lvevent": "uppcrash" } }
     ]
     }
 ]

--- a/maps/Nightmare/maps/DesertDam/scenario.json
+++ b/maps/Nightmare/maps/DesertDam/scenario.json
@@ -2,7 +2,7 @@
     {
     "type": "pick", "name": "uppcrash",
     "choices": [
-        { "weight": 2, "type": "def", "values": { "lvevent": "none" } },
+        { "weight": 0, "type": "def", "values": { "lvevent": "none" } },
         { "weight": 10, "type": "def", "values": { "lvevent": "uppcrash" } }
     ]
     }

--- a/maps/map_files/DesertDam/standalone/crashlanding-upp-alt1.dmm
+++ b/maps/map_files/DesertDam/standalone/crashlanding-upp-alt1.dmm
@@ -333,10 +333,6 @@
 /obj/structure/closet/crate/ammo,
 /obj/item/ammo_magazine/rifle/type71/ap,
 /obj/item/ammo_magazine/rifle/type71/ap,
-/obj/item/ammo_magazine/rifle/type71/ap,
-/obj/item/ammo_magazine/rifle/type71/ap,
-/obj/item/ammo_magazine/rifle/type71/ap,
-/obj/item/ammo_magazine/rifle/type71/ap,
 /turf/open/shuttle/dropship{
 	icon_state = "rasputin15"
 	},
@@ -836,8 +832,7 @@
 /area/desert_dam/exterior/valley/valley_civilian)
 "Ny" = (
 /obj/structure/closet/crate/ammo,
-/obj/item/ammo_magazine/pkp,
-/obj/item/weapon/gun/pkp,
+/obj/item/weapon/gun/rifle/type71/flamer,
 /turf/open/shuttle/dropship{
 	icon_state = "rasputin15"
 	},


### PR DESCRIPTION
# About the pull request

Removes 4 of the 6 AP magazines from the second crashed dropship. Also removes the Specialist PKP Machinegun and replaces it with a standard rifle + under barrel flamer. 

# Explain why it's good for the game

The nerf is to slightly reduce the power boost the UPP survs get if they raid the second ship. There are still strong benefits as they get access to guaranteed UPP rifles, more ammo and a few grenades, but now they don't get a very powerful spec Machinegun and AP ammo.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
maptweak: Removed the PKP Machinegun and most of the AP ammo from the second crashed UPP ship on Trijent Dam. 
/:cl:
