### PR TITLE
Fix a source of bad icon operations

### DIFF
--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -774,14 +774,14 @@ world
 
 	/* Debugguing due to gamebreaking performance in the Blend calls made by getFlatIcon (think 200ms+ per icon) and overtimes */
 	if(istype(thing, /atom))
-		var/atom/dir = thing
-		log_debug("costly_icon2html called on ref=[REF(dir)], instance=[dir], type=[dir.type], with [length(dir.overlays)] overlays, finished in [(REALTIMEOFDAY-start_time) / 10]s")
+		var/atom/D = thing
+		log_debug("costly_icon2html called on ref=[REF(D)], instance=[D], type=[D.type], with [length(D.overlays)] overlays, finished in [(REALTIMEOFDAY-start_time) / 10]s")
 	else if(isicon(thing))
-		var/icon/dir = thing
-		log_debug("costly_icon2html called on icon ref=[REF(dir)], instance=[dir] finished in [(REALTIMEOFDAY-start_time) / 10]s")
+		var/icon/D = thing
+		log_debug("costly_icon2html called on icon ref=[REF(D)], instance=[D] finished in [(REALTIMEOFDAY-start_time) / 10]s")
 	else
-		var/datum/dir = thing
-		log_debug("costly_icon2html called on unknown ref=[REF(dir)], instance=[dir], type=[dir.type]")
+		var/datum/D = thing
+		log_debug("costly_icon2html called on unknown ref=[REF(D)], instance=[D], type=[D.type]")
 
 /// Generate a filename for this asset
 /// The same asset will always lead to the same asset name

--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -876,13 +876,24 @@ world
 	return image_to_center
 
 //For creating consistent icons for human looking simple animals
-/proc/get_flat_human_icon(icon_id, datum/equipment_preset/preset, datum/preferences/prefs, dummy_key, showDirs = GLOB.cardinals, outfit_override)
+/proc/get_flat_human_icon(icon_id, equipment_preset_dresscode, datum/preferences/prefs, dummy_key, showDirs = GLOB.cardinals, outfit_override)
 	var/static/list/humanoid_icon_cache = list()
 	if(!icon_id || !humanoid_icon_cache[icon_id])
 		var/mob/living/carbon/human/dummy/body = generate_or_wait_for_human_dummy(dummy_key)
+
 		if(prefs)
 			prefs.copy_all_to(body)
-		arm_equipment(body, preset)
+			body.update_body()
+			body.update_hair()
+
+		// Assumption: Is a list
+		if(outfit_override)
+			for(var/obj/item/cur_item as anything in outfit_override)
+				body.equip_to_appropriate_slot(cur_item)
+
+		// Assumption: Is a string or path
+		if(equipment_preset_dresscode)
+			arm_equipment(body, equipment_preset_dresscode)
 
 		var/icon/out_icon = icon('icons/effects/effects.dmi', "nothing")
 		for(var/D in showDirs)
@@ -895,3 +906,63 @@ world
 		return out_icon
 	else
 		return humanoid_icon_cache[icon_id]
+
+/proc/get_flat_human_copy_icon(mob/living/carbon/human/original, equipment_preset_dresscode, showDirs = GLOB.cardinals, outfit_override)
+	var/mob/living/carbon/human/dummy/body = generate_or_wait_for_human_dummy(null)
+
+	if(original)
+		// From /datum/preferences/proc/copy_appearance_to
+		body.age = original.age
+		body.gender = original.gender
+		body.ethnicity = original.ethnicity
+		body.body_type = original.body_type
+
+		body.r_eyes = original.r_eyes
+		body.g_eyes = original.g_eyes
+		body.b_eyes = original.b_eyes
+
+		body.r_hair = original.r_hair
+		body.g_hair = original.g_hair
+		body.b_hair = original.b_hair
+
+		body.r_gradient = original.r_gradient
+		body.g_gradient = original.g_gradient
+		body.b_gradient = original.b_gradient
+		body.grad_style = original.grad_style
+
+		body.r_facial = original.r_facial
+		body.g_facial = original.g_facial
+		body.b_facial = original.b_facial
+
+		body.r_skin = original.r_skin
+		body.g_skin = original.g_skin
+		body.b_skin = original.b_skin
+
+		body.h_style = original.h_style
+		body.f_style = original.f_style
+
+		body.underwear = original.underwear
+		body.undershirt = original.undershirt
+
+		body.update_body()
+		body.update_hair()
+
+	// Assumption: Is a list
+	if(outfit_override)
+		for(var/obj/item/cur_item as anything in outfit_override)
+			body.equip_to_appropriate_slot(cur_item)
+
+	// Assumption: Is a string or path
+	if(equipment_preset_dresscode)
+		arm_equipment(body, equipment_preset_dresscode)
+
+	var/icon/out_icon = icon('icons/effects/effects.dmi', "nothing")
+	for(var/D in showDirs)
+		body.setDir(D)
+		var/icon/partial = getFlatIcon(body)
+		out_icon.Insert(partial, dir = D)
+
+	// log_debug("get_flat_human_copy_icon called on ref=[REF(original)], instance=[original], type=[original.type], with [length(original.overlays)] overlays reduced to [length(body.overlays)] overlays")
+
+	qdel(body)
+	return out_icon

--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -774,14 +774,14 @@ world
 
 	/* Debugguing due to gamebreaking performance in the Blend calls made by getFlatIcon (think 200ms+ per icon) and overtimes */
 	if(istype(thing, /atom))
-		var/atom/D = thing
-		log_debug("costly_icon2html called on ref=[REF(D)], instance=[D], type=[D.type], with [length(D.overlays)] overlays, finished in [(REALTIMEOFDAY-start_time) / 10]s")
+		var/atom/dir = thing
+		log_debug("costly_icon2html called on ref=[REF(dir)], instance=[dir], type=[dir.type], with [length(dir.overlays)] overlays, finished in [(REALTIMEOFDAY-start_time) / 10]s")
 	else if(isicon(thing))
-		var/icon/D = thing
-		log_debug("costly_icon2html called on icon ref=[REF(D)], instance=[D] finished in [(REALTIMEOFDAY-start_time) / 10]s")
+		var/icon/dir = thing
+		log_debug("costly_icon2html called on icon ref=[REF(dir)], instance=[dir] finished in [(REALTIMEOFDAY-start_time) / 10]s")
 	else
-		var/datum/D = thing
-		log_debug("costly_icon2html called on unknown ref=[REF(D)], instance=[D], type=[D.type]")
+		var/datum/dir = thing
+		log_debug("costly_icon2html called on unknown ref=[REF(dir)], instance=[dir], type=[dir.type]")
 
 /// Generate a filename for this asset
 /// The same asset will always lead to the same asset name
@@ -896,10 +896,10 @@ world
 			arm_equipment(body, equipment_preset_dresscode)
 
 		var/icon/out_icon = icon('icons/effects/effects.dmi', "nothing")
-		for(var/D in showDirs)
-			body.setDir(D)
+		for(var/dir in showDirs)
+			body.setDir(dir)
 			var/icon/partial = getFlatIcon(body)
-			out_icon.Insert(partial, dir = D)
+			out_icon.Insert(partial, dir = dir)
 
 		humanoid_icon_cache[icon_id] = out_icon
 		dummy_key ? unset_busy_human_dummy(dummy_key) : qdel(body)
@@ -957,10 +957,10 @@ world
 		arm_equipment(body, equipment_preset_dresscode)
 
 	var/icon/out_icon = icon('icons/effects/effects.dmi', "nothing")
-	for(var/D in showDirs)
-		body.setDir(D)
+	for(var/dir in showDirs)
+		body.setDir(dir)
 		var/icon/partial = getFlatIcon(body)
-		out_icon.Insert(partial, dir = D)
+		out_icon.Insert(partial, dir = dir)
 
 	// log_debug("get_flat_human_copy_icon called on ref=[REF(original)], instance=[original], type=[original.type], with [length(original.overlays)] overlays reduced to [length(body.overlays)] overlays")
 

--- a/code/controllers/subsystem/statpanel.dm
+++ b/code/controllers/subsystem/statpanel.dm
@@ -313,14 +313,39 @@ SUBSYSTEM_DEF(statpanels)
 	for(index in 1 to length(to_make))
 		var/atom/thing = to_make[index]
 
+		// var/start_time = REALTIMEOFDAY
 		var/generated_string
-		/* We're cheap and won't render all overlays. It's expensive and updates with onmob changes!
-		if(ismob(thing) || length(thing.overlays) > 2)
-			generated_string = costly_icon2html(thing, parent, sourceonly=TRUE)
+		// We're cheap and won't render all overlays. It's expensive and updates with onmob changes!
+		//if(ismob(thing) || length(thing.overlays) > 2)
+			//generated_string = costly_icon2html(thing, parent, sourceonly=TRUE)
+		if(ishuman(thing))
+			var/mob/living/carbon/human/human_thing = thing
+			var/icon
+
+			// Ensure they have their armor since its going to be the majority of their appearance
+			var/list/armor = list()
+			var/obj/item/uniform = human_thing.get_item_by_slot(WEAR_BODY)
+			if(uniform)
+				armor += new uniform.type
+			var/obj/item/hat = human_thing.get_item_by_slot(WEAR_HEAD)
+			if(hat)
+				armor += new hat.type
+			var/obj/item/suit = human_thing.get_item_by_slot(WEAR_JACKET)
+			if(suit)
+				armor += new suit.type
+			var/obj/item/gloves = human_thing.get_item_by_slot(WEAR_HANDS)
+			if(gloves)
+				armor += new gloves.type
+			var/obj/item/shoes = human_thing.get_item_by_slot(WEAR_FEET)
+			if(shoes)
+				armor += new shoes.type
+
+			// If we don't succeed making a flat human icon below, allowing the human to pass into icon2html will throw a bad icon operation because of a workaround in icon2html for humans...
+			icon = get_flat_human_copy_icon(human_thing, showDirs = list(SOUTH), outfit_override = armor)
+			generated_string = icon2html(icon, parent, sourceonly=TRUE)
+			// log_debug("object_window_info called on ref=[REF(thing)], instance=[thing], type=[thing.type], finished in [(REALTIMEOFDAY-start_time) / 10]s")
 		else
 			generated_string = icon2html(thing, parent, sourceonly=TRUE)
-		*/
-		generated_string = icon2html(thing, parent, sourceonly=TRUE)
 
 		newly_seen[thing] = generated_string
 		if(TICK_CHECK)


### PR DESCRIPTION

# About the pull request

This PR updates the stat panel examine of human mobs to use a dummy copy of the examined mob to fix runtimes related to a bad icon operation from a workaround in icon2html for humans. It is not a perfect copy to limit the upper end of cost for rendering humans, but should be fairly accurate visually and forced to face south. Initial testing seems to report 0 to 0.2 seconds per mob.

This PR doesn't eliminate the possibility of an icon2html of a human, but I am unsure if its wise to just remove that workaround. Even if it was just removed for this situation, the resulting icon would be empty for the human mob.

# Explain why it's good for the game

Fixes an issue that can result in tens of thousands of runtimes.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/cmss13-devs/cmss13/assets/76988376/8f715e79-f4f2-48c7-b59a-1a6ec9e71d6d)
![image](https://github.com/cmss13-devs/cmss13/assets/76988376/fce430b1-9c76-42ea-ba80-447d30a99651)

</details>


# Changelog
:cl: Drathek
fix: Fixed a cause of bad icon operations
/:cl:
