### PR TITLE
Weeds are conserved under walls being upgraded and destroyed

### DIFF
--- a/code/game/turfs/walls/walls.dm
+++ b/code/game/turfs/walls/walls.dm
@@ -88,8 +88,6 @@
 			if(istype(found_object, /obj/structure/sign/poster))
 				var/obj/structure/sign/poster/found_poster = found_object
 				found_poster.roll_and_drop(src)
-			if(istype(found_object, /obj/effect/alien/weeds))
-				qdel(found_object)
 
 		var/list/turf/cardinal_neighbors = list(get_step(src, NORTH), get_step(src, SOUTH), get_step(src, EAST), get_step(src, WEST))
 		for(var/turf/cardinal_turf as anything in cardinal_neighbors)


### PR DESCRIPTION

# About the pull request

Fixes #5060

Side effect of this PR is that when resin walls are destroyed then do not remove the weeds underneath. However those weeds should still be linked to a nearby node and recede as normal when that is destroyed.

# Explain why it's good for the game


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Upgraded resin walls can now nest hosts.
/🆑
