### PR TITLE
Adds 50 pixels to the Shuttle Manipulator width

### DIFF
--- a/code/controllers/subsystem/shuttles.dm
+++ b/code/controllers/subsystem/shuttles.dm
@@ -504,7 +504,7 @@ SUBSYSTEM_DEF(shuttle)
 /datum/controller/subsystem/shuttle/tgui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
-		ui = new(user, src, "ShuttleManipulator", name, 800, 600)
+		ui = new(user, src, "ShuttleManipulator", name, 850, 600)
 		ui.open()
 
 


### PR DESCRIPTION

# About the pull request
As title says, currently the shuttle manipulator opens up slightly too narrow to entirely fit the buttons on one line and this can make it hard to interpret what shuttle is being disabled. This makes the default width a bit bigger.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
ui: Shuttle manipulator UI is now slightly wider on initial startup.
/:cl:
