### PR TITLE
PO can remove queens override again, bit by bit edition

### DIFF
--- a/code/modules/shuttle/computers/dropship_computer.dm
+++ b/code/modules/shuttle/computers/dropship_computer.dm
@@ -146,7 +146,7 @@
 
 	if(dropship_control_lost)
 		var/remaining_time = timeleft(door_control_cooldown) / 10
-		to_chat(user, SPAN_WARNING("The shuttle is not responding due to an unauthorazed access attempt, the system will automatically remove the lockout in about [remaining_time] seconds."))
+		to_chat(user, SPAN_WARNING("The shuttle is not responding due to an unauthorazed access attempt, a large lockout timers reads that the lockout will be automatically removed in [remaining_time] seconds."))
 		if(!skillcheck(user, SKILL_PILOT, SKILL_PILOT_EXPERT))
 			return
 		if(user.action_busy || override_being_removed)
@@ -163,7 +163,7 @@
 				break
 			remaining_time = timeleft(door_control_cooldown) / 10 - 20
 			if(remaining_time > 0)
-				to_chat(user, SPAN_NOTICE("You partly remove the lockout, about [remaining_time] seconds left."))
+				to_chat(user, SPAN_NOTICE("You partly remove the lockout, only [remaining_time] seconds left."))
 				door_control_cooldown = addtimer(CALLBACK(src, PROC_REF(remove_door_lock)), remaining_time SECONDS, TIMER_STOPPABLE|TIMER_UNIQUE|TIMER_OVERRIDE|TIMER_NO_HASH_WAIT)
 	override_being_removed = FALSE
 	if(dropship_control_lost)

--- a/code/modules/shuttle/computers/dropship_computer.dm
+++ b/code/modules/shuttle/computers/dropship_computer.dm
@@ -146,7 +146,7 @@
 
 	if(dropship_control_lost)
 		var/remaining_time = timeleft(door_control_cooldown) / 10
-		to_chat(user, SPAN_WARNING("The shuttle is not responding due to an unauthorazed access attempt, a large lockout timers reads that the lockout will be automatically removed in [remaining_time] seconds."))
+		to_chat(user, SPAN_WARNING("The shuttle is not responding due to an unauthorized access attempt. In large text it says the lockout will be automatically removed in [remaining_time] seconds."))
 		if(!skillcheck(user, SKILL_PILOT, SKILL_PILOT_EXPERT))
 			return
 		if(user.action_busy || override_being_removed)

--- a/code/modules/shuttle/computers/dropship_computer.dm
+++ b/code/modules/shuttle/computers/dropship_computer.dm
@@ -143,21 +143,21 @@
 		to_chat(user, SPAN_NOTICE("\The [src] is not responsive"))
 		return
 	var/remaining_time = timeleft(door_control_cooldown) / 10
-	if(remaining_time > 60)
-		to_chat(user, SPAN_WARNING("The shuttle is not responding, try again in [remaining_time] seconds."))
+	to_chat(user, SPAN_WARNING("The shuttle is not responding, try again in [remaining_time] seconds."))
 	if(dropship_control_lost && skillcheck(user, SKILL_PILOT, SKILL_PILOT_EXPERT))
 		to_chat(user, SPAN_NOTICE("You start to remove the Queens override."))
 		if(do_after(user, 20 SECONDS, INTERRUPT_ALL, BUSY_ICON_HOSTILE))
 			remaining_time = timeleft(door_control_cooldown) / 10 - 20
 			if(remaining_time > 0)
-				to_chat(user, SPAN_WARNING("You partly remove the Queens override, only [remaining_time] seconds left."))
-				door_control_cooldown = addtimer(CALLBACK(src, PROC_REF(remove_door_lock)), remaining_time SECONDS, TIMER_STOPPABLE|TIMER_UNIQUE|TIMER_DELETE_ME|TIMER_OVERRIDE)
+				to_chat(user, SPAN_NOTICE("You partly remove the Queens override, only [remaining_time] seconds left."))
+				door_control_cooldown = addtimer(CALLBACK(src, PROC_REF(remove_door_lock)), remaining_time SECONDS, TIMER_STOPPABLE|TIMER_UNIQUE|TIMER_OVERRIDE|TIMER_NO_HASH_WAIT)
 				return
 		else
-			to_chat(user, SPAN_WARNING("You fail to remove the Queens override"))
+			to_chat(user, SPAN_WARNING("You fail to remove the Queens override!"))
 			return
 		if(dropship_control_lost)
 			remove_door_lock()
+		to_chat(user, SPAN_NOTICE("You succesfully removed the Queens override!"))
 		playsound(loc, 'sound/machines/terminal_success.ogg', KEYBOARD_SOUND_VOLUME, 1)
 
 	if(!shuttle.is_hijacked)
@@ -222,7 +222,7 @@
 	if(!dropship_control_lost)
 		dropship.control_doors("unlock", "all", TRUE)
 		dropship_control_lost = TRUE
-		door_control_cooldown = addtimer(CALLBACK(src, PROC_REF(remove_door_lock)), SHUTTLE_LOCK_COOLDOWN, TIMER_STOPPABLE|TIMER_UNIQUE|TIMER_DELETE_ME|TIMER_OVERRIDE)
+		door_control_cooldown = addtimer(CALLBACK(src, PROC_REF(remove_door_lock)), SHUTTLE_LOCK_COOLDOWN, TIMER_STOPPABLE|TIMER_UNIQUE|TIMER_OVERRIDE|TIMER_NO_HASH_WAIT)
 		if(GLOB.almayer_orbital_cannon)
 			GLOB.almayer_orbital_cannon.is_disabled = TRUE
 			addtimer(CALLBACK(GLOB.almayer_orbital_cannon, TYPE_PROC_REF(/obj/structure/orbital_cannon, enable)), 10 MINUTES, TIMER_UNIQUE)
@@ -305,6 +305,7 @@
 	playsound(loc, 'sound/machines/terminal_success.ogg', KEYBOARD_SOUND_VOLUME, 1)
 	dropship_control_lost = FALSE
 	if(door_control_cooldown)
+		deltimer(door_control_cooldown)
 		door_control_cooldown = null
 
 /obj/structure/machinery/computer/shuttle/dropship/flight/ui_data(mob/user)

--- a/code/modules/shuttle/computers/dropship_computer.dm
+++ b/code/modules/shuttle/computers/dropship_computer.dm
@@ -7,6 +7,7 @@
 	unacidable = TRUE
 	exproof = TRUE
 	needs_power = FALSE
+	var/override_being_removed = FALSE
 
 	// Admin disabled
 	var/disabled = FALSE
@@ -148,12 +149,14 @@
 		to_chat(user, SPAN_WARNING("The shuttle is not responding due to the Queen's override, the system will automatically remove the override in about [remaining_time] seconds."))
 		if(!skillcheck(user, SKILL_PILOT, SKILL_PILOT_EXPERT))
 			return
-		if(user.action_busy)
+		if(user.action_busy || override_being_removed)
 			return
 		to_chat(user, SPAN_NOTICE("You start to remove the Queen's override."))
+		override_being_removed = TRUE
 		for(var/i in 1 to n_ceil(remaining_time/40))
 			if(!do_after(user, 20 SECONDS, INTERRUPT_ALL, BUSY_ICON_HOSTILE))
 				to_chat(user, SPAN_WARNING("You fail to remove the Queen's override!"))
+				override_being_removed = FALSE
 				return
 			if(!dropship_control_lost)
 				to_chat(user, SPAN_NOTICE("The Queen's override is already removed."))
@@ -164,7 +167,7 @@
 				door_control_cooldown = addtimer(CALLBACK(src, PROC_REF(remove_door_lock)), remaining_time SECONDS, TIMER_STOPPABLE|TIMER_UNIQUE|TIMER_OVERRIDE|TIMER_NO_HASH_WAIT)
 			else
 				break
-
+	override_being_removed = FALSE
 	if(dropship_control_lost)
 		remove_door_lock()
 		to_chat(user, SPAN_NOTICE("You succesfully removed the Queen's override!"))

--- a/code/modules/shuttle/computers/dropship_computer.dm
+++ b/code/modules/shuttle/computers/dropship_computer.dm
@@ -146,29 +146,29 @@
 
 	if(dropship_control_lost)
 		var/remaining_time = timeleft(door_control_cooldown) / 10
-		to_chat(user, SPAN_WARNING("The shuttle is not responding due to the Queen's override, the system will automatically remove the override in about [remaining_time] seconds."))
+		to_chat(user, SPAN_WARNING("The shuttle is not responding due to an unauthorazed access attempt, the system will automatically remove the lockout in about [remaining_time] seconds."))
 		if(!skillcheck(user, SKILL_PILOT, SKILL_PILOT_EXPERT))
 			return
 		if(user.action_busy || override_being_removed)
 			return
-		to_chat(user, SPAN_NOTICE("You start to remove the Queen's override."))
+		to_chat(user, SPAN_NOTICE("You start to remove the lockout."))
 		override_being_removed = TRUE
 		while(remaining_time > 20)
 			if(!do_after(user, 20 SECONDS, INTERRUPT_ALL, BUSY_ICON_HOSTILE))
-				to_chat(user, SPAN_WARNING("You fail to remove the Queen's override!"))
+				to_chat(user, SPAN_WARNING("You fail to remove the lockout!"))
 				override_being_removed = FALSE
 				return
 			if(!dropship_control_lost)
-				to_chat(user, SPAN_NOTICE("The Queen's override is already removed."))
+				to_chat(user, SPAN_NOTICE("The lockout is already removed."))
 				break
 			remaining_time = timeleft(door_control_cooldown) / 10 - 20
 			if(remaining_time > 0)
-				to_chat(user, SPAN_NOTICE("You partly remove the Queen's override, about [remaining_time] seconds left."))
+				to_chat(user, SPAN_NOTICE("You partly remove the lockout, about [remaining_time] seconds left."))
 				door_control_cooldown = addtimer(CALLBACK(src, PROC_REF(remove_door_lock)), remaining_time SECONDS, TIMER_STOPPABLE|TIMER_UNIQUE|TIMER_OVERRIDE|TIMER_NO_HASH_WAIT)
 	override_being_removed = FALSE
 	if(dropship_control_lost)
 		remove_door_lock()
-		to_chat(user, SPAN_NOTICE("You succesfully removed the Queen's override!"))
+		to_chat(user, SPAN_NOTICE("You succesfully removed the lockout!"))
 		playsound(loc, 'sound/machines/terminal_success.ogg', KEYBOARD_SOUND_VOLUME, 1)
 
 	if(!shuttle.is_hijacked)

--- a/code/modules/shuttle/computers/dropship_computer.dm
+++ b/code/modules/shuttle/computers/dropship_computer.dm
@@ -154,7 +154,7 @@
 		to_chat(user, SPAN_NOTICE("You start to remove the lockout."))
 		override_being_removed = TRUE
 		while(remaining_time > 20)
-			if(!do_after(user, 20 SECONDS, INTERRUPT_ALL, BUSY_ICON_HOSTILE, numticks = 20))
+			if(!do_after(user, 20 SECONDS, INTERRUPT_ALL|INTERRUPT_CHANGED_LYING, BUSY_ICON_HOSTILE, numticks = 20))
 				to_chat(user, SPAN_WARNING("You fail to remove the lockout!"))
 				override_being_removed = FALSE
 				return

--- a/code/modules/shuttle/computers/dropship_computer.dm
+++ b/code/modules/shuttle/computers/dropship_computer.dm
@@ -154,7 +154,7 @@
 		to_chat(user, SPAN_NOTICE("You start to remove the lockout."))
 		override_being_removed = TRUE
 		while(remaining_time > 20)
-			if(!do_after(user, 20 SECONDS, INTERRUPT_ALL, BUSY_ICON_HOSTILE))
+			if(!do_after(user, 20 SECONDS, INTERRUPT_ALL, BUSY_ICON_HOSTILE, numticks = 20))
 				to_chat(user, SPAN_WARNING("You fail to remove the lockout!"))
 				override_being_removed = FALSE
 				return

--- a/code/modules/shuttle/computers/dropship_computer.dm
+++ b/code/modules/shuttle/computers/dropship_computer.dm
@@ -153,7 +153,7 @@
 			return
 		to_chat(user, SPAN_NOTICE("You start to remove the Queen's override."))
 		override_being_removed = TRUE
-		for(var/i in 1 to n_ceil(remaining_time/40))
+		while(remaining_time > 0)
 			if(!do_after(user, 20 SECONDS, INTERRUPT_ALL, BUSY_ICON_HOSTILE))
 				to_chat(user, SPAN_WARNING("You fail to remove the Queen's override!"))
 				override_being_removed = FALSE
@@ -165,8 +165,6 @@
 			if(remaining_time > 0)
 				to_chat(user, SPAN_NOTICE("You partly remove the Queen's override, about [remaining_time] seconds left."))
 				door_control_cooldown = addtimer(CALLBACK(src, PROC_REF(remove_door_lock)), remaining_time SECONDS, TIMER_STOPPABLE|TIMER_UNIQUE|TIMER_OVERRIDE|TIMER_NO_HASH_WAIT)
-			else
-				break
 	override_being_removed = FALSE
 	if(dropship_control_lost)
 		remove_door_lock()

--- a/code/modules/shuttle/computers/dropship_computer.dm
+++ b/code/modules/shuttle/computers/dropship_computer.dm
@@ -163,7 +163,7 @@
 				break
 			remaining_time = timeleft(door_control_cooldown) / 10 - 20
 			if(remaining_time > 0)
-				to_chat(user, SPAN_NOTICE("You partly remove the lockout, only [remaining_time] seconds left."))
+				to_chat(user, SPAN_NOTICE("You partially bypass the lockout, only [remaining_time] seconds left."))
 				door_control_cooldown = addtimer(CALLBACK(src, PROC_REF(remove_door_lock)), remaining_time SECONDS, TIMER_STOPPABLE|TIMER_UNIQUE|TIMER_OVERRIDE|TIMER_NO_HASH_WAIT)
 	override_being_removed = FALSE
 	if(dropship_control_lost)

--- a/code/modules/shuttle/computers/dropship_computer.dm
+++ b/code/modules/shuttle/computers/dropship_computer.dm
@@ -153,7 +153,7 @@
 			return
 		to_chat(user, SPAN_NOTICE("You start to remove the Queen's override."))
 		override_being_removed = TRUE
-		while(remaining_time > 0)
+		while(remaining_time > 20)
 			if(!do_after(user, 20 SECONDS, INTERRUPT_ALL, BUSY_ICON_HOSTILE))
 				to_chat(user, SPAN_WARNING("You fail to remove the Queen's override!"))
 				override_being_removed = FALSE


### PR DESCRIPTION

# About the pull request
PO can perform a 20 seconds do_after to remove additional 20 seconds of the lockdown.

# Explain why it's good for the game
You used to be able to remove lockdown completely if you perform a 3 minutes do_after, but it was lost during the port to new shuttle system. Now it's back in another, better form! Gives marines a chance to remove lockdown sooner if they control the cockpit. In best case scenario you can remove the lock in 5 minutes.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: ihatethisengine
balance: PO can remove queens dropship override again.
/:cl:
