### PR TITLE
Research fire chemicals buff

### DIFF
--- a/code/modules/reagents/chemistry_properties/prop_positive.dm
+++ b/code/modules/reagents/chemistry_properties/prop_positive.dm
@@ -756,7 +756,7 @@
 	description = "The chemical is oxidizing, increasing the intensity of chemical fires. However, the fuel is also burned slightly faster because of it."
 	rarity = PROPERTY_COMMON
 	value = 1
-	intensity_per_level = 6
+	intensity_per_level = 10
 	duration_per_level = -2
 
 	intensitymod_per_level = 0.2

--- a/code/modules/reagents/chemistry_reagents/other.dm
+++ b/code/modules/reagents/chemistry_reagents/other.dm
@@ -494,7 +494,7 @@
 	falloff_modifier = -0.1
 	burncolor = "#ff9900"
 	chemclass = CHEM_CLASS_RARE
-	properties = list(PROPERTY_FUELING = 5, PROPERTY_OXIDIZING = 3, PROPERTY_VISCOUS = 4, PROPERTY_TOXIC = 1)
+	properties = list(PROPERTY_FUELING = 5, PROPERTY_OXIDIZING = 2, PROPERTY_VISCOUS = 4, PROPERTY_TOXIC = 1)
 
 /datum/reagent/space_cleaner
 	name = "Space cleaner"


### PR DESCRIPTION
Stronger custom fire chems
# About the pull request

This PR is to buff the ability of research in making fire chems.

Currently. Fire chems are ridiculously expensive and inferior in all ways compared to your standard MST/NST meta stim.
For example, if you were to make a fueling10, oxi10, flowing5 (required to make the chemical work with a flamethrower). You would create a chemical that's but barely stronger than regular naphtalm.

With this PR, my hope is to bring this very neat ability of research into something more viable in the current state of the game. And hopefully, push current players in doing something else than always the same tired MST/NST stims


# Explain why it's good for the game

It allows research to produce viable flamer fuels more easily than before

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/cmss13-devs/cmss13/assets/115213778/c2b81b58-ef1d-4c30-94be-2519c4eb6a1f)

 
Here is pictured an oxidizing 10, fueling 10 chemical with the changes to the oxidizing property. The fuel is of course, much stronger but still allows certain castes to pat themselves out alone and survive it.
</details>


# Changelog
:cl:
balance: made the oxidizing property stronger.
/:cl:
