### PR TITLE
Splits hivemind messages into their own chat category

### DIFF
--- a/code/__DEFINES/chat.dm
+++ b/code/__DEFINES/chat.dm
@@ -6,6 +6,7 @@
 #define MESSAGE_TYPE_SYSTEM "system"
 #define MESSAGE_TYPE_LOCALCHAT "localchat"
 #define MESSAGE_TYPE_RADIO "radio"
+#define MESSAGE_TYPE_HIVEMIND "hivemind"
 #define MESSAGE_TYPE_INFO "info"
 #define MESSAGE_TYPE_WARNING "warning"
 #define MESSAGE_TYPE_DEADCHAT "deadchat"

--- a/tgui/packages/tgui-panel/chat/constants.js
+++ b/tgui/packages/tgui-panel/chat/constants.js
@@ -24,6 +24,7 @@ export const MESSAGE_TYPE_INTERNAL = 'internal';
 export const MESSAGE_TYPE_SYSTEM = 'system';
 export const MESSAGE_TYPE_LOCALCHAT = 'localchat';
 export const MESSAGE_TYPE_RADIO = 'radio';
+export const MESSAGE_TYPE_HIVEMIND = 'hivemind';
 export const MESSAGE_TYPE_INFO = 'info';
 export const MESSAGE_TYPE_WARNING = 'warning';
 export const MESSAGE_TYPE_HELPFUL = 'helpful';
@@ -62,7 +63,13 @@ export const MESSAGE_TYPES = [
     type: MESSAGE_TYPE_RADIO,
     name: 'Radio',
     description: 'All departments of radio messages',
-    selector: '.radio, .xeno, .xenoqueen, .xenoleader, .alert, .newscaster',
+    selector: '.radio, .alert, .newscaster',
+  },
+  {
+    type: MESSAGE_TYPE_HIVEMIND,
+    name: 'Hivemind',
+    description: 'Xenomorph hivemind messages',
+    selector: '.xeno, .xenoqueen, .xenoleader',
   },
   {
     type: MESSAGE_TYPE_INFO,


### PR DESCRIPTION

# About the pull request

Separates xeno hivemind chat messages into their own toggleable category.

(It seems like TGUI-chat handles a new category being added by just making it enabled for everything, so it'll need to be manually disabled in custom 'OOC'/'Admin'/etc. tabs. (although better that than having it be *disabled* by default))

# Explain why it's good for the game
A lot of the time when observing it can be very hard to make out what's being said in the hivemind chat with how similar its colour is to local xeno chat, charlie radio, JTAC radio, colony radio, etc., especially if chat is moving quickly. This doesn't *really* solve that, but it does make it possible to set up a custom chat tab just for hivemind/xeno messages. (Or to stop seeing the hivemind I guess, if someone wanted to do that.)

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

https://github.com/cmss13-devs/cmss13/assets/57483089/5a5f0515-3712-46d3-88c3-24d662da044d

</details>


# Changelog
:cl:
ui: Separated xeno hivemind chat messages into their own toggleable category, separate from 'Radio'.
/:cl:
