### PR TITLE
Fix ability to fulton revivable bodies

### DIFF
--- a/code/game/objects/items/fulton.dm
+++ b/code/game/objects/items/fulton.dm
@@ -90,7 +90,7 @@ var/global/list/deployed_fultons = list()
 			var/mob/living/carbon/human/H = target_atom
 			if(isyautja(H) && H.stat == DEAD)
 				can_attach = TRUE
-			else if((H.stat != DEAD || H.mind && H.check_tod() && H.is_revivable()))
+			else if((H.stat != DEAD || H.check_tod() && H.is_revivable()))
 				to_chat(user, SPAN_WARNING("You can't attach [src] to [target_atom], they still have a chance!"))
 				return
 			else


### PR DESCRIPTION
# About the pull request

Fixes the ability to fulton revivable bodies when the player inside the body has ghosted.
Closes #4926

# Explain why it's good for the game

No more permaing in space or Normandy because an IO decided to kidnap you via fulton


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl:
fix: Removes the ability to fulton bodies that can still be revived
/:cl: