### PR TITLE
Fix Nano Subsystem Init Error

### DIFF
--- a/code/controllers/subsystem/nanoui.dm
+++ b/code/controllers/subsystem/nanoui.dm
@@ -1,5 +1,6 @@
 SUBSYSTEM_DEF(nano)
 	name  = "Nano UI"
+	flags = SS_NO_INIT
 	wait  = 2 SECONDS
 	priority = SS_PRIORITY_NANOUI
 	runlevels = RUNLEVELS_DEFAULT|RUNLEVEL_LOBBY


### PR DESCRIPTION

# About the pull request

This PR fixes an unintended change made in #4940 where the flag for the nano subsystem was changed. If Initialize was used instead of New this change would be correct, but using New is intentional.

# Explain why it's good for the game

Fixes: `Initialized Nano UI subsystem with errors within 0 seconds!` and `[20:19:57]WARNING: Nano UI subsystem does not implement Initialize() or it returns ..(). If the former is true, the SS_NO_INIT flag should be set for this subsystem.`

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/cmss13-devs/cmss13/assets/76988376/5b32237a-cc7e-4bd6-95fc-1a3ac41c382b)

</details>


# Changelog
:cl: Drathek
fix: Fix some errors regarding the nano subystem
/:cl:
