### PR TITLE
/tg/ Status Effects Prelude C - Mob Density Refactor

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -131,6 +131,9 @@
 /// Example trait
 // #define TRAIT_X "t_x"
 //-- mob traits --
+/// Apply this to make a mob not dense, and remove it when you want it to no longer make them undense, other sorces of undesity will still apply. Always define a unique source when adding a new instance of this!
+#define TRAIT_UNDENSE "undense"
+
 // SPECIES TRAITS
 /// Knowledge of Yautja technology
 #define TRAIT_YAUTJA_TECH "t_yautja_tech"
@@ -279,6 +282,7 @@ GLOBAL_LIST_INIT(mob_traits, list(
 */
 GLOBAL_LIST_INIT(traits_by_type, list(
 	/mob = list(
+		"TRAIT_UNDENSE" = TRAIT_UNDENSE,
 		"TRAIT_YAUTJA_TECH" = TRAIT_YAUTJA_TECH,
 		"TRAIT_SUPER_STRONG" = TRAIT_SUPER_STRONG,
 		"TRAIT_FOREIGN_BIO" = TRAIT_FOREIGN_BIO,
@@ -355,6 +359,8 @@ GLOBAL_LIST(trait_name_map)
 // #define TRAIT_SOURCE_Y "t_s_y"
 #define TRAIT_SOURCE_INHERENT "t_s_inherent"
 //-- mob traits --
+///Status trait coming from lying down through update_canmove()
+#define LYING_TRAIT "lying"
 ///Status trait coming from species. .human/species_gain()
 #define TRAIT_SOURCE_SPECIES "t_s_species"
 ///Status trait coming from the hive.
@@ -379,6 +385,8 @@ GLOBAL_LIST(trait_name_map)
 #define TRAIT_SOURCE_ABILITY(ability) "t_s_ability_[ability]"
 ///Status trait forced by the xeno action charge
 #define TRAIT_SOURCE_XENO_ACTION_CHARGE "t_s_xeno_action_charge"
+///Status trait coming from a xeno nest
+#define XENO_NEST_TRAIT "xeno_nest"
 //-- structure traits --
 ///Status trait coming from being flipped or unflipped.
 #define TRAIT_SOURCE_FLIP_TABLE "t_s_flip_table"
@@ -390,3 +398,12 @@ GLOBAL_LIST(trait_name_map)
 
 //Status trait coming from clothing.
 #define TRAIT_SOURCE_CLOTHING "t_s_clothing"
+
+/// trait effect related to active specialist gear
+#define SPECIALIST_GEAR_TRAIT "specialist_gear"
+/// traits associated with usage of snowflake dropship double seats
+#define DOUBLE_SEATS_TRAIT "double_seats"
+/// traits associated with xeno on-ground weeds
+#define XENO_WEED_TRAIT "xeno_weed"
+/// traits from chloroform usage
+#define CHLOROFORM_TRAIT "chloroform"

--- a/code/datums/agents/tools/chloroform.dm
+++ b/code/datums/agents/tools/chloroform.dm
@@ -48,7 +48,7 @@
 /obj/item/weapon/chloroform/proc/grab_stun(mob/living/M, mob/living/user)
 	M.anchored = TRUE
 	M.frozen = TRUE
-	M.density = FALSE
+	ADD_TRAIT(M, TRAIT_UNDENSE, CHLOROFORM_TRAIT)
 	M.able_to_speak = FALSE
 	M.update_canmove()
 
@@ -83,6 +83,7 @@
 	M.able_to_speak = TRUE
 	M.layer = MOB_LAYER
 	M.unfreeze()
+	REMOVE_TRAIT(M, TRAIT_UNDENSE, CHLOROFORM_TRAIT)
 
 	QDEL_NULL(mask_item)
 

--- a/code/datums/components/weed_food.dm
+++ b/code/datums/components/weed_food.dm
@@ -259,7 +259,7 @@
 	active = FALSE
 	merged = TRUE
 
-	parent_mob.density = FALSE
+	ADD_TRAIT(parent_mob, TRAIT_UNDENSE, XENO_WEED_TRAIT)
 	parent_mob.anchored = TRUE
 	parent_mob.mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	parent_mob.plane = FLOOR_PLANE

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -116,7 +116,14 @@ directive is properly returned.
 
 //===========================================================================
 
-
+// TODO make all atoms use set_density, do not rely on it at present
+///Setter for the `density` variable to append behavior related to its changing.
+/atom/proc/set_density(new_value)
+	SHOULD_CALL_PARENT(TRUE)
+	if(density == new_value)
+		return
+	. = density
+	density = new_value
 
 //atmos procs
 

--- a/code/game/objects/structures/stool_bed_chair_nest/xeno_nest.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/xeno_nest.dm
@@ -53,7 +53,7 @@
 		current_mob.pixel_y = buckling_y["[dir]"]
 		current_mob.pixel_x = buckling_x["[dir]"]
 		current_mob.dir = turn(dir, 180)
-		current_mob.density = FALSE
+		ADD_TRAIT(current_mob, TRAIT_UNDENSE, XENO_NEST_TRAIT)
 		pixel_y = buckling_y["[dir]"]
 		pixel_x = buckling_x["[dir]"]
 		if(dir == SOUTH)
@@ -67,7 +67,7 @@
 
 	current_mob.pixel_y = initial(buckled_mob.pixel_y)
 	current_mob.pixel_x = initial(buckled_mob.pixel_x)
-	current_mob.density = !(current_mob.lying || current_mob.stat == DEAD)
+	REMOVE_TRAIT(current_mob, TRAIT_UNDENSE, XENO_NEST_TRAIT)
 	if(dir == SOUTH)
 		current_mob.layer = initial(current_mob.layer)
 		if(!ishuman(current_mob))

--- a/code/modules/clothing/suits/marine_armor.dm
+++ b/code/modules/clothing/suits/marine_armor.dm
@@ -901,10 +901,10 @@
 		COMSIG_MOB_DEATH,
 		COMSIG_HUMAN_EXTINGUISH
 	), PROC_REF(deactivate_camouflage))
-	RegisterSignal(H, COMSIG_MOB_POST_UPDATE_CANMOVE, PROC_REF(fix_density))
 	camo_active = TRUE
 	H.alpha = full_camo_alpha
 	H.FF_hit_evade = 1000
+	ADD_TRAIT(H, TRAIT_UNDENSE, SPECIALIST_GEAR_TRAIT)
 	H.density = FALSE
 
 	RegisterSignal(H, COMSIG_MOB_MOVE_OR_LOOK, PROC_REF(handle_mob_move_or_look))
@@ -938,8 +938,7 @@
 	camo_active = FALSE
 	animate(H, alpha = initial(H.alpha), flags = ANIMATION_END_NOW)
 	H.FF_hit_evade = initial(H.FF_hit_evade)
-	if(!H.lying)
-		H.density = TRUE
+	REMOVE_TRAIT(H, TRAIT_UNDENSE, SPECIALIST_GEAR_TRAIT)
 	H.update_canmove()
 
 	var/datum/mob_hud/security/advanced/SA = huds[MOB_HUD_SECURITY_ADVANCED]
@@ -959,11 +958,6 @@
 		H.alpha = current_camo
 		addtimer(CALLBACK(src, PROC_REF(fade_out_finish), H), camouflage_break, TIMER_OVERRIDE|TIMER_UNIQUE)
 		animate(H, alpha = full_camo_alpha + 5, time = camouflage_break, easing = LINEAR_EASING, flags = ANIMATION_END_NOW)
-
-/obj/item/clothing/suit/storage/marine/ghillie/proc/fix_density(mob/user)
-	SIGNAL_HANDLER
-	if(camo_active)
-		user.density = FALSE
 
 /obj/item/clothing/suit/storage/marine/ghillie/proc/fade_out_finish(mob/living/carbon/human/H)
 	if(camo_active && H.wear_suit == src)

--- a/code/modules/mob/living/carbon/xenomorph/abilities/burrower/burrower_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/burrower/burrower_powers.dm
@@ -47,6 +47,7 @@
 				COMSIG_LIVING_FLAMER_FLAMED,
 		), PROC_REF(flamer_crossed_immune))
 	ADD_TRAIT(src, TRAIT_ABILITY_BURROWED, TRAIT_SOURCE_ABILITY("Burrow"))
+	ADD_TRAIT(src, TRAIT_UNDENSE, TRAIT_SOURCE_ABILITY("Burrow"))
 	playsound(src.loc, 'sound/effects/burrowing_b.ogg', 25)
 	update_canmove()
 	update_icons()
@@ -76,6 +77,7 @@
 				COMSIG_LIVING_FLAMER_FLAMED,
 		))
 	REMOVE_TRAIT(src, TRAIT_ABILITY_BURROWED, TRAIT_SOURCE_ABILITY("Burrow"))
+	REMOVE_TRAIT(src, TRAIT_UNDENSE, TRAIT_SOURCE_ABILITY("Burrow"))
 	frozen = FALSE
 	invisibility = FALSE
 	anchored = FALSE

--- a/code/modules/mob/living/init_signals.dm
+++ b/code/modules/mob/living/init_signals.dm
@@ -1,0 +1,8 @@
+/// Called on [/mob/living/Initialize(mapload)], for the mob to register to relevant signals.
+/mob/living/proc/register_init_signals()
+	RegisterSignal(src, list(SIGNAL_ADDTRAIT(TRAIT_UNDENSE), SIGNAL_REMOVETRAIT(TRAIT_UNDENSE)), PROC_REF(undense_changed))
+
+/// Called when [TRAIT_UNDENSE] is gained or lost
+/mob/living/proc/undense_changed(datum/source)
+	SIGNAL_HANDLER
+	update_density()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -16,6 +16,7 @@
 
 	attack_icon = image("icon" = 'icons/effects/attacks.dmi',"icon_state" = "", "layer" = 0)
 
+	register_init_signals()
 	initialize_incision_depths()
 	initialize_pain()
 	initialize_stamina()
@@ -463,3 +464,9 @@
 	switch(stat)
 		if(DEAD)
 			SEND_SIGNAL(src, COMSIG_MOB_STAT_SET_DEAD)
+
+/mob/living/proc/update_density()
+	if(HAS_TRAIT(src, TRAIT_UNDENSE))
+		set_density(FALSE)
+	else
+		set_density(TRUE)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -465,7 +465,7 @@
 		if(DEAD)
 			SEND_SIGNAL(src, COMSIG_MOB_STAT_SET_DEAD)
 
-/// Uses presence [TRAIT_UNDENSE] to figure out what is the correct density state for the mob. Triggered by trait signal.
+/// Uses presence of [TRAIT_UNDENSE] to figure out what is the correct density state for the mob. Triggered by trait signal.
 /mob/living/proc/update_density()
 	if(HAS_TRAIT(src, TRAIT_UNDENSE))
 		set_density(FALSE)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -465,6 +465,7 @@
 		if(DEAD)
 			SEND_SIGNAL(src, COMSIG_MOB_STAT_SET_DEAD)
 
+/// Uses presence [TRAIT_UNDENSE] to figure out what is the correct density state for the mob. Triggered by trait signal.
 /mob/living/proc/update_density()
 	if(HAS_TRAIT(src, TRAIT_UNDENSE))
 		set_density(FALSE)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -729,13 +729,13 @@ note dizziness decrements automatically in the mob's Life() proc.
 
 	if(lying_prev != lying)
 		if(lying)
-			density = FALSE
+			ADD_TRAIT(src, TRAIT_UNDENSE, LYING_TRAIT)
 			add_temp_pass_flags(PASS_MOB_THRU)
 			drop_l_hand()
 			drop_r_hand()
 			SEND_SIGNAL(src, COMSIG_MOB_KNOCKED_DOWN)
 		else
-			density = TRUE
+			REMOVE_TRAIT(src, TRAIT_UNDENSE, LYING_TRAIT)
 			SEND_SIGNAL(src, COMSIG_MOB_GETTING_UP)
 			remove_temp_pass_flags(PASS_MOB_THRU)
 		update_transform()

--- a/code/modules/vehicles/interior/interactable/seats.dm
+++ b/code/modules/vehicles/interior/interactable/seats.dm
@@ -376,14 +376,14 @@
 			//if both seats on same tile have buckled mob, we become dense, otherwise, not dense.
 			if(buckled_mob)
 				if(VS.buckled_mob)
-					buckled_mob.density = TRUE
-					VS.buckled_mob.density = TRUE
+					REMOVE_TRAIT(buckled_mob, TRAIT_UNDENSE, DOUBLE_SEATS_TRAIT)
+					REMOVE_TRAIT(VS.buckled_mob, TRAIT_UNDENSE, DOUBLE_SEATS_TRAIT)
 				else
-					buckled_mob.density = FALSE
+					ADD_TRAIT(buckled_mob, TRAIT_UNDENSE, DOUBLE_SEATS_TRAIT)
 			else
 				if(VS.buckled_mob)
-					VS.buckled_mob.density = FALSE
-				M.density = TRUE
+					ADD_TRAIT(VS.buckled_mob, TRAIT_UNDENSE, DOUBLE_SEATS_TRAIT)
+				REMOVE_TRAIT(M, TRAIT_UNDENSE, DOUBLE_SEATS_TRAIT)
 			break
 
 	handle_rotation()

--- a/colonialmarines.dme
+++ b/colonialmarines.dme
@@ -1809,6 +1809,7 @@
 #include "code\modules\mob\language\languages.dm"
 #include "code\modules\mob\living\blood.dm"
 #include "code\modules\mob\living\damage_procs.dm"
+#include "code\modules\mob\living\init_signals.dm"
 #include "code\modules\mob\living\living.dm"
 #include "code\modules\mob\living\living_defense.dm"
 #include "code\modules\mob\living\living_defines.dm"


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

Part of #4828

Implements the undense trait. This both lets us stack and unstack sources of undensity properly avoiding issues eg. we've had with nests in the past, and lays some groundwork for updates when main PR gets rid of update_canmove 

# Testing Photographs and Procedure
Minor testing, mostly tested as part of parent PR


# Changelog
:cl:
fix: Density effects should now properly update when stacked and unstacked.
/:cl:
