### PR TITLE
fix bug with landing zone camera.

### DIFF
--- a/maps/map_files/BigRed/BigRed.dmm
+++ b/maps/map_files/BigRed/BigRed.dmm
@@ -45482,8 +45482,7 @@ aae
 aaf
 aai
 aah
-aah
-aah
+aaF
 aah
 aah
 aah
@@ -45501,6 +45500,7 @@ aah
 aah
 aah
 aah
+aaF
 aah
 aeh
 aaf
@@ -45700,7 +45700,6 @@ aaf
 aaj
 aah
 aah
-aaF
 aah
 aah
 aah
@@ -45716,7 +45715,8 @@ aah
 aah
 aah
 aah
-aaF
+aah
+aah
 aah
 aah
 aei
@@ -46884,7 +46884,7 @@ aSB
 bgX
 bhu
 bie
-bie
+bje
 bie
 bie
 bie
@@ -46902,7 +46902,7 @@ bie
 bie
 bie
 bie
-bie
+bje
 bie
 bsb
 eWd
@@ -47102,7 +47102,7 @@ bgX
 bhv
 bie
 bie
-bje
+bie
 bie
 bie
 bie
@@ -47118,7 +47118,7 @@ bie
 bie
 bjo
 bie
-bje
+bie
 bie
 bie
 bsc
@@ -47436,7 +47436,6 @@ aaf
 aaj
 aah
 aah
-aaF
 aah
 aah
 aah
@@ -47452,7 +47451,8 @@ aah
 aah
 aah
 aah
-aaF
+aah
+aah
 aah
 aah
 aei
@@ -47652,8 +47652,7 @@ aae
 aaf
 aak
 aah
-aah
-aah
+aaF
 aah
 aah
 aah
@@ -47671,6 +47670,7 @@ aah
 aah
 aah
 aah
+aaF
 aah
 aej
 aaf
@@ -48838,7 +48838,6 @@ eWd
 bhv
 bie
 bie
-bje
 bie
 bie
 bie
@@ -48854,7 +48853,8 @@ bie
 bie
 bie
 bie
-bje
+bie
+bie
 bie
 bie
 bsc
@@ -49054,7 +49054,7 @@ aSB
 bgX
 bhw
 bie
-bie
+bje
 bie
 bie
 bie
@@ -49072,7 +49072,7 @@ bie
 bie
 bie
 bie
-bie
+bje
 bie
 bsd
 eWd

--- a/maps/map_files/DesertDam/Desert_Dam.dmm
+++ b/maps/map_files/DesertDam/Desert_Dam.dmm
@@ -64577,6 +64577,10 @@
 /obj/structure/desertdam/decals/road_edge,
 /turf/open/asphalt,
 /area/desert_dam/exterior/valley/valley_labs)
+"tcB" = (
+/obj/structure/machinery/camera/autoname/lz_camera,
+/turf/open/floor/plating,
+/area/desert_dam/exterior/landing_pad_two)
 "tdf" = (
 /obj/structure/surface/table,
 /obj/item/folder/yellow,
@@ -65007,6 +65011,10 @@
 	icon_state = "dirt2"
 	},
 /area/desert_dam/exterior/valley/valley_crashsite)
+"uHT" = (
+/obj/structure/machinery/camera/autoname/lz_camera,
+/turf/open/floor/plating,
+/area/desert_dam/exterior/landing_pad_one)
 "uKo" = (
 /obj/structure/platform/mineral/sandstone/runed{
 	dir = 4
@@ -70120,6 +70128,7 @@ dTs
 cDb
 cDK
 cDY
+tcB
 cDY
 cDY
 cDY
@@ -70128,6 +70137,7 @@ cDY
 cDY
 cDY
 cDY
+tcB
 cDY
 cDY
 cDY
@@ -70136,9 +70146,7 @@ cDY
 cDY
 cDY
 cDY
-cDY
-cDY
-cDY
+tcB
 cDY
 cMD
 cBS
@@ -72460,6 +72468,7 @@ cDc
 cDb
 cDV
 cDY
+tcB
 cDY
 cDY
 cDY
@@ -72468,6 +72477,7 @@ cDY
 cDY
 cDY
 cDY
+tcB
 cDY
 cDY
 cDY
@@ -72476,9 +72486,7 @@ cDY
 cDY
 cDY
 cDY
-cDY
-cDY
-cDY
+tcB
 cDY
 cNb
 cBS
@@ -72982,6 +72990,7 @@ aUD
 aVj
 acI
 aWh
+uHT
 aWh
 aWh
 aWh
@@ -72990,6 +72999,7 @@ aWh
 aWh
 aWh
 aWh
+uHT
 aWh
 aWh
 aWh
@@ -72998,9 +73008,7 @@ aWh
 aWh
 aWh
 aWh
-aWh
-aWh
-aWh
+uHT
 aWh
 bAF
 aVi
@@ -75322,6 +75330,7 @@ aUD
 aVg
 acJ
 aWh
+uHT
 aWh
 aWh
 aWh
@@ -75330,6 +75339,7 @@ aWh
 aWh
 aWh
 aWh
+uHT
 aWh
 aWh
 aWh
@@ -75338,9 +75348,7 @@ aWh
 aWh
 aWh
 aWh
-aWh
-aWh
-aWh
+uHT
 aWh
 bFg
 aVi

--- a/maps/map_files/FOP_v3_Sciannex/Fiorina_SciAnnex.dmm
+++ b/maps/map_files/FOP_v3_Sciannex/Fiorina_SciAnnex.dmm
@@ -73029,7 +73029,7 @@ nZB
 nZB
 iTt
 wQN
-wSm
+xnU
 wSm
 wSm
 wSm
@@ -73047,7 +73047,7 @@ wSm
 wSm
 wSm
 wSm
-wSm
+xnU
 wQN
 eAM
 wSm
@@ -73242,7 +73242,6 @@ nZB
 gBe
 wSm
 wSm
-xnU
 wSm
 wSm
 wSm
@@ -73258,7 +73257,8 @@ wSm
 wSm
 wSm
 wSm
-xnU
+wSm
+wSm
 wSm
 wSm
 eSF
@@ -74938,7 +74938,6 @@ nZB
 gBe
 wSm
 wSm
-xnU
 wSm
 wSm
 wSm
@@ -74954,7 +74953,8 @@ wSm
 wSm
 wSm
 wSm
-xnU
+wSm
+wSm
 wSm
 wSm
 eSF
@@ -75149,7 +75149,7 @@ nZB
 nZB
 bne
 wQN
-wSm
+xnU
 wSm
 wSm
 wSm
@@ -75167,7 +75167,7 @@ wSm
 wSm
 wSm
 wSm
-wSm
+xnU
 wQN
 xrH
 wSm
@@ -88846,7 +88846,7 @@ qaL
 nGZ
 uNs
 iOa
-xeO
+cCx
 xeO
 xeO
 xeO
@@ -88864,7 +88864,7 @@ xeO
 xeO
 xeO
 xeO
-xeO
+cCx
 iOa
 eLB
 uYi
@@ -89059,7 +89059,6 @@ pYD
 ehy
 xeO
 xeO
-cCx
 xeO
 xeO
 xeO
@@ -89075,7 +89074,8 @@ xeO
 xeO
 xeO
 xeO
-cCx
+xeO
+xeO
 xeO
 xeO
 oGR
@@ -90755,7 +90755,6 @@ pqY
 ehy
 doA
 xeO
-cCx
 xeO
 xeO
 xeO
@@ -90771,7 +90770,8 @@ xeO
 xeO
 xeO
 xeO
-cCx
+xeO
+xeO
 xeO
 xeO
 kIh
@@ -90966,7 +90966,7 @@ qaL
 nGZ
 aTe
 iOa
-xeO
+cCx
 xeO
 xeO
 xeO
@@ -90984,7 +90984,7 @@ xeO
 xeO
 xeO
 xeO
-xeO
+cCx
 iOa
 rrD
 uYi

--- a/maps/map_files/Kutjevo/Kutjevo.dmm
+++ b/maps/map_files/Kutjevo/Kutjevo.dmm
@@ -20100,8 +20100,8 @@ wGH
 cWV
 exI
 nbV
-nbV
 umo
+nbV
 nbV
 nbV
 lAI
@@ -21172,8 +21172,8 @@ sVF
 xBm
 wvX
 hzN
-hzN
 wqk
+hzN
 hzN
 hzN
 ppX
@@ -21770,8 +21770,8 @@ wGH
 cWV
 uhO
 bbc
-nbV
 umo
+nbV
 nbV
 nbV
 lAI
@@ -22842,8 +22842,8 @@ oJE
 xBm
 saK
 hzN
-hzN
 wqk
+hzN
 hzN
 hzN
 ppX

--- a/maps/map_files/LV624/LV624.dmm
+++ b/maps/map_files/LV624/LV624.dmm
@@ -31401,7 +31401,7 @@ aZP
 aOB
 oOB
 aRg
-aRg
+aCi
 aRg
 aRg
 aRg
@@ -31419,7 +31419,7 @@ aRg
 aRg
 aRg
 aRg
-aRg
+aCi
 aRg
 odw
 aRg
@@ -31631,7 +31631,6 @@ aTv
 aRg
 aRg
 aRg
-aCi
 aRg
 aRg
 aRg
@@ -31646,7 +31645,8 @@ aRg
 aRg
 aRg
 aRg
-aCi
+aRg
+aRg
 aKO
 aRg
 aEw
@@ -33455,7 +33455,7 @@ aTv
 aRg
 aRg
 aRg
-aCi
+aRg
 aRg
 aRg
 aRg
@@ -33470,7 +33470,7 @@ aRg
 aRg
 aRg
 aRg
-aCi
+aRg
 aRg
 aRg
 aEw
@@ -33681,7 +33681,7 @@ aZP
 aOB
 kvE
 aRg
-aRg
+aCi
 aRg
 aRg
 aRg
@@ -33699,7 +33699,7 @@ aRg
 aRg
 aRg
 aRg
-aRg
+aCi
 aRg
 byK
 aRg
@@ -58084,8 +58084,8 @@ aGz
 aGz
 aDJ
 ank
-ank
 ano
+ank
 ank
 ank
 ank
@@ -60364,8 +60364,8 @@ btF
 aDi
 aDL
 ank
-ank
 ano
+ank
 ank
 ank
 ank

--- a/maps/map_files/New_Varadero/New_Varadero.dmm
+++ b/maps/map_files/New_Varadero/New_Varadero.dmm
@@ -86,10 +86,6 @@
 	icon_state = "multi_tiles"
 	},
 /area/varadero/interior/medical)
-"ade" = (
-/obj/structure/machinery/camera/autoname/lz_camera,
-/turf/open/gm/dirt,
-/area/varadero/exterior/lz2_near)
 "adw" = (
 /turf/closed/wall/r_wall,
 /area/varadero/interior/cargo)
@@ -12292,14 +12288,6 @@
 	icon_state = "asteroidfloor"
 	},
 /area/varadero/interior/comms1)
-"ias" = (
-/obj/structure/machinery/camera/autoname/lz_camera,
-/obj/structure/machinery/landinglight/ds1/spoke{
-	pixel_y = -5;
-	pixel_x = 13
-	},
-/turf/open/auto_turf/sand_white/layer1,
-/area/varadero/exterior/lz2_near)
 "iat" = (
 /obj/structure/barricade/wooden{
 	dir = 1
@@ -18127,6 +18115,14 @@
 /obj/effect/spawner/random/attachment,
 /turf/open/floor/carpet,
 /area/varadero/interior/administration)
+"lIW" = (
+/obj/structure/machinery/landinglight/ds1/spoke{
+	pixel_y = -5;
+	pixel_x = 13
+	},
+/obj/structure/machinery/camera/autoname/lz_camera,
+/turf/open/auto_turf/sand_white/layer1,
+/area/varadero/exterior/lz2_near)
 "lJo" = (
 /obj/structure/machinery/light{
 	dir = 8
@@ -28324,6 +28320,14 @@
 	},
 /turf/open/floor/wood,
 /area/varadero/interior/beach_bar)
+"sbP" = (
+/obj/structure/machinery/landinglight/ds1/spoke{
+	pixel_y = -5;
+	pixel_x = -13
+	},
+/obj/structure/machinery/camera/autoname/lz_camera,
+/turf/open/auto_turf/sand_white/layer1,
+/area/varadero/exterior/lz2_near)
 "sbX" = (
 /obj/structure/flora/pottedplant{
 	icon_state = "pottedplant_22";
@@ -36538,14 +36542,6 @@
 	icon_state = "blue"
 	},
 /area/varadero/interior/technical_storage)
-"xpL" = (
-/obj/structure/machinery/camera/autoname/lz_camera,
-/obj/structure/machinery/landinglight/ds1/spoke{
-	pixel_y = -5;
-	pixel_x = -13
-	},
-/turf/open/auto_turf/sand_white/layer1,
-/area/varadero/exterior/lz2_near)
 "xpP" = (
 /turf/closed/wall/r_wall,
 /area/varadero/interior/comms1)
@@ -49964,8 +49960,7 @@ wMw
 pbp
 sHV
 bZU
-bZU
-bZU
+rtm
 bZU
 bZU
 bZU
@@ -49983,6 +49978,7 @@ bZU
 bZU
 bZU
 bZU
+rtm
 bZU
 xsH
 mrC
@@ -50163,7 +50159,7 @@ bZU
 bZU
 bZU
 qOh
-rtm
+bZU
 bZU
 bZU
 bwP
@@ -51619,7 +51615,7 @@ qOh
 bZU
 bZU
 bZU
-rtm
+bZU
 bZU
 bZU
 bwP
@@ -51784,8 +51780,7 @@ wMw
 pbp
 cYZ
 bZU
-bZU
-bZU
+rtm
 bZU
 bZU
 bZU
@@ -51803,6 +51798,7 @@ bZU
 bZU
 bZU
 bZU
+rtm
 bZU
 miF
 mrC
@@ -63426,25 +63422,25 @@ wlB
 lTg
 lTg
 lTg
-lTg
+emP
 pXT
 lTg
 lTg
 wlB
 wlB
 wlB
-lTg
 lTg
 lTg
 emP
 lTg
+lTg
 wlB
 wlB
 wlB
 wlB
 wlB
 lTg
-pXT
+lIW
 pXT
 rhu
 wlB
@@ -63610,7 +63606,7 @@ eia
 lTg
 lTg
 lTg
-ade
+wlB
 wlB
 wlB
 wlB
@@ -63625,7 +63621,7 @@ wlB
 wlB
 wlB
 nFX
-ias
+pXT
 lTg
 wlB
 lTg
@@ -65066,7 +65062,7 @@ lTg
 lTg
 lTg
 lTg
-ade
+wlB
 wlB
 wlB
 wlB
@@ -65081,7 +65077,7 @@ nFX
 wlB
 wlB
 wlB
-xpL
+uHD
 lTg
 wlB
 lTg
@@ -65246,25 +65242,25 @@ lTg
 lTg
 wlB
 lTg
-lTg
+emP
 uHD
 lTg
 lTg
 wlB
 wlB
 wlB
-lTg
 lTg
 lTg
 emP
 lTg
+lTg
 wlB
 wlB
 wlB
 wlB
 wlB
 lTg
-uHD
+sbP
 uHD
 lTg
 lTg

--- a/maps/map_files/New_Varadero/New_Varadero.dmm
+++ b/maps/map_files/New_Varadero/New_Varadero.dmm
@@ -50144,7 +50144,7 @@ irk
 bZU
 bZU
 bZU
-rtm
+bZU
 bZU
 bZU
 bZU
@@ -51600,7 +51600,7 @@ irk
 bZU
 bZU
 bZU
-rtm
+bZU
 bZU
 bZU
 bZU


### PR DESCRIPTION
# About the pull request
basicly a bunch of camera badly place would get attach to DS when DS land on them meaning they could no longer function as intented.

fixes: https://github.com/cmss13-devs/cmss13/issues/5071
some camera where badly placed so it decided to standardize all the camera placement of the map in rotation?


<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: added landing zone camera on trijent.
fix: fixed landing zone camera on all map in rotation.
/:cl:
