### PR TITLE
Shuttle & Predator ship lighting fixes

### DIFF
--- a/code/game/area/shuttles.dm
+++ b/code/game/area/shuttles.dm
@@ -10,6 +10,11 @@
 	unique = FALSE
 
 	base_lighting_alpha = 255
+	area_has_alphamasking = TRUE
+
+	base_lighting_multiply_types = list(
+		/turf/open/floor/plating
+	)
 
 
 ///area/shuttle/Initialize()

--- a/code/game/area/shuttles.dm
+++ b/code/game/area/shuttles.dm
@@ -13,7 +13,7 @@
 	area_has_alphamasking = TRUE
 
 	base_lighting_multiply_types = list(
-		/turf/open/floor/plating
+		/turf/open/floor/plating,
 	)
 
 

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -37,6 +37,10 @@
 	/// set when a player uses a pen on a renamable object
 	var/renamedByPlayer = FALSE
 
+	//The alphamasking is used for objects where the turf below it has lighting. It is only used in combination with base lighting, when the "area_has_alphamasking" property is enabled.
+	var/use_alphamasking = FALSE
+	var/mutable_appearance/alphamask_appearance = null
+
 
 /obj/Initialize(mapload, ...)
 	. = ..()
@@ -47,6 +51,8 @@
 	if(buckled_mob)
 		unbuckle()
 	. = ..()
+	if(alphamask_appearance != null)
+		QDEL_NULL(alphamask_appearance)
 	remove_from_garbage(src)
 
 /obj/vv_get_dropdown()

--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -18,8 +18,12 @@
 
 	update_icon()
 
+
 /turf/open/update_icon()
 	overlays.Cut()
+
+	var/area/area = get_area(src)
+	area.add_base_lighting_for_turf(src)
 
 	add_cleanable_overlays()
 

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -97,16 +97,11 @@
 
 	//Get area light
 	var/area/current_area = loc
-	if(current_area?.lighting_effect)
-		overlays += current_area.lighting_effect
+	if(current_area?.get_turf_lighting_effect(src))
+		overlays += current_area.get_turf_lighting_effect(src)
 
 	if(opacity)
 		directional_opacity = ALL_CARDINALS
-
-	//Get area light
-	var/area/A = loc
-	if(A?.lighting_effect)
-		overlays += A.lighting_effect
 
 	return INITIALIZE_HINT_NORMAL
 
@@ -432,8 +427,8 @@
 		W.reconsider_lights()
 
 	var/area/thisarea = get_area(W)
-	if(thisarea.lighting_effect)
-		W.overlays += thisarea.lighting_effect
+	if(thisarea.get_turf_lighting_effect(src))
+		W.overlays += thisarea.get_turf_lighting_effect(src)
 
 	W.levelupdate()
 	return W

--- a/code/modules/cm_marines/dropship_equipment.dm
+++ b/code/modules/cm_marines/dropship_equipment.dm
@@ -452,38 +452,49 @@
 	point_cost = 50
 	var/spotlights_cooldown
 	var/brightness = 11
+	var/on = FALSE
 
 /obj/structure/dropship_equipment/electronics/spotlights/equipment_interact(mob/user)
 	if(spotlights_cooldown > world.time)
 		to_chat(user, SPAN_WARNING("[src] is busy."))
 		return //prevents spamming deployment/undeployment
-	if(luminosity != brightness)
-		set_light(brightness)
-		icon_state = "spotlights_on"
+	if(!on)
+		set_on_status(TRUE)
 		to_chat(user, SPAN_NOTICE("You turn on [src]."))
 	else
-		set_light(0)
-		icon_state = "spotlights_off"
+		set_on_status(FALSE)
 		to_chat(user, SPAN_NOTICE("You turn off [src]."))
 	spotlights_cooldown = world.time + 50
+
+
+/obj/structure/dropship_equipment/electronics/spotlights/proc/set_on_status(activate)
+	if(activate)
+		on = TRUE
+		set_light(brightness)
+		icon_state = "spotlights_on"
+	else 
+		on = FALSE
+		set_light(0)
+		icon_state = "spotlights_off"
 
 /obj/structure/dropship_equipment/electronics/spotlights/update_equipment()
 	..()
 	if(ship_base)
-		if(luminosity != brightness)
+		if(!on)
 			icon_state = "spotlights_off"
 		else
 			icon_state = "spotlights_on"
 	else
 		icon_state = "spotlights"
-		if(luminosity)
+		if(on)
+			on = FALSE
 			set_light(0)
 
 /obj/structure/dropship_equipment/electronics/spotlights/on_launch()
-	set_light(0)
+	set_on_status(FALSE)
 
 /obj/structure/dropship_equipment/electronics/spotlights/on_arrival()
-	set_light(brightness)
+	set_on_status(TRUE)
 
 #undef LIGHTING_MAX_LUMINOSITY_SHIPLIGHTS
 

--- a/code/modules/lighting/lighting_area.dm
+++ b/code/modules/lighting/lighting_area.dm
@@ -81,7 +81,7 @@
 	lighting_multiply_effect.color = base_lighting_color
 	return lighting_multiply_effect
 
-/area/proc/add_base_lighting_for_turf(var/turf/T)
+/area/proc/add_base_lighting_for_turf(turf/T)
 	if(!area_has_base_lighting && (!base_lighting_alpha || !base_lighting_color))
 		return
 
@@ -94,13 +94,13 @@
 	if(area_has_alphamasking)
 		apply_alphamask_to_turf_contents(T)
 
-/area/proc/apply_alphamask_to_turf_contents(var/turf/T)
+/area/proc/apply_alphamask_to_turf_contents(turf/T)
 	for(var/obj/item in contents)
 		if(item.use_alphamasking != null)
 			item.alphamask_appearance = get_alphamask_apperance(item)
 			item.overlays += item.alphamask_appearance
 
-/area/proc/get_alphamask_apperance(var/obj/item)
+/area/proc/get_alphamask_apperance(obj/item)
 	var/mutable_appearance/effect = mutable_appearance('icons/effects/alphacolors.dmi', "white")
 	effect.plane = LIGHTING_PLANE
 	effect.layer = LIGHTING_PRIMARY_LAYER
@@ -114,7 +114,7 @@
 	return effect
 
 
-/area/proc/get_turf_lighting_effect(var/turf/T)
+/area/proc/get_turf_lighting_effect(turf/T)
 	if(!area_has_base_lighting && (!base_lighting_alpha || !base_lighting_color))
 		return null
 	var/mutable_appearance/appearance = get_lighting_params()

--- a/code/modules/lighting/lighting_area.dm
+++ b/code/modules/lighting/lighting_area.dm
@@ -2,12 +2,19 @@
 	luminosity = 1
 	///The mutable appearance we underlay to show light
 	var/mutable_appearance/lighting_effect = null
+	///The mutable appearance we underlay to show light, same params as lighting_effect with BLEND_MULTIPLY
+	var/mutable_appearance/lighting_multiply_effect = null
 	///Whether this area has a currently active base lighting, bool
 	var/area_has_base_lighting = FALSE
 	///alpha 0-255 of lighting_effect and thus baselighting intensity
 	var/base_lighting_alpha = 0
 	///The colour of the light acting on this area
 	var/base_lighting_color = COLOR_WHITE
+
+	//This is used to indicate that of some turfs in the given area should have all of their contents scanned for alpha masking. 
+	// Use this sparingly or it will have performance issues on startup.
+	var/area_has_alphamasking = FALSE
+	var/list/base_lighting_multiply_types = null
 
 /area/proc/set_base_lighting(new_base_lighting_color = -1, new_alpha = -1)
 	if(base_lighting_alpha == new_alpha && base_lighting_color == new_base_lighting_color)
@@ -42,11 +49,18 @@
 
 /area/proc/remove_base_lighting()
 	for(var/turf/T in src)
+		if(base_lighting_multiply_types != null)
+			if (T.type in base_lighting_multiply_types)
+				T.overlays -= lighting_multiply_effect
+				continue
 		T.overlays -= lighting_effect
 	QDEL_NULL(lighting_effect)
+	QDEL_NULL(lighting_multiply_effect)
 	area_has_base_lighting = FALSE
 
 /area/proc/get_lighting_params()
+	if (lighting_effect != null)
+		return lighting_effect
 	lighting_effect = mutable_appearance('icons/effects/alphacolors.dmi', "white")
 	lighting_effect.plane = LIGHTING_PLANE
 	lighting_effect.layer = LIGHTING_PRIMARY_LAYER
@@ -56,14 +70,60 @@
 	lighting_effect.appearance_flags = RESET_COLOR
 	return lighting_effect
 
-/area/proc/add_base_lighting_for_turf(var/turf/T, var/mutable_appearance/lighting_effect = get_lighting_params())
+/area/proc/get_lighting_multiply_params()
+	if (lighting_multiply_effect != null)
+		return lighting_multiply_effect
+	lighting_multiply_effect = mutable_appearance('icons/effects/alphacolors.dmi', "white")
+	lighting_multiply_effect.plane = LIGHTING_PLANE
+	lighting_multiply_effect.layer = LIGHTING_PRIMARY_LAYER
+	lighting_multiply_effect.blend_mode = BLEND_MULTIPLY
+	lighting_multiply_effect.alpha = base_lighting_alpha
+	lighting_multiply_effect.color = base_lighting_color
+	return lighting_multiply_effect
+
+/area/proc/add_base_lighting_for_turf(var/turf/T)
 	if(!area_has_base_lighting && (!base_lighting_alpha || !base_lighting_color))
 		return
-	T.overlays += lighting_effect
+
+	var/mutable_appearance/appearance = get_turf_lighting_effect(T)
+
+	T.overlays += appearance
 	T.luminosity = 1
 
+	// do not enable this in an area with many contents or it will LAG!
+	if(area_has_alphamasking)
+		apply_alphamask_to_turf_contents(T)
+
+/area/proc/apply_alphamask_to_turf_contents(var/turf/T)
+	for(var/obj/item in contents)
+		if(item.use_alphamasking != null)
+			item.alphamask_appearance = get_alphamask_apperance(item)
+			item.overlays += item.alphamask_appearance
+
+/area/proc/get_alphamask_apperance(var/obj/item)
+	var/mutable_appearance/effect = mutable_appearance('icons/effects/alphacolors.dmi', "white")
+	effect.plane = LIGHTING_PLANE
+	effect.layer = LIGHTING_PRIMARY_LAYER
+	effect.blend_mode = BLEND_ADD
+	effect.alpha = 255
+	effect.color = COLOR_WHITE
+	effect.appearance_flags = KEEP_APART
+	effect.icon = item.icon
+	effect.icon_state = item.icon_state
+	
+	return effect
+
+
+/area/proc/get_turf_lighting_effect(var/turf/T)
+	if(!area_has_base_lighting && (!base_lighting_alpha || !base_lighting_color))
+		return null
+	var/mutable_appearance/appearance = get_lighting_params()
+	if(base_lighting_multiply_types != null)
+		if (T.type in base_lighting_multiply_types)
+			appearance = get_lighting_multiply_params()
+	return appearance
+	
 /area/proc/add_base_lighting()
-	var/mutable_appearance/lighting_effect = get_lighting_params()
 	for(var/turf/T in src)
-		add_base_lighting_for_turf(T, lighting_effect)
+		add_base_lighting_for_turf(T)
 	area_has_base_lighting = TRUE

--- a/code/modules/lighting/lighting_area.dm
+++ b/code/modules/lighting/lighting_area.dm
@@ -105,7 +105,7 @@
 	effect.plane = LIGHTING_PLANE
 	effect.layer = LIGHTING_PRIMARY_LAYER
 	effect.blend_mode = BLEND_ADD
-	effect.alpha = 255
+	effect.alpha = base_lighting_alpha
 	effect.color = COLOR_WHITE
 	effect.appearance_flags = KEEP_APART
 	effect.icon = item.icon

--- a/code/modules/lighting/lighting_area.dm
+++ b/code/modules/lighting/lighting_area.dm
@@ -46,14 +46,24 @@
 	QDEL_NULL(lighting_effect)
 	area_has_base_lighting = FALSE
 
-/area/proc/add_base_lighting()
+/area/proc/get_lighting_params()
 	lighting_effect = mutable_appearance('icons/effects/alphacolors.dmi', "white")
 	lighting_effect.plane = LIGHTING_PLANE
 	lighting_effect.layer = LIGHTING_PRIMARY_LAYER
 	lighting_effect.blend_mode = BLEND_ADD
 	lighting_effect.alpha = base_lighting_alpha
 	lighting_effect.color = base_lighting_color
+	lighting_effect.appearance_flags = RESET_COLOR
+	return lighting_effect
+
+/area/proc/add_base_lighting_for_turf(var/turf/T, var/mutable_appearance/lighting_effect = get_lighting_params())
+	if(!area_has_base_lighting && (!base_lighting_alpha || !base_lighting_color))
+		return
+	T.overlays += lighting_effect
+	T.luminosity = 1
+
+/area/proc/add_base_lighting()
+	var/mutable_appearance/lighting_effect = get_lighting_params()
 	for(var/turf/T in src)
-		T.overlays += lighting_effect
-		T.luminosity = 1
+		add_base_lighting_for_turf(T, lighting_effect)
 	area_has_base_lighting = TRUE

--- a/code/modules/lighting/lighting_static/static_lighting_turf.dm
+++ b/code/modules/lighting/lighting_static/static_lighting_turf.dm
@@ -39,10 +39,10 @@
 			else
 				static_lighting_clear_overlay()
 	//Inherit overlay of new area
-	if(old_area.lighting_effect)
-		overlays -= old_area.lighting_effect
-	if(new_area.lighting_effect)
-		overlays += new_area.lighting_effect
+	if(old_area.get_turf_lighting_effect(src))
+		overlays -= old_area.get_turf_lighting_effect(src)
+	if(new_area.get_turf_lighting_effect(src))
+		overlays += new_area.get_turf_lighting_effect(src)
 
 /turf/proc/static_generate_missing_corners()
 	if (!lighting_corner_NE)

--- a/code/modules/shuttle/dropship.dm
+++ b/code/modules/shuttle/dropship.dm
@@ -16,6 +16,7 @@
 
 /obj/structure/shuttle/part/dropship1/transparent
 	opacity = FALSE
+	use_alphamasking = TRUE
 
 /obj/structure/shuttle/part/dropship1/transparent/nose_top_right
 	icon_state = "102"
@@ -121,6 +122,7 @@
 
 /obj/structure/shuttle/part/dropship2/transparent
 	opacity = FALSE
+	use_alphamasking = TRUE
 
 /obj/structure/shuttle/part/dropship2/transparent/nose_top_right
 	icon_state = "102"

--- a/code/modules/shuttle/shuttles/dropship.dm
+++ b/code/modules/shuttle/shuttles/dropship.dm
@@ -238,6 +238,12 @@
 	for(var/obj/structure/dropship_equipment/eq as anything in dropship.equipments)
 		eq.on_launch()
 
+/obj/docking_port/stationary/marine_dropship/on_arrival(obj/docking_port/mobile/departing_shuttle)
+	. = ..()
+	var/obj/docking_port/mobile/marine_dropship/dropship = departing_shuttle
+	for(var/obj/structure/dropship_equipment/eq as anything in dropship.equipments)
+		eq.on_arrival()
+
 /obj/docking_port/stationary/marine_dropship/lz1
 	name = "LZ1 Landing Zone"
 	id = DROPSHIP_LZ1


### PR DESCRIPTION
# About the pull request

This PR contains the following changes
 * Corrected visual issues on tiles on predator ship
 * Corrected floorlight issues after turning off due to overlays being cut and not reapplied in open turfs `update_icon` function
 * Corrected shuttle ships lighting
 * Fixed where shuttle lights turned off after taking on, but not back on, as well as the shuttle light could never be shut off
* Added the `marine_dropship/on_arrival` callback, so that dropship equipment have the expected event triggered. This event was not triggering for the spotlights because it was missing.

# Explain why it's good for the game
This PR fixes various lighting related issues which are explained above as well as better explained in the images below. Overall these changes bring a better lighting experience for both marines and predators.


# Testing Photographs and Procedure
## Important notes
It is important to note that the shuttle only appears graphically correct when the base alpha is above 128. I tried playing with the colour matrix and other methods to have them consistent in all situations, but I am unsure if this is even a use-case which happens. Please let me know if there is a need to handle this situation and I can spend more time on it, but the alpha masking changes only apply to the shuttles using the `use_alphamasking` property.

Additionally, these changes add a method which should be used to get lighting effects for base lighting instead of referencing the property directly from the area. It is named `get_turf_lighting_effect`

Additionally, while I have not been able to spot any graphical issues, the changes to the `lighting_effect` property do affect the base lighting for **all tiles**, so any feedback on things to look out for would be welcomed. I have checked the ship over and common areas on surface maps but it can be tricky to spot things.
<details>
<summary>Screenshots & Videos</summary>

### Tile colour blending changes
#### Before
![colour_blending_before](https://github.com/cmss13-devs/cmss13/assets/149045778/5b252965-5a36-4bfb-8ae6-099ed72c9bb2)
#### After
![colour_blending_after](https://github.com/cmss13-devs/cmss13/assets/149045778/159c29dc-5352-48bd-b6a9-9a48269c7edc)

### Floorlight fix
#### Before
![light_tile_offstate_before](https://github.com/cmss13-devs/cmss13/assets/149045778/4a2fc9f4-4e71-4ec4-a57d-5cf39c4eb141)
#### After
![light_tile_offstate_after](https://github.com/cmss13-devs/cmss13/assets/149045778/a8ed2677-56db-4d78-ab18-ff607d87470d)

### Dropship lighting changes
#### Before
![shuttle_lightsoff_before](https://github.com/cmss13-devs/cmss13/assets/149045778/6d45b838-4b70-402b-8795-594820a3b708)
![shuttle_lighting_surface_lightsoff_before](https://github.com/cmss13-devs/cmss13/assets/149045778/58bb4cad-367e-446b-8af9-149b87e6a66a)

#### After
![dropship_lighting_after](https://github.com/cmss13-devs/cmss13/assets/149045778/c5071f33-7ca4-4031-b0e0-d87c0ae25dc0)
![shuttle_lighting_surface_lightsoff_after](https://github.com/cmss13-devs/cmss13/assets/149045778/4c6db0cd-9979-40c0-892b-ed8c6e3d3662)


</details>


# Changelog
:cl:
fix: Fixed marine shuttle and predator ship lighting issues
fix: Fixed floorlight lighting issues
fix: Fixed marine shuttle spotlight toggling issues
/:cl:
