### PR TITLE
Xeno Tunnel and Shuttle Building/Anchoring Changes

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -174,7 +174,6 @@ Also change the icon to reflect the amount of sheets, if possible.*/
 		if(R.on_floor && istype(usr.loc, /turf/open))
 			var/turf/open/OT = usr.loc
 			var/obj/structure/blocker/anti_cade/AC = locate(/obj/structure/blocker/anti_cade) in usr.loc // for M2C HMG, look at smartgun_mount.dm
-			var/obj/structure/tunnel/TUNNELBLOCK = locate(/obj/structure/tunnel) in usr.loc
 			if(!OT.allow_construction)
 				to_chat(usr, SPAN_WARNING("The [R.title] must be constructed on a proper surface!"))
 				return
@@ -183,7 +182,8 @@ Also change the icon to reflect the amount of sheets, if possible.*/
 				to_chat(usr, SPAN_WARNING("The [R.title] cannot be built here!"))  //might cause some friendly fire regarding other items like barbed wire, shouldn't be a problem?
 				return
 
-			if(TUNNELBLOCK)
+			var/obj/structure/tunnel/tunnel = locate(/obj/structure/tunnel) in usr.loc
+			if(tunnel)
 				to_chat(usr, SPAN_WARNING("The [R.title] cannot be constructed on a tunnel!"))
 				return
 

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -174,12 +174,17 @@ Also change the icon to reflect the amount of sheets, if possible.*/
 		if(R.on_floor && istype(usr.loc, /turf/open))
 			var/turf/open/OT = usr.loc
 			var/obj/structure/blocker/anti_cade/AC = locate(/obj/structure/blocker/anti_cade) in usr.loc // for M2C HMG, look at smartgun_mount.dm
+			var/obj/structure/tunnel/TUNNELBLOCK = locate(/obj/structure/tunnel) in usr.loc
 			if(!OT.allow_construction)
 				to_chat(usr, SPAN_WARNING("The [R.title] must be constructed on a proper surface!"))
 				return
 
 			if(AC)
 				to_chat(usr, SPAN_WARNING("The [R.title] cannot be built here!"))  //might cause some friendly fire regarding other items like barbed wire, shouldn't be a problem?
+				return
+
+			if(TUNNELBLOCK)
+				to_chat(usr, SPAN_WARNING("The [R.title] cannot be constructed on a tunnel!"))
 				return
 
 		if((R.flags & RESULT_REQUIRES_SNOW) && !(istype(usr.loc, /turf/open/snow) || istype(usr.loc, /turf/open/auto_turf/snow)))

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -173,12 +173,12 @@
 			return do_reinforced_wall(W, user)
 		if(STATE_DISPLACED)
 			if(HAS_TRAIT(W, TRAIT_TOOL_CROWBAR))
-				var/turf/open/CONBLOCK = loc
-				var/obj/structure/tunnel/TUNNELBLOCK = locate(/obj/structure/tunnel) in loc
-				if(!(istype(CONBLOCK) && CONBLOCK.allow_construction))
+				var/turf/open/floor = loc
+				var/obj/structure/tunnel/tunnel = locate(/obj/structure/tunnel) in loc
+				if(!floor.allow_construction)
 					to_chat(user, SPAN_WARNING("The girder must be secured on a proper surface!"))
 					return
-				if(TUNNELBLOCK)
+				if(tunnel)
 					to_chat(user, SPAN_WARNING("The girder cannot be secured on a tunnel!"))
 					return
 				playsound(loc, 'sound/items/Crowbar.ogg', 25, 1)

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -173,6 +173,14 @@
 			return do_reinforced_wall(W, user)
 		if(STATE_DISPLACED)
 			if(HAS_TRAIT(W, TRAIT_TOOL_CROWBAR))
+				var/turf/open/CONBLOCK = loc
+				var/obj/structure/tunnel/TUNNELBLOCK = locate(/obj/structure/tunnel) in loc
+				if(!(istype(CONBLOCK) && CONBLOCK.allow_construction))
+					to_chat(user, SPAN_WARNING("The girder must be secured on a proper surface!"))
+					return
+				if(TUNNELBLOCK)
+					to_chat(user, SPAN_WARNING("The girder cannot be secured on a tunnel!"))
+					return
 				playsound(loc, 'sound/items/Crowbar.ogg', 25, 1)
 				to_chat(user, SPAN_NOTICE("Now securing the girder..."))
 				if(!do_after(user, 40 * user.get_skill_duration_multiplier(SKILL_CONSTRUCTION), INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD))

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -174,10 +174,10 @@
 		if(STATE_DISPLACED)
 			if(HAS_TRAIT(W, TRAIT_TOOL_CROWBAR))
 				var/turf/open/floor = loc
-				var/obj/structure/tunnel/tunnel = locate(/obj/structure/tunnel) in loc
 				if(!floor.allow_construction)
 					to_chat(user, SPAN_WARNING("The girder must be secured on a proper surface!"))
 					return
+				var/obj/structure/tunnel/tunnel = locate(/obj/structure/tunnel) in loc
 				if(tunnel)
 					to_chat(user, SPAN_WARNING("The girder cannot be secured on a tunnel!"))
 					return


### PR DESCRIPTION
# About the pull request

This PR removes the ability to build walls (and other ground structures) on top of xeno tunnels, and removes the ability to anchor wall girders on shuttle tiles and tunnels. Barricades can still be moved on top of the tunnel's tile and anchored, though they can't be built while standing on it. 

# Explain why it's good for the game

Being able to build walls on top of a gaping hole in the ground is pretty dumb, and results in weird interactions like having to right click to use the tunnel that's currently being covered up by a wall. The shuttle tiles were changed because, while you can't complete the girders if they're in a shuttle, you can still anchor them down. That doesn't seem intended since you can't build them while in a shuttle, and you also can't build/anchor barricades in shuttles.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>


</details>


# Changelog
:cl:IowaPotatoFarmer
del: Removed the ability to build ground structures or anchor wall girders on top of xeno tunnels.
fix: Fixed wall girders being anchorable on shuttle tiles.
/:cl:
