### PR TITLE
Fix queen death not readmitting banished xenos fully

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
@@ -792,12 +792,23 @@
 		return TRUE
 
 /mob/living/carbon/xenomorph/queen/death(cause, gibbed)
-	if(hive.living_xeno_queen == src)
+	if(src == hive?.living_xeno_queen)
 		hive.xeno_queen_timer = world.time + XENO_QUEEN_DEATH_DELAY
-		hive.banished_ckeys   = list() // Reset the banished ckey list
+
+		// Reset the banished ckey list
+		if(length(hive.banished_ckeys))
+			for(var/mob/living/carbon/xenomorph/target_xeno in hive.totalXenos)
+				if(!target_xeno.ckey)
+					continue
+				for(var/mob_name in hive.banished_ckeys)
+					if(target_xeno.ckey == hive.banished_ckeys[mob_name])
+						target_xeno.banished = FALSE
+						target_xeno.hud_update_banished()
+						target_xeno.lock_evolve = FALSE
+			hive.banished_ckeys = list()
+
 	icon = queen_standing_icon
 	return ..()
-
 
 /mob/living/carbon/xenomorph/queen/proc/mount_ovipositor()
 	if(ovipositor)


### PR DESCRIPTION

# About the pull request

This PR fixes either an oversight, or a recent bug that I've not been able to find the source, of where the death of a queen resets the hive's banished keys list, but doesn't fully unbanish those xenos leaving them in a state that they can't be banished properly again nor readmitted.

# Explain why it's good for the game

A queen should retain her ability to banish and readmit all xenos freely and not be beholden to the will of some former queen.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![free](https://github.com/cmss13-devs/cmss13/assets/76988376/5817bf86-e7d1-4f05-a7ee-412cd0d7d25f)

</details>


# Changelog
:cl: Drathek
fix: Fix queen death not fully readmitting any banished xenos
/:cl:
