### PR TITLE
Fix job entry message wiki links

### DIFF
--- a/code/__DEFINES/urls.dm
+++ b/code/__DEFINES/urls.dm
@@ -1,3 +1,7 @@
+// placeholder strings to be replaced
+#define WIKI_PLACEHOLDER "%WIKIURL%"
+#define LAW_PLACEHOLDER "%LAWURL%"
+
 // ------ MISC WIKI LINKS ------ //
 #define URL_WIKI_LAW "Marine_Law"
 #define URL_WIKI_XENO_QUICKSTART "Xeno_Quickstart_Guide"

--- a/code/controllers/configuration/configuration.dm
+++ b/code/controllers/configuration/configuration.dm
@@ -22,6 +22,8 @@
 	var/static/regex/ic_filter_regex
 	var/list/fail_to_topic_whitelisted_ips
 
+	var/is_loaded = FALSE
+
 /datum/controller/configuration/proc/admin_reload()
 	if(IsAdminAdvancedProcCall())
 		alert_proccall("configuration admin_reload")
@@ -54,6 +56,8 @@
 	loadmaplist(CONFIG_SHIP_MAPS_FILE, SHIP_MAP)
 	LoadChatFilter()
 	LoadTopicRateWhitelist()
+
+	is_loaded = TRUE
 
 	if(Master)
 		Master.OnConfigLoad()

--- a/code/game/jobs/job/civilians/other/liaison.dm
+++ b/code/game/jobs/job/civilians/other/liaison.dm
@@ -6,7 +6,7 @@
 	selection_class = "job_cl"
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT
 	gear_preset = /datum/equipment_preset/uscm_ship/liaison
-	entry_message_body = "As a <a href='%WIKIURL%'>representative of Weyland-Yutani Corporation</a>, your job requires you to stay in character at all times. You are not required to follow military orders; however, you cannot give military orders. Your primary job is to observe and report back your findings to Weyland-Yutani. Follow regular game rules unless told otherwise by your superiors. Use your office fax machine to communicate with corporate headquarters or to acquire new directives. You may not receive anything back, and this is normal."
+	entry_message_body = "As a <a href='"+WIKI_PLACEHOLDER+"'>representative of Weyland-Yutani Corporation</a>, your job requires you to stay in character at all times. You are not required to follow military orders; however, you cannot give military orders. Your primary job is to observe and report back your findings to Weyland-Yutani. Follow regular game rules unless told otherwise by your superiors. Use your office fax machine to communicate with corporate headquarters or to acquire new directives. You may not receive anything back, and this is normal."
 	var/mob/living/carbon/human/active_liaison
 
 /datum/job/civilian/liaison/generate_entry_conditions(mob/living/liaison, whitelist_status)

--- a/code/game/jobs/job/civilians/other/mess_seargent.dm
+++ b/code/game/jobs/job/civilians/other/mess_seargent.dm
@@ -6,7 +6,7 @@
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT
 	supervisors = "the auxiliary support officer"
 	gear_preset = /datum/equipment_preset/uscm_ship/chef
-	entry_message_body = "<a href='%WIKIURL%'>Your job is to service the marines with excellent food</a>, drinks and entertaining the shipside crew when needed. You have a lot of freedom and it is up to you, to decide what to do with it. Good luck!"
+	entry_message_body = "<a href='"+WIKI_PLACEHOLDER+"'>Your job is to service the marines with excellent food</a>, drinks and entertaining the shipside crew when needed. You have a lot of freedom and it is up to you, to decide what to do with it. Good luck!"
 
 /obj/effect/landmark/start/chef
 	name = JOB_MESS_SERGEANT

--- a/code/game/jobs/job/civilians/support/cmo.dm
+++ b/code/game/jobs/job/civilians/support/cmo.dm
@@ -6,7 +6,7 @@
 	selection_class = "job_cmo"
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT
 	gear_preset = /datum/equipment_preset/uscm_ship/uscm_medical/cmo
-	entry_message_body = "You're a commissioned officer of the USCM. <a href='%WIKIURL%'>You have authority over everything related to Medbay and Research</a>, only able to be overriden by the XO and CO. You are in charge of medical staff, surgery, chemistry, stimulants and keeping the marines healthy overall."
+	entry_message_body = "You're a commissioned officer of the USCM. <a href='"+WIKI_PLACEHOLDER+"'>You have authority over everything related to Medbay and Research</a>, only able to be overriden by the XO and CO. You are in charge of medical staff, surgery, chemistry, stimulants and keeping the marines healthy overall."
 
 AddTimelock(/datum/job/civilian/professor, list(
 	JOB_MEDIC_ROLES = 10 HOURS

--- a/code/game/jobs/job/civilians/support/nurse.dm
+++ b/code/game/jobs/job/civilians/support/nurse.dm
@@ -6,7 +6,7 @@
 	selection_class = "job_doctor"
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT
 	gear_preset = /datum/equipment_preset/uscm_ship/uscm_medical/nurse
-	entry_message_body = "<a href='%WIKIURL%'>You are tasked with keeping the Marines healthy and strong.</a> You are also an expert when it comes to medication and treatment, and can do minor surgical procedures. Focus on assisting doctors and triaging wounded marines."
+	entry_message_body = "<a href='"+WIKI_PLACEHOLDER+"'>You are tasked with keeping the Marines healthy and strong.</a> You are also an expert when it comes to medication and treatment, and can do minor surgical procedures. Focus on assisting doctors and triaging wounded marines."
 
 /obj/effect/landmark/start/nurse
 	name = JOB_NURSE

--- a/code/game/jobs/job/civilians/support/researcher.dm
+++ b/code/game/jobs/job/civilians/support/researcher.dm
@@ -10,7 +10,7 @@
 	selection_class = "job_researcher"
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT
 	gear_preset = /datum/equipment_preset/uscm_ship/uscm_medical/researcher
-	entry_message_body = "You're a commissioned officer of the USCM, though you are not in the ship's chain of command. You are tasked with <a href='%WIKIURL%'>researching</a> and developing new medical treatments, helping your fellow doctors, and generally learning new things. Your role involves a lot of roleplaying, but you can perform the function of a regular doctor. Do not hand out things to Marines without getting permission from your supervisor."
+	entry_message_body = "You're a commissioned officer of the USCM, though you are not in the ship's chain of command. You are tasked with <a href='"+WIKI_PLACEHOLDER+"'>researching</a> and developing new medical treatments, helping your fellow doctors, and generally learning new things. Your role involves a lot of roleplaying, but you can perform the function of a regular doctor. Do not hand out things to Marines without getting permission from your supervisor."
 
 /datum/job/civilian/researcher/set_spawn_positions(count)
 	spawn_positions = rsc_slot_formula(count)

--- a/code/game/jobs/job/civilians/support/synthetic.dm
+++ b/code/game/jobs/job/civilians/support/synthetic.dm
@@ -9,7 +9,7 @@
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT|ROLE_ADMIN_NOTIFY|ROLE_WHITELISTED|ROLE_CUSTOM_SPAWN
 	flags_whitelist = WHITELIST_SYNTHETIC
 	gear_preset = /datum/equipment_preset/synth/uscm
-	entry_message_body = "You are a <a href='%WIKIURL%'>Synthetic!</a> You are held to a higher standard and are required to obey not only the Server Rules but Marine Law and Synthetic Rules. Failure to do so may result in your White-list Removal. Your primary job is to support and assist all USCM Departments and Personnel on-board. In addition, being a Synthetic gives you knowledge in every field and specialization possible on-board the ship. As a Synthetic you answer to the acting commanding officer. Special circumstances may change this!"
+	entry_message_body = "You are a <a href='"+WIKI_PLACEHOLDER+"'>Synthetic!</a> You are held to a higher standard and are required to obey not only the Server Rules but Marine Law and Synthetic Rules. Failure to do so may result in your White-list Removal. Your primary job is to support and assist all USCM Departments and Personnel on-board. In addition, being a Synthetic gives you knowledge in every field and specialization possible on-board the ship. As a Synthetic you answer to the acting commanding officer. Special circumstances may change this!"
 
 /datum/job/civilian/synthetic/New()
 	. = ..()

--- a/code/game/jobs/job/command/auxiliary/auxiliary_support_officer.dm
+++ b/code/game/jobs/job/command/auxiliary/auxiliary_support_officer.dm
@@ -5,7 +5,7 @@
 	allow_additional = TRUE
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT
 	gear_preset = /datum/equipment_preset/uscm_ship/auxiliary_officer
-	entry_message_body = "<a href='%WIKIPAGE%'>Your job is to oversee</a> the hangar crew, the intel officers, the engineering department, and requisition department. You have many responsibilities and a few plates to keep spinning but your subordinates are mostly self-reliant. Assist where you can and make sure command personnel are confident the auxiliary departments are operating at peak efficiency."
+	entry_message_body = "<a href='"+WIKI_PLACEHOLDER+"'>Your job is to oversee</a> the hangar crew, the intel officers, the engineering department, and requisition department. You have many responsibilities and a few plates to keep spinning but your subordinates are mostly self-reliant. Assist where you can and make sure command personnel are confident the auxiliary departments are operating at peak efficiency."
 
 AddTimelock(/datum/job/command/auxiliary_officer, list(
 	JOB_SQUAD_ROLES = 5 HOURS,

--- a/code/game/jobs/job/command/auxiliary/crew_chief.dm
+++ b/code/game/jobs/job/command/auxiliary/crew_chief.dm
@@ -7,7 +7,7 @@
 	supervisors = "the pilot officers"
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT
 	gear_preset = /datum/equipment_preset/uscm_ship/dcc
-	entry_message_body = "<a href='%WIKIPAGE%'>Your job is to assist</a> the pilot officer maintain the ship's dropship. You have authority only on the dropship, but you are expected to maintain order, as not to disrupt the pilot."
+	entry_message_body = "<a href='"+WIKI_PLACEHOLDER+"'>Your job is to assist</a> the pilot officer maintain the ship's dropship. You have authority only on the dropship, but you are expected to maintain order, as not to disrupt the pilot."
 
 AddTimelock(/datum/job/command/crew_chief, list(
 	JOB_SQUAD_ROLES = 5 HOURS

--- a/code/game/jobs/job/command/auxiliary/intel.dm
+++ b/code/game/jobs/job/command/auxiliary/intel.dm
@@ -8,7 +8,7 @@
 	supervisors = "the auxiliary support officer"
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT|ROLE_ADD_TO_SQUAD
 	gear_preset = "USCM Intelligence Officer (IO) (Cryo)"
-	entry_message_body = "<a href='%WIKIURL%'>Your job is to assist the marines in collecting intelligence related</a> to the current operation to better inform command of their opposition. You are in charge of gathering any data disks, folders, and notes you may find on the operational grounds and decrypt them to grant the USCM additional resources."
+	entry_message_body = "<a href='"+WIKI_PLACEHOLDER+"'>Your job is to assist the marines in collecting intelligence related</a> to the current operation to better inform command of their opposition. You are in charge of gathering any data disks, folders, and notes you may find on the operational grounds and decrypt them to grant the USCM additional resources."
 
 /datum/job/command/intel/set_spawn_positions(count)
 	spawn_positions = int_slot_formula(count)

--- a/code/game/jobs/job/command/auxiliary/pilot.dm
+++ b/code/game/jobs/job/command/auxiliary/pilot.dm
@@ -7,7 +7,7 @@
 	supervisors = "the auxiliary support officer"
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT
 	gear_preset = /datum/equipment_preset/uscm_ship/po
-	entry_message_body = "<a href='%WIKIPAGE%'>Your job is to fly, protect, and maintain the ship's dropship.</a> While you are an officer, your authority is limited to the dropship, where you have authority over the enlisted personnel. If you are not piloting, there is an autopilot fallback for command, but don't leave the dropship without reason."
+	entry_message_body = "<a href='"+WIKI_PLACEHOLDER+"'>Your job is to fly, protect, and maintain the ship's dropship.</a> While you are an officer, your authority is limited to the dropship, where you have authority over the enlisted personnel. If you are not piloting, there is an autopilot fallback for command, but don't leave the dropship without reason."
 
 // Dropship Roles is both PO and DCC combined to not force people to backtrack
 AddTimelock(/datum/job/command/pilot, list(

--- a/code/game/jobs/job/command/auxiliary/senior.dm
+++ b/code/game/jobs/job/command/auxiliary/senior.dm
@@ -7,7 +7,7 @@
 	job_options = list("Gunnery Sergeant" = "GySGT", "Master Sergeant" = "MSgt", "First Sergeant" = "1Sgt", "Master Gunnery Sergeant" = "MGySgt", "Sergeant Major" = "SgtMaj")
 
 /datum/job/command/senior/on_config_load()
-	entry_message_body = "<a href='%WIKIPAGE%'>You are</a> held to a higher standard and are required to obey not only the Server Rules but <a href='%LAWURL%'>Marine Law</a> and <a href='[CONFIG_GET(string/wikiarticleurl)]/[URL_WIKI_SOP]'>Standard Operating Procedure</a>. Failure to do so may result in your Mentorship Removal. Your primary job is to teach others the game and its mechanics, and offer advice to all USCM Departments and Personnel on-board."
+	entry_message_body = "<a href='"+WIKI_PLACEHOLDER+"'>You are</a> held to a higher standard and are required to obey not only the Server Rules but <a href='"+LAW_PLACEHOLDER+"'>Marine Law</a> and <a href='[CONFIG_GET(string/wikiarticleurl)]/[URL_WIKI_SOP]'>Standard Operating Procedure</a>. Failure to do so may result in your Mentorship Removal. Your primary job is to teach others the game and its mechanics, and offer advice to all USCM Departments and Personnel on-board."
 	return ..()
 
 /datum/job/command/senior/announce_entry_message(mob/living/carbon/human/H)

--- a/code/game/jobs/job/command/cic/captain.dm
+++ b/code/game/jobs/job/command/cic/captain.dm
@@ -16,7 +16,7 @@
 	)
 
 /datum/job/command/commander/generate_entry_message()
-	entry_message_body = "<a href='%WIKIPAGE%'>You are the Commanding Officer of the [MAIN_SHIP_NAME] as well as the operation.</a> Your goal is to lead the Marines on their mission as well as protect and command the ship and her crew. Your job involves heavy roleplay and requires you to behave like a high-ranking officer and to stay in character at all times. As the Commanding Officer your only superior is High Command itself. You must abide by the <a href='[CONFIG_GET(string/wikiarticleurl)]/[URL_WIKI_CO_RULES]'>Commanding Officer Code of Conduct</a>. Failure to do so may result in punitive action against you. Godspeed."
+	entry_message_body = "<a href='[generate_wiki_link()]'>You are the Commanding Officer of the [MAIN_SHIP_NAME] as well as the operation.</a> Your goal is to lead the Marines on their mission as well as protect and command the ship and her crew. Your job involves heavy roleplay and requires you to behave like a high-ranking officer and to stay in character at all times. As the Commanding Officer your only superior is High Command itself. You must abide by the <a href='[CONFIG_GET(string/wikiarticleurl)]/[URL_WIKI_CO_RULES]'>Commanding Officer Code of Conduct</a>. Failure to do so may result in punitive action against you. Godspeed."
 	return ..()
 
 /datum/job/command/commander/get_whitelist_status(list/roles_whitelist, client/player)

--- a/code/game/jobs/job/command/cic/staffofficer.dm
+++ b/code/game/jobs/job/command/cic/staffofficer.dm
@@ -6,7 +6,7 @@
 	scaled = FALSE
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT
 	gear_preset = /datum/equipment_preset/uscm_ship/so
-	entry_message_body = "<a href='%WIKIPAGE%'>Your job is to monitor the Marines, man the CIC, and listen to your superior officers.</a> You are in charge of logistics and the overwatch system. You are also in line to take command after other eligible superior commissioned officers."
+	entry_message_body = "<a href='"+WIKI_PLACEHOLDER+"'>Your job is to monitor the Marines, man the CIC, and listen to your superior officers.</a> You are in charge of logistics and the overwatch system. You are also in line to take command after other eligible superior commissioned officers."
 
 /datum/job/command/bridge/set_spawn_positions(count)
 	spawn_positions = so_slot_formula(count)

--- a/code/game/jobs/job/command/police/chief_police.dm
+++ b/code/game/jobs/job/command/police/chief_police.dm
@@ -4,7 +4,7 @@
 	selection_class = "job_cmp"
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT
 	gear_preset = /datum/equipment_preset/uscm_ship/uscm_police/cmp
-	entry_message_body = "<a href='%WIKIURL%'>You</a> are held by a higher standard and are required to obey not only the server rules but the <a href='%LAWURL%'>Marine Law</a>. Failure to do so may result in a job ban or server ban. You lead the Military Police, ensure your officers maintain peace and stability aboard the ship. Marines can get rowdy after a few weeks of cryosleep! In addition, you are tasked with the security of high-ranking personnel, including the command staff. Keep them safe!"
+	entry_message_body = "<a href='"+WIKI_PLACEHOLDER+"'>You</a> are held by a higher standard and are required to obey not only the server rules but the <a href='"+LAW_PLACEHOLDER+"'>Marine Law</a>. Failure to do so may result in a job ban or server ban. You lead the Military Police, ensure your officers maintain peace and stability aboard the ship. Marines can get rowdy after a few weeks of cryosleep! In addition, you are tasked with the security of high-ranking personnel, including the command staff. Keep them safe!"
 
 AddTimelock(/datum/job/command/warrant, list(
 	JOB_POLICE_ROLES = 15 HOURS,

--- a/code/game/jobs/job/command/police/police.dm
+++ b/code/game/jobs/job/command/police/police.dm
@@ -8,7 +8,7 @@
 	selection_class = "job_mp"
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT
 	gear_preset = /datum/equipment_preset/uscm_ship/uscm_police/mp
-	entry_message_body = "<a href='%WIKIPAGE%'>You</a> are held by a higher standard and are required to obey not only the server rules but the <a href='%LAWURL%'>Marine Law</a>. Failure to do so may result in a job ban or server ban. Your primary job is to maintain peace and stability aboard the ship. Marines can get rowdy after a few weeks of cryosleep! In addition, you are tasked with the security of high-ranking personnel, including the command staff. Keep them safe!"
+	entry_message_body = "<a href='"+WIKI_PLACEHOLDER+"'>You</a> are held by a higher standard and are required to obey not only the server rules but the <a href='"+LAW_PLACEHOLDER+"'>Marine Law</a>. Failure to do so may result in a job ban or server ban. Your primary job is to maintain peace and stability aboard the ship. Marines can get rowdy after a few weeks of cryosleep! In addition, you are tasked with the security of high-ranking personnel, including the command staff. Keep them safe!"
 
 /datum/job/command/police/set_spawn_positions(count)
 	spawn_positions = mp_slot_formula(count)

--- a/code/game/jobs/job/command/police/warden.dm
+++ b/code/game/jobs/job/command/police/warden.dm
@@ -5,7 +5,7 @@
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT
 	supervisors = "the Chief MP"
 	gear_preset = /datum/equipment_preset/uscm_ship/uscm_police/warden
-	entry_message_body = "<a href='%WIKIPAGE%'>You</a> are held by a higher standard and are required to obey not only the server rules but the <a href='%LAWURL%'>Marine Law</a>. Failure to do so may result in a job ban or server ban. Your primary job is to maintain peace and stability aboard the ship. Marines can get rowdy after a few weeks of cryosleep! In addition, you are tasked with the mainting security records and overwatching any prisoners in Brig."
+	entry_message_body = "<a href='"+WIKI_PLACEHOLDER+"'>You</a> are held by a higher standard and are required to obey not only the server rules but the <a href='"+LAW_PLACEHOLDER+"'>Marine Law</a>. Failure to do so may result in a job ban or server ban. Your primary job is to maintain peace and stability aboard the ship. Marines can get rowdy after a few weeks of cryosleep! In addition, you are tasked with the mainting security records and overwatching any prisoners in Brig."
 
 AddTimelock(/datum/job/command/warden, list(
 	JOB_POLICE_ROLES = 10 HOURS

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -49,6 +49,9 @@
 	if(!disp_title)
 		disp_title = title
 
+	if(global.config.is_loaded)
+		on_config_load()
+
 /datum/job/proc/on_config_load()
 	if(entry_message_body)
 		entry_message_body = replace_placeholders(entry_message_body)

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -54,8 +54,8 @@
 		entry_message_body = replace_placeholders(entry_message_body)
 
 /datum/job/proc/replace_placeholders(replacement_string)
-	replacement_string = replacetextEx(replacement_string, "%WIKIURL%", generate_wiki_link())
-	replacement_string = replacetextEx(replacement_string, "%LAWURL%", "[CONFIG_GET(string/wikiarticleurl)]/[URL_WIKI_LAW]")
+	replacement_string = replacetextEx(replacement_string, WIKI_PLACEHOLDER, generate_wiki_link())
+	replacement_string = replacetextEx(replacement_string, LAW_PLACEHOLDER, "[CONFIG_GET(string/wikiarticleurl)]/[URL_WIKI_LAW]")
 	return replacement_string
 
 /datum/job/proc/generate_wiki_link()

--- a/code/game/jobs/job/logistics/cargo/cargo_tech.dm
+++ b/code/game/jobs/job/logistics/cargo/cargo_tech.dm
@@ -8,7 +8,7 @@
 	selection_class = "job_ct"
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT
 	gear_preset = /datum/equipment_preset/uscm_ship/cargo
-	entry_message_body = "<a href='%WIKIURL%'>Your job</a> is to dispense supplies to the marines, including weapon attachments. Stay in your department when possible to ensure the marines have full access to the supplies they may require. Listen to the radio in case someone requests a supply drop via the overwatch system."
+	entry_message_body = "<a href='"+WIKI_PLACEHOLDER+"'>Your job</a> is to dispense supplies to the marines, including weapon attachments. Stay in your department when possible to ensure the marines have full access to the supplies they may require. Listen to the radio in case someone requests a supply drop via the overwatch system."
 
 /datum/job/logistics/cargo/set_spawn_positions(count)
 	spawn_positions = ct_slot_formula(count)

--- a/code/game/jobs/job/logistics/cargo/chief_req.dm
+++ b/code/game/jobs/job/logistics/cargo/chief_req.dm
@@ -3,7 +3,7 @@
 	selection_class = "job_qm"
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT
 	gear_preset = /datum/equipment_preset/uscm_ship/qm
-	entry_message_body = "<a href='%WIKIURL%'>Your job</a> is to dispense supplies to the marines, including weapon attachments. Your cargo techs can help you out, but you have final say in your department. Make sure they're not goofing off. While you may request paperwork for supplies, do not go out of your way to screw with marines, unless you want to get deposed. A happy ship is a well-functioning ship."
+	entry_message_body = "<a href='"+WIKI_PLACEHOLDER+"'>Your job</a> is to dispense supplies to the marines, including weapon attachments. Your cargo techs can help you out, but you have final say in your department. Make sure they're not goofing off. While you may request paperwork for supplies, do not go out of your way to screw with marines, unless you want to get deposed. A happy ship is a well-functioning ship."
 
 AddTimelock(/datum/job/logistics/requisition, list(
 	JOB_REQUISITION_ROLES = 10 HOURS,

--- a/code/game/jobs/job/logistics/engi/chief_engineer.dm
+++ b/code/game/jobs/job/logistics/engi/chief_engineer.dm
@@ -3,7 +3,7 @@
 	selection_class = "job_ce"
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT
 	gear_preset = /datum/equipment_preset/uscm_ship/chief_engineer
-	entry_message_body = "<a href='%WIKIURL%'>Your job</a> is to maintain your department and keep your technicians in check. You are responsible for engineering, power, ordnance, and the orbital cannon. Should the commanding and executive officer be unavailable, you are next in the chain of command."
+	entry_message_body = "<a href='"+WIKI_PLACEHOLDER+"'>Your job</a> is to maintain your department and keep your technicians in check. You are responsible for engineering, power, ordnance, and the orbital cannon. Should the commanding and executive officer be unavailable, you are next in the chain of command."
 
 AddTimelock(/datum/job/logistics/engineering, list(
 	JOB_ENGINEER_ROLES = 10 HOURS,

--- a/code/game/jobs/job/logistics/engi/maint_tech.dm
+++ b/code/game/jobs/job/logistics/engi/maint_tech.dm
@@ -6,7 +6,7 @@
 	selection_class = "job_ot"
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT
 	gear_preset = /datum/equipment_preset/uscm_ship/maint
-	entry_message_body = "<a href='%WIKIURL%'>Your job is to maintain the integrity of the ship, including the orbital cannon.</a> You remain one of the more flexible roles on the ship and as such may receive other menial tasks from your superiors."
+	entry_message_body = "<a href='"+WIKI_PLACEHOLDER+"'>Your job is to maintain the integrity of the ship, including the orbital cannon.</a> You remain one of the more flexible roles on the ship and as such may receive other menial tasks from your superiors."
 
 /obj/effect/landmark/start/maint
 	name = JOB_MAINT_TECH

--- a/code/game/jobs/job/logistics/engi/ordnance_tech.dm
+++ b/code/game/jobs/job/logistics/engi/ordnance_tech.dm
@@ -9,7 +9,7 @@
 	selection_class = "job_ot"
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT
 	gear_preset = /datum/equipment_preset/uscm_ship/ordn
-	entry_message_body = "<a href='%WIKIURL%'>Your job</a> is to maintain the integrity of the USCM weapons, munitions and equipment, including the orbital cannon. You can use the workshop in the portside hangar to construct new armaments for the marines. However you remain one of the more flexible roles on the ship and as such may receive other menial tasks from your superiors."
+	entry_message_body = "<a href='"+WIKI_PLACEHOLDER+"'>Your job</a> is to maintain the integrity of the USCM weapons, munitions and equipment, including the orbital cannon. You can use the workshop in the portside hangar to construct new armaments for the marines. However you remain one of the more flexible roles on the ship and as such may receive other menial tasks from your superiors."
 
 /datum/job/logistics/otech/set_spawn_positions(count)
 	spawn_positions = ot_slot_formula(count)

--- a/code/game/jobs/job/marine/squad/engineer.dm
+++ b/code/game/jobs/job/marine/squad/engineer.dm
@@ -5,7 +5,7 @@
 	allow_additional = 1
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT|ROLE_ADD_TO_SQUAD
 	gear_preset = /datum/equipment_preset/uscm/engineer
-	entry_message_body = "You have the <a href='%WIKIURL%'>equipment and skill</a> to build fortifications, reroute power lines, and bunker down. Your squaddies will look to you when it comes to construction in the field of battle."
+	entry_message_body = "You have the <a href='"+WIKI_PLACEHOLDER+"'>equipment and skill</a> to build fortifications, reroute power lines, and bunker down. Your squaddies will look to you when it comes to construction in the field of battle."
 
 /datum/job/marine/engineer/set_spawn_positions(count)
 	for(var/datum/squad/sq in RoleAuthority.squads)

--- a/code/game/jobs/job/marine/squad/leader.dm
+++ b/code/game/jobs/job/marine/squad/leader.dm
@@ -5,7 +5,7 @@
 	supervisors = "the acting commanding officer"
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT|ROLE_ADD_TO_SQUAD
 	gear_preset = /datum/equipment_preset/uscm/leader
-	entry_message_body = "<a href='%WIKIPAGE%'>You are responsible for the men and women of your squad.</a> Make sure they are on task, working together, and communicating. You are also in charge of communicating with command and letting them know about the situation first hand. Keep out of harm's way."
+	entry_message_body = "<a href='"+WIKI_PLACEHOLDER+"'>You are responsible for the men and women of your squad.</a> Make sure they are on task, working together, and communicating. You are also in charge of communicating with command and letting them know about the situation first hand. Keep out of harm's way."
 
 /datum/job/marine/leader/whiskey
 	title = JOB_WO_SQUAD_LEADER

--- a/code/game/jobs/job/marine/squad/medic.dm
+++ b/code/game/jobs/job/marine/squad/medic.dm
@@ -5,7 +5,7 @@
 	allow_additional = 1
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT|ROLE_ADD_TO_SQUAD
 	gear_preset = /datum/equipment_preset/uscm/medic
-	entry_message_body = "<a href='%WIKIPAGE%'>You tend the wounds of your squad mates</a> and make sure they are healthy and active. You may not be a fully-fledged doctor, but you stand between life and death when it matters."
+	entry_message_body = "<a href='"+WIKI_PLACEHOLDER+"'>You tend the wounds of your squad mates</a> and make sure they are healthy and active. You may not be a fully-fledged doctor, but you stand between life and death when it matters."
 
 /datum/job/marine/medic/set_spawn_positions(count)
 	for(var/datum/squad/sq in RoleAuthority.squads)

--- a/code/game/jobs/job/marine/squad/smartgunner.dm
+++ b/code/game/jobs/job/marine/squad/smartgunner.dm
@@ -6,7 +6,7 @@
 	scaled = 1
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT|ROLE_ADD_TO_SQUAD
 	gear_preset = /datum/equipment_preset/uscm/sg
-	entry_message_body = "<a href='%WIKIPAGE%'>You are the smartgunner.</a> Your task is to provide heavy weapons support."
+	entry_message_body = "<a href='"+WIKI_PLACEHOLDER+"'>You are the smartgunner.</a> Your task is to provide heavy weapons support."
 
 /datum/job/marine/smartgunner/set_spawn_positions(count)
 	spawn_positions = sg_slot_formula(count)

--- a/code/game/jobs/job/marine/squad/specialist.dm
+++ b/code/game/jobs/job/marine/squad/specialist.dm
@@ -6,7 +6,7 @@
 	scaled = 1
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT|ROLE_ADD_TO_SQUAD
 	gear_preset = /datum/equipment_preset/uscm/spec
-	entry_message_body = "<a href='%WIKIPAGE%'>You are the very rare and valuable weapon expert</a>, trained to use special equipment. You can serve a variety of roles, so choose carefully."
+	entry_message_body = "<a href='"+WIKI_PLACEHOLDER+"'>You are the very rare and valuable weapon expert</a>, trained to use special equipment. You can serve a variety of roles, so choose carefully."
 
 /datum/job/marine/specialist/set_spawn_positions(count)
 	spawn_positions = spec_slot_formula(count)

--- a/code/game/jobs/job/marine/squad/standard.dm
+++ b/code/game/jobs/job/marine/squad/standard.dm
@@ -6,7 +6,10 @@
 	spawn_positions = -1
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT|ROLE_ADD_TO_SQUAD
 	gear_preset = /datum/equipment_preset/uscm/pfc
-	entry_message_body = "You are a rank-and-file <a href='"+URL_WIKI_MARINE_QUICKSTART+"'>Marine of the USCM</a>, and that is your strength. What you lack alone, you gain standing shoulder to shoulder with the men and women of the corps. Ooh-rah!"
+
+/datum/job/marine/standard/on_config_load()
+	entry_message_body = "You are a rank-and-file <a href='[CONFIG_GET(string/wikiarticleurl)]/[URL_WIKI_MARINE_QUICKSTART]'>Marine of the USCM</a>, and that is your strength. What you lack alone, you gain standing shoulder to shoulder with the men and women of the corps. Ooh-rah!"
+	return ..()
 
 /datum/job/marine/standard/set_spawn_positions(count)
 	spawn_positions = max((round(count * STANDARD_MARINE_TO_TOTAL_SPAWN_RATIO)), 8)

--- a/code/game/jobs/job/marine/squad/tl.dm
+++ b/code/game/jobs/job/marine/squad/tl.dm
@@ -5,7 +5,7 @@
 	allow_additional = 1
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT|ROLE_ADD_TO_SQUAD
 	gear_preset = /datum/equipment_preset/uscm/tl
-	entry_message_body = "You are the <a href='%WIKIPAGE%'>Team Leader.</a>Your task is to assist the squad leader in leading the squad as well as utilize ordnance such as orbital bombardments, CAS, and mortar as well as coordinating resupply with Requisitions and CIC. If the squad leader dies, you are expected to lead in their place."
+	entry_message_body = "You are the <a href='"+WIKI_PLACEHOLDER+"'>Team Leader.</a>Your task is to assist the squad leader in leading the squad as well as utilize ordnance such as orbital bombardments, CAS, and mortar as well as coordinating resupply with Requisitions and CIC. If the squad leader dies, you are expected to lead in their place."
 
 /datum/job/marine/tl/generate_entry_conditions(mob/living/carbon/human/spawning_human)
 	. = ..()

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -132,6 +132,7 @@ FORUMURL https://forum.cm-ss13.com/
 
 ## Wiki address
 WIKIURL https://cm-ss13.com/w
+WIKIARTICLEURL https://cm-ss13.com/wiki
 
 ## Rules address
 RULESURL https://cm-ss13.com/viewtopic.php?f=57&t=5094


### PR DESCRIPTION

# About the pull request

This PR is a followup to the issues created by #4449 fixing job entry_message_body links to the wiki.

/datum/controller/configuration now has a variable `is_loaded` that can be checked to see if configuration has already occurred such as the case for the ASO where subsequent creations of the job datum were not hitting the proc that would be called on the config load signal.

# Explain why it's good for the game

Broken wiki links harm the new player experience.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![aso](https://github.com/cmss13-devs/cmss13/assets/76988376/73c0b8e4-78f6-4f34-bfbe-9f74b7f05b14)
![CO](https://github.com/cmss13-devs/cmss13/assets/76988376/30b627bc-afe3-4064-b745-fecab5925970)
![marine](https://github.com/cmss13-devs/cmss13/assets/76988376/25250d85-445f-4506-8d91-3c12d500d20c)

</details>


# Changelog
:cl: Drathek
fix: Fixed various job's entry messages having broken links to the wiki
/:cl:
