### PR TITLE
Fix double options button

### DIFF
--- a/html/statbrowser.js
+++ b/html/statbrowser.js
@@ -1036,6 +1036,9 @@ Byond.subscribeTo("remove_mc", remove_mc);
 Byond.subscribeTo("add_verb_list", add_verb_list);
 
 function createOptionsButton() {
+	if (document.getElementById("options")) {
+		return;
+	}
 	var button = document.createElement("BUTTON");
 	button.onclick = function () {
 		openOptionsMenu();


### PR DESCRIPTION

# About the pull request

This PR simply prevents adding another Options button on your stat panel if there already is one. Occurs if you open multiple clients, or I guess now enter from lobby.

# Explain why it's good for the game

We only need one options button, it just looks funny.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: Drathek
ui: Fixed a duplicate Options button
/:cl:
