### PR TITLE
Balloon Alerts for Gun Safety

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -1538,6 +1538,7 @@ not all weapons use normal magazines etc. load_into_chamber() itself is designed
 
 		if(flags_gun_features & GUN_TRIGGER_SAFETY)
 			to_chat(user, SPAN_WARNING("The safety is on!"))
+			gun_user.balloon_alert(gun_user, "safety on")
 			return
 		if(active_attachable)
 			if(active_attachable.flags_attach_features & ATTACH_PROJECTILE)
@@ -1933,8 +1934,8 @@ not all weapons use normal magazines etc. load_into_chamber() itself is designed
 
 	if(gun_user.client?.prefs?.toggle_prefs & TOGGLE_HELP_INTENT_SAFETY && (gun_user.a_intent == INTENT_HELP))
 		if(world.time % 3) // Limits how often this message pops up, saw this somewhere else and thought it was clever
-			//Absolutely SCREAM this at people so they don't get killed by it
-			to_chat(gun_user, SPAN_HIGHDANGER("Help intent safety is on! Switch to another intent to fire your weapon."))
+			to_chat(gun_user, SPAN_DANGER("Help intent safety is on! Switch to another intent to fire your weapon."))
+			gun_user.balloon_alert(gun_user, "help intent safety")
 			click_empty(gun_user)
 		return FALSE
 


### PR DESCRIPTION
# About the pull request
When attempting to shoot a gun while safety is on (either the gun safety itself or triggering help intent safety) you'll get a balloon alert informing you.
help intent safety is on (will be in lowercase):
![image](https://github.com/cmss13-devs/cmss13/assets/54422837/1942e2ae-546b-4ab3-814f-2ef0e425544d)
gun safety toggled on:
![image](https://github.com/cmss13-devs/cmss13/assets/54422837/631db7b8-c266-42f5-a322-6d80882b86e1)

also decreases the size of the "Help intent safety is on! Switch to another intent to fire your weapon." message to normal size.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

Reading chat when you're (presumably) in the middle of trying to shoot at a xeno is quite hard, having it as a balloon alert allows you to quickly realize what's happening. 

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
qol: Gun safety messages now use balloon alerts.
/:cl:
