### PR TITLE
Lockdown actually closes doors on DS

### DIFF
--- a/code/game/machinery/door_control.dm
+++ b/code/game/machinery/door_control.dm
@@ -64,7 +64,7 @@
 	if(is_mainship_level(z)) // on the almayer
 		return
 
-	shuttle.control_doors("lock", "all", force=FALSE)
+	shuttle.control_doors("force-lock", "all", force=FALSE)
 
 /obj/structure/machinery/door_control/proc/handle_door()
 	for(var/obj/structure/machinery/door/airlock/D in range(range))

--- a/tgui/packages/tgui/interfaces/DropshipFlightControl.tsx
+++ b/tgui/packages/tgui/interfaces/DropshipFlightControl.tsx
@@ -45,7 +45,7 @@ const DropshipDoorControl = (_, context) => {
                 disabled={disable_door_controls}
                 onClick={() =>
                   act('door-control', {
-                    interaction: 'lock',
+                    interaction: 'force-lock',
                     location: 'all',
                   })
                 }
@@ -81,7 +81,7 @@ const DropshipDoorControl = (_, context) => {
                     <Button
                       onClick={() =>
                         act('door-control', {
-                          interaction: 'lock',
+                          interaction: 'force-lock',
                           location: x.id,
                         })
                       }


### PR DESCRIPTION
# About the pull request

Lockdown actually closes doors on DS.

# Explain why it's good for the game

It used to be the case before the gui rework. I think. Anyway DP should be able to control doors, hunting for the moment when all doors are closed to lock them is extremely not fun.


# Testing Photographs and Procedure
<details>
:)</details>


# Changelog
:cl: ihatethisengine
add: Locking down dropship's doors closes them before locking.
/:cl:
