### PR TITLE
Makes Thunderdome Floor Explosion-Proof

### DIFF
--- a/code/game/turfs/floor_types.dm
+++ b/code/game/turfs/floor_types.dm
@@ -203,6 +203,13 @@
 	icon_state = "default"
 	plating_type = /turf/open/floor/plating/almayer
 
+/// Admin level thunderdome floor. Doesn't get damaged by explosions and such for pristine testing
+/turf/open/floor/tdome
+	icon = 'icons/turf/almayer.dmi'
+	icon_state = "plating"
+	plating_type = /turf/open/floor/tdome
+	hull_floor = TRUE
+
 //Cargo elevator
 /turf/open/floor/almayer/empty
 	name = "empty space"

--- a/maps/map_files/generic/Admin_level.dmm
+++ b/maps/map_files/generic/Admin_level.dmm
@@ -12,7 +12,7 @@
 /turf/open/floor/wood/ship,
 /area/adminlevel/ert_station)
 "ad" = (
-/turf/open/floor/almayer{
+/turf/open/floor/tdome{
 	dir = 5;
 	icon_state = "plating"
 	},
@@ -27,7 +27,7 @@
 	id = "tdome_observer";
 	name = "\improper Observer Shutters"
 	},
-/turf/open/floor/almayer{
+/turf/open/floor/tdome{
 	dir = 5;
 	icon_state = "plating"
 	},
@@ -63,7 +63,7 @@
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
 	},
-/turf/open/floor/almayer{
+/turf/open/floor/tdome{
 	dir = 5;
 	icon_state = "plating"
 	},
@@ -72,7 +72,7 @@
 /obj/effect/decal/warning_stripes{
 	icon_state = "E"
 	},
-/turf/open/floor/almayer{
+/turf/open/floor/tdome{
 	dir = 5;
 	icon_state = "plating"
 	},
@@ -83,7 +83,7 @@
 	id = "tdome_t2";
 	name = "\improper Team 2 Shutters"
 	},
-/turf/open/floor/almayer{
+/turf/open/floor/tdome{
 	icon_state = "test_floor4"
 	},
 /area/tdome)
@@ -101,7 +101,7 @@
 /turf/open/space,
 /area/space)
 "aE" = (
-/turf/open/floor/almayer{
+/turf/open/floor/tdome{
 	dir = 1;
 	icon_state = "w-y0"
 	},
@@ -683,7 +683,7 @@
 /obj/item/device/binoculars{
 	pixel_y = 4
 	},
-/turf/open/floor/almayer{
+/turf/open/floor/tdome{
 	dir = 5;
 	icon_state = "plating"
 	},
@@ -896,7 +896,7 @@
 	},
 /area/adminlevel/ert_station/shuttle_dispatch)
 "wj" = (
-/turf/open/floor/almayer{
+/turf/open/floor/tdome{
 	dir = 1;
 	icon_state = "w-y2"
 	},
@@ -921,7 +921,7 @@
 /area/adminlevel/ert_station)
 "wv" = (
 /obj/structure/machinery/vending/snack,
-/turf/open/floor/almayer{
+/turf/open/floor/tdome{
 	dir = 5;
 	icon_state = "plating"
 	},
@@ -1147,7 +1147,7 @@
 /obj/effect/decal/warning_stripes{
 	icon_state = "E"
 	},
-/turf/open/floor/almayer{
+/turf/open/floor/tdome{
 	dir = 5;
 	icon_state = "plating"
 	},
@@ -1163,7 +1163,7 @@
 /obj/structure/flora/pottedplant{
 	icon_state = "pottedplant_20"
 	},
-/turf/open/floor/almayer{
+/turf/open/floor/tdome{
 	dir = 5;
 	icon_state = "plating"
 	},
@@ -1277,13 +1277,13 @@
 /turf/open/floor/plating/almayer,
 /area/adminlevel/ert_station/shuttle_dispatch)
 "DV" = (
-/turf/open/floor/almayer{
+/turf/open/floor/tdome{
 	icon_state = "tcomms"
 	},
 /area/tdome)
 "Ee" = (
 /obj/effect/landmark/thunderdome/one,
-/turf/open/floor/almayer{
+/turf/open/floor/tdome{
 	dir = 5;
 	icon_state = "plating"
 	},
@@ -1375,7 +1375,7 @@
 "Fw" = (
 /obj/structure/surface/table/almayer,
 /obj/item/storage/fancy/cigar,
-/turf/open/floor/almayer{
+/turf/open/floor/tdome{
 	dir = 5;
 	icon_state = "plating"
 	},
@@ -1639,7 +1639,7 @@
 /turf/closed/wall/mineral/gold,
 /area/adminlevel/ert_station)
 "Kq" = (
-/turf/open/floor/almayer{
+/turf/open/floor/tdome{
 	icon_state = "redfull"
 	},
 /area/tdome/tdome2)
@@ -1738,7 +1738,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/turf/open/floor/almayer{
+/turf/open/floor/tdome{
 	dir = 5;
 	icon_state = "plating"
 	},
@@ -1871,7 +1871,7 @@
 /area/adminlevel/ert_station)
 "NU" = (
 /obj/structure/machinery/vending/cola,
-/turf/open/floor/almayer{
+/turf/open/floor/tdome{
 	dir = 5;
 	icon_state = "plating"
 	},
@@ -1937,7 +1937,7 @@
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
 	},
-/turf/open/floor/almayer{
+/turf/open/floor/tdome{
 	dir = 5;
 	icon_state = "plating"
 	},
@@ -1967,13 +1967,13 @@
 /area/adminlevel/simulation)
 "PF" = (
 /obj/effect/landmark/thunderdome/two,
-/turf/open/floor/almayer{
+/turf/open/floor/tdome{
 	dir = 5;
 	icon_state = "plating"
 	},
 /area/tdome/tdome2)
 "PJ" = (
-/turf/open/floor/almayer{
+/turf/open/floor/tdome{
 	dir = 1;
 	icon_state = "w-y1"
 	},
@@ -2041,7 +2041,7 @@
 /area/adminlevel/ert_station)
 "QL" = (
 /obj/structure/bed/chair/comfy/black,
-/turf/open/floor/almayer{
+/turf/open/floor/tdome{
 	icon_state = "tcomms"
 	},
 /area/tdome/tdomeobserve)
@@ -2095,7 +2095,7 @@
 	id = "tdome_t1";
 	name = "\improper Team 1 Shutters"
 	},
-/turf/open/floor/almayer{
+/turf/open/floor/tdome{
 	icon_state = "test_floor4"
 	},
 /area/tdome)
@@ -2165,7 +2165,7 @@
 	name = "Observer Shutters";
 	pixel_y = 9
 	},
-/turf/open/floor/almayer{
+/turf/open/floor/tdome{
 	dir = 5;
 	icon_state = "plating"
 	},
@@ -2313,7 +2313,7 @@
 /area/adminlevel/ert_station)
 "VD" = (
 /obj/structure/machinery/vending/cigarette/free,
-/turf/open/floor/almayer{
+/turf/open/floor/tdome{
 	dir = 5;
 	icon_state = "plating"
 	},
@@ -2483,7 +2483,7 @@
 	},
 /area/adminlevel/ert_station)
 "YP" = (
-/turf/open/floor/almayer{
+/turf/open/floor/tdome{
 	dir = 5;
 	icon_state = "plating"
 	},
@@ -2498,7 +2498,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/adminlevel/ert_station)
 "Zd" = (
-/turf/open/floor/almayer{
+/turf/open/floor/tdome{
 	icon_state = "bluefull"
 	},
 /area/tdome/tdome1)


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

Explosions could permanently mess with the tdome floor. This looks ugly and happens frequently with the amount of abombs thrown in it.

# Explain why it's good for the game
Admin level looks cleaner and clearer.

# Testing Photographs and Procedure
Drop-Bomb enter enter

DMM edited in-place via regex, shouldn't be any mapmerging issues

# Changelog
:cl:
fix: The Thunderdome floor is now explosion-proof.
/:cl:
