### PR TITLE
Fixes runtime in stripping

### DIFF
--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -495,7 +495,8 @@
 	/// Multiplier for how quickly the user can strip things.
 	var/user_speed = user.get_skill_duration_multiplier(SKILL_CQC)
 	/// The total skill level of CQC & Police
-	var/target_skills = (target.skills.get_skill_level(SKILL_CQC) + target.skills.get_skill_level(SKILL_POLICE))
+	var/target_skills = 0
+	target_skills += (target.skills?.get_skill_level(SKILL_CQC) + target.skills?.get_skill_level(SKILL_POLICE))
 
 	/// Delay then gets + 0.5s per skill level, so long as not dead or cuffed.
 	if(!(target.stat || target.handcuffed))


### PR DESCRIPTION

# About the pull request

The dummy as an example doesn't have skills so we runtime when stripping them.

```
[2023-12-27 21:52:42.147] runtime error: Cannot execute null.get skill level().
 - proc name: get strip delay (/mob/living/carbon/human/proc/get_strip_delay)
 -   source file: code/modules/mob/living/carbon/human/inventory.dm,498
 -   usr: (src)
 -   src: Jack Samerus (/mob/living/carbon/human)
 -   src.loc: the floor (140,46,3) (/turf/open/floor/almayer)
 -   call stack:
 - Jack Samerus (/mob/living/carbon/human): get strip delay(Jack Samerus (/mob/living/carbon/human), Professor DUMMY the Medical Ma... (/mob/living/carbon/human))
 - Jack Samerus (/mob/living/carbon/human): stripPanelUnequip(Professor DUMMY tablet (/obj/item/device/professor_dummy_tablet), Professor DUMMY the Medical Ma... (/mob/living/carbon/human), "r_hand")
 - Professor DUMMY the Medical Ma... (/mob/living/carbon/human): Topic("src=\[0x3000232];item=r_hand", /list (/list))
 - **** (/client): Topic("src=\[0x3000232];item=r_hand", /list (/list), Professor DUMMY the Medical Ma... (/mob/living/carbon/human))
```

# Explain why it's good for the game
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Runtime in inventory.dm
/:cl:
