### PR TITLE
DEBUG: src.pulledby.pulling == src

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -9,6 +9,7 @@
 	var/throw_range = 7
 	var/cur_speed = MIN_SPEED // Current speed of an atom (account for speed when launched/thrown as well)
 	var/mob/pulledby = null
+	var/debug_pulledby_warned = FALSE
 	var/rebounds = FALSE
 	var/rebounding = FALSE // whether an object that was launched was rebounded (to prevent infinite recursive loops from wall bouncing)
 

--- a/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
@@ -766,7 +766,7 @@
 /mob/living/carbon/xenomorph/resist_grab(moving_resist)
 	if(!pulledby)
 		return
-	if(pulledby && pulledby?.pulling != pulledby && !debug_pulledby_warned)
+	if(pulledby && pulledby?.pulling != src && !debug_pulledby_warned)
 		debug_pulledby_warned = TRUE
 		debug_pulledby()
 	if(pulledby.grab_level)

--- a/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
@@ -766,6 +766,9 @@
 /mob/living/carbon/xenomorph/resist_grab(moving_resist)
 	if(!pulledby)
 		return
+	if(pulledby && pulledby?.pulling != pulledby && !debug_pulledby_warned)
+		debug_pulledby_warned = TRUE
+		debug_pulledby()
 	if(pulledby.grab_level)
 		visible_message(SPAN_DANGER("[src] has broken free of [pulledby]'s grip!"), null, null, 5)
 	pulledby.stop_pulling()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -215,6 +215,9 @@
 /mob/living/resist_grab(moving_resist)
 	if(!pulledby)
 		return
+	if(pulledby && pulledby?.pulling != pulledby && !debug_pulledby_warned)
+		debug_pulledby_warned = TRUE
+		debug_pulledby()
 	if(pulledby.grab_level)
 		if(prob(50))
 			playsound(src.loc, 'sound/weapons/thudswoosh.ogg', 25, 1, 7)
@@ -228,6 +231,8 @@
 		pulledby.stop_pulling()
 		return 1
 
+/mob/proc/debug_pulledby()
+	log_debug("PULLEDBY: Improper pulling relationship between pullee \[[src.name] (type:[src.type]) @ \ref[src]\] [ADMIN_VV(src)] and would-be puller \[[src.pulledby?.name] (type:[src.pulledby?.type]) @ \ref[src.pulledby]\] [ADMIN_VV(src.pulledby)]")
 
 /mob/living/movement_delay()
 	. = ..()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -215,7 +215,7 @@
 /mob/living/resist_grab(moving_resist)
 	if(!pulledby)
 		return
-	if(pulledby && pulledby?.pulling != pulledby && !debug_pulledby_warned)
+	if(pulledby && pulledby?.pulling != src && !debug_pulledby_warned)
 		debug_pulledby_warned = TRUE
 		debug_pulledby()
 	if(pulledby.grab_level)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -542,9 +542,9 @@
 			return
 	else if(istype(AM, /obj))
 		AM.add_fingerprint(src)
-
 	pulling = AM
 	AM.pulledby = src
+	AM.debug_pulledby_warned = FALSE
 
 	var/obj/item/grab/G = new /obj/item/grab()
 	G.grabbed_thing = AM


### PR DESCRIPTION
Live debug for an elusive and rare issue invalidating this relationship, apparently causing some people to render warriors unable to keep grabs on things. Possibly affects all forms of grabbing, this debug also aims at determining that.

It's very rare and as of now we can't pinpoint the location so hoping this gives some more insight into how this is triggered to fix it...