### PR TITLE
Survivors Spawn In Same Area

### DIFF
--- a/maps/map_files/BigRed/BigRed.dmm
+++ b/maps/map_files/BigRed/BigRed.dmm
@@ -3942,13 +3942,6 @@
 	icon_state = "redcorner"
 	},
 /area/bigredv2/outside/marshal_office)
-"alt" = (
-/obj/effect/landmark/survivor_spawner,
-/turf/open/floor{
-	dir = 4;
-	icon_state = "redcorner"
-	},
-/area/bigredv2/outside/marshal_office)
 "alu" = (
 /turf/closed/wall/solaris,
 /area/bigredv2/outside/medical)
@@ -4292,7 +4285,6 @@
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
 	},
-/obj/effect/landmark/survivor_spawner,
 /turf/open/floor,
 /area/bigredv2/outside/marshal_office)
 "amv" = (
@@ -4350,13 +4342,6 @@
 	},
 /turf/open/floor{
 	icon_state = "wood"
-	},
-/area/bigredv2/outside/marshal_office)
-"amB" = (
-/obj/effect/landmark/survivor_spawner,
-/obj/structure/pipes/standard/simple/hidden/green,
-/turf/open/floor{
-	icon_state = "grimy"
 	},
 /area/bigredv2/outside/marshal_office)
 "amC" = (
@@ -5160,11 +5145,6 @@
 	dir = 9;
 	icon_state = "redfull"
 	},
-/area/bigredv2/outside/marshal_office)
-"aoW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/survivor_spawner,
-/turf/open/floor,
 /area/bigredv2/outside/marshal_office)
 "aoX" = (
 /obj/structure/surface/table/woodentable/fancy,
@@ -8391,13 +8371,6 @@
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor,
 /area/bigredv2/outside/dorms)
-"axH" = (
-/obj/structure/bed/chair{
-	dir = 4
-	},
-/obj/effect/landmark/survivor_spawner,
-/turf/open/floor,
-/area/bigredv2/outside/dorms)
 "axI" = (
 /obj/structure/surface/table,
 /obj/effect/spawner/random/tool,
@@ -8880,12 +8853,6 @@
 /obj/structure/window/framed/solaris,
 /turf/open/floor/plating,
 /area/bigredv2/outside/engineering)
-"aza" = (
-/obj/effect/landmark/survivor_spawner,
-/turf/open/floor{
-	icon_state = "grimy"
-	},
-/area/bigredv2/outside/dorms)
 "azb" = (
 /obj/structure/window/framed/solaris/reinforced,
 /obj/structure/machinery/door/poddoor/shutters/almayer{
@@ -13094,6 +13061,7 @@
 /area/bigredv2/outside/bar)
 "aKw" = (
 /obj/item/clothing/head/welding,
+/obj/effect/landmark/survivor_spawner,
 /turf/open/floor{
 	icon_state = "wood"
 	},
@@ -14391,6 +14359,7 @@
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
 	},
+/obj/effect/landmark/survivor_spawner,
 /turf/open/floor{
 	icon_state = "wood"
 	},
@@ -15116,12 +15085,6 @@
 /obj/structure/bed/chair/office/dark{
 	dir = 8
 	},
-/turf/open/floor{
-	icon_state = "white"
-	},
-/area/bigredv2/outside/admin_building)
-"aPM" = (
-/obj/effect/landmark/survivor_spawner,
 /turf/open/floor{
 	icon_state = "white"
 	},
@@ -15918,11 +15881,6 @@
 	dir = 5;
 	icon_state = "whitebluefull"
 	},
-/area/bigredv2/outside/general_store)
-"aRP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/survivor_spawner,
-/turf/open/floor,
 /area/bigredv2/outside/general_store)
 "aRQ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -18128,12 +18086,6 @@
 	icon_state = "dark"
 	},
 /area/bigredv2/outside/admin_building)
-"aYk" = (
-/obj/effect/landmark/survivor_spawner,
-/turf/open/floor{
-	icon_state = "dark"
-	},
-/area/bigredv2/outside/admin_building)
 "aYl" = (
 /obj/item/cell/hyper/empty,
 /turf/open/floor{
@@ -19006,10 +18958,6 @@
 	icon_state = "delivery"
 	},
 /area/bigredv2/outside/cargo)
-"bbh" = (
-/obj/effect/landmark/survivor_spawner,
-/turf/open/floor,
-/area/bigredv2/outside/cargo)
 "bbi" = (
 /obj/structure/barricade/wooden{
 	desc = "This barricade is heavily reinforced. Nothing short of blasting it open seems like it'll do the trick, that or melting the breams supporting it...";
@@ -19340,10 +19288,6 @@
 	icon_state = "grimy"
 	},
 /area/bigredv2/outside/admin_building)
-"bcd" = (
-/obj/effect/landmark/survivor_spawner,
-/turf/open/floor/plating,
-/area/bigredv2/outside/admin_building)
 "bce" = (
 /obj/structure/surface/rack,
 /obj/effect/spawner/random/tech_supply,
@@ -19388,16 +19332,6 @@
 	icon_state = "delivery"
 	},
 /area/bigredv2/outside/office_complex)
-"bcl" = (
-/obj/structure/bed/chair/wood/normal{
-	dir = 8
-	},
-/obj/effect/landmark/survivor_spawner,
-/turf/open/floor{
-	dir = 4;
-	icon_state = "chapel"
-	},
-/area/bigredv2/outside/chapel)
 "bcn" = (
 /obj/effect/landmark/crap_item,
 /turf/open/mars_cave{
@@ -20171,11 +20105,6 @@
 "beL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/pipes/standard/simple/hidden/green,
-/turf/open/floor,
-/area/bigredv2/outside/office_complex)
-"beM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/survivor_spawner,
 /turf/open/floor,
 /area/bigredv2/outside/office_complex)
 "beN" = (
@@ -21044,13 +20973,6 @@
 "bhi" = (
 /turf/closed/wall/solaris/rock,
 /area/bigredv2/outside/c)
-"bhk" = (
-/obj/effect/landmark/survivor_spawner,
-/turf/open/floor{
-	dir = 8;
-	icon_state = "redcorner"
-	},
-/area/bigredv2/outside/office_complex)
 "bhl" = (
 /obj/structure/pipes/vents/pump{
 	dir = 1
@@ -22150,7 +22072,6 @@
 /turf/open/floor,
 /area/bigredv2/outside/filtration_plant)
 "blB" = (
-/obj/effect/landmark/survivor_spawner,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/machinery/camera/autoname{
 	dir = 4
@@ -22245,7 +22166,6 @@
 "bma" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/survivor_spawner,
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 10
 	},
@@ -22967,10 +22887,6 @@
 	icon_state = "asteroidwarning"
 	},
 /area/bigredv2/outside/filtration_plant)
-"bpe" = (
-/obj/effect/landmark/survivor_spawner,
-/turf/open/floor,
-/area/bigredv2/outside/engineering)
 "bpf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/pipes/standard/simple/hidden/green{
@@ -23381,11 +23297,6 @@
 	icon_state = "delivery"
 	},
 /area/bigredv2/outside/engineering)
-"bqT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/survivor_spawner,
-/turf/open/floor,
-/area/bigredv2/outside/filtration_plant)
 "bqV" = (
 /obj/structure/machinery/light{
 	dir = 4
@@ -27413,6 +27324,13 @@
 /obj/structure/blocker/forcefield/multitile_vehicles,
 /turf/closed/wall/solaris/rock,
 /area/bigredv2/caves)
+"coF" = (
+/obj/structure/bed/chair/wood/normal,
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/bigredv2/outside/bar)
 "coT" = (
 /obj/effect/landmark/objective_landmark/science,
 /turf/open/floor{
@@ -29230,6 +29148,13 @@
 	icon_state = "mars_dirt_10"
 	},
 /area/bigredv2/outside/eta)
+"fZz" = (
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "carpet11-12"
+	},
+/area/bigredv2/outside/bar)
 "gad" = (
 /turf/open/floor{
 	icon_state = "delivery"
@@ -29246,6 +29171,15 @@
 	icon_state = "bcircuitoff"
 	},
 /area/bigredv2/caves/lambda/research)
+"gaS" = (
+/obj/structure/bed/chair/wood/normal{
+	dir = 4
+	},
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/bigredv2/outside/bar)
 "gcR" = (
 /obj/effect/landmark/crap_item,
 /turf/open/mars_cave{
@@ -31957,6 +31891,13 @@
 	icon_state = "bcircuitoff"
 	},
 /area/bigredv2/caves/lambda/research)
+"lQm" = (
+/obj/structure/bed/stool,
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/bigredv2/outside/bar)
 "lQN" = (
 /turf/open/mars_cave{
 	icon_state = "mars_cave_18"
@@ -32463,6 +32404,15 @@
 	icon_state = "mars_cave_2"
 	},
 /area/bigredv2/caves_research)
+"nbW" = (
+/obj/structure/bed/chair/wood/normal{
+	dir = 1
+	},
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/bigredv2/outside/bar)
 "ncv" = (
 /obj/effect/landmark/corpsespawner/ua_riot,
 /obj/effect/decal/cleanable/blood{
@@ -33742,6 +33692,15 @@
 	icon_state = "mars_cave_14"
 	},
 /area/bigredv2/caves/mining)
+"pKL" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/bigredv2/outside/bar)
 "pLj" = (
 /obj/structure/largecrate/random/barrel/red,
 /turf/open/mars_cave{
@@ -33926,6 +33885,13 @@
 /obj/vehicle/powerloader/ft,
 /turf/open/floor/plating,
 /area/bigredv2/outside/nw/ceiling)
+"qbn" = (
+/obj/structure/pipes/standard/simple/hidden/green,
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/bigredv2/outside/bar)
 "qez" = (
 /obj/structure/blocker/forcefield/multitile_vehicles,
 /turf/open/mars_cave{
@@ -38084,6 +38050,13 @@
 	icon_state = "mars_cave_17"
 	},
 /area/bigredv2/caves_research)
+"ybl" = (
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "carpet13-5"
+	},
+/area/bigredv2/outside/bar)
 "ybT" = (
 /obj/structure/machinery/door/airlock/almayer/maint/colony{
 	name = "\improper Machine room"
@@ -50523,7 +50496,7 @@ bmf
 bnQ
 bmi
 bmi
-bpe
+bmi
 axX
 jYF
 bmi
@@ -50915,7 +50888,7 @@ aNk
 aOB
 aOB
 aOB
-aRP
+aOB
 aOy
 aOB
 aOB
@@ -52230,7 +52203,7 @@ asK
 aZu
 aZu
 aZu
-bbh
+aZu
 bbT
 bcB
 asK
@@ -55904,7 +55877,7 @@ aof
 apC
 aNB
 aOG
-aPM
+aMf
 aQZ
 aRX
 aof
@@ -56165,7 +56138,7 @@ ayZ
 ayr
 ayr
 ayr
-bpe
+bmi
 bor
 bmi
 bmi
@@ -56300,7 +56273,7 @@ afS
 afS
 aki
 aer
-alt
+agz
 ahn
 ahj
 anx
@@ -56999,7 +56972,7 @@ aRd
 aRd
 aSW
 aOM
-aYk
+aOM
 aOM
 aOM
 aZX
@@ -57824,7 +57797,7 @@ amq
 ahj
 aeJ
 adS
-aoW
+adk
 aeJ
 aqH
 aqL
@@ -59423,7 +59396,7 @@ awp
 awp
 bpQ
 blX
-bqT
+blX
 blX
 blX
 blX
@@ -60043,7 +60016,7 @@ aNL
 aUb
 aof
 bbq
-bcd
+aTa
 bcU
 bds
 aYO
@@ -60657,7 +60630,7 @@ amn
 avE
 asJ
 awY
-axH
+awY
 asJ
 asJ
 azT
@@ -61509,7 +61482,7 @@ ajS
 akv
 akT
 alC
-amB
+alC
 alC
 alC
 aon
@@ -62630,7 +62603,7 @@ aLp
 aEO
 aMH
 aEO
-aLp
+gaS
 aEO
 aEO
 anJ
@@ -62841,7 +62814,7 @@ atY
 aAE
 aHG
 aIr
-aJn
+ybl
 aEQ
 aLq
 aMh
@@ -63263,7 +63236,7 @@ awr
 axg
 axO
 ayu
-aza
+awq
 aws
 aAE
 atY
@@ -63278,11 +63251,11 @@ aIs
 aJo
 aEO
 aEO
-aEO
+aMj
 psE
-aNS
+pKL
 aEO
-aEO
+aMj
 aRj
 aqz
 aHD
@@ -63707,7 +63680,7 @@ amn
 amn
 amn
 amn
-aHI
+fZz
 aHI
 aJp
 aKv
@@ -63925,13 +63898,13 @@ aEO
 aEO
 aEO
 aEO
-aEO
+aMj
 aEO
 aKw
 aLr
 aEO
 aEO
-aNS
+pKL
 aLr
 aPY
 aEO
@@ -64147,7 +64120,7 @@ aER
 aER
 aER
 aER
-aER
+qbn
 aNU
 aEO
 aEO
@@ -64574,12 +64547,12 @@ anJ
 aNS
 aEQ
 jUM
-aGI
-aEQ
+nbW
+coF
 jUM
 aJq
-aKx
-aKx
+lQm
+lQm
 aKx
 aKx
 aNW
@@ -64800,7 +64773,7 @@ aLu
 aMi
 aMI
 aNX
-aKx
+lQm
 aNS
 aRn
 aqz
@@ -65013,9 +64986,9 @@ aHJ
 aIu
 anJ
 aEO
-aEO
 aMj
 aEO
+aMj
 aFW
 aKx
 aNS
@@ -65232,10 +65205,10 @@ aJr
 aEO
 coT
 aEO
-aEO
+aMj
 aNY
 aKx
-aNS
+pKL
 aRk
 anJ
 bhR
@@ -65690,7 +65663,7 @@ bbB
 bai
 bai
 bbB
-beM
+aXU
 bfp
 asv
 bgi
@@ -66347,7 +66320,7 @@ bfO
 bgk
 bgx
 bgR
-bhk
+bgx
 bgx
 biD
 bqa
@@ -72195,7 +72168,7 @@ nRT
 bap
 baT
 bbF
-bcl
+bap
 baT
 nRT
 atb

--- a/maps/map_files/DesertDam/Desert_Dam.dmm
+++ b/maps/map_files/DesertDam/Desert_Dam.dmm
@@ -9445,10 +9445,6 @@
 /obj/structure/closet/cabinet,
 /turf/open/floor/interior/wood,
 /area/desert_dam/interior/dam_interior/east_tunnel_entrance)
-"aCv" = (
-/obj/effect/landmark/survivor_spawner,
-/turf/open/floor/interior/wood,
-/area/desert_dam/interior/dam_interior/east_tunnel_entrance)
 "aCw" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/interior/wood,
@@ -9625,7 +9621,6 @@
 /turf/open/floor/interior/wood,
 /area/desert_dam/interior/dam_interior/east_tunnel_entrance)
 "aCZ" = (
-/obj/effect/landmark/survivor_spawner,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -12216,12 +12211,6 @@
 	icon_state = "tile"
 	},
 /area/desert_dam/exterior/valley/valley_cargo)
-"aKV" = (
-/obj/effect/landmark/survivor_spawner,
-/turf/open/floor{
-	icon_state = "whitegreen"
-	},
-/area/desert_dam/building/lab_northwest/west_lab_xenoflora)
 "aKW" = (
 /obj/structure/desertdam/decals/road_edge{
 	icon_state = "road_edge_decal2"
@@ -16829,12 +16818,6 @@
 	icon_state = "blue"
 	},
 /area/desert_dam/building/administration/control_room)
-"aZy" = (
-/obj/effect/landmark/survivor_spawner,
-/turf/open/floor/prison{
-	icon_state = "bright_clean2"
-	},
-/area/desert_dam/building/administration/control_room)
 "aZz" = (
 /obj/structure/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -18259,12 +18242,6 @@
 	dir = 1
 	},
 /area/desert_dam/building/administration/meetingrooom)
-"beh" = (
-/obj/effect/landmark/survivor_spawner,
-/turf/open/floor/carpet/edge{
-	dir = 1
-	},
-/area/desert_dam/building/administration/meetingrooom)
 "bei" = (
 /turf/open/floor/carpet/edge{
 	dir = 5
@@ -19638,13 +19615,6 @@
 /turf/open/floor/prison{
 	dir = 8;
 	icon_state = "darkbrown3"
-	},
-/area/desert_dam/interior/dam_interior/hanger)
-"biI" = (
-/obj/effect/landmark/survivor_spawner,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
 "biJ" = (
@@ -23872,12 +23842,6 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
-"bwz" = (
-/obj/effect/landmark/survivor_spawner,
-/turf/open/floor/prison{
-	dir = 10
-	},
-/area/desert_dam/interior/dam_interior/engine_east_wing)
 "bwA" = (
 /obj/structure/machinery/power/port_gen/pacman/super,
 /turf/open/floor/prison{
@@ -24866,12 +24830,6 @@
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/control_room)
-"bzP" = (
-/obj/effect/landmark/survivor_spawner,
-/turf/open/floor{
-	icon_state = "neutral"
-	},
-/area/desert_dam/interior/dam_interior/engine_room)
 "bzQ" = (
 /obj/structure/surface/table,
 /obj/item/storage/box/lights/mixed,
@@ -24911,10 +24869,6 @@
 	icon_state = "cement1"
 	},
 /area/desert_dam/exterior/valley/valley_wilderness)
-"bzW" = (
-/obj/effect/landmark/survivor_spawner,
-/turf/open/floor/interior/wood/alt,
-/area/desert_dam/building/security/courtroom)
 "bzX" = (
 /obj/structure/surface/table,
 /obj/item/device/taperecorder,
@@ -26070,13 +26024,6 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/interior/dam_interior/north_tunnel)
-"bEo" = (
-/obj/effect/landmark/survivor_spawner,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/prison{
-	dir = 10
-	},
-/area/desert_dam/interior/dam_interior/auxilary_tool_storage)
 "bEp" = (
 /obj/structure/platform,
 /turf/open/asphalt/cement{
@@ -27118,10 +27065,6 @@
 /obj/structure/prop/dam/boulder/boulder3,
 /turf/open/desert/rock,
 /area/desert_dam/interior/caves/central_caves)
-"bHu" = (
-/obj/effect/landmark/survivor_spawner,
-/turf/open/floor/prison,
-/area/desert_dam/building/security/staffroom)
 "bHv" = (
 /turf/open/floor{
 	dir = 7;
@@ -29949,12 +29892,6 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/interior/dam_interior/workshop)
-"bQW" = (
-/obj/effect/landmark/survivor_spawner,
-/turf/open/floor/prison{
-	icon_state = "sterile_white"
-	},
-/area/desert_dam/interior/dam_interior/workshop)
 "bQY" = (
 /obj/effect/decal/sand_overlay/sand2/corner2,
 /turf/open/floor/prison{
@@ -31259,13 +31196,6 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/control_room)
-"bVj" = (
-/obj/effect/landmark/survivor_spawner,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/prison{
-	dir = 10
-	},
-/area/desert_dam/interior/dam_interior/hangar_storage)
 "bVk" = (
 /obj/effect/decal/sand_overlay/sand2/corner2{
 	dir = 4
@@ -32341,7 +32271,6 @@
 /area/desert_dam/interior/dam_interior/disposals)
 "bYy" = (
 /obj/item/trash/pistachios,
-/obj/effect/landmark/survivor_spawner,
 /turf/open/floor/plating,
 /area/desert_dam/interior/dam_interior/disposals)
 "bYA" = (
@@ -36002,12 +35931,6 @@
 	icon_state = "cement_sunbleached17"
 	},
 /area/desert_dam/exterior/valley/valley_cargo)
-"ckq" = (
-/obj/effect/landmark/survivor_spawner,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/interior/wood/alt,
-/area/desert_dam/building/bar/bar)
 "ckr" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N"
@@ -36691,13 +36614,6 @@
 	dir = 8
 	},
 /area/desert_dam/exterior/river/riverside_south)
-"cms" = (
-/obj/effect/landmark/survivor_spawner,
-/turf/open/floor/prison{
-	dir = 8;
-	icon_state = "sterile_white"
-	},
-/area/desert_dam/building/warehouse/breakroom)
 "cmt" = (
 /obj/structure/machinery/photocopier,
 /turf/open/floor/prison{
@@ -37869,14 +37785,6 @@
 	icon_state = "whitegreen"
 	},
 /area/desert_dam/building/medical/west_wing_hallway)
-"cqu" = (
-/obj/effect/landmark/survivor_spawner,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean"
-	},
-/area/desert_dam/interior/dam_interior/primary_tool_storage)
 "cqv" = (
 /obj/structure/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -39134,10 +39042,6 @@
 	icon_state = "greencorner"
 	},
 /area/desert_dam/building/substation/west)
-"cuB" = (
-/obj/effect/landmark/survivor_spawner,
-/turf/open/floor/prison,
-/area/desert_dam/building/substation/west)
 "cuH" = (
 /turf/open/desert/dirt{
 	icon_state = "rock1"
@@ -39418,6 +39322,7 @@
 /area/desert_dam/building/bar/bar)
 "cvu" = (
 /obj/structure/bed/chair/wood/normal,
+/obj/effect/landmark/survivor_spawner,
 /turf/open/floor/interior/tatami,
 /area/desert_dam/building/bar/bar)
 "cvv" = (
@@ -40002,6 +39907,7 @@
 "cxh" = (
 /obj/structure/bed/chair/wood/normal,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/survivor_spawner,
 /turf/open/floor/interior/tatami,
 /area/desert_dam/building/bar/bar)
 "cxi" = (
@@ -41494,13 +41400,6 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/building/medical/office1)
-"cBC" = (
-/obj/effect/landmark/survivor_spawner,
-/turf/open/floor/prison{
-	dir = 8;
-	icon_state = "sterile_white"
-	},
-/area/desert_dam/building/medical/office1)
 "cBD" = (
 /obj/structure/machinery/light{
 	dir = 4
@@ -42819,6 +42718,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/landmark/survivor_spawner,
 /turf/open/floor/interior/tatami,
 /area/desert_dam/building/bar/bar)
 "cFE" = (
@@ -42847,6 +42747,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/survivor_spawner,
 /turf/open/floor/interior/tatami,
 /area/desert_dam/building/bar/bar)
 "cFH" = (
@@ -42894,6 +42795,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/survivor_spawner,
 /turf/open/floor/interior/tatami,
 /area/desert_dam/building/bar/bar)
 "cFO" = (
@@ -44338,6 +44240,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/survivor_spawner,
 /turf/open/floor/interior/tatami,
 /area/desert_dam/building/bar/bar)
 "cKn" = (
@@ -46045,6 +45948,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/survivor_spawner,
 /turf/open/floor/interior/tatami,
 /area/desert_dam/building/bar/bar)
 "cQb" = (
@@ -46072,6 +45976,7 @@
 /obj/structure/bed/chair/wood/normal{
 	dir = 1
 	},
+/obj/effect/landmark/survivor_spawner,
 /turf/open/floor/interior/tatami,
 /area/desert_dam/building/bar/bar)
 "cQf" = (
@@ -46201,6 +46106,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
+/obj/effect/landmark/survivor_spawner,
 /turf/open/floor/interior/wood/alt,
 /area/desert_dam/building/bar/bar)
 "cQE" = (
@@ -46303,6 +46209,7 @@
 /obj/structure/bed/chair/wood/normal{
 	dir = 4
 	},
+/obj/effect/landmark/survivor_spawner,
 /turf/open/floor/interior/tatami,
 /area/desert_dam/building/bar/bar)
 "cQU" = (
@@ -46343,12 +46250,14 @@
 	dir = 8
 	},
 /obj/structure/pipes/standard/simple/hidden/green,
+/obj/effect/landmark/survivor_spawner,
 /turf/open/floor/interior/tatami,
 /area/desert_dam/building/bar/bar)
 "cRa" = (
 /obj/structure/bed/chair/wood/normal{
 	dir = 8
 	},
+/obj/effect/landmark/survivor_spawner,
 /turf/open/floor/interior/tatami,
 /area/desert_dam/building/bar/bar)
 "cRc" = (
@@ -46465,6 +46374,7 @@
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
 	},
+/obj/effect/landmark/survivor_spawner,
 /turf/open/floor/interior/tatami,
 /area/desert_dam/building/bar/bar)
 "cRy" = (
@@ -46506,6 +46416,7 @@
 /obj/structure/bed/chair/wood/normal{
 	dir = 1
 	},
+/obj/effect/landmark/survivor_spawner,
 /turf/open/floor/interior/tatami,
 /area/desert_dam/building/bar/bar)
 "cRE" = (
@@ -46557,6 +46468,10 @@
 /obj/structure/desertdam/decals/road_edge,
 /turf/open/asphalt,
 /area/desert_dam/exterior/valley/valley_cargo)
+"cRP" = (
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor/interior/wood/alt,
+/area/desert_dam/building/bar/bar)
 "cRQ" = (
 /obj/structure/toilet{
 	dir = 1
@@ -47236,13 +47151,6 @@
 	},
 /turf/open/asphalt,
 /area/desert_dam/exterior/valley/valley_cargo)
-"cUs" = (
-/obj/effect/landmark/survivor_spawner,
-/turf/open/floor/prison{
-	dir = 8;
-	icon_state = "sterile_white"
-	},
-/area/desert_dam/building/hydroponics/hydroponics_breakroom)
 "cUv" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/prison{
@@ -48321,14 +48229,6 @@
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "darkbrown2"
-	},
-/area/desert_dam/building/warehouse/loading)
-"cZy" = (
-/obj/effect/landmark/survivor_spawner,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/warehouse/loading)
 "cZz" = (
@@ -51442,10 +51342,6 @@
 	dir = 8;
 	icon_state = "red"
 	},
-/area/desert_dam/building/water_treatment_one/lobby)
-"dsc" = (
-/obj/effect/landmark/survivor_spawner,
-/turf/open/floor/prison,
 /area/desert_dam/building/water_treatment_one/lobby)
 "dsf" = (
 /obj/effect/blocker/toxic_water/Group_2,
@@ -54730,14 +54626,6 @@
 	icon_state = "whitegreenfull"
 	},
 /area/desert_dam/building/dorms/pool)
-"dKs" = (
-/obj/effect/landmark/survivor_spawner,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor{
-	dir = 4;
-	icon_state = "whiteyellowcorner"
-	},
-/area/desert_dam/interior/dam_interior/break_room)
 "dKt" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor{
@@ -57641,14 +57529,6 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/hydroponics/hydroponics)
-"dUF" = (
-/obj/effect/landmark/survivor_spawner,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean"
-	},
-/area/desert_dam/building/hydroponics/hydroponics)
 "dUG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -57680,14 +57560,6 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/hydroponics/hydroponics)
-"dUJ" = (
-/obj/effect/landmark/survivor_spawner,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean"
-	},
-/area/desert_dam/building/hydroponics/hydroponics_storage)
 "dUK" = (
 /obj/effect/decal/cleanable/vomit,
 /obj/effect/decal/cleanable/dirt,
@@ -60801,13 +60673,6 @@
 /obj/structure/blocker/forcefield/multitile_vehicles,
 /turf/closed/wall/r_wall/chigusa,
 /area/desert_dam/interior/lab_northeast/east_lab_lobby)
-"gak" = (
-/obj/effect/landmark/survivor_spawner,
-/turf/open/floor/prison{
-	dir = 4;
-	icon_state = "whitegreencorner"
-	},
-/area/desert_dam/building/medical/emergency_room)
 "gca" = (
 /obj/structure/fence,
 /turf/open/desert/dirt,
@@ -60898,6 +60763,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/asphalt,
 /area/desert_dam/building/hydroponics/hydroponics_loading)
+"gnl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor/interior/wood/alt,
+/area/desert_dam/building/bar/bar)
 "gnu" = (
 /obj/effect/decal/sand_overlay/sand1{
 	dir = 1
@@ -61260,6 +61131,11 @@
 	icon_state = "cement_sunbleached1"
 	},
 /area/desert_dam/exterior/valley/south_valley_dam)
+"hul" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor/interior/wood/alt,
+/area/desert_dam/building/bar/bar)
 "hvG" = (
 /turf/open/desert/dirt{
 	dir = 4;
@@ -61397,12 +61273,6 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/mining/workshop)
-"hTg" = (
-/obj/effect/landmark/survivor_spawner,
-/turf/open/floor{
-	icon_state = "dark"
-	},
-/area/desert_dam/building/church)
 "hTr" = (
 /obj/effect/decal/sand_overlay/sand1{
 	dir = 1
@@ -62094,16 +61964,6 @@
 /obj/structure/blocker/forcefield/multitile_vehicles,
 /turf/open/floor/prison,
 /area/desert_dam/building/dorms/hallway_northwing)
-"kEq" = (
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 4
-	},
-/obj/effect/landmark/survivor_spawner,
-/turf/open/floor/prison{
-	dir = 1;
-	icon_state = "whitegreen"
-	},
-/area/desert_dam/building/medical/virology_wing)
 "kFW" = (
 /obj/structure/machinery/door/poddoor/almayer{
 	dir = 2;
@@ -62484,6 +62344,10 @@
 	icon_state = "tile"
 	},
 /area/desert_dam/exterior/valley/valley_labs)
+"lSJ" = (
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor/interior/wood,
+/area/desert_dam/building/bar/bar)
 "lUl" = (
 /obj/structure/surface/table/woodentable/fancy,
 /turf/open/floor{
@@ -62514,6 +62378,11 @@
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
 /turf/open/desert/dirt,
 /area/desert_dam/exterior/valley/valley_crashsite)
+"lYx" = (
+/obj/structure/machinery/light,
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor/interior/wood/alt,
+/area/desert_dam/building/bar/bar)
 "mar" = (
 /obj/structure/surface/rack,
 /obj/effect/spawner/random/tech_supply,
@@ -63723,14 +63592,6 @@
 	icon_state = "cement_sunbleached13"
 	},
 /area/desert_dam/exterior/valley/valley_labs)
-"qwZ" = (
-/obj/structure/bed/chair,
-/obj/effect/landmark/survivor_spawner,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "bright_clean2"
-	},
-/area/desert_dam/building/medical/surgury_observation)
 "qxv" = (
 /obj/structure/machinery/colony_floodlight,
 /turf/open/desert/dirt,
@@ -63928,15 +63789,6 @@
 "rdW" = (
 /turf/open/asphalt,
 /area/desert_dam/exterior/valley/valley_hydro)
-"rdX" = (
-/obj/structure/bed/chair{
-	dir = 1
-	},
-/obj/effect/landmark/survivor_spawner,
-/turf/open/floor{
-	icon_state = "white"
-	},
-/area/desert_dam/interior/dam_interior/garage)
 "rfm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human,
@@ -64967,6 +64819,10 @@
 /obj/structure/surface/rack,
 /turf/open/floor/plating,
 /area/desert_dam/building/cafeteria/backroom)
+"uys" = (
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor/interior/tatami,
+/area/desert_dam/building/bar/bar)
 "uzL" = (
 /turf/open/desert/dirt{
 	dir = 5;
@@ -65229,12 +65085,6 @@
 	},
 /turf/open/asphalt,
 /area/desert_dam/exterior/valley/valley_telecoms)
-"vxt" = (
-/obj/effect/landmark/survivor_spawner,
-/turf/open/floor{
-	icon_state = "freezerfloor"
-	},
-/area/desert_dam/building/water_treatment_one/breakroom)
 "vzj" = (
 /turf/open/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached18"
@@ -69160,7 +69010,7 @@ csp
 ckv
 cmZ
 cqd
-cuB
+cih
 cvF
 cvF
 cvF
@@ -70290,7 +70140,7 @@ bou
 aUr
 bgz
 bgz
-bzW
+bgz
 bgz
 bgz
 bgz
@@ -71416,7 +71266,7 @@ bLW
 bNZ
 bLW
 bPP
-bQW
+bLW
 bKt
 bVf
 bLW
@@ -71635,7 +71485,7 @@ bhu
 bzi
 bzi
 bTA
-bVj
+bTA
 bzi
 bzi
 bzi
@@ -72831,7 +72681,7 @@ aLX
 dTs
 arF
 gxo
-rdX
+wsD
 pzd
 sfK
 ebZ
@@ -73715,7 +73565,7 @@ aSa
 bhy
 bhz
 bhz
-biI
+bhz
 bhz
 bhz
 bhz
@@ -77941,7 +77791,7 @@ dTs
 bni
 bnN
 bDi
-bEo
+bDi
 bDi
 bDi
 bDi
@@ -78017,7 +77867,7 @@ aTR
 aNH
 bAa
 bBV
-bHu
+bvD
 bvD
 bKR
 bNw
@@ -79070,7 +78920,7 @@ aSn
 aSq
 afq
 bdE
-aZy
+aWl
 aWl
 dJL
 aWl
@@ -79227,7 +79077,7 @@ cJk
 cJg
 cJg
 cJg
-hTg
+cJg
 cJg
 cNZ
 cJg
@@ -80646,7 +80496,7 @@ aKT
 doE
 bpY
 bRA
-cms
+brL
 cne
 brL
 cps
@@ -80660,7 +80510,7 @@ cZB
 cIq
 cWX
 cYz
-cZy
+cVN
 cVN
 deQ
 deP
@@ -81724,7 +81574,7 @@ bOY
 bYE
 bZm
 dEb
-dKs
+dEb
 dKW
 bZX
 lkZ
@@ -83342,7 +83192,7 @@ cts
 bHa
 bHa
 bHa
-cqu
+ciT
 ciT
 csL
 ckT
@@ -83618,11 +83468,11 @@ bTs
 adt
 ceF
 cgA
-cik
+gnl
 csy
 cEb
 cPY
-cij
+cRP
 cgA
 cQR
 cRt
@@ -84090,11 +83940,11 @@ cit
 cvs
 cFC
 cil
-cil
+hul
 cij
 cij
 cRz
-cRI
+lYx
 adw
 lNu
 lNu
@@ -84320,10 +84170,10 @@ adt
 adt
 adw
 chk
-cij
+cRP
 cvt
 cFD
-cxi
+uys
 cil
 cvt
 cQT
@@ -84439,7 +84289,7 @@ axJ
 aGz
 aHo
 aIf
-aKV
+aIN
 vpR
 aJt
 aLc
@@ -84554,7 +84404,7 @@ ccc
 cdr
 ceL
 cgy
-ckq
+cik
 cvu
 cFF
 cQa
@@ -85030,7 +84880,7 @@ cij
 cij
 cij
 cRz
-cil
+hul
 but
 lNu
 lNu
@@ -85255,8 +85105,8 @@ bcn
 ccc
 cdZ
 ceN
-cgy
-cij
+lSJ
+cRP
 cxg
 cFN
 cQd
@@ -85732,7 +85582,7 @@ cij
 cxi
 cRa
 cRF
-cij
+cRP
 but
 sHk
 lNu
@@ -85959,14 +85809,14 @@ ceb
 ceN
 cgy
 cng
-cij
+cRP
 cFL
 cil
 cQD
 cil
 cij
-cij
-cij
+cRP
+cRP
 but
 lNu
 lNu
@@ -86570,7 +86420,7 @@ ame
 bcU
 bdp
 bdj
-beh
+bef
 bex
 bex
 bfd
@@ -86865,7 +86715,7 @@ dTs
 dTs
 aEa
 aCl
-aCv
+aCA
 aEa
 aCA
 aCW
@@ -87209,7 +87059,7 @@ dtu
 dtp
 dyb
 dAn
-vxt
+dAn
 ecN
 dwl
 dyb
@@ -89289,7 +89139,7 @@ dUg
 dDQ
 dbs
 dUA
-dUF
+dTP
 deu
 dbn
 dbu
@@ -91177,7 +91027,7 @@ fdk
 hOK
 die
 drQ
-dsc
+dqV
 eak
 edP
 eaO
@@ -92078,7 +91928,7 @@ cQA
 cPL
 cPL
 cTO
-cUs
+cTO
 cTO
 cTO
 cVV
@@ -94096,7 +93946,7 @@ bvk
 bwv
 bwv
 bwv
-bzP
+bwv
 bwv
 bwv
 btQ
@@ -95607,7 +95457,7 @@ dTY
 dUr
 dUr
 dTX
-dUJ
+dTX
 dUq
 dUr
 dcY
@@ -98305,7 +98155,7 @@ bse
 bsN
 bsN
 bvn
-bwz
+bsN
 bsN
 bsN
 cYp
@@ -99312,7 +99162,7 @@ crA
 cCf
 cDi
 cEj
-gak
+cDp
 cCi
 cCi
 cHz
@@ -103747,7 +103597,7 @@ dPJ
 crR
 ctZ
 cvb
-qwZ
+cvW
 cwQ
 cxE
 cyh
@@ -108214,7 +108064,7 @@ cKG
 cIT
 cMa
 cNd
-kEq
+cNM
 dTh
 cLp
 cPQ
@@ -109136,7 +108986,7 @@ dTs
 dTs
 czO
 cAE
-cBC
+cCA
 cCA
 cDz
 dRk

--- a/maps/map_files/FOP_v3_Sciannex/Fiorina_SciAnnex.dmm
+++ b/maps/map_files/FOP_v3_Sciannex/Fiorina_SciAnnex.dmm
@@ -2016,12 +2016,6 @@
 	icon_state = "greenfull"
 	},
 /area/fiorina/tumor/civres)
-"aZZ" = (
-/obj/effect/landmark/survivor_spawner,
-/turf/open/floor/prison{
-	icon_state = "darkpurplefull2"
-	},
-/area/fiorina/station/research_cells)
 "bac" = (
 /obj/item/stack/sheet/wood{
 	pixel_x = 1;
@@ -3587,6 +3581,12 @@
 /obj/structure/machinery/newscaster,
 /turf/closed/wall/prison,
 /area/fiorina/station/civres_blue)
+"ccM" = (
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor/prison{
+	icon_state = "floor_plate"
+	},
+/area/fiorina/station/central_ring)
 "cdD" = (
 /turf/open/floor/prison{
 	dir = 1;
@@ -4638,10 +4638,6 @@
 	name = "astroturf"
 	},
 /area/fiorina/tumor/fiberbush)
-"cJW" = (
-/obj/effect/landmark/survivor_spawner,
-/turf/open/floor/carpet,
-/area/fiorina/station/security/wardens)
 "cKa" = (
 /turf/closed/wall/prison,
 /area/fiorina/station/research_cells)
@@ -4819,13 +4815,6 @@
 	icon_state = "darkpurplefull2"
 	},
 /area/fiorina/tumor/servers)
-"cRs" = (
-/obj/effect/landmark/survivor_spawner,
-/turf/open/floor/prison{
-	dir = 4;
-	icon_state = "blue"
-	},
-/area/fiorina/station/power_ring)
 "cRB" = (
 /obj/structure/machinery/door/airlock/prison/horizontal{
 	density = 0;
@@ -6122,10 +6111,6 @@
 	icon_state = "floor_plate"
 	},
 /area/fiorina/station/telecomm/lz1_cargo)
-"dCF" = (
-/obj/effect/landmark/survivor_spawner,
-/turf/open/floor/prison,
-/area/fiorina/station/power_ring)
 "dCM" = (
 /obj/structure/window/framed/prison/reinforced/hull,
 /turf/open/floor/plating/prison,
@@ -6392,10 +6377,6 @@
 	icon_state = "floor_plate"
 	},
 /area/fiorina/tumor/civres)
-"dKX" = (
-/obj/effect/landmark/survivor_spawner,
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/fiorina/maintenance)
 "dLq" = (
 /obj/structure/bed/chair/comfy{
 	dir = 1
@@ -8386,6 +8367,10 @@
 	icon_state = "sterile_white"
 	},
 /area/fiorina/station/medbay)
+"fcf" = (
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/fiorina/station/central_ring)
 "fcp" = (
 /obj/item/trash/burger,
 /obj/effect/landmark/monkey_spawn,
@@ -8730,12 +8715,6 @@
 	icon_state = "whitepurple"
 	},
 /area/fiorina/station/research_cells)
-"fmM" = (
-/obj/effect/landmark/survivor_spawner,
-/turf/open/floor/prison{
-	icon_state = "floor_plate"
-	},
-/area/fiorina/station/power_ring)
 "fmU" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison{
@@ -13153,6 +13132,13 @@
 	icon_state = "doubleside"
 	},
 /area/fiorina/maintenance)
+"hUP" = (
+/obj/effect/landmark/survivor_spawner,
+/turf/open/organic/grass{
+	desc = "It'll get in your shoes no matter what you do.";
+	name = "astroturf"
+	},
+/area/fiorina/station/central_ring)
 "hUV" = (
 /obj/item/clothing/head/helmet/marine/veteran/ua_riot,
 /turf/open/floor/prison{
@@ -15571,12 +15557,6 @@
 	icon_state = "yellow"
 	},
 /area/fiorina/station/lowsec)
-"jsE" = (
-/obj/effect/landmark/survivor_spawner,
-/turf/open/floor/prison{
-	icon_state = "floor_plate"
-	},
-/area/fiorina/station/lowsec)
 "jta" = (
 /obj/structure/bed{
 	icon_state = "psychbed"
@@ -15615,12 +15595,6 @@
 	icon_state = "greenfull"
 	},
 /area/fiorina/station/botany)
-"juS" = (
-/obj/effect/landmark/survivor_spawner,
-/turf/open/floor/prison{
-	icon_state = "floor_plate"
-	},
-/area/fiorina/station/security)
 "juW" = (
 /obj/item/reagent_container/food/snacks/meat,
 /turf/open/floor/prison,
@@ -15760,7 +15734,6 @@
 /obj/item/ammo_casing{
 	icon_state = "cartridge_1"
 	},
-/obj/effect/landmark/survivor_spawner,
 /turf/open/floor/prison,
 /area/fiorina/station/medbay)
 "jAW" = (
@@ -16645,6 +16618,13 @@
 	icon_state = "floor_plate"
 	},
 /area/fiorina/station/lowsec)
+"kar" = (
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor/prison{
+	icon_state = "floor_plate"
+	},
+/area/fiorina/station/central_ring)
 "kau" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/stool{
@@ -21528,12 +21508,6 @@
 /obj/item/tool/warning_cone,
 /turf/open/floor/plating/prison,
 /area/fiorina/maintenance)
-"mTS" = (
-/obj/effect/landmark/survivor_spawner,
-/turf/open/floor/prison{
-	icon_state = "darkredfull2"
-	},
-/area/fiorina/station/research_cells)
 "mTX" = (
 /turf/open/floor/prison{
 	dir = 8;
@@ -26383,12 +26357,6 @@
 	icon_state = "greenfull"
 	},
 /area/fiorina/station/chapel)
-"pYO" = (
-/obj/effect/landmark/survivor_spawner,
-/turf/open/floor/prison{
-	icon_state = "darkyellowcorners2"
-	},
-/area/fiorina/station/telecomm/lz1_cargo)
 "pZb" = (
 /turf/open/floor/prison{
 	dir = 8;
@@ -27726,6 +27694,16 @@
 	icon_state = "floor_plate"
 	},
 /area/fiorina/tumor/aux_engi)
+"qNs" = (
+/obj/structure/flora/bush/ausbushes/grassybush{
+	icon_state = "lavendergrass_1"
+	},
+/obj/effect/landmark/survivor_spawner,
+/turf/open/organic/grass{
+	desc = "It'll get in your shoes no matter what you do.";
+	name = "astroturf"
+	},
+/area/fiorina/station/central_ring)
 "qNv" = (
 /obj/structure/machinery/door/airlock/prison_hatch/autoname{
 	dir = 1
@@ -31622,13 +31600,6 @@
 	icon_state = "yellow"
 	},
 /area/fiorina/station/lowsec)
-"tnr" = (
-/obj/effect/landmark/survivor_spawner,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "whitegreenfull"
-	},
-/area/fiorina/station/medbay)
 "tnA" = (
 /obj/structure/platform,
 /obj/structure/machinery/light/double/blue{
@@ -32687,12 +32658,6 @@
 /obj/structure/window/framed/prison/reinforced/hull,
 /turf/open/floor/plating/prison,
 /area/fiorina/station/medbay)
-"tQJ" = (
-/obj/effect/landmark/survivor_spawner,
-/turf/open/floor/prison{
-	icon_state = "darkbrown2"
-	},
-/area/fiorina/station/park)
 "tQL" = (
 /obj/structure/platform{
 	dir = 1
@@ -34199,13 +34164,6 @@
 	icon_state = "whitegreen"
 	},
 /area/fiorina/station/medbay)
-"uRe" = (
-/obj/effect/landmark/survivor_spawner,
-/turf/open/floor/prison{
-	dir = 10;
-	icon_state = "floor_plate"
-	},
-/area/fiorina/station/disco)
 "uRu" = (
 /turf/open/floor/prison{
 	dir = 4;
@@ -37502,10 +37460,6 @@
 	icon_state = "floor_plate"
 	},
 /area/fiorina/station/telecomm/lz1_cargo)
-"wQs" = (
-/obj/effect/landmark/survivor_spawner,
-/turf/open/floor/prison,
-/area/fiorina/station/park)
 "wQN" = (
 /obj/structure/machinery/floodlight/landing/floor,
 /turf/open/floor/plating/prison,
@@ -38970,6 +38924,10 @@
 "xKX" = (
 /turf/open/floor/plating/prison,
 /area/fiorina/station/disco)
+"xKY" = (
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor/prison,
+/area/fiorina/station/central_ring)
 "xLa" = (
 /turf/open/floor/prison{
 	dir = 4;
@@ -54377,7 +54335,7 @@ bDN
 bDN
 bDN
 gqH
-tQJ
+ajK
 dqa
 sbf
 vhI
@@ -63072,7 +63030,7 @@ uGM
 uGM
 uGM
 uGM
-wQs
+uGM
 uGM
 eLu
 cME
@@ -64149,7 +64107,7 @@ afk
 iWq
 tPN
 cWR
-dKX
+gfo
 gfo
 aXM
 bTG
@@ -68149,7 +68107,7 @@ fnB
 xnR
 gIB
 fnB
-juS
+sRV
 fnB
 fYB
 vUv
@@ -68262,7 +68220,7 @@ trH
 kqz
 fPZ
 fPZ
-tnr
+fPZ
 fPZ
 fPZ
 kqz
@@ -69451,7 +69409,7 @@ ipa
 rJO
 rJO
 ipa
-cJW
+rJO
 rTH
 bMh
 ewx
@@ -69997,7 +69955,7 @@ qbr
 vPM
 mGe
 vPM
-tvI
+hUP
 tvI
 tvI
 tvI
@@ -70207,12 +70165,12 @@ tvI
 tvI
 tvI
 vPM
-dGw
+xKY
 vPM
 tvI
 tvI
 tvI
-tvI
+hUP
 tvI
 tvI
 tvI
@@ -70417,11 +70375,11 @@ tvI
 tvI
 tvI
 oKQ
-tvI
+hUP
 vPM
 mGe
 vPM
-tvI
+hUP
 oKQ
 tvI
 tvI
@@ -70678,7 +70636,7 @@ tHs
 fnB
 fnB
 pTj
-juS
+sRV
 gmS
 dhs
 sYP
@@ -70840,16 +70798,16 @@ vPM
 vPM
 vPM
 vPM
+ccM
 vPM
-vPM
-vPM
+ccM
 dGw
+ccM
+vPM
+ccM
 vPM
 vPM
-vPM
-vPM
-vPM
-vPM
+ccM
 vPM
 sYe
 tJT
@@ -71266,11 +71224,11 @@ vPM
 vPM
 vPM
 vPM
-jZx
+kar
 dGw
-vPM
+ccM
 dHI
-vPM
+ccM
 vPM
 vPM
 vPM
@@ -71476,13 +71434,13 @@ tvI
 tvI
 tvI
 tvI
-tvI
+hUP
 tvI
 vPM
-mGe
+fcf
 vPM
 tvI
-tvI
+hUP
 tvI
 tvI
 tvI
@@ -71690,13 +71648,13 @@ tvI
 tvI
 oKQ
 tvI
-vPM
+ccM
 mGe
 vPM
-tvI
+hUP
 oKQ
 tvI
-vYE
+qNs
 tvI
 xXw
 hVS
@@ -71904,7 +71862,7 @@ tvI
 rxu
 vPM
 dGw
-vPM
+ccM
 tvI
 tvI
 rxu
@@ -74891,7 +74849,7 @@ glW
 vei
 mcc
 mcc
-jsE
+mcc
 mcc
 mcc
 mcc
@@ -76825,7 +76783,7 @@ lAS
 lAS
 uyq
 lAS
-dCF
+lAS
 lAS
 mxQ
 nmT
@@ -77192,7 +77150,7 @@ kPz
 bQM
 jmG
 wQh
-mTS
+mIE
 jas
 uhm
 ebP
@@ -78859,7 +78817,7 @@ ikq
 dyM
 cKa
 uvh
-aZZ
+vJD
 vJD
 cKa
 ikq
@@ -79164,7 +79122,7 @@ uZX
 oYM
 kvd
 ihA
-fmM
+oYM
 oYM
 mxQ
 mxQ
@@ -83202,7 +83160,7 @@ nVq
 rev
 oYM
 pmo
-cRs
+nLl
 nLl
 lAS
 oYM
@@ -83340,7 +83298,7 @@ iSQ
 tHP
 ilv
 jLs
-pYO
+mDV
 iSQ
 fCz
 iEz
@@ -83997,7 +83955,7 @@ bzG
 lEz
 waz
 bEX
-uRe
+mQZ
 mQZ
 bhX
 aRG
@@ -84243,7 +84201,7 @@ kfA
 qos
 wAv
 beV
-fmM
+oYM
 oYM
 lXf
 uod

--- a/maps/map_files/Kutjevo/Kutjevo.dmm
+++ b/maps/map_files/Kutjevo/Kutjevo.dmm
@@ -1294,7 +1294,6 @@
 /area/kutjevo/interior/colony_S_East)
 "bPf" = (
 /obj/structure/platform_decoration/kutjevo,
-/obj/effect/landmark/survivor_spawner,
 /turf/open/floor/plating/kutjevo,
 /area/kutjevo/interior/foremans_office)
 "bPV" = (
@@ -1945,6 +1944,11 @@
 	dir = 8
 	},
 /area/kutjevo/exterior/runoff_dunes)
+"cKj" = (
+/obj/effect/landmark/objective_landmark/science,
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor/kutjevo/tan,
+/area/kutjevo/interior/construction)
 "cKH" = (
 /obj/structure/platform_decoration/kutjevo{
 	dir = 8
@@ -2826,6 +2830,7 @@
 /obj/structure/bed/chair{
 	dir = 4
 	},
+/obj/effect/landmark/survivor_spawner,
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
 "dLR" = (
@@ -7010,10 +7015,6 @@
 /obj/item/stack/sheet/wood,
 /turf/open/floor/kutjevo/tan/multi_tiles,
 /area/kutjevo/interior/power/comms)
-"jGX" = (
-/obj/effect/landmark/survivor_spawner,
-/turf/open/floor/kutjevo/colors,
-/area/kutjevo/interior/complex/botany)
 "jIt" = (
 /obj/structure/platform/kutjevo{
 	dir = 1
@@ -7630,7 +7631,6 @@
 /area/kutjevo/interior/colony_north)
 "kDl" = (
 /obj/structure/bed/chair/office/light,
-/obj/effect/landmark/survivor_spawner,
 /obj/structure/machinery/computer/cameras/telescreen/entertainment{
 	icon_state = "ai_bsod";
 	pixel_y = 32
@@ -8612,7 +8612,6 @@
 	},
 /area/kutjevo/interior/oob)
 "lYW" = (
-/obj/effect/landmark/survivor_spawner,
 /turf/open/floor/kutjevo/colors,
 /area/kutjevo/interior/complex/med)
 "lZz" = (
@@ -10706,10 +10705,6 @@
 /obj/effect/landmark/hunter_primary,
 /turf/open/auto_turf/sand/layer0,
 /area/kutjevo/exterior/scrubland)
-"oMw" = (
-/obj/effect/landmark/survivor_spawner,
-/turf/open/floor/kutjevo/colors/orange,
-/area/kutjevo/interior/foremans_office)
 "oMS" = (
 /obj/structure/stairs/perspective/kutjevo{
 	dir = 1;
@@ -11573,10 +11568,6 @@
 	},
 /turf/open/floor/kutjevo/colors/orange,
 /area/kutjevo/interior/power)
-"pOI" = (
-/obj/effect/landmark/survivor_spawner,
-/turf/open/floor/kutjevo/colors/cyan,
-/area/kutjevo/interior/complex/med)
 "pPn" = (
 /obj/item/stack/sheet/wood,
 /obj/effect/landmark/objective_landmark/close,
@@ -11745,6 +11736,11 @@
 "qev" = (
 /obj/item/trash/chunk,
 /turf/open/auto_turf/sand/layer2,
+/area/kutjevo/interior/construction)
+"qeN" = (
+/obj/effect/landmark/survivor_spawner,
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
 "qfw" = (
 /obj/structure/barricade/wooden{
@@ -12670,10 +12666,6 @@
 /obj/item/ammo_magazine/rifle/m16,
 /turf/open/floor/kutjevo/tan/multi_tiles,
 /area/kutjevo/interior/complex/botany)
-"rxr" = (
-/obj/effect/landmark/survivor_spawner,
-/turf/open/floor/kutjevo/tan,
-/area/kutjevo/interior/power_pt2_electric_boogaloo)
 "rxX" = (
 /obj/effect/spawner/random/toolbox{
 	pixel_x = -2;
@@ -14160,6 +14152,10 @@
 /obj/structure/bed/chair/office/light,
 /turf/open/floor/kutjevo/grey/plate,
 /area/kutjevo/interior/complex/botany/east_tech)
+"tyQ" = (
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor/kutjevo/tan,
+/area/kutjevo/interior/construction)
 "tyW" = (
 /obj/item/weapon/gun/revolver/cmb,
 /turf/open/floor/kutjevo/tan,
@@ -14375,7 +14371,6 @@
 /obj/structure/barricade/deployable{
 	dir = 8
 	},
-/obj/effect/landmark/survivor_spawner,
 /obj/structure/bed/chair{
 	dir = 8
 	},
@@ -16000,6 +15995,7 @@
 /obj/structure/bed/chair{
 	dir = 8
 	},
+/obj/effect/landmark/survivor_spawner,
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
 "vQJ" = (
@@ -16573,10 +16569,6 @@
 /obj/item/trash/barcardine,
 /turf/open/auto_turf/sand/layer1,
 /area/kutjevo/interior/colony_central)
-"wIG" = (
-/obj/effect/landmark/survivor_spawner,
-/turf/open/floor/kutjevo/multi_tiles,
-/area/kutjevo/interior/power)
 "wJZ" = (
 /obj/structure/flora/grass/desert/lightgrass_4,
 /obj/structure/blocker/invisible_wall,
@@ -26412,7 +26404,7 @@ hQj
 hQj
 xgV
 pnM
-wIG
+hQj
 hQj
 ips
 pyp
@@ -36673,7 +36665,7 @@ gld
 msK
 gwY
 klP
-pOI
+snr
 gLg
 jzl
 qXd
@@ -36691,7 +36683,7 @@ fpO
 lHs
 tIy
 nLC
-jGX
+cAt
 tRp
 igE
 nhT
@@ -38039,7 +38031,7 @@ xRh
 frx
 xRh
 eVv
-rxr
+rQY
 qJx
 cqc
 dip
@@ -38540,7 +38532,7 @@ xRh
 xRh
 xRh
 eVv
-rxr
+rQY
 pxb
 kHO
 dip
@@ -38997,10 +38989,10 @@ alo
 vfr
 hkq
 dKO
-euj
-euj
-euj
-euj
+tyQ
+qeN
+tyQ
+tyQ
 sCG
 mYM
 vKQ
@@ -39330,11 +39322,11 @@ mDm
 qaI
 mDz
 euj
-euj
-hma
-euj
-euj
-euj
+tyQ
+cKj
+tyQ
+tyQ
+tyQ
 sCG
 twn
 vFc
@@ -39664,11 +39656,11 @@ fyF
 qaI
 iLU
 oMW
-euj
+tyQ
 bKm
 vMf
 fEz
-euj
+tyQ
 txH
 qaI
 eQQ
@@ -39835,7 +39827,7 @@ qOM
 euj
 vQg
 vQg
-euj
+tyQ
 sCG
 mYM
 avT
@@ -40505,7 +40497,7 @@ oUh
 nFM
 cgJ
 hmR
-oMw
+lly
 agG
 nFM
 vFc

--- a/maps/map_files/LV624/LV624.dmm
+++ b/maps/map_files/LV624/LV624.dmm
@@ -2928,10 +2928,6 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/gm/coast/beachcorner2/south_east,
 /area/lv624/ground/river/west_river)
-"aph" = (
-/obj/effect/landmark/survivor_spawner,
-/turf/open/gm/grass/grass1,
-/area/lv624/ground/jungle/west_jungle)
 "apl" = (
 /obj/structure/fence,
 /turf/open/gm/grass/grass1,
@@ -3257,10 +3253,6 @@
 "arE" = (
 /turf/open/gm/dirtgrassborder/grassdirt_corner2/north_east,
 /area/lv624/ground/jungle/west_jungle)
-"arG" = (
-/obj/effect/landmark/survivor_spawner,
-/turf/open/gm/dirt,
-/area/lv624/lazarus/quartstorage/outdoors)
 "arH" = (
 /obj/structure/girder/displaced,
 /turf/open/gm/dirt,
@@ -3607,12 +3599,6 @@
 	amount = 2
 	},
 /turf/open/floor/vault,
-/area/lv624/lazarus/quartstorage)
-"atF" = (
-/obj/effect/landmark/survivor_spawner,
-/turf/open/floor{
-	icon_state = "dark"
-	},
 /area/lv624/lazarus/quartstorage)
 "atG" = (
 /obj/structure/machinery/light/small{
@@ -4467,13 +4453,6 @@
 /obj/item/storage/toolbox/mechanical,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/north_west_jungle)
-"awG" = (
-/obj/effect/landmark/survivor_spawner,
-/turf/open/floor{
-	dir = 5;
-	icon_state = "whitepurple"
-	},
-/area/lv624/lazarus/research)
 "awH" = (
 /obj/item/prop/alien/hugger,
 /turf/open/floor{
@@ -4664,10 +4643,6 @@
 	icon_state = "wood-broken"
 	},
 /area/lv624/ground/caves/north_central_caves)
-"axp" = (
-/obj/effect/landmark/survivor_spawner,
-/turf/open/floor/wood,
-/area/lv624/ground/jungle/west_jungle/ceiling)
 "axt" = (
 /turf/open/floor{
 	dir = 9;
@@ -4968,6 +4943,7 @@
 	pixel_x = 2;
 	pixel_y = 2
 	},
+/obj/effect/landmark/survivor_spawner,
 /turf/open/floor{
 	dir = 4;
 	icon_state = "whitepurplecorner"
@@ -5964,7 +5940,6 @@
 /obj/structure/bed/chair/comfy/lime{
 	dir = 1
 	},
-/obj/effect/landmark/survivor_spawner,
 /obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
 /turf/open/floor{
 	dir = 9;
@@ -6287,10 +6262,6 @@
 /obj/structure/bed/chair/wood/normal,
 /turf/open/floor/wood,
 /area/lv624/ground/caves/north_central_caves)
-"aCI" = (
-/obj/effect/landmark/survivor_spawner,
-/turf/open/gm/dirt,
-/area/lv624/lazarus/landing_zones/lz2)
 "aCK" = (
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/plating{
@@ -6448,7 +6419,6 @@
 /obj/structure/bed/chair/comfy/orange{
 	dir = 1
 	},
-/obj/effect/landmark/survivor_spawner,
 /turf/open/floor{
 	icon_state = "bluecorner"
 	},
@@ -6785,7 +6755,6 @@
 	icon_state = "coffin_open";
 	opened = 1
 	},
-/obj/effect/landmark/survivor_spawner,
 /obj/structure/pipes/standard/simple/hidden/cyan{
 	dir = 4
 	},
@@ -7011,15 +6980,6 @@
 /obj/structure/toilet{
 	dir = 8
 	},
-/turf/open/floor{
-	icon_state = "freezerfloor"
-	},
-/area/lv624/lazarus/toilet)
-"aFk" = (
-/obj/structure/machinery/shower{
-	dir = 4
-	},
-/obj/effect/landmark/survivor_spawner,
 /turf/open/floor{
 	icon_state = "freezerfloor"
 	},
@@ -7324,12 +7284,6 @@
 /area/lv624/ground/jungle/west_central_jungle)
 "aGm" = (
 /obj/effect/glowshroom,
-/turf/open/floor{
-	icon_state = "freezerfloor"
-	},
-/area/lv624/lazarus/toilet)
-"aGn" = (
-/obj/effect/landmark/survivor_spawner,
 /turf/open/floor{
 	icon_state = "freezerfloor"
 	},
@@ -8532,18 +8486,6 @@
 /obj/effect/landmark/xeno_spawn,
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/west_caves)
-"aLs" = (
-/obj/effect/landmark/survivor_spawner,
-/turf/open/floor/plating{
-	icon_state = "platebot"
-	},
-/area/lv624/lazarus/robotics)
-"aLt" = (
-/obj/effect/landmark/survivor_spawner,
-/turf/open/floor{
-	icon_state = "vault"
-	},
-/area/lv624/lazarus/robotics)
 "aLv" = (
 /turf/open/gm/grass/grass2,
 /area/lv624/ground/jungle/central_jungle)
@@ -9283,13 +9225,6 @@
 /obj/structure/pipes/standard/simple/hidden/cyan,
 /turf/open/floor/grass,
 /area/lv624/lazarus/main_hall)
-"aON" = (
-/obj/effect/landmark/survivor_spawner,
-/turf/open/floor{
-	dir = 9;
-	icon_state = "brown"
-	},
-/area/lv624/lazarus/comms)
 "aOO" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -9564,10 +9499,6 @@
 /obj/structure/window/framed/colony/reinforced,
 /turf/open/floor/plating,
 /area/lv624/lazarus/comms)
-"aPU" = (
-/obj/effect/landmark/survivor_spawner,
-/turf/open/gm/river,
-/area/lv624/lazarus/yggdrasil)
 "aPV" = (
 /obj/structure/flora/bush/ausbushes/var3/fernybush,
 /obj/structure/flora/jungle/vines/light_1,
@@ -10556,10 +10487,6 @@
 	icon_state = "platebot"
 	},
 /area/lv624/lazarus/engineering)
-"aTS" = (
-/obj/effect/landmark/survivor_spawner,
-/turf/open/gm/dirt,
-/area/lv624/ground/colony/north_tcomms_road)
 "aTU" = (
 /obj/effect/decal/remains/xeno,
 /obj/structure/flora/grass/tallgrass/jungle/corner{
@@ -12237,12 +12164,6 @@
 /obj/structure/prop/mech/drill,
 /turf/open/floor/greengrid,
 /area/lv624/lazarus/secure_storage)
-"aZM" = (
-/obj/effect/landmark/survivor_spawner,
-/turf/open/floor{
-	icon_state = "dark"
-	},
-/area/lv624/lazarus/engineering)
 "aZO" = (
 /obj/effect/landmark/xeno_spawn,
 /turf/open/gm/dirt,
@@ -12744,6 +12665,13 @@
 /obj/effect/landmark/crap_item,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/colony/west_tcomms_road)
+"bTp" = (
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "warnwhite"
+	},
+/area/lv624/lazarus/fitness)
 "bTw" = (
 /obj/effect/landmark/nightmare{
 	insert_tag = "cargospecial"
@@ -16213,6 +16141,13 @@
 	},
 /turf/open/gm/dirt,
 /area/lv624/ground/jungle/east_jungle)
+"kHp" = (
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "warnwhite"
+	},
+/area/lv624/lazarus/fitness)
 "kHB" = (
 /turf/open/gm/dirt{
 	icon_state = "desert3"
@@ -17172,10 +17107,6 @@
 /obj/structure/flora/jungle/vines/light_1,
 /turf/closed/wall/r_wall,
 /area/lv624/lazarus/corporate_dome)
-"nfD" = (
-/obj/effect/landmark/survivor_spawner,
-/turf/open/gm/dirt,
-/area/lv624/ground/colony/south_nexus_road)
 "nfK" = (
 /obj/structure/flora/jungle/vines/heavy,
 /turf/closed/wall/strata_ice/jungle,
@@ -18474,10 +18405,6 @@
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/gm/dirt,
 /area/lv624/ground/barrens/north_east_barrens)
-"pHx" = (
-/obj/effect/landmark/survivor_spawner,
-/turf/open/gm/dirt,
-/area/lv624/ground/colony/west_tcomms_road)
 "pHA" = (
 /obj/structure/surface/table/reinforced/prison,
 /turf/open/floor{
@@ -27447,7 +27374,7 @@ aAp
 asc
 aAp
 aAp
-aph
+aro
 ayT
 ayT
 aAp
@@ -28112,7 +28039,7 @@ aqi
 ase
 aFm
 aZn
-axp
+auf
 auf
 aFm
 aAl
@@ -33149,7 +33076,7 @@ svh
 aXX
 aZP
 aDv
-aCI
+aDv
 aDv
 aRx
 twg
@@ -33405,7 +33332,7 @@ efp
 uSq
 qIO
 qIO
-pHx
+qIO
 ntL
 kxI
 kxI
@@ -33593,12 +33520,12 @@ axf
 axA
 axe
 ayF
-aLt
+axj
 axi
 axj
 ayF
 axe
-aLs
+axe
 aCk
 ado
 aXX
@@ -35414,7 +35341,7 @@ psh
 tLQ
 ado
 axe
-aLs
+axe
 axe
 ayF
 axj
@@ -37728,7 +37655,7 @@ cPV
 bCH
 aPT
 aQn
-aON
+aQn
 aQn
 aQn
 aQn
@@ -38604,7 +38531,7 @@ aum
 avq
 aum
 awl
-awG
+aum
 avq
 axF
 ayq
@@ -38860,7 +38787,7 @@ aJr
 aJr
 uiN
 byY
-aTS
+byY
 byY
 byY
 byY
@@ -38876,7 +38803,7 @@ aTg
 rVH
 aQn
 aQn
-aON
+aQn
 aQn
 aQn
 aPO
@@ -42057,7 +41984,7 @@ aMU
 aNF
 aOv
 aPh
-aPU
+aLN
 aQt
 aQo
 aSj
@@ -42483,7 +42410,7 @@ awx
 atX
 axt
 ayt
-ayt
+kHp
 ayt
 azj
 adp
@@ -42528,7 +42455,7 @@ aWF
 aSX
 aXs
 aTM
-aZM
+aTM
 aTM
 aXg
 kyN
@@ -42705,9 +42632,9 @@ udP
 atw
 axz
 atX
-atX
+awS
 avN
-atX
+awS
 atX
 axu
 ayv
@@ -42939,7 +42866,7 @@ atX
 atX
 axv
 axQ
-ayx
+bTp
 ayx
 azl
 atw
@@ -43161,14 +43088,14 @@ adp
 buo
 auD
 atX
+awS
+atX
+awS
+atX
+awS
 atX
 atX
-atX
-atX
-atX
-atX
-atX
-atX
+awS
 atX
 azL
 adp
@@ -43390,12 +43317,12 @@ atX
 auF
 auF
 avv
-aEn
 auF
+auF
+atX
+atX
+atX
 awS
-atX
-atX
-atX
 atX
 atX
 atX
@@ -43431,7 +43358,7 @@ xuk
 oUy
 aSL
 aTu
-aZM
+aTM
 aTM
 aVj
 aTM
@@ -43615,13 +43542,13 @@ udP
 udP
 atz
 atX
-auF
+aEn
 auE
 auE
 auE
-auF
+aEn
 atX
-atX
+awS
 atX
 ayy
 atX
@@ -43847,11 +43774,11 @@ auF
 auE
 avw
 auE
-auF
+aEn
 atX
 atX
 atX
-atX
+awS
 atX
 azm
 atw
@@ -44077,7 +44004,7 @@ auE
 auE
 auF
 atX
-atX
+awS
 atX
 avM
 atX
@@ -44301,9 +44228,9 @@ ppR
 atY
 auF
 auF
+aEn
 auF
-auF
-auF
+aEn
 atX
 atX
 atX
@@ -45462,7 +45389,7 @@ aDS
 aEA
 aGH
 aGH
-aGn
+aGH
 aGH
 aQF
 aDy
@@ -46144,7 +46071,7 @@ aAP
 aAU
 aDT
 aED
-aFk
+aFO
 aFO
 aGo
 aGJ
@@ -49595,7 +49522,7 @@ aWj
 azt
 yle
 yle
-nfD
+yle
 yle
 cqw
 jxG
@@ -51816,7 +51743,7 @@ cpY
 cpY
 aqG
 aqW
-arG
+aqW
 aqW
 aqW
 aqW
@@ -56150,7 +56077,7 @@ dLY
 dLY
 asN
 asN
-atF
+axa
 axa
 ati
 tfA

--- a/maps/map_files/New_Varadero/New_Varadero.dmm
+++ b/maps/map_files/New_Varadero/New_Varadero.dmm
@@ -598,13 +598,6 @@
 	icon_state = "multi_tiles"
 	},
 /area/varadero/interior/hall_SE)
-"avy" = (
-/obj/effect/landmark/survivor_spawner,
-/turf/open/floor/shiva{
-	dir = 1;
-	icon_state = "multi_tiles"
-	},
-/area/varadero/interior/administration)
 "avD" = (
 /turf/closed/wall/huntership,
 /area/varadero/interior_protected/vessel)
@@ -1450,15 +1443,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/varadero/interior_protected/maintenance/south)
-"aTS" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "W"
-	},
-/obj/effect/landmark/survivor_spawner,
-/turf/open/floor/shiva{
-	dir = 1
-	},
-/area/varadero/interior/cargo)
 "aTY" = (
 /obj/structure/prop/rock/brown,
 /turf/open/gm/river{
@@ -1894,9 +1878,7 @@
 /area/varadero/interior/hall_N)
 "bhU" = (
 /obj/structure/machinery/floodlight{
-	name = "Floodlight";
-	unacidable = 0;
-	wrenchable = 1
+	name = "Floodlight"
 	},
 /obj/structure/platform_decoration/kutjevo{
 	dir = 8
@@ -2587,7 +2569,6 @@
 	pixel_x = 7;
 	pixel_y = -6
 	},
-/obj/effect/landmark/survivor_spawner,
 /turf/open/floor/plating/icefloor{
 	icon_state = "asteroidplating"
 	},
@@ -4438,7 +4419,6 @@
 /obj/structure/bed/sofa/pews/flipped{
 	dir = 4
 	},
-/obj/effect/landmark/survivor_spawner,
 /turf/open/floor/carpet,
 /area/varadero/interior/chapel)
 "cOK" = (
@@ -4756,14 +4736,6 @@
 /obj/item/stack/tile/plasteel,
 /turf/open/auto_turf/sand_white/layer1,
 /area/varadero/interior/hall_SE)
-"daA" = (
-/obj/structure/bed/chair,
-/obj/effect/landmark/survivor_spawner,
-/turf/open/floor/shiva{
-	dir = 1;
-	icon_state = "green"
-	},
-/area/varadero/interior/court)
 "daS" = (
 /obj/structure/flora/bush/ausbushes/var3/stalkybush,
 /turf/open/gm/river{
@@ -5724,6 +5696,7 @@
 /obj/structure/bed/chair{
 	dir = 4
 	},
+/obj/effect/landmark/survivor_spawner,
 /turf/open/floor/shiva{
 	icon_state = "multi_tiles"
 	},
@@ -10717,9 +10690,7 @@
 /area/varadero/interior/security)
 "gRU" = (
 /obj/structure/machinery/floodlight{
-	name = "Floodlight";
-	unacidable = 0;
-	wrenchable = 1
+	name = "Floodlight"
 	},
 /turf/open/auto_turf/sand_white/layer1,
 /area/varadero/interior_protected/caves/digsite)
@@ -10877,12 +10848,6 @@
 "gYh" = (
 /turf/closed/wall/wood,
 /area/varadero/interior/beach_bar)
-"gZq" = (
-/obj/effect/landmark/survivor_spawner,
-/turf/open/floor/shiva{
-	icon_state = "floor3"
-	},
-/area/varadero/interior/morgue)
 "gZI" = (
 /obj/structure/filingcabinet{
 	density = 0;
@@ -11237,7 +11202,6 @@
 /area/varadero/interior/electrical)
 "hlw" = (
 /obj/effect/decal/cleanable/blood/drip,
-/obj/effect/landmark/survivor_spawner,
 /turf/open/floor/carpet,
 /area/varadero/interior/maintenance/north)
 "hlF" = (
@@ -11661,10 +11625,6 @@
 /obj/structure/largecrate/random/case/double,
 /turf/open/gm/dirt,
 /area/varadero/exterior/lz1_near)
-"hAh" = (
-/obj/effect/landmark/survivor_spawner,
-/turf/open/floor/wood,
-/area/varadero/interior/court)
 "hAI" = (
 /obj/structure/platform_decoration/kutjevo{
 	dir = 8
@@ -13252,6 +13212,13 @@
 	icon_state = "green"
 	},
 /area/varadero/interior/mess)
+"iBZ" = (
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor/shiva{
+	dir = 1;
+	icon_state = "multi_tiles"
+	},
+/area/varadero/interior/electrical)
 "iCy" = (
 /turf/open/floor/shiva{
 	icon_state = "multi_tiles"
@@ -13862,9 +13829,7 @@
 /area/varadero/interior/administration)
 "iWX" = (
 /obj/structure/machinery/floodlight{
-	name = "Floodlight";
-	unacidable = 0;
-	wrenchable = 1
+	name = "Floodlight"
 	},
 /turf/open/auto_turf/sand_white/layer1,
 /area/varadero/exterior/eastbeach)
@@ -15543,6 +15508,7 @@
 /obj/structure/bed/chair{
 	dir = 8
 	},
+/obj/effect/landmark/survivor_spawner,
 /turf/open/floor/shiva{
 	icon_state = "multi_tiles"
 	},
@@ -16012,7 +15978,6 @@
 /obj/structure/bed/chair/comfy/beige{
 	dir = 8
 	},
-/obj/effect/landmark/survivor_spawner,
 /turf/open/floor/carpet,
 /area/varadero/interior/chapel)
 "ksn" = (
@@ -16375,6 +16340,7 @@
 /obj/structure/bed/chair{
 	dir = 4
 	},
+/obj/effect/landmark/survivor_spawner,
 /turf/open/floor/shiva{
 	icon_state = "multi_tiles"
 	},
@@ -17766,15 +17732,6 @@
 	},
 /turf/open/gm/coast/beachcorner/north_west,
 /area/varadero/exterior/eastbeach)
-"lxr" = (
-/obj/structure/prop/invuln/minecart_tracks{
-	dir = 8
-	},
-/obj/effect/landmark/survivor_spawner,
-/turf/open/floor/plating/icefloor{
-	icon_state = "asteroidplating"
-	},
-/area/varadero/interior/comms1)
 "lxs" = (
 /obj/structure/flora/bush/ausbushes/var3/fernybush,
 /turf/open/gm/river{
@@ -18709,7 +18666,6 @@
 /obj/structure/bed/chair{
 	dir = 4
 	},
-/obj/effect/landmark/survivor_spawner,
 /turf/open/floor/plating/icefloor{
 	icon_state = "asteroidplating"
 	},
@@ -18719,7 +18675,6 @@
 	dir = 10;
 	icon_state = "bshell_"
 	},
-/obj/effect/landmark/survivor_spawner,
 /turf/open/floor/carpet,
 /area/varadero/interior/security)
 "map" = (
@@ -19324,9 +19279,7 @@
 /area/varadero/interior/cargo)
 "mtp" = (
 /obj/structure/machinery/floodlight{
-	name = "Floodlight";
-	unacidable = 0;
-	wrenchable = 1
+	name = "Floodlight"
 	},
 /turf/open/floor/plating/icefloor{
 	icon_state = "asteroidplating"
@@ -19414,9 +19367,7 @@
 /area/varadero/interior/hall_SE)
 "mvO" = (
 /obj/structure/machinery/floodlight{
-	name = "Floodlight";
-	unacidable = 0;
-	wrenchable = 1
+	name = "Floodlight"
 	},
 /turf/open/floor/shiva{
 	dir = 1;
@@ -19929,9 +19880,7 @@
 	dir = 1
 	},
 /obj/structure/machinery/floodlight{
-	name = "Floodlight";
-	unacidable = 0;
-	wrenchable = 1
+	name = "Floodlight"
 	},
 /turf/open/floor/shiva{
 	dir = 1;
@@ -20008,7 +19957,6 @@
 /area/varadero/interior/maintenance)
 "mPI" = (
 /obj/structure/pipes/standard/simple/hidden/green,
-/obj/effect/landmark/survivor_spawner,
 /turf/open/floor/shiva{
 	icon_state = "floor3"
 	},
@@ -20147,7 +20095,6 @@
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
 	},
-/obj/effect/landmark/survivor_spawner,
 /turf/open/floor/carpet,
 /area/varadero/interior/chapel)
 "mUz" = (
@@ -20285,6 +20232,7 @@
 /area/varadero/interior/hall_SE)
 "mYd" = (
 /obj/structure/bed/chair,
+/obj/effect/landmark/survivor_spawner,
 /turf/open/floor/shiva{
 	dir = 1;
 	icon_state = "multi_tiles"
@@ -20823,11 +20771,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/varadero/interior/maintenance/north)
-"npF" = (
-/obj/effect/landmark/survivor_spawner,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/varadero/interior/beach_bar)
 "npW" = (
 /obj/item/tool/warning_cone{
 	pixel_x = -8
@@ -21628,7 +21571,6 @@
 	pixel_x = 10;
 	pixel_y = -9
 	},
-/obj/effect/landmark/survivor_spawner,
 /turf/open/floor/shiva{
 	dir = 8;
 	icon_state = "bluefull"
@@ -21778,12 +21720,6 @@
 	dir = 1
 	},
 /area/varadero/interior/cargo)
-"nZd" = (
-/obj/effect/landmark/survivor_spawner,
-/turf/open/floor/shiva{
-	icon_state = "floor3"
-	},
-/area/varadero/interior/medical)
 "nZi" = (
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -21995,6 +21931,7 @@
 /obj/structure/bed/chair{
 	dir = 8
 	},
+/obj/effect/landmark/survivor_spawner,
 /turf/open/floor/shiva{
 	icon_state = "multi_tiles"
 	},
@@ -27779,6 +27716,7 @@
 /obj/structure/bed/chair{
 	dir = 1
 	},
+/obj/effect/landmark/survivor_spawner,
 /turf/open/floor/shiva{
 	dir = 1;
 	icon_state = "multi_tiles"
@@ -28740,7 +28678,6 @@
 "spP" = (
 /obj/structure/bed/chair,
 /obj/structure/pipes/standard/simple/hidden/green,
-/obj/effect/landmark/survivor_spawner,
 /turf/open/floor/shiva{
 	dir = 1;
 	icon_state = "green"
@@ -32581,7 +32518,6 @@
 /obj/item/storage/bible/booze{
 	pixel_x = 6
 	},
-/obj/effect/landmark/survivor_spawner,
 /turf/open/floor/carpet,
 /area/varadero/interior/chapel)
 "uUF" = (
@@ -45060,7 +44996,7 @@ huF
 huF
 nPx
 arC
-lxr
+wBY
 lMB
 wjB
 sGY
@@ -46173,7 +46109,7 @@ gsw
 qZH
 hUU
 rrA
-aTS
+wDG
 oJB
 wIm
 xqP
@@ -47288,7 +47224,7 @@ cAX
 vsP
 cAX
 kDF
-nZd
+maN
 maN
 maN
 maN
@@ -49459,7 +49395,7 @@ sKC
 iTd
 iTd
 dCz
-gZq
+eYG
 eYG
 uuj
 sFJ
@@ -50579,7 +50515,7 @@ qvo
 xUq
 jMr
 rQY
-avy
+rzg
 rzg
 rQY
 rzM
@@ -54388,7 +54324,7 @@ khb
 qLs
 iwg
 ara
-hAh
+ara
 nZk
 hPD
 uQH
@@ -54565,7 +54501,7 @@ urA
 lss
 rHv
 pVN
-daA
+cMf
 khb
 urd
 mwd
@@ -55114,7 +55050,7 @@ pVN
 cMf
 khb
 urd
-hAh
+ara
 ara
 ara
 nZk
@@ -57790,7 +57726,7 @@ ctE
 gYh
 xuJ
 fgW
-npF
+sKF
 trB
 gYh
 eBm
@@ -59474,10 +59410,10 @@ wOO
 mNm
 kCA
 tlT
-cbq
+iBZ
 dNU
 kDd
-cbq
+iBZ
 aFK
 kCA
 jaL
@@ -60566,10 +60502,10 @@ oSX
 uwQ
 kCA
 tlT
-cbq
+iBZ
 oga
 kca
-cbq
+iBZ
 tlT
 kCA
 rsB

--- a/maps/map_files/Sorokyne_Strata/Sorokyne_Strata.dmm
+++ b/maps/map_files/Sorokyne_Strata/Sorokyne_Strata.dmm
@@ -9631,6 +9631,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/blood,
+/obj/effect/landmark/survivor_spawner,
 /turf/open/floor/strata{
 	dir = 4;
 	icon_state = "white_cyan1"
@@ -9660,6 +9661,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/blood,
+/obj/effect/landmark/survivor_spawner,
 /turf/open/floor/strata{
 	dir = 4;
 	icon_state = "white_cyan1"
@@ -9943,6 +9945,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/blood,
+/obj/effect/landmark/survivor_spawner,
 /turf/open/floor/strata{
 	dir = 8;
 	icon_state = "white_cyan2"
@@ -10421,6 +10424,7 @@
 /area/strata/ag/exterior/paths/north_outpost)
 "aFw" = (
 /obj/structure/pipes/standard/manifold/fourway/hidden/cyan,
+/obj/effect/landmark/survivor_spawner,
 /turf/open/floor/strata{
 	dir = 4;
 	icon_state = "white_cyan1"
@@ -30290,6 +30294,16 @@
 	icon_state = "orange_cover"
 	},
 /area/strata/ag/interior/outpost/engi/drome)
+"dFk" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor/strata{
+	dir = 4;
+	icon_state = "white_cyan1"
+	},
+/area/strata/ag/interior/outpost/canteen/lower_cafeteria)
 "dFU" = (
 /obj/structure/stairs/perspective{
 	color = "#6e6e6e";
@@ -34010,6 +34024,17 @@
 	icon_state = "floor3"
 	},
 /area/strata/ag/interior/tcomms)
+"jXK" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/obj/structure/pipes/standard/simple/hidden/cyan,
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor/strata{
+	dir = 8;
+	icon_state = "white_cyan2"
+	},
+/area/strata/ag/interior/outpost/canteen/lower_cafeteria)
 "jXQ" = (
 /obj/structure/flora/grass/tallgrass/ice/corner{
 	dir = 9
@@ -34574,6 +34599,7 @@
 /area/strata/ag/exterior/paths/cabin_area)
 "kXR" = (
 /obj/effect/landmark/corpsespawner/doctor,
+/obj/effect/landmark/survivor_spawner,
 /turf/open/floor/strata{
 	dir = 8;
 	icon_state = "white_cyan2"
@@ -35165,6 +35191,13 @@
 	icon_state = "floor2"
 	},
 /area/strata/ug/interior/jungle/deep/structures/engi)
+"lWX" = (
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor/strata{
+	dir = 8;
+	icon_state = "white_cyan2"
+	},
+/area/strata/ag/interior/outpost/canteen/lower_cafeteria)
 "lXd" = (
 /obj/structure/barricade/handrail/strata{
 	dir = 4
@@ -35186,6 +35219,17 @@
 "lZf" = (
 /turf/open/auto_turf/ice/layer2,
 /area/strata/ag/exterior/marsh/river)
+"lZN" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood,
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor/strata{
+	dir = 8;
+	icon_state = "white_cyan2"
+	},
+/area/strata/ag/interior/outpost/canteen/lower_cafeteria)
 "mam" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
 /obj/structure/pipes/vents/pump{
@@ -36106,6 +36150,16 @@
 	icon_state = "cement3"
 	},
 /area/strata/ug/interior/jungle/platform/east/scrub)
+"nzc" = (
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 4
+	},
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor/strata{
+	dir = 4;
+	icon_state = "white_cyan1"
+	},
+/area/strata/ag/interior/outpost/canteen/lower_cafeteria)
 "nAf" = (
 /turf/open/gm/coast/beachcorner2/south_west,
 /area/strata/ug/interior/jungle/deep/east_carp)
@@ -38375,6 +38429,13 @@
 	icon_state = "cement4"
 	},
 /area/strata/ug/interior/jungle/platform/east/scrub)
+"rkT" = (
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor/strata{
+	dir = 4;
+	icon_state = "white_cyan1"
+	},
+/area/strata/ag/interior/outpost/canteen/lower_cafeteria)
 "rno" = (
 /obj/structure/largecrate/random,
 /turf/open/floor/strata{
@@ -38621,6 +38682,14 @@
 	icon_state = "floor2"
 	},
 /area/strata/ag/interior/outpost/med)
+"rNt" = (
+/obj/structure/pipes/standard/simple/hidden/cyan,
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor/strata{
+	dir = 8;
+	icon_state = "white_cyan2"
+	},
+/area/strata/ag/interior/outpost/canteen/lower_cafeteria)
 "rNI" = (
 /turf/open/auto_turf/ice/layer1,
 /area/strata/ag/exterior/nearlz2)
@@ -41200,6 +41269,14 @@
 "vVK" = (
 /turf/open/auto_turf/strata_grass/layer1,
 /area/strata/ug/interior/jungle/deep/minehead)
+"vVO" = (
+/obj/structure/bed/chair,
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor/strata{
+	dir = 4;
+	icon_state = "white_cyan1"
+	},
+/area/strata/ag/interior/outpost/canteen/lower_cafeteria)
 "vXt" = (
 /obj/structure/flora/grass/ice/brown/snowgrassbb_2,
 /turf/open/auto_turf/snow/brown_base/layer2,
@@ -71221,9 +71298,9 @@ ccp
 ccp
 slL
 ccp
-ccp
+rkT
 aDk
-slL
+dFk
 aFu
 dDr
 ccp
@@ -71611,10 +71688,10 @@ awk
 awk
 awk
 ccp
-ccr
-ccr
+lWX
+lWX
 aEi
-ckM
+nzc
 aGI
 cgn
 aJE
@@ -71806,9 +71883,9 @@ cgW
 cgW
 bZB
 cbz
-cgo
-bZB
-bZB
+jXK
+rNt
+rNt
 aFw
 aGJ
 cgo
@@ -72001,10 +72078,10 @@ ccr
 ccr
 caL
 ccp
-ccr
-cfC
-ccr
-ckM
+lWX
+bZE
+lWX
+nzc
 cfC
 aEj
 ccr
@@ -72196,10 +72273,10 @@ bZE
 ccr
 ccr
 aAK
-ccr
+lWX
 kXR
-aEj
-ckM
+lZN
+nzc
 ccr
 ccr
 ccr
@@ -72586,10 +72663,10 @@ awm
 ccp
 azi
 ccp
-cjl
+vVO
 aDo
-ccp
-ckM
+rkT
+nzc
 awm
 awm
 awm


### PR DESCRIPTION

# About the pull request

Survivors will now spawn in the same area on all maps. 

# Explain why it's good for the game

This has been a long-standing idea that Morrow put forward a long time ago.

The concept would help enhance the survivor experience as it will encourage all survivors to remain as a team and start with each other at the start of the game, it would also be a boon for new surv players who will lack the experience and game sense of where to go. 


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Survivors now spawn in the same area on all maps. 
/:cl:
