### PR TITLE
Fix Xmas barricade decorator not working

### DIFF
--- a/code/game/objects/structures/barricade/barricade.dm
+++ b/code/game/objects/structures/barricade/barricade.dm
@@ -103,7 +103,7 @@
 
 	if(is_wired)
 		if(!closed)
-			overlays += image(wire_icon, icon_state = "[src.barricade_type]_wire")
+			overlays += image(wire_icon, icon_state = "[barricade_type]_wire")
 		else
 			overlays += image(wire_icon, icon_state = "[src.barricade_type]_closed_wire")
 

--- a/code/game/objects/structures/barricade/barricade.dm
+++ b/code/game/objects/structures/barricade/barricade.dm
@@ -19,6 +19,7 @@
 	var/force_level_absorption = 5 //How much force an item needs to even damage it at all.
 	var/barricade_hitsound
 	var/barricade_type = "barricade" //"metal", "plasteel", etc.
+	var/wire_icon = 'icons/obj/structures/barricades.dmi' //! Icon file used for the wiring
 	var/can_change_dmg_state = TRUE
 	var/damage_state = BARRICADE_DMG_NONE
 	var/closed = FALSE
@@ -102,9 +103,9 @@
 
 	if(is_wired)
 		if(!closed)
-			overlays += image('icons/obj/structures/barricades.dmi', icon_state = "[src.barricade_type]_wire")
+			overlays += image(wire_icon, icon_state = "[src.barricade_type]_wire")
 		else
-			overlays += image('icons/obj/structures/barricades.dmi', icon_state = "[src.barricade_type]_closed_wire")
+			overlays += image(wire_icon, icon_state = "[src.barricade_type]_closed_wire")
 
 	..()
 

--- a/code/game/objects/structures/barricade/barricade.dm
+++ b/code/game/objects/structures/barricade/barricade.dm
@@ -105,7 +105,7 @@
 		if(!closed)
 			overlays += image(wire_icon, icon_state = "[barricade_type]_wire")
 		else
-			overlays += image(wire_icon, icon_state = "[src.barricade_type]_closed_wire")
+			overlays += image(wire_icon, icon_state = "[barricade_type]_closed_wire")
 
 	..()
 

--- a/code/modules/decorators/christmas.dm
+++ b/code/modules/decorators/christmas.dm
@@ -65,7 +65,7 @@
 /datum/decorator/christmas/barricade/decorate(obj/structure/barricade/barricade)
 	if(!istype(barricade))
 		return
-	barricade.icon = 'icons/obj/structures/barricades_christmas.dmi'
+	barricade.wire_icon = 'icons/obj/structures/barricades_christmas.dmi'
 	barricade.update_icon()
 
 


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->
Decorator changed the main icon of barricades. Not only this is bad due to the file not being up to date, but also wiring doesn't care and reuses the builtin icon file.

# Explain why it's good for the game
Event code not working

# Testing Photographs and Procedure
Spawn in, test


# Changelog
:cl:
fix: Fixed X-mas barricade wiring not applying properly.
/:cl:
