### PR TITLE
Refactors Xeno name generation and set hive and update

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
@@ -554,19 +554,13 @@
 //Off-load this proc so it can be called freely
 //Since Xenos change names like they change shoes, we need somewhere to hammer in all those legos
 //We set their name first, then update their real_name AND their mind name
+//Off-load this proc so it can be called freely
+//Since Xenos change names like they change shoes, we need somewhere to hammer in all those legos
+//We set their name first, then update their real_name AND their mind name
 /mob/living/carbon/xenomorph/proc/generate_name()
 	//We don't have a nicknumber yet, assign one to stick with us
 	if(!nicknumber)
-		var/tempnumber = rand(1, 999)
-		var/list/numberlist = list()
-		for(var/mob/living/carbon/xenomorph/X in GLOB.xeno_mob_list)
-			numberlist += X.nicknumber
-
-		while(tempnumber in numberlist)
-			tempnumber = rand(1, 999)
-
-		nicknumber = tempnumber
-
+		generate_and_set_nicknumber()
 	// Even if we don't have the hive datum we usually still have the hive number
 	var/datum/hive_status/in_hive = hive
 	if(!in_hive)
@@ -575,12 +569,10 @@
 	//Im putting this in here, because this proc gets called when a player inhabits a SSD xeno and it needs to go somewhere (sorry)
 	hud_set_marks()
 
-	handle_name(in_hive)
-
-/mob/living/carbon/xenomorph/proc/handle_name(datum/hive_status/in_hive)
 	var/name_prefix = in_hive.prefix
 	var/name_client_prefix = ""
 	var/name_client_postfix = ""
+	var/number_decorator = ""
 	if(client)
 		name_client_prefix = "[(client.xeno_prefix||client.xeno_postfix) ? client.xeno_prefix : "XX"]-"
 		name_client_postfix = client.xeno_postfix ? ("-"+client.xeno_postfix) : ""
@@ -591,9 +583,12 @@
 
 	var/age_display = show_age_prefix ? age_prefix : ""
 	var/name_display = ""
+	// Rare easter egg
+	if(nicknumber == 666)
+		number_decorator = "Infernal "
 	if(show_name_numbers)
 		name_display = show_only_numbers ? " ([nicknumber])" : " ([name_client_prefix][nicknumber][name_client_postfix])"
-	name = "[name_prefix][age_display][caste.display_name || caste.caste_type][name_display]"
+	name = "[name_prefix][number_decorator][age_display][caste.display_name || caste.caste_type][name_display]"
 
 	//Update linked data so they show up properly
 	change_real_name(src, name)
@@ -813,23 +808,17 @@
 /mob/living/carbon/xenomorph/proc/set_hive_and_update(new_hivenumber = XENO_HIVE_NORMAL)
 	var/datum/hive_status/new_hive = GLOB.hive_datum[new_hivenumber]
 	if(!new_hive)
-		return
+		return FALSE
 
-	for(var/T in _status_traits) // They can't keep getting away with this!!!
-		REMOVE_TRAIT(src, T, TRAIT_SOURCE_HIVE)
+	for(var/trait in _status_traits) // They can't keep getting away with this!!!
+		REMOVE_TRAIT(src, trait, TRAIT_SOURCE_HIVE)
 
 	new_hive.add_xeno(src)
 
-	for(var/T in new_hive.hive_inherant_traits)
-		ADD_TRAIT(src, T, TRAIT_SOURCE_HIVE)
+	for(var/trait in new_hive.hive_inherant_traits)
+		ADD_TRAIT(src, trait, TRAIT_SOURCE_HIVE)
 
-	if(istype(src, /mob/living/carbon/xenomorph/larva))
-		var/mob/living/carbon/xenomorph/larva/L = src
-		L.update_icons() // larva renaming done differently
-	else
-		generate_name()
-	if(istype(src, /mob/living/carbon/xenomorph/queen))
-		update_living_queens()
+	generate_name()
 
 	lock_evolve = FALSE
 	banished = FALSE
@@ -839,6 +828,9 @@
 
 	// Update the hive status UI
 	new_hive.hive_ui.update_all_xeno_data()
+
+	return TRUE
+
 
 //*********************************************************//
 //********************Mutator functions********************//
@@ -1112,3 +1104,16 @@
 	. = ..()
 	if(!resting) // !resting because we dont wanna prematurely update wounds if they're just trying to rest
 		update_wounds()
+
+///Generate a new unused nicknumber for the current hive, if hive doesn't exist return 0
+/mob/living/carbon/xenomorph/proc/generate_and_set_nicknumber()
+	if(!hive)
+		//If hive doesn't exist make it 0
+		nicknumber = 0
+		return
+	var/datum/hive_status/hive_status = hive
+	if(length(hive_status.available_nicknumbers))
+		nicknumber = pick_n_take(hive_status.available_nicknumbers)
+	else
+		//If we somehow use all 999 numbers fallback on 0
+		nicknumber = 0

--- a/code/modules/mob/living/carbon/xenomorph/castes/Larva.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Larva.dm
@@ -50,15 +50,22 @@
 
 	var/burrowable = TRUE //Can it be safely burrowed if it has no player?
 	var/state_override
+	var/is_bloody = TRUE //We're still "bloody"
 
 	icon_xeno = 'icons/mob/xenos/larva.dmi'
 	icon_xenonid = 'icons/mob/xenonids/larva.dmi'
 
-/mob/living/carbon/xenomorph/larva/initialize_pass_flags(datum/pass_flags_container/PF)
+/mob/living/carbon/xenomorph/larva/Life()
+	if(is_bloody && (evolution_stored >= evolution_threshold / 2)) //We're no longer bloody so update our name...
+		generate_name()
+		is_bloody = FALSE
+	return ..()
+
+/mob/living/carbon/xenomorph/larva/initialize_pass_flags(datum/pass_flags_container/pass_flags)
 	..()
-	if (PF)
-		PF.flags_pass = PASS_MOB_THRU|PASS_FLAGS_CRAWLER
-		PF.flags_can_pass_all = PASS_ALL^PASS_OVER_THROW_ITEM
+	if (pass_flags)
+		pass_flags.flags_pass = PASS_MOB_THRU|PASS_FLAGS_CRAWLER
+		pass_flags.flags_can_pass_all = PASS_ALL^PASS_OVER_THROW_ITEM
 
 /mob/living/carbon/xenomorph/larva/corrupted
 	hivenumber = XENO_HIVE_CORRUPTED
@@ -101,29 +108,10 @@
 
 //Larva code is just a mess, so let's get it over with
 /mob/living/carbon/xenomorph/larva/update_icons()
-	var/progress = "" //Naming convention, three different names
 	var/state = "" //Icon convention, two different sprite sets
 
-	var/name_prefix = ""
-
-	if(hive)
-		name_prefix = hive.prefix
-		color = hive.color
-
-	if(evolution_stored >= evolution_threshold)
-		progress = "Mature "
-	else if(evolution_stored < evolution_threshold / 2) //We're still bloody
-		progress = "Bloody "
+	if(evolution_stored < evolution_threshold / 2) //We're still bloody
 		state = "Bloody "
-	else
-		progress = ""
-
-	name = "[name_prefix][progress]Larva ([nicknumber])"
-
-	if(istype(src,/mob/living/carbon/xenomorph/larva/predalien)) state = "Predalien " //Sort of a hack.
-
-	//Update linked data so they show up properly
-	change_real_name(src, name)
 
 	if(stat == DEAD)
 		icon_state = "[state_override || state]Larva Dead"
@@ -141,16 +129,13 @@
 /mob/living/carbon/xenomorph/larva/alter_ghost(mob/dead/observer/ghost)
 	ghost.icon_state = "[caste.caste_type]"
 
-/mob/living/carbon/xenomorph/larva/handle_name()
-	return
-
 /mob/living/carbon/xenomorph/larva/start_pulling(atom/movable/AM)
 	return
 
 /mob/living/carbon/xenomorph/larva/pull_response(mob/puller)
 	return TRUE
 
-/mob/living/carbon/xenomorph/larva/UnarmedAttack(atom/A, proximity, click_parameters, tile_attack, ignores_resin = FALSE)
+/mob/living/carbon/xenomorph/larva/UnarmedAttack(atom/atom, proximity, click_parameters, tile_attack, ignores_resin = FALSE)
 	a_intent = INTENT_HELP //Forces help intent for all interactions.
 	if(!caste)
 		return FALSE
@@ -158,21 +143,50 @@
 	if(lying) //No attacks while laying down
 		return FALSE
 
-	A.attack_larva(src)
+	atom.attack_larva(src)
 	xeno_attack_delay(src) //Adds some lag to the 'attack'
 
-/proc/spawn_hivenumber_larva(atom/A, hivenumber)
-	if(!GLOB.hive_datum[hivenumber] || isnull(A))
+/proc/spawn_hivenumber_larva(atom/atom, hivenumber)
+	if(!GLOB.hive_datum[hivenumber] || isnull(atom))
 		return
 
-	var/mob/living/carbon/xenomorph/larva/L = new /mob/living/carbon/xenomorph/larva(A)
+	var/mob/living/carbon/xenomorph/larva/larva = new /mob/living/carbon/xenomorph/larva(atom)
 
-	L.set_hive_and_update(hivenumber)
+	larva.set_hive_and_update(hivenumber)
 
-	return L
+	return larva
 
 /mob/living/carbon/xenomorph/larva/emote(act, m_type, message, intentional, force_silence)
 	playsound(loc, "alien_roar_larva", 15)
 
 /mob/living/carbon/xenomorph/larva/is_xeno_grabbable()
 	return TRUE
+
+/*
+Larva name generation, set nicknumber = (number between 1 & 999) which isn't taken by any other xenos in GLOB.xeno_mob_list if doesn't already exist.
+Also handles the "Mature / Bloody naming convention. Call this to update the name."
+*/
+/mob/living/carbon/xenomorph/larva/generate_name()
+	if(!nicknumber)
+		generate_and_set_nicknumber()
+
+	var/progress = "" //Naming convention, three different names
+	var/name_prefix = "" // Prefix for hive
+
+	if(hive)
+		name_prefix = hive.prefix
+		color = hive.color
+
+	if(evolution_stored >= evolution_threshold)
+		progress = "Mature "
+	else if(evolution_stored < evolution_threshold / 2) //We're still bloody
+		progress = "Bloody "
+
+	name = "[name_prefix][progress]Larva ([nicknumber])"
+
+	//Update linked data so they show up properly
+	change_real_name(src, name)
+	//Update the hive status UI
+	if(hive)
+		var/datum/hive_status/hive_status = hive
+		hive_status.hive_ui.update_xeno_info()

--- a/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
@@ -409,8 +409,10 @@
 
 	AddComponent(/datum/component/footstep, 2 , 35, 11, 4, "alien_footstep_large")
 
-/mob/living/carbon/xenomorph/queen/handle_name(datum/hive_status/in_hive)
-	var/name_prefix = in_hive.prefix
+/mob/living/carbon/xenomorph/queen/generate_name()
+	if(!nicknumber)
+		generate_and_set_nicknumber()
+	var/name_prefix = hive.prefix
 	if(queen_aged)
 		age_xeno()
 		switch(age)
@@ -439,7 +441,7 @@
 		name_client_prefix = "[(client.xeno_prefix||client.xeno_postfix) ? client.xeno_prefix : "XX"]-"
 		name_client_postfix = client.xeno_postfix ? ("-"+client.xeno_postfix) : ""
 	full_designation = "[name_client_prefix][nicknumber][name_client_postfix]"
-	color = in_hive.color
+	color = hive.color
 
 	//Update linked data so they show up properly
 	change_real_name(src, name)

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -365,6 +365,8 @@
 	var/datum/tacmap/drawing/xeno/tacmap
 	var/minimap_type = MINIMAP_FLAG_XENO
 
+	var/list/available_nicknumbers = list()
+
 /datum/hive_status/New()
 	mutators.hive = src
 	hive_ui = new(src)
@@ -376,6 +378,9 @@
 		internal_faction = name
 	if(hivenumber != XENO_HIVE_NORMAL)
 		return
+
+	for(var/number in 1 to 999)
+		available_nicknumbers += number
 
 	RegisterSignal(SSdcs, COMSIG_GLOB_POST_SETUP, PROC_REF(post_setup))
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Refactors xenomorph name generation. Everything is now handled in `generate_name()`. Refactored out `istype(src)`
Larva name generation no longer handled in `update_icons()`

All hive datums now have a list of 1-999 which gets picked from. If that list is empty it will fall-back on 0. I can add functionality for generating a new list but seriously when do we ever get through 999 lives.

Removes `istype(src)` from `set_hive_and_update()`

Adds "Infernal" name prefix for xeno who rolls 666 as a little easter egg.

# Explain why it's good for the game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
add: "Infernal" name prefix for xeno who rolls number 666
code: Refactors xeno name generation. Larva name generation and removes some istype(src)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
