### PR TITLE
Fixes crash in Join as Freed Mob if some had been deleted

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -192,7 +192,7 @@ GLOBAL_LIST_INIT(frozen_items, list(SQUAD_MARINE_1 = list(), SQUAD_MARINE_2 = li
 
 //Lifted from Unity stasis.dm and refactored. ~Zuhayr
 /obj/structure/machinery/cryopod/process()
-	if(occupant && !(WEAKREF(occupant) in GLOB.freed_mob_list)) //ignore freed mobs
+	if(!(occupant in GLOB.freed_mob_list)) //ignore freed mobs
 		//if occupant ghosted, time till despawn is severely shorter
 		if(!occupant.key && time_till_despawn == 10 MINUTES)
 			time_till_despawn -= 8 MINUTES

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -192,7 +192,7 @@ GLOBAL_LIST_INIT(frozen_items, list(SQUAD_MARINE_1 = list(), SQUAD_MARINE_2 = li
 
 //Lifted from Unity stasis.dm and refactored. ~Zuhayr
 /obj/structure/machinery/cryopod/process()
-	if(!(occupant in GLOB.freed_mob_list)) //ignore freed mobs
+	if(occupant && !(occupant in GLOB.freed_mob_list)) //ignore freed mobs
 		//if occupant ghosted, time till despawn is severely shorter
 		if(!occupant.key && time_till_despawn == 10 MINUTES)
 			time_till_despawn -= 8 MINUTES

--- a/code/modules/admin/verbs/freeforghosts.dm
+++ b/code/modules/admin/verbs/freeforghosts.dm
@@ -20,7 +20,7 @@
 	if(mind || client)
 		ghostize(FALSE)
 
-	GLOB.freed_mob_list |= WEAKREF(src)
+	GLOB.freed_mob_list |= src
 
 	if(!notify)
 		return

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -1012,13 +1012,12 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		return
 
 	var/list/mobs_by_role = list() // the list the mobs are assigned to first, for sorting purposes
-	for(var/datum/weakref/ref as anything in GLOB.freed_mob_list)
-		var/mob/living/resolved_mob = ref.resolve()
-		var/role_name = resolved_mob.get_role_name()
+	for(var/mob/freed_mob as anything in GLOB.freed_mob_list)
+		var/role_name = freed_mob.get_role_name()
 		if(!role_name)
 			role_name = "No Role"
 		LAZYINITLIST(mobs_by_role[role_name])
-		mobs_by_role[role_name] += resolved_mob
+		mobs_by_role[role_name] += freed_mob
 
 	var/list/freed_mob_choices = list() // the list we'll be choosing from
 	for(var/role in mobs_by_role)
@@ -1034,18 +1033,15 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	handle_joining_as_freed_mob(L)
 
 /mob/dead/proc/handle_joining_as_freed_mob(mob/living/freed_mob)
-	if(!freed_mob || !(WEAKREF(freed_mob) in GLOB.freed_mob_list))
-		return
-
-	if(!istype(freed_mob))
+	if(!istype(freed_mob) || !(freed_mob in GLOB.freed_mob_list))
 		return
 
 	if(QDELETED(freed_mob) || freed_mob.client)
-		GLOB.freed_mob_list -= WEAKREF(freed_mob)
+		GLOB.freed_mob_list -= freed_mob
 		to_chat(src, SPAN_WARNING("Something went wrong."))
 		return
 
-	GLOB.freed_mob_list -= WEAKREF(freed_mob)
+	GLOB.freed_mob_list -= freed_mob
 	mind.transfer_to(freed_mob, TRUE)
 
 /mob/dead/verb/join_as_hellhound()


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

Improper usage of weakrefs in ghost freed code resulted in them not being cleared on deletion + the Join as Freed Mob verb to crash if such an entry was still present. 

Because /mob/Destroy already clears the hard reference, there is no actual reason to use weak references at all, so i just removed all of them.

# Explain why it's good for the game
Feature must work!

# Testing Photographs and Procedure
Customary testing that Freed Mobs joining still works after fix.

# Changelog
:cl:
fix: Fixed 'Join as Freed Mob' verb crashing if freed mobs had previously been deleted.
/:cl:
