### PR TITLE
Ares Final Scan takes 1 minute instead of 3

### DIFF
--- a/code/game/gamemodes/colonialmarines/colonialmarines.dm
+++ b/code/game/gamemodes/colonialmarines/colonialmarines.dm
@@ -1,5 +1,5 @@
 #define HIJACK_EXPLOSION_COUNT 5
-#define MARINE_MAJOR_ROUND_END_DELAY 3 MINUTES
+#define MARINE_MAJOR_ROUND_END_DELAY 1 MINUTES
 
 /datum/game_mode/colonialmarines
 	name = "Distress Signal"
@@ -149,7 +149,7 @@
 /datum/game_mode/colonialmarines/proc/ares_conclude()
 	ai_silent_announcement("Bioscan complete. No unknown lifeform signature detected.", ".V")
 	ai_silent_announcement("Saving operational report to archive.", ".V")
-	ai_silent_announcement("Commencing final systems scan in 3 minutes.", ".V")
+	ai_silent_announcement("Commencing final systems scan in 1 minute.", ".V")
 
 ////////////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION

# About the pull request

when the last xeno dies, there's a THREE MINUTE DELAY BEFORE THE ROUND ENDS.
and when the round ends there's even more waiting for the server to restart
this PR cuts down the delay for roundend from 3 minutes to 1 minute

# Explain why it's good for the game
Waiting to play again (if you're a xeno) or standing around (if you're a marine) isn't really fun.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
qol: After final xeno dies, the round ends after one minute instead of three.
/:cl:
