### PR TITLE
north facing m56d shooting angle fix

### DIFF
--- a/code/modules/cm_marines/smartgun_mount.dm
+++ b/code/modules/cm_marines/smartgun_mount.dm
@@ -703,6 +703,9 @@
 	if((dir == NORTH) && (angle > 180) && (abs(360 - angle) > shoot_degree)) // If north and shooting to the left, we do some extra math
 		return
 
+	if((dir == NORTH) && (angle < 180) && (angle > shoot_degree))
+		return
+
 	else if((dir != NORTH) && (abs(angle - dir2angle(dir)) > shoot_degree))
 		return
 


### PR DESCRIPTION

# About the pull request

prevents m56d from shooting anywhere to the right when facing north

# Explain why it's good for the game

fix good


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: m56d can not longer shoot backwards when facing north
/:cl:
