### PR TITLE
Fixes custom ERT calling

### DIFF
--- a/code/datums/emergency_calls/cryo_marines.dm
+++ b/code/datums/emergency_calls/cryo_marines.dm
@@ -13,7 +13,7 @@
 	var/leaders = 0
 	spawn_max_amount = TRUE
 
-/datum/emergency_call/cryo_squad/spawn_candidates(announce, override_spawn_loc)
+/datum/emergency_call/cryo_squad/spawn_candidates(quiet_launch, announce_incoming, override_spawn_loc)
 	var/datum/squad/marine/cryo/cryo_squad = RoleAuthority.squads_by_type[/datum/squad/marine/cryo]
 	leaders = cryo_squad.num_leaders
 	. = ..()

--- a/code/datums/emergency_calls/cryo_marines.dm
+++ b/code/datums/emergency_calls/cryo_marines.dm
@@ -13,7 +13,7 @@
 	var/leaders = 0
 	spawn_max_amount = TRUE
 
-/datum/emergency_call/cryo_squad/spawn_candidates(announce, override_spawn_loc, announce_dispatch_message)
+/datum/emergency_call/cryo_squad/spawn_candidates(announce, override_spawn_loc)
 	var/datum/squad/marine/cryo/cryo_squad = RoleAuthority.squads_by_type[/datum/squad/marine/cryo]
 	leaders = cryo_squad.num_leaders
 	. = ..()

--- a/code/datums/emergency_calls/cryo_marines_heavy.dm
+++ b/code/datums/emergency_calls/cryo_marines_heavy.dm
@@ -16,7 +16,7 @@
 
 	var/leaders = 0
 
-/datum/emergency_call/cryo_squad_equipped/spawn_candidates(announce, override_spawn_loc)
+/datum/emergency_call/cryo_squad_equipped/spawn_candidates(quiet_launch, announce_incoming, override_spawn_loc)
 	var/datum/squad/marine/cryo/cryo_squad = RoleAuthority.squads_by_type[/datum/squad/marine/cryo]
 	leaders = cryo_squad.num_leaders
 	. = ..()

--- a/code/datums/emergency_calls/cryo_marines_heavy.dm
+++ b/code/datums/emergency_calls/cryo_marines_heavy.dm
@@ -16,7 +16,7 @@
 
 	var/leaders = 0
 
-/datum/emergency_call/cryo_squad_equipped/spawn_candidates(announce, override_spawn_loc, announce_dispatch_message)
+/datum/emergency_call/cryo_squad_equipped/spawn_candidates(announce, override_spawn_loc)
 	var/datum/squad/marine/cryo/cryo_squad = RoleAuthority.squads_by_type[/datum/squad/marine/cryo]
 	leaders = cryo_squad.num_leaders
 	. = ..()

--- a/code/datums/emergency_calls/emergency_call.dm
+++ b/code/datums/emergency_calls/emergency_call.dm
@@ -91,12 +91,12 @@
 	else
 		return chosen_call
 
-/datum/game_mode/proc/get_specific_call(call_name, quiet_launch = FALSE, announce = TRUE, is_emergency = TRUE, info = "", announce_dispatch_message = TRUE)
+/datum/game_mode/proc/get_specific_call(call_name, quiet_launch = FALSE, announce_incoming = TRUE, info = "")
 	for(var/datum/emergency_call/E in all_calls) //Loop through all potential candidates
 		if(E.name == call_name)
 			var/datum/emergency_call/em_call = new E.type()
 			em_call.objective_info = info
-			em_call.activate(quiet_launch, announce, is_emergency, announce_dispatch_message)
+			em_call.activate(quiet_launch, announce_incoming)
 			return
 	error("get_specific_call could not find emergency call '[call_name]'")
 	return
@@ -192,7 +192,7 @@
 	else
 		to_chat(src, SPAN_WARNING("You did not get enlisted in the response team. Better luck next time!"))
 
-/datum/emergency_call/proc/activate(quiet_launch = FALSE, announce = TRUE, turf/override_spawn_loc, announce_dispatch_message = TRUE)
+/datum/emergency_call/proc/activate(quiet_launch = FALSE, announce_incoming = TRUE, turf/override_spawn_loc)
 	set waitfor = 0
 	if(!SSticker.mode) //Something horribly wrong with the gamemode ticker
 		return
@@ -205,9 +205,9 @@
 	if(!quiet_launch)
 		marine_announcement("A distress beacon has been launched from the [MAIN_SHIP_NAME].", "Priority Alert", 'sound/AI/distressbeacon.ogg', logging = ARES_LOG_SECURITY)
 
-	addtimer(CALLBACK(src, TYPE_PROC_REF(/datum/emergency_call, spawn_candidates), quiet_launch, announce, override_spawn_loc, announce_dispatch_message), 30 SECONDS)
+	addtimer(CALLBACK(src, TYPE_PROC_REF(/datum/emergency_call, spawn_candidates), quiet_launch, announce_incoming, override_spawn_loc), 30 SECONDS)
 
-/datum/emergency_call/proc/spawn_candidates(quiet_launch = FALSE, announce = TRUE, override_spawn_loc, announce_dispatch_message = TRUE)
+/datum/emergency_call/proc/spawn_candidates(quiet_launch = FALSE, announce_incoming = TRUE, override_spawn_loc)
 	if(SSticker.mode)
 		SSticker.mode.picked_calls -= src
 
@@ -248,7 +248,7 @@
 				if(I.current)
 					to_chat(I.current, SPAN_WARNING("You didn't get selected to join the distress team. Better luck next time!"))
 
-	if(announce)
+	if(announce_incoming)
 		marine_announcement(dispatch_message, "Distress Beacon", 'sound/AI/distressreceived.ogg', logging = ARES_LOG_SECURITY) //Announcement that the Distress Beacon has been answered, does not hint towards the chosen ERT
 
 	message_admins("Distress beacon: [src.name] finalized, setting up candidates.")
@@ -304,7 +304,7 @@
 			create_member(null, override_spawn_loc)
 
 	candidates = list()
-	if(arrival_message && announce)
+	if(arrival_message && announce_incoming)
 		marine_announcement(arrival_message, "Intercepted Tranmission:")
 
 /datum/emergency_call/proc/add_candidate(mob/M)

--- a/code/game/gamemodes/colonialmarines/colonialmarines.dm
+++ b/code/game/gamemodes/colonialmarines/colonialmarines.dm
@@ -265,7 +265,7 @@
 			continue
 
 	if(groundside_humans > (groundside_xenos * GROUNDSIDE_XENO_MULTIPLIER))
-		SSticker.mode.get_specific_call("Xenomorphs Groundside (Forsaken)", TRUE, FALSE, FALSE, announce_dispatch_message = FALSE)
+		SSticker.mode.get_specific_call("Xenomorphs Groundside (Forsaken)", TRUE, FALSE)
 
 	TIMER_COOLDOWN_START(src, COOLDOWN_HIJACK_GROUND_CHECK, 1 MINUTES)
 

--- a/code/game/gamemodes/colonialmarines/whiskey_outpost.dm
+++ b/code/game/gamemodes/colonialmarines/whiskey_outpost.dm
@@ -193,7 +193,7 @@
 	announce_xeno_wave(wave)
 	if(xeno_wave == 7)
 		//Wave when Marines get reinforcements!
-		get_specific_call("Marine Reinforcements (Squad)", FALSE, TRUE, FALSE)
+		get_specific_call("Marine Reinforcements (Squad)", FALSE, TRUE)
 	xeno_wave = min(xeno_wave + 1, WO_MAX_WAVE)
 
 

--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -1251,7 +1251,7 @@ var/datum/controller/supply/supply_controller = new()
 
 /datum/controller/supply/proc/black_market_investigation()
 	black_market_heat = -1
-	SSticker.mode.get_specific_call("Inspection - Colonial Marshal Ledger Investigation Team", TRUE, TRUE, FALSE)
+	SSticker.mode.get_specific_call("Inspection - Colonial Marshal Ledger Investigation Team", TRUE, TRUE)
 	log_game("Black Market Inspection auto-triggered.")
 
 /obj/structure/machinery/computer/supplycomp/proc/is_buyable(datum/supply_packs/supply_pack)

--- a/code/modules/admin/tabs/event_tab.dm
+++ b/code/modules/admin/tabs/event_tab.dm
@@ -218,14 +218,17 @@
 	if(!istype(chosen_ert))
 		return
 
-	var/quiet_launch = tgui_alert(usr, "Would you like to announce the distress beacon to the server population? This will reveal the distress beacon to all players.", "Announce distress beacon?", list("Yes", "No"), 20 SECONDS)
-	if(!quiet_launch)
-		qdel(chosen_ert)
-		return
-	if(quiet_launch == "No")
-		quiet_launch = TRUE
-	if (quiet_launch == "Yes")
-		quiet_launch = FALSE
+	var/launch_broadcast = tgui_alert(usr, "Would you like to broadcast the beacon launch? This will reveal the distress beacon to all players.", "Announce distress beacon?", list("Yes", "No"), 20 SECONDS)
+	if(launch_broadcast == "Yes")
+		launch_broadcast = TRUE
+	else
+		launch_broadcast = FALSE
+
+	var/announce_receipt = tgui_alert(usr, "Would you like to announce the beacon received message? This will reveal the distress beacon to all players.", "Announce beacon received?", list("Yes", "No"), 20 SECONDS)
+	if(announce_receipt == "Yes")
+		announce_receipt = TRUE
+	else
+		announce_receipt = FALSE
 
 	var/turf/override_spawn_loc
 	var/prompt = tgui_alert(usr, "Spawn at their assigned spawn, or at your location?", "Spawnpoint Selection", list("Spawn", "Current Location"), 0)
@@ -235,7 +238,7 @@
 	if(prompt == "Current Location")
 		override_spawn_loc = get_turf(usr)
 
-	chosen_ert.activate(quiet_launch = quiet_launch, announce = !quiet_launch, override_spawn_loc = override_spawn_loc)
+	chosen_ert.activate(quiet_launch = launch_broadcast, announce_incoming = announce_receipt, override_spawn_loc = override_spawn_loc)
 
 	message_admins("[key_name_admin(usr)] admin-called a [choice == "Randomize" ? "randomized ":""]distress beacon: [chosen_ert.name]")
 

--- a/code/modules/admin/topic/topic.dm
+++ b/code/modules/admin/topic/topic.dm
@@ -2017,7 +2017,7 @@
 	if(distress_cancel)
 		return
 	distress_cancel = TRUE
-	SSticker.mode.get_specific_call("[ert_called]", TRUE, FALSE, FALSE)
+	SSticker.mode.get_specific_call("[ert_called]", TRUE, FALSE)
 	log_game("[key_name_admin(approver)] has sent [ert_called], requested by [key_name_admin(ref_person)]")
 	message_admins("[key_name_admin(approver)] has sent [ert_called], requested by [key_name_admin(ref_person)]")
 

--- a/code/modules/admin/topic/topic_events.dm
+++ b/code/modules/admin/topic/topic_events.dm
@@ -206,7 +206,19 @@
 			em_call.players_to_offer = humans
 			em_call.owner = owner
 
-			em_call.activate(announce = FALSE)
+			var/launch_broadcast = tgui_alert(usr, "Would you like to broadcast the beacon launch? This will reveal the distress beacon to all players.", "Announce distress beacon?", list("Yes", "No"), 20 SECONDS)
+			if(launch_broadcast == "Yes")
+				launch_broadcast = TRUE
+			else
+				launch_broadcast = FALSE
+
+			var/announce_receipt = tgui_alert(usr, "Would you like to announce the beacon received message? This will reveal the distress beacon to all players.", "Announce beacon received?", list("Yes", "No"), 20 SECONDS)
+			if(announce_receipt == "Yes")
+				announce_receipt = TRUE
+			else
+				announce_receipt = FALSE
+
+			em_call.activate(launch_broadcast, announce_receipt)
 
 		message_admins("[key_name_admin(usr)] created [humans_to_spawn] humans as [job_name] at [get_area(initial_spot)]")
 
@@ -284,7 +296,19 @@
 			em_call.players_to_offer = xenos
 			em_call.owner = owner
 
-			em_call.activate(announce = FALSE)
+			var/launch_broadcast = tgui_alert(usr, "Would you like to broadcast the beacon launch? This will reveal the distress beacon to all players.", "Announce distress beacon?", list("Yes", "No"), 20 SECONDS)
+			if(launch_broadcast == "Yes")
+				launch_broadcast = TRUE
+			else
+				launch_broadcast = FALSE
+
+			var/announce_receipt = tgui_alert(usr, "Would you like to announce the beacon received message? This will reveal the distress beacon to all players.", "Announce beacon received?", list("Yes", "No"), 20 SECONDS)
+			if(announce_receipt == "Yes")
+				announce_receipt = TRUE
+			else
+				announce_receipt = FALSE
+
+			em_call.activate(launch_broadcast, announce_receipt)
 
 		message_admins("[key_name_admin(usr)] created [xenos_to_spawn] xenos as [xeno_caste] at [get_area(initial_spot)]")
 

--- a/code/modules/cm_tech/techs/marine/tier3/cryo_spec.dm
+++ b/code/modules/cm_tech/techs/marine/tier3/cryo_spec.dm
@@ -21,4 +21,4 @@
 
 /datum/tech/cryomarine/on_unlock()
 	. = ..()
-	SSticker.mode.get_specific_call("Marine Cryo Reinforcement (Spec)", TRUE, FALSE, FALSE, announce_dispatch_message = FALSE)
+	SSticker.mode.get_specific_call("Marine Cryo Reinforcement (Spec)", TRUE, FALSE)

--- a/code/modules/cm_tech/techs/marine/tier3/cryorine.dm
+++ b/code/modules/cm_tech/techs/marine/tier3/cryorine.dm
@@ -23,4 +23,4 @@
 
 /datum/tech/repeatable/cryomarine/on_unlock()
 	. = ..()
-	SSticker.mode.get_specific_call("Marine Cryo Reinforcements (Tech)", TRUE, FALSE, FALSE, announce_dispatch_message = FALSE)
+	SSticker.mode.get_specific_call("Marine Cryo Reinforcements (Tech)", TRUE, FALSE)

--- a/code/modules/reagents/chemistry_properties/prop_special.dm
+++ b/code/modules/reagents/chemistry_properties/prop_special.dm
@@ -96,7 +96,7 @@
 		H.contract_disease(new /datum/disease/xeno_transformation(0),1) //This is the real reason PMCs are being sent to retrieve it.
 
 /datum/chem_property/special/DNA_Disintegrating/trigger()
-	SSticker.mode.get_specific_call("Weyland-Yutani Goon (Chemical Investigation Squad)", TRUE, FALSE, FALSE, holder.name, TRUE)
+	SSticker.mode.get_specific_call("Weyland-Yutani Goon (Chemical Investigation Squad)", TRUE, FALSE, holder.name)
 	chemical_data.update_credits(10)
 	message_admins("The research department has discovered DNA_Disintegrating in [holder.name] adding 10 bonus tech points.")
 	var/datum/techtree/tree = GET_TREE(TREE_MARINE)


### PR DESCRIPTION

# About the pull request
Removes announce_dispatch_message variable as it was a defunct duplicate of a different variable.
Adds and fixes the announcement settings for custom ERTs.

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Fixes custom ERT calling broadcasting when it should not.
code: Removes unused vars from ERT procs.
code: Renames the announce var in ERT procs to be more indicative of what it does.
add: Added a setting on custom ERTs for announcing beacon was received.
/:cl:
