### PR TITLE
Zerker cannot use eviscerate below 5 rage

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/ravager/ravager_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/ravager/ravager_abilities.dm
@@ -100,12 +100,11 @@
 	xeno_cooldown = 23 SECONDS
 
 	// Config values
-	var/activation_delay = 20
+	var/activation_delay = 1 SECONDS
 
 	var/base_damage = 25
-	var/damage_at_rage_levels = list(5, 10, 25, 45, 70)
-	var/range_at_rage_levels = list(1, 1, 1, 2, 2)
-	var/windup_reduction_at_rage_levels = list(0, 2, 4, 6, 10)
+	var/eviscerate_damage = 70
+	var/eviscerate_range = 2
 
 
 ////// HEDGEHOG ABILITIES


### PR DESCRIPTION
# About the pull request
Zerker cannot use eviscerate below 5 rage

# Explain why it's good for the game
While the idea of an ability scaling with your rage sounds pretty cool, in practice there is never a reason to use eviscerate below 5 rage. It's just suboptimal. You just put yourself into more risk standing still for two seconds and gain basically nothing, while in these 2 seconds you could easily get enough stacks to actually do something. The only reason people use eviscerate below 5 rage is misclick. 


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>
I tested it fr fr

</details>


# Changelog
:cl: ihatethisengine
qol: berserker ravager can use eviscerate only at maximum rage stacks.
balance: berserker eviscerate now has a flat 2 range, flat 70 damage, and flat wind-up speed of 1 second.
/:cl:
