### PR TITLE
Fix post-SD detonation timer

### DIFF
--- a/code/controllers/subsystem/hijack.dm
+++ b/code/controllers/subsystem/hijack.dm
@@ -238,7 +238,7 @@ SUBSYSTEM_DEF(hijack)
 			return "Complete"
 
 /datum/controller/subsystem/hijack/proc/get_sd_eta()
-	if(!sd_time_remaining)
+	if(sd_detonated)
 		return "Complete"
 
 	if(overloaded_generators <= 0)


### PR DESCRIPTION

# About the pull request
The timer would loop over to 1h after SD went off, this fixes that.

# Explain why it's good for the game
Bugs bad

# Changelog
:cl:
fix: The Self Destruct timer in the status panel will now stop once SD has gone off.
/:cl:
