### PR TITLE
Almayer fixes 19/10/2023

### DIFF
--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -15618,10 +15618,10 @@
 	},
 /area/almayer/living/starboard_garden)
 "biV" = (
-/obj/structure/window/framed/almayer,
 /obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 2
+	dir = 8
 	},
+/obj/structure/window/framed/almayer,
 /turf/open/floor/plating,
 /area/almayer/living/starboard_garden)
 "bja" = (
@@ -29360,20 +29360,6 @@
 	icon_state = "sterile_green_side"
 	},
 /area/almayer/shipboard/brig/surgery)
-"dav" = (
-/obj/structure/machinery/door/poddoor/almayer/open{
-	id = "Brig Lockdown Shutters";
-	name = "\improper Brig Lockdown Shutter"
-	},
-/obj/structure/machinery/door/airlock/almayer/maint{
-	access_modified = 1;
-	dir = 2;
-	req_one_access = list(2,34,30)
-	},
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/hull/upper_hull/u_f_s)
 "daz" = (
 /turf/closed/wall/almayer/white/hull,
 /area/almayer/command/airoom)
@@ -32452,6 +32438,9 @@
 "ekY" = (
 /obj/structure/machinery/door/airlock/almayer/generic/glass{
 	name = "\improper Memorial Room"
+	},
+/obj/structure/machinery/door/firedoor/border_only/almayer{
+	dir = 8
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -95400,7 +95389,7 @@ adG
 adG
 gqq
 iCz
-dav
+aFN
 rPC
 rPC
 kDb


### PR DESCRIPTION

# About the pull request

This PR fixes 2 minor issues with the USS Almayer missed in a previous sweep

Incorrect DIR on fire shutters
Incorrect tile under door in maint

# Explain why it's good for the game

Admittedly these were both mistakes I made in a prior project I believe strongly in personally correcting bugs I put into the game thus I made this PR as soon as I noticed them


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: SpartanBobby
maptweak: Fixes incorrect DIR on fireshutters in memorial
maptweak: Corrects lack of warning stripe tile under door in north brig maint
/:cl:
