### PR TITLE
Fixes stack of flags anchoring after placing one down

### DIFF
--- a/code/game/objects/items/stacks/flags.dm
+++ b/code/game/objects/items/stacks/flags.dm
@@ -71,7 +71,7 @@
 	var/obj/item/stack/flag/newflag = new src.type(T)
 	newflag.amount = 1
 	newflag.upright = TRUE
-	anchored = TRUE
+	newflag.anchored = TRUE
 	newflag.name = newflag.singular_name
 	newflag.icon_state = "[newflag.base_state]_open"
 	newflag.visible_message("<b>[user]</b> plants [newflag] firmly in the ground.")


### PR DESCRIPTION
# About the pull request

Currently, when you put down a flag, the stack of flags in your hand becomes anchored instead of the placed down flag. Fixes #5145

# Explain why it's good for the game

The actual flag gets anchored, not the stack of flags in your hands.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

https://github.com/cmss13-devs/cmss13/assets/49321394/fb9092a5-9c2e-4d86-a591-e9f793a62a2e

</details>


# Changelog

:cl:
fix: Placing flags now anchors the actual flag, not the stack of flags in your hand.
/:cl: