### PR TITLE
Makes the `do_after()` icon render above everything else

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -933,86 +933,103 @@ GLOBAL_DATUM(action_purple_power_up, /image)
 		if(!GLOB.busy_indicator_clock)
 			GLOB.busy_indicator_clock = image('icons/mob/mob.dmi', null, "busy_generic", "pixel_y" = 22)
 			GLOB.busy_indicator_clock.layer = FLY_LAYER
+			GLOB.busy_indicator_clock.plane = ABOVE_HUD_PLANE
 		return GLOB.busy_indicator_clock
 	else if(busy_type == BUSY_ICON_MEDICAL)
 		if(!GLOB.busy_indicator_medical)
 			GLOB.busy_indicator_medical = image('icons/mob/mob.dmi', null, "busy_medical", "pixel_y" = 0) //This shows directly on top of the mob, no offset!
 			GLOB.busy_indicator_medical.layer = FLY_LAYER
+			GLOB.busy_indicator_medical.plane = ABOVE_HUD_PLANE
 		return GLOB.busy_indicator_medical
 	else if(busy_type == BUSY_ICON_BUILD)
 		if(!GLOB.busy_indicator_build)
 			GLOB.busy_indicator_build = image('icons/mob/mob.dmi', null, "busy_build", "pixel_y" = 22)
 			GLOB.busy_indicator_build.layer = FLY_LAYER
+			GLOB.busy_indicator_build.plane = ABOVE_HUD_PLANE
 		return GLOB.busy_indicator_build
 	else if(busy_type == BUSY_ICON_FRIENDLY)
 		if(!GLOB.busy_indicator_friendly)
 			GLOB.busy_indicator_friendly = image('icons/mob/mob.dmi', null, "busy_friendly", "pixel_y" = 22)
 			GLOB.busy_indicator_friendly.layer = FLY_LAYER
+			GLOB.busy_indicator_friendly.plane = ABOVE_HUD_PLANE
 		return GLOB.busy_indicator_friendly
 	else if(busy_type == BUSY_ICON_HOSTILE)
 		if(!GLOB.busy_indicator_hostile)
 			GLOB.busy_indicator_hostile = image('icons/mob/mob.dmi', null, "busy_hostile", "pixel_y" = 22)
 			GLOB.busy_indicator_hostile.layer = FLY_LAYER
+			GLOB.busy_indicator_hostile.plane = ABOVE_HUD_PLANE
 		return GLOB.busy_indicator_hostile
 	else if(busy_type == EMOTE_ICON_HIGHFIVE)
 		if(!GLOB.emote_indicator_highfive)
 			GLOB.emote_indicator_highfive = image('icons/mob/mob.dmi', null, "emote_highfive", "pixel_y" = 22)
 			GLOB.emote_indicator_highfive.layer = FLY_LAYER
+			GLOB.emote_indicator_highfive.plane = ABOVE_HUD_PLANE
 		return GLOB.emote_indicator_highfive
 	else if(busy_type == EMOTE_ICON_FISTBUMP)
 		if(!GLOB.emote_indicator_fistbump)
 			GLOB.emote_indicator_fistbump = image('icons/mob/mob.dmi', null, "emote_fistbump", "pixel_y" = 22)
 			GLOB.emote_indicator_fistbump.layer = FLY_LAYER
+			GLOB.emote_indicator_fistbump.plane = ABOVE_HUD_PLANE
 		return GLOB.emote_indicator_fistbump
 	else if(busy_type == EMOTE_ICON_ROCK_PAPER_SCISSORS)
 		if(!GLOB.emote_indicator_rock_paper_scissors)
 			GLOB.emote_indicator_rock_paper_scissors = image('icons/mob/mob.dmi', null, "emote_rps", "pixel_y" = 22)
 			GLOB.emote_indicator_rock_paper_scissors.layer = FLY_LAYER
+			GLOB.emote_indicator_rock_paper_scissors.plane = ABOVE_HUD_PLANE
 		return GLOB.emote_indicator_rock_paper_scissors
 	else if(busy_type == EMOTE_ICON_ROCK)
 		if(!GLOB.emote_indicator_rock)
 			GLOB.emote_indicator_rock = image('icons/mob/mob.dmi', null, "emote_rock", "pixel_y" = 22)
 			GLOB.emote_indicator_rock.layer = FLY_LAYER
+			GLOB.emote_indicator_rock.plane = ABOVE_HUD_PLANE
 		return GLOB.emote_indicator_rock
 	else if(busy_type == EMOTE_ICON_PAPER)
 		if(!GLOB.emote_indicator_paper)
 			GLOB.emote_indicator_paper = image('icons/mob/mob.dmi', null, "emote_paper", "pixel_y" = 22)
 			GLOB.emote_indicator_paper.layer = FLY_LAYER
+			GLOB.emote_indicator_paper.plane = ABOVE_HUD_PLANE
 		return GLOB.emote_indicator_paper
 	else if(busy_type == EMOTE_ICON_SCISSORS)
 		if(!GLOB.emote_indicator_scissors)
 			GLOB.emote_indicator_scissors = image('icons/mob/mob.dmi', null, "emote_scissors", "pixel_y" = 22)
 			GLOB.emote_indicator_scissors.layer = FLY_LAYER
+			GLOB.emote_indicator_scissors.plane = ABOVE_HUD_PLANE
 		return GLOB.emote_indicator_scissors
 	else if(busy_type == EMOTE_ICON_HEADBUTT)
 		if(!GLOB.emote_indicator_headbutt)
 			GLOB.emote_indicator_headbutt = image('icons/mob/mob.dmi', null, "emote_headbutt", "pixel_y" = 22)
 			GLOB.emote_indicator_headbutt.layer = FLY_LAYER
+			GLOB.emote_indicator_headbutt.plane = ABOVE_HUD_PLANE
 		return GLOB.emote_indicator_headbutt
 	else if(busy_type == EMOTE_ICON_TAILSWIPE)
 		if(!GLOB.emote_indicator_tailswipe)
 			GLOB.emote_indicator_tailswipe = image('icons/mob/mob.dmi', null, "emote_tailswipe", "pixel_y" = 22)
 			GLOB.emote_indicator_tailswipe.layer = FLY_LAYER
+			GLOB.emote_indicator_tailswipe.plane = ABOVE_HUD_PLANE
 		return GLOB.emote_indicator_tailswipe
 	else if(busy_type == ACTION_RED_POWER_UP)
 		if(!GLOB.action_red_power_up)
 			GLOB.action_red_power_up = image('icons/effects/effects.dmi', null, "anger", "pixel_x" = 16)
 			GLOB.action_red_power_up.layer = FLY_LAYER
+			GLOB.action_red_power_up.plane = ABOVE_HUD_PLANE
 		return GLOB.action_red_power_up
 	else if(busy_type == ACTION_GREEN_POWER_UP)
 		if(!GLOB.action_green_power_up)
 			GLOB.action_green_power_up = image('icons/effects/effects.dmi', null, "vitality", "pixel_x" = 16)
 			GLOB.action_green_power_up.layer = FLY_LAYER
+			GLOB.action_green_power_up.plane = ABOVE_HUD_PLANE
 		return GLOB.action_green_power_up
 	else if(busy_type == ACTION_BLUE_POWER_UP)
 		if(!GLOB.action_blue_power_up)
 			GLOB.action_blue_power_up = image('icons/effects/effects.dmi', null, "shock", "pixel_x" = 16)
 			GLOB.action_blue_power_up.layer = FLY_LAYER
+			GLOB.action_blue_power_up.plane = ABOVE_HUD_PLANE
 		return GLOB.action_blue_power_up
 	else if(busy_type == ACTION_PURPLE_POWER_UP)
 		if(!GLOB.action_purple_power_up)
 			GLOB.action_purple_power_up = image('icons/effects/effects.dmi', null, "pain", "pixel_x" = 16)
 			GLOB.action_purple_power_up.layer = FLY_LAYER
+			GLOB.action_purple_power_up.plane = ABOVE_HUD_PLANE
 		return GLOB.action_purple_power_up
 
 


### PR DESCRIPTION

# About the pull request

Makes the `do_after()` progress icons always render above everything else. (Other than screentext and cinematics)

# Explain why it's good for the game

The icon can occasionally be blocked be something on the tile above the player, leading to other players moving you around when you're splinting or performing CPR, for example.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

**Before:**
![before](https://github.com/cmss13-devs/cmss13/assets/57483089/65cd1d80-a272-4e3d-9c9d-a041c1cec133)

**After:**
![after](https://github.com/cmss13-devs/cmss13/assets/57483089/c6de98b9-0909-4596-9287-1877b172b3b7)

</details>


# Changelog
:cl:
fix: Fixed the 'busy' circle icon sometimes rendering behind object on the tile above.
/:cl:
