### PR TITLE
Fixes screen alert tooltips getting stuck open

### DIFF
--- a/code/modules/maptext_alerts/screen_alerts.dm
+++ b/code/modules/maptext_alerts/screen_alerts.dm
@@ -242,6 +242,10 @@
 	if(!QDELETED(src))
 		openToolTip(usr, src, params, title = name, content = desc, theme = alerttooltipstyle)
 
+/atom/movable/screen/alert/MouseExited(location, control, params)
+	. = ..()
+	closeToolTip(usr)
+
 /atom/movable/screen/alert/notify_action
 	name = "Notification"
 	desc = "A new notification. You can enter it."


### PR DESCRIPTION

# About the pull request

Fixes #5344 by making alert tooltips close when the user's mouse exits the alert.
(This is how it work on other codebases that I've checked, so I guess it was just accidentally left out when alerts were ported here?)

# Explain why it's good for the game

Tooltips should be able to open *and* close.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Fixed screen alert tooltips ('Buckled' indicator and stuff) getting stuck open.
/:cl:
