### PR TITLE
Phone QOL - Last Caller ID

### DIFF
--- a/code/modules/cm_phone/phone.dm
+++ b/code/modules/cm_phone/phone.dm
@@ -26,6 +26,8 @@ GLOBAL_LIST_EMPTY_TYPED(transmitters, /obj/structure/transmitter)
 	var/enabled = TRUE
 	/// Whether or not the phone is receiving calls or not. Varies between on/off or forcibly on/off.
 	var/do_not_disturb = PHONE_DND_OFF
+	/// The Phone_ID of the last person to call this telephone.
+	var/last_caller
 
 	var/base_icon_state
 
@@ -138,6 +140,7 @@ GLOBAL_LIST_EMPTY_TYPED(transmitters, /obj/structure/transmitter)
 	var/list/data = list()
 
 	data["availability"] = do_not_disturb
+	data["last_caller"] = last_caller
 
 	return data
 
@@ -175,6 +178,7 @@ GLOBAL_LIST_EMPTY_TYPED(transmitters, /obj/structure/transmitter)
 
 	calling = T
 	T.caller = src
+	T.last_caller = src.phone_id
 	T.update_icon()
 
 	to_chat(user, SPAN_PURPLE("[icon2html(src, user)] Dialing [calling_phone_id].."))

--- a/tgui/packages/tgui/interfaces/PhoneMenu.js
+++ b/tgui/packages/tgui/interfaces/PhoneMenu.js
@@ -15,7 +15,7 @@ export const PhoneMenu = (props, context) => {
 
 const GeneralPanel = (props, context) => {
   const { act, data } = useBackend(context);
-  const { availability } = data;
+  const { availability, last_caller } = data;
   const available_transmitters = Object.keys(data.available_transmitters);
   const transmitters = data.transmitters.filter((val1) =>
     available_transmitters.includes(val1.phone_id)
@@ -131,6 +131,7 @@ const GeneralPanel = (props, context) => {
             />
           </Stack.Item>
         )}
+        {!!last_caller && <Stack.Item>Last Caller: {last_caller}</Stack.Item>}
         <Stack.Item>
           <Button
             content="Do Not Disturb"


### PR DESCRIPTION

# About the pull request
Phones now log the last phone_id to call them.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
QOL, sometimes you miss calls, other times people are... irritating.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.
![image](https://github.com/cmss13-devs/cmss13/assets/41653574/9d90f07a-82be-4e1c-94e8-88a366c97425)

</details>


# Changelog
:cl:
add: Telephones now list the last attempted caller, above the DND button.
/:cl:
