### PR TITLE
LZ Name Consistency

### DIFF
--- a/maps/map_files/BigRed/BigRed.dmm
+++ b/maps/map_files/BigRed/BigRed.dmm
@@ -118,11 +118,23 @@
 	},
 /area/bigredv2/outside/space_port)
 "aau" = (
-/obj/docking_port/stationary/marine_dropship/lz1{
-	name = "Communications Landing Zone"
+/obj/structure/platform_decoration/kutjevo/rock{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/bigredv2/outside/space_port)
+/obj/structure/platform_decoration/kutjevo/rock{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/retaliate/clown{
+	desc = "Always returning. Always watching.";
+	health = 10000;
+	move_to_delay = 2;
+	name = "Gonzo the Magnificent";
+	rapid = 1
+	},
+/turf/open/mars_cave{
+	icon_state = "mars_cave_2"
+	},
+/area/space)
 "aav" = (
 /obj/structure/machinery/landinglight/ds1/delaytwo{
 	dir = 8
@@ -167,6 +179,12 @@
 /turf/open/floor{
 	icon_state = "dark"
 	},
+/area/bigredv2/outside/space_port)
+"aaB" = (
+/obj/docking_port/stationary/marine_dropship/lz1{
+	name = "LZ1: Communications Landing Zone"
+	},
+/turf/open/floor/plating,
 /area/bigredv2/outside/space_port)
 "aaC" = (
 /obj/structure/surface/table,
@@ -343,6 +361,12 @@
 	icon_state = "asteroidwarning"
 	},
 /area/bigredv2/outside/space_port)
+"abb" = (
+/obj/docking_port/stationary/marine_dropship/lz2{
+	name = "LZ 2: Engineering Landing Zone"
+	},
+/turf/open/floor/plating,
+/area/bigredv2/outside/space_port_lz2)
 "abc" = (
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/plating,
@@ -987,24 +1011,6 @@
 "acZ" = (
 /turf/open/floor/greengrid,
 /area/bigredv2/outside/telecomm)
-"ada" = (
-/mob/living/simple_animal/hostile/retaliate/clown{
-	desc = "Always returning. Always watching.";
-	health = 10000;
-	move_to_delay = 2;
-	name = "Gonzo the Magnificent";
-	rapid = 1
-	},
-/obj/structure/platform_decoration/kutjevo/rock{
-	dir = 8
-	},
-/obj/structure/platform_decoration/kutjevo/rock{
-	dir = 4
-	},
-/turf/open/mars_cave{
-	icon_state = "mars_cave_2"
-	},
-/area/space)
 "adb" = (
 /obj/structure/surface/table,
 /obj/item/tool/hand_labeler,
@@ -21452,12 +21458,6 @@
 	icon_state = "asteroidwarning"
 	},
 /area/bigredv2/outside/space_port_lz2)
-"biI" = (
-/obj/docking_port/stationary/marine_dropship/lz2{
-	name = "Engineering Landing Zone"
-	},
-/turf/open/floor/plating,
-/area/bigredv2/outside/space_port_lz2)
 "biK" = (
 /obj/effect/landmark/corpsespawner/security/marshal,
 /turf/open/floor,
@@ -39095,8 +39095,7 @@
 /area/bigredv2/caves/mining)
 "vVz" = (
 /obj/structure/machinery/power/geothermal{
-	name = "Reactor Turbine";
-	power_generation_max = 100000
+	name = "Reactor Turbine"
 	},
 /turf/open/floor{
 	icon_state = "delivery"
@@ -41489,7 +41488,7 @@ aaa
 aab
 aao
 cnk
-ada
+aau
 qjO
 gsW
 aao
@@ -46497,7 +46496,7 @@ aah
 aah
 aah
 aah
-aau
+aaB
 aah
 aah
 aah
@@ -47899,7 +47898,7 @@ bie
 bie
 bie
 bie
-biI
+abb
 bie
 bie
 bie

--- a/maps/map_files/CORSAT/Corsat.dmm
+++ b/maps/map_files/CORSAT/Corsat.dmm
@@ -179,7 +179,6 @@
 "aaF" = (
 /obj/structure/machinery/door/airlock/almayer/security/glass/colony{
 	dir = 1;
-	locked = 0;
 	name = "CORSAT Armory";
 	req_access_txt = "101"
 	},
@@ -2354,7 +2353,6 @@
 /obj/structure/machinery/door/airlock/almayer/maint/colony{
 	damage_cap = 4000;
 	dir = 1;
-	locked = 0;
 	name = "\improper Emergency Access";
 	req_access_txt = "100";
 	req_one_access = null
@@ -5915,7 +5913,6 @@
 "arv" = (
 /obj/structure/machinery/door/airlock/almayer/maint/colony{
 	damage_cap = 4000;
-	locked = 0;
 	name = "\improper Emergency Access";
 	req_access_txt = "100";
 	req_one_access = null
@@ -21864,8 +21861,7 @@
 /area/corsat/gamma/engineering)
 "bij" = (
 /obj/structure/machinery/floodlight{
-	name = "Floodlight";
-	unacidable = 0
+	name = "Floodlight"
 	},
 /turf/open/auto_turf/snow/layer3,
 /area/corsat/gamma/biodome)
@@ -29011,7 +29007,6 @@
 /area/corsat/omega/checkpoint)
 "bDv" = (
 /obj/structure/machinery/door/airlock/almayer/security/glass/colony{
-	locked = 0;
 	name = "Security Armory";
 	req_access_txt = "101"
 	},
@@ -30469,8 +30464,7 @@
 /area/corsat/gamma/airlock/control)
 "bJE" = (
 /obj/structure/machinery/floodlight{
-	name = "Floodlight";
-	unacidable = 0
+	name = "Floodlight"
 	},
 /turf/open/mars,
 /area/corsat/sigma/biodome)
@@ -34235,8 +34229,7 @@
 /area/corsat/sigma/airlock/control)
 "bVD" = (
 /obj/structure/machinery/floodlight{
-	name = "Floodlight";
-	unacidable = 0
+	name = "Floodlight"
 	},
 /turf/open/floor{
 	dir = 1;
@@ -35485,7 +35478,6 @@
 /obj/structure/machinery/door/airlock/almayer/research/glass/colony{
 	dir = 1;
 	name = "Weapons Development";
-	req_access = null;
 	req_one_access_txt = "103"
 	},
 /obj/structure/pipes/standard/simple/hidden/green,
@@ -35812,8 +35804,7 @@
 /area/corsat/omega/control)
 "caS" = (
 /obj/structure/machinery/floodlight{
-	name = "Floodlight";
-	unacidable = 0
+	name = "Floodlight"
 	},
 /turf/open/floor/plating,
 /area/corsat/sigma/biodome/testgrounds)
@@ -37871,8 +37862,7 @@
 /area/corsat/omega/hallways)
 "dFb" = (
 /obj/structure/machinery/floodlight{
-	name = "Floodlight";
-	unacidable = 0
+	name = "Floodlight"
 	},
 /turf/open/auto_turf/snow/layer0,
 /area/corsat/gamma/biodome)
@@ -38222,7 +38212,7 @@
 /area/corsat/omega/complex)
 "dUj" = (
 /obj/docking_port/stationary/marine_dropship/lz2{
-	name = "Sigma Landing Zone"
+	name = "LZ2: Sigma Landing Zone"
 	},
 /turf/open/floor/plating,
 /area/corsat/sigma/hangar)
@@ -48479,7 +48469,6 @@
 /obj/structure/machinery/door/airlock/almayer/research/glass/colony{
 	dir = 1;
 	name = "Teleportation Lab";
-	req_access = null;
 	req_one_access_txt = "103"
 	},
 /obj/structure/pipes/standard/simple/hidden/green,
@@ -49113,8 +49102,7 @@
 /area/corsat/omega/airlocknorth/id)
 "lUY" = (
 /obj/structure/machinery/floodlight{
-	name = "Floodlight";
-	unacidable = 0
+	name = "Floodlight"
 	},
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/auto_turf/snow/layer3,
@@ -50975,7 +50963,6 @@
 /obj/structure/machinery/door/airlock/almayer/research/glass/colony{
 	dir = 1;
 	name = "Teleportation Chamber";
-	req_access = null;
 	req_one_access_txt = "101;103"
 	},
 /turf/open/floor/corsat{
@@ -61761,7 +61748,6 @@
 "vqF" = (
 /obj/structure/machinery/door/airlock/almayer/maint/colony{
 	damage_cap = 4000;
-	locked = 0;
 	name = "\improper Emergency Access";
 	req_access_txt = "100";
 	req_one_access = null

--- a/maps/map_files/FOP_v2_Cellblocks/Prison_Station_FOP.dmm
+++ b/maps/map_files/FOP_v2_Cellblocks/Prison_Station_FOP.dmm
@@ -1378,8 +1378,7 @@
 /obj/structure/machinery/door/airlock/almayer/security/glass/colony{
 	density = 0;
 	icon_state = "door_open";
-	name = "Cell Access";
-	req_access = null
+	name = "Cell Access"
 	},
 /turf/open/floor/prison{
 	dir = 10;
@@ -1574,8 +1573,7 @@
 	density = 0;
 	icon_state = "door_open";
 	name = "Cell";
-	opacity = 0;
-	req_access = null
+	opacity = 0
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -1621,8 +1619,7 @@
 	dir = 2;
 	icon_state = "door_open";
 	name = "Cell";
-	opacity = 0;
-	req_access = null
+	opacity = 0
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/prison{
@@ -3915,8 +3912,7 @@
 /obj/structure/machinery/door/airlock/almayer/security/glass/colony{
 	density = 0;
 	icon_state = "door_open";
-	name = "Cell Access";
-	req_access = null
+	name = "Cell Access"
 	},
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -5305,7 +5301,7 @@
 /area/prison/hanger/research)
 "aoj" = (
 /obj/docking_port/stationary/marine_dropship/lz2{
-	name = "Research Landing Zone"
+	name = "LZ2: Research Landing Zone"
 	},
 /turf/open/floor/plating,
 /area/prison/hanger/research)
@@ -8229,13 +8225,6 @@
 	icon_state = "bright_clean"
 	},
 /area/prison/chapel)
-"awd" = (
-/obj/structure/machinery/door/airlock/almayer/security/colony{
-	locked = 0;
-	name = "Research Containment Locker"
-	},
-/turf/open/floor/prison,
-/area/prison/research/secret)
 "awe" = (
 /obj/structure/window/framed/prison/reinforced/hull,
 /turf/open/floor/plating,
@@ -19201,7 +19190,7 @@
 /area/prison/hanger/main)
 "bcF" = (
 /obj/docking_port/stationary/marine_dropship/lz1{
-	name = "Hangar Landing Zone"
+	name = "LZ1: Hangar Landing Zone"
 	},
 /turf/open/floor/plating,
 /area/prison/hanger/main)
@@ -28265,8 +28254,7 @@
 /area/prison/hallway/east)
 "bDU" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/comdoor/colony{
-	dir = 2;
-	req_access = null
+	dir = 2
 	},
 /turf/open/floor/prison{
 	dir = 10;
@@ -31414,9 +31402,7 @@
 /turf/open/floor/wood,
 /area/prison/residential/south)
 "bNt" = (
-/obj/structure/machinery/door/airlock/multi_tile/almayer/generic{
-	locked = 0
-	},
+/obj/structure/machinery/door/airlock/multi_tile/almayer/generic,
 /turf/open/floor/prison{
 	icon_state = "damaged3"
 	},
@@ -87111,7 +87097,7 @@ aeZ
 aeZ
 aiN
 aiN
-awd
+atK
 aiN
 aiN
 aiN

--- a/maps/map_files/FOP_v3_Sciannex/Fiorina_SciAnnex.dmm
+++ b/maps/map_files/FOP_v3_Sciannex/Fiorina_SciAnnex.dmm
@@ -6510,7 +6510,7 @@
 /area/fiorina/station/disco)
 "dYp" = (
 /obj/docking_port/stationary/marine_dropship/lz1{
-	name = "Hangar Landing Zone"
+	name = "LZ1: Hangar Landing Zone"
 	},
 /turf/open/floor/plating/prison,
 /area/fiorina/lz/near_lzI)
@@ -39335,7 +39335,9 @@
 /turf/open/floor/plating/prison,
 /area/fiorina/station/civres_blue)
 "xYg" = (
-/obj/docking_port/stationary/marine_dropship/lz2,
+/obj/docking_port/stationary/marine_dropship/lz2{
+	name = "LZ2: Landing Zone"
+	},
 /turf/open/floor/plating/prison,
 /area/fiorina/lz/near_lzII)
 "xYo" = (

--- a/maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
+++ b/maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
@@ -853,7 +853,6 @@
 	dir = 4
 	},
 /obj/structure/machinery/door/airlock/almayer/secure/colony{
-	locked = 0;
 	name = "Colony Requesitions Storage Pod"
 	},
 /turf/open/floor/plating/icefloor,
@@ -1333,7 +1332,6 @@
 "aeC" = (
 /obj/structure/machinery/door/airlock{
 	id_tag = "st_5";
-	locked = 0;
 	name = "Storage Unit";
 	req_one_access_txt = "100;101;102;103"
 	},
@@ -11961,7 +11959,6 @@
 "aHB" = (
 /obj/structure/machinery/door/airlock/almayer/secure/colony{
 	id = "st_17";
-	locked = 0;
 	name = "Power Storage Unit"
 	},
 /turf/open/floor{
@@ -12406,7 +12403,6 @@
 /obj/structure/machinery/door/airlock/almayer/secure/colony{
 	dir = 2;
 	id = "st_18";
-	locked = 0;
 	name = "Disposals Storage Unit"
 	},
 /turf/open/floor{
@@ -13697,7 +13693,6 @@
 /obj/structure/machinery/door/airlock/almayer/secure/colony{
 	dir = 2;
 	id = "st_19";
-	locked = 0;
 	name = "Research Storage Unit"
 	},
 /turf/open/floor{
@@ -14545,7 +14540,6 @@
 "aQm" = (
 /obj/structure/machinery/door/airlock/almayer/secure/colony{
 	id = "research_entrance";
-	locked = 0;
 	name = "Omicron Research Dome"
 	},
 /obj/structure/pipes/standard/simple/hidden/green{
@@ -19677,7 +19671,6 @@
 /area/ice_colony/underground/maintenance/north)
 "bgR" = (
 /obj/structure/machinery/door/airlock/almayer/maint/colony{
-	locked = 0;
 	name = "\improper Underground Maintenance"
 	},
 /turf/open/floor/plating,
@@ -20402,7 +20395,6 @@
 "bjz" = (
 /obj/structure/machinery/door/airlock/almayer/maint/colony{
 	dir = 1;
-	locked = 0;
 	name = "\improper Underground Maintenance";
 	req_access_txt = "100"
 	},
@@ -23731,7 +23723,6 @@
 /obj/structure/machinery/door/airlock/almayer/secure/colony{
 	dir = 2;
 	id = "engine_electrical_maintenance";
-	locked = 0;
 	name = "Underground Power Substation"
 	},
 /turf/open/floor{
@@ -24970,7 +24961,6 @@
 /obj/structure/machinery/door/airlock/almayer/secure/colony{
 	dir = 2;
 	id = "engine_electrical_maintenance";
-	locked = 0;
 	name = "Underground Power Substation"
 	},
 /turf/open/floor/plating,
@@ -28109,7 +28099,6 @@
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/structure/machinery/door/airlock/almayer/secure/colony{
 	dir = 2;
-	locked = 0;
 	name = "Underground Secure Technical Storage"
 	},
 /turf/open/floor{
@@ -34904,7 +34893,7 @@
 /area/ice_colony/surface/hangar/alpha)
 "sto" = (
 /obj/docking_port/stationary/marine_dropship/lz1{
-	name = "Hangar Landing Zone"
+	name = "LZ1: Hangar Landing Zone"
 	},
 /turf/open/floor/plating,
 /area/ice_colony/exterior/surface/landing_pad)

--- a/maps/map_files/Ice_Colony_v3/Shivas_Snowball.dmm
+++ b/maps/map_files/Ice_Colony_v3/Shivas_Snowball.dmm
@@ -7354,7 +7354,9 @@
 /turf/open/auto_turf/snow/layer2,
 /area/shiva/exterior/junkyard)
 "boD" = (
-/obj/docking_port/stationary/marine_dropship/lz1,
+/obj/docking_port/stationary/marine_dropship/lz1{
+	name = "LZ1: Landing Zone"
+	},
 /turf/open/floor/plating,
 /area/shiva/exterior/lz1_valley)
 "boS" = (
@@ -17375,7 +17377,7 @@
 /area/shiva/interior/caves/s_lz2)
 "mlX" = (
 /obj/docking_port/stationary/marine_dropship/lz2{
-	name = "Research Landing Zone"
+	name = "LZ2: Research Landing Zone"
 	},
 /turf/open/floor/plating,
 /area/shiva/exterior/lz2_fortress)

--- a/maps/map_files/Kutjevo/Kutjevo.dmm
+++ b/maps/map_files/Kutjevo/Kutjevo.dmm
@@ -4883,7 +4883,7 @@
 /area/kutjevo/interior/oob)
 "gnj" = (
 /obj/docking_port/stationary/marine_dropship/lz1{
-	name = "Dunes Landing Zone"
+	name = "LZ1: Dunes Landing Zone"
 	},
 /turf/open/floor/plating/kutjevo,
 /area/shuttle/drop1/kutjevo)
@@ -8316,7 +8316,7 @@
 /area/kutjevo/interior/power/comms)
 "lkY" = (
 /obj/docking_port/stationary/marine_dropship/lz2{
-	name = "NW Colony Landing Zone"
+	name = "LZ2: NW Colony Landing Zone"
 	},
 /turf/open/floor/plating/kutjevo,
 /area/shuttle/drop2/kutjevo)

--- a/maps/map_files/LV522_Chances_Claim/LV522_Chances_Claim.dmm
+++ b/maps/map_files/LV522_Chances_Claim/LV522_Chances_Claim.dmm
@@ -7115,7 +7115,7 @@
 /area/lv522/indoors/a_block/dorms)
 "dos" = (
 /obj/docking_port/stationary/marine_dropship/lz1{
-	name = "Southwest Landing Zone"
+	name = "LZ1: Southwest Landing Zone"
 	},
 /turf/open/floor/plating,
 /area/shuttle/drop1/lv522)
@@ -27052,8 +27052,7 @@
 "kNM" = (
 /obj/structure/machinery/door/airlock/almayer/generic{
 	dir = 1;
-	name = "\improper Dormitories";
-	welded = null
+	name = "\improper Dormitories"
 	},
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor/corsat{
@@ -51667,9 +51666,7 @@
 /area/lv522/indoors/lone_buildings/storage_blocks)
 "tNT" = (
 /obj/structure/prop/vehicles/crawler{
-	icon_state = "crawler_covered_bed";
-	unacidable = 0;
-	unslashable = 0
+	icon_state = "crawler_covered_bed"
 	},
 /turf/open/floor/corsat{
 	icon_state = "plate"

--- a/maps/map_files/LV624/LV624.dmm
+++ b/maps/map_files/LV624/LV624.dmm
@@ -8590,7 +8590,7 @@
 /area/lv624/ground/jungle/south_west_jungle)
 "aLz" = (
 /obj/docking_port/stationary/marine_dropship/lz1{
-	name = "Nexus Landing Zone"
+	name = "LZ1: Nexus Landing Zone"
 	},
 /turf/open/floor/plating,
 /area/lv624/lazarus/landing_zones/lz1)


### PR DESCRIPTION

# About the pull request

Alters the lz1/lz2 names of each map placed object to have LZ1 or LZ2 in the front of the name, that way there's never any confusion over which is which when looking at the DS consoles.  "We're going to LZ2" should never be a point of confusion for new POs anymore.

# Explain why it's good for the game

Information good.  


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
maptweak: Standardized the names of LZs to include the name of the LZ.
/:cl:
