### PR TITLE
Requisitions elevator lighting fix

### DIFF
--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -17,29 +17,25 @@ GLOBAL_DATUM_INIT(supply_controller, /datum/controller/supply, new())
 /area/supply
 	ceiling = CEILING_METAL
 
-/area/supply/station //DO NOT TURN THE lighting_use_dynamic STUFF ON FOR SHUTTLES. IT BREAKS THINGS.
+/area/supply/station
 	name = "Supply Shuttle"
 	icon_state = "shuttle3"
-	base_lighting_alpha = 255
 	requires_power = 0
 	ambience_exterior = AMBIENCE_ALMAYER
 
-/area/supply/dock //DO NOT TURN THE lighting_use_dynamic STUFF ON FOR SHUTTLES. IT BREAKS THINGS.
+/area/supply/dock
 	name = "Supply Shuttle"
 	icon_state = "shuttle3"
-	base_lighting_alpha = 255
 	requires_power = 0
 
-/area/supply/station_vehicle //DO NOT TURN THE lighting_use_dynamic STUFF ON FOR SHUTTLES. IT BREAKS THINGS.
+/area/supply/station_vehicle
 	name = "Vehicle ASRS"
 	icon_state = "shuttle3"
-	base_lighting_alpha = 255
 	requires_power = 0
 
-/area/supply/dock_vehicle //DO NOT TURN THE lighting_use_dynamic STUFF ON FOR SHUTTLES. IT BREAKS THINGS.
+/area/supply/dock_vehicle
 	name = "Vehicle ASRS"
 	icon_state = "shuttle3"
-	base_lighting_alpha = 255
 	requires_power = 0
 
 //SUPPLY PACKS MOVED TO /code/defines/obj/supplypacks.dm

--- a/code/modules/shuttles/shuttle.dm
+++ b/code/modules/shuttles/shuttle.dm
@@ -221,11 +221,11 @@
 		if(iselevator)
 			if(istype(T,/turf/open/space))
 				if(is_mainship_level(T.z))
-					new /turf/open/floor/almayer/empty(T)
+					T.ChangeTurf(/turf/open/floor/almayer/empty)
 				else
-					new /turf/open/gm/empty(T)
+					T.ChangeTurf(/turf/open/gm/empty)
 		else if(istype(T,/turf/open/space))
-			new /turf/open/floor/plating(T)
+			T.ChangeTurf(/turf/open/floor/plating)
 
 	return
 


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

This PR fixes the elevator lighting by changing the way the turf cloning logic works to use the pre-existing ChangeTurf function, which will result in the static lighting properties being copied properly. By doing this change, we can disable the base lighting properties from the shuttle area and have the static lighting system apply to the elevator turf in requisition which is consistent with how the room lighting already works.

# Explain why it's good for the game

The existing elevator has many visual effect issues, requiring other forms of lighting to compensate for the problem, such as placing movable lights (flashlight), or other non-static lighting sources. Without these work arounds the elevator will be completely black after the first time the space turfs are cloned.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

## Before


https://github.com/cmss13-devs/cmss13/assets/149045778/f15fca7b-3a77-45ff-9632-63ee371eff64

## After

https://github.com/cmss13-devs/cmss13/assets/149045778/f99ae1af-f4ba-4a64-a66d-c13d5b2e13f8


</details>


# Changelog
:cl:
fix: Requisitions elevator lighting fix
/:cl:
