### PR TITLE
Fix runtimes in toxic water targeting unliving

### DIFF
--- a/code/modules/desert_dam/filtration/filtration.dm
+++ b/code/modules/desert_dam/filtration/filtration.dm
@@ -136,7 +136,7 @@ var/global/east_riverstart = 0
 	else
 		return
 
-	if(ismob(A))
+	if(isliving(A))
 		var/mob/living/M = A
 
 		// Inside a xeno for example


### PR DESCRIPTION

# About the pull request

You've heard this story before. This causes runtimes with Queen Eye and probably other camera mobs. Observers exempt due to a dead check later down.

No player facing changes.