### PR TITLE
Fixes photos only being viewable from adjacent tiles as an observer

### DIFF
--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -75,7 +75,7 @@
 
 /obj/item/paper/get_examine_text(mob/user)
 	. = ..()
-	if(in_range(user, src) || istype(user, /mob/dead/observer))
+	if(in_range(user, src) || isobserver(user))
 		if(!(istype(user, /mob/dead/observer) || istype(user, /mob/living/carbon/human) || isRemoteControlling(user)))
 			// Show scrambled paper if they aren't a ghost, human, or silicone.
 			if(photo_list)

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -46,7 +46,7 @@
 	..()
 
 /obj/item/photo/get_examine_text(mob/user)
-	if(in_range(user, src))
+	if(in_range(user, src) || isobserver(user))
 		show(user)
 		return list(desc)
 	else


### PR DESCRIPTION
# About the pull request

Fixes #3855 , observer mobs can now view photos from any distance.

# Explain why it's good for the game

bug bad

# Changelog

:cl:
fix: Fixes photos not being viewable from any distance as an observer
/:cl:

