### PR TITLE
Adds possibility to customize crates

### DIFF
--- a/code/__DEFINES/dcs/signals/atom/signals_obj.dm
+++ b/code/__DEFINES/dcs/signals/atom/signals_obj.dm
@@ -29,3 +29,5 @@
 
 /// from /obj/proc/afterbuckle()
 #define COSMIG_OBJ_AFTER_BUCKLE "signal_obj_after_buckle"
+
+#define COMSIG_STRUCTURE_CRATE_SQUAD_LAUNCHED "structure_crate_squad_launched"

--- a/code/datums/components/crate_tag.dm
+++ b/code/datums/components/crate_tag.dm
@@ -29,6 +29,7 @@
 		parent.AddComponent(/datum/component/label, name)
 		src.name = name // Keep it around additionally for notifications
 
+/// Handler to notify an overwatched squad that this crate has been dropped for them
 /datum/component/crate_tag/proc/notify_squad(datum/source, datum/squad/squad)
 	SIGNAL_HANDLER
 	squad.send_message("'[name]' supply drop incoming. Heads up!")

--- a/code/datums/components/crate_tag.dm
+++ b/code/datums/components/crate_tag.dm
@@ -1,0 +1,35 @@
+/datum/component/crate_tag
+	dupe_mode = COMPONENT_DUPE_UNIQUE_PASSARGS
+	/// The crate tag used for notifications and as label
+	var/name
+
+/datum/component/crate_tag/Initialize(name, obj/structure/closet/crate/masquarade_type)
+	var/obj/structure/closet/crate/crate = parent
+	if(!istype(crate))
+		return COMPONENT_INCOMPATIBLE
+	setup(name, masquarade_type)
+	RegisterSignal(parent, COMSIG_STRUCTURE_CRATE_SQUAD_LAUNCHED, PROC_REF(notify_squad))
+
+/datum/component/crate_tag/InheritComponent(datum/component/C, i_am_original, name, obj/structure/closet/crate/masquarade_type)
+	. = ..()
+	setup(name, masquarade_type)
+
+/datum/component/crate_tag/proc/setup(name, obj/structure/closet/crate/masquarade_type)
+	var/obj/structure/closet/crate/crate = parent
+	if(masquarade_type)
+		crate.name = initial(masquarade_type.name)
+		crate.desc = initial(masquarade_type.desc)
+		crate.icon_opened = initial(masquarade_type.icon_opened)
+		crate.icon_closed = initial(masquarade_type.icon_closed)
+		if(crate.opened)
+			crate.icon_state = crate.icon_opened
+		else
+			crate.icon_state = crate.icon_closed
+	if(name)
+		parent.AddComponent(/datum/component/label, name)
+		src.name = name // Keep it around additionally for notifications
+
+/datum/component/crate_tag/proc/notify_squad(datum/source, datum/squad/squad)
+	SIGNAL_HANDLER
+	squad.send_message("'[name]' supply drop incoming. Heads up!")
+	squad.send_maptext(name, "Incoming Supply Drop:")

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -12,6 +12,19 @@
 	throwpass = 1 //prevents moving crates by hurling things at them
 	store_mobs = FALSE
 	var/rigged = 0
+	/// Types this crate can be made into
+	var/list/crate_customizing_types = list(
+		"Plain" = /obj/structure/closet/crate,
+		"Weapons" = /obj/structure/closet/crate/weapon,
+		"Supply" = /obj/structure/closet/crate/supply,
+		"Ammo" = /obj/structure/closet/crate/ammo,
+		"Construction" = /obj/structure/closet/crate/construction,
+		"Explosives" = /obj/structure/closet/crate/explosives,
+		"Alpha" = /obj/structure/closet/crate/alpha,
+		"Bravo" = /obj/structure/closet/crate/bravo,
+		"Charlie" = /obj/structure/closet/crate/charlie,
+		"Delta" = /obj/structure/closet/crate/delta,
+	)
 
 /obj/structure/closet/crate/initialize_pass_flags(datum/pass_flags_container/PF)
 	..()
@@ -207,6 +220,7 @@
 	icon_state = "closed_freezer"
 	icon_opened = "open_freezer"
 	icon_closed = "closed_freezer"
+	crate_customizing_types = null
 	var/target_temp = T0C - 40
 	var/cooling_power = 40
 

--- a/code/game/objects/structures/crates_lockers/secure_crates.dm
+++ b/code/game/objects/structures/crates_lockers/secure_crates.dm
@@ -4,6 +4,7 @@
 	icon_state = "secure_locked_basic"
 	icon_opened = "secure_open_basic"
 	icon_closed = "secure_locked_basic"
+	crate_customizing_types = null
 	var/icon_locked = "secure_locked_basic"
 	var/icon_unlocked = "secure_unlocked_basic"
 	var/sparks = "securecratesparks"

--- a/code/modules/cm_marines/overwatch.dm
+++ b/code/modules/cm_marines/overwatch.dm
@@ -841,18 +841,14 @@
 
 	busy = TRUE
 	C.visible_message(SPAN_WARNING("\The [C] loads into a launch tube. Stand clear!"))
-	C.anchored = TRUE //To avoid accidental pushes
-	current_squad.send_message("'[C.name]' supply drop incoming. Heads up!")
-	current_squad.send_maptext(C.name, "Incoming Supply Drop:")
-	var/datum/squad/S = current_squad //in case the operator changes the overwatched squad mid-drop
-	COOLDOWN_START(S, next_supplydrop, 500 SECONDS)
+	SEND_SIGNAL(C, COMSIG_STRUCTURE_CRATE_SQUAD_LAUNCHED, current_squad)
+	COOLDOWN_START(current_squad, next_supplydrop, 500 SECONDS)
 	if(ismob(usr))
 		var/mob/M = usr
 		M.count_niche_stat(STATISTICS_NICHE_CRATES)
 
 	playsound(C.loc,'sound/effects/bamf.ogg', 50, 1)  //Ehh
-	var/obj/structure/droppod/supply/pod = new()
-	C.forceMove(pod)
+	var/obj/structure/droppod/supply/pod = new(null, C)
 	pod.launch(T)
 	visible_message("[icon2html(src, viewers(src))] [SPAN_BOLDNOTICE("'[C.name]' supply drop launched! Another launch will be available in five minutes.")]")
 	busy = FALSE

--- a/code/modules/cm_tech/droppod/supply.dm
+++ b/code/modules/cm_tech/droppod/supply.dm
@@ -1,16 +1,31 @@
 /obj/structure/droppod/supply
-	name = "\improper USCM requisitions droppod"
+	name = "\improper USCM requisitions package"
 	drop_time = 10 SECONDS
 	dropping_time = 2 SECONDS
 	open_time = 2 SECONDS
+	var/obj/structure/package
+
+/obj/structure/droppod/supply/Initialize(mapload, obj/structure/closet/crate/package)
+	. = ..()
+	if(!istype(package))
+		return INITIALIZE_HINT_QDEL
+	package.forceMove(src)
+	src.package = package
+
+/obj/structure/droppod/supply/Destroy()
+	. = ..()
+	package = null
+
+/* Pose as the crate so we see it falling from the skies */
+/obj/structure/droppod/supply/update_icon()
+	. = ..()
+	icon = package.icon
+	icon_state = package.icon_state
 
 /obj/structure/droppod/supply/open()
 	. = ..()
 	for(var/atom/movable/content as anything in contents)
-		///Crates are anchored when launched to avoid pushing them while launching and this created issues with them being anchored when they landed groundside.
-		///This unanchors them before moving them out to make sure that crates are able to be moved when groundside.
-		if(istype(content, /obj/structure/closet/crate))
-			content.anchored = FALSE
 		content.forceMove(loc)
+	package = null
 	qdel(src)
 

--- a/code/modules/cm_tech/droppod/supply.dm
+++ b/code/modules/cm_tech/droppod/supply.dm
@@ -3,18 +3,19 @@
 	drop_time = 10 SECONDS
 	dropping_time = 2 SECONDS
 	open_time = 2 SECONDS
+	/// The contained parimary object, used as a replacer for the droppod icon
 	var/obj/structure/package
 
-/obj/structure/droppod/supply/Initialize(mapload, obj/structure/closet/crate/package)
+/obj/structure/droppod/supply/Initialize(mapload, obj/structure/package)
 	. = ..()
 	if(!istype(package))
 		return INITIALIZE_HINT_QDEL
 	package.forceMove(src)
 	src.package = package
 
-/obj/structure/droppod/supply/Destroy()
-	. = ..()
+/obj/structure/droppod/supply/Destroy(force)
 	package = null
+	return ..()
 
 /* Pose as the crate so we see it falling from the skies */
 /obj/structure/droppod/supply/update_icon()

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -282,36 +282,36 @@
 			if(!chosen_type || !ispath(crate.crate_customizing_types[chosen_type]) || !user.Adjacent(target) || !target.z)
 				return
 			target.AddComponent(/datum/component/crate_tag, label, crate.crate_customizing_types[chosen_type])
-			src.amount -= 3
+			amount -= 3
 		else
-			if (src.amount > 3 && !crate.opened)
-				var/obj/structure/bigDelivery/P = new /obj/structure/bigDelivery(get_turf(crate.loc))
-				P.icon_state = "deliverycrate"
-				P.wrapped = crate
-				crate.forceMove(P)
-				src.amount -= 3
+			if (amount > 3 && !crate.opened)
+				var/obj/structure/bigDelivery/package = new /obj/structure/bigDelivery(get_turf(crate.loc))
+				package.icon_state = "deliverycrate"
+				package.wrapped = crate
+				crate.forceMove(package)
+				amount -= 3
 				user.visible_message("\The [user] wraps \a [target] with \a [src].",\
 				SPAN_NOTICE("You wrap \the [target], leaving [amount] units of paper on \the [src]."),\
 				"You hear someone taping paper around a large object.")
-			else if(src.amount < 3)
+			else if(amount < 3)
 				to_chat(user, SPAN_WARNING("You need more paper."))
 	else if (istype (target, /obj/structure/closet))
-		var/obj/structure/closet/O = target
-		if (src.amount > 3 && !O.opened)
-			var/obj/structure/bigDelivery/P = new /obj/structure/bigDelivery(get_turf(O.loc))
-			P.wrapped = O
-			O.welded = 1
-			O.forceMove(P)
-			src.amount -= 3
+		var/obj/structure/closet/object = target
+		if (amount > 3 && !object.opened)
+			var/obj/structure/bigDelivery/package = new /obj/structure/bigDelivery(get_turf(object.loc))
+			package.wrapped = object
+			object.welded = 1
+			object.forceMove(package)
+			amount -= 3
 			user.visible_message("\The [user] wraps \a [target] with \a [src].",\
 			SPAN_NOTICE("You wrap \the [target], leaving [amount] units of paper on \the [src]."),\
 			"You hear someone taping paper around a large object.")
-		else if(src.amount < 3)
+		else if(amount < 3)
 			to_chat(user, SPAN_WARNING("You need more paper."))
 	else
 		to_chat(user, SPAN_NOTICE(" The object you are trying to wrap is unsuitable for the sorting machinery!"))
-	if (src.amount <= 0)
-		new /obj/item/trash/c_tube( src.loc )
+	if (amount <= 0)
+		new /obj/item/trash/c_tube( loc )
 		qdel(src)
 		return
 	return

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -263,8 +263,8 @@
 			O.add_fingerprint(usr)
 			src.add_fingerprint(usr)
 			src.amount--
-			user.visible_message("\The [user] wraps \a [target] with \a [src].",\
-			SPAN_NOTICE("You wrap \the [target], leaving [amount] units of paper on \the [src]."),\
+			user.visible_message("[user] wraps [target] with [src].",\
+			SPAN_NOTICE("You wrap [target], leaving [amount] units of paper on [src]."),\
 			"You hear someone taping paper around a small object.")
 	else if (istype(target, /obj/structure/closet/crate))
 		var/obj/structure/closet/crate/crate = target
@@ -290,8 +290,8 @@
 				package.wrapped = crate
 				crate.forceMove(package)
 				amount -= 3
-				user.visible_message("\The [user] wraps \a [target] with \a [src].",\
-				SPAN_NOTICE("You wrap \the [target], leaving [amount] units of paper on \the [src]."),\
+				user.visible_message("[user] wraps [target] with [src].",\
+				SPAN_NOTICE("You wrap [target], leaving [amount] units of paper on [src]."),\
 				"You hear someone taping paper around a large object.")
 			else if(amount < 3)
 				to_chat(user, SPAN_WARNING("You need more paper."))
@@ -303,8 +303,8 @@
 			object.welded = 1
 			object.forceMove(package)
 			amount -= 3
-			user.visible_message("\The [user] wraps \a [target] with \a [src].",\
-			SPAN_NOTICE("You wrap \the [target], leaving [amount] units of paper on \the [src]."),\
+			user.visible_message("[user] wraps [target] with [src].",\
+			SPAN_NOTICE("You wrap [target], leaving [amount] units of paper on [src]."),\
 			"You hear someone taping paper around a large object.")
 		else if(amount < 3)
 			to_chat(user, SPAN_WARNING("You need more paper."))

--- a/colonialmarines.dme
+++ b/colonialmarines.dme
@@ -373,6 +373,7 @@
 #include "code\datums\components\bonus_damage_stack.dm"
 #include "code\datums\components\cluster_stack.dm"
 #include "code\datums\components\connect_mob_behalf.dm"
+#include "code\datums\components\crate_tag.dm"
 #include "code\datums\components\footstep.dm"
 #include "code\datums\components\healing_reduction.dm"
 #include "code\datums\components\id_lock.dm"

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -42111,6 +42111,7 @@
 	amount = 50
 	},
 /obj/structure/surface/rack,
+/obj/item/packageWrap,
 /turf/open/floor/almayer{
 	dir = 4;
 	icon_state = "green"
@@ -56264,6 +56265,7 @@
 /obj/structure/surface/table/almayer,
 /obj/effect/spawner/random/powercell,
 /obj/effect/spawner/random/tool,
+/obj/item/packageWrap,
 /turf/open/floor/almayer{
 	dir = 8;
 	icon_state = "green"
@@ -77582,6 +77584,7 @@
 "xfw" = (
 /obj/structure/surface/table/almayer,
 /obj/item/storage/fancy/cigarettes/lucky_strikes,
+/obj/item/packageWrap,
 /turf/open/floor/almayer{
 	dir = 9;
 	icon_state = "green"


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

You can now customize non-secure crates using packaging wrap, by tagging them and changing their appearance to a list of common crates. The tag works as a labeler label, and is also displayed in the overwatch supply drop alert.

# Explain why it's good for the game
If anything, it's that these Squad crates are just sitting there unused. I don't know if this feature will be used much by live Reqs.

# Changelog
:cl:
add: You can now use package wrap to change standard crates visuals.
add: You can now label crate with package wrap, which will also be shown during overwatch supply drop alert.
mapadd: Added more packaging wrap to Requisitions.
/:cl:
