### PR TITLE
Pill packets fit in helmets now

### DIFF
--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -338,7 +338,7 @@ GLOBAL_LIST_INIT(allowed_helmet_items, list(
 	/obj/item/stack/medical/ointment = "ointment",
 	/obj/item/tool/surgery/scalpel = "scalpel",
 	/obj/item/reagent_container/hypospray/autoinjector = "helmet_injector",
-	/obj/item/storage/pill_bottle/packet ="brutepack (bandages)",
+	/obj/item/storage/pill_bottle/packet = "brutepack (bandages)",
 ))
 
 /obj/item/clothing/head/helmet/marine

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -337,7 +337,8 @@ GLOBAL_LIST_INIT(allowed_helmet_items, list(
 	/obj/item/stack/medical/bruise_pack ="brutepack (bandages)",
 	/obj/item/stack/medical/ointment = "ointment",
 	/obj/item/tool/surgery/scalpel = "scalpel",
-	/obj/item/reagent_container/hypospray/autoinjector = "helmet_injector"
+	/obj/item/reagent_container/hypospray/autoinjector = "helmet_injector",
+	/obj/item/storage/pill_bottle/packet ="brutepack (bandages)",
 ))
 
 /obj/item/clothing/head/helmet/marine


### PR DESCRIPTION
# About the pull request

Makes it so you can put pill packets in your helmet since i didnt know how to originally, for now im only doing this for the helmet, but over the next week or so ill be making it so they can fit in all the marine hats that can fit autoinjectors 

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

Pill packets shouldve been able to be placed in your helmet, i didnt know how to do this when they were added, this remedies that
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

testing consisted of joining a private server and seeing if they fit in helmets 
# Changelog
:cl:
balance: Makes it so that Pill packets fit in helmets
/:cl:
