### PR TITLE
Fixes the CLs office Posters and a Pinup Poster which was in the wrong category

### DIFF
--- a/code/game/objects/effects/decals/posters.dm
+++ b/code/game/objects/effects/decals/posters.dm
@@ -160,14 +160,14 @@
 	icon_state = "poster3"
 
 /obj/structure/sign/poster/music/Initialize()
-	serial_number = pick(3,5,25,26,29,38,39)
+	serial_number = pick(3,5,25,26,38,39)
 	.=..()
 
 /obj/structure/sign/poster/pinup
 	icon_state = "poster12"
 
 /obj/structure/sign/poster/pinup/Initialize()
-	serial_number = pick(12,16,17)
+	serial_number = pick(12,16,17,29)
 	.=..()
 
 /obj/structure/sign/poster/propaganda

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -13828,10 +13828,7 @@
 /obj/structure/machinery/photocopier{
 	anchored = 0
 	},
-/obj/structure/sign/poster{
-	desc = "A large piece of cheap printed paper. This one proudly demands that you REMEMBER IO!";
-	icon_state = "poster14";
-	name = "propaganda poster";
+/obj/structure/sign/poster/art{
 	pixel_y = 32
 	},
 /turf/open/floor/wood/ship,
@@ -28870,13 +28867,8 @@
 /obj/structure/bed/chair{
 	dir = 1
 	},
-/obj/structure/sign/poster{
-	desc = "Koorlander Golds, lovingly machine rolled for YOUR pleasure.";
-	icon_state = "poster10";
-	name = "Koorlander Gold Poster";
-	pixel_x = 29;
-	pixel_y = 6;
-	serial_number = 10
+/obj/structure/sign/poster/ad{
+	pixel_x = 30
 	},
 /turf/open/floor/wood/ship,
 /area/almayer/command/corporateliaison)
@@ -30742,14 +30734,13 @@
 /turf/open/floor/almayer,
 /area/almayer/engineering/upper_engineering/port)
 "eNw" = (
-/obj/structure/machinery/atm{
-	name = "Weyland-Yutani Automatic Teller Machine";
-	pixel_y = 30
-	},
 /obj/structure/surface/table/almayer,
 /obj/item/spacecash/c1000/counterfeit,
 /obj/item/storage/box/drinkingglasses,
 /obj/item/storage/fancy/cigar,
+/obj/structure/machinery/atm{
+	pixel_y = 32
+	},
 /turf/open/floor/almayer,
 /area/almayer/command/corporateliaison)
 "eNx" = (
@@ -37220,14 +37211,11 @@
 /obj/structure/flora/pottedplant{
 	icon_state = "pottedplant_21"
 	},
-/obj/structure/sign/poster{
-	desc = "A large piece of cheap printed paper. This one proudly demands that you REMEMBER IO!";
-	icon_state = "poster14";
-	name = "propaganda poster";
-	pixel_y = 32
-	},
 /obj/structure/sign/safety/escapepod{
 	pixel_x = -17
+	},
+/obj/structure/sign/poster/hero/voteno{
+	pixel_y = 32
 	},
 /turf/open/floor/wood/ship,
 /area/almayer/command/corporateliaison)
@@ -67519,7 +67507,7 @@
 /area/almayer/command/cic)
 "sSP" = (
 /obj/structure/flora/pottedplant{
-	icon_state = "pottedplant_21"
+	icon_state = "pottedplant_29"
 	},
 /turf/open/floor/wood/ship,
 /area/almayer/command/corporateliaison)
@@ -70165,17 +70153,12 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/hangar)
 "tQM" = (
-/obj/structure/sign/poster{
-	desc = "One of those hot, tanned babes back the beaches of good ol' Earth.";
-	icon_state = "poster12";
-	name = "Beach Babe Pinup";
-	pixel_x = -30;
-	pixel_y = 6;
-	serial_number = 12
-	},
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
 	pixel_x = 1
+	},
+/obj/structure/sign/poster/pinup{
+	pixel_x = -30
 	},
 /turf/open/floor/almayer{
 	icon_state = "dark_sterile"


### PR DESCRIPTION

# About the pull request

Title says it all apart from the new plant and the ATM change in the CLs office aswell, just a QOL change.

# Explain why it's good for the game

PROUDLY REMEMBER IO! Posters were a bug which was fixed, until a PR reverted that change. I fixed it again.

Pinup poster being wrong is also fixed.

Added a cactus in the stead of a basic plant in the CLs office because the sprite looks cool.

Changed the ATM Machine in the CLs office purely because the name was a useless mapedit which annoyed me.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
qol: Spruced up the CLs office by adding a new plant, changing the stuck posters to be random every round
fix: Fixed the ATM Machine in the CLs office having Weyland-Yutani Automatic Teller Machine and not Wey-Yu. Same thing, useless mapedit.
fix: Fixes the PROUDLY REMEMBER IO! Posters in the CLs office (Again)
fix: Puts the 29th Poster which was a pinup into the pinup posters and not the music ones.
/:cl:
