### PR TITLE
remove a tgs chat command warning, change tgs round restart order

### DIFF
--- a/code/__HELPERS/chat.dm
+++ b/code/__HELPERS/chat.dm
@@ -1,11 +1,12 @@
 /**
- * Sends a message to TGS chat channels.
+ * Asynchronously sends a message to TGS chat channels.
  *
- * message - The message to send.
+ * message - The [/datum/tgs_message_content] to send.
  * channel_tag - Required. If "", the message with be sent to all connected (Game-type for TGS3) channels. Otherwise, it will be sent to TGS4 channels with that tag (Delimited by ','s).
  * admin_only - Determines if this communication can only be sent to admin only channels.
  */
-/proc/send2chat(message, channel_tag, admin_only = FALSE)
+/proc/send2chat(datum/tgs_message_content/message, channel_tag, admin_only = FALSE)
+	set waitfor = FALSE
 	if(channel_tag == null || !world.TgsAvailable())
 		return
 

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -61,6 +61,11 @@ SUBSYSTEM_DEF(mapping)
 		if(MC.perf_mode)
 			GLOB.perf_flags |= MC.perf_mode
 
+	if(configs[GROUND_MAP])
+		send2chat(new /datum/tgs_message_content("<@&[CONFIG_GET(string/new_round_alert_role_id)]> Round restarted! Map is [configs[GROUND_MAP].map_name]"), CONFIG_GET(string/new_round_alert_channel))
+	else
+		send2chat(new /datum/tgs_message_content("<@&[CONFIG_GET(string/new_round_alert_role_id)]> Round started!"), CONFIG_GET(string/new_round_alert_channel))
+
 	return SS_INIT_SUCCESS
 
 /datum/controller/subsystem/mapping/proc/wipe_reservations(wipe_safety_delay = 100)

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -247,16 +247,13 @@ GLOBAL_LIST_INIT(reboot_sfx, file2list("config/reboot_sfx.txt"))
 		shutdown()
 
 /world/proc/send_tgs_restart()
-	if(CONFIG_GET(string/new_round_alert_channel) && CONFIG_GET(string/new_round_alert_role_id))
-		if(GLOB.round_statistics)
-			send2chat("[GLOB.round_statistics.round_name][GLOB.round_id ? " (Round [GLOB.round_id])" : ""] completed!", CONFIG_GET(string/new_round_alert_channel))
-		if(SSmapping.next_map_configs)
-			var/datum/map_config/next_map = SSmapping.next_map_configs[GROUND_MAP]
-			if(next_map)
-				send2chat("<@&[CONFIG_GET(string/new_round_alert_role_id)]> Restarting! Next map is [next_map.map_name]", CONFIG_GET(string/new_round_alert_channel))
-		else
-			send2chat("<@&[CONFIG_GET(string/new_round_alert_role_id)]> Restarting!", CONFIG_GET(string/new_round_alert_channel))
-	return
+	if(!CONFIG_GET(string/new_round_alert_channel))
+		return
+
+	if(!GLOB.round_statistics)
+		return
+
+	send2chat(new /datum/tgs_message_content("[GLOB.round_statistics.round_name][GLOB.round_id ? " (Round [GLOB.round_id])" : ""] completed!"), CONFIG_GET(string/new_round_alert_channel))
 
 /world/proc/send_reboot_sound()
 	var/reboot_sound = SAFEPICK(GLOB.reboot_sfx)

--- a/code/modules/admin/chat_commands.dm
+++ b/code/modules/admin/chat_commands.dm
@@ -8,7 +8,7 @@
 /datum/tgs_chat_command/sdql/Run(datum/tgs_chat_user/sender, params)
 	var/list/results = HandleUserlessSDQL(sender.friendly_name, params)
 	if(!results)
-		return "Query produced no output"
+		return new /datum/tgs_message_content("Query produced no output")
 	var/list/text_res = results.Copy(1, 3)
 	var/list/refs = length(results) > 3 ? results.Copy(4) : null
-	return "[text_res.Join("\n")][refs ? "\nRefs: [refs.Join(" ")]" : ""]"
+	return new /datum/tgs_message_content("[text_res.Join("\n")][refs ? "\nRefs: [refs.Join(" ")]" : ""]")


### PR DESCRIPTION
![CleanShot 2023-12-06 at 18 36 34@2x](https://github.com/cmss13-devs/cmss13/assets/55142896/22115e45-568c-4ea9-aef4-28111b93e57a)

removes this tgs warning

moves the restart notification to when a new round initialises instead of the end of the last round 