### PR TITLE
Fixes runtime on death by decapitation

### DIFF
--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -954,7 +954,13 @@ This function completely restores a damaged organ to perfect condition.
 		// OK so maybe your limb just flew off, but if it was attached to a pair of cuffs then hooray! Freedom!
 		release_restraints()
 
-		if(vital) owner.death(cause)
+		if(vital)
+			var/mob/caused_mob
+			if(istype(cause, /mob))
+				caused_mob = cause
+			if(!istype(cause, /datum/cause_data))
+				cause = create_cause_data("lost vital limb", caused_mob)
+			owner.death(cause)
 
 /*
 			HELPERS


### PR DESCRIPTION
# About the pull request

Fixes two runtimes caused by passing an invalid argument type to `death()` it should be `/datum/cause_data` and we passed a `/mob`.

Player decapitated themselves by shooting themselves in the head.

The extra typechecks are there because I don't want to assume that `cause` is always going to be a `mob`. If it's not a `mob` or `cause_data` already then we create a cause data with mob = null so at least we're passing it correctly to `death()`

```
[2023-12-28 17:54:11.462] runtime error: death called with string cause (Unknown (as Sherri Baker)) instead of datum
 - proc name: stack trace (/proc/stack_trace)
 -   source file: code/__HELPERS/unsorted.dm,1888
 -   usr: Unknown (as Sherri Baker) (/mob/living/carbon/human)
 -   src: null
 -   usr.loc: the floor (288,32,4) (/turf/open/floor/almayer)
 -   call stack:
 - stack trace("death called with string cause...")
 - Unknown (as Sherri Baker) (/mob/living/carbon/human): death(Unknown (as Sherri Baker) (/mob/living/carbon/human), 0, "seizes up and falls limp, thei...")
 - Unknown (as Sherri Baker) (/mob/living/carbon/human): death(Unknown (as Sherri Baker) (/mob/living/carbon/human), null)
 - the head (/obj/limb/head): droplimb(0, 0, Unknown (as Sherri Baker) (/mob/living/carbon/human), null)
 - the head (/obj/limb/head): limb delimb(Unknown (as Sherri Baker) (/mob/living/carbon/human))
 - the head (/obj/limb/head): take damage(44, 0, 0, 0, null, /list (/list), 0, Unknown (as Sherri Baker) (/mob/living/carbon/human), -1, 0, 0)
 - the head (/obj/limb/head): take damage(44, 0, 0, 0, null, /list (/list), 0, Unknown (as Sherri Baker) (/mob/living/carbon/human), -1, -1)
 - Unknown (as Sherri Baker) (/mob/living/carbon/human): apply damage(44, "brute", "head", 0, 0, null, 0, 0, Unknown (as Sherri Baker) (/mob/living/carbon/human), 0)
 - Unknown (as Sherri Baker) (/mob/living/carbon/human): bullet act(the rifle bullet (/obj/projectile))
 - the M41A pulse rifle MK2 (Wiel... (/obj/item/weapon/gun/rifle/m41a): attack(Unknown (as Sherri Baker) (/mob/living/carbon/human), Unknown (as Sherri Baker) (/mob/living/carbon/human), null)
 - Unknown (as Sherri Baker) (/mob/living/carbon/human): attackby(the M41A pulse rifle MK2 (Wiel... (/obj/item/weapon/gun/rifle/m41a), Unknown (as Sherri Baker) (/mob/living/carbon/human), /list (/list))
 - Unknown (as Sherri Baker) (/mob/living/carbon/human): attackby(the M41A pulse rifle MK2 (Wiel... (/obj/item/weapon/gun/rifle/m41a), Unknown (as Sherri Baker) (/mob/living/carbon/human), /list (/list))
 - Unknown (as Sherri Baker) (/mob/living/carbon/human): click adjacent(Unknown (as Sherri Baker) (/mob/living/carbon/human), the M41A pulse rifle MK2 (Wiel... (/obj/item/weapon/gun/rifle/m41a), /list (/list))
 - Unknown (as Sherri Baker) (/mob/living/carbon/human): do click(Unknown (as Sherri Baker) (/mob/living/carbon/human), the floor (288,32,4) (/turf/open/floor/almayer), "icon-x=17;icon-y=19;left=1;but...")
 - **** (/client): Click(Unknown (as Sherri Baker) (/mob/living/carbon/human), the floor (288,32,4) (/turf/open/floor/almayer), "mapwindow.map", "icon-x=17;icon-y=19;left=1;but...")
 - 
[2023-12-28 17:54:11.465] runtime error: undefined variable /mob/living/carbon/human/var/cause_name
 - proc name: death (/mob/living/carbon/human/death)
 -   source file: code/modules/mob/living/carbon/human/death.dm,117
 -   usr: (src)
 -   src: Unknown (as Sherri Baker) (/mob/living/carbon/human)
 -   src.loc: the floor (288,32,4) (/turf/open/floor/almayer)
 -   call stack:
 - Unknown (as Sherri Baker) (/mob/living/carbon/human): death(Unknown (as Sherri Baker) (/mob/living/carbon/human), null)
 - the head (/obj/limb/head): droplimb(0, 0, Unknown (as Sherri Baker) (/mob/living/carbon/human), null)
 - the head (/obj/limb/head): limb delimb(Unknown (as Sherri Baker) (/mob/living/carbon/human))
 - the head (/obj/limb/head): take damage(44, 0, 0, 0, null, /list (/list), 0, Unknown (as Sherri Baker) (/mob/living/carbon/human), -1, 0, 0)
 - the head (/obj/limb/head): take damage(44, 0, 0, 0, null, /list (/list), 0, Unknown (as Sherri Baker) (/mob/living/carbon/human), -1, -1)
 - Unknown (as Sherri Baker) (/mob/living/carbon/human): apply damage(44, "brute", "head", 0, 0, null, 0, 0, Unknown (as Sherri Baker) (/mob/living/carbon/human), 0)
 - Unknown (as Sherri Baker) (/mob/living/carbon/human): bullet act(the rifle bullet (/obj/projectile))
 - the M41A pulse rifle MK2 (/obj/item/weapon/gun/rifle/m41a): attack(Unknown (as Sherri Baker) (/mob/living/carbon/human), Unknown (as Sherri Baker) (/mob/living/carbon/human), null)
 - Unknown (as Sherri Baker) (/mob/living/carbon/human): attackby(the M41A pulse rifle MK2 (/obj/item/weapon/gun/rifle/m41a), Unknown (as Sherri Baker) (/mob/living/carbon/human), /list (/list))
 - Unknown (as Sherri Baker) (/mob/living/carbon/human): attackby(the M41A pulse rifle MK2 (/obj/item/weapon/gun/rifle/m41a), Unknown (as Sherri Baker) (/mob/living/carbon/human), /list (/list))
 - Unknown (as Sherri Baker) (/mob/living/carbon/human): click adjacent(Unknown (as Sherri Baker) (/mob/living/carbon/human), the M41A pulse rifle MK2 (/obj/item/weapon/gun/rifle/m41a), /list (/list))
 - Unknown (as Sherri Baker) (/mob/living/carbon/human): do click(Unknown (as Sherri Baker) (/mob/living/carbon/human), the floor (288,32,4) (/turf/open/floor/almayer), "icon-x=17;icon-y=19;left=1;but...")
 - **** (/client): Click(Unknown (as Sherri Baker) (/mob/living/carbon/human), the floor (288,32,4) (/turf/open/floor/almayer), "mapwindow.map", "icon-x=17;icon-y=19;left=1;but...")
 - 

```
# Explain why it's good for the game
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Fixes a runtime on decapping one's self.
/:cl:
