### PR TITLE
fix reqs vendors sprites

### DIFF
--- a/code/game/machinery/vending/vendor_types/requisitions.dm
+++ b/code/game/machinery/vending/vendor_types/requisitions.dm
@@ -192,7 +192,7 @@
 				turf_to_vent_to = H.loc
 	return turf_to_vent_to
 
-/obj/structure/machinery/cm_vending/sorted/cargo_guns/blend
+/obj/structure/machinery/cm_vending/sorted/cargo_guns/cargo/blend
 	icon_state = "req_guns_wall"
 	tiles_with = list(
 		/obj/structure/window/framed/almayer,
@@ -296,7 +296,7 @@
 			updateUsrDialog()
 			return //We found our item, no reason to go on.
 
-/obj/structure/machinery/cm_vending/sorted/cargo_ammo/blend
+/obj/structure/machinery/cm_vending/sorted/cargo_ammo/cargo/blend
 		icon_state = "req_ammo_wall"
 		tiles_with = list(
 			/obj/structure/window/framed/almayer,

--- a/code/game/turfs/walls/wall_types.dm
+++ b/code/game/turfs/walls/wall_types.dm
@@ -24,8 +24,8 @@
 		/obj/structure/girder,
 		/obj/structure/machinery/door,
 		/obj/structure/machinery/cm_vending/sorted/attachments/blend,
-		/obj/structure/machinery/cm_vending/sorted/cargo_ammo/blend,
-		/obj/structure/machinery/cm_vending/sorted/cargo_guns/blend,
+		/obj/structure/machinery/cm_vending/sorted/cargo_ammo/cargo/blend,
+		/obj/structure/machinery/cm_vending/sorted/cargo_guns/cargo/blend,
 	)
 
 /turf/closed/wall/almayer/update_icon()

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -22749,9 +22749,7 @@
 /turf/closed/wall/almayer,
 /area/almayer/squads/req)
 "bQS" = (
-/obj/structure/machinery/cm_vending/sorted/cargo_ammo/cargo{
-	icon_state = "req_ammo_wall"
-	},
+/obj/structure/machinery/cm_vending/sorted/cargo_ammo/blend,
 /turf/open/floor/almayer{
 	icon_state = "green"
 	},
@@ -24366,9 +24364,7 @@
 /turf/open/floor/almayer,
 /area/almayer/hallways/vehiclehangar)
 "bYa" = (
-/obj/structure/machinery/cm_vending/sorted/cargo_guns/cargo{
-	icon_state = "req_guns_wall"
-	},
+/obj/structure/machinery/cm_vending/sorted/cargo_guns/blend,
 /turf/open/floor/almayer{
 	dir = 10;
 	icon_state = "green"

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -22749,7 +22749,7 @@
 /turf/closed/wall/almayer,
 /area/almayer/squads/req)
 "bQS" = (
-/obj/structure/machinery/cm_vending/sorted/cargo_ammo/blend,
+/obj/structure/machinery/cm_vending/sorted/cargo_ammo/cargo/blend,
 /turf/open/floor/almayer{
 	icon_state = "green"
 	},
@@ -24364,7 +24364,7 @@
 /turf/open/floor/almayer,
 /area/almayer/hallways/vehiclehangar)
 "bYa" = (
-/obj/structure/machinery/cm_vending/sorted/cargo_guns/blend,
+/obj/structure/machinery/cm_vending/sorted/cargo_guns/cargo/blend,
 /turf/open/floor/almayer{
 	dir = 10;
 	icon_state = "green"


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

Snowflake Reqs sprites for vendors are instanciated in map rather than using the dedicated subtypes. This causes the sprite to revert to normal vendor rack when you use it. Bleh.

Witness: 
![image](https://github.com/cmss13-devs/cmss13/assets/604624/c80d6182-2bc5-4776-88f3-be6caf5bf70e)

![image](https://github.com/cmss13-devs/cmss13/assets/604624/8e8da429-8514-4169-bf28-ccd8437652d5)

The attachie vendor just wasn't messed up. I'm pretty sure this already got fixed before and was just reverted by sloppy map merging.

# Explain why it's good for the game
CM Dev gave me these cool sprites, I'm going to use all the cool sprites!!!

# Testing Photographs and Procedure
See above.


# Changelog
:cl:
fix: Fixed incorrect Reqs vendors visuals on the Almayer. They now blend in with the walls again.
/:cl:
