### PR TITLE
M39 being able to use vertical grip again [BUFF]

### DIFF
--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -51,7 +51,7 @@
 		/obj/item/attachable/reddot,
 		/obj/item/attachable/reflex,
 		/obj/item/attachable/angledgrip,
-        /obj/item/attachable/verticalgrip
+        /obj/item/attachable/verticalgrip,
 		/obj/item/attachable/flashlight/grip,
 		/obj/item/attachable/stock/smg,
 		/obj/item/attachable/stock/smg/collapsible,

--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -51,6 +51,7 @@
 		/obj/item/attachable/reddot,
 		/obj/item/attachable/reflex,
 		/obj/item/attachable/angledgrip,
+        /obj/item/attachable/verticalgrip
 		/obj/item/attachable/flashlight/grip,
 		/obj/item/attachable/stock/smg,
 		/obj/item/attachable/stock/smg/collapsible,

--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -11,7 +11,7 @@
 	aim_slowdown = SLOWDOWN_ADS_QUICK
 	wield_delay = WIELD_DELAY_VERY_FAST
 	attachable_allowed = list(
-		/obj/item/attachable/suppressor,
+		/obj/item/attachable/suppressor,			
 		/obj/item/attachable/reddot,
 		/obj/item/attachable/reflex,
 		/obj/item/attachable/flashlight,
@@ -50,8 +50,8 @@
 		/obj/item/attachable/suppressor,
 		/obj/item/attachable/reddot,
 		/obj/item/attachable/reflex,
-		/obj/item/attachable/angledgrip,
-        /obj/item/attachable/verticalgrip,
+		/obj/item/attachable/angledgrip,	
+		/obj/item/attachable/verticalgrip,
 		/obj/item/attachable/flashlight/grip,
 		/obj/item/attachable/stock/smg,
 		/obj/item/attachable/stock/smg/collapsible,


### PR DESCRIPTION

# About the pull request

M39 receives a buff, which allows it to use a attachment that make sit viable.

# Explain why it's good for the game

M39 as it stands is quite useless, the vertical grip might help it become a viable choice over the M4RA, the MK2 and the M37 :)


# Testing Photographs and Procedure

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: stalkerino
balance: m39 is able to use vertigrip
/:cl:
