### PR TITLE
Fix xeno wounds layering over weeded xenos

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/update_icons.dm
+++ b/code/modules/mob/living/carbon/xenomorph/update_icons.dm
@@ -308,7 +308,6 @@
 		return
 
 	var/health_threshold
-	wound_icon_holder.layer = layer + 0.01
 	health_threshold = max(CEILING((health * 4) / (maxHealth), 1), 0) //From 0 to 4, in 25% chunks
 	if(health > HEALTH_THRESHOLD_DEAD)
 		if(health_threshold > 3)
@@ -323,10 +322,9 @@
 		else
 			wound_icon_holder.icon_state = handle_special_wound_states(health_threshold)
 
-
 ///Used to display the xeno wounds/backpacks without rapidly switching overlays
 /atom/movable/vis_obj
-	vis_flags = VIS_INHERIT_ID|VIS_INHERIT_DIR
+	vis_flags = VIS_INHERIT_ID|VIS_INHERIT_DIR|VIS_INHERIT_LAYER|VIS_INHERIT_PLANE
 	appearance_flags = RESET_COLOR
 
 /atom/movable/vis_obj/xeno_wounds


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

This PR is a follow up to #5118 to fix the xeno wounds object appearing above their weeded appearance. It now synchronizes its plane and layer with the mob using vis_flags.

# Explain why it's good for the game

Fixes:
![image](https://github.com/cmss13-devs/cmss13/assets/76988376/186acf03-c686-4114-9d53-c82687e0129c)


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

![image](https://github.com/cmss13-devs/cmss13/assets/76988376/e5c4d69b-e9a3-429b-a2d5-e7a5915c5fee)

# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl: Drathek
fix: Fix xeno wounds layering over weeds when merged with the weeds
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
