### PR TITLE
Fixes an exploit with Praetorian Oppressor hook

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/praetorian/praetorian_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/praetorian/praetorian_powers.dm
@@ -326,6 +326,8 @@
 	else if (LAZYLEN(targets) >= 3)
 		xeno.balloon_alert(xeno, "our tail catches and stuns [LAZYLEN(targets)] targets!", text_color = "#51a16c")
 
+	apply_cooldown()
+
 	for (var/mob/living/carbon/target in targets)
 		xeno.visible_message(SPAN_XENODANGER("\The [xeno]'s hooked tail coils itself around [target]!"), SPAN_XENODANGER("Our hooked tail coils itself around [target]!"))
 
@@ -359,7 +361,6 @@
 		qdel(tail_beam) // hook beam catches target, throws them back, is deleted (throw_atom has sleeps), then hook beam catches another target, repeat
 		addtimer(CALLBACK(src, /datum/action/xeno_action/activable/prae_abduct/proc/remove_tail_overlay, target, tail_image), 0.5 SECONDS) //needed so it can actually be seen as it gets deleted too quickly otherwise.
 
-	apply_cooldown()
 	return ..()
 
 /datum/action/xeno_action/activable/prae_abduct/proc/remove_tail_overlay(mob/living/carbon/human/overlayed_human, image/tail_image)


### PR DESCRIPTION

# About the pull request

The cooldown was not applied until after `throw_atom()` which sleeps was operated on which allowed a brief but usable window to cast the ability twice if we hit something. We now apply cooldown before we start throwing atoms around so this is no longer possible.

![dreamseeker_2024-01-03_21-58-31](https://github.com/cmss13-devs/cmss13/assets/25027759/cb0b3662-4a1d-4fd5-8e38-6e41c8229f80)
![dreamseeker_2024-01-03_22-01-19](https://github.com/cmss13-devs/cmss13/assets/25027759/e2bf14b5-df0b-428b-be5f-e67a5956a794)

# Explain why it's good for the game
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Fixed exploit in praetorian hook caused by an oversight.
/:cl:
