### PR TITLE
Fixes Smartfridge deletions + Turing/Smartfridge networking issue

### DIFF
--- a/code/game/machinery/kitchen/smartfridge.dm
+++ b/code/game/machinery/kitchen/smartfridge.dm
@@ -23,7 +23,7 @@
 	var/icon_on = "smartfridge"
 	var/icon_off = "smartfridge-off"
 	var/icon_panel = "smartfridge-panel"
-	var/item_quants = list()
+	var/list/item_quants = list() //! Assoc list of names -> list(items)
 	var/ispowered = TRUE //starts powered
 	var/is_secure_fridge = FALSE
 	var/shoot_inventory = FALSE
@@ -39,6 +39,24 @@
 	. = ..()
 	GLOB.vending_products[/obj/item/reagent_container/glass/bottle] = 1
 	GLOB.vending_products[/obj/item/storage/pill_bottle] = 1
+
+/obj/structure/machinery/smartfridge/Destroy(force)
+	if(is_in_network()) // Delete all contents from networked storage index
+		for(var/atom/movable/item as anything in contents)
+			delete_contents(item)
+	item_quants.Cut()
+	return ..() // parent will delete contents if we're not networked
+
+/// Deletes given object in contents of the smartfridge
+/obj/structure/machinery/smartfridge/proc/delete_contents(obj/item/item)
+	if(item.loc != src)
+		return
+	contents -= item
+	if(item_quants[item.name])
+		item_quants[item.name] -= item
+	if(is_in_network() && chemical_data.shared_item_storage[item.name])
+		chemical_data.shared_item_storage[item.name] -= item
+	qdel(item)
 
 /obj/structure/machinery/smartfridge/proc/accept_check(obj/item/O as obj)
 	if(istype(O,/obj/item/reagent_container/food/snacks/grown/) || istype(O,/obj/item/seeds/))

--- a/code/modules/reagents/chemistry_machinery/autodispenser.dm
+++ b/code/modules/reagents/chemistry_machinery/autodispenser.dm
@@ -346,8 +346,7 @@
 					C.reagents.trans_to(container, amount)
 					//We don't care about keeping empty bottles stored
 					if(C.reagents.total_volume <= 0 && istypestrict(C,/obj/item/reagent_container/glass/bottle))
-						linked_storage.item_quants[C.name]--
-						qdel(C) //Might want to connect it to a disposal system later instead
+						linked_storage.delete_contents(C)
 
 					if(stage_missing)
 						amount = stage_missing


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

This fixes 2 things:
 * Smartfridges deletion would not clean `item_quants` keeping references preventing contents deletion
 * The Turing machine was never updated to work with new Smartfridges and would botch `item_quants` when trying to delete empty bottles

The second would manifest as such in game logs:
`RUNTIME: type mismatch: -4 += Phoron bottle (/obj/item/reagent_container/glass/bottle) - code/game/machinery/kitchen/smartfridge.dm@136`
because the Turing was still using it as a number and not a list.

This probably fixes all sorts of weirdnesses with Turing/Fridge and possibly links to #4694 - but i recommend this be TMed by Real Research Mains to ensure nothing broke

# Explain why it's good for the game
Less bugs more consistency

# Testing Photographs and Procedure
Tested simple Turing usage, and chemical auto-bottling (looping phoron without new chems creation)

# Changelog
:cl:
fix: Fixed various issues in the Networking between Turing machine and Smartfridges.
/:cl:
