### PR TITLE
Fixes list for the vehicle computer. [NO GAMEPLAY EFFECT]

### DIFF
--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -1331,9 +1331,9 @@ var/datum/controller/supply/supply_controller = new()
 	. = ..()
 
 	vehicles = list(
-		/datum/vehicle_order/apc,
-		/datum/vehicle_order/apc/med,
-		/datum/vehicle_order/apc/cmd,
+		new /datum/vehicle_order/apc,
+		new /datum/vehicle_order/apc/med,
+		new /datum/vehicle_order/apc/cmd,
 	)
 
 	for(var/order as anything in vehicles)

--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -1331,9 +1331,9 @@ var/datum/controller/supply/supply_controller = new()
 	. = ..()
 
 	vehicles = list(
-		new /datum/vehicle_order/apc,
-		new /datum/vehicle_order/apc/med,
-		new /datum/vehicle_order/apc/cmd,
+		new /datum/vehicle_order/apc(),
+		new /datum/vehicle_order/apc/med(),
+		new /datum/vehicle_order/apc/cmd(),
 	)
 
 	for(var/order as anything in vehicles)


### PR DESCRIPTION

Apparentally the vehicle ordering computer wouldn't work even if one attempted to set spent = TRUE. This was due to the datums in the vehicles list not properly set up.

# Explain why it's good for the game

Helps staff spawn vehicles through the consoles, the OG way, instead of spawning stuff individually.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
admin: Fixes vehicle list for the vehicle ASRS computer.
/:cl:
