### PR TITLE
Removes thermal goggles from spawning in game

### DIFF
--- a/code/game/objects/effects/spawners/random.dm
+++ b/code/game/objects/effects/spawners/random.dm
@@ -268,9 +268,7 @@
 	icon_state = "loot_goggles"
 
 /obj/effect/spawner/random/goggles/item_to_spawn()
-	return pick(prob(4);/obj/item/clothing/glasses/thermal/syndi/bug_b_gone,\
-				prob(4);/obj/item/clothing/glasses/thermal/syndi,\
-				prob(4);/obj/item/clothing/glasses/thermal/monocle,\
+	return pick(prob(4);/obj/item/clothing/glasses/thermal/monocle,\
 				prob(4);/obj/item/clothing/glasses/thermal/eyepatch,\
 				prob(4);/obj/item/clothing/glasses/welding/superior,\
 				prob(4);/obj/item/clothing/glasses/hud/security/jensenshades,\

--- a/code/game/objects/effects/spawners/random.dm
+++ b/code/game/objects/effects/spawners/random.dm
@@ -268,9 +268,7 @@
 	icon_state = "loot_goggles"
 
 /obj/effect/spawner/random/goggles/item_to_spawn()
-	return pick(prob(4);/obj/item/clothing/glasses/thermal/monocle,\
-				prob(4);/obj/item/clothing/glasses/thermal/eyepatch,\
-				prob(4);/obj/item/clothing/glasses/welding/superior,\
+	return pick(prob(4);/obj/item/clothing/glasses/welding/superior,\
 				prob(4);/obj/item/clothing/glasses/hud/security/jensenshades,\
 				prob(4);/obj/item/clothing/glasses/meson/refurbished,\
 				prob(4);/obj/item/clothing/glasses/science,\

--- a/maps/map_files/Kutjevo/Kutjevo.dmm
+++ b/maps/map_files/Kutjevo/Kutjevo.dmm
@@ -5968,9 +5968,6 @@
 /area/kutjevo/exterior/lz_dunes)
 "idX" = (
 /obj/structure/closet/firecloset/full,
-/obj/item/clothing/glasses/thermal/syndi{
-	icon_state = "kutjevo_goggles"
-	},
 /obj/effect/landmark/objective_landmark/close,
 /turf/open/floor/kutjevo/multi_tiles,
 /area/kutjevo/interior/complex/med/locks)
@@ -12914,20 +12911,6 @@
 	},
 /turf/open/floor/kutjevo/tan/multi_tiles,
 /area/kutjevo/interior/complex/botany/east_tech)
-"rRC" = (
-/obj/structure/surface/table/reinforced/prison,
-/obj/structure/barricade/handrail/kutjevo{
-	layer = 3.1
-	},
-/obj/item/clipboard,
-/obj/item/clothing/glasses/thermal/syndi{
-	icon_state = "kutjevo_goggles";
-	pixel_y = -2
-	},
-/turf/open/floor/kutjevo/multi_tiles{
-	dir = 4
-	},
-/area/kutjevo/interior/colony_South/power2)
 "rRL" = (
 /obj/structure/platform/kutjevo{
 	dir = 1
@@ -41206,7 +41189,7 @@ rfE
 rdm
 rdm
 rsM
-rRC
+eVO
 aoJ
 tnx
 iiG

--- a/maps/map_files/Sorokyne_Strata/Sorokyne_Strata.dmm
+++ b/maps/map_files/Sorokyne_Strata/Sorokyne_Strata.dmm
@@ -29652,7 +29652,6 @@
 "czw" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/storage/box/ids,
-/obj/item/clothing/glasses/thermal/syndi,
 /turf/open/floor/strata{
 	icon_state = "purp1"
 	},
@@ -38350,7 +38349,6 @@
 /turf/open/asphalt/cement,
 /area/strata/ag/exterior/tcomms/tcomms_deck)
 "rkb" = (
-/obj/item/clothing/glasses/thermal/syndi,
 /obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
 /turf/open/floor/strata{
 	dir = 8;


### PR DESCRIPTION
# About the pull request

Removes a pair of very overpowered items from two maps (Soro and Kut) as well as a RNG spawner. 

# Explain why it's good for the game

Items usually reserved for whiteout or other high-strength entities should not be available in normal gameplay. 

Vision and sightlines are a highly contentious area of balance, the game is carefully crafted around the idea that humans have limited visibility and they typically have to expend some effort or resource to increase that visiblity. Certain Marines have access to night vision, but this is either a rare kit (spec) or at greater cost (NVG optic that has a high cost + power drain).

Free thermal visors that not only provide night vision, but thermal vision, for free and forever, are highly overpowered in the hands of a marine. Normally reserved for Xenos, Predators or rare elite ERTs or whiteout operators, this is not a item I believe should be accessible to an average marine or survivor. 

(Don't forget this could be combined with binocs for extra long vision)

Furthermore this is a case of "the rich get richer", its more likely a veteran player will know of these items locations, ergo more experienced players will find it, and thus gain an ever stronger advantage of other players. 

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
maptweak: Removed in game access to thermal goggles from Kutjevo and Sorokyne, as well as removing a RNG spawner that can have them be spawned in. 
/:cl:
