### PR TITLE
Adds TWE to ERT rotation

### DIFF
--- a/code/datums/emergency_calls/emergency_call.dm
+++ b/code/datums/emergency_calls/emergency_call.dm
@@ -30,7 +30,7 @@
 	var/arrival_message = "" //Msg to display about when the shuttle arrives
 	var/objectives //Txt of objectives to display to joined. Todo: make this into objective notes
 	var/objective_info //For additional info in the objectives txt
-	var/probability = 0 //Chance of it occurring. Total must equal 100%
+	var/probability = 0
 	var/hostility //For ERTs who are either hostile or friendly by random chance.
 	var/list/datum/mind/members = list() //Currently-joined members.
 	var/list/datum/mind/candidates = list() //Potential candidates for enlisting.

--- a/code/datums/emergency_calls/royal_marines.dm
+++ b/code/datums/emergency_calls/royal_marines.dm
@@ -1,7 +1,7 @@
 /datum/emergency_call/royal_marines
 	name = "Royal Marines Commando (Squad) (Friendly)"
 	mob_max = 7
-	probability = 0
+	probability = 15
 	name_of_spawn = /obj/effect/landmark/ert_spawns/distress_twe
 	item_spawn = /obj/effect/landmark/ert_spawns/distress_twe/item
 	max_engineers =  0


### PR DESCRIPTION

# About the pull request
Adds the Three-World ERT as a possible distress beacon response with chances slightly lower than other common (UPP, PMC, etc.) ERTs.

# Explain why it's good for the game
The TWE ERT seems to be fairly complete and has been sitting largely unused in the code for several months. More sensible variation in distress beacons is good.


# Changelog
:cl:
add: The Three-World Empire will now occasionally respond to distress beacons.
/:cl:
