### PR TITLE
Close-Doors-When-Lockdown-Dropship

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -787,7 +787,7 @@ GLOBAL_LIST_INIT(airlock_wire_descriptions, list(
 /obj/structure/machinery/door/airlock/proc/lock(forced = FALSE)
 	if((operating && !forced) || locked)
 		return
-
+	close()
 	playsound(loc, 'sound/machines/hydraulics_1.ogg', 25)
 	locked = TRUE
 	visible_message(SPAN_NOTICE("\The [src] airlock emits a loud thunk, then a click."))


### PR DESCRIPTION
Closes Doors when you click "lockdown" on dropships before it locks the doors.
# About the pull request

it closes the doors when you click lockdown before it locks the doors in the dropship on the airlock door level. 
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
when you lockdown a dropship, you intend for the doors to be closed then locked. 
Before this change, doors may be locked open. 
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>
I opened a door, then went to control panel and clicked "lockdown" and saw it closed the doors immediately, and locked them where as before the change, doors may remain open. 

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
qol: made doors close when you locked down dropships.
/:cl:
