### PR TITLE
reset CAS direct camera on change to avoid duplicated signal handlers

### DIFF
--- a/code/game/machinery/computer/dropship_weapons.dm
+++ b/code/game/machinery/computer/dropship_weapons.dm
@@ -594,14 +594,21 @@
 			return
 
 		var/targ_id = text2num(href_list["cas_camera"])
+
+		var/datum/cas_signal/new_signal
 		for(var/datum/cas_signal/LT as anything in cas_group.cas_signals)
 			if(LT.target_id == targ_id && LT.valid_signal())
-				selected_cas_signal = LT
+				new_signal = LT
 				break
 
-		if(!selected_cas_signal)
+		if(!new_signal)
 			to_chat(usr, SPAN_WARNING("Target lost or obstructed."))
 			return
+
+		if(usr in selected_cas_signal?.linked_cam?.viewing_users) // Reset previous cam
+			remove_from_view(usr)
+
+		selected_cas_signal = new_signal
 		if(selected_cas_signal && selected_cas_signal.linked_cam)
 			selected_cas_signal.linked_cam.view_directly(usr)
 		else


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

Explicitely resets CAS direct guidance camera before setting a new one, avoiding log being flooded by double signal registrations

```
runtime error: mob_resist overridden. Use override = TRUE to suppress this warning
proc name: stack trace (/proc/stack_trace)
  source file: code/__HELPERS/unsorted.dm,1893
  usr: Honk (/mob/living/carbon/human)
  src: null
  usr.loc: the floor (206,40,4) (/turf/open/shuttle/dropship)
```