### PR TITLE
CL Headsets can utilize two more keys.

### DIFF
--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -14,7 +14,7 @@
 	inherent_traits = list(TRAIT_ITEM_EAR_EXCLUSIVE)
 	var/translate_apollo = FALSE
 	var/translate_hive = FALSE
-	var/maximum_keys = 5
+	var/maximum_keys = 3
 	var/list/initial_keys //Typepaths of objects to be created at initialisation.
 	var/list/keys //Actual objects.
 	maxf = 1489
@@ -520,6 +520,7 @@
 	name = "corporate liaison radio headset"
 	desc = "Used by the CL to convince people to sign NDAs. Channels are as follows: :v - marine command, :a - alpha squad, :b - bravo squad, :c - charlie squad, :d - delta squad, :n - engineering, :m - medbay, :u - requisitions, :j - JTAC, :t - intel, :y for WY."
 	icon_state = "wy_headset"
+	var/maximum_keys = 5
 	initial_keys = list(/obj/item/device/encryptionkey/mcom/cl)
 
 /obj/item/device/radio/headset/almayer/reporter

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -520,7 +520,7 @@
 	name = "corporate liaison radio headset"
 	desc = "Used by the CL to convince people to sign NDAs. Channels are as follows: :v - marine command, :a - alpha squad, :b - bravo squad, :c - charlie squad, :d - delta squad, :n - engineering, :m - medbay, :u - requisitions, :j - JTAC, :t - intel, :y for WY."
 	icon_state = "wy_headset"
-	var/maximum_keys = 5
+	maximum_keys = 5
 	initial_keys = list(/obj/item/device/encryptionkey/mcom/cl)
 
 /obj/item/device/radio/headset/almayer/reporter

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -14,7 +14,7 @@
 	inherent_traits = list(TRAIT_ITEM_EAR_EXCLUSIVE)
 	var/translate_apollo = FALSE
 	var/translate_hive = FALSE
-	var/maximum_keys = 3
+	var/maximum_keys = 5
 	var/list/initial_keys //Typepaths of objects to be created at initialisation.
 	var/list/keys //Actual objects.
 	maxf = 1489


### PR DESCRIPTION
# About the pull request

CLs have access to more keys now for CL purposes.  This bump should allow them to utilize the new keys without feeling awkwardly limited by the key count.

# Explain why it's good for the game

You use utility by having limited key access, this should allow people who use keys more frequently to take part in broader information spaces.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Max CL Headset radio keys from 3 to 5.  (+2 increase)
/:cl:
