### PR TITLE
Fixed Lagnchat Xeno offsets again, final edition i swear

### DIFF
--- a/code/datums/langchat/langchat.dm
+++ b/code/datums/langchat/langchat.dm
@@ -47,6 +47,13 @@
 				M.client.images -= langchat_image
 	langchat_listeners = null
 
+/atom/proc/langchat_set_x_offset()
+	langchat_image.maptext_x = world.icon_size / 2 - langchat_image.maptext_width / 2
+/atom/movable/langchat_set_x_offset()
+	langchat_image.maptext_x = bound_width / 2 - langchat_image.maptext_width / 2
+/mob/langchat_set_x_offset()
+	langchat_image.maptext_x = icon_size / 2 - langchat_image.maptext_width / 2
+
 ///Creates the image if one does not exist, resets settings that are modified by speech procs.
 /atom/proc/langchat_make_image(override_color = null)
 	if(!langchat_image)
@@ -56,8 +63,8 @@
 		langchat_image.appearance_flags = NO_CLIENT_COLOR|KEEP_APART|RESET_COLOR|RESET_TRANSFORM
 		langchat_image.maptext_y = langchat_height
 		langchat_image.maptext_height = 64
-		langchat_image.maptext_x = - world.icon_size - get_pixel_position_x(src, TRUE)
 		langchat_image.maptext_y -= LANGCHAT_MESSAGE_POP_Y_SINK
+		langchat_set_x_offset()
 
 	langchat_image.pixel_y = 0
 	langchat_image.alpha = 0
@@ -102,7 +109,7 @@
 
 	langchat_image.maptext = text_to_display
 	langchat_image.maptext_width = LANGCHAT_WIDTH
-	langchat_image.maptext_x = - world.icon_size - get_pixel_position_x(src, TRUE)
+	langchat_set_x_offset()
 
 	langchat_listeners = listeners
 	for(var/mob/M in langchat_listeners)
@@ -149,7 +156,7 @@
 
 	langchat_image.maptext = text_to_display
 	langchat_image.maptext_width = LANGCHAT_WIDTH * 2
-	langchat_image.maptext_x = - world.icon_size - get_pixel_position_x(src, TRUE) - LANGCHAT_WIDTH / 2
+	langchat_set_x_offset()
 
 	langchat_listeners = listeners
 	for(var/mob/M in langchat_listeners)


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

Fixes for Xeno langchat offsets, AGAIN. My math keeps being wrong and failing under specific cases... It turns out it's a lot simpler than what i've been trying to do too. AGH!

# Testing Photographs and Procedure
I brought PROPER photos of PROPER testing which hopefully means that it's a PROPER fix this time

### CLF are not very good at briefings
![image](https://github.com/cmss13-devs/cmss13/assets/604624/ba9c96b3-1d86-4a9a-8a35-c486fad73bfe)

### Bad CLF but with megaphone
![image](https://github.com/cmss13-devs/cmss13/assets/604624/19ace90b-6b36-4470-a0e8-07897c640d01)

### Queen (icon_size=64) has joined the chat
![image](https://github.com/cmss13-devs/cmss13/assets/604624/02e88372-b881-4b21-866e-f9562e644ea5)

### Queen but offset by pixel_x
![image](https://github.com/cmss13-devs/cmss13/assets/604624/4319d02a-cf69-4f16-a5a1-01b2fcacaea7)

# Changelog
:cl:
fix: Re-Re-Fixed Xeno Above Head Chat offsets, for real this time
/:cl:
