### PR TITLE
Fixes runtime with fire extinguisher cabinets on lifeboats

### DIFF
--- a/code/game/objects/structures/extinguisher.dm
+++ b/code/game/objects/structures/extinguisher.dm
@@ -13,6 +13,7 @@
 	. = ..()
 	base_icon = initial(icon_state)
 	has_extinguisher = new /obj/item/tool/extinguisher()
+	has_extinguisher.forceMove(src)
 
 /obj/structure/extinguisher_cabinet/lifeboat
 	name = "extinguisher cabinet"
@@ -22,15 +23,15 @@
 /obj/structure/extinguisher_cabinet/alt
 	icon_state = "extinguisher_alt"
 
-/obj/structure/extinguisher_cabinet/attackby(obj/item/O, mob/user)
+/obj/structure/extinguisher_cabinet/attackby(obj/item/item, mob/user)
 	if(isrobot(user))
 		return
-	if(istype(O, /obj/item/tool/extinguisher))
+	if(istype(item, /obj/item/tool/extinguisher))
 		if(!has_extinguisher && opened)
 			user.drop_held_item()
-			contents += O
-			has_extinguisher = O
-			to_chat(user, SPAN_NOTICE("You place [O] in [src]."))
+			item.forceMove(src)
+			has_extinguisher = item
+			to_chat(user, SPAN_NOTICE("You place [item] in [src]."))
 		else
 			opened = !opened
 	else
@@ -46,7 +47,7 @@
 		user.put_in_hands(has_extinguisher)
 		to_chat(user, SPAN_NOTICE("You take [has_extinguisher] from [src]."))
 		has_extinguisher = null
-		opened = 1
+		opened = TRUE
 	else
 		opened = !opened
 	update_icon()

--- a/code/game/objects/structures/extinguisher.dm
+++ b/code/game/objects/structures/extinguisher.dm
@@ -5,13 +5,14 @@
 	icon_state = "extinguisher"
 	anchored = TRUE
 	density = FALSE
-	var/obj/item/tool/extinguisher/has_extinguisher = new/obj/item/tool/extinguisher
+	var/obj/item/tool/extinguisher/has_extinguisher
 	var/opened = 0
 	var/base_icon
 
 /obj/structure/extinguisher_cabinet/Initialize()
 	. = ..()
 	base_icon = initial(icon_state)
+	has_extinguisher = new /obj/item/tool/extinguisher()
 
 /obj/structure/extinguisher_cabinet/lifeboat
 	name = "extinguisher cabinet"


### PR DESCRIPTION

# About the pull request
Fixes #3998

Fire extinguisher cabinets now new() a fire extinguisher properly in `Intialize()`

# Explain why it's good for the game

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Lifeboats fire extinguisher runtime.
/:cl:
