### PR TITLE
Fixes dead marines being able to use the M56D

### DIFF
--- a/code/modules/cm_marines/m2c.dm
+++ b/code/modules/cm_marines/m2c.dm
@@ -454,8 +454,12 @@
 // DISASSEMBLY
 
 /obj/structure/machinery/m56d_hmg/auto/MouseDrop(over_object, src_location, over_location)
-	if(!ishuman(usr)) return
+	if(!ishuman(usr))
+		return
 	var/mob/living/carbon/human/user = usr
+	// If the user is unconscious or dead.
+	if(user.stat)
+		return
 
 	if(over_object == user && in_range(src, user))
 		if((rounds > 0) && (user.a_intent & (INTENT_GRAB)))

--- a/code/modules/cm_marines/smartgun_mount.dm
+++ b/code/modules/cm_marines/smartgun_mount.dm
@@ -45,7 +45,7 @@
 	///How many rounds are in the weapon. This is useful if we break down our guns.
 	var/rounds = 0
 	///Indicates whether the M56D will come with its folding mount already attached
-	var/has_mount = FALSE 
+	var/has_mount = FALSE
 	///The distance this has to be away from other m56d_hmg and m56d_post to be placed.
 	var/defense_check_range = 5
 
@@ -826,6 +826,9 @@
 /obj/structure/machinery/m56d_hmg/proc/try_mount_gun(mob/living/carbon/human/user)
 	// If the user isn't a human.
 	if(!istype(user))
+		return
+	// If the user is unconscious or dead.
+	if(user.stat)
 		return
 
 	// If the user isn't actually allowed to use guns.


### PR DESCRIPTION

# About the pull request

Fixes dead marines being able to man and fire the M56D.

Also adds a `stat` check to the M2C as well. It doesn't have the same problem as the M56, but when dragging it onto your body a progress indicator will flash up before quickly disappearing, so this just stops it appearing in the first place.

# Explain why it's good for the game

Dead marines firing machine guns is spooky.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

**Before:**

https://github.com/cmss13-devs/cmss13/assets/57483089/e4e6fd55-ed71-493f-9f52-4c517f4eec61

**After:**

https://github.com/cmss13-devs/cmss13/assets/57483089/6459571f-02b8-457f-bb14-a6105c11ab19

</details>


# Changelog
:cl:
fix: Fixed dead marines being able to man and fire the M56D.
/:cl:
