### PR TITLE
Adds NVG Auto Response

### DIFF
--- a/code/modules/mentor/mentorhelp.dm
+++ b/code/modules/mentor/mentorhelp.dm
@@ -304,7 +304,7 @@
 		to_chat(responder, SPAN_NOTICE("<b>NOTICE:</b> A mentor is already handling this thread!"))
 		return
 
-	var/choice = tgui_input_list(usr, "Which autoresponse option do you want to send to the player?\n\n L - A webpage link.\n A - An answer to a common question.", "Autoresponse", list ("L: Discord", "L: Xeno Quickstart Guide", "L: Marine Quickstart Guide", "L: Current Map", "A: No plasma regen", "A: Devour as Xeno", "T: Tunnel", "E: Event in progress", "R: Radios", "B: Binoculars", "D: Joining disabled", "L: Leaving the server", "M: Macros", "C: Changelog", "H: Clear Cache", "O: Combat Click-Drag Override"))
+	var/choice = tgui_input_list(usr, "Which autoresponse option do you want to send to the player?\n\n L - A webpage link.\n A - An answer to a common question.", "Autoresponse", list ("L: Discord", "L: Xeno Quickstart Guide", "L: Marine Quickstart Guide", "L: Current Map", "A: No plasma regen", "A: Devour as Xeno", "T: Tunnel", "E: Event in progress", "R: Radios", "B: Binoculars", "D: Joining disabled", "L: Leaving the server", "M: Macros", "C: Changelog", "H: Clear Cache", "O: Combat Click-Drag Override", "A: Recharge NVG Optics"))
 	if(!choice)
 		return
 
@@ -358,5 +358,7 @@
 			msg += "In order to clear cache, you need to click on gear icon located in upper-right corner of your BYOND client and select preferences. Switch to Games tab and click Clear Cache button. In some cases you need to manually delete cache. To do that, select Advanced tab and click Open User Directory and delete \"cache\" folder there."
 		if("O: Combat Click-Drag Override")
 			msg += "When clicking while moving the mouse, Byond sometimes detects it as a click-and-drag attempt and prevents the click from taking effect, even if the button was only held down for an instant.\nThis toggle means that when you're on disarm or harm intent, depressing the mouse triggers a click immediately even if you hold it down - unless you're trying to click-drag yourself, an ally, or something in your own inventory."
+		if("A: Recharge NVG Optics")
+			msg += "NVG Optics can be toggled via a helmet visor. To switch between HUDs, simply click the icon in the upper left-hand portion of your screen. The Night Vision optic has roughly five minutes of use before needing to be recharged. To recharge the optic, use a screwdriver on your helmet to remove. This will remove all attached HUDs/optics. Take the Night Vision optic and place it in a recharger to recharge its battery."
 
 	message_handlers(msg, responder, author)


### PR DESCRIPTION

# About the pull request

[Request from Ethan](https://forum.cm-ss13.com/t/lack-of-mentors/4696/20)

Adds auto response to the Mentor AutoResponses on 

> "How to Recharge NVG Optics" with the following description. "NVG Optics can be toggled via a helmet visor. To switch between HUDs, simply click the icon in the upper left-hand portion of your screen. The Night Vision optic has roughly five minutes of use before needing to be recharged. To recharge the optic, use a screwdriver on your helmet to remove. This will remove all attached HUDs/optics. Take the Night Vision optic and place it in a recharger to recharge its battery."

# Explain why it's good for the game
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: New auto response for how to recharge Night Vision Goggles for Mentors
/:cl:
