### PR TITLE
Expands LV Fog To Most Maps

### DIFF
--- a/maps/map_files/BigRed/BigRed.dmm
+++ b/maps/map_files/BigRed/BigRed.dmm
@@ -2709,6 +2709,7 @@
 	},
 /area/bigredv2/outside/n)
 "ahT" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor{
 	dir = 6;
 	icon_state = "asteroidwarning"
@@ -7309,6 +7310,7 @@
 	},
 /area/bigredv2/outside/n)
 "auF" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor{
 	dir = 5;
 	icon_state = "asteroidwarning"
@@ -20182,7 +20184,6 @@
 /area/bigredv2/outside/office_complex)
 "beP" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/mars_cave{
 	icon_state = "mars_dirt_4"
 	},
@@ -23049,7 +23050,6 @@
 	},
 /area/bigredv2/outside/sw)
 "bpy" = (
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/mars{
 	icon_state = "mars_dirt_12"
 	},
@@ -23248,7 +23248,6 @@
 	},
 /area/bigredv2/outside/space_port_lz2)
 "bqe" = (
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor{
 	dir = 5;
 	icon_state = "asteroidwarning"
@@ -23722,7 +23721,6 @@
 /turf/open/floor,
 /area/bigredv2/outside/filtration_cave_cas)
 "bsI" = (
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/mars{
 	icon_state = "mars_dirt_3"
 	},
@@ -27180,13 +27178,6 @@
 	icon_state = "dark"
 	},
 /area/bigredv2/outside/marshal_office)
-"bPv" = (
-/obj/effect/landmark/lv624/fog_blocker/short,
-/turf/open/floor{
-	dir = 1;
-	icon_state = "asteroidfloor"
-	},
-/area/bigredv2/outside/w)
 "bPy" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_nest,
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_nest,
@@ -27415,13 +27406,6 @@
 /obj/structure/blocker/forcefield/multitile_vehicles,
 /turf/closed/wall/solaris/rock,
 /area/bigredv2/caves)
-"cod" = (
-/obj/effect/landmark/lv624/fog_blocker/short,
-/turf/open/floor{
-	dir = 8;
-	icon_state = "asteroidwarning"
-	},
-/area/bigredv2/outside/sw)
 "coT" = (
 /obj/effect/landmark/objective_landmark/science,
 /turf/open/floor{
@@ -28082,10 +28066,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/bigredv2/caves/mining)
-"dJY" = (
-/obj/effect/landmark/lv624/fog_blocker/short,
-/turf/open/mars_cave,
-/area/bigredv2/outside/lz2_west_cas)
 "dKo" = (
 /obj/item/ore/iron{
 	pixel_x = 6;
@@ -28225,12 +28205,6 @@
 /obj/structure/closet/toolcloset,
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
-"dXe" = (
-/obj/effect/landmark/lv624/fog_blocker/short,
-/turf/open/mars{
-	icon_state = "mars_dirt_11"
-	},
-/area/bigredv2/outside/w)
 "dXs" = (
 /obj/item/tool/pickaxe{
 	pixel_y = 12
@@ -28320,6 +28294,10 @@
 	icon_state = "asteroidfloor"
 	},
 /area/bigred/ground/garage_workshop)
+"edv" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/mars_cave,
+/area/bigredv2/outside/lz1_telecomm_cas)
 "egI" = (
 /obj/item/ore,
 /obj/item/ore{
@@ -29031,13 +29009,6 @@
 	icon_state = "darkred2"
 	},
 /area/bigredv2/caves/eta/research)
-"fEx" = (
-/obj/effect/landmark/lv624/fog_blocker/short,
-/turf/open/floor{
-	dir = 4;
-	icon_state = "asteroidwarning"
-	},
-/area/bigredv2/outside/space_port_lz2)
 "fFG" = (
 /obj/structure/largecrate/random/barrel,
 /turf/open/mars_cave{
@@ -29189,10 +29160,6 @@
 	icon_state = "mars_cave_17"
 	},
 /area/bigredv2/caves/mining)
-"fQN" = (
-/obj/effect/landmark/lv624/fog_blocker/short,
-/turf/open/mars,
-/area/bigredv2/outside/w)
 "fRo" = (
 /obj/item/tool/pickaxe/drill,
 /turf/open/mars_cave{
@@ -29442,13 +29409,6 @@
 	icon_state = "mars_dirt_4"
 	},
 /area/space)
-"gtv" = (
-/obj/effect/landmark/lv624/fog_blocker/short,
-/turf/open/floor{
-	dir = 1;
-	icon_state = "asteroidfloor"
-	},
-/area/bigredv2/outside/space_port_lz2)
 "gtX" = (
 /turf/open/mars_cave,
 /area/bigredv2/caves_se)
@@ -29541,13 +29501,6 @@
 	icon_state = "mars_cave_2"
 	},
 /area/bigredv2/caves_east)
-"gFj" = (
-/obj/effect/landmark/lv624/fog_blocker/short,
-/turf/open/floor{
-	dir = 8;
-	icon_state = "asteroidwarning"
-	},
-/area/bigredv2/outside/w)
 "gGO" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating{
@@ -29571,13 +29524,6 @@
 	icon_state = "mars_cave_4"
 	},
 /area/bigredv2/caves_virology)
-"gMl" = (
-/obj/effect/landmark/lv624/fog_blocker/short,
-/turf/open/floor{
-	dir = 1;
-	icon_state = "asteroidwarning"
-	},
-/area/bigredv2/outside/w)
 "gNz" = (
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_door,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
@@ -30510,13 +30456,6 @@
 	icon_state = "mars_cave_6"
 	},
 /area/bigredv2/caves_research)
-"iRd" = (
-/obj/effect/landmark/lv624/fog_blocker/short,
-/turf/open/floor{
-	dir = 4;
-	icon_state = "asteroidwarning"
-	},
-/area/bigredv2/outside/sw)
 "iRf" = (
 /obj/structure/fence,
 /turf/open/floor{
@@ -30584,6 +30523,14 @@
 	icon_state = "redfull"
 	},
 /area/bigredv2/caves/eta/research)
+"iYP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "asteroidfloor"
+	},
+/area/bigredv2/outside/nw)
 "iYR" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor{
@@ -31090,12 +31037,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/bigredv2/caves/mining)
-"jRI" = (
-/obj/effect/landmark/lv624/fog_blocker/short,
-/turf/open/mars_cave{
-	icon_state = "mars_dirt_4"
-	},
-/area/bigredv2/outside/cargo)
 "jUc" = (
 /obj/structure/surface/table,
 /obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
@@ -31235,12 +31176,6 @@
 	icon_state = "mars_cave_6"
 	},
 /area/bigredv2/caves/mining)
-"kbC" = (
-/obj/effect/landmark/lv624/fog_blocker/short,
-/turf/open/mars_cave{
-	icon_state = "mars_cave_7"
-	},
-/area/bigredv2/outside/lz2_west_cas)
 "kcx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/weapon/broken_bottle,
@@ -31262,7 +31197,6 @@
 	},
 /area/bigredv2/outside/filtration_plant)
 "kdh" = (
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/mars_cave{
 	icon_state = "mars_dirt_6"
 	},
@@ -31581,7 +31515,6 @@
 /area/bigredv2/caves/eta/storage)
 "kHK" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor{
 	dir = 1;
 	icon_state = "asteroidfloor"
@@ -32283,6 +32216,12 @@
 	icon_state = "platingdmg3"
 	},
 /area/bigredv2/caves/mining)
+"mmz" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/mars_cave{
+	icon_state = "mars_cave_2"
+	},
+/area/bigredv2/outside/lz1_telecomm_cas)
 "moE" = (
 /turf/open/mars_cave{
 	icon_state = "mars_cave_9"
@@ -32636,10 +32575,6 @@
 	icon_state = "mars_dirt_4"
 	},
 /area/bigredv2/caves/mining)
-"ndq" = (
-/obj/effect/landmark/lv624/fog_blocker/short,
-/turf/closed/wall/solaris/reinforced/hull,
-/area/bigredv2/caves)
 "ndy" = (
 /obj/effect/decal/cleanable/blood/drip{
 	pixel_x = -3;
@@ -32865,12 +32800,6 @@
 	icon_state = "asteroidfloor"
 	},
 /area/bigredv2/outside/telecomm/lz2_cave)
-"nHh" = (
-/obj/effect/landmark/lv624/fog_blocker/short,
-/turf/open/mars_cave{
-	icon_state = "mars_cave_2"
-	},
-/area/bigredv2/outside/lz2_west_cas)
 "nHQ" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
 /obj/structure/machinery/door/poddoor/almayer/closed{
@@ -33141,7 +33070,6 @@
 /turf/open/floor/plating,
 /area/bigredv2/caves/mining)
 "oip" = (
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/mars{
 	icon_state = "mars_dirt_6"
 	},
@@ -33382,11 +33310,6 @@
 	icon_state = "mars_cave_5"
 	},
 /area/bigredv2/caves_virology)
-"oCx" = (
-/obj/structure/blocker/forcefield/multitile_vehicles,
-/obj/effect/landmark/lv624/fog_blocker/short,
-/turf/open/mars_cave,
-/area/bigredv2/outside/lz2_west_cas)
 "oDB" = (
 /obj/structure/closet/l3closet,
 /obj/effect/landmark/objective_landmark/close,
@@ -33695,6 +33618,7 @@
 /obj/effect/landmark/nightmare{
 	insert_tag = "lz1entrance"
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/mars,
 /area/bigredv2/outside/nw)
 "pdW" = (
@@ -33766,12 +33690,6 @@
 	icon_state = "mars_dirt_11"
 	},
 /area/bigredv2/caves_north)
-"pov" = (
-/obj/effect/landmark/lv624/fog_blocker/short,
-/turf/open/mars_cave{
-	icon_state = "mars_dirt_4"
-	},
-/area/bigredv2/outside/w)
 "pow" = (
 /obj/structure/blocker/forcefield/multitile_vehicles,
 /turf/open/mars_cave{
@@ -34016,12 +33934,6 @@
 /obj/item/weapon/broken_bottle,
 /turf/open/floor/plating,
 /area/bigredv2/caves/mining)
-"pUt" = (
-/obj/effect/landmark/lv624/fog_blocker/short,
-/turf/open/mars_cave{
-	icon_state = "mars_dirt_4"
-	},
-/area/bigredv2/outside/sw)
 "pVp" = (
 /obj/structure/prop/invuln/minecart_tracks{
 	dir = 1
@@ -34366,14 +34278,6 @@
 	icon_state = "mars_cave_13"
 	},
 /area/bigredv2/caves/mining)
-"qBj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/lv624/fog_blocker/short,
-/turf/open/floor{
-	dir = 8;
-	icon_state = "asteroidwarning"
-	},
-/area/bigredv2/outside/w)
 "qCK" = (
 /turf/open/floor{
 	icon_state = "asteroidwarning"
@@ -34700,13 +34604,6 @@
 	},
 /turf/closed/wall/solaris/reinforced,
 /area/bigredv2/caves/mining)
-"rjL" = (
-/obj/effect/landmark/lv624/fog_blocker/short,
-/turf/open/floor{
-	dir = 1;
-	icon_state = "asteroidfloor"
-	},
-/area/bigredv2/outside/sw)
 "rkS" = (
 /obj/structure/cable{
 	icon_state = "5-6"
@@ -36276,10 +36173,6 @@
 	icon_state = "mars_cave_15"
 	},
 /area/bigredv2/caves/mining)
-"tWO" = (
-/obj/effect/landmark/lv624/fog_blocker/short,
-/turf/open/mars,
-/area/bigredv2/outside/sw)
 "tWS" = (
 /obj/effect/landmark/item_pool_spawner/survivor_ammo,
 /turf/open/mars_cave{
@@ -36725,14 +36618,6 @@
 	icon_state = "mars_cave_3"
 	},
 /area/bigredv2/caves_sw)
-"uYq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/lv624/fog_blocker/short,
-/turf/open/floor{
-	dir = 4;
-	icon_state = "asteroidwarning"
-	},
-/area/bigredv2/outside/w)
 "vbi" = (
 /turf/open/floor{
 	dir = 5;
@@ -36833,6 +36718,7 @@
 /obj/structure/machinery/light{
 	dir = 8
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor{
 	dir = 1;
 	icon_state = "asteroidwarning"
@@ -37208,6 +37094,7 @@
 /obj/structure/machinery/light{
 	dir = 8
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor{
 	icon_state = "asteroidwarning"
 	},
@@ -37492,12 +37379,6 @@
 	icon_state = "delivery"
 	},
 /area/bigredv2/caves/lambda/virology)
-"wAI" = (
-/obj/effect/landmark/lv624/fog_blocker/short,
-/turf/open/mars_cave{
-	icon_state = "mars_cave_6"
-	},
-/area/bigredv2/outside/lz2_west_cas)
 "wBi" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
@@ -37517,17 +37398,6 @@
 	icon_state = "mars_dirt_4"
 	},
 /area/bigredv2/caves/mining)
-"wCq" = (
-/obj/structure/machinery/light{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/lv624/fog_blocker/short,
-/turf/open/floor{
-	dir = 8;
-	icon_state = "asteroidwarning"
-	},
-/area/bigredv2/outside/cargo)
 "wDa" = (
 /obj/effect/decal/cleanable/blood/drip{
 	pixel_x = 6
@@ -37917,13 +37787,6 @@
 	icon_state = "mars_cave_2"
 	},
 /area/space)
-"xop" = (
-/obj/effect/landmark/lv624/fog_blocker/short,
-/turf/open/floor{
-	dir = 4;
-	icon_state = "asteroidwarning"
-	},
-/area/bigredv2/outside/w)
 "xpb" = (
 /turf/open/floor{
 	dir = 5;
@@ -38034,10 +37897,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/bigredv2/caves/mining)
-"xwK" = (
-/obj/effect/landmark/lv624/fog_blocker/short,
-/turf/closed/wall/solaris/reinforced,
-/area/bigredv2/outside/virology)
 "xya" = (
 /obj/structure/barricade/wooden{
 	desc = "This barricade is heavily reinforced. Nothing short of blasting it open seems like it'll do the trick, that or melting the breams supporting it...";
@@ -38137,7 +37996,6 @@
 /turf/open/mars_cave,
 /area/bigredv2/caves_lambda)
 "xGT" = (
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor{
 	dir = 9;
 	icon_state = "asteroidwarning"
@@ -38252,6 +38110,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor,
 /area/bigredv2/outside/cargo)
+"xQJ" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/mars,
+/area/bigredv2/outside/nw)
 "xQM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/lv624/fog_blocker/short,
@@ -41499,7 +41361,7 @@ aao
 aao
 aao
 aao
-nHh
+cYJ
 cYJ
 cYJ
 cYJ
@@ -41715,8 +41577,8 @@ aao
 aao
 aao
 aao
-nHh
-nHh
+cYJ
+cYJ
 vMj
 vMj
 cYJ
@@ -41860,16 +41722,16 @@ aas
 all
 slK
 aao
-xmy
-gda
-gda
-gda
-gda
-gda
-gda
-gda
-xmy
-xmy
+mmz
+edv
+edv
+edv
+edv
+edv
+edv
+edv
+mmz
+mmz
 aao
 aao
 aao
@@ -41932,8 +41794,8 @@ aao
 aao
 aao
 cYJ
-nHh
-kbC
+cYJ
+uyk
 tDv
 cYJ
 cYJ
@@ -42149,8 +42011,8 @@ cYJ
 cYJ
 cYJ
 cYJ
-wAI
-nHh
+vMj
+cYJ
 cYJ
 cYJ
 ski
@@ -42366,8 +42228,8 @@ cYJ
 cYJ
 cYJ
 cYJ
-nHh
-nHh
+cYJ
+cYJ
 cYJ
 cdA
 aao
@@ -42583,8 +42445,8 @@ rtL
 rtL
 rtL
 tft
-oCx
-dJY
+tft
+ski
 ski
 oNu
 aao
@@ -45553,7 +45415,7 @@ qEJ
 qsE
 aao
 aao
-aeI
+xQJ
 aeI
 aeI
 aiz
@@ -45759,18 +45621,18 @@ iaD
 aae
 aao
 aao
-aeI
-aeI
-aeI
+xQJ
+xQJ
+xQJ
 viN
-ajx
-ajx
-aoN
-ajx
+giv
+giv
+iYP
+giv
 vXp
 pdN
-aeI
-aeI
+xQJ
+xQJ
 aeI
 aoO
 aiw
@@ -45821,10 +45683,10 @@ aoD
 aoD
 aoD
 aoa
-ndq
-ndq
-ndq
-fQN
+azR
+azR
+azR
+aYF
 aYF
 bbc
 aSB
@@ -45975,18 +45837,18 @@ aam
 ago
 pjZ
 oxV
-aeI
-aeI
-aeI
-aeI
+xQJ
+xQJ
+xQJ
+xQJ
 auF
-ajx
-aoN
-ajx
-ajx
+giv
+iYP
+giv
+giv
 ahT
-aeI
-aeI
+xQJ
+xQJ
 aeI
 aeI
 ajy
@@ -46033,15 +45895,15 @@ aEV
 aEu
 aEu
 aoa
-pov
-pov
-xwK
-pov
-pov
-ndq
-pov
-pov
-dXe
+aSB
+aSB
+aoD
+aSB
+aSB
+azR
+aSB
+aSB
+bax
 bax
 aSB
 aSB
@@ -46250,15 +46112,15 @@ aEu
 aEu
 aEu
 aEu
-pov
-pov
-pov
-pov
+aSB
+aSB
+aSB
+aSB
 beP
 beP
 beP
-pov
-pov
+aSB
+aSB
 aSB
 aSB
 aSB
@@ -46474,8 +46336,8 @@ aWk
 aVI
 aWk
 aWk
-qBj
-qBj
+aVI
+aVI
 aWk
 aWk
 aWk
@@ -46691,8 +46553,8 @@ aUQ
 bdZ
 bdZ
 bdZ
-xop
-uYq
+aXA
+aWV
 aXA
 aXA
 aXA
@@ -46909,7 +46771,7 @@ bdZ
 bdZ
 beu
 beP
-pov
+aSB
 aSB
 aSB
 aSB
@@ -47126,7 +46988,7 @@ aUQ
 bdZ
 bev
 beP
-pov
+aSB
 bfT
 aSB
 aSB
@@ -47343,7 +47205,7 @@ aUQ
 bdZ
 bev
 beP
-pov
+aSB
 aSB
 aSB
 aSB
@@ -47559,30 +47421,30 @@ bdZ
 aUQ
 bdZ
 bev
-pov
-pov
+aSB
+aSB
 aSB
 xGT
-gFj
-gtv
-gtv
+aWk
+eWd
+eWd
 kHK
 kHK
-gtv
-gtv
-gtv
-gtv
-gtv
-gtv
-gtv
-fEx
-fEx
-fEx
-fEx
-fEx
-fEx
-fEx
-fEx
+eWd
+eWd
+eWd
+eWd
+eWd
+eWd
+eWd
+bmN
+bmN
+bmN
+bmN
+bmN
+bmN
+bmN
+bmN
 eWd
 eWd
 eWd
@@ -47776,10 +47638,10 @@ bdZ
 bdZ
 bdZ
 bev
-pov
-pov
 aSB
-gMl
+aSB
+aSB
+aVG
 asK
 asK
 asK
@@ -47799,7 +47661,7 @@ axX
 bmi
 boD
 axX
-pUt
+bpx
 ufD
 bpv
 brd
@@ -47993,10 +47855,10 @@ bdZ
 bdZ
 bdZ
 bev
-pov
-pov
+aSB
+aSB
 bfU
-gMl
+aVG
 asK
 svp
 svp
@@ -48016,7 +47878,7 @@ azb
 bmi
 bmi
 azb
-pUt
+bpx
 ufD
 bpv
 brd
@@ -48210,10 +48072,10 @@ bdZ
 bdZ
 bdZ
 beQ
-pov
-pov
 aSB
-gMl
+aSB
+aSB
+aVG
 asK
 bhb
 bhb
@@ -48233,7 +48095,7 @@ azb
 bmi
 bmi
 azb
-pUt
+bpx
 ufD
 bpv
 brd
@@ -48427,10 +48289,10 @@ bdZ
 bdZ
 bdZ
 beQ
-pov
-pov
 aSB
-gMl
+aSB
+aSB
+aVG
 asK
 bhc
 bbe
@@ -48450,7 +48312,7 @@ azb
 bmi
 bmi
 azb
-pUt
+bpx
 ufD
 bpv
 bpv
@@ -48460,7 +48322,7 @@ brG
 brG
 brG
 brG
-cod
+brG
 qzO
 cHn
 cHn
@@ -48644,10 +48506,10 @@ bcs
 bcs
 bcs
 bew
-jRI
-pov
-pov
-gMl
+beR
+aSB
+aSB
+aVG
 asK
 bhd
 bhD
@@ -48677,7 +48539,7 @@ bpv
 bpv
 bpv
 bpv
-rjL
+bpv
 qzO
 bGL
 bGL
@@ -48861,10 +48723,10 @@ bdf
 bdf
 beb
 bdf
-wCq
-gFj
-gFj
-bPv
+beS
+aWk
+aWk
+bdZ
 asK
 oEJ
 oEJ
@@ -48884,17 +48746,17 @@ azb
 bmi
 bmi
 azb
-tWO
+bme
 bqe
-iRd
-iRd
-iRd
-iRd
-iRd
-iRd
-iRd
 heU
-iRd
+heU
+heU
+heU
+heU
+heU
+heU
+heU
+heU
 qzO
 bGL
 bGL
@@ -49109,7 +48971,7 @@ azB
 azB
 axX
 axX
-pUt
+bpx
 bpy
 bpy
 glB
@@ -49327,7 +49189,7 @@ bob
 bsJ
 axX
 bsI
-tWO
+bme
 aao
 glB
 rJJ
@@ -49543,8 +49405,8 @@ bmi
 bmi
 bmi
 azb
-tWO
-tWO
+bme
+bme
 aao
 glB
 jOc
@@ -49760,8 +49622,8 @@ bmg
 bre
 bsK
 axX
-tWO
-tWO
+bme
+bme
 aao
 glB
 xpb
@@ -49977,8 +49839,8 @@ bmg
 bre
 bsL
 azb
-tWO
-pUt
+bme
+bpx
 aao
 euF
 dEV
@@ -50194,8 +50056,8 @@ bmi
 bmi
 bsM
 axX
-pUt
-pUt
+bpx
+bpx
 aao
 euF
 euF
@@ -50411,7 +50273,7 @@ ayr
 brf
 axX
 axX
-pUt
+bpx
 kdh
 aao
 aao
@@ -50627,9 +50489,9 @@ bmi
 brI
 bmi
 azb
-pUt
-pUt
-pUt
+bpx
+bpx
+bpx
 aao
 aao
 aao

--- a/maps/map_files/BigRed/BigRed.dmm
+++ b/maps/map_files/BigRed/BigRed.dmm
@@ -3581,7 +3581,6 @@
 /area/bigredv2/outside/marshal_office)
 "akl" = (
 /obj/structure/sign/safety/hazard,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/closed/wall/solaris/reinforced,
 /area/bigredv2/outside/telecomm)
 "akm" = (
@@ -3904,7 +3903,6 @@
 	},
 /area/bigredv2/caves/lambda/xenobiology)
 "all" = (
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor{
 	icon_state = "asteroidwarning"
 	},
@@ -27203,7 +27201,6 @@
 /area/bigredv2/oob)
 "bRm" = (
 /obj/structure/blocker/forcefield/multitile_vehicles,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/mars_cave{
 	icon_state = "mars_cave_7"
 	},
@@ -28260,6 +28257,7 @@
 	},
 /area/bigredv2/caves/eta/storage)
 "eci" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/mars_cave{
 	icon_state = "mars_cave_11"
 	},
@@ -28968,6 +28966,7 @@
 	},
 /area/bigredv2/oob)
 "fxK" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/mars_cave{
 	icon_state = "mars_cave_10"
 	},
@@ -29627,6 +29626,7 @@
 /area/bigredv2/caves_sw)
 "hcb" = (
 /obj/effect/landmark/hunter_secondary,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/mars_cave{
 	icon_state = "mars_cave_2"
 	},
@@ -32341,14 +32341,6 @@
 "mzV" = (
 /turf/open/mars,
 /area/bigredv2/outside/filtration_plant)
-"mAd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/lv624/fog_blocker/short,
-/turf/open/floor{
-	dir = 1;
-	icon_state = "asteroidfloor"
-	},
-/area/bigredv2/outside/telecomm)
 "mBo" = (
 /obj/item/weapon/twohanded/folded_metal_chair{
 	pixel_x = -7;
@@ -32678,6 +32670,12 @@
 	icon_state = "mars_cave_6"
 	},
 /area/bigredv2/outside/filtration_cave_cas)
+"nti" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/mars_cave{
+	icon_state = "mars_cave_10"
+	},
+/area/bigredv2/caves_virology)
 "ntX" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor{
@@ -35146,6 +35144,11 @@
 	icon_state = "asteroidwarning"
 	},
 /area/bigred/ground/garage_workshop)
+"sip" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/mars,
+/area/bigredv2/outside/nw)
 "siu" = (
 /turf/open/floor{
 	icon_state = "asteroidwarning"
@@ -35179,10 +35182,6 @@
 	},
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
-"slK" = (
-/obj/effect/landmark/lv624/fog_blocker/short,
-/turf/closed/wall/solaris/reinforced,
-/area/bigredv2/outside/telecomm)
 "smh" = (
 /obj/structure/blocker/forcefield/multitile_vehicles,
 /turf/open/floor/plating,
@@ -35415,11 +35414,6 @@
 /obj/structure/machinery/light,
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
-"sCO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/lv624/fog_blocker/short,
-/turf/closed/wall/solaris/reinforced,
-/area/bigredv2/outside/telecomm)
 "sDs" = (
 /obj/structure/closet/crate/miningcar,
 /obj/item/weapon/gun/smg/nailgun,
@@ -35529,7 +35523,6 @@
 /area/bigredv2/caves/mining)
 "sOE" = (
 /obj/structure/blocker/forcefield/multitile_vehicles,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/mars_cave{
 	icon_state = "mars_cave_6"
 	},
@@ -36821,13 +36814,6 @@
 	icon_state = "mars_cave_11"
 	},
 /area/bigredv2/caves_research)
-"vrp" = (
-/obj/effect/landmark/lv624/fog_blocker/short,
-/turf/open/floor{
-	dir = 1;
-	icon_state = "asteroidfloor"
-	},
-/area/bigredv2/outside/telecomm)
 "vrt" = (
 /turf/open/mars{
 	icon_state = "mars_dirt_14"
@@ -37659,6 +37645,12 @@
 	icon_state = "mars_dirt_7"
 	},
 /area/bigredv2/caves/mining)
+"xdx" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/mars_cave{
+	icon_state = "mars_cave_7"
+	},
+/area/bigredv2/outside/lz1_telecomm_cas)
 "xeN" = (
 /obj/effect/landmark/lv624/xeno_tunnel,
 /turf/open/mars_cave{
@@ -39139,7 +39131,7 @@ aao
 aao
 aao
 aao
-jCY
+nti
 fLj
 fLj
 fmn
@@ -39356,7 +39348,7 @@ aao
 aao
 aao
 fxK
-xmy
+mmz
 rDP
 rDP
 rDP
@@ -39572,8 +39564,8 @@ aao
 aao
 aao
 fxK
-xmy
-xmy
+mmz
+mmz
 rDP
 iwG
 rDP
@@ -39788,9 +39780,9 @@ aao
 aao
 aao
 aao
-rCA
-xmy
-xmy
+xdx
+mmz
+mmz
 rDP
 rDP
 rDP
@@ -40005,9 +39997,9 @@ xmy
 xmy
 xmy
 fxK
-xmy
-xmy
-xmy
+mmz
+mmz
+mmz
 rDP
 rDP
 rDP
@@ -40221,10 +40213,10 @@ xmy
 xmy
 xmy
 xmy
-rCA
-xmy
-xmy
-xmy
+xdx
+mmz
+mmz
+mmz
 rDP
 rDP
 rDP
@@ -40438,10 +40430,10 @@ xmy
 xmy
 lrH
 xmy
-rCA
-xmy
-xmy
-xmy
+xdx
+mmz
+mmz
+mmz
 rDP
 rDP
 rDP
@@ -40634,8 +40626,8 @@ acA
 acA
 acA
 acA
-sCO
-slK
+ahN
+acA
 sOE
 csE
 xmy
@@ -40655,10 +40647,10 @@ xmy
 xmy
 xmy
 csE
-xmy
-xmy
+mmz
+mmz
 hcb
-xmy
+mmz
 rDP
 rDP
 rDP
@@ -40872,10 +40864,10 @@ xmy
 xmy
 xmy
 xmy
-xmy
-xmy
-xmy
-xmy
+mmz
+mmz
+mmz
+mmz
 rDP
 rDP
 rDP
@@ -41069,7 +41061,7 @@ aas
 ahd
 ahd
 all
-slK
+acA
 bRm
 xmy
 xmy
@@ -41089,10 +41081,10 @@ xmy
 xmy
 xmy
 xmy
-xmy
-xmy
-xmy
-xmy
+mmz
+mmz
+mmz
+mmz
 rDP
 rDP
 rDP
@@ -41286,7 +41278,7 @@ aas
 aas
 aas
 all
-slK
+acA
 bRm
 xmy
 xmy
@@ -41306,10 +41298,10 @@ xmy
 xmy
 xmy
 xmy
-xmy
-xmy
-gda
-gda
+mmz
+mmz
+edv
+edv
 fOc
 rDP
 rDP
@@ -41503,7 +41495,7 @@ aas
 ahd
 aaZ
 all
-slK
+acA
 bRm
 xmy
 xmy
@@ -41523,7 +41515,7 @@ xmy
 csE
 csE
 rCA
-gda
+edv
 eci
 aao
 aao
@@ -41720,18 +41712,18 @@ aas
 ahd
 aas
 all
-slK
+acA
 aao
-mmz
-edv
-edv
-edv
-edv
-edv
-edv
-edv
-mmz
-mmz
+xmy
+gda
+gda
+gda
+gda
+gda
+gda
+gda
+xmy
+xmy
 aao
 aao
 aao
@@ -41931,11 +41923,11 @@ afL
 acQ
 aas
 ahd
-mAd
-vrp
-vrp
-mAd
-vrp
+ahd
+aas
+aas
+ahd
+aas
 all
 akl
 aao
@@ -42148,13 +42140,13 @@ acQ
 acQ
 acA
 ahN
-slK
-slK
-slK
-slK
-slK
-slK
-slK
+acA
+acA
+acA
+acA
+acA
+acA
+acA
 aao
 aao
 qsE
@@ -45416,7 +45408,7 @@ qsE
 aao
 aao
 xQJ
-aeI
+xQJ
 aeI
 aiz
 aog
@@ -45848,8 +45840,8 @@ giv
 giv
 ahT
 xQJ
+sip
 xQJ
-aeI
 aeI
 ajy
 ajx
@@ -46054,8 +46046,8 @@ aah
 xyp
 pjZ
 oxV
-aeI
-aeI
+xQJ
+xQJ
 aeI
 aeI
 aeI
@@ -46271,7 +46263,7 @@ aah
 xyp
 pjZ
 oxV
-aeI
+xQJ
 aeI
 aeI
 aeI
@@ -49959,7 +49951,7 @@ aao
 aao
 aao
 aao
-aeI
+xQJ
 aeI
 aiA
 ajy

--- a/maps/map_files/BigRed/BigRed.dmm
+++ b/maps/map_files/BigRed/BigRed.dmm
@@ -1071,6 +1071,7 @@
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 9
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating{
 	dir = 8;
 	icon_state = "platingdmg2"
@@ -2151,6 +2152,7 @@
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor{
 	dir = 6;
 	icon_state = "asteroidwarning"
@@ -2166,6 +2168,7 @@
 /obj/structure/pipes/standard/manifold/hidden/green{
 	dir = 1
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/bigredv2/outside/space_port)
 "ags" = (
@@ -2191,6 +2194,7 @@
 /area/bigredv2/outside/space_port)
 "agw" = (
 /obj/item/stack/rods,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating{
 	dir = 8;
 	icon_state = "platingdmg3"
@@ -2198,6 +2202,7 @@
 /area/bigredv2/outside/space_port)
 "agx" = (
 /obj/structure/girder/displaced,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating{
 	dir = 8;
 	icon_state = "platingdmg3"
@@ -2458,6 +2463,7 @@
 /area/bigredv2/outside/general_offices)
 "ahg" = (
 /obj/item/stack/sheet/metal,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating{
 	dir = 8;
 	icon_state = "platingdmg3"
@@ -2465,6 +2471,7 @@
 /area/bigredv2/outside/space_port)
 "ahh" = (
 /obj/structure/girder/reinforced,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/closed/wall/solaris/reinforced,
 /area/bigredv2/outside/space_port)
 "ahi" = (
@@ -2709,6 +2716,7 @@
 /area/bigredv2/outside/nw)
 "ahU" = (
 /obj/structure/lz_sign/solaris_sign,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor{
 	icon_state = "asteroidwarning"
 	},
@@ -2721,6 +2729,7 @@
 "ahW" = (
 /obj/item/stack/rods,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor{
 	icon_state = "asteroidwarning"
 	},
@@ -2733,6 +2742,7 @@
 /obj/item/stack/sheet/metal,
 /obj/item/stack/rods,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor{
 	icon_state = "asteroidwarning"
 	},
@@ -2741,6 +2751,7 @@
 /obj/item/stack/rods,
 /obj/item/stack/rods,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor{
 	icon_state = "asteroidwarning"
 	},
@@ -3569,6 +3580,7 @@
 /area/bigredv2/outside/marshal_office)
 "akl" = (
 /obj/structure/sign/safety/hazard,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/closed/wall/solaris/reinforced,
 /area/bigredv2/outside/telecomm)
 "akm" = (
@@ -3891,6 +3903,7 @@
 	},
 /area/bigredv2/caves/lambda/xenobiology)
 "all" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor{
 	icon_state = "asteroidwarning"
 	},
@@ -8307,7 +8320,7 @@
 /turf/open/mars{
 	icon_state = "mars_dirt_8"
 	},
-/area/bigredv2/outside/nw)
+/area/bigredv2/outside/c)
 "axv" = (
 /turf/open/floor{
 	icon_state = "delivery"
@@ -10478,7 +10491,7 @@
 	dir = 10;
 	icon_state = "asteroidwarning"
 	},
-/area/bigredv2/outside/nw)
+/area/bigredv2/outside/c)
 "aDx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/pipes/standard/simple/hidden/green{
@@ -10488,7 +10501,7 @@
 	dir = 1;
 	icon_state = "asteroidfloor"
 	},
-/area/bigredv2/outside/nw)
+/area/bigredv2/outside/c)
 "aDy" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
@@ -10498,16 +10511,6 @@
 	icon_state = "asteroidfloor"
 	},
 /area/bigredv2/outside/e)
-"aDz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 4
-	},
-/turf/open/floor{
-	dir = 1;
-	icon_state = "asteroidfloor"
-	},
-/area/bigredv2/outside/nw)
 "aDA" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 10
@@ -10516,7 +10519,7 @@
 	dir = 4;
 	icon_state = "asteroidwarning"
 	},
-/area/bigredv2/outside/nw)
+/area/bigredv2/outside/c)
 "aDB" = (
 /turf/open/floor{
 	dir = 5;
@@ -10835,12 +10838,6 @@
 "aEu" = (
 /turf/closed/wall/solaris/rock,
 /area/bigredv2/outside)
-"aEv" = (
-/obj/effect/landmark/crap_item,
-/turf/open/floor{
-	icon_state = "asteroidwarning"
-	},
-/area/bigredv2/outside/nw)
 "aEw" = (
 /obj/structure/surface/table,
 /obj/item/tool/surgery/scalpel/manager,
@@ -11883,7 +11880,7 @@
 	dir = 1;
 	icon_state = "asteroidfloor"
 	},
-/area/bigredv2/outside/nw)
+/area/bigredv2/outside/c)
 "aHm" = (
 /obj/effect/decal/cleanable/blood,
 /obj/structure/pipes/standard/simple/hidden/green,
@@ -11891,11 +11888,11 @@
 	dir = 4;
 	icon_state = "asteroidwarning"
 	},
-/area/bigredv2/outside/nw)
+/area/bigredv2/outside/c)
 "aHn" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/mars,
-/area/bigredv2/outside/nw)
+/area/bigredv2/outside/c)
 "aHo" = (
 /obj/structure/closet/secure_closet/medical2,
 /turf/open/floor{
@@ -12231,7 +12228,7 @@
 	dir = 4;
 	icon_state = "asteroidwarning"
 	},
-/area/bigredv2/outside/nw)
+/area/bigredv2/outside/c)
 "aIj" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -13683,7 +13680,7 @@
 	dir = 1;
 	icon_state = "asteroidwarning"
 	},
-/area/bigredv2/outside/nw)
+/area/bigredv2/outside/c)
 "aMa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/sheet/wood{
@@ -13693,14 +13690,7 @@
 	dir = 1;
 	icon_state = "asteroidwarning"
 	},
-/area/bigredv2/outside/nw)
-"aMb" = (
-/obj/effect/landmark/crap_item,
-/turf/open/floor{
-	dir = 1;
-	icon_state = "asteroidwarning"
-	},
-/area/bigredv2/outside/nw)
+/area/bigredv2/outside/c)
 "aMc" = (
 /turf/open/floor{
 	dir = 1;
@@ -20192,6 +20182,7 @@
 /area/bigredv2/outside/office_complex)
 "beP" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/mars_cave{
 	icon_state = "mars_dirt_4"
 	},
@@ -23058,6 +23049,7 @@
 	},
 /area/bigredv2/outside/sw)
 "bpy" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/mars{
 	icon_state = "mars_dirt_12"
 	},
@@ -23256,6 +23248,7 @@
 	},
 /area/bigredv2/outside/space_port_lz2)
 "bqe" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor{
 	dir = 5;
 	icon_state = "asteroidwarning"
@@ -23729,6 +23722,7 @@
 /turf/open/floor,
 /area/bigredv2/outside/filtration_cave_cas)
 "bsI" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/mars{
 	icon_state = "mars_dirt_3"
 	},
@@ -27186,6 +27180,13 @@
 	icon_state = "dark"
 	},
 /area/bigredv2/outside/marshal_office)
+"bPv" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "asteroidfloor"
+	},
+/area/bigredv2/outside/w)
 "bPy" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_nest,
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_nest,
@@ -27211,6 +27212,7 @@
 /area/bigredv2/oob)
 "bRm" = (
 /obj/structure/blocker/forcefield/multitile_vehicles,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/mars_cave{
 	icon_state = "mars_cave_7"
 	},
@@ -27413,6 +27415,13 @@
 /obj/structure/blocker/forcefield/multitile_vehicles,
 /turf/closed/wall/solaris/rock,
 /area/bigredv2/caves)
+"cod" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "asteroidwarning"
+	},
+/area/bigredv2/outside/sw)
 "coT" = (
 /obj/effect/landmark/objective_landmark/science,
 /turf/open/floor{
@@ -28073,6 +28082,10 @@
 	icon_state = "platingdmg3"
 	},
 /area/bigredv2/caves/mining)
+"dJY" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/mars_cave,
+/area/bigredv2/outside/lz2_west_cas)
 "dKo" = (
 /obj/item/ore/iron{
 	pixel_x = 6;
@@ -28212,6 +28225,12 @@
 /obj/structure/closet/toolcloset,
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
+"dXe" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/mars{
+	icon_state = "mars_dirt_11"
+	},
+/area/bigredv2/outside/w)
 "dXs" = (
 /obj/item/tool/pickaxe{
 	pixel_y = 12
@@ -28241,6 +28260,13 @@
 	icon_state = "mars_cave_14"
 	},
 /area/bigredv2/caves/mining)
+"eaE" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/plating{
+	dir = 8;
+	icon_state = "platingdmg3"
+	},
+/area/bigredv2/outside/space_port)
 "eaW" = (
 /obj/structure/disposalpipe/segment,
 /obj/item/frame/rack,
@@ -28640,6 +28666,12 @@
 	icon_state = "mars_cave_2"
 	},
 /area/bigredv2/outside/lz1_telecomm_cas)
+"ePg" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
+/area/bigredv2/outside/space_port)
 "ePk" = (
 /obj/structure/prop/server_equipment/broken,
 /turf/open/floor/greengrid,
@@ -28999,6 +29031,13 @@
 	icon_state = "darkred2"
 	},
 /area/bigredv2/caves/eta/research)
+"fEx" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "asteroidwarning"
+	},
+/area/bigredv2/outside/space_port_lz2)
 "fFG" = (
 /obj/structure/largecrate/random/barrel,
 /turf/open/mars_cave{
@@ -29150,6 +29189,10 @@
 	icon_state = "mars_cave_17"
 	},
 /area/bigredv2/caves/mining)
+"fQN" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/mars,
+/area/bigredv2/outside/w)
 "fRo" = (
 /obj/item/tool/pickaxe/drill,
 /turf/open/mars_cave{
@@ -29169,6 +29212,7 @@
 /area/bigredv2/caves/mining)
 "fSJ" = (
 /obj/structure/pipes/standard/simple/hidden/green,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor{
 	icon_state = "delivery"
 	},
@@ -29282,6 +29326,13 @@
 "gio" = (
 /turf/open/mars_cave,
 /area/bigredv2/outside/filtration_cave_cas)
+"giv" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "asteroidfloor"
+	},
+/area/bigredv2/outside/nw)
 "giY" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
@@ -29391,6 +29442,13 @@
 	icon_state = "mars_dirt_4"
 	},
 /area/space)
+"gtv" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "asteroidfloor"
+	},
+/area/bigredv2/outside/space_port_lz2)
 "gtX" = (
 /turf/open/mars_cave,
 /area/bigredv2/caves_se)
@@ -29483,6 +29541,13 @@
 	icon_state = "mars_cave_2"
 	},
 /area/bigredv2/caves_east)
+"gFj" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "asteroidwarning"
+	},
+/area/bigredv2/outside/w)
 "gGO" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating{
@@ -29506,6 +29571,13 @@
 	icon_state = "mars_cave_4"
 	},
 /area/bigredv2/caves_virology)
+"gMl" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "asteroidwarning"
+	},
+/area/bigredv2/outside/w)
 "gNz" = (
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_door,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
@@ -30040,6 +30112,16 @@
 	},
 /turf/open/floor,
 /area/bigredv2/outside/cargo)
+"iaD" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "asteroidfloor"
+	},
+/area/bigredv2/outside/space_port)
 "iaN" = (
 /obj/structure/largecrate/random/barrel/red,
 /obj/effect/decal/cleanable/dirt,
@@ -30161,6 +30243,12 @@
 	icon_state = "mars_cave_2"
 	},
 /area/bigredv2/caves_research)
+"imL" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/mars_cave{
+	icon_state = "mars_cave_13"
+	},
+/area/bigredv2/outside/lz1_north_cas)
 "inx" = (
 /obj/item/tool/warning_cone,
 /turf/open/floor{
@@ -30358,6 +30446,13 @@
 	icon_state = "mars_cave_13"
 	},
 /area/bigredv2/caves/mining)
+"iJX" = (
+/obj/structure/pipes/standard/simple/hidden/green,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "asteroidwarning"
+	},
+/area/bigredv2/outside/c)
 "iKn" = (
 /turf/open/floor{
 	dir = 1;
@@ -30415,6 +30510,13 @@
 	icon_state = "mars_cave_6"
 	},
 /area/bigredv2/caves_research)
+"iRd" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "asteroidwarning"
+	},
+/area/bigredv2/outside/sw)
 "iRf" = (
 /obj/structure/fence,
 /turf/open/floor{
@@ -30909,6 +31011,12 @@
 	icon_state = "delivery"
 	},
 /area/bigredv2/outside/lz2_south_cas)
+"jOR" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor{
+	icon_state = "asteroidwarning"
+	},
+/area/bigredv2/outside/c)
 "jOS" = (
 /obj/structure/surface/rack,
 /obj/item/tool/pickaxe/plasmacutter{
@@ -30982,6 +31090,12 @@
 	icon_state = "platingdmg3"
 	},
 /area/bigredv2/caves/mining)
+"jRI" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/mars_cave{
+	icon_state = "mars_dirt_4"
+	},
+/area/bigredv2/outside/cargo)
 "jUc" = (
 /obj/structure/surface/table,
 /obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
@@ -31121,6 +31235,12 @@
 	icon_state = "mars_cave_6"
 	},
 /area/bigredv2/caves/mining)
+"kbC" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/mars_cave{
+	icon_state = "mars_cave_7"
+	},
+/area/bigredv2/outside/lz2_west_cas)
 "kcx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/weapon/broken_bottle,
@@ -31142,6 +31262,7 @@
 	},
 /area/bigredv2/outside/filtration_plant)
 "kdh" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/mars_cave{
 	icon_state = "mars_dirt_6"
 	},
@@ -31460,6 +31581,7 @@
 /area/bigredv2/caves/eta/storage)
 "kHK" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor{
 	dir = 1;
 	icon_state = "asteroidfloor"
@@ -31908,6 +32030,12 @@
 	icon_state = "platingdmg3"
 	},
 /area/bigredv2/caves/mining)
+"lKR" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/mars_cave{
+	icon_state = "mars_dirt_4"
+	},
+/area/bigredv2/outside/lz1_north_cas)
 "lLf" = (
 /obj/structure/largecrate/random/case,
 /turf/open/floor/plating{
@@ -32135,6 +32263,12 @@
 	},
 /turf/open/floor,
 /area/bigred/ground/garage_workshop)
+"mlq" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/mars_cave{
+	icon_state = "mars_cave_2"
+	},
+/area/bigredv2/outside/lz1_north_cas)
 "mmg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/drip{
@@ -32268,6 +32402,14 @@
 "mzV" = (
 /turf/open/mars,
 /area/bigredv2/outside/filtration_plant)
+"mAd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "asteroidfloor"
+	},
+/area/bigredv2/outside/telecomm)
 "mBo" = (
 /obj/item/weapon/twohanded/folded_metal_chair{
 	pixel_x = -7;
@@ -32289,6 +32431,13 @@
 	icon_state = "asteroidfloor"
 	},
 /area/bigredv2/outside/filtration_cave_cas)
+"mDJ" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/plating{
+	dir = 8;
+	icon_state = "platingdmg2"
+	},
+/area/bigredv2/outside/space_port)
 "mDN" = (
 /turf/open/mars_cave{
 	icon_state = "mars_cave_15"
@@ -32487,6 +32636,10 @@
 	icon_state = "mars_dirt_4"
 	},
 /area/bigredv2/caves/mining)
+"ndq" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/closed/wall/solaris/reinforced/hull,
+/area/bigredv2/caves)
 "ndy" = (
 /obj/effect/decal/cleanable/blood/drip{
 	pixel_x = -3;
@@ -32688,6 +32841,11 @@
 	icon_state = "mars_cave_3"
 	},
 /area/bigredv2/caves/mining)
+"nFG" = (
+/obj/item/stack/sheet/metal,
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/plating,
+/area/bigredv2/outside/space_port)
 "nGm" = (
 /obj/structure/fence,
 /obj/structure/blocker/forcefield/multitile_vehicles,
@@ -32707,6 +32865,12 @@
 	icon_state = "asteroidfloor"
 	},
 /area/bigredv2/outside/telecomm/lz2_cave)
+"nHh" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/mars_cave{
+	icon_state = "mars_cave_2"
+	},
+/area/bigredv2/outside/lz2_west_cas)
 "nHQ" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
 /obj/structure/machinery/door/poddoor/almayer/closed{
@@ -32977,6 +33141,7 @@
 /turf/open/floor/plating,
 /area/bigredv2/caves/mining)
 "oip" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/mars{
 	icon_state = "mars_dirt_6"
 	},
@@ -33178,6 +33343,12 @@
 	icon_state = "mars_cave_5"
 	},
 /area/bigredv2/caves_research)
+"oxV" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor{
+	icon_state = "asteroidwarning"
+	},
+/area/bigredv2/outside/nw)
 "oye" = (
 /turf/open/mars_cave{
 	icon_state = "mars_cave_5"
@@ -33211,6 +33382,11 @@
 	icon_state = "mars_cave_5"
 	},
 /area/bigredv2/caves_virology)
+"oCx" = (
+/obj/structure/blocker/forcefield/multitile_vehicles,
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/mars_cave,
+/area/bigredv2/outside/lz2_west_cas)
 "oDB" = (
 /obj/structure/closet/l3closet,
 /obj/effect/landmark/objective_landmark/close,
@@ -33550,6 +33726,10 @@
 	icon_state = "mars_cave_6"
 	},
 /area/bigredv2/caves_research)
+"pjZ" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/closed/wall/solaris/reinforced,
+/area/bigredv2/outside/space_port)
 "plx" = (
 /obj/structure/machinery/power/apc{
 	dir = 4
@@ -33586,6 +33766,12 @@
 	icon_state = "mars_dirt_11"
 	},
 /area/bigredv2/caves_north)
+"pov" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/mars_cave{
+	icon_state = "mars_dirt_4"
+	},
+/area/bigredv2/outside/w)
 "pow" = (
 /obj/structure/blocker/forcefield/multitile_vehicles,
 /turf/open/mars_cave{
@@ -33802,6 +33988,12 @@
 	icon_state = "platingdmg3"
 	},
 /area/bigredv2/caves/mining)
+"pTa" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/mars_cave{
+	icon_state = "mars_dirt_5"
+	},
+/area/bigredv2/outside/lz1_north_cas)
 "pTA" = (
 /obj/structure/platform_decoration/shiva{
 	dir = 1
@@ -33824,6 +34016,12 @@
 /obj/item/weapon/broken_bottle,
 /turf/open/floor/plating,
 /area/bigredv2/caves/mining)
+"pUt" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/mars_cave{
+	icon_state = "mars_dirt_4"
+	},
+/area/bigredv2/outside/sw)
 "pVp" = (
 /obj/structure/prop/invuln/minecart_tracks{
 	dir = 1
@@ -33992,6 +34190,14 @@
 	icon_state = "mars_cave_6"
 	},
 /area/bigredv2/caves/mining)
+"qhR" = (
+/obj/structure/pipes/standard/simple/hidden/green,
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "asteroidfloor"
+	},
+/area/bigredv2/outside/nw)
 "qiA" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
@@ -34160,6 +34366,14 @@
 	icon_state = "mars_cave_13"
 	},
 /area/bigredv2/caves/mining)
+"qBj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "asteroidwarning"
+	},
+/area/bigredv2/outside/w)
 "qCK" = (
 /turf/open/floor{
 	icon_state = "asteroidwarning"
@@ -34486,6 +34700,13 @@
 	},
 /turf/closed/wall/solaris/reinforced,
 /area/bigredv2/caves/mining)
+"rjL" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "asteroidfloor"
+	},
+/area/bigredv2/outside/sw)
 "rkS" = (
 /obj/structure/cable{
 	icon_state = "5-6"
@@ -34552,6 +34773,13 @@
 	icon_state = "mars_cave_3"
 	},
 /area/bigredv2/caves/mining)
+"rta" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor{
+	icon_state = "asteroidwarning"
+	},
+/area/bigredv2/outside/nw)
 "rtL" = (
 /obj/structure/blocker/forcefield/multitile_vehicles,
 /turf/open/mars_cave{
@@ -34872,6 +35100,12 @@
 	icon_state = "mars_dirt_7"
 	},
 /area/bigredv2/caves/mining)
+"rVS" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/mars_cave{
+	icon_state = "mars_cave_20"
+	},
+/area/bigredv2/outside/lz1_north_cas)
 "rWF" = (
 /obj/item/stack/cable_coil/cut{
 	pixel_x = 6;
@@ -35025,6 +35259,12 @@
 	icon_state = "mars_cave_18"
 	},
 /area/bigredv2/outside/lz1_telecomm_cas)
+"skc" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/mars_cave{
+	icon_state = "mars_cave_17"
+	},
+/area/bigredv2/outside/lz1_north_cas)
 "ski" = (
 /turf/open/mars_cave,
 /area/bigredv2/outside/lz2_west_cas)
@@ -35042,6 +35282,10 @@
 	},
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
+"slK" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/closed/wall/solaris/reinforced,
+/area/bigredv2/outside/telecomm)
 "smh" = (
 /obj/structure/blocker/forcefield/multitile_vehicles,
 /turf/open/floor/plating,
@@ -35274,6 +35518,11 @@
 /obj/structure/machinery/light,
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
+"sCO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/closed/wall/solaris/reinforced,
+/area/bigredv2/outside/telecomm)
 "sDs" = (
 /obj/structure/closet/crate/miningcar,
 /obj/item/weapon/gun/smg/nailgun,
@@ -35383,6 +35632,7 @@
 /area/bigredv2/caves/mining)
 "sOE" = (
 /obj/structure/blocker/forcefield/multitile_vehicles,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/mars_cave{
 	icon_state = "mars_cave_6"
 	},
@@ -36026,6 +36276,10 @@
 	icon_state = "mars_cave_15"
 	},
 /area/bigredv2/caves/mining)
+"tWO" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/mars,
+/area/bigredv2/outside/sw)
 "tWS" = (
 /obj/effect/landmark/item_pool_spawner/survivor_ammo,
 /turf/open/mars_cave{
@@ -36471,6 +36725,14 @@
 	icon_state = "mars_cave_3"
 	},
 /area/bigredv2/caves_sw)
+"uYq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "asteroidwarning"
+	},
+/area/bigredv2/outside/w)
 "vbi" = (
 /turf/open/floor{
 	dir = 5;
@@ -36673,6 +36935,13 @@
 	icon_state = "mars_cave_11"
 	},
 /area/bigredv2/caves_research)
+"vrp" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "asteroidfloor"
+	},
+/area/bigredv2/outside/telecomm)
 "vrt" = (
 /turf/open/mars{
 	icon_state = "mars_dirt_14"
@@ -37223,6 +37492,12 @@
 	icon_state = "delivery"
 	},
 /area/bigredv2/caves/lambda/virology)
+"wAI" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/mars_cave{
+	icon_state = "mars_cave_6"
+	},
+/area/bigredv2/outside/lz2_west_cas)
 "wBi" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
@@ -37242,6 +37517,17 @@
 	icon_state = "mars_dirt_4"
 	},
 /area/bigredv2/caves/mining)
+"wCq" = (
+/obj/structure/machinery/light{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "asteroidwarning"
+	},
+/area/bigredv2/outside/cargo)
 "wDa" = (
 /obj/effect/decal/cleanable/blood/drip{
 	pixel_x = 6
@@ -37631,6 +37917,13 @@
 	icon_state = "mars_cave_2"
 	},
 /area/space)
+"xop" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "asteroidwarning"
+	},
+/area/bigredv2/outside/w)
 "xpb" = (
 /turf/open/floor{
 	dir = 5;
@@ -37741,6 +38034,10 @@
 	icon_state = "platingdmg3"
 	},
 /area/bigredv2/caves/mining)
+"xwK" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/closed/wall/solaris/reinforced,
+/area/bigredv2/outside/virology)
 "xya" = (
 /obj/structure/barricade/wooden{
 	desc = "This barricade is heavily reinforced. Nothing short of blasting it open seems like it'll do the trick, that or melting the breams supporting it...";
@@ -37754,6 +38051,13 @@
 	icon_state = "mars_dirt_4"
 	},
 /area/bigredv2/caves/mining)
+"xyp" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/plating,
+/area/bigredv2/outside/space_port)
 "xyu" = (
 /obj/structure/closet/l3closet/security,
 /turf/open/floor{
@@ -37833,6 +38137,7 @@
 /turf/open/mars_cave,
 /area/bigredv2/caves_lambda)
 "xGT" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor{
 	dir = 9;
 	icon_state = "asteroidwarning"
@@ -37947,6 +38252,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor,
 /area/bigredv2/outside/cargo)
+"xQM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor{
+	dir = 6;
+	icon_state = "asteroidwarning"
+	},
+/area/bigredv2/outside/nw)
 "xRl" = (
 /obj/item/weapon/gun/pistol/b92fs{
 	pixel_x = 13;
@@ -40459,8 +40772,8 @@ acA
 acA
 acA
 acA
-ahN
-acA
+sCO
+slK
 sOE
 csE
 xmy
@@ -40894,7 +41207,7 @@ aas
 ahd
 ahd
 all
-acA
+slK
 bRm
 xmy
 xmy
@@ -41111,7 +41424,7 @@ aas
 aas
 aas
 all
-acA
+slK
 bRm
 xmy
 xmy
@@ -41186,7 +41499,7 @@ aao
 aao
 aao
 aao
-cYJ
+nHh
 cYJ
 cYJ
 cYJ
@@ -41328,7 +41641,7 @@ aas
 ahd
 aaZ
 all
-acA
+slK
 bRm
 xmy
 xmy
@@ -41402,8 +41715,8 @@ aao
 aao
 aao
 aao
-cYJ
-cYJ
+nHh
+nHh
 vMj
 vMj
 cYJ
@@ -41545,7 +41858,7 @@ aas
 ahd
 aas
 all
-acA
+slK
 aao
 xmy
 gda
@@ -41619,8 +41932,8 @@ aao
 aao
 aao
 cYJ
-cYJ
-uyk
+nHh
+kbC
 tDv
 cYJ
 cYJ
@@ -41756,11 +42069,11 @@ afL
 acQ
 aas
 ahd
-ahd
-aas
-aas
-ahd
-aas
+mAd
+vrp
+vrp
+mAd
+vrp
 all
 akl
 aao
@@ -41836,8 +42149,8 @@ cYJ
 cYJ
 cYJ
 cYJ
-vMj
-cYJ
+wAI
+nHh
 cYJ
 cYJ
 ski
@@ -41973,13 +42286,13 @@ acQ
 acQ
 acA
 ahN
-acA
-acA
-acA
-acA
-acA
-acA
-acA
+slK
+slK
+slK
+slK
+slK
+slK
+slK
 aao
 aao
 qsE
@@ -42053,8 +42366,8 @@ cYJ
 cYJ
 cYJ
 cYJ
-cYJ
-cYJ
+nHh
+nHh
 cYJ
 cdA
 aao
@@ -42270,8 +42583,8 @@ rtL
 rtL
 rtL
 tft
-tft
-ski
+oCx
+dJY
 ski
 oNu
 aao
@@ -43305,7 +43618,7 @@ aao
 aao
 aao
 aao
-aeI
+aBR
 aoD
 aFv
 aGr
@@ -43518,11 +43831,11 @@ aao
 aao
 aao
 aao
-aeI
-aeI
-aeI
-aeI
-aeI
+aBR
+aBR
+aBR
+aBR
+aBR
 aoD
 aFv
 aGr
@@ -43731,14 +44044,14 @@ aao
 aao
 aao
 aao
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
+aBR
+aBR
+aBR
+aBR
+aBR
+aBR
+aBR
+aBR
 aoD
 aoD
 aFw
@@ -43948,15 +44261,15 @@ aeI
 aeI
 aao
 aao
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
+aBR
+aBR
+aBR
+aBR
+aBR
+aBR
+aBR
+aBR
+aBR
 aoD
 aFt
 aFt
@@ -44164,16 +44477,16 @@ aeI
 aeI
 aeI
 aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
+aBR
+aBR
+aBR
+aBR
+aBR
+aBR
+aBR
+aBR
+aBR
+aBR
 aoD
 aFt
 aFt
@@ -44381,15 +44694,15 @@ aeI
 aeI
 aeI
 aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
+aBR
+aBR
+aBR
+aBR
+aBR
+aBR
+aBR
+aBR
+aBR
 aoD
 aoD
 aFt
@@ -44598,16 +44911,16 @@ aeI
 aeI
 aeI
 aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
+aBR
+aBR
+aBR
+aBR
+aBR
+aBR
+aBR
+aBR
+aBR
+aBR
 aoD
 aFt
 aFt
@@ -44815,16 +45128,16 @@ aeI
 aeI
 aiz
 ahO
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
+aBR
+aBR
+aBR
+aBR
+aBR
+aBR
+aBR
+aBR
+aBR
+aBR
 aoD
 aFt
 aFt
@@ -45032,16 +45345,16 @@ atQ
 aiz
 ahP
 ahP
-aog
+aKl
 axu
-aeI
-aeI
-aeI
-aiz
-aog
-ahO
-aeI
-aeI
+aBR
+aBR
+aBR
+aLd
+aKl
+aIm
+aBR
+aBR
 aoD
 aFt
 aGs
@@ -45249,16 +45562,16 @@ aog
 ahP
 ahP
 ahP
-ahP
-ahP
-aog
-aog
-aog
-ahP
-ahP
-ahP
-aog
-aog
+aIn
+aIn
+aKl
+aKl
+aKl
+aIn
+aIn
+aIn
+aKl
+aKl
 aoD
 aFt
 aoD
@@ -45442,7 +45755,7 @@ aaf
 aag
 aaf
 aaf
-acJ
+iaD
 aae
 aao
 aao
@@ -45466,17 +45779,17 @@ aqp
 aqp
 aiw
 aqp
-aqp
-aiw
-aiw
-aiw
-aiw
-aiw
-aqp
-aiw
-aqp
+aCN
+aFM
+aFM
+aFM
+aFM
+aFM
+aCN
+aFM
+aCN
 aDw
-aoD
+lBc
 aoD
 aoD
 aHj
@@ -45508,10 +45821,10 @@ aoD
 aoD
 aoD
 aoa
-azR
-azR
-azR
-aYF
+ndq
+ndq
+ndq
+fQN
 aYF
 bbc
 aSB
@@ -45660,8 +45973,8 @@ aam
 aam
 aam
 ago
-aae
-ahR
+pjZ
+oxV
 aeI
 aeI
 aeI
@@ -45683,24 +45996,24 @@ akd
 akd
 akd
 aiy
-aoN
-ajx
-amc
-aix
-aix
-aix
-aix
-aix
-aix
+bhU
+aHF
+beB
+aVp
+aVp
+aVp
+aVp
+aVp
+aVp
 aDx
 aDw
-ahP
+aIn
 aoD
 grU
 aIg
 grU
 aoa
-aln
+aWJ
 aoD
 aEu
 aEu
@@ -45720,15 +46033,15 @@ aEV
 aEu
 aEu
 aoa
-aSB
-aSB
-aoD
-aSB
-aSB
-azR
-aSB
-aSB
-bax
+pov
+pov
+xwK
+pov
+pov
+ndq
+pov
+pov
+dXe
 bax
 aSB
 aSB
@@ -45876,9 +46189,9 @@ aah
 aah
 aah
 aah
-aeG
-aae
-ahR
+xyp
+pjZ
+oxV
 aeI
 aeI
 aeI
@@ -45900,24 +46213,24 @@ ahP
 aqJ
 ahP
 ahP
-ajy
-ajx
-ajY
-ajx
-ajx
-ajx
-ajx
-ajx
-ajx
-ajY
-akK
-ahP
-auF
-ajx
-ajY
-ajx
-ahT
-aln
+aMc
+aHF
+bhR
+aHF
+aHF
+aHF
+aHF
+aHF
+aHF
+bhR
+jOR
+aIn
+aMd
+aHF
+bhR
+aHF
+axW
+aWJ
 aEu
 aEu
 aEu
@@ -45937,15 +46250,15 @@ aEu
 aEu
 aEu
 aEu
-aSB
-aSB
-aSB
-aSB
+pov
+pov
+pov
+pov
 beP
 beP
 beP
-aSB
-aSB
+pov
+pov
 aSB
 aSB
 aSB
@@ -46093,9 +46406,9 @@ aah
 aah
 aah
 aah
-aeG
-aae
-ahR
+xyp
+pjZ
+oxV
 aeI
 aeI
 aeI
@@ -46117,25 +46430,25 @@ aqJ
 aoO
 aiw
 aiw
-ajx
-ajx
-ajY
-ajx
-ajx
-ajx
-ajx
-ajx
-ajx
-aDz
-aEv
-ahP
-ahP
-ajy
-ajY
-ahR
-ahP
-ama
-aeI
+aHF
+aHF
+bhR
+aHF
+aHF
+aHF
+aHF
+aHF
+aHF
+beC
+gpt
+aIn
+aIn
+aMc
+bhR
+aHD
+aIn
+aIp
+aBR
 aEu
 aEu
 aEu
@@ -46161,8 +46474,8 @@ aWk
 aVI
 aWk
 aWk
-aVI
-aVI
+qBj
+qBj
 aWk
 aWk
 aWk
@@ -46310,9 +46623,9 @@ aah
 aah
 aah
 aah
-aeG
-aae
-ahR
+xyp
+pjZ
+oxV
 ahO
 aeI
 aeI
@@ -46342,18 +46655,18 @@ anp
 anp
 anp
 anp
-ajx
-ajY
-akK
-ahP
-ahP
-ajy
-ajY
-ahR
-aln
-aeI
-aeI
-aeI
+aHF
+bhR
+jOR
+aIn
+aIn
+aMc
+bhR
+aHD
+aWJ
+aBR
+aBR
+aBR
 aEu
 aEu
 aEu
@@ -46378,8 +46691,8 @@ aUQ
 bdZ
 bdZ
 bdZ
-aXA
-aWV
+xop
+uYq
 aXA
 aXA
 aXA
@@ -46527,9 +46840,9 @@ aah
 aah
 aah
 aah
-aeG
-aae
-ahR
+xyp
+pjZ
+oxV
 ahP
 ahO
 aeI
@@ -46559,18 +46872,18 @@ azn
 avT
 avT
 anp
-ajx
-ajY
-ahR
-ahP
-ahP
-ajy
-ajY
-ahR
-aln
-aeI
-aeI
-aEu
+aHF
+bhR
+aHD
+aIn
+aIn
+aMc
+bhR
+aHD
+aWJ
+aBR
+aBR
+bhi
 aEu
 aEu
 aEu
@@ -46596,7 +46909,7 @@ bdZ
 bdZ
 beu
 beP
-aSB
+pov
 aSB
 aSB
 aSB
@@ -46744,9 +47057,9 @@ aah
 aah
 aah
 aah
-aeG
-aae
-ahR
+xyp
+pjZ
+oxV
 ahP
 ahP
 ahO
@@ -46776,18 +47089,18 @@ azo
 aAq
 aAZ
 anp
-ajx
-ajY
-ajx
-aiw
-aiw
+aHF
+bhR
+aHF
+aFM
+aFM
 aHl
-ajY
-ahR
-aln
-aeI
-aoO
-aqp
+bhR
+aHD
+aWJ
+aBR
+aWI
+aCN
 aEu
 aEu
 aEu
@@ -46813,7 +47126,7 @@ aUQ
 bdZ
 bev
 beP
-aSB
+pov
 bfT
 aSB
 aSB
@@ -46961,9 +47274,9 @@ aah
 aah
 aah
 aah
-aeG
-ahK
-ajx
+xyp
+ePg
+giv
 aiw
 aiw
 aiw
@@ -46993,17 +47306,17 @@ avT
 avT
 avT
 anp
-ajx
+aHF
 aDA
-alm
-alm
-alm
+iJX
+iJX
+iJX
 aHm
 aIi
-ahT
-aln
-aeI
-ajy
+axW
+aWJ
+aBR
+aMc
 aoH
 aoH
 aoH
@@ -47030,7 +47343,7 @@ aUQ
 bdZ
 bev
 beP
-aSB
+pov
 aSB
 aSB
 aSB
@@ -47180,7 +47493,7 @@ aah
 aah
 agr
 fSJ
-aix
+qhR
 aix
 aix
 aix
@@ -47210,17 +47523,17 @@ avT
 avT
 avT
 anp
-ahR
-ahV
-ahV
-ahV
-ahP
-ahP
-ahP
-ahP
-ama
-aeI
-ajz
+aHD
+aKt
+aKt
+aKt
+aIn
+aIn
+aIn
+aIn
+aIp
+aBR
+biz
 apt
 aNk
 aOv
@@ -47246,30 +47559,30 @@ bdZ
 aUQ
 bdZ
 bev
-aSB
-aSB
+pov
+pov
 aSB
 xGT
-aWk
-eWd
-eWd
+gFj
+gtv
+gtv
 kHK
 kHK
-eWd
-eWd
-eWd
-eWd
-eWd
-eWd
-eWd
-bmN
-bmN
-bmN
-bmN
-bmN
-bmN
-bmN
-bmN
+gtv
+gtv
+gtv
+gtv
+gtv
+gtv
+gtv
+fEx
+fEx
+fEx
+fEx
+fEx
+fEx
+fEx
+fEx
 eWd
 eWd
 eWd
@@ -47395,9 +47708,9 @@ aah
 acx
 aah
 aah
-aeG
-ahK
-ajx
+xyp
+ePg
+giv
 aiy
 aiy
 ajx
@@ -47427,17 +47740,17 @@ azo
 aAq
 aAZ
 anp
-ahR
-aeI
-aeI
-ahi
-aiB
-ahV
-ama
-aeI
-aeI
-aeI
-ajz
+aHD
+aBR
+aBR
+aFL
+aYK
+aKt
+aIp
+aBR
+aBR
+aBR
+biz
 apt
 aNk
 aNo
@@ -47463,10 +47776,10 @@ bdZ
 bdZ
 bdZ
 bev
+pov
+pov
 aSB
-aSB
-aSB
-aVG
+gMl
 asK
 asK
 asK
@@ -47486,7 +47799,7 @@ axX
 bmi
 boD
 axX
-bpx
+pUt
 ufD
 bpv
 brd
@@ -47612,8 +47925,8 @@ aah
 aah
 aah
 aah
-aeG
-aae
+xyp
+pjZ
 ahU
 ahP
 ahP
@@ -47644,17 +47957,17 @@ avT
 avT
 avT
 anp
-ahR
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-ajz
+aHD
+aBR
+aBR
+aBR
+aBR
+aBR
+aBR
+aBR
+aBR
+aBR
+biz
 apt
 aNk
 aOw
@@ -47680,10 +47993,10 @@ bdZ
 bdZ
 bdZ
 bev
-aSB
-aSB
+pov
+pov
 bfU
-aVG
+gMl
 asK
 svp
 svp
@@ -47703,7 +48016,7 @@ azb
 bmi
 bmi
 azb
-bpx
+pUt
 ufD
 bpv
 brd
@@ -47829,9 +48142,9 @@ aah
 aah
 aah
 aah
-aeG
-aae
-ahR
+xyp
+pjZ
+oxV
 ahP
 ahP
 ajy
@@ -47861,17 +48174,17 @@ avT
 avT
 aBa
 anp
-ahR
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-ajz
+aHD
+aBR
+aBR
+aBR
+aBR
+aBR
+aBR
+aBR
+aBR
+aBR
+biz
 apt
 aNk
 aOx
@@ -47897,10 +48210,10 @@ bdZ
 bdZ
 bdZ
 beQ
+pov
+pov
 aSB
-aSB
-aSB
-aVG
+gMl
 asK
 bhb
 bhb
@@ -47920,7 +48233,7 @@ azb
 bmi
 bmi
 azb
-bpx
+pUt
 ufD
 bpv
 brd
@@ -48047,8 +48360,8 @@ aeF
 afg
 afg
 adl
-aae
-ahR
+pjZ
+oxV
 ahV
 ahP
 ajy
@@ -48078,16 +48391,16 @@ avT
 avT
 avT
 anp
-ahR
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
+aHD
+aBR
+aBR
+aBR
+aBR
+aBR
+aBR
+aBR
+aBR
+aBR
 aLZ
 aoH
 aNl
@@ -48114,10 +48427,10 @@ bdZ
 bdZ
 bdZ
 beQ
+pov
+pov
 aSB
-aSB
-aSB
-aVG
+gMl
 asK
 bhc
 bbe
@@ -48137,7 +48450,7 @@ azb
 bmi
 bmi
 azb
-bpx
+pUt
 ufD
 bpv
 bpv
@@ -48147,7 +48460,7 @@ brG
 brG
 brG
 brG
-brG
+cod
 qzO
 cHn
 cHn
@@ -48263,7 +48576,7 @@ aah
 aeG
 afh
 afM
-agv
+mDJ
 ahg
 ahW
 ahX
@@ -48295,17 +48608,17 @@ avT
 avT
 avT
 anp
-ahR
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-ajy
+aHD
+aBR
+aBR
+aBR
+aBR
+aBR
+aBR
+aBR
+aBR
+aBR
+aMc
 aoH
 aNm
 aOx
@@ -48331,10 +48644,10 @@ bcs
 bcs
 bcs
 bew
-beR
-aSB
-aSB
-aVG
+jRI
+pov
+pov
+gMl
 asK
 bhd
 bhD
@@ -48364,7 +48677,7 @@ bpv
 bpv
 bpv
 bpv
-bpv
+rjL
 qzO
 bGL
 bGL
@@ -48481,8 +48794,8 @@ aeH
 aah
 afM
 agw
-agv
-akK
+mDJ
+rta
 ahX
 aiA
 ajy
@@ -48512,17 +48825,17 @@ avT
 avT
 avT
 anp
-ahR
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-ajy
+aHD
+aBR
+aBR
+aBR
+aBR
+aBR
+aBR
+aBR
+aBR
+aBR
+aMc
 aoH
 fmd
 aOx
@@ -48548,10 +48861,10 @@ bdf
 bdf
 beb
 bdf
-beS
-aWk
-aWk
-bdZ
+wCq
+gFj
+gFj
+bPv
 asK
 oEJ
 oEJ
@@ -48571,17 +48884,17 @@ azb
 bmi
 bmi
 azb
-bme
+tWO
 bqe
+iRd
+iRd
+iRd
+iRd
+iRd
+iRd
+iRd
 heU
-heU
-heU
-heU
-heU
-heU
-heU
-heU
-heU
+iRd
 qzO
 bGL
 bGL
@@ -48698,7 +49011,7 @@ aah
 aah
 aah
 agx
-agv
+mDJ
 ahY
 aeI
 aiA
@@ -48729,17 +49042,17 @@ avT
 avT
 avT
 anp
-ahR
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-ajy
+aHD
+aBR
+aBR
+aBR
+aBR
+aBR
+aBR
+aBR
+aBR
+aBR
+aMc
 aoH
 aNm
 aOz
@@ -48796,7 +49109,7 @@ azB
 azB
 axX
 axX
-bpx
+pUt
 bpy
 bpy
 glB
@@ -48914,9 +49227,9 @@ aah
 aah
 aah
 aah
-afM
+eaE
 agw
-ahR
+oxV
 ahX
 aiA
 ajy
@@ -48946,17 +49259,17 @@ avT
 avT
 aBa
 anp
-ahR
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-ajy
+aHD
+aBR
+aBR
+aBR
+aBR
+aBR
+aBR
+aBR
+aBR
+aBR
+aMc
 aoH
 aNn
 aOy
@@ -49014,7 +49327,7 @@ bob
 bsJ
 axX
 bsI
-bme
+tWO
 aao
 glB
 rJJ
@@ -49131,8 +49444,8 @@ aah
 aah
 aah
 agv
-afh
-agv
+nFG
+mDJ
 ahZ
 aeI
 aiA
@@ -49163,17 +49476,17 @@ avT
 avT
 avT
 anp
-ahR
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-ajy
+aHD
+aBR
+aBR
+aBR
+aBR
+aBR
+aBR
+aBR
+aBR
+aBR
+aMc
 apt
 aNk
 aOy
@@ -49230,8 +49543,8 @@ bmi
 bmi
 bmi
 azb
-bme
-bme
+tWO
+tWO
 aao
 glB
 jOc
@@ -49348,9 +49661,9 @@ aah
 aah
 aah
 aah
-afM
+eaE
 ahh
-akK
+rta
 aeI
 aiA
 ajy
@@ -49380,17 +49693,17 @@ azo
 aAq
 aAZ
 anp
-ahR
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-ajy
+aHD
+aBR
+aBR
+aBR
+aBR
+aBR
+aBR
+aBR
+aBR
+aBR
+aMc
 apt
 aNk
 aOy
@@ -49447,8 +49760,8 @@ bmg
 bre
 bsK
 axX
-bme
-bme
+tWO
+tWO
 aao
 glB
 xpb
@@ -49565,9 +49878,9 @@ aae
 aae
 aae
 aae
-aae
-aae
-atm
+pjZ
+pjZ
+xQM
 aeI
 aiA
 ajz
@@ -49597,16 +49910,16 @@ avT
 avT
 avT
 anp
-ahR
-aeI
-aeI
-aeI
-aeI
+aHD
+aBR
+aBR
+aBR
+aBR
 aHn
-aeI
-aeI
-aeI
-aeI
+aBR
+aBR
+aBR
+aBR
 aMa
 apu
 aNm
@@ -49664,8 +49977,8 @@ bmg
 bre
 bsL
 azb
-bme
-bpx
+tWO
+pUt
 aao
 euF
 dEV
@@ -49814,17 +50127,17 @@ anp
 anp
 anp
 anp
-ahR
-aeI
-aeI
-ahi
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aMb
+aHD
+aBR
+aBR
+aFL
+aBR
+aBR
+aBR
+aBR
+aBR
+aBR
+aWW
 apu
 aNl
 aOy
@@ -49881,8 +50194,8 @@ bmi
 bmi
 bsM
 axX
-bpx
-bpx
+pUt
+pUt
 aao
 euF
 euF
@@ -50027,21 +50340,21 @@ alu
 aqw
 azv
 alu
-ajx
-ajx
-ajx
-ajx
-ahR
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-ajy
+aHF
+aHF
+aHF
+aHF
+aHD
+aBR
+aBR
+aBR
+aBR
+aBR
+aBR
+aBR
+aBR
+aBR
+aMc
 apt
 aNk
 aOy
@@ -50098,7 +50411,7 @@ ayr
 brf
 axX
 axX
-bpx
+pUt
 kdh
 aao
 aao
@@ -50244,21 +50557,21 @@ alu
 aqw
 aye
 alu
-ajx
-ajx
-ajx
-ajx
-ajx
-aiw
-aiw
-aiw
-aiw
-aiw
-aiw
-ahQ
-aeI
-aeI
-ajz
+aHF
+aHF
+aHF
+aHF
+aHF
+aFM
+aFM
+aFM
+aFM
+aFM
+aFM
+aHC
+aBR
+aBR
+biz
 apt
 aNk
 aOy
@@ -50314,9 +50627,9 @@ bmi
 brI
 bmi
 azb
-bpx
-bpx
-bpx
+pUt
+pUt
+pUt
 aao
 aao
 aao
@@ -52360,12 +52673,12 @@ aao
 aao
 aao
 aao
-pXu
-iyY
-pXu
-pXu
-pXu
-pXu
+mlq
+imL
+mlq
+mlq
+mlq
+mlq
 aao
 aao
 aao
@@ -52578,12 +52891,12 @@ aao
 aao
 aao
 aao
-wXg
-cGZ
-iyY
-pXu
-pXu
-pXu
+lKR
+rVS
+imL
+mlq
+mlq
+mlq
 aao
 aao
 aao
@@ -52795,13 +53108,13 @@ aao
 aao
 aao
 aao
-pMv
-wXg
-wXg
-wKx
-pXu
-pXu
-pXu
+pTa
+lKR
+lKR
+skc
+mlq
+mlq
+mlq
 aao
 aao
 aao

--- a/maps/map_files/BigRed/BigRed.dmm
+++ b/maps/map_files/BigRed/BigRed.dmm
@@ -785,8 +785,7 @@
 /area/bigredv2/outside/marshal_office)
 "acu" = (
 /obj/structure/surface/table/reinforced/prison,
-/obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
-/obj/item/weapon/gun/shotgun/pump/dual_tube/cmb,
+/obj/effect/spawner/random/tool,
 /turf/open/floor{
 	dir = 1;
 	icon_state = "asteroidwarning"
@@ -27780,6 +27779,10 @@
 	icon_state = "mars_cave_15"
 	},
 /area/bigredv2/caves/mining)
+"dhZ" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plating,
+/area/bigredv2/outside/nw/ceiling)
 "dij" = (
 /obj/structure/fence,
 /obj/structure/blocker/forcefield/multitile_vehicles,
@@ -29351,6 +29354,12 @@
 	icon_state = "platingdmg3"
 	},
 /area/bigredv2/caves/mining)
+"goC" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
+/obj/item/tool/extinguisher,
+/turf/open/floor/plating,
+/area/bigredv2/outside/nw/ceiling)
 "gpg" = (
 /turf/open/mars_cave,
 /area/bigredv2/caves_east)
@@ -29749,6 +29758,10 @@
 	icon_state = "asteroidwarning"
 	},
 /area/bigredv2/outside/lz2_south_cas)
+"hqF" = (
+/obj/effect/vehicle_spawner/van/decrepit,
+/turf/open/floor/plating,
+/area/bigredv2/outside/nw/ceiling)
 "hqO" = (
 /obj/structure/blocker/forcefield/multitile_vehicles,
 /turf/open/mars,
@@ -30265,6 +30278,12 @@
 	icon_state = "mars_cave_19"
 	},
 /area/bigredv2/caves_north)
+"isD" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
+/obj/item/weapon/gun/shotgun/pump/dual_tube/cmb,
+/turf/open/floor/plating,
+/area/bigredv2/outside/nw/ceiling)
 "itL" = (
 /obj/structure/closet/l3closet/virology,
 /obj/effect/landmark/objective_landmark/science,
@@ -34110,8 +34129,7 @@
 /area/bigredv2/outside/nw)
 "qiA" = (
 /obj/structure/surface/table/reinforced/prison,
-/obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
-/obj/item/tool/extinguisher,
+/obj/effect/spawner/random/toolbox,
 /turf/open/floor{
 	dir = 1;
 	icon_state = "asteroidwarning"
@@ -36490,7 +36508,6 @@
 	},
 /area/bigredv2/caves/mining)
 "uIB" = (
-/obj/effect/vehicle_spawner/van/decrepit,
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor{
 	dir = 1;
@@ -48242,7 +48259,7 @@ avT
 axZ
 avT
 avT
-avT
+hqF
 avT
 anp
 aHD
@@ -48677,7 +48694,7 @@ ayb
 avT
 avT
 avT
-avT
+isD
 anp
 aHD
 aBR
@@ -48894,7 +48911,7 @@ axZ
 avT
 avT
 avT
-avT
+goC
 anp
 aHD
 aBR
@@ -49328,7 +49345,7 @@ axZ
 avT
 avT
 avT
-avT
+dhZ
 anp
 aHD
 aBR

--- a/maps/map_files/DesertDam/Desert_Dam.dmm
+++ b/maps/map_files/DesertDam/Desert_Dam.dmm
@@ -1029,6 +1029,7 @@
 	dir = 8
 	},
 /obj/structure/prop/dam/truck/damaged,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached1"
 	},
@@ -1251,6 +1252,7 @@
 /turf/open/desert/dirt,
 /area/desert_dam/interior/lab_northeast/east_lab_west_entrance)
 "aee" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/closed/wall/r_wall/bunker{
 	name = "reinforced metal wall"
 	},
@@ -1270,6 +1272,7 @@
 	dir = 8
 	},
 /obj/structure/largecrate/random/case/small,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached1"
 	},
@@ -1568,6 +1571,7 @@
 /area/desert_dam/interior/lab_northeast/east_lab_west_entrance)
 "aeY" = (
 /obj/structure/prop/dam/boulder/boulder1,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/desert/dirt,
 /area/desert_dam/exterior/valley/valley_northwest)
 "aeZ" = (
@@ -1742,6 +1746,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt{
 	icon_state = "tile"
 	},
@@ -2057,6 +2062,7 @@
 	dir = 1
 	},
 /obj/structure/prop/dam/truck/cargo,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached18"
 	},
@@ -3569,6 +3575,7 @@
 /area/desert_dam/exterior/valley/north_valley_dam)
 "akU" = (
 /obj/structure/prop/dam/truck/cargo,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt,
 /area/desert_dam/exterior/landing_pad_one)
 "akV" = (
@@ -4388,6 +4395,7 @@
 /area/desert_dam/exterior/valley/north_valley_dam)
 "anh" = (
 /obj/effect/decal/sand_overlay/sand1/corner1,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt{
 	icon_state = "tile"
 	},
@@ -5022,6 +5030,7 @@
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_central_hallway)
 "apa" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached4"
 	},
@@ -11575,6 +11584,7 @@
 /obj/structure/platform{
 	dir = 4
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/desert/dirt,
 /area/desert_dam/exterior/valley/valley_telecoms)
 "aIQ" = (
@@ -13103,6 +13113,7 @@
 /obj/effect/decal/warning_stripes{
 	icon_state = "N"
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/desert_dam/exterior/valley/valley_cargo)
 "aNn" = (
@@ -13203,6 +13214,7 @@
 /obj/structure/machinery/conveyor_switch{
 	id = "cargo_landing"
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/desert_dam/exterior/valley/valley_cargo)
 "aNB" = (
@@ -15357,6 +15369,7 @@
 /obj/effect/decal/sand_overlay/sand1{
 	dir = 8
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached9"
 	},
@@ -15490,6 +15503,7 @@
 /obj/effect/decal/sand_overlay/sand1{
 	dir = 8
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached1"
 	},
@@ -15604,6 +15618,7 @@
 /obj/effect/decal/sand_overlay/sand1{
 	dir = 8
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached15"
 	},
@@ -17327,6 +17342,7 @@
 	dir = 8;
 	icon_state = "stop_decal5"
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt,
 /area/desert_dam/exterior/valley/valley_northwest)
 "baX" = (
@@ -17815,6 +17831,7 @@
 	icon_state = "road_edge_decal4"
 	},
 /obj/structure/desertdam/decals/road_stop,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt,
 /area/desert_dam/exterior/valley/valley_northwest)
 "bcD" = (
@@ -18316,6 +18333,7 @@
 /obj/effect/decal/sand_overlay/sand1{
 	dir = 6
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt{
 	icon_state = "tile"
 	},
@@ -18630,12 +18648,14 @@
 /obj/effect/decal/warning_stripes{
 	icon_state = "N"
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt,
 /area/desert_dam/exterior/landing_pad_one)
 "bfo" = (
 /obj/effect/decal/sand_overlay/sand1{
 	dir = 8
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached13"
 	},
@@ -19073,6 +19093,7 @@
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt,
 /area/desert_dam/exterior/landing_pad_one)
 "bgO" = (
@@ -19153,6 +19174,7 @@
 /obj/effect/decal/sand_overlay/sand1{
 	dir = 4
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached17"
 	},
@@ -19161,6 +19183,7 @@
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached19"
 	},
@@ -19169,6 +19192,7 @@
 /obj/effect/decal/warning_stripes{
 	icon_state = "E"
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached16"
 	},
@@ -19177,6 +19201,7 @@
 /obj/effect/decal/sand_overlay/sand1{
 	dir = 8
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached15"
 	},
@@ -34647,6 +34672,7 @@
 /obj/effect/decal/sand_overlay/sand1/corner1{
 	dir = 8
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached12"
 	},
@@ -34745,6 +34771,7 @@
 /area/desert_dam/exterior/valley/valley_medical)
 "cfC" = (
 /obj/structure/platform,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/desert/dirt,
 /area/desert_dam/exterior/valley/valley_telecoms)
 "cfD" = (
@@ -35188,6 +35215,7 @@
 /area/desert_dam/exterior/valley/valley_telecoms)
 "chw" = (
 /obj/structure/platform_decoration,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/desert/dirt,
 /area/desert_dam/exterior/valley/valley_telecoms)
 "chx" = (
@@ -35241,6 +35269,7 @@
 /obj/effect/decal/sand_overlay/sand1{
 	dir = 4
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt{
 	icon_state = "tile"
 	},
@@ -36994,6 +37023,7 @@
 /obj/effect/decal/sand_overlay/sand1/corner1{
 	dir = 4
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt,
 /area/desert_dam/exterior/valley/valley_cargo)
 "cnB" = (
@@ -39617,6 +39647,13 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/building/medical/surgury_observation)
+"cwa" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/desert/dirt{
+	dir = 4;
+	icon_state = "desert_transition_edge1"
+	},
+/area/desert_dam/exterior/valley/valley_northwest)
 "cwb" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/pipes/standard/simple/hidden/green,
@@ -46061,6 +46098,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt,
 /area/desert_dam/exterior/valley/valley_cargo)
 "cQd" = (
@@ -48449,6 +48487,7 @@
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/desert_dam/exterior/valley/valley_cargo)
 "dax" = (
@@ -48546,6 +48585,7 @@
 /turf/open/asphalt,
 /area/desert_dam/exterior/valley/valley_civilian)
 "daU" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/desert_dam/exterior/valley/valley_cargo)
 "daX" = (
@@ -48574,6 +48614,7 @@
 /obj/structure/machinery/conveyor_switch{
 	id = "cargo_landing"
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/desert_dam/exterior/valley/valley_cargo)
 "dbd" = (
@@ -49506,6 +49547,7 @@
 	icon_state = "stop_decal5"
 	},
 /obj/effect/landmark/railgun_camera_pos,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt,
 /area/desert_dam/exterior/valley/valley_northwest)
 "deA" = (
@@ -60037,6 +60079,13 @@
 "eft" = (
 /turf/open/asphalt,
 /area/desert_dam/exterior/valley/bar_valley_dam)
+"efw" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/desert/dirt{
+	dir = 6;
+	icon_state = "desert_transition_edge1"
+	},
+/area/desert_dam/exterior/valley/valley_northwest)
 "efT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -60315,6 +60364,15 @@
 	icon_state = "tile"
 	},
 /area/desert_dam/exterior/valley/valley_telecoms)
+"eoJ" = (
+/obj/effect/decal/sand_overlay/sand1{
+	dir = 4
+	},
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached3"
+	},
+/area/desert_dam/exterior/valley/valley_telecoms)
 "eqo" = (
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_wall,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
@@ -60461,6 +60519,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/asphalt,
 /area/desert_dam/exterior/valley/valley_hydro)
+"eYj" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/asphalt,
+/area/desert_dam/exterior/valley/valley_cargo)
 "eYn" = (
 /obj/structure/surface/table/woodentable/fancy,
 /obj/structure/machinery/computer/objective{
@@ -60580,6 +60642,13 @@
 "fmP" = (
 /turf/open/gm/empty,
 /area/shuttle/trijent_shuttle/lz1)
+"fof" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/desert/dirt{
+	dir = 8;
+	icon_state = "desert_transition_edge1"
+	},
+/area/desert_dam/exterior/valley/valley_northwest)
 "foq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -60632,6 +60701,11 @@
 	icon_state = "wood"
 	},
 /area/desert_dam/building/dorms/hallway_westwing)
+"fvo" = (
+/obj/effect/decal/sand_overlay/sand1/corner1,
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/asphalt/cement_sunbleached,
+/area/desert_dam/exterior/valley/valley_telecoms)
 "fxs" = (
 /obj/structure/desertdam/decals/road_edge{
 	icon_state = "road_edge_decal6"
@@ -60644,6 +60718,15 @@
 	icon_state = "desert_transition_edge1"
 	},
 /area/desert_dam/exterior/valley/south_valley_dam)
+"fyK" = (
+/obj/effect/decal/sand_overlay/sand1{
+	dir = 8
+	},
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/asphalt{
+	icon_state = "tile"
+	},
+/area/desert_dam/exterior/valley/valley_northwest)
 "fyO" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/prison{
@@ -60651,6 +60734,13 @@
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/garage)
+"fyY" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/desert/dirt{
+	dir = 9;
+	icon_state = "desert_transition_edge1"
+	},
+/area/desert_dam/exterior/valley/valley_northwest)
 "fBF" = (
 /obj/structure/desertdam/decals/road_edge{
 	icon_state = "road_edge_decal7"
@@ -60844,6 +60934,12 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/garage)
+"gkA" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/asphalt{
+	icon_state = "tile"
+	},
+/area/desert_dam/exterior/valley/valley_telecoms)
 "gls" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
@@ -60943,6 +61039,15 @@
 /obj/item/storage/fancy/vials/random,
 /turf/open/floor/prison,
 /area/desert_dam/building/hydroponics/hydroponics)
+"gsh" = (
+/obj/effect/decal/sand_overlay/sand1{
+	dir = 5
+	},
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/asphalt{
+	icon_state = "tile"
+	},
+/area/desert_dam/exterior/valley/valley_telecoms)
 "gsr" = (
 /obj/structure/desertdam/decals/road_edge{
 	icon_state = "road_edge_decal11"
@@ -60959,6 +61064,15 @@
 	icon_state = "dirt2"
 	},
 /area/desert_dam/interior/caves/central_caves)
+"gwE" = (
+/obj/effect/decal/sand_overlay/sand1/corner1{
+	dir = 4
+	},
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached18"
+	},
+/area/desert_dam/exterior/valley/valley_northwest)
 "gxo" = (
 /obj/structure/surface/table,
 /obj/item/clothing/glasses/welding{
@@ -60996,6 +61110,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/sandstone/runed,
 /area/desert_dam/interior/caves/temple)
+"gDh" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "N"
+	},
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/asphalt,
+/area/desert_dam/exterior/valley/valley_northwest)
 "gEj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -61009,6 +61130,11 @@
 	icon_state = "cement_sunbleached18"
 	},
 /area/desert_dam/exterior/valley/south_valley_dam)
+"gGz" = (
+/obj/structure/flora/grass/desert/heavygrass_4,
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/desert/dirt,
+/area/desert_dam/exterior/valley/valley_northwest)
 "gGC" = (
 /turf/closed/wall/mineral/sandstone/runed/decor,
 /area/desert_dam/interior/caves/temple)
@@ -61100,6 +61226,14 @@
 	},
 /turf/open/floor/plating,
 /area/desert_dam/exterior/telecomm/lz2_containers)
+"gRE" = (
+/obj/structure/desertdam/decals/road_stop{
+	dir = 8;
+	icon_state = "stop_decal5"
+	},
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/asphalt,
+/area/desert_dam/exterior/valley/valley_northwest)
 "gTD" = (
 /obj/item/tool/wrench,
 /turf/open/asphalt/cement,
@@ -61215,6 +61349,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/asphalt,
 /area/desert_dam/exterior/valley/valley_hydro)
+"hkN" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/desert/dirt,
+/area/desert_dam/exterior/valley/valley_telecoms)
 "hmA" = (
 /obj/structure/surface/table/almayer,
 /obj/item/paper_bin,
@@ -61238,6 +61376,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/sandstone/runed,
 /area/desert_dam/interior/caves/temple)
+"hoG" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "E"
+	},
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/asphalt,
+/area/desert_dam/exterior/landing_pad_one)
 "hpw" = (
 /turf/open/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached3"
@@ -61338,6 +61483,15 @@
 	},
 /turf/open/desert/dirt,
 /area/desert_dam/exterior/valley/valley_labs)
+"hES" = (
+/obj/effect/decal/sand_overlay/sand1/corner1{
+	dir = 4
+	},
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached1"
+	},
+/area/desert_dam/exterior/valley/valley_telecoms)
 "hEU" = (
 /obj/effect/blocker/toxic_water/Group_1,
 /obj/structure/barricade/wooden{
@@ -61620,6 +61774,13 @@
 	icon_state = "rock3"
 	},
 /area/desert_dam/interior/caves/temple)
+"iwc" = (
+/obj/structure/desertdam/decals/road_edge{
+	icon_state = "road_edge_decal8"
+	},
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/asphalt,
+/area/desert_dam/exterior/valley/valley_cargo)
 "iwh" = (
 /turf/open/desert/dirt{
 	dir = 4;
@@ -61663,6 +61824,13 @@
 	icon_state = "desert_transition_edge1"
 	},
 /area/desert_dam/exterior/valley/valley_wilderness)
+"iCX" = (
+/obj/structure/desertdam/decals/road_edge{
+	icon_state = "road_edge_decal3"
+	},
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/asphalt,
+/area/desert_dam/exterior/valley/valley_northwest)
 "iIB" = (
 /obj/structure/surface/table/reinforced,
 /obj/effect/landmark/objective_landmark/far,
@@ -61686,6 +61854,11 @@
 	icon_state = "whiteyellow"
 	},
 /area/desert_dam/interior/dam_interior/garage)
+"iNh" = (
+/obj/structure/flora/grass/desert/heavygrass_9,
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/desert/dirt,
+/area/desert_dam/exterior/valley/valley_northwest)
 "iNF" = (
 /turf/open/desert/desert_shore/shore_edge1,
 /area/desert_dam/interior/caves/temple)
@@ -61744,6 +61917,12 @@
 	dir = 10
 	},
 /area/desert_dam/interior/dam_interior/hanger)
+"iYi" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached3"
+	},
+/area/desert_dam/exterior/valley/valley_telecoms)
 "iYy" = (
 /obj/structure/surface/table,
 /obj/item/device/lightreplacer,
@@ -61946,6 +62125,12 @@
 	icon_state = "cement_sunbleached12"
 	},
 /area/desert_dam/exterior/valley/valley_hydro)
+"jQd" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached3"
+	},
+/area/desert_dam/exterior/valley/valley_northwest)
 "jSS" = (
 /obj/structure/desertdam/decals/road_edge{
 	icon_state = "road_edge_decal2"
@@ -62056,6 +62241,13 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/building/cafeteria/loading)
+"koR" = (
+/obj/structure/platform_decoration{
+	dir = 8
+	},
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/desert/dirt,
+/area/desert_dam/exterior/valley/valley_telecoms)
 "kry" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N"
@@ -62294,6 +62486,17 @@
 	icon_state = "whiteyellow"
 	},
 /area/desert_dam/interior/dam_interior/break_room)
+"llS" = (
+/obj/structure/machinery/conveyor{
+	dir = 8;
+	id = "cargo_container"
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
+	},
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/plating,
+/area/desert_dam/exterior/valley/valley_cargo)
 "lmq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/vomit,
@@ -62302,6 +62505,13 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/smes_main)
+"lnr" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/desert/dirt{
+	dir = 10;
+	icon_state = "desert_transition_edge1"
+	},
+/area/desert_dam/exterior/valley/valley_northwest)
 "lnG" = (
 /obj/effect/decal/sand_overlay/sand1/corner1,
 /turf/open/asphalt{
@@ -62389,10 +62599,28 @@
 	icon_state = "freezerfloor"
 	},
 /area/desert_dam/building/water_treatment_one/breakroom)
+"lAd" = (
+/obj/structure/largecrate/random/secure,
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/desert/dirt,
+/area/desert_dam/exterior/valley/valley_northwest)
 "lDT" = (
 /obj/structure/flora/grass/desert/lightgrass_3,
 /turf/open/desert/dirt,
 /area/desert_dam/exterior/valley/bar_valley_dam)
+"lEf" = (
+/obj/effect/decal/sand_overlay/sand1{
+	dir = 1
+	},
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/asphalt{
+	icon_state = "tile"
+	},
+/area/desert_dam/exterior/valley/valley_telecoms)
+"lEG" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/closed/wall/r_wall/bunker,
+/area/desert_dam/building/substation/west)
 "lFc" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E"
@@ -62438,6 +62666,13 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/building/medical/north_wing_hallway)
+"lLd" = (
+/obj/structure/desertdam/decals/road_edge{
+	icon_state = "road_edge_decal2"
+	},
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/asphalt,
+/area/desert_dam/exterior/valley/valley_cargo)
 "lLI" = (
 /obj/structure/filingcabinet,
 /obj/effect/landmark/objective_landmark/close,
@@ -62491,12 +62726,26 @@
 	icon_state = "carpet15-15"
 	},
 /area/desert_dam/building/administration/office)
+"lUt" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "N"
+	},
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/asphalt,
+/area/desert_dam/exterior/landing_pad_one)
 "lUU" = (
 /obj/effect/landmark/monkey_spawn,
 /turf/open/desert/dirt{
 	icon_state = "desert_transition_edge1"
 	},
 /area/desert_dam/exterior/valley/south_valley_dam)
+"lVH" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
+	},
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/asphalt,
+/area/desert_dam/exterior/valley/valley_northwest)
 "lVW" = (
 /obj/effect/decal/sand_overlay/sand1{
 	dir = 4
@@ -62696,6 +62945,10 @@
 	},
 /turf/open/gm/river/desert/shallow,
 /area/desert_dam/exterior/river/riverside_south)
+"mBX" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/asphalt,
+/area/desert_dam/exterior/landing_pad_one)
 "mDz" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/asphalt/cement_sunbleached{
@@ -62831,6 +63084,12 @@
 	icon_state = "cement_sunbleached3"
 	},
 /area/desert_dam/exterior/valley/valley_crashsite)
+"mZL" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/desert/dirt{
+	icon_state = "rock1"
+	},
+/area/desert_dam/exterior/valley/valley_northwest)
 "naF" = (
 /obj/effect/landmark/objective_landmark/close,
 /turf/open/floor/plating,
@@ -62916,6 +63175,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/asphalt,
 /area/desert_dam/exterior/valley/valley_telecoms)
+"nmS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/asphalt,
+/area/desert_dam/exterior/valley/valley_cargo)
 "nnl" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/effect/landmark/objective_landmark/science,
@@ -62982,6 +63246,11 @@
 /obj/structure/closet/coffin/predator,
 /turf/open/floor/sandstone/runed,
 /area/desert_dam/interior/caves/temple)
+"nFz" = (
+/obj/structure/fence,
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/desert/dirt,
+/area/desert_dam/exterior/valley/valley_cargo)
 "nFW" = (
 /obj/structure/surface/table,
 /obj/effect/landmark/objective_landmark/medium,
@@ -63053,6 +63322,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/asphalt,
 /area/desert_dam/exterior/valley/valley_medical)
+"nWe" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/asphalt,
+/area/desert_dam/exterior/valley/valley_northwest)
 "nXu" = (
 /obj/structure/desertdam/decals/road_edge{
 	icon_state = "road_edge_decal2"
@@ -63153,12 +63426,25 @@
 	icon_state = "cement_sunbleached13"
 	},
 /area/desert_dam/exterior/valley/valley_labs)
+"opN" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached12"
+	},
+/area/desert_dam/exterior/valley/valley_northwest)
 "opZ" = (
 /obj/effect/decal/sand_overlay/sand1,
 /turf/open/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached12"
 	},
 /area/desert_dam/exterior/valley/bar_valley_dam)
+"oqb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached9"
+	},
+/area/desert_dam/exterior/valley/valley_northwest)
 "oqy" = (
 /obj/structure/desertdam/decals/road_edge{
 	icon_state = "road_edge_decal2"
@@ -63325,6 +63611,12 @@
 	icon_state = "wood"
 	},
 /area/desert_dam/building/dorms/hallway_northwing)
+"oVP" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached14"
+	},
+/area/desert_dam/exterior/valley/valley_northwest)
 "oXx" = (
 /obj/structure/machinery/colony_floodlight,
 /turf/open/asphalt{
@@ -63404,6 +63696,13 @@
 /obj/structure/flora/grass/desert/lightgrass_1,
 /turf/open/desert/dirt,
 /area/desert_dam/exterior/telecomm/lz1_xenoflora)
+"pmG" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/desert/dirt{
+	dir = 9;
+	icon_state = "desert_transition_edge1"
+	},
+/area/desert_dam/exterior/valley/valley_telecoms)
 "poi" = (
 /obj/structure/desertdam/decals/road_edge,
 /obj/effect/decal/cleanable/dirt,
@@ -63430,6 +63729,15 @@
 	icon_state = "whitegreen"
 	},
 /area/desert_dam/building/medical/virology_isolation)
+"pua" = (
+/obj/effect/decal/sand_overlay/sand1{
+	dir = 1
+	},
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached18"
+	},
+/area/desert_dam/exterior/valley/valley_northwest)
 "puM" = (
 /obj/structure/machinery/light{
 	dir = 1
@@ -63637,6 +63945,17 @@
 	icon_state = "cement_sunbleached14"
 	},
 /area/desert_dam/exterior/valley/valley_crashsite)
+"pYP" = (
+/obj/structure/desertdam/decals/road_edge{
+	icon_state = "road_edge_decal4"
+	},
+/obj/structure/desertdam/decals/road_stop{
+	dir = 8;
+	icon_state = "stop_decal5"
+	},
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/asphalt,
+/area/desert_dam/exterior/valley/valley_northwest)
 "qbC" = (
 /obj/structure/surface/table/woodentable,
 /turf/open/floor/wood,
@@ -63652,6 +63971,19 @@
 /obj/structure/flora/bush/desert,
 /turf/open/desert/dirt,
 /area/desert_dam/exterior/valley/valley_hydro)
+"qgO" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached15"
+	},
+/area/desert_dam/exterior/valley/valley_telecoms)
+"qij" = (
+/obj/effect/decal/sand_overlay/sand1/corner1,
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached18"
+	},
+/area/desert_dam/exterior/valley/valley_northwest)
 "qjg" = (
 /turf/open/desert/rock/deep/transition{
 	dir = 6
@@ -63735,6 +64067,15 @@
 /obj/structure/machinery/colony_floodlight,
 /turf/open/desert/dirt,
 /area/desert_dam/exterior/valley/valley_labs)
+"qxZ" = (
+/obj/effect/decal/sand_overlay/sand1{
+	dir = 8
+	},
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached1"
+	},
+/area/desert_dam/exterior/valley/valley_telecoms)
 "qyu" = (
 /obj/structure/prop/dam/boulder/boulder1,
 /turf/open/desert/dirt{
@@ -63864,6 +64205,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/asphalt,
 /area/desert_dam/exterior/valley/valley_cargo)
+"qNm" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached15"
+	},
+/area/desert_dam/exterior/valley/valley_northwest)
 "qPl" = (
 /obj/structure/machinery/door/poddoor/almayer{
 	dir = 2;
@@ -63881,6 +64228,22 @@
 	icon_state = "cement_sunbleached18"
 	},
 /area/desert_dam/exterior/valley/south_valley_dam)
+"qTm" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/desert/dirt{
+	dir = 1;
+	icon_state = "desert_transition_corner1"
+	},
+/area/desert_dam/exterior/valley/valley_northwest)
+"qTS" = (
+/obj/effect/decal/sand_overlay/sand1{
+	dir = 1
+	},
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached4"
+	},
+/area/desert_dam/exterior/valley/valley_cargo)
 "qVN" = (
 /obj/structure/desertdam/decals/road_edge{
 	icon_state = "road_edge_decal7"
@@ -64024,6 +64387,13 @@
 	},
 /turf/open/desert/rock/deep,
 /area/desert_dam/interior/caves/temple)
+"rvT" = (
+/obj/structure/platform{
+	dir = 1
+	},
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/desert/dirt,
+/area/desert_dam/exterior/valley/valley_telecoms)
 "rxS" = (
 /obj/docking_port/stationary/trijent_elevator/lz1,
 /turf/open/gm/empty,
@@ -64131,6 +64501,15 @@
 /obj/structure/desertdam/decals/road_edge,
 /turf/open/asphalt,
 /area/desert_dam/exterior/valley/bar_valley_dam)
+"rMP" = (
+/obj/effect/decal/sand_overlay/sand1{
+	dir = 1
+	},
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/asphalt{
+	icon_state = "tile"
+	},
+/area/desert_dam/exterior/valley/valley_northwest)
 "rNg" = (
 /obj/structure/machinery/door/poddoor/almayer/locked{
 	dir = 4;
@@ -64365,6 +64744,13 @@
 	icon_state = "bright_clean2"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_west_hallway)
+"sup" = (
+/obj/structure/desertdam/decals/road_edge{
+	icon_state = "road_edge_decal4"
+	},
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/asphalt,
+/area/desert_dam/exterior/valley/valley_northwest)
 "svy" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
@@ -64377,6 +64763,16 @@
 	icon_state = "bright_clean2"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_workshop)
+"swI" = (
+/obj/structure/desertdam/decals/road_edge{
+	icon_state = "road_edge_decal2"
+	},
+/obj/effect/decal/sand_overlay/sand1{
+	dir = 8
+	},
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/asphalt,
+/area/desert_dam/exterior/valley/valley_cargo)
 "sye" = (
 /obj/effect/decal/cleanable/blood/oil/streak,
 /turf/open/asphalt/cement,
@@ -64604,6 +65000,13 @@
 /obj/structure/flora/grass/desert/heavygrass_4,
 /turf/open/desert/dirt,
 /area/desert_dam/exterior/telecomm/lz2_storage)
+"tiq" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/desert/dirt{
+	dir = 8;
+	icon_state = "desert_transition_edge1"
+	},
+/area/desert_dam/exterior/valley/valley_telecoms)
 "tjX" = (
 /obj/structure/flora/grass/desert/lightgrass_3,
 /turf/open/desert/dirt,
@@ -64670,12 +65073,30 @@
 	icon_state = "bright_clean2"
 	},
 /area/desert_dam/building/security/staffroom)
+"txI" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached12"
+	},
+/area/desert_dam/exterior/valley/valley_telecoms)
 "tyc" = (
 /obj/structure/desertdam/decals/road_edge{
 	icon_state = "road_edge_decal4"
 	},
 /turf/open/asphalt,
 /area/desert_dam/exterior/valley/bar_valley_dam)
+"tyD" = (
+/obj/structure/flora/grass/desert/heavygrass_3,
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/desert/dirt,
+/area/desert_dam/exterior/valley/valley_northwest)
+"tzc" = (
+/obj/effect/decal/sand_overlay/sand1,
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached12"
+	},
+/area/desert_dam/exterior/valley/valley_cargo)
 "tAs" = (
 /turf/open/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached18"
@@ -64711,6 +65132,13 @@
 	icon_state = "wood"
 	},
 /area/desert_dam/building/dorms/hallway_westwing)
+"tDC" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/desert/dirt{
+	dir = 5;
+	icon_state = "desert_transition_edge1"
+	},
+/area/desert_dam/exterior/valley/valley_northwest)
 "tEn" = (
 /obj/structure/machinery/door/poddoor/almayer/locked{
 	dir = 4;
@@ -64749,6 +65177,12 @@
 /obj/effect/decal/remains/human,
 /turf/open/desert/rock,
 /area/desert_dam/interior/caves/temple)
+"tIx" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/asphalt{
+	icon_state = "tile"
+	},
+/area/desert_dam/exterior/valley/valley_cargo)
 "tKQ" = (
 /turf/open/desert/dirt{
 	icon_state = "rock1"
@@ -64795,6 +65229,13 @@
 	icon_state = "desert_transition_edge1"
 	},
 /area/desert_dam/exterior/telecomm/lz1_xenoflora)
+"tPD" = (
+/obj/effect/decal/sand_overlay/sand1,
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached12"
+	},
+/area/desert_dam/exterior/valley/valley_telecoms)
 "tPP" = (
 /obj/structure/platform,
 /turf/open/desert/dirt,
@@ -64979,11 +65420,25 @@
 	icon_state = "desert_transition_edge1"
 	},
 /area/desert_dam/exterior/valley/valley_hydro)
+"uAI" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "W"
+	},
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/asphalt,
+/area/desert_dam/exterior/landing_pad_one)
 "uBP" = (
 /obj/structure/surface/rack,
 /obj/item/tool/pickaxe,
 /turf/open/desert/rock,
 /area/desert_dam/interior/caves/central_caves)
+"uDf" = (
+/obj/effect/decal/sand_overlay/sand1,
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/asphalt{
+	icon_state = "tile"
+	},
+/area/desert_dam/exterior/valley/valley_northwest)
 "uFX" = (
 /turf/open/asphalt/cement_sunbleached,
 /area/desert_dam/exterior/valley/valley_hydro)
@@ -65077,6 +65532,16 @@
 /obj/structure/flora/grass/tallgrass/desert,
 /turf/open/desert/dirt,
 /area/desert_dam/exterior/valley/valley_cargo)
+"uTs" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached18"
+	},
+/area/desert_dam/exterior/valley/valley_northwest)
+"uUI" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/desert/dirt,
+/area/desert_dam/exterior/valley/valley_cargo)
 "uVm" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
 /turf/open/asphalt/cement_sunbleached{
@@ -65153,6 +65618,15 @@
 /obj/structure/fence,
 /turf/open/desert/dirt,
 /area/desert_dam/exterior/valley/valley_hydro)
+"vmN" = (
+/obj/effect/decal/sand_overlay/sand1{
+	dir = 4
+	},
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached13"
+	},
+/area/desert_dam/exterior/landing_pad_one)
 "vnf" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
@@ -65259,6 +65733,10 @@
 	},
 /turf/open/asphalt,
 /area/desert_dam/exterior/valley/bar_valley_dam)
+"vAo" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/desert/dirt,
+/area/desert_dam/exterior/valley/valley_northwest)
 "vAN" = (
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_wall,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
@@ -65278,6 +65756,13 @@
 	icon_state = "cement_sunbleached4"
 	},
 /area/desert_dam/exterior/valley/valley_labs)
+"vCY" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/desert/dirt{
+	dir = 8;
+	icon_state = "desert_transition_corner1"
+	},
+/area/desert_dam/exterior/valley/valley_northwest)
 "vDJ" = (
 /obj/structure/desertdam/decals/road_edge{
 	icon_state = "road_edge_decal4"
@@ -65434,6 +65919,12 @@
 	icon_state = "desert_transition_corner1"
 	},
 /area/desert_dam/exterior/valley/bar_valley_dam)
+"wgF" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached18"
+	},
+/area/desert_dam/exterior/landing_pad_one)
 "wiF" = (
 /obj/structure/machinery/cm_vending/sorted/tech/tool_storage,
 /turf/open/floor/prison{
@@ -65459,6 +65950,15 @@
 	icon_state = "floor_marked"
 	},
 /area/desert_dam/building/cafeteria/loading)
+"wlt" = (
+/obj/effect/decal/sand_overlay/sand1{
+	dir = 8
+	},
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/asphalt{
+	icon_state = "tile"
+	},
+/area/desert_dam/exterior/valley/valley_telecoms)
 "wnE" = (
 /obj/structure/closet/crate/hydroponics/prespawned,
 /obj/effect/landmark/objective_landmark/close,
@@ -65471,6 +65971,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall/bunker,
 /area/desert_dam/interior/dam_interior/garage)
+"woD" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/desert/dirt{
+	icon_state = "desert_transition_corner1"
+	},
+/area/desert_dam/exterior/valley/valley_northwest)
 "wpW" = (
 /obj/structure/flora/grass/desert/lightgrass_6,
 /turf/open/desert/dirt,
@@ -65851,6 +66357,13 @@
 	icon_state = "desert_transition_edge1"
 	},
 /area/desert_dam/exterior/valley/valley_northwest)
+"xrL" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/desert/dirt{
+	dir = 4;
+	icon_state = "desert_transition_corner1"
+	},
+/area/desert_dam/exterior/valley/valley_northwest)
 "xss" = (
 /obj/structure/machinery/door/poddoor/almayer/locked{
 	dir = 4;
@@ -65906,6 +66419,12 @@
 	icon_state = "desert_transition_edge1"
 	},
 /area/desert_dam/exterior/telecomm/lz1_valley)
+"xyW" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached13"
+	},
+/area/desert_dam/exterior/valley/valley_northwest)
 "xzc" = (
 /obj/structure/surface/table,
 /turf/open/floor{
@@ -66056,6 +66575,13 @@
 	icon_state = "squareswood"
 	},
 /area/desert_dam/interior/caves/temple)
+"xXd" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
+	},
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/asphalt,
+/area/desert_dam/exterior/landing_pad_one)
 "xYb" = (
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_wall,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
@@ -66127,6 +66653,12 @@
 	icon_state = "bright_clean2"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_west_entrance)
+"ykS" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached2"
+	},
+/area/desert_dam/exterior/valley/valley_northwest)
 "ylf" = (
 /obj/structure/desertdam/decals/road_edge{
 	icon_state = "road_edge_decal6"
@@ -69847,8 +70379,8 @@ dTs
 dTs
 dTs
 aIP
-chv
-cgm
+koR
+lEG
 cgm
 chb
 ciC
@@ -70080,10 +70612,10 @@ cez
 hvG
 dTs
 dTs
-bPA
-kzQ
-ceA
-cgm
+lEf
+rvT
+hkN
+lEG
 cgm
 cgm
 cgm
@@ -70198,9 +70730,9 @@ aiY
 aiZ
 apu
 apt
-ahu
-air
-apt
+mZL
+qTm
+woD
 dTs
 dTs
 dTs
@@ -70317,8 +70849,8 @@ aUm
 emt
 kzQ
 ceA
-ceA
-ceA
+hkN
+hkN
 ceA
 ceA
 ceA
@@ -70432,10 +70964,10 @@ aiZ
 aiZ
 aiZ
 bge
-amP
-aiY
-apu
-amP
+cwa
+efw
+tDC
+cwa
 bht
 bht
 bht
@@ -70551,8 +71083,8 @@ cjO
 aIT
 aKb
 ceB
-ceB
-ceB
+eoJ
+eoJ
 ceB
 ceB
 ceB
@@ -70666,9 +71198,9 @@ aQe
 aQe
 aQe
 aQe
-aQe
-aQe
-aQe
+vmN
+vmN
+vmN
 bhe
 bhu
 bhN
@@ -70785,8 +71317,8 @@ cjO
 csu
 aSK
 aSK
-cdk
-bao
+fvo
+qxZ
 bao
 bao
 bao
@@ -70900,10 +71432,10 @@ aQU
 aQU
 aQU
 aQU
-aQU
-aQU
-aQU
-aQU
+uAI
+uAI
+uAI
+uAI
 bbV
 bhO
 bil
@@ -71019,7 +71551,7 @@ cjO
 cFd
 cgb
 aSK
-chG
+tPD
 chw
 ciF
 ciF
@@ -71134,10 +71666,10 @@ aQV
 aQV
 aQV
 aQV
-aQV
-aQV
-aQV
-aQV
+mBX
+mBX
+mBX
+mBX
 bdD
 bhP
 bhP
@@ -71253,7 +71785,7 @@ bRw
 bSV
 cgj
 cey
-chG
+tPD
 cfC
 cjO
 cjO
@@ -71368,10 +71900,10 @@ aQV
 aQV
 aQV
 aQW
-aQW
-aQV
-aQV
-aQV
+hoG
+mBX
+mBX
+mBX
 bdD
 bhP
 bhP
@@ -71487,7 +72019,7 @@ dTs
 bPA
 kzQ
 aSI
-chG
+tPD
 cfC
 cjO
 ccm
@@ -71602,10 +72134,10 @@ aQV
 aQV
 aQV
 aQV
-aQV
-aQV
-aQV
-aQV
+mBX
+mBX
+mBX
+mBX
 bdD
 bhP
 bhP
@@ -71721,7 +72253,7 @@ dTs
 bPA
 kzQ
 aSI
-chG
+tPD
 cfC
 cjO
 tAs
@@ -71836,10 +72368,10 @@ aQV
 aQV
 aQV
 aQU
-aQU
-aQV
-aQV
-aQV
+uAI
+mBX
+mBX
+mBX
 bdD
 bhQ
 bhP
@@ -71955,7 +72487,7 @@ dTs
 emt
 kzQ
 aSI
-chG
+tPD
 cfC
 cjO
 tAs
@@ -72070,10 +72602,10 @@ aQV
 aQV
 aQV
 aQV
-aQV
-aQV
-aQV
-aQV
+mBX
+mBX
+mBX
+mBX
 bdD
 bhP
 bhP
@@ -72189,7 +72721,7 @@ dTs
 cjO
 kzQ
 aSI
-chG
+tPD
 cfC
 cjO
 tAs
@@ -72304,10 +72836,10 @@ aQV
 aQV
 aQV
 aQV
-aQV
-aQV
-aQV
-aQV
+mBX
+mBX
+mBX
+mBX
 bdD
 bhR
 mKW
@@ -72425,7 +72957,7 @@ cgk
 cew
 cfo
 chC
-cjO
+gkA
 tAs
 ckr
 cmj
@@ -72538,10 +73070,10 @@ aQg
 aQV
 aQV
 aQV
-aQV
-aQV
-aQV
-aQV
+mBX
+mBX
+mBX
+mBX
 bdD
 bhP
 bhP
@@ -72658,8 +73190,8 @@ cjO
 cjO
 cex
 cfp
-cjO
-cjO
+gkA
+gkA
 tAs
 ckr
 cmj
@@ -72772,10 +73304,10 @@ aQg
 aQV
 aSY
 aQV
-aQg
-aQV
-aQV
-aQV
+lUt
+mBX
+mBX
+mBX
 bdD
 bhP
 bhP
@@ -72892,9 +73424,9 @@ dTs
 bRw
 cey
 aSK
-beO
-beO
-aSL
+iYi
+iYi
+txI
 ckr
 cmj
 cmj
@@ -73006,10 +73538,10 @@ aQg
 aQV
 aSY
 aQV
-aQg
-aQV
-aQV
-aQV
+lUt
+mBX
+mBX
+mBX
 bdD
 bhP
 bhP
@@ -73127,8 +73659,8 @@ cwl
 aSI
 cdk
 bao
-bnB
-aTU
+hES
+qgO
 ckt
 rTP
 cmk
@@ -73240,9 +73772,9 @@ aQg
 aQV
 aQV
 aQV
-aQV
-aQV
-aSY
+mBX
+mBX
+xXd
 bhf
 bhu
 bhS
@@ -73361,8 +73893,8 @@ cxk
 aSI
 chG
 ceA
-bPB
-bRw
+gsh
+wlt
 yeL
 yeL
 yeL
@@ -73474,10 +74006,10 @@ aQg
 aQV
 aQV
 aQV
-aQV
-aQV
-aSY
-aSa
+mBX
+mBX
+xXd
+wgF
 bKM
 bhT
 bhT
@@ -73595,8 +74127,8 @@ cxk
 aSI
 chG
 aUh
-baz
-ceD
+pmG
+tiq
 dTs
 dTs
 dTs
@@ -73708,10 +74240,10 @@ aQg
 aQV
 aQV
 aQV
-aQV
-aQV
-aSY
-aSa
+mBX
+mBX
+xXd
+wgF
 bhy
 bhz
 bhz
@@ -73858,24 +74390,24 @@ cuJ
 cuJ
 cuJ
 cuJ
-cuJ
+swI
 cnA
-cMJ
-cMJ
-cMJ
-cMJ
-cMJ
-cMJ
-cUk
-crx
-dvo
+lLd
+lLd
+lLd
+lLd
+lLd
+lLd
+iwc
+eYj
+nmS
 cQc
-cMJ
-cMJ
-cMJ
-cMJ
-cMJ
-cMJ
+lLd
+lLd
+lLd
+lLd
+lLd
+lLd
 cMJ
 cMJ
 cMJ
@@ -73942,10 +74474,10 @@ aQg
 aQV
 aSY
 aQV
-aQg
-aQV
-aSY
-aSa
+lUt
+mBX
+xXd
+wgF
 bhz
 bhz
 bhz
@@ -74176,10 +74708,10 @@ aQg
 aQV
 aSY
 aQV
-aQg
-aQV
-aSY
-aSa
+lUt
+mBX
+xXd
+wgF
 bKM
 bhT
 bhT
@@ -74410,9 +74942,9 @@ aQg
 aQV
 aQV
 aQV
-aQV
-aQV
-aSY
+mBX
+mBX
+xXd
 bhg
 bhu
 bhO
@@ -74644,10 +75176,10 @@ aQg
 aQV
 aQV
 aQV
-aQV
-aQV
-aQV
-aQV
+mBX
+mBX
+mBX
+mBX
 alX
 bhP
 bhP
@@ -74783,10 +75315,10 @@ aee
 aee
 aee
 aee
-doE
-cJx
-cfd
-doE
+uUI
+qTS
+tzc
+uUI
 aee
 aee
 aee
@@ -74812,13 +75344,13 @@ cVH
 aMw
 aMI
 dbc
-aMJ
-cQm
-cQm
+llS
+tIx
+tIx
 aNm
 aNA
-cKr
-doE
+nFz
+uUI
 doE
 doE
 dTs
@@ -74878,10 +75410,10 @@ aQg
 aQV
 aQV
 aQV
-aQV
-aQV
-aQV
-aQV
+mBX
+mBX
+mBX
+mBX
 ams
 bhP
 bhP
@@ -75013,17 +75545,17 @@ cwB
 dTs
 dTs
 aee
-doE
-doE
+uUI
+uUI
 aee
-doE
-doE
-cJx
-cfd
-doE
-doE
+uUI
+uUI
+qTS
+tzc
+uUI
+uUI
 aee
-doE
+uUI
 dTs
 aee
 dTs
@@ -75052,7 +75584,7 @@ bvA
 ddJ
 bvA
 bvA
-doE
+uUI
 doE
 dTs
 dTs
@@ -75112,10 +75644,10 @@ aQg
 aQV
 aSY
 aQV
-aQg
-aQV
-aQV
-aQV
+lUt
+mBX
+mBX
+mBX
 cck
 bhP
 mKW
@@ -75346,10 +75878,10 @@ aQg
 aQV
 aSY
 aQV
-aQg
-aQV
-aQV
-aQV
+lUt
+mBX
+mBX
+mBX
 cck
 bhQ
 bhP
@@ -75580,10 +76112,10 @@ aQg
 aQV
 aQV
 aQV
-aQV
-aQV
-aQV
-aQV
+mBX
+mBX
+mBX
+mBX
 cck
 bhT
 bhP
@@ -75814,9 +76346,9 @@ aQg
 aQV
 aQV
 aQV
-aQV
-aQV
-aQV
+mBX
+mBX
+mBX
 akU
 cck
 bhR
@@ -76048,10 +76580,10 @@ aQg
 aQV
 aQV
 aQV
-aQV
-aQV
-aQV
-aQV
+mBX
+mBX
+mBX
+mBX
 cck
 bhP
 bhP
@@ -76282,10 +76814,10 @@ aQg
 aQV
 aSY
 aQV
-aQg
-aQV
-aQV
-aQV
+lUt
+mBX
+mBX
+mBX
 cck
 bhP
 bhP
@@ -76516,10 +77048,10 @@ aQg
 aQV
 aSY
 aQV
-aQg
-aQV
-aQV
-aQV
+lUt
+mBX
+mBX
+mBX
 cck
 bhP
 bhP
@@ -76750,9 +77282,9 @@ aQg
 aQV
 aQV
 aQV
-aQV
-aQV
-aSY
+mBX
+mBX
+xXd
 bhf
 buI
 bhS
@@ -76953,41 +77485,41 @@ aNp
 aNp
 aNp
 aNp
-alo
-alo
-alo
-alo
-alo
-alo
-alo
-alo
-alo
-aNp
-aNp
-alo
-alo
-aNp
-aNp
-aNp
-aNp
-aNp
-apO
-apA
+jQd
+jQd
+jQd
+jQd
+jQd
+jQd
+jQd
+jQd
+jQd
+xyW
+xyW
+jQd
+jQd
+xyW
+xyW
+xyW
+xyW
+xyW
+oVP
+pYP
 dez
-aNL
+gRE
 baW
-aky
-aNp
-aNp
-apO
+ykS
+xyW
+xyW
+oVP
 bfn
-aQW
-aQW
-aQW
-aQW
-aQW
+hoG
+hoG
+hoG
+hoG
+hoG
 bgN
-aSa
+wgF
 bhu
 bhN
 bin
@@ -77196,23 +77728,23 @@ adq
 aeg
 aVk
 aVH
-aoe
+fyK
 afy
 apa
-aoG
+opN
 anh
-aoe
-aoe
-aoe
-aoe
-bco
+fyK
+fyK
+fyK
+fyK
+gwE
 bcC
-aNL
-aNL
+gRE
+gRE
 baW
-aoE
+uTs
 anh
-aoe
+fyK
 aUH
 bfo
 bfo
@@ -77421,41 +77953,41 @@ rFz
 rFz
 bzU
 aOc
-bej
-bfp
-bej
-aiZ
-acW
-aiZ
-aiZ
-aiZ
+tyD
+iNh
+tyD
+vAo
+lAd
+vAo
+vAo
+vAo
 aeY
-aiZ
-ajS
-bvh
-avC
-aDe
-beD
-aiZ
-aiZ
-aiZ
-aIa
-apz
-aql
-ara
-asa
-aoE
-aDe
-aiZ
-aqy
-aja
-aiZ
-aqy
-ars
-aja
-aiZ
-aiZ
-aqy
+vAo
+rMP
+oqb
+qNm
+uDf
+gGz
+vAo
+vAo
+vAo
+pua
+sup
+lVH
+gDh
+iCX
+uTs
+uDf
+vAo
+fyY
+lnr
+vAo
+fyY
+fof
+lnr
+vAo
+vAo
+fyY
 dTs
 dTs
 dTs
@@ -77655,8 +78187,8 @@ rFz
 rFz
 aRc
 aau
-aja
-bej
+lnr
+tyD
 aVI
 aVI
 aVI
@@ -77672,23 +78204,23 @@ aWM
 aVI
 aVI
 aVI
-aiZ
+vAo
 agx
-apz
-aqg
-aqg
-asa
-bdV
+sup
+nWe
+nWe
+iCX
+qij
 bep
-aqy
-axY
-ait
-ars
+fyY
+vCY
+xrL
+fof
 dTs
 dTs
-ait
-ars
-ars
+xrL
+fof
+fof
 dTs
 dTs
 dTs
@@ -77889,8 +78421,8 @@ aPF
 aPF
 aRc
 aau
-ait
-aja
+xrL
+lnr
 aVI
 azf
 aYu
@@ -77921,7 +78453,7 @@ dTs
 dTs
 dTs
 dTs
-ahu
+mZL
 dTs
 dTs
 dTs
@@ -78123,8 +78655,8 @@ aRD
 aTg
 aTh
 aOc
-ahu
-ait
+mZL
+xrL
 aVI
 aNs
 aWl

--- a/maps/map_files/FOP_v3_Sciannex/Fiorina_SciAnnex.dmm
+++ b/maps/map_files/FOP_v3_Sciannex/Fiorina_SciAnnex.dmm
@@ -2770,6 +2770,23 @@
 	icon_state = "stan25"
 	},
 /area/fiorina/tumor/aux_engi)
+"bAo" = (
+/obj/structure/platform{
+	dir = 8
+	},
+/obj/structure/platform{
+	dir = 4
+	},
+/obj/structure/platform,
+/obj/structure/platform_decoration{
+	dir = 6
+	},
+/obj/structure/platform_decoration{
+	dir = 10
+	},
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/plating/prison,
+/area/fiorina/lz/near_lzI)
 "bAS" = (
 /obj/structure/machinery/light/double/blue,
 /turf/open/floor/prison{
@@ -7052,6 +7069,13 @@
 	icon_state = "bluefull"
 	},
 /area/fiorina/station/power_ring)
+"ehr" = (
+/obj/structure/monorail{
+	name = "launch track"
+	},
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/plating/prison,
+/area/fiorina/lz/near_lzI)
 "ehA" = (
 /obj/structure/bed{
 	icon_state = "abed"
@@ -12008,6 +12032,15 @@
 	icon_state = "yellow"
 	},
 /area/fiorina/station/lowsec)
+"hiy" = (
+/obj/structure/monorail{
+	name = "launch track"
+	},
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/prison{
+	icon_state = "floor_plate"
+	},
+/area/fiorina/lz/near_lzI)
 "hiG" = (
 /obj/item/storage/backpack/souto,
 /turf/open/floor/prison,
@@ -15992,6 +16025,10 @@
 	},
 /turf/open/floor/prison,
 /area/fiorina/station/central_ring)
+"jED" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/plating/prison,
+/area/fiorina/lz/near_lzI)
 "jEG" = (
 /obj/structure/prop/resin_prop,
 /turf/open/floor/prison{
@@ -38997,6 +39034,25 @@
 	icon_state = "bright_clean_marked"
 	},
 /area/fiorina/station/medbay)
+"xHx" = (
+/obj/structure/platform{
+	dir = 1
+	},
+/obj/structure/platform{
+	dir = 8
+	},
+/obj/structure/platform{
+	dir = 4
+	},
+/obj/structure/platform_decoration{
+	dir = 9
+	},
+/obj/structure/platform_decoration{
+	dir = 5
+	},
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/plating/prison,
+/area/fiorina/lz/near_lzI)
 "xHV" = (
 /turf/closed/wall/mineral/bone_resin,
 /area/fiorina/tumor/civres)
@@ -89004,7 +89060,7 @@ qrw
 kMM
 hze
 pNm
-kfA
+pNm
 kfA
 kfA
 aMz
@@ -90469,7 +90525,7 @@ wRP
 xeO
 hjW
 hjW
-xeO
+jED
 vzB
 xeO
 vzB
@@ -90680,8 +90736,8 @@ lIv
 xFP
 sov
 eXr
-eXr
-yls
+hiy
+ehr
 ssD
 yls
 ssD
@@ -92163,7 +92219,7 @@ hKI
 hKI
 lmM
 hKI
-hKI
+dkL
 qDD
 fkK
 iVb
@@ -92374,8 +92430,8 @@ lRT
 atl
 aZD
 lRT
-atl
-aZD
+xHx
+bAo
 lRT
 scM
 scM

--- a/maps/map_files/FOP_v3_Sciannex/Fiorina_SciAnnex.dmm
+++ b/maps/map_files/FOP_v3_Sciannex/Fiorina_SciAnnex.dmm
@@ -316,6 +316,7 @@
 /obj/structure/platform{
 	dir = 8
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating/prison,
 /area/fiorina/station/telecomm/lz1_tram)
 "aif" = (
@@ -711,6 +712,13 @@
 	},
 /turf/open/floor/plating/prison,
 /area/fiorina/station/telecomm/lz2_maint)
+"asF" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/prison{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
+/area/fiorina/lz/near_lzI)
 "atl" = (
 /obj/structure/platform{
 	dir = 1
@@ -2679,6 +2687,12 @@
 	},
 /turf/open/floor/prison,
 /area/fiorina/tumor/fiberbush)
+"bya" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/prison{
+	icon_state = "floor_plate"
+	},
+/area/fiorina/lz/near_lzI)
 "byb" = (
 /turf/closed/shuttle/ert{
 	icon_state = "stan27"
@@ -2988,6 +3002,7 @@
 	dir = 1;
 	icon_state = "p_stair_full"
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "darkyellow2"
@@ -3330,6 +3345,15 @@
 	icon_state = "darkbrown2"
 	},
 /area/fiorina/tumor/aux_engi)
+"bTd" = (
+/obj/structure/monorail{
+	name = "launch track"
+	},
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/prison{
+	icon_state = "floor_plate"
+	},
+/area/fiorina/station/telecomm/lz1_tram)
 "bTe" = (
 /turf/open/floor/prison{
 	dir = 9;
@@ -4755,6 +4779,13 @@
 	icon_state = "sterile_white"
 	},
 /area/fiorina/tumor/ice_lab)
+"cON" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "darkyellowfull2"
+	},
+/area/fiorina/station/telecomm/lz1_tram)
 "cPq" = (
 /obj/structure/machinery/light/double/blue{
 	dir = 4;
@@ -5487,6 +5518,10 @@
 	icon_state = "darkbrown2"
 	},
 /area/fiorina/station/park)
+"dkL" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/prison,
+/area/fiorina/lz/near_lzI)
 "dkP" = (
 /obj/structure/largecrate/random,
 /obj/structure/machinery/light/double/blue,
@@ -7854,6 +7889,7 @@
 /obj/structure/platform_decoration{
 	dir = 4
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	icon_state = "floor_plate"
 	},
@@ -8662,6 +8698,10 @@
 	dir = 9
 	},
 /area/fiorina/tumor/aux_engi)
+"fkK" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/closed/wall/r_wall/prison,
+/area/fiorina/station/telecomm/lz1_tram)
 "fkP" = (
 /obj/structure/platform{
 	dir = 1
@@ -9898,6 +9938,7 @@
 	dir = 1;
 	icon_state = "p_stair_full"
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 8;
 	icon_state = "darkyellow2"
@@ -11887,6 +11928,13 @@
 /obj/structure/largecrate/random/case/small,
 /turf/open/floor/plating/prison,
 /area/fiorina/station/central_ring)
+"hgK" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/prison{
+	dir = 5;
+	icon_state = "darkyellow2"
+	},
+/area/fiorina/station/telecomm/lz1_tram)
 "hgS" = (
 /turf/closed/shuttle/ert{
 	icon_state = "stan5"
@@ -12514,6 +12562,12 @@
 	icon_state = "floor_plate"
 	},
 /area/fiorina/station/civres_blue)
+"hze" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/prison{
+	icon_state = "floor_plate"
+	},
+/area/fiorina/station/power_ring)
 "hzq" = (
 /obj/item/storage/fancy/cigarettes/lucky_strikes,
 /obj/structure/surface/table/reinforced/prison,
@@ -12753,6 +12807,13 @@
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "darkyellowfull2"
+	},
+/area/fiorina/lz/near_lzI)
+"hHn" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "darkyellow2"
 	},
 /area/fiorina/lz/near_lzI)
 "hHq" = (
@@ -13666,6 +13727,7 @@
 	},
 /area/fiorina/station/research_cells)
 "inh" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 1;
 	icon_state = "darkyellow2"
@@ -13745,6 +13807,7 @@
 /obj/structure/platform{
 	dir = 1
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating/prison,
 /area/fiorina/station/power_ring)
 "iqV" = (
@@ -14708,6 +14771,7 @@
 /area/fiorina/lz/near_lzI)
 "iVb" = (
 /obj/structure/largecrate/random,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "darkyellowfull2"
@@ -17216,6 +17280,7 @@
 	dir = 8;
 	layer = 2.5
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating/prison,
 /area/fiorina/station/telecomm/lz1_tram)
 "kqr" = (
@@ -17986,6 +18051,12 @@
 "kMq" = (
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/fiorina/station/civres_blue)
+"kMM" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/prison{
+	icon_state = "blue"
+	},
+/area/fiorina/station/power_ring)
 "kMU" = (
 /obj/effect/spawner/gibspawner/robot,
 /turf/open/floor/plating/plating_catwalk/prison,
@@ -20785,6 +20856,13 @@
 	icon_state = "red"
 	},
 /area/fiorina/station/power_ring)
+"myM" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/prison{
+	dir = 9;
+	icon_state = "darkyellow2"
+	},
+/area/fiorina/station/telecomm/lz1_tram)
 "myO" = (
 /obj/structure/closet/firecloset/full,
 /obj/structure/machinery/light/double/blue{
@@ -22002,6 +22080,7 @@
 /obj/structure/platform{
 	dir = 4
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison,
 /area/fiorina/station/telecomm/lz1_tram)
 "nhi" = (
@@ -22218,6 +22297,7 @@
 /obj/structure/platform_decoration{
 	dir = 1
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	icon_state = "floor_plate"
 	},
@@ -25988,6 +26068,7 @@
 	dir = 4;
 	icon_state = "p_stair_full"
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating/prison,
 /area/fiorina/station/power_ring)
 "pIX" = (
@@ -26101,6 +26182,12 @@
 /obj/structure/bookcase,
 /turf/open/floor/carpet,
 /area/fiorina/station/civres_blue)
+"pNm" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/prison{
+	icon_state = "bluefull"
+	},
+/area/fiorina/station/power_ring)
 "pNI" = (
 /obj/item/stack/tile/plasteel{
 	pixel_x = 3;
@@ -27015,6 +27102,13 @@
 	icon_state = "whitepurplecorner"
 	},
 /area/fiorina/station/research_cells)
+"qrw" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/prison{
+	dir = 1;
+	icon_state = "blue"
+	},
+/area/fiorina/station/power_ring)
 "qrz" = (
 /obj/item/explosive/plastic,
 /turf/open/floor/plating/prison,
@@ -27438,6 +27532,7 @@
 	pixel_y = -3
 	},
 /obj/structure/largecrate/random/case,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison,
 /area/fiorina/lz/near_lzI)
 "qDG" = (
@@ -34768,6 +34863,7 @@
 /obj/structure/platform{
 	dir = 8
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison,
 /area/fiorina/station/telecomm/lz1_tram)
 "vgP" = (
@@ -36619,6 +36715,16 @@
 	icon_state = "kitchen"
 	},
 /area/fiorina/station/civres_blue)
+"wpc" = (
+/obj/structure/machinery/light/double/blue{
+	dir = 1;
+	pixel_y = 21
+	},
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/prison{
+	icon_state = "floor_plate"
+	},
+/area/fiorina/station/power_ring)
 "wpf" = (
 /obj/structure/bed/chair/comfy,
 /turf/open/floor/prison{
@@ -38145,6 +38251,7 @@
 	dir = 4;
 	icon_state = "p_stair_full"
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating/prison,
 /area/fiorina/station/power_ring)
 "xnq" = (
@@ -88892,11 +88999,11 @@ bQM
 bQM
 bQM
 bzO
-tnH
-nVq
-rev
-oYM
-kfA
+wpc
+qrw
+kMM
+hze
+pNm
 kfA
 kfA
 kfA
@@ -89317,8 +89424,8 @@ hbC
 ssD
 kqe
 eML
-lNg
-lNg
+bTd
+bTd
 npz
 ahR
 vrN
@@ -90785,7 +90892,7 @@ giX
 giX
 giX
 qHC
-qHC
+bya
 scM
 scM
 xkv
@@ -90997,9 +91104,9 @@ eps
 mYZ
 hKI
 hKI
-hKI
-lnK
-jUK
+dkL
+fkK
+cON
 qVt
 jUK
 scM
@@ -91209,9 +91316,9 @@ hjW
 hKI
 hjW
 hjW
-hKI
+dkL
 vfR
-ydX
+myM
 hDL
 qQl
 jTk
@@ -91421,7 +91528,7 @@ sEi
 sEi
 sEi
 sEi
-sEi
+asF
 fXe
 inh
 ydX
@@ -91633,7 +91740,7 @@ dlW
 dlW
 dlW
 dlW
-dlW
+hHn
 bHl
 inh
 gFq
@@ -91845,9 +91952,9 @@ hjW
 hKI
 hjW
 hjW
-hKI
+dkL
 nhd
-gFq
+hgK
 nes
 qQl
 jTk
@@ -92058,7 +92165,7 @@ lmM
 hKI
 hKI
 qDD
-lnK
+fkK
 iVb
 dIK
 iJM

--- a/maps/map_files/Kutjevo/Kutjevo.dmm
+++ b/maps/map_files/Kutjevo/Kutjevo.dmm
@@ -331,6 +331,10 @@
 	},
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/colony_north)
+"auo" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/auto_turf/sand/layer1,
+/area/kutjevo/exterior/lz_dunes)
 "avf" = (
 /obj/structure/machinery/light{
 	dir = 4
@@ -2343,6 +2347,7 @@
 /area/kutjevo/exterior/lz_river)
 "dfz" = (
 /obj/structure/machinery/vending/cola,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/kutjevo/grey/plate,
 /area/kutjevo/interior/complex/Northwest_Dorms)
 "dfY" = (
@@ -2459,6 +2464,7 @@
 /obj/structure/machinery/landinglight/ds2/delayone{
 	dir = 1
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/kutjevo/multi_tiles,
 /area/kutjevo/exterior/Northwest_Colony)
 "dpH" = (
@@ -3629,6 +3635,11 @@
 	color = "#995555"
 	},
 /area/kutjevo/interior/oob)
+"eKN" = (
+/obj/structure/machinery/door/airlock/multi_tile/almayer/generic/autoname,
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/kutjevo/grey/plate,
+/area/kutjevo/interior/complex/Northwest_Dorms)
 "eLO" = (
 /obj/structure/flora/grass/tallgrass/desert/corner{
 	dir = 9
@@ -3764,6 +3775,7 @@
 /obj/structure/machinery/colony_floodlight{
 	pixel_y = 10
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/auto_turf/sand/layer0,
 /area/kutjevo/exterior/lz_river)
 "eRN" = (
@@ -4387,6 +4399,10 @@
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
 /turf/open/auto_turf/sand/layer1,
 /area/kutjevo/interior/colony_N_East)
+"fLv" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/kutjevo/multi_tiles,
+/area/kutjevo/exterior/Northwest_Colony)
 "fLE" = (
 /obj/structure/platform_decoration/kutjevo{
 	dir = 8
@@ -4581,6 +4597,10 @@
 /obj/structure/prop/dam/gravestone,
 /turf/open/auto_turf/sand/layer0,
 /area/kutjevo/interior/colony_N_East)
+"fYe" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/closed/wall/kutjevo/rock,
+/area/kutjevo/exterior/Northwest_Colony)
 "fYE" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/computer/shuttle/dropship/flight/lz2,
@@ -5135,6 +5155,13 @@
 	},
 /turf/open/floor/kutjevo/colors/cyan/tile,
 /area/kutjevo/interior/complex/med/operating)
+"gOy" = (
+/obj/structure/machinery/landinglight/ds2/delaytwo{
+	dir = 8
+	},
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/kutjevo/multi_tiles,
+/area/kutjevo/exterior/Northwest_Colony)
 "gPW" = (
 /obj/structure/platform_decoration/kutjevo/rock{
 	dir = 1
@@ -5468,6 +5495,12 @@
 "hpB" = (
 /turf/open/floor/kutjevo/grey/plate,
 /area/kutjevo/exterior/construction)
+"hqs" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/kutjevo/tan/alt_edge{
+	dir = 4
+	},
+/area/kutjevo/exterior/Northwest_Colony)
 "hqN" = (
 /obj/structure/stairs/perspective/kutjevo{
 	dir = 1;
@@ -6047,6 +6080,10 @@
 /obj/item/stack/sheet/metal,
 /turf/open/floor/plating/kutjevo,
 /area/kutjevo/interior/complex/botany/east_tech)
+"ikM" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/closed/wall/kutjevo/colony,
+/area/kutjevo/interior/complex/Northwest_Dorms)
 "ikW" = (
 /turf/open/floor/kutjevo/colors/purple/edge{
 	dir = 4
@@ -6486,6 +6523,7 @@
 /area/kutjevo/interior/colony_South/power2)
 "iXh" = (
 /obj/structure/surface/table/almayer,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/complex/Northwest_Dorms)
 "iXj" = (
@@ -7343,6 +7381,7 @@
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/light,
 /obj/effect/landmark/objective_landmark/far,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/kutjevo/grey/plate,
 /area/kutjevo/interior/complex/Northwest_Dorms)
 "klE" = (
@@ -7628,6 +7667,11 @@
 /obj/effect/landmark/monkey_spawn,
 /turf/open/auto_turf/sand/layer1,
 /area/kutjevo/interior/colony_north)
+"kBJ" = (
+/obj/item/stack/sheet/metal,
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/auto_turf/sand/layer0,
+/area/kutjevo/exterior/Northwest_Colony)
 "kDl" = (
 /obj/structure/bed/chair/office/light,
 /obj/effect/landmark/survivor_spawner,
@@ -7716,6 +7760,10 @@
 "kIn" = (
 /turf/open/auto_turf/sand/layer2,
 /area/kutjevo/exterior/scrubland)
+"kIt" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/kutjevo/grey/plate,
+/area/kutjevo/interior/complex/Northwest_Dorms)
 "kKb" = (
 /obj/structure/barricade/wooden{
 	dir = 8
@@ -7801,6 +7849,11 @@
 /obj/item/weapon/gun/shotgun/pump/dual_tube/cmb/m3717,
 /turf/open/floor/kutjevo/multi_tiles,
 /area/kutjevo/interior/colony_central/mine_elevator)
+"kPe" = (
+/obj/item/prop/alien/hugger,
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/kutjevo/tan,
+/area/kutjevo/interior/complex/Northwest_Dorms)
 "kPw" = (
 /obj/effect/landmark/nightmare{
 	insert_tag = "trappedmonke"
@@ -7860,6 +7913,7 @@
 /area/kutjevo/interior/oob/dev_room)
 "kSy" = (
 /obj/effect/decal/cleanable/blood/xeno,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/kutjevo/tan/grey_edge{
 	dir = 10
 	},
@@ -8207,6 +8261,10 @@
 	dir = 4
 	},
 /area/kutjevo/interior/power/comms)
+"lta" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/auto_turf/sand/layer2,
+/area/kutjevo/exterior/Northwest_Colony)
 "ltv" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
 /turf/open/floor/kutjevo/colors/orange,
@@ -8480,6 +8538,7 @@
 /obj/structure/machinery/landinglight/ds2/delaytwo{
 	dir = 1
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/kutjevo/multi_tiles,
 /area/kutjevo/exterior/Northwest_Colony)
 "lNt" = (
@@ -9139,6 +9198,10 @@
 /obj/item/stack/cable_coil/random,
 /turf/open/floor/kutjevo/colors/orange,
 /area/kutjevo/interior/colony_South/power2)
+"mFc" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/auto_turf/sand/layer1,
+/area/kutjevo/exterior/lz_river)
 "mFd" = (
 /obj/structure/platform/kutjevo{
 	dir = 4
@@ -9376,6 +9439,13 @@
 /obj/effect/landmark/xeno_spawn,
 /turf/open/auto_turf/sand/layer1,
 /area/kutjevo/interior/colony_north)
+"mTH" = (
+/obj/structure/machinery/landinglight/ds2{
+	dir = 8
+	},
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/kutjevo/multi_tiles,
+/area/kutjevo/exterior/Northwest_Colony)
 "mTV" = (
 /obj/structure/largecrate/random,
 /turf/open/asphalt/cement_sunbleached,
@@ -9500,6 +9570,13 @@
 	dir = 1
 	},
 /area/kutjevo/interior/complex/med/triage)
+"nfk" = (
+/obj/structure/machinery/landinglight/ds2{
+	dir = 4
+	},
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/kutjevo/multi_tiles,
+/area/kutjevo/exterior/Northwest_Colony)
 "ngp" = (
 /obj/structure/platform_decoration/kutjevo{
 	dir = 1
@@ -9690,6 +9767,7 @@
 /area/kutjevo/interior/complex/botany)
 "ntz" = (
 /obj/structure/surface/table/almayer,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/kutjevo/grey/plate,
 /area/kutjevo/interior/complex/Northwest_Dorms)
 "ntF" = (
@@ -10425,6 +10503,12 @@
 	},
 /turf/open/gm/grass/grass1/weedable,
 /area/kutjevo/exterior/complex_border/med_park)
+"onS" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/kutjevo/tan/alt_edge{
+	dir = 8
+	},
+/area/kutjevo/exterior/Northwest_Colony)
 "oor" = (
 /obj/structure/surface/rack,
 /obj/item/stack/sheet/metal/large_stack,
@@ -10438,6 +10522,10 @@
 "opQ" = (
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/complex/Northwest_Security_Checkpoint)
+"opT" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/auto_turf/sand/layer1,
+/area/kutjevo/exterior/Northwest_Colony)
 "oqd" = (
 /obj/effect/landmark/objective_landmark/science,
 /turf/open/floor/kutjevo/colors,
@@ -10622,6 +10710,10 @@
 	},
 /turf/open/auto_turf/sand/layer1,
 /area/kutjevo/exterior/Northwest_Colony)
+"oFh" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/kutjevo/tan,
+/area/kutjevo/interior/complex/Northwest_Dorms)
 "oFs" = (
 /obj/structure/blocker/invisible_wall,
 /turf/open/desert/desert_shore/shore_edge1{
@@ -10992,6 +11084,15 @@
 /obj/item/device/analyzer/plant_analyzer,
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/complex/botany)
+"phe" = (
+/obj/structure/surface/table/almayer,
+/obj/structure/flora/pottedplant{
+	icon_state = "pottedplant_21";
+	pixel_y = 14
+	},
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/kutjevo/grey/plate,
+/area/kutjevo/interior/complex/Northwest_Dorms)
 "phv" = (
 /obj/structure/stairs/perspective/kutjevo{
 	dir = 1;
@@ -11066,6 +11167,12 @@
 	icon_state = "8,0"
 	},
 /area/kutjevo/interior/construction)
+"pki" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/kutjevo/tan/grey_edge{
+	dir = 6
+	},
+/area/kutjevo/interior/complex/Northwest_Dorms)
 "pks" = (
 /obj/structure/blocker/invisible_wall,
 /turf/open/floor/coagulation{
@@ -11446,6 +11553,7 @@
 /area/kutjevo/interior/power)
 "pHR" = (
 /obj/structure/machinery/light,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/kutjevo/grey/plate,
 /area/kutjevo/interior/complex/Northwest_Dorms)
 "pId" = (
@@ -11659,6 +11767,7 @@
 	dir = 1;
 	pixel_y = 14
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/almayer/research/containment/floor2,
 /area/kutjevo/exterior/Northwest_Colony)
 "pVd" = (
@@ -12290,6 +12399,7 @@
 /obj/structure/machinery/landinglight/ds2/delaythree{
 	dir = 1
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/kutjevo/multi_tiles,
 /area/kutjevo/exterior/Northwest_Colony)
 "qTN" = (
@@ -12361,6 +12471,13 @@
 	},
 /turf/open/floor/kutjevo/colors/cyan,
 /area/kutjevo/interior/complex/med)
+"qXu" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/kutjevo/tan,
+/area/kutjevo/interior/complex/Northwest_Dorms)
 "qYn" = (
 /obj/structure/stairs/perspective/kutjevo{
 	dir = 8;
@@ -12616,6 +12733,10 @@
 /obj/structure/prop/dam/boulder/boulder2,
 /turf/open/auto_turf/sand/layer0,
 /area/kutjevo/exterior/stonyfields)
+"rtS" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/auto_turf/sand/layer0,
+/area/kutjevo/exterior/Northwest_Colony)
 "ruM" = (
 /obj/structure/platform_decoration/kutjevo{
 	dir = 4
@@ -12684,6 +12805,13 @@
 "ryB" = (
 /turf/open/floor/kutjevo/colors/cyan/edge,
 /area/kutjevo/interior/complex/med/triage)
+"ryR" = (
+/obj/structure/machinery/landinglight/ds2/delaythree{
+	dir = 8
+	},
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/kutjevo/multi_tiles,
+/area/kutjevo/exterior/Northwest_Colony)
 "ryY" = (
 /obj/effect/landmark/monkey_spawn,
 /turf/open/floor/kutjevo/grey/plate,
@@ -14410,6 +14538,10 @@
 	dir = 8
 	},
 /area/kutjevo/exterior/runoff_dunes)
+"tQG" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/almayer/research/containment/floor1,
+/area/kutjevo/exterior/Northwest_Colony)
 "tQO" = (
 /obj/structure/stairs/perspective/kutjevo{
 	dir = 8;
@@ -15488,12 +15620,24 @@
 	dir = 4
 	},
 /area/kutjevo/interior/complex/med)
+"vgM" = (
+/obj/structure/machinery/floodlight/landing,
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/kutjevo/plate,
+/area/kutjevo/exterior/Northwest_Colony)
 "vgX" = (
 /obj/effect/decal/cleanable/blood/xeno{
 	icon_state = "xgibmid1"
 	},
 /turf/open/floor/kutjevo/colors/red/tile,
 /area/kutjevo/interior/complex/botany)
+"vhn" = (
+/obj/structure/machinery/landinglight/ds2/delaythree{
+	dir = 4
+	},
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/kutjevo/multi_tiles,
+/area/kutjevo/exterior/Northwest_Colony)
 "vhA" = (
 /obj/structure/filingcabinet,
 /obj/structure/machinery/light{
@@ -15685,6 +15829,13 @@
 /obj/item/ammo_magazine/shotgun/buckshot,
 /turf/open/floor/kutjevo/tan/alt_edge,
 /area/kutjevo/interior/complex/Northwest_Flight_Control)
+"vxX" = (
+/obj/structure/machinery/landinglight/ds2/delayone{
+	dir = 8
+	},
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/kutjevo/multi_tiles,
+/area/kutjevo/exterior/Northwest_Colony)
 "vys" = (
 /obj/structure/platform_decoration/kutjevo{
 	dir = 1
@@ -15956,6 +16107,10 @@
 /obj/structure/fence,
 /turf/open/auto_turf/sand/layer1,
 /area/kutjevo/interior/construction)
+"vMo" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/auto_turf/sand/layer2,
+/area/kutjevo/exterior/lz_dunes)
 "vNt" = (
 /obj/structure/bed/sofa/vert/white/top{
 	pixel_y = 17
@@ -16044,6 +16199,11 @@
 /obj/structure/flora/grass/tallgrass/desert,
 /turf/open/auto_turf/sand/layer0,
 /area/kutjevo/exterior/runoff_dunes)
+"vWU" = (
+/obj/item/stack/sheet/metal,
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/auto_turf/sand/layer1,
+/area/kutjevo/exterior/Northwest_Colony)
 "vXd" = (
 /obj/structure/platform/kutjevo{
 	dir = 4
@@ -16205,6 +16365,10 @@
 /obj/structure/platform/kutjevo/rock{
 	dir = 8
 	},
+/turf/open/auto_turf/sand/layer0,
+/area/kutjevo/exterior/lz_dunes)
+"wit" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/auto_turf/sand/layer0,
 /area/kutjevo/exterior/lz_dunes)
 "wix" = (
@@ -16377,6 +16541,7 @@
 /area/kutjevo/interior/construction)
 "wvg" = (
 /obj/item/stack/sheet/metal,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/almayer/research/containment/floor1,
 /area/kutjevo/exterior/Northwest_Colony)
 "wvr" = (
@@ -16461,6 +16626,10 @@
 	},
 /turf/open/floor/kutjevo/grey/plate,
 /area/kutjevo/interior/complex/med)
+"wzw" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/almayer/research/containment/floor2,
+/area/kutjevo/exterior/Northwest_Colony)
 "wzC" = (
 /obj/structure/stairs/perspective/kutjevo{
 	dir = 4;
@@ -16548,6 +16717,7 @@
 	dir = 1;
 	pixel_y = 13
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/almayer/research/containment/floor2,
 /area/kutjevo/exterior/Northwest_Colony)
 "wFa" = (
@@ -16714,6 +16884,7 @@
 /obj/structure/machinery/landinglight/ds2{
 	dir = 1
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/kutjevo/multi_tiles,
 /area/kutjevo/exterior/Northwest_Colony)
 "wXy" = (
@@ -19951,9 +20122,9 @@ hrz
 hrz
 hrz
 hrz
-hrz
-iin
-iin
+rtS
+lta
+lta
 sVF
 sVF
 huR
@@ -20118,9 +20289,9 @@ sVF
 hrz
 hrz
 hrz
-hrz
-hrz
-sVF
+rtS
+rtS
+opT
 sVF
 sVF
 huR
@@ -20285,9 +20456,9 @@ sVF
 sVF
 sVF
 sVF
-qDH
-qDH
-qDH
+hqs
+hqs
+hqs
 sVF
 sVF
 huR
@@ -20452,9 +20623,9 @@ dht
 dht
 dht
 dht
-dht
-dht
-dht
+tQG
+tQG
+tQG
 lRy
 huR
 huR
@@ -20619,9 +20790,9 @@ hnq
 dhL
 wrk
 ccs
-hnq
-dhL
-tGE
+vhn
+nfk
+vgM
 xBm
 huR
 huR
@@ -21898,9 +22069,9 @@ jqt
 ich
 ich
 jqt
-wGH
-wGH
-prJ
+auo
+auo
+wit
 dxF
 dxF
 dxF
@@ -22224,7 +22395,7 @@ wGH
 wGH
 prJ
 prJ
-prJ
+wit
 ich
 ich
 ceG
@@ -22391,7 +22562,7 @@ wGH
 wGH
 wGH
 wGH
-wGH
+auo
 xxY
 ceG
 ceG
@@ -22558,7 +22729,7 @@ wGH
 wGH
 wGH
 wGH
-wGH
+auo
 ans
 teN
 teN
@@ -22613,19 +22784,19 @@ xDR
 tHI
 pPz
 jUK
-xDR
-tHI
-pPz
-jUK
-xDR
-tHI
-pPz
-jUK
-xDR
-tHI
-pPz
-jUK
-tGE
+ryR
+gOy
+vxX
+mTH
+ryR
+gOy
+vxX
+mTH
+ryR
+gOy
+vxX
+mTH
+vgM
 xBm
 huR
 huR
@@ -22697,7 +22868,7 @@ boR
 bHA
 vXo
 qzd
-ubV
+mFc
 prJ
 prJ
 prJ
@@ -22724,8 +22895,8 @@ wGH
 wGH
 wGH
 wGH
-vei
-vei
+vMo
+vMo
 wGH
 wGH
 wGH
@@ -22780,19 +22951,19 @@ dht
 dht
 dht
 dht
-dht
-dht
-dht
-dht
-dht
-dht
-dht
-dht
-dht
-dht
-dht
-dht
-dht
+tQG
+tQG
+tQG
+tQG
+tQG
+tQG
+tQG
+tQG
+tQG
+tQG
+tQG
+tQG
+tQG
 lRy
 huR
 huR
@@ -22864,7 +23035,7 @@ kMP
 kMP
 pmu
 qzd
-ubV
+mFc
 wGH
 vei
 vei
@@ -22891,7 +23062,7 @@ prJ
 prJ
 jqt
 wGH
-vei
+vMo
 vei
 vei
 wGH
@@ -22947,19 +23118,19 @@ rSU
 sVF
 sVF
 sVF
-sVF
-sVF
-sVF
-sVF
-sVF
-sVF
-sVF
-sVF
-sVF
-sVF
-sVF
-sVF
-rSU
+opT
+opT
+opT
+opT
+opT
+opT
+opT
+opT
+opT
+opT
+opT
+opT
+onS
 sVF
 huR
 huR
@@ -23031,7 +23202,7 @@ kMP
 kMP
 pmu
 qzd
-ubV
+mFc
 wGH
 wGH
 prJ
@@ -23058,7 +23229,7 @@ prJ
 prJ
 wGH
 wGH
-wGH
+auo
 wGH
 vTc
 wGH
@@ -23112,21 +23283,21 @@ sVF
 sVF
 hrz
 sVF
-sVF
-hrz
-hrz
-hrz
-hrz
-iin
-iin
-oKx
-oKx
-sVF
-qDH
-qDH
-qDH
-qDH
-qDH
+opT
+rtS
+rtS
+rtS
+rtS
+lta
+lta
+fYe
+fYe
+opT
+hqs
+hqs
+hqs
+hqs
+hqs
 sVF
 huR
 huR
@@ -23198,7 +23369,7 @@ boR
 bHA
 pyE
 qzd
-ubV
+mFc
 wGH
 prJ
 prJ
@@ -23225,7 +23396,7 @@ prJ
 prJ
 wGH
 wGH
-wGH
+auo
 wGH
 wGH
 wGH
@@ -23279,11 +23450,11 @@ sVF
 dFx
 hrz
 hrz
-hrz
-hrz
-hrz
-sVF
-hrz
+rtS
+rtS
+rtS
+opT
+rtS
 hrz
 hrz
 hrz
@@ -23391,8 +23562,8 @@ wGH
 prJ
 wGH
 prJ
-prJ
-wGH
+wit
+auo
 wGH
 prJ
 prJ
@@ -23446,9 +23617,9 @@ xAr
 dht
 xAr
 wvg
-dht
-dht
-dht
+tQG
+tQG
+tQG
 dht
 lRy
 hrz
@@ -23555,10 +23726,10 @@ jqt
 wGH
 szJ
 wGH
-wGH
-prJ
-prJ
-prJ
+auo
+wit
+wit
+wit
 prJ
 prJ
 wGH
@@ -23613,9 +23784,9 @@ uzp
 acx
 uzp
 acx
-jnV
-jnV
-aUF
+ikM
+ikM
+fLv
 aUF
 xBm
 hrz
@@ -23720,9 +23891,9 @@ ovY
 prJ
 prJ
 wGH
-vei
-wGH
-wGH
+vMo
+auo
+auo
 prJ
 prJ
 prJ
@@ -23781,10 +23952,10 @@ vXs
 sjE
 sjE
 pHR
-jnV
-jnV
-aUF
-xBm
+ikM
+ikM
+fLv
+wzw
 sVF
 hrz
 hrz
@@ -23869,10 +24040,10 @@ iaj
 iaj
 iaj
 iaj
-wGH
-vei
-wGH
-vei
+auo
+vMo
+auo
+vMo
 prJ
 prJ
 wGH
@@ -23887,7 +24058,7 @@ wGH
 gZj
 vei
 vei
-wGH
+auo
 prJ
 prJ
 wGH
@@ -23947,11 +24118,11 @@ aTQ
 laI
 cWc
 cWc
-cWc
-hst
-jnV
-jnV
-xBm
+oFh
+phe
+ikM
+ikM
+wzw
 sVF
 fYF
 hrz
@@ -24054,7 +24225,7 @@ wGH
 prJ
 wGH
 prJ
-prJ
+wit
 wGH
 wGH
 wGH
@@ -24114,11 +24285,11 @@ cWc
 cWc
 cWc
 wCJ
-cWc
-cWc
+oFh
+oFh
 dfz
-jnV
-xBm
+ikM
+wzw
 sVF
 fSK
 sVF
@@ -24220,8 +24391,8 @@ prJ
 wGH
 wGH
 prJ
-prJ
-wGH
+wit
+auo
 wGH
 wGH
 jqt
@@ -24281,10 +24452,10 @@ cWc
 cWc
 cWc
 cWc
-cWc
-cWc
+oFh
+oFh
 kSy
-pma
+eKN
 wEU
 sVF
 iiy
@@ -24376,18 +24547,18 @@ prJ
 wGH
 jqt
 jqt
-wGH
-wGH
-wGH
-prJ
-prJ
+auo
+auo
+auo
+wit
+wit
 jqt
 jqt
-wGH
-wGH
-wGH
-wGH
-prJ
+auo
+auo
+auo
+auo
+wit
 wGH
 wGH
 aaT
@@ -24448,10 +24619,10 @@ cWc
 jcL
 cWc
 cWc
-tiL
-cWc
-jiX
-fto
+kPe
+oFh
+pki
+kIt
 pUB
 sVF
 arh
@@ -24615,11 +24786,11 @@ lSc
 cWc
 cWc
 cWc
-lSc
-lSc
-fto
-jnV
-xBm
+qXu
+qXu
+kIt
+ikM
+wzw
 sVF
 sVF
 sVF
@@ -24784,9 +24955,9 @@ cWc
 yhm
 iXh
 ntz
-jnV
-jnV
-xBm
+ikM
+ikM
+wzw
 sVF
 sVF
 sVF
@@ -24950,9 +25121,9 @@ wnK
 mLY
 awJ
 klu
-jnV
-jnV
-jnV
+ikM
+ikM
+ikM
 rzh
 dxF
 dxF
@@ -25116,8 +25287,8 @@ jnV
 jnV
 jnV
 jnV
-jnV
-jnV
+ikM
+ikM
 dxF
 dxF
 dxF
@@ -26773,12 +26944,12 @@ dxF
 dxF
 dxF
 dxF
-iin
-iin
-sVF
-sVF
-iin
-iin
+lta
+lta
+opT
+opT
+lta
+lta
 dxF
 dxF
 dxF
@@ -26940,12 +27111,12 @@ dxF
 dxF
 dxF
 dxF
-hrz
-sWG
-hrz
-sVF
-iin
-iin
+rtS
+kBJ
+rtS
+opT
+lta
+lta
 dxF
 dxF
 dxF
@@ -27108,12 +27279,12 @@ dxF
 dxF
 dxF
 dxF
-hrz
-hrz
-sVF
-sVF
-iin
-hrz
+rtS
+rtS
+opT
+opT
+lta
+rtS
 dxF
 dxF
 dxF
@@ -27275,13 +27446,13 @@ dxF
 dxF
 dxF
 dxF
-hrz
-hrz
-sVF
-dFx
-iin
-iin
-hrz
+rtS
+rtS
+opT
+vWU
+lta
+lta
+rtS
 dxF
 hrz
 hrz

--- a/maps/map_files/Kutjevo/Kutjevo.dmm
+++ b/maps/map_files/Kutjevo/Kutjevo.dmm
@@ -4283,6 +4283,11 @@
 	},
 /turf/open/auto_turf/sand/layer2,
 /area/kutjevo/exterior/scrubland)
+"fDr" = (
+/obj/structure/flora/grass/tallgrass/desert/corner,
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/auto_turf/sand/layer1,
+/area/kutjevo/exterior/lz_dunes)
 "fDY" = (
 /obj/structure/platform/kutjevo/smooth/stair_plate,
 /obj/structure/platform/kutjevo/smooth{
@@ -13561,6 +13566,7 @@
 /area/kutjevo/interior/power)
 "szJ" = (
 /obj/effect/decal/cleanable/blood/drip,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/auto_turf/sand/layer1,
 /area/kutjevo/exterior/lz_dunes)
 "sAe" = (
@@ -14986,6 +14992,11 @@
 	dir = 6
 	},
 /area/kutjevo/interior/complex/botany)
+"uwW" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/auto_turf/sand/layer1,
+/area/kutjevo/exterior/lz_dunes)
 "uwY" = (
 /obj/structure/platform/kutjevo{
 	dir = 1
@@ -21735,9 +21746,9 @@ jqt
 jqt
 jqt
 jqt
-wGH
-wGH
-wGH
+auo
+auo
+auo
 dxF
 dxF
 dxF
@@ -21902,9 +21913,9 @@ jqt
 jqt
 jqt
 jqt
-wGH
-wGH
-wGH
+auo
+auo
+auo
 dxF
 dxF
 dxF
@@ -22228,18 +22239,18 @@ wGH
 wGH
 prJ
 prJ
-prJ
+wit
 jqt
 jqt
 ich
 ich
 ich
 fgo
-wGH
-wGH
-prJ
-prJ
-iDz
+auo
+uwW
+wit
+wit
+fDr
 dxF
 dxF
 dxF
@@ -22394,7 +22405,7 @@ wGH
 wGH
 wGH
 prJ
-prJ
+wit
 wit
 ich
 ich
@@ -22535,7 +22546,7 @@ oIV
 tlN
 dxF
 dxF
-prJ
+wit
 vei
 prJ
 wGH
@@ -22561,7 +22572,7 @@ wGH
 wGH
 wGH
 wGH
-wGH
+auo
 auo
 xxY
 ceG
@@ -22702,7 +22713,7 @@ giM
 tlN
 dfa
 eRE
-wGH
+auo
 prJ
 vei
 prJ
@@ -22728,7 +22739,7 @@ wGH
 wGH
 wGH
 wGH
-wGH
+auo
 auo
 ans
 teN
@@ -22869,7 +22880,7 @@ bHA
 vXo
 qzd
 mFc
-prJ
+wit
 prJ
 prJ
 vei
@@ -22894,7 +22905,7 @@ prJ
 wGH
 wGH
 wGH
-wGH
+auo
 vMo
 vMo
 wGH
@@ -23036,7 +23047,7 @@ kMP
 pmu
 qzd
 mFc
-wGH
+auo
 vei
 vei
 prJ
@@ -23061,7 +23072,7 @@ wGH
 prJ
 prJ
 jqt
-wGH
+auo
 vMo
 vei
 vei
@@ -23203,7 +23214,7 @@ kMP
 pmu
 qzd
 mFc
-wGH
+auo
 wGH
 prJ
 prJ
@@ -23228,7 +23239,7 @@ wGH
 prJ
 prJ
 wGH
-wGH
+auo
 auo
 wGH
 vTc
@@ -23370,7 +23381,7 @@ bHA
 pyE
 qzd
 mFc
-wGH
+auo
 prJ
 prJ
 prJ
@@ -23395,7 +23406,7 @@ wGH
 prJ
 prJ
 wGH
-wGH
+auo
 auo
 wGH
 wGH
@@ -23537,7 +23548,7 @@ giM
 tlN
 dfa
 eRE
-prJ
+wit
 prJ
 wGH
 vei
@@ -23559,9 +23570,9 @@ jqt
 vei
 prJ
 wGH
-prJ
-wGH
-prJ
+wit
+auo
+wit
 wit
 auo
 wGH
@@ -23704,8 +23715,8 @@ dux
 tlN
 iaj
 iaj
-prJ
-prJ
+wit
+wit
 vei
 vei
 vei
@@ -23725,7 +23736,7 @@ jqt
 jqt
 wGH
 szJ
-wGH
+auo
 auo
 wit
 wit
@@ -23873,10 +23884,10 @@ iaj
 iaj
 iaj
 iaj
-prJ
-vei
-vei
-prJ
+wit
+vMo
+vMo
+wit
 vei
 wGH
 wGH
@@ -23890,7 +23901,7 @@ sHu
 ovY
 prJ
 prJ
-wGH
+auo
 vMo
 auo
 auo
@@ -24044,7 +24055,7 @@ auo
 vMo
 auo
 vMo
-prJ
+wit
 prJ
 wGH
 wGH
@@ -24057,7 +24068,7 @@ wGH
 wGH
 gZj
 vei
-vei
+vMo
 auo
 prJ
 prJ
@@ -24211,20 +24222,20 @@ wGH
 vei
 wGH
 jqt
+wit
+prJ
+wGH
+wGH
+prJ
+prJ
 prJ
 prJ
 wGH
 wGH
-prJ
-prJ
-prJ
-prJ
-wGH
-wGH
 wGH
 prJ
 wGH
-prJ
+wit
 wit
 wGH
 wGH
@@ -24379,18 +24390,18 @@ prJ
 jqt
 jqt
 jqt
-prJ
-vei
-wGH
-prJ
-prJ
-prJ
-prJ
-prJ
-prJ
-wGH
-wGH
-prJ
+wit
+vMo
+auo
+wit
+wit
+wit
+wit
+wit
+wit
+auo
+auo
+wit
 wit
 auo
 wGH

--- a/maps/map_files/New_Varadero/New_Varadero.dmm
+++ b/maps/map_files/New_Varadero/New_Varadero.dmm
@@ -1302,6 +1302,16 @@
 	icon_state = "asteroidplating"
 	},
 /area/varadero/interior_protected/maintenance/south)
+"aOb" = (
+/obj/structure/machinery/storm_siren{
+	dir = 4;
+	pixel_x = -3
+	},
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/plating/icefloor{
+	icon_state = "asteroidplating"
+	},
+/area/varadero/exterior/lz1_near)
 "aOg" = (
 /turf/open/gm/grass/grass1/weedable,
 /area/varadero/interior_protected/caves/central)
@@ -1437,6 +1447,10 @@
 	icon_state = "floor3"
 	},
 /area/varadero/interior/medical)
+"aTw" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/gm/dirt,
+/area/varadero/exterior/lz2_near)
 "aTC" = (
 /obj/item/reagent_container/food/snacks/eat_bar{
 	pixel_x = 5;
@@ -1520,6 +1534,13 @@
 	icon_state = "wood"
 	},
 /area/varadero/interior/library)
+"aVC" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/gm/river/ocean{
+	name = "deep ocean";
+	default_name = "deep ocean"
+	},
+/area/varadero/exterior/eastocean)
 "aVF" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/structure/machinery/microwave{
@@ -1611,6 +1632,14 @@
 	default_name = "shallow ocean"
 	},
 /area/varadero/interior/caves/north_research)
+"aYQ" = (
+/obj/structure/platform/kutjevo/smooth{
+	climb_delay = 1;
+	layer = 2.99
+	},
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/gm/dirt,
+/area/varadero/exterior/lz2_near)
 "aZb" = (
 /obj/structure/bedsheetbin{
 	icon_state = "linenbin-empty"
@@ -1894,9 +1923,7 @@
 /area/varadero/interior/hall_N)
 "bhU" = (
 /obj/structure/machinery/floodlight{
-	name = "Floodlight";
-	unacidable = 0;
-	wrenchable = 1
+	name = "Floodlight"
 	},
 /obj/structure/platform_decoration/kutjevo{
 	dir = 8
@@ -1919,6 +1946,16 @@
 /obj/effect/spawner/random/powercell,
 /turf/open/floor/wood,
 /area/varadero/interior/chapel)
+"bix" = (
+/obj/structure/platform_decoration/kutjevo{
+	dir = 1
+	},
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/gm/river{
+	name = "shallow ocean";
+	default_name = "shallow ocean"
+	},
+/area/varadero/exterior/pontoon_beach)
 "biz" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/storage/surgical_tray,
@@ -2216,6 +2253,10 @@
 /obj/structure/pipes/vents/pump,
 /turf/open/floor/carpet,
 /area/varadero/interior/administration)
+"buu" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/gm/coast/beachcorner/south_west,
+/area/varadero/exterior/eastocean)
 "buB" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/structure/disposalpipe/segment,
@@ -3111,6 +3152,17 @@
 	icon_state = "floor3"
 	},
 /area/varadero/interior/cargo)
+"bXF" = (
+/obj/structure/platform/kutjevo/smooth{
+	climb_delay = 1;
+	layer = 2.99
+	},
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/gm/river/ocean{
+	name = "deep ocean";
+	default_name = "deep ocean"
+	},
+/area/varadero/exterior/pontoon_beach)
 "bYO" = (
 /obj/item/tool/shovel/spade,
 /turf/open/gm/dirt,
@@ -3931,6 +3983,13 @@
 	default_name = "shallow ocean"
 	},
 /area/varadero/interior/caves/north_research)
+"cyC" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/gm/river{
+	name = "shallow ocean";
+	default_name = "shallow ocean"
+	},
+/area/varadero/exterior/pontoon_beach)
 "cyT" = (
 /obj/structure/machinery/light/small,
 /obj/structure/prop/invuln/lattice_prop{
@@ -4009,6 +4068,7 @@
 	pixel_x = -9;
 	pixel_y = 12
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating/icefloor{
 	icon_state = "asteroidplating"
 	},
@@ -4223,6 +4283,7 @@
 /area/varadero/interior_protected/vessel)
 "cHY" = (
 /obj/effect/landmark/hunter_primary,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor{
 	dir = 1;
 	icon_state = "asteroidfloor"
@@ -4692,6 +4753,10 @@
 	icon_state = "greenfull"
 	},
 /area/varadero/interior/hall_N)
+"cYf" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/auto_turf/sand_white/layer1,
+/area/varadero/exterior/lz2_near)
 "cYr" = (
 /obj/structure/machinery/landinglight/ds2/delaytwo{
 	dir = 4
@@ -5667,6 +5732,7 @@
 /obj/item/reagent_container/food/drinks/cans/souto/grape,
 /obj/item/reagent_container/food/drinks/cans/souto/lime,
 /obj/item/reagent_container/food/drinks/cans/souto/grape,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating/icefloor{
 	icon_state = "asteroidplating"
 	},
@@ -6078,6 +6144,17 @@
 	icon_state = "yellow"
 	},
 /area/varadero/interior/cargo)
+"dZW" = (
+/obj/structure/platform/kutjevo/smooth{
+	climb_delay = 1;
+	layer = 2.99
+	},
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/gm/river{
+	name = "shallow ocean";
+	default_name = "shallow ocean"
+	},
+/area/varadero/exterior/pontoon_beach)
 "dZZ" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/clothing/mask/cigarette/cigar/tarbacks{
@@ -6735,6 +6812,7 @@
 /obj/structure/surface/rack,
 /obj/item/tool/crowbar/red,
 /obj/item/tank/emergency_oxygen,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor{
 	dir = 1;
 	icon_state = "asteroidfloor"
@@ -9132,6 +9210,7 @@
 /obj/structure/machinery/landinglight/ds2/delaythree{
 	dir = 8
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor{
 	dir = 1;
 	icon_state = "asteroidfloor"
@@ -9263,6 +9342,7 @@
 	pixel_y = 12
 	},
 /obj/item/trash/barcardine,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating/icefloor{
 	icon_state = "asteroidplating"
 	},
@@ -9340,6 +9420,7 @@
 	pixel_x = -7;
 	pixel_y = -4
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating/icefloor{
 	icon_state = "asteroidplating"
 	},
@@ -9448,6 +9529,11 @@
 /obj/structure/largecrate/random/barrel/white,
 /turf/open/gm/dirt,
 /area/varadero/exterior/eastbeach)
+"gcE" = (
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/gm/dirt,
+/area/varadero/exterior/lz2_near)
 "gcF" = (
 /obj/structure/prop/wooden_cross{
 	desc = "A grave to a fishing buddy, long gone"
@@ -10018,6 +10104,7 @@
 	icon_state = "hr_kutjevo";
 	name = "support struts"
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/gm/dirt,
 /area/varadero/exterior/lz1_near)
 "gtv" = (
@@ -10163,6 +10250,13 @@
 	icon_state = "asteroidplating"
 	},
 /area/varadero/interior/hall_SE)
+"gyg" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/gm/river/ocean{
+	name = "deep ocean";
+	default_name = "deep ocean"
+	},
+/area/varadero/exterior/lz2_near)
 "gyw" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
@@ -10717,9 +10811,7 @@
 /area/varadero/interior/security)
 "gRU" = (
 /obj/structure/machinery/floodlight{
-	name = "Floodlight";
-	unacidable = 0;
-	wrenchable = 1
+	name = "Floodlight"
 	},
 /turf/open/auto_turf/sand_white/layer1,
 /area/varadero/interior_protected/caves/digsite)
@@ -10755,6 +10847,7 @@
 	pixel_x = -6;
 	pixel_y = -3
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor{
 	dir = 1;
 	icon_state = "asteroidfloor"
@@ -10787,6 +10880,7 @@
 	climb_delay = 1;
 	layer = 2.99
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/gm/river{
 	name = "shallow ocean";
 	default_name = "shallow ocean"
@@ -11009,6 +11103,7 @@
 	pixel_x = -24;
 	start_charge = 0
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor{
 	dir = 1;
 	icon_state = "asteroidfloor"
@@ -11500,6 +11595,7 @@
 /area/varadero/interior/research)
 "huy" = (
 /obj/structure/closet/secure_closet/engineering_electrical,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor{
 	dir = 1;
 	icon_state = "asteroidfloor"
@@ -11665,6 +11761,12 @@
 /obj/effect/landmark/survivor_spawner,
 /turf/open/floor/wood,
 /area/varadero/interior/court)
+"hAn" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/plating/icefloor{
+	icon_state = "asteroidplating"
+	},
+/area/varadero/exterior/lz2_near)
 "hAI" = (
 /obj/structure/platform_decoration/kutjevo{
 	dir = 8
@@ -11971,6 +12073,7 @@
 /obj/structure/barricade/handrail/wire{
 	layer = 3.5
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating/icefloor{
 	icon_state = "asteroidplating"
 	},
@@ -12053,6 +12156,7 @@
 	name = "Construction Light"
 	},
 /obj/effect/decal/warning_stripes,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating/icefloor{
 	icon_state = "asteroidplating"
 	},
@@ -12440,6 +12544,7 @@
 	pixel_y = 4
 	},
 /obj/structure/surface/table,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/gm/dirt,
 /area/varadero/exterior/lz1_near)
 "icl" = (
@@ -13178,6 +13283,7 @@
 	pixel_x = 7;
 	pixel_y = -6
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating/icefloor{
 	icon_state = "asteroidplating"
 	},
@@ -13862,9 +13968,7 @@
 /area/varadero/interior/administration)
 "iWX" = (
 /obj/structure/machinery/floodlight{
-	name = "Floodlight";
-	unacidable = 0;
-	wrenchable = 1
+	name = "Floodlight"
 	},
 /turf/open/auto_turf/sand_white/layer1,
 /area/varadero/exterior/eastbeach)
@@ -14176,6 +14280,7 @@
 	},
 /area/varadero/interior/maintenance)
 "jgL" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor{
 	dir = 6;
 	icon_state = "asteroidwarning"
@@ -14208,6 +14313,12 @@
 	icon_state = "red"
 	},
 /area/varadero/interior/security)
+"jht" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/gm/dirt{
+	icon_state = "desert3"
+	},
+/area/varadero/exterior/eastbeach)
 "jhu" = (
 /obj/structure/platform/kutjevo/smooth{
 	dir = 1;
@@ -14704,6 +14815,7 @@
 /obj/structure/machinery/landinglight/ds2/delaytwo{
 	dir = 8
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor{
 	dir = 1;
 	icon_state = "asteroidfloor"
@@ -14732,6 +14844,7 @@
 	dir = 8;
 	pixel_x = 3
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating/icefloor{
 	icon_state = "asteroidplating"
 	},
@@ -14764,6 +14877,14 @@
 /obj/item/device/flashlight/lamp/tripod,
 /turf/open/auto_turf/sand_white/layer1,
 /area/varadero/interior_protected/caves)
+"jAL" = (
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "asteroidfloor"
+	},
+/area/varadero/exterior/lz2_near)
 "jBl" = (
 /obj/structure/machinery/light{
 	dir = 4
@@ -15530,6 +15651,16 @@
 	icon_state = "multi_tiles"
 	},
 /area/varadero/interior/hall_SE)
+"kbH" = (
+/obj/structure/machinery/light{
+	dir = 8
+	},
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "asteroidfloor"
+	},
+/area/varadero/exterior/lz1_near)
 "kbQ" = (
 /turf/open/auto_turf/sand_white/layer1,
 /area/varadero/interior/caves/east)
@@ -16116,6 +16247,7 @@
 /obj/structure/machinery/floodlight/landing/floor{
 	pixel_x = 1
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor{
 	dir = 1;
 	icon_state = "asteroidfloor"
@@ -16252,6 +16384,7 @@
 /obj/structure/bed/chair{
 	dir = 8
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating/icefloor{
 	icon_state = "asteroidplating"
 	},
@@ -17374,6 +17507,14 @@
 	icon_state = "multi_tiles"
 	},
 /area/varadero/interior/electrical)
+"lkf" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "asteroidfloor"
+	},
+/area/varadero/exterior/lz1_near)
 "lkz" = (
 /obj/effect/landmark/corpsespawner/colonist/burst,
 /turf/open/floor/prison/chapel_carpet{
@@ -17630,6 +17771,14 @@
 	icon_state = "multi_tiles"
 	},
 /area/varadero/interior/hall_NW)
+"ltP" = (
+/obj/structure/machinery/floodlight/landing/floor,
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "asteroidfloor"
+	},
+/area/varadero/exterior/lz1_near)
 "ltW" = (
 /turf/open/floor/shiva{
 	dir = 1
@@ -18010,6 +18159,13 @@
 	},
 /turf/open/floor/carpet,
 /area/varadero/interior/chapel)
+"lFe" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/gm/river/ocean{
+	name = "deep ocean";
+	default_name = "deep ocean"
+	},
+/area/varadero/exterior/pontoon_beach)
 "lFk" = (
 /obj/effect/landmark/corpsespawner/colonist/burst,
 /turf/open/auto_turf/sand_white/layer1,
@@ -18807,6 +18963,7 @@
 /area/varadero/exterior/eastbeach)
 "mcr" = (
 /obj/structure/machinery/light,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor{
 	dir = 1;
 	icon_state = "asteroidfloor"
@@ -19235,6 +19392,7 @@
 /area/varadero/interior/research)
 "mpH" = (
 /obj/structure/largecrate/random,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor{
 	dir = 1;
 	icon_state = "asteroidfloor"
@@ -19324,9 +19482,7 @@
 /area/varadero/interior/cargo)
 "mtp" = (
 /obj/structure/machinery/floodlight{
-	name = "Floodlight";
-	unacidable = 0;
-	wrenchable = 1
+	name = "Floodlight"
 	},
 /turf/open/floor/plating/icefloor{
 	icon_state = "asteroidplating"
@@ -19414,9 +19570,7 @@
 /area/varadero/interior/hall_SE)
 "mvO" = (
 /obj/structure/machinery/floodlight{
-	name = "Floodlight";
-	unacidable = 0;
-	wrenchable = 1
+	name = "Floodlight"
 	},
 /turf/open/floor/shiva{
 	dir = 1;
@@ -19929,9 +20083,7 @@
 	dir = 1
 	},
 /obj/structure/machinery/floodlight{
-	name = "Floodlight";
-	unacidable = 0;
-	wrenchable = 1
+	name = "Floodlight"
 	},
 /turf/open/floor/shiva{
 	dir = 1;
@@ -20390,6 +20542,10 @@
 	icon_state = "multi_tiles"
 	},
 /area/varadero/interior_protected/vessel)
+"nbx" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/gm/coast/beachcorner2/south_west,
+/area/varadero/exterior/eastocean)
 "nbA" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor/shiva{
@@ -20807,6 +20963,12 @@
 	icon_state = "multi_tiles"
 	},
 /area/varadero/interior/comms3)
+"noE" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/gm/dirt{
+	icon_state = "desert2"
+	},
+/area/varadero/exterior/lz2_near)
 "noR" = (
 /obj/item/shard{
 	icon_state = "medium"
@@ -21143,6 +21305,7 @@
 "nFB" = (
 /obj/structure/machinery/floodlight/landing,
 /obj/effect/decal/warning_stripes,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor{
 	dir = 1;
 	icon_state = "asteroidfloor"
@@ -21697,6 +21860,22 @@
 	icon_state = "red"
 	},
 /area/varadero/interior/morgue)
+"nWd" = (
+/obj/structure/platform/kutjevo/smooth{
+	climb_delay = 1;
+	layer = 2.99
+	},
+/obj/structure/platform/kutjevo/smooth{
+	dir = 8;
+	climb_delay = 1;
+	layer = 2.99
+	},
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/gm/river{
+	name = "shallow ocean";
+	default_name = "shallow ocean"
+	},
+/area/varadero/exterior/pontoon_beach)
 "nWg" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
@@ -21729,6 +21908,7 @@
 /obj/structure/machinery/landinglight/ds2{
 	dir = 8
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor{
 	dir = 1;
 	icon_state = "asteroidfloor"
@@ -21871,6 +22051,7 @@
 	pixel_y = -18;
 	indestructible = 1
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating/icefloor{
 	dir = 1;
 	icon_state = "warnplate"
@@ -21970,6 +22151,25 @@
 	icon_state = "asteroidplating"
 	},
 /area/varadero/interior/maintenance)
+"oeI" = (
+/obj/structure/prop/structure_lattice{
+	dir = 1;
+	health = 300
+	},
+/obj/structure/prop/structure_lattice{
+	dir = 1;
+	layer = 3.1;
+	pixel_y = 10
+	},
+/obj/structure/prop/invuln/ice_prefab/roof_greeble{
+	icon_state = "vent4";
+	pixel_y = 25
+	},
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/plating/icefloor{
+	icon_state = "asteroidplating"
+	},
+/area/varadero/exterior/lz1_near)
 "oeO" = (
 /obj/structure/surface/table,
 /obj/item/reagent_container/food/drinks/cup{
@@ -22091,6 +22291,7 @@
 /area/varadero/interior/administration)
 "ojm" = (
 /obj/structure/closet/toolcloset,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor{
 	dir = 1;
 	icon_state = "asteroidfloor"
@@ -22287,6 +22488,12 @@
 	icon_state = "floor3"
 	},
 /area/varadero/interior/security)
+"org" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/gm/dirt{
+	icon_state = "desert1"
+	},
+/area/varadero/exterior/lz2_near)
 "orr" = (
 /obj/effect/landmark/lv624/fog_blocker{
 	time_to_dispel = 25000
@@ -22318,6 +22525,13 @@
 	icon_state = "greenfull"
 	},
 /area/varadero/interior/hall_SE)
+"osb" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/gm/river{
+	name = "shallow ocean";
+	default_name = "shallow ocean"
+	},
+/area/varadero/exterior/eastocean)
 "osn" = (
 /obj/effect/landmark/xeno_hive_spawn,
 /obj/effect/landmark/ert_spawns/groundside_xeno,
@@ -23686,6 +23900,7 @@
 /area/varadero/exterior/eastbeach)
 "plm" = (
 /obj/effect/decal/cleanable/blood/gibs/xeno,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor{
 	dir = 1;
 	icon_state = "asteroidfloor"
@@ -23916,6 +24131,16 @@
 	icon_state = "red"
 	},
 /area/varadero/interior/medical)
+"pri" = (
+/obj/structure/platform/kutjevo/smooth{
+	climb_delay = 1;
+	layer = 2.99
+	},
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/plating/icefloor{
+	icon_state = "asteroidplating"
+	},
+/area/varadero/exterior/lz1_near)
 "prl" = (
 /obj/item/grown/log,
 /turf/open/gm/dirt,
@@ -24119,6 +24344,7 @@
 	},
 /area/varadero/interior/administration)
 "pAp" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating/icefloor{
 	dir = 1;
 	icon_state = "warnplate"
@@ -24319,6 +24545,7 @@
 /area/varadero/exterior/eastbeach)
 "pFF" = (
 /obj/effect/decal/cleanable/blood/gibs/xeno/limb,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor{
 	dir = 1;
 	icon_state = "asteroidfloor"
@@ -24478,6 +24705,7 @@
 /obj/structure/machinery/light/small{
 	dir = 4
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor{
 	dir = 1;
 	icon_state = "asteroidfloor"
@@ -25051,6 +25279,14 @@
 "qcN" = (
 /turf/closed/wall,
 /area/varadero/interior/medical)
+"qcV" = (
+/obj/structure/prop/rock/brown,
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/gm/river/ocean{
+	name = "deep ocean";
+	default_name = "deep ocean"
+	},
+/area/varadero/exterior/pontoon_beach)
 "qdd" = (
 /obj/structure/pipes/vents/pump{
 	dir = 1
@@ -25390,6 +25626,7 @@
 	},
 /area/varadero/interior/research)
 "qoE" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor{
 	dir = 5;
 	icon_state = "asteroidwarning"
@@ -26561,6 +26798,7 @@
 	pixel_x = 8;
 	pixel_y = -6
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating/icefloor{
 	icon_state = "asteroidplating"
 	},
@@ -26955,6 +27193,7 @@
 /area/varadero/interior/research)
 "rkA" = (
 /obj/structure/closet/secure_closet/engineering_welding,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor{
 	dir = 1;
 	icon_state = "asteroidfloor"
@@ -28020,6 +28259,7 @@
 /area/varadero/interior/cargo)
 "rSA" = (
 /obj/effect/decal/cleanable/blood/drip,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor{
 	dir = 1;
 	icon_state = "asteroidfloor"
@@ -28138,6 +28378,13 @@
 	icon_state = "purple"
 	},
 /area/varadero/interior/research)
+"rUB" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "asteroidfloor"
+	},
+/area/varadero/exterior/lz1_near)
 "rUI" = (
 /obj/structure/closet/crate/construction,
 /obj/item/reagent_container/food/snacks/wrapped/chunk,
@@ -28890,6 +29137,7 @@
 /obj/structure/barricade/handrail/wire{
 	dir = 8
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating/icefloor{
 	icon_state = "asteroidplating"
 	},
@@ -29384,6 +29632,7 @@
 /area/varadero/exterior/eastbeach)
 "sIQ" = (
 /obj/item/stack/sheet/wood/small_stack,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor{
 	dir = 1;
 	icon_state = "asteroidfloor"
@@ -29724,6 +29973,7 @@
 "sTT" = (
 /obj/structure/machinery/light,
 /obj/structure/closet/toolcloset,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor{
 	dir = 1;
 	icon_state = "asteroidfloor"
@@ -30254,6 +30504,7 @@
 	climb_delay = 1;
 	layer = 2.99
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/gm/river{
 	name = "shallow ocean";
 	default_name = "shallow ocean"
@@ -30634,6 +30885,13 @@
 	icon_state = "floor3"
 	},
 /area/varadero/interior/hall_NW)
+"tzs" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "asteroidwarning"
+	},
+/area/varadero/exterior/lz1_near)
 "tzw" = (
 /turf/open/floor{
 	icon_state = "wood"
@@ -30876,6 +31134,12 @@
 /obj/structure/window/framed/colony/reinforced,
 /turf/open/floor/plating,
 /area/varadero/interior/maintenance/security)
+"tLL" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/plating/icefloor{
+	icon_state = "asteroidplating"
+	},
+/area/varadero/exterior/lz1_near)
 "tLS" = (
 /obj/structure/flora/bush/ausbushes/var3/fullgrass,
 /turf/open/gm/dirt,
@@ -31175,6 +31439,17 @@
 	icon_state = "redfull"
 	},
 /area/varadero/interior/security)
+"tUV" = (
+/obj/structure/machinery/storm_siren{
+	dir = 4;
+	pixel_x = -3
+	},
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "asteroidfloor"
+	},
+/area/varadero/exterior/lz1_near)
 "tVf" = (
 /obj/structure/closet/crate,
 /obj/item/tool/stamp,
@@ -31356,6 +31631,7 @@
 /obj/structure/machinery/landinglight/ds2/delayone{
 	dir = 8
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor{
 	dir = 1;
 	icon_state = "asteroidfloor"
@@ -32119,6 +32395,17 @@
 	icon_state = "multi_tiles"
 	},
 /area/varadero/interior/hall_N)
+"uDG" = (
+/obj/structure/machinery/landinglight/ds2/spoke{
+	pixel_x = -1;
+	pixel_y = 22
+	},
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "asteroidfloor"
+	},
+/area/varadero/exterior/lz1_near)
 "uDQ" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
@@ -33278,6 +33565,7 @@
 /area/varadero/interior/caves/east)
 "vpr" = (
 /obj/effect/decal/cleanable/blood/xeno,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor{
 	dir = 1;
 	icon_state = "asteroidfloor"
@@ -34593,6 +34881,7 @@
 	climb_delay = 1;
 	layer = 2.99
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/gm/river/ocean{
 	name = "deep ocean";
 	default_name = "deep ocean"
@@ -34617,6 +34906,7 @@
 /turf/open/floor/shiva,
 /area/varadero/interior/technical_storage)
 "waP" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating/icefloor{
 	dir = 4;
 	icon_state = "warnplate"
@@ -34968,6 +35258,13 @@
 	icon_state = "multi_tiles"
 	},
 /area/varadero/interior/technical_storage)
+"wkK" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "asteroidfloor"
+	},
+/area/varadero/exterior/lz2_near)
 "wkM" = (
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -35493,6 +35790,7 @@
 /area/varadero/interior/records)
 "wCR" = (
 /obj/effect/decal/cleanable/blood/oil/streak,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating/icefloor{
 	icon_state = "asteroidplating"
 	},
@@ -36753,6 +37051,21 @@
 	icon_state = "yellowfull"
 	},
 /area/varadero/interior/cargo)
+"xwD" = (
+/obj/structure/platform/kutjevo/smooth{
+	dir = 1;
+	climb_delay = 1;
+	layer = 2.99
+	},
+/obj/structure/barricade/handrail{
+	desc = "Your platforms look pretty heavy king, let me support them for you.";
+	dir = 1;
+	icon_state = "hr_kutjevo";
+	name = "support struts"
+	},
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/gm/dirt,
+/area/varadero/exterior/lz2_near)
 "xwG" = (
 /obj/structure/prop/invuln/lattice_prop{
 	icon_state = "lattice12";
@@ -36972,6 +37285,7 @@
 /area/varadero/interior/hall_SE)
 "xBS" = (
 /obj/structure/largecrate/random/case/small,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor{
 	dir = 1;
 	icon_state = "asteroidfloor"
@@ -37157,6 +37471,7 @@
 	pixel_y = 22
 	},
 /obj/effect/decal/cleanable/blood/oil,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor{
 	dir = 1;
 	icon_state = "asteroidfloor"
@@ -37369,6 +37684,7 @@
 /area/varadero/interior/toilets)
 "xOI" = (
 /obj/item/tool/wrench,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating/icefloor{
 	icon_state = "asteroidplating"
 	},
@@ -37402,6 +37718,13 @@
 	dir = 1
 	},
 /area/varadero/interior/research)
+"xPH" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "asteroidwarning"
+	},
+/area/varadero/exterior/lz1_near)
 "xPV" = (
 /obj/structure/machinery/light,
 /turf/open/floor/shiva{
@@ -37607,6 +37930,7 @@
 "xXr" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/blood/gibs/xeno/body,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor{
 	dir = 1;
 	icon_state = "asteroidfloor"
@@ -37818,6 +38142,12 @@
 	icon_state = "multi_tiles"
 	},
 /area/varadero/interior_protected/vessel)
+"yee" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor{
+	icon_state = "asteroidwarning"
+	},
+/area/varadero/exterior/lz1_near)
 "yeF" = (
 /obj/item/reagent_container/glass/bucket/mopbucket,
 /obj/item/tool/mop,
@@ -48338,7 +48668,7 @@ pMG
 pMG
 qFC
 kME
-paq
+tUV
 gSY
 xBS
 qqJ
@@ -48520,13 +48850,13 @@ bnf
 vMe
 wMw
 vLV
-wMw
-wMw
-wMw
+rUB
+rUB
+rUB
 xJb
-wMw
-wMw
-wMw
+rUB
+rUB
+rUB
 mcr
 ccp
 qpK
@@ -48702,19 +49032,19 @@ wMw
 wMw
 wMw
 wMw
-wMw
-wMw
-wMw
-wMw
-wMw
-wMw
-wMw
-wMw
-kME
-wMw
+rUB
+rUB
+rUB
+rUB
+rUB
+rUB
+rUB
+rUB
+kbH
+rUB
 mpH
 hcz
-wMw
+rUB
 ojm
 huy
 qAp
@@ -48884,21 +49214,21 @@ wMw
 wMw
 wMw
 wMw
-wMw
-wMw
-wMw
-wMw
-wMw
-wMw
-wMw
-wMw
+rUB
+rUB
+rUB
+rUB
+rUB
+rUB
+rUB
+rUB
 sIQ
-wMw
-wMw
+rUB
+rUB
 mpH
-wMw
-wMw
-wMw
+rUB
+rUB
+rUB
 qzi
 jTL
 jTL
@@ -49066,21 +49396,21 @@ wMw
 xcE
 wMw
 wMw
-wMw
-wMw
-wMw
-wMw
-wMw
-wMw
-wMw
-wMw
+rUB
+rUB
+rUB
+rUB
+rUB
+rUB
+rUB
+rUB
 nFB
-wMw
+rUB
 sIQ
-wMw
-wMw
-wMw
-wMw
+rUB
+rUB
+rUB
+rUB
 oJm
 hyr
 hyr
@@ -49248,21 +49578,21 @@ wMw
 wMw
 wMw
 wMw
-wMw
-wMw
-wMw
-wMw
-wMw
-wMw
-wMw
-wMw
-wMw
-wMw
-wMw
-wMw
-wMw
-wMw
-wMw
+rUB
+rUB
+rUB
+rUB
+rUB
+rUB
+rUB
+rUB
+rUB
+rUB
+rUB
+rUB
+rUB
+rUB
+rUB
 qAp
 hyr
 eaQ
@@ -49440,10 +49770,10 @@ wMw
 wMw
 wMw
 wMw
-wMw
-wMw
-wMw
-wMw
+rUB
+rUB
+rUB
+rUB
 sTT
 bgE
 jTL
@@ -49622,11 +49952,11 @@ qFC
 qFC
 qFC
 kIJ
-wMw
-wMw
-wMw
-wMw
-wMw
+rUB
+rUB
+rUB
+rUB
+rUB
 qAp
 nwi
 igQ
@@ -49804,11 +50134,11 @@ onr
 ahK
 wCc
 mrC
-wMw
-wMw
-wMw
-wMw
-wMw
+rUB
+rUB
+rUB
+rUB
+rUB
 weJ
 qAp
 coz
@@ -49986,14 +50316,14 @@ bZU
 bZU
 xsH
 mrC
-wMw
-wMw
-wMw
-wMw
-wMw
-paq
+rUB
+rUB
+rUB
+rUB
+rUB
+tUV
 rkA
-wMw
+rUB
 mcr
 aMC
 aCY
@@ -50168,15 +50498,15 @@ bZU
 bZU
 bwP
 mrC
-wMw
-wMw
-wMw
-wMw
-wMw
-wMw
-wMw
-vLV
-wMw
+rUB
+rUB
+rUB
+rUB
+rUB
+rUB
+rUB
+uDG
+rUB
 aMC
 coz
 qzb
@@ -50350,14 +50680,14 @@ bZU
 bZU
 miF
 mrC
-wMw
-wMw
-wMw
-wMw
-wMw
-wMw
-wMw
-wMw
+rUB
+rUB
+rUB
+rUB
+rUB
+rUB
+rUB
+rUB
 obN
 aVs
 lzX
@@ -50532,14 +50862,14 @@ bZU
 bZU
 evX
 mrC
-wMw
-wMw
-wMw
+rUB
+rUB
+rUB
 nFB
-wMw
-wMw
-wMw
-wMw
+rUB
+rUB
+rUB
+rUB
 pAp
 aVs
 bgh
@@ -50671,9 +51001,9 @@ mPk
 mPk
 mPk
 rYC
-lTR
-pAX
-qwQ
+cyC
+qcV
+lFe
 qwQ
 lTR
 lTR
@@ -50714,13 +51044,13 @@ bZU
 bZU
 xsH
 mrC
-wMw
-wMw
-wMw
-wMw
-bnf
+rUB
+rUB
+rUB
+rUB
+lkf
 cHY
-wMw
+rUB
 rSA
 pAp
 aVs
@@ -50853,11 +51183,11 @@ mPk
 mPk
 mPk
 wBp
-lTR
-qwQ
-qwQ
-qwQ
-lTR
+cyC
+lFe
+lFe
+lFe
+cyC
 qwQ
 eDY
 lZR
@@ -50896,14 +51226,14 @@ bZU
 bZU
 hEs
 mrC
-wMw
-wMw
+rUB
+rUB
 vpr
-wMw
+rUB
 pFF
-wMw
-wMw
-wMw
+rUB
+rUB
+rUB
 pAp
 cFK
 kdV
@@ -51037,9 +51367,9 @@ mPk
 xVw
 dXg
 dXg
-qwQ
-qwQ
-qwQ
+lFe
+lFe
+lFe
 qwQ
 xLB
 gnC
@@ -51078,14 +51408,14 @@ bZU
 bZU
 miF
 mrC
-wMw
-wMw
-wMw
+rUB
+rUB
+rUB
 vpr
-wMw
-wMw
-wMw
-vLV
+rUB
+rUB
+rUB
+uDG
 mcr
 aMC
 bgE
@@ -51220,10 +51550,10 @@ wBp
 qwQ
 dXg
 dXg
-qwQ
-lTR
-qwQ
-fHf
+lFe
+cyC
+lFe
+bix
 wPl
 xOX
 lId
@@ -51260,15 +51590,15 @@ bZU
 bZU
 kMy
 lEm
-wMw
-wMw
+rUB
+rUB
 xXr
-wMw
+rUB
 plm
-wMw
+rUB
 rSA
-wMw
-wMw
+rUB
+rUB
 kdf
 hyr
 htP
@@ -51402,12 +51732,12 @@ wBp
 uYJ
 dXg
 dXg
-qwQ
-qwQ
-qwQ
-qwQ
-xLB
-xOX
+lFe
+lFe
+lFe
+lFe
+bXF
+pri
 bCM
 rlI
 rlI
@@ -51442,15 +51772,15 @@ bZU
 bZU
 xsH
 mrC
-wMw
-wMw
-wMw
+rUB
+rUB
+rUB
 rSA
-wMw
+rUB
 rSA
-wMw
+rUB
 rSA
-wMw
+rUB
 sid
 hyr
 hyr
@@ -51586,17 +51916,17 @@ qwQ
 dXg
 dXg
 dXg
-qwQ
-qwQ
-eDY
-xOX
+lFe
+lFe
+dZW
+pri
 tkV
-asx
-asx
-asx
+tLL
+tLL
+tLL
 cDm
-asx
-asx
+tLL
+tLL
 paq
 wMw
 pbp
@@ -51624,15 +51954,15 @@ bZU
 bZU
 bwP
 mrC
-wMw
-wMw
-wMw
-wMw
-wMw
-wMw
+rUB
+rUB
+rUB
+rUB
+rUB
+rUB
 euH
 pLp
-wMw
+rUB
 kdf
 hyr
 hyr
@@ -51770,16 +52100,16 @@ dXg
 dXg
 dXg
 dXg
-eDY
-asx
-asx
+dZW
+tLL
+tLL
 kzo
 izB
 fZx
-asx
+tLL
 hOp
-asx
-wMw
+tLL
+rUB
 wMw
 pbp
 cYZ
@@ -51806,10 +52136,10 @@ bZU
 bZU
 miF
 mrC
-wMw
-wMw
-wMw
-wMw
+rUB
+rUB
+rUB
+rUB
 xVQ
 kyz
 kqA
@@ -51954,17 +52284,17 @@ qwQ
 dXg
 xFS
 vZR
-eha
+nWd
 dKy
 qVD
 fXu
-asx
-asx
-asx
-wMw
-wMw
-pbp
-wCc
+tLL
+tLL
+tLL
+rUB
+rUB
+xPH
+ltP
 uaV
 uaV
 nXR
@@ -51986,12 +52316,12 @@ uaV
 nXR
 fUF
 jyq
-wCc
-mrC
-wMw
-olD
-olD
-olD
+ltP
+yee
+rUB
+tzs
+tzs
+tzs
 teH
 oaO
 wns
@@ -52142,38 +52472,38 @@ bJV
 bJV
 bJV
 qTs
-asx
-asx
+tLL
+tLL
 xOI
 qoE
-olD
-olD
-olD
-olD
-olD
-olD
-olD
-olD
-olD
-olD
-olD
-olD
-olD
-olD
-olD
-olD
-olD
-olD
-olD
-olD
-olD
-olD
-olD
+tzs
+tzs
+tzs
+tzs
+tzs
+tzs
+tzs
+tzs
+tzs
+tzs
+tzs
+tzs
+tzs
+tzs
+tzs
+tzs
+tzs
+tzs
+tzs
+tzs
+tzs
+tzs
+tzs
 jgL
-mrC
-asx
-asx
-asx
+yee
+tLL
+tLL
+tLL
 kqA
 aSe
 rFv
@@ -52324,38 +52654,38 @@ qwQ
 qwQ
 pAX
 rMl
-asx
-fZB
-asx
-wMw
-wMw
-wMw
-wMw
-wMw
-wMw
-wMw
-wMw
-wMw
-wMw
-wMw
-wMw
-wMw
-wMw
-wMw
-wMw
-wMw
-wMw
-wMw
-wMw
-wMw
-wMw
-wMw
-wMw
-wMw
-mrC
-asx
-fZB
-asx
+tLL
+oeI
+tLL
+rUB
+rUB
+rUB
+rUB
+rUB
+rUB
+rUB
+rUB
+rUB
+rUB
+rUB
+rUB
+rUB
+rUB
+rUB
+rUB
+rUB
+rUB
+rUB
+rUB
+rUB
+rUB
+rUB
+rUB
+rUB
+yee
+tLL
+oeI
+tLL
 kqA
 kEB
 sSp
@@ -52506,38 +52836,38 @@ qwQ
 qwQ
 qwQ
 btU
-asx
-asx
+tLL
+tLL
 wCR
 gsQ
 icb
-wMw
-wMw
-wMw
-wMw
-wMw
-wMw
-wMw
-wMw
-wMw
-wMw
-wMw
-wMw
-wMw
-wMw
-wMw
-wMw
-wMw
-wMw
-wMw
-wMw
-wMw
-wMw
-wMw
-mrC
-asx
-dlr
-asx
+rUB
+rUB
+rUB
+rUB
+rUB
+rUB
+rUB
+rUB
+rUB
+rUB
+rUB
+rUB
+rUB
+rUB
+rUB
+rUB
+rUB
+rUB
+rUB
+rUB
+rUB
+rUB
+rUB
+yee
+tLL
+aOb
+tLL
 bgE
 pTg
 ycY
@@ -60319,46 +60649,46 @@ mPk
 mPk
 mPk
 wBp
-qwQ
-qwQ
-qwQ
-qwQ
-qwQ
-pdK
-pdK
-pdK
-pdK
+lFe
+lFe
+lFe
+lFe
+lFe
+gyg
+gyg
+gyg
+gyg
 kgp
-pdK
-pdK
+gyg
+gyg
 gVP
-aQN
+hAn
 jzB
-aQN
-geK
-qNu
-wlB
-wlB
-wlB
-ghW
-mnU
-aQN
+hAn
+xwD
+org
+aTw
+aTw
+aTw
+noE
+aYQ
+hAn
 jzB
-aQN
-geK
-wlB
-wlB
-lTg
-ghW
-wlB
-mnU
+hAn
+xwD
+aTw
+aTw
+cYf
+noE
+aTw
+aYQ
 suY
-aQN
+hAn
 hMg
-lTg
-wlB
-wlB
-res
+cYf
+aTw
+aTw
+jht
 res
 kZe
 lrR
@@ -60540,7 +60870,7 @@ aQN
 vMo
 qNu
 wlB
-wlB
+aTw
 iUH
 cel
 jks
@@ -60722,7 +61052,7 @@ lTg
 aQN
 wlB
 lTg
-wlB
+aTw
 cFw
 cel
 jks
@@ -60904,7 +61234,7 @@ kYF
 kgp
 kgp
 wlB
-ghW
+noE
 cFw
 cFw
 cFw
@@ -61450,7 +61780,7 @@ nCl
 nCl
 nCl
 aQN
-wlB
+aTw
 gDr
 ihY
 ihY
@@ -61632,7 +61962,7 @@ iQr
 iQr
 tCV
 iQr
-iQr
+wkK
 sIK
 foE
 nnb
@@ -61814,7 +62144,7 @@ tCV
 iQr
 iQr
 iQr
-tCV
+jAL
 eJN
 vuA
 vuA
@@ -61996,7 +62326,7 @@ qNu
 wlB
 wlB
 aQN
-wlB
+aTw
 aKJ
 mrR
 cFw
@@ -62178,7 +62508,7 @@ wlB
 kgp
 doH
 nCl
-bbK
+gcE
 xmL
 iUH
 icm
@@ -62360,7 +62690,7 @@ kgp
 kgp
 kgp
 nCl
-wlB
+aTw
 cFw
 tPK
 cFw
@@ -62542,7 +62872,7 @@ wlB
 gjC
 kgp
 nCl
-wlB
+aTw
 cFw
 ihY
 qkq
@@ -62724,7 +63054,7 @@ gXw
 aQN
 wlB
 lTg
-wlB
+aTw
 uAM
 ihY
 ihY
@@ -62906,7 +63236,7 @@ ghW
 wlB
 wlB
 rBq
-wlB
+aTw
 xmL
 deE
 cFw
@@ -63088,7 +63418,7 @@ wlB
 wlB
 wlB
 nCl
-wlB
+aTw
 xmL
 cFw
 cFw
@@ -63270,7 +63600,7 @@ iQr
 wlB
 lTg
 nCl
-wlB
+aTw
 iig
 jks
 cFw
@@ -63452,7 +63782,7 @@ lTg
 wlB
 hPq
 aQN
-wlB
+aTw
 xmL
 qTE
 cFw
@@ -63634,7 +63964,7 @@ iQr
 kgp
 kgp
 nCl
-wlB
+aTw
 cFw
 tPK
 cFw
@@ -63816,7 +64146,7 @@ wlB
 kgp
 kgp
 nCl
-wlB
+aTw
 cFw
 cFw
 ihY
@@ -63998,7 +64328,7 @@ iQr
 eia
 kgp
 nCl
-wlB
+aTw
 cFw
 nwq
 ihY
@@ -64180,7 +64510,7 @@ fIk
 wlB
 kgp
 nCl
-ghW
+noE
 nwq
 cFw
 cFw
@@ -64362,7 +64692,7 @@ iQr
 wlB
 kgp
 kgp
-wlB
+aTw
 cFw
 cFw
 cFw
@@ -64544,7 +64874,7 @@ bDs
 aQN
 kgp
 kgp
-wlB
+aTw
 cFw
 cFw
 xmL
@@ -64726,7 +65056,7 @@ wlB
 dOl
 kgp
 kgp
-lTg
+cYf
 cFw
 cFw
 xmL
@@ -64908,7 +65238,7 @@ iQr
 wlB
 kgp
 kgp
-wlB
+aTw
 cFw
 iUH
 wfh
@@ -65090,7 +65420,7 @@ iQr
 kgp
 kgp
 kgp
-wlB
+aTw
 cFw
 cFw
 xmL
@@ -65272,7 +65602,7 @@ iQr
 aQN
 kgp
 nCl
-lTg
+cYf
 cFw
 nwq
 lxi
@@ -65454,7 +65784,7 @@ iQr
 aQN
 wlB
 nCl
-wlB
+aTw
 cFw
 ykU
 hMI
@@ -65636,7 +65966,7 @@ iQr
 aQN
 wlB
 nCl
-wlB
+aTw
 cFw
 cFw
 wfh
@@ -65818,7 +66148,7 @@ wlB
 aQN
 aQN
 nCl
-wlB
+aTw
 cFw
 nwq
 ihY
@@ -66000,7 +66330,7 @@ lTg
 hPq
 kgp
 nCl
-wlB
+aTw
 nwq
 cFw
 ihY
@@ -66182,7 +66512,7 @@ lTg
 kgp
 kgp
 aQN
-wlB
+aTw
 kyp
 kyp
 efy
@@ -66364,7 +66694,7 @@ kgp
 kgp
 kyP
 aQN
-lTg
+cYf
 iHN
 kyp
 kyp
@@ -66546,7 +66876,7 @@ tMZ
 pvQ
 lTg
 aQN
-wlB
+aTw
 kyp
 cFh
 cFh
@@ -66728,7 +67058,7 @@ lTg
 tmZ
 tmZ
 tmZ
-dTG
+buu
 kyp
 kyp
 jTj
@@ -66910,7 +67240,7 @@ tMZ
 pTI
 rnL
 pdK
-pjD
+nbx
 jek
 jek
 jek
@@ -67092,7 +67422,7 @@ fbw
 pdK
 pdK
 pdK
-xFb
+aVC
 xFb
 xFb
 xFb
@@ -67274,7 +67604,7 @@ tMZ
 pdK
 pdK
 pdK
-dRs
+osb
 xFb
 xFb
 xFb

--- a/maps/map_files/New_Varadero/New_Varadero.dmm
+++ b/maps/map_files/New_Varadero/New_Varadero.dmm
@@ -1117,6 +1117,7 @@
 	layer = 3.1;
 	pixel_y = 10
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating/icefloor{
 	icon_state = "asteroidplating"
 	},
@@ -5644,6 +5645,13 @@
 	icon_state = "white"
 	},
 /area/varadero/interior/toilets)
+"dHc" = (
+/obj/structure/fence,
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/plating/icefloor{
+	icon_state = "asteroidplating"
+	},
+/area/varadero/exterior/lz2_near)
 "dHD" = (
 /obj/item/device/flashlight/lamp/tripod,
 /turf/open/floor/strata{
@@ -12244,6 +12252,7 @@
 	pixel_x = 18;
 	pixel_y = 23
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating/icefloor{
 	icon_state = "asteroidplating"
 	},
@@ -14022,6 +14031,10 @@
 /obj/item/device/camera_film,
 /turf/open/floor/wood,
 /area/varadero/interior/security)
+"iZi" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/gm/coast/beachcorner2/south_east,
+/area/varadero/exterior/lz2_near)
 "iZj" = (
 /obj/structure/platform/kutjevo/smooth{
 	dir = 1;
@@ -17056,6 +17069,7 @@
 	climb_delay = 1;
 	layer = 2.99
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/gm/coast/east,
 /area/varadero/exterior/lz2_near)
 "kVE" = (
@@ -20542,6 +20556,10 @@
 	icon_state = "multi_tiles"
 	},
 /area/varadero/interior_protected/vessel)
+"naI" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/gm/coast/west,
+/area/varadero/exterior/lz2_near)
 "nbx" = (
 /obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/gm/coast/beachcorner2/south_west,
@@ -22085,6 +22103,7 @@
 	icon_state = "vent4";
 	pixel_y = 25
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating/icefloor{
 	icon_state = "asteroidplating"
 	},
@@ -22913,6 +22932,13 @@
 	icon_state = "desert0"
 	},
 /area/varadero/exterior/lz1_near)
+"oDi" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/gm/river{
+	name = "shallow ocean";
+	default_name = "shallow ocean"
+	},
+/area/varadero/exterior/lz2_near)
 "oDz" = (
 /obj/structure/surface/table/reinforced/prison,
 /turf/open/floor/shiva{
@@ -33872,6 +33898,7 @@
 /obj/structure/machinery/storm_siren{
 	pixel_y = 5
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/gm/dirt,
 /area/varadero/exterior/lz2_near)
 "vzt" = (
@@ -34391,6 +34418,7 @@
 /area/varadero/exterior/lz1_near)
 "vMo" = (
 /obj/item/tool/shovel,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating/icefloor{
 	icon_state = "asteroidplating"
 	},
@@ -37698,6 +37726,11 @@
 	icon_state = "asteroidplating"
 	},
 /area/varadero/exterior/lz1_near)
+"xOY" = (
+/obj/structure/flora/bush/ausbushes/var3/ywflowers,
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/gm/dirt,
+/area/varadero/exterior/lz2_near)
 "xPj" = (
 /obj/structure/machinery/light{
 	dir = 8
@@ -60831,45 +60864,45 @@ mPk
 mPk
 mPk
 rYC
-qwQ
-lTR
-lTR
-qwQ
-qwQ
-urD
-urD
-urD
+lFe
+cyC
+cyC
+lFe
+lFe
+oDi
+oDi
+oDi
 kgp
-pdK
-pdK
-fpq
+gyg
+gyg
+iZi
 kVq
-aQN
+hAn
 hQV
-aQN
-geK
-wlB
-lTg
-wlB
-wlB
-wlB
-mnU
-aQN
+hAn
+xwD
+aTw
+cYf
+aTw
+aTw
+aTw
+aYQ
+hAn
 ocz
-aQN
-geK
-wlB
-wlB
-wlB
-wlB
-wlB
-mnU
-wlB
+hAn
+xwD
+aTw
+aTw
+aTw
+aTw
+aTw
+aYQ
+aTw
 aHw
-aQN
+hAn
 vMo
-qNu
-wlB
+org
+aTw
 aTw
 iUH
 cel
@@ -61051,7 +61084,7 @@ wlB
 lTg
 aQN
 wlB
-lTg
+cYf
 aTw
 cFw
 cel
@@ -61233,7 +61266,7 @@ aQN
 kYF
 kgp
 kgp
-wlB
+aTw
 noE
 cFw
 cFw
@@ -61779,7 +61812,7 @@ nCl
 nCl
 nCl
 nCl
-aQN
+hAn
 aTw
 gDr
 ihY
@@ -61961,7 +61994,7 @@ tCV
 iQr
 iQr
 tCV
-iQr
+wkK
 wkK
 sIK
 foE
@@ -62143,7 +62176,7 @@ aCX
 tCV
 iQr
 iQr
-iQr
+wkK
 jAL
 eJN
 vuA
@@ -62325,7 +62358,7 @@ bSQ
 qNu
 wlB
 wlB
-aQN
+hAn
 aTw
 aKJ
 mrR
@@ -62507,7 +62540,7 @@ wlB
 wlB
 kgp
 doH
-nCl
+dHc
 gcE
 xmL
 iUH
@@ -62689,7 +62722,7 @@ wlB
 kgp
 kgp
 kgp
-nCl
+dHc
 aTw
 cFw
 tPK
@@ -62871,7 +62904,7 @@ lTg
 wlB
 gjC
 kgp
-nCl
+dHc
 aTw
 cFw
 ihY
@@ -63053,7 +63086,7 @@ doH
 gXw
 aQN
 wlB
-lTg
+cYf
 aTw
 uAM
 ihY
@@ -63235,7 +63268,7 @@ wlB
 ghW
 wlB
 wlB
-rBq
+xOY
 aTw
 xmL
 deE
@@ -63417,7 +63450,7 @@ wlB
 wlB
 wlB
 wlB
-nCl
+dHc
 aTw
 xmL
 cFw
@@ -63599,7 +63632,7 @@ wlB
 iQr
 wlB
 lTg
-nCl
+dHc
 aTw
 iig
 jks
@@ -63781,7 +63814,7 @@ wlB
 lTg
 wlB
 hPq
-aQN
+hAn
 aTw
 xmL
 qTE
@@ -63963,7 +63996,7 @@ lTg
 iQr
 kgp
 kgp
-nCl
+dHc
 aTw
 cFw
 tPK
@@ -64145,7 +64178,7 @@ rhu
 wlB
 kgp
 kgp
-nCl
+dHc
 aTw
 cFw
 cFw
@@ -64327,7 +64360,7 @@ eqT
 iQr
 eia
 kgp
-nCl
+dHc
 aTw
 cFw
 nwq
@@ -64509,7 +64542,7 @@ lTg
 fIk
 wlB
 kgp
-nCl
+dHc
 noE
 nwq
 cFw
@@ -65601,7 +65634,7 @@ lTg
 iQr
 aQN
 kgp
-nCl
+dHc
 cYf
 cFw
 nwq
@@ -65783,7 +65816,7 @@ iQr
 iQr
 aQN
 wlB
-nCl
+dHc
 aTw
 cFw
 ykU
@@ -65965,7 +65998,7 @@ wlB
 iQr
 aQN
 wlB
-nCl
+dHc
 aTw
 cFw
 cFw
@@ -66147,7 +66180,7 @@ wlB
 wlB
 aQN
 aQN
-nCl
+dHc
 aTw
 cFw
 nwq
@@ -66329,7 +66362,7 @@ wlB
 lTg
 hPq
 kgp
-nCl
+dHc
 aTw
 nwq
 cFw
@@ -66511,7 +66544,7 @@ wlB
 lTg
 kgp
 kgp
-aQN
+hAn
 aTw
 kyp
 kyp
@@ -66693,7 +66726,7 @@ ayx
 kgp
 kgp
 kyP
-aQN
+hAn
 cYf
 iHN
 kyp
@@ -66875,7 +66908,7 @@ aQN
 tMZ
 pvQ
 lTg
-aQN
+hAn
 aTw
 kyp
 cFh
@@ -67057,7 +67090,7 @@ tMZ
 lTg
 tmZ
 tmZ
-tmZ
+naI
 buu
 kyp
 kyp
@@ -67239,7 +67272,7 @@ aQN
 tMZ
 pTI
 rnL
-pdK
+gyg
 nbx
 jek
 jek
@@ -67421,7 +67454,7 @@ tMZ
 fbw
 pdK
 pdK
-pdK
+gyg
 aVC
 xFb
 xFb
@@ -67603,7 +67636,7 @@ pvQ
 tMZ
 pdK
 pdK
-pdK
+gyg
 osb
 xFb
 xFb

--- a/maps/map_files/Sorokyne_Strata/Sorokyne_Strata.dmm
+++ b/maps/map_files/Sorokyne_Strata/Sorokyne_Strata.dmm
@@ -942,6 +942,7 @@
 /area/strata/ag/interior/outpost/gen/bball)
 "acN" = (
 /obj/structure/window/framed/strata/reinforced,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/strata{
 	dir = 6;
 	icon_state = "multi_tiles"
@@ -3148,6 +3149,7 @@
 /area/strata/ag/exterior/paths/cabin_area)
 "aji" = (
 /obj/structure/machinery/door/airlock/almayer/maint/colony,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/strata{
 	icon_state = "multi_tiles"
 	},
@@ -3763,6 +3765,7 @@
 /area/strata/ag/interior/dorms/flight_control)
 "akV" = (
 /obj/structure/window/framed/strata/reinforced,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/strata{
 	dir = 6;
 	icon_state = "multi_tiles"
@@ -4440,6 +4443,7 @@
 /obj/structure/pipes/standard/simple/hidden/cyan{
 	dir = 4
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/strata,
 /area/strata/ag/interior/nearlz1)
 "ank" = (
@@ -4735,6 +4739,7 @@
 /area/strata/ag/interior/landingzone_1)
 "aol" = (
 /obj/structure/pipes/standard/simple/hidden/cyan,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/strata{
 	icon_state = "floor3"
 	},
@@ -4743,6 +4748,7 @@
 /obj/structure/machinery/light/small{
 	dir = 4
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/strata,
 /area/strata/ag/interior/nearlz1)
 "aon" = (
@@ -6792,6 +6798,7 @@
 /obj/structure/pipes/standard/manifold/hidden/cyan{
 	dir = 1
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/strata{
 	icon_state = "red1"
 	},
@@ -7132,6 +7139,7 @@
 /obj/structure/pipes/vents/pump{
 	dir = 1
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/strata{
 	icon_state = "floor3"
 	},
@@ -9726,6 +9734,7 @@
 /area/strata/ug/interior/jungle/deep/north_carp)
 "aDC" = (
 /obj/effect/decal/cleanable/blood/oil,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/strata{
 	icon_state = "floor3"
 	},
@@ -10957,6 +10966,7 @@
 /obj/structure/flora/pottedplant{
 	icon_state = "pottedplant_22"
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/strata,
 /area/strata/ag/interior/nearlz1)
 "aGZ" = (
@@ -14583,6 +14593,7 @@
 /turf/open/auto_turf/snow/brown_base/layer2,
 /area/strata/ag/exterior/paths/adminext)
 "aSN" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt/cement{
 	icon_state = "cement15"
 	},
@@ -15003,6 +15014,7 @@
 /obj/structure/pipes/standard/simple/hidden/cyan{
 	dir = 5
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/strata{
 	icon_state = "floor3"
 	},
@@ -15014,6 +15026,7 @@
 /obj/structure/pipes/standard/simple/hidden/cyan{
 	dir = 9
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/strata{
 	icon_state = "floor3"
 	},
@@ -15459,6 +15472,7 @@
 "aVX" = (
 /obj/structure/platform_decoration/strata/metal,
 /obj/structure/pipes/standard/simple/hidden/cyan,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/strata,
 /area/strata/ag/interior/nearlz1)
 "aVY" = (
@@ -15845,6 +15859,7 @@
 	dir = 8
 	},
 /obj/structure/platform/strata/metal,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/strata{
 	icon_state = "floor3"
 	},
@@ -15863,6 +15878,7 @@
 	pixel_x = 28;
 	start_charge = 0
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/strata{
 	icon_state = "floor3"
 	},
@@ -26430,6 +26446,12 @@
 	icon_state = "darkyellowfull2"
 	},
 /area/strata/ag/exterior/research_decks)
+"bZw" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/asphalt/cement{
+	icon_state = "cement1"
+	},
+/area/strata/ag/interior/landingzone_1)
 "bZB" = (
 /obj/structure/pipes/standard/simple/hidden/cyan,
 /turf/open/floor/strata{
@@ -28721,6 +28743,7 @@
 /obj/structure/pipes/standard/manifold/hidden/cyan{
 	dir = 1
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/strata{
 	icon_state = "floor3"
 	},
@@ -28837,6 +28860,7 @@
 /obj/structure/platform_decoration/strata/metal{
 	dir = 4
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/strata{
 	icon_state = "red1"
 	},
@@ -28929,6 +28953,7 @@
 /area/strata/ag/interior/dorms)
 "cry" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/strata{
 	icon_state = "multi_tiles"
 	},
@@ -29064,6 +29089,7 @@
 /obj/structure/pipes/standard/manifold/hidden/cyan{
 	dir = 8
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/strata{
 	icon_state = "floor3"
 	},
@@ -30100,6 +30126,15 @@
 	},
 /turf/closed/wall/strata_outpost,
 /area/strata/ag/interior/tcomms)
+"dqj" = (
+/obj/structure/platform/strata/metal{
+	dir = 8
+	},
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/strata{
+	icon_state = "orange_cover"
+	},
+/area/strata/ag/interior/nearlz1)
 "dqo" = (
 /turf/open/auto_turf/strata_grass/layer0,
 /area/strata/ug/interior/jungle/deep/south_engi)
@@ -31459,6 +31494,10 @@
 	},
 /turf/open/auto_turf/strata_grass/layer1,
 /area/strata/ug/interior/jungle/deep/east_engi)
+"fFP" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/closed/wall/strata_outpost/reinforced,
+/area/strata/ag/interior/dorms)
 "fHp" = (
 /obj/structure/pipes/standard/simple/hidden/cyan,
 /turf/open/floor/strata{
@@ -32510,6 +32549,16 @@
 	icon_state = "floor2"
 	},
 /area/strata/ug/interior/outpost/jung/dorms/med2)
+"hpQ" = (
+/obj/structure/platform/strata/metal{
+	dir = 4
+	},
+/obj/structure/pipes/standard/simple/hidden/cyan,
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/strata{
+	icon_state = "orange_cover"
+	},
+/area/strata/ag/interior/nearlz1)
 "hqw" = (
 /obj/effect/blocker/sorokyne_cold_water,
 /obj/effect/blocker/sorokyne_cold_water,
@@ -32618,6 +32667,16 @@
 	},
 /turf/open/auto_turf/strata_grass/layer1,
 /area/strata/ug/interior/jungle/platform/east/scrub)
+"hDZ" = (
+/obj/structure/machinery/light/small{
+	dir = 1;
+	pixel_y = 20
+	},
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/strata{
+	icon_state = "floor3"
+	},
+/area/strata/ag/interior/dorms)
 "hEz" = (
 /obj/structure/janitorialcart,
 /obj/item/tool/mop,
@@ -32911,6 +32970,13 @@
 	icon_state = "floor3"
 	},
 /area/strata/ug/interior/outpost/jung/dorms/sec1)
+"iiV" = (
+/obj/structure/platform_decoration/strata/metal{
+	dir = 1
+	},
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/strata,
+/area/strata/ag/interior/nearlz1)
 "ijo" = (
 /turf/closed/wall/strata_outpost/reinforced,
 /area/strata/ag/interior/outpost/security)
@@ -33228,6 +33294,15 @@
 	icon_state = "fake_wood"
 	},
 /area/strata/ug/interior/jungle/deep/minehead)
+"iHH" = (
+/obj/structure/platform/strata/metal{
+	dir = 8
+	},
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/strata{
+	icon_state = "floor3"
+	},
+/area/strata/ag/interior/nearlz1)
 "iHX" = (
 /obj/structure/largecrate/random/case/double,
 /turf/open/floor/strata,
@@ -33696,6 +33771,10 @@
 /obj/effect/decal/strata_decals/catwalk/prison,
 /turf/open/floor/greengrid,
 /area/strata/ag/interior/restricted/devroom)
+"jvU" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/closed/wall/strata_outpost/reinforced/hull,
+/area/strata/ag/interior/dorms/hive)
 "jww" = (
 /obj/structure/sign/safety/biohazard,
 /turf/closed/wall/strata_outpost/reinforced/hull,
@@ -33940,6 +34019,11 @@
 "jUA" = (
 /turf/open/auto_turf/strata_grass/layer1,
 /area/strata/ug/interior/jungle/deep/north_carp)
+"jUI" = (
+/obj/effect/decal/strata_decals/catwalk/prison,
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/greengrid,
+/area/strata/ag/interior/nearlz1)
 "jUS" = (
 /obj/structure/flora/grass/tallgrass/ice/corner{
 	dir = 1
@@ -33997,6 +34081,15 @@
 "jWz" = (
 /turf/closed/wall/strata_outpost,
 /area/strata/ug/interior/outpost/jung/dorms/med2)
+"jXd" = (
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 4
+	},
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/strata{
+	icon_state = "floor3"
+	},
+/area/strata/ag/interior/nearlz1)
 "jXD" = (
 /obj/item/weapon/gun/revolver/cmb,
 /obj/structure/surface/rack{
@@ -34336,6 +34429,12 @@
 	icon_state = "orange_cover"
 	},
 /area/strata/ag/interior/outpost/engi/drome)
+"kAO" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/strata{
+	icon_state = "floor3"
+	},
+/area/strata/ag/interior/dorms)
 "kBL" = (
 /obj/structure/flora/grass/ice/brown/snowgrassbb_1,
 /turf/open/auto_turf/snow/brown_base/layer2,
@@ -34404,6 +34503,7 @@
 /obj/structure/window/reinforced/tinted{
 	dir = 8
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/strata{
 	icon_state = "red1"
 	},
@@ -34522,6 +34622,7 @@
 /obj/structure/window/reinforced/tinted{
 	dir = 4
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/strata,
 /area/strata/ag/interior/nearlz1)
 "kSU" = (
@@ -34659,6 +34760,10 @@
 /obj/structure/flora/grass/tallgrass/ice/corner,
 /turf/open/auto_turf/ice/layer1,
 /area/strata/ag/exterior/paths/southresearch)
+"leY" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/closed/wall/strata_outpost/reinforced,
+/area/strata/ag/interior/dorms/hive)
 "lfj" = (
 /obj/structure/barricade/handrail/strata{
 	dir = 4
@@ -34677,6 +34782,16 @@
 	},
 /turf/open/auto_turf/strata_grass/layer0,
 /area/strata/ug/interior/jungle/platform/east/scrub)
+"lgO" = (
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 4
+	},
+/obj/structure/machinery/light/small,
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/strata{
+	icon_state = "floor3"
+	},
+/area/strata/ag/interior/dorms)
 "lhH" = (
 /obj/effect/landmark/monkey_spawn,
 /turf/open/gm/dirt,
@@ -34957,6 +35072,7 @@
 /area/strata/ag/interior/landingzone_checkpoint)
 "lHs" = (
 /obj/effect/landmark/railgun_camera_pos,
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/strata,
 /area/strata/ag/interior/nearlz1)
 "lHH" = (
@@ -35399,6 +35515,12 @@
 	icon_state = "purp2"
 	},
 /area/strata/ug/interior/jungle/deep/structures/engi)
+"mkU" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/strata{
+	icon_state = "floor3"
+	},
+/area/strata/ag/interior/nearlz1)
 "mlq" = (
 /obj/structure/pipes/standard/simple/hidden/cyan{
 	dir = 4
@@ -36561,6 +36683,12 @@
 /obj/item/storage/pill_bottle/bicaridine,
 /turf/open/floor/strata,
 /area/strata/ag/interior/mountain)
+"oxW" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/strata{
+	icon_state = "red1"
+	},
+/area/strata/ag/interior/nearlz1)
 "oyu" = (
 /obj/structure/machinery/shower{
 	dir = 8
@@ -36669,6 +36797,10 @@
 	icon_state = "cement12"
 	},
 /area/strata/ug/interior/jungle/platform/east/scrub)
+"oJG" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/strata,
+/area/strata/ag/interior/nearlz1)
 "oKl" = (
 /obj/structure/flora/grass/ice/brown/snowgrassbb_3,
 /turf/open/auto_turf/snow/brown_base/layer2,
@@ -36932,6 +37064,12 @@
 	icon_state = "floor3"
 	},
 /area/strata/ag/interior/dorms)
+"phy" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/strata{
+	icon_state = "multi_tiles"
+	},
+/area/strata/ag/interior/dorms/hive)
 "piD" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/reagent_container/food/snacks/cheesecakeslice,
@@ -37372,6 +37510,13 @@
 /obj/structure/machinery/light/small,
 /turf/open/floor/strata,
 /area/strata/ag/interior/outpost/engi/drome)
+"pJj" = (
+/obj/effect/decal/strata_decals/catwalk/prison,
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/strata{
+	icon_state = "orange_cover"
+	},
+/area/strata/ag/interior/nearlz1)
 "pJu" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/comdoor/colony{
 	dir = 1;
@@ -39628,6 +39773,7 @@
 /obj/structure/bed/chair{
 	dir = 8
 	},
+/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/strata,
 /area/strata/ag/interior/nearlz1)
 "tGZ" = (
@@ -39816,6 +39962,11 @@
 	icon_state = "floor3"
 	},
 /area/strata/ag/interior/tcomms)
+"tRW" = (
+/obj/effect/decal/strata_decals/catwalk/prison,
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/greengrid,
+/area/strata/ag/interior/dorms)
 "tSb" = (
 /obj/structure/flora/grass/ice/brown/snowgrassbb_2,
 /turf/open/auto_turf/snow/brown_base/layer3,
@@ -39987,6 +40138,13 @@
 	icon_state = "darkredfull2"
 	},
 /area/strata/ag/interior/landingzone_checkpoint)
+"ubq" = (
+/obj/structure/platform/strata/metal,
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/strata{
+	icon_state = "orange_cover"
+	},
+/area/strata/ag/interior/nearlz1)
 "ubx" = (
 /obj/structure/largecrate/random,
 /obj/item/paper_bin,
@@ -40822,6 +40980,13 @@
 /obj/effect/landmark/hunter_secondary,
 /turf/open/floor/plating,
 /area/strata/ag/exterior/landingzone_2)
+"vru" = (
+/obj/effect/landmark/lv624/fog_blocker/short,
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/asphalt/cement{
+	icon_state = "cement1"
+	},
+/area/strata/ag/interior/landingzone_1)
 "vrH" = (
 /obj/structure/pipes/standard/simple/hidden/cyan{
 	dir = 4
@@ -41015,6 +41180,13 @@
 	},
 /turf/open/floor/strata,
 /area/strata/ag/interior/outpost/engi)
+"vBR" = (
+/obj/structure/bed/nest,
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/open/floor/strata{
+	icon_state = "multi_tiles"
+	},
+/area/strata/ag/interior/dorms/hive)
 "vBV" = (
 /obj/structure/machinery/light/small{
 	dir = 4
@@ -42961,9 +43133,9 @@ aIf
 aIf
 aIf
 aMA
-aIf
-aIf
-aIf
+pJj
+pJj
+pJj
 aMA
 aIf
 aNI
@@ -43157,7 +43329,7 @@ aIg
 aIg
 aSG
 aUo
-aVW
+iHH
 aXv
 aIf
 bbX
@@ -43351,9 +43523,9 @@ arR
 atp
 apc
 cmA
-cnv
-cqE
-cot
+jXd
+oJG
+iiV
 aZS
 bce
 beJ
@@ -43546,9 +43718,9 @@ crE
 crE
 crW
 cmA
-cnv
-cqE
-cqE
+jXd
+oJG
+oJG
 cqE
 cqE
 beK
@@ -43741,9 +43913,9 @@ crE
 crE
 fuA
 cmA
-cnv
-cqE
-aQv
+jXd
+oJG
+jUI
 aQv
 cqE
 acY
@@ -43936,9 +44108,9 @@ crE
 crE
 dnS
 cmA
-cnv
-cqE
-aQv
+jXd
+oJG
+jUI
 aQv
 cqE
 acY
@@ -44131,9 +44303,9 @@ crE
 crE
 aRx
 cmA
-cnv
-cqE
-cqE
+jXd
+oJG
+oJG
 cqE
 cqE
 cot
@@ -44326,9 +44498,9 @@ crE
 crE
 crW
 cmA
-cnv
-cqE
-cqE
+jXd
+oJG
+oJG
 cqE
 cqE
 cqE
@@ -44523,7 +44695,7 @@ fuA
 aSH
 coX
 aVX
-pfQ
+hpQ
 pfQ
 bcf
 cqM
@@ -44716,9 +44888,9 @@ crE
 crE
 dnS
 cmA
-cnv
-acY
-aQv
+jXd
+ubq
+jUI
 aQv
 bck
 cqE
@@ -44911,9 +45083,9 @@ crE
 crE
 aRz
 cmA
-cnv
-acY
-aQv
+jXd
+ubq
+jUI
 aQv
 bck
 beJ
@@ -45106,9 +45278,9 @@ crE
 crE
 crW
 cmA
-cnv
-cot
-aXw
+jXd
+iiV
+dqj
 aXw
 bce
 cqE
@@ -45301,8 +45473,8 @@ crE
 crE
 fuA
 cmA
-cnv
-aoj
+jXd
+mkU
 aXx
 aoj
 bco
@@ -45496,8 +45668,8 @@ crE
 crE
 dnS
 cmA
-cnv
-aoj
+jXd
+mkU
 alz
 aUr
 aUr
@@ -45691,8 +45863,8 @@ auk
 cwQ
 apc
 cmA
-cnv
-aoj
+jXd
+mkU
 aXy
 aUs
 aVY
@@ -45883,11 +46055,11 @@ apm
 apm
 apm
 apm
-apm
-apm
+vru
+bZw
 aSN
-cnv
-aoj
+jXd
+mkU
 aXy
 aUt
 cqG
@@ -46053,7 +46225,7 @@ wrp
 wrp
 wrp
 cqu
-cqE
+oJG
 coX
 aol
 aol
@@ -46082,7 +46254,7 @@ aol
 cso
 aol
 aUq
-aoj
+mkU
 aXy
 aUt
 bhK
@@ -46243,38 +46415,38 @@ aac
 aac
 aac
 crA
-exO
+phy
 acN
 akr
 akV
-alC
-cqE
+oxW
+oJG
 anj
+oJG
+oJG
 cqE
-cqE
-cqE
-cqE
-cqE
-cqE
+oJG
+oJG
+oJG
 anj
-cqE
-cqE
-cqE
-cqE
-cqE
+oJG
+oJG
+oJG
+oJG
+oJG
 lHs
+oJG
+oJG
 cqE
 cqE
-cqE
-cqE
-cqE
-cqE
-cqE
-cqE
-cqE
-cqE
-cqE
-cnv
+oJG
+oJG
+oJG
+oJG
+oJG
+oJG
+oJG
+jXd
 aSP
 aUr
 aUr
@@ -46442,34 +46614,34 @@ cry
 acN
 aks
 akV
-alC
-cqE
+oxW
+oJG
 anj
 aom
 tEY
-cqE
-cqE
+oJG
+oJG
 tEY
 kSS
 anj
-cqE
-cqE
-cqE
-cqE
-cqE
-cqE
-cqE
+oJG
+oJG
+oJG
+oJG
+oJG
+oJG
+oJG
 aom
-cqE
+oJG
 aGY
-cqE
-cqE
+oJG
+oJG
 aGY
-cqE
+oJG
 aom
-cqE
-cqE
-cnv
+oJG
+oJG
+jXd
 azx
 aUs
 aVY
@@ -46632,14 +46804,14 @@ crA
 crA
 crA
 crA
-crA
+jvU
 aji
-ddp
-ddp
-ddp
-crY
-bAI
-bCh
+leY
+leY
+leY
+fFP
+hDZ
+lgO
 ctC
 bYE
 apV
@@ -46648,11 +46820,11 @@ crY
 kIK
 aul
 avn
-cbj
-bWy
-bWy
-bWy
-bWy
+tRW
+kAO
+kAO
+kAO
+kAO
 aDC
 crY
 aFL
@@ -46662,9 +46834,9 @@ aJO
 aFL
 aFL
 crY
-aoj
-aQv
-cnv
+mkU
+jUI
+jXd
 aSQ
 aUt
 agA
@@ -46828,7 +47000,7 @@ cnO
 cnO
 cnO
 cnO
-crz
+vBR
 cnO
 cnO
 ddp


### PR DESCRIPTION
# About the pull request

This PR adds LZ fog to most maps, akin to how it functions on Chances Claim. The fog will remain in place until 15 minutes have elapsed. 

This PR also adds a slight change to Big Reds' LZ1 to slightly expand the area that can be weeded by the main LZ, mostly to give attacking xenos more resin cover to assail the meta survivor hold area. 

All changes to maps, or lack of changes, are noted here.

- 624 : No fog changes due to the general design of the landing zones makes it either impractical or unnecessary to add fog. 
- Soro: North LZ has been fogged, south LZ has no fog due to its isolation and lack of defensive ability. 
- Fiorina: Eastern LZ has a set of fog covering comms area. 
- Solaris: Northern LZ has fog covering area, plus garage. 
- Trijent / Kutjevo / New Vara: Both LZ's have fog


# Explain why it's good for the game

Fog has two main factors, it helps discourage xenos from wanting to enter the LZ, and it discourages survivors from taking defence in the highly defendable, and unweedable, landing zones. This change expands this feature to cover most maps. 


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
mapadd: Most maps now have fog that covers the landing zones, dissipates after 15 minutes. 
mapadd: Slightly expanded the area weeds can be placed on Solaris near LZ1. 
/:cl:
