### PR TITLE
Medbelts pull from pillbottles as default

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -151,7 +151,7 @@
 	storage_slots = 14
 	max_w_class = SIZE_MEDIUM
 	max_storage_space = 28
-	var/mode = 0 //Pill picking mode
+	var/mode = 1 //Picking from pill bottle mode
 
 	can_hold = list(
 		/obj/item/device/healthanalyzer,


### PR DESCRIPTION
# About the pull request

Changes the medical belts to pull pills from bottles by default, rather than pulling the entire bottle out. Tested as it just changes a single variable

# Explain why it's good for the game

Waking up and forgetting to swap your belt mode as doctor or CMO is frustrating, this fixes that.

# Testing Photographs and Procedure

Tested and works fine.

# Changelog

:cl:
qol: Medbelts pull from pillbottles as default
/:cl:
