### PR TITLE
Character creation 'Preferred Armor' preview

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1620,6 +1620,8 @@ var/const/MAX_SAVE_SLOTS = 10
 					var/new_pref_armor = tgui_input_list(user, "Choose your character's default style of armor:", "Character Preferences", GLOB.armor_style_list)
 					if(new_pref_armor)
 						preferred_armor = new_pref_armor
+						// Update the dummy with the new armor style.
+						update_preview_icon()
 
 				if("limbs")
 					var/limb_name = tgui_input_list(user, "Which limb do you want to change?", list("Left Leg","Right Leg","Left Arm","Right Arm","Left Foot","Right Foot","Left Hand","Right Hand"))

--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -198,6 +198,16 @@
 
 	arm_equipment(preview_dummy, J, FALSE, FALSE, owner, show_job_gear)
 
+	// If the dummy was equipped with marine armor.
+	var/jacket = preview_dummy.get_item_by_slot(WEAR_JACKET)
+	if(istype(jacket, /obj/item/clothing/suit/storage/marine))
+		var/obj/item/clothing/suit/storage/marine/armor = jacket
+		// If the armor has different sprite variants.
+		if(armor.armor_variation)
+			// Set its `icon_state` to the style the player picked as their 'Preferred Armor'.
+			armor.set_armor_style(preferred_armor)
+			armor.update_icon(preview_dummy)
+
 	if(isnull(preview_front))
 		preview_front = new()
 		owner.add_to_screen(preview_front)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Makes the armour worn by the preview dummy in the character creation menu show the user's 'Preferred Armor' setting.

Also fixes a bug I found where the 'Padded' armour type would have its sprite replaced with the user's preferred style when vended.
This specifically affected the 'Padded' variant because that has the icon states of `L1`/`1`/`H1` for Light/Medium/Heavy, and `post_vendor_spawn_hook()` worked by replacing any `1`s in the `icon_state` with the user's preference.
(`post_vendor_spawn_hook()` now checks if the armour has style variants before anything else.)

# Explain why it's good for the game

The 'Preferred Armor' setting can be a bit confusing if you don't actually know what each armour style looks like. (Which I personally didn't until making this PR.)

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

**Character creation preview:**

https://github.com/cmss13-devs/cmss13/assets/57483089/e2ac29ea-c290-447f-b234-a3ca82397e23
<hr>

**Padded armour bug before:** (Preferred Armor set to 'Skull')

https://github.com/cmss13-devs/cmss13/assets/57483089/ba0bc7d0-2ea0-4d07-8185-3d8920790463

**Padded armour bug after:** (Preferred Armor set to 'Skull')

https://github.com/cmss13-devs/cmss13/assets/57483089/397ad4b4-a7e5-4433-84b5-196ce5df7ded
</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
add: Made the character preview in the character creation menu show the 'Preferred Armor' setting.
fix: Fixed 'Padded' armour being replaced by the user's armour style preference when vended.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
