### PR TITLE
molotov

### DIFF
--- a/code/game/objects/items/explosives/grenades/marines.dm
+++ b/code/game/objects/items/explosives/grenades/marines.dm
@@ -329,6 +329,7 @@
 	arm_sound = 'sound/items/Welder2.ogg'
 	underslug_launchable = FALSE
 	fire_type = FIRE_VARIANT_DEFAULT
+	antigrief_protection = FALSE
 
 /obj/item/explosive/grenade/incendiary/molotov/New(loc, custom_burn_level)
 	det_time = rand(10,40) //Adds some risk to using this thing.


### PR DESCRIPTION
# About the pull request
Molotovs no longer have IFF antigrief inhibitors.
there is no room for goverment microchips on a glass bottle full of welding fuel.

# Explain why it's good for the game
bug bad ?
#4606

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Molotovs no longer have IFF inhibitors

/:cl:
