### PR TITLE
Fixes Warrior Pulls breaking in future when lunging a M56D/M2C user from front

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/Warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Warrior.dm
@@ -96,7 +96,8 @@
 		if(should_neckgrab && living_mob.mob_size < MOB_SIZE_BIG)
 			living_mob.drop_held_items()
 			living_mob.apply_effect(get_xeno_stun_duration(living_mob, 2), WEAKEN)
-			living_mob.pulledby = src
+			if(living_mob.pulledby != src)
+				return // Garb was broken, probably as Stun sideeffect (eg. target getting knocked away from a manned M56D)
 			visible_message(SPAN_XENOWARNING("[src] grabs [living_mob] by the throat!"), \
 			SPAN_XENOWARNING("You grab [living_mob] by the throat!"))
 			lunging = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

So that one took a lot of debugging...

To keep it as short as possible, when you lunge a M56D/M2C user from front as Warrior, they get stunned. The stun cancels their HMG interaction, causing them to step away. This means they leave the grab range, breaking it. Warrior code incorrectly re-sets pulledby, resulting in a mob "pulledby" one that doesn't pull it.

In practice once this happens, this means that the "incorrectly" pulled mob will reset any active grabs from the Warrior when it moves. Negating the use of lunges completely.


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: Fixed a logic error in Warrior code causing lunging some M2C/M56D users to semi-permanently brick lunge.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
