### PR TITLE
Changes to M44 Special Ammo

### DIFF
--- a/code/datums/supply_packs/ammo.dm
+++ b/code/datums/supply_packs/ammo.dm
@@ -161,7 +161,7 @@
 	contains = list(
 		/obj/item/ammo_box/magazine/m44/marksman,
 	)
-	cost = 30
+	cost = 24
 	containertype = /obj/structure/closet/crate/ammo
 	containername = "\improper M44 Marksman speed loaders crate"
 	group = "Ammo"
@@ -171,7 +171,7 @@
 	contains = list(
 		/obj/item/ammo_box/magazine/m44/heavy,
 	)
-	cost = 40
+	cost = 28
 	containertype = /obj/structure/closet/crate/ammo
 	containername = "\improper M44 Heavy speed loaders crate"
 	group = "Ammo"

--- a/code/game/machinery/vending/vendor_types/requisitions.dm
+++ b/code/game/machinery/vending/vendor_types/requisitions.dm
@@ -242,8 +242,8 @@
 		list("SPECIAL AMMUNITION", -1, null, null),
 		list("M56 Battery", 4, /obj/item/smartgun_battery, VENDOR_ITEM_REGULAR),
 		list("M56 Smartgun Drum", 4, /obj/item/ammo_magazine/smartgun, VENDOR_ITEM_REGULAR),
-		list("M44 Heavy Speed Loader (.44)", round(scale * 10.5), /obj/item/ammo_magazine/revolver/heavy, VENDOR_ITEM_REGULAR),
-		list("M44 Marksman Speed Loader (.44)", round(scale * 5.7), /obj/item/ammo_magazine/revolver/marksman, VENDOR_ITEM_REGULAR),
+		list("M44 Heavy Speed Loader (.44)", round(scale * 8), /obj/item/ammo_magazine/revolver/heavy, VENDOR_ITEM_REGULAR),
+		list("M44 Marksman Speed Loader (.44)", round(scale * 10.5), /obj/item/ammo_magazine/revolver/marksman, VENDOR_ITEM_REGULAR),
 		list("M4A3 HP Magazine (9mm)", round(scale * 2), /obj/item/ammo_magazine/pistol/hp, VENDOR_ITEM_REGULAR),
 		list("M41AE2 Holo Target Rounds (10x24mm)", round(scale * 2), /obj/item/ammo_magazine/rifle/lmg/holo_target, VENDOR_ITEM_REGULAR),
 

--- a/code/game/machinery/vending/vendor_types/squad_prep/squad_prep.dm
+++ b/code/game/machinery/vending/vendor_types/squad_prep/squad_prep.dm
@@ -233,8 +233,8 @@
 
 		list("SPECIAL AMMUNITION", -1, null, null),
 		list("M56 Smartgun Drum", 1, /obj/item/ammo_magazine/smartgun, VENDOR_ITEM_REGULAR),
-		list("M44 Heavy Speed Loader (.44)", round(scale * 2), /obj/item/ammo_magazine/revolver/heavy, VENDOR_ITEM_REGULAR),
-		list("M44 Marksman Speed Loader (.44)", round(scale * 2), /obj/item/ammo_magazine/revolver/marksman, VENDOR_ITEM_REGULAR),
+		list("M44 Heavy Speed Loader (.44)", round(scale * 1.6), /obj/item/ammo_magazine/revolver/heavy, VENDOR_ITEM_REGULAR),
+		list("M44 Marksman Speed Loader (.44)", round(scale * 2.5), /obj/item/ammo_magazine/revolver/marksman, VENDOR_ITEM_REGULAR),
 
 		list("RESTRICTED FIREARM AMMUNITION", -1, null, null),
 		list("VP78 Magazine", round(scale * 5), /obj/item/ammo_magazine/pistol/vp78, VENDOR_ITEM_REGULAR),


### PR DESCRIPTION
# About the pull request

This PR changes the amount of M44 special ammos able to be acquired and used in-game.

# Explain why it's good for the game

M44 Heavies are not fun to fight against; they are loaded into an easily concealed weapon which can be carried on your armor, in your belt, in your pouch or even on your uniform or in a backpack which can easily chain-stun someone while others just gun the victim down. Chain-stuns in general are just un-fun to play against.

I also rarely, if ever, see anyone take the Marksman ammo for the M44. It would be nice for people to at least try to use the marksman rounds by making them more accessible. To compensate for the lowered amount available I have also lowered the price of buying a crates of them.

# Changelog

:cl:
balance: Increases M44 Marksman ammo amount by 25% in Squad Preparation Vendors
balance: Reduces M44 Heavy ammo amount by 20% in Squad Preparation Vendors
balance: Reduces price of M44 Marksman Crate from $3,000 to $2,400 (-20%)
balance: Reduces price of M44 Heavy Crate from $4,000 to $2,800 (-30%)
balance: Reduces amount of M44 Heavy ammo in Requisitions Ammo Vendor by roughly 20%
balance: Doubles amount of M44 Marksman ammo in Requisitions Ammo Vendor
/:cl:
