### PR TITLE
Fixes a Cabinet in the SW Solaris Mines.

### DIFF
--- a/maps/map_files/BigRed/BigRed.dmm
+++ b/maps/map_files/BigRed/BigRed.dmm
@@ -37444,11 +37444,10 @@
 	},
 /area/space)
 "weO" = (
-/obj/structure/closet/secure_closet/medical_wall,
-/turf/open/floor/plating{
-	dir = 8;
-	icon_state = "platingdmg3"
+/obj/structure/closet/secure_closet/medical_wall{
+	pixel_y = -5
 	},
+/turf/closed/wall/solaris/reinforced,
 /area/bigredv2/caves/mining)
 "wfd" = (
 /obj/effect/decal/cleanable/dirt,
@@ -44776,8 +44775,8 @@ aao
 aao
 aao
 aao
-uHQ
 weO
+pSa
 wtj
 rKs
 wJd


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Places a Cabinet on a Wall in the SW Big Red mines.

As evidenced by the below images, we did test it. Oddly enough, the cabinet was always empty. (Unless the cabinet's stuff was included in a sprinkle. In which case...Oops? We did check the sprinkle file names, but none seemed to mention the SW mines.)

# Explain why it's good for the game

Well. It probably isn't. It's an empty cabinet. But it looks nicer now?


# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

What's been done in StrongDMM

![LookIdontgetpaidforinformaticgraphics](https://github.com/cmss13-devs/cmss13/assets/38842059/c39fbe6b-949d-4742-b4f4-3989a8159a55)

What it looks like Ingame.

![Test SolarisRidgepixel](https://github.com/cmss13-devs/cmss13/assets/38842059/c50ffae8-0fd4-407a-8790-374a9d11b737)

</details>

# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl: Skye.
maptweak: Tweaks a Cabinet in the SW mines of Solaris Ridge
fix: On account of it being propped up on the floor like a cardboard cutout.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
