### PR TITLE
Fixes mobs unable to move after being flung while buckled.

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -405,6 +405,7 @@
 		return
 	if(buckled)
 		LM.invoke_end_throw_callbacks(src)
+		return
 	if(pulling)
 		stop_pulling() //being thrown breaks pulls.
 	if(pulledby)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -401,9 +401,10 @@
 /mob/living/launch_towards(datum/launch_metadata/LM)
 	if(src)
 		SEND_SIGNAL(src, COMSIG_MOB_MOVE_OR_LOOK, TRUE, dir, dir)
-	if(!istype(LM) || !LM.target || !src || buckled)
-		LM.invoke_end_throw_callbacks(src)
+	if(!istype(LM) || !LM.target || !src)
 		return
+	if(buckled)
+		LM.invoke_end_throw_callbacks(src)
 	if(pulling)
 		stop_pulling() //being thrown breaks pulls.
 	if(pulledby)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -402,6 +402,7 @@
 	if(src)
 		SEND_SIGNAL(src, COMSIG_MOB_MOVE_OR_LOOK, TRUE, dir, dir)
 	if(!istype(LM) || !LM.target || !src || buckled)
+		LM.invoke_end_throw_callbacks(src)
 		return
 	if(pulling)
 		stop_pulling() //being thrown breaks pulls.

--- a/code/modules/movement/launching/launching.dm
+++ b/code/modules/movement/launching/launching.dm
@@ -54,6 +54,16 @@
 			matching_procs += collision_callbacks[path]
 		return matching_procs
 
+/// Invoke end_throw_callbacks on this metadata.
+/// Takes argument of type /atom/movable
+/datum/launch_metadata/proc/invoke_end_throw_callbacks(atom/movable/movable_atom)
+	if(length(end_throw_callbacks))
+		for(var/datum/callback/callback as anything in end_throw_callbacks)
+			if(istype(callback, /datum/callback/dynamic))
+				callback.Invoke(movable_atom)
+			else
+				callback.Invoke()
+
 /atom/movable/var/datum/launch_metadata/launch_metadata = null
 
 //called when src is thrown into hit_atom
@@ -210,12 +220,7 @@
 		rebounding = FALSE
 		cur_speed = old_speed
 		remove_temp_pass_flags(pass_flags)
-		if(length(LM.end_throw_callbacks))
-			for(var/datum/callback/CB as anything in LM.end_throw_callbacks)
-				if(istype(CB, /datum/callback/dynamic))
-					CB.Invoke(src)
-				else
-					CB.Invoke()
+		LM.invoke_end_throw_callbacks(src)
 	QDEL_NULL(launch_metadata)
 
 /atom/movable/proc/throw_random_direction(range, speed = 0, atom/thrower, spin, launch_type = NORMAL_LAUNCH, pass_flags = NO_FLAGS)


### PR DESCRIPTION

# About the pull request

Buckled mobs didn't have their `TRAIT_IMMOBILIZED` removed properly since we return early from `launch_towards()` if `buckled`
https://github.com/cmss13-devs/cmss13/blob/939e283561d2446d5df4b60faba08097eaea1f79/code/modules/mob/living/living.dm#L401-L405

Therefore any callbacks in end_throw_callbacks are never invoked. In the case of xeno throws we rely on end_throw_callbacks to remove our immobilised trait

Fixes #5420

# Explain why it's good for the game
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Fixed buckled mobs unable to move after being thrown by a xeno.
/:cl:
