### PR TITLE
Fixes for new brig

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,7 +9,7 @@
 		"**/.pnp.*": true
 	},
 	"editor.codeActionsOnSave": {
-		"source.fixAll.eslint": true
+		"source.fixAll.eslint": "explicit"
 	},
 	"files.eol": "\n",
 	"files.insertFinalNewline": true,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,7 +9,7 @@
 		"**/.pnp.*": true
 	},
 	"editor.codeActionsOnSave": {
-		"source.fixAll.eslint": "explicit"
+		"source.fixAll.eslint": "true"
 	},
 	"files.eol": "\n",
 	"files.insertFinalNewline": true,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,7 +9,7 @@
 		"**/.pnp.*": true
 	},
 	"editor.codeActionsOnSave": {
-		"source.fixAll.eslint": "true"
+		"source.fixAll.eslint": true
 	},
 	"files.eol": "\n",
 	"files.insertFinalNewline": true,

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -29135,6 +29135,16 @@
 	icon_state = "green"
 	},
 /area/almayer/living/grunt_rnr)
+"dco" = (
+/obj/structure/surface/table/almayer,
+/obj/structure/machinery/computer/cameras/almayer_network{
+	dir = 4
+	},
+/turf/open/floor/almayer{
+	dir = 8;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/chief_mp_office)
 "dcp" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/plating/plating_catwalk,
@@ -40468,6 +40478,12 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/living/briefing)
+"hMc" = (
+/obj/structure/bed/chair/comfy/orange{
+	dir = 8
+	},
+/turf/open/floor/almayer,
+/area/almayer/shipboard/brig/chief_mp_office)
 "hMi" = (
 /obj/structure/pipes/vents/scrubber,
 /turf/open/floor/almayer,
@@ -45550,12 +45566,6 @@
 	dir = 1
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/shipboard/brig/chief_mp_office)
-"jPY" = (
-/obj/structure/bed/chair/comfy/orange{
-	dir = 8
-	},
-/turf/open/floor/almayer,
 /area/almayer/shipboard/brig/chief_mp_office)
 "jQt" = (
 /turf/open/floor/almayer/research/containment/floor2{
@@ -54813,16 +54823,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/squads/delta)
-"nvZ" = (
-/obj/structure/surface/table/almayer,
-/obj/structure/machinery/computer/cameras/almayer_network{
-	dir = 4
-	},
-/turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/chief_mp_office)
 "nwb" = (
 /obj/structure/pipes/vents/scrubber{
 	dir = 1
@@ -95005,7 +95005,7 @@ emp
 wIC
 puE
 crp
-nvZ
+dco
 dqZ
 wIC
 lTK
@@ -95207,7 +95207,7 @@ oIh
 iTl
 wIC
 cBZ
-jPY
+hMc
 vAG
 jIo
 wIC

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -2948,7 +2948,6 @@
 /turf/open/floor/plating,
 /area/almayer/hull/upper_hull/u_a_s)
 "ake" = (
-/obj/structure/largecrate/random/barrel/white,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
@@ -9056,8 +9055,8 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/pipes/standard/simple/hidden/supply,
 /obj/structure/machinery/door/airlock/almayer/security/glass{
-	name = "Brig";
-	dir = 2
+	dir = 2;
+	name = "Brig"
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -12861,10 +12860,10 @@
 	pixel_x = -17
 	},
 /obj/structure/machinery/door_control/brbutton{
-	pixel_y = 26;
 	id = "engie_store";
 	name = "Emergency Storage";
 	pixel_x = -2;
+	pixel_y = 26;
 	req_one_access_txt = "6"
 	},
 /turf/open/floor/almayer{
@@ -15291,8 +15290,8 @@
 /obj/structure/machinery/door_control{
 	id = "CMP Office Shutters";
 	name = "CMP Office Shutters";
-	req_one_access_txt = "24;31";
-	pixel_y = -20
+	pixel_y = -20;
+	req_one_access_txt = "24;31"
 	},
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -23495,11 +23494,17 @@
 	},
 /area/almayer/hull/lower_hull/l_f_p)
 "bVT" = (
-/obj/structure/largecrate/random/barrel/white,
-/turf/open/floor/almayer{
-	icon_state = "plate"
+/obj/structure/sign/safety/maint{
+	pixel_x = -19;
+	pixel_y = -6
 	},
-/area/almayer/hull/upper_hull/u_f_p)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/safety/bulkhead_door{
+	pixel_x = -19;
+	pixel_y = 6
+	},
+/turf/open/floor/almayer,
+/area/almayer/hull/upper_hull/u_f_s)
 "bVU" = (
 /turf/closed/wall/almayer/outer,
 /area/almayer/shipboard/port_point_defense)
@@ -28746,8 +28751,8 @@
 	dir = 2
 	},
 /obj/structure/machinery/door/airlock/almayer/security/glass/reinforced{
-	name = "\improper Armory";
-	dir = 2
+	dir = 2;
+	name = "\improper Armory"
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -28964,7 +28969,7 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	icon_state = "redcorner"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/brig/main_office)
 "cZm" = (
@@ -29248,7 +29253,7 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	icon_state = "greenfull"
+	icon_state = "test_floor4"
 	},
 /area/almayer/shipboard/brig/cells)
 "dfC" = (
@@ -30176,8 +30181,8 @@
 	name = "\improper cell shutter"
 	},
 /obj/structure/machinery/door/airlock/almayer/security/glass/reinforced{
-	name = "\improper Isolation Cell";
-	dir = 2
+	dir = 2;
+	name = "\improper Isolation Cell"
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -31436,6 +31441,17 @@
 	icon_state = "plate"
 	},
 /area/almayer/squads/req)
+"dXO" = (
+/obj/structure/sign/safety/maint{
+	pixel_x = -19;
+	pixel_y = -6
+	},
+/obj/structure/sign/safety/bulkhead_door{
+	pixel_x = -19;
+	pixel_y = 6
+	},
+/turf/open/floor/almayer,
+/area/almayer/hull/upper_hull/u_f_p)
 "dXV" = (
 /obj/structure/desertdam/decals/road_edge{
 	pixel_x = 16
@@ -32916,9 +32932,9 @@
 	icon_state = "pottedplant_10"
 	},
 /obj/structure/closet/secure_closet/cmdcabinet{
-	pixel_y = 24;
 	desc = "A bulletproof cabinet containing communications equipment.";
 	name = "communications cabinet";
+	pixel_y = 24;
 	req_access = null;
 	req_one_access_txt = "207;203"
 	},
@@ -34676,6 +34692,10 @@
 /area/almayer/command/airoom)
 "frX" = (
 /obj/structure/machinery/optable,
+/obj/structure/sign/safety/medical{
+	pixel_x = 8;
+	pixel_y = 29
+	},
 /turf/open/floor/almayer{
 	dir = 1;
 	icon_state = "sterile_green_corner"
@@ -34994,17 +35014,14 @@
 	},
 /area/almayer/shipboard/weapon_room)
 "fyp" = (
-/obj/structure/machinery/door/poddoor/shutters/almayer/open{
-	dir = 2;
-	id = "CMP Office Shutters";
-	name = "\improper Privacy Shutters"
+/obj/structure/machinery/cryopod{
+	layer = 3.1;
+	pixel_y = 13
 	},
-/obj/structure/window/framed/almayer,
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 2
+/turf/open/floor/almayer{
+	icon_state = "cargo"
 	},
-/turf/open/floor/plating,
-/area/almayer/shipboard/brig/chief_mp_office)
+/area/almayer/shipboard/brig/cryo)
 "fyD" = (
 /obj/structure/machinery/light,
 /obj/structure/ladder{
@@ -36615,6 +36632,16 @@
 	icon_state = "blue"
 	},
 /area/almayer/hallways/aft_hallway)
+"giR" = (
+/obj/structure/window/framed/almayer,
+/obj/structure/machinery/door/poddoor/shutters/almayer/open{
+	dir = 4;
+	id = "CMP Office Shutters";
+	name = "\improper Privacy Shutters"
+	},
+/obj/structure/machinery/door/firedoor/border_only/almayer,
+/turf/open/floor/plating,
+/area/almayer/shipboard/brig/chief_mp_office)
 "gjm" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N";
@@ -38473,9 +38500,9 @@
 /area/almayer/hull/lower_hull/l_a_p)
 "gXx" = (
 /obj/structure/closet/secure_closet/cmdcabinet{
-	pixel_y = 24;
 	desc = "A bulletproof cabinet containing communications equipment.";
 	name = "communications cabinet";
+	pixel_y = 24;
 	req_access = null;
 	req_one_access_txt = "3"
 	},
@@ -39220,8 +39247,8 @@
 	id = "Brig Lockdown Shutters";
 	name = "Brig Lockdown Shutters";
 	pixel_x = 16;
-	req_access_txt = "3";
-	pixel_y = 8
+	pixel_y = 8;
+	req_access_txt = "3"
 	},
 /turf/open/floor/almayer{
 	icon_state = "red"
@@ -41901,13 +41928,10 @@
 	},
 /area/almayer/engineering/upper_engineering/port)
 "iqR" = (
-/obj/structure/machinery/cryopod{
-	layer = 3.1;
-	pixel_y = 13
-	},
 /obj/structure/sign/safety/cryo{
 	pixel_x = -16
 	},
+/obj/structure/machinery/cryopod,
 /turf/open/floor/almayer{
 	icon_state = "cargo"
 	},
@@ -42391,11 +42415,20 @@
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
 	},
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "red"
+/obj/structure/machinery/door/poddoor/shutters/almayer/open{
+	dir = 4;
+	id = "CMP Office Shutters";
+	name = "\improper Privacy Shutters"
 	},
-/area/almayer/shipboard/brig/processing)
+/obj/structure/machinery/door/airlock/almayer/security/glass{
+	dir = 8;
+	name = "\improper Chief MP's Office"
+	},
+/obj/structure/machinery/door/firedoor/border_only/almayer,
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/shipboard/brig/chief_mp_office)
 "iBt" = (
 /turf/open/floor/plating,
 /area/almayer/hull/upper_hull/u_m_p)
@@ -43054,7 +43087,8 @@
 "iQB" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/computer/card{
-	dir = 4
+	dir = 4;
+	layer = 3.2
 	},
 /obj/structure/machinery/computer/secure_data{
 	dir = 4;
@@ -43197,23 +43231,12 @@
 	},
 /area/almayer/hull/upper_hull/u_a_p)
 "iTl" = (
-/obj/structure/machinery/door/poddoor/shutters/almayer/open{
-	dir = 2;
-	id = "CMP Office Shutters";
-	name = "\improper Privacy Shutters"
-	},
-/obj/structure/machinery/door/airlock/almayer/security/glass{
-	name = "\improper Chief MP's Office";
-	dir = 2
-	},
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 2
-	},
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	icon_state = "test_floor4"
+	dir = 4;
+	icon_state = "red"
 	},
 /area/almayer/shipboard/brig/chief_mp_office)
 "iTw" = (
@@ -44718,16 +44741,8 @@
 /obj/structure/machinery/light{
 	dir = 1
 	},
-/obj/structure/sign/safety/cryo{
-	pixel_x = 3;
-	pixel_y = 25
-	},
-/obj/structure/sign/safety/rewire{
-	pixel_x = 15;
-	pixel_y = 25
-	},
 /turf/open/floor/almayer{
-	allow_construction = 0
+	icon_state = "plate"
 	},
 /area/almayer/shipboard/brig/cryo)
 "jvX" = (
@@ -46428,10 +46443,11 @@
 	},
 /area/almayer/hull/lower_hull/l_f_s)
 "kif" = (
+/obj/structure/largecrate/random/barrel/white,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/shipboard/brig/main_office)
+/area/almayer/hull/upper_hull/u_f_s)
 "kij" = (
 /obj/structure/sign/safety/distribution_pipes{
 	pixel_x = -17
@@ -47052,7 +47068,8 @@
 "kuJ" = (
 /obj/structure/pipes/vents/scrubber,
 /turf/open/floor/almayer{
-	allow_construction = 0
+	dir = 1;
+	icon_state = "red"
 	},
 /area/almayer/shipboard/brig/processing)
 "kvh" = (
@@ -47355,8 +47372,8 @@
 	dir = 2
 	},
 /obj/structure/machinery/door/airlock/almayer/security/reinforced{
-	name = "\improper Execution Equipment";
-	dir = 2
+	dir = 2;
+	name = "\improper Execution Equipment"
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -47566,21 +47583,14 @@
 	icon_state = "redfull"
 	},
 /area/almayer/living/briefing)
-"kEN" = (
-/obj/structure/machinery/door/poddoor/almayer/open{
-	id = "Brig Lockdown Shutters";
-	name = "\improper Brig Lockdown Shutter"
-	},
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/hull/upper_hull/u_f_s)
 "kEU" = (
 /obj/structure/machinery/door/poddoor/almayer/open{
 	id = "Brig Lockdown Shutters";
 	name = "\improper Brig Lockdown Shutter"
 	},
-/turf/open/floor/plating/plating_catwalk,
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
 /area/almayer/hull/upper_hull/u_f_s)
 "kFe" = (
 /obj/effect/decal/cleanable/dirt,
@@ -47656,7 +47666,10 @@
 	},
 /area/almayer/hull/lower_hull/l_f_p)
 "kGu" = (
-/obj/structure/machinery/cryopod,
+/obj/structure/machinery/cryopod{
+	layer = 3.1;
+	pixel_y = 13
+	},
 /obj/structure/machinery/light{
 	dir = 8;
 	invisibility = 101
@@ -49178,8 +49191,8 @@
 	icon_state = "SE-out"
 	},
 /obj/structure/sign/safety/bathunisex{
-	pixel_y = 25;
-	pixel_x = 8
+	pixel_x = 8;
+	pixel_y = 25
 	},
 /turf/open/floor/almayer,
 /area/almayer/shipboard/brig/cells)
@@ -49337,11 +49350,6 @@
 	icon_state = "silvercorner"
 	},
 /area/almayer/shipboard/brig/cic_hallway)
-"lny" = (
-/turf/open/floor/almayer{
-	allow_construction = 0
-	},
-/area/almayer/shipboard/brig/cryo)
 "lnP" = (
 /obj/structure/machinery/vending/cola,
 /obj/structure/window/reinforced,
@@ -50416,9 +50424,9 @@
 	dir = 8
 	},
 /obj/structure/machinery/door/poddoor/almayer/open{
+	dir = 4;
 	id = "courtyard_cells";
-	name = "\improper Courtyard Lockdown Shutter";
-	dir = 4
+	name = "\improper Courtyard Lockdown Shutter"
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -51058,16 +51066,8 @@
 	},
 /area/almayer/shipboard/brig/processing)
 "lUz" = (
-/obj/structure/machinery/door/airlock/almayer/maint/reinforced,
-/obj/structure/machinery/door/poddoor/almayer/open{
-	dir = 4;
-	id = "Brig Lockdown Shutters";
-	name = "\improper Brig Lockdown Shutter"
-	},
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/shipboard/brig/main_office)
+/turf/closed/wall/almayer,
+/area/almayer/hull/upper_hull/u_f_s)
 "lUA" = (
 /obj/structure/surface/table/almayer,
 /obj/item/weapon/gun/rifle/l42a{
@@ -52189,12 +52189,35 @@
 	},
 /area/almayer/squads/delta)
 "mvE" = (
-/obj/structure/machinery/vending/security,
-/obj/structure/machinery/vending/security,
-/turf/open/floor/almayer{
-	icon_state = "plate"
+/obj/item/bedsheet/brown{
+	pixel_y = 13
 	},
-/area/almayer/shipboard/brig/general_equipment)
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 3.3;
+	pixel_y = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = -2;
+	pixel_y = 4
+	},
+/obj/structure/bed{
+	can_buckle = 0
+	},
+/obj/structure/bed{
+	buckling_y = 13;
+	layer = 3.5;
+	pixel_y = 13
+	},
+/obj/item/bedsheet/brown{
+	layer = 3.1
+	},
+/turf/open/floor/almayer{
+	dir = 9;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/main_office)
 "mvI" = (
 /obj/structure/machinery/camera/autoname/almayer{
 	dir = 4;
@@ -52713,8 +52736,8 @@
 /obj/structure/machinery/door_control{
 	id = "courtyard_cells";
 	name = "\improper Courtyard Lockdown Shutters";
-	req_access_txt = "3";
-	pixel_x = 6
+	pixel_x = 6;
+	req_access_txt = "3"
 	},
 /obj/structure/machinery/door_control{
 	id = "Brig Lockdown Shutters";
@@ -54152,7 +54175,6 @@
 /turf/open/floor/almayer,
 /area/almayer/squads/charlie_delta_shared)
 "nhG" = (
-/obj/structure/surface/table/almayer,
 /obj/item/newspaper{
 	name = "character sheet"
 	},
@@ -54176,6 +54198,7 @@
 	pixel_y = -6;
 	req_access_txt = "3"
 	},
+/obj/structure/surface/table/almayer,
 /turf/open/floor/almayer,
 /area/almayer/shipboard/brig/cells)
 "nig" = (
@@ -54353,7 +54376,8 @@
 "nkX" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/computer/cameras/almayer_network{
-	dir = 4
+	dir = 4;
+	layer = 2.8
 	},
 /obj/structure/sign/safety/terminal{
 	pixel_x = 8;
@@ -54777,9 +54801,9 @@
 "nux" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer,
 /obj/structure/machinery/door/poddoor/almayer/open{
+	dir = 4;
 	id = "perma_lockdown";
-	name = "\improper Perma Lockdown Shutter";
-	dir = 4
+	name = "\improper Perma Lockdown Shutter"
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -55465,12 +55489,9 @@
 	},
 /area/almayer/hull/upper_hull/u_a_p)
 "nJz" = (
-/obj/structure/sign/safety/rewire{
-	pixel_y = 32
-	},
 /turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "red"
+	dir = 4;
+	icon_state = "redcorner"
 	},
 /area/almayer/shipboard/brig/main_office)
 "nJH" = (
@@ -56480,12 +56501,12 @@
 /area/almayer/hull/upper_hull/u_f_p)
 "ogK" = (
 /obj/structure/bed/bedroll{
-	name = "cat bed";
-	desc = "A bed of cotton fabric, purposely made for a cat to comfortably sleep on."
+	desc = "A bed of cotton fabric, purposely made for a cat to comfortably sleep on.";
+	name = "cat bed"
 	},
 /obj/structure/machinery/firealarm{
-	pixel_y = 28;
-	pixel_x = -1
+	pixel_x = -1;
+	pixel_y = 28
 	},
 /mob/living/simple_animal/cat/Jones{
 	dir = 8
@@ -58592,6 +58613,14 @@
 /area/almayer/medical/containment)
 "pas" = (
 /obj/structure/machinery/cryopod/right,
+/obj/structure/sign/safety/cryo{
+	pixel_x = 3;
+	pixel_y = 25
+	},
+/obj/structure/sign/safety/rewire{
+	pixel_x = 15;
+	pixel_y = 25
+	},
 /turf/open/floor/almayer{
 	icon_state = "cargo"
 	},
@@ -59230,7 +59259,7 @@
 	name = "\improper Brig Lockdown Shutter"
 	},
 /turf/open/floor/almayer{
-	icon_state = "plate"
+	icon_state = "test_floor4"
 	},
 /area/almayer/hull/upper_hull/u_f_p)
 "prx" = (
@@ -61343,12 +61372,15 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/squads/charlie)
 "qkn" = (
-/obj/structure/sign/safety/maint{
-	pixel_x = -17
+/obj/structure/machinery/power/apc/almayer{
+	cell_type = /obj/item/cell/hyper;
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/almayer,
-/area/almayer/hull/upper_hull/u_f_s)
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/main_office)
 "qkP" = (
 /obj/item/frame/light_fixture{
 	anchored = 1;
@@ -61422,7 +61454,12 @@
 "qlS" = (
 /obj/structure/reagent_dispensers/water_cooler/stacks{
 	density = 0;
+	pixel_x = -7;
 	pixel_y = 17
+	},
+/obj/structure/sign/safety/cryo{
+	pixel_x = 12;
+	pixel_y = 28
 	},
 /turf/open/floor/almayer{
 	dir = 1;
@@ -63358,7 +63395,7 @@
 	icon_state = "pottedplant_18"
 	},
 /turf/open/floor/almayer{
-	dir = 9;
+	dir = 8;
 	icon_state = "red"
 	},
 /area/almayer/shipboard/brig/chief_mp_office)
@@ -63417,8 +63454,8 @@
 "rbi" = (
 /obj/structure/surface/table/almayer,
 /obj/item/storage/box/ids{
-	pixel_y = 8;
-	pixel_x = -6
+	pixel_x = -6;
+	pixel_y = 8
 	},
 /obj/item/device/flash,
 /obj/structure/machinery/light{
@@ -64846,7 +64883,9 @@
 	},
 /area/almayer/hull/upper_hull/u_f_s)
 "rDQ" = (
-/turf/open/floor/almayer,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
 /area/almayer/shipboard/brig/cryo)
 "rDV" = (
 /obj/structure/bed/chair/comfy{
@@ -64863,8 +64902,8 @@
 /obj/effect/spawner/random/powercell,
 /obj/structure/surface/rack,
 /obj/structure/machinery/camera/autoname/almayer{
-	name = "ship-grade camera";
-	dir = 1
+	dir = 1;
+	name = "ship-grade camera"
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/chief_mp_office)
@@ -64924,8 +64963,8 @@
 /area/almayer/command/computerlab)
 "rEO" = (
 /obj/structure/machinery/camera/autoname/almayer{
-	name = "ship-grade camera";
-	dir = 1
+	dir = 1;
+	name = "ship-grade camera"
 	},
 /turf/open/floor/almayer{
 	icon_state = "red"
@@ -64948,10 +64987,12 @@
 /area/almayer/shipboard/brig/cic_hallway)
 "rFg" = (
 /obj/structure/machinery/door/airlock/almayer/generic{
-	name = "Bathroom";
-	dir = 1
+	dir = 1;
+	name = "Bathroom"
 	},
-/turf/open/floor/wood/ship,
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
 /area/almayer/shipboard/brig/chief_mp_office)
 "rFs" = (
 /obj/structure/surface/table/reinforced/almayer_B,
@@ -65235,13 +65276,11 @@
 /turf/open/floor/almayer,
 /area/almayer/living/briefing)
 "rJN" = (
-/obj/item/bedsheet/brown{
-	pixel_y = 13
+/obj/structure/sign/safety/rewire{
+	pixel_y = 32
 	},
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 3.3;
-	pixel_y = 4
+/obj/item/bedsheet/brown{
+	layer = 3.1
 	},
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -65251,13 +65290,18 @@
 /obj/structure/bed{
 	can_buckle = 0
 	},
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 3.3;
+	pixel_y = 4
+	},
 /obj/structure/bed{
 	buckling_y = 13;
 	layer = 3.5;
 	pixel_y = 13
 	},
 /obj/item/bedsheet/brown{
-	layer = 3.1
+	pixel_y = 13
 	},
 /turf/open/floor/almayer{
 	dir = 5;
@@ -66427,9 +66471,9 @@
 	dir = 8
 	},
 /obj/structure/machinery/door/poddoor/almayer/open{
+	dir = 4;
 	id = "courtyard_cells";
-	name = "\improper Courtyard Lockdown Shutter";
-	dir = 4
+	name = "\improper Courtyard Lockdown Shutter"
 	},
 /turf/open/floor/plating,
 /area/almayer/shipboard/brig/chief_mp_office)
@@ -66530,7 +66574,7 @@
 	pixel_y = 27
 	},
 /turf/open/floor/almayer{
-	dir = 1;
+	dir = 9;
 	icon_state = "red"
 	},
 /area/almayer/shipboard/brig/processing)
@@ -66804,8 +66848,8 @@
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/faxmachine/uscm/brig,
 /obj/structure/machinery/camera/autoname/almayer{
-	name = "ship-grade camera";
-	dir = 1
+	dir = 1;
+	name = "ship-grade camera"
 	},
 /turf/open/floor/almayer{
 	icon_state = "red"
@@ -66836,8 +66880,8 @@
 /obj/structure/machinery/door/airlock/multi_tile/almayer/secdoor/glass/reinforced{
 	dir = 2;
 	name = "Brig";
-	req_one_access_txt = "1;3";
-	req_access = null
+	req_access = null;
+	req_one_access_txt = "1;3"
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -67084,11 +67128,11 @@
 	},
 /area/almayer/living/pilotbunks)
 "szR" = (
-/obj/structure/sign/safety/medical{
-	pixel_x = -17
+/obj/structure/machinery/cm_vending/sorted/medical/wall_med{
+	pixel_y = 25
 	},
-/turf/closed/wall/almayer,
-/area/almayer/shipboard/brig/surgery)
+/turf/open/floor/almayer,
+/area/almayer/shipboard/brig/main_office)
 "szU" = (
 /obj/structure/toilet{
 	dir = 8
@@ -68147,8 +68191,8 @@
 /obj/structure/machinery/door_control{
 	id = "cmp_armory";
 	name = "Armory Lockdown";
-	req_access_txt = "4";
-	pixel_y = 24
+	pixel_y = 24;
+	req_access_txt = "4"
 	},
 /obj/structure/sign/safety/ammunition{
 	pixel_y = 32
@@ -68200,16 +68244,19 @@
 	},
 /area/almayer/command/lifeboat)
 "sYE" = (
-/obj/structure/sign/safety/maint{
-	pixel_x = -19;
-	pixel_y = -6
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/sign/safety/bulkhead_door{
-	pixel_x = -19;
-	pixel_y = 6
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
 	},
-/turf/open/floor/almayer,
-/area/almayer/hull/upper_hull/u_f_p)
+/obj/structure/machinery/status_display{
+	pixel_y = -32
+	},
+/turf/open/floor/almayer{
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/main_office)
 "sYP" = (
 /obj/structure/reagent_dispensers/fueltank/custom,
 /turf/open/floor/almayer{
@@ -68344,9 +68391,9 @@
 	name = "\improper Perma Brig"
 	},
 /obj/structure/machinery/door/poddoor/almayer/open{
+	dir = 4;
 	id = "perma_lockdown";
-	name = "\improper Perma Lockdown Shutter";
-	dir = 4
+	name = "\improper Perma Lockdown Shutter"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -70157,8 +70204,8 @@
 	dir = 2
 	},
 /obj/structure/machinery/door/airlock/almayer/security/glass/reinforced{
-	name = "\improper Armory";
-	dir = 2
+	dir = 2;
+	name = "\improper Armory"
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -70225,9 +70272,9 @@
 	dir = 8
 	},
 /obj/structure/machinery/door/poddoor/almayer/open{
+	dir = 4;
 	id = "courtyard_cells";
-	name = "\improper Courtyard Lockdown Shutter";
-	dir = 4
+	name = "\improper Courtyard Lockdown Shutter"
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -70415,7 +70462,15 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_f_s)
 "tRX" = (
-/turf/closed/wall/almayer,
+/obj/structure/machinery/door/airlock/almayer/maint/reinforced,
+/obj/structure/machinery/door/poddoor/almayer/open{
+	dir = 4;
+	id = "Brig Lockdown Shutters";
+	name = "\improper Brig Lockdown Shutter"
+	},
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
 /area/almayer/hull/upper_hull/u_f_s)
 "tSc" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer{
@@ -71690,16 +71745,11 @@
 	},
 /area/almayer/medical/containment/cell)
 "utZ" = (
-/obj/structure/machinery/door/poddoor/almayer/open{
-	dir = 4;
-	id = "Brig Lockdown Shutters";
-	name = "\improper Brig Lockdown Shutter"
-	},
-/obj/structure/machinery/door/airlock/almayer/maint/reinforced,
 /turf/open/floor/almayer{
-	icon_state = "test_floor4"
+	dir = 4;
+	icon_state = "redcorner"
 	},
-/area/almayer/hull/upper_hull/u_f_p)
+/area/almayer/shipboard/brig/processing)
 "uuj" = (
 /obj/structure/surface/table/almayer,
 /obj/item/trash/USCMtray{
@@ -71878,8 +71928,8 @@
 /obj/structure/machinery/door/airlock/multi_tile/almayer/secdoor/glass/reinforced{
 	dir = 2;
 	name = "Brig";
-	req_one_access_txt = "1;3";
-	req_access = null
+	req_access = null;
+	req_one_access_txt = "1;3"
 	},
 /obj/structure/machinery/door/firedoor/border_only/almayer,
 /obj/structure/disposalpipe/segment{
@@ -73714,8 +73764,8 @@
 /area/almayer/command/airoom)
 "viH" = (
 /obj/structure/machinery/door/airlock/almayer/generic{
-	name = "Bathroom";
-	dir = 1
+	dir = 1;
+	name = "Bathroom"
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -74693,7 +74743,7 @@
 	name = "\improper Hydroponics Garden"
 	},
 /turf/open/floor/almayer{
-	icon_state = "greenfull"
+	icon_state = "test_floor4"
 	},
 /area/almayer/shipboard/brig/cells)
 "vzK" = (
@@ -75211,9 +75261,6 @@
 /obj/structure/machinery/light/small{
 	dir = 8
 	},
-/obj/structure/machinery/cm_vending/sorted/medical/wall_med{
-	pixel_y = -30
-	},
 /turf/open/floor/almayer{
 	dir = 4;
 	icon_state = "plating_striped"
@@ -75721,6 +75768,15 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/upper_hull/u_f_p)
+"vUP" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/chief_mp_office)
 "vUU" = (
 /obj/structure/machinery/camera/autoname/almayer{
 	dir = 8;
@@ -76229,7 +76285,7 @@
 	dir = 5;
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/processing)
+/area/almayer/shipboard/brig/chief_mp_office)
 "wdo" = (
 /obj/structure/machinery/door/airlock/almayer/research/reinforced{
 	dir = 8;
@@ -76344,9 +76400,6 @@
 /obj/structure/machinery/light{
 	unacidable = 1;
 	unslashable = 1
-	},
-/obj/structure/machinery/status_display{
-	pixel_y = -32
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -77382,10 +77435,9 @@
 	},
 /obj/structure/surface/table/almayer,
 /obj/effect/spawner/random/toy,
-/obj/effect/spawner/random/goggles/midchance,
 /obj/structure/machinery/camera/autoname/almayer{
-	name = "ship-grade camera";
-	dir = 1
+	dir = 1;
+	name = "ship-grade camera"
 	},
 /turf/open/floor/almayer{
 	dir = 6;
@@ -77436,6 +77488,17 @@
 	icon_state = "ai_floors"
 	},
 /area/almayer/command/airoom)
+"wCZ" = (
+/obj/structure/machinery/door/poddoor/almayer/open{
+	dir = 4;
+	id = "Brig Lockdown Shutters";
+	name = "\improper Brig Lockdown Shutter"
+	},
+/obj/structure/machinery/door/airlock/almayer/maint/reinforced,
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/hull/upper_hull/u_f_p)
 "wDm" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "NE-out";
@@ -78021,15 +78084,11 @@
 	},
 /area/almayer/hull/lower_hull)
 "wNt" = (
-/obj/structure/machinery/power/apc/almayer{
-	cell_type = /obj/item/cell/hyper;
-	dir = 1
-	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red"
+	icon_state = "redcorner"
 	},
-/area/almayer/shipboard/brig/main_office)
+/area/almayer/shipboard/brig/processing)
 "wNS" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
@@ -78630,7 +78689,9 @@
 /obj/structure/machinery/light/small{
 	dir = 8
 	},
-/turf/open/floor/almayer,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
 /area/almayer/shipboard/brig/execution)
 "wZT" = (
 /obj/structure/sign/safety/hvac_old{
@@ -79522,8 +79583,8 @@
 	dir = 5
 	},
 /obj/structure/sign/safety/rewire{
-	pixel_y = -24;
-	pixel_x = 12
+	pixel_x = 12;
+	pixel_y = -24
 	},
 /turf/open/floor/almayer{
 	icon_state = "red"
@@ -80384,8 +80445,8 @@
 	pixel_y = 28
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_y = 28;
-	pixel_x = -14
+	pixel_x = -14;
+	pixel_y = 28
 	},
 /turf/open/floor/almayer{
 	dir = 4;
@@ -80410,8 +80471,6 @@
 	icon_state = "pipe-c"
 	},
 /obj/structure/surface/table/almayer,
-/obj/effect/spawner/random/facepaint,
-/obj/effect/spawner/random/facepaint,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/lobby)
 "xJe" = (
@@ -81149,8 +81208,8 @@
 	name = "\improper cell shutter"
 	},
 /obj/structure/machinery/door/airlock/almayer/security/glass/reinforced{
-	name = "\improper Isolation Cell";
-	dir = 2
+	dir = 2;
+	name = "\improper Isolation Cell"
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -91702,16 +91761,16 @@ gcT
 rmv
 eRL
 eRL
-uJs
+rhl
+gcT
+gcT
 xVl
-xVl
-xVl
-xVl
+gcT
 lxy
-wdF
-wdF
-wdF
-wdF
+oRk
+oRk
+oRk
+utZ
 cMl
 hTt
 kMH
@@ -91914,7 +91973,7 @@ tpn
 xjF
 myP
 gDt
-wdF
+bju
 cMl
 lMc
 xkd
@@ -92107,7 +92166,7 @@ chv
 uhE
 vKB
 lrq
-eRL
+szR
 cZj
 tpn
 eVR
@@ -92117,7 +92176,7 @@ tpn
 mHb
 hjM
 xTH
-wdF
+bju
 wSm
 dEG
 xkd
@@ -92514,7 +92573,7 @@ qMD
 uqo
 lrq
 sYi
-igt
+sYE
 tpn
 gIU
 xIq
@@ -92726,7 +92785,7 @@ tpn
 xIu
 xvQ
 eDt
-wdF
+bju
 cMl
 kAL
 xkd
@@ -92922,14 +92981,14 @@ lrq
 hZU
 cWs
 fAE
-szR
+kHa
 frX
 mHA
 kHa
 snX
-wdF
-wdF
-wdF
+oIh
+oIh
+wNt
 cMl
 nlz
 vNp
@@ -93335,7 +93394,7 @@ kHa
 tzd
 tzd
 sgi
-wdF
+bju
 wSm
 kAL
 xkd
@@ -93351,7 +93410,7 @@ tov
 thL
 sUs
 xkd
-mnm
+lmk
 kIV
 xEF
 aag
@@ -93538,7 +93597,7 @@ swn
 gHt
 oIh
 eNR
-wdF
+bju
 wSm
 ybz
 rrz
@@ -93757,7 +93816,7 @@ iFc
 thL
 tUx
 fgR
-inC
+kIV
 fQk
 ils
 aag
@@ -93944,7 +94003,7 @@ qPO
 ptq
 oRk
 eNR
-wdF
+bju
 cMl
 dEG
 xkd
@@ -94135,7 +94194,7 @@ eaf
 bEv
 vyH
 ajj
-mvE
+rXd
 cqJ
 eRL
 igt
@@ -95351,7 +95410,7 @@ vxM
 rfY
 kGu
 iqR
-rfY
+fyp
 wJh
 ldu
 eRL
@@ -95755,8 +95814,8 @@ tCb
 aou
 vxM
 jvP
-lny
-lny
+rDQ
+rDQ
 rDQ
 ctT
 mLJ
@@ -95779,7 +95838,7 @@ emp
 emp
 emp
 iBl
-wIC
+giR
 wIC
 diP
 rWn
@@ -95981,8 +96040,8 @@ rCU
 rEY
 gxU
 emp
-iBl
-fyp
+vUP
+dgx
 qZA
 dgx
 fKi
@@ -96387,7 +96446,7 @@ wIQ
 xWv
 aQb
 emp
-emp
+wIC
 wIC
 hNY
 qFi
@@ -96768,7 +96827,7 @@ adG
 adG
 gqq
 iCz
-kEN
+kEU
 rPC
 rPC
 vBm
@@ -96975,8 +97034,8 @@ akC
 rDI
 rPC
 vBm
-vBm
-rJN
+mvE
+tak
 lCp
 iLo
 vBm
@@ -97177,9 +97236,9 @@ bzz
 akC
 cRc
 rPC
-wgi
 vBm
-wNt
+qkn
+eRL
 lwK
 vlN
 vBm
@@ -97380,8 +97439,8 @@ aHZ
 akC
 oCL
 rPC
-wgi
 vBm
+rJN
 nJz
 wgi
 rEO
@@ -97583,7 +97642,7 @@ btv
 akC
 dDC
 rPC
-wgi
+vBm
 vBm
 knO
 wgi
@@ -97814,9 +97873,9 @@ wtY
 aTg
 jIT
 wIC
-mnm
+mKf
 kIV
-bVT
+kIV
 kCi
 nwW
 btD
@@ -97987,7 +98046,7 @@ adu
 adu
 aHZ
 akC
-akC
+lUz
 tRX
 lUz
 vBm
@@ -98017,8 +98076,8 @@ yeR
 aTg
 nNg
 wIC
-utZ
 pUJ
+wCZ
 pUJ
 kCi
 nRR
@@ -98190,9 +98249,9 @@ nIt
 adu
 hxG
 akC
-fvu
-qkn
-wgi
+bVT
+wcn
+avl
 vBm
 vBm
 vBm
@@ -98220,9 +98279,9 @@ wIC
 wIC
 wIC
 wIC
-mnm
-sYE
 gpe
+mnm
+dXO
 kCi
 nNt
 vqC

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -11595,9 +11595,7 @@
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 5
 	},
-/turf/open/floor/almayer{
-	icon_state = "silver"
-	},
+/turf/open/floor/almayer,
 /area/almayer/shipboard/brig/cic_hallway)
 "aQg" = (
 /obj/structure/bed/chair/office/dark{
@@ -25689,10 +25687,7 @@
 	},
 /area/almayer/shipboard/brig/cic_hallway)
 "cgT" = (
-/obj/structure/bed/chair{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/junction,
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 5
 	},
@@ -27326,7 +27321,7 @@
 /area/almayer/lifeboat_pumps/south1)
 "crp" = (
 /obj/structure/surface/table/almayer,
-/obj/structure/machinery/computer/cameras/almayer_network{
+/obj/structure/machinery/computer/secure_data{
 	dir = 4
 	},
 /turf/open/floor/almayer{
@@ -27682,11 +27677,18 @@
 	},
 /area/almayer/medical/lower_medical_medbay)
 "cAy" = (
+/obj/structure/machinery/status_display{
+	pixel_y = -30
+	},
+/obj/structure/surface/table/almayer,
+/obj/structure/machinery/computer/emails{
+	dir = 4
+	},
 /turf/open/floor/almayer{
 	dir = 10;
-	icon_state = "red"
+	icon_state = "silver"
 	},
-/area/almayer/shipboard/brig/processing)
+/area/almayer/shipboard/brig/cic_hallway)
 "cAF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -27832,10 +27834,40 @@
 	},
 /area/almayer/hallways/starboard_hallway)
 "cBZ" = (
-/obj/structure/bed/chair/comfy/orange{
-	dir = 8
+/obj/structure/surface/table/almayer,
+/obj/structure/machinery/door_control{
+	id = "courtyard_cells";
+	name = "\improper Courtyard Lockdown Shutters";
+	pixel_x = 6;
+	req_access_txt = "3"
 	},
-/turf/open/floor/almayer,
+/obj/structure/machinery/door_control{
+	id = "Brig Lockdown Shutters";
+	name = "Brig Lockdown Shutters";
+	pixel_x = -6;
+	req_access_txt = "3"
+	},
+/obj/structure/machinery/door_control{
+	id = "courtyard window";
+	name = "Courtyard Window Shutters";
+	pixel_x = -6;
+	pixel_y = 9;
+	req_access_txt = "3"
+	},
+/obj/structure/machinery/door_control{
+	id = "Cell Privacy Shutters";
+	name = "Cell Privacy Shutters";
+	pixel_x = 6;
+	pixel_y = 9;
+	req_access_txt = "3"
+	},
+/obj/structure/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "red"
+	},
 /area/almayer/shipboard/brig/chief_mp_office)
 "cCa" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
@@ -29305,6 +29337,9 @@
 	},
 /area/almayer/hull/upper_hull/u_f_p)
 "dgx" = (
+/obj/structure/flora/pottedplant{
+	icon_state = "pottedplant_18"
+	},
 /turf/open/floor/almayer{
 	dir = 8;
 	icon_state = "red"
@@ -29423,17 +29458,14 @@
 	},
 /area/almayer/squads/alpha_bravo_shared)
 "diP" = (
-/obj/structure/machinery/door/poddoor/shutters/almayer/open{
-	dir = 4;
-	id = "CMP Office Shutters";
-	name = "\improper Privacy Shutters"
+/obj/structure/bed/chair{
+	dir = 8
 	},
-/obj/structure/window/framed/almayer,
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	layer = 1.9
+/turf/open/floor/almayer{
+	dir = 8;
+	icon_state = "silvercorner"
 	},
-/turf/open/floor/plating,
-/area/almayer/shipboard/brig/chief_mp_office)
+/area/almayer/shipboard/brig/cic_hallway)
 "djp" = (
 /obj/structure/closet/crate,
 /obj/item/stack/sheet/mineral/plastic{
@@ -36633,15 +36665,13 @@
 	},
 /area/almayer/hallways/aft_hallway)
 "giR" = (
-/obj/structure/window/framed/almayer,
-/obj/structure/machinery/door/poddoor/shutters/almayer/open{
-	dir = 4;
-	id = "CMP Office Shutters";
-	name = "\improper Privacy Shutters"
+/obj/structure/machinery/light/small{
+	dir = 4
 	},
-/obj/structure/machinery/door/firedoor/border_only/almayer,
-/turf/open/floor/plating,
-/area/almayer/shipboard/brig/chief_mp_office)
+/turf/open/floor/almayer{
+	icon_state = "silver"
+	},
+/area/almayer/shipboard/brig/cic_hallway)
 "gjm" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N";
@@ -37175,20 +37205,13 @@
 	},
 /area/almayer/hull/upper_hull/u_f_p)
 "gwj" = (
-/obj/structure/machinery/door/poddoor/shutters/almayer/open{
-	dir = 2;
-	id = "Warden Office Shutters";
-	name = "\improper Privacy Shutters"
-	},
-/obj/structure/pipes/standard/simple/hidden/supply,
-/obj/structure/machinery/door/airlock/almayer/security/glass/reinforced{
-	dir = 1;
-	name = "\improper Warden's Office"
+/obj/structure/pipes/standard/manifold/hidden/supply{
+	dir = 8
 	},
 /turf/open/floor/almayer{
-	icon_state = "test_floor4"
+	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/chief_mp_office)
+/area/almayer/shipboard/brig/processing)
 "gwm" = (
 /obj/structure/largecrate/random/case/small,
 /obj/item/device/taperecorder{
@@ -37344,12 +37367,7 @@
 /area/almayer/medical/containment/cell)
 "gxU" = (
 /obj/structure/surface/table/almayer,
-/obj/structure/machinery/status_display{
-	pixel_y = -30
-	},
-/obj/structure/machinery/computer/emails{
-	dir = 4
-	},
+/obj/item/toy/deck,
 /turf/open/floor/almayer{
 	dir = 10;
 	icon_state = "silver"
@@ -37638,7 +37656,7 @@
 	},
 /obj/structure/transmitter/rotary/no_dnd{
 	name = "Brig Cells Telephone";
-	phone_category = "Almayer";
+	phone_category = "MP Dept.";
 	phone_id = "Brig Cells";
 	pixel_x = 16
 	},
@@ -37719,6 +37737,16 @@
 	icon_state = "plate"
 	},
 /area/almayer/hull/lower_hull/l_m_s)
+"gFv" = (
+/obj/structure/surface/table/almayer,
+/obj/structure/machinery/computer/cameras/almayer_network{
+	dir = 4
+	},
+/turf/open/floor/almayer{
+	dir = 8;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/chief_mp_office)
 "gFG" = (
 /obj/structure/surface/rack,
 /obj/effect/spawner/random/tool,
@@ -38499,22 +38527,15 @@
 	},
 /area/almayer/hull/lower_hull/l_a_p)
 "gXx" = (
-/obj/structure/closet/secure_closet/cmdcabinet{
-	desc = "A bulletproof cabinet containing communications equipment.";
-	name = "communications cabinet";
-	pixel_y = 24;
-	req_access = null;
-	req_one_access_txt = "3"
+/obj/structure/machinery/power/apc/almayer{
+	dir = 4
 	},
-/obj/item/device/radio/listening_bug/radio_linked/mp{
-	pixel_y = 8
+/obj/structure/sign/safety/rewire{
+	pixel_x = 7;
+	pixel_y = -30
 	},
-/obj/item/device/radio/listening_bug/radio_linked/mp,
-/turf/open/floor/almayer{
-	dir = 5;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/chief_mp_office)
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/brig/cells)
 "gXB" = (
 /obj/structure/pipes/vents/pump,
 /obj/structure/bed/chair/comfy/delta{
@@ -41145,7 +41166,7 @@
 "hZU" = (
 /obj/structure/transmitter{
 	name = "Brig Offices Telephone";
-	phone_category = "Almayer";
+	phone_category = "MP Dept.";
 	phone_id = "Brig Main Offices";
 	pixel_y = 32
 	},
@@ -42412,23 +42433,11 @@
 	},
 /area/almayer/hallways/port_hallway)
 "iBl" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/machinery/door/poddoor/shutters/almayer/open{
-	dir = 4;
-	id = "CMP Office Shutters";
-	name = "\improper Privacy Shutters"
-	},
-/obj/structure/machinery/door/airlock/almayer/security/glass{
-	dir = 8;
-	name = "\improper Chief MP's Office"
-	},
-/obj/structure/machinery/door/firedoor/border_only/almayer,
 /turf/open/floor/almayer{
-	icon_state = "test_floor4"
+	dir = 10;
+	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/chief_mp_office)
+/area/almayer/shipboard/brig/processing)
 "iBt" = (
 /turf/open/floor/plating,
 /area/almayer/hull/upper_hull/u_m_p)
@@ -43232,13 +43241,10 @@
 /area/almayer/hull/upper_hull/u_a_p)
 "iTl" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 1
+	dir = 4
 	},
-/turf/open/floor/almayer{
-	dir = 4;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/chief_mp_office)
+/turf/open/floor/almayer,
+/area/almayer/shipboard/brig/processing)
 "iTw" = (
 /obj/structure/bed/chair/comfy{
 	dir = 4
@@ -43947,7 +43953,7 @@
 /obj/item/folder/red,
 /obj/structure/transmitter/rotary{
 	name = "Brig CMP's Office Telephone";
-	phone_category = "Offices";
+	phone_category = "MP Dept.";
 	phone_id = "Brig CMP's Office";
 	pixel_x = 15
 	},
@@ -45552,14 +45558,18 @@
 	},
 /area/almayer/engineering/upper_engineering/starboard)
 "jPP" = (
+/obj/structure/machinery/door/firedoor/border_only/almayer,
+/obj/structure/machinery/door/airlock/almayer/security/glass{
+	dir = 8;
+	name = "\improper Chief MP's Office"
+	},
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	dir = 4;
-	icon_state = "redcorner"
+	icon_state = "test_floor4"
 	},
-/area/almayer/shipboard/brig/processing)
+/area/almayer/shipboard/brig/chief_mp_office)
 "jPS" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 1
@@ -49324,21 +49334,13 @@
 	},
 /area/almayer/engineering/upper_engineering/port)
 "lnh" = (
-/obj/structure/surface/table/almayer,
-/obj/structure/machinery/recharger,
-/obj/structure/sign/safety/terminal{
-	pixel_y = 32
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 10
 	},
-/obj/structure/transmitter/rotary{
-	name = "Brig CMP's Office Telephone";
-	phone_category = "Offices";
-	phone_id = "Brig CMP's Office";
-	pixel_x = 15
+/obj/structure/machinery/light/small{
+	dir = 1
 	},
-/turf/open/floor/almayer{
-	dir = 9;
-	icon_state = "red"
-	},
+/turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/chief_mp_office)
 "lnm" = (
 /turf/open/floor/almayer{
@@ -52732,39 +52734,18 @@
 /turf/open/floor/almayer,
 /area/almayer/living/gym)
 "mHz" = (
-/obj/structure/surface/table/almayer,
-/obj/structure/machinery/door_control{
-	id = "courtyard_cells";
-	name = "\improper Courtyard Lockdown Shutters";
-	pixel_x = 6;
-	req_access_txt = "3"
+/obj/structure/machinery/door/poddoor/shutters/almayer/open{
+	dir = 2;
+	id = "Warden Office Shutters";
+	name = "\improper Privacy Shutters"
 	},
-/obj/structure/machinery/door_control{
-	id = "Brig Lockdown Shutters";
-	name = "Brig Lockdown Shutters";
-	pixel_x = -6;
-	req_access_txt = "3"
-	},
-/obj/structure/machinery/door_control{
-	id = "courtyard window";
-	name = "Courtyard Window Shutters";
-	pixel_x = -6;
-	pixel_y = 9;
-	req_access_txt = "3"
-	},
-/obj/structure/machinery/door_control{
-	id = "Cell Privacy Shutters";
-	name = "Cell Privacy Shutters";
-	pixel_x = 6;
-	pixel_y = 9;
-	req_access_txt = "3"
-	},
-/obj/structure/machinery/light{
-	dir = 1
+/obj/structure/pipes/standard/simple/hidden/supply,
+/obj/structure/machinery/door/airlock/almayer/security/glass/reinforced{
+	dir = 1;
+	name = "\improper Warden's Office"
 	},
 /turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "red"
+	icon_state = "test_floor4"
 	},
 /area/almayer/shipboard/brig/chief_mp_office)
 "mHA" = (
@@ -56814,10 +56795,7 @@
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 5
 	},
-/turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "silvercorner"
-	},
+/turf/open/floor/almayer,
 /area/almayer/shipboard/brig/cic_hallway)
 "omP" = (
 /obj/item/tool/mop,
@@ -59423,11 +59401,18 @@
 /area/almayer/shipboard/brig/main_office)
 "puE" = (
 /obj/structure/surface/table/almayer,
-/obj/structure/machinery/computer/secure_data{
-	dir = 4
+/obj/structure/machinery/recharger,
+/obj/structure/sign/safety/terminal{
+	pixel_y = 32
+	},
+/obj/structure/transmitter/rotary{
+	name = "Brig Wardens's Office Telephone";
+	phone_category = "MP Dept.";
+	phone_id = "Brig CMP's Office";
+	pixel_x = 15
 	},
 /turf/open/floor/almayer{
-	dir = 8;
+	dir = 9;
 	icon_state = "red"
 	},
 /area/almayer/shipboard/brig/chief_mp_office)
@@ -63391,8 +63376,8 @@
 /turf/open/floor/almayer,
 /area/almayer/living/briefing)
 "qZA" = (
-/obj/structure/flora/pottedplant{
-	icon_state = "pottedplant_18"
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
 	},
 /turf/open/floor/almayer{
 	dir = 8;
@@ -64798,15 +64783,22 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/living/briefing)
 "rCU" = (
-/obj/structure/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
+/obj/structure/closet/secure_closet/cmdcabinet{
+	desc = "A bulletproof cabinet containing communications equipment.";
+	name = "communications cabinet";
+	pixel_y = 24;
+	req_access = null;
+	req_one_access_txt = "3"
 	},
+/obj/item/device/radio/listening_bug/radio_linked/mp{
+	pixel_y = 8
+	},
+/obj/item/device/radio/listening_bug/radio_linked/mp,
 /turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "silver"
+	dir = 5;
+	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/cic_hallway)
+/area/almayer/shipboard/brig/chief_mp_office)
 "rDb" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 6
@@ -64978,8 +64970,10 @@
 	},
 /area/almayer/shipboard/brig/surgery)
 "rEY" = (
-/obj/structure/surface/table/almayer,
-/obj/item/toy/deck,
+/obj/structure/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
 /turf/open/floor/almayer{
 	dir = 8;
 	icon_state = "silver"
@@ -65539,7 +65533,7 @@
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 1
 	},
-/obj/structure/disposalpipe/junction,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer,
 /area/almayer/shipboard/brig/cic_hallway)
 "rQy" = (
@@ -73059,10 +73053,6 @@
 /obj/structure/machinery/light{
 	dir = 4
 	},
-/obj/structure/machinery/power/apc/almayer,
-/obj/structure/sign/safety/rewire{
-	pixel_y = -38
-	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/cells)
 "uVX" = (
@@ -75769,14 +75759,8 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/upper_hull/u_f_p)
 "vUP" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/chief_mp_office)
+/turf/closed/wall/almayer/reinforced,
+/area/almayer/shipboard/brig/cic_hallway)
 "vUU" = (
 /obj/structure/machinery/camera/autoname/almayer{
 	dir = 8;
@@ -76275,17 +76259,17 @@
 /turf/open/floor/almayer,
 /area/almayer/living/auxiliary_officer_office)
 "wdh" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 10
-	},
-/obj/structure/machinery/light/small{
-	dir = 4
+/obj/structure/surface/table/almayer,
+/obj/item/tool/extinguisher,
+/obj/item/reagent_container/spray/cleaner{
+	pixel_x = -8;
+	pixel_y = 3
 	},
 /turf/open/floor/almayer{
-	dir = 5;
-	icon_state = "red"
+	dir = 10;
+	icon_state = "silver"
 	},
-/area/almayer/shipboard/brig/chief_mp_office)
+/area/almayer/shipboard/brig/cic_hallway)
 "wdo" = (
 /obj/structure/machinery/door/airlock/almayer/research/reinforced{
 	dir = 8;
@@ -77059,7 +77043,9 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/obj/structure/pipes/standard/manifold/fourway/hidden/supply,
+/obj/structure/pipes/standard/manifold/hidden/supply{
+	dir = 4
+	},
 /turf/open/floor/almayer,
 /area/almayer/shipboard/brig/processing)
 "wst" = (
@@ -79475,12 +79461,11 @@
 	},
 /area/almayer/living/commandbunks)
 "xpo" = (
-/obj/structure/machinery/light,
-/turf/open/floor/almayer{
-	dir = 10;
-	icon_state = "silver"
+/obj/structure/bed/chair/comfy/orange{
+	dir = 8
 	},
-/area/almayer/shipboard/brig/cic_hallway)
+/turf/open/floor/almayer,
+/area/almayer/shipboard/brig/chief_mp_office)
 "xpt" = (
 /obj/structure/machinery/cm_vending/sorted/medical/wall_med{
 	pixel_y = 25
@@ -79679,19 +79664,11 @@
 	},
 /area/almayer/hull/upper_hull/u_m_s)
 "xuc" = (
-/obj/structure/surface/table/almayer,
-/obj/item/tool/extinguisher,
-/obj/item/reagent_container/spray/cleaner{
-	pixel_x = -8;
-	pixel_y = 3
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/turf/open/floor/almayer{
-	icon_state = "silver"
-	},
+/turf/open/floor/almayer,
 /area/almayer/shipboard/brig/cic_hallway)
 "xuB" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
@@ -94824,8 +94801,8 @@ iTI
 bQc
 pgP
 uVV
+gXx
 wIC
-smZ
 smZ
 smZ
 wIC
@@ -95027,11 +95004,11 @@ emp
 emp
 lFJ
 emp
+emp
 wIC
-lnh
 puE
 crp
-dgx
+gFv
 dqZ
 wIC
 lTK
@@ -95229,11 +95206,11 @@ slF
 oIh
 qUz
 ksg
-cAy
+oIh
+iBl
 wIC
-mHz
 cBZ
-vAG
+xpo
 vAG
 jIo
 wIC
@@ -95434,7 +95411,7 @@ oDy
 wsq
 vxK
 gwj
-jPS
+mHz
 jPS
 jPS
 sJm
@@ -95634,11 +95611,11 @@ emp
 bPH
 rJj
 mBx
-jPP
+utZ
 pyj
+iTl
 wIC
-gXx
-xqs
+rCU
 xqs
 rWF
 uSB
@@ -95837,10 +95814,10 @@ emp
 emp
 emp
 emp
-iBl
-giR
+emp
 wIC
-diP
+jPP
+wIC
 rWn
 rWn
 wIC
@@ -96036,12 +96013,12 @@ mSs
 xuZ
 xuZ
 xuZ
-rCU
+xuZ
 rEY
 gxU
-emp
+cAy
 vUP
-dgx
+wIC
 qZA
 dgx
 fKi
@@ -96242,10 +96219,10 @@ rWs
 rQt
 cgT
 xuc
-emp
+diP
 wdh
-iTl
-jPS
+wIC
+lnh
 jPS
 jPS
 xrt
@@ -96445,8 +96422,8 @@ uVA
 wIQ
 xWv
 aQb
-emp
-wIC
+vka
+jUY
 wIC
 hNY
 qFi
@@ -96649,7 +96626,7 @@ jfK
 wIQ
 mPj
 omy
-xpo
+sCQ
 wIC
 wvE
 jhI
@@ -97258,7 +97235,7 @@ udx
 qwp
 pZS
 jHh
-jUY
+giR
 wIC
 wIC
 vzj

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -25745,10 +25745,7 @@
 /area/almayer/hallways/aft_hallway)
 "chv" = (
 /obj/structure/closet/secure_closet/guncabinet/red/mp_armory_shotgun,
-/turf/open/floor/almayer{
-	dir = 4;
-	icon_state = "plating_striped"
-	},
+/turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/armory)
 "chC" = (
 /obj/structure/platform_decoration,
@@ -26119,6 +26116,17 @@
 	icon_state = "red"
 	},
 /area/almayer/hallways/port_hallway)
+"cjz" = (
+/obj/structure/bed/chair/bolted{
+	dir = 1
+	},
+/obj/structure/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/shipboard/brig/perma)
 "cjA" = (
 /obj/structure/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -27678,10 +27686,7 @@
 	dir = 4;
 	name = "ship-grade camera"
 	},
-/turf/open/floor/almayer{
-	dir = 4;
-	icon_state = "plating_striped"
-	},
+/turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/armory)
 "cAF" = (
 /obj/structure/disposalpipe/segment{
@@ -30402,6 +30407,16 @@
 	},
 /turf/open/floor/wood/ship,
 /area/almayer/shipboard/brig/chief_mp_office)
+"dBS" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "W";
+	layer = 2.5
+	},
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 10
+	},
+/turf/open/floor/almayer,
+/area/almayer/shipboard/brig/execution)
 "dCe" = (
 /obj/structure/machinery/cryopod{
 	pixel_y = 6
@@ -30623,18 +30638,10 @@
 /obj/item/weapon/shield/riot,
 /obj/item/weapon/shield/riot,
 /obj/item/weapon/shield/riot,
-/obj/effect/decal/warning_stripes{
-	icon_state = "SW-out";
-	pixel_x = -1;
-	pixel_y = -1
-	},
 /obj/structure/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/almayer{
-	dir = 5;
-	icon_state = "plating"
-	},
+/turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/armory)
 "dFk" = (
 /turf/open/floor/almayer{
@@ -32110,6 +32117,15 @@
 "eky" = (
 /turf/open/floor/almayer,
 /area/almayer/command/lifeboat)
+"ekF" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/main_office)
 "ekO" = (
 /obj/structure/machinery/cryopod{
 	pixel_y = 6
@@ -34015,6 +34031,9 @@
 /area/almayer/hallways/aft_hallway)
 "fag" = (
 /obj/effect/decal/cleanable/blood,
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
 /turf/open/floor/almayer,
 /area/almayer/shipboard/brig/execution)
 "fau" = (
@@ -34997,10 +35016,7 @@
 /obj/item/weapon/shield/riot,
 /obj/item/weapon/shield/riot,
 /obj/item/weapon/shield/riot,
-/turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "plating_striped"
-	},
+/turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/armory)
 "fxO" = (
 /obj/structure/machinery/vending/coffee{
@@ -35117,10 +35133,7 @@
 /area/almayer/command/corporateliason)
 "fAr" = (
 /obj/structure/closet/secure_closet/guncabinet/red/mp_armory_m39_submachinegun,
-/turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "plating_striped"
-	},
+/turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/armory)
 "fAt" = (
 /obj/structure/largecrate/guns/merc{
@@ -36281,7 +36294,10 @@
 /obj/structure/machinery/status_display{
 	pixel_y = 30
 	},
-/turf/open/floor/almayer,
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "red"
+	},
 /area/almayer/shipboard/brig/main_office)
 "gaJ" = (
 /turf/closed/wall/almayer,
@@ -38929,8 +38945,16 @@
 	pixel_x = -15;
 	pixel_y = 25
 	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "E";
+	pixel_x = 2
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "W";
+	pixel_x = -2
+	},
 /turf/open/floor/almayer{
-	icon_state = "plating_striped"
+	icon_state = "plate"
 	},
 /area/almayer/shipboard/brig/armory)
 "heK" = (
@@ -42434,7 +42458,7 @@
 	pixel_x = 7;
 	pixel_y = -30
 	},
-/turf/open/floor/plating/plating_catwalk,
+/turf/open/floor/almayer,
 /area/almayer/shipboard/brig/cells)
 "iBt" = (
 /turf/open/floor/plating,
@@ -42592,9 +42616,7 @@
 /turf/open/floor/wood/ship,
 /area/almayer/living/commandbunks)
 "iFc" = (
-/obj/structure/pipes/vents/pump{
-	dir = 1
-	},
+/obj/structure/pipes/vents/pump,
 /turf/open/floor/wood/ship,
 /area/almayer/shipboard/brig/cells)
 "iFm" = (
@@ -45851,9 +45873,6 @@
 	},
 /area/almayer/command/computerlab)
 "jVP" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
 /obj/structure/machinery/light{
 	unacidable = 1;
 	unslashable = 1
@@ -46889,9 +46908,6 @@
 	},
 /area/almayer/living/gym)
 "kry" = (
-/obj/structure/machinery/light{
-	dir = 1
-	},
 /obj/structure/machinery/flasher{
 	id = "Perma 1";
 	pixel_y = 24
@@ -47035,9 +47051,7 @@
 	pixel_y = 32
 	},
 /obj/structure/machinery/vending/security/riot,
-/turf/open/floor/almayer{
-	icon_state = "plating_striped"
-	},
+/turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/armory)
 "kuk" = (
 /obj/structure/pipes/vents/pump{
@@ -47525,13 +47539,8 @@
 /obj/item/vehicle_clamp,
 /obj/item/vehicle_clamp,
 /obj/item/vehicle_clamp,
-/obj/effect/decal/warning_stripes{
-	icon_state = "SE-out";
-	pixel_x = 1;
-	pixel_y = -1
-	},
 /obj/structure/closet/secure_closet/guncabinet/red/mp_armory_shotgun,
-/turf/open/floor/plating/almayer,
+/turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/armory)
 "kEg" = (
 /obj/structure/surface/table/almayer,
@@ -47662,10 +47671,6 @@
 /obj/structure/machinery/cryopod{
 	layer = 3.1;
 	pixel_y = 13
-	},
-/obj/structure/machinery/light{
-	dir = 8;
-	invisibility = 101
 	},
 /obj/structure/machinery/status_display{
 	pixel_x = -32
@@ -50830,9 +50835,7 @@
 /obj/structure/machinery/light{
 	dir = 1
 	},
-/obj/structure/pipes/vents/pump{
-	dir = 4
-	},
+/obj/structure/pipes/vents/pump,
 /turf/open/floor/almayer{
 	dir = 1;
 	icon_state = "red"
@@ -51569,9 +51572,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/starboard_hallway)
 "mjt" = (
-/obj/structure/pipes/vents/pump{
-	dir = 1
-	},
+/obj/structure/pipes/vents/pump,
 /turf/open/floor/almayer{
 	allow_construction = 0
 	},
@@ -52347,6 +52348,33 @@
 	icon_state = "red"
 	},
 /area/almayer/shipboard/brig/processing)
+"mza" = (
+/obj/structure/machinery/door/poddoor/shutters/almayer{
+	dir = 2;
+	id = "firearm_storage_armory";
+	name = "\improper Armory Shutters"
+	},
+/obj/structure/machinery/door/firedoor/border_only/almayer{
+	dir = 2
+	},
+/obj/structure/machinery/door/airlock/almayer/security/glass/reinforced{
+	dir = 2;
+	name = "\improper Armory"
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "NE-out";
+	pixel_x = 2;
+	pixel_y = 1
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "NW-out";
+	pixel_x = -2;
+	pixel_y = 1
+	},
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/shipboard/brig/armory)
 "mzb" = (
 /obj/structure/prop/invuln/overhead_pipe{
 	pixel_x = 12
@@ -53082,7 +53110,10 @@
 /obj/structure/pipes/standard/manifold/hidden/supply{
 	dir = 4
 	},
-/turf/open/floor/almayer,
+/turf/open/floor/almayer{
+	dir = 4;
+	icon_state = "red"
+	},
 /area/almayer/shipboard/brig/main_office)
 "mNf" = (
 /obj/structure/largecrate/random/case/double,
@@ -53813,9 +53844,6 @@
 	},
 /area/almayer/living/gym)
 "ncf" = (
-/obj/structure/machinery/light{
-	dir = 4
-	},
 /obj/structure/machinery/cryopod/right{
 	layer = 3.1;
 	pixel_y = 13
@@ -54528,6 +54556,19 @@
 	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/containment)
+"nqe" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "E";
+	pixel_x = 2
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "W";
+	pixel_x = -2
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/shipboard/brig/armory)
 "nqx" = (
 /obj/structure/pipes/standard/manifold/hidden/supply,
 /turf/open/floor/plating/plating_catwalk,
@@ -55809,9 +55850,7 @@
 	icon_state = "W";
 	layer = 2.5
 	},
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 10
-	},
+/obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer,
 /area/almayer/shipboard/brig/execution)
 "nSG" = (
@@ -56875,9 +56914,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/living/gym)
 "opF" = (
-/obj/structure/pipes/vents/pump{
-	dir = 1
-	},
+/obj/structure/pipes/vents/pump,
 /turf/open/floor/almayer{
 	dir = 4;
 	icon_state = "red"
@@ -58568,6 +58605,9 @@
 	pixel_x = 15;
 	pixel_y = 25
 	},
+/obj/structure/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/almayer{
 	icon_state = "cargo"
 	},
@@ -59925,7 +59965,7 @@
 	pixel_y = 5
 	},
 /obj/structure/surface/table/almayer,
-/turf/open/floor/almayer,
+/turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/armory)
 "pIf" = (
 /obj/structure/disposalpipe/junction{
@@ -61536,10 +61576,7 @@
 	dir = 4
 	},
 /obj/structure/closet/secure_closet/guncabinet/red/mp_armory_m39_submachinegun,
-/turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "plating_striped"
-	},
+/turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/armory)
 "qnd" = (
 /obj/effect/decal/warning_stripes{
@@ -62805,7 +62842,7 @@
 	pixel_x = -8;
 	pixel_y = 5
 	},
-/turf/open/floor/almayer,
+/turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/armory)
 "qMP" = (
 /obj/structure/bed/chair/comfy{
@@ -63490,6 +63527,9 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/blood,
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 6
+	},
 /turf/open/floor/almayer{
 	icon_state = "cargo"
 	},
@@ -63725,6 +63765,10 @@
 /area/almayer/living/port_emb)
 "rfY" = (
 /obj/structure/machinery/cryopod,
+/obj/structure/machinery/light{
+	dir = 8;
+	invisibility = 101
+	},
 /turf/open/floor/almayer{
 	icon_state = "cargo"
 	},
@@ -64602,7 +64646,10 @@
 /obj/structure/machinery/firealarm{
 	pixel_y = 28
 	},
-/turf/open/floor/almayer,
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "red"
+	},
 /area/almayer/shipboard/brig/main_office)
 "rAb" = (
 /turf/open/floor/almayer{
@@ -65706,7 +65753,9 @@
 	icon_state = "pipe-c"
 	},
 /obj/structure/pipes/standard/simple/hidden/supply,
-/turf/open/floor/almayer,
+/turf/open/floor/almayer{
+	icon_state = "redcorner"
+	},
 /area/almayer/shipboard/brig/main_office)
 "rVo" = (
 /obj/structure/machinery/light/small{
@@ -67368,8 +67417,16 @@
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_y = 26
 	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "E";
+	pixel_x = 2
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "W";
+	pixel_x = -2
+	},
 /turf/open/floor/almayer{
-	icon_state = "plating_striped"
+	icon_state = "plate"
 	},
 /area/almayer/shipboard/brig/armory)
 "sFf" = (
@@ -67571,9 +67628,7 @@
 	},
 /area/almayer/hull/lower_hull/l_a_p)
 "sJm" = (
-/obj/structure/pipes/vents/pump{
-	dir = 1
-	},
+/obj/structure/pipes/vents/pump,
 /turf/open/floor/almayer,
 /area/almayer/shipboard/brig/chief_mp_office)
 "sJC" = (
@@ -68993,9 +69048,7 @@
 /turf/open/floor/almayer,
 /area/almayer/living/briefing)
 "tmH" = (
-/obj/structure/pipes/vents/pump{
-	dir = 1
-	},
+/obj/structure/pipes/vents/pump,
 /obj/structure/machinery/camera/autoname/almayer{
 	dir = 4;
 	name = "ship-grade camera";
@@ -70164,17 +70217,27 @@
 	},
 /area/almayer/living/bridgebunks)
 "tLa" = (
-/obj/structure/machinery/door/poddoor/shutters/almayer{
-	dir = 2;
-	id = "firearm_storage_armory";
-	name = "\improper Armory Shutters"
-	},
 /obj/structure/machinery/door/firedoor/border_only/almayer{
 	dir = 2
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "NW-out";
+	pixel_x = -2;
+	pixel_y = 1
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "NE-out";
+	pixel_x = 2;
+	pixel_y = 1
 	},
 /obj/structure/machinery/door/airlock/almayer/security/glass/reinforced{
 	dir = 2;
 	name = "\improper Armory"
+	},
+/obj/structure/machinery/door/poddoor/shutters/almayer{
+	dir = 2;
+	id = "firearm_storage_armory";
+	name = "\improper Armory Shutters"
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -70747,6 +70810,9 @@
 /obj/structure/bed/chair/bolted{
 	dir = 1
 	},
+/obj/structure/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -71186,10 +71252,7 @@
 /area/almayer/living/offices)
 "uhE" = (
 /obj/structure/closet/secure_closet/guncabinet/red/mp_armory_m4ra_rifle,
-/turf/open/floor/almayer{
-	dir = 4;
-	icon_state = "plating_striped"
-	},
+/turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/armory)
 "uhM" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
@@ -71205,6 +71268,12 @@
 	icon_state = "cargo_arrow"
 	},
 /area/almayer/living/offices)
+"uhW" = (
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "redcorner"
+	},
+/area/almayer/shipboard/brig/main_office)
 "uia" = (
 /obj/structure/prop/invuln/overhead_pipe{
 	pixel_x = 12
@@ -72353,9 +72422,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull/l_m_s)
 "uGN" = (
-/obj/structure/pipes/vents/pump{
-	dir = 8
-	},
+/obj/structure/pipes/vents/pump,
 /turf/open/floor/almayer,
 /area/almayer/shipboard/brig/general_equipment)
 "uGQ" = (
@@ -73028,7 +73095,7 @@
 /obj/structure/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/plating/plating_catwalk,
+/turf/open/floor/almayer,
 /area/almayer/shipboard/brig/cells)
 "uVX" = (
 /obj/structure/machinery/light{
@@ -73926,9 +73993,7 @@
 /turf/open/floor/almayer,
 /area/almayer/shipboard/brig/cells)
 "vlN" = (
-/obj/structure/pipes/vents/pump{
-	dir = 8
-	},
+/obj/structure/pipes/vents/pump,
 /turf/open/floor/almayer{
 	icon_state = "red"
 	},
@@ -75226,10 +75291,7 @@
 /obj/structure/machinery/light/small{
 	dir = 8
 	},
-/turf/open/floor/almayer{
-	dir = 4;
-	icon_state = "plating_striped"
-	},
+/turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/armory)
 "vKF" = (
 /obj/structure/stairs{
@@ -76809,9 +76871,6 @@
 /turf/open/floor/plating,
 /area/almayer/command/airoom)
 "wnw" = (
-/obj/structure/machinery/light{
-	dir = 1
-	},
 /obj/structure/machinery/flasher{
 	id = "Perma 2";
 	pixel_y = 24
@@ -77395,7 +77454,6 @@
 	pixel_x = 32
 	},
 /obj/structure/surface/table/almayer,
-/obj/effect/spawner/random/toy,
 /obj/structure/machinery/camera/autoname/almayer{
 	dir = 1;
 	name = "ship-grade camera"
@@ -78629,9 +78687,7 @@
 	},
 /area/almayer/hull/lower_hull/l_a_s)
 "wZL" = (
-/obj/structure/pipes/vents/pump{
-	dir = 1
-	},
+/obj/structure/pipes/vents/pump,
 /turf/open/floor/almayer,
 /area/almayer/shipboard/brig/perma)
 "wZM" = (
@@ -89511,7 +89567,7 @@ mtl
 vdl
 nPb
 fZX
-fZX
+dBS
 nSu
 wld
 mtl
@@ -90519,7 +90575,7 @@ wcn
 tYB
 naB
 pQr
-tYW
+cjz
 wvI
 piK
 fvA
@@ -92338,10 +92394,10 @@ hKi
 rPC
 lrq
 heo
-uqo
-uqo
-uqo
-uqo
+nqe
+nqe
+nqe
+nqe
 tLa
 eRL
 igt
@@ -92744,11 +92800,11 @@ hUg
 wcn
 lrq
 sEZ
-uqo
-uqo
-uqo
-uqo
-tLa
+nqe
+nqe
+nqe
+nqe
+mza
 eRL
 wfB
 tpn
@@ -93764,7 +93820,7 @@ quj
 vgi
 rXd
 cqJ
-eRL
+ldu
 igt
 swn
 dfO
@@ -94170,7 +94226,7 @@ vyH
 ajj
 rXd
 cqJ
-eRL
+ldu
 igt
 swn
 plI
@@ -94577,7 +94633,7 @@ ajj
 tuk
 cQv
 rzY
-uJs
+igt
 swn
 skq
 dQv
@@ -94982,7 +95038,7 @@ cov
 cqJ
 hNl
 tak
-eRL
+uhW
 uJs
 tsX
 ngr
@@ -95995,7 +96051,7 @@ sbP
 sbP
 sbP
 wJh
-mLJ
+ekF
 uif
 vBm
 vBm
@@ -96198,8 +96254,8 @@ ncf
 kjk
 qxr
 wJh
-mLJ
-eRL
+ekF
+ugT
 qqC
 ceZ
 jnD

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -3320,7 +3320,7 @@
 	},
 /obj/structure/machinery/door/airlock/almayer/security/glass/reinforced{
 	dir = 1;
-	name = "\improper Brig"
+	name = "\improper Brig Maintenance"
 	},
 /obj/structure/machinery/door/poddoor/almayer/open{
 	id = "perma_lockdown_2";
@@ -9054,10 +9054,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/pipes/standard/simple/hidden/supply,
-/obj/structure/machinery/door/airlock/almayer/security/glass{
-	dir = 2;
-	name = "Brig"
-	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
 	},
@@ -27447,7 +27443,7 @@
 "ctT" = (
 /obj/structure/machinery/door/airlock/almayer/security/glass{
 	dir = 1;
-	name = "\improper Cryo Room"
+	name = "\improper Cryogenics Bay"
 	},
 /obj/structure/machinery/door/firedoor/border_only/almayer{
 	dir = 1
@@ -29441,18 +29437,16 @@
 	},
 /area/almayer/squads/alpha_bravo_shared)
 "diP" = (
-/obj/structure/machinery/status_display{
-	pixel_y = -30
+/obj/structure/machinery/door/firedoor/border_only/almayer{
+	dir = 1
 	},
-/obj/structure/surface/table/almayer,
-/obj/structure/machinery/computer/emails{
-	dir = 4
+/obj/structure/machinery/door/airlock/multi_tile/almayer/secdoor/glass/reinforced{
+	name = "\improper Brig Lobby"
 	},
 /turf/open/floor/almayer{
-	dir = 10;
-	icon_state = "silver"
+	icon_state = "test_floor4"
 	},
-/area/almayer/shipboard/brig/cic_hallway)
+/area/almayer/shipboard/brig/lobby)
 "djp" = (
 /obj/structure/closet/crate,
 /obj/item/stack/sheet/mineral/plastic{
@@ -33333,7 +33327,7 @@
 "eKa" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/secdoor/glass/reinforced{
 	dir = 2;
-	name = "Brig"
+	name = "\improper Brig Lobby"
 	},
 /obj/structure/machinery/door/firedoor/border_only/almayer,
 /turf/open/floor/almayer{
@@ -36654,12 +36648,16 @@
 	},
 /area/almayer/hallways/aft_hallway)
 "giR" = (
-/obj/structure/bed/chair{
-	dir = 8
+/obj/structure/machinery/status_display{
+	pixel_y = -30
+	},
+/obj/structure/surface/table/almayer,
+/obj/structure/machinery/computer/emails{
+	dir = 4
 	},
 /turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "silvercorner"
+	dir = 10;
+	icon_state = "silver"
 	},
 /area/almayer/shipboard/brig/cic_hallway)
 "gjm" = (
@@ -38509,11 +38507,12 @@
 	},
 /area/almayer/hull/lower_hull/l_a_p)
 "gXx" = (
-/obj/structure/machinery/light/small{
-	dir = 4
+/obj/structure/bed/chair{
+	dir = 8
 	},
 /turf/open/floor/almayer{
-	icon_state = "silver"
+	dir = 8;
+	icon_state = "silvercorner"
 	},
 /area/almayer/shipboard/brig/cic_hallway)
 "gXB" = (
@@ -39380,7 +39379,7 @@
 	dir = 4
 	},
 /obj/structure/machinery/door/airlock/almayer/security/glass{
-	name = "Brig Breakroom"
+	name = "\improper Brig Breakroom"
 	},
 /obj/structure/machinery/door/firedoor/border_only/almayer{
 	layer = 1.9
@@ -41500,7 +41499,7 @@
 	},
 /obj/structure/machinery/door/airlock/almayer/security/glass/reinforced{
 	dir = 1;
-	name = "\improper Brig"
+	name = "\improper Brig Prison Yard And Offices"
 	},
 /obj/structure/machinery/door/firedoor/border_only/almayer{
 	dir = 2
@@ -41852,15 +41851,13 @@
 	},
 /area/almayer/squads/alpha_bravo_shared)
 "ipH" = (
-/obj/structure/machinery/power/apc/almayer{
+/obj/structure/machinery/light/small{
 	dir = 4
 	},
-/obj/structure/sign/safety/rewire{
-	pixel_x = 7;
-	pixel_y = -30
+/turf/open/floor/almayer{
+	icon_state = "silver"
 	},
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/shipboard/brig/cells)
+/area/almayer/shipboard/brig/cic_hallway)
 "ipK" = (
 /obj/effect/step_trigger/message/memorial,
 /turf/open/floor/almayer{
@@ -42414,11 +42411,15 @@
 	},
 /area/almayer/hallways/port_hallway)
 "iBl" = (
-/turf/open/floor/almayer{
-	dir = 10;
-	icon_state = "red"
+/obj/structure/machinery/power/apc/almayer{
+	dir = 4
 	},
-/area/almayer/shipboard/brig/processing)
+/obj/structure/sign/safety/rewire{
+	pixel_x = 7;
+	pixel_y = -30
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/brig/cells)
 "iBt" = (
 /turf/open/floor/plating,
 /area/almayer/hull/upper_hull/u_m_p)
@@ -43221,10 +43222,10 @@
 	},
 /area/almayer/hull/upper_hull/u_a_p)
 "iTl" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
+/turf/open/floor/almayer{
+	dir = 10;
+	icon_state = "red"
 	},
-/turf/open/floor/almayer,
 /area/almayer/shipboard/brig/processing)
 "iTw" = (
 /obj/structure/bed/chair/comfy{
@@ -45539,23 +45540,22 @@
 	},
 /area/almayer/engineering/upper_engineering/starboard)
 "jPP" = (
-/obj/structure/machinery/door/firedoor/border_only/almayer,
-/obj/structure/machinery/door/airlock/almayer/security/glass{
-	dir = 8;
-	name = "\improper Chief MP's Office"
-	},
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
 	},
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/shipboard/brig/chief_mp_office)
+/turf/open/floor/almayer,
+/area/almayer/shipboard/brig/processing)
 "jPS" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 1
 	},
 /turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/brig/chief_mp_office)
+"jPY" = (
+/obj/structure/bed/chair/comfy/orange{
+	dir = 8
+	},
+/turf/open/floor/almayer,
 /area/almayer/shipboard/brig/chief_mp_office)
 "jQt" = (
 /turf/open/floor/almayer/research/containment/floor2{
@@ -48180,7 +48180,7 @@
 "kQz" = (
 /obj/structure/machinery/door/airlock/almayer/security/glass/reinforced{
 	dir = 1;
-	name = "\improper Brig"
+	name = "\improper Brig Maintenance"
 	},
 /obj/structure/machinery/door/poddoor/almayer/open{
 	id = "Brig Lockdown Shutters";
@@ -49307,13 +49307,17 @@
 	},
 /area/almayer/engineering/upper_engineering/port)
 "lnh" = (
+/obj/structure/machinery/door/firedoor/border_only/almayer,
+/obj/structure/machinery/door/airlock/almayer/security/glass{
+	dir = 8;
+	name = "\improper Chief MP's Office"
+	},
 /obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 10
+	dir = 4
 	},
-/obj/structure/machinery/light/small{
-	dir = 1
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
 	},
-/turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/chief_mp_office)
 "lnm" = (
 /turf/open/floor/almayer{
@@ -50387,7 +50391,7 @@
 /area/almayer/hull/lower_hull/l_m_p)
 "lFJ" = (
 /obj/structure/machinery/door/airlock/almayer/security/glass/reinforced{
-	name = "\improper Brig"
+	name = "\improper Brig Prisoner Yard"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -51031,7 +51035,7 @@
 /area/almayer/hull/upper_hull/u_f_p)
 "lUm" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/secdoor/glass/reinforced{
-	name = "Brig"
+	name = "\improper Brig Cells"
 	},
 /obj/structure/machinery/door/firedoor/border_only/almayer{
 	dir = 1
@@ -52707,19 +52711,13 @@
 /turf/open/floor/almayer,
 /area/almayer/living/gym)
 "mHz" = (
-/obj/structure/machinery/door/poddoor/shutters/almayer/open{
-	dir = 2;
-	id = "Warden Office Shutters";
-	name = "\improper Privacy Shutters"
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 10
 	},
-/obj/structure/pipes/standard/simple/hidden/supply,
-/obj/structure/machinery/door/airlock/almayer/security/glass/reinforced{
-	dir = 1;
-	name = "\improper Warden's Office"
+/obj/structure/machinery/light/small{
+	dir = 1
 	},
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
+/turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/chief_mp_office)
 "mHA" = (
 /obj/structure/closet/secure_closet/surgical{
@@ -54023,17 +54021,12 @@
 /obj/structure/sign/safety/intercom{
 	pixel_x = -17
 	},
-/obj/structure/surface/table/almayer,
-/obj/item/book/manual/marine_law{
-	pixel_x = -3;
-	pixel_y = 1
+/obj/structure/bed/sofa/south/grey/left,
+/obj/item/device/radio/intercom{
+	freerange = 1;
+	name = "General Listening Channel";
+	pixel_y = 28
 	},
-/obj/item/device/flashlight/lamp{
-	layer = 3.1;
-	pixel_x = 7;
-	pixel_y = 10
-	},
-/obj/item/poster,
 /turf/open/floor/almayer{
 	dir = 9;
 	icon_state = "red"
@@ -54820,6 +54813,16 @@
 	icon_state = "plate"
 	},
 /area/almayer/squads/delta)
+"nvZ" = (
+/obj/structure/surface/table/almayer,
+/obj/structure/machinery/computer/cameras/almayer_network{
+	dir = 4
+	},
+/turf/open/floor/almayer{
+	dir = 8;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/chief_mp_office)
 "nwb" = (
 /obj/structure/pipes/vents/scrubber{
 	dir = 1
@@ -55904,16 +55907,6 @@
 	icon_state = "green"
 	},
 /area/almayer/living/grunt_rnr)
-"nUf" = (
-/obj/structure/surface/table/almayer,
-/obj/structure/machinery/computer/cameras/almayer_network{
-	dir = 4
-	},
-/turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/chief_mp_office)
 "nUj" = (
 /obj/structure/machinery/door/airlock/almayer/generic{
 	dir = 1
@@ -57925,7 +57918,7 @@
 	},
 /obj/structure/machinery/door/airlock/multi_tile/almayer/secdoor/glass/reinforced{
 	dir = 2;
-	name = "Brig";
+	name = "\improper Brig Lobby";
 	req_access = null
 	},
 /turf/open/floor/almayer{
@@ -64773,20 +64766,18 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/living/briefing)
 "rCU" = (
-/obj/structure/closet/secure_closet/cmdcabinet{
-	desc = "A bulletproof cabinet containing communications equipment.";
-	name = "communications cabinet";
-	pixel_y = 24;
-	req_access = null;
-	req_one_access_txt = "3"
+/obj/structure/machinery/door/poddoor/shutters/almayer/open{
+	dir = 2;
+	id = "Warden Office Shutters";
+	name = "\improper Privacy Shutters"
 	},
-/obj/item/device/radio/listening_bug/radio_linked/mp{
-	pixel_y = 8
+/obj/structure/pipes/standard/simple/hidden/supply,
+/obj/structure/machinery/door/airlock/almayer/security/glass/reinforced{
+	dir = 1;
+	name = "\improper Warden's Office"
 	},
-/obj/item/device/radio/listening_bug/radio_linked/mp,
 /turf/open/floor/almayer{
-	dir = 5;
-	icon_state = "red"
+	icon_state = "test_floor4"
 	},
 /area/almayer/shipboard/brig/chief_mp_office)
 "rDb" = (
@@ -66863,7 +66854,7 @@
 	},
 /obj/structure/machinery/door/airlock/multi_tile/almayer/secdoor/glass/reinforced{
 	dir = 2;
-	name = "Brig";
+	name = "\improper Brig Armoury";
 	req_access = null;
 	req_one_access_txt = "1;3"
 	},
@@ -68372,7 +68363,7 @@
 /obj/structure/machinery/door/firedoor/border_only/almayer,
 /obj/structure/machinery/door/airlock/multi_tile/almayer/secdoor/reinforced{
 	dir = 2;
-	name = "\improper Perma Brig"
+	name = "\improper Brig Permanent Confinement"
 	},
 /obj/structure/machinery/door/poddoor/almayer/open{
 	dir = 4;
@@ -68488,12 +68479,14 @@
 	},
 /area/almayer/engineering/engine_core)
 "tdy" = (
-/obj/item/device/radio/intercom{
-	freerange = 1;
-	name = "General Listening Channel";
-	pixel_y = 28
+/obj/structure/bed/sofa/south/grey/right,
+/obj/structure/sign/safety/restrictedarea{
+	pixel_y = 32
 	},
-/obj/structure/bed/sofa/south/grey/left,
+/obj/structure/sign/safety/security{
+	pixel_x = 15;
+	pixel_y = 32
+	},
 /turf/open/floor/almayer{
 	dir = 1;
 	icon_state = "red"
@@ -68603,14 +68596,6 @@
 	},
 /area/almayer/engineering/upper_engineering/starboard)
 "tff" = (
-/obj/structure/sign/safety/restrictedarea{
-	pixel_y = 32
-	},
-/obj/structure/sign/safety/security{
-	pixel_x = 15;
-	pixel_y = 32
-	},
-/obj/structure/bed/sofa/south/grey/right,
 /turf/open/floor/almayer{
 	dir = 1;
 	icon_state = "red"
@@ -71609,7 +71594,7 @@
 	dir = 2
 	},
 /obj/structure/machinery/door/airlock/multi_tile/almayer/secdoor/glass/reinforced{
-	name = "Brig"
+	name = "\improper Brig Cells"
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -71911,7 +71896,7 @@
 "uwS" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/secdoor/glass/reinforced{
 	dir = 2;
-	name = "Brig";
+	name = "\improper Brig Armoury";
 	req_access = null;
 	req_one_access_txt = "1;3"
 	},
@@ -79451,10 +79436,21 @@
 	},
 /area/almayer/living/commandbunks)
 "xpo" = (
-/obj/structure/bed/chair/comfy/orange{
-	dir = 8
+/obj/structure/closet/secure_closet/cmdcabinet{
+	desc = "A bulletproof cabinet containing communications equipment.";
+	name = "communications cabinet";
+	pixel_y = 24;
+	req_access = null;
+	req_one_access_txt = "3"
 	},
-/turf/open/floor/almayer,
+/obj/item/device/radio/listening_bug/radio_linked/mp{
+	pixel_y = 8
+	},
+/obj/item/device/radio/listening_bug/radio_linked/mp,
+/turf/open/floor/almayer{
+	dir = 5;
+	icon_state = "red"
+	},
 /area/almayer/shipboard/brig/chief_mp_office)
 "xpt" = (
 /obj/structure/machinery/cm_vending/sorted/medical/wall_med{
@@ -80438,6 +80434,16 @@
 	icon_state = "pipe-c"
 	},
 /obj/structure/surface/table/almayer,
+/obj/item/book/manual/marine_law{
+	pixel_x = -3;
+	pixel_y = 1
+	},
+/obj/item/device/flashlight/lamp{
+	layer = 3.1;
+	pixel_x = 7;
+	pixel_y = 10
+	},
+/obj/item/poster,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/lobby)
 "xJe" = (
@@ -94792,7 +94798,7 @@ iTI
 bQc
 pgP
 uVV
-ipH
+iBl
 wIC
 smZ
 smZ
@@ -94999,7 +95005,7 @@ emp
 wIC
 puE
 crp
-nUf
+nvZ
 dqZ
 wIC
 lTK
@@ -95198,10 +95204,10 @@ oIh
 qUz
 ksg
 oIh
-iBl
+iTl
 wIC
 cBZ
-xpo
+jPY
 vAG
 jIo
 wIC
@@ -95384,7 +95390,7 @@ ldu
 eRL
 eRL
 uJs
-tsX
+diP
 tff
 cDN
 oFY
@@ -95402,7 +95408,7 @@ oDy
 wsq
 vxK
 gwj
-mHz
+rCU
 jPS
 jPS
 sJm
@@ -95604,9 +95610,9 @@ rJj
 mBx
 utZ
 pyj
-iTl
+jPP
 wIC
-rCU
+xpo
 xqs
 rWF
 uSB
@@ -95807,7 +95813,7 @@ emp
 emp
 emp
 wIC
-jPP
+lnh
 wIC
 rWn
 rWn
@@ -96007,7 +96013,7 @@ xuZ
 xuZ
 rEY
 gxU
-diP
+giR
 vUP
 wIC
 qZA
@@ -96210,10 +96216,10 @@ rWs
 rQt
 cgT
 xuc
-giR
+gXx
 wdh
 wIC
-lnh
+mHz
 jPS
 jPS
 xrt
@@ -97226,7 +97232,7 @@ udx
 qwp
 pZS
 jHh
-gXx
+ipH
 wIC
 wIC
 vzj

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -27787,9 +27787,6 @@
 /obj/structure/machinery/cm_vending/sorted/medical/wall_med{
 	pixel_y = 25
 	},
-/obj/structure/machinery/light{
-	dir = 1
-	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/general_equipment)
 "cBA" = (
@@ -28584,6 +28581,13 @@
 	icon_state = "cargo"
 	},
 /area/almayer/hull/lower_hull/l_f_s)
+"cQL" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/open/floor/almayer,
+/area/almayer/shipboard/brig/lobby)
 "cQN" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N";
@@ -28817,9 +28821,11 @@
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
 	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
+	},
 /turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "redcorner"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/brig/main_office)
 "cWt" = (
@@ -31864,7 +31870,8 @@
 	pixel_y = 32
 	},
 /turf/open/floor/almayer{
-	allow_construction = 0
+	dir = 8;
+	icon_state = "red"
 	},
 /area/almayer/shipboard/brig/processing)
 "efU" = (
@@ -35144,8 +35151,7 @@
 "fAE" = (
 /obj/structure/closet/firecloset/full,
 /turf/open/floor/almayer{
-	dir = 10;
-	icon_state = "red"
+	icon_state = "cargo"
 	},
 /area/almayer/shipboard/brig/main_office)
 "fAN" = (
@@ -39215,7 +39221,8 @@
 	dir = 8
 	},
 /turf/open/floor/almayer{
-	allow_construction = 0
+	dir = 4;
+	icon_state = "redcorner"
 	},
 /area/almayer/shipboard/brig/processing)
 "hki" = (
@@ -41890,14 +41897,6 @@
 	icon_state = "orangefull"
 	},
 /area/almayer/squads/alpha_bravo_shared)
-"ipH" = (
-/obj/structure/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/almayer{
-	icon_state = "silver"
-	},
-/area/almayer/shipboard/brig/cic_hallway)
 "ipK" = (
 /obj/effect/step_trigger/message/memorial,
 /turf/open/floor/almayer{
@@ -41995,8 +41994,7 @@
 "irF" = (
 /obj/structure/closet/emcloset/legacy,
 /turf/open/floor/almayer{
-	dir = 6;
-	icon_state = "red"
+	icon_state = "cargo"
 	},
 /area/almayer/shipboard/brig/main_office)
 "irS" = (
@@ -43117,11 +43115,12 @@
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/computer/card{
 	dir = 4;
-	layer = 3.2
+	layer = 3.2;
+	pixel_y = 4
 	},
 /obj/structure/machinery/computer/secure_data{
 	dir = 4;
-	pixel_y = 17
+	pixel_y = 23
 	},
 /obj/structure/machinery/light{
 	dir = 8
@@ -52713,7 +52712,8 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	allow_construction = 0
+	dir = 4;
+	icon_state = "red"
 	},
 /area/almayer/shipboard/brig/processing)
 "mHm" = (
@@ -54348,14 +54348,16 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	allow_construction = 0
+	dir = 1;
+	icon_state = "redcorner"
 	},
 /area/almayer/shipboard/brig/processing)
 "nkX" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/computer/cameras/almayer_network{
 	dir = 4;
-	layer = 2.8
+	layer = 2.8;
+	pixel_y = 5
 	},
 /obj/structure/sign/safety/terminal{
 	pixel_x = 8;
@@ -54556,6 +54558,16 @@
 	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/containment)
+"npO" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/brig/lobby)
 "nqe" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
@@ -58405,12 +58417,8 @@
 	pixel_x = 1;
 	pixel_y = 1
 	},
-/obj/structure/sign/safety/security{
-	pixel_x = 15;
-	pixel_y = 32
-	},
-/obj/structure/sign/safety/restrictedarea{
-	pixel_y = 32
+/obj/structure/machinery/light{
+	dir = 1
 	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
@@ -58917,7 +58925,8 @@
 /area/almayer/command/combat_correspondent)
 "phN" = (
 /obj/structure/disposalpipe/junction{
-	dir = 8
+	dir = 4;
+	icon_state = "pipe-j2"
 	},
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -60574,7 +60583,7 @@
 	pixel_y = 30
 	},
 /turf/open/floor/almayer{
-	allow_construction = 0
+	icon_state = "redfull"
 	},
 /area/almayer/shipboard/brig/processing)
 "pUJ" = (
@@ -62257,7 +62266,8 @@
 	},
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/computer/sentencing{
-	dir = 8
+	dir = 8;
+	pixel_y = 6
 	},
 /obj/structure/sign/safety/terminal{
 	pixel_x = 32;
@@ -64698,6 +64708,20 @@
 	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering/starboard)
+"rAX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "SW-out"
+	},
+/turf/open/floor/almayer{
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/main_office)
 "rBa" = (
 /obj/structure/machinery/cm_vending/clothing/synth,
 /obj/structure/prop/invuln/overhead_pipe{
@@ -65546,8 +65570,7 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/junction{
-	dir = 2;
-	icon_state = "pipe-j2"
+	dir = 1
 	},
 /turf/open/floor/almayer,
 /area/almayer/shipboard/brig/processing)
@@ -76428,6 +76451,9 @@
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
 	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "SE-out"
+	},
 /turf/open/floor/almayer{
 	icon_state = "red"
 	},
@@ -78274,7 +78300,8 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/junction{
-	dir = 1
+	dir = 4;
+	icon_state = "pipe-j2"
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/lobby)
@@ -80484,10 +80511,6 @@
 	},
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 9
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
 	},
 /obj/structure/surface/table/almayer,
 /obj/item/book/manual/marine_law{
@@ -92407,7 +92430,7 @@ cak
 vrM
 tpn
 pUD
-wdF
+bju
 wdF
 wdF
 wSm
@@ -93212,7 +93235,7 @@ iwV
 lrq
 lrq
 gob
-rhl
+cWs
 irF
 kHa
 rEQ
@@ -93415,7 +93438,7 @@ evR
 cQv
 cQv
 vtD
-igt
+rAX
 kHa
 kHa
 lRe
@@ -95450,8 +95473,8 @@ diP
 tff
 cDN
 oFY
-oFY
-yjG
+cQL
+npO
 ncl
 jcf
 bju
@@ -97288,7 +97311,7 @@ udx
 qwp
 pZS
 jHh
-ipH
+jUY
 wIC
 wIC
 vzj

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -3323,7 +3323,7 @@
 	name = "\improper Brig"
 	},
 /obj/structure/machinery/door/poddoor/almayer/open{
-	id = "perma_lockdown";
+	id = "perma_lockdown_2";
 	name = "\improper Perma Lockdown Shutter"
 	},
 /turf/open/floor/almayer{
@@ -15286,8 +15286,8 @@
 /area/almayer/engineering/lower_engineering)
 "bjk" = (
 /obj/structure/machinery/door_control{
-	id = "CMP Office Shutters";
-	name = "CMP Office Shutters";
+	id = "perma_lockdown_2";
+	name = "Maint Lockdown Shutters";
 	pixel_y = -20;
 	req_one_access_txt = "24;31"
 	},
@@ -27677,18 +27677,16 @@
 	},
 /area/almayer/medical/lower_medical_medbay)
 "cAy" = (
-/obj/structure/machinery/status_display{
-	pixel_y = -30
-	},
-/obj/structure/surface/table/almayer,
-/obj/structure/machinery/computer/emails{
-	dir = 4
+/obj/structure/closet/secure_closet/guncabinet/red/mp_armory_shotgun,
+/obj/structure/machinery/camera/autoname/almayer{
+	dir = 4;
+	name = "ship-grade camera"
 	},
 /turf/open/floor/almayer{
-	dir = 10;
-	icon_state = "silver"
+	dir = 4;
+	icon_state = "plating_striped"
 	},
-/area/almayer/shipboard/brig/cic_hallway)
+/area/almayer/shipboard/brig/armory)
 "cAF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -28773,23 +28771,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/living/gym)
-"cWb" = (
-/obj/structure/machinery/door/poddoor/shutters/almayer{
-	dir = 2;
-	id = "bot_armory";
-	name = "\improper Armory Shutters"
-	},
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 2
-	},
-/obj/structure/machinery/door/airlock/almayer/security/glass/reinforced{
-	dir = 2;
-	name = "\improper Armory"
-	},
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/shipboard/brig/armory)
 "cWr" = (
 /obj/structure/machinery/photocopier{
 	density = 0;
@@ -29338,8 +29319,10 @@
 /area/almayer/hull/upper_hull/u_f_p)
 "dgx" = (
 /obj/structure/flora/pottedplant{
-	icon_state = "pottedplant_18"
+	icon_state = "pottedplant_18";
+	pixel_y = 13
 	},
+/obj/structure/surface/table/almayer,
 /turf/open/floor/almayer{
 	dir = 8;
 	icon_state = "red"
@@ -29458,12 +29441,16 @@
 	},
 /area/almayer/squads/alpha_bravo_shared)
 "diP" = (
-/obj/structure/bed/chair{
-	dir = 8
+/obj/structure/machinery/status_display{
+	pixel_y = -30
+	},
+/obj/structure/surface/table/almayer,
+/obj/structure/machinery/computer/emails{
+	dir = 4
 	},
 /turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "silvercorner"
+	dir = 10;
+	icon_state = "silver"
 	},
 /area/almayer/shipboard/brig/cic_hallway)
 "djp" = (
@@ -30636,6 +30623,9 @@
 	icon_state = "SW-out";
 	pixel_x = -1;
 	pixel_y = -1
+	},
+/obj/structure/machinery/light{
+	dir = 1
 	},
 /turf/open/floor/almayer{
 	dir = 5;
@@ -33792,7 +33782,9 @@
 	pixel_x = -17;
 	pixel_y = 17
 	},
-/turf/open/floor/plating/almayer,
+/turf/open/floor/almayer{
+	icon_state = "cargo"
+	},
 /area/almayer/shipboard/brig/evidence_storage)
 "eVT" = (
 /obj/structure/disposalpipe/trunk{
@@ -36282,9 +36274,6 @@
 	},
 /area/almayer/hull/lower_hull/l_a_p)
 "gax" = (
-/obj/structure/machinery/light{
-	dir = 1
-	},
 /obj/structure/machinery/status_display{
 	pixel_y = 30
 	},
@@ -36665,11 +36654,12 @@
 	},
 /area/almayer/hallways/aft_hallway)
 "giR" = (
-/obj/structure/machinery/light/small{
-	dir = 4
+/obj/structure/bed/chair{
+	dir = 8
 	},
 /turf/open/floor/almayer{
-	icon_state = "silver"
+	dir = 8;
+	icon_state = "silvercorner"
 	},
 /area/almayer/shipboard/brig/cic_hallway)
 "gjm" = (
@@ -37737,16 +37727,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/hull/lower_hull/l_m_s)
-"gFv" = (
-/obj/structure/surface/table/almayer,
-/obj/structure/machinery/computer/cameras/almayer_network{
-	dir = 4
-	},
-/turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/chief_mp_office)
 "gFG" = (
 /obj/structure/surface/rack,
 /obj/effect/spawner/random/tool,
@@ -37920,7 +37900,9 @@
 	pixel_x = 1;
 	pixel_y = 1
 	},
-/turf/open/floor/plating/almayer,
+/turf/open/floor/almayer{
+	icon_state = "cargo"
+	},
 /area/almayer/shipboard/brig/evidence_storage)
 "gJd" = (
 /obj/structure/disposalpipe/segment{
@@ -38527,15 +38509,13 @@
 	},
 /area/almayer/hull/lower_hull/l_a_p)
 "gXx" = (
-/obj/structure/machinery/power/apc/almayer{
+/obj/structure/machinery/light/small{
 	dir = 4
 	},
-/obj/structure/sign/safety/rewire{
-	pixel_x = 7;
-	pixel_y = -30
+/turf/open/floor/almayer{
+	icon_state = "silver"
 	},
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/shipboard/brig/cells)
+/area/almayer/shipboard/brig/cic_hallway)
 "gXB" = (
 /obj/structure/pipes/vents/pump,
 /obj/structure/bed/chair/comfy/delta{
@@ -40518,8 +40498,10 @@
 /area/almayer/medical/operating_room_three)
 "hNl" = (
 /obj/structure/flora/pottedplant{
-	icon_state = "pottedplant_21"
+	icon_state = "pottedplant_21";
+	pixel_y = 16
 	},
+/obj/structure/surface/table/almayer,
 /turf/open/floor/almayer{
 	dir = 9;
 	icon_state = "red"
@@ -41870,16 +41852,15 @@
 	},
 /area/almayer/squads/alpha_bravo_shared)
 "ipH" = (
-/obj/effect/landmark/start/police,
 /obj/structure/machinery/power/apc/almayer{
-	dir = 1
+	dir = 4
 	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "W";
-	layer = 2.5
+/obj/structure/sign/safety/rewire{
+	pixel_x = 7;
+	pixel_y = -30
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/shipboard/brig/cryo)
+/area/almayer/shipboard/brig/cells)
 "ipK" = (
 /obj/effect/step_trigger/message/memorial,
 /turf/open/floor/almayer{
@@ -44744,7 +44725,7 @@
 	},
 /area/almayer/hull/upper_hull/u_a_p)
 "jvP" = (
-/obj/structure/machinery/light{
+/obj/structure/machinery/power/apc/almayer{
 	dir = 1
 	},
 /turf/open/floor/almayer{
@@ -46529,10 +46510,6 @@
 	},
 /area/almayer/living/briefing)
 "kjk" = (
-/obj/structure/machinery/camera/autoname/almayer{
-	dir = 8;
-	name = "ship-grade camera"
-	},
 /obj/structure/machinery/cryopod/right,
 /obj/structure/sign/safety/cryo{
 	pixel_x = 32
@@ -47047,10 +47024,6 @@
 	pixel_x = 15;
 	pixel_y = 32
 	},
-/obj/structure/machinery/light{
-	dir = 1
-	},
-/obj/structure/machinery/camera/autoname/almayer,
 /obj/structure/machinery/vending/security/riot,
 /turf/open/floor/almayer{
 	icon_state = "plating_striped"
@@ -53124,13 +53097,6 @@
 	},
 /area/almayer/medical/upper_medical)
 "mNK" = (
-/obj/structure/machinery/door_control{
-	id = "perma_lockdown";
-	name = "\improper Perma Cells Lockdown";
-	pixel_x = -24;
-	pixel_y = 6;
-	req_access_txt = "3"
-	},
 /obj/structure/closet/secure_closet/brig/restraints,
 /turf/open/floor/almayer{
 	dir = 8;
@@ -54783,7 +54749,7 @@
 /obj/structure/machinery/door/firedoor/border_only/almayer,
 /obj/structure/machinery/door/poddoor/almayer/open{
 	dir = 4;
-	id = "perma_lockdown";
+	id = "perma_lockdown_1";
 	name = "\improper Perma Lockdown Shutter"
 	},
 /turf/open/floor/almayer{
@@ -55938,6 +55904,16 @@
 	icon_state = "green"
 	},
 /area/almayer/living/grunt_rnr)
+"nUf" = (
+/obj/structure/surface/table/almayer,
+/obj/structure/machinery/computer/cameras/almayer_network{
+	dir = 4
+	},
+/turf/open/floor/almayer{
+	dir = 8;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/chief_mp_office)
 "nUj" = (
 /obj/structure/machinery/door/airlock/almayer/generic{
 	dir = 1
@@ -59408,7 +59384,7 @@
 /obj/structure/transmitter/rotary{
 	name = "Brig Wardens's Office Telephone";
 	phone_category = "MP Dept.";
-	phone_id = "Brig CMP's Office";
+	phone_id = "Brig Warden's Office";
 	pixel_x = 15
 	},
 /turf/open/floor/almayer{
@@ -62000,6 +61976,10 @@
 	layer = 3.1;
 	pixel_y = 13
 	},
+/obj/structure/machinery/camera/autoname/almayer{
+	dir = 8;
+	name = "ship-grade camera"
+	},
 /turf/open/floor/almayer{
 	icon_state = "cargo"
 	},
@@ -63387,7 +63367,15 @@
 "qZF" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/computer/cameras/almayer_network{
-	dir = 8
+	dir = 8;
+	pixel_y = 6
+	},
+/obj/structure/machinery/door_control{
+	id = "perma_lockdown_1";
+	name = "\improper Perma Cells Lockdown";
+	pixel_x = -8;
+	pixel_y = -4;
+	req_access_txt = "3"
 	},
 /turf/open/floor/almayer{
 	dir = 4;
@@ -64288,7 +64276,9 @@
 /obj/structure/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/plating/almayer,
+/turf/open/floor/almayer{
+	icon_state = "cargo"
+	},
 /area/almayer/shipboard/brig/evidence_storage)
 "rri" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
@@ -68183,7 +68173,7 @@
 /area/almayer/medical/lower_medical_medbay)
 "sYi" = (
 /obj/structure/machinery/door_control{
-	id = "cmp_armory";
+	id = "firearm_storage_armory";
 	name = "Armory Lockdown";
 	pixel_y = 24;
 	req_access_txt = "4"
@@ -68386,7 +68376,7 @@
 	},
 /obj/structure/machinery/door/poddoor/almayer/open{
 	dir = 4;
-	id = "perma_lockdown";
+	id = "perma_lockdown_1";
 	name = "\improper Perma Lockdown Shutter"
 	},
 /obj/structure/disposalpipe/segment{
@@ -70191,7 +70181,7 @@
 "tLa" = (
 /obj/structure/machinery/door/poddoor/shutters/almayer{
 	dir = 2;
-	id = "cmp_armory";
+	id = "firearm_storage_armory";
 	name = "\improper Armory Shutters"
 	},
 /obj/structure/machinery/door/firedoor/border_only/almayer{
@@ -81246,6 +81236,7 @@
 	dir = 4
 	},
 /obj/structure/pipes/standard/manifold/hidden/supply,
+/obj/structure/machinery/light,
 /turf/open/floor/almayer{
 	icon_state = "red"
 	},
@@ -92139,7 +92130,7 @@ aou
 lrq
 kEc
 chv
-chv
+cAy
 uhE
 vKB
 lrq
@@ -92751,7 +92742,7 @@ uqo
 uqo
 uqo
 uqo
-cWb
+tLa
 eRL
 wfB
 tpn
@@ -94801,7 +94792,7 @@ iTI
 bQc
 pgP
 uVV
-gXx
+ipH
 wIC
 smZ
 smZ
@@ -95008,7 +94999,7 @@ emp
 wIC
 puE
 crp
-gFv
+nUf
 dqZ
 wIC
 lTK
@@ -95993,7 +95984,7 @@ pCi
 oCL
 wcn
 vxM
-ipH
+sbP
 sbP
 sbP
 sbP
@@ -96016,7 +96007,7 @@ xuZ
 xuZ
 rEY
 gxU
-cAy
+diP
 vUP
 wIC
 qZA
@@ -96219,7 +96210,7 @@ rWs
 rQt
 cgT
 xuc
-diP
+giR
 wdh
 wIC
 lnh
@@ -97235,7 +97226,7 @@ udx
 qwp
 pZS
 jHh
-giR
+gXx
 wIC
 wIC
 vzj

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -30570,7 +30570,7 @@
 	unacidable = 1;
 	unslashable = 1
 	},
-/obj/structure/closet/secure_closet/brig/prisoner,
+/obj/structure/closet/secure_closet/brig,
 /turf/open/floor/almayer{
 	icon_state = "red"
 	},
@@ -34871,7 +34871,7 @@
 	},
 /area/almayer/hull/upper_hull/u_f_p)
 "fvA" = (
-/obj/structure/closet/secure_closet/brig/prisoner,
+/obj/structure/closet/secure_closet/brig,
 /turf/open/floor/almayer,
 /area/almayer/shipboard/brig/perma)
 "fvB" = (
@@ -41263,7 +41263,7 @@
 /turf/open/floor/almayer,
 /area/almayer/shipboard/brig/cells)
 "icZ" = (
-/obj/structure/closet/secure_closet/brig/prisoner,
+/obj/structure/closet/secure_closet/brig,
 /turf/open/floor/almayer{
 	dir = 8;
 	icon_state = "redcorner"
@@ -47350,7 +47350,7 @@
 	},
 /area/almayer/command/corporateliason)
 "kAL" = (
-/obj/structure/closet/secure_closet/brig/prisoner,
+/obj/structure/closet/secure_closet/brig,
 /turf/open/floor/almayer{
 	icon_state = "red"
 	},


### PR DESCRIPTION
# About the pull request

Fixes stuff about the new brig

Lights on windows
Lack of warning stripes under bulkheads
Lack of warning stripes under some doors
Fixes up some of the tiling to look better (hard to describe in the PR nanu knows about it)
Removes RNG loot spawner that could spawn thermals in the brig
Changes some 1x1 area
Changes the location of some of the semiotics 
Makes the north and south brig maint area symmetrical again
Fixes layering issues
Rewalls the CMPs office so that the outer brig hallways are symmetrical
Changes Brig Phone categories to "MP Dept."
fixes incorrect brig lockers
fixes incorrect door and button IDs
fixes incorrect door names
fixes incorrect pipe placement

# Explain why it's good for the game
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: SpartanBobby, LCMS1
maptweak: Numerous Fixes for new brig
/:cl:
