### PR TITLE
Adds a 'Time Since Death' counter to the status tab

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -1213,9 +1213,6 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 	. += ""
 
-	if(timeofdeath)
-		. += "Time Since Death: [duration2text_sec(world.time - timeofdeath)]"
-
 	if(SSticker.mode?.force_end_at)
 		var/time_left = SSticker.mode.force_end_at - world.time
 		if(time_left >= 0)
@@ -1234,6 +1231,10 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	if(client.prefs?.be_special & BE_ALIEN_AFTER_DEATH)
 		if(larva_queue_cached_message)
 			. += larva_queue_cached_message
+			. += ""
+
+	if(timeofdeath)
+		. += "Time Since Death: [duration2text_sec(world.time - timeofdeath)]"
 
 
 /proc/message_ghosts(message)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -1213,6 +1213,9 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 	. += ""
 
+	if(timeofdeath)
+		. += "Time Since Death: [duration2text_sec(world.time - timeofdeath)]"
+
 	if(SSticker.mode?.force_end_at)
 		var/time_left = SSticker.mode.force_end_at - world.time
 		if(time_left >= 0)


### PR DESCRIPTION
# About the pull request

Adds a 'Time Since Death' counter to the status tab, which shows in minutes and seconds how long it's been since the player died.
(The counter isn't shown to players who joined as observers, just ghosts.)

(also for the record I asked and this is fine in regards to the freeze: https://discord.com/channels/150315577943130112/745447048261795890/1189329387397578912)

# Explain why it's good for the game

Primarily, it would be very useful for tracking how long until it's possible to spawn as a lesser drone/facehugger without having to keep clicking the buttons to see the failure message.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

**Normal:**
![after normal](https://github.com/cmss13-devs/cmss13/assets/57483089/99b10552-a0a1-4288-a106-802cc52cd9e6)
<hr>

**With larva queue:**
![after with queue](https://github.com/cmss13-devs/cmss13/assets/57483089/a862c4f7-615f-4979-8d50-16c2551eb31d)
<hr>

**With hijack:**
![after with hijack](https://github.com/cmss13-devs/cmss13/assets/57483089/e7992cac-13a4-4202-a4ba-203653b0e468)
<hr>

**With both:**
![after](https://github.com/cmss13-devs/cmss13/assets/57483089/6cca3520-673d-4e7c-a718-edbc3ee02f9d)
<hr>

</details>


# Changelog
:cl:
qol: Added a 'Time Since Death' counter to the status tab for ghosts.
/:cl:
