### PR TITLE
'Time Since Death' hour wrapping fix

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -1235,17 +1235,11 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 			. += ""
 
 	if(timeofdeath)
-		var/time_since_death = debug_var
+		var/time_since_death = world.time - timeofdeath
 		var/format = (time_since_death >= 1 HOURS ? "hh:mm:ss" : "mm:ss")
 
 		. += "Time Since Death: [gameTimestamp(format, time_since_death)]"
 
-/mob/dead/observer/var/debug_var
-/mob/dead/observer/verb/debug_thing()
-	set category = "Ghost"
-	set name = "debug thing"
-
-	debug_var += 10 MINUTES
 
 /proc/message_ghosts(message)
 	for(var/mob/dead/observer/O as anything in GLOB.observer_list)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -1238,7 +1238,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		var/time_since_death = world.time - timeofdeath
 		var/format = (time_since_death >= 1 HOURS ? "hh:mm:ss" : "mm:ss")
 
-		. += "Time Since Death: [gameTimestamp(format, time_since_death)]"
+		. += "Time Since Death: [time2text(time_since_death, format)]"
 
 
 /proc/message_ghosts(message)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -1235,8 +1235,17 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 			. += ""
 
 	if(timeofdeath)
-		. += "Time Since Death: [duration2text_sec(world.time - timeofdeath)]"
+		var/time_since_death = debug_var
+		var/format = (time_since_death >= 1 HOURS ? "hh:mm:ss" : "mm:ss")
 
+		. += "Time Since Death: [gameTimestamp(format, time_since_death)]"
+
+/mob/dead/observer/var/debug_var
+/mob/dead/observer/verb/debug_thing()
+	set category = "Ghost"
+	set name = "debug thing"
+
+	debug_var += 10 MINUTES
 
 /proc/message_ghosts(message)
 	for(var/mob/dead/observer/O as anything in GLOB.observer_list)


### PR DESCRIPTION
# About the pull request

Tweaks the 'Time Since Death' counter added in #5314 so that it doesn't wrap around to '00:00' when it reaches one hour, instead adding an hour counter to the number.

I tried to see if I could make the minutes counter continue above 60 instead, but the best method I could figure out involved writing a whole time parsing thing, plus something to add zero padding so that it would display '61:02' and not '61:2', so I decided to just add a `>=` check instead.

Technically this does just push the wrapping threshold back a bit rather than actually fixing it, but if a round's been going for more than 24 hours then there's probably bigger problems.

# Explain why it's good for the game

Less confusing for ghosted players.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

https://github.com/cmss13-devs/cmss13/assets/57483089/cdc88e6b-ff1d-4a5a-a04f-b6f7a8abf4c4

(Runtime is unrelated, something to do with the DB I think?)

</details>


# Changelog
:cl:
fix: Made the 'Time Since Death' counter show hours if it passes 1 hour, rather than wrapping the minutes back to 0.
/:cl:
