### PR TITLE
Bedrolls no longer give metal when wrenched

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -420,6 +420,8 @@ GLOBAL_LIST_EMPTY(activated_medevac_stretchers)
 	buckling_y = 0
 	foldabletype = /obj/item/roller/bedroll
 	accepts_bodybag = FALSE
+	debris = null
+	buildstacktype = null
 
 /obj/item/roller/bedroll
 	name = "folded bedroll"


### PR DESCRIPTION

# About the pull request

Bedrolls no longer give metal when wrenched. This was an oversight by the author.

# Explain why it's good for the game
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Bedrolls no longer give metal when wrenched.
/:cl:
