### PR TITLE
Boiler: replace single letter vars and removes unused code, also fixes 5th hotkey.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/boiler/boiler_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/boiler/boiler_abilities.dm
@@ -86,30 +86,6 @@
 	/// Duration for the cooldown of abilities affected by acid shroud
 	var/cooldown_duration = 30 SECONDS
 
-/datum/action/xeno_action/onclick/dump_acid
-	name = "Dump Acid"
-	ability_name = "dump acid"
-	action_icon_state = "dump_acid"
-	plasma_cost = 10
-	macro_path = /datum/action/xeno_action/verb/verb_dump_acid
-	action_type = XENO_ACTION_ACTIVATE
-	ability_primacy = XENO_PRIMARY_ACTION_4
-	xeno_cooldown = 34 SECONDS
-
-	var/buffs_duration = 6 SECONDS
-	var/cooldown_duration = 30 SECONDS
-
-	var/speed_buff_amount = 0.5
-	var/movespeed_buff_applied = FALSE
-
-	/// List of types of actions to place on 20-second CD,if you ever want to subtype this for a strain or whatever, just change this var on the subtype
-	var/action_types_to_cd = list(
-		/datum/action/xeno_action/activable/xeno_spit/bombard,
-		/datum/action/xeno_action/onclick/dump_acid,
-		/datum/action/xeno_action/onclick/toggle_long_range/boiler,
-		/datum/action/xeno_action/activable/spray_acid/boiler,
-	)
-
 //////////////////////////// Trapper boiler abilities
 
 /datum/action/xeno_action/activable/boiler_trap

--- a/code/modules/mob/living/carbon/xenomorph/abilities/boiler/boiler_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/boiler/boiler_abilities.dm
@@ -68,7 +68,7 @@
 	ability_name = "Acid Shroud"
 	action_icon_state = "acid_shroud"
 	action_type = XENO_ACTION_ACTIVATE
-	ability_primacy = XENO_PRIMARY_ACTION_4
+	ability_primacy = XENO_PRIMARY_ACTION_5
 	plasma_cost = 10
 	macro_path = /datum/action/xeno_action/verb/verb_acid_shroud
 	/// Allows the sound to play. Flipped to false when sound is triggered and true after a timer. This prevents soundspam

--- a/code/modules/mob/living/carbon/xenomorph/abilities/boiler/boiler_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/boiler/boiler_powers.dm
@@ -1,13 +1,13 @@
-/datum/action/xeno_action/activable/acid_lance/use_ability(atom/A)
-	var/mob/living/carbon/xenomorph/X = owner
+/datum/action/xeno_action/activable/acid_lance/use_ability(atom/affected_atom)
+	var/mob/living/carbon/xenomorph/xeno = owner
 
-	if (!istype(X) || !X.check_state())
+	if (!istype(xeno) || !xeno.check_state())
 		return
 
 	if (!activated_once && !action_cooldown_check())
 		return
 
-	if(!A || A.layer >= FLY_LAYER || !isturf(X.loc))
+	if(!affected_atom || affected_atom.layer >= FLY_LAYER || !isturf(xeno.loc))
 		return
 
 	if (!activated_once)
@@ -16,8 +16,8 @@
 		if (!check_and_use_plasma_owner())
 			return
 
-		X.create_empower()
-		X.visible_message(SPAN_XENODANGER("[X] starts to gather its acid for a massive blast!"), SPAN_XENODANGER("You start to gather your acid for a massive blast!"))
+		xeno.create_empower()
+		xeno.visible_message(SPAN_XENODANGER("[xeno] starts to gather its acid for a massive blast!"), SPAN_XENODANGER("You start to gather your acid for a massive blast!"))
 		activated_once = TRUE
 		stack()
 		addtimer(CALLBACK(src, PROC_REF(timeout)), max_stacks*stack_time + time_after_max_before_end)
@@ -29,18 +29,18 @@
 		var/range = base_range + stacks*range_per_stack
 		var/damage = base_damage + stacks*damage_per_stack
 		var/turfs_visited = 0
-		for (var/turf/T in getline2(get_turf(X), A))
-			if(T.density || T.opacity)
+		for (var/turf/turf in getline2(get_turf(xeno), affected_atom))
+			if(turf.density || turf.opacity)
 				break
 
 			var/should_stop = FALSE
-			for(var/obj/structure/S in T)
-				if(istype(S, /obj/structure/window/framed))
-					var/obj/structure/window/framed/W = S
-					if(!W.unslashable)
-						W.deconstruct(disassembled = FALSE)
+			for(var/obj/structure/structure in turf)
+				if(istype(structure, /obj/structure/window/framed))
+					var/obj/structure/window/framed/window_frame = structure
+					if(!window_frame.unslashable)
+						window_frame.deconstruct(disassembled = FALSE)
 
-				if(S.opacity)
+				if(structure.opacity)
 					should_stop = TRUE
 					break
 
@@ -52,15 +52,15 @@
 
 			turfs_visited++
 
-			new /obj/effect/xenomorph/acid_damage_delay(T, damage, 7, FALSE, "You are blasted with a stream of high-velocity acid!", X)
+			new /obj/effect/xenomorph/acid_damage_delay(turf, damage, 7, FALSE, "You are blasted with a stream of high-velocity acid!", xeno)
 
-		X.visible_message(SPAN_XENODANGER("[X] fires a massive blast of acid at [A]!"), SPAN_XENODANGER("You fire a massive blast of acid at [A]!"))
+		xeno.visible_message(SPAN_XENODANGER("[xeno] fires a massive blast of acid at [affected_atom]!"), SPAN_XENODANGER("You fire a massive blast of acid at [affected_atom]!"))
 		remove_stack_effects("You feel your speed return to normal!")
 		return TRUE
 
 /datum/action/xeno_action/activable/acid_lance/proc/stack()
-	var/mob/living/carbon/xenomorph/X = owner
-	if (!istype(X))
+	var/mob/living/carbon/xenomorph/xeno = owner
+	if (!istype(xeno))
 		return
 
 	if (!activated_once)
@@ -68,31 +68,31 @@
 
 	stacks = min(max_stacks, stacks + 1)
 	if (stacks != max_stacks)
-		X.speed_modifier += movespeed_per_stack
+		xeno.speed_modifier += movespeed_per_stack
 		movespeed_nerf_applied += movespeed_per_stack
-		X.recalculate_speed()
+		xeno.recalculate_speed()
 		addtimer(CALLBACK(src, PROC_REF(stack)), stack_time)
 		return
 	else
-		to_chat(X, SPAN_XENOHIGHDANGER("You have charged your acid lance to maximum!"))
+		to_chat(xeno, SPAN_XENOHIGHDANGER("You have charged your acid lance to maximum!"))
 		return
 
 /datum/action/xeno_action/activable/acid_lance/proc/remove_stack_effects(message = null)
-	var/mob/living/carbon/xenomorph/X = owner
+	var/mob/living/carbon/xenomorph/xeno = owner
 
-	if (!istype(X))
+	if (!istype(xeno))
 		return
 
 	if (stacks <= 0)
 		return
 
 	if (message)
-		to_chat(X, SPAN_XENODANGER(message))
+		to_chat(xeno, SPAN_XENODANGER(message))
 
 	stacks = 0
-	X.speed_modifier -= movespeed_nerf_applied
+	xeno.speed_modifier -= movespeed_nerf_applied
 	movespeed_nerf_applied = 0
-	X.recalculate_speed()
+	xeno.recalculate_speed()
 
 /datum/action/xeno_action/activable/acid_lance/proc/timeout()
 	if (activated_once)
@@ -103,7 +103,7 @@
 /datum/action/xeno_action/activable/acid_lance/action_cooldown_check()
 	return (activated_once || ..())
 
-/datum/action/xeno_action/activable/xeno_spit/bombard/use_ability(atom/A)
+/datum/action/xeno_action/activable/xeno_spit/bombard/use_ability(atom/affected_atom)
 	. = ..()
 	var/mob/living/carbon/xenomorph/xeno = owner
 	if(!action_cooldown_check()) // activate c/d only if we already spit
@@ -114,7 +114,7 @@
 
 			xeno_action.apply_cooldown_override(cooldown_duration)
 
-/datum/action/xeno_action/onclick/acid_shroud/use_ability(atom/atom)
+/datum/action/xeno_action/onclick/acid_shroud/use_ability(atom/affected_atom)
 	var/datum/effect_system/smoke_spread/xeno_acid/spicy_gas
 	var/mob/living/carbon/xenomorph/xeno = owner
 	if (!isxeno(owner))
@@ -125,14 +125,18 @@
 
 	if (!xeno.check_state())
 		return
+
 	if(sound_play)
 		playsound(xeno,"acid_strike", 35, 1)
 		sound_play = FALSE
 		addtimer(VARSET_CALLBACK(src, sound_play, TRUE), 2 SECONDS)
+
 	if (!do_after(xeno, xeno.ammo.spit_windup/6.5, INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_HOSTILE, numticks = 2)) /// 0.7 seconds
 		to_chat(xeno, SPAN_XENODANGER("You decide to cancel your gas shroud."))
 		return
+
 	playsound(xeno,"acid_sizzle", 50, 1)
+
 	if(xeno.ammo == GLOB.ammo_list[/datum/ammo/xeno/boiler_gas/acid])
 		spicy_gas = new /datum/effect_system/smoke_spread/xeno_acid
 	else if(xeno.ammo == GLOB.ammo_list[/datum/ammo/xeno/boiler_gas])
@@ -143,6 +147,7 @@
 	spicy_gas.set_up(1, 0, get_turf(xeno), null, 6, new_cause_data = cause_data)
 	spicy_gas.start()
 	to_chat(xeno, SPAN_XENOHIGHDANGER("You dump your acid through your pores, creating a shroud of gas!"))
+
 	for (var/action_type in action_types_to_cd)
 		var/datum/action/xeno_action/xeno_action = get_xeno_action_by_type(xeno, action_type)
 		if (!istype(xeno_action))
@@ -154,12 +159,14 @@
 	return ..()
 
 /datum/action/xeno_action/onclick/dump_acid/proc/remove_speed_buff()
-	if (movespeed_buff_applied && isxeno(owner))
-		var/mob/living/carbon/xenomorph/xeno = owner
-		xeno.speed_modifier += speed_buff_amount
-		xeno.recalculate_speed()
-		movespeed_buff_applied = FALSE
-		UnregisterSignal(owner, COMSIG_MOB_MOVE_OR_LOOK)
+	if (!movespeed_buff_applied && !isxeno(owner))
+		return
+
+	var/mob/living/carbon/xenomorph/xeno = owner
+	xeno.speed_modifier += speed_buff_amount
+	xeno.recalculate_speed()
+	movespeed_buff_applied = FALSE
+	UnregisterSignal(owner, COMSIG_MOB_MOVE_OR_LOOK)
 
 /datum/action/xeno_action/onclick/dump_acid/proc/handle_mob_move_or_look(mob/living/carbon/xenomorph/mover, actually_moving, direction, specific_direction)
 	SIGNAL_HANDLER
@@ -181,29 +188,29 @@
 
 /////////////////////////////// Trapper boiler powers
 
-/datum/action/xeno_action/activable/boiler_trap/use_ability(atom/A)
-	var/mob/living/carbon/xenomorph/X = owner
+/datum/action/xeno_action/activable/boiler_trap/use_ability(atom/affected_atom)
+	var/mob/living/carbon/xenomorph/xeno = owner
 
-	if (!istype(X))
+	if (!istype(xeno))
 		return
 
 	if (!action_cooldown_check())
 		return
 
-	if (!X.check_state())
+	if (!xeno.check_state())
 		return
 
-	if (!can_see(X, A, TRAPPER_VIEWRANGE))
-		to_chat(X, SPAN_XENODANGER("You cannot see that location!"))
+	if (!can_see(xeno, affected_atom, TRAPPER_VIEWRANGE))
+		to_chat(xeno, SPAN_XENODANGER("You cannot see that location!"))
 		return
 
 	if (!check_and_use_plasma_owner())
 		return
 
 	// 5-long line of turfs orthogonal to the line between us and our target as precisely as we can figure it
-	var/dir_between = Get_Compass_Dir(X, A)
+	var/dir_between = Get_Compass_Dir(xeno, affected_atom)
 	var/list/target_turfs = list()
-	var/target_turf = get_turf(A)
+	var/target_turf = get_turf(affected_atom)
 	var/left_turf = get_step(target_turf, turn(dir_between, -90))
 	var/right_turf = get_step(target_turf, turn(dir_between, 90))
 	target_turfs += target_turf
@@ -212,70 +219,70 @@
 	target_turfs += get_step(left_turf, turn(dir_between, -90))
 	target_turfs += get_step(right_turf, turn(dir_between, 90))
 
-	for (var/turf/T in target_turfs)
-		if (!istype(T) || T.density)
+	for (var/turf/turf in target_turfs)
+		if (!istype(turf) || turf.density)
 			continue
 
 		var/trap_found = FALSE
-		for (var/obj/effect/alien/resin/boilertrap/BT in T)
+		for (var/obj/effect/alien/resin/boilertrap/boiler_trap in turf)
 			trap_found = TRUE
 			break
 
 		if (trap_found)
 			continue
 
-		var/obj/effect/alien/resin/boilertrap/BT
+		var/obj/effect/alien/resin/boilertrap/boiler_trap
 		if(empowered)
-			BT = new /obj/effect/alien/resin/boilertrap/empowered(T, X)
+			boiler_trap = new /obj/effect/alien/resin/boilertrap/empowered(turf, xeno)
 		else
-			BT = new /obj/effect/alien/resin/boilertrap/(T, X)
-		QDEL_IN(BT, trap_ttl)
+			boiler_trap = new /obj/effect/alien/resin/boilertrap(turf, xeno)
+		QDEL_IN(boiler_trap, trap_ttl)
 
 	if(empowered)
 		empowered = FALSE
 		empowering_charge_counter = 0
 		button.overlays -= "+empowered"
-		var/datum/action/xeno_action/activable/acid_mine/mine = get_xeno_action_by_type(X, /datum/action/xeno_action/activable/acid_mine)
+		var/datum/action/xeno_action/activable/acid_mine/mine = get_xeno_action_by_type(xeno, /datum/action/xeno_action/activable/acid_mine)
 		if(!mine.empowered)
 			mine.empowered = TRUE
 			mine.button.overlays += "+empowered"
-			to_chat(X, SPAN_XENODANGER("You tap in your reserves to prepare a stronger [mine.name]!"))
+			to_chat(xeno, SPAN_XENODANGER("You tap in your reserves to prepare a stronger [mine.name]!"))
 
 	apply_cooldown()
 	return ..()
 
-/datum/action/xeno_action/activable/acid_mine/use_ability(atom/A)
-	var/mob/living/carbon/xenomorph/X = owner
+/datum/action/xeno_action/activable/acid_mine/use_ability(atom/affected_atom)
+	var/mob/living/carbon/xenomorph/xeno = owner
 
-	if (!istype(X))
+	if (!istype(xeno))
 		return
 
-	if (!X.check_state())
+	if (!xeno.check_state())
 		return
 
 	if (!action_cooldown_check())
 		return
 
-	if(!A || A.layer >= FLY_LAYER || !isturf(X.loc))
+	if(!affected_atom || affected_atom.layer >= FLY_LAYER || !isturf(xeno.loc))
 		return
 
-	if(!check_clear_path_to_target(X, A, TRUE, TRAPPER_VIEWRANGE))
-		to_chat(X, SPAN_XENOWARNING("Something is in the way!"))
+	if(!check_clear_path_to_target(xeno, affected_atom, TRUE, TRAPPER_VIEWRANGE))
+		to_chat(xeno, SPAN_XENOWARNING("Something is in the way!"))
 		return
 
 	if (!check_and_use_plasma_owner())
 		return
 
-	var/turf/T = get_turf(A)
+	var/turf/turf = get_turf(affected_atom)
 	var/acid_bolt_message = "a bolt of acid"
 	if(empowered)
 		acid_bolt_message = "a powerful bolt of acid"
 
-	X.visible_message(SPAN_XENODANGER("[X] fires " + acid_bolt_message + " at [A]!"), SPAN_XENODANGER("You fire " + acid_bolt_message + " at [A]!"))
-	new /obj/effect/xenomorph/acid_damage_delay/boiler_landmine(T, damage, delay, empowered, "You are blasted with " + acid_bolt_message + "!", X, )
+	xeno.visible_message(SPAN_XENODANGER("[xeno] fires " + acid_bolt_message + " at [affected_atom]!"), SPAN_XENODANGER("You fire " + acid_bolt_message + " at [affected_atom]!"))
+	new /obj/effect/xenomorph/acid_damage_delay/boiler_landmine(turf, damage, delay, empowered, "You are blasted with " + acid_bolt_message + "!", xeno)
 
-	for (var/turf/targetTurf in orange(1, T))
-		new /obj/effect/xenomorph/acid_damage_delay/boiler_landmine(targetTurf, damage, delay, empowered, "You are blasted with a " + acid_bolt_message + "!", X)
+	for (var/turf/target_turf in orange(1, turf))
+		new /obj/effect/xenomorph/acid_damage_delay/boiler_landmine(target_turf, damage, delay, empowered, "You are blasted with a " + acid_bolt_message + "!", xeno)
 
 	if(empowered)
 		empowered = FALSE
@@ -284,7 +291,7 @@
 	apply_cooldown()
 	return ..()
 
-/datum/action/xeno_action/activable/acid_shotgun/use_ability(atom/target)
+/datum/action/xeno_action/activable/acid_shotgun/use_ability(atom/affected_atom)
 	var/mob/living/carbon/xenomorph/xeno = owner
 	if (!istype(xeno))
 		return
@@ -292,12 +299,12 @@
 	if (!action_cooldown_check())
 		return
 
-	if(!target || target.layer >= FLY_LAYER || !isturf(xeno.loc) || !xeno.check_state())
+	if(!affected_atom || affected_atom.layer >= FLY_LAYER || !isturf(xeno.loc) || !xeno.check_state())
 		return
 
-	xeno.visible_message(SPAN_XENOWARNING("The [xeno] fires a blast of acid at [target]!"), SPAN_XENOWARNING("You fire a blast of acid at [target]!"))
+	xeno.visible_message(SPAN_XENOWARNING("The [xeno] fires a blast of acid at [affected_atom]!"), SPAN_XENOWARNING("You fire a blast of acid at [affected_atom]!"))
 
-	var/turf/target_turf = locate(target.x, target.y, target.z)
+	var/turf/target_turf = locate(affected_atom.x, affected_atom.y, affected_atom.z)
 	var/obj/projectile/proj = new(xeno.loc, create_cause_data("acid shotgun", xeno))
 	var/datum/ammo/ammoDatum = new ammo_type()
 
@@ -335,7 +342,7 @@
 	bonus_projectiles_amount = 0
 	max_range = 4
 
-/datum/action/xeno_action/activable/tail_stab/boiler/use_ability(atom/A)
+/datum/action/xeno_action/activable/tail_stab/boiler/use_ability(atom/affected_atom)
 	var/mob/living/carbon/xenomorph/stabbing_xeno = owner
 	var/target = ..()
 	if(iscarbon(target))

--- a/code/modules/mob/living/carbon/xenomorph/abilities/boiler/boiler_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/boiler/boiler_powers.dm
@@ -143,6 +143,7 @@
 		spicy_gas = new /datum/effect_system/smoke_spread/xeno_weaken
 	else
 		CRASH("Globber has unknown ammo [xeno.ammo]! Oh no!")
+
 	var/datum/cause_data/cause_data = create_cause_data("acid shroud gas", owner)
 	spicy_gas.set_up(1, 0, get_turf(xeno), null, 6, new_cause_data = cause_data)
 	spicy_gas.start()
@@ -157,30 +158,6 @@
 
 	apply_cooldown()
 	return ..()
-
-/datum/action/xeno_action/onclick/dump_acid/proc/remove_speed_buff()
-	if (!movespeed_buff_applied && !isxeno(owner))
-		return
-
-	var/mob/living/carbon/xenomorph/xeno = owner
-	xeno.speed_modifier += speed_buff_amount
-	xeno.recalculate_speed()
-	movespeed_buff_applied = FALSE
-	UnregisterSignal(owner, COMSIG_MOB_MOVE_OR_LOOK)
-
-/datum/action/xeno_action/onclick/dump_acid/proc/handle_mob_move_or_look(mob/living/carbon/xenomorph/mover, actually_moving, direction, specific_direction)
-	SIGNAL_HANDLER
-
-	if(!actually_moving)
-		return
-
-	var/obj/effect/particle_effect/smoke/xeno_burn/smoke_effect = new(get_turf(mover), 1, create_cause_data("dumped acid gas", mover))
-	smoke_effect.time_to_live = 3
-	smoke_effect.spread_speed = 1000000
-
-/datum/action/xeno_action/onclick/dump_acid/remove_from()
-	remove_speed_buff()
-	..()
 
 /datum/action/xeno_action/onclick/shift_spits/boiler/use_ability(atom/A)
 	. = ..()

--- a/code/modules/mob/living/carbon/xenomorph/abilities/boiler/boiler_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/boiler/boiler_powers.dm
@@ -143,7 +143,6 @@
 		spicy_gas = new /datum/effect_system/smoke_spread/xeno_weaken
 	else
 		CRASH("Globber has unknown ammo [xeno.ammo]! Oh no!")
-
 	var/datum/cause_data/cause_data = create_cause_data("acid shroud gas", owner)
 	spicy_gas.set_up(1, 0, get_turf(xeno), null, 6, new_cause_data = cause_data)
 	spicy_gas.start()
@@ -159,7 +158,7 @@
 	apply_cooldown()
 	return ..()
 
-/datum/action/xeno_action/onclick/shift_spits/boiler/use_ability(atom/A)
+/datum/action/xeno_action/onclick/shift_spits/boiler/use_ability(atom/affected_atom)
 	. = ..()
 	apply_cooldown()
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/Boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Boiler.dm
@@ -69,8 +69,8 @@
 		/datum/action/xeno_action/activable/xeno_spit/bombard, //1st macro
 		/datum/action/xeno_action/onclick/shift_spits/boiler, //2nd macro
 		/datum/action/xeno_action/activable/spray_acid/boiler, //3rd macro
-		/datum/action/xeno_action/onclick/toggle_long_range/boiler, //4rd macro
-		/datum/action/xeno_action/onclick/acid_shroud, //4th macro
+		/datum/action/xeno_action/onclick/toggle_long_range/boiler, //4th macro
+		/datum/action/xeno_action/onclick/acid_shroud, //5th macro
 		/datum/action/xeno_action/onclick/tacmap,
 	)
 

--- a/code/modules/mob/living/carbon/xenomorph/mutators/strains/boiler/trapper.dm
+++ b/code/modules/mob/living/carbon/xenomorph/mutators/strains/boiler/trapper.dm
@@ -10,7 +10,6 @@
 		/datum/action/xeno_action/activable/xeno_spit/bombard,
 		/datum/action/xeno_action/onclick/shift_spits/boiler,
 		/datum/action/xeno_action/activable/spray_acid/boiler,
-		/datum/action/xeno_action/onclick/dump_acid,
 		/datum/action/xeno_action/onclick/toggle_long_range/boiler,
 		/datum/action/xeno_action/onclick/acid_shroud,
 	)


### PR DESCRIPTION
# About the pull request

- Replaces single letter vars
- Fixes acid shroud hotkey duplicate assignment, will now work on hotkey 5
- Removes unused acid dump ability
- Some minor styling (newlines, spaces)

# Explain why it's good for the game
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Boiler acid shroud now works on hotkey 5
code: Replaces single letter vars and removes unused code for boiler.
/:cl:
