### PR TITLE
Allows larvae and huggers to crawl through acid holes

### DIFF
--- a/code/game/objects/effects/acid_hole.dm
+++ b/code/game/objects/effects/acid_hole.dm
@@ -40,7 +40,7 @@
 
 
 /obj/effect/acid_hole/attack_alien(mob/living/carbon/xenomorph/user)
-	if (!holed_wall)
+	if(!holed_wall)
 		qdel(src) //no wall?! then cease existence...
 		return
 
@@ -48,6 +48,9 @@
 		if(user.mob_size >= MOB_SIZE_BIG)
 			expand_hole(user)
 			return XENO_NO_DELAY_ACTION
+
+/obj/effect/acid_hole/attack_larva(mob/living/carbon/xenomorph/larva/M)
+	attack_alien(M)
 
 /obj/effect/acid_hole/proc/expand_hole(mob/living/carbon/xenomorph/user)
 	if(user.action_busy || user.is_mob_incapacitated())


### PR DESCRIPTION

# About the pull request

Makes larvae and facehuggers able to crawl through acid holes in walls.

# Explain why it's good for the game

All xenomorphs below a certain size (other than these two) can crawl through wall holes, so it feels like this is just an oversight.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

https://github.com/cmss13-devs/cmss13/assets/57483089/1316b609-3598-4af9-8b31-64edea2a28bb

</details>


# Changelog
:cl:
add: Made xeno larvae and facehuggers able to crawl through acid holes in walls.
/:cl:
