### PR TITLE
Fix fax template images for CDN

### DIFF
--- a/code/modules/admin/fax_templates.dm
+++ b/code/modules/admin/fax_templates.dm
@@ -1,11 +1,13 @@
 
 /proc/generate_templated_fax(show_wy_logo, fax_header, fax_subject, addressed_to, message_body, sent_by, sent_title, sent_department)
+	var/datum/asset/asset = get_asset_datum(/datum/asset/simple/paper)
+
 	var/dat = ""
 	dat += "<style>"
 	dat += "body {"
 	dat += "margin:0 auto;"
 	dat += "padding:0;"
-	dat += "background-image: url('faxbackground.jpg');"
+	dat += "background-image: url('[asset.get_url_mappings()["faxbackground.jpg"]]');"
 	dat += "font-family: monospace;"
 	dat += "}"
 
@@ -63,7 +65,7 @@
 
 	if(show_wy_logo)
 		dat += "<div id='fax-logo'>"
-		dat += "<img src='faxwylogo.png' alt='Something fucked!'/>"
+		dat += "<img src='[asset.get_url_mappings()["faxwylogo.png"]]' alt='Something fucked!'/>"
 		dat += "</div>"
 
 	dat += "<div class='message-header-text'>"


### PR DESCRIPTION
# About the pull request

This PR fixes the fax templates' images for the paper background and WY logo. They were not using the URL mapping when using a CDN.

# Explain why it's good for the game

Immersion. A broken image with the caption "Something fucked!" is goofy.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>
Broken:

![image](https://github.com/cmss13-devs/cmss13/assets/76988376/0f9f02ca-5eb5-4998-880c-a7305bd78310)

Working:

![image](https://github.com/cmss13-devs/cmss13/assets/76988376/276dea9b-d72d-4ab8-90cb-0e095ba83bc4)

</details>


# Changelog
:cl: Drathek
fix: Fixed fax template images in CDN mode
/:cl:
