### PR TITLE
Echo pad droppod fix

### DIFF
--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -327,7 +327,7 @@ var/datum/controller/supply/supply_controller = new()
 		M.count_niche_stat(STATISTICS_NICHE_CRATES)
 
 	playsound(C.loc,'sound/effects/bamf.ogg', 50, 1)  //Ehh
-	var/obj/structure/droppod/supply/pod = new()
+	var/obj/structure/droppod/supply/pod = new(null, C)
 	C.forceMove(pod)
 	pod.launch(T)
 	visible_message("[icon2html(src, viewers(src))] [SPAN_BOLDNOTICE("'[C.name]' supply drop launched! Another launch will be available in five minutes.")]")


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

I manage to screw something up with every PR it seems - see #4868 

Updated droppod constructor arguments in droppod cosmetic PR (to make it so you have the crate falling down sky) but only did so for Overwatch pods, not Echo's.

This causes a deleted droppod to be launched anyway and remain on the ground. AWKWARD.


# Changelog
:cl:
fix: Fixed ghost droppods appearing when launching crates by Echo pad.
/:cl:
