### PR TITLE
Fixes disconnected ahelpers runtime

### DIFF
--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -753,6 +753,8 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 //
 
 /client/proc/giveadminhelpverb()
+	if(!src)
+		return
 	add_verb(src, /client/verb/adminhelp)
 	deltimer(adminhelptimerid)
 	adminhelptimerid = 0


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

If client disconnected, due to hard del, instances get replaced by null. This still goes through the timer CALLBACK somehow (?), causing invocation of the proc with src nulled out. 

# Explain why it's good for the game
Every time this happens are two different runtimes, one for add_verb and one for deltimer.

# Testing Photographs and Procedure
Untested


# Changelog

Internal change
