### PR TITLE
Liason typo fix and Goon construction buff.

### DIFF
--- a/code/datums/skills/civilian.dm
+++ b/code/datums/skills/civilian.dm
@@ -70,7 +70,7 @@ CIVILIAN
 
 /datum/skills/civilian/survivor/goon
 	name = "Survivor Goon"
-	skills = list(
+	additional_skills = list(
 		SKILL_CQC = SKILL_CQC_TRAINED,
 		SKILL_POLICE = SKILL_POLICE_SKILLED,
 		SKILL_FIREMAN = SKILL_FIREMAN_SKILLED,

--- a/code/game/area/almayer.dm
+++ b/code/game/area/almayer.dm
@@ -119,7 +119,7 @@
 	fake_zlevel = 1 // upperdeck
 	flags_area = AREA_NOTUNNEL
 
-/area/almayer/command/corporateliason
+/area/almayer/command/corporateliaison
 	name = "\improper Corporate Liaison Office"
 	icon_state = "corporatespace"
 	fake_zlevel = 1 // upperdeck

--- a/code/game/machinery/doors/shutters.dm
+++ b/code/game/machinery/doors/shutters.dm
@@ -179,7 +179,7 @@
 
 //make a subtype for CL office so it as a proper name.
 /obj/structure/machinery/door/poddoor/shutters/almayer/cl
-		name = "\improper Corporate Liason Privacy Shutters"
+		name = "\improper Corporate Liaison Privacy Shutters"
 //adding a subtype for CL office to use to secure access to cl office.
 /obj/structure/machinery/door/poddoor/shutters/almayer/cl/office
 /obj/structure/machinery/door/poddoor/shutters/almayer/cl/office/door

--- a/code/modules/gear_presets/survivors/corsat/preset_corsat.dm
+++ b/code/modules/gear_presets/survivors/corsat/preset_corsat.dm
@@ -35,11 +35,11 @@
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/shoes/white(new_human), WEAR_FEET)
 	..()
 
-/datum/equipment_preset/survivor/interstellar_commerce_commission_liason/corsat
+/datum/equipment_preset/survivor/interstellar_commerce_commission_liaison/corsat
 	name = "Survivor - Interstellar Commerce Commission Liaison CORSAT"
 	assignment = "Interstellar Commerce Commission Corporate Liaison"
 
-/datum/equipment_preset/survivor/interstellar_commerce_commission_liason/corsat/load_gear(mob/living/carbon/human/new_human)
+/datum/equipment_preset/survivor/interstellar_commerce_commission_liaison/corsat/load_gear(mob/living/carbon/human/new_human)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/under/liaison_suit/formal(new_human), WEAR_BODY)
 	new_human.equip_to_slot_or_del(new /obj/item/device/radio/headset/distress/CMB/limited(new_human), WEAR_L_EAR)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/head/hardhat/white(new_human), WEAR_HEAD)

--- a/code/modules/gear_presets/survivors/new_varadero/preset_new_varadero.dm
+++ b/code/modules/gear_presets/survivors/new_varadero/preset_new_varadero.dm
@@ -38,11 +38,11 @@
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/shoes/laceup(new_human), WEAR_FEET)
 	..()
 
-/datum/equipment_preset/survivor/interstellar_commerce_commission_liason/nv
+/datum/equipment_preset/survivor/interstellar_commerce_commission_liaison/nv
 	name = "Survivor - Interstellar Commerce Commission Liaison New Varadero"
 	assignment = "Interstellar Commerce Commission Corporate Liaison"
 
-/datum/equipment_preset/survivor/interstellar_commerce_commission_liason/nv/load_gear(mob/living/carbon/human/new_human)
+/datum/equipment_preset/survivor/interstellar_commerce_commission_liaison/nv/load_gear(mob/living/carbon/human/new_human)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/under/liaison_suit/formal(new_human), WEAR_BODY)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/head/hardhat/white(new_human), WEAR_HEAD)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/hazardvest/black(new_human), WEAR_JACKET)

--- a/code/modules/gear_presets/survivors/survivors.dm
+++ b/code/modules/gear_presets/survivors/survivors.dm
@@ -420,7 +420,7 @@ Everything bellow is a parent used as a base for one or multiple maps.
 // ----- Interstellar Commerce Commission Survivor
 
 // Used in Trijent Dam and New Varadero.
-/datum/equipment_preset/survivor/interstellar_commerce_commission_liason
+/datum/equipment_preset/survivor/interstellar_commerce_commission_liaison
 	name = "Survivor - Interstellar Commerce Commission Liaison"
 	assignment = "Interstellar Commerce Commission Corporate Liaison"
 	skills = /datum/skills/civilian/survivor
@@ -431,11 +431,11 @@ Everything bellow is a parent used as a base for one or multiple maps.
 
 	survivor_variant = CORPORATE_SURVIVOR
 
-/datum/equipment_preset/survivor/interstellar_commerce_commission_liason/New()
+/datum/equipment_preset/survivor/interstellar_commerce_commission_liaison/New()
 	. = ..()
 	access = get_access(ACCESS_LIST_CIVIL_LIAISON)
 
-/datum/equipment_preset/survivor/interstellar_commerce_commission_liason/load_gear(mob/living/carbon/human/new_human)
+/datum/equipment_preset/survivor/interstellar_commerce_commission_liaison/load_gear(mob/living/carbon/human/new_human)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/under/liaison_suit(new_human), WEAR_BODY)
 	new_human.equip_to_slot_or_del(new /obj/item/device/radio/headset/distress/CMB/limited(new_human), WEAR_L_EAR)
 

--- a/maps/corsat.json
+++ b/maps/corsat.json
@@ -13,7 +13,7 @@
         "/datum/equipment_preset/survivor/goon",
         "/datum/equipment_preset/survivor/doctor/corsat",
         "/datum/equipment_preset/survivor/security/corsat",
-        "/datum/equipment_preset/survivor/interstellar_commerce_commission_liason/corsat",
+        "/datum/equipment_preset/survivor/interstellar_commerce_commission_liaison/corsat",
         "/datum/equipment_preset/survivor/engineer/corsat",
         "/datum/equipment_preset/survivor/clf",
         "/datum/equipment_preset/survivor/civilian"

--- a/maps/desert_dam.json
+++ b/maps/desert_dam.json
@@ -7,7 +7,7 @@
         "/datum/equipment_preset/survivor/doctor/trijent",
         "/datum/equipment_preset/survivor/roughneck",
         "/datum/equipment_preset/survivor/chaplain/trijent",
-        "/datum/equipment_preset/survivor/interstellar_commerce_commission_liason",
+        "/datum/equipment_preset/survivor/interstellar_commerce_commission_liaison",
         "/datum/equipment_preset/survivor/colonial_marshal",
         "/datum/equipment_preset/survivor/engineer/trijent",
         "/datum/equipment_preset/survivor/engineer/trijent/hydro",

--- a/maps/map_files/LV522_Chances_Claim/LV522_Chances_Claim.dmm
+++ b/maps/map_files/LV522_Chances_Claim/LV522_Chances_Claim.dmm
@@ -62142,7 +62142,7 @@
 /area/lv522/indoors/c_block/casino)
 "xHz" = (
 /obj/structure/machinery/door/airlock/almayer/generic{
-	name = "\improper Corporate Liason Office "
+	name = "\improper Corporate Liaison Office "
 	},
 /turf/open/floor/corsat{
 	icon_state = "marked"

--- a/maps/map_files/LV624/LV624.dmm
+++ b/maps/map_files/LV624/LV624.dmm
@@ -12485,7 +12485,7 @@
 "bnz" = (
 /obj/structure/machinery/door/airlock/almayer/generic{
 	dir = 1;
-	name = "\improper Corporate Liason"
+	name = "\improper Corporate Liaison"
 	},
 /turf/open/floor{
 	icon_state = "white"
@@ -20011,7 +20011,7 @@
 "pQn" = (
 /obj/structure/machinery/door/airlock/almayer/generic{
 	locked = 1;
-	name = "\improper Corporate Liason"
+	name = "\improper Corporate Liaison"
 	},
 /turf/open/floor{
 	icon_state = "white"

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -7027,7 +7027,7 @@
 /area/almayer/command/cic)
 "awE" = (
 /turf/closed/wall/almayer,
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "awF" = (
 /turf/closed/wall/almayer/reinforced,
 /area/almayer/living/numbertwobunks)
@@ -9636,7 +9636,7 @@
 /area/almayer/living/bridgebunks)
 "aGt" = (
 /turf/open/floor/almayer,
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "aGv" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 1
@@ -10750,7 +10750,7 @@
 	icon_state = "pottedplant_21"
 	},
 /turf/open/floor/wood/ship,
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "aLS" = (
 /obj/item/device/radio/intercom{
 	freerange = 1;
@@ -11894,7 +11894,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "aRE" = (
 /obj/structure/machinery/alarm/almayer{
 	dir = 1
@@ -12229,7 +12229,7 @@
 "aSP" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/wood/ship,
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "aSY" = (
 /obj/structure/machinery/light/small{
 	dir = 4
@@ -13063,7 +13063,7 @@
 	pixel_y = 10
 	},
 /turf/open/floor/wood/ship,
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "aWT" = (
 /obj/structure/machinery/door/airlock/almayer/maint{
 	dir = 1
@@ -13504,7 +13504,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/open/floor/wood/ship,
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "aZK" = (
 /obj/structure/pipes/vents/pump{
 	dir = 4
@@ -13599,12 +13599,12 @@
 	},
 /obj/structure/machinery/faxmachine/corporate/liaison,
 /turf/open/floor/wood/ship,
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "bac" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/computer/emails,
 /turf/open/floor/wood/ship,
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "bad" = (
 /obj/structure/machinery/light,
 /turf/open/floor/almayer,
@@ -13690,7 +13690,7 @@
 "baD" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood/ship,
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "baG" = (
 /obj/structure/largecrate/random/barrel/blue,
 /turf/open/floor/almayer,
@@ -15124,7 +15124,7 @@
 "bhM" = (
 /obj/structure/safe/cl_office,
 /turf/open/floor/wood/ship,
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "bhT" = (
 /obj/structure/cargo_container/lockmart/mid{
 	layer = 3.1;
@@ -16474,7 +16474,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/open/floor/carpet,
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "bpj" = (
 /obj/structure/dropship_equipment/fulton_system,
 /turf/open/floor/almayer{
@@ -16678,11 +16678,11 @@
 	dir = 4
 	},
 /turf/open/floor/wood/ship,
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "bqw" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/wood/ship,
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "bqF" = (
 /obj/structure/dropship_equipment/fuel/fuel_enhancer,
 /turf/open/floor/almayer{
@@ -16972,11 +16972,11 @@
 	},
 /obj/structure/surface/table/woodentable/fancy,
 /turf/open/floor/carpet,
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "bse" = (
 /obj/structure/machinery/computer/arcade,
 /turf/open/floor/wood/ship,
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "bsj" = (
 /obj/structure/machinery/line_nexter/med{
 	dir = 4
@@ -17290,7 +17290,7 @@
 	dir = 4
 	},
 /turf/open/floor/carpet,
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "btC" = (
 /obj/structure/pipes/standard/manifold/hidden/supply{
 	dir = 1
@@ -17562,7 +17562,7 @@
 	serial_number = 10
 	},
 /turf/open/floor/wood/ship,
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "bvd" = (
 /obj/structure/machinery/constructable_frame,
 /turf/open/floor/almayer{
@@ -17585,7 +17585,7 @@
 "bvl" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer,
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "bvr" = (
 /obj/structure/bed/chair/office/dark,
 /obj/effect/decal/warning_stripes{
@@ -17684,7 +17684,7 @@
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
 	},
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "bvV" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer{
 	dir = 2
@@ -18164,14 +18164,14 @@
 	dir = 8
 	},
 /turf/open/floor/almayer,
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "byq" = (
 /obj/structure/machinery/light{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer,
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "byr" = (
 /obj/structure/largecrate/random/barrel/green,
 /turf/open/floor/almayer{
@@ -18342,7 +18342,7 @@
 /obj/structure/window/reinforced/tinted/frosted,
 /obj/item/tool/soap/deluxe,
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "bzy" = (
 /turf/closed/wall/almayer,
 /area/almayer/hallways/vehiclehangar)
@@ -18744,7 +18744,7 @@
 	pixel_x = -32
 	},
 /turf/open/floor/wood/ship,
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "bBl" = (
 /obj/structure/machinery/light{
 	dir = 4
@@ -23804,7 +23804,7 @@
 /obj/structure/pipes/standard/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood/ship,
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "bXw" = (
 /obj/structure/machinery/bioprinter{
 	stored_metal = 125
@@ -23822,7 +23822,7 @@
 	pixel_y = 25
 	},
 /turf/open/floor/wood/ship,
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "bXH" = (
 /obj/structure/pipes/standard/manifold/hidden/supply{
 	dir = 4
@@ -23975,7 +23975,7 @@
 /area/almayer/hull/upper_hull/u_a_s)
 "bYj" = (
 /turf/open/floor/wood/ship,
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "bYn" = (
 /turf/closed/wall/almayer/outer,
 /area/almayer/engineering/upper_engineering/port)
@@ -25364,7 +25364,7 @@
 	},
 /obj/item/device/portable_vendor/corporate,
 /turf/open/floor/wood/ship,
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "cer" = (
 /obj/structure/largecrate/random/case/double,
 /turf/open/floor/almayer{
@@ -27369,7 +27369,7 @@
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
 	},
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "csz" = (
 /turf/open/floor/almayer{
 	icon_state = "plate"
@@ -27506,7 +27506,7 @@
 	dir = 1
 	},
 /turf/open/floor/almayer,
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "cvH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -29387,7 +29387,7 @@
 	},
 /obj/item/device/camera,
 /turf/open/floor/almayer,
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "dhR" = (
 /obj/structure/machinery/door/poddoor/shutters/almayer/open{
 	dir = 4;
@@ -29502,7 +29502,7 @@
 	icon_state = "pottedplant_10"
 	},
 /turf/open/floor/wood/ship,
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "djM" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/reagentgrinder/industrial{
@@ -29825,7 +29825,7 @@
 	pixel_x = 24
 	},
 /turf/open/floor/wood/ship,
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "dqb" = (
 /obj/structure/sign/safety/security{
 	pixel_x = -16
@@ -31294,7 +31294,7 @@
 /turf/open/floor/almayer{
 	icon_state = "dark_sterile"
 	},
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "dTt" = (
 /obj/structure/surface/table/almayer,
 /obj/item/device/camera,
@@ -31746,7 +31746,7 @@
 	pixel_x = 2
 	},
 /turf/open/floor/carpet,
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "ecR" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
@@ -32251,7 +32251,7 @@
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
 	},
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "ene" = (
 /turf/open/floor/almayer{
 	dir = 4;
@@ -32994,7 +32994,7 @@
 	pixel_y = -3
 	},
 /turf/open/floor/wood/ship,
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "eCI" = (
 /obj/structure/window/reinforced/ultra{
 	pixel_y = -12
@@ -33297,7 +33297,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "eHx" = (
 /obj/structure/surface/table/reinforced/almayer_B,
 /obj/structure/machinery/faxmachine/uscm/command,
@@ -33425,7 +33425,7 @@
 /turf/open/floor/almayer{
 	icon_state = "dark_sterile"
 	},
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "eKM" = (
 /obj/structure/surface/rack,
 /obj/effect/decal/cleanable/dirt,
@@ -33749,7 +33749,7 @@
 	dir = 4
 	},
 /turf/open/floor/carpet,
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "eUZ" = (
 /obj/structure/machinery/firealarm{
 	pixel_y = 28
@@ -33985,7 +33985,7 @@
 "eYW" = (
 /obj/structure/filingcabinet/security,
 /turf/open/floor/wood/ship,
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "eZi" = (
 /obj/effect/projector{
 	name = "Almayer_Up4";
@@ -35137,7 +35137,7 @@
 	},
 /obj/structure/machinery/light,
 /turf/open/floor/wood/ship,
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "fAr" = (
 /obj/structure/closet/secure_closet/guncabinet/red/mp_armory_m39_submachinegun,
 /turf/open/floor/plating/plating_catwalk,
@@ -35163,7 +35163,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood/ship,
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "fAS" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/pipes/standard/simple/hidden/supply,
@@ -36406,7 +36406,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "gcc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -37155,7 +37155,7 @@
 	pixel_x = -32
 	},
 /turf/open/floor/carpet,
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "guS" = (
 /obj/structure/reagent_dispensers/fueltank/custom,
 /turf/open/floor/almayer{
@@ -37612,7 +37612,7 @@
 /obj/structure/window/framed/almayer,
 /obj/structure/machinery/door/poddoor/shutters/almayer/cl/quarter/window,
 /turf/open/floor/plating,
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "gBW" = (
 /obj/structure/machinery/floodlight/landing{
 	name = "bolted floodlight"
@@ -37735,7 +37735,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/open/floor/wood/ship,
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "gFa" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -38721,7 +38721,7 @@
 	pixel_y = -3
 	},
 /turf/open/floor/carpet,
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "haM" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/structure/machinery/constructable_frame,
@@ -39158,7 +39158,7 @@
 	dir = 1
 	},
 /turf/open/floor/wood/ship,
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "hiM" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/pipes/standard/simple/hidden/supply{
@@ -40193,7 +40193,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood/ship,
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "hEV" = (
 /obj/structure/pipes/vents/pump,
 /turf/open/floor/almayer,
@@ -40308,7 +40308,7 @@
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
 	},
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "hHR" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer{
@@ -41158,7 +41158,7 @@
 	pixel_x = 25
 	},
 /turf/open/floor/wood/ship,
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "hZj" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N";
@@ -41234,7 +41234,7 @@
 	dir = 1
 	},
 /turf/open/floor/carpet,
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "ial" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -41467,7 +41467,7 @@
 	pixel_x = 5
 	},
 /turf/open/floor/wood/ship,
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "igr" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "SE-out"
@@ -41591,7 +41591,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "iiC" = (
 /obj/structure/sign/safety/maint{
 	pixel_x = 8;
@@ -41642,7 +41642,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "ijp" = (
 /obj/structure/surface/rack,
 /obj/item/storage/toolbox/mechanical,
@@ -41691,7 +41691,7 @@
 	pixel_y = 37
 	},
 /turf/open/floor/wood/ship,
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "ikQ" = (
 /obj/structure/surface/table/woodentable/fancy,
 /obj/item/tool/stamp/hop{
@@ -41729,7 +41729,7 @@
 	pixel_y = 6
 	},
 /turf/open/floor/wood/ship,
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "ily" = (
 /obj/structure/machinery/light,
 /turf/open/floor/almayer,
@@ -42732,7 +42732,7 @@
 	pixel_y = 8
 	},
 /turf/open/floor/carpet,
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "iHF" = (
 /obj/structure/largecrate/random,
 /obj/item/reagent_container/food/snacks/cheesecakeslice{
@@ -43838,7 +43838,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood/ship,
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "jdG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -46004,7 +46004,7 @@
 	pixel_x = -25
 	},
 /turf/open/floor/wood/ship,
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "jYR" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N";
@@ -46659,7 +46659,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "kmM" = (
 /obj/structure/sink{
 	pixel_y = 24
@@ -47354,7 +47354,7 @@
 /turf/open/floor/almayer{
 	icon_state = "dark_sterile"
 	},
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "kAL" = (
 /obj/structure/closet/secure_closet/brig,
 /turf/open/floor/almayer{
@@ -50350,7 +50350,7 @@
 	},
 /obj/structure/machinery/door/poddoor/shutters/almayer/cl/office/window,
 /turf/open/floor/plating,
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "lFm" = (
 /turf/open/floor/almayer{
 	dir = 8;
@@ -50810,7 +50810,7 @@
 /turf/open/floor/almayer{
 	icon_state = "dark_sterile"
 	},
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "lOr" = (
 /obj/structure/window/framed/almayer,
 /obj/structure/machinery/door/firedoor/border_only/almayer,
@@ -51259,7 +51259,7 @@
 	dir = 1
 	},
 /turf/open/floor/almayer,
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "maw" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/machinery/door/airlock/almayer/maint{
@@ -54742,7 +54742,7 @@
 	dir = 1
 	},
 /turf/open/floor/wood/ship,
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "ntt" = (
 /obj/item/stool,
 /obj/effect/decal/warning_stripes{
@@ -55186,7 +55186,7 @@
 	},
 /obj/structure/surface/table/woodentable/fancy,
 /turf/open/floor/carpet,
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "nDo" = (
 /obj/structure/closet/l3closet/general,
 /obj/structure/window/reinforced{
@@ -56672,7 +56672,7 @@
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
 	},
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "ojF" = (
 /obj/structure/machinery/cm_vending/clothing/tl/charlie{
 	density = 0;
@@ -57089,7 +57089,7 @@
 	pixel_y = 32
 	},
 /turf/open/floor/wood/ship,
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "orH" = (
 /turf/open/floor/almayer/uscm/directional{
 	dir = 10
@@ -60360,7 +60360,7 @@
 	pixel_y = 20
 	},
 /turf/open/floor/almayer,
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "pQy" = (
 /obj/structure/window/framed/almayer,
 /turf/open/floor/plating,
@@ -62117,7 +62117,7 @@
 /obj/item/storage/photo_album,
 /obj/item/device/camera_film,
 /turf/open/floor/almayer,
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "qyD" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/recharger,
@@ -62634,7 +62634,7 @@
 /obj/item/clothing/under/redpyjamas,
 /obj/item/bedsheet/orange,
 /turf/open/floor/wood/ship,
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "qJY" = (
 /obj/structure/surface/table/almayer,
 /obj/item/reagent_container/food/drinks/bottle/orangejuice{
@@ -62831,7 +62831,7 @@
 	pixel_y = 28
 	},
 /turf/open/floor/wood/ship,
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "qMf" = (
 /obj/structure/bed/chair,
 /turf/open/floor/almayer{
@@ -63953,7 +63953,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "rjV" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/computer/cameras/wooden_tv/prop{
@@ -64142,7 +64142,7 @@
 /area/almayer/command/airoom)
 "rne" = (
 /turf/open/floor/carpet,
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "rnH" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N";
@@ -66034,7 +66034,7 @@
 	pixel_x = -17
 	},
 /turf/open/floor/wood/ship,
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "scg" = (
 /obj/structure/surface/rack,
 /obj/effect/spawner/random/toolbox,
@@ -69147,7 +69147,7 @@
 /obj/item/storage/box/drinkingglasses,
 /obj/item/storage/fancy/cigar,
 /turf/open/floor/almayer,
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "tnY" = (
 /obj/structure/machinery/cryopod{
 	pixel_y = 6
@@ -69418,7 +69418,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood/ship,
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "tsM" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N";
@@ -76439,7 +76439,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood/ship,
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "wfB" = (
 /obj/structure/machinery/light{
 	unacidable = 1;
@@ -76563,7 +76563,7 @@
 	pixel_y = -32
 	},
 /turf/open/floor/wood/ship,
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "wie" = (
 /obj/item/device/radio/intercom{
 	freerange = 1;
@@ -77450,7 +77450,7 @@
 	pixel_x = 25
 	},
 /turf/open/floor/wood/ship,
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "wzZ" = (
 /obj/structure/machinery/door/airlock/almayer/medical/glass{
 	dir = 1;
@@ -78214,7 +78214,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood/ship,
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "wQx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -79044,7 +79044,7 @@
 	dir = 1
 	},
 /turf/open/floor/wood/ship,
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "xgx" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "SE-out";
@@ -79396,7 +79396,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "xnl" = (
 /obj/structure/machinery/door/airlock/almayer/secure/reinforced{
 	name = "\improper Exterior Airlock";
@@ -80552,7 +80552,7 @@
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
 	},
-/area/almayer/command/corporateliason)
+/area/almayer/command/corporateliaison)
 "xJH" = (
 /turf/open/floor/almayer{
 	icon_state = "cargo"

--- a/maps/new_varadero.json
+++ b/maps/new_varadero.json
@@ -11,7 +11,7 @@
         "/datum/equipment_preset/survivor/chaplain/nv",
         "/datum/equipment_preset/survivor/engineer/nv",
         "/datum/equipment_preset/survivor/trucker/nv",
-        "/datum/equipment_preset/survivor/interstellar_commerce_commission_liason/nv",
+        "/datum/equipment_preset/survivor/interstellar_commerce_commission_liaison/nv",
         "/datum/equipment_preset/survivor/security/nv",
         "/datum/equipment_preset/survivor/beachbum",
         "/datum/equipment_preset/survivor/miner",


### PR DESCRIPTION
# About the pull request

Liason is not spelt like that, fixes the USS Almayer area and the ICC path.

Goon could not build cades due to skills = and not additional_skills allowing the parent, survivor, to give construction one to it's subpaths.

# Explain why it's good for the game

Spell check good

I am pretty sure that the Goon is the only survivor not being able to build basic cades, I don't see why we restrict that considering that all the other security survivors are able to build them.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: rebalanced goon skillset to include construction 1
spellcheck: fixed Liason area typos to Liaison
spellcheck: fixed the ICC Liason to ICC Liaison typo
/:cl:
