### PR TITLE
LV-624 Cave Aesthetic Change

### DIFF
--- a/code/game/objects/effects/decals/warning_stripes.dm
+++ b/code/game/objects/effects/decals/warning_stripes.dm
@@ -91,6 +91,20 @@
 /obj/effect/decal/sand_overlay/sand2/corner2
 	icon_state = "sand2_c"
 
+/obj/effect/decal/grass_overlay
+	name = "grass edge"
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+	unacidable = TRUE
+	icon = 'icons/turf/floors/auto_strata_grass.dmi'
+	layer = TURF_LAYER
+
+/obj/effect/decal/grass_overlay/grass1
+	icon_state = "grass_outercorner"
+
+/obj/effect/decal/grass_overlay/grass1/inner
+	name = "grass edge"
+	icon_state = "grass_innercorner"
+
 /obj/effect/decal/siding
 	name = "siding"
 	icon = 'icons/turf/floors/floors.dmi'

--- a/maps/map_files/LV624/LV624.dmm
+++ b/maps/map_files/LV624/LV624.dmm
@@ -283,6 +283,9 @@
 /area/lv624/ground/caves/west_caves)
 "abH" = (
 /obj/effect/landmark/good_item,
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 8
+	},
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/west_caves)
 "abI" = (
@@ -398,7 +401,7 @@
 "aco" = (
 /obj/effect/landmark/crap_item,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
-/turf/open/gm/dirt,
+/turf/open/auto_turf/strata_grass/layer1,
 /area/lv624/ground/caves/south_east_caves)
 "acp" = (
 /turf/closed/wall/cult,
@@ -506,7 +509,7 @@
 /obj/structure/tunnel{
 	id = "hole1"
 	},
-/turf/open/gm/dirt,
+/turf/open/auto_turf/strata_grass/layer1,
 /area/lv624/ground/caves/west_caves)
 "acL" = (
 /obj/item/tool/shovel,
@@ -581,6 +584,9 @@
 /area/lv624/lazarus/crashed_ship_containers)
 "acY" = (
 /obj/effect/landmark/hunter_primary,
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 10
+	},
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/south_central_caves)
 "acZ" = (
@@ -2581,6 +2587,13 @@
 /obj/structure/flora/jungle/alienplant1,
 /turf/open/gm/river,
 /area/lv624/ground/river/west_river)
+"amI" = (
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 9
+	},
+/obj/structure/flora/bush/ausbushes/ausbush,
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/west_caves)
 "amK" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/gm/dirtgrassborder/grassdirt_corner2/south_east,
@@ -2708,6 +2721,10 @@
 	icon_state = "whiteyellowcorner"
 	},
 /area/lv624/lazarus/corporate_dome)
+"anM" = (
+/obj/structure/flora/bush/ausbushes/var3/sparsegrass,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/north_east_caves)
 "anP" = (
 /obj/structure/flora/bush/ausbushes/ppflowers,
 /turf/open/gm/grass/grass1,
@@ -7923,6 +7940,12 @@
 /obj/effect/landmark/monkey_spawn,
 /turf/open/gm/dirtgrassborder/south,
 /area/lv624/ground/jungle/west_jungle)
+"aIA" = (
+/obj/item/reagent_container/food/snacks/grown/mushroom/plumphelmet{
+	pixel_x = 8
+	},
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_central_caves)
 "aIB" = (
 /obj/structure/closet,
 /turf/open/floor{
@@ -7930,6 +7953,17 @@
 	icon_state = "purple"
 	},
 /area/lv624/lazarus/sleep_female)
+"aIE" = (
+/obj/structure/flora/bush/ausbushes/var3/stalkybush,
+/obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
+	pixel_x = 11;
+	pixel_y = -2;
+	light_on = 1;
+	light_range = 1;
+	light_system = 1
+	},
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_west_caves)
 "aIH" = (
 /obj/structure/surface/table/woodentable/poor,
 /obj/item/clothing/mask/cigarette/cigar,
@@ -9532,6 +9566,14 @@
 	icon_state = "chapel"
 	},
 /area/lv624/lazarus/chapel)
+"aPM" = (
+/obj/effect/landmark/structure_spawner/xvx_hive/xeno_wall,
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 4
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/north_east_caves)
 "aPN" = (
 /obj/structure/window_frame/colony/reinforced,
 /turf/open/floor/plating,
@@ -10445,6 +10487,12 @@
 /obj/item/shard,
 /turf/open/floor/plating,
 /area/lv624/lazarus/captain)
+"aTy" = (
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 4
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/barrens/north_east_barrens)
 "aTB" = (
 /obj/structure/machinery/light/small,
 /turf/open/floor{
@@ -11911,6 +11959,11 @@
 	icon_state = "red"
 	},
 /area/lv624/lazarus/security)
+"aYI" = (
+/turf/open/gm/dirt{
+	icon_state = "desert0"
+	},
+/area/lv624/ground/caves/south_west_caves)
 "aYJ" = (
 /obj/structure/surface/table/woodentable/fancy,
 /obj/item/trash/chips,
@@ -12266,6 +12319,13 @@
 /obj/structure/flora/bush/ausbushes/var3/fullgrass,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/east_central_jungle)
+"bak" = (
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 5
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/north_west_caves)
 "bav" = (
 /obj/effect/decal/cleanable/blood/gibs/xeno/up,
 /turf/open/gm/dirt,
@@ -12344,6 +12404,29 @@
 /obj/structure/flora/jungle/vines/light_2,
 /turf/open/gm/grass/grass2,
 /area/lv624/ground/jungle/west_central_jungle)
+"bcb" = (
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 6
+	},
+/obj/structure/flora/bush/ausbushes/ppflowers,
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/west_caves)
+"bcU" = (
+/obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
+	pixel_x = -10;
+	pixel_y = -2;
+	light_on = 1;
+	light_range = 1;
+	light_system = 1
+	},
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_east_caves)
+"bdu" = (
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 8
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/north_west_caves)
 "bdL" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/stack/sheet/metal{
@@ -12414,9 +12497,21 @@
 /obj/structure/machinery/colony_floodlight,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/north_east_jungle)
+"bje" = (
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 9
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_central_caves)
 "bkG" = (
 /turf/open/gm/coast/beachcorner/north_west,
 /area/lv624/ground/river/central_river)
+"bkK" = (
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 9
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_east_caves)
 "bkP" = (
 /obj/structure/flora/jungle/vines/light_3,
 /obj/structure/blocker/forcefield/multitile_vehicles,
@@ -12444,6 +12539,12 @@
 /obj/structure/flora/bush/ausbushes/pointybush,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/north_west_jungle)
+"bnM" = (
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 5
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/central_caves)
 "bnX" = (
 /obj/structure/flora/bush/ausbushes/reedbush,
 /turf/open/gm/coast/beachcorner/south_west,
@@ -12476,6 +12577,10 @@
 /obj/structure/flora/jungle/vines/light_1,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/north_west_jungle)
+"brC" = (
+/obj/effect/landmark/objective_landmark/close,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_central_caves)
 "bsR" = (
 /turf/open/gm/dirtgrassborder/grassdirt_corner/south_west,
 /area/lv624/ground/jungle/south_west_jungle)
@@ -12548,6 +12653,17 @@
 /obj/structure/flora/jungle/plantbot1,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/colony/south_medbay_road)
+"bvj" = (
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/east_caves)
+"bvS" = (
+/obj/structure/flora/bush/ausbushes/var3/ywflowers,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/north_east_caves)
+"bvX" = (
+/obj/structure/flora/bush/ausbushes/ppflowers,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/central_caves)
 "bwc" = (
 /turf/open/gm/coast/beachcorner2/north_east,
 /area/lv624/ground/barrens/west_barrens)
@@ -12558,6 +12674,12 @@
 /obj/structure/machinery/colony_floodlight,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/west_central_jungle)
+"bxb" = (
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 5
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/barrens/north_east_barrens)
 "byl" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/gm/dirtgrassborder/grassdirt_corner2/south_east,
@@ -12601,6 +12723,14 @@
 "bBu" = (
 /turf/open/gm/coast/beachcorner2/south_west,
 /area/lv624/ground/jungle/west_jungle)
+"bBT" = (
+/obj/effect/landmark/structure_spawner/xvx_hive/xeno_door,
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 8
+	},
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_central_caves)
 "bCe" = (
 /turf/open/gm/dirtgrassborder/grassdirt_corner/south_west,
 /area/lv624/ground/jungle/south_east_jungle)
@@ -12614,6 +12744,14 @@
 	},
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/south_east_jungle)
+"bEj" = (
+/obj/effect/landmark/structure_spawner/xvx_hive/xeno_wall,
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 10
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/east_caves)
 "bEq" = (
 /turf/open/gm/dirtgrassborder/north,
 /area/lv624/ground/barrens/south_eastern_barrens)
@@ -12667,6 +12805,12 @@
 /obj/effect/landmark/corpsespawner/wygoon,
 /turf/open/floor/wood,
 /area/lv624/ground/caves/north_central_caves)
+"bJQ" = (
+/obj/effect/landmark/structure_spawner/xvx_hive/xeno_door,
+/obj/structure/blocker/forcefield/multitile_vehicles,
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_west_caves)
 "bLs" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_membrane,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_membrane,
@@ -12703,6 +12847,15 @@
 	},
 /turf/open/gm/dirt,
 /area/lv624/ground/barrens/south_eastern_barrens)
+"bOm" = (
+/obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
+	pixel_x = 4;
+	light_on = 1;
+	light_range = 1;
+	light_system = 1
+	},
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/barrens/north_east_barrens)
 "bOy" = (
 /obj/structure/machinery/door/airlock/almayer/engineering/colony{
 	dir = 1;
@@ -12717,6 +12870,17 @@
 	},
 /turf/open/gm/grass/grass2,
 /area/lv624/ground/jungle/north_east_jungle)
+"bPE" = (
+/obj/structure/flora/bush/ausbushes/pointybush,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/north_west_caves)
+"bQz" = (
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 10
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_east_caves)
 "bQA" = (
 /obj/structure/stairs/perspective{
 	color = "#b29082";
@@ -12828,6 +12992,10 @@
 	icon_state = "white"
 	},
 /area/lv624/lazarus/medbay)
+"cdw" = (
+/obj/effect/landmark/objective_landmark/science,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_west_caves)
 "cdF" = (
 /obj/effect/landmark/nightmare{
 	insert_tag = "lv-centralcaves"
@@ -12843,6 +13011,11 @@
 "cfD" = (
 /turf/closed/wall/r_wall/unmeltable,
 /area/lv624/lazarus/quartstorage/outdoors)
+"cfL" = (
+/obj/effect/landmark/structure_spawner/xvx_hive/xeno_wall,
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
+/turf/open/gm/grass/grass1/weedable,
+/area/lv624/ground/caves/north_east_caves)
 "cfN" = (
 /turf/open/gm/dirtgrassborder/grassdirt_corner/south_east,
 /area/lv624/ground/jungle/north_jungle)
@@ -12885,6 +13058,16 @@
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_core,
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/west_caves)
+"chi" = (
+/obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
+	pixel_x = -10;
+	pixel_y = -2;
+	light_on = 1;
+	light_range = 1;
+	light_system = 1
+	},
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_west_caves)
 "cij" = (
 /obj/structure/flora/jungle/vines/heavy,
 /turf/open/gm/dirtgrassborder/grassdirt_corner2/north_east,
@@ -12914,6 +13097,13 @@
 	},
 /turf/open/floor/sandstone/runed,
 /area/lv624/ground/caves/sand_temple)
+"clO" = (
+/obj/effect/landmark/crap_item,
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 4
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/west_caves)
 "cmf" = (
 /obj/structure/flora/jungle/planttop1,
 /turf/open/gm/grass/grass1,
@@ -12936,6 +13126,12 @@
 	icon_state = "squareswood"
 	},
 /area/lv624/ground/caves/sand_temple)
+"cop" = (
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 9
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/east_caves)
 "cpQ" = (
 /turf/open/gm/dirtgrassborder/north,
 /area/lv624/ground/caves/sand_temple)
@@ -12954,6 +13150,14 @@
 /obj/structure/flora/jungle/vines/light_1,
 /turf/closed/wall/strata_ice/jungle,
 /area/lv624/ground/jungle/north_west_jungle)
+"cqC" = (
+/obj/effect/landmark/structure_spawner/xvx_hive/xeno_door,
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 8
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/north_east_caves)
 "cqE" = (
 /obj/structure/barricade/wooden,
 /obj/structure/flora/jungle/vines/light_2,
@@ -12962,6 +13166,23 @@
 	icon_state = "warning"
 	},
 /area/lv624/lazarus/landing_zones/lz1)
+"cqH" = (
+/obj/item/reagent_container/food/snacks/grown/mushroom/chanterelle,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/central_caves)
+"cqN" = (
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 9
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/central_caves)
+"crn" = (
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 1
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/barrens/north_east_barrens)
 "crF" = (
 /obj/structure/flora/bush/ausbushes/var3/fernybush,
 /obj/structure/flora/jungle/vines/heavy,
@@ -12994,13 +13215,17 @@
 	icon_state = "desert_dug"
 	},
 /area/lv624/ground/barrens/west_barrens)
+"cxi" = (
+/obj/structure/flora/bush/ausbushes/var3/brflowers,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_central_caves)
 "cys" = (
 /obj/structure/foamed_metal,
 /turf/open/gm/dirtgrassborder/south,
 /area/lv624/ground/jungle/east_central_jungle)
 "czq" = (
 /obj/effect/landmark/objective_landmark/science,
-/turf/open/gm/dirt,
+/turf/open/auto_turf/strata_grass/layer1,
 /area/lv624/ground/caves/central_caves)
 "czu" = (
 /obj/structure/flora/bush/ausbushes/var3/leafybush,
@@ -13048,6 +13273,11 @@
 "cCr" = (
 /turf/open/gm/dirtgrassborder/south,
 /area/lv624/ground/jungle/east_jungle)
+"cCP" = (
+/turf/open/gm/dirt{
+	icon_state = "desert1"
+	},
+/area/lv624/ground/caves/south_west_caves)
 "cDr" = (
 /obj/structure/girder,
 /turf/open/gm/grass/grass1,
@@ -13072,6 +13302,12 @@
 /obj/structure/flora/bush/ausbushes/pointybush,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/north_east_jungle)
+"cEi" = (
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 9
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/barrens/north_east_barrens)
 "cEn" = (
 /obj/effect/decal/remains/xeno,
 /turf/open/gm/dirt,
@@ -13084,6 +13320,12 @@
 /obj/structure/flora/bush/ausbushes/var3/fullgrass,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/north_west_jungle)
+"cHW" = (
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 9
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/west_caves)
 "cIL" = (
 /obj/structure/flora/jungle/vines/heavy,
 /turf/open/gm/grass/grass1,
@@ -13096,6 +13338,9 @@
 /obj/structure/blocker/forcefield/multitile_vehicles,
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_door,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 6
+	},
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/south_central_caves)
 "cJw" = (
@@ -13131,6 +13376,12 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/wall/strata_ice/jungle,
 /area/lv624/ground/river/west_river)
+"cMG" = (
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 9
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/north_west_caves)
 "cNH" = (
 /obj/structure/surface/rack,
 /obj/item/storage/box/beakers,
@@ -13156,6 +13407,10 @@
 "cPV" = (
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/west_central_jungle)
+"cQB" = (
+/obj/item/reagent_container/food/snacks/grown/mushroom/amanita,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/west_caves)
 "cQJ" = (
 /obj/structure/machinery/colony_floodlight,
 /turf/open/gm/grass/grass1,
@@ -13181,6 +13436,12 @@
 /obj/item/tool/surgery/surgicaldrill/predatorsurgicaldrill,
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/sand_temple)
+"cSL" = (
+/obj/item/reagent_container/food/snacks/grown/mushroom/plumphelmet{
+	pixel_x = 8
+	},
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/central_caves)
 "cTi" = (
 /obj/structure/flora/jungle/vines/light_2,
 /turf/open/gm/grass/grass1,
@@ -13202,6 +13463,10 @@
 	},
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/colony/west_nexus_road)
+"cWs" = (
+/obj/structure/flora/bush/ausbushes/var3/sunnybush,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/north_west_caves)
 "cXd" = (
 /obj/effect/landmark/monkey_spawn,
 /obj/structure/flora/jungle/vines/heavy,
@@ -13229,6 +13494,14 @@
 /obj/structure/blocker/forcefield/multitile_vehicles,
 /turf/closed/wall/mineral/sandstone/runed,
 /area/lv624/ground/caves/sand_temple)
+"daY" = (
+/obj/effect/landmark/structure_spawner/xvx_hive/xeno_membrane,
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_membrane,
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 9
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_central_caves)
 "dbA" = (
 /obj/structure/xenoautopsy/tank,
 /turf/open/shuttle{
@@ -13265,7 +13538,7 @@
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_nest,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_nest,
 /obj/effect/landmark/corpsespawner/scientist,
-/turf/open/gm/dirt,
+/turf/open/auto_turf/strata_grass/layer1,
 /area/lv624/ground/caves/east_caves)
 "dhp" = (
 /obj/structure/flora/bush/ausbushes/reedbush,
@@ -13316,9 +13589,18 @@
 /obj/structure/flora/jungle/vines/light_3,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/north_west_jungle)
+"dmT" = (
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/west_caves)
 "dmZ" = (
 /turf/open/gm/grass/grass2,
 /area/lv624/ground/jungle/north_east_jungle)
+"doe" = (
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 5
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_west_caves)
 "dop" = (
 /obj/structure/flora/jungle/planttop1,
 /turf/open/gm/grass/grass1,
@@ -13376,6 +13658,13 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
+"dtr" = (
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 10
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/east_caves)
 "dvf" = (
 /obj/structure/flora/bush/ausbushes/var3/sparsegrass,
 /turf/open/gm/grass/grass1,
@@ -13438,6 +13727,31 @@
 	},
 /turf/open/gm/dirtgrassborder/grassdirt_corner2/north_east,
 /area/lv624/ground/caves/sand_temple)
+"dzM" = (
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 1
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/north_east_caves)
+"dAu" = (
+/obj/effect/landmark/crap_item,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_central_caves)
+"dBS" = (
+/obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
+	pixel_x = -10;
+	light_on = 1;
+	light_range = 1;
+	light_system = 1
+	},
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/north_west_caves)
+"dCD" = (
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 9
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/barrens/north_east_barrens)
 "dCL" = (
 /obj/item/reagent_container/food/drinks/cans/waterbottle{
 	pixel_x = 2
@@ -13482,6 +13796,9 @@
 "dFz" = (
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_membrane,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 10
+	},
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/west_caves)
 "dGc" = (
@@ -13495,6 +13812,10 @@
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/central_caves)
+"dHg" = (
+/obj/structure/flora/bush/ausbushes/var3/stalkybush,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/north_east_caves)
 "dHo" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/gm/dirtgrassborder/grassdirt_corner/south_east,
@@ -13505,6 +13826,18 @@
 	icon_state = "whiteblue"
 	},
 /area/lv624/lazarus/medbay)
+"dIj" = (
+/obj/structure/flora/bush/ausbushes/reedbush,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/north_west_caves)
+"dIu" = (
+/obj/structure/flora/bush/ausbushes/genericbush,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_west_caves)
+"dIv" = (
+/obj/structure/flora/bush/ausbushes/var3/leafybush,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/north_east_caves)
 "dID" = (
 /obj/effect/landmark/objective_landmark/science,
 /turf/open/floor/strata{
@@ -13526,6 +13859,10 @@
 "dKg" = (
 /turf/open/gm/dirtgrassborder/east,
 /area/lv624/ground/barrens/south_eastern_jungle_barrens)
+"dKl" = (
+/obj/structure/flora/bush/ausbushes/var3/fullgrass,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/west_caves)
 "dLd" = (
 /obj/structure/bookcase,
 /obj/item/book/manual/research_and_development,
@@ -13537,6 +13874,13 @@
 	icon_state = "whiteblue"
 	},
 /area/lv624/lazarus/corporate_dome)
+"dLm" = (
+/obj/structure/blocker/forcefield/multitile_vehicles,
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 8
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/central_caves)
 "dLn" = (
 /obj/effect/acid_hole,
 /turf/closed/wall/r_wall,
@@ -13547,6 +13891,12 @@
 	},
 /turf/open/gm/dirtgrassborder/grassdirt_corner/south_west,
 /area/lv624/ground/jungle/east_jungle)
+"dLW" = (
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 6
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/east_caves)
 "dLY" = (
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/east_jungle)
@@ -13578,11 +13928,19 @@
 	},
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/east_jungle)
+"dOb" = (
+/obj/item/reagent_container/food/snacks/grown/mushroom/angel,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_west_caves)
 "dOf" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/landmark/crap_item,
 /turf/open/gm/dirt,
 /area/lv624/lazarus/crashed_ship_containers)
+"dOA" = (
+/obj/structure/flora/bush/ausbushes/grassybush,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/west_caves)
 "dOC" = (
 /obj/structure/kitchenspike,
 /obj/effect/decal/cleanable/blood,
@@ -13641,12 +13999,18 @@
 /area/lv624/lazarus/crashed_ship_containers)
 "dWM" = (
 /obj/effect/landmark/monkey_spawn,
-/turf/open/gm/dirt,
+/turf/open/auto_turf/strata_grass/layer1,
 /area/lv624/ground/caves/south_west_caves)
 "dXq" = (
 /obj/structure/platform_decoration/mineral/sandstone/runed,
 /turf/open/gm/dirt,
 /area/lv624/ground/barrens/south_eastern_barrens)
+"dYx" = (
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 6
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_west_caves)
 "dYE" = (
 /obj/structure/fence,
 /turf/open/gm/dirt,
@@ -13670,6 +14034,14 @@
 /obj/effect/landmark/objective_landmark/close,
 /turf/open/floor/plating,
 /area/lv624/ground/barrens/central_barrens)
+"eaI" = (
+/obj/effect/landmark/structure_spawner/xvx_hive/xeno_wall,
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 1
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/north_east_caves)
 "eaJ" = (
 /obj/item/stack/sheet/wood{
 	amount = 2
@@ -13683,6 +14055,14 @@
 /obj/structure/fence,
 /turf/open/gm/dirtgrassborder/east,
 /area/lv624/ground/colony/south_nexus_road)
+"ecn" = (
+/obj/effect/landmark/structure_spawner/xvx_hive/xeno_wall,
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 4
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_east_caves)
 "ecy" = (
 /turf/closed/wall/sulaco,
 /area/lv624/lazarus/crashed_ship_containers)
@@ -13709,9 +14089,27 @@
 "efp" = (
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/colony/west_tcomms_road)
+"eft" = (
+/obj/effect/landmark/structure_spawner/xvx_hive/xeno_wall,
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 10
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/west_caves)
 "efX" = (
 /turf/open/gm/coast/east,
 /area/lv624/ground/river/east_river)
+"egc" = (
+/obj/structure/flora/bush/ausbushes/lavendergrass,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/north_east_caves)
+"egU" = (
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 10
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/east_caves)
 "ehy" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/generic{
 	name = "Hydroponics"
@@ -13743,6 +14141,14 @@
 /obj/structure/machinery/colony_floodlight,
 /turf/open/gm/grass/grass2,
 /area/lv624/ground/jungle/north_jungle)
+"ejp" = (
+/obj/effect/landmark/structure_spawner/xvx_hive/xeno_wall,
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 5
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/central_caves)
 "ejx" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/window/framed/colony,
@@ -13774,6 +14180,22 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
+"elp" = (
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 10
+	},
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 10
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/east_caves)
+"enn" = (
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 10
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/barrens/north_east_barrens)
 "eny" = (
 /obj/structure/flora/grass/tallgrass/jungle,
 /turf/open/gm/grass/grass1,
@@ -13788,6 +14210,10 @@
 	icon_state = "whitebluecorner"
 	},
 /area/lv624/lazarus/medbay)
+"eoW" = (
+/obj/structure/flora/bush/ausbushes/pointybush,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_west_caves)
 "epG" = (
 /obj/structure/showcase,
 /obj/structure/window/reinforced{
@@ -13817,6 +14243,10 @@
 	icon_state = "whitebluefull"
 	},
 /area/lv624/lazarus/medbay)
+"eqS" = (
+/obj/structure/flora/bush/ausbushes/var3/brflowers,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/north_east_caves)
 "erx" = (
 /turf/open/gm/coast/beachcorner/south_east,
 /area/lv624/ground/jungle/west_jungle)
@@ -13831,6 +14261,10 @@
 	icon_state = "cult"
 	},
 /area/lv624/ground/caves/south_west_caves)
+"etU" = (
+/obj/structure/flora/bush/ausbushes/var3/fernybush,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/east_caves)
 "euh" = (
 /obj/effect/landmark/objective_landmark/medium,
 /turf/open/gm/dirt,
@@ -13989,6 +14423,12 @@
 	icon_state = "floor4"
 	},
 /area/lv624/lazarus/crashed_ship_containers)
+"eMe" = (
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 8
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_east_caves)
 "eNK" = (
 /turf/open/gm/dirtgrassborder/grassdirt_corner/north_west,
 /area/lv624/ground/jungle/south_east_jungle)
@@ -14026,6 +14466,9 @@
 /obj/structure/largecrate/random,
 /turf/open/floor,
 /area/lv624/lazarus/landing_zones/lz1)
+"eQL" = (
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/barrens/north_east_barrens)
 "eSg" = (
 /obj/structure/flora/jungle/vines/heavy,
 /turf/closed/wall/strata_ice/jungle,
@@ -14046,6 +14489,10 @@
 	icon_state = "cult"
 	},
 /area/lv624/ground/caves/south_west_caves)
+"eYb" = (
+/obj/structure/flora/bush/ausbushes/var3/sunnybush,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/north_east_caves)
 "eYh" = (
 /obj/structure/surface/rack,
 /obj/effect/landmark/objective_landmark/close,
@@ -14059,6 +14506,10 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/gm/river,
 /area/lv624/ground/river/east_river)
+"eZg" = (
+/obj/item/reagent_container/food/snacks/grown/mushroom/amanita,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_west_caves)
 "eZC" = (
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_nest,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
@@ -14090,6 +14541,16 @@
 /obj/structure/flora/jungle/planttop1,
 /turf/closed/wall/strata_ice/jungle,
 /area/lv624/ground/jungle/east_jungle)
+"fcQ" = (
+/obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
+	pixel_x = -5;
+	pixel_y = -5;
+	light_on = 1;
+	light_range = 1;
+	light_system = 1
+	},
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_west_caves)
 "fdl" = (
 /turf/open/floor,
 /area/lv624/lazarus/hydroponics)
@@ -14196,12 +14657,25 @@
 	icon_state = "asteroidfloor"
 	},
 /area/lv624/lazarus/corporate_dome)
+"fmV" = (
+/obj/structure/flora/bush/ausbushes/ausbush,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/east_caves)
+"fmW" = (
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_west_caves)
 "fpn" = (
 /turf/open/gm/coast/beachcorner/north_east,
 /area/lv624/ground/barrens/east_barrens)
 "fqh" = (
 /turf/open/gm/dirtgrassborder/grassdirt_corner/south_west,
 /area/lv624/ground/jungle/east_jungle)
+"fqi" = (
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 5
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_central_caves)
 "fqM" = (
 /obj/structure/machinery/power/apc{
 	start_charge = 0
@@ -14211,6 +14685,12 @@
 	icon_state = "asteroidwarning"
 	},
 /area/lv624/ground/colony/telecomm/sw_lz2)
+"frV" = (
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 6
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/north_west_caves)
 "fsa" = (
 /obj/structure/surface/table,
 /turf/open/floor{
@@ -14218,6 +14698,12 @@
 	icon_state = "barber"
 	},
 /area/lv624/lazarus/kitchen)
+"fsc" = (
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 5
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/north_east_caves)
 "fsu" = (
 /obj/structure/machinery/light{
 	dir = 8
@@ -14313,10 +14799,18 @@
 	icon_state = "warning"
 	},
 /area/lv624/lazarus/landing_zones/lz1)
+"fDE" = (
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/central_caves)
 "fDO" = (
 /obj/structure/flora/jungle/alienplant1,
 /turf/open/gm/river,
 /area/lv624/ground/barrens/west_barrens)
+"fDT" = (
+/turf/open/gm/dirt{
+	icon_state = "desert_dug"
+	},
+/area/lv624/ground/caves/south_west_caves)
 "fEn" = (
 /obj/structure/flora/jungle/vines/light_1,
 /turf/open/gm/grass/grass1,
@@ -14357,6 +14851,11 @@
 	icon_state = "asteroidfloor"
 	},
 /area/lv624/ground/colony/telecomm/cargo)
+"fGn" = (
+/obj/effect/decal/grass_overlay/grass1,
+/obj/structure/flora/bush/ausbushes/pointybush,
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/east_caves)
 "fGO" = (
 /obj/structure/flora/bush/ausbushes/var3/ywflowers,
 /turf/open/gm/grass/grass1,
@@ -14391,12 +14890,24 @@
 /obj/structure/window/framed/colony/reinforced,
 /turf/open/floor,
 /area/lv624/lazarus/medbay)
+"fIW" = (
+/obj/effect/decal/grass_overlay/grass1,
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_east_caves)
 "fJQ" = (
 /obj/structure/flora/grass/tallgrass/jungle/corner{
 	dir = 1
 	},
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/colony/west_tcomms_road)
+"fKc" = (
+/obj/structure/flora/bush/ausbushes/ausbush,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_west_caves)
+"fLh" = (
+/obj/item/reagent_container/food/snacks/grown/mushroom/angel,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/west_caves)
 "fMl" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/generic{
 	dir = 1;
@@ -14422,6 +14933,14 @@
 "fQL" = (
 /turf/open/gm/coast/beachcorner2/south_east,
 /area/lv624/ground/river/west_river)
+"fRD" = (
+/obj/structure/flora/bush/ausbushes/ausbush,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/north_east_caves)
+"fRU" = (
+/obj/structure/flora/bush/ausbushes/genericbush,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/west_caves)
 "fSX" = (
 /turf/open/gm/grass/grass2,
 /area/lv624/ground/jungle/east_jungle)
@@ -14441,6 +14960,14 @@
 "fTM" = (
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/south_east_caves)
+"fTN" = (
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/north_west_caves)
+"fUj" = (
+/obj/structure/flora/bush/ausbushes/var3/stalkybush,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_east_caves)
 "fXr" = (
 /obj/effect/landmark/crap_item,
 /turf/open/gm/dirt,
@@ -14454,6 +14981,10 @@
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_membrane,
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/south_central_caves)
+"fYG" = (
+/obj/structure/flora/bush/ausbushes/ppflowers,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/east_caves)
 "fZO" = (
 /turf/open/gm/dirtgrassborder/east,
 /area/lv624/ground/jungle/north_west_jungle)
@@ -14487,6 +15018,16 @@
 /obj/structure/flora/bush/ausbushes/lavendergrass,
 /turf/open/gm/grass/grass2,
 /area/lv624/ground/jungle/south_central_jungle)
+"gcB" = (
+/obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
+	pixel_x = 6;
+	pixel_y = -8;
+	light_on = 1;
+	light_range = 1;
+	light_system = 1
+	},
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/central_caves)
 "gcI" = (
 /obj/effect/landmark/crap_item,
 /turf/open/shuttle{
@@ -14572,6 +15113,16 @@
 /obj/structure/flora/bush/ausbushes/lavendergrass,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/barrens/south_eastern_jungle_barrens)
+"gnt" = (
+/obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
+	pixel_x = -5;
+	pixel_y = -5;
+	light_on = 1;
+	light_range = 1;
+	light_system = 1
+	},
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/north_west_caves)
 "gnx" = (
 /turf/open/floor{
 	icon_state = "white"
@@ -14581,6 +15132,10 @@
 /obj/structure/fence,
 /turf/open/gm/dirtgrassborder/grassdirt_corner2/north_east,
 /area/lv624/ground/colony/north_nexus_road)
+"gos" = (
+/obj/structure/flora/bush/ausbushes/var3/fernybush,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_west_caves)
 "gpC" = (
 /obj/structure/flora/jungle/vines/light_2,
 /obj/structure/flora/jungle/vines/heavy,
@@ -14599,10 +15154,21 @@
 /obj/structure/flora/jungle/planttop1,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/north_jungle)
+"grW" = (
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 10
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/west_caves)
 "grZ" = (
 /obj/effect/landmark/objective_landmark/science,
 /turf/open/floor/plating,
 /area/lv624/ground/barrens/central_barrens)
+"gsq" = (
+/obj/effect/landmark/structure_spawner/xvx_hive/xeno_door,
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_east_caves)
 "gss" = (
 /obj/structure/largecrate/random/barrel/yellow,
 /turf/open/shuttle{
@@ -14642,6 +15208,17 @@
 /obj/structure/flora/jungle/vines/heavy,
 /turf/closed/wall/mineral/sandstone/runed/decor,
 /area/lv624/ground/jungle/south_west_jungle/ceiling)
+"gvm" = (
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 4
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/west_caves)
+"gvr" = (
+/obj/structure/flora/bush/ausbushes/var3/stalkybush,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/north_west_caves)
 "gwP" = (
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/west_caves)
@@ -14660,6 +15237,12 @@
 	},
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/south_central_jungle)
+"gze" = (
+/obj/effect/landmark/structure_spawner/xvx_hive/xeno_wall,
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
+/obj/effect/decal/grass_overlay/grass1,
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/north_east_caves)
 "gzo" = (
 /turf/open/gm/dirt{
 	icon_state = "desert3"
@@ -14671,6 +15254,10 @@
 	icon_state = "dark"
 	},
 /area/lv624/lazarus/quartstorage)
+"gzH" = (
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/north_east_caves)
 "gzW" = (
 /obj/effect/landmark/hunter_secondary,
 /turf/open/gm/dirt,
@@ -14746,12 +15333,22 @@
 	},
 /turf/open/floor/sandstone/runed,
 /area/lv624/ground/caves/sand_temple)
+"gPu" = (
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 9
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/central_caves)
 "gPN" = (
 /turf/open/gm/dirtgrassborder/grassdirt_corner2/north_west,
 /area/lv624/ground/barrens/south_eastern_barrens)
 "gQr" = (
 /turf/open/gm/coast/beachcorner/south_east,
 /area/lv624/ground/caves/sand_temple)
+"gRk" = (
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/west_caves)
 "gRm" = (
 /obj/structure/flora/bush/ausbushes/ppflowers,
 /turf/open/gm/dirtgrassborder/north,
@@ -14759,6 +15356,12 @@
 "gRx" = (
 /turf/open/gm/dirtgrassborder/south,
 /area/lv624/ground/colony/south_medbay_road)
+"gTj" = (
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 8
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_west_caves)
 "gTu" = (
 /obj/structure/filingcabinet{
 	density = 0;
@@ -14791,6 +15394,18 @@
 "gUq" = (
 /turf/open/gm/dirtgrassborder/south,
 /area/lv624/ground/jungle/south_east_jungle)
+"gVw" = (
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 8
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_central_caves)
+"gVR" = (
+/obj/effect/landmark/structure_spawner/xvx_hive/xeno_wall,
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
+/obj/effect/decal/grass_overlay/grass1/inner,
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/east_caves)
 "gWf" = (
 /obj/structure/surface/rack,
 /obj/item/stack/sandbags/large_stack{
@@ -14806,6 +15421,12 @@
 	icon_state = "vault"
 	},
 /area/lv624/lazarus/quartstorage)
+"gWE" = (
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 10
+	},
+/turf/open/floor/sandstone/runed,
+/area/lv624/ground/caves/south_east_caves)
 "gWI" = (
 /obj/structure/flora/bush/ausbushes/var3/ywflowers,
 /turf/open/gm/grass/grass1,
@@ -14831,6 +15452,16 @@
 /obj/structure/prop/brazier,
 /turf/open/gm/dirtgrassborder/east,
 /area/lv624/ground/caves/sand_temple)
+"han" = (
+/obj/item/reagent_container/food/snacks/grown/mushroom/amanita,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/central_caves)
+"hav" = (
+/obj/structure/blocker/forcefield/multitile_vehicles,
+/obj/effect/landmark/structure_spawner/xvx_hive/xeno_door,
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_central_caves)
 "haN" = (
 /obj/structure/flora/bush/ausbushes/grassybush,
 /turf/open/gm/grass/grass1,
@@ -14882,6 +15513,16 @@
 	icon_state = "asteroidwarning"
 	},
 /area/lv624/lazarus/landing_zones/lz2)
+"hez" = (
+/obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
+	pixel_x = 2;
+	pixel_y = 7;
+	light_on = 1;
+	light_range = 1;
+	light_system = 1
+	},
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/central_caves)
 "heC" = (
 /obj/structure/flora/grass/tallgrass/jungle/corner{
 	dir = 6
@@ -14914,6 +15555,11 @@
 	},
 /turf/closed/wall/strata_ice/jungle,
 /area/lv624/ground/jungle/west_jungle)
+"hhs" = (
+/obj/effect/landmark/structure_spawner/xvx_hive/xeno_wall,
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/west_caves)
 "hhv" = (
 /turf/open/floor{
 	dir = 8;
@@ -14929,6 +15575,12 @@
 /obj/structure/fence,
 /turf/open/gm/dirtgrassborder/east,
 /area/lv624/ground/colony/west_tcomms_road)
+"hjo" = (
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 5
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/west_caves)
 "hke" = (
 /obj/structure/platform/mineral/sandstone/runed,
 /obj/structure/stairs/perspective{
@@ -14938,6 +15590,25 @@
 	},
 /turf/open/gm/dirt,
 /area/lv624/ground/barrens/south_eastern_barrens)
+"hkT" = (
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 10
+	},
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_central_caves)
+"hmq" = (
+/obj/structure/flora/bush/ausbushes/ausbush,
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 8
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_west_caves)
+"hmJ" = (
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 8
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/barrens/north_east_barrens)
 "hmK" = (
 /obj/structure/flora/jungle/planttop1,
 /turf/open/gm/grass/grass1,
@@ -14953,6 +15624,16 @@
 	icon_state = "bot"
 	},
 /area/lv624/ground/caves/north_central_caves)
+"hpK" = (
+/obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
+	pixel_x = -10;
+	pixel_y = -2;
+	light_on = 1;
+	light_range = 1;
+	light_system = 1
+	},
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_central_caves)
 "hpN" = (
 /obj/structure/surface/table,
 /obj/effect/landmark/good_item,
@@ -14988,6 +15669,15 @@
 "hsc" = (
 /turf/closed/wall/r_wall,
 /area/lv624/ground/river/central_river)
+"htV" = (
+/obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
+	pixel_x = 4;
+	light_on = 1;
+	light_range = 1;
+	light_system = 1
+	},
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/west_caves)
 "huH" = (
 /obj/structure/flora/jungle/planttop1,
 /obj/structure/flora/jungle/vines/light_3,
@@ -15007,6 +15697,13 @@
 /obj/effect/decal/remains/xeno,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/barrens/south_eastern_jungle_barrens)
+"hyF" = (
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 10
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/west_caves)
 "hyK" = (
 /obj/effect/landmark/hunter_primary,
 /turf/open/gm/grass/grass1,
@@ -15042,6 +15739,10 @@
 /obj/effect/decal/remains/xeno,
 /turf/open/gm/dirt,
 /area/lv624/ground/colony/west_tcomms_road)
+"hEe" = (
+/obj/effect/landmark/crap_item,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/barrens/north_east_barrens)
 "hEl" = (
 /obj/structure/flora/jungle/vines/light_2,
 /turf/closed/wall/strata_ice/jungle,
@@ -15106,6 +15807,10 @@
 	},
 /turf/open/gm/grass/grass2,
 /area/lv624/ground/jungle/east_jungle)
+"hKP" = (
+/obj/effect/decal/grass_overlay/grass1/inner,
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/north_west_caves)
 "hLu" = (
 /turf/open/gm/dirtgrassborder/south,
 /area/lv624/ground/jungle/south_central_jungle)
@@ -15143,6 +15848,10 @@
 /obj/item/clothing/under/colonist,
 /turf/open/floor/vault,
 /area/lv624/lazarus/quartstorage)
+"hNT" = (
+/obj/item/reagent_container/food/snacks/grown/mushroom/plumphelmet,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/central_caves)
 "hPV" = (
 /obj/effect/decal/remains/xeno{
 	pixel_x = 31
@@ -15159,6 +15868,18 @@
 	icon_state = "vault"
 	},
 /area/lv624/lazarus/quartstorage)
+"hRy" = (
+/turf/open/gm/dirt{
+	icon_state = "desert3"
+	},
+/area/lv624/ground/caves/south_west_caves)
+"hRB" = (
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 6
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/barrens/north_east_barrens)
 "hRI" = (
 /obj/structure/flora/bush/ausbushes/reedbush,
 /turf/open/gm/grass/grass1,
@@ -15184,6 +15905,10 @@
 /obj/effect/landmark/monkey_spawn,
 /turf/open/gm/dirt,
 /area/lv624/ground/jungle/east_central_jungle)
+"hTR" = (
+/obj/structure/flora/bush/ausbushes/var3/ywflowers,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_east_caves)
 "hUs" = (
 /turf/open/gm/grass/grass2,
 /area/lv624/ground/jungle/south_west_jungle)
@@ -15261,6 +15986,10 @@
 /obj/structure/flora/jungle/vines/heavy,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/east_central_jungle)
+"icd" = (
+/obj/structure/flora/bush/ausbushes/grassybush,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/central_caves)
 "idz" = (
 /obj/item/weapon/claymore/mercsword{
 	pixel_x = 6;
@@ -15289,10 +16018,24 @@
 /obj/structure/flora/jungle/vines/light_3,
 /turf/open/gm/grass/grass1,
 /area/lv624/lazarus/landing_zones/lz1)
+"ieN" = (
+/obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
+	pixel_x = 2;
+	pixel_y = 7;
+	light_on = 1;
+	light_range = 1;
+	light_system = 1
+	},
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/west_caves)
 "ifk" = (
 /obj/structure/flora/bush/ausbushes/var3/brflowers,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/west_central_jungle)
+"ifr" = (
+/obj/structure/flora/bush/ausbushes/pointybush,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/east_caves)
 "ifF" = (
 /turf/open/gm/dirtgrassborder/grassdirt_corner2/north_west,
 /area/lv624/ground/jungle/south_east_jungle)
@@ -15303,6 +16046,11 @@
 	},
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/central_jungle)
+"igN" = (
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
+/obj/effect/decal/grass_overlay/grass1,
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/west_caves)
 "ihS" = (
 /obj/structure/surface/table,
 /obj/item/reagent_container/food/drinks/cans/lemon_lime{
@@ -15319,6 +16067,10 @@
 /obj/effect/landmark/queen_spawn,
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/east_caves)
+"ikA" = (
+/obj/item/reagent_container/food/snacks/grown/mushroom/chanterelle,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_west_caves)
 "ilf" = (
 /obj/structure/flora/jungle/vines/light_3,
 /obj/structure/flora/jungle/vines/heavy,
@@ -15326,6 +16078,13 @@
 /obj/structure/flora/jungle/planttop1,
 /turf/open/floor/plating,
 /area/lv624/lazarus/corporate_dome)
+"ilF" = (
+/obj/item/reagent_container/food/snacks/grown/mushroom/plumphelmet{
+	pixel_x = 8
+	},
+/obj/structure/flora/bush/ausbushes/ppflowers,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_west_caves)
 "ilO" = (
 /obj/structure/surface/table/woodentable/poor,
 /obj/item/device/flashlight/lantern{
@@ -15355,6 +16114,13 @@
 	},
 /turf/open/gm/dirt,
 /area/lv624/ground/jungle/east_jungle)
+"isL" = (
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 10
+	},
+/obj/structure/flora/bush/ausbushes/palebush,
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/north_east_caves)
 "isR" = (
 /obj/effect/landmark/objective_landmark/medium,
 /obj/structure/largecrate/random,
@@ -15369,6 +16135,13 @@
 	icon_state = "asteroidwarning"
 	},
 /area/lv624/lazarus/landing_zones/lz2)
+"iuf" = (
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 10
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/west_caves)
 "iuO" = (
 /turf/open/gm/dirtgrassborder{
 	icon_state = "desert3"
@@ -15400,6 +16173,12 @@
 	icon_state = "multi_tiles"
 	},
 /area/lv624/ground/caves/sand_temple)
+"iye" = (
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 8
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/east_caves)
 "iyr" = (
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_nest,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_nest,
@@ -15452,6 +16231,11 @@
 /obj/structure/fence,
 /turf/open/gm/dirtgrassborder/south,
 /area/lv624/ground/colony/west_nexus_road)
+"iDX" = (
+/obj/effect/landmark/structure_spawner/xvx_hive/xeno_membrane,
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_membrane,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_central_caves)
 "iFp" = (
 /obj/structure/flora/jungle/vines/light_1,
 /obj/structure/barricade/wooden{
@@ -15462,10 +16246,19 @@
 	icon_state = "warning"
 	},
 /area/lv624/lazarus/landing_zones/lz1)
+"iGf" = (
+/obj/effect/landmark/structure_spawner/xvx_hive/xeno_door,
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/west_caves)
 "iGn" = (
 /obj/effect/landmark/hunter_primary,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/south_west_jungle)
+"iGx" = (
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/west_caves)
 "iHQ" = (
 /obj/structure/xenoautopsy/tank/broken,
 /turf/open/gm/dirt,
@@ -15514,6 +16307,10 @@
 /obj/structure/ore_box,
 /turf/open/gm/dirt,
 /area/lv624/ground/barrens/south_west_barrens)
+"iNJ" = (
+/obj/structure/flora/bush/ausbushes/var3/leafybush,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/north_west_caves)
 "iOz" = (
 /obj/structure/barricade/handrail/strata{
 	dir = 4
@@ -15555,6 +16352,14 @@
 /obj/structure/flora/bush/ausbushes/ppflowers,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/central_jungle)
+"iTQ" = (
+/obj/effect/landmark/structure_spawner/xvx_hive/xeno_wall,
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 6
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/central_caves)
 "iUm" = (
 /obj/structure/flora/bush/ausbushes/var3/fernybush,
 /turf/open/gm/grass/grass1,
@@ -15581,6 +16386,10 @@
 /obj/structure/fence,
 /turf/open/gm/dirtgrassborder/east,
 /area/lv624/ground/colony/west_nexus_road)
+"iXX" = (
+/obj/item/reagent_container/food/snacks/grown/mushroom/angel,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/north_west_caves)
 "iYJ" = (
 /obj/structure/flora/bush/ausbushes/var3/fullgrass,
 /turf/open/gm/grass/grass1,
@@ -15613,6 +16422,12 @@
 	},
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/north_jungle)
+"jcn" = (
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 8
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/central_caves)
 "jdi" = (
 /obj/structure/flora/jungle/vines/heavy,
 /obj/structure/flora/jungle/vines/light_3,
@@ -15625,10 +16440,30 @@
 "jga" = (
 /turf/open/gm/river,
 /area/lv624/ground/jungle/west_jungle)
+"jgj" = (
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 6
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/east_caves)
+"jgy" = (
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 6
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/central_caves)
 "jgJ" = (
 /obj/structure/fence,
 /turf/open/gm/dirtgrassborder/grassdirt_corner2/north_east,
 /area/lv624/ground/colony/south_nexus_road)
+"jhj" = (
+/obj/effect/landmark/structure_spawner/xvx_hive/xeno_nest,
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_nest,
+/obj/effect/decal/grass_overlay/grass1/inner,
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/east_caves)
 "jhG" = (
 /obj/structure/barricade/handrail/strata{
 	dir = 8
@@ -15652,6 +16487,12 @@
 /obj/structure/machinery/colony_floodlight,
 /turf/open/gm/dirt,
 /area/lv624/ground/colony/north_tcomms_road)
+"jlt" = (
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 4
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_east_caves)
 "jnG" = (
 /obj/structure/machinery/door/airlock/almayer/engineering/colony{
 	dir = 1;
@@ -15675,6 +16516,21 @@
 	icon_state = "whitebluecorner"
 	},
 /area/lv624/lazarus/corporate_dome)
+"jpX" = (
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 10
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_central_caves)
+"jqr" = (
+/obj/effect/landmark/structure_spawner/xvx_hive/xeno_door,
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 8
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/west_caves)
 "jrC" = (
 /obj/structure/curtain/red,
 /turf/open/shuttle{
@@ -15699,6 +16555,12 @@
 /obj/structure/cargo_container/lockmart/mid,
 /turf/open/floor,
 /area/lv624/ground/barrens/containers)
+"jvQ" = (
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 8
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/west_caves)
 "jwW" = (
 /turf/open/floor/plating{
 	dir = 6;
@@ -15774,6 +16636,19 @@
 	icon_state = "floor6"
 	},
 /area/lv624/ground/caves/sand_temple)
+"jBl" = (
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 1
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/north_east_caves)
+"jCO" = (
+/obj/item/reagent_container/food/snacks/grown/mushroom/plumphelmet{
+	pixel_x = 8;
+	pixel_y = 13
+	},
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_west_caves)
 "jDY" = (
 /obj/effect/decal/cleanable/blood/gibs/xeno/limb,
 /turf/open/gm/dirt,
@@ -15798,6 +16673,12 @@
 /obj/structure/flora/bush/ausbushes/var3/brflowers,
 /turf/open/gm/dirt,
 /area/lv624/ground/jungle/south_west_jungle/ceiling)
+"jGU" = (
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 1
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/west_caves)
 "jGW" = (
 /turf/closed/wall/strata_ice/jungle,
 /area/lv624/ground/jungle/central_jungle)
@@ -15821,6 +16702,16 @@
 /obj/structure/flora/jungle/vines/light_3,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/central_jungle)
+"jJg" = (
+/obj/structure/flora/bush/ausbushes/var3/sparsegrass,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_east_caves)
+"jKc" = (
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 10
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/north_west_caves)
 "jKu" = (
 /obj/structure/flora/bush/ausbushes/var3/fernybush,
 /obj/structure/flora/jungle/vines/heavy,
@@ -15850,6 +16741,12 @@
 /obj/structure/flora/jungle/vines/heavy,
 /turf/open/gm/dirtgrassborder/south,
 /area/lv624/ground/jungle/west_central_jungle)
+"jLY" = (
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 4
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/north_west_caves)
 "jMk" = (
 /obj/structure/lattice{
 	layer = 2.9
@@ -15865,6 +16762,12 @@
 	icon_state = "warnplate"
 	},
 /area/lv624/lazarus/engineering)
+"jMD" = (
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 6
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_east_caves)
 "jMH" = (
 /obj/structure/stairs/perspective{
 	color = "#6b675e";
@@ -15939,6 +16842,16 @@
 /obj/effect/decal/cleanable/blood/xeno,
 /turf/open/gm/dirt,
 /area/lv624/ground/jungle/north_west_jungle)
+"jRL" = (
+/obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
+	pixel_x = 2;
+	pixel_y = 7;
+	light_on = 1;
+	light_range = 1;
+	light_system = 1
+	},
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/east_caves)
 "jRM" = (
 /obj/structure/flora/bush/ausbushes/var3/fullgrass,
 /obj/effect/landmark/lv624/fog_blocker,
@@ -16001,6 +16914,20 @@
 /obj/effect/landmark/monkey_spawn,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/north_jungle)
+"jZX" = (
+/obj/effect/landmark/structure_spawner/xvx_hive/xeno_wall,
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 6
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/central_caves)
+"kae" = (
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 10
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/barrens/north_east_barrens)
 "kbn" = (
 /obj/structure/machinery/sensortower,
 /turf/open/floor{
@@ -16023,6 +16950,10 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/wall/rock/brown,
 /area/lv624/ground/river/west_river)
+"kdj" = (
+/obj/structure/flora/bush/ausbushes/pointybush,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_central_caves)
 "keS" = (
 /turf/open/floor/plating,
 /area/lv624/ground/barrens/east_barrens/ceiling)
@@ -16049,6 +16980,18 @@
 /obj/structure/flora/jungle/vines/light_3,
 /turf/open/gm/dirtgrassborder/grassdirt_corner/south_west,
 /area/lv624/ground/jungle/east_jungle)
+"klD" = (
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 6
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/north_west_caves)
+"kmH" = (
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 9
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/east_caves)
 "kmP" = (
 /obj/item/stool,
 /turf/open/gm/dirt,
@@ -16068,6 +17011,12 @@
 /obj/structure/flora/bush/ausbushes/var3/sunnybush,
 /turf/open/gm/dirtgrassborder/grassdirt_corner/north_east,
 /area/lv624/ground/barrens/south_eastern_jungle_barrens)
+"kpx" = (
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 5
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/barrens/north_east_barrens)
 "kqx" = (
 /obj/structure/flora/jungle/plantbot1,
 /obj/structure/flora/jungle/vines/light_3,
@@ -16077,6 +17026,18 @@
 /obj/structure/flora/jungle/vines/light_3,
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/sand_temple)
+"krs" = (
+/turf/open/gm/dirt{
+	icon_state = "desert2"
+	},
+/area/lv624/ground/caves/south_west_caves)
+"ksc" = (
+/obj/structure/flora/bush/ausbushes/var3/sunnybush{
+	icon_state = "fernybush_2";
+	pixel_y = 10
+	},
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/north_west_caves)
 "ksB" = (
 /obj/structure/flora/jungle/vines/light_3,
 /turf/open/gm/dirtgrassborder/grassdirt_corner2/south_west,
@@ -16103,6 +17064,12 @@
 	},
 /turf/open/gm/dirtgrassborder/grassdirt_corner/north_east,
 /area/lv624/ground/barrens/south_eastern_barrens)
+"ktr" = (
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 6
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/north_east_caves)
 "kuP" = (
 /obj/item/tool/hatchet{
 	pixel_x = 6;
@@ -16133,12 +17100,25 @@
 /obj/effect/landmark/monkey_spawn,
 /turf/open/gm/grass/grass1,
 /area/lv624/lazarus/landing_zones/lz2)
+"kxv" = (
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 1
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/central_caves)
 "kxI" = (
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/south_central_jungle)
 "kyc" = (
 /turf/open/gm/coast/beachcorner/north_east,
 /area/lv624/ground/river/central_river)
+"kyt" = (
+/obj/effect/decal/grass_overlay/grass1/inner,
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 10
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_west_caves)
 "kyN" = (
 /obj/structure/flora/bush/ausbushes/var3/ywflowers,
 /turf/open/gm/grass/grass1,
@@ -16160,6 +17140,12 @@
 	icon_state = "green"
 	},
 /area/lv624/lazarus/hydroponics)
+"kzn" = (
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 5
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/north_west_caves)
 "kzu" = (
 /obj/structure/flora/bush/ausbushes/grassybush,
 /turf/open/gm/grass/grass1,
@@ -16168,6 +17154,10 @@
 /obj/structure/flora/bush/ausbushes/var3/sunnybush,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/north_west_jungle)
+"kzw" = (
+/obj/structure/flora/bush/ausbushes/var3/sunnybush,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_west_caves)
 "kzE" = (
 /obj/structure/cargo_container/lockmart/right,
 /turf/open/floor,
@@ -16199,6 +17189,10 @@
 	icon_state = "vault"
 	},
 /area/lv624/lazarus/quartstorage)
+"kCD" = (
+/obj/structure/flora/bush/ausbushes/var3/leafybush,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/west_caves)
 "kFx" = (
 /obj/structure/flora/jungle/plantbot1,
 /turf/open/gm/grass/grass1,
@@ -16221,6 +17215,10 @@
 "kHU" = (
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/caves/sand_temple)
+"kIM" = (
+/obj/structure/flora/bush/ausbushes/reedbush,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/central_caves)
 "kJm" = (
 /turf/open/gm/coast/beachcorner2/north_east,
 /area/lv624/ground/barrens/south_eastern_jungle_barrens)
@@ -16232,11 +17230,31 @@
 /obj/structure/flora/jungle/planttop1,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/south_west_jungle)
+"kKa" = (
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 4
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/north_west_caves)
+"kLl" = (
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 8
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/central_caves)
 "kLP" = (
 /obj/structure/flora/jungle/plantbot1,
 /obj/structure/flora/jungle/vines/light_2,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/north_east_jungle)
+"kML" = (
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 4
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/west_caves)
 "kNm" = (
 /obj/effect/landmark/hunter_primary,
 /turf/open/gm/grass/grass1,
@@ -16303,6 +17321,12 @@
 /obj/structure/fence,
 /turf/open/gm/dirtgrassborder/grassdirt_corner2/north_east,
 /area/lv624/ground/colony/north_tcomms_road)
+"kVG" = (
+/obj/effect/landmark/structure_spawner/xvx_hive/xeno_membrane,
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_membrane,
+/obj/effect/decal/grass_overlay/grass1,
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/west_caves)
 "kVP" = (
 /obj/structure/flora/jungle/plantbot1,
 /turf/open/gm/grass/grass1,
@@ -16318,6 +17342,10 @@
 	},
 /turf/open/floor/plating,
 /area/lv624/lazarus/landing_zones/lz2)
+"kWV" = (
+/obj/effect/decal/grass_overlay/grass1/inner,
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/west_caves)
 "kWX" = (
 /turf/open/floor{
 	dir = 8;
@@ -16361,6 +17389,11 @@
 	icon_state = "whiteblue"
 	},
 /area/lv624/lazarus/corporate_dome)
+"lav" = (
+/turf/open/gm/dirt{
+	icon_state = "desert_dug"
+	},
+/area/lv624/ground/caves/west_caves)
 "laY" = (
 /obj/structure/flora/jungle/vines/light_1,
 /turf/closed/wall/strata_ice/jungle,
@@ -16368,12 +17401,23 @@
 "lbd" = (
 /turf/open/gm/coast/beachcorner/north_west,
 /area/lv624/ground/barrens/west_barrens)
+"lbt" = (
+/obj/effect/landmark/hunter_primary,
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 9
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_central_caves)
 "lbX" = (
 /obj/structure/flora/grass/tallgrass/jungle/corner{
 	dir = 10
 	},
 /turf/open/gm/grass/grass2,
 /area/lv624/ground/jungle/east_jungle)
+"ldi" = (
+/obj/structure/flora/bush/ausbushes/grassybush,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_east_caves)
 "ldB" = (
 /obj/structure/flora/grass/tallgrass/jungle/corner{
 	dir = 4
@@ -16391,6 +17435,24 @@
 /obj/structure/flora/bush/ausbushes/genericbush,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/north_east_jungle)
+"lhE" = (
+/obj/effect/landmark/structure_spawner/xvx_hive/xeno_wall,
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
+/obj/effect/decal/grass_overlay/grass1,
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/east_caves)
+"lhH" = (
+/obj/structure/flora/bush/ausbushes/var3/stalkybush,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_central_caves)
+"liI" = (
+/obj/effect/landmark/structure_spawner/xvx_hive/xeno_wall,
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 10
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_central_caves)
 "lju" = (
 /turf/open/gm/coast/beachcorner2/south_east,
 /area/lv624/ground/river/central_river)
@@ -16402,6 +17464,11 @@
 /obj/structure/inflatable/popped/door,
 /turf/open/gm/dirt,
 /area/lv624/lazarus/crashed_ship_containers)
+"lkq" = (
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
+/obj/effect/decal/grass_overlay/grass1,
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_central_caves)
 "lkF" = (
 /obj/item/stack/sheet/wood{
 	amount = 2
@@ -16413,6 +17480,10 @@
 	icon_state = "warning"
 	},
 /area/lv624/lazarus/landing_zones/lz1)
+"lnr" = (
+/obj/structure/flora/bush/ausbushes/lavendergrass,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_central_caves)
 "lnK" = (
 /obj/structure/flora/bush/ausbushes/genericbush,
 /obj/effect/landmark/nightmare{
@@ -16428,6 +17499,16 @@
 /obj/effect/landmark/hunter_primary,
 /turf/open/gm/dirtgrassborder/grassdirt_corner2/south_east,
 /area/lv624/ground/jungle/south_east_jungle)
+"loP" = (
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 8
+	},
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 10
+	},
+/obj/structure/flora/bush/ausbushes/genericbush,
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_east_caves)
 "lpV" = (
 /turf/open/floor/plating{
 	icon_state = "platebotc"
@@ -16491,6 +17572,19 @@
 "lyS" = (
 /turf/closed/wall/r_wall/unmeltable,
 /area/lv624/lazarus/quartstorage)
+"lyZ" = (
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
+/obj/effect/landmark/structure_spawner/xvx_hive/xeno_door,
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/east_caves)
+"lzf" = (
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 8
+	},
+/obj/structure/flora/bush/ausbushes/grassybush,
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/north_east_caves)
 "lzE" = (
 /turf/open/gm/dirt{
 	icon_state = "desert0"
@@ -16500,6 +17594,12 @@
 /obj/structure/flora/bush/ausbushes/reedbush,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/south_central_jungle)
+"lBl" = (
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 10
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_east_caves)
 "lBq" = (
 /obj/structure/barricade/handrail/strata,
 /obj/structure/barricade/handrail/strata{
@@ -16582,6 +17682,13 @@
 	icon_state = "dark"
 	},
 /area/lv624/lazarus/quartstorage)
+"lIL" = (
+/obj/structure/blocker/forcefield/multitile_vehicles,
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 4
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/central_caves)
 "lIU" = (
 /turf/open/gm/dirtgrassborder/grassdirt_corner/north_west,
 /area/lv624/ground/jungle/south_central_jungle)
@@ -16621,6 +17728,16 @@
 	icon_state = "warning"
 	},
 /area/lv624/lazarus/landing_zones/lz2)
+"lKl" = (
+/obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
+	pixel_x = 6;
+	pixel_y = -8;
+	light_on = 1;
+	light_range = 1;
+	light_system = 1
+	},
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/west_caves)
 "lKF" = (
 /turf/closed/wall/rock/brown,
 /area/lv624/ground/barrens/containers)
@@ -16628,12 +17745,23 @@
 /obj/structure/shuttle/engine/propulsion,
 /turf/open/gm/dirt,
 /area/lv624/ground/barrens/north_east_barrens)
+"lLK" = (
+/obj/structure/flora/bush/ausbushes/ausbush,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/west_caves)
 "lLO" = (
 /obj/structure/flora/grass/tallgrass/jungle/corner{
 	dir = 10
 	},
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/east_jungle)
+"lLU" = (
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 10
+	},
+/obj/structure/flora/bush/ausbushes/genericbush,
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/north_east_caves)
 "lNe" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor{
@@ -16641,6 +17769,16 @@
 	icon_state = "whitebluecorner"
 	},
 /area/lv624/lazarus/corporate_dome)
+"lNG" = (
+/obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
+	pixel_x = 2;
+	pixel_y = 7;
+	light_on = 1;
+	light_range = 1;
+	light_system = 1
+	},
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_east_caves)
 "lPJ" = (
 /turf/open/gm/dirtgrassborder{
 	icon_state = "desert"
@@ -16678,6 +17816,23 @@
 	icon_state = "whiteblue"
 	},
 /area/lv624/lazarus/corporate_dome)
+"lSA" = (
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 9
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_east_caves)
+"lSN" = (
+/obj/effect/decal/grass_overlay/grass1/inner,
+/obj/structure/flora/bush/ausbushes/ausbush,
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_east_caves)
+"lTv" = (
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 1
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/north_west_caves)
 "lTZ" = (
 /obj/item/tool/shovel,
 /turf/open/gm/dirt,
@@ -16699,6 +17854,25 @@
 /obj/structure/prop/brazier/torch,
 /turf/closed/wall/rock/brown,
 /area/lv624/ground/caves/sand_temple)
+"lUQ" = (
+/obj/effect/landmark/structure_spawner/xvx_hive/xeno_door,
+/obj/structure/blocker/forcefield/multitile_vehicles,
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 1
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_west_caves)
+"lWh" = (
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 6
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_west_caves)
+"lWl" = (
+/obj/effect/decal/grass_overlay/grass1/inner,
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_west_caves)
 "lWw" = (
 /obj/structure/stairs/perspective{
 	color = "#b29082";
@@ -16711,6 +17885,12 @@
 "lWO" = (
 /turf/open/gm/dirtgrassborder/grassdirt_corner/south_east,
 /area/lv624/ground/jungle/south_west_jungle)
+"lYt" = (
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 9
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_west_caves)
 "lYB" = (
 /obj/structure/fence,
 /turf/open/gm/dirtgrassborder/grassdirt_corner2/north_west,
@@ -16758,6 +17938,16 @@
 /obj/structure/flora/jungle/vines/heavy,
 /turf/open/gm/dirt,
 /area/lv624/ground/jungle/east_jungle)
+"mca" = (
+/obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
+	pixel_x = 2;
+	pixel_y = 7;
+	light_on = 1;
+	light_range = 1;
+	light_system = 1
+	},
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_central_caves)
 "mdQ" = (
 /turf/closed/wall/rock/brown,
 /area/lv624/ground/caves/west_caves)
@@ -16765,6 +17955,16 @@
 /obj/structure/flora/jungle/vines/heavy,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/south_east_jungle)
+"mfn" = (
+/obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
+	pixel_x = 2;
+	pixel_y = -2;
+	light_on = 1;
+	light_range = 1;
+	light_system = 1
+	},
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/east_caves)
 "mfu" = (
 /obj/structure/flora/grass/tallgrass/jungle/corner{
 	dir = 8
@@ -16779,6 +17979,12 @@
 /obj/structure/flora/jungle/vines/light_1,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/central_jungle)
+"mgi" = (
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 10
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/north_west_caves)
 "mgs" = (
 /obj/structure/machinery/door/poddoor/almayer{
 	dir = 8;
@@ -16890,6 +18096,11 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/gm/dirt,
 /area/lv624/ground/river/east_river)
+"mrg" = (
+/obj/effect/landmark/structure_spawner/xvx_hive/xeno_wall,
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/central_caves)
 "mrQ" = (
 /obj/structure/bed/chair/comfy/black{
 	dir = 4
@@ -16982,6 +18193,12 @@
 	icon_state = "whiteblue"
 	},
 /area/lv624/lazarus/corporate_dome)
+"mEo" = (
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 10
+	},
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/north_east_caves)
 "mEw" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/gm/dirtgrassborder/south,
@@ -16990,10 +18207,22 @@
 /obj/effect/landmark/crap_item,
 /turf/open/gm/dirt,
 /area/lv624/ground/colony/north_nexus_road)
+"mFZ" = (
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 6
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/north_east_caves)
 "mGG" = (
 /obj/structure/window_frame/colony/reinforced,
 /turf/open/floor/plating,
 /area/lv624/lazarus/corporate_dome)
+"mHk" = (
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 10
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/east_caves)
 "mHM" = (
 /turf/open/gm/dirtgrassborder/grassdirt_corner2/south_west,
 /area/lv624/ground/colony/south_medbay_road)
@@ -17008,6 +18237,10 @@
 	icon_state = "whiteyellowcorner"
 	},
 /area/lv624/lazarus/corporate_dome)
+"mJF" = (
+/obj/structure/flora/bush/ausbushes/palebush,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_central_caves)
 "mKf" = (
 /turf/open/gm/dirt,
 /area/lv624/ground/colony/west_nexus_road)
@@ -17017,6 +18250,10 @@
 	},
 /turf/open/floor/sandstone/runed,
 /area/lv624/ground/caves/sand_temple)
+"mLv" = (
+/obj/structure/flora/bush/ausbushes/lavendergrass,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/east_caves)
 "mMq" = (
 /obj/structure/flora/jungle/planttop1,
 /turf/open/gm/grass/grass1,
@@ -17036,6 +18273,12 @@
 	icon_state = "vault"
 	},
 /area/lv624/lazarus/quartstorage)
+"mNl" = (
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 10
+	},
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/east_caves)
 "mNz" = (
 /obj/structure/flora/bush/ausbushes/var3/fernybush,
 /turf/open/gm/grass/grass1,
@@ -17052,6 +18295,10 @@
 /obj/structure/flora/bush/ausbushes/ausbush,
 /turf/open/gm/dirt,
 /area/lv624/ground/barrens/south_eastern_jungle_barrens)
+"mOL" = (
+/obj/structure/flora/bush/ausbushes/var3/leafybush,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_central_caves)
 "mPt" = (
 /turf/open/gm/dirtgrassborder/grassdirt_corner2/north_east,
 /area/lv624/ground/barrens/south_eastern_jungle_barrens)
@@ -17128,6 +18375,10 @@
 	icon_state = "whiteblue"
 	},
 /area/lv624/lazarus/corporate_dome)
+"mVr" = (
+/obj/structure/flora/bush/ausbushes/palebush,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/central_caves)
 "mVK" = (
 /obj/structure/machinery/colony_floodlight,
 /turf/open/gm/grass/grass1,
@@ -17138,6 +18389,10 @@
 "mWe" = (
 /turf/open/gm/dirtgrassborder/grassdirt_corner2/north_west,
 /area/lv624/ground/jungle/south_west_jungle)
+"mWA" = (
+/obj/structure/flora/bush/ausbushes/var3/fernybush,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/north_east_caves)
 "mXR" = (
 /turf/open/gm/dirtgrassborder/west,
 /area/lv624/ground/colony/north_nexus_road)
@@ -17168,10 +18423,22 @@
 	icon_state = "asteroidwarning"
 	},
 /area/lv624/lazarus/landing_zones/lz2)
+"ndk" = (
+/obj/structure/flora/bush/ausbushes/ppflowers,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/west_caves)
 "ndK" = (
 /obj/structure/flora/jungle/vines/light_1,
 /turf/closed/wall/r_wall,
 /area/lv624/lazarus/corporate_dome)
+"ner" = (
+/obj/effect/landmark/structure_spawner/xvx_hive/xeno_door,
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 8
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/central_caves)
 "nfD" = (
 /obj/effect/landmark/survivor_spawner,
 /turf/open/gm/dirt,
@@ -17186,6 +18453,14 @@
 	},
 /turf/open/gm/dirt,
 /area/lv624/ground/barrens/south_eastern_barrens)
+"nha" = (
+/obj/effect/landmark/structure_spawner/xvx_hive/xeno_door,
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 4
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/east_caves)
 "nhi" = (
 /obj/structure/flora/bush/ausbushes/genericbush,
 /turf/open/gm/grass/grass1,
@@ -17282,6 +18557,15 @@
 	},
 /turf/open/floor/vault,
 /area/lv624/lazarus/quartstorage)
+"nrR" = (
+/obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
+	pixel_x = -10;
+	light_on = 1;
+	light_range = 1;
+	light_system = 1
+	},
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_east_caves)
 "nsk" = (
 /turf/open/gm/dirt,
 /area/lv624/ground/river/west_river)
@@ -17379,6 +18663,12 @@
 	icon_state = "whiteyellowcorner"
 	},
 /area/lv624/lazarus/corporate_dome)
+"nys" = (
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 10
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_west_caves)
 "nzw" = (
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_wall,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
@@ -17535,6 +18825,12 @@
 /obj/structure/flora/grass/tallgrass/jungle,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/south_west_jungle)
+"nLF" = (
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 10
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_central_caves)
 "nLH" = (
 /obj/structure/prop/tower,
 /turf/open/floor{
@@ -17556,6 +18852,16 @@
 /obj/structure/flora/jungle/vines/heavy,
 /turf/closed/wall/r_wall,
 /area/lv624/lazarus/corporate_dome)
+"nNu" = (
+/obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
+	pixel_x = 6;
+	pixel_y = -8;
+	light_on = 1;
+	light_range = 1;
+	light_system = 1
+	},
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/barrens/north_east_barrens)
 "nNw" = (
 /obj/structure/fence,
 /turf/open/gm/dirtgrassborder/grassdirt_corner/north_west,
@@ -17587,6 +18893,16 @@
 	icon_state = "squareswood"
 	},
 /area/lv624/ground/caves/sand_temple)
+"nQH" = (
+/obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
+	pixel_x = 6;
+	pixel_y = -8;
+	light_on = 1;
+	light_range = 1;
+	light_system = 1
+	},
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_west_caves)
 "nRb" = (
 /obj/structure/stairs/perspective{
 	color = "#b29082";
@@ -17598,6 +18914,13 @@
 	icon_state = "whiteyellowfull"
 	},
 /area/lv624/ground/caves/sand_temple)
+"nRA" = (
+/obj/item/reagent_container/food/snacks/grown/mushroom/plumphelmet{
+	pixel_x = 8;
+	pixel_y = 13
+	},
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/west_caves)
 "nSg" = (
 /obj/structure/window/framed/colony,
 /turf/open/floor{
@@ -17647,6 +18970,10 @@
 	icon_state = "white"
 	},
 /area/lv624/lazarus/corporate_dome)
+"nUZ" = (
+/obj/effect/decal/grass_overlay/grass1,
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/central_caves)
 "nVC" = (
 /obj/structure/flora/grass/tallgrass/jungle/corner{
 	dir = 6
@@ -17777,10 +19104,21 @@
 	icon_state = "squareswood"
 	},
 /area/lv624/ground/caves/sand_temple)
+"ofg" = (
+/turf/open/gm/dirt{
+	icon_state = "desert1"
+	},
+/area/lv624/ground/caves/west_caves)
 "ofv" = (
 /obj/effect/landmark/crap_item,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/colony/south_medbay_road)
+"ogJ" = (
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 6
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/central_caves)
 "ogM" = (
 /turf/open/gm/dirt,
 /area/lv624/ground/river/east_river)
@@ -17794,6 +19132,21 @@
 /obj/structure/flora/bush/ausbushes/var3/stalkybush,
 /turf/open/gm/dirt,
 /area/lv624/ground/river/central_river)
+"oha" = (
+/obj/effect/landmark/structure_spawner/xvx_hive/xeno_door,
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 4
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/central_caves)
+"ohf" = (
+/obj/item/reagent_container/food/snacks/grown/mushroom/plumphelmet{
+	pixel_x = 8;
+	pixel_y = 13
+	},
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_central_caves)
 "ohE" = (
 /obj/structure/surface/table/woodentable/poor,
 /obj/item/reagent_container/food/snacks/tomatomeat,
@@ -17817,6 +19170,10 @@
 "omK" = (
 /turf/open/gm/coast/beachcorner/south_east,
 /area/lv624/ground/barrens/west_barrens)
+"onP" = (
+/obj/effect/decal/grass_overlay/grass1,
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_central_caves)
 "onU" = (
 /turf/closed/wall/strata_ice/jungle,
 /area/lv624/ground/caves/west_caves)
@@ -17853,6 +19210,20 @@
 	icon_state = "asteroidwarning"
 	},
 /area/lv624/ground/colony/telecomm/cargo)
+"osf" = (
+/obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
+	pixel_x = 11;
+	pixel_y = -2;
+	light_on = 1;
+	light_range = 1;
+	light_system = 1
+	},
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/central_caves)
+"otl" = (
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/central_caves)
 "oua" = (
 /obj/effect/landmark/crap_item,
 /turf/open/gm/dirt,
@@ -17872,9 +19243,21 @@
 /obj/item/stack/sheet/wood,
 /turf/open/gm/dirt,
 /area/lv624/lazarus/crashed_ship_containers)
+"owe" = (
+/obj/item/reagent_container/food/snacks/grown/mushroom/plumphelmet{
+	pixel_x = 8
+	},
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/west_caves)
 "owQ" = (
 /turf/open/gm/coast/east,
 /area/lv624/ground/barrens/east_barrens)
+"owZ" = (
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 6
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/west_caves)
 "oxY" = (
 /obj/structure/flora/grass/tallgrass/jungle/corner{
 	dir = 6
@@ -17936,6 +19319,10 @@
 	},
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/north_west_jungle)
+"oDE" = (
+/obj/effect/decal/grass_overlay/grass1,
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/east_caves)
 "oDY" = (
 /obj/structure/platform_decoration/mineral/sandstone/runed{
 	dir = 4
@@ -17976,6 +19363,14 @@
 "oFf" = (
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/river/east_river)
+"oFJ" = (
+/obj/effect/landmark/structure_spawner/xvx_hive/xeno_door,
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 8
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/central_caves)
 "oFO" = (
 /obj/structure/platform_decoration/mineral/sandstone/runed{
 	dir = 1
@@ -18079,6 +19474,10 @@
 	icon_state = "loadingarea"
 	},
 /area/lv624/lazarus/landing_zones/lz1)
+"oQm" = (
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/east_caves)
 "oRH" = (
 /turf/open/gm/dirtgrassborder/south,
 /area/lv624/ground/jungle/north_east_jungle)
@@ -18248,6 +19647,10 @@
 	},
 /turf/open/gm/dirtgrassborder/grassdirt_corner/north_east,
 /area/lv624/ground/barrens/south_eastern_barrens)
+"pgc" = (
+/obj/structure/flora/bush/ausbushes/var3/fullgrass,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/barrens/north_east_barrens)
 "pgf" = (
 /obj/structure/machinery/power/apc{
 	dir = 1;
@@ -18281,6 +19684,15 @@
 /obj/structure/flora/jungle/plantbot1,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/central_jungle)
+"pkU" = (
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 9
+	},
+/obj/item/reagent_container/food/snacks/grown/mushroom/plumphelmet{
+	pixel_x = 8
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/west_caves)
 "plf" = (
 /obj/structure/flora/jungle/vines/heavy,
 /turf/open/gm/dirtgrassborder/grassdirt_corner2/south_east,
@@ -18319,6 +19731,13 @@
 	icon_state = "white"
 	},
 /area/lv624/lazarus/corporate_dome)
+"poX" = (
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 6
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/central_caves)
 "ppR" = (
 /turf/open/gm/dirtgrassborder/grassdirt_corner2/south_east,
 /area/lv624/ground/colony/north_nexus_road)
@@ -18366,6 +19785,11 @@
 	icon_state = "floor4"
 	},
 /area/lv624/lazarus/crashed_ship_containers)
+"ptm" = (
+/turf/open/gm/dirt{
+	icon_state = "desert0"
+	},
+/area/lv624/ground/caves/west_caves)
 "ptr" = (
 /obj/structure/flora/bush/ausbushes/palebush,
 /turf/open/gm/grass/grass1,
@@ -18415,10 +19839,18 @@
 	icon_state = "white"
 	},
 /area/lv624/lazarus/medbay)
+"pAE" = (
+/obj/structure/flora/bush/ausbushes/var3/leafybush,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/central_caves)
 "pBk" = (
 /obj/structure/flora/bush/ausbushes/ppflowers,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/east_central_jungle)
+"pBH" = (
+/obj/structure/flora/jungle/plantbot1,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_west_caves)
 "pDh" = (
 /obj/structure/surface/table/reinforced/prison{
 	color = "#6b675e"
@@ -18457,6 +19889,12 @@
 /obj/effect/landmark/hunter_primary,
 /turf/open/gm/grass/grass1,
 /area/lv624/lazarus/landing_zones/lz1)
+"pET" = (
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 6
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_east_caves)
 "pEV" = (
 /turf/open/floor/strata{
 	color = "#5e5d5d";
@@ -18466,10 +19904,24 @@
 "pFe" = (
 /turf/open/gm/dirtgrassborder/west,
 /area/lv624/ground/jungle/south_east_jungle)
+"pFB" = (
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 4
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/north_east_caves)
 "pGD" = (
 /obj/structure/flora/bush/ausbushes/var3/fernybush,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/north_west_jungle)
+"pGL" = (
+/obj/effect/landmark/structure_spawner/xvx_hive/xeno_wall,
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 10
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_east_caves)
 "pHn" = (
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/gm/dirt,
@@ -18485,6 +19937,12 @@
 	icon_state = "whiteblue"
 	},
 /area/lv624/lazarus/corporate_dome)
+"pIl" = (
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 5
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_west_caves)
 "pIy" = (
 /obj/structure/fence,
 /turf/open/gm/dirtgrassborder/north,
@@ -18493,6 +19951,10 @@
 /obj/structure/platform_decoration/mineral/sandstone/runed,
 /turf/open/floor/sandstone/runed,
 /area/lv624/ground/barrens/south_eastern_barrens)
+"pIB" = (
+/obj/structure/flora/bush/ausbushes/ausbush,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_central_caves)
 "pIC" = (
 /obj/effect/landmark/hunter_secondary,
 /turf/open/gm/grass/grass1,
@@ -18526,6 +19988,15 @@
 /obj/structure/fence,
 /turf/open/gm/dirtgrassborder/grassdirt_corner/south_west,
 /area/lv624/ground/colony/west_nexus_road)
+"pLv" = (
+/obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
+	pixel_x = 4;
+	light_on = 1;
+	light_range = 1;
+	light_system = 1
+	},
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/north_west_caves)
 "pMM" = (
 /obj/structure/flora/bush/ausbushes/ppflowers,
 /turf/open/gm/dirtgrassborder/east,
@@ -18572,6 +20043,10 @@
 	icon_state = "white"
 	},
 /area/lv624/lazarus/corporate_dome)
+"pQV" = (
+/obj/structure/flora/bush/ausbushes/palebush,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/east_caves)
 "pRe" = (
 /obj/item/storage/firstaid/adv/empty,
 /obj/structure/machinery/door_control{
@@ -18618,9 +20093,21 @@
 	},
 /turf/open/gm/dirt,
 /area/lv624/ground/barrens/south_eastern_barrens)
+"pRD" = (
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 10
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/north_east_caves)
 "pRT" = (
 /turf/closed/wall/strata_ice/jungle,
 /area/lv624/ground/caves/sand_temple)
+"pSe" = (
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 5
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/north_west_caves)
 "pSt" = (
 /obj/structure/fence,
 /turf/open/gm/dirtgrassborder/grassdirt_corner2/north_west,
@@ -18635,6 +20122,15 @@
 "pUm" = (
 /turf/closed/wall/rock/brown,
 /area/lv624/ground/caves/east_caves)
+"pVZ" = (
+/obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
+	pixel_x = -10;
+	light_on = 1;
+	light_range = 1;
+	light_system = 1
+	},
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/central_caves)
 "pXI" = (
 /obj/structure/flora/grass/tallgrass/jungle,
 /turf/open/gm/grass/grass1,
@@ -18675,6 +20171,12 @@
 /obj/structure/machinery/colony_floodlight,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/east_jungle)
+"qdx" = (
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 8
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/west_caves)
 "qdQ" = (
 /obj/structure/machinery/colony_floodlight,
 /turf/open/gm/grass/grass1,
@@ -18707,9 +20209,25 @@
 /obj/structure/flora/jungle/vines/light_3,
 /turf/open/floor,
 /area/lv624/lazarus/landing_zones/lz2)
+"qfK" = (
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 10
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/north_east_caves)
 "qgA" = (
 /turf/open/gm/dirtgrassborder/grassdirt_corner/south_east,
 /area/lv624/ground/jungle/south_east_jungle)
+"qhl" = (
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 4
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/west_caves)
+"qiL" = (
+/obj/item/reagent_container/food/snacks/grown/mushroom/amanita,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/north_west_caves)
 "qjf" = (
 /turf/open/floor,
 /area/lv624/ground/barrens/containers)
@@ -18739,6 +20257,14 @@
 "qqJ" = (
 /turf/open/gm/dirtgrassborder/grassdirt_corner2/south_west,
 /area/lv624/ground/caves/sand_temple)
+"qrH" = (
+/obj/effect/landmark/structure_spawner/xvx_hive/xeno_wall,
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 4
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/north_west_caves)
 "qsM" = (
 /obj/structure/platform/mineral/sandstone/runed{
 	dir = 1
@@ -18748,6 +20274,14 @@
 "qtj" = (
 /turf/open/gm/dirt,
 /area/lv624/ground/jungle/south_central_jungle)
+"qtK" = (
+/obj/effect/landmark/structure_spawner/xvx_hive/xeno_door,
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 4
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/west_caves)
 "qtS" = (
 /obj/structure/flora/bush/ausbushes/reedbush,
 /turf/open/gm/grass/grass1,
@@ -18932,6 +20466,12 @@
 /obj/structure/flora/bush/ausbushes/var3/leafybush,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/north_jungle)
+"qJE" = (
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 5
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/west_caves)
 "qKl" = (
 /turf/open/gm/dirtgrassborder/east,
 /area/lv624/ground/colony/north_nexus_road)
@@ -18974,6 +20514,14 @@
 	icon_state = "whiteyellowfull"
 	},
 /area/lv624/ground/caves/sand_temple)
+"qPY" = (
+/obj/effect/landmark/structure_spawner/xvx_hive/xeno_wall,
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 10
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/east_caves)
 "qRj" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
 /turf/open/gm/dirt,
@@ -18984,6 +20532,16 @@
 	},
 /turf/open/gm/dirt,
 /area/lv624/lazarus/crashed_ship_containers)
+"qSG" = (
+/obj/effect/decal/grass_overlay/grass1,
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_west_caves)
+"qSS" = (
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 4
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_west_caves)
 "qSZ" = (
 /obj/structure/flora/grass/tallgrass/jungle/corner{
 	dir = 10
@@ -19006,9 +20564,32 @@
 "qUM" = (
 /turf/open/gm/dirtgrassborder/north,
 /area/lv624/ground/jungle/west_central_jungle)
+"qVh" = (
+/obj/effect/decal/grass_overlay/grass1,
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/north_west_caves)
+"qVi" = (
+/obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
+	pixel_x = -10;
+	pixel_y = -2;
+	light_on = 1;
+	light_range = 1;
+	light_system = 1
+	},
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/north_east_caves)
+"qVN" = (
+/obj/structure/flora/bush/ausbushes/ausbush,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/north_west_caves)
 "qWf" = (
 /turf/open/gm/dirtgrassborder/grassdirt_corner2/south_west,
 /area/lv624/ground/colony/west_nexus_road)
+"qWI" = (
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
+/obj/effect/decal/grass_overlay/grass1/inner,
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/central_caves)
 "qXo" = (
 /obj/structure/surface/rack,
 /obj/item/explosive/grenade/incendiary/molotov,
@@ -19025,6 +20606,10 @@
 /obj/structure/flora/bush/ausbushes/var3/sparsegrass,
 /turf/open/gm/grass/grass2,
 /area/lv624/ground/jungle/south_west_jungle)
+"qYS" = (
+/obj/structure/flora/bush/ausbushes/lavendergrass,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/north_west_caves)
 "qZv" = (
 /obj/structure/flora/grass/tallgrass/jungle,
 /turf/open/gm/grass/grass1,
@@ -19047,6 +20632,16 @@
 	icon_state = "desert1"
 	},
 /area/lv624/ground/barrens/west_barrens)
+"rbs" = (
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 10
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_central_caves)
+"rby" = (
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_east_caves)
 "rck" = (
 /obj/structure/flora/grass/tallgrass/jungle/corner{
 	dir = 5
@@ -19103,10 +20698,26 @@
 /obj/structure/flora/jungle/vines/heavy,
 /turf/closed/wall/r_wall,
 /area/lv624/lazarus/corporate_dome)
+"rgj" = (
+/obj/effect/decal/remains/xeno,
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 8
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_east_caves)
 "rgQ" = (
 /obj/structure/flora/jungle/plantbot1,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/north_east_jungle)
+"rhi" = (
+/obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
+	pixel_x = 4;
+	light_on = 1;
+	light_range = 1;
+	light_system = 1
+	},
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/east_caves)
 "rit" = (
 /turf/open/gm/coast/south,
 /area/lv624/ground/river/central_river)
@@ -19127,10 +20738,37 @@
 	icon_state = "dark"
 	},
 /area/lv624/lazarus/engineering)
+"rmt" = (
+/obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
+	pixel_x = 4;
+	light_on = 1;
+	light_range = 1;
+	light_system = 1
+	},
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_central_caves)
+"rmW" = (
+/obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
+	pixel_x = 11;
+	pixel_y = -2;
+	light_on = 1;
+	light_range = 1;
+	light_system = 1
+	},
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/west_caves)
 "rox" = (
 /obj/structure/flora/jungle/vines/light_1,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/south_central_jungle)
+"roQ" = (
+/obj/structure/flora/bush/ausbushes/lavendergrass,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/central_caves)
+"rpx" = (
+/obj/effect/decal/grass_overlay/grass1,
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/north_east_caves)
 "rpR" = (
 /obj/structure/flora/jungle/vines/heavy,
 /turf/open/floor{
@@ -19186,6 +20824,9 @@
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_nest,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_nest,
 /obj/effect/landmark/corpsespawner/wygoon,
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 10
+	},
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/east_caves)
 "rwB" = (
@@ -19199,6 +20840,11 @@
 	icon_state = "desert_dug"
 	},
 /area/lv624/ground/barrens/south_eastern_barrens)
+"ryp" = (
+/obj/effect/landmark/structure_spawner/xvx_hive/xeno_door,
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/central_caves)
 "ryJ" = (
 /obj/structure/surface/table,
 /obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
@@ -19213,6 +20859,12 @@
 	},
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/south_west_jungle)
+"rze" = (
+/obj/effect/landmark/structure_spawner/xvx_hive/xeno_door,
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
+/obj/effect/decal/grass_overlay/grass1,
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_central_caves)
 "rzT" = (
 /obj/structure/flora/jungle/vines/light_3,
 /obj/item/stack/sheet/wood{
@@ -19235,6 +20887,16 @@
 	icon_state = "asteroidfloor"
 	},
 /area/lv624/lazarus/corporate_dome)
+"rAU" = (
+/obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
+	pixel_x = 6;
+	pixel_y = -8;
+	light_on = 1;
+	light_range = 1;
+	light_system = 1
+	},
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/east_caves)
 "rBF" = (
 /obj/structure/flora/jungle/vines/light_2,
 /turf/open/gm/grass/grass1,
@@ -19253,6 +20915,13 @@
 "rCV" = (
 /turf/open/gm/grass/grass2,
 /area/lv624/ground/jungle/south_central_jungle)
+"rER" = (
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 6
+	},
+/obj/structure/flora/bush/ausbushes/reedbush,
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/east_caves)
 "rGd" = (
 /obj/structure/girder/displaced,
 /obj/structure/shuttle/engine/propulsion,
@@ -19271,6 +20940,16 @@
 	},
 /turf/open/floor/vault,
 /area/lv624/lazarus/quartstorage)
+"rGE" = (
+/obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
+	pixel_x = 6;
+	pixel_y = -8;
+	light_on = 1;
+	light_range = 1;
+	light_system = 1
+	},
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_east_caves)
 "rGW" = (
 /obj/structure/flora/jungle/vines/light_3,
 /turf/open/gm/dirtgrassborder/south,
@@ -19284,11 +20963,34 @@
 /obj/structure/flora/jungle/vines/heavy,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/south_central_jungle)
+"rHV" = (
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 10
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_west_caves)
+"rIc" = (
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 4
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/central_caves)
+"rIm" = (
+/obj/effect/decal/grass_overlay/grass1/inner,
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/north_east_caves)
 "rIq" = (
 /obj/structure/flora/jungle/vines/light_1,
 /obj/structure/flora/jungle/vines/heavy,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/west_central_jungle)
+"rID" = (
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 5
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/east_caves)
 "rJd" = (
 /obj/structure/bed/alien{
 	color = "#aba9a9"
@@ -19381,6 +21083,13 @@
 /obj/structure/flora/jungle/vines/heavy,
 /turf/open/gm/dirtgrassborder/south,
 /area/lv624/ground/colony/north_tcomms_road)
+"rTT" = (
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_central_caves)
+"rUX" = (
+/obj/structure/flora/bush/ausbushes/genericbush,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/central_caves)
 "rVH" = (
 /obj/structure/transmitter/colony_net{
 	phone_category = "Lazarus Landing";
@@ -19393,6 +21102,12 @@
 	icon_state = "brown"
 	},
 /area/lv624/lazarus/comms)
+"rWs" = (
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 4
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/central_caves)
 "rWW" = (
 /obj/structure/flora/bush/ausbushes/grassybush,
 /turf/open/gm/river,
@@ -19402,6 +21117,11 @@
 /obj/structure/flora/jungle/vines/light_3,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/west_central_jungle)
+"rYe" = (
+/obj/effect/landmark/structure_spawner/xvx_hive/xeno_wall,
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/north_east_caves)
 "rYA" = (
 /obj/structure/platform/mineral/sandstone/runed{
 	dir = 1
@@ -19434,6 +21154,12 @@
 	icon_state = "white"
 	},
 /area/lv624/lazarus/corporate_dome)
+"scs" = (
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 4
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/central_caves)
 "sdh" = (
 /obj/structure/barricade/sandbags/wired,
 /turf/open/floor/wood,
@@ -19467,6 +21193,16 @@
 /obj/structure/fence,
 /turf/open/gm/dirtgrassborder/grassdirt_corner/north_west,
 /area/lv624/ground/colony/north_nexus_road)
+"sgU" = (
+/obj/item/reagent_container/food/snacks/grown/mushroom/plumphelmet,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_west_caves)
+"shb" = (
+/obj/effect/landmark/structure_spawner/xvx_hive/xeno_wall,
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
+/obj/effect/decal/grass_overlay/grass1,
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_central_caves)
 "shq" = (
 /obj/structure/flora/grass/tallgrass/jungle/corner{
 	dir = 10
@@ -19497,6 +21233,15 @@
 	},
 /turf/open/floor/sandstone/runed,
 /area/lv624/ground/caves/sand_temple)
+"snc" = (
+/obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
+	pixel_x = 4;
+	light_on = 1;
+	light_range = 1;
+	light_system = 1
+	},
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_west_caves)
 "sne" = (
 /obj/item/ammo_casing/bullet{
 	icon_state = "cartridge_10_1"
@@ -19518,10 +21263,26 @@
 	icon_state = "cult"
 	},
 /area/lv624/lazarus/armory)
+"soz" = (
+/obj/effect/landmark/structure_spawner/xvx_hive/xeno_door,
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
+/obj/effect/decal/grass_overlay/grass1,
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/west_caves)
+"soY" = (
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 4
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/west_caves)
 "spm" = (
 /obj/structure/flora/jungle/alienplant1,
 /turf/open/gm/river,
 /area/lv624/ground/barrens/east_barrens)
+"spK" = (
+/obj/effect/decal/grass_overlay/grass1/inner,
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/central_caves)
 "sqj" = (
 /turf/open/gm/river,
 /area/lv624/ground/river/central_river)
@@ -19551,6 +21312,12 @@
 	icon_state = "whiteyellowfull"
 	},
 /area/lv624/ground/caves/sand_temple)
+"srn" = (
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 8
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/north_east_caves)
 "ssc" = (
 /turf/open/gm/dirtgrassborder/grassdirt_corner2/north_west,
 /area/lv624/ground/jungle/east_central_jungle)
@@ -19558,6 +21325,11 @@
 /obj/structure/flora/jungle/vines/light_3,
 /turf/closed/wall/mineral/sandstone/runed,
 /area/lv624/ground/caves/sand_temple)
+"stt" = (
+/obj/effect/landmark/structure_spawner/xvx_hive/xeno_wall,
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/north_west_caves)
 "suv" = (
 /obj/structure/flora/jungle/vines/light_1,
 /turf/open/gm/grass/grass2,
@@ -19575,9 +21347,21 @@
 /obj/structure/flora/bush/ausbushes/var3/ywflowers,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/north_jungle)
+"sxl" = (
+/obj/effect/landmark/structure_spawner/xvx_hive/xeno_wall,
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 10
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/west_caves)
 "sxn" = (
 /turf/open/gm/dirtgrassborder/grassdirt_corner2/south_west,
 /area/lv624/ground/barrens/south_eastern_barrens)
+"sxo" = (
+/obj/structure/flora/bush/ausbushes/var3/leafybush,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_east_caves)
 "sxY" = (
 /obj/structure/surface/rack,
 /obj/item/moneybag,
@@ -19595,6 +21379,16 @@
 /obj/structure/fence,
 /turf/open/gm/dirtgrassborder/north,
 /area/lv624/ground/colony/south_medbay_road)
+"sAh" = (
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 4
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_east_caves)
+"sAI" = (
+/obj/structure/flora/jungle/planttop1,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_west_caves)
 "sBg" = (
 /obj/structure/machinery/vending/cigarette,
 /obj/structure/machinery/light{
@@ -19613,6 +21407,9 @@
 /obj/structure/flora/bush/ausbushes/var3/leafybush,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/south_central_jungle)
+"sBY" = (
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/north_west_caves)
 "sCg" = (
 /obj/structure/stairs/perspective{
 	color = "#b29082";
@@ -19642,10 +21439,23 @@
 /obj/structure/flora/bush/ausbushes/var3/brflowers,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/south_central_jungle)
+"sET" = (
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 4
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/north_east_caves)
 "sFc" = (
 /obj/structure/flora/bush/ausbushes/var3/stalkybush,
 /turf/open/gm/river,
 /area/lv624/ground/river/west_river)
+"sFD" = (
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 4
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/north_east_caves)
 "sFY" = (
 /obj/structure/machinery/door/airlock/almayer/engineering/colony{
 	name = "\improper Workshop Storage";
@@ -19699,6 +21509,19 @@
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_core,
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/central_caves)
+"sLT" = (
+/obj/structure/flora/bush/ausbushes/palebush,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/north_west_caves)
+"sLU" = (
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
+/obj/effect/landmark/structure_spawner/xvx_hive/xeno_door,
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 10
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/central_caves)
 "sLX" = (
 /obj/structure/bed/chair/comfy/black{
 	dir = 8
@@ -19716,6 +21539,12 @@
 	},
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/north_east_jungle)
+"sNq" = (
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
+/obj/effect/landmark/structure_spawner/xvx_hive/xeno_door,
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/west_caves)
 "sOp" = (
 /obj/structure/flora/jungle/planttop1,
 /turf/open/gm/grass/grass1,
@@ -19739,6 +21568,10 @@
 /obj/structure/flora/bush/ausbushes/ausbush,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/south_east_jungle)
+"sPK" = (
+/obj/item/reagent_container/food/snacks/grown/mushroom/angel,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/central_caves)
 "sRH" = (
 /obj/structure/flora/bush/ausbushes/palebush,
 /turf/open/gm/grass/grass1,
@@ -19773,6 +21606,14 @@
 /obj/structure/window/framed/colony/reinforced,
 /turf/open/floor,
 /area/lv624/lazarus/hydroponics)
+"sVx" = (
+/obj/effect/landmark/structure_spawner/xvx_hive/xeno_membrane,
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_membrane,
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 1
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_central_caves)
 "sWy" = (
 /obj/effect/landmark/monkey_spawn,
 /turf/open/gm/grass/grass1,
@@ -19804,6 +21645,16 @@
 	icon_state = "squareswood"
 	},
 /area/lv624/ground/caves/sand_temple)
+"sXg" = (
+/obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
+	pixel_x = -10;
+	pixel_y = -2;
+	light_on = 1;
+	light_range = 1;
+	light_system = 1
+	},
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/west_caves)
 "sXi" = (
 /obj/structure/flora/grass/tallgrass/jungle/corner{
 	dir = 1
@@ -19833,6 +21684,16 @@
 /obj/structure/flora/jungle/vines/heavy,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/south_east_jungle)
+"tcF" = (
+/obj/structure/flora/bush/ausbushes/var3/brflowers,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/north_west_caves)
+"tde" = (
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 6
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_central_caves)
 "tdX" = (
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_door,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
@@ -19885,6 +21746,16 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/gm/coast/north,
 /area/lv624/ground/river/west_river)
+"thk" = (
+/obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
+	pixel_x = -5;
+	pixel_y = -5;
+	light_on = 1;
+	light_range = 1;
+	light_system = 1
+	},
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/central_caves)
 "thn" = (
 /obj/item/weapon/claymore/mercsword{
 	pixel_x = -6;
@@ -19913,6 +21784,13 @@
 	icon_state = "multi_tiles"
 	},
 /area/lv624/ground/caves/sand_temple)
+"thI" = (
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 1
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_west_caves)
 "thS" = (
 /obj/structure/barricade/handrail/strata{
 	dir = 8
@@ -19920,12 +21798,6 @@
 /obj/structure/barricade/handrail/strata,
 /turf/open/gm/dirtgrassborder/grassdirt_corner/south_west,
 /area/lv624/ground/barrens/south_eastern_barrens)
-"tiw" = (
-/mob/living/simple_animal/bat,
-/obj/effect/landmark/structure_spawner/xvx_hive/xeno_wall,
-/obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
-/turf/open/gm/dirt,
-/area/lv624/ground/caves/north_west_caves)
 "tka" = (
 /obj/item/ammo_casing/bullet{
 	icon_state = "casing_9_1"
@@ -19938,6 +21810,10 @@
 	},
 /turf/open/gm/dirt,
 /area/lv624/ground/jungle/north_west_jungle)
+"tlk" = (
+/obj/structure/flora/bush/ausbushes/reedbush,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/west_caves)
 "tlD" = (
 /obj/structure/flora/bush/ausbushes/var3/fernybush,
 /turf/open/gm/river,
@@ -19961,6 +21837,11 @@
 	},
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/east_central_jungle)
+"tnY" = (
+/turf/open/gm/dirt{
+	icon_state = "desert3"
+	},
+/area/lv624/ground/caves/west_caves)
 "toz" = (
 /obj/structure/flora/bush/ausbushes/pointybush,
 /turf/open/gm/grass/grass1,
@@ -19990,6 +21871,10 @@
 /obj/structure/flora/jungle/plantbot1,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/west_central_jungle)
+"tqQ" = (
+/obj/effect/decal/grass_overlay/grass1/inner,
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_east_caves)
 "trs" = (
 /obj/item/tool/shovel,
 /turf/open/gm/dirt,
@@ -20012,6 +21897,13 @@
 /obj/structure/fence,
 /turf/open/gm/dirtgrassborder/west,
 /area/lv624/ground/colony/north_nexus_road)
+"tti" = (
+/obj/item/reagent_container/food/snacks/grown/mushroom/plumphelmet{
+	pixel_x = 8;
+	pixel_y = 13
+	},
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/central_caves)
 "ttu" = (
 /obj/structure/flora/jungle/vines/light_1,
 /turf/open/gm/grass/grass1,
@@ -20027,6 +21919,16 @@
 /obj/structure/barricade/handrail/strata,
 /turf/open/gm/dirtgrassborder/grassdirt_corner/south_east,
 /area/lv624/ground/barrens/south_eastern_barrens)
+"tuJ" = (
+/obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
+	pixel_x = -5;
+	pixel_y = -5;
+	light_on = 1;
+	light_range = 1;
+	light_system = 1
+	},
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/north_east_caves)
 "tuX" = (
 /obj/effect/landmark/crap_item,
 /turf/open/floor/wood{
@@ -20102,6 +22004,14 @@
 	},
 /turf/open/gm/dirt,
 /area/lv624/ground/barrens/south_eastern_barrens)
+"tEm" = (
+/obj/effect/landmark/structure_spawner/xvx_hive/xeno_wall,
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 6
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/east_caves)
 "tEn" = (
 /obj/structure/flora/jungle/vines/light_3,
 /turf/open/floor{
@@ -20201,10 +22111,38 @@
 	icon_state = "whiteyellowfull"
 	},
 /area/lv624/ground/barrens/south_eastern_barrens)
+"tMQ" = (
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 9
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_central_caves)
 "tOS" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/west_caves)
+"tOV" = (
+/obj/structure/flora/bush/ausbushes/lavendergrass,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_west_caves)
+"tPH" = (
+/obj/effect/landmark/structure_spawner/xvx_hive/xeno_membrane,
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_membrane,
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 9
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_central_caves)
+"tQU" = (
+/obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
+	pixel_x = 2;
+	pixel_y = 7;
+	light_on = 1;
+	light_range = 1;
+	light_system = 1
+	},
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_west_caves)
 "tRu" = (
 /obj/effect/landmark/hunter_primary,
 /obj/structure/flora/jungle/vines/heavy,
@@ -20214,9 +22152,20 @@
 /obj/effect/decal/cleanable/blood/gibs/xeno,
 /turf/open/gm/dirt,
 /area/lv624/ground/jungle/north_west_jungle)
+"tRM" = (
+/obj/structure/flora/bush/ausbushes/palebush,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/west_caves)
 "tSd" = (
 /turf/open/gm/dirtgrassborder/grassdirt_corner/south_west,
 /area/lv624/lazarus/quartstorage/outdoors)
+"tSi" = (
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 8
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_east_caves)
 "tSN" = (
 /obj/structure/flora/bush/ausbushes/var3/ywflowers,
 /turf/open/gm/grass/grass1,
@@ -20231,6 +22180,12 @@
 /obj/structure/flora/jungle/vines/heavy,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/east_central_jungle)
+"tVw" = (
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 9
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/north_east_caves)
 "tWw" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor{
@@ -20254,8 +22209,17 @@
 /area/lv624/lazarus/crashed_ship_containers)
 "tYx" = (
 /obj/effect/landmark/objective_landmark/medium,
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 4
+	},
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/central_caves)
+"tYW" = (
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 6
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/barrens/north_east_barrens)
 "tZa" = (
 /obj/structure/flora/bush/ausbushes/var3/stalkybush,
 /turf/open/gm/coast/beachcorner/south_east,
@@ -20267,6 +22231,10 @@
 "tZD" = (
 /turf/closed/wall/r_wall,
 /area/lv624/lazarus/landing_zones/lz2)
+"uaL" = (
+/obj/structure/flora/bush/ausbushes/lavendergrass,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/west_caves)
 "uaP" = (
 /obj/structure/flora/bush/ausbushes/var3/fernybush,
 /turf/open/gm/grass/grass1,
@@ -20391,6 +22359,14 @@
 	icon_state = "desert1"
 	},
 /area/lv624/ground/barrens/south_eastern_barrens)
+"ukY" = (
+/obj/effect/landmark/structure_spawner/xvx_hive/xeno_door,
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 4
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/west_caves)
 "ukZ" = (
 /turf/open/floor{
 	dir = 1;
@@ -20432,6 +22408,10 @@
 /obj/structure/flora/jungle/vines/heavy,
 /turf/open/gm/dirtgrassborder/south,
 /area/lv624/ground/jungle/east_jungle)
+"uop" = (
+/obj/structure/flora/bush/ausbushes/reedbush,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/east_caves)
 "upM" = (
 /obj/effect/landmark/crap_item,
 /turf/open/gm/grass/grass1,
@@ -20449,6 +22429,10 @@
 	},
 /turf/open/gm/dirt,
 /area/lv624/ground/jungle/east_jungle)
+"uqm" = (
+/obj/structure/flora/bush/ausbushes/var3/fullgrass,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_west_caves)
 "urR" = (
 /turf/open/floor/corsat{
 	dir = 1;
@@ -20479,6 +22463,12 @@
 "uvh" = (
 /turf/open/gm/dirtgrassborder/grassdirt_corner/south_west,
 /area/lv624/ground/barrens/south_eastern_barrens)
+"uwG" = (
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 6
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_central_caves)
 "uxh" = (
 /obj/structure/flora/bush/ausbushes/var3/brflowers,
 /turf/open/gm/grass/grass1,
@@ -20488,6 +22478,16 @@
 /obj/effect/landmark/corpsespawner/security/liaison,
 /turf/open/floor/wood,
 /area/lv624/ground/caves/north_central_caves)
+"uxL" = (
+/obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
+	pixel_x = 11;
+	pixel_y = -2;
+	light_on = 1;
+	light_range = 1;
+	light_system = 1
+	},
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_central_caves)
 "uxT" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/gm/coast/east,
@@ -20498,6 +22498,12 @@
 "uya" = (
 /turf/open/gm/dirt,
 /area/lv624/lazarus/crashed_ship_containers)
+"uyn" = (
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 10
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_east_caves)
 "uzH" = (
 /turf/open/floor/plating{
 	dir = 8;
@@ -20507,6 +22513,11 @@
 "uAp" = (
 /turf/closed/wall/strata_ice/jungle,
 /area/lv624/ground/barrens/south_eastern_barrens)
+"uBR" = (
+/obj/effect/landmark/structure_spawner/xvx_hive/xeno_wall,
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/east_caves)
 "uDd" = (
 /obj/structure/showcase{
 	desc = "An ancient, dusty tomb with strange alien writing. It's best not to touch it.";
@@ -20568,6 +22579,12 @@
 	icon_state = "whitebluecorner"
 	},
 /area/lv624/lazarus/corporate_dome)
+"uHc" = (
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 9
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/north_east_caves)
 "uHI" = (
 /obj/structure/flora/bush/ausbushes/var3/leafybush,
 /turf/open/gm/grass/grass2,
@@ -20590,11 +22607,17 @@
 	},
 /turf/open/gm/grass/grass2,
 /area/lv624/ground/jungle/north_jungle)
+"uMd" = (
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 9
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/central_caves)
 "uMz" = (
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_door,
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_door,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
-/turf/open/gm/dirt,
+/turf/open/auto_turf/strata_grass/layer1,
 /area/lv624/ground/caves/central_caves)
 "uMD" = (
 /obj/structure/flora/jungle/vines/light_3,
@@ -20605,6 +22628,20 @@
 /obj/structure/flora/jungle/vines/light_3,
 /turf/open/gm/dirtgrassborder/grassdirt_corner/south_east,
 /area/lv624/ground/caves/sand_temple)
+"uOl" = (
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 5
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/central_caves)
+"uOu" = (
+/obj/item/reagent_container/food/snacks/grown/mushroom/libertycap,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/north_west_caves)
+"uOD" = (
+/obj/structure/flora/bush/ausbushes/var3/fullgrass,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_central_caves)
 "uOK" = (
 /obj/effect/landmark/objective_landmark/close,
 /turf/open/floor{
@@ -20615,6 +22652,10 @@
 /obj/structure/machinery/colony_floodlight,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/colony/west_tcomms_road)
+"uRe" = (
+/obj/effect/decal/grass_overlay/grass1,
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/west_caves)
 "uRE" = (
 /turf/open/gm/dirtgrassborder/west,
 /area/lv624/lazarus/landing_zones/lz2)
@@ -20693,6 +22734,9 @@
 	icon_state = "wood-broken"
 	},
 /area/lv624/ground/caves/north_central_caves)
+"uYj" = (
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/north_east_caves)
 "uYC" = (
 /obj/structure/flora/grass/tallgrass/jungle/corner{
 	dir = 6
@@ -20739,10 +22783,22 @@
 	},
 /turf/open/gm/dirt,
 /area/lv624/ground/jungle/east_jungle)
+"vbK" = (
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
+/obj/effect/landmark/structure_spawner/xvx_hive/xeno_door,
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
+/obj/effect/decal/grass_overlay/grass1,
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/central_caves)
 "vcY" = (
 /obj/structure/machinery/colony_floodlight,
 /turf/open/gm/grass/grass1,
 /area/lv624/lazarus/landing_zones/lz2)
+"vdt" = (
+/obj/effect/landmark/structure_spawner/xvx_hive/xeno_door,
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/north_east_caves)
 "vdy" = (
 /obj/structure/machinery/door/airlock/almayer/engineering/colony{
 	dir = 1;
@@ -20801,6 +22857,19 @@
 /obj/structure/girder,
 /turf/open/gm/dirt,
 /area/lv624/lazarus/crashed_ship_containers)
+"vih" = (
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 8
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_central_caves)
+"viC" = (
+/obj/effect/landmark/structure_spawner/xvx_hive/xeno_door,
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
+/obj/effect/decal/grass_overlay/grass1/inner,
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_east_caves)
 "vjH" = (
 /obj/structure/flora/jungle/vines/light_3,
 /turf/open/gm/grass/grass1,
@@ -20828,6 +22897,25 @@
 /obj/effect/landmark/objective_landmark/far,
 /turf/open/gm/dirt,
 /area/lv624/ground/jungle/south_central_jungle)
+"vkS" = (
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 10
+	},
+/obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
+	pixel_x = 2;
+	pixel_y = 7;
+	light_on = 1;
+	light_range = 1;
+	light_system = 1
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_east_caves)
+"vle" = (
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 9
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/west_caves)
 "vly" = (
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_door,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
@@ -20866,6 +22954,14 @@
 /obj/structure/flora/bush/ausbushes/ausbush,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/barrens/south_eastern_barrens)
+"vtk" = (
+/obj/effect/landmark/structure_spawner/xvx_hive/xeno_wall,
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 6
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_central_caves)
 "vtt" = (
 /obj/structure/flora/jungle/vines/light_2,
 /turf/open/gm/grass/grass1,
@@ -20900,6 +22996,13 @@
 	},
 /turf/open/gm/grass/grass1,
 /area/lv624/lazarus/landing_zones/lz2)
+"vxj" = (
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 9
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/north_east_caves)
 "vxU" = (
 /obj/structure/flora/bush/ausbushes/lavendergrass,
 /turf/open/gm/grass/grass1,
@@ -20911,6 +23014,25 @@
 	icon_state = "vault"
 	},
 /area/lv624/lazarus/quartstorage)
+"vAg" = (
+/obj/effect/landmark/structure_spawner/xvx_hive/xeno_wall,
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_east_caves)
+"vAB" = (
+/obj/structure/flora/bush/ausbushes/var3/fullgrass,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/central_caves)
+"vAT" = (
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_east_caves)
+"vBd" = (
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 4
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/central_caves)
 "vBe" = (
 /turf/open/gm/dirtgrassborder/east,
 /area/lv624/ground/jungle/east_central_jungle)
@@ -20957,6 +23079,19 @@
 	},
 /turf/open/gm/grass/grass1,
 /area/lv624/lazarus/landing_zones/lz1)
+"vGj" = (
+/obj/structure/flora/bush/ausbushes/ppflowers,
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 10
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_west_caves)
+"vGy" = (
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 1
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/north_west_caves)
 "vHe" = (
 /obj/structure/surface/rack,
 /obj/item/stack/sheet/plasteel{
@@ -21006,10 +23141,23 @@
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/south_west_caves)
+"vNs" = (
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 9
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/north_west_caves)
 "vNP" = (
 /obj/effect/landmark/monkey_spawn,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/east_jungle)
+"vNT" = (
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 1
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_east_caves)
 "vNW" = (
 /obj/structure/flora/bush/ausbushes/grassybush,
 /turf/open/gm/grass/grass1,
@@ -21021,6 +23169,14 @@
 "vOF" = (
 /turf/open/gm/dirtgrassborder/west,
 /area/lv624/ground/jungle/south_central_jungle)
+"vPo" = (
+/obj/effect/landmark/structure_spawner/xvx_hive/xeno_wall,
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 8
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/north_east_caves)
 "vPu" = (
 /obj/effect/landmark/objective_landmark/close,
 /turf/open/floor,
@@ -21028,6 +23184,10 @@
 "vPV" = (
 /turf/open/gm/dirtgrassborder/grassdirt_corner2/south_west,
 /area/lv624/ground/jungle/east_jungle)
+"vQR" = (
+/obj/structure/flora/bush/ausbushes/var3/sunnybush,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_east_caves)
 "vSG" = (
 /obj/structure/flora/jungle/vines/light_1,
 /turf/open/gm/grass/grass1,
@@ -21069,6 +23229,12 @@
 /obj/structure/flora/jungle/vines/light_3,
 /turf/closed/wall/strata_ice/jungle,
 /area/lv624/ground/jungle/east_jungle)
+"vXP" = (
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 8
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_west_caves)
 "vXW" = (
 /obj/structure/flora/jungle/vines/light_3,
 /obj/structure/flora/jungle/vines/heavy,
@@ -21078,6 +23244,18 @@
 /obj/effect/landmark/objective_landmark/close,
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/south_west_caves)
+"waw" = (
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 9
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/north_west_caves)
+"wbg" = (
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 1
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_central_caves)
 "wbK" = (
 /obj/structure/flora/jungle/vines/heavy,
 /turf/open/gm/grass/grass1,
@@ -21133,6 +23311,16 @@
 	},
 /turf/open/gm/dirtgrassborder/grassdirt_corner/south_west,
 /area/lv624/ground/caves/sand_temple)
+"whk" = (
+/obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
+	pixel_x = 2;
+	pixel_y = 7;
+	light_on = 1;
+	light_range = 1;
+	light_system = 1
+	},
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/north_west_caves)
 "whr" = (
 /obj/item/ammo_magazine/smg/mp5,
 /obj/item/ammo_magazine/smg/mp5,
@@ -21149,6 +23337,10 @@
 	icon_state = "desert2"
 	},
 /area/lv624/ground/barrens/south_eastern_barrens)
+"whx" = (
+/obj/structure/flora/bush/ausbushes/lavendergrass,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_east_caves)
 "whQ" = (
 /obj/structure/flora/bush/ausbushes/var3/sunnybush{
 	desc = "The oranges aren't done yet... this sucks.";
@@ -21243,9 +23435,19 @@
 	icon_state = "multi_tiles"
 	},
 /area/lv624/ground/caves/sand_temple)
+"woT" = (
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 4
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/east_caves)
 "wpw" = (
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/south_east_jungle)
+"wpY" = (
+/obj/structure/flora/bush/ausbushes/var3/leafybush,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/barrens/north_east_barrens)
 "wqy" = (
 /obj/structure/flora/bush/ausbushes/reedbush,
 /turf/open/gm/dirt,
@@ -21267,6 +23469,10 @@
 /obj/structure/flora/jungle/vines/light_2,
 /turf/closed/wall/strata_ice/jungle,
 /area/lv624/ground/jungle/north_east_jungle)
+"wty" = (
+/obj/structure/flora/bush/ausbushes/ppflowers,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_west_caves)
 "wtK" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/storage/fancy/cigarettes/wypacket{
@@ -21300,6 +23506,10 @@
 /obj/structure/flora/jungle/vines/heavy,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/north_west_jungle)
+"wzI" = (
+/obj/structure/flora/bush/ausbushes/var3/ywflowers,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_central_caves)
 "wAe" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/structure/machinery/door_control{
@@ -21312,6 +23522,12 @@
 	icon_state = "white"
 	},
 /area/lv624/lazarus/research)
+"wAF" = (
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 1
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_west_caves)
 "wAI" = (
 /obj/structure/flora/jungle/vines/light_2,
 /turf/open/gm/dirtgrassborder/south,
@@ -21324,6 +23540,12 @@
 /obj/item/clothing/suit/armor/yautja_flavor,
 /turf/open/floor/sandstone/runed,
 /area/lv624/ground/barrens/south_eastern_barrens)
+"wCs" = (
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 6
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/east_caves)
 "wEO" = (
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_door,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
@@ -21349,12 +23571,28 @@
 	icon_state = "wood-broken3"
 	},
 /area/lv624/ground/caves/north_central_caves)
+"wHh" = (
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 6
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/west_caves)
 "wHp" = (
 /turf/open/floor/plating{
 	dir = 1;
 	icon_state = "asteroidfloor"
 	},
 /area/lv624/lazarus/landing_zones/lz2)
+"wHE" = (
+/obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
+	pixel_x = -1;
+	pixel_y = 7;
+	light_on = 1;
+	light_range = 1;
+	light_system = 1
+	},
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_west_caves)
 "wJA" = (
 /obj/structure/flora/jungle/vines/light_3,
 /obj/structure/window/framed/colony/reinforced,
@@ -21389,10 +23627,24 @@
 	icon_state = "asteroidwarning"
 	},
 /area/lv624/lazarus/landing_zones/lz2)
+"wLT" = (
+/obj/structure/flora/bush/ausbushes/var3/fullgrass,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_east_caves)
 "wMk" = (
 /obj/structure/flora/jungle/vines/heavy,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/west_central_jungle)
+"wMr" = (
+/obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
+	pixel_x = 2;
+	pixel_y = 7;
+	light_on = 1;
+	light_range = 1;
+	light_system = 1
+	},
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/north_east_caves)
 "wNp" = (
 /obj/effect/landmark/objective_landmark/medium,
 /turf/open/gm/dirt,
@@ -21435,6 +23687,18 @@
 /obj/structure/flora/bush/ausbushes/grassybush,
 /turf/open/gm/grass/grass2,
 /area/lv624/ground/jungle/south_west_jungle)
+"wQK" = (
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 1
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/west_caves)
+"wRb" = (
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 8
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/north_east_caves)
 "wSg" = (
 /obj/structure/inflatable/popped,
 /turf/open/gm/dirt,
@@ -21568,6 +23832,18 @@
 /obj/structure/flora/jungle/vines/light_3,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/south_east_jungle)
+"wYz" = (
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 1
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_west_caves)
+"wYB" = (
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 5
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/north_east_caves)
 "wZc" = (
 /obj/structure/flora/bush/ausbushes/var3/brflowers,
 /turf/open/gm/grass/grass1,
@@ -21585,6 +23861,10 @@
 	},
 /turf/open/gm/dirt,
 /area/lv624/ground/barrens/south_eastern_barrens)
+"xar" = (
+/obj/effect/decal/grass_overlay/grass1/inner,
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/east_caves)
 "xbu" = (
 /obj/item/shard,
 /turf/open/floor{
@@ -21599,6 +23879,10 @@
 /obj/structure/flora/bush/ausbushes/pointybush,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/south_east_jungle)
+"xdb" = (
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_central_caves)
 "xdO" = (
 /turf/open/gm/dirtgrassborder/south,
 /area/lv624/ground/jungle/south_west_jungle)
@@ -21635,6 +23919,17 @@
 "xgE" = (
 /turf/closed/wall/r_wall,
 /area/lv624/lazarus/corporate_dome)
+"xhc" = (
+/mob/living/simple_animal/bat,
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 1
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/north_west_caves)
+"xhv" = (
+/obj/effect/decal/grass_overlay/grass1,
+/turf/open/gm/dirt,
+/area/lv624/ground/barrens/north_east_barrens)
 "xhC" = (
 /turf/open/gm/dirtgrassborder/grassdirt_corner/south_east,
 /area/lv624/ground/barrens/south_eastern_barrens)
@@ -21645,6 +23940,10 @@
 	icon_state = "whiteyellow"
 	},
 /area/lv624/lazarus/corporate_dome)
+"xmK" = (
+/obj/structure/flora/bush/ausbushes/grassybush,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/east_caves)
 "xov" = (
 /obj/effect/landmark/hunter_primary,
 /turf/open/gm/dirt,
@@ -21713,6 +24012,10 @@
 "xwr" = (
 /turf/open/gm/dirt,
 /area/lv624/ground/barrens/west_barrens)
+"xwN" = (
+/obj/structure/flora/bush/ausbushes/var3/brflowers,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/east_caves)
 "xwQ" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/handcuffs/cable/white{
@@ -21732,6 +24035,14 @@
 	icon_state = "whiteyellow"
 	},
 /area/lv624/lazarus/corporate_dome)
+"xyH" = (
+/obj/effect/landmark/structure_spawner/xvx_hive/xeno_wall,
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 1
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/west_caves)
 "xyI" = (
 /obj/item/ammo_magazine/rifle/nsg23{
 	current_rounds = 0
@@ -21755,6 +24066,10 @@
 "xBm" = (
 /turf/open/gm/river,
 /area/lv624/ground/barrens/west_barrens)
+"xBO" = (
+/obj/structure/flora/bush/ausbushes/palebush,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_west_caves)
 "xCF" = (
 /obj/item/ammo_magazine/smg/mp5,
 /obj/item/weapon/gun/smg/mp5,
@@ -21786,10 +24101,23 @@
 /obj/structure/flora/jungle/vines/heavy,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/east_central_jungle)
+"xGL" = (
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 6
+	},
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 9
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/east_caves)
 "xHa" = (
 /obj/effect/landmark/crap_item,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/north_west_jungle)
+"xHW" = (
+/obj/structure/flora/bush/ausbushes/var3/brflowers,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/west_caves)
 "xJA" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/gm/river,
@@ -21808,11 +24136,24 @@
 /obj/structure/flora/jungle/vines/light_3,
 /turf/open/gm/dirtgrassborder/east,
 /area/lv624/ground/jungle/west_jungle)
+"xKL" = (
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 10
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/west_caves)
 "xLi" = (
 /obj/structure/surface/rack,
 /obj/item/storage/box/lights/mixed,
 /turf/open/floor/vault,
 /area/lv624/lazarus/quartstorage)
+"xNi" = (
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 4
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/barrens/north_east_barrens)
 "xNK" = (
 /turf/open/gm/dirt,
 /area/lv624/ground/barrens/containers)
@@ -21844,12 +24185,22 @@
 	},
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/east_jungle)
+"xRe" = (
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 10
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/central_caves)
 "xRo" = (
 /obj/structure/flora/grass/tallgrass/jungle/corner{
 	dir = 1
 	},
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/south_central_jungle)
+"xSk" = (
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/north_east_caves)
 "xSA" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_door,
@@ -21883,6 +24234,12 @@
 "xVN" = (
 /turf/open/gm/dirtgrassborder/grassdirt_corner2/south_west,
 /area/lv624/ground/jungle/south_central_jungle)
+"xWy" = (
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 1
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/central_caves)
 "xXB" = (
 /obj/structure/flora/bush/ausbushes/var3/sunnybush,
 /turf/open/gm/grass/grass1,
@@ -21894,6 +24251,12 @@
 /obj/structure/flora/jungle/vines/light_2,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/east_central_jungle)
+"xYD" = (
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 9
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_west_caves)
 "xZE" = (
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_wall,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
@@ -21922,8 +24285,14 @@
 /area/lv624/ground/barrens/south_eastern_jungle_barrens)
 "ydz" = (
 /obj/structure/blocker/forcefield/multitile_vehicles,
-/turf/open/gm/dirt,
+/turf/open/auto_turf/strata_grass/layer1,
 /area/lv624/ground/caves/central_caves)
+"yfe" = (
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 8
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_east_caves)
 "yfH" = (
 /turf/open/shuttle{
 	icon_state = "floor4"
@@ -21961,6 +24330,11 @@
 	icon_state = "purple"
 	},
 /area/lv624/lazarus/sleep_female)
+"yhT" = (
+/turf/open/gm/dirt{
+	icon_state = "desert2"
+	},
+/area/lv624/ground/caves/west_caves)
 "yhY" = (
 /obj/structure/inflatable/door,
 /turf/open/gm/dirt,
@@ -21993,6 +24367,10 @@
 /obj/structure/fence,
 /turf/open/gm/dirtgrassborder/grassdirt_corner2/north_east,
 /area/lv624/ground/colony/west_tcomms_road)
+"yjs" = (
+/obj/structure/flora/bush/ausbushes/pointybush,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/central_caves)
 "yjN" = (
 /obj/structure/flora/jungle/vines/heavy,
 /obj/structure/machinery/door/airlock/sandstone/runed/destroyable{
@@ -23264,7 +25642,7 @@ mdQ
 mdQ
 gwP
 gwP
-gwP
+yhT
 mdQ
 mdQ
 mdQ
@@ -23716,10 +26094,10 @@ gwP
 gwP
 gwP
 tOS
-gwP
-gwP
-gwP
-tOS
+vle
+qdx
+qdx
+hyF
 gwP
 gwP
 gwP
@@ -23942,18 +26320,18 @@ gwP
 gwP
 gwP
 gwP
+vle
+qdx
+cHW
+dOA
+dmT
+grW
+xKL
 gwP
-gwP
-gwP
-gwP
-gwP
-gwP
-gwP
-gwP
-gwP
+yhT
 tOS
 gwP
-gwP
+ptm
 gwP
 gwP
 gwP
@@ -24165,19 +26543,19 @@ mdQ
 mdQ
 mdQ
 gwP
+ptm
 gwP
-gwP
-gwP
+tnY
 tOS
 gwP
-gwP
-gwP
-gwP
-gwP
-gwP
-gwP
-gwP
-gwP
+wQK
+cQB
+dmT
+dmT
+rmW
+ndk
+grW
+xKL
 gwP
 gwP
 gwP
@@ -24213,7 +26591,7 @@ amy
 ane
 ane
 ane
-ahF
+krs
 ahF
 ane
 ane
@@ -24398,14 +26776,14 @@ gwP
 gwP
 gwP
 gwP
-gwP
+wQK
 mdQ
 mdQ
 onU
 onU
-gwP
-gwP
-gwP
+owe
+dmT
+uRe
 gwP
 gwP
 gwP
@@ -24433,7 +26811,7 @@ nBh
 afV
 ahF
 ahF
-ahF
+aYI
 ahF
 ahF
 ahF
@@ -24623,23 +27001,23 @@ gwP
 gwP
 gwP
 gwP
-gwP
-gwP
-gwP
+vle
+qdx
+qdx
 mdQ
 mdQ
 mdQ
 onU
 onU
 mdQ
-gwP
-tOS
+dmT
+igN
 gwP
 gwP
 mdQ
 gwP
 gwP
-gwP
+yhT
 gwP
 gwP
 gwP
@@ -24850,9 +27228,9 @@ mdQ
 gwP
 gwP
 tOS
-gwP
-gwP
-gwP
+vle
+amI
+dmT
 mdQ
 mdQ
 onU
@@ -24860,8 +27238,8 @@ onU
 onU
 mdQ
 mdQ
-gwP
-gwP
+bcb
+wHh
 gwP
 gwP
 mdQ
@@ -24898,7 +27276,7 @@ ahF
 ahF
 ahF
 ahF
-ahF
+cCP
 ahF
 ane
 ane
@@ -25078,8 +27456,8 @@ gwP
 gwP
 gwP
 gwP
-gwP
-gwP
+wQK
+dmT
 mdQ
 mdQ
 onU
@@ -25302,13 +27680,13 @@ mdQ
 mdQ
 mdQ
 mdQ
+ofg
 gwP
 gwP
 gwP
-gwP
-gwP
-gwP
-gwP
+wQK
+dmT
+fRU
 onU
 onU
 onU
@@ -25317,7 +27695,7 @@ mdQ
 gwP
 gwP
 gwP
-gwP
+ptm
 gwP
 gwP
 mdQ
@@ -25336,8 +27714,8 @@ afV
 afV
 afV
 afV
-ahF
-ahF
+hRy
+aYI
 ahF
 afV
 afV
@@ -25530,18 +27908,18 @@ gwP
 mdQ
 mdQ
 gwP
+ptm
 gwP
 gwP
 gwP
-gwP
-gwP
-gwP
-gwP
-gwP
-gwP
+wQK
+dmT
+dmT
+nRA
+htV
 onU
 mdQ
-gwP
+uRe
 gwP
 gwP
 gwP
@@ -25562,6 +27940,7 @@ ahF
 ahF
 ahF
 ahF
+aYI
 ahF
 ahF
 ahF
@@ -25572,8 +27951,7 @@ ahF
 ahF
 ahF
 ahF
-ahF
-ahF
+krs
 ahF
 ane
 ane
@@ -25757,19 +28135,19 @@ gwP
 gwP
 mdQ
 mdQ
+lav
 gwP
 gwP
+ofg
 gwP
-gwP
-gwP
-gwP
-tOS
-gwP
-gwP
-gwP
-gwP
-gwP
-gwP
+hjo
+gvm
+qJE
+dmT
+dmT
+dmT
+fLh
+uRe
 gwP
 tOS
 gwP
@@ -25796,7 +28174,7 @@ ahF
 ahF
 ahF
 ahF
-ahF
+fDT
 ahF
 ahF
 ahF
@@ -25992,12 +28370,12 @@ gwP
 gwP
 gwP
 gwP
-gwP
-gwP
-gwP
-tOS
-gwP
-gwP
+hjo
+qJE
+tlk
+gRk
+owZ
+wHh
 gwP
 gwP
 gwP
@@ -26022,7 +28400,7 @@ ahF
 ahF
 ahF
 ahF
-ahF
+krs
 ahF
 ahF
 ahH
@@ -26030,14 +28408,14 @@ ahF
 ahF
 ahF
 ahF
-ahF
+cCP
 ahF
 ane
+fDT
 ahF
 ahF
 ahF
-ahF
-ahF
+aYI
 ahF
 ahF
 ane
@@ -26213,6 +28591,7 @@ gwP
 gwP
 gwP
 aca
+ptm
 gwP
 gwP
 gwP
@@ -26220,14 +28599,13 @@ gwP
 gwP
 gwP
 gwP
+hjo
+qhl
+qhl
+wHh
 gwP
-gwP
-gwP
-gwP
-gwP
-gwP
-gwP
-gwP
+ptm
+yhT
 gwP
 mdQ
 mdQ
@@ -26246,10 +28624,10 @@ ahF
 ahF
 ahV
 ahF
-ahF
-ahH
-ahF
-ahF
+xYD
+gTj
+gTj
+nys
 ahF
 ahF
 ahF
@@ -26472,13 +28850,13 @@ ane
 ane
 ahF
 ahF
-ahF
-ahF
-ahF
-ahF
-ahF
-ahF
-ahF
+xYD
+hmq
+lYt
+chi
+fmW
+rHV
+nys
 ePu
 ahF
 ahF
@@ -26493,9 +28871,9 @@ ane
 ahF
 ahF
 ahF
-ahF
-ahF
-ahF
+hRy
+hRy
+fDT
 afV
 ane
 ane
@@ -26640,7 +29018,7 @@ mdQ
 mdQ
 mdQ
 mdQ
-gwP
+uRe
 gwP
 gwP
 gwP
@@ -26699,19 +29077,19 @@ ane
 ane
 ane
 ane
-ahF
-ahF
-ahF
-ahF
+xYD
+lYt
+fmW
+fmW
 uWJ
+ilF
+fmW
+rHV
+nys
 ahF
 ahF
 ahF
-ahF
-ahF
-ahF
-ahF
-ahF
+aYI
 ahF
 ahH
 ahF
@@ -26827,9 +29205,9 @@ abB
 abB
 abB
 abN
-abN
-abN
-abN
+pSe
+kzn
+tcF
 amk
 amk
 amk
@@ -26838,7 +29216,7 @@ abM
 abM
 abM
 abM
-abN
+qVh
 abN
 abN
 abN
@@ -26866,9 +29244,9 @@ amk
 onU
 onU
 mdQ
-tOS
-gwP
-gwP
+gRk
+dmT
+uRe
 gwP
 gwP
 gwP
@@ -26927,16 +29305,16 @@ ane
 ane
 ane
 ahF
-ahF
-ahF
-ahF
+wAF
+aIE
+fmW
 uWJ
 uWJ
 uWJ
-ahF
-ahF
-ahF
-ahF
+fmW
+fmW
+vGj
+nys
 ahF
 ahF
 ahF
@@ -27052,21 +29430,21 @@ abM
 abM
 abB
 abB
-tiw
+abB
+tgL
 abN
 abN
-abN
-abN
-abN
-abN
+lTv
+pLv
+sBY
 amk
 amk
 amk
 amk
 amk
 abM
-abN
-abN
+qiL
+qVh
 abQ
 abN
 abN
@@ -27087,16 +29465,16 @@ abN
 abN
 abN
 abN
-abN
-abN
-abN
-abN
+cMG
+waw
+cWs
+sBY
 onU
 onU
 onU
-gwP
-gwP
-gwP
+lKl
+tRM
+uRe
 gwP
 gwP
 gwP
@@ -27111,11 +29489,11 @@ gwP
 gwP
 gwP
 gwP
-gwP
-gwP
-gwP
-gwP
-gwP
+vle
+jvQ
+jvQ
+jvQ
+xKL
 gwP
 gwP
 gwP
@@ -27155,20 +29533,20 @@ ane
 ane
 ahF
 ahF
-ahF
-ahF
+wAF
+fmW
 uWJ
 uWJ
 uWJ
+eoW
+fmW
+fmW
+fmW
+rHV
+vXP
+nys
 ahF
-ahF
-ahH
-ahF
-ahF
-ahF
-ahF
-ahF
-ahF
+aYI
 ahF
 ahF
 ahF
@@ -27284,17 +29662,17 @@ abN
 abN
 abN
 abN
-abN
-abN
-abN
-abN
-abN
+pSe
+kzn
+sBY
+sBY
+sBY
 amk
 amk
-abN
-abN
-abN
-abN
+gnt
+qVN
+sBY
+qVh
 abN
 abN
 abN
@@ -27314,17 +29692,17 @@ abN
 abN
 abN
 abQ
-abN
-abN
-abN
-abN
-abN
-aca
-gwP
-gwP
-gwP
-gwP
-gwP
+cMG
+waw
+sBY
+sBY
+sBY
+iGf
+dKl
+dmT
+dmT
+owZ
+wHh
 gwP
 gwP
 gwP
@@ -27337,14 +29715,14 @@ gwP
 aYC
 gwP
 gwP
-gwP
-gwP
-gwP
-tOS
-gwP
-gwP
-gwP
-gwP
+vle
+jvQ
+pkU
+gRk
+lLK
+dmT
+grW
+xKL
 gwP
 gwP
 gwP
@@ -27382,19 +29760,19 @@ ane
 ane
 ahF
 ahF
-ahH
 ahF
-ahF
-ahF
-ahF
-ahF
-ahF
-ahF
-ahF
-ahF
-ahF
-ahF
-ahF
+doe
+pIl
+eZg
+fmW
+fmW
+fmW
+fmW
+fmW
+fmW
+fmW
+fmW
+rHV
 ahF
 ahF
 ane
@@ -27513,16 +29891,16 @@ abN
 abN
 abN
 abN
-abQ
-abN
-abN
-abN
-abN
-abN
-abN
-abN
-abN
-abN
+bak
+kzn
+iXX
+sBY
+sBY
+iNJ
+sBY
+sBY
+frV
+klD
 abN
 abN
 abN
@@ -27541,39 +29919,39 @@ abN
 abN
 abN
 abN
-abN
-abN
-abN
-abN
-abQ
-abN
+cMG
+waw
+sBY
+sBY
+fTN
+sBY
+iGf
+dmT
+gRk
+owZ
+wHh
+gwP
+gwP
+gwP
+gwP
+gwP
+gwP
+gwP
+gwP
+gwP
+gwP
 aca
 gwP
-tOS
 gwP
-gwP
-gwP
-gwP
-gwP
-gwP
-gwP
-gwP
-gwP
-gwP
-gwP
-gwP
-aca
-gwP
-gwP
-gwP
-xZE
-xZE
-xZE
-gwP
-gwP
-gwP
-gwP
-gwP
+jGU
+hhs
+hhs
+hhs
+htV
+dOA
+fRU
+grW
+xKL
 gwP
 gwP
 gwP
@@ -27609,20 +29987,20 @@ ane
 ane
 ane
 ahF
+aYI
 ahF
 ahF
-ahF
-ahF
-ahF
-ahF
-ahF
-ahF
-ahF
-ahF
-ahF
-ahF
-ahF
-ahF
+doe
+pIl
+uqm
+fmW
+fmW
+fmW
+ikA
+fmW
+fmW
+wty
+chi
 ane
 ane
 ane
@@ -27635,7 +30013,7 @@ ane
 ahF
 ahF
 ahH
-ahF
+cCP
 ahF
 ane
 ane
@@ -27737,19 +30115,19 @@ abN
 abN
 abN
 abN
-abQ
-abN
-abN
-abN
-abN
-abN
-abN
-abN
-abN
-abN
-abN
-abQ
-abN
+vNs
+bdu
+bdu
+bdu
+jKc
+pSe
+jLY
+jLY
+jLY
+jLY
+jLY
+kKa
+klD
 abN
 abN
 abN
@@ -27768,17 +30146,17 @@ abM
 abB
 abN
 abN
-abN
-abN
-abN
-abN
-abN
-abN
-abN
-aca
-gwP
-gwP
-gwP
+cMG
+waw
+gvr
+uOu
+sBY
+iNJ
+sBY
+iGf
+owZ
+qhl
+wHh
 gwP
 qaE
 gwP
@@ -27798,11 +30176,11 @@ mdQ
 onU
 onU
 onU
-xZE
-xZE
-xZE
-gwP
-gwP
+hhs
+hhs
+hhs
+grW
+jvQ
 gwP
 gwP
 tOS
@@ -27841,22 +30219,22 @@ ahF
 vZT
 ahF
 ahF
-ahF
-ahF
-ahF
+doe
+qSS
+pIl
 dWM
-ahF
-ahF
-ahF
-ahF
-ahF
-ahF
+fmW
+fmW
+fmW
+fmW
+sAI
+pBH
 ane
 ane
 afV
 afV
-ahF
-ahF
+hRy
+krs
 afV
 afV
 ane
@@ -27962,16 +30340,16 @@ abN
 abN
 abN
 abN
-abN
-abN
-abN
-abN
-abN
-abN
-abN
-abN
-abN
-abN
+cMG
+bdu
+bdu
+waw
+tcF
+sBY
+sBY
+mgi
+bdu
+jKc
 abQ
 abN
 abN
@@ -27995,11 +30373,11 @@ abN
 abN
 dhD
 abN
-abQ
-abN
-abN
-abN
-abN
+vNs
+waw
+sBY
+sBY
+sBY
 amk
 abM
 abM
@@ -28028,11 +30406,11 @@ onU
 onU
 onU
 onU
-xZE
-xZE
-xZE
-gwP
-gwP
+hhs
+hhs
+hhs
+grW
+xKL
 gwP
 gwP
 gwP
@@ -28069,13 +30447,13 @@ ane
 ane
 ane
 ahF
+fDT
 ahF
-ahF
-ahF
-ahF
-ahF
-ahF
-ahF
+wAF
+fmW
+fmW
+snc
+fmW
 uWJ
 uWJ
 uWJ
@@ -28083,7 +30461,7 @@ ane
 ane
 afV
 ahF
-ahF
+aYI
 ahF
 ahF
 afV
@@ -28189,17 +30567,17 @@ abM
 abN
 abN
 abN
-abQ
-abN
-abN
-abN
-abN
-abN
-abN
-abN
-abN
-abN
-abN
+vNs
+waw
+dIj
+sBY
+sBY
+sBY
+sBY
+pLv
+sBY
+sBY
+hKP
 abN
 abN
 abN
@@ -28222,12 +30600,12 @@ abN
 abN
 abQ
 dhD
-abN
-abN
-abN
-abN
-abN
-abN
+cMG
+waw
+sBY
+sBY
+sBY
+sBY
 amk
 amk
 abM
@@ -28258,9 +30636,9 @@ onU
 onU
 onU
 onU
-xZE
-xZE
-gwP
+hhs
+hhs
+uRe
 gwP
 gwP
 gwP
@@ -28298,12 +30676,12 @@ afV
 afV
 afV
 ahF
-ahF
-ahH
-ahF
-ahF
-ahF
-ahF
+cCP
+wAF
+fmW
+fmW
+jCO
+uqm
 uWJ
 ane
 ane
@@ -28417,17 +30795,17 @@ abM
 abN
 abN
 abN
-abN
-abN
-abN
-abN
+vGy
+sBY
+whk
+sBY
 amk
 amk
 amk
 amk
-abN
-abN
-abN
+sBY
+sBY
+hKP
 abN
 abN
 abN
@@ -28450,11 +30828,11 @@ abN
 abN
 abN
 dhD
-abN
-abN
-abN
-abN
-abN
+vGy
+sBY
+sBY
+gnt
+sBY
 amk
 amk
 amk
@@ -28522,14 +30900,14 @@ ahF
 ahF
 ahF
 ahF
-ahF
+cCP
 ahF
 afJ
-ahF
-ahF
-ahF
-ahF
-ahF
+xYD
+vXP
+lYt
+dIu
+fmW
 ane
 ane
 ane
@@ -28542,7 +30920,7 @@ ahF
 ahF
 ahF
 ahF
-ahF
+cCP
 ahF
 ahF
 ahF
@@ -28645,7 +31023,7 @@ abN
 abN
 abN
 abN
-abN
+vGy
 abM
 abM
 amk
@@ -28678,10 +31056,10 @@ abN
 abN
 abN
 dhD
-abN
-abN
-abN
-abN
+vGy
+qVN
+sBY
+ksc
 amk
 amk
 amk
@@ -28744,7 +31122,7 @@ acp
 ane
 ane
 ahF
-ahF
+fDT
 ahF
 ahF
 ahH
@@ -28753,10 +31131,10 @@ ahF
 ahF
 ahF
 afJ
-ahF
-ahF
-ahF
-ahF
+wAF
+fmW
+fmW
+fmW
 ane
 ane
 ane
@@ -28872,8 +31250,8 @@ abM
 abN
 abN
 abN
-abN
-abN
+cMG
+waw
 abM
 abM
 abM
@@ -28976,13 +31354,13 @@ ahF
 ahF
 ahF
 ahF
-ahF
-ahF
-ahF
-ahF
+gTj
+gTj
+gTj
+nys
 afV
-ahF
-ahF
+wAF
+tQU
 uWJ
 uWJ
 ane
@@ -28999,7 +31377,7 @@ ahF
 ahF
 ahF
 ahF
-ahF
+krs
 ahF
 ahF
 ahF
@@ -29099,9 +31477,9 @@ abM
 abN
 abN
 abQ
-abN
-abN
-abN
+cMG
+waw
+tcF
 abM
 abM
 abM
@@ -29203,11 +31581,11 @@ afV
 ahF
 isF
 ahF
-ahF
-ahF
-ahF
-ahF
-ahF
+lYt
+fmW
+gos
+fmW
+lWl
 afV
 afV
 uWJ
@@ -29327,8 +31705,8 @@ abM
 abN
 abN
 abN
-abN
-abN
+vGy
+sBY
 abM
 abM
 abM
@@ -29430,13 +31808,13 @@ ane
 vUx
 vMV
 vMV
-vMV
-vMV
+lUQ
+bJQ
 uWJ
-ahF
-ahF
-ahF
-ahF
+nQH
+fmW
+lWl
+krs
 afV
 ane
 ane
@@ -29450,7 +31828,7 @@ ahF
 ahF
 ahF
 ahF
-ahF
+krs
 ahF
 ahV
 ahF
@@ -29554,9 +31932,9 @@ abM
 abM
 abN
 abN
-abN
-abN
-abN
+cMG
+waw
+pLv
 abM
 abM
 abM
@@ -29658,12 +32036,12 @@ ane
 afV
 ahF
 ahF
-ahF
-ahF
+wAF
+fmW
 uWJ
-ahF
-ahF
-ahF
+dIu
+fmW
+lWl
 ahF
 afV
 afV
@@ -29674,7 +32052,7 @@ afV
 ahF
 ahF
 ahF
-ahF
+fDT
 ahF
 ahH
 ahF
@@ -29684,7 +32062,7 @@ ahF
 ahF
 ahF
 ahF
-ahF
+aYI
 ahF
 ane
 ane
@@ -29781,9 +32159,9 @@ abM
 abM
 abN
 abN
-abN
-abN
-abN
+cMG
+waw
+sBY
 amk
 abM
 abM
@@ -29886,16 +32264,16 @@ ane
 ane
 ahF
 ahF
-ahH
-pmt
+thI
+cdw
 uWJ
 uWJ
+dOb
+lWl
+aYI
 ahF
 ahF
-ahF
-ahF
-ahF
-ahF
+krs
 ahF
 ahF
 ahF
@@ -30009,9 +32387,9 @@ abM
 abM
 abN
 abN
-abN
-abQ
-abN
+vGy
+fTN
+sLT
 amk
 amk
 abM
@@ -30112,20 +32490,20 @@ acp
 ane
 ane
 ane
+krs
 ahF
-ahF
-ahF
-ahF
+wAF
+fmW
 uWJ
 uWJ
+kzw
+kyt
+nys
 ahF
 ahF
 ahF
 ahF
-ahF
-ahF
-ahF
-ahF
+krs
 ahF
 ahF
 ahF
@@ -30237,8 +32615,8 @@ abM
 abN
 abN
 abN
-tgL
-abN
+xhc
+sBY
 amk
 amk
 amk
@@ -30342,22 +32720,22 @@ ane
 ane
 ahF
 ahF
-ahF
-ahF
-ahF
+wAF
+tOV
+fKc
 uWJ
+jCO
+fmW
+rHV
+nys
 ahF
 ahF
 ahF
 ahF
-ahH
 ahF
 ahF
 ahF
-ahF
-ahF
-ahF
-ahF
+krs
 ahF
 ahF
 ahF
@@ -30465,8 +32843,8 @@ abM
 abN
 abN
 abN
-abN
-abN
+vGy
+sBY
 amk
 amk
 abM
@@ -30570,17 +32948,17 @@ afV
 afV
 ahF
 ahF
-ahF
-ahF
-ahF
+doe
+pIl
+fmW
 uWJ
 ane
 uWJ
+fmW
+qSG
 ahF
 ahF
-ahF
-ahF
-ahF
+cCP
 ahF
 ahH
 ahF
@@ -30693,9 +33071,9 @@ abM
 abN
 abN
 abN
-abN
-abN
-abN
+vGy
+sBY
+bPE
 amk
 abM
 abM
@@ -30795,18 +33173,18 @@ acp
 ane
 ane
 ahF
+cCP
 ahF
 ahF
 ahF
-ahF
-ahF
-ahF
+wYz
+chi
 uWJ
 ane
 uWJ
-ahF
-ahF
-ahF
+fmW
+rHV
+nys
 ahF
 ahF
 ahF
@@ -30921,11 +33299,11 @@ abM
 abN
 abN
 abN
-abN
-abN
-abN
-abN
-abB
+pSe
+kzn
+sBY
+dBS
+stt
 abM
 abM
 abM
@@ -30996,8 +33374,8 @@ mdQ
 mdQ
 mdQ
 mdQ
-gwP
-gwP
+qdx
+xKL
 gwP
 gwP
 gwP
@@ -31027,15 +33405,15 @@ ahF
 ane
 ane
 ahF
-ahH
 ahF
+pIl
 ane
 ane
 uWJ
-ahF
-ahF
-ahF
-ahF
+tOV
+fmW
+rHV
+nys
 ahF
 ahF
 ahF
@@ -31150,12 +33528,12 @@ abM
 abN
 abN
 abN
-abQ
-abN
-abN
-abB
-abB
-abB
+bak
+kzn
+qYS
+stt
+stt
+stt
 abM
 abM
 abM
@@ -31223,9 +33601,9 @@ mdQ
 mdQ
 mdQ
 mdQ
-gwP
-gwP
-gwP
+tlk
+dmT
+uRe
 gwP
 gwP
 acS
@@ -31256,16 +33634,16 @@ ane
 ane
 ane
 ahF
-ahF
-ahF
-ahF
+doe
+pIl
+fmW
 uWJ
 uWJ
 ane
-ahF
-ahF
-ahF
-ahF
+eZg
+rHV
+gTj
+nys
 isF
 ahF
 ahF
@@ -31379,12 +33757,12 @@ abM
 abN
 abN
 abN
-abN
-abN
-abN
-abN
-abN
-abB
+pSe
+jLY
+jLY
+jLY
+jLY
+qrH
 abM
 abM
 abM
@@ -31452,8 +33830,8 @@ mdQ
 mdQ
 mdQ
 mdQ
-gwP
-tOS
+dmT
+igN
 gwP
 gwP
 gwP
@@ -31485,20 +33863,20 @@ ane
 ane
 ahF
 ahF
-ahF
-ahF
-ahF
+doe
+pIl
+fcQ
 uWJ
 ane
 ane
-ahF
-ahH
-ahF
-ahF
-ahF
+fmW
+fmW
+lWl
 ahF
 ahF
 ahF
+ahF
+krs
 ahF
 ahF
 ahF
@@ -31679,9 +34057,9 @@ mdQ
 mdQ
 mdQ
 onU
-gwP
-gwP
-gwP
+dmT
+dmT
+uRe
 gwP
 gwP
 gwP
@@ -31707,26 +34085,26 @@ mdQ
 ane
 afV
 ahF
+aYI
+krs
 ahF
 ahF
 ahF
 ahF
 ahF
-ahF
-ahF
-ahF
-ahF
-ahF
+wYz
+fmW
+fmW
 uWJ
 uWJ
 uWJ
+fmW
+lWl
 ahF
-ahF
-ahF
-ahF
-ahF
-ahF
-ahF
+hRy
+hRy
+hRy
+hRy
 ahF
 ahF
 ahF
@@ -31907,9 +34285,9 @@ mdQ
 mdQ
 onU
 onU
-gwP
-gwP
-sMx
+dmT
+dmT
+kVG
 sMx
 gwP
 gwP
@@ -31940,16 +34318,16 @@ ahF
 ahF
 ahF
 ahF
+fDT
 ahF
 ahF
-ahF
-ahH
-ahF
+pIl
+fmW
 uWJ
 uWJ
-ahF
-ahF
-ahF
+wHE
+fmW
+lWl
 ahF
 ahF
 ahF
@@ -32135,9 +34513,9 @@ mdQ
 mdQ
 onU
 onU
-gwP
-gwP
-sMx
+dmT
+xHW
+kVG
 sMx
 gwP
 gwP
@@ -32171,13 +34549,13 @@ ahF
 ahF
 ahF
 ahF
-ahF
-ahF
+wYz
+sgU
 uWJ
 ane
-ahF
-ahF
-ahF
+xBO
+lWh
+dYx
 ahF
 ahH
 ahF
@@ -32362,10 +34740,10 @@ mdQ
 mdQ
 mdQ
 onU
-gwP
-gwP
-gwP
-gwP
+lKl
+dmT
+dmT
+uRe
 gwP
 gwP
 gwP
@@ -32394,17 +34772,17 @@ ahF
 ane
 ane
 ane
+hRy
+hRy
+hRy
 ahF
 ahF
-ahF
-ahF
-ahF
-ahF
-ahF
+doe
+pIl
 ane
 ane
-ahF
-ahF
+lWh
+dYx
 ahH
 ahF
 ahF
@@ -32585,15 +34963,15 @@ mdQ
 mdQ
 onU
 onU
-gwP
-gwP
+ieN
+kWV
 xZE
-xZE
-xZE
-gwP
-gwP
-gwP
-gwP
+xyH
+hhs
+ndk
+dmT
+dmT
+uRe
 tOS
 gwP
 sMx
@@ -32622,7 +35000,7 @@ ahF
 ahF
 ane
 ane
-ahF
+krs
 afV
 afV
 afV
@@ -32809,19 +35187,19 @@ mdQ
 mdQ
 mdQ
 mdQ
-gwP
-gwP
+jGU
+ndk
 onU
+dmT
+dmT
+kWV
 gwP
-gwP
-gwP
-gwP
-gwP
-aca
-gwP
-abO
-gwP
-gwP
+hjo
+qtK
+qhl
+clO
+qhl
+wHh
 gwP
 gwP
 sMx
@@ -32850,20 +35228,20 @@ ahF
 ahF
 ane
 ane
-ahF
+cCP
 afV
 ahF
 ahF
 ahF
 ahF
 ane
-ahF
+aYI
 ahF
 ahF
 ane
 ahF
-ahF
-ahF
+aYI
+fDT
 ahF
 ane
 ane
@@ -33037,20 +35415,20 @@ gwP
 mdQ
 gwP
 gwP
-gwP
-gwP
-aca
-gwP
-gwP
-gwP
+jGU
+dmT
+iGf
+dmT
+owZ
+wHh
 tOS
 gwP
 aca
 gwP
 gwP
-gwP
-gwP
-gwP
+vle
+qdx
+xKL
 gwP
 gwP
 gwP
@@ -33265,22 +35643,22 @@ gwP
 gwP
 gwP
 gwP
+hjo
+kML
+ukY
+soY
+wHh
 gwP
-tOS
+gwP
+gwP
 aca
-gwP
-gwP
-gwP
-gwP
-gwP
-aca
-gwP
-gwP
-gwP
-gwP
-gwP
-gwP
-gwP
+vle
+qdx
+cHW
+dmT
+grW
+qdx
+xKL
 gwP
 gwP
 gwP
@@ -33503,15 +35881,15 @@ gwP
 gwP
 mdQ
 mdQ
-xZE
-xZE
-xZE
-gwP
-gwP
-gwP
+hhs
+hhs
+hhs
+fLh
+dmT
+grW
 acp
 acp
-gwP
+xKL
 gwP
 gwP
 abO
@@ -33733,14 +36111,14 @@ mdQ
 mdQ
 onU
 onU
-xZE
-xZE
-xZE
-gwP
-gwP
-xZE
-xZE
-gwP
+hhs
+hhs
+hhs
+dmT
+dmT
+hhs
+eft
+xKL
 gwP
 oMZ
 oMZ
@@ -33963,13 +36341,13 @@ mdQ
 onU
 onU
 acK
-gwP
-gwP
-gwP
-gwP
-xZE
-aca
-aca
+dmT
+dmT
+kCD
+dmT
+hhs
+soz
+jqr
 dFz
 oMZ
 aca
@@ -34191,15 +36569,15 @@ mdQ
 mdQ
 onU
 onU
-gwP
-gwP
-gwP
-gwP
-aYC
-eGD
-eGD
-eGD
-eGD
+htV
+dmT
+dmT
+dmT
+sNq
+rTT
+rTT
+nLF
+rbs
 eGD
 eGD
 eGD
@@ -34423,11 +36801,11 @@ onU
 onU
 onU
 onU
-xZE
-eGD
-eGD
-eGD
-acq
+hhs
+rTT
+aIA
+lhH
+lkq
 eGD
 eGD
 eGD
@@ -34653,10 +37031,10 @@ iIB
 iIB
 iIB
 iIB
-eGD
-eGD
-eGD
-ufG
+rTT
+rTT
+nLF
+liI
 eGD
 eGD
 ufG
@@ -34881,10 +37259,10 @@ abS
 iIB
 iIB
 iIB
-eGD
-adc
-eGD
-ufG
+rTT
+dAu
+hkT
+shb
 eGD
 eGD
 gIe
@@ -35072,8 +37450,8 @@ mdQ
 mdQ
 mdQ
 mdQ
-aca
-xZE
+jqr
+sxl
 xZE
 acp
 acu
@@ -35109,10 +37487,10 @@ abS
 abS
 iIB
 iIB
-eGD
-eGD
-eGD
-ufG
+rmt
+rTT
+tde
+vtk
 eGD
 acq
 eGD
@@ -35300,8 +37678,8 @@ mdQ
 mdQ
 mdQ
 mdQ
-gwP
-gwP
+fLh
+uRe
 acp
 acu
 acu
@@ -35337,9 +37715,9 @@ abS
 abS
 abS
 iIB
-eGD
-eGD
-eGD
+rTT
+rTT
+onP
 ufG
 eGD
 eGD
@@ -35528,8 +37906,8 @@ mdQ
 mdQ
 mdQ
 onU
-tOS
-gwP
+gRk
+uRe
 acu
 acu
 acu
@@ -35565,9 +37943,9 @@ abS
 abS
 abS
 abS
-eGD
-eGD
-eGD
+wzI
+tde
+uwG
 eGD
 eGD
 eGD
@@ -35756,8 +38134,8 @@ mdQ
 mdQ
 onU
 onU
-gwP
-gwP
+dmT
+uRe
 acp
 acu
 acy
@@ -35793,8 +38171,8 @@ abS
 ady
 ady
 ady
-eGD
-eGD
+tde
+uwG
 ufG
 hzR
 eGD
@@ -35984,8 +38362,8 @@ acf
 onU
 onU
 onU
-gwP
-gwP
+dmT
+grW
 xZE
 acp
 acu
@@ -36020,8 +38398,8 @@ abS
 abS
 ady
 eGD
-eGD
-eGD
+fqi
+uwG
 eGD
 ufG
 hzR
@@ -36212,8 +38590,8 @@ acf
 onU
 onU
 onU
-gwP
-gwP
+dOA
+dmT
 xZE
 xZE
 acp
@@ -36440,10 +38818,10 @@ acf
 mdQ
 onU
 mdQ
-gwP
-gwP
-gwP
-gwP
+htV
+dmT
+grW
+xKL
 xZE
 xZE
 xZE
@@ -36481,11 +38859,11 @@ adP
 eGD
 acq
 eGD
-eGD
-eGD
-acq
-eGD
-eGD
+bje
+gVw
+vih
+gVw
+rbs
 eGD
 eGD
 eGD
@@ -36668,10 +39046,10 @@ acf
 mdQ
 mdQ
 mdQ
-uSF
-gwP
-gwP
-gwP
+iGx
+dmT
+cQB
+uRe
 gwP
 gwP
 gwP
@@ -36707,14 +39085,14 @@ eGD
 adP
 adP
 adP
-eGD
-eGD
-eGD
-eGD
-eGD
-eGD
-eGD
-eGD
+bje
+gVw
+tMQ
+rTT
+mJF
+rTT
+nLF
+rbs
 eGD
 ady
 ady
@@ -36896,14 +39274,14 @@ acf
 acf
 mdQ
 mdQ
-xZE
-xZE
-gwP
-tOS
-gwP
+hhs
+hhs
+uaL
+iuf
+jvQ
 abH
-gwP
-gwP
+jvQ
+xKL
 gwP
 gwP
 gwP
@@ -36934,15 +39312,15 @@ eGD
 eGD
 eGD
 adP
-adP
-adP
-eGD
-eGD
-eGD
-eGD
-eGD
-eGD
-eGD
+daY
+tPH
+rTT
+pIB
+rTT
+hpK
+rTT
+ohf
+onP
 eGD
 ady
 abS
@@ -37125,15 +39503,15 @@ acf
 acf
 mdQ
 mdQ
-xZE
-xZE
-xZE
-xZE
-gwP
-gwP
-gwP
-gwP
-gwP
+hhs
+hhs
+hhs
+hhs
+dmT
+dmT
+grW
+jvQ
+xKL
 gwP
 gwP
 gwP
@@ -37162,15 +39540,15 @@ acq
 eGD
 eGD
 eGD
-adP
-adP
-eGD
-eGD
+sVx
+iDX
+kdj
+rTT
 iIB
 iIB
 iIB
-eGD
-eGD
+uOD
+onP
 abS
 abS
 abS
@@ -37358,11 +39736,11 @@ mdQ
 onU
 onU
 onU
+sXg
+dmT
+tlk
+uRe
 gwP
-gwP
-gwP
-gwP
-gwP
 acf
 acf
 acf
@@ -37389,10 +39767,10 @@ eGD
 eGD
 eGD
 eGD
-eGD
-eGD
-eGD
-eGD
+bje
+tMQ
+rTT
+rTT
 iIB
 iIB
 abS
@@ -37588,8 +39966,8 @@ uxU
 uxU
 uxU
 uxU
-dGQ
-any
+ryp
+vbK
 dGQ
 acf
 acf
@@ -37617,7 +39995,7 @@ eGD
 adc
 eGD
 eGD
-eGD
+fqi
 abS
 iIB
 iIB
@@ -37812,12 +40190,12 @@ acf
 acf
 acf
 acf
-abl
-abl
-abl
-abl
-abl
-abl
+fDE
+pAE
+fDE
+vAB
+fDE
+nUZ
 abl
 acf
 acf
@@ -38037,15 +40415,15 @@ acf
 acf
 acf
 acf
-abl
-abl
-abl
-abl
-abl
-abl
-abl
-abl
-abl
+pAE
+fDE
+fDE
+sPK
+ogJ
+scs
+scs
+scs
+jgy
 abl
 abl
 abl
@@ -38264,12 +40642,12 @@ acf
 izh
 izh
 izh
-izh
-abl
-abv
-abl
-abl
-abl
+ejp
+scs
+rIc
+scs
+scs
+jgy
 abl
 abl
 abl
@@ -38518,10 +40896,10 @@ abS
 abS
 eGD
 eGD
-eGD
-eGD
-eGD
-eGD
+bje
+gVw
+gVw
+rbs
 eGD
 acO
 eGD
@@ -38744,13 +41122,13 @@ abl
 abl
 abl
 dGQ
-eGD
-eGD
-acY
-eGD
-eGD
-eGD
-eGD
+bje
+gVw
+lbt
+rTT
+rTT
+nLF
+rbs
 acO
 eGD
 acq
@@ -38972,13 +41350,13 @@ abl
 abl
 abl
 dGQ
-eGD
-acq
-eGD
-eGD
-eGD
-eGD
-eGD
+wbg
+xdb
+rTT
+mca
+rTT
+rTT
+onP
 acO
 eGD
 eGD
@@ -39200,13 +41578,13 @@ abl
 abl
 abl
 dGQ
-eGD
-eGD
-eGD
+wbg
+rTT
+rTT
 iIB
 iIB
 abS
-eGD
+onP
 acO
 eGD
 eGD
@@ -40124,8 +42502,8 @@ abS
 abS
 abS
 abS
-eGD
-acq
+gVw
+jpX
 eGD
 abS
 abS
@@ -40352,8 +42730,8 @@ abS
 abS
 abS
 abS
-acO
-acO
+bBT
+rze
 acO
 abS
 abS
@@ -40580,9 +42958,9 @@ abS
 abS
 abS
 abS
-eGD
-eGD
-eGD
+rTT
+nLF
+rbs
 eGD
 xTa
 abS
@@ -40807,10 +43185,10 @@ abS
 abS
 abS
 iIB
-eGD
-eGD
-eGD
-eGD
+rTT
+kdj
+rTT
+onP
 eGD
 eGD
 abS
@@ -41035,10 +43413,10 @@ abS
 abS
 iIB
 iIB
-eGD
-eGD
-eGD
-eGD
+rTT
+rTT
+rTT
+onP
 eGD
 eGD
 abS
@@ -41263,10 +43641,10 @@ abS
 iIB
 iIB
 iIB
-eGD
-eGD
-eGD
-eGD
+mca
+rTT
+tde
+uwG
 eGD
 eGD
 abS
@@ -41489,11 +43867,11 @@ abS
 abS
 abS
 iIB
-eGD
-eGD
-eGD
-eGD
-eGD
+rTT
+rTT
+rTT
+rTT
+onP
 acq
 eGD
 eGD
@@ -41718,11 +44096,11 @@ abS
 abS
 abS
 abS
-eGD
-acq
-eGD
+rTT
+xdb
+rTT
 acY
-eGD
+rbs
 eGD
 eGD
 abS
@@ -41945,12 +44323,12 @@ abS
 abS
 abS
 abS
-eGD
-eGD
-eGD
-eGD
-eGD
-eGD
+wzI
+aIA
+rTT
+rTT
+rTT
+onP
 eGD
 eGD
 abS
@@ -42175,10 +44553,10 @@ abS
 abS
 abS
 iIB
-eGD
-eGD
-eGD
-eGD
+rTT
+rTT
+rTT
+onP
 eGD
 eGD
 abS
@@ -42404,9 +44782,9 @@ abS
 abS
 iIB
 iIB
-eGD
-eGD
-eGD
+rTT
+uxL
+onP
 eGD
 abS
 abS
@@ -42632,9 +45010,9 @@ abS
 abS
 abS
 iIB
-eGD
-eGD
-eGD
+rTT
+rTT
+onP
 eGD
 abS
 abS
@@ -42860,9 +45238,9 @@ abS
 abS
 abS
 iIB
-eGD
-eGD
-eGD
+rTT
+cxi
+onP
 eGD
 abS
 abS
@@ -43088,10 +45466,10 @@ abS
 abS
 abS
 abS
-eGD
-eGD
-eGD
-eGD
+rTT
+rTT
+nLF
+rbs
 eGD
 abS
 abS
@@ -43315,11 +45693,11 @@ abS
 abS
 abS
 abS
-eGD
-eGD
-eGD
-acq
-eGD
+rTT
+rTT
+hpK
+xdb
+onP
 eGD
 abS
 abS
@@ -43542,12 +45920,12 @@ abS
 abS
 abS
 abS
-xTa
-eGD
-eGD
-eGD
-eGD
-eGD
+brC
+rTT
+rTT
+rTT
+rTT
+onP
 eGD
 abS
 abS
@@ -43738,12 +46116,12 @@ abl
 abl
 abl
 abl
-abl
-abl
-abl
-abl
-abl
-abl
+gPu
+jcn
+jcn
+jcn
+jcn
+jcn
 acf
 acf
 acf
@@ -43770,12 +46148,12 @@ abS
 abS
 abS
 abS
-eGD
-eGD
-acq
-eGD
-eGD
-eGD
+rTT
+rTT
+xdb
+rTT
+lnr
+onP
 eGD
 abS
 abS
@@ -43966,12 +46344,12 @@ abv
 abl
 abl
 abl
-abl
-abl
-abl
-abl
-abl
-abl
+xWy
+cqH
+fDE
+bvX
+fDE
+fDE
 acf
 acf
 acf
@@ -43999,11 +46377,11 @@ abS
 abS
 abS
 abS
-eGD
-eGD
-eGD
-eGD
-eGD
+rTT
+mOL
+rTT
+tde
+uwG
 eGD
 abS
 abS
@@ -44197,9 +46575,9 @@ abl
 acf
 acf
 uxU
-dGQ
+ryp
 uMz
-dGQ
+ryp
 acf
 acf
 acf
@@ -44227,10 +46605,10 @@ abS
 abS
 abS
 abS
-eGD
-eGD
-eGD
-eGD
+ohf
+rTT
+rTT
+onP
 eGD
 abS
 abS
@@ -44426,9 +46804,9 @@ acf
 acf
 uxU
 uxU
-abl
-abl
-abl
+fDE
+gcB
+fDE
 acf
 acf
 acf
@@ -44455,10 +46833,10 @@ abS
 abS
 abS
 iIB
-eGD
-eGD
-acq
-eGD
+rTT
+rTT
+xdb
+onP
 eGD
 abS
 abS
@@ -44654,9 +47032,9 @@ acf
 acf
 acf
 uxU
-abl
-abl
-abl
+fDE
+tti
+fDE
 acf
 acf
 acf
@@ -44683,10 +47061,10 @@ abS
 abS
 iIB
 iIB
-eGD
-eGD
-eGD
-eGD
+rTT
+rmt
+rTT
+onP
 abS
 abS
 abS
@@ -44882,14 +47260,14 @@ acf
 acf
 acf
 uxU
-abl
-abv
-abl
-abl
+fDE
+otl
+fDE
+fDE
 acf
 acf
 uxU
-abl
+fDE
 acf
 acf
 acf
@@ -44899,7 +47277,7 @@ abl
 abl
 abv
 abl
-abl
+gPu
 abS
 abS
 abS
@@ -44911,10 +47289,10 @@ abS
 iIB
 iIB
 iIB
-eGD
-eGD
-eGD
-eGD
+rTT
+rTT
+rTT
+onP
 abS
 abS
 abS
@@ -45110,16 +47488,16 @@ acf
 acf
 acf
 acf
-abl
-abl
-abl
-abl
+fDE
+fDE
+fDE
+fDE
 uxU
 uxU
 uxU
-abl
-abl
-abl
+hez
+fDE
+spK
 acf
 acf
 acf
@@ -45127,7 +47505,7 @@ acf
 abl
 abl
 abl
-abl
+kxv
 abS
 abS
 abS
@@ -45139,8 +47517,8 @@ abS
 abS
 iIB
 iIB
-cIU
-cIU
+hav
+hav
 cIU
 abS
 abS
@@ -45339,15 +47717,15 @@ acf
 acf
 acf
 acf
-abl
-abl
-abl
+fDE
+fDE
+fDE
 czq
 uxU
 uxU
-abl
-abl
-abl
+rUX
+fDE
+spK
 abl
 acf
 acf
@@ -45355,8 +47733,8 @@ acf
 abl
 abl
 abl
-abl
-abl
+kxv
+han
 abS
 abS
 abS
@@ -45367,9 +47745,9 @@ abS
 abS
 abS
 abS
-pDt
-pDt
-pDt
+aTy
+aTy
+tYW
 abS
 pDt
 pDt
@@ -45568,14 +47946,14 @@ acf
 acf
 acf
 acf
-abl
-abl
-abl
+fDE
+fDE
+fDE
 uxU
-izh
-abl
-abv
-abl
+mrg
+fDE
+poX
+jgy
 acf
 acf
 acf
@@ -45583,8 +47961,8 @@ abl
 abl
 abl
 abl
-abl
-abl
+uMd
+bvX
 iIB
 abS
 abS
@@ -45796,13 +48174,13 @@ acf
 acf
 acf
 acf
-izh
-abl
-abl
-abv
-dGQ
-abl
-abl
+mrg
+fDE
+fDE
+otl
+ryp
+ogJ
+jgy
 abl
 acf
 acf
@@ -45810,8 +48188,8 @@ acf
 abl
 abl
 abl
-abl
-abl
+kxv
+fDE
 iIB
 iIB
 abS
@@ -46024,12 +48402,12 @@ acf
 acf
 acf
 acf
-izh
-abl
-abl
-abl
-izh
-abl
+mrg
+sPK
+fDE
+fDE
+mrg
+spK
 abl
 abl
 abl
@@ -46039,16 +48417,16 @@ abl
 abv
 abl
 abl
-abl
+uOl
 ydz
-pDt
-pDt
-pDt
-pDt
+eQL
+eQL
+eQL
+pgc
 iIB
 iIB
-pDt
-pDt
+bOm
+xhv
 abS
 pDt
 pDt
@@ -46253,11 +48631,11 @@ acf
 acf
 acf
 acf
-abl
-abl
-abl
-izh
-abl
+fDE
+fDE
+fDE
+mrg
+spK
 abl
 abl
 abl
@@ -46267,16 +48645,16 @@ abl
 abl
 abl
 abl
-abl
-ydz
-pDt
-qRj
-pDt
-pDt
-pDt
-pDt
-pDt
-pDt
+bnM
+lIL
+aTy
+xNi
+aTy
+bxb
+eQL
+eQL
+eQL
+xhv
 pDt
 pDt
 pDt
@@ -46482,29 +48860,29 @@ acf
 acf
 acf
 uxU
+tti
+fDE
+ryp
+spK
 abl
-abl
-dGQ
-abl
-abl
-abl
-abl
-dGQ
-abl
-abl
-abl
-abl
-abl
-abl
-ydz
+gPu
+jcn
+ner
+jcn
+jcn
+jcn
+jcn
+jcn
+jcn
+dLm
+kae
 pDt
 pDt
-pDt
-pDt
-pDt
-pDt
-pDt
-pDt
+kpx
+aTy
+aTy
+aTy
+tYW
 pDt
 pDt
 pDt
@@ -46710,29 +49088,29 @@ acf
 uxU
 uxU
 uxU
-abl
-abl
+fDE
+fDE
 acf
-abl
-abl
-abv
-abl
-dGQ
-abl
-abl
-abl
-abl
-abl
-abl
+xRe
+kLl
+cqN
+fDE
+ryp
+fDE
+fDE
+fDE
+fDE
+osf
+hNT
 ydz
+xhv
 pDt
 pDt
-pDt
-pDt
-pDt
-pDt
-pDt
-qRj
+dCD
+hmJ
+hmJ
+hmJ
+enn
 pDt
 pDt
 pDt
@@ -46936,31 +49314,31 @@ acf
 acf
 uxU
 uxU
-abl
-abl
-abl
-abl
+fDE
+fDE
+fDE
+fDE
 acf
 acf
-abl
-abl
-abl
+fDE
+icd
+fDE
 uxU
 uxU
-abl
-abl
-abl
-abv
-abl
+fDE
+fDE
+han
+otl
+fDE
 acf
+xhv
 pDt
-pDt
-pDt
-pDt
-pDt
-pDt
-pDt
-pDt
+dCD
+cEi
+wpY
+eQL
+eQL
+xhv
 pDt
 oeN
 oeN
@@ -47159,36 +49537,36 @@ abv
 abl
 abl
 acf
-abl
-abl
+xWy
+fDE
 acf
 uxU
-abl
-abl
-abl
-abl
-abl
+fDE
+fDE
+yjs
+fDE
+fDE
 acf
 acf
-abl
-abl
-abl
+fDE
+cSL
+fDE
 uxU
 acf
 acf
-abl
-abl
+fDE
+mVr
 uxU
 uxU
 acf
+tYW
 pDt
-pDt
-pDt
-pDt
-pDt
+crn
+eQL
+eQL
 ntr
-iZG
-pDt
+hEe
+xhv
 pDt
 oeN
 adC
@@ -47387,36 +49765,36 @@ abl
 abl
 abl
 abl
-abl
-abl
-dGQ
-abl
-abl
-abl
-abl
-abl
+xWy
+cSL
+ryp
+fDE
+fDE
+pVZ
+fDE
+fDE
 acf
 acf
 uxU
-abl
-abl
-abl
-abl
+fDE
+fDE
+fDE
+fDE
 acf
 acf
-abl
-abl
+fDE
+fDE
 uxU
 acf
 acf
 nbw
 pDt
-pDt
+crn
 nbw
 ntr
 ntr
-pDt
-pDt
+nNu
+xhv
 pDt
 oeN
 adD
@@ -47615,20 +49993,20 @@ abl
 abl
 abl
 abl
-abl
-abl
-dGQ
-abl
-abl
-abl
-abl
-abl
-abl
+bnM
+uOl
+ryp
+fDE
+fDE
+fDE
+fDE
+ogJ
+jgy
 acf
 uxU
 uxU
-abl
-abl
+fDE
+ogJ
 tYx
 acf
 acf
@@ -47642,9 +50020,9 @@ nbw
 nbw
 nbw
 nbw
-pDt
-pDt
-pDt
+eQL
+eQL
+xhv
 pDt
 oeN
 adE
@@ -47844,19 +50222,19 @@ abl
 abl
 abv
 abl
-abl
-dGQ
-abl
-abl
-abl
-abv
-abl
+bnM
+oha
+rWs
+rWs
+rWs
+vBd
+jgy
 abl
 acf
 uxU
-abl
-abl
-abv
+osf
+fDE
+qWI
 abl
 acf
 acf
@@ -47869,10 +50247,10 @@ acf
 nbw
 nbw
 nbw
-pDt
-pDt
-pDt
-qRj
+aTy
+aTy
+aTy
+hRB
 pDt
 oeN
 abt
@@ -48082,9 +50460,9 @@ abl
 abl
 acf
 acf
-abl
-abl
-abl
+fDE
+ogJ
+jgy
 abl
 acf
 acf
@@ -48304,14 +50682,14 @@ acf
 acf
 acf
 acf
-abl
-abl
-abl
+kLl
+kLl
+kLl
 abl
 acf
 acf
 acf
-abl
+jgy
 abl
 abl
 acf
@@ -48532,10 +50910,10 @@ acf
 acf
 acf
 uxU
-abl
-abl
-abl
-abl
+fDE
+roQ
+fDE
+spK
 abl
 acf
 abl
@@ -48760,10 +51138,10 @@ acf
 acf
 uxU
 uxU
-izh
-abl
-abl
-abv
+mrg
+fDE
+fDE
+qWI
 abl
 abl
 abl
@@ -48988,10 +51366,10 @@ acf
 acf
 uxU
 uxU
-izh
-abl
-abl
-abl
+mrg
+thk
+ogJ
+jgy
 abl
 abl
 abl
@@ -49216,9 +51594,9 @@ acf
 acf
 uxU
 acf
-izh
-abl
-abl
+mrg
+kIM
+spK
 abl
 abl
 abv
@@ -49444,9 +51822,9 @@ acf
 acf
 acf
 acf
-izh
-abl
-abl
+mrg
+fDE
+spK
 abl
 abl
 abl
@@ -49671,10 +52049,10 @@ acf
 acf
 acf
 acf
-izh
-izh
-abl
-abl
+mrg
+mrg
+ogJ
+jgy
 abl
 abl
 abl
@@ -49899,9 +52277,9 @@ acf
 acf
 acf
 acf
-izh
-abl
-abl
+iTQ
+rWs
+jgy
 abv
 abl
 abl
@@ -50127,7 +52505,7 @@ acf
 acf
 acf
 acf
-izh
+jZX
 abl
 abl
 abl
@@ -51268,8 +53646,8 @@ acf
 acf
 acf
 acf
-dGQ
-any
+oFJ
+sLU
 dGQ
 acf
 acf
@@ -51496,9 +53874,9 @@ pUm
 pUm
 pUm
 vVC
-acg
-acg
-acg
+bvj
+mHk
+egU
 pUm
 whU
 whU
@@ -51715,8 +54093,8 @@ acf
 vVC
 pUm
 pUm
-acg
-aaN
+iye
+dtr
 acg
 pUm
 pUm
@@ -51724,9 +54102,9 @@ pUm
 pUm
 vVC
 vVC
-acg
-acg
-acg
+uop
+bvj
+xar
 pUm
 whU
 whU
@@ -51942,19 +54320,19 @@ acf
 uxU
 vVC
 vVC
-acg
-acg
-acg
-acg
+fYG
+bvj
+mHk
+iye
 pUm
 pUm
 pUm
 pUm
 vVC
 vVC
-acg
-acg
-acg
+rhi
+etU
+xar
 pUm
 whU
 whU
@@ -52170,29 +54548,29 @@ vVC
 vVC
 vVC
 vVC
-acg
-acg
-acg
-acg
+bvj
+jRL
+bvj
+bvj
 pUm
 pUm
 pUm
 pUm
 vVC
-acg
-acg
-aaN
-acg
+bvj
+bvj
+jgj
+dLW
 pUm
 whU
 whU
 whU
 whU
 fTM
-fTM
-fTM
-fTM
-fTM
+lSA
+yfe
+yfe
+uyn
 fTM
 fTM
 fTM
@@ -52397,19 +54775,19 @@ pUm
 vVC
 vVC
 vVC
-acg
-acg
-acg
-acg
+bvj
+bvj
+pQV
+bvj
 pUm
 pUm
 pUm
 pUm
 pUm
 vVC
-acg
-acg
-acg
+xwN
+wCs
+dLW
 acg
 pUm
 whU
@@ -52418,20 +54796,20 @@ whU
 whU
 whU
 whU
-fTM
-fTM
-fTM
-fTM
-akL
-fTM
-fTM
+vAT
+wLT
+lBl
+yfe
+bQz
 fTM
 fTM
 fTM
 fTM
 fTM
-fTM
-fTM
+lSA
+eMe
+eMe
+uyn
 vCG
 pDt
 pDt
@@ -52625,9 +55003,9 @@ pUm
 vVC
 vVC
 vVC
-acg
-aaN
-acg
+bvj
+oQm
+bvj
 pUm
 pUm
 pUm
@@ -52635,8 +55013,8 @@ pUm
 pUm
 pUm
 pUm
-acg
-acg
+bvj
+xar
 acg
 pUm
 pUm
@@ -52647,19 +55025,19 @@ whU
 whU
 whU
 unp
-fTM
-fTM
-fTM
-fTM
-fTM
+vAT
+lNG
+vAT
+lBl
+uyn
 jMS
 jMS
 fTM
-fTM
-fTM
-fTM
-fTM
-fTM
+lSA
+bkK
+vAT
+vAT
+lBl
 vCG
 pDt
 pDt
@@ -52852,10 +55230,10 @@ pUm
 pUm
 pUm
 vVC
-acg
-acg
-acg
-acg
+bvj
+mfn
+bvj
+bvj
 pUm
 pUm
 pUm
@@ -52863,9 +55241,9 @@ pUm
 pUm
 pUm
 pUm
+nha
+tEm
 gkC
-nzw
-gkC
 pUm
 pUm
 whU
@@ -52877,16 +55255,16 @@ whU
 unp
 unp
 unp
-fTM
-fTM
-fTM
-jMS
-jMS
-akL
-fTM
-fTM
-fTM
-fTM
+wLT
+vAT
+lBl
+vAg
+pGL
+tSi
+bkK
+vAT
+jJg
+nrR
 whU
 whU
 pDt
@@ -53064,7 +55442,7 @@ aag
 pZb
 pZb
 pZb
-aag
+uYj
 xpR
 xpR
 xpR
@@ -53080,10 +55458,10 @@ pUm
 pUm
 pUm
 pUm
-acg
-acg
-acg
-acg
+bvj
+bvj
+bvj
+ifr
 pUm
 nzw
 nzw
@@ -53106,12 +55484,12 @@ whU
 whU
 unp
 unp
-fTM
-fTM
-fTM
-fTM
-fTM
-fTM
+vAT
+vAT
+vAT
+vAT
+vAT
+vAT
 whU
 unp
 unp
@@ -53281,21 +55659,21 @@ aag
 aag
 aag
 aag
-aag
-aag
-aag
-aag
-aag
+tVw
+srn
+srn
+srn
+pRD
 aag
 aag
 aag
 pZb
 pZb
 pZb
-aag
-aag
-aag
-aag
+uYj
+eqS
+uYj
+tuJ
 xpR
 xpR
 xpR
@@ -53307,12 +55685,12 @@ pZb
 pUm
 pUm
 pUm
-acg
-acg
-acg
-acg
-acg
-acg
+rID
+woT
+woT
+woT
+woT
+dLW
 acg
 acg
 acg
@@ -53333,12 +55711,12 @@ whU
 whU
 whU
 whU
-fTM
-fTM
-akL
-fTM
-fTM
-fTM
+vAT
+sxo
+rby
+vAT
+vAT
+jMD
 whU
 whU
 unp
@@ -53509,24 +55887,24 @@ aag
 aag
 aag
 aag
-aag
-aag
-aag
-aai
-aag
-aag
+dzM
+uYj
+tuJ
+gzH
+qfK
+pRD
 aag
 aag
 aag
 pZb
 pZb
-aag
-aag
-aag
-aag
-aag
-aag
-aag
+uYj
+uYj
+uYj
+mWA
+uYj
+uYj
+uYj
 pZb
 pZb
 pZb
@@ -53560,13 +55938,13 @@ whU
 whU
 whU
 whU
-fTM
-fTM
-fTM
-fTM
-fTM
-fTM
-fTM
+jlt
+jlt
+jlt
+jlt
+jlt
+jlt
+pET
 whU
 whU
 whU
@@ -53736,27 +56114,27 @@ aai
 aag
 aag
 aag
-aag
-aai
-aag
-aag
-aag
-aag
-aag
+tVw
+vxj
+uYj
+uYj
+dHg
+uYj
+rIm
 aag
 aai
 aag
 vly
-aag
-aag
-aag
-aag
-aag
-aag
-aag
-aag
-aag
-aag
+wYB
+pFB
+pFB
+fsc
+uYj
+uYj
+uYj
+dIv
+uYj
+uYj
 pZb
 pZb
 pZb
@@ -53799,9 +56177,9 @@ whU
 whU
 whU
 whU
-fTM
-fTM
-fTM
+yfe
+yfe
+uyn
 fTM
 fTM
 fTM
@@ -53963,14 +56341,14 @@ aag
 aag
 aag
 aag
-aag
-aag
-aag
-aag
+tVw
+uHc
+uYj
+uYj
 xpR
-aag
-aag
-aag
+uYj
+uYj
+rIm
 aag
 aag
 aag
@@ -53978,15 +56356,15 @@ vly
 aag
 aai
 aag
-aag
-aag
-aai
-aag
-aag
-aag
-aag
-aag
-aag
+wYB
+pFB
+sET
+pFB
+pFB
+pFB
+pFB
+pFB
+mFZ
 vly
 acg
 acg
@@ -54028,8 +56406,8 @@ whU
 whU
 whU
 whU
-fTM
-fTM
+vAT
+fIW
 fTM
 fTM
 fTM
@@ -54190,15 +56568,15 @@ aag
 aag
 aag
 aag
-aag
-aag
-aag
-aag
+tVw
+uHc
+uYj
+eYb
 xpR
 xpR
-aag
-aag
-aag
+uYj
+uYj
+rIm
 aag
 aag
 aag
@@ -54216,11 +56594,11 @@ aag
 aag
 aag
 vly
-acg
-acg
-acg
-acg
-acg
+cop
+iye
+iye
+iye
+egU
 acg
 acg
 acg
@@ -54256,8 +56634,8 @@ whU
 whU
 whU
 whU
-fTM
-fTM
+fUj
+fIW
 aeT
 fTM
 fTM
@@ -54418,15 +56796,15 @@ aag
 aag
 aag
 aag
-aag
-aag
-aab
+dzM
+uYj
+rYe
 xpR
 xpR
 xpR
-aag
-aag
-aag
+uYj
+uYj
+rIm
 aag
 aag
 aag
@@ -54442,14 +56820,14 @@ aag
 aag
 aag
 aag
-aag
-vly
-acg
-acg
-acg
-acg
-acg
-acg
+tVw
+cqC
+kmH
+mLv
+bvj
+bvj
+elp
+egU
 acg
 acg
 acg
@@ -54483,9 +56861,9 @@ whU
 whU
 whU
 unp
-fTM
-fTM
-fTM
+vAT
+vAT
+fIW
 fTM
 sIH
 fTM
@@ -54646,15 +57024,15 @@ aag
 aag
 aag
 aai
-aag
-aab
-aab
+dzM
+rYe
+rYe
 xpR
 xpR
-aab
-aag
-aag
-aag
+rYe
+uYj
+anM
+rIm
 aag
 aag
 aag
@@ -54670,15 +57048,15 @@ aag
 aag
 aai
 aag
-aag
-vly
-acg
-acg
-aaN
-acg
-acg
-acg
-acg
+jBl
+vdt
+bvj
+bvj
+oQm
+bvj
+mfn
+mHk
+egU
 acg
 acg
 acg
@@ -54712,8 +57090,8 @@ whU
 whU
 unp
 unp
-fTM
-fTM
+vAT
+fIW
 fTM
 agd
 afE
@@ -54874,15 +57252,15 @@ aag
 aag
 aag
 aag
-aab
-aab
+eaI
+rYe
 pZb
 xpR
 pZb
-aab
-aag
-aag
-aag
+rYe
+tuJ
+uYj
+rIm
 aag
 aag
 aag
@@ -54898,15 +57276,15 @@ aag
 aag
 aag
 aag
-aag
-aci
+jBl
+xSk
 vVC
 vVC
 vVC
 vVC
-acg
-acg
-acg
+bvj
+fmV
+oDE
 acg
 acg
 pUm
@@ -54940,8 +57318,8 @@ whU
 whU
 whU
 unp
-fTM
-fTM
+rGE
+fIW
 akL
 adZ
 fTM
@@ -55102,39 +57480,39 @@ aag
 aag
 aag
 aag
-aab
+eaI
 pZb
 pZb
 pZb
 pZb
-aab
+rYe
+ktr
+sFD
+mFZ
+aag
+aag
+aag
+pZb
+pZb
+pZb
+pZb
+pZb
+pZb
+pZb
+pZb
 aag
 aag
 aag
 aag
-aag
-aag
-pZb
-pZb
-pZb
-pZb
-pZb
-pZb
-pZb
-pZb
-aag
-aag
-aag
-aag
-aag
+wYB
 pZb
 pUm
 vVC
 vVC
 vVC
 vVC
-xSA
-nzw
+lyZ
+lhE
 gkC
 pUm
 pUm
@@ -55168,8 +57546,8 @@ whU
 whU
 whU
 unp
-fTM
-fTM
+vAT
+fIW
 fTM
 adH
 fTM
@@ -55319,10 +57697,10 @@ pZb
 pZb
 pZb
 pZb
-aab
-aab
-aag
-aag
+vPo
+vPo
+wRb
+pRD
 aag
 aag
 aag
@@ -55335,8 +57713,8 @@ pZb
 pZb
 pZb
 pZb
-aag
-aag
+ktr
+mFZ
 aag
 aag
 aai
@@ -55361,8 +57739,8 @@ pUm
 vVC
 vVC
 pUm
-acg
-acg
+fYG
+oDE
 acg
 pUm
 pUm
@@ -55395,9 +57773,9 @@ whU
 whU
 whU
 whU
-fTM
-fTM
-fTM
+vQR
+vAT
+fIW
 aeT
 aek
 agA
@@ -55547,23 +57925,23 @@ pZb
 pZb
 pZb
 pZb
+rYe
+fRD
+uYj
+lLU
+pRD
+aag
+aag
+aag
+aag
+aag
 aab
-aag
-aag
-aag
-aag
-aag
-aag
-aag
-aag
-aag
-aab
 pZb
 pZb
 pZb
 pZb
 pZb
-aag
+mFZ
 aag
 aag
 aag
@@ -55589,8 +57967,8 @@ pUm
 pUm
 pUm
 pUm
-acg
-acg
+wCs
+dLW
 acg
 pUm
 pUm
@@ -55623,9 +58001,9 @@ whU
 fTM
 whU
 whU
-fTM
-fTM
-fTM
+sAh
+sAh
+pET
 fTM
 adH
 fTM
@@ -55775,11 +58153,11 @@ pZb
 pZb
 pZb
 xpR
-aab
-aag
-aai
-aag
-aag
+rYe
+uYj
+gzH
+mEo
+rpx
 aag
 aag
 aag
@@ -55817,8 +58195,8 @@ pUm
 pUm
 pUm
 pUm
-acg
-acg
+xGL
+egU
 acg
 pUm
 pUm
@@ -56004,10 +58382,10 @@ pZb
 pZb
 xpR
 xpR
-aag
-aag
-aag
-aag
+uYj
+wMr
+uYj
+rpx
 aag
 aag
 aag
@@ -56046,8 +58424,8 @@ pUm
 pUm
 pUm
 pUm
-acg
-aaN
+mHk
+dtr
 pUm
 pUm
 pUm
@@ -56232,10 +58610,10 @@ pZb
 pZb
 xpR
 xpR
-aag
-aag
-aag
-aag
+uYj
+uYj
+uYj
+rpx
 aag
 aai
 aag
@@ -56274,9 +58652,9 @@ pUm
 pUm
 pUm
 vVC
-acg
-acg
-acg
+bvj
+mHk
+egU
 abj
 pUm
 acg
@@ -56312,9 +58690,9 @@ vCG
 fTM
 akL
 fTM
-fTM
-aeT
-agA
+lSA
+rgj
+gWE
 ahv
 ahv
 slW
@@ -56460,10 +58838,10 @@ pZb
 pZb
 pZb
 xpR
-aag
-aag
-aag
-aag
+bvS
+uYj
+ktr
+mFZ
 aag
 aag
 aag
@@ -56502,10 +58880,10 @@ pUm
 pUm
 vVC
 vVC
-acg
-acg
-acg
-acg
+xmK
+bvj
+mHk
+egU
 abo
 acg
 acg
@@ -56540,9 +58918,9 @@ vCG
 fTM
 fTM
 fTM
-fTM
-fTM
-fTM
+vNT
+vAT
+vkS
 ahv
 ahv
 slW
@@ -56688,9 +59066,9 @@ pZb
 pZb
 pZb
 pZb
-aag
-aag
-aag
+uYj
+ktr
+mFZ
 aag
 aag
 aag
@@ -56730,10 +59108,10 @@ pUm
 pUm
 vVC
 vVC
-acg
-acg
-acg
-acg
+rhi
+bvj
+mNl
+oDE
 acg
 acg
 acg
@@ -56767,10 +59145,10 @@ fTM
 whU
 whU
 fTM
-fTM
-fTM
-fTM
-fTM
+lSA
+bkK
+vAT
+vAT
 ahv
 ahv
 aeg
@@ -56916,8 +59294,8 @@ pZb
 pZb
 pZb
 pZb
-aab
-aag
+aPM
+mFZ
 aag
 aag
 aag
@@ -56958,10 +59336,10 @@ pUm
 pUm
 vVC
 vVC
-acg
-acg
-acg
-acg
+bvj
+bvj
+wCs
+dLW
 acg
 vjL
 acg
@@ -56985,10 +59363,10 @@ whU
 jMS
 jMS
 fTM
-fTM
-fTM
-fTM
-fTM
+lSA
+eMe
+eMe
+uyn
 jMS
 jMS
 fTM
@@ -56996,8 +59374,8 @@ whU
 ajc
 vCG
 whU
-fTM
-fTM
+vAT
+hTR
 pRT
 ahv
 ahv
@@ -57186,9 +59564,9 @@ pUm
 pUm
 pUm
 pUm
-acg
-acg
-acg
+bvj
+rER
+dLW
 iiK
 acg
 acg
@@ -57212,13 +59590,13 @@ whU
 whU
 whU
 whU
-fTM
-fTM
-fTM
-fTM
-fTM
-fTM
-akL
+eMe
+bkK
+ldi
+vAT
+lBl
+loP
+bQz
 fTM
 wEO
 fTM
@@ -57413,9 +59791,9 @@ pUm
 pUm
 pUm
 pUm
-acg
-acg
-acg
+woT
+woT
+dLW
 acg
 acg
 acg
@@ -57441,13 +59819,13 @@ whU
 whU
 whU
 aco
-fTM
-fTM
-fTM
-fTM
-fTM
-fTM
-fTM
+vAT
+vAT
+bcU
+vAT
+whx
+lBl
+uyn
 wEO
 fTM
 fTM
@@ -57672,10 +60050,10 @@ whU
 unp
 unp
 unp
-fTM
-fTM
-fTM
-fTM
+vAT
+vAT
+vAT
+tqQ
 eFS
 fTM
 fTM
@@ -57902,8 +60280,8 @@ whU
 unp
 unp
 unp
-wEO
-wEO
+gsq
+viC
 wEO
 fTM
 fTM
@@ -58129,9 +60507,9 @@ whU
 whU
 whU
 whU
-jMS
-fTM
-fTM
+vAg
+vAT
+lSN
 fTM
 akL
 fTM
@@ -58287,12 +60665,12 @@ pZb
 pZb
 pZb
 pZb
-aab
-aab
-aag
-aag
-aag
-aag
+vPo
+vPo
+lzf
+wRb
+wRb
+pRD
 aag
 aag
 aai
@@ -58357,9 +60735,9 @@ whU
 whU
 whU
 whU
-jMS
-fTM
-fTM
+ecn
+jlt
+pET
 fTM
 fTM
 diW
@@ -58516,15 +60894,15 @@ pZb
 pZb
 pZb
 pZb
-aab
-aab
-aag
-aai
-aag
-aag
-aag
-aag
-aag
+rYe
+rYe
+uYj
+gzH
+qfK
+wRb
+wRb
+wRb
+pRD
 aag
 aag
 aag
@@ -58745,15 +61123,15 @@ pZb
 pZb
 pZb
 pZb
-aab
-aab
-aag
-aag
-aag
-aag
-aag
-aag
-aag
+cfL
+rYe
+uYj
+qVi
+egc
+uYj
+mEo
+isL
+pRD
 aag
 aag
 aai
@@ -58778,7 +61156,7 @@ pZb
 pZb
 vVC
 vVC
-nzw
+uBR
 aaQ
 aaR
 aaR
@@ -58978,10 +61356,10 @@ xpR
 xpR
 xpR
 xpR
-aab
-aab
-aag
-aag
+rYe
+rYe
+uYj
+rpx
 aag
 aag
 aag
@@ -59006,8 +61384,8 @@ pZb
 pZb
 vVC
 vVC
-nzw
-nzw
+uBR
+uBR
 aaQ
 aaQ
 aaQ
@@ -59207,9 +61585,9 @@ xpR
 xpR
 xpR
 xpR
-aab
-aab
-aab
+rYe
+rYe
+gze
 aab
 aab
 aab
@@ -59234,8 +61612,8 @@ pZb
 pZb
 vVC
 vVC
-acg
-nzw
+bvj
+uBR
 nzw
 nzw
 nzw
@@ -59462,10 +61840,10 @@ pZb
 pZb
 vVC
 vVC
-acg
-acg
-acg
-acg
+bvj
+bvj
+mHk
+egU
 acg
 aaN
 acg
@@ -59478,9 +61856,9 @@ acg
 acg
 acg
 acg
-acg
-acg
-nzw
+iye
+iye
+bEj
 acg
 aaN
 acg
@@ -59691,10 +62069,10 @@ pZb
 vVC
 vVC
 vVC
-acg
-acg
-acg
-acg
+bvj
+bvj
+mHk
+egU
 acg
 nzw
 bfY
@@ -59706,9 +62084,9 @@ nzw
 nzw
 nzw
 pUm
-acg
-acg
-nzw
+pQV
+bvj
+lhE
 acg
 acg
 acg
@@ -59919,11 +62297,11 @@ pZb
 pUm
 vVC
 vVC
-acg
-acg
-aaN
-acg
-acg
+bvj
+bvj
+oQm
+mHk
+egU
 nzw
 nHq
 jAo
@@ -59932,11 +62310,11 @@ acg
 umb
 iyr
 eZC
-nzw
+uBR
 pUm
 vVC
-acg
-nzw
+rAU
+lhE
 acg
 acg
 acg
@@ -60148,11 +62526,11 @@ pUm
 vVC
 vVC
 vVC
-acg
-acg
-acg
-acg
-nzw
+bvj
+bvj
+bvj
+mHk
+bEj
 jAo
 acg
 gkC
@@ -60160,12 +62538,12 @@ acg
 gkC
 acg
 jAo
-nzw
+uBR
 vVC
 vVC
 aaQ
-nzw
-acg
+qPY
+egU
 acg
 acg
 acg
@@ -60378,9 +62756,9 @@ vVC
 vVC
 vVC
 pUm
-acg
-acg
-nzw
+bvj
+bvj
+gVR
 umb
 umb
 umb
@@ -60388,12 +62766,12 @@ aaN
 umb
 umb
 umb
-nzw
+uBR
 vVC
 vVC
 vVC
-nzw
-acg
+uBR
+oDE
 acg
 acg
 acg
@@ -60606,9 +62984,9 @@ pUm
 vVC
 vVC
 vVC
-acg
-acg
-nzw
+bvj
+bvj
+qPY
 rwx
 acg
 gkC
@@ -60616,12 +62994,12 @@ acg
 gkC
 acg
 dfJ
-nzw
+uBR
 pUm
 vVC
 vVC
-nzw
-acg
+uBR
+oDE
 acg
 acg
 acg
@@ -60836,21 +63214,21 @@ vVC
 vVC
 vVC
 pUm
-nzw
-rPK
+uBR
+jhj
 upQ
 umb
 acg
 umb
 fAD
 rPK
-nzw
+uBR
 pUm
 pUm
 vVC
-nzw
-acg
-aaN
+uBR
+mHk
+dtr
 acg
 acg
 acg
@@ -61064,8 +63442,8 @@ pUm
 vVC
 pUm
 pUm
-nzw
-nzw
+uBR
+gVR
 nzw
 nzw
 nzw
@@ -61076,9 +63454,9 @@ nzw
 pUm
 pUm
 pUm
-nzw
-acg
-acg
+uBR
+bvj
+fGn
 acg
 acg
 aaQ

--- a/maps/map_files/LV624/centralcaves/10.T.dmm
+++ b/maps/map_files/LV624/centralcaves/10.T.dmm
@@ -1,4 +1,22 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 5
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/central_caves)
+"b" = (
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 8
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_central_caves)
+"c" = (
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 9
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/central_caves)
 "d" = (
 /turf/closed/wall/rock/brown,
 /area/lv624/ground/caves/central_caves)
@@ -16,7 +34,7 @@
 /area/lv624/ground/caves/central_caves)
 "h" = (
 /obj/structure/blocker/forcefield/multitile_vehicles,
-/turf/open/gm/dirt,
+/turf/open/auto_turf/strata_grass/layer1,
 /area/lv624/ground/caves/central_caves)
 "i" = (
 /obj/structure/blocker/forcefield/multitile_vehicles,
@@ -24,6 +42,10 @@
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/south_central_caves)
+"j" = (
+/obj/item/reagent_container/food/snacks/grown/mushroom/amanita,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/central_caves)
 "k" = (
 /turf/open/gm/dirt,
 /area/lv624/ground/barrens/north_east_barrens)
@@ -53,48 +75,136 @@
 	icon_state = "warning"
 	},
 /area/lv624/ground/barrens/containers)
+"s" = (
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 10
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_central_caves)
+"t" = (
+/obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
+	pixel_x = 4;
+	light_on = 1;
+	light_range = 1;
+	light_system = 1
+	},
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/barrens/north_east_barrens)
+"u" = (
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/central_caves)
+"v" = (
+/obj/effect/decal/grass_overlay/grass1,
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_central_caves)
 "w" = (
 /obj/structure/blocker/forcefield/multitile_vehicles,
 /turf/open/gm/dirt,
 /area/lv624/ground/barrens/west_barrens)
-"z" = (
-/obj/effect/landmark/structure_spawner/xvx_hive/xeno_door,
-/obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
-/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
-/turf/open/gm/dirt,
-/area/lv624/ground/caves/central_caves)
 "A" = (
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_wall,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/central_caves)
+"B" = (
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 9
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_central_caves)
 "C" = (
 /obj/effect/landmark/objective_landmark/close,
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_central_caves)
+"D" = (
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 8
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_central_caves)
+"E" = (
+/turf/closed/wall/strata_ice/jungle,
+/area/lv624/ground/caves/south_central_caves)
+"F" = (
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 10
+	},
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/south_central_caves)
 "G" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/south_central_caves)
+"H" = (
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/barrens/north_east_barrens)
+"I" = (
+/obj/effect/decal/grass_overlay/grass1,
+/turf/open/gm/dirt,
+/area/lv624/ground/barrens/north_east_barrens)
+"K" = (
+/obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
+	pixel_x = 2;
+	pixel_y = 7;
+	light_on = 1;
+	light_range = 1;
+	light_system = 1
+	},
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_central_caves)
+"M" = (
+/obj/structure/flora/bush/ausbushes/var3/fullgrass,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/barrens/north_east_barrens)
+"N" = (
+/obj/effect/landmark/hunter_primary,
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 9
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_central_caves)
+"O" = (
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 1
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/central_caves)
 "Q" = (
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_door,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/south_central_caves)
+"R" = (
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 1
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_central_caves)
+"S" = (
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_central_caves)
+"U" = (
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_central_caves)
 "V" = (
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/south_central_caves)
+"Z" = (
+/obj/structure/flora/bush/ausbushes/ppflowers,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/central_caves)
 
 (1,1,1) = {"
 f
-z
-V
-V
-V
-V
-G
-V
-V
+g
+B
+b
+N
+S
+S
+s
+F
 Q
 V
 V
@@ -111,13 +221,13 @@ l
 (2,1,1) = {"
 f
 g
-V
-V
-V
-V
-V
-V
-V
+R
+U
+S
+K
+S
+S
+v
 Q
 V
 V
@@ -134,14 +244,14 @@ l
 (3,1,1) = {"
 f
 g
-V
-G
-V
-V
+R
+S
+S
+E
+E
 l
-l
-n
-n
+v
+Q
 V
 G
 V
@@ -157,10 +267,10 @@ w
 (4,1,1) = {"
 f
 A
-V
-C
 l
 l
+E
+E
 l
 l
 l
@@ -709,9 +819,9 @@ o
 (28,1,1) = {"
 f
 e
-V
-V
-V
+D
+D
+D
 l
 l
 l
@@ -731,9 +841,9 @@ p
 "}
 (29,1,1) = {"
 f
-f
-V
-V
+O
+S
+S
 l
 l
 l
@@ -754,8 +864,8 @@ p
 "}
 (30,1,1) = {"
 f
-f
-f
+O
+j
 l
 l
 l
@@ -777,9 +887,9 @@ p
 "}
 (31,1,1) = {"
 f
-f
-f
-l
+c
+Z
+E
 l
 l
 l
@@ -799,16 +909,16 @@ k
 p
 "}
 (32,1,1) = {"
-f
-f
+O
+u
+E
+E
 l
 l
 l
 l
-l
-l
-l
-l
+E
+E
 l
 l
 l
@@ -823,16 +933,16 @@ p
 "}
 (33,1,1) = {"
 f
-f
+a
 h
-k
-k
-k
-k
-l
-l
-k
-k
+H
+H
+H
+M
+E
+E
+t
+I
 l
 k
 k

--- a/maps/map_files/LV624/centralcaves/10.qc.dmm
+++ b/maps/map_files/LV624/centralcaves/10.qc.dmm
@@ -1,838 +1,1065 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"e" = (
-/obj/structure/blocker/forcefield/multitile_vehicles,
+"aD" = (
+/obj/effect/landmark/structure_spawner/xvx_hive/xeno_wall,
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_central_caves)
+"bV" = (
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 6
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_central_caves)
+"dd" = (
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 9
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_central_caves)
+"gU" = (
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 9
+	},
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/central_caves)
-"f" = (
-/turf/open/gm/dirt,
-/area/lv624/ground/caves/central_caves)
-"g" = (
-/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
+"hJ" = (
+/obj/effect/decal/grass_overlay/grass1,
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/south_central_caves)
-"h" = (
-/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
-/turf/open/gm/dirt,
-/area/lv624/ground/caves/central_caves)
-"k" = (
-/turf/open/gm/dirt,
-/area/lv624/ground/barrens/north_east_barrens)
-"l" = (
-/turf/closed/wall/rock/brown,
+"hP" = (
+/obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
+	pixel_x = 11;
+	pixel_y = -2;
+	light_on = 1;
+	light_range = 1;
+	light_system = 1
+	},
+/turf/open/auto_turf/strata_grass/layer1,
 /area/lv624/ground/caves/south_central_caves)
-"m" = (
-/obj/structure/blocker/forcefield/multitile_vehicles,
-/obj/effect/landmark/structure_spawner/xvx_hive/xeno_door,
-/obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
-/turf/open/gm/dirt,
-/area/lv624/ground/caves/south_central_caves)
-"n" = (
-/obj/effect/landmark/structure_spawner/xvx_hive/xeno_door,
-/obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
-/turf/open/gm/dirt,
-/area/lv624/ground/caves/south_central_caves)
-"o" = (
-/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
-/turf/open/gm/dirt,
-/area/lv624/ground/barrens/north_east_barrens)
-"q" = (
+"hW" = (
 /obj/structure/fence,
 /turf/open/floor{
 	dir = 9;
 	icon_state = "warning"
 	},
 /area/lv624/ground/barrens/containers)
-"r" = (
+"iS" = (
+/obj/item/reagent_container/food/snacks/grown/mushroom/plumphelmet{
+	pixel_x = 8
+	},
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_central_caves)
+"kc" = (
+/obj/structure/flora/bush/ausbushes/pointybush,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_central_caves)
+"ks" = (
+/obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
+	pixel_x = 2;
+	pixel_y = 7;
+	light_on = 1;
+	light_range = 1;
+	light_system = 1
+	},
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_central_caves)
+"lp" = (
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/central_caves)
+"lq" = (
+/turf/closed/wall/rock/brown,
+/area/lv624/ground/barrens/west_barrens)
+"mN" = (
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
+/turf/open/gm/dirt,
+/area/lv624/ground/barrens/north_east_barrens)
+"oB" = (
+/obj/item/reagent_container/food/snacks/grown/mushroom/amanita,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_central_caves)
+"oJ" = (
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/central_caves)
+"pd" = (
+/obj/structure/flora/bush/ausbushes/var3/ywflowers,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_central_caves)
+"pC" = (
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/barrens/north_east_barrens)
+"pR" = (
+/obj/item/reagent_container/food/snacks/grown/mushroom/plumphelmet{
+	pixel_x = 8;
+	pixel_y = 13
+	},
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_central_caves)
+"qK" = (
+/obj/effect/landmark/structure_spawner/xvx_hive/xeno_door,
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_central_caves)
+"ry" = (
+/obj/structure/flora/bush/ausbushes/var3/leafybush,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_central_caves)
+"sL" = (
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_central_caves)
+"sO" = (
+/turf/closed/wall/strata_ice/jungle,
+/area/lv624/ground/caves/south_central_caves)
+"vC" = (
+/obj/structure/blocker/forcefield/multitile_vehicles,
+/obj/effect/landmark/structure_spawner/xvx_hive/xeno_door,
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 6
+	},
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_central_caves)
+"vR" = (
+/obj/structure/flora/bush/ausbushes/var3/fullgrass,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_central_caves)
+"wk" = (
+/turf/closed/wall/rock/brown,
+/area/lv624/ground/caves/south_central_caves)
+"wL" = (
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 10
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_central_caves)
+"yv" = (
+/obj/effect/landmark/structure_spawner/xvx_hive/xeno_door,
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
+/obj/effect/decal/grass_overlay/grass1,
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_central_caves)
+"yD" = (
+/turf/open/gm/dirt,
+/area/lv624/ground/barrens/north_east_barrens)
+"yO" = (
+/obj/effect/decal/grass_overlay/grass1,
+/turf/open/gm/dirt,
+/area/lv624/ground/barrens/north_east_barrens)
+"zh" = (
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 6
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_central_caves)
+"An" = (
+/obj/structure/blocker/forcefield/multitile_vehicles,
+/obj/effect/landmark/structure_spawner/xvx_hive/xeno_door,
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_central_caves)
+"AL" = (
+/obj/effect/landmark/objective_landmark/close,
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_central_caves)
+"DG" = (
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 8
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_central_caves)
+"ER" = (
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_central_caves)
+"GE" = (
+/obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
+	pixel_x = 4;
+	light_on = 1;
+	light_range = 1;
+	light_system = 1
+	},
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/barrens/north_east_barrens)
+"GR" = (
+/obj/effect/landmark/hunter_primary,
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 10
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_central_caves)
+"Is" = (
+/obj/structure/blocker/forcefield/multitile_vehicles,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/central_caves)
+"Jf" = (
+/obj/structure/flora/bush/ausbushes/var3/brflowers,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_central_caves)
+"JB" = (
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 1
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_central_caves)
+"JX" = (
+/obj/structure/flora/bush/ausbushes/lavendergrass,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_central_caves)
+"JZ" = (
 /obj/structure/fence,
 /turf/open/floor{
 	dir = 1;
 	icon_state = "warning"
 	},
 /area/lv624/ground/barrens/containers)
-"w" = (
+"KX" = (
+/turf/open/gm/dirt,
+/area/lv624/ground/barrens/west_barrens)
+"Od" = (
+/obj/effect/landmark/structure_spawner/xvx_hive/xeno_door,
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 1
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_central_caves)
+"Oe" = (
+/obj/structure/flora/bush/ausbushes/ppflowers,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/central_caves)
+"Pd" = (
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_wall,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 1
+	},
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/south_central_caves)
-"x" = (
-/obj/effect/landmark/objective_landmark/close,
+"PB" = (
 /turf/open/gm/dirt,
+/area/lv624/ground/caves/central_caves)
+"Rx" = (
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
+/turf/open/auto_turf/strata_grass/layer1,
 /area/lv624/ground/caves/south_central_caves)
-"y" = (
-/turf/closed/wall/rock/brown,
-/area/lv624/ground/barrens/west_barrens)
-"C" = (
+"Tu" = (
+/obj/effect/landmark/structure_spawner/xvx_hive/xeno_door,
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 8
+	},
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_central_caves)
+"Uu" = (
+/obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
+	pixel_x = 4;
+	light_on = 1;
+	light_range = 1;
+	light_system = 1
+	},
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_central_caves)
+"UB" = (
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 1
+	},
 /turf/open/gm/dirt,
-/area/lv624/ground/caves/south_central_caves)
-"O" = (
+/area/lv624/ground/caves/central_caves)
+"Vd" = (
 /obj/effect/landmark/hunter_primary,
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 9
+	},
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/south_central_caves)
-"P" = (
-/obj/effect/landmark/structure_spawner/xvx_hive/xeno_membrane,
-/obj/effect/landmark/structure_spawner/setup/distress/xeno_membrane,
+"VY" = (
+/obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
+	pixel_x = -10;
+	pixel_y = -2;
+	light_on = 1;
+	light_range = 1;
+	light_system = 1
+	},
+/turf/open/auto_turf/strata_grass/layer1,
+/area/lv624/ground/caves/south_central_caves)
+"Xj" = (
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 10
+	},
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/south_central_caves)
-"Y" = (
+"XV" = (
 /turf/open/gm/dirt,
-/area/lv624/ground/barrens/west_barrens)
+/area/lv624/ground/caves/south_central_caves)
+"ZM" = (
+/obj/effect/decal/grass_overlay/grass1{
+	dir = 4
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/barrens/north_east_barrens)
+"ZU" = (
+/obj/effect/decal/grass_overlay/grass1/inner{
+	dir = 5
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/central_caves)
 
 (1,1,1) = {"
-f
-n
-C
-C
-O
-C
-C
-C
-C
-n
-C
-g
-C
-C
-l
-l
-l
-l
-l
-l
-l
+PB
+qK
+dd
+DG
+Vd
+ER
+ER
+wL
+Xj
+qK
+XV
+sL
+XV
+XV
+wk
+wk
+wk
+wk
+wk
+wk
+wk
 "}
 (2,1,1) = {"
-f
-n
-C
-g
-C
-C
-C
-g
-C
-n
-C
-C
-C
-C
-C
-l
-l
-l
-l
-y
-Y
+PB
+qK
+JB
+Rx
+ER
+ks
+ER
+ER
+hJ
+qK
+XV
+XV
+XV
+XV
+XV
+wk
+wk
+wk
+wk
+lq
+KX
 "}
 (3,1,1) = {"
-f
-n
-C
-C
-l
-l
-l
-w
-w
-w
-C
-C
-C
-C
-C
-C
-l
-l
-l
-Y
-Y
+PB
+qK
+JB
+ER
+ER
+sO
+sO
+wk
+hJ
+qK
+XV
+XV
+XV
+XV
+XV
+XV
+wk
+wk
+wk
+KX
+KX
 "}
 (4,1,1) = {"
-f
-w
-l
-l
-l
-l
-l
-l
-l
-l
-l
-C
-C
-C
-C
-C
-l
-l
-l
-Y
-Y
+PB
+aD
+wk
+wk
+sO
+sO
+wk
+wk
+wk
+wk
+wk
+XV
+XV
+XV
+XV
+XV
+wk
+wk
+wk
+KX
+KX
 "}
 (5,1,1) = {"
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-C
-C
-C
-C
-C
-C
-l
-l
-y
-Y
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+XV
+XV
+XV
+XV
+XV
+XV
+wk
+wk
+lq
+KX
 "}
 (6,1,1) = {"
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-C
-C
-C
-C
-C
-l
-y
-Y
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+XV
+XV
+XV
+XV
+XV
+wk
+lq
+KX
 "}
 (7,1,1) = {"
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-C
-g
-C
-C
-l
-l
-y
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+Tu
+yv
+qK
+qK
+wk
+wk
+lq
 "}
 (8,1,1) = {"
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-n
-n
-n
-n
-l
-l
-l
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+ER
+wL
+Xj
+XV
+AL
+wk
+wk
 "}
 (9,1,1) = {"
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-C
-C
-C
-C
-C
-l
-l
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+ER
+kc
+ER
+hJ
+XV
+XV
+wk
+wk
 "}
 (10,1,1) = {"
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-P
-C
-C
-C
-C
-C
-l
-l
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+sO
+ER
+ER
+ER
+hJ
+XV
+XV
+wk
+wk
 "}
 (11,1,1) = {"
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-P
-P
-C
-C
-C
-C
-l
-l
-l
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+sO
+sO
+ks
+ER
+bV
+zh
+XV
+XV
+wk
+wk
 "}
 (12,1,1) = {"
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-P
-P
-C
-C
-C
-C
-l
-l
-l
-l
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+sO
+sO
+sO
+ER
+ER
+hJ
+sL
+XV
+XV
+wk
+wk
 "}
 (13,1,1) = {"
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-P
-C
-C
-C
-C
-g
-l
-l
-l
-l
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+sO
+ER
+ER
+Rx
+ER
+GR
+Xj
+XV
+XV
+wk
+wk
 "}
 (14,1,1) = {"
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-C
-C
-C
-O
-C
-l
-l
-l
-l
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+sO
+ER
+ER
+ER
+ER
+hJ
+XV
+XV
+wk
+wk
 "}
 (15,1,1) = {"
-l
-l
-l
-l
-l
-l
-C
-C
-l
-l
-l
-l
-l
-C
-C
-C
-C
-C
-l
-l
-l
+wk
+wk
+wk
+wk
+wk
+wk
+XV
+XV
+wk
+wk
+wk
+pd
+iS
+ER
+ER
+ER
+hJ
+XV
+XV
+wk
+wk
 "}
 (16,1,1) = {"
-l
-l
-l
-l
-l
-C
-C
-C
-C
-l
-l
-l
-l
-l
-C
-C
-C
-C
-C
-l
-l
+wk
+wk
+wk
+wk
+wk
+XV
+XV
+XV
+XV
+wk
+wk
+wk
+sO
+sO
+ER
+hP
+hJ
+XV
+wk
+wk
+wk
 "}
 (17,1,1) = {"
-l
-l
-l
-C
-C
-C
-C
-C
-C
-C
-l
-l
-l
-C
-C
-g
-C
-x
-l
-l
-l
+wk
+wk
+wk
+XV
+XV
+XV
+XV
+XV
+XV
+XV
+wk
+wk
+wk
+sO
+ER
+ER
+hJ
+XV
+wk
+wk
+wk
 "}
 (18,1,1) = {"
-l
-l
-l
-C
-C
-g
-C
-C
-C
-g
-C
-C
-l
-C
-C
-C
-C
-P
-l
-l
-l
+wk
+wk
+wk
+XV
+XV
+sL
+XV
+XV
+XV
+sL
+XV
+XV
+wk
+sO
+ER
+Jf
+hJ
+XV
+wk
+wk
+wk
 "}
 (19,1,1) = {"
-l
-l
-C
-C
-C
-C
-C
-C
-C
-C
-C
-C
-n
-C
-C
-C
-C
-P
-l
-l
-l
+wk
+wk
+XV
+XV
+XV
+XV
+XV
+XV
+XV
+XV
+XV
+XV
+Od
+ER
+ER
+ER
+wL
+Xj
+XV
+wk
+wk
 "}
 (20,1,1) = {"
-l
-C
-C
-C
-C
-C
-l
-l
-C
-C
-C
-C
-n
-C
-C
-C
-C
-P
-P
-l
-l
+wk
+XV
+XV
+XV
+XV
+XV
+wk
+wk
+XV
+XV
+XV
+XV
+Od
+ER
+ER
+VY
+Rx
+hJ
+XV
+wk
+wk
 "}
 (21,1,1) = {"
-f
-C
-C
-C
-C
-C
-l
-l
-C
-C
-C
-g
-w
-C
-C
-C
-g
-C
-P
-l
-l
+PB
+XV
+XV
+XV
+XV
+XV
+wk
+wk
+XV
+XV
+XV
+sL
+Pd
+ER
+ER
+ER
+ER
+hJ
+XV
+wk
+wk
 "}
 (22,1,1) = {"
-f
-C
-g
-C
-C
-l
-l
-l
-l
-C
-C
-C
-n
-C
-C
-C
-C
-C
-P
-l
-l
+PB
+XV
+sL
+XV
+XV
+wk
+wk
+wk
+wk
+XV
+XV
+XV
+Od
+ER
+Rx
+ER
+JX
+hJ
+XV
+wk
+wk
 "}
 (23,1,1) = {"
-f
-f
-C
-C
-l
-l
-l
-l
-l
-l
-C
-C
-n
-C
-C
-C
-C
-C
-P
-l
-l
+PB
+PB
+XV
+XV
+wk
+wk
+wk
+wk
+wk
+wk
+XV
+XV
+Od
+ER
+ry
+ER
+bV
+zh
+XV
+wk
+wk
 "}
 (24,1,1) = {"
-f
-f
-C
-C
-l
-l
-l
-l
-l
-l
-l
-l
-l
-C
-C
-C
-C
-C
-C
-l
-l
+PB
+PB
+XV
+XV
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+pR
+ER
+ER
+hJ
+XV
+wk
+wk
+wk
 "}
 (25,1,1) = {"
-f
-f
-C
-l
-l
-l
-l
-l
-l
-l
-l
-l
-C
-C
-C
-C
-C
-C
-l
-l
-l
+PB
+PB
+XV
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+sO
+sO
+ER
+ER
+ER
+Rx
+hJ
+XV
+wk
+wk
+wk
 "}
 (26,1,1) = {"
-f
-f
-C
-l
-l
-l
-l
-l
-l
-l
-l
-x
-C
-C
-C
-g
-C
-C
-l
-l
-l
+PB
+PB
+XV
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+sO
+ER
+ER
+ER
+Uu
+ER
+hJ
+wk
+wk
+wk
+wk
 "}
 (27,1,1) = {"
-f
-f
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-C
-C
-C
-C
-C
-l
-l
-l
-q
+PB
+PB
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+sO
+sO
+ER
+ER
+ER
+ER
+hJ
+wk
+wk
+wk
+hW
 "}
 (28,1,1) = {"
-f
-h
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-C
-C
-C
-C
-l
-l
-l
-r
+PB
+oJ
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+ER
+ER
+ER
+wk
+wk
+wk
+wk
+JZ
 "}
 (29,1,1) = {"
-f
-f
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-m
-m
-m
-l
-l
-l
-l
-r
+PB
+UB
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+sO
+sO
+An
+An
+vC
+wk
+wk
+wk
+wk
+JZ
 "}
 (30,1,1) = {"
-f
-f
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-k
-k
-k
-l
-l
-k
-k
-r
+PB
+UB
+oB
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+ZM
+ZM
+ZM
+wk
+wk
+yD
+yD
+JZ
 "}
 (31,1,1) = {"
-f
-f
-f
-l
-l
-l
-l
-l
-l
-l
-l
-l
-k
-k
-k
-k
-k
-k
-k
-k
-r
+PB
+gU
+Oe
+sO
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+wk
+yD
+yD
+yD
+yD
+yD
+yD
+yD
+yD
+JZ
 "}
 (32,1,1) = {"
-h
-f
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-k
-k
-k
-k
-k
-o
-k
-r
+UB
+lp
+sO
+sO
+wk
+wk
+wk
+wk
+sO
+sO
+wk
+wk
+wk
+yD
+yD
+yD
+yD
+yD
+mN
+yD
+JZ
 "}
 (33,1,1) = {"
-f
-e
-e
-k
-k
-k
-l
-l
-l
-k
-k
-l
-k
-k
-k
-k
-k
-k
-k
-k
-r
+PB
+ZU
+Is
+pC
+pC
+pC
+vR
+sO
+sO
+GE
+yO
+wk
+yD
+yD
+yD
+yD
+yD
+yD
+yD
+yD
+JZ
 "}


### PR DESCRIPTION

# About the pull request

Alters the caves of LV-624 to have far more jungle grass and other similar aesthetics. No layout changes are effected. 

I hope to do more changes in the future, but I'll keep things separated for now. 

# Explain why it's good for the game

The caves of the map are quite bare in appearance, this is one small chance to help increase the style of the map. 


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
maptweak: LV-624's Caves have had an aesthetic change regarding jungle tiles and flora. 
/:cl:
