### PR TITLE
Further vanguard tweaks that drop the root from 2.5 to 1.8

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/praetorian/praetorian_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/praetorian/praetorian_abilities.dm
@@ -55,7 +55,7 @@
 
 	// Root config
 	var/root_duration_unbuffed = 1 SECONDS
-	var/root_duration_buffed = 2.5 SECONDS
+	var/root_duration_buffed = 1.8 SECONDS
 
 	// Fling config
 	var/fling_dist_unbuffed = 3


### PR DESCRIPTION


# About the pull request
I believe the latest buff pr i overtuned the root a bit too much, thinking it wouldnt be too hard since you can still technically act.
# Explain why it's good for the game

2.5 root is a bit too much currently so im bringing it down to 1.8 so its still good but not busted like 2.5

# Testing Photographs and Procedure
<details>
it works
</details>


# Changelog

:cl:
balance: Tweaks down the buffed root of vanguard down to 1.8 from 2.5
/:cl:
