### PR TITLE
Fixes non normal hive nickname numbering

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -376,10 +376,8 @@
 	tacmap = new(src, minimap_type)
 	if(!internal_faction)
 		internal_faction = name
-
 	for(var/number in 1 to 999)
 		available_nicknumbers += number
-
 	if(hivenumber != XENO_HIVE_NORMAL)
 		return
 

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -376,11 +376,12 @@
 	tacmap = new(src, minimap_type)
 	if(!internal_faction)
 		internal_faction = name
-	if(hivenumber != XENO_HIVE_NORMAL)
-		return
 
 	for(var/number in 1 to 999)
 		available_nicknumbers += number
+
+	if(hivenumber != XENO_HIVE_NORMAL)
+		return
 
 	RegisterSignal(SSdcs, COMSIG_GLOB_POST_SETUP, PROC_REF(post_setup))
 


### PR DESCRIPTION

# About the pull request

#4992 broke non normal hive nick numbering due to an oversight. You will laugh when you see why.
This fixes that.

# Explain why it's good for the game
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
🆑 
fix: Fixed non normal xeno hive nick numbering
/🆑 
