### PR TITLE
Eggsac carrier bugfix

### DIFF
--- a/code/modules/cm_aliens/structures/egg.dm
+++ b/code/modules/cm_aliens/structures/egg.dm
@@ -355,4 +355,8 @@ SPECIAL EGG USED BY EGG CARRIER
 
 /obj/effect/alien/egg/carrier_egg/Burst(kill, instant_trigger, mob/living/carbon/xenomorph/X, is_hugger_player_controlled)
 	. = ..()
-	owner = null
+	if(owner)
+		var/datum/behavior_delegate/carrier_eggsac/behavior = owner.behavior_delegate
+		behavior.remove_egg_owner(src)
+	if(life_timer)
+		deltimer(life_timer)

--- a/code/modules/mob/living/carbon/xenomorph/mutators/strains/carrier/eggsac.dm
+++ b/code/modules/mob/living/carbon/xenomorph/mutators/strains/carrier/eggsac.dm
@@ -67,8 +67,6 @@
 			remove_egg_owner(my_egg)
 			my_egg.start_unstoppable_decay()
 			to_chat(bound_xeno, SPAN_XENOWARNING("You can only sustain [egg_sustain_cap] eggs off hive weeds! Your oldest placed egg is decaying rapidly."))
-		else
-			eggs_sustained -= my_egg
 
 	for(var/obj/effect/alien/egg/carrier_egg/my_egg as anything in eggs_sustained)
 		//Get the distance from us to our sustained egg

--- a/code/modules/mob/living/carbon/xenomorph/mutators/strains/carrier/eggsac.dm
+++ b/code/modules/mob/living/carbon/xenomorph/mutators/strains/carrier/eggsac.dm
@@ -63,9 +63,12 @@
 /datum/behavior_delegate/carrier_eggsac/on_life()
 	if(length(eggs_sustained) > egg_sustain_cap)
 		var/obj/effect/alien/egg/carrier_egg/my_egg = eggs_sustained[1]
-		remove_egg_owner(my_egg)
-		my_egg.start_unstoppable_decay()
-		to_chat(bound_xeno, SPAN_XENOWARNING("You can only sustain [egg_sustain_cap] eggs off hive weeds! Your oldest placed egg is decaying rapidly."))
+		if(my_egg)
+			remove_egg_owner(my_egg)
+			my_egg.start_unstoppable_decay()
+			to_chat(bound_xeno, SPAN_XENOWARNING("You can only sustain [egg_sustain_cap] eggs off hive weeds! Your oldest placed egg is decaying rapidly."))
+		else
+			eggs_sustained -= my_egg
 
 	for(var/obj/effect/alien/egg/carrier_egg/my_egg as anything in eggs_sustained)
 		//Get the distance from us to our sustained egg


### PR DESCRIPTION
# About the pull request

So in one of various refactors of #4716 I removed some important code from `Burst()` for the new egg type which removes it from the carrier's sustained eggs. This is bad because we keep trying to call procs on eggs which have already burst etc.

This removes the egg from the carrier's sustain list properly on Burst().
I also added a check in Life() on the carrier to remove it from their sustained eggs. If something funky happens we don't want to impact the player from playing

# Explain why it's good for the game
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
🆑 
fix: Eggsack carrier eggs get properly removed from sustained list upon bursting.
/🆑 