### PR TITLE
Fixes Turing Machine UI breaking down if its Smartfridge is exploded

### DIFF
--- a/code/modules/reagents/chemistry_machinery/autodispenser.dm
+++ b/code/modules/reagents/chemistry_machinery/autodispenser.dm
@@ -154,8 +154,7 @@
 	data["multiplier"] = multiplier
 	data["cycle_limit"] = cycle_limit
 	data["automode"] = automode
-	data["linked_storage"] = linked_storage
-	data["networked_storage"] = linked_storage.is_in_network()
+	data["networked_storage"] = linked_storage?.is_in_network()
 	data["smartlink"] = smartlink
 	data["outputmode"] = outputmode
 	data["buffervolume"] = reagents.total_volume

--- a/tgui/packages/tgui/interfaces/Autodispenser.js
+++ b/tgui/packages/tgui/interfaces/Autodispenser.js
@@ -11,7 +11,6 @@ export const Autodispenser = (_props, context) => {
     multiplier,
     cycle_limit,
     automode,
-    linked_storage,
     networked_storage,
     smartlink,
     outputmode,


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

Just occured on live game - turns out Research can and will explode themselves (who guessed), and the Turing UI runtimes due to a little oopsie if there is no associated storage.

I didn't test if this actually broke the UI but a runtime mid ui_data makes it a safe bet

# Explain why it's good for the game
Freedom to explode things with controlled breakage.

# Testing Photographs and Procedure
Deleted the Smartfridge, pressed Turing buttons.

# Changelog
:cl:
fix: The Turing Machine should now keep working as intended if its linked Smartfridge is blown up.
/:cl:
