### PR TITLE
Fixes minor runtime in CAS Guidance system

### DIFF
--- a/code/game/cas_manager/datums/cas_fire_envelope.dm
+++ b/code/game/cas_manager/datums/cas_fire_envelope.dm
@@ -181,7 +181,7 @@
 		apply_upgrade(user)
 		if(!(user in guidance.users))
 			guidance.users += user
-			RegisterSignal(usr, COMSIG_MOB_RESISTED, PROC_REF(exit_cam_resist))
+			RegisterSignal(user, COMSIG_MOB_RESISTED, PROC_REF(exit_cam_resist))
 
 
 /datum/cas_fire_envelope/proc/apply_upgrade(user)
@@ -220,6 +220,7 @@
 			M.reset_view()
 			remove_upgrades(user)
 		guidance.users -= user
+		UnregisterSignal(user, COMSIG_MOB_RESISTED)
 
 /datum/cas_fire_envelope/proc/exit_cam_resist(mob/user)
 	SIGNAL_HANDLER


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

Recurring runtime on live server due to lack of unregistering the signal handler

```
proc name: stack trace (/proc/stack_trace)
  source file: code/__HELPERS/unsorted.dm,1893
  usr: CKEY (/mob/living/carbon/human)
  src: null
  usr.loc: the floor (135,75,4) (/turf/open/shuttle/dropship)
  call stack:
stack trace("mob_resist overridden. Use ove...")
/datum/cas_fire_envelope/uscm_... (/datum/cas_fire_envelope/uscm_dropship): RegisterSignal(CKEY (/mob/living/carbon/human), "mob_resist", "exit_cam_resist", 0)
/datum/cas_fire_envelope/uscm_... (/datum/cas_fire_envelope/uscm_dropship): add user to tracking(CKEY (/mob/living/carbon/human))
...
```

# Explain why it's good for the game
Less runtimes in log

# Testing Photographs and Procedure
Untested

# Changelog
No user facing changes
