### PR TITLE
A couple of M56D/M2C fixes

### DIFF
--- a/code/modules/cm_marines/m2c.dm
+++ b/code/modules/cm_marines/m2c.dm
@@ -446,33 +446,10 @@
 //ATTACK WITH BOTH HANDS COMBO
 
 /obj/structure/machinery/m56d_hmg/auto/attack_hand(mob/living/user)
-	..()
+	if(..())
+		return TRUE
 
-	var/turf/user_turf = get_turf(user)
-	for(var/opp_dir in reverse_nearby_direction(src.dir))
-		if(get_step(src, opp_dir) == user_turf)
-			if(operator) //If there is already a operator then they're manning it.
-				if(operator.interactee == null)
-					operator = null //this shouldn't happen, but just in case
-				else
-					to_chat(user, "Someone's already controlling it.")
-					return
-			if(!(user.alpha > 60))
-				to_chat(user, SPAN_WARNING("You aren't going to be setting up while cloaked."))
-				return
-			else
-				if(user.interactee) //Make sure we're not manning two guns at once, tentacle arms.
-					to_chat(user, "You're already manning something!")
-					return
-
-			if(user.get_active_hand() == null && user.get_inactive_hand() == null)
-				ADD_TRAIT(user, TRAIT_IMMOBILIZED, INTERACTION_TRAIT)
-				user.set_interaction(src)
-				give_action(user, /datum/action/human_action/mg_exit)
-			else
-				to_chat(usr, SPAN_NOTICE("Your hands are too busy holding things to grab the handles!"))
-		else
-			to_chat(usr, SPAN_NOTICE("You are too far from the handles to man [src]!"))
+	try_mount_gun(user)
 
 // DISASSEMBLY
 

--- a/code/modules/cm_marines/m2c.dm
+++ b/code/modules/cm_marines/m2c.dm
@@ -515,7 +515,6 @@
 	..()
 	ADD_TRAIT(user, TRAIT_OVERRIDE_CLICKDRAG, TRAIT_SOURCE_WEAPON)
 	RegisterSignal(user, COMSIG_MOVABLE_PRE_MOVE, PROC_REF(disable_interaction))
-	RegisterSignal(user, COMSIG_LIVING_SET_BODY_POSITION, PROC_REF(body_position_changed))
 
 // DISMOUNT THE MG
 
@@ -599,12 +598,6 @@
 	SIGNAL_HANDLER
 
 	if(user.body_position != STANDING_UP || get_dist(user,src) > 0 || user.is_mob_incapacitated() || !user.client)
-		user.unset_interaction()
-
-/obj/structure/machinery/m56d_hmg/auto/proc/body_position_changed(mob/living/user, body_position, old_body_position)
-	SIGNAL_HANDLER
-
-	if(body_position != STANDING_UP)
 		user.unset_interaction()
 
 /obj/structure/machinery/m56d_hmg/auto/proc/handle_rotating_gun(mob/user)

--- a/code/modules/cm_marines/m2c.dm
+++ b/code/modules/cm_marines/m2c.dm
@@ -137,14 +137,14 @@
 	M.anchored = TRUE
 	playsound(M, 'sound/items/m56dauto_setup.ogg', 75, TRUE)
 	to_chat(user, SPAN_NOTICE("You deploy [M]."))
-	if((rounds > 0) && !user.get_inactive_hand())
-		user.set_interaction(M)
-		give_action(user, /datum/action/human_action/mg_exit)
 	M.rounds = rounds
 	M.overheat_value = overheat_value
 	M.health = health
 	M.update_icon()
 	qdel(src)
+
+	if(M.rounds > 0)
+		M.try_mount_gun(user)
 
 /obj/item/device/m2c_gun/attackby(obj/item/O as obj, mob/user as mob)
 	if(!ishuman(user))

--- a/code/modules/cm_marines/smartgun_mount.dm
+++ b/code/modules/cm_marines/smartgun_mount.dm
@@ -835,8 +835,8 @@
 		if(get_step(src, opposite_dir) == user_turf)
 			found_user = TRUE
 			break
-	// If the user isn't standing behind the gun.
-	if(!found_user)
+	// If the user isn't standing behind or on top of the gun.
+	if(!found_user && user_turf != get_turf(src))
 		to_chat(user, SPAN_WARNING("You are too far from the handles to man [src]!"))
 		return
 


### PR DESCRIPTION

# About the pull request

Some fixes and a small refactor for the M56D and M2C (since it's a subtype).
I was initially only planning to add a few `allow_gun_usage` checks around, but I just kept finding more things to fix.

(I've tested this pretty thoroughly, but I'd still like to request a testmerge since a few of my other recent PRs have introduced new bugs.)

# Explain why it's good for the game

Fixes bugs

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Fixed non-combat synthetics being able to fire the M2C.
fix: Fixed scouts being able to use the M56D or M2C before their cloak's gun cooldown had ended.
fix: Fixed the M56D and M2C saying that the user is too far away to man it, even when they successfully man it.
fix: Fixed a runtime which was caused whenever someone manned an M56D or M2C.
refactor: Refactored some M56D and M2C manning/unmanning code.
/:cl:
