### PR TITLE
removes hardcoded server name from latejoiners

### DIFF
--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -29,9 +29,7 @@ SUBSYSTEM_DEF(mapping)
 /datum/controller/subsystem/mapping/proc/HACK_LoadMapConfig()
 	if(!configs)
 		configs = load_map_configs(ALL_MAPTYPES, error_if_missing = FALSE)
-		for(var/i in GLOB.clients)
-			var/client/C = i
-			winset(C, null, "mainwindow.title='[CONFIG_GET(string/title)] - [SSmapping.configs[SHIP_MAP].map_name]'")
+		world.name = "[CONFIG_GET(string/title)] - [SSmapping.configs[SHIP_MAP].map_name]"
 
 /datum/controller/subsystem/mapping/Initialize(timeofday)
 	HACK_LoadMapConfig()

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -164,7 +164,6 @@ window "mainwindow"
 		anchor2 = -1,-1
 		is-default = true
 		saved-params = "pos;size;is-minimized;is-maximized"
-		title = "CM-SS13 - USS Almayer"
 		is-maximized = true
 		statusbar = false
 		icon = 'icons\\taskbar\\gml_distress.png'


### PR DESCRIPTION
latejoiners were always shown the default skin in the .dmf as the custom title based on config was only shown if you happened to be connected when SSmapping was initializing

:cl:
server: the server now respects /string/title for late joiners
/:cl: