### PR TITLE
Better OB cannon logging

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -21,16 +21,16 @@
 #define between(low, middle, high) (max(min(middle, high), low))
 
 //Offuscate x for coord system
-#define obfuscate_x(x) (x + obfs_x)
+#define obfuscate_x(x) (x + GLOB.obfs_x)
 
 //Offuscate y for coord system
-#define obfuscate_y(y) (y + obfs_y)
+#define obfuscate_y(y) (y + GLOB.obfs_y)
 
 //Deoffuscate x for coord system
-#define deobfuscate_x(x) (x - obfs_x)
+#define deobfuscate_x(x) (x - GLOB.obfs_x)
 
 //Deoffuscate y for coord system
-#define deobfuscate_y(y) (y - obfs_y)
+#define deobfuscate_y(y) (y - GLOB.obfs_y)
 
 #define can_xeno_build(T) (!T.density && !(locate(/obj/structure/fence) in T) && !(locate(/obj/structure/tunnel) in T) && (locate(/obj/effect/alien/weeds) in T))
 

--- a/code/_globalvars/misc.dm
+++ b/code/_globalvars/misc.dm
@@ -30,3 +30,10 @@ GLOBAL_VAR_INIT(time_offset, setup_offset())
 
 /// The last count of possible candidates in the xeno larva queue (updated via get_alien_candidates)
 GLOBAL_VAR(xeno_queue_candidate_count)
+
+//Coordinate obsfucator
+//Used by the rangefinders and linked systems to prevent coords collection/prefiring
+/// A number between -500 and 500.
+GLOBAL_VAR(obfs_x)
+/// A number between -500 and 500.
+GLOBAL_VAR(obfs_y)

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -91,8 +91,8 @@ var/list/reboot_sfx = file2list("config/reboot_sfx.txt")
 	update_status()
 
 	//Scramble the coords obsfucator
-	obfs_x = rand(-500, 500) //A number between -100 and 100
-	obfs_y = rand(-500, 500) //A number between -100 and 100
+	GLOB.obfs_x = rand(-500, 500) //A number between -100 and 100
+	GLOB.obfs_y = rand(-500, 500) //A number between -100 and 100
 
 	spawn(3000) //so we aren't adding to the round-start lag
 		if(CONFIG_GET(flag/ToRban))

--- a/code/global.dm
+++ b/code/global.dm
@@ -153,14 +153,6 @@ var/list/nato_phonetic_alphabet = list("Alpha", "Bravo", "Charlie", "Delta", "Ec
 var/distress_cancel = 0
 var/destroy_cancel = 0
 
-//Coordinate obsfucator
-//Used by the rangefinders and linked systems to prevent coords collection/prefiring
-
-/// A number between -500 and 500.
-var/global/obfs_x = 0
-/// A number between -500 and 500.
-var/global/obfs_y = 0
-
 // Which lobby art is on display
 // This is updated by the lobby art turf when it initializes
 var/displayed_lobby_art = -1

--- a/code/modules/cm_marines/overwatch.dm
+++ b/code/modules/cm_marines/overwatch.dm
@@ -776,7 +776,7 @@
 	playsound(T,'sound/effects/alert.ogg', 25, 1)  //Placeholder
 	addtimer(CALLBACK(src, TYPE_PROC_REF(/obj/structure/machinery/computer/overwatch, alert_ob), T), 2 SECONDS)
 	addtimer(CALLBACK(src, TYPE_PROC_REF(/obj/structure/machinery/computer/overwatch, begin_fire)), 6 SECONDS)
-	addtimer(CALLBACK(src, TYPE_PROC_REF(/obj/structure/machinery/computer/overwatch, fire_bombard), user, A, T), 6 SECONDS + 6)
+	addtimer(CALLBACK(src, TYPE_PROC_REF(/obj/structure/machinery/computer/overwatch, fire_bombard), user, T), 6 SECONDS + 6)
 
 /obj/structure/machinery/computer/overwatch/proc/begin_fire()
 	for(var/mob/living/carbon/H in GLOB.alive_mob_list)
@@ -787,23 +787,20 @@
 	visible_message("[icon2html(src, viewers(src))] [SPAN_BOLDNOTICE("Orbital bombardment for squad '[current_squad]' has fired! Impact imminent!")]")
 	current_squad.send_message("WARNING! Ballistic trans-atmospheric launch detected! Get outside of Danger Close!")
 
-/obj/structure/machinery/computer/overwatch/proc/fire_bombard(mob/user, area/A, turf/T)
-	if(!A || !T)
+/obj/structure/machinery/computer/overwatch/proc/fire_bombard(mob/user,turf/T)
+	if(!T)
 		return
 
 	var/ob_name = lowertext(almayer_orbital_cannon.tray.warhead.name)
 	var/mutable_appearance/warhead_appearance = mutable_appearance(almayer_orbital_cannon.tray.warhead.icon, almayer_orbital_cannon.tray.warhead.icon_state)
-	notify_ghosts(header = "Bombardment Inbound", message = "\A [ob_name] targeting [A.name] has been fired!", source = T, alert_overlay = warhead_appearance, extra_large = TRUE)
-	message_admins(FONT_SIZE_HUGE("ALERT: [key_name(user)] fired an orbital bombardment in [A.name] for squad '[current_squad]' [ADMIN_JMP(T)]"))
-	log_attack("[key_name(user)] fired an orbital bombardment in [A.name] for squad '[current_squad]'")
+	notify_ghosts(header = "Bombardment Inbound", message = "\A [ob_name] targeting [get_area(T)] has been fired!", source = T, alert_overlay = warhead_appearance, extra_large = TRUE)
 
 	/// Project ARES interface log.
-	log_ares_bombardment(user.name, ob_name, "X[x_bomb], Y[y_bomb] in [A.name]")
+	log_ares_bombardment(user.name, ob_name, "X[x_bomb], Y[y_bomb] in [get_area(T)]")
 
 	busy = FALSE
-	var/turf/target = locate(T.x + rand(-3, 3), T.y + rand(-3, 3), T.z)
-	if(target && istype(target))
-		almayer_orbital_cannon.fire_ob_cannon(target, user)
+	if(istype(T))
+		almayer_orbital_cannon.fire_ob_cannon(T, user, current_squad)
 		user.count_niche_stat(STATISTICS_NICHE_OB)
 
 /obj/structure/machinery/computer/overwatch/proc/handle_supplydrop()

--- a/code/modules/shuttle/computers/dropship_computer.dm
+++ b/code/modules/shuttle/computers/dropship_computer.dm
@@ -214,19 +214,19 @@
 
 	// door controls being overriden
 	if(!dropship_control_lost)
-		to_chat(xeno, SPAN_XENONOTICE("You override the doors."))
-		xeno_message(SPAN_XENOANNOUNCE("The doors of the metal bird have been overridden! Rejoice!"), 3, xeno.hivenumber)
 		dropship.control_doors("unlock", "all", TRUE)
 		dropship_control_lost = TRUE
 		door_control_cooldown = addtimer(CALLBACK(src, PROC_REF(remove_door_lock)), SHUTTLE_LOCK_COOLDOWN, TIMER_STOPPABLE)
-		notify_ghosts(header = "Dropship Locked", message = "[xeno] has locked [dropship]!", source = xeno, action = NOTIFY_ORBIT)
-
 		if(almayer_orbital_cannon)
 			almayer_orbital_cannon.is_disabled = TRUE
 			addtimer(CALLBACK(almayer_orbital_cannon, TYPE_PROC_REF(/obj/structure/orbital_cannon, enable)), 10 MINUTES, TIMER_UNIQUE)
-
 		if(!GLOB.resin_lz_allowed)
 			set_lz_resin_allowed(TRUE)
+
+		to_chat(xeno, SPAN_XENONOTICE("You override the doors."))
+		xeno_message(SPAN_XENOANNOUNCE("The doors of the metal bird have been overridden! Rejoice!"), 3, xeno.hivenumber)
+		message_admins("[key_name(xeno)] has locked the dropship '[dropship]' [ADMIN_JMP(xeno)]")
+		notify_ghosts(header = "Dropship Locked", message = "[xeno] has locked [dropship]!", source = xeno, action = NOTIFY_ORBIT)
 		return
 
 	if(dropship_control_lost)

--- a/code/modules/shuttle/computers/dropship_computer.dm
+++ b/code/modules/shuttle/computers/dropship_computer.dm
@@ -225,7 +225,7 @@
 
 		to_chat(xeno, SPAN_XENONOTICE("You override the doors."))
 		xeno_message(SPAN_XENOANNOUNCE("The doors of the metal bird have been overridden! Rejoice!"), 3, xeno.hivenumber)
-		message_admins("[key_name(xeno)] has locked the dropship '[dropship]' [ADMIN_JMP(xeno)]")
+		message_admins("[key_name(xeno)] has locked the dropship '[dropship]'", xeno.x, xeno.y, xeno.z)
 		notify_ghosts(header = "Dropship Locked", message = "[xeno] has locked [dropship]!", source = xeno, action = NOTIFY_ORBIT)
 		return
 


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

This streamlines and expands OB cannon logging adding chambering log, misfuel information, and detailing both the hit target and intended aimed target. The inherent cannon inaccuracy is moved to be counted with fuel inaccuracy.

Also adds a log for locking of dropships by queen as mistakes happen every so often...

Additionally moves (JMP) for these logs to logging arguments so the whole HTML link doesnt get printed in logs

# Explain why it's good for the game
Auditing

# Testing Photographs and Procedure
Tested OB firing, OB JMP links, locking dropship

# Changelog
:cl:
admin: Added better logging for orbital bombardment.
/:cl:
