### PR TITLE
Fixes dummy preview for yautja bracers causing runtimes

### DIFF
--- a/code/modules/cm_preds/yaut_bracers.dm
+++ b/code/modules/cm_preds/yaut_bracers.dm
@@ -116,6 +116,9 @@
 	var/mob/living/carbon/human/human_owner = owner
 	var/turf/wearer_turf = get_turf(owner)
 	SSminimaps.remove_marker(owner)
+	if(!wearer_turf)
+		return
+
 	if(!isyautja(owner))
 		if(owner.stat >= DEAD)
 			if(human_owner.undefibbable)


### PR DESCRIPTION

# About the pull request

Fixes a simple runtime when the bracers are viewed off a character setup dummy, and therefore, nullspaced