### PR TITLE
Makes the enter key submit a search in the game panel

### DIFF
--- a/html/create_object.html
+++ b/html/create_object.html
@@ -9,7 +9,7 @@
 	<form name="spawner" action="byond://?src=/* ref src */" method="get">
 		<input type="hidden" name="src" value="/* ref src */">
 		<input type="hidden" name="admin_token" value="/* href token */">
-		Type: <input type="text" name="filter" onkeypress="submitFirst(event)" style="width:350px"> <input
+		Type: <input type="text" name="filter" onkeypress="filterKeyPressed(event)" style="width:350px"> <input
 			type="button" class="button" value="Search" onclick="updateSearch()" /><br>
 
 		Offset: <input type="text" name="offset" value="x,y,z" style="width:250px">
@@ -66,14 +66,19 @@
 			populateList(filtered);
 		}
 
-		function submitFirst(event) {
-			if (!object_list.options.length) {
-				return false;
-			}
-
+		function filterKeyPressed(event) {
 			// Carriage return
 			if (event.keyCode == 13 || event.which == 13) {
-				object_list.options[0].selected = 'true';
+				// If the value of the input bar is different to the previous search.
+				if (document.spawner.filter.value != old_search) {
+					// Search!
+					updateSearch()
+				}
+				// Otherwise, if there are entries in the object list.
+				else if (object_list.options.length){
+					// Select and spawn the one at the top.
+					object_list.options[0].selected = 'true';
+				}
 			}
 		}
 	</script>


### PR DESCRIPTION

# About the pull request

Edits the 'Create Object/Mob/Turf' interface so that pressing enter in the input bar will search for its value, rather than having to manually press the 'Search' button.
I also kept the previous functionality of the enter key spawning the first item in the results list. It seems a bit like an unintended "feature", but maybe it's used a lot by admins idk. (I can always just remove it in this PR if not.)

# Explain why it's good for the game

~~It slightly bugs me when I'm testing stuff~~
It makes it easier/more intuitive for admins to spawn atoms.

# Changelog
:cl:
admin: Made the enter key submit a search in the 'Create Object/Mob/Turf' panel.
/:cl:
