### PR TITLE
Hotfixes being able to put anything in your boots

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -341,9 +341,13 @@
 		return
 	if(stored_item)
 		return
+	var/allowed = FALSE
 	for(var/allowed_item in items_allowed)
-		if(!istype(attacking_item, allowed_item))
-			continue
+		if(istype(attacking_item, allowed_item))
+			allowed = TRUE
+			break
+	if(!allowed)
+		return
 	if(!insert_after)
 		return TRUE
 	insert_item(user, attacking_item)


### PR DESCRIPTION
![](https://cdn.discordapp.com/attachments/862155128441012234/1170748366125277214/dreamseeker_Akwa4enIMm.gif)

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

Typechecks weren't actually acted upon, letting you put anything in your boots. Like, anything.
It's funny but it's both breaking things and problematic for balance

# Explain why it's good for the game
Self evident i think

# Testing Photographs and Procedure
Can only put knives in now, as CM Dev intended


# Changelog
:cl:
fix: Fixed being able to put anything in your boots. You're not wizards!
/:cl:
