### PR TITLE
Fixes repaired vendor icons not updating

### DIFF
--- a/code/game/machinery/vending/cm_vending.dm
+++ b/code/game/machinery/vending/cm_vending.dm
@@ -84,7 +84,7 @@ IN_USE used for vending/denying
 	if(stat & NOPOWER || stat & TIPPED_OVER) //tipping off without breaking uses "_off" sprite
 		overlays += image(icon, "[icon_state]_off")
 	if(stat & MAINT) //if we require maintenance, then it is completely "_broken"
-		icon_state = "[initial(icon_state)]_broken"
+		overlays += image(icon, "[initial(icon_state)]_broken")
 		if(stat & IN_REPAIR) //if someone started repairs, they unscrewed "_panel"
 			overlays += image(icon, "[icon_state]_panel")
 


### PR DESCRIPTION

# About the pull request

Fixes #5016 

# Explain why it's good for the game
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Fixes vendor sprites not updating icon when fully repaired
/🆑 
