### PR TITLE
Removes flame particles

### DIFF
--- a/code/modules/projectiles/guns/flamer/flamer.dm
+++ b/code/modules/projectiles/guns/flamer/flamer.dm
@@ -375,29 +375,6 @@
 	. = ..()
 	set_fire_delay(FIRE_DELAY_TIER_7)
 
-GLOBAL_LIST_EMPTY(flamer_particles)
-/particles/flamer_fire
-	icon = 'icons/effects/particles/fire.dmi'
-	icon_state = "bonfire"
-	width = 100
-	height = 100
-	count = 1000
-	spawning = 8
-	lifespan = 0.7 SECONDS
-	fade = 1 SECONDS
-	grow = -0.01
-	velocity = list(0, 0)
-	position = generator("box", list(-16, -16), list(16, 16), NORMAL_RAND)
-	drift = generator("vector", list(0, -0.2), list(0, 0.2))
-	gravity = list(0, 0.95)
-	scale = generator("vector", list(0.3, 0.3), list(1,1), NORMAL_RAND)
-	rotation = 30
-	spin = generator("num", -20, 20)
-
-/particles/flamer_fire/New(set_color)
-	..()
-	color = set_color
-
 /obj/flamer_fire
 	name = "fire"
 	desc = "Ouch!"
@@ -453,10 +430,6 @@ GLOBAL_LIST_EMPTY(flamer_particles)
 		flame_icon = R.burn_sprite
 
 	set_light(l_color = R.burncolor)
-
-	if(!GLOB.flamer_particles[R.burncolor])
-		GLOB.flamer_particles[R.burncolor] = new /particles/flamer_fire(R.burncolor)
-	particles = GLOB.flamer_particles[R.burncolor]
 
 	tied_reagent = new R.type() // Can't get deleted this way
 	tied_reagent.make_alike(R)


### PR DESCRIPTION

# About the pull request

This is a paid PR.

Allegedly fire was lagging the player. I assume the particles are the issue.

# Explain why it's good for the game

Given the vast range of people who play CM with varying levels of computer hardware it would be prudent to remove anything that may be lagging players. Game feel good.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Morrow
del: Removed flame particles. Possibly increases performance for some players.
/:cl:
