### PR TITLE
Add Disposal Pipe Dispenser to Reactor Core Maintenance 

### DIFF
--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -57944,6 +57944,12 @@
 	icon_state = "plate"
 	},
 /area/almayer/living/bridgebunks)
+"oKM" = (
+/obj/structure/machinery/pipedispenser/disposal/orderable,
+/turf/open/floor/almayer{
+	icon_state = "cargo"
+	},
+/area/almayer/engineering/engine_core)
 "oLd" = (
 /obj/structure/platform{
 	dir = 4
@@ -68906,6 +68912,13 @@
 	icon_state = "green"
 	},
 /area/almayer/hallways/starboard_hallway)
+"tiB" = (
+/obj/structure/machinery/power/port_gen/pacman,
+/turf/open/floor/almayer{
+	dir = 5;
+	icon_state = "plating"
+	},
+/area/almayer/engineering/engine_core)
 "tiE" = (
 /obj/structure/window/framed/almayer,
 /obj/structure/machinery/door/firedoor/border_only/almayer,
@@ -137436,7 +137449,7 @@ tce
 bhB
 heg
 lfQ
-blo
+tiB
 vNF
 xuU
 vNF
@@ -137841,7 +137854,7 @@ jPf
 jPf
 bhB
 dVZ
-jyi
+oKM
 bPe
 bQm
 wlj


### PR DESCRIPTION

# About the pull request

Disposal Pipe Dispenser added to Reactore Core Maintenance, allowing building/replacement of disposal pipes

# Explain why it's good for the game

Almost every round disposal pipes are destroyed, allowing the crew to repair them will help allow MTs to do more to restore the ship (also allows them to expand the disposal system if they so choose)

# Changelog
:cl:
add: Disposal Pipe Dispenser added to Reactor Core Maintenance
/:cl:
