### PR TITLE
Fixes Disconnected Observers runtiming HUD

### DIFF
--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -116,6 +116,10 @@
 		return
 	var/mob/living/carbon/human/H = mymob
 	var/mob/screenmob = viewer || H
+
+	if(!screenmob?.client)
+		return
+
 	if(!gear.len)
 		inventory_shown = FALSE
 		return //species without inv slots don't show items.
@@ -180,6 +184,9 @@
 
 	var/mob/living/carbon/human/H = mymob
 	var/mob/screenmob = viewer || H
+
+	if(!screenmob?.client)
+		return
 
 	if(H.hud_used)
 		if(H.hud_used.hud_shown)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

A simple runtime job... Login() to an observed mob with a disconnected observer will crash the inventory HUD proc because it has no client. 

# Explain why it's good for the game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->

Less runtimes

# Testing Photographs and Procedure
Tested with dual client and breakpoints


# Changelog

Internal change only

<!-- Both :cl:'s are required for the changelog to work! -->
