### PR TITLE
Fix OT explosive assemblies not taking containers they are supposed to

### DIFF
--- a/code/game/objects/items/explosives/explosive.dm
+++ b/code/game/objects/items/explosives/explosive.dm
@@ -150,7 +150,7 @@
 			return
 		else
 			if(W.reagents.total_volume)
-				if(W.reagents.maximum_volume + current_container_volume > max_container_volume)
+				if((W.reagents.maximum_volume + current_container_volume) > max_container_volume)
 					to_chat(user, SPAN_DANGER("\the [W] is too large for [name]."))
 					return
 				if(user.temp_drop_inv_item(W))


### PR DESCRIPTION

# About the pull request

OT assemblies were not accepting added 120u containers, even though it should be taking anything up to it.
Due to some weird order of operation that goes against DM documentation.
For example here the (M15) assembly is not taking a 120u bucket.

![Screenshot_31](https://github.com/cmss13-devs/cmss13/assets/15560820/12e76ccb-7ead-4257-beb9-68f28c138b81)
This is essentially evaluating: 120+(0>120)
which equals 120, since its not 0 or a negative number it interprets it as True.

# Explain why it's good for the game

Pre-open source bugs in the code is bad.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Fixed a bug where OT explosive assemblies were not accepting reagent containers when they should have.
/:cl:
