### PR TITLE
Vehicles hear exterior audio

### DIFF
--- a/code/controllers/subsystem/interior.dm
+++ b/code/controllers/subsystem/interior.dm
@@ -42,7 +42,7 @@ SUBSYSTEM_DEF(interior)
 			continue
 		if(x >= bounds[1].x && x <= bounds[2].x && y >= bounds[1].y && y <= bounds[2].y)
 			return current_interior
-	return null
+	return
 
 /// Checks if an atom is in an interior
 /datum/controller/subsystem/interior/proc/in_interior(loc)

--- a/code/controllers/subsystem/interior.dm
+++ b/code/controllers/subsystem/interior.dm
@@ -42,7 +42,7 @@ SUBSYSTEM_DEF(interior)
 			continue
 		if(x >= bounds[1].x && x <= bounds[2].x && y >= bounds[1].y && y <= bounds[2].y)
 			return current_interior
-	return FALSE
+	return null
 
 /// Checks if an atom is in an interior
 /datum/controller/subsystem/interior/proc/in_interior(loc)
@@ -51,7 +51,7 @@ SUBSYSTEM_DEF(interior)
 	if(!isturf(loc))
 		loc = get_turf(loc)
 
-	var/datum/turf_reservation/interior/reservation = SSmapping.used_turfs[loc]
+	var/datum/weakref/reservation = SSmapping.used_turfs[loc]
 
 	if(!istype(reservation))
 		return FALSE

--- a/code/controllers/subsystem/sound.dm
+++ b/code/controllers/subsystem/sound.dm
@@ -41,5 +41,5 @@ SUBSYSTEM_DEF(sound)
 			if(VI?.ready)
 				var/list/bounds = VI.get_middle_coords()
 				if(bounds.len >= 2)
-					hearers |= SSquadtree.players_in_range(RECT(bounds[1], bounds[2], VI.map_template.height, VI.map_template.width), bounds[3])
+					hearers |= SSquadtree.players_in_range(RECT(bounds[1], bounds[2], VI.map_template.width, VI.map_template.height), bounds[3])
 	template_queue[template] = hearers

--- a/code/modules/vehicles/interior/interior.dm
+++ b/code/modules/vehicles/interior/interior.dm
@@ -318,7 +318,7 @@
 	var/turf/min = reservation.bottom_left_coords
 	var/turf/max = reservation.top_right_coords
 
-	return list(Floor(min[1] + (max[1] - min[1])), Floor(min[2] + (max[2] - min[2])), min[3])
+	return list(Floor(min[1] + (max[1] - min[1])/2), Floor(min[2] + (max[2] - min[2])/2), min[3])
 
 /datum/interior/proc/get_middle_turf()
 	var/list/turf/bounds = get_bound_turfs()


### PR DESCRIPTION

# About the pull request

As described in issue #4777 while vehicle interiors are intended to hear external sounds, it is largely nonfunctional. Sounds are either not heard or are inaudibly quiet. This is due to several smaller issues working together.

First, interiors are not detected as interiors. In commit https://github.com/cmss13-devs/cmss13/commit/0808500777f390bbe1d59142e955678344ef6d3e the types stored in the `used_turfs` list were changed to weakrefs, but the `is_interior()` function still checked for the old type, causing it to always return `FALSE`: https://github.com/cmss13-devs/cmss13/blob/5fbe14390f80225a5d295f07b9acf781fb8aa2b2/code/controllers/subsystem/interior.dm#L54-L58
Fixed by checking for the correct type.

Second, the `get_interior_by_coords()` function returned an object on success, but returned `FALSE` on failure - which still counted as an object. Since shuttles add turfs to `used_turfs` but don't have actual interiors, they would pass `is_interior()` but fail `get_interior_by_coords()`. The sound code expected any object received at this point to be valid, but using `FALSE` would thrown an error: https://github.com/cmss13-devs/cmss13/blob/5fbe14390f80225a5d295f07b9acf781fb8aa2b2/code/game/sound.dm#L82-L84
Fixed by returning `null` on failure.

Third, the audio was now playing but in the wrong part of the interior. It was offset to the top-right corner because `get_middle_coords()` got the difference between the bounds, but never actually averaged them: https://github.com/cmss13-devs/cmss13/blob/5fbe14390f80225a5d295f07b9acf781fb8aa2b2/code/modules/vehicles/interior/interior.dm#L321
Fixed by dividing the difference by two.

Fourth, the sound playback zone was oriented incorrectly because the width and height were transposed when creating the zone. Rectangles were defined as width then height, but the sound subsystem was passing height then width: https://github.com/cmss13-devs/cmss13/blob/5fbe14390f80225a5d295f07b9acf781fb8aa2b2/code/controllers/subsystem/sound.dm#L44
Fixed by passing width then height.

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

Vehicle interiors were intended to hear external sounds. This restores that functionality.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: vehicle interiors can hear exterior noises
/:cl:
