### PR TITLE
VP-78 range buff

### DIFF
--- a/code/datums/ammo/bullet/pistol.dm
+++ b/code/datums/ammo/bullet/pistol.dm
@@ -182,6 +182,7 @@
 
 	accuracy = HIT_ACCURACY_TIER_4
 	damage = 45
+	effective_range_max = 3
 	penetration= ARMOR_PENETRATION_TIER_6
 	shrapnel_chance = SHRAPNEL_CHANCE_TIER_2
 	damage_falloff = DAMAGE_FALLOFF_TIER_6 //"VP78 - the only pistol viable as a primary."-Vampmare, probably.


### PR DESCRIPTION
# About the pull request

It adds three tiles VP-78's range before falloff happens.

# Explain why it's good for the game

See Images below.
<details>
<summary>stuff</summary>

![image](https://github.com/cmss13-devs/cmss13/assets/61446250/1e26f30f-93eb-4105-94a9-8235375d027d)

![image](https://github.com/cmss13-devs/cmss13/assets/61446250/7d5ab9f6-81ce-43d9-a333-df670543837d)
</details>

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>
</details>


# Changelog
:cl:
balance: VP-78 has three tiles of full damage before falloff starts happening.
/:cl:
