### PR TITLE
Fix simulators demolition button

### DIFF
--- a/tgui/packages/tgui/interfaces/CasSim.tsx
+++ b/tgui/packages/tgui/interfaces/CasSim.tsx
@@ -21,7 +21,7 @@ export const CasSim = (_props, context) => {
   const timeLeft = data.nextdetonationtime - data.worldtime;
   const timeLeftPct = timeLeft / data.detonation_cooldown;
 
-  const canDetonate = timeLeft < 0 && data.configuration && data.looking;
+  const canDetonate = timeLeft < 0 && data.configuration && simulationView;
 
   return (
     <Box className="CasSim">

--- a/tgui/packages/tgui/interfaces/CasSim.tsx
+++ b/tgui/packages/tgui/interfaces/CasSim.tsx
@@ -3,7 +3,6 @@ import { Box, Button, Section, ProgressBar, NoticeBox, Stack } from '../componen
 
 interface CasSimData {
   configuration: any;
-  looking: 0 | 1;
   dummy_mode: string;
   worldtime: number;
   nextdetonationtime: number;

--- a/tgui/packages/tgui/interfaces/DemoSim.jsx
+++ b/tgui/packages/tgui/interfaces/DemoSim.jsx
@@ -13,7 +13,7 @@ export const DemoSim = (_props, context) => {
   const timeLeft = data.nextdetonationtime - data.worldtime;
   const timeLeftPct = timeLeft / data.detonation_cooldown;
 
-  const canDetonate = timeLeft < 0 && data.configuration && data.looking;
+  const canDetonate = timeLeft < 0 && data.configuration && simulationView;
 
   return (
     <Window width={550} height={300}>

--- a/tgui/packages/tgui/interfaces/DemoSim.tsx
+++ b/tgui/packages/tgui/interfaces/DemoSim.tsx
@@ -2,8 +2,16 @@ import { useBackend, useLocalState } from '../backend';
 import { Button, Section, ProgressBar, NoticeBox, Box, Stack } from '../components';
 import { Window } from '../layouts';
 
+interface DemoSimData {
+  configuration: any;
+  dummy_mode: string;
+  worldtime: number;
+  nextdetonationtime: number;
+  detonation_cooldown: number;
+}
+
 export const DemoSim = (_props, context) => {
-  const { act, data } = useBackend(context);
+  const { act, data } = useBackend<DemoSimData>(context);
   const [simulationView, setSimulationView] = useLocalState(
     context,
     'simulation_view',


### PR DESCRIPTION

# About the pull request

This PR is a followup to #5318 that changed a var used to determine whether detonation is possible.

# Explain why it's good for the game

Simulator is useless without this functionality.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![bombs](https://github.com/cmss13-devs/cmss13/assets/76988376/f8387688-a34f-4e59-b21d-c0497e8e0cdd)

</details>


# Changelog
:cl: Drathek
fix: Fixed simulators detonation button
/:cl:
