### PR TITLE
Makes it possible to complete the power intel objective on Kutjevo.

### DIFF
--- a/maps/map_files/Kutjevo/Kutjevo.dmm
+++ b/maps/map_files/Kutjevo/Kutjevo.dmm
@@ -8549,6 +8549,12 @@
 	},
 /turf/open/auto_turf/sand/layer0,
 /area/kutjevo/interior/colony_north)
+"lBu" = (
+/obj/structure/machinery/power/terminal{
+	dir = 4
+	},
+/turf/open/floor/kutjevo/multi_tiles,
+/area/kutjevo/interior/power)
 "lBP" = (
 /obj/structure/window/framed/kutjevo/reinforced,
 /obj/structure/machinery/door/poddoor/shutters/almayer{
@@ -25968,7 +25974,7 @@ uGd
 fkP
 vin
 pBV
-hQj
+lBu
 uBz
 cvm
 hQj
@@ -26135,7 +26141,7 @@ eyU
 dyU
 pyp
 pyp
-hQj
+sNp
 pyp
 xjY
 xjY


### PR DESCRIPTION
# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

Adds a second SMES. (I hate mapping)

# Explain why it's good for the game
This is a pretty big amount of intel points you can't get (5 is a lot)

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: The Kutjevo Refinery has been granted an additional SMES
/:cl:
