### PR TITLE
Hotfix for missing Traitbound Elements Handlers

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -10,6 +10,9 @@
 			_L = target._status_traits; \
 			_L[trait] = list(source); \
 			SEND_SIGNAL(target, SIGNAL_ADDTRAIT(trait), trait); \
+			if(trait in GLOB.traits_with_elements){ \
+				target.AddElement(GLOB.traits_with_elements[trait]); \
+			} \
 		} else { \
 			_L = target._status_traits; \
 			if (_L[trait]) { \
@@ -17,6 +20,9 @@
 			} else { \
 				_L[trait] = list(source); \
 				SEND_SIGNAL(target, SIGNAL_ADDTRAIT(trait), trait); \
+				if(trait in GLOB.traits_with_elements){ \
+					target.AddElement(GLOB.traits_with_elements[trait]); \
+				} \
 			} \
 		} \
 	} while (0)
@@ -38,6 +44,9 @@
 			if (!length(_L[trait])) { \
 				_L -= trait; \
 				SEND_SIGNAL(target, SIGNAL_REMOVETRAIT(trait), trait); \
+				if(trait in GLOB.traits_with_elements) { \
+					target.RemoveElement(GLOB.traits_with_elements[trait]); \
+				} \
 			}; \
 			if (!length(_L)) { \
 				target._status_traits = null \
@@ -62,6 +71,9 @@
 			if (!length(_traits_list[trait])) { \
 				_traits_list -= trait; \
 				SEND_SIGNAL(target, SIGNAL_REMOVETRAIT(trait), trait); \
+				if(trait in GLOB.traits_with_elements) { \
+					target.RemoveElement(GLOB.traits_with_elements[trait]); \
+				} \
 			}; \
 			if (!length(_traits_list)) { \
 				target._status_traits = null \
@@ -78,8 +90,11 @@
 				if (!length(_L[_T])) { \
 					_L -= _T; \
 					SEND_SIGNAL(target, SIGNAL_REMOVETRAIT(_T), _T); \
+					if(trait in GLOB.traits_with_elements) { \
+						target.RemoveElement(GLOB.traits_with_elements[trait]); \
 					}; \
 				};\
+			};\
 			if (!length(_L)) { \
 				target._status_traits = null\
 			};\
@@ -101,8 +116,11 @@
 				if (!length(_L[_T])) { \
 					_L -= _T; \
 					SEND_SIGNAL(target, SIGNAL_REMOVETRAIT(_T)); \
+					if(_T in GLOB.traits_with_elements) { \
+						target.RemoveElement(GLOB.traits_with_elements[_T]); \
 					}; \
 				};\
+			};\
 			if (!length(_L)) { \
 				target._status_traits = null\
 			};\
@@ -355,6 +373,8 @@ GLOBAL_LIST(trait_name_map)
 /// Example trait source
 // #define TRAIT_SOURCE_Y "t_s_y"
 #define TRAIT_SOURCE_INHERENT "t_s_inherent"
+/// cannot be removed without admin intervention
+#define ROUNDSTART_TRAIT "roundstart"
 //-- mob traits --
 ///Status trait coming from lying down through update_canmove()
 #define LYING_TRAIT "lying"
@@ -364,8 +384,6 @@ GLOBAL_LIST(trait_name_map)
 #define TRAIT_SOURCE_HIVE "t_s_hive"
 ///Status trait coming from being buckled.
 #define TRAIT_SOURCE_BUCKLE "t_s_buckle"
-///Status trait coming from roundstart quirks (that don't exist yet). Unremovable by REMOVE_TRAIT
-#define TRAIT_SOURCE_QUIRK "t_s_quirk"
 ///Status trait coming from being assigned as [acting] squad leader.
 #define TRAIT_SOURCE_SQUAD_LEADER "t_s_squad_leader"
 ///Status trait coming from their job

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -142,9 +142,6 @@
 /// Example trait
 // #define TRAIT_X "t_x"
 
-/// cannot be removed without admin intervention
-#define ROUNDSTART_TRAIT "roundstart"
-
 //-- mob traits --
 /// Apply this to make a mob not dense, and remove it when you want it to no longer make them undense, other sorces of undesity will still apply. Always define a unique source when adding a new instance of this!
 #define TRAIT_UNDENSE "undense"

--- a/code/modules/character_traits/biology_traits.dm
+++ b/code/modules/character_traits/biology_traits.dm
@@ -58,13 +58,13 @@
 		to_chat(target, SPAN_WARNING("Your species is too sophisticated for you be able to recieve the lisping trait."))
 		return
 
-	ADD_TRAIT(target, TRAIT_LISPING, TRAIT_SOURCE_QUIRK)
+	ADD_TRAIT(target, TRAIT_LISPING, ROUNDSTART_TRAIT)
 	target.speech_problem_flag = TRUE
 
 	..()
 
 /datum/character_trait/biology/lisp/unapply_trait(mob/living/carbon/human/target)
-	REMOVE_TRAIT(target, TRAIT_LISPING, TRAIT_SOURCE_QUIRK)
+	REMOVE_TRAIT(target, TRAIT_LISPING, ROUNDSTART_TRAIT)
 	target.speech_problem_flag = FALSE
 	..()
 
@@ -127,9 +127,9 @@
 		to_chat(target, SPAN_WARNING("Only riflemen can have the Hardcore trait."))
 		return
 
-	ADD_TRAIT(target, TRAIT_HARDCORE, TRAIT_SOURCE_QUIRK)
+	ADD_TRAIT(target, TRAIT_HARDCORE, ROUNDSTART_TRAIT)
 	..()
 
 /datum/character_trait/biology/hardcore/unapply_trait(mob/living/carbon/human/target)
-	REMOVE_TRAIT(target, TRAIT_HARDCORE, TRAIT_SOURCE_QUIRK)
+	REMOVE_TRAIT(target, TRAIT_HARDCORE, ROUNDSTART_TRAIT)
 	..()


### PR DESCRIPTION

# About the pull request

AKA "Why are my leadership action buttons missing?"

I was a bit too confident in #4869 copying over /tg/ backend and didn't question that Segrain's awesome CM-brewed traitbound elements bits were missing from their code. Oops.

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Restores functionality for eg. silenced guns and leadership action buttons

# Testing Photographs and Procedure
Tested the actions are back


# Changelog
:cl:
fix: Fixed an issue in traits backend update causing among others leadership action buttons to be missing.
/:cl:
