### PR TITLE
Fixes a simple race condition in XRF Setup

### DIFF
--- a/code/modules/reagents/chemistry_machinery/reagent_analyzer.dm
+++ b/code/modules/reagents/chemistry_machinery/reagent_analyzer.dm
@@ -29,6 +29,9 @@
 			updateUsrDialog()
 			if(!do_after(user, 1 SECONDS, INTERRUPT_ALL, BUSY_ICON_GENERIC))
 				return
+			if(!sample)
+				to_chat(user, SPAN_WARNING("Someone else removed the sample. Make up your mind!"))
+				return
 			processing = TRUE
 			if(sample.reagents.total_volume < 30 || sample.reagents.reagent_list.len > 1)
 				icon_state = "reagent_analyzer_error"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

As seen on ~~TV~~ Live game

Someone can remove the vial during the do_after, bricking the machine as it runtimes and is stuck with processing = TRUE

# Changelog

:cl:
fix: Fixed XRF Scanner bricking if people were adding and removing vials at same time.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
