### PR TITLE
Removes the welder deconstruction hint from resin walls

### DIFF
--- a/code/game/turfs/walls/walls.dm
+++ b/code/game/turfs/walls/walls.dm
@@ -149,8 +149,6 @@
 /turf/closed/wall/get_examine_text(mob/user)
 	. = ..()
 
-	if(flags_turf & TURF_ORGANIC)
-		return // Skip everything below. 'Organic' walls aren't deconstructable with tools.
 	if(hull)
 		.+= SPAN_WARNING("You don't think you have any tools able to even scratch this.")
 		return //If it's indestructable, we don't want to give the wrong impression by saying "you can decon it with a welder"
@@ -171,6 +169,9 @@
 
 		if (acided_hole)
 			. += SPAN_WARNING("There's a large hole in the wall that could've been caused by some sort of acid.")
+
+	if(flags_turf & TURF_ORGANIC)
+		return // Skip the part below. 'Organic' walls aren't deconstructable with tools.
 
 	switch(d_state)
 		if(WALL_STATE_WELD)

--- a/code/game/turfs/walls/walls.dm
+++ b/code/game/turfs/walls/walls.dm
@@ -149,6 +149,8 @@
 /turf/closed/wall/get_examine_text(mob/user)
 	. = ..()
 
+	if(flags_turf & TURF_ORGANIC)
+		return // Skip everything below. 'Organic' walls aren't deconstructable with tools.
 	if(hull)
 		.+= SPAN_WARNING("You don't think you have any tools able to even scratch this.")
 		return //If it's indestructable, we don't want to give the wrong impression by saying "you can decon it with a welder"


### PR DESCRIPTION
# About the pull request

Adds a check to `/turf/closed/wall/get_examine_text()` to remove the deconstruction hint for anything with the `TURF_ORGANIC` flag (currently only resin walls).

# Explain why it's good for the game

Given that resin walls/membranes can't actually be deconstructed with tools, it doesn't make much sense to show that message.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

**Before:**
![old](https://github.com/cmss13-devs/cmss13/assets/57483089/d2f1b351-5abd-4cb6-acb9-4d6e44c10a31)

**After:**
![new](https://github.com/cmss13-devs/cmss13/assets/57483089/5b234399-7f84-473e-9c5e-83f3c56eb808)

</details>


# Changelog
:cl:
fix: Fixed resin walls/membranes showing a welder deconstruction hint.
/:cl:
