### PR TITLE
Almayer Maintenance, Fixes for the USS Almayers recent change(s)

### DIFF
--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -10929,7 +10929,9 @@
 	dir = 1;
 	name = "\improper Tool Closet"
 	},
-/turf/open/floor/plating/plating_catwalk,
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
 /area/almayer/living/port_emb)
 "aKN" = (
 /obj/structure/surface/table/reinforced/almayer_B,
@@ -12018,11 +12020,11 @@
 /area/almayer/medical/upper_medical)
 "aQD" = (
 /obj/structure/machinery/door/airlock/almayer/security{
+	access_modified = 1;
 	dir = 2;
 	name = "\improper Security Checkpoint";
 	req_access = null;
-	req_one_access_txt = "3;19";
-	access_modified = 1
+	req_one_access_txt = "3;19"
 	},
 /obj/structure/machinery/door/firedoor/border_only/almayer{
 	dir = 2
@@ -14286,10 +14288,10 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/starboard_hallway)
 "bbJ" = (
-/obj/structure/pipes/standard/manifold/hidden/supply,
-/turf/open/floor/almayer{
-	icon_state = "green"
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 10
 	},
+/turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/starboard_hallway)
 "bbL" = (
 /turf/open/floor/almayer{
@@ -22992,10 +22994,10 @@
 /area/almayer/squads/req)
 "bRS" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/generic{
+	access_modified = 1;
 	dir = 1;
 	name = "\improper Kitchen Hydroponics";
-	req_one_access_txt = "30;19";
-	access_modified = 1
+	req_one_access_txt = "30;19"
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -27136,7 +27138,7 @@
 /area/almayer/squads/delta)
 "cmc" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
+	dir = 5
 	},
 /obj/structure/machinery/cm_vending/sorted/medical/wall_med{
 	pixel_y = -30
@@ -31820,6 +31822,7 @@
 /area/almayer/shipboard/brig/general_equipment)
 "eai" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer,
 /area/almayer/living/port_emb)
 "ean" = (
@@ -32092,7 +32095,17 @@
 	pixel_x = -7;
 	pixel_y = -6
 	},
-/turf/open/floor/almayer,
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 1
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "S";
+	pixel_y = -1
+	},
+/turf/open/floor/almayer{
+	icon_state = "dark_sterile"
+	},
 /area/almayer/living/port_emb)
 "efh" = (
 /obj/structure/surface/table/almayer,
@@ -33151,7 +33164,9 @@
 	pixel_x = -21;
 	pixel_y = -14
 	},
-/turf/open/floor/plating/plating_catwalk,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
 /area/almayer/living/port_emb)
 "ezQ" = (
 /obj/structure/sign/safety/restrictedarea{
@@ -33187,7 +33202,12 @@
 /obj/structure/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/almayer,
+/obj/effect/decal/warning_stripes{
+	icon_state = "W"
+	},
+/turf/open/floor/almayer{
+	icon_state = "dark_sterile"
+	},
 /area/almayer/living/port_emb)
 "ezX" = (
 /obj/structure/bed/chair/wood/normal,
@@ -33825,14 +33845,10 @@
 	},
 /area/almayer/hull/lower_hull/l_f_p)
 "eOs" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/pipes/standard/manifold/hidden/supply,
 /turf/open/floor/almayer{
-	icon_state = "plate"
+	icon_state = "dark_sterile"
 	},
-/area/almayer/hallways/starboard_hallway)
+/area/almayer/living/port_emb)
 "eOM" = (
 /obj/structure/machinery/door/airlock/almayer/secure/reinforced{
 	dir = 2;
@@ -34179,6 +34195,9 @@
 /turf/open/floor/almayer,
 /area/almayer/living/offices)
 "eXE" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 6
+	},
 /turf/open/floor/almayer{
 	dir = 9;
 	icon_state = "green"
@@ -34212,8 +34231,14 @@
 	},
 /area/almayer/living/briefing)
 "eYv" = (
-/obj/structure/machinery/power/apc/almayer{
-	dir = 8
+/obj/structure/machinery/disposal,
+/obj/item/reagent_container/food/drinks/cans/beer{
+	layer = 3.3;
+	pixel_x = -4;
+	pixel_y = 15
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/living/port_emb)
@@ -35384,9 +35409,9 @@
 	icon_state = "therapyred";
 	layer = 4.1;
 	name = "Sergeant Huggs";
+	pixel_x = 7;
 	pixel_y = -1;
-	throwforce = 15;
-	pixel_x = 7
+	throwforce = 15
 	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
@@ -35514,7 +35539,17 @@
 /obj/structure/pipes/standard/manifold/hidden/supply{
 	dir = 8
 	},
-/turf/open/floor/almayer,
+/obj/effect/decal/warning_stripes{
+	icon_state = "SW-out";
+	pixel_y = -1
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "NW-out";
+	pixel_y = 1
+	},
+/turf/open/floor/almayer{
+	icon_state = "dark_sterile"
+	},
 /area/almayer/living/port_emb)
 "fBD" = (
 /obj/effect/decal/warning_stripes{
@@ -36258,11 +36293,14 @@
 /turf/closed/wall/almayer,
 /area/almayer/hull/upper_hull/u_m_p)
 "fQQ" = (
-/turf/open/floor/almayer_hull{
-	dir = 8;
-	icon_state = "outerhull_dir"
+/obj/structure/platform{
+	dir = 1
 	},
-/area/almayer/hull/lower_hull/l_m_p)
+/obj/structure/pipes/vents/pump{
+	dir = 4
+	},
+/turf/open/floor/almayer,
+/area/almayer/living/briefing)
 "fRr" = (
 /obj/structure/machinery/light{
 	dir = 1
@@ -36319,7 +36357,12 @@
 	pixel_y = 5
 	},
 /obj/item/tool/soap/syndie,
-/turf/open/floor/almayer,
+/obj/effect/decal/warning_stripes{
+	icon_state = "W"
+	},
+/turf/open/floor/almayer{
+	icon_state = "dark_sterile"
+	},
 /area/almayer/living/port_emb)
 "fTi" = (
 /obj/structure/largecrate/supply/floodlights,
@@ -37597,7 +37640,12 @@
 	pixel_x = 23;
 	specialfunctions = 4
 	},
-/turf/open/floor/almayer,
+/obj/effect/decal/warning_stripes{
+	icon_state = "W"
+	},
+/turf/open/floor/almayer{
+	icon_state = "dark_sterile"
+	},
 /area/almayer/living/port_emb)
 "gwR" = (
 /obj/item/device/flashlight/lamp/green,
@@ -37889,13 +37937,10 @@
 	},
 /area/almayer/squads/bravo)
 "gBg" = (
-/obj/item/reagent_container/food/drinks/cans/beer{
-	layer = 3.1;
-	pixel_x = -7;
-	pixel_y = 16
-	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plating/plating_catwalk,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
 /area/almayer/living/port_emb)
 "gBi" = (
 /obj/structure/pipes/vents/pump{
@@ -38271,6 +38316,10 @@
 /obj/structure/pipes/standard/manifold/hidden/supply{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/open/floor/almayer,
 /area/almayer/living/port_emb)
 "gLz" = (
@@ -38610,9 +38659,9 @@
 "gSZ" = (
 /obj/structure/surface/table/reinforced/almayer_B,
 /obj/structure/machinery/door/window/eastright{
+	access_modified = 1;
 	dir = 8;
-	req_access_txt = "19";
-	access_modified = 1
+	req_access_txt = "19"
 	},
 /obj/effect/landmark/map_item,
 /obj/structure/machinery/door/window/eastleft{
@@ -38886,9 +38935,9 @@
 /area/almayer/hull/upper_hull/u_m_p)
 "gZj" = (
 /obj/structure/machinery/door/airlock/almayer/generic{
+	access_modified = 1;
 	name = "Kitchen";
-	req_one_access_txt = "30;19";
-	access_modified = 1
+	req_one_access_txt = "30;19"
 	},
 /obj/structure/machinery/door/firedoor/border_only/almayer,
 /turf/open/floor/almayer{
@@ -39012,10 +39061,14 @@
 	},
 /area/almayer/living/auxiliary_officer_office)
 "hbx" = (
-/obj/structure/pipes/standard/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/hallways/port_hallway)
+/obj/structure/platform{
+	dir = 1
+	},
+/obj/structure/pipes/vents/scrubber{
+	dir = 4
+	},
+/turf/open/floor/almayer,
+/area/almayer/living/briefing)
 "hbI" = (
 /obj/item/ammo_magazine/shotgun/buckshot,
 /obj/item/ammo_magazine/shotgun/buckshot,
@@ -40250,10 +40303,10 @@
 /area/almayer/hallways/hangar)
 "hBL" = (
 /obj/structure/machinery/door/airlock/almayer/security{
+	access_modified = 1;
 	name = "\improper Security Checkpoint";
 	req_access = null;
-	req_one_access_txt = "3;19";
-	access_modified = 1
+	req_one_access_txt = "3;19"
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -40417,12 +40470,12 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/upper_hull/u_f_s)
 "hGI" = (
-/obj/structure/bed/chair/comfy/delta,
-/obj/structure/pipes/standard/manifold/hidden/supply{
-	dir = 8
+/obj/structure/bed/chair/comfy/bravo{
+	dir = 1
 	},
+/obj/structure/pipes/standard/manifold/hidden/supply,
 /turf/open/floor/almayer{
-	icon_state = "bluefull"
+	icon_state = "orangefull"
 	},
 /area/almayer/living/briefing)
 "hGN" = (
@@ -40690,9 +40743,9 @@
 	},
 /obj/structure/machinery/door/firedoor/border_only/almayer,
 /obj/structure/machinery/door/poddoor/shutters/almayer{
+	dir = 8;
 	id = "laddersoutheast";
-	name = "\improper South East Ladders Shutters";
-	dir = 8
+	name = "\improper South East Ladders Shutters"
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -41473,7 +41526,9 @@
 /area/almayer/living/port_emb)
 "iew" = (
 /obj/structure/bed/chair/comfy/charlie,
-/obj/structure/pipes/standard/simple/hidden/supply,
+/obj/structure/pipes/vents/scrubber{
+	dir = 4
+	},
 /obj/item/trash/uscm_mre,
 /turf/open/floor/almayer{
 	icon_state = "emeraldfull"
@@ -41946,10 +42001,10 @@
 /area/almayer/squads/req)
 "ipb" = (
 /obj/structure/machinery/door/airlock/almayer/maint{
+	access_modified = 1;
 	dir = 1;
 	req_one_access = null;
-	req_one_access_txt = "30;19";
-	access_modified = 1
+	req_one_access_txt = "30;19"
 	},
 /obj/structure/machinery/door/firedoor/border_only/almayer{
 	dir = 2
@@ -42484,11 +42539,16 @@
 	},
 /area/almayer/squads/delta)
 "iza" = (
-/obj/structure/pipes/standard/manifold/hidden/supply{
+/obj/structure/bed/chair/comfy/bravo{
+	dir = 1
+	},
+/obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
 	},
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/hallways/starboard_hallway)
+/turf/open/floor/almayer{
+	icon_state = "orangefull"
+	},
+/area/almayer/living/briefing)
 "izk" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N";
@@ -42585,12 +42645,14 @@
 /turf/open/floor/plating,
 /area/almayer/hull/upper_hull/u_m_p)
 "iBx" = (
-/obj/structure/window/framed/almayer,
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 2
+/obj/structure/bed/chair/comfy/bravo{
+	dir = 1
+	},
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 9
 	},
 /turf/open/floor/almayer{
-	icon_state = "redfull"
+	icon_state = "orangefull"
 	},
 /area/almayer/living/briefing)
 "iBE" = (
@@ -42611,14 +42673,12 @@
 	},
 /area/almayer/hull/lower_hull/l_m_p)
 "iBT" = (
-/obj/structure/bed/chair/comfy/bravo{
-	dir = 1
+/obj/structure/pipes/standard/manifold/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/pipes/standard/simple/hidden/supply,
-/turf/open/floor/almayer{
-	icon_state = "orangefull"
-	},
-/area/almayer/living/briefing)
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hallways/starboard_hallway)
 "iBY" = (
 /obj/structure/machinery/vending/snack,
 /turf/open/floor/almayer{
@@ -42928,7 +42988,9 @@
 	density = 0;
 	pixel_x = 26
 	},
-/turf/open/floor/almayer,
+/turf/open/floor/almayer{
+	icon_state = "dark_sterile"
+	},
 /area/almayer/living/port_emb)
 "iKb" = (
 /obj/structure/surface/table/almayer,
@@ -44098,11 +44160,11 @@
 /area/almayer/living/offices)
 "jhz" = (
 /obj/structure/machinery/door/airlock/almayer/security{
+	access_modified = 1;
 	dir = 2;
 	name = "\improper Security Checkpoint";
 	req_access = null;
-	req_one_access_txt = "3;19";
-	access_modified = 1
+	req_one_access_txt = "3;19"
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -44747,15 +44809,12 @@
 	},
 /area/almayer/hull/lower_hull/l_m_s)
 "jwI" = (
-/obj/structure/window/framed/almayer,
-/obj/structure/pipes/standard/simple/hidden/supply,
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 2
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/almayer{
-	icon_state = "orangefull"
-	},
-/area/almayer/living/briefing)
+/obj/structure/pipes/standard/manifold/hidden/supply,
+/turf/open/floor/almayer,
+/area/almayer/hallways/starboard_hallway)
 "jwK" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer{
@@ -45159,9 +45218,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/living/offices)
 "jKl" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 6
-	},
+/obj/structure/pipes/standard/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer{
 	icon_state = "green"
@@ -45728,7 +45785,7 @@
 /obj/structure/pipes/standard/manifold/hidden/supply{
 	dir = 1
 	},
-/turf/open/floor/plating/plating_catwalk,
+/turf/open/floor/almayer,
 /area/almayer/hallways/port_hallway)
 "jUW" = (
 /obj/effect/step_trigger/clone_cleaner,
@@ -46170,15 +46227,11 @@
 	},
 /area/almayer/medical/lower_medical_lobby)
 "keO" = (
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 2
+/obj/structure/pipes/standard/manifold/hidden/supply{
+	dir = 8
 	},
-/obj/structure/pipes/standard/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/hallways/port_hallway)
+/turf/open/floor/almayer,
+/area/almayer/living/briefing)
 "keR" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer,
@@ -46498,15 +46551,9 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/lifeboat_pumps/north2)
 "kmH" = (
-/obj/structure/bed/chair/comfy/bravo{
-	dir = 1
-	},
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 10
-	},
-/turf/open/floor/almayer{
-	icon_state = "orangefull"
-	},
+/obj/structure/platform,
+/obj/structure/pipes/vents/pump,
+/turf/open/floor/almayer,
 /area/almayer/living/briefing)
 "kmK" = (
 /obj/structure/platform{
@@ -46552,8 +46599,8 @@
 "knG" = (
 /obj/structure/surface/table/almayer,
 /obj/effect/landmark/map_item{
-	pixel_x = 7;
 	layer = 3.03;
+	pixel_x = 7;
 	pixel_y = 4
 	},
 /obj/item/prop/helmetgarb/spacejam_tickets{
@@ -47702,7 +47749,10 @@
 /obj/structure/machinery/door/firedoor/border_only/almayer{
 	dir = 2
 	},
-/turf/open/floor/almayer,
+/obj/structure/pipes/standard/simple/hidden/supply,
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
 /area/almayer/living/briefing)
 "kLp" = (
 /obj/structure/sign/safety/stairs{
@@ -47723,11 +47773,11 @@
 	dir = 2
 	},
 /obj/structure/machinery/door/airlock/almayer/security{
+	access_modified = 1;
 	dir = 2;
 	name = "\improper Security Checkpoint";
 	req_access = null;
-	req_one_access_txt = "3;19";
-	access_modified = 1
+	req_one_access_txt = "3;19"
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -47898,6 +47948,9 @@
 	},
 /area/almayer/hallways/aft_hallway)
 "kOH" = (
+/obj/structure/machinery/power/apc/almayer{
+	dir = 4
+	},
 /turf/open/floor/almayer{
 	dir = 5;
 	icon_state = "blue"
@@ -48018,12 +48071,12 @@
 "kRm" = (
 /obj/structure/surface/table/almayer,
 /obj/item/reagent_container/food/snacks/mre_pack/xmas2{
-	pixel_y = 9;
-	pixel_x = 5
+	pixel_x = 5;
+	pixel_y = 9
 	},
 /obj/effect/landmark/map_item{
-	pixel_x = -7;
 	layer = 3.03;
+	pixel_x = -7;
 	pixel_y = 4
 	},
 /obj/item/reagent_container/food/snacks/mre_pack/xmas3{
@@ -48238,9 +48291,7 @@
 	},
 /area/almayer/lifeboat_pumps/south2)
 "kVm" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 5
-	},
+/obj/structure/pipes/standard/manifold/hidden/supply,
 /turf/open/floor/almayer{
 	dir = 1;
 	icon_state = "green"
@@ -48292,8 +48343,8 @@
 /obj/structure/bed/chair/comfy/alpha{
 	dir = 1
 	},
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 6
+/obj/structure/pipes/vents/scrubber{
+	dir = 4
 	},
 /turf/open/floor/almayer{
 	icon_state = "redfull"
@@ -48425,13 +48476,11 @@
 	},
 /area/almayer/living/offices)
 "kZf" = (
-/obj/structure/bed/chair/comfy/alpha{
-	dir = 1
+/obj/structure/platform,
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
 	},
-/obj/structure/pipes/standard/simple/hidden/supply,
-/turf/open/floor/almayer{
-	icon_state = "redfull"
-	},
+/turf/open/floor/almayer,
 /area/almayer/living/briefing)
 "kZA" = (
 /turf/open/floor/almayer{
@@ -49057,7 +49106,9 @@
 	pixel_x = 23;
 	specialfunctions = 4
 	},
-/turf/open/floor/almayer,
+/turf/open/floor/almayer{
+	icon_state = "dark_sterile"
+	},
 /area/almayer/living/port_emb)
 "lne" = (
 /obj/structure/bed/chair,
@@ -49630,7 +49681,12 @@
 	pixel_x = -1;
 	pixel_y = 24
 	},
-/turf/open/floor/almayer,
+/obj/effect/decal/warning_stripes{
+	icon_state = "W"
+	},
+/turf/open/floor/almayer{
+	icon_state = "dark_sterile"
+	},
 /area/almayer/living/port_emb)
 "lwC" = (
 /obj/structure/desertdam/decals/road_edge{
@@ -49876,12 +49932,21 @@
 	},
 /area/almayer/squads/charlie)
 "lBz" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/pipes/standard/manifold/hidden/supply{
+	dir = 8
 	},
-/obj/structure/pipes/standard/manifold/hidden/supply,
-/turf/open/floor/almayer,
-/area/almayer/hallways/starboard_hallway)
+/obj/effect/decal/warning_stripes{
+	icon_state = "NW-out";
+	pixel_y = 1
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "SW-out";
+	pixel_y = -1
+	},
+/turf/open/floor/almayer{
+	icon_state = "dark_sterile"
+	},
+/area/almayer/living/port_emb)
 "lBF" = (
 /obj/structure/surface/table/almayer,
 /obj/effect/spawner/random/toolbox,
@@ -50048,6 +50113,10 @@
 	icon_state = "HotlineAlt";
 	layer = 2.9;
 	name = "Richard the tiger"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /turf/open/floor/almayer{
 	dir = 9;
@@ -50702,7 +50771,10 @@
 /obj/structure/machinery/door/firedoor/border_only/almayer{
 	dir = 2
 	},
-/turf/open/floor/almayer,
+/obj/structure/pipes/standard/simple/hidden/supply,
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
 /area/almayer/living/briefing)
 "lSD" = (
 /obj/structure/closet/firecloset,
@@ -50717,9 +50789,9 @@
 /obj/structure/machinery/door_control{
 	id = "laddersoutheast";
 	name = "South East Ladders Shutters";
+	pixel_y = 25;
 	req_one_access_txt = "2;3;12;19";
-	throw_range = 15;
-	pixel_y = 25
+	throw_range = 15
 	},
 /turf/open/floor/almayer{
 	dir = 1;
@@ -50750,14 +50822,14 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/upper_hull/u_f_p)
 "lUB" = (
-/obj/structure/bed/chair/comfy/charlie,
-/obj/structure/pipes/standard/manifold/hidden/supply{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/almayer{
-	icon_state = "emeraldfull"
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 9
 	},
-/area/almayer/living/briefing)
+/turf/open/floor/almayer,
+/area/almayer/hallways/port_hallway)
 "lVl" = (
 /obj/structure/machinery/cm_vending/sorted/tech/electronics_storage,
 /turf/open/floor/almayer,
@@ -51795,7 +51867,9 @@
 /obj/structure/pipes/standard/manifold/hidden/supply{
 	dir = 8
 	},
-/turf/open/floor/almayer,
+/turf/open/floor/almayer{
+	icon_state = "dark_sterile"
+	},
 /area/almayer/living/port_emb)
 "mtX" = (
 /obj/structure/closet/secure_closet/guncabinet/red,
@@ -52950,7 +53024,7 @@
 /obj/structure/pipes/standard/manifold/hidden/supply{
 	dir = 1
 	},
-/obj/structure/disposalpipe/junction{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plating/plating_catwalk,
@@ -53208,9 +53282,9 @@
 /obj/structure/machinery/door_control{
 	id = "laddersoutheast";
 	name = "South East Ladders Shutters";
+	pixel_y = 25;
 	req_one_access_txt = "2;3;12;19";
-	throw_range = 15;
-	pixel_y = 25
+	throw_range = 15
 	},
 /turf/open/floor/almayer{
 	dir = 1;
@@ -53905,15 +53979,24 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/upper_hull/u_f_s)
 "nob" = (
-/obj/structure/pipes/standard/manifold/hidden/supply{
-	dir = 4
+/obj/structure/sink{
+	dir = 1;
+	pixel_y = -10
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/structure/pipes/vents/scrubber{
+	dir = 1
 	},
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/hallways/port_hallway)
+/obj/structure/surface/rack{
+	density = 0;
+	pixel_x = 26
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "W"
+	},
+/turf/open/floor/almayer{
+	icon_state = "dark_sterile"
+	},
+/area/almayer/living/port_emb)
 "noj" = (
 /obj/structure/largecrate,
 /obj/structure/prop/server_equipment/laptop{
@@ -54419,9 +54502,9 @@
 /area/almayer/hallways/starboard_hallway)
 "nyO" = (
 /obj/structure/machinery/door/poddoor/shutters/almayer{
+	dir = 8;
 	id = "laddernortheast";
-	name = "\improper North East Ladders Shutters";
-	dir = 8
+	name = "\improper North East Ladders Shutters"
 	},
 /obj/structure/machinery/door/firedoor/border_only/almayer,
 /turf/open/floor/almayer{
@@ -54722,9 +54805,9 @@
 	dir = 4
 	},
 /obj/structure/machinery/door/poddoor/shutters/almayer{
+	dir = 8;
 	id = "laddernortheast";
-	name = "\improper North East Ladders Shutters";
-	dir = 8
+	name = "\improper North East Ladders Shutters"
 	},
 /obj/structure/machinery/door/firedoor/border_only/almayer,
 /turf/open/floor/almayer{
@@ -54812,6 +54895,7 @@
 /obj/structure/machinery/light{
 	dir = 4
 	},
+/obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer,
 /area/almayer/living/briefing)
 "nHg" = (
@@ -55236,9 +55320,7 @@
 /obj/structure/bed/chair/comfy/alpha{
 	dir = 1
 	},
-/obj/structure/pipes/standard/manifold/hidden/supply{
-	dir = 8
-	},
+/obj/structure/pipes/vents/pump,
 /turf/open/floor/almayer{
 	icon_state = "redfull"
 	},
@@ -55460,9 +55542,9 @@
 /obj/structure/machinery/door_control{
 	id = "laddernortheast";
 	name = "North East Ladders Shutters";
+	pixel_y = -25;
 	req_one_access_txt = "2;3;12;19";
-	throw_range = 15;
-	pixel_y = -25
+	throw_range = 15
 	},
 /turf/open/floor/almayer{
 	icon_state = "green"
@@ -56036,11 +56118,21 @@
 	},
 /area/almayer/medical/medical_science)
 "oiZ" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "SE-out";
+	pixel_y = -1
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "NE-out";
+	pixel_y = 1
+	},
 /obj/structure/machinery/door/airlock/almayer/maint{
 	dir = 8;
 	name = "\improper Tool Closet"
 	},
-/turf/open/floor/almayer,
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
 /area/almayer/living/port_emb)
 "ojF" = (
 /obj/structure/machinery/cm_vending/clothing/tl/charlie{
@@ -56360,12 +56452,14 @@
 "oqc" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/machinery/door/airlock/almayer/maint{
+	access_modified = 1;
 	dir = 1;
 	req_one_access = null;
-	req_one_access_txt = "30;19";
-	access_modified = 1
+	req_one_access_txt = "30;19"
 	},
-/turf/open/floor/plating/plating_catwalk,
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
 /area/almayer/living/port_emb)
 "oqu" = (
 /obj/structure/machinery/disposal,
@@ -57264,9 +57358,9 @@
 "oJq" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer,
 /obj/structure/machinery/door/poddoor/shutters/almayer{
+	dir = 8;
 	id = "laddersoutheast";
-	name = "\improper South East Ladders Shutters";
-	dir = 8
+	name = "\improper South East Ladders Shutters"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -57511,16 +57605,6 @@
 	icon_state = "plating"
 	},
 /area/almayer/medical/upper_medical)
-"oNO" = (
-/obj/structure/window/framed/almayer,
-/obj/structure/pipes/standard/simple/hidden/supply,
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 2
-	},
-/turf/open/floor/almayer{
-	icon_state = "redfull"
-	},
-/area/almayer/living/briefing)
 "oOO" = (
 /obj/structure/sign/safety/debark_lounge{
 	pixel_x = 15;
@@ -57532,8 +57616,8 @@
 /area/almayer/command/lifeboat)
 "oPa" = (
 /obj/structure/sign/safety/storage{
-	pixel_y = -32;
-	pixel_x = 8
+	pixel_x = 8;
+	pixel_y = -32
 	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
@@ -57648,9 +57732,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/pipes/standard/manifold/hidden/supply{
-	dir = 4
-	},
+/obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/port_hallway)
 "oRj" = (
@@ -57976,11 +58058,11 @@
 /area/almayer/medical/lower_medical_medbay)
 "oZX" = (
 /obj/structure/machinery/door/airlock/almayer/medical/glass{
+	access_modified = 1;
 	dir = 2;
 	name = "\improper Field Surgery Equipment";
 	req_access_txt = "20";
-	req_one_access = null;
-	access_modified = 1
+	req_one_access = null
 	},
 /obj/structure/machinery/door/firedoor/border_only/almayer{
 	dir = 1
@@ -58508,16 +58590,6 @@
 	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical_medbay)
-"pon" = (
-/obj/structure/bed/chair/comfy/charlie,
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 10
-	},
-/obj/item/trash/uscm_mre,
-/turf/open/floor/almayer{
-	icon_state = "emeraldfull"
-	},
-/area/almayer/living/briefing)
 "pop" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 1
@@ -59383,7 +59455,7 @@
 /turf/open/floor/almayer,
 /area/almayer/lifeboat_pumps/south1)
 "pIX" = (
-/obj/structure/pipes/standard/manifold/hidden/supply,
+/obj/structure/pipes/standard/manifold/fourway/hidden/supply,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -60104,10 +60176,10 @@
 /area/almayer/squads/req)
 "pXW" = (
 /obj/structure/bed/chair/comfy/delta,
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 9
-	},
 /obj/item/trash/popcorn,
+/obj/structure/pipes/standard/manifold/hidden/supply{
+	dir = 1
+	},
 /turf/open/floor/almayer{
 	icon_state = "bluefull"
 	},
@@ -60340,7 +60412,10 @@
 /obj/structure/machinery/door/firedoor/border_only/almayer{
 	dir = 2
 	},
-/turf/open/floor/almayer,
+/obj/structure/pipes/standard/simple/hidden/supply,
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
 /area/almayer/living/briefing)
 "qdk" = (
 /obj/structure/surface/table/almayer,
@@ -60884,15 +60959,6 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/living/pilotbunks)
-"qnM" = (
-/obj/structure/window/framed/almayer,
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 2
-	},
-/turf/open/floor/almayer{
-	icon_state = "orangefull"
-	},
-/area/almayer/living/briefing)
 "qnP" = (
 /obj/structure/prop/invuln/overhead_pipe{
 	pixel_x = 12
@@ -61159,15 +61225,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/hallways/port_hallway)
-"quJ" = (
-/obj/structure/window/framed/almayer,
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 2
-	},
-/turf/open/floor/almayer{
-	icon_state = "emeraldfull"
-	},
-/area/almayer/living/briefing)
 "quT" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer{
 	layer = 1.9
@@ -61203,8 +61260,8 @@
 	},
 /area/almayer/shipboard/brig/cryo)
 "qvy" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
+/obj/structure/pipes/standard/manifold/hidden/supply{
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -62242,9 +62299,6 @@
 /obj/structure/bed/chair/comfy/bravo{
 	dir = 1
 	},
-/obj/structure/pipes/standard/manifold/hidden/supply{
-	dir = 4
-	},
 /obj/item/stack/folding_barricade,
 /obj/item/stack/sheet/mineral/uranium{
 	layer = 2.99
@@ -62655,6 +62709,7 @@
 	icon_state = "poster2";
 	pixel_x = -27
 	},
+/obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer,
 /area/almayer/living/briefing)
 "rbp" = (
@@ -63357,15 +63412,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/command/cichallway)
-"rpN" = (
-/obj/structure/bed/chair/comfy/charlie,
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 5
-	},
-/turf/open/floor/almayer{
-	icon_state = "emeraldfull"
-	},
-/area/almayer/living/briefing)
 "rpW" = (
 /obj/structure/prop/invuln/overhead_pipe{
 	pixel_x = 12
@@ -63638,7 +63684,12 @@
 /obj/structure/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/almayer,
+/obj/effect/decal/warning_stripes{
+	icon_state = "W"
+	},
+/turf/open/floor/almayer{
+	icon_state = "dark_sterile"
+	},
 /area/almayer/living/port_emb)
 "rvo" = (
 /obj/structure/machinery/power/apc/almayer{
@@ -63789,13 +63840,6 @@
 "rAb" = (
 /turf/open/floor/almayer{
 	icon_state = "bluecorner"
-	},
-/area/almayer/living/briefing)
-"rAt" = (
-/obj/structure/bed/chair/comfy/delta,
-/obj/structure/pipes/standard/simple/hidden/supply,
-/turf/open/floor/almayer{
-	icon_state = "bluefull"
 	},
 /area/almayer/living/briefing)
 "rAv" = (
@@ -64295,16 +64339,6 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/medical/lower_medical_lobby)
-"rIm" = (
-/obj/structure/window/framed/almayer,
-/obj/structure/pipes/standard/simple/hidden/supply,
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 2
-	},
-/turf/open/floor/almayer{
-	icon_state = "emeraldfull"
-	},
-/area/almayer/living/briefing)
 "rID" = (
 /turf/open/floor/almayer{
 	dir = 6;
@@ -64432,6 +64466,7 @@
 /obj/structure/sign/poster/safety{
 	pixel_x = 27
 	},
+/obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer,
 /area/almayer/living/briefing)
 "rKy" = (
@@ -64484,9 +64519,9 @@
 	},
 /obj/structure/machinery/door/firedoor/border_only/almayer,
 /obj/structure/machinery/door/poddoor/shutters/almayer{
+	dir = 8;
 	id = "laddersoutheast";
-	name = "\improper South East Ladders Shutters";
-	dir = 8
+	name = "\improper South East Ladders Shutters"
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -64740,7 +64775,9 @@
 /obj/structure/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/almayer,
+/turf/open/floor/almayer{
+	icon_state = "dark_sterile"
+	},
 /area/almayer/living/port_emb)
 "rTk" = (
 /obj/structure/pipes/standard/manifold/hidden/supply{
@@ -65204,13 +65241,11 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/upper_hull/u_a_s)
 "sfT" = (
-/obj/structure/pipes/vents/scrubber{
-	dir = 4
-	},
 /obj/structure/sign/poster{
 	icon_state = "poster14";
 	pixel_x = -27
 	},
+/obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer,
 /area/almayer/living/briefing)
 "sfU" = (
@@ -66029,12 +66064,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/living/bridgebunks)
-"sxH" = (
-/turf/open/floor/almayer_hull{
-	dir = 10;
-	icon_state = "outerhull_dir"
-	},
-/area/almayer/hull/lower_hull/l_m_p)
 "syH" = (
 /obj/structure/machinery/firealarm{
 	pixel_y = -28
@@ -66274,8 +66303,8 @@
 	dir = 8
 	},
 /turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "emeraldcorner"
+	dir = 8;
+	icon_state = "emerald"
 	},
 /area/almayer/hallways/port_hallway)
 "sEa" = (
@@ -68064,12 +68093,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/hull/upper_hull/u_a_p)
-"tpY" = (
-/turf/open/floor/almayer_hull{
-	dir = 9;
-	icon_state = "outerhull_dir"
-	},
-/area/almayer/hull/lower_hull/l_m_s)
 "tqe" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -68341,12 +68364,6 @@
 /obj/item/bedsheet/purple{
 	pixel_y = 13
 	},
-/obj/item/clothing/head/beret/centcom/captain{
-	color = "#4b5320";
-	desc = "Dusty beret bearing the logo of the royal marines. How did this get here?";
-	name = "dusty beret";
-	pixel_y = -6
-	},
 /obj/structure/window/reinforced{
 	dir = 4;
 	pixel_x = -2;
@@ -68365,6 +68382,8 @@
 	layer = 3.5;
 	pixel_y = 13
 	},
+/obj/item/clothing/head/beret/royal_marine,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer{
 	dir = 10;
 	icon_state = "emerald"
@@ -68749,7 +68768,10 @@
 /obj/structure/machinery/door/firedoor/border_only/almayer{
 	dir = 2
 	},
-/turf/open/floor/almayer,
+/obj/structure/pipes/standard/simple/hidden/supply,
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
 /area/almayer/living/briefing)
 "tDA" = (
 /obj/item/tool/weldpack{
@@ -68962,6 +68984,9 @@
 /area/almayer/shipboard/brig/cells)
 "tIb" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/almayer{
@@ -70334,13 +70359,6 @@
 	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical_medbay)
-"uoc" = (
-/obj/structure/bed/chair/comfy/charlie,
-/obj/structure/pipes/standard/simple/hidden/supply,
-/turf/open/floor/almayer{
-	icon_state = "emeraldfull"
-	},
-/area/almayer/living/briefing)
 "uoi" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
@@ -71207,6 +71225,7 @@
 /obj/structure/machinery/light{
 	dir = 8
 	},
+/obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer,
 /area/almayer/living/briefing)
 "uDn" = (
@@ -72145,15 +72164,6 @@
 	dir = 8
 	},
 /area/almayer/medical/containment/cell)
-"uXu" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/pipes/standard/manifold/hidden/supply{
-	dir = 1
-	},
-/turf/open/floor/almayer,
-/area/almayer/hallways/port_hallway)
 "uXL" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
@@ -72415,9 +72425,9 @@
 /obj/structure/pipes/standard/manifold/hidden/supply{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/structure/disposalpipe/junction{
+	dir = 2;
+	icon_state = "pipe-j2"
 	},
 /turf/open/floor/almayer,
 /area/almayer/living/port_emb)
@@ -73009,12 +73019,12 @@
 /area/almayer/hull/lower_hull/l_m_p)
 "voW" = (
 /obj/structure/machinery/door/airlock/almayer/maint{
+	access_modified = 1;
 	dir = 8;
-	req_one_access = list(2,34,30);
-	access_modified = 1
+	req_one_access = list(2,34,30)
 	},
 /turf/open/floor/almayer{
-	icon_state = "plate"
+	icon_state = "test_floor4"
 	},
 /area/almayer/hull/lower_hull/l_m_s)
 "vpn" = (
@@ -75288,7 +75298,17 @@
 	icon_state = "tube-broken";
 	name = "broken light fixture"
 	},
-/turf/open/floor/almayer,
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 1
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "S";
+	pixel_y = -1
+	},
+/turf/open/floor/almayer{
+	icon_state = "dark_sterile"
+	},
 /area/almayer/living/port_emb)
 "whA" = (
 /turf/open/floor/almayer/uscm/directional,
@@ -76238,11 +76258,6 @@
 	icon_state = "redcorner"
 	},
 /area/almayer/living/briefing)
-"wCK" = (
-/turf/open/floor/almayer_hull{
-	icon_state = "outerhull_dir"
-	},
-/area/almayer/hull/lower_hull/l_m_p)
 "wCM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -76589,11 +76604,19 @@
 /turf/closed/wall/almayer/research/containment/wall/east,
 /area/almayer/medical/containment/cell/cl)
 "wKd" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "SE-out";
+	pixel_y = -1
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "NE-out";
+	pixel_y = 1
+	},
 /obj/structure/machinery/door/airlock/almayer/maint{
 	dir = 8
 	},
 /turf/open/floor/almayer{
-	icon_state = "plate"
+	icon_state = "test_floor4"
 	},
 /area/almayer/living/port_emb)
 "wKn" = (
@@ -77198,7 +77221,17 @@
 	},
 /area/almayer/hull/lower_hull/l_f_s)
 "wVK" = (
-/turf/open/floor/almayer,
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 1
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "S";
+	pixel_y = -1
+	},
+/turf/open/floor/almayer{
+	icon_state = "dark_sterile"
+	},
 /area/almayer/living/port_emb)
 "wVP" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
@@ -78253,6 +78286,9 @@
 	dir = 1;
 	icon_state = "p_stair_full"
 	},
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 5
+	},
 /turf/open/floor/almayer,
 /area/almayer/living/briefing)
 "xtD" = (
@@ -79222,12 +79258,6 @@
 	dir = 6
 	},
 /area/almayer/command/cic)
-"xMK" = (
-/turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "emeraldcorner"
-	},
-/area/almayer/hallways/port_hallway)
 "xML" = (
 /obj/structure/machinery/computer/cameras/wooden_tv/prop{
 	pixel_x = -4;
@@ -79347,9 +79377,9 @@
 /obj/structure/machinery/door_control{
 	id = "laddernortheast";
 	name = "North East Ladders Shutters";
+	pixel_y = -25;
 	req_one_access_txt = "2;3;12;19";
-	throw_range = 15;
-	pixel_y = -25
+	throw_range = 15
 	},
 /turf/open/floor/almayer{
 	icon_state = "green"
@@ -79562,9 +79592,9 @@
 /area/almayer/shipboard/brig/lobby)
 "xSE" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/generic{
+	access_modified = 1;
 	name = "\improper Main Kitchen";
-	req_one_access_txt = "30;19";
-	access_modified = 1
+	req_one_access_txt = "30;19"
 	},
 /turf/open/floor/prison{
 	icon_state = "kitchen"
@@ -114329,7 +114359,7 @@ bdH
 bdH
 bdH
 bdH
-tpY
+aac
 aKW
 aKW
 aKW
@@ -114405,7 +114435,7 @@ yhQ
 yhQ
 yhQ
 yhQ
-sxH
+ajY
 aaa
 aaa
 aaa
@@ -114759,7 +114789,7 @@ aSh
 ccF
 tGG
 tGG
-iBx
+bdg
 aLG
 awb
 aLG
@@ -114787,7 +114817,7 @@ bdg
 buH
 hOR
 buH
-quJ
+bdg
 sNI
 wAU
 diw
@@ -114962,7 +114992,7 @@ tGG
 tGG
 tGG
 tGG
-iBx
+bdg
 aLG
 aYO
 aLG
@@ -114990,7 +115020,7 @@ bdg
 buH
 bHL
 buH
-quJ
+bdg
 sNI
 sNI
 sNI
@@ -115165,7 +115195,7 @@ tGG
 tGG
 tGG
 tGG
-iBx
+bdg
 aLG
 aYO
 aLG
@@ -115193,7 +115223,7 @@ bdg
 buH
 bHL
 buH
-quJ
+bdg
 sNI
 csG
 sNI
@@ -115353,7 +115383,7 @@ wVK
 viu
 nsY
 iIP
-wVK
+eOs
 dDt
 nsY
 xiz
@@ -115365,12 +115395,12 @@ bDQ
 kbV
 tGG
 kWF
-kZf
+tGG
 nQd
-kZf
-oNO
-crW
-eOs
+tGG
+bdg
+beB
+aYT
 beB
 bCx
 bqZ
@@ -115394,15 +115424,15 @@ beH
 bqZ
 bCx
 buH
-jUT
-bFu
-rIm
-rAt
-rAt
-hGI
-rAt
+bHL
+buH
+bdg
+sNI
+sNI
+sNI
+sNI
 pXW
-wNT
+kmH
 udV
 bdd
 hTf
@@ -115567,13 +115597,13 @@ bdd
 bqZ
 qgw
 beH
-duv
+qMR
 nGZ
-rJK
+dRT
 rKw
 qcN
-aLG
-aZi
+tBF
+iBT
 aLG
 nyw
 bqZ
@@ -115598,13 +115628,13 @@ vKe
 eVv
 bFu
 pIX
-buH
+bFu
 lSh
-beH
-beH
-rJK
-beH
-beH
+eBg
+eBg
+eBg
+eBg
+fOk
 epq
 bqZ
 bdd
@@ -115614,12 +115644,12 @@ wGb
 gUf
 nsY
 gwO
-mtS
+lBz
 ezW
 nsY
 lwA
-mtS
-iKa
+lBz
+nob
 nsY
 oDf
 oed
@@ -115827,8 +115857,8 @@ nsY
 oDf
 uqH
 yhQ
-fQQ
-fQQ
+aaf
+aaf
 ajY
 aaa
 aaa
@@ -115972,14 +116002,14 @@ aLf
 bdd
 bqZ
 kKL
-beH
-fcf
+aLJ
+eBg
 uCX
 sfT
-beH
+eBg
 tDz
-aLG
-awb
+tBF
+jwI
 aLG
 iuy
 bqZ
@@ -116003,13 +116033,13 @@ beH
 bqZ
 bdg
 buH
-hOR
-buH
+jUT
+bFu
 kLo
-beH
-beH
-duv
-beH
+eBg
+keO
+eBg
+eBg
 rbl
 xtc
 bqZ
@@ -116032,7 +116062,7 @@ oDf
 yhQ
 yhQ
 yhQ
-wCK
+ajZ
 aaa
 aaa
 aaa
@@ -116174,15 +116204,15 @@ lQu
 aSm
 bdd
 bDQ
-kbV
+fQQ
+hGI
 wmz
-kmH
-iBT
+wmz
 qRp
-iBT
-jwI
-tBF
-lBz
+wmz
+bdg
+aLG
+awb
 aLG
 bdg
 bqZ
@@ -116206,15 +116236,15 @@ bqZ
 bqZ
 bdg
 buH
-uXu
-bFu
-rIm
-uoc
+hOR
+buH
+bdg
+wLV
 iew
-lUB
-uoc
-rpN
-wNT
+wLV
+wLV
+wLV
+kZf
 bqZ
 bdd
 gKB
@@ -116378,12 +116408,12 @@ vUi
 bdd
 vTt
 kbV
-wmz
+iza
 vEn
 wmz
 wmz
 wmz
-qnM
+bdg
 aLG
 aYO
 bad
@@ -116411,12 +116441,12 @@ bdd
 bGe
 bHL
 buH
-quJ
+bdg
 wLV
 wLV
 wLV
 wLV
-pon
+gKH
 ldj
 cab
 bdd
@@ -116580,13 +116610,13 @@ qce
 aSm
 bdd
 bqZ
-kbV
+hbx
+iBx
 wmz
 wmz
 wmz
 wmz
-wmz
-qnM
+bdg
 beB
 aYT
 beB
@@ -116614,7 +116644,7 @@ bJz
 bJz
 bHT
 bJz
-quJ
+bdg
 wLV
 wLV
 wLV
@@ -116789,7 +116819,7 @@ vpt
 kQU
 wmz
 wmz
-qnM
+bdg
 aLG
 aYO
 aLG
@@ -116817,7 +116847,7 @@ buH
 buH
 bHL
 buH
-quJ
+bdg
 gKH
 cgz
 vyU
@@ -117227,8 +117257,8 @@ buH
 cbD
 iZH
 sDQ
-hOR
-xMK
+njL
+njL
 njL
 njL
 cbD
@@ -117240,7 +117270,7 @@ rdY
 bUM
 cbD
 eXE
-hOR
+lUB
 kJV
 fiq
 fiq
@@ -117425,12 +117455,12 @@ bdg
 buH
 bHa
 mTk
-hbx
-hvp
-keO
-hbx
-hbx
-nob
+buI
+bFu
+cbE
+buI
+buI
+buI
 buI
 buI
 buI
@@ -117443,7 +117473,7 @@ buI
 buI
 rpd
 kVm
-bHL
+bHY
 kro
 bGb
 uaa
@@ -117584,8 +117614,8 @@ nHF
 nHF
 aLB
 csl
-iza
-bbJ
+gjn
+jJs
 bBh
 aMM
 aMM
@@ -117787,7 +117817,7 @@ nHF
 nHF
 jUx
 aLG
-aNO
+bbJ
 cmc
 jeb
 jeb


### PR DESCRIPTION
# About the pull request

This PR attempts to fix, inconsistencies with floortile detailing, bugs, and other issues with the USS Almayer


# Explain why it's good for the game

Mostly some things were missed and some detailing consistencies should be maintained 


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:SpartanBobby
maptweak: fixes lack of warning stripes under doors in squad briefing areas and newly added maint doors onboard USS Almayer
maptweak: fixes incorrect tiles used under window frames in new squad briefing areas onboard USS Almayer
maptweak: fixes pipe sections under window frames in new squad briefing areas onboard USS Almayer
maptweak: fixes pipes that lead nowhere in new squad briefing areas onboard USS Almayer
maptweak: fixes button that was being hidden by light due to recent USS Almayer changes
maptweak: corrects strangely laid out vent sections due to recent USS Almayer changes
maptweak: makes USS Almayer Bunks consistent with the rest of the ship's shower and bathrooms
maptweak: updates "Dusty Beret" prop item to now be the RMC Beret it was originally referencing (now that the RMC are ingame) 
/:cl:
