### PR TITLE
Fix resin doors not closing on mob/living if they are merged with weeds

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -147,6 +147,8 @@
 #define TRAIT_IMMOBILIZED "immobilized"
 /// Apply this to make a mob not dense, and remove it when you want it to no longer make them undense, other sorces of undesity will still apply. Always define a unique source when adding a new instance of this!
 #define TRAIT_UNDENSE "undense"
+/// Apply this to identify a mob as merged with weeds
+#define TRAIT_MERGED_WITH_WEEDS "merged_with_weeds"
 
 // SPECIES TRAITS
 /// Knowledge of Yautja technology

--- a/code/datums/components/weed_food.dm
+++ b/code/datums/components/weed_food.dm
@@ -260,6 +260,7 @@
 	merged = TRUE
 
 	ADD_TRAIT(parent_mob, TRAIT_UNDENSE, XENO_WEED_TRAIT)
+	ADD_TRAIT(parent_mob, TRAIT_MERGED_WITH_WEEDS, XENO_WEED_TRAIT)
 	parent_mob.anchored = TRUE
 	parent_mob.mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	parent_mob.plane = FLOOR_PLANE
@@ -288,6 +289,7 @@
 		UnregisterSignal(absorbing_weeds, COMSIG_PARENT_QDELETING)
 	absorbing_weeds = null
 
+	REMOVE_TRAIT(parent_mob, TRAIT_MERGED_WITH_WEEDS, XENO_WEED_TRAIT)
 	parent_mob.anchored = FALSE
 	parent_mob.mouse_opacity = MOUSE_OPACITY_ICON
 	parent_mob.plane = GAME_PLANE

--- a/code/modules/cm_aliens/XenoStructures.dm
+++ b/code/modules/cm_aliens/XenoStructures.dm
@@ -422,14 +422,22 @@
 		if(!isSwitchingStates && state == 1)
 			Close()
 
+/obj/structure/mineral_door/resin/proc/close_blocked()
+	for(var/turf/turf in locs)
+		for(var/mob/living/living_mob in turf)
+			var/datum/component/weed_food/weed = living_mob.GetComponent(/datum/component/weed_food)
+			if(!weed?.merged)
+				return TRUE
+	return FALSE
+
 /obj/structure/mineral_door/resin/Close()
 	if(!state || !loc) return //already closed
 	//Can't close if someone is blocking it
-	for(var/turf/turf in locs)
-		if(locate(/mob/living) in turf)
-			spawn (close_delay)
-				Close()
-			return
+	if(close_blocked())
+		spawn(close_delay)
+			Close()
+		return
+
 	isSwitchingStates = 1
 	playsound(loc, "alien_resin_move", 25)
 	flick("[mineralType]closing",src)
@@ -440,10 +448,10 @@
 	update_icon()
 	isSwitchingStates = 0
 	layer = DOOR_CLOSED_LAYER
-	for(var/turf/turf in locs)
-		if(locate(/mob/living) in turf)
-			Open()
-			return
+
+	if(close_blocked())
+		Open()
+		return
 
 /obj/structure/mineral_door/resin/Dismantle(devastated = 0)
 	qdel(src)

--- a/code/modules/cm_aliens/XenoStructures.dm
+++ b/code/modules/cm_aliens/XenoStructures.dm
@@ -418,9 +418,7 @@
 	update_icon()
 	isSwitchingStates = 0
 	layer = DOOR_OPEN_LAYER
-	spawn(close_delay)
-		if(!isSwitchingStates && state == 1)
-			Close()
+	addtimer(CALLBACK(src, PROC_REF(Close)), close_delay, TIMER_UNIQUE|TIMER_OVERRIDE)
 
 /obj/structure/mineral_door/resin/proc/close_blocked()
 	for(var/turf/turf in locs)
@@ -430,11 +428,11 @@
 	return FALSE
 
 /obj/structure/mineral_door/resin/Close()
-	if(!state || !loc) return //already closed
+	if(!state || !loc || isSwitchingStates)
+		return //already closed or changing
 	//Can't close if someone is blocking it
 	if(close_blocked())
-		spawn(close_delay)
-			Close()
+		addtimer(CALLBACK(src, PROC_REF(Close)), close_delay, TIMER_UNIQUE|TIMER_OVERRIDE)
 		return
 
 	isSwitchingStates = 1

--- a/code/modules/cm_aliens/XenoStructures.dm
+++ b/code/modules/cm_aliens/XenoStructures.dm
@@ -425,8 +425,7 @@
 /obj/structure/mineral_door/resin/proc/close_blocked()
 	for(var/turf/turf in locs)
 		for(var/mob/living/living_mob in turf)
-			var/datum/component/weed_food/weed = living_mob.GetComponent(/datum/component/weed_food)
-			if(!weed?.merged)
+			if(!HAS_TRAIT(living_mob, TRAIT_MERGED_WITH_WEEDS))
 				return TRUE
 	return FALSE
 


### PR DESCRIPTION
# About the pull request

This PR simply changes the mob/living check in `/obj/structure/mineral_door/resin/Close()` to also account for whether they are merged with the weeds. As soon as xeno corpses are also merging with weeds this will handle them too.

# Explain why it's good for the game

Although I think this is a very rare situation, it can be especially confusing if a fully weeded corpse that intentionally is hard to see is causing a door to not close (seemingly arbitrarily).

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

https://github.com/cmss13-devs/cmss13/assets/76988376/4770ff65-c484-4e88-9381-19dfad22ffae

</details>


# Changelog
:cl: Drathek
fix: Resin doors will now close on dead mobs that are merged with weeds (currently only human).
fix: Resin doors will now restart their closing timer each open making the delay to close consistent.
code: Added a TRAIT_MERGED_WITH_WEEDS that is set whenever the mob is currently merged with weeds.
/:cl:
