### PR TITLE
Fixes bugs with designator usage

### DIFF
--- a/code/__DEFINES/dcs/signals/atom/mob/living/signals_human.dm
+++ b/code/__DEFINES/dcs/signals/atom/mob/living/signals_human.dm
@@ -36,6 +36,10 @@
 #define COMSIG_HUMAN_UPDATE_SIGHT "human_update_sight"
 	#define COMPONENT_OVERRIDE_UPDATE_SIGHT (1<<0)
 
+///from /mob/living/carbon/human/movement_delay()
+#define COMSIG_HUMAN_MOVEMENT_CANCEL_INTERACTION "human_movement_cancel_interaction"
+	#define COMPONENT_HUMAN_MOVEMENT_KEEP_USING (1<<0)
+
 ///from /mob/living/carbon/human/update_sight()
 #define COMSIG_HUMAN_POST_UPDATE_SIGHT "human_post_update_sight"
 ///from /mob/living/carbon/human/movement_delay(): (list/movedata)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -824,6 +824,8 @@ cases. Override_icon_state should be a list.*/
 	unzoom(user)
 
 /obj/item/proc/unzoom(mob/living/user)
+	if(user.interactee == src)
+		user.unset_interaction()
 	var/zoom_device = zoomdevicename ? "\improper [zoomdevicename] of [src]" : "\improper [src]"
 	INVOKE_ASYNC(user, TYPE_PROC_REF(/atom, visible_message), SPAN_NOTICE("[user] looks up from [zoom_device]."),
 	SPAN_NOTICE("You look up from [zoom_device]."))

--- a/code/game/objects/items/devices/binoculars.dm
+++ b/code/game/objects/items/devices/binoculars.dm
@@ -38,10 +38,14 @@
 
 /obj/item/device/binoculars/on_set_interaction(mob/user)
 	flags_atom |= RELAY_CLICK
-
+	RegisterSignal(user, COMSIG_HUMAN_MOVEMENT_CANCEL_INTERACTION, PROC_REF(interaction_handler))
 
 /obj/item/device/binoculars/on_unset_interaction(mob/user)
 	flags_atom &= ~RELAY_CLICK
+	UnregisterSignal(user, COMSIG_HUMAN_MOVEMENT_CANCEL_INTERACTION)
+
+/obj/item/device/binoculars/proc/interaction_handler()
+	return COMPONENT_HUMAN_MOVEMENT_KEEP_USING
 
 /obj/item/device/binoculars/civ
 	desc = "A pair of binoculars."

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -4,7 +4,8 @@
 	recalculate_move_delay = FALSE
 
 	if(interactee)// moving stops any kind of interaction
-		unset_interaction()
+		if(!(SEND_SIGNAL(src, COMSIG_HUMAN_MOVEMENT_CANCEL_INTERACTION) & COMPONENT_HUMAN_MOVEMENT_KEEP_USING))
+			unset_interaction()
 
 	if(species.slowdown)
 		. += species.slowdown


### PR DESCRIPTION
# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

The Laser Designator is a JTACer's workhorse and it's CLUNKY AS HELL. 

This fixes two main bugs:

 * The `interactee` is not properly cleared when using the designator (or any zoomed item), causing it to be unset instead of set the next time you use it. This means if you look up then back down your designator, you can't laze.

 * The interaction system wasn't made with movement in mind. It is a problem because zoom system allows movement, and designators are where the two meet. Now, they can explicitely keep interaction despite movement.

# Explain why it's good for the game

QoL that should have been done 6 years ago, give or take

Because Zooming interactions are an awful mess, i'm flagging this for Testmerge where it'll inevitably break down

# Testing Photographs and Procedure
I take designator, i look, i try to laze. I put them down, move, do it again. And again. Several combinations of actions.

The unzoom logic is blatantly busted and out of scope of the PR.

# Changelog
:cl:
fix: Fixed Rangefinders/Designators preventing you from lazing if you looked up/down them without moving.
fix: Fixed Rangefinders/Designators forcing you to look up/down again if you had moved while using them.
/:cl:
