### PR TITLE
Fix Crusher Pass Flags

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/crusher/crusher_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/crusher/crusher_powers.dm
@@ -306,7 +306,7 @@
 	var/target = get_step(get_step(Xeno, target_dir), target_dir)
 	var/list/collision_callbacks = list(/mob/living/carbon/human = CALLBACK(src, PROC_REF(handle_mob_collision)))
 	var/list/end_throw_callbacks = list(CALLBACK(src, PROC_REF(on_end_throw), start_charging))
-	Xeno.throw_atom(target, target_dist, SPEED_FAST, pass_flags = PASS_CRUSHER_CHARGE, end_throw_callbacks = end_throw_callbacks, collision_callbacks = collision_callbacks)
+	Xeno.throw_atom(target, target_dist, SPEED_FAST, launch_type = LOW_LAUNCH, pass_flags = PASS_CRUSHER_CHARGE, end_throw_callbacks = end_throw_callbacks, collision_callbacks = collision_callbacks)
 
 	apply_cooldown()
 	return ..()

--- a/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
@@ -433,7 +433,7 @@
 	pre_pounce_effects()
 
 	X.pounce_distance = get_dist(X, A)
-	X.throw_atom(A, distance, throw_speed, X, pass_flags = pounce_pass_flags, collision_callbacks = pounce_callbacks)
+	X.throw_atom(A, distance, throw_speed, X, launch_type = LOW_LAUNCH, pass_flags = pounce_pass_flags, collision_callbacks = pounce_callbacks)
 	X.update_icons()
 
 	additional_effects_always()


### PR DESCRIPTION

# About the pull request

This PR is a followup to #5175 that overlooked that the usage of throw_atom will by default add either `PASS_OVER_THROW_MOB` or `PASS_OVER_THROW_ITEM` to the pass flags unless `LOW_LAUNCH` is used instead.

# Explain why it's good for the game

Fixes #5220 

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![croosh](https://github.com/cmss13-devs/cmss13/assets/76988376/dac2e275-e261-475a-b52d-8823e14d0bc4)

</details>


# Changelog
:cl: Drathek
fix: Fix crusher charge and tumble abilities going over unwired cades
/:cl:
