### PR TITLE
Fixes Nuke failing to detonate

### DIFF
--- a/code/game/machinery/nuclearbomb.dm
+++ b/code/game/machinery/nuclearbomb.dm
@@ -396,45 +396,34 @@ GLOBAL_VAR_INIT(bomb_set, FALSE)
 	playsound(src, 'sound/machines/Alarm.ogg', 75, 0, 30)
 	world << pick('sound/theme/nuclear_detonation1.ogg','sound/theme/nuclear_detonation2.ogg')
 
-	var/list/alive_mobs = list() //Everyone who will be destroyed on the zlevel(s).
-	var/list/dead_mobs = list() //Everyone who only needs to see the cinematic.
+	var/list/mob/alive_mobs = list() //Everyone who will be destroyed on the zlevel(s).
+	var/list/mob/dead_mobs = list() //Everyone who only needs to see the cinematic.
 	for(var/mob/current_mob as anything in GLOB.mob_list)
-		if(!current_mob?.loc)
-			continue
-		if(current_mob.stat == DEAD)
-			dead_mobs |= current_mob
-			continue
 		var/turf/current_turf = get_turf(current_mob)
-		if(z == current_turf.z)
+		if(current_turf?.z == z)
+			if(current_mob.stat == DEAD)
+				dead_mobs |= current_mob
+				continue
 			alive_mobs |= current_mob
 			shake_camera(current_mob, 110, 4)
 
 	for(var/mob/current_mob in alive_mobs)
-		if(current_mob && current_mob.loc)
-			var/turf/current_mob_turf = get_turf(current_mob)
-			if(z == current_mob_turf.z)
-				if(istype(current_mob.loc, /obj/structure/closet/secure_closet/freezer/fridge))
-					continue
-				current_mob.death(create_cause_data("nuclear explosion"))
+		if(istype(current_mob.loc, /obj/structure/closet/secure_closet/freezer/fridge))
+			continue
+		current_mob.death(create_cause_data("nuclear explosion"))
 
-	for(var/mob/current_mob in (alive_mobs + dead_mobs))
-		if(current_mob && current_mob.loc)
-			var/turf/current_mob_turf = get_turf(current_mob)
-			if(z == current_mob_turf.z)
-				if(istype(current_mob.loc, /obj/structure/closet/secure_closet/freezer/fridge))
-					continue
-				for(var/obj/item/alien_embryo/embryo in current_mob)
-					qdel(embryo)
+	for(var/mob/living/current_mob in (alive_mobs + dead_mobs))
+		if(istype(current_mob.loc, /obj/structure/closet/secure_closet/freezer/fridge))
+			continue
+		for(var/obj/item/alien_embryo/embryo in current_mob)
+			qdel(embryo)
 
-	sleep(100)
+	sleep(10 SECONDS)
 	cell_explosion(loc, 500, 150, EXPLOSION_FALLOFF_SHAPE_LINEAR, null, create_cause_data(initial(name)))
 	qdel(src)
 	return TRUE
 
 /obj/structure/machinery/nuclearbomb/Destroy()
-	if(timing != -1)
-		message_admins("\The [src] has been unexpectedly deleted at ([x],[y],[x]). [ADMIN_JMP(src)]")
-		log_game("\The [src] has been unexpectedly deleted at ([x],[y],[x]).")
 	GLOB.bomb_set = FALSE
 	SSminimaps.remove_marker(src)
 	return ..()

--- a/code/game/machinery/nuclearbomb.dm
+++ b/code/game/machinery/nuclearbomb.dm
@@ -396,8 +396,15 @@ GLOBAL_VAR_INIT(bomb_set, FALSE)
 	playsound(src, 'sound/machines/Alarm.ogg', 75, 0, 30)
 	world << pick('sound/theme/nuclear_detonation1.ogg','sound/theme/nuclear_detonation2.ogg')
 
+	for(var/mob/current_mob as anything in GLOB.mob_list)
+		var/turf/current_turf = get_turf(current_mob)
+		if(current_turf?.z == z && current_mob.stat != DEAD)
+			shake_camera(current_mob, 110, 4)
+
+	sleep(10 SECONDS)
+
 	var/list/mob/alive_mobs = list() //Everyone who will be destroyed on the zlevel(s).
-	var/list/mob/dead_mobs = list() //Everyone who only needs to see the cinematic.
+	var/list/mob/dead_mobs = list() //Everyone that needs embryos cleared
 	for(var/mob/current_mob as anything in GLOB.mob_list)
 		var/turf/current_turf = get_turf(current_mob)
 		if(current_turf?.z == z)
@@ -405,7 +412,6 @@ GLOBAL_VAR_INIT(bomb_set, FALSE)
 				dead_mobs |= current_mob
 				continue
 			alive_mobs |= current_mob
-			shake_camera(current_mob, 110, 4)
 
 	for(var/mob/current_mob in alive_mobs)
 		if(istype(current_mob.loc, /obj/structure/closet/secure_closet/freezer/fridge))
@@ -418,7 +424,6 @@ GLOBAL_VAR_INIT(bomb_set, FALSE)
 		for(var/obj/item/alien_embryo/embryo in current_mob)
 			qdel(embryo)
 
-	sleep(10 SECONDS)
 	cell_explosion(loc, 500, 150, EXPLOSION_FALLOFF_SHAPE_LINEAR, null, create_cause_data(initial(name)))
 	qdel(src)
 	return TRUE


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

Under very specific circumstances (seen 2x or more on live), the nuke broken logic of checking eligbile mobs for explosion will cause it to crash completely and fail to detonate. The problem is primarily the `loc` check at top, which is not a sufficient safeguard.

Also moves the explosion delay so that people die when the nuke explode and not before...


# Testing Photographs and Procedure
Spawn in nuke and testers, safety off, proccall explode


# Changelog
:cl:
fix: Fixed Nuke failing to detonate under specific circumstances. It may involve a little rodent.
fix: Nuke explosion will now kill mobs on its actual explosion rather than at the start of the cinematic sequence.
/:cl:
