### PR TITLE
Fixes evac pods launching with more than three occupants

### DIFF
--- a/code/modules/shuttle/shuttles/crashable/escape_shuttle.dm
+++ b/code/modules/shuttle/shuttles/crashable/escape_shuttle.dm
@@ -73,6 +73,8 @@
 		for(var/mob/living/occupant in interior_area)
 			occupant_count++
 		for(var/obj/structure/machinery/cryopod/evacuation/cryotube in interior_area)
+			if(cryotube.occupant)
+				occupant_count++
 			cryos += list(cryotube)
 	if (occupant_count > max_capacity)
 		playsound(src,'sound/effects/escape_pod_warmup.ogg', 50, 1)


### PR DESCRIPTION

# About the pull request

Fixes #3650 , Evac pods can no longer launch if the occupant number is greater than three.

# Explain why it's good for the game

bug bad

# Changelog


:cl:
fix: Fixes evac pods launching with more than the occupant limit
/:cl:
