### PR TITLE
Hive collapse when less than 4 xenos is still a marine major.

### DIFF
--- a/code/game/gamemodes/colonialmarines/colonialmarines.dm
+++ b/code/game/gamemodes/colonialmarines/colonialmarines.dm
@@ -332,7 +332,10 @@
 			if(HS.living_xeno_queen && !is_admin_level(HS.living_xeno_queen.loc.z))
 				//Some Queen is alive, we shouldn't end the game yet
 				return
-		round_finished = MODE_INFESTATION_M_MINOR
+		if (HS.totalXenos <= 3)
+			round_finished = MODE_INFESTATION_M_MAJOR
+		else
+			round_finished = MODE_INFESTATION_M_MINOR
 
 ///////////////////////////////
 //Checks if the round is over//


### PR DESCRIPTION
# About the pull request

Why below 4 xenos? Because 15 xenos without a Queen is still a threat, 3 xenos can easily be killed.

(I don't like chasing lurkers down for 5 minutes after everyone else is dead)

# Explain why it's good for the game

I must have my Marine Major, not this silly Marine Minor. A single lurker being alive isn't a big deal


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: A hive collapse (No new Queen) while at 3 xenos or below is now a marine major, instead of a minor.
/:cl:
