### PR TITLE
Fixes Xeno Cultists always belonging to the Normal hive

### DIFF
--- a/code/modules/admin/player_panel/actions/antag.dm
+++ b/code/modules/admin/player_panel/actions/antag.dm
@@ -56,9 +56,8 @@
 	if(params["leader"])
 		preset = GLOB.gear_path_presets_list[/datum/equipment_preset/other/xeno_cultist/leader]
 
-
-	preset.load_race(H, params["hivenumber"])
-	preset.load_status(H)
+	preset.load_race(H)
+	preset.load_status(H, params["hivenumber"])
 
 	var/title = params["leader"]? "xeno cultist leader" : "cultist"
 

--- a/code/modules/admin/topic/topic.dm
+++ b/code/modules/admin/topic/topic.dm
@@ -836,14 +836,14 @@
 
 		if(href_list["makecultist"])
 			var/datum/equipment_preset/preset = GLOB.gear_path_presets_list[/datum/equipment_preset/other/xeno_cultist]
-			preset.load_race(H, hive.hivenumber)
-			preset.load_status(H)
+			preset.load_race(H)
+			preset.load_status(H, hive.hivenumber)
 			message_admins("[key_name_admin(usr)] has made [key_name_admin(H)] into a cultist for [hive.name].")
 
 		else if(href_list["makecultistleader"])
 			var/datum/equipment_preset/preset = GLOB.gear_path_presets_list[/datum/equipment_preset/other/xeno_cultist/leader]
-			preset.load_race(H, hive.hivenumber)
-			preset.load_status(H)
+			preset.load_race(H)
+			preset.load_status(H, hive.hivenumber)
 			message_admins("[key_name_admin(usr)] has made [key_name_admin(H)] into a cultist leader for [hive.name].")
 
 		H.faction = hive.internal_faction

--- a/code/modules/mob/living/carbon/human/human_abilities.dm
+++ b/code/modules/mob/living/carbon/human/human_abilities.dm
@@ -414,8 +414,8 @@ CULT
 		return
 
 	var/datum/equipment_preset/preset = GLOB.gear_path_presets_list[/datum/equipment_preset/other/xeno_cultist]
-	preset.load_race(chosen, H.hivenumber)
-	preset.load_status(chosen)
+	preset.load_race(chosen)
+	preset.load_status(chosen, H.hivenumber)
 
 	to_chat(chosen, SPAN_ROLE_HEADER("You are now a Xeno Cultist!"))
 	to_chat(chosen, SPAN_ROLE_BODY("Worship the Xenomorphs and listen to the Cult Leader for orders. The Cult Leader is typically the person who transformed you. Do not kill anyone unless you are wearing your black robes, you may defend yourself."))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

Turns out making a xeno cultist of a given hive completely ignores the hive and makes it as default hive, because it was passed to the wrong proc entirely. Funny huh?

# Explain why it's good for the game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->

Avoids mishaps during the few events using cultists, as seen recently. 

# Testing Photographs and Procedure
Tested before/after the setting of `hivenumber` on the human, as well as possibility of receiving hivemind messages.


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: Fixed xeno cultists always being created into normal hive, irrespective of the selected hive.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
