### PR TITLE
Fixes pounces targeting unliving on the landing turf

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
@@ -357,8 +357,8 @@
 
 /mob/living/carbon/xenomorph/proc/pounced_turf(turf/T)
 	if(!T.density)
-		for(var/mob/M in T)
-			pounced_mob(M)
+		for(var/mob/living/mob in T)
+			pounced_mob(mob)
 			break
 	else
 		turf_launch_collision(T)


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

Fixes #1053

Stops pounce landing from scanning ghosts/holograms and targeting them in place of a living target.

It was pretty obvious for Queen Eye but apparently seemed to actually happen with Ghosts aswell - since there was no message due to checks further down, it was overlooked

# Explain why it's good for the game
Invisible bugs aren't so fun


# Changelog
:cl:
fix: Fixed Ghosts and Queen Eye occasionally "eating" pounces in place of a mob on the same turf.
/:cl:
