### PR TITLE
Camera console green-ness fix

### DIFF
--- a/code/game/machinery/computer/camera_console.dm
+++ b/code/game/machinery/computer/camera_console.dm
@@ -40,8 +40,6 @@
 		instance.del_on_map_removal = FALSE
 		if(instance.blend_mode_override)
 			instance.blend_mode = instance.blend_mode_override
-		if(istype(instance, /atom/movable/screen/plane_master/lighting))
-			instance.add_filter("awooga", 1, color_matrix_filter(color_matrix_from_string("#90ee90")))
 		instance.screen_loc = "[map_name]:CENTER"
 		cam_plane_masters += instance
 


### PR DESCRIPTION

# About the pull request

Fixes #5077.
This was caused by a green lighting filter which was accidentally included in #4940.

If someone wants to add it properly then another PR could be opened after this, or maybe this one could be treated as a sort of 'reverse PR' and closed in order to keep the overlay.

# Explain why it's good for the game

It's technically a bug rather than a feature at the moment.

# Testing Photographs and Procedure
<details>
<summary>Screenshots</summary>

**Before:**
![UneAhPrK3C](https://github.com/cmss13-devs/cmss13/assets/57483089/3eb7fe0e-d526-4f56-aba8-09bafca8ad9c)

**After:**
![GZ9ZBPx3n1](https://github.com/cmss13-devs/cmss13/assets/57483089/34ee98a9-05f5-473a-b158-2af44912586b)

</details>


# Changelog
:cl:
del: Removed the green overlay from camera consoles.
/:cl:
