### PR TITLE
Makes the Queen's psychic messages bigger

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/Abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Abilities.dm
@@ -234,9 +234,9 @@
 			continue
 		target_list += possible_target
 		if(!istype(possible_target, /mob/living/carbon/xenomorph))
-			to_chat(possible_target, SPAN_XENO("You hear a strange, alien voice in your head. \"[msg]\""))
+			to_chat(possible_target, SPAN_XENOQUEEN("You hear a strange, alien voice in your head. \"[msg]\""))
 		else
-			to_chat(possible_target, SPAN_XENO("You hear the voice of [X] resonate in your head. \"[msg]\""))
+			to_chat(possible_target, SPAN_XENOQUEEN("You hear the voice of [X] resonate in your head. \"[msg]\""))
 	if(!length(target_list))
 		return
 	var/targetstring = english_list(target_list)

--- a/code/modules/mob/living/carbon/xenomorph/Abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Abilities.dm
@@ -207,9 +207,9 @@
 	if(msg)
 		log_say("PsychicWhisper: [key_name(X)]->[M.key] : [msg]")
 		if(!istype(M, /mob/living/carbon/xenomorph))
-			to_chat(M, SPAN_XENO("You hear a strange, alien voice in your head. \"[msg]\""))
+			to_chat(M, SPAN_XENOQUEEN("You hear a strange, alien voice in your head. \"[msg]\""))
 		else
-			to_chat(M, SPAN_XENO("You hear the voice of [X] resonate in your head. \"[msg]\""))
+			to_chat(M, SPAN_XENOQUEEN("You hear the voice of [X] resonate in your head. \"[msg]\""))
 		to_chat(X, SPAN_XENONOTICE("You said: \"[msg]\" to [M]"))
 	return ..()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

makes the queen's psychic messages (whisper and radiance) bigger.

# Explain why it's good for the game

unless you are specifically looking out for these messages, there is a really big likelihood that you're going to miss them in the heat of the moment. hopefully this should reduce such cases


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

![xenosmall](https://github.com/cmss13-devs/cmss13/assets/17518895/87cf78f4-af32-431f-aed9-869600844bf0)
![xenobig](https://github.com/cmss13-devs/cmss13/assets/17518895/614ef7e1-e795-4ed5-884f-7fd9543837d1)


</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
qol: The Queen's psychic messages now use a bigger font and are harder to miss.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
