### PR TITLE
Fix issue with null hud_used in stop_tracking_resin_mark

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
@@ -695,6 +695,12 @@
 	to_chat(src, SPAN_INFO("shift click the compass to watch the mark, alt click to stop tracking"))
 
 /mob/living/carbon/xenomorph/proc/stop_tracking_resin_mark(destroyed, silent = FALSE) //tracked_marker shouldnt be nulled outside this PROC!! >:C
+	if(QDELETED(src))
+		return
+
+	if(!hud_used)
+		CRASH("hud_used is null in stop_tracking_resin_mark")
+
 	var/atom/movable/screen/mark_locator/ML = hud_used.locate_marker
 	ML.overlays.Cut()
 


### PR DESCRIPTION
# About the pull request
![image](https://github.com/cmss13-devs/cmss13/assets/41448081/f061830e-975f-49fb-b17e-a139fc5bff09)

Fixes above runtime.

Unsure if `hud_used` being null is because this is being called during the destroy process of the xeno, or if it's a deeper issue. I've put in a crash to test.