### PR TITLE
SStechtree startup optimisation

### DIFF
--- a/code/controllers/subsystem/techtree.dm
+++ b/code/controllers/subsystem/techtree.dm
@@ -34,17 +34,6 @@ SUBSYSTEM_DEF(techtree)
 		var/datum/space_level/zpos = SSmapping.add_new_zlevel(tree.name, list(ZTRAIT_TECHTREE))
 		tree.zlevel = zpos
 
-		var/zlevel = zpos.z_value
-		var/turf/z_min = locate(1, 1, zlevel)
-		var/turf/z_max = locate(world.maxx, world.maxy, zlevel)
-
-
-
-		for(var/t in block(z_min, z_max))
-			var/turf/Tu = t
-			Tu.ChangeTurf(/turf/closed/void, list(/turf/closed/void))
-			new /area/techtree(Tu)
-
 		for(var/tier in tree.tree_tiers)
 			tree.unlocked_techs += tier
 			tree.all_techs += tier

--- a/code/modules/cm_tech/techtree.dm
+++ b/code/modules/cm_tech/techtree.dm
@@ -58,16 +58,24 @@
 		if(longest_tier < tier_length)
 			longest_tier = tier_length
 
-	// Clear out the area
-	for(var/t in block(locate(1, 1, zlevel.z_value), locate(longest_tier * 2 + 1, length(all_techs) * 3 + 1, zlevel.z_value)))
+	// Clear out and create the area
+	// (The `+ 2` on both of these is 1 for a buffer tile, and 1 for the outer `/turf/closed/void`.)
+	var/area_max_x = longest_tier * 2 + 2
+	var/area_max_y = length(all_techs) * 3 + 2
+	for(var/t in block(locate(1, 1, zlevel.z_value), locate(area_max_x, area_max_y, zlevel.z_value)))
 		var/turf/pos = t
 		for(var/A in pos)
 			qdel(A)
 
-		pos.ChangeTurf(/turf/open/blank)
-		pos.color = "#000000"
+		if(pos.x == area_max_x || pos.y == area_max_y)
+			// The turfs around the edge are closed.
+			pos.ChangeTurf(/turf/closed/void)
+		else
+			pos.ChangeTurf(/turf/open/blank)
+			pos.color = "#000000"
+		new /area/techtree(pos)
 
-
+	// Create the tech nodes
 	var/y_offset = 1
 	for(var/tier in all_techs)
 		var/tier_length = length(all_techs[tier])


### PR DESCRIPTION

# About the pull request

Optimises the initialisation time of the 'Tech Tree' subsystem.

Currently, `/datum/controller/subsystem/techtree/Initialize()` is changing the turf of every tile on the tech tree's z-level to `/turf/closed/void`, presumably so that it all appears black rather than space-y. However since it's calling `ChangeTurf()` on the *entire* z-level (300x226, or 67,800 turfs), this is pretty performance intensive.

This PR fixes that by just... not changing the turfs, instead only adding a few `/turf/closed/void`s around the edge of the tech tree area so that it still looks the same in-game. This changes the subsystem's init time from 6.4 seconds(ish), to 0.15 seconds(ish).

**Before:**
![before 1](https://github.com/cmss13-devs/cmss13/assets/57483089/b7423bfd-7cbf-434b-ac2b-49765d5a78cc)

**After:**
![after 1](https://github.com/cmss13-devs/cmss13/assets/57483089/543f1ef6-bf61-46c5-90f5-f85b171631bd)

Players viewing the tech tree through the console won't notice anything different, as the remaining layer of `/turf/closed/void`s block their view of the rest of the z-level.

# Explain why it's good for the game

About 6 seconds knocked off of the server's init time. (10%!) *(At least on my end)*


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>
<hr>

### Before/after init times from a few different tests:
**Before:**
![before 1](https://github.com/cmss13-devs/cmss13/assets/57483089/2c81c7d2-6376-4bea-a7c4-8e071cf09e3f)
![before 2](https://github.com/cmss13-devs/cmss13/assets/57483089/06d21d9a-1c86-4246-bf2b-f0108875713a)
![before 3](https://github.com/cmss13-devs/cmss13/assets/57483089/5590723d-291e-48c9-b0ae-10fef6b05410)

**After:**
![after 1](https://github.com/cmss13-devs/cmss13/assets/57483089/481324cd-fc0d-4876-9359-d9544fcc37c6)
![after 2](https://github.com/cmss13-devs/cmss13/assets/57483089/ffb8c2c7-a09f-4b15-806e-481927a5099d)
![after 3](https://github.com/cmss13-devs/cmss13/assets/57483089/1e9cb315-56b6-47a6-a0be-2a7973b25f88)

<hr>

### Teleporting to it as an observer, there *is* a visible difference:

**Before:**
![(null)scrnshot2](https://github.com/cmss13-devs/cmss13/assets/57483089/a133f889-7020-4477-84e5-e49c8cde03aa)

**After:**
![(null)scrnshot1](https://github.com/cmss13-devs/cmss13/assets/57483089/b7fd8ca6-220c-4366-b367-115c339fe207)

<hr>

### But viewing it IC, it all works exactly the same as before:

https://github.com/cmss13-devs/cmss13/assets/57483089/14fc7b05-5279-489f-99df-e9acc83b1420

<hr>

### The new `/turf/closed/void` tiles highlighted for reference:

![techtreebounds](https://github.com/cmss13-devs/cmss13/assets/57483089/02159fee-bbe4-4c8a-b0b7-4ba7963f233d)

</details>


# Changelog
:cl:
code: Made the Tech Tree subsystem initialise faster.
/:cl:
