### PR TITLE
Fix ghost alerts that are offset because of mapping/temporary changes

### DIFF
--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -576,12 +576,14 @@ var/global/list/limb_types_by_name = list(
 		var/iheight = source_icon.Height()
 		var/iwidth = source_icon.Width()
 		var/higher_power = (iheight > iwidth) ? iheight : iwidth
+		alert_overlay.pixel_y = initial(source.pixel_y)
+		alert_overlay.pixel_x = initial(source.pixel_x)
 		if(higher_power > 32)
 			var/diff = 32 / higher_power
 			alert_overlay.transform = alert_overlay.transform.Scale(diff, diff)
 			if(higher_power > 48)
-				alert_overlay.pixel_y = -(iheight / 2) * diff
-				alert_overlay.pixel_x = -(iwidth / 2) * diff
+				alert_overlay.pixel_y = -(iheight * 0.5) * diff
+				alert_overlay.pixel_x = -(iwidth * 0.5) * diff
 
 
 	alert_overlay.layer = FLOAT_LAYER


### PR DESCRIPTION

# About the pull request

This PR resets the pixel_x and pixel_y adjustments for ghost alerts on an atom to their initial value (to ignore any temporary or mapping changes). There are still some ghost alerts that don't handle the offset correctly though (only ovi queen as far as I've seen) that this change does not resolve that I couldn't find a way to fix without incorrectly offsetting everything else... See screenshots below in testing section.

# Explain why it's good for the game

More polished UI for ghosts.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![drone](https://github.com/cmss13-devs/cmss13/assets/76988376/539a91c2-191e-4a66-8b08-0ce26b826330)
![ghost](https://github.com/cmss13-devs/cmss13/assets/76988376/c51d8d81-393a-4f27-b61b-8b8e04b778ec)
![ghost2](https://github.com/cmss13-devs/cmss13/assets/76988376/bc7deb39-96f0-4b96-8fe8-a83e51d4efa0)
![hugged](https://github.com/cmss13-devs/cmss13/assets/76988376/c7a0fbb3-c454-4bbe-94f9-16c7bf10efd0)
![hugger](https://github.com/cmss13-devs/cmss13/assets/76988376/d25a1235-0276-48d5-94d3-501a6edde486)
![lesser](https://github.com/cmss13-devs/cmss13/assets/76988376/c08c093c-ff11-4a7a-bcbf-7f5acc3b7d14)
![queen](https://github.com/cmss13-devs/cmss13/assets/76988376/93c2716d-97e4-44e6-94b0-daf84802ce1f)
![tacmap](https://github.com/cmss13-devs/cmss13/assets/76988376/520e1177-1100-451a-9e53-730857473838)
![tacmap2](https://github.com/cmss13-devs/cmss13/assets/76988376/085dfbbf-6a32-44c6-93ca-a72270ef9af8)
![ovi](https://github.com/cmss13-devs/cmss13/assets/76988376/048ca721-db8a-4606-a575-093340c736dd)

</details>


# Changelog
:cl: Drathek
ui: Tweaked the position of some ghost alerts
/:cl:
