### PR TITLE
fix for donator backpack not showing

### DIFF
--- a/code/modules/cm_marines/Donator_Items.dm
+++ b/code/modules/cm_marines/Donator_Items.dm
@@ -1366,7 +1366,6 @@
 	name = "tactical radiopack"
 	desc = "A Radio backpack for use with the Juggernaut armor. DONOR ITEM"
 	icon_state = "skinnerpack"
-	item_state = "skinnerpack"
 
 /obj/item/clothing/glasses/fluff/alexwarhammer
 	name = "Black Jack's Dank Shades"


### PR DESCRIPTION
# About the pull request

Fixes a glitch for the tactical radiopack as it has a broken sprite as of current. 
removed item state leading to null icons for backpack.
Tested via private server and after discussing with a few other coders, now functions as intended on private test server
# Explain why it's good for the game

Fixes a currently bugged sprite causing it to be invisible.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Deleted item state line from code for backpack to use default item state
/:cl:
