### PR TITLE
adds mindbreaker toxin to hostile carp meat / zombie meat

### DIFF
--- a/code/game/objects/items/reagent_containers/food/snacks.dm
+++ b/code/game/objects/items/reagent_containers/food/snacks.dm
@@ -634,9 +634,17 @@
 
 /obj/item/reagent_container/food/snacks/carpmeat
 	name = "carp fillet"
-	desc = "A fillet of spess carp meat"
+	desc = "A fillet of spess carp meat" // space?
 	icon_state = "fishfillet"
 	filling_color = "#FFDEFE"
+
+/obj/item/reagent_container/food/snacks/carpmeat/space_carp
+	name = "space carp fillet"
+	desc = "A fillet of carp meat, it smells rather strange..."
+
+/obj/item/reagent_container/food/snacks/carpmeat/space_carp/Initialize()
+	. = ..()
+	reagents.add_reagent("mindbreaker",  5)
 
 /obj/item/reagent_container/food/snacks/carpmeat/Initialize()
 	. = ..()

--- a/code/game/objects/items/reagent_containers/food/snacks/meat.dm
+++ b/code/game/objects/items/reagent_containers/food/snacks/meat.dm
@@ -42,6 +42,17 @@
 	name = "human meat"
 	desc = "A slab of flesh for cannibals."
 
+/obj/item/reagent_container/food/snacks/meat/human/zombie
+	name = "zombie meat"
+	desc = "A slab of zombie flesh. Looks rather tasty"
+	icon_state = "xenomeat" // it fits, let it slide.
+	filling_color = "#43DE18"
+
+/obj/item/reagent_container/food/snacks/meat/human/zombie/Initialize()
+	. = ..()
+	reagents.add_reagent("blackgoo", 30)
+	reagents.add_reagent("mindbreaker", 5)
+
 /obj/item/reagent_container/food/snacks/meat/monkey
 	//same as plain meat
 

--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -9,7 +9,7 @@
 	icon_gib = "carp_gib"
 	speak_chance = 0
 	turns_per_move = 5
-	meat_type = /obj/item/reagent_container/food/snacks/carpmeat
+	meat_type = /obj/item/reagent_container/food/snacks/carpmeat/space_carp
 	response_help = "pets the"
 	response_disarm = "gently pushes aside the"
 	response_harm = "hits the"


### PR DESCRIPTION
# About the pull request
Hostile carp now has a new subtyped meat that when eaten gets you high. Zombies can now also be gibbed and have their meat eaten, which also gets you high and then gives you the black goo.

# Explain why it's good for the game
It's funny. When it comes to balance it takes roughly thirty seconds to gib a zombie plus the time it takes to drag it to the gibber. I highly doubt it would cause a significant game balance issue and considering zombie rounds are never balanced to begin with it probably won't detract from the gamemode and is a fun little feature. All carpmeat that isn't directly from the primitive hostile carp mob will not get you high and is the exact same as before.

# Todo
Add a new status effect called cannibalism. Eating human flesh will now cause symptoms of insanity for the full duration of the round. I would like this approved before implementation.


:cl:
add: adds mindbreaker toxin to hostile carp fillet
add: adds the ability to gib and eat zombie meat through the kitchen gibber
/:cl:

