### PR TITLE
Tentative Fix/Consistency for Dummy Limb Runtimes

### DIFF
--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -135,10 +135,7 @@
 /datum/species/proc/create_organs(mob/living/carbon/human/H) //Handles creation of mob organs and limbs.
 	//In case of pre-existing limbs/organs, we remove the old ones.
 	QDEL_LIST(H.limbs)
-	H.limbs.Cut()
-
 	QDEL_LIST(H.internal_organs)
-	H.internal_organs.Cut()
 	H.internal_organs_by_name.Cut()
 
 	//This is a basic humanoid limb setup.

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -133,10 +133,13 @@
 	return
 
 /datum/species/proc/create_organs(mob/living/carbon/human/H) //Handles creation of mob organs and limbs.
-	for(var/L in H.limbs) //In case of pre-existing limbs/organs, we remove the old ones.
-		qdel(L)
-	H.internal_organs = list()
-	H.internal_organs_by_name = list()
+	//In case of pre-existing limbs/organs, we remove the old ones.
+	QDEL_LIST(H.limbs)
+	H.limbs.Cut()
+
+	QDEL_LIST(H.internal_organs)
+	H.internal_organs.Cut()
+	H.internal_organs_by_name.Cut()
 
 	//This is a basic humanoid limb setup.
 	var/obj/limb/chest/C = new(H, null, H)


### PR DESCRIPTION
# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

Tentative fix for a recurring runtime in dummy generation (eg. in character setup) caused by invalid limbs. 
This is also a generally very bad spot in terms of deletions because it would prevent the organs from deleting properly, and prevent the limbs from being GC'ed.

As far as I can see only dummy preview and admin transform will cause cascading species change, so effect might not be obvious.

Tested for basic functionality (dummy render, running around, getting hit, healing).

# Changelog
:cl:
fix: Fixed Limbs and Organs deleting incorrectly on species change.
/:cl:
