### PR TITLE
Fixes carriers being unable to reduce their 'reserved facehuggers' number

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/carrier/carrier_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/carrier/carrier_powers.dm
@@ -10,6 +10,10 @@
 
 /datum/action/xeno_action/onclick/set_hugger_reserve/use_ability(atom/Atom)
 	var/mob/living/carbon/xenomorph/carrier/carrier = owner
-	carrier.huggers_reserved = tgui_input_number(usr, "How many facehuggers would you like to keep safe from Observers wanting to join as facehuggers?", "How many to reserve?", 0, carrier.huggers_max, carrier.huggers_reserved)
+	carrier.huggers_reserved = tgui_input_number(usr,
+		"How many facehuggers would you like to keep safe from Observers wanting to join as facehuggers?",
+		"How many to reserve?",
+		carrier.huggers_reserved, carrier.huggers_max, 0
+	)
 	to_chat(carrier, SPAN_XENONOTICE("We reserve [carrier.huggers_reserved] facehuggers for ourself."))
 	return ..()


### PR DESCRIPTION

# About the pull request

Fixes carriers being unable to reduce their 'reserved facehuggers' number.
This was caused by `carrier.huggers_reserved` being set as the *minimum* of the `tgui_input_number()`.

I've also changed the `default` argument from 0 to `carrier.huggers_reserved` so that you can see the current number before you change it.

# Explain why it's good for the game

Sometimes you might want to decrease the number.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Fixed carriers being unable to reduce their 'reserved facehuggers' number.
/:cl:
