### PR TITLE
Fixes matches doing brute instead of burn when accidently burning yourself

### DIFF
--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -302,7 +302,7 @@
 		if(istype(W) && !W.heat_source && !W.burnt)
 			if(prob(burn_chance))
 				to_chat(user, SPAN_WARNING("\The [W] lights, but you burn your hand in the process! Ouch!"))
-				user.apply_damage(3, BRUTE, pick("r_hand", "l_hand"))
+				user.apply_damage(3, BURN, pick("r_hand", "l_hand"))
 				if((user.pain.feels_pain) && prob(25))
 					user.emote("scream")
 				W.light_match()


### PR DESCRIPTION

# About the pull request
Burning yourself when trying to start a match now does burn damage, instead of brute.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
If the text says it burns ya, it should probably burn ya.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

ouch ow my fingers, burnt

</details>


# Changelog
:cl:
fix: Matches now do burn damage instead of brute, when you accidently burn your own hand.
/:cl:
