### PR TITLE
CORSAT poddoor and LZ fixes

### DIFF
--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -240,6 +240,7 @@
 
 /obj/structure/machinery/door/poddoor/filler_object
 	name = ""
+	icon = null
 	icon_state = ""
 	unslashable = TRUE
 	unacidable = TRUE

--- a/maps/map_files/CORSAT/Corsat.dmm
+++ b/maps/map_files/CORSAT/Corsat.dmm
@@ -37445,7 +37445,6 @@
 /area/corsat/gamma/biodome/virology)
 "drp" = (
 /obj/docking_port/stationary/marine_dropship/lz1{
-	dwidth = 1;
 	name = "Gamma Landing Zone"
 	},
 /turf/open/floor/plating,
@@ -38223,7 +38222,6 @@
 /area/corsat/omega/complex)
 "dUj" = (
 /obj/docking_port/stationary/marine_dropship/lz2{
-	dwidth = 1;
 	name = "Sigma Landing Zone"
 	},
 /turf/open/floor/plating,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Fixes CORSAT's LZs so that they can be landed on using the modern shuttle system.

Removed the icon from poddoors supposedly invisible `filler_object` so they will actually be invisible, as intended. There's a lot more to be said about wide poddoors using a completely separate system from wide airlocks but -- well, I don't want to.

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

A little less friction using an unmaintained map like CORSAT.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Before, LZs
![image](https://github.com/PvE-CMSS13/PvE-CMSS13/assets/14267245/6a92c821-2507-4bf4-8e69-d994dce16925)
Before, closed poddoors
![image](https://github.com/PvE-CMSS13/PvE-CMSS13/assets/14267245/9cc0ff68-efef-4d05-a1ba-b3c7c8ae86df)
Before, open poddoors
![image](https://github.com/PvE-CMSS13/PvE-CMSS13/assets/14267245/8b89866e-7b2d-499e-8b7c-858a8df2e3e3)

After, LZs
![image](https://github.com/PvE-CMSS13/PvE-CMSS13/assets/14267245/20348a33-e36d-4588-a9d0-06fa8bf61ea6)
After, closed poddoors
![image](https://github.com/PvE-CMSS13/PvE-CMSS13/assets/14267245/e63c0624-0e77-409c-af4a-c2290292517a)
After, open poddoors
![image](https://github.com/PvE-CMSS13/PvE-CMSS13/assets/14267245/62aacf64-2e00-445d-bfd5-a414121e84aa)

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: CORSAT poddoors no longer have extra sprites overlaid on them
maptweak: CORSAT LZs can be used by shuttles
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
