### PR TITLE
Fix incorrect location name

### DIFF
--- a/code/game/area/almayer.dm
+++ b/code/game/area/almayer.dm
@@ -374,7 +374,7 @@
 	fake_zlevel = 2 // lowerdeck
 
 /area/almayer/hallways/aft_hallway
-	name = "\improper Upper Deck Aft Hallway"
+	name = "\improper Upper Deck Fore Hallway"
 	icon_state = "aft"
 	fake_zlevel = 1 // upperdeck
 


### PR DESCRIPTION

# About the pull request

From observing a dead chat death and seeing where the person is - this is not aft, it is fore. I don't know every place that this should be changed but, at least I'll fix the crew monitor and dead chat this way hopefully.

# Explain why it's good for the game

bug bad


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Upper Deck Aft location was wrong, it's actually fore.
/:cl:
