### PR TITLE
mods can restart the server without starting the round

### DIFF
--- a/code/modules/admin/tabs/server_tab.dm
+++ b/code/modules/admin/tabs/server_tab.dm
@@ -6,10 +6,6 @@
 	if (!usr.client.admin_holder || !(usr.client.admin_holder.rights & R_MOD))
 		return
 
-	if(!check_rights(R_DEBUG, FALSE) && SSticker.current_state != GAME_STATE_FINISHED)
-		to_chat(usr, "You can't restart the world until the round has ended!")
-		return
-
 	var/confirm = alert("Restart the game world?", "Restart", "Yes", "Cancel")
 	if(confirm == "Cancel")
 		return


### PR DESCRIPTION
with the weird issues we've been accumulating lately which require a lobby restart this check is just annoying our mods and tadmins

:cl:
admin: administrators without R_DEBUG can now restart the server without starting the round
/:cl: