### PR TITLE
Moves lore descriptions into the chat window

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -499,8 +499,8 @@ Parameters are passed from New.
 		return TRUE
 
 	if(href_list["desc_lore"])
-		show_browser(usr, "<BODY><TT>[replacetext(desc_lore, "\n", "<BR>")]</TT></BODY>", name, name, "size=500x500")
-		onclose(usr, "[name]")
+		to_chat(usr, examine_block(desc_lore))
+
 
 ///This proc is called on atoms when they are loaded into a shuttle
 /atom/proc/connect_to_shuttle(obj/docking_port/mobile/port, obj/docking_port/stationary/dock, idnum, override=FALSE)


### PR DESCRIPTION

# About the pull request

Currently lore descriptions open their own browser window using BYONDs 'magic' method that's essentially what nanoUI does. This MR makes them display underneath regular descriptions (still only on click of the button), using the same styling brackets as regular descriptions do.

# Explain why it's good for the game

The end result is way less jarring, does not open an extra window on top of the game and respects tgchat font etc settings.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/cmss13-devs/cmss13/assets/103842328/0d4de774-1648-47e8-bde6-c297fb224920)

</details>


# Changelog
:cl:silencer_pl
ui: lore descriptions are now sent via examine brackets to the main chat window
/:cl:
