### PR TITLE
Weeds on destroyed non resin walls now delete as previously

### DIFF
--- a/code/game/turfs/walls/walls.dm
+++ b/code/game/turfs/walls/walls.dm
@@ -88,6 +88,8 @@
 			if(istype(found_object, /obj/structure/sign/poster))
 				var/obj/structure/sign/poster/found_poster = found_object
 				found_poster.roll_and_drop(src)
+			if(istype(found_object, /obj/effect/alien/weeds/weedwall))
+				qdel(found_object)
 
 		var/list/turf/cardinal_neighbors = list(get_step(src, NORTH), get_step(src, SOUTH), get_step(src, EAST), get_step(src, WEST))
 		for(var/turf/cardinal_turf as anything in cardinal_neighbors)


### PR DESCRIPTION

# About the pull request

#5096 left "weed walls" behind when non resin walls are destroyed. This reintroduces the check but narrows it to only `/obj/effect/alien/weeds/weedwall` so normal "floor weeds" are still unaffected. But "wall weeds" will die...

Fixes #5135 

# Explain why it's good for the game
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Wall weeds now destroyed when closed wall turfs are changed.
/:cl:
