### PR TITLE
reduces timer on joining ert after death to 30 seconds

### DIFF
--- a/code/datums/emergency_calls/emergency_call.dm
+++ b/code/datums/emergency_calls/emergency_call.dm
@@ -168,7 +168,7 @@
 		return
 	var/deathtime = world.time - usr.timeofdeath
 
-	if(deathtime < 1 MINUTES) //Nice try, ghosting right after the announcement
+	if(deathtime < 15 SECONDS) //Nice try, ghosting right after the announcement
 		if(SSmapping.configs[GROUND_MAP].map_name != MAP_WHISKEY_OUTPOST) // people ghost so often on whiskey outpost.
 			to_chat(src, SPAN_WARNING("You ghosted too recently."))
 			return

--- a/code/datums/emergency_calls/emergency_call.dm
+++ b/code/datums/emergency_calls/emergency_call.dm
@@ -168,7 +168,7 @@
 		return
 	var/deathtime = world.time - usr.timeofdeath
 
-	if(deathtime < 15 SECONDS) //Nice try, ghosting right after the announcement
+	if(deathtime < 30 SECONDS) //Nice try, ghosting right after the announcement
 		if(SSmapping.configs[GROUND_MAP].map_name != MAP_WHISKEY_OUTPOST) // people ghost so often on whiskey outpost.
 			to_chat(src, SPAN_WARNING("You ghosted too recently."))
 			return


### PR DESCRIPTION
# About the pull request

reduces timer

# Explain why it's good for the game

Having to wait a full minute to join an ERT is annoying, it was better b4 when timer from ERT was a minute as well, but 30 second ERT means if u die just b4 ERT goes you cant join regardless.

if ppl are ghosting bc they want ert then they are stupid.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: Timer on attempting to join ERT after death is now 30 seconds down from 1 minute
/:cl:
