### PR TITLE
Whiskey Outpost Reqs Tweaks

### DIFF
--- a/code/game/area/WhiskeyOutpost.dm
+++ b/code/game/area/WhiskeyOutpost.dm
@@ -65,7 +65,7 @@
 	icon_state = "livingspace"
 
 /area/whiskey_outpost/inside/supply
-	name = "\improper Supply Depo"
+	name = "\improper Supply Depot"
 	icon_state = "req"
 
 /*

--- a/code/game/gamemodes/colonialmarines/whiskey_outpost.dm
+++ b/code/game/gamemodes/colonialmarines/whiskey_outpost.dm
@@ -322,7 +322,7 @@
 		OT = "sup" //no breaking anything.
 
 	else if (OT == "sup")
-		randpick = rand(0,84)
+		randpick = rand(0,90)
 		switch(randpick)
 			if(0 to 3)//Marine Gear 3% Chance.
 				crate = new /obj/structure/closet/crate/secure/gear(T)

--- a/code/game/gamemodes/colonialmarines/whiskey_outpost.dm
+++ b/code/game/gamemodes/colonialmarines/whiskey_outpost.dm
@@ -429,21 +429,44 @@
 
 			if(58 to 65) // Sandbags kit
 				crate = new /obj/structure/closet/crate(T)
-				choosemax = rand(3,6)
 				spawnitems = list(/obj/item/tool/shovel/etool,
 								/obj/item/stack/sandbags_empty/half,
 								/obj/item/stack/sandbags_empty/half,
 								/obj/item/stack/sandbags_empty/half)
 
-			if(66 to 75) // Mortar shells. Pew Pew!
+			if(66 to 70) // Mortar shells. Pew Pew!
 				crate = new /obj/structure/closet/crate/secure/mortar_ammo(T)
 				choosemax = rand(6,10)
-				spawnitems = list(/obj/item/mortar_shell/he,
+				randomitems = list(/obj/item/mortar_shell/he,
 								/obj/item/mortar_shell/incendiary,
 								/obj/item/mortar_shell/flare,
 								/obj/item/mortar_shell/frag)
 
-			if(76 to 80)
+			if(71 to 79)
+				crate = new /obj/structure/closet/crate/ammo(T)
+				choosemax = rand(2, 3)
+				randomitems = list(/obj/item/ammo_box/rounds,
+								/obj/item/ammo_box/rounds/ap,
+								/obj/item/ammo_box/rounds/smg,
+								/obj/item/ammo_box/rounds/smg/ap,
+								/obj/item/ammo_box/magazine/ap,
+								/obj/item/ammo_box/magazine/ext,
+								/obj/item/ammo_box/magazine/m4ra/ap,
+								/obj/item/ammo_box/magazine/m4ra/ap,
+								/obj/item/ammo_box/magazine/m39/ap,
+								/obj/item/ammo_box/magazine/m39/ext,
+				)
+
+			if(80 to 82)
+				crate = new /obj/structure/closet/crate/ammo(T)
+				choosemax = rand(2, 3)
+				randomitems = list(/obj/item/ammo_magazine/rifle/lmg/holo_target,
+								/obj/item/ammo_magazine/rifle/lmg/holo_target,
+								/obj/item/ammo_magazine/rifle/lmg,
+								/obj/item/ammo_magazine/rifle/lmg,
+				)
+
+			if(83 to 86)
 				crate = new /obj/structure/closet/crate/ammo(T)
 				spawnitems = list(
 									/obj/item/attachable/magnetic_harness,
@@ -451,7 +474,7 @@
 									/obj/item/attachable/magnetic_harness,
 									/obj/item/attachable/magnetic_harness)
 
-			if(81 to 84)
+			if(86 to 90)
 				crate = new /obj/structure/closet/crate/secure/gear(T)
 				spawnitems = list(
 									/obj/item/device/binoculars/range,

--- a/code/game/gamemodes/colonialmarines/whiskey_outpost.dm
+++ b/code/game/gamemodes/colonialmarines/whiskey_outpost.dm
@@ -322,9 +322,9 @@
 		OT = "sup" //no breaking anything.
 
 	else if (OT == "sup")
-		randpick = rand(0,50)
+		randpick = rand(0,84)
 		switch(randpick)
-			if(0 to 5)//Marine Gear 10% Chance.
+			if(0 to 3)//Marine Gear 3% Chance.
 				crate = new /obj/structure/closet/crate/secure/gear(T)
 				choosemax = rand(5,10)
 				randomitems = list(/obj/item/clothing/head/helmet/marine,
@@ -340,19 +340,19 @@
 								/obj/effect/landmark/wo_supplies/storage/webbing,
 								/obj/item/device/binoculars)
 
-			if(6 to 10)//Lights and shiet 10%
+			if(4 to 6)//Lights and shiet 2%
 				new /obj/structure/largecrate/supply/floodlights(T)
 				new /obj/structure/largecrate/supply/supplies/flares(T)
 
 
-			if(11 to 13) //6% Chance to drop this !FUN! junk.
+			if(7 to 10) //3% Chance to drop this !FUN! junk.
 				crate = new /obj/structure/closet/crate/secure/gear(T)
 				spawnitems = list(/obj/item/storage/belt/utility/full,
 									/obj/item/storage/belt/utility/full,
 									/obj/item/storage/belt/utility/full,
 									/obj/item/storage/belt/utility/full)
 
-			if(14 to 18)//Materials 10% Chance.
+			if(11 to 22)//Materials 12% Chance.
 				crate = new /obj/structure/closet/crate/secure/gear(T)
 				choosemax = rand(3,8)
 				randomitems = list(/obj/item/stack/sheet/metal,
@@ -363,7 +363,7 @@
 								/obj/item/stack/sandbags_empty/half,
 								/obj/item/stack/sandbags_empty/half)
 
-			if(19 to 20)//Blood Crate 4% chance
+			if(23 to 25)//Blood Crate 2% chance
 				crate = new /obj/structure/closet/crate/medical(T)
 				spawnitems = list(/obj/item/reagent_container/blood/OMinus,
 								/obj/item/reagent_container/blood/OMinus,
@@ -371,7 +371,7 @@
 								/obj/item/reagent_container/blood/OMinus,
 								/obj/item/reagent_container/blood/OMinus)
 
-			if(21 to 25)//Advanced meds Crate 10%
+			if(26 to 30)//Advanced meds Crate 5%
 				crate = new /obj/structure/closet/crate/medical(T)
 				spawnitems = list(/obj/item/storage/firstaid/fire,
 								/obj/item/storage/firstaid/regular,
@@ -386,7 +386,7 @@
 								/obj/item/clothing/glasses/hud/health,
 								/obj/item/device/defibrillator)
 
-			if(26 to 30)//Random Medical Items 10% as well. Made the list have less small junk
+			if(31 to 34)//Random Medical Items 4%. Made the list have less small junk
 				crate = new /obj/structure/closet/crate/medical(T)
 				spawnitems = list(/obj/item/storage/belt/medical/lifesaver/full,
 								/obj/item/storage/belt/medical/lifesaver/full,
@@ -394,7 +394,7 @@
 								/obj/item/storage/belt/medical/lifesaver/full,
 								/obj/item/storage/belt/medical/lifesaver/full)
 
-			if(31 to 35)//Random explosives Crate 10% because the lord commeth and said let there be explosives.
+			if(35 to 40)//Random explosives Crate 5% because the lord commeth and said let there be explosives.
 				crate = new /obj/structure/closet/crate/ammo(T)
 				choosemax = rand(1,5)
 				randomitems = list(/obj/item/storage/box/explosive_mines,
@@ -404,7 +404,7 @@
 								/obj/item/explosive/grenade/high_explosive,
 								/obj/item/storage/box/nade_box
 								)
-			if(36 to 40) // Junk
+			if(41 to 44)
 				crate = new /obj/structure/closet/crate/ammo(T)
 				spawnitems = list(
 									/obj/item/attachable/heavy_barrel,
@@ -412,20 +412,52 @@
 									/obj/item/attachable/heavy_barrel,
 									/obj/item/attachable/heavy_barrel)
 
-			if(40 to 48)//Weapon + supply beacon drop. 6%
+			if(45 to 50)//Weapon + supply beacon drop. 5%
 				crate = new /obj/structure/closet/crate/ammo(T)
 				spawnitems = list(/obj/item/device/whiskey_supply_beacon,
 								/obj/item/device/whiskey_supply_beacon,
 								/obj/item/device/whiskey_supply_beacon,
 								/obj/item/device/whiskey_supply_beacon)
 
-			if(49 to 50)//Rare weapons. Around 4%
+			if(51 to 57)//Rare weapons. Around 6%
 				crate = new /obj/structure/closet/crate/ammo(T)
 				spawnitems = list(/obj/effect/landmark/wo_supplies/ammo/box/rare/m41aap,
 								/obj/effect/landmark/wo_supplies/ammo/box/rare/m41aapmag,
 								/obj/effect/landmark/wo_supplies/ammo/box/rare/m41aextend,
 								/obj/effect/landmark/wo_supplies/ammo/box/rare/smgap,
 								/obj/effect/landmark/wo_supplies/ammo/box/rare/smgextend)
+
+			if(58 to 65) // Sandbags kit
+				crate = new /obj/structure/closet/crate(T)
+				choosemax = rand(3,6)
+				spawnitems = list(/obj/item/tool/shovel/etool,
+								/obj/item/stack/sandbags_empty/half,
+								/obj/item/stack/sandbags_empty/half,
+								/obj/item/stack/sandbags_empty/half)
+
+			if(66 to 75) // Mortar shells. Pew Pew!
+				crate = new /obj/structure/closet/crate/secure/mortar_ammo(T)
+				choosemax = rand(6,10)
+				spawnitems = list(/obj/item/mortar_shell/he,
+								/obj/item/mortar_shell/incendiary,
+								/obj/item/mortar_shell/flare,
+								/obj/item/mortar_shell/frag)
+
+			if(76 to 80)
+				crate = new /obj/structure/closet/crate/ammo(T)
+				spawnitems = list(
+									/obj/item/attachable/magnetic_harness,
+									/obj/item/attachable/magnetic_harness,
+									/obj/item/attachable/magnetic_harness,
+									/obj/item/attachable/magnetic_harness)
+
+			if(81 to 84)
+				crate = new /obj/structure/closet/crate/secure/gear(T)
+				spawnitems = list(
+									/obj/item/device/binoculars/range,
+									/obj/item/device/binoculars/range,
+				)
+
 	if(crate)
 		crate.storage_capacity = 60
 

--- a/code/game/machinery/vending/cm_vending.dm
+++ b/code/game/machinery/vending/cm_vending.dm
@@ -37,8 +37,14 @@
 	var/vend_delay = 0 //delaying vending of an item (for drinks machines animation, for example). Make sure to synchronize this with animation duration
 	var/vend_sound //use with caution. Potential spam
 
+	/// X Offset to vend to
 	var/vend_x_offset = 0
+	/// Y Offset to vend to
 	var/vend_y_offset = 0
+	/// Vending direction from adjacent users, if not using vend_x_offset or vend_y_offset
+	var/vend_dir
+	/// Direction to adjacent user from which we're allowed to do offset vending
+	var/list/vend_dir_whitelist
 
 	var/list/listed_products = list()
 
@@ -125,11 +131,20 @@ GLOBAL_LIST_EMPTY(vending_products)
 			GLOB.vending_products[typepath] = 1
 
 //get which turf the vendor will dispense its products on.
-/obj/structure/machinery/cm_vending/proc/get_appropriate_vend_turf()
-	var/turf/T = loc
+/obj/structure/machinery/cm_vending/proc/get_appropriate_vend_turf(mob/living/carbon/human/user)
+	var/turf/turf = loc
 	if(vend_x_offset != 0 || vend_y_offset != 0) //this check should be more less expensive than using locate to locate your own tile every vending.
-		T = locate(x + vend_x_offset, y + vend_y_offset, z)
-	return T
+		turf = locate(x + vend_x_offset, y + vend_y_offset, z)
+		return turf
+	if(vend_dir)
+		if(vend_dir_whitelist)
+			var/user_dir = get_dir(loc, user)
+			if(!(user_dir in vend_dir_whitelist))
+				return turf
+		var/turf/relative_turf = get_step(user, vend_dir)
+		if(relative_turf.Adjacent(src))
+			return relative_turf
+	return turf
 
 /obj/structure/machinery/cm_vending/get_examine_text(mob/living/carbon/human/user)
 	. = ..()

--- a/code/game/machinery/vending/vendor_types/requisitions.dm
+++ b/code/game/machinery/vending/vendor_types/requisitions.dm
@@ -175,22 +175,8 @@
 //Special cargo-specific vendor with vending offsets
 /obj/structure/machinery/cm_vending/sorted/cargo_guns/cargo
 	vend_flags = VEND_CLUTTER_PROTECTION | VEND_LIMITED_INVENTORY | VEND_LOAD_AMMO_BOXES //We want to vend to turf not hand, since we are in requisitions
-
-/obj/structure/machinery/cm_vending/sorted/cargo_guns/cargo/get_appropriate_vend_turf(mob/living/carbon/human/H)
-	var/turf/turf_to_vent_to
-	if(vend_x_offset != 0 || vend_y_offset != 0) //this will allow to avoid code below that suits only Almayer.
-		turf_to_vent_to = locate(x + vend_x_offset, y + vend_y_offset, z)
-	else
-		turf_to_vent_to = get_turf(get_step(src, NORTH))
-		if(H.loc == turf_to_vent_to)
-			turf_to_vent_to = get_turf(get_step(H.loc, WEST))
-		else
-			turf_to_vent_to = get_turf(get_step(src, SOUTH))
-			if(H.loc == turf_to_vent_to)
-				turf_to_vent_to = get_turf(get_step(H.loc, WEST))
-			else
-				turf_to_vent_to = H.loc
-	return turf_to_vent_to
+	vend_dir = WEST
+	vend_dir_whitelist = list(NORTH, SOUTH)
 
 /obj/structure/machinery/cm_vending/sorted/cargo_guns/cargo/blend
 	icon_state = "req_guns_wall"
@@ -209,6 +195,8 @@
 	req_access = list(ACCESS_MARINE_CARGO)
 	vendor_theme = VENDOR_THEME_USCM
 	vend_flags = VEND_CLUTTER_PROTECTION | VEND_LIMITED_INVENTORY | VEND_TO_HAND | VEND_LOAD_AMMO_BOXES
+	vend_dir = WEST
+	vend_dir_whitelist = list(SOUTHWEST, NORTHWEST)
 
 /obj/structure/machinery/cm_vending/sorted/cargo_ammo/vend_fail()
 	return
@@ -307,22 +295,6 @@
 /obj/structure/machinery/cm_vending/sorted/cargo_ammo/cargo
 	vend_flags = VEND_CLUTTER_PROTECTION | VEND_LIMITED_INVENTORY | VEND_LOAD_AMMO_BOXES //We want to vend to turf not hand, since we are in requisitions
 
-/obj/structure/machinery/cm_vending/sorted/cargo_ammo/cargo/get_appropriate_vend_turf(mob/living/carbon/human/H)
-	var/turf/turf_to_vent_to
-	if(vend_x_offset != 0 || vend_y_offset != 0) //this will allow to avoid code below that suits only Almayer.
-		turf_to_vent_to = locate(x + vend_x_offset, y + vend_y_offset, z)
-	else
-		turf_to_vent_to = get_turf(get_step(src, NORTHWEST))
-		if(H.loc == turf_to_vent_to)
-			turf_to_vent_to = get_turf(get_step(H.loc, WEST))
-		else
-			turf_to_vent_to = get_turf(get_step(src, SOUTHWEST))
-			if(H.loc == turf_to_vent_to)
-				turf_to_vent_to = get_turf(get_step(H.loc, WEST))
-			else
-				turf_to_vent_to = H.loc
-	return turf_to_vent_to
-
 //------------ATTACHMENTS VENDOR---------------
 
 /obj/structure/machinery/cm_vending/sorted/attachments
@@ -331,6 +303,9 @@
 	req_access = list(ACCESS_MARINE_CARGO)
 	vendor_theme = VENDOR_THEME_USCM
 	icon_state = "req_attach"
+	vend_dir = WEST
+	vend_dir_whitelist = list(SOUTHEAST, NORTHEAST)
+	vend_flags = VEND_CLUTTER_PROTECTION | VEND_LIMITED_INVENTORY //We want to vend to turf not hand, since we are in requisitions
 
 /obj/structure/machinery/cm_vending/sorted/attachments/vend_fail()
 	return
@@ -379,22 +354,6 @@
 		list("M44 Magnum Sharpshooter Stock", round(scale * 4.5), /obj/item/attachable/stock/revolver, VENDOR_ITEM_REGULAR)
 		)
 
-/obj/structure/machinery/cm_vending/sorted/attachments/get_appropriate_vend_turf(mob/living/carbon/human/H)
-	var/turf/turf_to_vent_to
-	if(vend_x_offset != 0 || vend_y_offset != 0) //this will allow to avoid code below that suits only Almayer.
-		turf_to_vent_to = locate(x + vend_x_offset, y + vend_y_offset, z)
-	else
-		turf_to_vent_to = get_turf(get_step(src, NORTHEAST))
-		if(H.loc == turf_to_vent_to)
-			turf_to_vent_to = get_turf(get_step(H.loc, WEST))
-		else
-			turf_to_vent_to = get_turf(get_step(src, SOUTHEAST))
-			if(H.loc == turf_to_vent_to)
-				turf_to_vent_to = get_turf(get_step(H.loc, WEST))
-			else
-				turf_to_vent_to = loc
-	return turf_to_vent_to
-
 /obj/structure/machinery/cm_vending/sorted/attachments/blend
 	icon_state = "req_attach_wall"
 	tiles_with = list(
@@ -402,7 +361,6 @@
 		/obj/structure/machinery/door/airlock,
 		/turf/closed/wall/almayer,
 	)
-	vend_flags = VEND_CLUTTER_PROTECTION | VEND_LIMITED_INVENTORY //We want to vend to turf not hand, since we are in requisitions
 
 //------------UNIFORM VENDOR---------------
 

--- a/code/game/machinery/vending/vendor_types/wo_vendors.dm
+++ b/code/game/machinery/vending/vendor_types/wo_vendors.dm
@@ -110,52 +110,13 @@
 	)
 
 //------------REQ AMMUNITION VENDOR---------------
-/obj/structure/machinery/cm_vending/sorted/cargo_ammo/wo
+/obj/structure/machinery/cm_vending/sorted/cargo_ammo/cargo/wo
 	req_access = list(ACCESS_MARINE_CARGO)
 	req_one_access = list()
 
-/obj/structure/machinery/cm_vending/sorted/cargo_ammo/wo/populate_product_list(scale)
-	listed_products = list(
-		list("REGULAR AMMUNITION", -1, null, null),
-		list("Box Of Buckshot Shells", round(scale * 5), /obj/item/ammo_magazine/shotgun/buckshot, VENDOR_ITEM_REGULAR),
-		list("Box Of Flechette Shells", round(scale * 5), /obj/item/ammo_magazine/shotgun/flechette, VENDOR_ITEM_REGULAR),
-		list("Box Of Shotgun Slugs", round(scale * 5), /obj/item/ammo_magazine/shotgun/slugs, VENDOR_ITEM_REGULAR),
-		list("M4RA magazine (10x24mm)", round(scale * 10), /obj/item/ammo_magazine/rifle/m4ra, VENDOR_ITEM_REGULAR),
-		list("M39 HV Magazine (10x20mm)", round(scale * 10), /obj/item/ammo_magazine/smg/m39, VENDOR_ITEM_REGULAR),
-		list("M41A MK1 Magazine (10x24mm)", round(scale * 10), /obj/item/ammo_magazine/rifle/m41aMK1, VENDOR_ITEM_REGULAR),
-		list("M41A MK2 Magazine (10x24mm)", round(scale * 10), /obj/item/ammo_magazine/rifle, VENDOR_ITEM_REGULAR),
-		list("M44 Speed Loader (.44)", round(scale * 10), /obj/item/ammo_magazine/revolver, VENDOR_ITEM_REGULAR),
-		list("M4A3 Magazine (9mm)", round(scale * 10), /obj/item/ammo_magazine/pistol, VENDOR_ITEM_REGULAR),
-
-		list("ARMOR-PIERCING AMMUNITION", -1, null, null),
-		list("88 Mod 4 AP Magazine (9mm)", round(scale * 5), /obj/item/ammo_magazine/pistol/mod88, VENDOR_ITEM_REGULAR),
-		list("M4RA AP Magazine (10x24mm)", round(scale * 10), /obj/item/ammo_magazine/rifle/m4ra/ap, VENDOR_ITEM_REGULAR),
-		list("M39 AP Magazine (10x20mm)", round(scale * 5), /obj/item/ammo_magazine/smg/m39/ap, VENDOR_ITEM_REGULAR),
-		list("M41A MK1 AP Magazine (10x24mm)", round(scale * 10), /obj/item/ammo_magazine/rifle/m41aMK1/ap, VENDOR_ITEM_REGULAR),
-		list("M41A MK2 AP Magazine (10x24mm)", round(scale * 10), /obj/item/ammo_magazine/rifle/ap, VENDOR_ITEM_REGULAR),
-		list("M4A3 AP Magazine (9mm)", round(scale * 5), /obj/item/ammo_magazine/pistol/ap, VENDOR_ITEM_REGULAR),
-
-		list("EXTENDED AMMUNITION", -1, null, null),
-		list("M39 Extended Magazine (10x20mm)", round(scale * 1), /obj/item/ammo_magazine/smg/m39/extended, VENDOR_ITEM_REGULAR),
-		list("M41A MK2 Extended Magazine (10x24mm)", round(scale * 3), /obj/item/ammo_magazine/rifle/extended, VENDOR_ITEM_REGULAR),
-
-		list("INCENDIARY AMMUNITION", -1, null, null),
-		list("M4RA Incendiary Magazine (10x24mm)", round(scale * 3), /obj/item/ammo_magazine/rifle/m4ra/incendiary, VENDOR_ITEM_REGULAR),
-		list("M39 Incendiary Magazine (10x20mm)", round(scale * 2), /obj/item/ammo_magazine/smg/m39/incendiary, VENDOR_ITEM_REGULAR),
-		list("M41A MK2 Incendiary Magazine (10x24mm)", round(scale * 3), /obj/item/ammo_magazine/rifle/incendiary, VENDOR_ITEM_REGULAR),
-		list("M4A3 Incendiary Magazine (9mm)", round(scale * 1), /obj/item/ammo_magazine/pistol/incendiary, VENDOR_ITEM_REGULAR),
-
-		list("SPECIAL AMMUNITION", -1, null, null),
-		list("Incinerator Tank", round(scale * 2.5), /obj/item/ammo_magazine/flamer_tank, VENDOR_ITEM_REGULAR),
-		list("M41AE2 Ammo Box (10x24mm)", round(scale * 5), /obj/item/ammo_magazine/rifle/lmg, VENDOR_ITEM_REGULAR),
-		list("M44 Heavy Speed Loader (.44)", round(scale * 2), /obj/item/ammo_magazine/revolver/heavy, VENDOR_ITEM_REGULAR),
-		list("M44 Marksman Speed Loader (.44)", round(scale * 2), /obj/item/ammo_magazine/revolver/marksman, VENDOR_ITEM_REGULAR),
-		list("M4A3 HP Magazine (9mm)", round(scale * 5), /obj/item/ammo_magazine/pistol/hp, VENDOR_ITEM_REGULAR),
-		list("M56 Battery", round(scale * 5), /obj/item/smartgun_battery, VENDOR_ITEM_REGULAR),
-		list("M56 Smartgun Drum", round(scale * 2), /obj/item/ammo_magazine/smartgun, VENDOR_ITEM_REGULAR),
-		list("SU-6 Smartpistol Magazine (.45)", round(scale * 6), /obj/item/ammo_magazine/pistol/smart, VENDOR_ITEM_REGULAR),
-		list("VP78 Magazine", round(scale * 6), /obj/item/ammo_magazine/pistol/vp78, VENDOR_ITEM_REGULAR),
-
+/obj/structure/machinery/cm_vending/sorted/cargo_ammo/cargo/wo/populate_product_list(scale)
+	..()
+	listed_products += list(
 		list("EXTRA SCOUT AMMUNITION", -1, null, null, null),
 		list("A19 High Velocity Impact Magazine (10x24mm)", round(scale * 1), /obj/item/ammo_magazine/rifle/m4ra/custom/impact, VENDOR_ITEM_REGULAR),
 		list("A19 High Velocity Incendiary Magazine (10x24mm)", round(scale * 1), /obj/item/ammo_magazine/rifle/m4ra/custom/incendiary, VENDOR_ITEM_REGULAR),
@@ -181,96 +142,17 @@
 		list("Large Incinerator Tank", round(scale * 1), /obj/item/ammo_magazine/flamer_tank/large, VENDOR_ITEM_REGULAR),
 		list("Large Incinerator Tank (B) (Green Flame)", round(scale * 1), /obj/item/ammo_magazine/flamer_tank/large/B, VENDOR_ITEM_REGULAR),
 		list("Large Incinerator Tank (X) (Blue Flame)", round(scale * 1), /obj/item/ammo_magazine/flamer_tank/large/X, VENDOR_ITEM_REGULAR),
-
-		list("AMMUNITION BOXES", -1, null, null),
-		list("Rifle Ammunition Box (10x24mm)", round(scale * 0.9), /obj/item/ammo_box/rounds, VENDOR_ITEM_REGULAR),
-		list("Rifle Ammunition Box (10x24mm AP)", round(scale * 0.75), /obj/item/ammo_box/rounds/ap, VENDOR_ITEM_REGULAR),
-		list("SMG Ammunition Box (10x20mm HV)", round(scale * 0.9), /obj/item/ammo_box/rounds/smg, VENDOR_ITEM_REGULAR),
-		list("SMG Ammunition Box (10x20mm AP)", round(scale * 0.75), /obj/item/ammo_box/rounds/smg/ap, VENDOR_ITEM_REGULAR),
 		)
 
 //------------ARMAMENTS VENDOR---------------
 
-/obj/structure/machinery/cm_vending/sorted/cargo_guns/wo
+/obj/structure/machinery/cm_vending/sorted/cargo_guns/cargo/wo
 	req_access = list(ACCESS_MARINE_CARGO)
+	vend_dir = NORTH
+	vend_dir_whitelist = list(EAST, WEST)
 
-/obj/structure/machinery/cm_vending/sorted/cargo_guns/wo/populate_product_list(scale)
-	listed_products = list(
-		list("PRIMARY FIREARMS", -1, null, null),
-		list("M4RA Battle Rifle", round(scale * 20), /obj/item/weapon/gun/rifle/m4ra, VENDOR_ITEM_REGULAR),
-		list("M37A2 Pump Shotgun", round(scale * 10), /obj/item/weapon/gun/shotgun/pump, VENDOR_ITEM_REGULAR),
-		list("M39 Submachinegun", round(scale * 15), /obj/item/weapon/gun/smg/m39, VENDOR_ITEM_REGULAR),
-		list("M41A Pulse Rifle MK1", round(scale * 20), /obj/item/weapon/gun/rifle/m41aMK1, VENDOR_ITEM_REGULAR),
-		list("M41A Pulse Rifle MK2", round(scale * 20), /obj/item/weapon/gun/rifle/m41a, VENDOR_ITEM_REGULAR),
-		list("MK221 Tactical Shotgun", round(scale * 3), /obj/item/weapon/gun/shotgun/combat, VENDOR_ITEM_REGULAR),
-
-		list("SIDEARMS", -1, null, null),
-		list("88 Mod 4 Combat Pistol", round(scale * 15), /obj/item/weapon/gun/pistol/mod88, VENDOR_ITEM_REGULAR),
-		list("M44 Combat Revolver", round(scale * 10), /obj/item/weapon/gun/revolver/m44, VENDOR_ITEM_REGULAR),
-		list("M4A3 Service Pistol", round(scale * 20), /obj/item/weapon/gun/pistol/m4a3, VENDOR_ITEM_REGULAR),
-		list("SU-6 Smartpistol", round(scale * 2), /obj/item/weapon/gun/pistol/smart, VENDOR_ITEM_REGULAR),
-		list("M82F Flare Gun", round(scale * 5), /obj/item/weapon/gun/flare, VENDOR_ITEM_REGULAR),
-
-		list("RESTRICTED FIREARMS", -1, null, null),
-		list("VP78 Pistol", round(scale * 4), /obj/item/storage/box/guncase/vp78, VENDOR_ITEM_REGULAR),
-		list("SU-6 Smart Pistol", round(scale * 3), /obj/item/storage/box/guncase/smartpistol, VENDOR_ITEM_REGULAR),
-		list("M41AE2 Heavy Pulse Rifle", round(scale * 2), /obj/item/storage/box/guncase/lmg, VENDOR_ITEM_REGULAR),
-		list("M56D Heavy Machine Gun", round(scale * 2), /obj/item/storage/box/guncase/m56d, VENDOR_ITEM_REGULAR),
-		list("M2C Heavy Machine Gun", round(scale * 2), /obj/item/storage/box/guncase/m2c, VENDOR_ITEM_REGULAR),
-		list("M240 Incinerator Unit", round(scale * 2), /obj/item/storage/box/guncase/flamer, VENDOR_ITEM_REGULAR),
-
-		list("EXPLOSIVES", -1, null, null),
-		list("M15 Fragmentation Grenade", round(scale * 2), /obj/item/explosive/grenade/high_explosive/m15, VENDOR_ITEM_REGULAR),
-		list("M20 Claymore Anti-Personnel Mine", round(scale * 5), /obj/item/explosive/mine, VENDOR_ITEM_REGULAR),
-		list("M40 HEDP Grenade Box", round(scale * 1), /obj/item/storage/box/nade_box, VENDOR_ITEM_REGULAR),
-		list("M40 HIDP Incendiary Grenade", round(scale * 3), /obj/item/explosive/grenade/incendiary, VENDOR_ITEM_REGULAR),
-		list("M40 HSDP Smoke Grenade", round(scale * 5), /obj/item/explosive/grenade/smokebomb, VENDOR_ITEM_REGULAR),
-
-		list("BACKPACKS", -1, null, null),
-		list("Lightweight IMP Backpack", round(scale * 15), /obj/item/storage/backpack/marine, VENDOR_ITEM_REGULAR),
-		list("Shotgun Scabbard", round(scale * 10), /obj/item/storage/large_holster/m37, VENDOR_ITEM_REGULAR),
-		list("USCM Pyrotechnician G4-1 Fueltank", round(scale * 2), /obj/item/storage/backpack/marine/engineerpack/flamethrower/kit, VENDOR_ITEM_REGULAR),
-		list("USCM Technician Welderpack", round(scale * 2), /obj/item/storage/backpack/marine/engineerpack, VENDOR_ITEM_REGULAR),
-
-		list("BELTS", -1, null, null),
-		list("G8-A General Utility Pouch", round(scale * 3), /obj/item/storage/backpack/general_belt, VENDOR_ITEM_REGULAR),
-		list("M276 Pattern Ammo Load Rig", round(scale * 15), /obj/item/storage/belt/marine, VENDOR_ITEM_REGULAR),
-		list("M276 Pattern General Pistol Holster Rig", round(scale * 10), /obj/item/storage/belt/gun/m4a3, VENDOR_ITEM_REGULAR),
-		list("M276 Pattern M39 Holster Rig", round(scale * 5), /obj/item/storage/belt/gun/m39, VENDOR_ITEM_REGULAR),
-		list("M276 Pattern M44 Holster Rig", round(scale * 5), /obj/item/storage/belt/gun/m44, VENDOR_ITEM_REGULAR),
-		list("M276 M82F Holster Rig", round(scale * 2), /obj/item/storage/belt/gun/flaregun, VENDOR_ITEM_REGULAR),
-		list("M276 Pattern Shotgun Shell Loading Rig", round(scale * 10), /obj/item/storage/belt/shotgun, VENDOR_ITEM_REGULAR),
-
-		list("WEBBINGS", -1, null, null),
-		list("Black Webbing Vest", round(scale * 5), /obj/item/clothing/accessory/storage/black_vest, VENDOR_ITEM_REGULAR),
-		list("Brown Webbing Vest", round(scale * 5), /obj/item/clothing/accessory/storage/black_vest/brown_vest, VENDOR_ITEM_REGULAR),
-		list("Shoulder Holster", round(scale * 5), /obj/item/clothing/accessory/storage/holster, VENDOR_ITEM_REGULAR),
-		list("Webbing", round(scale * 5), /obj/item/clothing/accessory/storage/webbing, VENDOR_ITEM_REGULAR),
-		list("Knife Webbing", round(scale * 3), /obj/item/clothing/accessory/storage/knifeharness, VENDOR_ITEM_REGULAR),
-		list("Drop Pouch", round(scale * 5), /obj/item/clothing/accessory/storage/droppouch, VENDOR_ITEM_REGULAR),
-
-		list("POUCHES", -1, null, null),
-		list("Construction Pouch", round(scale * 2), /obj/item/storage/pouch/construction, VENDOR_ITEM_REGULAR),
-		list("Explosive Pouch", round(scale * 2), /obj/item/storage/pouch/explosive, VENDOR_ITEM_REGULAR),
-		list("First-Aid Pouch (Full)", round(scale * 5), /obj/item/storage/pouch/firstaid/full, VENDOR_ITEM_REGULAR),
-		list("First Responder Pouch", round(scale * 2), /obj/item/storage/pouch/first_responder, VENDOR_ITEM_REGULAR),
-		list("Flare Pouch (Full)", round(scale * 5), /obj/item/storage/pouch/flare/full, VENDOR_ITEM_REGULAR),
-		list("Fuel Tank Strap Pouch", round(scale * 4), /obj/item/storage/pouch/flamertank, VENDOR_ITEM_REGULAR),
-		list("Large Pistol Magazine Pouch", round(scale * 5), /obj/item/storage/pouch/magazine/pistol/large, VENDOR_ITEM_REGULAR),
-		list("Magazine Pouch", round(scale * 5), /obj/item/storage/pouch/magazine, VENDOR_ITEM_REGULAR),
-		list("Medical Pouch", round(scale * 2), /obj/item/storage/pouch/medical, VENDOR_ITEM_REGULAR),
-		list("Medium General Pouch", round(scale * 2), /obj/item/storage/pouch/general/medium, VENDOR_ITEM_REGULAR),
-		list("Medkit Pouch", round(scale * 2), /obj/item/storage/pouch/medkit, VENDOR_ITEM_REGULAR),
-		list("Sidearm Pouch", round(scale * 15), /obj/item/storage/pouch/pistol, VENDOR_ITEM_REGULAR),
-		list("Syringe Pouch", round(scale * 2), /obj/item/storage/pouch/syringe, VENDOR_ITEM_REGULAR),
-		list("Tools Pouch (Full)", round(scale * 2), /obj/item/storage/pouch/tools/full, VENDOR_ITEM_REGULAR),
-
-		list("MISCELLANEOUS", -1, null, null),
-		list("Combat Flashlight", round(scale * 5), /obj/item/device/flashlight/combat, VENDOR_ITEM_REGULAR),
-		list("Entrenching Tool (ET)", round(scale * 4), /obj/item/tool/shovel/etool, VENDOR_ITEM_REGULAR),
-		list("Gas Mask", round(scale * 10), /obj/item/clothing/mask/gas, VENDOR_ITEM_REGULAR),
-		list("M89-S Signal Flare Pack", round(scale * 2), /obj/item/storage/box/m94/signal, VENDOR_ITEM_REGULAR),
-		list("M94 Marking Flare Pack", round(scale * 10), /obj/item/storage/box/m94, VENDOR_ITEM_REGULAR),
-		list("Machete Scabbard (Full)", round(scale * 20), /obj/item/storage/large_holster/machete/full, VENDOR_ITEM_REGULAR),
-		list("MB-6 Folding Barricades (x3)", round(scale * 1), /obj/item/stack/folding_barricade/three, VENDOR_ITEM_REGULAR)
-		)
+//---- ATTACHIES
+/obj/structure/machinery/cm_vending/sorted/attachments/wo
+	req_access = list(ACCESS_MARINE_CARGO)
+	vend_dir = NORTH
+	vend_dir_whitelist = list(SOUTHWEST, SOUTHEAST)

--- a/code/modules/recycling/recycler.dm
+++ b/code/modules/recycling/recycler.dm
@@ -9,32 +9,39 @@
 	density = TRUE
 	var/recycle_dir = NORTH
 	var/list/stored_matter =  list("metal" = 0, "glass" = 0)
+	/// Amount of metal refunded per crate, by default about 2 metal sheets (building one takes 5)
+	var/crate_reward = 7500
+	/// Amount of sheets to stack before outputting a stack
+	var/sheets_per_batch = 10
 	var/last_recycle_sound //for sound cooldown
 	var/ignored_items = list(/obj/item/limb)
 
-/obj/structure/machinery/recycler/New()
-	..()
-	update_icon()
+/obj/structure/machinery/recycler/whiskey
+	crate_reward = 15000 //  Boosted reward (4 sheets) to make up for workload and the fact you can't sell them
 
+/obj/structure/machinery/recycler/Initialize(mapload, ...)
+	. = ..()
+	update_icon()
 
 /obj/structure/machinery/recycler/power_change()
 	..()
 	update_icon()
 
-
 /obj/structure/machinery/recycler/update_icon()
+	. = ..()
 	icon_state = "separator-AO[(inoperable()) ? "0":"1"]"
 
-
-/obj/structure/machinery/recycler/Collided(atom/movable/AM)
+/obj/structure/machinery/recycler/Collided(atom/movable/movable)
 	if(inoperable())
 		return
-	var/move_dir = get_dir(loc, AM.loc)
-	if(!AM.anchored && move_dir == recycle_dir)
-		if(istype(AM, /obj/item))
-			recycle(AM)
+	var/move_dir = get_dir(loc, movable.loc)
+	if(!movable.anchored && move_dir == recycle_dir)
+		if(istype(movable, /obj/item))
+			recycle(movable)
+		else if(istype(movable, /obj/structure/closet/crate))
+			recycle_crate(movable)
 		else
-			AM.forceMove(loc)
+			movable.forceMove(loc)
 
 
 /obj/structure/machinery/recycler/proc/recycle(obj/item/I)
@@ -63,7 +70,32 @@
 
 			stored_matter[material] += total_material
 	qdel(I)
+	play_recycle_sound()
+	output_materials()
+
+/obj/structure/machinery/recycler/proc/recycle_crate(obj/structure/closet/crate)
+	for(var/atom/movable/movable in crate)
+		movable.forceMove(loc)
+		recycle(movable)
+	stored_matter["metal"] += crate_reward
+	qdel(crate)
+	play_recycle_sound()
+	output_materials()
+
+/obj/structure/machinery/recycler/proc/play_recycle_sound()
 	if(last_recycle_sound < world.time)
 		playsound(loc, 'sound/items/Welder.ogg', 30, 1)
 		last_recycle_sound = world.time + 50
 
+/obj/structure/machinery/recycler/proc/output_materials()
+	for(var/material in stored_matter)
+		if(stored_matter[material] >= sheets_per_batch * 3750)
+			var/sheets = round(stored_matter[material] / 3750)
+			stored_matter[material] -= sheets * 3750
+			var/obj/item/stack/sheet/sheet_stack
+			switch(material)
+				if("metal") sheet_stack = new /obj/item/stack/sheet/metal(loc)
+				if("glass") sheet_stack = new /obj/item/stack/sheet/glass(loc)
+			if(sheet_stack)
+				sheet_stack.amount = sheets
+				sheet_stack.update_icon()

--- a/maps/map_files/Whiskey_Outpost_v2/Whiskey_Outpost_v2.dmm
+++ b/maps/map_files/Whiskey_Outpost_v2/Whiskey_Outpost_v2.dmm
@@ -166,6 +166,11 @@
 	},
 /turf/open/floor/wood,
 /area/whiskey_outpost/inside/cic)
+"aC" = (
+/turf/open/floor/almayer{
+	icon_state = "cargo"
+	},
+/area/whiskey_outpost/inside/cic)
 "aE" = (
 /obj/structure/bed,
 /obj/item/bedsheet/hop,
@@ -1042,7 +1047,7 @@
 /obj/structure/machinery/door/poddoor/shutters/almayer{
 	dir = 2;
 	id = "WOlineshutters1";
-	name = "\improper Supply Depot Line 1"
+	name = "\improper Supply Depo Line 1"
 	},
 /turf/open/floor/plating,
 /area/whiskey_outpost/inside/supply)
@@ -3065,7 +3070,7 @@
 /obj/structure/machinery/door/poddoor/shutters/almayer{
 	dir = 2;
 	id = "WOlineshutters2";
-	name = "\improper Supply Depot Line 2"
+	name = "\improper Supply Depo Line 2"
 	},
 /turf/open/floor/prison{
 	icon_state = "floor_plate"
@@ -5026,7 +5031,7 @@
 "rM" = (
 /obj/structure/machinery/door/airlock/almayer/marine/requisitions{
 	dir = 2;
-	name = "\improper Supply Depot";
+	name = "\improper Supply Depo";
 	no_panel = 1;
 	not_weldable = 1
 	},
@@ -6501,7 +6506,7 @@
 "wV" = (
 /obj/structure/machinery/door/airlock/almayer/marine/requisitions{
 	dir = 8;
-	name = "\improper Supply Depot";
+	name = "\improper Supply Depo";
 	no_panel = 1;
 	not_weldable = 1
 	},
@@ -8629,6 +8634,10 @@
 	icon_state = "grass_impenetrable"
 	},
 /area/whiskey_outpost/outside/north/northwest)
+"EL" = (
+/obj/structure/machinery/cm_vending/gear/synth,
+/turf/open/floor/plating/plating_catwalk,
+/area/whiskey_outpost/inside/cic)
 "EN" = (
 /obj/structure/largecrate/random/case/double,
 /turf/open/floor{
@@ -10754,7 +10763,7 @@
 /obj/structure/machinery/door/poddoor/shutters/almayer{
 	dir = 2;
 	id = "WOlineshutters1";
-	name = "\improper Supply Depot Line 1"
+	name = "\improper Supply Depo Line 1"
 	},
 /turf/open/floor/prison{
 	icon_state = "floor_plate"
@@ -12390,7 +12399,7 @@
 /obj/structure/machinery/door/poddoor/shutters/almayer{
 	dir = 2;
 	id = "WOlineshutters2";
-	name = "\improper Supply Depot Line 2"
+	name = "\improper Supply Depo Line 2"
 	},
 /turf/open/floor/plating,
 /area/whiskey_outpost/inside/supply)
@@ -12654,6 +12663,10 @@
 	icon_state = "asteroidwarning"
 	},
 /area/whiskey_outpost/outside/north)
+"WK" = (
+/obj/structure/machinery/cm_vending/own_points/experimental_tools,
+/turf/open/floor/plating/plating_catwalk,
+/area/whiskey_outpost/inside/cic)
 "WL" = (
 /obj/structure/flora/bush/ausbushes/var3/leafybush,
 /obj/structure/disposalpipe/segment{
@@ -19348,9 +19361,9 @@ mT
 mT
 mT
 mT
-mT
-mT
-mT
+ak
+ak
+ak
 mT
 mT
 mT
@@ -19551,7 +19564,7 @@ mT
 mT
 mT
 ak
-ak
+WK
 ak
 ak
 ak
@@ -19751,9 +19764,9 @@ mT
 mT
 mT
 mT
-mT
 ak
 ai
+aC
 qe
 ih
 Nr
@@ -19953,9 +19966,9 @@ mT
 mT
 mT
 mT
-mT
 ak
 Vy
+aC
 PB
 PM
 Ed
@@ -20157,7 +20170,7 @@ ak
 ak
 ak
 ak
-ak
+EL
 Mo
 Gx
 PM

--- a/maps/map_files/Whiskey_Outpost_v2/Whiskey_Outpost_v2.dmm
+++ b/maps/map_files/Whiskey_Outpost_v2/Whiskey_Outpost_v2.dmm
@@ -1042,7 +1042,7 @@
 /obj/structure/machinery/door/poddoor/shutters/almayer{
 	dir = 2;
 	id = "WOlineshutters1";
-	name = "\improper Supply Depo Line 1"
+	name = "\improper Supply Depot Line 1"
 	},
 /turf/open/floor/plating,
 /area/whiskey_outpost/inside/supply)
@@ -3065,7 +3065,7 @@
 /obj/structure/machinery/door/poddoor/shutters/almayer{
 	dir = 2;
 	id = "WOlineshutters2";
-	name = "\improper Supply Depo Line 2"
+	name = "\improper Supply Depot Line 2"
 	},
 /turf/open/floor/prison{
 	icon_state = "floor_plate"
@@ -5026,7 +5026,7 @@
 "rM" = (
 /obj/structure/machinery/door/airlock/almayer/marine/requisitions{
 	dir = 2;
-	name = "\improper Supply Depo";
+	name = "\improper Supply Depot";
 	no_panel = 1;
 	not_weldable = 1
 	},
@@ -6501,7 +6501,7 @@
 "wV" = (
 /obj/structure/machinery/door/airlock/almayer/marine/requisitions{
 	dir = 8;
-	name = "\improper Supply Depo";
+	name = "\improper Supply Depot";
 	no_panel = 1;
 	not_weldable = 1
 	},
@@ -10754,7 +10754,7 @@
 /obj/structure/machinery/door/poddoor/shutters/almayer{
 	dir = 2;
 	id = "WOlineshutters1";
-	name = "\improper Supply Depo Line 1"
+	name = "\improper Supply Depot Line 1"
 	},
 /turf/open/floor/prison{
 	icon_state = "floor_plate"
@@ -12390,7 +12390,7 @@
 /obj/structure/machinery/door/poddoor/shutters/almayer{
 	dir = 2;
 	id = "WOlineshutters2";
-	name = "\improper Supply Depo Line 2"
+	name = "\improper Supply Depot Line 2"
 	},
 /turf/open/floor/plating,
 /area/whiskey_outpost/inside/supply)

--- a/maps/map_files/Whiskey_Outpost_v2/Whiskey_Outpost_v2.dmm
+++ b/maps/map_files/Whiskey_Outpost_v2/Whiskey_Outpost_v2.dmm
@@ -868,6 +868,13 @@
 "dl" = (
 /turf/closed/wall/r_wall/unmeltable,
 /area/whiskey_outpost/inside/hospital)
+"dp" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/open/floor/prison,
+/area/whiskey_outpost/inside/supply)
 "dr" = (
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -2021,6 +2028,13 @@
 /obj/structure/surface/rack,
 /turf/open/jungle,
 /area/whiskey_outpost/outside/lane/two_south)
+"hr" = (
+/obj/structure/disposalpipe/trunk,
+/obj/structure/machinery/disposal/deliveryChute{
+	dir = 1
+	},
+/turf/open/floor/prison,
+/area/whiskey_outpost/inside/supply)
 "hs" = (
 /turf/open/gm/coast/beachcorner2/south_west,
 /area/whiskey_outpost/outside/lane/four_north)
@@ -3058,8 +3072,10 @@
 	},
 /area/whiskey_outpost/inside/supply)
 "kE" = (
-/obj/structure/surface/rack,
-/turf/open/floor/plating/plating_catwalk/prison,
+/obj/structure/machinery/computer/cryopod,
+/turf/open/floor/prison{
+	icon_state = "floor_plate"
+	},
 /area/whiskey_outpost/inside/supply)
 "kG" = (
 /obj/structure/bed/chair{
@@ -4260,6 +4276,10 @@
 /obj/effect/landmark/start/whiskey/pilot,
 /turf/open/gm/dirt,
 /area/whiskey_outpost/outside/mortar_pit)
+"pg" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/prison,
+/area/whiskey_outpost/inside/supply)
 "pj" = (
 /obj/effect/landmark/start/whiskey/engineer,
 /turf/open/gm/dirtgrassborder/north,
@@ -5151,7 +5171,7 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/whiskey_outpost/inside/engineering)
 "sh" = (
-/obj/structure/machinery/cm_vending/sorted/cargo_guns/wo,
+/obj/structure/machinery/cm_vending/sorted/cargo_guns/cargo/wo,
 /turf/open/floor/prison{
 	icon_state = "floor_plate"
 	},
@@ -5223,6 +5243,10 @@
 /obj/structure/sign/ROsign,
 /turf/closed/wall/r_wall,
 /area/whiskey_outpost)
+"sw" = (
+/obj/effect/decal/warning_stripes,
+/turf/open/floor/prison,
+/area/whiskey_outpost/inside/supply)
 "sx" = (
 /obj/structure/machinery/cm_vending/clothing/dress,
 /turf/open/floor/prison{
@@ -5251,7 +5275,7 @@
 	},
 /area/whiskey_outpost/inside/living)
 "sJ" = (
-/obj/structure/machinery/cm_vending/sorted/cargo_ammo/wo,
+/obj/structure/machinery/cm_vending/sorted/cargo_ammo/cargo/wo,
 /turf/open/floor/prison,
 /area/whiskey_outpost/inside/supply)
 "sK" = (
@@ -5356,9 +5380,8 @@
 /turf/open/floor/prison,
 /area/whiskey_outpost/inside/supply)
 "th" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/structure/disposalpipe/junction{
+	dir = 8
 	},
 /turf/open/floor/prison,
 /area/whiskey_outpost/inside/supply)
@@ -5729,11 +5752,12 @@
 	dir = 4;
 	id = "trash"
 	},
-/obj/structure/machinery/recycler{
-	recycle_dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/machinery/light/small,
+/obj/structure/machinery/recycler/whiskey{
+	recycle_dir = 8
 	},
 /turf/open/floor/prison{
 	dir = 4;
@@ -6274,6 +6298,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
+/obj/structure/machinery/light/small,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "darkyellowfull2"
@@ -6337,7 +6362,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/machinery/light/small,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "darkyellowfull2"
@@ -6403,6 +6427,14 @@
 "wK" = (
 /turf/open/gm/dirtgrassborder/grassdirt_corner2/south_east,
 /area/whiskey_outpost/outside/lane/two_south)
+"wL" = (
+/obj/structure/surface/rack,
+/obj/item/device/destTagger,
+/obj/item/packageWrap,
+/obj/item/packageWrap,
+/obj/item/packageWrap,
+/turf/open/floor/prison,
+/area/whiskey_outpost/inside/supply)
 "wM" = (
 /obj/structure/machinery/line_nexter{
 	dir = 1;
@@ -6533,10 +6565,17 @@
 	},
 /area/whiskey_outpost/inside/cic)
 "xk" = (
-/obj/structure/machinery/light,
-/turf/open/floor/prison{
-	icon_state = "floor_plate"
+/obj/structure/surface/rack,
+/obj/structure/machinery/light{
+	unacidable = 1;
+	unslashable = 1;
+	dir = 1
 	},
+/obj/item/device/destTagger,
+/obj/item/packageWrap,
+/obj/item/packageWrap,
+/obj/item/packageWrap,
+/turf/open/floor/prison,
 /area/whiskey_outpost/inside/supply)
 "xl" = (
 /obj/item/ammo_casing{
@@ -6788,6 +6827,7 @@
 /area/whiskey_outpost/inside/hospital)
 "yj" = (
 /obj/effect/landmark/start/whiskey/cargo,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/prison{
 	dir = 8;
 	icon_state = "darkyellowcorners2"
@@ -6867,10 +6907,6 @@
 	dir = 4;
 	health = 80
 	},
-/obj/structure/machinery/light{
-	unacidable = 1;
-	unslashable = 1
-	},
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "darkyellowfull2"
@@ -6926,6 +6962,9 @@
 	health = 80
 	},
 /obj/item/tool/hand_labeler,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/prison{
 	dir = 8;
 	icon_state = "darkyellow2"
@@ -7860,6 +7899,13 @@
 	icon_state = "floor_plate"
 	},
 /area/whiskey_outpost/inside/bunker/bunker/front)
+"Cd" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/closed/wall/r_wall/unmeltable,
+/area/whiskey_outpost/inside/supply)
 "Ce" = (
 /turf/open/gm/grass/grassbeach/west,
 /area/whiskey_outpost/outside/lane/one_north)
@@ -8361,6 +8407,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/whiskey_outpost/inside/bunker)
+"DW" = (
+/obj/structure/machinery/door/window/northleft,
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "darkyellowfull2"
+	},
+/area/whiskey_outpost/inside/engineering)
 "DX" = (
 /obj/structure/blocker/invisible_wall,
 /turf/open/gm/river,
@@ -9834,7 +9887,7 @@
 /turf/closed/wall/r_wall,
 /area/whiskey_outpost/inside/bunker/bunker/front)
 "Kc" = (
-/obj/structure/machinery/cm_vending/sorted/attachments,
+/obj/structure/machinery/cm_vending/sorted/attachments/wo,
 /turf/open/floor/plating,
 /area/whiskey_outpost/inside/supply)
 "Kd" = (
@@ -9880,6 +9933,18 @@
 /obj/structure/sign/poster,
 /turf/closed/wall/r_wall,
 /area/whiskey_outpost/inside/engineering)
+"Ks" = (
+/obj/structure/closet/secure_closet/cargotech,
+/obj/item/clothing/accessory/storage/webbing,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "darkyellowfull2"
+	},
+/area/whiskey_outpost/inside/supply)
 "Kt" = (
 /obj/structure/fence,
 /turf/open/gm/dirt,
@@ -10779,6 +10844,20 @@
 	icon_state = "white"
 	},
 /area/whiskey_outpost/inside/hospital/triage)
+"OI" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/structure/machinery/light{
+	unacidable = 1;
+	unslashable = 1
+	},
+/turf/open/floor{
+	dir = 1;
+	icon_state = "asteroidfloor"
+	},
+/area/whiskey_outpost)
 "OK" = (
 /turf/closed/wall/strata_ice/jungle,
 /area/whiskey_outpost/outside/south/far)
@@ -12234,6 +12313,16 @@
 	icon_state = "blue"
 	},
 /area/whiskey_outpost/inside/cic)
+"Vr" = (
+/obj/structure/machinery/light{
+	unacidable = 1;
+	unslashable = 1
+	},
+/obj/item/device/destTagger,
+/obj/item/packageWrap,
+/obj/item/packageWrap,
+/turf/open/floor/prison,
+/area/whiskey_outpost/inside/supply)
 "Vt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -12805,6 +12894,13 @@
 /obj/effect/spawner/random/tool,
 /turf/open/gm/dirtgrassborder/east,
 /area/whiskey_outpost/outside/lane/two_south)
+"XO" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "floor_marked"
+	},
+/area/whiskey_outpost/inside/supply)
 "XP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -21086,7 +21182,7 @@ vn
 tv
 wl
 nK
-ya
+JN
 ya
 ya
 nr
@@ -21287,8 +21383,8 @@ nK
 vv
 tv
 wz
-nK
-JN
+DW
+ya
 ya
 Jd
 nr
@@ -21692,7 +21788,7 @@ vw
 tv
 wA
 nK
-ya
+JN
 ya
 ya
 nr
@@ -22502,7 +22598,7 @@ uB
 uB
 yf
 xg
-vC
+xg
 nr
 fy
 fy
@@ -22704,7 +22800,7 @@ kS
 pK
 vL
 yz
-nr
+vC
 nr
 fy
 fy
@@ -23304,12 +23400,12 @@ cx
 rm
 uf
 wQ
-kS
-pK
-kS
-pK
+dp
+XO
+pg
+XO
 yj
-yF
+Ks
 nr
 nr
 UN
@@ -23706,14 +23802,14 @@ oW
 OX
 qT
 lw
-rZ
+xk
 kS
 kS
+pK
 kS
-kS
-kS
-kS
-nr
+sw
+hr
+Cd
 nr
 mT
 BT
@@ -23908,13 +24004,13 @@ oW
 OX
 qT
 lw
-rZ
+wL
 kS
 kS
 kS
 kS
 Dk
-vN
+Vr
 nr
 mT
 mT
@@ -24713,7 +24809,7 @@ la
 nn
 oI
 rg
-oP
+OI
 su
 Kc
 sh
@@ -24924,7 +25020,7 @@ kS
 tS
 tS
 wQ
-wQ
+kS
 nr
 zg
 yk
@@ -25123,11 +25219,11 @@ VF
 TP
 wQ
 kS
-kE
-kE
-xk
+tS
+tS
+wQ
+vN
 yv
-nr
 Av
 zG
 Av
@@ -25327,9 +25423,9 @@ kS
 kS
 tS
 tS
-wQ
+kE
 nr
-lw
+nr
 fj
 fj
 fj


### PR DESCRIPTION
# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

Right now reqs on WO is a pain for three major reasons:
 * Marines have less gearing option making Req Line an huge burden
 * A lot of stuff is defunct or removed such as the recycler, parcel network, and vendors not containing now basic gear nowadays
 * Because of all that there is little incentive to run Reqs beyond the attachies line, meaning it becomes a pure roaming game as assistant engineers

This attempts to address it in the following ways:
 * Fixing the recycler. It now outputs materials, and can now recycle all the crates that previously littered Reqs for metal
 * Fixing req vendors. They did not benefit from eg. attachies vendor dispensing to table like Almayers'
 * Standardize the vendors contents with Almayers' to bring useful things like binos or grenades that were missing. The ammo vendor retains the spec ammo in addition to this.
 * Readds a delivery chute, related piping, paper wrap, and destination taggers, allowing Reqs to once again fax whole crates to pillboxes
 * Tweak supply pad deliveries weights and contents to make it more interesting and hopefully not ignored. This means higher chances to get materials, and new packs such as mortar shells, while reducing highly redundant packs such as floodlights.
 * Minor Req mapping adjsutments 

Additionally it adds the two missing synth vendors from the Almayer to the map.

**!!! Note that this enables recycler output also for other instances of the Reyclers. I don't believe it will be a major problem but they could be issued a yield penalty if you think it might. !!!**

# Explain why it's good for the game
QoL and making Reqs more relevant on WO, aswell as incentive using the bunker building more

# Changelog
:cl:
fix: Fixed recyclers (including Whiskey Outposts') and added the possibility to recycle crates with them.
fix: Standardized "vend to table" functionality of vendors, enabling it to work for Whiskey Outpost's Reqs.
add: Whiskey Outpost vendors now contain the same items as Almayer's. WO still has spare specialist ammo on top of that.
add: Readded delivery chute, wrap and tagger to Whiskey Outpost Reqs, letting you pack and send crates and items via disposals again.
balance: Whiskey Outpost supply drops should now be more interesting and impactful. 
add: Added missing Synth vendors on WO.
/:cl:
