### PR TITLE
Shotgun tube toggle hotkey

### DIFF
--- a/code/__DEFINES/keybinding.dm
+++ b/code/__DEFINES/keybinding.dm
@@ -87,6 +87,7 @@
 #define COMSIG_KB_HUMAN_WEAPON_UNLOAD "keybinding_human_weapon_unload"
 #define COMSIG_KB_HUMAN_WEAPON_ATTACHMENT "keybinding_human_weapon_attachment"
 #define COMSIG_KB_HUMAN_WEAPON_ATTACHMENT_RAIL "keybinding_human_weapon_attachment_rail"
+#define COMSIG_KB_HUMAN_WEAPON_SHOTGUN_TUBE "keybinding_human_weapon_shotgun_tube"
 
 #define COMSIG_KB_HUMAN_WEAPON_TOGGLE_IFF "keybinding_human_weapon_toggle_iff"
 

--- a/code/datums/keybinding/human_combat.dm
+++ b/code/datums/keybinding/human_combat.dm
@@ -204,5 +204,6 @@
 		return
 	var/mob/living/carbon/human/human = user.mob
 	var/obj/item/weapon/gun/shotgun/pump/dual_tube/held_item = human.get_held_item()
-	held_item.toggle_tube()
-	return TRUE
+	if(istype(held_item, /obj/item/weapon/gun/shotgun/pump/dual_tube))
+		held_item.toggle_tube()
+		return TRUE

--- a/code/datums/keybinding/human_combat.dm
+++ b/code/datums/keybinding/human_combat.dm
@@ -204,6 +204,6 @@
 		return
 	var/mob/living/carbon/human/human = user.mob
 	var/obj/item/weapon/gun/shotgun/pump/dual_tube/held_item = human.get_held_item()
-	if(istype(held_item, /obj/item/weapon/gun/shotgun/pump/dual_tube))
+	if(istype(held_item))
 		held_item.toggle_tube()
 		return TRUE

--- a/code/datums/keybinding/human_combat.dm
+++ b/code/datums/keybinding/human_combat.dm
@@ -190,3 +190,19 @@
 		var/obj/item/weapon/gun/rifle/m46c/COgun = held_item
 		COgun.toggle_iff(human)
 		return TRUE
+
+/datum/keybinding/human/combat/toggle_shotgun_tube
+	hotkey_keys = list("Unbound")
+	classic_keys = list("Unbound")
+	name = "toggle_shotgun_tube"
+	full_name = "Toggle Shotgun Tube"
+	keybind_signal = COMSIG_KB_HUMAN_WEAPON_SHOTGUN_TUBE
+
+/datum/keybinding/human/combat/toggle_shotgun_tube/down(client/user)
+	. = ..()
+	if(.)
+		return
+	var/mob/living/carbon/human/human = user.mob
+	var/obj/item/weapon/gun/shotgun/pump/dual_tube/held_item = human.get_held_item()
+	held_item.toggle_tube()
+	return TRUE


### PR DESCRIPTION

# About the pull request

Adds hotkey to toggling multi magazine on multi tube shotgun.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

Having hotkeys for combat related actions is very important.

</details>


# Changelog
:cl:
add: added shotgun tube toggle hotkey
/:cl:
