### PR TITLE
Fix acid resisting

### DIFF
--- a/code/modules/mob/living/living_verbs.dm
+++ b/code/modules/mob/living/living_verbs.dm
@@ -173,7 +173,7 @@
 	if(mobility_flags & MOBILITY_MOVE)
 		if(on_fire)
 			resist_fire()
-		if(is_type_in_list(/datum/effects/acid, effects_list))
+		if(locate(/datum/effects/acid) in effects_list)
 			resist_acid()
 		if(last_special <= world.time)
 			resist_restraints()


### PR DESCRIPTION

# About the pull request

This PR is a follow up to #5253 which happened to alter how acid was detected, and it didn't do it correctly.

# Explain why it's good for the game

Resisting acid is intended.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![acid](https://github.com/cmss13-devs/cmss13/assets/76988376/553ed812-1858-4713-8a28-30725bea527e)

</details>


# Changelog
:cl: Drathek
fix: Fixed resisting acid
/:cl:
