### PR TITLE
Fixes the failure message when trying to switch pyro fuels

### DIFF
--- a/code/game/objects/items/storage/large_holster.dm
+++ b/code/game/objects/items/storage/large_holster.dm
@@ -253,9 +253,12 @@
 		to_chat(user, SPAN_WARNING("[src] must be equipped before you can switch types."))
 		return
 
-	var/obj/item/weapon/gun/flamer/M240T/flamer = user.get_active_hand()
-	if(!istype(flamer))
-		to_chat(user, SPAN_WARNING("You must be holding [flamer] to use [src]."))
+	if(!linked_flamer)
+		to_chat(user, SPAN_WARNING("An incinerator unit must be linked in order to switch fuel types."))
+		return
+
+	if(user.get_active_hand() != linked_flamer)
+		to_chat(user, SPAN_WARNING("You must be holding [linked_flamer] to use [src]."))
 		return
 
 	if(!active_fuel)
@@ -276,8 +279,8 @@
 
 	to_chat(user, "You switch the fuel tank to <b>[active_fuel.caliber]</b>")
 	playsound(src, 'sound/machines/click.ogg', 25, TRUE)
-	flamer.current_mag = active_fuel
-	flamer.update_icon()
+	linked_flamer.current_mag = active_fuel
+	linked_flamer.update_icon()
 
 	return TRUE
 


### PR DESCRIPTION

# About the pull request

Edits the pyro spec's fuel pack a bit to make it *slightly* more bug-proof, and to fix it sometimes giving weird failure messages like these:
![image](https://github.com/cmss13-devs/cmss13/assets/57483089/2fa746d0-acc6-402b-ad17-e8fff5f4e3cd)
![image](https://github.com/cmss13-devs/cmss13/assets/57483089/67cef060-55a4-4897-9e52-f6d01e43d3d1)

This was caused by me in #5121, presumably because I misread how the check was handled.

# Explain why it's good for the game

I broked it (sorry)

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Fixed the pyro spec's fuel pack sometimes giving weird failure messages when trying to switch fuel.
/:cl:
