### PR TITLE
Fixed hard hat user inventory head icon

### DIFF
--- a/code/modules/clothing/head/hardhat.dm
+++ b/code/modules/clothing/head/hardhat.dm
@@ -57,10 +57,11 @@
 		return
 
 	set_light_on(toggle_on)
-	if(user == loc)
-		user.update_inv_head()
 
 	update_icon()
+
+	if(user == loc)
+		user.update_inv_head()
 
 	for(var/datum/action/current_action as anything in actions)
 		current_action.update_button_icon()


### PR DESCRIPTION

# About the pull request
In the recent PR #5189 the action item for the hard hat was fixed. However because the icon was being turned on in hand instead of on head, it was overlooked that the user inventory head icon was also incorrect at times, specifically when turned on while the user is wearing it. This PR is related to the previous change mentioned because the `update_icon` call must occur first, due to the fact that both `update_button_icon` and `update_inv_head` both reference the icon and item state properties.

# Explain why it's good for the game
It is desirable for the icon state to be consistent in all situations. We want the light icon to show as shining when light is being emitted.


# Testing Photographs and Procedure
<details>

This update was tested both in hand and on head, as well as off states. The bug is reliably observable when the hard hat is activated while on head, however when in hand and placed on head in the on state, the bug does not occur. Upon various testing I have been unable to cause the icon to be in an inconsistent state.

<summary>Screenshots & Videos</summary>

## Before
![before](https://github.com/cmss13-devs/cmss13/assets/149045778/79702a78-22bb-462c-b681-f3d684099f14)

## After
![fixed](https://github.com/cmss13-devs/cmss13/assets/149045778/52f72b06-b615-4b51-953a-f6749a8fa5b6)



</details>


# Changelog
:cl:
fix: Fixed hard hat user inventory head icon
/:cl:
