### PR TITLE
Fixes nuke explosion runtiming if a living mob was in a nullspaced container

### DIFF
--- a/code/game/gamemodes/cm_self_destruct.dm
+++ b/code/game/gamemodes/cm_self_destruct.dm
@@ -259,12 +259,12 @@ var/global/datum/authority/branch/evacuation/EvacuationAuthority //This is initi
 		var/list/alive_mobs = list() //Everyone who will be destroyed on the zlevel(s).
 		var/list/dead_mobs = list() //Everyone who only needs to see the cinematic.
 		for(var/mob/current_mob as anything in GLOB.mob_list) //This only does something cool for the people about to die, but should prove pretty interesting.
-			if(!current_mob || !current_mob.loc)
+			var/turf/current_turf = get_turf(current_mob)
+			if(!current_mob || !current_mob.loc || !current_turf)
 				continue //In case something changes when we sleep().
 			if(current_mob.stat == DEAD)
 				dead_mobs |= current_mob
 				continue
-			var/turf/current_turf = get_turf(current_mob)
 			if(current_turf.z in z_levels)
 				alive_mobs |= current_mob
 				shake_camera(current_mob, 110, 4)
@@ -286,6 +286,8 @@ var/global/datum/authority/branch/evacuation/EvacuationAuthority //This is initi
 		for(var/mob/current_mob in alive_mobs)
 			if(current_mob && current_mob.loc) //Who knows, maybe they escaped, or don't exist anymore.
 				var/turf/current_mob_turf = get_turf(current_mob)
+				if(!current_mob_turf)
+					continue
 				if(current_mob_turf.z in z_levels)
 					if(istype(current_mob.loc, /obj/structure/closet/secure_closet/freezer/fridge))
 						continue


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

As per title.

I have no idea what causes this condition to begin with, live inspection didn't yield any results.

# Explain why it's good for the game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->

This might sound like an improbable case, and it is, but it actually happened last week. This caused the nuke explosion to stop and left everyone confused for the next 45 minutes the round lasted to end normally.

# Testing Photographs and Procedure
Untested.


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: Fix nuke explosion getting canceled in some very rare cases.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
