### PR TITLE
Allows MT, CT, and Nurse to take the "Bad Leg" trait.

### DIFF
--- a/code/modules/character_traits/biology_traits.dm
+++ b/code/modules/character_traits/biology_traits.dm
@@ -85,14 +85,14 @@
 /datum/character_trait/biology/bad_leg/New()
 	. = ..()
 	// Not on definition as several lists are added
-	inapplicable_roles = list(JOB_NURSE, JOB_PILOT, JOB_DROPSHIP_CREW_CHIEF, JOB_CREWMAN, JOB_INTEL, JOB_MAINT_TECH, JOB_ORDNANCE_TECH, JOB_CARGO_TECH, JOB_MARINE) + JOB_SQUAD_ROLES_LIST + JOB_MARINE_RAIDER_ROLES_LIST + JOB_ERT_GRUNT_LIST
+	inapplicable_roles = list(JOB_PILOT, JOB_DROPSHIP_CREW_CHIEF, JOB_CREWMAN, JOB_INTEL, JOB_ORDNANCE_TECH, JOB_MARINE) + JOB_SQUAD_ROLES_LIST + JOB_MARINE_RAIDER_ROLES_LIST + JOB_ERT_GRUNT_LIST
 	bad_cane_roles = list(JOB_SURVIVOR, JOB_STOWAWAY)
 	fancy_cane_roles = list(JOB_CO_SURVIVOR, CORPORATE_SURVIVOR, JOB_CMO, JOB_CORPORATE_LIAISON, JOB_SEA, JOB_CHIEF_ENGINEER) + JOB_COMMAND_ROLES_LIST
 	inapplicable_species = list(SPECIES_SYNTHETIC, SPECIES_YAUTJA)
 
 /datum/character_trait/biology/bad_leg/apply_trait(mob/living/carbon/human/target, datum/equipment_preset/preset)
 	if(target.job in inapplicable_roles)
-		to_chat(target, SPAN_WARNING("Your office is too combat-geared or starter for you to be able to recieve the bad leg trait."))
+		to_chat(target, SPAN_WARNING("Your office is too combat-geared for you to be able to recieve the bad leg trait."))
 		return
 	if(target.species.group in inapplicable_species)
 		to_chat(target, SPAN_WARNING("Your species is too sophisticated for you be able to recieve the bad leg trait."))


### PR DESCRIPTION
# About the pull request

This does as the title says, allowing Maintenance Techs, Cargo Techs, and Nurses to take the Bad Leg trait.

# Explain why it's good for the game

The reason that these roles *specifically* couldn't take this trait was due to them being "too rookie" which I think is a bit silly to say.  Even if we take all three of these to be roles only new players play (they aren't, definitely not MT or CT) - the player still intentionally had to go in and take the trait and therefore is assumed to accept the traits mechanics.  If they have an issue with the trait or handling it because they are new then that is an issue that can be resolved by them not taking detrimental traits.

Forgive me if the cl tagging is wrong, this is not my codebase this just annoyed me enough to PR it.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl:
qol: MT, CT, and Nurses can now take the bad leg trait.
/:cl: