### PR TITLE
adds returns to prevent runtimes in /datum/component/healing_reduction/process(delta_time) hopefuly

### DIFF
--- a/code/datums/components/healing_reduction.dm
+++ b/code/datums/components/healing_reduction.dm
@@ -70,7 +70,7 @@ Humans will take continuous damage instead.
 	var/atom/parent_atom = parent
 	parent_atom.remove_filter("healing_reduction")
 
-/datum/component/healing_reduction/proc/stat_append(mob/mob_with_list, list/stat_list)
+/datum/component/healing_reduction/proc/stat_append(mob/target_mob, list/stat_list)
 	SIGNAL_HANDLER
 	stat_list += "Healing Reduction: [healing_reduction]/[max_buildup]"
 


### PR DESCRIPTION

# About the pull request

when there is no parent the function deleted src but then kept going and asked for parent of null, it calls return now instead

# Explain why it's good for the game

runtime bad 


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: fixed a runtime in /datum/component/healing_reduction/process(delta_time)
/:cl:
