### PR TITLE
small lv map changes

### DIFF
--- a/maps/map_files/LV624/LV624.dmm
+++ b/maps/map_files/LV624/LV624.dmm
@@ -2647,9 +2647,9 @@
 /area/lv624/ground/river/west_river)
 "anc" = (
 /obj/structure/flora/jungle/vines/light_1,
-/obj/effect/landmark/lv624/fog_blocker,
+/obj/structure/flora/jungle/vines/heavy,
 /turf/open/gm/grass/grass1,
-/area/lv624/ground/jungle/north_east_jungle)
+/area/lv624/ground/jungle/north_west_jungle)
 "and" = (
 /obj/structure/flora/bush/ausbushes/var3/fullgrass,
 /obj/effect/landmark/lv624/fog_blocker,
@@ -2680,19 +2680,14 @@
 /turf/open/floor/plating,
 /area/lv624/lazarus/landing_zones/lz1)
 "anq" = (
-/obj/structure/flora/jungle/vines/light_3,
-/obj/effect/landmark/lv624/fog_blocker,
+/obj/structure/flora/jungle/vines/heavy,
+/obj/structure/flora/jungle/vines/heavy,
 /turf/open/gm/grass/grass1,
-/area/lv624/ground/jungle/north_east_jungle)
+/area/lv624/ground/jungle/north_west_jungle)
 "anv" = (
 /obj/structure/flora/bush/ausbushes/var3/sunnybush,
 /turf/open/gm/grass/grass1,
 /area/lv624/lazarus/landing_zones/lz1)
-"anx" = (
-/obj/structure/flora/jungle/vines/heavy,
-/obj/effect/landmark/lv624/fog_blocker,
-/turf/open/gm/grass/grass1,
-/area/lv624/ground/jungle/north_east_jungle)
 "any" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_door,
@@ -7956,11 +7951,11 @@
 "aIE" = (
 /obj/structure/flora/bush/ausbushes/var3/stalkybush,
 /obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
-	pixel_x = 11;
-	pixel_y = -2;
 	light_on = 1;
 	light_range = 1;
-	light_system = 1
+	light_system = 1;
+	pixel_x = 11;
+	pixel_y = -2
 	},
 /turf/open/auto_turf/strata_grass/layer1,
 /area/lv624/ground/caves/south_west_caves)
@@ -12369,11 +12364,11 @@
 /area/lv624/ground/caves/west_caves)
 "bcU" = (
 /obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
-	pixel_x = -10;
-	pixel_y = -2;
 	light_on = 1;
 	light_range = 1;
-	light_system = 1
+	light_system = 1;
+	pixel_x = -10;
+	pixel_y = -2
 	},
 /turf/open/auto_turf/strata_grass/layer1,
 /area/lv624/ground/caves/south_east_caves)
@@ -12805,10 +12800,10 @@
 /area/lv624/ground/barrens/south_eastern_barrens)
 "bOm" = (
 /obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
-	pixel_x = 4;
 	light_on = 1;
 	light_range = 1;
-	light_system = 1
+	light_system = 1;
+	pixel_x = 4
 	},
 /turf/open/auto_turf/strata_grass/layer1,
 /area/lv624/ground/barrens/north_east_barrens)
@@ -13016,11 +13011,11 @@
 /area/lv624/ground/caves/west_caves)
 "chi" = (
 /obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
-	pixel_x = -10;
-	pixel_y = -2;
 	light_on = 1;
 	light_range = 1;
-	light_system = 1
+	light_system = 1;
+	pixel_x = -10;
+	pixel_y = -2
 	},
 /turf/open/auto_turf/strata_grass/layer1,
 /area/lv624/ground/caves/south_west_caves)
@@ -13695,10 +13690,10 @@
 /area/lv624/ground/caves/south_central_caves)
 "dBS" = (
 /obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
-	pixel_x = -10;
 	light_on = 1;
 	light_range = 1;
-	light_system = 1
+	light_system = 1;
+	pixel_x = -10
 	},
 /turf/open/auto_turf/strata_grass/layer1,
 /area/lv624/ground/caves/north_west_caves)
@@ -14506,11 +14501,11 @@
 /area/lv624/ground/jungle/east_jungle)
 "fcQ" = (
 /obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
-	pixel_x = -5;
-	pixel_y = -5;
 	light_on = 1;
 	light_range = 1;
-	light_system = 1
+	light_system = 1;
+	pixel_x = -5;
+	pixel_y = -5
 	},
 /turf/open/auto_turf/strata_grass/layer1,
 /area/lv624/ground/caves/south_west_caves)
@@ -14983,11 +14978,11 @@
 /area/lv624/ground/jungle/south_central_jungle)
 "gcB" = (
 /obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
-	pixel_x = 6;
-	pixel_y = -8;
 	light_on = 1;
 	light_range = 1;
-	light_system = 1
+	light_system = 1;
+	pixel_x = 6;
+	pixel_y = -8
 	},
 /turf/open/auto_turf/strata_grass/layer1,
 /area/lv624/ground/caves/central_caves)
@@ -15078,11 +15073,11 @@
 /area/lv624/ground/barrens/south_eastern_jungle_barrens)
 "gnt" = (
 /obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
-	pixel_x = -5;
-	pixel_y = -5;
 	light_on = 1;
 	light_range = 1;
-	light_system = 1
+	light_system = 1;
+	pixel_x = -5;
+	pixel_y = -5
 	},
 /turf/open/auto_turf/strata_grass/layer1,
 /area/lv624/ground/caves/north_west_caves)
@@ -15478,11 +15473,11 @@
 /area/lv624/lazarus/landing_zones/lz2)
 "hez" = (
 /obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
-	pixel_x = 2;
-	pixel_y = 7;
 	light_on = 1;
 	light_range = 1;
-	light_system = 1
+	light_system = 1;
+	pixel_x = 2;
+	pixel_y = 7
 	},
 /turf/open/auto_turf/strata_grass/layer1,
 /area/lv624/ground/caves/central_caves)
@@ -15589,11 +15584,11 @@
 /area/lv624/ground/caves/north_central_caves)
 "hpK" = (
 /obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
-	pixel_x = -10;
-	pixel_y = -2;
 	light_on = 1;
 	light_range = 1;
-	light_system = 1
+	light_system = 1;
+	pixel_x = -10;
+	pixel_y = -2
 	},
 /turf/open/auto_turf/strata_grass/layer1,
 /area/lv624/ground/caves/south_central_caves)
@@ -15634,10 +15629,10 @@
 /area/lv624/ground/river/central_river)
 "htV" = (
 /obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
-	pixel_x = 4;
 	light_on = 1;
 	light_range = 1;
-	light_system = 1
+	light_system = 1;
+	pixel_x = 4
 	},
 /turf/open/auto_turf/strata_grass/layer1,
 /area/lv624/ground/caves/west_caves)
@@ -15983,11 +15978,11 @@
 /area/lv624/lazarus/landing_zones/lz1)
 "ieN" = (
 /obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
-	pixel_x = 2;
-	pixel_y = 7;
 	light_on = 1;
 	light_range = 1;
-	light_system = 1
+	light_system = 1;
+	pixel_x = 2;
+	pixel_y = 7
 	},
 /turf/open/auto_turf/strata_grass/layer1,
 /area/lv624/ground/caves/west_caves)
@@ -16807,11 +16802,11 @@
 /area/lv624/ground/jungle/north_west_jungle)
 "jRL" = (
 /obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
-	pixel_x = 2;
-	pixel_y = 7;
 	light_on = 1;
 	light_range = 1;
-	light_system = 1
+	light_system = 1;
+	pixel_x = 2;
+	pixel_y = 7
 	},
 /turf/open/auto_turf/strata_grass/layer1,
 /area/lv624/ground/caves/east_caves)
@@ -17317,12 +17312,6 @@
 /obj/effect/decal/grass_overlay/grass1/inner,
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/west_caves)
-"kWX" = (
-/turf/open/floor{
-	dir = 8;
-	icon_state = "asteroidwarning"
-	},
-/area/lv624/ground/colony/telecomm/sw_lz2)
 "kXE" = (
 /obj/structure/flora/bush/ausbushes/ausbush,
 /turf/open/gm/dirtgrassborder/north,
@@ -17701,11 +17690,11 @@
 /area/lv624/lazarus/landing_zones/lz2)
 "lKl" = (
 /obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
-	pixel_x = 6;
-	pixel_y = -8;
 	light_on = 1;
 	light_range = 1;
-	light_system = 1
+	light_system = 1;
+	pixel_x = 6;
+	pixel_y = -8
 	},
 /turf/open/auto_turf/strata_grass/layer1,
 /area/lv624/ground/caves/west_caves)
@@ -17742,11 +17731,11 @@
 /area/lv624/lazarus/corporate_dome)
 "lNG" = (
 /obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
-	pixel_x = 2;
-	pixel_y = 7;
 	light_on = 1;
 	light_range = 1;
-	light_system = 1
+	light_system = 1;
+	pixel_x = 2;
+	pixel_y = 7
 	},
 /turf/open/auto_turf/strata_grass/layer1,
 /area/lv624/ground/caves/south_east_caves)
@@ -17911,11 +17900,11 @@
 /area/lv624/ground/jungle/east_jungle)
 "mca" = (
 /obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
-	pixel_x = 2;
-	pixel_y = 7;
 	light_on = 1;
 	light_range = 1;
-	light_system = 1
+	light_system = 1;
+	pixel_x = 2;
+	pixel_y = 7
 	},
 /turf/open/auto_turf/strata_grass/layer1,
 /area/lv624/ground/caves/south_central_caves)
@@ -17928,11 +17917,11 @@
 /area/lv624/ground/jungle/south_east_jungle)
 "mfn" = (
 /obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
-	pixel_x = 2;
-	pixel_y = -2;
 	light_on = 1;
 	light_range = 1;
-	light_system = 1
+	light_system = 1;
+	pixel_x = 2;
+	pixel_y = -2
 	},
 /turf/open/auto_turf/strata_grass/layer1,
 /area/lv624/ground/caves/east_caves)
@@ -18533,10 +18522,10 @@
 /area/lv624/lazarus/quartstorage)
 "nrR" = (
 /obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
-	pixel_x = -10;
 	light_on = 1;
 	light_range = 1;
-	light_system = 1
+	light_system = 1;
+	pixel_x = -10
 	},
 /turf/open/auto_turf/strata_grass/layer1,
 /area/lv624/ground/caves/south_east_caves)
@@ -18828,11 +18817,11 @@
 /area/lv624/lazarus/corporate_dome)
 "nNu" = (
 /obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
-	pixel_x = 6;
-	pixel_y = -8;
 	light_on = 1;
 	light_range = 1;
-	light_system = 1
+	light_system = 1;
+	pixel_x = 6;
+	pixel_y = -8
 	},
 /turf/open/auto_turf/strata_grass/layer1,
 /area/lv624/ground/barrens/north_east_barrens)
@@ -18869,11 +18858,11 @@
 /area/lv624/ground/caves/sand_temple)
 "nQH" = (
 /obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
-	pixel_x = 6;
-	pixel_y = -8;
 	light_on = 1;
 	light_range = 1;
-	light_system = 1
+	light_system = 1;
+	pixel_x = 6;
+	pixel_y = -8
 	},
 /turf/open/auto_turf/strata_grass/layer1,
 /area/lv624/ground/caves/south_west_caves)
@@ -19186,11 +19175,11 @@
 /area/lv624/ground/colony/telecomm/cargo)
 "osf" = (
 /obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
-	pixel_x = 11;
-	pixel_y = -2;
 	light_on = 1;
 	light_range = 1;
-	light_system = 1
+	light_system = 1;
+	pixel_x = 11;
+	pixel_y = -2
 	},
 /turf/open/auto_turf/strata_grass/layer1,
 /area/lv624/ground/caves/central_caves)
@@ -19943,8 +19932,8 @@
 /area/lv624/lazarus/quartstorage/outdoors)
 "pKm" = (
 /turf/open/floor{
-	icon_state = "asteroidwarning";
-	dir = 8
+	dir = 8;
+	icon_state = "asteroidwarning"
 	},
 /area/lv624/ground/colony/telecomm/sw_lz2)
 "pKp" = (
@@ -19964,10 +19953,10 @@
 /area/lv624/ground/colony/west_nexus_road)
 "pLv" = (
 /obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
-	pixel_x = 4;
 	light_on = 1;
 	light_range = 1;
-	light_system = 1
+	light_system = 1;
+	pixel_x = 4
 	},
 /turf/open/auto_turf/strata_grass/layer1,
 /area/lv624/ground/caves/north_west_caves)
@@ -20098,10 +20087,10 @@
 /area/lv624/ground/caves/east_caves)
 "pVZ" = (
 /obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
-	pixel_x = -10;
 	light_on = 1;
 	light_range = 1;
-	light_system = 1
+	light_system = 1;
+	pixel_x = -10
 	},
 /turf/open/auto_turf/strata_grass/layer1,
 /area/lv624/ground/caves/central_caves)
@@ -20544,11 +20533,11 @@
 /area/lv624/ground/caves/north_west_caves)
 "qVi" = (
 /obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
-	pixel_x = -10;
-	pixel_y = -2;
 	light_on = 1;
 	light_range = 1;
-	light_system = 1
+	light_system = 1;
+	pixel_x = -10;
+	pixel_y = -2
 	},
 /turf/open/auto_turf/strata_grass/layer1,
 /area/lv624/ground/caves/north_east_caves)
@@ -20685,10 +20674,10 @@
 /area/lv624/ground/jungle/north_east_jungle)
 "rhi" = (
 /obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
-	pixel_x = 4;
 	light_on = 1;
 	light_range = 1;
-	light_system = 1
+	light_system = 1;
+	pixel_x = 4
 	},
 /turf/open/auto_turf/strata_grass/layer1,
 /area/lv624/ground/caves/east_caves)
@@ -20714,20 +20703,20 @@
 /area/lv624/lazarus/engineering)
 "rmt" = (
 /obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
-	pixel_x = 4;
 	light_on = 1;
 	light_range = 1;
-	light_system = 1
+	light_system = 1;
+	pixel_x = 4
 	},
 /turf/open/auto_turf/strata_grass/layer1,
 /area/lv624/ground/caves/south_central_caves)
 "rmW" = (
 /obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
-	pixel_x = 11;
-	pixel_y = -2;
 	light_on = 1;
 	light_range = 1;
-	light_system = 1
+	light_system = 1;
+	pixel_x = 11;
+	pixel_y = -2
 	},
 /turf/open/auto_turf/strata_grass/layer1,
 /area/lv624/ground/caves/west_caves)
@@ -20863,11 +20852,11 @@
 /area/lv624/lazarus/corporate_dome)
 "rAU" = (
 /obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
-	pixel_x = 6;
-	pixel_y = -8;
 	light_on = 1;
 	light_range = 1;
-	light_system = 1
+	light_system = 1;
+	pixel_x = 6;
+	pixel_y = -8
 	},
 /turf/open/auto_turf/strata_grass/layer1,
 /area/lv624/ground/caves/east_caves)
@@ -20916,11 +20905,11 @@
 /area/lv624/lazarus/quartstorage)
 "rGE" = (
 /obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
-	pixel_x = 6;
-	pixel_y = -8;
 	light_on = 1;
 	light_range = 1;
-	light_system = 1
+	light_system = 1;
+	pixel_x = 6;
+	pixel_y = -8
 	},
 /turf/open/auto_turf/strata_grass/layer1,
 /area/lv624/ground/caves/south_east_caves)
@@ -21209,10 +21198,10 @@
 /area/lv624/ground/caves/sand_temple)
 "snc" = (
 /obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
-	pixel_x = 4;
 	light_on = 1;
 	light_range = 1;
-	light_system = 1
+	light_system = 1;
+	pixel_x = 4
 	},
 /turf/open/auto_turf/strata_grass/layer1,
 /area/lv624/ground/caves/south_west_caves)
@@ -21626,11 +21615,11 @@
 /area/lv624/ground/caves/sand_temple)
 "sXg" = (
 /obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
-	pixel_x = -10;
-	pixel_y = -2;
 	light_on = 1;
 	light_range = 1;
-	light_system = 1
+	light_system = 1;
+	pixel_x = -10;
+	pixel_y = -2
 	},
 /turf/open/auto_turf/strata_grass/layer1,
 /area/lv624/ground/caves/west_caves)
@@ -21727,11 +21716,11 @@
 /area/lv624/ground/river/west_river)
 "thk" = (
 /obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
-	pixel_x = -5;
-	pixel_y = -5;
 	light_on = 1;
 	light_range = 1;
-	light_system = 1
+	light_system = 1;
+	pixel_x = -5;
+	pixel_y = -5
 	},
 /turf/open/auto_turf/strata_grass/layer1,
 /area/lv624/ground/caves/central_caves)
@@ -21900,11 +21889,11 @@
 /area/lv624/ground/barrens/south_eastern_barrens)
 "tuJ" = (
 /obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
-	pixel_x = -5;
-	pixel_y = -5;
 	light_on = 1;
 	light_range = 1;
-	light_system = 1
+	light_system = 1;
+	pixel_x = -5;
+	pixel_y = -5
 	},
 /turf/open/auto_turf/strata_grass/layer1,
 /area/lv624/ground/caves/north_east_caves)
@@ -22114,11 +22103,11 @@
 /area/lv624/ground/caves/south_central_caves)
 "tQU" = (
 /obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
-	pixel_x = 2;
-	pixel_y = 7;
 	light_on = 1;
 	light_range = 1;
-	light_system = 1
+	light_system = 1;
+	pixel_x = 2;
+	pixel_y = 7
 	},
 /turf/open/auto_turf/strata_grass/layer1,
 /area/lv624/ground/caves/south_west_caves)
@@ -22403,8 +22392,8 @@
 /area/lv624/ground/caves/east_caves)
 "upV" = (
 /obj/item/stack/cable_coil/random{
-	pixel_y = 9;
-	pixel_x = 7
+	pixel_x = 7;
+	pixel_y = 9
 	},
 /turf/open/gm/dirt,
 /area/lv624/ground/jungle/east_jungle)
@@ -22459,11 +22448,11 @@
 /area/lv624/ground/caves/north_central_caves)
 "uxL" = (
 /obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
-	pixel_x = 11;
-	pixel_y = -2;
 	light_on = 1;
 	light_range = 1;
-	light_system = 1
+	light_system = 1;
+	pixel_x = 11;
+	pixel_y = -2
 	},
 /turf/open/auto_turf/strata_grass/layer1,
 /area/lv624/ground/caves/south_central_caves)
@@ -22885,11 +22874,11 @@
 	dir = 10
 	},
 /obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
-	pixel_x = 2;
-	pixel_y = 7;
 	light_on = 1;
 	light_range = 1;
-	light_system = 1
+	light_system = 1;
+	pixel_x = 2;
+	pixel_y = 7
 	},
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/south_east_caves)
@@ -23303,11 +23292,11 @@
 /area/lv624/ground/caves/sand_temple)
 "whk" = (
 /obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
-	pixel_x = 2;
-	pixel_y = 7;
 	light_on = 1;
 	light_range = 1;
-	light_system = 1
+	light_system = 1;
+	pixel_x = 2;
+	pixel_y = 7
 	},
 /turf/open/auto_turf/strata_grass/layer1,
 /area/lv624/ground/caves/north_west_caves)
@@ -23563,11 +23552,11 @@
 /area/lv624/lazarus/landing_zones/lz2)
 "wHE" = (
 /obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
-	pixel_x = -1;
-	pixel_y = 7;
 	light_on = 1;
 	light_range = 1;
-	light_system = 1
+	light_system = 1;
+	pixel_x = -1;
+	pixel_y = 7
 	},
 /turf/open/auto_turf/strata_grass/layer1,
 /area/lv624/ground/caves/south_west_caves)
@@ -23615,11 +23604,11 @@
 /area/lv624/ground/jungle/west_central_jungle)
 "wMr" = (
 /obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
-	pixel_x = 2;
-	pixel_y = 7;
 	light_on = 1;
 	light_range = 1;
-	light_system = 1
+	light_system = 1;
+	pixel_x = 2;
+	pixel_y = 7
 	},
 /turf/open/auto_turf/strata_grass/layer1,
 /area/lv624/ground/caves/north_east_caves)
@@ -31164,7 +31153,7 @@ uiW
 sqs
 oTJ
 qKC
-kWX
+pKm
 hdh
 oKP
 aAp
@@ -37761,7 +37750,7 @@ oTJ
 teS
 psh
 psh
-nuW
+psh
 kRg
 nuW
 cTi
@@ -37989,7 +37978,7 @@ asH
 teS
 psh
 psh
-nuW
+psh
 cRT
 nuW
 nuW
@@ -38219,7 +38208,7 @@ kzv
 psh
 cRT
 cTi
-nuW
+cRT
 nuW
 nuW
 nuW
@@ -38445,14 +38434,14 @@ tlE
 gyP
 psh
 nuW
-nuW
-cqz
-hEl
+psh
 vEp
+cTi
+vEp
+anc
 nuW
 nuW
-nuW
-nuW
+psh
 psh
 psh
 psh
@@ -38673,14 +38662,14 @@ gyP
 psh
 psh
 nuW
-nuW
-dmS
-dmS
-cTi
 psh
-vEp
+dmS
+psh
 cRT
-vXW
+lBr
+cRT
+cRT
+psh
 psh
 cGb
 psh
@@ -38903,12 +38892,12 @@ psh
 nuW
 nuW
 kzv
+cRT
+anc
 vEp
-dmS
-cTi
-vXW
-txx
 vEp
+psh
+psh
 psh
 psh
 psh
@@ -39132,14 +39121,14 @@ cTi
 pYJ
 cqz
 cRT
+vEp
+vEp
 cRT
-cRT
-cRT
-cRT
-cTi
 psh
-nuW
-nuW
+psh
+psh
+psh
+psh
 pYq
 eny
 eny
@@ -39359,12 +39348,12 @@ dmS
 cRT
 txx
 pYJ
-txx
-cRT
-cRT
-txx
+lBr
 cRT
 vEp
+kzv
+psh
+psh
 psh
 psh
 psh
@@ -39589,8 +39578,8 @@ cRT
 cTi
 gDy
 vEp
-txx
-nuW
+cRT
+cRT
 psh
 psh
 psh
@@ -39816,10 +39805,10 @@ cRT
 dmS
 vEp
 psh
-psh
-psh
-psh
-psh
+cRT
+cRT
+anq
+cRT
 psh
 psh
 psh
@@ -40044,8 +40033,8 @@ psh
 psh
 psh
 psh
-psh
-psh
+cRT
+cRT
 lqI
 psh
 psh
@@ -46867,7 +46856,7 @@ sqj
 rit
 amo
 hJW
-amB
+tyG
 tyG
 tyG
 qJx
@@ -47095,7 +47084,7 @@ ajH
 alW
 dVH
 hJW
-amB
+tyG
 tyG
 tyG
 tyG
@@ -47323,7 +47312,7 @@ sqj
 alW
 dVH
 hJW
-amB
+tyG
 ldZ
 tyG
 tyG
@@ -47551,7 +47540,7 @@ kft
 alW
 byL
 hJW
-amC
+vqT
 ldZ
 tyG
 tyG
@@ -47780,7 +47769,7 @@ alX
 amr
 hJW
 tyG
-amB
+tyG
 tyG
 tyG
 tyG
@@ -48008,7 +47997,7 @@ alY
 amr
 hJW
 tyG
-amC
+vqT
 vqT
 tyG
 tyG
@@ -48236,7 +48225,7 @@ alY
 amr
 hJW
 tyG
-amB
+tyG
 tyG
 tyG
 dvf
@@ -48464,7 +48453,7 @@ alY
 amr
 hJW
 tyG
-amB
+tyG
 tyG
 ptr
 tyG
@@ -48692,7 +48681,7 @@ alX
 amr
 hJW
 tyG
-amB
+tyG
 tyG
 tyG
 tyG
@@ -48919,8 +48908,8 @@ eHq
 alW
 byL
 hJW
-amB
-amB
+tyG
+tyG
 tyG
 tyG
 tyG
@@ -49147,7 +49136,7 @@ sqj
 rit
 amr
 oRH
-guY
+cpY
 fuY
 wcS
 vjH
@@ -49375,7 +49364,7 @@ lju
 oTt
 ams
 amE
-gFm
+dmZ
 fuY
 fuY
 xPL
@@ -49600,14 +49589,14 @@ sqj
 sTX
 lju
 oTt
+amr
 dVH
-dVH
-amD
+oRH
 cpY
-gFm
-gFm
-anx
-anx
+dmZ
+dmZ
+cwV
+cwV
 cpY
 xPL
 vjH
@@ -49827,14 +49816,14 @@ sqj
 sqj
 sqj
 rit
-dVH
+amr
 dVH
 dVH
 oRH
-guY
+cpY
 dmZ
 dmZ
-anq
+vjH
 cwV
 lSs
 lSs
@@ -50055,13 +50044,13 @@ sqj
 lju
 hwR
 oTt
-hrG
+amo
 wqy
 dVH
 oRH
 fuY
 cpY
-guY
+cpY
 lnR
 lSs
 lSs
@@ -50283,13 +50272,13 @@ sqj
 rit
 dVH
 dVH
-dVH
+amr
 dVH
 dVH
 oRH
-guY
 cpY
-anc
+cpY
+vSG
 cwV
 vjH
 lSs
@@ -50511,12 +50500,12 @@ sqj
 rit
 dVH
 dVH
-dVH
+amr
 hrG
 dVH
 oRH
 cpY
-guY
+cpY
 wsZ
 xPL
 vSG
@@ -50739,13 +50728,13 @@ sTX
 dGG
 nPd
 dVH
-dVH
+amr
 bfe
 jXT
 bQP
 dmZ
 ubN
-guY
+cpY
 fuY
 fuY
 lSs
@@ -50967,12 +50956,12 @@ sqj
 kft
 dGG
 nPd
-bfe
+aUz
 bQP
 cpY
 qAu
 cpY
-guY
+cpY
 fuY
 fuY
 fuY
@@ -51196,12 +51185,12 @@ sqj
 lju
 oTt
 oRH
-cpY
+guY
 dmZ
 fuY
 cpY
 cpY
-guY
+cpY
 vjH
 vtt
 cwV
@@ -51428,7 +51417,7 @@ fuY
 cpY
 cpY
 cpY
-guY
+cpY
 cpY
 vSG
 vSG
@@ -51652,10 +51641,10 @@ hwR
 oTt
 dVH
 oRH
-cpY
-cpY
-cpY
 guY
+cpY
+cpY
+cpY
 fuY
 fuY
 fuY
@@ -51881,8 +51870,8 @@ dVH
 hrG
 oRH
 guY
-guY
-guY
+cpY
+cpY
 fuY
 fuY
 fuY

--- a/maps/map_files/LV624/standalone/lv-bridge-nofog.dmm
+++ b/maps/map_files/LV624/standalone/lv-bridge-nofog.dmm
@@ -158,7 +158,6 @@
 	},
 /area/lv624/ground/river/central_river)
 "EG" = (
-/obj/effect/landmark/lv624/fog_blocker,
 /turf/open/gm/grass/grass2,
 /area/lv624/ground/jungle/north_east_jungle)
 "Pz" = (


### PR DESCRIPTION
# About the pull request

makes it so you can go straight across the riverline pre-fog drop without having to go through <details>
<summary>this hellspot</summary>

![image](https://github.com/cmss13-devs/cmss13/assets/103988604/af7cbe64-79fb-4d91-9450-21bb5e4fa770)

</details>



this also adds a new path to the riverline just NW of scidome
<details>
<summary>pic</summary>

![image](https://github.com/cmss13-devs/cmss13/assets/103988604/d4f50cfe-68b7-4a28-8f71-3074b54a98bd)

</details>

# Explain why it's good for the game

change 1 allows easy access through the top side of the map pre-fog drop, allowing a route i like to take to get each side quicker pre-fog drop.

change 2 allows ppl to get to the actual riverline from lz2 easier, also gives a new escape route for xenos going either side as the other two close r annoying or usually in chokes with rines guarding

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
maptweak: the LV riverline is no longer seperated in two by the fog, you can now go across it without dipping into jungle vine hell
maptweak: adds a new way to get to the riverline north-west of sci-dome in some vines
/:cl:
