### PR TITLE
removes hard coded discord links

### DIFF
--- a/code/modules/mentor/mentorhelp.dm
+++ b/code/modules/mentor/mentorhelp.dm
@@ -327,7 +327,7 @@
 	var/msg = SPAN_MENTORSAY("<span class='prefix'>Autoresponse:</span> <span class='message'>[choice]</span>")
 	switch(choice)
 		if("L: Discord")
-			msg += "You can join our Discord server by using <a href='https://discordapp.com/invite/TByu8b5'>this link</a>!"
+			msg += "You can join our Discord server by using <a href='[CONFIG_GET(string/discordurl)]'>this link</a>!"
 		if("L: Xeno Quickstart Guide")
 			msg += "Your answer can be found on the Xeno Quickstart Guide on our wiki. <a href='[CONFIG_GET(string/wikiarticleurl)]/[URL_WIKI_XENO_QUICKSTART]'>Check it out here.</a>"
 		if("L: Marine Quickstart Guide")

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -55,7 +55,7 @@
 	if(tgui_alert(src, "This will open the discord in your browser. Are you sure?", "Confirm", list("Yes", "No")) != "Yes")
 		return
 
-	src << link("https://discord.gg/cmss13")
+	src << link("[CONFIG_GET(string/discordurl)]")
 	return
 
 /client/verb/submitbug()


### PR DESCRIPTION
i hate hardcoded urls

:cl:
fix: mentorhelp response no longer gives a dead discord link
/:cl: