### PR TITLE
Sorokyne Corporate Liaison

### DIFF
--- a/code/modules/clothing/suits/labcoat.dm
+++ b/code/modules/clothing/suits/labcoat.dm
@@ -299,3 +299,21 @@
 	name = "liaison's winter coat"
 	desc = "A Weyland-Yutani winter coat. Only the best comfort for the liaison in a cold environment."
 	icon_state = "snowsuit_liaison"
+
+/obj/item/clothing/suit/storage/snow_suit/liaison/modified
+	name = "modified liaison's winter coat"
+	desc = "A Weyland-Yutani winter coat. This one has been modified to holster guns and other objects. Only the best comfort and utility for the liaison surviving in a cold, hostile environment."
+	allowed = list(
+		/obj/item/weapon/gun,
+		/obj/item/tank/emergency_oxygen,
+		/obj/item/device/flashlight,
+		/obj/item/ammo_magazine,
+		/obj/item/explosive/grenade,
+		/obj/item/device/binoculars,
+		/obj/item/attachable/bayonet,
+		/obj/item/storage/large_holster/machete,
+		/obj/item/weapon/baseballbat,
+		/obj/item/weapon/baseballbat/metal,
+		/obj/item/device/motiondetector,
+		/obj/item/device/walkman,
+	)

--- a/code/modules/gear_presets/survivors/sorokyne_strata/preset_sorokyne_strata.dm
+++ b/code/modules/gear_presets/survivors/sorokyne_strata/preset_sorokyne_strata.dm
@@ -1,6 +1,6 @@
 /datum/equipment_preset/survivor/engineer/soro
-	name = "Survivor - Sorokyne Strata Political Prisioner"
-	assignment = "Sorokyne Strata Political Prisioner"
+	name = "Survivor - Sorokyne Strata Political Prisoner"
+	assignment = "Sorokyne Strata Political Prisoner"
 
 /datum/equipment_preset/survivor/engineer/soro/load_gear(mob/living/carbon/human/new_human)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/under/marine/veteran/UPP(new_human), WEAR_BODY)
@@ -58,3 +58,17 @@
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/snow_suit/survivor(new_human), WEAR_JACKET)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/head/ushanka(new_human), WEAR_HEAD)
 	..()
+
+/datum/equipment_preset/survivor/corporate/soro
+	name = "Survivor - Sorokyne Strata Corporate Liaison"
+	assignment = "Sorokyne Strata Corporate Liaison"
+
+/datum/equipment_preset/survivor/corporate/soro/load_gear(mob/living/carbon/human/new_human)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/under/liaison_suit/charcoal(new_human), WEAR_BODY)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/head/ushanka(new_human), WEAR_HEAD)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/mask/rebreather/scarf(new_human), WEAR_FACE)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/snow_suit/liaison/modified(new_human), WEAR_JACKET)
+	new_human.equip_to_slot_or_del(new /obj/item/storage/backpack/satchel/lockable/liaison, WEAR_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/shoes/marine/knife(new_human), WEAR_FEET)
+	..()
+

--- a/maps/sorokyne_strata.json
+++ b/maps/sorokyne_strata.json
@@ -11,6 +11,7 @@
         "/datum/equipment_preset/survivor/scientist/soro",
         "/datum/equipment_preset/survivor/doctor/soro",
         "/datum/equipment_preset/survivor/engineer/soro",
+        "/datum/equipment_preset/survivor/corporate/soro",
         "/datum/equipment_preset/survivor/security/soro",
         "/datum/equipment_preset/survivor/interstellar_human_rights_observer/soro"
     ],


### PR DESCRIPTION

# About the pull request

adds a corporate liaison survivor to sorokyne, along with a subtype of the liaison's winter coat that can holster guns and a few other utility items/weapons. it cannot hold any rifle magazines or similarly sized items in its pockets though because there should be a tradeoff for how cool it looks.

also fixed a very small typo in the political prisoner's name and assignment.

# Explain why it's good for the game

more diversity in survivor types is good, map didn't have a corporate survivor, a really cool sprite sees more use, fits with the map's lore, etc.

the subtype of the liaison's winter coat is only available on this map at the moment, and it's a downgrade from the survivor snowsuits/soviet snowcoats that already spawn on sorokyne, so it's a fine tradeoff for it looking cool i think. if needed i can always just make it a regular liaison's winter coat.

typos are bad!!!

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/cmss13-devs/cmss13/assets/106038874/17c74652-5e36-495e-b48c-8a7c269b22df)

It's a cold day in Hell, suit.
</details>

# Changelog
:cl:IowaPotatoFarmer
add: Added a Corporate Liaison survivor to Sorokyne.
add: Added a modified version of the liaison's winter coat that allows it to holster guns and a few other things. Only available to the Sorokyne Strata Corporate Liaison for now.
spellcheck: Fixed a typo in the Sorokyne Strata Political Prisoner's ID tag.
/:cl:
