### PR TITLE
Fixes some Almayer Walls randomly changing icons when hit

### DIFF
--- a/code/game/turfs/walls/wall_types.dm
+++ b/code/game/turfs/walls/wall_types.dm
@@ -28,15 +28,23 @@
 		/obj/structure/machinery/cm_vending/sorted/cargo_guns/cargo/blend,
 	)
 
+	/// The type of wall decoration we use, to avoid the wall changing icon all the time
+	var/decoration_type
+
+/turf/closed/wall/almayer/Initialize(mapload, ...)
+	if(!special_icon && prob(20))
+		decoration_type = rand(0,3)
+	return ..()
+
 /turf/closed/wall/almayer/update_icon()
-	..()
-	if(special_icon)
-		return
+	if(decoration_type == null)
+		return ..()
 	if(neighbors_list in list(EAST|WEST))
-		var/r1 = rand(0,10) //Make a random chance for this to happen
-		var/r2 = rand(0,3) // Which wall if we do choose it
-		if(r1 >= 9)
-			overlays += image(icon, icon_state = "almayer_deco_wall[r2]")
+		special_icon = TRUE
+		icon_state = "almayer_deco_wall[decoration_type]"
+	else // Wall connection was broken, return to normality
+		special_icon = FALSE
+	return ..()
 
 /turf/closed/wall/almayer/take_damage(dam, mob/M)
 	var/damage_check = max(0, damage + dam)


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

Horizontal Almayer walls have "decoration" variants that are placed randomly. Because these are applied in update_icon randomly, if you shoot such a wall, it will cycle randomly through available icons.

On top of that, because the replacement icon was applied as an overlay, it was drawn over everything else masking bullet and damage overlays.

This fixes both issues by making it use the icon instead and rolling decorations ahead of time.

# Explain why it's good for the game
Consistency. Awfully distracting if you're in the firing range too

# Changelog
:cl:
fix: Horizontal Almayer walls no longer change icon randomly, and now properly display damage overlays.
/:cl:
