### PR TITLE
SG ammo no longer uses vendor points

### DIFF
--- a/code/game/machinery/vending/vendor_types/squad_prep/squad_smartgunner.dm
+++ b/code/game/machinery/vending/vendor_types/squad_prep/squad_smartgunner.dm
@@ -4,9 +4,6 @@ GLOBAL_LIST_INIT(cm_vending_gear_smartgun, list(
 		list("SMARTGUN SET (MANDATORY)", 0, null, null, null),
 		list("Essential Smartgunner Set", 0, /obj/item/storage/box/m56_system, MARINE_CAN_BUY_ESSENTIALS, VENDOR_ITEM_MANDATORY),
 
-		list("SMARTGUN AMMUNITION", 0, null, null, null),
-		list("M56 Smartgun Drum", 15, /obj/item/ammo_magazine/smartgun, null, VENDOR_ITEM_RECOMMENDED),
-
 		list("GUN ATTACHMENTS (CHOOSE 1)", 0, null, null, null),
 		list("Laser Sight", 0, /obj/item/attachable/lasersight, MARINE_CAN_BUY_ATTACHMENT, VENDOR_ITEM_REGULAR),
 		list("Red-Dot Sight", 0, /obj/item/attachable/reddot, MARINE_CAN_BUY_ATTACHMENT, VENDOR_ITEM_REGULAR),

--- a/code/modules/cm_marines/equipment/weapons.dm
+++ b/code/modules/cm_marines/equipment/weapons.dm
@@ -5,7 +5,7 @@
 	icon = 'icons/obj/items/storage.dmi'
 	icon_state = "kit_case"
 	w_class = SIZE_HUGE
-	storage_slots = 4
+	storage_slots = 7
 	slowdown = 1
 	can_hold = list() //Nada. Once you take the stuff out it doesn't fit back in.
 	foldable = null
@@ -16,6 +16,8 @@
 	new /obj/item/weapon/gun/smartgun(src)
 	new /obj/item/smartgun_battery(src)
 	new /obj/item/clothing/suit/storage/marine/smartgunner(src)
+	for(var/i in 1 to 3)
+		new /obj/item/ammo_magazine/smartgun(src)
 	update_icon()
 
 /obj/item/storage/box/m56_system/update_icon()


### PR DESCRIPTION

# About the pull request
SG kit now has 3 drums inside, and removes the drums purchasable from the vendor.

# Explain why it's good for the game
Similar rationale to https://github.com/cmss13-devs/cmss13/pull/4454

It's a bad choice to take anything but SG drums. By removing the mandatory purchases, smartgunners can now spend their points on utility instead.

# Changelog
:cl:
balance: 3 smartgun drums now spawn in the SG's equipment crate. Smartgun drums cannot be purchased from the SG vendor.
/:cl:
