### PR TITLE
remove all of machinery from distillery/main.dm from all the maps exept big red.

### DIFF
--- a/maps/map_files/DesertDam/Desert_Dam.dmm
+++ b/maps/map_files/DesertDam/Desert_Dam.dmm
@@ -12676,7 +12676,7 @@
 /turf/open/floor/plating,
 /area/desert_dam/exterior/valley/valley_crashsite)
 "aMk" = (
-/obj/structure/machinery/mill,
+/obj/structure/machinery/autolathe,
 /turf/open/floor/plating,
 /area/desert_dam/exterior/valley/valley_crashsite)
 "aMl" = (
@@ -29518,12 +29518,6 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/interior/dam_interior/workshop)
-"bPQ" = (
-/obj/structure/machinery/mill,
-/turf/open/floor/prison{
-	icon_state = "sterile_white"
-	},
-/area/desert_dam/interior/dam_interior/workshop)
 "bPR" = (
 /obj/structure/machinery/power/apc{
 	dir = 1;
@@ -30710,10 +30704,6 @@
 	icon_state = "whiteyellowfull"
 	},
 /area/desert_dam/building/security/prison)
-"bTs" = (
-/obj/structure/machinery/squeezer,
-/turf/open/floor/interior/wood,
-/area/desert_dam/building/bar/backroom)
 "bTt" = (
 /obj/structure/window/framed/hangar/reinforced,
 /turf/open/floor/plating,
@@ -49261,10 +49251,6 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/turf/open/floor/prison,
-/area/desert_dam/building/hydroponics/hydroponics)
-"ddR" = (
-/obj/structure/machinery/fermenter,
 /turf/open/floor/prison,
 /area/desert_dam/building/hydroponics/hydroponics)
 "ddS" = (
@@ -72811,7 +72797,7 @@ bLW
 bLW
 bOa
 bLW
-bPQ
+bLW
 bLW
 bKt
 cGm
@@ -83606,7 +83592,7 @@ atl
 adt
 adz
 aqc
-bTs
+aec
 adt
 ceF
 cgA
@@ -91148,7 +91134,7 @@ daK
 daK
 dTP
 daK
-ddR
+ddS
 daF
 daF
 daF

--- a/maps/map_files/DesertDam/standalone/crashlanding-upp-bar.dmm
+++ b/maps/map_files/DesertDam/standalone/crashlanding-upp-bar.dmm
@@ -398,7 +398,6 @@
 /turf/open/asphalt,
 /area/desert_dam/exterior/valley/bar_valley_dam)
 "hk" = (
-/obj/structure/machinery/squeezer,
 /turf/open/floor/plating,
 /area/desert_dam/building/bar/backroom)
 "hm" = (

--- a/maps/map_files/LV522_Chances_Claim/LV522_Chances_Claim.dmm
+++ b/maps/map_files/LV522_Chances_Claim/LV522_Chances_Claim.dmm
@@ -3991,12 +3991,6 @@
 	icon_state = "whiteyellowfull"
 	},
 /area/lv522/oob/w_y_vault)
-"cbp" = (
-/obj/structure/machinery/squeezer,
-/turf/open/floor{
-	icon_state = "wood"
-	},
-/area/lv522/indoors/b_block/bar)
 "cbB" = (
 /obj/structure/prop/invuln/overhead/flammable_pipe/fly{
 	dir = 10;
@@ -13326,7 +13320,7 @@
 	},
 /area/lv522/outdoors/colony_streets/windbreaker/observation)
 "fRc" = (
-/obj/structure/machinery/mill,
+/obj/structure/machinery/autolathe,
 /turf/open/floor/prison{
 	icon_state = "darkbrownfull2"
 	},
@@ -39737,13 +39731,6 @@
 	icon_state = "blue_plate"
 	},
 /area/lv522/indoors/a_block/admin)
-"pDe" = (
-/obj/structure/machinery/squeezer,
-/turf/open/floor/prison{
-	dir = 4;
-	icon_state = "greenfull"
-	},
-/area/lv522/indoors/b_block/hydro)
 "pDh" = (
 /obj/structure/pipes/standard/manifold/hidden/green,
 /turf/open/floor/prison{
@@ -48184,7 +48171,7 @@
 /obj/structure/platform{
 	dir = 1
 	},
-/obj/structure/machinery/squeezer,
+/obj/structure/machinery/autolathe,
 /turf/open/floor/plating,
 /area/lv522/indoors/c_block/cargo)
 "sBH" = (
@@ -50462,7 +50449,7 @@
 /obj/structure/prop/invuln/ice_prefab/trim{
 	dir = 8
 	},
-/obj/structure/machinery/mill,
+/obj/structure/machinery/autolathe,
 /turf/open/auto_turf/shale/layer1,
 /area/lv522/outdoors/colony_streets/central_streets)
 "trZ" = (
@@ -77436,7 +77423,7 @@ rlI
 fLZ
 wCJ
 ghu
-cbp
+wuQ
 mBF
 mBF
 voI
@@ -80615,8 +80602,8 @@ xwD
 tSL
 tSL
 tSL
-pDe
 fNp
+yfR
 yfR
 tne
 xDQ

--- a/maps/map_files/LV624/LV624.dmm
+++ b/maps/map_files/LV624/LV624.dmm
@@ -7626,14 +7626,7 @@
 	},
 /area/lv624/lazarus/quart)
 "aHm" = (
-/obj/structure/machinery/fermenter,
-/turf/open/floor{
-	dir = 4;
-	icon_state = "whiteyellowfull"
-	},
-/area/lv624/lazarus/quart)
-"aHn" = (
-/obj/structure/machinery/still,
+/obj/structure/machinery/autolathe,
 /turf/open/floor{
 	dir = 4;
 	icon_state = "whiteyellowfull"
@@ -54213,7 +54206,7 @@ aFC
 aFv
 aHl
 aFv
-aHn
+aHm
 aDY
 aIu
 aJh


### PR DESCRIPTION

# About the pull request
Part of the plan to remove those obsolete machinery those must be purged...
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Part of the plan to remove those obsolete machinery
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
maptweak: remove all of machinery from distillery/main.dm from all the maps except big red.
/:cl:
