### PR TITLE
changes the runner pounce tip to be more accurate

### DIFF
--- a/strings/xenotips.txt
+++ b/strings/xenotips.txt
@@ -24,7 +24,7 @@ If you have difficulty clicking marines, try using Directional Slashing, though 
 You can diagonally pounce through the corners of fire as a Lurker or Runner without getting ignited.
 When playing as Xeno, consider aiming at the limbs instead of the chest. Marine armor doesn't protect the arms and legs as well as it does the body.
 As Xeno, you can break Night-Vision goggles that some marines wear on their helmets. Just aim for the head and slash until the goggles shatter.
-Pounces are ineffective on marines who are laying down.
+You can dodge pounces that aren't aimed directly at you by laying down.
 You may rest immediately during a pounce to pounce straight through mobs. It's not very practical or useful though.
 Pouncing someone who is buckled to a chair will still stun them, but you won't jump into their tile and they will not be knocked to the ground.
 Star shell dust from said grenades is just as meltable as normal flares.


### PR DESCRIPTION

# About the pull request

Pounces are ineffective on marines who are laying down. -> You can dodge pounces that aren't aimed directly at you by laying down.




# Explain why it's good for the game

the tip isn't actually true because runners CAN pounce marines that are resting, but **only** if the pounce is a spriteclick.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
spellcheck: Changed a tip related to runner pounce to be more accurate
/:cl:
