### PR TITLE
Fixes Yautja bracer lock

### DIFF
--- a/code/modules/cm_preds/yaut_bracers.dm
+++ b/code/modules/cm_preds/yaut_bracers.dm
@@ -1148,7 +1148,7 @@
 		return TRUE
 
 	var/mob/living/carbon/human/victim = held_mob.grabbed_thing
-	var/obj/item/clothing/gloves/yautja/hunter/bracer = victim.gloves
+	var/obj/item/clothing/gloves/yautja/bracer = victim.gloves
 	if(isspeciesyautja(victim) && !(victim.stat == DEAD))
 		to_chat(user, SPAN_WARNING("You cannot unlock the bracer of a living hunter!"))
 		return FALSE


### PR DESCRIPTION

# About the pull request
Preds can now unlock thrall bracers again. Whoops.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
I stoopid
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Yautja bracer lock can now properly unlock thrall bracers.
/:cl:
