### PR TITLE
Adds three new zippo lighters in the code

### DIFF
--- a/code/game/objects/items/tools/flame_tools.dm
+++ b/code/game/objects/items/tools/flame_tools.dm
@@ -721,6 +721,22 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 
 		log_admin("[user] has engraved \the [src] with engraving \"[str]\". (CKEY: ([user.ckey]))")
 
+/obj/item/tool/lighter/zippo/black
+	name = "black Zippo lighter"
+	desc = "A fancy black Zippo lighter. Ignite in style."
+	icon_state = "blackzippo"
+	item_state = "blackzippo"
+	icon_on = "blackzippoon"
+	icon_off = "blackzippo"
+
+/obj/item/tool/lighter/zippo/blue
+	name = "blue Zippo lighter"
+	desc = "A fancy blue Zippo lighter. Ignite in style."
+	icon_state = "bluezippo"
+	item_state = "bluezippo"
+	icon_on = "bluezippoon"
+	icon_off = "bluezippo"
+
 /obj/item/tool/lighter/zippo/gold
 	name = "golden Zippo lighter"
 	desc = "A gold-anodized Zippo lighter. Ostentatious, but it certainly stands out."
@@ -729,6 +745,15 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	icon_on = "goldzippoon"
 	icon_off = "goldzippo"
 	black_market_value = 30
+
+/obj/item/tool/lighter/zippo/executive
+	name = "Weyland-Yutani executive Zippo lighter"
+	desc = "A remarkable Zippo lighter embellished in the Company's black and gold shade."
+	icon_state = "execzippo"
+	item_state = "execzippo"
+	icon_on = "execzippoon"
+	icon_off = "execzippo"
+	black_market_value = 40
 
 /obj/item/tool/lighter/random
 

--- a/code/modules/client/preferences_gear.dm
+++ b/code/modules/client/preferences_gear.dm
@@ -863,6 +863,14 @@ GLOBAL_LIST_EMPTY(gear_datums_by_name)
 	display_name = "Lighter, zippo"
 	path = /obj/item/tool/lighter/zippo
 
+/datum/gear/smoking/zippo/black
+	display_name = "Black lighter, zippo"
+	path = /obj/item/tool/lighter/zippo/black
+
+/datum/gear/smoking/zippo/blue
+	display_name = "Blue lighter, zippo"
+	path = /obj/item/tool/lighter/zippo/blue
+
 /datum/gear/smoking/electronic_cigarette
 	display_name = "Electronic cigarette"
 	path = /obj/item/clothing/mask/electronic_cigarette
@@ -891,7 +899,7 @@ GLOBAL_LIST_EMPTY(gear_datums_by_name)
 /datum/gear/misc/facepaint_skull
 	display_name = "Facepaint, skull"
 	path = /obj/item/facepaint/skull
-	cost = 3 
+	cost = 3
 
 /datum/gear/misc/facepaint_body
 	display_name = "Fullbody paint"

--- a/maps/map_files/New_Varadero/New_Varadero.dmm
+++ b/maps/map_files/New_Varadero/New_Varadero.dmm
@@ -6074,10 +6074,7 @@
 	pixel_x = -7;
 	pixel_y = 8
 	},
-/obj/item/tool/lighter/zippo{
-	icon_off = "blackzippo";
-	icon_on = "blackzippoon";
-	icon_state = "blackzippo";
+/obj/item/tool/lighter/zippo/black{
 	pixel_x = -5;
 	pixel_y = 7
 	},


### PR DESCRIPTION

# About the pull request

Adds a black, blue and Wey-Yu Zippo Lighter to the code.

Adds the black and blue variant to the gear select menu next to the normal zippo.

# Explain why it's good for the game

We have these sprites and they aren't used, I don't see what's wrong with a bit of variety in zippos apart from the normal and the golden one.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Added three new Zippo Lighter sprites into the code.
add: Added black and blue variants to the gear pref menu.
fix: fixed the NV Zippo Lighter being black.
/:cl:
