### PR TITLE
Fixes minor runtime with null skills pushups

### DIFF
--- a/code/modules/mob/living/carbon/human/exercise.dm
+++ b/code/modules/mob/living/carbon/human/exercise.dm
@@ -102,7 +102,7 @@ Verbs related to getting fucking jacked, bro
 	//humans have 100 stamina
 	//default loss per pushup = 5 stamina
 	var/stamina_loss = 5
-	if(issynth(src))
+	if(!skills || issynth(src))
 		return 0
 	switch(skills.get_skill_level(SKILL_ENDURANCE))
 		if(SKILL_ENDURANCE_NONE)


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

Doing push up with null skills runtimes at every iteration since pushups don't account for it

I wouldn't normally bother but I came across an unreadable log spammed by zombie pushups, because our zombie players LOVE doing pushups

No functional changes, no changelog, etc
