### PR TITLE
Predators are no longer immune to molecular acid

### DIFF
--- a/code/modules/reagents/chemistry_reagents/toxin.dm
+++ b/code/modules/reagents/chemistry_reagents/toxin.dm
@@ -279,4 +279,4 @@
 	color = "#669900"
 	reagent_state = LIQUID
 	chemclass = CHEM_CLASS_NONE
-	properties = list(PROPERTY_CORROSIVE = 2, PROPERTY_TOXIC = 1)
+	properties = list(PROPERTY_CORROSIVE = 2, PROPERTY_TOXIC = 1, PROPERTY_CROSSMETABOLIZING = 3)


### PR DESCRIPTION
# About the pull request

molecular acid (from boiler and spitter tailstab) now affects predators, dealing
 12 burn damage for spitters, and 39 burn damage for boilers
 
do note that it metabolizes quite slowly (takes nearly a minute for a boiler's tailstab to be done)



# Explain why it's good for the game

I don't think predators are meant to be immune to acid???

labeled this as a fix as I don't think morrow wanted this to only work on humans
# Changelog

:cl:
balance: predators are no longer immune to molecular acid injected from spitter and boiler tailstabs
/:cl:
