### PR TITLE
suspect sec records qol fix

### DIFF
--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -95,7 +95,7 @@
 							if("Released")
 								background = "'background-color:#2981b3;'"
 							if("Suspect")
-								background = "'background-color:#008743;'"
+								background = "'background-color:#686A6C;'"
 							if("NJP")
 								background = "'background-color:#faa20a;'"
 							if("None")


### PR DESCRIPTION

# About the pull request

Missed another code line for making suspects nardo gray instead of green

# Explain why it's good for the game

Makes it easier to distinguish suspects from innocents on sec records

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: LTNTS
qol: makes suspect nardo gray
/:cl:

