### PR TITLE
Spitter ability bugfix

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/spitter/spitter_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/spitter/spitter_powers.dm
@@ -23,6 +23,7 @@
 	zenomorf.speed_modifier -= speed_buff_amount
 	zenomorf.armor_modifier += armor_buff_amount
 	zenomorf.recalculate_speed()
+	zenomorf.recalculate_armor()
 
 	/// Though the ability's other buffs are supposed to last for its duration, it's only supposed to enhance one spit.
 	RegisterSignal(zenomorf, COMSIG_XENO_POST_SPIT, PROC_REF(disable_spatter))
@@ -50,6 +51,7 @@
 	zenomorf.speed_modifier += speed_buff_amount
 	zenomorf.armor_modifier -= armor_buff_amount
 	zenomorf.recalculate_speed()
+	zenomorf.recalculate_armor()
 	to_chat(zenomorf, SPAN_XENOHIGHDANGER("We feel our movement speed slow down!"))
 	disable_spatter()
 	buffs_active = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Properly recalculates armor for when the ability is being used / deactivated


# Explain why it's good for the game

bugfix

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
it works
</details>


# Changelog

:cl:
fix: Spitter's charge spit abiltiy now properly adds and removes the 5 armor like its supposed to initially.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
