### PR TITLE
Makes xeno tunnel lists sort by distance to the player

### DIFF
--- a/code/__HELPERS/lists.dm
+++ b/code/__HELPERS/lists.dm
@@ -391,6 +391,19 @@
 	original += result
 	return original
 
+/// Returns a list of atoms sorted by each entry's distance to `target`.
+/proc/sort_list_dist(list/atom/list_to_sort, atom/target)
+	var/list/distances = list()
+	for(var/atom/A as anything in list_to_sort)
+		// Just in case this happens anyway.
+		if(!istype(A))
+			stack_trace("sort_list_dist() was called with a list containing a non-atom object. ([A.type])")
+			return list_to_sort
+
+		distances[A] = get_dist_sqrd(A, target)
+
+	return sortTim(distances, GLOBAL_PROC_REF(cmp_numeric_asc), TRUE)
+
 //Converts a bitfield to a list of numbers (or words if a wordlist is provided)
 /proc/bitfield2list(bitfield = 0, list/wordlist)
 	var/list/r = list()

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -571,9 +571,10 @@
 				options["Xeno Leader [xeno_lead]"] = list(TRACKER_LEADER, xeno_leader_index)
 			xeno_leader_index++
 
+		var/list/sorted_tunnels = sort_list_dist(user.hive.tunnels, get_turf(user))
 		var/tunnel_index = 1
-		for(var/obj/structure/tunnel/tracked_tunnel in user.hive.tunnels)
-			options["Tunnel [tracked_tunnel.tunnel_desc]"] = list(TRACKER_TUNNEL, tunnel_index)
+		for(var/obj/structure/tunnel/tunnel in sorted_tunnels)
+			options["Tunnel [tunnel.tunnel_desc]"] = list(TRACKER_TUNNEL, tunnel_index)
 			tunnel_index++
 
 		var/selected = tgui_input_list(user, "Select what you want the locator to track.", "Locator Options", options)

--- a/code/modules/cm_aliens/structures/tunnel.dm
+++ b/code/modules/cm_aliens/structures/tunnel.dm
@@ -144,15 +144,17 @@
 	if(!istype(X) || X.is_mob_incapacitated(TRUE) || !isfriendly(X) || !hive)
 		return FALSE
 	if(X in contents)
-		var/list/tunnels = list()
-		for(var/obj/structure/tunnel/T in hive.tunnels)
+		var/list/input_tunnels = list()
+
+		var/list/sorted_tunnels = sort_list_dist(hive.tunnels, get_turf(X))
+		for(var/obj/structure/tunnel/T in sorted_tunnels)
 			if(T == src)
 				continue
 			if(!is_ground_level(T.z))
 				continue
 
-			tunnels += list(T.tunnel_desc = T)
-		var/pick = tgui_input_list(usr, "Which tunnel would you like to move to?", "Tunnel", tunnels, theme="hive_status")
+			input_tunnels += list(T.tunnel_desc = T)
+		var/pick = tgui_input_list(usr, "Which tunnel would you like to move to?", "Tunnel", input_tunnels, theme="hive_status")
 		if(!pick)
 			return FALSE
 
@@ -173,7 +175,7 @@
 		if(!do_after(X, tunnel_time, INTERRUPT_NO_NEEDHAND, 0))
 			return FALSE
 
-		var/obj/structure/tunnel/T = tunnels[pick]
+		var/obj/structure/tunnel/T = input_tunnels[pick]
 
 		if(T.contents.len > 2)// max 3 xenos in a tunnel
 			to_chat(X, SPAN_WARNING("The tunnel is too crowded, wait for others to exit!"))

--- a/strings/xenotips.txt
+++ b/strings/xenotips.txt
@@ -36,3 +36,4 @@ As a Ravager your abilities become greatly enhanced when you empower with three 
 Resisting on a water tile will immediately put out fires. Make sure you're alone though - It's usually better to let a friendly Xenomorph pat you out than it is to expose yourself to open water.
 You can filter out the Xenomorphs displayed in hive status by health, allowing you to look only for wounded sisters.
 Each xeno has their own ‘tackle counter’ on a marine. The range to successfully tackle can be anywhere from two to six tackles based on caste. If a marine gets stunned or knocked over by other means it will reset everyone's tackle counters and they may get up!
+As a Xenomorph, the list of available tunnels is sorted by their distance to the player!


### PR DESCRIPTION

# About the pull request

Makes xeno tunnel lists sort by each tunnel's distance from the player. (When alt-clicking the 'Queen Locator', and when entering a tunnel.)

# Explain why it's good for the game

If the live tacmap isn't available then it can be pretty difficult for xeno players to find a nearby tunnel, especially if they haven't learned the map layout enough to know where each area is in relation to each other.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

https://github.com/cmss13-devs/cmss13/assets/57483089/3e7c0460-ab4a-4584-975c-1aa92d1da288

</details>


# Changelog
:cl:
add: Made xeno tunnel lists sort by distance to the player.
/:cl:
