### PR TITLE
Lesser Drones & Facehuggers can no longer speak

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -145,6 +145,8 @@
 //-- mob traits --
 /// Apply this to make a mob not dense, and remove it when you want it to no longer make them undense, other sorces of undesity will still apply. Always define a unique source when adding a new instance of this!
 #define TRAIT_UNDENSE "undense"
+/// Apply this to make a mob unable to speak ICly.
+#define TRAIT_MUTE "mute"
 
 // SPECIES TRAITS
 /// Knowledge of Yautja technology
@@ -295,6 +297,7 @@ GLOBAL_LIST_INIT(mob_traits, list(
 GLOBAL_LIST_INIT(traits_by_type, list(
 	/mob = list(
 		"TRAIT_UNDENSE" = TRAIT_UNDENSE,
+		"TRAIT_MUTE" = TRAIT_MUTE,
 		"TRAIT_YAUTJA_TECH" = TRAIT_YAUTJA_TECH,
 		"TRAIT_SUPER_STRONG" = TRAIT_SUPER_STRONG,
 		"TRAIT_FOREIGN_BIO" = TRAIT_FOREIGN_BIO,

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -60,7 +60,7 @@
 	var/message_range = world_view_size
 	var/italics = 0
 
-	if(!able_to_speak)
+	if((!able_to_speak) || (HAS_TRAIT(src, TRAIT_MUTE)))
 		to_chat(src, SPAN_DANGER("You try to speak, but nothing comes out!"))
 		return
 

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -53,6 +53,11 @@
 	else
 		.["message"] = message_and_language
 
+/mob/living/carbon/say(message)
+	if((HAS_TRAIT(src, TRAIT_MUTE)))
+		to_chat(src, SPAN_DANGER("You try to speak, but nothing comes out!"))
+		return
+
 /mob/living/carbon/human/say(message)
 
 	var/verb = "says"
@@ -60,7 +65,7 @@
 	var/message_range = world_view_size
 	var/italics = 0
 
-	if((!able_to_speak) || (HAS_TRAIT(src, TRAIT_MUTE)))
+	if((!able_to_speak))
 		to_chat(src, SPAN_DANGER("You try to speak, but nothing comes out!"))
 		return
 

--- a/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
@@ -265,6 +265,12 @@
 /mob/living/carbon/xenomorph/show_inv(mob/user)
 	return
 
+/mob/living/carbon/xenomorph/proc/mute()
+	ADD_TRAIT(src, TRAIT_MUTE, TRAIT_SOURCE_ABILITY("mute"))
+
+/mob/living/carbon/xenomorph/proc/un_mute()
+	REMOVE_TRAIT(src, TRAIT_MUTE, TRAIT_SOURCE_ABILITY("mute"))
+
 /mob/living/carbon/xenomorph/proc/pounced_mob(mob/living/L)
 	// This should only be called back by a mob that has pounce, so no need to check
 	var/datum/action/xeno_action/activable/pounce/pounceAction = get_xeno_action_by_type(src, /datum/action/xeno_action/activable/pounce)

--- a/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
@@ -40,7 +40,6 @@
 	counts_for_slots = FALSE
 	counts_for_roundend = FALSE
 	refunds_larva_if_banished = FALSE
-	can_hivemind_speak = FALSE
 	/// The lifetime hugs from this hugger
 	var/total_facehugs = 0
 	/// How many hugs the hugger needs to age
@@ -59,6 +58,10 @@
 
 	icon_xeno = 'icons/mob/xenos/facehugger.dmi'
 	icon_xenonid = 'icons/mob/xenonids/facehugger.dmi'
+
+/mob/living/carbon/xenomorph/facehugger/say()
+	to_chat(src, SPAN_DANGER("Your psychic power isn't strong enough to communicate."))
+	return
 
 /mob/living/carbon/xenomorph/facehugger/initialize_pass_flags(datum/pass_flags_container/PF)
 	..()

--- a/code/modules/mob/living/carbon/xenomorph/castes/lesser_drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/lesser_drone.dm
@@ -38,6 +38,7 @@
 	resin_build_order = GLOB.resin_build_order_lesser_drone
 
 /mob/living/carbon/xenomorph/lesser_drone
+	ADD_TRAIT(src, TRAIT_MUTE, TRAIT_SOURCE_ABILITY("mute"))
 	caste_type = XENO_CASTE_LESSER_DRONE
 	name = XENO_CASTE_LESSER_DRONE
 	desc = "An alien drone. Looks... smaller."
@@ -75,8 +76,6 @@
 		/mob/living/carbon/xenomorph/proc/set_hugger_reserve_for_morpher,
 	)
 
-	addtimer(CALLBACK(src, PROC_REF(un_mute)), 5 MINUTES)
-
 	mutation_type = DRONE_NORMAL
 
 	icon_xeno = 'icons/mob/xenos/lesser_drone.dmi'
@@ -91,6 +90,9 @@
 	hud_update()
 
 	xeno_jitter(25)
+
+/mob/living/carbon/xenomorph/lesser_drone/mute()
+	addtimer(CALLBACK(src, PROC_REF(un_mute)), 5 MINUTES)
 
 /mob/living/carbon/xenomorph/lesser_drone/initialize_pass_flags(datum/pass_flags_container/PF)
 	..()

--- a/code/modules/mob/living/carbon/xenomorph/castes/lesser_drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/lesser_drone.dm
@@ -80,6 +80,10 @@
 	icon_xeno = 'icons/mob/xenos/lesser_drone.dmi'
 	icon_xenonid = 'icons/mob/xenonids/lesser_drone.dmi'
 
+/mob/living/carbon/xenomorph/lesser_drone/say()
+	to_chat(src, SPAN_DANGER("Your psychic power isn't strong enough to communicate."))
+	return
+
 /mob/living/carbon/xenomorph/lesser_drone/age_xeno()
 	if(stat == DEAD || !caste || QDELETED(src) || !client)
 		return

--- a/code/modules/mob/living/carbon/xenomorph/castes/lesser_drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/lesser_drone.dm
@@ -75,14 +75,12 @@
 		/mob/living/carbon/xenomorph/proc/set_hugger_reserve_for_morpher,
 	)
 
+	addtimer(CALLBACK(src, PROC_REF(un_mute)), 5 MINUTES)
+
 	mutation_type = DRONE_NORMAL
 
 	icon_xeno = 'icons/mob/xenos/lesser_drone.dmi'
 	icon_xenonid = 'icons/mob/xenonids/lesser_drone.dmi'
-
-/mob/living/carbon/xenomorph/lesser_drone/say()
-	to_chat(src, SPAN_DANGER("Your psychic power isn't strong enough to communicate."))
-	return
 
 /mob/living/carbon/xenomorph/lesser_drone/age_xeno()
 	if(stat == DEAD || !caste || QDELETED(src) || !client)

--- a/code/modules/mob/living/carbon/xenomorph/castes/lesser_drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/lesser_drone.dm
@@ -38,7 +38,6 @@
 	resin_build_order = GLOB.resin_build_order_lesser_drone
 
 /mob/living/carbon/xenomorph/lesser_drone
-	ADD_TRAIT(src, TRAIT_MUTE, TRAIT_SOURCE_ABILITY("mute"))
 	caste_type = XENO_CASTE_LESSER_DRONE
 	name = XENO_CASTE_LESSER_DRONE
 	desc = "An alien drone. Looks... smaller."


### PR DESCRIPTION
# About the pull request

This removes the ability for lesser drones and facehuggers to speak.

# Explain why it's good for the game

Now, Lesser Drone/Facehugger meta gaming isn't something you see every game, and it's not something that's extremely obvious, but it is something that is possible and it is something that is done every few games.

https://forum.cm-ss13.com/t/remove-the-ability-to-speak-of-facehuggers-and-lesser-drones/5106

I'd like to add, personally, I don't think facehuggers or lesser drones really need the ability to talk.  The lesser drones purpose is to be a nuisance to marine, minor support to the larger castes, and set up the hive.

Facehuggers role is to run up to bigger bugs and stick with them to hug people they stun. Alternatively, they sit in the shadows and wait to capitalize off of traps.

Neither of these two roles require talking. Them being able to talk barely assists their intended purpose, if at all. The reason that only the lesser drone and the facehugger are an issue with talking and metagaming is the fact how quick and easy it is to pump these bugs out en masse.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![lesserdrone](https://github.com/cmss13-devs/cmss13/assets/91508746/faad53dd-aabc-47d2-a963-44e01737a6a6)

![facehugger](https://github.com/cmss13-devs/cmss13/assets/91508746/a5e09f91-277b-4ded-a01f-72263c332e37)

![sillyimage](https://github.com/cmss13-devs/cmss13/assets/91508746/d6ee710f-81d6-4215-b43f-ed3aae2253de)

![image](https://github.com/cmss13-devs/cmss13/assets/91508746/2669985e-a548-4406-be4a-cf75a013101d)


</details>


# Changelog
:cl:
balance: Facehuggers and Lesser Drones can no longer speak.
/:cl:
