### PR TITLE
More readable colour for the 'Maintainer' section in staffwho

### DIFF
--- a/code/game/verbs/who.dm
+++ b/code/game/verbs/who.dm
@@ -160,7 +160,7 @@
 	if(CONFIG_GET(flag/show_manager))
 		LAZYSET(mappings, "<B style='color:purple'>Management</B>", R_PERMISSIONS)
 	if(CONFIG_GET(flag/show_devs))
-		LAZYSET(mappings, "<B style='color:blue'>Maintainers</B>", R_PROFILER)
+		LAZYSET(mappings, "<B style='color:dodgerblue'>Maintainers</B>", R_PROFILER)
 	LAZYSET(mappings, "<B style='color:red'>Admins</B>", R_ADMIN)
 	if(CONFIG_GET(flag/show_mods))
 		LAZYSET(mappings, "<B style='color:orange'>Moderators</B>", R_MOD)


### PR DESCRIPTION

# About the pull request

Changes the colour of the Maintainer section in the staffwho interface from '`blue`' (`#0000FF`) to '`dodgerblue`' (`#1E90FF`).

# Explain why it's good for the game
It varies slightly between my monitors, but on both of them it's very hard to make out what the text actually says because of the bad contrast between its colour and the background.
# Testing Photographs and Procedure
<details>
<summary>Screenshots</summary>

**Before:**
![before](https://github.com/cmss13-devs/cmss13/assets/57483089/56843789-b05d-4f35-8323-bf5fdb5c60ca)

**After:**
![after](https://github.com/cmss13-devs/cmss13/assets/57483089/1b65994a-6856-4060-b1ee-c0955fb0e5b4)

</details>

*(See also: [Before](https://webaim.org/resources/contrastchecker/?fcolor=0000FF&bcolor=272727) vs [After](https://webaim.org/resources/contrastchecker/?fcolor=1E90FF&bcolor=272727) using WebAIM's contrast checker.)*


# Changelog
:cl:
ui: Tweaked the colour of the 'Maintainer' category in staffwho.
/:cl:
