### PR TITLE
Brings back NVG

### DIFF
--- a/code/datums/supply_packs/gear.dm
+++ b/code/datums/supply_packs/gear.dm
@@ -63,3 +63,15 @@
 	containertype = /obj/structure/closet/crate/ammo
 	containername = "fulton recovery device crate"
 	group = "Gear"
+
+/datum/supply_packs/nvg
+	name = "M2 Night Vision Goggles Crate (x3)"
+	contains = list(
+		/obj/item/prop/helmetgarb/helmet_nvg,
+		/obj/item/prop/helmetgarb/helmet_nvg,
+		/obj/item/prop/helmetgarb/helmet_nvg,
+	)
+	cost = 60
+	containertype = /obj/structure/closet/crate/supply
+	containername = "M2 Night Vission Goggles Crate"
+	group = "Gear"

--- a/code/game/machinery/vending/vendor_types/intelligence_officer.dm
+++ b/code/game/machinery/vending/vendor_types/intelligence_officer.dm
@@ -7,7 +7,7 @@ GLOBAL_LIST_INIT(cm_vending_gear_intelligence_officer, list(
 		list("SUPPLIES", 0, null, null, null),
 		list("Power Control Module", 5, /obj/item/circuitboard/apc, null, VENDOR_ITEM_REGULAR),
 		list("Binoculars", 5, /obj/item/device/binoculars, null, VENDOR_ITEM_REGULAR),
-		list("Night Vision Optic", 25, /obj/item/device/helmet_visor/night_vision, null, VENDOR_ITEM_RECOMMENDED),
+		list("M2 Night Vision Goggles", 25, /obj/item/prop/helmetgarb/helmet_nvg, null, VENDOR_ITEM_RECOMMENDED),
 		list("Data Detector", 5, /obj/item/device/motiondetector/intel, null, VENDOR_ITEM_REGULAR),
 		list("Intel Radio Encryption Key", 5, /obj/item/device/encryptionkey/intel, null, VENDOR_ITEM_REGULAR),
 		list("Fire Extinguisher (Portable)", 5, /obj/item/tool/extinguisher/mini, null, VENDOR_ITEM_REGULAR),

--- a/code/game/machinery/vending/vendor_types/squad_prep/squad_leader.dm
+++ b/code/game/machinery/vending/vendor_types/squad_prep/squad_leader.dm
@@ -23,7 +23,7 @@ GLOBAL_LIST_INIT(cm_vending_gear_leader, list(
 		list("Machete Pouch (Full)", 4, /obj/item/storage/pouch/machete/full, null, VENDOR_ITEM_REGULAR),
 		list("USCM Radio Telephone Pack", 5, /obj/item/storage/backpack/marine/satchel/rto, null, VENDOR_ITEM_REGULAR),
 		list("M276 Pattern Combat Toolbelt Rig", 15, /obj/item/storage/belt/gun/utility, null, VENDOR_ITEM_REGULAR),
-		list("Night Vision Optic", 20, /obj/item/device/helmet_visor/night_vision, null, VENDOR_ITEM_RECOMMENDED),
+		list("M2 Night Vision Goggles", 20, /obj/item/prop/helmetgarb/helmet_nvg, null, VENDOR_ITEM_RECOMMENDED),
 
 		list("UTILITIES", 0, null, null, null),
 		list("Whistle", 3, /obj/item/device/whistle, null, VENDOR_ITEM_REGULAR),

--- a/code/game/machinery/vending/vendor_types/squad_prep/squad_tl.dm
+++ b/code/game/machinery/vending/vendor_types/squad_prep/squad_tl.dm
@@ -40,7 +40,7 @@ GLOBAL_LIST_INIT(cm_vending_gear_tl, list(
 		list("M276 Pattern Combat Toolbelt Rig", 15, /obj/item/storage/belt/gun/utility, null, VENDOR_ITEM_REGULAR),
 		list("Autoinjector Pouch (Full)", 15, /obj/item/storage/pouch/autoinjector/full, null, VENDOR_ITEM_REGULAR),
 		list("Insulated Gloves", 3, /obj/item/clothing/gloves/yellow, null, VENDOR_ITEM_REGULAR),
-		list("Night Vision Optic", 30, /obj/item/device/helmet_visor/night_vision, null, VENDOR_ITEM_RECOMMENDED),
+		list("M2 Night Vision Goggles", 30, /obj/item/prop/helmetgarb/helmet_nvg, null, VENDOR_ITEM_RECOMMENDED),
 
 		list("UTILITIES", 0, null, null, null),
 		list("Binoculars", 5, /obj/item/device/binoculars, null, VENDOR_ITEM_REGULAR),


### PR DESCRIPTION

# About the pull request

Re-adds NVG (Night Vision Goggles) back to gameplay, removes NVO (Night Vision Optics (visor thing)) from gameplay.

# Explain why it's good for the game

Honestly, I was going to try to fix NVO, but in the end I decided it is not really worth it. Too many issues: 
1) Too inconvenient to use. Yeah switching between visors is a real pain.
2) Too inconvenient to recharge. You need someone to bring recharger, otherwise you won't be able to use the NVO more than for few minutes. 
3) NVO are way less balanced. You can use the binoculars with NVO, which is a HUGE advantage out of nowhere. Also, you can't break NVO as a xeno, and I think being able to break NVGs was a nice little counterplay.
4) It's really hard to tell if marine is using NVO, even if you know where to look. It's just 1 blinking pixel that doesn't really change the shape of the helmet. There is also some tiny green glow, but it's probably only relevant in HvH, as xeno you won't see it. Really, I was playing xeno for last months and I think I noticed NVO only once. The sprite is not very good either and it's also broken (it doesn't blink when you are facing north iirc).

While everything I mentioned can be fixed, I'm not sure it's worth it. Maybe NVO matches the aesthetics a little better, but it requires too much repairs to actually work and I'm not willing to spend that much time and energy fixing someone else's project (and I doubt that _someone_ will fix it either). And I cannot make new sprites for NVO anyway. So this is why I propose a revert to the thing that worked flawlessly and everyone was happy with.


# Testing Photographs and Procedure
<details>
I did not test it, but no one read this anyway.

</details>


# Changelog
:cl: ihatethisengine
add: Night Vision Goggles are obtainable again.
del: Night Vision Optics are no longer obtainable.
/:cl:
