### PR TITLE
Reduces the burst multiplier on the M39

### DIFF
--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -84,7 +84,7 @@
 	accuracy_mult = BASE_ACCURACY_MULT
 	accuracy_mult_unwielded = BASE_ACCURACY_MULT - HIT_ACCURACY_MULT_TIER_5
 	scatter = SCATTER_AMOUNT_TIER_4
-	burst_scatter_mult = SCATTER_AMOUNT_TIER_6
+	burst_scatter_mult = SCATTER_AMOUNT_TIER_7
 	scatter_unwielded = SCATTER_AMOUNT_TIER_4
 	damage_mult = BASE_BULLET_DAMAGE_MULT
 	recoil_unwielded = RECOIL_AMOUNT_TIER_5

--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -11,7 +11,7 @@
 	aim_slowdown = SLOWDOWN_ADS_QUICK
 	wield_delay = WIELD_DELAY_VERY_FAST
 	attachable_allowed = list(
-		/obj/item/attachable/suppressor,			
+		/obj/item/attachable/suppressor,
 		/obj/item/attachable/reddot,
 		/obj/item/attachable/reflex,
 		/obj/item/attachable/flashlight,
@@ -50,7 +50,7 @@
 		/obj/item/attachable/suppressor,
 		/obj/item/attachable/reddot,
 		/obj/item/attachable/reflex,
-		/obj/item/attachable/angledgrip,	
+		/obj/item/attachable/angledgrip,
 		/obj/item/attachable/verticalgrip,
 		/obj/item/attachable/flashlight/grip,
 		/obj/item/attachable/stock/smg,
@@ -84,7 +84,7 @@
 	accuracy_mult = BASE_ACCURACY_MULT
 	accuracy_mult_unwielded = BASE_ACCURACY_MULT - HIT_ACCURACY_MULT_TIER_5
 	scatter = SCATTER_AMOUNT_TIER_4
-	burst_scatter_mult = SCATTER_AMOUNT_TIER_4
+	burst_scatter_mult = SCATTER_AMOUNT_TIER_6
 	scatter_unwielded = SCATTER_AMOUNT_TIER_4
 	damage_mult = BASE_BULLET_DAMAGE_MULT
 	recoil_unwielded = RECOIL_AMOUNT_TIER_5


### PR DESCRIPTION

# About the pull request


Reduces the burst scatter multiplier on the M39 by 43%, from 7 to 4.

# Explain why it's good for the game

The weapon fails to shoot straight in burst mode even in its effective range. Automatic fire, which originally the M39 was touted as being good at when it was first being rolled out, is only slightly better than burst due to the fact the scatter ramps up. Neither modes are of any use in comparison to single fire, which is accurate at any range, including up to seven tiles. Even a M39 outfitted with the best scatter reducing attachments misses more shots than it has any right to.

In comparison, the MK2 rifle does not miss a single bullet in burst mode even at the edge of the screen, without a single attachment. A comparison video between the current firemodes and the tweaked ones are located in the testing section.

I personally think this is stupid and condemns the other two firemodes to never getting used. A 43% reduction from 7 to 4 is a lot, but this weapon could use some love beyond messing with damage or falloff (which I think are currently fine). With the current tweak, you still have to get really close to get use out of the firemodes if you have no attachments. However, applying a reflex sight or a vertical grip greatly enhances the use of the burst and auto mode, which is the way it should be:

As as side-note, this is the same tier the M39 had during its legendary BFG phase. However, since then we've lost the ability to attach the BFA to the M39, marines have completely lost access to the barrel charger and the M39 had its burst count lowered. Such a thing happening again shouldn't be a worry (hopefully).



# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Old value:

https://github.com/cmss13-devs/cmss13/assets/17518895/9b76f9fa-d5a3-4110-9c4a-74c8dd77d412

New value:

https://github.com/cmss13-devs/cmss13/assets/17518895/97ce0f8c-2b18-4475-924c-0f46485199f3



</details>


# Changelog
:cl:
balance: M39 burst scatter multiplier reduced from 7 to 4.
/:cl:
