### PR TITLE
Alamayer Perma chair faces the right way

### DIFF
--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -23180,10 +23180,12 @@
 	},
 /area/almayer/hallways/port_hallway)
 "cjz" = (
+/obj/structure/bed/chair/bolted{
+	dir = 1
+	},
 /obj/structure/machinery/light{
 	dir = 8
 	},
-/obj/structure/bed/chair/bolted,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -34659,6 +34661,10 @@
 	phone_id = "Medical Lower";
 	pixel_x = 16
 	},
+/obj/item/device/helmet_visor/medical/advanced,
+/obj/item/device/helmet_visor/medical/advanced,
+/obj/item/device/helmet_visor/medical/advanced,
+/obj/item/device/helmet_visor/medical/advanced,
 /turf/open/floor/almayer{
 	icon_state = "sterile_green"
 	},
@@ -70522,10 +70528,12 @@
 /turf/open/floor/wood/ship,
 /area/almayer/living/commandbunks)
 "tYW" = (
+/obj/structure/bed/chair/bolted{
+	dir = 1
+	},
 /obj/structure/machinery/light{
 	dir = 4
 	},
-/obj/structure/bed/chair/bolted,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -23180,12 +23180,10 @@
 	},
 /area/almayer/hallways/port_hallway)
 "cjz" = (
-/obj/structure/bed/chair/bolted{
-	dir = 1
-	},
 /obj/structure/machinery/light{
 	dir = 8
 	},
+/obj/structure/bed/chair/bolted,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -34661,10 +34659,6 @@
 	phone_id = "Medical Lower";
 	pixel_x = 16
 	},
-/obj/item/device/helmet_visor/medical/advanced,
-/obj/item/device/helmet_visor/medical/advanced,
-/obj/item/device/helmet_visor/medical/advanced,
-/obj/item/device/helmet_visor/medical/advanced,
 /turf/open/floor/almayer{
 	icon_state = "sterile_green"
 	},
@@ -70528,12 +70522,10 @@
 /turf/open/floor/wood/ship,
 /area/almayer/living/commandbunks)
 "tYW" = (
-/obj/structure/bed/chair/bolted{
-	dir = 1
-	},
 /obj/structure/machinery/light{
 	dir = 4
 	},
+/obj/structure/bed/chair/bolted,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -23180,12 +23180,10 @@
 	},
 /area/almayer/hallways/port_hallway)
 "cjz" = (
-/obj/structure/bed/chair/bolted{
-	dir = 1
-	},
 /obj/structure/machinery/light{
 	dir = 8
 	},
+/obj/structure/bed/chair/bolted,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -70528,12 +70526,10 @@
 /turf/open/floor/wood/ship,
 /area/almayer/living/commandbunks)
 "tYW" = (
-/obj/structure/bed/chair/bolted{
-	dir = 1
-	},
 /obj/structure/machinery/light{
 	dir = 4
 	},
+/obj/structure/bed/chair/bolted,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},


### PR DESCRIPTION

# About the pull request
chairs in permabrig now face south (towards their table) instead of north, towards the wall
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
perma prisoners should be able to sit at their chair and be facing the paper and pen instead of the wall??
# Changelog
:cl:
maptweak: Alamayer PermaBrig Chairs face the right way
/:cl:
