### PR TITLE
Runtime fix and code maintenance for vendors

### DIFF
--- a/code/game/machinery/vending/cm_vending.dm
+++ b/code/game/machinery/vending/cm_vending.dm
@@ -441,13 +441,6 @@ GLOBAL_LIST_EMPTY(vending_products)
 	tgui_interact(user)
 
 /// Handles redeeming coin tokens.
-/obj/structure/machinery/cm_vending/attackby(obj/item/attacking_item, mob/user)
-	if(!istype(attacking_item, /obj/item/coin/marine))
-		..()
-	if(!can_access_to_vend(user, ignore_hack = TRUE))
-		return FALSE
-	redeem_token(attacking_item, user)
-
 /obj/structure/machinery/cm_vending/proc/redeem_token(obj/item/coin/marine/token, mob/user)
 	var/reward_typepath
 	switch(token.token_type)
@@ -765,6 +758,13 @@ GLOBAL_LIST_EMPTY(vending_products)
 			return FALSE
 		hack_access(user)
 		return TRUE
+
+	///If we want to redeem a token
+	else if(istype(W, /obj/item/coin/marine))
+		if(!can_access_to_vend(user, ignore_hack = TRUE))
+			return FALSE
+		redeem_token(W, user)
+		return FALSE
 
 	..()
 

--- a/code/game/machinery/vending/cm_vending.dm
+++ b/code/game/machinery/vending/cm_vending.dm
@@ -763,8 +763,8 @@ GLOBAL_LIST_EMPTY(vending_products)
 	else if(istype(W, /obj/item/coin/marine))
 		if(!can_access_to_vend(user, ignore_hack = TRUE))
 			return FALSE
-		redeem_token(W, user)
-		return FALSE
+		. = redeem_token(W, user)
+		return
 
 	..()
 


### PR DESCRIPTION

# About the pull request

#5066 introduced a runtime in certain vendors when attacking them with anything.
Also removes duplicate `attackby()` definition.

```
[2023-12-03 16:04:24.708] runtime error: undefined variable /obj/item/storage/belt/marine/var/token_type
 - proc name: redeem token (/obj/structure/machinery/cm_vending/proc/redeem_token)
 -   source file: code/game/machinery/vending/cm_vending.dm,453
 -   usr: William Henderson (/mob/living/carbon/human)
 -   src: the ColMarTech Surplus Uniform... (/obj/structure/machinery/cm_vending/sorted/uniform_supply/squad_prep)
 -   usr.loc: the floor (186,73,3) (/turf/open/floor/almayer)
 -   src.loc: the floor (185,73,3) (/turf/open/floor/almayer)
 -   call stack:
 - the ColMarTech Surplus Uniform... (/obj/structure/machinery/cm_vending/sorted/uniform_supply/squad_prep): redeem token(the M276 pattern ammo load rig (/obj/item/storage/belt/marine), William Henderson (/mob/living/carbon/human))
 - the ColMarTech Surplus Uniform... (/obj/structure/machinery/cm_vending/sorted/uniform_supply/squad_prep): attackby(the M276 pattern ammo load rig (/obj/item/storage/belt/marine), William Henderson (/mob/living/carbon/human), /list (/list))
 - the ColMarTech Surplus Uniform... (/obj/structure/machinery/cm_vending/sorted/uniform_supply/squad_prep): attackby(the M276 pattern ammo load rig (/obj/item/storage/belt/marine), William Henderson (/mob/living/carbon/human), /list (/list))
 - William Henderson (/mob/living/carbon/human): click adjacent(the ColMarTech Surplus Uniform... (/obj/structure/machinery/cm_vending/sorted/uniform_supply/squad_prep), the M276 pattern ammo load rig (/obj/item/storage/belt/marine), /list (/list))
 - William Henderson (/mob/living/carbon/human): do click(the ColMarTech Surplus Uniform... (/obj/structure/machinery/cm_vending/sorted/uniform_supply/squad_prep), the floor (185,73,3) (/turf/open/floor/almayer), "icon-x=1;icon-y=22;left=1;butt...")
 - ***** (/client): Click(the ColMarTech Surplus Uniform... (/obj/structure/machinery/cm_vending/sorted/uniform_supply/squad_prep), the floor (185,73,3) (/turf/open/floor/almayer), "mapwindow.map", "icon-x=1;icon-y=22;left=1;butt...")

```

# Explain why it's good for the game

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Fixes a runtime in vendors
/🆑
