### PR TITLE
Hivecores perform multiple spawns at once

### DIFF
--- a/code/modules/cm_aliens/structures/special/pylon_core.dm
+++ b/code/modules/cm_aliens/structures/special/pylon_core.dm
@@ -272,12 +272,14 @@
 		if(spawning_larva || (last_larva_queue_time + spawn_cooldown * 4) < world.time)
 			last_larva_queue_time = world.time
 			var/list/players_with_xeno_pref = get_alien_candidates(linked_hive)
-			if(length(players_with_xeno_pref))
-				if(spawning_larva && spawn_burrowed_larva(players_with_xeno_pref[1]))
-					// We were in spawning_larva mode and successfully spawned someone
-					count_spawned = 1
-				// Update everyone's queue status
-				message_alien_candidates(players_with_xeno_pref, dequeued = count_spawned)
+			if(spawning_larva)
+				var/i = 0
+				while(i < length(players_with_xeno_pref) && can_spawn_larva())
+					if(spawn_burrowed_larva(players_with_xeno_pref[++i]))
+						// We were in spawning_larva mode and successfully spawned someone
+						count_spawned++
+			// Update everyone's queue status
+			message_alien_candidates(players_with_xeno_pref, dequeued = count_spawned)
 
 		if(linked_hive.hijack_burrowed_surge && (last_surge_time + surge_cooldown) < world.time)
 			last_surge_time = world.time


### PR DESCRIPTION
# About the pull request

This PR simply makes it so hive cores try to dequeue as many larva as they have stored_larva each larva spawn delay rather than a single larva.

# Explain why it's good for the game

Fixes #4945 

# Testing Photographs and Procedure
1. Spawn as queen
2. Create core
3. Ensure hive has 2 stored_larva
4. Ghost (Have two admin clients at this point observing)
5. Ensure both clients have xeno preference set and then lose larva protections (assuming admin)
6. Both will spawn at once
7. Try again with 1 stored_larva
8. One will spawn and other has queue message updated


# Changelog
:cl: Drathek
fix: Tweaked larva queue spawning: Now spawns as many larva as possible each cycle rather than one.
/:cl:
