### PR TITLE
Unbinds ahelp due to it being doubled up

### DIFF
--- a/code/datums/keybinding/client.dm
+++ b/code/datums/keybinding/client.dm
@@ -4,8 +4,8 @@
 
 
 /datum/keybinding/client/admin_help
-	hotkey_keys = list("F1")
-	classic_keys = list("F1")
+	hotkey_keys = list("Unbound")
+	classic_keys = list("Unbound")
 	name = "admin_help"
 	full_name = "Admin Help"
 	description = "Ask an admin for help."


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

This removes the default bind for AdminHelp because SSinput already has an hardcoded bind for it, causing it to fire twice. You're still welcome to also bind ahelp to another key. This does not affect existing users because it only changes the default preset. 

# Explain why it's good for the game
It's less of an issue with the new tgui ahelp box but has been a thing forever and still doubles up the chat help message.

# Testing Photographs and Procedure
Reset keybinds, pressed F1, tried reloading game etc


# Changelog
:cl:
fix: Removed redundant double binding for F1 to AdminHelp from default keybinds. This does not affect existing users or their settings.
/:cl:
