### PR TITLE
Bigred Changes Part 2: Engineering And Reactor small touches

### DIFF
--- a/maps/map_files/BigRed/BigRed.dmm
+++ b/maps/map_files/BigRed/BigRed.dmm
@@ -10233,6 +10233,15 @@
 	icon_state = "asteroidwarning"
 	},
 /area/bigredv2/outside/c)
+"aCO" = (
+/obj/structure/surface/table,
+/obj/item/stack/cable_coil,
+/obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
+/turf/open/floor{
+	dir = 10;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/filtration_plant)
 "aCP" = (
 /obj/structure/closet/secure_closet/bar,
 /obj/effect/landmark/objective_landmark/close,
@@ -13544,7 +13553,10 @@
 "aLJ" = (
 /obj/structure/filingcabinet,
 /obj/effect/landmark/objective_landmark/close,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "aLM" = (
 /obj/structure/machinery/shower{
@@ -13579,7 +13591,9 @@
 /obj/structure/surface/table,
 /obj/item/tool/lighter/random,
 /obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "aLQ" = (
 /obj/structure/window/reinforced/toughened{
@@ -13858,8 +13872,10 @@
 /obj/structure/surface/table,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/tool/pen,
-/obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "aMC" = (
 /obj/effect/landmark/railgun_camera_pos,
@@ -18585,6 +18601,13 @@
 	icon_state = "dark"
 	},
 /area/bigredv2/outside/chapel)
+"aZJ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor{
+	dir = 6;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/filtration_plant)
 "aZK" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 9
@@ -18655,6 +18678,15 @@
 	},
 /turf/open/floor/carpet,
 /area/bigredv2/outside/admin_building)
+"aZV" = (
+/obj/structure/surface/table,
+/obj/effect/spawner/random/tool,
+/obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/filtration_plant)
 "aZW" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
@@ -19377,6 +19409,13 @@
 	icon_state = "white"
 	},
 /area/bigredv2/outside/office_complex)
+"bcg" = (
+/obj/effect/decal/cleanable/liquid_fuel,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 "bch" = (
 /obj/structure/surface/table,
 /obj/item/clipboard,
@@ -21866,8 +21905,8 @@
 	dir = 1;
 	name = "\improper Atmospherics Condenser"
 	},
-/turf/open/floor{
-	icon_state = "delivery"
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
 	},
 /area/bigredv2/outside/filtration_plant)
 "bkw" = (
@@ -21875,8 +21914,8 @@
 	dir = 1;
 	name = "\improper Atmospherics Condenser"
 	},
-/turf/open/floor{
-	icon_state = "delivery"
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
 	},
 /area/bigredv2/outside/filtration_plant)
 "bkx" = (
@@ -21886,8 +21925,8 @@
 	dir = 1;
 	name = "\improper Atmospherics Condenser"
 	},
-/turf/open/floor{
-	icon_state = "delivery"
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
 	},
 /area/bigredv2/outside/filtration_plant)
 "bky" = (
@@ -21924,18 +21963,30 @@
 	icon_state = "sovietsoda-broken";
 	stat = 1
 	},
-/turf/open/floor,
+/turf/open/floor{
+	dir = 9;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bkE" = (
-/turf/open/floor,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bkG" = (
 /obj/structure/reagent_dispensers/watertank,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bkH" = (
 /obj/structure/dispenser/oxygen,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 5;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bkI" = (
 /obj/structure/cryofeed/right{
@@ -21954,7 +22005,9 @@
 "bkK" = (
 /obj/structure/closet/toolcloset,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor,
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bkL" = (
 /obj/structure/surface/table,
@@ -21962,29 +22015,43 @@
 	dir = 1
 	},
 /obj/item/tank/air,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 9;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bkM" = (
 /obj/structure/surface/table,
 /obj/effect/spawner/random/bomb_supply,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bkN" = (
 /obj/structure/surface/table,
 /obj/effect/spawner/random/tool,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bkO" = (
 /obj/structure/machinery/light{
 	dir = 1
 	},
-/turf/open/floor,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bkP" = (
 /obj/structure/machinery/door/airlock/almayer/engineering/colony{
 	name = "\improper Atmospherics Condenser Storage"
 	},
-/turf/open/floor,
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bkS" = (
 /obj/structure/closet/toolcloset,
@@ -21992,7 +22059,10 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bkT" = (
 /obj/structure/machinery/portable_atmospherics/powered/scrubber/huge/chan,
@@ -22144,19 +22214,27 @@
 /obj/effect/spawner/random/toolbox,
 /obj/item/tool/extinguisher,
 /obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bly" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/filtration_plant)
 "blA" = (
 /obj/structure/dispenser/oxygen,
 /obj/structure/machinery/camera/autoname{
 	dir = 8
 	},
-/turf/open/floor,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "blB" = (
 /obj/effect/landmark/survivor_spawner,
@@ -22168,24 +22246,34 @@
 	dir = 4;
 	pixel_x = -30
 	},
-/turf/open/floor,
+/turf/open/floor{
+	dir = 9;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "blC" = (
 /obj/structure/closet/firecloset/full,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "blD" = (
 /obj/structure/surface/table,
 /obj/item/circuitboard/firealarm,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "blE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/crap_item,
 /obj/structure/pipes/standard/simple/hidden/green,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/filtration_plant)
 "blF" = (
 /obj/structure/machinery/door/airlock/almayer/engineering/colony{
@@ -22199,12 +22287,6 @@
 	},
 /turf/open/floor/plating,
 /area/bigredv2/outside/filtration_plant)
-"blL" = (
-/obj/structure/pipes/standard/simple/hidden/green,
-/turf/open/floor{
-	icon_state = "delivery"
-	},
-/area/bigredv2/outside/engineering)
 "blT" = (
 /obj/structure/bed/chair/office/light{
 	dir = 8
@@ -22212,7 +22294,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/pipes/standard/simple/hidden/green,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/filtration_plant)
 "blV" = (
 /obj/structure/bed/chair/office/light{
@@ -22221,7 +22305,9 @@
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 6
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/filtration_plant)
 "blW" = (
 /obj/structure/surface/table,
@@ -22231,25 +22317,35 @@
 	dir = 8
 	},
 /obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "blX" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 9;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "blY" = (
 /obj/structure/bed/chair{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/filtration_plant)
 "blZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 5
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bma" = (
 /obj/effect/decal/cleanable/dirt,
@@ -22258,7 +22354,9 @@
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 10
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bmb" = (
 /obj/structure/surface/table,
@@ -22267,42 +22365,69 @@
 	pixel_x = 32
 	},
 /obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bme" = (
 /turf/open/mars,
 /area/bigredv2/outside/sw)
 "bmf" = (
 /obj/structure/closet/secure_closet/engineering_personal,
-/turf/open/floor,
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
 /area/bigredv2/outside/engineering)
 "bmg" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor,
+/obj/effect/decal/warning_stripes{
+	icon_state = "W";
+	pixel_x = -1
+	},
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "bmh" = (
 /obj/effect/decal/cleanable/liquid_fuel,
 /obj/structure/pipes/standard/simple/hidden/green,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "bmi" = (
-/turf/open/floor,
+/obj/effect/decal/cleanable/liquid_fuel,
+/obj/structure/curtain/red,
+/turf/open/floor{
+	icon_state = "freezerfloor"
+	},
 /area/bigredv2/outside/engineering)
 "bmj" = (
-/obj/structure/machinery/light{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/liquid_fuel,
-/turf/open/floor,
+/obj/structure/machinery/shower{
+	dir = 8
+	},
+/turf/open/floor{
+	icon_state = "freezerfloor"
+	},
 /area/bigredv2/outside/engineering)
 "bml" = (
 /obj/structure/machinery/portable_atmospherics/canister/air,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 9;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "bmm" = (
 /obj/structure/machinery/portable_atmospherics/canister/air,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "bmn" = (
 /obj/structure/machinery/power/smes/buildable{
@@ -22312,31 +22437,41 @@
 /area/bigredv2/outside/engineering)
 "bmp" = (
 /obj/structure/machinery/mill,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "bmq" = (
 /obj/structure/surface/table,
 /obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
-/turf/open/floor,
-/area/bigredv2/outside/engineering)
-"bmr" = (
-/obj/structure/surface/table,
-/obj/effect/spawner/random/tool,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "bms" = (
 /obj/structure/machinery/autolathe,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 5;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "bmt" = (
 /obj/structure/machinery/computer/atmos_alert,
 /obj/structure/surface/table,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 9;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "bmu" = (
 /obj/structure/machinery/computer/station_alert,
 /obj/structure/surface/table,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "bmw" = (
 /obj/structure/closet/secure_closet/engineering_chief,
@@ -22344,20 +22479,32 @@
 	dir = 1
 	},
 /obj/effect/landmark/objective_landmark/close,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "bmx" = (
 /obj/structure/bookcase/manuals/engineering,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 5;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "bmy" = (
 /obj/effect/decal/cleanable/liquid_fuel,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "bmz" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "bmA" = (
 /obj/structure/barricade/wooden,
@@ -22379,33 +22526,49 @@
 	dir = 4
 	},
 /obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bmD" = (
 /obj/structure/pipes/standard/manifold/hidden/green{
 	dir = 4
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bmF" = (
 /obj/structure/pipes/standard/simple/hidden/green,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bmG" = (
 /obj/structure/closet/wardrobe/atmospherics_yellow,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bmH" = (
 /obj/structure/surface/table,
 /obj/item/tool/lighter/random,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bmJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/pipes/standard/simple/hidden/green,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bmM" = (
 /obj/effect/landmark/hunter_primary,
@@ -22420,14 +22583,24 @@
 "bmO" = (
 /obj/effect/decal/cleanable/liquid_fuel,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor,
+/obj/effect/decal/warning_stripes{
+	icon_state = "W";
+	pixel_x = -1
+	},
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "bmP" = (
 /obj/effect/decal/cleanable/liquid_fuel,
 /obj/effect/decal/cleanable/liquid_fuel,
 /obj/item/stack/sheet/metal,
 /obj/structure/pipes/standard/simple/hidden/green,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "bmQ" = (
 /obj/structure/machinery/shower{
@@ -22443,13 +22616,18 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "bmS" = (
 /obj/structure/machinery/portable_atmospherics/canister/air,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/engineering)
 "bmT" = (
 /obj/structure/machinery/power/terminal{
@@ -22475,23 +22653,33 @@
 /area/bigredv2/outside/engineering)
 "bmW" = (
 /obj/effect/decal/cleanable/blood,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/engineering)
 "bmX" = (
 /obj/structure/bed/chair/office/dark,
 /obj/effect/landmark/corpsespawner/engineer,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/engineering)
 "bmZ" = (
 /obj/effect/decal/cleanable/liquid_fuel,
 /obj/effect/decal/cleanable/liquid_fuel,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "bna" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/liquid_fuel,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "bnb" = (
 /obj/structure/machinery/door_control{
@@ -22499,14 +22687,20 @@
 	name = "Storm Shutters";
 	pixel_x = -32
 	},
-/turf/open/floor,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bnd" = (
 /obj/structure/machinery/light{
 	dir = 4
 	},
-/obj/structure/machinery/computer3/server/rack,
-/turf/open/floor,
+/obj/structure/machinery/computer3/server,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bne" = (
 /obj/structure/cryofeed,
@@ -22519,7 +22713,10 @@
 /area/bigredv2/outside/filtration_plant)
 "bnf" = (
 /obj/structure/machinery/computer3/server/rack,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bng" = (
 /obj/effect/decal/cleanable/dirt,
@@ -22527,12 +22724,16 @@
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 6
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bnh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/pipes/standard/manifold/hidden/green,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bnj" = (
 /obj/structure/pipes/standard/simple/hidden/green{
@@ -22541,8 +22742,8 @@
 /obj/structure/machinery/door/airlock/almayer/engineering/colony{
 	name = "\improper Atmospherics Condenser Storage"
 	},
-/turf/open/floor{
-	icon_state = "delivery"
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
 	},
 /area/bigredv2/outside/filtration_plant)
 "bnl" = (
@@ -22550,66 +22751,93 @@
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bnm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 10
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bnn" = (
 /obj/structure/pipes/vents/pump,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bno" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/device/radio/headset,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bnp" = (
 /obj/structure/machinery/computer/area_atmos/area,
 /obj/structure/surface/table,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bnq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/pipes/standard/simple/hidden/green,
-/turf/open/floor,
+/obj/structure/machinery/light{
+	dir = 4
+	},
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "bnr" = (
 /obj/structure/largecrate/random,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "bns" = (
 /obj/structure/machinery/door/airlock/almayer/engineering/colony{
 	dir = 1;
 	name = "\improper Engineering SMES"
 	},
-/turf/open/floor{
-	icon_state = "delivery"
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
 	},
 /area/bigredv2/outside/engineering)
 "bnt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/glasses/welding,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/engineering)
 "bnu" = (
 /obj/structure/machinery/light{
 	dir = 4
 	},
-/turf/open/floor,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "bnw" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 6
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/engineering)
 "bnx" = (
 /obj/structure/surface/table,
@@ -22619,7 +22847,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/glasses/meson,
 /obj/effect/landmark/crap_item,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/engineering)
 "bny" = (
 /obj/structure/window/reinforced/toughened{
@@ -22644,41 +22874,55 @@
 /obj/structure/surface/table,
 /obj/item/tool/lighter/zippo,
 /obj/item/tool/lighter/zippo,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "bnA" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/engidoor/glass/colony{
 	dir = 1;
 	name = "\improper Atmospherics Condenser"
 	},
-/turf/open/floor{
-	icon_state = "delivery"
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
 	},
 /area/bigredv2/outside/filtration_plant)
 "bnB" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 6
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bnE" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bnF" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bnH" = (
 /obj/structure/machinery/computer/general_air_control,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bnI" = (
 /obj/structure/machinery/light,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bnK" = (
 /obj/structure/pipes/standard/simple/hidden/green{
@@ -22687,40 +22931,53 @@
 /obj/structure/machinery/camera/autoname{
 	dir = 1
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bnL" = (
 /obj/structure/pipes/standard/manifold/hidden/green,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bnM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 9
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bnN" = (
 /obj/structure/bed/chair{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bnO" = (
 /obj/structure/machinery/computer/atmos_alert{
 	dir = 8
 	},
 /obj/structure/surface/table,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 6;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bnQ" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/structure/machinery/light{
 	dir = 8
 	},
-/turf/open/floor,
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
 /area/bigredv2/outside/engineering)
 "bnR" = (
 /obj/structure/machinery/shower{
@@ -22733,30 +22990,40 @@
 /area/bigredv2/outside/engineering)
 "bnS" = (
 /obj/item/trash/eat,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/engineering)
 "bnT" = (
 /obj/structure/machinery/door/airlock/almayer/secure/colony{
 	name = "\improper Engineering Secure Storage"
 	},
-/turf/open/floor{
-	icon_state = "delivery"
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
 	},
 /area/bigredv2/outside/engineering)
 "bnV" = (
 /obj/structure/sign/safety/electronics{
 	pixel_y = 32
 	},
-/turf/open/floor,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "bnW" = (
 /obj/structure/pipes/vents/pump,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkyellowcorners2"
+	},
 /area/bigredv2/outside/engineering)
 "bnX" = (
 /obj/item/folder/yellow,
 /obj/effect/landmark/crap_item,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/engineering)
 "bnY" = (
 /obj/structure/machinery/photocopier,
@@ -22766,26 +23033,36 @@
 	name = "General Listening Channel";
 	pixel_x = 30
 	},
-/turf/open/floor,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "bnZ" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/engineering)
 "boa" = (
 /obj/structure/bed/chair{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/engineering)
 "bob" = (
 /obj/structure/bed/chair{
 	dir = 1
 	},
-/turf/open/floor,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "boc" = (
 /obj/structure/machinery/light{
@@ -22793,64 +23070,85 @@
 	},
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/effect/landmark/crap_item,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "boe" = (
-/obj/structure/machinery/computer3/server,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bof" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/filtration_plant)
 "boj" = (
 /obj/structure/closet/secure_closet/engineering_welding,
-/turf/open/floor,
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
 /area/bigredv2/outside/engineering)
 "bok" = (
 /obj/structure/largecrate/random,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor,
-/area/bigredv2/outside/engineering)
-"bop" = (
-/obj/structure/pipes/standard/simple/hidden/green,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "boq" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 5
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "bor" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "bos" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 10
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/engineering)
 "bou" = (
 /obj/structure/machinery/light{
 	dir = 8
 	},
 /obj/structure/machinery/computer3/server/rack,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bov" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/weapon/twohanded/fireaxe,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/filtration_plant)
 "box" = (
 /obj/item/frame/table,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "boy" = (
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_door,
@@ -22868,44 +23166,63 @@
 	dir = 1;
 	name = "\improper Engineering Complex"
 	},
-/turf/open/floor,
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
 /area/bigredv2/outside/engineering)
 "boG" = (
 /obj/structure/closet/secure_closet/engineering_electrical,
-/turf/open/floor,
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
 /area/bigredv2/outside/engineering)
 "boH" = (
 /obj/effect/decal/cleanable/liquid_fuel,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/crap_item,
 /obj/structure/pipes/standard/simple/hidden/green,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellowcorners2"
+	},
 /area/bigredv2/outside/engineering)
 "boI" = (
 /obj/structure/machinery/light{
 	dir = 1
 	},
-/turf/open/floor,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "boK" = (
 /obj/item/trash/pistachios,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/engineering)
 "boL" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "boM" = (
 /obj/structure/closet/firecloset/full,
 /obj/structure/machinery/light{
 	dir = 8
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "boN" = (
 /obj/structure/closet/firecloset/full,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "boR" = (
 /obj/structure/surface/table,
@@ -22914,14 +23231,19 @@
 	dir = 1
 	},
 /obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "boS" = (
 /obj/structure/surface/table,
 /obj/effect/spawner/random/tool,
 /obj/effect/spawner/random/technology_scanner,
 /obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 6;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "boU" = (
 /obj/structure/pipes/standard/simple/hidden/green,
@@ -22929,8 +23251,8 @@
 	dir = 1;
 	name = "\improper Chief Engineer's Office"
 	},
-/turf/open/floor{
-	icon_state = "delivery"
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
 	},
 /area/bigredv2/outside/engineering)
 "boV" = (
@@ -22938,17 +23260,22 @@
 /obj/structure/machinery/door/airlock/multi_tile/almayer/generic{
 	name = "\improper Engineering Complex"
 	},
-/turf/open/floor{
-	icon_state = "delivery"
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
 	},
 /area/bigredv2/outside/engineering)
 "boW" = (
 /obj/structure/closet/secure_closet/atmos_personal,
-/turf/open/floor,
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
 /area/bigredv2/outside/filtration_plant)
 "boX" = (
 /obj/structure/machinery/pipedispenser,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 9;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "boY" = (
 /obj/structure/machinery/cm_vending/sorted/tech/tool_storage,
@@ -22958,17 +23285,24 @@
 	phone_id = "Filtration";
 	pixel_y = 24
 	},
-/turf/open/floor,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "boZ" = (
 /obj/effect/landmark/crap_item,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bpa" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bpc" = (
 /obj/structure/barricade/handrail,
@@ -22978,26 +23312,41 @@
 /area/bigredv2/outside/filtration_plant)
 "bpe" = (
 /obj/effect/landmark/survivor_spawner,
-/turf/open/floor,
+/obj/effect/decal/warning_stripes{
+	icon_state = "W";
+	pixel_x = -1
+	},
+/turf/open/floor{
+	dir = 10;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "bpf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 5
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/engineering)
 "bpi" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/structure/machinery/light{
 	dir = 8
 	},
-/turf/open/floor,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "bpj" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "bpk" = (
 /obj/structure/pipes/standard/simple/hidden/green,
@@ -23005,19 +23354,26 @@
 	dir = 1;
 	name = "\improper Engineering Tool Storage"
 	},
-/turf/open/floor{
-	icon_state = "delivery"
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
 	},
 /area/bigredv2/outside/engineering)
 "bpl" = (
 /obj/structure/machinery/light{
 	dir = 8
 	},
-/turf/open/floor,
+/turf/open/floor{
+	dir = 9;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "bpm" = (
-/obj/effect/landmark/corpsespawner/engineer,
-/turf/open/floor,
+/obj/structure/surface/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/glasses/welding,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/engineering)
 "bpn" = (
 /obj/structure/pipes/standard/simple/hidden/green{
@@ -23026,25 +23382,34 @@
 /obj/structure/machinery/camera/autoname{
 	dir = 4
 	},
-/turf/open/floor,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bpo" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bpp" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 9
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bpq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/frame/table,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bpu" = (
 /obj/structure/machinery/landinglight/ds2/delaythree{
@@ -23076,8 +23441,8 @@
 	dir = 1;
 	name = "\improper Engineering Lockers"
 	},
-/turf/open/floor{
-	icon_state = "delivery"
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
 	},
 /area/bigredv2/outside/engineering)
 "bpA" = (
@@ -23086,44 +23451,51 @@
 	dir = 1;
 	name = "\improper Engineering Lockers"
 	},
-/turf/open/floor{
-	icon_state = "delivery"
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
 	},
 /area/bigredv2/outside/engineering)
 "bpC" = (
 /obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 6;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "bpD" = (
 /obj/structure/surface/rack,
 /obj/item/device/camera_film,
-/obj/item/device/analyzer,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 9;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "bpE" = (
 /obj/structure/surface/rack,
-/obj/item/weapon/gun/smg/nailgun,
-/obj/item/weapon/gun/smg/nailgun,
-/obj/item/ammo_magazine/smg/nailgun,
-/obj/item/ammo_magazine/smg/nailgun,
-/obj/item/ammo_magazine/smg/nailgun,
-/obj/item/ammo_magazine/smg/nailgun,
-/obj/item/ammo_magazine/smg/nailgun,
-/obj/item/ammo_magazine/smg/nailgun,
-/turf/open/floor,
+/obj/item/device/analyzer,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "bpF" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 6
 	},
-/turf/open/floor,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "bpH" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "bpI" = (
 /obj/structure/pipes/standard/simple/hidden/green{
@@ -23131,7 +23503,10 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/item/device/lightreplacer,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "bpK" = (
 /obj/structure/machinery/light{
@@ -23140,31 +23515,43 @@
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
 	},
-/turf/open/floor,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "bpL" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
 	},
 /obj/effect/landmark/hunter_secondary,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkyellowcorners2"
+	},
 /area/bigredv2/outside/engineering)
 "bpM" = (
-/obj/structure/pipes/standard/manifold/hidden/green,
-/turf/open/floor,
+/obj/structure/pipes/standard/manifold/fourway/hidden/green,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/engineering)
 "bpN" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/liquid_fuel,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/engineering)
 "bpO" = (
 /obj/structure/pipes/standard/manifold/hidden/green{
 	dir = 4
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/engineering)
 "bpP" = (
 /obj/structure/machinery/camera/autoname{
@@ -23173,7 +23560,9 @@
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 5
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bpQ" = (
 /obj/structure/machinery/light{
@@ -23183,20 +23572,26 @@
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bpR" = (
 /obj/structure/pipes/standard/manifold/hidden/green{
 	dir = 1
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bpS" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
 	},
 /obj/effect/landmark/good_item,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bpT" = (
 /obj/structure/pipes/standard/simple/hidden/green,
@@ -23207,13 +23602,14 @@
 "bpU" = (
 /obj/structure/machinery/portable_atmospherics/powered/scrubber/huge/stationary,
 /obj/effect/decal/warning_stripes,
-/turf/open/floor,
+/turf/open/floor/plating,
 /area/bigredv2/outside/filtration_plant)
 "bpV" = (
 /obj/effect/decal/warning_stripes{
-	icon_state = "N"
+	icon_state = "N";
+	pixel_y = 1
 	},
-/turf/open/floor,
+/turf/open/floor/plating,
 /area/bigredv2/outside/filtration_plant)
 "bpX" = (
 /turf/open/floor{
@@ -23275,8 +23671,8 @@
 	dir = 1;
 	name = "\improper Engineering Break Room"
 	},
-/turf/open/floor{
-	icon_state = "delivery"
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
 	},
 /area/bigredv2/outside/engineering)
 "bqg" = (
@@ -23291,34 +23687,39 @@
 	dir = 1;
 	pixel_y = -30
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "bql" = (
-/obj/effect/decal/cleanable/liquid_fuel,
 /obj/structure/machinery/door_control{
 	id = "Engineering";
 	name = "Storm Shutters";
 	pixel_y = -32
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "bqo" = (
 /obj/structure/bed/chair{
 	dir = 8
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/engineering)
 "bqv" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
 	},
-/turf/open/floor,
+/turf/open/floor/plating,
 /area/bigredv2/outside/filtration_plant)
 "bqw" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E-corner"
 	},
-/turf/open/floor,
+/turf/open/floor/plating,
 /area/bigredv2/outside/filtration_plant)
 "bqA" = (
 /obj/structure/closet/toolcloset,
@@ -23339,21 +23740,30 @@
 	icon_state = "snack-broken";
 	stat = 1
 	},
-/turf/open/floor,
+/turf/open/floor{
+	dir = 9;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "bqJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/machinery/camera/autoname{
 	dir = 4
 	},
-/turf/open/floor,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkyellowcorners2"
+	},
 /area/bigredv2/outside/engineering)
 "bqK" = (
 /obj/item/folder/yellow,
 /obj/structure/pipes/standard/manifold/hidden/green{
 	dir = 8
 	},
-/turf/open/floor,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellowcorners2"
+	},
 /area/bigredv2/outside/engineering)
 "bqL" = (
 /obj/structure/pipes/standard/simple/hidden/green{
@@ -23362,8 +23772,8 @@
 /obj/structure/machinery/door/airlock/almayer/engineering/colony{
 	name = "\improper Engineering Workshop"
 	},
-/turf/open/floor{
-	icon_state = "delivery"
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
 	},
 /area/bigredv2/outside/engineering)
 "bqM" = (
@@ -23371,29 +23781,39 @@
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/engineering)
 "bqN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 9
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/engineering)
 "bqP" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "SE-out";
+	pixel_x = 1;
+	pixel_y = -1
+	},
 /obj/structure/machinery/door/airlock/almayer/engineering/colony{
 	dir = 1;
 	name = "\improper Engine Reactor Control"
 	},
-/obj/structure/pipes/standard/simple/hidden/green,
-/turf/open/floor{
-	icon_state = "delivery"
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
 	},
 /area/bigredv2/outside/engineering)
 "bqT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/survivor_spawner,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bqV" = (
 /obj/structure/machinery/light{
@@ -23402,13 +23822,16 @@
 /obj/structure/surface/table,
 /obj/item/paper,
 /obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bqX" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
 	},
-/turf/open/floor,
+/turf/open/floor/plating,
 /area/bigredv2/outside/filtration_plant)
 "brb" = (
 /obj/structure/machinery/landinglight/ds2{
@@ -23434,14 +23857,17 @@
 /area/bigredv2/outside/sw)
 "bre" = (
 /obj/structure/bed/chair,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "brf" = (
 /obj/structure/machinery/door/airlock/almayer/engineering/colony{
 	name = "\improper Engineering Workshop"
 	},
-/turf/open/floor{
-	icon_state = "delivery"
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
 	},
 /area/bigredv2/outside/engineering)
 "brg" = (
@@ -23449,57 +23875,73 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/engineering)
 "bri" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/sheet/metal,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/engineering)
 "brj" = (
 /obj/structure/surface/table,
 /obj/effect/spawner/random/toolbox,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
-/turf/open/floor,
-/area/bigredv2/outside/engineering)
-"brm" = (
-/obj/structure/surface/table,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "brn" = (
-/obj/structure/surface/table,
-/obj/effect/spawner/random/technology_scanner,
-/obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
-/obj/structure/transmitter/colony_net{
-	phone_category = "Solaris Ridge";
-	phone_color = "yellow";
-	phone_id = "Engineering";
-	pixel_y = 24
+/obj/structure/machinery/power/breakerbox/activated,
+/obj/structure/machinery/light{
+	dir = 8
 	},
-/turf/open/floor,
+/turf/open/floor{
+	dir = 9;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "bro" = (
 /obj/structure/machinery/camera/autoname,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "bru" = (
 /obj/structure/machinery/vending/cigarette/colony,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "brv" = (
 /obj/structure/machinery/vending/snack,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "brw" = (
 /obj/structure/machinery/vending/cola,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 5;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "brx" = (
 /obj/structure/surface/table,
 /obj/item/stack/cable_coil,
 /obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bry" = (
 /obj/structure/pipes/standard/manifold/hidden/green{
@@ -23507,14 +23949,18 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/filtration_plant)
 "brz" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/filtration_plant)
 "brA" = (
 /obj/structure/surface/table,
@@ -23529,17 +23975,25 @@
 	pixel_x = 30
 	},
 /obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "brB" = (
 /obj/structure/machinery/light{
 	dir = 8
 	},
-/turf/open/floor,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "brC" = (
 /obj/effect/landmark/good_item,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/filtration_plant)
 "brD" = (
 /turf/open/floor/plating,
@@ -23560,42 +24014,61 @@
 /obj/item/stack/sheet/metal{
 	amount = 30
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/engineering)
 "brJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/sheet/glass,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/engineering)
 "brK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/hunter_primary,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/engineering)
 "brL" = (
 /obj/structure/bed/chair/office/light{
 	dir = 4
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/engineering)
 "brM" = (
 /obj/structure/surface/table,
 /obj/effect/spawner/random/powercell,
 /obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "brO" = (
 /obj/structure/machinery/light{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "brP" = (
 /obj/structure/bed/chair/office/light{
 	dir = 8
 	},
-/turf/open/floor,
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 6
+	},
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/engineering)
 "brR" = (
 /obj/item/device/radio/intercom{
@@ -23604,36 +24077,50 @@
 	name = "General Listening Channel";
 	pixel_x = 30
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "podhatchfloor"
+	},
 /area/bigredv2/outside/engineering)
 "brU" = (
 /obj/structure/surface/table,
 /obj/item/stack/cable_coil,
 /obj/item/stack/cable_coil,
 /obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "brV" = (
 /obj/structure/bed/chair/office/light{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/filtration_plant)
 "brW" = (
 /obj/structure/surface/table,
 /obj/item/weapon/baton,
 /obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "brY" = (
 /obj/structure/bed/chair/office/light,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/filtration_plant)
 "brZ" = (
 /obj/structure/bed/chair/office/light,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "darkyellowcorners2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bsa" = (
 /obj/structure/machinery/floodlight/landing/floor,
@@ -23683,11 +24170,9 @@
 	amount = 30
 	},
 /obj/effect/landmark/crap_item,
-/turf/open/floor,
-/area/bigredv2/outside/engineering)
-"bso" = (
-/obj/structure/machinery/power/geothermal,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/engineering)
 "bss" = (
 /obj/structure/prop/invuln/minecart_tracks{
@@ -23698,40 +24183,50 @@
 	},
 /turf/open/floor/plating,
 /area/bigredv2/caves/mining)
-"bsu" = (
-/obj/effect/landmark/crap_item,
-/turf/open/floor,
-/area/bigredv2/outside/engineering)
 "bsB" = (
 /obj/structure/surface/table,
 /obj/effect/spawner/random/tool,
 /obj/effect/spawner/random/tool,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 10;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bsC" = (
 /obj/structure/surface/table,
 /obj/effect/spawner/random/technology_scanner,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bsD" = (
 /obj/structure/surface/table,
 /obj/effect/spawner/random/tool,
 /obj/effect/spawner/random/toolbox,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bsE" = (
 /obj/structure/surface/table,
 /obj/effect/spawner/random/toolbox,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bsF" = (
 /obj/structure/surface/table,
 /obj/item/circuitboard/solar_tracker,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 6;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bsG" = (
 /obj/structure/closet/wardrobe/engineering_yellow,
-/turf/open/floor,
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bsH" = (
 /obj/effect/landmark/hunter_primary,
@@ -23747,19 +24242,26 @@
 	icon_state = "coffee-broken";
 	stat = 1
 	},
-/turf/open/floor,
+/turf/open/floor{
+	dir = 10;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "bsK" = (
 /obj/structure/machinery/light,
 /obj/structure/surface/table,
 /obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "bsL" = (
 /obj/effect/landmark/crap_item,
 /obj/structure/surface/table,
 /obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "bsM" = (
 /obj/structure/machinery/door_control{
@@ -23767,7 +24269,10 @@
 	name = "Storm Shutters";
 	pixel_y = -32
 	},
-/turf/open/floor,
+/turf/open/floor{
+	dir = 6;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "bsN" = (
 /obj/structure/surface/table,
@@ -23779,49 +24284,62 @@
 /obj/item/stack/sheet/glass{
 	amount = 30
 	},
-/turf/open/floor,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "bsP" = (
-/obj/structure/surface/table,
-/obj/effect/spawner/random/toolbox,
-/turf/open/floor,
+/obj/structure/closet/radiation,
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
 /area/bigredv2/outside/engineering)
 "bsX" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/generic{
 	name = "\improper Engineering Complex"
 	},
-/turf/open/floor{
-	icon_state = "delivery"
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
 	},
 /area/bigredv2/outside/engineering)
 "bsY" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/generic{
 	name = "\improper Atmospherics Condenser"
 	},
-/turf/open/floor{
-	icon_state = "delivery"
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
 	},
-/area/bigredv2/outside/filtration_plant)
+/area/bigredv2/outside/engineering)
 "bsZ" = (
 /obj/structure/janitorialcart,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 10;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "bta" = (
 /obj/structure/machinery/constructable_frame{
 	icon_state = "box_1"
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "btb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/machinery/constructable_frame,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "btc" = (
 /obj/structure/surface/table,
 /obj/structure/machinery/light,
 /obj/effect/spawner/random/tool,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "btd" = (
 /obj/structure/surface/table,
@@ -23829,28 +24347,48 @@
 /obj/item/stack/sheet/metal{
 	amount = 30
 	},
-/turf/open/floor,
+/turf/open/floor{
+	dir = 6;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "bte" = (
-/obj/structure/machinery/light,
-/turf/open/floor,
+/obj/structure/machinery/light{
+	dir = 4
+	},
+/obj/structure/sign/safety/high_rad{
+	pixel_x = 32
+	},
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "bti" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "btj" = (
 /obj/structure/bed/chair,
 /obj/structure/machinery/light{
 	dir = 1
 	},
-/turf/open/floor,
-/area/bigredv2/outside/filtration_plant)
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 "btk" = (
 /obj/structure/bed/chair,
-/turf/open/floor,
-/area/bigredv2/outside/filtration_plant)
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 "btn" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor{
@@ -23865,43 +24403,40 @@
 	},
 /area/bigredv2/outside/se)
 "btr" = (
-/obj/structure/machinery/computer/station_alert{
-	dir = 1
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkyellow2"
 	},
-/obj/structure/surface/table,
-/turf/open/floor,
-/area/bigredv2/outside/engineering)
-"bts" = (
-/obj/structure/machinery/power/monitor{
-	name = "Main Power Grid Monitoring"
-	},
-/turf/open/floor,
 /area/bigredv2/outside/engineering)
 "btt" = (
-/obj/structure/surface/table,
-/obj/item/device/analyzer,
-/obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
-/turf/open/floor,
+/obj/structure/bed/chair/office/light,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/engineering)
 "btu" = (
-/obj/structure/machinery/computer/atmos_alert{
-	dir = 1
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
 	},
-/obj/structure/surface/table,
-/turf/open/floor,
 /area/bigredv2/outside/engineering)
 "btw" = (
 /turf/open/floor/plating,
 /area/bigredv2/outside/lz2_south_cas)
 "btA" = (
 /obj/effect/landmark/hunter_primary,
-/turf/open/floor,
-/area/bigredv2/outside/filtration_plant)
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/bigredv2/outside/engineering)
 "btB" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor,
-/area/bigredv2/outside/filtration_plant)
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 "btD" = (
 /turf/open/mars_cave{
 	icon_state = "mars_dirt_7"
@@ -23915,8 +24450,8 @@
 	dir = 1;
 	name = "\improper Engineering Complex"
 	},
-/turf/open/floor{
-	icon_state = "delivery"
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
 	},
 /area/bigredv2/outside/engineering)
 "btJ" = (
@@ -23924,13 +24459,19 @@
 	dir = 4
 	},
 /obj/structure/machinery/light,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "btK" = (
-/obj/structure/pipes/standard/manifold/hidden/green{
-	dir = 1
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
 	},
-/turf/open/floor,
+/obj/item/stack/sheet/metal,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "btN" = (
 /obj/structure/pipes/standard/simple/hidden/green{
@@ -23940,15 +24481,18 @@
 /obj/structure/machinery/light{
 	dir = 4
 	},
-/turf/open/floor,
-/area/bigredv2/outside/filtration_plant)
+/turf/open/floor{
+	dir = 6;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 "bua" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/structure/machinery/door/airlock/multi_tile/almayer/generic{
 	name = "\improper Engineering Complex"
 	},
-/turf/open/floor{
-	icon_state = "delivery"
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
 	},
 /area/bigredv2/outside/engineering)
 "bub" = (
@@ -25524,7 +26068,9 @@
 /obj/structure/surface/table,
 /obj/item/trash/kepler,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/engineering)
 "bAp" = (
 /obj/structure/pipes/vents/pump{
@@ -25835,9 +26381,12 @@
 	},
 /area/bigredv2/caves/eta/xenobiology)
 "bBg" = (
-/obj/structure/machinery/power/geothermal,
-/turf/open/floor/plating,
-/area/bigredv2/outside/medical)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/filtration_plant)
 "bBh" = (
 /obj/structure/filingcabinet,
 /turf/open/floor{
@@ -27309,12 +27858,27 @@
 	icon_state = "asteroidwarning"
 	},
 /area/bigredv2/outside/telecomm/lz2_cave)
+"bYW" = (
+/obj/structure/pipes/vents/pump,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 "bZp" = (
 /obj/structure/bed/chair{
 	dir = 4
 	},
 /turf/open/floor/plating,
 /area/bigredv2/outside/nw/ceiling)
+"bZJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/suit/radiation,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkyellowcorners2"
+	},
+/area/bigredv2/outside/engineering)
 "bZL" = (
 /obj/effect/landmark/monkey_spawn,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
@@ -27338,7 +27902,10 @@
 /obj/structure/surface/table,
 /obj/effect/spawner/random/bomb_supply,
 /obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "cdA" = (
 /turf/open/mars_cave{
@@ -27386,6 +27953,14 @@
 	icon_state = "mars_dirt_4"
 	},
 /area/bigredv2/caves/mining)
+"cla" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/bigredv2/outside/engineering)
 "clB" = (
 /turf/open/floor{
 	dir = 1;
@@ -27505,10 +28080,15 @@
 	icon_state = "darkyellowcorners2"
 	},
 /area/bigredv2/caves/eta/living)
-"cuF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/pipes/standard/manifold/hidden/green,
-/turf/open/floor,
+"cud" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "W";
+	pixel_x = -1
+	},
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "cvi" = (
 /obj/effect/decal/cleanable/dirt,
@@ -27583,12 +28163,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/bigredv2/caves/mining)
-"cFb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/stack/sheet/metal,
-/obj/structure/bed/chair/office/light,
-/turf/open/floor,
-/area/bigredv2/outside/engineering)
 "cGQ" = (
 /obj/structure/blocker/forcefield/multitile_vehicles,
 /turf/open/floor{
@@ -27603,7 +28177,10 @@
 	pixel_x = -32;
 	start_charge = 0
 	},
-/turf/open/floor,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "cGZ" = (
 /turf/open/mars_cave{
@@ -27681,6 +28258,12 @@
 	icon_state = "mars_cave_20"
 	},
 /area/bigredv2/caves_north)
+"cKu" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor{
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 "cLZ" = (
 /obj/structure/closet/secure_closet/brig,
 /obj/effect/landmark/objective_landmark/close,
@@ -27688,12 +28271,31 @@
 	icon_state = "dark"
 	},
 /area/bigredv2/outside/marshal_office)
+"cNb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/machinery/light{
+	dir = 1
+	},
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/bigredv2/outside/engineering)
 "cNH" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor{
 	icon_state = "delivery"
 	},
 /area/bigredv2/outside/bar)
+"cOa" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/crap_item,
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/bigredv2/outside/engineering)
 "cOl" = (
 /turf/open/mars_cave{
 	icon_state = "mars_cave_18"
@@ -27799,6 +28401,12 @@
 /obj/effect/landmark/objective_landmark/medium,
 /turf/open/floor/plating,
 /area/bigredv2/caves/mining)
+"cZB" = (
+/obj/structure/pipes/standard/manifold/hidden/green,
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/bigredv2/outside/engineering)
 "daf" = (
 /obj/effect/landmark/crap_item,
 /turf/open/mars_cave{
@@ -27835,6 +28443,14 @@
 	icon_state = "delivery"
 	},
 /area/bigredv2/outside/c)
+"dhN" = (
+/obj/structure/window/framed/solaris,
+/obj/structure/machinery/door/poddoor/almayer{
+	id = "rad_door";
+	name = "\improper Radiation Shielding"
+	},
+/turf/open/floor/plating,
+/area/bigredv2/outside/engineering)
 "dhS" = (
 /obj/structure/machinery/light/small{
 	dir = 4
@@ -27926,6 +28542,19 @@
 	icon_state = "platingdmg3"
 	},
 /area/bigredv2/caves/mining)
+"dsm" = (
+/obj/item/stack/sheet/metal,
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/bigredv2/outside/engineering)
+"dsy" = (
+/obj/structure/platform,
+/obj/structure/platform{
+	dir = 8
+	},
+/turf/open/gm/river,
+/area/bigredv2/outside/engineering)
 "dtf" = (
 /obj/structure/prop/server_equipment/broken,
 /turf/open/floor{
@@ -27947,6 +28576,12 @@
 /obj/effect/landmark/corpsespawner/colonist/burst,
 /turf/open/floor/plating,
 /area/bigredv2/caves/mining)
+"duA" = (
+/obj/structure/platform{
+	dir = 1
+	},
+/turf/open/gm/river,
+/area/bigredv2/outside/engineering)
 "dvB" = (
 /obj/item/ore/coal{
 	pixel_x = 9;
@@ -27959,10 +28594,10 @@
 /area/bigredv2/caves/mining)
 "dvC" = (
 /obj/structure/pipes/standard/simple/hidden/green,
-/turf/open/floor{
-	icon_state = "delivery"
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
 	},
-/area/bigredv2/outside/filtration_plant)
+/area/bigredv2/outside/engineering)
 "dwL" = (
 /obj/structure/bed/chair{
 	buckling_y = 5;
@@ -27991,6 +28626,16 @@
 "dyv" = (
 /turf/open/mars,
 /area/bigredv2/caves/eta/xenobiology)
+"dyH" = (
+/obj/structure/machinery/computer/area_atmos{
+	dir = 1
+	},
+/obj/structure/surface/table,
+/turf/open/floor{
+	dir = 6;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 "dzY" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor{
@@ -28035,6 +28680,17 @@
 	icon_state = "platingdmg3"
 	},
 /area/bigredv2/caves/mining)
+"dBU" = (
+/obj/structure/barricade/handrail{
+	dir = 1;
+	layer = 3.01;
+	pixel_y = 9
+	},
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 "dCb" = (
 /obj/effect/landmark/corpsespawner/security/marshal,
 /obj/effect/decal/cleanable/blood/oil,
@@ -28227,6 +28883,12 @@
 	icon_state = "mars_cave_23"
 	},
 /area/bigredv2/caves/mining)
+"dQw" = (
+/obj/structure/blocker/forcefield/multitile_vehicles,
+/turf/open/mars_cave{
+	icon_state = "mars_cave_5"
+	},
+/area/bigredv2/caves_sw)
 "dQF" = (
 /obj/effect/spawner/random/tool,
 /turf/open/mars_cave{
@@ -28234,16 +28896,13 @@
 	},
 /area/bigredv2/caves/mining)
 "dQZ" = (
-/obj/structure/machinery/door/airlock/almayer/engineering/colony{
-	name = "\improper Engine Reactor Control"
-	},
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 4
-	},
+/obj/structure/closet/toolcloset,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor{
-	icon_state = "delivery"
+	dir = 5;
+	icon_state = "darkyellow2"
 	},
-/area/bigredv2/outside/engineering)
+/area/bigredv2/outside/filtration_plant)
 "dSg" = (
 /obj/effect/landmark/crap_item,
 /obj/effect/decal/cleanable/dirt,
@@ -28273,6 +28932,14 @@
 	icon_state = "mars_cave_5"
 	},
 /area/bigredv2/outside/lz2_south_cas)
+"dWd" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 5
+	},
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/bigredv2/outside/engineering)
 "dWg" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/mars{
@@ -28281,7 +28948,10 @@
 /area/bigredv2/outside/c)
 "dWl" = (
 /obj/structure/closet/toolcloset,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 9;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "dXs" = (
 /obj/item/tool/pickaxe{
@@ -28325,6 +28995,13 @@
 	icon_state = "platingdmg3"
 	},
 /area/bigredv2/caves/mining)
+"ebr" = (
+/obj/structure/pipes/standard/simple/hidden/green,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellowcorners2"
+	},
+/area/bigredv2/outside/engineering)
 "ebZ" = (
 /turf/open/floor{
 	icon_state = "darkgreencorners2"
@@ -28375,6 +29052,14 @@
 	icon_state = "mars_dirt_6"
 	},
 /area/bigredv2/caves/mining)
+"egL" = (
+/obj/structure/surface/table,
+/obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
+/turf/open/floor{
+	dir = 10;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 "egS" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
@@ -28548,6 +29233,13 @@
 	icon_state = "mars_cave_2"
 	},
 /area/bigredv2/caves/mining)
+"ewv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/curtain/red,
+/turf/open/floor{
+	icon_state = "freezerfloor"
+	},
+/area/bigredv2/outside/engineering)
 "exc" = (
 /turf/open/floor{
 	dir = 4;
@@ -28635,10 +29327,9 @@
 	},
 /area/bigredv2/caves_sw)
 "eGM" = (
-/obj/structure/surface/table,
-/obj/item/device/lightreplacer,
-/obj/structure/pipes/standard/manifold/hidden/green,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "darkyellowcorners2"
+	},
 /area/bigredv2/outside/engineering)
 "eHA" = (
 /obj/structure/pipes/standard/simple/hidden/green,
@@ -28646,6 +29337,14 @@
 	icon_state = "dark"
 	},
 /area/bigredv2/caves/eta/xenobiology)
+"eIN" = (
+/obj/structure/machinery/power/port_gen/pacman,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 "eJE" = (
 /turf/open/floor{
 	dir = 4;
@@ -28670,7 +29369,10 @@
 	pixel_x = 30;
 	throw_range = 15
 	},
-/turf/open/floor,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "eLp" = (
 /obj/structure/closet/secure_closet/brig,
@@ -28738,6 +29440,13 @@
 	},
 /turf/closed/wall/solaris,
 /area/bigredv2/outside/dorms)
+"eSm" = (
+/obj/structure/pipes/standard/simple/hidden/green,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 "eSu" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
 /turf/open/mars_cave{
@@ -28883,8 +29592,13 @@
 /area/bigredv2/caves/lambda/research)
 "fgE" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/static_comms/net_two,
-/turf/open/floor,
+/obj/effect/decal/remains/human,
+/obj/effect/landmark/static_comms/net_two{
+	broken_on_spawn = 1
+	},
+/turf/open/floor{
+	icon_state = "podhatchfloor"
+	},
 /area/bigredv2/outside/engineering)
 "fhy" = (
 /obj/structure/bed/chair/comfy/blue{
@@ -29085,6 +29799,11 @@
 /obj/structure/pipes/standard/tank/phoron,
 /turf/open/floor/plating,
 /area/bigredv2/caves/mining)
+"fBo" = (
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/bigredv2/outside/filtration_plant)
 "fCb" = (
 /turf/open/floor,
 /area/bigredv2/outside/filtration_cave_cas)
@@ -29094,6 +29813,14 @@
 	icon_state = "darkred2"
 	},
 /area/bigredv2/caves/eta/research)
+"fEv" = (
+/obj/structure/machinery/door/airlock/almayer/secure/colony{
+	name = "\improper Engine Reactor"
+	},
+/turf/open/floor{
+	icon_state = "delivery"
+	},
+/area/bigredv2/outside/engineering)
 "fFG" = (
 /obj/structure/largecrate/random/barrel,
 /turf/open/mars_cave{
@@ -29141,6 +29868,12 @@
 	icon_state = "mars_cave_6"
 	},
 /area/bigredv2/caves_virology)
+"fLl" = (
+/turf/open/floor{
+	dir = 5;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 "fLA" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_door,
@@ -29221,7 +29954,10 @@
 /obj/structure/surface/table,
 /obj/effect/spawner/random/toolbox,
 /obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "fOM" = (
 /obj/effect/decal/warning_stripes{
@@ -29295,12 +30031,31 @@
 	icon_state = "asteroidwarning"
 	},
 /area/bigredv2/outside/filtration_plant)
+"fUp" = (
+/obj/structure/machinery/door/airlock/almayer/secure/colony{
+	dir = 1;
+	name = "\improper Engine Reactor"
+	},
+/turf/open/floor{
+	icon_state = "delivery"
+	},
+/area/bigredv2/outside/engineering)
 "fWw" = (
 /turf/open/jungle{
 	bushes_spawn = 0;
 	icon_state = "grass_impenetrable"
 	},
 /area/bigredv2/caves/eta/xenobiology)
+"fXm" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "E";
+	pixel_x = 1
+	},
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 "fYH" = (
 /turf/closed/wall/solaris/reinforced/hull,
 /area/bigredv2/caves/mining)
@@ -29330,8 +30085,8 @@
 	},
 /area/bigredv2/outside/eta)
 "gad" = (
-/turf/open/floor{
-	icon_state = "delivery"
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
 	},
 /area/bigredv2/outside/filtration_plant)
 "gan" = (
@@ -29354,6 +30109,12 @@
 "gda" = (
 /turf/open/mars_cave,
 /area/bigredv2/outside/lz1_telecomm_cas)
+"gdx" = (
+/turf/open/floor{
+	dir = 6;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 "gdN" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
 /turf/open/mars,
@@ -29363,6 +30124,14 @@
 	icon_state = "mars_dirt_6"
 	},
 /area/bigredv2/outside/lz1_north_cas)
+"gfX" = (
+/obj/structure/sign/safety/hazard{
+	pixel_y = -32
+	},
+/turf/open/floor{
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 "ggC" = (
 /obj/structure/surface/rack,
 /obj/effect/landmark/good_item,
@@ -29381,6 +30150,10 @@
 "gio" = (
 /turf/open/mars_cave,
 /area/bigredv2/outside/filtration_cave_cas)
+"giB" = (
+/obj/structure/blocker/forcefield/multitile_vehicles,
+/turf/open/mars_cave,
+/area/bigredv2/caves_sw)
 "giY" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
@@ -29420,6 +30193,15 @@
 /obj/structure/blocker/forcefield/multitile_vehicles,
 /turf/closed/wall/solaris/reinforced,
 /area/bigredv2/outside/lz2_south_cas)
+"gmm" = (
+/obj/structure/window/framed/solaris,
+/obj/effect/decal/cleanable/molten_item,
+/obj/structure/machinery/door/poddoor/almayer{
+	id = "rad_door";
+	name = "\improper Radiation Shielding"
+	},
+/turf/open/floor/plating,
+/area/bigredv2/outside/engineering)
 "gmN" = (
 /turf/open/mars_cave{
 	icon_state = "mars_cave_18"
@@ -29493,6 +30275,12 @@
 "gtX" = (
 /turf/open/mars_cave,
 /area/bigredv2/caves_se)
+"guu" = (
+/obj/structure/machinery/light,
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/bigredv2/outside/engineering)
 "guM" = (
 /turf/open/mars_cave{
 	icon_state = "mars_dirt_4"
@@ -29520,6 +30308,13 @@
 	icon_state = "elevatorshaft"
 	},
 /area/bigredv2/caves/lambda/breakroom)
+"gwg" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 "gxJ" = (
 /turf/open/mars_cave{
 	icon_state = "mars_cave_18"
@@ -29568,7 +30363,10 @@
 "gCx" = (
 /obj/structure/surface/table,
 /obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "gCC" = (
 /obj/structure/closet/secure_closet,
@@ -29596,6 +30394,13 @@
 	icon_state = "mars_cave_2"
 	},
 /area/bigredv2/caves_east)
+"gFR" = (
+/obj/structure/machinery/power/port_gen/pacman,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 "gGO" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating{
@@ -29609,6 +30414,13 @@
 	icon_state = "mars_cave_2"
 	},
 /area/bigredv2/caves/mining)
+"gHV" = (
+/obj/structure/surface/table,
+/turf/open/floor{
+	dir = 6;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 "gJw" = (
 /obj/structure/blocker/forcefield/multitile_vehicles,
 /turf/open/mars_cave,
@@ -29619,6 +30431,13 @@
 	icon_state = "mars_cave_4"
 	},
 /area/bigredv2/caves_virology)
+"gML" = (
+/obj/structure/machinery/power/turbine,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 "gNz" = (
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_door,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
@@ -29640,6 +30459,15 @@
 	icon_state = "mars_cave_2"
 	},
 /area/bigredv2/caves_research)
+"gPh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/machinery/door/airlock/almayer/secure/colony{
+	name = "\improper Engine Reactor"
+	},
+/turf/open/floor{
+	icon_state = "delivery"
+	},
+/area/bigredv2/outside/engineering)
 "gPE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/device/flashlight/lantern,
@@ -29683,6 +30511,28 @@
 	icon_state = "platingdmg3"
 	},
 /area/bigredv2/caves/mining)
+"gUD" = (
+/obj/structure/barricade/handrail{
+	dir = 1;
+	layer = 3.01;
+	pixel_y = 9
+	},
+/turf/open/floor{
+	dir = 9;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
+"gVl" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "NE-out";
+	pixel_x = 1;
+	pixel_y = 1
+	},
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellowcorners2"
+	},
+/area/bigredv2/outside/engineering)
 "gVm" = (
 /turf/open/floor{
 	dir = 6;
@@ -29726,12 +30576,50 @@
 	icon_state = "mars_cave_2"
 	},
 /area/bigredv2/caves_sw)
+"gZc" = (
+/obj/structure/machinery/light{
+	dir = 8
+	},
+/obj/structure/sign/safety/high_rad{
+	pixel_x = -32
+	},
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
+"haT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/filtration_plant)
 "hcb" = (
 /obj/effect/landmark/hunter_secondary,
 /turf/open/mars_cave{
 	icon_state = "mars_cave_2"
 	},
 /area/bigredv2/outside/lz1_telecomm_cas)
+"hcH" = (
+/obj/structure/surface/table,
+/obj/effect/spawner/random/tool,
+/obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
+"hdc" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 "heG" = (
 /obj/structure/bed/chair{
 	can_buckle = 0;
@@ -29776,6 +30664,12 @@
 	icon_state = "mars_dirt_7"
 	},
 /area/bigredv2/outside/lz1_north_cas)
+"hhK" = (
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 "hiP" = (
 /obj/structure/sign/safety/one{
 	pixel_x = 16
@@ -29874,7 +30768,9 @@
 "hsF" = (
 /obj/structure/closet/firecloset/full,
 /obj/effect/landmark/objective_landmark/close,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "hsJ" = (
 /obj/item/ore,
@@ -30126,6 +31022,18 @@
 	icon_state = "mars_cave_15"
 	},
 /area/bigredv2/caves/mining)
+"hYB" = (
+/obj/structure/platform{
+	dir = 1
+	},
+/obj/structure/platform{
+	dir = 8
+	},
+/obj/structure/platform_decoration{
+	dir = 5
+	},
+/turf/open/gm/river,
+/area/bigredv2/outside/engineering)
 "hYI" = (
 /obj/effect/landmark/xeno_hive_spawn,
 /obj/effect/landmark/ert_spawns/groundside_xeno,
@@ -30161,6 +31069,10 @@
 	},
 /turf/open/floor,
 /area/bigredv2/outside/cargo)
+"iaC" = (
+/obj/structure/platform,
+/turf/open/gm/river,
+/area/bigredv2/outside/engineering)
 "iaN" = (
 /obj/structure/largecrate/random/barrel/red,
 /obj/effect/decal/cleanable/dirt,
@@ -30186,6 +31098,13 @@
 	icon_state = "mars_cave_6"
 	},
 /area/bigredv2/caves_sw)
+"idM" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 "iep" = (
 /obj/structure/surface/rack,
 /obj/item/clothing/head/hardhat/dblue{
@@ -30254,6 +31173,11 @@
 	icon_state = "mars_dirt_7"
 	},
 /area/bigredv2/outside/eta)
+"iig" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/framed/solaris,
+/turf/open/floor/plating,
+/area/bigredv2/outside/engineering)
 "ijU" = (
 /obj/structure/prop/almayer/cannon_cables{
 	name = "\improper Cables"
@@ -30387,13 +31311,24 @@
 "iyd" = (
 /obj/structure/machinery/computer/general_air_control,
 /obj/structure/surface/table,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "iyY" = (
 /turf/open/mars_cave{
 	icon_state = "mars_cave_13"
 	},
 /area/bigredv2/outside/lz1_north_cas)
+"izb" = (
+/obj/structure/surface/table,
+/obj/effect/spawner/random/tool,
+/obj/effect/spawner/random/technology_scanner,
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/bigredv2/outside/engineering)
 "izh" = (
 /turf/open/mars_cave{
 	icon_state = "mars_cave_2"
@@ -30422,6 +31357,12 @@
 	icon_state = "mars_cave_11"
 	},
 /area/bigredv2/caves_sw)
+"iAI" = (
+/obj/structure/platform{
+	dir = 8
+	},
+/turf/open/gm/river,
+/area/bigredv2/outside/engineering)
 "iDJ" = (
 /obj/effect/landmark/corpsespawner/miner,
 /obj/effect/decal/cleanable/blood{
@@ -30471,6 +31412,14 @@
 	icon_state = "platingdmg3"
 	},
 /area/bigredv2/caves/mining)
+"iFa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/bananapeel,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 "iGK" = (
 /turf/open/mars_cave,
 /area/bigredv2/caves_sw)
@@ -30511,10 +31460,8 @@
 	},
 /area/bigredv2/caves/mining)
 "iNR" = (
-/turf/open/mars_cave{
-	icon_state = "mars_cave_20"
-	},
-/area/bigredv2/caves_sw)
+/turf/open/gm/river,
+/area/bigredv2/outside/engineering)
 "iOL" = (
 /obj/effect/landmark/crap_item,
 /turf/open/mars_cave{
@@ -30534,12 +31481,10 @@
 /turf/open/gm/river,
 /area/bigredv2/outside/filtration_plant)
 "iQC" = (
-/obj/structure/surface/table,
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 4
+/obj/effect/landmark/crap_item,
+/turf/open/floor{
+	icon_state = "dark"
 	},
-/obj/item/clothing/head/welding,
-/turf/open/floor,
 /area/bigredv2/outside/engineering)
 "iQG" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
@@ -30569,6 +31514,15 @@
 	icon_state = "mars_cave_2"
 	},
 /area/bigredv2/caves_research)
+"iSz" = (
+/obj/structure/barricade/handrail{
+	dir = 1;
+	layer = 3.01;
+	pixel_y = 9
+	},
+/obj/structure/barricade/handrail,
+/turf/open/floor/plating/plating_catwalk,
+/area/bigredv2/outside/engineering)
 "iUe" = (
 /turf/open/floor{
 	dir = 6;
@@ -30869,6 +31823,19 @@
 	icon_state = "bcircuitoff"
 	},
 /area/bigredv2/caves/lambda/research)
+"jxA" = (
+/obj/structure/barricade/handrail,
+/turf/open/floor/plating/plating_catwalk,
+/area/bigredv2/outside/engineering)
+"jxS" = (
+/obj/structure/machinery/light{
+	dir = 4
+	},
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 "jzD" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
 /turf/open/floor{
@@ -30894,6 +31861,11 @@
 	icon_state = "mars_cave_5"
 	},
 /area/bigredv2/caves_sw)
+"jAJ" = (
+/turf/open/floor{
+	icon_state = "podhatchfloor"
+	},
+/area/bigredv2/outside/engineering)
 "jAN" = (
 /obj/item/tool/pickaxe,
 /turf/open/mars_cave{
@@ -30949,6 +31921,14 @@
 	},
 /turf/open/floor/plating,
 /area/bigredv2/caves/mining)
+"jDT" = (
+/obj/structure/surface/table,
+/obj/effect/spawner/random/technology_scanner,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 "jEx" = (
 /obj/structure/machinery/power/port_gen/pacman/super,
 /turf/open/mars_cave{
@@ -31036,6 +32016,16 @@
 	icon_state = "mars_cave_2"
 	},
 /area/bigredv2/caves_sw)
+"jMn" = (
+/obj/structure/machinery/light{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/ash,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 "jOc" = (
 /obj/structure/machinery/door/poddoor/almayer/closed{
 	dir = 4;
@@ -31119,6 +32109,21 @@
 	icon_state = "platingdmg3"
 	},
 /area/bigredv2/caves/mining)
+"jRn" = (
+/obj/structure/machinery/computer3/server,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/filtration_plant)
+"jTk" = (
+/obj/structure/surface/table,
+/obj/effect/decal/cleanable/molten_item,
+/turf/open/floor{
+	dir = 10;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 "jUc" = (
 /obj/structure/surface/table,
 /obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
@@ -31199,6 +32204,25 @@
 	icon_state = "mars_cave_13"
 	},
 /area/bigredv2/caves/mining)
+"jXf" = (
+/obj/structure/pipes/standard/manifold/hidden/green{
+	dir = 4
+	},
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
+"jXJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/machinery/light_construct{
+	dir = 8
+	},
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 "jXP" = (
 /obj/item/stack/cable_coil/cut,
 /turf/open/mars_cave{
@@ -31220,7 +32244,9 @@
 /area/bigredv2/caves/mining)
 "jYF" = (
 /obj/structure/machinery/recharge_station,
-/turf/open/floor,
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
 /area/bigredv2/outside/engineering)
 "jYS" = (
 /obj/effect/decal/cleanable/blood,
@@ -31415,6 +32441,15 @@
 	icon_state = "mars_dirt_6"
 	},
 /area/bigredv2/caves/mining)
+"kka" = (
+/obj/structure/barricade/handrail,
+/obj/structure/barricade/handrail{
+	dir = 1;
+	layer = 3.01;
+	pixel_y = 9
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/bigredv2/outside/engineering)
 "kli" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
 /turf/open/mars_cave{
@@ -31448,6 +32483,12 @@
 	icon_state = "delivery"
 	},
 /area/bigredv2/outside/admin_building)
+"kmx" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor{
+	icon_state = "darkyellowcorners2"
+	},
+/area/bigredv2/outside/engineering)
 "knN" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
@@ -31490,6 +32531,13 @@
 /obj/effect/decal/cleanable/blood/writing,
 /turf/open/floor/plating,
 /area/bigredv2/caves/mining)
+"ksO" = (
+/obj/structure/pipes/standard/simple/hidden/green,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/bigredv2/outside/engineering)
 "ktE" = (
 /obj/item/tool/wrench{
 	pixel_x = -7;
@@ -31507,6 +32555,13 @@
 	icon_state = "mars_cave_17"
 	},
 /area/bigredv2/outside/filtration_plant)
+"ktY" = (
+/obj/effect/landmark/survivor_spawner,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 "kuu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/trash/cigbutt,
@@ -31675,6 +32730,13 @@
 	icon_state = "mars_cave_2"
 	},
 /area/bigredv2/caves_research)
+"kNK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/pipes/standard/simple/hidden/green,
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/bigredv2/outside/engineering)
 "kNP" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 9
@@ -31758,10 +32820,10 @@
 	},
 /area/bigredv2/outside/filtration_cave_cas)
 "kVT" = (
-/obj/structure/flora/pottedplant{
-	icon_state = "pottedplant_21"
+/turf/open/floor{
+	dir = 10;
+	icon_state = "darkyellow2"
 	},
-/turf/open/floor,
 /area/bigredv2/outside/engineering)
 "kVY" = (
 /obj/structure/surface/rack,
@@ -31808,6 +32870,13 @@
 	},
 /turf/open/floor/plating,
 /area/bigredv2/caves/mining)
+"lck" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 "lcu" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/clothing/mask/cigarette,
@@ -31866,6 +32935,13 @@
 	},
 /turf/open/floor,
 /area/bigredv2/outside/lz2_south_cas)
+"lmi" = (
+/obj/structure/closet/toolcloset,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 "lms" = (
 /turf/open/floor{
 	dir = 6;
@@ -31885,6 +32961,16 @@
 	icon_state = "mars_cave_3"
 	},
 /area/bigredv2/caves/mining)
+"lqo" = (
+/obj/item/tool/lighter/random,
+/obj/structure/pipes/vents/pump{
+	dir = 4
+	},
+/obj/structure/surface/table,
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/bigredv2/outside/engineering)
 "lrH" = (
 /obj/effect/landmark/crap_item,
 /turf/open/mars_cave{
@@ -32036,6 +33122,14 @@
 	icon_state = "redfull"
 	},
 /area/bigredv2/caves/eta/research)
+"lEi" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/bigredv2/outside/engineering)
 "lEw" = (
 /obj/item/tool/pickaxe{
 	pixel_y = -3
@@ -32181,6 +33275,23 @@
 	icon_state = "asteroidwarning"
 	},
 /area/bigredv2/outside/filtration_cave_cas)
+"lTi" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 1
+	},
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/filtration_plant)
+"lTM" = (
+/obj/item/folder/yellow,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellowcorners2"
+	},
+/area/bigredv2/outside/engineering)
 "lUd" = (
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_door,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
@@ -32234,6 +33345,12 @@
 	icon_state = "platingdmg2"
 	},
 /area/bigredv2/caves/mining)
+"lYH" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor{
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/filtration_plant)
 "lYZ" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 8
@@ -32246,8 +33363,8 @@
 	},
 /area/bigredv2/caves/mining)
 "maD" = (
-/turf/open/floor{
-	icon_state = "delivery"
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
 	},
 /area/bigredv2/outside/engineering)
 "maF" = (
@@ -32256,6 +33373,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/bigredv2/caves/mining)
+"maH" = (
+/obj/structure/surface/table,
+/obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 "mdU" = (
 /obj/structure/machinery/power/apc{
 	dir = 1;
@@ -32294,6 +33419,21 @@
 	},
 /turf/closed/wall/solaris/reinforced/hull,
 /area/bigredv2/caves/mining)
+"mhZ" = (
+/obj/structure/machinery/portable_atmospherics/canister/air,
+/turf/open/floor{
+	dir = 5;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
+"mij" = (
+/obj/item/folder/yellow,
+/obj/effect/landmark/crap_item,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 "miD" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/landmark/corpsespawner/security/marshal,
@@ -32308,6 +33448,13 @@
 	},
 /turf/open/floor,
 /area/bigred/ground/garage_workshop)
+"mlV" = (
+/obj/structure/surface/table,
+/obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/bigredv2/outside/engineering)
 "mmg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/drip{
@@ -32338,6 +33485,12 @@
 	icon_state = "platingdmg3"
 	},
 /area/bigredv2/caves/mining)
+"mqh" = (
+/obj/structure/window/framed/solaris,
+/turf/open/floor{
+	icon_state = "panelscorched"
+	},
+/area/bigredv2/outside/engineering)
 "mqX" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
 /turf/open/mars_cave{
@@ -32563,6 +33716,14 @@
 	icon_state = "mars_cave_2"
 	},
 /area/bigredv2/caves/mining)
+"mPK" = (
+/obj/effect/decal/cleanable/liquid_fuel,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 "mRi" = (
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_core,
 /turf/open/mars_cave{
@@ -32581,6 +33742,12 @@
 	icon_state = "asteroidwarning"
 	},
 /area/bigredv2/outside/c)
+"mSS" = (
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkyellowcorners2"
+	},
+/area/bigredv2/outside/engineering)
 "mST" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "SE-out";
@@ -32678,6 +33845,12 @@
 	icon_state = "mars_dirt_4"
 	},
 /area/bigredv2/caves/mining)
+"ndw" = (
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellowcorners2"
+	},
+/area/bigredv2/outside/engineering)
 "ndy" = (
 /obj/effect/decal/cleanable/blood/drip{
 	pixel_x = -3;
@@ -32699,6 +33872,15 @@
 	icon_state = "mars_dirt_6"
 	},
 /area/bigredv2/caves/mining)
+"niQ" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 6
+	},
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkyellowcorners2"
+	},
+/area/bigredv2/outside/engineering)
 "njf" = (
 /turf/open/mars_cave{
 	icon_state = "mars_dirt_6"
@@ -32734,6 +33916,12 @@
 	icon_state = "mars_dirt_6"
 	},
 /area/bigredv2/caves/mining)
+"nlJ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor{
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/filtration_plant)
 "nlW" = (
 /obj/structure/platform/kutjevo/rock,
 /obj/structure/platform/kutjevo/rock{
@@ -32742,6 +33930,13 @@
 /obj/structure/platform_decoration/kutjevo/rock,
 /turf/open/mars,
 /area/space)
+"nmU" = (
+/obj/structure/surface/table,
+/obj/item/device/analyzer,
+/turf/open/floor{
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 "nny" = (
 /turf/open/mars_cave{
 	icon_state = "mars_dirt_7"
@@ -32754,6 +33949,23 @@
 	icon_state = "asteroidfloor"
 	},
 /area/bigredv2/outside/e)
+"nnU" = (
+/obj/structure/machinery/door_control{
+	desc = "A remote control-switch for opening the engines blast doors.";
+	id = "rad_door";
+	name = "Reactor Radiation Shielding control";
+	pixel_x = 30;
+	req_access_txt = "7"
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 1
+	},
+/turf/open/floor{
+	dir = 5;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 "npz" = (
 /obj/structure/surface/table,
 /obj/item/spacecash/c100,
@@ -32811,6 +34023,18 @@
 	icon_state = "platingdmg3"
 	},
 /area/bigredv2/caves/mining)
+"nug" = (
+/obj/structure/platform{
+	dir = 1
+	},
+/obj/structure/platform{
+	dir = 4
+	},
+/obj/structure/platform_decoration{
+	dir = 9
+	},
+/turf/open/gm/river,
+/area/bigredv2/outside/engineering)
 "nuw" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "NE-out";
@@ -32821,6 +34045,19 @@
 	icon_state = "dark"
 	},
 /area/bigredv2/outside/admin_building)
+"nuz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/handrail,
+/turf/open/floor{
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
+"nwB" = (
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/filtration_plant)
 "nwS" = (
 /obj/item/ore{
 	pixel_x = -7;
@@ -32838,6 +34075,13 @@
 	icon_state = "mars_cave_3"
 	},
 /area/bigredv2/caves/mining)
+"nzN" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 "nBb" = (
 /obj/item/ammo_magazine/pistol/b92fs,
 /obj/item/weapon/gun/pistol/b92fs{
@@ -32875,6 +34119,14 @@
 	icon_state = "mars_dirt_5"
 	},
 /area/bigredv2/outside/eta)
+"nEP" = (
+/obj/structure/surface/table,
+/obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkyellowcorners2"
+	},
+/area/bigredv2/outside/filtration_plant)
 "nEV" = (
 /obj/item/weapon/twohanded/folded_metal_chair{
 	pixel_x = -10;
@@ -32931,6 +34183,15 @@
 	icon_state = "delivery"
 	},
 /area/bigredv2/outside/filtration_cave_cas)
+"nIi" = (
+/obj/structure/machinery/door/airlock/almayer/secure/colony{
+	dir = 1;
+	name = "\improper Engine Reactor"
+	},
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/bigredv2/outside/engineering)
 "nKL" = (
 /obj/structure/prop/invuln/minecart_tracks{
 	desc = "An exchange valve";
@@ -32944,6 +34205,12 @@
 	icon_state = "platingdmg3"
 	},
 /area/bigredv2/caves/mining)
+"nLw" = (
+/obj/structure/blocker/forcefield/multitile_vehicles,
+/turf/open/mars_cave{
+	icon_state = "mars_dirt_4"
+	},
+/area/bigredv2/outside/sw)
 "nMB" = (
 /obj/structure/machinery/door_control{
 	id = "workshop_br_g";
@@ -32963,6 +34230,15 @@
 	icon_state = "platingdmg3"
 	},
 /area/bigredv2/caves/mining)
+"nPz" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 "nQl" = (
 /obj/item/ore{
 	pixel_x = -1;
@@ -33023,10 +34299,9 @@
 	},
 /area/bigredv2/outside/filtration_cave_cas)
 "nVq" = (
-/obj/structure/surface/table,
-/obj/item/clothing/glasses/welding,
-/obj/structure/pipes/vents/pump,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/engineering)
 "nVw" = (
 /turf/open/mars_cave{
@@ -33211,6 +34486,12 @@
 	icon_state = "mars_dirt_6"
 	},
 /area/bigredv2/outside/sw)
+"ojD" = (
+/obj/structure/platform_decoration{
+	dir = 4
+	},
+/turf/open/gm/river,
+/area/bigredv2/outside/engineering)
 "okh" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -33351,7 +34632,9 @@
 "orZ" = (
 /obj/structure/closet/secure_closet/atmos_personal,
 /obj/effect/landmark/objective_landmark/medium,
-/turf/open/floor,
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
 /area/bigredv2/outside/filtration_plant)
 "otb" = (
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_wall,
@@ -33368,6 +34651,13 @@
 	icon_state = "platingdmg3"
 	},
 /area/bigredv2/caves/mining)
+"ouh" = (
+/obj/item/tool/extinguisher,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 "ovq" = (
 /turf/open/floor{
 	icon_state = "delivery"
@@ -33491,6 +34781,16 @@
 	icon_state = "mars_cave_3"
 	},
 /area/bigredv2/caves/mining)
+"oIK" = (
+/obj/structure/platform,
+/obj/structure/platform{
+	dir = 4
+	},
+/obj/structure/platform_decoration{
+	dir = 6
+	},
+/turf/open/gm/river,
+/area/bigredv2/outside/engineering)
 "oJd" = (
 /obj/structure/prop/invuln/minecart_tracks{
 	desc = "A heavy duty power cable for high voltage applications";
@@ -33657,6 +34957,14 @@
 	icon_state = "darkblue2"
 	},
 /area/bigredv2/outside/admin_building)
+"oWp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/handrail,
+/turf/open/floor{
+	dir = 10;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 "oWC" = (
 /obj/structure/prop/invuln/minecart_tracks{
 	desc = "A heavy duty power cable for high voltage applications";
@@ -33807,6 +35115,13 @@
 	icon_state = "mars_cave_2"
 	},
 /area/bigredv2/caves/mining)
+"pgk" = (
+/obj/structure/machinery/portable_atmospherics/canister/air,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 "pgu" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W-corner"
@@ -33856,6 +35171,15 @@
 	icon_state = "mars_dirt_11"
 	},
 /area/bigredv2/caves_north)
+"pog" = (
+/obj/structure/platform{
+	dir = 1
+	},
+/obj/structure/platform{
+	dir = 8
+	},
+/turf/open/gm/river,
+/area/bigredv2/outside/engineering)
 "pow" = (
 /obj/structure/blocker/forcefield/multitile_vehicles,
 /turf/open/mars_cave{
@@ -33963,6 +35287,13 @@
 	icon_state = "dark"
 	},
 /area/bigredv2/outside/admin_building)
+"pBv" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor{
+	dir = 10;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/filtration_plant)
 "pBD" = (
 /turf/open/floor{
 	dir = 4;
@@ -34037,12 +35368,28 @@
 	icon_state = "mars_cave_14"
 	},
 /area/bigredv2/caves/mining)
+"pKP" = (
+/obj/structure/surface/table,
+/obj/effect/spawner/random/tool,
+/obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 "pLj" = (
 /obj/structure/largecrate/random/barrel/red,
 /turf/open/mars_cave{
 	icon_state = "mars_cave_19"
 	},
 /area/bigredv2/caves/mining)
+"pMi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/tool/extinguisher,
+/turf/open/floor{
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 "pMm" = (
 /turf/open/floor{
 	dir = 8;
@@ -34076,12 +35423,28 @@
 	icon_state = "wood"
 	},
 /area/bigredv2/outside/admin_building)
+"pOg" = (
+/obj/structure/machinery/compressor{
+	dir = 1
+	},
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 "pOL" = (
 /obj/structure/closet/crate/miningcar/yellow,
 /turf/open/mars_cave{
 	icon_state = "mars_dirt_4"
 	},
 /area/bigredv2/caves/mining)
+"pPo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/pipes/standard/simple/hidden/green,
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/bigredv2/outside/filtration_plant)
 "pQv" = (
 /obj/structure/surface/table,
 /obj/effect/landmark/objective_landmark/close,
@@ -34098,6 +35461,14 @@
 /obj/structure/blocker/forcefield/multitile_vehicles,
 /turf/open/mars_cave,
 /area/bigredv2/outside/lz1_telecomm_cas)
+"pRG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 "pRP" = (
 /turf/closed/wall/solaris/reinforced,
 /area/bigredv2/outside/telecomm/n_cave)
@@ -34137,6 +35508,16 @@
 	icon_state = "mars_cave_13"
 	},
 /area/bigredv2/caves/mining)
+"pVv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/machinery/compressor{
+	dir = 1
+	},
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 "pVP" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor{
@@ -34144,6 +35525,14 @@
 	icon_state = "asteroidfloor"
 	},
 /area/bigred/ground/garage_workshop)
+"pWs" = (
+/obj/structure/barricade/handrail{
+	dir = 1;
+	layer = 3.01;
+	pixel_y = 9
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/bigredv2/outside/engineering)
 "pXm" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
@@ -34241,7 +35630,10 @@
 /obj/structure/surface/table,
 /obj/effect/spawner/random/tool,
 /obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 5;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "qeX" = (
 /obj/structure/largecrate,
@@ -34395,6 +35787,13 @@
 	icon_state = "asteroidwarning"
 	},
 /area/bigredv2/outside/filtration_plant)
+"qqw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor{
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/filtration_plant)
 "qrZ" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/storage/firstaid/fire,
@@ -34541,6 +35940,20 @@
 	icon_state = "platingdmg3"
 	},
 /area/bigredv2/caves/mining)
+"qGY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/pipes/standard/simple/hidden/green,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
+"qHc" = (
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkyellowcorners2"
+	},
+/area/bigredv2/outside/filtration_plant)
 "qHY" = (
 /turf/open/mars_cave{
 	icon_state = "mars_cave_10"
@@ -34640,6 +36053,15 @@
 	icon_state = "dark"
 	},
 /area/bigredv2/caves/eta/xenobiology)
+"qUF" = (
+/obj/structure/machinery/computer/area_atmos{
+	dir = 1
+	},
+/obj/structure/surface/table,
+/turf/open/floor{
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 "qUS" = (
 /turf/open/mars_cave{
 	icon_state = "mars_dirt_6"
@@ -34743,6 +36165,13 @@
 	icon_state = "mars_cave_16"
 	},
 /area/bigredv2/caves_research)
+"rdr" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 "rdR" = (
 /turf/open/floor,
 /area/bigredv2/outside/lz2_south_cas)
@@ -34793,6 +36222,18 @@
 	icon_state = "warnplate"
 	},
 /area/bigredv2/outside/telecomm/warehouse)
+"rhP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/warning_stripes{
+	icon_state = "NW-out";
+	pixel_x = -1;
+	pixel_y = 1
+	},
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkyellowcorners2"
+	},
+/area/bigredv2/outside/engineering)
 "rie" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/item/stack/cable_coil/cut{
@@ -34830,6 +36271,12 @@
 "rnc" = (
 /turf/open/mars_cave,
 /area/bigredv2/caves_research)
+"rnV" = (
+/obj/item/stack/sheet/glass,
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/bigredv2/outside/engineering)
 "row" = (
 /turf/open/floor{
 	dir = 8;
@@ -34934,6 +36381,12 @@
 	icon_state = "mars_dirt_6"
 	},
 /area/bigredv2/caves/mining)
+"rvS" = (
+/obj/structure/blocker/forcefield/multitile_vehicles,
+/turf/open/mars_cave{
+	icon_state = "mars_cave_2"
+	},
+/area/bigredv2/caves_sw)
 "rxh" = (
 /turf/open/mars_cave{
 	icon_state = "mars_cave_2"
@@ -34945,6 +36398,12 @@
 	icon_state = "mars_cave_23"
 	},
 /area/bigredv2/caves_east)
+"rzb" = (
+/obj/structure/bed/chair,
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/bigredv2/outside/engineering)
 "rzO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/reagent_dispensers/water_cooler/stacks{
@@ -35194,6 +36653,12 @@
 	},
 /turf/open/floor/plating,
 /area/bigredv2/caves/mining)
+"rUN" = (
+/obj/structure/platform{
+	dir = 4
+	},
+/turf/open/gm/river,
+/area/bigredv2/outside/engineering)
 "rUZ" = (
 /obj/structure/machinery/light/small{
 	dir = 8
@@ -35249,6 +36714,13 @@
 	icon_state = "darkpurple2"
 	},
 /area/bigredv2/caves/lambda/research)
+"rYr" = (
+/obj/structure/surface/table,
+/obj/effect/decal/cleanable/ash,
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/bigredv2/outside/engineering)
 "rYt" = (
 /obj/effect/landmark/crap_item,
 /turf/open/mars_cave{
@@ -35276,6 +36748,23 @@
 	icon_state = "mars_cave_15"
 	},
 /area/bigredv2/caves/mining)
+"sap" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 1
+	},
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
+"saX" = (
+/obj/structure/machinery/power/turbine,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 "sbk" = (
 /obj/effect/landmark/corpsespawner/miner,
 /obj/effect/decal/cleanable/blood,
@@ -35374,11 +36863,17 @@
 	icon_state = "mars_dirt_5"
 	},
 /area/bigredv2/caves/mining)
-"slG" = (
-/obj/structure/pipes/vents/pump{
-	dir = 4
+"slC" = (
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkyellowcorners2"
 	},
-/turf/open/floor,
+/area/bigredv2/outside/engineering)
+"slG" = (
+/obj/structure/pipes/standard/simple/hidden/green,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/engineering)
 "smh" = (
 /obj/structure/blocker/forcefield/multitile_vehicles,
@@ -35411,6 +36906,15 @@
 	icon_state = "mars_cave_2"
 	},
 /area/bigredv2/outside/filtration_cave_cas)
+"snv" = (
+/obj/structure/machinery/light_construct{
+	dir = 4
+	},
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 "sog" = (
 /obj/item/explosive/grenade/slug/baton{
 	dir = 1;
@@ -35596,6 +37100,19 @@
 	icon_state = "mars_dirt_6"
 	},
 /area/bigredv2/caves/mining)
+"szy" = (
+/obj/structure/pipes/standard/simple/hidden/green,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkyellowcorners2"
+	},
+/area/bigredv2/outside/engineering)
+"sAG" = (
+/obj/effect/landmark/hunter_primary,
+/turf/open/mars_cave{
+	icon_state = "mars_cave_2"
+	},
+/area/bigredv2/caves_sw)
 "sAS" = (
 /obj/item/toy/prize/fireripley{
 	pixel_y = 19
@@ -35603,6 +37120,17 @@
 /obj/structure/surface/table/reinforced/prison,
 /turf/open/floor/plating,
 /area/bigredv2/caves/mining)
+"sBm" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/bigredv2/outside/engineering)
 "sBu" = (
 /obj/effect/landmark/hunter_secondary,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
@@ -35617,9 +37145,9 @@
 	},
 /area/bigredv2/caves/mining)
 "sCt" = (
-/obj/structure/closet/toolcloset,
-/obj/structure/machinery/light,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "sDs" = (
 /obj/structure/closet/crate/miningcar,
@@ -35639,6 +37167,20 @@
 	icon_state = "mars_cave_9"
 	},
 /area/bigredv2/caves_sw)
+"sDO" = (
+/obj/structure/machinery/power/port_gen/pacman,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
+"sDZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/head/welding,
+/turf/open/floor{
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 "sEi" = (
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_door,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
@@ -35716,6 +37258,12 @@
 /obj/structure/machinery/suit_storage_unit/carbon_unit,
 /turf/open/floor/plating,
 /area/bigredv2/outside/admin_building)
+"sNP" = (
+/obj/structure/window/framed/solaris,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/bigredv2/outside/engineering)
 "sNQ" = (
 /turf/open/mars_cave{
 	icon_state = "mars_cave_11"
@@ -35850,6 +37398,10 @@
 	icon_state = "mars_cave_3"
 	},
 /area/bigredv2/caves_research)
+"tcP" = (
+/obj/effect/decal/cleanable/dirt/greenglow,
+/turf/closed/wall/solaris/reinforced,
+/area/bigredv2/outside/engineering)
 "tdn" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 6
@@ -35875,6 +37427,14 @@
 	icon_state = "mars_cave_2"
 	},
 /area/bigredv2/caves_se)
+"tdN" = (
+/obj/structure/surface/table,
+/obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
+/turf/open/floor{
+	dir = 9;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 "tdZ" = (
 /obj/item/tool/pickaxe/drill,
 /obj/structure/machinery/light{
@@ -35965,6 +37525,17 @@
 	icon_state = "mars_dirt_4"
 	},
 /area/bigredv2/caves/mining)
+"tju" = (
+/obj/structure/machinery/shower{
+	dir = 8
+	},
+/obj/structure/machinery/light{
+	dir = 8
+	},
+/turf/open/floor{
+	icon_state = "freezerfloor"
+	},
+/area/bigredv2/outside/engineering)
 "tkN" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 5
@@ -36034,7 +37605,10 @@
 /obj/structure/surface/table,
 /obj/effect/spawner/random/tool,
 /obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "trW" = (
 /obj/item/clothing/suit/storage/hazardvest,
@@ -36086,6 +37660,15 @@
 	icon_state = "mars_cave_14"
 	},
 /area/bigredv2/outside/lz2_south_cas)
+"tub" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 5
+	},
+/turf/open/floor{
+	dir = 10;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 "tuu" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
@@ -36110,12 +37693,29 @@
 	icon_state = "asteroidwarning"
 	},
 /area/bigredv2/outside/lz2_south_cas)
+"tvH" = (
+/obj/structure/machinery/compressor{
+	dir = 1
+	},
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 "twS" = (
 /turf/open/floor{
 	dir = 1;
 	icon_state = "asteroidwarning"
 	},
 /area/bigredv2/outside/telecomm/lz2_cave)
+"tzJ" = (
+/obj/structure/machinery/door/airlock/almayer/engineering/colony{
+	name = "\improper Engine Reactor Control"
+	},
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/bigredv2/outside/engineering)
 "tAe" = (
 /obj/structure/bed,
 /obj/effect/landmark/objective_landmark/close,
@@ -36253,6 +37853,13 @@
 	icon_state = "mars_cave_7"
 	},
 /area/bigredv2/caves_lambda)
+"tIv" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/filtration_plant)
 "tIA" = (
 /obj/structure/surface/rack,
 /obj/effect/spawner/random/toolbox,
@@ -36282,6 +37889,15 @@
 	icon_state = "mars_dirt_4"
 	},
 /area/bigredv2/caves/mining)
+"tKr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/bigredv2/outside/filtration_plant)
 "tKC" = (
 /obj/structure/surface/table,
 /obj/item/reagent_container/food/drinks/cans/beer{
@@ -36394,9 +38010,10 @@
 	},
 /area/bigredv2/caves/lambda/research)
 "tTI" = (
-/obj/structure/surface/table,
-/obj/item/pizzabox,
-/turf/open/floor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/engineering)
 "tUL" = (
 /obj/effect/decal/cleanable/dirt,
@@ -36444,6 +38061,17 @@
 	icon_state = "darkpurple2"
 	},
 /area/bigredv2/caves/lambda/research)
+"uaS" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/obj/structure/machinery/door/airlock/almayer/engineering/colony{
+	name = "\improper Engine Reactor Control"
+	},
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/bigredv2/outside/engineering)
 "ubY" = (
 /obj/structure/barricade/wooden,
 /turf/open/mars_cave{
@@ -36458,6 +38086,13 @@
 	icon_state = "mars_cave_4"
 	},
 /area/bigredv2/caves_se)
+"ueL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/framed/solaris,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/bigredv2/outside/engineering)
 "ufu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/oil,
@@ -36581,6 +38216,14 @@
 	icon_state = "delivery"
 	},
 /area/bigredv2/outside/admin_building)
+"urn" = (
+/obj/structure/surface/table,
+/obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
+/turf/open/floor{
+	dir = 6;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/filtration_plant)
 "usg" = (
 /obj/item/tool/warning_cone,
 /turf/open/floor{
@@ -36657,6 +38300,14 @@
 	icon_state = "platingdmg3"
 	},
 /area/bigredv2/caves/mining)
+"uBi" = (
+/obj/structure/pipes/standard/manifold/hidden/green{
+	dir = 1
+	},
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/bigredv2/outside/engineering)
 "uCa" = (
 /obj/effect/landmark/corpsespawner/miner,
 /turf/open/floor/plating{
@@ -36677,6 +38328,12 @@
 	},
 /turf/closed/wall/wood,
 /area/bigredv2/caves/mining)
+"uDA" = (
+/obj/item/stack/sheet/glass,
+/turf/open/floor{
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 "uDI" = (
 /obj/structure/prop/invuln/minecart_tracks{
 	desc = "A pipe.";
@@ -36726,6 +38383,13 @@
 	icon_state = "mars_cave_15"
 	},
 /area/bigredv2/caves/mining)
+"uGs" = (
+/obj/structure/surface/table,
+/obj/effect/decal/cleanable/ash,
+/turf/open/floor{
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 "uGz" = (
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_wall,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
@@ -36761,6 +38425,15 @@
 	icon_state = "asteroidfloor"
 	},
 /area/bigred/ground/garage_workshop)
+"uJj" = (
+/obj/structure/machinery/light{
+	dir = 8
+	},
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 "uJu" = (
 /obj/item/robot_parts/robot_component/diagnosis_unit{
 	pixel_y = 15
@@ -36858,6 +38531,13 @@
 	icon_state = "mars_dirt_10"
 	},
 /area/bigredv2/outside/space_port_lz2)
+"uTO" = (
+/obj/structure/machinery/pipedispenser,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/filtration_plant)
 "uUV" = (
 /obj/structure/prop/server_equipment/yutani_server/broken,
 /turf/open/floor/greengrid,
@@ -36868,6 +38548,12 @@
 	icon_state = "asteroidwarning"
 	},
 /area/bigredv2/outside/filtration_cave_cas)
+"uVn" = (
+/obj/structure/blocker/forcefield/multitile_vehicles,
+/turf/open/mars_cave{
+	icon_state = "mars_cave_7"
+	},
+/area/bigredv2/caves_sw)
 "uWo" = (
 /obj/structure/pipes/standard/manifold/fourway/hidden/green,
 /obj/effect/decal/cleanable/dirt,
@@ -36891,6 +38577,13 @@
 	icon_state = "darkpurple2"
 	},
 /area/bigredv2/caves/lambda/research)
+"vbp" = (
+/obj/structure/pipes/standard/simple/hidden/green,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 "vcm" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
@@ -36918,6 +38611,17 @@
 	icon_state = "mars_cave_2"
 	},
 /area/bigredv2/caves/mining)
+"vdl" = (
+/obj/effect/decal/cleanable/liquid_fuel,
+/obj/effect/decal/warning_stripes{
+	icon_state = "W";
+	pixel_x = -1
+	},
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 "vdS" = (
 /obj/item/explosive/grenade/incendiary/molotov{
 	pixel_x = -10;
@@ -36967,6 +38671,14 @@
 	icon_state = "mars_cave_13"
 	},
 /area/bigredv2/caves/mining)
+"vin" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/bigredv2/outside/filtration_plant)
 "vis" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
@@ -37067,6 +38779,14 @@
 	icon_state = "wood"
 	},
 /area/bigredv2/outside/library)
+"voG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/handrail,
+/turf/open/floor{
+	dir = 6;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 "vpu" = (
 /obj/item/weapon/twohanded/folded_metal_chair,
 /turf/open/mars_cave{
@@ -37222,6 +38942,13 @@
 	icon_state = "platingdmg3"
 	},
 /area/bigredv2/caves/mining)
+"vCf" = (
+/obj/structure/surface/table,
+/obj/effect/spawner/random/toolbox,
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/bigredv2/outside/engineering)
 "vCU" = (
 /turf/open/mars_cave{
 	icon_state = "mars_cave_16"
@@ -37350,6 +39077,13 @@
 	icon_state = "mars_cave_2"
 	},
 /area/bigredv2/caves/mining)
+"vTt" = (
+/obj/structure/surface/table,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 "vVl" = (
 /obj/structure/machinery/door/airlock/almayer/generic{
 	name = "\improper Dormitories Toilet"
@@ -37359,6 +39093,15 @@
 	icon_state = "platingdmg3"
 	},
 /area/bigredv2/caves/mining)
+"vVz" = (
+/obj/structure/machinery/power/geothermal{
+	name = "Reactor Turbine";
+	power_generation_max = 100000
+	},
+/turf/open/floor{
+	icon_state = "delivery"
+	},
+/area/bigredv2/outside/engineering)
 "vVF" = (
 /obj/effect/decal/cleanable/blood/drip{
 	pixel_x = -5;
@@ -37371,6 +39114,12 @@
 "vVZ" = (
 /turf/closed/wall/solaris,
 /area/bigredv2/outside/filtration_cave_cas)
+"vWm" = (
+/obj/structure/surface/table,
+/turf/open/floor{
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 "vXp" = (
 /obj/structure/machinery/light{
 	dir = 8
@@ -37516,7 +39265,9 @@
 "whE" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/effect/landmark/objective_landmark/close,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/filtration_plant)
 "whZ" = (
 /obj/effect/decal/cleanable/blood/oil/streak,
@@ -37535,10 +39286,9 @@
 /area/bigred/ground/garage_workshop)
 "wiK" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/machinery/light{
-	dir = 1
+/turf/open/floor{
+	icon_state = "podhatchfloor"
 	},
-/turf/open/floor,
 /area/bigredv2/outside/engineering)
 "wjW" = (
 /obj/structure/platform/shiva{
@@ -37586,6 +39336,12 @@
 	icon_state = "mars_cave_19"
 	},
 /area/bigredv2/caves_north)
+"wpn" = (
+/obj/structure/closet/radiation,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
+/area/bigredv2/outside/engineering)
 "wpT" = (
 /obj/effect/landmark/lv624/xeno_tunnel,
 /turf/open/mars,
@@ -37621,7 +39377,16 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/pipes/standard/simple/hidden/green,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/bigredv2/outside/filtration_plant)
+"wtG" = (
+/obj/structure/machinery/computer3/server/rack,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "wtJ" = (
 /obj/effect/decal/cleanable/blood{
@@ -37666,20 +39431,34 @@
 	},
 /area/bigredv2/outside/virology)
 "wvK" = (
-/obj/structure/machinery/power/geothermal,
-/turf/open/floor/plating,
-/area/bigredv2/outside/admin_building)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/bigredv2/outside/filtration_plant)
 "wvR" = (
 /turf/open/floor{
 	icon_state = "delivery"
 	},
 /area/bigredv2/caves/lambda/virology)
+"wwT" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/solaris/reinforced,
+/area/bigredv2/outside/engineering)
 "wxo" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor{
 	icon_state = "asteroidwarning"
 	},
 /area/bigredv2/outside/c)
+"wyF" = (
+/obj/structure/surface/table,
+/obj/effect/spawner/random/toolbox,
+/obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
+/turf/open/floor{
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 "wBi" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
@@ -37722,12 +39501,14 @@
 	},
 /area/bigredv2/caves_north)
 "wFL" = (
-/obj/structure/surface/table,
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/safety/hazard{
+	pixel_x = 8;
+	pixel_y = -32
 	},
-/obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "wFO" = (
 /turf/open/mars_cave{
@@ -37841,6 +39622,19 @@
 	icon_state = "mars_cave_9"
 	},
 /area/bigredv2/caves_north)
+"wMM" = (
+/obj/structure/pipes/vents/pump{
+	dir = 8
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "E";
+	pixel_x = 1
+	},
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 "wMQ" = (
 /obj/structure/largecrate/random/secure,
 /turf/open/floor,
@@ -37919,6 +39713,22 @@
 	icon_state = "mars_cave_13"
 	},
 /area/bigredv2/caves/mining)
+"wVw" = (
+/turf/open/floor{
+	dir = 6;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/filtration_plant)
+"wVB" = (
+/obj/structure/platform,
+/obj/structure/platform{
+	dir = 8
+	},
+/obj/structure/platform_decoration{
+	dir = 10
+	},
+/turf/open/gm/river,
+/area/bigredv2/outside/engineering)
 "wVQ" = (
 /turf/open/mars_cave{
 	icon_state = "mars_cave_17"
@@ -37954,6 +39764,16 @@
 	icon_state = "wood"
 	},
 /area/bigredv2/outside/bar)
+"wYE" = (
+/obj/structure/prop/server_equipment/yutani_server{
+	density = 0;
+	pixel_y = 16
+	},
+/turf/open/floor{
+	dir = 5;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 "wZC" = (
 /turf/open/mars{
 	icon_state = "mars_dirt_11"
@@ -38295,7 +40115,10 @@
 /obj/structure/machinery/power/apc{
 	dir = 1
 	},
-/turf/open/floor,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "xBn" = (
 /obj/structure/platform{
@@ -38327,8 +40150,8 @@
 "xDW" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor{
-	icon_state = "delivery"
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
 	},
 /area/bigredv2/outside/engineering)
 "xFZ" = (
@@ -38552,6 +40375,17 @@
 	icon_state = "mars_dirt_7"
 	},
 /area/bigredv2/caves/mining)
+"xXq" = (
+/obj/structure/barricade/handrail{
+	dir = 1;
+	layer = 3.01;
+	pixel_y = 9
+	},
+/turf/open/floor{
+	dir = 5;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 "xXP" = (
 /obj/structure/prop/invuln/minecart_tracks/bumper,
 /turf/open/mars_cave{
@@ -38588,6 +40422,12 @@
 	icon_state = "mars_dirt_7"
 	},
 /area/bigredv2/caves/mining)
+"yar" = (
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/filtration_plant)
 "ybk" = (
 /turf/open/mars_cave{
 	icon_state = "mars_cave_17"
@@ -38677,6 +40517,20 @@
 	icon_state = "platingdmg3"
 	},
 /area/bigredv2/caves/mining)
+"ygP" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 1
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "W";
+	pixel_x = -1
+	},
+/turf/open/floor{
+	dir = 9;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 "yha" = (
 /obj/structure/surface/table,
 /obj/item/device/radio{
@@ -38704,8 +40558,8 @@
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
 	},
-/turf/open/floor{
-	icon_state = "delivery"
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
 	},
 /area/bigredv2/outside/filtration_plant)
 "yjU" = (
@@ -38715,6 +40569,15 @@
 	icon_state = "platingdmg3"
 	},
 /area/bigredv2/caves/mining)
+"yjV" = (
+/obj/structure/platform_decoration{
+	dir = 8
+	},
+/turf/open/gm/river,
+/area/bigredv2/outside/engineering)
+"ykR" = (
+/turf/closed/wall/mineral/uranium,
+/area/bigredv2/outside/engineering)
 "ykW" = (
 /obj/effect/decal/cleanable/blood/drip{
 	pixel_x = -3;
@@ -47992,7 +49855,7 @@ ayf
 bsa
 ayf
 axX
-bmi
+maD
 boD
 axX
 bpx
@@ -48209,8 +50072,8 @@ ayf
 ayf
 ayf
 azb
-bmi
-bmi
+hhK
+sCt
 azb
 bpx
 ufD
@@ -48426,8 +50289,8 @@ aFc
 aFc
 aFc
 azb
-bmi
-bmi
+hhK
+sCt
 azb
 bpx
 ufD
@@ -48643,8 +50506,8 @@ aFc
 aFc
 bme
 azb
-bmi
-bmi
+hhK
+sCt
 azb
 bpx
 ufD
@@ -48860,8 +50723,8 @@ aFc
 aFc
 bme
 azb
-bmi
-bmi
+hhK
+sCt
 azb
 bpy
 ufD
@@ -49077,8 +50940,8 @@ aFc
 aFc
 bme
 azb
-bmi
-bmi
+hhK
+sCt
 azb
 bme
 bqe
@@ -49294,8 +51157,8 @@ aFc
 bme
 bme
 azb
-bmi
-bmi
+hhK
+sCt
 axX
 azB
 axX
@@ -49511,15 +51374,15 @@ bme
 bme
 bme
 azb
-bmi
-bmi
-bmi
-bmi
+hhK
+mSS
+btr
+kVT
 azb
 bqI
 bre
-bmq
-bob
+maH
+hdc
 bsJ
 axX
 bsI
@@ -49728,16 +51591,16 @@ bme
 bme
 bme
 azb
-bmi
-bmi
-bmi
-bmi
+hhK
+nVq
+nVq
+sCt
 azb
-bmi
-bmi
-bmi
-bmi
-bmi
+hhK
+nVq
+nVq
+nVq
+sCt
 azb
 bme
 bme
@@ -49945,15 +51808,15 @@ bme
 bme
 bme
 azb
-bmi
-bmi
-bmi
-bmi
+hhK
+nVq
+nVq
+nVq
 bqf
-bmi
-bmi
-bmg
-bre
+nVq
+nVq
+tTI
+rzb
 bsK
 axX
 bme
@@ -50162,15 +52025,15 @@ bme
 bme
 bme
 azb
-bmi
-bmi
-bmi
-bmi
+hhK
+nVq
+nVq
+sCt
 azb
-bmi
-bmi
-bmg
-bre
+hhK
+nVq
+tTI
+rzb
 bsL
 azb
 bme
@@ -50379,15 +52242,15 @@ bme
 bme
 bme
 azb
-bmi
-bmi
-bmi
-bmi
+fLl
+btu
+btu
+gdx
 azb
-bmi
-bmi
-bmi
-bmi
+fLl
+nVq
+btu
+nVq
 bsM
 axX
 bpx
@@ -50817,16 +52680,16 @@ boj
 boG
 boj
 axX
-bmi
-bmi
-bmi
+jYF
+sap
+nVq
 brI
-bmi
+sCt
 azb
 bpx
 bpx
 bpx
-aao
+bpx
 aao
 aao
 aao
@@ -51030,21 +52893,21 @@ bmf
 bmf
 bmf
 bnQ
-bmi
-bmi
+ygP
+cud
 bpe
 axX
 jYF
-bmi
-bmi
-bmg
-bmi
+sap
+nVq
+tTI
+sCt
 azb
 kdh
-aao
-aao
-aao
-aao
+bpx
+bpx
+bpx
+bpx
 aao
 aao
 euF
@@ -51245,23 +53108,23 @@ bli
 bsX
 bmg
 bmO
-bmy
-bmy
-bmg
-bmg
-bmi
+vdl
+vdl
+rhP
+tTI
+sCt
 axX
 ayr
 ayr
 brg
-bmg
-bmi
+tTI
+sCt
 axX
 axX
 axX
-aao
-aao
-aao
+bpx
+bpx
+bpx
 aao
 aao
 aao
@@ -51459,26 +53322,26 @@ bfB
 bbe
 bbe
 blj
-blL
+dvC
 bmh
 bmP
 bnq
-bnq
-bnq
+qGY
+qGY
 boH
 bpf
 bpz
-bmg
+lck
 bqJ
-bmg
+tTI
 brJ
-bpF
+niQ
 bsN
 bsZ
 axX
-aao
-aao
-aao
+bpx
+bpx
+bpx
 aao
 aao
 aao
@@ -51685,17 +53548,17 @@ ayr
 boI
 bor
 ayr
-bmg
-bmg
-bmg
+tTI
+tTI
+tTI
 brK
-bor
-bmg
-bmi
+cla
+tTI
+sCt
 axX
-aao
-aao
-aao
+bpx
+bpx
+bpx
 aao
 aao
 aao
@@ -51896,25 +53759,23 @@ aZr
 axX
 bmj
 bmQ
-bmQ
+tju
 bnR
-bnR
-bnW
+ewv
+bYW
 bpO
 bpA
-bop
+eSm
 bqK
-bnq
-bop
+kNK
+slG
 bqN
-bmg
+tTI
 bta
-axX
-aao
-aao
-aao
-aao
-aao
+azb
+nLw
+bpx
+bpx
 aao
 aao
 aao
@@ -51923,9 +53784,11 @@ aao
 aao
 aao
 wog
+oQI
 wog
-trk
-jXX
+wog
+wog
+wog
 aao
 uCD
 aao
@@ -52120,30 +53983,30 @@ ayr
 ayr
 ayr
 ayr
-bor
+nPz
 bri
-bmi
+nVq
 bsm
-bmi
+nVq
 btb
-axX
-aao
-aao
-aao
-aao
-aao
-aao
-aao
-aao
+azb
+nLw
+bpx
+bpx
 aao
 aao
 aao
 wog
 wog
-hiY
-dxV
-dxV
-dxV
+wog
+wog
+sAG
+wog
+oQI
+wog
+wog
+wog
+aao
 aao
 aao
 aao
@@ -52335,20 +54198,18 @@ bnr
 bok
 bnr
 bpi
-bmi
+kVT
 ayr
-bor
-bmi
+nPz
+nVq
 brL
-bmi
-bmi
+nVq
+nVq
 btc
 axX
-aao
-aao
-aao
-aao
-aao
+nLw
+bpx
+bpx
 aao
 aao
 aao
@@ -52356,11 +54217,13 @@ wog
 wog
 wog
 wog
-trk
-jXX
-dxV
-qUS
-dxV
+wog
+wog
+wog
+icQ
+wog
+aao
+aao
 aao
 aao
 aao
@@ -52547,38 +54410,38 @@ bll
 axX
 bmm
 bmS
-bmg
-bmg
-bsu
+tTI
+tTI
+iQC
 boK
-bmi
-bmg
+nVq
+cKu
 ayr
-bor
+nPz
 brj
 brM
 aMB
-bmg
+gwg
 btd
 axX
+nLw
+nLw
+aao
+aao
+aao
+giB
+giB
+giB
+giB
+giB
+giB
+giB
+giB
+giB
 aao
 aao
 aao
 aao
-aao
-aao
-wog
-wog
-trk
-wog
-wog
-jXX
-dxV
-dxV
-dxV
-dxV
-buz
-sDC
 aao
 aao
 qUS
@@ -52762,11 +54625,11 @@ aZu
 aZu
 blm
 axX
-bmm
-bmm
-bmi
+mhZ
+pgk
+btu
 bnS
-bmg
+tTI
 boL
 bpj
 bpC
@@ -52778,24 +54641,24 @@ ayZ
 axX
 axX
 axX
+axX
+axX
+axX
+axX
+axX
+axX
+axX
+axX
+wwT
+axX
+axX
+axX
+axX
+axX
+axX
+axX
+axX
 aao
-aao
-aao
-aao
-aao
-aao
-aao
-jXX
-dxV
-qgY
-hiY
-dxV
-dxV
-dxV
-dxV
-dxV
-qgY
-wog
 aao
 aao
 aao
@@ -52988,32 +54851,32 @@ ayr
 ayr
 ayr
 ayr
-bor
-bmi
-bmg
-bso
-bso
-bso
+cla
+btr
+lck
+kVT
+ayZ
+bsP
+ayZ
+ouh
+lck
+jXJ
+btr
+sDO
+pOg
+saX
+pVv
+saX
+eIN
+lck
+btr
+ayZ
+btr
+kVT
+axX
 axX
 aao
 aao
-aao
-aao
-aao
-aao
-aao
-dxV
-dxV
-qgY
-hiY
-dxV
-pYt
-dxV
-pYt
-dxV
-iNR
-wog
-wog
 wog
 wog
 wog
@@ -53199,37 +55062,37 @@ axX
 bmn
 bmT
 ayr
-bmg
-bmg
+nzN
+tTI
 boM
 ayr
 bpD
-bmi
+btr
 bqM
-bmi
-bmi
-bmi
-bmi
+rnV
+nVq
+tTI
+nIi
 bte
+nIi
+btu
+gwg
+gwg
+gwg
+tTI
+btu
+gwg
+gwg
+tTI
+btu
+btu
+ndw
+fUp
+nVq
+sCt
+wpn
 axX
 aao
-aao
-aao
-aao
-aao
-aao
-dxV
-dxV
-dxV
-qgY
-hiY
-dxV
-dxV
-buz
-sDC
-dxV
-dxV
-qgY
 wog
 wog
 wog
@@ -53416,37 +55279,37 @@ axX
 bmn
 bmU
 bns
-bmi
-bmg
+hhK
+tTI
 boN
 ayr
 bpE
-bmi
-bor
-bmi
-bmi
-bso
-bso
-bso
+nVq
+cla
+nVq
+nVq
+gfX
+axX
+axX
+axX
+iig
+iig
+iig
+mqh
+fEv
+iig
+iig
+ayZ
+fEv
+ueL
+ueL
+ayZ
+axX
+fEv
+ayZ
+axX
 axX
 aao
-aao
-aao
-aao
-aao
-dxV
-dxV
-dxV
-buz
-wog
-hiY
-dxV
-buz
-wog
-hiY
-dxV
-dxV
-qgY
 wog
 wog
 wog
@@ -53634,36 +55497,36 @@ bmn
 bmV
 ayr
 bnV
-bmg
-bmg
+tTI
+cKu
 ayZ
 bpF
-bop
+slG
 bqN
-bmi
-bmi
-bmi
-bmi
+nVq
+nVq
+uDA
 bsP
+bsP
+axX
+hYB
+iAI
+iAI
+dsy
+iSz
+hYB
+iAI
+wVB
+kka
+pog
+iAI
+wVB
+ayZ
+ndw
+sCt
 axX
 aao
 aao
-aao
-aao
-dxV
-dxV
-buz
-ibZ
-wog
-wog
-wog
-ibZ
-wog
-wog
-wog
-sDC
-dxV
-iNR
 wog
 wog
 wog
@@ -53851,36 +55714,36 @@ ayr
 ayr
 ayr
 xAX
-bmg
-bmg
-ayZ
-bor
-bmg
 tTI
-brm
-bmi
-bmi
-bmi
-brm
+cKu
+ayZ
+nPz
+tTI
+tTI
+tTI
+dsm
+mSS
+mij
+kVT
+dhN
+duA
+iNR
+ykR
+iaC
+iSz
+duA
+iNR
+iaC
+kka
+duA
+ykR
+iaC
+ayZ
+hhK
+sCt
 axX
 aao
-aao
-dxV
-aao
-dxV
-dxV
-qgY
 wog
-wog
-wog
-wog
-aao
-wog
-wog
-wog
-jXX
-dxV
-dxV
 qgY
 wog
 hiY
@@ -54065,39 +55928,39 @@ asK
 asK
 axX
 dWl
-bmi
-bmi
+btr
+btr
 bnW
-bop
-bmz
+slG
+ksO
 bpk
 bpM
-bmi
-bmi
-bmi
-bmi
-bmi
-bmi
+slG
+slG
+slG
+slG
+slG
+dWd
+sCt
+dhN
+duA
+iNR
+iNR
+iaC
+iSz
+duA
+iNR
+iaC
+kka
+duA
+iNR
+iaC
+ayZ
+hhK
 sCt
 axX
 aao
-aao
-dxV
-dxV
-dxV
-dxV
-iNR
 wog
-wog
-aao
-aao
-aao
-aao
-wog
-hiY
-dxV
-dxV
-buz
 wog
 wog
 hiY
@@ -54281,40 +56144,40 @@ bjx
 bjx
 bjw
 axX
-dWl
-bmi
-bmg
-bmg
-bmg
-bmg
+lmi
+nVq
+tTI
+tTI
+tTI
+cKu
 ayZ
 bpH
-bmg
-bmg
-bmg
+kmx
+gwg
+gwg
 brO
-bmg
-bmi
-dWl
-axX
-aao
-aao
-dxV
-qUS
-pYt
-dxV
-dxV
-qgY
-aao
-aao
-aao
-aao
-aao
-wog
-hiY
-dxV
-dxV
+gwg
+cla
+gdx
+dhN
+nug
+yjV
+ykR
+iaC
+iSz
+duA
 iNR
+iaC
+kka
+duA
+ykR
+iaC
+ayZ
+hhK
+sCt
+axX
+uVn
+wog
 wog
 wog
 hiY
@@ -54499,39 +56362,39 @@ bjB
 blq
 axX
 bmp
-bmi
-bmg
+nVq
+tTI
 bnX
-bmg
+tTI
 aLP
 ayZ
 bpI
-bmg
+cKu
 axX
 axX
 axX
 axX
+uaS
 axX
 axX
 axX
-aao
-aao
-aao
-dxV
-dxV
-dxV
-dxV
-qgY
-aao
-aao
-aao
-aao
-qUS
+duA
 iNR
-jXX
-dxV
-dxV
-dxV
+iaC
+iSz
+nug
+rUN
+oIK
+kka
+duA
+iNR
+iaC
+ayZ
+hhK
+sCt
+axX
+dQw
+wog
 qgY
 wog
 wog
@@ -54716,39 +56579,39 @@ bkp
 blq
 axX
 bmq
-bmi
+nVq
 bnt
-bmg
-bmi
+tTI
+nVq
 boR
 ayr
-bor
-bmi
+nPz
+sCt
 axX
 brn
-bmq
-trr
-bpl
+jDT
+vTt
+cla
 btr
-axX
-aao
-aao
-aao
-dxV
-dxV
-dxV
-dxV
-qgY
+jTk
+dhN
+duA
+ykR
+iaC
+pWs
+vVz
+vVz
+vVz
+jxA
+duA
+ykR
+iaC
+ueL
+nzN
+sCt
+tcP
+dQw
 wog
-aao
-aao
-aao
-dxV
-dxV
-dxV
-dxV
-dxV
-buz
 wog
 wog
 wog
@@ -54933,38 +56796,38 @@ bjA
 blq
 axX
 trr
-bmg
-bmg
-bmi
-bmi
-fOK
+tTI
+tTI
+nVq
+nVq
+wyF
 ayZ
 bpH
-bmg
+cKu
 axX
 bro
 brP
 slG
-bmg
-trr
-axX
-aao
-aao
-aao
-aao
-dxV
-dxV
-buz
-wog
-wog
-aao
-aao
-dxV
-dxV
-pYt
-dxV
-dxV
-buz
+bqN
+btt
+uGs
+gmm
+duA
+iNR
+iaC
+gUD
+btr
+jxS
+btr
+oWp
+duA
+iNR
+iaC
+ueL
+nzN
+cKu
+tcP
+rvS
 wog
 wog
 wog
@@ -55150,38 +57013,38 @@ bjA
 blq
 axX
 bms
-bmg
+gwg
 bnu
 bnY
-trr
+hcH
 boS
 ayZ
 btK
-bnq
+tTI
 bqP
-bop
-bop
-bpM
-bmg
-bts
+fXm
+wMM
+gVl
+tTI
+nVq
+qUF
+dhN
+duA
+ykR
+iaC
+dBU
+guu
 axX
-aao
-aao
-aao
-aao
-aao
-buz
-wog
-wog
-wog
-wog
-wog
-ibZ
-sDC
-dxV
-dxV
-buz
-wog
+cNb
+nuz
+duA
+ykR
+iaC
+ayZ
+hhK
+cKu
+axX
+rvS
 wog
 wog
 wog
@@ -55378,27 +57241,27 @@ bqk
 axX
 wiK
 fgE
-bor
-cFb
+sap
+tTI
 btt
+nmU
+dhN
+duA
+iNR
+iaC
+xXq
+btu
+uJj
+gwg
+voG
+duA
+iNR
+iaC
+ayZ
+hhK
+sCt
 axX
-aao
-aao
-aao
-aao
-aao
-wog
-wog
-trk
-trk
-wog
-wog
-wog
-wog
-ibZ
-ibZ
-wog
-wog
+rvS
 wog
 wog
 trk
@@ -55584,39 +57447,39 @@ bjH
 blq
 axX
 bmt
-bmi
+btr
 fOK
-trr
-bmq
+pKP
+egL
 ayZ
 bpl
 bpL
-bmg
+cKu
 axX
-bmi
+jAJ
 brR
-bor
-bmi
+nnU
+nVq
 btu
+gHV
+dhN
+duA
+ykR
+iaC
+pWs
+vVz
+vVz
+vVz
+jxA
+duA
+ykR
+iaC
+ayZ
+nzN
+sCt
 axX
-aao
-aao
-aao
-aao
+rvS
 wog
-wog
-jXX
-dxV
-dxV
-iNR
-wog
-wog
-wog
-wog
-wog
-aao
-aao
-aao
 jXX
 pYt
 dxV
@@ -55801,37 +57664,37 @@ bjH
 blq
 axX
 bmu
-bmi
+nVq
 bnw
 bnZ
 boq
 azE
-bmi
-bor
+hhK
+cla
 bql
 axX
 axX
 axX
-dQZ
+axX
+tzJ
 axX
 axX
 axX
-aao
-aao
-aao
-wog
-wog
-hiY
-dxV
-dxV
-pYt
-dxV
+duA
 iNR
-wog
-wog
-trk
-trk
-aao
+iaC
+iSz
+hYB
+iAI
+wVB
+kka
+duA
+iNR
+iaC
+ayZ
+nzN
+sCt
+axX
 aao
 aao
 aao
@@ -56023,32 +57886,32 @@ bnx
 boa
 bor
 ayZ
-bmi
-bor
-bmg
-bmi
-bmi
-bmi
-bor
-bmg
+hhK
+cla
+bZJ
+btr
+btr
+jMn
+btr
+tTI
 kVT
-axX
-axX
-aao
-aao
-wog
-wog
-wog
-sDC
-dxV
-dxV
-dxV
-dxV
+dhN
+hYB
+ojD
+ykR
+iaC
+iSz
+duA
 iNR
-jXX
-dxV
-aao
-aao
+iaC
+kka
+duA
+ykR
+iaC
+iig
+nzN
+sCt
+axX
 aao
 aao
 aao
@@ -56237,35 +58100,35 @@ axX
 bmw
 bmX
 bAo
-bmg
+tTI
 bos
 boU
-bop
-bpM
-bmi
-bmi
-bmi
-bmi
-bor
-bmg
-bmi
+slG
+cZB
+cOa
+lEi
+lEi
+tTI
+nVq
+tTI
+sCt
+dhN
+duA
+iNR
+iNR
+iaC
+iSz
+duA
+iNR
+iaC
+kka
+duA
+iNR
+iaC
+ayZ
+hhK
+sCt
 axX
-aao
-aao
-aao
-aao
-wog
-wog
-wog
-ibZ
-ibZ
-sDC
-dxV
-dxV
-dxV
-dxV
-aao
-aao
 aao
 aao
 aao
@@ -56452,37 +58315,37 @@ bjH
 blr
 axX
 bmx
-bmW
+rdr
 bnz
 bob
-bmi
+gdx
 ayZ
-bmy
-bor
+bcg
+cla
 bpm
-bmi
-bre
-bmr
+izb
+rYr
+tTI
 iQC
-bob
-bmi
+nVq
+vWm
+dhN
+duA
+iNR
+ykR
+iaC
+iSz
+duA
+iNR
+iaC
+kka
+duA
+ykR
+iaC
+ayZ
+hhK
+sCt
 axX
-aao
-aao
-aao
-aao
-aao
-wog
-wog
-wog
-wog
-hiY
-dxV
-dxV
-aao
-aao
-aao
-aao
 aao
 aao
 aao
@@ -56674,32 +58537,32 @@ ayZ
 ayr
 ayr
 ayr
-bpe
-bor
-bmi
-bmi
-bre
+ktY
+cla
+vCf
+mlV
+lqo
 nVq
 eGM
-bob
-bmi
+btu
+dyH
 axX
-aao
-aao
-aao
-aao
-aao
-aao
-aao
-wog
-aao
-aao
-qUS
-aao
-aao
-aao
-aao
-aao
+nug
+rUN
+rUN
+oIK
+iSz
+nug
+rUN
+oIK
+kka
+nug
+rUN
+oIK
+ayZ
+slC
+sCt
+axX
 aao
 aao
 aao
@@ -56888,36 +58751,36 @@ bsX
 bmy
 bmZ
 bmZ
-bmO
-bmg
+mPK
+lck
 boV
-bmi
+slC
 bpN
-bmi
-bmi
-bre
-fOK
+bqo
+bqo
+sBm
+tTI
 wFL
-bob
-bmg
 axX
-aao
-aao
-aao
-aao
-aao
-aao
-aao
-aao
-aao
-aao
-aao
-aao
-aao
-aao
-aao
-aao
-aao
+axX
+axX
+ayZ
+ayZ
+ayZ
+ayZ
+fEv
+ayZ
+sNP
+ueL
+gPh
+sNP
+ayZ
+ayZ
+axX
+fEv
+ayZ
+axX
+axX
 aao
 aao
 aao
@@ -57108,33 +58971,33 @@ bmz
 boc
 bmz
 xDW
-bop
+eSm
+jXf
+eSm
+ebr
 bpO
-bop
-bop
-bop
-bnq
-cuF
-bmi
-bmi
+bpf
+tTI
+nIi
+gZc
+nIi
+btr
+lck
+lck
+lck
+tTI
+lck
+lck
+ouh
+tTI
+btr
+btr
+slC
+fUp
+nVq
+sCt
+wpn
 axX
-axX
-aao
-aao
-aao
-aao
-aao
-aao
-aao
-aao
-bub
-aao
-aao
-aao
-aao
-aao
-aao
-aao
 aao
 aao
 aao
@@ -57328,30 +59191,30 @@ axX
 axX
 axX
 axX
+wYE
+lTM
+bqM
+pMi
+ayZ
+bsP
+ayZ
+btu
+iFa
+snv
+btu
+gFR
+tvH
+gML
+tvH
+gML
+gFR
+btu
+btu
+ayZ
+btu
+gdx
 axX
-bmi
-bmg
-bor
-bmg
-bmi
 axX
-axX
-axX
-gNH
-aao
-bjA
-bjA
-bjA
-bjH
-bub
-bub
-bub
-aao
-aao
-aao
-aao
-aao
-aao
 aao
 aao
 aao
@@ -57481,7 +59344,7 @@ axC
 alu
 ayV
 ayV
-bBg
+ayV
 alu
 aHF
 aMg
@@ -57543,31 +59406,31 @@ bjx
 bjx
 bjx
 bjx
-bjx
 bjw
 axX
+axX
 bru
-bmg
 bqM
-bmi
-bmi
+sDZ
 axX
 axX
 axX
 axX
-bjY
-bjA
-bjA
-bjA
-bjH
-bub
-bub
-bub
-aao
-aao
-aao
-aao
-aao
+axX
+axX
+axX
+axX
+axX
+axX
+axX
+axX
+axX
+axX
+axX
+axX
+axX
+axX
+axX
 aao
 aao
 aao
@@ -57698,7 +59561,7 @@ axE
 alu
 ayW
 ayV
-bBg
+ayV
 alu
 aHD
 aBR
@@ -57760,17 +59623,17 @@ bjA
 bjA
 bjA
 bjA
-bjA
-blq
+blu
+bjw
 axX
 brv
-bmi
 bos
-bop
-bop
-bop
-bop
-boq
+szy
+vbp
+vbp
+vbp
+vbp
+tub
 axX
 bjY
 bjA
@@ -57981,12 +59844,12 @@ bjA
 blq
 axX
 brw
-bmi
-bmg
+btu
+pRG
 brO
 bti
-bpC
-bmi
+idM
+ndw
 bor
 axX
 bjY
@@ -58418,9 +60281,9 @@ bjx
 bjx
 bjw
 ayr
-bmq
-bmq
-bmi
+tdN
+maH
+slC
 bor
 ayr
 bjY
@@ -58637,7 +60500,7 @@ blq
 ayr
 bmq
 bqo
-bmi
+nVq
 btJ
 ayr
 bjw
@@ -58803,8 +60666,8 @@ aXL
 aPS
 aOM
 aof
-wvK
-wvK
+aTa
+aTa
 aof
 oWe
 aOM
@@ -58852,10 +60715,10 @@ bjy
 bjy
 blq
 bsX
-bmi
-bmi
-bmi
-btK
+nVq
+nVq
+nVq
+uBi
 bua
 buo
 buo
@@ -59069,10 +60932,10 @@ bjy
 bjy
 blq
 maD
-bmi
-bmi
-bsu
-bor
+nVq
+nVq
+iQC
+cla
 maD
 bjw
 bjw
@@ -59285,12 +61148,12 @@ bkb
 bkb
 bkb
 bjw
-awp
+ayr
 btj
-bkE
-bkE
-bpo
-awp
+nVq
+nVq
+bor
+ayr
 bjw
 bjY
 bjy
@@ -59502,12 +61365,12 @@ awp
 awp
 awp
 awp
-awp
+ayr
 btk
-bkE
-bkE
-bpo
-awp
+nVq
+nVq
+bor
+ayr
 bjw
 bjY
 bjy
@@ -59705,7 +61568,7 @@ aMg
 awp
 bkD
 blx
-qeK
+aZV
 bmC
 bnb
 bnB
@@ -59714,17 +61577,17 @@ bku
 bmF
 bmF
 bpP
-bkE
-gCx
+fBo
+nEP
 brx
 brU
-brx
-awp
+aCO
+ayr
 btk
-bkE
+nVq
 btA
-bpo
-awp
+bor
+ayr
 bjw
 bjY
 bjz
@@ -59924,24 +61787,24 @@ bmF
 wtC
 blT
 bmD
-bmJ
+pPo
 bpp
 boe
 awp
 awp
 awp
 bpQ
-blX
+wvK
 bqT
-blX
-blX
-blX
+wvK
+wvK
+wvK
 bsY
-bkE
-bkE
-bkE
-bpo
-awp
+slC
+nVq
+nVq
+bor
+ayr
 bjw
 bjY
 bkq
@@ -60141,12 +62004,12 @@ bkE
 bly
 bly
 bly
-blX
-bkE
-bkE
+wvK
+fBo
+boe
 ayF
 boW
-bkE
+lTi
 bpR
 bnF
 bnF
@@ -60154,11 +62017,11 @@ bry
 bnF
 bof
 dvC
-bmF
-bmF
+eSm
+eSm
 btB
 btN
-awp
+ayr
 bjw
 bjY
 bjA
@@ -60355,27 +62218,27 @@ erf
 aHF
 awp
 bkG
-blX
-blX
-blX
-bkE
-bkE
-bkE
+wvK
+wvK
+tKr
+vin
+fBo
+boe
 ayF
 orZ
-bkE
+lTi
 bpS
-blX
-blX
+wvK
+wvK
 brz
 brV
-bkE
-awp
-awp
-awp
-awp
-awp
-awp
+boe
+ayr
+ayr
+ayr
+ayr
+ayr
+ayr
 bjw
 bjY
 bjA
@@ -60573,20 +62436,20 @@ bkf
 awp
 bkH
 blA
-bkE
-bkE
+wtG
+jRn
 bnd
-bnf
-boe
+wtG
+wVw
 ayF
 boW
-bkE
+lTi
 bpo
-bkE
+fBo
 bqV
 brA
 brW
-gCx
+urn
 awp
 bjw
 bjx
@@ -61016,7 +62879,7 @@ awM
 boX
 bpn
 bpp
-bkE
+fBo
 bnb
 brB
 bkN
@@ -61235,8 +63098,8 @@ bpo
 bpU
 bqv
 bpU
-blX
-blX
+wvK
+wvK
 bsC
 awp
 bjY
@@ -61447,12 +63310,12 @@ awM
 awM
 awM
 awM
-boX
+uTO
 bpo
 bpV
-bkE
+bkU
 bqX
-blX
+wvK
 brY
 bsD
 awp
@@ -61658,19 +63521,19 @@ aHF
 awp
 bkK
 blB
-blX
-bkE
+tIv
+nwB
 bnf
 bnf
 bnf
 bou
-bkE
+qHc
 bpo
 bpU
-bkE
+bkU
 bpU
-blX
-blX
+wvK
+wvK
 bsE
 awp
 bjY
@@ -61874,19 +63737,19 @@ erf
 aHF
 awp
 bkK
-blX
-blX
-blX
-blX
+bBg
+wvK
+wvK
+wvK
 bnE
-blX
-blX
+wvK
+wvK
 boZ
 bpo
 bpV
-bkE
+bkU
 bqX
-bkE
+fBo
 brZ
 bsF
 azG
@@ -62091,8 +63954,8 @@ auX
 aHF
 awp
 bkL
-bkE
-bkE
+qHc
+fBo
 bly
 bng
 bnF
@@ -62104,7 +63967,7 @@ bpU
 bqw
 bpU
 brC
-blX
+nlJ
 bsG
 azG
 btn
@@ -62308,20 +64171,20 @@ auX
 aHF
 awp
 bkM
-bkE
+fBo
 blV
 bmF
 bnh
-blX
-blX
+wvK
+wvK
 bly
 bpa
 bpq
-blX
-blX
-bkE
-blX
-bly
+wvK
+wvK
+fBo
+wvK
+qqw
 bsG
 azG
 bjY
@@ -62530,15 +64393,15 @@ blW
 ccP
 bpo
 bnH
-bkE
+yar
 box
-bkE
+yar
 iyd
 iyd
 eKU
-bkE
-bkE
-blX
+yar
+yar
+aZJ
 bsG
 awp
 bjY
@@ -62963,7 +64826,7 @@ blC
 awp
 bmG
 bpo
-bkG
+lYH
 awp
 bWk
 bWk
@@ -63397,7 +65260,7 @@ blC
 awp
 bmG
 bpo
-bkE
+boe
 awp
 bWk
 bMf
@@ -63831,7 +65694,7 @@ blD
 cGT
 bmH
 bnl
-blX
+pBv
 ayF
 vjc
 bpc
@@ -64043,10 +65906,10 @@ asv
 beI
 bgx
 awp
-blX
-blX
+bBg
+wvK
 blY
-blX
+wvK
 bnm
 bnK
 ayF
@@ -64477,11 +66340,11 @@ asv
 bjL
 bkg
 awp
-blX
+bBg
 bly
 bma
-bmJ
-bmJ
+pPo
+pPo
 bnM
 ayF
 bWk
@@ -64697,7 +66560,7 @@ awp
 bkS
 bly
 bly
-blX
+wvK
 bno
 bnN
 ayF
@@ -64911,8 +66774,8 @@ aZF
 bjM
 bgx
 awp
-bkK
-bly
+dQZ
+haT
 bmb
 gCx
 bnp

--- a/maps/map_files/BigRed/sprinkles/15.reactor_meltdown.dmm
+++ b/maps/map_files/BigRed/sprinkles/15.reactor_meltdown.dmm
@@ -1,7 +1,9 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "ai" = (
 /obj/structure/pipes/standard/simple/hidden/green,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/engineering)
 "ak" = (
 /obj/effect/spawner/random/tool,
@@ -10,25 +12,35 @@
 "al" = (
 /obj/structure/surface/table,
 /obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/engineering)
 "am" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 5
 	},
-/turf/open/floor,
+/turf/open/floor{
+	dir = 10;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "an" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
 	},
-/turf/open/floor,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "ao" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 10
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/engineering)
 "aq" = (
 /turf/closed/wall/solaris/reinforced,
@@ -42,13 +54,17 @@
 "aD" = (
 /obj/structure/surface/table,
 /obj/effect/spawner/random/toolbox,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/engineering)
 "aE" = (
 /obj/structure/surface/table,
 /obj/effect/spawner/random/tool,
 /obj/effect/spawner/random/technology_scanner,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/engineering)
 "aF" = (
 /obj/structure/window/framed/solaris,
@@ -56,34 +72,51 @@
 /area/bigredv2/outside/engineering)
 "aT" = (
 /obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "aU" = (
 /obj/structure/surface/rack,
 /obj/item/device/camera_film,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 9;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "aV" = (
 /obj/structure/surface/rack,
 /obj/item/device/analyzer,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "aW" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 6
 	},
-/turf/open/floor,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "aY" = (
 /obj/structure/pipes/standard/manifold/fourway/hidden/green,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/engineering)
 "aZ" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "ba" = (
 /obj/structure/pipes/standard/simple/hidden/green{
@@ -91,14 +124,20 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/item/device/lightreplacer,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "bb" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
 	},
 /obj/item/stack/sheet/metal,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "bc" = (
 /obj/structure/machinery/light{
@@ -107,41 +146,58 @@
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
 	},
-/turf/open/floor,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "bd" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
 	},
 /obj/effect/landmark/hunter_secondary,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkyellowcorners2"
+	},
 /area/bigredv2/outside/engineering)
 "be" = (
 /obj/structure/pipes/standard/manifold/hidden/green,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/engineering)
 "bf" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/liquid_fuel,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/engineering)
 "bg" = (
 /obj/structure/pipes/standard/manifold/hidden/green{
 	dir = 4
 	},
-/turf/open/floor,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "bi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/mask/breath,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/engineering)
 "bj" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/item/stack/sheet/metal,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/engineering)
 "bk" = (
 /obj/effect/decal/cleanable/dirt,
@@ -149,7 +205,9 @@
 	dir = 1;
 	pixel_y = -30
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "bl" = (
 /obj/effect/decal/cleanable/liquid_fuel,
@@ -158,7 +216,9 @@
 	name = "Storm Shutters";
 	pixel_y = -32
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "bm" = (
 /obj/structure/bed/chair{
@@ -166,26 +226,35 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/crap_item,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/engineering)
 "bn" = (
 /obj/structure/surface/table,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/glasses/welding,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/engineering)
 "bo" = (
 /obj/structure/bed/chair{
 	dir = 8
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/engineering)
 "bp" = (
 /obj/item/folder/yellow,
 /obj/structure/pipes/standard/manifold/hidden/green{
 	dir = 8
 	},
-/turf/open/floor,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellowcorners2"
+	},
 /area/bigredv2/outside/engineering)
 "bq" = (
 /obj/structure/pipes/standard/simple/hidden/green{
@@ -194,14 +263,18 @@
 /obj/structure/machinery/door/airlock/almayer/engineering/colony{
 	name = "\improper Engineering Workshop"
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/engineering)
 "br" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/engineering)
 "bs" = (
 /obj/effect/decal/cleanable/dirt,
@@ -217,41 +290,60 @@
 	dir = 1;
 	name = "\improper Engine Reactor Control"
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/telecomm/engi)
 "bv" = (
 /obj/structure/bed/chair{
 	dir = 4
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/engineering)
 "bw" = (
-/turf/open/floor,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "bx" = (
 /obj/structure/machinery/computer/arcade,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 5;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "by" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/pipes/standard/simple/hidden/green,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/engineering)
 "bz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/sheet/metal,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/engineering)
 "bA" = (
 /obj/structure/surface/table,
 /obj/effect/spawner/random/toolbox,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "bB" = (
 /obj/item/stack/sheet/glass,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/engineering)
 "bC" = (
 /obj/effect/decal/cleanable/dirt,
@@ -269,19 +361,30 @@
 	dir = 8
 	},
 /obj/effect/spawner/random/technology_scanner,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 9;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/telecomm/engi)
 "bF" = (
 /obj/structure/machinery/camera/autoname,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/telecomm/engi)
 "bG" = (
-/turf/open/floor,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/telecomm/engi)
 "bH" = (
 /obj/structure/surface/table,
 /obj/effect/decal/cleanable/ash,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/engineering)
 "bJ" = (
 /obj/structure/bed/chair{
@@ -290,46 +393,70 @@
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/engineering)
 "bK" = (
 /obj/item/folder/yellow,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellowcorners2"
+	},
 /area/bigredv2/outside/engineering)
 "bL" = (
 /obj/structure/machinery/vending/cigarette/colony,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "bM" = (
 /obj/structure/machinery/vending/snack,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "bN" = (
 /obj/structure/machinery/vending/cola,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 5;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "bO" = (
 /obj/structure/bed/chair/office/light{
 	dir = 4
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/engineering)
 "bP" = (
 /obj/structure/surface/table,
 /obj/effect/spawner/random/powercell,
 /obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "bQ" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "darkyellowcorners2"
+	},
 /area/bigredv2/outside/engineering)
 "bR" = (
 /obj/structure/machinery/light{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "bS" = (
 /obj/structure/bed/chair/office/light{
@@ -338,13 +465,18 @@
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 6
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/telecomm/engi)
 "bT" = (
 /obj/structure/pipes/vents/pump{
 	dir = 8
 	},
-/turf/open/floor,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/telecomm/engi)
 "bU" = (
 /obj/item/device/radio/intercom{
@@ -353,21 +485,27 @@
 	name = "General Listening Channel";
 	pixel_x = 30
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "podhatchfloor"
+	},
 /area/bigredv2/outside/telecomm/engi)
 "bV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 5
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/engineering)
 "bX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 9
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/engineering)
 "bY" = (
 /obj/effect/decal/cleanable/dirt,
@@ -375,19 +513,27 @@
 	amount = 30
 	},
 /obj/effect/landmark/crap_item,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/engineering)
 "bZ" = (
 /obj/structure/surface/table,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/tool/pen,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "ca" = (
 /obj/structure/sign/safety/hazard{
 	pixel_y = -32
 	},
-/turf/open/floor,
+/turf/open/floor{
+	dir = 10;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "ce" = (
 /obj/item/tool/lighter/random,
@@ -395,7 +541,9 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/ash,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/engineering)
 "cf" = (
 /obj/item/stack/sheet/metal,
@@ -411,38 +559,55 @@
 /area/bigredv2/outside/engineering)
 "ch" = (
 /obj/effect/landmark/crap_item,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/engineering)
 "ck" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/suit/radiation,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkyellowcorners2"
+	},
 /area/bigredv2/outside/engineering)
 "cl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/head/welding,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "cm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/oil,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "cn" = (
 /obj/structure/machinery/door/airlock/almayer/secure/colony{
 	dir = 1;
 	name = "\improper Engine Reactor"
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/engineering)
 "co" = (
 /obj/structure/closet/radiation,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/engineering)
 "cp" = (
 /obj/item/folder/yellow,
 /obj/effect/landmark/crap_item,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "cq" = (
 /obj/effect/decal/cleanable/ash,
@@ -453,7 +618,10 @@
 /area/bigredv2/outside/telecomm/engi)
 "cr" = (
 /obj/effect/decal/cleanable/molten_item,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/telecomm/engi)
 "cs" = (
 /obj/structure/pipes/standard/simple/hidden/green{
@@ -462,7 +630,9 @@
 /obj/structure/machinery/door/airlock/almayer/engineering/colony{
 	name = "\improper Engine Reactor Control"
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/telecomm/engi)
 "ct" = (
 /obj/structure/machinery/door_control{
@@ -480,7 +650,9 @@
 /obj/structure/machinery/door/airlock/almayer/engineering/colony{
 	name = "\improper Engine Reactor Control"
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/telecomm/engi)
 "cw" = (
 /obj/structure/pipes/standard/simple/hidden/green{
@@ -494,18 +666,24 @@
 /obj/structure/machinery/constructable_frame{
 	icon_state = "box_1"
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "cy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/machinery/constructable_frame,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "cz" = (
 /obj/structure/surface/table,
 /obj/structure/machinery/light,
 /obj/effect/spawner/random/tool,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "cA" = (
 /obj/structure/surface/table,
@@ -513,7 +691,10 @@
 /obj/item/stack/sheet/metal{
 	amount = 30
 	},
-/turf/open/floor,
+/turf/open/floor{
+	dir = 6;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "cB" = (
 /obj/structure/machinery/light{
@@ -522,7 +703,9 @@
 /obj/structure/sign/safety/high_rad{
 	pixel_x = 32
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/engineering)
 "cC" = (
 /obj/structure/pipes/standard/simple/hidden/green{
@@ -534,7 +717,10 @@
 /area/bigredv2/outside/engineering)
 "cD" = (
 /obj/structure/machinery/computer/area_atmos,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 6;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "cE" = (
 /obj/structure/machinery/light{
@@ -543,12 +729,17 @@
 /obj/structure/sign/safety/high_rad{
 	pixel_x = -32
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/engineering)
 "cF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "cG" = (
 /obj/structure/window/framed/solaris/reinforced,
@@ -564,7 +755,9 @@
 /obj/effect/landmark/static_comms/net_two{
 	broken_on_spawn = 1
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "podhatchfloor"
+	},
 /area/bigredv2/outside/telecomm/engi)
 "cI" = (
 /obj/structure/sign/safety/hazard{
@@ -572,12 +765,16 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/item/tool/extinguisher,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "cK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/molten_item,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/telecomm/engi)
 "cM" = (
 /turf/open/mars,
@@ -615,7 +812,9 @@
 	dir = 1;
 	name = "\improper Engineering Complex"
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "delivery"
+	},
 /area/bigredv2/outside/engineering)
 "cY" = (
 /turf/open/mars_cave{
@@ -655,7 +854,10 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/ash,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/engineering)
 "dj" = (
 /obj/effect/decal/cleanable/dirt/greenglow,
@@ -991,7 +1193,10 @@
 /area/bigredv2/outside/engineering)
 "eI" = (
 /obj/effect/decal/cleanable/ash,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/telecomm/engi)
 "eJ" = (
 /obj/effect/decal/cleanable/molten_item,
@@ -1024,6 +1229,31 @@
 "eO" = (
 /turf/closed/wall/mineral/uranium/leaking,
 /area/bigredv2/outside/engineering)
+"fI" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/bigredv2/outside/engineering)
+"gT" = (
+/turf/open/floor{
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
+"im" = (
+/obj/structure/pipes/standard/manifold/hidden/green{
+	dir = 4
+	},
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/bigredv2/outside/engineering)
+"iQ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor{
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 "jr" = (
 /obj/structure/blocker/forcefield/multitile_vehicles,
 /turf/open/mars_cave{
@@ -1034,6 +1264,14 @@
 /obj/structure/blocker/forcefield/multitile_vehicles,
 /turf/open/mars_cave,
 /area/bigredv2/outside/lz2_south_cas)
+"ng" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/bigredv2/outside/engineering)
 "oE" = (
 /obj/structure/machinery/door/poddoor/almayer{
 	id = "rad_door";
@@ -1041,12 +1279,26 @@
 	},
 /turf/open/floor/plating,
 /area/bigredv2/outside/telecomm/engi)
+"oK" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 "sU" = (
 /obj/structure/blocker/forcefield/multitile_vehicles,
 /turf/open/mars_cave{
 	icon_state = "mars_dirt_6"
 	},
 /area/bigredv2/outside/lz2_south_cas)
+"to" = (
+/obj/structure/pipes/standard/simple/hidden/green,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 "vs" = (
 /turf/closed/wall/solaris/reinforced,
 /area/bigredv2/outside/telecomm/engi)
@@ -1056,6 +1308,19 @@
 	},
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
+	},
+/area/bigredv2/outside/telecomm/engi)
+"xl" = (
+/obj/structure/pipes/standard/simple/hidden/green,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkyellowcorners2"
+	},
+/area/bigredv2/outside/engineering)
+"xz" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor{
+	icon_state = "dark"
 	},
 /area/bigredv2/outside/telecomm/engi)
 "yH" = (
@@ -1072,7 +1337,9 @@
 /area/bigredv2/outside/lz2_south_cas)
 "Bo" = (
 /obj/structure/pipes/standard/simple/hidden/green,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/telecomm/engi)
 "CA" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1083,6 +1350,26 @@
 	icon_state = "panelscorched"
 	},
 /area/bigredv2/outside/telecomm/engi)
+"Dh" = (
+/obj/structure/pipes/standard/simple/hidden/green,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellowcorners2"
+	},
+/area/bigredv2/outside/engineering)
+"Dq" = (
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
+"ET" = (
+/obj/structure/pipes/standard/simple/hidden/green,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 "IE" = (
 /obj/structure/blocker/forcefield/multitile_vehicles,
 /turf/open/mars_cave{
@@ -1093,10 +1380,29 @@
 /obj/structure/window_frame/solaris/reinforced,
 /turf/open/floor/plating,
 /area/bigredv2/outside/telecomm/engi)
+"Lf" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/turf/open/floor{
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 "LE" = (
 /obj/effect/decal/cleanable/ash,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
+	},
+/area/bigredv2/outside/telecomm/engi)
+"Nv" = (
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/bigredv2/outside/engineering)
+"NT" = (
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellowcorners2"
 	},
 /area/bigredv2/outside/telecomm/engi)
 "NX" = (
@@ -1116,10 +1422,35 @@
 	icon_state = "panelscorched"
 	},
 /area/bigredv2/outside/telecomm/engi)
+"Sz" = (
+/obj/item/stack/sheet/glass,
+/turf/open/floor{
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
+"SC" = (
+/turf/open/floor{
+	icon_state = "delivery"
+	},
+/area/bigredv2/outside/engineering)
+"Tv" = (
+/turf/open/floor{
+	icon_state = "podhatchfloor"
+	},
+/area/bigredv2/outside/telecomm/engi)
 "Uo" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "podhatchfloor"
+	},
 /area/bigredv2/outside/telecomm/engi)
+"WI" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/engineering)
 
 (1,1,1) = {"
 au
@@ -1131,7 +1462,7 @@ bp
 by
 ai
 bX
-bQ
+fI
 cx
 cG
 Ah
@@ -1161,9 +1492,9 @@ au
 au
 an
 bz
-bw
+Nv
 bY
-bw
+Nv
 cy
 cG
 NX
@@ -1192,10 +1523,10 @@ au
 au
 au
 an
-bw
+Nv
 bO
-bw
-bw
+Nv
+Nv
 cz
 aq
 Ph
@@ -1227,7 +1558,7 @@ an
 bA
 bP
 bZ
-bQ
+WI
 cA
 aq
 Ph
@@ -1287,9 +1618,9 @@ au
 au
 au
 au
-an
+ng
 bw
-bQ
+oK
 ca
 aq
 co
@@ -1321,8 +1652,8 @@ aU
 bw
 br
 bB
-bw
-bQ
+Nv
+fI
 cn
 cB
 cn
@@ -1350,11 +1681,11 @@ au
 au
 au
 aV
-bw
-an
-bw
-bw
-bw
+Nv
+ng
+Nv
+Nv
+gT
 aq
 aq
 aq
@@ -1384,9 +1715,9 @@ au
 aW
 ai
 bs
-bw
+Nv
 ew
-bB
+Sz
 co
 co
 dk
@@ -1479,8 +1810,8 @@ au
 au
 aZ
 bQ
-bQ
-bQ
+WI
+WI
 bR
 ez
 cC
@@ -1510,7 +1841,7 @@ au
 au
 au
 ba
-bQ
+iQ
 vs
 vs
 vs
@@ -1542,7 +1873,7 @@ au
 au
 au
 an
-bw
+gT
 vs
 bE
 eI
@@ -1574,7 +1905,7 @@ au
 au
 au
 aZ
-bQ
+iQ
 vs
 bF
 bS
@@ -1606,12 +1937,12 @@ ak
 au
 au
 bb
-bQ
+fI
 bu
 bG
 bT
-bG
-Uo
+NT
+xz
 RN
 eE
 oE
@@ -1670,9 +2001,9 @@ au
 au
 au
 bd
-bQ
+iQ
 vs
-bG
+Tv
 bU
 ct
 RN
@@ -1701,7 +2032,7 @@ dR
 au
 au
 au
-an
+ng
 bl
 vs
 vs
@@ -1733,13 +2064,13 @@ dT
 au
 au
 au
-an
+ng
 ck
 bw
 bw
 di
 bw
-bQ
+fI
 ew
 dr
 cS
@@ -1769,8 +2100,8 @@ be
 bm
 bv
 bv
-bQ
-bw
+fI
+Nv
 ez
 ew
 dr
@@ -1797,11 +2128,11 @@ dT
 au
 au
 au
-an
+ng
 bn
 aE
 bH
-bQ
+fI
 ch
 ew
 ew
@@ -1829,11 +2160,11 @@ dT
 au
 au
 au
-an
+ng
 aD
 al
 ce
-bw
+Nv
 ew
 ew
 cD
@@ -1865,8 +2196,8 @@ bf
 bo
 bo
 bJ
-bQ
-bQ
+fI
+iQ
 aq
 aq
 aq
@@ -1894,11 +2225,11 @@ au
 au
 au
 bg
-ai
-ai
-bg
+to
+Dh
+im
 bV
-bQ
+fI
 cn
 cE
 cn
@@ -1994,11 +2325,11 @@ au
 aq
 bM
 ao
-ai
-ai
-ai
-ai
-ai
+xl
+ET
+ET
+ET
+ET
 am
 aq
 as
@@ -2025,13 +2356,13 @@ au
 au
 aq
 bN
-bw
+Dq
 cm
 bR
 cF
 aT
-bw
-an
+Nv
+Lf
 aq
 as
 as
@@ -2062,7 +2393,7 @@ aq
 aq
 aq
 aq
-bw
+SC
 cX
 aq
 as

--- a/maps/map_files/BigRed/sprinkles/35.filtration_restored.dmm
+++ b/maps/map_files/BigRed/sprinkles/35.filtration_restored.dmm
@@ -7,7 +7,9 @@
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/filtration_plant)
 "ad" = (
 /obj/effect/decal/cleanable/dirt,
@@ -17,12 +19,16 @@
 /obj/structure/pipes/vents/pump,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/filtration_plant)
 "af" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/pipes/standard/simple/hidden/green,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/filtration_plant)
 "ah" = (
 /obj/structure/window/framed/solaris,
@@ -36,13 +42,19 @@
 /area/bigredv2/caves)
 "ak" = (
 /obj/structure/closet/wardrobe/atmospherics_yellow,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "al" = (
 /obj/structure/surface/table,
 /obj/item/tool/lighter/random,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "am" = (
 /turf/open/floor{
@@ -53,43 +65,59 @@
 "an" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/filtration_plant)
 "ap" = (
 /obj/structure/reagent_dispensers/watertank,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "aq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/machinery/camera/autoname{
 	dir = 1
 	},
-/turf/open/floor,
+/turf/open/floor{
+	dir = 10;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "ar" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 5
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/filtration_plant)
 "as" = (
 /obj/structure/pipes/standard/manifold/hidden/green,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "at" = (
 /obj/structure/bed/chair{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/filtration_plant)
 "au" = (
 /obj/structure/machinery/computer/atmos_alert{
 	dir = 8
 	},
 /obj/structure/surface/table,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 6;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "av" = (
 /obj/item/tool/warning_cone,
@@ -123,8 +151,8 @@
 /obj/structure/machinery/door/airlock/almayer/engineering/colony{
 	name = "\improper Atmospherics Condenser Storage"
 	},
-/turf/open/floor{
-	icon_state = "delivery"
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
 	},
 /area/bigredv2/outside/filtration_plant)
 "aB" = (
@@ -132,8 +160,8 @@
 	dir = 1;
 	name = "\improper Atmospherics Condenser"
 	},
-/turf/open/floor{
-	icon_state = "delivery"
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
 	},
 /area/bigredv2/outside/filtration_plant)
 "aC" = (
@@ -141,7 +169,9 @@
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 10
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/filtration_plant)
 "aD" = (
 /obj/structure/machinery/door/airlock/almayer/engineering/colony{
@@ -149,14 +179,16 @@
 	name = "\improper Atmospherics Condenser"
 	},
 /obj/structure/pipes/standard/simple/hidden/green,
-/turf/open/floor{
-	icon_state = "delivery"
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
 	},
 /area/bigredv2/outside/filtration_plant)
 "aE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/device/radio/headset,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/filtration_plant)
 "aF" = (
 /obj/structure/machinery/portable_atmospherics/powered/scrubber/huge/chan,
@@ -173,7 +205,9 @@
 /obj/structure/pipes/standard/manifold/hidden/green{
 	dir = 4
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/filtration_plant)
 "aJ" = (
 /turf/open/floor{
@@ -187,39 +221,49 @@
 /area/bigredv2/outside/se)
 "aL" = (
 /obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor{
-	dir = 1;
-	icon_state = "bot"
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
 	},
 /area/bigredv2/outside/filtration_plant)
 "aM" = (
 /obj/structure/reagent_dispensers/watertank,
-/turf/open/floor{
-	dir = 1;
-	icon_state = "bot"
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
 	},
 /area/bigredv2/outside/filtration_plant)
 "aN" = (
 /obj/structure/pipes/standard/simple/hidden/green,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/filtration_plant)
 "aO" = (
 /obj/structure/pipes/vents/pump,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/filtration_plant)
 "aP" = (
 /obj/effect/landmark/crap_item,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/filtration_plant)
 "aQ" = (
 /obj/structure/surface/table,
 /obj/effect/landmark/good_item,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "aR" = (
 /obj/structure/surface/table,
 /obj/effect/spawner/random/toolbox,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "aS" = (
 /turf/open/floor{
@@ -229,9 +273,8 @@
 /area/bigredv2/outside/filtration_plant)
 "aT" = (
 /obj/structure/dispenser/oxygen,
-/turf/open/floor{
-	dir = 1;
-	icon_state = "bot"
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
 	},
 /area/bigredv2/outside/filtration_plant)
 "aV" = (
@@ -239,24 +282,34 @@
 	icon_state = "U-N"
 	},
 /obj/structure/machinery/computer3/server/rack,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/filtration_plant)
 "aW" = (
 /obj/structure/pipes/standard/manifold/hidden/green,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/filtration_plant)
 "aX" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 10
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/filtration_plant)
 "aY" = (
 /turf/closed/wall/solaris/reinforced,
 /area/bigredv2/outside/filtration_plant)
 "aZ" = (
 /obj/structure/machinery/computer/general_air_control,
-/turf/open/floor,
+/obj/structure/surface/table,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bb" = (
 /obj/structure/surface/table,
@@ -264,23 +317,34 @@
 /obj/structure/machinery/light{
 	dir = 1
 	},
-/turf/open/floor,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/surface/rack,
 /obj/effect/spawner/random/tool,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bd" = (
 /obj/structure/surface/table,
 /obj/effect/spawner/random/tool,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 5;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "be" = (
 /obj/structure/surface/table,
 /obj/item/circuitboard/solar_tracker,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 6;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bf" = (
 /obj/structure/machinery/light{
@@ -293,34 +357,53 @@
 /obj/effect/decal/warning_stripes{
 	icon_state = "U-S"
 	},
-/turf/open/floor,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bh" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "U-S"
 	},
 /obj/structure/machinery/computer3/server/rack,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bj" = (
 /obj/structure/surface/rack,
 /obj/item/tank/air,
 /obj/item/tool/pickaxe,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bk" = (
 /obj/structure/surface/rack,
 /obj/effect/spawner/random/tool,
 /obj/structure/machinery/light,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bl" = (
 /obj/structure/machinery/door/airlock/almayer/engineering/colony{
 	dir = 1;
 	name = "\improper Filtration Facility"
 	},
-/turf/open/floor{
-	icon_state = "delivery"
+/obj/effect/decal/warning_stripes{
+	icon_state = "NE-out";
+	pixel_x = 1;
+	pixel_y = 1
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "NW-out";
+	pixel_y = 1
+	},
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
 	},
 /area/bigredv2/outside/filtration_plant)
 "bm" = (
@@ -329,34 +412,42 @@
 	name = "\improper Filtration Facility"
 	},
 /obj/structure/pipes/standard/simple/hidden/green,
-/turf/open/floor{
-	icon_state = "delivery"
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
 	},
 /area/bigredv2/outside/filtration_plant)
 "bn" = (
-/obj/structure/closet/firecloset/full,
 /obj/structure/sign/safety/distribution_pipes{
 	pixel_x = 32
 	},
-/turf/open/floor,
+/turf/open/floor{
+	dir = 5;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bo" = (
 /obj/item/tank/air,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bp" = (
 /obj/structure/pipes/vents/pump{
 	dir = 4
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bq" = (
 /obj/effect/landmark/crap_item,
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/filtration_plant)
 "br" = (
 /obj/structure/machinery/door/airlock/almayer/engineering/colony{
@@ -365,8 +456,8 @@
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
 	},
-/turf/open/floor{
-	icon_state = "delivery"
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
 	},
 /area/bigredv2/outside/filtration_plant)
 "bt" = (
@@ -378,7 +469,9 @@
 	dir = 4
 	},
 /obj/item/frame/table,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bv" = (
 /obj/structure/machinery/portable_atmospherics/powered/scrubber/huge/chan,
@@ -393,7 +486,9 @@
 	dir = 9
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bz" = (
 /obj/effect/decal/cleanable/dirt,
@@ -413,7 +508,10 @@
 /obj/structure/machinery/computer/atmos_alert{
 	dir = 4
 	},
-/turf/open/floor,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bD" = (
 /obj/structure/window/framed/solaris/reinforced/hull,
@@ -435,11 +533,20 @@
 /area/bigredv2/outside/filtration_plant)
 "bG" = (
 /obj/structure/surface/table,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bH" = (
-/obj/structure/machinery/computer/area_atmos/area,
-/turf/open/floor,
+/obj/structure/machinery/computer/area_atmos/area{
+	dir = 8
+	},
+/obj/structure/surface/table,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bI" = (
 /obj/structure/window_frame/solaris/reinforced,
@@ -450,7 +557,10 @@
 /area/bigredv2/outside/filtration_plant)
 "bJ" = (
 /obj/item/weapon/twohanded/fireaxe,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 10;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bK" = (
 /turf/open/mars,
@@ -458,7 +568,10 @@
 "bN" = (
 /obj/structure/surface/table,
 /obj/effect/spawner/random/technology_scanner,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 10;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bO" = (
 /turf/open/mars_cave{
@@ -475,29 +588,36 @@
 /obj/structure/surface/table,
 /obj/effect/spawner/random/technology_scanner,
 /obj/structure/machinery/light,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bS" = (
 /obj/item/frame/table,
 /obj/structure/machinery/light,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/frame/table,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/surface/table,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "bW" = (
-/obj/structure/largecrate/random,
 /turf/open/floor{
-	dir = 1;
-	icon_state = "bot"
+	icon_state = "dark"
 	},
 /area/bigredv2/outside/filtration_plant)
 "bX" = (
@@ -519,7 +639,9 @@
 	pixel_x = -32
 	},
 /obj/structure/machinery/light,
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "ce" = (
 /obj/structure/machinery/light,
@@ -533,8 +655,8 @@
 	id = "FiltrationShutters";
 	name = "\improper Airlock Shutters"
 	},
-/turf/open/floor{
-	icon_state = "delivery"
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
 	},
 /area/bigredv2/outside/filtration_plant)
 "cg" = (
@@ -559,7 +681,10 @@
 /area/bigredv2/outside/filtration_cave_cas)
 "cj" = (
 /obj/item/tool/pickaxe,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "bot"
+	},
 /area/bigredv2/outside/filtration_plant)
 "ck" = (
 /obj/effect/decal/warning_stripes{
@@ -581,13 +706,61 @@
 	icon_state = "delivery"
 	},
 /area/bigredv2/outside/filtration_plant)
+"cO" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/bigredv2/outside/filtration_plant)
+"et" = (
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/bigredv2/outside/filtration_plant)
+"eL" = (
+/obj/structure/machinery/light{
+	dir = 1
+	},
+/turf/open/floor{
+	dir = 5;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/filtration_plant)
+"ff" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/bigredv2/outside/filtration_plant)
+"gt" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor{
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/filtration_plant)
+"hk" = (
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/filtration_plant)
 "jh" = (
 /obj/structure/machinery/light,
 /turf/open/floor,
 /area/bigredv2/outside/filtration_plant)
 "ka" = (
 /obj/structure/closet/firecloset/full,
-/turf/open/floor,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/filtration_plant)
+"kE" = (
+/obj/structure/machinery/light,
+/turf/open/floor{
+	dir = 6;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "nk" = (
 /obj/structure/blocker/forcefield/multitile_vehicles,
@@ -597,23 +770,152 @@
 /obj/item/tank/air,
 /turf/open/floor,
 /area/bigredv2/outside/filtration_plant)
+"oE" = (
+/obj/structure/machinery/light{
+	dir = 1
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "W";
+	layer = 2.5
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "E";
+	pixel_x = 1
+	},
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/bigredv2/outside/filtration_plant)
+"qi" = (
+/obj/structure/machinery/light{
+	dir = 1
+	},
+/obj/structure/closet/firecloset/full,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "bot"
+	},
+/area/bigredv2/outside/filtration_plant)
+"ti" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "bot"
+	},
+/area/bigredv2/outside/filtration_plant)
+"tp" = (
+/obj/structure/largecrate/random,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/filtration_plant)
+"tz" = (
+/turf/open/floor{
+	dir = 9;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/filtration_plant)
 "tB" = (
 /obj/effect/landmark/crap_item,
 /turf/open/mars_cave{
 	icon_state = "mars_cave_2"
 	},
 /area/bigredv2/outside/filtration_cave_cas)
+"vK" = (
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/filtration_plant)
+"xd" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/filtration_plant)
+"yi" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/filtration_plant)
+"yZ" = (
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkyellowcorners2"
+	},
+/area/bigredv2/outside/filtration_plant)
 "zu" = (
 /turf/open/mars_cave{
 	icon_state = "mars_cave_7"
 	},
 /area/bigredv2/outside/filtration_cave_cas)
+"Ap" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellowcorners2"
+	},
+/area/bigredv2/outside/filtration_plant)
+"AD" = (
+/turf/open/floor{
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/filtration_plant)
+"Ee" = (
+/obj/structure/machinery/light{
+	dir = 1
+	},
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/filtration_plant)
+"FI" = (
+/turf/open/floor{
+	dir = 4;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/filtration_plant)
+"FK" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "W";
+	layer = 2.5
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "E";
+	pixel_x = 1
+	},
+/turf/open/floor{
+	icon_state = "dark"
+	},
+/area/bigredv2/outside/filtration_plant)
+"Jy" = (
+/obj/structure/closet/firecloset/full,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "bot"
+	},
+/area/bigredv2/outside/filtration_plant)
+"Kp" = (
+/obj/structure/surface/table,
+/turf/open/floor{
+	dir = 10;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/filtration_plant)
 "Ms" = (
 /obj/structure/machinery/computer3/server/rack,
 /obj/effect/decal/warning_stripes{
 	icon_state = "U-N"
 	},
-/turf/open/floor,
+/turf/open/floor{
+	dir = 8;
+	icon_state = "darkyellow2"
+	},
 /area/bigredv2/outside/filtration_plant)
 "Qx" = (
 /obj/effect/decal/cleanable/dirt,
@@ -623,6 +925,12 @@
 	icon_state = "asteroidwarning"
 	},
 /area/bigredv2/outside/filtration_plant)
+"QJ" = (
+/turf/open/floor{
+	dir = 10;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/filtration_plant)
 "Rv" = (
 /obj/structure/blocker/forcefield/multitile_vehicles,
 /turf/open/floor{
@@ -630,11 +938,36 @@
 	icon_state = "asteroidwarning"
 	},
 /area/bigredv2/outside/filtration_plant)
+"Sj" = (
+/obj/structure/machinery/door/airlock/almayer/engineering/colony{
+	dir = 1;
+	name = "\improper Filtration Facility"
+	},
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/bigredv2/outside/filtration_plant)
+"Sk" = (
+/obj/structure/machinery/light,
+/obj/structure/largecrate/random,
+/turf/open/floor{
+	dir = 6;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/filtration_plant)
+"TC" = (
+/obj/structure/machinery/light,
+/turf/open/floor{
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/filtration_plant)
 "TX" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
 	},
-/turf/open/floor,
+/turf/open/floor{
+	icon_state = "dark"
+	},
 /area/bigredv2/outside/filtration_plant)
 "UH" = (
 /obj/effect/decal/warning_stripes{
@@ -656,12 +989,34 @@
 	icon_state = "bot"
 	},
 /area/bigredv2/outside/filtration_plant)
+"Wc" = (
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkyellowcorners2"
+	},
+/area/bigredv2/outside/filtration_plant)
+"Wz" = (
+/obj/structure/machinery/light{
+	dir = 1
+	},
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/filtration_plant)
 "WD" = (
 /obj/structure/blocker/forcefield/multitile_vehicles,
 /turf/open/mars_cave{
 	icon_state = "mars_cave_2"
 	},
 /area/bigredv2/outside/filtration_cave_cas)
+"Xx" = (
+/obj/structure/surface/table,
+/obj/effect/spawner/random/technology_scanner,
+/turf/open/floor{
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/outside/filtration_plant)
 "XC" = (
 /obj/structure/cargo_container/grant/right,
 /turf/open/floor{
@@ -710,12 +1065,12 @@ TX
 ap
 aa
 aL
-aS
+et
 aL
 aL
 aa
-az
-az
+tz
+vK
 bJ
 bw
 bw
@@ -734,16 +1089,16 @@ bw
 (3,1,1) = {"
 ak
 TX
-jh
+TC
 aa
-bf
-az
-az
-az
+oE
+FK
+FK
+FK
 bl
-az
+bW
 bp
-az
+AD
 bw
 bw
 bw
@@ -761,19 +1116,19 @@ aY
 (4,1,1) = {"
 ak
 TX
-az
+AD
 aa
 aT
 aM
 aT
-aS
+et
 aa
-az
+hk
 TX
-az
+yZ
 bU
 bB
-bG
+Kp
 aY
 cg
 az
@@ -795,17 +1150,17 @@ aa
 aa
 aa
 aa
-bf
+Wz
 bq
-az
-az
-az
+bW
+bW
+bW
 cb
 aY
 bf
 ad
-ad
-ad
+ti
+ti
 az
 aS
 aS
@@ -817,22 +1172,22 @@ al
 ac
 aq
 aa
-az
+tz
 bg
 Ms
-az
+QJ
 aa
-az
+hk
 TX
-aS
-aS
-aS
-az
+bW
+bW
+bW
+bW
 cf
 az
 ad
-ad
-az
+ti
+aS
 az
 aS
 VW
@@ -840,21 +1195,21 @@ az
 bw
 "}
 (7,1,1) = {"
-ad
+ff
 aC
 ar
 aB
-az
-az
-az
-az
-bl
-az
-TX
-aL
 bW
-aS
-az
+bW
+bW
+bW
+Sj
+bW
+TX
+bW
+bW
+bW
+bW
 cf
 az
 az
@@ -871,22 +1226,22 @@ an
 ae
 as
 ah
-az
+hk
 bh
 aV
-ad
+gt
 ah
-ad
+xd
 TX
-aS
-aS
 bW
-az
+bW
+bW
+bW
 cf
 az
 az
-az
-az
+aS
+aS
 az
 aS
 XC
@@ -901,19 +1256,19 @@ aD
 aN
 aN
 ar
-az
+AD
 ah
-az
+hk
 TX
-aS
-aS
-aS
-az
+bW
+bW
+bW
+bW
 cf
 az
 az
-az
-az
+aS
+aS
 np
 bz
 aS
@@ -921,25 +1276,25 @@ jh
 aY
 "}
 (10,1,1) = {"
-ad
+ff
 aE
 at
 aa
-bf
-az
+Wz
+bW
 ac
 bk
 aa
-bf
+eL
 TX
-az
-az
-az
-jh
+FI
+yi
+tp
+Sk
 aY
 bf
 az
-az
+aS
 cj
 az
 aS
@@ -980,11 +1335,11 @@ ah
 ah
 aa
 ka
-az
+bW
 TX
-az
+AD
 aa
-az
+tz
 TX
 bN
 bw
@@ -1013,7 +1368,7 @@ aN
 bm
 aN
 aW
-bN
+Xx
 bt
 bF
 bF
@@ -1034,11 +1389,11 @@ ai
 ai
 aa
 bb
-az
-az
-jh
+bW
+bW
+TC
 ay
-bf
+Wz
 TX
 bQ
 bw
@@ -1065,9 +1420,9 @@ aR
 aQ
 be
 aa
-az
+hk
 TX
-bN
+Xx
 bw
 bF
 bF
@@ -1092,9 +1447,9 @@ aa
 ay
 aa
 aa
-az
+hk
 TX
-az
+AD
 bw
 bD
 bD
@@ -1116,10 +1471,10 @@ am
 am
 am
 aY
-bf
+Ee
 bj
 bj
-az
+Wc
 TX
 bS
 aa
@@ -1142,14 +1497,14 @@ am
 am
 am
 am
-US
-az
-az
-az
-az
+et
+bW
+bW
+bW
+bW
 bu
-ad
-cn
+ff
+cO
 WD
 bO
 bO
@@ -1169,14 +1524,14 @@ am
 am
 am
 am
-US
-az
-az
+et
+bW
+bW
 aP
 aO
 by
-az
-US
+bW
+et
 WD
 bO
 bO
@@ -1196,14 +1551,14 @@ am
 am
 am
 am
-US
-az
-az
-ad
+et
+FI
+FI
+Ap
 bo
-az
+bW
 bT
-US
+et
 WD
 bO
 bO
@@ -1224,12 +1579,12 @@ am
 aG
 aG
 aY
-bf
-ka
+qi
+Jy
 bn
-az
-az
-jh
+FI
+FI
+kE
 bX
 WD
 bO


### PR DESCRIPTION
# About the pull request

This PR does alot of floor detailing in the areas of engineering, filt and their nightmare incerts

This PR also re-adds the reactor to the main file of bigred

# Explain why it's good for the game

Basically, every building in bigred uses the same floor tiles so I wanted engineering and filt to have their own look

The reactor was removed from bigreds main file due to Xenos choosing to nest in there causing the nested marines to die from radiation poisoning that problem has since been removed and because the area that replaced the reactor is a bland cave with no detailing whatever I believe that readding and updating the reactor is the right choice to make engineering a bit more visually interesting

this PR also removes the scattered engineering reactors from bigred since they were added when the reactor was removed now all of bigreds repairable engines are once again inside the reactor proper

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: SpartanBobby, GDS Pathe
maptweak: Updates bigred floortiles
maptweak: Re-adds reactor to bigred
/:cl:
