### PR TITLE
Fixed hard hat action item icon

### DIFF
--- a/code/modules/clothing/head/hardhat.dm
+++ b/code/modules/clothing/head/hardhat.dm
@@ -60,10 +60,10 @@
 	if(user == loc)
 		user.update_inv_head()
 
+	update_icon()
+
 	for(var/datum/action/current_action as anything in actions)
 		current_action.update_button_icon()
-
-	update_icon()
 
 /obj/item/clothing/head/hardhat/attack_alien(mob/living/carbon/xenomorph/attacking_xeno)
 	if(!can_be_broken)


### PR DESCRIPTION
# About the pull request

This PR fixes the hard hat icon so that it is consistent with the actual state. Previously the action item will be the opposite of the expected state. For example when the light is off, the action item will display it as on.
# Explain why it's good for the game

It is confusing to have the states be inconsistent. By doing this change the icon is now consistent which will result in a better experience for players.


# Testing Photographs and Procedure
Before:
![image](https://github.com/cmss13-devs/cmss13/assets/149045778/828fa4c2-8781-47c6-9488-926a9ed7c465)

After:
![image](https://github.com/cmss13-devs/cmss13/assets/149045778/6867b4aa-b512-4907-8ce1-ae2c6714245d)



# Changelog
:cl:
fix: fixed hardhat action item icon
/:cl:
