### PR TITLE
fixes upp medic/sapper survivor paygrade

### DIFF
--- a/code/modules/gear_presets/survivors/trijent/crashlanding_upp_bar_insert_trijent.dm
+++ b/code/modules/gear_presets/survivors/trijent/crashlanding_upp_bar_insert_trijent.dm
@@ -64,7 +64,7 @@
 //crashlanding-upp-bar.dmm
 /datum/equipment_preset/survivor/upp/sapper
 	name = "Survivor - UPP Sapper"
-	paygrade = "UE3S"
+	paygrade = "UE3"
 	assignment = JOB_UPP_ENGI
 	rank = JOB_UPP_ENGI
 	skills = /datum/skills/military/survivor/upp_sapper
@@ -92,7 +92,7 @@
 //crashlanding-upp-bar.dmm
 /datum/equipment_preset/survivor/upp/medic
 	name = "Survivor - UPP Medic"
-	paygrade = "UE3M"
+	paygrade = "UE3"
 	assignment = JOB_UPP_MEDIC
 	rank = JOB_UPP_MEDIC
 	skills = /datum/skills/military/survivor/upp_medic


### PR DESCRIPTION

# About the pull request

fixes the paygrade for UPP medic/sapper survivor because i forgot they existed in the pr i made simplifying ranks

# Explain why it's good for the game

Korporal Medic "SURVIVOR FRAGGER" Guy says, "I wanna frag xenos" > UE3M Medic "SURVIVOR FRAGGER" Guy says, "I wanna frag xenos"

# Testing Photographs and Procedure

Probably works I did not test this.

# Changelog
:cl:
fix: UPP Sapper/Medic survivor use their correct paygrade instead of UE3M/UE3S
/:cl:
