### PR TITLE
Fixed default value in cash splitting being out of bounds for tgui_input_number

### DIFF
--- a/code/modules/economy/cash.dm
+++ b/code/modules/economy/cash.dm
@@ -87,7 +87,7 @@
 /obj/item/spacecash/bundle/attack_self(mob/user)
 	..()
 	var/oldloc = loc
-	var/amount = tgui_input_number(user, "How many dollars do you want to take? (0 to [src.worth])", "Take Money", 20, src.worth, 0)
+	var/amount = tgui_input_number(user, "How many dollars do you want to take? (0 to [src.worth])", "Take Money", 0, src.worth, 0)
 	amount = round(Clamp(amount, 0, src.worth))
 	if(amount == 0)
 		return


### PR DESCRIPTION
`[2023-10-13 22:54:01.748] runtime error: Default value is greater than max value. (How many dollars do you want to take? (0 to 2), Take Money)`

obviously a default of 20 can be out of bounds for a maximum of an arbitary positive value

don't mock the poor...