### PR TITLE
small 'typo' fix

### DIFF
--- a/code/modules/clothing/glasses/night.dm
+++ b/code/modules/clothing/glasses/night.dm
@@ -187,7 +187,7 @@
 	if(target)
 		var/obj/item/clothing/glasses/night/m56_goggles/G = target
 		G.set_far_sight(owner, !G.far_sight)
-		to_chat(owner, SPAN_NOTICE("You [G.far_sight ? "enable" : "disable"] \the [src]'s far sight system."))
+		to_chat(owner, SPAN_NOTICE("You [G.far_sight ? "enable" : "disable"] \the [G]'s far sight system."))
 
 /datum/action/item_action/m56_goggles/far_sight/update_button_icon()
 	if(!target)


### PR DESCRIPTION
# About the pull request

fixes smartgunner far sight's log mentioning action name instead of head mounted sight's name

# Explain why it's good for the game
it was probably a mistype
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>
before

You enable Toggle Far Sight's far sight system.

and after
You enable M56 head mounted sight's far sight system.
</details>


# Changelog
spellcheck: Tweaked message when using the M56 far sight system
