### PR TITLE
I need more bullets!

### DIFF
--- a/code/__DEFINES/weapon_stats.dm
+++ b/code/__DEFINES/weapon_stats.dm
@@ -252,6 +252,7 @@ As such, don't expect any values assigned to common firearms to even consider ho
 //See Neth's armor comments for how this works. Higher is better.
 */
 
+#define ARMOR_PENETRATION_NONE 0
 #define ARMOR_PENETRATION_TIER_1 5
 #define ARMOR_PENETRATION_TIER_2 10
 #define ARMOR_PENETRATION_TIER_3 15

--- a/code/datums/ammo/bullet/pistol.dm
+++ b/code/datums/ammo/bullet/pistol.dm
@@ -30,7 +30,7 @@
 	name = "hollowpoint pistol bullet"
 
 	damage = 55 //hollowpoint is strong
-	penetration = 0 //hollowpoint can't pierce armor!
+	penetration = ARMOR_PENETRATION_NONE //hollowpoint can't pierce armor!
 	shrapnel_chance = SHRAPNEL_CHANCE_TIER_3 //hollowpoint causes shrapnel
 
 // Used by M4A3 AP and mod88
@@ -94,40 +94,36 @@
 	name = "stun pistol bullet"
 	sound_override = null
 
-// Used by M1911, Deagle and KT-42
+// Used for High Calibers (.50 , pistol .44 and 7.62x25mm)
 /datum/ammo/bullet/pistol/heavy
 	name = "heavy pistol bullet"
 	headshot_state = HEADSHOT_OVERLAY_MEDIUM
 	accuracy = -HIT_ACCURACY_TIER_3
-	accuracy_var_low = PROJECTILE_VARIANCE_TIER_6
-	damage = 55
-	penetration = ARMOR_PENETRATION_TIER_3
+	accuracy_var_low = PROJECTILE_VARIANCE_TIER_7
+	damage = 50
+	penetration = ARMOR_PENETRATION_TIER_4
 	shrapnel_chance = SHRAPNEL_CHANCE_TIER_2
 
 /datum/ammo/bullet/pistol/heavy/super //Commander's variant
-	name = ".50 heavy pistol bullet"
-	damage = 60
-	damage_var_low = PROJECTILE_VARIANCE_TIER_8
-	damage_var_high = PROJECTILE_VARIANCE_TIER_6
-	penetration = ARMOR_PENETRATION_TIER_4
+	name = ".50s heavy pistol bullet"
+	damage_var_high = PROJECTILE_VARIANCE_TIER_8
+	accuracy = -HIT_ACCURACY_TIER_2
+	debilitate = list(0,0,0,0,0,1,0,0)
+	damage = 70
 
 /datum/ammo/bullet/pistol/heavy/super/highimpact
-	name = ".50 high-impact pistol bullet"
-	penetration = ARMOR_PENETRATION_TIER_1
+	name = ".50s high-impact pistol bullet"
+	penetration = ARMOR_PENETRATION_NONE // the tip was removed to transfer more energy therefore no pen
 	debilitate = list(0,1.5,0,0,0,1,0,0)
 	flags_ammo_behavior = AMMO_BALLISTIC
 
-/datum/ammo/bullet/pistol/heavy/super/highimpact/ap
-	name = ".50 high-impact armor piercing pistol bullet"
+/datum/ammo/bullet/pistol/heavy/super/ap
+	name = ".50s armor piercing pistol bullet"
 	penetration = ARMOR_PENETRATION_TIER_10
-	damage = 45
+	damage = 55
 
 /datum/ammo/bullet/pistol/heavy/super/highimpact/upp
-	name = "high-impact pistol bullet"
 	sound_override = 'sound/weapons/gun_DE50.ogg'
-	penetration = ARMOR_PENETRATION_TIER_6
-	debilitate = list(0,1.5,0,0,0,1,0,0)
-	flags_ammo_behavior = AMMO_BALLISTIC
 
 /datum/ammo/bullet/pistol/heavy/super/highimpact/New()
 	..()
@@ -135,15 +131,6 @@
 
 /datum/ammo/bullet/pistol/heavy/super/highimpact/on_hit_mob(mob/M, obj/projectile/P)
 	knockback(M, P, 4)
-
-/datum/ammo/bullet/pistol/deagle
-	name = ".50 heavy pistol bullet"
-	damage = 45
-	headshot_state = HEADSHOT_OVERLAY_HEAVY
-	accuracy = -HIT_ACCURACY_TIER_3
-	accuracy_var_low = PROJECTILE_VARIANCE_TIER_6
-	penetration = ARMOR_PENETRATION_TIER_6
-	shrapnel_chance = SHRAPNEL_CHANCE_TIER_5
 
 /datum/ammo/bullet/pistol/incendiary
 	name = "incendiary pistol bullet"
@@ -179,11 +166,10 @@
 	name = "squash-head pistol bullet"
 	headshot_state = HEADSHOT_OVERLAY_MEDIUM
 	debilitate = list(0,0,0,0,0,0,0,2)
-
 	accuracy = HIT_ACCURACY_TIER_4
 	damage = 45
-	penetration= ARMOR_PENETRATION_TIER_6
-	shrapnel_chance = SHRAPNEL_CHANCE_TIER_2
+	penetration= ARMOR_PENETRATION_TIER_4
+	shrapnel_chance = SHRAPNEL_CHANCE_TIER_6
 	damage_falloff = DAMAGE_FALLOFF_TIER_6 //"VP78 - the only pistol viable as a primary."-Vampmare, probably.
 
 /datum/ammo/bullet/pistol/squash/toxin
@@ -238,7 +224,6 @@
 	damage_type = BURN
 	debilitate = list(4,4,0,0,0,0,0,0)
 	flags_ammo_behavior = AMMO_IGNORE_ARMOR
-
 	damage = 15
 	damage_var_high = PROJECTILE_VARIANCE_TIER_5
 	shell_speed = AMMO_SPEED_TIER_2
@@ -257,9 +242,7 @@
 /datum/ammo/bullet/pistol/smart
 	name = "smartpistol bullet"
 	flags_ammo_behavior = AMMO_BALLISTIC
-
 	accuracy = HIT_ACCURACY_TIER_8
 	damage = 30
-	penetration = 20
+	penetration = ARMOR_PENETRATION_TIER_4
 	shrapnel_chance = SHRAPNEL_CHANCE_TIER_2
-

--- a/code/modules/projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/guns/pistols.dm
@@ -226,7 +226,7 @@
 	scatter = SCATTER_AMOUNT_TIER_6
 	burst_scatter_mult = SCATTER_AMOUNT_TIER_6
 	scatter_unwielded = SCATTER_AMOUNT_TIER_6
-	damage_mult = BASE_BULLET_DAMAGE_MULT + BULLET_DAMAGE_MULT_TIER_1
+	damage_mult = BASE_BULLET_DAMAGE_MULT + BULLET_DAMAGE_MULT_TIER_8
 	recoil = RECOIL_AMOUNT_TIER_5
 	recoil_unwielded = RECOIL_AMOUNT_TIER_3
 
@@ -685,7 +685,6 @@
 	icon = 'icons/obj/items/weapons/guns/guns_by_faction/uscm.dmi'
 	icon_state = "vp78"
 	item_state = "vp78"
-
 	fire_sound = 'sound/weapons/gun_vp78_v2.ogg'
 	reload_sound = 'sound/weapons/gun_vp78_reload.ogg'
 	unload_sound = 'sound/weapons/gun_vp78_unload.ogg'
@@ -717,7 +716,7 @@
 
 /obj/item/weapon/gun/pistol/vp78/set_gun_config_values()
 	..()
-	set_fire_delay(FIRE_DELAY_TIER_4)
+	set_fire_delay(FIRE_DELAY_TIER_6)
 	set_burst_amount(BURST_AMOUNT_TIER_3)
 	set_burst_delay(FIRE_DELAY_TIER_11)
 	accuracy_mult = BASE_ACCURACY_MULT

--- a/code/modules/projectiles/magazines/pistols.dm
+++ b/code/modules/projectiles/magazines/pistols.dm
@@ -163,7 +163,8 @@
 
 /obj/item/ammo_magazine/pistol/heavy
 	name = "\improper Desert Eagle magazine (.50)"
-	default_ammo = /datum/ammo/bullet/pistol/deagle
+	desc = "Seven rounds of devastatingly powerful 50 destruction."
+	default_ammo = /datum/ammo/bullet/pistol/heavy
 	caliber = ".50"
 	icon = 'icons/obj/items/weapons/guns/ammo_by_faction/colony.dmi'
 	icon_state = "deagle"
@@ -173,22 +174,21 @@
 	ammo_band_icon_empty = "+deagle_band_e"
 
 /obj/item/ammo_magazine/pistol/heavy/super //Commander's variant
-	name = "\improper Heavy Desert Eagle magazine (.50)"
-	desc = "Seven rounds of devastatingly powerful 50-caliber destruction."
+	name = "\improper Heavy Desert Eagle magazine (.50s)"
 	gun_type = /obj/item/weapon/gun/pistol/heavy/co
 	default_ammo = /datum/ammo/bullet/pistol/heavy/super
 	ammo_band_color = AMMO_BAND_COLOR_SUPER
 
 /obj/item/ammo_magazine/pistol/heavy/super/highimpact
-	name = "\improper High Impact Desert Eagle magazine (.50)"
+	name = "\improper High Impact Desert Eagle magazine (.50s)"
 	desc = "Seven rounds of devastatingly powerful 50-caliber destruction. The bullets are tipped with a synthesized osmium and lead alloy to stagger absolutely anything they hit. Point away from anything you value."
 	default_ammo = /datum/ammo/bullet/pistol/heavy/super/highimpact
 	ammo_band_color = AMMO_BAND_COLOR_HIGH_IMPACT
 
 /obj/item/ammo_magazine/pistol/heavy/super/highimpact/ap
-	name = "\improper High Impact Armor-Piercing Desert Eagle magazine (.50)"
-	desc = "Seven rounds of devastatingly powerful 50-caliber destruction. Packs a devastating punch. The bullets are tipped with an osmium-tungsten carbide alloy to not only stagger but shred through any target's armor. Issued in few numbers due to the massive production cost and worries about hull breaches. Point away from anything you value."
-	default_ammo = /datum/ammo/bullet/pistol/heavy/super/highimpact/ap
+	name = "\improper Armor-Piercing Desert Eagle magazine (.50s)"
+	desc = "Seven rounds of devastatingly powerful 50-caliber destruction. The bullets are tipped with an osmium-tungsten carbide alloy to shred through any target's armor. Issued in few numbers due to the massive production cost and worries about hull breaches. Point away from anything you value."
+	default_ammo = /datum/ammo/bullet/pistol/heavy/super/ap
 	ammo_band_color = AMMO_BAND_COLOR_AP
 
 //-------------------------------------------------------


### PR DESCRIPTION
# About the pull request ----




Weapons:
**VP78:**
Increases Firerate of VP78 by 2 
Decreases penetration by 1 tier
Increases Shrapnel chance by 4 tiers (squash head lol)

**Deagle**
Increased damage ( new damage = 70 aprox)
removed variable damage ( most weapons dont use it anymore)


**CO deagle**
-decreased accuracy penalty
-Renamed Caliber to .50s ( super!!)
-damage increased to 98
-Penetration removed on High impact rounds
-Stun removed on AP rounds

Code:
-removed empty lines 
-Merged .50 ammunition with Heavy bullets.
-Removed CO bullet parent will now be /super , not /superhighimpact
-deleted repeated arguments


# Explain why it's good for the game

Deagle and heavy pistols in general currently feel in a bad shape . they are slow . have little to no ammo and outgunned by smaller calibers . this PR aims to make your portable bazooka a viable solution winout being overpowered.

regarding CO weapon:
Its been tested ingame and it deals about the same DMG than the mateba . In the future i plan to remove the stun from the mateba AP but that may be a task for later.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: Increased VP78 Firerate by 2 tiers , reduced AP by 1 tier
balance: Increased Deagle damage to 70.
balance: increased CO deagle damage to 98. adjusted Accuracy and penetration on alternative ammo
removal: removed stun from AP high impact rounds.
/:cl:
