### PR TITLE
Automatic Fireteams

### DIFF
--- a/code/game/jobs/job/marine/squad/tl.dm
+++ b/code/game/jobs/job/marine/squad/tl.dm
@@ -1,7 +1,7 @@
 /datum/job/marine/tl
 	title = JOB_SQUAD_TEAM_LEADER
-	total_positions = 8
-	spawn_positions = 8
+	total_positions = 12
+	spawn_positions = 12
 	allow_additional = 1
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT|ROLE_ADD_TO_SQUAD
 	gear_preset = /datum/equipment_preset/uscm/tl

--- a/code/game/jobs/job/marine/squads.dm
+++ b/code/game/jobs/job/marine/squads.dm
@@ -50,7 +50,7 @@
 	/// maximum # of specs allowed in the squad
 	var/max_specialists = 1
 	/// maximum # of fireteam leaders allowed in the suqad
-	var/max_tl = 2
+	var/max_tl = 3
 	/// maximum # of smartgunners allowed in the squad
 	var/max_smartgun = 1
 	/// maximum # of squad leaders allowed in the squad
@@ -453,24 +453,53 @@
 	var/list/extra_access = list()
 
 	switch(GET_DEFAULT_ROLE(M.job))
+		if(JOB_SQUAD_MARINE)	//Marines always get a random fireteam
+			var/rng_fireteam = pick("FT1", "FT2", "FT3")
+			assign_fireteam(rng_fireteam, M)
 		if(JOB_SQUAD_ENGI)
 			assignment = JOB_SQUAD_ENGI
 			num_engineers++
 			C.claimedgear = FALSE
+			switch(num_engineers)
+				if(1)			//Every squad needs 1 engineer and one medic, but FT3 lacks spec/SG so they might get an extra.
+					assign_fireteam("FT1", M)
+				if(2)
+					assign_fireteam("FT2", M)
+				else
+					assign_fireteam("FT3", M)
 		if(JOB_SQUAD_MEDIC)
 			assignment = JOB_SQUAD_MEDIC
 			num_medics++
 			C.claimedgear = FALSE
+			switch(num_medics)
+				if(1)
+					assign_fireteam("FT1", M)
+				if(2)
+					assign_fireteam("FT2", M)
+				else
+					assign_fireteam("FT3", M)
 		if(JOB_SQUAD_SPECIALIST)
 			assignment = JOB_SQUAD_SPECIALIST
 			num_specialists++
+			assign_fireteam("FT1", M)	//Specialists are always first Fireteam.
+		if(JOB_SQUAD_SMARTGUN)
+			assignment = JOB_SQUAD_SMARTGUN
+			num_smartgun++
+			assign_fireteam("FT2", M)	//Smartgunners are always second Fireteam.
 		if(JOB_SQUAD_TEAM_LEADER)
 			assignment = JOB_SQUAD_TEAM_LEADER
 			num_tl++
 			M.important_radio_channels += radio_freq
-		if(JOB_SQUAD_SMARTGUN)
-			assignment = JOB_SQUAD_SMARTGUN
-			num_smartgun++
+			switch(num_tl)
+				if(1)
+					assign_fireteam("FT1", M)			//Can't set FTL without adding to fireteam. I tried - Kitsunemitu
+					assign_ft_leader("FT1", M)
+				if(2)
+					assign_fireteam("FT2", M)
+					assign_ft_leader("FT2", M)
+				if(3)
+					assign_fireteam("FT3", M)		
+					assign_ft_leader("FT3", M)
 		if(JOB_SQUAD_LEADER)
 			if(squad_leader && GET_DEFAULT_ROLE(squad_leader.job) != JOB_SQUAD_LEADER) //field promoted SL
 				var/old_lead = squad_leader

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -567,6 +567,7 @@
 
 /obj/item/device/radio/headset/almayer/marine
 	initial_keys = list(/obj/item/device/encryptionkey/public)
+	locate_setting = TRACKER_FTL	//Tracks FTL by default; FTLs track SLs.
 
 //############################## ALPHA ###############################
 /obj/item/device/radio/headset/almayer/marine/alpha
@@ -580,12 +581,14 @@
 	desc = "This is used by the marine Alpha squad leader. Channels are as follows: :v - marine command, :j - JTAC. When worn, grants access to Squad Leader tracker. Click tracker with empty hand to open Squad Info window."
 	initial_keys = list(/obj/item/device/encryptionkey/public, /obj/item/device/encryptionkey/squadlead)
 	volume = RADIO_VOLUME_CRITICAL
+	locate_setting = TRACKER_SL
 
 /obj/item/device/radio/headset/almayer/marine/alpha/tl
 	name = "marine alpha team leader radio headset"
 	desc = "This is used by the marine Alpha team leader. Channels are as follows: :u - requisitions, :j - JTAC. When worn, grants access to Squad Leader tracker. Click tracker with empty hand to open Squad Info window."
 	initial_keys = list(/obj/item/device/encryptionkey/public, /obj/item/device/encryptionkey/jtac)
 	volume = RADIO_VOLUME_RAISED
+	locate_setting = TRACKER_SL
 
 /obj/item/device/radio/headset/almayer/marine/alpha/engi
 	name = "marine alpha engineer radio headset"
@@ -609,12 +612,14 @@
 	desc = "This is used by the marine Bravo squad leader. Channels are as follows: :v - marine command, :j - JTAC. When worn, grants access to Squad Leader tracker. Click tracker with empty hand to open Squad Info window."
 	initial_keys = list(/obj/item/device/encryptionkey/public, /obj/item/device/encryptionkey/squadlead)
 	volume = RADIO_VOLUME_CRITICAL
+	locate_setting = TRACKER_SL
 
 /obj/item/device/radio/headset/almayer/marine/bravo/tl
 	name = "marine bravo team leader radio headset"
 	desc = "This is used by the marine Bravo team leader. Channels are as follows: :u - requisitions, :j - JTAC. When worn, grants access to Squad Leader tracker. Click tracker with empty hand to open Squad Info window."
 	initial_keys = list(/obj/item/device/encryptionkey/public, /obj/item/device/encryptionkey/jtac)
 	volume = RADIO_VOLUME_RAISED
+	locate_setting = TRACKER_SL
 
 /obj/item/device/radio/headset/almayer/marine/bravo/engi
 	name = "marine bravo engineer radio headset"
@@ -638,12 +643,14 @@
 	desc = "This is used by the marine Charlie squad leader. Channels are as follows: :v - marine command, :j - JTAC. When worn, grants access to Squad Leader tracker. Click tracker with empty hand to open Squad Info window."
 	initial_keys = list(/obj/item/device/encryptionkey/public, /obj/item/device/encryptionkey/squadlead)
 	volume = RADIO_VOLUME_CRITICAL
+	locate_setting = TRACKER_SL
 
 /obj/item/device/radio/headset/almayer/marine/charlie/tl
 	name = "marine charlie team leader radio headset"
 	desc = "This is used by the marine Charlie team leader. Channels are as follows: :u - requisitions, :j - JTAC. When worn, grants access to Squad Leader tracker. Click tracker with empty hand to open Squad Info window."
 	initial_keys = list(/obj/item/device/encryptionkey/public, /obj/item/device/encryptionkey/jtac)
 	volume = RADIO_VOLUME_RAISED
+	locate_setting = TRACKER_SL
 
 /obj/item/device/radio/headset/almayer/marine/charlie/engi
 	name = "marine charlie engineer radio headset"
@@ -667,12 +674,14 @@
 	desc = "This is used by the marine Delta squad leader. Channels are as follows: :v - marine command, :j - JTAC. When worn, grants access to Squad Leader tracker. Click tracker with empty hand to open Squad Info window."
 	initial_keys = list(/obj/item/device/encryptionkey/public, /obj/item/device/encryptionkey/squadlead)
 	volume = RADIO_VOLUME_CRITICAL
+	locate_setting = TRACKER_SL
 
 /obj/item/device/radio/headset/almayer/marine/delta/tl
 	name = "marine delta team leader radio headset"
 	desc = "This is used by the marine Delta team leader. Channels are as follows: :u - requisitions, :j - JTAC. When worn, grants access to Squad Leader tracker. Click tracker with empty hand to open Squad Info window."
 	initial_keys = list(/obj/item/device/encryptionkey/public, /obj/item/device/encryptionkey/jtac)
 	volume = RADIO_VOLUME_RAISED
+	locate_setting = TRACKER_SL
 
 /obj/item/device/radio/headset/almayer/marine/delta/engi
 	name = "marine delta engineer radio headset"
@@ -696,12 +705,14 @@
 	desc = "This is used by the marine Echo squad leader. Channels are as follows: :v - marine command, :j - JTAC. When worn, grants access to Squad Leader tracker. Click tracker with empty hand to open Squad Info window."
 	initial_keys = list(/obj/item/device/encryptionkey/public, /obj/item/device/encryptionkey/squadlead)
 	volume = RADIO_VOLUME_CRITICAL
+	locate_setting = TRACKER_SL
 
 /obj/item/device/radio/headset/almayer/marine/echo/tl
 	name = "marine echo team leader radio headset"
 	desc = "This is used by the marine Echo team leader. Channels are as follows: :u - requisitions, :j - JTAC. When worn, grants access to Squad Leader tracker. Click tracker with empty hand to open Squad Info window."
 	initial_keys = list(/obj/item/device/encryptionkey/public, /obj/item/device/encryptionkey/jtac)
 	volume = RADIO_VOLUME_RAISED
+	locate_setting = TRACKER_SL
 
 /obj/item/device/radio/headset/almayer/marine/echo/engi
 	name = "marine echo engineer radio headset"
@@ -726,12 +737,14 @@
 	desc = "This is used by the marine Foxtrot squad leader. Channels are as follows: :v - marine command, :j - JTAC. When worn, grants access to Squad Leader tracker. Click tracker with empty hand to open Squad Info window."
 	initial_keys = list(/obj/item/device/encryptionkey/public, /obj/item/device/encryptionkey/squadlead)
 	volume = RADIO_VOLUME_CRITICAL
+	locate_setting = TRACKER_SL
 
 /obj/item/device/radio/headset/almayer/marine/cryo/tl
 	name = "marine foxtrot team leader radio headset"
 	desc = "This is used by the marine Foxtrot team leader. Channels are as follows: :u - requisitions, :j - JTAC. When worn, grants access to Squad Leader tracker. Click tracker with empty hand to open Squad Info window."
 	initial_keys = list(/obj/item/device/encryptionkey/public, /obj/item/device/encryptionkey/jtac)
 	volume = RADIO_VOLUME_RAISED
+	locate_setting = TRACKER_SL
 
 /obj/item/device/radio/headset/almayer/marine/cryo/engi
 	name = "marine foxtrot engineer radio headset"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request
Adds in 4 more fireteam leaders, one for each squad.
Marines automatically have their headset swapped to FTL instead of SL.

### Sets up automatic Fireteams along this scheme:
Fireteam Leaders, Medics and Engis - Fill FT1 > FT2 > FT3
Specialist - FT1
Smartgunner - FT2
Marines - Fill randomly.

### Possible Alternative 1
Fill FTLs in FT3 > FT2 > FT1
Set Spec/SG to FTL until one wakes up

### Possible Alternative 2
Remove FTL role Slot back to 2 per round, Fill FTL1 and FTL2.
SG fills FTL3. (Possible bump back to CPL just like the good old days)
Spec goes to FT3
Marines are half as likely to join FT3.


# Explain why it's good for the game
FTL is just a Cpl rank PFC+. This PR makes them more useful by automatically assigning Fireteams, and encourages Marines to stick with their FTL by automatically setting their headsets.
This may lead to a more Platoon-like structure, with smaller squad-like cells.

I would at least like a test on this.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>
Example of auto-generated Squad.
![image](https://github.com/cmss13-devs/cmss13/assets/77302679/cd72a012-bb9b-439f-8eeb-542acd5f8027)

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
add: Marines are now automatically added into fireteams.
balance: Headsets track FTL instead of SL by default, except on the FTLs and SLs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
