### PR TITLE
Spittin Facts

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
@@ -6,7 +6,7 @@
 	caste_type = XENO_CASTE_QUEEN
 	tier = 0
 
-	melee_damage_lower = XENO_DAMAGE_TIER_4
+	melee_damage_lower = XENO_DAMAGE_TIER_5
 	melee_damage_upper = XENO_DAMAGE_TIER_6
 	melee_vehicle_damage = XENO_DAMAGE_TIER_9 //Queen and Ravs have extra multiplier when dealing damage in multitile_interaction.dm
 	max_health = XENO_HEALTH_QUEEN
@@ -20,14 +20,14 @@
 
 	build_time_mult = BUILD_TIME_MULT_BUILDER
 
-	is_intelligent = 1
+	is_intelligent = TRUE
 	evolution_allowed = FALSE
 	fire_immunity = FIRE_IMMUNITY_NO_DAMAGE|FIRE_IMMUNITY_NO_IGNITE
 	caste_desc = "The biggest and baddest xeno. The Queen controls the hive and plants eggs"
-	spit_types = list(/datum/ammo/xeno/toxin/queen, /datum/ammo/xeno/acid/spatter)
-	can_hold_facehuggers = 0
+	spit_types = list(/datum/ammo/xeno/toxin/queen, /datum/ammo/xeno/acid/praetorian)
+	can_hold_facehuggers = FALSE
 	can_hold_eggs = CAN_HOLD_ONE_HAND
-	acid_level = 2
+	acid_level = 3
 	weed_level = WEED_LEVEL_STANDARD
 	can_be_revived = FALSE
 


### PR DESCRIPTION

# About the pull request
- This PR mainly adds changes to Spitting and neuro. specially focusing on Sentinel and Queen.

**Sentinel**
Sentinel slowing spit now has a "combo" mechanic. that works like this:
1)Slow (4 seconds)
2)Super slow (2 seconds) - IF slowed
3)Daze ( 2 seconds)+ funny jitter effect - If super slowed
4)Stun (1.75 seconds) - if both Dazed and Superslowed or already knocked down  ( stun doesnt stack) // PD : no its not infinite stun.

**old behaviour**
Super slow (2.5 seconds)

-No armor spit now only applies a 1.75 second stun instead of 3 seconds and doesnt stack.
-If you are hit with a no armor you will now be only stuned , not stunned and superslowed like before.
-Improved Var names and reduced code lines from slowing spit.

**Queen**
-Queen Acid spit will now use Praetorian Spit instead of Spitter Special spit. ( same damage but more range) to encourage queens to use this spit instead of the stun spit.
-Queen slash damage will now only vary by 1 tier instead of 2 ( thats how most xenos work currently)
-Queen Acid is now level 3

# Explain why it's good for the game
Adds more gaming to sentinels so they can be more usefull as a utility-ranged Caste .

Queen gets encouraged to use the acid spit option and more consistent damage output like all other xenos.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Sentinel Slowing spit has a chain of effects (slow>superslow>daze>stun)
balance: Queen Slash damage variable is now only 1 tier instead of 2 ( 35-45 > 40-45)
balance: Queen Acid spits will no use the Praetorian version ( same damage more range)
balance: Queen now has acid tier 3
/:cl:
