### PR TITLE
Thermal Alternate PR

### DIFF
--- a/maps/map_files/FOP_v3_Sciannex/Fiorina_SciAnnex.dmm
+++ b/maps/map_files/FOP_v3_Sciannex/Fiorina_SciAnnex.dmm
@@ -4537,11 +4537,6 @@
 	icon_state = "bluefull"
 	},
 /area/fiorina/station/power_ring)
-"cFX" = (
-/obj/structure/largecrate/supply/supplies,
-/obj/effect/spawner/random/goggles/lowchance,
-/turf/open/floor/plating/prison,
-/area/fiorina/station/power_ring)
 "cGg" = (
 /obj/structure/machinery/gibber,
 /turf/open/floor/prison{
@@ -23497,13 +23492,6 @@
 	icon_state = "floor_plate"
 	},
 /area/fiorina/station/power_ring)
-"ohs" = (
-/obj/structure/surface/table/reinforced/prison,
-/obj/effect/spawner/random/goggles/lowchance,
-/turf/open/floor/prison{
-	icon_state = "redfull"
-	},
-/area/fiorina/station/security)
 "ohF" = (
 /obj/structure/platform/kutjevo/smooth,
 /turf/closed/wall/mineral/bone_resin,
@@ -28706,12 +28694,6 @@
 	icon_state = "floor_plate"
 	},
 /area/fiorina/station/lowsec)
-"rru" = (
-/obj/effect/spawner/random/goggles/midchance,
-/turf/open/organic/grass{
-	name = "astroturf"
-	},
-/area/fiorina/station/research_cells)
 "rrP" = (
 /obj/effect/spawner/random/tool,
 /turf/open/floor/prison{
@@ -30529,16 +30511,6 @@
 	icon_state = "floor_plate"
 	},
 /area/fiorina/tumor/aux_engi)
-"sAx" = (
-/obj/structure/bed{
-	icon_state = "abed"
-	},
-/obj/effect/spawner/random/goggles/lowchance,
-/turf/open/floor/prison{
-	dir = 6;
-	icon_state = "whitepurple"
-	},
-/area/fiorina/station/research_cells)
 "sAK" = (
 /obj/item/device/flashlight/lamp/tripod,
 /turf/open/floor/prison{
@@ -31707,8 +31679,8 @@
 /area/fiorina/maintenance)
 "tpt" = (
 /obj/structure/closet/wardrobe/chaplain_black,
-/obj/effect/spawner/random/goggles,
 /obj/effect/landmark/objective_landmark/close,
+/obj/item/clothing/glasses/thermal/syndi/bug_b_gone,
 /turf/open/floor/prison/chapel_carpet,
 /area/fiorina/station/chapel)
 "tpO" = (
@@ -35323,13 +35295,6 @@
 /obj/item/clothing/suit/storage/hazardvest,
 /turf/open/floor/wood,
 /area/fiorina/station/civres_blue)
-"vyz" = (
-/obj/structure/surface/table/reinforced/prison,
-/obj/effect/spawner/random/goggles/lowchance,
-/turf/open/floor/prison{
-	icon_state = "floor_plate"
-	},
-/area/fiorina/station/park)
 "vyA" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -58824,7 +58789,7 @@ xub
 cdD
 ajK
 kXD
-vyz
+gbU
 itd
 uGM
 bNT
@@ -72168,7 +72133,7 @@ xBI
 xBI
 xBI
 gIB
-ohs
+lgy
 qgA
 tHs
 sRV
@@ -76958,7 +76923,7 @@ ikq
 dyM
 cKa
 ikq
-sAx
+dSw
 cKa
 xMR
 iqV
@@ -82888,7 +82853,7 @@ uTp
 uTp
 bXk
 nmm
-rru
+nmm
 nmm
 djB
 wJd
@@ -85923,7 +85888,7 @@ dGj
 mxQ
 mxQ
 tUs
-cFX
+wBX
 mxQ
 mxQ
 mxQ

--- a/maps/map_files/Kutjevo/Kutjevo.dmm
+++ b/maps/map_files/Kutjevo/Kutjevo.dmm
@@ -3544,6 +3544,19 @@
 /obj/structure/machinery/cryo_cell,
 /turf/open/floor/kutjevo/grey/plate,
 /area/kutjevo/interior/complex/med/cells)
+"eDz" = (
+/obj/structure/machinery/light{
+	dir = 4
+	},
+/obj/structure/safe{
+	spawnkey = 0
+	},
+/obj/item/clothing/glasses/thermal/syndi{
+	icon_state = "kutjevo_goggles";
+	pixel_y = -2
+	},
+/turf/open/floor/kutjevo/grey/plate,
+/area/kutjevo/interior/construction)
 "eDQ" = (
 /obj/structure/blocker/invisible_wall,
 /turf/open/desert/desert_shore/shore_edge1{
@@ -5968,9 +5981,6 @@
 /area/kutjevo/exterior/lz_dunes)
 "idX" = (
 /obj/structure/closet/firecloset/full,
-/obj/item/clothing/glasses/thermal/syndi{
-	icon_state = "kutjevo_goggles"
-	},
 /obj/effect/landmark/objective_landmark/close,
 /turf/open/floor/kutjevo/multi_tiles,
 /area/kutjevo/interior/complex/med/locks)
@@ -12915,19 +12925,17 @@
 /turf/open/floor/kutjevo/tan/multi_tiles,
 /area/kutjevo/interior/complex/botany/east_tech)
 "rRC" = (
-/obj/structure/surface/table/reinforced/prison,
-/obj/structure/barricade/handrail/kutjevo{
-	layer = 3.1
+/obj/structure/flora/pottedplant{
+	icon_state = "pottedplant_29";
+	pixel_y = 6
 	},
-/obj/item/clipboard,
 /obj/item/clothing/glasses/thermal/syndi{
 	icon_state = "kutjevo_goggles";
-	pixel_y = -2
+	pixel_x = -1;
+	pixel_y = 19
 	},
-/turf/open/floor/kutjevo/multi_tiles{
-	dir = 4
-	},
-/area/kutjevo/interior/colony_South/power2)
+/turf/open/floor/kutjevo/colors/orange,
+/area/kutjevo/interior/colony_central/mine_elevator)
 "rRL" = (
 /obj/structure/platform/kutjevo{
 	dir = 1
@@ -41206,7 +41214,7 @@ rfE
 rdm
 rdm
 rsM
-rRC
+eVO
 aoJ
 tnx
 iiG
@@ -43692,7 +43700,7 @@ mbR
 xMm
 feg
 qaI
-wSU
+eDz
 oQL
 hrR
 qaI
@@ -51387,7 +51395,7 @@ vdv
 vdv
 vdv
 cyc
-tlq
+rRC
 cgM
 tlq
 pGc

--- a/maps/map_files/Sorokyne_Strata/Sorokyne_Strata.dmm
+++ b/maps/map_files/Sorokyne_Strata/Sorokyne_Strata.dmm
@@ -35116,6 +35116,15 @@
 	icon_state = "cement3"
 	},
 /area/strata/ag/exterior/tcomms/tcomms_deck)
+"lUb" = (
+/obj/item/clothing/glasses/thermal/syndi,
+/obj/structure/safe{
+	spawnkey = 0
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/strata/ug/interior/jungle/deep/structures/res)
 "lUg" = (
 /obj/structure/pipes/standard/simple/hidden/cyan{
 	dir = 9
@@ -38350,7 +38359,6 @@
 /turf/open/asphalt/cement,
 /area/strata/ag/exterior/tcomms/tcomms_deck)
 "rkb" = (
-/obj/item/clothing/glasses/thermal/syndi,
 /obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
 /turf/open/floor/strata{
 	dir = 8;
@@ -88748,7 +88756,7 @@ bRl
 bRl
 bRl
 aeY
-agq
+lUb
 ahm
 ahm
 air


### PR DESCRIPTION
# About the pull request

This PR is an alternate to https://github.com/cmss13-devs/cmss13/pull/4778 which strives to maintain the kit in the game. These items have been in the game for half a decade, and are/have been a non-issue for this entire time. What happens is someone (usually a surv) gets them, then they die and no one takes them because no one thinks they matter. This PR makes it harder to gain access to these items by placing them further afield, and often time placing them inside of a safe further increasing the opportunity cost and time sink required to achieve these items.


# Explain why it's good for the game

I do not think there is a warranted reason to remove thermals from normal play, they've been in the game and actively used for half a decade and I've hardly seen any complaints about them in all of that time. The spawns that were easily accessed have been moved further away, often put into safes so the risk is extremely high. I think this type of gear balancing (time and opportunity cost combined with risk vs reward) should be considered as the norm for dealing with survivor gear rather than simply removing or randomizing gear.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/cmss13-devs/cmss13/assets/133173804/354fb00e-13f8-431b-af63-e91f242c5f53)
Science annex has had all of its random goggle spawners removed, and the old thermal spawn in chapel has been returned. With the removal of the west bridge in yard, its still in a high risk area to go for.

![image](https://github.com/cmss13-devs/cmss13/assets/133173804/e4113e73-f105-46be-87a0-37b35f374e1b)
One of the thermal goggles has been moved into the NE of soro and put into a safe. Getting access to this item will be a major risk.

![image](https://github.com/cmss13-devs/cmss13/assets/133173804/4904de0b-419c-4160-942e-71ff9e513660)
One of kutjevo's goggles have been moved into a safe and to the rear of construction. High risk area because its almost always weeded within 3min of the game starting, and you'll need to guess the safe's combo to get it.

![image](https://github.com/cmss13-devs/cmss13/assets/133173804/df0adf2b-f680-440e-a12f-ff373c850de3)
The other kutjevo goggles have been moved to where the golden HG spawn is. Super far into the map, you'll need to take a major risk to get it.

</details>


# Changelog

:cl:
balance: Rebalanced the thermal placement on Soro, Science Annex, and Kutjevo
/:cl:


