### PR TITLE
Eggsac carrier revival

### DIFF
--- a/code/modules/cm_aliens/structures/egg.dm
+++ b/code/modules/cm_aliens/structures/egg.dm
@@ -320,12 +320,28 @@ SPECIAL EGG USED BY EGG CARRIER
 	else
 		//Die after maximum lifetime
 		life_timer = addtimer(CALLBACK(src, PROC_REF(remove_owner_and_decay)), CARRIER_EGG_MAXIMUM_LIFE, TIMER_STOPPABLE)
+		set_owner(planter)
 
-/obj/effect/alien/egg/carrier_egg/proc/remove_owner_and_decay()
+/obj/effect/alien/egg/carrier_egg/Destroy()
+	. = ..()
+	remove_owner()
+	if(life_timer)
+		deltimer(life_timer)
+
+/obj/effect/alien/egg/carrier_egg/proc/set_owner(mob/living/carbon/xenomorph/carrier/planter)
+	var/datum/behavior_delegate/carrier_eggsac/my_delegate = planter.behavior_delegate
+	my_delegate.eggs_sustained += src
+	owner = planter
+
+/obj/effect/alien/egg/carrier_egg/proc/remove_owner()
 	if(owner)
 		var/mob/living/carbon/xenomorph/carrier/my_owner = owner
 		var/datum/behavior_delegate/carrier_eggsac/my_delegate = my_owner.behavior_delegate
-		my_delegate.eggs_sustained += src
+		my_delegate.eggs_sustained -= src
+		owner = null
+
+/obj/effect/alien/egg/carrier_egg/proc/remove_owner_and_decay()
+	remove_owner()
 	start_unstoppable_decay()
 
 /obj/effect/alien/egg/carrier_egg/proc/check_decay()
@@ -335,7 +351,13 @@ SPECIAL EGG USED BY EGG CARRIER
 
 /obj/effect/alien/egg/carrier_egg/proc/start_unstoppable_decay()
 	addtimer(CALLBACK(src, PROC_REF(Burst), TRUE), 10 SECONDS)
-	deltimer(life_timer)
+	if(life_timer)
+		deltimer(life_timer)
+
+/obj/effect/alien/egg/carrier_egg/Burst(kill, instant_trigger, mob/living/carbon/xenomorph/X, is_hugger_player_controlled)
+	. = ..()
+	remove_owner()
+
 
 #undef CARRIER_EGG_UNSUSTAINED_LIFE
 #undef CARRIER_EGG_MAXIMUM_LIFE

--- a/code/modules/cm_aliens/structures/egg.dm
+++ b/code/modules/cm_aliens/structures/egg.dm
@@ -323,15 +323,16 @@ SPECIAL EGG USED BY EGG CARRIER
 		set_owner(planter)
 
 /obj/effect/alien/egg/carrier_egg/Destroy()
-	. = ..()
 	if(life_timer)
 		deltimer(life_timer)
+	owner = null
+	. = ..()
 
+/// Set the owner of the egg to the planter.
 /obj/effect/alien/egg/carrier_egg/proc/set_owner(mob/living/carbon/xenomorph/carrier/planter)
 	var/datum/behavior_delegate/carrier_eggsac/my_delegate = planter.behavior_delegate
 	my_delegate.eggs_sustained += src
 	owner = planter
-	RegisterSignal(owner, COMSIG_PARENT_QDELETING, PROC_REF(cleanup_owner))
 
 ///Check the last refreshed time and burst the egg if we're over the lifetime of the egg
 /obj/effect/alien/egg/carrier_egg/proc/check_decay()
@@ -346,10 +347,4 @@ SPECIAL EGG USED BY EGG CARRIER
 
 /obj/effect/alien/egg/carrier_egg/Burst(kill, instant_trigger, mob/living/carbon/xenomorph/X, is_hugger_player_controlled)
 	. = ..()
-	UnregisterSignal(owner, COMSIG_PARENT_QDELETING)
 	owner = null
-
-/obj/effect/alien/egg/carrier_egg/proc/cleanup_owner()
-	SIGNAL_HANDLER
-	owner = null
-

--- a/code/modules/cm_aliens/structures/egg.dm
+++ b/code/modules/cm_aliens/structures/egg.dm
@@ -307,8 +307,11 @@ SPECIAL EGG USED BY EGG CARRIER
 /obj/effect/alien/egg/carrier_egg
 	name = "fragile egg"
 	desc = "It looks like a weird, fragile egg."
+	///Owner of the fragile egg, must be a mob/living/carbon/xenomorph/carrier
 	var/mob/living/carbon/xenomorph/carrier/owner = null
+	///Time that the carrier was last within refresh range of the egg (14 tiles)
 	var/last_refreshed = null
+	/// Timer holder for the maximum lifetime of the egg as defined CARRIER_EGG_MAXIMUM_LIFE
 	var/life_timer = null
 
 /obj/effect/alien/egg/carrier_egg/Initialize(mapload, hivenumber, planter = null)
@@ -326,7 +329,7 @@ SPECIAL EGG USED BY EGG CARRIER
 	if(life_timer)
 		deltimer(life_timer)
 	owner = null
-	. = ..()
+	return ..()
 
 /// Set the owner of the egg to the planter.
 /obj/effect/alien/egg/carrier_egg/proc/set_owner(mob/living/carbon/xenomorph/carrier/planter)

--- a/code/modules/cm_aliens/structures/egg.dm
+++ b/code/modules/cm_aliens/structures/egg.dm
@@ -338,6 +338,7 @@ SPECIAL EGG USED BY EGG CARRIER
 	if(last_refreshed + CARRIER_EGG_UNSUSTAINED_LIFE < world.time)
 		start_unstoppable_decay()
 
+///Burst the egg without hugger release after a 10 second timer & remove the life timer.
 /obj/effect/alien/egg/carrier_egg/proc/start_unstoppable_decay()
 	addtimer(CALLBACK(src, PROC_REF(Burst), TRUE), 10 SECONDS)
 	if(life_timer)
@@ -345,8 +346,8 @@ SPECIAL EGG USED BY EGG CARRIER
 
 /obj/effect/alien/egg/carrier_egg/Burst(kill, instant_trigger, mob/living/carbon/xenomorph/X, is_hugger_player_controlled)
 	. = ..()
+	UnregisterSignal(owner, COMSIG_PARENT_QDELETING)
 	owner = null
-
 
 /obj/effect/alien/egg/carrier_egg/proc/cleanup_owner()
 	SIGNAL_HANDLER

--- a/code/modules/cm_aliens/structures/egg.dm
+++ b/code/modules/cm_aliens/structures/egg.dm
@@ -328,7 +328,12 @@ SPECIAL EGG USED BY EGG CARRIER
 /obj/effect/alien/egg/carrier_egg/Destroy()
 	if(life_timer)
 		deltimer(life_timer)
-	owner = null
+	//Remove reference to src in owner's behavior_delegate and set owner to null
+	if(owner)
+		var/mob/living/carbon/xenomorph/carrier/my_owner = owner
+		var/datum/behavior_delegate/carrier_eggsac/behavior = my_owner.behavior_delegate
+		behavior.eggs_sustained -= src
+		my_owner = null
 	return ..()
 
 /// Set the owner of the egg to the planter.

--- a/code/modules/cm_aliens/structures/egg.dm
+++ b/code/modules/cm_aliens/structures/egg.dm
@@ -309,7 +309,7 @@ SPECIAL EGG USED BY EGG CARRIER
 	desc = "It looks like a weird, fragile egg."
 	var/owner = null
 	var/last_refreshed = null
-	var/life_timer
+	var/life_timer = null
 
 /obj/effect/alien/egg/carrier_egg/Initialize(mapload, hivenumber, planter = null)
 	. = ..()

--- a/code/modules/mob/living/carbon/xenomorph/egg_item.dm
+++ b/code/modules/mob/living/carbon/xenomorph/egg_item.dm
@@ -98,7 +98,7 @@
 		to_chat(user, SPAN_XENOWARNING("[src] must be planted on [lowertext(hive.prefix)]weeds."))
 		return
 
-	if(!hive_weeds)
+	if(!hive_weeds && user.mutation_type != CARRIER_EGGSAC)
 		to_chat(user, SPAN_XENOWARNING("[src] can only be planted on [lowertext(hive.prefix)]hive weeds."))
 		return
 
@@ -117,9 +117,16 @@
 		return
 
 	for(var/obj/effect/alien/weeds/weed in T)
-		if(weed.weed_strength >= WEED_LEVEL_HIVE)
+		if(weed.weed_strength >= WEED_LEVEL_HIVE || user.mutation_type == CARRIER_EGGSAC)
 			user.use_plasma(30)
-			var/obj/effect/alien/egg/newegg = new /obj/effect/alien/egg(T, hivenumber)
+			var/obj/effect/alien/egg/newegg
+			if(weed.weed_strength >= WEED_LEVEL_HIVE)
+				newegg = new /obj/effect/alien/egg(T, hivenumber)
+			else if(weed.weed_strength == WEED_LEVEL_STANDARD)
+				newegg = new /obj/effect/alien/egg/carrier_egg(T,hivenumber, user)
+			else
+				to_chat(user, SPAN_XENOWARNING("[src] can't be planted on these weeds."))
+				return
 
 			newegg.flags_embryo = flags_embryo
 

--- a/code/modules/mob/living/carbon/xenomorph/mutators/strains/carrier/eggsac.dm
+++ b/code/modules/mob/living/carbon/xenomorph/mutators/strains/carrier/eggsac.dm
@@ -53,7 +53,8 @@
 	var/sustain_distance = 14
 
 /datum/behavior_delegate/carrier_eggsac/append_to_stat()
-	. = "Eggs sustained: [length(eggs_sustained)] / [egg_sustain_cap]"
+	. = list()
+	. += "Eggs sustained: [length(eggs_sustained)] / [egg_sustain_cap]"
 
 /datum/behavior_delegate/carrier_eggsac/on_life()
 	if(length(eggs_sustained) > egg_sustain_cap)

--- a/code/modules/mob/living/carbon/xenomorph/mutators/strains/carrier/eggsac.dm
+++ b/code/modules/mob/living/carbon/xenomorph/mutators/strains/carrier/eggsac.dm
@@ -86,6 +86,11 @@
 		remove_egg_owner(my_egg)
 		my_egg.start_unstoppable_decay()
 
+///Remove all references to src in eggs_sustained
+/datum/behavior_delegate/carrier_eggsac/Destroy()
+	for(var/obj/effect/alien/egg/carrier_egg/my_egg as anything in eggs_sustained)
+		my_egg.owner = null
+
 /datum/action/xeno_action/active_toggle/generate_egg
 	name = "Generate Eggs (50)"
 	action_icon_state = "lay_egg"

--- a/code/modules/mob/living/carbon/xenomorph/mutators/strains/carrier/eggsac.dm
+++ b/code/modules/mob/living/carbon/xenomorph/mutators/strains/carrier/eggsac.dm
@@ -90,6 +90,7 @@
 /datum/behavior_delegate/carrier_eggsac/Destroy()
 	for(var/obj/effect/alien/egg/carrier_egg/my_egg as anything in eggs_sustained)
 		my_egg.owner = null
+	return ..()
 
 /datum/action/xeno_action/active_toggle/generate_egg
 	name = "Generate Eggs (50)"

--- a/code/modules/mob/living/carbon/xenomorph/mutators/strains/carrier/eggsac.dm
+++ b/code/modules/mob/living/carbon/xenomorph/mutators/strains/carrier/eggsac.dm
@@ -1,5 +1,3 @@
-#define EGGSAC_OFF_WEED_EGGCAP 4
-
 /datum/xeno_mutator/eggsac
 	name = "STRAIN: Carrier - Eggsac"
 	description = "In exchange for your ability to store huggers and place traps, you gain larger plasma stores, strong pheromones, and the ability to lay eggs by using your plasma stores. In addition, you can now carry twelve eggs at once and can place eggs one pace further than normal. \n\nYou can also place a small number of fragile eggs on normal weeds. These eggs have a lifetime of five minutes while you remain within 14 tiles. Or one minute if you leave this range."
@@ -46,11 +44,17 @@
 	apply_behavior_holder(carrier)
 	return TRUE
 
+#define EGGSAC_OFF_WEED_EGGCAP 4
+#define EGGSAC_EGG_SUSTAIN_DISTANCE 14
+
 /datum/behavior_delegate/carrier_eggsac
 	name = "Eggsac Carrier Behavior Delegate"
+	///List of /obj/effect/alien/egg/carrier_egg sustained by the carrier on normal weeds
 	var/list/eggs_sustained = list()
+	///Total number of eggs which can be sustained defined as EGGSAC_OFF_WEED_EGGCAP
 	var/egg_sustain_cap = EGGSAC_OFF_WEED_EGGCAP
-	var/sustain_distance = 14
+	///Distance from the egg that the carrier can go before it stops sustaining it
+	var/sustain_distance = EGGSAC_EGG_SUSTAIN_DISTANCE
 
 /datum/behavior_delegate/carrier_eggsac/append_to_stat()
 	. = list()
@@ -119,3 +123,4 @@
 				xeno.update_icons()
 
 #undef EGGSAC_OFF_WEED_EGGCAP
+#undef EGGSAC_EGG_SUSTAIN_DISTANCE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

[Forum Thread](https://forum.cm-ss13.com/t/eggsac-carrier-revival/4711)

# About the pull request

The concept of this PR is to find a middle ground between the current eggsac carrier and the pre #4459 eggsac carrier.

This PR will make the following changes. (From this point "normal weeds" can be substituted for "off hive weeds" Placing eggs on hive weeds is **unchanged**.)

- Eggsac carrier can once again place eggs on normal weeds.
- Eggsac carrier can only place 4 eggs at once on normal weeds.
- If the Eggsac places more than 4 eggs on normal weeds, their oldest placed egg will die. No hugger release.
- Eggs placed on normal weeds have a maximum lifetime of 5 MINUTES after which they will die. No hugger release.
- Eggs placed on normal weeds have a 1 MINUTE life whilst the carrier is further than 14 tiles away from them.
- If the carrier dies, all of their sustained eggs die.

# Explain why it's good for the game

Eggsac carrier at the moment is in a bit of a poor place and has gone from being very strong to quite poor. Considering the limitation of having to place only on hive weeds.
The majority of feedback I read against eggsac carrier was with the quantity of eggs able to be placed, as well as the locations they can be placed in, all across the map and with impunity.

This PR aims to address those concerns to make the eggsac both less infuriating to play against while still being satisfying to play as a frontline support or as a stealthy trapper.

Eggs can no longer be placed all over the map because of the 4 egg limit off weeds, so the carrier has to think where they want to impact the map. The carrier also has to stay within a reasonable distance to where they are impacting with their eggs which localises their impact to their immediate play area. The carrier also has to be more reactive to current events as they cannot place an egg which then becomes useful 30 minutes later.

Killing the carrier also has a small reward as in addition to removing a xeno from the game, the eggs they are sustaining are cleared. If a carrier is supporting the front and dies, the marines don't then have to clear X number of eggs AFTER the kill.

# Testing Photographs and Procedure

1. Spawn as egg carrier.
2. Plant egg on normal weeds.
3. Move 15+ tiles away.
4. Wait 1 minute
5. OR Wait 5 minutes within 14 tiles.
6. Kill the carrier.

The 5 minute lifetime of the eggs will also clear the eggs in the case that the carrier is admin deleted, or some other weird stuff happens which doesn't result in a death. This will also catch carriers de-evolving

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
add: Eggsac carrier can now place eggs on normal weeds to a maximum of 4 eggs.
add: Eggsac carrier eggs on normal weeds have an expiry date.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
