### PR TITLE
Fix req ammo vendor not dispensing to the table

### DIFF
--- a/code/game/machinery/vending/cm_vending.dm
+++ b/code/game/machinery/vending/cm_vending.dm
@@ -140,7 +140,7 @@ GLOBAL_LIST_EMPTY(vending_products)
 		if(vend_dir_whitelist)
 			var/user_dir = get_dir(loc, user)
 			if(!(user_dir in vend_dir_whitelist))
-				return turf
+				return get_turf(user)
 		var/turf/relative_turf = get_step(user, vend_dir)
 		if(relative_turf)
 			return relative_turf

--- a/code/game/machinery/vending/cm_vending.dm
+++ b/code/game/machinery/vending/cm_vending.dm
@@ -142,7 +142,7 @@ GLOBAL_LIST_EMPTY(vending_products)
 			if(!(user_dir in vend_dir_whitelist))
 				return turf
 		var/turf/relative_turf = get_step(user, vend_dir)
-		if(relative_turf.Adjacent(src))
+		if(relative_turf)
 			return relative_turf
 	return turf
 


### PR DESCRIPTION
# About the pull request

This PR fixes #4852 caused by #4803 simply because the vendor is not adjacent to the table it is supposed to vend to.

# Explain why it's good for the game

It was unintentional for this to change.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>


https://github.com/cmss13-devs/cmss13/assets/76988376/e56607a3-7641-4c91-b585-fddeefb97098

After changing from turf to get_turf(user) per Fira:


https://github.com/cmss13-devs/cmss13/assets/76988376/a7a55df4-531c-40ea-a8a3-9b28d550f656

</details>


# Changelog
:cl: Drathek
fix: Fix the ColMarTechAutomated Munition Vendor in req not vending to the table.
/:cl:
