### PR TITLE
Predators Rounds are no longer random

### DIFF
--- a/maps/Nightmare/scenario.json
+++ b/maps/Nightmare/scenario.json
@@ -1,3 +1,3 @@
 [
-    { "type": "def", "values": { "predator_round": true }, "chance": 0.2 }
+    { "type": "def", "values": { "predator_round": true }, "chance": 0.0 }
 ]


### PR DESCRIPTION
Predator Rounds must now be triggered manually by admins as an event
# About the pull request

Predator rounds won't trigger randomly, and instead need to be done as events.

# Explain why it's good for the game

Various issues with Predator makes it better as an event only type thing.

# Testing Photographs and Procedure
I did NOT test it.

# Changelog

:cl: Grimreaperx15
del: Removed random predator rounds
/:cl:
