### PR TITLE
Big Red Changes Part 1: Admin

### DIFF
--- a/maps/map_files/BigRed/BigRed.dmm
+++ b/maps/map_files/BigRed/BigRed.dmm
@@ -18022,6 +18022,9 @@
 	density = 0;
 	req_one_access_txt = "200"
 	},
+/obj/structure/machinery/light{
+	dir = 8
+	},
 /turf/open/floor{
 	dir = 10;
 	icon_state = "darkblue2"
@@ -18168,10 +18171,14 @@
 	},
 /area/bigredv2/outside/admin_building)
 "aYq" = (
-/obj/structure/machinery/light{
-	dir = 1
-	},
 /obj/effect/landmark/objective_landmark/far,
+/obj/structure/sink{
+	pixel_x = 1;
+	pixel_y = 20
+	},
+/obj/structure/mirror{
+	pixel_y = 29
+	},
 /turf/open/floor{
 	icon_state = "freezerfloor"
 	},
@@ -18181,6 +18188,9 @@
 	dir = 8
 	},
 /obj/item/prop/alien/hugger,
+/obj/structure/machinery/light{
+	dir = 4
+	},
 /turf/open/floor{
 	icon_state = "freezerfloor"
 	},
@@ -58151,7 +58161,7 @@ aWD
 aWD
 aXN
 kRK
-aYU
+aWH
 aOM
 aZY
 aof

--- a/maps/map_files/BigRed/BigRed.dmm
+++ b/maps/map_files/BigRed/BigRed.dmm
@@ -11058,21 +11058,10 @@
 /turf/closed/wall/solaris/rock,
 /area/bigredv2/outside/sw)
 "aFd" = (
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/structure/flora/jungle/plantbot1{
+	pixel_y = 10
 	},
-/obj/structure/window/reinforced{
-	dir = 4;
-	health = 80
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/turf/open/jungle{
-	bushes_spawn = 0;
-	icon_state = "grass_impenetrable"
-	},
+/turf/open/jungle,
 /area/bigredv2/outside/admin_building)
 "aFf" = (
 /obj/structure/closet/secure_closet/scientist,
@@ -12526,10 +12515,7 @@
 "aIY" = (
 /obj/structure/surface/table,
 /obj/effect/landmark/objective_landmark/medium,
-/turf/open/floor{
-	dir = 8;
-	icon_state = "carpet15-15"
-	},
+/turf/open/floor/carpet,
 /area/bigredv2/outside/admin_building)
 "aIZ" = (
 /obj/effect/decal/warning_stripes{
@@ -14231,7 +14217,6 @@
 /area/bigredv2/outside/admin_building)
 "aNC" = (
 /obj/structure/machinery/computer/station_alert,
-/obj/structure/machinery/camera/autoname,
 /obj/structure/surface/table,
 /turf/open/floor{
 	icon_state = "white"
@@ -14286,6 +14271,7 @@
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 10
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor{
 	dir = 9;
 	icon_state = "darkred2"
@@ -14298,6 +14284,7 @@
 	},
 /area/bigredv2/outside/admin_building)
 "aNK" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor{
 	dir = 9;
 	icon_state = "darkred2"
@@ -14321,6 +14308,7 @@
 /area/bigredv2/outside/admin_building)
 "aNN" = (
 /obj/structure/machinery/vending/coffee,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor{
 	dir = 1;
 	icon_state = "darkred2"
@@ -14342,6 +14330,9 @@
 /area/bigredv2/outside/admin_building)
 "aNQ" = (
 /obj/structure/bed,
+/obj/item/bedsheet/brown{
+	layer = 3.1
+	},
 /turf/open/floor{
 	icon_state = "wood"
 	},
@@ -15145,16 +15136,22 @@
 	},
 /area/bigredv2/outside/admin_building)
 "aPP" = (
-/turf/open/floor{
+/obj/structure/stairs/perspective{
 	dir = 1;
-	icon_state = "rampbottom"
+	icon_state = "p_stair_full"
+	},
+/turf/open/floor{
+	icon_state = "dark"
 	},
 /area/bigredv2/outside/admin_building)
 "aPQ" = (
 /obj/structure/pipes/standard/simple/hidden/green,
-/turf/open/floor{
+/obj/structure/stairs/perspective{
 	dir = 1;
-	icon_state = "rampbottom"
+	icon_state = "p_stair_full"
+	},
+/turf/open/floor{
+	icon_state = "dark"
 	},
 /area/bigredv2/outside/admin_building)
 "aPS" = (
@@ -15182,7 +15179,17 @@
 	},
 /area/bigredv2/outside/admin_building)
 "aPW" = (
-/obj/structure/coatrack,
+/obj/structure/coatrack{
+	pixel_x = -5;
+	pixel_y = 13
+	},
+/obj/item/clothing/shoes/dress{
+	pixel_y = -13
+	},
+/obj/item/clothing/under/suit_jacket/trainee{
+	pixel_x = -6;
+	pixel_y = 15
+	},
 /turf/open/floor{
 	icon_state = "wood"
 	},
@@ -15653,6 +15660,7 @@
 	name = "Storm Shutters";
 	pixel_y = -32
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor{
 	icon_state = "darkred2"
 	},
@@ -15987,9 +15995,8 @@
 	},
 /area/bigredv2/outside/admin_building)
 "aRZ" = (
-/obj/structure/machinery/door/airlock/almayer/command/colony{
-	dir = 1;
-	name = "\improper Operations EVA"
+/obj/structure/machinery/door/airlock/almayer/maint{
+	dir = 1
 	},
 /turf/open/floor{
 	icon_state = "delivery"
@@ -16309,6 +16316,14 @@
 	},
 /area/bigredv2/outside/general_store)
 "aSQ" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "SW-out";
+	pixel_y = -1
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "SE-out";
+	pixel_x = 1
+	},
 /obj/structure/machinery/door/airlock/almayer/command/colony{
 	dir = 1;
 	name = "\improper Operations"
@@ -16319,6 +16334,8 @@
 /area/bigredv2/outside/admin_building)
 "aSR" = (
 /obj/structure/pipes/vents/pump,
+/obj/structure/surface/rack,
+/obj/item/weapon/gun/smg/mp27,
 /turf/open/floor{
 	dir = 8;
 	icon_state = "redcorner"
@@ -16355,6 +16372,7 @@
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
 	},
+/obj/item/prop/alien/hugger,
 /turf/open/floor{
 	dir = 1;
 	icon_state = "darkred2"
@@ -16370,8 +16388,14 @@
 	},
 /area/bigredv2/outside/admin_building)
 "aSX" = (
-/obj/structure/machinery/suit_storage_unit/carbon_unit,
-/turf/open/floor/plating,
+/obj/structure/pipes/standard/simple/hidden/green,
+/obj/structure/stairs/perspective{
+	dir = 1;
+	icon_state = "p_stair_full"
+	},
+/turf/open/floor{
+	icon_state = "white"
+	},
 /area/bigredv2/outside/admin_building)
 "aSZ" = (
 /obj/structure/machinery/power/apc{
@@ -16384,10 +16408,12 @@
 /turf/open/floor/plating,
 /area/bigredv2/outside/admin_building)
 "aTb" = (
-/obj/structure/surface/table/woodentable,
-/obj/effect/landmark/objective_landmark/close,
+/obj/structure/stairs/perspective{
+	dir = 1;
+	icon_state = "p_stair_full"
+	},
 /turf/open/floor{
-	icon_state = "wood"
+	icon_state = "white"
 	},
 /area/bigredv2/outside/admin_building)
 "aTc" = (
@@ -16696,7 +16722,10 @@
 	},
 /area/bigredv2/outside/general_store)
 "aTU" = (
-/obj/structure/machinery/message_server,
+/obj/structure/prop/server_equipment/yutani_server{
+	density = 0;
+	pixel_y = 16
+	},
 /turf/open/floor{
 	icon_state = "podhatchfloor"
 	},
@@ -16704,12 +16733,6 @@
 "aTV" = (
 /turf/open/floor{
 	icon_state = "podhatchfloor"
-	},
-/area/bigredv2/outside/admin_building)
-"aTX" = (
-/obj/structure/machinery/computer3/server,
-/turf/open/floor{
-	icon_state = "dark"
 	},
 /area/bigredv2/outside/admin_building)
 "aTY" = (
@@ -16720,8 +16743,6 @@
 	},
 /area/bigredv2/outside/admin_building)
 "aTZ" = (
-/obj/structure/surface/rack,
-/obj/item/weapon/gun/smg/mp27,
 /obj/structure/machinery/light{
 	dir = 4
 	},
@@ -16747,28 +16768,34 @@
 	},
 /area/bigredv2/outside/admin_building)
 "aUd" = (
-/obj/structure/machinery/alarm{
-	dir = 1;
-	pixel_y = -30
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor{
+	dir = 5;
+	icon_state = "darkred2"
 	},
-/turf/open/floor/plating,
 /area/bigredv2/outside/admin_building)
 "aUe" = (
 /obj/structure/machinery/light{
 	dir = 4
 	},
+/obj/structure/machinery/alarm{
+	dir = 1;
+	pixel_y = -30
+	},
+/obj/structure/machinery/suit_storage_unit/carbon_unit,
 /turf/open/floor/plating,
 /area/bigredv2/outside/admin_building)
 "aUf" = (
 /obj/effect/landmark/good_item,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor{
 	dir = 8;
 	icon_state = "darkred2"
 	},
 /area/bigredv2/outside/admin_building)
 "aUg" = (
-/obj/structure/surface/table/woodentable,
-/obj/item/device/camera,
+/obj/structure/closet/secure_closet/personal/cabinet,
+/obj/effect/landmark/objective_landmark/close,
 /turf/open/floor{
 	icon_state = "wood"
 	},
@@ -17148,12 +17175,10 @@
 	dir = 4
 	},
 /turf/open/floor{
-	icon_state = "dark"
+	icon_state = "podhatchfloor"
 	},
 /area/bigredv2/outside/admin_building)
 "aVk" = (
-/obj/structure/surface/rack,
-/obj/item/weapon/gun/pistol/mod88,
 /turf/open/floor{
 	dir = 8;
 	icon_state = "redcorner"
@@ -17382,13 +17407,11 @@
 	dir = 1;
 	network = list("interrogation")
 	},
-/obj/structure/machinery/computer3/server,
 /turf/open/floor{
 	icon_state = "podhatchfloor"
 	},
 /area/bigredv2/outside/admin_building)
 "aVT" = (
-/obj/structure/machinery/computer3/server,
 /turf/open/floor{
 	dir = 9;
 	icon_state = "darkblue2"
@@ -17404,7 +17427,6 @@
 /obj/structure/machinery/light{
 	dir = 1
 	},
-/obj/structure/machinery/photocopier,
 /turf/open/floor{
 	dir = 1;
 	icon_state = "darkblue2"
@@ -17420,13 +17442,16 @@
 	phone_id = "Operations";
 	pixel_y = 24
 	},
+/obj/item/prop/alien/hugger,
 /turf/open/floor{
 	dir = 1;
 	icon_state = "darkblue2"
 	},
 /area/bigredv2/outside/admin_building)
 "aVX" = (
-/obj/structure/machinery/computer/cameras,
+/obj/structure/machinery/computer/cameras{
+	dir = 8
+	},
 /obj/structure/surface/table,
 /turf/open/floor{
 	dir = 5;
@@ -17608,7 +17633,6 @@
 	},
 /area/bigredv2/outside/admin_building)
 "aWD" = (
-/obj/structure/machinery/computer3/server,
 /turf/open/floor{
 	dir = 8;
 	icon_state = "darkblue2"
@@ -17628,7 +17652,9 @@
 	},
 /area/bigredv2/outside/admin_building)
 "aWG" = (
-/obj/structure/machinery/computer/communications,
+/obj/structure/machinery/computer/communications{
+	dir = 8
+	},
 /obj/structure/surface/table,
 /turf/open/floor{
 	dir = 6;
@@ -17636,10 +17662,10 @@
 	},
 /area/bigredv2/outside/admin_building)
 "aWH" = (
-/obj/structure/surface/table/woodentable,
-/obj/item/device/pinpointer,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor{
-	icon_state = "wood"
+	dir = 1;
+	icon_state = "darkred2"
 	},
 /area/bigredv2/outside/admin_building)
 "aWI" = (
@@ -17797,6 +17823,10 @@
 	pixel_y = 32
 	},
 /obj/effect/landmark/good_item,
+/obj/structure/stairs/perspective{
+	dir = 10;
+	icon_state = "p_stair_full"
+	},
 /turf/open/floor{
 	dir = 1;
 	icon_state = "darkred2"
@@ -17811,12 +17841,9 @@
 	},
 /area/bigredv2/outside/admin_building)
 "aXk" = (
-/obj/structure/machinery/light{
-	dir = 4
-	},
+/obj/item/prop/alien/hugger,
 /turf/open/floor{
-	dir = 4;
-	icon_state = "darkred2"
+	icon_state = "white"
 	},
 /area/bigredv2/outside/admin_building)
 "aXl" = (
@@ -17976,16 +18003,17 @@
 /turf/open/floor/plating,
 /area/bigredv2/outside/cargo)
 "aXL" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor{
-	dir = 10;
+	dir = 8;
 	icon_state = "darkred2"
 	},
 /area/bigredv2/outside/admin_building)
 "aXM" = (
-/obj/structure/pipes/standard/simple/hidden/green,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor{
-	dir = 8;
-	icon_state = "darkredcorners2"
+	dir = 4;
+	icon_state = "darkred2"
 	},
 /area/bigredv2/outside/admin_building)
 "aXN" = (
@@ -18000,6 +18028,7 @@
 	},
 /area/bigredv2/outside/admin_building)
 "aXO" = (
+/obj/item/prop/alien/hugger,
 /turf/open/floor{
 	icon_state = "darkblue2"
 	},
@@ -18082,22 +18111,23 @@
 /area/bigredv2/outside/cargo)
 "aYh" = (
 /obj/structure/pipes/standard/simple/hidden/green,
-/obj/structure/machinery/light{
-	dir = 8
-	},
 /turf/open/floor{
 	dir = 8;
-	icon_state = "darkred2"
+	icon_state = "darkredcorners2"
 	},
 /area/bigredv2/outside/admin_building)
 "aYi" = (
 /obj/effect/spawner/random/toolbox,
+/obj/structure/platform_decoration,
 /turf/open/floor{
 	icon_state = "dark"
 	},
 /area/bigredv2/outside/admin_building)
 "aYk" = (
 /obj/effect/landmark/survivor_spawner,
+/obj/structure/platform_decoration{
+	dir = 1
+	},
 /turf/open/floor{
 	icon_state = "dark"
 	},
@@ -18119,16 +18149,22 @@
 	},
 /area/bigredv2/outside/admin_building)
 "aYo" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "SW-out";
+	pixel_y = -1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor{
+	dir = 5;
+	icon_state = "darkred2"
+	},
+/area/bigredv2/outside/admin_building)
+"aYp" = (
 /obj/structure/machinery/door/airlock/almayer/generic{
 	name = "\improper Operations Toilet"
 	},
 /turf/open/floor{
 	icon_state = "delivery"
-	},
-/area/bigredv2/outside/admin_building)
-"aYp" = (
-/turf/open/floor{
-	icon_state = "freezerfloor"
 	},
 /area/bigredv2/outside/admin_building)
 "aYq" = (
@@ -18144,6 +18180,7 @@
 /obj/structure/toilet{
 	dir = 8
 	},
+/obj/item/prop/alien/hugger,
 /turf/open/floor{
 	icon_state = "freezerfloor"
 	},
@@ -18263,21 +18300,25 @@
 	},
 /area/bigredv2/outside/c)
 "aYL" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor{
-	dir = 8;
-	icon_state = "carpet6-2"
+	icon_state = "dark"
 	},
 /area/bigredv2/outside/admin_building)
 "aYM" = (
+/obj/item/prop/alien/hugger,
 /turf/open/floor{
-	dir = 8;
-	icon_state = "carpet14-10"
+	dir = 4;
+	icon_state = "darkred2"
 	},
 /area/bigredv2/outside/admin_building)
 "aYN" = (
+/obj/structure/machinery/door/airlock/almayer/command/colony{
+	dir = 1;
+	name = "\improper Operations Meeting Room"
+	},
 /turf/open/floor{
-	dir = 8;
-	icon_state = "carpet10-8"
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/admin_building)
 "aYO" = (
@@ -18294,6 +18335,7 @@
 	name = "Weyland-Yutani Automatic Teller Machine";
 	pixel_y = 30
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor{
 	dir = 1;
 	icon_state = "darkred2"
@@ -18303,6 +18345,7 @@
 /obj/structure/machinery/light{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor{
 	dir = 1;
 	icon_state = "darkred2"
@@ -18479,9 +18522,9 @@
 /obj/structure/machinery/light{
 	dir = 8
 	},
+/obj/item/prop/alien/hugger,
 /turf/open/floor{
-	dir = 8;
-	icon_state = "carpet7-3"
+	icon_state = "wood"
 	},
 /area/bigredv2/outside/admin_building)
 "aZA" = (
@@ -18492,16 +18535,10 @@
 /area/bigredv2/outside/admin_building)
 "aZB" = (
 /obj/structure/bed/chair/comfy/black,
-/turf/open/floor{
-	dir = 8;
-	icon_state = "carpet15-15"
-	},
+/turf/open/floor/carpet,
 /area/bigredv2/outside/admin_building)
 "aZC" = (
-/turf/open/floor{
-	dir = 8;
-	icon_state = "carpet11-12"
-	},
+/turf/open/floor/carpet,
 /area/bigredv2/outside/admin_building)
 "aZE" = (
 /turf/open/floor{
@@ -18587,27 +18624,26 @@
 /turf/open/floor,
 /area/bigredv2/outside/cargo)
 "aZS" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/obj/structure/machinery/camera/autoname{
+	dir = 1
+	},
 /turf/open/floor{
-	dir = 8;
-	icon_state = "carpet7-3"
+	icon_state = "white"
 	},
 /area/bigredv2/outside/admin_building)
 "aZT" = (
 /obj/structure/surface/table,
-/obj/structure/machinery/computer3/laptop/secure_data,
-/turf/open/floor{
-	dir = 8;
-	icon_state = "carpet15-15"
-	},
+/obj/structure/prop/server_equipment/laptop/on,
+/turf/open/floor/carpet,
 /area/bigredv2/outside/admin_building)
 "aZU" = (
-/obj/structure/bed/chair/office/dark{
+/obj/structure/bed/chair/comfy/blue{
 	dir = 8
 	},
-/turf/open/floor{
-	dir = 8;
-	icon_state = "carpet15-15"
-	},
+/turf/open/floor/carpet,
 /area/bigredv2/outside/admin_building)
 "aZW" = (
 /obj/structure/pipes/standard/simple/hidden/green{
@@ -18831,13 +18867,10 @@
 	},
 /area/bigredv2/outside/cargo)
 "baG" = (
-/obj/structure/bed/chair/office/dark{
+/obj/structure/bed/chair/comfy/blue{
 	dir = 4
 	},
-/turf/open/floor{
-	dir = 8;
-	icon_state = "carpet15-15"
-	},
+/turf/open/floor/carpet,
 /area/bigredv2/outside/admin_building)
 "baI" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/comdoor/colony{
@@ -18849,6 +18882,7 @@
 /area/bigredv2/outside/admin_building)
 "baJ" = (
 /obj/structure/pipes/standard/simple/hidden/green,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor,
 /area/bigredv2/outside/admin_building)
 "baK" = (
@@ -18989,10 +19023,7 @@
 "bbj" = (
 /obj/structure/surface/table,
 /obj/item/alienjar,
-/turf/open/floor{
-	dir = 8;
-	icon_state = "carpet15-15"
-	},
+/turf/open/floor/carpet,
 /area/bigredv2/outside/admin_building)
 "bbk" = (
 /obj/structure/machinery/light{
@@ -19018,7 +19049,9 @@
 /area/bigredv2/outside/admin_building)
 "bbm" = (
 /obj/structure/surface/table,
-/obj/structure/machinery/computer/med_data/laptop,
+/obj/structure/machinery/computer/med_data/laptop{
+	dir = 4
+	},
 /turf/open/floor{
 	dir = 8;
 	icon_state = "carpet15-15"
@@ -19033,11 +19066,14 @@
 	},
 /area/bigredv2/outside/admin_building)
 "bbo" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/comfy/blue,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor,
 /area/bigredv2/outside/admin_building)
 "bbp" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/sofa/south/grey/left{
+	pixel_y = 6
+	},
 /obj/structure/machinery/atm{
 	name = "Weyland-Yutani Automatic Teller Machine";
 	pixel_y = 30
@@ -19045,7 +19081,9 @@
 /turf/open/floor,
 /area/bigredv2/outside/admin_building)
 "bbq" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/sofa/south/grey{
+	pixel_y = 6
+	},
 /obj/structure/machinery/light{
 	dir = 1
 	},
@@ -19055,6 +19093,7 @@
 /obj/structure/surface/table,
 /obj/item/storage/photo_album,
 /obj/item/tool/pen/red,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor,
 /area/bigredv2/outside/admin_building)
 "bbs" = (
@@ -19276,14 +19315,16 @@
 	},
 /area/bigredv2/outside/admin_building)
 "bbY" = (
-/obj/structure/bed/chair/office/dark,
+/obj/structure/bed/chair/comfy/blue,
 /turf/open/floor{
 	icon_state = "wood"
 	},
 /area/bigredv2/outside/admin_building)
 "bbZ" = (
 /obj/structure/surface/table,
-/obj/structure/machinery/computer/cameras/wooden_tv,
+/obj/structure/machinery/computer/cameras/wooden_tv{
+	dir = 8
+	},
 /obj/structure/machinery/light{
 	dir = 4
 	},
@@ -19494,53 +19535,47 @@
 /obj/structure/pipes/vents/pump{
 	dir = 4
 	},
-/turf/open/floor{
-	dir = 8;
-	icon_state = "carpet15-15"
-	},
+/obj/item/prop/alien/hugger,
+/turf/open/floor/carpet,
 /area/bigredv2/outside/admin_building)
 "bcF" = (
-/obj/structure/bed/chair/office/dark{
+/obj/structure/bed/chair/comfy/blue{
 	dir = 8
 	},
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
 	},
-/turf/open/floor{
-	dir = 8;
-	icon_state = "carpet15-15"
-	},
+/turf/open/floor/carpet,
 /area/bigredv2/outside/admin_building)
 "bcG" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
 	},
-/turf/open/floor{
-	dir = 8;
-	icon_state = "carpet11-12"
-	},
+/turf/open/floor/carpet,
 /area/bigredv2/outside/admin_building)
 "bcH" = (
 /obj/structure/pipes/standard/simple/hidden/green{
-	dir = 10
+	dir = 4
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "wood"
+	},
 /area/bigredv2/outside/admin_building)
 "bcI" = (
 /obj/structure/pipes/standard/manifold/hidden/green{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor{
 	dir = 8;
 	icon_state = "darkred2"
 	},
 /area/bigredv2/outside/admin_building)
 "bcJ" = (
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 4
-	},
+/obj/structure/pipes/standard/simple/hidden/green,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor{
-	dir = 4;
+	dir = 8;
 	icon_state = "darkred2"
 	},
 /area/bigredv2/outside/admin_building)
@@ -19704,45 +19739,38 @@
 	},
 /area/bigredv2/outside/c)
 "bdl" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor{
-	dir = 8;
-	icon_state = "carpet9-4"
+	icon_state = "darkred2"
 	},
 /area/bigredv2/outside/admin_building)
 "bdm" = (
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 5
+/obj/structure/surface/table/woodentable,
+/turf/open/floor{
+	icon_state = "wood"
 	},
-/turf/open/floor,
 /area/bigredv2/outside/admin_building)
 "bdn" = (
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 4
+/obj/structure/machinery/light{
+	dir = 1
 	},
-/obj/structure/machinery/door/airlock/almayer/command/colony{
-	name = "\improper Operations Meeting Room"
-	},
+/obj/structure/surface/table/woodentable,
+/obj/item/device/camera,
 /turf/open/floor{
-	icon_state = "delivery"
+	icon_state = "wood"
 	},
 /area/bigredv2/outside/admin_building)
 "bdo" = (
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 9
-	},
 /turf/open/floor{
-	icon_state = "dark"
+	dir = 10;
+	icon_state = "darkred2"
 	},
 /area/bigredv2/outside/admin_building)
 "bdp" = (
-/obj/item/device/radio/intercom{
-	freerange = 1;
-	frequency = 1469;
-	name = "General Listening Channel";
-	pixel_x = 30
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/prop/alien/hugger,
 /turf/open/floor{
-	dir = 4;
+	dir = 6;
 	icon_state = "darkred2"
 	},
 /area/bigredv2/outside/admin_building)
@@ -19755,6 +19783,7 @@
 /area/bigredv2/outside/admin_building)
 "bdr" = (
 /obj/structure/machinery/vending/snack,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor,
 /area/bigredv2/outside/admin_building)
 "bds" = (
@@ -19877,7 +19906,9 @@
 /area/bigredv2/outside/cargo)
 "bdO" = (
 /obj/structure/machinery/vending/coffee,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "wood"
+	},
 /area/bigredv2/outside/admin_building)
 "bdP" = (
 /obj/structure/machinery/photocopier,
@@ -27127,6 +27158,15 @@
 	icon_state = "mars_cave_2"
 	},
 /area/bigredv2/caves_se)
+"bMa" = (
+/obj/structure/surface/rack,
+/obj/item/weapon/gun/pistol/mod88,
+/obj/item/weapon/gun/pistol/mod88,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "redcorner"
+	},
+/area/bigredv2/outside/admin_building)
 "bMf" = (
 /turf/open/floor{
 	icon_state = "asteroidwarning"
@@ -27166,6 +27206,10 @@
 	icon_state = "mars_cave_18"
 	},
 /area/bigredv2/outside/lz2_west_cas)
+"bQe" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor,
+/area/bigredv2/outside/admin_building)
 "bQi" = (
 /turf/open/floor{
 	icon_state = "darkish"
@@ -27278,10 +27322,7 @@
 "caN" = (
 /obj/structure/surface/table,
 /obj/effect/landmark/objective_landmark/close,
-/turf/open/floor{
-	dir = 8;
-	icon_state = "carpet15-15"
-	},
+/turf/open/floor/carpet,
 /area/bigredv2/outside/admin_building)
 "ccP" = (
 /obj/structure/surface/table,
@@ -27489,6 +27530,10 @@
 /obj/structure/surface/table/reinforced/prison,
 /turf/open/floor/plating,
 /area/bigredv2/caves/mining)
+"czS" = (
+/obj/effect/landmark/objective_landmark/medium,
+/turf/open/floor/plating,
+/area/bigredv2/outside/admin_building)
 "czV" = (
 /obj/item/tool/pickaxe,
 /turf/open/mars_cave{
@@ -27588,6 +27633,23 @@
 /obj/item/paper/bigred/smuggling,
 /turf/open/floor,
 /area/bigredv2/outside/cargo)
+"cJa" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "NW-out";
+	pixel_y = 1
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "NE-out";
+	pixel_x = 1
+	},
+/obj/structure/machinery/door/airlock/almayer/command/colony{
+	dir = 1;
+	name = "\improper Operations"
+	},
+/turf/open/floor{
+	icon_state = "delivery"
+	},
+/area/bigredv2/outside/admin_building)
 "cJh" = (
 /obj/structure/bed/chair{
 	dir = 8;
@@ -27701,6 +27763,14 @@
 "cVY" = (
 /turf/open/mars,
 /area/bigredv2/outside/space_port_lz2)
+"cXG" = (
+/obj/structure/machinery/light{
+	dir = 8
+	},
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/bigredv2/outside/admin_building)
 "cYI" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
@@ -27770,6 +27840,16 @@
 	icon_state = "mars_cave_2"
 	},
 /area/bigredv2/outside/filtration_cave_cas)
+"din" = (
+/obj/structure/machinery/blackbox_recorder,
+/obj/item/prop/almayer/flight_recorder/colony{
+	pixel_x = -6;
+	pixel_y = 10
+	},
+/turf/open/floor{
+	icon_state = "podhatchfloor"
+	},
+/area/bigredv2/outside/admin_building)
 "dlr" = (
 /obj/effect/landmark/static_comms/net_two,
 /turf/open/floor,
@@ -27921,6 +28001,14 @@
 	icon_state = "platingdmg3"
 	},
 /area/bigredv2/caves/mining)
+"dBm" = (
+/obj/structure/platform{
+	dir = 8
+	},
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/bigredv2/outside/admin_building)
 "dBE" = (
 /obj/item/trash/cigbutt/cigarbutt{
 	pixel_x = 2;
@@ -28354,6 +28442,12 @@
 	},
 /turf/open/floor/plating,
 /area/bigredv2/caves/mining)
+"eoU" = (
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "w-y2"
+	},
+/area/bigredv2/outside/admin_building)
 "epe" = (
 /turf/open/floor{
 	dir = 1;
@@ -28640,6 +28734,15 @@
 	icon_state = "mars_dirt_7"
 	},
 /area/bigredv2/caves/mining)
+"eSN" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 1
+	},
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/bigredv2/outside/admin_building)
 "eTj" = (
 /obj/structure/reagent_dispensers/fueltank/gas,
 /turf/open/mars{
@@ -28773,6 +28876,15 @@
 /obj/effect/landmark/static_comms/net_two,
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
+"fhy" = (
+/obj/structure/bed/chair/comfy/blue{
+	dir = 8
+	},
+/turf/open/floor{
+	dir = 8;
+	icon_state = "carpet15-15"
+	},
+/area/bigredv2/outside/admin_building)
 "fhI" = (
 /obj/effect/landmark/hunter_secondary,
 /turf/open/mars_cave{
@@ -29108,6 +29220,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/bigredv2/caves/mining)
+"fPB" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/bigredv2/outside/admin_building)
 "fQv" = (
 /obj/structure/prop/invuln/minecart_tracks{
 	desc = "A heavy duty power cable for high voltage applications";
@@ -29382,8 +29498,8 @@
 /area/bigredv2/caves/lambda/breakroom)
 "gvI" = (
 /obj/structure/transmitter/colony_net{
-	do_not_disturb = 1;
 	dir = 4;
+	do_not_disturb = 1;
 	phone_category = "Lambda Labs";
 	phone_color = "red";
 	phone_id = "Secure Storage";
@@ -29563,6 +29679,19 @@
 	icon_state = "darkblue2"
 	},
 /area/bigredv2/caves/eta/research)
+"gWU" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 1
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "S";
+	pixel_y = -1
+	},
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/bigredv2/outside/admin_building)
 "gXp" = (
 /turf/open/mars_cave{
 	icon_state = "mars_cave_6"
@@ -29652,6 +29781,15 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/bigredv2/caves/eta/storage)
+"hkY" = (
+/obj/structure/machinery/light{
+	dir = 4
+	},
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkred2"
+	},
+/area/bigredv2/outside/admin_building)
 "hmm" = (
 /turf/open/floor{
 	icon_state = "delivery"
@@ -29757,6 +29895,13 @@
 	icon_state = "dark"
 	},
 /area/bigredv2/caves/lambda/research)
+"hxs" = (
+/obj/structure/closet/secure_closet/personal/cabinet,
+/obj/effect/landmark/objective_landmark/far,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/bigredv2/outside/admin_building)
 "hyv" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_wall,
@@ -30289,6 +30434,17 @@
 	icon_state = "darkgreencorners2"
 	},
 /area/bigredv2/caves/eta/research)
+"iDT" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "E";
+	pixel_x = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkredcorners2"
+	},
+/area/bigredv2/outside/admin_building)
 "iDW" = (
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_wall,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
@@ -30455,6 +30611,14 @@
 	icon_state = "asteroidwarning"
 	},
 /area/bigredv2/outside/filtration_plant)
+"iZc" = (
+/obj/structure/stairs/perspective{
+	icon_state = "p_stair_full"
+	},
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/bigredv2/outside/admin_building)
 "iZh" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E-corner"
@@ -30589,6 +30753,12 @@
 /obj/structure/reagent_dispensers/fueltank/gas,
 /turf/open/floor/plating,
 /area/bigredv2/caves/mining)
+"jna" = (
+/obj/item/prop/alien/hugger,
+/turf/open/floor{
+	icon_state = "darkred2"
+	},
+/area/bigredv2/outside/admin_building)
 "jnR" = (
 /turf/open/floor{
 	dir = 9;
@@ -30696,8 +30866,13 @@
 	},
 /area/bigredv2/caves/lambda/virology)
 "jAm" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
-/obj/effect/landmark/objective_landmark/far,
+/obj/structure/coatrack{
+	pixel_x = -8;
+	pixel_y = 16
+	},
+/obj/item/clothing/shoes/black{
+	pixel_y = -7
+	},
 /turf/open/floor{
 	icon_state = "wood"
 	},
@@ -31192,6 +31367,14 @@
 	icon_state = "mars_dirt_7"
 	},
 /area/bigredv2/caves/mining)
+"khP" = (
+/obj/structure/platform{
+	dir = 1
+	},
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/bigredv2/outside/admin_building)
 "khR" = (
 /obj/structure/machinery/floodlight,
 /turf/open/mars_cave{
@@ -31417,6 +31600,13 @@
 	icon_state = "asteroidfloor"
 	},
 /area/bigredv2/outside/space_port_lz2)
+"kIv" = (
+/obj/structure/curtain/red,
+/obj/item/prop/alien/hugger,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/bigredv2/outside/admin_building)
 "kIW" = (
 /obj/structure/fence,
 /turf/open/floor{
@@ -31510,6 +31700,10 @@
 "kRo" = (
 /turf/open/floor/plating,
 /area/bigredv2/outside/telecomm/warehouse)
+"kRK" = (
+/obj/structure/window/framed/solaris/reinforced,
+/turf/open/floor/plating,
+/area/bigredv2/outside/admin_building)
 "kSm" = (
 /obj/item/storage/belt/grenade,
 /obj/structure/closet/crate,
@@ -32141,13 +32335,9 @@
 	},
 /area/bigredv2/caves/mining)
 "mrH" = (
-/obj/structure/machinery/blackbox_recorder,
-/obj/item/prop/almayer/flight_recorder/colony{
-	pixel_x = -6;
-	pixel_y = 10
-	},
+/obj/structure/machinery/computer3/server,
 /turf/open/floor{
-	icon_state = "dark"
+	icon_state = "podhatchfloor"
 	},
 /area/bigredv2/outside/admin_building)
 "mrS" = (
@@ -32263,6 +32453,16 @@
 	icon_state = "mars_cave_15"
 	},
 /area/bigredv2/outside/lz1_north_cas)
+"mEH" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkred2"
+	},
+/area/bigredv2/outside/admin_building)
 "mFT" = (
 /obj/item/weapon/gun/shotgun/pump/dual_tube/cmb,
 /obj/effect/landmark/corpsespawner/russian,
@@ -32280,7 +32480,7 @@
 "mGS" = (
 /obj/effect/landmark/static_comms/net_one,
 /turf/open/floor{
-	icon_state = "dark"
+	icon_state = "podhatchfloor"
 	},
 /area/bigredv2/outside/admin_building)
 "mHp" = (
@@ -32371,6 +32571,18 @@
 	icon_state = "asteroidwarning"
 	},
 /area/bigredv2/outside/c)
+"mST" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "SE-out";
+	pixel_x = 1;
+	pixel_y = -1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkred2"
+	},
+/area/bigredv2/outside/admin_building)
 "mUy" = (
 /turf/open/mars_cave{
 	icon_state = "mars_cave_7"
@@ -32482,6 +32694,11 @@
 	icon_state = "mars_dirt_6"
 	},
 /area/bigredv2/outside/lz2_south_cas)
+"nky" = (
+/obj/structure/machinery/vending/coffee,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor,
+/area/bigredv2/outside/admin_building)
 "nkQ" = (
 /turf/open/mars_cave{
 	icon_state = "mars_cave_23"
@@ -32584,6 +32801,16 @@
 	icon_state = "platingdmg3"
 	},
 /area/bigredv2/caves/mining)
+"nuw" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "NE-out";
+	pixel_x = 1;
+	pixel_y = 1
+	},
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/bigredv2/outside/admin_building)
 "nwS" = (
 /obj/item/ore{
 	pixel_x = -7;
@@ -32843,6 +33070,14 @@
 /obj/item/tool/warning_cone,
 /turf/open/mars,
 /area/bigredv2/outside/s)
+"nZD" = (
+/obj/structure/platform_decoration{
+	dir = 8
+	},
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/bigredv2/outside/admin_building)
 "nZK" = (
 /obj/item/ore/diamond,
 /obj/item/stack/sheet/mineral/diamond{
@@ -32984,6 +33219,12 @@
 	icon_state = "platingdmg3"
 	},
 /area/bigredv2/caves/mining)
+"ole" = (
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "w-y0"
+	},
+/area/bigredv2/outside/admin_building)
 "olT" = (
 /obj/effect/landmark/corpsespawner/engineer,
 /turf/open/shuttle/escapepod{
@@ -33204,12 +33445,30 @@
 	icon_state = "vault"
 	},
 /area/bigredv2/outside/general_offices)
+"oDW" = (
+/obj/structure/pipes/standard/simple/hidden/green,
+/obj/structure/machinery/light{
+	dir = 8
+	},
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkred2"
+	},
+/area/bigredv2/outside/admin_building)
 "oEJ" = (
 /obj/structure/surface/table,
 /obj/effect/spawner/random/toolbox,
 /obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
 /turf/open/floor,
 /area/bigredv2/outside/cargo)
+"oFY" = (
+/obj/structure/pipes/standard/simple/hidden/green,
+/obj/item/prop/alien/hugger,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkred2"
+	},
+/area/bigredv2/outside/admin_building)
 "oIc" = (
 /obj/effect/decal/cleanable/blood{
 	base_icon = 'icons/obj/items/weapons/grenade.dmi';
@@ -33378,6 +33637,16 @@
 	icon_state = "mars_cave_2"
 	},
 /area/bigredv2/caves_sw)
+"oWe" = (
+/obj/structure/machinery/photocopier{
+	density = 0;
+	pixel_y = 16
+	},
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkblue2"
+	},
+/area/bigredv2/outside/admin_building)
 "oWC" = (
 /obj/structure/prop/invuln/minecart_tracks{
 	desc = "A heavy duty power cable for high voltage applications";
@@ -33500,6 +33769,12 @@
 	icon_state = "mars_dirt_10"
 	},
 /area/bigredv2/outside/filtration_plant)
+"pdG" = (
+/obj/item/prop/alien/hugger,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/bigredv2/outside/admin_building)
 "pdN" = (
 /obj/effect/landmark/nightmare{
 	insert_tag = "lz1entrance"
@@ -33653,6 +33928,31 @@
 	icon_state = "mars_cave_14"
 	},
 /area/bigredv2/caves/mining)
+"pxH" = (
+/obj/structure/platform_decoration{
+	dir = 4
+	},
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/bigredv2/outside/admin_building)
+"pyU" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "NW-out";
+	pixel_y = 1
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "SW-out";
+	pixel_y = -1
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "E";
+	pixel_x = 1
+	},
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/bigredv2/outside/admin_building)
 "pBD" = (
 /turf/open/floor{
 	dir = 4;
@@ -33756,6 +34056,16 @@
 	icon_state = "darkred2"
 	},
 /area/bigredv2/caves/eta/research)
+"pNU" = (
+/obj/structure/bed,
+/obj/item/prop/alien/hugger,
+/obj/item/bedsheet/brown{
+	layer = 3.1
+	},
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/bigredv2/outside/admin_building)
 "pOL" = (
 /obj/structure/closet/crate/miningcar/yellow,
 /turf/open/mars_cave{
@@ -34060,6 +34370,12 @@
 	icon_state = "mars_dirt_7"
 	},
 /area/bigredv2/caves/mining)
+"qoN" = (
+/obj/structure/pipes/standard/manifold/hidden/green,
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/bigredv2/outside/admin_building)
 "qpn" = (
 /obj/item/tool/warning_cone{
 	pixel_x = -6
@@ -34126,6 +34442,16 @@
 	icon_state = "platingdmg3"
 	},
 /area/bigredv2/caves/mining)
+"qyi" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "NW-out";
+	pixel_y = 1
+	},
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkredcorners2"
+	},
+/area/bigredv2/outside/admin_building)
 "qzO" = (
 /obj/structure/blocker/forcefield/multitile_vehicles,
 /obj/structure/machinery/door/poddoor/almayer/closed{
@@ -34332,6 +34658,13 @@
 	icon_state = "mars_cave_17"
 	},
 /area/bigredv2/caves/mining)
+"qXi" = (
+/obj/structure/surface/table/woodentable,
+/obj/item/device/pinpointer,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/bigredv2/outside/admin_building)
 "qYY" = (
 /obj/structure/prop/invuln/minecart_tracks{
 	dir = 8
@@ -34508,6 +34841,16 @@
 	icon_state = "mars_cave_2"
 	},
 /area/bigredv2/caves/mining)
+"rpI" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "W";
+	layer = 2.5
+	},
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkred2"
+	},
+/area/bigredv2/outside/admin_building)
 "rqa" = (
 /obj/structure/tunnel{
 	id = "hole4"
@@ -35229,6 +35572,15 @@
 	icon_state = "delivery"
 	},
 /area/bigredv2/caves_lambda)
+"szi" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor{
+	icon_state = "darkred2"
+	},
+/area/bigredv2/outside/admin_building)
 "szw" = (
 /turf/open/mars_cave{
 	icon_state = "mars_dirt_6"
@@ -35351,7 +35703,7 @@
 	},
 /area/bigredv2/caves_sw)
 "sLS" = (
-/obj/effect/landmark/objective_landmark/medium,
+/obj/structure/machinery/suit_storage_unit/carbon_unit,
 /turf/open/floor/plating,
 /area/bigredv2/outside/admin_building)
 "sNQ" = (
@@ -35390,6 +35742,17 @@
 	icon_state = "mars_cave_23"
 	},
 /area/bigredv2/outside/lz1_telecomm_cas)
+"sRy" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/obj/structure/machinery/door/airlock/almayer/command/colony{
+	name = "\improper Operations Meeting Room"
+	},
+/turf/open/floor{
+	icon_state = "delivery"
+	},
+/area/bigredv2/outside/admin_building)
 "sSU" = (
 /turf/open/mars_cave{
 	icon_state = "mars_cave_19"
@@ -35460,6 +35823,12 @@
 	icon_state = "dark"
 	},
 /area/bigredv2/caves/eta/xenobiology)
+"tap" = (
+/obj/structure/machinery/message_server,
+/turf/open/floor{
+	icon_state = "podhatchfloor"
+	},
+/area/bigredv2/outside/admin_building)
 "tcb" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/pizzabox/meat,
@@ -35625,6 +35994,11 @@
 	icon_state = "mars_dirt_4"
 	},
 /area/bigredv2/caves_research)
+"toA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/prop/alien/hugger,
+/turf/open/floor,
+/area/bigredv2/outside/admin_building)
 "tpR" = (
 /obj/structure/bed/chair{
 	dir = 4;
@@ -35778,6 +36152,12 @@
 	icon_state = "platingdmg3"
 	},
 /area/bigredv2/caves/mining)
+"tBD" = (
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "w-y1"
+	},
+/area/bigredv2/outside/admin_building)
 "tBK" = (
 /obj/structure/surface/rack,
 /obj/item/tool/pickaxe{
@@ -35871,6 +36251,19 @@
 	},
 /turf/open/floor,
 /area/bigred/ground/garage_workshop)
+"tJn" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "W";
+	layer = 2.5
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "E";
+	pixel_x = 1
+	},
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/bigredv2/outside/admin_building)
 "tJv" = (
 /obj/structure/tunnel{
 	id = "hole3"
@@ -36173,6 +36566,7 @@
 /area/bigred/ground/garage_workshop)
 "upV" = (
 /obj/structure/pipes/standard/simple/hidden/green,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor{
 	icon_state = "delivery"
 	},
@@ -36381,6 +36775,16 @@
 	icon_state = "mars_cave_2"
 	},
 /area/bigredv2/caves/mining)
+"uKH" = (
+/obj/structure/stairs/perspective{
+	dir = 6;
+	icon_state = "p_stair_full"
+	},
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkred2"
+	},
+/area/bigredv2/outside/admin_building)
 "uNW" = (
 /obj/effect/decal/cleanable/blood{
 	dir = 8;
@@ -36659,6 +37063,15 @@
 	icon_state = "mars_cave_3"
 	},
 /area/bigredv2/caves/mining)
+"vpx" = (
+/obj/structure/platform,
+/obj/structure/flora/jungle/planttop1{
+	pixel_y = 10
+	},
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/bigredv2/outside/admin_building)
 "vpY" = (
 /obj/structure/machinery/door/poddoor/almayer/closed{
 	id = "eta";
@@ -36865,6 +37278,19 @@
 	icon_state = "mars_cave_5"
 	},
 /area/bigredv2/caves_virology)
+"vOs" = (
+/obj/structure/coatrack{
+	pixel_x = 12
+	},
+/obj/item/clothing/shoes/jackboots,
+/obj/item/clothing/suit/storage/windbreaker/windbreaker_gray{
+	pixel_x = 11;
+	pixel_y = 4
+	},
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/bigredv2/outside/admin_building)
 "vPP" = (
 /obj/effect/decal/cleanable/blood/drip{
 	pixel_x = 6
@@ -37018,6 +37444,22 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/solaris/reinforced,
 /area/bigredv2/caves/mining)
+"wfk" = (
+/obj/structure/filingcabinet/medical{
+	density = 0;
+	pixel_x = -8;
+	pixel_y = 16
+	},
+/obj/structure/filingcabinet/medical{
+	density = 0;
+	pixel_x = 7;
+	pixel_y = 16
+	},
+/obj/effect/landmark/objective_landmark/close,
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/bigredv2/outside/admin_building)
 "wfm" = (
 /obj/structure/bed/chair{
 	buckling_y = 5;
@@ -37223,6 +37665,12 @@
 	icon_state = "delivery"
 	},
 /area/bigredv2/caves/lambda/virology)
+"wxo" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor{
+	icon_state = "asteroidwarning"
+	},
+/area/bigredv2/outside/c)
 "wBi" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
@@ -37288,6 +37736,24 @@
 /obj/structure/closet/firecloset/full,
 /turf/open/mars,
 /area/bigredv2/outside/c)
+"wGD" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 1
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "S";
+	pixel_y = -1
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "W";
+	layer = 2.5
+	},
+/obj/item/prop/alien/hugger,
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/bigredv2/outside/admin_building)
 "wGF" = (
 /obj/item/tool/warning_cone,
 /turf/open/floor{
@@ -37301,6 +37767,16 @@
 	icon_state = "asteroidwarning"
 	},
 /area/bigredv2/outside/c)
+"wHx" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "S";
+	pixel_y = -1
+	},
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkredcorners2"
+	},
+/area/bigredv2/outside/admin_building)
 "wIw" = (
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_door,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
@@ -37503,6 +37979,15 @@
 	icon_state = "mars_dirt_7"
 	},
 /area/bigredv2/caves/mining)
+"xej" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "S";
+	pixel_y = -1
+	},
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/bigredv2/outside/admin_building)
 "xeN" = (
 /obj/effect/landmark/lv624/xeno_tunnel,
 /turf/open/mars_cave{
@@ -37803,6 +38288,14 @@
 	},
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
+"xBn" = (
+/obj/structure/platform{
+	dir = 4
+	},
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/bigredv2/outside/admin_building)
 "xBr" = (
 /obj/item/ore{
 	pixel_x = 9
@@ -37889,6 +38382,13 @@
 /obj/structure/prop/server_equipment/yutani_server,
 /turf/open/floor/greengrid,
 /area/bigredv2/caves/lambda/research)
+"xKG" = (
+/obj/structure/bed/sofa/south/grey/right{
+	pixel_y = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor,
+/area/bigredv2/outside/admin_building)
 "xLM" = (
 /obj/structure/machinery/light{
 	dir = 1
@@ -54602,17 +55102,17 @@ aHF
 aHF
 apC
 apC
-apC
 apJ
-apJ
-apC
-apC
-apC
-apC
-apC
 apJ
 apJ
 apC
+apC
+apC
+apC
+apC
+apJ
+apJ
+apJ
 apC
 apC
 apC
@@ -54825,19 +55325,19 @@ aRT
 aof
 aTV
 mGS
-aTV
+tap
 aof
 aNK
 aXL
+bdo
 aof
-aYL
 aZz
-aZS
-aZS
-aZS
-aZS
-aZz
-bcM
+aOO
+aOO
+aOO
+aOO
+cXG
+aOO
 apC
 apC
 aHD
@@ -55038,23 +55538,23 @@ aGD
 aMf
 aPL
 aMf
-aMf
+aXk
 aof
 aTV
+aTV
+din
+aof
+aWH
 aOM
-aTV
-aof
-aNL
-aUb
+jna
 asT
-aYM
-aZA
-aZA
+aZC
+aZC
 baG
-aZA
+aZC
 baG
-aZA
-bcN
+aZC
+aOO
 bdO
 apC
 aHD
@@ -55258,21 +55758,21 @@ aQW
 aRU
 aof
 aTU
-aOM
+wGD
 aTV
 aof
 aYU
+aOM
 aUb
 asT
-aYM
 aZB
 aZT
 aIY
 bbj
 caN
 bcE
-bcN
-aYO
+aOO
+aOO
 apC
 aHD
 aBR
@@ -55466,7 +55966,7 @@ awQ
 aJl
 aKo
 aKo
-aKo
+aSX
 aMF
 aNz
 aKo
@@ -55475,21 +55975,21 @@ aQX
 aRV
 aof
 aTV
-aOM
+gWU
 aVS
 aof
 aXg
+aOM
 aUb
-asT
-aYM
-aZA
+aof
+aZC
 aZU
-aZA
+aZC
 aZU
-aZA
+aZC
 bcF
-bcN
-aYO
+aOO
+aOO
 apD
 aHD
 aBR
@@ -55683,7 +56183,7 @@ aDN
 ayN
 aKp
 aQW
-aMf
+aTb
 kmm
 aNA
 aMf
@@ -55691,13 +56191,13 @@ aMf
 aQY
 aMf
 aSQ
+tJn
+pyU
+tJn
+cJa
+iZc
 aOM
 aOM
-aOM
-aSQ
-aNL
-aUb
-asT
 aYN
 aZC
 aZC
@@ -55705,8 +56205,8 @@ aZC
 aZC
 aZC
 bcG
-bdl
-aYO
+aOO
+aOO
 apD
 aHD
 aBR
@@ -55908,22 +56408,22 @@ aPM
 aQZ
 aRX
 aof
-aTX
+mrH
 aVj
 mrH
 aof
-aNL
+uKH
+aOM
 aUb
-asT
-aYO
-aYO
-aYO
-aYO
-aYO
-aYO
+aof
+aOO
+aOO
+aOO
+aOO
+aOO
 bcH
-bdm
-aYO
+aOO
+aOO
 apC
 aHD
 aBR
@@ -56118,7 +56618,7 @@ alu
 aKq
 aHF
 aHF
-apC
+apD
 aNC
 aMf
 aPN
@@ -56130,19 +56630,19 @@ aof
 aof
 aof
 aNL
+aOM
 aUb
 aof
-asT
-asT
-asT
+aof
 asT
 asT
 asT
 aof
-bdn
+sRy
+aof
 aof
 apC
-aHD
+wxo
 aBR
 aBR
 bhi
@@ -56337,9 +56837,9 @@ aHF
 aHF
 apD
 aND
+aXk
 aMf
-aMf
-aQZ
+aZS
 aof
 aSR
 aTY
@@ -56347,19 +56847,19 @@ aTY
 aTY
 aWC
 aXj
-aXM
+aOI
 aYh
-aRd
-aRd
+oDW
+oFY
 bcI
-aRd
+bcJ
 aRd
 aVl
-bcI
+qoN
 bdo
-aXL
-apC
-aHD
+apD
+bhU
+wxo
 aBR
 aBR
 bhi
@@ -56561,21 +57061,21 @@ aof
 aSS
 aTZ
 aVk
-aVk
+bMa
 aof
-aSV
+mEH
 aOM
 aYi
-aOM
-aOM
+xBn
+nZD
 aPS
 aOM
 aOM
 aOM
 aPS
-aOM
-aUb
-apC
+bdl
+apD
+bhU
 aHD
 aBR
 aBR
@@ -56780,19 +57280,19 @@ aof
 aof
 aof
 aof
-aSV
+mEH
 aOM
-aOM
+vpx
 aFd
-aOM
+khP
 aZW
 aOK
 bbk
 aOK
-bcJ
+aPS
 bdp
-aUc
-apC
+apD
+aHF
 aHD
 aBR
 aBR
@@ -56996,12 +57496,12 @@ aST
 aRd
 aVl
 aRd
-aRd
+bcJ
 aSW
 aOM
 aYk
-aOM
-aOM
+dBm
+pxH
 aZX
 aof
 aof
@@ -57211,11 +57711,11 @@ aRc
 aof
 aSU
 aUa
+aXM
 aOK
 aOK
 aOK
-aXk
-aOK
+hkY
 aYl
 aYS
 aOM
@@ -57427,11 +57927,11 @@ aof
 aof
 aof
 aSV
-aUb
+bdl
 aof
 aof
-aof
-aof
+kRK
+kRK
 aof
 aof
 aYT
@@ -57641,16 +58141,16 @@ apD
 aNI
 aRd
 bcI
-aRd
+bcJ
 aRY
 aSW
-aUb
-aof
+bdl
+kRK
 aVT
 aWD
 aWD
 aXN
-aof
+kRK
 aYU
 aOM
 aZY
@@ -57659,7 +58159,7 @@ bbm
 aJb
 bcN
 aof
-aJT
+wfk
 apC
 aHD
 aIn
@@ -57855,27 +58355,27 @@ aBR
 aBR
 aMc
 apD
-aNJ
-aOK
+aUd
+aXM
 aPS
 aOM
 aOK
 aOK
 aUc
-aof
+aYm
 aVU
 aOM
 aOM
 aXO
-aof
+kRK
 aNL
 aOM
 aZX
 aof
-aZU
+fhy
 aZA
 bcN
-aOO
+kIv
 aOO
 apC
 aHD
@@ -58290,21 +58790,21 @@ aBR
 aMc
 apD
 aNK
-aOL
+aXL
 aPS
 aOM
 aof
 wvK
-aSX
+wvK
 aof
-aVU
+oWe
 aOM
 aXl
 aXP
 aof
 aNL
 aOM
-aZX
+szi
 aof
 aNQ
 aOO
@@ -58512,16 +59012,16 @@ aPS
 aOM
 aRZ
 aTa
-aUd
-aof
+aTa
+aRZ
 aVU
 aWE
 aXm
 aXQ
-aof
+kRK
 aYV
 aOM
-aZX
+szi
 aof
 aOO
 bbY
@@ -58729,12 +59229,12 @@ aPS
 aUb
 aof
 aSZ
-aTa
+czS
 aof
 aVW
 aWF
 aof
-aof
+kRK
 aof
 aYU
 aOM
@@ -58943,18 +59443,18 @@ apC
 aNN
 aOM
 aPS
-aUb
+bdl
 aof
 sLS
 aUe
 aof
 aVX
 aWG
-aof
+kRK
 aNK
-aOL
-aYW
-aOM
+mST
+iDT
+nuw
 aZX
 aof
 aof
@@ -59157,7 +59657,7 @@ aBR
 aBR
 aMc
 apD
-aNL
+aWH
 aOM
 aPS
 aRh
@@ -59165,20 +59665,20 @@ aof
 aof
 aof
 aof
+kRK
+kRK
 aof
-aof
-aof
-aNL
-aOM
-aOM
-aOM
+aWH
+xej
+ole
+eSN
 aPS
 baI
 aYO
 bca
 bcQ
 bdr
-bdO
+nky
 apC
 beC
 aNw
@@ -59378,24 +59878,24 @@ aNL
 aOM
 aPV
 aRi
-aOL
-aOL
+aXL
+aXL
 aUf
 aVm
 aOL
 aOL
 aOL
 aYW
-aOM
-aOM
-aOM
+xej
+tBD
+eSN
 aZZ
 upV
 baJ
 bcb
 bcR
 bcc
-aYO
+toA
 apC
 aTh
 aIn
@@ -59591,28 +60091,28 @@ aKr
 aBR
 aMc
 apC
-aNJ
-aOM
-aOK
-aOK
-aOK
-aOM
-aOK
+aUd
+aYL
+aYM
 aOK
 aOK
 aOM
 aOK
 aOK
-aOM
 aOK
-aYS
-aUb
+aYL
+aXM
+aOK
+wHx
+eoU
+eSN
+bdl
 aof
 bbo
 bcc
 bcS
 bcc
-aYO
+bQe
 apD
 aTh
 aIn
@@ -59821,9 +60321,9 @@ aON
 aof
 aof
 aYo
-aof
-aNL
-aUb
+rpI
+qyi
+bdl
 aof
 bbp
 bcc
@@ -60029,17 +60529,17 @@ aNO
 aOO
 aPW
 aof
-aNO
+bdm
 aOO
-aPW
+vOs
 aof
 jAm
 aOO
-aPW
+hxs
 aof
 aYp
 aof
-aNL
+aWH
 aUb
 aof
 bbq
@@ -60246,20 +60746,20 @@ aNP
 aOO
 aOO
 aof
-aNP
+bdn
 aOO
 aOO
 aof
 aNP
-aOO
-aOO
+pdG
+qXi
 aof
 aYq
 aof
-aNL
+aWH
 aUb
 aof
-bbo
+xKG
 aTa
 bcV
 bdt
@@ -60463,12 +60963,12 @@ aNQ
 aGG
 aPX
 aof
-aNQ
-aTb
+pNU
+aOO
 aUg
 aof
 aNQ
-aWH
+aOO
 aXn
 aof
 aYr
@@ -60477,10 +60977,10 @@ aNJ
 aUc
 aof
 bbr
+toA
 aYO
-aYO
-aTa
-aYO
+fPB
+bQe
 bek
 bjZ
 aMg

--- a/maps/map_files/BigRed/sprinkles/40.admin_pmc.dmm
+++ b/maps/map_files/BigRed/sprinkles/40.admin_pmc.dmm
@@ -2,10 +2,6 @@
 "ab" = (
 /turf/closed/wall/solaris/reinforced,
 /area/bigredv2/outside/admin_building)
-"ac" = (
-/obj/effect/acid_hole,
-/turf/closed/wall/solaris,
-/area/bigredv2/outside/admin_building)
 "ad" = (
 /obj/structure/window/framed/solaris,
 /turf/open/floor/plating,
@@ -15,88 +11,68 @@
 /area/bigredv2/outside/admin_building)
 "af" = (
 /obj/structure/pipes/standard/simple/hidden/green,
-/obj/structure/machinery/light{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/blood/xeno,
 /turf/open/floor{
-	icon_state = "darkred2";
-	dir = 8
+	dir = 8;
+	icon_state = "darkredcorners2"
 	},
 /area/bigredv2/outside/admin_building)
 "ag" = (
 /obj/effect/spawner/random/toolbox,
+/obj/structure/platform_decoration,
 /turf/open/floor{
 	icon_state = "dark"
 	},
 /area/bigredv2/outside/admin_building)
 "ai" = (
 /obj/effect/landmark/survivor_spawner,
+/obj/structure/platform_decoration{
+	dir = 1
+	},
 /turf/open/floor{
 	icon_state = "dark"
 	},
 /area/bigredv2/outside/admin_building)
 "aj" = (
+/turf/open/floor{
+	icon_state = "darkred2"
+	},
+/area/bigredv2/outside/admin_building)
+"ak" = (
 /obj/structure/window_frame/solaris,
 /obj/item/shard,
 /turf/open/floor/plating,
 /area/bigredv2/outside/admin_building)
-"ak" = (
-/obj/structure/barricade/metal/wired{
-	icon_state = "metal_2";
-	dir = 1
-	},
-/turf/open/floor{
-	icon_state = "carpet14-10";
-	dir = 8
-	},
-/area/bigredv2/outside/admin_building)
 "al" = (
-/obj/structure/barricade/metal/wired{
-	dir = 1
+/obj/structure/machinery/door/airlock/almayer/command/colony{
+	dir = 1;
+	name = "\improper Operations Meeting Room"
 	},
 /turf/open/floor{
-	icon_state = "carpet10-8";
-	dir = 8
+	icon_state = "delivery"
 	},
 /area/bigredv2/outside/admin_building)
 "am" = (
-/obj/structure/barricade/metal/wired{
-	dir = 1
+/obj/structure/platform,
+/obj/structure/flora/jungle/planttop1{
+	pixel_y = 10
 	},
-/obj/structure/barricade/metal/wired{
-	icon_state = "metal_2";
-	dir = 4
+/turf/open/floor{
+	icon_state = "dark"
 	},
-/obj/item/ammo_magazine/rifle{
-	current_rounds = 0;
-	pixel_x = -9;
-	pixel_y = -4
-	},
-/turf/open/floor,
 /area/bigredv2/outside/admin_building)
 "an" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor{
-	icon_state = "darkred2";
-	dir = 8
+	dir = 8;
+	icon_state = "darkred2"
 	},
 /area/bigredv2/outside/admin_building)
 "ap" = (
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/structure/flora/jungle/plantbot1{
+	pixel_y = 10
 	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/turf/open/jungle{
-	bushes_spawn = 0;
-	icon_state = "grass_impenetrable"
-	},
+/turf/open/jungle,
 /area/bigredv2/outside/admin_building)
 "ar" = (
 /obj/structure/machinery/light{
@@ -106,38 +82,30 @@
 	icon_state = "gib6"
 	},
 /turf/open/floor{
-	icon_state = "carpet7-3";
-	dir = 8
-	},
-/area/bigredv2/outside/admin_building)
-"as" = (
-/turf/open/floor{
-	icon_state = "carpet15-15";
-	dir = 8
+	icon_state = "wood"
 	},
 /area/bigredv2/outside/admin_building)
 "at" = (
 /obj/structure/bed/chair/comfy/black,
-/turf/open/floor{
-	icon_state = "carpet15-15";
-	dir = 8
-	},
+/turf/open/floor/carpet,
 /area/bigredv2/outside/admin_building)
 "au" = (
 /obj/effect/landmark/corpsespawner/wygoon,
-/turf/open/floor{
-	icon_state = "carpet11-12";
-	dir = 8
-	},
+/turf/open/floor/carpet,
 /area/bigredv2/outside/admin_building)
 "av" = (
 /obj/structure/barricade/metal/wired{
-	icon_state = "metal_2";
-	dir = 4
+	dir = 4;
+	icon_state = "metal_2"
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "wood"
+	},
 /area/bigredv2/outside/admin_building)
 "aw" = (
+/obj/structure/platform_decoration{
+	dir = 8
+	},
 /obj/effect/decal/cleanable/blood/xeno,
 /turf/open/floor{
 	icon_state = "dark"
@@ -151,33 +119,23 @@
 "aA" = (
 /obj/effect/landmark/corpsespawner/wygoon,
 /turf/open/floor{
-	icon_state = "carpet7-3";
-	dir = 8
+	icon_state = "wood"
 	},
 /area/bigredv2/outside/admin_building)
 "aB" = (
 /obj/structure/surface/table,
-/obj/structure/machinery/computer3/laptop/secure_data,
-/turf/open/floor{
-	icon_state = "carpet15-15";
-	dir = 8
-	},
+/obj/structure/prop/server_equipment/laptop/on,
+/turf/open/floor/carpet,
 /area/bigredv2/outside/admin_building)
 "aC" = (
-/obj/structure/bed/chair/office/dark{
+/obj/structure/bed/chair/comfy/blue{
 	dir = 8
 	},
-/turf/open/floor{
-	icon_state = "carpet15-15";
-	dir = 8
-	},
+/turf/open/floor/carpet,
 /area/bigredv2/outside/admin_building)
 "aD" = (
-/obj/item/stack/sheet/metal/small_stack,
-/turf/open/floor{
-	icon_state = "carpet6-2";
-	dir = 8
-	},
+/obj/effect/acid_hole,
+/turf/closed/wall/solaris,
 /area/bigredv2/outside/admin_building)
 "aG" = (
 /obj/structure/pipes/standard/simple/hidden/green{
@@ -196,20 +154,11 @@
 	icon_state = "darkred2"
 	},
 /area/bigredv2/outside/admin_building)
-"aI" = (
-/turf/open/floor{
-	icon_state = "carpet7-3";
-	dir = 8
-	},
-/area/bigredv2/outside/admin_building)
 "aJ" = (
-/obj/structure/bed/chair/office/dark{
+/obj/structure/bed/chair/comfy/blue{
 	dir = 4
 	},
-/turf/open/floor{
-	icon_state = "carpet15-15";
-	dir = 8
-	},
+/turf/open/floor/carpet,
 /area/bigredv2/outside/admin_building)
 "aK" = (
 /obj/structure/surface/table,
@@ -219,54 +168,41 @@
 	name = "dented M4A3 service pistol"
 	},
 /obj/item/ammo_magazine/pistol/rubber,
-/turf/open/floor{
-	icon_state = "carpet15-15";
-	dir = 8
-	},
+/turf/open/floor/carpet,
 /area/bigredv2/outside/admin_building)
 "aL" = (
 /obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor{
-	icon_state = "carpet11-12";
-	dir = 8
-	},
+/turf/open/floor/carpet,
 /area/bigredv2/outside/admin_building)
 "aM" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/structure/barricade/sandbags/wired,
 /turf/open/floor{
-	icon_state = "darkred2";
-	dir = 8
+	dir = 8;
+	icon_state = "darkred2"
 	},
 /area/bigredv2/outside/admin_building)
 "aN" = (
 /obj/structure/barricade/sandbags/wired,
 /turf/open/floor{
-	icon_state = "darkred2";
-	dir = 4
+	dir = 4;
+	icon_state = "darkred2"
 	},
 /area/bigredv2/outside/admin_building)
 "aO" = (
 /obj/item/storage/secure/briefcase,
-/turf/open/floor{
-	icon_state = "carpet15-15";
-	dir = 8
-	},
+/turf/open/floor/carpet,
 /area/bigredv2/outside/admin_building)
 "aP" = (
 /obj/structure/barricade/metal/wired{
 	dir = 4
 	},
-/turf/open/floor,
-/area/bigredv2/outside/admin_building)
-"aQ" = (
 /turf/open/floor{
-	icon_state = "carpet11-12";
-	dir = 8
+	icon_state = "wood"
 	},
 /area/bigredv2/outside/admin_building)
-"aR" = (
-/turf/open/floor,
+"aQ" = (
+/turf/open/floor/carpet,
 /area/bigredv2/outside/admin_building)
 "aS" = (
 /obj/item/ammo_magazine/rifle/rubber{
@@ -274,10 +210,7 @@
 	pixel_x = -3;
 	pixel_y = -6
 	},
-/turf/open/floor{
-	icon_state = "carpet11-12";
-	dir = 8
-	},
+/turf/open/floor/carpet,
 /area/bigredv2/outside/admin_building)
 "aT" = (
 /obj/effect/decal/cleanable/blood,
@@ -291,38 +224,32 @@
 	},
 /obj/item/storage/toolbox/syndicate,
 /turf/open/floor{
-	icon_state = "darkred2";
-	dir = 4
+	dir = 4;
+	icon_state = "darkred2"
 	},
 /area/bigredv2/outside/admin_building)
 "aV" = (
 /obj/structure/surface/table,
 /obj/item/ammo_magazine/rifle/rubber,
-/turf/open/floor{
-	icon_state = "carpet15-15";
-	dir = 8
-	},
+/turf/open/floor/carpet,
 /area/bigredv2/outside/admin_building)
 "aW" = (
 /obj/effect/decal/cleanable/blood,
 /obj/item/tool/weldingtool,
-/turf/open/floor{
-	icon_state = "carpet11-12";
-	dir = 8
-	},
+/turf/open/floor/carpet,
 /area/bigredv2/outside/admin_building)
 "aX" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/effect/landmark/crap_item,
 /turf/open/floor{
-	icon_state = "darkred2";
-	dir = 8
+	dir = 8;
+	icon_state = "darkred2"
 	},
 /area/bigredv2/outside/admin_building)
 "aY" = (
 /turf/open/floor{
-	icon_state = "darkred2";
-	dir = 4
+	dir = 4;
+	icon_state = "darkred2"
 	},
 /area/bigredv2/outside/admin_building)
 "aZ" = (
@@ -338,8 +265,7 @@
 	num_of_magazines = 2
 	},
 /turf/open/floor{
-	icon_state = "carpet7-3";
-	dir = 8
+	icon_state = "wood"
 	},
 /area/bigredv2/outside/admin_building)
 "ba" = (
@@ -348,52 +274,45 @@
 	dir = 4
 	},
 /obj/item/clothing/head/helmet/marine/veteran/pmc/leader,
-/turf/open/floor{
-	icon_state = "carpet15-15";
-	dir = 8
-	},
+/turf/open/floor/carpet,
 /area/bigredv2/outside/admin_building)
 "bb" = (
-/obj/structure/bed/chair/office/dark{
+/obj/structure/bed/chair/comfy/blue{
 	dir = 8
 	},
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
 	},
 /obj/effect/landmark/corpsespawner/wygoon,
-/turf/open/floor{
-	icon_state = "carpet15-15";
-	dir = 8
-	},
+/turf/open/floor/carpet,
 /area/bigredv2/outside/admin_building)
 "bc" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/blood,
-/turf/open/floor{
-	icon_state = "carpet11-12";
-	dir = 8
-	},
+/turf/open/floor/carpet,
 /area/bigredv2/outside/admin_building)
 "bd" = (
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 10
-	},
 /obj/item/ammo_magazine/rifle{
 	current_rounds = 0;
 	pixel_x = -8;
 	pixel_y = 9
 	},
-/turf/open/floor,
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/turf/open/floor{
+	icon_state = "wood"
+	},
 /area/bigredv2/outside/admin_building)
 "be" = (
 /obj/structure/pipes/standard/manifold/hidden/green{
 	dir = 8
 	},
 /turf/open/floor{
-	icon_state = "darkred2";
-	dir = 8
+	dir = 8;
+	icon_state = "darkred2"
 	},
 /area/bigredv2/outside/admin_building)
 "bf" = (
@@ -409,8 +328,8 @@
 	dir = 4
 	},
 /turf/open/floor{
-	icon_state = "darkred2";
-	dir = 4
+	dir = 4;
+	icon_state = "darkred2"
 	},
 /area/bigredv2/outside/admin_building)
 "bh" = (
@@ -429,43 +348,28 @@
 	num_of_magazines = 1
 	},
 /turf/open/floor{
-	icon_state = "carpet5-1";
-	dir = 8
-	},
-/area/bigredv2/outside/admin_building)
-"bj" = (
-/turf/open/floor{
-	icon_state = "carpet13-5";
-	dir = 8
-	},
-/area/bigredv2/outside/admin_building)
-"bk" = (
-/turf/open/floor{
-	icon_state = "carpet9-4";
-	dir = 8
+	icon_state = "wood"
 	},
 /area/bigredv2/outside/admin_building)
 "bl" = (
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 5
+/turf/open/floor{
+	icon_state = "wood"
 	},
-/turf/open/floor,
 /area/bigredv2/outside/admin_building)
 "bm" = (
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 4
-	},
-/obj/structure/machinery/door/airlock/almayer/command/colony{
-	name = "\improper Operations Meeting Room"
-	},
-/turf/open/floor,
-/area/bigredv2/outside/admin_building)
-"bn" = (
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 9
+/obj/structure/pipes/standard/simple/hidden/green,
+/obj/structure/machinery/light{
+	dir = 8
 	},
 /turf/open/floor{
-	icon_state = "dark"
+	dir = 8;
+	icon_state = "darkred2"
+	},
+/area/bigredv2/outside/admin_building)
+"bn" = (
+/turf/open/floor{
+	dir = 10;
+	icon_state = "darkred2"
 	},
 /area/bigredv2/outside/admin_building)
 "bo" = (
@@ -476,30 +380,21 @@
 	pixel_x = 30
 	},
 /turf/open/floor{
-	icon_state = "darkred2";
-	dir = 4
+	dir = 6;
+	icon_state = "darkred2"
 	},
 /area/bigredv2/outside/admin_building)
 "bp" = (
 /obj/structure/machinery/vending/coffee,
 /turf/open/floor,
 /area/bigredv2/outside/admin_building)
-"bq" = (
-/turf/open/floor{
-	icon_state = "darkred2";
-	dir = 10
-	},
-/area/bigredv2/outside/admin_building)
-"br" = (
-/turf/open/floor{
-	icon_state = "darkred2"
-	},
-/area/bigredv2/outside/admin_building)
 "bs" = (
-/turf/open/floor{
-	icon_state = "darkred2";
-	dir = 6
+/obj/structure/window/framed/solaris/reinforced,
+/obj/structure/machinery/door/poddoor/shutters/almayer{
+	id = "Operations";
+	name = "\improper Operations Shutters"
 	},
+/turf/open/floor/plating,
 /area/bigredv2/outside/admin_building)
 "dp" = (
 /obj/item/ammo_magazine/rifle/rubber{
@@ -507,28 +402,24 @@
 	pixel_x = -6;
 	pixel_y = -4
 	},
-/turf/open/floor{
-	icon_state = "carpet15-15";
-	dir = 8
-	},
+/turf/open/floor/carpet,
 /area/bigredv2/outside/admin_building)
 "is" = (
 /obj/item/ammo_magazine/pistol/rubber{
 	current_rounds = 0
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "wood"
+	},
 /area/bigredv2/outside/admin_building)
 "jq" = (
 /obj/item/weapon/gun/rifle/m41a/corporate{
 	current_mag = /obj/item/ammo_magazine/rifle/rubber;
+	desc = "A Weyland-Yutani creation, this M41A MK2 comes equipped in corporate white. Uses 10x24mm caseless ammunition. It seems to be pretty battered and broken up.";
 	name = "battered M41A pulse rifle MK2";
-	pixel_x = 4;
-	desc = "A Weyland-Yutani creation, this M41A MK2 comes equipped in corporate white. Uses 10x24mm caseless ammunition. It seems to be pretty battered and broken up."
+	pixel_x = 4
 	},
-/turf/open/floor{
-	icon_state = "carpet15-15";
-	dir = 8
-	},
+/turf/open/floor/carpet,
 /area/bigredv2/outside/admin_building)
 "lz" = (
 /obj/item/ammo_magazine/rifle/rubber{
@@ -536,8 +427,7 @@
 	pixel_y = 11
 	},
 /turf/open/floor{
-	icon_state = "carpet7-3";
-	dir = 8
+	icon_state = "wood"
 	},
 /area/bigredv2/outside/admin_building)
 "rv" = (
@@ -545,8 +435,7 @@
 	current_rounds = 0
 	},
 /turf/open/floor{
-	icon_state = "carpet7-3";
-	dir = 8
+	icon_state = "wood"
 	},
 /area/bigredv2/outside/admin_building)
 "si" = (
@@ -564,15 +453,52 @@
 	pixel_y = 17
 	},
 /turf/open/floor{
-	icon_state = "carpet13-5";
-	dir = 8
+	icon_state = "wood"
 	},
 /area/bigredv2/outside/admin_building)
 "uv" = (
 /obj/item/ammo_magazine/rifle{
 	current_rounds = 0;
-	pixel_y = 7;
-	pixel_x = -9
+	pixel_x = -9;
+	pixel_y = 7
+	},
+/turf/open/floor{
+	icon_state = "wood"
+	},
+/area/bigredv2/outside/admin_building)
+"vH" = (
+/obj/structure/platform{
+	dir = 8
+	},
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/bigredv2/outside/admin_building)
+"vO" = (
+/obj/structure/platform{
+	dir = 4
+	},
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/bigredv2/outside/admin_building)
+"yf" = (
+/obj/structure/platform_decoration{
+	dir = 4
+	},
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/bigredv2/outside/admin_building)
+"za" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/obj/structure/machinery/door/airlock/almayer/command/colony{
+	name = "\improper Operations Meeting Room"
+	},
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
 	},
 /turf/open/floor,
 /area/bigredv2/outside/admin_building)
@@ -580,17 +506,25 @@
 /obj/item/ammo_magazine/pistol/rubber{
 	current_rounds = 0
 	},
-/turf/open/floor{
-	icon_state = "carpet15-15";
-	dir = 8
-	},
+/turf/open/floor/carpet,
 /area/bigredv2/outside/admin_building)
 "Br" = (
 /obj/structure/surface/table,
 /obj/item/storage/firstaid/regular/empty,
+/turf/open/floor/carpet,
+/area/bigredv2/outside/admin_building)
+"ND" = (
+/obj/structure/pipes/standard/manifold/hidden/green,
 /turf/open/floor{
-	icon_state = "carpet15-15";
-	dir = 8
+	icon_state = "dark"
+	},
+/area/bigredv2/outside/admin_building)
+"Pk" = (
+/obj/structure/platform{
+	dir = 1
+	},
+/turf/open/floor{
+	icon_state = "dark"
 	},
 /area/bigredv2/outside/admin_building)
 "QR" = (
@@ -600,7 +534,9 @@
 /obj/item/ammo_magazine/pistol/rubber{
 	current_rounds = 0
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "wood"
+	},
 /area/bigredv2/outside/admin_building)
 "Sz" = (
 /obj/item/ammo_magazine/rifle/rubber{
@@ -608,14 +544,11 @@
 	pixel_x = 5;
 	pixel_y = -5
 	},
-/turf/open/floor{
-	icon_state = "carpet15-15";
-	dir = 8
-	},
+/turf/open/floor/carpet,
 /area/bigredv2/outside/admin_building)
 
 (1,1,1) = {"
-ab
+aj
 ab
 ab
 ab
@@ -627,12 +560,12 @@ ab
 ab
 "}
 (2,1,1) = {"
-ac
+aj
 aD
 ar
 aA
 lz
-aI
+bl
 rv
 aZ
 bi
@@ -646,7 +579,7 @@ AC
 aJ
 aO
 aJ
-as
+aQ
 si
 bp
 "}
@@ -659,23 +592,23 @@ aK
 Br
 aV
 ba
-bj
+bl
 uv
 "}
 (5,1,1) = {"
 aj
-ak
+ae
 jq
 aC
-as
+aQ
 aC
 Sz
 bb
-bj
-aR
+bl
+bl
 "}
 (6,1,1) = {"
-ad
+ay
 al
 au
 aW
@@ -683,12 +616,12 @@ aL
 aS
 aQ
 bc
-bk
+bl
 is
 "}
 (7,1,1) = {"
-ad
-am
+aj
+ae
 av
 aP
 aP
@@ -696,35 +629,35 @@ QR
 aP
 bd
 bl
-aR
+bl
 "}
 (8,1,1) = {"
-ae
 aj
-aj
-ad
+ae
+ae
 ad
 ad
 ad
 ae
-bm
+za
+ae
 ae
 "}
 (9,1,1) = {"
 af
-an
+bm
 an
 be
 aM
 an
 aX
-be
+ND
 bn
-bq
+bs
 "}
 (10,1,1) = {"
 ag
-ay
+vO
 aw
 bf
 ay
@@ -732,12 +665,12 @@ aT
 ay
 bf
 ay
-br
+bs
 "}
 (11,1,1) = {"
-ay
+am
 ap
-ay
+Pk
 aG
 aN
 aU
@@ -748,8 +681,8 @@ bs
 "}
 (12,1,1) = {"
 ai
-ay
-ay
+vH
+yf
 aH
 ae
 ae

--- a/maps/map_files/BigRed/standalone/medbay-passage.dmm
+++ b/maps/map_files/BigRed/standalone/medbay-passage.dmm
@@ -61,6 +61,31 @@
 "m" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/oil,
+/obj/structure/stairs/perspective{
+	dir = 5;
+	icon_state = "p_stair_full"
+	},
+/turf/open/floor{
+	dir = 1;
+	icon_state = "asteroidfloor"
+	},
+/area/bigredv2/outside/c)
+"n" = (
+/obj/structure/stairs/perspective{
+	dir = 9;
+	icon_state = "p_stair_full"
+	},
+/turf/open/floor{
+	dir = 1;
+	icon_state = "asteroidfloor"
+	},
+/area/bigredv2/outside/c)
+"w" = (
+/obj/structure/pipes/standard/simple/hidden/green,
+/obj/structure/stairs/perspective{
+	dir = 1;
+	icon_state = "p_stair_full"
+	},
 /turf/open/floor{
 	dir = 1;
 	icon_state = "asteroidfloor"
@@ -83,6 +108,16 @@
 	icon_state = "white"
 	},
 /area/bigredv2/outside/admin_building)
+"X" = (
+/obj/structure/stairs/perspective{
+	dir = 1;
+	icon_state = "p_stair_full"
+	},
+/turf/open/floor{
+	dir = 1;
+	icon_state = "asteroidfloor"
+	},
+/area/bigredv2/outside/c)
 
 (1,1,1) = {"
 a
@@ -97,7 +132,7 @@ a
 a
 c
 h
-l
+n
 R
 "}
 (3,1,1) = {"
@@ -105,7 +140,7 @@ a
 a
 d
 i
-d
+w
 S
 "}
 (4,1,1) = {"
@@ -113,7 +148,7 @@ a
 a
 e
 l
-l
+X
 T
 "}
 (5,1,1) = {"


### PR DESCRIPTION

# About the pull request

This (hopefully) string of PRs aims to re-detail areas of big red that visually don't have a lot going on, such as breaking up copy-pasted bedrooms, adding dirt and grime floor decals, and placing props / adding new ways into underused areas 

This PR focuses entirely on colony admin and the nightmare inserts in it I've added to that funny little middle room that no one goes into to hopefully make it more seen and used and widened some hallways, of course, some minor retailing and honestly not much else 

# Explain why it's good for the game

Honestly feel like Big Red is one of the maps in most need of a glow up, it can get pretty barebones in places and has a lot of underused rooms I'm not aiming to rework the entire map just small additions piece by piece because the last time I did this I did it all at once and my map file corrupted trying to fix merge conflicts

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: SpartanBobby
maptweak: Alot of changes to big reds admin area, including new windows, prop placement, room detailing, new doors
/:cl:
