### PR TITLE
Fix vending_products register continue check

### DIFF
--- a/code/modules/asset_cache/asset_list.dm
+++ b/code/modules/asset_cache/asset_list.dm
@@ -18,12 +18,6 @@ GLOBAL_LIST_EMPTY(asset_datums)
 	GLOB.asset_datums[type] = src
 	register()
 
-/datum/asset/Destroy(force, ...)
-	. = ..()
-
-	log_debug("[type] has been destroyed.")
-	stack_trace("[type] has been destroyed.") // Remove these after testing - Morrow
-
 /datum/asset/proc/get_url_mappings()
 	return list()
 

--- a/code/modules/asset_cache/asset_list.dm
+++ b/code/modules/asset_cache/asset_list.dm
@@ -18,6 +18,12 @@ GLOBAL_LIST_EMPTY(asset_datums)
 	GLOB.asset_datums[type] = src
 	register()
 
+/datum/asset/Destroy(force, ...)
+	. = ..()
+
+	log_debug("[type] has been destroyed.")
+	stack_trace("[type] has been destroyed.") // Remove these after testing - Morrow
+
 /datum/asset/proc/get_url_mappings()
 	return list()
 

--- a/code/modules/asset_cache/asset_list_items.dm
+++ b/code/modules/asset_cache/asset_list_items.dm
@@ -305,6 +305,9 @@
 	name = "vending"
 
 /datum/asset/spritesheet/vending_products/register()
+	log_debug("[type] is registering.")
+	stack_trace("[type] is registering.") // Remove these after testing - Morrow
+
 	for (var/k in GLOB.vending_products)
 		var/atom/item = k
 		var/icon_file = initial(item.icon)
@@ -315,7 +318,9 @@
 			log_debug("not atom! [item]")
 			continue
 
-		if (sprites[icon_file])
+		var/imgid = replacetext(replacetext("[k]", "/obj/item/", ""), "/", "-")
+
+		if(sprites[imgid])
 			continue
 
 		if(icon_state in icon_states(icon_file))
@@ -339,7 +344,6 @@
 				item = new k()
 				I = icon(item.icon, item.icon_state, SOUTH)
 				qdel(item)
-		var/imgid = replacetext(replacetext("[k]", "/obj/item/", ""), "/", "-")
 
 		Insert(imgid, I)
 	return ..()

--- a/code/modules/asset_cache/asset_list_items.dm
+++ b/code/modules/asset_cache/asset_list_items.dm
@@ -305,9 +305,6 @@
 	name = "vending"
 
 /datum/asset/spritesheet/vending_products/register()
-	log_debug("[type] is registering.")
-	stack_trace("[type] is registering.") // Remove these after testing - Morrow
-
 	for (var/k in GLOB.vending_products)
 		var/atom/item = k
 		var/icon_file = initial(item.icon)


### PR DESCRIPTION
# About the pull request

This PR cherry picks https://github.com/PvE-CMSS13/PvE-CMSS13/pull/68 but removes the extra logging. That PR was attempting to resolve server hitching, but the hitching seems to have gone away with it and a TGS update.

I am not currently able to discern any noticeable differences from this change, however the change looks correct for the continue check to ever work correctly. See Testing Notes below.

Let me know if you do find a change this does improve, or maybe somewhere else we should expect superfluous calls to getFlatIcon.

# Explain why it's good for the game

The continue check as written looks like it would never work, whereas now the string that will be used for inserting into the list sprites is the same string we check before creating new icons.

# Testing Photographs and Procedure
<details>
<summary>Testing Notes</summary>

Debugging only:

Lobby (LV-624): 
One event of registering (master -> init Assets -> vending_products)
55 getFlatIcon calls (.124 total cpu)

Game Start: 
No changes

After opening CO vendors and cig vendor:
No changes

Alt+click self:
77 getFlatIcon calls (.353 total cpu)

Alt+click self again:
No changes

-----

After continue change:

Lobby (LV-624): 
One event of registering (master -> init Assets -> vending_products)
55 getFlatIcon calls (.117 total cpu)

Game Start: 
No changes

After opening CO vendors and cig vendor:
No changes

Alt+click self:
77 getFlatIcon calls (.346 total cpu)

Alt+click self again:
No changes

------

Debugging only w/ SVN:

Lobby (LV-624): 
One event of registering (master -> init Assets -> vending_products)
55 getFlatIcon calls (.124 total cpu)

Game Start: 
No changes

After opening CO vendors and cig vendor:
a GET was performed for first CO vendor and first cig vendor opened (never again)

Alt+click self:
77 getFlatIcon calls (.351 total cpu)
A GET is performed for every item listed

Alt+click self again:
A GET is performed for every item listed

-----

After continue change w/ SVN:

Lobby (LV-624): 
One event of registering (master -> init Assets -> vending_products)
55 getFlatIcon calls (.120 total cpu)

Game Start: 
No changes

After opening CO vendors and cig vendor:
a GET was performed for first CO vendor and first cig vendor opened (never again)

Alt+click self:
77 getFlatIcon calls (.347 total cpu)
A GET is performed for every item listed

Alt+click self again:
A GET is performed for every item listed

</details>


# Changelog
:cl: Morrow
code: Corrected a check to avoid repeat work in /datum/asset/spritesheet/vending_products/register()
/:cl:
