### PR TITLE
Fixes immobilized mobs being able to buckle onto chairs

### DIFF
--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -278,6 +278,10 @@
 	if (iszombie(user))
 		return
 
+	// mobs that get knocked down should not be able to buckle themselves.
+	if(M == user && HAS_TRAIT(user, TRAIT_IMMOBILIZED))
+		return
+
 	if(density)
 		density = FALSE
 		if(!step(M, get_dir(M, src)) && loc != M.loc)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -278,7 +278,7 @@
 	if (iszombie(user))
 		return
 
-	// mobs that get knocked down should not be able to buckle themselves.
+	// mobs that become immobilized should not be able to buckle themselves.
 	if(M == user && HAS_TRAIT(user, TRAIT_IMMOBILIZED))
 		to_chat(user, SPAN_WARNING("You are unable to do this in your current state."))
 		return

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -280,6 +280,7 @@
 
 	// mobs that get knocked down should not be able to buckle themselves.
 	if(M == user && HAS_TRAIT(user, TRAIT_IMMOBILIZED))
+		to_chat(user, SPAN_WARNING("You are unable to do this in your current state."))
 		return
 
 	if(density)


### PR DESCRIPTION
# About the pull request

#5277, fixes the issue outlined here, incapacitated marines should not be able to buckle themselves.

# Explain why it's good for the game

bug bad

# Changelog

:cl:
fix: fixes immobilized mobs being able to buckle themselves
/:cl:

