### PR TITLE
Boiler can fire globs through membranes!

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
@@ -787,9 +787,20 @@
 	spitting = FALSE
 
 	SEND_SIGNAL(xeno, COMSIG_XENO_POST_SPIT)
-
+	if(xeno.ammo.spit_windup)
+		RegisterSignal(proj, COMSIG_BULLET_PRE_HANDLE_TURF, PROC_REF(xeno_spit_check_turf))
 	apply_cooldown()
 	return ..()
+
+/datum/action/xeno_action/activable/xeno_spit/proc/xeno_spit_check_turf(obj/projectile/projectile, turf/turf)
+	SIGNAL_HANDLER
+	if(!istype(turf, /turf/closed/wall/resin/membrane) || !istype(projectile.ammo, /datum/ammo/xeno/boiler_gas))
+		return
+	var/turf/closed/wall/resin/membrane/membrane = turf
+	xeno_announcement(SPAN_XENOANNOUNCE("TEST"), membrane.hivenumber, XENO_GENERAL_ANNOUNCE)
+	if(membrane.can_bombard(projectile.firer))
+		xeno_announcement(SPAN_XENOANNOUNCE("TEST4"), membrane.hivenumber, XENO_GENERAL_ANNOUNCE)
+		return COMPONENT_BULLET_PASS_THROUGH
 
 /datum/action/xeno_action/activable/bombard/use_ability(atom/A)
 	var/mob/living/carbon/xenomorph/X = owner


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request
Yeah, you can fire through (friendly) membranes just like before!

# Explain why it's good for the game
It's probably not, but I thought it would be pretty cool. Membranes are useful again I guess.

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

https://github.com/cmss13-devs/cmss13/assets/115417687/e3ab7b6a-6873-46cf-9e89-03bbb0461b33


Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl: ihatethisengine
balance: boiler glob can be fired through membranes again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
