### PR TITLE
Prayer and USCM message visibility tweaks

### DIFF
--- a/code/modules/admin/verbs/pray.dm
+++ b/code/modules/admin/verbs/pray.dm
@@ -17,13 +17,14 @@
 		liaison = 1
 
 	if(liaison)
-		msg = SPAN_STAFF_IC("<b><font color=purple>LIAISON: </font>[key_name(src, 1)] [CC_MARK(src)] [ADMIN_PP(src)] [ADMIN_VV(src)] [ADMIN_SM(src)] [ADMIN_JMP_USER(src)] [ADMIN_SC(src)]:</b> [msg]")
+		msg = "<b><big>[SPAN_STAFF_IC("<font color=purple>LIAISON:</font>")][key_name(src, 1)] [CC_MARK(src)] [ADMIN_PP(src)] [ADMIN_VV(src)] [ADMIN_SM(src)] [ADMIN_JMP_USER(src)] [ADMIN_SC(src)]: [msg]</b></big>"
 	else
-		msg = SPAN_STAFF_IC("<b><font color=purple>PRAY: </font>[key_name(src, 1)] [CC_MARK(src)] [ADMIN_PP(src)] [ADMIN_VV(src)] [ADMIN_SM(src)] [ADMIN_JMP_USER(src)] [ADMIN_SC(src)]:</b> [msg]")
+		msg = "<b><big>[SPAN_STAFF_IC("<font color=purple>PRAY: </font>")][key_name(src, 1)] [CC_MARK(src)] [ADMIN_PP(src)] [ADMIN_VV(src)] [ADMIN_SM(src)] [ADMIN_JMP_USER(src)] [ADMIN_SC(src)]: [msg]</b></big>"
 	log_admin(msg)
 	for(var/client/C in GLOB.admins)
 		if(AHOLD_IS_MOD(C.admin_holder) && C.prefs.toggles_chat & CHAT_PRAYER)
 			to_chat(C, msg)
+			C << 'sound/machines/terminal_alert.ogg'
 	if(liaison)
 		to_chat(usr, "Your corporate overlords at Weyland-Yutani have received your message.")
 	else
@@ -31,7 +32,7 @@
 
 /proc/high_command_announce(text , mob/Sender , iamessage)
 	var/msg = copytext(sanitize(text), 1, MAX_MESSAGE_LEN)
-	msg = "<b>[SPAN_STAFF_IC("<font color=orange>USCM[iamessage ?  "IA" : ""]:</font>")][key_name(Sender, 1)] [CC_MARK(Sender)] [ADMIN_PP(Sender)] [ADMIN_VV(Sender)] [ADMIN_SM(Sender)] [ADMIN_JMP_USER(Sender)] [CC_REPLY(Sender)]:</b> [msg]"
+	msg = "<b><big>[SPAN_STAFF_IC("<font color=orange>USCM[iamessage ?  "IA" : ""]:</font>")][key_name(Sender, 1)] [CC_MARK(Sender)] [ADMIN_PP(Sender)] [ADMIN_VV(Sender)] [ADMIN_SM(Sender)] [ADMIN_JMP_USER(Sender)] [CC_REPLY(Sender)]: [msg]</b></big>"
 	log_admin(msg)
 	for(var/client/C in GLOB.admins)
 		if((R_ADMIN|R_MOD) & C.admin_holder.rights)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

This PR adds one of the distinct, but hopefully not disruptive terminal sounds to the message prompt mods/admins relieve when a player sends a prayer and makes both the USCM emergency message prompts and prayer prompts one size up from current font size and bolded for better visibility.

Something something downstream improvement that really should be upstream something.

# Explain why it's good for the game

Prayer visibility in particular has always been an issue, now not only there is a sound, these messages are bolded and slightly bigger. 


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

My font settings:
![image](https://github.com/cmss13-devs/cmss13/assets/103842328/8e57b411-9b31-4bd4-a71c-ef5ec3de4f10)

The messages, surrounding a regular prompt:

![image](https://github.com/cmss13-devs/cmss13/assets/103842328/f4b7577e-f9be-43be-8850-e86aacc53085)

The sound is sound\machines\terminal_alert.ogg


</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
admin: Recieving prayers now makes a sound
admin: Prayers and USCM emergency messages are now better highlighted for mods/admins
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
