### PR TITLE
More accurate directions for trackers and messages

### DIFF
--- a/code/datums/agents/tools/tracker.dm
+++ b/code/datums/agents/tools/tracker.dm
@@ -12,7 +12,7 @@
 	overlays.Cut()
 
 	if(active && tracked_object)
-		overlays += icon(icon, "+tracker_arrow", get_dir(src, tracked_object))
+		overlays += icon(icon, "+tracker_arrow", Get_Compass_Dir(src, tracked_object))
 
 /obj/item/device/tracker/attack_self(mob/user)
 	if(!skillcheckexplicit(user, SKILL_ANTAG, SKILL_ANTAG_AGENT))

--- a/code/game/cas_manager/datums/cas_fire_mission.dm
+++ b/code/game/cas_manager/datums/cas_fire_mission.dm
@@ -114,7 +114,7 @@
 		if(get_turf(M) == initial_turf)
 			relative_dir = 0
 		else
-			relative_dir = get_dir(M, initial_turf)
+			relative_dir = Get_Compass_Dir(M, initial_turf)
 
 		var/ds_identifier = "LARGE BIRD"
 		if (M.mob_flags & KNOWS_TECHNOLOGY)
@@ -132,7 +132,7 @@
 		if(get_turf(M) == initial_turf)
 			relative_dir = 0
 		else
-			relative_dir = get_dir(M, initial_turf)
+			relative_dir = Get_Compass_Dir(M, initial_turf)
 
 		var/ds_identifier = "LARGE BIRD"
 		if (M.mob_flags & KNOWS_TECHNOLOGY)

--- a/code/game/objects/items/devices/multitool.dm
+++ b/code/game/objects/items/devices/multitool.dm
@@ -53,8 +53,8 @@
 	var/area/A = get_area(src)
 	var/APC = A? A.get_apc() : null
 	if(APC)
-		to_chat(user, SPAN_NOTICE("The local APC is located at [SPAN_BOLD("[get_dist(src, APC)] units [dir2text(get_dir(src, APC))]")]."))
-		user.balloon_alert(user, "[get_dist(src, APC)] units [dir2text(get_dir(src, APC))]")
+		to_chat(user, SPAN_NOTICE("The local APC is located at [SPAN_BOLD("[get_dist(src, APC)] units [dir2text(Get_Compass_Dir(src, APC))]")]."))
+		user.balloon_alert(user, "[get_dist(src, APC)] units [dir2text(Get_Compass_Dir(src, APC))]")
 	else
 		to_chat(user, SPAN_WARNING("ERROR: Could not locate local APC."))
 		user.balloon_alert(user, "could not locate!")

--- a/code/game/objects/items/devices/personal_data_transmitter.dm
+++ b/code/game/objects/items/devices/personal_data_transmitter.dm
@@ -122,7 +122,7 @@
 		return
 
 	var/dist = get_dist(self_turf, bracelet_turf)
-	var/direction = dir2text_short(get_dir(self_turf, bracelet_turf))
+	var/direction = dir2text_short(Get_Compass_Dir(self_turf, bracelet_turf))
 	if(dist > 1)
 		to_chat(user, SPAN_BOLDNOTICE("The display on \the [src] lights up: <b>[dist]-[direction]</b>"))
 	else

--- a/code/game/objects/items/devices/pinpointer.dm
+++ b/code/game/objects/items/devices/pinpointer.dm
@@ -31,7 +31,7 @@
 		if(!the_disk)
 			icon_state = "pinonnull"
 			return
-	setDir(get_dir(src,the_disk))
+	setDir(Get_Compass_Dir(src,the_disk))
 	switch(get_dist(src,the_disk))
 		if(0)
 			icon_state = "pinondirect"
@@ -80,7 +80,7 @@
 	if(!location)
 		icon_state = "pinonnull"
 		return
-	setDir(get_dir(src,location))
+	setDir(Get_Compass_Dir(src,location))
 	switch(get_dist(src,location))
 		if(0)
 			icon_state = "pinondirect"
@@ -99,7 +99,7 @@
 	if(!target)
 		icon_state = "pinonnull"
 		return
-	setDir(get_dir(src,target))
+	setDir(Get_Compass_Dir(src,target))
 	switch(get_dist(src,target))
 		if(0)
 			icon_state = "pinondirect"

--- a/code/modules/cm_marines/equipment/mortar/mortars.dm
+++ b/code/modules/cm_marines/equipment/mortar/mortars.dm
@@ -314,7 +314,7 @@
 		if(get_turf(M) == target)
 			relative_dir = 0
 		else
-			relative_dir = get_dir(M, target)
+			relative_dir = Get_Compass_Dir(M, target)
 		M.show_message( \
 			SPAN_DANGER("A SHELL IS COMING DOWN [SPAN_UNDERLINE(relative_dir ? uppertext(("TO YOUR " + dir2text(relative_dir))) : uppertext("right above you"))]!"), SHOW_MESSAGE_VISIBLE, \
 			SPAN_DANGER("YOU HEAR SOMETHING COMING DOWN [SPAN_UNDERLINE(relative_dir ? uppertext(("TO YOUR " + dir2text(relative_dir))) : uppertext("right above you"))]!"), SHOW_MESSAGE_AUDIBLE \
@@ -324,7 +324,7 @@
 		if(get_turf(M) == target)
 			relative_dir = 0
 		else
-			relative_dir = get_dir(M, target)
+			relative_dir = Get_Compass_Dir(M, target)
 		M.show_message( \
 			SPAN_HIGHDANGER("A SHELL IS ABOUT TO IMPACT [SPAN_UNDERLINE(relative_dir ? uppertext(("TO YOUR " + dir2text(relative_dir))) : uppertext("right above you"))]!"), SHOW_MESSAGE_VISIBLE, \
 			SPAN_HIGHDANGER("YOU HEAR SOMETHING VERY CLOSE COMING DOWN [SPAN_UNDERLINE(relative_dir ? uppertext(("TO YOUR " + dir2text(relative_dir))) : uppertext("right above you"))]!"), SHOW_MESSAGE_AUDIBLE \

--- a/code/modules/cm_marines/orbital_cannon.dm
+++ b/code/modules/cm_marines/orbital_cannon.dm
@@ -397,7 +397,7 @@ var/list/ob_type_fuel_requirements
 		if(get_turf(M) == target)
 			relative_dir = 0
 		else
-			relative_dir = get_dir(M, target)
+			relative_dir = Get_Compass_Dir(M, target)
 		M.show_message( \
 			SPAN_HIGHDANGER("The sky erupts into flames [SPAN_UNDERLINE(relative_dir ? ("to the " + dir2text(relative_dir)) : "right above you")]!"), SHOW_MESSAGE_VISIBLE, \
 			SPAN_HIGHDANGER("You hear a very loud sound coming from above to the [SPAN_UNDERLINE(relative_dir ? ("to the " + dir2text(relative_dir)) : "right above you")]!"), SHOW_MESSAGE_AUDIBLE \
@@ -408,7 +408,7 @@ var/list/ob_type_fuel_requirements
 		if(get_turf(M) == target)
 			relative_dir = 0
 		else
-			relative_dir = get_dir(M, target)
+			relative_dir = Get_Compass_Dir(M, target)
 		M.show_message( \
 			SPAN_HIGHDANGER("The sky roars louder [SPAN_UNDERLINE(relative_dir ? ("to the " + dir2text(relative_dir)) : "right above you")]!"), SHOW_MESSAGE_VISIBLE, \
 			SPAN_HIGHDANGER("The sound becomes louder [SPAN_UNDERLINE(relative_dir ? ("to the " + dir2text(relative_dir)) : "right above you")]!"), SHOW_MESSAGE_AUDIBLE \

--- a/code/modules/cm_marines/overwatch.dm
+++ b/code/modules/cm_marines/overwatch.dm
@@ -205,7 +205,7 @@
 						acting_sl = " (acting SL)"
 					is_squad_leader = TRUE
 				else if(current_turf && (current_turf.z == SL_z))
-					distance = "[get_dist(marine_human, current_squad.squad_leader)] ([dir2text_short(get_dir(current_squad.squad_leader, marine_human))])"
+					distance = "[get_dist(marine_human, current_squad.squad_leader)] ([dir2text_short(Get_Compass_Dir(current_squad.squad_leader, marine_human))])"
 
 
 			switch(marine_human.stat)

--- a/code/modules/cm_preds/yaut_bracers.dm
+++ b/code/modules/cm_preds/yaut_bracers.dm
@@ -496,7 +496,7 @@
 			if(dist < closest)
 				closest = dist
 				closest_item = tracked_item
-				direction = get_dir(M,loc)
+				direction = Get_Compass_Dir(M,loc)
 				areaLoc = loc
 	for(var/mob/living/carbon/human/Y as anything in GLOB.yautja_mob_list)
 		if(Y.stat != DEAD)
@@ -513,7 +513,7 @@
 			var/dist = get_dist(M,Y)
 			if(dist < closest)
 				closest = dist
-				direction = get_dir(M,Y)
+				direction = Get_Compass_Dir(M,Y)
 				areaLoc = loc
 
 	var/output = FALSE

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1330,7 +1330,7 @@
 			else if(C.z != src.z || get_dist(src,C) < 1)
 				hud_used.locate_leader.icon_state = "trackondirect_lz"
 			else
-				hud_used.locate_leader.setDir(get_dir(src,C))
+				hud_used.locate_leader.setDir(Get_Compass_Dir(src,C))
 				hud_used.locate_leader.icon_state = "trackon_lz"
 			return
 		if(TRACKER_FTL)
@@ -1360,7 +1360,7 @@
 	if(H.z != src.z || get_dist(src,H) < 1 || src == H)
 		hud_used.locate_leader.icon_state = "trackondirect[tracking_suffix]"
 	else
-		hud_used.locate_leader.setDir(get_dir(src,H))
+		hud_used.locate_leader.setDir(Get_Compass_Dir(src,H))
 		hud_used.locate_leader.icon_state = "trackon[tracking_suffix]"
 
 /mob/living/carbon/proc/locate_nearest_nuke()
@@ -1378,7 +1378,7 @@
 	if(get_dist(src,N) < 1)
 		hud_used.locate_nuke.icon_state = "nuke_trackondirect"
 	else
-		hud_used.locate_nuke.setDir(get_dir(src,N))
+		hud_used.locate_nuke.setDir(Get_Compass_Dir(src,N))
 		hud_used.locate_nuke.icon_state = "nuke_trackon"
 
 

--- a/code/modules/mob/living/carbon/human/species/yautja/yautja_sound.dm
+++ b/code/modules/mob/living/carbon/human/species/yautja/yautja_sound.dm
@@ -65,6 +65,6 @@
 		return
 
 	for(var/mob/current_mob as anything in get_mobs_in_z_level_range(get_turf(user), 18) - user)
-		var/relative_dir = get_dir(current_mob, user)
+		var/relative_dir = Get_Compass_Dir(current_mob, user)
 		var/final_dir = dir2text(relative_dir)
 		to_chat(current_mob, SPAN_HIGHDANGER("You hear a loud roar coming from [final_dir ? "the [final_dir]" : "nearby"]!"))

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -455,7 +455,7 @@ Make sure their actual health updates immediately.*/
 		var/area/A = get_area(loc)
 		var/area/QA = get_area(tracking_atom.loc)
 		if(A.fake_zlevel == QA.fake_zlevel)
-			QL.setDir(get_dir(src, tracking_atom))
+			QL.setDir(Get_Compass_Dir(src, tracking_atom))
 			QL.icon_state = "trackon"
 		else
 			QL.icon_state = "trackondirect"
@@ -484,7 +484,7 @@ Make sure their actual health updates immediately.*/
 		ML.overlays |= image('icons/mob/hud/xeno_markers.dmi', "all_direction")
 		return
 	else if(A.fake_zlevel == MA.fake_zlevel) //normal tracking
-		ML.setDir(get_dir(src, tracked_marker_turf))
+		ML.setDir(Get_Compass_Dir(src, tracked_marker_turf))
 		ML.overlays |= image(tracked_marker.seenMeaning, "pixel_y" = 0)
 		ML.overlays |= image('icons/mob/hud/xeno_markers.dmi', "center_glow")
 		ML.overlays |= image('icons/mob/hud/xeno_markers.dmi', "direction")

--- a/code/modules/projectiles/guns/boltaction.dm
+++ b/code/modules/projectiles/guns/boltaction.dm
@@ -214,7 +214,7 @@
 		return .
 
 	for(var/mob/current_mob as anything in get_mobs_in_z_level_range(get_turf(user), fire_message_range) - user)
-		var/relative_dir = get_dir(current_mob, user)
+		var/relative_dir = Get_Compass_Dir(current_mob, user)
 		var/final_dir = dir2text(relative_dir)
 		to_chat(current_mob, SPAN_HIGHDANGER("You hear a massive boom coming from [final_dir ? "the [final_dir]" : "nearby"]!"))
 		if(current_mob.client)

--- a/code/modules/shuttle/shuttles/crashable/crashable.dm
+++ b/code/modules/shuttle/shuttles/crashable/crashable.dm
@@ -26,7 +26,7 @@
 			found_turf.ChangeTurf(/turf/open/floor)
 
 	for(var/mob/current_mob as anything in get_mobs_in_z_level_range(destination.return_center_turf(), 18))
-		var/relative_dir = get_dir(current_mob, destination.return_center_turf())
+		var/relative_dir = Get_Compass_Dir(current_mob, destination.return_center_turf())
 		var/final_dir = dir2text(relative_dir)
 		to_chat(current_mob, SPAN_HIGHDANGER("You hear something crashing down from above [final_dir ? "to the [final_dir]" : "nearby"]!"))
 


### PR DESCRIPTION

# About the pull request

![image](https://github.com/cmss13-devs/cmss13/assets/14267245/cd0fcfba-04ae-4494-b0bf-106a645f69ef)

Swaps out `get_dir()` for `Get_Compass_Dir()` in multiple places. The criteria for the swap was:
- subject can be more than one tile away (otherwise results identical to `get_dir()`)
- is fed into a pointer or a warning message
- not used outside the pointer or message

This should not effect any actual game logic, only informative indicators.

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

Directional indicators should mean what people generally understand them to be. "Northeast" should be more accurate than "east and one tile north".
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Before:
![image](https://github.com/cmss13-devs/cmss13/assets/14267245/a5512b1f-7082-4990-9711-83dcef9204b6)

After:
![image](https://github.com/cmss13-devs/cmss13/assets/14267245/af10fbad-138f-4761-b988-76fbdd0ef1d8)

</details>


# Changelog
:cl:
qol: directions in trackers and messages are more accurate
/:cl:
