### PR TITLE
Fixes ocassional observer minimap desync

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -760,9 +760,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	following = null
 	spawn(0)
 		// To stop the ghost flickering.
-		x = tx
-		y = ty
-		z = tz
+		forceMove(locate(tx, ty, tz))
 		sleep(15)
 
 /mob/dead/observer/verb/dead_teleport_mob() //Moves the ghost instead of just changing the ghosts's eye -Nodrak

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -758,10 +758,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	if(!tx || !ty || !tz)
 		return
 	following = null
-	spawn(0)
-		// To stop the ghost flickering.
-		forceMove(locate(tx, ty, tz))
-		sleep(15)
+	forceMove(locate(tx, ty, tz))
 
 /mob/dead/observer/verb/dead_teleport_mob() //Moves the ghost instead of just changing the ghosts's eye -Nodrak
 	set category = "Ghost"


### PR DESCRIPTION

# About the pull request

Fixes annoying bug involving jumptocoord hrefs in some deadchat messages, making ghost's minimap desync with the map observer is in.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Bugs bad. Removing bugs good.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: MrDas
fix: Observer minimap should no longer occasionally show wrong / no map.
/:cl:
