### PR TITLE
Hotfixes #4890 bug adds mising newline

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -460,10 +460,11 @@
 			else
 				msg += "\[[criminal]\]\n"
 
-			msg += "<span class = 'deptradio'>Security records:</span> <a href='?src=\ref[src];secrecord=1'>\[View\]\n</a>"
+			msg += "<span class = 'deptradio'>Security records:</span> <a href='?src=\ref[src];secrecord=1'>\[View\]</a>"
 			if(!observer)
 				msg += " <a href='?src=\ref[src];secrecordadd=1'>\[Add comment\]</a>\n"
-
+			else
+				msg += "\n"
 	if(hasHUD(user,"medical"))
 		var/cardcolor = holo_card_color
 		if(!cardcolor) cardcolor = "none"

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -460,7 +460,7 @@
 			else
 				msg += "\[[criminal]\]\n"
 
-			msg += "<span class = 'deptradio'>Security records:</span> <a href='?src=\ref[src];secrecord=1'>\[View\]</a>"
+			msg += "<span class = 'deptradio'>Security records:</span> <a href='?src=\ref[src];secrecord=1'>\[View\]\n</a>"
 			if(!observer)
 				msg += " <a href='?src=\ref[src];secrecordadd=1'>\[Add comment\]</a>\n"
 


### PR DESCRIPTION

# About the pull request

Adds missing newline after [View] so that flavour text displays below.

# Explain why it's good for the game
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Adds missing newline when viewing sec records as observer.
/:cl:
