### PR TITLE
Fixes fire alarm closing shutters for adjacent area doors

### DIFF
--- a/code/game/machinery/computer/demo_sim.dm
+++ b/code/game/machinery/computer/demo_sim.dm
@@ -55,7 +55,6 @@
 	var/list/data = list()
 
 	data["configuration"] = configuration
-	data["looking"] = simulation.looking_at_simulation
 	data["dummy_mode"] = simulation.dummy_mode
 
 	data["worldtime"] = world.time
@@ -104,8 +103,7 @@
 /obj/structure/machinery/computer/demo_sim/ui_close(mob/user)
 
 	. = ..()
-	if(simulation.looking_at_simulation)
-		simulation.stop_watching(user)
+	simulation.stop_watching(user)
 
 // DEMOLITIONS TGUI SHIT END \\
 

--- a/code/game/machinery/computer/demo_sim.dm
+++ b/code/game/machinery/computer/demo_sim.dm
@@ -59,7 +59,7 @@
 
 	data["worldtime"] = world.time
 	data["nextdetonationtime"] = simulation.detonation_cooldown
-	data["detonation_cooldown"] = simulation.detonation_cooldown_time
+	data["detonation_cooldown"] = DETONATION_COOLDOWN_TIME
 
 	return data
 

--- a/code/game/machinery/computer/demo_sim.dm
+++ b/code/game/machinery/computer/demo_sim.dm
@@ -59,7 +59,7 @@
 
 	data["worldtime"] = world.time
 	data["nextdetonationtime"] = simulation.detonation_cooldown
-	data["detonation_cooldown"] = DETONATION_COOLDOWN_TIME
+	data["detonation_cooldown"] = simulation.detonation_cooldown_time
 
 	return data
 

--- a/code/game/machinery/computer/dropship_weapons.dm
+++ b/code/game/machinery/computer/dropship_weapons.dm
@@ -152,8 +152,7 @@
 /obj/structure/machinery/computer/dropship_weapons/ui_close(mob/user)
 	. = ..()
 	SEND_SIGNAL(src, COMSIG_CAMERA_UNREGISTER_UI, user)
-	if(simulation.looking_at_simulation)
-		simulation.stop_watching(user)
+	simulation.stop_watching(user)
 
 /obj/structure/machinery/computer/dropship_weapons/ui_status(mob/user, datum/ui_state/state)
 	. = ..()
@@ -239,7 +238,6 @@
 		.["firemission_selected_laser"] = firemission_envelope.recorded_loc ? firemission_envelope.recorded_loc.get_name() : "NOT SELECTED"
 
 	.["configuration"] = configuration
-	.["looking"] = simulation.looking_at_simulation
 	.["dummy_mode"] = simulation.dummy_mode
 	.["worldtime"] = world.time
 	.["nextdetonationtime"] = simulation.detonation_cooldown

--- a/code/game/machinery/computer/dropship_weapons.dm
+++ b/code/game/machinery/computer/dropship_weapons.dm
@@ -241,7 +241,7 @@
 	.["dummy_mode"] = simulation.dummy_mode
 	.["worldtime"] = world.time
 	.["nextdetonationtime"] = simulation.detonation_cooldown
-	.["detonation_cooldown"] = simulation.detonation_cooldown_time
+	.["detonation_cooldown"] = DETONATION_COOLDOWN_TIME
 
 /obj/structure/machinery/computer/dropship_weapons/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
 	. = ..()

--- a/code/game/machinery/computer/dropship_weapons.dm
+++ b/code/game/machinery/computer/dropship_weapons.dm
@@ -241,7 +241,7 @@
 	.["dummy_mode"] = simulation.dummy_mode
 	.["worldtime"] = world.time
 	.["nextdetonationtime"] = simulation.detonation_cooldown
-	.["detonation_cooldown"] = DETONATION_COOLDOWN_TIME
+	.["detonation_cooldown"] = simulation.detonation_cooldown_time
 
 /obj/structure/machinery/computer/dropship_weapons/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
 	. = ..()

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -54,11 +54,11 @@
 	A.all_doors.Add(src)
 	areas_added = list(A)
 
-	for(var/direction in GLOB.cardinals)
-		A = get_area(get_step(src,direction))
-		if(istype(A) && !(A in areas_added))
-			A.all_doors.Add(src)
-			areas_added += A
+	// for(var/direction in GLOB.cardinals)  // why are even adding adjacent doors?!
+	// 	A = get_area(get_step(src,direction))
+	// 	if(istype(A) && !(A in areas_added))
+	// 		A.all_doors.Add(src)
+	// 		areas_added += A
 
 /obj/structure/machinery/door/firedoor/Destroy()
 	for(var/area/A in areas_added)

--- a/code/game/sim_manager/datums/simulator.dm
+++ b/code/game/sim_manager/datums/simulator.dm
@@ -107,4 +107,3 @@
 	addtimer(CALLBACK(src, PROC_REF(sim_turf_garbage_collection)), 30 SECONDS, TIMER_STOPPABLE)
 
 #undef GRID_CLEARING_SIZE
-#undef DETONATION_COOLDOWN_TIME

--- a/code/game/sim_manager/datums/simulator.dm
+++ b/code/game/sim_manager/datums/simulator.dm
@@ -1,10 +1,10 @@
 #define GRID_CLEARING_SIZE 16
-#define DETONATION_COOLDOWN_TIME 2 MINUTES
 
 /datum/simulator
 
 	// Necessary to prevent multiple users from simulating at the same time.
 	var/static/detonation_cooldown = 0
+	var/static/detonation_cooldown_time = 2 MINUTES
 	var/static/sim_reboot_state = TRUE
 
 	var/dummy_mode = CLF_MODE

--- a/code/game/sim_manager/datums/simulator.dm
+++ b/code/game/sim_manager/datums/simulator.dm
@@ -1,17 +1,20 @@
+#define GRID_CLEARING_SIZE 16
+#define DETONATION_COOLDOWN_TIME 2 MINUTES
+
 /datum/simulator
 
 	// Necessary to prevent multiple users from simulating at the same time.
 	var/static/detonation_cooldown = 0
 	var/static/sim_reboot_state = TRUE
 
-	var/looking_at_simulation = FALSE
-	var/detonation_cooldown_time = 2 MINUTES
 	var/dummy_mode = CLF_MODE
 	var/obj/structure/machinery/camera/simulation/sim_camera
-	var/grid_clearing_size = 16
 
 	// garbage collection,
 	var/static/list/delete_targets = list()
+
+	// list of users currently inside the simulator
+	var/static/list/users_in_sim = list()
 
 	/*
 	unarmoured humans are unnencessary clutter as they tend to explode easily
@@ -29,7 +32,7 @@
 
 /datum/simulator/proc/start_watching(mob/living/user)
 
-	if(looking_at_simulation)
+	if(user in users_in_sim)
 		to_chat(user, SPAN_WARNING("You are already looking at the simulation."))
 		return
 	if(!sim_camera)
@@ -41,13 +44,15 @@
 		to_chat(user, SPAN_WARNING("You're too busy looking at something else."))
 		return
 	user.reset_view(sim_camera)
-	looking_at_simulation = TRUE
+	users_in_sim += user
 
 /datum/simulator/proc/stop_watching(mob/living/user)
+	if(!(user in users_in_sim))
+		return
 	user.unset_interaction()
 	user.reset_view(null)
 	user.cameraFollow = null
-	looking_at_simulation = FALSE
+	users_in_sim -= user
 
 /datum/simulator/proc/sim_turf_garbage_collection()
 
@@ -67,8 +72,8 @@
 	y:2 | x: 1 2 3 4 ... 16
 	y:1 | x: 1 2 3 4 ... 16
 	*/
-	for (var/y_pos in 1 to grid_clearing_size)// outer y
-		for (var/x_pos in 1 to grid_clearing_size) // inner x
+	for (var/y_pos in 1 to GRID_CLEARING_SIZE)// outer y
+		for (var/x_pos in 1 to GRID_CLEARING_SIZE) // inner x
 			var/turf/current_grid = locate(sim_grid_start_pos.x + x_pos,sim_grid_start_pos.y + y_pos,sim_grid_start_pos.z)
 
 			current_grid.empty(/turf/open/floor/engine)
@@ -79,7 +84,7 @@
 		to_chat(user, SPAN_WARNING("GPU damaged! Unable to start simulation."))
 		return
 
-	COOLDOWN_START(src, detonation_cooldown, detonation_cooldown_time)
+	COOLDOWN_START(src, detonation_cooldown, DETONATION_COOLDOWN_TIME)
 
 	var/spawn_path = target_types[dummy_mode]
 	for(var/spawn_loc in GLOB.simulator_targets)
@@ -101,3 +106,5 @@
 
 	addtimer(CALLBACK(src, PROC_REF(sim_turf_garbage_collection)), 30 SECONDS, TIMER_STOPPABLE)
 
+#undef GRID_CLEARING_SIZE
+#undef DETONATION_COOLDOWN_TIME

--- a/code/game/sim_manager/datums/simulator.dm
+++ b/code/game/sim_manager/datums/simulator.dm
@@ -84,7 +84,7 @@
 		to_chat(user, SPAN_WARNING("GPU damaged! Unable to start simulation."))
 		return
 
-	COOLDOWN_START(src, detonation_cooldown, DETONATION_COOLDOWN_TIME)
+	COOLDOWN_START(src, detonation_cooldown, detonation_cooldown_time)
 
 	var/spawn_path = target_types[dummy_mode]
 	for(var/spawn_loc in GLOB.simulator_targets)

--- a/html/changelogs/AutoChangeLog-pr-5299.yml
+++ b/html/changelogs/AutoChangeLog-pr-5299.yml
@@ -1,0 +1,4 @@
+author: "SabreML"
+delete-after: True
+changes:
+  - bugfix: "Fixed the Queen Eye still showing as \"Immature\" after the Queen ages."

--- a/tgui/packages/tgui/interfaces/CasSim.tsx
+++ b/tgui/packages/tgui/interfaces/CasSim.tsx
@@ -1,4 +1,4 @@
-import { useBackend } from '../backend';
+import { useBackend, useLocalState } from '../backend';
 import { Box, Button, Section, ProgressBar, NoticeBox, Stack } from '../components';
 
 interface CasSimData {
@@ -12,6 +12,11 @@ interface CasSimData {
 
 export const CasSim = (_props, context) => {
   const { act, data } = useBackend<CasSimData>(context);
+  const [simulationView, setSimulationView] = useLocalState(
+    context,
+    'simulation_view',
+    false
+  );
 
   const timeLeft = data.nextdetonationtime - data.worldtime;
   const timeLeftPct = timeLeft / data.detonation_cooldown;
@@ -48,13 +53,16 @@ export const CasSim = (_props, context) => {
       <Section title="Cas Simulation Controls">
         <Stack>
           <Stack.Item grow>
-            {(!data.looking && (
+            {(!simulationView && (
               <Button
                 fluid={1}
                 icon="eye"
                 color="good"
                 content="Enter simulation"
-                onClick={() => act('start_watching')}
+                onClick={() => {
+                  act('start_watching');
+                  setSimulationView(true);
+                }}
               />
             )) || (
               <Button
@@ -62,7 +70,10 @@ export const CasSim = (_props, context) => {
                 icon="eye-slash"
                 color="good"
                 content="Exit simulation"
-                onClick={() => act('stop_watching')}
+                onClick={() => {
+                  act('stop_watching');
+                  setSimulationView(false);
+                }}
               />
             )}
           </Stack.Item>

--- a/tgui/packages/tgui/interfaces/DemoSim.js
+++ b/tgui/packages/tgui/interfaces/DemoSim.js
@@ -1,9 +1,14 @@
-import { useBackend } from '../backend';
+import { useBackend, useLocalState } from '../backend';
 import { Button, Section, ProgressBar, NoticeBox, Box, Stack } from '../components';
 import { Window } from '../layouts';
 
 export const DemoSim = (_props, context) => {
   const { act, data } = useBackend(context);
+  const [simulationView, setSimulationView] = useLocalState(
+    context,
+    'simulation_view',
+    false
+  );
 
   const timeLeft = data.nextdetonationtime - data.worldtime;
   const timeLeftPct = timeLeft / data.detonation_cooldown;
@@ -45,14 +50,17 @@ export const DemoSim = (_props, context) => {
         <Section title="Detonation controls">
           <Stack>
             <Stack.Item grow>
-              {(!data.looking && (
+              {(!simulationView && (
                 <Button
                   fontSize="16px"
                   fluid={1}
                   icon="eye"
                   color="good"
                   content="Enter simulation"
-                  onClick={() => act('start_watching')}
+                  onClick={() => {
+                    act('start_watching');
+                    setSimulationView(true);
+                  }}
                 />
               )) || (
                 <Button
@@ -61,7 +69,10 @@ export const DemoSim = (_props, context) => {
                   icon="eye-slash"
                   color="good"
                   content="Exit simulation"
-                  onClick={() => act('stop_watching')}
+                  onClick={() => {
+                    act('stop_watching');
+                    setSimulationView(false);
+                  }}
                 />
               )}
             </Stack.Item>


### PR DESCRIPTION
# About the pull request

This looks intentional.... is it even a bug? #4880.

# Explain why it's good for the game

having all adjacent shutters close in a given area just looks a bit silly. 

<img width="994" alt="Screen Shot 2023-12-27 at 6 57 42 PM" src="https://github.com/cmss13-devs/cmss13/assets/122310258/17aa2776-bbb1-47c4-b0f6-5e3ad6b60637">

# Changelog

:cl:
fix: fixes adjacent shutters closing after a fire alarm is pulled.
/:cl:
