### PR TITLE
Fixes runtime in fruit.dm

### DIFF
--- a/code/modules/cm_aliens/structures/fruit.dm
+++ b/code/modules/cm_aliens/structures/fruit.dm
@@ -403,7 +403,8 @@
 	if(cant_consume)
 		user.affected_message(affected_xeno,
 			SPAN_HELPFUL("You <b>fail to [user == affected_xeno ? "eat" : "feed [affected_xeno]"] [current_fruit]</b>."),
-			SPAN_HELPFUL("[user] <b>fails to feed</b> you <b>[current_fruit]</b>."))
+			SPAN_HELPFUL("[user] <b>fails to feed</b> you <b>[current_fruit]</b>."),
+			SPAN_NOTICE("[user] fails to [user == affected_xeno ? "eat" : "feed [affected_xeno]"] [current_fruit]."))
 		return
 	user.affected_message(affected_xeno,
 		SPAN_HELPFUL("You <b>start [user == affected_xeno ? "eating" : "feeding [affected_xeno]"] [current_fruit]</b>."),
@@ -417,7 +418,8 @@
 	if(cant_consume) //Check again after the timer incase they ate another fruit
 		user.affected_message(affected_xeno,
 			SPAN_HELPFUL("You <b>fail to [user == affected_xeno ? "eat" : "feed [affected_xeno]"] [current_fruit]</b>."),
-			SPAN_HELPFUL("[user] <b>fails to feed</b> you <b>[current_fruit]</b>."))
+			SPAN_HELPFUL("[user] <b>fails to feed</b> you <b>[current_fruit]</b>."),
+			SPAN_NOTICE("[user] fails to [user == affected_xeno ? "eat" : "feed [affected_xeno]"] [current_fruit]."))
 		return
 
 	user.affected_message(affected_xeno,


### PR DESCRIPTION

# About the pull request

`affected_message()` should take four arguments in these two cases `message_viewer` was missing and would pass null which runtimes `to_chat()`

```
[2024-01-04 14:16:27.696] runtime error: Empty or null string in to_chat proc call.
 - proc name: to chat (/proc/to_chat)
 -   source file: code/modules/tgchat/to_chat.dm,89
 -   usr: Ancient Praetorian (L-725) (/mob/living/carbon/xenomorph/praetorian)
 -   src: null
 -   usr.loc: the floor (96,80,2) (/turf/open/floor)
 -   call stack:
 - to chat(Prime Defender (XX-410) (/mob/living/carbon/xenomorph/defender), "", null, "", 0, 1, 1, 0)
 - Prime Defender (XX-410) (/mob/living/carbon/xenomorph/defender): show message(null, 1, null, null, 0)
 - Ancient Praetorian (L-725) (/mob/living/carbon/xenomorph/praetorian): affected message(Ancient Praetorian (L-725) (/mob/living/carbon/xenomorph/praetorian), "<span class=\'helpful\'>You <b...", "<span class=\'helpful\'>Ancien...", null)
 - Greater Resin Fruit (/obj/item/reagent_container/food/snacks/resin_fruit/greater): attack(Ancient Praetorian (L-725) (/mob/living/carbon/xenomorph/praetorian), Ancient Praetorian (L-725) (/mob/living/carbon/xenomorph/praetorian))
 - Ancient Praetorian (L-725) (/mob/living/carbon/xenomorph/praetorian): attackby(Greater Resin Fruit (/obj/item/reagent_container/food/snacks/resin_fruit/greater), Ancient Praetorian (L-725) (/mob/living/carbon/xenomorph/praetorian), /list (/list))
 - Ancient Praetorian (L-725) (/mob/living/carbon/xenomorph/praetorian): attackby(Greater Resin Fruit (/obj/item/reagent_container/food/snacks/resin_fruit/greater), Ancient Praetorian (L-725) (/mob/living/carbon/xenomorph/praetorian), /list (/list))
 - Ancient Praetorian (L-725) (/mob/living/carbon/xenomorph/praetorian): click adjacent(Ancient Praetorian (L-725) (/mob/living/carbon/xenomorph/praetorian), Greater Resin Fruit (/obj/item/reagent_container/food/snacks/resin_fruit/greater), /list (/list))
 - Ancient Praetorian (L-725) (/mob/living/carbon/xenomorph/praetorian): do click(Ancient Praetorian (L-725) (/mob/living/carbon/xenomorph/praetorian), the floor (96,80,2) (/turf/open/floor), "icon-x=38;icon-y=18;left=1;but...")
 - **** (/client): Click(Ancient Praetorian (L-725) (/mob/living/carbon/xenomorph/praetorian), the floor (96,80,2) (/turf/open/floor), "mapwindow.map", "icon-x=38;icon-y=18;left=1;but...")
```

# Explain why it's good for the game
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Runtime when consuming xeno fruits.
/:cl:
