### PR TITLE
Remove Direct Hit Limb Penalty against Xenos

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -418,6 +418,3 @@ var/list/default_xeno_onmob_icons = list(
 #define EXTREMITY_LIMBS list("l_leg","l_foot","r_leg","r_foot","l_arm","l_hand","r_arm","r_hand")
 #define CORE_LIMBS list("chest","head","groin")
 
-
-/// Overall percentage miss chance if you were to target a random body part, averaged from entries in global list base_miss_chance
-#define MOB_OVERALL_MISS_CHANCE 15

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -417,3 +417,7 @@ var/list/default_xeno_onmob_icons = list(
 #define HANDLING_LIMBS list("l_arm","l_hand", "r_arm", "r_hand")
 #define EXTREMITY_LIMBS list("l_leg","l_foot","r_leg","r_foot","l_arm","l_hand","r_arm","r_hand")
 #define CORE_LIMBS list("chest","head","groin")
+
+
+/// Overall percentage miss chance if you were to target a random body part, averaged from entries in global list base_miss_chance
+#define MOB_OVERALL_MISS_CHANCE 15

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -28,7 +28,7 @@
 
 //TODO: Integrate defence zones and targeting body parts with the actual organ system, move these into organ definitions.
 
-//The base miss chance for the different defence zones
+/// The base miss chance for the different defence zones (see also MOB_OVERALL_MISS_CHANCE)
 var/list/global/base_miss_chance = list(
 	"head" = 10,
 	"chest" = 0,

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -28,7 +28,7 @@
 
 //TODO: Integrate defence zones and targeting body parts with the actual organ system, move these into organ definitions.
 
-/// The base miss chance for the different defence zones (see also MOB_OVERALL_MISS_CHANCE)
+/// The base miss chance for the different defence zones
 var/list/global/base_miss_chance = list(
 	"head" = 10,
 	"chest" = 0,

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -476,12 +476,10 @@
 		// At present, Xenos have no inherent effects or localized damage stemming from limb targeting
 		// Therefore we exempt the shooter from direct hit accuracy penalties as well,
 		// simply to avoid them from resetting target to chest every time they want to shoot a xeno
-		if(isxeno(L))
-			if(!direct_hit)
-				hit_chance -= MOB_OVERALL_MISS_CHANCE // Averaged miss chance across all limbs
-			// else treat this as a chest shot (0 penalty) regardless of aim for the pupose of hit rolls
-		else // For all other normal people we just apply per-limb hit penalty
+
+		if(!direct_hit || !isxeno(L)) // For normal people or direct hits we apply the limb accuracy penalty
 			hit_chance -= base_miss_chance[def_zone]
+		// else for direct hits on xenos, we skip it, pretending it's a chest shot with zero penalty
 
 		#if DEBUG_HIT_CHANCE
 		to_world(SPAN_DEBUG("([L]) Hit chance: [hit_chance] | Roll: [hit_roll]"))

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -455,12 +455,33 @@
 	if(hit_chance) // Calculated from combination of both ammo accuracy and gun accuracy
 
 		var/hit_roll = rand(1,100)
+		var/direct_hit = FALSE
 
-		if(original != L || hit_roll > hit_chance-base_miss_chance[def_zone]-20) // If hit roll is high or the firer wasn't aiming at this mob, we still hit but now we might hit the wrong body part
+		// Wasn't the clicked target
+		if(original != L)
 			def_zone = rand_zone()
+
+		// Xenos get a RNG limb miss chance regardless of being clicked target or not, see below
+		else if(isxeno(L) && hit_roll > hit_chance - 20)
+			def_zone = rand_zone()
+
+		// Other targets do the same roll with penalty - a near hit will hit but redirected to another limb
+		else if(!isxeno(L) && hit_roll > hit_chance - 20 - base_miss_chance[def_zone])
+			def_zone = rand_zone()
+
 		else
+			direct_hit = TRUE
 			SEND_SIGNAL(firer, COMSIG_BULLET_DIRECT_HIT, L)
-		hit_chance -= base_miss_chance[def_zone] // Reduce accuracy based on spot.
+
+		// At present, Xenos have no inherent effects or localized damage stemming from limb targeting
+		// Therefore we exempt the shooter from direct hit accuracy penalties as well,
+		// simply to avoid them from resetting target to chest every time they want to shoot a xeno
+		if(isxeno(L))
+			if(!direct_hit)
+				hit_chance -= MOB_OVERALL_MISS_CHANCE // Averaged miss chance across all limbs
+			// else treat this as a chest shot (0 penalty) regardless of aim for the pupose of hit rolls
+		else // For all other normal people we just apply per-limb hit penalty
+			hit_chance -= base_miss_chance[def_zone]
 
 		#if DEBUG_HIT_CHANCE
 		to_world(SPAN_DEBUG("([L]) Hit chance: [hit_chance] | Roll: [hit_roll]"))


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

## Simple version

Selecting a body part on doll at bottom right applies an inherent accuracy debuff to shots (an hand is harder to hit than chest). 

This penalty still applied to sprite-click attacks on Xenomorphs, despite the localized damage having no effect.

This means that you'd have to constantly reset your aimed part to chest every time you try to shoot a Xeno, or would suffer a "free" penalty.

## Detailled version

Old flow went as follow:
 * Get base Hit Chance and Roll
 * If it's only a near hit, or target's not the shot clicked target, the shot targeted limb is reset to a random one
 * Hit chance receives a penalty based on aimed limb
 * We proceed checking hit chance vs roll

Because of the above problem this is changed to:

* Get base Hit Chance and Roll
* If it's a near hit (including limb penalty), a near xeno hit (excluding limb penalty), or not the sprite-clicked target, aimed limb is reset to a random one
* Else if the target is a xeno and it was a proper direct hit, there is no penalty -- functionally similar to a chest shot
* Else Finally, apply per-limb penalty as usual
* We proceed checking hit chance vs roll

# Explain why it's good for the game
Avoids an invisible noobtrap debuff for just about everyone in the game that isn't in the know - and the neccessity to constantly reset targeting to chest for medics. 

# Testing Photographs and Procedure
The problem was tested by a player on discord -- the fix i tested just was spawning stuff and shooting up the place observing RNG misses. I did not take detailed statistics over time to confirm.


# Changelog
:cl:
fix: Sprite-click shots onto Xenos are no longer affected by limb-targeting penalty, because it was an accuracy debuff when there is no inherent benefit to targeting Xeno limbs.
/:cl:
