### PR TITLE
Fix plushie/fountain pen/family photo pickup runtime

### DIFF
--- a/code/game/objects/items/props/helmetgarb.dm
+++ b/code/game/objects/items/props/helmetgarb.dm
@@ -529,7 +529,7 @@
 /obj/item/prop/helmetgarb/family_photo/pickup(mob/user, silent)
 	. = ..()
 	if(!owner)
-		RegisterSignal(user, COMSIG_POST_SPAWN_UPDATE, PROC_REF(set_owner))
+		RegisterSignal(user, COMSIG_POST_SPAWN_UPDATE, PROC_REF(set_owner), override = TRUE)
 
 
 ///Sets the owner of the family photo to the human it spawns with, needs var/source for signals

--- a/code/game/objects/items/tools/misc_tools.dm
+++ b/code/game/objects/items/tools/misc_tools.dm
@@ -289,7 +289,7 @@
 /obj/item/tool/pen/fountain/pickup(mob/user, silent)
 	. = ..()
 	if(!owner_name)
-		RegisterSignal(user, COMSIG_POST_SPAWN_UPDATE, PROC_REF(set_owner))
+		RegisterSignal(user, COMSIG_POST_SPAWN_UPDATE, PROC_REF(set_owner), override = TRUE)
 
 ///Sets the owner of the pen to who it spawns with, requires var/source for signals
 /obj/item/tool/pen/fountain/proc/set_owner(datum/source)

--- a/code/game/objects/items/toys/toys.dm
+++ b/code/game/objects/items/toys/toys.dm
@@ -591,7 +591,7 @@
 
 /obj/item/toy/plush/random_plushie/pickup(mob/user, silent)
 	. = ..()
-	RegisterSignal(user, COMSIG_POST_SPAWN_UPDATE, PROC_REF(create_plushie))
+	RegisterSignal(user, COMSIG_POST_SPAWN_UPDATE, PROC_REF(create_plushie), override = TRUE)
 
 ///The randomizer picking and spawning a plushie on either the ground or in the humans backpack. Needs var/source due to signals
 /obj/item/toy/plush/random_plushie/proc/create_plushie(datum/source)


### PR DESCRIPTION
# About the pull request

![image](https://github.com/cmss13-devs/cmss13/assets/41448081/12e1f453-b26c-4c7e-aaed-cd5079a0ce4b)

I'm not 100% on why this happens. My best guess is it's the usual "clients don't follow the rules" stuff that lets them attempt to take the plushie out of their satchel before they're fully spawned in and started.