### PR TITLE
Tactical Supply Kit For Synth Experimental Vendor

### DIFF
--- a/code/game/machinery/vending/vendor_types/crew/synthetic.dm
+++ b/code/game/machinery/vending/vendor_types/crew/synthetic.dm
@@ -356,7 +356,7 @@ GLOBAL_LIST_INIT(cm_vending_clothing_synth_snowflake, list(
 		list("Maintenance Jack", 15, /obj/item/maintenance_jack, null, VENDOR_ITEM_REGULAR),
 		list("Portable Dialysis Machine", 15, /obj/item/tool/portadialysis, null, VENDOR_ITEM_REGULAR),
 		list("Telescopic Baton", 15, /obj/item/weapon/telebaton, null, VENDOR_ITEM_REGULAR),
-		list("Tactical Tools and C4", 15, /obj/item/storage/box/kit/tactical_kit, null, VENDOR_ITEM_REGULAR),
+		list("Tactical Equipment and C4", 15, /obj/item/storage/box/kit/tactical_kit, null, VENDOR_ITEM_REGULAR),
 	)
 
 //------------EXPERIMENTAL TOOL KITS---------------

--- a/code/game/machinery/vending/vendor_types/crew/synthetic.dm
+++ b/code/game/machinery/vending/vendor_types/crew/synthetic.dm
@@ -356,6 +356,7 @@ GLOBAL_LIST_INIT(cm_vending_clothing_synth_snowflake, list(
 		list("Maintenance Jack", 15, /obj/item/maintenance_jack, null, VENDOR_ITEM_REGULAR),
 		list("Portable Dialysis Machine", 15, /obj/item/tool/portadialysis, null, VENDOR_ITEM_REGULAR),
 		list("Telescopic Baton", 15, /obj/item/weapon/telebaton, null, VENDOR_ITEM_REGULAR),
+		list("Tactical Tools and C4", 15, /obj/item/storage/box/kit/tactical_kit, null, VENDOR_ITEM_REGULAR),
 	)
 
 //------------EXPERIMENTAL TOOL KITS---------------

--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -683,6 +683,10 @@
 	new /obj/item/reagent_container/hypospray/autoinjector/stimulant/redemption_stimulant(src)
 	new /obj/item/reagent_container/hypospray/autoinjector/stimulant/speed_stimulant(src)
 
+/obj/item/storage/pouch/medical/socmed/synth
+	desc = "A heavy pouch that can carry a full suite of medical supplies, this one is a limited issue version sometimes given to USCM synthetic units."
+	storage_slots = 7
+
 /obj/item/storage/pouch/medical/socmed/dutch
 	name = "\improper Dutch's Medical Pouch"
 	desc = "A pouch bought from a black market trader by Dutch quite a few years ago. Rumoured to be stolen from secret USCM assets. Its contents have been slowly used up and replaced over the years."
@@ -1255,6 +1259,11 @@
 	new /obj/item/tool/wirecutters(src)
 	new /obj/item/tool/weldingtool(src)
 	new /obj/item/tool/wrench(src)
+
+/obj/item/storage/pouch/tools/tactical/synth
+	desc = "This particular toolkit full of sharp, heavy objects was designed for breaking into things rather than fixing them. Still does the latter pretty well, though. Special issue version given to some USCM synthetic units."
+	icon_state = "soctools"
+	storage_slots = 4
 
 /obj/item/storage/pouch/sling
 	name = "sling strap"

--- a/code/modules/cm_marines/equipment/kit_boxes.dm
+++ b/code/modules/cm_marines/equipment/kit_boxes.dm
@@ -544,3 +544,16 @@
 	new /obj/item/storage/pouch/construction/low_grade_full(src)
 	new /obj/item/storage/pouch/electronics/full(src)
 	new /obj/item/clothing/glasses/welding(src)
+
+/obj/item/storage/box/kit/tactical_kit
+	name = "\improper Tactical Engineering Kit"
+
+/obj/item/storage/box/kit/tactical_kit/fill_preset_inventory()
+	new /obj/item/tool/screwdriver/tactical(src)
+	new /obj/item/tool/wirecutters/tactical(src)
+	new /obj/item/tool/crowbar/tactical(src)
+	new /obj/item/stack/cable_coil(src)
+	new /obj/item/device/multitool(src)
+	new /obj/item/tool/wrench(src)
+	new /obj/item/explosive/plastic(src)
+	new /obj/item/explosive/plastic(src)

--- a/code/modules/cm_marines/equipment/kit_boxes.dm
+++ b/code/modules/cm_marines/equipment/kit_boxes.dm
@@ -546,9 +546,11 @@
 	new /obj/item/clothing/glasses/welding(src)
 
 /obj/item/storage/box/kit/tactical_kit
-	name = "\improper Tactical Engineering Kit"
+	name = "\improper Tactical Equipment Kit"
 
 /obj/item/storage/box/kit/tactical_kit/fill_preset_inventory()
+	new /obj/item/storage/pouch/medical/socmed/synth(src)
+	new /obj/item/storage/pouch/tools/tactical/synth(src)
 	new /obj/item/tool/screwdriver/tactical(src)
 	new /obj/item/tool/wirecutters/tactical(src)
 	new /obj/item/tool/crowbar/tactical(src)


### PR DESCRIPTION

# About the pull request

Adds the option to purchase a suite of tactical tools and pouches to the Synthetics experimental tool vendor.

The tools are functionally near identical to regular tools, the pouches are the marsoc tactical tools, but changed to be identical to their regular marine counterparts in terms of storage, ergo this is more of a fluff purchase for a synthetic. 

# Explain why it's good for the game

Additional and cool looking tools may help enhance a synth players aesthetic design for what they want their loadout to look like, the tools also offer an alternative purchase option if they are not interested in any of the other experimental options, as this one offers no unique tactical advantage and thus is not a balance concern. 

I chose to keep the pouches identical to their regular counterparts for balance reasons, so their appearance is more fluff/aesthetic than a balance change. 

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![Screenshot 2023-10-27 12 39 53](https://github.com/cmss13-devs/cmss13/assets/6595389/6f46ac48-9841-47b7-8660-af9322739ae5)


</details>


# Changelog
:cl:
add: Synthetics can now purchase a set of tactical equipment and pouches from their experimental vendor, the tools are functionally similar to their regular counterparts, thus are more of a fluff addition. 
/:cl:
