### PR TITLE
removes double APC in trijent dam security and on engi east tunnel entrance

### DIFF
--- a/maps/map_files/DesertDam/Desert_Dam.dmm
+++ b/maps/map_files/DesertDam/Desert_Dam.dmm
@@ -9512,14 +9512,6 @@
 	icon_state = "desert_transition_edge1"
 	},
 /area/desert_dam/exterior/valley/valley_crashsite)
-"aCH" = (
-/obj/structure/machinery/power/apc{
-	dir = 1;
-	pixel_y = 24;
-	start_charge = 0
-	},
-/turf/open/floor/interior/wood/alt,
-/area/desert_dam/interior/dam_interior/east_tunnel_entrance)
 "aCI" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/interior/wood/alt,
@@ -86399,7 +86391,7 @@ dTs
 dTs
 dTs
 aEa
-aCH
+aCJ
 aCI
 aDh
 aCJ

--- a/maps/map_files/DesertDam/Desert_Dam.dmm
+++ b/maps/map_files/DesertDam/Desert_Dam.dmm
@@ -25382,17 +25382,6 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/interior/wood,
 /area/desert_dam/building/security/courtroom)
-"bBU" = (
-/obj/structure/machinery/power/apc{
-	dir = 8;
-	pixel_x = -30;
-	start_charge = 0
-	},
-/turf/open/floor/prison{
-	dir = 8;
-	icon_state = "darkred2"
-	},
-/area/desert_dam/building/security/southern_hallway)
 "bBV" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
@@ -76387,7 +76376,7 @@ bsS
 bvy
 bsS
 bsS
-bBU
+bsS
 bFr
 aQH
 bIX


### PR DESCRIPTION
# About the pull request
![image](https://github.com/cmss13-devs/cmss13/assets/54422837/a3434bc0-5c61-4a7a-9cbb-209b535e8e79)
to
![image](https://github.com/cmss13-devs/cmss13/assets/54422837/a01b410e-d6c9-4ffe-8ff9-df9456c5ad3d)

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Rooms aren't supposed to have 2 APCs(?)
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Trijent security southern hallway and engineering east tunnel no longer have 2 APCs
/:cl:
