### PR TITLE
Fixes camera EMP sprites

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -64,7 +64,14 @@
 
 /obj/structure/machinery/camera/update_icon()
 	. = ..()
-	if(icon_state == "autocam_editor")
+	// If the camera has been EMPed.
+	if(stat & EMPED)
+		icon_state = "cameraemp"
+	// If the camera isn't EMPed, but is disabled.
+	else if(!status)
+		icon_state = "camera1"
+	// Otherwise, just give it the normal animated `icon_state`.
+	else
 		icon_state = "camera"
 
 /obj/structure/machinery/camera/set_pixel_location()
@@ -76,24 +83,27 @@
 
 /obj/structure/machinery/camera/emp_act(severity)
 	. = ..()
-	if(!isEmpProof())
-		if(prob(100/severity))
-			icon_state = "[initial(icon_state)]emp"
-			var/list/previous_network = network
-			network = list()
-			GLOB.cameranet.removeCamera(src)
-			stat |= EMPED
-			set_light(0)
-			triggerCameraAlarm()
-			spawn(900)
-				network = previous_network
-				icon_state = initial(icon_state)
-				stat &= ~EMPED
-				cancelCameraAlarm()
-				if(can_use())
-					GLOB.cameranet.addCamera(src)
-			kick_viewers()
+	// If the camera is EMP proof, or it passed the RNG check.
+	if(isEmpProof() || !prob(100 / severity))
+		return
 
+	var/list/previous_network = network
+	network = list()
+	GLOB.cameranet.removeCamera(src)
+	stat |= EMPED
+	update_icon()
+	set_light(0)
+	triggerCameraAlarm()
+	kick_viewers()
+	addtimer(CALLBACK(src, PROC_REF(undo_emp), previous_network), 90 SECONDS)
+
+/obj/structure/machinery/camera/proc/undo_emp(previous_network)
+	network = previous_network
+	stat &= ~EMPED
+	update_icon()
+	cancelCameraAlarm()
+	if(can_use())
+		GLOB.cameranet.addCamera(src)
 
 /obj/structure/machinery/camera/ex_act(severity)
 	if(src.invuln)
@@ -189,10 +199,7 @@
 			visible_message(SPAN_WARNING("[user] has reactivated [src]!"))
 		else
 			visible_message(SPAN_WARNING("[user] has deactivated [src]!"))
-	if(status)
-		icon_state = "camera"
-	else
-		icon_state = "camera1"
+	update_icon()
 	// now disconnect anyone using the camera
 	//Apparently, this will disconnect anyone even if the camera was re-activated.
 	//I guess that doesn't matter since they can't use it anyway?


### PR DESCRIPTION

# About the pull request

Fixes the `icon_state` of cameras changing to the mapping helper sprite after being EMPed.
This was caused by the `initial(icon_state)` calls in `/obj/structure/machinery/camera/emp_act()`, which were setting its sprite to `"autocam_editoremp"` and `"autocam_editor"`.

To fix it, I modified `update_icon()` so that it handles all of the camera's states, and made everything just use that. (Plus a tiny refactor of `emp_act()`.)

# Explain why it's good for the game

Mapping helpers shouldn't be visible in-game.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

I can't really do comparison videos since it takes 90 seconds for the EMP to wear off, but here's what was happening previously:

![mapping helper](https://github.com/cmss13-devs/cmss13/assets/57483089/7850d904-a39a-4a67-996e-3597cdfa5dce)
</details>

# Changelog
:cl:
fix: Fixed camera sprites changing to their mapping helper after being EMPed.
/:cl:
