### PR TITLE
Gives Scout Spec A Crew Monitor

### DIFF
--- a/code/modules/cm_marines/equipment/kit_boxes.dm
+++ b/code/modules/cm_marines/equipment/kit_boxes.dm
@@ -86,6 +86,7 @@
 	new /obj/item/ammo_magazine/rifle/m4ra/custom/incendiary(src)
 	new /obj/item/ammo_magazine/rifle/m4ra/custom/impact(src)
 	new /obj/item/ammo_magazine/rifle/m4ra/custom/impact(src)
+	new /obj/item/tool/crew_monitor(src)
 	new /obj/item/weapon/gun/pistol/vp78(src)
 	new /obj/item/ammo_magazine/pistol/vp78(src)
 	new /obj/item/ammo_magazine/pistol/vp78(src)
@@ -137,7 +138,6 @@
 	new /obj/item/weapon/gun/pistol/vp78(src)
 	new /obj/item/ammo_magazine/pistol/vp78(src)
 	new /obj/item/ammo_magazine/pistol/vp78(src)
-	new /obj/item/tool/crew_monitor(src)
 	new /obj/item/device/binoculars(src)
 
 

--- a/code/modules/cm_marines/equipment/kit_boxes.dm
+++ b/code/modules/cm_marines/equipment/kit_boxes.dm
@@ -137,6 +137,7 @@
 	new /obj/item/weapon/gun/pistol/vp78(src)
 	new /obj/item/ammo_magazine/pistol/vp78(src)
 	new /obj/item/ammo_magazine/pistol/vp78(src)
+	new /obj/item/tool/crew_monitor(src)
 	new /obj/item/device/binoculars(src)
 
 


### PR DESCRIPTION

# About the pull request

Adds a portable crew monitor to the Scout Specialists default gear.

# Explain why it's good for the game

One of the many roles a Scout can perform is body recovery, they have tools designed to help this. A crew monitor would help incentivize a scout to perform this task. This can already be psudo-done by a Scout finding the 'meta hidden' monitor, but I believe a Scout should not need to find the hidden monitor to do their job. 


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Added a portable crew monitor to the Scout Specialists loadout kit. 
/:cl:
