### PR TITLE
Fixes OB Warheads deletions

### DIFF
--- a/code/modules/admin/tabs/event_tab.dm
+++ b/code/modules/admin/tabs/event_tab.dm
@@ -931,13 +931,8 @@
 		message_admins("[key_name(usr)] has fired \an [warhead.name] at ([target.x],[target.y],[target.z]).")
 		warhead.warhead_impact(target)
 
-		if(istype(warhead, /obj/structure/ob_ammo/warhead/cluster))
-		// so the user's screen can shake for the duration of the cluster, otherwise we get a runtime.
-			QDEL_IN(warhead, OB_CLUSTER_DURATION)
-		else
-			QDEL_IN(warhead, OB_CRASHING_DOWN)
 	else
-		warhead.loc = target
+		warhead.forceMove(target)
 
 /client/proc/change_taskbar_icon()
 	set name = "Set Taskbar Icon"

--- a/code/modules/cm_marines/orbital_cannon.dm
+++ b/code/modules/cm_marines/orbital_cannon.dm
@@ -472,6 +472,8 @@ var/list/ob_type_fuel_requirements
 			qdel(src)
 			return
 
+	qdel(src)
+
 /obj/structure/ob_ammo/warhead/incendiary
 	name = "\improper Incendiary orbital warhead"
 	warhead_kind = "incendiary"
@@ -541,7 +543,7 @@ var/list/ob_type_fuel_requirements
 				continue
 			fire_in_a_hole(U)
 		sleep(delay_between_clusters)
-	qdel(src)
+	QDEL_IN(src, 5 SECONDS) // Leave time for last handle_ob_shake below
 
 /obj/structure/ob_ammo/warhead/cluster/proc/fire_in_a_hole(turf/loc)
 	new /obj/effect/overlay/temp/blinking_laser (loc)


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

`runtime error: addtimer called with a callback assigned to a qdeleted object. In the future such timers will not be supported and may refuse to run or run with a 0 wait`

Makes OB Warheads and especially cluster delete timely (after their explosion) saving us incertainties for most warheads, and a few hundreds of runtimes for cluster.

# Explain why it's good for the game
Cleaner logs, i can't see what's going on in there geez

# Testing Photographs and Procedure
Fired a cluster checking runtimes. That's it.


# Changelog

No player facing changes

