### PR TITLE
Fix null parent crash in radial slice clicked()

### DIFF
--- a/code/_onclick/hud/radial.dm
+++ b/code/_onclick/hud/radial.dm
@@ -34,6 +34,12 @@ GLOBAL_LIST_EMPTY(radial_menus)
 
 
 /atom/movable/screen/radial/slice/clicked(mob/user)
+	if(QDELETED(src))
+		return
+
+	if(!parent)
+		CRASH("clicked() called on a radial slice with a null parent while not deleted/deleting")
+
 	if(user.client == parent.current_user)
 		if(next_page)
 			parent.next_page()


### PR DESCRIPTION
function
# About the pull request

Same method as
https://github.com/cmss13-devs/cmss13/pull/4948

![image](https://github.com/cmss13-devs/cmss13/assets/41448081/c11029df-2442-4698-8002-da8625c0c7a0)
