### PR TITLE
Fixes tgchat regex

### DIFF
--- a/tgui/packages/tgui-panel/chat/renderer.js
+++ b/tgui/packages/tgui-panel/chat/renderer.js
@@ -235,6 +235,8 @@ class ChatRenderer {
           highlightWords.push(line);
         }
       }
+      const regexStr = regexExpressions.join('|');
+      const flags = 'g' + (matchCase ? '' : 'i');
       // We wrap this in a try-catch to ensure that broken regex doesn't break
       // the entire chat.
       try {


### PR DESCRIPTION
# About the pull request

close #5232

# Changelog

:cl:
fix: Regular expressions in chat highlights work again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
