### PR TITLE
Nuke takes 3 minutes to explode

### DIFF
--- a/code/game/machinery/nuclearbomb.dm
+++ b/code/game/machinery/nuclearbomb.dm
@@ -445,7 +445,7 @@ var/bomb_set = FALSE
 	var/decryption_end_time = null
 	var/decrypting = FALSE
 
-	timeleft = 1 MINUTES
+	timeleft = 3 MINUTES
 	timer_announcements_flags = NUKE_DECRYPT_SHOW_TIMER_ALL
 
 	var/list/linked_decryption_towers


### PR DESCRIPTION

# About the pull request
Nuke takes 3 minutes to explode instead of 1.

# Explain why it's good for the game
Gives a better chance for xenos, makes it more interesting for marines, makes "pausing" the nuke more punishing since it resets the timer.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: ihatethisengine
balance: nuke takes 3 minutes to explode
/:cl:
