### PR TITLE
Add forsaken handling to weeded corpses

### DIFF
--- a/code/datums/components/weed_food.dm
+++ b/code/datums/components/weed_food.dm
@@ -90,6 +90,7 @@
 	RegisterSignal(parent_mob, COMSIG_MOVABLE_MOVED, PROC_REF(on_move))
 	RegisterSignal(parent_mob, list(COMSIG_LIVING_REJUVENATED, COMSIG_HUMAN_REVIVED), PROC_REF(on_rejuv))
 	RegisterSignal(parent_mob, COMSIG_HUMAN_SET_UNDEFIBBABLE, PROC_REF(on_update))
+	RegisterSignal(SSdcs, COMSIG_GLOB_GROUNDSIDE_FORSAKEN_HANDLING, PROC_REF(on_forsaken))
 	if(parent_turf)
 		RegisterSignal(parent_turf, COMSIG_WEEDNODE_GROWTH, PROC_REF(on_update))
 
@@ -109,6 +110,7 @@
 		UnregisterSignal(parent_buckle, COSMIG_OBJ_AFTER_BUCKLE)
 	if(parent_nest)
 		UnregisterSignal(parent_nest, COMSIG_PARENT_QDELETING)
+	UnregisterSignal(SSdcs, COMSIG_GLOB_GROUNDSIDE_FORSAKEN_HANDLING)
 
 /// SIGNAL_HANDLER for COMSIG_MOVABLE_MOVED
 /datum/component/weed_food/proc/on_move()
@@ -177,6 +179,20 @@
 		parent_mob.plane = FLOOR_PLANE
 	UnregisterSignal(parent_nest, COMSIG_PARENT_QDELETING)
 	parent_nest = null
+
+/// SIGNAL_HANDLER for COMSIG_GLOB_GROUNDSIDE_FORSAKEN_HANDLING
+/datum/component/weed_food/proc/on_forsaken()
+	SIGNAL_HANDLER
+
+	UnregisterSignal(SSdcs, COMSIG_GLOB_GROUNDSIDE_FORSAKEN_HANDLING)
+
+	if(!merged)
+		return
+	if(!is_ground_level(parent_mob.z))
+		return
+
+	var/datum/hive_status/hive = GLOB.hive_datum[XENO_HIVE_FORSAKEN]
+	weed_appearance.color = hive.color
 
 /**
  * Try to start the process to turn into weeds


### PR DESCRIPTION

# About the pull request

This PR adds the forsaken handling signal to weed_food so they can change color when the weeds change hives. Unfortunately the weeds don't change color immediately, so I must just force the color in weed_food rather than read what color the weeds are.

# Explain why it's good for the game

Fixes #5370 

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![forsaken](https://github.com/cmss13-devs/cmss13/assets/76988376/bdf72d7f-9a90-44e2-9be7-55ac917cfaad)

</details>


# Changelog
:cl: Drathek
fix: Fixed weeded corpses not changing color during forsaken conversion
/:cl:
