### PR TITLE
Kutjevo Tunnels Upgrade

### DIFF
--- a/maps/map_files/Kutjevo/Kutjevo.dmm
+++ b/maps/map_files/Kutjevo/Kutjevo.dmm
@@ -563,6 +563,10 @@
 	},
 /turf/open/auto_turf/sand/layer0,
 /area/kutjevo/exterior/scrubland)
+"aKg" = (
+/obj/structure/tunnel,
+/turf/open/auto_turf/sand/layer0,
+/area/kutjevo/interior/colony_South)
 "aKl" = (
 /obj/structure/machinery/landinglight/ds1{
 	dir = 1
@@ -964,7 +968,7 @@
 "bsq" = (
 /obj/structure/tunnel,
 /turf/open/auto_turf/sand/layer0,
-/area/kutjevo/interior/colony_central)
+/area/kutjevo/interior/colony_north)
 "bsw" = (
 /obj/structure/platform/kutjevo/smooth{
 	dir = 8
@@ -8631,11 +8635,9 @@
 /turf/open/floor/almayer/research/containment/floor2,
 /area/kutjevo/interior/complex/med/auto_doc)
 "lZT" = (
-/obj/structure/tunnel{
-	id = "hole1"
-	},
-/turf/open/auto_turf/sand/layer2,
-/area/kutjevo/interior/colony_north)
+/obj/structure/tunnel,
+/turf/open/auto_turf/sand/layer1,
+/area/kutjevo/exterior/construction)
 "lZZ" = (
 /obj/structure/platform_decoration/kutjevo{
 	dir = 4
@@ -9543,11 +9545,9 @@
 /turf/open/desert/desert_shore/shore_corner2,
 /area/kutjevo/exterior/runoff_river)
 "niP" = (
-/obj/structure/tunnel{
-	id = "hole3"
-	},
+/obj/structure/tunnel,
 /turf/open/auto_turf/sand/layer0,
-/area/kutjevo/exterior/complex_border/botany_medical_cave)
+/area/kutjevo/exterior/runoff_river)
 "niT" = (
 /obj/structure/flora/grass/tallgrass/desert/corner{
 	dir = 1
@@ -11686,6 +11686,10 @@
 	},
 /turf/open/floor/kutjevo/colors/cyan/inner_corner,
 /area/kutjevo/interior/complex/med/triage)
+"pVH" = (
+/obj/structure/tunnel,
+/turf/open/auto_turf/sand/layer2,
+/area/kutjevo/exterior/runoff_river)
 "pWe" = (
 /obj/structure/platform_decoration/kutjevo/rock{
 	dir = 1
@@ -12195,11 +12199,9 @@
 	},
 /area/kutjevo/interior/oob)
 "qLV" = (
-/obj/structure/tunnel{
-	id = "hole2"
-	},
-/turf/open/auto_turf/sand/layer1,
-/area/kutjevo/exterior/stonyfields)
+/obj/structure/tunnel,
+/turf/open/auto_turf/sand/layer0,
+/area/kutjevo/interior/colony_S_East)
 "qMC" = (
 /obj/structure/machinery/light{
 	dir = 4
@@ -15689,11 +15691,9 @@
 /turf/open/floor/kutjevo/multi_tiles,
 /area/kutjevo/exterior/runoff_bridge)
 "vzy" = (
-/obj/structure/tunnel{
-	id = "hole4"
-	},
-/turf/open/auto_turf/sand/layer0,
-/area/kutjevo/exterior/scrubland)
+/obj/structure/tunnel,
+/turf/open/gm/dirtgrassborder2,
+/area/kutjevo/exterior/complex_border/med_park)
 "vzC" = (
 /obj/structure/platform/kutjevo{
 	dir = 1
@@ -27671,7 +27671,7 @@ sYd
 bXl
 bXl
 bXl
-vzy
+bXl
 sYd
 bXl
 sYd
@@ -31167,7 +31167,7 @@ bEp
 bEp
 bEp
 bEp
-tKY
+niP
 dic
 dic
 dic
@@ -33232,7 +33232,7 @@ xJg
 xJg
 xJg
 xJg
-qLV
+xJg
 jfQ
 jfQ
 xJg
@@ -34516,7 +34516,7 @@ jhS
 jhS
 jhS
 wff
-niP
+wff
 wff
 wff
 jhS
@@ -35144,7 +35144,7 @@ dxF
 mxB
 mxB
 mxB
-quy
+vzy
 tUm
 wYp
 bGV
@@ -37390,7 +37390,7 @@ nKh
 nKh
 nKh
 wtH
-sbX
+pVH
 mtS
 fPH
 dTM
@@ -42333,7 +42333,7 @@ bkR
 wTt
 bkR
 bEH
-lZT
+bEH
 hUk
 hUk
 hUk
@@ -42680,7 +42680,7 @@ hUk
 hUk
 hUk
 hUk
-xWK
+lZT
 nlA
 xWK
 xWK
@@ -46404,7 +46404,7 @@ wXd
 wXd
 wXd
 wXd
-mMH
+aKg
 bpj
 npL
 bpj
@@ -48327,7 +48327,7 @@ bkR
 bkR
 bkR
 wTt
-wTt
+bsq
 hUk
 hUk
 hUk
@@ -49701,7 +49701,7 @@ kZz
 feg
 feg
 feg
-bsq
+uiK
 mnT
 mnT
 mnT
@@ -53907,7 +53907,7 @@ ptY
 ebB
 ebB
 bOc
-ptY
+qLV
 dxF
 dxF
 dxF


### PR DESCRIPTION
# About the pull request

As part of my ongoing series of PRs to update tunnel placements, especially on older maps, Kutjevo has had its original five tunnels replaced with 7 new tunnels with more of a focus on the center and right sides of the map.

# Explain why it's good for the game

Kutjevo's tunnels I find are mediocre at best, to start with there's a very limited quantity of five tunnels, which was like Sorokyne until recently, and of which three of them I believed to be mediocre at best and the other two to be not particularly useful most times.

The scrubland tunnel is out in the open with no natural cover and it is rather close to the LZ, this attempts to move it further backwards and make it a little more out of the way. 

The stony fields tunnel is not terrible but it suffers from a lack of use since there was already a better option between botany and medical and from personal experience I find the majority of landings are at the north LZ rather than the south LZ. Since it's so out of the way it can become a free shortcut to the comms tower in the late game should it spawn at Hydroelectric.

The afforementioned botany-medical tunnel isn't bad, it's just plainly in the open and it doesn't last particularly long once a foothold has been established in medical or botany. The two existing tunnels inside the caves are mediocre at best and from my personal experience any normal hive tends to be just far enough away from them to make an in-Hive tunnel a requirement.

I've opted to give both medical and botany their own "dedicated" tunnels in the medical park and the NE corner of botany. I have moved the scrubland tunnel further east behind some cover. The other tunnels provide better access to the caves and the eastern construction area in general.

# Testing Photographs and Procedure

(The lines are just visual aids to make finding the tunnel spots easier, they are not indicative of other functions*)

Kutjevo's Existing Tunnels:
![Kutjevo Tunnel Map V2 0](https://github.com/cmss13-devs/cmss13/assets/31109792/addc07ed-c272-4e8c-94a1-2c25558b836b)

Kutjevo's New Tunnels:
![Kutjevo Tunnel Map V3 0](https://github.com/cmss13-devs/cmss13/assets/31109792/4fd97c14-4d62-4b64-961e-aaf61ba8b32e)

# Changelog

:cl:
mappadd: Added 7 new tunnels to Kutjevo
maptweak: Removed the 5 original tunnels on Kutjevo
/:cl:
