### PR TITLE
team lead now properly ranked in squad info menu

### DIFF
--- a/tgui/packages/tgui/interfaces/SquadInfo.tsx
+++ b/tgui/packages/tgui/interfaces/SquadInfo.tsx
@@ -135,7 +135,7 @@ const FireTeam = (props: { ft: string }, context) => {
       fireteam?.tl?.name === 'Not assigned' ||
       fireteam?.tl?.name === 'Unassigned' ||
       fireteam?.tl?.name === undefined);
-  const rankList = ['Mar', 'ass', 'Med', 'Eng', 'SG', 'Spc', 'RTO', 'SL'];
+  const rankList = ['Mar', 'ass', 'Med', 'Eng', 'SG', 'Spc', 'TL', 'SL'];
   const rankSort = (a: SquadMarineEntry, b: SquadMarineEntry) => {
     if (a.rank === 'Mar' && b.rank === 'Mar') {
       return a.paygrade === 'PFC' ? -1 : 1;
@@ -283,7 +283,7 @@ const SquadObjectives = (props, context) => {
 };
 
 export const SquadInfo = (_, context) => {
-  const { config, data } = useBackend<SquadProps>(context);
+  const { data } = useBackend<SquadProps>(context);
   const fireteams = ['FT1', 'FT2', 'FT3', 'Unassigned'];
 
   return (


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

When RTO was moved to TL - the team lead would not be properly sorted, leaving the Cpls at the bottom of the list. This puts TLs in their rightful place.

# Explain why it's good for the game
Fix regression with squad info page.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.
![image](https://github.com/cmss13-devs/cmss13/assets/101871009/94e6100b-121d-4e9a-8224-a90109e3c3f0)

</details>


# Changelog
:cl:
fix: properly sorted team lead position in squad info page
/:cl:
