### PR TITLE
Makes the bipod HPR switch you to full auto when deployed

### DIFF
--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -3369,6 +3369,8 @@ Defined in conflicts.dm of the #defines folder.
 
 				if(G.flags_gun_features & GUN_SUPPORT_PLATFORM)
 					G.add_firemode(GUN_FIREMODE_AUTOMATIC)
+					//Automatically switch us to full auto.
+					G.do_toggle_firemode(user, null, GUN_FIREMODE_AUTOMATIC)
 
 				if(heavy_bipod)
 					user.anchored = TRUE


### PR DESCRIPTION

# About the pull request

Deploying the bipod with a HPR immediately switches you to full auto.

# Explain why it's good for the game

There is very little reason to stick to single fire or burst fire when you deploy the bipod on a HPR. Some people might not even know it exists. Automatically switching to full auto will save the user a couple of button presses and remove needless frustration.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>



https://github.com/cmss13-devs/cmss13/assets/17518895/615a7863-8a78-4759-a5cc-39d428cce3d7


# Changelog
:cl:
qol: Deploying the bipod on a HPR will now immediately switch you to full auto.
/:cl:
