### PR TITLE
Break Up Secure Storage LV-624: V2

### DIFF
--- a/maps/map_files/LV624/LV624.dmm
+++ b/maps/map_files/LV624/LV624.dmm
@@ -9229,12 +9229,6 @@
 /obj/effect/landmark/crap_item,
 /obj/effect/landmark/crap_item,
 /obj/item/clothing/suit/armor/vest/security,
-/obj/structure/machinery/door_control{
-	id = "secure_inner_blast";
-	name = "Secure Inner Doors";
-	pixel_x = 25;
-	pixel_y = 5
-	},
 /turf/open/floor{
 	icon_state = "cult"
 	},
@@ -11199,32 +11193,11 @@
 /obj/item/ore/silver,
 /turf/open/floor/greengrid,
 /area/lv624/lazarus/secure_storage)
-"aWb" = (
-/obj/structure/machinery/door_control{
-	id = "secure_inner_blast";
-	name = "Secure Inner Doors";
-	pixel_x = 25;
-	pixel_y = 5
-	},
-/obj/structure/machinery/door_control{
-	id = "secure_outer_blast";
-	name = "Secure Outer Doors";
-	pixel_x = 25;
-	pixel_y = -5
-	},
-/turf/open/floor/greengrid,
-/area/lv624/lazarus/secure_storage)
 "aWc" = (
 /obj/structure/computerframe{
 	anchored = 1
 	},
-/obj/structure/machinery/door_control{
-	id = "secure_outer_blast";
-	name = "Secure Outer Doors";
-	pixel_x = 25;
-	pixel_y = -5
-	},
-/turf/open/floor/greengrid,
+/turf/open/floor/plating,
 /area/lv624/lazarus/secure_storage)
 "aWd" = (
 /obj/structure/machinery/cm_vending/sorted/tech/comp_storage,
@@ -11342,24 +11315,7 @@
 /obj/structure/flora/jungle/vines/light_1,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/south_west_jungle)
-"aWu" = (
-/obj/structure/machinery/door/poddoor/almayer{
-	dir = 4;
-	id = "secure_inner_blast";
-	layer = 3.3;
-	name = "\improper Secure Armory Blast Door";
-	unacidable = 1
-	},
-/turf/open/floor/greengrid,
-/area/lv624/lazarus/secure_storage)
 "aWv" = (
-/obj/structure/machinery/door/poddoor/almayer{
-	dir = 4;
-	id = "secure_outer_blast";
-	layer = 3.3;
-	name = "\improper Secure Armory Blast Door";
-	unacidable = 1
-	},
 /turf/open/floor/plating{
 	icon_state = "platebotc"
 	},
@@ -13900,6 +13856,10 @@
 "dLY" = (
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/east_jungle)
+"dMc" = (
+/obj/structure/flora/jungle/planttop1,
+/turf/open/gm/dirtgrassborder/south,
+/area/lv624/ground/jungle/south_central_jungle)
 "dMF" = (
 /obj/structure/surface/table/reinforced/prison{
 	color = "#6b675e"
@@ -14051,6 +14011,9 @@
 	icon_state = "bot"
 	},
 /area/lv624/lazarus/landing_zones/lz1)
+"ebr" = (
+/turf/open/gm/dirtgrassborder/east,
+/area/lv624/ground/jungle/south_central_jungle)
 "ebS" = (
 /obj/structure/fence,
 /turf/open/gm/dirtgrassborder/east,
@@ -17042,6 +17005,10 @@
 /obj/structure/flora/jungle/vines/light_3,
 /turf/open/gm/dirtgrassborder/grassdirt_corner2/south_west,
 /area/lv624/ground/caves/sand_temple)
+"ksM" = (
+/obj/structure/flora/bush/ausbushes/var3/sparsegrass,
+/turf/open/gm/dirtgrassborder/south,
+/area/lv624/ground/jungle/south_central_jungle)
 "ksQ" = (
 /obj/structure/surface/rack,
 /obj/item/storage/toolbox/mechanical{
@@ -17189,6 +17156,10 @@
 	icon_state = "vault"
 	},
 /area/lv624/lazarus/quartstorage)
+"kBq" = (
+/obj/structure/flora/bush/ausbushes/ausbush,
+/turf/open/gm/dirtgrassborder/grassdirt_corner/south_west,
+/area/lv624/ground/jungle/south_west_jungle)
 "kCD" = (
 /obj/structure/flora/bush/ausbushes/var3/leafybush,
 /turf/open/auto_turf/strata_grass/layer1,
@@ -18026,6 +17997,9 @@
 	icon_state = "grass1"
 	},
 /area/lv624/ground/barrens/south_eastern_barrens)
+"mkn" = (
+/turf/open/floor/plating,
+/area/lv624/lazarus/secure_storage)
 "mko" = (
 /obj/structure/fence,
 /turf/open/gm/dirtgrassborder/north,
@@ -21614,6 +21588,11 @@
 	},
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/south_central_caves)
+"sWk" = (
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/lv624/lazarus/secure_storage)
 "sWy" = (
 /obj/effect/landmark/monkey_spawn,
 /turf/open/gm/grass/grass1,
@@ -22728,6 +22707,10 @@
 "uWJ" = (
 /turf/closed/wall/strata_ice/jungle,
 /area/lv624/ground/caves/south_west_caves)
+"uXV" = (
+/obj/structure/flora/bush/ausbushes/lavendergrass,
+/turf/open/gm/dirt,
+/area/lv624/ground/jungle/south_central_jungle)
 "uXW" = (
 /obj/structure/barricade/sandbags/wired,
 /turf/open/floor/wood{
@@ -23192,6 +23175,10 @@
 /obj/structure/flora/jungle/vines/light_1,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/north_east_jungle)
+"vUj" = (
+/obj/structure/flora/bush/ausbushes/var3/sparsegrass,
+/turf/open/gm/dirtgrassborder/south,
+/area/lv624/ground/jungle/south_west_jungle)
 "vUw" = (
 /obj/structure/flora/bush/ausbushes/var3/fullgrass,
 /turf/open/gm/dirt,
@@ -23205,6 +23192,9 @@
 /obj/effect/landmark/objective_landmark/medium,
 /turf/open/floor/greengrid,
 /area/lv624/lazarus/secure_storage)
+"vVe" = (
+/turf/open/gm/dirtgrassborder/grassdirt_corner/south_east,
+/area/lv624/ground/jungle/south_central_jungle)
 "vVf" = (
 /turf/open/floor{
 	dir = 5;
@@ -23510,18 +23500,6 @@
 /obj/structure/flora/bush/ausbushes/var3/ywflowers,
 /turf/open/auto_turf/strata_grass/layer1,
 /area/lv624/ground/caves/south_central_caves)
-"wAe" = (
-/obj/effect/decal/cleanable/blood/splatter,
-/obj/structure/machinery/door_control{
-	id = "secure_inner_blast";
-	name = "Secure Inner Doors";
-	pixel_x = -25;
-	pixel_y = 5
-	},
-/turf/open/floor{
-	icon_state = "white"
-	},
-/area/lv624/lazarus/research)
 "wAF" = (
 /obj/effect/decal/grass_overlay/grass1/inner{
 	dir = 1
@@ -24147,6 +24125,11 @@
 /obj/item/storage/box/lights/mixed,
 /turf/open/floor/vault,
 /area/lv624/lazarus/quartstorage)
+"xLT" = (
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/lv624/lazarus/secure_storage)
 "xNi" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
 /obj/effect/decal/grass_overlay/grass1{
@@ -24157,6 +24140,10 @@
 "xNK" = (
 /turf/open/gm/dirt,
 /area/lv624/ground/barrens/containers)
+"xNQ" = (
+/obj/structure/flora/bush/ausbushes/var3/sparsegrass,
+/turf/open/gm/dirtgrassborder/east,
+/area/lv624/ground/jungle/south_central_jungle)
 "xPk" = (
 /turf/open/gm/dirtgrassborder/grassdirt_corner2/north_west,
 /area/lv624/ground/colony/south_medbay_road)
@@ -33500,10 +33487,10 @@ aTf
 aTf
 aTf
 aUQ
-aWb
 aUQ
 aUQ
 aUQ
+sWk
 aUQ
 aUQ
 aTf
@@ -33729,11 +33716,11 @@ aTf
 aTf
 aTf
 aTf
-aWu
-aWu
-aWu
-aTf
-aTf
+mkn
+xLT
+mkn
+xLT
+sWk
 aTf
 aTf
 aXh
@@ -33957,13 +33944,13 @@ efp
 aTf
 aTf
 aWc
-aUQ
-aUQ
-aUQ
-aTf
-aTf
-aTf
-cWm
+mkn
+mkn
+sWk
+mkn
+mkn
+xLT
+kBq
 aXh
 aXh
 aKb
@@ -34185,13 +34172,13 @@ efp
 efp
 aTf
 aTf
+xLT
 aWv
 aWv
-aWv
-aTf
-aXh
-aXh
-aXh
+xLT
+xTT
+xTT
+vUj
 qGH
 aLj
 aXk
@@ -34416,10 +34403,10 @@ uSq
 qIO
 qIO
 qIO
-ntL
-mnK
-kxI
-wkP
+qIO
+uXV
+qtj
+dMc
 knp
 iIU
 kZw
@@ -34644,10 +34631,10 @@ uSq
 njC
 qIO
 qIO
-ntL
-kxI
-tsa
-kxI
+qIO
+qtj
+qtj
+ksM
 rox
 wqz
 kZw
@@ -34873,9 +34860,9 @@ hDX
 qIO
 qIO
 aXH
-kxI
-gGd
-kxI
+ebr
+xNQ
+vVe
 kxI
 wbK
 rHp
@@ -41666,7 +41653,7 @@ auV
 atU
 avE
 atp
-wAe
+awr
 atU
 axH
 aum

--- a/maps/map_files/LV624/armory/10.cheese.dmm
+++ b/maps/map_files/LV624/armory/10.cheese.dmm
@@ -182,12 +182,6 @@
 	pixel_x = 8;
 	pixel_y = -4
 	},
-/obj/structure/machinery/door_control{
-	id = "secure_inner_blast";
-	name = "Secure Inner Doors";
-	pixel_x = 25;
-	pixel_y = 5
-	},
 /turf/open/floor{
 	icon_state = "cult"
 	},

--- a/maps/map_files/LV624/armory/10.extra.dmm
+++ b/maps/map_files/LV624/armory/10.extra.dmm
@@ -187,12 +187,6 @@
 /obj/effect/landmark/crap_item,
 /obj/item/ammo_magazine/smg/m39/extended,
 /obj/item/weapon/gun/smg/m39,
-/obj/structure/machinery/door_control{
-	id = "secure_inner_blast";
-	name = "Secure Inner Doors";
-	pixel_x = 25;
-	pixel_y = 5
-	},
 /turf/open/floor{
 	icon_state = "cult"
 	},

--- a/maps/map_files/LV624/armory/10.looted.dmm
+++ b/maps/map_files/LV624/armory/10.looted.dmm
@@ -186,18 +186,6 @@
 	icon_state = "cult"
 	},
 /area/lv624/lazarus/armory)
-"K" = (
-/obj/item/stack/sheet/metal,
-/obj/structure/machinery/door_control{
-	id = "secure_inner_blast";
-	name = "Secure Inner Doors";
-	pixel_x = 25;
-	pixel_y = 5
-	},
-/turf/open/floor{
-	icon_state = "cult"
-	},
-/area/lv624/lazarus/armory)
 "T" = (
 /obj/structure/machinery/door_control{
 	id = "garage_blast";
@@ -272,7 +260,7 @@ i
 w
 w
 w
-K
+w
 p
 i
 "}

--- a/maps/map_files/LV624/science/10.yautja.dmm
+++ b/maps/map_files/LV624/science/10.yautja.dmm
@@ -538,18 +538,6 @@
 	icon_state = "white"
 	},
 /area/lv624/lazarus/research)
-"WJ" = (
-/obj/effect/landmark/crap_item,
-/obj/structure/machinery/door_control{
-	id = "secure_inner_blast";
-	name = "Secure Inner Doors";
-	pixel_x = -25;
-	pixel_y = 5
-	},
-/turf/open/floor{
-	icon_state = "white"
-	},
-/area/lv624/lazarus/research)
 "Zw" = (
 /obj/structure/surface/table,
 /obj/item/storage/fancy/vials/random,
@@ -670,7 +658,7 @@ al
 ar
 aJ
 Lo
-WJ
+gd
 ar
 aZ
 CC

--- a/maps/map_files/LV624/science/40.fullylocked.dmm
+++ b/maps/map_files/LV624/science/40.fullylocked.dmm
@@ -417,17 +417,6 @@
 "bF" = (
 /turf/closed/wall/strata_ice/jungle,
 /area/lv624/ground/jungle/central_jungle)
-"gu" = (
-/obj/structure/machinery/door_control{
-	id = "secure_inner_blast";
-	name = "Secure Inner Doors";
-	pixel_x = -25;
-	pixel_y = 5
-	},
-/turf/open/floor{
-	icon_state = "white"
-	},
-/area/lv624/lazarus/research)
 "ky" = (
 /obj/effect/landmark/objective_landmark/science,
 /turf/open/floor{
@@ -608,7 +597,7 @@ ay
 au
 aQ
 Kl
-gu
+ak
 au
 bp
 ay


### PR DESCRIPTION
Breaks open the secure storage on LV-624. 

Remake of #4767 

Mapping changes are identical, however this PR has also removed buttons that reference the now removed secure dome shutters from the rest of the map, and similar nightmare inserts.

# Explain why it's good for the game

Survivor holds on 624 are usually a case of either the survivors running and gunning or hiding in secure storage for 18 minutes until the xenos reach T3, then its a case of if the Xenos can breach secure storage before the Marines arrive. Secure storage is simply not a fun exercise for both sides, if survivors are going to survive there should be more effort than hiding in a pre-made bunker. 

I should note that this does not make Secure Storage a impossible hold, only that its now not 100% inaccessible to xenos until they reach T3. 

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
maptweak: Secure Storage on LV-624 has been broken open, making it far less defendable but easier to access. 
/:cl:
