### PR TITLE
Functional M5 Gasmask 2: Electric Boogaloo

### DIFF
--- a/code/game/objects/items/props/helmetgarb.dm
+++ b/code/game/objects/items/props/helmetgarb.dm
@@ -502,11 +502,11 @@
 
 	var/obj/item/Helmet = HelmetInternalInv.master_object
 
-	if(!istype(Helmet, /obj/item/clothing/head/helmet/marine))
+	if(!istype(Helmet, /obj/item/clothing/head/helmet))
 		return
 
-	Helmet.flags_inventory = BLOCKSHARPOBJ | COVERMOUTH | COVEREYES | ALLOWINTERNALS | BLOCKGASEFFECT | ALLOWREBREATH | ALLOWCPR
-	Helmet.flags_inv_hide = HIDEEARS|HIDEFACE|HIDELOWHAIR
+	Helmet.flags_inventory = initial(Helmet.flags_inventory)+BLOCKGASEFFECT
+	Helmet.flags_inv_hide = initial(Helmet.flags_inv_hide)+HIDEFACE
 	..()
 
 /obj/item/prop/helmetgarb/helmet_gasmask/on_exit_storage(obj/item/storage/internal/HelmetInternalInv)
@@ -515,11 +515,11 @@
 
 	var/obj/item/Helmet = HelmetInternalInv.master_object
 
-	if(!istype(Helmet, /obj/item/clothing/head/helmet/marine))
+	if(!istype(Helmet, /obj/item/clothing/head/helmet))
 		return
 
-	Helmet.flags_inventory = BLOCKSHARPOBJ
-	Helmet.flags_inv_hide = HIDEEARS
+	Helmet.flags_inventory = initial(Helmet.flags_inventory)
+	Helmet.flags_inv_hide = initial(Helmet.flags_inv_hide)
 	return..()
 
 /obj/item/prop/helmetgarb/trimmed_wire

--- a/code/game/objects/items/props/helmetgarb.dm
+++ b/code/game/objects/items/props/helmetgarb.dm
@@ -496,30 +496,30 @@
 	desc = "The USCM had its funding pulled for these when it became apparent that not every deployed enlisted was wearing a helmet 24/7; much to the bafflement of UA High Command."
 	icon_state = "helmet_gasmask"
 
-/obj/item/prop/helmetgarb/helmet_gasmask/on_enter_storage(obj/item/storage/internal/HelmetInternalInv)
-	if(!istype(HelmetInternalInv))
+/obj/item/prop/helmetgarb/helmet_gasmask/on_enter_storage(obj/item/storage/internal/helmet_internal_inventory)
+	if(!istype(helmet_internal_inventory))
 		return
 
-	var/obj/item/Helmet = HelmetInternalInv.master_object
+	var/obj/item/clothing/head/helmet/helmet_item = helmet_internal_inventory.master_object
 
-	if(!istype(Helmet, /obj/item/clothing/head/helmet))
+	if(!istype(helmet_item))
 		return
 
-	Helmet.flags_inventory = initial(Helmet.flags_inventory)+BLOCKGASEFFECT
-	Helmet.flags_inv_hide = initial(Helmet.flags_inv_hide)+HIDEFACE
+	helmet_item.flags_inventory|=BLOCKGASEFFECT
+	helmet_item.flags_inv_hide|=HIDEFACE
 	..()
 
-/obj/item/prop/helmetgarb/helmet_gasmask/on_exit_storage(obj/item/storage/internal/HelmetInternalInv)
-	if(!istype(HelmetInternalInv))
+/obj/item/prop/helmetgarb/helmet_gasmask/on_exit_storage(obj/item/storage/internal/helmet_internal_inventory)
+	if(!istype(helmet_internal_inventory))
 		return
 
-	var/obj/item/Helmet = HelmetInternalInv.master_object
+	var/obj/item/clothing/head/helmet/helmet_item = helmet_internal_inventory.master_object
 
-	if(!istype(Helmet, /obj/item/clothing/head/helmet))
+	if(!istype(helmet_item))
 		return
 
-	Helmet.flags_inventory = initial(Helmet.flags_inventory)
-	Helmet.flags_inv_hide = initial(Helmet.flags_inv_hide)
+	helmet_item.flags_inventory = initial(helmet_item.flags_inventory)
+	helmet_item.flags_inv_hide = initial(helmet_item.flags_inv_hide)
 	return..()
 
 /obj/item/prop/helmetgarb/trimmed_wire

--- a/code/game/objects/items/props/helmetgarb.dm
+++ b/code/game/objects/items/props/helmetgarb.dm
@@ -498,6 +498,8 @@
 
 /obj/item/prop/helmetgarb/helmet_gasmask/on_enter_storage(obj/item/storage/internal/helmet_internal_inventory)
 	..()
+	if(!istype(helmet_internal_inventory))
+		return
 	var/obj/item/clothing/head/helmet/helmet_item = helmet_internal_inventory.master_object
 
 	if(!istype(helmet_item))
@@ -508,13 +510,15 @@
 
 /obj/item/prop/helmetgarb/helmet_gasmask/on_exit_storage(obj/item/storage/internal/helmet_internal_inventory)
 	..()
+	if(!istype(helmet_internal_inventory))
+		return
 	var/obj/item/clothing/head/helmet/helmet_item = helmet_internal_inventory.master_object
 
 	if(!istype(helmet_item))
 		return
 
-	helmet_item.flags_inventory = initial(helmet_item.flags_inventory)
-	helmet_item.flags_inv_hide = initial(helmet_item.flags_inv_hide)
+	helmet_item.flags_inventory &= ~(BLOCKGASEFFECT)
+	helmet_item.flags_inv_hide &= ~(HIDEFACE)
 
 /obj/item/prop/helmetgarb/trimmed_wire
 	name = "trimmed barbed wire"

--- a/code/game/objects/items/props/helmetgarb.dm
+++ b/code/game/objects/items/props/helmetgarb.dm
@@ -496,30 +496,30 @@
 	desc = "The USCM had its funding pulled for these when it became apparent that not every deployed enlisted was wearing a helmet 24/7; much to the bafflement of UA High Command."
 	icon_state = "helmet_gasmask"
 
-/obj/item/prop/helmetgarb/helmet_gasmask/on_enter_storage(obj/item/storage/internal/S)
-	if(!istype(S))
+/obj/item/prop/helmetgarb/helmet_gasmask/on_enter_storage(obj/item/storage/internal/HelmetInternalInv)
+	if(!istype(HelmetInternalInv))
 		return
 
-	var/obj/item/MO = S.master_object
+	var/obj/item/Helmet = HelmetInternalInv.master_object
 
-	if(!istype(MO, /obj/item/clothing/head/helmet/marine))
+	if(!istype(Helmet, /obj/item/clothing/head/helmet/marine))
 		return
 
-	MO.flags_inventory = BLOCKSHARPOBJ | COVERMOUTH | COVEREYES | ALLOWINTERNALS | BLOCKGASEFFECT | ALLOWREBREATH | ALLOWCPR
-	MO.flags_inv_hide = HIDEEARS|HIDEFACE|HIDELOWHAIR
+	Helmet.flags_inventory = BLOCKSHARPOBJ | COVERMOUTH | COVEREYES | ALLOWINTERNALS | BLOCKGASEFFECT | ALLOWREBREATH | ALLOWCPR
+	Helmet.flags_inv_hide = HIDEEARS|HIDEFACE|HIDELOWHAIR
 	..()
 
-/obj/item/prop/helmetgarb/helmet_gasmask/on_exit_storage(obj/item/storage/internal/S)
-	if(!istype(S))
+/obj/item/prop/helmetgarb/helmet_gasmask/on_exit_storage(obj/item/storage/internal/HelmetInternalInv)
+	if(!istype(HelmetInternalInv))
 		return
 
-	var/obj/item/MO = S.master_object
+	var/obj/item/Helmet = HelmetInternalInv.master_object
 
-	if(!istype(MO, /obj/item/clothing/head/helmet/marine))
+	if(!istype(Helmet, /obj/item/clothing/head/helmet/marine))
 		return
 
-	MO.flags_inventory = BLOCKSHARPOBJ
-	MO.flags_inv_hide = HIDEEARS
+	Helmet.flags_inventory = BLOCKSHARPOBJ
+	Helmet.flags_inv_hide = HIDEEARS
 	return..()
 
 /obj/item/prop/helmetgarb/trimmed_wire

--- a/code/game/objects/items/props/helmetgarb.dm
+++ b/code/game/objects/items/props/helmetgarb.dm
@@ -496,6 +496,32 @@
 	desc = "The USCM had its funding pulled for these when it became apparent that not every deployed enlisted was wearing a helmet 24/7; much to the bafflement of UA High Command."
 	icon_state = "helmet_gasmask"
 
+/obj/item/prop/helmetgarb/helmet_gasmask/on_enter_storage(obj/item/storage/internal/S)
+	if(!istype(S))
+		return
+
+	var/obj/item/MO = S.master_object
+
+	if(!istype(MO, /obj/item/clothing/head/helmet/marine))
+		return
+
+	MO.flags_inventory = BLOCKSHARPOBJ | COVERMOUTH | COVEREYES | ALLOWINTERNALS | BLOCKGASEFFECT | ALLOWREBREATH | ALLOWCPR
+	MO.flags_inv_hide = HIDEEARS|HIDEFACE|HIDELOWHAIR
+	..()
+
+/obj/item/prop/helmetgarb/helmet_gasmask/on_exit_storage(obj/item/storage/internal/S)
+	if(!istype(S))
+		return
+
+	var/obj/item/MO = S.master_object
+
+	if(!istype(MO, /obj/item/clothing/head/helmet/marine))
+		return
+
+	MO.flags_inventory = BLOCKSHARPOBJ
+	MO.flags_inv_hide = HIDEEARS
+	return..()
+
 /obj/item/prop/helmetgarb/trimmed_wire
 	name = "trimmed barbed wire"
 	desc = "It is a length of barbed wire that's had most of the sharp points filed down so that it is safe to handle."

--- a/code/game/objects/items/props/helmetgarb.dm
+++ b/code/game/objects/items/props/helmetgarb.dm
@@ -497,22 +497,17 @@
 	icon_state = "helmet_gasmask"
 
 /obj/item/prop/helmetgarb/helmet_gasmask/on_enter_storage(obj/item/storage/internal/helmet_internal_inventory)
-	if(!istype(helmet_internal_inventory))
-		return
-
+	..()
 	var/obj/item/clothing/head/helmet/helmet_item = helmet_internal_inventory.master_object
 
 	if(!istype(helmet_item))
 		return
 
-	helmet_item.flags_inventory|=BLOCKGASEFFECT
-	helmet_item.flags_inv_hide|=HIDEFACE
-	..()
+	helmet_item.flags_inventory |= BLOCKGASEFFECT
+	helmet_item.flags_inv_hide |= HIDEFACE
 
 /obj/item/prop/helmetgarb/helmet_gasmask/on_exit_storage(obj/item/storage/internal/helmet_internal_inventory)
-	if(!istype(helmet_internal_inventory))
-		return
-
+	..()
 	var/obj/item/clothing/head/helmet/helmet_item = helmet_internal_inventory.master_object
 
 	if(!istype(helmet_item))
@@ -520,7 +515,6 @@
 
 	helmet_item.flags_inventory = initial(helmet_item.flags_inventory)
 	helmet_item.flags_inv_hide = initial(helmet_item.flags_inv_hide)
-	return..()
 
 /obj/item/prop/helmetgarb/trimmed_wire
 	name = "trimmed barbed wire"


### PR DESCRIPTION
# About the pull request
Makes the M5 Gasmask actually work
70% NVG code 30% trial and error

### This time I *probably* won't fuck things up.
#5072 
# Explain why it's good for the game
Consistency, the regular gasmask protects you against CN20 Nerve Gas, whereas the helmet gasmask previously did not.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

https://github.com/cmss13-devs/cmss13/assets/95509996/8f4c2eed-4ad6-477d-83d4-1b87630d7ff7

</details>

# Changelog
:cl: Ediblebomb
add: M5 Helmet Gasmask now functions as a gasmask when in a marine helmet (and yes, gasmasks do still have some functionality)
/:cl: