### PR TITLE
Kills var/burrow replaces with trait

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -535,7 +535,7 @@
 	if(!user.hive.living_xeno_queen)
 		to_chat(user, SPAN_WARNING("Without a queen your psychic link is broken!"))
 		return FALSE
-	if(user.burrow || user.is_mob_incapacitated() || user.buckled)
+	if(HAS_TRAIT(user, TRAIT_ABILITY_BURROWED) || user.is_mob_incapacitated() || user.buckled)
 		return FALSE
 	user.hive.mark_ui.update_all_data()
 	user.hive.mark_ui.open_mark_menu(user)
@@ -583,7 +583,7 @@
 	if(!user.hive.living_xeno_queen)
 		to_chat(user, SPAN_WARNING("Your hive doesn't have a living queen!"))
 		return FALSE
-	if(user.burrow || user.is_mob_incapacitated() || user.buckled)
+	if(HAS_TRAIT(user, TRAIT_ABILITY_BURROWED) || user.is_mob_incapacitated() || user.buckled)
 		return FALSE
 	user.overwatch(user.hive.living_xeno_queen)
 

--- a/code/_onclick/xeno.dm
+++ b/code/_onclick/xeno.dm
@@ -3,7 +3,7 @@
 */
 
 /mob/living/carbon/xenomorph/UnarmedAttack(atom/target, proximity, click_parameters, tile_attack = FALSE, ignores_resin = FALSE)
-	if(lying || burrow) //No attacks while laying down
+	if(lying || HAS_TRAIT(src, TRAIT_ABILITY_BURROWED)) //No attacks while laying down
 		return FALSE
 	var/mob/alt
 

--- a/code/modules/mob/living/carbon/xenomorph/XenoAttacks.dm
+++ b/code/modules/mob/living/carbon/xenomorph/XenoAttacks.dm
@@ -90,7 +90,7 @@
 //Hot hot Aliens on Aliens action.
 //Actually just used for eating people.
 /mob/living/carbon/xenomorph/attack_alien(mob/living/carbon/xenomorph/M)
-	if (M.fortify || M.burrow)
+	if (M.fortify || HAS_TRAIT(M, TRAIT_ABILITY_BURROWED))
 		return XENO_NO_DELAY_ACTION
 
 	if(HAS_TRAIT(src, TRAIT_ABILITY_BURROWED))

--- a/code/modules/mob/living/carbon/xenomorph/XenoOverwatch.dm
+++ b/code/modules/mob/living/carbon/xenomorph/XenoOverwatch.dm
@@ -12,7 +12,7 @@
 	var/mob/living/carbon/xenomorph/X = owner
 	if(!istype(X))
 		return FALSE
-	if(X.is_mob_incapacitated() || X.buckled || X.burrow)
+	if(X.is_mob_incapacitated() || X.buckled || HAS_TRAIT(X, TRAIT_ABILITY_BURROWED))
 		return FALSE
 	else
 		return TRUE

--- a/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
@@ -656,7 +656,7 @@
 
 
 /mob/living/carbon/xenomorph/burn_skin(burn_amount)
-	if(burrow)
+	if(HAS_TRAIT(src, TRAIT_ABILITY_BURROWED))
 		return FALSE
 
 	if(caste.fire_immunity & FIRE_IMMUNITY_NO_DAMAGE)

--- a/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
@@ -274,7 +274,6 @@
 	var/tunnel = FALSE
 	/// for check on lurker invisibility
 	var/stealth = FALSE
-	var/burrow = FALSE
 	var/fortify = FALSE
 	var/crest_defense = FALSE
 	/// 0/FALSE - upright, 1/TRUE - all fours
@@ -541,7 +540,7 @@
 /mob/living/carbon/xenomorph/proc/fire_immune(mob/living/L)
 	SIGNAL_HANDLER
 
-	if(L.fire_reagent?.fire_penetrating && !burrow)
+	if(L.fire_reagent?.fire_penetrating && !HAS_TRAIT(src, TRAIT_ABILITY_BURROWED))
 		return
 
 	return COMPONENT_CANCEL_IGNITION
@@ -554,7 +553,7 @@
 
 	. = COMPONENT_NO_BURN
 	// Burrowed xenos also cannot be ignited
-	if((caste.fire_immunity & FIRE_IMMUNITY_NO_IGNITE) || burrow)
+	if((caste.fire_immunity & FIRE_IMMUNITY_NO_IGNITE) || HAS_TRAIT(src, TRAIT_ABILITY_BURROWED))
 		. |= COMPONENT_NO_IGNITE
 	if(caste.fire_immunity & FIRE_IMMUNITY_XENO_FRENZY)
 		. |= COMPONENT_XENO_FRENZY
@@ -746,7 +745,7 @@
 	if(SEND_SIGNAL(AM, COMSIG_MOVABLE_XENO_START_PULLING, src) & COMPONENT_ALLOW_PULL)
 		return do_pull(AM, lunge, no_msg)
 
-	if(burrow)
+	if(HAS_TRAIT(src,TRAIT_ABILITY_BURROWED))
 		return
 	if(!isliving(AM))
 		return FALSE

--- a/code/modules/mob/living/carbon/xenomorph/abilities/ability_helper_procs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/ability_helper_procs.dm
@@ -11,7 +11,7 @@
 			to_chat(src, SPAN_WARNING("[O] is too far away."))
 			return
 
-	if(!isturf(loc) || burrow)
+	if(!isturf(loc) || HAS_TRAIT(src, TRAIT_ABILITY_BURROWED))
 		to_chat(src, SPAN_WARNING("You can't melt [O] from here!"))
 		return
 

--- a/code/modules/mob/living/carbon/xenomorph/abilities/burrower/burrower_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/burrower/burrower_abilities.dm
@@ -11,7 +11,7 @@
 
 /datum/action/xeno_action/activable/burrow/use_ability(atom/A)
 	var/mob/living/carbon/xenomorph/X = owner
-	if(X.burrow)
+	if(HAS_TRAIT(X, TRAIT_ABILITY_BURROWED))
 		X.tunnel(get_turf(A))
 	else
 		X.burrow()

--- a/code/modules/mob/living/carbon/xenomorph/abilities/burrower/burrower_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/burrower/burrower_powers.dm
@@ -35,7 +35,6 @@
 		return
 	// TODO Make immune to all damage here.
 	to_chat(src, SPAN_XENOWARNING("You burrow yourself into the ground."))
-	burrow = TRUE
 	frozen = TRUE
 	invisibility = 101
 	anchored = TRUE
@@ -56,20 +55,19 @@
 	process_burrow()
 
 /mob/living/carbon/xenomorph/proc/process_burrow()
-	if(!burrow)
+	if(!HAS_TRAIT(src, TRAIT_ABILITY_BURROWED))
 		return
 	if(world.time > burrow_timer && !tunnel)
 		burrow_off()
 	if(observed_xeno)
 		overwatch(observed_xeno, TRUE)
-	if(burrow)
+	if(HAS_TRAIT(src, TRAIT_ABILITY_BURROWED))
 		addtimer(CALLBACK(src, PROC_REF(process_burrow)), 1 SECONDS)
 
 /mob/living/carbon/xenomorph/proc/burrow_off()
 	if(caste_type && GLOB.xeno_datum_list[caste_type])
 		caste = GLOB.xeno_datum_list[caste_type]
 	to_chat(src, SPAN_NOTICE("You resurface."))
-	burrow = FALSE
 	if(caste.fire_immunity == FIRE_IMMUNITY_NONE)
 		UnregisterSignal(src, list(
 				COMSIG_LIVING_PREIGNITION,
@@ -93,7 +91,7 @@
 
 /mob/living/carbon/xenomorph/proc/do_burrow_cooldown()
 	used_burrow = FALSE
-	if(burrow)
+	if(HAS_TRAIT(src, TRAIT_ABILITY_BURROWED))
 		to_chat(src, SPAN_NOTICE("You can now surface."))
 	for(var/X in actions)
 		var/datum/action/act = X
@@ -104,7 +102,7 @@
 	if(!check_state())
 		return
 
-	if(!burrow)
+	if(!HAS_TRAIT(src, TRAIT_ABILITY_BURROWED))
 		to_chat(src, SPAN_NOTICE("You must be burrowed to do this."))
 		return
 
@@ -201,7 +199,7 @@
 	return !xeno.used_tremor
 
 /mob/living/carbon/xenomorph/proc/tremor() //More support focused version of crusher earthquakes.
-	if(burrow || is_ventcrawling)
+	if(HAS_TRAIT(src, TRAIT_ABILITY_BURROWED) || is_ventcrawling)
 		to_chat(src, SPAN_XENOWARNING("You must be above ground to do this."))
 		return
 

--- a/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
@@ -9,7 +9,7 @@
 		return
 	if(!xeno.check_state())
 		return
-	if(xeno.burrow)
+	if(HAS_TRAIT(xeno, TRAIT_ABILITY_BURROWED))
 		return
 
 	var/turf/turf = xeno.loc
@@ -89,7 +89,7 @@
 		to_chat(src, SPAN_WARNING("You cannot rest while fortified!"))
 		return
 
-	if(burrow)
+	if(HAS_TRAIT(src, TRAIT_ABILITY_BURROWED))
 		to_chat(src, SPAN_WARNING("You cannot rest while burrowed!"))
 		return
 
@@ -529,7 +529,7 @@
 
 	if (istype(X, /mob/living/carbon/xenomorph/burrower))
 		var/mob/living/carbon/xenomorph/burrower/B = X
-		if (B.burrow)
+		if (HAS_TRAIT(B, TRAIT_ABILITY_BURROWED))
 			return
 
 	var/turf/T = get_turf(X)
@@ -908,7 +908,7 @@
 /datum/action/xeno_action/activable/tail_stab/use_ability(atom/targetted_atom)
 	var/mob/living/carbon/xenomorph/stabbing_xeno = owner
 
-	if(stabbing_xeno.burrow || stabbing_xeno.is_ventcrawling)
+	if(HAS_TRAIT(stabbing_xeno, TRAIT_ABILITY_BURROWED) || stabbing_xeno.is_ventcrawling)
 		to_chat(stabbing_xeno, SPAN_XENOWARNING("You must be above ground to do this."))
 		return
 

--- a/code/modules/mob/living/carbon/xenomorph/abilities/runner/runner_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/runner/runner_powers.dm
@@ -58,7 +58,7 @@
 			to_chat(src, SPAN_WARNING("[O] is too far away."))
 			return
 
-	if(!isturf(loc) || burrow)
+	if(!isturf(loc) || HAS_TRAIT(src, TRAIT_ABILITY_BURROWED))
 		to_chat(src, SPAN_WARNING("You can't melt [O] from here!"))
 		return
 

--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -9,7 +9,7 @@
 
 
 /mob/living/carbon/human/attack_alien(mob/living/carbon/xenomorph/M, dam_bonus)
-	if(M.fortify || M.burrow)
+	if(M.fortify || HAS_TRAIT(M, TRAIT_ABILITY_BURROWED))
 		return XENO_NO_DELAY_ACTION
 
 	var/intent = M.a_intent
@@ -220,7 +220,7 @@
 
 //Every other type of nonhuman mob
 /mob/living/attack_alien(mob/living/carbon/xenomorph/M)
-	if(M.fortify || M.burrow)
+	if(M.fortify || HAS_TRAIT(M, TRAIT_ABILITY_BURROWED))
 		return XENO_NO_DELAY_ACTION
 
 	switch(M.a_intent)

--- a/code/modules/mob/living/carbon/xenomorph/castes/Burrower.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Burrower.dm
@@ -86,29 +86,29 @@
 
 /mob/living/carbon/xenomorph/burrower/update_canmove()
 	. = ..()
-	if(burrow)
+	if(HAS_TRAIT(src, TRAIT_ABILITY_BURROWED))
 		density = FALSE
 		canmove = FALSE
 		return canmove
 
 /mob/living/carbon/xenomorph/burrower/ex_act(severity)
-	if(burrow)
+	if(HAS_TRAIT(src, TRAIT_ABILITY_BURROWED))
 		return
 	..()
 
 /mob/living/carbon/xenomorph/burrower/attack_hand()
-	if(burrow)
+	if(HAS_TRAIT(src, TRAIT_ABILITY_BURROWED))
 		return
 	..()
 
 /mob/living/carbon/xenomorph/burrower/attackby()
-	if(burrow)
+	if(HAS_TRAIT(src, TRAIT_ABILITY_BURROWED))
 		return
 	..()
 
 /mob/living/carbon/xenomorph/burrower/get_projectile_hit_chance()
 	. = ..()
-	if(burrow)
+	if(HAS_TRAIT(src, TRAIT_ABILITY_BURROWED))
 		return 0
 
 /datum/behavior_delegate/burrower_base
@@ -118,6 +118,6 @@
 	if(bound_xeno.stat == DEAD)
 		return
 
-	if(bound_xeno.burrow)
+	if(HAS_TRAIT(bound_xeno, TRAIT_ABILITY_BURROWED))
 		bound_xeno.icon_state = "[bound_xeno.mutation_icon_state] Burrower Burrowed"
 		return TRUE

--- a/code/modules/mob/living/living_verbs.dm
+++ b/code/modules/mob/living/living_verbs.dm
@@ -13,7 +13,7 @@
 
 	if(isxeno(src))
 		var/mob/living/carbon/xenomorph/xeno = src
-		if(xeno.burrow)
+		if(HAS_TRAIT(xeno, TRAIT_ABILITY_BURROWED))
 			to_chat(src, SPAN_WARNING("You can't resist in your current state."))
 			return
 

--- a/code/modules/vehicles/multitile/multitile_bump.dm
+++ b/code/modules/vehicles/multitile/multitile_bump.dm
@@ -740,7 +740,7 @@
 
 //BURROWER
 /mob/living/carbon/xenomorph/burrower/handle_vehicle_bump(obj/vehicle/multitile/V)
-	if(burrow)
+	if(HAS_TRAIT(src, TRAIT_ABILITY_BURROWED))
 		return TRUE
 	else
 		return . = ..()


### PR DESCRIPTION
# About the pull request

Replaces var/burrow with `TRAIT_ABILITY_BURROWED`

# Explain why it's good for the game


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
code: Replaces burrow var from Xenomorph with burrowed trait
/:cl:
