### PR TITLE
Adds Corpsman Sterile Gloves

### DIFF
--- a/code/game/machinery/vending/vendor_types/squad_prep/squad_medic.dm
+++ b/code/game/machinery/vending/vendor_types/squad_prep/squad_medic.dm
@@ -117,6 +117,7 @@ GLOBAL_LIST_INIT(cm_vending_gear_medic, list(
 GLOBAL_LIST_INIT(cm_vending_clothing_medic, list(
 		list("STANDARD EQUIPMENT (TAKE ALL)", 0, null, null, null),
 		list("Standard Marine Apparel", 0, list(/obj/item/clothing/under/marine/medic, /obj/item/clothing/shoes/marine/knife, /obj/item/clothing/gloves/marine, /obj/item/device/radio/headset/almayer/marine, /obj/item/clothing/head/helmet/marine/medic), MARINE_CAN_BUY_UNIFORM, VENDOR_ITEM_MANDATORY),
+		list("Combat Sterile Gloves", 0, /obj/item/clothing/gloves/marine/medical, MARINE_CAN_BUY_KIT, VENDOR_ITEM_REGULAR),
 		list("MRE", 0, /obj/item/storage/box/MRE, MARINE_CAN_BUY_MRE, VENDOR_ITEM_MANDATORY),
 		list("Map", 0, /obj/item/map/current_map, MARINE_CAN_BUY_KIT, VENDOR_ITEM_MANDATORY),
 

--- a/code/modules/clothing/gloves/marine_gloves.dm
+++ b/code/modules/clothing/gloves/marine_gloves.dm
@@ -53,6 +53,14 @@
 	item_state = "brown"
 	adopts_squad_color = FALSE
 
+/obj/item/clothing/gloves/marine/medical
+	name = "marine medical combat gloves"
+	desc = "Standard issue marine sterile gloves, offers regular protection whilst offering the user a better grip when performing medical work."
+	icon_state = "latex"
+	item_state = "lgloves"
+	adopts_squad_color = FALSE
+
+
 /obj/item/clothing/gloves/marine/officer
 	name = "officer gloves"
 	desc = "Shiny and impressive. They look expensive."


### PR DESCRIPTION

# About the pull request

Adds a set of marine corpsman sterile gloves that Corpsman can vend. The gloves are identical to regular gloves except they have the sterile glove sprite. 

# Explain why it's good for the game

Helps increase loadout customization of Corpsman. 

Considering these gloves would further advertise the medical nature of the Corpsman, these gloves will not be a balance issue.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Corpsman can chose to optionally vend a set of armoured sterile gloves as a alternative to regular gloves. They provide full glove protection, but are otherwise an aesthetic choice. 
/:cl:
