### PR TITLE
Fix runtimes and multitool bricking if a sentry_computer is deleted

### DIFF
--- a/code/modules/defenses/sentry_computer.dm
+++ b/code/modules/defenses/sentry_computer.dm
@@ -78,6 +78,8 @@
 	last_camera_turf = null
 	current = null
 	registered_tools = null
+	for(var/obj/structure/machinery/defenses/sentry/sentrygun as anything in paired_sentry)
+		unpair_sentry(sentrygun)
 	paired_sentry = null
 
 /obj/item/device/sentry_computer/proc/camera_mapname_update(source, value)
@@ -211,7 +213,7 @@
 					for(var/key_id in tool.encryption_keys)
 						var/datum/weakref/ref = tool.encryption_keys[key_id]
 						var/obj/item/device/sentry_computer/key_object = ref.resolve()
-						key_object.registered_tools -= id
+						key_object?.registered_tools -= id
 					tool.encryption_keys = list()
 				to_chat(user, SPAN_NOTICE("Existing encryption keys cleared."))
 			to_chat(usr, SPAN_NOTICE("You begin encryption key to \the [tool]."))
@@ -319,9 +321,8 @@
 	.["sentry_static"] = list()
 	.["mapRef"] = camera_map_name
 	var/index = 1
-	for(var/sentry in paired_sentry)
+	for(var/obj/structure/machinery/defenses/sentry/sentrygun as anything in paired_sentry)
 		var/list/sentry_holder = list()
-		var/obj/structure/machinery/defenses/sentry/sentrygun = sentry
 		sentry_holder["selection_menu"] = list()
 		sentry_holder["index"] = index
 		sentry_holder["name"] = sentrygun.name


### PR DESCRIPTION
# About the pull request

This PR resolves some runtimes and the bricking of a multitool if it is loaded with a deleted sentry. The weakref resolve in the multitool wasn't checked if the resolve passed. Additionally, the sentries would remain encrypted to a non-existent computer. If bricking an encrypted sentry is intended, it needs to be handled more gracefully.

# Explain why it's good for the game

Fixes a runtime when using a multitool linked to a deleted sentry_computer:
![image](https://github.com/cmss13-devs/cmss13/assets/76988376/4db7c411-aff1-4b56-9cee-b2cec6e05519)

Fixes a runtime when using said multitool to unpair the sentry from a deleted sentry_computer.
![image](https://github.com/cmss13-devs/cmss13/assets/76988376/946f002d-2246-4632-a554-e2cfd6ad5a9d)

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

1. Link tuner w/ a laptop
2. Delete laptop
3. Spawn a new laptop
4. Use tuner on new laptop
5. Runtime when trying to clear because the weakref resolve wasn't checked.

https://github.com/cmss13-devs/cmss13/assets/76988376/bfe447ce-a6dc-4d88-b3e8-b4ee6efb1daf

</details>


# Changelog
:cl: Drathek
fix: Fix handling of sentry_computer deletion
/:cl:
