### PR TITLE
Fixes Xeno Name preference requring a reconnect to apply

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -330,13 +330,8 @@ GLOBAL_LIST_INIT(whitelisted_client_procs, list(
 	prefs.last_ip = address //these are gonna be used for banning
 	prefs.last_id = computer_id //these are gonna be used for banning
 	fps = prefs.fps
-	xeno_prefix = prefs.xeno_prefix
-	xeno_postfix = prefs.xeno_postfix
-	xeno_name_ban = prefs.xeno_name_ban
-	if(!xeno_prefix || xeno_name_ban)
-		xeno_prefix = "XX"
-	if(!xeno_postfix || xeno_name_ban)
-		xeno_postfix = ""
+
+	load_xeno_name()
 
 	human_name_ban = prefs.human_name_ban
 
@@ -790,3 +785,12 @@ GLOBAL_LIST_INIT(whitelisted_client_procs, list(
 	if(admin_holder)
 		admin_holder.particle_test = new /datum/particle_editor(in_atom)
 		admin_holder.particle_test.tgui_interact(mob)
+
+/client/proc/load_xeno_name()
+	xeno_prefix = prefs.xeno_prefix
+	xeno_postfix = prefs.xeno_postfix
+	xeno_name_ban = prefs.xeno_name_ban
+	if(!xeno_prefix || xeno_name_ban)
+		xeno_prefix = "XX"
+	if(!xeno_postfix || xeno_name_ban)
+		xeno_postfix = ""

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1409,6 +1409,7 @@ var/const/MAX_SAVE_SLOTS = 10
 
 					if(length(new_xeno_prefix)==0)
 						xeno_prefix = "XX"
+						owner.load_xeno_name()
 					else
 						var/all_ok = TRUE
 						for(var/i=1, i<=length(new_xeno_prefix), i++)
@@ -1420,6 +1421,7 @@ var/const/MAX_SAVE_SLOTS = 10
 									all_ok = FALSE //everything else - won't
 						if(all_ok)
 							xeno_prefix = new_xeno_prefix
+							owner.load_xeno_name()
 						else
 							to_chat(user, "<font color='red'>Invalid Xeno Prefix. Your Prefix can contain either single letter or two letters.</font>")
 
@@ -1444,6 +1446,7 @@ var/const/MAX_SAVE_SLOTS = 10
 						return
 					else if(length(new_xeno_postfix)==0)
 						xeno_postfix = ""
+						owner.load_xeno_name()
 					else
 						var/all_ok = TRUE
 						var/first_char = TRUE
@@ -1469,6 +1472,7 @@ var/const/MAX_SAVE_SLOTS = 10
 							first_char = FALSE
 						if(all_ok)
 							xeno_postfix = new_xeno_postfix
+							owner.load_xeno_name()
 						else
 							to_chat(user, "<font color='red'>Invalid Xeno Postfix. Your Postfix can contain single letter and an optional digit after it.</font>")
 

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -34,8 +34,8 @@
 		return
 
 	var/tempnumber = rand(1, 999)
-	var/postfix_text = (client.prefs && client.prefs.xeno_postfix) ? ("-"+client.prefs.xeno_postfix) : ""
-	var/prefix_text = (client.prefs && client.prefs.xeno_prefix) ? client.prefs.xeno_prefix : "XX"
+	var/postfix_text = (client.xeno_postfix) ? ("-"+client.xeno_postfix) : ""
+	var/prefix_text = (client.xeno_prefix) ? client.xeno_prefix : "XX"
 	var/xeno_text = "[prefix_text]-[tempnumber][postfix_text]"
 	var/round_start = !SSticker || !SSticker.mode || SSticker.current_state <= GAME_STATE_PREGAME
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

See #4436 for an indepth description of the issue - basically Xeno name is cached on client and updating preferences won't update it without a reconnect

# Explain why it's good for the game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->

Less confusion

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
Basic testing performed in the form of:
   Changing Xeno Name
   Launching game, observing
   Spawning a Xeno and possessing it
And observing which xeno name is present.


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: Xeno Name preference does not require a reconnection to apply anymore. It still won't change your current Xenomorph's name however.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
