### PR TITLE
Adds Jungle boots to the surplus vendors

### DIFF
--- a/code/game/machinery/vending/vendor_types/squad_prep/squad_prep.dm
+++ b/code/game/machinery/vending/vendor_types/squad_prep/squad_prep.dm
@@ -72,6 +72,7 @@
 		list("STANDARD EQUIPMENT", -1, null, null, null),
 		list("Marine Combat Boots", round(scale * 15), /obj/item/clothing/shoes/marine, VENDOR_ITEM_REGULAR),
 		list("Marine Brown Combat Boots", round(scale * 15), /obj/item/clothing/shoes/marine/brown, VENDOR_ITEM_REGULAR),
+		list("Marine Jungle Combat Boots", round(scale * 15), /obj/item/clothing/shoes/marine/jungle, VENDOR_ITEM_REGULAR),
 		list("USCM Uniform", round(scale * 15), /obj/item/clothing/under/marine, VENDOR_ITEM_REGULAR),
 		list("Marine Combat Gloves", round(scale * 15), /obj/item/clothing/gloves/marine, VENDOR_ITEM_REGULAR),
 		list("Marine Brown Combat Gloves", round(scale * 15), /obj/item/clothing/gloves/marine/brown, VENDOR_ITEM_REGULAR),


### PR DESCRIPTION

# About the pull request
Adds the Jungle Combat Boots to the marine vendor.

# Explain why it's good for the game

This completes #4996 and let's you save even more loadout points to spend on candy.


# Testing Photographs and Procedure
![CMjungleboots](https://github.com/cmss13-devs/cmss13/assets/59937074/f1120bbe-418f-43cd-95c1-81e193598b79)

# Changelog

:cl: Googles_Hands
add: Jungle boots are now vendable from the surplus vendors.
/:cl: