### PR TITLE
removes click delay when interacting with botany trays

### DIFF
--- a/code/modules/hydroponics/hydro_tray.dm
+++ b/code/modules/hydroponics/hydro_tray.dm
@@ -499,6 +499,7 @@
 	return
 
 /obj/structure/machinery/portable_atmospherics/hydroponics/attackby(obj/item/O as obj, mob/user as mob)
+	user.next_move = world.time
 
 	if (O.is_open_container())
 		return 0
@@ -675,6 +676,7 @@
 	return info
 
 /obj/structure/machinery/portable_atmospherics/hydroponics/attack_hand(mob/user as mob)
+	user.next_move = world.time
 
 	if(istype(user, /mob/living/silicon))
 		return


### PR DESCRIPTION

# About the pull request

removes click delay when interacting with botany trays

# Explain why it's good for the game

quality of life
botany is now less painful

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
qol: Interacting with hydroponic trays no longer gives you a click delay.
/:cl:
