### PR TITLE
Fixes Langchat X offsets for Megaphone/Xenos

### DIFF
--- a/code/datums/langchat/langchat.dm
+++ b/code/datums/langchat/langchat.dm
@@ -13,7 +13,6 @@
 
 #define LANGCHAT_LONGEST_TEXT 64
 #define LANGCHAT_WIDTH 96
-#define LANGCHAT_X_OFFSET -32
 #define LANGCHAT_MAX_ALPHA 196
 
 //pop defines
@@ -57,7 +56,7 @@
 		langchat_image.appearance_flags = NO_CLIENT_COLOR|KEEP_APART|RESET_COLOR|RESET_TRANSFORM
 		langchat_image.maptext_y = langchat_height
 		langchat_image.maptext_height = 64
-		langchat_image.maptext_x = LANGCHAT_X_OFFSET
+		langchat_image.maptext_x = - world.icon_size - get_pixel_position_x(src, TRUE)
 		langchat_image.maptext_y -= LANGCHAT_MESSAGE_POP_Y_SINK
 
 	langchat_image.pixel_y = 0
@@ -149,6 +148,7 @@
 
 	langchat_image.maptext = text_to_display
 	langchat_image.maptext_width = LANGCHAT_WIDTH * 2
+	langchat_image.maptext_x -= LANGCHAT_WIDTH / 2
 
 	langchat_listeners = listeners
 	for(var/mob/M in langchat_listeners)


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

Langchat has incorrect calc for X offsets, which results in goofy speech through megaphone and some big xenos text being off-center

This brings them in line accounting for atom dimension using `get_pixel_position_x`

# Explain why it's good for the game
Looks less goofy especially for megaphone

# Testing Photographs and Procedure
Tested megaphone and queen result in centered text. Also tested adjusting pixel_x on source atom and that it was still the case.

I'd post an image of the problem but all i have is current round's

# Changelog
:cl:
fix: Xeno and Megaphone abovehead chat speech should now properly be centered horizontally.
/:cl:
