### PR TITLE
Refactor got handling infection stage and progess of the black goo disease

### DIFF
--- a/code/datums/diseases/black_goo.dm
+++ b/code/datums/diseases/black_goo.dm
@@ -18,8 +18,6 @@
 
 	/// whether we're currently transforming the host into a zombie.
 	var/zombie_transforming = 0
-	/// to make sure we don't spam messages too often.
-	//var/goo_message_cooldown = 0
 	/// tells a dead infectee their stage, so they can know when-abouts they'll revive
 	var/stage_counter = 0
 

--- a/code/datums/diseases/black_goo.dm
+++ b/code/datums/diseases/black_goo.dm
@@ -34,7 +34,7 @@
 	var/stage_level_check = 360
 
 	/// cooldown between each check to see if we display a symptome idea is to get 60s between symptome atleast.
-	var/message_cooldown_time = 600
+	var/message_cooldown_time = 1 MINUTES
 	COOLDOWN_DECLARE(goo_message_cooldown)
 
 /datum/disease/black_goo/stage_act()

--- a/code/datums/diseases/black_goo.dm
+++ b/code/datums/diseases/black_goo.dm
@@ -45,9 +45,9 @@
 
 	//we want to check if we have reach enough stage level to gain a stage
 	// change to 60 for testing should be at 360 normaly
-	if(stage_level >= 60)
+	if(stage_level >= 120)
 		stage ++
-		stage_level = stage_level - 60
+		stage_level = stage_level - 120
 
 	switch(stage)
 		//stage 1 : Viatiate "afflicted"

--- a/code/datums/diseases/black_goo.dm
+++ b/code/datums/diseases/black_goo.dm
@@ -33,8 +33,8 @@
 	///the number of stage level needed to pass another stage.
 	var/stage_level_check = 360
 
-	/// cooldown between each check to see if we display a symptome
-	var/message_cooldown_time = 100
+	/// cooldown between each check to see if we display a symptome idea is to get 60s between symptome atleast.
+	var/message_cooldown_time = 600
 	COOLDOWN_DECLARE(goo_message_cooldown)
 
 /datum/disease/black_goo/stage_act()
@@ -75,7 +75,9 @@
 			COOLDOWN_START(src, goo_message_cooldown, message_cooldown_time)
 
 			switch(rand(0, 100))
-				if(0 to 75)
+				if(0 to 25)
+
+				if(25 to 75)
 					to_chat(affected_mob, SPAN_DANGER("You feel warm..."))
 					stage_level += 9
 				if(75 to 95)
@@ -97,7 +99,9 @@
 			COOLDOWN_START(src, goo_message_cooldown, message_cooldown_time)
 
 			switch(rand(0, 100))
-				if(0 to 50)
+				if(0 to 25)
+				
+				if(25 to 50)
 					to_chat(affected_mob, SPAN_DANGER("You can't trust them..."))
 					stage_level += 5
 				if(50 to 75)

--- a/code/datums/diseases/black_goo.dm
+++ b/code/datums/diseases/black_goo.dm
@@ -12,17 +12,24 @@
 	agent = "Unknown Biological Organism X-65"
 	hidden = list(1,0) //Hidden from med-huds, but not pandemic scanners.  BLOOD TESTS FOR THE WIN
 	permeability_mod = 2
-
 	survive_mob_death = TRUE //We want the dead to turn into zombie.
 	longevity = 500 //the virus tend to die before the dead is turn into zombie this should fix it.
-	var/zombie_transforming = 0 //whether we're currently transforming the host into a zombie.
-	var/goo_message_cooldown = 0 //to make sure we don't spam messages too often.
-	var/stage_counter = 0 // tells a dead infectee their stage, so they can know when-abouts they'll revive
-
-	// set of new var to handle stage progress and
-	var/stage_level = 0 // we start at zero when dead everything go twice as fast each stage take 6 min so it need 360 and if your dead it require 180 so 3 min
-	var/infection_rate = 1
 	stage_prob = 0//no randomness
+
+	/// whether we're currently transforming the host into a zombie.
+	var/zombie_transforming = 0
+	/// to make sure we don't spam messages too often.
+	var/goo_message_cooldown = 0
+	/// tells a dead infectee their stage, so they can know when-abouts they'll revive
+	var/stage_counter = 0
+
+//new variables to handle infection progression inside a stage.
+
+	/// variable that contain accumulated virus progression for an host.
+	var/stage_level = 0
+	/// variable that handle passive increase of the virus of an host.
+	var/infection_rate = 1
+
 
 /datum/disease/black_goo/stage_act()
 	..()
@@ -42,7 +49,7 @@
 		infection_rate = 1
 
 	// here we add the new infection rate to the stage level.
-	stage_level = stage_level + infection_rate
+	stage_level += infection_rate
 
 	// we want to check if we have reach enough stage level to gain a stage 3 stage of 6 min if you get it once.
 	if(stage_level >= 360)
@@ -50,7 +57,6 @@
 		stage_level = stage_level - 360
 
 	switch(stage)
-		//stage 1 : Viatiate "afflicted"
 		if(1)
 			if(H.stat == DEAD && stage_counter != stage)
 				to_chat(H, SPAN_CENTERBOLD("Your zombie infection is now at Stage One! Zombie transformation begins at Stage Three."))
@@ -59,13 +65,12 @@
 				if(prob(5))
 					to_chat(affected_mob, SPAN_DANGER("You feel warm..."))
 					goo_message_cooldown = world.time + 100
-					stage_level = stage_level + 4
+					stage_level += 4
 				else if(prob(3))
 					to_chat(affected_mob, SPAN_DANGER("You can't trust them..."))
 					goo_message_cooldown = world.time + 100
-					stage_level = stage_level + 2
+					stage_level += 2
 
-		//stage 2 : Ague "Febrile"
 		if(2)
 			if(H.stat == DEAD && stage_counter != stage)
 				to_chat(H, SPAN_CENTERBOLD("Your zombie infection is now at Stage Two! Zombie transformation begins at Stage Three."))
@@ -73,22 +78,21 @@
 			if(goo_message_cooldown < world.time)
 				if (prob(5))
 					to_chat(affected_mob, SPAN_DANGER("Your throat is really dry..."))
-					stage_level = stage_level + 10
+					stage_level += 10
 				else if (prob(6))
 					to_chat(affected_mob, SPAN_DANGER("You feel really warm..."))
-					stage_level = stage_level +5
+					stage_level += 5
 				else if (prob(2))
 					to_chat(affected_mob, SPAN_DANGER("You cough up some black fluid..."))
-					stage_level = stage_level + 20
+					stage_level += 20
 				else if (prob(2))
 					H.vomit_on_floor()
-					stage_level = stage_level + 15
+					stage_level += 15
 				else if(prob(3))
 					to_chat(affected_mob, SPAN_DANGER("You can't trust them..."))
-					stage_level = stage_level + 4
+					stage_level += 4
 				goo_message_cooldown = world.time + 100
 
-		//stage 3 : Lusus "Freak"
 		if(3)
 			//check if your already a zombie just return to avoid weird stuff... if for some weird reason first filter deoesn't work...
 			if(H.species.name == SPECIES_ZOMBIE || zombie_transforming == TRUE)

--- a/code/datums/diseases/black_goo.dm
+++ b/code/datums/diseases/black_goo.dm
@@ -73,12 +73,15 @@
 			COOLDOWN_START(src, goo_message_cooldown, message_cooldown_time)
 
 			switch(rand(0, 100))
-				if(0 to 95)
+				if(0 to 50)
 					to_chat(affected_mob, SPAN_DANGER("You feel warm..."))
-					stage_level += 3
+					stage_level += 2
+				if(0 to 50)
+					to_chat(affected_mob, SPAN_DANGER("Your throat is really dry..."))
+					stage_level += 5
 				if(95 to 100)
 					to_chat(affected_mob, SPAN_DANGER("You can't trust them..."))
-					stage_level += 5
+					stage_level += 10
 
 		if(2)
 			if(H.stat == DEAD && stage_counter != stage)
@@ -90,13 +93,13 @@
 			COOLDOWN_START(src, goo_message_cooldown, message_cooldown_time)
 
 			switch(rand(0, 100))
-				if(0 to 75)
+				if(0 to 50)
 					to_chat(affected_mob, SPAN_DANGER("You can't trust them..."))
 					stage_level += 4
-				if(75 to 80)
+				if(50 to 70)
 					to_chat(affected_mob, SPAN_DANGER("You feel really warm..."))
 					stage_level += 5
-				if(80 to 85)
+				if(70 to 85)
 					to_chat(affected_mob, SPAN_DANGER("Your throat is really dry..."))
 					stage_level += 10
 				if(85 to 95)

--- a/code/datums/diseases/black_goo.dm
+++ b/code/datums/diseases/black_goo.dm
@@ -7,17 +7,15 @@
 	spread = "Bites"
 	spread_type = SPECIAL
 	affected_species = list("Human")
-	curable = 0
-	cure_chance = 100
-	desc = ""
+	cure_chance = 100 //meaning the cure will kill the virus asap
 	severity = "Medium"
 	agent = "Unknown Biological Organism X-65"
 	hidden = list(1,0) //Hidden from med-huds, but not pandemic scanners.  BLOOD TESTS FOR THE WIN
 	permeability_mod = 2
 	stage_prob = 4
 	stage_minimum_age = 150
-	survive_mob_death = TRUE //FALSE //switch to true to make dead infected humans still transform
-	longevity = 500 //should allow the dead to rise
+	survive_mob_death = TRUE //We want the dead to turn into zombie.
+	longevity = 500 //the virus tend to die before the dead is turn into zombie this should fix it.
 	var/zombie_transforming = 0 //whether we're currently transforming the host into a zombie.
 	var/goo_message_cooldown = 0 //to make sure we don't spam messages too often.
 	var/stage_counter = 0 // tells a dead infectee their stage, so they can know when-abouts they'll revive
@@ -35,7 +33,6 @@
 			if(H.stat == DEAD && stage_counter != stage)
 				to_chat(H, SPAN_CENTERBOLD("Your zombie infection is now at Stage One! Zombie transformation begins at Stage Four."))
 				stage_counter = stage
-			survive_mob_death = TRUE //changed because infection rate was REALLY horrible.
 			if(goo_message_cooldown < world.time )
 				if(prob(3))
 					to_chat(affected_mob, SPAN_DANGER("You feel really warm..."))
@@ -54,7 +51,6 @@
 				to_chat(H, SPAN_CENTERBOLD("Your zombie infection is now at Stage Three! Zombie transformation begins at Stage Four, which will be soon."))
 				stage_counter = stage
 			hidden = list(0,0)
-			//survive_mob_death = TRUE //even if host dies now, the transformation will occur.
 			H.next_move_slowdown = max(H.next_move_slowdown, 1)
 			if(goo_message_cooldown < world.time)
 				if (prob(3))

--- a/code/datums/diseases/black_goo.dm
+++ b/code/datums/diseases/black_goo.dm
@@ -135,7 +135,7 @@
 		playsound(human.loc, 'sound/hallucinations/wail.ogg', 25, 1)
 		human.jitteriness = 0
 		human.set_species(SPECIES_ZOMBIE)
-		stage = 5
+		stage = 3
 		human.faction = FACTION_ZOMBIE
 		zombie_transforming = FALSE
 

--- a/code/datums/diseases/black_goo.dm
+++ b/code/datums/diseases/black_goo.dm
@@ -29,7 +29,7 @@
 	var/mob/living/carbon/human/H = affected_mob
 
 	// check if your already a zombie or in the process of being transform into one...
-	if(H.species.name == SPECIES_ZOMBIE || zombie_transforming = TRUE)
+	if(H.species.name == SPECIES_ZOMBIE || zombie_transforming == TRUE)
 		return
 
 	//check if dead
@@ -86,7 +86,7 @@
 		// at the end of stage 3 you will be turned into a "zombie"
 		if(3)
 			//check if your already a zombie just return to avoid weird stuff... if for some weird reason first filter deoesn't work...
-			if(H.species.name == SPECIES_ZOMBIE || zombie_transforming = TRUE)
+			if(H.species.name == SPECIES_ZOMBIE || zombie_transforming == TRUE)
 				return
 
 			if(H.stat == DEAD && stage_counter != stage)

--- a/code/datums/diseases/black_goo.dm
+++ b/code/datums/diseases/black_goo.dm
@@ -67,8 +67,6 @@
 			if(H.stat == DEAD && stage_counter != stage)
 				to_chat(H, SPAN_CENTERBOLD("Your zombie infection is now at stage one! Zombie transformation begins at stage three."))
 				stage_counter = stage
-				//doesn't want dead to have symptome make no sense
-				return
 
 			if (!COOLDOWN_FINISHED(src, goo_message_cooldown))
 				return
@@ -91,8 +89,6 @@
 			if(H.stat == DEAD && stage_counter != stage)
 				to_chat(H, SPAN_CENTERBOLD("Your zombie infection is now at stage two! Zombie transformation begins at stage three."))
 				stage_counter = stage
-				//doesn't want dead to have symptome make no sense
-				return
 
 			if (!COOLDOWN_FINISHED(src, goo_message_cooldown))
 				return

--- a/code/datums/diseases/black_goo.dm
+++ b/code/datums/diseases/black_goo.dm
@@ -22,6 +22,7 @@
 	// set of new var to handle stage progress and
 	var/stage_level = 0 // we start at zero when dead everything go twice as fast each stage take 6 min so it need 360 and if your dead it require 180 so 3 min
 	var/infection_rate = 1
+	stage_prob = 0//no randomness
 
 /datum/disease/black_goo/stage_act()
 	..()

--- a/code/datums/diseases/black_goo.dm
+++ b/code/datums/diseases/black_goo.dm
@@ -30,11 +30,12 @@
 	/// variable that handle passive increase of the virus of an host.
 	var/infection_rate = 1
 
-//cooldown
-
+	///the number of stage level needed to pass another stage.
+	var/stage_level_check = 360
+	
+	/// cooldown between each check to see if we display a symptome
 	var/message_cooldown_time = 100
 	COOLDOWN_DECLARE(goo_message_cooldown)
-	
 
 /datum/disease/black_goo/stage_act()
 	..()
@@ -57,9 +58,9 @@
 	stage_level += infection_rate
 
 	// we want to check if we have reach enough stage level to gain a stage 3 stage of 6 min if you get it once.
-	if(stage_level >= 360)
-		stage ++
-		stage_level -= 360
+	if(stage_level >= stage_level_check)
+		stage++
+		stage_level -= stage_level_check
 
 	switch(stage)
 		if(1)
@@ -70,13 +71,13 @@
 			if (!COOLDOWN_FINISHED(src, goo_message_cooldown))
 				return
 			COOLDOWN_START(src, goo_message_cooldown, message_cooldown_time)
-
-			if(prob(5))
-				to_chat(affected_mob, SPAN_DANGER("You feel warm..."))
-				stage_level += 4
-			else if(prob(3))
+			switch(rand(0, 100))
+				if(80 to 95)
+					to_chat(affected_mob, SPAN_DANGER("You feel warm..."))
+					stage_level += 3
+				if(95 to 100)
 				to_chat(affected_mob, SPAN_DANGER("You can't trust them..."))
-				stage_level += 2
+				stage_level += 5
 
 		if(2)
 			if(H.stat == DEAD && stage_counter != stage)
@@ -87,21 +88,22 @@
 				return
 			COOLDOWN_START(src, goo_message_cooldown, message_cooldown_time)
 
-			if (prob(5))
-				to_chat(affected_mob, SPAN_DANGER("Your throat is really dry..."))
-				stage_level += 10
-			else if (prob(6))
-				to_chat(affected_mob, SPAN_DANGER("You feel really warm..."))
-				stage_level += 5
-			else if (prob(2))
-				to_chat(affected_mob, SPAN_DANGER("You cough up some black fluid..."))
-				stage_level += 20
-			else if (prob(2))
-				H.vomit_on_floor()
-				stage_level += 15
-			else if(prob(3))
-				to_chat(affected_mob, SPAN_DANGER("You can't trust them..."))
-				stage_level += 4
+			switch(rand(0, 100))
+				if(65 to 75)
+					to_chat(affected_mob, SPAN_DANGER("You can't trust them..."))
+					stage_level += 4
+				if(75 to 80)
+					to_chat(affected_mob, SPAN_DANGER("You feel really warm..."))
+					stage_level += 5
+				if(80 to 85)
+					to_chat(affected_mob, SPAN_DANGER("Your throat is really dry..."))
+					stage_level += 10
+				if(85 to 95)
+					H.vomit_on_floor()
+					stage_level += 15
+				if(95 to 100)
+					to_chat(affected_mob, SPAN_DANGER("You cough up some black fluid..."))
+					stage_level += 20
 
 		if(3)
 			//check if your already a zombie just return to avoid weird stuff... if for some weird reason first filter deoesn't work...

--- a/code/datums/diseases/black_goo.dm
+++ b/code/datums/diseases/black_goo.dm
@@ -71,13 +71,14 @@
 			if (!COOLDOWN_FINISHED(src, goo_message_cooldown))
 				return
 			COOLDOWN_START(src, goo_message_cooldown, message_cooldown_time)
+
 			switch(rand(0, 100))
 				if(80 to 95)
 					to_chat(affected_mob, SPAN_DANGER("You feel warm..."))
 					stage_level += 3
 				if(95 to 100)
-				to_chat(affected_mob, SPAN_DANGER("You can't trust them..."))
-				stage_level += 5
+					to_chat(affected_mob, SPAN_DANGER("You can't trust them..."))
+					stage_level += 5
 
 		if(2)
 			if(H.stat == DEAD && stage_counter != stage)

--- a/code/datums/diseases/black_goo.dm
+++ b/code/datums/diseases/black_goo.dm
@@ -74,7 +74,6 @@
 
 			switch(rand(0, 100))
 				if(0 to 25)
-
 				if(25 to 75)
 					to_chat(affected_mob, SPAN_DANGER("You feel warm..."))
 					stage_level += 9
@@ -96,7 +95,6 @@
 
 			switch(rand(0, 100))
 				if(0 to 25)
-				
 				if(25 to 50)
 					to_chat(affected_mob, SPAN_DANGER("You can't trust them..."))
 					stage_level += 5

--- a/code/datums/diseases/black_goo.dm
+++ b/code/datums/diseases/black_goo.dm
@@ -19,7 +19,7 @@
 	/// whether we're currently transforming the host into a zombie.
 	var/zombie_transforming = 0
 	/// to make sure we don't spam messages too often.
-	var/goo_message_cooldown = 0
+	//var/goo_message_cooldown = 0
 	/// tells a dead infectee their stage, so they can know when-abouts they'll revive
 	var/stage_counter = 0
 
@@ -29,6 +29,12 @@
 	var/stage_level = 0
 	/// variable that handle passive increase of the virus of an host.
 	var/infection_rate = 1
+
+//cooldown
+
+	var/message_cooldown_time = 100
+	COOLDOWN_DECLARE(goo_message_cooldown)
+	COOLDOWN_START(src, goo_message_cooldown, message_cooldown_time)
 
 /datum/disease/black_goo/stage_act()
 	..()
@@ -60,37 +66,42 @@
 			if(H.stat == DEAD && stage_counter != stage)
 				to_chat(H, SPAN_CENTERBOLD("Your zombie infection is now at Stage One! Zombie transformation begins at Stage Three."))
 				stage_counter = stage
-			if(goo_message_cooldown < world.time )
-				if(prob(5))
-					to_chat(affected_mob, SPAN_DANGER("You feel warm..."))
-					goo_message_cooldown = world.time + 100
-					stage_level += 4
-				else if(prob(3))
-					to_chat(affected_mob, SPAN_DANGER("You can't trust them..."))
-					goo_message_cooldown = world.time + 100
-					stage_level += 2
+
+			if (!COOLDOWN_FINISHED(src, goo_message_cooldown))
+				return
+			COOLDOWN_RESET(src, goo_message_cooldown)
+
+			if(prob(5))
+				to_chat(affected_mob, SPAN_DANGER("You feel warm..."))
+				stage_level += 4
+			else if(prob(3))
+				to_chat(affected_mob, SPAN_DANGER("You can't trust them..."))
+				stage_level += 2
 
 		if(2)
 			if(H.stat == DEAD && stage_counter != stage)
 				to_chat(H, SPAN_CENTERBOLD("Your zombie infection is now at Stage Two! Zombie transformation begins at Stage Three."))
 				stage_counter = stage
-			if(goo_message_cooldown < world.time)
-				if (prob(5))
-					to_chat(affected_mob, SPAN_DANGER("Your throat is really dry..."))
-					stage_level += 10
-				else if (prob(6))
-					to_chat(affected_mob, SPAN_DANGER("You feel really warm..."))
-					stage_level += 5
-				else if (prob(2))
-					to_chat(affected_mob, SPAN_DANGER("You cough up some black fluid..."))
-					stage_level += 20
-				else if (prob(2))
-					H.vomit_on_floor()
-					stage_level += 15
-				else if(prob(3))
-					to_chat(affected_mob, SPAN_DANGER("You can't trust them..."))
-					stage_level += 4
-				goo_message_cooldown = world.time + 100
+
+			if (!COOLDOWN_FINISHED(src, goo_message_cooldown))
+				return
+			COOLDOWN_RESET(src, goo_message_cooldown)
+
+			if (prob(5))
+				to_chat(affected_mob, SPAN_DANGER("Your throat is really dry..."))
+				stage_level += 10
+			else if (prob(6))
+				to_chat(affected_mob, SPAN_DANGER("You feel really warm..."))
+				stage_level += 5
+			else if (prob(2))
+				to_chat(affected_mob, SPAN_DANGER("You cough up some black fluid..."))
+				stage_level += 20
+			else if (prob(2))
+				H.vomit_on_floor()
+				stage_level += 15
+			else if(prob(3))
+				to_chat(affected_mob, SPAN_DANGER("You can't trust them..."))
+				stage_level += 4
 
 		if(3)
 			//check if your already a zombie just return to avoid weird stuff... if for some weird reason first filter deoesn't work...

--- a/code/datums/diseases/black_goo.dm
+++ b/code/datums/diseases/black_goo.dm
@@ -74,6 +74,7 @@
 
 			switch(rand(0, 100))
 				if(0 to 25)
+					return
 				if(25 to 75)
 					to_chat(affected_mob, SPAN_DANGER("You feel warm..."))
 					stage_level += 9
@@ -95,6 +96,7 @@
 
 			switch(rand(0, 100))
 				if(0 to 25)
+					return
 				if(25 to 50)
 					to_chat(affected_mob, SPAN_DANGER("You can't trust them..."))
 					stage_level += 5

--- a/code/datums/diseases/black_goo.dm
+++ b/code/datums/diseases/black_goo.dm
@@ -32,7 +32,7 @@
 
 	///the number of stage level needed to pass another stage.
 	var/stage_level_check = 360
-	
+
 	/// cooldown between each check to see if we display a symptome
 	var/message_cooldown_time = 100
 	COOLDOWN_DECLARE(goo_message_cooldown)
@@ -73,7 +73,7 @@
 			COOLDOWN_START(src, goo_message_cooldown, message_cooldown_time)
 
 			switch(rand(0, 100))
-				if(80 to 95)
+				if(0 to 95)
 					to_chat(affected_mob, SPAN_DANGER("You feel warm..."))
 					stage_level += 3
 				if(95 to 100)
@@ -90,7 +90,7 @@
 			COOLDOWN_START(src, goo_message_cooldown, message_cooldown_time)
 
 			switch(rand(0, 100))
-				if(65 to 75)
+				if(0 to 75)
 					to_chat(affected_mob, SPAN_DANGER("You can't trust them..."))
 					stage_level += 4
 				if(75 to 80)

--- a/code/datums/diseases/black_goo.dm
+++ b/code/datums/diseases/black_goo.dm
@@ -67,26 +67,30 @@
 			if(H.stat == DEAD && stage_counter != stage)
 				to_chat(H, SPAN_CENTERBOLD("Your zombie infection is now at stage one! Zombie transformation begins at stage three."))
 				stage_counter = stage
+				//doesn't want dead to have symptome make no sense
+				return
 
 			if (!COOLDOWN_FINISHED(src, goo_message_cooldown))
 				return
 			COOLDOWN_START(src, goo_message_cooldown, message_cooldown_time)
 
 			switch(rand(0, 100))
-				if(0 to 50)
+				if(0 to 75)
 					to_chat(affected_mob, SPAN_DANGER("You feel warm..."))
-					stage_level += 2
-				if(0 to 50)
+					stage_level += 9
+				if(75 to 95)
 					to_chat(affected_mob, SPAN_DANGER("Your throat is really dry..."))
-					stage_level += 5
+					stage_level += 18
 				if(95 to 100)
 					to_chat(affected_mob, SPAN_DANGER("You can't trust them..."))
-					stage_level += 10
+					stage_level += 36
 
 		if(2)
 			if(H.stat == DEAD && stage_counter != stage)
 				to_chat(H, SPAN_CENTERBOLD("Your zombie infection is now at stage two! Zombie transformation begins at stage three."))
 				stage_counter = stage
+				//doesn't want dead to have symptome make no sense
+				return
 
 			if (!COOLDOWN_FINISHED(src, goo_message_cooldown))
 				return
@@ -95,19 +99,19 @@
 			switch(rand(0, 100))
 				if(0 to 50)
 					to_chat(affected_mob, SPAN_DANGER("You can't trust them..."))
-					stage_level += 4
-				if(50 to 70)
-					to_chat(affected_mob, SPAN_DANGER("You feel really warm..."))
 					stage_level += 5
-				if(70 to 85)
+				if(50 to 75)
+					to_chat(affected_mob, SPAN_DANGER("You feel really warm..."))
+					stage_level += 9
+				if(75 to 85)
 					to_chat(affected_mob, SPAN_DANGER("Your throat is really dry..."))
-					stage_level += 10
+					stage_level += 18
 				if(85 to 95)
 					H.vomit_on_floor()
-					stage_level += 15
+					stage_level += 36
 				if(95 to 100)
 					to_chat(affected_mob, SPAN_DANGER("You cough up some black fluid..."))
-					stage_level += 20
+					stage_level += 42
 
 		if(3)
 			//check if your already a zombie just return to avoid weird stuff... if for some weird reason first filter deoesn't work...

--- a/code/datums/diseases/black_goo.dm
+++ b/code/datums/diseases/black_goo.dm
@@ -35,7 +35,7 @@
 
 	// check if dead
 	if(H.stat == DEAD)
-		infection_rate = 2
+		infection_rate = 4
 
 	// check if he isn't dead
 	if(H.stat != DEAD)

--- a/code/datums/diseases/black_goo.dm
+++ b/code/datums/diseases/black_goo.dm
@@ -34,7 +34,7 @@
 
 	var/message_cooldown_time = 100
 	COOLDOWN_DECLARE(goo_message_cooldown)
-	COOLDOWN_START(src, goo_message_cooldown, message_cooldown_time)
+	
 
 /datum/disease/black_goo/stage_act()
 	..()
@@ -69,7 +69,7 @@
 
 			if (!COOLDOWN_FINISHED(src, goo_message_cooldown))
 				return
-			COOLDOWN_RESET(src, goo_message_cooldown)
+			COOLDOWN_START(src, goo_message_cooldown, message_cooldown_time)
 
 			if(prob(5))
 				to_chat(affected_mob, SPAN_DANGER("You feel warm..."))
@@ -85,7 +85,7 @@
 
 			if (!COOLDOWN_FINISHED(src, goo_message_cooldown))
 				return
-			COOLDOWN_RESET(src, goo_message_cooldown)
+			COOLDOWN_START(src, goo_message_cooldown, message_cooldown_time)
 
 			if (prob(5))
 				to_chat(affected_mob, SPAN_DANGER("Your throat is really dry..."))

--- a/code/datums/diseases/black_goo.dm
+++ b/code/datums/diseases/black_goo.dm
@@ -33,58 +33,62 @@
 	if(H.species.name == SPECIES_ZOMBIE || zombie_transforming == TRUE)
 		return
 
-	//check if dead
+	// check if dead
 	if(H.stat == DEAD)
 		infection_rate = 2
 
-	//check if he isn't dead
+	// check if he isn't dead
 	if(H.stat != DEAD)
 		infection_rate = 1
 
 	// here we add the new infection rate to the stage level.
 	stage_level = stage_level + infection_rate
 
-	//we want to check if we have reach enough stage level to gain a stage
-	// change to 60 for testing should be at 360 normaly
-	if(stage_level >= 120)
+	// we want to check if we have reach enough stage level to gain a stage 3 stage of 6 min if you get it once.
+	if(stage_level >= 360)
 		stage ++
-		stage_level = stage_level - 120
+		stage_level = stage_level - 360
 
 	switch(stage)
 		//stage 1 : Viatiate "afflicted"
-		// goign to keep you feel warm and maybe add you can experience paranoia don't know how?
 		if(1)
 			if(H.stat == DEAD && stage_counter != stage)
 				to_chat(H, SPAN_CENTERBOLD("Your zombie infection is now at Stage One! Zombie transformation begins at Stage Three."))
 				stage_counter = stage
 			if(goo_message_cooldown < world.time )
 				if(prob(5))
-					to_chat(affected_mob, SPAN_DANGER("You feel warm..."))//small hint that your infected
+					to_chat(affected_mob, SPAN_DANGER("You feel warm..."))
 					goo_message_cooldown = world.time + 100
+					stage_level = stage_level + 4
 				else if(prob(3))
-					to_chat(affected_mob, SPAN_DANGER("You can't trust them..."))//try at making you feel paranoic
+					to_chat(affected_mob, SPAN_DANGER("You can't trust them..."))
 					goo_message_cooldown = world.time + 100
+					stage_level = stage_level + 2
 
 		//stage 2 : Ague "Febrile"
-		//pain fever and the eye will darken ? some veine become dark as the tissue start to necrose
-		//maybe febrile seizure due to fever basicly. pain is from necrosis...(witch is not ingame)
-		// screaming, seizure from fever fever symptome, pain
 		if(2)
 			if(H.stat == DEAD && stage_counter != stage)
 				to_chat(H, SPAN_CENTERBOLD("Your zombie infection is now at Stage Two! Zombie transformation begins at Stage Three."))
 				stage_counter = stage
 			if(goo_message_cooldown < world.time)
-				if (prob(3)) to_chat(affected_mob, SPAN_DANGER("Your throat is really dry..."))
-				else if (prob(6)) to_chat(affected_mob, SPAN_DANGER("You feel really warm..."))
-				else if (prob(2)) to_chat(affected_mob, SPAN_DANGER("You cough up some black fluid..."))
-				else if (prob(2))to_chat(affected_mob, SPAN_DANGER("Your throat is really dry..."))
-				else if (prob(2)) H.vomit_on_floor()
+				if (prob(5))
+					to_chat(affected_mob, SPAN_DANGER("Your throat is really dry..."))
+					stage_level = stage_level + 10
+				else if (prob(6))
+					to_chat(affected_mob, SPAN_DANGER("You feel really warm..."))
+					stage_level = stage_level +5
+				else if (prob(2))
+					to_chat(affected_mob, SPAN_DANGER("You cough up some black fluid..."))
+					stage_level = stage_level + 20
+				else if (prob(2))
+					H.vomit_on_floor()
+					stage_level = stage_level + 15
+				else if(prob(3))
+					to_chat(affected_mob, SPAN_DANGER("You can't trust them..."))
+					stage_level = stage_level + 4
 				goo_message_cooldown = world.time + 100
 
-		//stage 3 : Lusus "Freak" you turn into a zombie (should be pretty dramatic scream etc... convulsion coma etc...?)
-		//you become animalistic husk you will attack everyone on sight some can retain some inteligence (using tools ) maybe just make it justify
-		// for them to avoid running to certain death and allow them to be "smart" will staying withing RP///
-		// at the end of stage 3 you will be turned into a "zombie"
+		//stage 3 : Lusus "Freak"
 		if(3)
 			//check if your already a zombie just return to avoid weird stuff... if for some weird reason first filter deoesn't work...
 			if(H.species.name == SPECIES_ZOMBIE || zombie_transforming == TRUE)
@@ -93,32 +97,11 @@
 			if(H.stat == DEAD && stage_counter != stage)
 				to_chat(H, SPAN_CENTERBOLD("Your zombie infection is now at Stage Three! Zombie transformation begin!"))
 				stage_counter = stage
-			//hidden = list(0,0)//why?
+			hidden = list(0,0)
 			if(!zombie_transforming)
 				zombie_transform(H)
-			H.next_move_slowdown = max(H.next_move_slowdown, 2)//what is this?
-/*shouldn't need this going to test it without it...
-		//stage 4 : Lusus "Freak" this part will be to force people to turn in case stage 3 fail
-		// safety stage will be remove if nobody reach it in my tests..
-		if(4)
-			if(H.stat == DEAD && stage_counter != stage)
-				to_chat(H, SPAN_CENTERBOLD("Your zombie infection is now at Stage Four! Zombie transformation begin!"))
-				stage_counter = stage
-			if(H.stat == DEAD && stage_counter != stage)
-					stage_counter = stage
-					if(H.species.name != SPECIES_ZOMBIE && !zombie_transforming)
-						to_chat(H, SPAN_CENTERBOLD("Your zombie infection is now at Stage Five! Your transformation should have happened already, but will be forced now."))
-						zombie_transform(H)
-			if(!zombie_transforming && prob(50))
-				if(H.stat != DEAD)
-					var/healamt = 2
-					if(H.health < H.maxHealth)
-						H.apply_damage(-healamt, BURN)
-						H.apply_damage(-healamt, BRUTE)
-						H.apply_damage(-healamt, TOX)
-						H.apply_damage(-healamt, OXY)
-				H.nutrition = NUTRITION_MAX //never hungry
-*/
+			H.next_move_slowdown = max(H.next_move_slowdown, 2)
+
 /datum/disease/black_goo/proc/zombie_transform(mob/living/carbon/human/human)
 	set waitfor = 0
 	zombie_transforming = TRUE

--- a/code/datums/diseases/black_goo.dm
+++ b/code/datums/diseases/black_goo.dm
@@ -30,14 +30,13 @@
 	/// variable that handle passive increase of the virus of an host.
 	var/infection_rate = 1
 
-
 /datum/disease/black_goo/stage_act()
 	..()
 	if(!ishuman(affected_mob)) return
 	var/mob/living/carbon/human/H = affected_mob
 
 	// check if your already a zombie or in the process of being transform into one...
-	if(H.species.name == SPECIES_ZOMBIE || zombie_transforming == TRUE)
+	if(iszombie(H))
 		return
 
 	// check if dead
@@ -54,7 +53,7 @@
 	// we want to check if we have reach enough stage level to gain a stage 3 stage of 6 min if you get it once.
 	if(stage_level >= 360)
 		stage ++
-		stage_level = stage_level - 360
+		stage_level -= 360
 
 	switch(stage)
 		if(1)
@@ -95,7 +94,7 @@
 
 		if(3)
 			//check if your already a zombie just return to avoid weird stuff... if for some weird reason first filter deoesn't work...
-			if(H.species.name == SPECIES_ZOMBIE || zombie_transforming == TRUE)
+			if(iszombie(H))
 				return
 
 			if(H.stat == DEAD && stage_counter != stage)

--- a/code/datums/diseases/black_goo.dm
+++ b/code/datums/diseases/black_goo.dm
@@ -64,7 +64,7 @@
 	switch(stage)
 		if(1)
 			if(H.stat == DEAD && stage_counter != stage)
-				to_chat(H, SPAN_CENTERBOLD("Your zombie infection is now at Stage One! Zombie transformation begins at Stage Three."))
+				to_chat(H, SPAN_CENTERBOLD("Your zombie infection is now at stage one! Zombie transformation begins at stage three."))
 				stage_counter = stage
 
 			if (!COOLDOWN_FINISHED(src, goo_message_cooldown))
@@ -80,7 +80,7 @@
 
 		if(2)
 			if(H.stat == DEAD && stage_counter != stage)
-				to_chat(H, SPAN_CENTERBOLD("Your zombie infection is now at Stage Two! Zombie transformation begins at Stage Three."))
+				to_chat(H, SPAN_CENTERBOLD("Your zombie infection is now at stage two! Zombie transformation begins at stage three."))
 				stage_counter = stage
 
 			if (!COOLDOWN_FINISHED(src, goo_message_cooldown))
@@ -109,7 +109,7 @@
 				return
 
 			if(H.stat == DEAD && stage_counter != stage)
-				to_chat(H, SPAN_CENTERBOLD("Your zombie infection is now at Stage Three! Zombie transformation begin!"))
+				to_chat(H, SPAN_CENTERBOLD("Your zombie infection is now at stage three! Zombie transformation begin!"))
 				stage_counter = stage
 			hidden = list(0,0)
 			if(!zombie_transforming)

--- a/code/datums/diseases/black_goo.dm
+++ b/code/datums/diseases/black_goo.dm
@@ -1,7 +1,7 @@
 //Disease Datum
 /datum/disease/black_goo
 	name = "Black Goo"
-	max_stages = 4
+	max_stages = 3
 	cure = "Anti-Zed"
 	cure_id = "antiZed"
 	spread = "Bites"
@@ -96,7 +96,7 @@
 			if(!zombie_transforming)
 				zombie_transform(H)
 			H.next_move_slowdown = max(H.next_move_slowdown, 2)//what is this?
-
+/*shouldn't need this going to test it without it...
 		//stage 4 : Lusus "Freak" this part will be to force people to turn in case stage 3 fail
 		// safety stage will be remove if nobody reach it in my tests..
 		if(4)
@@ -117,7 +117,7 @@
 						H.apply_damage(-healamt, TOX)
 						H.apply_damage(-healamt, OXY)
 				H.nutrition = NUTRITION_MAX //never hungry
-
+*/
 /datum/disease/black_goo/proc/zombie_transform(mob/living/carbon/human/human)
 	set waitfor = 0
 	zombie_transforming = TRUE


### PR DESCRIPTION
# About the pull request

1- reduce the number of stages from 5 to 3. each stage take 6 min or 360s

2-rework the logic that handle the disease progress

A-Set stage_prob to zero to prevent random stage increase.

B-add a stage_level variable that when is at-least 360 make an increase of the disease stage...

C-add an infection_rate variable that handle how fast the stage_level increase passively.
( stage_level = stage_level +infection_rate )
i also made it so that infection-rate is quadruple when the host is dead.

D-I also added that the goo messages (you feel warm ....) give a boost to stage_level to add some randomness to the infection progress.

To do list:
i need to figure out how to increase stage level when someone get hit by a zombie after he is infected...
no idea if i can manage that so i am just going to put what i made up for review...

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
those change are to make infection evolution less random and way more smooth progress with the addition of some random boost with the good message since it's something that could represent a natural boost of the infection progress in the host.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: reduce the number of stages from 5 to 3. each stage take 6 min or 360s.
balance: rework the logic that handle the disease progress
balance: A-Set stage_prob to zero to prevent random stage increase.
balance: B-add a stage_level variable that when is at-least 360 make an increase of the disease stage...
balance: C-add an infection_rate variable that handle how fast the stage_level increase passively.
balance: D-infection_rate is quadruple when the host is dead.
balance: E-I also added that the goo messages (you feel warm ....) give a boost to stage_level to add some randomness to the infection progress.
/:cl:
