### PR TITLE
Fixes a couple of runtimes with xenos dying

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
@@ -512,7 +512,7 @@
 
 /datum/action/xeno_action/onclick/xenohide/proc/unhide_on_stat(mob/living/carbon/xenomorph/source, new_stat, old_stat)
 	SIGNAL_HANDLER
-	if(new_stat >= UNCONSCIOUS && old_stat <= UNCONSCIOUS)
+	if(!QDELETED(source) && (new_stat >= UNCONSCIOUS && old_stat <= UNCONSCIOUS))
 		post_attack()
 
 /datum/action/xeno_action/onclick/place_trap/use_ability(atom/A)


### PR DESCRIPTION

# About the pull request

Trying to call `post_attack()` on something which has already been qdeleted within gib()

```
[2023-12-27 22:10:14.636] runtime error: Cannot read null.comp_lookup
 - proc name: UnregisterSignal (/datum/proc/UnregisterSignal)
 -   source file: code/datums/components/_component.dm,219
 -   usr: null
 -   src: Hide (/datum/action/xeno_action/onclick/xenohide)
 -   call stack:
 - Hide (/datum/action/xeno_action/onclick/xenohide): UnregisterSignal(null, "mob_statchange")
 - Hide (/datum/action/xeno_action/onclick/xenohide): post attack()
 - Hide (/datum/action/xeno_action/onclick/xenohide): unhide on stat(Veteran Facehugger (896) (/mob/living/carbon/xenomorph/facehugger), 2, 0)
 - CallAsync(Hide (/datum/action/xeno_action/onclick/xenohide), "unhide_on_stat", /list (/list))
 - Veteran Facehugger (896) (/mob/living/carbon/xenomorph/facehugger):  SendSignal("mob_statchange", /list (/list))
 - Veteran Facehugger (896) (/mob/living/carbon/xenomorph/facehugger): set stat(2)
 - Veteran Facehugger (896) (/mob/living/carbon/xenomorph/facehugger): set stat(2)
 - Veteran Facehugger (896) (/mob/living/carbon/xenomorph/facehugger): set stat(2)
 - Veteran Facehugger (896) (/mob/living/carbon/xenomorph/facehugger): death(/datum/cause_data (/datum/cause_data), 1, "lets out a waning guttural scr...")
 - Veteran Facehugger (896) (/mob/living/carbon/xenomorph/facehugger): death(/datum/cause_data (/datum/cause_data), 1)
 - ...
 - Veteran Facehugger (896) (/mob/living/carbon/xenomorph/facehugger): updatehealth()
 - Veteran Facehugger (896) (/mob/living/carbon/xenomorph/facehugger): apply damage(36, "brute", "r_foot", null, 0, 0, 0)
 - Veteran Facehugger (896) (/mob/living/carbon/xenomorph/facehugger): bullet act(the rifle bullet (/obj/projectile))
 - the rifle bullet (/obj/projectile): handle mob(Veteran Facehugger (896) (/mob/living/carbon/xenomorph/facehugger))
 - the rifle bullet (/obj/projectile): scan a turf(the catwalk (20,151,2) (/turf/open/floor/plating/plating_catwalk/shiva), 8)
 - the rifle bullet (/obj/projectile): process(1.19104)
 - Projectiles (/datum/controller/subsystem/projectiles): handle projectile flight(the rifle bullet (/obj/projectile), 5)
 - Projectiles (/datum/controller/subsystem/projectiles): ignite(0)
 - Master (/datum/controller/master): Loop(2)
 - Master (/datum/controller/master): StartProcessing(0)
 - 
[2023-12-27 22:10:14.636] runtime error: Cannot read null.layer
 - proc name: post attack (/datum/action/xeno_action/onclick/xenohide/proc/post_attack)
 -   source file: code/modules/mob/living/carbon/xenomorph/abilities/general_abilities.dm,398
 -   usr: null
 -   src: Hide (/datum/action/xeno_action/onclick/xenohide)
 -   call stack:
 - Hide (/datum/action/xeno_action/onclick/xenohide): post attack()
 - Hide (/datum/action/xeno_action/onclick/xenohide): unhide on stat(Veteran Facehugger (896) (/mob/living/carbon/xenomorph/facehugger), 2, 0)
 - CallAsync(Hide (/datum/action/xeno_action/onclick/xenohide), "unhide_on_stat", /list (/list))
 - Veteran Facehugger (896) (/mob/living/carbon/xenomorph/facehugger):  SendSignal("mob_statchange", /list (/list))
 - Veteran Facehugger (896) (/mob/living/carbon/xenomorph/facehugger): set stat(2)
 - Veteran Facehugger (896) (/mob/living/carbon/xenomorph/facehugger): set stat(2)
 - Veteran Facehugger (896) (/mob/living/carbon/xenomorph/facehugger): set stat(2)
 - Veteran Facehugger (896) (/mob/living/carbon/xenomorph/facehugger): death(/datum/cause_data (/datum/cause_data), 1, "lets out a waning guttural scr...")
 - Veteran Facehugger (896) (/mob/living/carbon/xenomorph/facehugger): death(/datum/cause_data (/datum/cause_data), 1)
 - Veteran Facehugger (896) (/mob/living/carbon/xenomorph/facehugger): gib(/datum/cause_data (/datum/cause_data))
 - ...
 - Veteran Facehugger (896) (/mob/living/carbon/xenomorph/facehugger): apply damage(36, "brute", "r_foot", null, 0, 0, 0)
 - Veteran Facehugger (896) (/mob/living/carbon/xenomorph/facehugger): bullet act(the rifle bullet (/obj/projectile))
 - the rifle bullet (/obj/projectile): handle mob(Veteran Facehugger (896) (/mob/living/carbon/xenomorph/facehugger))
 - the rifle bullet (/obj/projectile): scan a turf(the catwalk (20,151,2) (/turf/open/floor/plating/plating_catwalk/shiva), 8)
 - the rifle bullet (/obj/projectile): fly()
 - Projectiles (/datum/controller/subsystem/projectiles): process wrapper(the rifle bullet (/obj/projectile), 5)
 - Projectiles (/datum/controller/subsystem/projectiles): fire(0)
 - Master (/datum/controller/master): RunQueue()
 - Master (/datum/controller/master): StartProcessing(0)
 - 
```

# Explain why it's good for the game
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Fixes runtime calling post_attack() on a mob which has already been qdeleted via gibbing.
/:cl:
