### PR TITLE
Removes Stunprod from LV522

### DIFF
--- a/maps/map_files/LV522_Chances_Claim/LV522_Chances_Claim.dmm
+++ b/maps/map_files/LV522_Chances_Claim/LV522_Chances_Claim.dmm
@@ -20717,7 +20717,7 @@
 /area/lv522/atmos/cargo_intake)
 "iFe" = (
 /obj/structure/closet/crate,
-/obj/item/weapon/stunprod,
+/obj/item/weapon/classic_baton,
 /turf/open/floor/prison{
 	icon_state = "darkbrownfull2"
 	},
@@ -48141,10 +48141,7 @@
 	pixel_y = 6
 	},
 /obj/item/handcuffs,
-/obj/item/weapon/baton{
-	pixel_x = -2;
-	pixel_y = 10
-	},
+/obj/item/weapon/classic_baton,
 /turf/open/floor/prison{
 	icon_state = "darkredfull2"
 	},


### PR DESCRIPTION
# About the pull request

Removes stunprod from LV522 Chances Claim

# Explain why it's good for the game

I've been getting DM'd about this stunprod for over a week and since the synth council doesn't believe a synth stunning xenos on the frontline to be combat synthing I'm just going to remove it


Edit for the sake of a better explanation. Realistically this item should have never been on LV522 I had placed it before not knowing its fully power and I'll take responsibility for that no map should have an item with the power to stun every xeno on it regardless if it only has 6 charges or not

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:SpartanBobby
maptweak: Removes stunprod from LV522 
/:cl:
