### PR TITLE
Removes the scrollbar from the 'Player setup' menu

### DIFF
--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -63,7 +63,7 @@
 	output += "</div>"
 	if (refresh)
 		close_browser(src, "playersetup")
-	show_browser(src, output, null, "playersetup", "size=240x[round_start ? 330 : 460];can_close=0;can_minimize=0")
+	show_browser(src, output, null, "playersetup", "size=240x[round_start ? 360 : 460];can_close=0;can_minimize=0")
 	return
 
 /mob/new_player/Topic(href, href_list[])


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Removes the scrollbar from the pre-roundstart 'Player setup' menu by increasing its height slightly.

# Explain why it's good for the game

There's nowhere to actually scroll to, so it's just taking up a big chunk of the space on the right side of the window.


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

**Before:**
![old 1](https://github.com/cmss13-devs/cmss13/assets/57483089/bcf463ed-390e-41df-91b4-29d65d6dd943)

**After:**
![new 1](https://github.com/cmss13-devs/cmss13/assets/57483089/ca75110c-4a0c-4ca1-8251-d4c1c981b263)

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
ui: Removed the scrollbar from the 'Player setup' menu.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
