### PR TITLE
Fixes 2 gun runtime sources

### DIFF
--- a/code/datums/components/autofire/autofire.dm
+++ b/code/datums/components/autofire/autofire.dm
@@ -123,19 +123,19 @@
 		if(GUN_FIREMODE_BURSTFIRE)
 			shots_fired++
 			if(shots_fired == burst_shots_to_fire)
-				callback_bursting.Invoke(FALSE)
-				callback_display_ammo.Invoke()
+				callback_bursting?.Invoke(FALSE)
+				callback_display_ammo?.Invoke()
 				bursting = FALSE
 				stop_firing()
 				if(have_to_reset_at_burst_end)//We failed to reset because we were bursting, we do it now
-					callback_reset_fire.Invoke()
+					callback_reset_fire?.Invoke()
 					have_to_reset_at_burst_end = FALSE
 				return
-			callback_bursting.Invoke(TRUE)
+			callback_bursting?.Invoke(TRUE)
 			bursting = TRUE
 			next_fire = world.time + burstfire_shot_delay
 		if(GUN_FIREMODE_AUTOMATIC)
-			callback_set_firing.Invoke(TRUE)
+			callback_set_firing?.Invoke(TRUE)
 			next_fire = world.time + (auto_fire_shot_delay * automatic_delay_mult)
 		if(GUN_FIREMODE_SEMIAUTO)
 			return

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -1963,6 +1963,7 @@ not all weapons use normal magazines etc. load_into_chamber() itself is designed
 
 /// Setter proc for fa_firing
 /obj/item/weapon/gun/proc/set_auto_firing(auto = FALSE)
+	SIGNAL_HANDLER
 	fa_firing = auto
 
 /// Getter for gun_user

--- a/code/modules/projectiles/guns/lever_action.dm
+++ b/code/modules/projectiles/guns/lever_action.dm
@@ -405,9 +405,9 @@ their unique feature is that a direct hit will buff your damage and firerate
 
 /obj/item/weapon/gun/lever_action/xm88/wield(mob/user)
 	. = ..()
-
-	RegisterSignal(src, COMSIG_ITEM_ZOOM, PROC_REF(scope_on))
-	RegisterSignal(src, COMSIG_ITEM_UNZOOM, PROC_REF(scope_off))
+	if(.)
+		RegisterSignal(src, COMSIG_ITEM_ZOOM, PROC_REF(scope_on))
+		RegisterSignal(src, COMSIG_ITEM_UNZOOM, PROC_REF(scope_off))
 
 /obj/item/weapon/gun/lever_action/xm88/proc/scope_on(atom/source, mob/current_user)
 	SIGNAL_HANDLER


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

This fixes two issues happening on live game:

* The XM88 does not check for successful wielding before registering signals, presumably causing overriding errors in logs.
* M56D/M2C HMGs do not correctly reset the autofire component when the operator is removed. This causes it to try to keep firing without an operator which generates runtimes (presumably in burst fire mode). In addition this may solve other issues such as the fabled "can use HMG while dead" one, but I can't confirm it.

# Explain why it's good for the game
Readable logs and less clunky interactions down the line

# Changelog
:cl:
fix: M56D/M2C should now properly stop firing when they stop being used.
/:cl:
