### PR TITLE
Fixes the Queen Eye being stuck as immature

### DIFF
--- a/code/__DEFINES/dcs/signals/atom/mob/signals_mob.dm
+++ b/code/__DEFINES/dcs/signals/atom/mob/signals_mob.dm
@@ -77,6 +77,9 @@
 ///from base of /mob/Logout(): ()
 #define COMSIG_MOB_LOGOUT "mob_logout"
 
+/// From /mob/proc/change_real_name(): (old_name, new_name)
+#define COMSIG_MOB_REAL_NAME_CHANGED "mob_real_name_changed"
+
 //from /mob/proc/on_deafness_gain()
 #define COMSIG_MOB_DEAFENED "mob_deafened"
 //from /mob/proc/on_deafness_loss()

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -73,6 +73,7 @@
 /mob/proc/change_real_name(mob/M, new_name)
 	if(!new_name)
 		return FALSE
+	var/old_name = M.real_name
 
 	M.real_name = new_name
 	M.name = new_name
@@ -83,6 +84,7 @@
 	// If we are humans, we need to update our voice as well
 	M.change_mob_voice(new_name)
 
+	SEND_SIGNAL(src, COMSIG_MOB_REAL_NAME_CHANGED, old_name, new_name)
 	return TRUE
 
 /mob/proc/change_mind_name(new_mind_name)

--- a/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
@@ -103,6 +103,7 @@
 		COMSIG_XENO_STOP_OVERWATCH,
 		COMSIG_XENO_STOP_OVERWATCH_XENO
 	), PROC_REF(stop_watching))
+	RegisterSignal(Q, COMSIG_MOB_REAL_NAME_CHANGED, PROC_REF(on_name_changed))
 	RegisterSignal(src, COMSIG_MOVABLE_TURF_ENTER, PROC_REF(turf_weed_only))
 
 	// Default color
@@ -157,6 +158,10 @@
 	is_watching = null
 	X.reset_view()
 	return
+
+/mob/hologram/queen/proc/on_name_changed(mob/parent, old_name, new_name)
+	SIGNAL_HANDLER
+	name = "[initial(src.name)] ([new_name])"
 
 /mob/hologram/queen/proc/turf_weed_only(mob/self, turf/crossing_turf)
 	SIGNAL_HANDLER


### PR DESCRIPTION

# About the pull request

Makes the 'Queen Eye' mob update its name when the Queen passes the 'Immature' stage, by adding a `COMSIG_MOB_REAL_NAME_CHANGED` signal.

This would be better if it was more similar to TG's `COMSIG_ATOM_UPDATE_NAME`, but from looking into that it would take a *big* refactor to implement `update_name()`/`update_appearance()`, so this'll probably do for the time being.

# Explain why it's good for the game

Fixes the queen eye being stuck as immature unless the queen toggles it on and off.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

**Before:**

https://github.com/cmss13-devs/cmss13/assets/57483089/329b8e92-29b3-4629-bd94-c0096bea6508

**After:**

https://github.com/cmss13-devs/cmss13/assets/57483089/49746267-03f5-4e62-aa5b-6f36927cc3e9

</details>


# Changelog
:cl:
fix: Fixed the Queen Eye still showing as "Immature" after the Queen ages.
/:cl:
