### PR TITLE
Fixes GC deletion issues around reagents

### DIFF
--- a/code/game/objects/items/reagent_containers/reagent_container.dm
+++ b/code/game/objects/items/reagent_containers/reagent_container.dm
@@ -67,12 +67,6 @@
 	if (N)
 		R.amount_per_transfer_from_this = N
 
-/obj/item/reagent_container/Initialize()
-	. = ..()
-	if (!possible_transfer_amounts)
-		verbs -= /obj/item/reagent_container/verb/set_APTFT //which objects actually uses it?
-	create_reagents(volume)
-
 /obj/item/reagent_container/Destroy()
 	possible_transfer_amounts = null
 	return ..()

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -713,5 +713,6 @@
 // Convenience proc to create a reagents holder for an atom
 // Max vol is maximum volume of holder
 /atom/proc/create_reagents(max_vol)
+	QDEL_NULL(reagents)
 	reagents = new/datum/reagents(max_vol)
 	reagents.my_atom = src


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

Fixes a potential GC consistency issue around reagents and reagents_containers

In theory this should do nothing because `reagents` is *supposed* to get soft GC'ed anyway when it is swapped out. 

There is something more to it somewhere, because on live bottles get deleted and retain their `reagents`. In this case it's a circular reference preventing deletion.

# Explain why it's good for the game
backend consistency / long term performance
