### PR TITLE
Slightly optimizes client performance

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -90,7 +90,7 @@
 	initialize_power()
 
 /area/Initialize(mapload, ...)
-	icon_state = "" //Used to reset the icon overlay, I assume.
+	icon = null
 	layer = AREAS_LAYER
 	uid = ++global_uid
 	. = ..()


### PR DESCRIPTION

# About the pull request
Ports https://github.com/DaedalusDock/daedalusdock/pull/638, credit to Kapu for the PR

# Explain why it's good for the game
By having the `icon` be `null` (instead of `icon_state` being `""`), BYOND processes one less appearance (that of the invisible area) per turf. That being said, appearance-to-icon is cached, but this is free performance.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

It doesn't fuck with weather or anything

</details>


