### PR TITLE
Fixes facehuggers ghosting upon unsuccessful attachment

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
@@ -158,6 +158,9 @@
 /mob/living/carbon/xenomorph/facehugger/proc/handle_hug(mob/living/carbon/human/human)
 	var/obj/item/clothing/mask/facehugger/hugger = new /obj/item/clothing/mask/facehugger(loc, hivenumber)
 	var/did_hug = hugger.attach(human, TRUE, 1, src)
+	if(!did_hug)
+		qdel(hugger)
+		return
 	if(client)
 		client.player_data?.adjust_stat(PLAYER_STAT_FACEHUGS, STAT_CATEGORY_XENO, 1)
 	qdel(src)


### PR DESCRIPTION
# About the pull request

Fixes #5453 

Adds an extra check to see if the player successfully attached to the person and only then ghosts them.

# Explain why it's good for the game

Removes a situation where a player might be ghosted out before actually becoming a facehugger mask (see the video on the issue report).

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

https://github.com/cmss13-devs/cmss13/assets/49321394/0bfc97ca-fffc-4805-b912-ad6a04f5ea17

</details>


# Changelog

:cl:
fix: Fixes an issue where player-controlled facehuggers would ghost out when smashing against anti-hugging headgear like the B18 helmet.
/:cl:
