### PR TITLE
reduces volume of halucinations from neurotoxin from 100 to 65

### DIFF
--- a/code/datums/effects/neurotoxin.dm
+++ b/code/datums/effects/neurotoxin.dm
@@ -150,7 +150,7 @@
 			victim.hallucination = 3
 			victim.druggy = 3
 		if(70 to 100) // sound based hallucination
-			playsound_client(victim.client,pick('sound/voice/alien_distantroar_3.ogg','sound/voice/xenos_roaring.ogg','sound/voice/alien_queen_breath1.ogg', 'sound/voice/4_xeno_roars.ogg','sound/misc/notice2.ogg',"bone_break","gun_pulse","metalbang","pry","shatter"))
+			playsound_client(client = victim.client, soundin = pick('sound/voice/alien_distantroar_3.ogg','sound/voice/xenos_roaring.ogg','sound/voice/alien_queen_breath1.ogg', 'sound/voice/4_xeno_roars.ogg','sound/misc/notice2.ogg',"bone_break","gun_pulse","metalbang","pry","shatter"),vol = 65)
 
 
 

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -100,8 +100,8 @@
 
 
 //This is the replacement for playsound_local. Use this for sending sounds directly to a client
-/proc/playsound_client(client/C, soundin, atom/origin, vol = 100, random_freq, vol_cat = VOLUME_SFX, channel = 0, status, list/echo, y_s_offset, x_s_offset)
-	if(!istype(C) || !C.soundOutput) return FALSE
+/proc/playsound_client(client/client, soundin, atom/origin, vol = 100, random_freq, vol_cat = VOLUME_SFX, channel = 0, status, list/echo, y_s_offset, x_s_offset)
+	if(!istype(client) || !client.soundOutput) return FALSE
 	var/datum/sound_template/S = new()
 	if(origin)
 		var/turf/T = get_turf(origin)
@@ -126,7 +126,7 @@
 	S.echo = echo
 	S.y_s_offset = y_s_offset
 	S.x_s_offset = x_s_offset
-	SSsound.queue(S, list(C))
+	SSsound.queue(S, list(client))
 
 /// Plays sound to all mobs that are map-level contents of an area
 /proc/playsound_area(area/A, soundin, vol = 100, channel = 0, status, vol_cat = VOLUME_SFX, list/echo, y_s_offset, x_s_offset)


### PR DESCRIPTION

# About the pull request

reduces volume of halucination sounds from default 100 to 65, just under queen screech volume.

# Explain why it's good for the game

halucinations right now blast your ears off due to default volume being 100 while queen screech is 70, lowers the volume to 65 just under queen screech as it is played several time and volume 100 is painful to the players.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: lowers volume of neurohalucination from 100 (no outher sounds are so laud) to 65 (just about under queen screech level).
/:cl:
