### PR TITLE
Fix buried larva spawn grace period at start of round

### DIFF
--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -370,13 +370,13 @@ Additional game mode variables.
 		if(!hive.hive_location && (world.time > XENO_BURIED_LARVA_TIME_LIMIT + SSticker.round_start_time))
 			continue
 
-			if(SSticker.mode && (SSticker.mode.flags_round_type & MODE_RANDOM_HIVE))
-				available_xenos |= "any buried larva"
-				LAZYADD(available_xenos["any buried larva"], hive)
-			else
-				var/larva_option = "buried larva ([hive])"
-				available_xenos += larva_option
-				available_xenos[larva_option] = list(hive)
+		if(SSticker.mode && (SSticker.mode.flags_round_type & MODE_RANDOM_HIVE))
+			available_xenos |= "any buried larva"
+			LAZYADD(available_xenos["any buried larva"], hive)
+		else
+			var/larva_option = "buried larva ([hive])"
+			available_xenos += larva_option
+			available_xenos[larva_option] = list(hive)
 
 	if(!available_xenos.len || (instant_join && !available_xenos_non_ssd.len))
 		if(!xeno_candidate.client || !xeno_candidate.client.prefs || !(xeno_candidate.client.prefs.be_special & BE_ALIEN_AFTER_DEATH))

--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -356,21 +356,27 @@ Additional game mode variables.
 		else
 			available_xenos_non_ssd += cur_xeno
 
-	// Only offer buried larva if there is no queue:
-	// This basically means this block of code will almost never execute, because we are instead relying on the hive cores/larva pops to handle their larva
-	// Technically this should be after a get_alien_candidates() call to be accurate, but we are intentionally trying to not call that proc as much as possible
-	if(GLOB.xeno_queue_candidate_count < 1)
-		var/datum/hive_status/hive
-		for(var/hivenumber in GLOB.hive_datum)
-			hive = GLOB.hive_datum[hivenumber]
-			if(!hive.hardcore && hive.stored_larva && (hive.hive_location || (world.time < XENO_BURIED_LARVA_TIME_LIMIT + SSticker.round_start_time)))
-				if(SSticker.mode && (SSticker.mode.flags_round_type & MODE_RANDOM_HIVE))
-					available_xenos |= "any buried larva"
-					LAZYADD(available_xenos["any buried larva"], hive)
-				else
-					var/larva_option = "buried larva ([hive])"
-					available_xenos += larva_option
-					available_xenos[larva_option] = list(hive)
+	var/datum/hive_status/hive
+	for(var/hivenumber in GLOB.hive_datum)
+		hive = GLOB.hive_datum[hivenumber]
+		if(hive.hardcore)
+			continue
+		if(!hive.stored_larva)
+			continue
+		// Only offer buried larva if there is no queue because we are instead relying on the hive cores/larva pops to handle their larva:
+		// Technically this should be after a get_alien_candidates() call to be accurate, but we are intentionally trying to not call that proc as much as possible
+		if(hive.hive_location && GLOB.xeno_queue_candidate_count > 0)
+			continue
+		if(!hive.hive_location && (world.time > XENO_BURIED_LARVA_TIME_LIMIT + SSticker.round_start_time))
+			continue
+
+			if(SSticker.mode && (SSticker.mode.flags_round_type & MODE_RANDOM_HIVE))
+				available_xenos |= "any buried larva"
+				LAZYADD(available_xenos["any buried larva"], hive)
+			else
+				var/larva_option = "buried larva ([hive])"
+				available_xenos += larva_option
+				available_xenos[larva_option] = list(hive)
 
 	if(!available_xenos.len || (instant_join && !available_xenos_non_ssd.len))
 		if(!xeno_candidate.client || !xeno_candidate.client.prefs || !(xeno_candidate.client.prefs.be_special & BE_ALIEN_AFTER_DEATH))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Looking at the code again, #4502 is unintentionally eliminating the buried larva grace period when there is no core. The first 30 minutes should have a core be optional (because the hive is still being established), but the queue requires a core (or nested bodies) to dequeue players from the queue. So as soon as there is one player in queue, buried spawns during the no-core grace period would be stopped.

This PR makes it so the queue will only prevent manual buried spawns when there is a core.

# Explain why it's good for the game

Fixes a situation that needlessly hinders xeno start if the hive puts off creating a core.

Also the logic was getting fairly complex here so the early returns should make it more manageable.

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl: Drathek
fix: Fixed buried larva spawn grace period at start of round if there is a queue: Now join as xeno when there's a queue will only prevent buried larva spawns if there is no core.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
