### PR TITLE
MP gaming

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -2274,10 +2274,17 @@
 	shell_speed = AMMO_SPEED_TIER_1 // Slightly faster
 	hit_effect_color = "#FFFF00"
 
-/datum/ammo/energy/taser/on_hit_mob(mob/M, obj/projectile/P)
-	if(ishuman(M))
-		var/mob/living/carbon/human/H = M
-		H.disable_special_items() // Disables scout cloak
+/datum/ammo/energy/taser/on_hit_mob(mob/morbius, obj/projectile/P)
+	if(ishuman(morbius))
+		var/mob/living/carbon/human/humanus = morbius
+		humanus.disable_special_items() // Disables scout cloak
+		if(!isyautja(humanus) && !issynth(humanus))
+			humanus.make_jittery(40)
+
+	if(isxeno(morbius))
+		var/mob/living/carbon/xenomorph/xenoids = morbius
+		xenoids.apply_effect(2, SLOW)
+		xenoids.xeno_jitter(1 SECONDS)
 
 /datum/ammo/energy/taser/precise
 	name = "precise taser bolt"


### PR DESCRIPTION

# About the pull request

Disablers will now slow xenomorphs on hit and make a Jittery effect.
Impacting a human 3 times with a disabler will make it jittery for a while.

# Explain why it's good for the game
Aliens usually are able to receive damage from electric shock i wanted to give it a snowflake effect.

humans will now shake when hit by the taser too.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: disablers can now affect xenomorphs.
qol: marines now shake while tased with a disabler.
/:cl:
