### PR TITLE
Fixes Kutjevo space tiles

### DIFF
--- a/maps/map_files/Kutjevo/sprinkles/35.communications.dmm
+++ b/maps/map_files/Kutjevo/sprinkles/35.communications.dmm
@@ -108,10 +108,6 @@
 	dir = 1
 	},
 /area/template_noop)
-"qI" = (
-/obj/structure/window/framed/kutjevo,
-/turf/open/space/basic,
-/area/template_noop)
 "qM" = (
 /obj/structure/machinery/light,
 /obj/effect/decal/cleanable/blood/oil,
@@ -492,7 +488,7 @@ Re
 EK
 "}
 (5,1,1) = {"
-qI
+EK
 wC
 rG
 LO
@@ -506,7 +502,7 @@ cm
 YO
 "}
 (6,1,1) = {"
-qI
+EK
 rm
 lZ
 nn

--- a/maps/map_files/Whiskey_Outpost_v2/Whiskey_Outpost_v2.dmm
+++ b/maps/map_files/Whiskey_Outpost_v2/Whiskey_Outpost_v2.dmm
@@ -2220,9 +2220,6 @@
 	icon_state = "floor_plate"
 	},
 /area/whiskey_outpost/inside/living)
-"hP" = (
-/turf/open/space/basic,
-/area/whiskey_outpost/inside/caves)
 "hQ" = (
 /turf/open/floor/prison{
 	icon_state = "floor_plate"
@@ -22778,7 +22775,7 @@ mT
 mT
 mT
 mT
-hP
+mT
 mT
 mT
 dl
@@ -23177,12 +23174,12 @@ mT
 mT
 mT
 mT
-hP
 mT
 mT
 mT
 mT
-hP
+mT
+mT
 mT
 mT
 qz


### PR DESCRIPTION

# About the pull request

Fixes #5013 by replacing a couple of space tiles under a window with plating.
(They were in a 'Nightmare' submap, so I didn't need to touch the main map file.)

I also checked the other maps for any more hidden space tiles, and found a few out of bounds in Whiskey Outpost, so I figured I'd add those too.

# Explain why it's good for the game
They don't actually seem to do anything bad, but either way spess tiles shouldn't be visible on a ground map.
# Testing Photographs and Procedure
<details>
<summary>Screenshots</summary>

**Before:**
![scrnshot1](https://github.com/cmss13-devs/cmss13/assets/57483089/24b104bd-73bf-4de4-86d7-496db8bb9fef)

**After:**
![scrnshot2](https://github.com/cmss13-devs/cmss13/assets/57483089/f99538a2-e16b-4aaf-927c-38a0abfc22ed)

</details>


# Changelog
:cl:
fix: Fixed a few space tiles under a window in Kutjevo Refinery.
/:cl:
