### PR TITLE
Removes clan menu honor count

### DIFF
--- a/nano/templates/clan_menu.tmpl
+++ b/nano/templates/clan_menu.tmpl
@@ -46,7 +46,7 @@
 	}
 
 	#clan_list {
-		border-collapse: collapse; 
+		border-collapse: collapse;
 		width: 100%;
 	}
 </style>
@@ -76,9 +76,6 @@
 	<h1 class="whiteTitle">{{:data.clan_name}}</h1>
 	<pre class="whiteDescription">{{:data.clan_description}}</pre>
 
-	{{if data.clan_honor != null}}
-		<h3 class="whiteTitle">Honor: {{:data.clan_honor}}</h3>
-	{{/if}}
 	<table>
 		<tr>
 			{{if data.player_rename_clan}}
@@ -111,7 +108,6 @@
 		<th class="noPadCell"></th>
 		<th>Name</th>
 		<th>Rank</th>
-		<th>Honor</th>
 		{{if data.player_modify_ranks}}
 			<th></th>
 		{{/if}}
@@ -128,7 +124,6 @@
 			<td class="noPadCell"></td>
 			<td id="clan_name">{{:keys.name}}</td>
 			<td>{{:keys.rank}}</td>
-			<td>{{:keys.honor}}</td>
 			{{if data.player_rank_pos > keys.rank_pos}}
 				{{if data.player_modify_ranks}}
 					<td><div unselectable="on">{{:helper.link('Set Rank', '', { 'clan_target_href' : keys.player_id, 'clan_action': 'modifyrank' })}}</div></td>


### PR DESCRIPTION

# About the pull request
![image](https://github.com/cmss13-devs/cmss13/assets/41448081/bc633d43-394b-40d9-b565-5429cafb8ba5)

Removes the visible honor count from predators in the clan menu

# Explain why it's good for the game
- Scoreboards inherently build a system of "who can get the highest score", RP be damned.
- Killing shouldn't be the primary goal of preds, as the honor system can imply, it should be RP.

# Changelog
:cl:
del: Predators can no longer see their or others cross-round honor count.
/:cl:
