### PR TITLE
Disables code in icon2html that causes bad icon operations

### DIFF
--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -732,11 +732,12 @@ world
 		if (isnull(dir))
 			dir = thing.dir
 
-		if (ishuman(thing)) // Shitty workaround for a BYOND issue.
+		// Commented out because this is seemingly our source of bad icon operations
+		/* if (ishuman(thing)) // Shitty workaround for a BYOND issue.
 			var/icon/temp = icon2collapse
 			icon2collapse = icon()
 			icon2collapse.Insert(temp, dir = SOUTH)
-			dir = SOUTH
+			dir = SOUTH*/
 	else
 		if (isnull(dir))
 			dir = SOUTH


### PR DESCRIPTION

# About the pull request

This PR disables MrStonedOne's workaround in icon2html specifically for humans. Rather than throwing a bad icon operation, the resulting icon will just be blank.

# Explain why it's good for the game
Situations that cause tens of thousands of runtimes in a round need to be eliminated. 

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

1. Inject Carbon and Nitrogen into self
2. Inject Oxygen into self
3. Observe a reaction for a blank icon (you) rather than throwing errors.
![image](https://github.com/cmss13-devs/cmss13/assets/76988376/efbd7eea-69c5-4968-8c24-8f79c66970df)

</details>


# Changelog
:cl: Drathek
fix: Disabled code in icon2html that is causing bad icon operations
/:cl:
