### PR TITLE
fixes orbit menu for 0 health and admins refreshing

### DIFF
--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -65,7 +65,7 @@
 
 	var/is_admin = FALSE
 	if(user && user.client)
-		is_admin = check_other_rights(user.client, R_ADMIN, FALSE)
+		is_admin = check_client_rights(user.client, R_ADMIN, FALSE)
 	var/list/pois = getpois(skip_mindless = !is_admin, specify_dead_role = FALSE)
 	for(var/name in pois)
 		var/list/serialized = list()

--- a/tgui/packages/tgui/interfaces/Orbit/helpers.ts
+++ b/tgui/packages/tgui/interfaces/Orbit/helpers.ts
@@ -31,7 +31,9 @@ export const getDisplayName = (full_name: string, nickname?: string) => {
 };
 
 /** Returns the display color for certain health percentages */
-export const getHealthColor = (health: number) => {
+export const getHealthColor = (health?: number) => {
+  if (!health) return 'bad';
+
   switch (true) {
     case health > HEALTH.Good:
       return 'good';

--- a/tgui/packages/tgui/interfaces/Orbit/index.tsx
+++ b/tgui/packages/tgui/interfaces/Orbit/index.tsx
@@ -215,6 +215,8 @@ const ObservableItem = (
 
   const [autoObserve] = useLocalState<boolean>(context, 'autoObserve', false);
 
+  const displayHealth = typeof health === 'number';
+
   return (
     <Button
       color={'transparent'}
@@ -225,9 +227,9 @@ const ObservableItem = (
         'color': color ? 'white' : 'grey',
       }}
       onClick={() => act('orbit', { ref: ref })}
-      tooltip={!!health && <ObservableTooltip item={item} />}
+      tooltip={displayHealth && <ObservableTooltip item={item} />}
       tooltipPosition="bottom-start">
-      {!!health && (
+      {displayHealth && (
         <ColorBox
           color={getHealthColor(health)}
           style={{ 'margin-right': '0.5em' }}

--- a/tgui/packages/tgui/interfaces/Orbit/index.tsx
+++ b/tgui/packages/tgui/interfaces/Orbit/index.tsx
@@ -252,7 +252,9 @@ const ObservableTooltip = (props: { item: Observable }) => {
   const {
     item: { caste, health, job, full_name, icon, background_color },
   } = props;
-  const displayHealth = !!health && health >= 0 ? `${health}%` : 'Critical';
+
+  const displayHealth = typeof health === 'number';
+  const healthText = !!health && health >= 0 ? `${health}%` : 'Critical';
 
   return (
     <LabeledList>
@@ -275,8 +277,8 @@ const ObservableTooltip = (props: { item: Observable }) => {
           {job}
         </LabeledList.Item>
       )}
-      {!!health && (
-        <LabeledList.Item label="Health">{displayHealth}</LabeledList.Item>
+      {displayHealth && (
+        <LabeledList.Item label="Health">{healthText}</LabeledList.Item>
       )}
     </LabeledList>
   );


### PR DESCRIPTION
closes #5031

:cl:
fix: the health indicator in the tooltip and colorbox is still present when a POI has 0 health
fix: admins can refresh the orbit menu without runtimes
/:cl: