### PR TITLE
Port Overlay Lighting Fixes

### DIFF
--- a/code/datums/components/overlay_lighting.dm
+++ b/code/datums/components/overlay_lighting.dm
@@ -194,7 +194,7 @@
 	get_new_turfs()
 
 
-///Adds the luminosity and source for the afected movable atoms to keep track of their visibility.
+///Adds the luminosity and source for the affected movable atoms to keep track of their visibility.
 /datum/component/overlay_lighting/proc/add_dynamic_lumi()
 	LAZYSET(current_holder.affected_movable_lights, src, lumcount_range + 1)
 	current_holder.underlays += visible_mask
@@ -202,7 +202,7 @@
 	if(directional)
 		current_holder.underlays += cone
 
-///Removes the luminosity and source for the afected movable atoms to keep track of their visibility.
+///Removes the luminosity and source for the affected movable atoms to keep track of their visibility.
 /datum/component/overlay_lighting/proc/remove_dynamic_lumi()
 	LAZYREMOVE(current_holder.affected_movable_lights, src)
 	current_holder.underlays -= visible_mask
@@ -262,6 +262,9 @@
 ///Used to determine the new valid current_holder from the parent's loc.
 /datum/component/overlay_lighting/proc/check_holder()
 	var/atom/movable/movable_parent = GET_PARENT
+	if(QDELETED(movable_parent))
+		set_holder(null)
+		return
 	if(isturf(movable_parent.loc))
 		set_holder(movable_parent)
 		return
@@ -270,13 +273,21 @@
 		set_holder(null)
 		return
 	if(isturf(inside.loc))
-		set_holder(inside)
+		// storage items block light, also don't be moving into a qdeleted item
+		if(QDELETED(inside) || istype(inside, /obj/item/storage))
+			set_holder(null)
+		else
+			set_holder(inside)
 		return
 	set_holder(null)
 
 
 ///Called when the current_holder is qdeleted, to remove the light effect.
 /datum/component/overlay_lighting/proc/on_holder_qdel(atom/movable/source, force)
+	SIGNAL_HANDLER
+	if(QDELETED(current_holder))
+		set_holder(null)
+		return
 	UnregisterSignal(current_holder, list(COMSIG_PARENT_QDELETING, COMSIG_MOVABLE_MOVED))
 	if(directional)
 		UnregisterSignal(current_holder, COMSIG_ATOM_DIR_CHANGE)
@@ -285,6 +296,7 @@
 
 ///Called when current_holder changes loc.
 /datum/component/overlay_lighting/proc/on_holder_moved(atom/movable/source, OldLoc, Dir, Forced)
+	SIGNAL_HANDLER
 	if(!(overlay_lighting_flags & LIGHTING_ON))
 		return
 	make_luminosity_update()
@@ -443,8 +455,7 @@
 	. = lum_power
 	lum_power = new_lum_power
 	var/difference = . - lum_power
-	for(var/t in affected_turfs)
-		var/turf/lit_turf = t
+	for(var/turf/lit_turf as anything in affected_turfs)
 		lit_turf.dynamic_lumcount -= difference
 
 ///Here we append the behavior associated to changing lum_power.


### PR DESCRIPTION
# About the pull request

This PR ports https://github.com/tgstation/tgstation/pull/79939 and fixes a few other things in the overlay_lighting component.

# Explain why it's good for the game

Less hard deletes and lights in objects disables the light (despite actually still being on).

Fixes: 

https://github.com/cmss13-devs/cmss13/assets/76988376/4a89b0de-ccb2-4d80-a081-2ec2d311f753

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![flares](https://github.com/cmss13-devs/cmss13/assets/76988376/12765f93-78e9-42f3-90f9-5118ad62af65)

https://github.com/cmss13-devs/cmss13/assets/76988376/cb7b2d6d-9f2d-4e0e-86cd-82371582524e

</details>


# Changelog
:cl: Drathek
refactor: Refactored the overlay_lighting component to better handle objects deleting
fix: Fix putting lights in bags somereason keeping the light on
/:cl:
