### PR TITLE
Fixes a freeze when opening the 'Create Object' panel

### DIFF
--- a/code/modules/admin/create_mob.dm
+++ b/code/modules/admin/create_mob.dm
@@ -8,4 +8,4 @@
 		create_mob_html = replacetext(create_mob_html, "null /* object types */", "\"[mobjs]\"")
 		create_mob_html = replacetext(create_mob_html, "/* href token */", RawHrefToken(forceGlobal = TRUE))
 
-	show_browser(user, replacetext(create_mob_html, "/* ref src */", "\ref[src]"), "Create Mob", "create_mob", "size=425x475")
+	show_browser(user, replacetext(create_mob_html, "/* ref src */", "\ref[src]"), "Create Mob", "create_mob", "size=450x525")

--- a/code/modules/admin/create_object.dm
+++ b/code/modules/admin/create_object.dm
@@ -8,7 +8,7 @@
 		create_object_html = replacetext(create_object_html, "null /* object types */", "\"[objectjs]\"")
 		create_object_html = replacetext(create_object_html, "/* href token */", RawHrefToken(forceGlobal = TRUE))
 
-	show_browser(user, replacetext(create_object_html, "/* ref src */", "\ref[src]"), "Create Object", "create_object", "size=425x475")
+	show_browser(user, replacetext(create_object_html, "/* ref src */", "\ref[src]"), "Create Object", "create_object", "size=450x525")
 
 
 /datum/admins/proc/quick_create_object(mob/user)
@@ -46,4 +46,4 @@
 		quick_create_object_html = replacetext(quick_create_object_html, "null /* object types */", "\"[objectjs]\"")
 		quick_create_object_html = replacetext(quick_create_object_html, "/* href token */", RawHrefToken(forceGlobal = TRUE))
 
-	show_browser(user, replacetext(quick_create_object_html, "/* ref src */", "\ref[src]"), "Quick Create Object", "quick_create_object", "size=425x475")
+	show_browser(user, replacetext(quick_create_object_html, "/* ref src */", "\ref[src]"), "Quick Create Object", "quick_create_object", "size=450x525")

--- a/code/modules/admin/create_turf.dm
+++ b/code/modules/admin/create_turf.dm
@@ -8,4 +8,4 @@
 		create_turf_html = replacetext(create_turf_html, "null /* object types */", "\"[turfjs]\"")
 		create_turf_html = replacetext(create_turf_html, "/* href token */", RawHrefToken(forceGlobal = TRUE))
 
-	show_browser(usr, replacetext(create_turf_html, "/* ref src */", "\ref[src]"), "Create Turf", "create_turf", "size=425x475")
+	show_browser(usr, replacetext(create_turf_html, "/* ref src */", "\ref[src]"), "Create Turf", "create_turf", "size=450x525")

--- a/html/create_object.html
+++ b/html/create_object.html
@@ -9,16 +9,17 @@
 	<form name="spawner" action="byond://?src=/* ref src */" method="get">
 		<input type="hidden" name="src" value="/* ref src */">
 		<input type="hidden" name="admin_token" value="/* href token */">
-		Type <input type="text" name="filter" value="" onkeypress="submitFirst(event)" style="width:350px"> <input
+		Type: <input type="text" name="filter" onkeypress="submitFirst(event)" style="width:350px"> <input
 			type="button" class="button" value="Search" onclick="updateSearch()" /><br>
-		Offset: <input type="text" name="offset" value="x,y,z" style="width:250px">
 
+		Offset: <input type="text" name="offset" value="x,y,z" style="width:250px">
 		A <input type="radio" class="radioButton" name="offset_type" value="absolute">
 		R <input type="radio" class="radioButton" name="offset_type" value="relative" checked="checked"><br>
 
 		Number: <input type="text" name="object_count" value="1" style="width:30px">
 		Dir: <input type="text" name="object_dir" value="2" style="width:30px">
-		Name: <input type="text" name="object_name" value="" style="width:180px"><br>
+		Name: <input type="text" name="object_name" style="width:180px"><br>
+
 		Where:
 		<select name='object_where' style="width:320px">
 			<option value='onfloor'>On floor below own mob</option>
@@ -26,6 +27,7 @@
 			<option value='inmarked'>In marked object</option>
 		</select>
 		<br><br>
+
 		<select name="object_list" size="18" multiple style="width:98%"></select><br>
 		<input type="submit" class="button" value="Spawn">
 	</form>
@@ -41,8 +43,7 @@
 		function populateList(from_list) {
 			object_list.options.length = 0;
 
-			var i;
-			for (i in from_list) {
+			for (var i in from_list) {
 				var new_option = document.createElement("option");
 				new_option.value = from_list[i];
 				new_option.text = from_list[i];
@@ -70,6 +71,7 @@
 				return false;
 			}
 
+			// Carriage return
 			if (event.keyCode == 13 || event.which == 13) {
 				object_list.options[0].selected = 'true';
 			}


### PR DESCRIPTION

# About the pull request

Removes the long freeze when opening the 'Create Object' interface through the game panel.
This was caused by line 40 of `create_object.html`, which attempts to fill the object list with every subtype of `/obj` when the interface is first opened. The "fix" was just removing that line.
https://github.com/cmss13-devs/cmss13/blob/0b133929724c569aff3945749c65559c4e65e4c5/html/create_object.html#L33-L42
This does mean that the user has to search for a type before anything shows up, but I would consider that a pretty minor trade-off.
<hr>

I also increased the window size so that the 'Spawn' button is on the screen by default, removed a couple of empty `value`s, and added some spaces so that the HTML code lines up a bit more with the final UI.

# Explain why it's good for the game

Fixes a 30ish second freeze for admins. (Give or take a bit, but it's still long either way.)

# Testing Photographs and Procedure
<details>
<summary>Videos</summary>

**Before:**

https://github.com/cmss13-devs/cmss13/assets/57483089/6d5d0aa7-74a9-4fbc-b78f-4bd6a960af87

**After:**

https://github.com/cmss13-devs/cmss13/assets/57483089/93fc0f99-41a5-4df6-9061-38740aa0e751

</details>


# Changelog
:cl:
admin: Fixed a freeze when opening the the 'Create Object' interface.
admin: Adjusted the size and positioning of the 'Create Object/Mob/Turf' panels so that everything fits into the window.
/:cl:
