### PR TITLE
Fiorina SciAnnex - Removes Janicart

### DIFF
--- a/maps/map_files/FOP_v3_Sciannex/Fiorina_SciAnnex.dmm
+++ b/maps/map_files/FOP_v3_Sciannex/Fiorina_SciAnnex.dmm
@@ -359,7 +359,9 @@
 	},
 /area/fiorina/station/research_cells)
 "akW" = (
-/obj/structure/bed/chair/janicart,
+/obj/structure/reagent_dispensers/watertank{
+	layer = 2.6
+	},
 /turf/open/floor/prison,
 /area/fiorina/station/medbay)
 "akZ" = (
@@ -70809,7 +70811,7 @@ fIT
 hVI
 mEO
 mEO
-ddD
+akW
 hVI
 lmn
 fkH
@@ -71021,7 +71023,7 @@ mEO
 sJu
 mEO
 mEO
-akW
+ddD
 hVI
 gZf
 bLM


### PR DESCRIPTION
# About the pull request

Removes the Janicart from Fiorina SciAnnex.

# Explain why it's good for the game

During Round 19787 I saw a marine in a Janicart towing a wheelchair behind him which he used to recover bodies and at least once towed a marine in a wheelchair at high speed while the marine was still fully capable of shooting.

While unlikely to ever happen, I don't exactly want to see the possibilities of something like a SADAR doing drive-bys on the Queen or T3s, or a Smartgunner rolling shooting up everything around at what appeared to be about the speed of a Runner, if you cannot shoot while buckled into a roller bed for example then I don't believe this should be allowed to stay.

_It also appears the Janicart may negate grabs? Or at least make it harder to grab whoever's driving it? Regardless it just feels overly cheesy._

# Changelog

:cl:
del: Removed Janicart from Fiorina SciAnnex
/:cl:

