### PR TITLE
Adds a verb to hide action buttons

### DIFF
--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -11,9 +11,9 @@
 	var/cost = 0 // By default an action has no cost -> will be utilized by skill actions/xeno actions
 	var/action_flags = 0 // Check out __game.dm for flags
 	/// Whether the action is hidden from its owner
-	/// Useful for when you want to preserve action state while preventing
-	/// a mob from using said action
-	var/hidden = FALSE
+	var/hidden = FALSE //Preserve action state while preventing mob from using action
+	///Hide the action from the owner without preventing them from using it (incase of keybind listen_signal)
+	var/player_hidden = FALSE
 	var/unique = TRUE
 	/// A signal on the mob that will cause the action to activate
 	var/listen_signal
@@ -227,7 +227,7 @@
 			var/atom/movable/screen/action_button/B = A.button
 			if(reload_screen)
 				client.add_to_screen(B)
-			if(A.hidden)
+			if(A.hidden || A.player_hidden)
 				B.screen_loc = null
 				continue
 			button_number++

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -842,3 +842,34 @@ GLOBAL_LIST_INIT(whitelisted_client_procs, list(
 		total_t3_playtime += get_job_playtime(src, caste_name)
 
 	return total_t3_playtime
+
+/client/verb/action_hide_menu()
+	set name = "Show/Hide Actions"
+	set category = "IC"
+
+	if(!ismob(usr))
+		return
+	var/mob/user = usr
+
+	var/list/actions_list = list()
+	for(var/datum/action/action as anything in user.actions)
+		var/action_name = action.name
+		if(action.player_hidden)
+			action_name += " (Hidden)"
+		actions_list[action_name] += action
+
+	if(!LAZYLEN(actions_list))
+		to_chat(user, SPAN_WARNING("You have no actions available."))
+		return
+
+	var/selected_action_name = tgui_input_list(user, "Show or hide selected action", "Show/Hide Actions", actions_list, 30 SECONDS)
+	if(!selected_action_name)
+		to_chat(user, SPAN_WARNING("You did not select an action."))
+		return
+
+	var/datum/action/selected_action = actions_list[selected_action_name]
+	selected_action.player_hidden = !selected_action.player_hidden
+	user.update_action_buttons()
+
+	if(!selected_action.player_hidden && selected_action.hidden) //Inform the player that even if they are unhiding it, itll still not be visible
+		to_chat(user, SPAN_NOTICE("[selected_action] is forcefully hidden, bypassing player unhiding."))

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -847,8 +847,6 @@ GLOBAL_LIST_INIT(whitelisted_client_procs, list(
 	set name = "Show/Hide Actions"
 	set category = "IC"
 
-	if(!ismob(usr))
-		return
 	var/mob/user = usr
 
 	var/list/actions_list = list()

--- a/code/modules/mob/mob_verbs.dm
+++ b/code/modules/mob/mob_verbs.dm
@@ -245,34 +245,3 @@
 				//so we must undo it here so the victim can move right away
 				M.client.next_movement = world.time
 			M.update_transform(TRUE)
-
-/mob/verb/action_hide_menu()
-	set name = "Show/Hide Actions"
-	set category = "IC"
-
-	if(!ismob(usr))
-		return
-	var/mob/user = usr
-
-	var/list/actions_list = list()
-	for(var/datum/action/action as anything in user.actions)
-		var/action_name = action.name
-		if(action.player_hidden)
-			action_name += " (Hidden)"
-		actions_list[action_name] += action
-
-	if(!LAZYLEN(actions_list))
-		to_chat(user, SPAN_WARNING("You have no actions available."))
-		return
-
-	var/selected_action_name = tgui_input_list(user, "Show or hide selected action", "Show/Hide Actions", actions_list, 30 SECONDS)
-	if(!selected_action_name)
-		to_chat(user, SPAN_WARNING("You did not select an action."))
-		return
-
-	var/datum/action/selected_action = actions_list[selected_action_name]
-	selected_action.player_hidden = !selected_action.player_hidden
-	user.update_action_buttons()
-
-	if(!selected_action.player_hidden && selected_action.hidden) //Inform the player that even if they are unhiding it, itll still not be visible
-		to_chat(user, SPAN_NOTICE("[selected_action] is forcefully hidden, bypassing player unhiding."))

--- a/code/modules/mob/mob_verbs.dm
+++ b/code/modules/mob/mob_verbs.dm
@@ -245,3 +245,34 @@
 				//so we must undo it here so the victim can move right away
 				M.client.next_movement = world.time
 			M.update_transform(TRUE)
+
+/mob/verb/action_hide_menu()
+	set name = "Show/Hide Actions"
+	set category = "IC"
+
+	if(!ismob(usr))
+		return
+	var/mob/user = usr
+
+	var/list/actions_list = list()
+	for(var/datum/action/action as anything in user.actions)
+		var/action_name = action.name
+		if(action.player_hidden)
+			action_name += " (Hidden)"
+		actions_list[action_name] += action
+
+	if(!LAZYLEN(actions_list))
+		to_chat(user, SPAN_WARNING("You have no actions available."))
+		return
+
+	var/selected_action_name = tgui_input_list(user, "Show or hide selected action", "Show/Hide Actions", actions_list, 30 SECONDS)
+	if(!selected_action_name)
+		to_chat(user, SPAN_WARNING("You did not select an action."))
+		return
+
+	var/datum/action/selected_action = actions_list[selected_action_name]
+	selected_action.player_hidden = !selected_action.player_hidden
+	user.update_action_buttons()
+
+	if(!selected_action.player_hidden && selected_action.hidden) //Inform the player that even if they are unhiding it, itll still not be visible
+		to_chat(user, SPAN_NOTICE("[selected_action] is forcefully hidden, bypassing player unhiding."))


### PR DESCRIPTION
# About the pull request

Adds a verb on /client to show/hide action buttons
Makes it a new variable, as var/hidden also prevents the action from being used

![image](https://github.com/cmss13-devs/cmss13/assets/56142455/1d78441c-5085-4165-a2b7-f7c3e9f7e2c3)

# Changelog

:cl:
qol: Adds the ability to hide your action buttons
/:cl:
