### PR TITLE
Lesser drones now die upon ghosting

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/lesser_drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/lesser_drone.dm
@@ -99,7 +99,7 @@
 /mob/living/carbon/xenomorph/lesser_drone/ghostize(can_reenter_corpse = FALSE, aghosted = FALSE)
 	. = ..()
 	if(. && !aghosted)
-		src.gib()
+		gib()
 
 /mob/living/carbon/xenomorph/lesser_drone/handle_ghost_message()
 	return

--- a/code/modules/mob/living/carbon/xenomorph/castes/lesser_drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/lesser_drone.dm
@@ -95,3 +95,11 @@
 	if (PF)
 		PF.flags_pass = PASS_MOB_IS_XENO|PASS_MOB_THRU_XENO
 		PF.flags_can_pass_all = PASS_MOB_IS_XENO|PASS_MOB_THRU_XENO
+
+/mob/living/carbon/xenomorph/lesser_drone/ghostize(can_reenter_corpse = FALSE, aghosted = FALSE)
+	. = ..()
+	if(.)
+		src.gib()
+
+/mob/living/carbon/xenomorph/lesser_drone/handle_ghost_message()
+	return

--- a/code/modules/mob/living/carbon/xenomorph/castes/lesser_drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/lesser_drone.dm
@@ -98,7 +98,7 @@
 
 /mob/living/carbon/xenomorph/lesser_drone/ghostize(can_reenter_corpse = FALSE, aghosted = FALSE)
 	. = ..()
-	if(.)
+	if(. && !aghosted)
 		src.gib()
 
 /mob/living/carbon/xenomorph/lesser_drone/handle_ghost_message()


### PR DESCRIPTION

# About the pull request

https://forum.cm-ss13.com/t/ghosted-lesser-drones-should-just-die/4356/10

Lessers now die upon ghosting and are not offered to observers.

# Explain why it's good for the game

Nobody likes trying to join as xeno or see their position in the queue only to see

Lesser Drone (420)
Lesser Drone (69)

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
del: Lesser drones die upon ghosting and are not offered to observers.
/:cl:
