### PR TITLE
Fix Imaginary Friends Initialization

### DIFF
--- a/code/modules/mob/camera/imaginary_friend.dm
+++ b/code/modules/mob/camera/imaginary_friend.dm
@@ -261,7 +261,7 @@
 	icon = friend_image
 	mouse_opacity = MOUSE_OPACITY_ICON
 	var/mob/ghost = ..()
-	if(ghost.mind)
+	if(ghost?.mind)
 		ghost.mind.original = aghosted_original_mob
 	return ghost
 


### PR DESCRIPTION

# About the pull request

This PR fixes the runtime that occurs during the initialization of an imaginary friend preventing the appearance from getting set up until the user manually requests to change their appearance yet again.

The altered code probably could be removed altogether, but maybe there are scenarios where the ghost won't be null.

# Explain why it's good for the game

Features should not break or throw runtimes.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/cmss13-devs/cmss13/assets/76988376/f0e66ecc-95a6-491f-8515-797c79923339)

</details>


# Changelog
:cl: Drathek
fix: Fixed imaginary friends not initializing correctly and throwing a runtime
/:cl:
