### PR TITLE
New Varadero Survivor Outfit Changes

### DIFF
--- a/code/modules/gear_presets/survivors/new_varadero/preset_new_varadero.dm
+++ b/code/modules/gear_presets/survivors/new_varadero/preset_new_varadero.dm
@@ -17,10 +17,10 @@
 	assignment = "New Varadero Medical Technician"
 
 /datum/equipment_preset/survivor/doctor/nv/load_gear(mob/living/carbon/human/new_human)
-	new_human.equip_to_slot_or_del(new /obj/item/clothing/under/rank/medical(new_human), WEAR_BODY)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/under/rank/synthetic/utility(new_human), WEAR_BODY)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/mask/surgical(new_human), WEAR_FACE)
 	new_human.equip_to_slot_or_del(new /obj/item/storage/firstaid/adv(new_human.back), WEAR_IN_BACK)
-	new_human.equip_to_slot_or_del(new /obj/item/clothing/head/cmcap/boonie(new_human), WEAR_HEAD)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/head/cmcap(new_human), WEAR_HEAD)
 	..()
 
 /datum/equipment_preset/survivor/scientist/nv
@@ -28,13 +28,14 @@
 	assignment = "New Varadero Researcher"
 
 /datum/equipment_preset/survivor/scientist/nv/load_gear(mob/living/carbon/human/new_human)
-	new_human.equip_to_slot_or_del(new /obj/item/clothing/under/rank/medical/purple(new_human), WEAR_BODY)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/under/marine/officer/researcher(new_human), WEAR_BODY)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/labcoat(new_human), WEAR_JACKET)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/head/cmcap/boonie(new_human), WEAR_HEAD)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/gloves/latex(new_human), WEAR_HANDS)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/mask/surgical(new_human), WEAR_FACE)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/glasses/science(new_human), WEAR_EYES)
 	new_human.equip_to_slot_or_del(new /obj/item/storage/backpack/satchel/chem(new_human), WEAR_BACK)
-	new_human.equip_to_slot_or_del(new /obj/item/clothing/shoes/purple(new_human), WEAR_FEET)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/shoes/laceup(new_human), WEAR_FEET)
 	..()
 
 /datum/equipment_preset/survivor/interstellar_commerce_commission_liason/nv
@@ -51,15 +52,16 @@
 	..()
 
 /datum/equipment_preset/survivor/trucker/nv
-	name = "Survivor - New Varadero Vehicle Operator"
-	assignment = "New Varadero Vehicle Operator"
+	name = "Survivor - New Varadero Cargo Technician"
+	assignment = "New Varadero Cargo Technician"
 
 /datum/equipment_preset/survivor/trucker/nv/load_gear(mob/living/carbon/human/new_human)
-	new_human.equip_to_slot_or_del(new /obj/item/clothing/under/rank/cargo(new_human), WEAR_BODY)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/under/colonist/wy_davisone(new_human), WEAR_BODY)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/glasses/meson(new_human), WEAR_EYES)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/shoes/marine/knife(new_human), WEAR_FEET)
-	new_human.equip_to_slot_or_del(new /obj/item/clothing/head/cmcap/boonie(new_human), WEAR_HEAD)
-	new_human.equip_to_slot_or_del(new /obj/item/storage/backpack/satchel(new_human), WEAR_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/head/beanie/tan(new_human), WEAR_HEAD)
+	new_human.equip_to_slot_or_del(new /obj/item/storage/backpack/marine/satchel/tech(new_human), WEAR_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/gloves/marine/brown(new_human), WEAR_HANDS)
 	..()
 
 /datum/equipment_preset/survivor/engineer/nv
@@ -67,11 +69,11 @@
 	assignment = "New Varadero Engineer"
 
 /datum/equipment_preset/survivor/engineer/nv/load_gear(mob/living/carbon/human/new_human)
-	new_human.equip_to_slot_or_del(new /obj/item/clothing/under/rank/dispatch(new_human), WEAR_BODY)
-	new_human.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/hazardvest(new_human), WEAR_JACKET)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/under/colonist/ua_civvies(new_human), WEAR_BODY)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/hazardvest/blue(new_human), WEAR_JACKET)
 	new_human.equip_to_slot_or_del(new /obj/item/storage/backpack/satchel/eng(new_human), WEAR_BACK)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/shoes/marine/knife(new_human), WEAR_FEET)
-	new_human.equip_to_slot_or_del(new /obj/item/clothing/head/hardhat/orange(new_human), WEAR_HEAD)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/head/hardhat/dblue(new_human), WEAR_HEAD)
 	..()
 
 /datum/equipment_preset/survivor/chaplain/nv


### PR DESCRIPTION

# About the pull request

This PR adds new equipment presets for the New Varadero survivors, replacing some of their uniforms with United American utility jumpsuits. The Researcher preset has been tweaked to be less mismatched and out of place with the outdated virologist's lab coat and purple scrubs. It also changes the Vehicle Operator's job title to Cargo Technician, but there's no changes for the skillset. This PR is solely visual changes, and includes no balance changes.

# Explain why it's good for the game
New Varadero is a UA outpost, so it makes sense that the people working and living there would have UA jumpsuits. It also gives the outfits some use outside of just being in the synth vendor, and makes some of the New Varadero survivors somewhat more visually distinct from the ones on LV, which New Varadero copies most of its presets from.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/cmss13-devs/cmss13/assets/106038874/3ba45ac0-daee-47cc-a75b-2c2377927890)

Left to Right - Cargo Technician, Medical Technician, Engineer, Researcher
</details>


# Changelog
:cl:IowaPotatoFarmer
add: Added new survivor presets for New Varadero to make them more visually distinct and unique to the map.
/:cl:
