### PR TITLE
Fixes CAS killing players with ammo crates instead of bullets

### DIFF
--- a/code/modules/cm_marines/dropship_ammo.dm
+++ b/code/modules/cm_marines/dropship_ammo.dm
@@ -12,8 +12,8 @@
 	var/fire_mission_delay = 4
 	/// Time to impact in deciseconds
 	var/travelling_time = 100
-	/// Type of equipment that accept this type of ammo.
-	var/equipment_type
+	/// Type of dropship equipment that accepts this type of ammo.
+	var/obj/structure/dropship_equipment/equipment_type
 	/// Ammunition count remaining
 	var/ammo_count
 	/// Maximal ammunition count
@@ -171,7 +171,7 @@
 		sleep(1)
 		for(var/j in 1 to 2) //rather than halving the sleep, were doubling the bullets shot "bang"
 			var/turf/impact_tile = pick(turf_list)
-			var/datum/cause_data/cause_data = create_cause_data(initial(name), source_mob)
+			var/datum/cause_data/cause_data = create_cause_data(initial(equipment_type.name), source_mob)
 			impact_tile.ex_act(EXPLOSION_THRESHOLD_VLOW, pick(GLOB.alldirs), cause_data)
 			create_shrapnel(impact_tile,1,0,0,shrapnel_type,cause_data,FALSE,100) //simulates a bullet
 			for(var/atom/movable/explosion_effect in impact_tile)
@@ -259,7 +259,7 @@
 
 
 /obj/structure/ship_ammo/laser_battery/proc/laser_burn(turf/T)
-	fire_spread_recur(T, create_cause_data(initial(name), source_mob), 1, null, 5, 75, "#EE6515")//Very, very intense, but goes out very quick
+	fire_spread_recur(T, create_cause_data(initial(equipment_type.name), source_mob), 1, null, 5, 75, "#EE6515")//Very, very intense, but goes out very quick
 
 
 //Rockets


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Fixes #3211 by making GAU-21 and Laser Cannon ammo pass the weapon to the `cause_data`, rather than the ammo crate/battery.

# Explain why it's good for the game

The dropship is meant to be firing the ammunition inside the crate, not the crate itself. (Although that is fun to imagine)

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: Fixed the death message from GAU-21 and Laser Cannon strikes saying that the player was killed by the ammo crate.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
