### PR TITLE
Maximum Limit to Sticky Resin

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/resin_constructions.dm
+++ b/code/modules/mob/living/carbon/xenomorph/resin_constructions.dm
@@ -239,6 +239,7 @@ GLOBAL_VAR_INIT(resin_lz_allowed, FALSE)
 	construction_name = "sticky resin"
 	cost = XENO_RESIN_STICKY_COST
 	build_time = 1 SECONDS
+	max_per_xeno = 50
 
 	build_path = /obj/effect/alien/resin/sticky
 


### PR DESCRIPTION

# About the pull request

Caps Sticky Resin to 50 per xeno.  

# Explain why it's good for the game

50x50 wide fields of sticky+node is obnoxious to deal with both as a marine moving through it, and as a builder who has to tear down the field to be able to build walls.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: Max Deployable Sticky Resin set to 50.
/:cl:
