### PR TITLE
Fix Detach and on_detach parameter oversights

### DIFF
--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -168,7 +168,8 @@ Defined in conflicts.dm of the #defines folder.
 /obj/item/attachable/proc/Detach(mob/user, obj/item/weapon/gun/detaching_gub)
 	if(!istype(detaching_gub)) return //Guns only
 
-	detaching_gub.on_detach(user)
+	if(user)
+		detaching_gub.on_detach(user, src)
 
 	if(flags_attach_features & ATTACH_ACTIVATION)
 		activate_attachment(detaching_gub, null, TRUE)

--- a/code/modules/projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/gun_helpers.dm
@@ -395,7 +395,7 @@ DEFINES in setup.dm, referenced here.
 			playsound(user, 'sound/handling/attachment_add.ogg', 15, 1, 4)
 			return TRUE
 
-/obj/item/weapon/gun/proc/on_detach(obj/item/attachable/attachment)
+/obj/item/weapon/gun/proc/on_detach(mob/user, obj/item/attachable/attachment)
 	return
 
 /obj/item/weapon/gun/proc/update_attachables() //Updates everything. You generally don't need to use this.


### PR DESCRIPTION

# About the pull request

This PR fixes some confusion with Detatch logic for gun attachments. The base implementation didn't seem to originally have a user variable but all other implementations did.

# Explain why it's good for the game

Less pitfalls for coders.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: Drathek
code: Cleaned up some oversights in attachment Detatch logic
/:cl:
