### PR TITLE
Minor fixes for Loadout Items

### DIFF
--- a/code/__DEFINES/dcs/signals/atom/signals_item.dm
+++ b/code/__DEFINES/dcs/signals/atom/signals_item.dm
@@ -66,5 +66,5 @@
 /// from  /obj/item/weapon/gun/proc/load_into_chamber() : ()
 #define COMSIG_GUN_INTERRUPT_FIRE "gun_interrupt_fire"
 
-//Additional procs on items that will be triggered right after the human finishes spawns in
+//from /datum/authority/branch/role/proc/equip_role()
 #define COMSIG_POST_SPAWN_UPDATE "post_spawn_update"

--- a/code/game/jobs/role_authority.dm
+++ b/code/game/jobs/role_authority.dm
@@ -579,9 +579,7 @@ I hope it's easier to tell what the heck this proc is even doing, unlike previou
 	new_human.sec_hud_set_ID()
 	new_human.hud_set_squad()
 
-	for(var/obj/current_item in new_human.get_contents())
-		SEND_SIGNAL(current_item, COMSIG_POST_SPAWN_UPDATE, new_human)
-
+	SEND_SIGNAL(new_human, COMSIG_POST_SPAWN_UPDATE)
 	SSround_recording.recorder.track_player(new_human)
 
 //Find which squad has the least population. If all 4 squads are equal it should just use a random one

--- a/code/game/objects/items/props/helmetgarb.dm
+++ b/code/game/objects/items/props/helmetgarb.dm
@@ -527,29 +527,38 @@
 	icon = 'icons/obj/items/items.dmi'
 	icon_state = "photo"
 	///The human who spawns with the photo
-	var/mob/living/carbon/human/owner
+	var/datum/weakref/owner
+	///The belonging human name
+	var/owner_name
+	///The belonging human faction
+	var/owner_faction
 	///Text written on the back
 	var/scribble
 
-/obj/item/prop/helmetgarb/family_photo/Initialize(mapload, ...)
+/obj/item/prop/helmetgarb/family_photo/pickup(mob/user, silent)
 	. = ..()
-	if(!mapload)
-		RegisterSignal(src, COMSIG_POST_SPAWN_UPDATE, PROC_REF(set_owner))
+	if(!owner)
+		RegisterSignal(user, COMSIG_POST_SPAWN_UPDATE, PROC_REF(set_owner))
+
 
 ///Sets the owner of the family photo to the human it spawns with, needs var/source for signals
-/obj/item/prop/helmetgarb/family_photo/proc/set_owner(source = src, mob/living/carbon/human/user)
-	UnregisterSignal(src, COMSIG_POST_SPAWN_UPDATE)
-	owner = user
+/obj/item/prop/helmetgarb/family_photo/proc/set_owner(datum/source)
+	SIGNAL_HANDLER
+	UnregisterSignal(source, COMSIG_POST_SPAWN_UPDATE)
+	var/mob/living/carbon/human/user = source
+	owner = WEAKREF(user)
+	owner_name = user.name
+	owner_faction = user.faction
 
 /obj/item/prop/helmetgarb/family_photo/get_examine_text(mob/user)
 	. = ..()
 	if(scribble)
 		. += "\"[scribble]\" is written on the back of the photo."
-	if(user == owner)
+	if(user.weak_reference == owner)
 		. += "A photo of you and your family."
 		return
-	if(user.faction == owner?.faction)
-		. += "A photo of [owner] and their family."
+	if(user.faction == owner_faction)
+		. += "A photo of [owner_name] and their family."
 		return
 	. += "A photo of a family you do not know."
 

--- a/code/game/objects/items/tools/misc_tools.dm
+++ b/code/game/objects/items/tools/misc_tools.dm
@@ -284,21 +284,23 @@
 	matter = list("metal" = 20, "gold" = 10)
 	var/static/list/colour_list = list("red", "blue", "green", "yellow", "purple", "pink", "brown", "black", "orange") // Can add more colors as required
 	var/current_colour_index = 1
-	var/owner = "hard to read text"
+	var/owner_name
 
-/obj/item/tool/pen/fountain/Initialize(mapload, ...)
+/obj/item/tool/pen/fountain/pickup(mob/user, silent)
 	. = ..()
-	if(!mapload)
-		RegisterSignal(src, COMSIG_POST_SPAWN_UPDATE, PROC_REF(set_owner))
+	if(!owner_name)
+		RegisterSignal(user, COMSIG_POST_SPAWN_UPDATE, PROC_REF(set_owner))
 
 ///Sets the owner of the pen to who it spawns with, requires var/source for signals
-/obj/item/tool/pen/fountain/proc/set_owner(source = src, mob/living/carbon/human/user)
-	UnregisterSignal(src, COMSIG_POST_SPAWN_UPDATE)
-	owner = user
+/obj/item/tool/pen/fountain/proc/set_owner(datum/source)
+	SIGNAL_HANDLER
+	UnregisterSignal(source, COMSIG_POST_SPAWN_UPDATE)
+	var/mob/living/carbon/human/user = source
+	owner_name = user.name
 
 /obj/item/tool/pen/fountain/get_examine_text(mob/user)
 	. = ..()
-	. += "There's a laser engraving of [owner] on it."
+	. += "There's a laser engraving of [owner_name] on it."
 
 /obj/item/tool/pen/fountain/attack_self(mob/living/carbon/human/user)
 	if(on)

--- a/code/game/objects/items/tools/misc_tools.dm
+++ b/code/game/objects/items/tools/misc_tools.dm
@@ -300,7 +300,8 @@
 
 /obj/item/tool/pen/fountain/get_examine_text(mob/user)
 	. = ..()
-	. += "There's a laser engraving of [owner_name] on it."
+	if(owner_name)
+		. += "There's a laser engraving of [owner_name] on it."
 
 /obj/item/tool/pen/fountain/attack_self(mob/living/carbon/human/user)
 	if(on)

--- a/code/game/objects/items/toys/toys.dm
+++ b/code/game/objects/items/toys/toys.dm
@@ -553,15 +553,15 @@
 	///Hexadecimal 0-F (0-15)
 	var/static/list/hexadecimal = list("0", "1", "2", "3" , "4", "5", "6", "7", "8", "9", "A", "B", "C", "D", "E", "F")
 
-/obj/item/toy/plush/therapy/random_color/New(loc, ...)
+/obj/item/toy/plush/therapy/random_color/Initialize(mapload, ...)
 	. = ..()
 	var/color_code = "#[pick(hexadecimal)][pick(hexadecimal)][pick(hexadecimal)][pick(hexadecimal)][pick(hexadecimal)][pick(hexadecimal)]" //This is dumb and I hope theres a better way I'm missing
 	color = color_code
-	desc = "A custom therapy plush, in a unique color. This one is labeled with \"#[color_code]\"."
+	desc = "A custom therapy plush, in a unique color."
 
 /obj/item/toy/plush/random_plushie //Not using an effect so it can fit into storage from loadout
 	name = "random plush"
-	desc = "You should not be seeing this"
+	desc = "This plush looks awfully standard and bland. Is it actually yours?"
 	/// Standard plushies for the spawner to pick from
 	var/list/plush_list = list(
 		/obj/item/toy/plush/farwa,

--- a/code/game/objects/items/toys/toys.dm
+++ b/code/game/objects/items/toys/toys.dm
@@ -587,22 +587,32 @@
 	. = ..()
 	if(mapload) //Placed in mapping, will be randomized instantly on spawn
 		create_plushie()
-		return
-	RegisterSignal(src, COMSIG_POST_SPAWN_UPDATE, PROC_REF(create_plushie))
+		return INITIALIZE_HINT_QDEL
+
+/obj/item/toy/plush/random_plushie/pickup(mob/user, silent)
+	. = ..()
+	RegisterSignal(user, COMSIG_POST_SPAWN_UPDATE, PROC_REF(create_plushie))
 
 ///The randomizer picking and spawning a plushie on either the ground or in the humans backpack. Needs var/source due to signals
-/obj/item/toy/plush/random_plushie/proc/create_plushie(source = src, mob/living/user)
-	UnregisterSignal(src, COMSIG_POST_SPAWN_UPDATE)
+/obj/item/toy/plush/random_plushie/proc/create_plushie(datum/source)
+	SIGNAL_HANDLER
+	if(source)
+		UnregisterSignal(source, COMSIG_POST_SPAWN_UPDATE)
+	var/turf/spawn_location = get_turf(src)
 	var/plush_list_variety = pick(60; plush_list, 40; therapy_plush_list)
 	var/random_plushie = pick(plush_list_variety)
-	var/obj/item/toy/plush/plush = new random_plushie(get_turf(src)) //Starts on floor by default
+	var/obj/item/toy/plush/plush = new random_plushie(spawn_location) //Starts on floor by default
+	var/mob/living/carbon/human/user = source
 
 	if(!user) //If it didn't spawn on a humanoid
 		qdel(src)
 		return
+
 	var/obj/item/storage/backpack/storage = locate() in user //If the user has a backpack, put it there
 	if(storage?.can_be_inserted(plush, user, stop_messages = TRUE))
 		storage.attempt_item_insertion(plush, TRUE, user)
+	if(plush.loc == spawn_location) // Still on the ground
+		user.put_in_hands(plush, drop_on_fail = TRUE)
 	qdel(src)
 
 //Admin plushies


### PR DESCRIPTION

# About the pull request

Minor fixes for #4801 

 * Removes hard ref in photo and pen
 * Switches post-spawn signaling to avoid recursing mob contents
 * Fix unset pen displaying bogus text
 * Add a fallback for plushie generator to put it in hands if theres no backpack
 * Fix lingering reference for map-placed random plushies

And with any luck that also fixes the photo initialization bug

# Explain why it's good for the game
Is fix

# Testing Photographs and Procedure
Just tested spawning in with plushie / photo a few times
