### PR TITLE
Fixes colliding keybinds for asay/mentorsay

### DIFF
--- a/code/__DEFINES/keybinding.dm
+++ b/code/__DEFINES/keybinding.dm
@@ -14,6 +14,7 @@
 #define COMSIG_KB_ADMIN_INVISIMINTOGGLE_DOWN "keybinding_admin_invisimintoggle_down"
 #define COMSIG_KB_ADMIN_DEADMIN_DOWN "keybinding_admin_deadmin_down"
 #define COMSIG_KB_ADMIN_READMIN_DOWN "keybinding_admin_readmin_down"
+#define COMSIG_KB_ADMIN_MENTORSAY_DOWN "keybinding_admin_mentorsay_down"
 
 //Carbon
 #define COMSIG_KB_CARBON_HOLDRUNMOVEINTENT_DOWN "keybinding_carbon_holdrunmoveintent_down"

--- a/code/__DEFINES/speech_channels.dm
+++ b/code/__DEFINES/speech_channels.dm
@@ -1,6 +1,7 @@
 // Used to direct channels to speak into.
 #define SAY_CHANNEL "Say"
 #define COMMS_CHANNEL "Comms"
+#define WHISPER_CHANNEL "Whisper"
 #define ME_CHANNEL "Me"
 #define OOC_CHANNEL "OOC"
 #define LOOC_CHANNEL "LOOC"

--- a/code/datums/keybinding/communication.dm
+++ b/code/datums/keybinding/communication.dm
@@ -32,7 +32,7 @@
 /datum/keybinding/client/communication/whisper
 	hotkey_keys = list("Unbound")
 	classic_keys = list("Unbound")
-	name = "Whisper"
+	name = WHISPER_CHANNEL
 	full_name = "IC Whisper"
 	keybind_signal = COMSIG_KB_CLIENT_WHISPER_DOWN
 
@@ -56,4 +56,4 @@
 	name = MENTOR_CHANNEL
 	full_name = "Mentor Say"
 	description = "Talk with other mentors."
-	keybind_signal = COMSIG_KB_ADMIN_ASAY_DOWN
+	keybind_signal = COMSIG_KB_ADMIN_MENTORSAY_DOWN

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -724,7 +724,7 @@ GLOBAL_LIST_INIT(whitelisted_client_procs, list(
 							winset(src, "srvkeybinds-[REF(key)]", "parent=default;name=[key];command=mentorsay")
 					else
 						winset(src, "srvkeybinds-[REF(key)]", "parent=default;name=[key];command=")
-				if("Whisper")
+				if(WHISPER_CHANNEL)
 					winset(src, "srvkeybinds-[REF(key)]", "parent=default;name=[key];command=whisper")
 
 /client/proc/toggle_fullscreen(new_value)


### PR DESCRIPTION

# About the pull request

Keybind signals were colliding which probably caused god knows what kind of malfunctions in SSinput and tgui_say.

I'd be very happy if this just happened to randomly fix the fact that both asay and mentorsay keep breaking.

# Changelog
:cl:
fix: Fixed incorrect signals causing malfunctions in tgui_say for ASAY and MentorSay channel hotkeys.
/:cl:
