### PR TITLE
Sanitizes burrower tunnel names to alphanumeric only

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -30,6 +30,11 @@
 		text = replacetext(text, char, repl_chars[char])
 	return text
 
+///Helper for only alphanumeric characters plus common punctuation, spaces, underscore and hyphen _ -.
+/proc/replace_non_alphanumeric_plus(text)
+	var/regex/alphanumeric = regex(@{"[^a-z0-9 ,.?!\-_&]"}, "gi")
+	return alphanumeric.Replace(text, "")
+
 /proc/readd_quotes(text)
 	var/list/repl_chars = list("&#34;" = "\"", "&#39;" = "'")
 	for(var/char in repl_chars)

--- a/code/modules/mob/living/carbon/xenomorph/Abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Abilities.dm
@@ -75,6 +75,7 @@
 	X.tunnel_delay = 1
 	addtimer(CALLBACK(src, PROC_REF(cooldown_end)), 4 MINUTES)
 	var/msg = strip_html(input("Add a description to the tunnel:", "Tunnel Description") as text|null)
+	msg = replace_non_alphanumeric_plus(msg)
 	var/description
 	if(msg)
 		description = msg

--- a/code/modules/mob/living/carbon/xenomorph/abilities/burrower/burrower_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/burrower/burrower_powers.dm
@@ -189,6 +189,7 @@
 		return
 
 	var/new_name = strip_html(input("Change the description of the tunnel:", "Tunnel Description") as text|null)
+	new_name = replace_non_alphanumeric_plus(new_name)
 	if(new_name)
 		new_name = "[new_name] ([get_area_name(T)])"
 		log_admin("[key_name(src)] has renamed the tunnel \"[T.tunnel_desc]\" as \"[new_name]\".")


### PR DESCRIPTION

# About the pull request

Someone made a tunnel with the characters `'🐝･ﾟ ･ﾟ·:｡･ﾟﾟ･`  and the tunnel was broken and not usable. This PR restricts them to alphanumeric characters only.

# Explain why it's good for the game
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Restricts burrower tunnels to alphanumeric characters as some other characters break the tunnel.
code; Adds new proc to replace non alphanumeric or space characters.
/:cl:
