### PR TITLE
Mess tech scaling

### DIFF
--- a/code/game/jobs/job/civilians/other/mess_seargent.dm
+++ b/code/game/jobs/job/civilians/other/mess_seargent.dm
@@ -1,12 +1,30 @@
 /datum/job/civilian/chef
 	title = JOB_MESS_SERGEANT
-	total_positions = 1
+	total_positions = 2
 	spawn_positions = 1
+	allow_additional = 1
+	scaled = 1
 	selection_class = "job_ot"
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT
 	supervisors = "the auxiliary support officer"
 	gear_preset = /datum/equipment_preset/uscm_ship/chef
 	entry_message_body = "<a href='%WIKIURL%'>Your job is to service the marines with excellent food</a>, drinks and entertaining the shipside crew when needed. You have a lot of freedom and it is up to you, to decide what to do with it. Good luck!"
+
+/datum/job/civilian/chef/set_spawn_positions(count)
+	spawn_positions = mess_sergeant_slot_formula(count)
+
+/datum/job/civilian/chef/get_total_positions(latejoin = 0)
+	var/positions = spawn_positions
+	if(latejoin)
+		positions = mess_sergeant_slot_formula(get_total_marines())
+		if(positions <= total_positions_so_far)
+			positions = total_positions_so_far
+		else
+			total_positions_so_far = positions
+	else
+		total_positions_so_far = positions
+
+	return positions
 
 /obj/effect/landmark/start/chef
 	name = JOB_MESS_SERGEANT

--- a/code/game/jobs/job/civilians/other/mess_seargent.dm
+++ b/code/game/jobs/job/civilians/other/mess_seargent.dm
@@ -13,7 +13,7 @@
 /datum/job/civilian/chef/set_spawn_positions(count)
 	spawn_positions = mess_sergeant_slot_formula(count)
 
-/datum/job/civilian/chef/get_total_positions(latejoin = 0)
+/datum/job/civilian/chef/get_total_positions(latejoin = FALSE)
 	var/positions = spawn_positions
 	if(latejoin)
 		positions = mess_sergeant_slot_formula(get_total_marines())

--- a/code/game/jobs/job/civilians/other/mess_seargent.dm
+++ b/code/game/jobs/job/civilians/other/mess_seargent.dm
@@ -3,7 +3,7 @@
 	total_positions = 2
 	spawn_positions = 1
 	allow_additional = 1
-	scaled = 1
+	scaled = TRUE
 	selection_class = "job_ot"
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT
 	supervisors = "the auxiliary support officer"

--- a/code/game/jobs/job/civilians/other/mess_seargent.dm
+++ b/code/game/jobs/job/civilians/other/mess_seargent.dm
@@ -2,7 +2,7 @@
 	title = JOB_MESS_SERGEANT
 	total_positions = 2
 	spawn_positions = 1
-	allow_additional = 1
+	allow_additional = TRUE
 	scaled = TRUE
 	selection_class = "job_ot"
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT

--- a/code/game/jobs/slot_scaling.dm
+++ b/code/game/jobs/slot_scaling.dm
@@ -50,3 +50,6 @@
 
 /proc/working_joe_slot_formula(playercount)
 	return job_slot_formula(playercount,30,1,3,6)
+
+/proc/mess_sergeant_slot_formula(playercount)
+	return job_slot_formula(playercount, 70, 1, 1, 2)


### PR DESCRIPTION

# About the pull request

This PR adds scaling to allow for an extra mess tech slot once there are 70 marines playing.

This is a paid code request from a player.

# Explain why it's good for the game

Mess tech can be a lonely job and it can spice things up to have a partner in the culinary arts.

# Testing Photographs and Procedure

I spawned in as a mess tech.

I then created 50 marines and checked if I could spawn in as a mess tech. As expected the answer was no.

I then creates 20 more marines and checked if I could spawn in as a mess tech and could.


# Changelog

:cl: Morrow
add: Mess tech positions now scale from 1 to 2 after 70 marines are in the game
/:cl:
