### PR TITLE
Fixes Observer Death Messages being delayed

### DIFF
--- a/code/datums/statistics/entities/death_stats.dm
+++ b/code/datums/statistics/entities/death_stats.dm
@@ -84,6 +84,10 @@
 	if(!mind || statistic_exempt)
 		return
 
+	var/area/area = get_area(death_loc)
+	handle_observer_message(cause_data, cause_mob, death_loc, area)
+
+	// Perform logging above before get_player_from_key to avoid delays
 	var/datum/entity/statistic/death/new_death = DB_ENTITY(/datum/entity/statistic/death)
 	var/datum/entity/player/player_entity = get_player_from_key(mind.ckey)
 	if(player_entity)
@@ -95,11 +99,8 @@
 	new_death.role_name = get_role_name()
 	new_death.mob_name = real_name
 	new_death.faction_name = faction
-
 	new_death.is_xeno = FALSE
-
-	var/area/A = get_area(death_loc)
-	new_death.area_name = A.name
+	new_death.area_name = area.name
 
 	new_death.cause_name = cause_data?.cause_name
 	var/datum/entity/player/cause_player = get_player_from_key(cause_data?.ckey)
@@ -131,8 +132,6 @@
 	new_death.total_time_alive = life_time_total
 	new_death.total_damage_taken = life_damage_taken_total
 	new_death.total_revives_done = life_revives_total
-
-	handle_observer_message(cause_data, cause_mob, death_loc, A)
 
 	if(round_statistics)
 		round_statistics.track_death(new_death)


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

Long standing bug - due to waiting for not one but two full database entities loading, the death message in dchat is delayed.

It's also symptomatic of a scheduling problem with DBQM as you can see deaths occuring in "batches" every couple seconds, indicating the queries are not processed timely - but this is out of scope for this PR.

Instead it just moves the observer logging to take place before DB ops.

# Explain why it's good for the game
Feels less clunky.

# Testing Photographs and Procedure
Just spawned stuff and abombed it.


# Changelog
:cl:
fix: deadchat death messages should now display immediately rather than being delayed a couple seconds.
/:cl:
