### PR TITLE
Nightmare Survivor Hostility Indicator

### DIFF
--- a/code/game/jobs/job/civilians/other/survivors.dm
+++ b/code/game/jobs/job/civilians/other/survivors.dm
@@ -69,10 +69,6 @@
 
 /datum/job/civilian/survivor/generate_entry_message(mob/living/carbon/human/survivor)
 	if(intro_text)
-		if(hostile)
-			to_chat(survivor, SPAN_HIGHDANGER("You are HOSTILE to the USCM!"))
-		else
-			to_chat(survivor, SPAN_XENOHIGHDANGER("You are NON-HOSTILE to the USCM!"))
 		for(var/line in intro_text)
 			to_chat(survivor, line)
 	else
@@ -86,6 +82,11 @@
 		survivor.mind.memory += story_text
 	else
 		tell_survivor_story(survivor)
+
+	if(hostile)
+		to_chat(survivor, SPAN_HIGHDANGER("You are HOSTILE to the USCM!"))
+	else
+		to_chat(survivor, SPAN_XENOHIGHDANGER("You are NON-HOSTILE to the USCM!"))
 
 /datum/job/civilian/survivor/proc/tell_survivor_story(mob/living/carbon/human/H)
 	var/list/survivor_story = list(

--- a/code/game/jobs/job/civilians/other/survivors.dm
+++ b/code/game/jobs/job/civilians/other/survivors.dm
@@ -10,6 +10,7 @@
 	job_options = SURVIVOR_VARIANT_LIST
 	var/intro_text
 	var/story_text
+	/// Whether or not the survivor is an inherently hostile to marines.
 	var/hostile = FALSE
 
 /datum/job/civilian/survivor/set_spawn_positions(count)

--- a/code/game/jobs/job/civilians/other/survivors.dm
+++ b/code/game/jobs/job/civilians/other/survivors.dm
@@ -10,6 +10,7 @@
 	job_options = SURVIVOR_VARIANT_LIST
 	var/intro_text
 	var/story_text
+	var/hostile = FALSE
 
 /datum/job/civilian/survivor/set_spawn_positions(count)
 	spawn_positions = Clamp((round(count * SURVIVOR_TO_TOTAL_SPAWN_RATIO)), 2, 8)
@@ -59,23 +60,31 @@
 
 	if(picked_spawner.story_text)
 		story_text = picked_spawner.story_text
+
+	if(picked_spawner.hostile)
+		hostile = TRUE
+
 	new /datum/cm_objective/move_mob/almayer/survivor(H)
 
-/datum/job/civilian/survivor/generate_entry_message(mob/living/carbon/human/H)
+/datum/job/civilian/survivor/generate_entry_message(mob/living/carbon/human/survivor)
 	if(intro_text)
+		if(hostile)
+			to_chat(survivor, SPAN_HIGHDANGER("You are HOSTILE to the USCM!"))
+		else
+			to_chat(survivor, SPAN_XENOHIGHDANGER("You are NON-HOSTILE to the USCM!"))
 		for(var/line in intro_text)
-			to_chat(H, line)
+			to_chat(survivor, line)
 	else
-		to_chat(H, "<h2>You are a survivor!</h2>")
-		to_chat(H, SPAN_NOTICE(SSmapping.configs[GROUND_MAP].survivor_message))
-		to_chat(H, SPAN_NOTICE("You are fully aware of the xenomorph threat and are able to use this knowledge as you see fit."))
-		to_chat(H, SPAN_NOTICE("You are NOT aware of the marines or their intentions. "))
+		to_chat(survivor, "<h2>You are a survivor!</h2>")
+		to_chat(survivor, SPAN_NOTICE(SSmapping.configs[GROUND_MAP].survivor_message))
+		to_chat(survivor, SPAN_NOTICE("You are fully aware of the xenomorph threat and are able to use this knowledge as you see fit."))
+		to_chat(survivor, SPAN_NOTICE("You are NOT aware of the marines or their intentions. "))
 
 	if(story_text)
-		to_chat(H, story_text)
-		H.mind.memory += story_text
+		to_chat(survivor, story_text)
+		survivor.mind.memory += story_text
 	else
-		tell_survivor_story(H)
+		tell_survivor_story(survivor)
 
 /datum/job/civilian/survivor/proc/tell_survivor_story(mob/living/carbon/human/H)
 	var/list/survivor_story = list(

--- a/code/game/objects/effects/landmarks/survivor_spawner.dm
+++ b/code/game/objects/effects/landmarks/survivor_spawner.dm
@@ -8,6 +8,7 @@
 	var/roundstart_damage_min = 0
 	var/roundstart_damage_max = 0
 	var/roundstart_damage_times = 1
+	var/hostile = FALSE
 
 	var/spawn_priority = LOWEST_SPAWN_PRIORITY
 
@@ -27,6 +28,7 @@
 	return TRUE
 
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf
+	hostile = TRUE
 	equipment = /datum/equipment_preset/survivor/clf
 	synth_equipment = /datum/equipment_preset/clf/synth
 	intro_text = list("<h2>You are a survivor of a crash landing!</h2>",\
@@ -40,6 +42,7 @@
 	spawn_priority = SPAWN_PRIORITY_HIGH
 
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf_engineer
+	hostile = TRUE
 	equipment = /datum/equipment_preset/clf/engineer
 	synth_equipment = /datum/equipment_preset/clf/synth
 	intro_text = list("<h2>You are a survivor of a crash landing!</h2>",\
@@ -53,6 +56,7 @@
 	spawn_priority = SPAWN_PRIORITY_VERY_HIGH
 
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf_medic
+	hostile = TRUE
 	equipment = /datum/equipment_preset/clf/medic
 	synth_equipment = /datum/equipment_preset/clf/synth
 	intro_text = list("<h2>You are a survivor of a crash landing!</h2>",\

--- a/code/game/objects/effects/landmarks/survivor_spawner.dm
+++ b/code/game/objects/effects/landmarks/survivor_spawner.dm
@@ -8,6 +8,7 @@
 	var/roundstart_damage_min = 0
 	var/roundstart_damage_max = 0
 	var/roundstart_damage_times = 1
+	/// Whether or not the spawner is for an inherently hostile survivor subtype.
 	var/hostile = FALSE
 
 	var/spawn_priority = LOWEST_SPAWN_PRIORITY


### PR DESCRIPTION

# About the pull request
Adds a big bold message for Nightmare survivors to know if they're hostile to marines or not.
This does not apply to natural map-specific survivors, only those in nightmare inserts.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Makes it clearer for nightmare inserts to indicate if survivors are hostile. Good example of this is UPP on trijent are non hostile but this isn't always clear.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Added a big line to Nightmare survivor spawns that indicates hostility.
/:cl:
