### PR TITLE
prevents a href token error when changing gamemode

### DIFF
--- a/code/modules/admin/topic/topic.dm
+++ b/code/modules/admin/topic/topic.dm
@@ -697,7 +697,6 @@
 		to_world(SPAN_NOTICE("<b><i>The mode is now: [GLOB.master_mode]!</i></b>"))
 		Game() // updates the main game menu
 		SSticker.save_mode(GLOB.master_mode)
-		.(href, list("c_mode"=1))
 
 
 	else if(href_list["f_secret2"])


### PR DESCRIPTION
they were trying to recall topic but without providing a href token. i could provide a href token so this panel updated correctly, but i also don't think it matters that much (given it never worked, anyway)

:cl:
admin: no more href token errors when changing the game mode via game panel
/:cl: