### PR TITLE
Fixes evac pods launching with more than three occupants

### DIFF
--- a/code/modules/cm_aliens/XenoStructures.dm
+++ b/code/modules/cm_aliens/XenoStructures.dm
@@ -160,7 +160,6 @@
 /obj/effect/alien/resin/sticky/Crossed(atom/movable/AM)
 	. = ..()
 	var/mob/living/carbon/human/H = AM
-	// Wait doesn't this stack slows if you get dragged over it? What's going on here?
 	if(istype(H) && !H.ally_of_hivenumber(hivenumber))
 		H.next_move_slowdown = max(H.next_move_slowdown, slow_amt)
 		return .

--- a/code/modules/cm_aliens/XenoStructures.dm
+++ b/code/modules/cm_aliens/XenoStructures.dm
@@ -162,11 +162,11 @@
 	var/mob/living/carbon/human/H = AM
 	// Wait doesn't this stack slows if you get dragged over it? What's going on here?
 	if(istype(H) && !H.ally_of_hivenumber(hivenumber))
-		H.next_move_slowdown = H.next_move_slowdown + slow_amt
+		H.next_move_slowdown = max(H.next_move_slowdown, slow_amt)
 		return .
 	var/mob/living/carbon/xenomorph/X = AM
 	if(istype(X) && !X.ally_of_hivenumber(hivenumber))
-		X.next_move_slowdown = X.next_move_slowdown + slow_amt
+		X.next_move_slowdown = max(X.next_move_slowdown, slow_amt)
 		return .
 
 /obj/effect/alien/resin/sticky/proc/forsaken_handling()

--- a/code/modules/cm_aliens/weeds.dm
+++ b/code/modules/cm_aliens/weeds.dm
@@ -186,7 +186,7 @@
 	SEND_SIGNAL(crossing_mob, COMSIG_MOB_WEED_SLOWDOWN, slowdata, src)
 	var/final_slowdown = slowdata["movement_slowdown"]
 
-	crossing_mob.next_move_slowdown += POSITIVE(final_slowdown)
+	crossing_mob.next_move_slowdown = max(crossing_mob.next_move_slowdown, POSITIVE(final_slowdown))
 
 // Uh oh, we might be dying!
 // I know this is bad proc naming but it was too good to pass on and it's only used in this file anyways

--- a/code/modules/shuttle/shuttles/crashable/escape_shuttle.dm
+++ b/code/modules/shuttle/shuttles/crashable/escape_shuttle.dm
@@ -73,6 +73,8 @@
 		for(var/mob/living/occupant in interior_area)
 			occupant_count++
 		for(var/obj/structure/machinery/cryopod/evacuation/cryotube in interior_area)
+			if(cryotube.occupant)
+				occupant_count++
 			cryos += list(cryotube)
 	if (occupant_count > max_capacity)
 		playsound(src,'sound/effects/escape_pod_warmup.ogg', 50, 1)


### PR DESCRIPTION
# About the pull request

Fixes #3650 . Evac pods can no longer launch if the occupant number is greater than three.

# Explain why it's good for the game

bug bad

# Changelog

:cl:
fix: Fixes evac pods launching with more than the occupant limit
/:cl:

