### PR TITLE
Fix missing delay on climbing objects

### DIFF
--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -145,6 +145,8 @@
 	user.forceMove(TT)
 	for(var/atom/movable/thing as anything in grabbed_things) // grabbed things aren't moved to the tile immediately to: make the animation better, preserve the grab
 		thing.forceMove(TT)
+	if(user.client) // Reset movement cooldown so we don't instantly move a second time after climbing
+		user.client.next_movement = max(user.client.next_movement, world.time + user.client.move_delay)
 
 /obj/structure/proc/structure_shaken()
 


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

When you climb a structure such as railings or platform, the movement delay is not currently applied. 
This means that while you're waiting for the climbing windup, the movement comes off cooldown, you climb, and move immediately a second time walking. 

More than concerns about balance or consistency, i'm opening this PR because it's janky: it just *feels* really weird especially given that for a movement that is some distance away, BYOND will NOT apply the movement glide effrect and instead "teleport" you. This would be fine for Req Railings you jump over, but eg. lifeboat pumps platforms you constantly walk on/off simply by moving around.


# Changelog
:cl:
fix: Climbing rails and platforms now respects movement delay, preventing from "teleporting" 2 tiles at once.
/:cl:
