### PR TITLE
Differentiates pylons in same area when spawning as lesser drone

### DIFF
--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -591,7 +591,11 @@ Additional game mode variables.
 
 	for(var/obj/effect/alien/resin/special/pylon/cycled_pylon as anything in hive.hive_structures[XENO_STRUCTURE_PYLON])
 		if(cycled_pylon.lesser_drone_spawns >= 1)
-			selection_list += "[cycled_pylon.name] at [get_area(cycled_pylon)]"
+			var/pylon_name = "[cycled_pylon.name] at [get_area(cycled_pylon)]"
+			if(!(pylon_name in selection_list))
+				selection_list += pylon_name
+			else
+				selection_list += pylon_name + " (1)"
 			selection_list_structure += cycled_pylon
 
 	if(!length(selection_list))

--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -591,11 +591,14 @@ Additional game mode variables.
 
 	for(var/obj/effect/alien/resin/special/pylon/cycled_pylon as anything in hive.hive_structures[XENO_STRUCTURE_PYLON])
 		if(cycled_pylon.lesser_drone_spawns >= 1)
+			var/pylon_number = 1
 			var/pylon_name = "[cycled_pylon.name] at [get_area(cycled_pylon)]"
-			if(!(pylon_name in selection_list))
-				selection_list += pylon_name
-			else
-				selection_list += pylon_name + " (1)"
+			//For renaming the pylon if we have duplicates
+			var/pylon_selection_name = pylon_name
+			while(pylon_selection_name in selection_list)
+				pylon_selection_name = "[pylon_name] ([pylon_number])"
+				pylon_number ++
+			selection_list += pylon_selection_name
 			selection_list_structure += cycled_pylon
 
 	if(!length(selection_list))


### PR DESCRIPTION

# About the pull request

Adds a (1) to duplicate named pylons if they reside in the same area when trying to spawn at pylon as lesser drone.
Fixes #4424 

# Explain why it's good for the game
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Pylons now differentiated in the input list with a (1) if in the same area.
/:cl:
