### PR TITLE
smartpistol buff, removes AP gives higher damage

### DIFF
--- a/code/datums/ammo/bullet/pistol.dm
+++ b/code/datums/ammo/bullet/pistol.dm
@@ -259,7 +259,7 @@
 	flags_ammo_behavior = AMMO_BALLISTIC
 
 	accuracy = HIT_ACCURACY_TIER_8
-	damage = 30
-	penetration = 20
+	damage = 40
+	penetration = 5
 	shrapnel_chance = SHRAPNEL_CHANCE_TIER_2
 


### PR DESCRIPTION

# About the pull request

increases raw damage from the smartpistol, lowers its armor piercing value

# Explain why it's good for the game

as it currently stands, su-6 is a pistol meant for backliners to protect their patients or people they are defending. 
it has way too low damage to handle frontline castes but enough armor piercing for it, if it had higher damage
it has way too low damage to handle backline castes, but armor piercing is useless for it
i take it as: 
MOD88 should be used for AP, frontline
M4A3 is a good inbetween, hollowpoint and standard magazines makes it a specialized weapon
VP78 is in a rough spot, but as of right now it is a close range, frontline, armor piercing pistol

smartpistol does not have any place, i want to see if this will help the people using it without severely impacting the game


# Testing Photographs and Procedure
its a number change

</details>


# Changelog

:cl: stalkerino
balance:  gives smartpistol 40 dmg, lowers its AP to 5
/:cl:
