### PR TITLE
Compass Headgear now shows your direction when examined

### DIFF
--- a/code/__DEFINES/maps.dm
+++ b/code/__DEFINES/maps.dm
@@ -32,6 +32,7 @@ require only minor tweaks.
 #define ZTRAIT_FOG "Fog"
 #define ZTRAIT_LOCKDOWN "Lockdown"
 #define ZTRAIT_BASIC_RT "BasicRT"
+#define ZTRAIT_IN_SPACE "InSpace" // Is our ground_level considered in space or on a space station
 
 // boolean - weather types that occur on the level
 #define ZTRAIT_SNOWSTORM "weather_snowstorm"

--- a/code/game/objects/items/props/helmetgarb.dm
+++ b/code/game/objects/items/props/helmetgarb.dm
@@ -602,6 +602,13 @@
 	icon_state = "compass"
 	w_class = SIZE_SMALL
 
+/obj/item/prop/helmetgarb/compass/get_examine_text(mob/user)
+	. = ..()
+	if(is_ground_level(user.z) && !SSmapping.configs[GROUND_MAP].environment_traits[ZTRAIT_IN_SPACE])
+		. += SPAN_NOTICE("It seems you are facing [dir2text(user.dir)].")
+		return
+	. += SPAN_NOTICE("The needle is not moving.")
+
 /obj/item/prop/helmetgarb/bug_spray
 	name = "insect repellent"
 	desc = "A store-brand insect repellent, to keep any variety of pest or mosquito away from you."

--- a/maps/corsat.json
+++ b/maps/corsat.json
@@ -4,7 +4,8 @@
     "map_file": "Corsat.dmm",
     "environment_traits": {
         "Lockdown": true,
-        "COLD": true
+        "COLD": true,
+        "InSpace": true
     },
     "survivor_types": [
         "/datum/equipment_preset/survivor/scientist/corsat",

--- a/maps/fiorina_sciannex.json
+++ b/maps/fiorina_sciannex.json
@@ -26,6 +26,7 @@
     "survivor_message": "You are a survivor of the attack on Fiorina Orbital Penitentiary. You worked or lived on the prison station, and managed to avoid the alien attacks... until now.",
     "map_item_type": "/obj/item/map/FOP_map_v3",
     "announce_text": "An automated distress signal has been received from maximum-security prison \"Fiorina Orbital Penitentiary\". A response team from the ###SHIPNAME### will be dispatched shortly to investigate.",
+    "environment_traits": { "InSpace": true },
     "traits": [{ "Ground": true }],
     "nightmare_path": "maps/Nightmare/maps/FOP_v3_Sciannex/",
     "xvx_hives": {

--- a/maps/prison_station_fop.json
+++ b/maps/prison_station_fop.json
@@ -24,7 +24,10 @@
     "survivor_message": "You are a survivor of the attack on Fiorina Orbital Penitentiary. You worked or lived on the prison station, and managed to avoid the alien attacks... until now.",
     "map_item_type": "/obj/item/map/FOP_map",
     "announce_text": "An automated distress signal has been received from maximum-security prison \"Fiorina Orbital Penitentiary\". A response team from the ###SHIPNAME### will be dispatched shortly to investigate.",
-    "environment_traits": { "Lockdown": true },
+    "environment_traits": {
+        "Lockdown": true,
+        "InSpace": true
+    },
     "traits": [{ "Ground": true }],
     "nightmare_path": "maps/Nightmare/maps/FOP_v2_Cellblocks/",
     "xvx_hives": {


### PR DESCRIPTION
# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->
When the compass headgear is now examined, it will tell you the direction your character is facing (north, south, east, or west). This only works when you're on a planet, this means being groundside and not on a map that is situated in space.

I've considered changing the description, but I've left it because I couldn't think of a better one.

# Explain why it's good for the game
When I used the compass in game, I expected to actually tell me which direction I'm facing, but I was a bit disappointed when it didn't. So, I change it to work in a realistic way.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

On LV-624, where the compass works (left). On the ship, were the compass does not work (right).
![image](https://github.com/cmss13-devs/cmss13/assets/91113370/323a14ce-551f-4d38-8a25-a3b666f98226)

On maps like Fiorina where are situated in space, the compass will not work.
![image](https://github.com/cmss13-devs/cmss13/assets/91113370/4548efd9-c674-400e-af38-0bfb4c7749c8)

</details>


# Changelog
:cl:
add: The compass headgear will now tell you what direction you're facing when on a planet.
code: Added a new ground environmental trait for a ground level in space.
/:cl:
My discord is: contrabang, if you would like to contact me, that is the best place.