### PR TITLE
Fixes donor helmets not having an accessory slot

### DIFF
--- a/code/modules/cm_marines/Donator_Items.dm
+++ b/code/modules/cm_marines/Donator_Items.dm
@@ -17,7 +17,7 @@
 	flags_inv_hide = HIDEEARS
 	flags_atom = FPRINT|CONDUCT|NO_NAME_OVERRIDE|NO_SNOW_TYPE
 	min_cold_protection_temperature = ICE_PLANET_MIN_COLD_PROT
-	flags_marine_helmet = NO_FLAGS
+	flags_marine_helmet = HELMET_GARB_OVERLAY
 
 /obj/item/clothing/head/helmet/marine/fluff/verb/toggle_squad_markings()
 	set src in usr


### PR DESCRIPTION
# About the pull request

Fixes donor helmets not having an accessory slot by making have the garb overlay on by default. Before this fix, Initialization code essentially removes that accessory slot as soon as the helmet is loaded in as the helmet lacks garb overlay.

# Explain why it's good for the game

Let them have that slot.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Fixed donor helmets not having an accessory slot.
/:cl:
