### PR TITLE
Fixes fire resist spamming

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
@@ -1015,20 +1015,17 @@
 		return
 	var/breakouttime = legcuffed.breakouttime
 
-	next_move = world.time + 100
-	last_special = world.time + 10
+	next_move = world.time + 10 SECONDS
+	last_special = world.time + 1 SECONDS
 
 	var/displaytime = max(1, round(breakouttime / 600)) //Minutes
-	to_chat(src, SPAN_WARNING("We attempt to remove [legcuffed]. (This will take around [displaytime] minute(s) and we must stand still)"))
-	for(var/mob/O in viewers(src))
-		O.show_message(SPAN_DANGER("<B>[usr] attempts to remove [legcuffed]!</B>"), SHOW_MESSAGE_VISIBLE)
-	if(!do_after(src, breakouttime, INTERRUPT_NO_NEEDHAND^INTERRUPT_RESIST, BUSY_ICON_HOSTILE))
+	visible_message(SPAN_DANGER("<b>[src] attempts to remove [legcuffed]!</b>"),
+		SPAN_WARNING("We attempt to remove [legcuffed]. (This will take around [displaytime] minute\s and we must stand still)"))
+	if(!do_after(src, breakouttime, INTERRUPT_NO_NEEDHAND ^ INTERRUPT_RESIST, BUSY_ICON_HOSTILE))
 		return
 	if(!legcuffed || buckled)
-		return // time leniency for lag which also might make this whole thing pointless but the server
-	for(var/mob/O in viewers(src))//  lags so hard that 40s isn't lenient enough - Quarxink
-		O.show_message(SPAN_DANGER("<B>[src] manages to remove [legcuffed]!</B>"), SHOW_MESSAGE_VISIBLE)
-	to_chat(src, SPAN_NOTICE(" We successfully remove [legcuffed]."))
+		return
+	visible_message(SPAN_DANGER("<b>[src] manages to remove [legcuffed]!</b>"), SPAN_NOTICE("We successfully remove [legcuffed]."))
 	drop_inv_item_on_ground(legcuffed)
 
 /mob/living/carbon/xenomorph/IgniteMob()

--- a/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
@@ -1011,6 +1011,8 @@
 		SPAN_NOTICE("We extinguish ourselves."), null, 5)
 
 /mob/living/carbon/xenomorph/resist_restraints()
+	if(!legcuffed)
+		return
 	var/breakouttime = legcuffed.breakouttime
 
 	next_move = world.time + 100

--- a/code/modules/mob/living/living_verbs.dm
+++ b/code/modules/mob/living/living_verbs.dm
@@ -170,24 +170,15 @@
 			return
 
 	//breaking out of handcuffs & putting out fires
-	if(!is_mob_incapacitated(TRUE))
+	if(mobility_flags & MOBILITY_MOVE)
 		if(on_fire)
 			resist_fire()
-
-		var/on_acid = FALSE
-		for(var/datum/effects/acid/A in effects_list)
-			on_acid = TRUE
-			break
-		if(on_acid)
+		if(is_type_in_list(/datum/effects/acid, effects_list))
 			resist_acid()
+		if(last_special <= world.time)
+			resist_restraints()
 
 	SEND_SIGNAL(src, COMSIG_MOB_RESISTED)
-
-	if(!iscarbon(src))
-		return
-	var/mob/living/carbon/C = src
-	if((C.handcuffed || C.legcuffed) && (C.mobility_flags & MOBILITY_MOVE) && (C.last_special <= world.time))
-		resist_restraints()
 
 /mob/living/proc/resist_buckle()
 	buckled.manual_unbuckle(src)


### PR DESCRIPTION

# About the pull request

Fixes #5247 and fixes #5124 by changing the `if(!is_mob_incapacitated(TRUE))` check near the end of `/mob/living/verb/resist()` to `if(mobility_flags & MOBILITY_MOVE)`.
This was causing the bug because `is_mob_incapacitated()` doesn't check for the `WEAKEN` effect, which is what is added by `resist_fire()`.
(Editing `is_mob_incapacitated()` so that it checks for it would probably work too, but since TG uses the `MOBILITY_MOVE` thing and this system is ported from there, I figured I'd just go with that.)

# Explain why it's good for the game

Fixes fire being too easy to remove.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

**Before:**

https://github.com/cmss13-devs/cmss13/assets/57483089/0b5b6777-4286-4eb1-9293-09ffcaa4fb4b

**After:**

https://github.com/cmss13-devs/cmss13/assets/57483089/84097909-a081-4c4f-8400-59e955b8a443

(Ignore the "There are no pipes within range" message, that's from one of my macros.)

</details>


# Changelog
:cl:
fix: Fixed being able to remove multiple stacks of fire by spamming resist.
/:cl:
