### PR TITLE
Makes the squad attachments vendor vend to hand

### DIFF
--- a/code/game/machinery/vending/vendor_types/squad_prep/squad_prep.dm
+++ b/code/game/machinery/vending/vendor_types/squad_prep/squad_prep.dm
@@ -307,6 +307,7 @@
 	req_access = list(ACCESS_MARINE_ALPHA)
 	req_one_access = list(ACCESS_MARINE_LEADER, ACCESS_MARINE_SPECPREP, ACCESS_MARINE_RO)
 	hackable = TRUE
+	vend_flags = VEND_CLUTTER_PROTECTION | VEND_LIMITED_INVENTORY | VEND_TO_HAND
 
 	vend_y_offset = 1
 


### PR DESCRIPTION

# About the pull request

Adds the `VEND_TO_HAND` flag to the squad attachments vendor so that vended items are put into the user's hand (if possible) rather than going directly onto the floor.

Fixes #4875.

# Explain why it's good for the game

Good for QOL/consistency, since all the other vendors in squad prep already have this functionality.


# Testing Photographs and Procedure
<details>
<summary>Videos</summary>
<hr>

**Before:**

https://github.com/cmss13-devs/cmss13/assets/57483089/301a15b1-ffe5-4af3-bed7-f6c567607a80

**After:**

https://github.com/cmss13-devs/cmss13/assets/57483089/8dd0cf18-ce15-4517-989b-19d017612520

</details>


# Changelog
:cl:
qol: Made the squad prep attachments vendors vend items into the user's hands.
/:cl:
