### PR TITLE
Fixes larvae sometimes spawning in space

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/hive_status.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_status.dm
@@ -779,7 +779,12 @@
 		spawning_area = pick(totalXenos) // FUCK IT JUST GO ANYWHERE
 	var/list/turf_list
 	for(var/turf/open/open_turf in orange(3, spawning_area))
+		if(istype(open_turf, /turf/open/space))
+			continue
 		LAZYADD(turf_list, open_turf)
+	// just on the off-chance
+	if(!LAZYLEN(turf_list))
+		return FALSE
 	var/turf/open/spawning_turf = pick(turf_list)
 
 	var/mob/living/carbon/xenomorph/larva/new_xeno = spawn_hivenumber_larva(spawning_turf, hivenumber)


### PR DESCRIPTION

# About the pull request

Fixes larvae sometimes spawning in space on Fiorina. (And any other space-based maps)

I think this is being caused by the `do_buried_larva_spawn()` proc looking for any `/turf/open` subtypes in range, but not performing any checks on them.

# Explain why it's good for the game

Occasionally at roundstart on Fiorina a larva will spawn outside of the station's walls in space, and need an admin to teleport them back inside. Although it *is* pretty funny when it happens, it's probably best to fix it.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Fixed larvae sometimes spawning in space on Fiorina.
/:cl:
