### PR TITLE
Removes a couple of istype(src) & unused proc

### DIFF
--- a/code/__HELPERS/job.dm
+++ b/code/__HELPERS/job.dm
@@ -14,17 +14,7 @@
 		all_jobs += new jobtype
 	return all_jobs
 
-
 /proc/get_all_centcom_jobs() return list()
-
-//gets the actual job rank (ignoring alt titles)
-//this is used solely for sechuds
-/obj/proc/GetJobRealName()
-	if (!istype(src,/obj/item/card/id)) return
-	var/obj/item/card/id/I = src
-	if(I.rank in GLOB.joblist) return I.rank
-	if(I.assignment in GLOB.joblist) return I.assignment
-	return "Unknown"
 
 /proc/get_all_job_icons() return GLOB.joblist + list("Prisoner")//For all existing HUD icons
 

--- a/code/__HELPERS/job.dm
+++ b/code/__HELPERS/job.dm
@@ -18,18 +18,6 @@
 
 /proc/get_all_job_icons() return GLOB.joblist + list("Prisoner")//For all existing HUD icons
 
-/obj/proc/GetJobName() //Used in secHUD icon generation
-	var/obj/item/card/id/I = src
-	if(istype(I))
-		var/job_icons = get_all_job_icons()
-		var/centcom = get_all_centcom_jobs()
-
-		if(I.assignment in job_icons) return I.assignment//Check if the job has a hud icon
-		if(I.rank in job_icons) return I.rank
-		if(I.assignment in centcom) return "Centcom"//Return with the NT logo if it is a Centcom job
-		if(I.rank in centcom) return "Centcom"
-	return "Unknown" //Return unknown if none of the above apply
-
 /proc/get_actual_job_name(mob/M)
 	if(!M)
 		return null

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -97,6 +97,21 @@
 	. = ..()
 	screen_loc = null
 
+/obj/item/card/id/proc/GetJobName() //Used in secHUD icon generation
+
+	var/job_icons = get_all_job_icons()
+	var/centcom = get_all_centcom_jobs()
+
+	if(assignment in job_icons)
+		return assignment//Check if the job has a hud icon
+	if(rank in job_icons)
+		return rank
+	if(assignment in centcom)
+		return "Centcom"//Return with the NT logo if it is a Centcom job
+	if(rank in centcom)
+		return "Centcom"
+	return "Unknown" //Return unknown if none of the above apply
+
 /obj/item/card/id/attack_self(mob/user as mob)
 	..()
 	user.visible_message("[user] shows you: [icon2html(src, viewers(user))] [name]: assignment: [assignment]")

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1741,3 +1741,9 @@
 		return FALSE
 
 	. = ..()
+
+/mob/living/carbon/human/make_dizzy(amount)
+	dizziness = min(500, dizziness + amount) // store what will be new value
+													// clamped to max 500
+	if(dizziness > 100 && !is_dizzy)
+		INVOKE_ASYNC(src, PROC_REF(dizzy_process))

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -593,20 +593,13 @@
 adds a dizziness amount to a mob
 use this rather than directly changing var/dizziness
 since this ensures that the dizzy_process proc is started
-currently only humans get dizzy
+currently only mob/living/carbon/human get dizzy
 
 value of dizziness ranges from 0 to 1000
 below 100 is not dizzy
 */
 /mob/proc/make_dizzy(amount)
-	if(!istype(src, /mob/living/carbon/human)) // for the moment, only humans get dizzy
-		return
-
-	dizziness = min(500, dizziness + amount) // store what will be new value
-													// clamped to max 500
-	if(dizziness > 100 && !is_dizzy)
-		INVOKE_ASYNC(src, PROC_REF(dizzy_process))
-
+	return
 
 /*
 dizzy process - wiggles the client's pixel offset over time


### PR DESCRIPTION
# About the pull request

Removes a couple if istype(src) I noticed.

- GetJobRealName() removed this is never called
- GetJobName() moved into the scope of `/obj/item/card/id` instead of `/obj` This is only ever called in that object.
- Moves `make_dizzy()` processing into `/mob/living/carbon/human` and removes istype(src) on `/mob`

# Explain why it's good for the game
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
code: Removes some istype(src)
/:cl:
