### PR TITLE
Adds Synthetic Manufacturers 

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -82,6 +82,8 @@ var/const/MAX_SAVE_SLOTS = 10
 	//Synthetic specific preferences
 	var/synthetic_name = "Undefined"
 	var/synthetic_type = SYNTH_GEN_THREE
+	var/synth_manufacturer = "Weyland-Yutani"
+	var/new_manufacturer = "Weyland-Yutani"
 	//Predator specific preferences.
 	var/predator_name = "Undefined"
 	var/predator_gender = MALE
@@ -498,6 +500,7 @@ var/const/MAX_SAVE_SLOTS = 10
 				dat += "<b>Synthetic Name:</b> <a href='?_src_=prefs;preference=synth_name;task=input'><b>[synthetic_name]</b></a><br>"
 				dat += "<b>Synthetic Type:</b> <a href='?_src_=prefs;preference=synth_type;task=input'><b>[synthetic_type]</b></a><br>"
 				dat += "<b>Synthetic Whitelist Status:</b> <a href='?_src_=prefs;preference=synth_status;task=input'><b>[synth_status]</b></a><br>"
+				dat += "<b>Manufacturer:</b> <a href ='?_src_=prefs;preference=synth_manufacturer;task=input'><b>[new_manufacturer]</b></a><br>"
 				dat += "</div>"
 			else
 				dat += "<b>You do not have the whitelist for this role.</b>"
@@ -1610,6 +1613,11 @@ var/const/MAX_SAVE_SLOTS = 10
 					var/new_relation = input(user, "Choose your relation to the Weyland-Yutani company. Note that this represents what others can find out about your character by researching your background, not what your character actually thinks.", "Character Preference")  as null|anything in list("Loyal", "Supportive", "Neutral", "Skeptical", "Opposed")
 					if(new_relation)
 						nanotrasen_relation = new_relation
+
+				if("synth_manufacturer")
+					var/synth_builder = input(user, "Choose your manufacturer.")  as null|anything in list("Weyland-Yutani", "Borgia Industries", "Hyperdyne Systems", "Lasalle Bionational", "Sieg and Son", "Independent Manufacturer")
+					if(synth_builder)
+						new_manufacturer = synth_builder
 
 				if("prefsquad")
 					var/new_pref_squad = input(user, "Choose your preferred squad.", "Character Preference")  as null|anything in list("Alpha", "Bravo", "Charlie", "Delta", "None")

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1615,7 +1615,7 @@ var/const/MAX_SAVE_SLOTS = 10
 						nanotrasen_relation = new_relation
 
 				if("synth_manufacturer")
-					var/synth_builder = input(user, "Choose your manufacturer.")  as null|anything in list("Weyland-Yutani", "Borgia Industries", "Hyperdyne Systems", "Lasalle Bionational", "Sieg and Son", "MedTech", "Grant Corporation", "AlphaTech Hardware", "Independent Manufacturer")
+					var/synth_builder = input(user, "Choose your manufacturer.")  as null|anything in list("Weyland-Yutani", "Borgia Industries", "Hyperdyne Systems", "Lasalle Bionational", "Seegson", "MedTech", "Grant Corporation", "AlphaTech Hardware", "Independent Manufacturer")
 					if(synth_builder)
 						new_manufacturer = synth_builder
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1615,7 +1615,7 @@ var/const/MAX_SAVE_SLOTS = 10
 						nanotrasen_relation = new_relation
 
 				if("synth_manufacturer")
-					var/synth_builder = input(user, "Choose your manufacturer.")  as null|anything in list("Weyland-Yutani", "Borgia Industries", "Hyperdyne Systems", "Lasalle Bionational", "Sieg and Son", "Independent Manufacturer")
+					var/synth_builder = input(user, "Choose your manufacturer.")  as null|anything in list("Weyland-Yutani", "Borgia Industries", "Hyperdyne Systems", "Lasalle Bionational", "Sieg and Son", "MedTech", "Grant Corporation", "AlphaTech Hardware", "Independent Manufacturer")
 					if(synth_builder)
 						new_manufacturer = synth_builder
 

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -165,6 +165,7 @@
 
 	S["synth_name"] >> synthetic_name
 	S["synth_type"] >> synthetic_type
+	S["synth_manufacturer"] >> synth_manufacturer
 	S["pred_name"] >> predator_name
 	S["pred_gender"] >> predator_gender
 	S["pred_age"] >> predator_age
@@ -242,6 +243,7 @@
 	adaptive_zoom = sanitize_integer(adaptive_zoom, 0, 2, 0)
 	tooltips = sanitize_integer(tooltips, FALSE, TRUE, TRUE)
 
+	if(isnull(synth_manufacturer)) synth_manufacturer = initial(synth_manufacturer)
 	synthetic_name = synthetic_name ? sanitize_text(synthetic_name, initial(synthetic_name)) : initial(synthetic_name)
 	synthetic_type = sanitize_inlist(synthetic_type, PLAYER_SYNTHS, initial(synthetic_type))
 	predator_name = predator_name ? sanitize_text(predator_name, initial(predator_name)) : initial(predator_name)
@@ -353,6 +355,7 @@
 
 	S["synth_name"] << synthetic_name
 	S["synth_type"] << synthetic_type
+	S["synth_manufacturer"] << synth_manufacturer
 	S["pred_name"] << predator_name
 	S["pred_gender"] << predator_gender
 	S["pred_age"] << predator_age


### PR DESCRIPTION
# About the pull request

Allows Synthetic players to select a manufacturer for their Synthetic character.

This currently does not have any tangible in-game effect outside of allowing a Synthetic player to inform themselves of who manufactured them. 

In addition to a broad suite of manufactures, all of which have some basis in Aliens lore (noted in the photos below), I added a 'independent manufacturer' for edge cases. Currently players will default to Weyland-Yutani if they don't select anything. 

# Explain why it's good for the game

Adds a little bit of lore and flavour to a Synthetic players character building.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![Screenshot 2023-10-15 13 53 32](https://github.com/cmss13-devs/cmss13/assets/6595389/c487851b-2c9f-4b77-bdfb-3db5b3d0b441)


</details>


# Changelog
:cl:
add: Synthetics may now select their manufacturer. This currently has no tangible in-game effect. 
/:cl:
