### PR TITLE
Adds safety check to bioprinter for resources and already printing

### DIFF
--- a/code/game/machinery/bioprinter.dm
+++ b/code/game/machinery/bioprinter.dm
@@ -113,6 +113,10 @@
 
 	switch(action)
 		if("print")
+			if(working)
+				//If we're already printing something then we're too busy to multi task.
+				to_chat(usr, SPAN_NOTICE("[src] is busy at the moment."))
+				return FALSE
 			var/recipe = params["recipe_id"]
 			var/valid_recipe = FALSE
 			for(var/datum/bioprinter_recipe/product_recipes in products)
@@ -124,6 +128,10 @@
 				message_admins("[key_name(usr)] attempted to print an invalid recipe on \the [src].")
 				return FALSE
 			var/datum/bioprinter_recipe/recipe_datum = new recipe
+			if(stored_metal < recipe_datum.metal)
+				to_chat(usr, SPAN_NOTICE("[src] does not have enough stored metal."))
+				QDEL_NULL(recipe_datum)
+				return FALSE
 			stored_metal -= recipe_datum.metal
 			to_chat(usr, SPAN_NOTICE("\The [src] is now printing the selected organ. Please hold."))
 			working = TRUE
@@ -146,6 +154,8 @@
 
 /obj/structure/machinery/bioprinter/proc/print_limb(limb_path)
 	if(inoperable())
+		//In case we lose power or anything between the print and the callback we don't want to permenantly break the printer
+		working = FALSE
 		return
 	new limb_path(get_turf(src))
 	working = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Fixes #4338 

Also adds check to see if we actually have enough metal, all safety checks were done inside the tgui, better to have them here.

# Explain why it's good for the game

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl:
fix: Limb printer can no longer double print or print without metal.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
