### PR TITLE
Adds splints to the survival pouch & updates its description

### DIFF
--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -144,7 +144,7 @@
 	name = "survival pouch"
 	desc = "A pouch given to colonists in the event of an emergency."
 	icon_state = "tools"
-	storage_slots = 6
+	storage_slots = 7
 	max_w_class = SIZE_MEDIUM
 	can_hold = list(
 		/obj/item/device/flashlight,

--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -142,7 +142,7 @@
 
 /obj/item/storage/pouch/survival
 	name = "survival pouch"
-	desc = "It can carry flashlights, a pill, a crowbar, metal sheets, and some bandages."
+	desc = "A pouch given to colonists in the event of an emergency."
 	icon_state = "tools"
 	storage_slots = 6
 	max_w_class = SIZE_MEDIUM
@@ -153,6 +153,7 @@
 		/obj/item/stack/medical/bruise_pack,
 		/obj/item/device/radio,
 		/obj/item/attachable/bayonet,
+		/obj/item/stack/medical/splint,
 	)
 
 /obj/item/storage/pouch/survival/full/fill_preset_inventory()
@@ -162,7 +163,7 @@
 	new /obj/item/stack/medical/bruise_pack(src)
 	new /obj/item/device/radio(src)
 	new /obj/item/attachable/bayonet(src)
-
+	new /obj/item/stack/medical/splint(src)
 /obj/item/storage/pouch/survival/synth
 	name = "synth survival pouch"
 	desc = "An emergency pouch given to synthetics in the event of an emergency."


### PR DESCRIPTION

# About the pull request

Adds splints to the survival pouch that survivors spawn with, increases the survival pouch storage space from 6 to 7 & updates the survival pouch description.

# Explain why it's good for the game

Generally, unless you're actively inside of a survivor hold, getting a bone-break is essentially a death-sentence, as if you manage to kill whatever threat is attacking you, you are forced to either stop moving, or run the risk of gaining IB for each step you take. This wouldn't be an issue if it weren't for the large amount of RNG in getting a bone-break. You could just as easily have a ravager maul you to death and not break any bones as you could get a broken bone within one or two slashes from a runner.

The current description is  out-dated and straight-up wrong. The description is based off of the old survival pouch, which could hold metal sheets.


# Testing Photographs and Procedure
It does indeed work

</details>


# Changelog

:cl: foxtrot1322
add: Added splints to the survival pouch
add: Increased survival pouch storage space by 1
spellcheck: Updates the survival pouch's description
/:cl:
