### PR TITLE
Vanguard tweaks

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/praetorian/praetorian_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/praetorian/praetorian_abilities.dm
@@ -60,8 +60,6 @@
 	// Fling config
 	var/fling_dist_unbuffed = 3
 	var/fling_dist_buffed = 6
-	var/stun_power = 0.5
-	var/weaken_power = 0.5
 
 	// Root or do a punch-like-effect.
 	var/root_toggle = TRUE

--- a/code/modules/mob/living/carbon/xenomorph/abilities/praetorian/praetorian_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/praetorian/praetorian_abilities.dm
@@ -36,7 +36,7 @@
 
 	var/buff_duration = 12
 	var/damage = 40
-	var/shield_regen_threshold = 2
+	var/shield_regen_threshold = 1
 
 	var/activated_once = FALSE
 	var/time_until_timeout = 20
@@ -54,12 +54,14 @@
 	xeno_cooldown = 120
 
 	// Root config
-	var/root_duration_unbuffed = 5
-	var/root_duration_buffed = 12.5
+	var/root_duration_unbuffed = 1 SECONDS
+	var/root_duration_buffed = 2.5 SECONDS
 
 	// Fling config
 	var/fling_dist_unbuffed = 3
 	var/fling_dist_buffed = 6
+	var/stun_power = 0.5
+	var/weaken_power = 0.5
 
 	// Root or do a punch-like-effect.
 	var/root_toggle = TRUE

--- a/code/modules/mob/living/carbon/xenomorph/abilities/praetorian/praetorian_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/praetorian/praetorian_powers.dm
@@ -52,7 +52,7 @@
 				if(!(mob_to_act in target_mobs))
 					target_mobs += mob_to_act
 
-	source_xeno.visible_message(SPAN_XENODANGER("[source_xeno] slashes its tail through the area in front of it!"), SPAN_XENODANGER("You slash your tail through the area in front of you!"))
+	source_xeno.visible_message(SPAN_XENODANGER("[source_xeno] slashes its claws through the area in front of it!"), SPAN_XENODANGER("You slash your claws through the area in front of you!"))
 	source_xeno.animation_attack_on(targetted_atom, 15)
 
 	source_xeno.emote("roar")
@@ -67,6 +67,7 @@
 
 		current_mob.flick_attack_overlay(current_mob, "slash")
 		current_mob.apply_armoured_damage(get_xeno_damage_slash(current_mob, damage), ARMOR_MELEE, BRUTE, null, 20)
+		playsound(current_mob, 'sound/weapons/alien_tail_attack.ogg', 30, TRUE)
 
 	if (target_mobs.len >= shield_regen_threshold)
 		if (source_xeno.mutation_type == PRAETORIAN_VANGUARD)


### PR DESCRIPTION
# About the pull request
This catches up vanguard to current gameplay as it was last changed approximately 4 years ago


# Explain why it's good for the game
Currently Vanguard is supposed to be a frontlining tier 3 who dashes in > stays in and gets some damage in and goes out  (thats why the shield is a thing) and you're supposed to be able to stay there because your abilities (pierce and dash) resets your shield. But with the recent addition of just more damage in general be it m56d, full auto mode or just the amnout of extra damage you can receive from the front compared 4 years ago.

The strain currently struggles and is near useless other then the occasional go in and lucky fling.

I've changed up the dash to reset your shield once you hit ONE person, rather then two so that you dont instantly die while going in, the shield is very situational as it will most likely decay before you can even go in.

Listening to people who play vanguard, i've also increased the root to 2.5 seconds (this is buffed so when the prae has the shield) the marine can still shoot back when they're rooted so i dont think the duration is a big problem (this is going to be a test merge so i will be watching)

# Testing Photographs and Procedure
it just works

</details>


# Changelog

:cl:
balance: Vanguard dash now restores your shield if you hit ANYONE instead of 2 people.
balance: Vanguard buffed root now roots you for 2.5 seconds, unbuffed for 1 second
qol: Vanguard's pierce has now a hit sound for better feedback
/:cl:
