### PR TITLE
Minor sound changes and clarity.

### DIFF
--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -17,6 +17,8 @@
 		/obj/item/storage/firstaid = list(SKILL_MEDICAL, SKILL_MEDICAL_MEDIC),
 		/obj/item/storage/toolkit = list(SKILL_ENGINEER, SKILL_ENGINEER_ENGI),
 		)
+	pickup_sound = "armorequip"
+	drop_sound = "armorequip"
 	var/worn_accessible = FALSE //whether you can access its content while worn on the back
 	var/obj/item/card/id/locking_id = null
 	var/is_id_lockable = FALSE

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -275,6 +275,7 @@
 			if(user.a_intent == INTENT_HARM)
 				if(user.grab_level > GRAB_AGGRESSIVE)
 					if (prob(15)) M.apply_effect(5, WEAKEN)
+					playsound(loc, 'sound/weapons/thudswoosh.ogg', 25, 1, 7)
 					M.apply_damage(8, def_zone = "head")
 					user.visible_message(SPAN_DANGER("[user] slams [M]'s face against [src]!"),
 					SPAN_DANGER("You slam [M]'s face against [src]!"))
@@ -285,8 +286,9 @@
 			else if(user.grab_level >= GRAB_AGGRESSIVE)
 				M.forceMove(loc)
 				M.apply_effect(5, WEAKEN)
-				user.visible_message(SPAN_DANGER("[user] throws [M] on [src]."),
-				SPAN_DANGER("You throw [M] on [src]."))
+				playsound(loc, 'sound/weapons/thudswoosh.ogg', 25, 1, 7)
+				user.visible_message(SPAN_DANGER("[user] throws [M] on [src], stunning them!"),
+				SPAN_DANGER("You throw [M] on [src], stunning them!"))
 		return
 
 	if(HAS_TRAIT(W, TRAIT_TOOL_WRENCH) && !(user.a_intent == INTENT_HELP))

--- a/code/modules/clothing/shoes/marine_shoes.dm
+++ b/code/modules/clothing/shoes/marine_shoes.dm
@@ -21,6 +21,8 @@
 	var/armor_stage = 0
 	items_allowed = list(/obj/item/attachable/bayonet, /obj/item/weapon/throwing_knife, /obj/item/weapon/gun/pistol/holdout, /obj/item/weapon/gun/pistol/clfpistol, /obj/item/tool/screwdriver, /obj/item/tool/surgery/scalpel, /obj/item/weapon/straight_razor)
 	var/knife_type
+	pickup_sound = "armorequip"
+	drop_sound = "armorequip"
 
 /obj/item/clothing/shoes/marine/Initialize(mapload, ...)
 	. = ..()

--- a/code/modules/clothing/under/marine_uniform.dm
+++ b/code/modules/clothing/under/marine_uniform.dm
@@ -17,6 +17,8 @@
 	armor_rad = CLOTHING_ARMOR_NONE
 	armor_internaldamage = CLOTHING_ARMOR_LOW
 	flags_jumpsuit = UNIFORM_SLEEVE_ROLLABLE
+	pickup_sound = "armorequip"
+	drop_sound = "armorequip"
 	///Makes it so that we can see the right name in the vendor.
 	var/specialty = "USCM"
 	///List of map variants that use sleeve rolling on something else, like snow uniforms rolling the collar, and therefore shouldn't hide patches etc when rolled.

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -175,7 +175,7 @@
 				else
 					drop_held_item()
 					visible_message(SPAN_DANGER("<B>[attacking_mob] has disarmed [src]!</B>"), null, null, 5)
-				playsound(loc, 'sound/weapons/thudswoosh.ogg', 25, 1, 7)
+				playsound(loc, 'sound/weapons/punchmiss.ogg', 25, 1, 7)
 				return
 
 			playsound(loc, 'sound/weapons/punchmiss.ogg', 25, 1, 7)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Adds the armorequip noise to backpack, uniform, shoes. Changes the whoosh (disarm-stun) noise to only trigger when you stun someone. Adds whoosh to tablestun, and changes tablestun text to be more clear to new players that it stuns.

# Explain why it's good for the game

In human vs human fights, sometimes your back/uniform/shoes get stolen. The armorequip sound is a good clue to draw attention to when this happens, both for the victim and the attacker, so adding it to a few more important gear pieces should be a benefit in these fringe cases. The effect is subtle enough, and the situation rare enough, that I don't think it would be too much. The whoosh sound is currently triggering when you "disarm" someone even when they are holding nothing in hand, which doesn't make sense. Now it's reserved for when a disarm-stun goes off, or a tablestun because tablestun being silent doesn't make sense either. From my experience talking to players, tablestun is not very well known outside of veteran players who familiarized themselves with that niche interaction, so adding a sound and changing the text to make the effect clear should be a benefit.

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
ui: tablestun text is more clear that it stuns
soundadd: equip/unequip noise added to uniform, backpack, shoes. whoosh added to tablestun.
sounddel: for disarms, whoosh only triggers on stun. otherwise, the miss sound plays
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
