### PR TITLE
Consistent LZ names.

### DIFF
--- a/maps/map_files/BigRed/BigRed.dmm
+++ b/maps/map_files/BigRed/BigRed.dmm
@@ -119,7 +119,7 @@
 /area/bigredv2/outside/space_port)
 "aau" = (
 /obj/docking_port/stationary/marine_dropship/lz1{
-	name = "Communications Landing Zone"
+	name = "LZ1: Communications Landing Zone"
 	},
 /turf/open/floor/plating,
 /area/bigredv2/outside/space_port)
@@ -21454,7 +21454,7 @@
 /area/bigredv2/outside/space_port_lz2)
 "biI" = (
 /obj/docking_port/stationary/marine_dropship/lz2{
-	name = "Engineering Landing Zone"
+	name = "LZ2: Engineering Landing Zone"
 	},
 /turf/open/floor/plating,
 /area/bigredv2/outside/space_port_lz2)

--- a/maps/map_files/CORSAT/Corsat.dmm
+++ b/maps/map_files/CORSAT/Corsat.dmm
@@ -37445,7 +37445,7 @@
 /area/corsat/gamma/biodome/virology)
 "drp" = (
 /obj/docking_port/stationary/marine_dropship/lz1{
-	name = "Gamma Landing Zone"
+	name = "LZ1: Gamma Landing Zone"
 	},
 /turf/open/floor/plating,
 /area/corsat/gamma/hangar)
@@ -38222,7 +38222,7 @@
 /area/corsat/omega/complex)
 "dUj" = (
 /obj/docking_port/stationary/marine_dropship/lz2{
-	name = "Sigma Landing Zone"
+	name = "LZ2: Sigma Landing Zone"
 	},
 /turf/open/floor/plating,
 /area/corsat/sigma/hangar)

--- a/maps/map_files/FOP_v2_Cellblocks/Prison_Station_FOP.dmm
+++ b/maps/map_files/FOP_v2_Cellblocks/Prison_Station_FOP.dmm
@@ -5305,7 +5305,7 @@
 /area/prison/hanger/research)
 "aoj" = (
 /obj/docking_port/stationary/marine_dropship/lz2{
-	name = "Research Landing Zone"
+	name = "LZ2: Research Landing Zone"
 	},
 /turf/open/floor/plating,
 /area/prison/hanger/research)
@@ -19201,7 +19201,7 @@
 /area/prison/hanger/main)
 "bcF" = (
 /obj/docking_port/stationary/marine_dropship/lz1{
-	name = "Hangar Landing Zone"
+	name = "LZ1: Hangar Landing Zone"
 	},
 /turf/open/floor/plating,
 /area/prison/hanger/main)

--- a/maps/map_files/FOP_v3_Sciannex/Fiorina_SciAnnex.dmm
+++ b/maps/map_files/FOP_v3_Sciannex/Fiorina_SciAnnex.dmm
@@ -6510,7 +6510,7 @@
 /area/fiorina/station/disco)
 "dYp" = (
 /obj/docking_port/stationary/marine_dropship/lz1{
-	name = "Hangar Landing Zone"
+	name = "LZ1: Hangar Landing Zone"
 	},
 /turf/open/floor/plating/prison,
 /area/fiorina/lz/near_lzI)

--- a/maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
+++ b/maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
@@ -34904,7 +34904,7 @@
 /area/ice_colony/surface/hangar/alpha)
 "sto" = (
 /obj/docking_port/stationary/marine_dropship/lz1{
-	name = "Hangar Landing Zone"
+	name = "LZ1: Hangar Landing Zone"
 	},
 /turf/open/floor/plating,
 /area/ice_colony/exterior/surface/landing_pad)

--- a/maps/map_files/Ice_Colony_v3/Shivas_Snowball.dmm
+++ b/maps/map_files/Ice_Colony_v3/Shivas_Snowball.dmm
@@ -17375,7 +17375,7 @@
 /area/shiva/interior/caves/s_lz2)
 "mlX" = (
 /obj/docking_port/stationary/marine_dropship/lz2{
-	name = "Research Landing Zone"
+	name = "LZ2: Research Landing Zone"
 	},
 /turf/open/floor/plating,
 /area/shiva/exterior/lz2_fortress)

--- a/maps/map_files/Kutjevo/Kutjevo.dmm
+++ b/maps/map_files/Kutjevo/Kutjevo.dmm
@@ -4883,7 +4883,7 @@
 /area/kutjevo/interior/oob)
 "gnj" = (
 /obj/docking_port/stationary/marine_dropship/lz1{
-	name = "Dunes Landing Zone"
+	name = "LZ1: Dunes Landing Zone"
 	},
 /turf/open/floor/plating/kutjevo,
 /area/shuttle/drop1/kutjevo)
@@ -8316,7 +8316,7 @@
 /area/kutjevo/interior/power/comms)
 "lkY" = (
 /obj/docking_port/stationary/marine_dropship/lz2{
-	name = "NW Colony Landing Zone"
+	name = "LZ2: NW Colony Landing Zone"
 	},
 /turf/open/floor/plating/kutjevo,
 /area/shuttle/drop2/kutjevo)

--- a/maps/map_files/LV522_Chances_Claim/LV522_Chances_Claim.dmm
+++ b/maps/map_files/LV522_Chances_Claim/LV522_Chances_Claim.dmm
@@ -1030,7 +1030,7 @@
 /area/lv522/outdoors/colony_streets/north_east_street)
 "aDE" = (
 /obj/docking_port/stationary/marine_dropship/lz2{
-	name = "Southeast Landing Zone"
+	name = "LZ2: Southeast Landing Zone"
 	},
 /turf/open/floor/plating,
 /area/shuttle/drop2/lv522)
@@ -7115,7 +7115,7 @@
 /area/lv522/indoors/a_block/dorms)
 "dos" = (
 /obj/docking_port/stationary/marine_dropship/lz1{
-	name = "Southwest Landing Zone"
+	name = "LZ1: Southwest Landing Zone"
 	},
 /turf/open/floor/plating,
 /area/shuttle/drop1/lv522)

--- a/maps/map_files/LV624/LV624.dmm
+++ b/maps/map_files/LV624/LV624.dmm
@@ -5862,7 +5862,7 @@
 /area/lv624/ground/river/west_river)
 "aBo" = (
 /obj/docking_port/stationary/marine_dropship/lz2{
-	name = "Robotics Landing Zone"
+	name = "LZ2: Robotics Landing Zone"
 	},
 /turf/open/floor/plating,
 /area/lv624/lazarus/landing_zones/lz2)
@@ -8590,7 +8590,7 @@
 /area/lv624/ground/jungle/south_west_jungle)
 "aLz" = (
 /obj/docking_port/stationary/marine_dropship/lz1{
-	name = "Nexus Landing Zone"
+	name = "LZ1: Nexus Landing Zone"
 	},
 /turf/open/floor/plating,
 /area/lv624/lazarus/landing_zones/lz1)

--- a/maps/map_files/New_Varadero/New_Varadero.dmm
+++ b/maps/map_files/New_Varadero/New_Varadero.dmm
@@ -788,7 +788,7 @@
 /area/varadero/exterior/pool)
 "aAX" = (
 /obj/docking_port/stationary/marine_dropship/lz2{
-	name = "LZ2 - Palm Airfield"
+	name = "LZ2: Palm Airfield"
 	},
 /turf/open/gm/dirt,
 /area/varadero/exterior/lz2_near)
@@ -23224,7 +23224,7 @@
 /area/varadero/interior/security)
 "oXw" = (
 /obj/docking_port/stationary/marine_dropship/lz1{
-	name = "LZ1 - Pontoon Dock"
+	name = "LZ1: Pontoon Dock"
 	},
 /turf/open/floor/plating/icefloor,
 /area/varadero/exterior/lz1_near)


### PR DESCRIPTION
# About the pull request

Alters the lz1/lz2 names of each map placed object to have LZ1 or LZ2 in the front of the name, that way there's never any confusion over which is which when looking at the DS consoles.  "We're going to LZ2" should never be a point of confusion for new POs anymore.

# Explain why it's good for the game

Information good.  


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
maptweak: Standardized the names of LZs to include the name of the LZ.
/:cl: