### PR TITLE
Grenadier Hugger Vulnerability

### DIFF
--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -825,7 +825,6 @@ GLOBAL_LIST_INIT(allowed_helmet_items, list(
 	armor_internaldamage = CLOTHING_ARMOR_HIGH
 	clothing_traits = list(TRAIT_EAR_PROTECTION)
 	unacidable = TRUE
-	anti_hug = 6
 	specialty = "M3-G4 grenadier"
 	flags_item = MOB_LOCK_ON_EQUIP|NO_CRYO_STORE
 


### PR DESCRIPTION

# About the pull request

Removes the Grenadier helmets facehugging protection. 

# Explain why it's good for the game

An ancient hold over from when the Grenadier used the B18 armour. It makes little sense for a support Specialist, who hides in the rear, to have facehug protection. This also can punish smart hugger traps or hugger players who catch the Grenadier off guard but then discover they have protection. 

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: The Grenadier Specialists helmet has lost its facehugger protection.
/:cl:
