### PR TITLE
Vehicles can be followed by ghosts

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -249,7 +249,7 @@
 
 ///makes the ghost see the target hud and sets the eye at the target.
 /mob/dead/observer/proc/do_observe(mob/target)
-	if(!client || !target || !istype(target))
+	if(!client || !target || !ismovableatom(target))
 		return
 
 	ManualFollow(target)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -248,8 +248,8 @@
 	RegisterSignal(observe_target_client, COMSIG_CLIENT_SCREEN_REMOVE, PROC_REF(observe_target_screen_remove))
 
 ///makes the ghost see the target hud and sets the eye at the target.
-/mob/dead/observer/proc/do_observe(mob/target)
-	if(!client || !target || !ismovableatom(target))
+/mob/dead/observer/proc/do_observe(atom/movable/target)
+	if(!client || !target || !istype(target))
 		return
 
 	ManualFollow(target)
@@ -257,24 +257,23 @@
 
 	if(!ishuman(target) || !client.prefs?.auto_observe)
 		return
+	var/mob/living/carbon/human/human_target = target
 
-	client.eye = target
+	client.eye = human_target
 
-	if(!target.hud_used)
+	if(!human_target.hud_used)
 		return
 
 	client.clear_screen()
-	LAZYINITLIST(target.observers)
-	target.observers |= src
-	target.hud_used.show_hud(target.hud_used.hud_version, src)
-
-	var/mob/living/carbon/human/human_target = target
+	LAZYINITLIST(human_target.observers)
+	human_target.observers |= src
+	human_target.hud_used.show_hud(human_target.hud_used.hud_version, src)
 
 	var/list/target_contents = human_target.get_contents()
 
 	//Handles any currently open storage containers the target is looking in when we observe
 	for(var/obj/item/storage/checked_storage in target_contents)
-		if(!(target in checked_storage.content_watchers))
+		if(!(human_target in checked_storage.content_watchers))
 			continue
 
 		client.add_to_screen(checked_storage.closer)
@@ -289,7 +288,7 @@
 
 		break
 
-	observe_target_mob = target
+	observe_target_mob = human_target
 	RegisterSignal(observe_target_mob, COMSIG_PARENT_QDELETING, PROC_REF(clean_observe_target))
 	RegisterSignal(observe_target_mob, COMSIG_MOB_GHOSTIZE, PROC_REF(observe_target_ghosting))
 	RegisterSignal(observe_target_mob, COMSIG_MOB_NEW_MIND, PROC_REF(observe_target_new_mind))
@@ -297,8 +296,8 @@
 
 	RegisterSignal(src, COMSIG_MOVABLE_MOVED, PROC_REF(observer_move_react))
 
-	if(target.client)
-		observe_target_client = target.client
+	if(human_target.client)
+		observe_target_client = human_target.client
 		RegisterSignal(observe_target_client, COMSIG_CLIENT_SCREEN_ADD, PROC_REF(observe_target_screen_add))
 		RegisterSignal(observe_target_client, COMSIG_CLIENT_SCREEN_REMOVE, PROC_REF(observe_target_screen_remove))
 		return


### PR DESCRIPTION

# About the pull request

Loosens the type restrictions on what a ghost can orbit from `mob` to `atom/movable`, allowing vehicles to be orbited again. Doesn't effect ghosts viewing player UIs as that is still guarded by an `ishuman()` check.

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

Vehicles are listed in a ghost's "Follow" menu but clicking them does nothing. This PR allows the ghost to follow the vehicle, as expected.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/PvE-CMSS13/PvE-CMSS13/assets/14267245/70d96097-f3cb-4c99-bb98-f99bbf3de40d)

![image](https://github.com/PvE-CMSS13/PvE-CMSS13/assets/14267245/77e37a1c-6215-49f1-bdbd-61748b8ced59)

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: vehicles can be followed by ghosts
/:cl:
