### PR TITLE
Fusion reactor explosion handling

### DIFF
--- a/code/game/machinery/fusion_engine.dm
+++ b/code/game/machinery/fusion_engine.dm
@@ -357,7 +357,7 @@
 			. += SPAN_INFO("There is no fuel cell in the receptacle.")
 
 /obj/structure/machinery/power/fusion_engine/ex_act(severity)
-	if(overloaded)
+	if(overloaded && severity >= EXPLOSION_THRESHOLD_MLOW)
 		set_overloading(FALSE)
 	return
 

--- a/code/game/machinery/fusion_engine.dm
+++ b/code/game/machinery/fusion_engine.dm
@@ -356,6 +356,11 @@
 		else
 			. += SPAN_INFO("There is no fuel cell in the receptacle.")
 
+/obj/structure/machinery/power/fusion_engine/ex_act(severity)
+	if(overloaded)
+		set_overloading(FALSE)
+	return
+
 /obj/structure/machinery/power/fusion_engine/update_icon()
 	switch(buildstate)
 		if(0)


### PR DESCRIPTION

# About the pull request
You cannot destroy fusion reactors with explosives. Explosions do disable overloading tho as a little feature.

# Explain why it's good for the game
Not only it causes bugs, reactors is an important objective and you should not be able to destroy them with HEDP.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: ihatethisengine
fix: fusion reactors cannot be destroyed with explosions
/:cl:
