### PR TITLE
fixes is_interior(), fixing xeno construction on dropships during transport

### DIFF
--- a/code/controllers/subsystem/interior.dm
+++ b/code/controllers/subsystem/interior.dm
@@ -51,10 +51,16 @@ SUBSYSTEM_DEF(interior)
 	if(!isturf(loc))
 		loc = get_turf(loc)
 
-	var/datum/weakref/reservation = SSmapping.used_turfs[loc]
+	var/datum/weakref/reservation_weakref = SSmapping.used_turfs[loc]
+
+	if(!reservation_weakref)
+		return
+
+	var/datum/turf_reservation/interior/reservation = reservation_weakref.resolve()
 
 	if(!istype(reservation))
 		return FALSE
+
 	return TRUE
 
 #undef INTERIOR_BORDER_SIZE


### PR DESCRIPTION
huh? how'd this not get reported?

:cl:
fix: xenos can construct in dropships during transport again
/:cl: