### PR TITLE
Fixes deleted mobs not unbuckling

### DIFF
--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -226,9 +226,14 @@
 /obj/proc/afterbuckle(mob/M as mob) // Called after somebody buckled / unbuckled
 	handle_rotation()
 	SEND_SIGNAL(src, COSMIG_OBJ_AFTER_BUCKLE, buckled_mob)
+	if(!buckled_mob)
+		UnregisterSignal(M, COMSIG_PARENT_QDELETING)
+	else
+		RegisterSignal(buckled_mob, COMSIG_PARENT_QDELETING, PROC_REF(unbuckle))
 	return buckled_mob
 
 /obj/proc/unbuckle()
+	SIGNAL_HANDLER
 	if(buckled_mob && buckled_mob.buckled == src)
 		buckled_mob.buckled = null
 		buckled_mob.anchored = initial(buckled_mob.anchored)


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

This makes mobs unbuckle on deletion.

Why this matters:
 - Leftover references as buckled_mob on the buckled object
 - The object cannot be used by someone else, since someone is still buckled to it
 - In most extreme case eg. shuttle chairs, the shuttle will pull the deleted mob out of nullspace and back to chair when traveling

# Explain why it's good for the game
Less bugs and less confused admins having to re-spawn an entire tank over it

# Testing Photographs and Procedure
Tested buckling/deleting without errors
