### PR TITLE
Fixes milk runtime in on_mob_life() (and maybe other reagents)

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -152,6 +152,9 @@ GLOBAL_LIST_INIT(name2reagent, build_name2reagent())
 	handle_processing(M, mods, delta_time)
 	holder.remove_reagent(id, custom_metabolism * delta_time)
 
+	if(!holder)
+		return FALSE
+
 	return TRUE
 
 //Pre-processing

--- a/code/modules/reagents/chemistry_reagents/drink.dm
+++ b/code/modules/reagents/chemistry_reagents/drink.dm
@@ -163,8 +163,10 @@
 
 /datum/reagent/drink/milk/on_mob_life(mob/living/M)
 	. = ..()
-	if(!.) return
-	if(M.getBruteLoss() && prob(20)) M.heal_limb_damage(1,0)
+	if(!.)
+		return
+	if(M.getBruteLoss() && prob(20))
+		M.heal_limb_damage(1,0)
 	holder.remove_reagent("capsaicin", 10*REAGENTS_METABOLISM)
 	holder.remove_reagent("hotsauce", 10*REAGENTS_METABOLISM)
 


### PR DESCRIPTION

# About the pull request

Seen this runtime a couple of times now with milk specifically. But this situation I believe could also occur in other `reagent/on_mob_life()`

`holder` being null can occur if we qdel the reagent during `remove_reagent()` and we then try to call procs on the now null holder further down the thread of `on_mob_life()`. We now check again if `!holder` after calling `remove_reagent()` at 
`/datum/reagent` level which will cause us to return early in `on_mob_life()` which should call parent when implemented and not operate on a null `holder`
```
[2023-12-28 17:57:27.386] runtime error: Cannot execute null.remove reagent().
 - proc name: on mob life (/datum/reagent/drink/milk/on_mob_life)
 -   source file: code/modules/reagents/chemistry_reagents/drink.dm,168
 -   usr: null
 -   src: Milk (/datum/reagent/drink/milk)
 -   call stack:
 - Milk (/datum/reagent/drink/milk): on mob life(Gilles Liebreich (/mob/living/carbon/human), 0, 2)
 - /datum/reagents (/datum/reagents): metabolize(Gilles Liebreich (/mob/living/carbon/human), 0, 2)
 - Gilles Liebreich (/mob/living/carbon/human): handle chemicals in body(2)
 - Gilles Liebreich (/mob/living/carbon/human): Life(2)
 - Human Life (/datum/controller/subsystem/human): fire(0)
 - Human Life (/datum/controller/subsystem/human): ignite(0)
 - Master (/datum/controller/master): RunQueue()
 - Master (/datum/controller/master): Loop(2)
 - Master (/datum/controller/master): StartProcessing(0)
 - 

```
# Explain why it's good for the game
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Runtime with milk and possibly other reagent's on_mob_life()
/:cl:
