### PR TITLE
renamed 'M56 Battery' to 'M56 DV9 Battery' in requisitions munition vendor

### DIFF
--- a/code/game/machinery/vending/vendor_types/requisitions.dm
+++ b/code/game/machinery/vending/vendor_types/requisitions.dm
@@ -228,7 +228,7 @@
 		list("M41A MK2 Extended Magazine (10x24mm)", round(scale * 8), /obj/item/ammo_magazine/rifle/extended, VENDOR_ITEM_REGULAR),
 
 		list("SPECIAL AMMUNITION", -1, null, null),
-		list("M56 Battery", 4, /obj/item/smartgun_battery, VENDOR_ITEM_REGULAR),
+		list("M56 DV9 Battery", 4, /obj/item/smartgun_battery, VENDOR_ITEM_REGULAR),
 		list("M56 Smartgun Drum", 4, /obj/item/ammo_magazine/smartgun, VENDOR_ITEM_REGULAR),
 		list("M44 Heavy Speed Loader (.44)", 10, /obj/item/ammo_magazine/revolver/heavy, VENDOR_ITEM_REGULAR),
 		list("M44 Marksman Speed Loader (.44)", 6, /obj/item/ammo_magazine/revolver/marksman, VENDOR_ITEM_REGULAR),


### PR DESCRIPTION

# About the pull request
Renames 'M56 Battery' in requisitions munition vendor to 'M56 DV9 Battery'

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
A Smartgunner will ask a Cargo Tech for a DV9 and they will be unable to search for one causing confusion. The battery itself is called a DV9 which is what the SG asks for and this edit fixes the vendor not listing it as such.
# Testing Photographs and Procedure
Minor text change. I verified it in-game and it's working correctly.


# Changelog
:cl:
spellcheck: Edited 'M56 Battery' to 'M56 DV9 Battery' in requisitions munition vendor
/:cl:
