### PR TITLE
Fixes tunnels not showing on the minimap

### DIFF
--- a/code/modules/cm_aliens/structures/tunnel.dm
+++ b/code/modules/cm_aliens/structures/tunnel.dm
@@ -48,8 +48,10 @@
 	if(resin_trap)
 		qdel(resin_trap)
 
-		if(hivenumber == XENO_HIVE_NORMAL)
-			RegisterSignal(SSdcs, COMSIG_GLOB_GROUNDSIDE_FORSAKEN_HANDLING, PROC_REF(forsaken_handling))
+	if(hivenumber == XENO_HIVE_NORMAL)
+		RegisterSignal(SSdcs, COMSIG_GLOB_GROUNDSIDE_FORSAKEN_HANDLING, PROC_REF(forsaken_handling))
+
+	SSminimaps.add_marker(src, z, get_minimap_flag_for_faction(hivenumber), "xenotunnel")
 
 /obj/structure/tunnel/proc/forsaken_handling()
 	SIGNAL_HANDLER
@@ -61,8 +63,6 @@
 		hive.tunnels += src
 
 	UnregisterSignal(SSdcs, COMSIG_GLOB_GROUNDSIDE_FORSAKEN_HANDLING)
-
-	SSminimaps.add_marker(src, z, get_minimap_flag_for_faction(hivenumber), "xenotunnel")
 
 /obj/structure/tunnel/Destroy()
 	if(hive)


### PR DESCRIPTION

# About the pull request

Fixes tunnels not showing on the minimap for xenos and observers.
Also fixes tunnels not having forsaken handling unless they were placed on top of a resin trap.

It was just a small indentation/positioning error in #5394.

# Explain why it's good for the game

ˈfɪksɪz

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

**Before:**
![dreamseeker_ruDebdbg8W](https://github.com/cmss13-devs/cmss13/assets/57483089/61a2c4a7-1c4e-4341-8525-e313b32f45ea)

**After:**
![dreamseeker_fDSFTLzkHW](https://github.com/cmss13-devs/cmss13/assets/57483089/08f31a8e-5f05-4942-a5fb-904e601d689c)


</details>


# Changelog
:cl:
fix: Fixed tunnels not showing on the minimap.
/:cl:
