### PR TITLE
Allows for trailing or leading whitespace in VV edits

### DIFF
--- a/code/modules/admin/view_variables/get_variables.dm
+++ b/code/modules/admin/view_variables/get_variables.dm
@@ -121,12 +121,12 @@
 
 	switch(.["class"])
 		if(VV_TEXT)
-			.["value"] = tgui_input_text(usr, "Enter new text:", "Text", current_value, encode = FALSE)
+			.["value"] = tgui_input_text(usr, "Enter new text:", "Text", current_value, encode = FALSE, trim = FALSE)
 			if(.["value"] == null)
 				.["class"] = null
 				return
 		if(VV_MESSAGE)
-			.["value"] = tgui_input_text(usr, "Enter new text:", "Text", current_value, encode = FALSE)
+			.["value"] = tgui_input_text(usr, "Enter new text:", "Text", current_value, encode = FALSE, trim = FALSE)
 			if(.["value"] == null)
 				.["class"] = null
 				return

--- a/code/modules/tgui_input/text.dm
+++ b/code/modules/tgui_input/text.dm
@@ -14,8 +14,9 @@
  * * multiline -  Bool that determines if the input box is much larger. Good for large messages, laws, etc.
  * * encode - Toggling this determines if input is filtered via html_encode. Setting this to FALSE gives raw input.
  * * timeout - The timeout of the textbox, after which the modal will close and qdel itself. Set to zero for no timeout.
+ * * trim - Whether or not to trim leading and trailing whitespace from your input. Defaults to TRUE
  */
-/proc/tgui_input_text(mob/user, message = "", title = "Text Input", default, max_length = MAX_MESSAGE_LEN, multiline = FALSE, encode = TRUE, timeout = 0)
+/proc/tgui_input_text(mob/user, message = "", title = "Text Input", default, max_length = MAX_MESSAGE_LEN, multiline = FALSE, encode = TRUE, timeout = 0, trim = TRUE)
 	if (!user)
 		user = usr
 	if (!istype(user))
@@ -39,7 +40,7 @@
 				return input(user, message, title, default) as text|null
 	*/
 
-	var/datum/tgui_input_text/text_input = new(user, message, title, default, max_length, multiline, encode, timeout)
+	var/datum/tgui_input_text/text_input = new(user, message, title, default, max_length, multiline, encode, timeout, trim)
 	text_input.tgui_interact(user)
 	text_input.wait()
 	if (text_input)
@@ -73,14 +74,17 @@
 	var/timeout
 	/// The title of the TGUI window
 	var/title
+	/// Whether to trim leading and trailing spaces
+	var/trim
 
-/datum/tgui_input_text/New(mob/user, message, title, default, max_length, multiline, encode, timeout)
+/datum/tgui_input_text/New(mob/user, message, title, default, max_length, multiline, encode, timeout, trim)
 	src.default = default
 	src.encode = encode
 	src.max_length = max_length
 	src.message = message
 	src.multiline = multiline
 	src.title = title
+	src.trim = trim
 	if (timeout)
 		src.timeout = timeout
 		start_time = world.time
@@ -141,7 +145,7 @@
 					CRASH("[usr] typed a text string longer than the max length")
 				if(encode && (length(html_encode(params["entry"])) > max_length))
 					to_chat(usr, SPAN_NOTICE("Your message was clipped due to special character usage."))
-			set_entry(params["entry"])
+			set_entry(params["entry"], trim)
 			closed = TRUE
 			SStgui.close_uis(src)
 			return TRUE
@@ -156,7 +160,10 @@
  * This can sometimes result in a string that is longer than the max length.
  * If the string is longer than the max length, it will be clipped.
  */
-/datum/tgui_input_text/proc/set_entry(entry)
+/datum/tgui_input_text/proc/set_entry(entry, trim)
 	if(!isnull(entry))
 		var/converted_entry = encode ? html_encode(entry) : entry
-		src.entry = trim(converted_entry, max_length)
+		if(trim)
+			src.entry = trim(converted_entry)
+		else
+			src.entry = converted_entry


### PR DESCRIPTION
# About the pull request

Removes trimming from VV edits for strings.
As a byproduct you can now provide the argument of `trim = FALSE` to `tgui_input_text()` to return untrimmed input.

# Explain why it's good for the game

VV editors shouldn't have the input box arbitrarily trim their leading or trailing whitespace from editing variables.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
code: Changing a string in VV no longer trims whitespace.
/:cl:
