### PR TITLE
Lesser drones and facehuggers cannot speak for 3 minutes after spawning

### DIFF
--- a/code/__DEFINES/dcs/signals/atom/mob/living/signals_xeno.dm
+++ b/code/__DEFINES/dcs/signals/atom/mob/living/signals_xeno.dm
@@ -62,3 +62,7 @@
 
 /// For any additional things that should happen when a xeno's melee_attack_additional_effects_self() proc is called
 #define COMSIG_XENO_SLASH_ADDITIONAL_EFFECTS_SELF "xeno_slash_additional_effects_self"
+
+/// From /mob/living/carbon/xenomorph/proc/hivemind_talk(): (message)
+#define COMSIG_XENO_TRY_HIVEMIND_TALK "xeno_try_hivemind_talk"
+	#define COMPONENT_CANCEL_HIVEMIND_TALK (1<<0)

--- a/code/datums/components/temporary_mute.dm
+++ b/code/datums/components/temporary_mute.dm
@@ -1,0 +1,45 @@
+/datum/component/temporary_mute
+	dupe_mode = COMPONENT_DUPE_UNIQUE
+	/// A message to tell the user when they attempt to speak, if any
+	var/on_speak_message = ""
+	/// A message to tell the user when they become no longer mute, if any
+	var/on_unmute_message = ""
+	/// How long after the component's initialization it should be deleted. -1 means it will never delete
+	var/time_until_unmute = 5 MINUTES
+
+/datum/component/temporary_mute/Initialize(on_speak_message = "", on_unmute_message = "", time_until_unmute = 5 MINUTES)
+	. = ..()
+	if(!ismob(parent))
+		return COMPONENT_INCOMPATIBLE
+
+	src.on_speak_message = on_speak_message
+	src.on_unmute_message = on_unmute_message
+	src.time_until_unmute = time_until_unmute
+	if(time_until_unmute != -1)
+		QDEL_IN(src, time_until_unmute)
+
+
+/datum/component/temporary_mute/RegisterWithParent()
+	..()
+	RegisterSignal(parent, COMSIG_LIVING_SPEAK, PROC_REF(on_speak))
+
+/datum/component/temporary_mute/UnregisterFromParent()
+	..()
+	if(parent)
+		to_chat(parent, SPAN_NOTICE(on_unmute_message))
+		UnregisterSignal(parent, COMSIG_LIVING_SPEAK)
+
+/datum/component/temporary_mute/proc/on_speak(
+	message,
+	datum/language/speaking = null,
+	verb = "says",
+	alt_name = "",
+	italics = FALSE,
+	message_range = GLOB.world_view_size,
+	sound/speech_sound,
+	sound_vol,
+	nolog = FALSE,
+	message_mode = null
+)
+	to_chat(parent, SPAN_BOLDNOTICE(on_speak_message))
+	return COMPONENT_OVERRIDE_SPEAK

--- a/code/datums/components/temporary_mute.dm
+++ b/code/datums/components/temporary_mute.dm
@@ -22,6 +22,7 @@
 /datum/component/temporary_mute/RegisterWithParent()
 	..()
 	RegisterSignal(parent, COMSIG_LIVING_SPEAK, PROC_REF(on_speak))
+	RegisterSignal(parent, COMSIG_XENO_TRY_HIVEMIND_TALK, PROC_REF(on_speak))
 
 /datum/component/temporary_mute/UnregisterFromParent()
 	..()
@@ -41,5 +42,8 @@
 	nolog = FALSE,
 	message_mode = null
 )
+	var/mob/mob_parent = parent
+
+	log_say("[mob_parent.name != "Unknown" ? mob_parent.name : "([mob_parent.real_name])"] attempted to say the following before their xenomorph spawn mute ended: [message] (CKEY: [mob_parent.key]) (JOB: [mob_parent.job])")
 	to_chat(parent, SPAN_BOLDNOTICE(on_speak_message))
 	return COMPONENT_OVERRIDE_SPEAK

--- a/code/datums/components/temporary_mute.dm
+++ b/code/datums/components/temporary_mute.dm
@@ -29,6 +29,7 @@
 	if(parent)
 		to_chat(parent, SPAN_NOTICE(on_unmute_message))
 		UnregisterSignal(parent, COMSIG_LIVING_SPEAK)
+		UnregisterFromParent(parent, COMSIG_XENO_TRY_HIVEMIND_TALK)
 
 /datum/component/temporary_mute/proc/on_speak(
 	message,

--- a/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
@@ -64,6 +64,15 @@
 	weed_food_states = list("Facehugger_1","Facehugger_2","Facehugger_3")
 	weed_food_states_flipped = list("Facehugger_1","Facehugger_2","Facehugger_3")
 
+/mob/living/carbon/xenomorph/facehugger/Initialize(mapload, mob/living/carbon/xenomorph/old_xeno, hivenumber)
+	. = ..()
+	AddComponent(\
+		/datum/component/temporary_mute,\
+		"We aren't old enough to vocalize anything yet.",\
+		"We feel old enough to be able to vocalize and speak to the hivemind.",\
+		3 MINUTES,\
+	)
+
 /mob/living/carbon/xenomorph/facehugger/initialize_pass_flags(datum/pass_flags_container/PF)
 	..()
 	if (PF)

--- a/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
@@ -63,15 +63,21 @@
 	weed_food_icon = 'icons/mob/xenos/weeds_48x48.dmi'
 	weed_food_states = list("Facehugger_1","Facehugger_2","Facehugger_3")
 	weed_food_states_flipped = list("Facehugger_1","Facehugger_2","Facehugger_3")
+	/// The last ckey to have inhabited this mob
+	var/last_ckey_inhabited = ""
 
-/mob/living/carbon/xenomorph/facehugger/Initialize(mapload, mob/living/carbon/xenomorph/old_xeno, hivenumber)
+/mob/living/carbon/xenomorph/facehugger/Login()
 	. = ..()
+	if(ckey == last_ckey_inhabited)
+		return
+
 	AddComponent(\
 		/datum/component/temporary_mute,\
 		"We aren't old enough to vocalize anything yet.",\
 		"We feel old enough to be able to vocalize and speak to the hivemind.",\
 		3 MINUTES,\
 	)
+	last_ckey_inhabited = ckey
 
 /mob/living/carbon/xenomorph/facehugger/initialize_pass_flags(datum/pass_flags_container/PF)
 	..()

--- a/code/modules/mob/living/carbon/xenomorph/castes/lesser_drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/lesser_drone.dm
@@ -83,6 +83,15 @@
 	weed_food_states = list("Lesser_Drone_1","Lesser_Drone_2","Lesser_Drone_3")
 	weed_food_states_flipped = list("Lesser_Drone_1","Lesser_Drone_2","Lesser_Drone_3")
 
+/mob/living/carbon/xenomorph/lesser_drone/Initialize(mapload, mob/living/carbon/xenomorph/old_xeno, hivenumber)
+	. = ..()
+	AddComponent(\
+		/datum/component/temporary_mute,\
+		"We aren't old enough to vocalize anything yet.",\
+		"We feel old enough to be able to vocalize and speak to the hivemind.",\
+		3 MINUTES,\
+	)
+
 /mob/living/carbon/xenomorph/lesser_drone/age_xeno()
 	if(stat == DEAD || !caste || QDELETED(src) || !client)
 		return

--- a/code/modules/mob/living/carbon/xenomorph/castes/lesser_drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/lesser_drone.dm
@@ -82,15 +82,21 @@
 	weed_food_icon = 'icons/mob/xenos/weeds.dmi'
 	weed_food_states = list("Lesser_Drone_1","Lesser_Drone_2","Lesser_Drone_3")
 	weed_food_states_flipped = list("Lesser_Drone_1","Lesser_Drone_2","Lesser_Drone_3")
+	/// The last ckey to have inhabited this mob
+	var/last_ckey_inhabited = ""
 
-/mob/living/carbon/xenomorph/lesser_drone/Initialize(mapload, mob/living/carbon/xenomorph/old_xeno, hivenumber)
+/mob/living/carbon/xenomorph/lesser_drone/Login()
 	. = ..()
+	if(ckey == last_ckey_inhabited)
+		return
+
 	AddComponent(\
 		/datum/component/temporary_mute,\
 		"We aren't old enough to vocalize anything yet.",\
 		"We feel old enough to be able to vocalize and speak to the hivemind.",\
 		3 MINUTES,\
 	)
+	last_ckey_inhabited = ckey
 
 /mob/living/carbon/xenomorph/lesser_drone/age_xeno()
 	if(stat == DEAD || !caste || QDELETED(src) || !client)

--- a/code/modules/mob/living/carbon/xenomorph/say.dm
+++ b/code/modules/mob/living/carbon/xenomorph/say.dm
@@ -98,6 +98,9 @@
 		to_chat(src, SPAN_WARNING("A headhunter temporarily cut off your psychic connection!"))
 		return
 
+	if(SEND_SIGNAL(src, COMSIG_XENO_TRY_HIVEMIND_TALK, message) & COMPONENT_CANCEL_HIVEMIND_TALK)
+		return
+
 	hivemind_broadcast(message, hive)
 
 /mob/living/carbon/proc/hivemind_broadcast(message, datum/hive_status/hive)

--- a/colonialmarines.dme
+++ b/colonialmarines.dme
@@ -404,6 +404,7 @@
 #include "code\datums\components\overlay_lighting.dm"
 #include "code\datums\components\rename.dm"
 #include "code\datums\components\speed_modifier.dm"
+#include "code\datums\components\temporary_mute.dm"
 #include "code\datums\components\toxin_buildup.dm"
 #include "code\datums\components\tutorial_status.dm"
 #include "code\datums\components\weed_damage_reduction.dm"


### PR DESCRIPTION

# About the pull request
Lessers and facehuggers are unable to speak (locally and hivemind) for 3m after spawning.

# Explain why it's good for the game
The ability for ghosts to spawn as instant, cheap xenos has caused a noticeable uptick in bad faith players abusing the system. This delay means that lessers and huggers will be less able to spawn in and immediately announce marine pushes, flanks, etc. while still allowing the high-effort ones the ability to communicate and RP once they've lived long enough to invalidate most of the metainfo they had.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/cmss13-devs/cmss13/assets/41448081/bc3a25f4-9d38-4804-97b9-96f7d2c9a9bc)

</details>


# Changelog
:cl:
balance: Lesser drones and facehuggers cannot speak for 3 minutes after spawning.
/:cl:
