### PR TITLE
Fixes LV Engi and Research not showning up correctly on the tacmap

### DIFF
--- a/code/game/area/LV624.dm
+++ b/code/game/area/LV624.dm
@@ -382,10 +382,12 @@
 /area/lv624/lazarus/engineering
 	name = "\improper Engineering"
 	icon_state = "engine_smes"
+	minimap_color = MINIMAP_AREA_ENGI
 
 /area/lv624/lazarus/comms
 	name = "\improper Communications Relay"
 	icon_state = "tcomsatcham"
+	minimap_color = MINIMAP_AREA_ENGI
 
 /area/lv624/lazarus/secure_storage
 	name = "\improper Secure Storage"
@@ -400,6 +402,7 @@
 /area/lv624/lazarus/research
 	name = "\improper Research Lab"
 	icon_state = "toxlab"
+	minimap_color = MINIMAP_AREA_RESEARCH
 
 /area/lv624/lazarus/fitness
 	name = "\improper Fitness Room"


### PR DESCRIPTION
# About the pull request

Title basically, Engie and Research did not show up in the correct colours on the tacmap

# Explain why it's good for the game

Bugs bad


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: fixed Engie not showing up an Engie Area on tacmap on LV-624
fix: Fixed Research not showing up as a Research Area on tacmap on LV-624
/:cl:
