### PR TITLE
Fixes a runtime in spiders.dm attackby()

### DIFF
--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -21,7 +21,7 @@
 	return
 
 /obj/effect/spider/attackby(obj/item/W, mob/user)
-	if(W.attack_verb.len)
+	if(LAZYLEN(W.attack_verb))
 		visible_message(SPAN_DANGER("<B>\The [src] have been [pick(W.attack_verb)] with \the [W][(user ? "by [user]." : ".")]"))
 	else
 		visible_message(SPAN_DANGER("<B>\The [src] have been attacked with \the [W][(user ? "by [user]." : ".")]"))


### PR DESCRIPTION

# About the pull request

```
[2023-12-03 16:02:14.678] runtime error: Cannot read null.len
 - proc name: attackby (/obj/effect/spider/attackby)
 -   source file: code/game/objects/effects/spiders.dm,24
 -   usr: Conner Scott (/mob/living/carbon/human)
 -   src: the spiderling (/obj/effect/spider/spiderling/nogrow)
 -   usr.loc: the floor (90,115,2) (/turf/open/floor/prison)
 -   src.loc: the catwalk (89,116,2) (/turf/open/floor/plating/plating_catwalk/prison)
 -   call stack:
 - the spiderling (/obj/effect/spider/spiderling/nogrow): attackby(the box of shotgun slugs (/obj/item/ammo_magazine/shotgun/slugs), Conner Scott (/mob/living/carbon/human), /list (/list))
 - Conner Scott (/mob/living/carbon/human): click adjacent(the spiderling (/obj/effect/spider/spiderling/nogrow), the box of shotgun slugs (/obj/item/ammo_magazine/shotgun/slugs), /list (/list))
 - Conner Scott (/mob/living/carbon/human): do click(the spiderling (/obj/effect/spider/spiderling/nogrow), the catwalk (89,116,2) (/turf/open/floor/plating/plating_catwalk/prison), "icon-x=18;icon-y=15;left=1;but...")
 - ****** (/client): Click(the spiderling (/obj/effect/spider/spiderling/nogrow), the catwalk (89,116,2) (/turf/open/floor/plating/plating_catwalk/prison), "mapwindow.map", "icon-x=18;icon-y=15;left=1;but...")
```

# Explain why it's good for the game
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Fixes runtime in spiders.dm
/🆑
