### PR TITLE
Early JSON logging implementation

### DIFF
--- a/code/__HELPERS/_time.dm
+++ b/code/__HELPERS/_time.dm
@@ -38,6 +38,10 @@ var/rollovercheck_last_timeofday = 0
 		wtime = world.time
 	return time2text(wtime - GLOB.timezoneOffset, format)
 
+/// Show the current date and time in ISO 8601 format
+/proc/iso_time_stamp()
+	return "[time2text(world.realtime, "YYYY-MM-DD")]T[time2text(world.realtime, "hh:mm:ss")]Z"
+
 /proc/time_stamp() // Shows current GMT time
 	return time2text(world.timeofday, "hh:mm:ss")
 

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -132,6 +132,7 @@ var/global/cas_tracking_id_increment = 0 //this var used to assign unique tracki
 	if(round_statistics)
 		round_statistics.track_round_end()
 	log_game("Round end result: [round_finished]")
+	log_json_event("Round completed: [round_finished]", logtype = "STATS", module = "game_mode", eventtype = "round_end", data = list("duration" = ROUND_TIME, "result" = round_finished))
 	to_chat_spaced(world, margin_top = 2, type = MESSAGE_TYPE_SYSTEM, html = SPAN_ROUNDHEADER("|Round Complete|"))
 	to_chat_spaced(world, type = MESSAGE_TYPE_SYSTEM, html = SPAN_ROUNDBODY("Thus ends the story of the brave men and women of the [MAIN_SHIP_NAME] and their struggle on [SSmapping.configs[GROUND_MAP].map_name].\nThe game-mode was: [master_mode]!\n[CONFIG_GET(string/endofroundblurb)]"))
 

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -138,6 +138,7 @@ var/world_topic_spam_protect_time = world.timeofday
 	GLOB.round_stats = "[GLOB.log_directory]/round_stats.log"
 	GLOB.scheduler_stats = "[GLOB.log_directory]/round_scheduler_stats.log"
 	GLOB.mutator_logs = "[GLOB.log_directory]/mutator_logs.log"
+	GLOB.json_event_log = "[GLOB.log_directory]/json_event_log.log"
 
 	start_log(GLOB.tgui_log)
 	start_log(GLOB.world_href_log)
@@ -147,6 +148,7 @@ var/world_topic_spam_protect_time = world.timeofday
 	start_log(GLOB.round_stats)
 	start_log(GLOB.scheduler_stats)
 	start_log(GLOB.mutator_logs)
+	log_json_event(logtype = "WORLD", module = "logging", eventtype = "logstart", data = list("round_id" = GLOB.round_id))
 
 	if(fexists(GLOB.config_error_log))
 		fcopy(GLOB.config_error_log, "[GLOB.log_directory]/config_error.log")

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -302,6 +302,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	var/list/activemins = adm["present"]
 	var/admin_number_present = activemins.len
 
+	log_json_event("New ahelp ticket", logtype = "ADMIN", module = "adminhelp", eventtype = "new_ticket", actor = initiator, data = list("ticket_id" = id, "ahelp_message" = message, "admins_present" = admin_number_present))
 	log_admin_private("Ticket #[id]: [key_name(initiator)]: [name] - heard by [admin_number_present] non-AFK admins who have +BAN.")
 	if(admin_number_present <= 0)
 		to_chat(initiator, SPAN_NOTICE("No active admins are online, your adminhelp was sent to admins who are available through IRC or Discord."), confidential = TRUE)

--- a/code/modules/logging/global_logs.dm
+++ b/code/modules/logging/global_logs.dm
@@ -28,6 +28,9 @@ GLOBAL_PROTECT(scheduler_stats)
 GLOBAL_VAR(mutator_logs)
 GLOBAL_PROTECT(mutator_logs)
 
+GLOBAL_VAR(json_event_log)
+GLOBAL_PROTECT(json_event_log)
+
 GLOBAL_VAR(round_stats)
 GLOBAL_PROTECT(round_stats)
 


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
A simple JSON logging implementation for feeding in logstash/opensearch because:
 * I'm sick of seeing unreadable logs containing HTML and href tokens 
 * ADMIN_JMP() overeuse alos contributes to HTML logs
 * We're missing "classic" event logging for some big events such as job assignments or round results
 * We don't currently have a way to do aggregations on said important events anyway
 
While our current usage of OpenSearch with legacy HTML-hybrid logs is great for fulltext searching about anything, it immensely falls short when you want to obtain data in a structured fashion (eg ahelp tickets text), filtering by id (eg ahelp lines by sender), or want to do aggregations (eg round results)

Just a sample impl for testing this workflow, it's incomplete, not well enough thought out (defines? port another backend instead?), and only contains a few log lines right now
