### PR TITLE
ASRS Supply Pools -- Crates Carryover and MessTech supply

### DIFF
--- a/code/__DEFINES/supply.dm
+++ b/code/__DEFINES/supply.dm
@@ -1,0 +1,14 @@
+//We use the cost to determine the spawn chance this equals out the crates that spawn later in the round.
+#define ASRS_HIGHEST_WEIGHT 0 //warning this weight wont change.
+#define ASRS_VERY_HIGH_WEIGHT 5
+#define ASRS_HIGH_WEIGHT 15
+#define ASRS_MEDIUM_WEIGHT 25
+#define ASRS_LOW_WEIGHT 35
+#define ASRS_VERY_LOW_WEIGHT 50
+#define ASRS_LOWEST_WEIGHT 100
+
+// List of pools of supply packs, rolled individually by the ASRS system
+/// Main pool of ASRS supplies, dispensing military supplies such as ammo
+#define ASRS_POOL_MAIN "Main"
+/// Secondary ASRS pool dispening food related items for MessTech
+#define ASRS_POOL_FOOD "Food"

--- a/code/__DEFINES/supply.dm
+++ b/code/__DEFINES/supply.dm
@@ -14,4 +14,4 @@
 #define ASRS_POOL_FOOD "Food"
 
 /// Divider to the amount of xeno forces on the planet to ASRS provided crates. It is used as such sqrt(xenos/ASRS_XENO_CRATES_DIVIDER))
-#define ASRS_XENO_CRATES_DIVIDER 3.5
+#define ASRS_XENO_CRATES_DIVIDER 4

--- a/code/__DEFINES/supply.dm
+++ b/code/__DEFINES/supply.dm
@@ -12,3 +12,6 @@
 #define ASRS_POOL_MAIN "Main"
 /// Secondary ASRS pool dispening food related items for MessTech
 #define ASRS_POOL_FOOD "Food"
+
+/// Divider to the amount of xeno forces on the planet to ASRS provided crates. It is used as such sqrt(xenos/ASRS_XENO_CRATES_DIVIDER))
+#define ASRS_XENO_CRATES_DIVIDER 3.5

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -254,7 +254,7 @@ SUBSYSTEM_DEF(ticker)
 	if(round_statistics)
 		to_chat_spaced(world, html = FONT_SIZE_BIG(SPAN_ROLE_BODY("<B>Welcome to [round_statistics.round_name]</B>")))
 
-	supply_controller.process() //Start the supply shuttle regenerating points -- TLE
+	supply_controller.start_processing()
 
 	for(var/i in GLOB.closet_list) //Set up special equipment for lockers and vendors, depending on gamemode
 		var/obj/structure/closet/C = i

--- a/code/datums/ASRS.dm
+++ b/code/datums/ASRS.dm
@@ -2,133 +2,136 @@
 //These are non orderable packs that get in automaticly though the ARSR system.
 //Note these should never show up to buy and some will only show up later in the round.
 //BIG NOTE: Don't add living things to crates, that's bad, it will break the shuttle.
-//We use the cost to determine the spawn chance this equals out the crates that spawn later in the round.
-#define ASRS_HIGHEST_WEIGHT 0 //warning this weight wont change.
-#define ASRS_VERY_HIGH_WEIGHT 5
-#define ASRS_HIGH_WEIGHT 15
-#define ASRS_MEDIUM_WEIGHT 25
-#define ASRS_LOW_WEIGHT 35
-#define ASRS_VERY_LOW_WEIGHT 50
-#define ASRS_LOWEST_WEIGHT 100
+
+
+/datum/supply_packs_asrs
+	/// How likely we are to select this pack over others
+	var/cost = ASRS_MEDIUM_WEIGHT
+	/// Which pool of ASRS automatically dispensed supplies this belongs to
+	var/pool = ASRS_POOL_MAIN
+	/// What supply pack would this dispense
+	var/datum/supply_packs/reference_package
 
 //===================================
 // Rounds
-/datum/supply_packs/ammo_rounds_box_rifle/asrs
-	buyable = 0
-	group = "ASRS"
+/datum/supply_packs_asrs/ammo_rounds_box_rifle
+	reference_package = /datum/supply_packs/ammo_rounds_box_rifle
 	cost = ASRS_MEDIUM_WEIGHT
 
-/datum/supply_packs/ammo_rounds_box_rifle_ap/asrs
-	buyable = 0
-	group = "ASRS"
+/datum/supply_packs_asrs/ammo_rounds_box_rifle_ap
+	reference_package = /datum/supply_packs/ammo_rounds_box_rifle_ap
 	cost = ASRS_LOW_WEIGHT
 
-/datum/supply_packs/ammo_rounds_box_xm88/asrs
-	buyable = 0
-	group = "ASRS"
+/datum/supply_packs_asrs/ammo_rounds_box_xm88
+	reference_package = /datum/supply_packs/ammo_rounds_box_xm88
 	cost = ASRS_LOW_WEIGHT
 
 //===================================
 // Magazines
-/datum/supply_packs/gun/ammo_hpr/asrs
-	buyable = 0
-	group = "ASRS"
+/datum/supply_packs_asrs/gun/ammo_hpr
+	reference_package = /datum/supply_packs/ammo_hpr
 	cost = ASRS_LOWEST_WEIGHT
 
-/datum/supply_packs/ammo_m4a3_mag_box/asrs
-	buyable = 0
-	group = "ASRS"
+/datum/supply_packs_asrs/ammo_m4a3_mag_box
+	reference_package = /datum/supply_packs/ammo_m4a3_mag_box
 	cost = ASRS_LOW_WEIGHT
 
-/datum/supply_packs/ammo_m4a3_mag_box_ap/asrs
-	buyable = 0
-	group = "ASRS"
+/datum/supply_packs_asrs/ammo_m4a3_mag_box_ap
+	reference_package = /datum/supply_packs/ammo_m4a3_mag_box_ap
 	cost = ASRS_VERY_LOW_WEIGHT
 
-/datum/supply_packs/ammo_mag_box/asrs
-	buyable = 0
-	group = "ASRS"
+/datum/supply_packs_asrs/ammo_mag_box
+	reference_package = /datum/supply_packs/ammo_mag_box
 	cost = ASRS_VERY_LOW_WEIGHT
 
-/datum/supply_packs/ammo_mag_box_ap/asrs
-	buyable = 0
-	group = "ASRS"
+/datum/supply_packs_asrs/ammo_mag_box_ap
+	reference_package = /datum/supply_packs/ammo_mag_box_ap
 
-/datum/supply_packs/ammo_m4ra_mag_box/asrs
-	buyable = 0
-	group = "ASRS"
+/datum/supply_packs_asrs/ammo_m4ra_mag_box
+	reference_package = /datum/supply_packs/ammo_m4ra_mag_box
 	cost = ASRS_VERY_LOW_WEIGHT
 
-/datum/supply_packs/ammo_m4ra_mag_box_ap/asrs
-	buyable = 0
-	group = "ASRS"
+/datum/supply_packs_asrs/ammo_m4ra_mag_box_ap
+	reference_package = /datum/supply_packs/ammo_m4ra_mag_box_ap
 
-/datum/supply_packs/ammo_shell_box/asrs
-	buyable = 0
-	group = "ASRS"
+/datum/supply_packs_asrs/ammo_shell_box
+	reference_package = /datum/supply_packs/ammo_shell_box
 	cost = ASRS_VERY_LOW_WEIGHT
 
-/datum/supply_packs/ammo_shell_box_buck/asrs
-	buyable = 0
-	group = "ASRS"
+/datum/supply_packs_asrs/ammo_shell_box_buck
+	reference_package = /datum/supply_packs/ammo_shell_box_buck
 	cost = ASRS_VERY_LOW_WEIGHT
 
-/datum/supply_packs/ammo_shell_box_flechette/asrs
-	buyable = 0
-	group = "ASRS"
+/datum/supply_packs_asrs/ammo_shell_box_flechette
+	reference_package = /datum/supply_packs/ammo_shell_box_flechette
 	cost = ASRS_VERY_LOW_WEIGHT
 
-/datum/supply_packs/ammo_smartgun/asrs
-	buyable = 0
-	group = "ASRS"
+/datum/supply_packs_asrs/ammo_smartgun
+	reference_package = /datum/supply_packs/ammo_smartgun
 
-/datum/supply_packs/ammo_napalm/asrs
-	buyable = 0
-	group = "ASRS"
+/datum/supply_packs_asrs/ammo_napalm
+	reference_package = /datum/supply_packs/ammo_napalm
 	cost = ASRS_VERY_LOW_WEIGHT
 
-/datum/supply_packs/ammo_napalm_gel/asrs
-	buyable = 0
-	group = "ASRS"
+/datum/supply_packs_asrs/ammo_napalm_gel
+	reference_package = /datum/supply_packs/ammo_napalm_gel
 	cost = ASRS_VERY_LOW_WEIGHT
 
-/datum/supply_packs/ammo_flamer_mixed/asrs
-	buyable = 0
-	group = "ASRS"
+/datum/supply_packs_asrs/ammo_flamer_mixed
+	reference_package = /datum/supply_packs/ammo_flamer_mixed
 	cost = ASRS_VERY_LOW_WEIGHT
 
 //===================================
 // Mortar ammo
-/datum/supply_packs/ammo_mortar_he/asrs
-	buyable = 0
-	group = "ASRS"
+/datum/supply_packs_asrs/ammo_mortar_he
+	reference_package = /datum/supply_packs/ammo_mortar_he
 
-/datum/supply_packs/ammo_mortar_incend/asrs
-	buyable = 0
-	group = "ASRS"
+/datum/supply_packs_asrs/ammo_mortar_incend
+	reference_package = /datum/supply_packs/ammo_mortar_incend
 
-/datum/supply_packs/ammo_mortar_flare/asrs
-	buyable = 0
-	group = "ASRS"
+/datum/supply_packs_asrs/ammo_mortar_flare
+	reference_package = /datum/supply_packs/ammo_mortar_flare
 
 //===================================
 // Misc supplies
-/datum/supply_packs/flares/asrs
-	buyable = 0
-	group = "ASRS"
+/datum/supply_packs_asrs/flares
+	reference_package = /datum/supply_packs/flares
 	cost = ASRS_LOW_WEIGHT
 
-/datum/supply_packs/mre/asrs
-	buyable = 0
-	group = "ASRS"
+/datum/supply_packs_asrs/mre
+	reference_package = /datum/supply_packs/mre
 	cost = ASRS_VERY_LOW_WEIGHT
 
-/datum/supply_packs/flashlights/asrs
-	buyable = 0
-	group = "ASRS"
+/datum/supply_packs_asrs/flashlights
+	reference_package = /datum/supply_packs/flashlights
 	cost = ASRS_VERY_LOW_WEIGHT
 
-/datum/supply_packs/batteries/asrs
-	buyable = 0
-	group = "ASRS"
+/datum/supply_packs_asrs/batteries
+	reference_package = /datum/supply_packs/batteries
 	cost = ASRS_VERY_LOW_WEIGHT
+
+// ============================
+// FOOD POOL - for Mess Tech gradual supplies throughout the round
+/datum/supply_packs_asrs/funfood
+	reference_package = /datum/supply_packs/funfood
+	pool = ASRS_POOL_FOOD
+
+/datum/supply_packs_asrs/condiment
+	reference_package = /datum/supply_packs/condiment
+	pool = ASRS_POOL_FOOD
+
+/datum/supply_packs_asrs/meat
+	reference_package = /datum/supply_packs/meat
+	pool = ASRS_POOL_FOOD
+
+/datum/supply_packs_asrs/potato
+	reference_package = /datum/supply_packs/potato
+	pool = ASRS_POOL_FOOD
+
+/datum/supply_packs_asrs/tomato
+	reference_package = /datum/supply_packs/tomato
+	pool = ASRS_POOL_FOOD
+
+/datum/supply_packs_asrs/wheat
+	reference_package = /datum/supply_packs/wheat
+	pool = ASRS_POOL_FOOD

--- a/code/datums/supply_packs/_supply_packs.dm
+++ b/code/datums/supply_packs/_supply_packs.dm
@@ -20,7 +20,6 @@
 	var/group = null
 	var/buyable = 1 ///Can this pack be bought? These packs don't show up at all - they have to be spawned externally (fe: DEFCON ASRS)
 	var/randomised_num_contained = 0 //Randomly picks X of items out of the contains list instead of using all.
-	var/iteration_needed = 0
 	/// How many W-Y dollars are deducted from the supply controller. Only use for contraband.
 	var/dollar_cost = 0
 	/// How much "heat" this crate adds, too much heat will send an investigation. Only use for contraband.

--- a/code/datums/supply_packs/operations.dm
+++ b/code/datums/supply_packs/operations.dm
@@ -24,7 +24,6 @@
 	containername = "OB Ammo Crate (Incendiary x2)"
 	buyable = 0
 	group = "Operations"
-	iteration_needed = null
 
 /datum/supply_packs/ob_explosive
 	contains = list(
@@ -48,7 +47,6 @@
 	containername = "OB Ammo Crate (HE x2)"
 	buyable = 0
 	group = "Operations"
-	iteration_needed = null
 
 /datum/supply_packs/ob_cluster
 	contains = list(
@@ -72,7 +70,6 @@
 	containername = "OB Ammo Crate (Cluster x2)"
 	buyable = 0
 	group = "Operations"
-	iteration_needed = null
 
 /datum/supply_packs/telecommsparts
 	name = "Replacement Telecommunications Parts"
@@ -99,7 +96,6 @@
 	containertype = /obj/structure/machinery/nuclearbomb
 	buyable = 0
 	group = "Operations"
-	iteration_needed = null
 
 /datum/supply_packs/technuclearbomb
 	name = "Encrypted Operational Nuke"
@@ -107,7 +103,6 @@
 	containertype = /obj/structure/machinery/nuclearbomb/tech
 	buyable = 0
 	group = "Operations"
-	iteration_needed = null
 
 /datum/supply_packs/spec_kits
 	name = "Weapons Specialist Kits"
@@ -122,4 +117,3 @@
 	containername = "weapons specialist kits crate"
 	buyable = 0
 	group = "Operations"
-	iteration_needed = null

--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -9,6 +9,8 @@
 #define KILL_MENDOZA -1
 
 GLOBAL_LIST_EMPTY_TYPED(asrs_empty_space_tiles_list, /turf/open/floor/almayer/empty)
+GLOBAL_SUBTYPE_PATHS_LIST_INDEXED(supply_packs_types, /datum/supply_packs, name)
+GLOBAL_REFERENCE_LIST_INDEXED_SORTED(supply_packs_datums, /datum/supply_packs, type)
 
 var/datum/controller/supply/supply_controller = new()
 
@@ -367,7 +369,7 @@ var/datum/controller/supply/supply_controller = new()
 
 /datum/controller/supply
 	var/processing = 1
-	var/processing_interval = 300
+	var/processing_interval = 30 SECONDS
 	var/iteration = 0
 	//supply points
 	var/points = 120
@@ -389,15 +391,18 @@ var/datum/controller/supply/supply_controller = new()
 	/// If the players killed him by sending a live hostile below.. this goes false and they can't order any more contraband.
 	var/mendoza_status = TRUE
 
-	var/base_random_crate_interval = 10 //Every how many processing intervals do we get a random crates.
+	/// How many processing intervals do we get random crates for each pool. Currently only [ASRS_POOL_MAIN] gets scaled amount of crates.
+	var/list/base_random_crate_intervals = list(ASRS_POOL_MAIN = 10, ASRS_POOL_FOOD = 3) // FIXME probably ~40 for food, one every 20 min
+	/// How many partial crates are stored in ASRS per pool to smooth amount given out
+	var/list/random_crates_carry = list()
+	/// Pools mapped to list of random ASRS packs that belong to it
+	var/list/asrs_supply_packs_by_pool
 
 	var/crate_iteration = 0
 	//control
 	var/ordernum
 	var/list/shoppinglist = list()
 	var/list/requestlist = list()
-	var/list/supply_packs = list()
-	var/list/random_supply_packs = list()
 	//shuttle movement
 	var/datum/shuttle/ferry/supply/shuttle
 
@@ -436,72 +441,92 @@ var/datum/controller/supply/supply_controller = new()
 	var/tank_points = 0
 
 /datum/controller/supply/New()
+	. = ..()
 	ordernum = rand(1,9000)
 	LAZYINITLIST(black_market_sold_items)
+	asrs_supply_packs_by_pool = list()
+	for(var/subtype in subtypesof(/datum/supply_packs_asrs))
+		var/datum/supply_packs_asrs/initial_datum = subtype
+		var/pool = initial(initial_datum.pool)
+		if(!pool)
+			continue
+		LAZYADD(asrs_supply_packs_by_pool[pool], new subtype())
+	random_crates_carry = list()
+	for(var/pool in base_random_crate_intervals)
+		random_crates_carry[pool] = 0
+
+/datum/controller/supply/proc/start_processing()
+	START_PROCESSING(SSslowobj, src)
 
 //Supply shuttle ticker - handles supply point regenertion and shuttle travelling between centcomm and the station
-/datum/controller/supply/process()
-	for(var/typepath in subtypesof(/datum/supply_packs))
-		var/datum/supply_packs/supply_pack = new typepath()
-		if(supply_pack.group == "ASRS")
-			random_supply_packs += supply_pack
-		else
-			supply_packs[supply_pack.name] = supply_pack
-	spawn(0)
-		set background = 1
-		while(1)
-			if(processing)
-				iteration++
-				points += points_per_process
-				if(iteration >= 20 && iteration % base_random_crate_interval == 0 && supply_controller.shoppinglist.len <= 20)
-					add_random_crates()
-					crate_iteration++
-			sleep(processing_interval)
+/datum/controller/supply/process(delta_time)
+	iteration++
+	points += points_per_process
+	if(iteration < 20)
+		return
+	for(var/pool in base_random_crate_intervals)
+		var/interval = base_random_crate_intervals[pool]
+		if(interval && iteration % interval == 0 && supply_controller.shoppinglist.len <= 20)
+			add_random_crates(pool)
+		crate_iteration++
 
 //This adds function adds the amount of crates that calculate_crate_amount returns
-/datum/controller/supply/proc/add_random_crates()
-	for(var/I=0, I<calculate_crate_amount(), I++)
-		add_random_crate()
+/datum/controller/supply/proc/add_random_crates(pool)
+	for(var/crate_count in 1 to calculate_crate_amount(pool))
+		add_random_crate(pool)
 
 //Here we calculate the amount of crates to spawn.
-//Marines get one crate for each the amount of marines on the surface devided by the amount of marines per crate.
+//Marines get one crate for each the amount of XENOS on the surface devided by the amount of marines per crate.
 //They always get the mincrates amount.
-/datum/controller/supply/proc/calculate_crate_amount()
+/datum/controller/supply/proc/calculate_crate_amount(pool)
+	if(pool != ASRS_POOL_MAIN)
+		return 1 // Pool scaling coming in a future update if needed, for now tweak base_random_crate_intervals instead
 
-	// Sqrt(NUM_XENOS/4)
-	var/crate_amount = Floor(max(0, sqrt(SSticker.mode.count_xenos(SSmapping.levels_by_trait(ZTRAIT_GROUND))/3)))
+	var/ground_xenos_amount = rand(1, 20) //TESTING //SSticker.mode.count_xenos(SSmapping.levels_by_trait(ZTRAIT_GROUND))
+	var/crate_amount = max(0, sqrt(ground_xenos_amount/3))
 
-	if(crate_iteration <= 5)
+	if(crate_iteration <= 5 && crate_amount < 4)
 		crate_amount = 4
 
-	return crate_amount
+	var/unit_crate_amount = floor(crate_amount)
+	var/carry = crate_amount - unit_crate_amount
+	random_crates_carry[pool] += carry
+	var/total_carry = random_crates_carry[pool]
+
+	if(total_carry >= 1)
+		var/additional_crates = floor(total_carry)
+		random_crates_carry[pool] -= additional_crates
+		unit_crate_amount += additional_crates
+		log_debug("Awarded [additional_crates] extra crates in pool [pool]") //TESTING
+
+	return unit_crate_amount
 
 //Here we pick what crate type to send to the marines.
 //This is a weighted pick based upon their cost.
 //Their cost will go up if the crate is picked
-/datum/controller/supply/proc/add_random_crate()
-	var/datum/supply_packs/C = supply_controller.pick_weighted_crate(random_supply_packs)
-	if(C == null)
+/datum/controller/supply/proc/add_random_crate(pool)
+	if(!asrs_supply_packs_by_pool[pool])
 		return
-	C.cost = round(C.cost * ASRS_COST_MULTIPLIER) //We still do this to raise the weight
+	var/datum/supply_packs_asrs/supply_info = pick_weighted_crate(asrs_supply_packs_by_pool[pool])
+	if(!GLOB.supply_packs_datums[supply_info.reference_package])
+		return
+
+	supply_info.cost = round(supply_info.cost * ASRS_COST_MULTIPLIER) //We still do this to raise the weight
 	//We have to create a supply order to make the system spawn it. Here we transform a crate into an order.
 	var/datum/supply_order/supply_order = new /datum/supply_order()
-	supply_order.ordernum = supply_controller.ordernum
-	supply_order.object = C
+	supply_order.ordernum = ordernum++
+	supply_order.object = GLOB.supply_packs_datums[supply_info.reference_package]
 	supply_order.orderedby = "ASRS"
 	supply_order.approvedby = "ASRS"
 	//We add the order to the shopping list
-	supply_controller.shoppinglist += supply_order
+	shoppinglist += supply_order
 
 //Here we weigh the crate based upon it's cost
-/datum/controller/supply/proc/pick_weighted_crate(list/cratelist)
-	var/weighted_crate_list[]
-	for(var/datum/supply_packs/crate in cratelist)
-		var/crate_to_add[0]
+/datum/controller/supply/proc/pick_weighted_crate(list/datum/supply_packs_asrs/cratelist)
+	var/list/datum/supply_packs_asrs/weighted_crate_list = list()
+	for(var/datum/supply_packs_asrs/crate in cratelist)
 		var/weight = (round(10000/crate.cost))
-		if(iteration > crate.iteration_needed)
-			crate_to_add[crate] = weight
-			weighted_crate_list += crate_to_add
+		weighted_crate_list[crate] = weight
 	return pickweight(weighted_crate_list)
 
 //To stop things being sent to centcomm which should not be sent to centcomm. Recursively checks for these types.
@@ -590,8 +615,8 @@ var/datum/controller/supply/supply_controller = new()
 		if(order.object.contraband == TRUE && prob(5))
 		// Mendoza loaded the wrong order in. What a dunce!
 			var/list/contraband_list
-			for(var/supply_name in supply_controller.supply_packs)
-				var/datum/supply_packs/supply_pack = supply_controller.supply_packs[supply_name]
+			for(var/supply_type in GLOB.supply_packs_datums)
+				var/datum/supply_packs/supply_pack = GLOB.supply_packs_datums[supply_type]
 				if(supply_pack.contraband == FALSE)
 					continue
 				LAZYADD(contraband_list, supply_pack)
@@ -745,10 +770,11 @@ var/datum/controller/supply/supply_controller = new()
 			temp = "<b>Supply budget: $[supply_controller.points * SUPPLY_TO_MONEY_MUPLTIPLIER]</b><BR>"
 			temp += "<A href='?src=\ref[src];order=categories'>Back to all categories</A><HR><BR><BR>"
 			temp += "<b>Request from: [last_viewed_group]</b><BR><BR>"
-			for(var/supply_name in supply_controller.supply_packs )
-				var/datum/supply_packs/N = supply_controller.supply_packs[supply_name]
-				if(N.contraband || N.group != last_viewed_group || !N.buyable) continue //Have to send the type instead of a reference to
-				temp += "<A href='?src=\ref[src];doorder=[supply_name]'>[supply_name]</A> Cost: $[round(N.cost) * SUPPLY_TO_MONEY_MUPLTIPLIER]<BR>" //the obj because it would get caught by the garbage
+			for(var/supply_type in GLOB.supply_packs_datums)
+				var/datum/supply_packs/supply_pack = GLOB.supply_packs_datums[supply_type]
+				if(supply_pack.contraband || supply_pack.group != last_viewed_group || !supply_pack.buyable)
+					continue //Have to send the type instead of a reference to
+				temp += "<A href='?src=\ref[src];doorder=[supply_pack/name]'>[supply_pack.name]</A> Cost: $[round(supply_pack.cost) * SUPPLY_TO_MONEY_MUPLTIPLIER]<BR>" //the obj because it would get caught by the garbage
 
 	else if (href_list["doorder"])
 		if(world.time < reqtime)
@@ -757,8 +783,10 @@ var/datum/controller/supply/supply_controller = new()
 			return
 
 		//Find the correct supply_pack datum
-		var/datum/supply_packs/supply_pack = supply_controller.supply_packs[href_list["doorder"]]
-		if(!istype(supply_pack)) return
+		var/supply_pack_type = GLOB.supply_packs_types[href_list["doorder"]]
+		if(!supply_pack_type)
+			return
+		var/datum/supply_packs/supply_pack = GLOB.supply_packs_datums[supply_pack_type]
 
 		if(supply_pack.contraband || !supply_pack.buyable)
 			return
@@ -944,11 +972,11 @@ var/datum/controller/supply/supply_controller = new()
 				temp = "<b>Supply budget: $[supply_controller.points * SUPPLY_TO_MONEY_MUPLTIPLIER]</b><BR>"
 				temp += "<A href='?src=\ref[src];order=categories'>Back to all categories</A><HR><BR><BR>"
 				temp += "<b>Request from: [last_viewed_group]</b><BR><BR>"
-				for(var/supply_name in supply_controller.supply_packs )
-					var/datum/supply_packs/supply_pack = supply_controller.supply_packs[supply_name]
+				for(var/supply_type in GLOB.supply_packs_datums)
+					var/datum/supply_packs/supply_pack = GLOB.supply_packs_datums[supply_type]
 					if(!is_buyable(supply_pack))
 						continue
-					temp += "<A href='?src=\ref[src];doorder=[supply_name]'>[supply_name]</A> Cost: $[round(supply_pack.cost) * SUPPLY_TO_MONEY_MUPLTIPLIER]<BR>"		//the obj because it would get caught by the garbage
+					temp += "<A href='?src=\ref[src];doorder=[supply_pack.name]'>[supply_pack.name]</A> Cost: $[round(supply_pack.cost) * SUPPLY_TO_MONEY_MUPLTIPLIER]<BR>"		//the obj because it would get caught by the garbage
 
 	else if (href_list["doorder"])
 		if(world.time < reqtime)
@@ -957,7 +985,8 @@ var/datum/controller/supply/supply_controller = new()
 			return
 
 		//Find the correct supply_pack datum
-		var/datum/supply_packs/supply_pack = supply_controller.supply_packs[href_list["doorder"]]
+		var/supply_pack_type = GLOB.supply_packs_types[href_list["doorder"]]
+		var/datum/supply_packs/supply_pack = GLOB.supply_packs_datums[supply_pack_type]
 
 		if(!istype(supply_pack))
 			return
@@ -1123,11 +1152,11 @@ var/datum/controller/supply/supply_controller = new()
 	temp = "<b>W-Y Dollars: $[supply_controller.black_market_points]</b><BR>"
 	temp += "<A href='?src=\ref[src];order=Black Market'>Back to black market categories</A><HR><BR><BR>"
 	temp += "<b>Purchase from: [last_viewed_group]</b><BR><BR>"
-	for(var/supply_name in supply_controller.supply_packs )
-		var/datum/supply_packs/supply_pack = supply_controller.supply_packs[supply_name]
+	for(var/supply_type in GLOB.supply_packs_datums)
+		var/datum/supply_packs/supply_pack = GLOB.supply_packs_datums[supply_type]
 		if(!is_buyable(supply_pack))
 			continue
-		temp += "<A href='?src=\ref[src];doorder=[supply_name]'>[supply_name]</A> Cost: $[round(supply_pack.dollar_cost)]<BR>"
+		temp += "<A href='?src=\ref[src];doorder=[supply_pack.name]'>[supply_pack.name]</A> Cost: $[round(supply_pack.dollar_cost)]<BR>"
 
 /obj/structure/machinery/computer/supplycomp/proc/handle_mendoza_dialogue()
 

--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -482,7 +482,7 @@ var/datum/controller/supply/supply_controller = new()
 	if(pool != ASRS_POOL_MAIN)
 		return 1 // Pool scaling coming in a future update if needed, for now tweak base_random_crate_intervals instead
 
-	var/ground_xenos_amount = rand(1, 20) //TESTING //SSticker.mode.count_xenos(SSmapping.levels_by_trait(ZTRAIT_GROUND))
+	var/ground_xenos_amount = SSticker.mode.count_xenos(SSmapping.levels_by_trait(ZTRAIT_GROUND))
 	var/crate_amount = max(0, sqrt(ground_xenos_amount/ASRS_XENO_CRATES_DIVIDER))
 
 	if(crate_iteration <= 5 && crate_amount < 4)
@@ -497,7 +497,6 @@ var/datum/controller/supply/supply_controller = new()
 		var/additional_crates = floor(total_carry)
 		random_crates_carry[pool] -= additional_crates
 		unit_crate_amount += additional_crates
-		log_debug("Awarded [additional_crates] extra crates in pool [pool]") //TESTING
 
 	return unit_crate_amount
 

--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -392,7 +392,7 @@ var/datum/controller/supply/supply_controller = new()
 	var/mendoza_status = TRUE
 
 	/// How many processing intervals do we get random crates for each pool. Currently only [ASRS_POOL_MAIN] gets scaled amount of crates.
-	var/list/base_random_crate_intervals = list(ASRS_POOL_MAIN = 10, ASRS_POOL_FOOD = 3) // FIXME probably ~40 for food, one every 20 min
+	var/list/base_random_crate_intervals = list(ASRS_POOL_MAIN = 10, ASRS_POOL_FOOD = 40)
 	/// How many partial crates are stored in ASRS per pool to smooth amount given out
 	var/list/random_crates_carry = list()
 	/// Pools mapped to list of random ASRS packs that belong to it

--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -483,7 +483,7 @@ var/datum/controller/supply/supply_controller = new()
 		return 1 // Pool scaling coming in a future update if needed, for now tweak base_random_crate_intervals instead
 
 	var/ground_xenos_amount = rand(1, 20) //TESTING //SSticker.mode.count_xenos(SSmapping.levels_by_trait(ZTRAIT_GROUND))
-	var/crate_amount = max(0, sqrt(ground_xenos_amount/3))
+	var/crate_amount = max(0, sqrt(ground_xenos_amount/ASRS_XENO_CRATES_DIVIDER))
 
 	if(crate_iteration <= 5 && crate_amount < 4)
 		crate_amount = 4

--- a/code/modules/admin/tabs/event_tab.dm
+++ b/code/modules/admin/tabs/event_tab.dm
@@ -424,18 +424,20 @@
 /client/proc/give_nuke()
 	if(!check_rights(R_ADMIN))
 		return
-	var/nuketype = "Decrypted Operational Nuke"
+	var/nukename = "Decrypted Operational Nuke"
 	var/encrypt = tgui_alert(src, "Do you want the nuke to be already decrypted?", "Nuke Type", list("Encrypted", "Decrypted"), 20 SECONDS)
 	if(encrypt == "Encrypted")
-		nuketype = "Encrypted Operational Nuke"
+		nukename = "Encrypted Operational Nuke"
 	var/prompt = tgui_alert(src, "THIS CAN BE USED TO END THE ROUND. Are you sure you want to spawn a nuke? The nuke will be put onto the ASRS Lift.", "DEFCON 1", list("No", "Yes"), 30 SECONDS)
 	if(prompt != "Yes")
 		return
 
+	var/nuketype = GLOB.supply_packs_types[nukename]
+
 	var/datum/supply_order/new_order = new()
 	new_order.ordernum = supply_controller.ordernum
 	supply_controller.ordernum++
-	new_order.object = supply_controller.supply_packs[nuketype]
+	new_order.object = GLOB.supply_packs_datums[nuketype]
 	new_order.orderedby = MAIN_AI_SYSTEM
 	new_order.approvedby = MAIN_AI_SYSTEM
 	supply_controller.shoppinglist += new_order

--- a/code/modules/admin/topic/topic.dm
+++ b/code/modules/admin/topic/topic.dm
@@ -1820,19 +1820,20 @@
 		var/mob/ref_person = locate(href_list["nukeapprove"])
 		if(!istype(ref_person))
 			return FALSE
-		var/nuketype = "Encrypted Operational Nuke"
+		var/nukename = "Encrypted Operational Nuke"
 		var/prompt = tgui_alert(usr, "Do you want the nuke to be Encrypted?", "Nuke Type", list("Encrypted", "Decrypted"), 20 SECONDS)
 		if(prompt == "Decrypted")
-			nuketype = "Decrypted Operational Nuke"
-		prompt = tgui_alert(usr, "Are you sure you want to authorize a [nuketype] to the marines? This will greatly affect the round!", "DEFCON 1", list("No", "Yes"))
+			nukename = "Decrypted Operational Nuke"
+		prompt = tgui_alert(usr, "Are you sure you want to authorize a '[nukename]' to the marines? This will greatly affect the round!", "DEFCON 1", list("No", "Yes"))
 		if(prompt != "Yes")
 			return
 
+		var/nuketype = GLOB.supply_packs_types[nukename]
 		//make ASRS order for nuke
 		var/datum/supply_order/new_order = new()
 		new_order.ordernum = supply_controller.ordernum
 		supply_controller.ordernum++
-		new_order.object = supply_controller.supply_packs[nuketype]
+		new_order.object = GLOB.supply_packs_datums[nuketype]
 		new_order.orderedby = ref_person
 		new_order.approvedby = "USCM High Command"
 		supply_controller.shoppinglist += new_order

--- a/code/modules/cm_tech/techs/marine/tier2/orbital_ammo.dm
+++ b/code/modules/cm_tech/techs/marine/tier2/orbital_ammo.dm
@@ -19,7 +19,8 @@
 	var/datum/supply_order/O = new /datum/supply_order()
 	O.ordernum = supply_controller.ordernum
 	supply_controller.ordernum++
-	O.object = supply_controller.supply_packs[type_to_give]
+	var/actual_type = GLOB.supply_packs_types[type_to_give]
+	O.object = GLOB.supply_packs_datums[actual_type]
 	O.orderedby = MAIN_AI_SYSTEM
 
 	supply_controller.shoppinglist += O

--- a/code/modules/cm_tech/techs/marine/tier4/nuke.dm
+++ b/code/modules/cm_tech/techs/marine/tier4/nuke.dm
@@ -23,7 +23,8 @@
 	var/datum/supply_order/new_order = new()
 	new_order.ordernum = supply_controller.ordernum
 	supply_controller.ordernum++
-	new_order.object = supply_controller.supply_packs["Encrypted Operational Nuke"]
+	var/actual_type = GLOB.supply_packs_types["Encrypted Operational Nuke"]
+	new_order.object = GLOB.supply_packs_datums[actual_type]
 	new_order.orderedby = MAIN_AI_SYSTEM
 	new_order.approvedby = MAIN_AI_SYSTEM
 

--- a/colonialmarines.dme
+++ b/colonialmarines.dme
@@ -101,6 +101,7 @@
 #include "code\__DEFINES\stats.dm"
 #include "code\__DEFINES\STUI.dm"
 #include "code\__DEFINES\subsystems.dm"
+#include "code\__DEFINES\supply.dm"
 #include "code\__DEFINES\surgery.dm"
 #include "code\__DEFINES\techtree.dm"
 #include "code\__DEFINES\text.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

Code refactor aside this has two main effects:
* Adds ASRS supply pools. These are categories of ASRS spawned gear that run in parallel of each other, that is to say not taking away from the military operation pool of crates. Right now they're hardcoded to give only one crate, and send a crate of food ingredients every roughly 20 minutes as proof of concept, to resupply the MessTech.
* Adds smooth scaling to amount of crates given by ASRS. The legacy formula is `floor(sqrt(xenos/3))` which is rough as for example once the Xeno count goes below 27 you immediately go from 3 crates awarded to 2. To provide a more consistent and reliable supply flow, it's no longer floored - instead the decimal part carries over. **To make up for this, the divider factor of 3 got increasded to 4, reducing available supply by effectively around 15%.** It is still expected to be an overall supply buff and could be increased.

# Explain why it's good for the game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->

As explained above this aims to fix two main issues. 

The first is lack of supply for shipside roles, you have to budget them which many Reqs won't do - now they can get some supplies regardless. More can still be ordered as needed. In both cases this is additional player interaction shipside.

The second is the amount of ASRS crates being highly variable and dropping off suddenly. Carrying over "partial" crates should give a more consistent supply flow.

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
![image](https://github.com/cmss13-devs/cmss13/assets/604624/edc14437-7726-431e-aa32-292a76d38c94)

Alternate food pool spawning in in parallel - here with boosted frequency for testing


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
add: Introduced ASRS supply pools. As proof of concept, ASRS now spawns a crate of food ingredients every 20 minutes, in addition to regular gear.
balance: ASRS now keeps track of partial crates awarded. This means if you should receive 2.5 then 2.5 crates, you now get 2 then 3, rather than 2 and 2. This is intended to result in smoother, more reliable transitions and scaling with varying amount of Xenos on map.
balance: Amount of ASRS crates awarded was reduced by about 15.5% to make up for crates carrying over.
code: Refactored part of ASRS supply code to be less of a pain.
fix: Fixed incorrect weighting in the ASRS supply code, effects unknown
fix: Fixed HPR ammo ASRS packs failing to spawn and ending up as MK1s instead
fix: Fixed ASRS order numbers not increasing the order IDs...
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
