### PR TITLE
Replaces tricord autoinjector with pill packet

### DIFF
--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -211,7 +211,7 @@
 	new /obj/item/reagent_container/hypospray/autoinjector/emergency(src)
 
 /obj/item/storage/pouch/firstaid/full/alternate/fill_preset_inventory()
-	new /obj/item/reagent_container/hypospray/autoinjector/tricord(src)
+	new /obj/item/storage/pill_bottle/packet/tricordrazine(src)
 	new /obj/item/stack/medical/splint(src)
 	new /obj/item/stack/medical/ointment(src)
 	new /obj/item/stack/medical/bruise_pack(src)


### PR DESCRIPTION

# About the pull request
one of the first aid pouches still uses a skilled version of a autoinjector, which for PFCs got replaced with E-Z autoinjectors, which leads me to belive this was overlooked so to remedy that im changing the autoinjector it comes with to a pill packet, 

<!-- Remove this text and explain what the purpose of your PR is.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

Skilled tricord < skillless pill packet

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Changes the tricordrazine autoinjector to a tricordrazine pill packet in one of the first aid pouches

/:cl:
