### PR TITLE
Makes `xenoboldnotice` actually bold

### DIFF
--- a/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
@@ -1101,7 +1101,7 @@ em {
 
 .xenoboldnotice {
   color: #51a16c;
-  font-style: italic;
+  font-weight: bold;
 }
 
 .xenowarning {

--- a/tgui/packages/tgui-panel/styles/goon/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-light.scss
@@ -1133,7 +1133,7 @@ h2.alert {
 
 .xenoboldnotice {
   color: #2a623d;
-  font-style: italic;
+  font-weight: bold;
 }
 
 .xenowarning {


### PR DESCRIPTION

# About the pull request

Makes the `xenoboldnotice` span class actually bold, rather than italic.
Interestingly, it's correct on the 'old chat' stylesheet, so presumably it just got missed when TG-chat was added.
https://github.com/cmss13-devs/cmss13/blob/53f62c436dabcea7970fcfde1faaa1dcc37a4229/code/stylesheet.dm#L102

# Explain why it's good for the game

The class called 'xenoboldnotice' should be bold.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

**Before:**
![before](https://github.com/cmss13-devs/cmss13/assets/57483089/46fa54cc-1ee6-4046-ba86-2f75deadc7fe)

**After:**
![after](https://github.com/cmss13-devs/cmss13/assets/57483089/896a8119-fcec-4c9f-be11-86e7cd95ac44)

<hr>

**Current 'old chat' version, for reference:**
![old](https://github.com/cmss13-devs/cmss13/assets/57483089/d14538d4-7abf-4b20-8b83-076863248cfc)

</details>


# Changelog
:cl:
spellcheck: Made the `xenoboldnotice` span class bold rather than italic.
/:cl:
