### PR TITLE
Adds a fog gap for the CLF Insert on LV

### DIFF
--- a/html/changelogs/AutoChangeLog-pr-5110.yml
+++ b/html/changelogs/AutoChangeLog-pr-5110.yml
@@ -1,0 +1,4 @@
+author: "Tsurupeta"
+delete-after: True
+changes:
+  - bugfix: "fixed saving of certain preferences."

--- a/maps/map_files/LV624/standalone/clfship.dmm
+++ b/maps/map_files/LV624/standalone/clfship.dmm
@@ -119,6 +119,9 @@
 	icon_state = "platingdmg3"
 	},
 /area/lv624/lazarus/crashed_ship)
+"dw" = (
+/turf/open/gm/coast/north,
+/area/lv624/ground/river/west_river)
 "dN" = (
 /turf/open/floor/plating,
 /area/lv624/lazarus/crashed_ship)
@@ -147,10 +150,9 @@
 /obj/structure/largecrate/random/barrel/red,
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/south_west_caves)
-"eH" = (
-/obj/effect/landmark/lv624/fog_blocker,
-/turf/open/gm/coast/beachcorner2/north_west,
-/area/template_noop)
+"eS" = (
+/turf/open/gm/coast/beachcorner2/south_east,
+/area/lv624/ground/river/west_river)
 "eT" = (
 /turf/closed/shuttle/ert{
 	icon_state = "stan_inner_t_left"
@@ -174,6 +176,9 @@
 	icon_state = "bluecorner"
 	},
 /area/lv624/lazarus/crashed_ship)
+"fm" = (
+/turf/open/gm/coast/beachcorner2/north_west,
+/area/lv624/ground/river/west_river)
 "ft" = (
 /obj/item/stool,
 /turf/open/floor{
@@ -344,6 +349,10 @@
 	icon_state = "damaged3"
 	},
 /area/lv624/lazarus/crashed_ship)
+"iJ" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/gm/coast/beachcorner2/south_east,
+/area/lv624/ground/river/west_river)
 "jb" = (
 /obj/structure/largecrate/random/barrel/red,
 /turf/open/floor/almayer,
@@ -629,6 +638,9 @@
 	icon_state = "stan2"
 	},
 /area/lv624/lazarus/crashed_ship)
+"pt" = (
+/turf/open/gm/coast/south,
+/area/lv624/ground/river/west_river)
 "pK" = (
 /obj/structure/largecrate/random/barrel/white,
 /turf/open/floor/almayer,
@@ -670,6 +682,9 @@
 	icon_state = "platingdmg1"
 	},
 /area/lv624/lazarus/crashed_ship)
+"qW" = (
+/turf/open/gm/coast/beachcorner/north_west,
+/area/lv624/ground/river/west_river)
 "rf" = (
 /obj/item/ammo_casing/shell{
 	icon_state = "casing_7_1"
@@ -738,6 +753,10 @@
 /obj/structure/bed/chair,
 /turf/open/floor/wood,
 /area/lv624/lazarus/crashed_ship)
+"uc" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/gm/coast/west,
+/area/lv624/ground/river/west_river)
 "ug" = (
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor{
@@ -784,6 +803,9 @@
 	icon_state = "platingdmg1"
 	},
 /area/lv624/lazarus/crashed_ship)
+"vn" = (
+/turf/open/gm/coast/east,
+/area/lv624/ground/river/west_river)
 "vo" = (
 /turf/closed/shuttle/ert{
 	icon_state = "stan23"
@@ -1015,6 +1037,10 @@
 "Ar" = (
 /turf/open/floor/wood,
 /area/lv624/lazarus/crashed_ship)
+"Ax" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/gm/coast/beachcorner2/north_west,
+/area/lv624/ground/river/west_river)
 "AD" = (
 /obj/structure/bed,
 /obj/item/bedsheet/purple,
@@ -1314,6 +1340,10 @@
 "Hj" = (
 /turf/closed/wall/rock/brown,
 /area/lv624/ground/caves/south_west_caves)
+"Hq" = (
+/obj/structure/flora/bush/ausbushes/reedbush,
+/turf/open/gm/coast/beachcorner2/south_east,
+/area/lv624/ground/river/west_river)
 "HN" = (
 /turf/open/floor/almayer{
 	dir = 8;
@@ -1413,6 +1443,9 @@
 	icon_state = "stan_leftengine"
 	},
 /area/lv624/lazarus/crashed_ship)
+"Kr" = (
+/turf/open/gm/coast/beachcorner/south_east,
+/area/lv624/ground/river/west_river)
 "Kt" = (
 /turf/closed/shuttle/ert{
 	icon_state = "stan5"
@@ -1495,6 +1528,9 @@
 	icon_state = "bluecorner"
 	},
 /area/lv624/lazarus/crashed_ship)
+"MC" = (
+/turf/open/gm/coast/west,
+/area/lv624/ground/river/west_river)
 "MO" = (
 /obj/structure/machinery/light/small{
 	dir = 1;
@@ -1638,9 +1674,16 @@
 	icon_state = "orangecorner"
 	},
 /area/lv624/lazarus/crashed_ship)
-"Pi" = (
+"Pd" = (
+/obj/effect/landmark/lv624/fog_blocker,
 /turf/open/gm/coast/east,
-/area/template_noop)
+/area/lv624/ground/river/west_river)
+"Pl" = (
+/obj/effect/landmark/nightmare{
+	insert_tag = "clfship"
+	},
+/turf/closed/wall/rock/brown,
+/area/lv624/ground/caves/south_west_caves)
 "Pu" = (
 /obj/effect/landmark/corpsespawner/clf,
 /turf/open/floor{
@@ -2105,6 +2148,10 @@
 	opacity = 0
 	},
 /area/lv624/lazarus/crashed_ship)
+"YK" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/gm/river,
+/area/lv624/ground/river/west_river)
 "YX" = (
 /turf/open/floor/plating{
 	dir = 6;
@@ -2191,7 +2238,7 @@ Hj
 Hj
 Hj
 Hj
-OG
+Pl
 "}
 (2,1,1) = {"
 by
@@ -3412,8 +3459,8 @@ Yj
 Yj
 Yj
 Yj
-fC
-oU
+qW
+uc
 "}
 (28,1,1) = {"
 by
@@ -3459,8 +3506,8 @@ Yj
 Yj
 Yj
 Yj
-on
-CS
+dw
+YK
 "}
 (29,1,1) = {"
 by
@@ -3506,8 +3553,8 @@ Yj
 Yj
 Yj
 Yj
-on
-CS
+dw
+YK
 "}
 (30,1,1) = {"
 by
@@ -3552,9 +3599,9 @@ Yj
 Yj
 Yj
 Yj
-fC
-ev
-CS
+qW
+fm
+YK
 "}
 (31,1,1) = {"
 Hj
@@ -3599,9 +3646,9 @@ Yj
 Yj
 Yj
 Yj
-on
+dw
 Yj
-CS
+YK
 "}
 (32,1,1) = {"
 Hj
@@ -3644,11 +3691,11 @@ Yj
 Yj
 Yj
 Yj
-fC
-Fb
-ev
+qW
+MC
+fm
 Yj
-CS
+YK
 "}
 (33,1,1) = {"
 Hj
@@ -3691,11 +3738,11 @@ Yj
 Yj
 Yj
 Yj
-on
+dw
 Yj
 Yj
 Yj
-CS
+YK
 "}
 (34,1,1) = {"
 Hj
@@ -3738,11 +3785,11 @@ Yj
 Yj
 Yj
 Yj
-on
+dw
 Yj
 Yj
 Yj
-CS
+YK
 "}
 (35,1,1) = {"
 Hj
@@ -3785,11 +3832,11 @@ Yj
 Yj
 Yj
 Yj
-eH
+Ax
 Yj
 Yj
 Yj
-CS
+YK
 "}
 (36,1,1) = {"
 Hj
@@ -3832,11 +3879,11 @@ Yj
 Yj
 Yj
 Yj
-CS
+YK
 Yj
 Yj
 Yj
-CS
+YK
 "}
 (37,1,1) = {"
 Hj
@@ -3879,11 +3926,11 @@ Yj
 Yj
 Yj
 Yj
-CS
+YK
 Yj
 Yj
 Yj
-CS
+YK
 "}
 (38,1,1) = {"
 Hj
@@ -3926,11 +3973,11 @@ Yj
 Yj
 Yj
 Yj
-CS
+YK
 Yj
 Yj
 Yj
-UN
+iJ
 "}
 (39,1,1) = {"
 Hj
@@ -3973,11 +4020,11 @@ Yj
 Yj
 Yj
 Yj
-CS
+YK
 Yj
 Yj
 Yj
-BW
+pt
 "}
 (40,1,1) = {"
 Hj
@@ -4020,11 +4067,11 @@ Yj
 Yj
 Yj
 Yj
-CS
+YK
 Yj
 Yj
 Yj
-BW
+pt
 "}
 (41,1,1) = {"
 Hj
@@ -4067,11 +4114,11 @@ Yj
 Yj
 Yj
 Yj
-CS
+YK
 Yj
-aT
-Pi
-Um
+eS
+vn
+Kr
 "}
 (42,1,1) = {"
 Hj
@@ -4114,9 +4161,9 @@ Yj
 Yj
 Yj
 Yj
-CS
-Lt
-Um
+YK
+Hq
+Kr
 Yj
 Yj
 "}
@@ -4161,8 +4208,8 @@ Yj
 Yj
 Yj
 Yj
-CS
-BW
+YK
+pt
 Yj
 Yj
 Yj
@@ -4208,8 +4255,8 @@ Yj
 Yj
 Yj
 Yj
-kz
-Um
+Pd
+Kr
 Yj
 Yj
 Yj

--- a/maps/map_files/LV624/standalone/clfship.dmm
+++ b/maps/map_files/LV624/standalone/clfship.dmm
@@ -36,9 +36,6 @@
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/south_west_caves)
-"aT" = (
-/turf/open/gm/coast/beachcorner2/south_east,
-/area/template_noop)
 "aY" = (
 /obj/structure/tunnel{
 	id = "hole3"
@@ -133,9 +130,6 @@
 /obj/structure/surface/table/reinforced/prison,
 /turf/open/gm/dirt,
 /area/lv624/lazarus/crashed_ship)
-"ev" = (
-/turf/open/gm/coast/beachcorner2/north_west,
-/area/template_noop)
 "eD" = (
 /obj/structure/surface/table/woodentable,
 /obj/effect/spawner/random/toolbox,
@@ -196,9 +190,6 @@
 	icon_state = "bluecorner"
 	},
 /area/lv624/lazarus/crashed_ship)
-"fC" = (
-/turf/open/gm/coast/beachcorner/north_west,
-/area/template_noop)
 "fX" = (
 /obj/item/stool,
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
@@ -453,10 +444,6 @@
 	icon_state = "platingdmg1"
 	},
 /area/lv624/lazarus/crashed_ship)
-"kz" = (
-/obj/effect/landmark/lv624/fog_blocker,
-/turf/open/gm/coast/east,
-/area/template_noop)
 "kO" = (
 /obj/structure/bed,
 /obj/item/bedsheet/green,
@@ -595,9 +582,6 @@
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/plating,
 /area/lv624/lazarus/crashed_ship)
-"on" = (
-/turf/open/gm/coast/north,
-/area/template_noop)
 "ou" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor{
@@ -620,10 +604,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/lv624/lazarus/crashed_ship)
-"oU" = (
-/obj/effect/landmark/lv624/fog_blocker,
-/turf/open/gm/coast/west,
-/area/template_noop)
 "oW" = (
 /obj/structure/barricade/metal/wired{
 	dir = 4;
@@ -1101,9 +1081,6 @@
 	},
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/south_west_caves)
-"BW" = (
-/turf/open/gm/coast/south,
-/area/template_noop)
 "BY" = (
 /obj/structure/cargo_container/arious/leftmid,
 /turf/open/floor{
@@ -1142,10 +1119,6 @@
 	},
 /turf/open/gm/dirt,
 /area/lv624/lazarus/crashed_ship)
-"CS" = (
-/obj/effect/landmark/lv624/fog_blocker,
-/turf/open/gm/river,
-/area/template_noop)
 "CZ" = (
 /turf/open/floor/almayer{
 	dir = 4;
@@ -1289,9 +1262,6 @@
 	icon_state = "greencorner"
 	},
 /area/lv624/lazarus/crashed_ship)
-"Fb" = (
-/turf/open/gm/coast/west,
-/area/template_noop)
 "Gf" = (
 /obj/structure/barricade/metal/wired{
 	dir = 8;
@@ -1467,10 +1437,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/lv624/lazarus/crashed_ship)
-"Lt" = (
-/obj/structure/flora/bush/ausbushes/reedbush,
-/turf/open/gm/coast/beachcorner2/south_east,
-/area/template_noop)
 "LD" = (
 /obj/item/stack/rods,
 /turf/open/floor/plating{
@@ -1641,12 +1607,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/lv624/lazarus/crashed_ship)
-"OG" = (
-/obj/effect/landmark/nightmare{
-	insert_tag = "clfship"
-	},
-/turf/closed/wall/rock/brown,
-/area/lv624/ground/caves/south_west_caves)
 "OL" = (
 /obj/structure/machinery/vending/cigarette/colony,
 /turf/open/floor/plating/plating_catwalk,
@@ -1678,12 +1638,6 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/gm/coast/east,
 /area/lv624/ground/river/west_river)
-"Pl" = (
-/obj/effect/landmark/nightmare{
-	insert_tag = "clfship"
-	},
-/turf/closed/wall/rock/brown,
-/area/lv624/ground/caves/south_west_caves)
 "Pu" = (
 /obj/effect/landmark/corpsespawner/clf,
 /turf/open/floor{
@@ -1908,9 +1862,6 @@
 	icon_state = "emeraldcorner"
 	},
 /area/lv624/lazarus/crashed_ship)
-"Um" = (
-/turf/open/gm/coast/beachcorner/south_east,
-/area/template_noop)
 "Up" = (
 /obj/structure/surface/table/almayer,
 /obj/item/tank/oxygen/red,
@@ -1939,10 +1890,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/lv624/lazarus/crashed_ship)
-"UN" = (
-/obj/effect/landmark/lv624/fog_blocker,
-/turf/open/gm/coast/beachcorner2/south_east,
-/area/template_noop)
 "UV" = (
 /turf/open/floor{
 	icon_state = "platingdmg1"
@@ -2238,7 +2185,7 @@ Hj
 Hj
 Hj
 Hj
-Pl
+Hj
 "}
 (2,1,1) = {"
 by

--- a/maps/map_files/LV624/standalone/clfship.dmm
+++ b/maps/map_files/LV624/standalone/clfship.dmm
@@ -36,6 +36,9 @@
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/south_west_caves)
+"aT" = (
+/turf/open/gm/coast/beachcorner2/south_east,
+/area/template_noop)
 "aY" = (
 /obj/structure/tunnel{
 	id = "hole3"
@@ -127,6 +130,9 @@
 /obj/structure/surface/table/reinforced/prison,
 /turf/open/gm/dirt,
 /area/lv624/lazarus/crashed_ship)
+"ev" = (
+/turf/open/gm/coast/beachcorner2/north_west,
+/area/template_noop)
 "eD" = (
 /obj/structure/surface/table/woodentable,
 /obj/effect/spawner/random/toolbox,
@@ -141,6 +147,10 @@
 /obj/structure/largecrate/random/barrel/red,
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/south_west_caves)
+"eH" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/gm/coast/beachcorner2/north_west,
+/area/template_noop)
 "eT" = (
 /turf/closed/shuttle/ert{
 	icon_state = "stan_inner_t_left"
@@ -181,6 +191,9 @@
 	icon_state = "bluecorner"
 	},
 /area/lv624/lazarus/crashed_ship)
+"fC" = (
+/turf/open/gm/coast/beachcorner/north_west,
+/area/template_noop)
 "fX" = (
 /obj/item/stool,
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
@@ -431,6 +444,10 @@
 	icon_state = "platingdmg1"
 	},
 /area/lv624/lazarus/crashed_ship)
+"kz" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/gm/coast/east,
+/area/template_noop)
 "kO" = (
 /obj/structure/bed,
 /obj/item/bedsheet/green,
@@ -569,6 +586,9 @@
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf,
 /turf/open/floor/plating,
 /area/lv624/lazarus/crashed_ship)
+"on" = (
+/turf/open/gm/coast/north,
+/area/template_noop)
 "ou" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor{
@@ -591,6 +611,10 @@
 	icon_state = "platingdmg3"
 	},
 /area/lv624/lazarus/crashed_ship)
+"oU" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/gm/coast/west,
+/area/template_noop)
 "oW" = (
 /obj/structure/barricade/metal/wired{
 	dir = 4;
@@ -1051,6 +1075,9 @@
 	},
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/south_west_caves)
+"BW" = (
+/turf/open/gm/coast/south,
+/area/template_noop)
 "BY" = (
 /obj/structure/cargo_container/arious/leftmid,
 /turf/open/floor{
@@ -1089,6 +1116,10 @@
 	},
 /turf/open/gm/dirt,
 /area/lv624/lazarus/crashed_ship)
+"CS" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/gm/river,
+/area/template_noop)
 "CZ" = (
 /turf/open/floor/almayer{
 	dir = 4;
@@ -1232,6 +1263,9 @@
 	icon_state = "greencorner"
 	},
 /area/lv624/lazarus/crashed_ship)
+"Fb" = (
+/turf/open/gm/coast/west,
+/area/template_noop)
 "Gf" = (
 /obj/structure/barricade/metal/wired{
 	dir = 8;
@@ -1400,6 +1434,10 @@
 	icon_state = "platingdmg3"
 	},
 /area/lv624/lazarus/crashed_ship)
+"Lt" = (
+/obj/structure/flora/bush/ausbushes/reedbush,
+/turf/open/gm/coast/beachcorner2/south_east,
+/area/template_noop)
 "LD" = (
 /obj/item/stack/rods,
 /turf/open/floor/plating{
@@ -1567,6 +1605,12 @@
 	icon_state = "platingdmg3"
 	},
 /area/lv624/lazarus/crashed_ship)
+"OG" = (
+/obj/effect/landmark/nightmare{
+	insert_tag = "clfship"
+	},
+/turf/closed/wall/rock/brown,
+/area/lv624/ground/caves/south_west_caves)
 "OL" = (
 /obj/structure/machinery/vending/cigarette/colony,
 /turf/open/floor/plating/plating_catwalk,
@@ -1594,6 +1638,9 @@
 	icon_state = "orangecorner"
 	},
 /area/lv624/lazarus/crashed_ship)
+"Pi" = (
+/turf/open/gm/coast/east,
+/area/template_noop)
 "Pu" = (
 /obj/effect/landmark/corpsespawner/clf,
 /turf/open/floor{
@@ -1818,6 +1865,9 @@
 	icon_state = "emeraldcorner"
 	},
 /area/lv624/lazarus/crashed_ship)
+"Um" = (
+/turf/open/gm/coast/beachcorner/south_east,
+/area/template_noop)
 "Up" = (
 /obj/structure/surface/table/almayer,
 /obj/item/tank/oxygen/red,
@@ -1846,6 +1896,10 @@
 	icon_state = "platingdmg3"
 	},
 /area/lv624/lazarus/crashed_ship)
+"UN" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/gm/coast/beachcorner2/south_east,
+/area/template_noop)
 "UV" = (
 /turf/open/floor{
 	icon_state = "platingdmg1"
@@ -2137,7 +2191,7 @@ Hj
 Hj
 Hj
 Hj
-Hj
+OG
 "}
 (2,1,1) = {"
 by
@@ -3358,8 +3412,8 @@ Yj
 Yj
 Yj
 Yj
-Yj
-Yj
+fC
+oU
 "}
 (28,1,1) = {"
 by
@@ -3405,8 +3459,8 @@ Yj
 Yj
 Yj
 Yj
-Yj
-Yj
+on
+CS
 "}
 (29,1,1) = {"
 by
@@ -3452,8 +3506,8 @@ Yj
 Yj
 Yj
 Yj
-Yj
-Yj
+on
+CS
 "}
 (30,1,1) = {"
 by
@@ -3498,9 +3552,9 @@ Yj
 Yj
 Yj
 Yj
-Yj
-Yj
-Yj
+fC
+ev
+CS
 "}
 (31,1,1) = {"
 Hj
@@ -3545,9 +3599,9 @@ Yj
 Yj
 Yj
 Yj
+on
 Yj
-Yj
-Yj
+CS
 "}
 (32,1,1) = {"
 Hj
@@ -3590,11 +3644,11 @@ Yj
 Yj
 Yj
 Yj
+fC
+Fb
+ev
 Yj
-Yj
-Yj
-Yj
-Yj
+CS
 "}
 (33,1,1) = {"
 Hj
@@ -3637,11 +3691,11 @@ Yj
 Yj
 Yj
 Yj
+on
 Yj
 Yj
 Yj
-Yj
-Yj
+CS
 "}
 (34,1,1) = {"
 Hj
@@ -3684,11 +3738,11 @@ Yj
 Yj
 Yj
 Yj
+on
 Yj
 Yj
 Yj
-Yj
-Yj
+CS
 "}
 (35,1,1) = {"
 Hj
@@ -3731,11 +3785,11 @@ Yj
 Yj
 Yj
 Yj
+eH
 Yj
 Yj
 Yj
-Yj
-Yj
+CS
 "}
 (36,1,1) = {"
 Hj
@@ -3778,11 +3832,11 @@ Yj
 Yj
 Yj
 Yj
+CS
 Yj
 Yj
 Yj
-Yj
-Yj
+CS
 "}
 (37,1,1) = {"
 Hj
@@ -3825,11 +3879,11 @@ Yj
 Yj
 Yj
 Yj
+CS
 Yj
 Yj
 Yj
-Yj
-Yj
+CS
 "}
 (38,1,1) = {"
 Hj
@@ -3872,11 +3926,11 @@ Yj
 Yj
 Yj
 Yj
+CS
 Yj
 Yj
 Yj
-Yj
-Yj
+UN
 "}
 (39,1,1) = {"
 Hj
@@ -3919,11 +3973,11 @@ Yj
 Yj
 Yj
 Yj
+CS
 Yj
 Yj
 Yj
-Yj
-Yj
+BW
 "}
 (40,1,1) = {"
 Hj
@@ -3966,11 +4020,11 @@ Yj
 Yj
 Yj
 Yj
+CS
 Yj
 Yj
 Yj
-Yj
-Yj
+BW
 "}
 (41,1,1) = {"
 Hj
@@ -4013,11 +4067,11 @@ Yj
 Yj
 Yj
 Yj
+CS
 Yj
-Yj
-Yj
-Yj
-Yj
+aT
+Pi
+Um
 "}
 (42,1,1) = {"
 Hj
@@ -4060,9 +4114,9 @@ Yj
 Yj
 Yj
 Yj
-Yj
-Yj
-Yj
+CS
+Lt
+Um
 Yj
 Yj
 "}
@@ -4107,8 +4161,8 @@ Yj
 Yj
 Yj
 Yj
-Yj
-Yj
+CS
+BW
 Yj
 Yj
 Yj
@@ -4154,8 +4208,8 @@ Yj
 Yj
 Yj
 Yj
-Yj
-Yj
+kz
+Um
 Yj
 Yj
 Yj


### PR DESCRIPTION

# About the pull request

Adds a fog gap for the CLF LV Nightmare Insert

# Explain why it's good for the game

The CLF on LV having their ship spawn on the North side of the river and not getting RNG Jesus'd by having a fog gap nightmare insert spawn in, are basically doomed because they cannot hold their ship since it's too large and they can't hold anywhere outside it because it's wide open ground easy for xeno pickings. So giving them a small fog gap which in my opinion by the time the marines deploy will either not be noticed due to the fog dropping in general or be a gap for 3-4 minutes if they land early. I feel like this is a lakehouse situation but with the fog making it virtually impossible for the CLF to have a game unless the xenos let them survive, which to give them some credit they have done so. Not to mention that the insert is very rare so the gameplay balance side of it will not be so unbalanced towards one side. It is just giving the survs a chance and increasing their survivability from zero (I better not hear the usual "But surv is meant to be hard deal with it skill issue" If that's the case might aswell remove the insert like the lakehouse one.)


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
maptweak: tweaked the CLF nightmare insert map
/:cl:
