### PR TITLE
trijent shuttle now generic

### DIFF
--- a/code/__DEFINES/shuttles.dm
+++ b/code/__DEFINES/shuttles.dm
@@ -100,12 +100,12 @@
 #define MOBILE_SHUTTLE_ID_ERT_BIG "ert_boarding_shuttle"
 
 #define MOBILE_TRIJENT_ELEVATOR "trijentshuttle2"
-#define STAT_TRIJENT_EMPTY "trigent_empty"
-#define STAT_TRIJENT_OCCUPIED "trigent_occupied"
-#define STAT_TRIJENT_LZ1 "trigent_lz1"
-#define STAT_TRIJENT_LZ2 "trigent_lz2"
-#define STAT_TRIJENT_ENGI "trigent_engineering"
-#define STAT_TRIJENT_OMEGA "trigent_omega"
+#define STAT_TRIJENT_EMPTY "trijent_empty"
+#define STAT_TRIJENT_OCCUPIED "trijent_occupied"
+#define STAT_TRIJENT_LZ1 "trijent_lz1"
+#define STAT_TRIJENT_LZ2 "trijent_lz2"
+#define STAT_TRIJENT_ENGI "trijent_engineering"
+#define STAT_TRIJENT_OMEGA "trijent_omega"
 
 #define MOBILE_SHUTTLE_LIFEBOAT_PORT "lifeboat-port"
 #define MOBILE_SHUTTLE_LIFEBOAT_STARBOARD "lifeboat-starboard"

--- a/code/__DEFINES/shuttles.dm
+++ b/code/__DEFINES/shuttles.dm
@@ -100,6 +100,8 @@
 #define MOBILE_SHUTTLE_ID_ERT_BIG "ert_boarding_shuttle"
 
 #define MOBILE_TRIJENT_ELEVATOR "trijentshuttle2"
+#define STAT_TRIJENT_EMPTY "trigent_empty"
+#define STAT_TRIJENT_OCCUPIED "trigent_occupied"
 #define STAT_TRIJENT_LZ1 "trigent_lz1"
 #define STAT_TRIJENT_LZ2 "trigent_lz2"
 #define STAT_TRIJENT_ENGI "trigent_engineering"

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -9,6 +9,7 @@ SUBSYSTEM_DEF(mapping)
 	var/list/map_templates = list()
 
 	var/list/shuttle_templates = list()
+	var/list/all_shuttle_templates = list()
 
 	var/list/areas_in_z = list()
 
@@ -240,6 +241,7 @@ SUBSYSTEM_DEF(mapping)
 		var/datum/map_template/shuttle/S = new shuttle_type()
 
 		shuttle_templates[S.shuttle_id] = S
+		all_shuttle_templates[item] = S
 		map_templates[S.shuttle_id] = S
 
 /datum/controller/subsystem/mapping/proc/RequestBlockReservation(width, height, z, type = /datum/turf_reservation, turf_type_override)

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -110,11 +110,6 @@
 	shuttle_id = MOBILE_TRIJENT_ELEVATOR
 	var/elevator_network
 
-/datum/map_template/shuttle/trijent_elevator/post_load(obj/docking_port/mobile/mobile_dock)
-	if(elevator_network)
-		var/obj/docking_port/mobile/trijent_elevator/elev = mobile_dock
-		elev.elevator_network = elevator_network
-
 /datum/map_template/shuttle/trijent_elevator/A
 	elevator_network = "A"
 

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -14,8 +14,6 @@
 	var/port_x_offset
 	var/port_y_offset
 
-	var/tags
-
 /datum/map_template/shuttle/proc/prerequisites_met()
 	return TRUE
 
@@ -101,8 +99,7 @@
 /datum/map_template/shuttle/proc/post_load(obj/docking_port/mobile/M)
 	if(movement_force)
 		M.movement_force = movement_force.Copy()
-	if(tags)
-		M.tag = tags
+
 
 /datum/map_template/shuttle/vehicle
 	shuttle_id = MOBILE_SHUTTLE_VEHICLE_ELEVATOR
@@ -111,9 +108,15 @@
 /datum/map_template/shuttle/trijent_elevator
 	name = "Trijent Elevator"
 	shuttle_id = MOBILE_TRIJENT_ELEVATOR
+	var/elevator_network
+
+/datum/map_template/shuttle/trijent_elevator/post_load(obj/docking_port/mobile/M)
+	if(elevator_network)
+		var/obj/docking_port/mobile/trijent_elevator/elev = M
+		elev.elevator_network = elevator_network
 
 /datum/map_template/shuttle/trijent_elevator/A
-	tags="A"
+	elevator_network="A"
 
 /datum/map_template/shuttle/trijent_elevator/B
-	tags="B"
+	elevator_network="B"

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -116,7 +116,7 @@
 		elev.elevator_network = elevator_network
 
 /datum/map_template/shuttle/trijent_elevator/A
-	elevator_network="A"
+	elevator_network = "A"
 
 /datum/map_template/shuttle/trijent_elevator/B
-	elevator_network="B"
+	elevator_network = "B"

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -110,9 +110,9 @@
 	shuttle_id = MOBILE_TRIJENT_ELEVATOR
 	var/elevator_network
 
-/datum/map_template/shuttle/trijent_elevator/post_load(obj/docking_port/mobile/M)
+/datum/map_template/shuttle/trijent_elevator/post_load(obj/docking_port/mobile/mobile_dock)
 	if(elevator_network)
-		var/obj/docking_port/mobile/trijent_elevator/elev = M
+		var/obj/docking_port/mobile/trijent_elevator/elev = mobile_dock
 		elev.elevator_network = elevator_network
 
 /datum/map_template/shuttle/trijent_elevator/A

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -14,6 +14,8 @@
 	var/port_x_offset
 	var/port_y_offset
 
+	var/tags
+
 /datum/map_template/shuttle/proc/prerequisites_met()
 	return TRUE
 
@@ -99,7 +101,19 @@
 /datum/map_template/shuttle/proc/post_load(obj/docking_port/mobile/M)
 	if(movement_force)
 		M.movement_force = movement_force.Copy()
+	if(tags)
+		M.tag = tags
 
 /datum/map_template/shuttle/vehicle
 	shuttle_id = MOBILE_SHUTTLE_VEHICLE_ELEVATOR
 	name = "Vehicle Elevator"
+
+/datum/map_template/shuttle/trijent_elevator
+	name = "Trijent Elevator"
+	shuttle_id = MOBILE_TRIJENT_ELEVATOR
+
+/datum/map_template/shuttle/trijent_elevator/A
+	tags="A"
+
+/datum/map_template/shuttle/trijent_elevator/B
+	tags="B"

--- a/code/modules/shuttle/computers/trijent_elevator_control.dm
+++ b/code/modules/shuttle/computers/trijent_elevator_control.dm
@@ -46,7 +46,7 @@
 	var/obj/docking_port/mobile/trijent_elevator/shuttle = SSshuttle.getShuttle(shuttleId)
 
 	for(var/obj/docking_port/stationary/trijent_elevator/elev in SSshuttle.stationary)
-		if(shuttle.elevator_network == "" || elev.elevator_network == null)
+		if(!shuttle.elevator_network)
 			. += list(elev)
 			continue
 		if(shuttle.elevator_network == elev.elevator_network)

--- a/code/modules/shuttle/computers/trijent_elevator_control.dm
+++ b/code/modules/shuttle/computers/trijent_elevator_control.dm
@@ -43,12 +43,13 @@
 
 /obj/structure/machinery/computer/shuttle/elevator_controller/proc/get_landing_zones()
 	. = list()
-	var/obj/docking_port/mobile/shuttle = SSshuttle.getShuttle(shuttleId)
+	var/obj/docking_port/mobile/trijent_elevator/shuttle = SSshuttle.getShuttle(shuttleId)
+
 	for(var/obj/docking_port/stationary/trijent_elevator/elev in SSshuttle.stationary)
-		if(shuttle.tag == "")
+		if(shuttle.elevator_network == "" || elev.elevator_network == null)
 			. += list(elev)
 			continue
-		if(shuttle.tag == elev.tag)
+		if(shuttle.elevator_network == elev.elevator_network)
 			. += list(elev)
 			continue
 

--- a/code/modules/shuttle/computers/trijent_elevator_control.dm
+++ b/code/modules/shuttle/computers/trijent_elevator_control.dm
@@ -1,8 +1,6 @@
 /obj/structure/machinery/computer/shuttle/elevator_controller/elevator_call
 	name = "\improper Elevator Call"
 	desc = "Control panel for the elevator"
-	icon = 'icons/obj/structures/machinery/computer.dmi'
-	icon_state = "elevator_screen"
 	shuttleId = MOBILE_TRIJENT_ELEVATOR
 	is_call = TRUE
 	var/dockId
@@ -10,6 +8,13 @@
 
 /obj/structure/machinery/computer/shuttle/elevator_controller/elevator_call/get_landing_zones()
 	return list(SSshuttle.getDock(dockId))
+
+/obj/structure/machinery/computer/shuttle/elevator_controller/elevator_call/trijent/occupied
+	dockId = STAT_TRIJENT_OCCUPIED
+
+/obj/structure/machinery/computer/shuttle/elevator_controller/elevator_call/trijent/empty
+	dockId = STAT_TRIJENT_EMPTY
+
 /obj/structure/machinery/computer/shuttle/elevator_controller/elevator_call/trijent/lz1
 	dockId = STAT_TRIJENT_LZ1
 
@@ -38,8 +43,14 @@
 
 /obj/structure/machinery/computer/shuttle/elevator_controller/proc/get_landing_zones()
 	. = list()
+	var/obj/docking_port/mobile/shuttle = SSshuttle.getShuttle(shuttleId)
 	for(var/obj/docking_port/stationary/trijent_elevator/elev in SSshuttle.stationary)
-		. += list(elev)
+		if(shuttle.tag == "")
+			. += list(elev)
+			continue
+		if(shuttle.tag == elev.tag)
+			. += list(elev)
+			continue
 
 /obj/structure/machinery/computer/shuttle/elevator_controller/tgui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -268,8 +268,6 @@
 		if(!roundstart_template)
 			CRASH("json_key:[json_key] value \[[sid]\] resulted in a null shuttle template for [src]")
 	else if(roundstart_template) // passed a PATH
-		var/sid = "[initial(roundstart_template.shuttle_id)]"
-
 		roundstart_template = SSmapping.all_shuttle_templates[roundstart_template]
 		if(!roundstart_template)
 			CRASH("Invalid path ([roundstart_template]) passed to docking port.")

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -270,7 +270,7 @@
 	else if(roundstart_template) // passed a PATH
 		var/sid = "[initial(roundstart_template.shuttle_id)]"
 
-		roundstart_template = SSmapping.shuttle_templates[sid]
+		roundstart_template = SSmapping.all_shuttle_templates[roundstart_template]
 		if(!roundstart_template)
 			CRASH("Invalid path ([roundstart_template]) passed to docking port.")
 
@@ -433,7 +433,7 @@
 // Called after the shuttle is loaded from template
 /obj/docking_port/mobile/proc/linkup(datum/map_template/shuttle/template, obj/docking_port/stationary/dock)
 	var/list/static/shuttle_id = list()
-	var/idnum = ++shuttle_id[template]
+	var/idnum = ++shuttle_id[id]
 	if(idnum > 1)
 		if(id == initial(id))
 			id = "[id][idnum]"

--- a/code/modules/shuttle/shuttles.md
+++ b/code/modules/shuttle/shuttles.md
@@ -20,7 +20,7 @@ A shuttle has a height, width, dheight and dwidth. The height and width is the s
 
 # Generic Elevator Shuttle
 
-The elevator used on Trident (DesertDam) can be used in any map and multiple can exist on one map.
+The elevator used on Trijent (DesertDam) can be used in any map and multiple can exist on one map.
 
 Do not modify the trident shuttle map. You can code in elevators from the following two docking ports (where the elevator can go):
 

--- a/code/modules/shuttle/shuttles.md
+++ b/code/modules/shuttle/shuttles.md
@@ -16,3 +16,27 @@ Shuttle map templates are used to define what the shuttle should look like.
 When defining the shuttle dimensions, define the height/width as if it was orienting north. The subsystem will properly line everything up, this allows for stationary docks to be in different orientations to their defined map template.
 
 A shuttle has a height, width, dheight and dwidth. The height and width is the size of the shuttle, with respect to its direction. If the template direction is North/South then width is your X coordinate and height is your Y. If the template direction is East/West then width is your Y direction and height is your X. On stationary docking ports, you can specify dwidth and dheight (auto generated for mobile), these are offsets for how your shuttle should land on the site. When a mobile port lands on a stationary port it wants to place the bottom left of the shuttle turfs on the stationary port. The dwidth/dheight allows you to offset this.
+
+
+# Generic Elevator Shuttle
+
+The elevator used on Trident (DesertDam) can be used in any map and multiple can exist on one map.
+
+Do not modify the trident shuttle map. You can code in elevators from the following two docking ports (where the elevator can go):
+
+- /obj/docking_port/stationary/trijent_elevator/occupied
+- /obj/docking_port/stationary/trijent_elevator/empty
+
+An occupied stationary port will start the map with an elevator and an empty one will not.
+All docking ports are, by default, linked together. One elevator can go to all docking ports.
+To limit access between docking ports you can use tags.
+
+To setup an elevator:
+- place the docking port where you want the elevator to sit
+- give the docking port instance a unique ID
+- give the docking port instance a unique Name
+- give the docking port shuttle_area the area name for where it sits
+- if you want to build a docking port 'network' then change the roudnstart_template to a subclass
+- if you want to assign a docking port to a 'network' then give it a value in "tag"
+
+If things are unclear, look at trident. It has two elevator networks.

--- a/code/modules/shuttle/shuttles.md
+++ b/code/modules/shuttle/shuttles.md
@@ -35,6 +35,7 @@ To setup an elevator:
 - place the docking port where you want the elevator to sit
 - give the docking port instance a unique ID
 - give the docking port instance a unique Name
+- make sure the door direction is correct west/east
 - give the docking port shuttle_area the area name for where it sits
 - if you want to build a docking port 'network' then change the roudnstart_template to a subclass
 - if you want to assign a docking port to a 'network' then give it a value in "tag"

--- a/code/modules/shuttle/shuttles/trijent_elevator.dm
+++ b/code/modules/shuttle/shuttles/trijent_elevator.dm
@@ -19,6 +19,7 @@
 
 	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0)
 	var/datum/door_controller/aggregate/door_control
+	var/elevator_network
 
 /obj/docking_port/mobile/trijent_elevator/Initialize(mapload, ...)
 	. = ..()
@@ -43,6 +44,7 @@
 	// shutters to clear the area
 	var/airlock_area
 	var/airlock_exit
+	var/elevator_network
 
 /obj/docking_port/stationary/trijent_elevator/proc/get_doors()
 	. = list()
@@ -57,8 +59,6 @@
 	if(istype(arriving_shuttle, /obj/docking_port/mobile/trijent_elevator))
 		var/obj/docking_port/mobile/trijent_elevator/elevator = arriving_shuttle
 		elevator.door_control.control_doors("open", airlock_exit)
-		if(elevator.tag != "")
-			elevator.tag = tag
 
 	// open dock doors
 	var/datum/door_controller/single/door_control = new()

--- a/code/modules/shuttle/shuttles/trijent_elevator.dm
+++ b/code/modules/shuttle/shuttles/trijent_elevator.dm
@@ -77,9 +77,9 @@
 	qdel(door_control)
 
 /obj/docking_port/stationary/trijent_elevator/occupied
-	name="occupied"
-	id=STAT_TRIJENT_OCCUPIED
-	airlock_exit="west"
+	name = "occupied"
+	id = STAT_TRIJENT_OCCUPIED
+	airlock_exit = "west"
 	roundstart_template = /datum/map_template/shuttle/trijent_elevator
 
 /obj/docking_port/stationary/trijent_elevator/empty

--- a/code/modules/shuttle/shuttles/trijent_elevator.dm
+++ b/code/modules/shuttle/shuttles/trijent_elevator.dm
@@ -37,6 +37,12 @@
 	. = ..()
 	door_control.control_doors("force-lock-launch", "all", force=TRUE)
 
+/obj/docking_port/mobile/trijent_elevator/linkup(datum/map_template/shuttle/template, obj/docking_port/stationary/dock)
+	..()
+	var/datum/map_template/shuttle/trijent_elevator/elev = template
+	elevator_network = elev.elevator_network
+	log_debug("Adding network [elev.elevator_network] to [id]")
+
 /obj/docking_port/stationary/trijent_elevator
 	dir=NORTH
 	width=7

--- a/code/modules/shuttle/shuttles/trijent_elevator.dm
+++ b/code/modules/shuttle/shuttles/trijent_elevator.dm
@@ -57,6 +57,8 @@
 	if(istype(arriving_shuttle, /obj/docking_port/mobile/trijent_elevator))
 		var/obj/docking_port/mobile/trijent_elevator/elevator = arriving_shuttle
 		elevator.door_control.control_doors("open", airlock_exit)
+		if(elevator.tag != "")
+			elevator.tag = tag
 
 	// open dock doors
 	var/datum/door_controller/single/door_control = new()
@@ -73,6 +75,17 @@
 	door_control.doors = get_doors()
 	door_control.control_doors("force-lock-launch")
 	qdel(door_control)
+
+/obj/docking_port/stationary/trijent_elevator/occupied
+	name="occupied"
+	id=STAT_TRIJENT_OCCUPIED
+	airlock_exit="west"
+	roundstart_template = /datum/map_template/shuttle/trijent_elevator
+
+/obj/docking_port/stationary/trijent_elevator/empty
+	name="empty"
+	id=STAT_TRIJENT_EMPTY
+	airlock_exit="west"
 
 /obj/docking_port/stationary/trijent_elevator/lz1
 	name="Lz1 Elevator"
@@ -98,7 +111,3 @@
 	id=STAT_TRIJENT_OMEGA
 	airlock_area=/area/shuttle/trijent_shuttle/omega
 	airlock_exit="east"
-
-/datum/map_template/shuttle/trijent_elevator
-	name = "Trijent Elevator"
-	shuttle_id = MOBILE_TRIJENT_ELEVATOR

--- a/code/modules/shuttle/shuttles/trijent_elevator.dm
+++ b/code/modules/shuttle/shuttles/trijent_elevator.dm
@@ -83,9 +83,9 @@
 	roundstart_template = /datum/map_template/shuttle/trijent_elevator
 
 /obj/docking_port/stationary/trijent_elevator/empty
-	name="empty"
-	id=STAT_TRIJENT_EMPTY
-	airlock_exit="west"
+	name = "empty"
+	id = STAT_TRIJENT_EMPTY
+	airlock_exit = "west"
 
 /obj/docking_port/stationary/trijent_elevator/lz1
 	name="Lz1 Elevator"

--- a/maps/map_files/DesertDam/Desert_Dam.dmm
+++ b/maps/map_files/DesertDam/Desert_Dam.dmm
@@ -10112,7 +10112,8 @@
 	icon_state = "S"
 	},
 /obj/structure/machinery/computer/shuttle/elevator_controller/elevator_call/trijent/omega{
-	pixel_y = 32
+	pixel_y = 32;
+	shuttleId = "trijentshuttle22"
 	},
 /turf/open/floor/prison{
 	dir = 8;
@@ -14387,7 +14388,11 @@
 /turf/open/desert/dirt,
 /area/desert_dam/exterior/valley/valley_telecoms)
 "aRB" = (
-/obj/docking_port/stationary/trijent_elevator/lz2,
+/obj/docking_port/stationary/trijent_elevator/occupied{
+	id = "trigent_lz2";
+	name = "Lz2 Elevator";
+	airlock_area = /area/shuttle/trijent_shuttle/lz2
+	},
 /turf/open/gm/empty,
 /area/shuttle/trijent_shuttle/lz2)
 "aRC" = (
@@ -61538,7 +61543,12 @@
 /turf/open/gm/river/desert/shallow,
 /area/desert_dam/interior/caves/temple)
 "ipQ" = (
-/obj/docking_port/stationary/trijent_elevator/omega,
+/obj/docking_port/stationary/trijent_elevator/empty{
+	id = "trigent_omega";
+	name = "Omega Elevator";
+	airlock_exit = "east";
+	airlock_area = /area/shuttle/trijent_shuttle/omega
+	},
 /turf/open/gm/empty,
 /area/shuttle/trijent_shuttle/omega)
 "iqs" = (
@@ -62546,7 +62556,8 @@
 /area/desert_dam/exterior/valley/valley_labs)
 "mej" = (
 /obj/structure/machinery/computer/shuttle/elevator_controller/elevator_call/trijent/lz2{
-	pixel_x = 32
+	pixel_x = 32;
+	shuttleId = "trijentshuttle22"
 	},
 /turf/open/floor/prison{
 	dir = 4;
@@ -63387,7 +63398,13 @@
 	},
 /area/desert_dam/interior/caves/central_caves)
 "pif" = (
-/obj/docking_port/stationary/trijent_elevator/engineering,
+/obj/docking_port/stationary/trijent_elevator/empty{
+	id = "trigent_engineering";
+	name = "Engineering Elevator";
+	airlock_exit = "east";
+	tag = "A";
+	airlock_area = /area/shuttle/trijent_shuttle/engi
+	},
 /turf/open/gm/empty,
 /area/shuttle/trijent_shuttle/engi)
 "pij" = (
@@ -64025,7 +64042,11 @@
 /turf/open/desert/rock/deep,
 /area/desert_dam/interior/caves/temple)
 "rxS" = (
-/obj/docking_port/stationary/trijent_elevator/lz1,
+/obj/docking_port/stationary/trijent_elevator/occupied{
+	id = "trigent_lz1";
+	name = "Lz1 Elevator";
+	tag = "A"
+	},
 /turf/open/gm/empty,
 /area/shuttle/trijent_shuttle/lz1)
 "ryG" = (

--- a/maps/map_files/DesertDam/Desert_Dam.dmm
+++ b/maps/map_files/DesertDam/Desert_Dam.dmm
@@ -14389,10 +14389,11 @@
 /area/desert_dam/exterior/valley/valley_telecoms)
 "aRB" = (
 /obj/docking_port/stationary/trijent_elevator/occupied{
-	id = "trigent_lz2";
+	id = "trijent_lz2";
 	name = "Lz2 Elevator";
 	airlock_area = /area/shuttle/trijent_shuttle/lz2;
-	elevator_network = "B"
+	elevator_network = "B";
+	roundstart_template = /datum/map_template/shuttle/trijent_elevator/B
 	},
 /turf/open/gm/empty,
 /area/shuttle/trijent_shuttle/lz2)
@@ -61545,7 +61546,7 @@
 /area/desert_dam/interior/caves/temple)
 "ipQ" = (
 /obj/docking_port/stationary/trijent_elevator/empty{
-	id = "trigent_omega";
+	id = "trijent_omega";
 	name = "Omega Elevator";
 	airlock_exit = "east";
 	airlock_area = /area/shuttle/trijent_shuttle/omega;
@@ -63401,7 +63402,7 @@
 /area/desert_dam/interior/caves/central_caves)
 "pif" = (
 /obj/docking_port/stationary/trijent_elevator/empty{
-	id = "trigent_engineering";
+	id = "trijent_engineering";
 	name = "Engineering Elevator";
 	airlock_exit = "east";
 	airlock_area = /area/shuttle/trijent_shuttle/engi;
@@ -64045,10 +64046,11 @@
 /area/desert_dam/interior/caves/temple)
 "rxS" = (
 /obj/docking_port/stationary/trijent_elevator/occupied{
-	id = "trigent_lz1";
+	id = "trijent_lz1";
 	name = "Lz1 Elevator";
 	elevator_network = "A";
-	airlock_area = /area/shuttle/trijent_shuttle/lz1
+	airlock_area = /area/shuttle/trijent_shuttle/lz1;
+	roundstart_template = /datum/map_template/shuttle/trijent_elevator/A
 	},
 /turf/open/gm/empty,
 /area/shuttle/trijent_shuttle/lz1)

--- a/maps/map_files/DesertDam/Desert_Dam.dmm
+++ b/maps/map_files/DesertDam/Desert_Dam.dmm
@@ -14391,7 +14391,8 @@
 /obj/docking_port/stationary/trijent_elevator/occupied{
 	id = "trigent_lz2";
 	name = "Lz2 Elevator";
-	airlock_area = /area/shuttle/trijent_shuttle/lz2
+	airlock_area = /area/shuttle/trijent_shuttle/lz2;
+	elevator_network = "B"
 	},
 /turf/open/gm/empty,
 /area/shuttle/trijent_shuttle/lz2)
@@ -61547,7 +61548,8 @@
 	id = "trigent_omega";
 	name = "Omega Elevator";
 	airlock_exit = "east";
-	airlock_area = /area/shuttle/trijent_shuttle/omega
+	airlock_area = /area/shuttle/trijent_shuttle/omega;
+	elevator_network = "B"
 	},
 /turf/open/gm/empty,
 /area/shuttle/trijent_shuttle/omega)
@@ -63402,8 +63404,8 @@
 	id = "trigent_engineering";
 	name = "Engineering Elevator";
 	airlock_exit = "east";
-	tag = "A";
-	airlock_area = /area/shuttle/trijent_shuttle/engi
+	airlock_area = /area/shuttle/trijent_shuttle/engi;
+	elevator_network = "A"
 	},
 /turf/open/gm/empty,
 /area/shuttle/trijent_shuttle/engi)
@@ -64045,7 +64047,8 @@
 /obj/docking_port/stationary/trijent_elevator/occupied{
 	id = "trigent_lz1";
 	name = "Lz1 Elevator";
-	tag = "A"
+	elevator_network = "A";
+	airlock_area = /area/shuttle/trijent_shuttle/lz1
 	},
 /turf/open/gm/empty,
 /area/shuttle/trijent_shuttle/lz1)


### PR DESCRIPTION
# About the pull request

I have made the Trijent shuttle generic, allowing this to be reused on other mapping projects. We can also have multiple elevators in the same mission.

Trijent dam also now has two elevators.

1. LZ1 to Engineering
2. LZ2 to Omega

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

Other maps will be able to incorporate the Trijent elevator shuttle.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
refactor: reworked trijent elevators to be reusable on new maps
maptweak: Trijent map now has two elevators, lz1 to engineering and lz2 to omega
/:cl:
