### PR TITLE
Resting now cancels xenomorph Evolve again

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/Evolution.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Evolution.dm
@@ -105,8 +105,8 @@
 	evolving = TRUE
 	var/level_to_switch_to = get_vision_level()
 
-	if(!do_after(src, 2.5 SECONDS, INTERRUPT_INCAPACITATED, BUSY_ICON_HOSTILE)) // Can evolve while moving
-		to_chat(src, SPAN_WARNING("You quiver, but nothing happens. Hold still while evolving."))
+	if(!do_after(src, 2.5 SECONDS, INTERRUPT_INCAPACITATED|INTERRUPT_CHANGED_LYING, BUSY_ICON_HOSTILE)) // Can evolve while moving, resist or rest to cancel it.
+		to_chat(src, SPAN_WARNING("You quiver, but nothing happens. Your evolution has ceased for now..."))
 		evolving = FALSE
 		return
 


### PR DESCRIPTION

# About the pull request

Resting once again cancels xenomorph evolve..

nb. You can also resist to do the same.

# Explain why it's good for the game
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Resting once again cancels xenomorph evolve.
/:cl:
