### PR TITLE
Refactors a few vars on /mob/living/carbon/xenomorph

### DIFF
--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -72,9 +72,9 @@
 		return FALSE
 
 	// Create their vis object if needed
-	if(!xeno.backpack_icon_carrier)
-		xeno.backpack_icon_carrier = new(null, xeno)
-		xeno.vis_contents += xeno.backpack_icon_carrier
+	if(!xeno.backpack_icon_holder)
+		xeno.backpack_icon_holder = new(null, xeno)
+		xeno.vis_contents += xeno.backpack_icon_holder
 
 	target_mob.put_in_back(src)
 	return FALSE

--- a/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
@@ -21,7 +21,8 @@
 	if(mind in SSticker.mode.xenomorphs)
 		to_chat(src, SPAN_DEBUG("[src] mind is in the xenomorph list. Mind key is [mind.key]."))
 		to_chat(src, SPAN_DEBUG("Current mob is: [mind.current]. Original mob is: [mind.original]."))
-	else to_chat(src, SPAN_DEBUG("This xenomorph is not in the xenomorph list."))
+	else
+		to_chat(src, SPAN_DEBUG("This xenomorph is not in the xenomorph list."))
 #endif
 
 #undef DEBUG_XENO

--- a/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
@@ -345,16 +345,16 @@
 	//Taken from update_icon for all xeno's
 	var/list/overlays_standing[X_TOTAL_LAYERS]
 
-	var/atom/movable/vis_obj/xeno_wounds/wound_icon_carrier
-	var/atom/movable/vis_obj/xeno_pack/backpack_icon_carrier
+	var/atom/movable/vis_obj/xeno_wounds/wound_icon_holder
+	var/atom/movable/vis_obj/xeno_pack/backpack_icon_holder
 
 /mob/living/carbon/xenomorph/Initialize(mapload, mob/living/carbon/xenomorph/oldXeno, h_number)
 	var/area/A = get_area(src)
 	if(A && A.statistic_exempt)
 		statistic_exempt = TRUE
 
-	wound_icon_carrier = new(null, src)
-	vis_contents += wound_icon_carrier
+	wound_icon_holder = new(null, src)
+	vis_contents += wound_icon_holder
 
 	if(oldXeno)
 		set_movement_intent(oldXeno.m_intent)
@@ -708,11 +708,11 @@
 
 	built_structures = null
 
-	vis_contents -= wound_icon_carrier
-	QDEL_NULL(wound_icon_carrier)
-	if(backpack_icon_carrier)
-		vis_contents -= backpack_icon_carrier
-		QDEL_NULL(backpack_icon_carrier)
+	vis_contents -= wound_icon_holder
+	QDEL_NULL(wound_icon_holder)
+	if(backpack_icon_holder)
+		vis_contents -= backpack_icon_holder
+		QDEL_NULL(backpack_icon_holder)
 
 	QDEL_NULL(iff_tag)
 

--- a/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
@@ -338,9 +338,6 @@
 
 	//Burrower Vars
 	var/used_tremor = 0
-	// Defender vars
-	var/used_headbutt = 0
-	var/used_fortify = 0
 	// Burrowers
 	var/used_burrow = 0
 	var/used_tunnel = 0

--- a/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
@@ -345,14 +345,6 @@
 	var/used_burrow = 0
 	var/used_tunnel = 0
 
-	//Carrier vars
-	var/threw_a_hugger = 0
-	var/huggers_cur = 0
-	var/eggs_cur = 0
-	var/huggers_max = 0
-	var/eggs_max = 0
-	var/laid_egg = 0
-
 	//Taken from update_icon for all xeno's
 	var/list/overlays_standing[X_TOTAL_LAYERS]
 
@@ -946,8 +938,9 @@
 		if(is_zoomed)
 			zoom_out()
 	if(iscarrier(src))
-		huggers_max = caste.huggers_max
-		eggs_max = caste.eggs_max
+		var/mob/living/carbon/xenomorph/carrier/carrier
+		carrier.huggers_max = caste.huggers_max
+		carrier.eggs_max = caste.eggs_max
 	need_weeds = mutators.need_weeds
 
 

--- a/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
@@ -280,7 +280,6 @@
 	/// 0/FALSE - upright, 1/TRUE - all fours
 	var/agility = FALSE
 	var/ripping_limb = FALSE
-	var/steelcrest = FALSE
 	/// The world.time at which we will regurgitate our currently-vored victim
 	var/devour_timer = 0
 	/// For drones/hivelords. Extends the maximum build range they have

--- a/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
@@ -935,7 +935,7 @@
 		if(is_zoomed)
 			zoom_out()
 	if(iscarrier(src))
-		var/mob/living/carbon/xenomorph/carrier/carrier
+		var/mob/living/carbon/xenomorph/carrier/carrier = src
 		carrier.huggers_max = caste.huggers_max
 		carrier.eggs_max = caste.eggs_max
 	need_weeds = mutators.need_weeds

--- a/code/modules/mob/living/carbon/xenomorph/abilities/defender/defender_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/defender/defender_powers.dm
@@ -51,7 +51,7 @@
 	if(!check_and_use_plasma_owner())
 		return
 
-	if(fendy.fortify && !fendy.steelcrest)
+	if(fendy.fortify && !fendy.mutation_type == DEFENDER_STEELCREST)
 		to_chat(fendy, SPAN_XENOWARNING("You cannot use headbutt while fortified."))
 		return
 
@@ -78,7 +78,9 @@
 	SPAN_XENOWARNING("You ram [carbone] with your armored crest!"))
 
 	if(carbone.stat != DEAD && (!(carbone.status_flags & XENO_HOST) || !HAS_TRAIT(carbone, TRAIT_NESTED)) )
-		var/h_damage = 30 - (fendy.crest_defense * 10) + (fendy.steelcrest * 7.5) //30 if crest up, 20 if down, plus 7.5
+		var/h_damage = 30 - (fendy.crest_defense * 10)
+		if(fendy.mutation_type == DEFENDER_STEELCREST)
+			h_damage += 7.5
 		carbone.apply_armoured_damage(get_xeno_damage_slash(carbone, h_damage), ARMOR_MELEE, BRUTE, "chest", 5)
 
 	var/facing = get_dir(fendy, carbone)
@@ -159,7 +161,7 @@
 	if (!istype(xeno))
 		return
 
-	if(xeno.crest_defense && xeno.steelcrest)
+	if(xeno.crest_defense && xeno.mutation_type == DEFENDER_STEELCREST)
 		to_chat(src, SPAN_XENOWARNING("You cannot fortify while your crest is already down!"))
 		return
 
@@ -207,7 +209,7 @@
 
 	if(fortify_state)
 		to_chat(X, SPAN_XENOWARNING("You tuck yourself into a defensive stance."))
-		if(X.steelcrest)
+		if(X.mutation_type == DEFENDER_STEELCREST)
 			X.armor_deflection_buff += 10
 			X.armor_explosive_buff += 60
 			X.ability_speed_modifier += 3
@@ -228,7 +230,7 @@
 		to_chat(X, SPAN_XENOWARNING("You resume your normal stance."))
 		X.frozen = FALSE
 		X.anchored = FALSE
-		if(X.steelcrest)
+		if(X.mutation_type == DEFENDER_STEELCREST)
 			X.armor_deflection_buff -= 10
 			X.armor_explosive_buff -= 60
 			X.ability_speed_modifier -= 3

--- a/code/modules/mob/living/carbon/xenomorph/castes/Carrier.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Carrier.dm
@@ -84,6 +84,14 @@
 	var/mutable_appearance/hugger_overlays_icon
 	var/mutable_appearance/eggsac_overlays_icon
 
+	//Carrier specific vars
+	var/threw_a_hugger = 0
+	var/huggers_cur = 0
+	var/eggs_cur = 0
+	var/huggers_max = 0
+	var/eggs_max = 0
+	var/laid_egg = 0
+
 /mob/living/carbon/xenomorph/carrier/update_icons()
 	. = ..()
 	if (mutation_type == CARRIER_NORMAL)

--- a/code/modules/mob/living/carbon/xenomorph/mutators/strains/carrier/eggsac.dm
+++ b/code/modules/mob/living/carbon/xenomorph/mutators/strains/carrier/eggsac.dm
@@ -58,7 +58,7 @@
 
 /datum/action/xeno_action/active_toggle/generate_egg/should_use_plasma()
 	. = FALSE
-	var/mob/living/carbon/xenomorph/xeno = owner
+	var/mob/living/carbon/xenomorph/carrier/xeno = owner
 	if(!xeno)
 		return
 	if(xeno.eggs_cur < xeno.eggs_max)
@@ -67,7 +67,7 @@
 /datum/action/xeno_action/active_toggle/generate_egg/life_tick()
 	. = ..()
 	if(.)
-		var/mob/living/carbon/xenomorph/xeno = owner
+		var/mob/living/carbon/xenomorph/carrier/xeno = owner
 		if(!xeno)
 			return
 		if(xeno.eggs_cur < xeno.eggs_max)

--- a/code/modules/mob/living/carbon/xenomorph/mutators/strains/defender/steel_crest.dm
+++ b/code/modules/mob/living/carbon/xenomorph/mutators/strains/defender/steel_crest.dm
@@ -23,7 +23,6 @@
 	defender.mutation_type = DEFENDER_STEELCREST
 	defender.mutation_icon_state = DEFENDER_STEELCREST
 	defender.damage_modifier -= XENO_DAMAGE_MOD_VERY_SMALL
-	defender.steelcrest = TRUE
 	if(defender.fortify)
 		defender.ability_speed_modifier += 2.5
 	mutator_update_actions(defender)

--- a/code/modules/mob/living/carbon/xenomorph/update_icons.dm
+++ b/code/modules/mob/living/carbon/xenomorph/update_icons.dm
@@ -131,12 +131,12 @@
 		apply_overlay(X_L_HAND_LAYER)
 
 /mob/living/carbon/xenomorph/update_inv_back()
-	if(!backpack_icon_carrier)
+	if(!backpack_icon_holder)
 		return // Xenos will only have a vis_obj if they've been equipped with a pack before
 
 	var/obj/item/storage/backpack/backpack = back
 	if(!backpack?.xeno_icon_state)
-		backpack_icon_carrier.icon_state = "none"
+		backpack_icon_holder.icon_state = "none"
 		return
 
 	var/state_modifier = ""
@@ -150,11 +150,11 @@
 	else if(handle_special_state())
 		state_modifier = handle_special_backpack_states()
 
-	backpack_icon_carrier.icon_state = backpack.xeno_icon_state + state_modifier
+	backpack_icon_holder.icon_state = backpack.xeno_icon_state + state_modifier
 
-	backpack_icon_carrier.layer = -X_BACK_LAYER
+	backpack_icon_holder.layer = -X_BACK_LAYER
 	if(dir == NORTH && (back.flags_item & ITEM_OVERRIDE_NORTHFACE))
-		backpack_icon_carrier.layer = -X_BACK_FRONT_LAYER
+		backpack_icon_holder.layer = -X_BACK_FRONT_LAYER
 
 /mob/living/carbon/xenomorph/proc/update_inv_resource()
 	remove_overlay(X_RESOURCE_LAYER)
@@ -269,24 +269,24 @@
 
 // Shamelessly inspired from the equivalent proc on TGCM
 /mob/living/carbon/xenomorph/proc/update_wounds()
-	if(!wound_icon_carrier)
+	if(!wound_icon_holder)
 		return
 
 	var/health_threshold
-	wound_icon_carrier.layer = layer + 0.01
+	wound_icon_holder.layer = layer + 0.01
 	health_threshold = max(CEILING((health * 4) / (maxHealth), 1), 0) //From 0 to 4, in 25% chunks
 	if(health > HEALTH_THRESHOLD_DEAD)
 		if(health_threshold > 3)
-			wound_icon_carrier.icon_state = "none"
+			wound_icon_holder.icon_state = "none"
 		else if(lying)
 			if((resting || sleeping) && (!knocked_down && !knocked_out && health > 0))
-				wound_icon_carrier.icon_state = "[caste.caste_type]_rest_[health_threshold]"
+				wound_icon_holder.icon_state = "[caste.caste_type]_rest_[health_threshold]"
 			else
-				wound_icon_carrier.icon_state = "[caste.caste_type]_downed_[health_threshold]"
+				wound_icon_holder.icon_state = "[caste.caste_type]_downed_[health_threshold]"
 		else if(!handle_special_state())
-			wound_icon_carrier.icon_state = "[caste.caste_type]_walk_[health_threshold]"
+			wound_icon_holder.icon_state = "[caste.caste_type]_walk_[health_threshold]"
 		else
-			wound_icon_carrier.icon_state = handle_special_wound_states(health_threshold)
+			wound_icon_holder.icon_state = handle_special_wound_states(health_threshold)
 
 
 ///Used to display the xeno wounds/backpacks without rapidly switching overlays

--- a/code/modules/mob/living/simple_animal/hostile/alien.dm
+++ b/code/modules/mob/living/simple_animal/hostile/alien.dm
@@ -40,7 +40,7 @@
 	pixel_x = -12
 	old_x = -12
 
-	var/atom/movable/vis_obj/xeno_wounds/wound_icon_carrier
+	var/atom/movable/vis_obj/xeno_wounds/wound_icon_holder
 
 /mob/living/simple_animal/hostile/alien/Initialize()
 	maxHealth = health
@@ -52,8 +52,8 @@
 		var/datum/hive_status/hive = GLOB.hive_datum[hivenumber]
 		color = hive.color
 
-	wound_icon_carrier = new(null, src)
-	vis_contents += wound_icon_carrier
+	wound_icon_holder = new(null, src)
+	vis_contents += wound_icon_holder
 
 /mob/living/simple_animal/hostile/alien/proc/generate_name()
 	change_real_name(src, "[caste_name] (BD-[rand(1, 999)])")
@@ -105,22 +105,22 @@
 	update_wounds()
 
 /mob/living/simple_animal/hostile/alien/proc/update_wounds()
-	if(!wound_icon_carrier)
+	if(!wound_icon_holder)
 		return
 
-	wound_icon_carrier.layer = layer + 0.01
-	wound_icon_carrier.dir = dir
+	wound_icon_holder.layer = layer + 0.01
+	wound_icon_holder.dir = dir
 	var/health_threshold = max(CEILING((health * 4) / (maxHealth), 1), 0) //From 0 to 4, in 25% chunks
 	if(health > HEALTH_THRESHOLD_DEAD)
 		if(health_threshold > 3)
-			wound_icon_carrier.icon_state = "none"
+			wound_icon_holder.icon_state = "none"
 		else if(lying)
 			if((resting || sleeping) && (!knocked_down && !knocked_out && health > 0))
-				wound_icon_carrier.icon_state = "[caste_name]_rest_[health_threshold]"
+				wound_icon_holder.icon_state = "[caste_name]_rest_[health_threshold]"
 			else
-				wound_icon_carrier.icon_state = "[caste_name]_downed_[health_threshold]"
+				wound_icon_holder.icon_state = "[caste_name]_downed_[health_threshold]"
 		else
-			wound_icon_carrier.icon_state = "[caste_name]_walk_[health_threshold]"
+			wound_icon_holder.icon_state = "[caste_name]_walk_[health_threshold]"
 
 /mob/living/simple_animal/hostile/alien/bullet_act(obj/projectile/P)
 	. = ..()
@@ -148,8 +148,8 @@
 	animate(src, 5 SECONDS, alpha = 0, easing = CUBIC_EASING)
 
 /mob/living/simple_animal/hostile/alien/Destroy()
-	vis_contents -= wound_icon_carrier
-	QDEL_NULL(wound_icon_carrier)
+	vis_contents -= wound_icon_holder
+	QDEL_NULL(wound_icon_holder)
 	return ..()
 
 /mob/living/simple_animal/hostile/alien/ravager


### PR DESCRIPTION

# About the pull request

- Renames `wound_icon_carrier` &  `backpack_icon_carrier` to `wound_icon_holder` and `backpack_icon_holder` respectively. We have a caste called Carrier & disabiguation good.
- Deletes unused defender related vars
- Replaces `var/steelcrest` on all xenos with a check for `mutation_type == DEFENDER_STEELCREST` in defender code.
- Corrects small style inconsistency in `/mob/verb/debug_xeno_mind()`

No gameplay impact.

# Explain why it's good for the game
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
code: Starts refactoring some vars on xenomorph class
/:cl:
