### PR TITLE
M39 arm brace stock disables when dropped

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -526,7 +526,7 @@ As sniper rifles have both and weapon mods can change them as well. ..() deals w
 
 	for(var/obj/item/attachable/stock/smg/collapsible/brace/current_stock in contents) //SMG armbrace folds to stop it getting stuck on people
 		if(current_stock.stock_activated)
-			current_stock.activate_attachment(src, user, TRUE)
+			current_stock.activate_attachment(src, user, turn_off = TRUE)
 
 	unwield(user)
 	set_gun_user(null)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -524,6 +524,10 @@ As sniper rifles have both and weapon mods can change them as well. ..() deals w
 	if(fire_delay_group && delay_left > 0)
 		LAZYSET(user.fire_delay_next_fire, src, world.time + delay_left)
 
+	for(var/obj/item/attachable/stock/smg/collapsible/brace/current_stock in contents) //SMG armbrace folds to stop it getting stuck on people
+		if(current_stock.stock_activated)
+			current_stock.activate_attachment(src, user, TRUE)
+
 	unwield(user)
 	set_gun_user(null)
 


### PR DESCRIPTION
# About the pull request

If you got delimbed while the brace was locked, the next person to equip it gets it stuck on their hand
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
It should fix the gun accidentally getting stuck to peoples hands

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: M39 arm brace disables when dropped
/:cl:
