### PR TITLE
Lurker no longer lose pounce privileges on bumping

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/Lurker.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Lurker.dm
@@ -167,9 +167,13 @@
 	if(!lurker_invisibility_action)
 		return
 
+	if(bound_xeno.alpha >= 85)
+		return
+
 	var/mob/living/carbon/human/bumped_into = movable_atom
+
 	if(HAS_TRAIT(bumped_into, TRAIT_CLOAKED)) //ignore invisible scouts and preds
 		return
 
-	to_chat(bound_xeno, SPAN_XENOHIGHDANGER("You bumped into someone and lost your invisibility!"))
-	lurker_invisibility_action.invisibility_off()
+	to_chat(bound_xeno, SPAN_XENOHIGHDANGER("You bumped into someone and partly lost your invisibility!"))
+	animate(bound_xeno, alpha = 85, time = 0.1 SECONDS, easing = QUAD_EASING)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Since morrow is gone and salty PRs already reappearing, I am going to do the same. This is my old attempt to remove invisible lurker pushing without making regular lurker gameplay (when you have no intention to invis push anyone) so annoying.
https://github.com/cmss13-devs/cmss13/pull/3921 
It was shot down by morrow, but there was no real reasoning besides "skill issue".

So instead of completely removing invisibility and ability to pounce on bumping, this PR make it so you just lose a huge chunk of your invisibility, so marine you are trying to push can shoot you and whatever.

# Explain why it's good for the game

I am going to tell you a story. About two months ago I was fighting two marines on LV as a lurker. I pounced one of them and put him into crit. Then I was trying to dodge bullets from the second marine, using some bushes as cover and waiting for my invisibility to cooldown. As soon as I activated my invisibility again, the first marine suddenly stood up. And since I was moving on the same tile, I bumped into him. I lost my pounce privileges just because. I wasn't trying to invis bump. I couldn't anticipate this marine is going to stand again and when. And this is just a single example, this change made playing as lurker a lot more annoying. 

If you don't want to have invis bumping in the game, this PR should suffice.
If you want to make lurker harder to play, find another way, this is just annoying. (Not to mention that the original PR was presented not as a nerf, but simply as an elimination of the cheese tactic)

# Testing Photographs and Procedure
https://github.com/cmss13-devs/cmss13/assets/115417687/58990b87-1cd2-45e0-a1ac-830b07fcdc00


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl: ihatethisengine
balance: lurker no longer loses ability to pounce after bumping into someone, instead lurker just partly lose invisibility.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
