### PR TITLE
Add Item & Footprints offsets

### DIFF
--- a/code/game/objects/effects/decals/cleanable/blood/tracks.dm
+++ b/code/game/objects/effects/decals/cleanable/blood/tracks.dm
@@ -14,8 +14,8 @@
 
 	var/list/overlay_images = list()
 
-	/// Amount of pixels to shift either way in an attempt to make the trakcs more organic
-	var/transverse_amplitude = 2
+	/// Amount of pixels to shift either way in an attempt to make the tracks more organic
+	var/transverse_amplitude = 3
 
 /obj/effect/decal/cleanable/blood/tracks/Crossed()
 	return

--- a/code/game/objects/effects/decals/cleanable/blood/tracks.dm
+++ b/code/game/objects/effects/decals/cleanable/blood/tracks.dm
@@ -14,6 +14,9 @@
 
 	var/list/overlay_images = list()
 
+	/// Amount of pixels to shift either way in an attempt to make the trakcs more organic
+	var/transverse_amplitude = 3
+
 /obj/effect/decal/cleanable/blood/tracks/Crossed()
 	return
 
@@ -21,19 +24,27 @@
 	return FALSE
 
 /obj/effect/decal/cleanable/blood/tracks/proc/add_tracks(direction, tcolor, out)
-	var/image/I = image(icon = icon, icon_state = out ? going_state : coming_state, dir = direction)
-	var/mutable_appearance/MA = new(I)
+	var/image/image = image(icon = icon, icon_state = out ? going_state : coming_state, dir = direction)
+
+	var/mutable_appearance/MA = new(image)
 	MA.color = tcolor
 	MA.layer = layer
 	MA.appearance_flags |= RESET_COLOR
-	I.appearance = MA
-	if(out)
-		LAZYSET(steps_out, "[direction]", I)
-	else
-		LAZYSET(steps_in, "[direction]", I)
+	image.appearance = MA
 
-	overlay_images += I
-	cleanable_turf.overlays += I
+	switch(direction)
+		if(NORTH, SOUTH)
+			image.pixel_x += rand(-transverse_amplitude, transverse_amplitude)
+		if(EAST, WEST)
+			image.pixel_y += rand(-transverse_amplitude, transverse_amplitude)
+
+	if(out)
+		LAZYSET(steps_out, "[direction]", image)
+	else
+		LAZYSET(steps_in, "[direction]", image)
+
+	overlay_images += image
+	cleanable_turf.overlays += image
 
 /obj/effect/decal/cleanable/blood/tracks/clear_overlay()
 	if(length(overlay_images))

--- a/code/game/objects/effects/decals/cleanable/blood/tracks.dm
+++ b/code/game/objects/effects/decals/cleanable/blood/tracks.dm
@@ -15,7 +15,7 @@
 	var/list/overlay_images = list()
 
 	/// Amount of pixels to shift either way in an attempt to make the trakcs more organic
-	var/transverse_amplitude = 3
+	var/transverse_amplitude = 2
 
 /obj/effect/decal/cleanable/blood/tracks/Crossed()
 	return

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -156,6 +156,11 @@
 
 	var/list/inherent_traits
 
+	/// How much to offset the item alongside X visually
+	var/ground_offset_x = 2
+	/// How much to offset the item alongside X visually
+	var/ground_offset_y = 2
+
 /obj/item/Initialize(mapload, ...)
 	. = ..()
 
@@ -174,6 +179,8 @@
 
 	if(flags_item & MOB_LOCK_ON_EQUIP)
 		AddComponent(/datum/component/id_lock)
+
+	scatter_item()
 
 /obj/item/Destroy()
 	flags_item &= ~DELONDROP //to avoid infinite loop of unequip, delete, unequip, delete.
@@ -458,6 +465,11 @@ cases. Override_icon_state should be a list.*/
 //sometimes we only want to grant the item's action if it's equipped in a specific slot.
 /obj/item/proc/item_action_slot_check(mob/user, slot)
 	return TRUE
+
+/obj/item/proc/scatter_item()
+	if(!pixel_x && !pixel_y)
+		pixel_x = rand(-ground_offset_x, ground_offset_x)
+		pixel_y = rand(-ground_offset_y, ground_offset_y)
 
 // The mob M is attempting to equip this item into the slot passed through as 'slot'. return TRUE if it can do this and 0 if it can't.
 // If you are making custom procs but would like to retain partial or complete functionality of this one, include a 'return ..()' to where you want this to happen.

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -156,10 +156,10 @@
 
 	var/list/inherent_traits
 
-	/// How much to offset the item alongside X visually
-	var/ground_offset_x = 2
-	/// How much to offset the item alongside Y visually
-	var/ground_offset_y = 2
+	/// How much to offset the item randomly etiher way alongside X visually
+	var/ground_offset_x = 0
+	/// How much to offset the item randomly etiher way alongside Y visually
+	var/ground_offset_y = 0
 
 /obj/item/Initialize(mapload, ...)
 	. = ..()

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -156,9 +156,9 @@
 
 	var/list/inherent_traits
 
-	/// How much to offset the item randomly etiher way alongside X visually
+	/// How much to offset the item randomly either way alongside X visually
 	var/ground_offset_x = 0
-	/// How much to offset the item randomly etiher way alongside Y visually
+	/// How much to offset the item randomly either way alongside Y visually
 	var/ground_offset_y = 0
 
 /obj/item/Initialize(mapload, ...)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -158,7 +158,7 @@
 
 	/// How much to offset the item alongside X visually
 	var/ground_offset_x = 2
-	/// How much to offset the item alongside X visually
+	/// How much to offset the item alongside Y visually
 	var/ground_offset_y = 2
 
 /obj/item/Initialize(mapload, ...)

--- a/code/game/objects/items/devices/coins.dm
+++ b/code/game/objects/items/devices/coins.dm
@@ -11,11 +11,8 @@
 	black_market_value = 10
 	var/string_attached
 	var/sides = 2
-
-/obj/item/coin/Initialize()
-	. = ..()
-	pixel_x = rand(0,16)-8
-	pixel_y = rand(0,8)-8
+	ground_offset_x = 8
+	ground_offset_y = 4
 
 /obj/item/coin/gold
 	name = "gold coin"

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -35,7 +35,7 @@
 	else
 		icon_state = initial(icon_state)
 
-/obj/item/device/flashlight/flare/animation_spin(speed = 5, loop_amount = -1, clockwise = TRUE, sections = 3, angular_offset = 0, pixel_fuzz = 0)
+/obj/item/device/flashlight/animation_spin(speed = 5, loop_amount = -1, clockwise = TRUE, sections = 3, angular_offset = 0, pixel_fuzz = 0)
 	clockwise = pick(TRUE, FALSE)
 	angular_offset = rand(360)
 	return ..()

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -12,6 +12,8 @@
 
 	light_range = 5
 	light_power = 1
+	ground_offset_x = 2
+	ground_offset_y = 6
 
 	actions_types = list(/datum/action/item_action)
 	var/on = FALSE
@@ -32,6 +34,11 @@
 		icon_state = "[initial(icon_state)]-on"
 	else
 		icon_state = initial(icon_state)
+
+/obj/item/device/flashlight/flare/animation_spin(speed = 5, loop_amount = -1, clockwise = TRUE, sections = 3, angular_offset = 0, pixel_fuzz = 0)
+	clockwise = pick(TRUE, FALSE)
+	angular_offset = rand(360)
+	return ..()
 
 /obj/item/device/flashlight/proc/update_brightness(mob/user = null)
 	if(on)
@@ -296,8 +303,6 @@
 
 // Causes flares to stop with a rotation offset for visual purposes
 /obj/item/device/flashlight/flare/animation_spin(speed = 5, loop_amount = -1, clockwise = TRUE, sections = 3, angular_offset = 0, pixel_fuzz = 0)
-	clockwise = pick(TRUE, FALSE)
-	angular_offset = rand(360)
 	pixel_fuzz = 16
 	return ..()
 /obj/item/device/flashlight/flare/pickup()

--- a/code/game/objects/items/explosives/grenades/grenade.dm
+++ b/code/game/objects/items/explosives/grenades/grenade.dm
@@ -20,12 +20,12 @@
 	var/hand_throwable = TRUE
 	harmful = TRUE //Is it harmful? Are they banned for synths?
 	antigrief_protection = TRUE //Should it be checked by antigrief?
+	ground_offset_x = 7
+	ground_offset_y = 6
 
 /obj/item/explosive/grenade/Initialize()
 	. = ..()
 	det_time = max(0, rand(det_time - 5, det_time + 5))
-	pixel_y = rand(-6, 6)
-	pixel_x = rand(-7, 7)
 
 /obj/item/explosive/grenade/proc/can_use_grenade(mob/living/carbon/human/user)
 	if(!hand_throwable)

--- a/code/game/objects/items/explosives/warhead.dm
+++ b/code/game/objects/items/explosives/warhead.dm
@@ -2,11 +2,8 @@
 	icon = 'icons/obj/items/weapons/grenade.dmi'
 	customizable = TRUE
 	allowed_sensors = list() //We only need a detonator
-
-/obj/item/explosive/warhead/Initialize(mapload, ...)
-	. = ..()
-	pixel_y = rand(-6, 6)
-	pixel_x = rand(-7, 7)
+	ground_offset_x = 7
+	ground_offset_y = 6
 
 /obj/item/explosive/warhead/rocket
 	name = "84mm rocket warhead"

--- a/code/game/objects/items/reagent_containers/glass.dm
+++ b/code/game/objects/items/reagent_containers/glass.dm
@@ -363,11 +363,8 @@
 	matter = list()
 	possible_transfer_amounts = list(5,10,15,25,30)
 	flags_atom = FPRINT|OPENCONTAINER
-
-/obj/item/reagent_container/glass/beaker/vial/Initialize()
-	. = ..()
-	pixel_y = rand(-8, 8)
-	pixel_x = rand(-9, 9)
+	ground_offset_x = 9
+	ground_offset_y = 8
 
 /obj/item/reagent_container/glass/beaker/vial/tricordrazine
 	name = "tricordrazine vial"

--- a/code/game/objects/items/reagent_containers/pill.dm
+++ b/code/game/objects/items/reagent_containers/pill.dm
@@ -23,6 +23,8 @@
 	w_class = SIZE_TINY
 	volume = 60
 	reagent_desc_override = TRUE //it has a special examining mechanic
+	ground_offset_x = 7
+	ground_offset_y = 7
 	var/identificable = TRUE //can medically trained people tell what's in it?
 	var/pill_desc = "An unknown pill." // The real description of the pill, shown when examined by a medically trained person
 	var/pill_icon_class = "random" // Pills with the same icon class share icons

--- a/code/game/objects/items/reagent_containers/reagent_container.dm
+++ b/code/game/objects/items/reagent_containers/reagent_container.dm
@@ -14,6 +14,8 @@
 	var/transparent = FALSE //can we see what's in it?
 	var/reagent_desc_override = FALSE //does it have a special examining mechanic that should override the normal /reagent_containers examine proc?
 	actions_types = list(/datum/action/item_action/reagent_container/set_transfer_amount)
+	ground_offset_x = 7
+	ground_offset_y = 7
 
 /obj/item/reagent_container/Initialize()
 	if(!possible_transfer_amounts)

--- a/code/game/objects/items/stacks/cable_coil.dm
+++ b/code/game/objects/items/stacks/cable_coil.dm
@@ -20,14 +20,14 @@
 	attack_verb = list("whipped", "lashed", "disciplined", "flogged")
 	stack_id = "cable coil"
 	attack_speed = 3
+	ground_offset_x = 2
+	ground_offset_y = 2
 
 /obj/item/stack/cable_coil/Initialize(mapload, length = MAXCOIL, param_color = null)
 	. = ..()
 	src.amount = length
 	if (param_color) // It should be red by default, so only recolor it if parameter was specified.
 		color = param_color
-	pixel_x = rand(-2,2)
-	pixel_y = rand(-2,2)
 	updateicon()
 	update_wclass()
 
@@ -276,8 +276,6 @@
 /obj/item/stack/cable_coil/cut/Initialize()
 	. = ..()
 	src.amount = rand(1,2)
-	pixel_x = rand(-2,2)
-	pixel_y = rand(-2,2)
 	updateicon()
 	update_wclass()
 

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -69,6 +69,7 @@ var/global/list/datum/stack_recipe/metal_recipes = list ( \
 	sheettype = "metal"
 	stack_id = "metal"
 
+
 /obj/item/stack/sheet/metal/small_stack
 	amount = STACK_10
 
@@ -114,6 +115,8 @@ var/global/list/datum/stack_recipe/plasteel_recipes = list ( \
 	amount_sprites = TRUE
 	sheettype = "plasteel"
 	stack_id = "plasteel"
+	ground_offset_x = 4
+	ground_offset_y = 5
 
 /obj/item/stack/sheet/plasteel/New(loc, amount=null)
 	recipes = plasteel_recipes

--- a/code/game/objects/structures/surface.dm
+++ b/code/game/objects/structures/surface.dm
@@ -61,8 +61,7 @@
 		draw_item_overlays()
 
 /obj/structure/surface/proc/detach_item(obj/item/O)
-	O.pixel_x = initial(O.pixel_x)
-	O.pixel_y = initial(O.pixel_y)
+	O.scatter_item()
 	UnregisterSignal(O, COMSIG_ATOM_DECORATED)
 	draw_item_overlays()
 	return

--- a/code/modules/cm_marines/equipment/guncases.dm
+++ b/code/modules/cm_marines/equipment/guncases.dm
@@ -9,6 +9,7 @@
 	can_hold = list()//define on a per case basis for the original firearm.
 	foldable = TRUE
 	foldable = /obj/item/stack/sheet/mineral/plastic//it makes sense
+	ground_offset_y = 5
 
 /obj/item/storage/box/guncase/update_icon()
 	if(LAZYLEN(contents))

--- a/code/modules/cm_marines/equipment/kit_boxes.dm
+++ b/code/modules/cm_marines/equipment/kit_boxes.dm
@@ -274,12 +274,12 @@
 	slowdown = 1
 	can_hold = list() //Nada. Once you take the stuff out it doesn't fit back in.
 	foldable = TRUE
+	ground_offset_x = 5
+	ground_offset_y = 5
 	var/pro_case_overlay
 
 /obj/item/storage/box/kit/Initialize()
 	. = ..()
-	pixel_x = rand(-5, 5)
-	pixel_y = rand(-5, 5)
 	if(pro_case_overlay)
 		overlays += image('icons/obj/items/storage.dmi', "+[pro_case_overlay]")
 

--- a/code/modules/cm_marines/equipment/mortar/mortar_shells.dm
+++ b/code/modules/cm_marines/equipment/mortar/mortar_shells.dm
@@ -6,11 +6,9 @@
 	w_class = SIZE_HUGE
 	flags_atom = FPRINT|CONDUCT
 	var/datum/cause_data/cause_data
+	ground_offset_x = 7
+	ground_offset_y = 6
 
-/obj/item/mortar_shell/Initialize(mapload, ...)
-	. = ..()
-	pixel_y = rand(-6, 6)
-	pixel_x = rand(-7, 7)
 
 /obj/item/mortar_shell/Destroy()
 	. = ..()

--- a/code/modules/cm_marines/orbital_cannon.dm
+++ b/code/modules/cm_marines/orbital_cannon.dm
@@ -546,8 +546,8 @@ var/list/ob_type_fuel_requirements
 	icon_state = "ob_fuel"
 	is_solid_fuel = 1
 
-/obj/structure/ob_ammo/ob_fuel/New()
-	..()
+/obj/structure/ob_ammo/ob_fuel/Initialize()
+	. = ..()
 	pixel_x = rand(-5,5)
 	pixel_y = rand(-5,5)
 

--- a/code/modules/hydroponics/botany_disks.dm
+++ b/code/modules/hydroponics/botany_disks.dm
@@ -4,14 +4,12 @@
 	icon = 'icons/obj/items/disk.dmi'
 	icon_state = "botanydisk"
 	w_class = SIZE_TINY
+	ground_offset_x = 5
+	ground_offset_y = 5
 
 	var/list/genes = list()
 	var/genesource = "unknown"
 
-/obj/item/disk/botany/Initialize()
-	. = ..()
-	pixel_x = rand(-5,5)
-	pixel_y = rand(-5,5)
 
 /obj/item/disk/botany/attack_self(mob/user)
 	..()

--- a/code/modules/objectives/data_retrieval.dm
+++ b/code/modules/objectives/data_retrieval.dm
@@ -177,6 +177,8 @@
 	var/datum/cm_objective/retrieve_item/document/retrieve_objective
 	var/display_color = "white"
 	var/disk_color = "White"
+	ground_offset_x = 9
+	ground_offset_y = 8
 
 /obj/item/disk/objective/Initialize(mapload, ...)
 	. = ..()
@@ -210,8 +212,6 @@
 	name = "[disk_color] computer disk [label]"
 	objective = new /datum/cm_objective/retrieve_data/disk(src)
 	retrieve_objective = new /datum/cm_objective/retrieve_item/document(src)
-	pixel_y = rand(-8, 8)
-	pixel_x = rand(-9, 9)
 	w_class = SIZE_TINY
 
 /obj/item/disk/objective/Destroy()

--- a/code/modules/objectives/documents.dm
+++ b/code/modules/objectives/documents.dm
@@ -122,6 +122,8 @@
 	unacidable = TRUE
 	indestructible = 1
 	is_objective = TRUE
+	ground_offset_x = 9
+	ground_offset_y = 8
 	var/label // label on the document
 	var/renamed = FALSE //Once someone reads a document the item gets renamed based on the objective they are linked to)
 
@@ -131,8 +133,6 @@
 	objective = new objective_type(src)
 	retrieve_objective = new /datum/cm_objective/retrieve_item/document(src)
 	LAZYADD(objective.enables_objectives, retrieve_objective)
-	pixel_y = rand(-8, 8)
-	pixel_x = rand(-9, 9)
 
 /obj/item/document_objective/Destroy()
 	qdel(objective)

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -19,6 +19,8 @@
 	flags_equip_slot = SLOT_HEAD
 	flags_armor_protection = BODY_FLAG_HEAD
 	attack_verb = list("bapped")
+	ground_offset_x = 9
+	ground_offset_y = 8
 
 	var/info //What's actually written on the paper.
 	var/info_links //A different version of the paper which includes html links at fields and EOF
@@ -42,8 +44,6 @@
 
 /obj/item/paper/Initialize(mapload, photo_list)
 	. = ..()
-	pixel_y = rand(-8, 8)
-	pixel_x = rand(-9, 9)
 	stamps = ""
 	src.photo_list = photo_list
 

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -82,8 +82,6 @@
 				p.update_icon()
 				p.icon_state = "paper_words"
 				p.name = bundle.name
-				p.pixel_y = rand(-8, 8)
-				p.pixel_x = rand(-9, 9)
 				sleep(15*j)
 			updateUsrDialog()
 	else if(href_list["remove"])

--- a/code/modules/projectiles/ammo_boxes/ammo_boxes.dm
+++ b/code/modules/projectiles/ammo_boxes/ammo_boxes.dm
@@ -85,6 +85,8 @@
 	var/handful = "shells" //used for 'magazine' boxes that give handfuls to determine what kind for the sprite
 	can_explode = TRUE
 	limit_per_tile = 2
+	ground_offset_x = 5
+	ground_offset_y = 5
 
 /obj/item/ammo_box/magazine/empty
 	empty = TRUE
@@ -102,8 +104,6 @@
 		while(i < num_of_magazines)
 			contents += new magazine_type(src)
 			i++
-	pixel_x = rand(-5, 5)
-	pixel_y = rand(-5, 5)
 	update_icon()
 
 /obj/item/ammo_box/magazine/update_icon()

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -18,6 +18,8 @@ They're all essentially identical when it comes to getting the job done.
 	w_class = SIZE_SMALL
 	throw_speed = SPEED_SLOW
 	throw_range = 6
+	ground_offset_x = 7
+	ground_offset_y = 6
 	var/default_ammo = /datum/ammo/bullet
 	var/caliber = null // This is used for matching handfuls to each other or whatever the mag is. Examples are" "12g" ".44" ".357" etc.
 	var/current_rounds = -1 //Set this to something else for it not to start with different initial counts.
@@ -50,8 +52,7 @@ They're all essentially identical when it comes to getting the job done.
 		if(0)
 			icon_state += "_e" //In case it spawns empty instead.
 			item_state += "_e"
-	pixel_y = rand(-6, 6)
-	pixel_x = rand(-7, 7)
+
 	if(ammo_band_color && ammo_band_icon)
 		update_ammo_band()
 

--- a/code/modules/reagents/chemistry_machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry_machinery/chem_master.dm
@@ -237,8 +237,6 @@
 			while (count--)
 				var/obj/item/reagent_container/pill/P = new/obj/item/reagent_container/pill(loc)
 				P.pill_desc = "A custom pill."
-				P.pixel_x = rand(-7, 7) //random position
-				P.pixel_y = rand(-7, 7)
 				P.icon_state = "pill"+pillsprite
 				reagents.trans_to(P,amount_per_pill)
 				if(loaded_pill_bottle)
@@ -271,8 +269,6 @@
 					P.name = "[name] vial"
 					reagents.trans_to(P, 30)
 
-				P.pixel_x = rand(-7, 7) //random position
-				P.pixel_y = rand(-7, 7)
 				P.update_icon()
 
 				if(href_list["store"])


### PR DESCRIPTION
# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

This:
* Adds transverse offsets to blood footprints
* Adds notable pixel offsets to a few items
* Adds a very slight pixel offset to all items
* Enables rotation for thrown flashlights
* Cause objects exiting a surface (rack/table) to regenerate offset instead of being stuck at center
* Stops random offsets from overwriting mapped offsets

# Explain why it's good for the game
The goal is to have map visuals more organic when we have a lot of objects on the ground - targeting in particular items you find readily in dense areas such as Reqs or a FOB.

Consider this for example, the blood footprints are all aligned, in more extreme situations (eg WO) it makes an actual "grid" which i personally find very immersion breaking
![image](https://github.com/cmss13-devs/cmss13/assets/604624/83883e15-a9a0-4a2d-aa90-41c785e047b9)

Adding a slight offset helps counter that:
![image](https://github.com/cmss13-devs/cmss13/assets/604624/504d1baf-385c-4774-86f3-6331c4ac87ed)

# Changelog
:cl:
add: Bloody footprints are now slightly offset to break long visual straight lines.
fix: Items do not align back to the center of turfs anymore when picked from a surface (table or rack)
add: Some more items now have offsets on the map display, and they all can be slightly offset.
/:cl:
