### PR TITLE
Eggsac Carrier Hardy weed fix.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/egg_item.dm
+++ b/code/modules/mob/living/carbon/xenomorph/egg_item.dm
@@ -122,7 +122,7 @@
 			var/obj/effect/alien/egg/newegg
 			if(weed.weed_strength >= WEED_LEVEL_HIVE)
 				newegg = new /obj/effect/alien/egg(T, hivenumber)
-			else if(weed.weed_strength == WEED_LEVEL_STANDARD)
+			else if(weed.weed_strength >= WEED_LEVEL_STANDARD)
 				newegg = new /obj/effect/alien/egg/carrier_egg(T,hivenumber, user)
 			else
 				to_chat(user, SPAN_XENOWARNING("[src] can't be planted on these weeds."))


### PR DESCRIPTION

# About the pull request

In #4716 I forgot about hardy weeds. This allows carrier to plant the fragile eggs on standard and hardy weeds which are basically standard weeds +.

# Explain why it's good for the game
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Eggsac fragile eggs can be placed on hardy weeds.
/:cl:
